### PR TITLE
projects/WeTek_*: Move userdata wipe to factory_update_param script

### DIFF
--- a/projects/WeTek_Core/install/updater-script
+++ b/projects/WeTek_Core/install/updater-script
@@ -1,9 +1,6 @@
 show_progress(0.500000, 3);
 set_bootloader_env("upgrade_step", "3");
 
-ui_print("Wiping Userdata");
-format("ext4", "EMMC", "/dev/block/data", "0", "/data");
-
 ui_print("Writing kernel image");
 assert(package_extract_file("KERNEL", "/tmp/boot.img"),
     write_raw_image("/tmp/boot.img", "boot"),

--- a/projects/WeTek_Play/install/updater-script
+++ b/projects/WeTek_Play/install/updater-script
@@ -1,9 +1,6 @@
 show_progress(0.500000, 3);
 set_bootloader_env("upgrade_step", "3");
 
-ui_print("Wiping Userdata");
-format("ext4", "EMMC", "/dev/block/data", "0", "/data");
-
 show_progress(0.020000, 0);
 
 ui_print("Wiping System");

--- a/scripts/image
+++ b/scripts/image
@@ -407,6 +407,8 @@ fi
           echo "Creating Amlogic ZIP auto-install package"
           pushd sign > /dev/null
           echo --update_package=/sdcard/$IMAGE_NAME-update.zip > factory_update_param.aml
+          echo --wipe_data >> factory_update_param.aml
+          echo --wipe_cache >> factory_update_param.aml
           cp $INSTALL_SRC_DIR/files/recovery.img .
           if [ -f $INSTALL_SRC_DIR/files/aml_autoscript ]; then
             cp $INSTALL_SRC_DIR/files/aml_autoscript .


### PR DESCRIPTION
This allows updating LibreELEC via recovery without wiping userdata while keeping toothpick method work when a clean flash is needed. Without this patch _update_ in ZIP name can be confusing as it does user data wipe.

Ping @codesnake - are you OK with this?