### PR TITLE
Revert "Python: don't include _sysconfigdata.py"

### DIFF
--- a/packages/lang/Python/package.mk
+++ b/packages/lang/Python/package.mk
@@ -124,7 +124,6 @@ post_makeinstall_target() {
   python -Wi -t -B ../Lib/compileall.py $INSTALL/usr/lib/python*/ -f
   rm -rf `find $INSTALL/usr/lib/python*/ -name "*.py"`
 
-  rm -rf $INSTALL/usr/lib/python*/_sysconfigdata.pyo
   rm -rf $INSTALL/usr/lib/python*/config
   rm -rf $INSTALL/usr/bin/2to3
   rm -rf $INSTALL/usr/bin/idle


### PR DESCRIPTION
This reverts commit 70ee30ebf92754e333eee3fd72a79c239b7ec4fd.