### PR TITLE
kodi-binary-addons: Update unofficial addons

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="audiodecoder.asap"
-PKG_VERSION="53566f4"
+PKG_VERSION="e56a821"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="audiodecoder.upse"
-PKG_VERSION="a6a41d1"
+PKG_VERSION="23a5430"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="audiodecoder.usf"
-PKG_VERSION="85bd171"
+PKG_VERSION="ce4b75c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="audiodecoder.wsr"
-PKG_VERSION="f5aff29"
+PKG_VERSION="746fcbb"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.mpd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.mpd/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="inputstream.mpd"
-PKG_VERSION="84d294f"
+PKG_VERSION="350838d"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/liberty-developer/inputstream.mpd/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/visualization.pictureit/patches/visualization.pictureit-01-rename_find_package_to_Kodi.patch
+++ b/packages/mediacenter/kodi-binary-addons/visualization.pictureit/patches/visualization.pictureit-01-rename_find_package_to_Kodi.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ada0ea8..0162b63 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.6)
+ 
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
+ 
+-find_package(kodi REQUIRED)
++find_package(Kodi REQUIRED)
+ find_package(OpenGL)
+ 
+ if(OPENGL_FOUND)

--- a/packages/mediacenter/kodi-binary-addons/visualization.wavforhue/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.wavforhue/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="visualization.wavforhue"
-PKG_VERSION="e57e436"
+PKG_VERSION="b1805db"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -54,6 +54,24 @@ resolve_hash() {
   fi
 }
 
+# Get url in git:// notation for a package.mk, assuming it is a github.com url
+# Return 1 if not a github domain
+geturl() {
+  local addon="$1"
+  local domain owner repo
+
+  . ../../packages/mediacenter/kodi-binary-addons/${addon}/package.mk 1>/dev/null 2>/dev/null
+
+  domain="$(echo "${PKG_URL}" | cut -d/ -f3)"
+  [ "${domain}" = "github.com" ] || return 1
+
+  owner="$(echo "${PKG_URL}" | cut -d/ -f4)"
+  repo="$(echo "${PKG_URL}" | cut -d/ -f5)"
+
+  echo "git://${domain}/${owner}/${repo}.git"
+  return 0
+}
+
 if [ ! -d $KODI_DIR ] ; then
   echo "meh.. $KODI_DIR does not exist"
   exit 127
@@ -87,6 +105,9 @@ if [ -f ../../packages/mediacenter/kodi-platform/package.mk ] ; then
 fi
 rm -rf $PKG_NAME.git
 
+PROCESSED=/tmp/update_binary_addons.dat
+rm -f ${PROCESSED}
+
 # addons
 for addontxt in $KODI_DIR/project/cmake/addons/bootstrap/repositories/*-addons.txt ; do
   ADDONS=$(cat $addontxt | awk '{print $1}')
@@ -98,6 +119,8 @@ for addontxt in $KODI_DIR/project/cmake/addons/bootstrap/repositories/*-addons.t
     REPO=$(cat $addon/$ADDON.txt | awk '{print $2}')
     GIT_HASH=$(cat $addon/$ADDON.txt | awk '{print $3}')
     PKG_NAME="$ADDON"
+
+    echo "${PKG_NAME}" >> ${PROCESSED}
 
     if ! grep -q all $addon/platforms.txt && ! grep -q linux $addon/platforms.txt && ! grep -q ! $addon/platforms.txt; then
       continue
@@ -121,4 +144,23 @@ for addontxt in $KODI_DIR/project/cmake/addons/bootstrap/repositories/*-addons.t
   done
   echo "followed addons was skipped, please add packages for this:"
   echo "$SKIPPED_ADDONS"
+done
+
+# finally, any other unofficial addons
+for ADDON in $(ls -1 ../../packages/mediacenter/kodi-binary-addons); do
+  # ignore already processed addons
+  grep -qE "^${ADDON}$" ${PROCESSED} && continue
+
+  # Obtain git url - ignore if not a suitable repo
+  REPO="$(geturl "${ADDON}")" || continue
+
+  git_clone $REPO master $ADDON.git HEAD
+
+  # update package.mk for stale github.com packages
+  RESOLVED_HASH=$(resolve_hash ${ADDON}.git HEAD) || continue
+
+  sed -e "s|PKG_VERSION=.*|PKG_VERSION=\"$RESOLVED_HASH\"|g" \
+    -i ../../packages/mediacenter/kodi-binary-addons/$ADDON/package.mk
+
+  rm -rf $ADDON.git
 done


### PR DESCRIPTION
Bump those addons not officially supported by https://github.com/xbmc/repo-binary-addons

Unlike officially supported Kodi binary addons, these "unofficial" binary addons will be blindly bumped - they may or may not be compatible with latest Kodi, as is the case with `visualization.pictureit` which requires a slight modification to build against latest Kodi (which might suggest there is and will be ongoing maintenance/support issues with this add-on - consider dropping?)