### PR TITLE
kodi-binary-addons: Fix update_binary-addons

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.mpd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.mpd/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="inputstream.mpd"
-PKG_VERSION="350838d"
+PKG_VERSION="b171dff"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/liberty-developer/inputstream.mpd/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="acba9f1"
+PKG_VERSION="ad1f7d6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.shadertoy"
-PKG_VERSION="394de3d"
+PKG_VERSION="9e0d1e4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -72,6 +72,22 @@ geturl() {
   return 0
 }
 
+# For the specified addon, verify that the package url
+# matches the url retrieved from Kodi
+validate_pkg_url() {
+  local addon="$1" url1="$2"
+  local domain owner repo url2
+
+  domain="$(echo "${url1}" | cut -d/ -f3)"
+  owner="$(echo "${url1}" | cut -d/ -f4)"
+  repo="$(echo "${url1}" | cut -d/ -f5)"
+
+  url1="git://${domain}/${owner}/${repo}.git"
+  url2="$(geturl "${addon}")"
+
+  [ "${url1}" = "${url2}" ] && return 0 || return 1
+}
+
 if [ ! -d $KODI_DIR ] ; then
   echo "meh.. $KODI_DIR does not exist"
   exit 127
@@ -105,9 +121,6 @@ if [ -f ../../packages/mediacenter/kodi-platform/package.mk ] ; then
 fi
 rm -rf $PKG_NAME.git
 
-PROCESSED=/tmp/update_binary_addons.dat
-rm -f ${PROCESSED}
-
 # addons
 for addontxt in $KODI_DIR/project/cmake/addons/bootstrap/repositories/*-addons.txt ; do
   ADDONS=$(cat $addontxt | awk '{print $1}')
@@ -120,7 +133,11 @@ for addontxt in $KODI_DIR/project/cmake/addons/bootstrap/repositories/*-addons.t
     GIT_HASH=$(cat $addon/$ADDON.txt | awk '{print $3}')
     PKG_NAME="$ADDON"
 
-    echo "${PKG_NAME}" >> ${PROCESSED}
+    # Verify the Kodi repo matches our package repo
+    # If different, ignore the addon and process it later as an "unofficial" addon
+    validate_pkg_url "$ADDON" "$REPO" || continue
+
+    PROCESSED="${PROCESSED}${PKG_NAME}\n"
 
     if ! grep -q all $addon/platforms.txt && ! grep -q linux $addon/platforms.txt && ! grep -q ! $addon/platforms.txt; then
       continue
@@ -136,7 +153,6 @@ for addontxt in $KODI_DIR/project/cmake/addons/bootstrap/repositories/*-addons.t
           -i ../../packages/mediacenter/kodi-binary-addons/$ADDON/package.mk
 
       rm -rf $PKG_NAME.git
-
     else
       echo "[mkpkg] Skipped $ADDON"
       SKIPPED_ADDONS="$SKIPPED_ADDONS $ADDON"
@@ -149,7 +165,7 @@ done
 # finally, any other unofficial addons
 for ADDON in $(ls -1 ../../packages/mediacenter/kodi-binary-addons); do
   # ignore already processed addons
-  grep -qE "^${ADDON}$" ${PROCESSED} && continue
+  echo -e "${PROCESSED}" | grep -qE "^${ADDON}$" && continue
 
   # Obtain git url - ignore if not a suitable repo
   REPO="$(geturl "${ADDON}")" || continue


### PR DESCRIPTION
Certain binary addons are configured in Kodi to use a different repo to the repo our package will ultimately build.

For example:
`inputstream.mpd` (Kodi: mapfau, LE: libertydeveloper)
`screensaver.shadertoy` (Kodi: afedchin; LE: popcornmix)

This means we will pull a rev (version) based on the Kodi repo, then build our repo using this wrong rev. Often this works, as the repo we are using is a fork of the Kodi repo, but it does mean the version of the code we use is not necessarily the latest for the repo we ultimately build.

This change to `update_binary-addons` will detect when the Kodi repo does not match our package repo, and will defer processing of the repository treating it as an "unofficial" addon.