### PR TITLE
kodi: create sym link for latest crashlog

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi.sh
+++ b/packages/mediacenter/kodi/scripts/kodi.sh
@@ -82,6 +82,7 @@ print_crash_report()
   OFILE="$FILE"
   FILE="$CRASHLOG_DIR/kodi_crashlog_$DATE.log"
   mv "$OFILE" "$FILE"
+  ln -sf "$FILE" "$CRASHLOG_DIR/kodi_crash.log"
   echo "Crash report available at $FILE"
 }
 


### PR DESCRIPTION
Create `/storage/.kodi/temp/kodi_crash.log` sym link to latest Kodi crash log.

Main reason for adding this is to simplify instructions to users, as there can be up to 10 crashlogs and we usually only ever want the latest.

Will backport this.
