### PR TITLE
xf86-input-synaptics: add package

### DIFF
--- a/packages/virtual/x11/package.mk
+++ b/packages/virtual/x11/package.mk
@@ -51,7 +51,7 @@ get_graphicdrivers
 if [ -n "$LIBINPUT" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-input-libinput"
 else
-  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-input-evdev"
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-input-evdev xf86-input-synaptics"
 fi
 
 for drv in $XORG_DRIVERS; do

--- a/packages/x11/driver/xf86-input-synaptics/package.mk
+++ b/packages/x11/driver/xf86-input-synaptics/package.mk
@@ -1,0 +1,34 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="xf86-input-synaptics"
+PKG_VERSION="1.9.0"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://lists.freedesktop.org/mailman/listinfo/xorg"
+PKG_URL="http://xorg.freedesktop.org/archive/individual/driver/$PKG_NAME-$PKG_VERSION.tar.bz2"
+PKG_DEPENDS_TARGET="toolchain libXi"
+PKG_SECTION="x11/driver"
+PKG_SHORTDESC="Synaptics touchpad driver for X.Org."
+PKG_LONGDESC="Synaptics touchpad driver for X.Org."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_CONFIGURE_OPTS_TARGET="--with-xorg-module-dir=$XORG_PATH_MODULES"


### PR DESCRIPTION
Add Synaptics x11 input driver (if using evdev instead of libinput), to handle some touchpad models.