### PR TITLE
linux: drm/i915: Fix setting of boost freq tunable

### DIFF
--- a/packages/linux/patches/default/linux-999-i915-fix-setting-of-boost-freq-tunable.patch
+++ b/packages/linux/patches/default/linux-999-i915-fix-setting-of-boost-freq-tunable.patch
@@ -1,0 +1,37 @@
+From 73a798711314b54cbd4fe224e24db92c306a8d8c Mon Sep 17 00:00:00 2001
+From: Mika Kuoppala <mika.kuoppala@linux.intel.com>
+Date: Wed, 14 Dec 2016 14:26:20 +0200
+Subject: drm/i915: Fix setting of boost freq tunable
+
+For limiting the max frequency of gpu, the max freq tunable
+is not enough to hard limit the max gap. We now have also per
+client boost max freq. When this tunable was introduced,
+it was mistakenly made read only. Allow user to gain control by
+setting it writable.
+
+Fixes: 29ecd78d3b79 ("drm/i915: Define a separate variable and control for RPS waitboost frequency")
+Cc: <stable@vger.kernel.org> # v4.9+
+Cc: Chris Wilson <chris@chris-wilson.co.uk>
+Cc: Mika Kuoppala <mika.kuoppala@intel.com>
+Cc: Daniel Vetter <daniel.vetter@intel.com>
+Cc: Jani Nikula <jani.nikula@linux.intel.com>
+Reviewed-by: Chris Wilson <chris@chris-wilson.co.uk>
+Signed-off-by: Mika Kuoppala <mika.kuoppala@intel.com>
+Link: http://patchwork.freedesktop.org/patch/msgid/1481718380-9170-1-git-send-email-mika.kuoppala@intel.com
+
+diff --git a/drivers/gpu/drm/i915/i915_sysfs.c b/drivers/gpu/drm/i915/i915_sysfs.c
+index b99fd96..40c0ac7 100644
+--- a/drivers/gpu/drm/i915/i915_sysfs.c
++++ b/drivers/gpu/drm/i915/i915_sysfs.c
+@@ -460,7 +460,7 @@ static ssize_t gt_min_freq_mhz_store(struct device *kdev,
+ 
+ static DEVICE_ATTR(gt_act_freq_mhz, S_IRUGO, gt_act_freq_mhz_show, NULL);
+ static DEVICE_ATTR(gt_cur_freq_mhz, S_IRUGO, gt_cur_freq_mhz_show, NULL);
+-static DEVICE_ATTR(gt_boost_freq_mhz, S_IRUGO, gt_boost_freq_mhz_show, gt_boost_freq_mhz_store);
++static DEVICE_ATTR(gt_boost_freq_mhz, S_IRUGO | S_IWUSR, gt_boost_freq_mhz_show, gt_boost_freq_mhz_store);
+ static DEVICE_ATTR(gt_max_freq_mhz, S_IRUGO | S_IWUSR, gt_max_freq_mhz_show, gt_max_freq_mhz_store);
+ static DEVICE_ATTR(gt_min_freq_mhz, S_IRUGO | S_IWUSR, gt_min_freq_mhz_show, gt_min_freq_mhz_store);
+ 
+-- 
+cgit v0.10.2
+


### PR DESCRIPTION
This might prove beneficial to anyone hoping to tune their Intel system.

There haven't yet been any reports of this being an issue, but that could happen in future.