### PR TITLE
scripts/unpack: clean unpatched packages

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -52,6 +52,11 @@ for i in $BUILD/$1-*; do
   fi
 done
 
+if [ -d "$PKG_BUILD" -a ! -f "$STAMP" ]; then
+  # stale pkg build dir
+  $SCRIPTS/clean $1
+fi
+
 [ -f "$STAMP" ] && exit 0
 
 printf "%${BUILD_INDENT}c ${boldcyan}UNPACK${endcolor}   $1\n" ' '>&$SILENT_OUT


### PR DESCRIPTION
This fixes an unpack annoyance after patches has failed to apply.

With this the unpack script will clean a package the second time build/unpack is run after a patch has failed to apply instead of trying to apply patches a second time.