### PR TITLE
fluxbox: add key binding alt + escape to close window

### DIFF
--- a/packages/x11/other/fluxbox/config/keys
+++ b/packages/x11/other/fluxbox/config/keys
@@ -6,6 +6,7 @@ Mod1 Shift Tab :PrevWindow {groups} (workspace=[current])
 # current window commands
 Mod1 F10 :Maximize
 Mod1 F11 :Fullscreen
+Mod1 Escape :Close
 
 # Normal window movement
 OnTitlebar Move1 :StartMoving


### PR DESCRIPTION
When running Spotify in a container, I found that there is actually no way to exit Spotify in the application itself. Having a keybinding to close the window in Fluxbox can be handy.