### PR TITLE
protobuf: set protoc path

### DIFF
--- a/packages/addons/addon-depends/protobuf/package.mk
+++ b/packages/addons/addon-depends/protobuf/package.mk
@@ -39,6 +39,8 @@ PKG_CMAKE_OPTS_HOST="-DCMAKE_NO_SYSTEM_FROM_IMPORTED=1 \
 
 PKG_CMAKE_OPTS_TARGET="$PKG_CMAKE_OPTS_HOST"
 
+PKG_CONFIGURE_OPTS_TARGET="--with-protoc=$ROOT/$TOOLCHAIN/bin/protoc"
+
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin
 


### PR DESCRIPTION
Without this protobuf fail on imx6 because protoc is used from target folder.

Before merging I will build on Jenkins Generic and RPi2 project to not brake something.