### PR TITLE
dvblast: fix build with aml-3.14

### DIFF
--- a/packages/addons/addon-depends/dvb-tools-depends/dvblast/patches/dvblast-0001-fe-caps-t.patch
+++ b/packages/addons/addon-depends/dvb-tools-depends/dvblast/patches/dvblast-0001-fe-caps-t.patch
@@ -1,0 +1,16 @@
+diff --git a/dvb.c b/dvb.c
+index d1c8409..52ff3c2 100644
+--- a/dvb.c
++++ b/dvb.c
+@@ -86,6 +86,11 @@ static void FrontendRead(struct ev_loop *loop, struct ev_io *w, int revents);
+ static void FrontendLockCb(struct ev_loop *loop, struct ev_timer *w, int revents);
+ static void FrontendSet( bool b_reset );
+ 
++// aml 3.14 is meh ?
++#ifndef fe_caps_t
++typedef enum fe_caps fe_caps_t;
++#endif
++
+ /*****************************************************************************
+  * dvb_Open
+  *****************************************************************************/


### PR DESCRIPTION
I'm unable to figure out this error

```
dvb.c:639:30: error: unknown type name 'fe_caps_t'
 static fe_code_rate_t GetFEC(fe_caps_t fe_caps, int i_fec_value)
```