### PR TITLE
backport of #399

### DIFF
--- a/packages/addons/service/oscam/changelog.txt
+++ b/packages/addons/service/oscam/changelog.txt
@@ -1,2 +1,6 @@
+7.0.101
+- Update OSCam to 11233
+- fix the WeTek_Play problems
+
 7.0.100
 - initial LibreELEC version

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="oscam"
-PKG_VERSION="09609e1"
-PKG_VERSION_NUMBER="11225"
-PKG_REV="100"
+PKG_VERSION="c677c6e"
+PKG_VERSION_NUMBER="11233"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.streamboard.tv/oscam/wiki"


### PR DESCRIPTION
updates OSCam and fixes (WeTek_Play) - OSCam did not work
>[WARNING] parser: The timediff for TELETEXT is big (3249104422), using current dts
[  ERROR] descrambler: ECM late (18 seconds) for service "abcdefgh"