### PR TITLE
leave unittest for make possible install flexget

### DIFF
--- a/packages/lang/Python/package.mk
+++ b/packages/lang/Python/package.mk
@@ -113,7 +113,7 @@ makeinstall_target() {
 }
 
 post_makeinstall_target() {
-  EXCLUDE_DIRS="bsddb idlelib lib-tk lib2to3 msilib pydoc_data test unittest"
+  EXCLUDE_DIRS="bsddb idlelib lib-tk lib2to3 msilib pydoc_data test"
   for dir in $EXCLUDE_DIRS; do
     rm -rf $INSTALL/usr/lib/python*/$dir
   done


### PR DESCRIPTION
Hi
there is no addon and docker right now for Flexget, so is possible manualy install
but for that we need unittest in system.

This make life easier for many users
https://gist.github.com/cvium/a9cdb6d50d314a5e3933