### PR TITLE
Update image script to expose build filename

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -43,6 +43,7 @@ if [ "$LIBREELEC_VERSION" = "devel" ]; then
   GIT_ABBREV=$(git log -1 --pretty=format:%h)
   DEVEL_VERSION=$LIBREELEC_VERSION
   LIBREELEC_VERSION=$LIBREELEC_VERSION-$BUILD_DATE-r$GIT_BUILD-g$GIT_ABBREV
+  echo "$LIBREELEC_VERSION" > $BUILD/BUILD_FILENAME
 fi
 
 # Get origin url, fix git:// and git@github.com: urls if necessary


### PR DESCRIPTION
Update script image to expose build filename so that it can be accessed by external scripts; i.e. copying builds from Jenkins to web03.