### PR TITLE
procps-ng: Default to old top colour scheme

### DIFF
--- a/packages/tools/procps-ng/package.mk
+++ b/packages/tools/procps-ng/package.mk
@@ -33,6 +33,7 @@ PKG_AUTORECONF="yes"
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            ac_cv_func_realloc_0_nonnull=yes \
                            --disable-shared \
+                           --disable-modern-top \
                            --enable-static"
 
 makeinstall_target() {


### PR DESCRIPTION
While I'm grateful for the more functional `top` provided by procps-ng (thanks, @lrusak) I've no idea what the procps-ng developers are smoking but I don't want any of it - the new "modern" default UI scheme for `top` is awful (it's practically unusable) and quite a few other distributions - Arch, OpenEmbedded, Ubuntu 16.04 - would all seem to agree, as they're disabling it by default too.