### PR TITLE
kodi: disable compiler optimization for arm (fixes segmentation fault)

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -321,6 +321,11 @@ pre_configure_target() {
   export CXXFLAGS="$CXXFLAGS $KODI_CXXFLAGS"
   export LIBS="$LIBS -lz"
 
+# disable optimization for arm to fix segmentation fault (http://forum.odroid.com/viewtopic.php?f=62&t=20345)
+  if [ "$ARCH" = "arm" -a "$OPTIMIZATIONS" = "normal" ]; then
+    export CXXFLAGS="`echo $CXXFLAGS | sed -e 's|-O2|-Os|'`"
+  fi
+
   export JSON_BUILDER=$ROOT/$TOOLCHAIN/bin/JsonSchemaBuilder
 
 # libdvd


### PR DESCRIPTION
With OPTIMIZATIONS=normal set in project options, Kodi crashes with segmentation fault when adding to the library. Reproduced only on arm/RPi2, Generic seems fine. Using -Os instead of -O2 avoids the issue.

References:

https://forum.libreelec.tv/thread-302-post-9754.html#pid9754
http://forum.odroid.com/viewtopic.php?f=62&t=20345