### PR TITLE
Add media-backports package

### DIFF
--- a/packages/linux-drivers/media-backports/package.mk
+++ b/packages/linux-drivers/media-backports/package.mk
@@ -1,0 +1,56 @@
+################################################################################
+#      This file is part of LibreELEC - https://LibreELEC.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="media-backports"
+PKG_VERSION="4.4.2"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://backports.wiki.kernel.org"
+PKG_URL="http://www.kernel.org/pub/linux/kernel/projects/backports/stable/v$PKG_VERSION/backports-$PKG_VERSION-$PKG_REV.tar.xz"
+PKG_SOURCE_DIR="backports-$PKG_VERSION-$PKG_REV"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_PRIORITY="optional"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Linux media drivers backports"
+PKG_LONGDESC="Linux media drivers backports"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+make_target() {
+  make defconfig-media \
+       CC=gcc \
+       KLIB=$INSTALL \
+       KLIB_BUILD=$(kernel_path)
+  LDFLAGS="" CFLAGS="" make \
+       KLIB=$INSTALL \
+       KLIB_BUILD=$(kernel_path) \
+       ARCH=$TARGET_KERNEL_ARCH \
+       CROSS_COMPILE=$TARGET_PREFIX
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/lib/modules/$(get_module_dir)/updates/$PKG_NAME
+
+  pushd $ROOT/$PKG_BUILD
+  find compat/ -name \*.ko -exec cp --parents {} $INSTALL/lib/modules/$(get_module_dir)/updates/$PKG_NAME \;
+  find drivers/ -name \*.ko -exec cp --parents {} $INSTALL/lib/modules/$(get_module_dir)/updates/$PKG_NAME \;
+  popd
+}

--- a/projects/Odroid_C2/options
+++ b/projects/Odroid_C2/options
@@ -105,7 +105,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU RTL8192EU RTL8812AU"
+    ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU RTL8192EU RTL8812AU media-backports"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/Odroid_C2/patches/media-backports/media-backports-ERR_PTR.patch
+++ b/projects/Odroid_C2/patches/media-backports/media-backports-ERR_PTR.patch
@@ -1,0 +1,11 @@
+diff --git a/backport-include/linux/mm.h b/backport-include/linux/mm.h
+index 7e6f77c..48935e2 100644
+--- a/backport-include/linux/mm.h
++++ b/backport-include/linux/mm.h
+@@ -1,5 +1,6 @@
+ #ifndef __BACKPORT_MM_H
+ #define __BACKPORT_MM_H
++#include <linux/err.h>
+ #include_next <linux/mm.h>
+ 
+ #ifndef VM_NODUMP

--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -126,7 +126,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS media-backports"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/WeTek_Core/patches/media-backports/media-backports-ERR_PTR.patch
+++ b/projects/WeTek_Core/patches/media-backports/media-backports-ERR_PTR.patch
@@ -1,0 +1,24 @@
+diff --git a/backport-include/linux/mm.h b/backport-include/linux/mm.h
+index 7e6f77c..48935e2 100644
+--- a/backport-include/linux/mm.h
++++ b/backport-include/linux/mm.h
+@@ -1,5 +1,6 @@
+ #ifndef __BACKPORT_MM_H
+ #define __BACKPORT_MM_H
++#include <linux/err.h>
+ #include_next <linux/mm.h>
+ 
+ #ifndef VM_NODUMP
+
+diff --git a/drivers/media/v4l2-core/v4l2-of.c b/drivers/media/v4l2-core/v4l2-of.c
+index b27cbb1..ee11aae 100644
+--- a/drivers/media/v4l2-core/v4l2-of.c
++++ b/drivers/media/v4l2-core/v4l2-of.c
+@@ -11,6 +11,7 @@
+  * it under the terms of version 2 of the GNU General Public License as
+  * published by the Free Software Foundation.
+  */
++#include <linux/err.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/of.h>

--- a/projects/WeTek_Core/patches/media-backports/media-backports-disable.patch
+++ b/projects/WeTek_Core/patches/media-backports/media-backports-disable.patch
@@ -1,0 +1,12 @@
+diff --git a/defconfigs/media b/defconfigs/media
+index c8f2e4d..99664b4 100644
+--- a/defconfigs/media
++++ b/defconfigs/media
+@@ -418,7 +418,6 @@ CPTCFG_VIDEO_OV9650=m
+ CPTCFG_VIDEO_PVRUSB2=m
+ CPTCFG_VIDEO_PXA27x=m
+ CPTCFG_VIDEO_S3C_CAMIF=m
+-CPTCFG_VIDEO_S5C73M3=m
+ CPTCFG_VIDEO_S5K4ECGX=m
+ CPTCFG_VIDEO_S5K6AA=m
+ CPTCFG_VIDEO_S5P_FIMC=m

--- a/projects/WeTek_Core/patches/media-backports/media-backports-of_i2c.patch
+++ b/projects/WeTek_Core/patches/media-backports/media-backports-of_i2c.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/media/platform/soc_camera/soc_camera.c b/drivers/media/platform/soc_camera/soc_camera.c
+index 680ab43..fbf53da 100644
+--- a/drivers/media/platform/soc_camera/soc_camera.c
++++ b/drivers/media/platform/soc_camera/soc_camera.c
+@@ -23,6 +23,7 @@
+ #include <linux/list.h>
+ #include <linux/module.h>
+ #include <linux/mutex.h>
++#include <linux/of_i2c.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/regulator/consumer.h>

--- a/projects/WeTek_Core/patches/media-backports/media-backports-smiapp.patch
+++ b/projects/WeTek_Core/patches/media-backports/media-backports-smiapp.patch
@@ -1,0 +1,35 @@
+diff --git a/include/uapi/linux/smiapp.h b/include/uapi/linux/smiapp.h
+new file mode 100644
+index 0000000..53938f4
+--- /dev/null
++++ b/include/uapi/linux/smiapp.h
+@@ -0,0 +1,29 @@
++/*
++ * include/uapi/linux/smiapp.h
++ *
++ * Generic driver for SMIA/SMIA++ compliant camera modules
++ *
++ * Copyright (C) 2014 Intel Corporation
++ * Contact: Sakari Ailus <sakari.ailus@iki.fi>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * version 2 as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * General Public License for more details.
++ *
++ */
++
++#ifndef __UAPI_LINUX_SMIAPP_H_
++#define __UAPI_LINUX_SMIAPP_H_
++
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_DISABLED			0
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_SOLID_COLOUR		1
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_COLOUR_BARS		2
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_COLOUR_BARS_GREY		3
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_PN9			4
++
++#endif /* __UAPI_LINUX_SMIAPP_H_ */

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -120,7 +120,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS wetekdvb"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS wetekdvb media-backports"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/WeTek_Play/patches/media-backports/media-backports-ERR_PTR.patch
+++ b/projects/WeTek_Play/patches/media-backports/media-backports-ERR_PTR.patch
@@ -1,0 +1,24 @@
+diff --git a/backport-include/linux/mm.h b/backport-include/linux/mm.h
+index 7e6f77c..48935e2 100644
+--- a/backport-include/linux/mm.h
++++ b/backport-include/linux/mm.h
+@@ -1,5 +1,6 @@
+ #ifndef __BACKPORT_MM_H
+ #define __BACKPORT_MM_H
++#include <linux/err.h>
+ #include_next <linux/mm.h>
+ 
+ #ifndef VM_NODUMP
+
+diff --git a/drivers/media/v4l2-core/v4l2-of.c b/drivers/media/v4l2-core/v4l2-of.c
+index b27cbb1..ee11aae 100644
+--- a/drivers/media/v4l2-core/v4l2-of.c
++++ b/drivers/media/v4l2-core/v4l2-of.c
+@@ -11,6 +11,7 @@
+  * it under the terms of version 2 of the GNU General Public License as
+  * published by the Free Software Foundation.
+  */
++#include <linux/err.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/of.h>

--- a/projects/WeTek_Play/patches/media-backports/media-backports-disable.patch
+++ b/projects/WeTek_Play/patches/media-backports/media-backports-disable.patch
@@ -1,0 +1,12 @@
+diff --git a/defconfigs/media b/defconfigs/media
+index c8f2e4d..99664b4 100644
+--- a/defconfigs/media
++++ b/defconfigs/media
+@@ -418,7 +418,6 @@ CPTCFG_VIDEO_OV9650=m
+ CPTCFG_VIDEO_PVRUSB2=m
+ CPTCFG_VIDEO_PXA27x=m
+ CPTCFG_VIDEO_S3C_CAMIF=m
+-CPTCFG_VIDEO_S5C73M3=m
+ CPTCFG_VIDEO_S5K4ECGX=m
+ CPTCFG_VIDEO_S5K6AA=m
+ CPTCFG_VIDEO_S5P_FIMC=m

--- a/projects/WeTek_Play/patches/media-backports/media-backports-of_i2c.patch
+++ b/projects/WeTek_Play/patches/media-backports/media-backports-of_i2c.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/media/platform/soc_camera/soc_camera.c b/drivers/media/platform/soc_camera/soc_camera.c
+index 680ab43..fbf53da 100644
+--- a/drivers/media/platform/soc_camera/soc_camera.c
++++ b/drivers/media/platform/soc_camera/soc_camera.c
+@@ -23,6 +23,7 @@
+ #include <linux/list.h>
+ #include <linux/module.h>
+ #include <linux/mutex.h>
++#include <linux/of_i2c.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/regulator/consumer.h>

--- a/projects/WeTek_Play/patches/media-backports/media-backports-smiapp.patch
+++ b/projects/WeTek_Play/patches/media-backports/media-backports-smiapp.patch
@@ -1,0 +1,35 @@
+diff --git a/include/uapi/linux/smiapp.h b/include/uapi/linux/smiapp.h
+new file mode 100644
+index 0000000..53938f4
+--- /dev/null
++++ b/include/uapi/linux/smiapp.h
+@@ -0,0 +1,29 @@
++/*
++ * include/uapi/linux/smiapp.h
++ *
++ * Generic driver for SMIA/SMIA++ compliant camera modules
++ *
++ * Copyright (C) 2014 Intel Corporation
++ * Contact: Sakari Ailus <sakari.ailus@iki.fi>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * version 2 as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * General Public License for more details.
++ *
++ */
++
++#ifndef __UAPI_LINUX_SMIAPP_H_
++#define __UAPI_LINUX_SMIAPP_H_
++
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_DISABLED			0
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_SOLID_COLOUR		1
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_COLOUR_BARS		2
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_COLOUR_BARS_GREY		3
++#define V4L2_SMIAPP_TEST_PATTERN_MODE_PN9			4
++
++#endif /* __UAPI_LINUX_SMIAPP_H_ */


### PR DESCRIPTION
This PR adds media-backports package to provide support for DVB tuners and other media devices for older kernels.

For now 2 tuners have been confirmed to work with 3.14 kernel: Geniatech T230 and DVBSky S960.

I think it's better to make the package opt-in (project has to add it in `options`) rather than have a project-specific definition in `package.mk` - but I'm open to suggestions.

Please keep this PR open for now as it needs to be tested with WeTek Play's built-in tuners - I'll be able to test it in a few days.