### PR TITLE
zlib: Fix dead link by bumping to 1.2.11

### DIFF
--- a/packages/compress/zlib/package.mk
+++ b/packages/compress/zlib/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="zlib"
-PKG_VERSION="1.2.9"
+PKG_VERSION="1.2.11"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.zlib.net"


### PR DESCRIPTION
For reference: https://forum.libreelec.tv/thread-4254-post-30631.html#pid30631

Please test.