### PR TITLE
init: synchronise UEFI and legacy syslinux.cfg updates

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -698,6 +698,7 @@
 
           mount -o remount,rw /flash
           sed -i "s/^DEFAULT .*/DEFAULT $SYSLINUX_DEFAULT/" /flash/syslinux.cfg
+          [ -f /flash/EFI/BOOT/syslinux.cfg ] && cp /flash/syslinux.cfg /flash/EFI/BOOT/syslinux.cfg
           mount -o remount,ro /flash
         fi
       fi


### PR DESCRIPTION
Legacy boots with `/flash/syslinux.cfg`
UEFI boots with `/flash/EFI/BOOT/syslinux.cfg`

This change keeps the two in sync.