### PR TITLE
tvheadend42: wizard fix + general config updates

### DIFF
--- a/packages/addons/service/tvheadend42/source/defaults/config
+++ b/packages/addons/service/tvheadend42/source/defaults/config
@@ -1,6 +1,7 @@
 {
+	"wizard": "hello",
 	"uilevel": 1,
-	"uilevel_nochange": false,
+	"uilevel_nochange": true,
 	"ui_quicktips": true,
 	"cookie_expires": 14,
 	"caclient_ui": true,

--- a/packages/addons/service/tvheadend42/source/defaults/dvr/config/8d0f5b7ae354d956d7fe5db25f5d0d24
+++ b/packages/addons/service/tvheadend42/source/defaults/dvr/config/8d0f5b7ae354d956d7fe5db25f5d0d24
@@ -1,15 +1,18 @@
 {
 	"storage": "/storage/recordings",
-	"retention-days": 31,
+	"retention-days": 2147483646,
+	"removal-days": 2147483647,
 	"pre-extra-time": 0,
 	"post-extra-time": 0,
-	"day-dir": 0,
-	"channel-dir": 0,
-	"channel-in-title": 0,
-	"date-in-title": 0,
-	"time-in-title": 0,
-	"whitespace-in-title": 0,
-	"title-dir": 0,
-	"episode-in-title": 0,
-	"tag-files": 1
+	"day-dir": false,
+	"channel-dir": false,
+	"channel-in-title": true,
+	"date-in-title": true,
+	"time-in-title": true,
+	"whitespace-in-title": false,
+	"title-dir": true,
+	"episode-in-title": true,
+	"tag-files": true,
+	"windows-compatible-filenames": true,
+	"charset": "UTF-8"
 }

--- a/packages/addons/service/tvheadend42/source/defaults/epggrab/config
+++ b/packages/addons/service/tvheadend42/source/defaults/epggrab/config
@@ -5,6 +5,69 @@
 	"epgdb_periodicsave": 2,
 	"ota_initial": true,
 	"modules": {
+		"opentv-skyit": {
+			"class": "epggrab_mod_ota",
+			"name": "OpenTV: Sky Italia",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 2
+		},
+		"opentv-skynz": {
+			"class": "epggrab_mod_ota",
+			"name": "OpenTV: Sky NZ",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 2
+		},
+		"opentv-skyuk": {
+			"class": "epggrab_mod_ota",
+			"name": "OpenTV: Sky UK",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 2
+		},
+		"opentv-ausat": {
+			"class": "epggrab_mod_ota",
+			"name": "OpenTV: Ausat",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 2
+		},
+		"psip": {
+			"class": "epggrab_mod_ota",
+			"name": "PSIP: ATSC Grabber",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 1
+		},
+		"Bulsatcom_39E": {
+			"class": "epggrab_mod_ota",
+			"name": "Bulsatcom: Bula 39E",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 5
+		},
+		"viasat_baltic": {
+			"class": "epggrab_mod_ota",
+			"name": "VIASAT: Baltic",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 5
+		},
+		"uk_freeview": {
+			"class": "epggrab_mod_ota",
+			"name": "UK: Freeview",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 5
+		},
+		"uk_freesat": {
+			"class": "epggrab_mod_ota",
+			"name": "UK: Freesat",
+			"type": "Over-the-air",
+			"enabled": true,
+			"priority": 5
+		},
 		"eit": {
 			"class": "epggrab_mod_ota",
 			"name": "EIT: DVB Grabber",


### PR DESCRIPTION
@CvH I'm pinging you as you seems to be the maintainer ;-)

It seems that the default configs are a bit outdated and can cause issues with non advanced users and SMB shares. Also the wizard on the first setup isn't working because of the predefined config. A big complain about tvheadend is that's it's hard to configure. My aim is to keep things simple, the user should be able to watch TV after running the wizard and enabling pvr.hts. 

General config:
* Use "basic" interface level, this is the default when installing tvheadend on other systems and it should be comparable to what regular STB's offer.
* Disable the switch interface level button to avoid user confusion. 
* Enable the wizard on the first start. This is the default when installing tvheadend on other systems.
-> it will guide the user trough a tuner setup, scan, and channel mapping (everything a basic users needs)
* Fix picon path

DVR config:
* Retention of 31 days is bad as recordings will disappear from Kodi after this period (while the files stay on disk). -> Use "on file removal" (INT_MAX-1) as retention to list all recordings in kodi that are actually available on the disk.
* Booleaans should be 'true' or 'false'
* Recordings are shared over SMB by libreelec but this has some issues:

1) Recording names are meaningless (bones-1, bones-2,bones-3, etc), it's better to include channel, date-time and episode (for show scrapers). In this way the user can find back the recording he wants.

2) Group recordings in Kodi isn't working because recordings are not grouped on the file system. Subdirectory's based on title will make this option working and will give the user a better overview when opening the SMB share.

3) As we use SMB shares, we should use windows compatible filenames or we will end up with issues like this:
http://forum.kodi.tv/showthread.php?tid=217071

EPG config:
* Enable OTA grabbers by default, the user should get epg data after setting up channels. (like a regular STB), this is also the default by tvheadend.

Also a small question: is there a reason why "channel_rename" is enabled?




