### PR TITLE
scripts/unpack: use relative path for showing a patch file

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -171,7 +171,7 @@ for i in $PKG_DIR/patches/$PKG_NAME-*.patch \
   fi
 
   if [ -f "$i" ]; then
-    printf "%${BUILD_INDENT}c ${boldgreen}APPLY PATCH${endcolor} ${boldwhite}${PATCH_DESC}${endcolor}   $i\n" ' '>&$SILENT_OUT
+    printf "%${BUILD_INDENT}c ${boldgreen}APPLY PATCH${endcolor} ${boldwhite}${PATCH_DESC}${endcolor}   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
     if [ -n "$(grep -E '^GIT binary patch$' $i)" ]; then
       cat $i | git apply --directory=`echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 --verbose --whitespace=nowarn >&$VERBOSE_OUT
     else


### PR DESCRIPTION
from
`APPLY PATCH (common)   /data/LibreELEC.tv/packages/audio/alsa-lib/patches/alsa-lib-USB_Soundblaster_HD.patch
`
to
`APPLY PATCH (common)   packages/audio/alsa-lib/patches/alsa-lib-USB_Soundblaster_HD.patch`
