### PR TITLE
Fixup post-/usr: need /usr/lib64

### DIFF
--- a/packages/virtual/initramfs/package.mk
+++ b/packages/virtual/initramfs/package.mk
@@ -45,6 +45,8 @@ post_install() {
   ( cd $ROOT/$BUILD/initramfs
     if [ "$TARGET_ARCH" = "x86_64" -o "$TARGET_ARCH" = "powerpc64" ]; then
       ln -sf /usr/lib $ROOT/$BUILD/initramfs/lib64
+      mkdir -p $ROOT/$BUILD/initramfs/usr
+      ln -sf /usr/lib $ROOT/$BUILD/initramfs/usr/lib64
     fi
 
     ln -sf /usr/lib $ROOT/$BUILD/initramfs/lib

--- a/scripts/image
+++ b/scripts/image
@@ -123,6 +123,8 @@ ln -sf /usr/sbin $INSTALL/sbin
 
 if [ "$TARGET_ARCH" = "x86_64" -o "$TARGET_ARCH" = "powerpc64" ]; then
   ln -s /usr/lib $INSTALL/lib64
+  mkdir -p $INSTALL/usr
+  ln -s /usr/lib $INSTALL/usr/lib64
 fi
 
 echo "$TARGET_VERSION" > $INSTALL/etc/release


### PR DESCRIPTION
After #805 (merge /usr), we need a `/usr/lib64` sym link.
```
NUC:~ # lsb_release
LibreELEC (Milhouse) - Version: devel-20161214021654-#1213x-g4b0e759 [Build #1213x]
NUC:~ # ls -la /usr/bin/Xorg
-rwxr-xr-x    1 root     root       1893088 Dec 14 02:18 /usr/bin/Xorg
NUC:~ # ldd /usr/bin/Xorg
$       not a dynamic executable
```
```
@escalade

9:41 AM you'll get not a dynamic executable
9:41strace shows ldd looking for /usr/lib/ld-linux.so.2, which isn't there then /usr/lib64/ld-linux-x86-64.so.2 which isn't there either
9:41there's /usr/lib/ld-linux-x86-64.so.2
9:42 in my build i symlinked /usr/lib to /usr/lib64 and it works
```

/usr/bin/ldd before /usr:
```
RTLDLIST="/lib/ld-linux.so.2 /lib64/ld-linux-x86-64.so.2 /libx32/ld-linux-x32.so.2"
```
/usr/bin/ldd AFTER /usr:
```
RTLDLIST="/usr/lib/ld-linux.so.2 /usr/lib64/ld-linux-x86-64.so.2 /usr/libx32/ld-linux-x32.so.2"
```
We only have `/lib64` sym link, while `/usr/lib64` is missing.

Not entirely sure if the `/usr/lib64` sym link in initrd is required - haven't had time to investigate that but guess it does no harm. Quickly run-time tested and system boots, `ldd` works again.