### PR TITLE
xf86-video-ati: add xorg-radeon.conf to enable dri3 and glamor

### DIFF
--- a/packages/x11/driver/xf86-video-ati/config/xorg-radeon.conf
+++ b/packages/x11/driver/xf86-video-ati/config/xorg-radeon.conf
@@ -1,0 +1,6 @@
+Section "Device"
+        Identifier  "AMD Graphics"
+        Driver      "radeon"
+        Option      "DRI3"        "1"
+        Option      "AccelMethod" "glamor"
+Endsection

--- a/packages/x11/driver/xf86-video-ati/package.mk
+++ b/packages/x11/driver/xf86-video-ati/package.mk
@@ -32,3 +32,8 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-glamor --with-xorg-module-dir=$XORG_PATH_MODULES"
+
+post_makeinstall_target() {
+  mkdir -p $INSTALL/etc/X11
+    cp $PKG_DIR/config/*.conf $INSTALL/etc/X11
+}


### PR DESCRIPTION
@MilhouseVH would you be able to include this in some builds to see if there are any negative side effects for pre-GCN users?

/var/log/Xorg.0.log
```
[2085616.061] (**) RADEON(0): DRI3 enabled
[2085616.116] (II) RADEON(0): Use GLAMOR acceleration.
```