### PR TITLE
kodi: database migration splash text

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.17-dbupgrade-dynamic-splash-message.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.17-dbupgrade-dynamic-splash-message.patch
@@ -1,0 +1,211 @@
+diff --git a/xbmc/DatabaseManager.cpp b/xbmc/DatabaseManager.cpp
+index ed0178d..6430252 100644
+--- a/xbmc/DatabaseManager.cpp
++++ b/xbmc/DatabaseManager.cpp
+@@ -51,7 +51,7 @@ CDatabaseManager::~CDatabaseManager()
+ void CDatabaseManager::Initialize(bool addonsOnly)
+ {
+   Deinitialize();
+-  { CAddonDatabase db; UpdateDatabase(db); }
++  { CAddonDatabase db; UpdateDatabase(db, NULL, false); }
+   if (addonsOnly)
+     return;
+   CLog::Log(LOGDEBUG, "%s, updating databases...", __FUNCTION__);
+@@ -83,11 +83,11 @@ bool CDatabaseManager::CanOpen(const std::string &name)
+   return false; // db isn't even attempted to update yet
+ }
+ 
+-void CDatabaseManager::UpdateDatabase(CDatabase &db, DatabaseSettings *settings)
++void CDatabaseManager::UpdateDatabase(CDatabase &db, DatabaseSettings *settings, bool bShowSplash)
+ {
+   std::string name = db.GetBaseDBName();
+   UpdateStatus(name, DB_UPDATING);
+-  if (db.Update(settings ? *settings : DatabaseSettings()))
++  if (db.Update(settings ? *settings : DatabaseSettings(), bShowSplash))
+     UpdateStatus(name, DB_READY);
+   else
+     UpdateStatus(name, DB_FAILED);
+diff --git a/xbmc/DatabaseManager.h b/xbmc/DatabaseManager.h
+index c3bfba5..e75aae0 100644
+--- a/xbmc/DatabaseManager.h
++++ b/xbmc/DatabaseManager.h
+@@ -61,7 +61,7 @@ public:
+ 
+    \param name the name of the database to check.
+    \return true if the database can be opened, false otherwise.
+-   */ 
++   */
+   bool CanOpen(const std::string &name);
+ 
+ private:
+@@ -73,7 +73,7 @@ private:
+ 
+   enum DB_STATUS { DB_CLOSED, DB_UPDATING, DB_READY, DB_FAILED };
+   void UpdateStatus(const std::string &name, DB_STATUS status);
+-  void UpdateDatabase(CDatabase &db, DatabaseSettings *settings = NULL);
++  void UpdateDatabase(CDatabase &db, DatabaseSettings *settings = NULL, bool bShowSplash = true);
+ 
+   CCriticalSection            m_section;     ///< Critical section protecting m_dbStatus.
+   std::map<std::string, DB_STATUS> m_dbStatus;    ///< Our database status map.
+diff --git a/xbmc/dbwrappers/Database.cpp b/xbmc/dbwrappers/Database.cpp
+index 4dc71c5..6d06e8f 100644
+--- a/xbmc/dbwrappers/Database.cpp
++++ b/xbmc/dbwrappers/Database.cpp
+@@ -29,6 +29,7 @@
+ #include "sqlitedataset.h"
+ #include "DatabaseManager.h"
+ #include "DbUrl.h"
++#include "utils/Splash.h"
+ 
+ #ifdef HAS_MYSQL
+ #include "mysqldataset.h"
+@@ -356,7 +357,7 @@ void CDatabase::InitSettings(DatabaseSettings &dbSettings)
+     dbSettings.name = GetBaseDBName();
+ }
+ 
+-bool CDatabase::Update(const DatabaseSettings &settings)
++bool CDatabase::Update(const DatabaseSettings &settings, bool bShowSplash)
+ {
+   DatabaseSettings dbSettings = settings;
+   InitSettings(dbSettings);
+@@ -367,6 +368,7 @@ bool CDatabase::Update(const DatabaseSettings &settings)
+ 
+   while (version >= GetMinSchemaVersion())
+   {
++    std::string splashmsg;
+     std::string dbName = dbSettings.name;
+     if (version)
+       dbName += StringUtils::Format("%d", version);
+@@ -378,6 +380,13 @@ bool CDatabase::Update(const DatabaseSettings &settings)
+       {
+         CLog::Log(LOGNOTICE, "Old database found - updating from version %i to %i", version, GetSchemaVersion());
+ 
++        if (bShowSplash)
++        {
++          splashmsg = "Database migration in progress - please wait...";
++          splashmsg += "\nMigrating database " + dbSettings.name + " from v" + StringUtils::Format("%d", version) + " to v" + StringUtils::Format("%d", GetSchemaVersion());
++          CSplash::GetInstance().Show(splashmsg);
++	    }
++
+         bool copy_fail = false;
+ 
+         try
+diff --git a/xbmc/dbwrappers/Database.h b/xbmc/dbwrappers/Database.h
+index 0117ecd..961f486 100644
+--- a/xbmc/dbwrappers/Database.h
++++ b/xbmc/dbwrappers/Database.h
+@@ -42,7 +42,7 @@ public:
+     Filter() : fields("*") {};
+     Filter(const char *w) : fields("*"), where(w) {};
+     Filter(const std::string &w) : fields("*"), where(w) {};
+-    
++
+     void AppendField(const std::string &strField);
+     void AppendJoin(const std::string &strJoin);
+     void AppendWhere(const std::string &strWhere, bool combineWithAnd = true);
+@@ -163,7 +163,7 @@ public:
+ 
+ protected:
+   friend class CDatabaseManager;
+-  bool Update(const DatabaseSettings &db);
++  bool Update(const DatabaseSettings &db, bool bShowSplash);
+ 
+   void Split(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName);
+ 
+diff --git a/xbmc/utils/Splash.cpp b/xbmc/utils/Splash.cpp
+index 7e1d885..c9dd388 100644
+--- a/xbmc/utils/Splash.cpp
++++ b/xbmc/utils/Splash.cpp
+@@ -30,13 +30,16 @@
+ using namespace XFILE;
+ 
+ CSplash::CSplash()
+-  : m_image(nullptr)
+ {
++  m_messageLayout = NULL;
++  m_image = NULL;
++  m_layoutWasLoading = false;
+ }
+ 
+ CSplash::~CSplash()
+ {
+   delete m_image;
++  delete m_messageLayout;
+ }
+ 
+ CSplash& CSplash::GetInstance()
+@@ -47,6 +50,11 @@ CSplash& CSplash::GetInstance()
+ 
+ void CSplash::Show()
+ {
++  Show("");
++}
++
++void CSplash::Show(const std::string& message)
++{
+   if (!m_image)
+   {
+     std::string splashImage = "special://home/media/Splash.png";
+@@ -70,6 +78,34 @@ void CSplash::Show()
+   m_image->Render();
+   m_image->FreeResources();
+ 
++  // render message
++  if (!message.empty())
++  {
++    if (!m_layoutWasLoading)
++    {
++      // load arial font, white body, no shadow, size: 20, no additional styling
++      CGUIFont *messageFont = g_fontManager.LoadTTF("__splash__", "arial.ttf", 0xFFFFFFFF, 0, 24, FONT_STYLE_NORMAL, false, 1.25f, 1.0f, &res);
++      if (messageFont)
++        m_messageLayout = new CGUITextLayout(messageFont, true, 0);
++      m_layoutWasLoading = true;
++    }
++    if (m_messageLayout)
++    {
++      m_messageLayout->Update(message, 1150, false, true);
++      float textWidth, textHeight;
++      m_messageLayout->GetTextExtent(textWidth, textHeight);
++
++      int width = g_graphicsContext.GetWidth();
++      int height = g_graphicsContext.GetHeight();
++
++      // ideally place text in center of empty area below splash image
++      float y = m_image->GetTextureHeight() - 180;
++      if (y + textHeight > height) // make sure entire text is visible
++        y = height - textHeight - 30; // -30 for safe viewing area
++      m_messageLayout->RenderOutline(width/2, y, 0, 0xFF000000, XBFONT_CENTER_X, width);
++    }
++  }
++
+   //show it on screen
+   g_Windowing.EndRender();
+   g_graphicsContext.Flip(true, false);
+diff --git a/xbmc/utils/Splash.h b/xbmc/utils/Splash.h
+index d8c81c2..66fbae0 100644
+--- a/xbmc/utils/Splash.h
++++ b/xbmc/utils/Splash.h
+@@ -22,6 +22,7 @@
+ 
+ #include <string>
+ 
++class CGUITextLayout;
+ class CGUIImage;
+ 
+ class CSplash
+@@ -30,6 +31,7 @@ public:
+   static CSplash& GetInstance();
+ 
+   void Show();
++  void Show(const std::string& message);
+ 
+ protected:
+   CSplash();
+@@ -38,5 +40,7 @@ protected:
+   virtual ~CSplash();
+ 
+ private:
++  CGUITextLayout* m_messageLayout;
+   CGUIImage* m_image;
++  bool m_layoutWasLoading;
+ };


### PR DESCRIPTION
This is based on the work of @MrMC: https://github.com/MrMC/mrmc/commit/dcf671d09393eede19255f448d86d5d054ddd843

Details of each database to be upgraded will be overlayed on the Kodi splash image. If the user has disabled the Kodi splash image, the Kodi splash image will be displayed anyway during database migrations.

Tested with MySQL migration of Videos and Music. Should work when migrating SQLite databases, and also when migrating other databases eg. Addons etc.

This is just a temporary solution until the issue of database migrations is solved upstream in Kodi (this fix will not be accepted upstream due to the Splash dependency being added to Database). However as there is no timeframe on such a solution, this is better than nothing.

![s1](http://i.imgur.com/eHwrzfk.png)