### PR TITLE
efivar: allocate enough memory in makeguids tool (backport)

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/depends/efivar/patches/efivar-makeguids-allocate-fix.patch
+++ b/packages/addons/addon-depends/system-tools-depends/depends/efivar/patches/efivar-makeguids-allocate-fix.patch
@@ -1,0 +1,32 @@
+fix for
+
+./makeguids guids.txt guids.bin names.bin guid-symbols.S efivar-guids.h
+makeguids: malloc.c:2395: sysmalloc: Assertion `(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_top) && ((unsigned long) old_end & (pagesize - 1)) == 0)' failed.
+
+--- a/src/makeguids.c	2014-10-15 06:48:49.000000000 -0700
++++ b/src/makeguids.c	2016-05-05 05:40:35.964612900 -0700
+@@ -99,10 +99,8 @@
+ 	if (rc < 0)
+ 		err(1, "makeguids: could not read \"%s\"", argv[1]);
+ 
+-	/* strictly speaking, this *has* to be too large. */
+-	struct guidname *outbuf = calloc(inlen, sizeof (char));
+-	if (!outbuf)
+-		err(1, "makeguids");
++	/* reallocate later to required size */
++	struct guidname *outbuf = NULL;
+ 
+ 	char *guidstr = inbuf;
+ 	unsigned int line;
+@@ -133,6 +131,11 @@
+ 			err(1, "makeguids: \"%s\": 4 invalid data on line %d",
+ 				argv[1], line);
+ 
++		outbuf = realloc(outbuf, line * sizeof (struct guidname));
++		if (!outbuf)
++			err(1, "makeguids");
++
++		bzero(&outbuf[line-1], sizeof (struct guidname));
+ 		memcpy(&outbuf[line-1].guid, &guid, sizeof(guid));
+ 		strcpy(outbuf[line-1].symbol, "efi_guid_");
+ 		strncat(outbuf[line-1].symbol, symbol,


### PR DESCRIPTION
Without execution (sometimes) fail:

./makeguids guids.txt guids.bin names.bin guid-symbols.S efivar-guids.h
makeguids: malloc.c:2395: sysmalloc: Assertion `(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_top) && ((unsigned long) old_end & (pagesize - 1)) == 0)' failed.
