### PR TITLE
Revert "dvb-firmware: update to 1.2.0"

### DIFF
--- a/packages/linux-firmware/dvb-firmware/package.mk
+++ b/packages/linux-firmware/dvb-firmware/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="dvb-firmware"
-PKG_VERSION="1.2.0"
+PKG_VERSION="1.1.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Free-to-use"


### PR DESCRIPTION
as we don't have proper dvb driver support in 8.0 we don't need the additional firmwares

re-revert if #1073 gets merged