### PR TITLE
emby: upgrade to 3.0.8300

### DIFF
--- a/packages/addons/addon-depends/emby-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/emby-depends/ffmpegx/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="ffmpegx"
 PKG_VERSION="libreelec"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"

--- a/packages/addons/service/emby/changelog.txt
+++ b/packages/addons/service/emby/changelog.txt
@@ -1,3 +1,7 @@
+107
+- Updated to version 3.0.8300
+- Rebuilt ffmpegx
+
 106
 - Updated to version 3.0.8100
 - Rebuilt ffmpegx

--- a/packages/addons/service/emby/package.mk
+++ b/packages/addons/service/emby/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="emby"
-PKG_VERSION="3.0.8100"
-PKG_REV="106"
+PKG_VERSION="3.0.8300"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://emby.media"


### PR DESCRIPTION
Yay! No more artefacts on RPi3 when transcoding from 1080o to 720p/4MBps.