### PR TITLE
scripts/checkdeps: add patchutils as dependency

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -28,8 +28,8 @@ if  [ -f /etc/os-release ]; then
   DISTRO=$(grep ^ID= /etc/os-release | cut -d "=" -f 2 | tr A-Z a-z)
 fi
 
-deps="wget bash bc gcc sed patch tar bzip2 gzip perl gawk gperf zip unzip diff makeinfo lzop"
-deps_pkg="wget bash bc gcc sed patch tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop"
+deps="wget bash bc gcc sed patch lsdiff tar bzip2 gzip perl gawk gperf zip unzip diff makeinfo lzop"
+deps_pkg="wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop"
 
 files="/usr/include/stdio.h /usr/include/ncurses.h"
 files_pkg="libc6-dev libncurses5-dev"


### PR DESCRIPTION
lsdiff is needed to build media_build (included in patchutils)

lsdiff it the program we need, patchutils the package that include it