### PR TITLE
u-boot: Fix update.sh script for imx6

### DIFF
--- a/packages/tools/u-boot/scripts/update.sh
+++ b/packages/tools/u-boot/scripts/update.sh
@@ -33,7 +33,7 @@ if [ -z "$BOOT_DISK" ]; then
 fi
 
 SYSTEM_TYPE=""
-if [ -f $SYSTEM_ROOT/usr/lib/librenelec/imx6-system-type ]; then
+if [ -f $SYSTEM_ROOT/usr/lib/libreelec/imx6-system-type ]; then
   . $SYSTEM_ROOT/usr/lib/libreelec/imx6-system-type
 fi
 


### PR DESCRIPTION
Check if imx6-system-type exist has wrong path. It seems that error happened at renaming openelec to libreelec.