### PR TITLE
Update bluez

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bluez"
-PKG_VERSION="5.38"
+PKG_VERSION="5.39"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/network/bluez/system.d/bluetooth.service
+++ b/packages/network/bluez/system.d/bluetooth.service
@@ -12,6 +12,9 @@ ExecStart=/usr/lib/bluetooth/bluetoothd $BLUEZ_ARGS $BLUEZ_DEBUG
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 LimitNPROC=1
 TimeoutStopSec=1s
+Restart=on-failure
+RestartSec=2
+StartLimitInterval=0
 
 [Install]
 WantedBy=bluetooth.target


### PR DESCRIPTION
Updates bluez to 5.39 and changes to restart bluetoothd on failure
5.39 fixes a double free and some audio related crashes

http://www.bluez.org/release-of-bluez-5-39/
"This is almost entirely a bug fix release with important fixes to GATT, HoG, AVRCP & A2DP. It is recommended to upgrade if you were previously using 5.38."
