### PR TITLE
packages/linux-drivers/brcmap6xxx-aml: enable 40MHz channels for 2.4G

### DIFF
--- a/packages/linux-drivers/brcmap6xxx-aml/config/config.txt
+++ b/packages/linux-drivers/brcmap6xxx-aml/config/config.txt
@@ -1,6 +1,7 @@
 kso_enable=0
 ccode=CN
 regrev=38
+mimo_bw_cap=1
 PM=0
 nv_by_chip=1 \
 17209 1 nvram_ap6335.txt


### PR DESCRIPTION
This enables 150Mbps using 2.4Ghz band. 5Ghz unaffected (at least with 802.11n).