### PR TITLE
LibreELEC addon repository: change to xml.gz

### DIFF
--- a/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
@@ -5,8 +5,8 @@
 		provider-name="Team LibreELEC">
 	<extension point="xbmc.addon.repository"
 		name="LibreELEC Add-ons">
-		<info>@ADDON_URL@/addons.xml</info>
-		<checksum>@ADDON_URL@/addons.xml.md5</checksum>
+		<info>@ADDON_URL@/addons.xml.gz</info>
+		<checksum>@ADDON_URL@/addons.xml.gz.md5</checksum>
 		<datadir zip="true">@ADDON_URL@</datadir>
 	</extension>
 	<extension point="xbmc.addon.metadata">


### PR DESCRIPTION
- saves 75% of size/bandwidth

this is untested (@chewitt knows what to do)

I'm unsure what `<hashes>` does - Kodi wiki didn't tell the story (Kodi addon repo has this value).