### PR TITLE
image: BUG_REPORT_URL should reflect origin repo used for build

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -45,6 +45,15 @@ if [ "$LIBREELEC_VERSION" = "devel" ]; then
   LIBREELEC_VERSION=$LIBREELEC_VERSION-$BUILD_DATE-r$GIT_BUILD-g$GIT_ABBREV
 fi
 
+# Get origin url, fix git:// and git@github.com: urls if necessary
+ORIGIN_URL="$(git remote -v | awk '$1 == "origin" { print $2 }' | head -1 | sed 's#\.git$##;s#^git:#https:#;s#^git@github\.com:#https://github.com/#')"
+
+if [ "$OFFICIAL" = "yes" ]; then
+  LIBREELEC_BUILD="official"
+else
+  LIBREELEC_BUILD="community"
+fi
+
 TARGET_VERSION="$PROJECT.$TARGET_ARCH-$LIBREELEC_VERSION"
 IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
 if [ "$DEVEL_VERSION" = "devel" ] ; then
@@ -98,17 +107,13 @@ fi
   echo -e "VERSION=\"$LIBREELEC_VERSION\"" >> $INSTALL/etc/os-release
   echo -e "ID=\"libreelec\"" >> $INSTALL/etc/os-release
   echo -e "VERSION_ID=\"$OS_VERSION\"" >> $INSTALL/etc/os-release
-  echo -e "PRETTY_NAME=\"$DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" ||  echo "community")) - Version: $LIBREELEC_VERSION\"" >> $INSTALL/etc/os-release
+  echo -e "PRETTY_NAME=\"$DISTRONAME ($LIBREELEC_BUILD) - Version: $LIBREELEC_VERSION\"" >> $INSTALL/etc/os-release
   echo -e "HOME_URL=\"http://www.libreelec.tv\"" >> $INSTALL/etc/os-release
-  echo -e "BUG_REPORT_URL=\"https://github.com/LibreELEC/LibreELEC.tv\"" >> $INSTALL/etc/os-release
+  echo -e "BUG_REPORT_URL=\"$ORIGIN_URL\"" >> $INSTALL/etc/os-release
   echo -e "BUILD_ID=\"$GIT_HASH\"" >> $INSTALL/etc/os-release
   echo -e "OPENELEC_ARCH=\"$PROJECT.$TARGET_ARCH\"" >> $INSTALL/etc/os-release
   echo -e "LIBREELEC_ARCH=\"$PROJECT.$TARGET_ARCH\"" >> $INSTALL/etc/os-release
-  if [ "$OFFICIAL" = "yes" ]; then
-    echo -e "LIBREELEC_BUILD=\"official\"" >> $INSTALL/etc/os-release
-  else
-    echo -e "LIBREELEC_BUILD=\"community\"" >> $INSTALL/etc/os-release
-  fi
+  echo -e "LIBREELEC_BUILD=\"$LIBREELEC_BUILD\"" >> $INSTALL/etc/os-release
 
 # create /etc/issue
   echo "$GREETING0" >  $INSTALL/etc/issue
@@ -116,7 +121,7 @@ fi
   echo "$GREETING2" >> $INSTALL/etc/issue
   echo "$GREETING3" >> $INSTALL/etc/issue
   echo "$GREETING4" >> $INSTALL/etc/issue
-  echo "$DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" ||  echo "community")) Version: $LIBREELEC_VERSION" >> $INSTALL/etc/issue
+  echo "$DISTRONAME ($LIBREELEC_BUILD) Version: $LIBREELEC_VERSION" >> $INSTALL/etc/issue
   if [ "$DEVEL_VERSION" = "devel" ] ; then
     echo "$DISTRONAME git: $GIT_HASH" >> $INSTALL/etc/issue
   fi


### PR DESCRIPTION
Requested by @chewitt to further differentiate community builds from official builds.

Builds from forked repositories will now point to their own issues page ie. https://github.com/chewitt/LibreELEC.tv/issues instead of https://github.com/LibreELEC/LibreELEC.tv/issues.

Builds from the upstream repository will continue to point to https://github.com/LibreELEC/LibreELEC.tv/issues.

Expressions where `official`/`community` is used have been simplified.