### PR TITLE
dtc: fix host install path

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -36,3 +36,8 @@ makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
     cp -P $ROOT/$PKG_BUILD/dtc $INSTALL/usr/bin
 }
+
+makeinstall_host() {
+  mkdir -p $INSTALL/usr/bin
+    cp -P $ROOT/$PKG_BUILD/dtc $INSTALL/usr/bin
+}


### PR DESCRIPTION
currenly dtc package install everything in $HOME when build for the
:host target. 
It's not the intended behavior, so override the path PREFIX in the Makefile and 
define a makeinstall_host function that will set the PREFIX variable to the proper 
:host path for dtc.

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>