### PR TITLE
repository: use xml.gz

### DIFF
--- a/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
@@ -5,8 +5,8 @@
 		provider-name="Team LibreELEC">
 	<extension point="xbmc.addon.repository"
 		name="LibreELEC Add-ons">
-		<info>@ADDON_URL@/addons.xml</info>
-		<checksum>@ADDON_URL@/addons.xml.md5</checksum>
+		<info>@ADDON_URL@/addons.xml.gz</info>
+		<checksum>@ADDON_URL@/addons.xml.gz.md5</checksum>
 		<datadir zip="true">@ADDON_URL@</datadir>
 	</extension>
 	<extension point="xbmc.addon.metadata">


### PR DESCRIPTION
This backports #175 to the libreelec-7.0 branch. I am publishing addons.xml and addons.xml.gz to the 7.0 repo to ensure we support users on builds before/after this change.