### PR TITLE
projects/*/options: disable lcdproc for all projects except Generic/Virtual

### DIFF
--- a/projects/Odroid_C2/options
+++ b/projects/Odroid_C2/options
@@ -110,6 +110,9 @@
   # build and install IRServer IR/LCD support (yes / no)
     IRSERVER_SUPPORT="no"
 
+  # "none" for disable LCD support
+    LCD_DRIVER="none"
+
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="no"
 

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -120,6 +120,9 @@
   # build and install IRServer IR/LCD support (yes / no)
     IRSERVER_SUPPORT="no"
 
+  # "none" for disable LCD support
+    LCD_DRIVER="none"
+
   # build with swap support (yes / no)
     SWAP_SUPPORT="yes"
 

--- a/projects/RPi2/options
+++ b/projects/RPi2/options
@@ -120,6 +120,9 @@
   # build and install IRServer IR/LCD support (yes / no)
     IRSERVER_SUPPORT="no"
 
+  # "none" for disable LCD support
+    LCD_DRIVER="none"
+
   # build with swap support (yes / no)
     SWAP_SUPPORT="yes"
 

--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -130,6 +130,9 @@
   # build and install IRServer IR/LCD support (yes / no)
     IRSERVER_SUPPORT="no"
 
+  # "none" for disable LCD support
+    LCD_DRIVER="none"
+
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="yes"
 

--- a/projects/WeTek_Hub/options
+++ b/projects/WeTek_Hub/options
@@ -118,6 +118,9 @@
   # build and install IRServer IR/LCD support (yes / no)
     IRSERVER_SUPPORT="no"
 
+  # "none" for disable LCD support
+    LCD_DRIVER="none"
+
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="yes"
 

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -124,6 +124,9 @@
   # build and install IRServer IR/LCD support (yes / no)
     IRSERVER_SUPPORT="no"
 
+  # "none" for disable LCD support
+    LCD_DRIVER="none"
+
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="yes"
 

--- a/projects/WeTek_Play_2/options
+++ b/projects/WeTek_Play_2/options
@@ -117,6 +117,9 @@
   # build and install IRServer IR/LCD support (yes / no)
     IRSERVER_SUPPORT="no"
 
+  # "none" for disable LCD support
+    LCD_DRIVER="none"
+
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="yes"
 

--- a/projects/imx6/options
+++ b/projects/imx6/options
@@ -145,6 +145,9 @@
   # build and install IRServer IR/LCD support (yes / no)
     IRSERVER_SUPPORT="no"
 
+  # "none" for disable LCD support
+    LCD_DRIVER="none"
+
   # build with swap support (yes / no)
     SWAP_SUPPORT="no"
 


### PR DESCRIPTION
It's not needed on any systems other than Generic as far as I know.

Please pipe up if you disagree.