### PR TITLE
scripts/mkimage: we dont need md5 files in the image

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -149,8 +149,6 @@ EOF
     echo "image: copying files to part1..."
     mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
     mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-    mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-    mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
 
     mmd EFI EFI/BOOT
     mcopy $ROOT/$TOOLCHAIN/share/syslinux/bootx64.efi ::/EFI/BOOT
@@ -169,8 +167,6 @@ EOF
     echo "image: copying files to part1..."
     mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
     mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-    mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-    mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
 
     mcopy $RELEASE_DIR/3rdparty/bootloader/bootcode.bin ::
     mcopy $RELEASE_DIR/3rdparty/bootloader/fixup.dat ::
@@ -217,8 +213,6 @@ elif [ "$BOOTLOADER" = "u-boot" ]; then
     echo "image: copying files to part1..."
     mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
     mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-    mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-    mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
 
     if [ -n "$UBOOT_SYSTEM" -a -f "$RELEASE_DIR/3rdparty/bootloader/u-boot-$UBOOT_SYSTEM.img" ]; then
       mcopy "$RELEASE_DIR/3rdparty/bootloader/u-boot-$UBOOT_SYSTEM.img" ::/u-boot.img


### PR DESCRIPTION
This is not needed and just leaves unused files in the first partition.