### PR TITLE
build: Install gdb for release builds (RFC)

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -173,7 +173,9 @@ fi
 
 # Devtools... (not for Release)
   [ "$TESTING" = "yes" ] && $SCRIPTS/install testing
-  [ "$DEVTOOLS" = "yes" ] && $SCRIPTS/install debug
+
+# Install gdb in all builds, including releases
+  $SCRIPTS/install debug
 
 # OEM packages
   [ "$OEM_SUPPORT" = "yes" ] && $SCRIPTS/install oem


### PR DESCRIPTION
Quite often users experience a crash and the crash log is useless without `gdb`. We could offer `gdb` as an addon, but it's too late to capture the crash and users can't be expected to install the addon (assuming they're even able to install addons) and reproduce the crash.

This change will install `gdb` by default. There will be no way to __not__ install `gdb` - it's useful, why would you not want it? Though this could be made optional if required.

The size of `/usr/bin/gdb` is 3.5MB (RPi/RPi2) and 5.2MB (x86), so it will have a small impact on the overall size of SYSTEM.

I think the advantages of having `gdb` installed by default (more useful problem reports) outweigh any disadvantages (mainly, increased image size).

Any concerns, questions, issues? Happy to close if we're unable to reach agreement.