### PR TITLE
Image script : allow to execute a distro image script prior to image script

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -20,6 +20,10 @@
 
 . config/options $1
 
+if [ -f $DISTRO_DIR/$DISTRO/scripts/image ]; then
+  . $DISTRO_DIR/$DISTRO/scripts/image
+fi
+
 show_config
 
 $SCRIPTS/checkdeps


### PR DESCRIPTION
This allosw to run some operation, specifically to compute the CUSTOM_IMAGE_NAME