### PR TITLE
libbluray: Update 0.9.3, add 3D MVC ISO support (RPi)

### DIFF
--- a/packages/multimedia/libbluray/package.mk
+++ b/packages/multimedia/libbluray/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libbluray"
-PKG_VERSION="0.9.2"
+PKG_VERSION="0.9.3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
@@ -60,3 +60,10 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-werror \
                            --with-fontconfig \
                            --with-libxml2 \
                            --with-gnu-ld"
+
+post_makeinstall_target() {
+  mkdir -p $SYSROOT_PREFIX/usr/include/$PKG_NAME/util
+    cp $ROOT/$PKG_BUILD/src/util/attributes.h $SYSROOT_PREFIX/usr/include/$PKG_NAME/util
+  mkdir -p $SYSROOT_PREFIX/usr/include/$PKG_NAME/bdnav
+    cp $ROOT/$PKG_BUILD/src/libbluray/bdnav/clpi_data.h $SYSROOT_PREFIX/usr/include/$PKG_NAME/bdnav
+}

--- a/packages/multimedia/libbluray/patches/libbluray-01-install-extra-headers.patch
+++ b/packages/multimedia/libbluray/patches/libbluray-01-install-extra-headers.patch
@@ -1,0 +1,13 @@
+diff -Naur a/Makefile.am b/Makefile.am
+--- a/Makefile.am	2015-11-25 08:00:27.000000000 +0000
++++ b/Makefile.am	2016-03-01 19:30:08.475070195 +0000
+@@ -166,6 +166,9 @@
+ 	src/libbluray/keys.h \
+ 	src/libbluray/player_settings.h \
+ 	src/libbluray/bdnav/clpi_data.h \
++	src/libbluray/bdnav/clpi_parse.h \
++	src/libbluray/bdnav/mpls_parse.h \
++	src/libbluray/bdnav/uo_mask_table.h \
+ 	src/libbluray/bdnav/meta_data.h \
+ 	src/libbluray/decoders/overlay.h \
+ 	src/util/log_control.h


### PR DESCRIPTION
This has been in my RPi and Generic test builds for the last couple of months.