### PR TITLE
rtl8812au: fix AP timeout value patch

### DIFF
--- a/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-05-fix-AP-timeout.patch
+++ b/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-05-fix-AP-timeout.patch
@@ -17,7 +17,7 @@ index d1d5894..7dd78ad 100644
  //  This will increase the chance to receive the probe response from SoftAP.
  
 -#define SURVEY_TO       (100)
-+#define SURVEY_TO       (0)
++#define SURVEY_TO       (150)
  #define REAUTH_TO       (300) //(50)
  #define REASSOC_TO      (300) //(50)
  //#define DISCONNECT_TO (3000)


### PR DESCRIPTION
This corrects the patch in #654 with an increased timeout value instead of deleting it.