### PR TITLE
bcm2835-bootloader : allow to have a per distro config.txt

### DIFF
--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -44,5 +44,10 @@ makeinstall_target() {
     cp -PRv start_x.elf $INSTALL/usr/share/bootloader/start.elf
 
     cp -PRv $PKG_DIR/scripts/update.sh $INSTALL/usr/share/bootloader
-    cp -PRv $PKG_DIR/files/3rdparty/bootloader/config.txt $INSTALL/usr/share/bootloader
+    
+    if [ -f $DISTRO_DIR/config/config.txt ]; then
+      cp -PRv $DISTRO_DIR/config/config.txt $INSTALL/usr/share/bootloader
+    else
+      cp -PRv $PKG_DIR/files/3rdparty/bootloader/config.txt $INSTALL/usr/share/bootloader
+    fi
 }


### PR DESCRIPTION
This allows another distro to use a different config.txt.

Typically we use alsa for which we need `dtparam=audio=on` to be added to the config.txt.
This would not be a good idea for Kodi, but mandatory for us.