### PR TITLE
settings: bump to v0.7.1

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="2d8c7c6"
+PKG_VERSION="69d7952"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="prop."


### PR DESCRIPTION
fixes the last OE logo and adds text for wait-for-network