### PR TITLE
kodi: fix aml audio patch

### DIFF
--- a/packages/mediacenter/kodi/patches/aarch64/kodi-0002-AESinkALSA-force-default-device-for-non-passthrough.patch
+++ b/packages/mediacenter/kodi/patches/aarch64/kodi-0002-AESinkALSA-force-default-device-for-non-passthrough.patch
@@ -16,7 +16,7 @@ index 6a9066b..4d7f85d 100644
    }
  #if defined(HAS_LIBAMCODEC)
 -  if (aml_present())
-+  if (!m_passthrough && aml_present())
++  if (!m_passthrough && device.find("hdmi:CARD=AMLM8AUDIO") != std::string::npos)
    {
 -    aml_set_audio_passthrough(m_passthrough);
      device = "default";


### PR DESCRIPTION
This PR changes the force default device patch to only force to default device when the on-board hdmi device is selected.

Should make USB-audio work without requiring a `asound.conf`-file, see https://forum.libreelec.tv/thread-1746-post-15596.html#pid15596