### PR TITLE
addons: add libmad and faad2 to addon-depends

### DIFF
--- a/packages/addons/addon-depends/faad2/package.mk
+++ b/packages/addons/addon-depends/faad2/package.mk
@@ -1,0 +1,47 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="faad2"
+PKG_VERSION="2.7"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.audiocoding.com/"
+PKG_URL="$SOURCEFORGE_SRC/faac/faad2-src/$PKG_NAME-$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="audio"
+PKG_SHORTDESC="faad: An MPEG-4 AAC decoder"
+PKG_LONGDESC="The FAAD project includes the AAC decoder FAAD2. It supports several MPEG-4 object types (LC, Main, LTP, HE AAC, PS) and file formats (ADTS AAC, raw AAC, MP4), multichannel and gapless decoding as well as MP4 metadata tags. The codecs are compatible with standard-compliant audio applications using one or more of these profiles."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_MAINTAINER="Team LibreELEC (addons@libreelec.tv)"
+
+# package specific configure options
+PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+                           --disable-shared \
+                           --without-xmms \
+                           --without-drm \
+                           --without-mpeg4ip \
+                           --with-gnu-ld"
+
+post_makeinstall_target() {
+  rm -rf $INSTALL/usr/bin
+}

--- a/packages/addons/addon-depends/faad2/patches/faad2-2.7-automake_1.13.patch
+++ b/packages/addons/addon-depends/faad2/patches/faad2-2.7-automake_1.13.patch
@@ -1,0 +1,12 @@
+diff -Naur faad2-2.7-old/configure.in faad2-2.7-new/configure.in
+--- faad2-2.7-old/configure.in	2009-02-04 16:51:03.000000000 -0800
++++ faad2-2.7-new/configure.in	2012-12-30 14:58:33.000000000 -0800
+@@ -25,7 +25,7 @@
+ AC_PROG_MAKE_SET
+ AC_CHECK_PROGS(RPMBUILD, rpmbuild, rpm)
+ 
+-AM_CONFIG_HEADER(config.h)
++AC_CONFIG_HEADERS(config.h)
+ 
+ AC_ARG_WITH(xmms,[  --with-xmms             compile XMMS-1 plugin],
+ 	     WITHXMMS=$withval, WITHXMMS=no)

--- a/packages/addons/addon-depends/faad2/patches/faad2-2.7-mp4ff_shared.patch
+++ b/packages/addons/addon-depends/faad2/patches/faad2-2.7-mp4ff_shared.patch
@@ -1,0 +1,28 @@
+diff -Naur faad2-2.7-old/common/mp4ff/Makefile.am faad2-2.7-new/common/mp4ff/Makefile.am
+--- faad2-2.7-old/common/mp4ff/Makefile.am	2009-02-06 06:24:21.000000000 -0800
++++ faad2-2.7-new/common/mp4ff/Makefile.am	2009-02-11 05:36:14.000000000 -0800
+@@ -1,7 +1,7 @@
+-lib_LIBRARIES = libmp4ff.a
+-include_HEADERS = mp4ff.h mp4ffint.h
++lib_LTLIBRARIES = libmp4ff.la
++include_HEADERS = mp4ff.h mp4ffint.h mp4ff_int_types.h
+ 
+-libmp4ff_a_CFLAGS = -DUSE_TAGGING=1
++libmp4ff_la_CFLAGS = -DUSE_TAGGING=1
+ 
+-libmp4ff_a_SOURCES = mp4ff.c mp4atom.c mp4meta.c mp4sample.c mp4util.c \
+-		     mp4tagupdate.c mp4ff.h mp4ffint.h mp4ff_int_types.h
++libmp4ff_la_SOURCES = mp4ff.c mp4atom.c mp4meta.c mp4sample.c mp4util.c \
++                      mp4tagupdate.c mp4ff.h mp4ffint.h mp4ff_int_types.h
+diff -Naur faad2-2.7-old/frontend/Makefile.am faad2-2.7-new/frontend/Makefile.am
+--- faad2-2.7-old/frontend/Makefile.am	2009-02-06 08:03:37.000000000 -0800
++++ faad2-2.7-new/frontend/Makefile.am	2009-02-11 05:35:52.000000000 -0800
+@@ -5,7 +5,7 @@
+ 	   -I$(top_srcdir)/common/mp4ff
+ 
+ faad_LDADD = $(top_builddir)/libfaad/libfaad.la \
+-	     $(top_builddir)/common/mp4ff/libmp4ff.a
++	     $(top_builddir)/common/mp4ff/libmp4ff.la
+ 
+ faad_SOURCES = main.c \
+ 	       audio.c audio.h \

--- a/packages/addons/addon-depends/libmad/package.mk
+++ b/packages/addons/addon-depends/libmad/package.mk
@@ -1,0 +1,56 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libmad"
+PKG_VERSION="0.15.1b"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.mars.org/home/rob/proj/mpeg/"
+PKG_URL="$SOURCEFORGE_SRC/mad/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="audio"
+PKG_SHORTDESC="libmad: MPEG Audio Decoder"
+PKG_LONGDESC="MAD is a high-quality MPEG audio decoder. It currently supports MPEG-1 and the MPEG-2 extension to Lower Sampling Frequencies, as well as the so-called MPEG 2.5 format. All three audio layers (Layer I, Layer II, and Layer III a.k.a. MP3) are fully implemented."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+# package specific configure options
+PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+if [ "$TARGET_ARCH" = "x86_64" ] ; then
+  PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-accuracy --enable-fpm=64bit"
+fi
+
+post_makeinstall_target() {
+  mkdir -p $SYSROOT_PREFIX/usr/lib/pkgconfig
+  cat > $SYSROOT_PREFIX/usr/lib/pkgconfig/mad.pc << "EOF"
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: mad
+Description: MPEG audio decoder
+Requires:
+Version: 0.15.1b
+Libs: -L${libdir} -lmad
+Cflags: -I${includedir}
+EOF
+}

--- a/packages/addons/addon-depends/libmad/patches/libmad-0.15.1b-automake_1.13.patch
+++ b/packages/addons/addon-depends/libmad/patches/libmad-0.15.1b-automake_1.13.patch
@@ -1,0 +1,12 @@
+diff -Naur libmad-0.15.1b-old/configure.ac libmad-0.15.1b-new/configure.ac
+--- libmad-0.15.1b-old/configure.ac	2004-01-23 01:41:32.000000000 -0800
++++ libmad-0.15.1b-new/configure.ac	2012-12-30 15:14:37.000000000 -0800
+@@ -28,7 +28,7 @@
+ 
+ AM_INIT_AUTOMAKE
+ 
+-AM_CONFIG_HEADER([config.h])
++AC_CONFIG_HEADERS([config.h])
+ 
+ dnl System type.
+ 

--- a/packages/addons/addon-depends/libmad/patches/libmad-0.15.1b-cflags-O2.patch
+++ b/packages/addons/addon-depends/libmad/patches/libmad-0.15.1b-cflags-O2.patch
@@ -1,0 +1,12 @@
+diff -Naur libmad-0.15.1b-orig/configure.ac libmad-0.15.1b/configure.ac
+--- libmad-0.15.1b-orig/configure.ac	2007-07-01 12:58:13.000000000 -0600
++++ libmad-0.15.1b/configure.ac	2007-07-01 12:59:13.000000000 -0600
+@@ -105,7 +105,7 @@
+ 	    shift
+ 	    ;;
+ 	-O2)
+-	    optimize="-O"
++	    optimize="-O2"
+ 	    shift
+ 	    ;;
+ 	-fomit-frame-pointer)

--- a/packages/addons/addon-depends/libmad/patches/libmad-0.15.1b-cflags.patch
+++ b/packages/addons/addon-depends/libmad/patches/libmad-0.15.1b-cflags.patch
@@ -1,0 +1,146 @@
+diff -Naur libmad-0.15.1b-orig/configure.ac libmad-0.15.1b/configure.ac
+--- libmad-0.15.1b-orig/configure.ac	2007-06-30 20:22:31.000000000 -0600
++++ libmad-0.15.1b/configure.ac	2007-06-30 20:25:31.000000000 -0600
+@@ -122,74 +122,74 @@
+     esac
+ done
+ 
+-if test "$GCC" = yes
+-then
+-    if test -z "$arch"
+-    then
+-	case "$host" in
+-	    i386-*)           ;;
+-	    i?86-*)           arch="-march=i486" ;;
+-	    arm*-empeg-*)     arch="-march=armv4 -mtune=strongarm1100" ;;
+-	    armv4*-*)         arch="-march=armv4 -mtune=strongarm" ;;
+-	    powerpc-*)        ;;
+-	    mips*-agenda-*)   arch="-mcpu=vr4100" ;;
+-	    mips*-luxsonor-*) arch="-mips1 -mcpu=r3000 -Wa,-m4010" ;;
+-	esac
+-    fi
+-
+-    case "$optimize" in
+-	-O|"-O "*)
+-	    optimize="-O"
+-	    optimize="$optimize -fforce-mem"
+-	    optimize="$optimize -fforce-addr"
+-	    : #x optimize="$optimize -finline-functions"
+-	    : #- optimize="$optimize -fstrength-reduce"
+-	    optimize="$optimize -fthread-jumps"
+-	    optimize="$optimize -fcse-follow-jumps"
+-	    optimize="$optimize -fcse-skip-blocks"
+-	    : #x optimize="$optimize -frerun-cse-after-loop"
+-	    : #x optimize="$optimize -frerun-loop-opt"
+-	    : #x optimize="$optimize -fgcse"
+-	    optimize="$optimize -fexpensive-optimizations"
+-	    optimize="$optimize -fregmove"
+-	    : #* optimize="$optimize -fdelayed-branch"
+-	    : #x optimize="$optimize -fschedule-insns"
+-	    optimize="$optimize -fschedule-insns2"
+-	    : #? optimize="$optimize -ffunction-sections"
+-	    : #? optimize="$optimize -fcaller-saves"
+-	    : #> optimize="$optimize -funroll-loops"
+-	    : #> optimize="$optimize -funroll-all-loops"
+-	    : #x optimize="$optimize -fmove-all-movables"
+-	    : #x optimize="$optimize -freduce-all-givs"
+-	    : #? optimize="$optimize -fstrict-aliasing"
+-	    : #* optimize="$optimize -fstructure-noalias"
+-
+-	    case "$host" in
+-		arm*-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    ;;
+-		mips*-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    optimize="$optimize -finline-functions"
+-		    ;;
+-		i?86-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    ;;
+-		powerpc-apple-*)
+-		    # this triggers an internal compiler error with gcc2
+-		    : #optimize="$optimize -fstrength-reduce"
+-
+-		    # this is really only beneficial with gcc3
+-		    : #optimize="$optimize -finline-functions"
+-		    ;;
+-		*)
+-		    # this sometimes provokes bugs in gcc 2.95.2
+-		    : #optimize="$optimize -fstrength-reduce"
+-		    ;;
+-	    esac
+-	    ;;
+-    esac
+-fi
++#if test "$GCC" = yes
++#then
++#    if test -z "$arch"
++#    then
++#	case "$host" in
++#	    i386-*)           ;;
++#	    i?86-*)           arch="-march=i486" ;;
++#	    arm*-empeg-*)     arch="-march=armv4 -mtune=strongarm1100" ;;
++#	    armv4*-*)         arch="-march=armv4 -mtune=strongarm" ;;
++#	    powerpc-*)        ;;
++#	    mips*-agenda-*)   arch="-mcpu=vr4100" ;;
++#	    mips*-luxsonor-*) arch="-mips1 -mcpu=r3000 -Wa,-m4010" ;;
++#	esac
++#    fi
++#
++#    case "$optimize" in
++#	-O|"-O "*)
++#	    optimize="-O"
++#	    optimize="$optimize -fforce-mem"
++#	    optimize="$optimize -fforce-addr"
++#	    : #x optimize="$optimize -finline-functions"
++#	    : #- optimize="$optimize -fstrength-reduce"
++#	    optimize="$optimize -fthread-jumps"
++#	    optimize="$optimize -fcse-follow-jumps"
++#	    optimize="$optimize -fcse-skip-blocks"
++#	    : #x optimize="$optimize -frerun-cse-after-loop"
++#	    : #x optimize="$optimize -frerun-loop-opt"
++#	    : #x optimize="$optimize -fgcse"
++#	    optimize="$optimize -fexpensive-optimizations"
++#	    optimize="$optimize -fregmove"
++#	    : #* optimize="$optimize -fdelayed-branch"
++#	    : #x optimize="$optimize -fschedule-insns"
++#	    optimize="$optimize -fschedule-insns2"
++#	    : #? optimize="$optimize -ffunction-sections"
++#	    : #? optimize="$optimize -fcaller-saves"
++#	    : #> optimize="$optimize -funroll-loops"
++#	    : #> optimize="$optimize -funroll-all-loops"
++#	    : #x optimize="$optimize -fmove-all-movables"
++#	    : #x optimize="$optimize -freduce-all-givs"
++#	    : #? optimize="$optimize -fstrict-aliasing"
++#	    : #* optimize="$optimize -fstructure-noalias"
++#
++#	    case "$host" in
++#		arm*-*)
++#		    optimize="$optimize -fstrength-reduce"
++#		    ;;
++#		mips*-*)
++#		    optimize="$optimize -fstrength-reduce"
++#		    optimize="$optimize -finline-functions"
++#		    ;;
++#		i?86-*)
++#		    optimize="$optimize -fstrength-reduce"
++#		    ;;
++#		powerpc-apple-*)
++#		    # this triggers an internal compiler error with gcc2
++#		    : #optimize="$optimize -fstrength-reduce"
++#
++#		    # this is really only beneficial with gcc3
++#		    : #optimize="$optimize -finline-functions"
++#		    ;;
++#		*)
++#		    # this sometimes provokes bugs in gcc 2.95.2
++#		    : #optimize="$optimize -fstrength-reduce"
++#		    ;;
++#	    esac
++#	    ;;
++#    esac
++#fi
+ 
+ case "$host" in
+     mips*-agenda-*)


### PR DESCRIPTION
backported from 8.0, these are required for mpg123 and sqeezelite in #373 