### PR TITLE
pulseaudio: update to 9.0

### DIFF
--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pulseaudio"
-PKG_VERSION="8.0"
+PKG_VERSION="9.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
This should be pretty safe to merge as it's only used for bluetooth audio.