### PR TITLE
Update dbus packages

### DIFF
--- a/packages/devel/dbus-glib/package.mk
+++ b/packages/devel/dbus-glib/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="dbus-glib"
-PKG_VERSION="0.106"
+PKG_VERSION="0.108"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/python/system/dbus-python/package.mk
+++ b/packages/python/system/dbus-python/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="dbus-python"
-PKG_VERSION="1.2.0"
+PKG_VERSION="1.2.4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/sysutils/dbus/package.mk
+++ b/packages/sysutils/dbus/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="dbus"
-PKG_VERSION="1.11.2"
+PKG_VERSION="1.10.14"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
This PR updates dbus packages to latest versions

- `dbus` is downgraded to stable 1.10.14 release (https://lists.freedesktop.org/archives/dbus/2016-November/017063.html)
- `dbus-glib` and `dbus-python` is upgraded to latest versions and mostly contains changes to docs, test and build scripts

This was tested together with https://github.com/LibreELEC/service.libreelec.settings/pull/45 on a WeTek Hub