### PR TITLE
linux: update to linux-4.9.4

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -58,7 +58,7 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.9.3"
+    PKG_VERSION="4.9.4"
     PKG_URL="http://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,7 +1,7 @@
-From 726155a02a2642c4f992655ae4a4c062a0761260 Mon Sep 17 00:00:00 2001
+From 63e11e0da8f387b5ad081842eb0d958c593e955b Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
-Subject: [PATCH 001/122] smsx95xx: fix crimes against truesize
+Subject: [PATCH 001/126] smsx95xx: fix crimes against truesize
 
 smsc95xx is adjusting truesize when it shouldn't, and following a recent patch from Eric this is now triggering warnings.
 
@@ -48,10 +48,10 @@ index 831aa33d078ae7d2dd57fdded5de71d1eb915f99..b77935bded8c0ff7808b00f170ff10e5
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From f1afc1dcb1c34955d1a9d756abb1b61c3a9f1da8 Mon Sep 17 00:00:00 2001
+From 77f9b5bad4bfae625f9f7eb226b99b1a7d295301 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
-Subject: [PATCH 002/122] smsc95xx: Experimental: Enable turbo_mode and
+Subject: [PATCH 002/126] smsc95xx: Experimental: Enable turbo_mode and
  packetsize=2560 by default
 
 See: http://forum.kodi.tv/showthread.php?tid=285288
@@ -94,10 +94,10 @@ index b77935bded8c0ff7808b00f170ff10e594300ad0..693f163684de921404738e33244881e0
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From 69f6712212df74f6c27b1dfec7e3cc1408416653 Mon Sep 17 00:00:00 2001
+From d4abac0ef0d247e2cbc464e1b7cd3bf50985a965 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
-Subject: [PATCH 003/122] Allow mac address to be set in smsc95xx
+Subject: [PATCH 003/126] Allow mac address to be set in smsc95xx
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -193,10 +193,10 @@ index 693f163684de921404738e33244881e0aab92ec9..df60c989fc229bf0aab3c27e95ccd453
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From 10945e4697799ceff36fbdea420081b746d67429 Mon Sep 17 00:00:00 2001
+From 64c379b2a2825b495d9d80602194a9de8ead3ee1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
-Subject: [PATCH 004/122] Protect __release_resource against resources without
+Subject: [PATCH 004/126] Protect __release_resource against resources without
  parents
 
 Without this patch, removing a device tree overlay can crash here.
@@ -224,10 +224,10 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From ab1aef30de5e9424f87d7d6e1edb1a5240a76ae5 Mon Sep 17 00:00:00 2001
+From 7323c6a2d443bad79d0d0d39d108e52f3a9eb94d Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
-Subject: [PATCH 005/122] mm: Remove the PFN busy warning
+Subject: [PATCH 005/126] mm: Remove the PFN busy warning
 
 See commit dae803e165a11bc88ca8dbc07a11077caf97bbcb -- the warning is
 expected sometimes when using CMA.  However, that commit still spams
@@ -252,10 +252,10 @@ index 34ada718ef47c4b27730214d584f9350fefb9883..3fa01a5280db96075798e4cbd58d5520
  		goto done;
  	}
 
-From a1c2520dc2663b442e4b43010df6917f233ff40e Mon Sep 17 00:00:00 2001
+From 654e28c06539aa4f7e55dc4d009d04c6d06e2e70 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
-Subject: [PATCH 006/122] irq-bcm2836: Prevent spurious interrupts, and trap
+Subject: [PATCH 006/126] irq-bcm2836: Prevent spurious interrupts, and trap
  them early
 
 The old arch-specific IRQ macros included a dsb to ensure the
@@ -282,10 +282,10 @@ index d96b2c947e74e3edab3917551c64fbd1ced0f34c..93e3f7660c4230c9f1dd3b195958cb49
  #endif
  	} else if (stat) {
 
-From 2d51d14c0cea3d9d52f323b58a0a5d99a65eef24 Mon Sep 17 00:00:00 2001
+From 0fb8f05c814b8bfa2587ad74d204259d0504ebcd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
-Subject: [PATCH 007/122] irqchip: bcm2835: Add FIQ support
+Subject: [PATCH 007/126] irqchip: bcm2835: Add FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -414,10 +414,10 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 2d9b0ef8dc1a5975dfccfb7e78b8f5a94ab5f2bb Mon Sep 17 00:00:00 2001
+From 04dd06e02458b52417db6803414f5cb958cd3555 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
-Subject: [PATCH 008/122] irqchip: irq-bcm2835: Add 2836 FIQ support
+Subject: [PATCH 008/126] irqchip: irq-bcm2835: Add 2836 FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -516,10 +516,10 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From 39974a29633d89316e5de24d87294b444b24f381 Mon Sep 17 00:00:00 2001
+From 74a1a4a4b4bea0653a09eabc8df33e02db13bdd5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
-Subject: [PATCH 009/122] spidev: Add "spidev" compatible string to silence
+Subject: [PATCH 009/126] spidev: Add "spidev" compatible string to silence
  warning
 
 See: https://github.com/raspberrypi/linux/issues/1054
@@ -540,10 +540,10 @@ index 2e05046f866bd01bf87edcdeff0d5b76d4d0aea7..d780491b8013a4e97fa843958964454e
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 51c39f512e9b370f126afcdcf6306561ea1f50f2 Mon Sep 17 00:00:00 2001
+From 9bc2b7840e95ae09a708109e86bb23637a27f5d7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 30 Jun 2015 14:12:42 +0100
-Subject: [PATCH 010/122] serial: 8250: Don't crash when nr_uarts is 0
+Subject: [PATCH 010/126] serial: 8250: Don't crash when nr_uarts is 0
 
 ---
  drivers/tty/serial/8250/8250_core.c | 2 ++
@@ -563,10 +563,10 @@ index 240a361b674fe72ce657067e5303156b7add6a6f..14f6cdfd744209482056d206dc476d94
  	for (i = 0; i < nr_uarts; i++) {
  		struct uart_8250_port *up = &serial8250_ports[i];
 
-From f56196076549fabcdf0cca5685d1ea3e0308622a Mon Sep 17 00:00:00 2001
+From ccf3116935778517465cd8bdc8c27c146e66e7ab Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
-Subject: [PATCH 011/122] pinctrl-bcm2835: Set base to 0 give expected gpio
+Subject: [PATCH 011/126] pinctrl-bcm2835: Set base to 0 give expected gpio
  numbering
 
 Signed-off-by: Noralf Tronnes <notro@tronnes.org>
@@ -588,10 +588,10 @@ index fa77165fab2c1348163979da507df17e7168c49b..d11e2e4ea189466e686d762cb6c6fef9
  	.can_sleep = false,
  };
 
-From 40a7420d0d585951fbc02f232df97a15beff7a57 Mon Sep 17 00:00:00 2001
+From 31583da17782d176a60e1312650795a5edd3b3c6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
-Subject: [PATCH 012/122] pinctrl-bcm2835: Fix interrupt handling for GPIOs
+Subject: [PATCH 012/126] pinctrl-bcm2835: Fix interrupt handling for GPIOs
  28-31 and 46-53
 
 Contrary to the documentation, the BCM2835 GPIO controller actually has
@@ -737,10 +737,10 @@ index d11e2e4ea189466e686d762cb6c6fef9111ecf8e..107ad7d58de8f8a7f55e09c9cdcf7d66
  	},
  };
 
-From a19df9159eb1e9745593febf2ef6aa5868e8d12f Mon Sep 17 00:00:00 2001
+From b2ce0dec4ec06b7698b05e6192d8e67a72c16475 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
-Subject: [PATCH 013/122] pinctrl-bcm2835: Only request the interrupts listed
+Subject: [PATCH 013/126] pinctrl-bcm2835: Only request the interrupts listed
  in the DTB
 
 Although the GPIO controller can generate three interrupts (four counting
@@ -767,10 +767,10 @@ index 107ad7d58de8f8a7f55e09c9cdcf7d66fa7ab66b..644bdecbcfcb79d3b84a33769265fca5
  		pc->irq_data[i].irqgroup = i;
  
 
-From eee7c2b51a8b1753aca3d01ecda24713576d14e5 Mon Sep 17 00:00:00 2001
+From 5cac86fa1ade5f2308f5fce0098718f780b5b9fe Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 May 2016 12:32:47 +0100
-Subject: [PATCH 014/122] pinctrl-bcm2835: Return pins to inputs when freed
+Subject: [PATCH 014/126] pinctrl-bcm2835: Return pins to inputs when freed
 
 When dynamically unloading overlays, it is important that freed pins are
 restored to being inputs to prevent functions from being enabled in
@@ -811,10 +811,10 @@ index 644bdecbcfcb79d3b84a33769265fca5d3d0c9e5..81a66cba2ab0f7e3ae179de7edd10122
  	.get_function_name = bcm2835_pmx_get_function_name,
  	.get_function_groups = bcm2835_pmx_get_function_groups,
 
-From 7d54b896b5523a49b1038dd301b2d359d2321ef2 Mon Sep 17 00:00:00 2001
+From 720b313ed69c685d273546c3999a745076fdf4da Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
-Subject: [PATCH 015/122] spi-bcm2835: Support pin groups other than 7-11
+Subject: [PATCH 015/126] spi-bcm2835: Support pin groups other than 7-11
 
 The spi-bcm2835 driver automatically uses GPIO chip-selects due to
 some unreliability of the native ones. In doing so it chooses the
@@ -895,10 +895,10 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From de045c3b6df0c0d56f02c0f782627249bbad09d2 Mon Sep 17 00:00:00 2001
+From a1a469614cac7e788aa2894125f91471508a7374 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
-Subject: [PATCH 016/122] spi-bcm2835: Disable forced software CS
+Subject: [PATCH 016/126] spi-bcm2835: Disable forced software CS
 
 Select software CS in bcm2708_common.dtsi, and disable the automatic
 conversion in the driver to allow hardware CS to be re-enabled with an
@@ -932,10 +932,10 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From a161509667da54c9d5066a0c6bc0584d093a8923 Mon Sep 17 00:00:00 2001
+From 65e258d609312dc6700a398bd1766f8154cf7d08 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
-Subject: [PATCH 017/122] spi-bcm2835: Remove unused code
+Subject: [PATCH 017/126] spi-bcm2835: Remove unused code
 
 ---
  drivers/spi/spi-bcm2835.c | 61 -----------------------------------------------
@@ -1023,10 +1023,10 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From 2ec6cfba14ff71b08f797c69d1a9c5bd53fc66a6 Mon Sep 17 00:00:00 2001
+From d47f0f76f25cb14852a10b548fb78b000b421987 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
-Subject: [PATCH 018/122] ARM: bcm2835: Set Serial number and Revision
+Subject: [PATCH 018/126] ARM: bcm2835: Set Serial number and Revision
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1079,10 +1079,10 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 7cd4e838461cb6cefa1ca5246ef3a6773363f0e0 Mon Sep 17 00:00:00 2001
+From 303f00d215fd55c7251899585db84a65629bd78d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
-Subject: [PATCH 019/122] dmaengine: bcm2835: Load driver early and support
+Subject: [PATCH 019/126] dmaengine: bcm2835: Load driver early and support
  legacy API
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -1185,10 +1185,10 @@ index e18dc596cf2447fa9ef7e41b62d9396e29043426..80d35f760b4a4a51e60c355a84d538ba
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From e19d2f37545f78b50f4f82b72099b036f42d2bcd Mon Sep 17 00:00:00 2001
+From cb868455a02d8c15093949b3dcec58f5cf4993a7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
-Subject: [PATCH 020/122] firmware: Updated mailbox header
+Subject: [PATCH 020/126] firmware: Updated mailbox header
 
 ---
  include/soc/bcm2835/raspberrypi-firmware.h | 11 +++++++++++
@@ -1251,10 +1251,10 @@ index 3fb357193f09914fe21f8555a4b8613f74f22bc3..227a107214a02deadcca3db202da265e
  	RPI_FIRMWARE_GET_COMMAND_LINE =                       0x00050001,
  	RPI_FIRMWARE_GET_DMA_CHANNELS =                       0x00060001,
 
-From 99e1f06dcc2bf78742380b9697c354b627fd02c2 Mon Sep 17 00:00:00 2001
+From aafd4292fbbb7f22d05f10d6cb8336ffac9c8ad4 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
-Subject: [PATCH 021/122] clk: bcm2835: Mark GPIO clocks enabled at boot as
+Subject: [PATCH 021/126] clk: bcm2835: Mark GPIO clocks enabled at boot as
  critical.
 
 These divide off of PLLD_PER and are used for the ethernet and wifi
@@ -1292,10 +1292,10 @@ index 3bbd2a58db470a89b870a793e59ddf9fc4f48e57..7040c6426e35c11608121893b662c601
  		init.ops = &bcm2835_vpu_clock_clk_ops;
  	} else {
 
-From 946babad832c9ed45bbb31fd89fce025a9f7db48 Mon Sep 17 00:00:00 2001
+From ae325b043eaba7f7bac66d2cb01644bee6933b6a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
-Subject: [PATCH 022/122] rtc: Add SPI alias for pcf2123 driver
+Subject: [PATCH 022/126] rtc: Add SPI alias for pcf2123 driver
 
 Without this alias, Device Tree won't cause the driver
 to be loaded.
@@ -1315,10 +1315,10 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From a929f2b203a1bafb1ca88f7022cb286f28fa98bd Mon Sep 17 00:00:00 2001
+From d08f818da57e017f41cba3d0f16e1fd8eec99b20 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
-Subject: [PATCH 023/122] watchdog: bcm2835: Support setting reboot partition
+Subject: [PATCH 023/126] watchdog: bcm2835: Support setting reboot partition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1442,10 +1442,10 @@ index 4dddd8298a227d64862f2e92954a465f2e44b3f6..1f545e024422f59280932713e6a1b051
  	register_restart_handler(&wdt->restart_handler);
  	if (pm_power_off == NULL)
 
-From 2e7833eae38410bc31d3a86166868a55d0999394 Mon Sep 17 00:00:00 2001
+From 0f74ee7f936f83ad48d8c69640516c3da1fd65a7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
-Subject: [PATCH 024/122] reboot: Use power off rather than busy spinning when
+Subject: [PATCH 024/126] reboot: Use power off rather than busy spinning when
  halt is requested
 
 ---
@@ -1468,10 +1468,10 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From 0d4700ca51eb31fa70e10da67fa92e986275f2d3 Mon Sep 17 00:00:00 2001
+From f87f4d388f2486ebe8e404b0920a771100b37c96 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
-Subject: [PATCH 025/122] bcm: Make RASPBERRYPI_POWER depend on PM
+Subject: [PATCH 025/126] bcm: Make RASPBERRYPI_POWER depend on PM
 
 ---
  drivers/soc/bcm/Kconfig | 1 +
@@ -1490,10 +1490,10 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 53b503a7256d432bfa51f5ffba58a446c2cc6ebb Mon Sep 17 00:00:00 2001
+From a724c93f4805fe577d215b97231db4463832ce7d Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
-Subject: [PATCH 026/122] Register the clocks early during the boot process, so
+Subject: [PATCH 026/126] Register the clocks early during the boot process, so
  that special/critical clocks can get enabled early on in the boot process
  avoiding the risk of disabling a clock, pll_divider or pll when a claiming
  driver fails to install propperly - maybe it needs to defer.
@@ -1538,10 +1538,10 @@ index 7040c6426e35c11608121893b662c601cd8d6543..21e2a538ff0d0ab4e63adff9b93705f3
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From e367c208dc6a9d92e5c0d6e5e089e7b56c7cf189 Mon Sep 17 00:00:00 2001
+From 5bb87da5723ea02dc3a2da5a267bb90c562f9bb4 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
-Subject: [PATCH 027/122] bcm2835-rng: Avoid initialising if already enabled
+Subject: [PATCH 027/126] bcm2835-rng: Avoid initialising if already enabled
 
 Avoids the 0x40000 cycles of warmup again if firmware has already used it
 ---
@@ -1567,10 +1567,10 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From da0b1ac76230b33baa5cd0391388d32d43889d69 Mon Sep 17 00:00:00 2001
+From 5926afb27f2dc5dad6f99af9394b8f1b3289e071 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
-Subject: [PATCH 028/122] kbuild: Ignore dtco targets when filtering symbols
+Subject: [PATCH 028/126] kbuild: Ignore dtco targets when filtering symbols
 
 ---
  scripts/Kbuild.include | 2 +-
@@ -1590,10 +1590,10 @@ index 179219845dfcdfbeb586d12c5ec1296095d9fbf4..e0743e44f84188667a0c322e8c3d36f1
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From f96bacbe5b20000d29c0b1bc81f66f5b15231b48 Mon Sep 17 00:00:00 2001
+From 3042782f257be2823820f7040b771ad5d72cf0e9 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
-Subject: [PATCH 029/122] BCM2835_DT: Fix I2S register map
+Subject: [PATCH 029/126] BCM2835_DT: Fix I2S register map
 
 ---
  Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.txt   | 4 ++--
@@ -1631,10 +1631,10 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From 967e1d016f69607cb5f1d8337f9249ef31e19d81 Mon Sep 17 00:00:00 2001
+From dc83f1171efc493dfb233113a748734033b213a8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
-Subject: [PATCH 030/122] Main bcm2708/bcm2709 linux port
+Subject: [PATCH 030/126] Main bcm2708/bcm2709 linux port
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1841,10 +1841,10 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 9ccdf13082f318de0091066517c7f7309b245456 Mon Sep 17 00:00:00 2001
+From edbeb9ac886a21d9ca45b4e5a84b9914b0a14f1d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
-Subject: [PATCH 031/122] Add dwc_otg driver
+Subject: [PATCH 031/126] Add dwc_otg driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -62901,10 +62901,10 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 990bd0f738984c3582e6dbba14a1826ea28f9fb6 Mon Sep 17 00:00:00 2001
+From 38da51175e2ecc08d375d7274b4ff9c91ab9f042 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
-Subject: [PATCH 032/122] bcm2708 framebuffer driver
+Subject: [PATCH 032/126] bcm2708 framebuffer driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66363,10 +66363,10 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From baa447618d238275c592e7caa6455b8e4b1d3d77 Mon Sep 17 00:00:00 2001
+From cad92641e0a0f0b49cbdfa5f0b3c27401e492de6 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
-Subject: [PATCH 033/122] dmaengine: Add support for BCM2708
+Subject: [PATCH 033/126] dmaengine: Add support for BCM2708
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66997,10 +66997,10 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From b7d8765eb1e1bb854be09a08acabaf92cd1c45ab Mon Sep 17 00:00:00 2001
+From 8c0181ad0bd96059733c3473bf12745c1375fd66 Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
-Subject: [PATCH 034/122] MMC: added alternative MMC driver
+Subject: [PATCH 034/126] MMC: added alternative MMC driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -68750,10 +68750,10 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From a56eb108067d0211a3ba3b987ec15986ac5577a6 Mon Sep 17 00:00:00 2001
+From 9c2e7cd3627b3017ef409610b1db962601271147 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
-Subject: [PATCH 035/122] Adding bcm2835-sdhost driver, and an overlay to
+Subject: [PATCH 035/126] Adding bcm2835-sdhost driver, and an overlay to
  enable it
 
 BCM2835 has two SD card interfaces. This driver uses the other one.
@@ -71158,10 +71158,10 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 0eda1e885a24ef523c6f88b4f62dc928c47f00c6 Mon Sep 17 00:00:00 2001
+From ee4d028beb367877f76181a1bc56aa1859a8f374 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
-Subject: [PATCH 036/122] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
+Subject: [PATCH 036/126] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
 
 Some SD cards have been found that corrupt data when small blocks
 are erased. Add a quirk to indicate that ERASE should not be used,
@@ -71297,10 +71297,10 @@ index 73fad83acbcb6a157587180516f9ffe7c61eb7d7..e7c9d3098ac06e3c6554fa3373a311f9
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From ebd7f1f66e66573d57edc087910e4f34f71a52d9 Mon Sep 17 00:00:00 2001
+From 4e12fb038c44a2e713965013ec86899a47b78403 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:31:47 +0100
-Subject: [PATCH 037/122] cma: Add vc_cma driver to enable use of CMA
+Subject: [PATCH 037/126] cma: Add vc_cma driver to enable use of CMA
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -72636,10 +72636,10 @@ index 0000000000000000000000000000000000000000..be2819d5d41f9d5ed65daf8eedb94c9e
 +
 +#endif /* VC_CMA_H */
 
-From 20fda0a0bcd46a01ba801a968f81c55398ff925e Mon Sep 17 00:00:00 2001
+From a04f5f2ffe8373ea31e17b82be9b3843fe65c0f3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 26 Mar 2012 22:15:50 +0100
-Subject: [PATCH 038/122] bcm2708: alsa sound driver
+Subject: [PATCH 038/126] bcm2708: alsa sound driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -75374,10 +75374,10 @@ index 0000000000000000000000000000000000000000..af3e6eb690113fc32ce9e06bd2f0f294
 +
 +#endif // _VC_AUDIO_DEFS_H_
 
-From f173c4ba6bb591fd104486fec7229cff3648f715 Mon Sep 17 00:00:00 2001
+From ba414e3d840b41eb38faba2eb4a2713094241514 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
-Subject: [PATCH 039/122] vc_mem: Add vc_mem driver for querying firmware
+Subject: [PATCH 039/126] vc_mem: Add vc_mem driver for querying firmware
  memory addresses
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -75901,10 +75901,10 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From 826895d0d097fa010aca39acf19d85a1e065876d Mon Sep 17 00:00:00 2001
+From 61fd7be07724c515e7a1aab2149f09c75555a233 Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
-Subject: [PATCH 040/122] vcsm: VideoCore shared memory service for BCM2835
+Subject: [PATCH 040/126] vcsm: VideoCore shared memory service for BCM2835
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -80311,10 +80311,10 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From 3d892851d6e52bec4c02b06146967ecc52b50af0 Mon Sep 17 00:00:00 2001
+From 6bb05242468217f5f3b426f7bc8e7bec5fbb8cfe Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
-Subject: [PATCH 041/122] Add /dev/gpiomem device for rootless user GPIO access
+Subject: [PATCH 041/126] Add /dev/gpiomem device for rootless user GPIO access
 
 Signed-off-by: Luke Wren <luke@raspberrypi.org>
 
@@ -80625,10 +80625,10 @@ index 0000000000000000000000000000000000000000..911f5b7393ed48ceed8751f06967ae64
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From fbaa743648d031cbb8afeb81e37f546b4fd7b6b5 Mon Sep 17 00:00:00 2001
+From b76610b93035441ca90043e0214291405b390bd8 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
-Subject: [PATCH 042/122] Add SMI driver
+Subject: [PATCH 042/126] Add SMI driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -82579,10 +82579,10 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From 7df434185cb69481bdb857fb30c153685feb7c4e Mon Sep 17 00:00:00 2001
+From 1f83979d14ace2092bcb03627aed5f1bbc129268 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
-Subject: [PATCH 043/122] MISC: bcm2835: smi: use clock manager and fix reload
+Subject: [PATCH 043/126] MISC: bcm2835: smi: use clock manager and fix reload
  issues
 
 Use clock manager instead of self-made clockmanager.
@@ -82752,10 +82752,10 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From e80a053c8ec7283b7c93f468b437c1e53ffdd5dc Mon Sep 17 00:00:00 2001
+From d49666e230c6379c4c130ba3b01e481b0d7ddce9 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
-Subject: [PATCH 044/122] Add SMI NAND driver
+Subject: [PATCH 044/126] Add SMI NAND driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -83120,10 +83120,10 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From d5fe3a35c384918e40ad67ae26c5997ca941c98e Mon Sep 17 00:00:00 2001
+From 34a4d656715ed74b00db49b706649c09188ceef1 Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
-Subject: [PATCH 045/122] lirc: added support for RaspberryPi GPIO
+Subject: [PATCH 045/126] lirc: added support for RaspberryPi GPIO
 
 lirc_rpi: Use read_current_timer to determine transmitter delay. Thanks to jjmz and others
 See: https://github.com/raspberrypi/linux/issues/525
@@ -83986,10 +83986,10 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From f66f635379d5b4ebc82d4d18c9bd77d2fbcbdfa6 Mon Sep 17 00:00:00 2001
+From 14a72a5cd0b417e11140e026d0795895f9aadfae Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
-Subject: [PATCH 046/122] Add cpufreq driver
+Subject: [PATCH 046/126] Add cpufreq driver
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -84256,10 +84256,10 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 478277f128dbdcbea6394c4744ada90fce9ab66e Mon Sep 17 00:00:00 2001
+From c1a1eccd357ab6a8e537c9c3a8a89b9925b1fde9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
-Subject: [PATCH 047/122] Added hwmon/thermal driver for reporting core
+Subject: [PATCH 047/126] Added hwmon/thermal driver for reporting core
  temperature. Thanks Dorian
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -84425,10 +84425,10 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From aaac339b97bfcc6a67fd3f51400d87fc2ff00198 Mon Sep 17 00:00:00 2001
+From 070ea1d5e9fb411df507ba44d68beb6cc2ca0796 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
-Subject: [PATCH 048/122] Add Chris Boot's i2c driver
+Subject: [PATCH 048/126] Add Chris Boot's i2c driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85093,10 +85093,10 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From fa468e89c790f2e432205e3b16d26e5365d98ec7 Mon Sep 17 00:00:00 2001
+From 98104aeaddf60e81755ae39ffaac0af8a4d73493 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
-Subject: [PATCH 049/122] char: broadcom: Add vcio module
+Subject: [PATCH 049/126] char: broadcom: Add vcio module
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85322,10 +85322,10 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 83532363df9ebe5f7e8cea458bcfd9b67a0e815a Mon Sep 17 00:00:00 2001
+From bbcc4b0a7b02f5121ec6d3909e301cd8745a916d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
-Subject: [PATCH 050/122] firmware: bcm2835: Support ARCH_BCM270x
+Subject: [PATCH 050/126] firmware: bcm2835: Support ARCH_BCM270x
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85408,10 +85408,10 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From c1316c3428ecf0ef0ad3c39a6ff7e367b3483c4f Mon Sep 17 00:00:00 2001
+From 3aee9a3ae96fc98195c2dced5e736d5a48b85514 Mon Sep 17 00:00:00 2001
 From: Vincent Sanders <vincent.sanders@collabora.co.uk>
 Date: Wed, 30 Jan 2013 12:45:18 +0000
-Subject: [PATCH 051/122] bcm2835: add v4l2 camera device
+Subject: [PATCH 051/126] bcm2835: add v4l2 camera device
 
 - Supports raw YUV capture, preview, JPEG and H264.
 - Uses videobuf2 for data transfer, using dma_buf.
@@ -93153,10 +93153,10 @@ index 0000000000000000000000000000000000000000..9d1d11e4a53e510c04a416d92d195a7d
 +
 +#endif /* MMAL_VCHIQ_H */
 
-From 6b480eb543d3fb86623e58d6d0f884f67f5ba804 Mon Sep 17 00:00:00 2001
+From 55965f9245ae2d3f76e786602265c0acee7e4987 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
-Subject: [PATCH 052/122] scripts: Add mkknlimg and knlinfo scripts from tools
+Subject: [PATCH 052/126] scripts: Add mkknlimg and knlinfo scripts from tools
  repo
 
 The Raspberry Pi firmware looks for a trailer on the kernel image to
@@ -93676,10 +93676,10 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 94cbd8ee19d8f0e25c4af4598b07b0c22c5083ae Mon Sep 17 00:00:00 2001
+From 3e22a0b4652e890fa957b2f0c8f203c82dae93f1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 10 Aug 2015 09:49:15 +0100
-Subject: [PATCH 053/122] scripts/dtc: Update to upstream version 1.4.1
+Subject: [PATCH 053/126] scripts/dtc: Update to upstream version 1.4.1
 
 Includes the new localfixups format.
 
@@ -96530,10 +96530,10 @@ index ad9b05ae698b0495ecbda42ffcf4743555313a27..2595dfda020fd9e03f0beff5006f229d
 -#define DTC_VERSION "DTC 1.4.1-g53bf130b"
 +#define DTC_VERSION "DTC 1.4.1-g25efc119"
 
-From ef3f51080fa0d993456fa3635e442b845051b70a Mon Sep 17 00:00:00 2001
+From 949833a082ee10c4002ae38bc5ff719002f5628e Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
-Subject: [PATCH 054/122] BCM2708: Add core Device Tree support
+Subject: [PATCH 054/126] BCM2708: Add core Device Tree support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -106661,10 +106661,10 @@ index 0a07f9014944ed92a8e2e42983ae43be60b3e471..1967878a843461c3ff1f473b9a030eb0
  
  # Bzip2
 
-From 52e8a3802aa8428a69561607209bfe9b98cabde6 Mon Sep 17 00:00:00 2001
+From b2279fed6fed3d31a291ad70a99f9f78ad72c673 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
-Subject: [PATCH 055/122] BCM270x_DT: Add pwr_led, and the required "input"
+Subject: [PATCH 055/126] BCM270x_DT: Add pwr_led, and the required "input"
  trigger
 
 The "input" trigger makes the associated GPIO an input.  This is to support
@@ -106840,10 +106840,10 @@ index ddfcb2df3656cf0ab6aebd1fa3d624a6ec2e94e9..271563eb835f9018712e2076a88f341d
  	/* Set LED brightness level
  	 * Must not sleep. Use brightness_set_blocking for drivers
 
-From e958cbc43c1add6076ea3ed0aa17365335774024 Mon Sep 17 00:00:00 2001
+From bd8d69ec5255cfcbd180de34be0f33012d46a5ca Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
-Subject: [PATCH 056/122] fbdev: add FBIOCOPYAREA ioctl
+Subject: [PATCH 056/126] fbdev: add FBIOCOPYAREA ioctl
 
 Based on the patch authored by Ali Gholami Rudi at
     https://lkml.org/lkml/2009/7/13/153
@@ -107095,10 +107095,10 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From cf7188188aabe5b8ae10cf449ea6c9b0c6c29c90 Mon Sep 17 00:00:00 2001
+From 978324fba4d05f46f9d6031fad81051510806319 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
-Subject: [PATCH 057/122] Speed up console framebuffer imageblit function
+Subject: [PATCH 057/126] Speed up console framebuffer imageblit function
 
 Especially on platforms with a slower CPU but a relatively high
 framebuffer fill bandwidth, like current ARM devices, the existing
@@ -107307,10 +107307,10 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From 132a1f15dea64eef7dbf9cc5b98e1668cedb2eea Mon Sep 17 00:00:00 2001
+From a7c447247614e5f265e6db25099bc17fafbe8566 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
-Subject: [PATCH 058/122] enabling the realtime clock 1-wire chip DS1307 and
+Subject: [PATCH 058/126] enabling the realtime clock 1-wire chip DS1307 and
  1-wire on GPIO4 (as a module)
 
 1-wire: Add support for configuring pin for w1-gpio kernel module
@@ -107560,10 +107560,10 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From 3a29fd5c4e71ff439e60097ca14a4d97c8c63f5f Mon Sep 17 00:00:00 2001
+From cf6e96b086db65f9a98ab466a2fcc4a073ed8464 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 18 Dec 2013 22:16:19 +0000
-Subject: [PATCH 059/122] config: Enable CONFIG_MEMCG, but leave it disabled
+Subject: [PATCH 059/126] config: Enable CONFIG_MEMCG, but leave it disabled
  (due to memory cost). Enable with cgroup_enable=memory.
 
 ---
@@ -107613,10 +107613,10 @@ index 85bc9beb046d9a6deda2e3564f4d5bd01d6fc27b..4acdbef46a8f0556469b5580a39c18ce
   * css_tryget_online_from_dir - get corresponding css from a cgroup dentry
   * @dentry: directory dentry of interest
 
-From 7a094c94cc5e4275d62f541780238f86b7e1a944 Mon Sep 17 00:00:00 2001
+From 7e8c1c718caac29476b4532dc6b31969298d3db0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
-Subject: [PATCH 060/122] hid: Reduce default mouse polling interval to 60Hz
+Subject: [PATCH 060/126] hid: Reduce default mouse polling interval to 60Hz
 
 Reduces overhead when using X
 ---
@@ -107652,10 +107652,10 @@ index ae83af649a607f67239f1a64bf45dd4b5770cc7d..4a7af9d0b910f59d17421ce14138400d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From 844a5a997e65b9ba913904f020f88893087ba2b2 Mon Sep 17 00:00:00 2001
+From 829e3fbc9c26fda09c7fbbcd18ba82f890b58679 Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
-Subject: [PATCH 061/122] rpi-ft5406: Add touchscreen driver for pi LCD display
+Subject: [PATCH 061/126] rpi-ft5406: Add touchscreen driver for pi LCD display
 
 Fix driver detection failure Check that the buffer response is non-zero meaning the touchscreen was detected
 
@@ -108013,10 +108013,10 @@ index 227a107214a02deadcca3db202da265eba1fdd21..b0f6e33bd30c35664ceee057f4c3ad32
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 3b84c6d542a8066b50fc3efdd916c8a7b88b9d1f Mon Sep 17 00:00:00 2001
+From a0bb7fd95ba2cf472535622612cd450a67d57c86 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
-Subject: [PATCH 062/122] Improve __copy_to_user and __copy_from_user
+Subject: [PATCH 062/126] Improve __copy_to_user and __copy_from_user
  performance
 
 Provide a __copy_from_user that uses memcpy. On BCM2708, use
@@ -109591,10 +109591,10 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From d5dc9d3eb0f7177be235596e3009f8b53b4e25b5 Mon Sep 17 00:00:00 2001
+From 229ec73ed7f80802ee4531e77dc9f9f17aa4d270 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
-Subject: [PATCH 063/122] gpio-poweroff: Allow it to work on Raspberry Pi
+Subject: [PATCH 063/126] gpio-poweroff: Allow it to work on Raspberry Pi
 
 The Raspberry Pi firmware manages the power-down and reboot
 process. To do this it installs a pm_power_off handler, causing
@@ -109629,10 +109629,10 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From 78515e0aa6204095c519dce39d811d796cb9dc18 Mon Sep 17 00:00:00 2001
+From 456cc9c6aea54449e345ce35d5bedec82f1e1fed Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
-Subject: [PATCH 064/122] mfd: Add Raspberry Pi Sense HAT core driver
+Subject: [PATCH 064/126] mfd: Add Raspberry Pi Sense HAT core driver
 
 ---
  drivers/input/joystick/Kconfig           |   8 +
@@ -110497,10 +110497,10 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 92261bb1ae13c929b053aab7db4cc660d4565511 Mon Sep 17 00:00:00 2001
+From 78d7f25e0c5ac106b503718438905c7019fac2f4 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
-Subject: [PATCH 065/122] ASoC: Add support for HifiBerry DAC
+Subject: [PATCH 065/126] ASoC: Add support for HifiBerry DAC
 
 This adds a machine driver for the HifiBerry DAC.
 It is a sound card that can
@@ -110675,10 +110675,10 @@ index 0000000000000000000000000000000000000000..45f2b770ad9e67728ca599a7445d6ae9
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From b6df383dd105286109669674cf79c61b5f88bba9 Mon Sep 17 00:00:00 2001
+From 2a1788013f5edd5a4a2cbadfaf2925b24a29fc99 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
-Subject: [PATCH 066/122] ASoC: Add support for Rpi-DAC
+Subject: [PATCH 066/126] ASoC: Add support for Rpi-DAC
 
 ---
  sound/soc/bcm/Kconfig       |   7 +++
@@ -110962,10 +110962,10 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From 32447fa52c6b39d4447c53b0a7ae8a2096ee901e Mon Sep 17 00:00:00 2001
+From df70c2c133f6fc4d7120cef4d1d81036a907443a Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
-Subject: [PATCH 067/122] ASoC: wm8804: Implement MCLK configuration options,
+Subject: [PATCH 067/126] ASoC: wm8804: Implement MCLK configuration options,
  add 32bit support WM8804 can run with PLL frequencies of 256xfs and 128xfs
  for most sample rates. At 192kHz only 128xfs is supported. The existing
  driver selects 128xfs automatically for some lower samples rates. By using an
@@ -111014,10 +111014,10 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From cd919b3554a2544cf2600822593b6057d4297316 Mon Sep 17 00:00:00 2001
+From fdb0336dd40074201ffadcb567bab47238192555 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
-Subject: [PATCH 068/122] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
+Subject: [PATCH 068/126] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
  based on the patched WM8804 driver.
 
 Signed-off-by: Daniel Matuschek <daniel@matuschek.net>
@@ -111361,10 +111361,10 @@ index 0000000000000000000000000000000000000000..19dc953b7227ba86123fc7a2ba654499
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 9c1f52bc905674a484e6b9c5e91fbef279890c68 Mon Sep 17 00:00:00 2001
+From f2e7914949f17d216fd8d4bc87869489418e0a69 Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
-Subject: [PATCH 069/122] Add IQaudIO Sound Card support for Raspberry Pi
+Subject: [PATCH 069/126] Add IQaudIO Sound Card support for Raspberry Pi
 
 Set a limit of 0dB on Digital Volume Control
 
@@ -111694,10 +111694,10 @@ index 0000000000000000000000000000000000000000..4e8e6dec14bcf4a1ff286c43742d4097
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From fef54ca8d87499607d6cb086210e44126b304f6d Mon Sep 17 00:00:00 2001
+From fbc916e505a4aeb05ce50158c6e84a37a1882ac7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jul 2016 17:06:50 +0100
-Subject: [PATCH 070/122] iqaudio-dac: Compile fix - untested
+Subject: [PATCH 070/126] iqaudio-dac: Compile fix - untested
 
 ---
  sound/soc/bcm/iqaudio-dac.c | 6 +++++-
@@ -111721,10 +111721,10 @@ index 4e8e6dec14bcf4a1ff286c43742d4097249d6777..aa15bc4b49ca95edec905fddd8fd0a6d
  	if (dapm->dev != codec_dai->dev)
  		return 0;
 
-From 31bee6011867bb7a1846d35901b080a208669515 Mon Sep 17 00:00:00 2001
+From 3a6a5f368a4acfbed5452c98b71df3bb9e66508c Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
-Subject: [PATCH 071/122] Added support for HiFiBerry DAC+
+Subject: [PATCH 071/126] Added support for HiFiBerry DAC+
 
 The driver is based on the HiFiBerry DAC driver. However HiFiBerry DAC+ uses
 a different codec chip (PCM5122), therefore a new driver is necessary.
@@ -112354,10 +112354,10 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From f11ffc75b1a5ba748f160765164337eabea0b6e1 Mon Sep 17 00:00:00 2001
+From 11da66cf778a33b6260dbee25f8b6a026077bc74 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
-Subject: [PATCH 072/122] Added driver for HiFiBerry Amp amplifier add-on board
+Subject: [PATCH 072/126] Added driver for HiFiBerry Amp amplifier add-on board
 
 The driver contains a low-level hardware driver for the TAS5713 and the
 drivers for the Raspberry Pi I2S subsystem.
@@ -113190,10 +113190,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From e06a867b4795e7c7e8dd9d13257a77494ea5f610 Mon Sep 17 00:00:00 2001
+From a0fe24a015581d82174ae5ad95a2b3fb78a66964 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Dec 2016 16:26:54 +0000
-Subject: [PATCH 073/122] Revert "Added driver for HiFiBerry Amp amplifier
+Subject: [PATCH 073/126] Revert "Added driver for HiFiBerry Amp amplifier
  add-on board"
 
 This reverts commit 3e6b00833d92a50cbcc9922deb6e1bc8fcdbb587.
@@ -114015,10 +114015,10 @@ index 8f019e04898754d2f87e9630137be9e8f612a342..00000000000000000000000000000000
 -
 -#endif  /* _TAS5713_H */
 
-From adf38c2875a20b75d2870d9e9897f711835811ea Mon Sep 17 00:00:00 2001
+From a38a031c9e5f5ac9666559849624d45e03cdecd7 Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
-Subject: [PATCH 074/122] Update ds1307 driver for device-tree support
+Subject: [PATCH 074/126] Update ds1307 driver for device-tree support
 
 Signed-off-by: Ryan Coe <bluemrp9@gmail.com>
 ---
@@ -114045,10 +114045,10 @@ index 4e31036ee2596dec93accd26f627c5b95591ae9f..b92044cf03e750afa521a93519500e9d
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From 23122064c9a8be975b07aad67e74213cf9fdc7d8 Mon Sep 17 00:00:00 2001
+From 32a492700e8b8529453eb92e383b1937f089b525 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
-Subject: [PATCH 075/122] Add driver for rpi-proto
+Subject: [PATCH 075/126] Add driver for rpi-proto
 
 Forward port of 3.10.x driver from https://github.com/koalo
 We are using a custom board and would like to use rpi 3.18.x
@@ -114263,10 +114263,10 @@ index 0000000000000000000000000000000000000000..9db678e885efd63d84d60a098a84ed67
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 23e17d37207fc0039b141c8988644c24885ba10a Mon Sep 17 00:00:00 2001
+From 781f54e3321c508c8c751a14fc3595d4ae8c9054 Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
-Subject: [PATCH 076/122] RaspiDAC3 support
+Subject: [PATCH 076/126] RaspiDAC3 support
 
 Signed-off-by: Jan Grulich <jan@grulich.eu>
 
@@ -114509,10 +114509,10 @@ index 0000000000000000000000000000000000000000..dd9eeea2af0382307f437e6db09d1546
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From 328c723f04e73cc2484ae7d5d6f317fc22fbd386 Mon Sep 17 00:00:00 2001
+From 341233e6fd362244d9567c68d5cd91cb6c48da88 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
-Subject: [PATCH 077/122] Add Support for JustBoom Audio boards
+Subject: [PATCH 077/126] Add Support for JustBoom Audio boards
 
 justboom-dac: Adjust for ALSA API change
 
@@ -114966,10 +114966,10 @@ index 0000000000000000000000000000000000000000..91acb666380faa3c0deb2230f8a0f8bb
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From 070a41a6ef5eb0427354b758ce45fee7476e8e84 Mon Sep 17 00:00:00 2001
+From 5984a7e19d18881abe5c4b65cacef8b44bc7606a Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
-Subject: [PATCH 078/122] ARM: adau1977-adc: Add basic machine driver for
+Subject: [PATCH 078/126] ARM: adau1977-adc: Add basic machine driver for
  adau1977 codec driver.
 
 This commit adds basic support for the codec usage including: Device tree overlay,
@@ -115151,10 +115151,10 @@ index 0000000000000000000000000000000000000000..6e2ee027926ee63c89222f75ceb89e3d
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From d3f05a999f9f646a4fad423073c2bfd16ac8cdb7 Mon Sep 17 00:00:00 2001
+From e1d49ab6ab68353e4b07e0b7a0d04cc51f483b49 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
-Subject: [PATCH 079/122] New AudioInjector.net Pi soundcard with low jitter
+Subject: [PATCH 079/126] New AudioInjector.net Pi soundcard with low jitter
  audio in and out.
 
 Contains the sound/soc/bcm ALSA machine driver and necessary alterations to the Kconfig and Makefile.
@@ -115405,10 +115405,10 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 6cdf489fe02f677a7a5312dd53f5b5dfa1632487 Mon Sep 17 00:00:00 2001
+From fc69717b48db3b7dc01de5ecaeca65c6204799dc Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
-Subject: [PATCH 080/122] Add IQAudIO Digi WM8804 board support
+Subject: [PATCH 080/126] Add IQAudIO Digi WM8804 board support
 
 Support IQAudIO Digi board with iqaudio_digi machine driver and
  iqaudio-digi-wm8804-audio overlay.
@@ -115708,10 +115708,10 @@ index 0000000000000000000000000000000000000000..9b6e829bcb5b1762a853775e78163196
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 922b72225da0a94bdc3a2c7a52ac04431e67a6a8 Mon Sep 17 00:00:00 2001
+From 9a4a4b46d8e0393d552df4802ee81c7e3107a88b Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
-Subject: [PATCH 081/122] New driver for RRA DigiDAC1 soundcard using WM8741 +
+Subject: [PATCH 081/126] New driver for RRA DigiDAC1 soundcard using WM8741 +
  WM8804
 
 ---
@@ -116184,10 +116184,10 @@ index 0000000000000000000000000000000000000000..446796e7e4c14a7d95b2f2a01211d9a0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From 1a76a9a2ca9445123234adc7b30e448216da6017 Mon Sep 17 00:00:00 2001
+From 87f27e8fb1b8aad86838390780c9b18b3ec8ce45 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
-Subject: [PATCH 082/122] Add support for Dion Audio LOCO DAC-AMP HAT
+Subject: [PATCH 082/126] Add support for Dion Audio LOCO DAC-AMP HAT
 
 Using dedicated machine driver and pcm5102a codec driver.
 
@@ -116360,10 +116360,10 @@ index 0000000000000000000000000000000000000000..89e65317512bc774453ac8d0d5b0ff98
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From 38964afabad4b0ae7e3d50153daf97dd98277597 Mon Sep 17 00:00:00 2001
+From be51160525620e1ae9466eb654f40f572811738b Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
-Subject: [PATCH 083/122] Allo Piano DAC boards: Initial 2 channel (stereo)
+Subject: [PATCH 083/126] Allo Piano DAC boards: Initial 2 channel (stereo)
  support (#1645)
 
 Add initial 2 channel (stereo) support for Allo Piano DAC (2.0/2.1) boards,
@@ -116570,10 +116570,10 @@ index 0000000000000000000000000000000000000000..8e8e62e5a36a279b425ed4655cfbac99
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 32c97c8263ee9440ac09cf4c117a00563ba86748 Mon Sep 17 00:00:00 2001
+From 2b118b3d839c96a49195e76fc1e2c56f6efdc177 Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
-Subject: [PATCH 084/122] Support for Blokas Labs pisound board
+Subject: [PATCH 084/126] Support for Blokas Labs pisound board
 
 Pisound dynamic overlay (#1760)
 
@@ -117750,10 +117750,10 @@ index 0000000000000000000000000000000000000000..4b8545487d06e4ea70073a5d063fb231
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From 96f367ff7d360c52f563775dd1e9cee71aa63c6d Mon Sep 17 00:00:00 2001
+From 623658bec57485daecf0b62095533005b97f44e9 Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
-Subject: [PATCH 085/122] rpi_display: add backlight driver and overlay
+Subject: [PATCH 085/126] rpi_display: add backlight driver and overlay
 
 Add a mailbox-driven backlight controller for the Raspberry Pi DSI
 touchscreen display. Requires updated GPU firmware to recognise the
@@ -117922,10 +117922,10 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 859fe9e43315cc5f8ec150814ac4d841c9bfdcf1 Mon Sep 17 00:00:00 2001
+From 41b5fdbdfc6f620f3c9e27e78e145c5b16db9733 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
-Subject: [PATCH 086/122] bcm2835-virtgpio: Virtual GPIO driver
+Subject: [PATCH 086/126] bcm2835-virtgpio: Virtual GPIO driver
 
 Add a virtual GPIO driver that uses the firmware mailbox interface to
 request that the VPU toggles LEDs.
@@ -118199,10 +118199,10 @@ index b0f6e33bd30c35664ceee057f4c3ad32b914291d..e92278968b2b979db2a1f855f70e7aaf
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 7968227bc3b1b0b1297b304fbfd4a76de6a1f40e Mon Sep 17 00:00:00 2001
+From cd0910eafeb92301bdd74f837c037d7df56594f5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
-Subject: [PATCH 087/122] amba_pl011: Don't use DT aliases for numbering
+Subject: [PATCH 087/126] amba_pl011: Don't use DT aliases for numbering
 
 The pl011 driver looks for DT aliases of the form "serial<n>",
 and if found uses <n> as the device ID. This can cause
@@ -118231,10 +118231,10 @@ index e2c33b9528d82ed7a2c27d083d7b1d222da68178..5a11ff833e1fd112ba04df3a427cd94b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From 0dba8271302e1c9a96f1ead8f5a7b9a0ffc7325e Mon Sep 17 00:00:00 2001
+From 4fd4dfaeaa45dabafd295bc1fabdee97f51db9dc Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
-Subject: [PATCH 088/122] OF: DT-Overlay configfs interface
+Subject: [PATCH 088/126] OF: DT-Overlay configfs interface
 
 This is a port of Pantelis Antoniou's v3 port that makes use of the
 new upstreamed configfs support for binary attributes.
@@ -118666,10 +118666,10 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From 7599baf5d2f2a063d430fce4de57db739ac1d05c Mon Sep 17 00:00:00 2001
+From 2ab49319b885c35f13a42916631dfb938325dff9 Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
-Subject: [PATCH 089/122] brcm: adds support for BCM43341 wifi
+Subject: [PATCH 089/126] brcm: adds support for BCM43341 wifi
 
 brcmfmac: Disable power management
 
@@ -118832,10 +118832,10 @@ index d0407d9ad7827cd756b6311410ffe2d9a7cacc78..f1fb8a3c7a3211e8429585861f2f42e0
  #define BRCM_CC_4335_CHIP_ID		0x4335
  #define BRCM_CC_4339_CHIP_ID		0x4339
 
-From 409e8d08947ff33556f6bcb8eb6bfdc47613ce6b Mon Sep 17 00:00:00 2001
+From da4c77489f6060aae18847f7311b1df2c53dd7f6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
-Subject: [PATCH 090/122] hci_h5: Don't send conf_req when ACTIVE
+Subject: [PATCH 090/126] hci_h5: Don't send conf_req when ACTIVE
 
 Without this patch, a modem and kernel can continuously bombard each
 other with conf_req and conf_rsp messages, in a demented game of tag.
@@ -118858,10 +118858,10 @@ index 0879d64b1caf58afb6e5d494c07d9ab7e7cdf983..5161ab30fd533d50f516bb93d5b9f402
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From 5fd6ff953ace9d64a39412f410b4a6eb09dd4711 Mon Sep 17 00:00:00 2001
+From 83c7b3c8210b305b4f4c444123cbf571bdfe45cd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
-Subject: [PATCH 091/122] config: Add default configs
+Subject: [PATCH 091/126] config: Add default configs
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1297 +++++++++++++++++++++++++++++++++++
@@ -121488,10 +121488,10 @@ index 0000000000000000000000000000000000000000..8acee9f31202ec14f2933d92dd70831c
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 7452484b501a3dd0ca66226de11cf4fb9a576390 Mon Sep 17 00:00:00 2001
+From f73229cccfd305e29341e82387423756651b495b Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
-Subject: [PATCH 092/122] Add arm64 configuration and device tree differences.
+Subject: [PATCH 092/126] Add arm64 configuration and device tree differences.
  Disable MMC_BCM2835_SDHOST and MMC_BCM2835 since these drivers are crashing
  at the moment.
 
@@ -122906,10 +122906,10 @@ index 0000000000000000000000000000000000000000..d7406f5a4620151044b8f716b4d10bb8
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2708_VCHIQ=n
 
-From d5f278b5d66aaae13361aa90bf4a06a9babf5746 Mon Sep 17 00:00:00 2001
+From 893731162036cdde6253fc5897847eff1ba8d9f7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 7 Mar 2016 15:05:11 +0000
-Subject: [PATCH 093/122] vchiq_arm: Tweak the logging output
+Subject: [PATCH 093/126] vchiq_arm: Tweak the logging output
 
 Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 ---
@@ -122984,10 +122984,10 @@ index 2c98da4307dff994a00dc246574ef0aaee05d5da..160db24aeea33a8296923501009c1f02
  
  		switch (type) {
 
-From b65b8cb1ff93d43d24558076bb81f19b1ab5ea50 Mon Sep 17 00:00:00 2001
+From 1531a7c935fe10425e1ff2342987056423b5965a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 14:16:25 +0000
-Subject: [PATCH 094/122] vchiq_arm: Access the dequeue_pending flag locked
+Subject: [PATCH 094/126] vchiq_arm: Access the dequeue_pending flag locked
 
 Reading through this code looking for another problem (now found in userland)
 the use of dequeue_pending outside a lock didn't seem safe.
@@ -123045,10 +123045,10 @@ index 7b6cd4d80621e38ff6d47fcd87b45fbe9cd4259b..d8669fa7f39b077877eca1829ba9538b
  
  	return add_completion(instance, reason, header, user_service,
 
-From 1236ef13699c7ce7cb486c13c244be0038419918 Mon Sep 17 00:00:00 2001
+From 05b4add4ce45d8ed80e1971d4370213c03283e00 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 20:53:47 +0000
-Subject: [PATCH 095/122] vchiq_arm: Service callbacks must not fail
+Subject: [PATCH 095/126] vchiq_arm: Service callbacks must not fail
 
 Service callbacks are not allowed to return an error. The internal callback
 that delivers events and messages to user tasks does not enqueue them if
@@ -123074,10 +123074,10 @@ index d8669fa7f39b077877eca1829ba9538bf2e21a82..54552c6ce54f413c9781ba279b936f98
  		DEBUG_TRACE(SERVICE_CALLBACK_LINE);
  	}
 
-From 42c9df04946a82e2e84ce093e9fe8e0e00183e05 Mon Sep 17 00:00:00 2001
+From 6743ef891cf68252c0d2f6db0e30878bfeb4d075 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 21 Apr 2016 13:49:32 +0100
-Subject: [PATCH 096/122] vchiq_arm: Add completion records under the mutex
+Subject: [PATCH 096/126] vchiq_arm: Add completion records under the mutex
 
 An issue was observed when flushing openmax components
 which generate a large number of messages returning
@@ -123140,10 +123140,10 @@ index 54552c6ce54f413c9781ba279b936f98be4f47b0..bde8955b7d8505d73579b77b5b392154
  
  	return VCHIQ_SUCCESS;
 
-From e027b929fb8e3c2ca6ee3b9c26104cd88a6ad4b6 Mon Sep 17 00:00:00 2001
+From 476463d6d4adc9379860d16e245928f740a5aec4 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 20 Jun 2016 13:51:44 +0100
-Subject: [PATCH 097/122] vchiq_arm: Avoid use of mutex in add_completion
+Subject: [PATCH 097/126] vchiq_arm: Avoid use of mutex in add_completion
 
 Claiming the completion_mutex within add_completion did prevent some
 messages appearing twice, but provokes a deadlock caused by vcsm using
@@ -123337,10 +123337,10 @@ index 160db24aeea33a8296923501009c1f02bc41e599..71a3bedc55314f3b22dbff40c05dedf0
  		up(&state->slot_available_event);
  	}
 
-From 36afbf3ec01bb2c073b99d9f8e09e72d3aba6b08 Mon Sep 17 00:00:00 2001
+From 94625bf75e63068de1dec7f5955ce68d7780b9b5 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:14:10 -0700
-Subject: [PATCH 098/122] staging/vchi: Convert to current get_user_pages()
+Subject: [PATCH 098/126] staging/vchi: Convert to current get_user_pages()
  arguments.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123377,10 +123377,10 @@ index e5cdda12c7e5c35c69eb96991cfdb8326def167f..085d37588c59198b4e5f00b9249bb842
  		num_pages,                /* len */
  		0,                        /* gup_flags */
 
-From 78c3ef34645364c0313d5322eed35c608e75ed32 Mon Sep 17 00:00:00 2001
+From afa0928172d77ae7cf2d94975e0d47a625f76854 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:16:03 -0700
-Subject: [PATCH 099/122] staging/vchi: Update for rename of
+Subject: [PATCH 099/126] staging/vchi: Update for rename of
  page_cache_release() to put_page().
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123425,10 +123425,10 @@ index 085d37588c59198b4e5f00b9249bb8421695854f..5a2b8fb459ebe086ec229f37b6381bdb
  	kfree(pages);
  }
 
-From 7bc3755fca9fc00495e6ad3857bbf75756a0ad74 Mon Sep 17 00:00:00 2001
+From 53930c65fa8e4bd78ecc765f47f7874d5bea1610 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:21:17 -0700
-Subject: [PATCH 100/122] drivers/vchi: Remove dependency on CONFIG_BROKEN.
+Subject: [PATCH 100/126] drivers/vchi: Remove dependency on CONFIG_BROKEN.
 
 The driver builds now.
 
@@ -123450,10 +123450,10 @@ index 9676fb29075a457109e4d4235f086987aec74868..db8e1beb89f9f8c48ea5964016c8285e
  	help
  		Kernel to VideoCore communication interface for the
 
-From 47fc16ef621f8b834e809715c77f601e104caa3e Mon Sep 17 00:00:00 2001
+From b4b34d440e5bf77e017fcf162f967179abf51984 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
-Subject: [PATCH 101/122] raspberrypi-firmware: Export the general transaction
+Subject: [PATCH 101/126] raspberrypi-firmware: Export the general transaction
  function.
 
 The vc4-firmware-kms module is going to be doing the MBOX FB call.
@@ -123497,10 +123497,10 @@ index e92278968b2b979db2a1f855f70e7aafb224fa98..09e3d871d110eb0762ebdb5ea3293537
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 9ae6d3437ea35dacb0bc1353d7c6646dd2b7913d Mon Sep 17 00:00:00 2001
+From a50f50a57dfd2de0803c126d33527347be3b2e40 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
-Subject: [PATCH 102/122] raspberrypi-firmware: Define the MBOX channel in the
+Subject: [PATCH 102/126] raspberrypi-firmware: Define the MBOX channel in the
  header.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123522,10 +123522,10 @@ index 09e3d871d110eb0762ebdb5ea329353738d58661..2859db09e25bb945251e85edb39bc434
  
  enum rpi_firmware_property_status {
 
-From 23c8fb1fa456520a1abe7a50484eee18e94f09bc Mon Sep 17 00:00:00 2001
+From 0aefda6c34dc1903faba3b3565c2342daaddb3da Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
-Subject: [PATCH 103/122] drm/vc4: Add a mode for using the closed firmware for
+Subject: [PATCH 103/126] drm/vc4: Add a mode for using the closed firmware for
  display.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -124292,10 +124292,10 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From 26a8008c3e11309384b26b46cfc4c6499c2fe676 Mon Sep 17 00:00:00 2001
+From cfbfd37fc669472f667e16ff8206867cbe184650 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 17 Sep 2016 15:07:10 +0200
-Subject: [PATCH 104/122] i2c: bcm2835: Fix hang for writing messages larger
+Subject: [PATCH 104/126] i2c: bcm2835: Fix hang for writing messages larger
  than 16 bytes
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124385,10 +124385,10 @@ index d4f3239b56865919e1b781b20a7c5ebcd76b4eb9..f283b714aa79e2e4685ed95b04b6b289
  	i2c_dev->msg_buf_remaining = msg->len;
  	reinit_completion(&i2c_dev->completion);
 
-From c91628e1f62406194456f78889477efa6ebe1592 Mon Sep 17 00:00:00 2001
+From c046422b6b934be40a16ab5766856ddd7dbc74be Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 18:24:38 +0200
-Subject: [PATCH 105/122] i2c: bcm2835: Protect against unexpected TXW/RXR
+Subject: [PATCH 105/126] i2c: bcm2835: Protect against unexpected TXW/RXR
  interrupts
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124513,10 +124513,10 @@ index f283b714aa79e2e4685ed95b04b6b289f7e9eee7..d2ba1a4de36af512e8e3c97251bd3537
  		return -ETIMEDOUT;
  	}
 
-From 878f3d3cb001a41cefc17e11e5b527b576478959 Mon Sep 17 00:00:00 2001
+From a796f385989cf751c6021771b8393a45cc964282 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Mon, 19 Sep 2016 17:19:41 +0200
-Subject: [PATCH 106/122] i2c: bcm2835: Use dev_dbg logging on transfer errors
+Subject: [PATCH 106/126] i2c: bcm2835: Use dev_dbg logging on transfer errors
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124548,10 +124548,10 @@ index d2ba1a4de36af512e8e3c97251bd3537ae61591a..54d510abd46a117c9238fc6d7edec840
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From dd301c9f8456669afa77139328d78bac9f2fcb48 Mon Sep 17 00:00:00 2001
+From f7823a7a9b751637d754dbc9f8c372e5d2f89206 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Thu, 22 Sep 2016 22:05:50 +0200
-Subject: [PATCH 107/122] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
+Subject: [PATCH 107/126] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124595,10 +124595,10 @@ index 54d510abd46a117c9238fc6d7edec84019d1f60d..565ef69ce61423544dc0558c85ef318b
  
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
 
-From 17019eef014c360549b56b67f8f6448e718b9496 Mon Sep 17 00:00:00 2001
+From ea6e7ccb8148543d8c6d93ff9ce318c5595a952b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:54:27 +0200
-Subject: [PATCH 108/122] i2c: bcm2835: Add support for Repeated Start
+Subject: [PATCH 108/126] i2c: bcm2835: Add support for Repeated Start
  Condition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124780,10 +124780,10 @@ index 565ef69ce61423544dc0558c85ef318b0ae9c324..241e08ae7c27cec23fad3c1bf3ebad3a
  
  static u32 bcm2835_i2c_func(struct i2c_adapter *adap)
 
-From 90f2d2d5fb2aa94eafd361372b6a55fa3ad1b029 Mon Sep 17 00:00:00 2001
+From 591327b2fb94f5ad8b60eeb1cccf95c244dd5170 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:57:17 +0200
-Subject: [PATCH 109/122] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
+Subject: [PATCH 109/126] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124820,10 +124820,10 @@ index 241e08ae7c27cec23fad3c1bf3ebad3a4d2a8e6f..d2085dd3742eabebc537621968088261
  		bcm2835_i2c_writel(i2c_dev, BCM2835_I2C_C,
  				   BCM2835_I2C_C_CLEAR);
 
-From d0724c34a0fc6d93228c19bede299e63afe0c036 Mon Sep 17 00:00:00 2001
+From 3d9abe0bcee2568e4893aae0aa281f1e747e20eb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 27 Sep 2016 01:00:08 +0200
-Subject: [PATCH 110/122] i2c: bcm2835: Add support for dynamic clock
+Subject: [PATCH 110/126] i2c: bcm2835: Add support for dynamic clock
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124939,10 +124939,10 @@ index d2085dd3742eabebc537621968088261f8dc7ea8..c3436f627028477f7e21b47e079fd5ab
  	irq = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
  	if (!irq) {
 
-From 0cc815d16e01c81698ecb53c57222ffb003377bf Mon Sep 17 00:00:00 2001
+From b98f544f2297bcb0dbf9197d1015a0dd2461b58e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
-Subject: [PATCH 111/122] i2c: bcm2835: Add debug support
+Subject: [PATCH 111/126] i2c: bcm2835: Add debug support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -125131,10 +125131,10 @@ index c3436f627028477f7e21b47e079fd5ab06ec188a..8642f580ce41803bd22c76a0fa80d083
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 683eb2a626bdf358dd1d447bfe3b0e7d112d8024 Mon Sep 17 00:00:00 2001
+From 504f40794f52d8e68ed09cd4a5befc4594a7a6b9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 31 Dec 2016 14:15:50 +0000
-Subject: [PATCH 112/122] arm64: Add CONFIG_ARCH_BCM2835
+Subject: [PATCH 112/126] arm64: Add CONFIG_ARCH_BCM2835
 
 ---
  arch/arm64/configs/bcmrpi3_defconfig | 1 +
@@ -125150,10 +125150,10 @@ index d7406f5a4620151044b8f716b4d10bb818648e06..53da5c7a33e5898a66e549fb0c39fe3d
  CONFIG_BCM2708_VCHIQ=n
 +CONFIG_ARCH_BCM2835=y
 
-From 8ec76aa6373a8c90eac7d8c8e980fa333ff69464 Mon Sep 17 00:00:00 2001
+From 3b1db21ebe44c4a08d2d54e84f130a9fd487f497 Mon Sep 17 00:00:00 2001
 From: Alex Tucker <alex@floop.org.uk>
 Date: Tue, 13 Dec 2016 19:50:18 +0000
-Subject: [PATCH 113/122] Add support for Silicon Labs Si7013/20/21
+Subject: [PATCH 113/126] Add support for Silicon Labs Si7013/20/21
  humidity/temperature sensor.
 
 ---
@@ -125228,10 +125228,10 @@ index f6d134c095af2398fc55ae7d2b0e86456c30627c..31bda8da4cb6a56bfe493a81b9189009
  	};
  };
 
-From 3b6760e6f2f03b620e4e88d67d3b640c56ce7fd3 Mon Sep 17 00:00:00 2001
+From f1b7b8223e554bafa84153b47a8455a97ede511f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 3 Jan 2017 21:27:46 +0000
-Subject: [PATCH 114/122] Document the si7020 option
+Subject: [PATCH 114/126] Document the si7020 option
 
 ---
  arch/arm/boot/dts/overlays/README | 3 +++
@@ -125252,10 +125252,10 @@ index 81d991803be335e5a1bc3bb0a8c7a2c9f5c392bd..e8fa4ccb44c34a20485c4e6155467af9
  Name:   i2c0-bcm2708
  Info:   Enable the i2c_bcm2708 driver for the i2c0 bus. Not all pin combinations
 
-From 4ef541bea608cd9f84bc76c8092fafaad1702e3f Mon Sep 17 00:00:00 2001
+From 42d2251f9849b14b58402da3c177a2eb325a182a Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Thu, 5 Jan 2017 02:38:16 +0200
-Subject: [PATCH 115/122] pisound improvements:
+Subject: [PATCH 115/126] pisound improvements:
 
 * Added a writable sysfs object to enable scripts / user space software
 to blink MIDI activity LEDs for variable duration.
@@ -125549,10 +125549,10 @@ index 4b8545487d06e4ea70073a5d063fb2310b3b94d0..ba70734b89e61a11201657406223f0b3
  };
  
 
-From 425e9111b1dfad787b1f787ec5086fdf1893584e Mon Sep 17 00:00:00 2001
+From 7a6348a0ef0c816a772df87b67f42db4e8ecd7b1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:23:06 +0000
-Subject: [PATCH 116/122] Revert "Revert "Added driver for HiFiBerry Amp
+Subject: [PATCH 116/126] Revert "Revert "Added driver for HiFiBerry Amp
  amplifier add-on board""
 
 This reverts commit bf84babd8fffcb79c60f1342c2416f8e1e4b7af9.
@@ -126376,10 +126376,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 15550aafac107a499180a103bcaceed80f37dacd Mon Sep 17 00:00:00 2001
+From 7aa495fd4a95be275e8174a87a07c7f24f4b9a44 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:42:09 +0000
-Subject: [PATCH 117/122] hifiberry-amp: Adjust for ALSA object refactoring
+Subject: [PATCH 117/126] hifiberry-amp: Adjust for ALSA object refactoring
 
 See: https://github.com/raspberrypi/linux/issues/1775
 ---
@@ -126404,10 +126404,10 @@ index 9b2713861dcbed751842ca29c88eb1eae5867411..560234d58a6b0a6e7fd3a63e8de73339
  
  
 
-From d3a7daff54ea1d57654aa2be744d6173441b5e35 Mon Sep 17 00:00:00 2001
+From 45c5e3bb6025a71296f677060e32a1f9f36f6f15 Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Sun, 8 Jan 2017 15:58:54 +0200
-Subject: [PATCH 118/122] bcm2835-i2s: Changes for allowing asymmetric sample
+Subject: [PATCH 118/126] bcm2835-i2s: Changes for allowing asymmetric sample
  formats.
 
 This is achieved by making changes only to the requested
@@ -126497,10 +126497,10 @@ index 6ba20498202ed36906b52096893a88867a79269f..171c2401dfe192740fca3356268aff64
  
  	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);
 
-From a268f59a304d04349f3a0358db1f434e47cda8b6 Mon Sep 17 00:00:00 2001
+From efccc436e8c92a264cf87cc63786f62b04ee514c Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Tue, 10 Jan 2017 16:05:41 +0000
-Subject: [PATCH 119/122] Add driver_name property
+Subject: [PATCH 119/126] Add driver_name property
 
 Add driver name property for use with 5.1 passthrough audio in LibreElec and other Kodi based OSs
 ---
@@ -126520,10 +126520,10 @@ index 8fd50dbe681508a2cfe8fdde1c9fedbe9a507fa7..05a224ec712d06b8b7587ab6b8bb562d
  	.dai_link     = snd_rpi_justboom_dac_dai,
  	.num_links    = ARRAY_SIZE(snd_rpi_justboom_dac_dai),
 
-From ad475b3f75da457818fa6fab1c1e2f89f453dc07 Mon Sep 17 00:00:00 2001
+From f325733abda5130df8f1f26d826a03538ef6575e Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Tue, 10 Jan 2017 16:11:04 +0000
-Subject: [PATCH 120/122] Add driver_name paramater
+Subject: [PATCH 120/126] Add driver_name paramater
 
 Add driver_name parameter for use with 5.1 passthrough audio in LibreElec and other Kodi OSs
 ---
@@ -126543,10 +126543,10 @@ index 91acb666380faa3c0deb2230f8a0f8bbec59417b..abfdc5c4dd5811e6847bddda4921abe3
  	.dai_link     = snd_rpi_justboom_digi_dai,
  	.num_links    = ARRAY_SIZE(snd_rpi_justboom_digi_dai),
 
-From 987aadab51987bac29470f3ee200fa8bfa2eae6b Mon Sep 17 00:00:00 2001
+From 9a5475f6f85e40500f4120e318f84b974c19c0b7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 Jan 2017 13:01:21 +0000
-Subject: [PATCH 121/122] BCM270X_DT: Add pi3-disable-wifi overlay
+Subject: [PATCH 121/126] BCM270X_DT: Add pi3-disable-wifi overlay
 
 pi3-disable-wifi is a minimal overlay to disable the onboard WiFi.
 
@@ -126607,10 +126607,10 @@ index 0000000000000000000000000000000000000000..017199554bf2f4e381efcc7bb71e750c
 +	};
 +};
 
-From 5c94b3839b261c3c73893677ab6e2355a1177b74 Mon Sep 17 00:00:00 2001
+From 6b6de5861eec98a4f765cc61d0eecddb152e6373 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
-Subject: [PATCH 122/122] ARM64: Make it work again on 4.9 (#1790)
+Subject: [PATCH 122/126] ARM64: Make it work again on 4.9 (#1790)
 
 * Invoke the dtc compiler with the same options used in arm mode.
 * ARM64 now uses the bcm2835 platform just like ARM32.
@@ -127014,3 +127014,186 @@ index 53da5c7a33e5898a66e549fb0c39fe3da555ca87..c7e891d72969a388d9b135a36dbfc9c9
  CONFIG_LIBCRC32C=y
 -CONFIG_BCM2708_VCHIQ=n
 -CONFIG_ARCH_BCM2835=y
+
+From b00cfaf9d203423b82499a3e05e94ed4d7e95913 Mon Sep 17 00:00:00 2001
+From: Electron752 <mzoran@crowfest.net>
+Date: Sat, 14 Jan 2017 02:54:26 -0800
+Subject: [PATCH 123/126] ARM64: Enable Kernel Address Space Randomization
+ (#1792)
+
+Randomization allows the mapping between virtual addresses and physical
+address to be different on each boot.  This makes it more difficult
+to exploit security vulnerabilities that require knowledge of fixed
+hardware addresses.
+
+The firmware generates a 8 byte random number during bootup and stores
+it in the device tree under chosen/kaslr-seed. This number is used
+to randomize the address mapping.
+
+This change enables this feature in the build configuration for ARM64.
+
+Signed-off-by: Michael Zoran <mzoran@crowfest.net>
+---
+ arch/arm64/configs/bcmrpi3_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/configs/bcmrpi3_defconfig b/arch/arm64/configs/bcmrpi3_defconfig
+index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..974d8889c0cf695eb88b57bbef11bc5aa556b635 100644
+--- a/arch/arm64/configs/bcmrpi3_defconfig
++++ b/arch/arm64/configs/bcmrpi3_defconfig
+@@ -53,6 +53,7 @@ CONFIG_ARMV8_DEPRECATED=y
+ CONFIG_SWP_EMULATION=y
+ CONFIG_CP15_BARRIER_EMULATION=y
+ CONFIG_SETEND_EMULATION=y
++CONFIG_RANDOMIZE_BASE=y
+ CONFIG_CMDLINE="console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
+ CONFIG_BINFMT_MISC=y
+ CONFIG_COMPAT=y
+
+From b1dfb870425346b48c7b588eb3bd50a4a629cd7c Mon Sep 17 00:00:00 2001
+From: Michael Zoran <mzoran@crowfest.net>
+Date: Sun, 15 Jan 2017 07:31:59 -0800
+Subject: [PATCH 124/126] ARM64: Enable RTL8187/RTL8192CU wifi in build config
+
+These drivers build now, so they can be enabled back
+in the build configuration just like they are for
+32 bit.
+
+Signed-off-by: Michael Zoran <mzoran@crowfest.net>
+---
+ arch/arm64/configs/bcmrpi3_defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/configs/bcmrpi3_defconfig b/arch/arm64/configs/bcmrpi3_defconfig
+index 974d8889c0cf695eb88b57bbef11bc5aa556b635..4670a490dfb1e582ec24a3b39a3cb9b2488b1864 100644
+--- a/arch/arm64/configs/bcmrpi3_defconfig
++++ b/arch/arm64/configs/bcmrpi3_defconfig
+@@ -531,6 +531,8 @@ CONFIG_RT2800USB_RT3573=y
+ CONFIG_RT2800USB_RT53XX=y
+ CONFIG_RT2800USB_RT55XX=y
+ CONFIG_RT2800USB_UNKNOWN=y
++CONFIG_RTL8187=m
++CONFIG_RTL8192CU=m
+ CONFIG_USB_ZD1201=m
+ CONFIG_ZD1211RW=m
+ CONFIG_MAC80211_HWSIM=m
+
+From 919a5200ce78100c08f4dc1e6c2964acc60a4976 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Mon, 16 Jan 2017 14:53:12 +0000
+Subject: [PATCH 125/126] BCM270X_DT: Add spi0-cs overlay
+
+The spi0-cs overlay allows the software chip selectts to be modified
+using the cs0_pin and cs1_pin parameters.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ arch/arm/boot/dts/overlays/Makefile            |  1 +
+ arch/arm/boot/dts/overlays/README              |  9 +++++++-
+ arch/arm/boot/dts/overlays/spi0-cs-overlay.dts | 29 ++++++++++++++++++++++++++
+ 3 files changed, 38 insertions(+), 1 deletion(-)
+ create mode 100644 arch/arm/boot/dts/overlays/spi0-cs-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index f1191c1ded82490be5f793ab6483bc5af5891db2..45fafd5c39bdc6e80b12e49d3bcd281638bec471 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -83,6 +83,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	smi-nand.dtbo \
+ 	spi-gpio35-39.dtbo \
+ 	spi-rtc.dtbo \
++	spi0-cs.dtbo \
+ 	spi0-hw-cs.dtbo \
+ 	spi1-1cs.dtbo \
+ 	spi1-2cs.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/README b/arch/arm/boot/dts/overlays/README
+index 34109c69416c1caf28910895320a2b9cd539588e..4992a6203a5507144b6d405e03ed2bebaa11325f 100644
+--- a/arch/arm/boot/dts/overlays/README
++++ b/arch/arm/boot/dts/overlays/README
+@@ -1138,7 +1138,7 @@ Params: <None>
+ 
+ 
+ Name:   spi-gpio35-39
+-Info:   move SPI function block to GPIO 35 to 39
++Info:   Move SPI function block to GPIO 35 to 39
+ Load:   dtoverlay=spi-gpio35-39
+ Params: <None>
+ 
+@@ -1149,6 +1149,13 @@ Load:   dtoverlay=spi-rtc,<param>=<val>
+ Params: pcf2123                 Select the PCF2123 device
+ 
+ 
++Name:   spi0-cs
++Info:   Allows the (software) CS pins for SPI0 to be changed
++Load:   dtoverlay=spi0-cs,<param>=<val>
++Params: cs0_pin                 GPIO pin for CS0 (default 8)
++        cs1_pin                 GPIO pin for CS1 (default 7)
++
++
+ Name:   spi0-hw-cs
+ Info:   Re-enables hardware CS/CE (chip selects) for SPI0
+ Load:   dtoverlay=spi0-hw-cs
+diff --git a/arch/arm/boot/dts/overlays/spi0-cs-overlay.dts b/arch/arm/boot/dts/overlays/spi0-cs-overlay.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..7f79029d043c04d7496c7c3480450c691dc9a5cb
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/spi0-cs-overlay.dts
+@@ -0,0 +1,29 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
++
++	fragment@0 {
++		target = <&spi0_cs_pins>;
++		frag0: __overlay__ {
++			brcm,pins = <8 7>;
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		frag1: __overlay__ {
++			cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
++			status = "okay";
++		};
++	};
++
++	__overrides__ {
++		cs0_pin  = <&frag0>,"brcm,pins:0",
++			   <&frag1>,"cs-gpios:4";
++		cs1_pin  = <&frag0>,"brcm,pins:4",
++			   <&frag1>,"cs-gpios:16";
++	};
++};
+
+From e99d502473165aab168bb777e5e4818e6069e03a Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Fri, 1 Jul 2016 22:09:24 +0100
+Subject: [PATCH 126/126] spi-bcm2835: Disable forced software CS
+
+Select software CS in bcm2708_common.dtsi, and disable the automatic
+conversion in the driver to allow hardware CS to be re-enabled with an
+overlay.
+
+See: https://github.com/raspberrypi/linux/issues/1547
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ arch/arm/boot/dts/bcm283x.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/boot/dts/bcm283x.dtsi b/arch/arm/boot/dts/bcm283x.dtsi
+index 46d46d894a441d69dcf784fb2cf54d4d72038aa0..8c495461f9b850cc985d074d275446741a7367c1 100644
+--- a/arch/arm/boot/dts/bcm283x.dtsi
++++ b/arch/arm/boot/dts/bcm283x.dtsi
+@@ -163,6 +163,7 @@
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+ 			status = "disabled";
++			cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 		};
+ 
+ 		i2c0: i2c@7e205000 {

--- a/projects/RPi2/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi2/patches/linux/linux-01-RPi_support.patch
@@ -1,7 +1,7 @@
-From 726155a02a2642c4f992655ae4a4c062a0761260 Mon Sep 17 00:00:00 2001
+From 63e11e0da8f387b5ad081842eb0d958c593e955b Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
-Subject: [PATCH 001/122] smsx95xx: fix crimes against truesize
+Subject: [PATCH 001/126] smsx95xx: fix crimes against truesize
 
 smsc95xx is adjusting truesize when it shouldn't, and following a recent patch from Eric this is now triggering warnings.
 
@@ -48,10 +48,10 @@ index 831aa33d078ae7d2dd57fdded5de71d1eb915f99..b77935bded8c0ff7808b00f170ff10e5
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From f1afc1dcb1c34955d1a9d756abb1b61c3a9f1da8 Mon Sep 17 00:00:00 2001
+From 77f9b5bad4bfae625f9f7eb226b99b1a7d295301 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
-Subject: [PATCH 002/122] smsc95xx: Experimental: Enable turbo_mode and
+Subject: [PATCH 002/126] smsc95xx: Experimental: Enable turbo_mode and
  packetsize=2560 by default
 
 See: http://forum.kodi.tv/showthread.php?tid=285288
@@ -94,10 +94,10 @@ index b77935bded8c0ff7808b00f170ff10e594300ad0..693f163684de921404738e33244881e0
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From 69f6712212df74f6c27b1dfec7e3cc1408416653 Mon Sep 17 00:00:00 2001
+From d4abac0ef0d247e2cbc464e1b7cd3bf50985a965 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
-Subject: [PATCH 003/122] Allow mac address to be set in smsc95xx
+Subject: [PATCH 003/126] Allow mac address to be set in smsc95xx
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -193,10 +193,10 @@ index 693f163684de921404738e33244881e0aab92ec9..df60c989fc229bf0aab3c27e95ccd453
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From 10945e4697799ceff36fbdea420081b746d67429 Mon Sep 17 00:00:00 2001
+From 64c379b2a2825b495d9d80602194a9de8ead3ee1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
-Subject: [PATCH 004/122] Protect __release_resource against resources without
+Subject: [PATCH 004/126] Protect __release_resource against resources without
  parents
 
 Without this patch, removing a device tree overlay can crash here.
@@ -224,10 +224,10 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From ab1aef30de5e9424f87d7d6e1edb1a5240a76ae5 Mon Sep 17 00:00:00 2001
+From 7323c6a2d443bad79d0d0d39d108e52f3a9eb94d Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
-Subject: [PATCH 005/122] mm: Remove the PFN busy warning
+Subject: [PATCH 005/126] mm: Remove the PFN busy warning
 
 See commit dae803e165a11bc88ca8dbc07a11077caf97bbcb -- the warning is
 expected sometimes when using CMA.  However, that commit still spams
@@ -252,10 +252,10 @@ index 34ada718ef47c4b27730214d584f9350fefb9883..3fa01a5280db96075798e4cbd58d5520
  		goto done;
  	}
 
-From a1c2520dc2663b442e4b43010df6917f233ff40e Mon Sep 17 00:00:00 2001
+From 654e28c06539aa4f7e55dc4d009d04c6d06e2e70 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
-Subject: [PATCH 006/122] irq-bcm2836: Prevent spurious interrupts, and trap
+Subject: [PATCH 006/126] irq-bcm2836: Prevent spurious interrupts, and trap
  them early
 
 The old arch-specific IRQ macros included a dsb to ensure the
@@ -282,10 +282,10 @@ index d96b2c947e74e3edab3917551c64fbd1ced0f34c..93e3f7660c4230c9f1dd3b195958cb49
  #endif
  	} else if (stat) {
 
-From 2d51d14c0cea3d9d52f323b58a0a5d99a65eef24 Mon Sep 17 00:00:00 2001
+From 0fb8f05c814b8bfa2587ad74d204259d0504ebcd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
-Subject: [PATCH 007/122] irqchip: bcm2835: Add FIQ support
+Subject: [PATCH 007/126] irqchip: bcm2835: Add FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -414,10 +414,10 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 2d9b0ef8dc1a5975dfccfb7e78b8f5a94ab5f2bb Mon Sep 17 00:00:00 2001
+From 04dd06e02458b52417db6803414f5cb958cd3555 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
-Subject: [PATCH 008/122] irqchip: irq-bcm2835: Add 2836 FIQ support
+Subject: [PATCH 008/126] irqchip: irq-bcm2835: Add 2836 FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -516,10 +516,10 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From 39974a29633d89316e5de24d87294b444b24f381 Mon Sep 17 00:00:00 2001
+From 74a1a4a4b4bea0653a09eabc8df33e02db13bdd5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
-Subject: [PATCH 009/122] spidev: Add "spidev" compatible string to silence
+Subject: [PATCH 009/126] spidev: Add "spidev" compatible string to silence
  warning
 
 See: https://github.com/raspberrypi/linux/issues/1054
@@ -540,10 +540,10 @@ index 2e05046f866bd01bf87edcdeff0d5b76d4d0aea7..d780491b8013a4e97fa843958964454e
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 51c39f512e9b370f126afcdcf6306561ea1f50f2 Mon Sep 17 00:00:00 2001
+From 9bc2b7840e95ae09a708109e86bb23637a27f5d7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 30 Jun 2015 14:12:42 +0100
-Subject: [PATCH 010/122] serial: 8250: Don't crash when nr_uarts is 0
+Subject: [PATCH 010/126] serial: 8250: Don't crash when nr_uarts is 0
 
 ---
  drivers/tty/serial/8250/8250_core.c | 2 ++
@@ -563,10 +563,10 @@ index 240a361b674fe72ce657067e5303156b7add6a6f..14f6cdfd744209482056d206dc476d94
  	for (i = 0; i < nr_uarts; i++) {
  		struct uart_8250_port *up = &serial8250_ports[i];
 
-From f56196076549fabcdf0cca5685d1ea3e0308622a Mon Sep 17 00:00:00 2001
+From ccf3116935778517465cd8bdc8c27c146e66e7ab Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
-Subject: [PATCH 011/122] pinctrl-bcm2835: Set base to 0 give expected gpio
+Subject: [PATCH 011/126] pinctrl-bcm2835: Set base to 0 give expected gpio
  numbering
 
 Signed-off-by: Noralf Tronnes <notro@tronnes.org>
@@ -588,10 +588,10 @@ index fa77165fab2c1348163979da507df17e7168c49b..d11e2e4ea189466e686d762cb6c6fef9
  	.can_sleep = false,
  };
 
-From 40a7420d0d585951fbc02f232df97a15beff7a57 Mon Sep 17 00:00:00 2001
+From 31583da17782d176a60e1312650795a5edd3b3c6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
-Subject: [PATCH 012/122] pinctrl-bcm2835: Fix interrupt handling for GPIOs
+Subject: [PATCH 012/126] pinctrl-bcm2835: Fix interrupt handling for GPIOs
  28-31 and 46-53
 
 Contrary to the documentation, the BCM2835 GPIO controller actually has
@@ -737,10 +737,10 @@ index d11e2e4ea189466e686d762cb6c6fef9111ecf8e..107ad7d58de8f8a7f55e09c9cdcf7d66
  	},
  };
 
-From a19df9159eb1e9745593febf2ef6aa5868e8d12f Mon Sep 17 00:00:00 2001
+From b2ce0dec4ec06b7698b05e6192d8e67a72c16475 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
-Subject: [PATCH 013/122] pinctrl-bcm2835: Only request the interrupts listed
+Subject: [PATCH 013/126] pinctrl-bcm2835: Only request the interrupts listed
  in the DTB
 
 Although the GPIO controller can generate three interrupts (four counting
@@ -767,10 +767,10 @@ index 107ad7d58de8f8a7f55e09c9cdcf7d66fa7ab66b..644bdecbcfcb79d3b84a33769265fca5
  		pc->irq_data[i].irqgroup = i;
  
 
-From eee7c2b51a8b1753aca3d01ecda24713576d14e5 Mon Sep 17 00:00:00 2001
+From 5cac86fa1ade5f2308f5fce0098718f780b5b9fe Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 May 2016 12:32:47 +0100
-Subject: [PATCH 014/122] pinctrl-bcm2835: Return pins to inputs when freed
+Subject: [PATCH 014/126] pinctrl-bcm2835: Return pins to inputs when freed
 
 When dynamically unloading overlays, it is important that freed pins are
 restored to being inputs to prevent functions from being enabled in
@@ -811,10 +811,10 @@ index 644bdecbcfcb79d3b84a33769265fca5d3d0c9e5..81a66cba2ab0f7e3ae179de7edd10122
  	.get_function_name = bcm2835_pmx_get_function_name,
  	.get_function_groups = bcm2835_pmx_get_function_groups,
 
-From 7d54b896b5523a49b1038dd301b2d359d2321ef2 Mon Sep 17 00:00:00 2001
+From 720b313ed69c685d273546c3999a745076fdf4da Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
-Subject: [PATCH 015/122] spi-bcm2835: Support pin groups other than 7-11
+Subject: [PATCH 015/126] spi-bcm2835: Support pin groups other than 7-11
 
 The spi-bcm2835 driver automatically uses GPIO chip-selects due to
 some unreliability of the native ones. In doing so it chooses the
@@ -895,10 +895,10 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From de045c3b6df0c0d56f02c0f782627249bbad09d2 Mon Sep 17 00:00:00 2001
+From a1a469614cac7e788aa2894125f91471508a7374 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
-Subject: [PATCH 016/122] spi-bcm2835: Disable forced software CS
+Subject: [PATCH 016/126] spi-bcm2835: Disable forced software CS
 
 Select software CS in bcm2708_common.dtsi, and disable the automatic
 conversion in the driver to allow hardware CS to be re-enabled with an
@@ -932,10 +932,10 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From a161509667da54c9d5066a0c6bc0584d093a8923 Mon Sep 17 00:00:00 2001
+From 65e258d609312dc6700a398bd1766f8154cf7d08 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
-Subject: [PATCH 017/122] spi-bcm2835: Remove unused code
+Subject: [PATCH 017/126] spi-bcm2835: Remove unused code
 
 ---
  drivers/spi/spi-bcm2835.c | 61 -----------------------------------------------
@@ -1023,10 +1023,10 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From 2ec6cfba14ff71b08f797c69d1a9c5bd53fc66a6 Mon Sep 17 00:00:00 2001
+From d47f0f76f25cb14852a10b548fb78b000b421987 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
-Subject: [PATCH 018/122] ARM: bcm2835: Set Serial number and Revision
+Subject: [PATCH 018/126] ARM: bcm2835: Set Serial number and Revision
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1079,10 +1079,10 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 7cd4e838461cb6cefa1ca5246ef3a6773363f0e0 Mon Sep 17 00:00:00 2001
+From 303f00d215fd55c7251899585db84a65629bd78d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
-Subject: [PATCH 019/122] dmaengine: bcm2835: Load driver early and support
+Subject: [PATCH 019/126] dmaengine: bcm2835: Load driver early and support
  legacy API
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -1185,10 +1185,10 @@ index e18dc596cf2447fa9ef7e41b62d9396e29043426..80d35f760b4a4a51e60c355a84d538ba
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From e19d2f37545f78b50f4f82b72099b036f42d2bcd Mon Sep 17 00:00:00 2001
+From cb868455a02d8c15093949b3dcec58f5cf4993a7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
-Subject: [PATCH 020/122] firmware: Updated mailbox header
+Subject: [PATCH 020/126] firmware: Updated mailbox header
 
 ---
  include/soc/bcm2835/raspberrypi-firmware.h | 11 +++++++++++
@@ -1251,10 +1251,10 @@ index 3fb357193f09914fe21f8555a4b8613f74f22bc3..227a107214a02deadcca3db202da265e
  	RPI_FIRMWARE_GET_COMMAND_LINE =                       0x00050001,
  	RPI_FIRMWARE_GET_DMA_CHANNELS =                       0x00060001,
 
-From 99e1f06dcc2bf78742380b9697c354b627fd02c2 Mon Sep 17 00:00:00 2001
+From aafd4292fbbb7f22d05f10d6cb8336ffac9c8ad4 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
-Subject: [PATCH 021/122] clk: bcm2835: Mark GPIO clocks enabled at boot as
+Subject: [PATCH 021/126] clk: bcm2835: Mark GPIO clocks enabled at boot as
  critical.
 
 These divide off of PLLD_PER and are used for the ethernet and wifi
@@ -1292,10 +1292,10 @@ index 3bbd2a58db470a89b870a793e59ddf9fc4f48e57..7040c6426e35c11608121893b662c601
  		init.ops = &bcm2835_vpu_clock_clk_ops;
  	} else {
 
-From 946babad832c9ed45bbb31fd89fce025a9f7db48 Mon Sep 17 00:00:00 2001
+From ae325b043eaba7f7bac66d2cb01644bee6933b6a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
-Subject: [PATCH 022/122] rtc: Add SPI alias for pcf2123 driver
+Subject: [PATCH 022/126] rtc: Add SPI alias for pcf2123 driver
 
 Without this alias, Device Tree won't cause the driver
 to be loaded.
@@ -1315,10 +1315,10 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From a929f2b203a1bafb1ca88f7022cb286f28fa98bd Mon Sep 17 00:00:00 2001
+From d08f818da57e017f41cba3d0f16e1fd8eec99b20 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
-Subject: [PATCH 023/122] watchdog: bcm2835: Support setting reboot partition
+Subject: [PATCH 023/126] watchdog: bcm2835: Support setting reboot partition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1442,10 +1442,10 @@ index 4dddd8298a227d64862f2e92954a465f2e44b3f6..1f545e024422f59280932713e6a1b051
  	register_restart_handler(&wdt->restart_handler);
  	if (pm_power_off == NULL)
 
-From 2e7833eae38410bc31d3a86166868a55d0999394 Mon Sep 17 00:00:00 2001
+From 0f74ee7f936f83ad48d8c69640516c3da1fd65a7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
-Subject: [PATCH 024/122] reboot: Use power off rather than busy spinning when
+Subject: [PATCH 024/126] reboot: Use power off rather than busy spinning when
  halt is requested
 
 ---
@@ -1468,10 +1468,10 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From 0d4700ca51eb31fa70e10da67fa92e986275f2d3 Mon Sep 17 00:00:00 2001
+From f87f4d388f2486ebe8e404b0920a771100b37c96 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
-Subject: [PATCH 025/122] bcm: Make RASPBERRYPI_POWER depend on PM
+Subject: [PATCH 025/126] bcm: Make RASPBERRYPI_POWER depend on PM
 
 ---
  drivers/soc/bcm/Kconfig | 1 +
@@ -1490,10 +1490,10 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 53b503a7256d432bfa51f5ffba58a446c2cc6ebb Mon Sep 17 00:00:00 2001
+From a724c93f4805fe577d215b97231db4463832ce7d Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
-Subject: [PATCH 026/122] Register the clocks early during the boot process, so
+Subject: [PATCH 026/126] Register the clocks early during the boot process, so
  that special/critical clocks can get enabled early on in the boot process
  avoiding the risk of disabling a clock, pll_divider or pll when a claiming
  driver fails to install propperly - maybe it needs to defer.
@@ -1538,10 +1538,10 @@ index 7040c6426e35c11608121893b662c601cd8d6543..21e2a538ff0d0ab4e63adff9b93705f3
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From e367c208dc6a9d92e5c0d6e5e089e7b56c7cf189 Mon Sep 17 00:00:00 2001
+From 5bb87da5723ea02dc3a2da5a267bb90c562f9bb4 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
-Subject: [PATCH 027/122] bcm2835-rng: Avoid initialising if already enabled
+Subject: [PATCH 027/126] bcm2835-rng: Avoid initialising if already enabled
 
 Avoids the 0x40000 cycles of warmup again if firmware has already used it
 ---
@@ -1567,10 +1567,10 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From da0b1ac76230b33baa5cd0391388d32d43889d69 Mon Sep 17 00:00:00 2001
+From 5926afb27f2dc5dad6f99af9394b8f1b3289e071 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
-Subject: [PATCH 028/122] kbuild: Ignore dtco targets when filtering symbols
+Subject: [PATCH 028/126] kbuild: Ignore dtco targets when filtering symbols
 
 ---
  scripts/Kbuild.include | 2 +-
@@ -1590,10 +1590,10 @@ index 179219845dfcdfbeb586d12c5ec1296095d9fbf4..e0743e44f84188667a0c322e8c3d36f1
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From f96bacbe5b20000d29c0b1bc81f66f5b15231b48 Mon Sep 17 00:00:00 2001
+From 3042782f257be2823820f7040b771ad5d72cf0e9 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
-Subject: [PATCH 029/122] BCM2835_DT: Fix I2S register map
+Subject: [PATCH 029/126] BCM2835_DT: Fix I2S register map
 
 ---
  Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.txt   | 4 ++--
@@ -1631,10 +1631,10 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From 967e1d016f69607cb5f1d8337f9249ef31e19d81 Mon Sep 17 00:00:00 2001
+From dc83f1171efc493dfb233113a748734033b213a8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
-Subject: [PATCH 030/122] Main bcm2708/bcm2709 linux port
+Subject: [PATCH 030/126] Main bcm2708/bcm2709 linux port
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1841,10 +1841,10 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 9ccdf13082f318de0091066517c7f7309b245456 Mon Sep 17 00:00:00 2001
+From edbeb9ac886a21d9ca45b4e5a84b9914b0a14f1d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
-Subject: [PATCH 031/122] Add dwc_otg driver
+Subject: [PATCH 031/126] Add dwc_otg driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -62901,10 +62901,10 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 990bd0f738984c3582e6dbba14a1826ea28f9fb6 Mon Sep 17 00:00:00 2001
+From 38da51175e2ecc08d375d7274b4ff9c91ab9f042 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
-Subject: [PATCH 032/122] bcm2708 framebuffer driver
+Subject: [PATCH 032/126] bcm2708 framebuffer driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66363,10 +66363,10 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From baa447618d238275c592e7caa6455b8e4b1d3d77 Mon Sep 17 00:00:00 2001
+From cad92641e0a0f0b49cbdfa5f0b3c27401e492de6 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
-Subject: [PATCH 033/122] dmaengine: Add support for BCM2708
+Subject: [PATCH 033/126] dmaengine: Add support for BCM2708
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66997,10 +66997,10 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From b7d8765eb1e1bb854be09a08acabaf92cd1c45ab Mon Sep 17 00:00:00 2001
+From 8c0181ad0bd96059733c3473bf12745c1375fd66 Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
-Subject: [PATCH 034/122] MMC: added alternative MMC driver
+Subject: [PATCH 034/126] MMC: added alternative MMC driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -68750,10 +68750,10 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From a56eb108067d0211a3ba3b987ec15986ac5577a6 Mon Sep 17 00:00:00 2001
+From 9c2e7cd3627b3017ef409610b1db962601271147 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
-Subject: [PATCH 035/122] Adding bcm2835-sdhost driver, and an overlay to
+Subject: [PATCH 035/126] Adding bcm2835-sdhost driver, and an overlay to
  enable it
 
 BCM2835 has two SD card interfaces. This driver uses the other one.
@@ -71158,10 +71158,10 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 0eda1e885a24ef523c6f88b4f62dc928c47f00c6 Mon Sep 17 00:00:00 2001
+From ee4d028beb367877f76181a1bc56aa1859a8f374 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
-Subject: [PATCH 036/122] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
+Subject: [PATCH 036/126] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
 
 Some SD cards have been found that corrupt data when small blocks
 are erased. Add a quirk to indicate that ERASE should not be used,
@@ -71297,10 +71297,10 @@ index 73fad83acbcb6a157587180516f9ffe7c61eb7d7..e7c9d3098ac06e3c6554fa3373a311f9
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From ebd7f1f66e66573d57edc087910e4f34f71a52d9 Mon Sep 17 00:00:00 2001
+From 4e12fb038c44a2e713965013ec86899a47b78403 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:31:47 +0100
-Subject: [PATCH 037/122] cma: Add vc_cma driver to enable use of CMA
+Subject: [PATCH 037/126] cma: Add vc_cma driver to enable use of CMA
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -72636,10 +72636,10 @@ index 0000000000000000000000000000000000000000..be2819d5d41f9d5ed65daf8eedb94c9e
 +
 +#endif /* VC_CMA_H */
 
-From 20fda0a0bcd46a01ba801a968f81c55398ff925e Mon Sep 17 00:00:00 2001
+From a04f5f2ffe8373ea31e17b82be9b3843fe65c0f3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 26 Mar 2012 22:15:50 +0100
-Subject: [PATCH 038/122] bcm2708: alsa sound driver
+Subject: [PATCH 038/126] bcm2708: alsa sound driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -75374,10 +75374,10 @@ index 0000000000000000000000000000000000000000..af3e6eb690113fc32ce9e06bd2f0f294
 +
 +#endif // _VC_AUDIO_DEFS_H_
 
-From f173c4ba6bb591fd104486fec7229cff3648f715 Mon Sep 17 00:00:00 2001
+From ba414e3d840b41eb38faba2eb4a2713094241514 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
-Subject: [PATCH 039/122] vc_mem: Add vc_mem driver for querying firmware
+Subject: [PATCH 039/126] vc_mem: Add vc_mem driver for querying firmware
  memory addresses
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -75901,10 +75901,10 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From 826895d0d097fa010aca39acf19d85a1e065876d Mon Sep 17 00:00:00 2001
+From 61fd7be07724c515e7a1aab2149f09c75555a233 Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
-Subject: [PATCH 040/122] vcsm: VideoCore shared memory service for BCM2835
+Subject: [PATCH 040/126] vcsm: VideoCore shared memory service for BCM2835
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -80311,10 +80311,10 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From 3d892851d6e52bec4c02b06146967ecc52b50af0 Mon Sep 17 00:00:00 2001
+From 6bb05242468217f5f3b426f7bc8e7bec5fbb8cfe Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
-Subject: [PATCH 041/122] Add /dev/gpiomem device for rootless user GPIO access
+Subject: [PATCH 041/126] Add /dev/gpiomem device for rootless user GPIO access
 
 Signed-off-by: Luke Wren <luke@raspberrypi.org>
 
@@ -80625,10 +80625,10 @@ index 0000000000000000000000000000000000000000..911f5b7393ed48ceed8751f06967ae64
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From fbaa743648d031cbb8afeb81e37f546b4fd7b6b5 Mon Sep 17 00:00:00 2001
+From b76610b93035441ca90043e0214291405b390bd8 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
-Subject: [PATCH 042/122] Add SMI driver
+Subject: [PATCH 042/126] Add SMI driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -82579,10 +82579,10 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From 7df434185cb69481bdb857fb30c153685feb7c4e Mon Sep 17 00:00:00 2001
+From 1f83979d14ace2092bcb03627aed5f1bbc129268 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
-Subject: [PATCH 043/122] MISC: bcm2835: smi: use clock manager and fix reload
+Subject: [PATCH 043/126] MISC: bcm2835: smi: use clock manager and fix reload
  issues
 
 Use clock manager instead of self-made clockmanager.
@@ -82752,10 +82752,10 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From e80a053c8ec7283b7c93f468b437c1e53ffdd5dc Mon Sep 17 00:00:00 2001
+From d49666e230c6379c4c130ba3b01e481b0d7ddce9 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
-Subject: [PATCH 044/122] Add SMI NAND driver
+Subject: [PATCH 044/126] Add SMI NAND driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -83120,10 +83120,10 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From d5fe3a35c384918e40ad67ae26c5997ca941c98e Mon Sep 17 00:00:00 2001
+From 34a4d656715ed74b00db49b706649c09188ceef1 Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
-Subject: [PATCH 045/122] lirc: added support for RaspberryPi GPIO
+Subject: [PATCH 045/126] lirc: added support for RaspberryPi GPIO
 
 lirc_rpi: Use read_current_timer to determine transmitter delay. Thanks to jjmz and others
 See: https://github.com/raspberrypi/linux/issues/525
@@ -83986,10 +83986,10 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From f66f635379d5b4ebc82d4d18c9bd77d2fbcbdfa6 Mon Sep 17 00:00:00 2001
+From 14a72a5cd0b417e11140e026d0795895f9aadfae Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
-Subject: [PATCH 046/122] Add cpufreq driver
+Subject: [PATCH 046/126] Add cpufreq driver
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -84256,10 +84256,10 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 478277f128dbdcbea6394c4744ada90fce9ab66e Mon Sep 17 00:00:00 2001
+From c1a1eccd357ab6a8e537c9c3a8a89b9925b1fde9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
-Subject: [PATCH 047/122] Added hwmon/thermal driver for reporting core
+Subject: [PATCH 047/126] Added hwmon/thermal driver for reporting core
  temperature. Thanks Dorian
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -84425,10 +84425,10 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From aaac339b97bfcc6a67fd3f51400d87fc2ff00198 Mon Sep 17 00:00:00 2001
+From 070ea1d5e9fb411df507ba44d68beb6cc2ca0796 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
-Subject: [PATCH 048/122] Add Chris Boot's i2c driver
+Subject: [PATCH 048/126] Add Chris Boot's i2c driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85093,10 +85093,10 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From fa468e89c790f2e432205e3b16d26e5365d98ec7 Mon Sep 17 00:00:00 2001
+From 98104aeaddf60e81755ae39ffaac0af8a4d73493 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
-Subject: [PATCH 049/122] char: broadcom: Add vcio module
+Subject: [PATCH 049/126] char: broadcom: Add vcio module
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85322,10 +85322,10 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 83532363df9ebe5f7e8cea458bcfd9b67a0e815a Mon Sep 17 00:00:00 2001
+From bbcc4b0a7b02f5121ec6d3909e301cd8745a916d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
-Subject: [PATCH 050/122] firmware: bcm2835: Support ARCH_BCM270x
+Subject: [PATCH 050/126] firmware: bcm2835: Support ARCH_BCM270x
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85408,10 +85408,10 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From c1316c3428ecf0ef0ad3c39a6ff7e367b3483c4f Mon Sep 17 00:00:00 2001
+From 3aee9a3ae96fc98195c2dced5e736d5a48b85514 Mon Sep 17 00:00:00 2001
 From: Vincent Sanders <vincent.sanders@collabora.co.uk>
 Date: Wed, 30 Jan 2013 12:45:18 +0000
-Subject: [PATCH 051/122] bcm2835: add v4l2 camera device
+Subject: [PATCH 051/126] bcm2835: add v4l2 camera device
 
 - Supports raw YUV capture, preview, JPEG and H264.
 - Uses videobuf2 for data transfer, using dma_buf.
@@ -93153,10 +93153,10 @@ index 0000000000000000000000000000000000000000..9d1d11e4a53e510c04a416d92d195a7d
 +
 +#endif /* MMAL_VCHIQ_H */
 
-From 6b480eb543d3fb86623e58d6d0f884f67f5ba804 Mon Sep 17 00:00:00 2001
+From 55965f9245ae2d3f76e786602265c0acee7e4987 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
-Subject: [PATCH 052/122] scripts: Add mkknlimg and knlinfo scripts from tools
+Subject: [PATCH 052/126] scripts: Add mkknlimg and knlinfo scripts from tools
  repo
 
 The Raspberry Pi firmware looks for a trailer on the kernel image to
@@ -93676,10 +93676,10 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 94cbd8ee19d8f0e25c4af4598b07b0c22c5083ae Mon Sep 17 00:00:00 2001
+From 3e22a0b4652e890fa957b2f0c8f203c82dae93f1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 10 Aug 2015 09:49:15 +0100
-Subject: [PATCH 053/122] scripts/dtc: Update to upstream version 1.4.1
+Subject: [PATCH 053/126] scripts/dtc: Update to upstream version 1.4.1
 
 Includes the new localfixups format.
 
@@ -96530,10 +96530,10 @@ index ad9b05ae698b0495ecbda42ffcf4743555313a27..2595dfda020fd9e03f0beff5006f229d
 -#define DTC_VERSION "DTC 1.4.1-g53bf130b"
 +#define DTC_VERSION "DTC 1.4.1-g25efc119"
 
-From ef3f51080fa0d993456fa3635e442b845051b70a Mon Sep 17 00:00:00 2001
+From 949833a082ee10c4002ae38bc5ff719002f5628e Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
-Subject: [PATCH 054/122] BCM2708: Add core Device Tree support
+Subject: [PATCH 054/126] BCM2708: Add core Device Tree support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -106661,10 +106661,10 @@ index 0a07f9014944ed92a8e2e42983ae43be60b3e471..1967878a843461c3ff1f473b9a030eb0
  
  # Bzip2
 
-From 52e8a3802aa8428a69561607209bfe9b98cabde6 Mon Sep 17 00:00:00 2001
+From b2279fed6fed3d31a291ad70a99f9f78ad72c673 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
-Subject: [PATCH 055/122] BCM270x_DT: Add pwr_led, and the required "input"
+Subject: [PATCH 055/126] BCM270x_DT: Add pwr_led, and the required "input"
  trigger
 
 The "input" trigger makes the associated GPIO an input.  This is to support
@@ -106840,10 +106840,10 @@ index ddfcb2df3656cf0ab6aebd1fa3d624a6ec2e94e9..271563eb835f9018712e2076a88f341d
  	/* Set LED brightness level
  	 * Must not sleep. Use brightness_set_blocking for drivers
 
-From e958cbc43c1add6076ea3ed0aa17365335774024 Mon Sep 17 00:00:00 2001
+From bd8d69ec5255cfcbd180de34be0f33012d46a5ca Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
-Subject: [PATCH 056/122] fbdev: add FBIOCOPYAREA ioctl
+Subject: [PATCH 056/126] fbdev: add FBIOCOPYAREA ioctl
 
 Based on the patch authored by Ali Gholami Rudi at
     https://lkml.org/lkml/2009/7/13/153
@@ -107095,10 +107095,10 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From cf7188188aabe5b8ae10cf449ea6c9b0c6c29c90 Mon Sep 17 00:00:00 2001
+From 978324fba4d05f46f9d6031fad81051510806319 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
-Subject: [PATCH 057/122] Speed up console framebuffer imageblit function
+Subject: [PATCH 057/126] Speed up console framebuffer imageblit function
 
 Especially on platforms with a slower CPU but a relatively high
 framebuffer fill bandwidth, like current ARM devices, the existing
@@ -107307,10 +107307,10 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From 132a1f15dea64eef7dbf9cc5b98e1668cedb2eea Mon Sep 17 00:00:00 2001
+From a7c447247614e5f265e6db25099bc17fafbe8566 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
-Subject: [PATCH 058/122] enabling the realtime clock 1-wire chip DS1307 and
+Subject: [PATCH 058/126] enabling the realtime clock 1-wire chip DS1307 and
  1-wire on GPIO4 (as a module)
 
 1-wire: Add support for configuring pin for w1-gpio kernel module
@@ -107560,10 +107560,10 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From 3a29fd5c4e71ff439e60097ca14a4d97c8c63f5f Mon Sep 17 00:00:00 2001
+From cf6e96b086db65f9a98ab466a2fcc4a073ed8464 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 18 Dec 2013 22:16:19 +0000
-Subject: [PATCH 059/122] config: Enable CONFIG_MEMCG, but leave it disabled
+Subject: [PATCH 059/126] config: Enable CONFIG_MEMCG, but leave it disabled
  (due to memory cost). Enable with cgroup_enable=memory.
 
 ---
@@ -107613,10 +107613,10 @@ index 85bc9beb046d9a6deda2e3564f4d5bd01d6fc27b..4acdbef46a8f0556469b5580a39c18ce
   * css_tryget_online_from_dir - get corresponding css from a cgroup dentry
   * @dentry: directory dentry of interest
 
-From 7a094c94cc5e4275d62f541780238f86b7e1a944 Mon Sep 17 00:00:00 2001
+From 7e8c1c718caac29476b4532dc6b31969298d3db0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
-Subject: [PATCH 060/122] hid: Reduce default mouse polling interval to 60Hz
+Subject: [PATCH 060/126] hid: Reduce default mouse polling interval to 60Hz
 
 Reduces overhead when using X
 ---
@@ -107652,10 +107652,10 @@ index ae83af649a607f67239f1a64bf45dd4b5770cc7d..4a7af9d0b910f59d17421ce14138400d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From 844a5a997e65b9ba913904f020f88893087ba2b2 Mon Sep 17 00:00:00 2001
+From 829e3fbc9c26fda09c7fbbcd18ba82f890b58679 Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
-Subject: [PATCH 061/122] rpi-ft5406: Add touchscreen driver for pi LCD display
+Subject: [PATCH 061/126] rpi-ft5406: Add touchscreen driver for pi LCD display
 
 Fix driver detection failure Check that the buffer response is non-zero meaning the touchscreen was detected
 
@@ -108013,10 +108013,10 @@ index 227a107214a02deadcca3db202da265eba1fdd21..b0f6e33bd30c35664ceee057f4c3ad32
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 3b84c6d542a8066b50fc3efdd916c8a7b88b9d1f Mon Sep 17 00:00:00 2001
+From a0bb7fd95ba2cf472535622612cd450a67d57c86 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
-Subject: [PATCH 062/122] Improve __copy_to_user and __copy_from_user
+Subject: [PATCH 062/126] Improve __copy_to_user and __copy_from_user
  performance
 
 Provide a __copy_from_user that uses memcpy. On BCM2708, use
@@ -109591,10 +109591,10 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From d5dc9d3eb0f7177be235596e3009f8b53b4e25b5 Mon Sep 17 00:00:00 2001
+From 229ec73ed7f80802ee4531e77dc9f9f17aa4d270 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
-Subject: [PATCH 063/122] gpio-poweroff: Allow it to work on Raspberry Pi
+Subject: [PATCH 063/126] gpio-poweroff: Allow it to work on Raspberry Pi
 
 The Raspberry Pi firmware manages the power-down and reboot
 process. To do this it installs a pm_power_off handler, causing
@@ -109629,10 +109629,10 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From 78515e0aa6204095c519dce39d811d796cb9dc18 Mon Sep 17 00:00:00 2001
+From 456cc9c6aea54449e345ce35d5bedec82f1e1fed Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
-Subject: [PATCH 064/122] mfd: Add Raspberry Pi Sense HAT core driver
+Subject: [PATCH 064/126] mfd: Add Raspberry Pi Sense HAT core driver
 
 ---
  drivers/input/joystick/Kconfig           |   8 +
@@ -110497,10 +110497,10 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 92261bb1ae13c929b053aab7db4cc660d4565511 Mon Sep 17 00:00:00 2001
+From 78d7f25e0c5ac106b503718438905c7019fac2f4 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
-Subject: [PATCH 065/122] ASoC: Add support for HifiBerry DAC
+Subject: [PATCH 065/126] ASoC: Add support for HifiBerry DAC
 
 This adds a machine driver for the HifiBerry DAC.
 It is a sound card that can
@@ -110675,10 +110675,10 @@ index 0000000000000000000000000000000000000000..45f2b770ad9e67728ca599a7445d6ae9
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From b6df383dd105286109669674cf79c61b5f88bba9 Mon Sep 17 00:00:00 2001
+From 2a1788013f5edd5a4a2cbadfaf2925b24a29fc99 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
-Subject: [PATCH 066/122] ASoC: Add support for Rpi-DAC
+Subject: [PATCH 066/126] ASoC: Add support for Rpi-DAC
 
 ---
  sound/soc/bcm/Kconfig       |   7 +++
@@ -110962,10 +110962,10 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From 32447fa52c6b39d4447c53b0a7ae8a2096ee901e Mon Sep 17 00:00:00 2001
+From df70c2c133f6fc4d7120cef4d1d81036a907443a Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
-Subject: [PATCH 067/122] ASoC: wm8804: Implement MCLK configuration options,
+Subject: [PATCH 067/126] ASoC: wm8804: Implement MCLK configuration options,
  add 32bit support WM8804 can run with PLL frequencies of 256xfs and 128xfs
  for most sample rates. At 192kHz only 128xfs is supported. The existing
  driver selects 128xfs automatically for some lower samples rates. By using an
@@ -111014,10 +111014,10 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From cd919b3554a2544cf2600822593b6057d4297316 Mon Sep 17 00:00:00 2001
+From fdb0336dd40074201ffadcb567bab47238192555 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
-Subject: [PATCH 068/122] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
+Subject: [PATCH 068/126] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
  based on the patched WM8804 driver.
 
 Signed-off-by: Daniel Matuschek <daniel@matuschek.net>
@@ -111361,10 +111361,10 @@ index 0000000000000000000000000000000000000000..19dc953b7227ba86123fc7a2ba654499
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 9c1f52bc905674a484e6b9c5e91fbef279890c68 Mon Sep 17 00:00:00 2001
+From f2e7914949f17d216fd8d4bc87869489418e0a69 Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
-Subject: [PATCH 069/122] Add IQaudIO Sound Card support for Raspberry Pi
+Subject: [PATCH 069/126] Add IQaudIO Sound Card support for Raspberry Pi
 
 Set a limit of 0dB on Digital Volume Control
 
@@ -111694,10 +111694,10 @@ index 0000000000000000000000000000000000000000..4e8e6dec14bcf4a1ff286c43742d4097
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From fef54ca8d87499607d6cb086210e44126b304f6d Mon Sep 17 00:00:00 2001
+From fbc916e505a4aeb05ce50158c6e84a37a1882ac7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jul 2016 17:06:50 +0100
-Subject: [PATCH 070/122] iqaudio-dac: Compile fix - untested
+Subject: [PATCH 070/126] iqaudio-dac: Compile fix - untested
 
 ---
  sound/soc/bcm/iqaudio-dac.c | 6 +++++-
@@ -111721,10 +111721,10 @@ index 4e8e6dec14bcf4a1ff286c43742d4097249d6777..aa15bc4b49ca95edec905fddd8fd0a6d
  	if (dapm->dev != codec_dai->dev)
  		return 0;
 
-From 31bee6011867bb7a1846d35901b080a208669515 Mon Sep 17 00:00:00 2001
+From 3a6a5f368a4acfbed5452c98b71df3bb9e66508c Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
-Subject: [PATCH 071/122] Added support for HiFiBerry DAC+
+Subject: [PATCH 071/126] Added support for HiFiBerry DAC+
 
 The driver is based on the HiFiBerry DAC driver. However HiFiBerry DAC+ uses
 a different codec chip (PCM5122), therefore a new driver is necessary.
@@ -112354,10 +112354,10 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From f11ffc75b1a5ba748f160765164337eabea0b6e1 Mon Sep 17 00:00:00 2001
+From 11da66cf778a33b6260dbee25f8b6a026077bc74 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
-Subject: [PATCH 072/122] Added driver for HiFiBerry Amp amplifier add-on board
+Subject: [PATCH 072/126] Added driver for HiFiBerry Amp amplifier add-on board
 
 The driver contains a low-level hardware driver for the TAS5713 and the
 drivers for the Raspberry Pi I2S subsystem.
@@ -113190,10 +113190,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From e06a867b4795e7c7e8dd9d13257a77494ea5f610 Mon Sep 17 00:00:00 2001
+From a0fe24a015581d82174ae5ad95a2b3fb78a66964 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Dec 2016 16:26:54 +0000
-Subject: [PATCH 073/122] Revert "Added driver for HiFiBerry Amp amplifier
+Subject: [PATCH 073/126] Revert "Added driver for HiFiBerry Amp amplifier
  add-on board"
 
 This reverts commit 3e6b00833d92a50cbcc9922deb6e1bc8fcdbb587.
@@ -114015,10 +114015,10 @@ index 8f019e04898754d2f87e9630137be9e8f612a342..00000000000000000000000000000000
 -
 -#endif  /* _TAS5713_H */
 
-From adf38c2875a20b75d2870d9e9897f711835811ea Mon Sep 17 00:00:00 2001
+From a38a031c9e5f5ac9666559849624d45e03cdecd7 Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
-Subject: [PATCH 074/122] Update ds1307 driver for device-tree support
+Subject: [PATCH 074/126] Update ds1307 driver for device-tree support
 
 Signed-off-by: Ryan Coe <bluemrp9@gmail.com>
 ---
@@ -114045,10 +114045,10 @@ index 4e31036ee2596dec93accd26f627c5b95591ae9f..b92044cf03e750afa521a93519500e9d
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From 23122064c9a8be975b07aad67e74213cf9fdc7d8 Mon Sep 17 00:00:00 2001
+From 32a492700e8b8529453eb92e383b1937f089b525 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
-Subject: [PATCH 075/122] Add driver for rpi-proto
+Subject: [PATCH 075/126] Add driver for rpi-proto
 
 Forward port of 3.10.x driver from https://github.com/koalo
 We are using a custom board and would like to use rpi 3.18.x
@@ -114263,10 +114263,10 @@ index 0000000000000000000000000000000000000000..9db678e885efd63d84d60a098a84ed67
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 23e17d37207fc0039b141c8988644c24885ba10a Mon Sep 17 00:00:00 2001
+From 781f54e3321c508c8c751a14fc3595d4ae8c9054 Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
-Subject: [PATCH 076/122] RaspiDAC3 support
+Subject: [PATCH 076/126] RaspiDAC3 support
 
 Signed-off-by: Jan Grulich <jan@grulich.eu>
 
@@ -114509,10 +114509,10 @@ index 0000000000000000000000000000000000000000..dd9eeea2af0382307f437e6db09d1546
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From 328c723f04e73cc2484ae7d5d6f317fc22fbd386 Mon Sep 17 00:00:00 2001
+From 341233e6fd362244d9567c68d5cd91cb6c48da88 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
-Subject: [PATCH 077/122] Add Support for JustBoom Audio boards
+Subject: [PATCH 077/126] Add Support for JustBoom Audio boards
 
 justboom-dac: Adjust for ALSA API change
 
@@ -114966,10 +114966,10 @@ index 0000000000000000000000000000000000000000..91acb666380faa3c0deb2230f8a0f8bb
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From 070a41a6ef5eb0427354b758ce45fee7476e8e84 Mon Sep 17 00:00:00 2001
+From 5984a7e19d18881abe5c4b65cacef8b44bc7606a Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
-Subject: [PATCH 078/122] ARM: adau1977-adc: Add basic machine driver for
+Subject: [PATCH 078/126] ARM: adau1977-adc: Add basic machine driver for
  adau1977 codec driver.
 
 This commit adds basic support for the codec usage including: Device tree overlay,
@@ -115151,10 +115151,10 @@ index 0000000000000000000000000000000000000000..6e2ee027926ee63c89222f75ceb89e3d
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From d3f05a999f9f646a4fad423073c2bfd16ac8cdb7 Mon Sep 17 00:00:00 2001
+From e1d49ab6ab68353e4b07e0b7a0d04cc51f483b49 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
-Subject: [PATCH 079/122] New AudioInjector.net Pi soundcard with low jitter
+Subject: [PATCH 079/126] New AudioInjector.net Pi soundcard with low jitter
  audio in and out.
 
 Contains the sound/soc/bcm ALSA machine driver and necessary alterations to the Kconfig and Makefile.
@@ -115405,10 +115405,10 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 6cdf489fe02f677a7a5312dd53f5b5dfa1632487 Mon Sep 17 00:00:00 2001
+From fc69717b48db3b7dc01de5ecaeca65c6204799dc Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
-Subject: [PATCH 080/122] Add IQAudIO Digi WM8804 board support
+Subject: [PATCH 080/126] Add IQAudIO Digi WM8804 board support
 
 Support IQAudIO Digi board with iqaudio_digi machine driver and
  iqaudio-digi-wm8804-audio overlay.
@@ -115708,10 +115708,10 @@ index 0000000000000000000000000000000000000000..9b6e829bcb5b1762a853775e78163196
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 922b72225da0a94bdc3a2c7a52ac04431e67a6a8 Mon Sep 17 00:00:00 2001
+From 9a4a4b46d8e0393d552df4802ee81c7e3107a88b Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
-Subject: [PATCH 081/122] New driver for RRA DigiDAC1 soundcard using WM8741 +
+Subject: [PATCH 081/126] New driver for RRA DigiDAC1 soundcard using WM8741 +
  WM8804
 
 ---
@@ -116184,10 +116184,10 @@ index 0000000000000000000000000000000000000000..446796e7e4c14a7d95b2f2a01211d9a0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From 1a76a9a2ca9445123234adc7b30e448216da6017 Mon Sep 17 00:00:00 2001
+From 87f27e8fb1b8aad86838390780c9b18b3ec8ce45 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
-Subject: [PATCH 082/122] Add support for Dion Audio LOCO DAC-AMP HAT
+Subject: [PATCH 082/126] Add support for Dion Audio LOCO DAC-AMP HAT
 
 Using dedicated machine driver and pcm5102a codec driver.
 
@@ -116360,10 +116360,10 @@ index 0000000000000000000000000000000000000000..89e65317512bc774453ac8d0d5b0ff98
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From 38964afabad4b0ae7e3d50153daf97dd98277597 Mon Sep 17 00:00:00 2001
+From be51160525620e1ae9466eb654f40f572811738b Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
-Subject: [PATCH 083/122] Allo Piano DAC boards: Initial 2 channel (stereo)
+Subject: [PATCH 083/126] Allo Piano DAC boards: Initial 2 channel (stereo)
  support (#1645)
 
 Add initial 2 channel (stereo) support for Allo Piano DAC (2.0/2.1) boards,
@@ -116570,10 +116570,10 @@ index 0000000000000000000000000000000000000000..8e8e62e5a36a279b425ed4655cfbac99
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 32c97c8263ee9440ac09cf4c117a00563ba86748 Mon Sep 17 00:00:00 2001
+From 2b118b3d839c96a49195e76fc1e2c56f6efdc177 Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
-Subject: [PATCH 084/122] Support for Blokas Labs pisound board
+Subject: [PATCH 084/126] Support for Blokas Labs pisound board
 
 Pisound dynamic overlay (#1760)
 
@@ -117750,10 +117750,10 @@ index 0000000000000000000000000000000000000000..4b8545487d06e4ea70073a5d063fb231
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From 96f367ff7d360c52f563775dd1e9cee71aa63c6d Mon Sep 17 00:00:00 2001
+From 623658bec57485daecf0b62095533005b97f44e9 Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
-Subject: [PATCH 085/122] rpi_display: add backlight driver and overlay
+Subject: [PATCH 085/126] rpi_display: add backlight driver and overlay
 
 Add a mailbox-driven backlight controller for the Raspberry Pi DSI
 touchscreen display. Requires updated GPU firmware to recognise the
@@ -117922,10 +117922,10 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 859fe9e43315cc5f8ec150814ac4d841c9bfdcf1 Mon Sep 17 00:00:00 2001
+From 41b5fdbdfc6f620f3c9e27e78e145c5b16db9733 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
-Subject: [PATCH 086/122] bcm2835-virtgpio: Virtual GPIO driver
+Subject: [PATCH 086/126] bcm2835-virtgpio: Virtual GPIO driver
 
 Add a virtual GPIO driver that uses the firmware mailbox interface to
 request that the VPU toggles LEDs.
@@ -118199,10 +118199,10 @@ index b0f6e33bd30c35664ceee057f4c3ad32b914291d..e92278968b2b979db2a1f855f70e7aaf
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 7968227bc3b1b0b1297b304fbfd4a76de6a1f40e Mon Sep 17 00:00:00 2001
+From cd0910eafeb92301bdd74f837c037d7df56594f5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
-Subject: [PATCH 087/122] amba_pl011: Don't use DT aliases for numbering
+Subject: [PATCH 087/126] amba_pl011: Don't use DT aliases for numbering
 
 The pl011 driver looks for DT aliases of the form "serial<n>",
 and if found uses <n> as the device ID. This can cause
@@ -118231,10 +118231,10 @@ index e2c33b9528d82ed7a2c27d083d7b1d222da68178..5a11ff833e1fd112ba04df3a427cd94b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From 0dba8271302e1c9a96f1ead8f5a7b9a0ffc7325e Mon Sep 17 00:00:00 2001
+From 4fd4dfaeaa45dabafd295bc1fabdee97f51db9dc Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
-Subject: [PATCH 088/122] OF: DT-Overlay configfs interface
+Subject: [PATCH 088/126] OF: DT-Overlay configfs interface
 
 This is a port of Pantelis Antoniou's v3 port that makes use of the
 new upstreamed configfs support for binary attributes.
@@ -118666,10 +118666,10 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From 7599baf5d2f2a063d430fce4de57db739ac1d05c Mon Sep 17 00:00:00 2001
+From 2ab49319b885c35f13a42916631dfb938325dff9 Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
-Subject: [PATCH 089/122] brcm: adds support for BCM43341 wifi
+Subject: [PATCH 089/126] brcm: adds support for BCM43341 wifi
 
 brcmfmac: Disable power management
 
@@ -118832,10 +118832,10 @@ index d0407d9ad7827cd756b6311410ffe2d9a7cacc78..f1fb8a3c7a3211e8429585861f2f42e0
  #define BRCM_CC_4335_CHIP_ID		0x4335
  #define BRCM_CC_4339_CHIP_ID		0x4339
 
-From 409e8d08947ff33556f6bcb8eb6bfdc47613ce6b Mon Sep 17 00:00:00 2001
+From da4c77489f6060aae18847f7311b1df2c53dd7f6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
-Subject: [PATCH 090/122] hci_h5: Don't send conf_req when ACTIVE
+Subject: [PATCH 090/126] hci_h5: Don't send conf_req when ACTIVE
 
 Without this patch, a modem and kernel can continuously bombard each
 other with conf_req and conf_rsp messages, in a demented game of tag.
@@ -118858,10 +118858,10 @@ index 0879d64b1caf58afb6e5d494c07d9ab7e7cdf983..5161ab30fd533d50f516bb93d5b9f402
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From 5fd6ff953ace9d64a39412f410b4a6eb09dd4711 Mon Sep 17 00:00:00 2001
+From 83c7b3c8210b305b4f4c444123cbf571bdfe45cd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
-Subject: [PATCH 091/122] config: Add default configs
+Subject: [PATCH 091/126] config: Add default configs
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1297 +++++++++++++++++++++++++++++++++++
@@ -121488,10 +121488,10 @@ index 0000000000000000000000000000000000000000..8acee9f31202ec14f2933d92dd70831c
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 7452484b501a3dd0ca66226de11cf4fb9a576390 Mon Sep 17 00:00:00 2001
+From f73229cccfd305e29341e82387423756651b495b Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
-Subject: [PATCH 092/122] Add arm64 configuration and device tree differences.
+Subject: [PATCH 092/126] Add arm64 configuration and device tree differences.
  Disable MMC_BCM2835_SDHOST and MMC_BCM2835 since these drivers are crashing
  at the moment.
 
@@ -122906,10 +122906,10 @@ index 0000000000000000000000000000000000000000..d7406f5a4620151044b8f716b4d10bb8
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2708_VCHIQ=n
 
-From d5f278b5d66aaae13361aa90bf4a06a9babf5746 Mon Sep 17 00:00:00 2001
+From 893731162036cdde6253fc5897847eff1ba8d9f7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 7 Mar 2016 15:05:11 +0000
-Subject: [PATCH 093/122] vchiq_arm: Tweak the logging output
+Subject: [PATCH 093/126] vchiq_arm: Tweak the logging output
 
 Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 ---
@@ -122984,10 +122984,10 @@ index 2c98da4307dff994a00dc246574ef0aaee05d5da..160db24aeea33a8296923501009c1f02
  
  		switch (type) {
 
-From b65b8cb1ff93d43d24558076bb81f19b1ab5ea50 Mon Sep 17 00:00:00 2001
+From 1531a7c935fe10425e1ff2342987056423b5965a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 14:16:25 +0000
-Subject: [PATCH 094/122] vchiq_arm: Access the dequeue_pending flag locked
+Subject: [PATCH 094/126] vchiq_arm: Access the dequeue_pending flag locked
 
 Reading through this code looking for another problem (now found in userland)
 the use of dequeue_pending outside a lock didn't seem safe.
@@ -123045,10 +123045,10 @@ index 7b6cd4d80621e38ff6d47fcd87b45fbe9cd4259b..d8669fa7f39b077877eca1829ba9538b
  
  	return add_completion(instance, reason, header, user_service,
 
-From 1236ef13699c7ce7cb486c13c244be0038419918 Mon Sep 17 00:00:00 2001
+From 05b4add4ce45d8ed80e1971d4370213c03283e00 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 20:53:47 +0000
-Subject: [PATCH 095/122] vchiq_arm: Service callbacks must not fail
+Subject: [PATCH 095/126] vchiq_arm: Service callbacks must not fail
 
 Service callbacks are not allowed to return an error. The internal callback
 that delivers events and messages to user tasks does not enqueue them if
@@ -123074,10 +123074,10 @@ index d8669fa7f39b077877eca1829ba9538bf2e21a82..54552c6ce54f413c9781ba279b936f98
  		DEBUG_TRACE(SERVICE_CALLBACK_LINE);
  	}
 
-From 42c9df04946a82e2e84ce093e9fe8e0e00183e05 Mon Sep 17 00:00:00 2001
+From 6743ef891cf68252c0d2f6db0e30878bfeb4d075 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 21 Apr 2016 13:49:32 +0100
-Subject: [PATCH 096/122] vchiq_arm: Add completion records under the mutex
+Subject: [PATCH 096/126] vchiq_arm: Add completion records under the mutex
 
 An issue was observed when flushing openmax components
 which generate a large number of messages returning
@@ -123140,10 +123140,10 @@ index 54552c6ce54f413c9781ba279b936f98be4f47b0..bde8955b7d8505d73579b77b5b392154
  
  	return VCHIQ_SUCCESS;
 
-From e027b929fb8e3c2ca6ee3b9c26104cd88a6ad4b6 Mon Sep 17 00:00:00 2001
+From 476463d6d4adc9379860d16e245928f740a5aec4 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 20 Jun 2016 13:51:44 +0100
-Subject: [PATCH 097/122] vchiq_arm: Avoid use of mutex in add_completion
+Subject: [PATCH 097/126] vchiq_arm: Avoid use of mutex in add_completion
 
 Claiming the completion_mutex within add_completion did prevent some
 messages appearing twice, but provokes a deadlock caused by vcsm using
@@ -123337,10 +123337,10 @@ index 160db24aeea33a8296923501009c1f02bc41e599..71a3bedc55314f3b22dbff40c05dedf0
  		up(&state->slot_available_event);
  	}
 
-From 36afbf3ec01bb2c073b99d9f8e09e72d3aba6b08 Mon Sep 17 00:00:00 2001
+From 94625bf75e63068de1dec7f5955ce68d7780b9b5 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:14:10 -0700
-Subject: [PATCH 098/122] staging/vchi: Convert to current get_user_pages()
+Subject: [PATCH 098/126] staging/vchi: Convert to current get_user_pages()
  arguments.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123377,10 +123377,10 @@ index e5cdda12c7e5c35c69eb96991cfdb8326def167f..085d37588c59198b4e5f00b9249bb842
  		num_pages,                /* len */
  		0,                        /* gup_flags */
 
-From 78c3ef34645364c0313d5322eed35c608e75ed32 Mon Sep 17 00:00:00 2001
+From afa0928172d77ae7cf2d94975e0d47a625f76854 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:16:03 -0700
-Subject: [PATCH 099/122] staging/vchi: Update for rename of
+Subject: [PATCH 099/126] staging/vchi: Update for rename of
  page_cache_release() to put_page().
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123425,10 +123425,10 @@ index 085d37588c59198b4e5f00b9249bb8421695854f..5a2b8fb459ebe086ec229f37b6381bdb
  	kfree(pages);
  }
 
-From 7bc3755fca9fc00495e6ad3857bbf75756a0ad74 Mon Sep 17 00:00:00 2001
+From 53930c65fa8e4bd78ecc765f47f7874d5bea1610 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:21:17 -0700
-Subject: [PATCH 100/122] drivers/vchi: Remove dependency on CONFIG_BROKEN.
+Subject: [PATCH 100/126] drivers/vchi: Remove dependency on CONFIG_BROKEN.
 
 The driver builds now.
 
@@ -123450,10 +123450,10 @@ index 9676fb29075a457109e4d4235f086987aec74868..db8e1beb89f9f8c48ea5964016c8285e
  	help
  		Kernel to VideoCore communication interface for the
 
-From 47fc16ef621f8b834e809715c77f601e104caa3e Mon Sep 17 00:00:00 2001
+From b4b34d440e5bf77e017fcf162f967179abf51984 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
-Subject: [PATCH 101/122] raspberrypi-firmware: Export the general transaction
+Subject: [PATCH 101/126] raspberrypi-firmware: Export the general transaction
  function.
 
 The vc4-firmware-kms module is going to be doing the MBOX FB call.
@@ -123497,10 +123497,10 @@ index e92278968b2b979db2a1f855f70e7aafb224fa98..09e3d871d110eb0762ebdb5ea3293537
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 9ae6d3437ea35dacb0bc1353d7c6646dd2b7913d Mon Sep 17 00:00:00 2001
+From a50f50a57dfd2de0803c126d33527347be3b2e40 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
-Subject: [PATCH 102/122] raspberrypi-firmware: Define the MBOX channel in the
+Subject: [PATCH 102/126] raspberrypi-firmware: Define the MBOX channel in the
  header.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -123522,10 +123522,10 @@ index 09e3d871d110eb0762ebdb5ea329353738d58661..2859db09e25bb945251e85edb39bc434
  
  enum rpi_firmware_property_status {
 
-From 23c8fb1fa456520a1abe7a50484eee18e94f09bc Mon Sep 17 00:00:00 2001
+From 0aefda6c34dc1903faba3b3565c2342daaddb3da Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
-Subject: [PATCH 103/122] drm/vc4: Add a mode for using the closed firmware for
+Subject: [PATCH 103/126] drm/vc4: Add a mode for using the closed firmware for
  display.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -124292,10 +124292,10 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From 26a8008c3e11309384b26b46cfc4c6499c2fe676 Mon Sep 17 00:00:00 2001
+From cfbfd37fc669472f667e16ff8206867cbe184650 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 17 Sep 2016 15:07:10 +0200
-Subject: [PATCH 104/122] i2c: bcm2835: Fix hang for writing messages larger
+Subject: [PATCH 104/126] i2c: bcm2835: Fix hang for writing messages larger
  than 16 bytes
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124385,10 +124385,10 @@ index d4f3239b56865919e1b781b20a7c5ebcd76b4eb9..f283b714aa79e2e4685ed95b04b6b289
  	i2c_dev->msg_buf_remaining = msg->len;
  	reinit_completion(&i2c_dev->completion);
 
-From c91628e1f62406194456f78889477efa6ebe1592 Mon Sep 17 00:00:00 2001
+From c046422b6b934be40a16ab5766856ddd7dbc74be Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 18:24:38 +0200
-Subject: [PATCH 105/122] i2c: bcm2835: Protect against unexpected TXW/RXR
+Subject: [PATCH 105/126] i2c: bcm2835: Protect against unexpected TXW/RXR
  interrupts
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124513,10 +124513,10 @@ index f283b714aa79e2e4685ed95b04b6b289f7e9eee7..d2ba1a4de36af512e8e3c97251bd3537
  		return -ETIMEDOUT;
  	}
 
-From 878f3d3cb001a41cefc17e11e5b527b576478959 Mon Sep 17 00:00:00 2001
+From a796f385989cf751c6021771b8393a45cc964282 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Mon, 19 Sep 2016 17:19:41 +0200
-Subject: [PATCH 106/122] i2c: bcm2835: Use dev_dbg logging on transfer errors
+Subject: [PATCH 106/126] i2c: bcm2835: Use dev_dbg logging on transfer errors
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124548,10 +124548,10 @@ index d2ba1a4de36af512e8e3c97251bd3537ae61591a..54d510abd46a117c9238fc6d7edec840
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From dd301c9f8456669afa77139328d78bac9f2fcb48 Mon Sep 17 00:00:00 2001
+From f7823a7a9b751637d754dbc9f8c372e5d2f89206 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Thu, 22 Sep 2016 22:05:50 +0200
-Subject: [PATCH 107/122] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
+Subject: [PATCH 107/126] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124595,10 +124595,10 @@ index 54d510abd46a117c9238fc6d7edec84019d1f60d..565ef69ce61423544dc0558c85ef318b
  
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
 
-From 17019eef014c360549b56b67f8f6448e718b9496 Mon Sep 17 00:00:00 2001
+From ea6e7ccb8148543d8c6d93ff9ce318c5595a952b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:54:27 +0200
-Subject: [PATCH 108/122] i2c: bcm2835: Add support for Repeated Start
+Subject: [PATCH 108/126] i2c: bcm2835: Add support for Repeated Start
  Condition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -124780,10 +124780,10 @@ index 565ef69ce61423544dc0558c85ef318b0ae9c324..241e08ae7c27cec23fad3c1bf3ebad3a
  
  static u32 bcm2835_i2c_func(struct i2c_adapter *adap)
 
-From 90f2d2d5fb2aa94eafd361372b6a55fa3ad1b029 Mon Sep 17 00:00:00 2001
+From 591327b2fb94f5ad8b60eeb1cccf95c244dd5170 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:57:17 +0200
-Subject: [PATCH 109/122] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
+Subject: [PATCH 109/126] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124820,10 +124820,10 @@ index 241e08ae7c27cec23fad3c1bf3ebad3a4d2a8e6f..d2085dd3742eabebc537621968088261
  		bcm2835_i2c_writel(i2c_dev, BCM2835_I2C_C,
  				   BCM2835_I2C_C_CLEAR);
 
-From d0724c34a0fc6d93228c19bede299e63afe0c036 Mon Sep 17 00:00:00 2001
+From 3d9abe0bcee2568e4893aae0aa281f1e747e20eb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 27 Sep 2016 01:00:08 +0200
-Subject: [PATCH 110/122] i2c: bcm2835: Add support for dynamic clock
+Subject: [PATCH 110/126] i2c: bcm2835: Add support for dynamic clock
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -124939,10 +124939,10 @@ index d2085dd3742eabebc537621968088261f8dc7ea8..c3436f627028477f7e21b47e079fd5ab
  	irq = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
  	if (!irq) {
 
-From 0cc815d16e01c81698ecb53c57222ffb003377bf Mon Sep 17 00:00:00 2001
+From b98f544f2297bcb0dbf9197d1015a0dd2461b58e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
-Subject: [PATCH 111/122] i2c: bcm2835: Add debug support
+Subject: [PATCH 111/126] i2c: bcm2835: Add debug support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -125131,10 +125131,10 @@ index c3436f627028477f7e21b47e079fd5ab06ec188a..8642f580ce41803bd22c76a0fa80d083
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 683eb2a626bdf358dd1d447bfe3b0e7d112d8024 Mon Sep 17 00:00:00 2001
+From 504f40794f52d8e68ed09cd4a5befc4594a7a6b9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 31 Dec 2016 14:15:50 +0000
-Subject: [PATCH 112/122] arm64: Add CONFIG_ARCH_BCM2835
+Subject: [PATCH 112/126] arm64: Add CONFIG_ARCH_BCM2835
 
 ---
  arch/arm64/configs/bcmrpi3_defconfig | 1 +
@@ -125150,10 +125150,10 @@ index d7406f5a4620151044b8f716b4d10bb818648e06..53da5c7a33e5898a66e549fb0c39fe3d
  CONFIG_BCM2708_VCHIQ=n
 +CONFIG_ARCH_BCM2835=y
 
-From 8ec76aa6373a8c90eac7d8c8e980fa333ff69464 Mon Sep 17 00:00:00 2001
+From 3b1db21ebe44c4a08d2d54e84f130a9fd487f497 Mon Sep 17 00:00:00 2001
 From: Alex Tucker <alex@floop.org.uk>
 Date: Tue, 13 Dec 2016 19:50:18 +0000
-Subject: [PATCH 113/122] Add support for Silicon Labs Si7013/20/21
+Subject: [PATCH 113/126] Add support for Silicon Labs Si7013/20/21
  humidity/temperature sensor.
 
 ---
@@ -125228,10 +125228,10 @@ index f6d134c095af2398fc55ae7d2b0e86456c30627c..31bda8da4cb6a56bfe493a81b9189009
  	};
  };
 
-From 3b6760e6f2f03b620e4e88d67d3b640c56ce7fd3 Mon Sep 17 00:00:00 2001
+From f1b7b8223e554bafa84153b47a8455a97ede511f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 3 Jan 2017 21:27:46 +0000
-Subject: [PATCH 114/122] Document the si7020 option
+Subject: [PATCH 114/126] Document the si7020 option
 
 ---
  arch/arm/boot/dts/overlays/README | 3 +++
@@ -125252,10 +125252,10 @@ index 81d991803be335e5a1bc3bb0a8c7a2c9f5c392bd..e8fa4ccb44c34a20485c4e6155467af9
  Name:   i2c0-bcm2708
  Info:   Enable the i2c_bcm2708 driver for the i2c0 bus. Not all pin combinations
 
-From 4ef541bea608cd9f84bc76c8092fafaad1702e3f Mon Sep 17 00:00:00 2001
+From 42d2251f9849b14b58402da3c177a2eb325a182a Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Thu, 5 Jan 2017 02:38:16 +0200
-Subject: [PATCH 115/122] pisound improvements:
+Subject: [PATCH 115/126] pisound improvements:
 
 * Added a writable sysfs object to enable scripts / user space software
 to blink MIDI activity LEDs for variable duration.
@@ -125549,10 +125549,10 @@ index 4b8545487d06e4ea70073a5d063fb2310b3b94d0..ba70734b89e61a11201657406223f0b3
  };
  
 
-From 425e9111b1dfad787b1f787ec5086fdf1893584e Mon Sep 17 00:00:00 2001
+From 7a6348a0ef0c816a772df87b67f42db4e8ecd7b1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:23:06 +0000
-Subject: [PATCH 116/122] Revert "Revert "Added driver for HiFiBerry Amp
+Subject: [PATCH 116/126] Revert "Revert "Added driver for HiFiBerry Amp
  amplifier add-on board""
 
 This reverts commit bf84babd8fffcb79c60f1342c2416f8e1e4b7af9.
@@ -126376,10 +126376,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 15550aafac107a499180a103bcaceed80f37dacd Mon Sep 17 00:00:00 2001
+From 7aa495fd4a95be275e8174a87a07c7f24f4b9a44 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:42:09 +0000
-Subject: [PATCH 117/122] hifiberry-amp: Adjust for ALSA object refactoring
+Subject: [PATCH 117/126] hifiberry-amp: Adjust for ALSA object refactoring
 
 See: https://github.com/raspberrypi/linux/issues/1775
 ---
@@ -126404,10 +126404,10 @@ index 9b2713861dcbed751842ca29c88eb1eae5867411..560234d58a6b0a6e7fd3a63e8de73339
  
  
 
-From d3a7daff54ea1d57654aa2be744d6173441b5e35 Mon Sep 17 00:00:00 2001
+From 45c5e3bb6025a71296f677060e32a1f9f36f6f15 Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Sun, 8 Jan 2017 15:58:54 +0200
-Subject: [PATCH 118/122] bcm2835-i2s: Changes for allowing asymmetric sample
+Subject: [PATCH 118/126] bcm2835-i2s: Changes for allowing asymmetric sample
  formats.
 
 This is achieved by making changes only to the requested
@@ -126497,10 +126497,10 @@ index 6ba20498202ed36906b52096893a88867a79269f..171c2401dfe192740fca3356268aff64
  
  	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);
 
-From a268f59a304d04349f3a0358db1f434e47cda8b6 Mon Sep 17 00:00:00 2001
+From efccc436e8c92a264cf87cc63786f62b04ee514c Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Tue, 10 Jan 2017 16:05:41 +0000
-Subject: [PATCH 119/122] Add driver_name property
+Subject: [PATCH 119/126] Add driver_name property
 
 Add driver name property for use with 5.1 passthrough audio in LibreElec and other Kodi based OSs
 ---
@@ -126520,10 +126520,10 @@ index 8fd50dbe681508a2cfe8fdde1c9fedbe9a507fa7..05a224ec712d06b8b7587ab6b8bb562d
  	.dai_link     = snd_rpi_justboom_dac_dai,
  	.num_links    = ARRAY_SIZE(snd_rpi_justboom_dac_dai),
 
-From ad475b3f75da457818fa6fab1c1e2f89f453dc07 Mon Sep 17 00:00:00 2001
+From f325733abda5130df8f1f26d826a03538ef6575e Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Tue, 10 Jan 2017 16:11:04 +0000
-Subject: [PATCH 120/122] Add driver_name paramater
+Subject: [PATCH 120/126] Add driver_name paramater
 
 Add driver_name parameter for use with 5.1 passthrough audio in LibreElec and other Kodi OSs
 ---
@@ -126543,10 +126543,10 @@ index 91acb666380faa3c0deb2230f8a0f8bbec59417b..abfdc5c4dd5811e6847bddda4921abe3
  	.dai_link     = snd_rpi_justboom_digi_dai,
  	.num_links    = ARRAY_SIZE(snd_rpi_justboom_digi_dai),
 
-From 987aadab51987bac29470f3ee200fa8bfa2eae6b Mon Sep 17 00:00:00 2001
+From 9a5475f6f85e40500f4120e318f84b974c19c0b7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 Jan 2017 13:01:21 +0000
-Subject: [PATCH 121/122] BCM270X_DT: Add pi3-disable-wifi overlay
+Subject: [PATCH 121/126] BCM270X_DT: Add pi3-disable-wifi overlay
 
 pi3-disable-wifi is a minimal overlay to disable the onboard WiFi.
 
@@ -126607,10 +126607,10 @@ index 0000000000000000000000000000000000000000..017199554bf2f4e381efcc7bb71e750c
 +	};
 +};
 
-From 5c94b3839b261c3c73893677ab6e2355a1177b74 Mon Sep 17 00:00:00 2001
+From 6b6de5861eec98a4f765cc61d0eecddb152e6373 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
-Subject: [PATCH 122/122] ARM64: Make it work again on 4.9 (#1790)
+Subject: [PATCH 122/126] ARM64: Make it work again on 4.9 (#1790)
 
 * Invoke the dtc compiler with the same options used in arm mode.
 * ARM64 now uses the bcm2835 platform just like ARM32.
@@ -127014,3 +127014,186 @@ index 53da5c7a33e5898a66e549fb0c39fe3da555ca87..c7e891d72969a388d9b135a36dbfc9c9
  CONFIG_LIBCRC32C=y
 -CONFIG_BCM2708_VCHIQ=n
 -CONFIG_ARCH_BCM2835=y
+
+From b00cfaf9d203423b82499a3e05e94ed4d7e95913 Mon Sep 17 00:00:00 2001
+From: Electron752 <mzoran@crowfest.net>
+Date: Sat, 14 Jan 2017 02:54:26 -0800
+Subject: [PATCH 123/126] ARM64: Enable Kernel Address Space Randomization
+ (#1792)
+
+Randomization allows the mapping between virtual addresses and physical
+address to be different on each boot.  This makes it more difficult
+to exploit security vulnerabilities that require knowledge of fixed
+hardware addresses.
+
+The firmware generates a 8 byte random number during bootup and stores
+it in the device tree under chosen/kaslr-seed. This number is used
+to randomize the address mapping.
+
+This change enables this feature in the build configuration for ARM64.
+
+Signed-off-by: Michael Zoran <mzoran@crowfest.net>
+---
+ arch/arm64/configs/bcmrpi3_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/configs/bcmrpi3_defconfig b/arch/arm64/configs/bcmrpi3_defconfig
+index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..974d8889c0cf695eb88b57bbef11bc5aa556b635 100644
+--- a/arch/arm64/configs/bcmrpi3_defconfig
++++ b/arch/arm64/configs/bcmrpi3_defconfig
+@@ -53,6 +53,7 @@ CONFIG_ARMV8_DEPRECATED=y
+ CONFIG_SWP_EMULATION=y
+ CONFIG_CP15_BARRIER_EMULATION=y
+ CONFIG_SETEND_EMULATION=y
++CONFIG_RANDOMIZE_BASE=y
+ CONFIG_CMDLINE="console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
+ CONFIG_BINFMT_MISC=y
+ CONFIG_COMPAT=y
+
+From b1dfb870425346b48c7b588eb3bd50a4a629cd7c Mon Sep 17 00:00:00 2001
+From: Michael Zoran <mzoran@crowfest.net>
+Date: Sun, 15 Jan 2017 07:31:59 -0800
+Subject: [PATCH 124/126] ARM64: Enable RTL8187/RTL8192CU wifi in build config
+
+These drivers build now, so they can be enabled back
+in the build configuration just like they are for
+32 bit.
+
+Signed-off-by: Michael Zoran <mzoran@crowfest.net>
+---
+ arch/arm64/configs/bcmrpi3_defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/configs/bcmrpi3_defconfig b/arch/arm64/configs/bcmrpi3_defconfig
+index 974d8889c0cf695eb88b57bbef11bc5aa556b635..4670a490dfb1e582ec24a3b39a3cb9b2488b1864 100644
+--- a/arch/arm64/configs/bcmrpi3_defconfig
++++ b/arch/arm64/configs/bcmrpi3_defconfig
+@@ -531,6 +531,8 @@ CONFIG_RT2800USB_RT3573=y
+ CONFIG_RT2800USB_RT53XX=y
+ CONFIG_RT2800USB_RT55XX=y
+ CONFIG_RT2800USB_UNKNOWN=y
++CONFIG_RTL8187=m
++CONFIG_RTL8192CU=m
+ CONFIG_USB_ZD1201=m
+ CONFIG_ZD1211RW=m
+ CONFIG_MAC80211_HWSIM=m
+
+From 919a5200ce78100c08f4dc1e6c2964acc60a4976 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Mon, 16 Jan 2017 14:53:12 +0000
+Subject: [PATCH 125/126] BCM270X_DT: Add spi0-cs overlay
+
+The spi0-cs overlay allows the software chip selectts to be modified
+using the cs0_pin and cs1_pin parameters.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ arch/arm/boot/dts/overlays/Makefile            |  1 +
+ arch/arm/boot/dts/overlays/README              |  9 +++++++-
+ arch/arm/boot/dts/overlays/spi0-cs-overlay.dts | 29 ++++++++++++++++++++++++++
+ 3 files changed, 38 insertions(+), 1 deletion(-)
+ create mode 100644 arch/arm/boot/dts/overlays/spi0-cs-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index f1191c1ded82490be5f793ab6483bc5af5891db2..45fafd5c39bdc6e80b12e49d3bcd281638bec471 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -83,6 +83,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	smi-nand.dtbo \
+ 	spi-gpio35-39.dtbo \
+ 	spi-rtc.dtbo \
++	spi0-cs.dtbo \
+ 	spi0-hw-cs.dtbo \
+ 	spi1-1cs.dtbo \
+ 	spi1-2cs.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/README b/arch/arm/boot/dts/overlays/README
+index 34109c69416c1caf28910895320a2b9cd539588e..4992a6203a5507144b6d405e03ed2bebaa11325f 100644
+--- a/arch/arm/boot/dts/overlays/README
++++ b/arch/arm/boot/dts/overlays/README
+@@ -1138,7 +1138,7 @@ Params: <None>
+ 
+ 
+ Name:   spi-gpio35-39
+-Info:   move SPI function block to GPIO 35 to 39
++Info:   Move SPI function block to GPIO 35 to 39
+ Load:   dtoverlay=spi-gpio35-39
+ Params: <None>
+ 
+@@ -1149,6 +1149,13 @@ Load:   dtoverlay=spi-rtc,<param>=<val>
+ Params: pcf2123                 Select the PCF2123 device
+ 
+ 
++Name:   spi0-cs
++Info:   Allows the (software) CS pins for SPI0 to be changed
++Load:   dtoverlay=spi0-cs,<param>=<val>
++Params: cs0_pin                 GPIO pin for CS0 (default 8)
++        cs1_pin                 GPIO pin for CS1 (default 7)
++
++
+ Name:   spi0-hw-cs
+ Info:   Re-enables hardware CS/CE (chip selects) for SPI0
+ Load:   dtoverlay=spi0-hw-cs
+diff --git a/arch/arm/boot/dts/overlays/spi0-cs-overlay.dts b/arch/arm/boot/dts/overlays/spi0-cs-overlay.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..7f79029d043c04d7496c7c3480450c691dc9a5cb
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/spi0-cs-overlay.dts
+@@ -0,0 +1,29 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
++
++	fragment@0 {
++		target = <&spi0_cs_pins>;
++		frag0: __overlay__ {
++			brcm,pins = <8 7>;
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		frag1: __overlay__ {
++			cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
++			status = "okay";
++		};
++	};
++
++	__overrides__ {
++		cs0_pin  = <&frag0>,"brcm,pins:0",
++			   <&frag1>,"cs-gpios:4";
++		cs1_pin  = <&frag0>,"brcm,pins:4",
++			   <&frag1>,"cs-gpios:16";
++	};
++};
+
+From e99d502473165aab168bb777e5e4818e6069e03a Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Fri, 1 Jul 2016 22:09:24 +0100
+Subject: [PATCH 126/126] spi-bcm2835: Disable forced software CS
+
+Select software CS in bcm2708_common.dtsi, and disable the automatic
+conversion in the driver to allow hardware CS to be re-enabled with an
+overlay.
+
+See: https://github.com/raspberrypi/linux/issues/1547
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ arch/arm/boot/dts/bcm283x.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/boot/dts/bcm283x.dtsi b/arch/arm/boot/dts/bcm283x.dtsi
+index 46d46d894a441d69dcf784fb2cf54d4d72038aa0..8c495461f9b850cc985d074d275446741a7367c1 100644
+--- a/arch/arm/boot/dts/bcm283x.dtsi
++++ b/arch/arm/boot/dts/bcm283x.dtsi
+@@ -163,6 +163,7 @@
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+ 			status = "disabled";
++			cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 		};
+ 
+ 		i2c0: i2c@7e205000 {

--- a/tools/RPi/rpi-linux-rebase.sh
+++ b/tools/RPi/rpi-linux-rebase.sh
@@ -17,6 +17,7 @@ DROP_COMMITS="
 Added Device IDs for August DVB-T 205
 net\: Add non-mainline source for rtl8192cu wlan
 net\: Fix rtl8192cu build errors on other platforms
+ARM64\: Fix build break for RTL8187\/RTL8192CU wifi
 "
 
 IFS=$'\n'


### PR DESCRIPTION
Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.9.4

Not bumping the RPi firmware to latest master with this PR, as there might be a regression (https://github.com/Hexxeh/rpi-firmware/issues/133). Can bump firmware later once this issue is resolved.