### PR TITLE
alsa-utils: fix man build in same enviroments

### DIFF
--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -37,7 +37,8 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-dependency-tracking \
                            --disable-alsaloop \
                            --enable-alsatest \
                            --disable-bat \
-                           --disable-nls"
+                           --disable-nls \
+                           --disable-rst2man"
 
 
 post_makeinstall_target() {


### PR DESCRIPTION
new alsa-utils failed to build, when python-docutils is installed.
With this patch, the problematic man files are not build (there are not needed)