### PR TITLE
Virtual Project Staging

### DIFF
--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -1,6 +1,7 @@
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+#      Copyright (C) 2016-     Team LibreELEC
 #
 #  OpenELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -33,6 +34,7 @@ PKG_LONGDESC="GLib is a library which includes support routines for C such as li
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
+PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared"
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_mmap_fixed_mapped=yes \
                            ac_cv_func_posix_getpwuid_r=yes \
                            ac_cv_func_posix_getgrgid_r=yes \

--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -1,0 +1,49 @@
+################################################################################
+#      This file is part of LibreELEC - http://www.libreelec.tv
+#      Copyright (C) 2016- Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="qemu"
+PKG_VERSION="2.5.1"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://wiki.qemu.org"
+PKG_URL="http://wiki.qemu-project.org/download/qemu-$PKG_VERSION.tar.bz2"
+PKG_DEPENDS_HOST="toolchain Python:host zlib:host glib:host"
+PKG_PRIORITY="optional"
+PKG_SECTION="tools"
+PKG_SHORTDESC="QEMU is a generic and open source machine emulator and virtualizer."
+PKG_LONGDESC="QEMU is a generic and open source machine emulator and virtualizer."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+HOST_CONFIGURE_OPTS="--prefix=$ROOT/$TOOLCHAIN \
+  --bindir=$ROOT/$TOOLCHAIN/bin \
+  --sbindir=$ROOT/$TOOLCHAIN/sbin \
+  --sysconfdir=$ROOT/$TOOLCHAIN/etc \
+  --libexecdir=$ROOT/$TOOLCHAIN/lib \
+  --localstatedir=$ROOT/$TOOLCHAIN/var \
+  --extra-cflags=-I$ROOT/$TOOLCHAIN/include \
+  --extra-ldflags=-L$ROOT/$TOOLCHAIN/lib \
+  --static \
+  --disable-vnc \
+  --disable-werror \
+  --disable-blobs \
+  --disable-system \
+  --disable-user \
+  --disable-docs"

--- a/packages/virtual/virtual/package.mk
+++ b/packages/virtual/virtual/package.mk
@@ -1,0 +1,33 @@
+################################################################################
+#      This file is part of LibreELEC - http://www.libreelec.tv
+#      Copyright (C) 2016-     Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="virtual"
+PKG_VERSION=""
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.libreelec.tv"
+PKG_URL=""
+PKG_DEPENDS_TARGET="qemu:host"
+PKG_PRIORITY="optional"
+PKG_SECTION="virtual"
+PKG_SHORTDESC="virtual: Meta package to install Virtual project extra deps"
+PKG_LONGDESC="virtual is a Meta package to install Virtual project extra dependencies"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"

--- a/projects/Virtual/config/ovf.template
+++ b/projects/Virtual/config/ovf.template
@@ -28,7 +28,7 @@ xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemS
       <Info>A human-readable annotation</Info>
       <Annotation>LibreELEC is &#x2018;Just enough OS&#x2019; for Kodi, a Linux distribution built to run Kodi on current and popular mediacentre hardware. We are an evolution of the popular OpenELEC project.</Annotation>
     </AnnotationSection>
-    <OperatingSystemSection ovf:id="1" vmw:osType="*other3xLinux64Guest">
+    <OperatingSystemSection ovf:id="94" vmw:osType="Ubuntu 64-bit">
       <Info>The kind of installed guest operating system</Info>
     </OperatingSystemSection>
     <VirtualHardwareSection> <Info>Virtual hardware requirements</Info>

--- a/projects/Virtual/config/ovf.template
+++ b/projects/Virtual/config/ovf.template
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?> <Envelope vmw:buildId="build-3018522" xmlns="http://schemas.dmtf.org/ovf/envelope/1" 
+xmlns:cim="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" 
+xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <References>
+    <File ovf:href="@DISK@.vmdk" ovf:id="file" ovf:size="@DISK_SIZE@"/>
+  </References>
+  <DiskSection>
+    <Info>Virtual disk information</Info>
+    <Disk ovf:capacity="548" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="disk" ovf:fileRef="file" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>The list of logical networks</Info>
+    <Network ovf:name="bridged">
+      <Description>The bridged network</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="@DISTRO@">
+    <Info>A virtual machine</Info>
+    <Name>@DISTRO@</Name>
+    <ProductSection>
+      <Info>Meta-information about the installed software</Info>
+      <Product>LibreELEC</Product>
+      <Vendor>LibreELEC</Vendor>
+      <ProductUrl>http://libreelec.tv</ProductUrl>
+      <VendorUrl>http://libreelec.tv</VendorUrl>
+    </ProductSection>
+    <AnnotationSection>
+      <Info>A human-readable annotation</Info>
+      <Annotation>LibreELEC is &#x2018;Just enough OS&#x2019; for Kodi, a Linux distribution built to run Kodi on current and popular mediacentre hardware. We are an evolution of the popular OpenELEC project.</Annotation>
+    </AnnotationSection>
+    <OperatingSystemSection ovf:id="1" vmw:osType="*other3xLinux64Guest">
+      <Info>The kind of installed guest operating system</Info>
+    </OperatingSystemSection>
+    <VirtualHardwareSection> <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>LibreELEC</vssd:VirtualSystemIdentifier>
+        <vssd:VirtualSystemType>vmx-09</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>512MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>512</rasd:VirtualQuantity>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>USB Controller (EHCI)</rasd:Description>
+        <rasd:ElementName>usb</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.usb.ehci</rasd:ResourceSubType>
+        <rasd:ResourceType>23</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="ehciEnabled" vmw:value="true"/>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>ideController0</rasd:ElementName>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>disk0</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/disk</rasd:HostResource>
+        <rasd:InstanceID>5</rasd:InstanceID>
+        <rasd:Parent>4</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>1</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>bridged</rasd:Connection>
+        <rasd:Description>E1000 ethernet adapter on &quot;bridged&quot;</rasd:Description>
+        <rasd:ElementName>ethernet0</rasd:ElementName>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:ElementName>sound</rasd:ElementName>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.soundcard.hdaudio</rasd:ResourceSubType>
+        <rasd:ResourceType>1</rasd:ResourceType>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:ElementName>video</rasd:ElementName>
+        <rasd:InstanceID>8</rasd:InstanceID>
+        <rasd:ResourceType>24</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="enable3DSupport" vmw:value="true"/>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:ElementName>vmci</rasd:ElementName>
+        <rasd:InstanceID>9</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.vmci</rasd:ResourceSubType>
+        <rasd:ResourceType>1</rasd:ResourceType>
+      </Item>
+      <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+      <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+      <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="soft"/>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>

--- a/scripts/image
+++ b/scripts/image
@@ -177,6 +177,9 @@ fi
 # LCD support
   [ ! "$LCD_DRIVER" = "none" ] && $SCRIPTS/install lcdproc
 
+# Virtual image creation support
+  [ "$PROJECT" = Virtual ] && $SCRIPTS/install virtual
+
 # Installer support
   [ "$INSTALLER_SUPPORT" = "yes" ] && $SCRIPTS/install installer
 

--- a/scripts/image
+++ b/scripts/image
@@ -367,6 +367,9 @@ fi
           PATH="$PATH:/sbin" \
           ROOT="$ROOT" \
           TOOLCHAIN="$TOOLCHAIN" \
+          PROJECT_DIR="$PROJECT_DIR" \
+          PROJECT="$PROJECT" \
+          DISTRO="$DISTRO" \
           TARGET_IMG="$TARGET_IMG" \
           IMAGE_NAME="$IMAGE_NAME" \
           BOOTLOADER="$BOOTLOADER" \

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -108,7 +108,7 @@ fi
   HEADS=4
   TRACKS=32
   SECTORS=$(( $SYSTEM_SIZE * 1024 * 1024 / 512 / $HEADS / $TRACKS ))
-  
+
   shopt -s expand_aliases  # enables alias expansion in script
   alias mformat="mformat -i $DISK@@$OFFSET -h $HEADS -t $TRACKS -s $SECTORS"
   alias mcopy="mcopy -i $DISK@@$OFFSET"
@@ -138,6 +138,18 @@ LABEL live
   KERNEL /$KERNEL_NAME
   APPEND boot=UUID=$UUID_SYSTEM live quiet tty vga=current
 EOF
+
+  if [ "$PROJECT" = Virtual ]; then
+    cat << EOF > "$OE_TMP"/syslinux.cfg
+DEFAULT virtual
+TIMEOUT 50
+PROMPT 0
+
+LABEL virtual
+  KERNEL /$KERNEL_NAME
+  APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet tty vga=current
+EOF
+  fi
 
     mcopy "$OE_TMP/syslinux.cfg" ::
 
@@ -255,7 +267,7 @@ fi # bootloader
   sync
 
 # add resize mark
-  if [ "$BOOTLOADER" != "syslinux" ]; then
+  if [ "$BOOTLOADER" != "syslinux" -o "$PROJECT" = Virtual ]; then
     mkdir "$OE_TMP/part2.fs"
     touch "$OE_TMP/part2.fs/.please_resize_me"
     echo "image: populating filesystem on part2..."
@@ -268,6 +280,7 @@ fi # bootloader
   echo "image: merging part2 back to image..."
   dd if="$OE_TMP/part2.ext4" of="$DISK" bs=512 seek="$STORAGE_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
 
+
 # extract part1 from image to run fsck
   echo "image: extracting part1 from image..."
   SYSTEM_PART_COUNT=$(( $SYSTEM_PART_END - $SYSTEM_PART_START + 1 ))
@@ -275,6 +288,17 @@ fi # bootloader
   dd if="$DISK" of="$OE_TMP/part1.fat" bs=512 skip="$SYSTEM_PART_START" count="$SYSTEM_PART_COUNT" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
   echo "image: checking filesystem on part1..."
   fsck -n $OE_TMP/part1.fat >"$SAVE_ERROR" 2>&1 || show_error
+
+# create virtual images
+  if [ "$PROJECT" = Virtual ]; then
+    echo "image: creating open virtual appliance..."
+    qemu-img convert -O vmdk -o subformat=streamOptimized "$DISK" "$DISK.vmdk"
+    sed -e "s,@DISTRO@,$DISTRO,g" -e "s,@DISK@,$(basename $DISK),g" -e "s,@DISK_SIZE@,$(ls -l $DISK.vmdk | awk '{print $5}'),g" $PROJECT_DIR/$PROJECT/config/ovf.template > $DISK.ovf
+    tar -C $TARGET_IMG -cf $DISK.ova $(basename $DISK).ovf $(basename $DISK).vmdk
+    echo "image: cleaning up..."
+    rm $DISK.vmdk $DISK.ovf
+    [ -n "$SUDO_USER" ] && chown $SUDO_USER: $DISK.ova
+  fi
 
 # gzip
   echo "image: compressing..."


### PR DESCRIPTION
This is a placeholder PR until this is cleaned up and finalized.

We are trying to make VMware and Virtualbox images during the regular `make image` process.  They should be generic enough to "just work" for use and be sane enough to handle both older versions of VB, or VMware.

Current status:

*VMware*
 - Import .ova file works as expected.
 - vmdk needs to be physically expanded by the user prior to booting for the first time or the storage partition will continue to stay the 32MB (which may be fine for the user).
   - If [PR#205](https://github.com/LibreELEC/LibreELEC.tv/pull/205) is used in conjunction, then user can resize disk at any point, then use the Reset LE to defaults option.
 - sound is working now

*Virtualbox*
 - Import .ova file works as expected.
 - image uses vmdk, so if the user wants to expand the disk, they will have to:
`vboxmanage clonehd $image.vmdk $image.vdi ; vboxmanage modifyhd $image.vdi --resize $size_in_mb`  : user can then attach the newly expanded vdi to their vm.
   - If [PR#205](https://github.com/LibreELEC/LibreELEC.tv/pull/205) is used in conjunction, then user can resize disk at any point, then use the Reset LE to defaults option.
