### PR TITLE
lcdproc: LCD_DRIVER glcd should depend on freetype

### DIFF
--- a/packages/sysutils/lcdproc/package.mk
+++ b/packages/sysutils/lcdproc/package.mk
@@ -40,7 +40,7 @@ fi
 IFS=$','
 for i in $LCD_DRIVER; do
   case $i in
-    glcd) PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET serdisplib"
+    glcd) PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET freetype serdisplib"
       ;;
     *)
   esac


### PR DESCRIPTION
from: http://lcdproc.sourceforge.net/docs/lcdproc-0-5-7-user.html#glcd-howto

>  The glcd driver (graphic lcd) driver is a "meta driver" that renders text for display on graphic displays. It uses either a built-in 5x8 font (the same as used in elsewhere in LCDproc) or Freetype 2 to draw the characters and icons into an internal frame buffer. That frame buffer is then copied to the display by a small sub-driver called connection type driver (CT-driver). 