### PR TITLE
LIRC: Disable YAML python module autodetection

### DIFF
--- a/packages/sysutils/lirc/patches/lirc-0007-disable-python-yaml-mod.patch
+++ b/packages/sysutils/lirc/patches/lirc-0007-disable-python-yaml-mod.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac.orig	2016-10-17 22:23:59.484494213 +0200
++++ b/configure.ac	2016-10-17 22:25:08.045520993 +0200
+@@ -76,7 +76,7 @@
+   fi
+ fi
+ AX_PYTHON_MODULE([yaml])
+-AM_CONDITIONAL([HAVE_PYMOD_YAML], test $HAVE_PYMOD_YAML = "yes")
++AM_CONDITIONAL([HAVE_PYMOD_YAML], false)
+ forkpty=""
+ AC_CHECK_FUNCS(forkpty)
+ if test "$ac_cv_func_forkpty" != yes; then


### PR DESCRIPTION
It's not used by LibreELEC and it trigger a build failure on recent
GNU/Linux distribution like Fedora 24.

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>