### PR TITLE
Drop xf86-video-intel, use modesetting driver instead

### DIFF
--- a/packages/x11/xserver/xorg-server/config/xorg-modesetting.conf
+++ b/packages/x11/xserver/xorg-server/config/xorg-modesetting.conf
@@ -1,0 +1,4 @@
+Section "Device"
+    Identifier  "Intel Graphics"
+    Driver      "modesetting"
+EndSection

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -165,9 +165,8 @@ post_makeinstall_target() {
   mkdir -p $INSTALL/etc/X11
     if [ -f $PROJECT_DIR/$PROJECT/xorg/xorg.conf ]; then
       cp $PROJECT_DIR/$PROJECT/xorg/xorg.conf $INSTALL/etc/X11
-    elif [ -f $PKG_DIR/config/xorg.conf ]; then
-      cp $PKG_DIR/config/xorg.conf $INSTALL/etc/X11
     fi
+    cp $PKG_DIR/config/xorg*.conf $INSTALL/etc/X11
 
   if [ ! "$DEVTOOLS" = yes ]; then
     rm -rf $INSTALL/usr/bin/cvt

--- a/packages/x11/xserver/xorg-server/udev.d/97-xorg.rules
+++ b/packages/x11/xserver/xorg-server/udev.d/97-xorg.rules
@@ -31,7 +31,7 @@ GOTO="end_video"
 
 # check for drivers using the pci substem
 LABEL="subsystem_pci"
-DRIVER=="i915", ENV{xorg_driver}="i915", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xorg-configure@i915.service"
+DRIVER=="i915", ENV{xorg_driver}="modesetting", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xorg-configure@modesetting.service"
 DRIVER=="amdgpu", ENV{xorg_driver}="amdgpu", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xorg-configure@amdgpu.service"
 DRIVER=="radeon", ENV{xorg_driver}="radeon", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xorg-configure@radeon.service"
 GOTO="end_video"


### PR DESCRIPTION
Thanks for the tip @fritsch 

apparently,

1. the intel devs suggest using the modesetting driver + glamor
2. Ubuntu 16.04 may ship with the modesetting driver + glamor

I *think* I have done this correctly, but I don't have any intel graphics to test with.

see, https://www.reddit.com/r/archlinux/comments/4cojj9/it_is_probably_time_to_ditch_xf86videointel/