### PR TITLE
iwlwifi-firmware: use github for package, bump to cb23d96

### DIFF
--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="iwlwifi-firmware"
-PKG_VERSION="0.0.5"
+PKG_VERSION="cb23d96"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Free-to-use"
-PKG_SITE="https://github.com/OpenELEC/iwlwifi-firmware"
-PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_SITE="https://github.com/LibreELEC/iwlwifi-firmware"
+PKG_URL="https://github.com/LibreELEC/iwlwifi-firmware/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="firmware"
 PKG_SHORTDESC="iwlwifi-firmware: firmwares for various Intel WLAN drivers"


### PR DESCRIPTION
Need this before https://github.com/LibreELEC/iwlwifi-firmware/pull/2, or at least before we can pull in that update. I'll update this PR if #2 is merged before this PR.