### PR TITLE
WeTek: Set the resolution more precisely at boot

### DIFF
--- a/projects/WeTek_Core/initramfs/platform_init
+++ b/projects/WeTek_Core/initramfs/platform_init
@@ -1,7 +1,7 @@
 #!/bin/sh
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+#      Copyright (C) 2014 Alex Deryskyba (alex@codesnake.com)
 #
 #  OpenELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-hdmimode=720p
+hdmimode="720p"
 
 # Parse command line arguments
 for arg in $(cat /proc/cmdline); do
@@ -51,15 +51,67 @@ echo 0 > /sys/class/graphics/fb0/free_scale
 # set initial video state
 echo 1 > /sys/class/video/disable_video
 
-# Set framebuffer geometry to match the resolution
-case "$hdmimode" in
-  720*)
-    fbset -fb /dev/fb0 -g 1280 720 1920 2160 32
+# Set default resolution parameters
+bpp=32;
+xRes=1280;
+yRes=720;
+
+# Get max supported display resolution by hdmi device
+maxRes=$(tail -n1 /sys/class/amhdmitx/amhdmitx0/disp_cap | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//');
+if [ -z "$maxRes" ]; then
+  maxRes="$hdmimode";
+fi
+case "$maxRes" in
+  480*)
+    xRes=720; yRes=480;
+    ;;
+  576*)
+    xRes=720; yRes=576;
     ;;
   1080*)
-    fbset -fb /dev/fb0 -g 1920 1080 1920 2160 32
+    xRes=1920; yRes=1080;
+    ;;
+  4k2k*hz|2160p*)
+    xRes=3840; yRes=2160;
+    ;;
+  4k2ksmpte|smpte24hz)
+    xRes=4096; yRes=2160;
     ;;
 esac
+vXRes=$xRes;
+vYRes=$(( $yRes * 2 ));
+
+# Choose boot resolution by hdmimode param
+case "$hdmimode" in
+  480*)
+    if [ "$vXRes" -ge 720 -a "$vYRes" -ge 960 ]; then
+      xRes=720; yRes=480;
+    fi
+    ;;
+  576*)
+    if [ "$vXRes" -ge 720 -a "$vYRes" -ge 1152 ]; then
+      xRes=720; yRes=576;
+    fi
+    ;;
+  720*)
+    if [ "$vXRes" -ge 1280 -a "$vYRes" -ge 1440 ]; then
+      xRes=1280; yRes=720;
+    fi
+    ;;
+  1080*)
+    if [ "$vXRes" -ge 1920 -a "$vYRes" -ge 2160 ]; then
+      xRes=1920; yRes=1080;
+    fi
+    ;;
+  4k2k*hz|2160p*)
+    if [ "$vXRes" -ge 3840 -a "$vYRes" -ge 4320 ]; then
+      xRes=3840; yRes=2160;
+    fi
+    ;;
+esac
+
+# Set framebuffer geometry to match the resolution
+fbset -fb /dev/fb0 -g $xRes $yRes $vXRes $vYRes $bpp;
 
 # Include deinterlacer into default VFM map
 echo rm default > /sys/class/vfm/map

--- a/projects/WeTek_Play/initramfs/platform_init
+++ b/projects/WeTek_Play/initramfs/platform_init
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
 #      Copyright (C) 2014 Alex Deryskyba (alex@codesnake.com)
@@ -18,7 +17,7 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-hdmimode=720p
+hdmimode="720p"
 
 # Parse command line arguments
 for arg in $(cat /proc/cmdline); do
@@ -40,8 +39,11 @@ done
 
 echo "$hdmimode" > /sys/class/display/mode
 
-# Enable framebuffer device
+# Enable first framebuffer
 echo 0 > /sys/class/graphics/fb0/blank
+
+# Disable second framebuffer
+echo 1 > /sys/class/graphics/fb1/blank
 
 # Disable framebuffer scaling
 echo 0 > /sys/class/graphics/fb0/free_scale
@@ -49,15 +51,67 @@ echo 0 > /sys/class/graphics/fb0/free_scale
 # set initial video state
 echo 1 > /sys/class/video/disable_video
 
-# Set framebuffer geometry to match the resolution
-case "$hdmimode" in
-  720*)
-    fbset -fb /dev/fb0 -g 1280 720 1920 2160 32
+# Set default resolution parameters
+bpp=32;
+xRes=1280;
+yRes=720;
+
+# Get max supported display resolution by hdmi device
+maxRes=$(tail -n1 /sys/class/amhdmitx/amhdmitx0/disp_cap | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//');
+if [ -z "$maxRes" ]; then
+  maxRes="$hdmimode";
+fi
+case "$maxRes" in
+  480*)
+    xRes=720; yRes=480;
+    ;;
+  576*)
+    xRes=720; yRes=576;
     ;;
   1080*)
-    fbset -fb /dev/fb0 -g 1920 1080 1920 2160 32
+    xRes=1920; yRes=1080;
+    ;;
+  4k2k*hz|2160p*)
+    xRes=3840; yRes=2160;
+    ;;
+  4k2ksmpte|smpte24hz)
+    xRes=4096; yRes=2160;
     ;;
 esac
+vXRes=$xRes;
+vYRes=$(( $yRes * 2 ));
+
+# Choose boot resolution by hdmimode param
+case "$hdmimode" in
+  480*)
+    if [ "$vXRes" -ge 720 -a "$vYRes" -ge 960 ]; then
+      xRes=720; yRes=480;
+    fi
+    ;;
+  576*)
+    if [ "$vXRes" -ge 720 -a "$vYRes" -ge 1152 ]; then
+      xRes=720; yRes=576;
+    fi
+    ;;
+  720*)
+    if [ "$vXRes" -ge 1280 -a "$vYRes" -ge 1440 ]; then
+      xRes=1280; yRes=720;
+    fi
+    ;;
+  1080*)
+    if [ "$vXRes" -ge 1920 -a "$vYRes" -ge 2160 ]; then
+      xRes=1920; yRes=1080;
+    fi
+    ;;
+  4k2k*hz|2160p*)
+    if [ "$vXRes" -ge 3840 -a "$vYRes" -ge 4320 ]; then
+      xRes=3840; yRes=2160;
+    fi
+    ;;
+esac
+
+# Set framebuffer geometry to match the resolution
+fbset -fb /dev/fb0 -g $xRes $yRes $vXRes $vYRes $bpp;
 
 # Include deinterlacer into default VFM map
 echo rm default > /sys/class/vfm/map


### PR DESCRIPTION
This commit checks the resolution capabilities of the hdmi device and sets the framebuffer resolution depending on the max resolution of the device and the selected resolution by hdmimode boot parameter.

Tested with WeTek Core and Beelink MXIII (S802) connected to a 4K Hisense tv.

**Edit**: Nothing. :D