### PR TITLE
system-tools: fix hddtemp

### DIFF
--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -97,6 +97,7 @@ addon() {
 
     # hddtemp
     cp -P $(get_build_dir hddtemp)/.$TARGET_NAME/src/hddtemp $ADDON_BUILD/$PKG_ADDON_ID/bin
+    cp -P $(get_build_dir hddtemp)/debian/hddtemp.db $ADDON_BUILD/$PKG_ADDON_ID/data
 
     # hd-idle
     cp -P $(get_build_dir hd-idle)/hd-idle $ADDON_BUILD/$PKG_ADDON_ID/bin


### PR DESCRIPTION
install hddtemp database to get rid of:

htpc:~ # hddtemp /dev/sda
hddtemp: can't open /storage/.kodi/addons/virtual.system-tools/data/hddtemp.db: No such file or directory
