### PR TITLE
samba: fix directory creation

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -165,5 +165,4 @@
   browsable = yes
   public = yes
   writable = yes
-  root preexec = mkdir -p /storage/picons/tvh
-  root preexec = mkdir -p /storage/picons/vdr
+  root preexec = mkdir -p /storage/picons/tvh /storage/picons/vdr


### PR DESCRIPTION
I have no idea why two times root preexec doesn't work here (it works for the log dir).