### PR TITLE
media_build: custom config should be named .myconfig

### DIFF
--- a/packages/linux-drivers/media_build/package.mk
+++ b/packages/linux-drivers/media_build/package.mk
@@ -42,11 +42,11 @@ make_target() {
   # copy config file
   if [ "$PROJECT" = Generic ] || [ "$PROJECT" = Virtual ]; then
     if [ -f $PKG_DIR/config/generic.config ]; then
-      cp $PKG_DIR/config/generic.config v4l/.config
+      cp $PKG_DIR/config/generic.config v4l/.myconfig
     fi
   else
     if [ -f $PKG_DIR/config/usb.config ]; then
-      cp $PKG_DIR/config/usb.config v4l/.config
+      cp $PKG_DIR/config/usb.config v4l/.myconfig
     fi
   fi
 


### PR DESCRIPTION
When custom media_build config is provided, it should be named .myconfig.
Otherwise v4l/version.txt is not taken into account and building fails for
older kernel versions.