### PR TITLE
Virtual network package: Fix samba and openvpn build options

### DIFF
--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -23,7 +23,7 @@ PKG_ARCH="any"
 PKG_LICENSE="various"
 PKG_SITE="http://www.openelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain connman iana-etc ethtool openssh openvpn"
+PKG_DEPENDS_TARGET="toolchain connman iana-etc ethtool openssh"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="network: Metapackage for packages to install network support"
 PKG_LONGDESC="network: Metapackage for various packages to install network support"
@@ -37,4 +37,8 @@ fi
 
 if [ "$SAMBA_SERVER" = "yes" ] || [ "$SAMBA_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET samba"
+fi
+
+if [ "$OPENVPN_SUPPORT" = "yes" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET openvpn"
 fi

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -35,3 +35,6 @@ if [ "$BLUETOOTH_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET bluez"
 fi
 
+if [ "$SAMBA_SERVER" = "yes" ] || [ "$SAMBA_SUPPORT" = "yes" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET samba"
+fi


### PR DESCRIPTION
For now the samba package is built only when KODI_SAMBA_SUPPORT is set to yes, whatever the setting of SAMBA_SERVER and/or SAMBA_SUPPORT in distributions/LibreELEC/options.

So if one doesn't want/need Kodi samba support he cannot have OS samba server/client.

This PR fixes it.