### PR TITLE
build: fix host build enviroment

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -83,14 +83,14 @@ setup_toolchain() {
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)" >> $CMAKE_CONF
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)" >> $CMAKE_CONF
       fi
-      export HOST_CC="$HOST_CC"
-      export HOST_CXX="$HOST_CXX"
-      export HOSTCC="$HOST_CC"
-      export HOSTCXX="$HOST_CXX"
-      export CC_FOR_BUILD="$HOST_CC"
-      export CXX_FOR_BUILD="$HOST_CXX"
-      export BUILD_CC="$HOST_CC"
-      export BUILD_CXX="$HOST_CXX"
+      export HOST_CC="$CC"
+      export HOST_CXX="$CXX"
+      export HOSTCC="$CC"
+      export HOSTCXX="$CXX"
+      export CC_FOR_BUILD="$CC"
+      export CXX_FOR_BUILD="$CXX"
+      export BUILD_CC="$CC"
+      export BUILD_CXX="$CXX"
       ;;
   esac
 }


### PR DESCRIPTION
HOST_CC/CXX (and follow ups) is only set for :target.
But :host need a correct set HOST_CC/CXX, too.

for example a clean ./scripts/install bzip2:host will create an unusable host bzip2.

clean build for RPi2 was fine