### PR TITLE
kodi-config: Hack to work around repo issue following OE-to-LE migration

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -22,6 +22,23 @@
 # done in kodi on addon install. but just in case..
 chmod +x /storage/.kodi/addons/*/bin/*
 
+# Nasty hack to work around OE to LE migration - Addons*.db needs to forget all about OE addons
+ADDONSDB=$(ls -1 /storage/.kodi/userdata/Database/Addons20.db 2>/dev/null)
+if [ -n "${ADDONSDB}" ]; then
+  OEREPO="'repository.openelec.tv'"
+
+  if [ -n "$(sqlite3 $ADDONSDB "SELECT id FROM repo WHERE addonID IN (${OEREPO})")" ]; then
+
+    [ -f ${ADDONSDB}.OE2LE_Backup ] || cp ${ADDONSDB} ${ADDONSDB}.OE2LE_Backup
+
+    sqlite3 $ADDONSDB "DELETE FROM addon WHERE id IN (SELECT idAddon FROM addonlinkrepo a JOIN repo b ON (a.idRepo = b.id) WHERE b.addonID in (${OEREPO}))"
+    sqlite3 $ADDONSDB "DELETE FROM addonextra WHERE id IN (SELECT idAddon FROM addonlinkrepo a JOIN repo b ON (a.idRepo = b.id) WHERE b.addonID in (${OEREPO}))"
+    sqlite3 $ADDONSDB "DELETE FROM dependencies WHERE id IN (SELECT idAddon FROM addonlinkrepo a JOIN repo b ON (a.idRepo = b.id) WHERE b.addonID in (${OEREPO}))"
+    sqlite3 $ADDONSDB "DELETE FROM addonlinkrepo WHERE idRepo in (SELECT id FROM repo WHERE addonID IN (${OEREPO}))"
+    sqlite3 $ADDONSDB "DELETE FROM repo WHERE addonID IN (${OEREPO})"
+  fi
+fi
+
 # hack: update RSSnews.xml in userdata
 if [ -f /storage/.kodi/userdata/RssFeeds.xml ]; then
   sed -e "s,http://libreelec.tv/news?format=feed&type=rss,http://feeds.libreelec.tv/news,g" \


### PR DESCRIPTION
An OE Kodi 16 installation will, naturally enough, have an Addons*.db that is populated with OE addons linked to the `repository.openelec.tv` repo.

However, following the migration to LE, Kodi 16 adds the same addons to Addons*.db, but now for the `repository.libreelec.tv` repo - the old OE addons are still present in the database, even though the `repository.openelec.tv` repo no longer exists.

So now, for example, there will be two `pvr.demo` addons in the `addon` table, one linked to the OE repo (usually with a low id, ie. 8) and again for the LE repo, but now with a much higher id, eg. 980.

When the user attempts to install the `pvr.demo` addon from the LE repository, Kodi seems to use the first addon it comes across, which is typically the addon with the lowest id and thus the legacy addon linked to the now non-existant `repository.openelec.tv`. Result: nothing happens - no error is shown to the user, or written to the log. The addon simply fails to install, silently.

As a quick fix, this PR simply deletes the OE repository and all associated addons from the latest pre-v21 Addons*.db. It also creates a backup, should the user decide to go back to OE.

Ideally, Kodi 16 would simply ignore those addons linked to repositories that are no longer available/valid.

Merge if nobody finds a better solution to the problem.