### PR TITLE
scripts/create_addon: workaround for pvr addons

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -137,6 +137,12 @@ pack_addon() {
       mkdir -p $ADDON_INSTALL_DIR/resources
       cp $ADDON_BUILD/$PKG_ADDON_ID/resources/icon.png $ADDON_INSTALL_DIR/resources/icon.png
     fi
+
+    # workaround for kodi pvr addons
+    if [ -f $ADDON_BUILD/$PKG_ADDON_ID/icon.png ]; then
+      cp $ADDON_BUILD/$PKG_ADDON_ID/icon.png $ADDON_INSTALL_DIR/icon.png
+    fi
+
     if [ -f $ADDON_BUILD/$PKG_ADDON_ID/resources/fanart.png ]; then
       mkdir -p $ADDON_INSTALL_DIR/resources
       cp $ADDON_BUILD/$PKG_ADDON_ID/resources/fanart.png $ADDON_INSTALL_DIR/resources/fanart.png


### PR DESCRIPTION
- the pvr addons ship the addon.xml in the old format, icon.png is at the old path (not in the resources sub folder) and at the addon.xml the entries for news, icon and fanart are missing

- what **is** working: icon and fanart is at the right folder that it gets picked up and properly recognised at the repo addon.xml (icon and fanart gets shown if addon is not installed), icon is in the right place to match the addon.xml from the addon (if the addon is installed)

- what is **not** working: fanart.png is at the resources sub folder of the addon but not recognised in the addon.xml from the addon (if the addon is installed), the news entry is also missing

A real fix is to support the new format by kodi-pvr instead of maintain the old version.