### PR TITLE
Kodi: use system libraries to play dvd

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -114,6 +114,7 @@ else
 fi
 
 if [ "$KODI_DVDCSS_SUPPORT" = yes ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libdvdnav"
   KODI_DVDCSS="--enable-dvdcss"
 else
   KODI_DVDCSS="--disable-dvdcss"

--- a/packages/mediacenter/kodi/patches/kodi-100.31-make-libdvdnav-arch-independent.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.31-make-libdvdnav-arch-independent.patch
@@ -1,0 +1,12 @@
+diff -Naur kodi-17.0-alpha2-4e90409.orig/xbmc/DllPaths_generated.h.in kodi-17.0-alpha2-4e90409/xbmc/DllPaths_generated.h.in
+--- kodi-17.0-alpha2-4e90409.orig/xbmc/DllPaths_generated.h.in	2016-05-05 11:08:45.000000000 +0200
++++ kodi-17.0-alpha2-4e90409/xbmc/DllPaths_generated.h.in	2016-06-05 11:35:54.571848302 +0200
+@@ -41,7 +41,7 @@
+ 
+ /* VideoPlayer */
+ #define DLL_PATH_LIBASS        "@ASS_SONAME@"
+-#define DLL_PATH_LIBDVDNAV     "special://xbmcbin/system/players/VideoPlayer/libdvdnav-@ARCH@.so"
++#define DLL_PATH_LIBDVDNAV     "special://xbmcbin/system/players/VideoPlayer/libdvdnav.so"
+ #define DLL_PATH_LIBMPEG2      "@MPEG2_SONAME@"
+ 
+ /* libbluray */

--- a/packages/multimedia/libdvdcss/package.mk
+++ b/packages/multimedia/libdvdcss/package.mk
@@ -32,4 +32,4 @@ PKG_LONGDESC="libdvdcss is a simple library designed for accessing DVDs as a blo
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-static"
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"

--- a/packages/multimedia/libdvdcss/package.mk
+++ b/packages/multimedia/libdvdcss/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="libdvdcss"
-PKG_VERSION=`git ls-remote https://github.com/xbmc/libdvdcss | grep refs/heads/master | cut -c1-7`
+PKG_VERSION="2f12236"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/libdvdcss"
-PKG_URL="https://github.com/xbmc/libdvdcss/archive/master.tar.gz"
+PKG_URL="https://github.com/xbmc/libdvdcss/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="multimedia"
@@ -33,8 +33,3 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-static"
-
-unpack() {
-  tar xzf "$SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz" -C $BUILD
-  mv $BUILD/$PKG_NAME-* $BUILD/$PKG_NAME-${PKG_VERSION}
-}

--- a/packages/multimedia/libdvdcss/package.mk
+++ b/packages/multimedia/libdvdcss/package.mk
@@ -32,4 +32,4 @@ PKG_LONGDESC="libdvdcss is a simple library designed for accessing DVDs as a blo
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
+PKG_CONFIGURE_OPTS_TARGET="--disable-static"

--- a/packages/multimedia/libdvdcss/package.mk
+++ b/packages/multimedia/libdvdcss/package.mk
@@ -1,0 +1,40 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libdvdcss"
+PKG_VERSION=`git ls-remote https://github.com/xbmc/libdvdcss | grep refs/heads/master | cut -c1-7`
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/libdvdcss"
+PKG_URL="https://github.com/xbmc/libdvdcss/archive/master.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="multimedia"
+PKG_SHORTDESC="libdvdcss: a simple library designed for accessing DVDs as a block device without having to bother about the decryption."
+PKG_LONGDESC="libdvdcss is a simple library designed for accessing DVDs as a block device without having to bother about the decryption."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-static"
+
+unpack() {
+  tar xzf "$SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz" -C $BUILD
+  mv $BUILD/$PKG_NAME-* $BUILD/$PKG_NAME-${PKG_VERSION}
+}

--- a/packages/multimedia/libdvdnav/package.mk
+++ b/packages/multimedia/libdvdnav/package.mk
@@ -32,7 +32,7 @@ PKG_LONGDESC="libdvdnav is a library that allows easy use of sophisticated DVD n
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
+PKG_CONFIGURE_OPTS_TARGET="--disable-static"
 
 pre_configure_target() {
   export CFLAGS="-D_XBMC -DHAVE_DVDCSS_DVDCSS_H $CFLAGS"

--- a/packages/multimedia/libdvdnav/package.mk
+++ b/packages/multimedia/libdvdnav/package.mk
@@ -32,7 +32,7 @@ PKG_LONGDESC="libdvdnav is a library that allows easy use of sophisticated DVD n
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-static"
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
 
 pre_configure_target() {
   export CFLAGS="-D_XBMC -DHAVE_DVDCSS_DVDCSS_H $CFLAGS"

--- a/packages/multimedia/libdvdnav/package.mk
+++ b/packages/multimedia/libdvdnav/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="libdvdnav"
-PKG_VERSION=`git ls-remote https://github.com/xbmc/libdvdnav | grep refs/heads/master | cut -c1-7`
+PKG_VERSION="43b5f81"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/libdvdnav"
-PKG_URL="https://github.com/xbmc/libdvdnav/archive/master.tar.gz"
+PKG_URL="https://github.com/xbmc/libdvdnav/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libdvdread"
 PKG_PRIORITY="optional"
 PKG_SECTION="multimedia"
@@ -33,11 +33,6 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-static"
-
-unpack() {
-  tar xzf "$SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz" -C $BUILD
-  mv $BUILD/$PKG_NAME-* $BUILD/$PKG_NAME-${PKG_VERSION}
-}
 
 pre_configure_target() {
   export CFLAGS="-D_XBMC -DHAVE_DVDCSS_DVDCSS_H $CFLAGS"

--- a/packages/multimedia/libdvdnav/package.mk
+++ b/packages/multimedia/libdvdnav/package.mk
@@ -1,0 +1,49 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libdvdnav"
+PKG_VERSION=`git ls-remote https://github.com/xbmc/libdvdnav | grep refs/heads/master | cut -c1-7`
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/libdvdnav"
+PKG_URL="https://github.com/xbmc/libdvdnav/archive/master.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libdvdread"
+PKG_PRIORITY="optional"
+PKG_SECTION="multimedia"
+PKG_SHORTDESC="libdvdnav: a library that allows easy use of sophisticated DVD navigation features such as DVD menus, multiangle playback and even interactive DVD games."
+PKG_LONGDESC="libdvdnav is a library that allows easy use of sophisticated DVD navigation features such as DVD menus, multiangle playback and even interactive DVD games."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-static"
+
+unpack() {
+  tar xzf "$SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz" -C $BUILD
+  mv $BUILD/$PKG_NAME-* $BUILD/$PKG_NAME-${PKG_VERSION}
+}
+
+pre_configure_target() {
+  export CFLAGS="-D_XBMC -DHAVE_DVDCSS_DVDCSS_H $CFLAGS"
+}
+
+post_makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/kodi/system/players/VideoPlayer/
+    ln -s ../../../../libdvdnav.so $INSTALL/usr/lib/kodi/system/players/VideoPlayer/libdvdnav-$TARGET_ARCH-linux.so
+}

--- a/packages/multimedia/libdvdnav/package.mk
+++ b/packages/multimedia/libdvdnav/package.mk
@@ -40,5 +40,5 @@ pre_configure_target() {
 
 post_makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/kodi/system/players/VideoPlayer/
-    ln -s ../../../../libdvdnav.so $INSTALL/usr/lib/kodi/system/players/VideoPlayer/libdvdnav-$TARGET_ARCH-linux.so
+    ln -s /usr/lib/libdvdnav.so $INSTALL/usr/lib/kodi/system/players/VideoPlayer/libdvdnav.so
 }

--- a/packages/multimedia/libdvdread/package.mk
+++ b/packages/multimedia/libdvdread/package.mk
@@ -32,7 +32,7 @@ PKG_LONGDESC="libdvdread is a library which provides a simple foundation for rea
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-static --with-libdvdcss"
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static --with-libdvdcss"
 
 pre_configure_target() {
   export CFLAGS="-D_XBMC $CFLAGS"

--- a/packages/multimedia/libdvdread/package.mk
+++ b/packages/multimedia/libdvdread/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="libdvdread"
-PKG_VERSION=`git ls-remote git://github.com/xbmc/libdvdread | grep refs/heads/master | cut -c1-7`
+PKG_VERSION="17d99db"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/libdvdread"
-PKG_URL="https://github.com/xbmc/libdvdread/archive/master.tar.gz"
+PKG_URL="https://github.com/xbmc/libdvdread/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libdvdcss"
 PKG_PRIORITY="optional"
 PKG_SECTION="multimedia"
@@ -36,9 +36,4 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-static --with-libdvdcss"
 
 pre_configure_target() {
   export CFLAGS="-D_XBMC $CFLAGS"
-}
-
-unpack() {
-  tar xzf "$SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz" -C $BUILD
-  mv $BUILD/$PKG_NAME-* $BUILD/$PKG_NAME-${PKG_VERSION}
 }

--- a/packages/multimedia/libdvdread/package.mk
+++ b/packages/multimedia/libdvdread/package.mk
@@ -32,7 +32,7 @@ PKG_LONGDESC="libdvdread is a library which provides a simple foundation for rea
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static --with-libdvdcss"
+PKG_CONFIGURE_OPTS_TARGET="--disable-static --with-libdvdcss"
 
 pre_configure_target() {
   export CFLAGS="-D_XBMC $CFLAGS"

--- a/packages/multimedia/libdvdread/package.mk
+++ b/packages/multimedia/libdvdread/package.mk
@@ -1,0 +1,44 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libdvdread"
+PKG_VERSION=`git ls-remote git://github.com/xbmc/libdvdread | grep refs/heads/master | cut -c1-7`
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/libdvdread"
+PKG_URL="https://github.com/xbmc/libdvdread/archive/master.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libdvdcss"
+PKG_PRIORITY="optional"
+PKG_SECTION="multimedia"
+PKG_SHORTDESC="libdvdread: a library which provides a simple foundation for reading DVDs."
+PKG_LONGDESC="libdvdread is a library which provides a simple foundation for reading DVDs."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-static --with-libdvdcss"
+
+pre_configure_target() {
+  export CFLAGS="-D_XBMC $CFLAGS"
+}
+
+unpack() {
+  tar xzf "$SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz" -C $BUILD
+  mv $BUILD/$PKG_NAME-* $BUILD/$PKG_NAME-${PKG_VERSION}
+}


### PR DESCRIPTION
Since kodi 17 is not possible to build bundled dvd related libraries.
The idea is to use the same libraries bundled with the kodi tree, but built in the system tree. This way works well for me. It's only an idea, maybe a workaround... Please comment for the appropriate corrections