### PR TITLE
tvheadend42: update to 4.1.1945

### DIFF
--- a/packages/addons/service/tvheadend42/changelog.txt
+++ b/packages/addons/service/tvheadend42/changelog.txt
@@ -1,6 +1,7 @@
-8.0.100
+8.0.102
 - Update for LibreELEC 8.0
-- Update to Tvheadend 4.1.1928
+- Update to Tvheadend 4.1.1945
+- fix the XMLTV import script
 
 7.0.100
 - initial LibreELEC version

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="tvheadend42"
-PKG_VERSION="ac2d90e"
-PKG_VERSION_NUMBER="4.1.1928"
-PKG_REV="100"
+PKG_VERSION="5374573"
+PKG_VERSION_NUMBER="4.1.1945"
+PKG_REV="102"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"


### PR DESCRIPTION
- fixes the problem that DVBC sticks won't work