### PR TITLE
build: ignore PKG_SOURCE_DIR when not required

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -85,10 +85,12 @@ else
   fi
 fi
 
-if [ -n "$PKG_SOURCE_DIR" ]; then
-  mv $BUILD/$PKG_SOURCE_DIR $BUILD/$PKG_NAME-$PKG_VERSION
-elif [ -d $BUILD/$PKG_NAME-$PKG_VERSION* -a ! -d $BUILD/$PKG_NAME-$PKG_VERSION ]; then
-  mv $BUILD/$PKG_NAME-$PKG_VERSION* $BUILD/$PKG_NAME-$PKG_VERSION
+if [ ! -d $BUILD/$PKG_NAME-$PKG_VERSION ]; then
+  if [ -n "$PKG_SOURCE_DIR" ]; then
+    mv $BUILD/$PKG_SOURCE_DIR $BUILD/$PKG_NAME-$PKG_VERSION
+  elif [ -d $BUILD/$PKG_NAME-$PKG_VERSION* ]; then
+    mv $BUILD/$PKG_NAME-$PKG_VERSION* $BUILD/$PKG_NAME-$PKG_VERSION
+  fi
 fi
 
 if [ -d "$PKG_DIR/sources" ]; then


### PR DESCRIPTION
If the package unpacks correctly, and `PKG_SOURCE_DIR` is being set, we can ignore the `PKG_SOURCE_DIR`.