### PR TITLE
move back to DRI2

### DIFF
--- a/packages/x11/driver/xf86-video-ati/config/xorg-radeon.conf
+++ b/packages/x11/driver/xf86-video-ati/config/xorg-radeon.conf
@@ -1,6 +1,8 @@
 Section "Device"
         Identifier  "AMD Graphics"
         Driver      "radeon"
-        Option      "DRI3"        "1"
-        Option      "AccelMethod" "glamor"
+
+        # uncomment the following options to use DRI3 and glamor, otherwise DRI2 and exa
+        # Option      "DRI3"        "1"
+        # Option      "AccelMethod" "glamor"
 Endsection

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -51,7 +51,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-backlight \
                            --disable-tear-free \
                            --disable-create2 \
                            --disable-async-swap \
-                           --with-default-dri=3 \
+                           --with-default-dri=2 \
                            --with-xorg-module-dir=$XORG_PATH_MODULES"
 
 pre_configure_target() {


### PR DESCRIPTION
I didn't want to revert the previous commits as I want to leave DRI3 enabled but make it possible for users to opt in.

I would like others to comment as I consider this a bug fix as some people were reporting problems flickering, etc.

