### PR TITLE
init: Fix updating from img.gz when kernel resides on block device

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -253,6 +253,7 @@ makeinstall_init() {
   cp $PKG_DIR/scripts/functions $INSTALL
   cp $PKG_DIR/scripts/init $INSTALL
   sed -e "s/@DISTRONAME@/$DISTRONAME/g" \
+      -e "s/@KERNEL_NAME@/$KERNEL_NAME/g" \
       -i $INSTALL/init
   chmod 755 $INSTALL/init
 }

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -727,7 +727,11 @@
       # don't make temporary files but instead copy
       # directly from mountpoint to /flash
       UPDATE_DIR=$UPDATE_ROOT/.tmp/mnt
-      UPDATE_KERNEL=$(basename $IMAGE_KERNEL)
+      if [ ! -b $IMAGE_KERNEL -o -z "@KERNEL_NAME@" ]; then
+        UPDATE_KERNEL=$(basename $IMAGE_KERNEL)
+      else
+        UPDATE_KERNEL="@KERNEL_NAME@"
+      fi
     fi
 
     sync


### PR DESCRIPTION
This fixes updating LE from img.gz when installed on WeTek internal memory.