### PR TITLE
emby: update and enable optional platform specific hardware transcoding

### DIFF
--- a/packages/addons/addon-depends/emby-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/emby-depends/ffmpegx/package.mk
@@ -1,0 +1,105 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="ffmpegx"
+PKG_VERSION="libreelec"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="LGPLv2.1+"
+PKG_SITE="https://ffmpeg.org"
+PKG_DEPENDS_TARGET="toolchain ffmpeg lame x264"
+PKG_PRIORITY="optional"
+PKG_SECTION="multimedia"
+PKG_SHORTDESC="FFmpeg+"
+PKG_LONGDESC="FFmpeg built static with additional features"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+pre_configure_target() {
+  cd "$ROOT/$PKG_BUILD"
+  rm -rf ".$TARGET_NAME"
+  cp -PR $(get_build_dir ffmpeg)/* .
+  make clean
+
+# ffmpeg builds better with these options
+  strip_gold
+  strip_lto
+
+  if [ "$KODIPLAYER_DRIVER" == "bcm2835-driver" ]; then
+    CFLAGS="-DRPI=1 -I$SYSROOT_PREFIX/usr/include/IL -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux $CFLAGS"
+    FFMPEG_LIBS="-lbcm_host -ldl -lmmal -lmmal_core -lmmal_util -lvchiq_arm -lvcos -lvcsm"
+    FFMPEG_RPI_HADE="--enable-mmal --enable-omx-rpi"
+  fi
+
+  if [ "$TARGET_ARCH" == "arm" ]; then
+    FFMPEG_ARM_AO="--enable-hardcoded-tables"
+  fi
+}
+
+configure_target() {
+  ./configure \
+    \
+    `#Licensing options` \
+    --enable-gpl \
+    \
+    `#Documentation options` \
+    --disable-doc \
+    \
+    `#Hardware accelerated decoding encoding` \
+    $FFMPEG_RPI_HADE \
+    \
+    `#External library support` \
+    --enable-libmp3lame \
+    --enable-libx264 \
+    --enable-openssl \
+    \
+    `#Toolchain options` \
+    --arch="$TARGET_ARCH" \
+    --cpu="$TARGET_CPU" \
+    --cross-prefix="$TARGET_PREFIX" \
+    --enable-cross-compile \
+    --sysroot="$SYSROOT_PREFIX" \
+    --sysinclude="$SYSROOT_PREFIX/usr/include" \
+    --target-os="linux" \
+    --nm="$NM" \
+    --ar="$AR" \
+    --as="$CC" \
+    --cc="$CC" \
+    --ld="$CC" \
+    --pkg-config="$ROOT/$TOOLCHAIN/bin/pkg-config" \
+    --host-cc="$HOST_CC" \
+    --host-cflags="$HOST_CFLAGS" \
+    --host-ldflags="$HOST_LDFLAGS" \
+    --host-libs="-lm" \
+    --extra-cflags="$CFLAGS" \
+    --extra-ldflags="$LDFLAGS" \
+    --extra-libs="$FFMPEG_LIBS" \
+    --extra-version="x" \
+    --enable-pic \
+    \
+    `#Advanced options` \
+    $FFMPEG_ARM_AO \
+
+}
+
+post_makeinstall_target() {
+  for ff in $INSTALL/usr/local/bin/*; do mv $ff ${ff}x; done
+  rm -fr $INSTALL/usr/local/include
+  rm -fr $INSTALL/usr/local/share/ffmpeg/examples
+}

--- a/packages/addons/addon-depends/emby-depends/imagemagick/package.mk
+++ b/packages/addons/addon-depends/emby-depends/imagemagick/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="imagemagick"
-PKG_VERSION="6.9.4-9"
+PKG_VERSION="6.9.5-4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="http://www.imagemagick.org/script/license.php"

--- a/packages/addons/addon-depends/emby-depends/x264/package.mk
+++ b/packages/addons/addon-depends/emby-depends/x264/package.mk
@@ -1,0 +1,53 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="x264"
+PKG_VERSION="snapshot-20160623-2245"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.videolan.org/developers/x264.html"
+PKG_URL="ftp://ftp.videolan.org/pub/videolan/x264/snapshots/$PKG_NAME-$PKG_VERSION.tar.bz2"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="multimedia"
+PKG_SHORTDESC="x264"
+PKG_LONGDESC="x264"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+pre_configure_target() {
+  cd $ROOT/$PKG_BUILD
+  rm -rf .$TARGET_NAME
+}
+
+configure_target() {
+  ./configure \
+    --prefix="/usr" \
+    --extra-cflags="$CFLAGS" \
+    --extra-ldflags="$LDFLAGS" \
+    --disable-cli \
+    --enable-static \
+    --enable-strip \
+    --disable-asm \
+    --enable-pic \
+    --host="$TARGET_NAME" \
+    --cross-prefix="$TARGET_PREFIX" \
+    --sysroot="$SYSROOT_PREFIX"
+}

--- a/packages/addons/service/emby/changelog.txt
+++ b/packages/addons/service/emby/changelog.txt
@@ -1,3 +1,8 @@
+8.0.102
+- Updated to version 3.0.6030
+- Added dedicated ffmpeg and ffprobe
+- Removed unused shared libraries
+
 8.0.101
 - Updated to version 3.0.5985
 - Removed mono build dependency

--- a/packages/addons/service/emby/package.mk
+++ b/packages/addons/service/emby/package.mk
@@ -17,13 +17,13 @@
 ################################################################################
 
 PKG_NAME="emby"
-PKG_VERSION="3.0.5985"
-PKG_REV="101"
+PKG_VERSION="3.0.6030"
+PKG_REV="102"
 PKG_ARCH="arm x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="http://emby.media"
 PKG_URL="https://github.com/MediaBrowser/Emby/releases/download/$PKG_VERSION/Emby.Mono.zip"
-PKG_DEPENDS_TARGET="toolchain imagemagick"
+PKG_DEPENDS_TARGET="toolchain ffmpegx imagemagick"
 PKG_PRIORITY="optional"
 PKG_SECTION="service"
 PKG_SHORTDESC="Emby: a personal media server"
@@ -55,6 +55,13 @@ addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/Emby.Mono
   unzip -q $ROOT/$SOURCES/$PKG_NAME/$PKG_SOURCE_NAME -d $ADDON_BUILD/$PKG_ADDON_ID/Emby.Mono
 
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin
+  cp -L $(get_build_dir ffmpegx)/.install_pkg/usr/local/bin/ffmpegx  \
+        $(get_build_dir ffmpegx)/.install_pkg/usr/local/bin/ffprobex \
+        $ADDON_BUILD/$PKG_ADDON_ID/bin/
+
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PR $(get_build_dir imagemagick)/.install_pkg/usr/lib/* $ADDON_BUILD/$PKG_ADDON_ID/lib/
+  cp -L $(get_build_dir imagemagick)/.install_pkg/usr/lib/libMagickCore-6.Q8.so.2 \
+        $(get_build_dir imagemagick)/.install_pkg/usr/lib/libMagickWand-6.Q8.so   \
+        $ADDON_BUILD/$PKG_ADDON_ID/lib/
 }

--- a/packages/addons/service/emby/source/bin/emby.start
+++ b/packages/addons/service/emby/source/bin/emby.start
@@ -21,7 +21,12 @@
 oe_setup_addon service.emby
 
 chmod +x $ADDON_DIR/bin/*
-
 mkdir -p $ADDON_HOME
 
-mono $ADDON_DIR/Emby.Mono/MediaBrowser.Server.Mono.exe -programdata $ADDON_HOME
+if [ "$emby_ffmpeg" = "true" ]
+then
+  emby_flags="-ffmpeg $ADDON_DIR/bin/ffmpegx -ffprobe $ADDON_DIR/bin/ffprobex"
+fi
+
+mono $ADDON_DIR/Emby.Mono/MediaBrowser.Server.Mono.exe -programdata $ADDON_HOME \
+  $emby_flags

--- a/packages/addons/service/emby/source/resources/language/English/strings.po
+++ b/packages/addons/service/emby/source/resources/language/English/strings.po
@@ -1,0 +1,11 @@
+# Kodi Media Center language file
+msgid ""
+msgstr ""
+
+msgctxt "#30000"
+msgid "Configuration"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Use dedicated ffmpeg/ffprobe (experimental)"
+msgstr ""

--- a/packages/addons/service/emby/source/resources/settings.xml
+++ b/packages/addons/service/emby/source/resources/settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+   <category   label="30000">
+      <setting label="30001" id="emby_ffmpeg" type="bool" default="false" />
+    </category>
+</settings>


### PR DESCRIPTION
This enables optional platform specific hardware transcoding to Emby. h264_omx transcodes a 1080p stream faster than it is be played, but still displays the stream on the screen. Basis for testing and further improvement.