### PR TITLE
systemd: add patch to disable colors

### DIFF
--- a/packages/sysutils/systemd/profile.d/90-systemd.conf
+++ b/packages/sysutils/systemd/profile.d/90-systemd.conf
@@ -1,0 +1,19 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+export SYSTEMD_COLORS=0


### PR DESCRIPTION
This is the best solution I have found.

busybox less cannot interpret the color ANSI codes produced by systemd, so lets disable them.

~~I tried settings `SYSTEMD_COLORS=0` in the profile, but this didn't work, so it probably has to be set before systemd is invoked in the init, however, this solution works just as well.~~

Edit: I needed to export it.

This is the issue I am talking about
```
[[0;1;31m●[[0m LibreELEC
    State: [[0;1;31mdegraded[[0m
     Jobs: 0 queued
   Failed: 1 units
    Since: Thu 2017-01-12 10:42:38 PST; 13min ago
   CGroup: /
```
and
```
[[0;1;32m●[[0m kodi.service - Kodi Media Center
   Loaded: loaded (/usr/lib/systemd/system/kodi.service; disabled; vendor preset: disabled)
   Active: [[0;1;32mactive (running)[[0m since Thu 2017-01-12 10:42:44 PST; 14min ago
  Process: 584 ExecStartPre=/usr/lib/kodi/kodi-config (code=exited, status=0/SUCCESS)
 Main PID: 589 (kodi.sh)
```
This allows these characters to be printed like so
```
● LibreELEC
    State: degraded
     Jobs: 0 queued
   Failed: 1 units
    Since: Thu 2017-01-12 10:42:38 PST; 14min ago
   CGroup: /
```
and
```
● kodi.service - Kodi Media Center
   Loaded: loaded (/usr/lib/systemd/system/kodi.service; disabled; vendor preset: disabled)
   Active: active (running) since Thu 2017-01-12 10:42:44 PST; 14min ago
  Process: 584 ExecStartPre=/usr/lib/kodi/kodi-config (code=exited, status=0/SUCCESS)
 Main PID: 589 (kodi.sh)
```

reference:
https://bugs.busybox.net/show_bug.cgi?id=5546
https://bugs.busybox.net/show_bug.cgi?id=8186

