### PR TITLE
Revert "libconfig: update to libconfig-1.6"

### DIFF
--- a/packages/addons/addon-depends/libconfig/package.mk
+++ b/packages/addons/addon-depends/libconfig/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libconfig"
-PKG_VERSION="1.6"
+PKG_VERSION="1.5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"


### PR DESCRIPTION
This reverts commit 2642b4f4cb74206f915aac96f2b042b56df7265e.

Doesn't build (apologies - couple of add-on related packages crept in to #1075).