### PR TITLE
mesa: add Apollo and Kaby Lake support to 7.90.009

### DIFF
--- a/packages/graphics/mesa/patches/mesa-01-i965-add-APL-and-KBL-SKU-strings.patch
+++ b/packages/graphics/mesa/patches/mesa-01-i965-add-APL-and-KBL-SKU-strings.patch
@@ -1,0 +1,39 @@
+From b8509c8936bdb3deaeac86e2ee9716c06d4e0865 Mon Sep 17 00:00:00 2001
+From: Ben Widawsky <ben@bwidawsk.net>
+Date: Tue, 18 Oct 2016 13:32:08 -0700
+Subject: i965: Add some APL and KBL SKU strings
+
+We got a couple for products that exist on ark.intel.com, so let's just
+put them in now.
+
+Signed-off-by: Ben Widawsky <ben@bwidawsk.net>
+
+diff --git a/include/pci_ids/i965_pci_ids.h b/include/pci_ids/i965_pci_ids.h
+index 1566afd..a93228d 100644
+--- a/include/pci_ids/i965_pci_ids.h
++++ b/include/pci_ids/i965_pci_ids.h
+@@ -144,11 +144,11 @@ CHIPSET(0x5913, kbl_gt1_5, "Intel(R) Kabylake GT1.5")
+ CHIPSET(0x5915, kbl_gt1_5, "Intel(R) Kabylake GT1.5")
+ CHIPSET(0x5917, kbl_gt1_5, "Intel(R) Kabylake GT1.5")
+ CHIPSET(0x5912, kbl_gt2, "Intel(R) Kabylake GT2")
+-CHIPSET(0x5916, kbl_gt2, "Intel(R) Kabylake GT2")
++CHIPSET(0x5916, kbl_gt2, "Intel(R) HD Graphics 620 (Intel(R) Kabylake GT2)")
+ CHIPSET(0x591A, kbl_gt2, "Intel(R) Kabylake GT2")
+ CHIPSET(0x591B, kbl_gt2, "Intel(R) Kabylake GT2")
+ CHIPSET(0x591D, kbl_gt2, "Intel(R) Kabylake GT2")
+-CHIPSET(0x591E, kbl_gt2, "Intel(R) Kabylake GT2")
++CHIPSET(0x591E, kbl_gt2, "Intel(R) HD Graphics 615 (Kabylake GT2)")
+ CHIPSET(0x5921, kbl_gt2, "Intel(R) Kabylake GT2F")
+ CHIPSET(0x5923, kbl_gt3, "Intel(R) Kabylake GT3")
+ CHIPSET(0x5926, kbl_gt3, "Intel(R) Kabylake GT3")
+@@ -161,5 +161,5 @@ CHIPSET(0x22B3, chv,     "Intel(R) HD Graphics (Cherryview)")
+ CHIPSET(0x0A84, bxt,     "Intel(R) HD Graphics (Broxton)")
+ CHIPSET(0x1A84, bxt,     "Intel(R) HD Graphics (Broxton)")
+ CHIPSET(0x1A85, bxt_2x6, "Intel(R) HD Graphics (Broxton 2x6)")
+-CHIPSET(0x5A84, bxt,     "Intel(R) HD Graphics (Broxton)")
+-CHIPSET(0x5A85, bxt_2x6, "Intel(R) HD Graphics (Broxton 2x6)")
++CHIPSET(0x5A84, bxt,     "Intel(R) HD Graphics 505 (Broxton)")
++CHIPSET(0x5A85, bxt_2x6, "Intel(R) HD Graphics 500 (Broxton 2x6)")
+-- 
+cgit v0.10.2
+


### PR DESCRIPTION
I know this hardware is already supported by mesa 13.0.2 (#1006), but backporting to mesa 13.0.0 for 7.90.009 would be useful (tested in my builds).

ping @chewitt

@lrusak: Drop this in #1006...