### PR TITLE
oscam: fix settings-default.xml

### DIFF
--- a/packages/addons/service/oscam/changelog.txt
+++ b/packages/addons/service/oscam/changelog.txt
@@ -1,3 +1,6 @@
+8.0.102
+- fix settings-default.xml
+
 8.0.101
 - Update OSCam to 11233
 - fix the WeTek_Play problems

--- a/packages/addons/service/oscam/changelog.txt
+++ b/packages/addons/service/oscam/changelog.txt
@@ -1,12 +1,9 @@
-8.0.102
-- fix settings-default.xml
+102
+- fix the delayed start workaround
 
-8.0.101
+101
 - Update OSCam to 11233
 - fix the WeTek_Play problems
 
-8.0.100
+100
 - Update for LibreELEC 8.0
-
-7.0.100
-- initial LibreELEC version

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -19,7 +19,7 @@
 PKG_NAME="oscam"
 PKG_VERSION="c677c6e"
 PKG_VERSION_NUMBER="11233"
-PKG_REV="101"
+PKG_REV="102"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.streamboard.tv/oscam/wiki"

--- a/packages/addons/service/oscam/source/settings-default.xml
+++ b/packages/addons/service/oscam/source/settings-default.xml
@@ -1,7 +1,7 @@
 <settings>
     <setting id="RESTART_ON_RESUME" value="false" />
     <setting id="WAIT_FOR_FEINIT" value="false" />
-    <setting id="$WORKAROUND_SLEEP" value="false" />
-    <setting id="$WORKAROUND_SLEEP_TIME" value="1" />
+    <setting id="WORKAROUND_SLEEP" value="false" />
+    <setting id="WORKAROUND_SLEEP_TIME" value="1" />
     <setting id="NUM_ADAPTERS" value="1" />
 </settings>


### PR DESCRIPTION
Because of those $s `eval` in `oe_setup_addon` fails (see `packages/mediacenter/kodi/profile.d/00-addons.conf`).
