### PR TITLE
packages/linux-drivers/wetekdvb: Update to wetekdvb-20161127

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wetekdvb"
-PKG_VERSION="20160930"
+PKG_VERSION="20161127"
 PKG_REV="1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"


### PR DESCRIPTION
Update WeTek proprietary DVB modules to wetekdvb-20161127.