### PR TITLE
Fix "File not found" error when opening /dev/lirc0

### DIFF
--- a/packages/sysutils/lirc/system.d/lircd@.service
+++ b/packages/sysutils/lirc/system.d/lircd@.service
@@ -1,13 +1,12 @@
 [Unit]
 Description=Lirc with %I
-After=lircd-defaults.service
+After=lircd-defaults.service systemd-modules-load.service
 Requires=lircd-defaults.service
 
 ConditionPathExists=/storage/.cache/services/lircd.conf
 
 [Service]
 Type=oneshot
-After=systemd-modules-load.service
 ExecStart=/usr/lib/libreelec/lircd_helper add %I
 ExecStop=/usr/lib/libreelec/lircd_helper remove %I
 TimeoutStopSec=1

--- a/packages/sysutils/lirc/system.d/lircd@.service
+++ b/packages/sysutils/lirc/system.d/lircd@.service
@@ -7,6 +7,7 @@ ConditionPathExists=/storage/.cache/services/lircd.conf
 
 [Service]
 Type=oneshot
+After=systemd-modules-load.service
 ExecStart=/usr/lib/libreelec/lircd_helper add %I
 ExecStop=/usr/lib/libreelec/lircd_helper remove %I
 TimeoutStopSec=1


### PR DESCRIPTION
If lircd is started before the lirc_rpi kernel module is loaded, the device file doesn't exist yet and the daemon exists with a "File not found" error. Waiting for systemd-modules-load.service avoids the problem.