### PR TITLE
ffmpeg: rework

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -34,10 +34,10 @@ PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert a
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
-# configure GPU drivers and dependencies:
-  get_graphicdrivers
+# Dependencies
+get_graphicdrivers
 
-if [ "$VAAPI_SUPPORT" = yes ]; then
+if [ "$VAAPI_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libva-intel-driver"
   FFMPEG_VAAPI="--enable-vaapi"
 else
@@ -51,7 +51,7 @@ else
   FFMPEG_VDPAU="--disable-vdpau"
 fi
 
-if [ "$DEBUG" = yes ]; then
+if [ "$DEBUG" = "yes" ]; then
   FFMPEG_DEBUG="--enable-debug --disable-stripping"
 else
   FFMPEG_DEBUG="--disable-debug --enable-stripping"
@@ -63,55 +63,48 @@ fi
 
 case "$TARGET_ARCH" in
   arm)
-      FFMPEG_CPU=""
-      FFMPEG_TABLES="--enable-hardcoded-tables"
-      FFMPEG_PIC="--enable-pic"
-  ;;
-  x86_64)
-      FFMPEG_CPU=""
-      FFMPEG_TABLES="--disable-hardcoded-tables"
-      FFMPEG_PIC="--enable-pic"
-  ;;
+    FFMPEG_TABLES="--enable-hardcoded-tables"
+    ;;
+  *)
+    FFMPEG_TABLES="--disable-hardcoded-tables"
+    ;;
 esac
 
 case "$TARGET_FPU" in
   neon*)
-      FFMPEG_FPU="--enable-neon"
-  ;;
-  vfp*)
-      FFMPEG_FPU=""
-  ;;
+    FFMPEG_FPU="--enable-neon"
+    ;;
   *)
-      FFMPEG_FPU=""
-  ;;
+    FFMPEG_FPU="--disable-neon"
+    ;;
 esac
 
 pre_configure_target() {
   cd $ROOT/$PKG_BUILD
   rm -rf .$TARGET_NAME
 
-# ffmpeg fails building with LTO support
+# ffmpeg fails building for x86_64 with LTO support
   strip_lto
 
 # ffmpeg fails running with GOLD support
   strip_gold
 
+
   if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
-    export CFLAGS="-I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux -DRPI=1 $CFLAGS"
-    export FFMPEG_LIBS="-lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
+    CFLAGS="-I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux -DRPI=1 $CFLAGS"
+    FFMPEG_LIBS="-lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
   fi
 }
 
 configure_target() {
-  ./configure --prefix=/usr \
-              --cpu=$TARGET_CPU \
-              --arch=$TARGET_ARCH \
+  ./configure --prefix="/usr" \
+              --cpu="$TARGET_CPU" \
+              --arch="$TARGET_ARCH" \
               --enable-cross-compile \
-              --cross-prefix=$TARGET_PREFIX \
-              --sysroot=$SYSROOT_PREFIX \
+              --cross-prefix="$TARGET_PREFIX" \
+              --sysroot="$SYSROOT_PREFIX" \
               --sysinclude="$SYSROOT_PREFIX/usr/include" \
               --target-os="linux" \
-              --extra-version="$PKG_VERSION" \
               --nm="$NM" \
               --ar="$AR" \
               --as="$CC" \
@@ -122,10 +115,8 @@ configure_target() {
               --host-ldflags="$HOST_LDFLAGS" \
               --host-libs="-lm" \
               --extra-cflags="$CFLAGS" \
-              --extra-ldflags="$LDFLAGS -fPIC" \
+              --extra-ldflags="$LDFLAGS" \
               --extra-libs="$FFMPEG_LIBS" \
-              --extra-version="" \
-              --build-suffix="" \
               --disable-static \
               --enable-shared \
               --enable-gpl \
@@ -134,7 +125,7 @@ configure_target() {
               --enable-logging \
               --disable-doc \
               $FFMPEG_DEBUG \
-              $FFMPEG_PIC \
+              --enable-pic \
               --pkg-config="$ROOT/$TOOLCHAIN/bin/pkg-config" \
               --enable-optimizations \
               --disable-extra-warnings \
@@ -215,7 +206,6 @@ configure_target() {
               --enable-zlib \
               --enable-asm \
               --disable-altivec \
-              $FFMPEG_CPU \
               $FFMPEG_FPU \
               --enable-yasm \
               --disable-symver


### PR DESCRIPTION
I wanted to know how building FFmpeg for LibreELEC compared to a vanilla FFmpeg cross compilation. I think this is it.

~~The only update is that --enable-pic was added for aarch64.~~

The ~~other~~ changes should be cosmetic:
- removed the default and autodetected build options
- removed superfluous variables (FFMPEG_CPU, FFMPEG_FPU and FFMPEG_PIC)
- split the code into logic for dependencies and logic for pre_configure_target.

The output of the configure step is the same as with the previous version of ffmpeg for Generic and RPi2. We could maybe use Jenkins to check the other builds