### PR TITLE
libamcodec: requires alsa-lib

### DIFF
--- a/packages/multimedia/libamcodec/package.mk
+++ b/packages/multimedia/libamcodec/package.mk
@@ -31,7 +31,7 @@ case $TARGET_ARCH in
     PKG_URL="http://amlinux.ru/source/$PKG_NAME-$PKG_VERSION.tar.gz"
     ;;
 esac
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain alsa-lib"
 PKG_SECTION="multimedia"
 PKG_SHORTDESC="libamcodec: Interface library for Amlogic media codecs"
 PKG_LONGDESC="libamplayer: Interface library for Amlogic media codecs"


### PR DESCRIPTION
this should fix building hyperion on Jenkins.

```
audio_out/alsa-out.c:18:28: fatal error: alsa/asoundlib.h: No such file or directory
```