### PR TITLE
kodi: Fix package version

### DIFF
--- a/packages/mediacenter/kodi-theme-Estuary/package.mk
+++ b/packages/mediacenter/kodi-theme-Estuary/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="kodi-theme-Estuary"
-PKG_VERSION="17.0-alpha2-f3ca4eaf9"
+PKG_VERSION="17.0-alpha2-f3ca4ea"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="kodi"
-PKG_VERSION="17.0-alpha2-f3ca4eaf9"
+PKG_VERSION="17.0-alpha2-f3ca4ea"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
The package on the mirror is `f3ca4ea`, which I could change/regenerate, but our standard is 7-chars so fixing that instead.