### PR TITLE
projects/WeTek_Hub: Map Home button on IR remote to KEY_HOME

### DIFF
--- a/projects/WeTek_Hub/filesystem/etc/amremote/remote.conf
+++ b/projects/WeTek_Hub/filesystem/etc/amremote/remote.conf
@@ -50,15 +50,15 @@ mouse_begin
 mouse_end
 
 key_begin
-    0xf1 116
-    0xf2 102
-    0xf4 103
-    0xf5 108
-    0xf6 105
-    0xf7 106
-    0xf8 28
-    0xf9 1
-    0xfa 46
-    0xfb 115
-    0xfc 114
+    0xf1 116 ; Power
+    0xf2 102 ; Home
+    0xf4 103 ; Up
+    0xf5 108 ; Down
+    0xf6 105 ; Left
+    0xf7 106 ; Right
+    0xf8 28  ; OK
+    0xf9 1   ; Back
+    0xfa 46  ; Menu
+    0xfb 115 ; Volume Up
+    0xfc 114 ; Volume Down
 key_end

--- a/projects/WeTek_Hub/filesystem/etc/amremote/remote.conf
+++ b/projects/WeTek_Hub/filesystem/etc/amremote/remote.conf
@@ -51,7 +51,7 @@ mouse_end
 
 key_begin
     0xf1 116
-    0xf2 388
+    0xf2 102
     0xf4 103
     0xf5 108
     0xf6 105


### PR DESCRIPTION
Map Home button on WeTek Hub's IR remote to KEY_HOME and add button labels to the IR remote config file.