### PR TITLE
drm/i915: Limit the depth of the display pipeline to the framebuffer

### DIFF
--- a/packages/linux/patches/4.8.4/linux-999-i915-chris-wilson-limit-depth-of-display-pipeline.patch
+++ b/packages/linux/patches/4.8.4/linux-999-i915-chris-wilson-limit-depth-of-display-pipeline.patch
@@ -1,0 +1,60 @@
+From 428ce1a022a0bc30cf2d09cde4c1352a88d70d0a Mon Sep 17 00:00:00 2001
+From: Chris Wilson <chris@chris-wilson.co.uk>
+Date: Fri, 26 Aug 2016 19:26:01 +0100
+Subject: [PATCH] drm/i915: Limit the depth of the display pipeline to the
+ framebuffer
+
+There is little point in using higher bitdepth inside the pipeline if
+the endpoints are of lower accuracy. Using the higher bitdepth requires
+extra bandwidth, often to the point of failure - such as signal loss and
+blank displays.
+
+Since commit 7a0baa623446 ("Revert "drm/i915: Disable 12bpc hdmi for
+now"") we have had users reporting blank screens and rightfully
+complaining about the regressions. Whilst these are using due to some
+other underlying bug, they have lingered and still remain unresolved. So
+let's try a different tact and avoid using higher bitdepths than
+required.
+
+Signed-off-by: Chris Wilson <chris@chris-wilson.co.uk>
+---
+ drivers/gpu/drm/i915/intel_display.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/intel_display.c b/drivers/gpu/drm/i915/intel_display.c
+index af551a2c89ba..05ad77dae2e8 100644
+--- a/drivers/gpu/drm/i915/intel_display.c
++++ b/drivers/gpu/drm/i915/intel_display.c
+@@ -12695,9 +12695,11 @@ compute_baseline_pipe_bpp(struct intel_crtc *crtc,
+ 			  struct intel_crtc_state *pipe_config)
+ {
+ 	struct drm_device *dev = crtc->base.dev;
+-	struct drm_atomic_state *state;
++	struct drm_atomic_state *state = pipe_config->base.state;
++
+ 	struct drm_connector *connector;
+ 	struct drm_connector_state *connector_state;
++	struct drm_plane_state *plane_state;
+ 	int bpp, i;
+ 
+ 	if ((IS_G4X(dev) || IS_VALLEYVIEW(dev) || IS_CHERRYVIEW(dev)))
+@@ -12707,11 +12709,14 @@ compute_baseline_pipe_bpp(struct intel_crtc *crtc,
+ 	else
+ 		bpp = 8*3;
+ 
++	plane_state = drm_atomic_get_plane_state(state, crtc->base.primary);
++	if (plane_state->fb->depth < bpp)
++		bpp = 8*3;
+ 
++	DRM_DEBUG_KMS("initial pipeline bpp = %d (fb depth %d)\n",
++		      bpp, plane_state->fb->depth);
+ 	pipe_config->pipe_bpp = bpp;
+ 
+-	state = pipe_config->base.state;
+-
+ 	/* Clamp display bpp to EDID value */
+ 	for_each_connector_in_state(state, connector, connector_state, i) {
+ 		if (connector_state->crtc != &crtc->base)
+-- 
+2.9.3
+


### PR DESCRIPTION
https://bugs.freedesktop.org/show_bug.cgi?id=97442#c15

Helps avoid blank screens on some Intel systems.