### PR TITLE
backport of #257

### DIFF
--- a/packages/tools/mtools/patches/mtools-05-fix-install.patch
+++ b/packages/tools/mtools/patches/mtools-05-fix-install.patch
@@ -1,0 +1,16 @@
+removes installing of floppyd, manuals and info
+should fix occasional mtools installation problems few of us had
+
+--- a/Makefile.in	2010-10-17 17:41:09.000000000 +0200
++++ b/Makefile.in	2016-04-28 11:42:28.015052786 +0200
+@@ -236,8 +236,8 @@
+ uninstall-info:
+ 	cd $(DESTDIR)$(infodir) && rm -f mtools.info*
+ 
+-install:	$(DESTDIR)$(bindir)/mtools @BINFLOPPYD@ install-man install-links \
+-		$(DESTDIR)$(bindir)/mkmanifest install-scripts install-info
++install:	$(DESTDIR)$(bindir)/mtools install-links \
++		$(DESTDIR)$(bindir)/mkmanifest install-scripts
+ 
+ uninstall:	uninstall-bin uninstall-man uninstall-links \
+ 		uninstall-scripts


### PR DESCRIPTION
I just was hit by the info/dir: empty file issue again during an RPi build of 7.0.1 - the fix didn't seem to have made it into the 7.0 branch