### PR TITLE
bcm2835-bootloader : make sure we deploy the proper config.txt

### DIFF
--- a/packages/tools/bcm2835-bootloader/release
+++ b/packages/tools/bcm2835-bootloader/release
@@ -27,3 +27,4 @@ mkdir -p $RELEASE_DIR/3rdparty/bootloader
   cp -PR $BUILD/bcm2835-bootloader-*/start_x.elf $RELEASE_DIR/3rdparty/bootloader/start.elf
   cp -PR $INSTALL/usr/share/bootloader/*.dtb $RELEASE_DIR/3rdparty/bootloader/
   cp -PR $INSTALL/usr/share/bootloader/overlays $RELEASE_DIR/3rdparty/bootloader/
+  cp -PR $INSTALL/usr/share/bootloader/config.txt $RELEASE_DIR/3rdparty/bootloader/


### PR DESCRIPTION
Distro can use a differnt config.txt which is deployed to usr/share/bootloader.
therefore we need to keep the consistency.

This is a follow up of the last PR : https://github.com/LibreELEC/LibreELEC.tv/pull/145