### PR TITLE
bump libressl to 2.3.8

### DIFF
--- a/packages/security/libressl/package.mk
+++ b/packages/security/libressl/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libressl"
-PKG_VERSION="2.3.5"
+PKG_VERSION="2.3.8"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"


### PR DESCRIPTION
just some security updates.

http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.6-relnotes.txt
http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.7-relnotes.txt
http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.8-relnotes.txt