### PR TITLE
mesa: enable-dri3

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -72,7 +72,7 @@ PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            --disable-gles1 \
                            --disable-gles2 \
                            --enable-dri \
-                           --disable-dri3 \
+                           --enable-dri3 \
                            --enable-glx \
                            --disable-osmesa \
                            --disable-gallium-osmesa \
@@ -101,6 +101,10 @@ PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            --with-gallium-drivers=$GALLIUM_DRIVERS \
                            --with-dri-drivers=$DRI_DRIVERS \
                            --with-sysroot=$SYSROOT_PREFIX"
+
+pre_configure_target() {
+  export LIBS="-lxcb-dri3 -lxcb-present -lxcb-sync -lxshmfence"
+}
 
 post_makeinstall_target() {
   # rename and relink for cooperate with nvidia drivers


### PR DESCRIPTION
I'd like to get this in before beta.

for intel dri3 is broken and disabled at compile time.
nvidia doesn't use the dri system
for radeon dri3 is built in but must be manually enabled via xorg.conf like so

```
Section "Device"
   Identifier  "Radeon"
   Driver      "radeon"
   Option      "DRI3"   "on"
EndSection
```

So this shouldn't harm anything and we can have people test DRI3 on radeon to see if we want to enable this by default in the future.