### PR TITLE
projects/WeTek_Hub/patches/kodi: use poweroff instead of suspend

### DIFF
--- a/projects/WeTek_Hub/patches/kodi/0004-powermanagement-disable-suspend.patch
+++ b/projects/WeTek_Hub/patches/kodi/0004-powermanagement-disable-suspend.patch
@@ -1,12 +1,3 @@
-From 5095bcfcb4bf235855f2474ff229a95c8f20fc2d Mon Sep 17 00:00:00 2001
-From: Alex Deryskyba <alex@codesnake.com>
-Date: Tue, 14 Jul 2015 16:02:35 +0300
-Subject: [PATCH 4/5] [powermanagement] Perform suspend instead of powerdown
-
----
- xbmc/powermanagement/linux/LogindUPowerSyscall.cpp |    4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
 diff --git a/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp b/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
 index 4e5bcc6..ad5847d 100644
 --- a/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
@@ -20,15 +11,3 @@ index 4e5bcc6..ad5847d 100644
  
    InhibitDelayLock();
  
-@@ -98,7 +98,7 @@ CLogindUPowerSyscall::~CLogindUPowerSyscall()
- 
- bool CLogindUPowerSyscall::Powerdown()
- {
--  return LogindSetPowerState("PowerOff");
-+  return Suspend();
- }
- 
- bool CLogindUPowerSyscall::Reboot()
--- 
-1.7.10.4
-


### PR DESCRIPTION
This changes to use poweroff instead of suspend when selecting 'Power off system' in Kodi, the wifi driver causes a kernel crash on suspend.

The device can be powered back on using the power button on the remote.