### PR TITLE
packages/linux-drivers/brcmap6xxx-aml: disable power saving by default

### DIFF
--- a/packages/linux-drivers/brcmap6xxx-aml/config/config.txt
+++ b/packages/linux-drivers/brcmap6xxx-aml/config/config.txt
@@ -1,5 +1,6 @@
 kso_enable=0
 ccode=CN
 regrev=38
+PM=0
 nv_by_chip=1 \
 17209 1 nvram_ap6335.txt


### PR DESCRIPTION
This disables WiFi power saving by default, most visible in delays when typing over SSH. Power saving can be turned back on by user on demand.