### PR TITLE
Package updates: nvidia 375.26 and nvidia-legacy 340.101

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="xf86-video-nvidia-legacy"
-PKG_VERSION="340.98"
+PKG_VERSION="340.101"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"

--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -20,7 +20,7 @@ PKG_NAME="xf86-video-nvidia"
 # Remember to run "python packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py" and commit changes to
 # "packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules" whenever bumping version.
 # Host may require installation of python-lxml and python-requests packages.
-PKG_VERSION="375.20"
+PKG_VERSION="375.26"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"


### PR DESCRIPTION
nvidia 375.26: [changelog](https://devtalk.nvidia.com/default/topic/981831)
nvidia-legacy 340.101: [changelog](https://devtalk.nvidia.com/default/topic/981835)

Builds fine with kernel 4.8 and also 4.9 (no nvidia-legacy-linux-4.9 patch required - #1017 updated).

nvidia-legacy successfully tested on ION2 (both 4.8.13 and 4.9.0)