### PR TITLE
patch to make ffmpeg work with tls 1.2 servers

### DIFF
--- a/packages/multimedia/ffmpeg/patches/ffmpeg-99.1010-tls-1.2.patch
+++ b/packages/multimedia/ffmpeg/patches/ffmpeg-99.1010-tls-1.2.patch
@@ -1,0 +1,17 @@
+--- a/libavformat/tls_openssl.c
++++ b/libavformat/tls_openssl.c
+@@ -233,12 +233,13 @@ static int tls_open(URLContext *h, const char *uri, int flags, AVDictionary **op
+     if ((ret = ff_tls_open_underlying(c, h, uri, options)) < 0)
+         goto fail;
+
+-    p->ctx = SSL_CTX_new(c->listen ? TLSv1_server_method() : TLSv1_client_method());
++    p->ctx = SSL_CTX_new(c->listen ? SSLv23_server_method() : SSLv23_client_method());
+     if (!p->ctx) {
+         av_log(h, AV_LOG_ERROR, "%s\n", ERR_error_string(ERR_get_error(), NULL));
+         ret = AVERROR(EIO);
+         goto fail;
+     }
++    SSL_CTX_set_options(p->ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+     if (c->ca_file) {
+         if (!SSL_CTX_load_verify_locations(p->ctx, c->ca_file, NULL))
+             av_log(h, AV_LOG_ERROR, "SSL_CTX_load_verify_locations %s\n", ERR_error_string(ERR_get_error(), NULL));


### PR DESCRIPTION
ffmpeg couldnt open streams on tls 1.2 servers. @vpeter4 made this patch and its tested and works.
Also sent to ffmpeg, so this can be removed later when its merge, ill try to keep on an eye open for it.