### PR TITLE
kodi: Temporarily revert PR10247 for Kodi 17 beta1 due to OOM

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.99-Revert-PR10247.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99-Revert-PR10247.patch
@@ -1,0 +1,103 @@
+commit 62fa4175cb82e40ea3b67887f08d1f9424aa8a8d
+Author: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date:   Wed Aug 31 04:37:27 2016
+
+    Revert "VideoPlayer: passthrough fixes"
+    
+    This reverts commit 14af37aac18b0f471694dac7c65a96d39afaf327.
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+index 3af25db..8009297 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+@@ -27,10 +27,6 @@
+ 
+ #include "cores/AudioEngine/AEFactory.h"
+ 
+-extern "C" {
+-#include "libavcodec/avcodec.h"
+-}
+-
+ #define TRUEHD_BUF_SIZE 61440
+ 
+ CDVDAudioCodecPassthrough::CDVDAudioCodecPassthrough(CProcessInfo &processInfo) :
+@@ -118,7 +114,6 @@ void CDVDAudioCodecPassthrough::Dispose()
+ int CDVDAudioCodecPassthrough::Decode(uint8_t* pData, int iSize, double dts, double pts)
+ {
+   int used = 0;
+-  int skip = 0;
+   if (m_backlogSize)
+   {
+     if (m_currentPts == DVD_NOPTS_VALUE)
+@@ -132,25 +127,12 @@ int CDVDAudioCodecPassthrough::Decode(uint8_t* pData, int iSize, double dts, dou
+     m_bufferSize = std::max(m_bufferSize, m_dataSize);
+     if (consumed != m_backlogSize)
+     {
+-      memmove(m_backlogBuffer, m_backlogBuffer+consumed, m_backlogSize-consumed);
++      memmove(m_backlogBuffer, m_backlogBuffer+consumed, consumed);
+       m_backlogSize -= consumed;
+     }
+   }
+ 
+-  // get rid of potential side data
+-  if (pData)
+-  {
+-    AVPacket pkt;
+-    av_init_packet(&pkt);
+-    pkt.data = pData;
+-    pkt.size = iSize;
+-    av_packet_split_side_data(&pkt);
+-    skip = iSize - pkt.size;
+-    pData = pkt.data;
+-    iSize = pkt.size;
+-  }
+-
+-  if (pData && !m_backlogSize)
++  if (pData && !m_dataSize)
+   {
+     if (iSize <= 0)
+       return 0;
+@@ -187,20 +169,6 @@ int CDVDAudioCodecPassthrough::Decode(uint8_t* pData, int iSize, double dts, dou
+   if (!m_dataSize)
+     return used;
+ 
+-  if (m_dataSize)
+-  {
+-    m_format.m_dataFormat = AE_FMT_RAW;
+-    m_format.m_streamInfo = m_parser.GetStreamInfo();
+-    m_format.m_sampleRate = m_parser.GetSampleRate();
+-    m_format.m_frameSize = 1;
+-    CAEChannelInfo layout;
+-    for (unsigned int i=0; i<m_parser.GetChannels(); i++)
+-    {
+-      layout += AE_CH_RAW;
+-    }
+-    m_format.m_channelLayout = layout;
+-  }
+-
+   if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
+   {
+     if (!m_trueHDoffset)
+@@ -222,7 +190,21 @@ int CDVDAudioCodecPassthrough::Decode(uint8_t* pData, int iSize, double dts, dou
+       m_dataSize = 0;
+   }
+ 
+-  return used + skip;
++  if (m_dataSize)
++  {
++    m_format.m_dataFormat = AE_FMT_RAW;
++    m_format.m_streamInfo = m_parser.GetStreamInfo();
++    m_format.m_sampleRate = m_parser.GetSampleRate();
++    m_format.m_frameSize = 1;
++    CAEChannelInfo layout;
++    for (unsigned int i=0; i<m_parser.GetChannels(); i++)
++    {
++      layout += AE_CH_RAW;
++    }
++    m_format.m_channelLayout = layout;
++  }
++
++  return used;
+ }
+ 
+ void CDVDAudioCodecPassthrough::GetData(DVDAudioFrame &frame)


### PR DESCRIPTION
See https://github.com/xbmc/xbmc/pull/10247

@FernetMenta is on holiday and with the imminent release of 7.90.005 it would be better to revert PR10247. There is a partial fix, https://github.com/xbmc/xbmc/pull/10367, however seeking remains a bit off in which case from the user experience point of view reverting the entire change is best.

The OOM issue will no doubt be fixed (in Kodi 17 Beta2) once fernet returns from holiday in which case this can be dropped from 7.90.006/LE8b1.

Close if not wanted.