### PR TITLE
LibreSSL: update to 2.4.4

### DIFF
--- a/packages/security/libressl/package.mk
+++ b/packages/security/libressl/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libressl"
-PKG_VERSION="2.3.9"
+PKG_VERSION="2.4.4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"


### PR DESCRIPTION
This update bump the shared object version of the LibreSSL libraries.

LibreSSL in this version disable by default all weaks ciphering
or digesting algorithms and protocols like MD5, SHA1, SSLv2, SSLv3, etc.

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>