### PR TITLE
tvheadend42: update to 4.1.1933

### DIFF
--- a/packages/addons/service/tvheadend42/changelog.txt
+++ b/packages/addons/service/tvheadend42/changelog.txt
@@ -1,3 +1,7 @@
+7.0.102
+- Update to Tvheadend 4.1.1933
+- fixes problems with DVB-C sticks
+
 7.0.101
 - Update to Tvheadend 4.1.1928
 

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="tvheadend42"
-PKG_VERSION="ac2d90e"
-PKG_VERSION_NUMBER="4.1.1928"
-PKG_REV="101"
+PKG_VERSION="7f24603"
+PKG_VERSION_NUMBER="4.1.1933"
+PKG_REV="102"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"


### PR DESCRIPTION
- fixes the problem that DVBC sticks won't work