### PR TITLE
ccache: support build-specific directory

### DIFF
--- a/config/path
+++ b/config/path
@@ -186,7 +186,9 @@ XORG_PATH_DRIVERS=/usr/lib/xorg/modules/drivers
 . config/optimize
 
 if [ -z "$CCACHE_DIR" ]; then
-  if [ -n "$DEVICE" ]; then
+  if [ "$CCACHE_IN_BUILD_DIR" = "yes" ]; then
+    export CCACHE_DIR=$ROOT/$BUILD/.ccache
+  elif [ -n "$DEVICE" ]; then
     export CCACHE_DIR=$ROOT/.ccache/$PROJECT.$DEVICE.$TARGET_ARCH-$OS_VERSION
   else
     export CCACHE_DIR=$ROOT/.ccache/$PROJECT.$TARGET_ARCH-$OS_VERSION


### PR DESCRIPTION
Currently we have a "project" specific `.ccache` folder in the root, which is then shared between projects (even when building the same project with different options, for example with and without DEBUG).

This PR allows the `.ccache` folder to be within the build directory, making it build-specific.

To enable this, add `CCACHE_IN_BUILD_DIR=yes` in `$HOME/.libreelec/options`.