### PR TITLE
imx6/linux 4.4: remove evbug option

### DIFF
--- a/projects/imx6/linux/4.4-xbian/linux.arm.conf
+++ b/projects/imx6/linux/4.4-xbian/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.4.14 Kernel Configuration
+# Linux/arm 4.4.19 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_ARM_HAS_SG_CHAIN=y
@@ -2564,7 +2564,7 @@ CONFIG_INPUT_MOUSEDEV_SCREEN_X=1024
 CONFIG_INPUT_MOUSEDEV_SCREEN_Y=768
 CONFIG_INPUT_JOYDEV=m
 CONFIG_INPUT_EVDEV=y
-CONFIG_INPUT_EVBUG=m
+# CONFIG_INPUT_EVBUG is not set
 # CONFIG_INPUT_APMPOWER is not set
 
 #


### PR DESCRIPTION
and lines in dmesg
[ 2226.525427] evbug: Event. Dev: input5, Type: 0, Code: 0, Value: 0
[ 2226.697409] evbug: Event. Dev: input5, Type: 1, Code: 304, Value: 0
[ 2226.697423] evbug: Event. Dev: input5, Type: 0, Code: 0, Value: 0