### PR TITLE
Add big.LITTLE support to buildsystem.

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -4,27 +4,12 @@
   fi
 
 # TARGET_CPU:
-# arm2 arm250 arm3 arm6 arm60 arm600 arm610 arm620 arm7 arm7m arm7d
-# arm7dm arm7di arm7dmi arm70 arm700 arm700i arm710 arm710c arm7100
-# arm720 arm7500 arm7500fe arm7tdmi arm7tdmi-s arm710t arm720t
-# arm740t strongarm strongarm110 strongarm1100 strongarm1110 arm8
-# arm810 arm9 arm9e arm920 arm920t arm922t arm946e-s arm966e-s
-# arm968e-s arm926ej-s arm940t arm9tdmi arm10tdmi arm1020t
-# arm1026ej-s arm10e arm1020e arm1022e arm1136j-s arm1136jf-s
-# mpcore mpcorenovfp arm1156t2-s arm1156t2f-s arm1176jz-s
-# arm1176jzf-s generic-armv7-a cortex-a5 cortex-a7 cortex-a8
-# cortex-a9 cortex-a12 cortex-a15 cortex-a17 cortex-a53
-# cortex-a57 cortex-a72 cortex-r4 cortex-r4f cortex-r5 cortex-r7
-# cortex-m7 cortex-m4 cortex-m3 cortex-m1 cortex-m0 cortex-m0plus
-# cortex-m1.small-multiply cortex-m0.small-multiply
-# cortex-m0plus.small-multiply exynos-m1 qdf24xx marvell-pj4
-# xscale iwmmxt iwmmxt2 ep9312 fa526 fa626 fa606te fa626te fmp626
-# fa726te xgene1 cortex-a15.cortex-a7 cortex-a17.cortex-a7
+# cortex-a53 cortex-a57 cortex-a72
 # cortex-a57.cortex-a53 cortex-a72.cortex-a53
 
 # determine architecture's family
   case $TARGET_CPU in
-    cortex-a53)
+    cortex-a53|cortex-a57|cortex-a57.cortex-a53|cortex-a72.cortex-a53)
       TARGET_SUBARCH=aarch64
       TARGET_VARIANT=armv8-a
       TARGET_ABI=eabi
@@ -34,7 +19,7 @@
       ;;
   esac
 
-  TARGET_GCC_ARCH=$(echo $TARGET_SUBARCH | sed -e "s,-,,")
+  TARGET_GCC_ARCH=${TARGET_SUBARCH/-}
   TARGET_KERNEL_ARCH=arm64
 
 # setup ARCH specific *FLAGS

--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -4,12 +4,13 @@
   fi
 
 # TARGET_CPU:
-# cortex-a53 cortex-a57 cortex-a72
-# cortex-a57.cortex-a53 cortex-a72.cortex-a53
+# generic cortex-a35 cortex-a53 cortex-a57 cortex-a72
+# exynos-m1 qdf24xx thunderx xgene1 cortex-a57.cortex-a53
+# cortex-a72.cortex-a53
 
 # determine architecture's family
   case $TARGET_CPU in
-    cortex-a53|cortex-a57|cortex-a57.cortex-a53|cortex-a72.cortex-a53)
+    generic|cortex-a35|cortex-a53|cortex-a57|cortex-a72|exynos-m1|qdf24xx|thunderx|xgene1|cortex-a57.cortex-a53|cortex-a72.cortex-a53)
       TARGET_SUBARCH=aarch64
       TARGET_VARIANT=armv8-a
       TARGET_ABI=eabi

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -31,7 +31,7 @@
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       SIMD_SUPPORT="no"
       ;;
-    cortex-a7|cortex-a15)
+    cortex-a7|cortex-a15|cortex-a15.cortex-a7|cortex-a17.cortex-a7)
       TARGET_SUBARCH=armv7ve
       TARGET_ABI=eabi
       TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
@@ -47,7 +47,7 @@
       ;;
   esac
 
-  TARGET_GCC_ARCH=$(echo $TARGET_SUBARCH | sed -e "s,-,,")
+  TARGET_GCC_ARCH=${TARGET_SUBARCH/-}
   TARGET_KERNEL_ARCH=arm
 
 # setup ARCH specific *FLAGS


### PR DESCRIPTION
Allows building code with big.LITTLE [optimization](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).

I use this on one of my community builds (Odroid_XU3).

I removed the aarch32 cpu's from the comments (cosmetic) of the aarch64 file and fixed a seemingly extra sed call with a bash substitution in both aarch32 and aarch64.