### PR TITLE
RPi-Tools: add same Adafruit library for LED backpacks

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/Adafruit_Python_GPIO/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/Adafruit_Python_GPIO/package.mk
@@ -1,0 +1,39 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="Adafruit_Python_GPIO"
+PKG_VERSION="fdf0fca"
+PKG_REV="1"
+PKG_ARCH="arm"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/adafruit/${PKG_NAME}"
+PKG_URL="https://github.com/adafruit/${PKG_NAME}/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain Python distutilscross:host"
+PKG_PRIORITY="optional"
+PKG_SECTION="python"
+PKG_SHORTDESC="Adafruit Python GPIO Library"
+PKG_LONGDESC="Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the RPi.GPIO and Adafruit_BBIO librarie"
+PKG_AUTORECONF="no"
+
+make_target() {
+  : # nop
+}
+
+makeinstall_target() {
+  : # nop
+}

--- a/packages/addons/addon-depends/rpi-tools-depends/Adafruit_Python_LED_Backpack/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/Adafruit_Python_LED_Backpack/package.mk
@@ -1,0 +1,39 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="Adafruit_Python_LED_Backpack"
+PKG_VERSION="d3bd401"
+PKG_REV="1"
+PKG_ARCH="arm"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/adafruit/${PKG_NAME}"
+PKG_URL="https://github.com/adafruit/${PKG_NAME}/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain Python distutilscross:host"
+PKG_PRIORITY="optional"
+PKG_SECTION="python"
+PKG_SHORTDESC="Python library for controlling LED backpack displays."
+PKG_LONGDESC="Python library for controlling LED backpack displays such as 8x8 matrices, bar graphs, and 7/14-segment displays on a Raspberry Pi or BeagleBone Black."
+PKG_AUTORECONF="no"
+
+make_target() {
+  : # nop
+}
+
+makeinstall_target() {
+  : # nop
+}

--- a/packages/addons/addon-depends/rpi-tools-depends/Adafruit_Python_PureIO/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/Adafruit_Python_PureIO/package.mk
@@ -1,0 +1,39 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="Adafruit_Python_PureIO"
+PKG_VERSION="a29d95a"
+PKG_REV="1"
+PKG_ARCH="arm"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/adafruit/${PKG_NAME}"
+PKG_URL="https://github.com/adafruit/${PKG_NAME}/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain Python distutilscross:host"
+PKG_PRIORITY="optional"
+PKG_SECTION="python"
+PKG_SHORTDESC="Pure python access to Linux IO including I2C and SPI."
+PKG_LONGDESC="Pure python access to Linux IO including I2C and SPI. Drop in replacement for smbus and spidev modules."
+PKG_AUTORECONF="no"
+
+make_target() {
+  : # nop
+}
+
+makeinstall_target() {
+  : # nop
+}

--- a/packages/addons/tools/rpi-tools/package.mk
+++ b/packages/addons/tools/rpi-tools/package.mk
@@ -18,16 +18,16 @@
 
 PKG_NAME="rpi-tools"
 PKG_VERSION=""
-PKG_REV="100"
+PKG_REV="101"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE=""
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain RPi.GPIO picamera gpiozero"
+PKG_DEPENDS_TARGET="toolchain RPi.GPIO picamera gpiozero Adafruit_Python_LED_Backpack Adafruit_Python_GPIO Adafruit_Python_PureIO"
 PKG_PRIORITY="optional"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of tools and programs for use on the Raspberry Pi"
-PKG_LONGDESC="This bundle currently includes RPi.GPIO, picamera, and gpiozero python modules"
+PKG_LONGDESC="This bundle currently includes RPi.GPIO, picamera, gpiozero and same Adafruit (LED-Backpack, GPIO, PureIO) python modules"
 PKG_DISCAIMER="Raspberry Pi is a trademark of the Raspberry Pi Foundation http://www.raspberrypi.org"
 
 PKG_IS_ADDON="yes"
@@ -44,6 +44,9 @@ addon() {
     cp -PR $(get_build_dir RPi.GPIO)/build/lib.linux-*/RPi/* $ADDON_BUILD/$PKG_ADDON_ID/lib/RPi
     cp -PR $(get_build_dir picamera)/picamera $ADDON_BUILD/$PKG_ADDON_ID/lib/
     cp -PR $(get_build_dir gpiozero)/gpiozero $ADDON_BUILD/$PKG_ADDON_ID/lib/
+    cp -PR $(get_build_dir Adafruit_Python_PureIO)/Adafruit_PureIO $ADDON_BUILD/$PKG_ADDON_ID/lib/
+    cp -PR $(get_build_dir Adafruit_Python_GPIO)/Adafruit_GPIO $ADDON_BUILD/$PKG_ADDON_ID/lib/
+    cp -PR $(get_build_dir Adafruit_Python_LED_Backpack)/Adafruit_LED_Backpack $ADDON_BUILD/$PKG_ADDON_ID/lib/
 
   BCM2835_DIR="$(get_build_dir bcm2835-driver)"
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin/


### PR DESCRIPTION
add support for LED-backpacks like HT16K33 into the rpi-tools addon