### PR TITLE
addon_depends: serdisplib - use libusb-config from sysroot

### DIFF
--- a/packages/addons/addon-depends/serdisplib/package.mk
+++ b/packages/addons/addon-depends/serdisplib/package.mk
@@ -38,13 +38,17 @@ PKG_CONFIGURE_OPTS_TARGET="--prefix=$SYSROOT_PREFIX/usr \
                            --with-drivers=all"
 
 pre_configure_target() {
-  # serdisplib fails to build in subdirs (found this in packages/devel/attr/package.mk)
+  # serdisplib fails to build in subdirs
   cd $ROOT/$PKG_BUILD
     rmdir .$TARGET_NAME
+
+  # use libusb-config from sysroot
+  export ac_cv_path_LIBUSB_CONFIG=$SYSROOT_PREFIX/usr/bin/libusb-config
 }
 
 post_make_target() {
-  # copy necessary libs and headers to build the driver glcd from lcdproc
+  # copy necessary libs and headers to build serdisplib support
+  # into the driver glcd from lcdproc
   mkdir -p $SYSROOT_PREFIX/usr/include/serdisplib
   cp include/serdisplib/*.h $SYSROOT_PREFIX/usr/include/serdisplib
   mkdir -p $SYSROOT_PREFIX/usr/lib


### PR DESCRIPTION
**before:**
```
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/bin/armv7a-libreelec-linux-gnueabi-ar -r ../lib/libserdisp.a serdisp_fctptr.o serdisp_control.o serdisp_connect.o serdisp_colour.o serdisp_tools.o serdisp_messages.o serdisp_connect_usb.o serdisp_specific_sed153x.o serdisp_specific_pcd8544.o serdisp_specific_sed156x.o serdisp_specific_i2c.o serdisp_specific_t6963.o serdisp_specific_sed133x.o serdisp_specific_nokcol.o serdisp_specific_ks0108.o serdisp_specific_lh155.o serdisp_specific_ssdoled.o serdisp_specific_l4m.o serdisp_specific_goldelox.o serdisp_specific_stv8105.o serdisp_specific_acoolsdcm.o serdisp_specific_lc7981.o
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/bin/armv7a-libreelec-linux-gnueabi-gcc -fPIC -shared -Wl,-soname,libserdisp.so.1 -o ../lib/libserdisp.so.1.97.9 serdisp_fctptr.o serdisp_control.o serdisp_connect.o serdisp_colour.o serdisp_tools.o serdisp_messages.o serdisp_connect_usb.o serdisp_specific_sed153x.o serdisp_specific_pcd8544.o serdisp_specific_sed156x.o serdisp_specific_i2c.o serdisp_specific_t6963.o serdisp_specific_sed133x.o serdisp_specific_nokcol.o serdisp_specific_ks0108.o serdisp_specific_lh155.o serdisp_specific_ssdoled.o serdisp_specific_l4m.o serdisp_specific_goldelox.o serdisp_specific_stv8105.o serdisp_specific_acoolsdcm.o serdisp_specific_lc7981.o -march=armv7-a -mtune=cortex-a9 -Wl,--as-needed -fuse-ld=gold  -L/usr/lib64 -lusb
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/bin/armv7a-libreelec-linux-gnueabi-ar: creating ../lib/libserdisp.a
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/lib/gcc/armv7a-libreelec-linux-gnueabi/6.2.0/../../../../armv7a-libreelec-linux-gnueabi/bin/ld.gold: warning: skipping incompatible /usr/lib64/libusb.so while searching for usb
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/lib/gcc/armv7a-libreelec-linux-gnueabi/6.2.0/../../../../armv7a-libreelec-linux-gnueabi/bin/ld.gold: warning: skipping incompatible /usr/lib64/libc.so while searching for c
if [ -n "9" ]  ; then \
  cd ../lib && ln -s -f libserdisp.so.1.97.9 libserdisp.so.1.97 ; \
fi
cd ../lib && ln -s -f libserdisp.so.1.97.9 libserdisp.so.1
cd ../lib && ln -s -f libserdisp.so.1 libserdisp.so
```

**now:**
```
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/bin/armv7a-libreelec-linux-gnueabi-ar -r ../lib/libserdisp.a serdisp_fctptr.o serdisp_control.o serdisp_connect.o serdisp_colour.o serdisp_tools.o serdisp_messages.o serdisp_connect_usb.o serdisp_specific_sed153x.o serdisp_specific_pcd8544.o serdisp_specific_sed156x.o serdisp_specific_i2c.o serdisp_specific_t6963.o serdisp_specific_sed133x.o serdisp_specific_nokcol.o serdisp_specific_ks0108.o serdisp_specific_lh155.o serdisp_specific_ssdoled.o serdisp_specific_l4m.o serdisp_specific_goldelox.o serdisp_specific_stv8105.o serdisp_specific_acoolsdcm.o serdisp_specific_lc7981.o
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/bin/armv7a-libreelec-linux-gnueabi-ar: creating ../lib/libserdisp.a
/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/bin/armv7a-libreelec-linux-gnueabi-gcc -o testserdisp testserdisp.o ../lib/libserdisp.a -march=armv7-a -mtune=cortex-a9 -Wl,--as-needed -fuse-ld=gold -fuse-linker-plugin -flto -L/home/michael/workspace/LibreELEC.tv/build.LibreELEC-imx6.arm-8.0-devel/toolchain/armv7a-libreelec-linux-gnueabi/sysroot/usr/lib -lusb
if [ -n "9" ]  ; then \
  cd ../lib && ln -s -f libserdisp.so.1.97.9 libserdisp.so.1.97 ; \
fi
cd ../lib && ln -s -f libserdisp.so.1.97.9 libserdisp.so.1
cd ../lib && ln -s -f libserdisp.so.1 libserdisp.so
```