### PR TITLE
gcc: compile with -std=gnu++98 to fix build with gcc6

### DIFF
--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -110,6 +110,10 @@ PKG_CONFIGURE_OPTS_HOST="--target=$TARGET_NAME \
                          --enable-checking=release \
                          --with-default-libstdcxx-abi=gcc4-compatible"
 
+pre_configure_host() {
+  export CXXFLAGS="$CXXFLAGS -std=gnu++98"
+}
+
 pre_configure_bootstrap() {
   setup_toolchain host
 }


### PR DESCRIPTION
Compiling gcc 5.3.0 with gcc 6 fails. Using -std=gnu++98 remedies this.