### PR TITLE
mpd: Bump rev, needs a clean build (static link libogg)

### DIFF
--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -20,7 +20,7 @@
 
 PKG_NAME="mpd"
 PKG_VERSION="0.19.15"
-PKG_REV="100"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mpd.wikia.com/wiki/Music_Player_Daemon_Wiki"


### PR DESCRIPTION
Apparently the current mpd is using a shared libogg, which no longer exists. The addon needs to static link libogg.

@chewitt can you make sure this addon gets a clean build, please? Thanks.