### PR TITLE
Allow for a custom system partition start sector + custom system size

### DIFF
--- a/config/noobs/partitions.json
+++ b/config/noobs/partitions.json
@@ -3,7 +3,7 @@
     {
       "label":                     "@DISTRONAME@_@PROJECT@_System",
       "filesystem_type":           "FAT",
-      "partition_size_nominal":    512,
+      "partition_size_nominal":    @SYSTEM_SIZE@,
       "want_maximised":            false,
       "uncompressed_tarball_size": 120,
       "mkfs_options":              ""

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -204,3 +204,8 @@
 # set the addon dirs
   ADDON_PATH="$ADDON_VERSION/$PROJECT/$TARGET_ARCH"
   ADDON_URL="$ADDON_SERVER_URL/$ADDON_PATH"
+
+# Default size of system partition, in MB, eg. 512
+  SYSTEM_SIZE=512
+# Default system partition offset, in sectors, eg. 2048
+  SYSTEM_PART_START=2048

--- a/packages/tools/installer/config/installer.conf
+++ b/packages/tools/installer/config/installer.conf
@@ -19,8 +19,11 @@
   DISKLABEL_SYSTEM="System"
   DISKLABEL_STORAGE="Storage"
 
-# Defaultsize of system partition (Cylinder: 16=132MB, 31=255MB, 66=517MiB)
-  PARTSIZE_SYSTEM="66"
+# Default size of system partition, in MB, eg. 512
+  PARTSIZE_SYSTEM="@SYSTEM_SIZE@"
+
+# Default starting offset for system partition, in sectors (1 sector = 512B), eg. 2048
+  PARTSIZE_SYSTEM_OFFSET="@SYSTEM_PART_START@"
 
 # additional parameters to extlinux
   EXTLINUX_PARAMETERS=""

--- a/packages/tools/installer/package.mk
+++ b/packages/tools/installer/package.mk
@@ -50,6 +50,9 @@ post_install() {
     else
       cp $PKG_DIR/config/installer.conf $INSTALL/etc
     fi
+    sed -e "s/@SYSTEM_SIZE@/$SYSTEM_SIZE/g" \
+        -e "s/@SYSTEM_PART_START@/$SYSTEM_PART_START/g" \
+        -i $INSTALL/etc/installer.conf
 
   enable_service installer.service
 }

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -253,15 +253,20 @@ do_install_quick() {
         cat /usr/share/syslinux/mbr.bin > $INSTALL_DEVICE
       fi
 
+      partsize_system_start=$PARTSIZE_SYSTEM_OFFSET
+      partsize_system_end=$(((PARTSIZE_SYSTEM * 1024 * 1024 / 512) + partsize_system_start))
+      partsize_storage_start=$((partsize_system_end + 2048))
+      partsize_storage_end=-1024
+
       msg_progress_install "10" "creating partition on $INSTALL_DEVICE"
       if [ "$UEFI" = "1" ]; then
-        parted -s $INSTALL_DEVICE unit cyl mkpart primary fat32 -- 0 $PARTSIZE_SYSTEM >> $LOGFILE 2>&1
+        parted -s $INSTALL_DEVICE unit s mkpart primary fat32 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
       else
-        parted -s $INSTALL_DEVICE unit cyl mkpart primary ext2 -- 0 $PARTSIZE_SYSTEM >> $LOGFILE 2>&1
+        parted -s $INSTALL_DEVICE unit s mkpart primary ext2  -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
       fi
 
       msg_progress_install "13" "creating partition on $INSTALL_DEVICE"
-      parted -s $INSTALL_DEVICE unit cyl mkpart primary ext2 -- $PARTSIZE_SYSTEM -2 >> $LOGFILE 2>&1
+      parted -s $INSTALL_DEVICE unit s mkpart primary ext2 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
 
       msg_progress_install "16" "setup bootflag on partition 1 of $INSTALL_DEVICE"
       parted -s $INSTALL_DEVICE set 1 boot on >> $LOGFILE 2>&1
@@ -629,7 +634,7 @@ do_poweroff() {
 }
 
 # setup needed variables
-INSTALLER_VERSION="0.2.7"
+INSTALLER_VERSION="0.2.8"
 OS_VERSION=$(lsb_release)
 BACKTITLE="LibreELEC Installer $INSTALLER_VERSION - $OS_VERSION"
 

--- a/scripts/image
+++ b/scripts/image
@@ -357,6 +357,8 @@ fi
           UUID_STORAGE="$(uuidgen)" \
           UBOOT_SYSTEM="$UBOOT_SYSTEM" \
           EXTRA_CMDLINE="$EXTRA_CMDLINE" \
+          SYSTEM_SIZE="$SYSTEM_SIZE" \
+          SYSTEM_PART_START="$SYSTEM_PART_START" \
           $SCRIPTS/mkimage
       fi
 
@@ -453,6 +455,7 @@ fi
 
       sed -e "s%@DISTRONAME@%$DISTRONAME%g" \
           -e "s%@PROJECT@%$PROJECT%g" \
+          -e "s%@SYSTEM_SIZE@%$SYSTEM_SIZE%g" \
           -i $RELEASE_DIR/${DISTRONAME}_${PROJECT}/partitions.json
 
     # create System dir

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -27,7 +27,11 @@
   OE_TMP=$(mktemp -d)
   SAVE_ERROR="$OE_TMP/save_error"
 
-  SYSTEM_SIZE=512
+  if [ -z "$SYSTEM_SIZE" -o -z "$SYSTEM_PART_START" ]; then
+    echo "mkimage: SYSTEM_SIZE and SYSTEM_PART_START must be configured!"
+    exit 1
+  fi
+
   STORAGE_SIZE=32 # STORAGE_SIZE must be >= 32 !
 
   DISK_SIZE=$(( $SYSTEM_SIZE + $STORAGE_SIZE + 4 ))
@@ -74,8 +78,8 @@ trap cleanup SIGINT
 
 # create part1
   echo "image: creating part1..."
-  SYSTEM_PART_END=$(( $SYSTEM_SIZE * 1024 * 1024 / 512 + 2048 ))
-  parted -s "$DISK" -a min unit s mkpart primary fat32 2048 $SYSTEM_PART_END
+  SYSTEM_PART_END=$(( ($SYSTEM_SIZE * 1024 * 1024 / 512) + $SYSTEM_PART_START ))
+  parted -s "$DISK" -a min unit s mkpart primary fat32 $SYSTEM_PART_START $SYSTEM_PART_END
   if [ "$BOOTLOADER" = "syslinux" ]; then
     parted -s "$DISK" set 1 legacy_boot on
   else
@@ -100,7 +104,7 @@ fi
 
 # create filesystem on part1
   echo "image: creating filesystem on part1..."
-  OFFSET=$(( 2048 * 512 ))
+  OFFSET=$(( $SYSTEM_PART_START * 512 ))
   HEADS=4
   TRACKS=32
   SECTORS=$(( $SYSTEM_SIZE * 1024 * 1024 / 512 / $HEADS / $TRACKS ))


### PR DESCRIPTION
This is an enhanced version of #49. ping @zalaare .

The default system partition size and offset will be 512MB and 2048 respectively, However this can be overridden by adding `SYSTEM_SIZE` and/or `SYSTEM_PART_START` to `$DISTRO/options` or `$PROJECT/options`.

Since I don't have any x86 systems I'm willing to trash, I've only been able to run a simulated test of the installer, but it seems to work as expected.

Testing with an 8GB SD card, the following partitions were created:

##### `SYSTEM_SIZE=512` and `SYSTEM_PART_START=2048`

In sectors:
```
Model: Generic- USB3.0 CRW -SD (scsi)
Disk /dev/sde: 15523840s
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags:

Number  Start     End        Size       Type     File system  Flags
 1      2048s     1050624s   1048577s   primary  ext4         boot
 2      1052672s  15522816s  14470145s  primary  ext4
```
In KiB:
```
Model: Generic- USB3.0 CRW -SD (scsi)
Disk /dev/sde: 7948206kB
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags:

Number  Start     End        Size       Type     File system  Flags
 1      1049kB    537920kB   536871kB   primary  ext4         boot
 2      538968kB  7947682kB  7408714kB  primary  ext4
```
and finally in MiB:
```
Model: Generic- USB3.0 CRW -SD (scsi)
Disk /dev/sde: 7948MB
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags:

Number  Start   End     Size    Type     File system  Flags
 1      1.05MB  538MB   537MB   primary  ext4         boot
 2      539MB   7948MB  7409MB  primary  ext4
```

##### `SYSTEM_SIZE=512` and `SYSTEM_PART_START=3072`

sectors:
```
Number  Start     End        Size       Type     File system  Flags
 1      3072s     1051648s   1048577s   primary  ext4         boot
 2      1053696s  15522816s  14469121s  primary  ext4
```
KiB:
```
Number  Start     End        Size       Type     File system  Flags
 1      1573kB    538444kB   536871kB   primary  ext4         boot
 2      539492kB  7947682kB  7408190kB  primary  ext4
```
MiB:
```
Number  Start   End     Size    Type     File system  Flags
 1      1.57MB  538MB   537MB   primary  ext4         boot
 2      539MB   7948MB  7408MB  primary  ext4
```
~~Before this merges I would like add a fix for `init` which currently references a hard-coded 512MB partition sise. I'll add that after #44 has merged.~~ (not worth it)