### PR TITLE
emby: update and rebuild ffmpegx

### DIFF
--- a/packages/addons/addon-depends/emby-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/emby-depends/ffmpegx/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="ffmpegx"
 PKG_VERSION="libreelec"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"

--- a/packages/addons/service/emby/changelog.txt
+++ b/packages/addons/service/emby/changelog.txt
@@ -1,3 +1,7 @@
+8.0.104
+- Updated to version 3.0.6300
+- Rebuilt ffmpegx
+
 8.0.103
 - Updated to version 3.0.6070
 - Build for all architectures

--- a/packages/addons/service/emby/package.mk
+++ b/packages/addons/service/emby/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="emby"
-PKG_VERSION="3.0.6070"
-PKG_REV="103"
+PKG_VERSION="3.0.6300"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://emby.media"


### PR DESCRIPTION
Wow!
The latest xbmc/ffmpeg release significantly improves h264 omx transcoding performance on RPi.
CPU usage is reduced from ~400% to ~200% on a RPi 3.
Transcoded stream is however still displayed on the screen.