### PR TITLE
Fix digital audio crackling when playing music on non Kodi based setups.

### DIFF
--- a/packages/audio/alsa-utils/scripts/soundconfig
+++ b/packages/audio/alsa-utils/scripts/soundconfig
@@ -41,9 +41,9 @@ else
   card=`echo $1 | sed 's/[^0-9]*//g'`
 
 # set common mixer params
-  mixer $card Master 100%
+  mixer $card Master 0db
   mixer $card Front 100%
-  mixer $card PCM 100%
+  mixer $card PCM 0db
   mixer $card Synth 100%
 
 # mute CD, since using digital audio instead


### PR DESCRIPTION
To avoid audio crackling on digital audio on the RPi we need to change the Master/PCM audio volumes to 0db instead of 100%. 100% results in 104db, so a 4db amplification on the RPi and causes a bad experience with audio crackling when playing music.