### PR TITLE
distros : config files paths fixups

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -174,9 +174,9 @@ makeinstall_target() {
     if [ -f $PROJECT_DIR/$PROJECT/config/smb.conf ]; then
       mkdir -p $INSTALL/etc/samba
         cp $PROJECT_DIR/$PROJECT/config/smb.conf $INSTALL/etc/samba
-    elif [ -f $DISTRO_DIR/config/smb.conf ]; then
+    elif [ -f $DISTRO_DIR/$DISTRO/config/smb.conf ]; then
       mkdir -p $INSTALL/etc/samba
-        cp $DISTRO_DIR/config/smb.conf $INSTALL/etc/samba
+        cp $DISTRO_DIR/$DISTRO/config/smb.conf $INSTALL/etc/samba
     else
       mkdir -p $INSTALL/etc/samba
         cp $PKG_DIR/config/smb.conf $INSTALL/etc/samba

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -45,8 +45,8 @@ makeinstall_target() {
 
     cp -PRv $PKG_DIR/scripts/update.sh $INSTALL/usr/share/bootloader
     
-    if [ -f $DISTRO_DIR/config/config.txt ]; then
-      cp -PRv $DISTRO_DIR/config/config.txt $INSTALL/usr/share/bootloader
+    if [ -f $DISTRO_DIR/$DISTRO/config/config.txt ]; then
+      cp -PRv $DISTRO_DIR/$DISTRO/config/config.txt $INSTALL/usr/share/bootloader
     else
       cp -PRv $PKG_DIR/files/3rdparty/bootloader/config.txt $INSTALL/usr/share/bootloader
     fi


### PR DESCRIPTION
The distro specific paths for which samba & RPi bootloader are looking are incorrect.

`$DISTRO_DIR`actually points to `LibreELEC.tv/distributions` so we need to add `$DISTRO` there.
Didn't see that before because of build tree remains :(