### PR TITLE
scripts/create_addon: copy fanart to buildfolder too

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -137,6 +137,10 @@ pack_addon() {
       mkdir -p $ADDON_INSTALL_DIR/resources
       cp $ADDON_BUILD/$PKG_ADDON_ID/resources/icon.png $ADDON_INSTALL_DIR/resources/icon.png
     fi
+    if [ -f $ADDON_BUILD/$PKG_ADDON_ID/resources/fanart.png ]; then
+      mkdir -p $ADDON_INSTALL_DIR/resources
+      cp $ADDON_BUILD/$PKG_ADDON_ID/resources/fanart.png $ADDON_INSTALL_DIR/resources/fanart.png
+    fi
     for f in $ADDON_BUILD/$PKG_ADDON_ID/resources/screenshot-*.{jpg,png}; do
       if [ -f "$f" ]; then
         mkdir -p $ADDON_INSTALL_DIR/resources


### PR DESCRIPTION
copy the fanart.png to the `target/addons/8.1/arch/addon_name/resources/` folder, without the fanart is missing at the repo