### PR TITLE
RBP: Add GL symlinks to toolchain

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -44,7 +44,9 @@ make_target() {
 
   mkdir -p $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libbrcmEGL.so $SYSROOT_PREFIX/usr/lib
+    ln -s $SYSROOT_PREFIX/usr/lib/libbrcmEGL.so $SYSROOT_PREFIX/usr/lib/libEGL.so
     cp -PRv $FLOAT/opt/vc/lib/libbrcmGLESv2.so $SYSROOT_PREFIX/usr/lib
+    ln -s $SYSROOT_PREFIX/usr/lib/libbrcmGLESv2.so $SYSROOT_PREFIX/usr/lib/libGLESv2.so
     cp -PRv $FLOAT/opt/vc/lib/libbcm_host.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libcontainers.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libopenmaxil.so $SYSROOT_PREFIX/usr/lib


### PR DESCRIPTION
Pushing this as an alternative to #605.

On RPi the `libEGL`/`libGLESv2` libraries are now called  `libbrcmEGL`/`libbrcmGLESv2`. This breaks addons that expect to link against `libEGL`/`libGLESv2`.

The background for the renaming is in this change: https://github.com/raspberrypi/firmware/issues/625#issuecomment-230356111.

This PR will create sym links in the toolchain that will allow RPi builds to appear "normal" as far as `libEGL`/`libGLESv2` are concerned, allowing untouched addons to build against these libraries (that are just symbolic links to the real things - `libbrcm*`).

We already include sym links in the image for `libEGL`/`libGLESv2`, to `libbrcm*`, these are intended for backward compatibility but while we ourselves continue to link against `libEGL`/`libGLESv2` they will always be required.

With #605 we would at least be linking against the correct `libbrcmEGL`/`libbrcmGLESv2` libraries - this is really the biggest difference between the two solutions, however while we continue to include the sym links for `libEGL`/`libGLESv2` in the image, it's probably only a very minor benefit.

Push this PR or #605, they're both valid changes.
