### PR TITLE
mono_sqlite: accommodate the addon building script

### DIFF
--- a/packages/addons/addon-depends/mono-depends/mono_sqlite/package.mk
+++ b/packages/addons/addon-depends/mono-depends/mono_sqlite/package.mk
@@ -16,7 +16,10 @@
 #  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-. $ROOT/$PACKAGES/databases/sqlite/package.mk
+if [ -n "$ROOT" ]
+then 
+  . $ROOT/$PACKAGES/databases/sqlite/package.mk
+fi
 
 PKG_NAME="mono_sqlite"
 PKG_URL=""


### PR DESCRIPTION
Prevent the addon building script to fail because $ROOT is not defined