### PR TITLE
EDID overriding for aarch64

### DIFF
--- a/packages/mediacenter/kodi/patches/aarch64/kodi-0008-allow-EDID-override.patch
+++ b/packages/mediacenter/kodi/patches/aarch64/kodi-0008-allow-EDID-override.patch
@@ -1,0 +1,41 @@
+From: Eric Gandt <gandteric@yahoo.com>
+Date: Fri, 14 Oct 2016
+Subject: Allow overriding of the EDID resultion detection, as it does not find many valid modes set in the EDID, this can be teh chipset or the device connected, if no over-ride is provided use the generated version
+
+---
+
+diff --git a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+index 67f9984..b096308 100644
+--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
++++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+@@ -29,6 +29,7 @@
+ #include <linux/fb.h>
+ #include <sys/ioctl.h>
+ #include <EGL/egl.h>
++#include <fstream>
+ 
+ CEGLNativeTypeAmlogic::CEGLNativeTypeAmlogic()
+ {
+@@ -154,10 +155,21 @@ bool CEGLNativeTypeAmlogic::SetNativeResolution(const RESOLUTION_INFO &res)
+   return result;
+ }
+ 
++// detect if a file exists requires unistd.h
++bool fexists(const char *filename) {
++  std::ifstream ifile(filename);
++  return (bool)ifile;
++}
++
+ bool CEGLNativeTypeAmlogic::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
+ {
+   std::string valstr;
+-  SysfsUtils::GetString("/sys/class/amhdmitx/amhdmitx0/disp_cap", valstr);
++  if(fexists("/storage/.config/disp_cap")) {      
++    SysfsUtils::GetString("/storage/.config/disp_cap", valstr);
++  } else {
++    SysfsUtils::GetString("/sys/class/amhdmitx/amhdmitx0/disp_cap", valstr);
++  }
++    
+   std::vector<std::string> probe_str = StringUtils::Split(valstr, "\n");
+ 
+   resolutions.clear();


### PR DESCRIPTION
EDID detection is broken at least the ODRIOD C2, but simply put EDID detection is always a best guess situation, I confirmed this porblen.

I built a custom EDID, not fun that has only the following modes:

1080p30
1080p29
1080p25
1080p24
720p60

Yet the ODROID C2 finds:
1080p60
720p60

That means it discovers non-existent values from the EDID (1080p60) and simply ignored the 30, 29, 25, 24 which are all that are set as valid.


Worse looking at aud_cap shows (nothing no sound at all), yet I can can verify that:
8 channel PCM
6 channel AC-3
6 channel DTS
8 channel DTS-HD
8 channel EAC-3
Are all present in the EDID, yet it discovered none of them.

The EDID in question is:
00 FF FF FF FF FF FF 00 15 A7 01 00 01 00 00 00
20 1A 01 03 80 00 00 78 1A EE 91 A3 54 4C 99 26
0F 50 54 A1 4B 00 31 40 45 40 61 40 71 40 81 80
01 00 01 01 01 01 A9 1A 80 A0 70 38 10 40 30 20
35 00 40 44 21 00 00 1E 2B 16 80 A0 70 38 0E 40
30 20 35 00 40 44 21 00 00 1E 31 15 80 A0 70 38
0E 40 30 20 35 00 40 44 21 00 00 1E 00 00 00 FD
00 0F 4B 1E 53 10 00 00 00 00 00 00 00 00 01 4B
02 03 36 71 48 A2 CA A1 A0 C8 84 BE C2 32 0F 16
07 95 07 50 3E 06 C0 E7 7E 00 51 FF 01 59 7E 01
83 4F 00 00 6A 03 0C 00 10 00 80 2D 20 80 00 E3
05 03 01 E2 00 FF A9 1A 80 A0 70 38 10 40 30 20
35 00 40 44 21 00 00 1E C8 19 80 A0 70 38 0F 40
30 20 35 00 40 44 21 00 00 1E 2B 16 80 A0 70 38
0E 40 30 20 35 00 40 44 21 00 00 1E 18 15 80 A0
70 38 0E 40 30 20 35 00 40 44 21 00 00 1E 00 B5

Since this was constructed purely to match what I need, was then loaded to the Genfen, and finally verified via a Nvidia card as matching what I entered, I know the issue is with the aarch64 detection of the EDIDs.

This simply allows one to override the detection if so desired with a local copy in /storage/.config/disp_cap.  I have tested on the ODRIOD C2 an found that it is doing exactly what it should be, a person could in theory set resolutions that are not possible using this, but then they can not confirm the change.  Also one can always log into the LibreELEC instance and remove the file to recover, think there is any way to cause permanent issues even using an over-ride.  If companies simply had better detection and better reporting of capabilities then  this kind of fix would not be required.

Thanks,
ERIC