### PR TITLE
libmad: fix 'unary operator expected' error

### DIFF
--- a/packages/addons/addon-depends/libmad/package.mk
+++ b/packages/addons/addon-depends/libmad/package.mk
@@ -34,7 +34,7 @@ PKG_AUTORECONF="yes"
 
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-if [ $TARGET_ARCH == "x86_64" ] ; then
+if [ "$TARGET_ARCH" = "x86_64" ] ; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-accuracy --enable-fpm=64bit"
 fi
 


### PR DESCRIPTION
```packages/addons/addon-depends/libmad/package.mk: line 37: [: ==: unary operator expected```