### PR TITLE
build: start using .libreelec-unpack

### DIFF
--- a/scripts/clean
+++ b/scripts/clean
@@ -30,8 +30,8 @@ clean_package() {
   fi
 
   for i in $BUILD/$1-*; do
-    if [ -d $i -a -f "$i/.openelec-unpack" ] ; then
-      . "$i/.openelec-unpack"
+    if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
+      . "$i/.libreelec-unpack"
       if [ "$STAMP_PKG_NAME" = "$1" ]; then
         printf "%${BUILD_INDENT}c ${boldred}*${endcolor} ${red}Removing $i ...${endcolor}\n" ' '>&$SILENT_OUT
         rm -rf $i

--- a/scripts/skip_unpack
+++ b/scripts/skip_unpack
@@ -30,7 +30,7 @@ if [ ! -f $PKG_DIR/package.mk ]; then
   exit 1
 fi
 
-STAMP=$PKG_BUILD/.openelec-unpack
+STAMP=$PKG_BUILD/.libreelec-unpack
 
 if [ -f $STAMP ] ; then
   printf "%${BUILD_INDENT}c ${boldcyan}SKIP_UNPACK${endcolor}   $1\n" ' '>&$SILENT_OUT

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -32,7 +32,7 @@ fi
 
 $SCRIPTS/get $1
 
-STAMP=$PKG_BUILD/.openelec-unpack
+STAMP=$PKG_BUILD/.libreelec-unpack
 
 mkdir -p $BUILD
 
@@ -41,8 +41,8 @@ mkdir -p $BUILD
 STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
 
 for i in $BUILD/$1-*; do
-  if [ -d $i -a -f "$i/.openelec-unpack" ] ; then
-    . "$i/.openelec-unpack"
+  if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
+    . "$i/.libreelec-unpack"
     if [ "$STAMP_PKG_NAME" = "$1" ]; then
       PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
       if [ ! "$PKG_DEEPMD5" = "$STAMP_PKG_DEEPMD5" ] ; then


### PR DESCRIPTION
NOTE: This will require a clean build! Best to include next time we bump something which requires a clean build, such as gcc or similar.