### PR TITLE
build: evaluate DEVTOOLS after $HOME options

### DIFF
--- a/config/options
+++ b/config/options
@@ -82,11 +82,6 @@ fi
 # directory.
   CCACHE_CACHE_SIZE="10G"
 
-# install devtools on development builds
-  if [ "$LIBREELEC_VERSION" = "devel" ]; then
-    DEVTOOLS=yes
-  fi
-
 # read options from $HOME if available
   if [ -f "$HOME/.libreelec/options" ]; then
     . $HOME/.libreelec/options
@@ -98,6 +93,11 @@ fi
 # read distro options from $HOME if available
   if [ -f "$HOME/.libreelec/options.$DISTRO" ]; then
     . $HOME/.libreelec/options.$DISTRO
+  fi
+
+# install devtools on development builds
+  if [ -z "$DEVTOOLS" -a "$LIBREELEC_VERSION" = "devel" ]; then
+    DEVTOOLS=yes
   fi
 
 # overwrite OEM_SUPPORT via commandline


### PR DESCRIPTION
If `LIBREELEC_VERSION` is ever set in `$HOME/.libreelec/options` or `$HOME/.libreelec/projects/$PROJECT/options` (eg. `7.0.2`) the `DEVTOOLS` option would always be set to `yes` whenever the tree value for `LIBREELEC_VERSION` is `devel`. This corrects that error.