### PR TITLE
libdvbcsa: add NEON support on aarch64

### DIFF
--- a/packages/addons/addon-depends/libdvbcsa/package.mk
+++ b/packages/addons/addon-depends/libdvbcsa/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libdvbcsa"
-PKG_VERSION="f988715"
+PKG_VERSION="1613dd4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"


### PR DESCRIPTION
more here:
https://github.com/glenvt18/libdvbcsa/commit/1613dd4071c6d7291a88eed2a2938e2a94ee2849

just switched commit to brach with NEON for aarch64
but i can if you want make a patch ... (that only 1 commit more compare to master)