### PR TITLE
RBP: update to firmware debe2d2

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="6df93de"
+PKG_VERSION="debe2d2"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="6df93de"
+PKG_VERSION="debe2d2"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"


### PR DESCRIPTION
(As mentioned in #1207)

 firmware: di_adv: Fix for green artefacts regression

See: http://forum.kodi.tv/showthread.php?tid=304573

firmware: di_adv: Avoid artefacts at bottom of video for YUV420
See: http://forum.kodi.tv/showthread.php?tid=304814

firmware: raspistill: Added SIGUSR2 signal to capture and exit immediately
See: raspberrypi/userland#368

firmware: dispmanx: Protect a null element access

firmware: leds: Provide a way of changing LED assignments for CM3
firmware: leds: Prevent re-initialisation