### PR TITLE
add lcms2 support for kodi

### DIFF
--- a/packages/devel/lcms2/package.mk
+++ b/packages/devel/lcms2/package.mk
@@ -1,0 +1,41 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="lcms2"
+PKG_VERSION="2.8"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="MIT"
+PKG_SITE="http://www.littlecms.com"
+PKG_URL="http://downloads.sourceforge.net/sourceforge/lcms/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain zlib libjpeg-turbo tiff"
+PKG_SECTION="system"
+PKG_SHORTDESC="Small-footprint color management engine, version 2"
+PKG_LONGDESC="Small-footprint color management engine, version 2"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+                           --disable-shared \
+                           --with-zlib \
+                           --with-threads"
+
+post_makeinstall_target() {
+  rm -rf $INSTALL
+}

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -23,7 +23,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host xmlstarlet:host Python zlib systemd pciutils lzo pcre swig:host libass curl fontconfig fribidi tinyxml libjpeg-turbo freetype libcdio taglib libxml2 libxslt yajl sqlite ffmpeg crossguid giflib libdvdnav libhdhomerun"
+PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host xmlstarlet:host Python zlib systemd pciutils lzo pcre swig:host libass curl fontconfig fribidi tinyxml libjpeg-turbo freetype libcdio taglib libxml2 libxslt yajl sqlite ffmpeg crossguid giflib libdvdnav libhdhomerun lcms2"
 PKG_SECTION="mediacenter"
 PKG_SHORTDESC="kodi: Kodi Mediacenter"
 PKG_LONGDESC="Kodi Media Center (which was formerly named Xbox Media Center or XBMC) is a free and open source cross-platform media player and home entertainment system software with a 10-foot user interface designed for the living-room TV. Its graphical user interface allows the user to easily manage video, photos, podcasts, and music from a computer, optical disk, local network, and the internet using a remote control."
@@ -209,6 +209,7 @@ PKG_CMAKE_OPTS_TARGET="-DNATIVEPREFIX=$ROOT/$TOOLCHAIN \
                        -DFFMPEG_INCLUDE_DIRS=$SYSROOT_PREFIX/usr \
                        -DENABLE_INTERNAL_CROSSGUID=OFF \
                        -DENABLE_SDL=OFF \
+                       -DENABLE_LCMS2=ON \
                        -DENABLE_OPENSSL=ON \
                        -DENABLE_UDEV=ON \
                        -DENABLE_DBUS=ON \

--- a/packages/mediacenter/kodi/patches/kodi-999.10-PR11072.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.10-PR11072.patch
@@ -1,0 +1,77 @@
+From 7012d3f0dafd3c643b48214a477a3d452f6c57fa Mon Sep 17 00:00:00 2001
+From: "h.udo" <hudokkow@gmail.com>
+Date: Tue, 6 Dec 2016 10:57:18 +0000
+Subject: [PATCH] [cmake] Add support for LCMS2
+
+---
+ project/cmake/CMakeLists.txt          |  2 +-
+ project/cmake/modules/FindLCMS2.cmake | 47 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 48 insertions(+), 1 deletion(-)
+ create mode 100644 project/cmake/modules/FindLCMS2.cmake
+
+diff --git a/project/cmake/CMakeLists.txt b/project/cmake/CMakeLists.txt
+index 430fdb6..d68f44f 100644
+--- a/project/cmake/CMakeLists.txt
++++ b/project/cmake/CMakeLists.txt
+@@ -119,7 +119,7 @@ endif()
+ # Optional dependencies
+ set(optional_deps MicroHttpd MySqlClient SSH XSLT
+                   Alsa UDEV DBus Avahi SmbClient
+-                  PulseAudio VDPAU VAAPI)
++                  PulseAudio VDPAU VAAPI LCMS2)
+ 
+ # Required, dyloaded deps
+ set(required_dyload Curl ASS)
+diff --git a/project/cmake/modules/FindLCMS2.cmake b/project/cmake/modules/FindLCMS2.cmake
+new file mode 100644
+index 0000000..d718314
+--- /dev/null
++++ b/project/cmake/modules/FindLCMS2.cmake
+@@ -0,0 +1,47 @@
++#.rst:
++# FindLCMS2
++# -----------
++# Finds the LCMS Color Management library
++#
++# This will will define the following variables::
++#
++# LCMS2_FOUND - system has LCMS Color Management
++# LCMS2_INCLUDE_DIRS - the LCMS Color Management include directory
++# LCMS2_LIBRARIES - the LCMS Color Management libraries
++# LCMS2_DEFINITIONS - the LCMS Color Management definitions
++#
++# and the following imported targets::
++#
++#   LCMS2::LCMS2   - The LCMS Color Management library
++
++if(PKG_CONFIG_FOUND)
++  pkg_check_modules(PC_LCMS2 lcms2 QUIET)
++endif()
++
++find_path(LCMS2_INCLUDE_DIR NAMES lcms2.h
++                            PATHS ${PC_LCMS2_INCLUDEDIR})
++find_library(LCMS2_LIBRARY NAMES lcms2 liblcms2
++                           PATHS ${PC_LCMS2_LIBDIR})
++
++set(LCMS2_VERSION ${PC_LCMS2_VERSION})
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(LCMS2
++                                  REQUIRED_VARS LCMS2_LIBRARY LCMS2_INCLUDE_DIR
++                                  VERSION_VAR LCMS2_VERSION)
++
++if(LCMS2_FOUND)
++  set(LCMS2_LIBRARIES ${LCMS2_LIBRARY})
++  set(LCMS2_INCLUDE_DIRS ${LCMS2_INCLUDE_DIR})
++  set(LCMS2_DEFINITIONS -DHAVE_LCMS2=1)
++
++  if(NOT TARGET LCMS2::LCMS2)
++    add_library(LCMS2::LCMS2 UNKNOWN IMPORTED)
++    set_target_properties(LCMS2::LCMS2 PROPERTIES
++                                       IMPORTED_LOCATION "${LCMS2_LIBRARY}"
++                                       INTERFACE_INCLUDE_DIRECTORIES "${LCMS2_INCLUDE_DIR}"
++                                       INTERFACE_COMPILE_DEFINITIONS HAVE_LCMS2=1)
++  endif()
++endif()
++
++mark_as_advanced(LCMS2_INCLUDE_DIR LCMS2_LIBRARY)


### PR DESCRIPTION
Not sure how I ever missed this.

This allows color management profiles in kodi

This adds an upstream patch from https://github.com/xbmc/xbmc/pull/11072
