### PR TITLE
Backport Avermedia TD110 support to i.MX6 4.4 kernel.

### DIFF
--- a/projects/imx6/patches/linux/4.4-xbian/linux-002-add-avermedia-td110-id.patch
+++ b/projects/imx6/patches/linux/4.4-xbian/linux-002-add-avermedia-td110-id.patch
@@ -1,0 +1,31 @@
+diff -rU5 a/drivers/media/dvb-core/dvb-usb-ids.h b/drivers/media/dvb-core/dvb-usb-ids.h
+--- a/drivers/media/dvb-core/dvb-usb-ids.h	2015-11-02 01:05:25.000000000 +0100
++++ b/drivers/media/dvb-core/dvb-usb-ids.h	2015-11-30 12:53:14.482337310 +0100
+@@ -239,10 +239,11 @@
+ #define USB_PID_AVERMEDIA_A835B_3835			0x3835
+ #define USB_PID_AVERMEDIA_A835B_4835			0x4835
+ #define USB_PID_AVERMEDIA_1867				0x1867
+ #define USB_PID_AVERMEDIA_A867				0xa867
+ #define USB_PID_AVERMEDIA_H335				0x0335
++#define USB_PID_AVERMEDIA_TD110				0xa110
+ #define USB_PID_AVERMEDIA_TWINSTAR			0x0825
+ #define USB_PID_TECHNOTREND_CONNECT_S2400               0x3006
+ #define USB_PID_TECHNOTREND_CONNECT_S2400_8KEEPROM	0x3009
+ #define USB_PID_TECHNOTREND_CONNECT_CT3650		0x300d
+ #define USB_PID_TECHNOTREND_CONNECT_S2_4600             0x3011
+diff -rU5 a/drivers/media/usb/dvb-usb-v2/af9035.c b/drivers/media/usb/dvb-usb-v2/af9035.c
+--- a/drivers/media/usb/dvb-usb-v2/af9035.c	2015-11-02 01:05:25.000000000 +0100
++++ b/drivers/media/usb/dvb-usb-v2/af9035.c	2015-11-30 17:15:09.149803276 +0100
+@@ -2051,10 +2051,12 @@
+ 		&af9035_props, "Avermedia A835B(2835)", RC_MAP_IT913X_V2) },
+ 	{ DVB_USB_DEVICE(USB_VID_AVERMEDIA, USB_PID_AVERMEDIA_A835B_3835,
+ 		&af9035_props, "Avermedia A835B(3835)", RC_MAP_IT913X_V2) },
+ 	{ DVB_USB_DEVICE(USB_VID_AVERMEDIA, USB_PID_AVERMEDIA_A835B_4835,
+ 		&af9035_props, "Avermedia A835B(4835)",	RC_MAP_IT913X_V2) },
++	{ DVB_USB_DEVICE(USB_VID_AVERMEDIA, USB_PID_AVERMEDIA_TD110,
++		&af9035_props, "Avermedia AverTV Volar HD 2 (TD110)", RC_MAP_AVERMEDIA_RM_KS) },
+ 	{ DVB_USB_DEVICE(USB_VID_AVERMEDIA, USB_PID_AVERMEDIA_H335,
+ 		&af9035_props, "Avermedia H335", RC_MAP_IT913X_V2) },
+ 	{ DVB_USB_DEVICE(USB_VID_KWORLD_2, USB_PID_KWORLD_UB499_2T_T09,
+ 		&af9035_props, "Kworld UB499-2T T09", RC_MAP_IT913X_V1) },
+ 	{ DVB_USB_DEVICE(USB_VID_KWORLD_2, USB_PID_SVEON_STV22_IT9137,


### PR DESCRIPTION
Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>