### PR TITLE
scripts/mkimage: Add run mode, remember default selection, resize gpt…

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -51,7 +51,7 @@ if [ -e /storage/.please_resize_me ] ; then
   # just in case
   if [ ! -z "$DISK" -a ! -z "$PART" ] ; then
     # get storage partition start
-    PART_START=$(parted -s -m $DISK unit b print |grep -v ^/dev |grep -v BYT | grep ^2: |  cut -f2 -d ":")
+    PART_START=$(parted -s -m $DISK unit b print 2>/dev/null | grep -v ^/dev | grep -v BYT | grep ^2: |  cut -f2 -d ":")
 
     # failed to get partition start offset ?
     if [ ! -z "$PART_START" ] ; then
@@ -62,6 +62,9 @@ if [ -e /storage/.please_resize_me ] ; then
       echo "Please do not reboot or turn off your @DISTRONAME@ device!"
       echo ""
 
+      # fix any minor issues, such as gpt header not at end of disk
+      StartProgress spinner "Checking layout...   " "parted $DISK print fix &>/dev/null"
+
       StartProgress spinner "Deleting /storage... " "parted -s -m $DISK rm 2 &>/dev/null"
       StartProgress spinner "Creating /storage... " "parted -s -m $DISK unit b mkpart primary $PART_START 100% &>/dev/null"
       StartProgress spinner "Checking /storage... " "e2fsck -f -p $PART &>/dev/null"
@@ -71,4 +74,4 @@ if [ -e /storage/.please_resize_me ] ; then
     fi
   fi
 fi
-reboot -f
+reboot -f &>/dev/null

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -52,6 +52,7 @@
   MD5_FAILED="0"
   RUN_FSCK="yes"
   RUN_FSCK_DISKS=""
+  SYSLINUX_DEFAULT=""
 
   NBD_DEVS="0"
   FLASH_FREE_MIN="5"
@@ -125,6 +126,7 @@
         ;;
       installer)
         INIT_UNIT="--unit=installer.target"
+        SYSLINUX_DEFAULT="installer"
         ;;
       debugging)
         DEBUG=yes
@@ -144,6 +146,10 @@
         ;;
       live)
         LIVE=yes
+        SYSLINUX_DEFAULT="live"
+        ;;
+      portable)
+        SYSLINUX_DEFAULT="run"
         ;;
       overlay)
         OVERLAY=yes
@@ -620,6 +626,24 @@
     fi
   }
 
+  # Make last bootloader label (installer, live, run etc.) as the new default
+  update_syslinux() {
+    local crnt_default
+
+    if [ -n "$SYSLINUX_DEFAULT" -a -f /flash/syslinux.cfg ]; then
+      if grep -q "^LABEL $SYSLINUX_DEFAULT\$" /flash/syslinux.cfg; then
+        crnt_default="$(awk '/^DEFAULT/ {print $2}' /flash/syslinux.cfg)"
+        if [ ! "$crnt_default" = "$SYSLINUX_DEFAULT" ]; then
+          progress "Updating /flash/syslinux.cfg [$crnt_default -> $SYSLINUX_DEFAULT]"
+
+          mount -o remount,rw /flash
+          sed -i "s/^DEFAULT .*/DEFAULT $SYSLINUX_DEFAULT/" /flash/syslinux.cfg
+          mount -o remount,ro /flash
+        fi
+      fi
+    fi
+  }
+
   check_out_of_space() {
     if [ "$(df /storage | awk '/[0-9]%/{print $4}')" -eq "0" ]; then
       echo ""
@@ -914,6 +938,7 @@
       load_modules \
       check_disks \
       mount_flash \
+      update_syslinux \
       load_splash \
       mount_storage \
       check_update \

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -126,7 +126,7 @@ if [ "$BOOTLOADER" = "syslinux" ]; then
   # create bootloader configuration
     echo "image: creating bootloader configuration..."
     cat << EOF > "$OE_TMP"/syslinux.cfg
-SAY Press <TAB> to edit options
+SAY Press <TAB> to edit options (installer, live, run)
 DEFAULT installer
 TIMEOUT 50
 PROMPT 1
@@ -138,6 +138,10 @@ LABEL installer
 LABEL live
   KERNEL /$KERNEL_NAME
   APPEND boot=UUID=$UUID_SYSTEM live quiet tty vga=current
+
+LABEL run
+  KERNEL /$KERNEL_NAME
+  APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE portable quiet
 EOF
 
   if [ "$PROJECT" = Virtual ]; then
@@ -277,14 +281,12 @@ fi # bootloader
   sync
 
 # add resize mark
-  if [ "$BOOTLOADER" != "syslinux" -o "$PROJECT" = Virtual ]; then
-    mkdir "$OE_TMP/part2.fs"
-    touch "$OE_TMP/part2.fs/.please_resize_me"
-    echo "image: populating filesystem on part2..."
-    populatefs -U -d "$OE_TMP/part2.fs" "$OE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
-    sync
-    e2fsck -n "$OE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
-  fi
+  mkdir "$OE_TMP/part2.fs"
+  touch "$OE_TMP/part2.fs/.please_resize_me"
+  echo "image: populating filesystem on part2..."
+  populatefs -U -d "$OE_TMP/part2.fs" "$OE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+  sync
+  e2fsck -n "$OE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
 
 # merge part2 back to disk image
   echo "image: merging part2 back to image..."


### PR DESCRIPTION
… partitions

This has been discussed previously (#582).

The `run` mode will persist storage across boots, and can be useful as a "portable" solution, or when the `live` mode (which doesn't persist any storage) is not enough but users still don't want a full/permanent installation.

The last selected option (`installer`, `live`, `run`) will be remembered, simplifying subsequent boots (particularly without a keyboard) - ie. if you boot once into `run` mode, next time you boot the default boot will be `run` etc. There will still be a 5 second prompt for every boot.

Resizing of gpt partitions is now fixed, and they should be resized correctly. The first time `run` is selected it will resize the `/storage` partition on the USB drive.