### PR TITLE
mtools: Fix creation of dot directories (. and ..)

### DIFF
--- a/packages/tools/mtools/patches/mtools-01-fix-creation-of-dot-directories.patch
+++ b/packages/tools/mtools/patches/mtools-01-fix-creation-of-dot-directories.patch
@@ -1,0 +1,11 @@
+diff -Naur a/direntry.c b/direntry.c
+--- a/direntry.c	2016-06-09 11:43:10.440631427 +0100
++++ b/direntry.c	2016-06-09 11:44:02.084949449 +0100
+@@ -24,6 +24,7 @@
+ 
+ void initializeDirentry(direntry_t *entry, Stream_t *Dir)
+ {
++	memset(entry, 0, sizeof(direntry_t));
+ 	entry->entry = -1;
+ /*	entry->parent = getDirentry(Dir);*/
+ 	entry->Dir = Dir;


### PR DESCRIPTION
See: https://lists.gnu.org/archive/html/info-mtools/2014-08/msg00000.html

Without this patch we sometimes experience corrupted MSDOS directories in the image.
```
fsck from util-linux 2.27.1
fsck.fat 3.0.28 (2015-05-16)
/OVERLAYS/.
  Bad short file name (.).
  Auto-renaming it.
  Renamed to FSCK0000.000
/OVERLAYS/..
  Bad short file name (..).
  Auto-renaming it.
  Renamed to FSCK0000.001
/OVERLAYS/FSCK0000.000
  File size is 0 bytes, cluster chain length is > 0 bytes.
  Truncating file to 0 bytes.
Performing changes.
```