### PR TITLE
enable X11grab for add possibility record screen

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -142,7 +142,7 @@ configure_target() {
               --disable-devices \
               --enable-pthreads \
               --disable-w32threads \
-              --disable-x11grab \
+              --enable-x11grab \
               --enable-network \
               --disable-gnutls --enable-openssl \
               --disable-gray \


### PR DESCRIPTION
I was using this some time ago when ffmpeg was installed from unofficial addon repo 

with that tool a was able to record picture from our tv screen
more here
http://wiki.oz9aec.net/index.php/High_quality_screen_capture_with_Ffmpeg
https://trac.ffmpeg.org/wiki/Capture/Desktop

But this change --enable-x11grab need also lib in system libxcb which are not delivered now :(
after compiling without any error/issue:

Unknown input format: 'x11grab' - when i tried use  :/

So maybe some one could extended my pull request and add needed changes

ldd /usr/bin/ffmpeg - no libxcb
http://pastebin.com/Q5YQYFQx

now with that one change ffmpeg will build without issue but x11grab will no work yet without changes in libxcb
