### PR TITLE
docker: update to 1.12.0

### DIFF
--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="containerd"
-PKG_VERSION="9dc2b32"
+PKG_VERSION="0ac3cd1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="APL"
@@ -66,7 +66,6 @@ pre_make_target() {
 
 make_target() {
   mkdir -p bin
-  $GOLANG build -v -o bin/ctr             -a -tags "static_build" -ldflags "$LDFLAGS" ./ctr
   $GOLANG build -v -o bin/containerd      -a -tags "static_build" -ldflags "$LDFLAGS" ./containerd
   $GOLANG build -v -o bin/containerd-shim -a -tags "static_build" -ldflags "$LDFLAGS" ./containerd-shim
 }

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="go"
-PKG_VERSION="1.6.2"
+PKG_VERSION="1.6.3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="runc"
-PKG_VERSION="baf6536"
+PKG_VERSION="cc29e3d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="APL"

--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,9 @@
+8.0.105
+- Update to docker 1.12.0
+- Update to golang 1.6.3
+- Use overlay2 driver (new installs only)
+- Remove docker-containerd-ctr
+
 8.0.104
 - Update to docker 1.11.2
 

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="docker"
-PKG_VERSION="1.11.2"
-PKG_REV="104"
+PKG_VERSION="1.12.0"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_ADDON_PROJECTS="Generic RPi RPi2"
 PKG_LICENSE="ASL"
@@ -82,7 +82,8 @@ configure_target() {
 
 make_target() {
   mkdir -p bin
-  $GOLANG build -v -o bin/docker -a -tags "$DOCKER_BUILDTAGS" -ldflags "$LDFLAGS" ./docker
+  $GOLANG build -v -o bin/docker -a -tags "$DOCKER_BUILDTAGS" -ldflags "$LDFLAGS" ./cmd/docker
+  $GOLANG build -v -o bin/dockerd -a -tags "$DOCKER_BUILDTAGS" -ldflags "$LDFLAGS" ./cmd/dockerd
 }
 
 makeinstall_target() {
@@ -92,11 +93,11 @@ makeinstall_target() {
 addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin
     cp -P $ROOT/$PKG_BUILD/bin/docker $ADDON_BUILD/$PKG_ADDON_ID/bin
+    cp -P $ROOT/$PKG_BUILD/bin/dockerd $ADDON_BUILD/$PKG_ADDON_ID/bin
 
     # containerd
     cp -P $(get_build_dir containerd)/bin/containerd $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-containerd
     cp -P $(get_build_dir containerd)/bin/containerd-shim $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-containerd-shim
-    cp -P $(get_build_dir containerd)/bin/ctr $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-containerd-ctr
 
     # runc
     cp -P $(get_build_dir runc)/bin/runc $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-runc

--- a/packages/addons/service/docker/patches/docker-001-use-addon-storage-location.patch
+++ b/packages/addons/service/docker/patches/docker-001-use-addon-storage-location.patch
@@ -1,19 +1,31 @@
 # Created with
 # find . -name "*.go" -print | xargs sed -i 's/\/etc\/docker/\/storage\/.kodi\/userdata\/addon_data\/service.system.docker\/config/g'
 
-diff -Naur a/docker/daemon_unix.go b/docker/daemon_unix.go
---- a/docker/daemon_unix.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/docker/daemon_unix.go	2016-05-02 12:19:20.461479163 -0700
-@@ -16,7 +16,7 @@
- 	"github.com/docker/docker/pkg/system"
+diff -Naur a/cmd/dockerd/daemon_solaris.go b/cmd/dockerd/daemon_solaris.go
+--- a/cmd/dockerd/daemon_solaris.go	2016-06-17 13:28:45.000000000 -0700
++++ b/cmd/dockerd/daemon_solaris.go	2016-06-23 10:53:28.544141675 -0700
+@@ -39,7 +39,7 @@
+ }
+ 
+ func getDaemonConfDir() string {
+-	return "/etc/docker"
++	return "/storage/.kodi/userdata/addon_data/service.system.docker/config"
+ }
+ 
+ // setupConfigReloadTrap configures the USR2 signal to reload the configuration.
+diff -Naur a/cmd/dockerd/daemon_unix.go b/cmd/dockerd/daemon_unix.go
+--- a/cmd/dockerd/daemon_unix.go	2016-06-17 13:28:45.000000000 -0700
++++ b/cmd/dockerd/daemon_unix.go	2016-06-23 10:53:28.542141655 -0700
+@@ -18,7 +18,7 @@
+ 	"github.com/docker/libnetwork/portallocator"
  )
  
 -const defaultDaemonConfigFile = "/etc/docker/daemon.json"
 +const defaultDaemonConfigFile = "/storage/.kodi/userdata/addon_data/service.system.docker/config/daemon.json"
  
- func setPlatformServerConfig(serverConfig *apiserver.Config, daemonCfg *daemon.Config) *apiserver.Config {
- 	serverConfig.EnableCors = daemonCfg.EnableCors
-@@ -49,7 +49,7 @@
+ // currentUserIsOwner checks whether the current user is the owner of the given
+ // file.
+@@ -44,7 +44,7 @@
  }
  
  func getDaemonConfDir() string {
@@ -23,9 +35,9 @@ diff -Naur a/docker/daemon_unix.go b/docker/daemon_unix.go
  
  // setupConfigReloadTrap configures the USR2 signal to reload the configuration.
 diff -Naur a/integration-cli/docker_cli_authz_unix_test.go b/integration-cli/docker_cli_authz_unix_test.go
---- a/integration-cli/docker_cli_authz_unix_test.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/integration-cli/docker_cli_authz_unix_test.go	2016-05-02 12:19:20.291477565 -0700
-@@ -134,10 +134,10 @@
+--- a/integration-cli/docker_cli_authz_unix_test.go	2016-06-17 13:28:45.000000000 -0700
++++ b/integration-cli/docker_cli_authz_unix_test.go	2016-06-23 10:53:28.339139631 -0700
+@@ -142,10 +142,10 @@
  		w.Write(b)
  	})
  
@@ -38,7 +50,7 @@ diff -Naur a/integration-cli/docker_cli_authz_unix_test.go b/integration-cli/doc
  	err = ioutil.WriteFile(fileName, []byte(s.server.URL), 0644)
  	c.Assert(err, checker.IsNil)
  }
-@@ -186,7 +186,7 @@
+@@ -194,7 +194,7 @@
  
  	s.server.Close()
  
@@ -48,9 +60,9 @@ diff -Naur a/integration-cli/docker_cli_authz_unix_test.go b/integration-cli/doc
  }
  
 diff -Naur a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_cli_daemon_test.go
---- a/integration-cli/docker_cli_daemon_test.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/integration-cli/docker_cli_daemon_test.go	2016-05-02 12:19:20.356478174 -0700
-@@ -512,13 +512,13 @@
+--- a/integration-cli/docker_cli_daemon_test.go	2016-06-17 13:28:45.000000000 -0700
++++ b/integration-cli/docker_cli_daemon_test.go	2016-06-23 10:53:28.411140349 -0700
+@@ -553,13 +553,13 @@
  
  func (s *DockerDaemonSuite) TestDaemonKeyGeneration(c *check.C) {
  	// TODO: skip or update for Windows daemon
@@ -66,7 +78,7 @@ diff -Naur a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_
  	if err != nil {
  		c.Fatalf("Error opening key file")
  	}
-@@ -531,7 +531,7 @@
+@@ -572,7 +572,7 @@
  
  func (s *DockerDaemonSuite) TestDaemonKeyMigration(c *check.C) {
  	// TODO: skip or update for Windows daemon
@@ -75,7 +87,7 @@ diff -Naur a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_
  	k1, err := libtrust.GenerateECP256PrivateKey()
  	if err != nil {
  		c.Fatalf("Error generating private key: %s", err)
-@@ -548,7 +548,7 @@
+@@ -589,7 +589,7 @@
  	}
  	s.d.Stop()
  
@@ -84,7 +96,7 @@ diff -Naur a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_
  	if err != nil {
  		c.Fatalf("Error opening key file")
  	}
-@@ -1296,7 +1296,7 @@
+@@ -1337,7 +1337,7 @@
  		Y   string `json:"y"`
  	}
  
@@ -93,7 +105,7 @@ diff -Naur a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_
  	if err := s.d.Start(); err != nil {
  		c.Fatalf("Failed to start daemon: %v", err)
  	}
-@@ -1306,7 +1306,7 @@
+@@ -1347,7 +1347,7 @@
  	}
  
  	config := &Config{}
@@ -102,7 +114,7 @@ diff -Naur a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_
  	if err != nil {
  		c.Fatalf("Error reading key.json file: %s", err)
  	}
-@@ -1326,11 +1326,11 @@
+@@ -1367,11 +1367,11 @@
  	}
  
  	// write back
@@ -117,9 +129,9 @@ diff -Naur a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_
  	if err := s.d.Start(); err == nil {
  		c.Fatalf("It should not be successful to start daemon with wrong key: %v", err)
 diff -Naur a/integration-cli/docker_cli_external_graphdriver_unix_test.go b/integration-cli/docker_cli_external_graphdriver_unix_test.go
---- a/integration-cli/docker_cli_external_graphdriver_unix_test.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go	2016-05-02 12:19:20.382478419 -0700
-@@ -306,10 +306,10 @@
+--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go	2016-06-17 13:28:45.000000000 -0700
++++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go	2016-06-23 10:53:28.444140678 -0700
+@@ -321,10 +321,10 @@
  		respond(w, &graphDriverResponse{Size: size})
  	})
  
@@ -133,7 +145,7 @@ diff -Naur a/integration-cli/docker_cli_external_graphdriver_unix_test.go b/inte
  	err = ioutil.WriteFile(specFile, b, 0644)
  	c.Assert(err, check.IsNil, check.Commentf("error writing to %s", specFile))
  }
-@@ -318,8 +318,8 @@
+@@ -333,8 +333,8 @@
  	s.server.Close()
  	s.jserver.Close()
  
@@ -144,41 +156,11 @@ diff -Naur a/integration-cli/docker_cli_external_graphdriver_unix_test.go b/inte
  }
  
  func (s *DockerExternalGraphdriverSuite) TestExternalGraphDriver(c *check.C) {
-diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/docker_cli_network_unix_test.go
---- a/integration-cli/docker_cli_network_unix_test.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/integration-cli/docker_cli_network_unix_test.go	2016-05-02 12:19:20.380478400 -0700
-@@ -200,14 +200,14 @@
- 		}
- 	})
- 
--	err := os.MkdirAll("/etc/docker/plugins", 0755)
-+	err := os.MkdirAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", 0755)
- 	c.Assert(err, checker.IsNil)
- 
--	fileName := fmt.Sprintf("/etc/docker/plugins/%s.spec", netDrv)
-+	fileName := fmt.Sprintf("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/%s.spec", netDrv)
- 	err = ioutil.WriteFile(fileName, []byte(url), 0644)
- 	c.Assert(err, checker.IsNil)
- 
--	ipamFileName := fmt.Sprintf("/etc/docker/plugins/%s.spec", ipamDrv)
-+	ipamFileName := fmt.Sprintf("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/%s.spec", ipamDrv)
- 	err = ioutil.WriteFile(ipamFileName, []byte(url), 0644)
- 	c.Assert(err, checker.IsNil)
- }
-@@ -219,7 +219,7 @@
- 
- 	s.server.Close()
- 
--	err := os.RemoveAll("/etc/docker/plugins")
-+	err := os.RemoveAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins")
- 	c.Assert(err, checker.IsNil)
- }
- 
-diff -Naur a/integration-cli/docker_cli_start_volume_driver_unix_test.go b/integration-cli/docker_cli_start_volume_driver_unix_test.go
---- a/integration-cli/docker_cli_start_volume_driver_unix_test.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/integration-cli/docker_cli_start_volume_driver_unix_test.go	2016-05-02 12:19:20.387478466 -0700
-@@ -216,17 +216,17 @@
- 		send(w, nil)
+diff -Naur a/integration-cli/docker_cli_external_volume_driver_unix_test.go b/integration-cli/docker_cli_external_volume_driver_unix_test.go
+--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go	2016-06-17 13:28:45.000000000 -0700
++++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go	2016-06-23 10:53:28.435140588 -0700
+@@ -239,17 +239,17 @@
+ 		send(w, `{"Capabilities": { "Scope": "global" }}`)
  	})
  
 -	err := os.MkdirAll("/etc/docker/plugins", 0755)
@@ -198,7 +180,7 @@ diff -Naur a/integration-cli/docker_cli_start_volume_driver_unix_test.go b/integ
  	c.Assert(err, checker.IsNil)
  }
  
-@@ -311,7 +311,7 @@
+@@ -334,7 +334,7 @@
  
  // Make sure a request to use a down driver doesn't block other requests
  func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverLookupNotBlocked(c *check.C) {
@@ -207,7 +189,7 @@ diff -Naur a/integration-cli/docker_cli_start_volume_driver_unix_test.go b/integ
  	err := ioutil.WriteFile(specPath, []byte("tcp://127.0.0.7:9999"), 0644)
  	c.Assert(err, check.IsNil)
  	defer os.RemoveAll(specPath)
-@@ -350,7 +350,7 @@
+@@ -373,7 +373,7 @@
  	err := s.d.StartWithBusybox()
  	c.Assert(err, checker.IsNil)
  
@@ -216,9 +198,39 @@ diff -Naur a/integration-cli/docker_cli_start_volume_driver_unix_test.go b/integ
  	os.RemoveAll(specPath)
  	defer os.RemoveAll(specPath)
  
+diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/docker_cli_network_unix_test.go
+--- a/integration-cli/docker_cli_network_unix_test.go	2016-06-17 13:28:45.000000000 -0700
++++ b/integration-cli/docker_cli_network_unix_test.go	2016-06-23 10:53:28.441140648 -0700
+@@ -201,14 +201,14 @@
+ 		}
+ 	})
+ 
+-	err := os.MkdirAll("/etc/docker/plugins", 0755)
++	err := os.MkdirAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", 0755)
+ 	c.Assert(err, checker.IsNil)
+ 
+-	fileName := fmt.Sprintf("/etc/docker/plugins/%s.spec", netDrv)
++	fileName := fmt.Sprintf("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/%s.spec", netDrv)
+ 	err = ioutil.WriteFile(fileName, []byte(url), 0644)
+ 	c.Assert(err, checker.IsNil)
+ 
+-	ipamFileName := fmt.Sprintf("/etc/docker/plugins/%s.spec", ipamDrv)
++	ipamFileName := fmt.Sprintf("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/%s.spec", ipamDrv)
+ 	err = ioutil.WriteFile(ipamFileName, []byte(url), 0644)
+ 	c.Assert(err, checker.IsNil)
+ }
+@@ -220,7 +220,7 @@
+ 
+ 	s.server.Close()
+ 
+-	err := os.RemoveAll("/etc/docker/plugins")
++	err := os.RemoveAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins")
+ 	c.Assert(err, checker.IsNil)
+ }
+ 
 diff -Naur a/pkg/plugins/discovery.go b/pkg/plugins/discovery.go
---- a/pkg/plugins/discovery.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/pkg/plugins/discovery.go	2016-05-02 12:19:20.540479907 -0700
+--- a/pkg/plugins/discovery.go	2016-06-17 13:28:45.000000000 -0700
++++ b/pkg/plugins/discovery.go	2016-06-23 10:53:28.636142593 -0700
 @@ -16,7 +16,7 @@
  	// ErrNotFound plugin not found
  	ErrNotFound = errors.New("plugin not found")
@@ -229,8 +241,8 @@ diff -Naur a/pkg/plugins/discovery.go b/pkg/plugins/discovery.go
  
  // localRegistry defines a registry that is local (using unix socket).
 diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
---- a/pkg/plugins/plugins.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/pkg/plugins/plugins.go	2016-05-02 12:19:20.539479898 -0700
+--- a/pkg/plugins/plugins.go	2016-06-17 13:28:45.000000000 -0700
++++ b/pkg/plugins/plugins.go	2016-06-23 10:53:28.636142593 -0700
 @@ -4,7 +4,7 @@
  // Docker discovers plugins by looking for them in the plugin directory whenever
  // a user or container tries to use one by name. UNIX domain socket files must
@@ -241,8 +253,8 @@ diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
  // its name if it exists.
  //
 diff -Naur a/registry/config_unix.go b/registry/config_unix.go
---- a/registry/config_unix.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/registry/config_unix.go	2016-05-02 12:19:20.502479549 -0700
+--- a/registry/config_unix.go	2016-06-17 13:28:45.000000000 -0700
++++ b/registry/config_unix.go	2016-06-23 10:53:28.594142174 -0700
 @@ -4,7 +4,7 @@
  
  var (
@@ -253,8 +265,8 @@ diff -Naur a/registry/config_unix.go b/registry/config_unix.go
  
  // cleanPath is used to ensure that a directory name is valid on the target
 diff -Naur a/registry/endpoint_v1.go b/registry/endpoint_v1.go
---- a/registry/endpoint_v1.go	2016-04-25 20:35:31.000000000 -0700
-+++ b/registry/endpoint_v1.go	2016-05-02 12:19:20.501479540 -0700
+--- a/registry/endpoint_v1.go	2016-06-17 13:28:45.000000000 -0700
++++ b/registry/endpoint_v1.go	2016-06-23 10:53:28.593142164 -0700
 @@ -49,7 +49,7 @@
  		if endpoint.IsSecure {
  			// If registry is secure and HTTPS failed, show user the error and tell them about `--insecure-registry`

--- a/packages/addons/service/docker/source/config/docker.conf
+++ b/packages/addons/service/docker/source/config/docker.conf
@@ -1,2 +1,2 @@
 DOCKER_DAEMON_OPTS="--graph=/storage/.kodi/userdata/addon_data/service.system.docker/docker"
-DOCKER_STORAGE_OPTS="--storage-driver=overlay"
+DOCKER_STORAGE_OPTS="--storage-driver=overlay2"

--- a/packages/addons/service/docker/source/systemd/service.system.docker.service
+++ b/packages/addons/service/docker/source/systemd/service.system.docker.service
@@ -9,7 +9,7 @@ Type=notify
 Environment=PATH=/bin:/sbin:/usr/bin:/usr/sbin:/storage/.kodi/addons/service.system.docker/bin
 ExecStartPre=/storage/.kodi/addons/service.system.docker/bin/docker-config
 EnvironmentFile=-/storage/.kodi/userdata/addon_data/service.system.docker/config/docker.conf
-ExecStart=/storage/.kodi/addons/service.system.docker/bin/docker daemon -H fd:// $DOCKER_DAEMON_OPTS $DOCKER_STORAGE_OPTS
+ExecStart=/storage/.kodi/addons/service.system.docker/bin/dockerd --host=fd:// --group=root $DOCKER_DAEMON_OPTS $DOCKER_STORAGE_OPTS
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
This is a pretty big change, I've tested it quite thoroughly on my RPi and RPi2

I changed to the storage driver overlay2 as this uses the updated overlayfs in kernel 4.0+.

People can manually change to the overlay2 driver by editing or removing the file
`/storage/.kodi/userdata/addon_data/service.system.docker/config/docker.conf`
then restarting docker (or rebooting)

I'll update this to 1.12 final when it is released (which should be soon)