### PR TITLE
libcec: shouldn't have dropped PR208

### DIFF
--- a/packages/devel/libcec/patches/libcec-PR208.patch
+++ b/packages/devel/libcec/patches/libcec-PR208.patch
@@ -1,0 +1,38 @@
+From f70c4d76e1d9c0219a3927b6b66090b7575e7933 Mon Sep 17 00:00:00 2001
+From: Gerald Dachs <gda@dachsweb.de>
+Date: Thu, 17 Mar 2016 12:12:51 +0100
+Subject: [PATCH] use system audio mode request instead of power on to start
+ AVR reliable
+
+---
+ src/libcec/devices/CECBusDevice.cpp | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/src/libcec/devices/CECBusDevice.cpp b/src/libcec/devices/CECBusDevice.cpp
+index 55939d1..e2d5ea3 100644
+--- a/src/libcec/devices/CECBusDevice.cpp
++++ b/src/libcec/devices/CECBusDevice.cpp
+@@ -1025,14 +1025,19 @@ bool CCECBusDevice::ActivateSource(uint64_t iDelay /* = 0 */)
+   bool bReturn(true);
+   if (iDelay == 0)
+   {
+-    /** some AVRs fail to be powered up by the TV when it powers up. power up the AVR explicitly */
++    /** send system audio mode request if AVR exists */
+     if (m_iLogicalAddress != CECDEVICE_AUDIOSYSTEM)
+     {
+       CCECBusDevice* audioSystem(m_processor->GetDevice(CECDEVICE_AUDIOSYSTEM));
+-      if (audioSystem && audioSystem->IsPresent() && audioSystem->GetPowerStatus(m_iLogicalAddress) != CEC_POWER_STATUS_ON)
++      if (audioSystem && audioSystem->IsPresent())
+       {
+-        LIB_CEC->AddLog(CEC_LOG_DEBUG, "powering up the AVR");
+-        audioSystem->PowerOn(m_iLogicalAddress);
++        cec_command command;
++
++        LIB_CEC->AddLog(CEC_LOG_DEBUG, "sending system audio mode request for '%s'", ToString(m_iLogicalAddress));
++        cec_command::Format(command, m_iLogicalAddress, CECDEVICE_AUDIOSYSTEM, CEC_OPCODE_SYSTEM_AUDIO_MODE_REQUEST);
++        command.parameters.PushBack((uint8_t) ((m_iPhysicalAddress >> 8) & 0xFF));
++        command.parameters.PushBack((uint8_t) (m_iPhysicalAddress & 0xFF));
++        bReturn = m_handler->Transmit(command, false, false);
+       }
+     }
+ 


### PR DESCRIPTION
Shouldn't have dropped this. I had it marked as "merged upstream" but only because I'm already building with latest libcec unreleased master - LibreELEC still needs this.