### PR TITLE
samba: disable strict allocate

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -50,7 +50,10 @@
   # domain master = auto
   # os level = 20
 
-  strict allocate = yes
+  # "strict allocate = yes" breaks large network transfers to external hdd
+  # Force this to "no" in case "yes" becomes the default in future
+  strict allocate = no
+
   allocation roundup size = 0
 
 # Using the following configurations as a template allows you to add


### PR DESCRIPTION
This resolves an issue reported by users when transferring large files from the network to an external HDD:

http://forum.kodi.tv/showthread.php?tid=298461&pid=2476327#pid2476327
http://forum.kodi.tv/showthread.php?tid=298462&pid=2476329#pid2476329

As `strict allocate` may be enabled by default in future versions of Samba ([ref](https://wiki.samba.org/index.php/Linux_Performance#How_do_I_get_the_patch_.3F)), this PR will always force `strict allocate` to be disabled even though with 3.6.25 it is not currently necessary. That way if it is enabled by default in future we shouldn't see broken behaviour again.