### PR TITLE
Add option for CUSTOM_IMAGE_NAME to allow for alternate image naming

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -64,7 +64,7 @@ if [ "$PROJECT" == "imx6" -a -n "$SYSTEM" ]; then
   IMAGE_NAME="$IMAGE_NAME-$SYSTEM"
 fi
 
-if [ ! -z "$CUSTOM_IMAGE_NAME" ]; then
+if [ -n "$CUSTOM_IMAGE_NAME" ]; then
    IMAGE_NAME="$CUSTOM_IMAGE_NAME" 
 fi
 

--- a/scripts/image
+++ b/scripts/image
@@ -64,6 +64,10 @@ if [ "$PROJECT" == "imx6" -a -n "$SYSTEM" ]; then
   IMAGE_NAME="$IMAGE_NAME-$SYSTEM"
 fi
 
+if [ ! -z "$CUSTOM_IMAGE_NAME" ]; then
+   IMAGE_NAME="$CUSTOM_IMAGE_NAME" 
+fi
+
 if [ -n "$IMAGE_SUFFIX" ]; then
   IMAGE_NAME="$IMAGE_NAME-$IMAGE_SUFFIX"
 fi


### PR DESCRIPTION
In our case we use an alternate image name in order to comply with our client apps updater setup, eg. PlexMediaPlayer-1.0.6.236-1ce41570.RPi2-arm.img

And to allow for custom image naming via the distributions options file we would like to have this added.'

An example of how to add this to the distro file would be for instance to add:

```
# Uncomment and Define CUSTOM_IMAGE_NAME in order to set custom image name on build
CUSTOM_IMAGE_NAME="$DISTRONAME-1.0.6.236-12345678.$PROJECT-$TARGET_ARCH"
```

This would result in: `LibreELEC-1.0.6.236-12345678.Generic-x86_64`

Other uses could be to feed the build with variables during build time:

eg. `CUSTOM_IMAGE_NAME="$DISTRONAME-$MYVARIABLE-$PROJECT-$TARGET_ARCH"`

Which by adding `MYVARIABLE=1.0.6.236-12345678` will result in `LibreELEC-1.0.6.236-12345678-Generic-x86_64`