### PR TITLE
buildsystem: fix LD_LIBRARY_PATH for older ld

### DIFF
--- a/config/path
+++ b/config/path
@@ -200,7 +200,9 @@ if [ -z "$PATH" -o "$PATH" = "${PATH#$ROOT/$TOOLCHAIN/bin:}" ]; then
   export PATH="$ROOT/$TOOLCHAIN/bin:$ROOT/$TOOLCHAIN/sbin:$PATH"
 fi
 
-if [ -z "$LD_LIBRARY_PATH" -o "$LD_LIBRARY_PATH" = "${LD_LIBRARY_PATH#$ROOT/$TOOLCHAIN/lib:}" ]; then
+if [ -z "$LD_LIBRARY_PATH" ]; then
+  export LD_LIBRARY_PATH="$ROOT/$TOOLCHAIN/lib"
+elif [ "$LD_LIBARY_PATH" != "$ROOT/$TOOLCHAIN/lib" -a "$LD_LIBRARY_PATH" = "${LD_LIBRARY_PATH#$ROOT/$TOOLCHAIN/lib:}" ]; then
   export LD_LIBRARY_PATH="$ROOT/$TOOLCHAIN/lib:$LD_LIBRARY_PATH"
 fi
 

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -49,7 +49,8 @@ PKG_CMAKE_OPTS_HOST="-DLLVM_INCLUDE_TOOLS=ON \
                      -DLLVM_ENABLE_ASSERTIONS=OFF \
                      -DLLVM_ENABLE_WERROR=OFF \
                      -DLLVM_ENABLE_ZLIB=OFF \
-                     -DLLVM_OPTIMIZED_TABLEGEN=ON"
+                     -DLLVM_OPTIMIZED_TABLEGEN=ON \
+                     -DCMAKE_INSTALL_RPATH=$ROOT/$TOOLCHAIN/lib"
 
 make_host() {
   make llvm-config llvm-tblgen


### PR DESCRIPTION
* LD_LIBRARY_PATH should not end with ':'
* llvm-host should not include $ORIGIN/../lib

fixes @ozolli build issue from PR #805 

build tested under debian stable for Generic and RPi2