### PR TITLE
backport of #429 (docker: update to 1.11.2)

### DIFF
--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="containerd"
-PKG_VERSION="d2f0386"
+PKG_VERSION="9dc2b32"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="APL"

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="runc"
-PKG_VERSION="e874369"
+PKG_VERSION="baf6536"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="APL"

--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,6 @@
+7.0.104
+- Update to docker 1.11.2
+
 7.0.103
 - Allow using kodi notifications based on Docker events API
 

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="docker"
-PKG_VERSION="1.11.1"
-PKG_REV="103"
+PKG_VERSION="1.11.2"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_ADDON_PROJECTS="Generic RPi RPi2"
 PKG_LICENSE="ASL"


### PR DESCRIPTION
backport of #429 