### PR TITLE
bcm2835-driver: create symlinks for new firmware [backport]

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -43,20 +43,9 @@ make_target() {
     cp -PRv $FLOAT/opt/vc/include/* $SYSROOT_PREFIX/usr/include
 
   mkdir -p $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libEGL.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libGLESv2.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libbcm_host.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libcontainers.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libopenmaxil.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libvchiq_arm.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libvcos.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal_components.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal_core.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal_util.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal_vc_client.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libvcsm.so $SYSROOT_PREFIX/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libdtovl.so $SYSROOT_PREFIX/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/*.so $SYSROOT_PREFIX/usr/lib
+    ln -sf $SYSROOT_PREFIX/usr/lib/libbrcmEGL.so $SYSROOT_PREFIX/usr/lib/libEGL.so
+    ln -sf $SYSROOT_PREFIX/usr/lib/libbrcmGLESv2.so $SYSROOT_PREFIX/usr/lib/libGLESv2.so
 }
 
 makeinstall_target() {
@@ -64,27 +53,15 @@ makeinstall_target() {
     cp -PRv $FLOAT/opt/vc/sbin/vcfiled $INSTALL/usr/sbin
 
   mkdir -p $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libEGL.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libGLESv2.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libbcm_host.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libcontainers.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libopenmaxil.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libvchiq_arm.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libvcos.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal_components.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal_core.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal_util.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libmmal_vc_client.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libvcsm.so $INSTALL/usr/lib
-    cp -PRv $FLOAT/opt/vc/lib/libdtovl.so $INSTALL/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/*.so $INSTALL/usr/lib
+    ln -sf /usr/lib/libbrcmEGL.so $INSTALL/usr/lib/libEGL.so
+    ln -sf /usr/lib/libbrcmGLESv2.so $INSTALL/usr/lib/libGLESv2.so
 
 # some usefull debug tools
   mkdir -p $INSTALL/usr/bin
     cp -PRv $FLOAT/opt/vc/bin/dtoverlay $INSTALL/usr/bin
     ln -s dtoverlay $INSTALL/usr/bin/dtparam
     cp -PRv $FLOAT/opt/vc/bin/vcdbg $INSTALL/usr/bin
-    cp -PRv $FLOAT/opt/vc/lib/libdebug_sym.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/bin/vcgencmd $INSTALL/usr/bin
     cp -PRv $FLOAT/opt/vc/bin/tvservice $INSTALL/usr/bin
     cp -PRv $FLOAT/opt/vc/bin/edidparser $INSTALL/usr/bin


### PR DESCRIPTION
Backport of #768, required by latest firmware which itself is required to support RPi2B+...