### PR TITLE
e2fsprogs: make e2fsprogs bumpable

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -114,6 +114,9 @@ makeinstall_host() {
   rm -fr $(pwd)/.install/bin
   rm -fr $(pwd)/.install/usr/share
 
+  # Ensure installed files are writeable and not read-only, otherwise future package bumps will fail to overwrite toolchain
+  chmod -R +w $(pwd)/.install/usr/*
+
   cp -Pa $(pwd)/.install/usr/* $ROOT/$TOOLCHAIN
 }
 


### PR DESCRIPTION
`e2fsprogs:host` will create files in the `.install` directory that are read-only:

```
neil@nm-linux:~/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel$ ls -la e2fsprogs-1.43.3/.x86_64-linux-gnu/.install/usr/lib/
total 580
drwxrwxr-x 3 neil neil   4096 Jan 17 23:11 .
drwxrwxr-x 4 neil neil   4096 Jan 17 23:11 ..
-r--r--r-- 1 neil neil  19016 Jan 17 23:11 libcom_err.a
-r--r--r-- 1 neil neil 557982 Jan 17 23:11 libext2fs.a
drwxrwxr-x 2 neil neil   4096 Jan 17 23:11 pkgconfig
```

These files are then copied to `toolchain/lib` with the same read-only file attributes.

When the package is subsequently bumped and new toolchain files are created, the new files cannot be copied if the destination folder already contains read-only files from a previous build. The build fails.