### PR TITLE
LibreSSL: update to 2.4.3

### DIFF
--- a/packages/security/libressl/package.mk
+++ b/packages/security/libressl/package.mk
@@ -17,12 +17,13 @@
 ################################################################################
 
 PKG_NAME="libressl"
-PKG_VERSION="2.3.8"
+PKG_VERSION="2.4.3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.libressl.org/"
 PKG_URL="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_HOST="ccache:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="security"
 PKG_SHORTDESC="libressl: a FREE version of the SSL/TLS protocol forked from OpenSSL"
@@ -30,7 +31,7 @@ PKG_LONGDESC="LibreSSL is a FREE version of the SSL/TLS protocol forked from Ope
 
 PKG_IS_ADDON="no"
 PKG_USE_CMAKE="no"
-PKG_AUTORECONF="yes"
+PKG_AUTORECONF="no"
 
 post_makeinstall_target() {
   # backwards comatibility

--- a/packages/security/libressl/package.mk
+++ b/packages/security/libressl/package.mk
@@ -34,7 +34,9 @@ PKG_USE_CMAKE="no"
 PKG_AUTORECONF="no"
 
 post_makeinstall_target() {
-  # backwards comatibility
+  # backwards compatibility
   mkdir -p $INSTALL/etc/pki/tls
     ln -sf /etc/ssl/cert.pem $INSTALL/etc/pki/tls/cacert.pem
+  mkdir -p $INSTALL/etc/pki/tls/certs
+    ln -sf /etc/ssl/cert.pem $INSTALL/etc/pki/tls/certs/ca-bundle.crt
 }


### PR DESCRIPTION
This update cover issues with weak ciphering and digesting algorithm that are now disabled by default. 

Signed-off-by: Jérôme Benoit jerome.benoit@piment-noir.org
