### PR TITLE
build: switch to build-specific ccache by default

### DIFF
--- a/config/path
+++ b/config/path
@@ -187,11 +187,7 @@ XORG_PATH_DRIVERS=/usr/lib/xorg/modules/drivers
 . config/optimize
 
 if [ -z "$CCACHE_DIR" ]; then
-  if [ -n "$DEVICE" ]; then
-    export CCACHE_DIR=$ROOT/.ccache/$PROJECT.$DEVICE.$TARGET_ARCH-$OS_VERSION
-  else
-    export CCACHE_DIR=$ROOT/.ccache/$PROJECT.$TARGET_ARCH-$OS_VERSION
-  fi
+  export CCACHE_DIR=$ROOT/$BUILD/.ccache
 fi
 export MAKEFLAGS=-j$CONCURRENCY_MAKE_LEVEL
 export PKG_CONFIG=$ROOT/$TOOLCHAIN/bin/pkg-config


### PR DESCRIPTION
This is an alternative to #938 

In this version, the build-specific ccache is now the default, as this is the most complicated ccache folder name to determine, while being potentially the "safest" ccache variant.

Anyone wanting the old project-specific ccache can add the following to `$HOME/.libreelec/options`:
```
  if [ -n "$DEVICE" ]; then
    export CCACHE_DIR=$ROOT/.ccache/$PROJECT.$DEVICE.$TARGET_ARCH-$OS_VERSION
  else
    export CCACHE_DIR=$ROOT/.ccache/$PROJECT.$TARGET_ARCH-$OS_VERSION
  fi
```
If `$DEVICE` is not a concern, then it's a one line addition to `$HOME/.librelec/options` to re-instate a project-specific ccache, or whatever/whereve type of ccache you desire.