### PR TITLE
libva/libva-intel-driver: update to 1.7.1

### DIFF
--- a/packages/multimedia/libva-intel-driver/package.mk
+++ b/packages/multimedia/libva-intel-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libva-intel-driver"
-PKG_VERSION="1.7.0"
+PKG_VERSION="1.7.1"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"

--- a/packages/multimedia/libva-intel-driver/patches/libva-intel-driver-01-update-pci-ids.patch
+++ b/packages/multimedia/libva-intel-driver/patches/libva-intel-driver-01-update-pci-ids.patch
@@ -1,0 +1,42 @@
+Von: "Xiang, Haihao" <haihao.xiang@intel.com>
+Datum: 24.06.2016 4:06 vorm.
+Betreff: [Libva] [Libva-intel-driver][PATCH] Update PCI IDs for Kabylake
+An: <libva@lists.freedesktop.org>
+Cc: <Xiang@freedesktop.org>
+
+Remove unused PCI IDs and add new PCI IDs for KBL, the IDs are taken
+directly from intel-gfx patches, which are under review:
+
+https://lists.freedesktop.org/archives/intel-gfx/2016-June/099263.html
+https://lists.freedesktop.org/archives/intel-gfx/2016-June/099264.html
+
+Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>
+---
+ src/i965_pciids.h | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/src/i965_pciids.h b/src/i965_pciids.h
+index fe3f4d0..1ea3c98 100644
+--- a/src/i965_pciids.h
++++ b/src/i965_pciids.h
+@@ -174,14 +174,12 @@ CHIPSET(0x591E, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x5912, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x5917, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x5902, kbl, kbl,       "Intel(R) Kabylake")
+-CHIPSET(0x5932, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x591B, kbl, kbl,       "Intel(R) Kabylake")
+-CHIPSET(0x592B, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x593B, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x590B, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x591A, kbl, kbl,       "Intel(R) Kabylake")
+-CHIPSET(0x592A, kbl, kbl,       "Intel(R) Kabylake")
+-CHIPSET(0x593A, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x590A, kbl, kbl,       "Intel(R) Kabylake")
+ CHIPSET(0x591D, kbl, kbl,       "Intel(R) Kabylake")
+-CHIPSET(0x593D, kbl, kbl,       "Intel(R) Kabylake")
+\ No newline at end of file
++CHIPSET(0x5908, kbl, kbl,       "Intel(R) Kabylake")
++CHIPSET(0x5923, kbl, kbl,       "Intel(R) Kabylake")
++CHIPSET(0x5927, kbl, kbl,       "Intel(R) Kabylake")
+--
+2.8.3

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libva"
-PKG_VERSION="1.7.0"
+PKG_VERSION="1.7.1"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
This bumped version of `libva-intel-driver` includes the custom patch I've had in my Generic builds for the last few weeks (thanks @fritsch): http://nmacleod.com/public/oebuild/patches/00_intel_CSC_average_logic.txt