### PR TITLE
Python: don't build curses and readline modules for host

### DIFF
--- a/packages/lang/Python/package.mk
+++ b/packages/lang/Python/package.mk
@@ -75,7 +75,7 @@ post_patch() {
 make_host() {
   make PYTHON_MODULES_INCLUDE="$HOST_INCDIR" \
        PYTHON_MODULES_LIB="$HOST_LIBDIR" \
-       PYTHON_DISABLE_MODULES="$PY_DISABLED_MODULES"
+       PYTHON_DISABLE_MODULES="readline _curses _curses_panel $PY_DISABLED_MODULES"
 
   # python distutils per default adds -L$LIBDIR when linking binary extensions
     sed -e "s|^ 'LIBDIR':.*| 'LIBDIR': '/usr/lib',|g" -i $(cat pybuilddir.txt)/_sysconfigdata.py
@@ -84,7 +84,7 @@ make_host() {
 makeinstall_host() {
   make PYTHON_MODULES_INCLUDE="$HOST_INCDIR" \
        PYTHON_MODULES_LIB="$HOST_LIBDIR" \
-       PYTHON_DISABLE_MODULES="$PY_DISABLED_MODULES" \
+       PYTHON_DISABLE_MODULES="readline _curses _curses_panel $PY_DISABLED_MODULES" \
        install
 }
 


### PR DESCRIPTION
#301 broke compilation of the curses module for some. We need netbsd-curses:host and a patch to fix this:

`/root/LibreELEC.tv/build.LibreELEC-Generic.x86_64-8.0-devel/Python-2.7.11/Modules/_cursesmodule.c: In function 'PyCursesWindow_EchoChar':
/root/LibreELEC.tv/build.LibreELEC-Generic.x86_64-8.0-devel/Python-2.7.11/Modules/_cursesmodule.c:808:18: error: dereferencing pointer to incomplete type 'WINDOW {aka struct __window}'
     if (self->win->_flags & _ISPAD)`