### PR TITLE
system-tools: mrxvt: set terminal type to "xterm"

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/mrxvt/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mrxvt/package.mk
@@ -64,7 +64,8 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_setpgrp_void=no \
             --disable-use-fifo \
             --disable-greek \
             --disable-xim \
-            --disable-utempter"
+            --disable-utempter\
+            --with-term=xterm"
 
 makeinstall_target() {
   : # nop

--- a/packages/addons/addon-depends/system-tools-depends/mrxvt/patches/mrxvt-01_xterm.patch
+++ b/packages/addons/addon-depends/system-tools-depends/mrxvt/patches/mrxvt-01_xterm.patch
@@ -1,0 +1,11 @@
+--- mrxvt-0.5.4/src/rxvt.h.org	2008-08-04 09:41:35.000000000 +0200
++++ mrxvt-0.5.4/src/rxvt.h	2016-05-24 19:23:28.000000000 +0200
+@@ -631,7 +631,7 @@
+ #define APL_NAME	"mrxvt"	/* normal name */
+ 
+ /* COLORTERM, TERM environment variables */
+-#define COLORTERMENV	"rxvt"
++#define COLORTERMENV	"xterm"
+ #ifdef BACKGROUND_IMAGE
+ # define COLORTERMENVFULL COLORTERMENV "-xpm"
+ #else


### PR DESCRIPTION
The default "rxvt" terminal type is not available in LE