### PR TITLE
libreelec: Re-add OPENELEC_ARCH for temporary backwards compatability

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -103,6 +103,7 @@ fi
   if [ -n "$GIT_HASH" ]; then
 	echo -e "BUILD_ID=\"$GIT_HASH\"" >> $INSTALL/etc/os-release
   fi
+  echo -e "OPENELEC_ARCH=\"$PROJECT.$TARGET_ARCH\"" >> $INSTALL/etc/os-release
   echo -e "LIBREELEC_ARCH=\"$PROJECT.$TARGET_ARCH\"" >> $INSTALL/etc/os-release
   if [ "$OFFICIAL" = "yes" ]; then
     echo -e "LIBREELEC_BUILD=\"official\"" >> $INSTALL/etc/os-release


### PR DESCRIPTION
This is needed for add-ons that currently check for OPENELEC_ARCH and if not found, default to an arch that may result in unexpected behaviour.

This can be removed for LE 8.0
