### PR TITLE
samba: fix allocation/size on disk issues reported by Windows 8.x+

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -50,6 +50,8 @@
   # domain master = auto
   # os level = 20
 
+  strict allocate = yes
+  allocation roundup size = 0
 
 # Using the following configurations as a template allows you to add
 # writable shares of disks and paths under /storage


### PR DESCRIPTION
See: https://forum.libreelec.tv/thread-2485.html, which should be fixed by adding `allocation roundup size = 0`.

I've also added `strict allocate = yes` as this may improve performance (https://wiki.samba.org/index.php/Linux_Performance).

I'd like about a week of test builds without any incident before merging this, so keep open.
