### PR TITLE
linux: add support for ZOTAC IR reciver

### DIFF
--- a/packages/linux/patches/4.8.4/linux-053-spinelplus-remote-0.2.patch
+++ b/packages/linux/patches/4.8.4/linux-053-spinelplus-remote-0.2.patch
@@ -1,27 +1,29 @@
 diff -Naur linux-3.19/drivers/hid/hid-core.c linux-3.19.patch/drivers/hid/hid-core.c
 --- linux-3.19/drivers/hid/hid-core.c	2015-02-09 03:54:22.000000000 +0100
 +++ linux-3.19.patch/drivers/hid/hid-core.c	2015-02-11 00:06:14.966131308 +0100
-@@ -1886,6 +1886,9 @@
+@@ -1886,6 +1886,10 @@
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ORTEK, USB_DEVICE_ID_ORTEK_WKB2000) },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_PENMOUNT, USB_DEVICE_ID_PENMOUNT_6000) },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_PETALYNX, USB_DEVICE_ID_PETALYNX_MAXTER_REMOTE) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_PHILIPS, USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_1) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_PHILIPS, USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_2) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_PHILIPS, USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_3) },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_PHILIPS, USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_4) },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_PLANTRONICS, HID_ANY_ID) },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_PRIMAX, USB_DEVICE_ID_PRIMAX_KEYBOARD) },
  #if IS_ENABLED(CONFIG_HID_ROCCAT)
 diff -Naur linux-3.19/drivers/hid/hid-ids.h linux-3.19.patch/drivers/hid/hid-ids.h
 --- linux-3.19/drivers/hid/hid-ids.h	2015-02-09 03:54:22.000000000 +0100
 +++ linux-3.19.patch/drivers/hid/hid-ids.h	2015-02-11 00:04:45.885977057 +0100
-@@ -743,6 +743,9 @@
- 
+@@ -743,6 +743,10 @@
+
  #define USB_VENDOR_ID_PHILIPS		0x0471
  #define USB_DEVICE_ID_PHILIPS_IEEE802154_DONGLE 0x0617
 +#define USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_1	0x206c
 +#define USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_2	0x20cc
 +#define USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_3	0x0613
- 
++#define USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_4	0x2168
+
  #define USB_VENDOR_ID_PI_ENGINEERING	0x05f3
  #define USB_DEVICE_ID_PI_ENGINEERING_VEC_USB_FOOTPEDAL	0xff
 diff -Naur linux-3.19/drivers/hid/hid-spinelplus.c linux-3.19.patch/drivers/hid/hid-spinelplus.c
@@ -108,6 +110,7 @@ diff -Naur linux-3.19/drivers/hid/hid-spinelplus.c linux-3.19.patch/drivers/hid/
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_PHILIPS,USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_1) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_PHILIPS,USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_2) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_PHILIPS,USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_3) },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_PHILIPS,USB_DEVICE_ID_PHILIPS_SPINEL_PLUS_4) },
 +	{ }
 +};
 +MODULE_DEVICE_TABLE(hid, spinelplus_devices);
@@ -138,12 +141,12 @@ diff -Naur linux-3.19/drivers/hid/Kconfig linux-3.19.patch/drivers/hid/Kconfig
 @@ -702,6 +702,12 @@
  	---help---
  	Support for Steelseries SRW-S1 steering wheel
- 
+
 +config HID_SPINELPLUS
 +	tristate "Spinel Plus remote control"
 +	depends on USB_HID
 +	---help---
-+	  Say Y here if you have a Spinel Plus (0471:206c/20cc/0613) remote
++	  Say Y here if you have a Spinel Plus (0471:206c/20cc/0613/2168) remote
 +
  config HID_SUNPLUS
  	tristate "Sunplus wireless desktop"


### PR DESCRIPTION
patch is renamed for 4.8.4, supersedes #776