### PR TITLE
mysql: fixes debug build for aarch64

### DIFF
--- a/packages/databases/mysql/package.mk
+++ b/packages/databases/mysql/package.mk
@@ -59,6 +59,12 @@ PKG_CMAKE_OPTS_HOST="-DCMAKE_BUILD_TYPE=Release \
                      -DWITH_UNIT_TESTS=OFF \
                      -DWITH_ZLIB=bundled"
 
+if [ "$DEBUG" = yes -a "$TARGET_ARCH" = aarch64 ]; then
+  pre_configure_target() {
+    strip_lto
+  }
+fi
+
 make_host() {
   make comp_err
   make gen_lex_hash


### PR DESCRIPTION
Debug builds, at least for WH, failing at mysql. This quick fix works for me, ofc it only workaround the real problem. Someone with proper knowledge pls decide if this can be merged or not.