### PR TITLE
Parameters removed, which are responsible for a factory reset/wiping …

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -416,8 +416,6 @@ fi
           echo "Creating Amlogic ZIP auto-install package"
           pushd sign > /dev/null
           echo --update_package=/sdcard/$IMAGE_NAME-update.zip > factory_update_param.aml
-          echo --wipe_data >> factory_update_param.aml
-          echo --wipe_cache >> factory_update_param.aml
           cp $INSTALL_SRC_DIR/files/recovery.img .
           if [ -f $INSTALL_SRC_DIR/files/aml_autoscript ]; then
             cp $INSTALL_SRC_DIR/files/aml_autoscript .


### PR DESCRIPTION
…user data by installations on devices which are using the Amlogic autoinstallation method. With these two parameters the "normal" autoinstallation doesn't work on WeTek devices after switching from Android to LE.