### PR TITLE
vdr-plugin-xmltv2vdr: build static

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
@@ -36,7 +36,7 @@ pre_configure_target() {
   export CFLAGS="$CFLAGS -fPIC"
   export CXXFLAGS="$CXXFLAGS -fPIC"
   export LDFLAGS="$LDFLAGS -fPIC"
-  export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv"
+  export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv -L$SYSROOT_PREFIX/usr/lib"
 }
 
 make_target() {


### PR DESCRIPTION
otherwise xmltv2vdr fails with: ERROR: libsqlite3.so.0: cannot open shared object file: No such file or directory