### PR TITLE
Add Custom config.txt copy to boot loader during update and version check

### DIFF
--- a/packages/tools/bcm2835-bootloader/files/3rdparty/bootloader/config.txt
+++ b/packages/tools/bcm2835-bootloader/files/3rdparty/bootloader/config.txt
@@ -108,3 +108,10 @@
 # all values below this line were inserted from config.txt.bk (your old config)
 # and can be merged with the above values
 ################################################################################
+
+################################################################################
+# Include distribution specific config file if it exists.
+################################################################################
+
+[all]
+include distroconfig.txt

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -48,7 +48,10 @@ makeinstall_target() {
     [ -f dt-blob.bin ] && cp -PRv dt-blob.bin $INSTALL/usr/share/bootloader/dt-blob.bin
 
     cp -PRv $PKG_DIR/scripts/update.sh $INSTALL/usr/share/bootloader
-    
+
+    if [ -f $DISTRO_DIR/$DISTRO/config/distroconfig.txt ]; then
+      cp -PRv $DISTRO_DIR/$DISTRO/config/distroconfig.txt $INSTALL/usr/share/bootloader
+    fi
     if [ -f $DISTRO_DIR/$DISTRO/config/config.txt ]; then
       cp -PRv $DISTRO_DIR/$DISTRO/config/config.txt $INSTALL/usr/share/bootloader
     else

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -51,7 +51,10 @@ makeinstall_target() {
 
     if [ -f $DISTRO_DIR/$DISTRO/config/distroconfig.txt ]; then
       cp -PRv $DISTRO_DIR/$DISTRO/config/distroconfig.txt $INSTALL/usr/share/bootloader
+    else
+      cp -PRv $PKG_DIR/files/3rdparty/bootloader/distroconfig.txt $INSTALL/usr/share/bootloader
     fi
+
     if [ -f $DISTRO_DIR/$DISTRO/config/config.txt ]; then
       cp -PRv $DISTRO_DIR/$DISTRO/config/config.txt $INSTALL/usr/share/bootloader
     else

--- a/packages/tools/bcm2835-bootloader/scripts/update.sh
+++ b/packages/tools/bcm2835-bootloader/scripts/update.sh
@@ -58,7 +58,7 @@
 
 # Add distro config file.
   if [ -f $SYSTEM_ROOT/usr/share/bootloader/distroconfig.txt ]; then
-    cp $SYSTEM_ROOT/usr/share/bootloader/distroconfig.txt $BOOT_ROOT
+    cp -p $SYSTEM_ROOT/usr/share/bootloader/distroconfig.txt $BOOT_ROOT
   fi
 
 # mount $BOOT_ROOT r/o

--- a/packages/tools/bcm2835-bootloader/scripts/update.sh
+++ b/packages/tools/bcm2835-bootloader/scripts/update.sh
@@ -53,6 +53,9 @@
 #    sed -e "s,gpu_mem=100,gpu_mem=128,g" -i $BOOT_ROOT/config.txt
 #    sed -e "s,gpu_mem_256=100,# gpu_mem_256=128,g" -i $BOOT_ROOT/config.txt
 #    sed -e "s,gpu_mem_512=128,# gpu_mem_512=128,g" -i $BOOT_ROOT/config.txt
+  # Add distribution specific extra configuration file for the bootloader
+  elif [ -f $SYSTEM_ROOT/usr/share/bootloader/distroconfig.txt ]; then
+    cp $SYSTEM_ROOT/usr/share/bootloader/distroconfig.txt $BOOT_ROOT
   fi
 
 # mount $BOOT_ROOT r/o

--- a/packages/tools/bcm2835-bootloader/scripts/update.sh
+++ b/packages/tools/bcm2835-bootloader/scripts/update.sh
@@ -54,7 +54,10 @@
 #    sed -e "s,gpu_mem_256=100,# gpu_mem_256=128,g" -i $BOOT_ROOT/config.txt
 #    sed -e "s,gpu_mem_512=128,# gpu_mem_512=128,g" -i $BOOT_ROOT/config.txt
   # Add distribution specific extra configuration file for the bootloader
-  elif [ -f $SYSTEM_ROOT/usr/share/bootloader/distroconfig.txt ]; then
+  fi
+
+# Add distro config file.
+  if [ -f $SYSTEM_ROOT/usr/share/bootloader/distroconfig.txt ]; then
     cp $SYSTEM_ROOT/usr/share/bootloader/distroconfig.txt $BOOT_ROOT
   fi
 


### PR DESCRIPTION
We noticed that our custom config.txt isn't being copied from the system image to the bootloader on updates.

This should allow for a string in the config.txt file to be matched and version checked. So if custom version on system image is higher than on the bootloader it will update it.

Thoughts are welcome.