### PR TITLE
config/functions : allow to have a per distro functions script

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -471,3 +471,8 @@ debug_strip() {
     $STRIP `find $* -type f -executable 2>/dev/null` 2>/dev/null || :
   fi
 }
+
+# Use distribution functions if any
+if [ -f "distributions/$DISTRO/config/functions" ]; then
+  . distributions/$DISTRO/config/functions
+fi


### PR DESCRIPTION
This PR will allow each distribution to have it's own set of functions that a custom package could use.

It also enables to override some default functions so that they behave slightly differently.

Typically, for each build we release, we dump symbols for a few packages so that we can use minidumps. that requires to override the debug_strip() default function so that we dump the symbols before stripping the binaries.

