### PR TITLE
kodi: use KODI_DEPENDSBUILD

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -208,6 +208,7 @@ PKG_CMAKE_OPTS_TARGET="-DNATIVEPREFIX=$ROOT/$TOOLCHAIN \
                        -DGIT_VERSION=$PKG_VERSION \
                        -DENABLE_INTERNAL_FFMPEG=OFF \
                        -DFFMPEG_INCLUDE_DIRS=$SYSROOT_PREFIX/usr \
+                       -DKODI_DEPENDSBUILD=ON \
                        -DENABLE_INTERNAL_CROSSGUID=OFF \
                        -DENABLE_SDL=OFF \
                        -DENABLE_OPENSSL=ON \


### PR DESCRIPTION
Probably the most confusing naming scheme ever.

It's a miracle that this even worked without it.