### PR TITLE
Qt5 x86 build modifications 

### DIFF
--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -80,6 +80,7 @@ PKG_CONFIGURE_OPTS_TARGET="--without-ada \
 pre_configure_target() {
   # causes some segmentation fault's (dialog) when compiled with gcc's link time optimization.
   strip_lto
+  CFLAGS="$CFLAGS -fPIC"
 }
 
 post_makeinstall_target() {

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -55,6 +55,12 @@ for drv in $GRAPHIC_DRIVERS; do
   [ "$drv" = "vmware" ] && XA_CONFIG="--enable-xa"
 done
 
+if [ "$OPENGLES_SUPPORT" = "yes" ]; then
+  MESA_GLES="--enable-gles2"
+else
+  MESA_GLES="--disable-gles2"
+fi
+ 
 PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            CXX_FOR_BUILD=$HOST_CXX \
                            CFLAGS_FOR_BUILD= \
@@ -70,7 +76,7 @@ PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            --disable-selinux \
                            --enable-opengl \
                            --disable-gles1 \
-                           --disable-gles2 \
+                           $MESA_GLES \
                            --enable-dri \
                            --enable-dri3 \
                            --enable-glx \

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -174,6 +174,9 @@ makeinstall_target() {
     if [ -f $PROJECT_DIR/$PROJECT/config/smb.conf ]; then
       mkdir -p $INSTALL/etc/samba
         cp $PROJECT_DIR/$PROJECT/config/smb.conf $INSTALL/etc/samba
+    elif [ -f $DISTRO_DIR/config/smb.conf ]; then
+      mkdir -p $INSTALL/etc/samba
+        cp $DISTRO_DIR/config/smb.conf $INSTALL/etc/samba
     else
       mkdir -p $INSTALL/etc/samba
         cp $PKG_DIR/config/smb.conf $INSTALL/etc/samba

--- a/packages/virtual/mediacenter/package.mk
+++ b/packages/virtual/mediacenter/package.mk
@@ -23,7 +23,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain $MEDIACENTER $MEDIACENTER-theme-$SKIN_DEFAULT"
+PKG_DEPENDS_TARGET="toolchain $MEDIACENTER"
 PKG_PRIORITY="optional"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="Mediacenter: Metapackage"
@@ -32,11 +32,13 @@ PKG_LONGDESC=""
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
-for i in $SKINS; do
-  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET $MEDIACENTER-theme-$i"
-done
-
 if [ "$MEDIACENTER" = "kodi" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET $MEDIACENTER-theme-$SKIN_DEFAULT"
+
+  for i in $SKINS; do
+    PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET $MEDIACENTER-theme-$i"
+  done
+  
 # some python stuff needed for various addons
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET Pillow"
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET simplejson"


### PR DESCRIPTION
On x86, qt5 build uses x11.
Although it's also requiring eglfs to build the associated plugin, which is why we need mesa to support it.

Lastly the mediacenter virtual package assumes that the mediacenter uses skins and themes, which is valid for Kodi, but not necessarilly for other platforms. 

