### PR TITLE
peripheral-joystick: bump to abff316

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -18,6 +18,7 @@
 
 PKG_NAME="peripheral.joystick"
 PKG_VERSION="263aa84"
+PKG_VERSION="abff316"
 PKG_REV="0"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
https://github.com/kodi-game/peripheral.joystick/pull/53 fixes weird stack-smashing crashes on RPi2.

Might be useful to have in 7.90.006.