### PR TITLE
installer: cosmetic touches

### DIFF
--- a/packages/tools/installer/config/installer.conf
+++ b/packages/tools/installer/config/installer.conf
@@ -39,4 +39,4 @@
 
 # color scheme to use for Whiptail/Newt
 # see http://askubuntu.com/questions/776831/whiptail-change-background-color-dynamically-from-magenta
-  WHIPTAIL_COLORS="root=,magenta;entry=,magenta;label=magenta,;actlistbox=,magenta;roottext=white,magenta"
+  WHIPTAIL_COLORS=""

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -305,7 +305,7 @@ do_install_quick() {
           msg_progress_install "100" "Remove $TMPDIR/part2"
           rmdir $TMPDIR/part2 >> $LOGFILE 2>&1
         fi
-      } | whiptail --gauge "Please wait while your system is being setup ..." 6 73 0
+      } | whiptail --backtitle "$BACKTITLE" --gauge "Please wait while your system is being setup ..." 6 73 0
 
       # install complete
       MSG_TITLE="@DISTRONAME@ Install Complete"
@@ -409,7 +409,7 @@ out during the installation. \
   whiptail --backtitle "$BACKTITLE" --cancel-button "$MSG_CANCEL" \
     --title "$MSG_TITLE" --menu "$MSG_MENU" 18 73 3 \
       1 "Install @DISTRONAME@" \
-      2 "Show the log file" \
+      2 "Installation log" \
       3 "Reboot" 2> $TMPDIR/mainmenu
 
   case $? in
@@ -431,7 +431,7 @@ out during the installation. \
 }
 
 logfile_show() {
-  whiptail --textbox "$LOGFILE" 20 73 --scrolltext
+  whiptail --textbox "$LOGFILE" 20 73 --scrolltext --backtitle "$BACKTITLE"
   clear
   menu_main
 }


### PR DESCRIPTION
Revert back to the default colours (blue background like Anaconda etc.). Also make sure that the "backtitle" is visible during the whole installation process.