### PR TITLE
gcc: do not abort when including host headers like from /usr/include,…

### DIFF
--- a/packages/lang/gcc/patches/gcc-crosscompile-badness.patch
+++ b/packages/lang/gcc/patches/gcc-crosscompile-badness.patch
@@ -2,7 +2,7 @@ Index: gcc-4.4+svnr145550/gcc/incpath.c
 ===================================================================
 --- gcc-4.4+svnr145550.orig/gcc/incpath.c	2009-04-04 13:48:31.000000000 -0700
 +++ gcc-4.4+svnr145550/gcc/incpath.c	2009-04-04 14:49:29.000000000 -0700
-@@ -417,6 +417,26 @@
+@@ -449,6 +449,26 @@
    p->construct = 0;
    p->user_supplied_p = user_supplied_p;
  
@@ -15,13 +15,13 @@ Index: gcc-4.4+svnr145550/gcc/incpath.c
 +		/* printf("Adding Path: %s\n", p->name ); */
 +		if( strstr(p->name, "/usr/include" ) == p->name ) {
 +			fprintf(stderr, _("CROSS COMPILE Badness: /usr/include in INCLUDEPATH: %s\n"), p->name);
-+			abort();
++			return;
 +		} else if( strstr(p->name, "/sw/include") == p->name ) {
 +			fprintf(stderr, _("CROSS COMPILE Badness: /sw/include in INCLUDEPATH: %s\n"), p->name);
-+			abort();
++			return;
 +		} else if( strstr(p->name, "/opt/include") == p->name ) {
 +			fprintf(stderr, _("CROSS COMPILE Badness: /opt/include in INCLUDEPATH: %s\n"), p->name);
-+			abort();
++			return;
 +		 }
 +	}
 +


### PR DESCRIPTION
… just ignore them

done as in https://github.com/stefansaraev/TB/commit/d002358d0fb711b2e0685a3398b331f8084667df

Path checking should be moved upper using path directly. Now we have small memory leak because of XNEW but probably only few bytes.