### PR TITLE
nvidia: Enable USLEEP to reduce CPU load while rendering

### DIFF
--- a/packages/mediacenter/kodi/system.d/kodi.service
+++ b/packages/mediacenter/kodi/system.d/kodi.service
@@ -5,6 +5,7 @@ Requires=graphical.target
 Wants=network-online.target
 
 [Service]
+Environment=__GL_YIELD=USLEEP
 Environment=DISPLAY=:0.0
 Environment=SDL_MOUSE_RELATIVE=0
 Environment=HOME=/storage


### PR DESCRIPTION
See forum thread: http://forum.kodi.tv/showthread.php?tid=276075

From nvidia driver README.txt:
```
11F. OPENGL YIELD BEHAVIOR

There are several cases where the NVIDIA OpenGL driver needs to wait for
external state to change before continuing. To avoid consuming too much CPU
time in these cases, the driver will sometimes yield so the kernel can
schedule other processes to run while the driver waits. For example, when
waiting for free space in a command buffer, if the free space has not become
available after a certain number of iterations, the driver will yield before
it continues to loop.

By default, the driver calls sched_yield() to do this. However, this can cause
the calling process to be scheduled out for a relatively long period of time
if there are other, same-priority processes competing for time on the CPU. One
example of this is when an OpenGL-based composite manager is moving and
repainting a window and the X server is trying to update the window as it
moves, which are both CPU-intensive operations.

You can use the __GL_YIELD environment variable to work around these
scheduling problems. This variable allows the user to specify what the driver
should do when it wants to yield. The possible values are:

    __GL_YIELD         Behavior
    ---------------    ------------------------------------------------------
    <unset>            By default, OpenGL will call sched_yield() to yield.
    "NOTHING"          OpenGL will never yield.
    "USLEEP"           OpenGL will call usleep(0) to yield.
```

There may be a better way to set this environment variable - if anyone has any ideas I'll update this PR.