### PR TITLE
installer : allow to have per distro EXTLINUX_PARAMETERS

### DIFF
--- a/packages/tools/installer/config/installer.conf
+++ b/packages/tools/installer/config/installer.conf
@@ -26,7 +26,7 @@
   PARTSIZE_SYSTEM_OFFSET="@SYSTEM_PART_START@"
 
 # additional parameters to extlinux
-  EXTLINUX_PARAMETERS=""
+  EXTLINUX_PARAMETERS="@EXTLINUX_PARAMETERS@"
 
 # enable BIOS update function
   BIOS_UPDATE="no"

--- a/packages/tools/installer/package.mk
+++ b/packages/tools/installer/package.mk
@@ -52,6 +52,7 @@ post_install() {
     fi
     sed -e "s/@SYSTEM_SIZE@/$SYSTEM_SIZE/g" \
         -e "s/@SYSTEM_PART_START@/$SYSTEM_PART_START/g" \
+        -e "s/@EXTLINUX_PARAMETERS@/$EXTLINUX_PARAMETERS/g" \
         -i $INSTALL/etc/installer.conf
 
   enable_service installer.service


### PR DESCRIPTION
This patch allows to define a per distro EXTLINUX_PARAMETERS.

The main goal of this is that you ssh isn't enabled on default distro, and it will only be anbled with thru kodi addon, which we don't have.

defining `EXTLINUX_PARAMETERS` in `$DISTRO/options` allows then to have default ssh 