### PR TITLE
libressl: add patch to add back a verisign cert

### DIFF
--- a/packages/security/libressl/patches/libressl-0001-add-back-verisign-cert.patch
+++ b/packages/security/libressl/patches/libressl-0001-add-back-verisign-cert.patch
@@ -1,0 +1,59 @@
+diff -Naur a/apps/cert.pem b/apps/cert.pem
+--- a/apps/cert.pem	2016-01-28 10:15:54.000000000 -0800
++++ b/apps/cert.pem	2016-04-19 23:26:35.648701712 -0700
+@@ -533,6 +533,55 @@
+ -----END CERTIFICATE-----
+ Certificate:
+     Data:
++        Version: 1 (0x0)
++        Serial Number:
++            3c:91:31:cb:1f:f6:d0:1b:0e:9a:b8:d0:44:bf:12:be
++    Signature Algorithm: sha1WithRSAEncryption
++        Issuer: C=US, O=VeriSign, Inc., OU=Class 3 Public Primary Certification Authority
++        Validity
++            Not Before: Jan 29 00:00:00 1996 GMT
++            Not After : Aug  2 23:59:59 2028 GMT
++        Subject: C=US, O=VeriSign, Inc., OU=Class 3 Public Primary Certification Authority
++        Subject Public Key Info:
++            Public Key Algorithm: rsaEncryption
++                Public-Key: (1024 bit)
++                Modulus:
++                    00:c9:5c:59:9e:f2:1b:8a:01:14:b4:10:df:04:40:
++                    db:e3:57:af:6a:45:40:8f:84:0c:0b:d1:33:d9:d9:
++                    11:cf:ee:02:58:1f:25:f7:2a:a8:44:05:aa:ec:03:
++                    1f:78:7f:9e:93:b9:9a:00:aa:23:7d:d6:ac:85:a2:
++                    63:45:c7:72:27:cc:f4:4c:c6:75:71:d2:39:ef:4f:
++                    42:f0:75:df:0a:90:c6:8e:20:6f:98:0f:f8:ac:23:
++                    5f:70:29:36:a4:c9:86:e7:b1:9a:20:cb:53:a5:85:
++                    e7:3d:be:7d:9a:fe:24:45:33:dc:76:15:ed:0f:a2:
++                    71:64:4c:65:2e:81:68:45:a7
++                Exponent: 65537 (0x10001)
++    Signature Algorithm: sha1WithRSAEncryption
++         10:72:52:a9:05:14:19:32:08:41:f0:c5:6b:0a:cc:7e:0f:21:
++         19:cd:e4:67:dc:5f:a9:1b:e6:ca:e8:73:9d:22:d8:98:6e:73:
++         03:61:91:c5:7c:b0:45:40:6e:44:9d:8d:b0:b1:96:74:61:2d:
++         0d:a9:45:d2:a4:92:2a:d6:9a:75:97:6e:3f:53:fd:45:99:60:
++         1d:a8:2b:4c:f9:5e:a7:09:d8:75:30:d7:d2:65:60:3d:67:d6:
++         48:55:75:69:3f:91:f5:48:0b:47:69:22:69:82:96:be:c9:c8:
++         38:86:4a:7a:2c:73:19:48:69:4e:6b:7c:65:bf:0f:fc:70:ce:
++         88:90
++SHA1 Fingerprint=A1:DB:63:93:91:6F:17:E4:18:55:09:40:04:15:C7:02:40:B0:AE:6B
++-----BEGIN CERTIFICATE-----
++MIICPDCCAaUCEDyRMcsf9tAbDpq40ES/Er4wDQYJKoZIhvcNAQEFBQAwXzELMAkG
++A1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFz
++cyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTk2
++MDEyOTAwMDAwMFoXDTI4MDgwMjIzNTk1OVowXzELMAkGA1UEBhMCVVMxFzAVBgNV
++BAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFzcyAzIFB1YmxpYyBQcmlt
++YXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MIGfMA0GCSqGSIb3DQEBAQUAA4GN
++ADCBiQKBgQDJXFme8huKARS0EN8EQNvjV69qRUCPhAwL0TPZ2RHP7gJYHyX3KqhE
++BarsAx94f56TuZoAqiN91qyFomNFx3InzPRMxnVx0jnvT0Lwdd8KkMaOIG+YD/is
++I19wKTakyYbnsZogy1Olhec9vn2a/iRFM9x2Fe0PonFkTGUugWhFpwIDAQABMA0G
++CSqGSIb3DQEBBQUAA4GBABByUqkFFBkyCEHwxWsKzH4PIRnN5GfcX6kb5sroc50i
++2JhucwNhkcV8sEVAbkSdjbCxlnRhLQ2pRdKkkirWmnWXbj9T/UWZYB2oK0z5XqcJ
++2HUw19JlYD1n1khVdWk/kfVIC0dpImmClr7JyDiGSnoscxlIaU5rfGW/D/xwzoiQ
++-----END CERTIFICATE-----
++Certificate:
++    Data:
+         Version: 3 (0x2)
+         Serial Number:
+             18:da:d1:9e:26:7d:e8:bb:4a:21:58:cd:cc:6b:3b:4a


### PR DESCRIPTION
to fix the stupid pandora issue.

I tested and it works both with curl and python's urllib2