### PR TITLE
kodi: readd os.openelec.tv for backwards compatibility

### DIFF
--- a/packages/mediacenter/kodi/config/os.openelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/os.openelec.tv/addon.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon id="os.openelec.tv" version="@OS_VERSION@" provider-name="OpenELEC.tv">
+  <requires>
+    <import addon="xbmc.addon" version="12.0"/>
+  </requires>
+</addon>

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -369,6 +369,8 @@ post_makeinstall_target() {
   rm -rf $INSTALL/usr/share/xsessions
 
   mkdir -p $INSTALL/usr/share/kodi/addons
+    cp -R $PKG_DIR/config/os.openelec.tv $INSTALL/usr/share/kodi/addons
+    $SED "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.openelec.tv/addon.xml
     cp -R $PKG_DIR/config/os.libreelec.tv $INSTALL/usr/share/kodi/addons
     $SED "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.libreelec.tv/addon.xml
     cp -R $PKG_DIR/config/repository.libreelec.tv $INSTALL/usr/share/kodi/addons


### PR DESCRIPTION
This is needed for people moving from OE so their add-ons aren't marked as broken.

This can probable removed for LE 8.0