### PR TITLE
LibreELEC-settings: update to 6e3f5df

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="11b7fb4"
+PKG_VERSION="6e3f5df"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="prop."


### PR DESCRIPTION
[3924775](https://github.com/LibreELEC/service.libreelec.settings/commit/3924775301338b4e57218a207ee51ebcb40ae20f) This adds the migration function for those moving from OpenELEC.

[f60ceed](https://github.com/LibreELEC/service.libreelec.settings/commit/f60ceed9157a0cfaea04c9a8652ceab1a408ce13) This allows the auto updater to use .img.gz files

