### PR TITLE
scripts/mkimage: set real volume label on system partition

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -59,8 +59,9 @@ trap cleanup SIGINT
 # generate volume id for fat partition
   UUID_1=$(date '+%d%m')
   UUID_2=$(date '+%M%S')
-  FAT_VOL_ID="${UUID_1}${UUID_2}"
+  FAT_SERIAL_NUMBER="${UUID_1}${UUID_2}"
   UUID_SYSTEM="${UUID_1}-${UUID_2}"
+  FAT_VOLUME_LABEL="LIBREELEC"
 
 # create an image
   echo
@@ -115,9 +116,9 @@ fi
   alias mmd="mmd -i $DISK@@$OFFSET"
 
   if [ "$BOOTLOADER" = "syslinux" ]; then
-    mformat -v "$FAT_VOL_ID" -N "$FAT_VOL_ID" ::
+    mformat -v "$FAT_VOLUME_LABEL" -N "$FAT_SERIAL_NUMBER" ::
   elif [ "$BOOTLOADER" = "bcm2835-bootloader" -o "$BOOTLOADER" = "u-boot" ]; then
-    mformat ::
+    mformat -v "$FAT_VOLUME_LABEL" ::
   fi
   sync
 


### PR DESCRIPTION
for all projects, useful when disk is mounted showing nice label LIBREELEC instead of numbers or NO NAME (like with our USB-SD creator tool)
label is all upper case but this could be changed with fatlabel from dosfstools
tested with imx6 and Generic without visible side effects