### PR TITLE
system-tools: bump file package

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/file/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/file/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="file"
-PKG_VERSION="5.25"
+PKG_VERSION="5.29"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,8 +1,11 @@
+104
+- Bump file package
+
 103
 - Add nmon
 
 102
--Add inotify-tools, mc
+- Add inotify-tools, mc
 
 101
 - mrxvt can be started from KODI

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION=""
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""


### PR DESCRIPTION
fixes
```
LibreELEC:~ # file /bin/busybox
Aborted (core dumped)
```