### PR TITLE
pkg-config: prefix sysroot path

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -17,9 +17,12 @@ setup_toolchain() {
       export CFLAGS="$TARGET_CFLAGS"
       export CXXFLAGS="$TARGET_CXXFLAGS"
       export LDFLAGS="$TARGET_LDFLAGS"
+      export PKG_CONFIG="$ROOT/$TOOLCHAIN/bin/pkg-config"
       export PKG_CONFIG_PATH=""
       export PKG_CONFIG_LIBDIR="$SYSROOT_PREFIX/usr/lib/pkgconfig:$SYSROOT_PREFIX/usr/share/pkgconfig"
       export PKG_CONFIG_SYSROOT_DIR="$SYSROOT_PREFIX"
+      export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1
+      export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1
       export CMAKE_CONF=$ROOT/$TOOLCHAIN/etc/cmake-$TARGET_NAME.conf
       export CMAKE="cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF -DCMAKE_INSTALL_PREFIX=/usr"
       if [ ! -f $CMAKE_CONF ] ; then
@@ -66,9 +69,12 @@ setup_toolchain() {
       export CFLAGS="$HOST_CFLAGS"
       export CXXFLAGS="$HOST_CXXFLAGS"
       export LDFLAGS="$HOST_LDFLAGS"
+      export PKG_CONFIG="$ROOT/$TOOLCHAIN/bin/pkg-config"
       export PKG_CONFIG_PATH=""
       export PKG_CONFIG_LIBDIR="$ROOT/$TOOLCHAIN/lib/pkgconfig:$ROOT/$TOOLCHAIN/share/pkgconfig"
       export PKG_CONFIG_SYSROOT_DIR=""
+      unset PKG_CONFIG_ALLOW_SYSTEM_CFLAGS
+      unset PKG_CONFIG_ALLOW_SYSTEM_LIBS
       export CMAKE_CONF=$ROOT/$TOOLCHAIN/etc/cmake-$HOST_NAME.conf
       export CMAKE="cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF -DCMAKE_INSTALL_PREFIX=$ROOT/$TOOLCHAIN"
       if [ ! -f $CMAKE_CONF ] ; then

--- a/packages/devel/pkg-config/patches/pkg-config-0001-use-sysroot-path.patch
+++ b/packages/devel/pkg-config/patches/pkg-config-0001-use-sysroot-path.patch
@@ -1,0 +1,28 @@
+diff -Naur a/pkg.c b/pkg.c
+--- a/pkg.c	2016-02-26 17:56:52.000000000 +0100
++++ b/pkg.c	2017-01-02 19:48:34.000000000 +0100
+@@ -468,11 +468,14 @@
+     Flag *flag = tmp->data;
+     char *tmpstr = flag->arg;
+ 
+-    if (pcsysrootdir != NULL && flag->type & (CFLAGS_I | LIBS_L)) {
++    if (pcsysrootdir != NULL && flag->type & (CFLAGS_I | LIBS_L) && strncmp(tmpstr+2, pcsysrootdir, strlen(pcsysrootdir)) != 0) {
+       g_string_append_c (str, '-');
+       g_string_append_c (str, tmpstr[1]);
+       g_string_append (str, pcsysrootdir);
+       g_string_append (str, tmpstr+2);
++    } else if (pcsysrootdir != NULL && strncmp(tmpstr, "/usr", 4) == 0 && strncmp(tmpstr, pcsysrootdir, strlen(pcsysrootdir)) != 0) {
++      g_string_append (str, pcsysrootdir);
++      g_string_append (str, tmpstr);
+     } else {
+       g_string_append (str, tmpstr);
+     }
+@@ -1087,6 +1090,8 @@
+         {
+           if (str->len > 0)
+             g_string_append_c (str, ' ');
++          if (pcsysrootdir != NULL && (strcmp(varname, "includedir") == 0 || strcmp(varname, "libdir") == 0) && strncmp(var, pcsysrootdir, strlen(pcsysrootdir)) != 0)
++            g_string_append (str, pcsysrootdir);
+           g_string_append (str, var);
+           g_free (var);
+         }

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
@@ -32,9 +32,6 @@ PKG_AUTORECONF="no"
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.audioencoder"
 
-PKG_CMAKE_OPTS_TARGET="-DFLAC_INCLUDE_DIRS=$SYSROOT_PREFIX/usr/include \
-                       -DOGG_INCLUDE_DIRS=$SYSROOT_PREFIX/usr/include"
-
 addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/
   cp -R $PKG_BUILD/.install_pkg/usr/share/kodi/addons/$PKG_NAME/* $ADDON_BUILD/$PKG_ADDON_ID/

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
@@ -32,8 +32,6 @@ PKG_AUTORECONF="no"
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.audioencoder"
 
-PKG_CMAKE_OPTS_TARGET="-DLAME_INCLUDE_DIRS=$SYSROOT_PREFIX/usr/include"
-
 addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/
   cp -R $PKG_BUILD/.install_pkg/usr/share/kodi/addons/$PKG_NAME/* $ADDON_BUILD/$PKG_ADDON_ID/

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
@@ -32,10 +32,6 @@ PKG_AUTORECONF="no"
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.audioencoder"
 
-PKG_CMAKE_OPTS_TARGET="-DOGG_INCLUDE_DIRS=$SYSROOT_PREFIX/usr/include \
-                       -DVORBIS_INCLUDE_DIRS=$SYSROOT_PREFIX/usr/include \
-                       -DVORBISENC_INCLUDE_DIRS=$SYSROOT_PREFIX/usr/include"
-
 addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/
   cp -R $PKG_BUILD/.install_pkg/usr/share/kodi/addons/$PKG_NAME/* $ADDON_BUILD/$PKG_ADDON_ID/

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -32,9 +32,6 @@ PKG_AUTORECONF="no"
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.pvrclient"
 
-PKG_CMAKE_OPTS_TARGET="-DHDHOMERUN_LIBRARIES=$SYSROOT_PREFIX/usr/lib/libhdhomerun.so \
-                       -DHDHOMERUN_INCLUDE_DIRS=$SYSROOT_PREFIX/usr/include/hdhomerun"
-
 addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/
   cp -R $PKG_BUILD/.install_pkg/usr/share/kodi/addons/$PKG_NAME/* $ADDON_BUILD/$PKG_ADDON_ID/


### PR DESCRIPTION
This PR makes cmake set sysroot prefixed `<package>_INCLUDE_DIRS` and other variables when a package is found by pkg-config.

This adds a patch to pkg-config that changes the following behaviors:
- Include and library path is included in output for target, `PKG_CONFIG_ALLOW_SYSTEM_(CFLAGS|LIBS)`
- Sysroot path is no longer double prefixed when `.pc`-file already contains a sysroot path
- Sysroot path is prefixed for static library files
- Sysroot path is prefixed for `includedir` and `libdir` variables, they are usually added to cmake `<package>_INCLUDE_DIRS`

Needs more build and runtime testing.