### PR TITLE
Enable custom fonts to be installed in place of liberation fonts

### DIFF
--- a/packages/virtual/corefonts/package.mk
+++ b/packages/virtual/corefonts/package.mk
@@ -23,7 +23,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain liberation-fonts-ttf"
+PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="corefonts: Metapackage for installing fonts"
@@ -31,3 +31,9 @@ PKG_LONGDESC="corefonts is a Metapackage for installing fonts"
 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
+
+if [ -n "$CUSTOM_FONTS" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET $CUSTOM_FONTS"
+else
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET liberation-fonts-ttf"
+fi

--- a/packages/x11/other/fontconfig/package.mk
+++ b/packages/x11/other/fontconfig/package.mk
@@ -34,7 +34,7 @@ PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--with-arch=$TARGET_ARCH \
                            --with-cache-dir=/storage/.cache/fontconfig \
-                           --with-default-fonts=/usr/share/fonts/liberation \
+                           --with-default-fonts=/usr/share/fonts \
                            --without-add-fonts \
                            --disable-dependency-tracking \
                            --disable-docs"


### PR DESCRIPTION
So we use our own fonts on Plex Media Player and Liberation fonts break our fonts as fontconfig is hardcoded to /usr/share/fonts/liberation.

This PR should address that with an option to put an alternate font using distro option file.