### PR TITLE
gcc: Bump to gcc-6.2.0

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-live/patches/vdr-plugin-live-gcc6.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-live/patches/vdr-plugin-live-gcc6.patch
@@ -1,0 +1,43 @@
+--- a/stdext.h.orig	2016-02-07 12:55:05.958100061 +0100
++++ b/stdext.h	2016-02-07 12:56:49.583375455 +0100
+@@ -3,8 +3,38 @@
+ 
+ #if __GNUC__ >= 4
+ 
+-#	include <tr1/functional>
+-#	include <tr1/memory>
++#if __GNUC__ >= 6
++
++#include <memory>
++#include <functional>
++
++namespace std {
++namespace tr1 {
++
++       using std::bind;
++       using std::shared_ptr;
++       using std::weak_ptr;
++
++       namespace placeholders {
++               using std::placeholders::_1;
++               using std::placeholders::_2;
++               using std::placeholders::_3;
++               using std::placeholders::_4;
++               using std::placeholders::_5;
++               using std::placeholders::_6;
++               using std::placeholders::_7;
++               using std::placeholders::_8;
++               using std::placeholders::_9;
++       }
++} // namespace tr1
++} // namespace std
++
++#else
++
++ #      include <tr1/functional>
++ #      include <tr1/memory>
++
++# endif
+ 
+ #else
+ 

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
@@ -34,9 +34,9 @@ PKG_AUTORECONF="no"
 
 pre_configure_target() {
   export CFLAGS="$CFLAGS -fPIC"
-  export CXXFLAGS="$CXXFLAGS -fPIC"
+  export CXXFLAGS="$CXXFLAGS -fPIC -Wno-narrowing"
   export LDFLAGS="$LDFLAGS -fPIC"
-  export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv"
+  export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv -lpcre -lpcrecpp"
 }
 
 make_target() {

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/patches/vdr-plugin-xmltv2vdr-gcc6.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/patches/vdr-plugin-xmltv2vdr-gcc6.patch
@@ -1,0 +1,12 @@
+diff -Naur a/import.cpp b/import.cpp
+--- a/import.cpp	2016-08-23 15:16:10.362347074 +0100
++++ b/import.cpp	2016-08-23 15:16:22.814431356 +0100
+@@ -250,7 +250,7 @@
+ char *cImport::Add2Description(char *description, const char *Name, int Value)
+ {
+     char *value=NULL;
+-    if (asprintf(&value,"%i",Value)==-1) return false;
++    if (asprintf(&value,"%i",Value)==-1) return NULL;
+     description = strcatrealloc(description,Name);
+     description = strcatrealloc(description,": ");
+     description = strcatrealloc(description,value);

--- a/packages/addons/depends/audio/libopenmpt/patches/libopenmpt-bug-769.patch
+++ b/packages/addons/depends/audio/libopenmpt/patches/libopenmpt-bug-769.patch
@@ -1,0 +1,14 @@
+Index: soundlib/tuning.cpp
+===================================================================
+--- a/soundlib/tuning.cpp	(revision 6294)
++++ b/soundlib/tuning.cpp	(working copy)
+@@ -375,7 +375,8 @@
+ 	if(!IsOfType(TT_GROUPGEOMETRIC)) return 0;
+ 
+ 	if(note >= 0) return note % GetGroupSize();
+-	else return (GetGroupSize() -  (abs(note) % GetGroupSize())) % GetGroupSize();
++	// static_cast<int>(note) because g++-6 template-disables std::abs overloads for 8bit and 16bit integer types via std::enable_if.
++	else return (GetGroupSize() - (std::abs(static_cast<int>(note)) % GetGroupSize())) % GetGroupSize();
+ }
+ 
+ 

--- a/packages/addons/service/tvheadend42/patches/tvheadend42-03_gcc6.patch
+++ b/packages/addons/service/tvheadend42/patches/tvheadend42-03_gcc6.patch
@@ -1,0 +1,12 @@
+diff -Naur a/Makefile.ffmpeg b/Makefile.ffmpeg
+--- a/Makefile.ffmpeg	2016-08-23 22:33:53.857013081 +0100
++++ b/Makefile.ffmpeg	2016-08-23 22:35:03.249419823 +0100
+@@ -446,7 +446,7 @@
+ $(LIB_ROOT)/$(LIBFDKAAC)/.tvh_build: \
+ 		$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download
+ 	cd $(LIB_ROOT)/$(LIBFDKAAC) && \
+-		CXXFLAGS="$(CFLAGS_PI)" CFLAGS="$(CFLAGS_PI)" $(CONFIGURE)
++		CXXFLAGS="$(CFLAGS_PI) -Wno-narrowing" CFLAGS="$(CFLAGS_PI)" $(CONFIGURE)
+ 	DESTDIR=$(EBUILDIR) \
+ 		$(MAKE) -C $(LIB_ROOT)/$(LIBFDKAAC) install
+ 	@touch $@

--- a/packages/audio/espeak/patches/espeak-1.48-gcc-6-fix.patch
+++ b/packages/audio/espeak/patches/espeak-1.48-gcc-6-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/src/tr_languages.cpp b/src/tr_languages.cpp
+--- a/src/tr_languages.cpp
++++ b/src/tr_languages.cpp
+@@ -198,7 +198,7 @@ static const unsigned short chars_ignore_zwnj_hyphen[] = {
+ 	0x200d,  1, // zero width joiner
+ 	0, 0 };
+ 
+-const char string_ordinal[] = {0xc2,0xba,0};  // masculine ordinal character, UTF-8
++const char string_ordinal[] = {'\xc2','\xba',0};  // masculine ordinal character, UTF-8
+ 
+ 
+ static Translator* NewTranslator(void)

--- a/packages/audio/sidplay-libs/package.mk
+++ b/packages/audio/sidplay-libs/package.mk
@@ -37,4 +37,6 @@ pre_configure_target() {
   # fails to build in subdirs
   cd $ROOT/$PKG_BUILD
   rm -rf .$TARGET_NAME
+
+  export CXXFLAGS="$CXXFLAGS -Wno-narrowing"
 }

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="glibc"
-PKG_VERSION="2.23"
+PKG_VERSION="2.24"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -99,19 +99,16 @@ pre_configure_target() {
   unset LD_LIBRARY_PATH
 
   # set some CFLAGS we need
-  export CFLAGS="$CFLAGS -g -fno-stack-protector -fgnu89-inline"
+  export CFLAGS="$CFLAGS -g -fno-stack-protector"
 
   export BUILD_CC=$HOST_CC
   export OBJDUMP_FOR_HOST=objdump
 
 cat >config.cache <<EOF
-ac_cv_header_cpuid_h=yes
 libc_cv_forced_unwind=yes
 libc_cv_c_cleanup=yes
-libc_cv_gnu89_inline=yes
 libc_cv_ssp=no
 libc_cv_ssp_strong=no
-libc_cv_ctors_header=yes
 libc_cv_slibdir=/lib
 EOF
 

--- a/packages/graphics/libprojectM/patches/libprojectM-c++14.patch
+++ b/packages/graphics/libprojectM/patches/libprojectM-c++14.patch
@@ -1,0 +1,61 @@
+diff -x '*orig' -rup a/Common.hpp b/Common.hpp
+--- a/Common.hpp	2012-05-20 04:43:26.000000000 +0100
++++ b/Common.hpp	2016-03-17 05:00:14.176905540 +0000
+@@ -63,7 +63,8 @@ extern FILE *fmemopen(void *buf, size_t
+ 
+ #ifdef LINUX
+ #include <cstdlib>
+-#define projectM_isnan isnan
++#include <cmath>
++#define projectM_isnan std::isnan
+ 
+ #endif
+ 
+diff -x '*orig' -rup a/MilkdropPresetFactory/Parser.cpp b/MilkdropPresetFactory/Parser.cpp
+--- a/MilkdropPresetFactory/Parser.cpp	2012-05-20 04:43:26.000000000 +0100
++++ b/MilkdropPresetFactory/Parser.cpp	2016-03-17 05:00:14.177905556 +0000
+@@ -1406,7 +1406,7 @@ PerFrameEqn * Parser::parse_implicit_per
+   PerFrameEqn * per_frame_eqn;
+   GenExpr * gen_expr;
+ 
+-  if (fs == NULL)
++  if (!fs)
+     return NULL;
+   if (param_string == NULL)
+     return NULL;
+@@ -1561,7 +1561,7 @@ InitCond * Parser::parse_per_frame_init_
+ 
+   if (preset == NULL)
+     return NULL;
+-  if (fs == NULL)
++  if (!fs)
+     return NULL;
+ 
+   if ((token = parseToken(fs, name)) != tEq)
+@@ -1875,7 +1875,7 @@ int Parser::parse_shapecode(char * token
+   /* Null argument checks */
+   if (preset == NULL)
+     return PROJECTM_FAILURE;
+-  if (fs == NULL)
++  if (!fs)
+     return PROJECTM_FAILURE;
+   if (token == NULL)
+     return PROJECTM_FAILURE;
+@@ -2166,7 +2166,7 @@ int Parser::parse_wave(char * token, std
+ 
+   if (token == NULL)
+     return PROJECTM_FAILURE;
+-  if (fs == NULL)
++  if (!fs)
+     return PROJECTM_FAILURE;
+   if (preset == NULL)
+     return PROJECTM_FAILURE;
+@@ -2348,7 +2348,7 @@ int Parser::parse_shape(char * token, st
+   if (token == NULL)
+ 
+     return PROJECTM_FAILURE;
+-  if (fs == NULL)
++  if (!fs)
+     return PROJECTM_FAILURE;
+   if (preset == NULL)
+     return PROJECTM_FAILURE;

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="gcc"
-PKG_VERSION="6.1.0"
+PKG_VERSION="6.2.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="gcc"
-PKG_VERSION="5.4.0"
+PKG_VERSION="6.1.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/lang/gcc/patches/gcc-reduce-genautomata-memory-footprint-for-arm-bug-70473.patch
+++ b/packages/lang/gcc/patches/gcc-reduce-genautomata-memory-footprint-for-arm-bug-70473.patch
@@ -1,0 +1,42 @@
+--- trunk/gcc/config/arm/cortex-a8-neon.md	2016/08/26 10:22:08	239771
++++ trunk/gcc/config/arm/cortex-a8-neon.md	2016/08/26 10:23:20	239772
+@@ -357,30 +357,34 @@
+        (eq_attr "type" "fmuls"))
+   "cortex_a8_vfp,cortex_a8_vfplite*11")
+ 
++;; Don't model a reservation for more than 15 cycles as this explodes the
++;; state space of the automaton for little gain.  It is unlikely that the
++;; scheduler will find enough instructions to hide the full latency of the
++;; instructions.
+ (define_insn_reservation "cortex_a8_vfp_muld" 17
+   (and (eq_attr "tune" "cortexa8")
+        (eq_attr "type" "fmuld"))
+-  "cortex_a8_vfp,cortex_a8_vfplite*16")
++  "cortex_a8_vfp,cortex_a8_vfplite*15")
+ 
+ (define_insn_reservation "cortex_a8_vfp_macs" 21
+   (and (eq_attr "tune" "cortexa8")
+        (eq_attr "type" "fmacs,ffmas"))
+-  "cortex_a8_vfp,cortex_a8_vfplite*20")
++  "cortex_a8_vfp,cortex_a8_vfplite*15")
+ 
+ (define_insn_reservation "cortex_a8_vfp_macd" 26
+   (and (eq_attr "tune" "cortexa8")
+        (eq_attr "type" "fmacd,ffmad"))
+-  "cortex_a8_vfp,cortex_a8_vfplite*25")
++  "cortex_a8_vfp,cortex_a8_vfplite*15")
+ 
+ (define_insn_reservation "cortex_a8_vfp_divs" 37
+   (and (eq_attr "tune" "cortexa8")
+        (eq_attr "type" "fdivs, fsqrts"))
+-  "cortex_a8_vfp,cortex_a8_vfplite*36")
++  "cortex_a8_vfp,cortex_a8_vfplite*15")
+ 
+ (define_insn_reservation "cortex_a8_vfp_divd" 65
+   (and (eq_attr "tune" "cortexa8")
+        (eq_attr "type" "fdivd, fsqrtd"))
+-  "cortex_a8_vfp,cortex_a8_vfplite*64")
++  "cortex_a8_vfp,cortex_a8_vfplite*15")
+ 
+ ;; Comparisons can actually take 7 cycles sometimes instead of four,
+ ;; but given all the other instructions lumped into type=ffarith that

--- a/packages/mediacenter/kodi-binary-addons/adsp.biquad.filters/patches/adsp.biquad.filters-gcc-6.patch
+++ b/packages/mediacenter/kodi-binary-addons/adsp.biquad.filters/patches/adsp.biquad.filters-gcc-6.patch
@@ -1,0 +1,35 @@
+From abae62ace5cd09025acaf8e03e5edad94131ff07 Mon Sep 17 00:00:00 2001
+From: Bernd Kuhls <bernd.kuhls@t-online.de>
+Date: Sun, 24 Apr 2016 22:42:07 +0200
+Subject: [PATCH] ADSPHelpers.cpp: Fix compilation with gcc6
+
+Fixes https://github.com/kodi-adsp/adsp.biquad.filters/issues/13
+
+Patch inspired by
+https://github.com/assaultcube/AC/commit/752950989b4e286459ca9aee3d61a868d7b20fa4
+---
+ src/template/ADSPHelpers.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/template/ADSPHelpers.cpp b/src/template/ADSPHelpers.cpp
+index 5aa6a7d..f66e77f 100644
+--- a/src/template/ADSPHelpers.cpp
++++ b/src/template/ADSPHelpers.cpp
+@@ -24,7 +24,7 @@
+ using namespace std;
+ 
+ #if !defined(TARGET_WINDOWS)
+-  inline float abs(float Val)
++  inline float iabs(float Val)
+   {
+     if(Val >= 0.0f)
+     {
+@@ -441,7 +441,7 @@ float CADSPHelpers::Convert_dB_TO_Value(float dB)
+ 
+ float CADSPHelpers::Convert_Value_TO_dB(float Scale)
+ {
+-  return 20.0f*log10f(abs(Scale));
++  return 20.0f*log10f(iabs(Scale));
+ }
+ 
+ // reserved for future implementation

--- a/packages/security/libgcrypt/package.mk
+++ b/packages/security/libgcrypt/package.mk
@@ -31,7 +31,10 @@ PKG_LONGDESC="Libgcrypt is a general purpose cryptographic library based on the 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-asm --with-gnu-ld --with-libgpg-error-prefix=$SYSROOT_PREFIX/usr"
+PKG_CONFIGURE_OPTS_TARGET="ac_cv_sys_symbol_underscore=no \
+                           --enable-asm \
+                           --with-gnu-ld \
+                           --with-libgpg-error-prefix=$SYSROOT_PREFIX/usr"
 
 post_makeinstall_target() {
   sed -e "s:\(['= ]\)\"/usr:\\1\"$SYSROOT_PREFIX/usr:g" -i src/$PKG_NAME-config

--- a/packages/security/libgcrypt/patches/libgcrypt-ac_cv_sys_symbol_underscore.patch
+++ b/packages/security/libgcrypt/patches/libgcrypt-ac_cv_sys_symbol_underscore.patch
@@ -1,0 +1,27 @@
+diff --git a/acinclude.m4 b/acinclude.m4
+index a7bc0fa..1a5bffc 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -76,13 +76,14 @@ case "${host}" in
+     i386-emx-os2 | i[3456]86-pc-os2*emx | i386-pc-msdosdjgpp)
+         ac_cv_sys_symbol_underscore=yes
+         ;;
+-    *)
+-      if test "$cross_compiling" = yes; then
+-        if test "x$ac_cv_sys_symbol_underscore" = x ; then
+-           ac_cv_sys_symbol_underscore=yes
+-        fi
+-      else
+-         tmp_do_check="yes"
++    *) if test -z "$ac_cv_sys_symbol_underscore"; then
++         if test "$cross_compiling" = yes; then
++           if test "x$ac_cv_sys_symbol_underscore" = x ; then
++              ac_cv_sys_symbol_underscore=yes
++           fi
++         else
++            tmp_do_check="yes"
++         fi
+       fi
+        ;;
+ esac
+ 

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -56,6 +56,10 @@ pre_configure_target() {
 
 # dont build in parallel because of problems
   MAKEFLAGS=-j1
+
+# copy compiler-gcc5.h to compiler-gcc6. for fake building
+  cp include/linux/compiler-gcc5.h include/linux/compiler-gcc6.h
+
 }
 
 make_target() {

--- a/projects/Odroid_C2/patches/linux/linux-compiler-gcc.h.patch
+++ b/projects/Odroid_C2/patches/linux/linux-compiler-gcc.h.patch
@@ -1,0 +1,166 @@
+From cb984d101b30eb7478d32df56a0023e4603cba7f Mon Sep 17 00:00:00 2001
+From: Joe Perches <joe@perches.com>
+Date: Thu, 25 Jun 2015 15:01:02 -0700
+Subject: compiler-gcc: integrate the various compiler-gcc[345].h files
+
+As gcc major version numbers are going to advance rather rapidly in the
+future, there's no real value in separate files for each compiler
+version.
+
+Deduplicate some of the macros #defined in each file too.
+
+Neaten comments using normal kernel commenting style.
+
+Signed-off-by: Joe Perches <joe@perches.com>
+Cc: Andi Kleen <andi@firstfloor.org>
+Cc: Michal Marek <mmarek@suse.cz>
+Cc: Segher Boessenkool <segher@kernel.crashing.org>
+Cc: Sasha Levin <levinsasha928@gmail.com>
+Cc: Anton Blanchard <anton@samba.org>
+Cc: Alan Modra <amodra@gmail.com>
+Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ include/linux/compiler-gcc.h  | 120 ++++++++++++++++++++++++++++++++++++++++--
+ include/linux/compiler-gcc3.h |  23 --------
+ include/linux/compiler-gcc4.h |  91 --------------------------------
+ include/linux/compiler-gcc5.h |  67 -----------------------
+ 4 files changed, 116 insertions(+), 185 deletions(-)
+ delete mode 100644 include/linux/compiler-gcc3.h
+ delete mode 100644 include/linux/compiler-gcc4.h
+ delete mode 100644 include/linux/compiler-gcc5.h
+
+diff --git a/include/linux/compiler-gcc.h b/include/linux/compiler-gcc.h
+index 5c2c14e..dfaa7b3 100644
+--- a/include/linux/compiler-gcc.h
++++ b/include/linux/compiler-gcc.h
+@@ -122,10 +122,122 @@
+ #define __maybe_unused		__attribute__((unused))
+ #define __always_unused		__attribute__((unused))
+ 
+-#define __gcc_header(x) #x
+-#define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
+-#define gcc_header(x) _gcc_header(x)
+-#include gcc_header(__GNUC__)
++/* gcc version specific checks */
++
++#if GCC_VERSION < 30200
++# error Sorry, your compiler is too old - please upgrade it.
++#endif
++
++#if GCC_VERSION < 30300
++# define __used			__attribute__((__unused__))
++#else
++# define __used			__attribute__((__used__))
++#endif
++
++#ifdef CONFIG_GCOV_KERNEL
++# if GCC_VERSION < 30400
++#   error "GCOV profiling support for gcc versions below 3.4 not included"
++# endif /* __GNUC_MINOR__ */
++#endif /* CONFIG_GCOV_KERNEL */
++
++#if GCC_VERSION >= 30400
++#define __must_check		__attribute__((warn_unused_result))
++#endif
++
++#if GCC_VERSION >= 40000
++
++/* GCC 4.1.[01] miscompiles __weak */
++#ifdef __KERNEL__
++# if GCC_VERSION >= 40100 &&  GCC_VERSION <= 40101
++#  error Your version of gcc miscompiles the __weak directive
++# endif
++#endif
++
++#define __used			__attribute__((__used__))
++#define __compiler_offsetof(a, b)					\
++	__builtin_offsetof(a, b)
++
++#if GCC_VERSION >= 40100 && GCC_VERSION < 40600
++# define __compiletime_object_size(obj) __builtin_object_size(obj, 0)
++#endif
++
++#if GCC_VERSION >= 40300
++/* Mark functions as cold. gcc will assume any path leading to a call
++ * to them will be unlikely.  This means a lot of manual unlikely()s
++ * are unnecessary now for any paths leading to the usual suspects
++ * like BUG(), printk(), panic() etc. [but let's keep them for now for
++ * older compilers]
++ *
++ * Early snapshots of gcc 4.3 don't support this and we can't detect this
++ * in the preprocessor, but we can live with this because they're unreleased.
++ * Maketime probing would be overkill here.
++ *
++ * gcc also has a __attribute__((__hot__)) to move hot functions into
++ * a special section, but I don't see any sense in this right now in
++ * the kernel context
++ */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++#endif /* GCC_VERSION >= 40300 */
++
++#if GCC_VERSION >= 40500
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++#endif /* GCC_VERSION >= 40500 */
++
++#if GCC_VERSION >= 40600
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible	__attribute__((externally_visible))
++#endif
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#if GCC_VERSION >= 40400
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#endif
++#if GCC_VERSION >= 40800 || (defined(__powerpc__) && GCC_VERSION >= 40600)
++#define __HAVE_BUILTIN_BSWAP16__
++#endif
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#if GCC_VERSION >= 50000
++#define KASAN_ABI_VERSION 4
++#elif GCC_VERSION >= 40902
++#define KASAN_ABI_VERSION 3
++#endif
++
++#endif	/* gcc version >= 40000 specific checks */
+ 
+ #if !defined(__noclone)
+ #define __noclone	/* not needed */
+-- 
+cgit v0.12
+

--- a/projects/WeTek_Core/patches/linux/linux-compiler-gcc.h.patch
+++ b/projects/WeTek_Core/patches/linux/linux-compiler-gcc.h.patch
@@ -1,0 +1,166 @@
+From cb984d101b30eb7478d32df56a0023e4603cba7f Mon Sep 17 00:00:00 2001
+From: Joe Perches <joe@perches.com>
+Date: Thu, 25 Jun 2015 15:01:02 -0700
+Subject: compiler-gcc: integrate the various compiler-gcc[345].h files
+
+As gcc major version numbers are going to advance rather rapidly in the
+future, there's no real value in separate files for each compiler
+version.
+
+Deduplicate some of the macros #defined in each file too.
+
+Neaten comments using normal kernel commenting style.
+
+Signed-off-by: Joe Perches <joe@perches.com>
+Cc: Andi Kleen <andi@firstfloor.org>
+Cc: Michal Marek <mmarek@suse.cz>
+Cc: Segher Boessenkool <segher@kernel.crashing.org>
+Cc: Sasha Levin <levinsasha928@gmail.com>
+Cc: Anton Blanchard <anton@samba.org>
+Cc: Alan Modra <amodra@gmail.com>
+Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ include/linux/compiler-gcc.h  | 120 ++++++++++++++++++++++++++++++++++++++++--
+ include/linux/compiler-gcc3.h |  23 --------
+ include/linux/compiler-gcc4.h |  91 --------------------------------
+ include/linux/compiler-gcc5.h |  67 -----------------------
+ 4 files changed, 116 insertions(+), 185 deletions(-)
+ delete mode 100644 include/linux/compiler-gcc3.h
+ delete mode 100644 include/linux/compiler-gcc4.h
+ delete mode 100644 include/linux/compiler-gcc5.h
+
+diff --git a/include/linux/compiler-gcc.h b/include/linux/compiler-gcc.h
+index 5c2c14e..dfaa7b3 100644
+--- a/include/linux/compiler-gcc.h
++++ b/include/linux/compiler-gcc.h
+@@ -122,10 +122,122 @@
+ #define __maybe_unused		__attribute__((unused))
+ #define __always_unused		__attribute__((unused))
+ 
+-#define __gcc_header(x) #x
+-#define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
+-#define gcc_header(x) _gcc_header(x)
+-#include gcc_header(__GNUC__)
++/* gcc version specific checks */
++
++#if GCC_VERSION < 30200
++# error Sorry, your compiler is too old - please upgrade it.
++#endif
++
++#if GCC_VERSION < 30300
++# define __used			__attribute__((__unused__))
++#else
++# define __used			__attribute__((__used__))
++#endif
++
++#ifdef CONFIG_GCOV_KERNEL
++# if GCC_VERSION < 30400
++#   error "GCOV profiling support for gcc versions below 3.4 not included"
++# endif /* __GNUC_MINOR__ */
++#endif /* CONFIG_GCOV_KERNEL */
++
++#if GCC_VERSION >= 30400
++#define __must_check		__attribute__((warn_unused_result))
++#endif
++
++#if GCC_VERSION >= 40000
++
++/* GCC 4.1.[01] miscompiles __weak */
++#ifdef __KERNEL__
++# if GCC_VERSION >= 40100 &&  GCC_VERSION <= 40101
++#  error Your version of gcc miscompiles the __weak directive
++# endif
++#endif
++
++#define __used			__attribute__((__used__))
++#define __compiler_offsetof(a, b)					\
++	__builtin_offsetof(a, b)
++
++#if GCC_VERSION >= 40100 && GCC_VERSION < 40600
++# define __compiletime_object_size(obj) __builtin_object_size(obj, 0)
++#endif
++
++#if GCC_VERSION >= 40300
++/* Mark functions as cold. gcc will assume any path leading to a call
++ * to them will be unlikely.  This means a lot of manual unlikely()s
++ * are unnecessary now for any paths leading to the usual suspects
++ * like BUG(), printk(), panic() etc. [but let's keep them for now for
++ * older compilers]
++ *
++ * Early snapshots of gcc 4.3 don't support this and we can't detect this
++ * in the preprocessor, but we can live with this because they're unreleased.
++ * Maketime probing would be overkill here.
++ *
++ * gcc also has a __attribute__((__hot__)) to move hot functions into
++ * a special section, but I don't see any sense in this right now in
++ * the kernel context
++ */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++#endif /* GCC_VERSION >= 40300 */
++
++#if GCC_VERSION >= 40500
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++#endif /* GCC_VERSION >= 40500 */
++
++#if GCC_VERSION >= 40600
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible	__attribute__((externally_visible))
++#endif
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#if GCC_VERSION >= 40400
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#endif
++#if GCC_VERSION >= 40800 || (defined(__powerpc__) && GCC_VERSION >= 40600)
++#define __HAVE_BUILTIN_BSWAP16__
++#endif
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#if GCC_VERSION >= 50000
++#define KASAN_ABI_VERSION 4
++#elif GCC_VERSION >= 40902
++#define KASAN_ABI_VERSION 3
++#endif
++
++#endif	/* gcc version >= 40000 specific checks */
+ 
+ #if !defined(__noclone)
+ #define __noclone	/* not needed */
+-- 
+cgit v0.12
+

--- a/projects/WeTek_Hub/patches/linux/linux-compiler-gcc.h.patch
+++ b/projects/WeTek_Hub/patches/linux/linux-compiler-gcc.h.patch
@@ -1,0 +1,166 @@
+From cb984d101b30eb7478d32df56a0023e4603cba7f Mon Sep 17 00:00:00 2001
+From: Joe Perches <joe@perches.com>
+Date: Thu, 25 Jun 2015 15:01:02 -0700
+Subject: compiler-gcc: integrate the various compiler-gcc[345].h files
+
+As gcc major version numbers are going to advance rather rapidly in the
+future, there's no real value in separate files for each compiler
+version.
+
+Deduplicate some of the macros #defined in each file too.
+
+Neaten comments using normal kernel commenting style.
+
+Signed-off-by: Joe Perches <joe@perches.com>
+Cc: Andi Kleen <andi@firstfloor.org>
+Cc: Michal Marek <mmarek@suse.cz>
+Cc: Segher Boessenkool <segher@kernel.crashing.org>
+Cc: Sasha Levin <levinsasha928@gmail.com>
+Cc: Anton Blanchard <anton@samba.org>
+Cc: Alan Modra <amodra@gmail.com>
+Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ include/linux/compiler-gcc.h  | 120 ++++++++++++++++++++++++++++++++++++++++--
+ include/linux/compiler-gcc3.h |  23 --------
+ include/linux/compiler-gcc4.h |  91 --------------------------------
+ include/linux/compiler-gcc5.h |  67 -----------------------
+ 4 files changed, 116 insertions(+), 185 deletions(-)
+ delete mode 100644 include/linux/compiler-gcc3.h
+ delete mode 100644 include/linux/compiler-gcc4.h
+ delete mode 100644 include/linux/compiler-gcc5.h
+
+diff --git a/include/linux/compiler-gcc.h b/include/linux/compiler-gcc.h
+index 5c2c14e..dfaa7b3 100644
+--- a/include/linux/compiler-gcc.h
++++ b/include/linux/compiler-gcc.h
+@@ -122,10 +122,122 @@
+ #define __maybe_unused		__attribute__((unused))
+ #define __always_unused		__attribute__((unused))
+ 
+-#define __gcc_header(x) #x
+-#define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
+-#define gcc_header(x) _gcc_header(x)
+-#include gcc_header(__GNUC__)
++/* gcc version specific checks */
++
++#if GCC_VERSION < 30200
++# error Sorry, your compiler is too old - please upgrade it.
++#endif
++
++#if GCC_VERSION < 30300
++# define __used			__attribute__((__unused__))
++#else
++# define __used			__attribute__((__used__))
++#endif
++
++#ifdef CONFIG_GCOV_KERNEL
++# if GCC_VERSION < 30400
++#   error "GCOV profiling support for gcc versions below 3.4 not included"
++# endif /* __GNUC_MINOR__ */
++#endif /* CONFIG_GCOV_KERNEL */
++
++#if GCC_VERSION >= 30400
++#define __must_check		__attribute__((warn_unused_result))
++#endif
++
++#if GCC_VERSION >= 40000
++
++/* GCC 4.1.[01] miscompiles __weak */
++#ifdef __KERNEL__
++# if GCC_VERSION >= 40100 &&  GCC_VERSION <= 40101
++#  error Your version of gcc miscompiles the __weak directive
++# endif
++#endif
++
++#define __used			__attribute__((__used__))
++#define __compiler_offsetof(a, b)					\
++	__builtin_offsetof(a, b)
++
++#if GCC_VERSION >= 40100 && GCC_VERSION < 40600
++# define __compiletime_object_size(obj) __builtin_object_size(obj, 0)
++#endif
++
++#if GCC_VERSION >= 40300
++/* Mark functions as cold. gcc will assume any path leading to a call
++ * to them will be unlikely.  This means a lot of manual unlikely()s
++ * are unnecessary now for any paths leading to the usual suspects
++ * like BUG(), printk(), panic() etc. [but let's keep them for now for
++ * older compilers]
++ *
++ * Early snapshots of gcc 4.3 don't support this and we can't detect this
++ * in the preprocessor, but we can live with this because they're unreleased.
++ * Maketime probing would be overkill here.
++ *
++ * gcc also has a __attribute__((__hot__)) to move hot functions into
++ * a special section, but I don't see any sense in this right now in
++ * the kernel context
++ */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++#endif /* GCC_VERSION >= 40300 */
++
++#if GCC_VERSION >= 40500
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++#endif /* GCC_VERSION >= 40500 */
++
++#if GCC_VERSION >= 40600
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible	__attribute__((externally_visible))
++#endif
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#if GCC_VERSION >= 40400
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#endif
++#if GCC_VERSION >= 40800 || (defined(__powerpc__) && GCC_VERSION >= 40600)
++#define __HAVE_BUILTIN_BSWAP16__
++#endif
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#if GCC_VERSION >= 50000
++#define KASAN_ABI_VERSION 4
++#elif GCC_VERSION >= 40902
++#define KASAN_ABI_VERSION 3
++#endif
++
++#endif	/* gcc version >= 40000 specific checks */
+ 
+ #if !defined(__noclone)
+ #define __noclone	/* not needed */
+-- 
+cgit v0.12
+

--- a/projects/WeTek_Play/patches/linux/linux-compiler-gcc.h.patch
+++ b/projects/WeTek_Play/patches/linux/linux-compiler-gcc.h.patch
@@ -1,0 +1,166 @@
+From cb984d101b30eb7478d32df56a0023e4603cba7f Mon Sep 17 00:00:00 2001
+From: Joe Perches <joe@perches.com>
+Date: Thu, 25 Jun 2015 15:01:02 -0700
+Subject: compiler-gcc: integrate the various compiler-gcc[345].h files
+
+As gcc major version numbers are going to advance rather rapidly in the
+future, there's no real value in separate files for each compiler
+version.
+
+Deduplicate some of the macros #defined in each file too.
+
+Neaten comments using normal kernel commenting style.
+
+Signed-off-by: Joe Perches <joe@perches.com>
+Cc: Andi Kleen <andi@firstfloor.org>
+Cc: Michal Marek <mmarek@suse.cz>
+Cc: Segher Boessenkool <segher@kernel.crashing.org>
+Cc: Sasha Levin <levinsasha928@gmail.com>
+Cc: Anton Blanchard <anton@samba.org>
+Cc: Alan Modra <amodra@gmail.com>
+Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ include/linux/compiler-gcc.h  | 120 ++++++++++++++++++++++++++++++++++++++++--
+ include/linux/compiler-gcc3.h |  23 --------
+ include/linux/compiler-gcc4.h |  91 --------------------------------
+ include/linux/compiler-gcc5.h |  67 -----------------------
+ 4 files changed, 116 insertions(+), 185 deletions(-)
+ delete mode 100644 include/linux/compiler-gcc3.h
+ delete mode 100644 include/linux/compiler-gcc4.h
+ delete mode 100644 include/linux/compiler-gcc5.h
+
+diff --git a/include/linux/compiler-gcc.h b/include/linux/compiler-gcc.h
+index 5c2c14e..dfaa7b3 100644
+--- a/include/linux/compiler-gcc.h
++++ b/include/linux/compiler-gcc.h
+@@ -122,10 +122,122 @@
+ #define __maybe_unused		__attribute__((unused))
+ #define __always_unused		__attribute__((unused))
+ 
+-#define __gcc_header(x) #x
+-#define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
+-#define gcc_header(x) _gcc_header(x)
+-#include gcc_header(__GNUC__)
++/* gcc version specific checks */
++
++#if GCC_VERSION < 30200
++# error Sorry, your compiler is too old - please upgrade it.
++#endif
++
++#if GCC_VERSION < 30300
++# define __used			__attribute__((__unused__))
++#else
++# define __used			__attribute__((__used__))
++#endif
++
++#ifdef CONFIG_GCOV_KERNEL
++# if GCC_VERSION < 30400
++#   error "GCOV profiling support for gcc versions below 3.4 not included"
++# endif /* __GNUC_MINOR__ */
++#endif /* CONFIG_GCOV_KERNEL */
++
++#if GCC_VERSION >= 30400
++#define __must_check		__attribute__((warn_unused_result))
++#endif
++
++#if GCC_VERSION >= 40000
++
++/* GCC 4.1.[01] miscompiles __weak */
++#ifdef __KERNEL__
++# if GCC_VERSION >= 40100 &&  GCC_VERSION <= 40101
++#  error Your version of gcc miscompiles the __weak directive
++# endif
++#endif
++
++#define __used			__attribute__((__used__))
++#define __compiler_offsetof(a, b)					\
++	__builtin_offsetof(a, b)
++
++#if GCC_VERSION >= 40100 && GCC_VERSION < 40600
++# define __compiletime_object_size(obj) __builtin_object_size(obj, 0)
++#endif
++
++#if GCC_VERSION >= 40300
++/* Mark functions as cold. gcc will assume any path leading to a call
++ * to them will be unlikely.  This means a lot of manual unlikely()s
++ * are unnecessary now for any paths leading to the usual suspects
++ * like BUG(), printk(), panic() etc. [but let's keep them for now for
++ * older compilers]
++ *
++ * Early snapshots of gcc 4.3 don't support this and we can't detect this
++ * in the preprocessor, but we can live with this because they're unreleased.
++ * Maketime probing would be overkill here.
++ *
++ * gcc also has a __attribute__((__hot__)) to move hot functions into
++ * a special section, but I don't see any sense in this right now in
++ * the kernel context
++ */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++#endif /* GCC_VERSION >= 40300 */
++
++#if GCC_VERSION >= 40500
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++#endif /* GCC_VERSION >= 40500 */
++
++#if GCC_VERSION >= 40600
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible	__attribute__((externally_visible))
++#endif
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#if GCC_VERSION >= 40400
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#endif
++#if GCC_VERSION >= 40800 || (defined(__powerpc__) && GCC_VERSION >= 40600)
++#define __HAVE_BUILTIN_BSWAP16__
++#endif
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#if GCC_VERSION >= 50000
++#define KASAN_ABI_VERSION 4
++#elif GCC_VERSION >= 40902
++#define KASAN_ABI_VERSION 3
++#endif
++
++#endif	/* gcc version >= 40000 specific checks */
+ 
+ #if !defined(__noclone)
+ #define __noclone	/* not needed */
+-- 
+cgit v0.12
+

--- a/projects/imx6/patches/linux/3.14-mx6-sr/linux-compiler-gcc.h.patch
+++ b/projects/imx6/patches/linux/3.14-mx6-sr/linux-compiler-gcc.h.patch
@@ -1,0 +1,166 @@
+From cb984d101b30eb7478d32df56a0023e4603cba7f Mon Sep 17 00:00:00 2001
+From: Joe Perches <joe@perches.com>
+Date: Thu, 25 Jun 2015 15:01:02 -0700
+Subject: compiler-gcc: integrate the various compiler-gcc[345].h files
+
+As gcc major version numbers are going to advance rather rapidly in the
+future, there's no real value in separate files for each compiler
+version.
+
+Deduplicate some of the macros #defined in each file too.
+
+Neaten comments using normal kernel commenting style.
+
+Signed-off-by: Joe Perches <joe@perches.com>
+Cc: Andi Kleen <andi@firstfloor.org>
+Cc: Michal Marek <mmarek@suse.cz>
+Cc: Segher Boessenkool <segher@kernel.crashing.org>
+Cc: Sasha Levin <levinsasha928@gmail.com>
+Cc: Anton Blanchard <anton@samba.org>
+Cc: Alan Modra <amodra@gmail.com>
+Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ include/linux/compiler-gcc.h  | 120 ++++++++++++++++++++++++++++++++++++++++--
+ include/linux/compiler-gcc3.h |  23 --------
+ include/linux/compiler-gcc4.h |  91 --------------------------------
+ include/linux/compiler-gcc5.h |  67 -----------------------
+ 4 files changed, 116 insertions(+), 185 deletions(-)
+ delete mode 100644 include/linux/compiler-gcc3.h
+ delete mode 100644 include/linux/compiler-gcc4.h
+ delete mode 100644 include/linux/compiler-gcc5.h
+
+diff --git a/include/linux/compiler-gcc.h b/include/linux/compiler-gcc.h
+index 5c2c14e..dfaa7b3 100644
+--- a/include/linux/compiler-gcc.h
++++ b/include/linux/compiler-gcc.h
+@@ -122,10 +122,122 @@
+ #define __maybe_unused		__attribute__((unused))
+ #define __always_unused		__attribute__((unused))
+ 
+-#define __gcc_header(x) #x
+-#define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
+-#define gcc_header(x) _gcc_header(x)
+-#include gcc_header(__GNUC__)
++/* gcc version specific checks */
++
++#if GCC_VERSION < 30200
++# error Sorry, your compiler is too old - please upgrade it.
++#endif
++
++#if GCC_VERSION < 30300
++# define __used			__attribute__((__unused__))
++#else
++# define __used			__attribute__((__used__))
++#endif
++
++#ifdef CONFIG_GCOV_KERNEL
++# if GCC_VERSION < 30400
++#   error "GCOV profiling support for gcc versions below 3.4 not included"
++# endif /* __GNUC_MINOR__ */
++#endif /* CONFIG_GCOV_KERNEL */
++
++#if GCC_VERSION >= 30400
++#define __must_check		__attribute__((warn_unused_result))
++#endif
++
++#if GCC_VERSION >= 40000
++
++/* GCC 4.1.[01] miscompiles __weak */
++#ifdef __KERNEL__
++# if GCC_VERSION >= 40100 &&  GCC_VERSION <= 40101
++#  error Your version of gcc miscompiles the __weak directive
++# endif
++#endif
++
++#define __used			__attribute__((__used__))
++#define __compiler_offsetof(a, b)					\
++	__builtin_offsetof(a, b)
++
++#if GCC_VERSION >= 40100 && GCC_VERSION < 40600
++# define __compiletime_object_size(obj) __builtin_object_size(obj, 0)
++#endif
++
++#if GCC_VERSION >= 40300
++/* Mark functions as cold. gcc will assume any path leading to a call
++ * to them will be unlikely.  This means a lot of manual unlikely()s
++ * are unnecessary now for any paths leading to the usual suspects
++ * like BUG(), printk(), panic() etc. [but let's keep them for now for
++ * older compilers]
++ *
++ * Early snapshots of gcc 4.3 don't support this and we can't detect this
++ * in the preprocessor, but we can live with this because they're unreleased.
++ * Maketime probing would be overkill here.
++ *
++ * gcc also has a __attribute__((__hot__)) to move hot functions into
++ * a special section, but I don't see any sense in this right now in
++ * the kernel context
++ */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++#endif /* GCC_VERSION >= 40300 */
++
++#if GCC_VERSION >= 40500
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++#endif /* GCC_VERSION >= 40500 */
++
++#if GCC_VERSION >= 40600
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible	__attribute__((externally_visible))
++#endif
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#if GCC_VERSION >= 40400
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#endif
++#if GCC_VERSION >= 40800 || (defined(__powerpc__) && GCC_VERSION >= 40600)
++#define __HAVE_BUILTIN_BSWAP16__
++#endif
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#if GCC_VERSION >= 50000
++#define KASAN_ABI_VERSION 4
++#elif GCC_VERSION >= 40902
++#define KASAN_ABI_VERSION 3
++#endif
++
++#endif	/* gcc version >= 40000 specific checks */
+ 
+ #if !defined(__noclone)
+ #define __noclone	/* not needed */
+-- 
+cgit v0.12
+


### PR DESCRIPTION
Build and run-time tested on RPi, RPi2 and Generic with 4.7.0 kernel. I've built the main system plus PVR and inputstream addons without any issues. Obviously a clean build is required.

Needs testing on all other platforms. Addons need building too. I've added stack-protection config options to the Wetek and imx6 kernels as they support this feature - the 3.10 kernels do not.

No rush to merge, but would be nice to nail any build issues before merging once master is open for LE9 (i.e after we branch for LE8 beta).
