### PR TITLE
backport of #981 (docker: update to 1.12.3)

### DIFF
--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,6 @@
+7.0.109
+- Update to docker 1.12.3
+
 7.0.108
 - Update to docker 1.12.2
 

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="docker"
-PKG_VERSION="1.12.2"
-PKG_REV="108"
+PKG_VERSION="1.12.3"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_ADDON_PROJECTS="Generic RPi RPi2"
 PKG_LICENSE="ASL"


### PR DESCRIPTION
backport of #981 

no ctop because the python isn't build with curses support.