### PR TITLE
scripts/create_addon: use PKG_REV as part of the binary addon version

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -63,7 +63,8 @@ pack_addon() {
       echo "*** ERROR: $ADDON has addon.xml shipped, you need 'xmlstarlet' ***"
       exit 255
     fi
-    ADDONVER=$(xmlstarlet sel -t -v "/addon/@version" $ADDON_BUILD/$PKG_ADDON_ID/addon.xml)
+    ADDONVER="$(xmlstarlet sel -t -v "/addon/@version" $ADDON_BUILD/$PKG_ADDON_ID/addon.xml).$PKG_REV"
+    xmlstarlet ed --inplace -u "/addon[@version]/@version" -v "$ADDONVER" $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
   fi
 
   if [ -d $PKG_DIR/source ]; then


### PR DESCRIPTION
This should have always been the case. I have been using this with retroplayer add-ons as often the emulator package would get updated but the binary add-on would stay the same, so the addon version would stay the same but the PKG_REV can allow the new add-on to exist.

This isn't the case for all binary add-ons but many use third party libraries that can be bumped independently from the binary add-on.

all PKG_REV should be reset to `1` or `100` for binary add-ons. I can include that in this PR if all agree.