### PR TITLE
systemd: fix machine-id uniqueness

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -184,7 +184,7 @@ makeinstall_target() {
     touch $INSTALL/etc/fstab
 
   # /etc/machine-id, needed by systemd and dbus
-    ln -sf /run/machine-id $INSTALL/etc/machine-id
+    ln -sf /storage/.cache/machine-id $INSTALL/etc/machine-id
 
   # /etc/mtab is needed by udisks etc...
     ln -sf /proc/self/mounts $INSTALL/etc/mtab

--- a/packages/sysutils/systemd/scripts/systemd-machine-id-setup
+++ b/packages/sysutils/systemd/scripts/systemd-machine-id-setup
@@ -17,21 +17,25 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-# Attempts to generate a unique machine ID based on one local MAC address
-# MACHINEID SHOULD be the same between upgrades/reinstalls
-# MAC is hashed so that it cant be reversed making it anonymous
-# Used to help with global usage statistics, also used for dbus and systemd
+# Creates a unique machine-id based on a local MAC address which persists over
+# reboots, upgrades and reinstallation. For systems with slow loading network
+# drivers (no MAC's available) dbus-uuidgen is used which persists over reboot
+# and upgrades but not reinstallation. If a MAC is used it is hashed to make it
+# anonymous. The machine-id is used by dbus and systemd, and to collect basic
+# active-installation statistics on LibreELEC users.
 
-# creating machine-id, systemd otherwise does this automatically if not present.
-# this we want to avoid to have the same machine-id over reboot, fallback
-# to systemd's solution if this dont work here
-
-if [ -e "/sys/class/net/eth0/address" ]; then
-  MAC_ADRESS=`cat /sys/class/net/eth0/address`
+if [ -e "/storage/.cache/machine-id" ]; then
+  MACHINEID=`cat /storage/.cache/machine-id`
+elif [ -e "/sys/class/net/eth0/address" ]; then
+  MAC_ADDRESS=`cat /sys/class/net/eth0/address`
 elif [ -e "/sys/class/net/wlan0/address" ]; then
-  MAC_ADRESS=`cat /sys/class/net/wlan0/address`
+  MAC_ADDRESS=`cat /sys/class/net/wlan0/address`
+else
+  MAC_ADDRESS=`/usr/bin/dbus-uuidgen`
 fi
 
-MACHINEID=`echo $MAC_ADRESS | md5sum | cut -f1 -d" "`
+if [ -z "$MACHINEID" ]; then
+  MACHINEID=`echo $MAC_ADDRESS | md5sum | cut -f1 -d" "`
+fi
 
-echo "$MACHINEID" > /run/machine-id
+echo "$MACHINEID" > /storage/.cache/machine-id


### PR DESCRIPTION
In @kszaq builds (and likely others) multiple hosts report `68b329da9893e34099c7d8ad5cb9c940` as the machine-id hash is being derived from the "/sys/class/net/eth0/address: No such file or directory" error message due to delayed driver loading and no MAC being present. This change sets BLANK as a default value then backgrounds a task that tries at 250ms intervals for 15 seconds until the ethernet or wireless interfaces appear. Once eth0 or wlan0 appear the correct MAC hash overwrites BLANK and is used in all future update queries so that project stats show correctly.