### PR TITLE
buildsys: no more extra optimizations

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -354,7 +354,6 @@ show_config() {
   config_message="$config_message\n - FLOAT:\t\t\t\t $TARGET_FLOAT"
   config_message="$config_message\n - FPU:\t\t\t\t\t $TARGET_FPU"
   config_message="$config_message\n - SIMD support:\t\t\t $SIMD_SUPPORT"
-  config_message="$config_message\n - Optimizations:\t\t\t $OPTIMIZATIONS"
   config_message="$config_message\n - LTO (Link Time Optimization) support: $LTO_SUPPORT"
   config_message="$config_message\n - GOLD (Google Linker) Support:\t $GOLD_SUPPORT"
   config_message="$config_message\n - LLVM support:\t\t\t $LLVM_SUPPORT"


### PR DESCRIPTION
OPTIMIZATIONS variable removed in 4df4ea789c44137f90c8c804888649cd35ae5e7c