### PR TITLE
transmission: addon proposal

### DIFF
--- a/packages/addons/service/docker.transmission/changelog.txt
+++ b/packages/addons/service/docker.transmission/changelog.txt
@@ -1,0 +1,2 @@
+8.0.100
+- Initial addon

--- a/packages/addons/service/docker.transmission/package.mk
+++ b/packages/addons/service/docker.transmission/package.mk
@@ -1,0 +1,61 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="transmission"
+PKG_VERSION="1.0.0"
+PKG_REV="100"
+PKG_ARCH="any"
+PKG_LICENSE="GPLv2"
+PKG_SITE="http://www.libreelec.tv"
+PKG_DEPENDS_TARGET=""
+PKG_AUTORECONF="no"
+PKG_PRIORITY="optional"
+PKG_SECTION="service/docker"
+PKG_SHORTDESC="Transmission"
+PKG_LONGDESC="an open source, easy, lean and powerful BitTorrent client"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_NAME="Transmission (Docker)"
+PKG_ADDON_TYPE="xbmc.service"
+PKG_ADDON_REPOVERSION="8.0"
+PKG_ADDON_REQUIRES="service.system.docker:0.0.0"
+
+make_target() {
+  : # nothing to do here
+}
+
+makeinstall_target() {
+  : # nothing to do here
+}
+
+addon() {
+  case $ARCH in
+    arm)
+      OWNER="libreelecarm"
+      ;;
+    x86_64)
+      OWNER="libreelec"
+      ;;
+  esac
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID
+  cp -r $ROOT/$PKG_BUILD/* $ADDON_BUILD/$PKG_ADDON_ID
+  sed -e "s/@OWNER@/$OWNER/g" \
+      -e "s/@NAME@/$PKG_NAME/g" \
+      -e "s/@TAG@/$PKG_VERSION/g" \
+      -i $ADDON_BUILD/$PKG_ADDON_ID/bin/transmission.sh
+}

--- a/packages/addons/service/docker.transmission/sources/bin/transmission.sh
+++ b/packages/addons/service/docker.transmission/sources/bin/transmission.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+# Dispose of legacy services
+for service in service.downloadmanager.@NAME@ @NAME@
+do
+  systemctl stop "$service" 2>/dev/null
+  systemctl disable "$service" 2>/dev/null
+done
+
+. /etc/profile
+oe_setup_addon service.docker.@NAME@
+
+mkdir -p "$tx_config" "$tx_downloads" "$tx_incomplete" "$tx_watch"
+
+docker rm @NAME@ 2>/dev/null
+docker run --rm \
+           --name=@NAME@ \
+           --hostname=libreelec-@NAME@ \
+           --volume="$tx_config":/config \
+           --volume="$tx_downloads":/downloads \
+           --volume="$tx_incomplete":/incomplete \
+           --volume="$tx_watch":/watch \
+           --publish="$tx_peer":45555 \
+           --publish="$tx_rpc":9091 \
+           "@OWNER@/@NAME@:@TAG@"

--- a/packages/addons/service/docker.transmission/sources/default.py
+++ b/packages/addons/service/docker.transmission/sources/default.py
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+import subprocess
+import xbmc
+import xbmcaddon
+
+
+class Monitor(xbmc.Monitor):
+
+   def __init__(self, *args, **kwargs):
+      xbmc.Monitor.__init__(self)
+      self.id = xbmcaddon.Addon().getAddonInfo('id')
+
+   def onSettingsChanged(self):
+      subprocess.call(['systemctl', 'restart', self.id])
+
+
+if __name__ == "__main__":
+   Monitor().waitForAbort()

--- a/packages/addons/service/docker.transmission/sources/resources/language/English/strings.po
+++ b/packages/addons/service/docker.transmission/sources/resources/language/English/strings.po
@@ -1,0 +1,38 @@
+msgid ""
+msgstr ""
+
+msgctxt "#30000"
+msgid "Settings"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Folders"
+msgstr ""
+
+msgctxt "#30002"
+msgid "config"
+msgstr ""
+
+msgctxt "#30003"
+msgid "downloads"
+msgstr ""
+
+msgctxt "#30004"
+msgid "incomplete"
+msgstr ""
+
+msgctxt "#30005"
+msgid "watch"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Ports"
+msgstr ""
+
+msgctxt "#30007"
+msgid "peer"
+msgstr ""
+
+msgctxt "#30008"
+msgid "rpc"
+msgstr ""

--- a/packages/addons/service/docker.transmission/sources/resources/settings.xml
+++ b/packages/addons/service/docker.transmission/sources/resources/settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+   <category   label="30000">
+      <setting label="30001" type="lsep" />
+      <setting label="30002" type="folder" id="tx_config"     default="/storage/downloads/transmission/config"          option="writeable" />
+      <setting label="30003" type="folder" id="tx_downloads"  default="/storage/downloads/transmission/downloads"       option="writeable" />
+      <setting label="30004" type="folder" id="tx_incomplete" default="/storage/downloads/transmission/incomplete"      option="writeable" />
+      <setting label="30005" type="folder" id="tx_watch"      default="/storage/downloads/transmission/watch"           option="writeable" />
+      <setting label="30006" type="lsep" />
+      <setting label="30007" type="number" id="tx_peer" default="45555" />
+      <setting label="30008" type="number" id="tx_rpc"  default="9091"  />
+   </category>
+</settings>

--- a/packages/addons/service/docker.transmission/sources/settings-default.xml
+++ b/packages/addons/service/docker.transmission/sources/settings-default.xml
@@ -1,0 +1,8 @@
+<settings>
+    <setting id="tx_config" value="/storage/downloads/transmission/config" />
+    <setting id="tx_downloads" value="/storage/downloads/transmission/downloads" />
+    <setting id="tx_incomplete" value="/storage/downloads/transmission/incomplete" />
+    <setting id="tx_peer" value="45555" />
+    <setting id="tx_rpc" value="9091" />
+    <setting id="tx_watch" value="/storage/downloads/transmission/watch" />
+</settings>

--- a/packages/addons/service/docker.transmission/sources/system.d/service.docker.transmission.service
+++ b/packages/addons/service/docker.transmission/sources/system.d/service.docker.transmission.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=transmission container
+Requires=service.system.docker.service
+After=service.system.docker.service
+
+[Service]
+Restart=always
+RestartSec=10s
+TimeoutStartSec=0
+ExecStart=/bin/sh /storage/.kodi/addons/%p/bin/transmission.sh
+ExecStop=/storage/.kodi/addons/service.system.docker/bin/docker kill transmission
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hello,

This is a proposal to simplify installation of a docker service (transmission). It runs on my RPI2 LE7.0.

It has several advantages, among which: installation from the user interface, enable/start of the service upon install, disable/stop service upon uninstall, check of docker dependency, possibility to move settings to the user interface (a la dispmanx_vnc).

It also comes with obvious disadvantages, among which: additional maintenance, no feedback about the state of the image, etc.

This request is for discussion only, so I did not bother too much about the details.

Thank you for your attention