### PR TITLE
linux: update to linux-4.9.7

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="debe2d2"
+PKG_VERSION="72b44d8"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -59,7 +59,7 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.9.6"
+    PKG_VERSION="4.9.7"
     PKG_URL="http://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="debe2d2"
+PKG_VERSION="72b44d8"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,4 +1,4 @@
-From 19b19e36968fd1bda47e59e4aaa3d1b0a048e2af Mon Sep 17 00:00:00 2001
+From 01c050eb771ed7280bd23ebe6fc2b59cd482916f Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
 Subject: [PATCH 001/139] smsx95xx: fix crimes against truesize
@@ -48,7 +48,7 @@ index 831aa33d078ae7d2dd57fdded5de71d1eb915f99..b77935bded8c0ff7808b00f170ff10e5
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From 3b849a978a066d4a542b35a3c9115e1d0dd33daa Mon Sep 17 00:00:00 2001
+From db2a4f2b3eae2a900ab27c46e2a31a61fb616b24 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
 Subject: [PATCH 002/139] smsc95xx: Experimental: Enable turbo_mode and
@@ -94,7 +94,7 @@ index b77935bded8c0ff7808b00f170ff10e594300ad0..693f163684de921404738e33244881e0
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From 323e1c431de92e9eedf6a2a4ab69dacf68d192e8 Mon Sep 17 00:00:00 2001
+From b8b58f81dc5c0859d80de6c09cbd20e5d3c2730c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
 Subject: [PATCH 003/139] Allow mac address to be set in smsc95xx
@@ -193,7 +193,7 @@ index 693f163684de921404738e33244881e0aab92ec9..df60c989fc229bf0aab3c27e95ccd453
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From aa23572116974823b66c52d9aeb7c883c3f57027 Mon Sep 17 00:00:00 2001
+From cd6385d269e0b80c58c262039b18e3a1f81d176c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
 Subject: [PATCH 004/139] Protect __release_resource against resources without
@@ -224,7 +224,7 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From a4282163e4a337ce384ce7e41617905bfea37ba4 Mon Sep 17 00:00:00 2001
+From 9fbb3ee3831d7983504979453c032ed92430e294 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
 Subject: [PATCH 005/139] mm: Remove the PFN busy warning
@@ -239,10 +239,10 @@ Signed-off-by: Eric Anholt <eric@anholt.net>
  1 file changed, 2 deletions(-)
 
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 34ada718ef47c4b27730214d584f9350fefb9883..3fa01a5280db96075798e4cbd58d5520ddf36d88 100644
+index f4a02e240fb68acbaa0d3a0c7ac5a498c051a272..0e1fba92702858ceaf2f92a1d5fa53d5b16b52fe 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
-@@ -7297,8 +7297,6 @@ int alloc_contig_range(unsigned long start, unsigned long end,
+@@ -7323,8 +7323,6 @@ int alloc_contig_range(unsigned long start, unsigned long end,
  
  	/* Make sure the range is really isolated. */
  	if (test_pages_isolated(outer_start, end, false)) {
@@ -252,7 +252,7 @@ index 34ada718ef47c4b27730214d584f9350fefb9883..3fa01a5280db96075798e4cbd58d5520
  		goto done;
  	}
 
-From 4d80990d04e9f05d22b5f2aa60b04eac17e0a992 Mon Sep 17 00:00:00 2001
+From d542076feb89d4520ad894db111be43625412749 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
 Subject: [PATCH 006/139] irq-bcm2836: Prevent spurious interrupts, and trap
@@ -282,7 +282,7 @@ index d96b2c947e74e3edab3917551c64fbd1ced0f34c..93e3f7660c4230c9f1dd3b195958cb49
  #endif
  	} else if (stat) {
 
-From 776cdf599f81ae27fee194ff1830dea2ba888d75 Mon Sep 17 00:00:00 2001
+From cb2a38096d0532522957d17bfea943b4a749ba9e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
 Subject: [PATCH 007/139] irqchip: bcm2835: Add FIQ support
@@ -414,7 +414,7 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 1b4bd9d956338a403c31de5f27c058f2d8a5fec5 Mon Sep 17 00:00:00 2001
+From 5e8863cff89dff4c4d1eb9b7cf432e1e128cbc6d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
 Subject: [PATCH 008/139] irqchip: irq-bcm2835: Add 2836 FIQ support
@@ -516,7 +516,7 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From e9ae9ecfd8dbbfe62ab50769139b6987d6472567 Mon Sep 17 00:00:00 2001
+From 9c064ac67f884d4eb641a201726153dced37fbb7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
 Subject: [PATCH 009/139] spidev: Add "spidev" compatible string to silence
@@ -540,7 +540,7 @@ index 2e05046f866bd01bf87edcdeff0d5b76d4d0aea7..d780491b8013a4e97fa843958964454e
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 796c3fb31d9d46dfd7a52c542ab42b8fa9746c10 Mon Sep 17 00:00:00 2001
+From 4fa58613ec686f255ee03153abd8cf0d960f648f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 30 Jun 2015 14:12:42 +0100
 Subject: [PATCH 010/139] serial: 8250: Don't crash when nr_uarts is 0
@@ -563,7 +563,7 @@ index e8819aa20415603c80547e382838a8fa3ce54792..cf9c7d2e3f95e1a19410247a89c2e49c
  	for (i = 0; i < nr_uarts; i++) {
  		struct uart_8250_port *up = &serial8250_ports[i];
 
-From 1b904739cb5a74f77a0a2cd441d1fbad44a87056 Mon Sep 17 00:00:00 2001
+From eabec7d99729342aab788e0139d25648510eece5 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
 Subject: [PATCH 011/139] pinctrl-bcm2835: Set base to 0 give expected gpio
@@ -588,7 +588,7 @@ index fa77165fab2c1348163979da507df17e7168c49b..d11e2e4ea189466e686d762cb6c6fef9
  	.can_sleep = false,
  };
 
-From 2231c8737d0513e5ef63e8f3813d78acde428a81 Mon Sep 17 00:00:00 2001
+From e88af0dd4b9765386c158ccdaa3fc8f86ac6664f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
 Subject: [PATCH 012/139] pinctrl-bcm2835: Fix interrupt handling for GPIOs
@@ -737,7 +737,7 @@ index d11e2e4ea189466e686d762cb6c6fef9111ecf8e..107ad7d58de8f8a7f55e09c9cdcf7d66
  	},
  };
 
-From c661156e0d492293fe8f9f302bfaae94debb6ea0 Mon Sep 17 00:00:00 2001
+From ff3a2bf24e366702a2a5443e0cb5e93c46d2cf8f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
 Subject: [PATCH 013/139] pinctrl-bcm2835: Only request the interrupts listed
@@ -767,7 +767,7 @@ index 107ad7d58de8f8a7f55e09c9cdcf7d66fa7ab66b..644bdecbcfcb79d3b84a33769265fca5
  		pc->irq_data[i].irqgroup = i;
  
 
-From 5ed11f16df89c1906aeabe516893535cedd22163 Mon Sep 17 00:00:00 2001
+From 32b41178bba5b6f6aa3c145dd1dfa27899aa81cd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 May 2016 12:32:47 +0100
 Subject: [PATCH 014/139] pinctrl-bcm2835: Return pins to inputs when freed
@@ -811,7 +811,7 @@ index 644bdecbcfcb79d3b84a33769265fca5d3d0c9e5..81a66cba2ab0f7e3ae179de7edd10122
  	.get_function_name = bcm2835_pmx_get_function_name,
  	.get_function_groups = bcm2835_pmx_get_function_groups,
 
-From 72e89a6e4e63a370ff774485e9f34736b46dc0a1 Mon Sep 17 00:00:00 2001
+From b5c557274a3511135a2d53742f922f21619bb355 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
 Subject: [PATCH 015/139] spi-bcm2835: Support pin groups other than 7-11
@@ -895,7 +895,7 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From a2d8f5ea8f099c827b430075495cd4f66bbcfea3 Mon Sep 17 00:00:00 2001
+From a2fdb5a45fa7b94058b027b4bafb8a8289406d99 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
 Subject: [PATCH 016/139] spi-bcm2835: Disable forced software CS
@@ -932,7 +932,7 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From 6026a5b9fa567b03ef223f850ecd39530cd122ca Mon Sep 17 00:00:00 2001
+From 089d470d2d65c2052c6386725d4efeab116bc117 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
 Subject: [PATCH 017/139] spi-bcm2835: Remove unused code
@@ -1023,7 +1023,7 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From f13be437d58ecb8d95e017926f4e47732f3eefb4 Mon Sep 17 00:00:00 2001
+From 98db138a65fa16c16da1d236ddc32c42ec5630b6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
 Subject: [PATCH 018/139] ARM: bcm2835: Set Serial number and Revision
@@ -1079,7 +1079,7 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 0328437d8ab1ce8e27b7b1fbc65ee02e30af4673 Mon Sep 17 00:00:00 2001
+From a5dfd7ae772896fe5937a229348f510e3e817147 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
 Subject: [PATCH 019/139] dmaengine: bcm2835: Load driver early and support
@@ -1185,7 +1185,7 @@ index e18dc596cf2447fa9ef7e41b62d9396e29043426..80d35f760b4a4a51e60c355a84d538ba
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From ca1f2d494d953107927917bf79546ca2ced82efb Mon Sep 17 00:00:00 2001
+From 9033cf9c424d98b4d9a961704d81d94bd047b677 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
 Subject: [PATCH 020/139] firmware: Updated mailbox header
@@ -1251,7 +1251,7 @@ index 3fb357193f09914fe21f8555a4b8613f74f22bc3..227a107214a02deadcca3db202da265e
  	RPI_FIRMWARE_GET_COMMAND_LINE =                       0x00050001,
  	RPI_FIRMWARE_GET_DMA_CHANNELS =                       0x00060001,
 
-From 3476f48a6308c25a552bafb7d75b827700bf4f6b Mon Sep 17 00:00:00 2001
+From 4e7f6f0cda5121055243e9bb5b263e8344148d20 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
 Subject: [PATCH 021/139] clk: bcm2835: Mark GPIO clocks enabled at boot as
@@ -1292,7 +1292,7 @@ index 3bbd2a58db470a89b870a793e59ddf9fc4f48e57..7040c6426e35c11608121893b662c601
  		init.ops = &bcm2835_vpu_clock_clk_ops;
  	} else {
 
-From 3987d68ac3af1cf84fb920b0cd6aa32a53266cf5 Mon Sep 17 00:00:00 2001
+From 912c917ab1ed21ff38359f4dcd5c51b0341df5f8 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
 Subject: [PATCH 022/139] rtc: Add SPI alias for pcf2123 driver
@@ -1315,7 +1315,7 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From 7c4ad5b6dfd0947c786a18a1bbe20055d89a5681 Mon Sep 17 00:00:00 2001
+From bbed45b34f60b140809b56c231e0871347384ab2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
 Subject: [PATCH 023/139] watchdog: bcm2835: Support setting reboot partition
@@ -1442,7 +1442,7 @@ index 4dddd8298a227d64862f2e92954a465f2e44b3f6..1f545e024422f59280932713e6a1b051
  	register_restart_handler(&wdt->restart_handler);
  	if (pm_power_off == NULL)
 
-From 4faf393423adc1f2e66722521e4b02e6ed1bffa5 Mon Sep 17 00:00:00 2001
+From 50423ce4268fc282d5c126c976d5e102f03a69a8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
 Subject: [PATCH 024/139] reboot: Use power off rather than busy spinning when
@@ -1468,7 +1468,7 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From c19bf9210f674641ca6a7763e5d17702985cd823 Mon Sep 17 00:00:00 2001
+From a1ec11d449c006e308ef58df856e698fa81baae3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
 Subject: [PATCH 025/139] bcm: Make RASPBERRYPI_POWER depend on PM
@@ -1490,7 +1490,7 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 97461aecb75e4aa4fef0493367484d5efefe1242 Mon Sep 17 00:00:00 2001
+From a7ebd08838c2ec41b7736e8304add41b6ef84b09 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
 Subject: [PATCH 026/139] Register the clocks early during the boot process, so
@@ -1538,7 +1538,7 @@ index 7040c6426e35c11608121893b662c601cd8d6543..21e2a538ff0d0ab4e63adff9b93705f3
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From ddcf6876434d1d4de6c20cd7a246ec6761278b7a Mon Sep 17 00:00:00 2001
+From d7ad57c0c17f97fea7d7966262de245a958af3b8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
 Subject: [PATCH 027/139] bcm2835-rng: Avoid initialising if already enabled
@@ -1567,7 +1567,7 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From 8213c5e839ed73f290c31f8fa8771109d71d333f Mon Sep 17 00:00:00 2001
+From c1c9b2d17864f0c1fcd49544bb1b87e541d8c3cf Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
 Subject: [PATCH 028/139] kbuild: Ignore dtco targets when filtering symbols
@@ -1590,7 +1590,7 @@ index 179219845dfcdfbeb586d12c5ec1296095d9fbf4..e0743e44f84188667a0c322e8c3d36f1
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From 08420db89a7b0f3bc93d53d26f082a87e7a3126f Mon Sep 17 00:00:00 2001
+From 23de699fe8e92a866a90d4306ec582d03ccf75a3 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
 Subject: [PATCH 029/139] BCM2835_DT: Fix I2S register map
@@ -1631,7 +1631,7 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From eddd2846e5da35c427a1449afcb1cdcef4d6c0ce Mon Sep 17 00:00:00 2001
+From 1db3842e9597c0b3f2fb19d05d43970f38987e30 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
 Subject: [PATCH 030/139] Main bcm2708/bcm2709 linux port
@@ -1841,7 +1841,7 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 50b9b81411581b78ec6de8ca8c60fa16b0c731cf Mon Sep 17 00:00:00 2001
+From 0016753b3635c513fa72188470af6ecbc7559a7f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
 Subject: [PATCH 031/139] Add dwc_otg driver
@@ -62901,7 +62901,7 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 617354ba9cb3ef301169e87d257495f80122bce9 Mon Sep 17 00:00:00 2001
+From ad9942bb532876f79cc571cf6cc42d5d2328a353 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
 Subject: [PATCH 032/139] bcm2708 framebuffer driver
@@ -66363,7 +66363,7 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From e453972328537f2d7df0457a3a588c7425837e22 Mon Sep 17 00:00:00 2001
+From 7ea8d3a2f73b5f083d5a26d79fad7b0e7be187a8 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
 Subject: [PATCH 033/139] dmaengine: Add support for BCM2708
@@ -66997,7 +66997,7 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From fa6a7864e4a03147b20bcda3dc587ffedcaaf39c Mon Sep 17 00:00:00 2001
+From f6cf10c027b6eacd650e3abed744d4c0d2e6d2c9 Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
 Subject: [PATCH 034/139] MMC: added alternative MMC driver
@@ -68750,7 +68750,7 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From a36ad8e9b50f8e475bf934c76412b4c915cd7b26 Mon Sep 17 00:00:00 2001
+From 84a680ff080a3948716b861c1d4c1af277eff880 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
 Subject: [PATCH 035/139] Adding bcm2835-sdhost driver, and an overlay to
@@ -71158,7 +71158,7 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 44542e41e3612387f6323b7b606ecc433bb45bb6 Mon Sep 17 00:00:00 2001
+From 5c89ae0b871ea731650ee6fc2fd651b7c1452c91 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
 Subject: [PATCH 036/139] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
@@ -71297,7 +71297,7 @@ index 73fad83acbcb6a157587180516f9ffe7c61eb7d7..e7c9d3098ac06e3c6554fa3373a311f9
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From 6f9bd29d66d6944241605966aff61b2ebabf0f65 Mon Sep 17 00:00:00 2001
+From 625996a0af8c967c3507641fffb92ac0110798e7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:31:47 +0100
 Subject: [PATCH 037/139] cma: Add vc_cma driver to enable use of CMA
@@ -72636,7 +72636,7 @@ index 0000000000000000000000000000000000000000..be2819d5d41f9d5ed65daf8eedb94c9e
 +
 +#endif /* VC_CMA_H */
 
-From 2118117473b152a28312fe2191ee4ba1d2f1ddd4 Mon Sep 17 00:00:00 2001
+From 816b630221c9db00e4550f297a7f453c89fda534 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 26 Mar 2012 22:15:50 +0100
 Subject: [PATCH 038/139] bcm2708: alsa sound driver
@@ -75374,7 +75374,7 @@ index 0000000000000000000000000000000000000000..af3e6eb690113fc32ce9e06bd2f0f294
 +
 +#endif // _VC_AUDIO_DEFS_H_
 
-From cb677622dcf82cc659fe1944565c707c1ae386c7 Mon Sep 17 00:00:00 2001
+From 350652c81704c5247ef752809e6307f126cc7819 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
 Subject: [PATCH 039/139] vc_mem: Add vc_mem driver for querying firmware
@@ -75901,7 +75901,7 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From fcfeb0de0a54c9ee86502dbb18d149df84579e29 Mon Sep 17 00:00:00 2001
+From b2291fe7f6849c8dd94fb10e9fa2f6f868573db0 Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
 Subject: [PATCH 040/139] vcsm: VideoCore shared memory service for BCM2835
@@ -80311,7 +80311,7 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From 9e6a2694faa752923ca52e7a0d7470f1d7147a58 Mon Sep 17 00:00:00 2001
+From 5b87381726a9f48c5d208c4e98aba34a7b168e58 Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
 Subject: [PATCH 041/139] Add /dev/gpiomem device for rootless user GPIO access
@@ -80625,7 +80625,7 @@ index 0000000000000000000000000000000000000000..911f5b7393ed48ceed8751f06967ae64
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From a91ab8be19eece779b19176a5a6f22e6117a8a68 Mon Sep 17 00:00:00 2001
+From 91fc76494224cbb83636ebc0e1dd2fa53ad7f8ca Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
 Subject: [PATCH 042/139] Add SMI driver
@@ -82579,7 +82579,7 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From 0e4b6b76f6302299113e328c3a52feba8d973a3b Mon Sep 17 00:00:00 2001
+From b2fab22bd471cfc549d894df89bd7a186c59b4cc Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
 Subject: [PATCH 043/139] MISC: bcm2835: smi: use clock manager and fix reload
@@ -82752,7 +82752,7 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 5e96c04566a4405e2060ebb6d3c356a55b9f60ae Mon Sep 17 00:00:00 2001
+From 15da3de9ea39a5c06b40feb3a3dd426ee409df57 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
 Subject: [PATCH 044/139] Add SMI NAND driver
@@ -83120,7 +83120,7 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From fd2826446ae8feb0345413e5293bf9c4e339283c Mon Sep 17 00:00:00 2001
+From 09f878c5895dc95e8a4974055733ed6567ea5aca Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
 Subject: [PATCH 045/139] lirc: added support for RaspberryPi GPIO
@@ -83986,7 +83986,7 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From d101d1e54c9d0c552ddb9ea8cf91036676b75d63 Mon Sep 17 00:00:00 2001
+From f2ce126a6164b9386ae7ba47d44181cba6dc2618 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
 Subject: [PATCH 046/139] Add cpufreq driver
@@ -84256,7 +84256,7 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 4d36baabc5401412e9a91c0c6a5c298749696c7e Mon Sep 17 00:00:00 2001
+From 95b11a85c28a7a35496f1e06df6f1369cab3dc9f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
 Subject: [PATCH 047/139] Added hwmon/thermal driver for reporting core
@@ -84425,7 +84425,7 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From 71ef724e8655eb0164293c65aa6d77dd49a56585 Mon Sep 17 00:00:00 2001
+From af84b2c9ba73dbe9aca6cfdfade47b9e49e57e6e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
 Subject: [PATCH 048/139] Add Chris Boot's i2c driver
@@ -85093,7 +85093,7 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 9f186fb7bcbde7efbfb2d646a99893434281e7f5 Mon Sep 17 00:00:00 2001
+From 935e7b0ec6cb2cb82854738777e8dd4db7646c4f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
 Subject: [PATCH 049/139] char: broadcom: Add vcio module
@@ -85322,7 +85322,7 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 0eb33414450647e69d5d814285e8987ff43bcd20 Mon Sep 17 00:00:00 2001
+From 6fa3d7513416c0f1f1c2592ec57fa6a5cf4b7024 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
 Subject: [PATCH 050/139] firmware: bcm2835: Support ARCH_BCM270x
@@ -85408,7 +85408,7 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From 883b24f2789355b2fcdc477d7e1592190e7105a0 Mon Sep 17 00:00:00 2001
+From 3653c5fb680c8ee30089fd22d3f73d9242289d3a Mon Sep 17 00:00:00 2001
 From: Vincent Sanders <vincent.sanders@collabora.co.uk>
 Date: Wed, 30 Jan 2013 12:45:18 +0000
 Subject: [PATCH 051/139] bcm2835: add v4l2 camera device
@@ -93153,7 +93153,7 @@ index 0000000000000000000000000000000000000000..9d1d11e4a53e510c04a416d92d195a7d
 +
 +#endif /* MMAL_VCHIQ_H */
 
-From 80518bfb29d55986781a5dcfe8045b4c04078a08 Mon Sep 17 00:00:00 2001
+From 129404457314ac4a012aa7532ca409d85d3069e3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
 Subject: [PATCH 052/139] scripts: Add mkknlimg and knlinfo scripts from tools
@@ -93676,7 +93676,7 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 84213193818c989afe26ebd7e7043c5450f8e987 Mon Sep 17 00:00:00 2001
+From 19d685b0ddc0e5ba4b46ce55493a16977f439812 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 10 Aug 2015 09:49:15 +0100
 Subject: [PATCH 053/139] scripts/dtc: Update to upstream version 1.4.1
@@ -96530,7 +96530,7 @@ index ad9b05ae698b0495ecbda42ffcf4743555313a27..2595dfda020fd9e03f0beff5006f229d
 -#define DTC_VERSION "DTC 1.4.1-g53bf130b"
 +#define DTC_VERSION "DTC 1.4.1-g25efc119"
 
-From f0618d8e890c7e4cc63af91bc7214d423bc7f4e7 Mon Sep 17 00:00:00 2001
+From 1630dd1730baed2c3c269fe7f20578b58271b67c Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
 Subject: [PATCH 054/139] BCM2708: Add core Device Tree support
@@ -106661,7 +106661,7 @@ index 0a07f9014944ed92a8e2e42983ae43be60b3e471..1967878a843461c3ff1f473b9a030eb0
  
  # Bzip2
 
-From 751d72116578b77c728b66bf570d6fb4eb5d53ff Mon Sep 17 00:00:00 2001
+From 3a7a382848170ecff5b436b832a0b1044e1675ec Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
 Subject: [PATCH 055/139] BCM270x_DT: Add pwr_led, and the required "input"
@@ -106840,7 +106840,7 @@ index ddfcb2df3656cf0ab6aebd1fa3d624a6ec2e94e9..271563eb835f9018712e2076a88f341d
  	/* Set LED brightness level
  	 * Must not sleep. Use brightness_set_blocking for drivers
 
-From 43c78d90576cb16c0e0d9b219ca3b953c6d8f6de Mon Sep 17 00:00:00 2001
+From e0ee334a25243c3dc1bf66f4981cedd301c572e7 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
 Subject: [PATCH 056/139] fbdev: add FBIOCOPYAREA ioctl
@@ -107095,7 +107095,7 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From 39ac9870d42b1a6b311f3fce180bac893050b8ab Mon Sep 17 00:00:00 2001
+From 41bd479f6f68ab21ef39d60479c3c3b412847af7 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
 Subject: [PATCH 057/139] Speed up console framebuffer imageblit function
@@ -107307,7 +107307,7 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From 0edd639f86a0c1d761d8ed77da544976984f0e48 Mon Sep 17 00:00:00 2001
+From 9e7a1df168cc429ab2a795ccad6304929dd69d0b Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
 Subject: [PATCH 058/139] enabling the realtime clock 1-wire chip DS1307 and
@@ -107560,7 +107560,7 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From 93562c1b53115f77cf09a13fbc7bf9e8fdfdee57 Mon Sep 17 00:00:00 2001
+From d88ed49cf9b4e33e4d5fefaeea2f6849912e4626 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 18 Dec 2013 22:16:19 +0000
 Subject: [PATCH 059/139] config: Enable CONFIG_MEMCG, but leave it disabled
@@ -107613,7 +107613,7 @@ index 85bc9beb046d9a6deda2e3564f4d5bd01d6fc27b..4acdbef46a8f0556469b5580a39c18ce
   * css_tryget_online_from_dir - get corresponding css from a cgroup dentry
   * @dentry: directory dentry of interest
 
-From e3cc908913ebd5bae2b0cca4e1fe42a2ae53f50e Mon Sep 17 00:00:00 2001
+From c3082b81c8431894f50fa88fddba30480cccc45d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
 Subject: [PATCH 060/139] hid: Reduce default mouse polling interval to 60Hz
@@ -107652,7 +107652,7 @@ index ae83af649a607f67239f1a64bf45dd4b5770cc7d..4a7af9d0b910f59d17421ce14138400d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From 9f43e0a8a7790ad9199e20cb3b622394906409e9 Mon Sep 17 00:00:00 2001
+From 38755f89c008a66b2debaf5de15fda603745e0fd Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
 Subject: [PATCH 061/139] rpi-ft5406: Add touchscreen driver for pi LCD display
@@ -108013,7 +108013,7 @@ index 227a107214a02deadcca3db202da265eba1fdd21..b0f6e33bd30c35664ceee057f4c3ad32
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 00b6c19a03fc81668a4999b4e0b52d2f2da3cf96 Mon Sep 17 00:00:00 2001
+From ae04e2eb95db06ce465a40fe86543e2bc5714320 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
 Subject: [PATCH 062/139] Improve __copy_to_user and __copy_from_user
@@ -109591,7 +109591,7 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From 386e8ec75004508ca5ef21df4e75e28021c08d22 Mon Sep 17 00:00:00 2001
+From b1001796bd3e4e4aca5fb0391bfe2dfd78dc75d2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
 Subject: [PATCH 063/139] gpio-poweroff: Allow it to work on Raspberry Pi
@@ -109629,7 +109629,7 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From 48626221a6826a0dd2ce19dada02bcdd197a1c12 Mon Sep 17 00:00:00 2001
+From 67370976c21ad611456ca00937e94302ebc51d84 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
 Subject: [PATCH 064/139] mfd: Add Raspberry Pi Sense HAT core driver
@@ -110497,7 +110497,7 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 8c3de85e40057b1d6ec5b8a6772e661cbebf2be7 Mon Sep 17 00:00:00 2001
+From 63f6dd81c9b54778fe3a6f09fd35d37ae905b308 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
 Subject: [PATCH 065/139] ASoC: Add support for HifiBerry DAC
@@ -110675,7 +110675,7 @@ index 0000000000000000000000000000000000000000..45f2b770ad9e67728ca599a7445d6ae9
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 0c4f4d2a354aa011cc5e808e745bc66b2e1019ff Mon Sep 17 00:00:00 2001
+From b6cc9da98604495e2f7f80fc373519fb5630c3ac Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
 Subject: [PATCH 066/139] ASoC: Add support for Rpi-DAC
@@ -110962,7 +110962,7 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From 28e35948f0cbfed9abd11844910db3224ddda010 Mon Sep 17 00:00:00 2001
+From 8868118677ec38b2c77c7162b39ab4c70e577916 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
 Subject: [PATCH 067/139] ASoC: wm8804: Implement MCLK configuration options,
@@ -111014,7 +111014,7 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From 84663a7e31d002d12bb05a7c0c903216fcfd25b7 Mon Sep 17 00:00:00 2001
+From f12a09b3eb2d5bc64dcb5f4162644bea5ee3b8b0 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
 Subject: [PATCH 068/139] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
@@ -111361,7 +111361,7 @@ index 0000000000000000000000000000000000000000..19dc953b7227ba86123fc7a2ba654499
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 1b03571b887bdf83b1a49880003dd62625fb1f7c Mon Sep 17 00:00:00 2001
+From 8c796f49adaf6fd267a06e6d4233b3a2a21b6d3f Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
 Subject: [PATCH 069/139] Add IQaudIO Sound Card support for Raspberry Pi
@@ -111694,7 +111694,7 @@ index 0000000000000000000000000000000000000000..4e8e6dec14bcf4a1ff286c43742d4097
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From f389a4b14734480574032f51168308ace40c529d Mon Sep 17 00:00:00 2001
+From ab9de808b428c251e89d2896944a50a43c1cb251 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jul 2016 17:06:50 +0100
 Subject: [PATCH 070/139] iqaudio-dac: Compile fix - untested
@@ -111721,7 +111721,7 @@ index 4e8e6dec14bcf4a1ff286c43742d4097249d6777..aa15bc4b49ca95edec905fddd8fd0a6d
  	if (dapm->dev != codec_dai->dev)
  		return 0;
 
-From ef2c5b5a21239094c6997e10f19a68f970e8af22 Mon Sep 17 00:00:00 2001
+From 41debd2f3f4c6ea0e55ad32bb28b97a290038182 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
 Subject: [PATCH 071/139] Added support for HiFiBerry DAC+
@@ -112354,7 +112354,7 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From 5e384d11d9656df7e9877ce331130a83e8ccb5a3 Mon Sep 17 00:00:00 2001
+From cea07a9c82e5217da838aa57b419b4d119d76c5b Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
 Subject: [PATCH 072/139] Added driver for HiFiBerry Amp amplifier add-on board
@@ -113190,7 +113190,7 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 5e621985175981470e86bd427516a8782f6008a6 Mon Sep 17 00:00:00 2001
+From fe9b02e262b822bcc441c56faa1c6e31f9c134eb Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Dec 2016 16:26:54 +0000
 Subject: [PATCH 073/139] Revert "Added driver for HiFiBerry Amp amplifier
@@ -114015,7 +114015,7 @@ index 8f019e04898754d2f87e9630137be9e8f612a342..00000000000000000000000000000000
 -
 -#endif  /* _TAS5713_H */
 
-From 05d51ab311a4af15bc07f97f7ddc9c103482b3cd Mon Sep 17 00:00:00 2001
+From ac3132fbcfcf8224504db1b56652ed9cde87fee6 Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
 Subject: [PATCH 074/139] Update ds1307 driver for device-tree support
@@ -114045,7 +114045,7 @@ index 4e31036ee2596dec93accd26f627c5b95591ae9f..b92044cf03e750afa521a93519500e9d
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From 1f0d9f787beb8351e2c39fb8ae789a6d7a1cd539 Mon Sep 17 00:00:00 2001
+From 0d76a093f831d5070add13a811a7a7bee403890a Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
 Subject: [PATCH 075/139] Add driver for rpi-proto
@@ -114263,7 +114263,7 @@ index 0000000000000000000000000000000000000000..9db678e885efd63d84d60a098a84ed67
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 3ecc8e028f7c64fa64c2f7b85de63aa0e920914b Mon Sep 17 00:00:00 2001
+From 38abe33d796ec0245f41fa3593591d8dd44f68ca Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
 Subject: [PATCH 076/139] RaspiDAC3 support
@@ -114509,7 +114509,7 @@ index 0000000000000000000000000000000000000000..dd9eeea2af0382307f437e6db09d1546
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From c6896319efdeef4e158c84fa77b0c533795d754c Mon Sep 17 00:00:00 2001
+From b82f88c937287c6c0682681fda378d3664ab710f Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
 Subject: [PATCH 077/139] Add Support for JustBoom Audio boards
@@ -114966,7 +114966,7 @@ index 0000000000000000000000000000000000000000..91acb666380faa3c0deb2230f8a0f8bb
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From c5865a7bf88ea9b6c34210b17272312f7c90b5e6 Mon Sep 17 00:00:00 2001
+From 705f0a75555c23741a4b6f8612dd5d205bac101a Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
 Subject: [PATCH 078/139] ARM: adau1977-adc: Add basic machine driver for
@@ -115151,7 +115151,7 @@ index 0000000000000000000000000000000000000000..6e2ee027926ee63c89222f75ceb89e3d
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From 2ed7e5179dc82b173ba4d8a6c33ad38e91606c98 Mon Sep 17 00:00:00 2001
+From ebeb0ad8b4c94e1ee9beea35f04041ba40c7523a Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
 Subject: [PATCH 079/139] New AudioInjector.net Pi soundcard with low jitter
@@ -115405,7 +115405,7 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 7b3f658737549988cc4a9592a44de0228ceb9a81 Mon Sep 17 00:00:00 2001
+From a146eda24e52f119a3669df48bf41eb0c52b89a4 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
 Subject: [PATCH 080/139] Add IQAudIO Digi WM8804 board support
@@ -115708,7 +115708,7 @@ index 0000000000000000000000000000000000000000..9b6e829bcb5b1762a853775e78163196
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 3c19d98018e7dba2d499226ce2ff4d466ff019da Mon Sep 17 00:00:00 2001
+From bb65999a85ef3bf0807fe244f53546f7e71ddc77 Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
 Subject: [PATCH 081/139] New driver for RRA DigiDAC1 soundcard using WM8741 +
@@ -116184,7 +116184,7 @@ index 0000000000000000000000000000000000000000..446796e7e4c14a7d95b2f2a01211d9a0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From 7754471b3eb6fa4e48360b49d01b86fc71a3b539 Mon Sep 17 00:00:00 2001
+From 83565664ffc9e8922176ce04e27dfd00be9a7645 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
 Subject: [PATCH 082/139] Add support for Dion Audio LOCO DAC-AMP HAT
@@ -116360,7 +116360,7 @@ index 0000000000000000000000000000000000000000..89e65317512bc774453ac8d0d5b0ff98
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From 00707f8af0f909bd1e73a66b227587c108e9950d Mon Sep 17 00:00:00 2001
+From 287a23b4358505b4e096dc910cde539afc94ff24 Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
 Subject: [PATCH 083/139] Allo Piano DAC boards: Initial 2 channel (stereo)
@@ -116570,7 +116570,7 @@ index 0000000000000000000000000000000000000000..8e8e62e5a36a279b425ed4655cfbac99
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 0dea69effd9cfbb945f86d715a94b7ab2a876094 Mon Sep 17 00:00:00 2001
+From e175ae25e958e045b5d2ec7f3e96b810ac702fdd Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
 Subject: [PATCH 084/139] Support for Blokas Labs pisound board
@@ -117750,7 +117750,7 @@ index 0000000000000000000000000000000000000000..4b8545487d06e4ea70073a5d063fb231
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From 627793624e12b70fa82f1c5ba0d43abc9c02de30 Mon Sep 17 00:00:00 2001
+From 3f7afb2353aabbb329a150797ff216f84c7c3d0f Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
 Subject: [PATCH 085/139] rpi_display: add backlight driver and overlay
@@ -117922,7 +117922,7 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 3e73b5398a672f71124cd49e5f49887f4561dc74 Mon Sep 17 00:00:00 2001
+From e2e08bb2c64f834d09dee57747187c45eeb52c14 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
 Subject: [PATCH 086/139] bcm2835-virtgpio: Virtual GPIO driver
@@ -118199,7 +118199,7 @@ index b0f6e33bd30c35664ceee057f4c3ad32b914291d..e92278968b2b979db2a1f855f70e7aaf
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 2195a08dc3e8e28fc6fcad8d57aa73d82d461efe Mon Sep 17 00:00:00 2001
+From a18071c6011ebf6a7a86e9ad5d9d4f0cf899a101 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
 Subject: [PATCH 087/139] amba_pl011: Don't use DT aliases for numbering
@@ -118231,7 +118231,7 @@ index e2c33b9528d82ed7a2c27d083d7b1d222da68178..5a11ff833e1fd112ba04df3a427cd94b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From 21defd9b3d89f388321638da4dc7a80f43e3ab33 Mon Sep 17 00:00:00 2001
+From 8237399e8ceafb4e0552014895c800e446e5bc1c Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
 Subject: [PATCH 088/139] OF: DT-Overlay configfs interface
@@ -118666,7 +118666,7 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From 20849553459552989d8cc985298c99ba6f0adaad Mon Sep 17 00:00:00 2001
+From d91e487c7d88fd680689df1655ebab1b1e4c2ae4 Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
 Subject: [PATCH 089/139] brcm: adds support for BCM43341 wifi
@@ -118832,7 +118832,7 @@ index d0407d9ad7827cd756b6311410ffe2d9a7cacc78..f1fb8a3c7a3211e8429585861f2f42e0
  #define BRCM_CC_4335_CHIP_ID		0x4335
  #define BRCM_CC_4339_CHIP_ID		0x4339
 
-From 70a7564fc0027a683a3539110e5a6754dac33b6a Mon Sep 17 00:00:00 2001
+From e115c9bc45a088adb4e74ffc0d0f0a4a88104b23 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
 Subject: [PATCH 090/139] hci_h5: Don't send conf_req when ACTIVE
@@ -118858,7 +118858,7 @@ index 0879d64b1caf58afb6e5d494c07d9ab7e7cdf983..5161ab30fd533d50f516bb93d5b9f402
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From 9d5271f68b5c9a1a169536fb80aaec80d44be9fb Mon Sep 17 00:00:00 2001
+From 24823d68518f34980e5ad2ec1a882cc8d913ffde Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
 Subject: [PATCH 091/139] config: Add default configs
@@ -121488,7 +121488,7 @@ index 0000000000000000000000000000000000000000..8acee9f31202ec14f2933d92dd70831c
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From e04d08b7f6ef287f06762af05f3508b5282cc890 Mon Sep 17 00:00:00 2001
+From 944b4f4646b9bcf17078736e442bd32fe664dca7 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
 Subject: [PATCH 092/139] Add arm64 configuration and device tree differences.
@@ -122906,7 +122906,7 @@ index 0000000000000000000000000000000000000000..d7406f5a4620151044b8f716b4d10bb8
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2708_VCHIQ=n
 
-From ef77c16713667c445b5550c388cf1dca491639f0 Mon Sep 17 00:00:00 2001
+From b3b7bf9f34ff8bb310261a156af5a711aa76b055 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 7 Mar 2016 15:05:11 +0000
 Subject: [PATCH 093/139] vchiq_arm: Tweak the logging output
@@ -122984,7 +122984,7 @@ index 2c98da4307dff994a00dc246574ef0aaee05d5da..160db24aeea33a8296923501009c1f02
  
  		switch (type) {
 
-From 0f95c67791ea96a735a9a93b4c347c6ebfb7a9c3 Mon Sep 17 00:00:00 2001
+From b0c2bcf368c10db7f6bed3163366e21aca4de06b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 14:16:25 +0000
 Subject: [PATCH 094/139] vchiq_arm: Access the dequeue_pending flag locked
@@ -123045,7 +123045,7 @@ index 7b6cd4d80621e38ff6d47fcd87b45fbe9cd4259b..d8669fa7f39b077877eca1829ba9538b
  
  	return add_completion(instance, reason, header, user_service,
 
-From e607cd62de503c30cd471ddf601f2fe44e82e61b Mon Sep 17 00:00:00 2001
+From 944839ed99bbfc801f5124a45a0becdec66cdc42 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 20:53:47 +0000
 Subject: [PATCH 095/139] vchiq_arm: Service callbacks must not fail
@@ -123074,7 +123074,7 @@ index d8669fa7f39b077877eca1829ba9538bf2e21a82..54552c6ce54f413c9781ba279b936f98
  		DEBUG_TRACE(SERVICE_CALLBACK_LINE);
  	}
 
-From 2bbf9b6bc1589f85fa7defddeda75767620fe8be Mon Sep 17 00:00:00 2001
+From 2665eaff5297e439a25dea009a5da87fcf44cdb6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 21 Apr 2016 13:49:32 +0100
 Subject: [PATCH 096/139] vchiq_arm: Add completion records under the mutex
@@ -123140,7 +123140,7 @@ index 54552c6ce54f413c9781ba279b936f98be4f47b0..bde8955b7d8505d73579b77b5b392154
  
  	return VCHIQ_SUCCESS;
 
-From 8ec8b734304b94bf6fe137ce11dbb5cc5699857f Mon Sep 17 00:00:00 2001
+From 94c56a1493788fcc56b53a9c520bd845693fd2a7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 20 Jun 2016 13:51:44 +0100
 Subject: [PATCH 097/139] vchiq_arm: Avoid use of mutex in add_completion
@@ -123337,7 +123337,7 @@ index 160db24aeea33a8296923501009c1f02bc41e599..71a3bedc55314f3b22dbff40c05dedf0
  		up(&state->slot_available_event);
  	}
 
-From 33ed8507e5087e15a7d47eba88ea2d8ba537b58e Mon Sep 17 00:00:00 2001
+From 20e5d7251d813ded6d78fe1aae41c1d08c65cfb5 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:14:10 -0700
 Subject: [PATCH 098/139] staging/vchi: Convert to current get_user_pages()
@@ -123377,7 +123377,7 @@ index e5cdda12c7e5c35c69eb96991cfdb8326def167f..085d37588c59198b4e5f00b9249bb842
  		num_pages,                /* len */
  		0,                        /* gup_flags */
 
-From 960a154027491572193142b91ea470147f5b78eb Mon Sep 17 00:00:00 2001
+From 2165acaceffc4bab5cc9a1ef89e5156b28c3bbca Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:16:03 -0700
 Subject: [PATCH 099/139] staging/vchi: Update for rename of
@@ -123425,7 +123425,7 @@ index 085d37588c59198b4e5f00b9249bb8421695854f..5a2b8fb459ebe086ec229f37b6381bdb
  	kfree(pages);
  }
 
-From d823ec3413a5c898c063a5eaccf15cd33b85384b Mon Sep 17 00:00:00 2001
+From 3e38b41b930bb25b661cb17b6ca8269e2c5adf52 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:21:17 -0700
 Subject: [PATCH 100/139] drivers/vchi: Remove dependency on CONFIG_BROKEN.
@@ -123450,7 +123450,7 @@ index 9676fb29075a457109e4d4235f086987aec74868..db8e1beb89f9f8c48ea5964016c8285e
  	help
  		Kernel to VideoCore communication interface for the
 
-From 61faced7aea265c5f8c7c97bebad43870487391a Mon Sep 17 00:00:00 2001
+From 9ec7e7221461bf7e6398163ab3a7c23b685f0134 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
 Subject: [PATCH 101/139] raspberrypi-firmware: Export the general transaction
@@ -123497,7 +123497,7 @@ index e92278968b2b979db2a1f855f70e7aafb224fa98..09e3d871d110eb0762ebdb5ea3293537
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 57f7ed87633050a3d85e034e7b7cb8e98a39221b Mon Sep 17 00:00:00 2001
+From 8688bb44fad47a82d542dc77cb0e58a97f5e0d34 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
 Subject: [PATCH 102/139] raspberrypi-firmware: Define the MBOX channel in the
@@ -123522,7 +123522,7 @@ index 09e3d871d110eb0762ebdb5ea329353738d58661..2859db09e25bb945251e85edb39bc434
  
  enum rpi_firmware_property_status {
 
-From e9b66b168babeea1653429f662bc46af84726280 Mon Sep 17 00:00:00 2001
+From 589e28b3e9047bb4b8fe1286cc89af88e4c2dd59 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
 Subject: [PATCH 103/139] drm/vc4: Add a mode for using the closed firmware for
@@ -123551,7 +123551,7 @@ index fb77db755e0a29d8589860da82186c7a1f394c72..c6dd06cca9830018c39b3b16afe4045e
  	vc4_gem.o \
  	vc4_hdmi.o \
 diff --git a/drivers/gpu/drm/vc4/vc4_crtc.c b/drivers/gpu/drm/vc4/vc4_crtc.c
-index 7f08d681a74b4e37529f6c09ae1d2c1a944dcabd..7366e76c38346f7c700534b28d1eff4eca2ec2fa 100644
+index d544ff9b0d4609aae945960bf82e8aeee6bc94a8..13212788eef0e4b77c1e92e6bf3a56c817c50322 100644
 --- a/drivers/gpu/drm/vc4/vc4_crtc.c
 +++ b/drivers/gpu/drm/vc4/vc4_crtc.c
 @@ -163,6 +163,9 @@ int vc4_crtc_get_scanoutpos(struct drm_device *dev, unsigned int crtc_id,
@@ -124292,7 +124292,7 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From c7de77a3b61cd7c25ff21718accb59c450fee7dc Mon Sep 17 00:00:00 2001
+From b52f5f3f01476a7afaf9f171ace83807c1ce2231 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 17 Sep 2016 15:07:10 +0200
 Subject: [PATCH 104/139] i2c: bcm2835: Fix hang for writing messages larger
@@ -124385,7 +124385,7 @@ index d4f3239b56865919e1b781b20a7c5ebcd76b4eb9..f283b714aa79e2e4685ed95b04b6b289
  	i2c_dev->msg_buf_remaining = msg->len;
  	reinit_completion(&i2c_dev->completion);
 
-From 941e536573397dad8f185229ce551086147e4034 Mon Sep 17 00:00:00 2001
+From 3f669a558ad59ab5942e04f5bd1a32f055fa0c0c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 18:24:38 +0200
 Subject: [PATCH 105/139] i2c: bcm2835: Protect against unexpected TXW/RXR
@@ -124513,7 +124513,7 @@ index f283b714aa79e2e4685ed95b04b6b289f7e9eee7..d2ba1a4de36af512e8e3c97251bd3537
  		return -ETIMEDOUT;
  	}
 
-From 80dabefa408508ca2b10b346381468eb25dce381 Mon Sep 17 00:00:00 2001
+From 9397ac3b79cde4cdf6c9cf589bd2dd33eb83f9c3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Mon, 19 Sep 2016 17:19:41 +0200
 Subject: [PATCH 106/139] i2c: bcm2835: Use dev_dbg logging on transfer errors
@@ -124548,7 +124548,7 @@ index d2ba1a4de36af512e8e3c97251bd3537ae61591a..54d510abd46a117c9238fc6d7edec840
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 1618e4b4cad41f57aaecb6ac9933ec064d6cd6e9 Mon Sep 17 00:00:00 2001
+From 2d626bfad93c486607411ce3e9b3022b93629f7f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Thu, 22 Sep 2016 22:05:50 +0200
 Subject: [PATCH 107/139] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
@@ -124595,7 +124595,7 @@ index 54d510abd46a117c9238fc6d7edec84019d1f60d..565ef69ce61423544dc0558c85ef318b
  
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
 
-From 0c3bd05e48d35df85fffbccba070ab8f1e7a7169 Mon Sep 17 00:00:00 2001
+From 9566c27f761f65435ed76ffa7773e03617ede6c7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:54:27 +0200
 Subject: [PATCH 108/139] i2c: bcm2835: Add support for Repeated Start
@@ -124780,7 +124780,7 @@ index 565ef69ce61423544dc0558c85ef318b0ae9c324..241e08ae7c27cec23fad3c1bf3ebad3a
  
  static u32 bcm2835_i2c_func(struct i2c_adapter *adap)
 
-From 2808e1610e59d749957295cb78fbed011d8ee295 Mon Sep 17 00:00:00 2001
+From 2d0f716726e6bdc56bf26e36eb9cb24c83eae092 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:57:17 +0200
 Subject: [PATCH 109/139] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
@@ -124820,7 +124820,7 @@ index 241e08ae7c27cec23fad3c1bf3ebad3a4d2a8e6f..d2085dd3742eabebc537621968088261
  		bcm2835_i2c_writel(i2c_dev, BCM2835_I2C_C,
  				   BCM2835_I2C_C_CLEAR);
 
-From a8c408645977ebe2b4d7a0bd51a14edde0ab5750 Mon Sep 17 00:00:00 2001
+From a0d4e753d28ccfaa2ad7ac1173fa836bb2f13cea Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 27 Sep 2016 01:00:08 +0200
 Subject: [PATCH 110/139] i2c: bcm2835: Add support for dynamic clock
@@ -124939,7 +124939,7 @@ index d2085dd3742eabebc537621968088261f8dc7ea8..c3436f627028477f7e21b47e079fd5ab
  	irq = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
  	if (!irq) {
 
-From fef62f9d68bb934e05f2b9e219d02c77dd3526e1 Mon Sep 17 00:00:00 2001
+From 7d425cc5f1ec065463dac3d2edbb2b37c4afa808 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
 Subject: [PATCH 111/139] i2c: bcm2835: Add debug support
@@ -125131,7 +125131,7 @@ index c3436f627028477f7e21b47e079fd5ab06ec188a..8642f580ce41803bd22c76a0fa80d083
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From a798a1ab516c19e7f02827001ed82a40b493d328 Mon Sep 17 00:00:00 2001
+From b126459dc19efe6acab1bb268dbcd92410f4b9cb Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 31 Dec 2016 14:15:50 +0000
 Subject: [PATCH 112/139] arm64: Add CONFIG_ARCH_BCM2835
@@ -125150,7 +125150,7 @@ index d7406f5a4620151044b8f716b4d10bb818648e06..53da5c7a33e5898a66e549fb0c39fe3d
  CONFIG_BCM2708_VCHIQ=n
 +CONFIG_ARCH_BCM2835=y
 
-From 077b0728cbdd7fdf11b7818f2775d80fcfe72fce Mon Sep 17 00:00:00 2001
+From a46090441a1b2dcf46918f61cc73d29739bb4518 Mon Sep 17 00:00:00 2001
 From: Alex Tucker <alex@floop.org.uk>
 Date: Tue, 13 Dec 2016 19:50:18 +0000
 Subject: [PATCH 113/139] Add support for Silicon Labs Si7013/20/21
@@ -125228,7 +125228,7 @@ index f6d134c095af2398fc55ae7d2b0e86456c30627c..31bda8da4cb6a56bfe493a81b9189009
  	};
  };
 
-From 3d970e2d6c45cd3cf3f25435b0bec4cd0775c141 Mon Sep 17 00:00:00 2001
+From b99978d546325b6547e40641895e395abd1f3820 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 3 Jan 2017 21:27:46 +0000
 Subject: [PATCH 114/139] Document the si7020 option
@@ -125252,7 +125252,7 @@ index 81d991803be335e5a1bc3bb0a8c7a2c9f5c392bd..e8fa4ccb44c34a20485c4e6155467af9
  Name:   i2c0-bcm2708
  Info:   Enable the i2c_bcm2708 driver for the i2c0 bus. Not all pin combinations
 
-From a4c802e176d7068e4e2a54e13dd618106b907951 Mon Sep 17 00:00:00 2001
+From 7c9abdbcd6204fabf158e4a223974199074c448a Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Thu, 5 Jan 2017 02:38:16 +0200
 Subject: [PATCH 115/139] pisound improvements:
@@ -125549,7 +125549,7 @@ index 4b8545487d06e4ea70073a5d063fb2310b3b94d0..ba70734b89e61a11201657406223f0b3
  };
  
 
-From 8772981b127180376c08ad97f60c53e051f15ee4 Mon Sep 17 00:00:00 2001
+From 2c3023376394ced6dd4d98620ef4b99973cca726 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:23:06 +0000
 Subject: [PATCH 116/139] Revert "Revert "Added driver for HiFiBerry Amp
@@ -126376,7 +126376,7 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 1305f68f9d7ce514916dc714db51271d53f2d953 Mon Sep 17 00:00:00 2001
+From 9819e281198546cd29cfef31987ac1db558e3c61 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:42:09 +0000
 Subject: [PATCH 117/139] hifiberry-amp: Adjust for ALSA object refactoring
@@ -126404,7 +126404,7 @@ index 9b2713861dcbed751842ca29c88eb1eae5867411..560234d58a6b0a6e7fd3a63e8de73339
  
  
 
-From 0750f5306b7f5354cbae714ade4299c7384f5976 Mon Sep 17 00:00:00 2001
+From 2e0be5ac06d1f2ca6cd6bd1da49511819d5699fc Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Sun, 8 Jan 2017 15:58:54 +0200
 Subject: [PATCH 118/139] bcm2835-i2s: Changes for allowing asymmetric sample
@@ -126497,7 +126497,7 @@ index 6ba20498202ed36906b52096893a88867a79269f..171c2401dfe192740fca3356268aff64
  
  	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);
 
-From 23f372d8a0d0b4266666eba1713f4c5496058a1a Mon Sep 17 00:00:00 2001
+From c8bfe609887b7f746f29a440838448d8d7cacb89 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Tue, 10 Jan 2017 16:05:41 +0000
 Subject: [PATCH 119/139] Add driver_name property
@@ -126520,7 +126520,7 @@ index 8fd50dbe681508a2cfe8fdde1c9fedbe9a507fa7..05a224ec712d06b8b7587ab6b8bb562d
  	.dai_link     = snd_rpi_justboom_dac_dai,
  	.num_links    = ARRAY_SIZE(snd_rpi_justboom_dac_dai),
 
-From 65d9e9253f3bc64368fa976a9576183934539c81 Mon Sep 17 00:00:00 2001
+From 5994a2af73ec370731447e0772779b03a59b02cc Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Tue, 10 Jan 2017 16:11:04 +0000
 Subject: [PATCH 120/139] Add driver_name paramater
@@ -126543,7 +126543,7 @@ index 91acb666380faa3c0deb2230f8a0f8bbec59417b..abfdc5c4dd5811e6847bddda4921abe3
  	.dai_link     = snd_rpi_justboom_digi_dai,
  	.num_links    = ARRAY_SIZE(snd_rpi_justboom_digi_dai),
 
-From 8861f1451d4532760b01fdedf18306edc4397a9b Mon Sep 17 00:00:00 2001
+From 0e6f718360bd09f7212d42a4d8986f4c9f6e0501 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 Jan 2017 13:01:21 +0000
 Subject: [PATCH 121/139] BCM270X_DT: Add pi3-disable-wifi overlay
@@ -126607,7 +126607,7 @@ index 0000000000000000000000000000000000000000..017199554bf2f4e381efcc7bb71e750c
 +	};
 +};
 
-From f1d7c34483947523bd055a8e69ca220bbbeefa95 Mon Sep 17 00:00:00 2001
+From aa871463608a1d9d7c9cddbc41f888a3dc622d20 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
 Subject: [PATCH 122/139] ARM64: Make it work again on 4.9 (#1790)
@@ -127015,7 +127015,7 @@ index 53da5c7a33e5898a66e549fb0c39fe3da555ca87..c7e891d72969a388d9b135a36dbfc9c9
 -CONFIG_BCM2708_VCHIQ=n
 -CONFIG_ARCH_BCM2835=y
 
-From 213c141365e1bc09ad95ebb92461cabeb4421e1f Mon Sep 17 00:00:00 2001
+From 56ed7b95748de35375951c3802d11f69523b3a5f Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 02:54:26 -0800
 Subject: [PATCH 123/139] ARM64: Enable Kernel Address Space Randomization
@@ -127050,7 +127050,7 @@ index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..974d8889c0cf695eb88b57bbef11bc5a
  CONFIG_BINFMT_MISC=y
  CONFIG_COMPAT=y
 
-From a23e36748b488b77cb92d28aa2642e1b350e6c40 Mon Sep 17 00:00:00 2001
+From 3fa49169714a512b7e9c3de2d3bd920c4b683e9a Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sun, 15 Jan 2017 07:31:59 -0800
 Subject: [PATCH 124/139] ARM64: Enable RTL8187/RTL8192CU wifi in build config
@@ -127078,7 +127078,7 @@ index 974d8889c0cf695eb88b57bbef11bc5aa556b635..4670a490dfb1e582ec24a3b39a3cb9b2
  CONFIG_ZD1211RW=m
  CONFIG_MAC80211_HWSIM=m
 
-From a8a16dca4352540a2a26cba7afc6d6368ac8c976 Mon Sep 17 00:00:00 2001
+From 1d6ca12e48db8fa517261148dd59e8c634764232 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 16 Jan 2017 14:53:12 +0000
 Subject: [PATCH 125/139] BCM270X_DT: Add spi0-cs overlay
@@ -127169,7 +127169,7 @@ index 0000000000000000000000000000000000000000..7f79029d043c04d7496c7c3480450c69
 +	};
 +};
 
-From cebce60296ccea936da1bb65b375d34a47f9a7a3 Mon Sep 17 00:00:00 2001
+From 324a7bf50e4db1288b1ecd500f8306e02af23747 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
 Subject: [PATCH 126/139] spi-bcm2835: Disable forced software CS
@@ -127198,7 +127198,7 @@ index 74dd21b7373c7564ede01d84a4f63b93a6d52fa7..51cdefbf5eb265f49bd05e0aa91dfbee
  
  		i2c0: i2c@7e205000 {
 
-From 69d606cb7dfc53bcf40db15d33907cff2e116377 Mon Sep 17 00:00:00 2001
+From ad85a8201dab1d5ede7b335cecd8004408cc3aa4 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 16 Jan 2017 16:33:54 +0000
 Subject: [PATCH 127/139] config: Add CONFIG_TCP_CONG_BBR See:
@@ -127236,7 +127236,7 @@ index 8acee9f31202ec14f2933d92dd70831cda8d7b51..219f67051a2542329449b0099165ae28
  CONFIG_IPV6_ROUTER_PREF=y
  CONFIG_INET6_AH=m
 
-From 029f0e68448aa9b9300572798dace30b33d6a85c Mon Sep 17 00:00:00 2001
+From bce2b1e8586ed431fd3885d73cb9814f2421385f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 16 Jan 2017 21:02:26 +0000
 Subject: [PATCH 128/139] Revert "bcm2835-i2s: Changes for allowing asymmetric
@@ -127329,7 +127329,7 @@ index 171c2401dfe192740fca3356268aff6432f284ea..6ba20498202ed36906b52096893a8886
  
  	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);
 
-From a3aab7c7a31e0f19658fd8d8e7f46d1824bfe506 Mon Sep 17 00:00:00 2001
+From 00d471421b2b4db27ffe9503df5aecee450d0344 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 17 Jan 2017 11:34:58 +0000
 Subject: [PATCH 129/139] BCM270X_DT: Enable UART0 on CM3
@@ -127355,7 +127355,7 @@ index 41874c25a84226c0e4af92ec4059e0a571fe6123..3ba6e621856c288ae4694f758604619f
  	sdhost_pins: sdhost_pins {
  		brcm,pins = <48 49 50 51 52 53>;
 
-From 63b95220a23a4b780cdc016ef11a656e06936edb Mon Sep 17 00:00:00 2001
+From 5a7bbecb2832ad7a805ce875e349cde80dc3a626 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 17 Jan 2017 14:39:39 +0000
 Subject: [PATCH 130/139] config: Add CONFIG_MD_M25P80 and CONFIG_MD_SPI_NOR
@@ -127397,7 +127397,7 @@ index 219f67051a2542329449b0099165ae2885022bec..c4898d63d74718097ec3a1d1fe60b230
  CONFIG_OF_CONFIGFS=y
  CONFIG_ZRAM=m
 
-From 3fc9aaeb72fe6ff39b5777f5d542c75309eb1f6e Mon Sep 17 00:00:00 2001
+From d55cbbfa197942a6cf4d78f22acd32b57f6db35a Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:33:51 -0800
 Subject: [PATCH 131/139] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
@@ -127743,7 +127743,7 @@ index 6b2c7d0c93f36a63863ff4b0ecc1f3eab77e058b..d7b700ff17821ad1944e36721fe6b2db
  /** The OS page size */
  #define DWC_OS_PAGE_SIZE	PAGE_SIZE
 
-From 4661054b08d26185d9478a047b7adbdcaad41c15 Mon Sep 17 00:00:00 2001
+From bf436f5da46aa94d6ae3795a6191d6aefb14082d Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:43:57 -0800
 Subject: [PATCH 132/139] ARM64: Round-Robin dispatch IRQs between CPUs.
@@ -127820,7 +127820,7 @@ index 93e3f7660c4230c9f1dd3b195958cb498949b0ca..486bcbfb32305ee417f6b3be7e91a3ff
  	.name		= "bcm2836-gpu",
  	.irq_mask	= bcm2836_arm_irqchip_mask_gpu_irq,
 
-From 19fce0d36b798ccb0dbb2d88333016288b7ef057 Mon Sep 17 00:00:00 2001
+From 988fdc545cc79b570f73b6bb4d50cddd8d614018 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:45:03 -0800
 Subject: [PATCH 133/139] ARM64: Enable DWC_OTG Driver In ARM64 Build
@@ -127844,7 +127844,7 @@ index 4670a490dfb1e582ec24a3b39a3cb9b2488b1864..8c4392344eb4495689c220d5d176ee8c
  CONFIG_USB_STORAGE=y
  CONFIG_USB_STORAGE_REALTEK=m
 
-From d4826d1d4392d61641fd32ddf94c11e1783275a3 Mon Sep 17 00:00:00 2001
+From 58717c70c9284167825f4a0ea03c4ecd7066ed00 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:46:04 -0800
 Subject: [PATCH 134/139] ARM64: Use dwc_otg driver by default for USB.
@@ -127873,7 +127873,7 @@ index f6def5d7e5d622cf09e8f87332c7374fe28da08b..3e134a1208610b90e2d0fc22f03c6e9f
 -};
 -#endif
 
-From a8b968f7966dfbf0f3133ea5aeaa9050346a8c9c Mon Sep 17 00:00:00 2001
+From 44e6eb62c72adf1f1d0f0c45d3c18e271be0ee14 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 23 Jan 2017 17:36:50 +0000
 Subject: [PATCH 135/139] BCM270X_DT: Add reference to audio_pins to CM dtb
@@ -127904,7 +127904,7 @@ index eb8662f0d222b4c0a9a2bcb8bccb13e86a0006b3..10be69972bd1440f574e35d515f3d6a0
  	hpd-gpios = <&gpio 46 GPIO_ACTIVE_HIGH>;
  };
 
-From 79679ab90389ab1f6a322adea03406ad98593925 Mon Sep 17 00:00:00 2001
+From 5a46acbdf4b4f8eb1125633971ca020200c51567 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 25 Jan 2017 11:30:38 +0000
 Subject: [PATCH 136/139] config: Add additional network scheduling modules
@@ -127959,7 +127959,7 @@ index c4898d63d74718097ec3a1d1fe60b2307a6a3140..b448eaa866c200f48351819072c7fefc
  CONFIG_NET_SCH_PLUG=m
  CONFIG_NET_CLS_BASIC=m
 
-From a0de1f189fb2a259b2c43b312c006284d08f26c6 Mon Sep 17 00:00:00 2001
+From e16464e3b96648063c35ccb1e37d111383682713 Mon Sep 17 00:00:00 2001
 From: chris johnson <plasticchris@gmail.com>
 Date: Sun, 22 Jan 2017 03:27:31 +0000
 Subject: [PATCH 137/139] ASoC: A simple-card overlay for ADAU7002
@@ -128060,7 +128060,7 @@ index 0000000000000000000000000000000000000000..e67e6625d7967abc92cf00cb604d4c12
 +    };
 +};
 
-From 7ff4705c04925daf6bd6069bfb1f6be3a9aeef02 Mon Sep 17 00:00:00 2001
+From fd8f14e2032e539688c50bf42f5ec054a99c9d6f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Jan 2017 21:17:23 +0000
 Subject: [PATCH 138/139] config: Add SND_SOC_ADAU7002 codec module
@@ -128098,7 +128098,7 @@ index b448eaa866c200f48351819072c7fefcd8ad8132..5105a592c9bcfee1cc6a8b50fd1c6c32
  CONFIG_SND_SOC_WM8804_I2C=m
  CONFIG_SND_SIMPLE_CARD=m
 
-From 705dd53e3dcd7630d59774ba7f7a980be45c7e9b Mon Sep 17 00:00:00 2001
+From e98a288171e9302d6e5074ff380f77e93b90cda5 Mon Sep 17 00:00:00 2001
 From: Scott Ellis <scott@jumpnowtek.com>
 Date: Fri, 27 Jan 2017 06:42:42 -0500
 Subject: [PATCH 139/139] Add overlay for mcp3008 adc (#1818)

--- a/projects/RPi2/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi2/patches/linux/linux-01-RPi_support.patch
@@ -1,4 +1,4 @@
-From 19b19e36968fd1bda47e59e4aaa3d1b0a048e2af Mon Sep 17 00:00:00 2001
+From 01c050eb771ed7280bd23ebe6fc2b59cd482916f Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
 Subject: [PATCH 001/139] smsx95xx: fix crimes against truesize
@@ -48,7 +48,7 @@ index 831aa33d078ae7d2dd57fdded5de71d1eb915f99..b77935bded8c0ff7808b00f170ff10e5
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From 3b849a978a066d4a542b35a3c9115e1d0dd33daa Mon Sep 17 00:00:00 2001
+From db2a4f2b3eae2a900ab27c46e2a31a61fb616b24 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
 Subject: [PATCH 002/139] smsc95xx: Experimental: Enable turbo_mode and
@@ -94,7 +94,7 @@ index b77935bded8c0ff7808b00f170ff10e594300ad0..693f163684de921404738e33244881e0
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From 323e1c431de92e9eedf6a2a4ab69dacf68d192e8 Mon Sep 17 00:00:00 2001
+From b8b58f81dc5c0859d80de6c09cbd20e5d3c2730c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
 Subject: [PATCH 003/139] Allow mac address to be set in smsc95xx
@@ -193,7 +193,7 @@ index 693f163684de921404738e33244881e0aab92ec9..df60c989fc229bf0aab3c27e95ccd453
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From aa23572116974823b66c52d9aeb7c883c3f57027 Mon Sep 17 00:00:00 2001
+From cd6385d269e0b80c58c262039b18e3a1f81d176c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
 Subject: [PATCH 004/139] Protect __release_resource against resources without
@@ -224,7 +224,7 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From a4282163e4a337ce384ce7e41617905bfea37ba4 Mon Sep 17 00:00:00 2001
+From 9fbb3ee3831d7983504979453c032ed92430e294 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
 Subject: [PATCH 005/139] mm: Remove the PFN busy warning
@@ -239,10 +239,10 @@ Signed-off-by: Eric Anholt <eric@anholt.net>
  1 file changed, 2 deletions(-)
 
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 34ada718ef47c4b27730214d584f9350fefb9883..3fa01a5280db96075798e4cbd58d5520ddf36d88 100644
+index f4a02e240fb68acbaa0d3a0c7ac5a498c051a272..0e1fba92702858ceaf2f92a1d5fa53d5b16b52fe 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
-@@ -7297,8 +7297,6 @@ int alloc_contig_range(unsigned long start, unsigned long end,
+@@ -7323,8 +7323,6 @@ int alloc_contig_range(unsigned long start, unsigned long end,
  
  	/* Make sure the range is really isolated. */
  	if (test_pages_isolated(outer_start, end, false)) {
@@ -252,7 +252,7 @@ index 34ada718ef47c4b27730214d584f9350fefb9883..3fa01a5280db96075798e4cbd58d5520
  		goto done;
  	}
 
-From 4d80990d04e9f05d22b5f2aa60b04eac17e0a992 Mon Sep 17 00:00:00 2001
+From d542076feb89d4520ad894db111be43625412749 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
 Subject: [PATCH 006/139] irq-bcm2836: Prevent spurious interrupts, and trap
@@ -282,7 +282,7 @@ index d96b2c947e74e3edab3917551c64fbd1ced0f34c..93e3f7660c4230c9f1dd3b195958cb49
  #endif
  	} else if (stat) {
 
-From 776cdf599f81ae27fee194ff1830dea2ba888d75 Mon Sep 17 00:00:00 2001
+From cb2a38096d0532522957d17bfea943b4a749ba9e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
 Subject: [PATCH 007/139] irqchip: bcm2835: Add FIQ support
@@ -414,7 +414,7 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 1b4bd9d956338a403c31de5f27c058f2d8a5fec5 Mon Sep 17 00:00:00 2001
+From 5e8863cff89dff4c4d1eb9b7cf432e1e128cbc6d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
 Subject: [PATCH 008/139] irqchip: irq-bcm2835: Add 2836 FIQ support
@@ -516,7 +516,7 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From e9ae9ecfd8dbbfe62ab50769139b6987d6472567 Mon Sep 17 00:00:00 2001
+From 9c064ac67f884d4eb641a201726153dced37fbb7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
 Subject: [PATCH 009/139] spidev: Add "spidev" compatible string to silence
@@ -540,7 +540,7 @@ index 2e05046f866bd01bf87edcdeff0d5b76d4d0aea7..d780491b8013a4e97fa843958964454e
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 796c3fb31d9d46dfd7a52c542ab42b8fa9746c10 Mon Sep 17 00:00:00 2001
+From 4fa58613ec686f255ee03153abd8cf0d960f648f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 30 Jun 2015 14:12:42 +0100
 Subject: [PATCH 010/139] serial: 8250: Don't crash when nr_uarts is 0
@@ -563,7 +563,7 @@ index e8819aa20415603c80547e382838a8fa3ce54792..cf9c7d2e3f95e1a19410247a89c2e49c
  	for (i = 0; i < nr_uarts; i++) {
  		struct uart_8250_port *up = &serial8250_ports[i];
 
-From 1b904739cb5a74f77a0a2cd441d1fbad44a87056 Mon Sep 17 00:00:00 2001
+From eabec7d99729342aab788e0139d25648510eece5 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
 Subject: [PATCH 011/139] pinctrl-bcm2835: Set base to 0 give expected gpio
@@ -588,7 +588,7 @@ index fa77165fab2c1348163979da507df17e7168c49b..d11e2e4ea189466e686d762cb6c6fef9
  	.can_sleep = false,
  };
 
-From 2231c8737d0513e5ef63e8f3813d78acde428a81 Mon Sep 17 00:00:00 2001
+From e88af0dd4b9765386c158ccdaa3fc8f86ac6664f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
 Subject: [PATCH 012/139] pinctrl-bcm2835: Fix interrupt handling for GPIOs
@@ -737,7 +737,7 @@ index d11e2e4ea189466e686d762cb6c6fef9111ecf8e..107ad7d58de8f8a7f55e09c9cdcf7d66
  	},
  };
 
-From c661156e0d492293fe8f9f302bfaae94debb6ea0 Mon Sep 17 00:00:00 2001
+From ff3a2bf24e366702a2a5443e0cb5e93c46d2cf8f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
 Subject: [PATCH 013/139] pinctrl-bcm2835: Only request the interrupts listed
@@ -767,7 +767,7 @@ index 107ad7d58de8f8a7f55e09c9cdcf7d66fa7ab66b..644bdecbcfcb79d3b84a33769265fca5
  		pc->irq_data[i].irqgroup = i;
  
 
-From 5ed11f16df89c1906aeabe516893535cedd22163 Mon Sep 17 00:00:00 2001
+From 32b41178bba5b6f6aa3c145dd1dfa27899aa81cd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 May 2016 12:32:47 +0100
 Subject: [PATCH 014/139] pinctrl-bcm2835: Return pins to inputs when freed
@@ -811,7 +811,7 @@ index 644bdecbcfcb79d3b84a33769265fca5d3d0c9e5..81a66cba2ab0f7e3ae179de7edd10122
  	.get_function_name = bcm2835_pmx_get_function_name,
  	.get_function_groups = bcm2835_pmx_get_function_groups,
 
-From 72e89a6e4e63a370ff774485e9f34736b46dc0a1 Mon Sep 17 00:00:00 2001
+From b5c557274a3511135a2d53742f922f21619bb355 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
 Subject: [PATCH 015/139] spi-bcm2835: Support pin groups other than 7-11
@@ -895,7 +895,7 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From a2d8f5ea8f099c827b430075495cd4f66bbcfea3 Mon Sep 17 00:00:00 2001
+From a2fdb5a45fa7b94058b027b4bafb8a8289406d99 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
 Subject: [PATCH 016/139] spi-bcm2835: Disable forced software CS
@@ -932,7 +932,7 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From 6026a5b9fa567b03ef223f850ecd39530cd122ca Mon Sep 17 00:00:00 2001
+From 089d470d2d65c2052c6386725d4efeab116bc117 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
 Subject: [PATCH 017/139] spi-bcm2835: Remove unused code
@@ -1023,7 +1023,7 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From f13be437d58ecb8d95e017926f4e47732f3eefb4 Mon Sep 17 00:00:00 2001
+From 98db138a65fa16c16da1d236ddc32c42ec5630b6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
 Subject: [PATCH 018/139] ARM: bcm2835: Set Serial number and Revision
@@ -1079,7 +1079,7 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 0328437d8ab1ce8e27b7b1fbc65ee02e30af4673 Mon Sep 17 00:00:00 2001
+From a5dfd7ae772896fe5937a229348f510e3e817147 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
 Subject: [PATCH 019/139] dmaengine: bcm2835: Load driver early and support
@@ -1185,7 +1185,7 @@ index e18dc596cf2447fa9ef7e41b62d9396e29043426..80d35f760b4a4a51e60c355a84d538ba
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From ca1f2d494d953107927917bf79546ca2ced82efb Mon Sep 17 00:00:00 2001
+From 9033cf9c424d98b4d9a961704d81d94bd047b677 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
 Subject: [PATCH 020/139] firmware: Updated mailbox header
@@ -1251,7 +1251,7 @@ index 3fb357193f09914fe21f8555a4b8613f74f22bc3..227a107214a02deadcca3db202da265e
  	RPI_FIRMWARE_GET_COMMAND_LINE =                       0x00050001,
  	RPI_FIRMWARE_GET_DMA_CHANNELS =                       0x00060001,
 
-From 3476f48a6308c25a552bafb7d75b827700bf4f6b Mon Sep 17 00:00:00 2001
+From 4e7f6f0cda5121055243e9bb5b263e8344148d20 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
 Subject: [PATCH 021/139] clk: bcm2835: Mark GPIO clocks enabled at boot as
@@ -1292,7 +1292,7 @@ index 3bbd2a58db470a89b870a793e59ddf9fc4f48e57..7040c6426e35c11608121893b662c601
  		init.ops = &bcm2835_vpu_clock_clk_ops;
  	} else {
 
-From 3987d68ac3af1cf84fb920b0cd6aa32a53266cf5 Mon Sep 17 00:00:00 2001
+From 912c917ab1ed21ff38359f4dcd5c51b0341df5f8 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
 Subject: [PATCH 022/139] rtc: Add SPI alias for pcf2123 driver
@@ -1315,7 +1315,7 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From 7c4ad5b6dfd0947c786a18a1bbe20055d89a5681 Mon Sep 17 00:00:00 2001
+From bbed45b34f60b140809b56c231e0871347384ab2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
 Subject: [PATCH 023/139] watchdog: bcm2835: Support setting reboot partition
@@ -1442,7 +1442,7 @@ index 4dddd8298a227d64862f2e92954a465f2e44b3f6..1f545e024422f59280932713e6a1b051
  	register_restart_handler(&wdt->restart_handler);
  	if (pm_power_off == NULL)
 
-From 4faf393423adc1f2e66722521e4b02e6ed1bffa5 Mon Sep 17 00:00:00 2001
+From 50423ce4268fc282d5c126c976d5e102f03a69a8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
 Subject: [PATCH 024/139] reboot: Use power off rather than busy spinning when
@@ -1468,7 +1468,7 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From c19bf9210f674641ca6a7763e5d17702985cd823 Mon Sep 17 00:00:00 2001
+From a1ec11d449c006e308ef58df856e698fa81baae3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
 Subject: [PATCH 025/139] bcm: Make RASPBERRYPI_POWER depend on PM
@@ -1490,7 +1490,7 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 97461aecb75e4aa4fef0493367484d5efefe1242 Mon Sep 17 00:00:00 2001
+From a7ebd08838c2ec41b7736e8304add41b6ef84b09 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
 Subject: [PATCH 026/139] Register the clocks early during the boot process, so
@@ -1538,7 +1538,7 @@ index 7040c6426e35c11608121893b662c601cd8d6543..21e2a538ff0d0ab4e63adff9b93705f3
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From ddcf6876434d1d4de6c20cd7a246ec6761278b7a Mon Sep 17 00:00:00 2001
+From d7ad57c0c17f97fea7d7966262de245a958af3b8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
 Subject: [PATCH 027/139] bcm2835-rng: Avoid initialising if already enabled
@@ -1567,7 +1567,7 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From 8213c5e839ed73f290c31f8fa8771109d71d333f Mon Sep 17 00:00:00 2001
+From c1c9b2d17864f0c1fcd49544bb1b87e541d8c3cf Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
 Subject: [PATCH 028/139] kbuild: Ignore dtco targets when filtering symbols
@@ -1590,7 +1590,7 @@ index 179219845dfcdfbeb586d12c5ec1296095d9fbf4..e0743e44f84188667a0c322e8c3d36f1
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From 08420db89a7b0f3bc93d53d26f082a87e7a3126f Mon Sep 17 00:00:00 2001
+From 23de699fe8e92a866a90d4306ec582d03ccf75a3 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
 Subject: [PATCH 029/139] BCM2835_DT: Fix I2S register map
@@ -1631,7 +1631,7 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From eddd2846e5da35c427a1449afcb1cdcef4d6c0ce Mon Sep 17 00:00:00 2001
+From 1db3842e9597c0b3f2fb19d05d43970f38987e30 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
 Subject: [PATCH 030/139] Main bcm2708/bcm2709 linux port
@@ -1841,7 +1841,7 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 50b9b81411581b78ec6de8ca8c60fa16b0c731cf Mon Sep 17 00:00:00 2001
+From 0016753b3635c513fa72188470af6ecbc7559a7f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
 Subject: [PATCH 031/139] Add dwc_otg driver
@@ -62901,7 +62901,7 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 617354ba9cb3ef301169e87d257495f80122bce9 Mon Sep 17 00:00:00 2001
+From ad9942bb532876f79cc571cf6cc42d5d2328a353 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
 Subject: [PATCH 032/139] bcm2708 framebuffer driver
@@ -66363,7 +66363,7 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From e453972328537f2d7df0457a3a588c7425837e22 Mon Sep 17 00:00:00 2001
+From 7ea8d3a2f73b5f083d5a26d79fad7b0e7be187a8 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
 Subject: [PATCH 033/139] dmaengine: Add support for BCM2708
@@ -66997,7 +66997,7 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From fa6a7864e4a03147b20bcda3dc587ffedcaaf39c Mon Sep 17 00:00:00 2001
+From f6cf10c027b6eacd650e3abed744d4c0d2e6d2c9 Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
 Subject: [PATCH 034/139] MMC: added alternative MMC driver
@@ -68750,7 +68750,7 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From a36ad8e9b50f8e475bf934c76412b4c915cd7b26 Mon Sep 17 00:00:00 2001
+From 84a680ff080a3948716b861c1d4c1af277eff880 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
 Subject: [PATCH 035/139] Adding bcm2835-sdhost driver, and an overlay to
@@ -71158,7 +71158,7 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 44542e41e3612387f6323b7b606ecc433bb45bb6 Mon Sep 17 00:00:00 2001
+From 5c89ae0b871ea731650ee6fc2fd651b7c1452c91 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
 Subject: [PATCH 036/139] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
@@ -71297,7 +71297,7 @@ index 73fad83acbcb6a157587180516f9ffe7c61eb7d7..e7c9d3098ac06e3c6554fa3373a311f9
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From 6f9bd29d66d6944241605966aff61b2ebabf0f65 Mon Sep 17 00:00:00 2001
+From 625996a0af8c967c3507641fffb92ac0110798e7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:31:47 +0100
 Subject: [PATCH 037/139] cma: Add vc_cma driver to enable use of CMA
@@ -72636,7 +72636,7 @@ index 0000000000000000000000000000000000000000..be2819d5d41f9d5ed65daf8eedb94c9e
 +
 +#endif /* VC_CMA_H */
 
-From 2118117473b152a28312fe2191ee4ba1d2f1ddd4 Mon Sep 17 00:00:00 2001
+From 816b630221c9db00e4550f297a7f453c89fda534 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 26 Mar 2012 22:15:50 +0100
 Subject: [PATCH 038/139] bcm2708: alsa sound driver
@@ -75374,7 +75374,7 @@ index 0000000000000000000000000000000000000000..af3e6eb690113fc32ce9e06bd2f0f294
 +
 +#endif // _VC_AUDIO_DEFS_H_
 
-From cb677622dcf82cc659fe1944565c707c1ae386c7 Mon Sep 17 00:00:00 2001
+From 350652c81704c5247ef752809e6307f126cc7819 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
 Subject: [PATCH 039/139] vc_mem: Add vc_mem driver for querying firmware
@@ -75901,7 +75901,7 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From fcfeb0de0a54c9ee86502dbb18d149df84579e29 Mon Sep 17 00:00:00 2001
+From b2291fe7f6849c8dd94fb10e9fa2f6f868573db0 Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
 Subject: [PATCH 040/139] vcsm: VideoCore shared memory service for BCM2835
@@ -80311,7 +80311,7 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From 9e6a2694faa752923ca52e7a0d7470f1d7147a58 Mon Sep 17 00:00:00 2001
+From 5b87381726a9f48c5d208c4e98aba34a7b168e58 Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
 Subject: [PATCH 041/139] Add /dev/gpiomem device for rootless user GPIO access
@@ -80625,7 +80625,7 @@ index 0000000000000000000000000000000000000000..911f5b7393ed48ceed8751f06967ae64
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From a91ab8be19eece779b19176a5a6f22e6117a8a68 Mon Sep 17 00:00:00 2001
+From 91fc76494224cbb83636ebc0e1dd2fa53ad7f8ca Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
 Subject: [PATCH 042/139] Add SMI driver
@@ -82579,7 +82579,7 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From 0e4b6b76f6302299113e328c3a52feba8d973a3b Mon Sep 17 00:00:00 2001
+From b2fab22bd471cfc549d894df89bd7a186c59b4cc Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
 Subject: [PATCH 043/139] MISC: bcm2835: smi: use clock manager and fix reload
@@ -82752,7 +82752,7 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 5e96c04566a4405e2060ebb6d3c356a55b9f60ae Mon Sep 17 00:00:00 2001
+From 15da3de9ea39a5c06b40feb3a3dd426ee409df57 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
 Subject: [PATCH 044/139] Add SMI NAND driver
@@ -83120,7 +83120,7 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From fd2826446ae8feb0345413e5293bf9c4e339283c Mon Sep 17 00:00:00 2001
+From 09f878c5895dc95e8a4974055733ed6567ea5aca Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
 Subject: [PATCH 045/139] lirc: added support for RaspberryPi GPIO
@@ -83986,7 +83986,7 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From d101d1e54c9d0c552ddb9ea8cf91036676b75d63 Mon Sep 17 00:00:00 2001
+From f2ce126a6164b9386ae7ba47d44181cba6dc2618 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
 Subject: [PATCH 046/139] Add cpufreq driver
@@ -84256,7 +84256,7 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 4d36baabc5401412e9a91c0c6a5c298749696c7e Mon Sep 17 00:00:00 2001
+From 95b11a85c28a7a35496f1e06df6f1369cab3dc9f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
 Subject: [PATCH 047/139] Added hwmon/thermal driver for reporting core
@@ -84425,7 +84425,7 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From 71ef724e8655eb0164293c65aa6d77dd49a56585 Mon Sep 17 00:00:00 2001
+From af84b2c9ba73dbe9aca6cfdfade47b9e49e57e6e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
 Subject: [PATCH 048/139] Add Chris Boot's i2c driver
@@ -85093,7 +85093,7 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 9f186fb7bcbde7efbfb2d646a99893434281e7f5 Mon Sep 17 00:00:00 2001
+From 935e7b0ec6cb2cb82854738777e8dd4db7646c4f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
 Subject: [PATCH 049/139] char: broadcom: Add vcio module
@@ -85322,7 +85322,7 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 0eb33414450647e69d5d814285e8987ff43bcd20 Mon Sep 17 00:00:00 2001
+From 6fa3d7513416c0f1f1c2592ec57fa6a5cf4b7024 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
 Subject: [PATCH 050/139] firmware: bcm2835: Support ARCH_BCM270x
@@ -85408,7 +85408,7 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From 883b24f2789355b2fcdc477d7e1592190e7105a0 Mon Sep 17 00:00:00 2001
+From 3653c5fb680c8ee30089fd22d3f73d9242289d3a Mon Sep 17 00:00:00 2001
 From: Vincent Sanders <vincent.sanders@collabora.co.uk>
 Date: Wed, 30 Jan 2013 12:45:18 +0000
 Subject: [PATCH 051/139] bcm2835: add v4l2 camera device
@@ -93153,7 +93153,7 @@ index 0000000000000000000000000000000000000000..9d1d11e4a53e510c04a416d92d195a7d
 +
 +#endif /* MMAL_VCHIQ_H */
 
-From 80518bfb29d55986781a5dcfe8045b4c04078a08 Mon Sep 17 00:00:00 2001
+From 129404457314ac4a012aa7532ca409d85d3069e3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
 Subject: [PATCH 052/139] scripts: Add mkknlimg and knlinfo scripts from tools
@@ -93676,7 +93676,7 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 84213193818c989afe26ebd7e7043c5450f8e987 Mon Sep 17 00:00:00 2001
+From 19d685b0ddc0e5ba4b46ce55493a16977f439812 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 10 Aug 2015 09:49:15 +0100
 Subject: [PATCH 053/139] scripts/dtc: Update to upstream version 1.4.1
@@ -96530,7 +96530,7 @@ index ad9b05ae698b0495ecbda42ffcf4743555313a27..2595dfda020fd9e03f0beff5006f229d
 -#define DTC_VERSION "DTC 1.4.1-g53bf130b"
 +#define DTC_VERSION "DTC 1.4.1-g25efc119"
 
-From f0618d8e890c7e4cc63af91bc7214d423bc7f4e7 Mon Sep 17 00:00:00 2001
+From 1630dd1730baed2c3c269fe7f20578b58271b67c Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
 Subject: [PATCH 054/139] BCM2708: Add core Device Tree support
@@ -106661,7 +106661,7 @@ index 0a07f9014944ed92a8e2e42983ae43be60b3e471..1967878a843461c3ff1f473b9a030eb0
  
  # Bzip2
 
-From 751d72116578b77c728b66bf570d6fb4eb5d53ff Mon Sep 17 00:00:00 2001
+From 3a7a382848170ecff5b436b832a0b1044e1675ec Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
 Subject: [PATCH 055/139] BCM270x_DT: Add pwr_led, and the required "input"
@@ -106840,7 +106840,7 @@ index ddfcb2df3656cf0ab6aebd1fa3d624a6ec2e94e9..271563eb835f9018712e2076a88f341d
  	/* Set LED brightness level
  	 * Must not sleep. Use brightness_set_blocking for drivers
 
-From 43c78d90576cb16c0e0d9b219ca3b953c6d8f6de Mon Sep 17 00:00:00 2001
+From e0ee334a25243c3dc1bf66f4981cedd301c572e7 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
 Subject: [PATCH 056/139] fbdev: add FBIOCOPYAREA ioctl
@@ -107095,7 +107095,7 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From 39ac9870d42b1a6b311f3fce180bac893050b8ab Mon Sep 17 00:00:00 2001
+From 41bd479f6f68ab21ef39d60479c3c3b412847af7 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
 Subject: [PATCH 057/139] Speed up console framebuffer imageblit function
@@ -107307,7 +107307,7 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From 0edd639f86a0c1d761d8ed77da544976984f0e48 Mon Sep 17 00:00:00 2001
+From 9e7a1df168cc429ab2a795ccad6304929dd69d0b Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
 Subject: [PATCH 058/139] enabling the realtime clock 1-wire chip DS1307 and
@@ -107560,7 +107560,7 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From 93562c1b53115f77cf09a13fbc7bf9e8fdfdee57 Mon Sep 17 00:00:00 2001
+From d88ed49cf9b4e33e4d5fefaeea2f6849912e4626 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 18 Dec 2013 22:16:19 +0000
 Subject: [PATCH 059/139] config: Enable CONFIG_MEMCG, but leave it disabled
@@ -107613,7 +107613,7 @@ index 85bc9beb046d9a6deda2e3564f4d5bd01d6fc27b..4acdbef46a8f0556469b5580a39c18ce
   * css_tryget_online_from_dir - get corresponding css from a cgroup dentry
   * @dentry: directory dentry of interest
 
-From e3cc908913ebd5bae2b0cca4e1fe42a2ae53f50e Mon Sep 17 00:00:00 2001
+From c3082b81c8431894f50fa88fddba30480cccc45d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
 Subject: [PATCH 060/139] hid: Reduce default mouse polling interval to 60Hz
@@ -107652,7 +107652,7 @@ index ae83af649a607f67239f1a64bf45dd4b5770cc7d..4a7af9d0b910f59d17421ce14138400d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From 9f43e0a8a7790ad9199e20cb3b622394906409e9 Mon Sep 17 00:00:00 2001
+From 38755f89c008a66b2debaf5de15fda603745e0fd Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
 Subject: [PATCH 061/139] rpi-ft5406: Add touchscreen driver for pi LCD display
@@ -108013,7 +108013,7 @@ index 227a107214a02deadcca3db202da265eba1fdd21..b0f6e33bd30c35664ceee057f4c3ad32
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 00b6c19a03fc81668a4999b4e0b52d2f2da3cf96 Mon Sep 17 00:00:00 2001
+From ae04e2eb95db06ce465a40fe86543e2bc5714320 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
 Subject: [PATCH 062/139] Improve __copy_to_user and __copy_from_user
@@ -109591,7 +109591,7 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From 386e8ec75004508ca5ef21df4e75e28021c08d22 Mon Sep 17 00:00:00 2001
+From b1001796bd3e4e4aca5fb0391bfe2dfd78dc75d2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
 Subject: [PATCH 063/139] gpio-poweroff: Allow it to work on Raspberry Pi
@@ -109629,7 +109629,7 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From 48626221a6826a0dd2ce19dada02bcdd197a1c12 Mon Sep 17 00:00:00 2001
+From 67370976c21ad611456ca00937e94302ebc51d84 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
 Subject: [PATCH 064/139] mfd: Add Raspberry Pi Sense HAT core driver
@@ -110497,7 +110497,7 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 8c3de85e40057b1d6ec5b8a6772e661cbebf2be7 Mon Sep 17 00:00:00 2001
+From 63f6dd81c9b54778fe3a6f09fd35d37ae905b308 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
 Subject: [PATCH 065/139] ASoC: Add support for HifiBerry DAC
@@ -110675,7 +110675,7 @@ index 0000000000000000000000000000000000000000..45f2b770ad9e67728ca599a7445d6ae9
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 0c4f4d2a354aa011cc5e808e745bc66b2e1019ff Mon Sep 17 00:00:00 2001
+From b6cc9da98604495e2f7f80fc373519fb5630c3ac Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
 Subject: [PATCH 066/139] ASoC: Add support for Rpi-DAC
@@ -110962,7 +110962,7 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From 28e35948f0cbfed9abd11844910db3224ddda010 Mon Sep 17 00:00:00 2001
+From 8868118677ec38b2c77c7162b39ab4c70e577916 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
 Subject: [PATCH 067/139] ASoC: wm8804: Implement MCLK configuration options,
@@ -111014,7 +111014,7 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From 84663a7e31d002d12bb05a7c0c903216fcfd25b7 Mon Sep 17 00:00:00 2001
+From f12a09b3eb2d5bc64dcb5f4162644bea5ee3b8b0 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
 Subject: [PATCH 068/139] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
@@ -111361,7 +111361,7 @@ index 0000000000000000000000000000000000000000..19dc953b7227ba86123fc7a2ba654499
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 1b03571b887bdf83b1a49880003dd62625fb1f7c Mon Sep 17 00:00:00 2001
+From 8c796f49adaf6fd267a06e6d4233b3a2a21b6d3f Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
 Subject: [PATCH 069/139] Add IQaudIO Sound Card support for Raspberry Pi
@@ -111694,7 +111694,7 @@ index 0000000000000000000000000000000000000000..4e8e6dec14bcf4a1ff286c43742d4097
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From f389a4b14734480574032f51168308ace40c529d Mon Sep 17 00:00:00 2001
+From ab9de808b428c251e89d2896944a50a43c1cb251 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jul 2016 17:06:50 +0100
 Subject: [PATCH 070/139] iqaudio-dac: Compile fix - untested
@@ -111721,7 +111721,7 @@ index 4e8e6dec14bcf4a1ff286c43742d4097249d6777..aa15bc4b49ca95edec905fddd8fd0a6d
  	if (dapm->dev != codec_dai->dev)
  		return 0;
 
-From ef2c5b5a21239094c6997e10f19a68f970e8af22 Mon Sep 17 00:00:00 2001
+From 41debd2f3f4c6ea0e55ad32bb28b97a290038182 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
 Subject: [PATCH 071/139] Added support for HiFiBerry DAC+
@@ -112354,7 +112354,7 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From 5e384d11d9656df7e9877ce331130a83e8ccb5a3 Mon Sep 17 00:00:00 2001
+From cea07a9c82e5217da838aa57b419b4d119d76c5b Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
 Subject: [PATCH 072/139] Added driver for HiFiBerry Amp amplifier add-on board
@@ -113190,7 +113190,7 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 5e621985175981470e86bd427516a8782f6008a6 Mon Sep 17 00:00:00 2001
+From fe9b02e262b822bcc441c56faa1c6e31f9c134eb Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Dec 2016 16:26:54 +0000
 Subject: [PATCH 073/139] Revert "Added driver for HiFiBerry Amp amplifier
@@ -114015,7 +114015,7 @@ index 8f019e04898754d2f87e9630137be9e8f612a342..00000000000000000000000000000000
 -
 -#endif  /* _TAS5713_H */
 
-From 05d51ab311a4af15bc07f97f7ddc9c103482b3cd Mon Sep 17 00:00:00 2001
+From ac3132fbcfcf8224504db1b56652ed9cde87fee6 Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
 Subject: [PATCH 074/139] Update ds1307 driver for device-tree support
@@ -114045,7 +114045,7 @@ index 4e31036ee2596dec93accd26f627c5b95591ae9f..b92044cf03e750afa521a93519500e9d
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From 1f0d9f787beb8351e2c39fb8ae789a6d7a1cd539 Mon Sep 17 00:00:00 2001
+From 0d76a093f831d5070add13a811a7a7bee403890a Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
 Subject: [PATCH 075/139] Add driver for rpi-proto
@@ -114263,7 +114263,7 @@ index 0000000000000000000000000000000000000000..9db678e885efd63d84d60a098a84ed67
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 3ecc8e028f7c64fa64c2f7b85de63aa0e920914b Mon Sep 17 00:00:00 2001
+From 38abe33d796ec0245f41fa3593591d8dd44f68ca Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
 Subject: [PATCH 076/139] RaspiDAC3 support
@@ -114509,7 +114509,7 @@ index 0000000000000000000000000000000000000000..dd9eeea2af0382307f437e6db09d1546
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From c6896319efdeef4e158c84fa77b0c533795d754c Mon Sep 17 00:00:00 2001
+From b82f88c937287c6c0682681fda378d3664ab710f Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
 Subject: [PATCH 077/139] Add Support for JustBoom Audio boards
@@ -114966,7 +114966,7 @@ index 0000000000000000000000000000000000000000..91acb666380faa3c0deb2230f8a0f8bb
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From c5865a7bf88ea9b6c34210b17272312f7c90b5e6 Mon Sep 17 00:00:00 2001
+From 705f0a75555c23741a4b6f8612dd5d205bac101a Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
 Subject: [PATCH 078/139] ARM: adau1977-adc: Add basic machine driver for
@@ -115151,7 +115151,7 @@ index 0000000000000000000000000000000000000000..6e2ee027926ee63c89222f75ceb89e3d
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From 2ed7e5179dc82b173ba4d8a6c33ad38e91606c98 Mon Sep 17 00:00:00 2001
+From ebeb0ad8b4c94e1ee9beea35f04041ba40c7523a Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
 Subject: [PATCH 079/139] New AudioInjector.net Pi soundcard with low jitter
@@ -115405,7 +115405,7 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 7b3f658737549988cc4a9592a44de0228ceb9a81 Mon Sep 17 00:00:00 2001
+From a146eda24e52f119a3669df48bf41eb0c52b89a4 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
 Subject: [PATCH 080/139] Add IQAudIO Digi WM8804 board support
@@ -115708,7 +115708,7 @@ index 0000000000000000000000000000000000000000..9b6e829bcb5b1762a853775e78163196
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 3c19d98018e7dba2d499226ce2ff4d466ff019da Mon Sep 17 00:00:00 2001
+From bb65999a85ef3bf0807fe244f53546f7e71ddc77 Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
 Subject: [PATCH 081/139] New driver for RRA DigiDAC1 soundcard using WM8741 +
@@ -116184,7 +116184,7 @@ index 0000000000000000000000000000000000000000..446796e7e4c14a7d95b2f2a01211d9a0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From 7754471b3eb6fa4e48360b49d01b86fc71a3b539 Mon Sep 17 00:00:00 2001
+From 83565664ffc9e8922176ce04e27dfd00be9a7645 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
 Subject: [PATCH 082/139] Add support for Dion Audio LOCO DAC-AMP HAT
@@ -116360,7 +116360,7 @@ index 0000000000000000000000000000000000000000..89e65317512bc774453ac8d0d5b0ff98
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From 00707f8af0f909bd1e73a66b227587c108e9950d Mon Sep 17 00:00:00 2001
+From 287a23b4358505b4e096dc910cde539afc94ff24 Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
 Subject: [PATCH 083/139] Allo Piano DAC boards: Initial 2 channel (stereo)
@@ -116570,7 +116570,7 @@ index 0000000000000000000000000000000000000000..8e8e62e5a36a279b425ed4655cfbac99
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 0dea69effd9cfbb945f86d715a94b7ab2a876094 Mon Sep 17 00:00:00 2001
+From e175ae25e958e045b5d2ec7f3e96b810ac702fdd Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
 Subject: [PATCH 084/139] Support for Blokas Labs pisound board
@@ -117750,7 +117750,7 @@ index 0000000000000000000000000000000000000000..4b8545487d06e4ea70073a5d063fb231
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From 627793624e12b70fa82f1c5ba0d43abc9c02de30 Mon Sep 17 00:00:00 2001
+From 3f7afb2353aabbb329a150797ff216f84c7c3d0f Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
 Subject: [PATCH 085/139] rpi_display: add backlight driver and overlay
@@ -117922,7 +117922,7 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 3e73b5398a672f71124cd49e5f49887f4561dc74 Mon Sep 17 00:00:00 2001
+From e2e08bb2c64f834d09dee57747187c45eeb52c14 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
 Subject: [PATCH 086/139] bcm2835-virtgpio: Virtual GPIO driver
@@ -118199,7 +118199,7 @@ index b0f6e33bd30c35664ceee057f4c3ad32b914291d..e92278968b2b979db2a1f855f70e7aaf
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 2195a08dc3e8e28fc6fcad8d57aa73d82d461efe Mon Sep 17 00:00:00 2001
+From a18071c6011ebf6a7a86e9ad5d9d4f0cf899a101 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
 Subject: [PATCH 087/139] amba_pl011: Don't use DT aliases for numbering
@@ -118231,7 +118231,7 @@ index e2c33b9528d82ed7a2c27d083d7b1d222da68178..5a11ff833e1fd112ba04df3a427cd94b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From 21defd9b3d89f388321638da4dc7a80f43e3ab33 Mon Sep 17 00:00:00 2001
+From 8237399e8ceafb4e0552014895c800e446e5bc1c Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
 Subject: [PATCH 088/139] OF: DT-Overlay configfs interface
@@ -118666,7 +118666,7 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From 20849553459552989d8cc985298c99ba6f0adaad Mon Sep 17 00:00:00 2001
+From d91e487c7d88fd680689df1655ebab1b1e4c2ae4 Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
 Subject: [PATCH 089/139] brcm: adds support for BCM43341 wifi
@@ -118832,7 +118832,7 @@ index d0407d9ad7827cd756b6311410ffe2d9a7cacc78..f1fb8a3c7a3211e8429585861f2f42e0
  #define BRCM_CC_4335_CHIP_ID		0x4335
  #define BRCM_CC_4339_CHIP_ID		0x4339
 
-From 70a7564fc0027a683a3539110e5a6754dac33b6a Mon Sep 17 00:00:00 2001
+From e115c9bc45a088adb4e74ffc0d0f0a4a88104b23 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
 Subject: [PATCH 090/139] hci_h5: Don't send conf_req when ACTIVE
@@ -118858,7 +118858,7 @@ index 0879d64b1caf58afb6e5d494c07d9ab7e7cdf983..5161ab30fd533d50f516bb93d5b9f402
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From 9d5271f68b5c9a1a169536fb80aaec80d44be9fb Mon Sep 17 00:00:00 2001
+From 24823d68518f34980e5ad2ec1a882cc8d913ffde Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
 Subject: [PATCH 091/139] config: Add default configs
@@ -121488,7 +121488,7 @@ index 0000000000000000000000000000000000000000..8acee9f31202ec14f2933d92dd70831c
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From e04d08b7f6ef287f06762af05f3508b5282cc890 Mon Sep 17 00:00:00 2001
+From 944b4f4646b9bcf17078736e442bd32fe664dca7 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
 Subject: [PATCH 092/139] Add arm64 configuration and device tree differences.
@@ -122906,7 +122906,7 @@ index 0000000000000000000000000000000000000000..d7406f5a4620151044b8f716b4d10bb8
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2708_VCHIQ=n
 
-From ef77c16713667c445b5550c388cf1dca491639f0 Mon Sep 17 00:00:00 2001
+From b3b7bf9f34ff8bb310261a156af5a711aa76b055 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 7 Mar 2016 15:05:11 +0000
 Subject: [PATCH 093/139] vchiq_arm: Tweak the logging output
@@ -122984,7 +122984,7 @@ index 2c98da4307dff994a00dc246574ef0aaee05d5da..160db24aeea33a8296923501009c1f02
  
  		switch (type) {
 
-From 0f95c67791ea96a735a9a93b4c347c6ebfb7a9c3 Mon Sep 17 00:00:00 2001
+From b0c2bcf368c10db7f6bed3163366e21aca4de06b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 14:16:25 +0000
 Subject: [PATCH 094/139] vchiq_arm: Access the dequeue_pending flag locked
@@ -123045,7 +123045,7 @@ index 7b6cd4d80621e38ff6d47fcd87b45fbe9cd4259b..d8669fa7f39b077877eca1829ba9538b
  
  	return add_completion(instance, reason, header, user_service,
 
-From e607cd62de503c30cd471ddf601f2fe44e82e61b Mon Sep 17 00:00:00 2001
+From 944839ed99bbfc801f5124a45a0becdec66cdc42 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 23 Mar 2016 20:53:47 +0000
 Subject: [PATCH 095/139] vchiq_arm: Service callbacks must not fail
@@ -123074,7 +123074,7 @@ index d8669fa7f39b077877eca1829ba9538bf2e21a82..54552c6ce54f413c9781ba279b936f98
  		DEBUG_TRACE(SERVICE_CALLBACK_LINE);
  	}
 
-From 2bbf9b6bc1589f85fa7defddeda75767620fe8be Mon Sep 17 00:00:00 2001
+From 2665eaff5297e439a25dea009a5da87fcf44cdb6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 21 Apr 2016 13:49:32 +0100
 Subject: [PATCH 096/139] vchiq_arm: Add completion records under the mutex
@@ -123140,7 +123140,7 @@ index 54552c6ce54f413c9781ba279b936f98be4f47b0..bde8955b7d8505d73579b77b5b392154
  
  	return VCHIQ_SUCCESS;
 
-From 8ec8b734304b94bf6fe137ce11dbb5cc5699857f Mon Sep 17 00:00:00 2001
+From 94c56a1493788fcc56b53a9c520bd845693fd2a7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 20 Jun 2016 13:51:44 +0100
 Subject: [PATCH 097/139] vchiq_arm: Avoid use of mutex in add_completion
@@ -123337,7 +123337,7 @@ index 160db24aeea33a8296923501009c1f02bc41e599..71a3bedc55314f3b22dbff40c05dedf0
  		up(&state->slot_available_event);
  	}
 
-From 33ed8507e5087e15a7d47eba88ea2d8ba537b58e Mon Sep 17 00:00:00 2001
+From 20e5d7251d813ded6d78fe1aae41c1d08c65cfb5 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:14:10 -0700
 Subject: [PATCH 098/139] staging/vchi: Convert to current get_user_pages()
@@ -123377,7 +123377,7 @@ index e5cdda12c7e5c35c69eb96991cfdb8326def167f..085d37588c59198b4e5f00b9249bb842
  		num_pages,                /* len */
  		0,                        /* gup_flags */
 
-From 960a154027491572193142b91ea470147f5b78eb Mon Sep 17 00:00:00 2001
+From 2165acaceffc4bab5cc9a1ef89e5156b28c3bbca Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:16:03 -0700
 Subject: [PATCH 099/139] staging/vchi: Update for rename of
@@ -123425,7 +123425,7 @@ index 085d37588c59198b4e5f00b9249bb8421695854f..5a2b8fb459ebe086ec229f37b6381bdb
  	kfree(pages);
  }
 
-From d823ec3413a5c898c063a5eaccf15cd33b85384b Mon Sep 17 00:00:00 2001
+From 3e38b41b930bb25b661cb17b6ca8269e2c5adf52 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 3 Oct 2016 10:21:17 -0700
 Subject: [PATCH 100/139] drivers/vchi: Remove dependency on CONFIG_BROKEN.
@@ -123450,7 +123450,7 @@ index 9676fb29075a457109e4d4235f086987aec74868..db8e1beb89f9f8c48ea5964016c8285e
  	help
  		Kernel to VideoCore communication interface for the
 
-From 61faced7aea265c5f8c7c97bebad43870487391a Mon Sep 17 00:00:00 2001
+From 9ec7e7221461bf7e6398163ab3a7c23b685f0134 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
 Subject: [PATCH 101/139] raspberrypi-firmware: Export the general transaction
@@ -123497,7 +123497,7 @@ index e92278968b2b979db2a1f855f70e7aafb224fa98..09e3d871d110eb0762ebdb5ea3293537
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 57f7ed87633050a3d85e034e7b7cb8e98a39221b Mon Sep 17 00:00:00 2001
+From 8688bb44fad47a82d542dc77cb0e58a97f5e0d34 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
 Subject: [PATCH 102/139] raspberrypi-firmware: Define the MBOX channel in the
@@ -123522,7 +123522,7 @@ index 09e3d871d110eb0762ebdb5ea329353738d58661..2859db09e25bb945251e85edb39bc434
  
  enum rpi_firmware_property_status {
 
-From e9b66b168babeea1653429f662bc46af84726280 Mon Sep 17 00:00:00 2001
+From 589e28b3e9047bb4b8fe1286cc89af88e4c2dd59 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
 Subject: [PATCH 103/139] drm/vc4: Add a mode for using the closed firmware for
@@ -123551,7 +123551,7 @@ index fb77db755e0a29d8589860da82186c7a1f394c72..c6dd06cca9830018c39b3b16afe4045e
  	vc4_gem.o \
  	vc4_hdmi.o \
 diff --git a/drivers/gpu/drm/vc4/vc4_crtc.c b/drivers/gpu/drm/vc4/vc4_crtc.c
-index 7f08d681a74b4e37529f6c09ae1d2c1a944dcabd..7366e76c38346f7c700534b28d1eff4eca2ec2fa 100644
+index d544ff9b0d4609aae945960bf82e8aeee6bc94a8..13212788eef0e4b77c1e92e6bf3a56c817c50322 100644
 --- a/drivers/gpu/drm/vc4/vc4_crtc.c
 +++ b/drivers/gpu/drm/vc4/vc4_crtc.c
 @@ -163,6 +163,9 @@ int vc4_crtc_get_scanoutpos(struct drm_device *dev, unsigned int crtc_id,
@@ -124292,7 +124292,7 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From c7de77a3b61cd7c25ff21718accb59c450fee7dc Mon Sep 17 00:00:00 2001
+From b52f5f3f01476a7afaf9f171ace83807c1ce2231 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 17 Sep 2016 15:07:10 +0200
 Subject: [PATCH 104/139] i2c: bcm2835: Fix hang for writing messages larger
@@ -124385,7 +124385,7 @@ index d4f3239b56865919e1b781b20a7c5ebcd76b4eb9..f283b714aa79e2e4685ed95b04b6b289
  	i2c_dev->msg_buf_remaining = msg->len;
  	reinit_completion(&i2c_dev->completion);
 
-From 941e536573397dad8f185229ce551086147e4034 Mon Sep 17 00:00:00 2001
+From 3f669a558ad59ab5942e04f5bd1a32f055fa0c0c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 18:24:38 +0200
 Subject: [PATCH 105/139] i2c: bcm2835: Protect against unexpected TXW/RXR
@@ -124513,7 +124513,7 @@ index f283b714aa79e2e4685ed95b04b6b289f7e9eee7..d2ba1a4de36af512e8e3c97251bd3537
  		return -ETIMEDOUT;
  	}
 
-From 80dabefa408508ca2b10b346381468eb25dce381 Mon Sep 17 00:00:00 2001
+From 9397ac3b79cde4cdf6c9cf589bd2dd33eb83f9c3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Mon, 19 Sep 2016 17:19:41 +0200
 Subject: [PATCH 106/139] i2c: bcm2835: Use dev_dbg logging on transfer errors
@@ -124548,7 +124548,7 @@ index d2ba1a4de36af512e8e3c97251bd3537ae61591a..54d510abd46a117c9238fc6d7edec840
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 1618e4b4cad41f57aaecb6ac9933ec064d6cd6e9 Mon Sep 17 00:00:00 2001
+From 2d626bfad93c486607411ce3e9b3022b93629f7f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Thu, 22 Sep 2016 22:05:50 +0200
 Subject: [PATCH 107/139] i2c: bcm2835: Can't support I2C_M_IGNORE_NAK
@@ -124595,7 +124595,7 @@ index 54d510abd46a117c9238fc6d7edec84019d1f60d..565ef69ce61423544dc0558c85ef318b
  
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
 
-From 0c3bd05e48d35df85fffbccba070ab8f1e7a7169 Mon Sep 17 00:00:00 2001
+From 9566c27f761f65435ed76ffa7773e03617ede6c7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:54:27 +0200
 Subject: [PATCH 108/139] i2c: bcm2835: Add support for Repeated Start
@@ -124780,7 +124780,7 @@ index 565ef69ce61423544dc0558c85ef318b0ae9c324..241e08ae7c27cec23fad3c1bf3ebad3a
  
  static u32 bcm2835_i2c_func(struct i2c_adapter *adap)
 
-From 2808e1610e59d749957295cb78fbed011d8ee295 Mon Sep 17 00:00:00 2001
+From 2d0f716726e6bdc56bf26e36eb9cb24c83eae092 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Sep 2016 04:57:17 +0200
 Subject: [PATCH 109/139] i2c: bcm2835: Support i2c-dev ioctl I2C_TIMEOUT
@@ -124820,7 +124820,7 @@ index 241e08ae7c27cec23fad3c1bf3ebad3a4d2a8e6f..d2085dd3742eabebc537621968088261
  		bcm2835_i2c_writel(i2c_dev, BCM2835_I2C_C,
  				   BCM2835_I2C_C_CLEAR);
 
-From a8c408645977ebe2b4d7a0bd51a14edde0ab5750 Mon Sep 17 00:00:00 2001
+From a0d4e753d28ccfaa2ad7ac1173fa836bb2f13cea Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 27 Sep 2016 01:00:08 +0200
 Subject: [PATCH 110/139] i2c: bcm2835: Add support for dynamic clock
@@ -124939,7 +124939,7 @@ index d2085dd3742eabebc537621968088261f8dc7ea8..c3436f627028477f7e21b47e079fd5ab
  	irq = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
  	if (!irq) {
 
-From fef62f9d68bb934e05f2b9e219d02c77dd3526e1 Mon Sep 17 00:00:00 2001
+From 7d425cc5f1ec065463dac3d2edbb2b37c4afa808 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
 Subject: [PATCH 111/139] i2c: bcm2835: Add debug support
@@ -125131,7 +125131,7 @@ index c3436f627028477f7e21b47e079fd5ab06ec188a..8642f580ce41803bd22c76a0fa80d083
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From a798a1ab516c19e7f02827001ed82a40b493d328 Mon Sep 17 00:00:00 2001
+From b126459dc19efe6acab1bb268dbcd92410f4b9cb Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 31 Dec 2016 14:15:50 +0000
 Subject: [PATCH 112/139] arm64: Add CONFIG_ARCH_BCM2835
@@ -125150,7 +125150,7 @@ index d7406f5a4620151044b8f716b4d10bb818648e06..53da5c7a33e5898a66e549fb0c39fe3d
  CONFIG_BCM2708_VCHIQ=n
 +CONFIG_ARCH_BCM2835=y
 
-From 077b0728cbdd7fdf11b7818f2775d80fcfe72fce Mon Sep 17 00:00:00 2001
+From a46090441a1b2dcf46918f61cc73d29739bb4518 Mon Sep 17 00:00:00 2001
 From: Alex Tucker <alex@floop.org.uk>
 Date: Tue, 13 Dec 2016 19:50:18 +0000
 Subject: [PATCH 113/139] Add support for Silicon Labs Si7013/20/21
@@ -125228,7 +125228,7 @@ index f6d134c095af2398fc55ae7d2b0e86456c30627c..31bda8da4cb6a56bfe493a81b9189009
  	};
  };
 
-From 3d970e2d6c45cd3cf3f25435b0bec4cd0775c141 Mon Sep 17 00:00:00 2001
+From b99978d546325b6547e40641895e395abd1f3820 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 3 Jan 2017 21:27:46 +0000
 Subject: [PATCH 114/139] Document the si7020 option
@@ -125252,7 +125252,7 @@ index 81d991803be335e5a1bc3bb0a8c7a2c9f5c392bd..e8fa4ccb44c34a20485c4e6155467af9
  Name:   i2c0-bcm2708
  Info:   Enable the i2c_bcm2708 driver for the i2c0 bus. Not all pin combinations
 
-From a4c802e176d7068e4e2a54e13dd618106b907951 Mon Sep 17 00:00:00 2001
+From 7c9abdbcd6204fabf158e4a223974199074c448a Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Thu, 5 Jan 2017 02:38:16 +0200
 Subject: [PATCH 115/139] pisound improvements:
@@ -125549,7 +125549,7 @@ index 4b8545487d06e4ea70073a5d063fb2310b3b94d0..ba70734b89e61a11201657406223f0b3
  };
  
 
-From 8772981b127180376c08ad97f60c53e051f15ee4 Mon Sep 17 00:00:00 2001
+From 2c3023376394ced6dd4d98620ef4b99973cca726 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:23:06 +0000
 Subject: [PATCH 116/139] Revert "Revert "Added driver for HiFiBerry Amp
@@ -126376,7 +126376,7 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 1305f68f9d7ce514916dc714db51271d53f2d953 Mon Sep 17 00:00:00 2001
+From 9819e281198546cd29cfef31987ac1db558e3c61 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 9 Jan 2017 09:42:09 +0000
 Subject: [PATCH 117/139] hifiberry-amp: Adjust for ALSA object refactoring
@@ -126404,7 +126404,7 @@ index 9b2713861dcbed751842ca29c88eb1eae5867411..560234d58a6b0a6e7fd3a63e8de73339
  
  
 
-From 0750f5306b7f5354cbae714ade4299c7384f5976 Mon Sep 17 00:00:00 2001
+From 2e0be5ac06d1f2ca6cd6bd1da49511819d5699fc Mon Sep 17 00:00:00 2001
 From: Giedrius Trainavicius <giedrius@blokas.io>
 Date: Sun, 8 Jan 2017 15:58:54 +0200
 Subject: [PATCH 118/139] bcm2835-i2s: Changes for allowing asymmetric sample
@@ -126497,7 +126497,7 @@ index 6ba20498202ed36906b52096893a88867a79269f..171c2401dfe192740fca3356268aff64
  
  	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);
 
-From 23f372d8a0d0b4266666eba1713f4c5496058a1a Mon Sep 17 00:00:00 2001
+From c8bfe609887b7f746f29a440838448d8d7cacb89 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Tue, 10 Jan 2017 16:05:41 +0000
 Subject: [PATCH 119/139] Add driver_name property
@@ -126520,7 +126520,7 @@ index 8fd50dbe681508a2cfe8fdde1c9fedbe9a507fa7..05a224ec712d06b8b7587ab6b8bb562d
  	.dai_link     = snd_rpi_justboom_dac_dai,
  	.num_links    = ARRAY_SIZE(snd_rpi_justboom_dac_dai),
 
-From 65d9e9253f3bc64368fa976a9576183934539c81 Mon Sep 17 00:00:00 2001
+From 5994a2af73ec370731447e0772779b03a59b02cc Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Tue, 10 Jan 2017 16:11:04 +0000
 Subject: [PATCH 120/139] Add driver_name paramater
@@ -126543,7 +126543,7 @@ index 91acb666380faa3c0deb2230f8a0f8bbec59417b..abfdc5c4dd5811e6847bddda4921abe3
  	.dai_link     = snd_rpi_justboom_digi_dai,
  	.num_links    = ARRAY_SIZE(snd_rpi_justboom_digi_dai),
 
-From 8861f1451d4532760b01fdedf18306edc4397a9b Mon Sep 17 00:00:00 2001
+From 0e6f718360bd09f7212d42a4d8986f4c9f6e0501 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 Jan 2017 13:01:21 +0000
 Subject: [PATCH 121/139] BCM270X_DT: Add pi3-disable-wifi overlay
@@ -126607,7 +126607,7 @@ index 0000000000000000000000000000000000000000..017199554bf2f4e381efcc7bb71e750c
 +	};
 +};
 
-From f1d7c34483947523bd055a8e69ca220bbbeefa95 Mon Sep 17 00:00:00 2001
+From aa871463608a1d9d7c9cddbc41f888a3dc622d20 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
 Subject: [PATCH 122/139] ARM64: Make it work again on 4.9 (#1790)
@@ -127015,7 +127015,7 @@ index 53da5c7a33e5898a66e549fb0c39fe3da555ca87..c7e891d72969a388d9b135a36dbfc9c9
 -CONFIG_BCM2708_VCHIQ=n
 -CONFIG_ARCH_BCM2835=y
 
-From 213c141365e1bc09ad95ebb92461cabeb4421e1f Mon Sep 17 00:00:00 2001
+From 56ed7b95748de35375951c3802d11f69523b3a5f Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 02:54:26 -0800
 Subject: [PATCH 123/139] ARM64: Enable Kernel Address Space Randomization
@@ -127050,7 +127050,7 @@ index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..974d8889c0cf695eb88b57bbef11bc5a
  CONFIG_BINFMT_MISC=y
  CONFIG_COMPAT=y
 
-From a23e36748b488b77cb92d28aa2642e1b350e6c40 Mon Sep 17 00:00:00 2001
+From 3fa49169714a512b7e9c3de2d3bd920c4b683e9a Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sun, 15 Jan 2017 07:31:59 -0800
 Subject: [PATCH 124/139] ARM64: Enable RTL8187/RTL8192CU wifi in build config
@@ -127078,7 +127078,7 @@ index 974d8889c0cf695eb88b57bbef11bc5aa556b635..4670a490dfb1e582ec24a3b39a3cb9b2
  CONFIG_ZD1211RW=m
  CONFIG_MAC80211_HWSIM=m
 
-From a8a16dca4352540a2a26cba7afc6d6368ac8c976 Mon Sep 17 00:00:00 2001
+From 1d6ca12e48db8fa517261148dd59e8c634764232 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 16 Jan 2017 14:53:12 +0000
 Subject: [PATCH 125/139] BCM270X_DT: Add spi0-cs overlay
@@ -127169,7 +127169,7 @@ index 0000000000000000000000000000000000000000..7f79029d043c04d7496c7c3480450c69
 +	};
 +};
 
-From cebce60296ccea936da1bb65b375d34a47f9a7a3 Mon Sep 17 00:00:00 2001
+From 324a7bf50e4db1288b1ecd500f8306e02af23747 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
 Subject: [PATCH 126/139] spi-bcm2835: Disable forced software CS
@@ -127198,7 +127198,7 @@ index 74dd21b7373c7564ede01d84a4f63b93a6d52fa7..51cdefbf5eb265f49bd05e0aa91dfbee
  
  		i2c0: i2c@7e205000 {
 
-From 69d606cb7dfc53bcf40db15d33907cff2e116377 Mon Sep 17 00:00:00 2001
+From ad85a8201dab1d5ede7b335cecd8004408cc3aa4 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 16 Jan 2017 16:33:54 +0000
 Subject: [PATCH 127/139] config: Add CONFIG_TCP_CONG_BBR See:
@@ -127236,7 +127236,7 @@ index 8acee9f31202ec14f2933d92dd70831cda8d7b51..219f67051a2542329449b0099165ae28
  CONFIG_IPV6_ROUTER_PREF=y
  CONFIG_INET6_AH=m
 
-From 029f0e68448aa9b9300572798dace30b33d6a85c Mon Sep 17 00:00:00 2001
+From bce2b1e8586ed431fd3885d73cb9814f2421385f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 16 Jan 2017 21:02:26 +0000
 Subject: [PATCH 128/139] Revert "bcm2835-i2s: Changes for allowing asymmetric
@@ -127329,7 +127329,7 @@ index 171c2401dfe192740fca3356268aff6432f284ea..6ba20498202ed36906b52096893a8886
  
  	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);
 
-From a3aab7c7a31e0f19658fd8d8e7f46d1824bfe506 Mon Sep 17 00:00:00 2001
+From 00d471421b2b4db27ffe9503df5aecee450d0344 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 17 Jan 2017 11:34:58 +0000
 Subject: [PATCH 129/139] BCM270X_DT: Enable UART0 on CM3
@@ -127355,7 +127355,7 @@ index 41874c25a84226c0e4af92ec4059e0a571fe6123..3ba6e621856c288ae4694f758604619f
  	sdhost_pins: sdhost_pins {
  		brcm,pins = <48 49 50 51 52 53>;
 
-From 63b95220a23a4b780cdc016ef11a656e06936edb Mon Sep 17 00:00:00 2001
+From 5a7bbecb2832ad7a805ce875e349cde80dc3a626 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 17 Jan 2017 14:39:39 +0000
 Subject: [PATCH 130/139] config: Add CONFIG_MD_M25P80 and CONFIG_MD_SPI_NOR
@@ -127397,7 +127397,7 @@ index 219f67051a2542329449b0099165ae2885022bec..c4898d63d74718097ec3a1d1fe60b230
  CONFIG_OF_CONFIGFS=y
  CONFIG_ZRAM=m
 
-From 3fc9aaeb72fe6ff39b5777f5d542c75309eb1f6e Mon Sep 17 00:00:00 2001
+From d55cbbfa197942a6cf4d78f22acd32b57f6db35a Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:33:51 -0800
 Subject: [PATCH 131/139] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
@@ -127743,7 +127743,7 @@ index 6b2c7d0c93f36a63863ff4b0ecc1f3eab77e058b..d7b700ff17821ad1944e36721fe6b2db
  /** The OS page size */
  #define DWC_OS_PAGE_SIZE	PAGE_SIZE
 
-From 4661054b08d26185d9478a047b7adbdcaad41c15 Mon Sep 17 00:00:00 2001
+From bf436f5da46aa94d6ae3795a6191d6aefb14082d Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:43:57 -0800
 Subject: [PATCH 132/139] ARM64: Round-Robin dispatch IRQs between CPUs.
@@ -127820,7 +127820,7 @@ index 93e3f7660c4230c9f1dd3b195958cb498949b0ca..486bcbfb32305ee417f6b3be7e91a3ff
  	.name		= "bcm2836-gpu",
  	.irq_mask	= bcm2836_arm_irqchip_mask_gpu_irq,
 
-From 19fce0d36b798ccb0dbb2d88333016288b7ef057 Mon Sep 17 00:00:00 2001
+From 988fdc545cc79b570f73b6bb4d50cddd8d614018 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:45:03 -0800
 Subject: [PATCH 133/139] ARM64: Enable DWC_OTG Driver In ARM64 Build
@@ -127844,7 +127844,7 @@ index 4670a490dfb1e582ec24a3b39a3cb9b2488b1864..8c4392344eb4495689c220d5d176ee8c
  CONFIG_USB_STORAGE=y
  CONFIG_USB_STORAGE_REALTEK=m
 
-From d4826d1d4392d61641fd32ddf94c11e1783275a3 Mon Sep 17 00:00:00 2001
+From 58717c70c9284167825f4a0ea03c4ecd7066ed00 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:46:04 -0800
 Subject: [PATCH 134/139] ARM64: Use dwc_otg driver by default for USB.
@@ -127873,7 +127873,7 @@ index f6def5d7e5d622cf09e8f87332c7374fe28da08b..3e134a1208610b90e2d0fc22f03c6e9f
 -};
 -#endif
 
-From a8b968f7966dfbf0f3133ea5aeaa9050346a8c9c Mon Sep 17 00:00:00 2001
+From 44e6eb62c72adf1f1d0f0c45d3c18e271be0ee14 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 23 Jan 2017 17:36:50 +0000
 Subject: [PATCH 135/139] BCM270X_DT: Add reference to audio_pins to CM dtb
@@ -127904,7 +127904,7 @@ index eb8662f0d222b4c0a9a2bcb8bccb13e86a0006b3..10be69972bd1440f574e35d515f3d6a0
  	hpd-gpios = <&gpio 46 GPIO_ACTIVE_HIGH>;
  };
 
-From 79679ab90389ab1f6a322adea03406ad98593925 Mon Sep 17 00:00:00 2001
+From 5a46acbdf4b4f8eb1125633971ca020200c51567 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 25 Jan 2017 11:30:38 +0000
 Subject: [PATCH 136/139] config: Add additional network scheduling modules
@@ -127959,7 +127959,7 @@ index c4898d63d74718097ec3a1d1fe60b2307a6a3140..b448eaa866c200f48351819072c7fefc
  CONFIG_NET_SCH_PLUG=m
  CONFIG_NET_CLS_BASIC=m
 
-From a0de1f189fb2a259b2c43b312c006284d08f26c6 Mon Sep 17 00:00:00 2001
+From e16464e3b96648063c35ccb1e37d111383682713 Mon Sep 17 00:00:00 2001
 From: chris johnson <plasticchris@gmail.com>
 Date: Sun, 22 Jan 2017 03:27:31 +0000
 Subject: [PATCH 137/139] ASoC: A simple-card overlay for ADAU7002
@@ -128060,7 +128060,7 @@ index 0000000000000000000000000000000000000000..e67e6625d7967abc92cf00cb604d4c12
 +    };
 +};
 
-From 7ff4705c04925daf6bd6069bfb1f6be3a9aeef02 Mon Sep 17 00:00:00 2001
+From fd8f14e2032e539688c50bf42f5ec054a99c9d6f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Jan 2017 21:17:23 +0000
 Subject: [PATCH 138/139] config: Add SND_SOC_ADAU7002 codec module
@@ -128098,7 +128098,7 @@ index b448eaa866c200f48351819072c7fefcd8ad8132..5105a592c9bcfee1cc6a8b50fd1c6c32
  CONFIG_SND_SOC_WM8804_I2C=m
  CONFIG_SND_SIMPLE_CARD=m
 
-From 705dd53e3dcd7630d59774ba7f7a980be45c7e9b Mon Sep 17 00:00:00 2001
+From e98a288171e9302d6e5074ff380f77e93b90cda5 Mon Sep 17 00:00:00 2001
 From: Scott Ellis <scott@jumpnowtek.com>
 Date: Fri, 27 Jan 2017 06:42:42 -0500
 Subject: [PATCH 139/139] Add overlay for mcp3008 adc (#1818)


### PR DESCRIPTION
Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.9.7

Firmware:
```
firmware: Fixup CEC code cleanup 8: fixed hdmi state machine clk
See: #732 (https://github.com/raspberrypi/firmware/issues/732)

firmware: CEC code cleanup 11: cec_release_logical_addr
firmware: CEC code cleanup 12: CEC init @ HPD
```