### PR TITLE
libass: update to 0.13.4

### DIFF
--- a/packages/multimedia/libass/package.mk
+++ b/packages/multimedia/libass/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libass"
-PKG_VERSION="0.13.2"
+PKG_VERSION="0.13.4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"


### PR DESCRIPTION
From @popcornmix: "if you test the SSA memory leak fix, note that current libssa has a cache size of 1G which is not very useful for most arm platforms. Latest 0.13.4 release limits caches to 192M (still a lot, but more reasonable). It also appears to fix some minor leaks and has improvements to caching, so I think it's worth testing in nightly and probably bumping in Kodi."

I'll include this in test builds, might want to wait a couple of days for positive feedback.