### PR TITLE
toolchain: only setup_toolchain target when building

### DIFF
--- a/config/path
+++ b/config/path
@@ -186,8 +186,6 @@ VERSION_SUFFIX=$TARGET_ARCH
 check_path
 check_config
 
-setup_toolchain target
-
 SILENT_OUT=3
 VERBOSE_OUT=4
 if [ "$VERBOSE" = yes ]; then

--- a/scripts/build
+++ b/scripts/build
@@ -20,6 +20,8 @@
 
 . config/options $1
 
+setup_toolchain target
+
 if [ -z "$1" ]; then
   echo "usage: $0 package_name[:<host|target|init|bootstrap>]"
   exit 1

--- a/scripts/image
+++ b/scripts/image
@@ -22,6 +22,8 @@
 
 show_config
 
+setup_toolchain target
+
 $SCRIPTS/checkdeps
 $SCRIPTS/build toolchain
 $SCRIPTS/build squashfs:host


### PR DESCRIPTION
Calling `setup_toolchain target` from `path` results in `$ROOT/$TOOLCHAIN/etc/cmake-$TARGET_NAME.conf` being the first time `options` is sourced, which may happen when a build isn't taking place, or before all build variables are defined (eg. `BUILD_SUFFIX`, which causes the conf to be written into the wrong build directory).

With this change we only call `setup_toolchain target` when actually building, by which time all variables needed should be correctly setup.

Also, this should be more efficient, as `options` is sourced thousands of times during a build.