### PR TITLE
config/functions: change debug_strip syntax

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -481,7 +481,7 @@ show_config() {
 # strip
 debug_strip() {
   if [ ! "$DEBUG" = yes ]; then
-    $STRIP `find $* -type f -executable 2>/dev/null` 2>/dev/null || :
+    find $* -type f -executable | xargs $STRIP 1>/dev/null || :
   fi
 }
 


### PR DESCRIPTION
@chewitt this should fix you issues building the *-tools add-ons.