### PR TITLE
config/version: set ADDON_VERSION to 8.1

### DIFF
--- a/config/version
+++ b/config/version
@@ -5,5 +5,5 @@
   OS_VERSION="8.0"
 
 # ADDON_VERSION: Addon version
-  ADDON_VERSION="8.0"
+  ADDON_VERSION="8.1"
 


### PR DESCRIPTION
We need this to bump all the add-ons without pissing people off because suddenly all their add-ons broke with the next alpha bump.

I'd sit on this till we have everything in a stable state again, then we can rebuild and push add-ons