### PR TITLE
RBP: Use force when creating symbolic links in toolchain

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -44,9 +44,9 @@ make_target() {
 
   mkdir -p $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libbrcmEGL.so $SYSROOT_PREFIX/usr/lib
-    ln -s $SYSROOT_PREFIX/usr/lib/libbrcmEGL.so $SYSROOT_PREFIX/usr/lib/libEGL.so
+    ln -sf $SYSROOT_PREFIX/usr/lib/libbrcmEGL.so $SYSROOT_PREFIX/usr/lib/libEGL.so
     cp -PRv $FLOAT/opt/vc/lib/libbrcmGLESv2.so $SYSROOT_PREFIX/usr/lib
-    ln -s $SYSROOT_PREFIX/usr/lib/libbrcmGLESv2.so $SYSROOT_PREFIX/usr/lib/libGLESv2.so
+    ln -sf $SYSROOT_PREFIX/usr/lib/libbrcmGLESv2.so $SYSROOT_PREFIX/usr/lib/libGLESv2.so
     cp -PRv $FLOAT/opt/vc/lib/libbcm_host.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libcontainers.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libopenmaxil.so $SYSROOT_PREFIX/usr/lib


### PR DESCRIPTION
Apologies for this. This is an update for #606. We need to use `-f` when creating symbolic links in the toolchain as the symbolic link may already exist from a previous build (and without `-f` the attempt to create the symbolic link will fail).