### PR TITLE
libcec: added imx6 virtual libcec package

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -114,6 +114,15 @@ post_patch() {
     sed -i -e "s|^CONFIG_ISCSI_IBFT=.*$|# CONFIG_ISCSI_IBFT is not set|" $PKG_BUILD/.config
   fi
 
+  # enable different libcec version for imx6 project with kernel 4.4
+  # using customized kernel driver
+  if [ "$PROJECT" = "imx6" ]; then
+    if [ "$LIBCEC_TYPE" = "xbian" -a "$LINUX" = "imx6-4.4-xbian" ]; then
+      sed -i -e "s|# CONFIG_MXC_HDMI_CEC is not set|CONFIG_MXC_HDMI_CEC=y|" $PKG_BUILD/.config
+      sed -i -e "s|CONFIG_MXC_HDMI_CEC_SR=y||" $PKG_BUILD/.config
+    fi
+  fi
+
   # copy some extra firmware to linux tree
   cp -R $PKG_DIR/firmware/* $PKG_BUILD/firmware
 

--- a/projects/imx6/options
+++ b/projects/imx6/options
@@ -71,6 +71,9 @@
       LINUX="imx6-4.4-xbian"
     fi
 
+  # libcec type for kernel 4.4 (native/xbian)
+    LIBCEC_TYPE="xbian"
+
 
 ################################################################################
 # setup build defaults

--- a/projects/imx6/packages/libcec-xbian/package.mk
+++ b/projects/imx6/packages/libcec-xbian/package.mk
@@ -1,0 +1,74 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libcec"
+PKG_VERSION="bdaa8fbd2230d977215b59f3fa1d60fe687f98c8"
+PKG_REV="1"
+PKG_ARCH="arm"
+PKG_LICENSE="GPL"
+PKG_SITE="http://libcec.pulse-eight.com/"
+PKG_URL="https://github.com/xbianonpi/xbian-sources-libcec/archive/$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="xbian-sources-libcec-$PKG_VERSION"
+PKG_DEPENDS_TARGET="toolchain systemd lockdev p8-platform"
+PKG_PRIORITY="optional"
+PKG_SECTION="system"
+PKG_SHORTDESC="libCEC is an open-source dual licensed library designed for communicating with the Pulse-Eight USB - CEC Adaptor"
+PKG_LONGDESC="libCEC is an open-source dual licensed library designed for communicating with the Pulse-Eight USB - CEC Adaptor."
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+if [ "$KODIPLAYER_DRIVER" = "bcm2835-firmware" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET bcm2835-firmware"
+fi
+
+if [ "$KODIPLAYER_DRIVER" = "libfslvpuwrap" ]; then
+  EXTRA_CMAKE_OPTS="$EXTRA_CMAKE_OPTS -DHAVE_IMX_API=1"
+else
+  EXTRA_CMAKE_OPTS="$EXTRA_CMAKE_OPTS -DHAVE_IMX_API=0"
+fi
+
+if [ "$KODIPLAYER_DRIVER" = "libamcodec" ]; then
+  EXTRA_CMAKE_OPTS="$EXTRA_CMAKE_OPTS -DHAVE_AMLOGIC_API=1"
+else
+  EXTRA_CMAKE_OPTS="$EXTRA_CMAKE_OPTS -DHAVE_AMLOGIC_API=0"
+fi
+
+configure_target() {
+  if [ "$KODIPLAYER_DRIVER" = "bcm2835-firmware" ]; then
+    export CXXFLAGS="$CXXFLAGS \
+      -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads/ \
+      -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux"
+
+    # detecting RPi support fails without -lvchiq_arm
+    export LDFLAGS="$LDFLAGS -lvchiq_arm"
+  fi
+
+  cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF \
+        -DBUILD_SHARED_LIBS=1 \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+        -DCMAKE_INSTALL_LIBDIR_NOARCH=/usr/lib \
+        -DCMAKE_INSTALL_PREFIX_TOOLCHAIN=$SYSROOT_PREFIX/usr \
+        -DCMAKE_PREFIX_PATH=$SYSROOT_PREFIX/usr \
+        $EXTRA_CMAKE_OPTS \
+        ..
+}
+
+post_makeinstall_target() {
+  mv $INSTALL/usr/lib/python2.7/dist-packages $INSTALL/usr/lib/python2.7/site-packages
+}

--- a/projects/imx6/packages/libcec-xbian/patches/libcec-01-remove-ccache-support.patch
+++ b/projects/imx6/packages/libcec-xbian/patches/libcec-01-remove-ccache-support.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt	2016-01-22 03:23:37.000000000 +0100
++++ b/CMakeLists.txt	2016-03-05 02:25:00.624648960 +0100
+@@ -5,12 +5,6 @@
+ set(LIBCEC_VERSION_MINOR 0)
+ set(LIBCEC_VERSION_PATCH 1)
+ 
+-find_program(CCACHE_FOUND ccache)
+-if(CCACHE_FOUND)
+-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+-endif(CCACHE_FOUND)
+-
+ # cec-client
+ add_subdirectory(src/cec-client)
+ add_dependencies(cec-client cec)

--- a/projects/imx6/packages/libcec/package.mk
+++ b/projects/imx6/packages/libcec/package.mk
@@ -1,0 +1,60 @@
+################################################################################
+#      This file is part of LibreELEC - https://LibreELEC.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libcec"
+PKG_VERSION=""
+PKG_REV="1"
+PKG_ARCH="arm"
+PKG_LICENSE="GPL"
+PKG_SITE=""
+PKG_URL=""
+PKG_PRIORITY="optional"
+PKG_SECTION="virtual"
+PKG_SHORTDESC="libcec: Metapackage to choose correct libcec version."
+PKG_LONGDESC="libcec: Metapackage to choose correct libcec version."
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+if [ "$LIBCEC_TYPE" = "xbian" -a "$LINUX" = "imx6-4.4-xbian" ]; then
+  PKG_DIR=$ROOT/projects/$PROJECT/packages/libcec-xbian
+  . $PKG_DIR/package.mk
+else
+  # find default one from packages folder
+  _ALL_DIRS=""
+  _FOUND=0
+  PKG_DIR=""
+  for DIR in $(find $ROOT/$PACKAGES -type d -name $PKG_NAME 2>/dev/null); do
+    if [ -r "$DIR/package.mk" ]; then
+      # found first, set $PKG_DIR
+      PKG_DIR="$DIR"
+      # keep track of dirs with package.mk for detecting multiple folders
+      _ALL_DIRS="${_ALL_DIRS}${DIR}\\n"
+      _FOUND=$((_FOUND+1))
+      if [ $_FOUND -gt 1 ]; then
+        # found more ? fail
+        echo "Error - multiple package folders:"
+        echo -e "$_ALL_DIRS"
+        exit 1
+      fi
+    fi
+  done
+
+  if [ -n "$PKG_DIR" ]; then
+    . $PKG_DIR/package.mk
+  fi
+fi

--- a/projects/imx6/packages/p8-platform/package.mk
+++ b/projects/imx6/packages/p8-platform/package.mk
@@ -1,0 +1,48 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="p8-platform"
+PKG_VERSION="2.0.1"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.kodi.tv"
+PKG_URL="https://github.com/Pulse-Eight/platform/archive/p8-platform-$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="platform-$PKG_NAME-$PKG_VERSION"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="multimedia"
+PKG_SHORTDESC="Platform support library used by libCEC and binary add-ons for Kodi"
+PKG_LONGDESC="Platform support library used by libCEC and binary add-ons for Kodi"
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+configure_target() {
+  cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+        -DCMAKE_INSTALL_LIBDIR_NOARCH=/usr/lib \
+        -DCMAKE_INSTALL_PREFIX_TOOLCHAIN=$SYSROOT_PREFIX/usr \
+        -DCMAKE_PREFIX_PATH=$SYSROOT_PREFIX/usr \
+        -DBUILD_SHARED_LIBS=0 \
+        ..
+}
+
+post_makeinstall_target() {
+  rm -rf $INSTALL/usr
+}

--- a/projects/imx6/packages/p8-platform/patches/p8-platform-01-revert-cc-badness.patch
+++ b/projects/imx6/packages/p8-platform/patches/p8-platform-01-revert-cc-badness.patch
@@ -1,0 +1,30 @@
+From f91594676d1f75530addd87363ccbc6510efb84e Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Fri, 8 May 2015 11:19:42 +0300
+Subject: [PATCH] revert cc badness
+
+this reverts upstream commit 68f8418
+---
+ CMakeLists.txt |    6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 73fae2e..dc3e1b5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,12 +22,6 @@   set(PLAT_SOURCES src/windows/dlfcn-win32.cpp
+                    src/windows/os-threads.cpp)
+ endif()
+ 
+-set(p8-platform_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include/p8-platform")
+-IF(WIN32)
+-  LIST(APPEND p8-platform_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include/p8-platform/windows")
+-ENDIF(WIN32)
+-set(p8-platform_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+-
+ if(NOT ${CORE_SYSTEM_NAME} STREQUAL "")
+   if(${CORE_SYSTEM_NAME} STREQUAL "osx" OR ${CORE_SYSTEM_NAME} STREQUAL "ios")
+     list(APPEND p8-platform_LIBRARIES "-framework CoreVideo -framework IOKit")
+-- 
+1.7.10.4
+

--- a/projects/imx6/packages/p8-platform/patches/p8-platform-02-os-socket-poll.patch
+++ b/projects/imx6/packages/p8-platform/patches/p8-platform-02-os-socket-poll.patch
@@ -1,0 +1,58 @@
+commit 5658f756cc865798da15a58dab9bd8f5f41e8248
+Author: Matus Kral <matuskral@me.com>
+Date:   Thu Mar 19 17:50:03 2015 +0100
+
+    IMX6: allowing infinite timeout on read from dev file.
+    
+    SocketRead() was changed to polling (instead of select()).
+    In order for this to work, kernel driver must be returning POLLHUP
+    to interrupt waiting SocketRead(). Otherwise infinite timeout will
+    block CEC adapter termination.
+
+diff --git a/platform/src/posix/os-socket.h b/platform/src/posix/os-socket.h
+index 05888c2..d77e17d 100644
+--- a/src/posix/os-socket.h
++++ b/src/posix/os-socket.h
+@@ -113,8 +113,7 @@ namespace PLATFORM
+ 
+   inline ssize_t SocketRead(socket_t socket, int *iError, void* data, size_t len, uint64_t iTimeoutMs /*= 0*/)
+   {
+-    fd_set port;
+-    struct timeval timeout, *tv;
++    struct pollfd fds;
+     ssize_t iBytesRead(0);
+     *iError = 0;
+     CTimeout readTimeout(iTimeoutMs);
+@@ -127,28 +126,16 @@ namespace PLATFORM
+ 
+     while (iBytesRead >= 0 && iBytesRead < (ssize_t)len && (iTimeoutMs == 0 || readTimeout.TimeLeft() > 0))
+     {
+-      if (iTimeoutMs == 0)
+-      {
+-        tv = NULL;
+-      }
+-      else
+-      {
+-        long iTimeLeft = (long)readTimeout.TimeLeft();
+-        timeout.tv_sec  = iTimeLeft / (long int)1000.;
+-        timeout.tv_usec = iTimeLeft % (long int)1000.;
+-        tv = &timeout;
+-      }
+-
+-      FD_ZERO(&port);
+-      FD_SET(socket, &port);
+-      int32_t returnv = select(socket + 1, &port, NULL, NULL, tv);
++      fds.fd = (int)socket;
++      fds.events = POLLIN | POLLHUP;
++      ssize_t returnv = (ssize_t)poll(&fds, 1, iTimeoutMs ? iTimeoutMs : -1);
+ 
+       if (returnv == -1)
+       {
+         *iError = errno;
+         return -errno;
+       }
+-      else if (returnv == 0)
++      else if (returnv == 0 || fds.revents & POLLHUP)
+       {
+         break; //nothing to read
+       }


### PR DESCRIPTION
to choose xbian's version if kernel 4.4 is used or native one
added libcec package from xbian
added required p8-platform package (will be removed when platform will be renamed in the future)