### PR TITLE
WeTek_Core:Revised install/update procedure

### DIFF
--- a/projects/WeTek_Core/install/updater-script
+++ b/projects/WeTek_Core/install/updater-script
@@ -1,26 +1,32 @@
-show_progress(0.500000, 3);
+show_progress(0, 0);
 set_bootloader_env("upgrade_step", "3");
 
-ui_print("Writing kernel image");
-assert(package_extract_file("KERNEL", "/tmp/boot.img"),
-    write_raw_image("/tmp/boot.img", "boot"),
-    delete("/tmp/boot.img"));
-
-show_progress(0.020000, 0);
-
-ui_print("Wiping System");
-format("ext4", "EMMC", "/dev/block/system", "0", "/system");
+show_progress(0.200000, 12);
+# Format data partition if previous installation is Android
 mount("ext4", "EMMC", "/dev/block/system", "/system");
-ui_print("Writing system files");
+if
+  sha1_check(read_file("/system/build.prop"))
+then
+  ui_print("Wiping data");
+  format("ext4", "EMMC", "/dev/block/data", "0", "/data");
+endif;
+unmount("/system");
+
+ui_print("Wiping system");
+format("ext4", "EMMC", "/dev/block/system", "0", "/system");
+
+show_progress(0.700000, 160);
+ui_print("Writing kernel");
+write_raw_image(package_extract_file("KERNEL"), "boot");
+
+ui_print("Writing system");
+mount("ext4", "EMMC", "/dev/block/system", "/system");
 package_extract_dir("system", "/system");
 unmount("/system");
 
-show_progress(0.300000, 60);
-
+show_progress(0.100000, 6);
 ui_print("Writing recovery");
 write_raw_image(package_extract_file("recovery.img"), "recovery");
-
-show_progress(0.018000, 0);
 
 ui_print("Writing bootloader");
 write_raw_image(package_extract_file("bootloader.img"), "bootloader");
@@ -29,5 +35,5 @@ ui_print("Writing logo");
 write_raw_image(package_extract_file("logo.img"), "logo");
 
 set_bootloader_env("upgrade_step", "1");
-show_progress(0.100000, 0);
+set_progress(1);
 ui_print("LibreELEC Installed Successfully");


### PR DESCRIPTION
This PR revises the updater-script for WeTek Core. The script checks now if the previous installation is android. If this is the case, the (user) data partition will be wiped. Otherwise the (user) data will be untouched by the update. I also restructured it a tiny bit.

Something similar would also make sense in the updater-script for WeTek Play imho. I don't have one, that's why I can't test it.

Can someone recheck the script? @codesnake @stefansaraev @kszaq 

PS: Heavily tested it on my WC.