### PR TITLE
Create symbolic links for systemd unit aliases

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -270,6 +270,11 @@ enable_service () {
       fi
     done
   fi
+  for target in `grep '^Alias' $target_dir/$unit_dir/$unit | cut -f2 -d=` ; do
+    if [ -n "$target" ]; then
+      ln -sf ${unit} ${target_dir}/$unit_dir/${target}
+    fi
+  done
 }
 
 check_path() {

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -346,10 +346,7 @@ post_makeinstall_target() {
 }
 
 post_install() {
-  # link default.target to kodi.target
-  ln -sf kodi.target $INSTALL/usr/lib/systemd/system/default.target
-
-  # enable default services
+  enable_service kodi.target
   enable_service kodi-autostart.service
   enable_service kodi-cleanlogs.service
   enable_service kodi-halt.service


### PR DESCRIPTION
This PR makes `enable_service` behave more like `systemctl enable`, symbolic links is now created for aliases defined by `Alias=` in addition to current `WantedBy=` symbolic links

`kodi.target` is the only systemd unit using `Alias=` in LibreELEC