### PR TITLE
init: Report out of space when unable to extract archive/compressed i…

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -612,6 +612,24 @@
     fi
   }
 
+  check_out_of_space() {
+    if [ "$(df /storage | awk '/[0-9]%/{print $4}')" -eq "0" ]; then
+      echo ""
+      echo "The $1 is corrupt, or there is not enough"
+      echo "free space on /storage to complete the upgrade!"
+      echo ""
+      echo "Please free up space on your /storage partition"
+      echo "by deleting unecessary files, then try again."
+      echo ""
+      return 0
+    else
+      echo ""
+      echo "The $1 is corrupt/invalid!"
+      echo ""
+      return 1
+    fi
+  }
+
   do_cleanup() {
     StartProgress spinner "Cleaning up... "
 
@@ -663,13 +681,29 @@
     echo ""
 
     if [ -f "$UPDATE_TAR" ] ; then
+      TARRESULT="0"
+
       echo "Found new .tar archive"
       StartProgress spinner "Extracting contents of archive... "
         mkdir -p $UPDATE_DIR/.tmp &>/dev/null
-        tar -xf "$UPDATE_TAR" -C $UPDATE_DIR/.tmp &>/dev/null
+        tar -xf "$UPDATE_TAR" -C $UPDATE_DIR/.tmp 1>/dev/null 2>/tmp/tarresult.txt || TARRESULT="1"
+
+      if [ "${TARRESULT}" -eq "0" ]; then
         mv $UPDATE_DIR/.tmp/*/target/* $UPDATE_DIR &>/dev/null
         sync
         StopProgress "done"
+      else
+        StopProgress "FAILED"
+
+        echo "Failed to extract contents of archive file!"
+        echo "tar result: '$(cat /tmp/tarresult.txt)'"
+
+        check_out_of_space "archive"
+
+        do_cleanup
+        StartProgress countdown "Normal startup in 30s... " 30 "NOW"
+        return 0
+      fi
     elif [ -f "$UPDATE_IMG_GZ" -o -f "$UPDATE_IMG" ] ; then
       mkdir -p $UPDATE_DIR/.tmp/mnt &>/dev/null
       IMG_FILE="$UPDATE_DIR/.tmp/update.img"
@@ -686,6 +720,9 @@
         if [ "${GZRESULT}" -eq "1" ]; then
           echo "Failed to decompress image file!"
           echo "gunzip result: '$(cat /tmp/gzresult.txt)'"
+
+          check_out_of_space "compressed image"
+
           do_cleanup
           StartProgress countdown "Normal startup in 30s... " 30 "NOW"
           return 0
@@ -760,7 +797,7 @@
             else
               StopProgress "FAILED"
               MD5_FAILED="1"
-	    fi
+            fi
 
           StartProgress spinner "Checking ${UPDATE_SYSTEM}.md5... "
             if md5sum -sc "$UPDATE_ROOT/${UPDATE_SYSTEM}.check.md5"; then


### PR DESCRIPTION
…mage

When extracting from the tar archive or unzipping the .img.gz, any failure is likely for two reasons:

1) Corrupt tar or corrupt img.gz
2) Insufficient space on /storage

Particularly in the case of the tar file, we don't inform the user of either of these outcomes and simply declare that we can't find the KERNEL or SYSTEM. Consequently the user tries again, and again, and again etc.

With this change we will display the error message from the tar command (as we do already with gunzip), and inform the user that the tar/img.gz file is corrupt, or - when there is no space on /storage - that there may be[1] insufficient space and that they should delete some files.

Example out-of-space failure using tar on RPi2:

![Imgur](http://i.imgur.com/kol45HX.jpg)

1. Even when `df` reports 0 blocks available it doesn't always mean the device is out of space. The default setting for the ext2/3/4 filesystem is to keep 5% in reserve, so even though `df` may show 0 blocks available and 100% in use, there could still be up to 5% space available. The only way to know for sure that the device is truly out of space, is to display the error message from `tar` or `gunzip`, which we now do with this PR.