### PR TITLE
libressl: drop back to 2.3.9 to avoid soname changes

### DIFF
--- a/packages/security/libressl/package.mk
+++ b/packages/security/libressl/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libressl"
-PKG_VERSION="2.4.3"
+PKG_VERSION="2.3.9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"


### PR DESCRIPTION
Instead of reverting all changes in #875 this drops back to the last version before the ABI change. Pick this or #919 - whichever is better.