### PR TITLE
RPi: Stop enabling serial console in devel images

### DIFF
--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -149,8 +149,3 @@
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS"
-
-  # set up serial console when building a development image
-    if [ "$DEVEL_VERSION" = "devel" ] ; then
-      EXTRA_CMDLINE="console=ttyAMA0,115200"
-    fi

--- a/projects/RPi2/options
+++ b/projects/RPi2/options
@@ -149,8 +149,3 @@
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS"
-
-  # set up serial console when building a development image
-    if [ "$DEVEL_VERSION" = "devel" ] ; then
-      EXTRA_CMDLINE="console=ttyAMA0,115200"
-    fi


### PR DESCRIPTION
Enabling `console=ttyAMA0,115200` as a default for devel images will result in no framebuffer console, which is frankly more useful to 99% of image users than a serial console.

Anyone that requires a serial console can add `EXTRA_CMDLINE=console=ttyAMA0,115200` to `$HOME/.libreelec/options`.

Although with recent firmware (since RPi3) the console device should now be `ttyS0`, as `ttyAMA0` is used for Bluetooth Serial on RPi3. Not sure if this also applies to RPi1 and RPi2, but could be handled by a project-specific `options` setting.