### PR TITLE
plymouth-lite: add bilinear interpolation patch

### DIFF
--- a/packages/tools/plymouth-lite/patches/plymouth-lite-0.6.0-31-bilinear-interpolation.patch
+++ b/packages/tools/plymouth-lite/patches/plymouth-lite-0.6.0-31-bilinear-interpolation.patch
@@ -1,0 +1,113 @@
+From 6a1141b74e6a7f3a1c2240d348a9fcda25f32169 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Mon, 16 May 2016 17:28:48 +0200
+Subject: [PATCH] bilinear interpolation
+
+---
+ ply-image.c | 65 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 60 insertions(+), 5 deletions(-)
+
+diff --git a/ply-image.c b/ply-image.c
+index 291b9ce..48644d8 100644
+--- a/ply-image.c
++++ b/ply-image.c
+@@ -296,6 +296,59 @@ ply_image_get_height (ply_image_t *image)
+   return image->height;
+ }
+ 
++static inline uint32_t
++ply_image_interpolate (ply_image_t *image,
++                       double       x,
++                       double       y)
++{
++  int ix;
++  int iy;
++  int width;
++  int height;
++
++  int i;
++
++  int offset_x;
++  int offset_y;
++  uint32_t pixels[2][2];
++  uint32_t reply = 0;
++
++  width = image->width;
++  height = image->height;
++
++  for (offset_y = 0; offset_y < 2; offset_y++)
++    {
++      for (offset_x = 0; offset_x < 2; offset_x++)
++        {
++          ix = x + offset_x;
++          iy = y + offset_y;
++
++          if (ix < 0 || ix >= width || iy < 0 || iy >= height)
++            pixels[offset_y][offset_x] = 0x00000000;
++          else
++            pixels[offset_y][offset_x] = image->layout.as_pixels[ix + iy * width];
++        }
++    }
++  if (!pixels[0][0] && !pixels[0][1] && !pixels[1][0] && !pixels[1][1])
++    return 0;
++
++  ix = x;
++  iy = y;
++  x -= ix;
++  y -= iy;
++  for (i = 0; i < 4; i++)
++    {
++      uint32_t value = 0;
++      uint32_t mask = 0xFF << (i * 8);
++      value += ((pixels[0][0]) & mask) * (1 - x) * (1 - y);
++      value += ((pixels[0][1]) & mask) * x * (1 - y);
++      value += ((pixels[1][0]) & mask) * (1 - x) * y;
++      value += ((pixels[1][1]) & mask) * x * y;
++      reply |= value & mask;
++    }
++  return reply;
++}
++
+ ply_image_t *
+ ply_image_resize (ply_image_t *image,
+                   long         width,
+@@ -303,7 +356,8 @@ ply_image_resize (ply_image_t *image,
+ {
+   ply_image_t *new_image;
+   int x, y;
+-  int old_x, old_y, old_width, old_height;
++  double old_x, old_y;
++  int old_width, old_height;
+   float scale_x, scale_y;
+ 
+   new_image = ply_image_new (image->filename);
+@@ -316,8 +370,8 @@ ply_image_resize (ply_image_t *image,
+   old_width = ply_image_get_width (image);
+   old_height = ply_image_get_height (image);
+ 
+-  scale_x = ((double) old_width) / width;
+-  scale_y = ((double) old_height) / height;
++  scale_x = ((double) old_width - 1) / MAX (width - 1, 1);
++  scale_y = ((double) old_height - 1) / MAX (height - 1, 1);
+ 
+   for (y = 0; y < height; y++)
+     {
+@@ -325,7 +379,7 @@ ply_image_resize (ply_image_t *image,
+       for (x=0; x < width; x++)
+         {
+           old_x = x * scale_x;
+-          new_image->layout.as_pixels[x + y * width] = image->layout.as_pixels[old_x + old_y * old_width];
++          new_image->layout.as_pixels[x + y * width] = ply_image_interpolate (image, old_x, old_y);
+         }
+     }
+   return new_image;
+@@ -465,7 +519,8 @@ main (int    argc,
+       return exit_code;
+     }
+ 
+-  image = ply_image_resize(image, buffer->area.width, buffer->area.height);
++  if (image->width != buffer->area.width || image->height != buffer->area.height)
++    image = ply_image_resize(image, buffer->area.width, buffer->area.height);
+ 
+   animate_at_time (buffer, image);
+ 


### PR DESCRIPTION
This PR should enhance boot splash image resize quality (makes our RasPlex boot splash look better when resized)
- Use bilinear interpolation when resizing image (backport from plymouth)
- Only resize image when image and frame buffer has different size