### PR TITLE
xf86-video-intel: enable dri3 and make it default

### DIFF
--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -40,7 +40,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-backlight \
                            --enable-dri \
                            --disable-dri1 \
                            --enable-dri2 \
-                           --disable-dri3 \
+                           --enable-dri3 \
                            --enable-kms --enable-kms-only \
                            --disable-ums --disable-ums-only \
                            --enable-sna \
@@ -51,6 +51,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-backlight \
                            --disable-tear-free \
                            --disable-create2 \
                            --disable-async-swap \
+                           --with-default-dri=3 \
                            --with-xorg-module-dir=$XORG_PATH_MODULES"
 
 pre_configure_target() {


### PR DESCRIPTION
From extended community build by @escalade 
Should improve VNC