### PR TITLE
aarch64: define CPU extensions project-wise

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -14,7 +14,6 @@
       TARGET_SUBARCH=aarch64
       TARGET_VARIANT=armv8-a
       TARGET_ABI=eabi
-      TARGET_CPU_FLAGS="+crc+crypto"
       TARGET_EXTRA_FLAGS="-mcpu=${TARGET_CPU}${TARGET_CPU_FLAGS}"
       SIMD_SUPPORT="yes"
       ;;

--- a/projects/Odroid_C2/options
+++ b/projects/Odroid_C2/options
@@ -18,6 +18,7 @@
         # arm1176jz-s arm1176jzf-s cortex-a8 cortex-a9 cortex-r4
         # cortex-r4f cortex-m3 cortex-m1 xscale iwmmxt iwmmxt2 ep9312.
         TARGET_CPU="cortex-a53"
+        TARGET_CPU_FLAGS="+crc+fp+simd"
         ;;
     esac
 

--- a/projects/WeTek_Hub/options
+++ b/projects/WeTek_Hub/options
@@ -19,6 +19,7 @@
         # cortex-r4f cortex-m3 cortex-m1 xscale iwmmxt iwmmxt2 ep9312.
         #
         TARGET_CPU="cortex-a53"
+        TARGET_CPU_FLAGS="+crc+fp+simd"
         ;;
     esac
 


### PR DESCRIPTION
S905 does not support crypto extensions, while other aarch64 CPUs may implement them.
Solution: define CPU extensions project-wise.