### PR TITLE
mono: update to 4.6.2.7

### DIFF
--- a/packages/addons/tools/mono/changelog.txt
+++ b/packages/addons/tools/mono/changelog.txt
@@ -1,7 +1,10 @@
-8.0.101
+102
+- Update to 4.6.2.7
+
+101
 - Update to 4.2.1.102
 - Build static for all projects and architectures
 - Remove uneeded binaries and libraries
 
-8.0.100
+100
 - Initial release

--- a/packages/addons/tools/mono/package.mk
+++ b/packages/addons/tools/mono/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="mono"
-PKG_VERSION="4.2.1.102"
-PKG_REV="101"
+PKG_VERSION="4.6.2.7"
+PKG_REV="102"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.mono-project.com"


### PR DESCRIPTION
Work in progress, do not merge.
For RPi2, this builds, WebGrab+Plus runs fine, but Emby crashes on start.
@escalade I could need some help with this. Thank you in advance.
Obviously, the 51 MB patch can not remain like this, and I intend to download it separately (if that version of Mono runs, of course).