### PR TITLE
saphire: rebuild against 4.7 kernel

### DIFF
--- a/packages/addons/driver/sapphire/changelog.txt
+++ b/packages/addons/driver/sapphire/changelog.txt
@@ -1,2 +1,5 @@
+8.0.101
+- Rebuild driver against 4.7 kernel
+
 8.0.100
 - Initial add-on

--- a/packages/addons/driver/sapphire/package.mk
+++ b/packages/addons/driver/sapphire/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="sapphire"
 PKG_VERSION="6.6"
-PKG_REV="100"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
According to https://forum.libreelec.tv/thread-634-post-8597.html#pid8597 the driver is not working in v7.90.004 and dmesg reports:

```# dmesg | grep sapphire
[    6.825862] sapphire: version magic '4.6.3 SMP mod_unload ' should be '4.7.0 SMP mod_unload '```

So this is just a plain version bump to rebuild against 4.7 kernel and ensure update. 

NB: It concerns me to discover this add-on is kernel version sensitive as we cannot assume that all users will be on latest LE version (with latest LE kernel). If any users are still using 001-003 builds this will break it for them, which is fine while we're in alpha, but is not acceptable once we move to beta and beyond.