### PR TITLE
systemd: ensure /storage/.cache exists before writing machine-id

### DIFF
--- a/packages/sysutils/systemd/scripts/systemd-machine-id-setup
+++ b/packages/sysutils/systemd/scripts/systemd-machine-id-setup
@@ -36,6 +36,7 @@ fi
 
 if [ -z "$MACHINEID" ]; then
   MACHINEID=`echo $MAC_ADDRESS | md5sum | cut -f1 -d" "`
+  mkdir -p /storage/.cache
 fi
 
 echo "$MACHINEID" > /storage/.cache/machine-id


### PR DESCRIPTION
machine-id.service can fail on first boot (noticed in noobs installs) if /storage/.cache hasn't been created by systemd-tmpfiles-setup.service before machine-id.service runs. Adding a dependency breaks stuff so this is simpler.