### PR TITLE
bluez: set AutoEnable policy

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -72,6 +72,12 @@ post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin/bluemoon
   rm -rf $INSTALL/usr/bin/ciptool
   rm -rf $INSTALL/usr/share/dbus-1
+
+  mkdir -p $INSTALL/etc/bluetooth
+    cp src/main.conf $INSTALL/etc/bluetooth
+    sed -i $INSTALL/etc/bluetooth/main.conf \
+        -e "s|^#\[Policy\]|\[Policy\]|g" \
+        -e "s|^#AutoEnable.*|AutoEnable=true|g"
 }
 
 post_install() {


### PR DESCRIPTION
Initial discussion: https://forum.libreelec.tv/thread-372-post-31335.html#pid31335
Bluetooth device is not powered up on the Asrock Beebox N3xxx machines. Maybe on some other machines too...

I then found that the fix has been added in OE: https://github.com/OpenELEC/OpenELEC.tv/commit/f887de1fc6e316629d770b83f773657fdf74c245

So this is the same fix here.