### PR TITLE
Revert "Merge pull request #136 from lrusak/modesetting"

### DIFF
--- a/packages/x11/xserver/xorg-server/config/xorg-modesetting.conf
+++ b/packages/x11/xserver/xorg-server/config/xorg-modesetting.conf
@@ -1,4 +1,0 @@
-Section "Device"
-    Identifier  "Intel Graphics"
-    Driver      "modesetting"
-EndSection

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -165,8 +165,9 @@ post_makeinstall_target() {
   mkdir -p $INSTALL/etc/X11
     if [ -f $PROJECT_DIR/$PROJECT/xorg/xorg.conf ]; then
       cp $PROJECT_DIR/$PROJECT/xorg/xorg.conf $INSTALL/etc/X11
+    elif [ -f $PKG_DIR/config/xorg.conf ]; then
+      cp $PKG_DIR/config/xorg.conf $INSTALL/etc/X11
     fi
-    cp $PKG_DIR/config/xorg*.conf $INSTALL/etc/X11
 
   if [ ! "$DEVTOOLS" = yes ]; then
     rm -rf $INSTALL/usr/bin/cvt

--- a/packages/x11/xserver/xorg-server/udev.d/97-xorg.rules
+++ b/packages/x11/xserver/xorg-server/udev.d/97-xorg.rules
@@ -31,7 +31,7 @@ GOTO="end_video"
 
 # check for drivers using the pci substem
 LABEL="subsystem_pci"
-DRIVER=="i915", ENV{xorg_driver}="modesetting", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xorg-configure@modesetting.service"
+DRIVER=="i915", ENV{xorg_driver}="i915", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xorg-configure@i915.service"
 DRIVER=="amdgpu", ENV{xorg_driver}="amdgpu", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xorg-configure@amdgpu.service"
 DRIVER=="radeon", ENV{xorg_driver}="radeon", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xorg-configure@radeon.service"
 GOTO="end_video"


### PR DESCRIPTION
This reverts commit fee76beb720901d4ae7f754f0ff8bf611e0ede1a.

the modesetting driver is only good for newer intel chipsets. Maybe we can find a way to differentiate intel chipsets in the future and decide the xorg driver based on that but for now this is better.