### PR TITLE
curl: bump to curl-7.51.0

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -25,7 +25,7 @@
 #   there: http://forum.xbmc.org/showthread.php?tid=177557
 
 PKG_NAME="curl"
-PKG_VERSION="7.50.1"
+PKG_VERSION="7.51.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
Numerous security fixes.

https://curl.haxx.se/docs/security.html