### PR TITLE
image: fakeroot chokes on image names with meta chars

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -255,8 +255,8 @@ if [ -z "$SQUASHFS_COMPRESSION" ]; then
   SQUASHFS_COMPRESSION="gzip"
 fi
 
-echo "rm -rf $TARGET_IMG/$IMAGE_NAME.system" >> $FAKEROOT_SCRIPT
-echo "$ROOT/$TOOLCHAIN/bin/mksquashfs $BUILD/image/system $TARGET_IMG/$IMAGE_NAME.system -noappend -comp $SQUASHFS_COMPRESSION" >> $FAKEROOT_SCRIPT
+echo "rm -rf \"$TARGET_IMG/$IMAGE_NAME.system\"" >> $FAKEROOT_SCRIPT
+echo "$ROOT/$TOOLCHAIN/bin/mksquashfs \"$BUILD/image/system\" \"$TARGET_IMG/$IMAGE_NAME.system\" -noappend -comp $SQUASHFS_COMPRESSION" >> $FAKEROOT_SCRIPT
 
 # run fakeroot
 $ROOT/$TOOLCHAIN/bin/fakeroot -- $FAKEROOT_SCRIPT


### PR DESCRIPTION
I automatically increment the build code in my builds, which (after a long day) resulted in a build code of "160826|" (having blown past `a`-`z` and `{` - yes I know it's lame, but that's not the point).

Anyway, once we had an image filename of the form `LibreELEC-RPi2.arm-8.0-devel-20160826202024-#0826|-ga0e3207.system` the fakeroot script choked as follows:

```
Version: Linux version 4.7.2 (email@address.com) (gcc version 5.4.0 (GCC) ) #1 Fri Aug 26 19:48:52 BST 2016
DT: y
DDT: y
270x: y
283x: n
...done
/home/neil/projects/LibreELEC.tv/.fakeroot.build.LibreELEC-RPi.arm-8.0-devel: line 6: -ga0e3207.system: command not found
/home/neil/projects/LibreELEC.tv/.fakeroot.build.LibreELEC-RPi.arm-8.0-devel: line 7: -ga0e3207.system: command not found
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 127
```

It would choke on a space too. Quoting the variable solves the issue.