### PR TITLE
scripts : remove some hardcoded LibreELEC distro name

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -168,6 +168,8 @@ makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libreelec
     cp $PKG_DIR/scripts/functions $INSTALL/usr/lib/libreelec
     cp $PKG_DIR/scripts/fs-resize $INSTALL/usr/lib/libreelec
+    sed -e "s/@DISTRONAME@/$DISTRONAME/g" \
+        -i $INSTALL/usr/lib/libreelec/fs-resize
 
   mkdir -p $INSTALL/etc
     cp $PKG_DIR/config/profile $INSTALL/etc
@@ -250,5 +252,7 @@ makeinstall_init() {
 
   cp $PKG_DIR/scripts/functions $INSTALL
   cp $PKG_DIR/scripts/init $INSTALL
+  sed -e "s/@DISTRONAME@/$DISTRONAME/g" \
+      -i $INSTALL/init
   chmod 755 $INSTALL/init
 }

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -59,7 +59,7 @@ if [ -e /storage/.please_resize_me ] ; then
 
       echo "PARTITION RESIZING IN PROGRESS"
       echo ""
-      echo "Please do not reboot or turn off your LibreELEC device!"
+      echo "Please do not reboot or turn off your @DISTRONAME@ device!"
       echo ""
 
       StartProgress spinner "Deleting /storage... " "parted -s -m $DISK rm 2 &>/dev/null"

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -461,7 +461,7 @@
       if [ "$(( $FSCK_RET & 8 ))" = 8 ] ; then
         # fubar
         echo "Forced fsck failed. Your system is broken beyond repair"
-        echo "Please re-install LibreELEC"
+        echo "Please re-install @DISTRONAME@"
         echo ""
         echo "Press enter to shutdown now"
         echo ""
@@ -612,7 +612,7 @@
 
     echo "UPGRADE IN PROGRESS"
     echo ""
-    echo "Please do not reboot or turn off your LibreELEC device!"
+    echo "Please do not reboot or turn off your @DISTRONAME@ device!"
     echo ""
 
     if [ -f "$UPDATE_TAR" ] ; then

--- a/packages/tools/installer/package.mk
+++ b/packages/tools/installer/package.mk
@@ -43,6 +43,8 @@ makeinstall_target() {
 post_install() {
   mkdir -p $INSTALL/usr/bin
     cp $PKG_DIR/scripts/installer $INSTALL/usr/bin
+    sed -e "s/@DISTRONAME@/$DISTRONAME/g" \
+        -i  $INSTALL/usr/bin/installer
 
   mkdir -p $INSTALL/etc
     if [ -f $PROJECT_DIR/$PROJECT/installer/installer.conf ]; then

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -372,7 +372,7 @@ do_install_quick() {
       fi
 
       # install complete
-      MSG_TITLE="\Z1[ LibreELEC Install Complete ]\Zn"
+      MSG_TITLE="\Z1[ @DISTRONAME@ Install Complete ]\Zn"
       MSG_DETAIL="\nYou may now remove the install media and reboot\n"
       dialog --colors --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 6 52
 
@@ -495,7 +495,7 @@ do_install_custom() {
       rmdir $TMPDIR/part1 >> $LOGFILE 2>&1
 
       # install complete
-      MSG_TITLE="\Z1[ LibreELEC Install Complete ]\Zn"
+      MSG_TITLE="\Z1[ @DISTRONAME@ Install Complete ]\Zn"
       MSG_DETAIL="\nYou may now remove the install media and reboot\n"
       dialog --colors --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 6 52
 
@@ -591,7 +591,7 @@ menu_main() {
 
   dialog --colors --backtitle "$BACKTITLE" --cancel-label "$MSG_CANCEL" \
     --title "$MSG_TITLE" --menu "$MSG_MENU" 20 70 5 \
-      1 "Quick Install of LibreELEC" \
+      1 "Quick Install of @DISTRONAME@" \
       2 "Repair / Upgrade" \
       3 "Show logfile" 2> $TMPDIR/mainmenu
 
@@ -636,7 +636,7 @@ do_poweroff() {
 # setup needed variables
 INSTALLER_VERSION="0.2.8"
 OS_VERSION=$(lsb_release)
-BACKTITLE="LibreELEC Installer $INSTALLER_VERSION - $OS_VERSION"
+BACKTITLE="@DISTRONAME@ Installer $INSTALLER_VERSION - $OS_VERSION"
 
 TMPDIR="/tmp/installer"
 LOGFILE="$TMPDIR/install.log"


### PR DESCRIPTION
Allows a distro to have it's name appear in installer and busybox scripts