### PR TITLE
samba: actually allow it to be disabled

### DIFF
--- a/packages/network/samba/system.d.opt/nmbd.service
+++ b/packages/network/samba/system.d.opt/nmbd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Samba NMB Daemon
 After=network.target smbd.service
+ConditionPathExists=/storage/.cache/services/samba.conf
 
 [Service]
 Type=forking

--- a/packages/network/samba/system.d.opt/smbd.service
+++ b/packages/network/samba/system.d.opt/smbd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Samba SMB Daemon
 After=network.target
+ConditionPathExists=/storage/.cache/services/samba.conf
 
 [Service]
 Type=forking


### PR DESCRIPTION
This was removed in the samba refactor, it's needed to actually disable samba via our settings add-on