### PR TITLE
tvheadend42: update to 4.1.2236

### DIFF
--- a/packages/addons/service/tvheadend42/changelog.txt
+++ b/packages/addons/service/tvheadend42/changelog.txt
@@ -1,3 +1,8 @@
+8.0.105
+- update to Tvheadend 4.1.2236
+- fixes picons download from Tvh server
+- fixes empty/incomplete frequency scan-tables
+
 8.0.104
 - update to Tvheadend 4.1.2195
 - added TRACE debug option at the addon config

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="tvheadend42"
-PKG_VERSION="65dfd15"
-PKG_VERSION_NUMBER="4.1.2195"
-PKG_REV="104"
+PKG_VERSION="817f67e"
+PKG_VERSION_NUMBER="4.1.2236"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"


### PR DESCRIPTION
- update to Tvheadend 4.1.2236
- fixes picons download from Tvh server
- fixes empty/incomplete frequency scan-tables