### PR TITLE
connman: remove full path in log

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -32,6 +32,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="WPASUPPLICANT=/usr/bin/wpa_supplicant \
+                           --srcdir=.. \
                            --disable-gtk-doc \
                            --disable-debug \
                            --disable-hh2serial-gps \


### PR DESCRIPTION
This PR removes full path to build dir in connman logs and replaces it with `../`

Before: `connmand[338]: /jenkins/workspace/LibreELEC/build.LibreELEC-Odroid_C2.aarch64-8.0-devel/connman-1.33/src/ntp.c:decode_msg() adjusting time 0 seconds, 23399 msecs`

Now: `connmand[313]: ../src/ntp.c:decode_msg() adjusting time 0 seconds, 23837 msecs`