### PR TITLE
Cpu temperature readings for devices with aml_thermal interface

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.16-cpu-temp-readings-amlogic-based-devices.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.16-cpu-temp-readings-amlogic-based-devices.patch
@@ -1,0 +1,59 @@
+From: Immanuel Klinkenberg <drieschel@yahoo.de>
+Date: Thu, 7 Jul 2016 ~ 20:50 +2GMT
+Subject: [PATCH] CPU temp readings fix for amlogic based devices which are using the aml_thermal interface.
+
+---
+
+diff -Naur kodi-16.1-c327c53.orig/xbmc/utils/CPUInfo.cpp kodi-16.1-c327c53/xbmc/utils/CPUInfo.cpp
+--- kodi-16.1-c327c53.orig/xbmc/utils/CPUInfo.cpp	2016-07-07 19:30:48.309897861 +0200
++++ kodi-16.1-c327c53/xbmc/utils/CPUInfo.cpp	2016-07-07 20:04:10.000000000 +0200
+@@ -24,6 +24,7 @@
+ #include "utils/Temperature.h"
+ #include <string>
+ #include <string.h>
++#include <sys/stat.h>
+ 
+ #if defined(TARGET_DARWIN)
+ #include <sys/types.h>
+@@ -259,8 +260,18 @@
+     m_cores[core.m_id] = core;
+   }
+ #else
++  struct stat stBuf;
++  m_isAmlThermal = stat("/sys/bus/platform/devices/aml_thermal", &stBuf) == 0 && S_ISDIR(stBuf.st_mode);
+   m_fProcStat = fopen("/proc/stat", "r");
+-  m_fProcTemperature = fopen("/proc/acpi/thermal_zone/THM0/temperature", "r");
++  
++  if(m_isAmlThermal)
++  {
++    m_fProcTemperature = fopen("/sys/class/thermal/thermal_zone1/temp", "r");
++    if (m_fProcTemperature == NULL)   
++      m_fProcTemperature = fopen("/sys/class/thermal/thermal_zone0/temp", "r");  
++  }
++  if (m_fProcTemperature == NULL)
++    m_fProcTemperature = fopen("/proc/acpi/thermal_zone/THM0/temperature", "r");
+   if (m_fProcTemperature == NULL)
+     m_fProcTemperature = fopen("/proc/acpi/thermal_zone/THRM/temperature", "r");
+   if (m_fProcTemperature == NULL)
+@@ -624,7 +635,9 @@
+     if (!ret)
+     {
+       ret = fscanf(m_fProcTemperature, "%d", &value);
+-      value = value / 1000;
++      if(!m_isAmlThermal)
++        value = value / 1000;
++      
+       scale = 'c';
+       ret++;
+     }
+diff -Naur kodi-16.1-c327c53.orig/xbmc/utils/CPUInfo.h kodi-16.1-c327c53/xbmc/utils/CPUInfo.h
+--- kodi-16.1-c327c53.orig/xbmc/utils/CPUInfo.h	2016-07-07 19:30:48.309897861 +0200
++++ kodi-16.1-c327c53/xbmc/utils/CPUInfo.h	2016-07-07 20:00:57.000000000 +0200
+@@ -111,6 +111,7 @@
+   FILE* m_fProcTemperature;
+   FILE* m_fCPUFreq;
+   bool m_cpuInfoForFreq;
++  bool m_isAmlThermal = false;
+ #elif defined(TARGET_WINDOWS)
+   PDH_HQUERY m_cpuQueryFreq;
+   PDH_HQUERY m_cpuQueryLoad;

--- a/packages/mediacenter/kodi/scripts/cputemp
+++ b/packages/mediacenter/kodi/scripts/cputemp
@@ -23,12 +23,27 @@
 
 TEMP=0
 
+isAmlThermal="no";
+if [ -d '/sys/bus/platform/devices/aml_thermal' ]; then
+  isAmlThermal="yes";
+fi
+
 if [ $(basename "$0") = "gputemp" -o "$1" = "gpu" ]; then
   if which lspci >/dev/null; then
     if lspci -n | grep 0300 | grep -q 10de; then
       [ -x /usr/bin/nvidia-smi ] && TEMP=`/usr/bin/nvidia-smi -q -x | grep '<gpu_temp>' | awk '{ print $1 }' | sed 's,<gpu_temp>,,g'`
     fi
   fi
+fi
+
+if [ "$isAmlThermal" = "yes" -a "$TEMP" = "0" ]; then
+  if [ -f /sys/class/thermal/thermal_zone1/temp ]; then
+    TEMP=`cat /sys/class/thermal/thermal_zone1/temp`
+  fi
+
+  if [ "$TEMP" = "0" -a -f /sys/class/thermal/thermal_zone0/temp ]; then
+    TEMP=`cat /sys/class/thermal/thermal_zone0/temp`
+  fi  
 fi
 
 if [ "$1" = "cpu" -o "$TEMP" = "0" ]; then


### PR DESCRIPTION
Adds correct cpu temperature readings for Amlogic devices which have the aml_thermal (AML_PLATFORM_THERMAL) interface enabled.

@MilhouseVH This time everything in a single commit (hopefully)^^
