### PR TITLE
imagemagic: udpate to 6.9.5-5

### DIFF
--- a/packages/addons/addon-depends/emby-depends/imagemagick/package.mk
+++ b/packages/addons/addon-depends/emby-depends/imagemagick/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="imagemagick"
-PKG_VERSION="6.9.5-4"
+PKG_VERSION="6.9.5-5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="http://www.imagemagick.org/script/license.php"


### PR DESCRIPTION
needed for emby; 6.9.5-4 is not on the upstream server so use 6.9.5-5 instead