### PR TITLE
Cleanup advanced settings in WeTek projects

### DIFF
--- a/projects/WeTek_Core/kodi/advancedsettings.xml
+++ b/projects/WeTek_Core/kodi/advancedsettings.xml
@@ -5,9 +5,4 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
-
-  <pvr>
-    <minvideocachelevel>5</minvideocachelevel>
-    <minaudiocachelevel>20</minaudiocachelevel>
-  </pvr>
 </advancedsettings>

--- a/projects/WeTek_Hub/kodi/advancedsettings.xml
+++ b/projects/WeTek_Hub/kodi/advancedsettings.xml
@@ -6,9 +6,5 @@
     <clienttimeout>30</clienttimeout>
   </samba>
 
-  <network>
-    <readbufferfactor>4.0</readbufferfactor>
-  </network>
-
   <loglevel>2</loglevel>
 </advancedsettings>

--- a/projects/WeTek_Hub/kodi/advancedsettings.xml
+++ b/projects/WeTek_Hub/kodi/advancedsettings.xml
@@ -10,10 +10,5 @@
     <readbufferfactor>4.0</readbufferfactor>
   </network>
 
-  <pvr>
-    <minvideocachelevel>5</minvideocachelevel>
-    <minaudiocachelevel>20</minaudiocachelevel>
-  </pvr>
-
   <loglevel>2</loglevel>
 </advancedsettings>

--- a/projects/WeTek_Hub/kodi/advancedsettings.xml
+++ b/projects/WeTek_Hub/kodi/advancedsettings.xml
@@ -5,6 +5,4 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
-
-  <loglevel>2</loglevel>
 </advancedsettings>

--- a/projects/WeTek_Play/kodi/advancedsettings.xml
+++ b/projects/WeTek_Play/kodi/advancedsettings.xml
@@ -5,9 +5,4 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
-
-  <pvr>
-    <minvideocachelevel>5</minvideocachelevel>
-    <minaudiocachelevel>20</minaudiocachelevel>
-  </pvr>
 </advancedsettings>


### PR DESCRIPTION
Remove settings that are not needed anymore from default advancedsettings.xml in WeTek projects.