### PR TITLE
libressl: update to 2.4.5 for security reasons

### DIFF
--- a/packages/security/libressl/package.mk
+++ b/packages/security/libressl/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libressl"
-PKG_VERSION="2.4.4"
+PKG_VERSION="2.4.5"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.libressl.org/"


### PR DESCRIPTION
libressl: update to 2.4.5 for security