### PR TITLE
peripheral.joystick: API versions out of alignment, temp fix

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/patches/peripheral.joystick-01-temp-fix-until-versions-aligned.patch
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/patches/peripheral.joystick-01-temp-fix-until-versions-aligned.patch
@@ -1,0 +1,13 @@
+diff --git a/peripheral.joystick/addon.xml.in b/peripheral.joystick/addon.xml.in
+index ac7b715..480d53c 100644
+--- a/peripheral.joystick/addon.xml.in
++++ b/peripheral.joystick/addon.xml.in
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <addon
+   id="peripheral.joystick"
+-  version="1.1.0"
++  version="1.1.1"
+   name="Joystick Support"
+   provider-name="Team-Kodi">
+   <requires>


### PR DESCRIPTION
`peripheral.joystick` version 1.1.0 is in the current repo and requires kodi.peripheral 1.0.17 (provided by Kodi 17a3).

`peripheral.joystick` version 1.1.0 is the version we are building for Kodi 17b1, and this requires kodi.peripheral 1.0.19 (provided by Kodi 17b1).

The repo takes precedence over the built-in add-on, leading to an incompatibility warning and broken add-on even though the built-in add-on is otherwise compatible.

Bumping the `peripheral.joystick` built-in version allows us to ignore the repo version (I'm not entirely sure why we have add-ons in the repo when we ship them built-in, but that's for another time).

The Kodi17 beta2 version of `peripheral.joystick` will be 1.2.0, so there should be no issues when we remove this patch and bump to the next version with Kodi 17 beta2.