### PR TITLE
eventlircd: Fix missing buttons with WP2 remote

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -74,6 +74,11 @@ SUBSYSTEMS=="input", ATTRS{name}=="gpio_keypad", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="default.evmap"
 
+# Amlogic Remotes
+SUBSYSTEMS=="input", ATTRS{name}=="aml_keypad", \
+  ENV{eventlircd_enable}="true", \
+  ENV{eventlircd_evmap}="default.evmap"
+
 #-------------------------------------------------------------------------------
 # Ask eventlircd to handle USB HID devices that show up as event devices and are
 # known to be remote controls. For simplicity, the event map file names have the

--- a/projects/WeTek_Play_2/filesystem/etc/amremote/remote.conf
+++ b/projects/WeTek_Play_2/filesystem/etc/amremote/remote.conf
@@ -64,7 +64,7 @@ key_begin
     0x30 10 # 9
     0x71 14 # delete
     0x21 11 # 0
-    0x72 58 # caps lock
+    0x72 87 # capslock (mapped as F11)
     0x48 127 # menu
     0x03 102 # home
     0x61 158 # back


### PR DESCRIPTION
I noticed that on WP2 some keys weren't working. For instance Chan-Up and Chan-Down.
aml_keypad was not handled with eventlircd.

Please test this.