### PR TITLE
console: enable cursor for textmode and RPi serial consoles

### DIFF
--- a/packages/sysutils/busybox/system.d/shell.service
+++ b/packages/sysutils/busybox/system.d/shell.service
@@ -5,6 +5,7 @@ After=multi-user.target
 [Service]
 Environment=TTY=1
 WorkingDirectory=/storage
+ExecStartPre=/bin/sh -c 'echo -en "\033[?25h"'
 ExecStart=/bin/sh -c 'clear; lsb_release; . /etc/profile; exec /bin/sh'
 
 Restart=always

--- a/projects/RPi/filesystem/usr/lib/systemd/system/serial-console.service
+++ b/projects/RPi/filesystem/usr/lib/systemd/system/serial-console.service
@@ -6,6 +6,7 @@ ConditionKernelCommandLine=console
 [Service]
 WorkingDirectory=/storage
 Environment="ENV=/etc/profile"
+ExecStartPre=/bin/sh -c 'echo -en "\033[?25h"'
 ExecStart=/bin/sh
 Restart=always
 RestartSec=0

--- a/projects/RPi2/filesystem/usr/lib/systemd/system/serial-console.service
+++ b/projects/RPi2/filesystem/usr/lib/systemd/system/serial-console.service
@@ -6,6 +6,7 @@ ConditionKernelCommandLine=console
 [Service]
 WorkingDirectory=/storage
 Environment="ENV=/etc/profile"
+ExecStartPre=/bin/sh -c 'echo -en "\033[?25h"'
 ExecStart=/bin/sh
 Restart=always
 RestartSec=0


### PR DESCRIPTION
The console cursor is left disabled by `init` after #44.

I've tested `textmode` and that now has a working cursor. I'm assuming the RPi/RPi2 serial console works similarly to imx6 (see #83), but I'm unable to test this.