### PR TITLE
RBP: Update firmware to be in sync with kernel

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="c230b2b"
+PKG_VERSION="046effa"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="c230b2b"
+PKG_VERSION="046effa"
 PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"


### PR DESCRIPTION
Currently we have a new kernel but old firmware from Mar 15, which lacks support for https://github.com/raspberrypi/firmware/commit/1c4f14521087dc557468c2454d0a11e76930ace2 and is [breaking Bluetooth](http://forum.libreelec.tv/thread-64-post-428.html#pid428).

This needs to go into 6.90.005, and adding to the distro server.