### PR TITLE
connman: bump to 1.33

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -17,8 +17,7 @@
 ################################################################################
 
 PKG_NAME="connman"
-# DO NOT UPGRADE!!
-PKG_VERSION="1.32"
+PKG_VERSION="1.33"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Minor bump to 1.33 .. and it's time to loose the warning message; it's mature code.