### PR TITLE
wlan-firmware: bump to 0.0.32

### DIFF
--- a/packages/linux-firmware/wlan-firmware/package.mk
+++ b/packages/linux-firmware/wlan-firmware/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="wlan-firmware"
-PKG_VERSION="0.0.31"
+PKG_VERSION="0.0.32"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Free-to-use"
-PKG_SITE="https://github.com/OpenELEC/wlan-firmware"
-PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_SITE="https://github.com/LibreELEC/wlan-firmware"
+PKG_URL="https://github.com/LibreELEC/wlan-firmware/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="firmware"


### PR DESCRIPTION
This is in anticipation of https://github.com/LibreELEC/wlan-firmware/pull/1 - if it doesn't merge I'll update the version of this PR back to 0.0.31 and then it's just a package URL change.