### PR TITLE
alsa-lib: add HiFiBerry config

### DIFF
--- a/projects/RPi/filesystem/usr/share/alsa/cards/HifiberryDigi.conf
+++ b/projects/RPi/filesystem/usr/share/alsa/cards/HifiberryDigi.conf
@@ -1,0 +1,24 @@
+<confdir:pcm/iec958.conf>
+HifiberryDigi.pcm.iec958.0 {
+    @args [ CARD AES0 AES1 AES2 AES3 ]
+    @args.CARD {
+        type string
+    }
+    @args.AES0 {
+        type integer
+    }
+    @args.AES1 {
+        type integer
+    }
+    @args.AES2 {
+        type integer
+    }
+    @args.AES3 {
+        type integer
+    }
+    type hooks
+    slave.pcm {
+        type hw
+        card $CARD
+    }
+}

--- a/projects/RPi2/filesystem/usr/share/alsa/cards/HifiberryDigi.conf
+++ b/projects/RPi2/filesystem/usr/share/alsa/cards/HifiberryDigi.conf
@@ -1,0 +1,24 @@
+<confdir:pcm/iec958.conf>
+HifiberryDigi.pcm.iec958.0 {
+    @args [ CARD AES0 AES1 AES2 AES3 ]
+    @args.CARD {
+        type string
+    }
+    @args.AES0 {
+        type integer
+    }
+    @args.AES1 {
+        type integer
+    }
+    @args.AES2 {
+        type integer
+    }
+    @args.AES3 {
+        type integer
+    }
+    type hooks
+    slave.pcm {
+        type hw
+        card $CARD
+    }
+}


### PR DESCRIPTION
From poppcornmix:
> Can you add a file /usr/share/alsa/cards/snd_rpi_hifiber.conf containing http://paste.ubuntu.com/23554758/ for Pi builds? I've tested it and it allows passthrough to be enabled on hifiberry dac without this kodi hack: https://github.com/popcornmix/xbmc/commit/ec36920251aa06c98856db52c162345fe0d41e5d