### PR TITLE
init: mount per-client boot/disk if available & configured

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -61,6 +61,10 @@
 
   LIVE="no"
 
+  # Get a serial number if present (eg. RPi) otherwise use MAC address from eth0
+  MACHINE_UID="$(cat /proc/cpuinfo | awk '/^Serial/{s=$3; gsub ("^0*","",s); print s}')"
+  [ -z "$MACHINE_UID" ] && MACHINE_UID="$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d :)"
+
   # hide kernel log messages on console
   echo '1 4 1 7' > /proc/sys/kernel/printk
 
@@ -338,6 +342,10 @@
         error "mount_part" "Unknown filesystem $1"
         ;;
     esac
+
+    # Substitute unique identifier if available or remove placeholder
+    MOUNT_TARGET="${MOUNT_TARGET//@UID@/$MACHINE_UID}"
+
     $MOUNT_CMD "$MOUNT_TARGET" "$2" "$3" "$4"
   }
 
@@ -861,6 +869,8 @@
   if [ "${boot%%=*}" = "FILE" ]; then
     error "check arguments" "boot argument can't be FILE type..."
   fi
+
+  debug_msg "Unique identifier for this client: ${MACHINE_UID:-NOT AVAILABLE}"
 
   # main boot sequence
   for BOOT_STEP in \


### PR DESCRIPTION
Now that the RPi3 can boot entirely from the network without an SD card\[1] (once the updated RPi firmware makes it into master), it's possible to configure multiple devices to boot from a single networked boot (System) partition/folder\[2]. However in this situation each client still needs to use a unique disk (Storage) partition/folder, which is tricky when there is only a single static `cmdline.txt` configuration file for all clients (retrieved from the shared boot partition).

In order to automatically match the booting client with the matching network Storage share, I've added the concept of a `@UID@` token which, in the case of the RPi[1-3], will be replaced by the serial number of the booting device (eg. `ff449f90`, `3b952c03` etc.).

There is no support at the moment for other non-RPi devices, but if it can be added (and perhaps just as importantly, makes sense to add - will other clients be netbooting?) then please provide the location/format of a suitable identifier.

Note that (as we have determined from previous machine-id issues) the MAC is not always a suitable machine identifier at such an early stage in the boot sequence. Although since this is a solution for netbooting clients, arguably there should always be a MAC available from somewhere as the client should have a functioning network interface by the time it executes `init`.

As an example, consider the following RPi3 `cmdline.txt` that can be used to network boot multiple clients from a single shared network boot partition:
```
boot=NFS=192.168.0.9:/nfs/System disk=NFS=192.168.0.9:/nfs/Storage/@UID@ quiet ssh ip=dhcp
```

With the above `cmdline.txt` all RPi clients would share a single `boot` partition/folder, and each client would have a dedicated `disk` partition/folder, eg. `192.168.0.9:/nfs/Storage/ff449f90`, `192.168.0.9:/nfs/Storage/3b952c03` etc.

There may be a better solution than this, or simply a better name for the token - all suggestions welcome.

---

1. RPi1 and RPi2 can network boot using an SD card containing only `bootcode.bin`
2. It is possible for each client to have a dedicated boot partition as the Pi will automatically attempt to load the firmware and kernel from a folder based on it's own serial number if such a folder exists (see [docs](https://github.com/raspberrypi/documentation/blob/master/hardware/raspberrypi/bootmodes/net.md)), finally falling back to the folder root. However when all clients are the same/identical this is an obvious redundancy. If there is a mixture of RPi[1-3] clients in a network then symbolically linking serial numbers to different Pi hardware-specific boot folders can minimise overhead, eg. `System/ff449f90` -> `System/RPi3`, `System/3b952c03` -> `RPi1`, `System/6789abcd` -> `RPi1` etc., then configure all clients with `boot=NFS=192.168.0.9:/nfs/System/@UID@` to mount client/hardware specific boot partitions.