### PR TITLE
hardkernel reference no longer need

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,10 +29,6 @@ PKG_SECTION="linux"
 PKG_SHORTDESC="linux26: The Linux kernel 2.6 precompiled kernel binary image and modules"
 PKG_LONGDESC="This package contains a precompiled kernel image and the modules."
 case "$LINUX" in
-  hardkernel)
-    PKG_VERSION="3b08361"
-    PKG_URL="https://github.com/hardkernel/linux/archive/$PKG_VERSION.tar.gz"
-    ;;
   amlogic-3.10)
     PKG_VERSION="86c93aa"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
The reference to hardkernel is not need after 73b406c4563da03326f375f858f13b4eee79dfaf