### PR TITLE
libamcodec: make source arch-specific, not project-specific

### DIFF
--- a/packages/multimedia/libamcodec/package.mk
+++ b/packages/multimedia/libamcodec/package.mk
@@ -21,12 +21,12 @@ PKG_REV="1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="other"
 PKG_SITE="http://openlinux.amlogic.com"
-case $PROJECT in
-  WeTek_Core|WeTek_Play)
+case $TARGET_ARCH in
+  arm)
     PKG_VERSION="45a1086"
     PKG_URL="https://github.com/codesnake/libamcodec/archive/$PKG_VERSION.tar.gz"
     ;;
-  Odroid_C2)
+  aarch64)
     PKG_VERSION="210755d"
     PKG_URL="http://amlinux.ru/source/$PKG_NAME-$PKG_VERSION.tar.gz"
     ;;


### PR DESCRIPTION
Let libamcodec build properly for other aarch64 Amlogic targets.