### PR TITLE
kodi: bump repository.libreelec.tv to 8.1 for consistency

### DIFF
--- a/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.libreelec.tv"
 		name="LibreELEC Add-ons"
-		version="8.0.0"
+		version="8.1.0"
 		provider-name="Team LibreELEC">
 	<extension point="xbmc.addon.repository"
 		name="LibreELEC Add-ons">


### PR DESCRIPTION
I'm not entirely sure whether this is supposed to be 8.0.0 repo to match 8.0.0 release or 8.1.0 repo to match 8.1 repo version. Merge or close as appropriate.