### PR TITLE
install : allow to have per project package profile.d file

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -77,6 +77,11 @@ if [ "$TARGET" = target ] ; then
     cp $PKG_DIR/profile.d/*.conf $INSTALL/etc/profile.d/
   fi
 
+  if [ -d $PKG_DIR/profile.d/$PROJECT ]; then
+    mkdir -p $INSTALL/etc/profile.d
+    cp $PKG_DIR/profile.d/$PROJECT/*.conf $INSTALL/etc/profile.d/
+  fi
+
   if [ -d $PKG_DIR/tmpfiles.d ]; then
     mkdir -p $INSTALL/usr/lib/tmpfiles.d
     cp $PKG_DIR/tmpfiles.d/*.conf $INSTALL/usr/lib/tmpfiles.d


### PR DESCRIPTION
This allows to define some specific envvars for instance depending on the projects. We need to have some set differently depending on the device we will be running on. ie for QT, some devices behave differently depending on features that can be anabled / disabled thru environment variables.