### PR TITLE
libiconv: add libiconv package

### DIFF
--- a/packages/addons/addon-depends/libiconv/package.mk
+++ b/packages/addons/addon-depends/libiconv/package.mk
@@ -1,0 +1,43 @@
+################################################################################
+#      This file is part of LibreELEC - https://LibreELEC.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libiconv"
+PKG_VERSION="1.14"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://savannah.gnu.org/projects/libiconv/"
+PKG_URL="http://ftp.gnu.org/pub/gnu/libiconv/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="devel"
+PKG_SHORTDESC="Libiconv converts from one character encoding to another through Unicode conversion."
+PKG_LONGDESC="Libiconv converts from one character encoding to another through Unicode conversion."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+PKG_CONFIGURE_OPTS_TARGET="--host=$TARGET_NAME \
+            --build=$HOST_NAME \
+            --prefix=/usr \
+            --sysconfdir=/etc \
+            --enable-static \
+            --disable-shared \
+            --disable-nls \
+            --disable-extra-encodings \
+            --with-gnu-ld"

--- a/packages/addons/addon-depends/libiconv/patches/libiconv-glibc-fix-2.16.patch
+++ b/packages/addons/addon-depends/libiconv/patches/libiconv-glibc-fix-2.16.patch
@@ -1,0 +1,16 @@
+from
+http://www.itkb.ro/kb/linux/patch-libiconv-pentru-glibc-216
+
+--- a/srclib/stdio.in.h.orig	2011-08-07 16:42:06.000000000 +0300
++++ b/srclib/stdio.in.h	2013-01-10 15:53:03.000000000 +0200
+@@ -695,7 +695,9 @@
+ /* It is very rare that the developer ever has full control of stdin,
+    so any use of gets warrants an unconditional warning.  Assume it is
+    always declared, since it is required by C89.  */
+-_GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
++#if defined(__GLIBC__) && !defined(__UCLIBC__) && !__GLIBC_PREREQ(2, 16)
++ _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
++#endif
+ #endif
+ 
+ 

--- a/packages/addons/addon-depends/vdr/package.mk
+++ b/packages/addons/addon-depends/vdr/package.mk
@@ -24,7 +24,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvdr.de"
 PKG_URL="ftp://ftp.tvdr.de/vdr/$PKG_NAME-$PKG_VERSION.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain fontconfig freetype libcap libjpeg-turbo bzip2"
+PKG_DEPENDS_TARGET="toolchain fontconfig freetype libcap libiconv libjpeg-turbo bzip2"
 PKG_PRIORITY="optional"
 PKG_SECTION="multimedia"
 PKG_SHORTDESC="vdr: A powerful DVB TV application"
@@ -48,7 +48,7 @@ pre_make_target() {
   VIDEODIR = /storage/videos
   CONFDIR = /storage/.config/vdr
   LOCDIR = /usr/share/locale
-
+  LIBS += -liconv
   NO_KBD=yes
   VDR_USER=root
 EOF


### PR DESCRIPTION
- vdr add dependencies
- libiconv is needed for Tvheadend (without this the character conversion won't work)