### PR TITLE
bcm2835-driver: update to version c230b2b and install dtoverlay userland

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -56,6 +56,7 @@ make_target() {
     cp -PRv $FLOAT/opt/vc/lib/libmmal_util.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libmmal_vc_client.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libvcsm.so $SYSROOT_PREFIX/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libdtovl.so $SYSROOT_PREFIX/usr/lib
 }
 
 makeinstall_target() {
@@ -76,9 +77,11 @@ makeinstall_target() {
     cp -PRv $FLOAT/opt/vc/lib/libmmal_util.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libmmal_vc_client.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libvcsm.so $INSTALL/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libdtovl.so $INSTALL/usr/lib
 
 # some usefull debug tools
   mkdir -p $INSTALL/usr/bin
+    cp -PRv $FLOAT/opt/vc/bin/dtoverlay $INSTALL/usr/bin
     cp -PRv $FLOAT/opt/vc/bin/vcdbg $INSTALL/usr/bin
       cp -PRv $FLOAT/opt/vc/lib/libdebug_sym.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/bin/vcgencmd $INSTALL/usr/bin

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="b48c36f"
+PKG_VERSION="c230b2b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="b48c36f"
+PKG_VERSION="c230b2b"
 PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"


### PR DESCRIPTION
This includes support for dynamic device tree overlays ([details](https://www.raspberrypi.org/forums/viewtopic.php?f=107&t=139732)) and adds `dtoverlay` userland binary to dynamically load/unload/query device tree overlays.