### PR TITLE
distro-tool: treat 350 status as valid for ftp

### DIFF
--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -274,7 +274,12 @@ class MyUtility(object):
     MyUtility.logmsg(msgs, 3, "[\n%s]" % headers)
 
     # Success if HTTP 200
-    result = True if MyUtility.search_HTTP_OK.search(headers) else False
+    if http_code == "200" or MyUtility.search_HTTP_OK.search(headers):
+      result = True
+    elif http_code == "350" and url.startswith("ftp:"):
+      result = True
+    else:
+      result = False
 
     tDelta = (datetime.datetime.now() - ts)
 


### PR DESCRIPTION
This is preventing the updated `mesa` package from downloading successfully.