### PR TITLE
libdvbcsa: build with -fPIC

### DIFF
--- a/packages/multimedia/libdvbcsa/package.mk
+++ b/packages/multimedia/libdvbcsa/package.mk
@@ -50,5 +50,7 @@ fi
 pre_configure_target() {
 # libdvbcsa is a bit faster without LTO, and tests will fail with gcc-5.x
   strip_lto
+
+  export CFLAGS="$CFLAGS -fPIC"
 }
 


### PR DESCRIPTION
Needed to build vdr.

```
/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-8.0-devel/toolchain/lib/gcc/armv7ve-openelec-linux-gnueabi/5.3.0/../../../../armv7ve-openelec-linux-gnueabi/bin/ld.gold: error: /home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-8.0-devel/toolchain/armv7ve-openelec-linux-gnueabi/sysroot/usr/lib/libdvbcsa.a(dvbcsa_bs_algo.o): requires unsupported dynamic reloc R_ARM_MOVW_ABS_NC; recompile with -fPIC
/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-8.0-devel/toolchain/lib/gcc/armv7ve-openelec-linux-gnueabi/5.3.0/../../../../armv7ve-openelec-linux-gnueabi/bin/ld.gold: error: /home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-8.0-devel/toolchain/armv7ve-openelec-linux-gnueabi/sysroot/usr/lib/libdvbcsa.a(dvbcsa_bs_block.o): requires unsupported dynamic reloc R_ARM_MOVW_ABS_NC; recompile with -fPIC
/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-8.0-devel/toolchain/lib/gcc/armv7ve-openelec-linux-gnueabi/5.3.0/../../../../armv7ve-openelec-linux-gnueabi/bin/ld.gold: error: /home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-8.0-devel/toolchain/armv7ve-openelec-linux-gnueabi/sysroot/usr/lib/libdvbcsa.a(dvbcsa_key.o): requires unsupported dynamic reloc R_ARM_MOVW_ABS_NC; recompile with -fPIC
collect2: error: ld returned 1 exit status
```