### PR TITLE
steamcontroller: update to 60499dc

### DIFF
--- a/packages/addons/driver/steamcontroller/changelog.txt
+++ b/packages/addons/driver/steamcontroller/changelog.txt
@@ -1,2 +1,6 @@
-100
+8.1.101
+- Update to 60499dc
+- Fix cpu usage due to high polling rate
+
+8.0.100
 - Initial add-on

--- a/packages/addons/driver/steamcontroller/package.mk
+++ b/packages/addons/driver/steamcontroller/package.mk
@@ -17,13 +17,13 @@
 ################################################################################
 
 PKG_NAME="steamcontroller"
-PKG_VERSION="02f27c4"
-PKG_REV="100"
+PKG_VERSION="60499dc"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ynsta/steamcontroller"
 PKG_URL="https://github.com/ynsta/steamcontroller/archive/$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain Python distutilscross:host python-libusb1 enum34 linux"
+PKG_DEPENDS_TARGET="toolchain Python distutilscross:host python-libusb1 enum34 linux:host"
 PKG_SECTION="driver"
 PKG_SHORTDESC="A standalone userland driver for the steam controller to be used where steam client can't be installed."
 PKG_LONGDESC="A standalone userland driver for the steam controller to be used where steam client can't be installed."

--- a/packages/addons/driver/steamcontroller/patches/steamcontroller-0001-fix-include-dir.patch
+++ b/packages/addons/driver/steamcontroller/patches/steamcontroller-0001-fix-include-dir.patch
@@ -1,7 +1,14 @@
-diff -Naur a/src/uinput.py b/src/uinput.py
---- a/src/uinput.py	2016-01-02 23:13:18.000000000 +0100
-+++ b/src/uinput.py	2016-01-03 08:44:34.003676619 +0100
-@@ -34,10 +34,10 @@
+commit 8da1123bcbf3ad12b6c9d7975ebbb3f8663fd166
+Author: Lukas Rusak <lorusak@gmail.com>
+Date:   Sat Jan 7 13:50:30 2017 -0800
+
+    fix include dir
+
+diff --git a/src/uinput.py b/src/uinput.py
+index 684a018..ffc2354 100644
+--- a/src/uinput.py
++++ b/src/uinput.py
+@@ -36,10 +36,10 @@ from steamcontroller.tools import get_so_extensions
  from collections import deque
  
  # Get All defines from linux headers

--- a/packages/addons/driver/steamcontroller/patches/steamcontroller-0002-append-python-path.patch
+++ b/packages/addons/driver/steamcontroller/patches/steamcontroller-0002-append-python-path.patch
@@ -1,6 +1,26 @@
-diff -Naur a/scripts/sc-desktop.py b/scripts/sc-desktop.py
---- a/scripts/sc-desktop.py	2016-01-02 23:13:18.000000000 +0100
-+++ b/scripts/sc-desktop.py	2016-01-04 22:00:18.536497613 +0100
+commit b1bcba9b73d1e5e755ef6cda014ea3cc5a5ba270
+Author: Lukas Rusak <lorusak@gmail.com>
+Date:   Sat Jan 7 13:51:01 2017 -0800
+
+    append python path
+
+diff --git a/scripts/sc-callbacks.py b/scripts/sc-callbacks.py
+index eaeb658..35a272a 100755
+--- a/scripts/sc-callbacks.py
++++ b/scripts/sc-callbacks.py
+@@ -25,6 +25,8 @@
+ """Steam Controller Callback Mode example"""
+ import sys
+ 
++sys.path.append('/storage/.kodi/addons/driver.steamcontroller/lib')
++
+ from steamcontroller import SteamController, SCButtons
+ from steamcontroller.events import EventMapper, Pos
+ from steamcontroller.uinput import Keys
+diff --git a/scripts/sc-desktop.py b/scripts/sc-desktop.py
+index 9eff430..e0b8ec7 100755
+--- a/scripts/sc-desktop.py
++++ b/scripts/sc-desktop.py
 @@ -22,6 +22,10 @@
  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  # THE SOFTWARE.
@@ -12,9 +32,53 @@ diff -Naur a/scripts/sc-desktop.py b/scripts/sc-desktop.py
  """Steam Controller Mouse, Keyboard mode"""
  
  from steamcontroller import SteamController, SCButtons
-diff -Naur a/scripts/sc-xbox.py b/scripts/sc-xbox.py
---- a/scripts/sc-xbox.py	2016-01-02 23:13:18.000000000 +0100
-+++ b/scripts/sc-xbox.py	2016-01-04 22:00:30.751519105 +0100
+diff --git a/scripts/sc-dump.py b/scripts/sc-dump.py
+index b6f2c24..b582771 100755
+--- a/scripts/sc-dump.py
++++ b/scripts/sc-dump.py
+@@ -25,6 +25,9 @@
+ """Steam Controller USB Dumper"""
+ 
+ import sys
++
++sys.path.append('/storage/.kodi/addons/driver.steamcontroller/lib')
++
+ from steamcontroller import SteamController
+ 
+ def dump(_, sci):
+diff --git a/scripts/sc-mixed.py b/scripts/sc-mixed.py
+index 4a9c3c0..5e25af9 100755
+--- a/scripts/sc-mixed.py
++++ b/scripts/sc-mixed.py
+@@ -22,6 +22,10 @@
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ # THE SOFTWARE.
+ 
++import sys
++
++sys.path.append('/storage/.kodi/addons/driver.steamcontroller/lib')
++
+ """Steam Controller XBOX360 Gamepad Emulator"""
+ 
+ from steamcontroller import \
+diff --git a/scripts/sc-test-cmsg.py b/scripts/sc-test-cmsg.py
+index 08c8481..a59fbe9 100755
+--- a/scripts/sc-test-cmsg.py
++++ b/scripts/sc-test-cmsg.py
+@@ -26,6 +26,9 @@
+ 
+ import sys
+ import struct
++
++sys.path.append('/storage/.kodi/addons/driver.steamcontroller/lib')
++
+ from steamcontroller import SteamController
+ 
+ def dump(_, sci):
+diff --git a/scripts/sc-xbox.py b/scripts/sc-xbox.py
+index 814c8bc..89d4f55 100755
+--- a/scripts/sc-xbox.py
++++ b/scripts/sc-xbox.py
 @@ -22,6 +22,10 @@
  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  # THE SOFTWARE.

--- a/packages/addons/driver/steamcontroller/patches/steamcontroller-0003-wait-for-controller-connection.patch
+++ b/packages/addons/driver/steamcontroller/patches/steamcontroller-0003-wait-for-controller-connection.patch
@@ -1,31 +1,62 @@
-diff -Naur a/src/__init__.py b/src/__init__.py
---- a/src/__init__.py	2016-09-14 13:00:35.000000000 -0700
-+++ b/src/__init__.py	2016-11-17 23:40:57.137095353 -0800
-@@ -116,18 +116,16 @@
+commit 21abfb33340ba34de9c7266568515fc42608b339
+Author: Lukas Rusak <lorusak@gmail.com>
+Date:   Fri Jan 13 14:27:18 2017 -0800
+
+    wait for controller
+
+diff --git a/src/__init__.py b/src/__init__.py
+index 1bf111e..353f032 100644
+--- a/src/__init__.py
++++ b/src/__init__.py
+@@ -24,7 +24,7 @@ import struct
+ from enum import IntEnum
+ 
+ from threading import Timer
+-from time import time
++from time import time, sleep
+ 
+ 
+ VENDOR_ID = 0x28de
+@@ -121,24 +121,28 @@ class SteamController(object):
          self._cmsg = []
          self._ctx = usb1.USBContext()
  
-+        while self._handle is None:
-+            for i in range(len(PRODUCT_ID)):
-+                pid = PRODUCT_ID[i]
-+                endpoint = ENDPOINT[i]
-+                ccidx = CONTROLIDX[i]
- 
++        _handle = None
+         handle = []
+         pid = []
+         endpoint = []
+         ccidx = []
 -        for i in range(len(PRODUCT_ID)):
--            pid = PRODUCT_ID[i]
--            endpoint = ENDPOINT[i]
--            ccidx = CONTROLIDX[i]
+-            _pid = PRODUCT_ID[i]
+-            _endpoint = ENDPOINT[i]
+-            _ccidx = CONTROLIDX[i]
 -
--            self._handle = self._ctx.openByVendorIDAndProductID(
--                VENDOR_ID, pid,
+-            _handle = self._ctx.openByVendorIDAndProductID(
+-                VENDOR_ID, _pid,
 -                skip_on_error=True,
 -            )
--            if self._handle is not None:
--                break
-+                self._handle = self._ctx.openByVendorIDAndProductID(
-+                    VENDOR_ID, pid,
+-            if _handle != None:
+-                handle.append(_handle)
+-                pid.append(_pid)
+-                endpoint.append(_endpoint)
+-                ccidx.append(_ccidx)
++
++        while _handle is None:
++            for i in range(len(PRODUCT_ID)):
++                _pid = PRODUCT_ID[i]
++                _endpoint = ENDPOINT[i]
++                _ccidx = CONTROLIDX[i]
++
++                _handle = self._ctx.openByVendorIDAndProductID(
++                    VENDOR_ID, _pid,
 +                    skip_on_error=True,
 +                )
++                if _handle != None:
++                    handle.append(_handle)
++                    pid.append(_pid)
++                    endpoint.append(_endpoint)
++                    ccidx.append(_ccidx)
++            sleep(2)
  
-         if self._handle is None:
-             raise ValueError('SteamControler Device not found')
+         if len(handle) == 0:
+             raise ValueError('No SteamControler Device found')

--- a/packages/addons/driver/steamcontroller/patches/steamcontroller-0004-use-run-for-pid-directory.patch
+++ b/packages/addons/driver/steamcontroller/patches/steamcontroller-0004-use-run-for-pid-directory.patch
@@ -1,24 +1,54 @@
-diff -Naur a/scripts/sc-desktop.py b/scripts/sc-desktop.py
---- a/scripts/sc-desktop.py	2016-11-18 13:31:29.522462062 -0800
-+++ b/scripts/sc-desktop.py	2016-11-18 13:33:09.268432661 -0800
-@@ -80,7 +80,7 @@
-         parser = argparse.ArgumentParser(description=__doc__)
-         parser.add_argument('command', type=str, choices=['start', 'stop', 'restart', 'debug'])
+commit 5947f69820db3ce2d976ac533fb64319637d3f93
+Author: Lukas Rusak <lorusak@gmail.com>
+Date:   Sat Jan 7 13:53:36 2017 -0800
+
+    use run for pid directory
+
+diff --git a/scripts/sc-desktop.py b/scripts/sc-desktop.py
+index e0b8ec7..ad494d8 100755
+--- a/scripts/sc-desktop.py
++++ b/scripts/sc-desktop.py
+@@ -87,9 +87,9 @@ if __name__ == '__main__':
+         parser.add_argument('-i', '--index', type=int, choices=[0,1,2,3], default=None)
          args = parser.parse_args()
--        daemon = SCDaemon('/tmp/steamcontroller.pid')
-+        daemon = SCDaemon('/run/steamcontroller.pid')
+         if args.index != None:
+-            daemon = SCDaemon('/tmp/steamcontroller{:d}.pid'.format(args.index))
++            daemon = SCDaemon('/run/steamcontroller{:d}.pid'.format(args.index))
+         else:
+-            daemon = SCDaemon('/tmp/steamcontroller.pid')
++            daemon = SCDaemon('/run/steamcontroller.pid')
  
          if 'start' == args.command:
              daemon.start()
-diff -Naur a/scripts/sc-xbox.py b/scripts/sc-xbox.py
---- a/scripts/sc-xbox.py	2016-11-18 13:31:29.522462062 -0800
-+++ b/scripts/sc-xbox.py	2016-11-18 13:33:09.266432642 -0800
-@@ -79,7 +79,7 @@
-         parser = argparse.ArgumentParser(description=__doc__)
-         parser.add_argument('command', type=str, choices=['start', 'stop', 'restart', 'debug'])
+diff --git a/scripts/sc-mixed.py b/scripts/sc-mixed.py
+index 5e25af9..c9139e7 100755
+--- a/scripts/sc-mixed.py
++++ b/scripts/sc-mixed.py
+@@ -126,9 +126,9 @@ if __name__ == '__main__':
+         parser.add_argument('-i', '--index', type=int, choices=[0,1,2,3], default=None)
          args = parser.parse_args()
--        daemon = SCDaemon('/tmp/steamcontroller.pid')
-+        daemon = SCDaemon('/run/steamcontroller.pid')
+         if args.index != None:
+-            daemon = SCDaemon('/tmp/steamcontroller{:d}.pid'.format(args.index))
++            daemon = SCDaemon('/run/steamcontroller{:d}.pid'.format(args.index))
+         else:
+-            daemon = SCDaemon('/tmp/steamcontroller.pid')
++            daemon = SCDaemon('/run/steamcontroller.pid')
+ 
+         if 'start' == args.command:
+             daemon.start()
+diff --git a/scripts/sc-xbox.py b/scripts/sc-xbox.py
+index 89d4f55..0c61b4e 100755
+--- a/scripts/sc-xbox.py
++++ b/scripts/sc-xbox.py
+@@ -86,9 +86,9 @@ if __name__ == '__main__':
+         parser.add_argument('-i', '--index', type=int, choices=[0,1,2,3], default=None)
+         args = parser.parse_args()
+         if args.index != None:
+-            daemon = SCDaemon('/tmp/steamcontroller{:d}.pid'.format(args.index))
++            daemon = SCDaemon('/run/steamcontroller{:d}.pid'.format(args.index))
+         else:
+-            daemon = SCDaemon('/tmp/steamcontroller.pid')
++            daemon = SCDaemon('/run/steamcontroller.pid')
  
          if 'start' == args.command:
              daemon.start()

--- a/packages/addons/driver/steamcontroller/patches/steamcontroller-0005-steam-client-will-never-be-running.patch
+++ b/packages/addons/driver/steamcontroller/patches/steamcontroller-0005-steam-client-will-never-be-running.patch
@@ -1,0 +1,41 @@
+commit 1467b7cd9d153be6680cc818b10c66967a2f0951
+Author: Lukas Rusak <lorusak@gmail.com>
+Date:   Sat Jan 7 14:11:25 2017 -0800
+
+    steam client will never be running
+
+diff --git a/src/daemon.py b/src/daemon.py
+index 964c765..fba7792 100644
+--- a/src/daemon.py
++++ b/src/daemon.py
+@@ -9,7 +9,6 @@ import time
+ import atexit
+ import signal
+ import syslog
+-import psutil
+ import traceback
+ import gc
+ 
+@@ -92,16 +91,12 @@ class Daemon(object):
+         self.daemonize()
+         syslog.syslog(syslog.LOG_INFO, '{}: started'.format(os.path.basename(sys.argv[0])))
+         while True:
+-            # look if steam is running
+-            if len([p for p in psutil.process_iter() if p.name() == 'steam']) == 0:
+-                try:
+-                    self.run()
+-                except Exception as e: # pylint: disable=W0703
+-                    syslog.syslog(syslog.LOG_ERR, '{}: {!s}'.format(os.path.basename(sys.argv[0]), e))
+-                    syslog.syslog(syslog.LOG_ERR, traceback.format_exc())
+-                    gc.collect()
+-            else:
+-                syslog.syslog(syslog.LOG_INFO, '{}: steam client is runing'.format(os.path.basename(sys.argv[0])))
++            try:
++                self.run()
++            except Exception as e: # pylint: disable=W0703
++                syslog.syslog(syslog.LOG_ERR, '{}: {!s}'.format(os.path.basename(sys.argv[0]), e))
++                syslog.syslog(syslog.LOG_ERR, traceback.format_exc())
++                gc.collect()
+             time.sleep(2)
+ 
+     def stop(self):

--- a/packages/addons/driver/steamcontroller/source/system.d/driver.steamcontroller.service
+++ b/packages/addons/driver/steamcontroller/source/system.d/driver.steamcontroller.service
@@ -1,9 +1,10 @@
 [Unit]
-Description=a standalone userland driver for the steam controller
+Description=Steam Controller driver
 
 [Service]
 Type=forking
 ExecStart=/usr/bin/python /storage/.kodi/addons/driver.steamcontroller/bin/sc-xbox.py start
+ExecReload=/usr/bin/python /storage/.kodi/addons/driver.steamcontroller/bin/sc-xbox.py restart
 ExecStop=/usr/bin/python /storage/.kodi/addons/driver.steamcontroller/bin/sc-xbox.py stop
 PIDFile=/run/steamcontroller.pid
 Restart=on-failure


### PR DESCRIPTION
There was high cpu usage before when no controller was plugged in because python was looping constantly. Now systemd will just restart the service every 10 seconds.