### PR TITLE
encode special characters in directory names as hex values

### DIFF
--- a/packages/addons/service/vdr-addon/changelog.txt
+++ b/packages/addons/service/vdr-addon/changelog.txt
@@ -1,3 +1,6 @@
+8.0.104
+- encode special characters in directory names as hex values
+
 8.0.103
 - add streamdev HEVC support
 - update VNSI to abd24d5

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -19,7 +19,7 @@
 
 PKG_NAME="vdr-addon"
 PKG_VERSION="8.0"
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openelec.tv"

--- a/packages/addons/service/vdr-addon/source/bin/vdr.start
+++ b/packages/addons/service/vdr-addon/source/bin/vdr.start
@@ -62,6 +62,8 @@ if [ "$ENABLE_EPGSEARCH" == "true" ] ; then
 fi
 VDR_ARG="$VDR_ARG --port=$SVDRP_PORT"
 
+VDR_ARG="$VDR_ARG --dirnames=,,1"
+
 VDR_ARG="$VDR_ARG --config=$ADDON_CONFIG_DIR"
 VDR_ARG="$VDR_ARG --resdir=$ADDON_DIR/res"
 VDR_ARG="$VDR_ARG --cachedir=$ADDON_CACHE_DIR"


### PR DESCRIPTION
Otherwise they may not be accesible from Windows via smb