### PR TITLE
Rework WP2 amremote keymapping

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -77,11 +77,6 @@ SUBSYSTEMS=="input", ATTRS{name}=="gpio_keypad", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="default.evmap"
 
-# Amlogic Remotes
-SUBSYSTEMS=="input", ATTRS{name}=="aml_keypad", \
-  ENV{eventlircd_enable}="true", \
-  ENV{eventlircd_evmap}="default.evmap"
-
 #-------------------------------------------------------------------------------
 # Ask eventlircd to handle USB HID devices that show up as event devices and are
 # known to be remote controls. For simplicity, the event map file names have the

--- a/projects/WeTek_Play_2/filesystem/etc/amremote/remote.conf
+++ b/projects/WeTek_Play_2/filesystem/etc/amremote/remote.conf
@@ -51,35 +51,35 @@ mouse_end
 
 key_begin
     0x02 116 # power
-    0x46 88 # 2nd power button (F12, ends WeTV)
+    0x46 88  # 2nd power button (F12, ends WeTV)
     0x10 113 # volume mute
-    0x22 2 # 1
-    0x23 3 # 2
-    0x24 4 # 3
-    0x25 5 # 4
-    0x26 6 # 5
-    0x27 7 # 6
-    0x28 8 # 7
-    0x29 9 # 8
-    0x30 10 # 9
-    0x71 14 # delete
-    0x21 11 # 0
-    0x72 58 # caps lock
+    0x22 2   # 1
+    0x23 3   # 2
+    0x24 4   # 3
+    0x25 5   # 4
+    0x26 6   # 5
+    0x27 7   # 6
+    0x28 8   # 7
+    0x29 9   # 8
+    0x30 10  # 9
+    0x71 14  # delete
+    0x21 11  # 0
+    0x72 58  # caps lock
     0x48 127 # menu
     0x03 102 # home
     0x61 158 # back
-    0x83 580 # app_switch
-    0x77 373 # assist
+    0x83 139 # app_switch (mapped as KEY_MENU)
+    0x77 138 # assist (mapped as KEY_HELP)
     0x50 103 # up
     0x4b 108 # down
     0x4c 105 # left
     0x4d 106 # right
-    0x47 28 # ok
+    0x47 28  # ok
     0x44 115 # volume up
     0x43 114 # volume down
-    0x41 402 # channel up
-    0x42 403 # channel down
-    0x4f 64 # * (mapped as f6)
+    0x41 104 # channel up (mapped as PageUp)
+    0x42 109 # channel down (mapped as PageDown)
+    0x4f 85  # *
     0x82 388 # teletext
     0x73 398 # red
     0x74 399 # green
@@ -96,35 +96,35 @@ key_end
 
 repeat_key_begin
     0x02 116 # power
-    0x46 88 # 2nd power button (F12, ends WeTV)
+    0x46 88  # 2nd power button (F12, ends WeTV)
     0x10 113 # volume mute
-    0x22 2 # 1
-    0x23 3 # 2
-    0x24 4 # 3
-    0x25 5 # 4
-    0x26 6 # 5
-    0x27 7 # 6
-    0x28 8 # 7
-    0x29 9 # 8
-    0x30 10 # 9
-    0x71 14 # delete
-    0x21 11 # 0
-    0x72 58 # caps lock
+    0x22 2   # 1
+    0x23 3   # 2
+    0x24 4   # 3
+    0x25 5   # 4
+    0x26 6   # 5
+    0x27 7   # 6
+    0x28 8   # 7
+    0x29 9   # 8
+    0x30 10  # 9
+    0x71 14  # delete
+    0x21 11  # 0
+    0x72 58  # caps lock
     0x48 127 # menu
     0x03 102 # home
     0x61 158 # back
-    0x83 580 # app_switch
-    0x77 373 # assist
+    0x83 139 # app_switch (mapped as KEY_MENU)
+    0x77 138 # assist (mapped as KEY_HELP)
     0x50 103 # up
     0x4b 108 # down
     0x4c 105 # left
     0x4d 106 # right
-    0x47 353 # ok
+    0x47 28  # ok
     0x44 115 # volume up
     0x43 114 # volume down
-    0x41 402 # channel up
-    0x42 403 # channel down
-    0x4f 64 # * (mapped as f6)
+    0x41 104 # channel up (mapped as PageUp)
+    0x42 109 # channel down (mapped as PageDown)
+    0x4f 85  # *
     0x82 388 # teletext
     0x73 398 # red
     0x74 399 # green

--- a/projects/WeTek_Play_2/filesystem/etc/amremote/remote.conf
+++ b/projects/WeTek_Play_2/filesystem/etc/amremote/remote.conf
@@ -64,7 +64,7 @@ key_begin
     0x30 10 # 9
     0x71 14 # delete
     0x21 11 # 0
-    0x72 87 # capslock (mapped as F11)
+    0x72 58 # caps lock
     0x48 127 # menu
     0x03 102 # home
     0x61 158 # back


### PR DESCRIPTION
This reverts my PR #1081 and fixes the missing buttons for the original WP2 remote.
Using eventlircd has the disadvantage that long press is no longer working also there are some problems with other Amlogic remotes as reported by @kszaq.

Most of the buttons work out of the box with Kodi as they should. Everything else can be remapped with Keymap Editor Addon.

EDIT:
sms style input works too: http://kodi.wiki/view/HOW-TO:Use_SMS-style_text_entry_for_remotes

Please test before merge.