### PR TITLE
Ignore warnings about C++11 compatibility

### DIFF
--- a/config/optimize
+++ b/config/optimize
@@ -38,6 +38,10 @@ HOST_LIBDIR="$ROOT/$TOOLCHAIN/lib"
 HOST_CFLAGS="$HOST_CFLAGS -Wno-format-security"
 HOST_CXXFLAGS="$HOST_CXXFLAGS -Wno-format-security" 
 
+# work around C++11 warning
+TARGET_CXXFLAGS="$TARGET_CXXFLAGS -Wno-literal-suffix"
+HOST_CXXFLAGS="$HOST_CXXFLAGS -Wno-literal-suffix"
+
 # add distro specific library dirs
   # ubuntu/debian specific "multiarch support"
     FAMILY_TRIPLET=$(echo $HOST_NAME | sed -e "s,$(uname -m),$(uname -i),")

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-streamdev/patches/vdr-plugin-streamdev-fixCpp11_h.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-streamdev/patches/vdr-plugin-streamdev-fixCpp11_h.patch
@@ -1,0 +1,11 @@
+--- vdr-plugin-streamdev-fc52e92/common.h.orig	2015-10-04 21:41:35.000000000 +0200
++++ vdr-plugin-streamdev-fc52e92/common.h	2016-12-13 13:23:28.967779478 +0100
+@@ -22,7 +22,7 @@
+ #define Dprintf(fmt, x...) {\
+ 	struct timespec ts;\
+ 	clock_gettime(CLOCK_MONOTONIC, &ts);\
+-	fprintf(stderr, "%ld.%.3ld [%d] "fmt,\
++	fprintf(stderr, "%ld.%.3ld [%d] " fmt,\
+ 		ts.tv_sec, ts.tv_nsec / 1000000, cThread::ThreadId(), ##x);\
+ }
+ #else


### PR DESCRIPTION
Build with GCC 6.2 fails for kodi and also for vdr-plugins-streamdef because of non C++11 compliant macro string concatenation.