### PR TITLE
libreelec: use build project directory for ccache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ mkpkg-temp
 /sources
 /.work
 
+# ccache
+/.ccache/
+
 # backup files
 *.orig
 

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,8 @@ amlpkg:
 clean:
 	rm -rf $(BUILD_DIRS)/* $(BUILD_DIRS)/.stamps
 
+distclean:
+	rm -rf ./.ccache ./$(BUILD_DIRS)
+
 src-pkg:
 	tar cvjf sources.tar.bz2 sources .stamps

--- a/config/options
+++ b/config/options
@@ -78,8 +78,9 @@ fi
 # Set the maximum size of the files stored in the cache. You can specify a
 # value in gigabytes, megabytes or kilobytes by appending a G, M or K to the
 # value. The default is gigabytes. The actual value stored is rounded down to
-# the nearest multiple of 16 kilobytes.
-  CCACHE_CACHE_SIZE="30G"
+# the nearest multiple of 16 kilobytes.  Keep in mind this per project .ccache
+# directory.
+  CCACHE_CACHE_SIZE="10G"
 
 # install devtools on development builds
   if [ "$LIBREELEC_VERSION" = "devel" ]; then

--- a/config/path
+++ b/config/path
@@ -239,7 +239,7 @@ HOST_PKG_CONFIG_LIBDIR="$ROOT/$TOOLCHAIN/lib/pkgconfig:$ROOT/$TOOLCHAIN/share/pk
 HOST_PKG_CONFIG_SYSROOT_DIR=""
 
 if [ -z "$CCACHE_DIR" ]; then
-    export CCACHE_DIR=$HOME/.ccache-libreelec
+    export CCACHE_DIR=$ROOT/.ccache/$PROJECT.$TARGET_ARCH-$OS_VERSION
 fi
 export MAKEFLAGS=-j$CONCURRENCY_MAKE_LEVEL
 export PKG_CONFIG=$ROOT/$TOOLCHAIN/bin/pkg-config


### PR DESCRIPTION
Saw this communicated elsewhere, and thought I'd take a dig at it.

Moved ccache for given project to its build.project directory.
`make clean` will blow it up along with the project.

No changes to current CCACHE_CACHE_SIZE="30G"