### PR TITLE
kodi-binary-addons: bump pvr.stalker and fix peripheral.joystick pkg

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -17,7 +17,6 @@
 ################################################################################
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="263aa84"
 PKG_VERSION="abff316"
 PKG_REV="0"
 PKG_ARCH="any"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="7df63b2"
+PKG_VERSION="168e35f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
No rebuild of v7.90.006 is required for perhipheral.joystick as the second PKG_VERSION value overwrote the first and built images contain the correct version. Thanks to @MartijnKaijser for spotting :)

pvr.stalker avoids some crash reports reported in Kodi forums.