### PR TITLE
addons: remove OE colours and 'official' text from LE repo

### DIFF
--- a/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.libreelec.tv"
-		name="[COLOR FF757677]Libre[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR] Add-ons (official)"
+		name="LibreELEC Add-ons"
 		version="7.0.0"
-		provider-name="Team [COLOR FF757677]Libre[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR]">
+		provider-name="Team LibreELEC">
 	<extension point="xbmc.addon.repository"
-		name="LibreELEC Add-ons (official)">
+		name="LibreELEC Add-ons">
 		<info>@ADDON_URL@/addons.xml</info>
 		<checksum>@ADDON_URL@/addons.xml.md5</checksum>
 		<datadir zip="true">@ADDON_URL@</datadir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
-		<summary>LibreELEC Add-ons (official)</summary>
-		<description>The LibreELEC official repository contains Kodi PVR Clients, Screensavers, Visualisations, the unofficial repo installer, and more. Add-ons in this repository are maintained and supported by LibreELEC staff and sponsors. If you find a broken or non-working add-on please report it via the forums.</description>
-		<platform>all</platform>	
+		<summary>LibreELEC Add-ons</summary>
+		<description>The LibreELEC add-on repository contains Kodi PVR Clients and Servers, Screensavers, Visualisations, and more. Add-ons in this repository are maintained and supported by LibreELEC staff and YOU the community. If you find a broken or non-working add-on please report it via the forums, or help by submitting fixes via GitHub.</description>
+		<platform>all</platform>
 	</extension>
 </addon>


### PR DESCRIPTION
This removes the OE blue/grey text colouring and multiple mentions of 'official' naming from the LE repo addon.xml