### PR TITLE
scripts/image: don't copy *-update.zip to target directory

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -434,8 +434,6 @@ fi
           popd > /dev/null
         fi
 
-        # copy update package to target directory
-        cp sign/$IMAGE_NAME-update.zip $TARGET_IMG
         popd > /dev/null
 
       elif [ "$1" = "noobs" ]; then


### PR DESCRIPTION
This file is not needed as it's included in "full" ZIP already. Keeping this file confuses some people.