### PR TITLE
vdr: fix NULL pointer segfault

### DIFF
--- a/packages/addons/addon-depends/vdr/patches/vdr-30_fix-dvbname-segfault.patch
+++ b/packages/addons/addon-depends/vdr/patches/vdr-30_fix-dvbname-segfault.patch
@@ -1,0 +1,41 @@
+--- vdr-2.2.0/dvbdevice.c.org	2015-01-14 13:09:19.000000000 +0100
++++ vdr-2.2.0/dvbdevice.c	2016-06-25 15:50:40.619609021 +0200
+@@ -1089,6 +1089,17 @@
+   NULL
+   };
+ 
++#define NUMDELIVERYSYSTEMNAMES (sizeof(DeliverySystemNames)/sizeof(*DeliverySystemNames)-1)
++
++const char *GetDeliverySystemName(int n)
++{
++  if (n < 0 || n >= NUMDELIVERYSYSTEMNAMES)
++     return DeliverySystemNames[0];
++
++  return DeliverySystemNames[n];
++}
++
++
+ cDvbDevice::cDvbDevice(int Adapter, int Frontend)
+ {
+   adapter = Adapter;
+@@ -1185,9 +1196,9 @@
+ {
+   if (dvbTuner) {
+      if (dvbTuner->FrontendType() != SYS_UNDEFINED)
+-        return DeliverySystemNames[dvbTuner->FrontendType()];
++        return GetDeliverySystemName(dvbTuner->FrontendType());
+      if (numDeliverySystems)
+-        return DeliverySystemNames[deliverySystems[0]]; // to have some reasonable default
++        return GetDeliverySystemName(deliverySystems[0]); // to have some reasonable default
+      }
+   return "";
+ }
+@@ -1318,7 +1329,7 @@
+   if (numDeliverySystems > 0) {
+      cString ds("");
+      for (int i = 0; i < numDeliverySystems; i++)
+-         ds = cString::sprintf("%s%s%s", *ds, i ? "," : "", DeliverySystemNames[deliverySystems[i]]);
++         ds = cString::sprintf("%s%s%s", *ds, i ? "," : "", GetDeliverySystemName(deliverySystems[i]));
+      cString ms("");
+      if (frontendInfo.caps & FE_CAN_QPSK)      { numModulations++; ms = cString::sprintf("%s%s%s", *ms, **ms ? "," : "", MapToUserString(QPSK, ModulationValues)); }
+      if (frontendInfo.caps & FE_CAN_QAM_16)    { numModulations++; ms = cString::sprintf("%s%s%s", *ms, **ms ? "," : "", MapToUserString(QAM_16, ModulationValues)); }


### PR DESCRIPTION
VDR segfaults when initializing a DVB-C2 capable device.

The patch limits access to available DeliverySystemNames[] elements.
