### PR TITLE
zlib: update to zlib-1.2.11

### DIFF
--- a/packages/compress/zlib/package.mk
+++ b/packages/compress/zlib/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="zlib"
-PKG_VERSION="1.2.9"
+PKG_VERSION="1.2.11"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.zlib.net"


### PR DESCRIPTION
From "http://www.zlib.net/"
"Due to the bug fixes, any installations of 1.2.9 or 1.2.10 should be immediately replaced with 1.2.11"
1.2.9 is not available to download.