### PR TITLE
lirc: check for socket in lircd-uinput.service

### DIFF
--- a/packages/sysutils/lirc/system.d/lircd-uinput@.service
+++ b/packages/sysutils/lirc/system.d/lircd-uinput@.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=lircd-uinput with %I
 
+ConditionPathExists=/run/lirc/lircd-%I
+
 [Service]
 ExecStart=/usr/sbin/lircd-uinput /run/lirc/lircd-%I
 Slice=system-lircd.slice


### PR DESCRIPTION
If the lircd service is enabled in LE settings but there isn't a lircd.conf then lircd-uinput will fail to start because lircd doesn't output to the socket. This makes the socket a condition to start.