### PR TITLE
functions : Make sure sure we also remove lto flags from TARGET_FLAGS.

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -211,15 +211,19 @@ strip_lto() {
   if [ -n "$GCC_OPTIM_LTO" ] ; then
     CFLAGS=`echo $CFLAGS | sed -e "s|$GCC_OPTIM_LTO||g"`
     CXXFLAGS=`echo $CXXFLAGS | sed -e "s|$GCC_OPTIM_LTO||g"`
+    TARGET_CFLAGS=`echo $TARGET_CFLAGS | sed -e "s|$GCC_OPTIM_LTO||g"`
+    TARGET_CXXFLAGS=`echo $TARGET_CXXFLAGS | sed -e "s|$GCC_OPTIM_LTO||g"`
   fi
   if [ -n "$LD_OPTIM_LTO" ] ; then
     LDFLAGS=`echo $LDFLAGS | sed -e "s|$LD_OPTIM_LTO||g"`
+    TARGET_LDFLAGS=`echo $TARGET_LDFLAGS | sed -e "s|$LD_OPTIM_LTO||g"`
   fi
 }
 
 strip_gold() {
   # strip out usage from GOLD linker
   LDFLAGS=`echo $LDFLAGS | sed -e "s|-fuse-ld=gold||g"`
+  TARGET_LDFLAGS=echo $TARGET_LDFLAGS | sed -e "s|-fuse-ld=gold||g"`
 }
 
 fix_module_depends() {


### PR DESCRIPTION
If some packages want to use strip_lto and use the TARGET_FLAGS, those still have the lto flags.