### PR TITLE
Allow extra xorg arguments at startup

### DIFF
--- a/packages/x11/xserver/xorg-server/scripts/xorg-configure
+++ b/packages/x11/xserver/xorg-server/scripts/xorg-configure
@@ -44,6 +44,7 @@ logger -t Xorg "### setup xorg.conf paths ###"
   XORG_CONF_USER_DRV="/storage/.config/xorg-$1.conf"
   XORG_CONF_DEFAULT="/etc/X11/xorg.conf"
   XORG_CONF_DEFAULT_DRV="/etc/X11/xorg-$1.conf"
+  XORG_ARGS_USER="/storage/.config/xorg-args.conf"
 
 ##############################################################################
 # creating start options
@@ -63,7 +64,12 @@ logger -t Xorg "### creating start options ###"
   elif [ -f "$XORG_CONF_DEFAULT_DRV" ]; then
     XORG_ARGS="$XORG_ARGS -config $XORG_CONF_DEFAULT_DRV"
   fi
-
+  
+  # load user defined xorg args, if exist
+  if [ -f "$XORG_ARGS_USER" ]; then
+    XORG_ARGS="$XORG_ARGS $XORG_ARGS_USER)"
+  fi
+  
 ##############################################################################
 # creating needed directories and symlinks
 ##############################################################################

--- a/packages/x11/xserver/xorg-server/scripts/xorg-configure
+++ b/packages/x11/xserver/xorg-server/scripts/xorg-configure
@@ -44,7 +44,7 @@ logger -t Xorg "### setup xorg.conf paths ###"
   XORG_CONF_USER_DRV="/storage/.config/xorg-$1.conf"
   XORG_CONF_DEFAULT="/etc/X11/xorg.conf"
   XORG_CONF_DEFAULT_DRV="/etc/X11/xorg-$1.conf"
-  XORG_ARGS_USER="/storage/.config/xorg-args.conf"
+  XORG_ARGS_USER="/storage/.config/xorgargs.conf"
 
 ##############################################################################
 # creating start options

--- a/packages/x11/xserver/xorg-server/scripts/xorg-configure
+++ b/packages/x11/xserver/xorg-server/scripts/xorg-configure
@@ -67,7 +67,7 @@ logger -t Xorg "### creating start options ###"
   
   # load user defined xorg args, if exist
   if [ -f "$XORG_ARGS_USER" ]; then
-    XORG_ARGS="$XORG_ARGS $XORG_ARGS_USER)"
+    XORG_ARGS="$XORG_ARGS $(cat $XORG_ARGS_USER)"
   fi
   
 ##############################################################################


### PR DESCRIPTION
Proposal to allow user to change xorg arguments at startup in the same way that user can have its own xorg.conf file.

User may want to append certain options to xorg before kodi is started.

Example: User may want to add the option -nocursor so when he/she starts a program outside of kodi, such as chromium in kiosk mode, the mouse cursor is not shown.