### PR TITLE
kodi: Fix green screen on Generic

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.99-PR10211-videoplayer-fix-handling-of-progressive-content-in-rendermanager.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99-PR10211-videoplayer-fix-handling-of-progressive-content-in-rendermanager.patch
@@ -1,0 +1,24 @@
+From 793d8434039e88f2fe098c51ff2a98561c54debc Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Mon, 1 Aug 2016 19:58:17 +0200
+Subject: [PATCH] VideoPlayer: fix handling of progressive content in
+ RenderManager
+
+---
+ xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+index b482fc1..558a1f3 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+@@ -806,6 +806,9 @@ void CRenderManager::FlipPage(volatile std::atomic_bool& bStop, double pts /* =
+   }
+   else
+   {
++    if (sync == FS_NONE)
++      presentmethod = PRESENT_METHOD_SINGLE;
++    else
+     {
+       bool invert = false;
+       if (interlacemethod == VS_INTERLACEMETHOD_RENDER_BLEND)


### PR DESCRIPTION
17.0alpha3 video playback is rendered as a green screen on Generic and therefore unwatchable without this Beta1 fixer-upper.