### PR TITLE
linux: update to linux-4.9.3

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="87edb82"
+PKG_VERSION="6df93de"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -58,7 +58,7 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.9.2"
+    PKG_VERSION="4.9.3"
     PKG_URL="http://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="87edb82"
+PKG_VERSION="6df93de"
 PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,7 +1,7 @@
-From ad221e75ca78e7b45517c4a596ee8f8e48b09960 Mon Sep 17 00:00:00 2001
+From 726155a02a2642c4f992655ae4a4c062a0761260 Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
-Subject: [PATCH 001/118] smsx95xx: fix crimes against truesize
+Subject: [PATCH 001/122] smsx95xx: fix crimes against truesize
 
 smsc95xx is adjusting truesize when it shouldn't, and following a recent patch from Eric this is now triggering warnings.
 
@@ -48,10 +48,10 @@ index 831aa33d078ae7d2dd57fdded5de71d1eb915f99..b77935bded8c0ff7808b00f170ff10e5
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From cfe436f9931be38d89cbecdf4d1ca13aee366990 Mon Sep 17 00:00:00 2001
+From f1afc1dcb1c34955d1a9d756abb1b61c3a9f1da8 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
-Subject: [PATCH 002/118] smsc95xx: Experimental: Enable turbo_mode and
+Subject: [PATCH 002/122] smsc95xx: Experimental: Enable turbo_mode and
  packetsize=2560 by default
 
 See: http://forum.kodi.tv/showthread.php?tid=285288
@@ -94,10 +94,10 @@ index b77935bded8c0ff7808b00f170ff10e594300ad0..693f163684de921404738e33244881e0
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From e4567736c09da23abfebb86e052047041bf30105 Mon Sep 17 00:00:00 2001
+From 69f6712212df74f6c27b1dfec7e3cc1408416653 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
-Subject: [PATCH 003/118] Allow mac address to be set in smsc95xx
+Subject: [PATCH 003/122] Allow mac address to be set in smsc95xx
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -193,10 +193,10 @@ index 693f163684de921404738e33244881e0aab92ec9..df60c989fc229bf0aab3c27e95ccd453
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From cdf57f590c9e3ff27d89dfa899d4a0b609ef769d Mon Sep 17 00:00:00 2001
+From 10945e4697799ceff36fbdea420081b746d67429 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
-Subject: [PATCH 004/118] Protect __release_resource against resources without
+Subject: [PATCH 004/122] Protect __release_resource against resources without
  parents
 
 Without this patch, removing a device tree overlay can crash here.
@@ -224,10 +224,10 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From f53e12f49ae97f55c8fa00e68de5de52b110bbc7 Mon Sep 17 00:00:00 2001
+From ab1aef30de5e9424f87d7d6e1edb1a5240a76ae5 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
-Subject: [PATCH 005/118] mm: Remove the PFN busy warning
+Subject: [PATCH 005/122] mm: Remove the PFN busy warning
 
 See commit dae803e165a11bc88ca8dbc07a11077caf97bbcb -- the warning is
 expected sometimes when using CMA.  However, that commit still spams
@@ -252,10 +252,10 @@ index 34ada718ef47c4b27730214d584f9350fefb9883..3fa01a5280db96075798e4cbd58d5520
  		goto done;
  	}
 
-From a6ef83b5f0634de5963aa6aabfeec2e55d8afd09 Mon Sep 17 00:00:00 2001
+From a1c2520dc2663b442e4b43010df6917f233ff40e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
-Subject: [PATCH 006/118] irq-bcm2836: Prevent spurious interrupts, and trap
+Subject: [PATCH 006/122] irq-bcm2836: Prevent spurious interrupts, and trap
  them early
 
 The old arch-specific IRQ macros included a dsb to ensure the
@@ -282,10 +282,10 @@ index d96b2c947e74e3edab3917551c64fbd1ced0f34c..93e3f7660c4230c9f1dd3b195958cb49
  #endif
  	} else if (stat) {
 
-From 968fe34e6ac79edbdcbadc5fa87082fdd77be3ca Mon Sep 17 00:00:00 2001
+From 2d51d14c0cea3d9d52f323b58a0a5d99a65eef24 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
-Subject: [PATCH 007/118] irqchip: bcm2835: Add FIQ support
+Subject: [PATCH 007/122] irqchip: bcm2835: Add FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -414,10 +414,10 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 0bac3ae5f7ee20fab229c5aeeeaa10a9b16ee9e8 Mon Sep 17 00:00:00 2001
+From 2d9b0ef8dc1a5975dfccfb7e78b8f5a94ab5f2bb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
-Subject: [PATCH 008/118] irqchip: irq-bcm2835: Add 2836 FIQ support
+Subject: [PATCH 008/122] irqchip: irq-bcm2835: Add 2836 FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -516,10 +516,10 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From 16340fb762b9570e5b577bea5708e660b154e41f Mon Sep 17 00:00:00 2001
+From 39974a29633d89316e5de24d87294b444b24f381 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
-Subject: [PATCH 009/118] spidev: Add "spidev" compatible string to silence
+Subject: [PATCH 009/122] spidev: Add "spidev" compatible string to silence
  warning
 
 See: https://github.com/raspberrypi/linux/issues/1054
@@ -540,10 +540,10 @@ index 2e05046f866bd01bf87edcdeff0d5b76d4d0aea7..d780491b8013a4e97fa843958964454e
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 332ead9fc0db97e1950bd1baaec720d92f86c58a Mon Sep 17 00:00:00 2001
+From 51c39f512e9b370f126afcdcf6306561ea1f50f2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 30 Jun 2015 14:12:42 +0100
-Subject: [PATCH 010/118] serial: 8250: Don't crash when nr_uarts is 0
+Subject: [PATCH 010/122] serial: 8250: Don't crash when nr_uarts is 0
 
 ---
  drivers/tty/serial/8250/8250_core.c | 2 ++
@@ -563,10 +563,10 @@ index 240a361b674fe72ce657067e5303156b7add6a6f..14f6cdfd744209482056d206dc476d94
  	for (i = 0; i < nr_uarts; i++) {
  		struct uart_8250_port *up = &serial8250_ports[i];
 
-From 4b12f273ccf3d7a3949419a6dfcb78b1abf72d6e Mon Sep 17 00:00:00 2001
+From f56196076549fabcdf0cca5685d1ea3e0308622a Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
-Subject: [PATCH 011/118] pinctrl-bcm2835: Set base to 0 give expected gpio
+Subject: [PATCH 011/122] pinctrl-bcm2835: Set base to 0 give expected gpio
  numbering
 
 Signed-off-by: Noralf Tronnes <notro@tronnes.org>
@@ -588,10 +588,10 @@ index fa77165fab2c1348163979da507df17e7168c49b..d11e2e4ea189466e686d762cb6c6fef9
  	.can_sleep = false,
  };
 
-From 0ab76cad363c7a9b847c775f966b9c28228e112d Mon Sep 17 00:00:00 2001
+From 40a7420d0d585951fbc02f232df97a15beff7a57 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
-Subject: [PATCH 012/118] pinctrl-bcm2835: Fix interrupt handling for GPIOs
+Subject: [PATCH 012/122] pinctrl-bcm2835: Fix interrupt handling for GPIOs
  28-31 and 46-53
 
 Contrary to the documentation, the BCM2835 GPIO controller actually has
@@ -737,10 +737,10 @@ index d11e2e4ea189466e686d762cb6c6fef9111ecf8e..107ad7d58de8f8a7f55e09c9cdcf7d66
  	},
  };
 
-From 74fdb3c2e15771b27e12085cf45bc97fb24af85d Mon Sep 17 00:00:00 2001
+From a19df9159eb1e9745593febf2ef6aa5868e8d12f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
-Subject: [PATCH 013/118] pinctrl-bcm2835: Only request the interrupts listed
+Subject: [PATCH 013/122] pinctrl-bcm2835: Only request the interrupts listed
  in the DTB
 
 Although the GPIO controller can generate three interrupts (four counting
@@ -767,10 +767,10 @@ index 107ad7d58de8f8a7f55e09c9cdcf7d66fa7ab66b..644bdecbcfcb79d3b84a33769265fca5
  		pc->irq_data[i].irqgroup = i;
  
 
-From aed251a577cad2c0b089908ac31de9278d43f0a6 Mon Sep 17 00:00:00 2001
+From eee7c2b51a8b1753aca3d01ecda24713576d14e5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 May 2016 12:32:47 +0100
-Subject: [PATCH 014/118] pinctrl-bcm2835: Return pins to inputs when freed
+Subject: [PATCH 014/122] pinctrl-bcm2835: Return pins to inputs when freed
 
 When dynamically unloading overlays, it is important that freed pins are
 restored to being inputs to prevent functions from being enabled in
@@ -811,10 +811,10 @@ index 644bdecbcfcb79d3b84a33769265fca5d3d0c9e5..81a66cba2ab0f7e3ae179de7edd10122
  	.get_function_name = bcm2835_pmx_get_function_name,
  	.get_function_groups = bcm2835_pmx_get_function_groups,
 
-From d1ad182a5691887e196dfa1f5a446a7ba7376b02 Mon Sep 17 00:00:00 2001
+From 7d54b896b5523a49b1038dd301b2d359d2321ef2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
-Subject: [PATCH 015/118] spi-bcm2835: Support pin groups other than 7-11
+Subject: [PATCH 015/122] spi-bcm2835: Support pin groups other than 7-11
 
 The spi-bcm2835 driver automatically uses GPIO chip-selects due to
 some unreliability of the native ones. In doing so it chooses the
@@ -895,10 +895,10 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From 7db6bd48d813575485cc9198945c1a7b35738d86 Mon Sep 17 00:00:00 2001
+From de045c3b6df0c0d56f02c0f782627249bbad09d2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
-Subject: [PATCH 016/118] spi-bcm2835: Disable forced software CS
+Subject: [PATCH 016/122] spi-bcm2835: Disable forced software CS
 
 Select software CS in bcm2708_common.dtsi, and disable the automatic
 conversion in the driver to allow hardware CS to be re-enabled with an
@@ -932,10 +932,10 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From 75f7a6605403141ed4d06512c7575b5a2c8ba98e Mon Sep 17 00:00:00 2001
+From a161509667da54c9d5066a0c6bc0584d093a8923 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
-Subject: [PATCH 017/118] spi-bcm2835: Remove unused code
+Subject: [PATCH 017/122] spi-bcm2835: Remove unused code
 
 ---
  drivers/spi/spi-bcm2835.c | 61 -----------------------------------------------
@@ -1023,10 +1023,10 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From 5f964e4c7a409259176d23a76d67921a5d9d4341 Mon Sep 17 00:00:00 2001
+From 2ec6cfba14ff71b08f797c69d1a9c5bd53fc66a6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
-Subject: [PATCH 018/118] ARM: bcm2835: Set Serial number and Revision
+Subject: [PATCH 018/122] ARM: bcm2835: Set Serial number and Revision
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1079,10 +1079,10 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 686de609ac017c025dc69c8a9a955cdf8f65fe9a Mon Sep 17 00:00:00 2001
+From 7cd4e838461cb6cefa1ca5246ef3a6773363f0e0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
-Subject: [PATCH 019/118] dmaengine: bcm2835: Load driver early and support
+Subject: [PATCH 019/122] dmaengine: bcm2835: Load driver early and support
  legacy API
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -1185,10 +1185,10 @@ index e18dc596cf2447fa9ef7e41b62d9396e29043426..80d35f760b4a4a51e60c355a84d538ba
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From 7a6973b406e694db4a471e02386dfff172956504 Mon Sep 17 00:00:00 2001
+From e19d2f37545f78b50f4f82b72099b036f42d2bcd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
-Subject: [PATCH 020/118] firmware: Updated mailbox header
+Subject: [PATCH 020/122] firmware: Updated mailbox header
 
 ---
  include/soc/bcm2835/raspberrypi-firmware.h | 11 +++++++++++
@@ -1251,10 +1251,10 @@ index 3fb357193f09914fe21f8555a4b8613f74f22bc3..227a107214a02deadcca3db202da265e
  	RPI_FIRMWARE_GET_COMMAND_LINE =                       0x00050001,
  	RPI_FIRMWARE_GET_DMA_CHANNELS =                       0x00060001,
 
-From 8c4038efde58ff4b6d435befe924380ef6e3045f Mon Sep 17 00:00:00 2001
+From 99e1f06dcc2bf78742380b9697c354b627fd02c2 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
-Subject: [PATCH 021/118] clk: bcm2835: Mark GPIO clocks enabled at boot as
+Subject: [PATCH 021/122] clk: bcm2835: Mark GPIO clocks enabled at boot as
  critical.
 
 These divide off of PLLD_PER and are used for the ethernet and wifi
@@ -1292,10 +1292,10 @@ index 3bbd2a58db470a89b870a793e59ddf9fc4f48e57..7040c6426e35c11608121893b662c601
  		init.ops = &bcm2835_vpu_clock_clk_ops;
  	} else {
 
-From 43129b4fa17eab0b3af27b7034719c5eb91fcaec Mon Sep 17 00:00:00 2001
+From 946babad832c9ed45bbb31fd89fce025a9f7db48 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
-Subject: [PATCH 022/118] rtc: Add SPI alias for pcf2123 driver
+Subject: [PATCH 022/122] rtc: Add SPI alias for pcf2123 driver
 
 Without this alias, Device Tree won't cause the driver
 to be loaded.
@@ -1315,10 +1315,10 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From ab70dae22d22f9c5f4f03e84ac1c1b1d4d35bef9 Mon Sep 17 00:00:00 2001
+From a929f2b203a1bafb1ca88f7022cb286f28fa98bd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
-Subject: [PATCH 023/118] watchdog: bcm2835: Support setting reboot partition
+Subject: [PATCH 023/122] watchdog: bcm2835: Support setting reboot partition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1442,10 +1442,10 @@ index 4dddd8298a227d64862f2e92954a465f2e44b3f6..1f545e024422f59280932713e6a1b051
  	register_restart_handler(&wdt->restart_handler);
  	if (pm_power_off == NULL)
 
-From 3937b628148a61d360f847848b11ac94afea29cd Mon Sep 17 00:00:00 2001
+From 2e7833eae38410bc31d3a86166868a55d0999394 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
-Subject: [PATCH 024/118] reboot: Use power off rather than busy spinning when
+Subject: [PATCH 024/122] reboot: Use power off rather than busy spinning when
  halt is requested
 
 ---
@@ -1468,10 +1468,10 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From dbd5f14e9ba84e12761d3193d082a0d74ed32008 Mon Sep 17 00:00:00 2001
+From 0d4700ca51eb31fa70e10da67fa92e986275f2d3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
-Subject: [PATCH 025/118] bcm: Make RASPBERRYPI_POWER depend on PM
+Subject: [PATCH 025/122] bcm: Make RASPBERRYPI_POWER depend on PM
 
 ---
  drivers/soc/bcm/Kconfig | 1 +
@@ -1490,10 +1490,10 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 6224c852d202401287990cc77ec5797218db6133 Mon Sep 17 00:00:00 2001
+From 53b503a7256d432bfa51f5ffba58a446c2cc6ebb Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
-Subject: [PATCH 026/118] Register the clocks early during the boot process, so
+Subject: [PATCH 026/122] Register the clocks early during the boot process, so
  that special/critical clocks can get enabled early on in the boot process
  avoiding the risk of disabling a clock, pll_divider or pll when a claiming
  driver fails to install propperly - maybe it needs to defer.
@@ -1538,10 +1538,10 @@ index 7040c6426e35c11608121893b662c601cd8d6543..21e2a538ff0d0ab4e63adff9b93705f3
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From ed16aee637b73805a208d0d4d2f00b5d9f5f789a Mon Sep 17 00:00:00 2001
+From e367c208dc6a9d92e5c0d6e5e089e7b56c7cf189 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
-Subject: [PATCH 027/118] bcm2835-rng: Avoid initialising if already enabled
+Subject: [PATCH 027/122] bcm2835-rng: Avoid initialising if already enabled
 
 Avoids the 0x40000 cycles of warmup again if firmware has already used it
 ---
@@ -1567,10 +1567,10 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From 44e47b69c75d81807f24131821f6599435755427 Mon Sep 17 00:00:00 2001
+From da0b1ac76230b33baa5cd0391388d32d43889d69 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
-Subject: [PATCH 028/118] kbuild: Ignore dtco targets when filtering symbols
+Subject: [PATCH 028/122] kbuild: Ignore dtco targets when filtering symbols
 
 ---
  scripts/Kbuild.include | 2 +-
@@ -1590,10 +1590,10 @@ index 179219845dfcdfbeb586d12c5ec1296095d9fbf4..e0743e44f84188667a0c322e8c3d36f1
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From b345482052faa86e6db9fe01613bae550fee93f8 Mon Sep 17 00:00:00 2001
+From f96bacbe5b20000d29c0b1bc81f66f5b15231b48 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
-Subject: [PATCH 029/118] BCM2835_DT: Fix I2S register map
+Subject: [PATCH 029/122] BCM2835_DT: Fix I2S register map
 
 ---
  Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.txt   | 4 ++--
@@ -1631,10 +1631,10 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From b14d3bae8ca43d7636bfd91dda5a8bc9c8a06154 Mon Sep 17 00:00:00 2001
+From 967e1d016f69607cb5f1d8337f9249ef31e19d81 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
-Subject: [PATCH 030/118] Main bcm2708/bcm2709 linux port
+Subject: [PATCH 030/122] Main bcm2708/bcm2709 linux port
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1841,10 +1841,10 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 94e3bcec0b0e4f94bca7374cbb32ed6e36d103d5 Mon Sep 17 00:00:00 2001
+From 9ccdf13082f318de0091066517c7f7309b245456 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
-Subject: [PATCH 031/118] Add dwc_otg driver
+Subject: [PATCH 031/122] Add dwc_otg driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -2546,10 +2546,10 @@ index 358ca8dd784fe43700ae070764fa783500a792fe..abaac7c7142d8887c1516957fc52162c
  	return i;
  }
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 0d81436c94bdaf6cea0f6a3b2063401c2caf1d3d..0248f67611a245505cfea708428536e28242f3e1 100644
+index aef81a16e2c8534701b8583392400faf77971d23..4197a5b5fb7abae67bd4aa32c29cb84c1f2fe22e 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
-@@ -5010,7 +5010,7 @@ static void port_event(struct usb_hub *hub, int port1)
+@@ -5009,7 +5009,7 @@ static void port_event(struct usb_hub *hub, int port1)
  	if (portchange & USB_PORT_STAT_C_OVERCURRENT) {
  		u16 status = 0, unused;
  
@@ -62901,10 +62901,10 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 83b46b448602db774a6fb361fd6c1b9e0c8509b0 Mon Sep 17 00:00:00 2001
+From 990bd0f738984c3582e6dbba14a1826ea28f9fb6 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
-Subject: [PATCH 032/118] bcm2708 framebuffer driver
+Subject: [PATCH 032/122] bcm2708 framebuffer driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66363,10 +66363,10 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From 3e6b7dca18903fbcef8b22805d2877704b8cc9f0 Mon Sep 17 00:00:00 2001
+From baa447618d238275c592e7caa6455b8e4b1d3d77 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
-Subject: [PATCH 033/118] dmaengine: Add support for BCM2708
+Subject: [PATCH 033/122] dmaengine: Add support for BCM2708
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66997,10 +66997,10 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From c88dfcfa730ab5573a722c208e9ff326563b375e Mon Sep 17 00:00:00 2001
+From b7d8765eb1e1bb854be09a08acabaf92cd1c45ab Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
-Subject: [PATCH 034/118] MMC: added alternative MMC driver
+Subject: [PATCH 034/122] MMC: added alternative MMC driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -68750,10 +68750,10 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From c276600e049838697dbf80363852e8968f63fa2a Mon Sep 17 00:00:00 2001
+From a56eb108067d0211a3ba3b987ec15986ac5577a6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
-Subject: [PATCH 035/118] Adding bcm2835-sdhost driver, and an overlay to
+Subject: [PATCH 035/122] Adding bcm2835-sdhost driver, and an overlay to
  enable it
 
 BCM2835 has two SD card interfaces. This driver uses the other one.
@@ -71158,10 +71158,10 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 380c5bcb89cb9ff9bb7233f468b4c56246469024 Mon Sep 17 00:00:00 2001
+From 0eda1e885a24ef523c6f88b4f62dc928c47f00c6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
-Subject: [PATCH 036/118] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
+Subject: [PATCH 036/122] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
 
 Some SD cards have been found that corrupt data when small blocks
 are erased. Add a quirk to indicate that ERASE should not be used,
@@ -71297,10 +71297,10 @@ index 73fad83acbcb6a157587180516f9ffe7c61eb7d7..e7c9d3098ac06e3c6554fa3373a311f9
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From 4242c82a0364d1451c54c4f921af3f4f2c537dc3 Mon Sep 17 00:00:00 2001
+From ebd7f1f66e66573d57edc087910e4f34f71a52d9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:31:47 +0100
-Subject: [PATCH 037/118] cma: Add vc_cma driver to enable use of CMA
+Subject: [PATCH 037/122] cma: Add vc_cma driver to enable use of CMA
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -72636,10 +72636,10 @@ index 0000000000000000000000000000000000000000..be2819d5d41f9d5ed65daf8eedb94c9e
 +
 +#endif /* VC_CMA_H */
 
-From 6ea5c5ec0e9223d94037f4501e520f9e594fcb68 Mon Sep 17 00:00:00 2001
+From 20fda0a0bcd46a01ba801a968f81c55398ff925e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 26 Mar 2012 22:15:50 +0100
-Subject: [PATCH 038/118] bcm2708: alsa sound driver
+Subject: [PATCH 038/122] bcm2708: alsa sound driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -75374,10 +75374,10 @@ index 0000000000000000000000000000000000000000..af3e6eb690113fc32ce9e06bd2f0f294
 +
 +#endif // _VC_AUDIO_DEFS_H_
 
-From 95547683299d0aef3ca13d192481e529cbcb6ad2 Mon Sep 17 00:00:00 2001
+From f173c4ba6bb591fd104486fec7229cff3648f715 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
-Subject: [PATCH 039/118] vc_mem: Add vc_mem driver for querying firmware
+Subject: [PATCH 039/122] vc_mem: Add vc_mem driver for querying firmware
  memory addresses
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -75901,10 +75901,10 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From 23b1ab3b736cd7d77cc610958a219f0284d84b70 Mon Sep 17 00:00:00 2001
+From 826895d0d097fa010aca39acf19d85a1e065876d Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
-Subject: [PATCH 040/118] vcsm: VideoCore shared memory service for BCM2835
+Subject: [PATCH 040/122] vcsm: VideoCore shared memory service for BCM2835
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -80311,10 +80311,10 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From e95f43b6d8757c6264ba1f665ec7b45732691ab6 Mon Sep 17 00:00:00 2001
+From 3d892851d6e52bec4c02b06146967ecc52b50af0 Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
-Subject: [PATCH 041/118] Add /dev/gpiomem device for rootless user GPIO access
+Subject: [PATCH 041/122] Add /dev/gpiomem device for rootless user GPIO access
 
 Signed-off-by: Luke Wren <luke@raspberrypi.org>
 
@@ -80625,10 +80625,10 @@ index 0000000000000000000000000000000000000000..911f5b7393ed48ceed8751f06967ae64
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From 82ff85d9274fccc8df9a59d99066e0e1f1772f9f Mon Sep 17 00:00:00 2001
+From fbaa743648d031cbb8afeb81e37f546b4fd7b6b5 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
-Subject: [PATCH 042/118] Add SMI driver
+Subject: [PATCH 042/122] Add SMI driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -82579,10 +82579,10 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From 7681571a6b97b4c2892ca63b76d5a8cb215c3802 Mon Sep 17 00:00:00 2001
+From 7df434185cb69481bdb857fb30c153685feb7c4e Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
-Subject: [PATCH 043/118] MISC: bcm2835: smi: use clock manager and fix reload
+Subject: [PATCH 043/122] MISC: bcm2835: smi: use clock manager and fix reload
  issues
 
 Use clock manager instead of self-made clockmanager.
@@ -82752,10 +82752,10 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 68b7fa34af2f20c36933fe3f7c657bafa400f458 Mon Sep 17 00:00:00 2001
+From e80a053c8ec7283b7c93f468b437c1e53ffdd5dc Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
-Subject: [PATCH 044/118] Add SMI NAND driver
+Subject: [PATCH 044/122] Add SMI NAND driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -83120,10 +83120,10 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From ac544a9fe824b139bbd4c2b75ae4cad9fba5777a Mon Sep 17 00:00:00 2001
+From d5fe3a35c384918e40ad67ae26c5997ca941c98e Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
-Subject: [PATCH 045/118] lirc: added support for RaspberryPi GPIO
+Subject: [PATCH 045/122] lirc: added support for RaspberryPi GPIO
 
 lirc_rpi: Use read_current_timer to determine transmitter delay. Thanks to jjmz and others
 See: https://github.com/raspberrypi/linux/issues/525
@@ -83986,10 +83986,10 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From e5cc98d9c41d2f8dcb912feefd8f5829ee7ce075 Mon Sep 17 00:00:00 2001
+From f66f635379d5b4ebc82d4d18c9bd77d2fbcbdfa6 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
-Subject: [PATCH 046/118] Add cpufreq driver
+Subject: [PATCH 046/122] Add cpufreq driver
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -84256,10 +84256,10 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From f544a8ce034e18a89daed574edc29dd9de74f536 Mon Sep 17 00:00:00 2001
+From 478277f128dbdcbea6394c4744ada90fce9ab66e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
-Subject: [PATCH 047/118] Added hwmon/thermal driver for reporting core
+Subject: [PATCH 047/122] Added hwmon/thermal driver for reporting core
  temperature. Thanks Dorian
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -84425,10 +84425,10 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From 660794f62a377f9ca817e7d29c06f1c548489a26 Mon Sep 17 00:00:00 2001
+From aaac339b97bfcc6a67fd3f51400d87fc2ff00198 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
-Subject: [PATCH 048/118] Add Chris Boot's i2c driver
+Subject: [PATCH 048/122] Add Chris Boot's i2c driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85093,10 +85093,10 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 08afd466271b5732eac8e4974361546aad8e3aca Mon Sep 17 00:00:00 2001
+From fa468e89c790f2e432205e3b16d26e5365d98ec7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
-Subject: [PATCH 049/118] char: broadcom: Add vcio module
+Subject: [PATCH 049/122] char: broadcom: Add vcio module
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85322,10 +85322,10 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 426ef96150c966b43d39a2ca6b9c055f8cd72930 Mon Sep 17 00:00:00 2001
+From 83532363df9ebe5f7e8cea458bcfd9b67a0e815a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
-Subject: [PATCH 050/118] firmware: bcm2835: Support ARCH_BCM270x
+Subject: [PATCH 050/122] firmware: bcm2835: Support ARCH_BCM270x
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85408,10 +85408,10 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From 986fa8434b81e4c5e7203434beb7dca80d4c9a42 Mon Sep 17 00:00:00 2001
+From c1316c3428ecf0ef0ad3c39a6ff7e367b3483c4f Mon Sep 17 00:00:00 2001
 From: Vincent Sanders <vincent.sanders@collabora.co.uk>
 Date: Wed, 30 Jan 2013 12:45:18 +0000
-Subject: [PATCH 051/118] bcm2835: add v4l2 camera device
+Subject: [PATCH 051/122] bcm2835: add v4l2 camera device
 
 - Supports raw YUV capture, preview, JPEG and H264.
 - Uses videobuf2 for data transfer, using dma_buf.
@@ -93153,10 +93153,10 @@ index 0000000000000000000000000000000000000000..9d1d11e4a53e510c04a416d92d195a7d
 +
 +#endif /* MMAL_VCHIQ_H */
 
-From 1eae4deb95fecca9b104385232470efbc8e348da Mon Sep 17 00:00:00 2001
+From 6b480eb543d3fb86623e58d6d0f884f67f5ba804 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
-Subject: [PATCH 052/118] scripts: Add mkknlimg and knlinfo scripts from tools
+Subject: [PATCH 052/122] scripts: Add mkknlimg and knlinfo scripts from tools
  repo
 
 The Raspberry Pi firmware looks for a trailer on the kernel image to
@@ -93676,10 +93676,10 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 899b7bf32634a929de96ccde06485f52676c4545 Mon Sep 17 00:00:00 2001
+From 94cbd8ee19d8f0e25c4af4598b07b0c22c5083ae Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 10 Aug 2015 09:49:15 +0100
-Subject: [PATCH 053/118] scripts/dtc: Update to upstream version 1.4.1
+Subject: [PATCH 053/122] scripts/dtc: Update to upstream version 1.4.1
 
 Includes the new localfixups format.
 
@@ -96530,10 +96530,10 @@ index ad9b05ae698b0495ecbda42ffcf4743555313a27..2595dfda020fd9e03f0beff5006f229d
 -#define DTC_VERSION "DTC 1.4.1-g53bf130b"
 +#define DTC_VERSION "DTC 1.4.1-g25efc119"
 
-From 52cb10b96ef40c97f0c7fe0f70846c6e582c3afe Mon Sep 17 00:00:00 2001
+From ef3f51080fa0d993456fa3635e442b845051b70a Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
-Subject: [PATCH 054/118] BCM2708: Add core Device Tree support
+Subject: [PATCH 054/122] BCM2708: Add core Device Tree support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -106661,10 +106661,10 @@ index 0a07f9014944ed92a8e2e42983ae43be60b3e471..1967878a843461c3ff1f473b9a030eb0
  
  # Bzip2
 
-From 1cdd49ad8df3ca95ddfe0c2d373d6ed7b4a5cefc Mon Sep 17 00:00:00 2001
+From 52e8a3802aa8428a69561607209bfe9b98cabde6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
-Subject: [PATCH 055/118] BCM270x_DT: Add pwr_led, and the required "input"
+Subject: [PATCH 055/122] BCM270x_DT: Add pwr_led, and the required "input"
  trigger
 
 The "input" trigger makes the associated GPIO an input.  This is to support
@@ -106840,10 +106840,10 @@ index ddfcb2df3656cf0ab6aebd1fa3d624a6ec2e94e9..271563eb835f9018712e2076a88f341d
  	/* Set LED brightness level
  	 * Must not sleep. Use brightness_set_blocking for drivers
 
-From 1265a84c23cb9aed8388e0a41643024a34333dc3 Mon Sep 17 00:00:00 2001
+From e958cbc43c1add6076ea3ed0aa17365335774024 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
-Subject: [PATCH 056/118] fbdev: add FBIOCOPYAREA ioctl
+Subject: [PATCH 056/122] fbdev: add FBIOCOPYAREA ioctl
 
 Based on the patch authored by Ali Gholami Rudi at
     https://lkml.org/lkml/2009/7/13/153
@@ -107095,10 +107095,10 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From 7eb7c996151bac6551a4f5f0a23abad1ca0389ea Mon Sep 17 00:00:00 2001
+From cf7188188aabe5b8ae10cf449ea6c9b0c6c29c90 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
-Subject: [PATCH 057/118] Speed up console framebuffer imageblit function
+Subject: [PATCH 057/122] Speed up console framebuffer imageblit function
 
 Especially on platforms with a slower CPU but a relatively high
 framebuffer fill bandwidth, like current ARM devices, the existing
@@ -107307,10 +107307,10 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From c3033b89522fdc4f7db951b18bca36ac35e2b1d6 Mon Sep 17 00:00:00 2001
+From 132a1f15dea64eef7dbf9cc5b98e1668cedb2eea Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
-Subject: [PATCH 058/118] enabling the realtime clock 1-wire chip DS1307 and
+Subject: [PATCH 058/122] enabling the realtime clock 1-wire chip DS1307 and
  1-wire on GPIO4 (as a module)
 
 1-wire: Add support for configuring pin for w1-gpio kernel module
@@ -107560,10 +107560,10 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From c816433b752c72c40773170eb7071cde1ebae347 Mon Sep 17 00:00:00 2001
+From 3a29fd5c4e71ff439e60097ca14a4d97c8c63f5f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 18 Dec 2013 22:16:19 +0000
-Subject: [PATCH 059/118] config: Enable CONFIG_MEMCG, but leave it disabled
+Subject: [PATCH 059/122] config: Enable CONFIG_MEMCG, but leave it disabled
  (due to memory cost). Enable with cgroup_enable=memory.
 
 ---
@@ -107613,10 +107613,10 @@ index 85bc9beb046d9a6deda2e3564f4d5bd01d6fc27b..4acdbef46a8f0556469b5580a39c18ce
   * css_tryget_online_from_dir - get corresponding css from a cgroup dentry
   * @dentry: directory dentry of interest
 
-From e3fbcedfa440961f973afc555c5c792e86072110 Mon Sep 17 00:00:00 2001
+From 7a094c94cc5e4275d62f541780238f86b7e1a944 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
-Subject: [PATCH 060/118] hid: Reduce default mouse polling interval to 60Hz
+Subject: [PATCH 060/122] hid: Reduce default mouse polling interval to 60Hz
 
 Reduces overhead when using X
 ---
@@ -107652,10 +107652,10 @@ index ae83af649a607f67239f1a64bf45dd4b5770cc7d..4a7af9d0b910f59d17421ce14138400d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From cb490033b6623d6df8a5568317e26501a511e1ee Mon Sep 17 00:00:00 2001
+From 844a5a997e65b9ba913904f020f88893087ba2b2 Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
-Subject: [PATCH 061/118] rpi-ft5406: Add touchscreen driver for pi LCD display
+Subject: [PATCH 061/122] rpi-ft5406: Add touchscreen driver for pi LCD display
 
 Fix driver detection failure Check that the buffer response is non-zero meaning the touchscreen was detected
 
@@ -108013,10 +108013,10 @@ index 227a107214a02deadcca3db202da265eba1fdd21..b0f6e33bd30c35664ceee057f4c3ad32
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 3eae543d276098fd975f15409724f49fc7f5fee2 Mon Sep 17 00:00:00 2001
+From 3b84c6d542a8066b50fc3efdd916c8a7b88b9d1f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
-Subject: [PATCH 062/118] Improve __copy_to_user and __copy_from_user
+Subject: [PATCH 062/122] Improve __copy_to_user and __copy_from_user
  performance
 
 Provide a __copy_from_user that uses memcpy. On BCM2708, use
@@ -109591,10 +109591,10 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From 5d1adffa7d058d9f53796dcde41a572c28b5c8fd Mon Sep 17 00:00:00 2001
+From d5dc9d3eb0f7177be235596e3009f8b53b4e25b5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
-Subject: [PATCH 063/118] gpio-poweroff: Allow it to work on Raspberry Pi
+Subject: [PATCH 063/122] gpio-poweroff: Allow it to work on Raspberry Pi
 
 The Raspberry Pi firmware manages the power-down and reboot
 process. To do this it installs a pm_power_off handler, causing
@@ -109629,10 +109629,10 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From 829742ee037607b5091e2044792aa28d3748af34 Mon Sep 17 00:00:00 2001
+From 78515e0aa6204095c519dce39d811d796cb9dc18 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
-Subject: [PATCH 064/118] mfd: Add Raspberry Pi Sense HAT core driver
+Subject: [PATCH 064/122] mfd: Add Raspberry Pi Sense HAT core driver
 
 ---
  drivers/input/joystick/Kconfig           |   8 +
@@ -110497,10 +110497,10 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 8623732fdf50b8808240d8d959d086553daf9197 Mon Sep 17 00:00:00 2001
+From 92261bb1ae13c929b053aab7db4cc660d4565511 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
-Subject: [PATCH 065/118] ASoC: Add support for HifiBerry DAC
+Subject: [PATCH 065/122] ASoC: Add support for HifiBerry DAC
 
 This adds a machine driver for the HifiBerry DAC.
 It is a sound card that can
@@ -110675,10 +110675,10 @@ index 0000000000000000000000000000000000000000..45f2b770ad9e67728ca599a7445d6ae9
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 30de099c2e20d442486331817d29a4f5ba1506fe Mon Sep 17 00:00:00 2001
+From b6df383dd105286109669674cf79c61b5f88bba9 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
-Subject: [PATCH 066/118] ASoC: Add support for Rpi-DAC
+Subject: [PATCH 066/122] ASoC: Add support for Rpi-DAC
 
 ---
  sound/soc/bcm/Kconfig       |   7 +++
@@ -110962,10 +110962,10 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From daf62d077f66270f3f88a3e5fa058c6d3885f54e Mon Sep 17 00:00:00 2001
+From 32447fa52c6b39d4447c53b0a7ae8a2096ee901e Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
-Subject: [PATCH 067/118] ASoC: wm8804: Implement MCLK configuration options,
+Subject: [PATCH 067/122] ASoC: wm8804: Implement MCLK configuration options,
  add 32bit support WM8804 can run with PLL frequencies of 256xfs and 128xfs
  for most sample rates. At 192kHz only 128xfs is supported. The existing
  driver selects 128xfs automatically for some lower samples rates. By using an
@@ -111014,10 +111014,10 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From 1e761e3e8abff0c154cd7be50eb3854157260032 Mon Sep 17 00:00:00 2001
+From cd919b3554a2544cf2600822593b6057d4297316 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
-Subject: [PATCH 068/118] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
+Subject: [PATCH 068/122] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
  based on the patched WM8804 driver.
 
 Signed-off-by: Daniel Matuschek <daniel@matuschek.net>
@@ -111361,10 +111361,10 @@ index 0000000000000000000000000000000000000000..19dc953b7227ba86123fc7a2ba654499
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From bbe7cec41a8c9178db2486477472ceb737761a7b Mon Sep 17 00:00:00 2001
+From 9c1f52bc905674a484e6b9c5e91fbef279890c68 Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
-Subject: [PATCH 069/118] Add IQaudIO Sound Card support for Raspberry Pi
+Subject: [PATCH 069/122] Add IQaudIO Sound Card support for Raspberry Pi
 
 Set a limit of 0dB on Digital Volume Control
 
@@ -111694,10 +111694,10 @@ index 0000000000000000000000000000000000000000..4e8e6dec14bcf4a1ff286c43742d4097
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From cc51f9a5cf72cb4e8178902cc3d80a878574377b Mon Sep 17 00:00:00 2001
+From fef54ca8d87499607d6cb086210e44126b304f6d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jul 2016 17:06:50 +0100
-Subject: [PATCH 070/118] iqaudio-dac: Compile fix - untested
+Subject: [PATCH 070/122] iqaudio-dac: Compile fix - untested
 
 ---
  sound/soc/bcm/iqaudio-dac.c | 6 +++++-
@@ -111721,10 +111721,10 @@ index 4e8e6dec14bcf4a1ff286c43742d4097249d6777..aa15bc4b49ca95edec905fddd8fd0a6d
  	if (dapm->dev != codec_dai->dev)
  		return 0;
 
-From 097012dbf23088dc7bfc7f637dac7e03ee9ac742 Mon Sep 17 00:00:00 2001
+From 31bee6011867bb7a1846d35901b080a208669515 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
-Subject: [PATCH 071/118] Added support for HiFiBerry DAC+
+Subject: [PATCH 071/122] Added support for HiFiBerry DAC+
 
 The driver is based on the HiFiBerry DAC driver. However HiFiBerry DAC+ uses
 a different codec chip (PCM5122), therefore a new driver is necessary.
@@ -112354,10 +112354,10 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From 798717fecb6f9c838b9eaa84f11acc760af0c966 Mon Sep 17 00:00:00 2001
+From f11ffc75b1a5ba748f160765164337eabea0b6e1 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
-Subject: [PATCH 072/118] Added driver for HiFiBerry Amp amplifier add-on board
+Subject: [PATCH 072/122] Added driver for HiFiBerry Amp amplifier add-on board
 
 The driver contains a low-level hardware driver for the TAS5713 and the
 drivers for the Raspberry Pi I2S subsystem.
@@ -113190,10 +113190,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 1094b85d81f72de26606f30482ca243867a90738 Mon Sep 17 00:00:00 2001
+From e06a867b4795e7c7e8dd9d13257a77494ea5f610 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Dec 2016 16:26:54 +0000
-Subject: [PATCH 073/118] Revert "Added driver for HiFiBerry Amp amplifier
+Subject: [PATCH 073/122] Revert "Added driver for HiFiBerry Amp amplifier
  add-on board"
 
 This reverts commit 3e6b00833d92a50cbcc9922deb6e1bc8fcdbb587.
@@ -114015,10 +114015,10 @@ index 8f019e04898754d2f87e9630137be9e8f612a342..00000000000000000000000000000000
 -
 -#endif  /* _TAS5713_H */
 
-From c8e89c69ce685339afdcfa83d35a2a1d295fcf9e Mon Sep 17 00:00:00 2001
+From adf38c2875a20b75d2870d9e9897f711835811ea Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
-Subject: [PATCH 074/118] Update ds1307 driver for device-tree support
+Subject: [PATCH 074/122] Update ds1307 driver for device-tree support
 
 Signed-off-by: Ryan Coe <bluemrp9@gmail.com>
 ---
@@ -114045,10 +114045,10 @@ index 4e31036ee2596dec93accd26f627c5b95591ae9f..b92044cf03e750afa521a93519500e9d
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From 7f314dbd22408377f9e7e3537dc0521ae933b53e Mon Sep 17 00:00:00 2001
+From 23122064c9a8be975b07aad67e74213cf9fdc7d8 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
-Subject: [PATCH 075/118] Add driver for rpi-proto
+Subject: [PATCH 075/122] Add driver for rpi-proto
 
 Forward port of 3.10.x driver from https://github.com/koalo
 We are using a custom board and would like to use rpi 3.18.x
@@ -114263,10 +114263,10 @@ index 0000000000000000000000000000000000000000..9db678e885efd63d84d60a098a84ed67
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 2ef9c52bf68b163dda3666a20dfefcbed2e42bf6 Mon Sep 17 00:00:00 2001
+From 23e17d37207fc0039b141c8988644c24885ba10a Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
-Subject: [PATCH 076/118] RaspiDAC3 support
+Subject: [PATCH 076/122] RaspiDAC3 support
 
 Signed-off-by: Jan Grulich <jan@grulich.eu>
 
@@ -114509,10 +114509,10 @@ index 0000000000000000000000000000000000000000..dd9eeea2af0382307f437e6db09d1546
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From b9bbce6e6914108063a3a1b2c17ed792a3dfd351 Mon Sep 17 00:00:00 2001
+From 328c723f04e73cc2484ae7d5d6f317fc22fbd386 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
-Subject: [PATCH 077/118] Add Support for JustBoom Audio boards
+Subject: [PATCH 077/122] Add Support for JustBoom Audio boards
 
 justboom-dac: Adjust for ALSA API change
 
@@ -114966,10 +114966,10 @@ index 0000000000000000000000000000000000000000..91acb666380faa3c0deb2230f8a0f8bb
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From d146863cec303731b37c7d86bcf56ddcafcd2199 Mon Sep 17 00:00:00 2001
+From 070a41a6ef5eb0427354b758ce45fee7476e8e84 Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
-Subject: [PATCH 078/118] ARM: adau1977-adc: Add basic machine driver for
+Subject: [PATCH 078/122] ARM: adau1977-adc: Add basic machine driver for
  adau1977 codec driver.
 
 This commit adds basic support for the codec usage including: Device tree overlay,
@@ -115151,10 +115151,10 @@ index 0000000000000000000000000000000000000000..6e2ee027926ee63c89222f75ceb89e3d
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From ed26616bccf0c8d84600da21240bcbd913ee7e7f Mon Sep 17 00:00:00 2001
+From d3f05a999f9f646a4fad423073c2bfd16ac8cdb7 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
-Subject: [PATCH 079/118] New AudioInjector.net Pi soundcard with low jitter
+Subject: [PATCH 079/122] New AudioInjector.net Pi soundcard with low jitter
  audio in and out.
 
 Contains the sound/soc/bcm ALSA machine driver and necessary alterations to the Kconfig and Makefile.
@@ -115405,10 +115405,10 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 4466167663935a49e4828c67d5788ec47a79d417 Mon Sep 17 00:00:00 2001
+From 6cdf489fe02f677a7a5312dd53f5b5dfa1632487 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
-Subject: [PATCH 080/118] Add IQAudIO Digi WM8804 board support
+Subject: [PATCH 080/122] Add IQAudIO Digi WM8804 board support
 
 Support IQAudIO Digi board with iqaudio_digi machine driver and
  iqaudio-digi-wm8804-audio overlay.
@@ -115708,10 +115708,10 @@ index 0000000000000000000000000000000000000000..9b6e829bcb5b1762a853775e78163196
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 24c4db954f875c5da3c9afd5c9b491f6c4210656 Mon Sep 17 00:00:00 2001
+From 922b72225da0a94bdc3a2c7a52ac04431e67a6a8 Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
-Subject: [PATCH 081/118] New driver for RRA DigiDAC1 soundcard using WM8741 +
+Subject: [PATCH 081/122] New driver for RRA DigiDAC1 soundcard using WM8741 +
  WM8804
 
 ---
@@ -116184,10 +116184,10 @@ index 0000000000000000000000000000000000000000..446796e7e4c14a7d95b2f2a01211d9a0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From 9519d83c7c32c808aa0dc201d1bda664666825bc Mon Sep 17 00:00:00 2001
+From 1a76a9a2ca9445123234adc7b30e448216da6017 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
-Subject: [PATCH 082/118] Add support for Dion Audio LOCO DAC-AMP HAT
+Subject: [PATCH 082/122] Add support for Dion Audio LOCO DAC-AMP HAT
 
 Using dedicated machine driver and pcm5102a codec driver.
 
@@ -116360,10 +116360,10 @@ index 0000000000000000000000000000000000000000..89e65317512bc774453ac8d0d5b0ff98
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From 48b527833946f505f1e8004207c2a2770e800767 Mon Sep 17 00:00:00 2001
+From 38964afabad4b0ae7e3d50153daf97dd98277597 Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
-Subject: [PATCH 083/118] Allo Piano DAC boards: Initial 2 channel (stereo)
+Subject: [PATCH 083/122] Allo Piano DAC boards: Initial 2 channel (stereo)
  support (#1645)
 
 Add initial 2 channel (stereo) support for Allo Piano DAC (2.0/2.1) boards,
@@ -116570,10 +116570,10 @@ index 0000000000000000000000000000000000000000..8e8e62e5a36a279b425ed4655cfbac99
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 6c886c8edd47456f9ea8735f003a71422c580b0e Mon Sep 17 00:00:00 2001
+From 32c97c8263ee9440ac09cf4c117a00563ba86748 Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
-Subject: [PATCH 084/118] Support for Blokas Labs pisound board
+Subject: [PATCH 084/122] Support for Blokas Labs pisound board
 
 Pisound dynamic overlay (#1760)
 
@@ -117750,10 +117750,10 @@ index 0000000000000000000000000000000000000000..4b8545487d06e4ea70073a5d063fb231
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From 6b2923c5d85c7daa2e1efdb6e083bda5db5579aa Mon Sep 17 00:00:00 2001
+From 96f367ff7d360c52f563775dd1e9cee71aa63c6d Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
-Subject: [PATCH 085/118] rpi_display: add backlight driver and overlay
+Subject: [PATCH 085/122] rpi_display: add backlight driver and overlay
 
 Add a mailbox-driven backlight controller for the Raspberry Pi DSI
 touchscreen display. Requires updated GPU firmware to recognise the
@@ -117922,10 +117922,10 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 7ce6a9a9e8e4ded0b5411be1f337e697c40ee38b Mon Sep 17 00:00:00 2001
+From 859fe9e43315cc5f8ec150814ac4d841c9bfdcf1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
-Subject: [PATCH 086/118] bcm2835-virtgpio: Virtual GPIO driver
+Subject: [PATCH 086/122] bcm2835-virtgpio: Virtual GPIO driver
 
 Add a virtual GPIO driver that uses the firmware mailbox interface to
 request that the VPU toggles LEDs.
@@ -118199,10 +118199,10 @@ index b0f6e33bd30c35664ceee057f4c3ad32b914291d..e92278968b2b979db2a1f855f70e7aaf
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 5310bef4d1b2160385c9bdd914e897f46d7e8911 Mon Sep 17 00:00:00 2001
+From 7968227bc3b1b0b1297b304fbfd4a76de6a1f40e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
-Subject: [PATCH 087/118] amba_pl011: Don't use DT aliases for numbering
+Subject: [PATCH 087/122] amba_pl011: Don't use DT aliases for numbering
 
 The pl011 driver looks for DT aliases of the form "serial<n>",
 and if found uses <n> as the device ID. This can cause
@@ -118231,10 +118231,10 @@ index e2c33b9528d82ed7a2c27d083d7b1d222da68178..5a11ff833e1fd112ba04df3a427cd94b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From c65323ecc55f9524e86136e2d7dd7c69cb376bcb Mon Sep 17 00:00:00 2001
+From 0dba8271302e1c9a96f1ead8f5a7b9a0ffc7325e Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
-Subject: [PATCH 088/118] OF: DT-Overlay configfs interface
+Subject: [PATCH 088/122] OF: DT-Overlay configfs interface
 
 This is a port of Pantelis Antoniou's v3 port that makes use of the
 new upstreamed configfs support for binary attributes.
@@ -118666,10 +118666,10 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From f302de7074e873da78f9ee2df75c86bf157a5521 Mon Sep 17 00:00:00 2001
+From 7599baf5d2f2a063d430fce4de57db739ac1d05c Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
-Subject: [PATCH 089/118] brcm: adds support for BCM43341 wifi
+Subject: [PATCH 089/122] brcm: adds support for BCM43341 wifi
 
 brcmfmac: Disable power management
 
@@ -118832,10 +118832,10 @@ index d0407d9ad7827cd756b6311410ffe2d9a7cacc78..f1fb8a3c7a3211e8429585861f2f42e0
  #define BRCM_CC_4335_CHIP_ID		0x4335
  #define BRCM_CC_4339_CHIP_ID		0x4339
 
-From 2ee94ce425179c2d3760ee39ea3482d03638d182 Mon Sep 17 00:00:00 2001
+From 409e8d08947ff33556f6bcb8eb6bfdc47613ce6b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
-Subject: [PATCH 090/118] hci_h5: Don't send conf_req when ACTIVE
+Subject: [PATCH 090/122] hci_h5: Don't send conf_req when ACTIVE
 
 Without this patch, a modem and kernel can continuously bombard each
 other with conf_req and conf_rsp messages, in a demented game of tag.
@@ -118858,10 +118858,10 @@ index 0879d64b1caf58afb6e5d494c07d9ab7e7cdf983..5161ab30fd533d50f516bb93d5b9f402
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From ceb9c9d3a20e4cdad47fd4f84511143f69cd3235 Mon Sep 17 00:00:00 2001
+From 5fd6ff953ace9d64a39412f410b4a6eb09dd4711 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
-Subject: [PATCH 091/118] config: Add default configs
+Subject: [PATCH 091/122] config: Add default configs
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1297 +++++++++++++++++++++++++++++++++++
@@ -121488,10 +121488,10 @@ index 0000000000000000000000000000000000000000..8acee9f31202ec14f2933d92dd70831c
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 4790a58452a6c6a8b8fd5d15dc46636f8a27dc0e Mon Sep 17 00:00:00 2001
+From 7452484b501a3dd0ca66226de11cf4fb9a576390 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
-Subject: [PATCH 092/118] Add arm64 configuration and device tree differences.
+Subject: [PATCH 092/122] Add arm64 configuration and device tree differences.
  Disable MMC_BCM2835_SDHOST and MMC_BCM2835 since these drivers are crashing
  at the moment.
 
@@ -122906,10 +122906,10 @@ index 0000000000000000000000000000000000000000..d7406f5a4620151044b8f716b4d10bb8
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2708_VCHIQ=n
 
-From afbfe676544fd2a127bab7baa1a11ecf3349569c Mon Sep 17 00:00:00 2001
+From d5f278b5d66aaae13361aa90bf4a06a9babf5746 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 7 Mar 2016 15:05:11 +0000
-Subject: [PATCH 093/118] vchiq_arm: Tweak the logging output
+Subject: [PATCH 093/122] vchiq_arm: Tweak the logging output
 
 Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 ---
@@ -122984,10 +122984,10 @@ index 2c98da4307dff994a00dc246574ef0aaee05d5da..160db24aeea33a8296923501009c1f02
  
  		switch (type) {
 
-From fc373b8605790ab0f0ebdbb9f057818873a2186e Mon Sep 17 00:00:00 2001
+From b65b8cb1ff93d43d24558076bb81f19b1ab5ea50 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 14:16:25 +0000
-Subject: [PATCH 094/118] vchiq_arm: Access the dequeue_pending flag locked
+Subject: [PATCH 094/122] vchiq_arm: Access the dequeue_pending flag locked
 
 Reading through this code looking for another problem (now found in userland)
 the use of dequeue_pending outside a lock didn't seem safe.
@@ -123045,10 +123045,10 @@ index 7b6cd4d80621e38ff6d47fcd87b45fbe9cd4259b..d8669fa7f39b077877eca1829ba9538b
  
  	return add_completion(instance, reason, header, user_service,
 
-From 566bfd7cc8e5acde2543833fcd56c848f8e9c46b Mon Sep 17 00:00:00 2001
+From 1236ef13699c7ce7cb486c13c244be0038419918 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 20:53:47 +0000
-Subject: [PATCH 095/118] vchiq_arm: Service callbacks must not fail
+Subject: [PATCH 095/122] vchiq_arm: Service callbacks must not fail
 
 Service callbacks are not allowed to return an error. The internal callback
 that delivers events and messages to user tasks does not enqueue them if
@@ -123074,10 +123074,10 @@ index d8669fa7f39b077877eca1829ba9538bf2e21a82..54552c6ce54f413c9781ba279b936f98
  		DEBUG_TRACE(SERVICE_CALLBACK_LINE);
  	}
 
-From 0f1f6312527a32f11e6ee42a8d63d75eba250925 Mon Sep 17 00:00:00 2001
+From 42c9df04946a82e2e84ce093e9fe8e0e00183e05 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 21 Apr 2016 13:49:32 +0100
-Subject: [PATCH 096/118] vchiq_arm: Add completion records under the mutex
+Subject: [PATCH 096/122] vchiq_arm: Add completion records under the mutex
 
 An issue was observed when flushing openmax components
 which generate a large number of messages returning
@@ -123140,10 +123140,10 @@ index 54552c6ce54f413c9781ba279b936f98be4f47b0..bde8955b7d8505d73579b77b5b392154
  
  	return VCHIQ_SUCCESS;
 
-From 89fdf1228ffb4140cc1211cd520adc5f002ec81b Mon Sep 17 00:00:00 2001
+From e027b929fb8e3c2ca6ee3b9c26104cd88a6ad4b6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 20 Jun 2016 13:51:44 +0100
-Subject: [PATCH 097/118] vchiq_arm: Avoid use of mutex in add_completion
+Subject: [PATCH 097/122] vchiq_arm: Avoid use of mutex in add_completion
 
 Claiming the completion_mutex within add_completion did prevent some
 messages appearing twice, but provokes a deadlock caused by vcsm using
@@ -123337,10 +123337,10 @@ index 160db24aeea33a8296923501009c1f02bc41e599..71a3bedc55314f3b22dbff40c05dedf0
  		up(&state->slot_available_event);
  	}
 
-From 8e1a7a0a6eb06e6d0af55aca76849c72a261a8e9 Mon Sep 17 00:00:00 2001
+From 36afbf3ec01bb2c073b99d9f8e09e72d3aba6b08 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:14:10 -0700
-Subject: [PATCH 098/118] staging/vchi: Convert to current get_user_pages()
+Subject: [PATCH 098/122] staging/vchi: Convert to current get_user_pages()
  arguments.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123377,10 +123377,10 @@ index e5cdda12c7e5c35c69eb96991cfdb8326def167f..085d37588c59198b4e5f00b9249bb842
  		num_pages,                /* len */
  		0,                        /* gup_flags */
 
-From efe65d3f6da0049c9cbb44f69eca21cb9ea50121 Mon Sep 17 00:00:00 2001
+From 78c3ef34645364c0313d5322eed35c608e75ed32 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:16:03 -0700
-Subject: [PATCH 099/118] staging/vchi: Update for rename of
+Subject: [PATCH 099/122] staging/vchi: Update for rename of
  page_cache_release() to put_page().
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123425,10 +123425,10 @@ index 085d37588c59198b4e5f00b9249bb8421695854f..5a2b8fb459ebe086ec229f37b6381bdb
  	kfree(pages);
  }
 
-From dc360754977a1532c5b736f7e71349e06f6f623c Mon Sep 17 00:00:00 2001
+From 7bc3755fca9fc00495e6ad3857bbf75756a0ad74 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:21:17 -0700
-Subject: [PATCH 100/118] drivers/vchi: Remove dependency on CONFIG_BROKEN.
+Subject: [PATCH 100/122] drivers/vchi: Remove dependency on CONFIG_BROKEN.
 
 The driver builds now.
 
@@ -123450,10 +123450,10 @@ index 9676fb29075a457109e4d4235f086987aec74868..db8e1beb89f9f8c48ea5964016c8285e
  	help
  		Kernel to VideoCore communication interface for the
 
-From 289c3f75740d07ac8fc64bcaa07ebf91d02d87ea Mon Sep 17 00:00:00 2001
+From 47fc16ef621f8b834e809715c77f601e104caa3e Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
-Subject: [PATCH 101/118] raspberrypi-firmware: Export the general transaction
+Subject: [PATCH 101/122] raspberrypi-firmware: Export the general transaction
  function.
 
 The vc4-firmware-kms module is going to be doing the MBOX FB call.
@@ -123497,10 +123497,10 @@ index e92278968b2b979db2a1f855f70e7aafb224fa98..09e3d871d110eb0762ebdb5ea3293537
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 7ab9682505e6ccaa7249f90e8c444c8ea4cdf259 Mon Sep 17 00:00:00 2001
+From 9ae6d3437ea35dacb0bc1353d7c6646dd2b7913d Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
-Subject: [PATCH 102/118] raspberrypi-firmware: Define the MBOX channel in the
+Subject: [PATCH 102/122] raspberrypi-firmware: Define the MBOX channel in the
  header.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123522,10 +123522,10 @@ index 09e3d871d110eb0762ebdb5ea329353738d58661..2859db09e25bb945251e85edb39bc434
  
  enum rpi_firmware_property_status {
 
-From b7aa695992e5e42a6be288ea307769b53e294c5d Mon Sep 17 00:00:00 2001
+From 23c8fb1fa456520a1abe7a50484eee18e94f09bc Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
-Subject: [PATCH 103/118] drm/vc4: Add a mode for using the closed firmware for
+Subject: [PATCH 103/122] drm/vc4: Add a mode for using the closed firmware for
  display.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -124292,10 +124292,10 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From 409fc2849c293e495a2fd3217c91ec19aa02a14c Mon Sep 17 00:00:00 2001
+From 26a8008c3e11309384b26b46cfc4c6499c2fe676 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 17 Sep 2016 15:07:10 +0200
-Subject: [PATCH 104/118] i2c: bcm2835: Fix hang for writing messages larger
+Subject: [PATCH 104/122] i2c: bcm2835: Fix hang for writing messages larger
  than 16 bytes
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124385,10 +124385,10 @@ index d4f3239b56865919e1b781b20a7c5ebcd76b4eb9..f283b714aa79e2e4685ed95b04b6b289
  	i2c_dev->msg_buf_remaining = msg->len;
  	reinit_completion(&i2c_dev->completion);
 
-From 2992b3ee682b67b8098aac4ca2cb244e9fdbdc7c Mon Sep 17 00:00:00 2001
+From c91628e1f62406194456f78889477efa6ebe1592 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 18:24:38 +0200
-Subject: [PATCH 105/118] i2c: bcm2835: Protect against unexpected TXW/RXR
+Subject: [PATCH 105/122] i2c: bcm2835: Protect against unexpected TXW/RXR
  interrupts
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124513,10 +124513,10 @@ index f283b714aa79e2e4685ed95b04b6b289f7e9eee7..d2ba1a4de36af512e8e3c97251bd3537
  		return -ETIMEDOUT;
  	}
 
-From eae3435b9be49b5d7fd3b21b5985665ac78e3bfb Mon Sep 17 00:00:00 2001
+From 878f3d3cb001a41cefc17e11e5b527b576478959 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Mon, 19 Sep 2016 17:19:41 +0200
-Subject: [PATCH 106/118] i2c: bcm2835: Use dev_dbg logging on transfer errors
+Subject: [PATCH 106/122] i2c: bcm2835: Use dev_dbg logging on transfer errors
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124548,10 +124548,10 @@ index d2ba1a4de36af512e8e3c97251bd3537ae61591a..54d510abd46a117c9238fc6d7edec840
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From d3b13d1fe86b367a2bb34bde541dea378a9bb159 Mon Sep 17 00:00:00 2001
+From dd301c9f8456669afa77139328d78bac9f2fcb48 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Thu, 22 Sep 2016 22:05:50 +0200
-Subject: [PATCH 107/118] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
+Subject: [PATCH 107/122] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124595,10 +124595,10 @@ index 54d510abd46a117c9238fc6d7edec84019d1f60d..565ef69ce61423544dc0558c85ef318b
  
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
 
-From 8d90227b02b2781f87de0e472990dc5e24eb8d7d Mon Sep 17 00:00:00 2001
+From 17019eef014c360549b56b67f8f6448e718b9496 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:54:27 +0200
-Subject: [PATCH 108/118] i2c: bcm2835: Add support for Repeated Start
+Subject: [PATCH 108/122] i2c: bcm2835: Add support for Repeated Start
  Condition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124780,10 +124780,10 @@ index 565ef69ce61423544dc0558c85ef318b0ae9c324..241e08ae7c27cec23fad3c1bf3ebad3a
  
  static u32 bcm2835_i2c_func(struct i2c_adapter *adap)
 
-From fa195989cbbf0c5935998064ceca71c1a7c0828a Mon Sep 17 00:00:00 2001
+From 90f2d2d5fb2aa94eafd361372b6a55fa3ad1b029 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:57:17 +0200
-Subject: [PATCH 109/118] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
+Subject: [PATCH 109/122] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124820,10 +124820,10 @@ index 241e08ae7c27cec23fad3c1bf3ebad3a4d2a8e6f..d2085dd3742eabebc537621968088261
  		bcm2835_i2c_writel(i2c_dev, BCM2835_I2C_C,
  				   BCM2835_I2C_C_CLEAR);
 
-From d51893d40fa09cc45705dd3455767994b063c23e Mon Sep 17 00:00:00 2001
+From d0724c34a0fc6d93228c19bede299e63afe0c036 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 27 Sep 2016 01:00:08 +0200
-Subject: [PATCH 110/118] i2c: bcm2835: Add support for dynamic clock
+Subject: [PATCH 110/122] i2c: bcm2835: Add support for dynamic clock
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124939,10 +124939,10 @@ index d2085dd3742eabebc537621968088261f8dc7ea8..c3436f627028477f7e21b47e079fd5ab
  	irq = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
  	if (!irq) {
 
-From ee509744d81b69d5be41a42ed1604ba36362a832 Mon Sep 17 00:00:00 2001
+From 0cc815d16e01c81698ecb53c57222ffb003377bf Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
-Subject: [PATCH 111/118] i2c: bcm2835: Add debug support
+Subject: [PATCH 111/122] i2c: bcm2835: Add debug support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -125131,10 +125131,10 @@ index c3436f627028477f7e21b47e079fd5ab06ec188a..8642f580ce41803bd22c76a0fa80d083
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 871ba19b271f2b4e5957005e88e0ec1a5100216b Mon Sep 17 00:00:00 2001
+From 683eb2a626bdf358dd1d447bfe3b0e7d112d8024 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 31 Dec 2016 14:15:50 +0000
-Subject: [PATCH 112/118] arm64: Add CONFIG_ARCH_BCM2835
+Subject: [PATCH 112/122] arm64: Add CONFIG_ARCH_BCM2835
 
 ---
  arch/arm64/configs/bcmrpi3_defconfig | 1 +
@@ -125150,10 +125150,10 @@ index d7406f5a4620151044b8f716b4d10bb818648e06..53da5c7a33e5898a66e549fb0c39fe3d
  CONFIG_BCM2708_VCHIQ=n
 +CONFIG_ARCH_BCM2835=y
 
-From c9f095b015beaa2b8926dc16a692d946367c0223 Mon Sep 17 00:00:00 2001
+From 8ec76aa6373a8c90eac7d8c8e980fa333ff69464 Mon Sep 17 00:00:00 2001
 From: Alex Tucker <alex@floop.org.uk>
 Date: Tue, 13 Dec 2016 19:50:18 +0000
-Subject: [PATCH 113/118] Add support for Silicon Labs Si7013/20/21
+Subject: [PATCH 113/122] Add support for Silicon Labs Si7013/20/21
  humidity/temperature sensor.
 
 ---
@@ -125228,10 +125228,10 @@ index f6d134c095af2398fc55ae7d2b0e86456c30627c..31bda8da4cb6a56bfe493a81b9189009
  	};
  };
 
-From 988ff6b453f319ec4bdd13160cd9c95c4347a703 Mon Sep 17 00:00:00 2001
+From 3b6760e6f2f03b620e4e88d67d3b640c56ce7fd3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 3 Jan 2017 21:27:46 +0000
-Subject: [PATCH 114/118] Document the si7020 option
+Subject: [PATCH 114/122] Document the si7020 option
 
 ---
  arch/arm/boot/dts/overlays/README | 3 +++
@@ -125252,10 +125252,10 @@ index 81d991803be335e5a1bc3bb0a8c7a2c9f5c392bd..e8fa4ccb44c34a20485c4e6155467af9
  Name:   i2c0-bcm2708
  Info:   Enable the i2c_bcm2708 driver for the i2c0 bus. Not all pin combinations
 
-From 1b0c1c6ce71d6076ec100bf1dbb3b5e87f64556b Mon Sep 17 00:00:00 2001
+From 4ef541bea608cd9f84bc76c8092fafaad1702e3f Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Thu, 5 Jan 2017 02:38:16 +0200
-Subject: [PATCH 115/118] pisound improvements:
+Subject: [PATCH 115/122] pisound improvements:
 
 * Added a writable sysfs object to enable scripts / user space software
 to blink MIDI activity LEDs for variable duration.
@@ -125549,10 +125549,10 @@ index 4b8545487d06e4ea70073a5d063fb2310b3b94d0..ba70734b89e61a11201657406223f0b3
  };
  
 
-From fcd5ab41bc1ff092661afd914247c667c45529ea Mon Sep 17 00:00:00 2001
+From 425e9111b1dfad787b1f787ec5086fdf1893584e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:23:06 +0000
-Subject: [PATCH 116/118] Revert "Revert "Added driver for HiFiBerry Amp
+Subject: [PATCH 116/122] Revert "Revert "Added driver for HiFiBerry Amp
  amplifier add-on board""
 
 This reverts commit bf84babd8fffcb79c60f1342c2416f8e1e4b7af9.
@@ -126376,10 +126376,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 85a791fa81082ce933ba66d0f63494486e50ca4d Mon Sep 17 00:00:00 2001
+From 15550aafac107a499180a103bcaceed80f37dacd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:42:09 +0000
-Subject: [PATCH 117/118] hifiberry-amp: Adjust for ALSA object refactoring
+Subject: [PATCH 117/122] hifiberry-amp: Adjust for ALSA object refactoring
 
 See: https://github.com/raspberrypi/linux/issues/1775
 ---
@@ -126404,10 +126404,10 @@ index 9b2713861dcbed751842ca29c88eb1eae5867411..560234d58a6b0a6e7fd3a63e8de73339
  
  
 
-From 02fd5648e60335c1408847b73bf43dce7c868ac9 Mon Sep 17 00:00:00 2001
+From d3a7daff54ea1d57654aa2be744d6173441b5e35 Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Sun, 8 Jan 2017 15:58:54 +0200
-Subject: [PATCH 118/118] bcm2835-i2s: Changes for allowing asymmetric sample
+Subject: [PATCH 118/122] bcm2835-i2s: Changes for allowing asymmetric sample
  formats.
 
 This is achieved by making changes only to the requested
@@ -126496,3 +126496,521 @@ index 6ba20498202ed36906b52096893a88867a79269f..171c2401dfe192740fca3356268aff64
  	}
  
  	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);
+
+From a268f59a304d04349f3a0358db1f434e47cda8b6 Mon Sep 17 00:00:00 2001
+From: Aaron Shaw <shawaj@gmail.com>
+Date: Tue, 10 Jan 2017 16:05:41 +0000
+Subject: [PATCH 119/122] Add driver_name property
+
+Add driver name property for use with 5.1 passthrough audio in LibreElec and other Kodi based OSs
+---
+ sound/soc/bcm/justboom-dac.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/soc/bcm/justboom-dac.c b/sound/soc/bcm/justboom-dac.c
+index 8fd50dbe681508a2cfe8fdde1c9fedbe9a507fa7..05a224ec712d06b8b7587ab6b8bb562d19956d47 100644
+--- a/sound/soc/bcm/justboom-dac.c
++++ b/sound/soc/bcm/justboom-dac.c
+@@ -98,6 +98,7 @@ static struct snd_soc_dai_link snd_rpi_justboom_dac_dai[] = {
+ /* audio machine driver */
+ static struct snd_soc_card snd_rpi_justboom_dac = {
+ 	.name         = "snd_rpi_justboom_dac",
++	.driver_name  = "JustBoomDac",
+ 	.owner        = THIS_MODULE,
+ 	.dai_link     = snd_rpi_justboom_dac_dai,
+ 	.num_links    = ARRAY_SIZE(snd_rpi_justboom_dac_dai),
+
+From ad475b3f75da457818fa6fab1c1e2f89f453dc07 Mon Sep 17 00:00:00 2001
+From: Aaron Shaw <shawaj@gmail.com>
+Date: Tue, 10 Jan 2017 16:11:04 +0000
+Subject: [PATCH 120/122] Add driver_name paramater
+
+Add driver_name parameter for use with 5.1 passthrough audio in LibreElec and other Kodi OSs
+---
+ sound/soc/bcm/justboom-digi.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/soc/bcm/justboom-digi.c b/sound/soc/bcm/justboom-digi.c
+index 91acb666380faa3c0deb2230f8a0f8bbec59417b..abfdc5c4dd5811e6847bddda4921abe33fa02812 100644
+--- a/sound/soc/bcm/justboom-digi.c
++++ b/sound/soc/bcm/justboom-digi.c
+@@ -154,6 +154,7 @@ static struct snd_soc_dai_link snd_rpi_justboom_digi_dai[] = {
+ /* audio machine driver */
+ static struct snd_soc_card snd_rpi_justboom_digi = {
+ 	.name         = "snd_rpi_justboom_digi",
++	.driver_name  = "JustBoomDigi",
+ 	.owner        = THIS_MODULE,
+ 	.dai_link     = snd_rpi_justboom_digi_dai,
+ 	.num_links    = ARRAY_SIZE(snd_rpi_justboom_digi_dai),
+
+From 987aadab51987bac29470f3ee200fa8bfa2eae6b Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Wed, 11 Jan 2017 13:01:21 +0000
+Subject: [PATCH 121/122] BCM270X_DT: Add pi3-disable-wifi overlay
+
+pi3-disable-wifi is a minimal overlay to disable the onboard WiFi.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ arch/arm/boot/dts/overlays/Makefile                     |  1 +
+ arch/arm/boot/dts/overlays/README                       |  6 ++++++
+ arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts | 13 +++++++++++++
+ 3 files changed, 20 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index 11dba31712840a9e4b91acd4565c2d6266315273..f1191c1ded82490be5f793ab6483bc5af5891db2 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -51,6 +51,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	mz61581.dtbo \
+ 	pi3-act-led.dtbo \
+ 	pi3-disable-bt.dtbo \
++	pi3-disable-wifi.dtbo \
+ 	pi3-miniuart-bt.dtbo \
+ 	piscreen.dtbo \
+ 	piscreen2r.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/README b/arch/arm/boot/dts/overlays/README
+index e8fa4ccb44c34a20485c4e6155467af99179153a..34109c69416c1caf28910895320a2b9cd539588e 100644
+--- a/arch/arm/boot/dts/overlays/README
++++ b/arch/arm/boot/dts/overlays/README
+@@ -800,6 +800,12 @@ Load:   dtoverlay=pi3-disable-bt
+ Params: <None>
+ 
+ 
++Name:   pi3-disable-wifi
++Info:   Disable Pi3 onboard WiFi
++Load:   dtoverlay=pi3-disable-wifi
++Params: <None>
++
++
+ Name:   pi3-miniuart-bt
+ Info:   Switch Pi3 Bluetooth function to use the mini-UART (ttyS0) and restore
+         UART0/ttyAMA0 over GPIOs 14 & 15. Note that this may reduce the maximum
+diff --git a/arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts b/arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..017199554bf2f4e381efcc7bb71e750c210343e0
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/{
++	compatible = "brcm,bcm2708";
++
++	fragment@0 {
++		target = <&mmc>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+
+From 5c94b3839b261c3c73893677ab6e2355a1177b74 Mon Sep 17 00:00:00 2001
+From: Electron752 <mzoran@crowfest.net>
+Date: Thu, 12 Jan 2017 07:07:08 -0800
+Subject: [PATCH 122/122] ARM64: Make it work again on 4.9 (#1790)
+
+* Invoke the dtc compiler with the same options used in arm mode.
+* ARM64 now uses the bcm2835 platform just like ARM32.
+* ARM64: Update bcmrpi3_defconfig
+
+Signed-off-by: Michael Zoran <mzoran@crowfest.net>
+---
+ arch/arm64/Kconfig.platforms          |  22 ------
+ arch/arm64/boot/dts/broadcom/Makefile |  10 ++-
+ arch/arm64/boot/dts/overlays          |   1 +
+ arch/arm64/configs/bcmrpi3_defconfig  | 126 ++++++++++------------------------
+ 4 files changed, 48 insertions(+), 111 deletions(-)
+ create mode 120000 arch/arm64/boot/dts/overlays
+
+diff --git a/arch/arm64/Kconfig.platforms b/arch/arm64/Kconfig.platforms
+index 7d213c2c904271c7a4622b83cd55a750d237bc2e..101794f5ce1008b7ff007fbfc7fa23d9e63bae67 100644
+--- a/arch/arm64/Kconfig.platforms
++++ b/arch/arm64/Kconfig.platforms
+@@ -1,27 +1,5 @@
+ menu "Platform selection"
+ 
+-config MACH_BCM2709
+-        bool
+-
+-config ARCH_BCM2709
+-        bool "Broadcom BCM2709 family"
+-        select MACH_BCM2709
+-        select HAVE_SMP
+-        select ARM_AMBA
+-        select COMMON_CLK
+-        select ARCH_HAS_CPUFREQ
+-        select GENERIC_CLOCKEVENTS
+-        select MULTI_IRQ_HANDLER
+-        select SPARSE_IRQ
+-        select MFD_SYSCON
+-        select VC4
+-        select USE_OF
+-        select ARCH_REQUIRE_GPIOLIB
+-        select PINCTRL
+-        select PINCTRL_BCM2835
+-        help
+-          This enables support for Broadcom BCM2709 boards.
+-
+ config ARCH_SUNXI
+ 	bool "Allwinner sunxi 64-bit SoC Family"
+ 	select GENERIC_IRQ_CHIP
+diff --git a/arch/arm64/boot/dts/broadcom/Makefile b/arch/arm64/boot/dts/broadcom/Makefile
+index 2152448c8cf5b22c573642d7ce45e85793f5fc9a..7aa03be73fda08d555a13323f483e9b95398f234 100644
+--- a/arch/arm64/boot/dts/broadcom/Makefile
++++ b/arch/arm64/boot/dts/broadcom/Makefile
+@@ -1,7 +1,15 @@
++# Enable fixups to support overlays on BCM2835 platforms
++
++ifeq ($(CONFIG_ARCH_BCM2835),y)
++DTC_FLAGS ?= -@ -H epapr
++endif
++
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2837-rpi-3-b.dtb
+ dtb-$(CONFIG_ARCH_BCM_IPROC) += ns2-svk.dtb
+ dtb-$(CONFIG_ARCH_VULCAN) += vulcan-eval.dtb
+-dtb-$(CONFIG_ARCH_BCM2709) += bcm2710-rpi-3-b.dtb
++dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-3-b.dtb
++
++dts-dirs += ../overlays
+ 
+ always		:= $(dtb-y)
+ subdir-y	:= $(dts-dirs)
+diff --git a/arch/arm64/boot/dts/overlays b/arch/arm64/boot/dts/overlays
+new file mode 120000
+index 0000000000000000000000000000000000000000..ded08646b6f66cdf734f8bf9c1be3a2e3a7103d7
+--- /dev/null
++++ b/arch/arm64/boot/dts/overlays
+@@ -0,0 +1 @@
++../../../arm/boot/dts/overlays
+\ No newline at end of file
+diff --git a/arch/arm64/configs/bcmrpi3_defconfig b/arch/arm64/configs/bcmrpi3_defconfig
+index 53da5c7a33e5898a66e549fb0c39fe3da555ca87..c7e891d72969a388d9b135a36dbfc9c9cb609bf8 100644
+--- a/arch/arm64/configs/bcmrpi3_defconfig
++++ b/arch/arm64/configs/bcmrpi3_defconfig
+@@ -1,52 +1,9 @@
+-# CONFIG_ARM_PATCH_PHYS_VIRT is not set
+-CONFIG_PHYS_OFFSET=0
+ CONFIG_LOCALVERSION="-v8"
+ # CONFIG_LOCALVERSION_AUTO is not set
+-CONFIG_64BIT=y
+ CONFIG_SYSVIPC=y
+ CONFIG_POSIX_MQUEUE=y
+ CONFIG_NO_HZ=y
+ CONFIG_HIGH_RES_TIMERS=y
+-
+-#
+-# ARM errata workarounds via the alternatives framework
+-#
+-CONFIG_ARM64_ERRATUM_826319=n
+-CONFIG_ARM64_ERRATUM_827319=n
+-CONFIG_ARM64_ERRATUM_824069=n
+-CONFIG_ARM64_ERRATUM_819472=n
+-CONFIG_ARM64_ERRATUM_832075=n
+-CONFIG_ARM64_ERRATUM_845719=n
+-CONFIG_ARM64_ERRATUM_843419=n
+-CONFIG_CAVIUM_ERRATUM_22375=n
+-CONFIG_CAVIUM_ERRATUM_23154=n
+-CONFIG_CAVIUM_ERRATUM_27456=n
+-CONFIG_ARM64_4K_PAGES=y
+-CONFIG_ARM64_VA_BITS_39=y
+-CONFIG_ARM64_VA_BITS=39
+-CONFIG_SCHED_MC=y
+-CONFIG_NR_CPUS=4
+-CONFIG_HOTPLUG_CPU=y
+-CONFIG_ARMV8_DEPRECATED=y
+-CONFIG_SWP_EMULATION=y
+-CONFIG_CP15_BARRIER_EMULATION=y
+-CONFIG_SETEND_EMULATION=y
+-
+-#
+-# ARMv8.1 architectural features
+-#
+-CONFIG_ARM64_HW_AFDBM=y
+-CONFIG_ARM64_PAN=y
+-CONFIG_ARM64_LSE_ATOMICS=y
+-CONFIG_ARM64_VHE=y
+-
+-#
+-# ARMv8.2 architectural features
+-#
+-CONFIG_ARM64_UAO=y
+-CONFIG_ARM64_MODULE_CMODEL_LARGE=n
+-CONFIG_RANDOMIZE_BASE=n
+-
+ CONFIG_BSD_PROCESS_ACCT=y
+ CONFIG_BSD_PROCESS_ACCT_V3=y
+ CONFIG_TASKSTATS=y
+@@ -55,7 +12,6 @@ CONFIG_TASK_XACCT=y
+ CONFIG_TASK_IO_ACCOUNTING=y
+ CONFIG_IKCONFIG=m
+ CONFIG_IKCONFIG_PROC=y
+-CONFIG_NMI_LOG_BUF_SHIFT=12
+ CONFIG_MEMCG=y
+ CONFIG_BLK_CGROUP=y
+ CONFIG_CGROUP_FREEZER=y
+@@ -69,54 +25,49 @@ CONFIG_BLK_DEV_INITRD=y
+ CONFIG_EMBEDDED=y
+ # CONFIG_COMPAT_BRK is not set
+ CONFIG_PROFILING=y
+-CONFIG_OPROFILE=m
+ CONFIG_KPROBES=y
+ CONFIG_JUMP_LABEL=y
+ CONFIG_MODULES=y
+ CONFIG_MODULE_UNLOAD=y
+ CONFIG_MODVERSIONS=y
+ CONFIG_MODULE_SRCVERSION_ALL=y
+-CONFIG_TRIM_UNUSED_KSYMS=y
+ CONFIG_BLK_DEV_THROTTLING=y
+ CONFIG_PARTITION_ADVANCED=y
+ CONFIG_MAC_PARTITION=y
+ CONFIG_CFQ_GROUP_IOSCHED=y
+-CONFIG_ARCH_BCM2709=y
+-# CONFIG_CACHE_L2X0 is not set
+-CONFIG_SMP=y
+-CONFIG_HAVE_ARM_ARCH_TIMER=y
+-CONFIG_VMSPLIT_2G=y
+-CONFIG_PREEMPT_VOLUNTARY=y
+-CONFIG_AEABI=y
+-CONFIG_OABI_COMPAT=y
+-# CONFIG_CPU_SW_DOMAIN_PAN is not set
++CONFIG_ARCH_BCM2835=y
++# CONFIG_CAVIUM_ERRATUM_22375 is not set
++# CONFIG_CAVIUM_ERRATUM_23154 is not set
++# CONFIG_CAVIUM_ERRATUM_27456 is not set
++CONFIG_SCHED_MC=y
++CONFIG_NR_CPUS=4
++CONFIG_PREEMPT=y
++CONFIG_HZ_1000=y
+ CONFIG_CLEANCACHE=y
+ CONFIG_FRONTSWAP=y
+ CONFIG_CMA=y
+ CONFIG_ZSMALLOC=m
+ CONFIG_PGTABLE_MAPPING=y
+-CONFIG_UACCESS_WITH_MEMCPY=y
+ CONFIG_SECCOMP=y
+-# CONFIG_ATAGS is not set
+-CONFIG_ZBOOT_ROM_TEXT=0x0
+-CONFIG_ZBOOT_ROM_BSS=0x0
++CONFIG_ARMV8_DEPRECATED=y
++CONFIG_SWP_EMULATION=y
++CONFIG_CP15_BARRIER_EMULATION=y
++CONFIG_SETEND_EMULATION=y
+ CONFIG_CMDLINE="console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
++CONFIG_BINFMT_MISC=y
++CONFIG_COMPAT=y
++# CONFIG_SUSPEND is not set
++CONFIG_PM=y
++CONFIG_CPU_IDLE=y
++CONFIG_ARM_CPUIDLE=y
+ CONFIG_CPU_FREQ=y
++CONFIG_CPU_FREQ_STAT=y
+ CONFIG_CPU_FREQ_DEFAULT_GOV_POWERSAVE=y
+ CONFIG_CPU_FREQ_GOV_PERFORMANCE=y
+ CONFIG_CPU_FREQ_GOV_USERSPACE=y
+ CONFIG_CPU_FREQ_GOV_ONDEMAND=y
+ CONFIG_CPU_FREQ_GOV_CONSERVATIVE=y
+ CONFIG_CPU_FREQ_GOV_SCHEDUTIL=y
+-CONFIG_VFP=y
+-CONFIG_NEON=y
+-CONFIG_KERNEL_MODE_NEON=y
+-CONFIG_BINFMT_MISC=m
+-CONFIG_COMPAT=y
+-CONFIG_SYSVIPC_COMPAT=y
+-
+-# CONFIG_SUSPEND is not set
+-CONFIG_PM=y
+ CONFIG_NET=y
+ CONFIG_PACKET=y
+ CONFIG_UNIX=y
+@@ -437,6 +388,7 @@ CONFIG_BT_MRVL=m
+ CONFIG_BT_MRVL_SDIO=m
+ CONFIG_BT_ATH3K=m
+ CONFIG_BT_WILINK=m
++CONFIG_CFG80211=m
+ CONFIG_MAC80211=m
+ CONFIG_MAC80211_MESH=y
+ CONFIG_WIMAX=m
+@@ -490,7 +442,6 @@ CONFIG_BONDING=m
+ CONFIG_DUMMY=m
+ CONFIG_IFB=m
+ CONFIG_MACVLAN=m
+-CONFIG_IPVLAN=m
+ CONFIG_VXLAN=m
+ CONFIG_NETCONSOLE=m
+ CONFIG_TUN=m
+@@ -579,8 +530,6 @@ CONFIG_RT2800USB_RT3573=y
+ CONFIG_RT2800USB_RT53XX=y
+ CONFIG_RT2800USB_RT55XX=y
+ CONFIG_RT2800USB_UNKNOWN=y
+-CONFIG_RTL8187=m
+-CONFIG_RTL8192CU=n
+ CONFIG_USB_ZD1201=m
+ CONFIG_ZD1211RW=m
+ CONFIG_MAC80211_HWSIM=m
+@@ -606,7 +555,7 @@ CONFIG_JOYSTICK_RPISENSE=m
+ CONFIG_INPUT_TOUCHSCREEN=y
+ CONFIG_TOUCHSCREEN_ADS7846=m
+ CONFIG_TOUCHSCREEN_EGALAX=m
+-CONFIG_TOUCHSCREEN_FT6236=m
++CONFIG_TOUCHSCREEN_EKTF2127=m
+ CONFIG_TOUCHSCREEN_RPI_FT5406=m
+ CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
+ CONFIG_TOUCHSCREEN_STMPE=m
+@@ -626,10 +575,8 @@ CONFIG_SERIO_RAW=m
+ CONFIG_GAMEPORT=m
+ CONFIG_GAMEPORT_NS558=m
+ CONFIG_GAMEPORT_L4=m
+-CONFIG_BRCM_CHAR_DRIVERS=n
+-CONFIG_BCM_VC_CMA=n
+-CONFIG_BCM_VCIO=n
+-CONFIG_BCM_VC_SM=n
++# CONFIG_BCM2835_DEVGPIOMEM is not set
++# CONFIG_BCM2835_SMI_DEV is not set
+ # CONFIG_LEGACY_PTYS is not set
+ # CONFIG_DEVKMEM is not set
+ CONFIG_SERIAL_8250=y
+@@ -638,6 +585,9 @@ CONFIG_SERIAL_8250_CONSOLE=y
+ # CONFIG_SERIAL_8250_DMA is not set
+ CONFIG_SERIAL_8250_NR_UARTS=1
+ CONFIG_SERIAL_8250_RUNTIME_UARTS=0
++CONFIG_SERIAL_8250_EXTENDED=y
++CONFIG_SERIAL_8250_SHARE_IRQ=y
++CONFIG_SERIAL_8250_BCM2835AUX=y
+ CONFIG_SERIAL_OF_PLATFORM=y
+ CONFIG_SERIAL_AMBA_PL011=y
+ CONFIG_SERIAL_AMBA_PL011_CONSOLE=y
+@@ -650,6 +600,7 @@ CONFIG_I2C=y
+ CONFIG_I2C_CHARDEV=m
+ CONFIG_I2C_MUX_PCA954x=m
+ CONFIG_I2C_BCM2708=m
++CONFIG_I2C_BCM2835=m
+ CONFIG_I2C_GPIO=m
+ CONFIG_SPI=y
+ CONFIG_SPI_BCM2835=m
+@@ -681,13 +632,13 @@ CONFIG_W1_SLAVE_DS2780=m
+ CONFIG_W1_SLAVE_DS2781=m
+ CONFIG_W1_SLAVE_DS28E04=m
+ CONFIG_W1_SLAVE_BQ27000=m
+-CONFIG_BATTERY_DS2760=m
+-CONFIG_POWER_RESET=y
+ CONFIG_POWER_RESET_GPIO=y
++CONFIG_BATTERY_DS2760=m
+ CONFIG_HWMON=m
+ CONFIG_SENSORS_LM75=m
+ CONFIG_SENSORS_SHT21=m
+ CONFIG_SENSORS_SHTC1=m
++CONFIG_SENSORS_INA2XX=m
+ CONFIG_THERMAL=y
+ CONFIG_THERMAL_BCM2835=y
+ CONFIG_WATCHDOG=y
+@@ -835,8 +786,6 @@ CONFIG_VIDEO_EM28XX_V4L2=m
+ CONFIG_VIDEO_EM28XX_ALSA=m
+ CONFIG_VIDEO_EM28XX_DVB=m
+ CONFIG_V4L_PLATFORM_DRIVERS=y
+-CONFIG_VIDEO_BCM2835=n
+-CONFIG_VIDEO_BCM2835_MMAL=n
+ CONFIG_RADIO_SI470X=y
+ CONFIG_USB_SI470X=m
+ CONFIG_I2C_SI470X=m
+@@ -892,8 +841,6 @@ CONFIG_SND_VIRMIDI=m
+ CONFIG_SND_MTPAV=m
+ CONFIG_SND_SERIAL_U16550=m
+ CONFIG_SND_MPU401=m
+-CONFIG_SND_ARM=n
+-CONFIG_SND_BCM2835=n
+ CONFIG_SND_USB_AUDIO=m
+ CONFIG_SND_USB_UA101=m
+ CONFIG_SND_USB_CAIAQ=m
+@@ -916,7 +863,10 @@ CONFIG_SND_BCM2708_SOC_ADAU1977_ADC=m
+ CONFIG_SND_AUDIOINJECTOR_PI_SOUNDCARD=m
+ CONFIG_SND_DIGIDAC1_SOUNDCARD=m
+ CONFIG_SND_BCM2708_SOC_DIONAUDIO_LOCO=m
++CONFIG_SND_BCM2708_SOC_ALLO_PIANO_DAC=m
++CONFIG_SND_PISOUND=m
+ CONFIG_SND_SOC_ADAU1701=m
++CONFIG_SND_SOC_AK4554=m
+ CONFIG_SND_SOC_WM8804_I2C=m
+ CONFIG_SND_SIMPLE_CARD=m
+ CONFIG_SOUND_PRIME=m
+@@ -979,8 +929,6 @@ CONFIG_USB_HIDDEV=y
+ CONFIG_USB=y
+ CONFIG_USB_ANNOUNCE_NEW_DEVICES=y
+ CONFIG_USB_MON=m
+-CONFIG_USB_DWCOTG=n
+-CONFIG_USB_DWC2=y
+ CONFIG_USB_PRINTER=m
+ CONFIG_USB_STORAGE=y
+ CONFIG_USB_STORAGE_REALTEK=m
+@@ -1001,6 +949,7 @@ CONFIG_USB_MICROTEK=m
+ CONFIG_USBIP_CORE=m
+ CONFIG_USBIP_VHCI_HCD=m
+ CONFIG_USBIP_HOST=m
++CONFIG_USB_DWC2=y
+ CONFIG_USB_SERIAL=m
+ CONFIG_USB_SERIAL_GENERIC=y
+ CONFIG_USB_SERIAL_AIRCABLE=m
+@@ -1096,6 +1045,7 @@ CONFIG_LEDS_TRIGGER_INPUT=y
+ CONFIG_LEDS_TRIGGER_PANIC=y
+ CONFIG_RTC_CLASS=y
+ # CONFIG_RTC_HCTOSYS is not set
++CONFIG_RTC_DRV_ABX80X=m
+ CONFIG_RTC_DRV_DS1307=m
+ CONFIG_RTC_DRV_DS1374=m
+ CONFIG_RTC_DRV_DS1672=m
+@@ -1103,7 +1053,6 @@ CONFIG_RTC_DRV_MAX6900=m
+ CONFIG_RTC_DRV_RS5C372=m
+ CONFIG_RTC_DRV_ISL1208=m
+ CONFIG_RTC_DRV_ISL12022=m
+-CONFIG_RTC_DRV_ISL12057=m
+ CONFIG_RTC_DRV_X1205=m
+ CONFIG_RTC_DRV_PCF8523=m
+ CONFIG_RTC_DRV_PCF8563=m
+@@ -1137,7 +1086,6 @@ CONFIG_STAGING=y
+ CONFIG_PRISM2_USB=m
+ CONFIG_R8712U=m
+ CONFIG_R8188EU=m
+-CONFIG_R8723AU=m
+ CONFIG_VT6656=m
+ CONFIG_SPEAKUP=m
+ CONFIG_SPEAKUP_SYNTH_SOFT=m
+@@ -1153,6 +1101,7 @@ CONFIG_FB_TFT_BD663474=m
+ CONFIG_FB_TFT_HX8340BN=m
+ CONFIG_FB_TFT_HX8347D=m
+ CONFIG_FB_TFT_HX8353D=m
++CONFIG_FB_TFT_HX8357D=m
+ CONFIG_FB_TFT_ILI9163=m
+ CONFIG_FB_TFT_ILI9320=m
+ CONFIG_FB_TFT_ILI9325=m
+@@ -1176,6 +1125,7 @@ CONFIG_FB_TFT_UPD161704=m
+ CONFIG_FB_TFT_WATTEROTT=m
+ CONFIG_FB_FLEX=m
+ CONFIG_FB_TFT_FBTFT_DEVICE=m
++# CONFIG_BCM2708_VCHIQ is not set
+ CONFIG_MAILBOX=y
+ CONFIG_BCM2835_MBOX=y
+ # CONFIG_IOMMU_SUPPORT is not set
+@@ -1189,6 +1139,7 @@ CONFIG_IIO_KFIFO_BUF=m
+ CONFIG_MCP320X=m
+ CONFIG_MCP3422=m
+ CONFIG_DHT11=m
++CONFIG_HTU21=m
+ CONFIG_PWM_BCM2835=m
+ CONFIG_PWM_PCA9685=m
+ CONFIG_RASPBERRYPI_FIRMWARE=y
+@@ -1309,6 +1260,7 @@ CONFIG_BOOT_PRINTK_DELAY=y
+ CONFIG_DEBUG_MEMORY_INIT=y
+ CONFIG_DETECT_HUNG_TASK=y
+ CONFIG_TIMER_STATS=y
++CONFIG_LATENCYTOP=y
+ CONFIG_IRQSOFF_TRACER=y
+ CONFIG_SCHED_TRACER=y
+ CONFIG_STACK_TRACER=y
+@@ -1331,5 +1283,3 @@ CONFIG_CRYPTO_USER_API_SKCIPHER=m
+ CONFIG_ARM64_CRYPTO=y
+ CONFIG_CRC_ITU_T=y
+ CONFIG_LIBCRC32C=y
+-CONFIG_BCM2708_VCHIQ=n
+-CONFIG_ARCH_BCM2835=y

--- a/projects/RPi2/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi2/patches/linux/linux-01-RPi_support.patch
@@ -1,7 +1,7 @@
-From ad221e75ca78e7b45517c4a596ee8f8e48b09960 Mon Sep 17 00:00:00 2001
+From 726155a02a2642c4f992655ae4a4c062a0761260 Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
-Subject: [PATCH 001/118] smsx95xx: fix crimes against truesize
+Subject: [PATCH 001/122] smsx95xx: fix crimes against truesize
 
 smsc95xx is adjusting truesize when it shouldn't, and following a recent patch from Eric this is now triggering warnings.
 
@@ -48,10 +48,10 @@ index 831aa33d078ae7d2dd57fdded5de71d1eb915f99..b77935bded8c0ff7808b00f170ff10e5
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From cfe436f9931be38d89cbecdf4d1ca13aee366990 Mon Sep 17 00:00:00 2001
+From f1afc1dcb1c34955d1a9d756abb1b61c3a9f1da8 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
-Subject: [PATCH 002/118] smsc95xx: Experimental: Enable turbo_mode and
+Subject: [PATCH 002/122] smsc95xx: Experimental: Enable turbo_mode and
  packetsize=2560 by default
 
 See: http://forum.kodi.tv/showthread.php?tid=285288
@@ -94,10 +94,10 @@ index b77935bded8c0ff7808b00f170ff10e594300ad0..693f163684de921404738e33244881e0
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From e4567736c09da23abfebb86e052047041bf30105 Mon Sep 17 00:00:00 2001
+From 69f6712212df74f6c27b1dfec7e3cc1408416653 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
-Subject: [PATCH 003/118] Allow mac address to be set in smsc95xx
+Subject: [PATCH 003/122] Allow mac address to be set in smsc95xx
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -193,10 +193,10 @@ index 693f163684de921404738e33244881e0aab92ec9..df60c989fc229bf0aab3c27e95ccd453
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From cdf57f590c9e3ff27d89dfa899d4a0b609ef769d Mon Sep 17 00:00:00 2001
+From 10945e4697799ceff36fbdea420081b746d67429 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
-Subject: [PATCH 004/118] Protect __release_resource against resources without
+Subject: [PATCH 004/122] Protect __release_resource against resources without
  parents
 
 Without this patch, removing a device tree overlay can crash here.
@@ -224,10 +224,10 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From f53e12f49ae97f55c8fa00e68de5de52b110bbc7 Mon Sep 17 00:00:00 2001
+From ab1aef30de5e9424f87d7d6e1edb1a5240a76ae5 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
-Subject: [PATCH 005/118] mm: Remove the PFN busy warning
+Subject: [PATCH 005/122] mm: Remove the PFN busy warning
 
 See commit dae803e165a11bc88ca8dbc07a11077caf97bbcb -- the warning is
 expected sometimes when using CMA.  However, that commit still spams
@@ -252,10 +252,10 @@ index 34ada718ef47c4b27730214d584f9350fefb9883..3fa01a5280db96075798e4cbd58d5520
  		goto done;
  	}
 
-From a6ef83b5f0634de5963aa6aabfeec2e55d8afd09 Mon Sep 17 00:00:00 2001
+From a1c2520dc2663b442e4b43010df6917f233ff40e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
-Subject: [PATCH 006/118] irq-bcm2836: Prevent spurious interrupts, and trap
+Subject: [PATCH 006/122] irq-bcm2836: Prevent spurious interrupts, and trap
  them early
 
 The old arch-specific IRQ macros included a dsb to ensure the
@@ -282,10 +282,10 @@ index d96b2c947e74e3edab3917551c64fbd1ced0f34c..93e3f7660c4230c9f1dd3b195958cb49
  #endif
  	} else if (stat) {
 
-From 968fe34e6ac79edbdcbadc5fa87082fdd77be3ca Mon Sep 17 00:00:00 2001
+From 2d51d14c0cea3d9d52f323b58a0a5d99a65eef24 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
-Subject: [PATCH 007/118] irqchip: bcm2835: Add FIQ support
+Subject: [PATCH 007/122] irqchip: bcm2835: Add FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -414,10 +414,10 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 0bac3ae5f7ee20fab229c5aeeeaa10a9b16ee9e8 Mon Sep 17 00:00:00 2001
+From 2d9b0ef8dc1a5975dfccfb7e78b8f5a94ab5f2bb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
-Subject: [PATCH 008/118] irqchip: irq-bcm2835: Add 2836 FIQ support
+Subject: [PATCH 008/122] irqchip: irq-bcm2835: Add 2836 FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -516,10 +516,10 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From 16340fb762b9570e5b577bea5708e660b154e41f Mon Sep 17 00:00:00 2001
+From 39974a29633d89316e5de24d87294b444b24f381 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
-Subject: [PATCH 009/118] spidev: Add "spidev" compatible string to silence
+Subject: [PATCH 009/122] spidev: Add "spidev" compatible string to silence
  warning
 
 See: https://github.com/raspberrypi/linux/issues/1054
@@ -540,10 +540,10 @@ index 2e05046f866bd01bf87edcdeff0d5b76d4d0aea7..d780491b8013a4e97fa843958964454e
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 332ead9fc0db97e1950bd1baaec720d92f86c58a Mon Sep 17 00:00:00 2001
+From 51c39f512e9b370f126afcdcf6306561ea1f50f2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 30 Jun 2015 14:12:42 +0100
-Subject: [PATCH 010/118] serial: 8250: Don't crash when nr_uarts is 0
+Subject: [PATCH 010/122] serial: 8250: Don't crash when nr_uarts is 0
 
 ---
  drivers/tty/serial/8250/8250_core.c | 2 ++
@@ -563,10 +563,10 @@ index 240a361b674fe72ce657067e5303156b7add6a6f..14f6cdfd744209482056d206dc476d94
  	for (i = 0; i < nr_uarts; i++) {
  		struct uart_8250_port *up = &serial8250_ports[i];
 
-From 4b12f273ccf3d7a3949419a6dfcb78b1abf72d6e Mon Sep 17 00:00:00 2001
+From f56196076549fabcdf0cca5685d1ea3e0308622a Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
-Subject: [PATCH 011/118] pinctrl-bcm2835: Set base to 0 give expected gpio
+Subject: [PATCH 011/122] pinctrl-bcm2835: Set base to 0 give expected gpio
  numbering
 
 Signed-off-by: Noralf Tronnes <notro@tronnes.org>
@@ -588,10 +588,10 @@ index fa77165fab2c1348163979da507df17e7168c49b..d11e2e4ea189466e686d762cb6c6fef9
  	.can_sleep = false,
  };
 
-From 0ab76cad363c7a9b847c775f966b9c28228e112d Mon Sep 17 00:00:00 2001
+From 40a7420d0d585951fbc02f232df97a15beff7a57 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
-Subject: [PATCH 012/118] pinctrl-bcm2835: Fix interrupt handling for GPIOs
+Subject: [PATCH 012/122] pinctrl-bcm2835: Fix interrupt handling for GPIOs
  28-31 and 46-53
 
 Contrary to the documentation, the BCM2835 GPIO controller actually has
@@ -737,10 +737,10 @@ index d11e2e4ea189466e686d762cb6c6fef9111ecf8e..107ad7d58de8f8a7f55e09c9cdcf7d66
  	},
  };
 
-From 74fdb3c2e15771b27e12085cf45bc97fb24af85d Mon Sep 17 00:00:00 2001
+From a19df9159eb1e9745593febf2ef6aa5868e8d12f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
-Subject: [PATCH 013/118] pinctrl-bcm2835: Only request the interrupts listed
+Subject: [PATCH 013/122] pinctrl-bcm2835: Only request the interrupts listed
  in the DTB
 
 Although the GPIO controller can generate three interrupts (four counting
@@ -767,10 +767,10 @@ index 107ad7d58de8f8a7f55e09c9cdcf7d66fa7ab66b..644bdecbcfcb79d3b84a33769265fca5
  		pc->irq_data[i].irqgroup = i;
  
 
-From aed251a577cad2c0b089908ac31de9278d43f0a6 Mon Sep 17 00:00:00 2001
+From eee7c2b51a8b1753aca3d01ecda24713576d14e5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 May 2016 12:32:47 +0100
-Subject: [PATCH 014/118] pinctrl-bcm2835: Return pins to inputs when freed
+Subject: [PATCH 014/122] pinctrl-bcm2835: Return pins to inputs when freed
 
 When dynamically unloading overlays, it is important that freed pins are
 restored to being inputs to prevent functions from being enabled in
@@ -811,10 +811,10 @@ index 644bdecbcfcb79d3b84a33769265fca5d3d0c9e5..81a66cba2ab0f7e3ae179de7edd10122
  	.get_function_name = bcm2835_pmx_get_function_name,
  	.get_function_groups = bcm2835_pmx_get_function_groups,
 
-From d1ad182a5691887e196dfa1f5a446a7ba7376b02 Mon Sep 17 00:00:00 2001
+From 7d54b896b5523a49b1038dd301b2d359d2321ef2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
-Subject: [PATCH 015/118] spi-bcm2835: Support pin groups other than 7-11
+Subject: [PATCH 015/122] spi-bcm2835: Support pin groups other than 7-11
 
 The spi-bcm2835 driver automatically uses GPIO chip-selects due to
 some unreliability of the native ones. In doing so it chooses the
@@ -895,10 +895,10 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From 7db6bd48d813575485cc9198945c1a7b35738d86 Mon Sep 17 00:00:00 2001
+From de045c3b6df0c0d56f02c0f782627249bbad09d2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
-Subject: [PATCH 016/118] spi-bcm2835: Disable forced software CS
+Subject: [PATCH 016/122] spi-bcm2835: Disable forced software CS
 
 Select software CS in bcm2708_common.dtsi, and disable the automatic
 conversion in the driver to allow hardware CS to be re-enabled with an
@@ -932,10 +932,10 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From 75f7a6605403141ed4d06512c7575b5a2c8ba98e Mon Sep 17 00:00:00 2001
+From a161509667da54c9d5066a0c6bc0584d093a8923 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
-Subject: [PATCH 017/118] spi-bcm2835: Remove unused code
+Subject: [PATCH 017/122] spi-bcm2835: Remove unused code
 
 ---
  drivers/spi/spi-bcm2835.c | 61 -----------------------------------------------
@@ -1023,10 +1023,10 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From 5f964e4c7a409259176d23a76d67921a5d9d4341 Mon Sep 17 00:00:00 2001
+From 2ec6cfba14ff71b08f797c69d1a9c5bd53fc66a6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
-Subject: [PATCH 018/118] ARM: bcm2835: Set Serial number and Revision
+Subject: [PATCH 018/122] ARM: bcm2835: Set Serial number and Revision
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1079,10 +1079,10 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 686de609ac017c025dc69c8a9a955cdf8f65fe9a Mon Sep 17 00:00:00 2001
+From 7cd4e838461cb6cefa1ca5246ef3a6773363f0e0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
-Subject: [PATCH 019/118] dmaengine: bcm2835: Load driver early and support
+Subject: [PATCH 019/122] dmaengine: bcm2835: Load driver early and support
  legacy API
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -1185,10 +1185,10 @@ index e18dc596cf2447fa9ef7e41b62d9396e29043426..80d35f760b4a4a51e60c355a84d538ba
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From 7a6973b406e694db4a471e02386dfff172956504 Mon Sep 17 00:00:00 2001
+From e19d2f37545f78b50f4f82b72099b036f42d2bcd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
-Subject: [PATCH 020/118] firmware: Updated mailbox header
+Subject: [PATCH 020/122] firmware: Updated mailbox header
 
 ---
  include/soc/bcm2835/raspberrypi-firmware.h | 11 +++++++++++
@@ -1251,10 +1251,10 @@ index 3fb357193f09914fe21f8555a4b8613f74f22bc3..227a107214a02deadcca3db202da265e
  	RPI_FIRMWARE_GET_COMMAND_LINE =                       0x00050001,
  	RPI_FIRMWARE_GET_DMA_CHANNELS =                       0x00060001,
 
-From 8c4038efde58ff4b6d435befe924380ef6e3045f Mon Sep 17 00:00:00 2001
+From 99e1f06dcc2bf78742380b9697c354b627fd02c2 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
-Subject: [PATCH 021/118] clk: bcm2835: Mark GPIO clocks enabled at boot as
+Subject: [PATCH 021/122] clk: bcm2835: Mark GPIO clocks enabled at boot as
  critical.
 
 These divide off of PLLD_PER and are used for the ethernet and wifi
@@ -1292,10 +1292,10 @@ index 3bbd2a58db470a89b870a793e59ddf9fc4f48e57..7040c6426e35c11608121893b662c601
  		init.ops = &bcm2835_vpu_clock_clk_ops;
  	} else {
 
-From 43129b4fa17eab0b3af27b7034719c5eb91fcaec Mon Sep 17 00:00:00 2001
+From 946babad832c9ed45bbb31fd89fce025a9f7db48 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
-Subject: [PATCH 022/118] rtc: Add SPI alias for pcf2123 driver
+Subject: [PATCH 022/122] rtc: Add SPI alias for pcf2123 driver
 
 Without this alias, Device Tree won't cause the driver
 to be loaded.
@@ -1315,10 +1315,10 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From ab70dae22d22f9c5f4f03e84ac1c1b1d4d35bef9 Mon Sep 17 00:00:00 2001
+From a929f2b203a1bafb1ca88f7022cb286f28fa98bd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
-Subject: [PATCH 023/118] watchdog: bcm2835: Support setting reboot partition
+Subject: [PATCH 023/122] watchdog: bcm2835: Support setting reboot partition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1442,10 +1442,10 @@ index 4dddd8298a227d64862f2e92954a465f2e44b3f6..1f545e024422f59280932713e6a1b051
  	register_restart_handler(&wdt->restart_handler);
  	if (pm_power_off == NULL)
 
-From 3937b628148a61d360f847848b11ac94afea29cd Mon Sep 17 00:00:00 2001
+From 2e7833eae38410bc31d3a86166868a55d0999394 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
-Subject: [PATCH 024/118] reboot: Use power off rather than busy spinning when
+Subject: [PATCH 024/122] reboot: Use power off rather than busy spinning when
  halt is requested
 
 ---
@@ -1468,10 +1468,10 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From dbd5f14e9ba84e12761d3193d082a0d74ed32008 Mon Sep 17 00:00:00 2001
+From 0d4700ca51eb31fa70e10da67fa92e986275f2d3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
-Subject: [PATCH 025/118] bcm: Make RASPBERRYPI_POWER depend on PM
+Subject: [PATCH 025/122] bcm: Make RASPBERRYPI_POWER depend on PM
 
 ---
  drivers/soc/bcm/Kconfig | 1 +
@@ -1490,10 +1490,10 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 6224c852d202401287990cc77ec5797218db6133 Mon Sep 17 00:00:00 2001
+From 53b503a7256d432bfa51f5ffba58a446c2cc6ebb Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
-Subject: [PATCH 026/118] Register the clocks early during the boot process, so
+Subject: [PATCH 026/122] Register the clocks early during the boot process, so
  that special/critical clocks can get enabled early on in the boot process
  avoiding the risk of disabling a clock, pll_divider or pll when a claiming
  driver fails to install propperly - maybe it needs to defer.
@@ -1538,10 +1538,10 @@ index 7040c6426e35c11608121893b662c601cd8d6543..21e2a538ff0d0ab4e63adff9b93705f3
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From ed16aee637b73805a208d0d4d2f00b5d9f5f789a Mon Sep 17 00:00:00 2001
+From e367c208dc6a9d92e5c0d6e5e089e7b56c7cf189 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
-Subject: [PATCH 027/118] bcm2835-rng: Avoid initialising if already enabled
+Subject: [PATCH 027/122] bcm2835-rng: Avoid initialising if already enabled
 
 Avoids the 0x40000 cycles of warmup again if firmware has already used it
 ---
@@ -1567,10 +1567,10 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From 44e47b69c75d81807f24131821f6599435755427 Mon Sep 17 00:00:00 2001
+From da0b1ac76230b33baa5cd0391388d32d43889d69 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
-Subject: [PATCH 028/118] kbuild: Ignore dtco targets when filtering symbols
+Subject: [PATCH 028/122] kbuild: Ignore dtco targets when filtering symbols
 
 ---
  scripts/Kbuild.include | 2 +-
@@ -1590,10 +1590,10 @@ index 179219845dfcdfbeb586d12c5ec1296095d9fbf4..e0743e44f84188667a0c322e8c3d36f1
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From b345482052faa86e6db9fe01613bae550fee93f8 Mon Sep 17 00:00:00 2001
+From f96bacbe5b20000d29c0b1bc81f66f5b15231b48 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
-Subject: [PATCH 029/118] BCM2835_DT: Fix I2S register map
+Subject: [PATCH 029/122] BCM2835_DT: Fix I2S register map
 
 ---
  Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.txt   | 4 ++--
@@ -1631,10 +1631,10 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From b14d3bae8ca43d7636bfd91dda5a8bc9c8a06154 Mon Sep 17 00:00:00 2001
+From 967e1d016f69607cb5f1d8337f9249ef31e19d81 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
-Subject: [PATCH 030/118] Main bcm2708/bcm2709 linux port
+Subject: [PATCH 030/122] Main bcm2708/bcm2709 linux port
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1841,10 +1841,10 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 94e3bcec0b0e4f94bca7374cbb32ed6e36d103d5 Mon Sep 17 00:00:00 2001
+From 9ccdf13082f318de0091066517c7f7309b245456 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
-Subject: [PATCH 031/118] Add dwc_otg driver
+Subject: [PATCH 031/122] Add dwc_otg driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -2546,10 +2546,10 @@ index 358ca8dd784fe43700ae070764fa783500a792fe..abaac7c7142d8887c1516957fc52162c
  	return i;
  }
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 0d81436c94bdaf6cea0f6a3b2063401c2caf1d3d..0248f67611a245505cfea708428536e28242f3e1 100644
+index aef81a16e2c8534701b8583392400faf77971d23..4197a5b5fb7abae67bd4aa32c29cb84c1f2fe22e 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
-@@ -5010,7 +5010,7 @@ static void port_event(struct usb_hub *hub, int port1)
+@@ -5009,7 +5009,7 @@ static void port_event(struct usb_hub *hub, int port1)
  	if (portchange & USB_PORT_STAT_C_OVERCURRENT) {
  		u16 status = 0, unused;
  
@@ -62901,10 +62901,10 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 83b46b448602db774a6fb361fd6c1b9e0c8509b0 Mon Sep 17 00:00:00 2001
+From 990bd0f738984c3582e6dbba14a1826ea28f9fb6 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
-Subject: [PATCH 032/118] bcm2708 framebuffer driver
+Subject: [PATCH 032/122] bcm2708 framebuffer driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66363,10 +66363,10 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From 3e6b7dca18903fbcef8b22805d2877704b8cc9f0 Mon Sep 17 00:00:00 2001
+From baa447618d238275c592e7caa6455b8e4b1d3d77 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
-Subject: [PATCH 033/118] dmaengine: Add support for BCM2708
+Subject: [PATCH 033/122] dmaengine: Add support for BCM2708
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66997,10 +66997,10 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From c88dfcfa730ab5573a722c208e9ff326563b375e Mon Sep 17 00:00:00 2001
+From b7d8765eb1e1bb854be09a08acabaf92cd1c45ab Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
-Subject: [PATCH 034/118] MMC: added alternative MMC driver
+Subject: [PATCH 034/122] MMC: added alternative MMC driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -68750,10 +68750,10 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From c276600e049838697dbf80363852e8968f63fa2a Mon Sep 17 00:00:00 2001
+From a56eb108067d0211a3ba3b987ec15986ac5577a6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
-Subject: [PATCH 035/118] Adding bcm2835-sdhost driver, and an overlay to
+Subject: [PATCH 035/122] Adding bcm2835-sdhost driver, and an overlay to
  enable it
 
 BCM2835 has two SD card interfaces. This driver uses the other one.
@@ -71158,10 +71158,10 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 380c5bcb89cb9ff9bb7233f468b4c56246469024 Mon Sep 17 00:00:00 2001
+From 0eda1e885a24ef523c6f88b4f62dc928c47f00c6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
-Subject: [PATCH 036/118] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
+Subject: [PATCH 036/122] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
 
 Some SD cards have been found that corrupt data when small blocks
 are erased. Add a quirk to indicate that ERASE should not be used,
@@ -71297,10 +71297,10 @@ index 73fad83acbcb6a157587180516f9ffe7c61eb7d7..e7c9d3098ac06e3c6554fa3373a311f9
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From 4242c82a0364d1451c54c4f921af3f4f2c537dc3 Mon Sep 17 00:00:00 2001
+From ebd7f1f66e66573d57edc087910e4f34f71a52d9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:31:47 +0100
-Subject: [PATCH 037/118] cma: Add vc_cma driver to enable use of CMA
+Subject: [PATCH 037/122] cma: Add vc_cma driver to enable use of CMA
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -72636,10 +72636,10 @@ index 0000000000000000000000000000000000000000..be2819d5d41f9d5ed65daf8eedb94c9e
 +
 +#endif /* VC_CMA_H */
 
-From 6ea5c5ec0e9223d94037f4501e520f9e594fcb68 Mon Sep 17 00:00:00 2001
+From 20fda0a0bcd46a01ba801a968f81c55398ff925e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 26 Mar 2012 22:15:50 +0100
-Subject: [PATCH 038/118] bcm2708: alsa sound driver
+Subject: [PATCH 038/122] bcm2708: alsa sound driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -75374,10 +75374,10 @@ index 0000000000000000000000000000000000000000..af3e6eb690113fc32ce9e06bd2f0f294
 +
 +#endif // _VC_AUDIO_DEFS_H_
 
-From 95547683299d0aef3ca13d192481e529cbcb6ad2 Mon Sep 17 00:00:00 2001
+From f173c4ba6bb591fd104486fec7229cff3648f715 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
-Subject: [PATCH 039/118] vc_mem: Add vc_mem driver for querying firmware
+Subject: [PATCH 039/122] vc_mem: Add vc_mem driver for querying firmware
  memory addresses
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -75901,10 +75901,10 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From 23b1ab3b736cd7d77cc610958a219f0284d84b70 Mon Sep 17 00:00:00 2001
+From 826895d0d097fa010aca39acf19d85a1e065876d Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
-Subject: [PATCH 040/118] vcsm: VideoCore shared memory service for BCM2835
+Subject: [PATCH 040/122] vcsm: VideoCore shared memory service for BCM2835
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -80311,10 +80311,10 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From e95f43b6d8757c6264ba1f665ec7b45732691ab6 Mon Sep 17 00:00:00 2001
+From 3d892851d6e52bec4c02b06146967ecc52b50af0 Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
-Subject: [PATCH 041/118] Add /dev/gpiomem device for rootless user GPIO access
+Subject: [PATCH 041/122] Add /dev/gpiomem device for rootless user GPIO access
 
 Signed-off-by: Luke Wren <luke@raspberrypi.org>
 
@@ -80625,10 +80625,10 @@ index 0000000000000000000000000000000000000000..911f5b7393ed48ceed8751f06967ae64
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From 82ff85d9274fccc8df9a59d99066e0e1f1772f9f Mon Sep 17 00:00:00 2001
+From fbaa743648d031cbb8afeb81e37f546b4fd7b6b5 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
-Subject: [PATCH 042/118] Add SMI driver
+Subject: [PATCH 042/122] Add SMI driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -82579,10 +82579,10 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From 7681571a6b97b4c2892ca63b76d5a8cb215c3802 Mon Sep 17 00:00:00 2001
+From 7df434185cb69481bdb857fb30c153685feb7c4e Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
-Subject: [PATCH 043/118] MISC: bcm2835: smi: use clock manager and fix reload
+Subject: [PATCH 043/122] MISC: bcm2835: smi: use clock manager and fix reload
  issues
 
 Use clock manager instead of self-made clockmanager.
@@ -82752,10 +82752,10 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 68b7fa34af2f20c36933fe3f7c657bafa400f458 Mon Sep 17 00:00:00 2001
+From e80a053c8ec7283b7c93f468b437c1e53ffdd5dc Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
-Subject: [PATCH 044/118] Add SMI NAND driver
+Subject: [PATCH 044/122] Add SMI NAND driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -83120,10 +83120,10 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From ac544a9fe824b139bbd4c2b75ae4cad9fba5777a Mon Sep 17 00:00:00 2001
+From d5fe3a35c384918e40ad67ae26c5997ca941c98e Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
-Subject: [PATCH 045/118] lirc: added support for RaspberryPi GPIO
+Subject: [PATCH 045/122] lirc: added support for RaspberryPi GPIO
 
 lirc_rpi: Use read_current_timer to determine transmitter delay. Thanks to jjmz and others
 See: https://github.com/raspberrypi/linux/issues/525
@@ -83986,10 +83986,10 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From e5cc98d9c41d2f8dcb912feefd8f5829ee7ce075 Mon Sep 17 00:00:00 2001
+From f66f635379d5b4ebc82d4d18c9bd77d2fbcbdfa6 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
-Subject: [PATCH 046/118] Add cpufreq driver
+Subject: [PATCH 046/122] Add cpufreq driver
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -84256,10 +84256,10 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From f544a8ce034e18a89daed574edc29dd9de74f536 Mon Sep 17 00:00:00 2001
+From 478277f128dbdcbea6394c4744ada90fce9ab66e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
-Subject: [PATCH 047/118] Added hwmon/thermal driver for reporting core
+Subject: [PATCH 047/122] Added hwmon/thermal driver for reporting core
  temperature. Thanks Dorian
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -84425,10 +84425,10 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From 660794f62a377f9ca817e7d29c06f1c548489a26 Mon Sep 17 00:00:00 2001
+From aaac339b97bfcc6a67fd3f51400d87fc2ff00198 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
-Subject: [PATCH 048/118] Add Chris Boot's i2c driver
+Subject: [PATCH 048/122] Add Chris Boot's i2c driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85093,10 +85093,10 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 08afd466271b5732eac8e4974361546aad8e3aca Mon Sep 17 00:00:00 2001
+From fa468e89c790f2e432205e3b16d26e5365d98ec7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
-Subject: [PATCH 049/118] char: broadcom: Add vcio module
+Subject: [PATCH 049/122] char: broadcom: Add vcio module
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85322,10 +85322,10 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 426ef96150c966b43d39a2ca6b9c055f8cd72930 Mon Sep 17 00:00:00 2001
+From 83532363df9ebe5f7e8cea458bcfd9b67a0e815a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
-Subject: [PATCH 050/118] firmware: bcm2835: Support ARCH_BCM270x
+Subject: [PATCH 050/122] firmware: bcm2835: Support ARCH_BCM270x
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85408,10 +85408,10 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From 986fa8434b81e4c5e7203434beb7dca80d4c9a42 Mon Sep 17 00:00:00 2001
+From c1316c3428ecf0ef0ad3c39a6ff7e367b3483c4f Mon Sep 17 00:00:00 2001
 From: Vincent Sanders <vincent.sanders@collabora.co.uk>
 Date: Wed, 30 Jan 2013 12:45:18 +0000
-Subject: [PATCH 051/118] bcm2835: add v4l2 camera device
+Subject: [PATCH 051/122] bcm2835: add v4l2 camera device
 
 - Supports raw YUV capture, preview, JPEG and H264.
 - Uses videobuf2 for data transfer, using dma_buf.
@@ -93153,10 +93153,10 @@ index 0000000000000000000000000000000000000000..9d1d11e4a53e510c04a416d92d195a7d
 +
 +#endif /* MMAL_VCHIQ_H */
 
-From 1eae4deb95fecca9b104385232470efbc8e348da Mon Sep 17 00:00:00 2001
+From 6b480eb543d3fb86623e58d6d0f884f67f5ba804 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
-Subject: [PATCH 052/118] scripts: Add mkknlimg and knlinfo scripts from tools
+Subject: [PATCH 052/122] scripts: Add mkknlimg and knlinfo scripts from tools
  repo
 
 The Raspberry Pi firmware looks for a trailer on the kernel image to
@@ -93676,10 +93676,10 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 899b7bf32634a929de96ccde06485f52676c4545 Mon Sep 17 00:00:00 2001
+From 94cbd8ee19d8f0e25c4af4598b07b0c22c5083ae Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 10 Aug 2015 09:49:15 +0100
-Subject: [PATCH 053/118] scripts/dtc: Update to upstream version 1.4.1
+Subject: [PATCH 053/122] scripts/dtc: Update to upstream version 1.4.1
 
 Includes the new localfixups format.
 
@@ -96530,10 +96530,10 @@ index ad9b05ae698b0495ecbda42ffcf4743555313a27..2595dfda020fd9e03f0beff5006f229d
 -#define DTC_VERSION "DTC 1.4.1-g53bf130b"
 +#define DTC_VERSION "DTC 1.4.1-g25efc119"
 
-From 52cb10b96ef40c97f0c7fe0f70846c6e582c3afe Mon Sep 17 00:00:00 2001
+From ef3f51080fa0d993456fa3635e442b845051b70a Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
-Subject: [PATCH 054/118] BCM2708: Add core Device Tree support
+Subject: [PATCH 054/122] BCM2708: Add core Device Tree support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -106661,10 +106661,10 @@ index 0a07f9014944ed92a8e2e42983ae43be60b3e471..1967878a843461c3ff1f473b9a030eb0
  
  # Bzip2
 
-From 1cdd49ad8df3ca95ddfe0c2d373d6ed7b4a5cefc Mon Sep 17 00:00:00 2001
+From 52e8a3802aa8428a69561607209bfe9b98cabde6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
-Subject: [PATCH 055/118] BCM270x_DT: Add pwr_led, and the required "input"
+Subject: [PATCH 055/122] BCM270x_DT: Add pwr_led, and the required "input"
  trigger
 
 The "input" trigger makes the associated GPIO an input.  This is to support
@@ -106840,10 +106840,10 @@ index ddfcb2df3656cf0ab6aebd1fa3d624a6ec2e94e9..271563eb835f9018712e2076a88f341d
  	/* Set LED brightness level
  	 * Must not sleep. Use brightness_set_blocking for drivers
 
-From 1265a84c23cb9aed8388e0a41643024a34333dc3 Mon Sep 17 00:00:00 2001
+From e958cbc43c1add6076ea3ed0aa17365335774024 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
-Subject: [PATCH 056/118] fbdev: add FBIOCOPYAREA ioctl
+Subject: [PATCH 056/122] fbdev: add FBIOCOPYAREA ioctl
 
 Based on the patch authored by Ali Gholami Rudi at
     https://lkml.org/lkml/2009/7/13/153
@@ -107095,10 +107095,10 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From 7eb7c996151bac6551a4f5f0a23abad1ca0389ea Mon Sep 17 00:00:00 2001
+From cf7188188aabe5b8ae10cf449ea6c9b0c6c29c90 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
-Subject: [PATCH 057/118] Speed up console framebuffer imageblit function
+Subject: [PATCH 057/122] Speed up console framebuffer imageblit function
 
 Especially on platforms with a slower CPU but a relatively high
 framebuffer fill bandwidth, like current ARM devices, the existing
@@ -107307,10 +107307,10 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From c3033b89522fdc4f7db951b18bca36ac35e2b1d6 Mon Sep 17 00:00:00 2001
+From 132a1f15dea64eef7dbf9cc5b98e1668cedb2eea Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
-Subject: [PATCH 058/118] enabling the realtime clock 1-wire chip DS1307 and
+Subject: [PATCH 058/122] enabling the realtime clock 1-wire chip DS1307 and
  1-wire on GPIO4 (as a module)
 
 1-wire: Add support for configuring pin for w1-gpio kernel module
@@ -107560,10 +107560,10 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From c816433b752c72c40773170eb7071cde1ebae347 Mon Sep 17 00:00:00 2001
+From 3a29fd5c4e71ff439e60097ca14a4d97c8c63f5f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 18 Dec 2013 22:16:19 +0000
-Subject: [PATCH 059/118] config: Enable CONFIG_MEMCG, but leave it disabled
+Subject: [PATCH 059/122] config: Enable CONFIG_MEMCG, but leave it disabled
  (due to memory cost). Enable with cgroup_enable=memory.
 
 ---
@@ -107613,10 +107613,10 @@ index 85bc9beb046d9a6deda2e3564f4d5bd01d6fc27b..4acdbef46a8f0556469b5580a39c18ce
   * css_tryget_online_from_dir - get corresponding css from a cgroup dentry
   * @dentry: directory dentry of interest
 
-From e3fbcedfa440961f973afc555c5c792e86072110 Mon Sep 17 00:00:00 2001
+From 7a094c94cc5e4275d62f541780238f86b7e1a944 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
-Subject: [PATCH 060/118] hid: Reduce default mouse polling interval to 60Hz
+Subject: [PATCH 060/122] hid: Reduce default mouse polling interval to 60Hz
 
 Reduces overhead when using X
 ---
@@ -107652,10 +107652,10 @@ index ae83af649a607f67239f1a64bf45dd4b5770cc7d..4a7af9d0b910f59d17421ce14138400d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From cb490033b6623d6df8a5568317e26501a511e1ee Mon Sep 17 00:00:00 2001
+From 844a5a997e65b9ba913904f020f88893087ba2b2 Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
-Subject: [PATCH 061/118] rpi-ft5406: Add touchscreen driver for pi LCD display
+Subject: [PATCH 061/122] rpi-ft5406: Add touchscreen driver for pi LCD display
 
 Fix driver detection failure Check that the buffer response is non-zero meaning the touchscreen was detected
 
@@ -108013,10 +108013,10 @@ index 227a107214a02deadcca3db202da265eba1fdd21..b0f6e33bd30c35664ceee057f4c3ad32
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 3eae543d276098fd975f15409724f49fc7f5fee2 Mon Sep 17 00:00:00 2001
+From 3b84c6d542a8066b50fc3efdd916c8a7b88b9d1f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
-Subject: [PATCH 062/118] Improve __copy_to_user and __copy_from_user
+Subject: [PATCH 062/122] Improve __copy_to_user and __copy_from_user
  performance
 
 Provide a __copy_from_user that uses memcpy. On BCM2708, use
@@ -109591,10 +109591,10 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From 5d1adffa7d058d9f53796dcde41a572c28b5c8fd Mon Sep 17 00:00:00 2001
+From d5dc9d3eb0f7177be235596e3009f8b53b4e25b5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
-Subject: [PATCH 063/118] gpio-poweroff: Allow it to work on Raspberry Pi
+Subject: [PATCH 063/122] gpio-poweroff: Allow it to work on Raspberry Pi
 
 The Raspberry Pi firmware manages the power-down and reboot
 process. To do this it installs a pm_power_off handler, causing
@@ -109629,10 +109629,10 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From 829742ee037607b5091e2044792aa28d3748af34 Mon Sep 17 00:00:00 2001
+From 78515e0aa6204095c519dce39d811d796cb9dc18 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
-Subject: [PATCH 064/118] mfd: Add Raspberry Pi Sense HAT core driver
+Subject: [PATCH 064/122] mfd: Add Raspberry Pi Sense HAT core driver
 
 ---
  drivers/input/joystick/Kconfig           |   8 +
@@ -110497,10 +110497,10 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 8623732fdf50b8808240d8d959d086553daf9197 Mon Sep 17 00:00:00 2001
+From 92261bb1ae13c929b053aab7db4cc660d4565511 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
-Subject: [PATCH 065/118] ASoC: Add support for HifiBerry DAC
+Subject: [PATCH 065/122] ASoC: Add support for HifiBerry DAC
 
 This adds a machine driver for the HifiBerry DAC.
 It is a sound card that can
@@ -110675,10 +110675,10 @@ index 0000000000000000000000000000000000000000..45f2b770ad9e67728ca599a7445d6ae9
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 30de099c2e20d442486331817d29a4f5ba1506fe Mon Sep 17 00:00:00 2001
+From b6df383dd105286109669674cf79c61b5f88bba9 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
-Subject: [PATCH 066/118] ASoC: Add support for Rpi-DAC
+Subject: [PATCH 066/122] ASoC: Add support for Rpi-DAC
 
 ---
  sound/soc/bcm/Kconfig       |   7 +++
@@ -110962,10 +110962,10 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From daf62d077f66270f3f88a3e5fa058c6d3885f54e Mon Sep 17 00:00:00 2001
+From 32447fa52c6b39d4447c53b0a7ae8a2096ee901e Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
-Subject: [PATCH 067/118] ASoC: wm8804: Implement MCLK configuration options,
+Subject: [PATCH 067/122] ASoC: wm8804: Implement MCLK configuration options,
  add 32bit support WM8804 can run with PLL frequencies of 256xfs and 128xfs
  for most sample rates. At 192kHz only 128xfs is supported. The existing
  driver selects 128xfs automatically for some lower samples rates. By using an
@@ -111014,10 +111014,10 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From 1e761e3e8abff0c154cd7be50eb3854157260032 Mon Sep 17 00:00:00 2001
+From cd919b3554a2544cf2600822593b6057d4297316 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
-Subject: [PATCH 068/118] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
+Subject: [PATCH 068/122] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
  based on the patched WM8804 driver.
 
 Signed-off-by: Daniel Matuschek <daniel@matuschek.net>
@@ -111361,10 +111361,10 @@ index 0000000000000000000000000000000000000000..19dc953b7227ba86123fc7a2ba654499
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From bbe7cec41a8c9178db2486477472ceb737761a7b Mon Sep 17 00:00:00 2001
+From 9c1f52bc905674a484e6b9c5e91fbef279890c68 Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
-Subject: [PATCH 069/118] Add IQaudIO Sound Card support for Raspberry Pi
+Subject: [PATCH 069/122] Add IQaudIO Sound Card support for Raspberry Pi
 
 Set a limit of 0dB on Digital Volume Control
 
@@ -111694,10 +111694,10 @@ index 0000000000000000000000000000000000000000..4e8e6dec14bcf4a1ff286c43742d4097
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From cc51f9a5cf72cb4e8178902cc3d80a878574377b Mon Sep 17 00:00:00 2001
+From fef54ca8d87499607d6cb086210e44126b304f6d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jul 2016 17:06:50 +0100
-Subject: [PATCH 070/118] iqaudio-dac: Compile fix - untested
+Subject: [PATCH 070/122] iqaudio-dac: Compile fix - untested
 
 ---
  sound/soc/bcm/iqaudio-dac.c | 6 +++++-
@@ -111721,10 +111721,10 @@ index 4e8e6dec14bcf4a1ff286c43742d4097249d6777..aa15bc4b49ca95edec905fddd8fd0a6d
  	if (dapm->dev != codec_dai->dev)
  		return 0;
 
-From 097012dbf23088dc7bfc7f637dac7e03ee9ac742 Mon Sep 17 00:00:00 2001
+From 31bee6011867bb7a1846d35901b080a208669515 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
-Subject: [PATCH 071/118] Added support for HiFiBerry DAC+
+Subject: [PATCH 071/122] Added support for HiFiBerry DAC+
 
 The driver is based on the HiFiBerry DAC driver. However HiFiBerry DAC+ uses
 a different codec chip (PCM5122), therefore a new driver is necessary.
@@ -112354,10 +112354,10 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From 798717fecb6f9c838b9eaa84f11acc760af0c966 Mon Sep 17 00:00:00 2001
+From f11ffc75b1a5ba748f160765164337eabea0b6e1 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
-Subject: [PATCH 072/118] Added driver for HiFiBerry Amp amplifier add-on board
+Subject: [PATCH 072/122] Added driver for HiFiBerry Amp amplifier add-on board
 
 The driver contains a low-level hardware driver for the TAS5713 and the
 drivers for the Raspberry Pi I2S subsystem.
@@ -113190,10 +113190,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 1094b85d81f72de26606f30482ca243867a90738 Mon Sep 17 00:00:00 2001
+From e06a867b4795e7c7e8dd9d13257a77494ea5f610 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Dec 2016 16:26:54 +0000
-Subject: [PATCH 073/118] Revert "Added driver for HiFiBerry Amp amplifier
+Subject: [PATCH 073/122] Revert "Added driver for HiFiBerry Amp amplifier
  add-on board"
 
 This reverts commit 3e6b00833d92a50cbcc9922deb6e1bc8fcdbb587.
@@ -114015,10 +114015,10 @@ index 8f019e04898754d2f87e9630137be9e8f612a342..00000000000000000000000000000000
 -
 -#endif  /* _TAS5713_H */
 
-From c8e89c69ce685339afdcfa83d35a2a1d295fcf9e Mon Sep 17 00:00:00 2001
+From adf38c2875a20b75d2870d9e9897f711835811ea Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
-Subject: [PATCH 074/118] Update ds1307 driver for device-tree support
+Subject: [PATCH 074/122] Update ds1307 driver for device-tree support
 
 Signed-off-by: Ryan Coe <bluemrp9@gmail.com>
 ---
@@ -114045,10 +114045,10 @@ index 4e31036ee2596dec93accd26f627c5b95591ae9f..b92044cf03e750afa521a93519500e9d
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From 7f314dbd22408377f9e7e3537dc0521ae933b53e Mon Sep 17 00:00:00 2001
+From 23122064c9a8be975b07aad67e74213cf9fdc7d8 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
-Subject: [PATCH 075/118] Add driver for rpi-proto
+Subject: [PATCH 075/122] Add driver for rpi-proto
 
 Forward port of 3.10.x driver from https://github.com/koalo
 We are using a custom board and would like to use rpi 3.18.x
@@ -114263,10 +114263,10 @@ index 0000000000000000000000000000000000000000..9db678e885efd63d84d60a098a84ed67
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 2ef9c52bf68b163dda3666a20dfefcbed2e42bf6 Mon Sep 17 00:00:00 2001
+From 23e17d37207fc0039b141c8988644c24885ba10a Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
-Subject: [PATCH 076/118] RaspiDAC3 support
+Subject: [PATCH 076/122] RaspiDAC3 support
 
 Signed-off-by: Jan Grulich <jan@grulich.eu>
 
@@ -114509,10 +114509,10 @@ index 0000000000000000000000000000000000000000..dd9eeea2af0382307f437e6db09d1546
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From b9bbce6e6914108063a3a1b2c17ed792a3dfd351 Mon Sep 17 00:00:00 2001
+From 328c723f04e73cc2484ae7d5d6f317fc22fbd386 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
-Subject: [PATCH 077/118] Add Support for JustBoom Audio boards
+Subject: [PATCH 077/122] Add Support for JustBoom Audio boards
 
 justboom-dac: Adjust for ALSA API change
 
@@ -114966,10 +114966,10 @@ index 0000000000000000000000000000000000000000..91acb666380faa3c0deb2230f8a0f8bb
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From d146863cec303731b37c7d86bcf56ddcafcd2199 Mon Sep 17 00:00:00 2001
+From 070a41a6ef5eb0427354b758ce45fee7476e8e84 Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
-Subject: [PATCH 078/118] ARM: adau1977-adc: Add basic machine driver for
+Subject: [PATCH 078/122] ARM: adau1977-adc: Add basic machine driver for
  adau1977 codec driver.
 
 This commit adds basic support for the codec usage including: Device tree overlay,
@@ -115151,10 +115151,10 @@ index 0000000000000000000000000000000000000000..6e2ee027926ee63c89222f75ceb89e3d
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From ed26616bccf0c8d84600da21240bcbd913ee7e7f Mon Sep 17 00:00:00 2001
+From d3f05a999f9f646a4fad423073c2bfd16ac8cdb7 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
-Subject: [PATCH 079/118] New AudioInjector.net Pi soundcard with low jitter
+Subject: [PATCH 079/122] New AudioInjector.net Pi soundcard with low jitter
  audio in and out.
 
 Contains the sound/soc/bcm ALSA machine driver and necessary alterations to the Kconfig and Makefile.
@@ -115405,10 +115405,10 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 4466167663935a49e4828c67d5788ec47a79d417 Mon Sep 17 00:00:00 2001
+From 6cdf489fe02f677a7a5312dd53f5b5dfa1632487 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
-Subject: [PATCH 080/118] Add IQAudIO Digi WM8804 board support
+Subject: [PATCH 080/122] Add IQAudIO Digi WM8804 board support
 
 Support IQAudIO Digi board with iqaudio_digi machine driver and
  iqaudio-digi-wm8804-audio overlay.
@@ -115708,10 +115708,10 @@ index 0000000000000000000000000000000000000000..9b6e829bcb5b1762a853775e78163196
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 24c4db954f875c5da3c9afd5c9b491f6c4210656 Mon Sep 17 00:00:00 2001
+From 922b72225da0a94bdc3a2c7a52ac04431e67a6a8 Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
-Subject: [PATCH 081/118] New driver for RRA DigiDAC1 soundcard using WM8741 +
+Subject: [PATCH 081/122] New driver for RRA DigiDAC1 soundcard using WM8741 +
  WM8804
 
 ---
@@ -116184,10 +116184,10 @@ index 0000000000000000000000000000000000000000..446796e7e4c14a7d95b2f2a01211d9a0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From 9519d83c7c32c808aa0dc201d1bda664666825bc Mon Sep 17 00:00:00 2001
+From 1a76a9a2ca9445123234adc7b30e448216da6017 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
-Subject: [PATCH 082/118] Add support for Dion Audio LOCO DAC-AMP HAT
+Subject: [PATCH 082/122] Add support for Dion Audio LOCO DAC-AMP HAT
 
 Using dedicated machine driver and pcm5102a codec driver.
 
@@ -116360,10 +116360,10 @@ index 0000000000000000000000000000000000000000..89e65317512bc774453ac8d0d5b0ff98
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From 48b527833946f505f1e8004207c2a2770e800767 Mon Sep 17 00:00:00 2001
+From 38964afabad4b0ae7e3d50153daf97dd98277597 Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
-Subject: [PATCH 083/118] Allo Piano DAC boards: Initial 2 channel (stereo)
+Subject: [PATCH 083/122] Allo Piano DAC boards: Initial 2 channel (stereo)
  support (#1645)
 
 Add initial 2 channel (stereo) support for Allo Piano DAC (2.0/2.1) boards,
@@ -116570,10 +116570,10 @@ index 0000000000000000000000000000000000000000..8e8e62e5a36a279b425ed4655cfbac99
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 6c886c8edd47456f9ea8735f003a71422c580b0e Mon Sep 17 00:00:00 2001
+From 32c97c8263ee9440ac09cf4c117a00563ba86748 Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
-Subject: [PATCH 084/118] Support for Blokas Labs pisound board
+Subject: [PATCH 084/122] Support for Blokas Labs pisound board
 
 Pisound dynamic overlay (#1760)
 
@@ -117750,10 +117750,10 @@ index 0000000000000000000000000000000000000000..4b8545487d06e4ea70073a5d063fb231
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From 6b2923c5d85c7daa2e1efdb6e083bda5db5579aa Mon Sep 17 00:00:00 2001
+From 96f367ff7d360c52f563775dd1e9cee71aa63c6d Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
-Subject: [PATCH 085/118] rpi_display: add backlight driver and overlay
+Subject: [PATCH 085/122] rpi_display: add backlight driver and overlay
 
 Add a mailbox-driven backlight controller for the Raspberry Pi DSI
 touchscreen display. Requires updated GPU firmware to recognise the
@@ -117922,10 +117922,10 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 7ce6a9a9e8e4ded0b5411be1f337e697c40ee38b Mon Sep 17 00:00:00 2001
+From 859fe9e43315cc5f8ec150814ac4d841c9bfdcf1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
-Subject: [PATCH 086/118] bcm2835-virtgpio: Virtual GPIO driver
+Subject: [PATCH 086/122] bcm2835-virtgpio: Virtual GPIO driver
 
 Add a virtual GPIO driver that uses the firmware mailbox interface to
 request that the VPU toggles LEDs.
@@ -118199,10 +118199,10 @@ index b0f6e33bd30c35664ceee057f4c3ad32b914291d..e92278968b2b979db2a1f855f70e7aaf
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 5310bef4d1b2160385c9bdd914e897f46d7e8911 Mon Sep 17 00:00:00 2001
+From 7968227bc3b1b0b1297b304fbfd4a76de6a1f40e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
-Subject: [PATCH 087/118] amba_pl011: Don't use DT aliases for numbering
+Subject: [PATCH 087/122] amba_pl011: Don't use DT aliases for numbering
 
 The pl011 driver looks for DT aliases of the form "serial<n>",
 and if found uses <n> as the device ID. This can cause
@@ -118231,10 +118231,10 @@ index e2c33b9528d82ed7a2c27d083d7b1d222da68178..5a11ff833e1fd112ba04df3a427cd94b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From c65323ecc55f9524e86136e2d7dd7c69cb376bcb Mon Sep 17 00:00:00 2001
+From 0dba8271302e1c9a96f1ead8f5a7b9a0ffc7325e Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
-Subject: [PATCH 088/118] OF: DT-Overlay configfs interface
+Subject: [PATCH 088/122] OF: DT-Overlay configfs interface
 
 This is a port of Pantelis Antoniou's v3 port that makes use of the
 new upstreamed configfs support for binary attributes.
@@ -118666,10 +118666,10 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From f302de7074e873da78f9ee2df75c86bf157a5521 Mon Sep 17 00:00:00 2001
+From 7599baf5d2f2a063d430fce4de57db739ac1d05c Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
-Subject: [PATCH 089/118] brcm: adds support for BCM43341 wifi
+Subject: [PATCH 089/122] brcm: adds support for BCM43341 wifi
 
 brcmfmac: Disable power management
 
@@ -118832,10 +118832,10 @@ index d0407d9ad7827cd756b6311410ffe2d9a7cacc78..f1fb8a3c7a3211e8429585861f2f42e0
  #define BRCM_CC_4335_CHIP_ID		0x4335
  #define BRCM_CC_4339_CHIP_ID		0x4339
 
-From 2ee94ce425179c2d3760ee39ea3482d03638d182 Mon Sep 17 00:00:00 2001
+From 409e8d08947ff33556f6bcb8eb6bfdc47613ce6b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
-Subject: [PATCH 090/118] hci_h5: Don't send conf_req when ACTIVE
+Subject: [PATCH 090/122] hci_h5: Don't send conf_req when ACTIVE
 
 Without this patch, a modem and kernel can continuously bombard each
 other with conf_req and conf_rsp messages, in a demented game of tag.
@@ -118858,10 +118858,10 @@ index 0879d64b1caf58afb6e5d494c07d9ab7e7cdf983..5161ab30fd533d50f516bb93d5b9f402
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From ceb9c9d3a20e4cdad47fd4f84511143f69cd3235 Mon Sep 17 00:00:00 2001
+From 5fd6ff953ace9d64a39412f410b4a6eb09dd4711 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
-Subject: [PATCH 091/118] config: Add default configs
+Subject: [PATCH 091/122] config: Add default configs
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1297 +++++++++++++++++++++++++++++++++++
@@ -121488,10 +121488,10 @@ index 0000000000000000000000000000000000000000..8acee9f31202ec14f2933d92dd70831c
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 4790a58452a6c6a8b8fd5d15dc46636f8a27dc0e Mon Sep 17 00:00:00 2001
+From 7452484b501a3dd0ca66226de11cf4fb9a576390 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
-Subject: [PATCH 092/118] Add arm64 configuration and device tree differences.
+Subject: [PATCH 092/122] Add arm64 configuration and device tree differences.
  Disable MMC_BCM2835_SDHOST and MMC_BCM2835 since these drivers are crashing
  at the moment.
 
@@ -122906,10 +122906,10 @@ index 0000000000000000000000000000000000000000..d7406f5a4620151044b8f716b4d10bb8
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2708_VCHIQ=n
 
-From afbfe676544fd2a127bab7baa1a11ecf3349569c Mon Sep 17 00:00:00 2001
+From d5f278b5d66aaae13361aa90bf4a06a9babf5746 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 7 Mar 2016 15:05:11 +0000
-Subject: [PATCH 093/118] vchiq_arm: Tweak the logging output
+Subject: [PATCH 093/122] vchiq_arm: Tweak the logging output
 
 Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 ---
@@ -122984,10 +122984,10 @@ index 2c98da4307dff994a00dc246574ef0aaee05d5da..160db24aeea33a8296923501009c1f02
  
  		switch (type) {
 
-From fc373b8605790ab0f0ebdbb9f057818873a2186e Mon Sep 17 00:00:00 2001
+From b65b8cb1ff93d43d24558076bb81f19b1ab5ea50 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 14:16:25 +0000
-Subject: [PATCH 094/118] vchiq_arm: Access the dequeue_pending flag locked
+Subject: [PATCH 094/122] vchiq_arm: Access the dequeue_pending flag locked
 
 Reading through this code looking for another problem (now found in userland)
 the use of dequeue_pending outside a lock didn't seem safe.
@@ -123045,10 +123045,10 @@ index 7b6cd4d80621e38ff6d47fcd87b45fbe9cd4259b..d8669fa7f39b077877eca1829ba9538b
  
  	return add_completion(instance, reason, header, user_service,
 
-From 566bfd7cc8e5acde2543833fcd56c848f8e9c46b Mon Sep 17 00:00:00 2001
+From 1236ef13699c7ce7cb486c13c244be0038419918 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 20:53:47 +0000
-Subject: [PATCH 095/118] vchiq_arm: Service callbacks must not fail
+Subject: [PATCH 095/122] vchiq_arm: Service callbacks must not fail
 
 Service callbacks are not allowed to return an error. The internal callback
 that delivers events and messages to user tasks does not enqueue them if
@@ -123074,10 +123074,10 @@ index d8669fa7f39b077877eca1829ba9538bf2e21a82..54552c6ce54f413c9781ba279b936f98
  		DEBUG_TRACE(SERVICE_CALLBACK_LINE);
  	}
 
-From 0f1f6312527a32f11e6ee42a8d63d75eba250925 Mon Sep 17 00:00:00 2001
+From 42c9df04946a82e2e84ce093e9fe8e0e00183e05 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 21 Apr 2016 13:49:32 +0100
-Subject: [PATCH 096/118] vchiq_arm: Add completion records under the mutex
+Subject: [PATCH 096/122] vchiq_arm: Add completion records under the mutex
 
 An issue was observed when flushing openmax components
 which generate a large number of messages returning
@@ -123140,10 +123140,10 @@ index 54552c6ce54f413c9781ba279b936f98be4f47b0..bde8955b7d8505d73579b77b5b392154
  
  	return VCHIQ_SUCCESS;
 
-From 89fdf1228ffb4140cc1211cd520adc5f002ec81b Mon Sep 17 00:00:00 2001
+From e027b929fb8e3c2ca6ee3b9c26104cd88a6ad4b6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 20 Jun 2016 13:51:44 +0100
-Subject: [PATCH 097/118] vchiq_arm: Avoid use of mutex in add_completion
+Subject: [PATCH 097/122] vchiq_arm: Avoid use of mutex in add_completion
 
 Claiming the completion_mutex within add_completion did prevent some
 messages appearing twice, but provokes a deadlock caused by vcsm using
@@ -123337,10 +123337,10 @@ index 160db24aeea33a8296923501009c1f02bc41e599..71a3bedc55314f3b22dbff40c05dedf0
  		up(&state->slot_available_event);
  	}
 
-From 8e1a7a0a6eb06e6d0af55aca76849c72a261a8e9 Mon Sep 17 00:00:00 2001
+From 36afbf3ec01bb2c073b99d9f8e09e72d3aba6b08 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:14:10 -0700
-Subject: [PATCH 098/118] staging/vchi: Convert to current get_user_pages()
+Subject: [PATCH 098/122] staging/vchi: Convert to current get_user_pages()
  arguments.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123377,10 +123377,10 @@ index e5cdda12c7e5c35c69eb96991cfdb8326def167f..085d37588c59198b4e5f00b9249bb842
  		num_pages,                /* len */
  		0,                        /* gup_flags */
 
-From efe65d3f6da0049c9cbb44f69eca21cb9ea50121 Mon Sep 17 00:00:00 2001
+From 78c3ef34645364c0313d5322eed35c608e75ed32 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:16:03 -0700
-Subject: [PATCH 099/118] staging/vchi: Update for rename of
+Subject: [PATCH 099/122] staging/vchi: Update for rename of
  page_cache_release() to put_page().
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123425,10 +123425,10 @@ index 085d37588c59198b4e5f00b9249bb8421695854f..5a2b8fb459ebe086ec229f37b6381bdb
  	kfree(pages);
  }
 
-From dc360754977a1532c5b736f7e71349e06f6f623c Mon Sep 17 00:00:00 2001
+From 7bc3755fca9fc00495e6ad3857bbf75756a0ad74 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:21:17 -0700
-Subject: [PATCH 100/118] drivers/vchi: Remove dependency on CONFIG_BROKEN.
+Subject: [PATCH 100/122] drivers/vchi: Remove dependency on CONFIG_BROKEN.
 
 The driver builds now.
 
@@ -123450,10 +123450,10 @@ index 9676fb29075a457109e4d4235f086987aec74868..db8e1beb89f9f8c48ea5964016c8285e
  	help
  		Kernel to VideoCore communication interface for the
 
-From 289c3f75740d07ac8fc64bcaa07ebf91d02d87ea Mon Sep 17 00:00:00 2001
+From 47fc16ef621f8b834e809715c77f601e104caa3e Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
-Subject: [PATCH 101/118] raspberrypi-firmware: Export the general transaction
+Subject: [PATCH 101/122] raspberrypi-firmware: Export the general transaction
  function.
 
 The vc4-firmware-kms module is going to be doing the MBOX FB call.
@@ -123497,10 +123497,10 @@ index e92278968b2b979db2a1f855f70e7aafb224fa98..09e3d871d110eb0762ebdb5ea3293537
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 7ab9682505e6ccaa7249f90e8c444c8ea4cdf259 Mon Sep 17 00:00:00 2001
+From 9ae6d3437ea35dacb0bc1353d7c6646dd2b7913d Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
-Subject: [PATCH 102/118] raspberrypi-firmware: Define the MBOX channel in the
+Subject: [PATCH 102/122] raspberrypi-firmware: Define the MBOX channel in the
  header.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123522,10 +123522,10 @@ index 09e3d871d110eb0762ebdb5ea329353738d58661..2859db09e25bb945251e85edb39bc434
  
  enum rpi_firmware_property_status {
 
-From b7aa695992e5e42a6be288ea307769b53e294c5d Mon Sep 17 00:00:00 2001
+From 23c8fb1fa456520a1abe7a50484eee18e94f09bc Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
-Subject: [PATCH 103/118] drm/vc4: Add a mode for using the closed firmware for
+Subject: [PATCH 103/122] drm/vc4: Add a mode for using the closed firmware for
  display.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -124292,10 +124292,10 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From 409fc2849c293e495a2fd3217c91ec19aa02a14c Mon Sep 17 00:00:00 2001
+From 26a8008c3e11309384b26b46cfc4c6499c2fe676 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 17 Sep 2016 15:07:10 +0200
-Subject: [PATCH 104/118] i2c: bcm2835: Fix hang for writing messages larger
+Subject: [PATCH 104/122] i2c: bcm2835: Fix hang for writing messages larger
  than 16 bytes
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124385,10 +124385,10 @@ index d4f3239b56865919e1b781b20a7c5ebcd76b4eb9..f283b714aa79e2e4685ed95b04b6b289
  	i2c_dev->msg_buf_remaining = msg->len;
  	reinit_completion(&i2c_dev->completion);
 
-From 2992b3ee682b67b8098aac4ca2cb244e9fdbdc7c Mon Sep 17 00:00:00 2001
+From c91628e1f62406194456f78889477efa6ebe1592 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 18:24:38 +0200
-Subject: [PATCH 105/118] i2c: bcm2835: Protect against unexpected TXW/RXR
+Subject: [PATCH 105/122] i2c: bcm2835: Protect against unexpected TXW/RXR
  interrupts
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124513,10 +124513,10 @@ index f283b714aa79e2e4685ed95b04b6b289f7e9eee7..d2ba1a4de36af512e8e3c97251bd3537
  		return -ETIMEDOUT;
  	}
 
-From eae3435b9be49b5d7fd3b21b5985665ac78e3bfb Mon Sep 17 00:00:00 2001
+From 878f3d3cb001a41cefc17e11e5b527b576478959 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Mon, 19 Sep 2016 17:19:41 +0200
-Subject: [PATCH 106/118] i2c: bcm2835: Use dev_dbg logging on transfer errors
+Subject: [PATCH 106/122] i2c: bcm2835: Use dev_dbg logging on transfer errors
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124548,10 +124548,10 @@ index d2ba1a4de36af512e8e3c97251bd3537ae61591a..54d510abd46a117c9238fc6d7edec840
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From d3b13d1fe86b367a2bb34bde541dea378a9bb159 Mon Sep 17 00:00:00 2001
+From dd301c9f8456669afa77139328d78bac9f2fcb48 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Thu, 22 Sep 2016 22:05:50 +0200
-Subject: [PATCH 107/118] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
+Subject: [PATCH 107/122] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124595,10 +124595,10 @@ index 54d510abd46a117c9238fc6d7edec84019d1f60d..565ef69ce61423544dc0558c85ef318b
  
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
 
-From 8d90227b02b2781f87de0e472990dc5e24eb8d7d Mon Sep 17 00:00:00 2001
+From 17019eef014c360549b56b67f8f6448e718b9496 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:54:27 +0200
-Subject: [PATCH 108/118] i2c: bcm2835: Add support for Repeated Start
+Subject: [PATCH 108/122] i2c: bcm2835: Add support for Repeated Start
  Condition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124780,10 +124780,10 @@ index 565ef69ce61423544dc0558c85ef318b0ae9c324..241e08ae7c27cec23fad3c1bf3ebad3a
  
  static u32 bcm2835_i2c_func(struct i2c_adapter *adap)
 
-From fa195989cbbf0c5935998064ceca71c1a7c0828a Mon Sep 17 00:00:00 2001
+From 90f2d2d5fb2aa94eafd361372b6a55fa3ad1b029 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:57:17 +0200
-Subject: [PATCH 109/118] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
+Subject: [PATCH 109/122] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124820,10 +124820,10 @@ index 241e08ae7c27cec23fad3c1bf3ebad3a4d2a8e6f..d2085dd3742eabebc537621968088261
  		bcm2835_i2c_writel(i2c_dev, BCM2835_I2C_C,
  				   BCM2835_I2C_C_CLEAR);
 
-From d51893d40fa09cc45705dd3455767994b063c23e Mon Sep 17 00:00:00 2001
+From d0724c34a0fc6d93228c19bede299e63afe0c036 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 27 Sep 2016 01:00:08 +0200
-Subject: [PATCH 110/118] i2c: bcm2835: Add support for dynamic clock
+Subject: [PATCH 110/122] i2c: bcm2835: Add support for dynamic clock
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124939,10 +124939,10 @@ index d2085dd3742eabebc537621968088261f8dc7ea8..c3436f627028477f7e21b47e079fd5ab
  	irq = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
  	if (!irq) {
 
-From ee509744d81b69d5be41a42ed1604ba36362a832 Mon Sep 17 00:00:00 2001
+From 0cc815d16e01c81698ecb53c57222ffb003377bf Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
-Subject: [PATCH 111/118] i2c: bcm2835: Add debug support
+Subject: [PATCH 111/122] i2c: bcm2835: Add debug support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -125131,10 +125131,10 @@ index c3436f627028477f7e21b47e079fd5ab06ec188a..8642f580ce41803bd22c76a0fa80d083
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 871ba19b271f2b4e5957005e88e0ec1a5100216b Mon Sep 17 00:00:00 2001
+From 683eb2a626bdf358dd1d447bfe3b0e7d112d8024 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 31 Dec 2016 14:15:50 +0000
-Subject: [PATCH 112/118] arm64: Add CONFIG_ARCH_BCM2835
+Subject: [PATCH 112/122] arm64: Add CONFIG_ARCH_BCM2835
 
 ---
  arch/arm64/configs/bcmrpi3_defconfig | 1 +
@@ -125150,10 +125150,10 @@ index d7406f5a4620151044b8f716b4d10bb818648e06..53da5c7a33e5898a66e549fb0c39fe3d
  CONFIG_BCM2708_VCHIQ=n
 +CONFIG_ARCH_BCM2835=y
 
-From c9f095b015beaa2b8926dc16a692d946367c0223 Mon Sep 17 00:00:00 2001
+From 8ec76aa6373a8c90eac7d8c8e980fa333ff69464 Mon Sep 17 00:00:00 2001
 From: Alex Tucker <alex@floop.org.uk>
 Date: Tue, 13 Dec 2016 19:50:18 +0000
-Subject: [PATCH 113/118] Add support for Silicon Labs Si7013/20/21
+Subject: [PATCH 113/122] Add support for Silicon Labs Si7013/20/21
  humidity/temperature sensor.
 
 ---
@@ -125228,10 +125228,10 @@ index f6d134c095af2398fc55ae7d2b0e86456c30627c..31bda8da4cb6a56bfe493a81b9189009
  	};
  };
 
-From 988ff6b453f319ec4bdd13160cd9c95c4347a703 Mon Sep 17 00:00:00 2001
+From 3b6760e6f2f03b620e4e88d67d3b640c56ce7fd3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 3 Jan 2017 21:27:46 +0000
-Subject: [PATCH 114/118] Document the si7020 option
+Subject: [PATCH 114/122] Document the si7020 option
 
 ---
  arch/arm/boot/dts/overlays/README | 3 +++
@@ -125252,10 +125252,10 @@ index 81d991803be335e5a1bc3bb0a8c7a2c9f5c392bd..e8fa4ccb44c34a20485c4e6155467af9
  Name:   i2c0-bcm2708
  Info:   Enable the i2c_bcm2708 driver for the i2c0 bus. Not all pin combinations
 
-From 1b0c1c6ce71d6076ec100bf1dbb3b5e87f64556b Mon Sep 17 00:00:00 2001
+From 4ef541bea608cd9f84bc76c8092fafaad1702e3f Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Thu, 5 Jan 2017 02:38:16 +0200
-Subject: [PATCH 115/118] pisound improvements:
+Subject: [PATCH 115/122] pisound improvements:
 
 * Added a writable sysfs object to enable scripts / user space software
 to blink MIDI activity LEDs for variable duration.
@@ -125549,10 +125549,10 @@ index 4b8545487d06e4ea70073a5d063fb2310b3b94d0..ba70734b89e61a11201657406223f0b3
  };
  
 
-From fcd5ab41bc1ff092661afd914247c667c45529ea Mon Sep 17 00:00:00 2001
+From 425e9111b1dfad787b1f787ec5086fdf1893584e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:23:06 +0000
-Subject: [PATCH 116/118] Revert "Revert "Added driver for HiFiBerry Amp
+Subject: [PATCH 116/122] Revert "Revert "Added driver for HiFiBerry Amp
  amplifier add-on board""
 
 This reverts commit bf84babd8fffcb79c60f1342c2416f8e1e4b7af9.
@@ -126376,10 +126376,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 85a791fa81082ce933ba66d0f63494486e50ca4d Mon Sep 17 00:00:00 2001
+From 15550aafac107a499180a103bcaceed80f37dacd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:42:09 +0000
-Subject: [PATCH 117/118] hifiberry-amp: Adjust for ALSA object refactoring
+Subject: [PATCH 117/122] hifiberry-amp: Adjust for ALSA object refactoring
 
 See: https://github.com/raspberrypi/linux/issues/1775
 ---
@@ -126404,10 +126404,10 @@ index 9b2713861dcbed751842ca29c88eb1eae5867411..560234d58a6b0a6e7fd3a63e8de73339
  
  
 
-From 02fd5648e60335c1408847b73bf43dce7c868ac9 Mon Sep 17 00:00:00 2001
+From d3a7daff54ea1d57654aa2be744d6173441b5e35 Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Sun, 8 Jan 2017 15:58:54 +0200
-Subject: [PATCH 118/118] bcm2835-i2s: Changes for allowing asymmetric sample
+Subject: [PATCH 118/122] bcm2835-i2s: Changes for allowing asymmetric sample
  formats.
 
 This is achieved by making changes only to the requested
@@ -126496,3 +126496,521 @@ index 6ba20498202ed36906b52096893a88867a79269f..171c2401dfe192740fca3356268aff64
  	}
  
  	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);
+
+From a268f59a304d04349f3a0358db1f434e47cda8b6 Mon Sep 17 00:00:00 2001
+From: Aaron Shaw <shawaj@gmail.com>
+Date: Tue, 10 Jan 2017 16:05:41 +0000
+Subject: [PATCH 119/122] Add driver_name property
+
+Add driver name property for use with 5.1 passthrough audio in LibreElec and other Kodi based OSs
+---
+ sound/soc/bcm/justboom-dac.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/soc/bcm/justboom-dac.c b/sound/soc/bcm/justboom-dac.c
+index 8fd50dbe681508a2cfe8fdde1c9fedbe9a507fa7..05a224ec712d06b8b7587ab6b8bb562d19956d47 100644
+--- a/sound/soc/bcm/justboom-dac.c
++++ b/sound/soc/bcm/justboom-dac.c
+@@ -98,6 +98,7 @@ static struct snd_soc_dai_link snd_rpi_justboom_dac_dai[] = {
+ /* audio machine driver */
+ static struct snd_soc_card snd_rpi_justboom_dac = {
+ 	.name         = "snd_rpi_justboom_dac",
++	.driver_name  = "JustBoomDac",
+ 	.owner        = THIS_MODULE,
+ 	.dai_link     = snd_rpi_justboom_dac_dai,
+ 	.num_links    = ARRAY_SIZE(snd_rpi_justboom_dac_dai),
+
+From ad475b3f75da457818fa6fab1c1e2f89f453dc07 Mon Sep 17 00:00:00 2001
+From: Aaron Shaw <shawaj@gmail.com>
+Date: Tue, 10 Jan 2017 16:11:04 +0000
+Subject: [PATCH 120/122] Add driver_name paramater
+
+Add driver_name parameter for use with 5.1 passthrough audio in LibreElec and other Kodi OSs
+---
+ sound/soc/bcm/justboom-digi.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/soc/bcm/justboom-digi.c b/sound/soc/bcm/justboom-digi.c
+index 91acb666380faa3c0deb2230f8a0f8bbec59417b..abfdc5c4dd5811e6847bddda4921abe33fa02812 100644
+--- a/sound/soc/bcm/justboom-digi.c
++++ b/sound/soc/bcm/justboom-digi.c
+@@ -154,6 +154,7 @@ static struct snd_soc_dai_link snd_rpi_justboom_digi_dai[] = {
+ /* audio machine driver */
+ static struct snd_soc_card snd_rpi_justboom_digi = {
+ 	.name         = "snd_rpi_justboom_digi",
++	.driver_name  = "JustBoomDigi",
+ 	.owner        = THIS_MODULE,
+ 	.dai_link     = snd_rpi_justboom_digi_dai,
+ 	.num_links    = ARRAY_SIZE(snd_rpi_justboom_digi_dai),
+
+From 987aadab51987bac29470f3ee200fa8bfa2eae6b Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Wed, 11 Jan 2017 13:01:21 +0000
+Subject: [PATCH 121/122] BCM270X_DT: Add pi3-disable-wifi overlay
+
+pi3-disable-wifi is a minimal overlay to disable the onboard WiFi.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ arch/arm/boot/dts/overlays/Makefile                     |  1 +
+ arch/arm/boot/dts/overlays/README                       |  6 ++++++
+ arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts | 13 +++++++++++++
+ 3 files changed, 20 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index 11dba31712840a9e4b91acd4565c2d6266315273..f1191c1ded82490be5f793ab6483bc5af5891db2 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -51,6 +51,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	mz61581.dtbo \
+ 	pi3-act-led.dtbo \
+ 	pi3-disable-bt.dtbo \
++	pi3-disable-wifi.dtbo \
+ 	pi3-miniuart-bt.dtbo \
+ 	piscreen.dtbo \
+ 	piscreen2r.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/README b/arch/arm/boot/dts/overlays/README
+index e8fa4ccb44c34a20485c4e6155467af99179153a..34109c69416c1caf28910895320a2b9cd539588e 100644
+--- a/arch/arm/boot/dts/overlays/README
++++ b/arch/arm/boot/dts/overlays/README
+@@ -800,6 +800,12 @@ Load:   dtoverlay=pi3-disable-bt
+ Params: <None>
+ 
+ 
++Name:   pi3-disable-wifi
++Info:   Disable Pi3 onboard WiFi
++Load:   dtoverlay=pi3-disable-wifi
++Params: <None>
++
++
+ Name:   pi3-miniuart-bt
+ Info:   Switch Pi3 Bluetooth function to use the mini-UART (ttyS0) and restore
+         UART0/ttyAMA0 over GPIOs 14 & 15. Note that this may reduce the maximum
+diff --git a/arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts b/arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..017199554bf2f4e381efcc7bb71e750c210343e0
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/{
++	compatible = "brcm,bcm2708";
++
++	fragment@0 {
++		target = <&mmc>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+
+From 5c94b3839b261c3c73893677ab6e2355a1177b74 Mon Sep 17 00:00:00 2001
+From: Electron752 <mzoran@crowfest.net>
+Date: Thu, 12 Jan 2017 07:07:08 -0800
+Subject: [PATCH 122/122] ARM64: Make it work again on 4.9 (#1790)
+
+* Invoke the dtc compiler with the same options used in arm mode.
+* ARM64 now uses the bcm2835 platform just like ARM32.
+* ARM64: Update bcmrpi3_defconfig
+
+Signed-off-by: Michael Zoran <mzoran@crowfest.net>
+---
+ arch/arm64/Kconfig.platforms          |  22 ------
+ arch/arm64/boot/dts/broadcom/Makefile |  10 ++-
+ arch/arm64/boot/dts/overlays          |   1 +
+ arch/arm64/configs/bcmrpi3_defconfig  | 126 ++++++++++------------------------
+ 4 files changed, 48 insertions(+), 111 deletions(-)
+ create mode 120000 arch/arm64/boot/dts/overlays
+
+diff --git a/arch/arm64/Kconfig.platforms b/arch/arm64/Kconfig.platforms
+index 7d213c2c904271c7a4622b83cd55a750d237bc2e..101794f5ce1008b7ff007fbfc7fa23d9e63bae67 100644
+--- a/arch/arm64/Kconfig.platforms
++++ b/arch/arm64/Kconfig.platforms
+@@ -1,27 +1,5 @@
+ menu "Platform selection"
+ 
+-config MACH_BCM2709
+-        bool
+-
+-config ARCH_BCM2709
+-        bool "Broadcom BCM2709 family"
+-        select MACH_BCM2709
+-        select HAVE_SMP
+-        select ARM_AMBA
+-        select COMMON_CLK
+-        select ARCH_HAS_CPUFREQ
+-        select GENERIC_CLOCKEVENTS
+-        select MULTI_IRQ_HANDLER
+-        select SPARSE_IRQ
+-        select MFD_SYSCON
+-        select VC4
+-        select USE_OF
+-        select ARCH_REQUIRE_GPIOLIB
+-        select PINCTRL
+-        select PINCTRL_BCM2835
+-        help
+-          This enables support for Broadcom BCM2709 boards.
+-
+ config ARCH_SUNXI
+ 	bool "Allwinner sunxi 64-bit SoC Family"
+ 	select GENERIC_IRQ_CHIP
+diff --git a/arch/arm64/boot/dts/broadcom/Makefile b/arch/arm64/boot/dts/broadcom/Makefile
+index 2152448c8cf5b22c573642d7ce45e85793f5fc9a..7aa03be73fda08d555a13323f483e9b95398f234 100644
+--- a/arch/arm64/boot/dts/broadcom/Makefile
++++ b/arch/arm64/boot/dts/broadcom/Makefile
+@@ -1,7 +1,15 @@
++# Enable fixups to support overlays on BCM2835 platforms
++
++ifeq ($(CONFIG_ARCH_BCM2835),y)
++DTC_FLAGS ?= -@ -H epapr
++endif
++
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2837-rpi-3-b.dtb
+ dtb-$(CONFIG_ARCH_BCM_IPROC) += ns2-svk.dtb
+ dtb-$(CONFIG_ARCH_VULCAN) += vulcan-eval.dtb
+-dtb-$(CONFIG_ARCH_BCM2709) += bcm2710-rpi-3-b.dtb
++dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-3-b.dtb
++
++dts-dirs += ../overlays
+ 
+ always		:= $(dtb-y)
+ subdir-y	:= $(dts-dirs)
+diff --git a/arch/arm64/boot/dts/overlays b/arch/arm64/boot/dts/overlays
+new file mode 120000
+index 0000000000000000000000000000000000000000..ded08646b6f66cdf734f8bf9c1be3a2e3a7103d7
+--- /dev/null
++++ b/arch/arm64/boot/dts/overlays
+@@ -0,0 +1 @@
++../../../arm/boot/dts/overlays
+\ No newline at end of file
+diff --git a/arch/arm64/configs/bcmrpi3_defconfig b/arch/arm64/configs/bcmrpi3_defconfig
+index 53da5c7a33e5898a66e549fb0c39fe3da555ca87..c7e891d72969a388d9b135a36dbfc9c9cb609bf8 100644
+--- a/arch/arm64/configs/bcmrpi3_defconfig
++++ b/arch/arm64/configs/bcmrpi3_defconfig
+@@ -1,52 +1,9 @@
+-# CONFIG_ARM_PATCH_PHYS_VIRT is not set
+-CONFIG_PHYS_OFFSET=0
+ CONFIG_LOCALVERSION="-v8"
+ # CONFIG_LOCALVERSION_AUTO is not set
+-CONFIG_64BIT=y
+ CONFIG_SYSVIPC=y
+ CONFIG_POSIX_MQUEUE=y
+ CONFIG_NO_HZ=y
+ CONFIG_HIGH_RES_TIMERS=y
+-
+-#
+-# ARM errata workarounds via the alternatives framework
+-#
+-CONFIG_ARM64_ERRATUM_826319=n
+-CONFIG_ARM64_ERRATUM_827319=n
+-CONFIG_ARM64_ERRATUM_824069=n
+-CONFIG_ARM64_ERRATUM_819472=n
+-CONFIG_ARM64_ERRATUM_832075=n
+-CONFIG_ARM64_ERRATUM_845719=n
+-CONFIG_ARM64_ERRATUM_843419=n
+-CONFIG_CAVIUM_ERRATUM_22375=n
+-CONFIG_CAVIUM_ERRATUM_23154=n
+-CONFIG_CAVIUM_ERRATUM_27456=n
+-CONFIG_ARM64_4K_PAGES=y
+-CONFIG_ARM64_VA_BITS_39=y
+-CONFIG_ARM64_VA_BITS=39
+-CONFIG_SCHED_MC=y
+-CONFIG_NR_CPUS=4
+-CONFIG_HOTPLUG_CPU=y
+-CONFIG_ARMV8_DEPRECATED=y
+-CONFIG_SWP_EMULATION=y
+-CONFIG_CP15_BARRIER_EMULATION=y
+-CONFIG_SETEND_EMULATION=y
+-
+-#
+-# ARMv8.1 architectural features
+-#
+-CONFIG_ARM64_HW_AFDBM=y
+-CONFIG_ARM64_PAN=y
+-CONFIG_ARM64_LSE_ATOMICS=y
+-CONFIG_ARM64_VHE=y
+-
+-#
+-# ARMv8.2 architectural features
+-#
+-CONFIG_ARM64_UAO=y
+-CONFIG_ARM64_MODULE_CMODEL_LARGE=n
+-CONFIG_RANDOMIZE_BASE=n
+-
+ CONFIG_BSD_PROCESS_ACCT=y
+ CONFIG_BSD_PROCESS_ACCT_V3=y
+ CONFIG_TASKSTATS=y
+@@ -55,7 +12,6 @@ CONFIG_TASK_XACCT=y
+ CONFIG_TASK_IO_ACCOUNTING=y
+ CONFIG_IKCONFIG=m
+ CONFIG_IKCONFIG_PROC=y
+-CONFIG_NMI_LOG_BUF_SHIFT=12
+ CONFIG_MEMCG=y
+ CONFIG_BLK_CGROUP=y
+ CONFIG_CGROUP_FREEZER=y
+@@ -69,54 +25,49 @@ CONFIG_BLK_DEV_INITRD=y
+ CONFIG_EMBEDDED=y
+ # CONFIG_COMPAT_BRK is not set
+ CONFIG_PROFILING=y
+-CONFIG_OPROFILE=m
+ CONFIG_KPROBES=y
+ CONFIG_JUMP_LABEL=y
+ CONFIG_MODULES=y
+ CONFIG_MODULE_UNLOAD=y
+ CONFIG_MODVERSIONS=y
+ CONFIG_MODULE_SRCVERSION_ALL=y
+-CONFIG_TRIM_UNUSED_KSYMS=y
+ CONFIG_BLK_DEV_THROTTLING=y
+ CONFIG_PARTITION_ADVANCED=y
+ CONFIG_MAC_PARTITION=y
+ CONFIG_CFQ_GROUP_IOSCHED=y
+-CONFIG_ARCH_BCM2709=y
+-# CONFIG_CACHE_L2X0 is not set
+-CONFIG_SMP=y
+-CONFIG_HAVE_ARM_ARCH_TIMER=y
+-CONFIG_VMSPLIT_2G=y
+-CONFIG_PREEMPT_VOLUNTARY=y
+-CONFIG_AEABI=y
+-CONFIG_OABI_COMPAT=y
+-# CONFIG_CPU_SW_DOMAIN_PAN is not set
++CONFIG_ARCH_BCM2835=y
++# CONFIG_CAVIUM_ERRATUM_22375 is not set
++# CONFIG_CAVIUM_ERRATUM_23154 is not set
++# CONFIG_CAVIUM_ERRATUM_27456 is not set
++CONFIG_SCHED_MC=y
++CONFIG_NR_CPUS=4
++CONFIG_PREEMPT=y
++CONFIG_HZ_1000=y
+ CONFIG_CLEANCACHE=y
+ CONFIG_FRONTSWAP=y
+ CONFIG_CMA=y
+ CONFIG_ZSMALLOC=m
+ CONFIG_PGTABLE_MAPPING=y
+-CONFIG_UACCESS_WITH_MEMCPY=y
+ CONFIG_SECCOMP=y
+-# CONFIG_ATAGS is not set
+-CONFIG_ZBOOT_ROM_TEXT=0x0
+-CONFIG_ZBOOT_ROM_BSS=0x0
++CONFIG_ARMV8_DEPRECATED=y
++CONFIG_SWP_EMULATION=y
++CONFIG_CP15_BARRIER_EMULATION=y
++CONFIG_SETEND_EMULATION=y
+ CONFIG_CMDLINE="console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
++CONFIG_BINFMT_MISC=y
++CONFIG_COMPAT=y
++# CONFIG_SUSPEND is not set
++CONFIG_PM=y
++CONFIG_CPU_IDLE=y
++CONFIG_ARM_CPUIDLE=y
+ CONFIG_CPU_FREQ=y
++CONFIG_CPU_FREQ_STAT=y
+ CONFIG_CPU_FREQ_DEFAULT_GOV_POWERSAVE=y
+ CONFIG_CPU_FREQ_GOV_PERFORMANCE=y
+ CONFIG_CPU_FREQ_GOV_USERSPACE=y
+ CONFIG_CPU_FREQ_GOV_ONDEMAND=y
+ CONFIG_CPU_FREQ_GOV_CONSERVATIVE=y
+ CONFIG_CPU_FREQ_GOV_SCHEDUTIL=y
+-CONFIG_VFP=y
+-CONFIG_NEON=y
+-CONFIG_KERNEL_MODE_NEON=y
+-CONFIG_BINFMT_MISC=m
+-CONFIG_COMPAT=y
+-CONFIG_SYSVIPC_COMPAT=y
+-
+-# CONFIG_SUSPEND is not set
+-CONFIG_PM=y
+ CONFIG_NET=y
+ CONFIG_PACKET=y
+ CONFIG_UNIX=y
+@@ -437,6 +388,7 @@ CONFIG_BT_MRVL=m
+ CONFIG_BT_MRVL_SDIO=m
+ CONFIG_BT_ATH3K=m
+ CONFIG_BT_WILINK=m
++CONFIG_CFG80211=m
+ CONFIG_MAC80211=m
+ CONFIG_MAC80211_MESH=y
+ CONFIG_WIMAX=m
+@@ -490,7 +442,6 @@ CONFIG_BONDING=m
+ CONFIG_DUMMY=m
+ CONFIG_IFB=m
+ CONFIG_MACVLAN=m
+-CONFIG_IPVLAN=m
+ CONFIG_VXLAN=m
+ CONFIG_NETCONSOLE=m
+ CONFIG_TUN=m
+@@ -579,8 +530,6 @@ CONFIG_RT2800USB_RT3573=y
+ CONFIG_RT2800USB_RT53XX=y
+ CONFIG_RT2800USB_RT55XX=y
+ CONFIG_RT2800USB_UNKNOWN=y
+-CONFIG_RTL8187=m
+-CONFIG_RTL8192CU=n
+ CONFIG_USB_ZD1201=m
+ CONFIG_ZD1211RW=m
+ CONFIG_MAC80211_HWSIM=m
+@@ -606,7 +555,7 @@ CONFIG_JOYSTICK_RPISENSE=m
+ CONFIG_INPUT_TOUCHSCREEN=y
+ CONFIG_TOUCHSCREEN_ADS7846=m
+ CONFIG_TOUCHSCREEN_EGALAX=m
+-CONFIG_TOUCHSCREEN_FT6236=m
++CONFIG_TOUCHSCREEN_EKTF2127=m
+ CONFIG_TOUCHSCREEN_RPI_FT5406=m
+ CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
+ CONFIG_TOUCHSCREEN_STMPE=m
+@@ -626,10 +575,8 @@ CONFIG_SERIO_RAW=m
+ CONFIG_GAMEPORT=m
+ CONFIG_GAMEPORT_NS558=m
+ CONFIG_GAMEPORT_L4=m
+-CONFIG_BRCM_CHAR_DRIVERS=n
+-CONFIG_BCM_VC_CMA=n
+-CONFIG_BCM_VCIO=n
+-CONFIG_BCM_VC_SM=n
++# CONFIG_BCM2835_DEVGPIOMEM is not set
++# CONFIG_BCM2835_SMI_DEV is not set
+ # CONFIG_LEGACY_PTYS is not set
+ # CONFIG_DEVKMEM is not set
+ CONFIG_SERIAL_8250=y
+@@ -638,6 +585,9 @@ CONFIG_SERIAL_8250_CONSOLE=y
+ # CONFIG_SERIAL_8250_DMA is not set
+ CONFIG_SERIAL_8250_NR_UARTS=1
+ CONFIG_SERIAL_8250_RUNTIME_UARTS=0
++CONFIG_SERIAL_8250_EXTENDED=y
++CONFIG_SERIAL_8250_SHARE_IRQ=y
++CONFIG_SERIAL_8250_BCM2835AUX=y
+ CONFIG_SERIAL_OF_PLATFORM=y
+ CONFIG_SERIAL_AMBA_PL011=y
+ CONFIG_SERIAL_AMBA_PL011_CONSOLE=y
+@@ -650,6 +600,7 @@ CONFIG_I2C=y
+ CONFIG_I2C_CHARDEV=m
+ CONFIG_I2C_MUX_PCA954x=m
+ CONFIG_I2C_BCM2708=m
++CONFIG_I2C_BCM2835=m
+ CONFIG_I2C_GPIO=m
+ CONFIG_SPI=y
+ CONFIG_SPI_BCM2835=m
+@@ -681,13 +632,13 @@ CONFIG_W1_SLAVE_DS2780=m
+ CONFIG_W1_SLAVE_DS2781=m
+ CONFIG_W1_SLAVE_DS28E04=m
+ CONFIG_W1_SLAVE_BQ27000=m
+-CONFIG_BATTERY_DS2760=m
+-CONFIG_POWER_RESET=y
+ CONFIG_POWER_RESET_GPIO=y
++CONFIG_BATTERY_DS2760=m
+ CONFIG_HWMON=m
+ CONFIG_SENSORS_LM75=m
+ CONFIG_SENSORS_SHT21=m
+ CONFIG_SENSORS_SHTC1=m
++CONFIG_SENSORS_INA2XX=m
+ CONFIG_THERMAL=y
+ CONFIG_THERMAL_BCM2835=y
+ CONFIG_WATCHDOG=y
+@@ -835,8 +786,6 @@ CONFIG_VIDEO_EM28XX_V4L2=m
+ CONFIG_VIDEO_EM28XX_ALSA=m
+ CONFIG_VIDEO_EM28XX_DVB=m
+ CONFIG_V4L_PLATFORM_DRIVERS=y
+-CONFIG_VIDEO_BCM2835=n
+-CONFIG_VIDEO_BCM2835_MMAL=n
+ CONFIG_RADIO_SI470X=y
+ CONFIG_USB_SI470X=m
+ CONFIG_I2C_SI470X=m
+@@ -892,8 +841,6 @@ CONFIG_SND_VIRMIDI=m
+ CONFIG_SND_MTPAV=m
+ CONFIG_SND_SERIAL_U16550=m
+ CONFIG_SND_MPU401=m
+-CONFIG_SND_ARM=n
+-CONFIG_SND_BCM2835=n
+ CONFIG_SND_USB_AUDIO=m
+ CONFIG_SND_USB_UA101=m
+ CONFIG_SND_USB_CAIAQ=m
+@@ -916,7 +863,10 @@ CONFIG_SND_BCM2708_SOC_ADAU1977_ADC=m
+ CONFIG_SND_AUDIOINJECTOR_PI_SOUNDCARD=m
+ CONFIG_SND_DIGIDAC1_SOUNDCARD=m
+ CONFIG_SND_BCM2708_SOC_DIONAUDIO_LOCO=m
++CONFIG_SND_BCM2708_SOC_ALLO_PIANO_DAC=m
++CONFIG_SND_PISOUND=m
+ CONFIG_SND_SOC_ADAU1701=m
++CONFIG_SND_SOC_AK4554=m
+ CONFIG_SND_SOC_WM8804_I2C=m
+ CONFIG_SND_SIMPLE_CARD=m
+ CONFIG_SOUND_PRIME=m
+@@ -979,8 +929,6 @@ CONFIG_USB_HIDDEV=y
+ CONFIG_USB=y
+ CONFIG_USB_ANNOUNCE_NEW_DEVICES=y
+ CONFIG_USB_MON=m
+-CONFIG_USB_DWCOTG=n
+-CONFIG_USB_DWC2=y
+ CONFIG_USB_PRINTER=m
+ CONFIG_USB_STORAGE=y
+ CONFIG_USB_STORAGE_REALTEK=m
+@@ -1001,6 +949,7 @@ CONFIG_USB_MICROTEK=m
+ CONFIG_USBIP_CORE=m
+ CONFIG_USBIP_VHCI_HCD=m
+ CONFIG_USBIP_HOST=m
++CONFIG_USB_DWC2=y
+ CONFIG_USB_SERIAL=m
+ CONFIG_USB_SERIAL_GENERIC=y
+ CONFIG_USB_SERIAL_AIRCABLE=m
+@@ -1096,6 +1045,7 @@ CONFIG_LEDS_TRIGGER_INPUT=y
+ CONFIG_LEDS_TRIGGER_PANIC=y
+ CONFIG_RTC_CLASS=y
+ # CONFIG_RTC_HCTOSYS is not set
++CONFIG_RTC_DRV_ABX80X=m
+ CONFIG_RTC_DRV_DS1307=m
+ CONFIG_RTC_DRV_DS1374=m
+ CONFIG_RTC_DRV_DS1672=m
+@@ -1103,7 +1053,6 @@ CONFIG_RTC_DRV_MAX6900=m
+ CONFIG_RTC_DRV_RS5C372=m
+ CONFIG_RTC_DRV_ISL1208=m
+ CONFIG_RTC_DRV_ISL12022=m
+-CONFIG_RTC_DRV_ISL12057=m
+ CONFIG_RTC_DRV_X1205=m
+ CONFIG_RTC_DRV_PCF8523=m
+ CONFIG_RTC_DRV_PCF8563=m
+@@ -1137,7 +1086,6 @@ CONFIG_STAGING=y
+ CONFIG_PRISM2_USB=m
+ CONFIG_R8712U=m
+ CONFIG_R8188EU=m
+-CONFIG_R8723AU=m
+ CONFIG_VT6656=m
+ CONFIG_SPEAKUP=m
+ CONFIG_SPEAKUP_SYNTH_SOFT=m
+@@ -1153,6 +1101,7 @@ CONFIG_FB_TFT_BD663474=m
+ CONFIG_FB_TFT_HX8340BN=m
+ CONFIG_FB_TFT_HX8347D=m
+ CONFIG_FB_TFT_HX8353D=m
++CONFIG_FB_TFT_HX8357D=m
+ CONFIG_FB_TFT_ILI9163=m
+ CONFIG_FB_TFT_ILI9320=m
+ CONFIG_FB_TFT_ILI9325=m
+@@ -1176,6 +1125,7 @@ CONFIG_FB_TFT_UPD161704=m
+ CONFIG_FB_TFT_WATTEROTT=m
+ CONFIG_FB_FLEX=m
+ CONFIG_FB_TFT_FBTFT_DEVICE=m
++# CONFIG_BCM2708_VCHIQ is not set
+ CONFIG_MAILBOX=y
+ CONFIG_BCM2835_MBOX=y
+ # CONFIG_IOMMU_SUPPORT is not set
+@@ -1189,6 +1139,7 @@ CONFIG_IIO_KFIFO_BUF=m
+ CONFIG_MCP320X=m
+ CONFIG_MCP3422=m
+ CONFIG_DHT11=m
++CONFIG_HTU21=m
+ CONFIG_PWM_BCM2835=m
+ CONFIG_PWM_PCA9685=m
+ CONFIG_RASPBERRYPI_FIRMWARE=y
+@@ -1309,6 +1260,7 @@ CONFIG_BOOT_PRINTK_DELAY=y
+ CONFIG_DEBUG_MEMORY_INIT=y
+ CONFIG_DETECT_HUNG_TASK=y
+ CONFIG_TIMER_STATS=y
++CONFIG_LATENCYTOP=y
+ CONFIG_IRQSOFF_TRACER=y
+ CONFIG_SCHED_TRACER=y
+ CONFIG_STACK_TRACER=y
+@@ -1331,5 +1283,3 @@ CONFIG_CRYPTO_USER_API_SKCIPHER=m
+ CONFIG_ARM64_CRYPTO=y
+ CONFIG_CRC_ITU_T=y
+ CONFIG_LIBCRC32C=y
+-CONFIG_BCM2708_VCHIQ=n
+-CONFIG_ARCH_BCM2835=y


### PR DESCRIPTION
Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.9.3

This updated RPi firmware includes usb/net booting support.

The RPi patches include the JustBoom driver name fix.