### PR TITLE
moonlight: bump depends and rebuild

### DIFF
--- a/packages/addons/addon-depends/moonlight-common-c/package.mk
+++ b/packages/addons/addon-depends/moonlight-common-c/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="moonlight-common-c"
-PKG_VERSION="6455381"
+PKG_VERSION="1d058cb"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/addons/script/moonlight/changelog.txt
+++ b/packages/addons/script/moonlight/changelog.txt
@@ -1,3 +1,6 @@
+8.1.104
+- update moonlight-common-c to support GFE 3.2
+
 8.0.103
 - update Moonlight to 2.2.2
 

--- a/packages/addons/script/moonlight/package.mk
+++ b/packages/addons/script/moonlight/package.mk
@@ -19,7 +19,7 @@
 PKG_NAME="moonlight"
 PKG_VERSION="391de3f"
 PKG_VERSION_NUMBER="2.2.2"
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/dead/script.moonlight"


### PR DESCRIPTION
fixes a bug with the new gamestream client