### PR TITLE
cmake: set -DWITH_CPU and -DWITH_ARCH for kodi

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -182,10 +182,14 @@ else
   KODI_VAAPI="-DENABLE_VAAPI=OFF"
 fi
 
+# Set CPU and ARCH of target so that cmake can use suitable optimisations.
+# Without setting CPU and ARCH, Kodi cmake only knows CPU but not ARCH, and for RPi/RPi2 will use
+# CPU=arm (from CMAKE_SYSTEM_PROCESSOR set in toolchain file, which is correct so don't change that!)
+# Kodi doesn't support our Generic TARGET_CPU which is x86-64 - it supports only x86_64, same as TARGET_ARCH...
 if [ "$TARGET_ARCH" = "x86_64" ]; then
-  KODI_ARCH="-DWITH_CPU=$TARGET_ARCH"
+  KODI_ARCH="-DWITH_CPU=$TARGET_ARCH -DWITH_ARCH=$TARGET_ARCH"
 else
-  KODI_ARCH="-DWITH_ARCH=$TARGET_ARCH"
+  KODI_ARCH="-DWITH_CPU=$TARGET_CPU -DWITH_ARCH=$TARGET_ARCH"
 fi
 
 if [ ! "$KODIPLAYER_DRIVER" = default ]; then


### PR DESCRIPTION
This change came about after discussion with @wsnipex and https://github.com/xbmc/xbmc/pull/11343

It turns out that with the current LE build system, when building Kodi, we set `-DWITH_CPU=$TARGET_ARCH` for Generic, and `-DWITH_ARCH=$TARGET_ARCH` for everything else.

This has the effect that for RPi/RPi2 the CPU is not correctly determined:
RPi:
```

-- Core system type: rbpi
-- Platform:
-- CPU: arm, ARCH: arm
-- Cross-Compiling: TRUE
```

RPi2:
```
-- Core system type: rbpi
-- Platform:
-- CPU: arm, ARCH: arm
-- Cross-Compiling: TRUE
```

Generic:
```
-- Core system type: linux
-- Platform:
-- CPU: x86_64, ARCH: x86_64-linux
-- Cross-Compiling: TRUE
```

If we completely remove the `-DWITH_CPU` and `-DWITH_ARCH` from kodi/package.mk then Generic builds normally, but the RPi/RPi2 builds fail as now ARCH is not determined and CPU is instead detected as `arm`:

```
-- Core system type: rbpi
-- Platform: 
-- CPU: arm, ARCH: 
-- Cross-Compiling: TRUE
```

`arm` is coming from [CMAKE_SYSTEM_PROCESSOR](https://cmake.org/cmake/help/v3.5/variable/CMAKE_SYSTEM_PROCESSOR.html?highlight=cmake_system_processor#cmake-system-processor) in the toolchain file. Despite sounding like it should be set to the processor type, this property is apparently set correctly as the target platform architecture.

If we then always set `-DWITH_CPU=$TARGET_CPU` then RPi/RPi2 builds will succeed (https://github.com/xbmc/xbmc/pull/11343 will ensure the ARCH is set correctly, but not the CPU), but now Generic fails with invalid CPU - this is because TARGET_CPU on Generic is `x86-64` which is [bogus](https://github.com/xbmc/xbmc/blob/c4da9e834abc7e4a208e818e7390d8d1283f6ee7/cmake/scripts/linux/ArchSetup.cmake#L9). For some reason our TARGET_CPU on Generic has a hyphen, not an underscore.

With the change in this PR cmake will always know both CPU **AND** ARCH every time we build with cmake, and - unlike when CPU is unknown - all suitable optimisations will be applied by cmake now that it knows both CPU and ARCH.

RPi:
```

-- Core system type: rbpi
-- Platform:
-- CPU: arm1176jzf-s, ARCH: arm
-- Cross-Compiling: TRUE
```

RPi2:
```
-- Core system type: rbpi
-- Platform:
-- CPU: cortex-a7, ARCH: arm
-- Cross-Compiling: TRUE
```

Generic:
```
-- Core system type: linux
-- Platform:
-- CPU: x86_64, ARCH: x86_64
-- Cross-Compiling: TRUE
```

On RPi and RPi2, the files and filenames in before/after images are indentical.

On Generic, there are 4 files that change name - #0103i is the new build that includes this PR:.

```
MISSING FROM  #0103i: 5,704         ./usr/lib/kodi/system/libsse4-x86_64-linux.so
MISSING FROM  #0103i: 27,136        ./usr/lib/kodi/system/libexif-x86_64-linux.so
MISSING FROM  #0103i: 68,440        ./usr/lib/kodi/system/libcpluff-x86_64-linux.so
MISSING FROM  #0103i: 200,712       ./usr/lib/kodi/system/players/VideoPlayer/libdvdnav-x86_64-linux.so
NEW FILE IN   #0103i: 5,704         ./usr/lib/kodi/system/libsse4-x86_64.so
NEW FILE IN   #0103i: 27,136        ./usr/lib/kodi/system/libexif-x86_64.so
NEW FILE IN   #0103i: 68,440        ./usr/lib/kodi/system/libcpluff-x86_64.so
NEW FILE IN   #0103i: 200,712       ./usr/lib/kodi/system/players/VideoPlayer/libdvdnav-x86_64.so
```

In the new build, the four files no longer include the `-linux` platform suffix. So far I have not seen any problem with this change.


#### **Question**
Why do we have TARGET_CPU=`x86-64` (with hyphen)? Should we change this to underscore instead and avoid this headache in future?