### PR TITLE
llvm, xorg-server, openssh, dbus package updates

### DIFF
--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="cmake"
-PKG_VERSION="3.4.3"
+PKG_VERSION="3.5.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.cmake.org/"
-PKG_URL="http://www.cmake.org/files/v3.4/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="http://www.cmake.org/files/v3.5/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_PRIORITY="optional"
 PKG_SECTION="toolchain/devel"

--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="ncurses"
-PKG_VERSION="5.9"
+PKG_VERSION="6.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
@@ -86,4 +86,6 @@ post_makeinstall_target() {
   cp misc/ncurses-config $ROOT/$TOOLCHAIN/bin
     chmod +x $ROOT/$TOOLCHAIN/bin/ncurses-config
     $SED "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $ROOT/$TOOLCHAIN/bin/ncurses-config
+
+  rm -rf $INSTALL/usr/bin/ncurses*-config
 }

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -17,13 +17,13 @@
 ################################################################################
 
 PKG_NAME="llvm"
-PKG_VERSION="f65e46b"
+PKG_VERSION="3.8.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://llvm.org/"
-PKG_URL="$DISTRO_SRC/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-#PKG_SOURCE_DIR="${PKG_NAME}-${PKG_VERSION}.src"
+PKG_URL="http://llvm.org/releases/$PKG_VERSION/${PKG_NAME}-${PKG_VERSION}.src.tar.xz"
+PKG_SOURCE_DIR="${PKG_NAME}-${PKG_VERSION}.src"
 PKG_DEPENDS_HOST=""
 PKG_DEPENDS_TARGET="toolchain llvm:host"
 PKG_PRIORITY="optional"

--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="openssh"
-PKG_VERSION="7.2p1"
+PKG_VERSION="7.2p2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"

--- a/packages/sysutils/dbus/package.mk
+++ b/packages/sysutils/dbus/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="dbus"
-PKG_VERSION="1.10.6"
+PKG_VERSION="1.10.8"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="expat"
-PKG_VERSION="2.1.0"
+PKG_VERSION="2.1.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://expat.sourceforge.net/"
-PKG_URL="$SOURCEFORGE_SRC/$PKG_NAME/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="$SOURCEFORGE_SRC/$PKG_NAME/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="textproc"

--- a/packages/x11/proto/videoproto/package.mk
+++ b/packages/x11/proto/videoproto/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="videoproto"
-PKG_VERSION="2.3.2"
+PKG_VERSION="2.3.3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="xorg-server"
-PKG_VERSION="1.18.1"
+PKG_VERSION="1.18.2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
llvm bump is just the final version, we were using a git version that was close to final before
[xorg-server 1.18.2](https://lists.x.org/archives/xorg-announce/2016-March/002681.html)
[openssh 7.2p2](http://www.openssh.com/txt/release-7.2p2)
[dbus 1.10.8](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?id=dc8f8c52941f4ecb8e903ed30330f805999d4c08)
[expat 2.1.1](http://expat.sourceforge.net/)
[videoproto 2.3.3](http://permalink.gmane.org/gmane.comp.freedesktop.xorg.announce/2408)
[cmake 3.5.0](https://cmake.org/cmake/help/v3.5/release/3.5.html)
[ncurses 6.0](https://www.gnu.org/software/ncurses/)