### PR TITLE
kodi: update appliance.xml after settings reshuffle.

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -88,7 +88,7 @@
     </category>
 
     <category id="pvrpowermanagement">
-      <group id="2">
+      <group id="1">
         <setting id="pvrpowermanagement.setwakeupcmd">
           <default>/usr/bin/setwakeup.sh</default>
         </setting>


### PR DESCRIPTION
Moves `pvrpowermanagement.setwakeupcmd` from group 2 to 1.

--
Untested.