### PR TITLE
distro-tool: Workaround packages that call exit

### DIFF
--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -456,9 +456,9 @@ class MyThread(threading.Thread):
 
         msgs = []
 
-        if pkg_version == "" or pkg_url == "":
+        if pkg_version == "" or pkg_version == "0.0invalid" or pkg_url == "":
           if pkg_section != "virtual":
-            MyUtility.show(msgs, 0, "cyan", "BLANK URL OR VERSION", "%s (ver [%s], url [%s])" % (pkg_name, pkg_version, pkg_url))
+            MyUtility.show(msgs, 0, "cyan", "UNKNOWN VER OR URL", "%s (ver [%s], url [%s])" % (pkg_name, pkg_version, pkg_url))
             self.output_queue.put(msgs)
           continue
 
@@ -670,6 +670,11 @@ generate_work() {
   fi
 
   (
+    # Override exit function so that packages calling exit don't terminate this sub-shell
+    exit() {
+      :
+    }
+
     init_progress
 
     cd $LIBREELEC_DIR
@@ -678,7 +683,7 @@ generate_work() {
     for package_name in ${packages}; do
       [ ${PROGRESS} == yes ] && progress ${pcount}
 
-      . config/options ${package_name} 2>/dev/null || true
+      source config/options ${package_name} 2>/dev/null || true
 
       if [ -n "${revision}" ]; then
         PKG_URL="${PKG_URL/${PKG_VERSION}/${revision}}"


### PR DESCRIPTION
`u-boot` package.mk is triggering an error due to it calling `exit 0`. Other packages could do something similar, so implement a fix.

`opengl-meson` resolves to version `0.0invalid` - handle this.