### PR TITLE
projects/imx6: use Linux kernel 4.4 by default (backport)

### DIFF
--- a/projects/imx6/options
+++ b/projects/imx6/options
@@ -62,14 +62,13 @@
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)
     KERNEL_MAKE_EXTRACMD=""
 
-  # Kernel to use. values can be:
-  # default:  default mainline kernel
-    if [ -z "$LINUX_VERSION" ]; then
-      LINUX="imx6"
-    else
+  # Kernel to use.
+  # default is 4.4 from xbian
+    if [ -z "$LINUX_VERSION" -o "$LINUX_VERSION" != "sr-3.14" ]; then
       LINUX="imx6-4.4-xbian"
+    else
+      LINUX="imx6"
     fi
-
 
 ################################################################################
 # setup build defaults


### PR DESCRIPTION
to use kernel 3.14 from solidrun use extra build parameter LINUX_VERSION="sr-3.14"