### PR TITLE
RBP: include missing libelftoolchain.so

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -89,6 +89,7 @@ makeinstall_target() {
     ln -s dtoverlay $INSTALL/usr/bin/dtparam
     cp -PRv $FLOAT/opt/vc/bin/vcdbg $INSTALL/usr/bin
     cp -PRv $FLOAT/opt/vc/lib/libdebug_sym.so $INSTALL/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libelftoolchain.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/bin/vcgencmd $INSTALL/usr/bin
     cp -PRv $FLOAT/opt/vc/bin/tvservice $INSTALL/usr/bin
     cp -PRv $FLOAT/opt/vc/bin/edidparser $INSTALL/usr/bin


### PR DESCRIPTION
Since https://github.com/raspberrypi/firmware/commit/83dc067c60fd3f66eda1114eab23e45f57be387d we now need this support library, otherwise...:
```
rpi22:~ # vcdbg log msg 2>&1
vcdbg: error while loading shared libraries: libelftoolchain.so: cannot open shared object file: No such file or directory
```

@chewitt: Only `vcdbg` seems to be affected. No brainer for 7.90.006, but not exactly essential either.