### PR TITLE
visualization.waveforhue: initial add-on

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/visualization.wavforhue/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.wavforhue/package.mk
@@ -1,0 +1,50 @@
+################################################################################
+#      This file is part of LibreELEC - http://www.libreelec.tv
+#      Copyright (C) 2009-2016 Lukas Rusak (lrusak@libreelec.tv)
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="visualization.wavforhue"
+PKG_VERSION="e57e436"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.kodi.tv"
+PKG_URL="https://github.com/hardyt/visualization.wavforhue/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_PRIORITY="optional"
+PKG_SECTION=""
+PKG_SHORTDESC="visualization.wavforhue"
+PKG_LONGDESC="visualization.wavforhue"
+PKG_AUTORECONF="no"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.player.musicviz"
+
+configure_target() {
+  cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_MODULE_PATH=$SYSROOT_PREFIX/usr/lib/kodi \
+        -DCMAKE_PREFIX_PATH=$SYSROOT_PREFIX/usr \
+        ..
+}
+
+addon() {
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/
+  cp -R $PKG_BUILD/.install_pkg/usr/share/kodi/addons/$PKG_NAME/* $ADDON_BUILD/$PKG_ADDON_ID/
+
+  ADDONSO=$(xmlstarlet sel -t -v "/addon/extension/@library_linux" $ADDON_BUILD/$PKG_ADDON_ID/addon.xml)
+  cp -L $PKG_BUILD/.install_pkg/usr/lib/kodi/addons/$PKG_NAME/$ADDONSO $ADDON_BUILD/$PKG_ADDON_ID/
+}

--- a/packages/mediacenter/kodi-binary-addons/visualization.wavforhue/patches/visualization.wavforhue-0001-undo-p8-platform.patch
+++ b/packages/mediacenter/kodi-binary-addons/visualization.wavforhue/patches/visualization.wavforhue-0001-undo-p8-platform.patch
@@ -1,0 +1,39 @@
+diff -Naur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2016-03-03 12:18:48.000000000 -0800
++++ b/CMakeLists.txt	2016-04-11 12:38:06.499927119 -0700
+@@ -6,8 +6,8 @@
+ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
+ 
+ find_package(kodi REQUIRED)
+-#find_package(platform REQUIRED)
+-find_package(p8-platform REQUIRED)
++find_package(platform REQUIRED)
++#find_package(p8-platform REQUIRED)
+ find_package(kodiplatform REQUIRED)
+ find_package(CURL REQUIRED)
+ #find_package(yajl REQUIRED) #why is it so damn difficult to include Kodi's libraries???
+@@ -94,9 +94,9 @@
+ endif()
+ 
+ include_directories(${INCLUDES}
+-                    ${CURL_INCLUDE_DIR}
++                    ${CURL_INCLUDE_DIR}  
+                     ${KODI_INCLUDE_DIR}
+-                    ${p8-platform_INCLUDE_DIRS}
++                    ${platform_INCLUDE_DIRS}
+                     ${kodiplatform_INCLUDE_DIRS})
+ #                    ${YAJL_INCLUDE_DIR}
+ #                    ${platform_INCLUDE_DIRS}           
+diff -Naur a/src/WavforHue_Kodi.h b/src/WavforHue_Kodi.h
+--- a/src/WavforHue_Kodi.h	2016-03-03 12:18:48.000000000 -0800
++++ b/src/WavforHue_Kodi.h	2016-04-11 12:38:06.500927127 -0700
+@@ -23,6 +23,6 @@
+ // Is this worth it?
+ //#include <libKODI_guilib.h>
+ #include <libXBMC_addon.h>
+-#include "p8-platform/util/util.h"
++#include "platform/util/util.h"
+ extern ADDON::CHelper_libXBMC_addon *XBMC;
+-#endif
++#endif
+\ No newline at end of file


### PR DESCRIPTION
Included a patch that reverts p8-platform. This patch can be dropped after #98 