### PR TITLE
ccache: fix build with CCACHE_DISABLE

### DIFF
--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -38,7 +38,9 @@ PKG_CONFIGURE_OPTS_HOST="--with-bundled-zlib"
 
 post_makeinstall_host() {
 # setup ccache
-  $ROOT/$TOOLCHAIN/bin/ccache --max-size=$CCACHE_CACHE_SIZE
+  if [ -z "$CCACHE_DISABLE" ]; then
+    $ROOT/$TOOLCHAIN/bin/ccache --max-size=$CCACHE_CACHE_SIZE
+  fi
 
   cat > $ROOT/$TOOLCHAIN/bin/host-gcc <<EOF
 #!/bin/sh


### PR DESCRIPTION
This PR fixes clean build when `CCACHE_DISABLE=1` is defined

ccache 3.1.10 included a bug fix for:
ccache no longer tries to create the cache directory when `CCACHE_DISABLE` is set. 

when max cache size is configured it stops with:
`ccache: error: could not set cache size limit: /path/to/.ccache/Generic.x86_64-8.0/ccache.conf: No such file or directory`