### PR TITLE
scripts/image: create SD card image wtih amlpkg

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -332,7 +332,7 @@ fi
       tar cf $TARGET_IMG/$IMAGE_NAME.tar -C target $IMAGE_NAME
 
     # create image files if requested
-      if [ "$1" = "mkimage" -a -n "$BOOTLOADER" ]; then
+      if [[ ( "$1" = "amlpkg" || "$1" = "mkimage" ) && -n "$BOOTLOADER" ]]; then
         # projects can set KERNEL_NAME (kernel.img)
         if [ -z "$KERNEL_NAME" ] ; then
           KERNEL_NAME="KERNEL"


### PR DESCRIPTION
With this patch **make amlpkg** for WeTek creates both SD card and NAND packages. This saves time : one less build run, one less squashfs to create. Another benefit is that KERNEL and SYSTEM images are bit-to-bit equal in all packages.