### PR TITLE
debug: make valgrind optional, disabled by default, not available for…

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -60,7 +60,8 @@ makeinstall_host() {
   cp -a bin/llvm-tblgen $ROOT/$TOOLCHAIN/bin
 }
 
-PKG_CMAKE_OPTS_TARGET="-DCMAKE_C_FLAGS="$CFLAGS" \
+PKG_CMAKE_OPTS_TARGET="-DCMAKE_BUILD_TYPE=MinSizeRel \
+                       -DCMAKE_C_FLAGS="$CFLAGS" \
                        -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
                        -DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_BUILD_TOOLS=OFF \

--- a/packages/virtual/debug/package.mk
+++ b/packages/virtual/debug/package.mk
@@ -38,6 +38,6 @@ if [ "$VDPAU_SUPPORT" = "yes" -a "$DISPLAYSERVER" = "x11" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET vdpauinfo"
 fi
 
-if [ "$DEBUG" = "yes" ]; then
-  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET  valgrind"
+if [ "$DEBUG" = "yes" -a "$VALGRIND" = "yes" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET valgrind"
 fi

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -129,6 +129,10 @@
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 
+  # build debug with valgrind (yes / no)
+  # Not available for armv6. Increases image size significantly
+    VALGRIND="no"
+
   # kernel image name
     KERNEL_NAME="kernel.img"
 


### PR DESCRIPTION
… armv6

Couple of issues now that valgrind is being built by default whenever `DEBUG=yes` (see #884):

1) valgrind isn't available for armv6 so RPi1 debug builds will fail: http://sprunge.us/DVQH:
```
checking for gdb... /usr/bin/gdb
checking dependency style of /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-8.0-devel-debug/toolchain/bin/armv6zk-libreelec-linux-gnueabi-gcc... gcc3
checking for diff -u... yes
checking for a supported version of gcc... ok (5.4.0)
checking build system type... x86_64-pc-linux-gnu
checking host system type... armv6zk-libreelec-linux-gnueabi
checking for a supported CPU... no (armv6zk)
configure: error: Unsupported host architecture. Sorry
```

Building and running valgrind on armv6 probably wouldn't make any sense even if it was supported.

2) x86 debug builds with valgrind are enormous - too large to install on a standard 512MB FAT system:
```
-rw-r--r-- 1 neil neil 421052416 Sep 23 23:10 x86-debug/LibreELEC-Generic.x86_64-8.0-devel-20160923224217-#0923g-g8a3b79d.system
-rw-r--r-- 1 neil neil 654532608 Nov  7 21:57 x86-debug/LibreELEC-Generic.x86_64-8.0-devel-20161107194901-#1107-g3f30170.system
```
We definitely don't want to build with valgrind by default, it should be enabled only when required.

Building valgrind for RPi2 adds about 30MB, which isn't too bad, but should still be included only when required...
```
-rw-rw-r-- 1 neil neil 334888960 Sep 23 22:44 pi2-debug/LibreELEC-RPi2.arm-8.0-devel-20160923224217-#0923g-g8a3b79d.tar
-rw-rw-r-- 1 neil neil 363704320 Nov  7 21:54 pi2-debug/LibreELEC-RPi2.arm-8.0-devel-20161107194901-#1107-g3f30170.tar
```

Adding `VALGRIND` option solves both #1 and #2.