### PR TITLE
path: optimize package processing

### DIFF
--- a/config/path
+++ b/config/path
@@ -74,49 +74,58 @@ SED="sed -i"
   PKG_IS_ADDON="no"
 
   if [ -n "$1" ]; then
-    _PKG_ROOT_NAME=$(echo $1 | cut -d: -f1)
+    _PKG_ROOT_NAME=${1%:*}
     _ALL_DIRS=""
     _FOUND=0
     PKG_DIR=""
 
-    # check project folder for a package if not found already
-    for DIR in $(find $ROOT/projects/$PROJECT/packages -type d -name $_PKG_ROOT_NAME 2>/dev/null); do
-      if [ -r "$DIR/package.mk" ]; then
+    # If the package caches are unset, then populate them
+    if [ -z "${_CACHE_PACKAGE_LOCAL+x}" -o -z "${_CACHE_PACKAGE_GLOBAL+x}" ]; then
+      _CACHE_PACKAGE_LOCAL=""
+      _CACHE_PACKAGE_GLOBAL=""
+
+      # cache project folder for a package
+      for DIR in $(find $ROOT/projects/$PROJECT/packages -type d 2>/dev/null); do
+        [ -r "$DIR/package.mk" ] && _CACHE_PACKAGE_LOCAL+="${DIR}\n"
+      done
+
+      # cache packages folder
+      for DIR in $(find $ROOT/$PACKAGES -type d 2>/dev/null); do
+        [ -r "$DIR/package.mk" ] && _CACHE_PACKAGE_GLOBAL+="${DIR}\n"
+      done
+
+      export _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL
+    fi
+
+    # Check for any available local package in preference to a global package
+    for DIR in $(echo -e "${_CACHE_PACKAGE_LOCAL}" | grep -E "^.*/${_PKG_ROOT_NAME}\$"); do
+      # found first, set $PKG_DIR
+      PKG_DIR="$DIR"
+      # keep track of dirs with package.mk for detecting multiple folders
+      _ALL_DIRS+="${DIR}\n"
+      _FOUND=$((_FOUND+1))
+    done
+
+    # If there's no local package available, use the global package
+    if [ $_FOUND -eq 0 ]; then
+      for DIR in $(echo -e "${_CACHE_PACKAGE_GLOBAL}" | grep -E "^.*/${_PKG_ROOT_NAME}\$"); do
         # found first, set $PKG_DIR
         PKG_DIR="$DIR"
         # keep track of dirs with package.mk for detecting multiple folders
-        _ALL_DIRS="${_ALL_DIRS}${DIR}\\n"
+        _ALL_DIRS+="${DIR}\n"
         _FOUND=$((_FOUND+1))
-        if [ $_FOUND -gt 1 ]; then
-          # _FOUND more ? fail
-          echo "Error - multiple package folders:"
-          echo -e "$_ALL_DIRS"
-          exit 1
-        fi
-      fi
-    done
-
-    # then check packages folder if not found already
-    if [ $_FOUND -eq 0 ]; then
-      for DIR in $(find $ROOT/$PACKAGES -type d -name $_PKG_ROOT_NAME 2>/dev/null); do
-        if [ -r "$DIR/package.mk" ]; then
-          # found first, set $PKG_DIR
-          PKG_DIR="$DIR"
-          # keep track of dirs with package.mk for detecting multiple folders
-          _ALL_DIRS="${_ALL_DIRS}${DIR}\\n"
-          _FOUND=$((_FOUND+1))
-          if [ $_FOUND -gt 1 ]; then
-            # found more ? fail
-            echo "Error - multiple package folders:"
-            echo -e "$_ALL_DIRS"
-            exit 1
-          fi
-        fi
       done
+    fi
+
+    # _FOUND multiple packages? fail
+    if [ $_FOUND -gt 1 ]; then
+      echo "Error - multiple package folders:"
+      echo -e "$_ALL_DIRS"
+      exit 1
     fi
   fi
 
-  if [ -r $PKG_DIR/package.mk ]; then
+  if [ -n "$PKG_DIR" -a -r $PKG_DIR/package.mk ]; then
     . $PKG_DIR/package.mk
   fi
 

--- a/scripts/image
+++ b/scripts/image
@@ -18,6 +18,8 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
+unset _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL
+
 . config/options $1
 
 show_config


### PR DESCRIPTION
Every time `config/options` is sourced for a specific package, the entire repository (ie. disk) is scanned for various matching directories. This happens almost 1500 times during a build (typically, each package will source `config/options` at least 3 times - more if it actually requires building). On systems with slow or contended IO, this can add up to significant overhead.

With this change we build a cache of package directories that we can refer to without incurring any additional IO overhead.

On a dedicated system with an SSD and fast processor this change saves ~45 seconds of processing time. It may not sound a lot, but this is on a system with plenty of IO. On a system with contended spinning rust (ie. limited IO) and/or slower processor, it will hopefully result in a much greater saving.