### PR TITLE
odroidc2_64_bit_omx_pts

### DIFF
--- a/projects/Odroid_C2/patches/kodi/kodi-0001-enable-OMX_PTS64.patch
+++ b/projects/Odroid_C2/patches/kodi/kodi-0001-enable-OMX_PTS64.patch
@@ -1,0 +1,25 @@
+From be8eb87a89b6d074c16b6d4d138bfe0ff16aa663 Mon Sep 17 00:00:00 2001
+From: Markus Pfau <pfau@peakwork.de>
+Date: Wed, 24 Aug 2016 19:16:24 +0200
+Subject: [PATCH] OMX_PTS type decision by sizeof(long)
+
+---
+ xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+index ca8e964..e384711 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+@@ -1895,7 +1895,7 @@ int CAMLCodec::DequeueBuffer(int64_t &pts)
+   // Since kernel 3.14 Amlogic changed length and units of PTS values reported here.
+   // To differentiate such PTS values we check for existence of omx_pts_interval_lower
+   // parameter, because it was introduced since kernel 3.14.
+-  if (access("/sys/module/amvideo/parameters/omx_pts_interval_lower", F_OK) != -1)
++  if (1)
+   {
+     pts = vbuf.timestamp.tv_sec & 0xFFFFFFFF;
+     pts <<= 32;
+-- 
+1.9.1
+


### PR DESCRIPTION
just a note on this: omx_pts_interval_lower is NOT set by the amvideo driver if using hardkernels 3.14 linux kernel. Therefore kodis AMLCodec assumes that omx_pts is 32 bit wich is not true.

On Wetek Hub omx_pts_interval_lower is set, because of this it runs well on Wetek devices. 