### PR TITLE
system-tools: optional start mrxvt from kodi

### DIFF
--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,2 +1,7 @@
+8.0.101
+- mrxvt can be started from KODI
+- correct mrxvt terminal type
+- make hddtemp work
+
 8.0.100
 - Initial Release

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION=""
-PKG_REV="100"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""

--- a/packages/addons/tools/system-tools/source/default.py
+++ b/packages/addons/tools/system-tools/source/default.py
@@ -17,6 +17,9 @@
 ################################################################################
 
 import xbmcgui
+import subprocess
 
-dialog = xbmcgui.Dialog()
-dialog.ok('', 'This is a console-only addon')
+yes = xbmcgui.Dialog().yesno('', 'This is a console-only addon','','Open a terminal window?','No','Yes')
+if yes:
+  subprocess.Popen(["systemd-run","sh","-c",". /etc/profile;exec mrxvt"], shell=False, close_fds=True)
+


### PR DESCRIPTION
Have the ability to open a mrxvt terminal window from kodi when selecting addon