### PR TITLE
busybox: Unset forced -Os optimization

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -117,10 +117,6 @@ configure_target() {
       sed -i -e "s|^CONFIG_FEATURE_MOUNT_CIFS=.*$|# CONFIG_FEATURE_MOUNT_CIFS is not set|" .config
     fi
 
-    # optimize for size
-    CFLAGS=`echo $CFLAGS | sed -e "s|-Ofast|-Os|"`
-    CFLAGS=`echo $CFLAGS | sed -e "s|-O.|-Os|"`
-
     # busybox fails to build with GOLD support enabled with binutils-2.25
     strip_gold
 


### PR DESCRIPTION
I don't know if there is a reason why -Os is forced on the busybox package.
Seems to work fine with O3.