### PR TITLE
libva: bump to libva-1.7.3 and libva-intel-driver-1.7.3

### DIFF
--- a/packages/multimedia/libva-intel-driver/package.mk
+++ b/packages/multimedia/libva-intel-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libva-intel-driver"
-PKG_VERSION="1.7.2"
+PKG_VERSION="1.7.3"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libva"
-PKG_VERSION="1.7.2"
+PKG_VERSION="1.7.3"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
libva: https://lists.freedesktop.org/archives/libva/2016-November/004730.html
* Bump VA API version to 0.39.4
* API: add support for bitrate control per temporal layer
* API: update the usage for framerate in VAEncMiscParameterFrameRate to
  support non-integer frame-rate
* Add has_prime_sharing flag in VADriverVTableWayland to indicate if  
  buffer sharing with prime fd can be used in the backend driver

libva-intel-driver: https://lists.freedesktop.org/archives/libva/2016-November/004731.html
* Add support for HEVC 10bit encoding on KBL
* Integrate the Google Test Framework for unit testing
* Add support for bitrate control per temporal layer for SVC-T
* Fix VA_STATUS_ERROR_UNIMPLEMENTED when sharpening with I420 surface (https://bugs.freedesktop.org/show_bug.cgi?id=96987)
* Fix crop issue when sharpening with NV12 surface (https://bugs.freedesktop.org/show_bug.cgi?id=96988)
* Fix GPU hang issue when using encoding with low power on SKL GT3+ (https://bugs.freedesktop.org/show_bug.cgi?id=97872)