### PR TITLE
Revert "boblightd: disable autoreconf"

### DIFF
--- a/packages/addons/service/boblightd/package.mk
+++ b/packages/addons/service/boblightd/package.mk
@@ -31,7 +31,7 @@ PKG_LONGDESC="Boblight($PKG_VERSION) is an opensource AmbiLight implementation."
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Boblight"
 PKG_ADDON_TYPE="xbmc.service"
-PKG_AUTORECONF="no"
+PKG_AUTORECONF="yes"
 
 if [ "$DISPLAYSERVER" = "x11" ] ; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libX11 libXext libXrender"


### PR DESCRIPTION
This reverts commit b8d54c996d2b9f7814265b3fd9428f6be7f79c3b.

This is needed to build boblight-aml