### PR TITLE
pvr.iptvsimple: update to 373b525

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="b741cac"
+PKG_VERSION="373b525"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Kodi API was changed in the latest revision. Please, update pvr.iptvsimple addon to latest revision. It works, I tested it.