### PR TITLE
libressl: Add /etc/pki/tls link for backwards compat

### DIFF
--- a/packages/security/libressl/package.mk
+++ b/packages/security/libressl/package.mk
@@ -31,3 +31,9 @@ PKG_LONGDESC="LibreSSL is a FREE version of the SSL/TLS protocol forked from Ope
 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
+
+post_makeinstall_target() {
+  # backwards comatibility
+  mkdir -p $INSTALL/etc/pki/tls
+    ln -sf /etc/ssl/cert.pem $INSTALL/etc/pki/tls/cacert.pem
+}


### PR DESCRIPTION
Addons such as Quasar have a dependency on `/etc/pki/tls/cacert.pem`.

http://forum.kodi.tv/showthread.php?tid=269814&pid=2328868#pid2328868