### PR TITLE
Network: smb & ntfs config mods

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -26,7 +26,7 @@
   netbios name = %h
   security = share
   guest account = root
-  socket options = TCP_NODELAY IPTOS_LOWDELAY SO_RCVBUF=65536 SO_SNDBUF=65536
+  socket options = TCP_NODELAY IPTOS_LOWDELAY
   smb ports = 445
   max protocol = SMB2
   min receivefile size = 16384

--- a/packages/sysutils/udevil/config/udevil.conf
+++ b/packages/sysutils/udevil/config/udevil.conf
@@ -221,7 +221,7 @@ default_options_vfat      = nosuid, noexec, nodev, noatime, fmask=0133, dmask=00
 default_options_exfat     = nosuid, noexec, nodev, noatime, utf8, nonempty
 default_options_msdos     = nosuid, noexec, nodev, noatime, fmask=0133, dmask=0022, uid=$UID, gid=$GID
 default_options_umsdos    = nosuid, noexec, nodev, noatime, fmask=0133, dmask=0022, uid=$UID, gid=$GID
-default_options_ntfs      = nosuid, noexec, nodev, noatime, fmask=0133, uid=$UID, gid=$GID, utf8
+default_options_ntfs      = nosuid, noexec, nodev, noatime, big_writes, fmask=0133, uid=$UID, gid=$GID, utf8
 default_options_cifs      = nosuid, noexec, nodev, uid=$UID, gid=$GID
 default_options_smbfs     = nosuid, noexec, nodev, uid=$UID, gid=$GID
 default_options_sshfs     = nosuid, noexec, nodev, noatime, uid=$UID, gid=$GID, nonempty, allow_other
@@ -242,7 +242,7 @@ default_options_ramfs     = nosuid, noexec, nodev, noatime, uid=$UID, gid=$GID
 # and GID.
 # If you want to forbid remounts, remove 'remount' from here.
 # WARNING:  OPTIONS HERE CAN CAUSE SERIOUS SECURITY PROBLEMS - CHOOSE CAREFULLY
-allowed_options           = nosuid, noexec, nodev, noatime, fmask=0133, dmask=0022, uid=$UID, gid=$GID, ro, rw, sync, flush, iocharset=*, utf8, remount
+allowed_options           = nosuid, noexec, nodev, noatime, big_writes, fmask=0133, dmask=0022, uid=$UID, gid=$GID, ro, rw, sync, flush, iocharset=*, utf8, remount
 allowed_options_nfs       = nosuid, noexec, nodev, noatime, ro, rw, sync, remount, port=*, rsize=*, wsize=*, hard, proto=*, timeo=*, retrans=*
 allowed_options_cifs      = nosuid, noexec, nodev, ro, rw, remount, port=*, user=*, username=*, pass=*, password=*, guest, domain=*, uid=$UID, gid=$GID, credentials=*
 allowed_options_smbfs     = nosuid, noexec, nodev, ro, rw, remount, port=*, user=*, username=*, pass=*, password=*, guest, domain=*, uid=$UID, gid=$GID, credentials=*


### PR DESCRIPTION
AML S905 ODROID C2 users were complaining about slow transfers over SMB and slow speeds writing to connected USB2.0 -  NTFS formatted HDD's,  so a C2 user **@infinity85** suggested some config tweaking might help:

The conversation and test results start from this post onwards:
http://forum.odroid.com/viewtopic.php?f=144&t=23405#p161855 

This may benefit other LE platforms.