### PR TITLE
kodi: configure volume steps to 20 by default

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -19,6 +19,13 @@
         </setting>
       </group>
     </category>
+    <category id="audiooutput">
+      <group id="3">
+        <setting id="audiooutput.volumesteps">
+          <default>20</default>
+        </setting>
+      </group>
+    </category>
   </section>
 
   <section id="services">


### PR DESCRIPTION
The default number of steps when changing volume is currently 100, which is painful to use with a remote that doesn't support auto-repeat.

@stefansaraev added a GUI option in Kodi 17 that allows the default number of steps to be changed.

I'm proposing we choose a sane system default for LibreELEC. I find 20 (as in this PR) to be quite usable, but 25 or 30 could also work. The existing 100 default is not sane.

An (internal - sorry) poll on the Kodi forum revealed the following preferences:

 Steps   | Votes | %
---------|-------|------
10|0|0%
10 < x <= 20*|6|33.33%
20 < x <= 30|2|11.11%
40 < x <= 50|2|11.11%
50 < x <= 60|3|16.67%
60 < x <= 70|0|0%
70 < x <= 80|0|0%
80 < x <= 90|0|0%
90 < x <= 100|5|27.78%

So the majority favoured change, with a bias towards the lower end (20-30).

The object of this change is to select a "sane" default, not necessarily your personal preference. If there are no objections by the end of the week, I'll hit the button.