### PR TITLE
lsioarmhf.plex: initial addon

### DIFF
--- a/packages/addons/docker/service/lsioarmhf.plex/changelog.txt
+++ b/packages/addons/docker/service/lsioarmhf.plex/changelog.txt
@@ -1,0 +1,2 @@
+100
+- Initial addon

--- a/packages/addons/docker/service/lsioarmhf.plex/package.mk
+++ b/packages/addons/docker/service/lsioarmhf.plex/package.mk
@@ -1,0 +1,45 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="lsioarmhf.plex"
+PKG_VERSION="11" # Update bin/docker.lsioarmhf.plex accordingly
+PKG_REV="100"
+PKG_ARCH="arm"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="docker"
+PKG_SITE="https://hub.docker.com/r/lsioarmhf/plex/"
+PKG_SHORTDESC="Plex Media Server as a Docker container"
+PKG_LONGDESC="Plex organizes video, music and photos from personal media libraries and streams them to smart televsions, streaming boxes and mobile devices"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_NAME="Plex (lsioarmhf/plex:$PKG_VERSION)"
+PKG_ADDON_PROJECTS="RPi RPi2 imx6"
+PKG_ADDON_REQUIRES="service.system.docker:0.0.0"
+PKG_ADDON_TYPE="xbmc.service"
+
+make_target() {
+  : #
+}
+
+makeinstall_target() {
+  : #
+}
+
+addon() {
+  : #
+}

--- a/packages/addons/docker/service/lsioarmhf.plex/source/bin/docker.lsioarmhf.plex
+++ b/packages/addons/docker/service/lsioarmhf.plex/source/bin/docker.lsioarmhf.plex
@@ -1,0 +1,33 @@
+#!/bin/sh
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+name="$(basename $0)"
+. /etc/profile
+oe_setup_addon "$name"
+
+docker rm "$name" 2>/dev/null
+docker run --name="$name" \
+           --net=host \
+           -e PUID="$E_PUID" \
+           -e PGID="$E_PGID" \
+           -v "$V_config":/config \
+           -v "$V_data_tvshows":/data/tvshows \
+           -v "$V_data_movies":/data/movies \
+           -v "$V_transcode":/transcode \
+           lsioarmhf/plex:11

--- a/packages/addons/docker/service/lsioarmhf.plex/source/default.py
+++ b/packages/addons/docker/service/lsioarmhf.plex/source/default.py
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+import subprocess
+import xbmc
+import xbmcaddon
+
+
+class Monitor(xbmc.Monitor):
+
+   def __init__(self, *args, **kwargs):
+      xbmc.Monitor.__init__(self)
+      self.id = xbmcaddon.Addon().getAddonInfo('id')
+
+   def onSettingsChanged(self):
+      subprocess.call(['systemctl', 'restart', self.id])
+
+
+if __name__ == '__main__':
+   Monitor().waitForAbort()

--- a/packages/addons/docker/service/lsioarmhf.plex/source/resources/language/English/strings.po
+++ b/packages/addons/docker/service/lsioarmhf.plex/source/resources/language/English/strings.po
@@ -1,0 +1,34 @@
+msgid ""
+msgstr ""
+
+msgctxt "#30000"
+msgid "Configuration"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Note: Kodi remote sources can not be used as Docker volume host sources"
+msgstr ""
+
+msgctxt "#30002"
+msgid "-e PUID"
+msgstr ""
+
+msgctxt "#30003"
+msgid "-e PGID"
+msgstr ""
+
+msgctxt "#30004"
+msgid "-v /config"
+msgstr ""
+
+msgctxt "#30005"
+msgid "-v /data/tvshows"
+msgstr ""
+
+msgctxt "#30006"
+msgid "-v /movies"
+msgstr ""
+
+msgctxt "#30007"
+msgid "-v /transcode"
+msgstr ""

--- a/packages/addons/docker/service/lsioarmhf.plex/source/resources/settings.xml
+++ b/packages/addons/docker/service/lsioarmhf.plex/source/resources/settings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+   <category   label="30000">
+      <setting label="30001" type="lsep" />
+      <setting label="30002" type="number" id="E_PUID"         default="0" />
+      <setting label="30003" type="number" id="E_PGID"         default="0" />
+      <setting label="30004" type="folder" id="V_config"       default="/storage/.kodi/userdata/addon_data/docker.lsioarmhf.plex" option="writeable" />
+      <setting label="30005" type="folder" id="V_data_tvshows" default="/storage/tvshows"                                         option="writeable" />
+      <setting label="30006" type="folder" id="V_data_movies"  default="/storage/videos"                                          option="writeable" />
+      <setting label="30007" type="folder" id="V_transcode"    default="/tmp"                                                     option="writeable" />
+   </category>
+</settings>

--- a/packages/addons/docker/service/lsioarmhf.plex/source/settings-default.xml
+++ b/packages/addons/docker/service/lsioarmhf.plex/source/settings-default.xml
@@ -1,0 +1,8 @@
+<settings>
+    <setting id="E_PGID" value="0" />
+    <setting id="E_PUID" value="0" />
+    <setting id="V_config" value="/storage/.kodi/userdata/addon_data/docker.lsioarmhf.plex" />
+    <setting id="V_data_movies" value="/storage/videos" />
+    <setting id="V_data_tvshows" value="/storage/tvshows" />
+    <setting id="V_transcode" value="/tmp" />
+</settings>

--- a/packages/addons/docker/service/lsioarmhf.plex/source/system.d/docker.lsioarmhf.plex.service
+++ b/packages/addons/docker/service/lsioarmhf.plex/source/system.d/docker.lsioarmhf.plex.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=%p container
+Requires=service.system.docker.service
+After=service.system.docker.service
+
+[Service]
+Restart=always
+RestartSec=10s
+TimeoutStartSec=0
+ExecStart=/bin/sh /storage/.kodi/addons/%p/bin/%p
+ExecStop=/storage/.kodi/addons/service.system.docker/bin/docker kill %p
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is how I propose to wrap docker containers into addons.

I have applied the following conventions:
- docker addons are grouped in the docker section
- the name of the addon (lsioarmhf.plex) corresponds to the docker hub owner/repo (lsioarmhf/plex)
- all the addons resources (files, folders, services, etc) are therefore prefixed by docker.owner.repo

The above conventions enable container variants, eg two Plex Media Server containers, to coexist.