### PR TITLE
ffmpeg: Switch to revision based versioning, not release

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -17,13 +17,14 @@
 ################################################################################
 
 PKG_NAME="ffmpeg"
-PKG_VERSION="3.0-xbmc"
+# Current branch is: release/3.0-xbmc
+PKG_VERSION="c44bf39"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
-PKG_URL="https://github.com/xbmc/FFmpeg/archive/release/${PKG_VERSION}.tar.gz"
-PKG_SOURCE_DIR="FFmpeg-release-${PKG_VERSION}"
+PKG_URL="https://github.com/xbmc/FFmpeg/archive/${PKG_VERSION}.tar.gz"
+PKG_SOURCE_DIR="FFmpeg-${PKG_VERSION}*"
 PKG_DEPENDS_TARGET="toolchain yasm:host zlib bzip2 libressl speex"
 PKG_PRIORITY="optional"
 PKG_SECTION="multimedia"


### PR DESCRIPTION
Discussing the proposed ffmpeg changes (#477) on slack brought up an issue with the current ffmpeg versioning.

If a builder downloads the 3.0-xbmc ffmpeg source tarball (as I did at the end of March) to their `sources` cache they won't ever download the 3.0-xbmc ffmpeg source tarball again even if is updated with new commits (unless they delete their existing tarball).

The current 3.0-xbmc ffmpeg version is now 3.0.2, which is 33 commits ahead of the 3.0.1 version I downloaded in March.

Someone building master who has never downloaded the ffmpeg tarball will build with the latest 3.0-xbmc (ie. 3.0.2, plus a few more commits) while I will continue building with 3.0.1, blissfully ignorant of any new fixes (or new bugs).

This clearly isn't a good situation, as we should all be building the same source code, hence this switch to hash based versioning.