### PR TITLE
spotify-connect-web: initial addon

### DIFF
--- a/packages/addons/service/spotify-connect-web/changelog.txt
+++ b/packages/addons/service/spotify-connect-web/changelog.txt
@@ -1,0 +1,2 @@
+8.0.100
+- Initial addon

--- a/packages/addons/service/spotify-connect-web/package.mk
+++ b/packages/addons/service/spotify-connect-web/package.mk
@@ -1,0 +1,53 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="spotify-connect-web"
+PKG_VERSION="0.0.3-alpha"
+PKG_REV="100"
+PKG_ARCH="arm"
+PKG_ADDON_PROJECTS="RPi2"
+PKG_LICENSE="prop."
+PKG_SITE="https://github.com/Fornoth/spotify-connect-web"
+PKG_URL="https://github.com/Fornoth/spotify-connect-web/releases/download/$PKG_VERSION/${PKG_NAME}_$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="spotify-connect-web"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="service"
+PKG_SHORTDESC="Spotify Connect Web: play Spotify through LibreELEC"
+PKG_LONGDESC="Spotify Connect Web ($PKG_VERSION) plays Spotify through LibreELEC, using a Spotify app as a remote."
+PKG_AUTORECONF="no"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_NAME="Spotify Connect Web"
+PKG_ADDON_TYPE="xbmc.service"
+PKG_ADDON_REPOVERSION="8.0"
+PKG_MAINTAINER="Anton Voyl (awiouy)"
+
+make_target() {
+  : # nop
+}
+
+makeinstall_target() {
+  : # nop
+}
+
+addon() {
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID
+  cp -PR $PKG_BUILD/* $ADDON_BUILD/$PKG_ADDON_ID/
+  rm $ADDON_BUILD/$PKG_ADDON_ID/libasound.so.2
+}

--- a/packages/addons/service/spotify-connect-web/source/bin/spotify-connect-web.start
+++ b/packages/addons/service/spotify-connect-web/source/bin/spotify-connect-web.start
@@ -1,0 +1,58 @@
+#!/bin/sh
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+. /etc/profile
+oe_setup_addon service.spotify-connect-web
+
+mkdir -p "$ADDON_HOME"
+
+if [ ! -f "$ADDON_HOME/spotify_appkey.key" ]
+then
+  echo "Exiting: no key"
+  exit
+fi
+
+if [ ! "$scw_p" ]
+then
+  echo "Exiting: no password"
+  exit
+fi
+
+if [ !  "$scw_u" ]
+then
+  echo "Exiting: no username"
+  exit
+fi
+
+amixer &> /dev/null || dtoverlay dtparam audio=on
+amixer cset numid=3 "$pcm_3"
+
+[ "$scw_b" ] && scw_B="-b $scw_b"
+[ "$scw_m" ] && scw_M="-m $scw_m"
+[ "$scw_o" ] && scw_O="-o $scw_o"
+
+cd $ADDON_DIR
+chmod +x spotify-connect-web
+./spotify-connect-web $scw_B \
+                      -k "$ADDON_HOME/spotify_appkey.key" \
+                      $scw_M \
+                      -n "$HOSTNAME" \
+                      $scw_O \
+                      -p "$scw_p" \
+                      -u "$scw_u"

--- a/packages/addons/service/spotify-connect-web/source/default.py
+++ b/packages/addons/service/spotify-connect-web/source/default.py
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+import subprocess
+import xbmc
+import xbmcaddon
+
+
+class Monitor(xbmc.Monitor):
+
+   def __init__(self, *args, **kwargs):
+      xbmc.Monitor.__init__(self)
+      self.id = xbmcaddon.Addon().getAddonInfo('id')
+
+   def onSettingsChanged(self):
+      subprocess.call(['systemctl', 'restart', self.id])
+
+
+if __name__ == "__main__":
+   Monitor().waitForAbort()

--- a/packages/addons/service/spotify-connect-web/source/resources/language/English/strings.po
+++ b/packages/addons/service/spotify-connect-web/source/resources/language/English/strings.po
@@ -1,0 +1,68 @@
+# Kodi Media Center language file
+# Addon Name: spotify-connect-web
+msgid ""
+msgstr ""
+
+msgctxt "#30000"
+msgid "Configuration"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Spotify"
+msgstr ""
+
+msgctxt "#30002"
+msgid "username"
+msgstr ""
+
+msgctxt "#30003"
+msgid "password"
+msgstr ""
+
+msgctxt "#30004"
+msgid "bit rate"
+msgstr ""
+
+msgctxt "#30005"
+msgid ""
+msgstr ""
+
+msgctxt "#30006"
+msgid "90"
+msgstr ""
+
+msgctxt "#30007"
+msgid "160"
+msgstr ""
+
+msgctxt "#30008"
+msgid "320"
+msgstr ""
+
+msgctxt "#30009"
+msgid "ALSA"
+msgstr ""
+
+msgctxt "#30010"
+msgid "playback device"
+msgstr ""
+
+msgctxt "#30011"
+msgid "playback route"
+msgstr ""
+
+msgctxt "#30012"
+msgid "auto detect"
+msgstr ""
+
+msgctxt "#30013"
+msgid "headphone jack"
+msgstr ""
+
+msgctxt "#30014"
+msgid "HDMI"
+msgstr ""
+
+msgctxt "#30015"
+msgid "mixer"
+msgstr ""

--- a/packages/addons/service/spotify-connect-web/source/resources/settings.xml
+++ b/packages/addons/service/spotify-connect-web/source/resources/settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+   <category   label="30000">
+      <setting label="30001" type="lsep"/>
+      <setting label="30002" id="scw_u" type="text" />
+      <setting label="30003" id="scw_p" type="text" option="hidden" />
+      <setting label="30004" id="scw_b" type="labelenum" lvalues="30005|30006|30007|30008" />
+      <setting label="30009" type="lsep"/>
+      <setting label="30010" id="scw_o" type="text" default="hw:0,1"/>
+      <setting label="30011" id="pcm_3" type="enum" lvalues="30012|30013|30014" />
+      <setting label="30015" id="scw_m" type="text" />
+    </category>
+</settings>

--- a/packages/addons/service/spotify-connect-web/source/settings-default.xml
+++ b/packages/addons/service/spotify-connect-web/source/settings-default.xml
@@ -1,0 +1,8 @@
+<settings>
+    <setting id="pcm_3" value="0" />
+    <setting id="scw_b" value="" />
+    <setting id="scw_m" value="" />
+    <setting id="scw_o" value="hw:0,1" />
+    <setting id="scw_p" value="" />
+    <setting id="scw_u" value="" />
+</settings>

--- a/packages/addons/service/spotify-connect-web/source/system.d/service.spotify-connect-web.service
+++ b/packages/addons/service/spotify-connect-web/source/system.d/service.spotify-connect-web.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=spotify-connect-web
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+ExecStart=/bin/sh /storage/.kodi/addons/service.spotify-connect-web/bin/spotify-connect-web.start
+Restart=on-failure
+
+[Install]
+WantedBy=kodi.target


### PR DESCRIPTION
This turns a RPi2/3 into a Spotify Connect device.

To try it out:
1. Install the addon
2. Get your spotify_appkey.key from [here](https://devaccount.spotify.com/my-account/keys/)
3. Place the spotify_appkey.key in the addon home folder
4. Configure Spotify username and password via the addon settings
5. Redirect Spotify streams from your device to LibreELEC
6. Enjoy!

Other implementations (native, docker) proved rather impractical,