### PR TITLE
xf86-video-nvidia-legacy: linux 4.9 fix

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia-legacy/patches/xf86-video-nvidia-legacy-kernel-4.9.patch
+++ b/packages/x11/driver/xf86-video-nvidia-legacy/patches/xf86-video-nvidia-legacy-kernel-4.9.patch
@@ -1,0 +1,15 @@
+diff -Naur a/kernel/nv-drm.c b/kernel/nv-drm.c
+--- a/kernel/nv-drm.c	2016-12-15 12:41:26.000000000 +0100
++++ b/kernel/nv-drm.c	2016-12-15 12:58:48.000000000 +0100
+@@ -115,7 +115,11 @@
+ };
+ 
+ static struct drm_driver nv_drm_driver = {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
++    .driver_features = DRIVER_GEM | DRIVER_PRIME | DRIVER_LEGACY,
++#else
+     .driver_features = DRIVER_GEM | DRIVER_PRIME,
++#endif
+     .load = nv_drm_load,
+     .unload = nv_drm_unload,
+     .fops = &nv_drm_fops,


### PR DESCRIPTION
Thanks to ejmarkow on the [NVIDIA Developer forum](https://devtalk.nvidia.com/default/topic/982052/linux/latest-nvidia-driver-340-101-builds-compiles-properly-but-fails-to-load-has-errors-with-linux-kernel-4-9-resolved-with-patch-/post/5039355/#5039355).

Build and run-time tested, 340.101 now loads normally wth 4.9.0.