### PR TITLE
repo: correct minimum add-on version for ls.io repo

### DIFF
--- a/packages/addons/repository/repository.linuxserver.docker/sources/addon.xml
+++ b/packages/addons/repository/repository.linuxserver.docker/sources/addon.xml
@@ -4,7 +4,7 @@
        version="@PKG_VERSION@.@PKG_REV@"
        provider-name="LinuxServer.io">
   <requires>
-    <import addon="xbmc.addon" version="@OS_VERSION@"/>
+    <import addon="xbmc.addon" version="16.1.0"/>
   </requires>
   <extension point="xbmc.addon.repository"
              name="LinuxServer.io's Docker Add-on Repository">


### PR DESCRIPTION
This sets the minimum Kodi version to 16.1 (Jarvis) which corresponds to LE 7.0. PKG_REV does not need to be bumped as nobody can install the current zip. I'll clean things up before pushing the updated version.