### PR TITLE
mesa: update to 13.0.4

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="mesa"
-PKG_VERSION="13.0.3"
+PKG_VERSION="13.0.4"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"


### PR DESCRIPTION
Mesa 13.0.4 is a bug fix release which fixes bugs found since the 13.0.3 release.
changelog: https://lists.freedesktop.org/archives/mesa-announce/2017-February/000294.html

tested