### PR TITLE
scripts/mkimage: add 'run' mode to boot options

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -125,7 +125,7 @@ if [ "$BOOTLOADER" = "syslinux" ]; then
   # create bootloader configuration
     echo "image: creating bootloader configuration..."
     cat << EOF > "$OE_TMP"/syslinux.cfg
-SAY Press <TAB> to edit options
+SAY Press <TAB> to edit options (installer, live, run)
 DEFAULT installer
 TIMEOUT 50
 PROMPT 1
@@ -137,6 +137,10 @@ LABEL installer
 LABEL live
   KERNEL /$KERNEL_NAME
   APPEND boot=UUID=$UUID_SYSTEM live quiet tty vga=current
+
+LABEL run
+  KERNEL /$KERNEL_NAME
+  APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet
 EOF
 
     mcopy "$OE_TMP/syslinux.cfg" ::
@@ -255,14 +259,12 @@ fi # bootloader
   sync
 
 # add resize mark
-  if [ "$BOOTLOADER" != "syslinux" ]; then
-    mkdir "$OE_TMP/part2.fs"
-    touch "$OE_TMP/part2.fs/.please_resize_me"
-    echo "image: populating filesystem on part2..."
-    populatefs -U -d "$OE_TMP/part2.fs" "$OE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
-    sync
-    e2fsck -n "$OE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
-  fi
+  mkdir "$OE_TMP/part2.fs"
+  touch "$OE_TMP/part2.fs/.please_resize_me"
+  echo "image: populating filesystem on part2..."
+  populatefs -U -d "$OE_TMP/part2.fs" "$OE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+  sync
+  e2fsck -n "$OE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
 
 # merge part2 back to disk image
   echo "image: merging part2 back to image..."


### PR DESCRIPTION
This allows to boot created USB stick directly without creating another stick. Also storage partition is resized on first boot. Config file /flash/syslinux.cfg must be edited manually to boot always in this mode.

Not sure if this also works for uefi or interfere in any way. If it does interfere then this PR can be just closed without merging.
Discussion is open...