### PR TITLE
libcec: update to libcec-4.0.1

### DIFF
--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libcec"
-PKG_VERSION="209884d"
+PKG_VERSION="2fc92b5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/projects/WeTek_Core/patches/libcec/libcec-00-amlogic-support.patch
+++ b/projects/WeTek_Core/patches/libcec/libcec-00-amlogic-support.patch
@@ -104,7 +104,7 @@ index 1e946e6..a539394 100644
  
  #if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_AOCEC_API)
  #error "libCEC doesn't have support for any type of adapter. please check your build system or configuration"
-@@ -173,11 +190,16 @@ IAdapterCommunication *CAdapterFactory::GetInstance(const char *strPort, uint16_
+@@ -173,6 +190,11 @@ IAdapterCommunication *CAdapterFactory::GetInstance(const char *strPort, uint16_
      return new CRPiCECAdapterCommunication(m_lib->m_cec);
  #endif
  
@@ -116,12 +116,6 @@ index 1e946e6..a539394 100644
  #if defined(HAVE_P8_USB)
    return new CUSBCECAdapterCommunication(m_lib->m_cec, strPort, iBaudRate);
  #endif
- 
--#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API)
-+#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API) && !defined(HAVE_AMLOGIC_API)
-   return NULL;
- #endif
- }
 diff --git a/src/libcec/adapter/Amlogic/AmlogicCEC.h b/src/libcec/adapter/Amlogic/AmlogicCEC.h
 new file mode 100644
 index 0000000..7b86982

--- a/projects/WeTek_Play/patches/libcec/libcec-00-amlogic-support.patch
+++ b/projects/WeTek_Play/patches/libcec/libcec-00-amlogic-support.patch
@@ -104,7 +104,7 @@ index 1e946e6..a539394 100644
  
  #if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_AOCEC_API)
  #error "libCEC doesn't have support for any type of adapter. please check your build system or configuration"
-@@ -173,11 +190,16 @@ IAdapterCommunication *CAdapterFactory::GetInstance(const char *strPort, uint16_
+@@ -173,6 +190,11 @@ IAdapterCommunication *CAdapterFactory::GetInstance(const char *strPort, uint16_
      return new CRPiCECAdapterCommunication(m_lib->m_cec);
  #endif
  
@@ -116,12 +116,6 @@ index 1e946e6..a539394 100644
  #if defined(HAVE_P8_USB)
    return new CUSBCECAdapterCommunication(m_lib->m_cec, strPort, iBaudRate);
  #endif
- 
--#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API)
-+#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API) && !defined(HAVE_AMLOGIC_API)
-   return NULL;
- #endif
- }
 diff --git a/src/libcec/adapter/Amlogic/AmlogicCEC.h b/src/libcec/adapter/Amlogic/AmlogicCEC.h
 new file mode 100644
 index 0000000..7b86982

--- a/projects/imx6/patches/libcec/libcec-100-from-xbian.patch
+++ b/projects/imx6/patches/libcec/libcec-100-from-xbian.patch
@@ -526,8 +526,8 @@ index 1e946e6..261c60d 100644
    return new CUSBCECAdapterCommunication(m_lib->m_cec, strPort, iBaudRate);
  #endif
  
--#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API)
-+#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API) && !defined(HAVE_IMX_API)
+-#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API) && !defined(HAVE_AOCEC_API)
++#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API) && !defined(HAVE_AOCEC_API) && !defined(HAVE_IMX_API)
    return NULL;
  #endif
  }


### PR DESCRIPTION
Bump to 4.0.1.

Should fix https://github.com/Pulse-Eight/libcec/issues/276 and https://github.com/Pulse-Eight/libcec/issues/272 and fixes missing [HAVE_AOCEC_API](https://github.com/Pulse-Eight/libcec/pull/274) (project patches updated, but untested).
