### PR TITLE
Sundtek-mediatv: use ARM64 installer for aarch64

### DIFF
--- a/packages/addons/driver/sundtek-mediatv/package.mk
+++ b/packages/addons/driver/sundtek-mediatv/package.mk
@@ -46,6 +46,9 @@ make_target() {
     arm)
       INSTALLER_URL="http://sundtek.de/media/netinst/armsysvhf/installer.tar.gz"
       ;;
+    aarch64)
+      INSTALLER_URL="http://sundtek.de/media/netinst/arm64/installer.tar.gz"
+      ;;
   esac
   
   wget -O installer.tar.gz $INSTALLER_URL


### PR DESCRIPTION
This now builds properly for the aarch64 platform like the S905 C2.