### PR TITLE
lcdproc: do not use freetype from host

### DIFF
--- a/packages/sysutils/lcdproc/package.mk
+++ b/packages/sysutils/lcdproc/package.mk
@@ -47,7 +47,7 @@ for i in $LCD_DRIVER; do
 done
 unset IFS
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-libusb --enable-drivers=$LCD_DRIVER,!curses,!svga --enable-seamless-hbars"
+PKG_CONFIGURE_OPTS_TARGET="--with-ft-prefix=$SYSROOT_PREFIX/usr --enable-libusb --enable-drivers=$LCD_DRIVER,!curses,!svga --enable-seamless-hbars"
 
 pre_make_target() {
   # dont build parallel


### PR DESCRIPTION
With enabled LCD_DRIVER  `glcd`  lcdproc fails to build, because freetype from my host was used ```-I/usr/include/freetype2```

```
...
checking if freetype support has been enabled... yes
checking for armv7a-libreelec-linux-gnueabi-freetype-config... no
checking for freetype-config... /usr/bin/freetype-config
configure: WARNING: using cross tools not prefixed with host triplet
checking for FreeType -- version >= 7.0.1... cross compiling; assuming OK... yes
...
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/bin/armv7a-libreelec-linux-gnueabi-gcc -DHAVE_CONFIG_H -I. -I/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/lcdproc-0.5.7-cvs20140217/server/drivers -I../..  -I/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/lcdproc-0.5.7-cvs20140217  -I/usr/include/freetype2 -I/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/include/libpng16 -I/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/armv7a-libreelec-linux-gnueabi/sysroot/usr/include/libusb-1.0  -fPIC -Wall -march=armv7-a -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -mcpu=cortex-a9 -mfloat-abi=hard -mfpu=neon -fomit-frame-pointer -Wall -pipe -Os -fexcess-precision=fast -flto -ffat-lto-objects  -Wno-unused-function -MT glcd-glcd_drv.o -MD -MP -MF .deps/glcd-glcd_drv.Tpo -c -o glcd-glcd_drv.o `test -f 'glcd_drv.c' || echo '/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/lcdproc-0.5.7-cvs20140217/server/drivers/'`glcd_drv.c
CROSS COMPILE Badness: /usr/include in INCLUDEPATH: /usr/include/freetype2
```

Also, without the LCD_DRIVER `glcd` there is the above-mentioned warning in configure, but lcdproc builds fine. This PR fix this issue.

btw: LibreELEC and kernel xbian-4.4 runs fine on my Hummingboard-i2eX (edit: sometimes a little bit laggy)