### PR TITLE
factory-reset: re-partition using max space available.

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
+++ b/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
@@ -45,10 +45,12 @@ get_hddinfo() {
   done
   case $part in
     /dev/mmcblk*)
-      disk="${part%p2}"
+      part_num="${part#*mmcblk*p}"
+      disk="${part%p${part_num}}"
       ;;
     *)
-      disk="${part%2}"
+      part_num="${part//[!0-9]/}"
+      disk="${part%${part_num}}"
       ;;
   esac
 }
@@ -60,12 +62,12 @@ if [ -f /storage/.cache/reset_oe ] ; then
   if [ ! -z $part ] ; then
     StartProgress spinner "Resetting System (hard)..."
     # get storage partition start
-    part_start=$(parted -s -m $disk unit b print |grep -v ^/dev |grep -v BYT | grep ^2: |  cut -f2 -d ":")
+    part_start=$(parted -s -m $disk unit b print |grep -v ^/dev |grep -v BYT | grep ^$part_num: |  cut -f2 -d ":")
     # failed to get partition start offset ?
     if [ -n "$part_start" ] ; then
       umount $part
 
-      parted -s -m $disk rm 2 2>&1 >/dev/null
+      parted -s -m $disk rm $part_num 2>&1 >/dev/null
       parted -s -m $disk unit b mkpart primary $part_start 100% 2>&1 >/dev/null
       mke2fs -F -t ext4 -m 0 $part 2>&1 >/dev/null
       if [ ! -z $label ] ; then

--- a/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
+++ b/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
@@ -2,6 +2,7 @@
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
 #      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#      Copyright (C) 2016-     Team LibreELEC
 #
 #  OpenELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,42 +18,58 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-get_target() {
+get_hddinfo() {
   for arg in $(cat /proc/cmdline); do
     case $arg in
       disk=*)
-        disk="${arg#*=}"
-        case $disk in
+        local _disk="${arg#*=}"
+        case $_disk in
           LABEL=*)
-            label="${disk#*=}"
-            target=`blkid -L $label`
+            label="${_disk#*=}"
+            part=`blkid -L $label`
             ;;
           UUID=*)
-            uuid="${disk#*=}"
-            target=`blkid -U $uuid`
+            uuid="${_disk#*=}"
+            part=`blkid -U $uuid`
             ;;
           /*)
-            target=$disk
+            part=$_disk
             ;;
         esac
         ;;
     esac
   done
+  case $part in
+    /dev/mmcblk*)
+      disk="${part%p2}"
+      ;;
+    *)
+      disk="${part%2}"
+      ;;
+  esac
 }
 
 if [ -f /storage/.cache/reset_oe ] ; then
   # hard reset
   rm -f /storage/.cache/reset_oe
-  get_target
-  if [ ! -z $target ] ; then
+  get_hddinfo
+  if [ ! -z $part ] ; then
     echo "hard resetting..."
-    umount /storage
-    mke2fs -t ext4 -m 0 $target 2>&1 >/dev/null
-    if [ ! -z $label ] ; then
-      tune2fs -U random -L $label $target
-    fi
-    if [ ! -z $uuid ] ; then
-      tune2fs -U $uuid $target
+    # get storage partition start
+    part_start=$(parted -s -m $disk unit b print |grep -v ^/dev |grep -v BYT | grep ^2: |  cut -f2 -d ":")
+    # failed to get partition start offset ?
+    if [ -n "$part_start" ] ; then
+      umount $part
+
+      parted -s -m $disk rm 2 2>&1 >/dev/null
+      parted -s -m $disk unit b mkpart primary $part_start 100% 2>&1 >/dev/null
+      mke2fs -F -t ext4 -m 0 $part 2>&1 >/dev/null
+      if [ ! -z $label ] ; then
+        tune2fs -U random -L $label $part 2>&1 >/dev/null
+      fi
+      if [ ! -z $uuid ] ; then
+        tune2fs -U $uuid $part 2>&1 >/dev/null
+      fi
     fi
     echo "done"
     sleep 5
@@ -60,8 +77,8 @@ if [ -f /storage/.cache/reset_oe ] ; then
 elif [ -f /storage/.cache/reset_xbmc ] ; then
   # soft reset
   rm -f /storage/.cache/reset_xbmc
-  get_target
-  if [ ! -z $target ] ; then
+  get_hddinfo
+  if [ ! -z $part ] ; then
     echo "soft resetting..."
     rm -rf /storage/.??* 2>&1 >/dev/null
     echo "done"

--- a/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
+++ b/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
@@ -18,6 +18,10 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
+. /usr/lib/libreelec/functions
+
+hidecursor
+
 get_hddinfo() {
   for arg in $(cat /proc/cmdline); do
     case $arg in
@@ -54,7 +58,7 @@ if [ -f /storage/.cache/reset_oe ] ; then
   rm -f /storage/.cache/reset_oe
   get_hddinfo
   if [ ! -z $part ] ; then
-    echo "hard resetting..."
+    StartProgress spinner "Resetting System (hard)..."
     # get storage partition start
     part_start=$(parted -s -m $disk unit b print |grep -v ^/dev |grep -v BYT | grep ^2: |  cut -f2 -d ":")
     # failed to get partition start offset ?
@@ -71,19 +75,15 @@ if [ -f /storage/.cache/reset_oe ] ; then
         tune2fs -U $uuid $part 2>&1 >/dev/null
       fi
     fi
-    echo "done"
-    sleep 5
   fi
 elif [ -f /storage/.cache/reset_xbmc ] ; then
   # soft reset
   rm -f /storage/.cache/reset_xbmc
   get_hddinfo
   if [ ! -z $part ] ; then
-    echo "soft resetting..."
-    rm -rf /storage/.??* 2>&1 >/dev/null
-    echo "done"
-    sleep 5
+    StartProgress spinner "Resetting System (soft)..." "rm -rf /storage/.??* 2>&1 >/dev/null"
   fi
 fi
 sync
+StartProgress countdown "Rebooting in " "5"
 reboot -f


### PR DESCRIPTION
When using the factory-reset option in LE, the system would reboot and call target factory-reset.service which runs the script factory-reset.  The script unmounted /storage and then re-created the filesystem.

In conjunction with [PR#164](https://github.com/LibreELEC/LibreELEC.tv/pull/164)  I felt that it would be much simpler to also resize the partition first, allowing the new fs to use up all the space.  This makes it simple to expand (or shrink) the disk, as then the only thing required is "Reset LibreELEC to defaults".  This script is based on the [fs-resize](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/sysutils/busybox/scripts/fs-resize) script.

Hopefully I'm using the new progress goodies right.  I've tested this multiple times in a Virtual environment with success.