### PR TITLE
kodi-binary-addons: update to latest versions, bring kodi 18a1 up to date.

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.2048"
-PKG_VERSION="dfc9b44"
+PKG_VERSION="5a215a7"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.4do/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.4do/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.4do"
-PKG_VERSION="eebaa59"
+PKG_VERSION="da1924b"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-bsnes"
-PKG_VERSION="06813d2"
+PKG_VERSION="1309c93"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-gba"
-PKG_VERSION="ce37573"
+PKG_VERSION="cc033fa"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-lynx"
-PKG_VERSION="f2e5c8c"
+PKG_VERSION="3f51d9f"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-ngp"
-PKG_VERSION="8b8f53c"
+PKG_VERSION="9dd7b91"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-pce-fast"
-PKG_VERSION="6c82028"
+PKG_VERSION="a0fce51"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-pcfx"
-PKG_VERSION="98ec2d4"
+PKG_VERSION="0224b9d"
 PKG_REV="100"
 PKG_ARCH="arm x86_64"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-psx"
-PKG_VERSION="230b806"
+PKG_VERSION="939e5c5"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-supergrafx"
-PKG_VERSION="c65a202"
+PKG_VERSION="1f7277a"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-vb"
-PKG_VERSION="2c729d7"
+PKG_VERSION="fc45c48"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-wswan"
-PKG_VERSION="ec5e504"
+PKG_VERSION="adfe9c1"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bluemsx"
-PKG_VERSION="87c86b8"
+PKG_VERSION="96623e2"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bnes"
-PKG_VERSION="3675df1"
+PKG_VERSION="4538b85"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-accuracy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-accuracy/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bsnes-mercury-accuracy"
-PKG_VERSION="2bfb710"
+PKG_VERSION="56abee8"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-balanced/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-balanced/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bsnes-mercury-balanced"
-PKG_VERSION="4aa86c4"
+PKG_VERSION="280ee53"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bsnes-mercury-performance"
-PKG_VERSION="e2cbccc"
+PKG_VERSION="0cf2426"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.cap32"
-PKG_VERSION="5b145f3"
+PKG_VERSION="c5eea43"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.desmume/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.desmume/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.desmume"
-PKG_VERSION="58b4ab1"
+PKG_VERSION="a26693c"
 PKG_REV="100"
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.dinothawr"
-PKG_VERSION="ff4195f"
+PKG_VERSION="cb07699"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.dosbox"
-PKG_VERSION="a6d044f"
+PKG_VERSION="663d9a3"
 PKG_REV="100"
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.fceumm"
-PKG_VERSION="5846c98"
+PKG_VERSION="c2f4e9f"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.fmsx"
-PKG_VERSION="749da98"
+PKG_VERSION="15771e9"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 exit 0
 PKG_NAME="game.libretro.fuse"
-PKG_VERSION="c7b0d5c"
+PKG_VERSION=""
 PKG_REV="3"
 PKG_ARCH="arm x86_64"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.gambatte"
-PKG_VERSION="64f3b8f"
+PKG_VERSION="7c3405c"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.genplus"
-PKG_VERSION="784ff03"
+PKG_VERSION="e0f33e5"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.gw"
-PKG_VERSION="7d6ae5c"
+PKG_VERSION="b210628"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.handy"
-PKG_VERSION="ddccb15"
+PKG_VERSION="8dd3e3f"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.hatari"
-PKG_VERSION="edf2300"
+PKG_VERSION="8ef6ec2"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.meteor/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.meteor/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.meteor"
-PKG_VERSION="92e1530"
+PKG_VERSION="85a6ef0"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.mgba"
-PKG_VERSION="2885f7b"
+PKG_VERSION="7be6f87"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.mupen64plus"
-PKG_VERSION="9e212b3"
+PKG_VERSION="b8cff94"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.nestopia"
-PKG_VERSION="2f7aac6"
+PKG_VERSION="c75c462"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.nx"
-PKG_VERSION="f7e94d4"
+PKG_VERSION="de82a7a"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.o2em"
-PKG_VERSION="32a8983"
+PKG_VERSION="ffea146"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.pcsx-rearmed"
-PKG_VERSION="e892353"
+PKG_VERSION="14d05fa"
 PKG_REV="100"
 PKG_ARCH="any"
 # RPi doesn't support neon

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.picodrive"
-PKG_VERSION="f3c90c4"
+PKG_VERSION="4936b6c"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.prboom"
-PKG_VERSION="ae18d54"
+PKG_VERSION="2811875"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.prosystem"
-PKG_VERSION="7366291"
+PKG_VERSION="6247d9a"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.quicknes"
-PKG_VERSION="255664c"
+PKG_VERSION="3f0c47b"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.reicast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.reicast/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.reicast"
-PKG_VERSION="ce16df3"
+PKG_VERSION="da50bf4"
 PKG_REV="100"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.scummvm"
-PKG_VERSION="c275967"
+PKG_VERSION="6bc6c3c"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.snes9x"
-PKG_VERSION="d18e6bf"
+PKG_VERSION="230865b"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.stella"
-PKG_VERSION="e0ff280"
+PKG_VERSION="bdb7f23"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.tgbdual"
-PKG_VERSION="77e67f7"
+PKG_VERSION="14f7347"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.tyrquake"
-PKG_VERSION="eeb89b8"
+PKG_VERSION="e3128a4"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vba-next/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vba-next/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.vba-next"
-PKG_VERSION="b6d5d5c"
+PKG_VERSION="2d29292"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.vbam"
-PKG_VERSION="31b6d73"
+PKG_VERSION="2441d35"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.vecx"
-PKG_VERSION="206863e"
+PKG_VERSION="0e70b5d"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.virtualjaguar"
-PKG_VERSION="e3255b5"
+PKG_VERSION="6429448"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.yabause"
-PKG_VERSION="a9f5a49"
+PKG_VERSION="ec518c3"
 PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="fc86263"
+PKG_VERSION="a347296"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/liberty-developer/inputstream.adaptive/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="987a818"
+PKG_VERSION="c786dbf"
 PKG_REV="0"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="08929ee"
+PKG_VERSION="5a36c58"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="147fd97"
+PKG_VERSION="8243935"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.dvblink"
-PKG_VERSION="418962c"
+PKG_VERSION="0015079"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.dvbviewer"
-PKG_VERSION="e066293"
+PKG_VERSION="9fb34b3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.filmon"
-PKG_VERSION="d043da6"
+PKG_VERSION="315e503"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.hdhomerun"
-PKG_VERSION="cb3f151"
+PKG_VERSION="98cb8d4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="0a40147"
+PKG_VERSION="b290c8c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="c9365a4"
+PKG_VERSION="53d63cc"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="379658a"
+PKG_VERSION="019c7e9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="41c3201"
+PKG_VERSION="dd9947b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="e7430e9"
+PKG_VERSION="cb1b541"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.njoy"
-PKG_VERSION="57393bd"
+PKG_VERSION="080cd32"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.octonet"
-PKG_VERSION="ff2d4a7"
+PKG_VERSION="8549a31"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.pctv"
-PKG_VERSION="b7b5fe0"
+PKG_VERSION="e67e969"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="c396e47"
+PKG_VERSION="a609149"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.vbox"
-PKG_VERSION="46a612d"
+PKG_VERSION="dea8335"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="0c9552e"
+PKG_VERSION="36023a3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="763a644"
+PKG_VERSION="6ff2eb2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="55218f5"
+PKG_VERSION="5f1db43"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.asteroids"
-PKG_VERSION="0fc066d"
+PKG_VERSION="8c2e182"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.asterwave"
-PKG_VERSION="c39ed33"
+PKG_VERSION="2c82b03"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.biogenesis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.biogenesis/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.biogenesis"
-PKG_VERSION="717fea7"
+PKG_VERSION="51452c2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.cpblobs/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.cpblobs/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.cpblobs"
-PKG_VERSION="04c1938"
+PKG_VERSION="585c25b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.greynetic"
-PKG_VERSION="980e301"
+PKG_VERSION="9c9064f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.matrixtrails"
-PKG_VERSION="8cebb75"
+PKG_VERSION="84ca058"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.pingpong/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.pingpong/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.pingpong"
-PKG_VERSION="f162213"
+PKG_VERSION="96db679"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.pyro"
-PKG_VERSION="4810d75"
+PKG_VERSION="379e102"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensaver.stars"
-PKG_VERSION="55764aa"
+PKG_VERSION="9d8e966"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensavers.rsxs/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensavers.rsxs/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screensavers.rsxs"
-PKG_VERSION="781f76f"
+PKG_VERSION="b68a652"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="visualization.fishbmc"
-PKG_VERSION="93d8845"
+PKG_VERSION="9704420"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="visualization.goom"
-PKG_VERSION="a23f4ad"
+PKG_VERSION="745d8c9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="visualization.projectm"
-PKG_VERSION="c5a86e9"
+PKG_VERSION="8064b36"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="visualization.shadertoy"
-PKG_VERSION="e88fd6e"
+PKG_VERSION="6a9a5ca"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="visualization.waveform"
-PKG_VERSION="a603d10"
+PKG_VERSION="ede2fd6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-platform/package.mk
+++ b/packages/mediacenter/kodi-platform/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="kodi-platform"
-PKG_VERSION="c8188d8"
+PKG_VERSION=""
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="kodi"
-PKG_VERSION="1f12c2f"
+PKG_VERSION="d829753"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"

--- a/packages/mediacenter/p8-platform/package.mk
+++ b/packages/mediacenter/p8-platform/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="p8-platform"
-PKG_VERSION="38343e0"
+PKG_VERSION=""
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"

--- a/projects/RPi/patches/kodi/kodi-001-backport.patch
+++ b/projects/RPi/patches/kodi/kodi-001-backport.patch
@@ -1,21 +1,51 @@
-From 011217b8d0ead7798bb0a7933a2c2994aab577e6 Mon Sep 17 00:00:00 2001
+From 3aab63db40b8d90327f35c4dd001a17add816142 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Mon, 19 Dec 2016 13:28:26 +0000
+Subject: [PATCH 01/61] [cec] Drop CEC_DOUBLE_TAP_TIMEOUT_MS_OLD code
+
+Kodi won't even build with libcec 3, so supporting a libcec 2.2 setting is of no value
+---
+ xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+index 54dc37e751ba4ec50cfa922cfe4c0b1fd354e3cd..73872e3c6126bf4a4e8b998491f87a35dcbdaceb 100644
+--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
++++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+@@ -1391,13 +1391,8 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
+   m_configuration.bPowerOffOnStandby = iStandbyAction == LOCALISED_ID_SUSPEND ? 1 : 0;
+   m_bShutdownOnStandby = iStandbyAction == LOCALISED_ID_POWEROFF;
+ 
+-#if defined(CEC_DOUBLE_TAP_TIMEOUT_MS_OLD)
+-  // double tap prevention timeout in ms. libCEC uses 50ms units for this in 2.2.0, so divide by 50
+-  m_configuration.iDoubleTapTimeout50Ms = GetSettingInt("double_tap_timeout_ms") / 50;
+-#else
+-  // backwards compatibility. will be removed once the next major release of libCEC is out
++  // double tap prevention timeout in ms
+   m_configuration.iDoubleTapTimeoutMs = GetSettingInt("double_tap_timeout_ms");
+-#endif
+ 
+   if (GetSettingBool("pause_playback_on_deactivate"))
+   {
+
+From 17d64855f20bbe87109cc1c92f8780316a20e3b0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 28 Oct 2014 00:19:40 +0000
-Subject: [PATCH 01/62] [cec] Add settings for configuring button repeats
+Subject: [PATCH 02/61] [cec] Add settings for configuring button repeats
 
 ---
  addons/resource.language.en_gb/resources/strings.po | 15 +++++++++++++++
  system/peripherals.xml                              |  4 +++-
- xbmc/peripherals/devices/PeripheralCecAdapter.cpp   | 16 ++++++++++++++++
- 3 files changed, 34 insertions(+), 1 deletion(-)
+ xbmc/peripherals/devices/PeripheralCecAdapter.cpp   | 11 +++++++++++
+ 3 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index abfc92bd5a9f1da9e2eed758a90416ce2d369e3b..15745a792a5a28c79c19effc4d9037e842535da6 100644
+index a3fc777c7d0a5b7549ca94b6721d84309050d4d6..84c2f8a56787242c050be5d6a18cf560c6761b53 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19714,3 +19714,18 @@ msgstr ""
- msgctxt "#39010"
- msgid "Select sort method"
+@@ -20421,3 +20421,18 @@ msgstr ""
+ msgctxt "#39014"
+ msgid "Would you also like to remove all related data (e.g. settings) of this add-on?"
  msgstr ""
 +
 +#: system/peripherals.xml
@@ -48,20 +78,15 @@ index d5704b249c3065b2980dc92c7c81dc7b384187bc..02b1a9ed6fce1986bd864bba09a9df06
  
    <peripheral vendor_product="2548:1001,2548:1002" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">
 diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-index d032ffd707fee5eec035e90bdf618530f7215c37..30367a3fde956090afdca9930fa52e829f35046f 100644
+index 73872e3c6126bf4a4e8b998491f87a35dcbdaceb..92c901e044aeb7b9bece17636ffe89c05648814f 100644
 --- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
 +++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-@@ -1296,6 +1296,20 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
+@@ -1296,6 +1296,15 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
    m_configuration.bActivateSource = config.bActivateSource;
    bChanged |= SetSetting("activate_source", m_configuration.bActivateSource == 1);
  
-+#if defined(CEC_DOUBLE_TAP_TIMEOUT_MS_OLD)
-+  m_configuration.iDoubleTapTimeout50Ms = config.iDoubleTapTimeout50Ms;
-+  bChanged |= SetSetting("double_tap_timeout_ms", (int)m_configuration.iDoubleTapTimeout50Ms * 50);
-+#else
 +  m_configuration.iDoubleTapTimeoutMs = config.iDoubleTapTimeoutMs;
 +  bChanged |= SetSetting("double_tap_timeout_ms", (int)m_configuration.iDoubleTapTimeoutMs);
-+#endif
 +
 +  m_configuration.iButtonRepeatRateMs = config.iButtonRepeatRateMs;
 +  bChanged |= SetSetting("button_repeat_rate_ms", (int)m_configuration.iButtonRepeatRateMs);
@@ -72,20 +97,101 @@ index d032ffd707fee5eec035e90bdf618530f7215c37..30367a3fde956090afdca9930fa52e82
    m_configuration.bPowerOffOnStandby = config.bPowerOffOnStandby;
  
    m_configuration.iFirmwareVersion = config.iFirmwareVersion;
-@@ -1398,6 +1412,8 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
-   // backwards compatibility. will be removed once the next major release of libCEC is out
+@@ -1393,6 +1402,8 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
+ 
+   // double tap prevention timeout in ms
    m_configuration.iDoubleTapTimeoutMs = GetSettingInt("double_tap_timeout_ms");
- #endif
 +  m_configuration.iButtonRepeatRateMs = GetSettingInt("button_repeat_rate_ms");
 +  m_configuration.iButtonReleaseDelayMs = GetSettingInt("button_release_delay_ms");
  
    if (GetSettingBool("pause_playback_on_deactivate"))
    {
 
-From 59f1631775f719f712048fc123bc6c36632a166b Mon Sep 17 00:00:00 2001
+From f2b97946dc5e44ed1099ef5274ce58f5f13ce163 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Mon, 3 Nov 2014 23:17:46 +0000
+Subject: [PATCH 03/61] [cec] Don't discard buttons when repeat mode is enabled
+
+---
+ xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+index 92c901e044aeb7b9bece17636ffe89c05648814f..da99db975e994c0e1d9d9b420f3ad92c6ed91eb6 100644
+--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
++++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+@@ -803,7 +803,10 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+   CLog::Log(LOGDEBUG, "%s - received key %2x duration %d", __FUNCTION__, key.iButton, key.iDuration);
+ 
+   CSingleLock lock(m_critSection);
+-  if (key.iDuration > 0)
++  // avoid the queue getting too long
++  if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
++    return;
++  if (m_configuration.iButtonRepeatRateMs == 0 && key.iDuration > 0)
+   {
+     if (m_currentButton.iButton == key.iButton && m_currentButton.iDuration == 0)
+     {
+
+From dc99fc2cb0b6216574d7f9b28713f26e18559858 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Tue, 4 Nov 2014 18:50:00 +0000
+Subject: [PATCH 04/61] [cec] Temp - more logging
+
+---
+ xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+index da99db975e994c0e1d9d9b420f3ad92c6ed91eb6..9114cec72ccaf16afa1e50d13b238c9ca0dee30d 100644
+--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
++++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+@@ -800,12 +800,15 @@ void CPeripheralCecAdapter::GetNextKey(void)
+ 
+ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+ {
+-  CLog::Log(LOGDEBUG, "%s - received key %2x duration %d", __FUNCTION__, key.iButton, key.iDuration);
++  CLog::Log(LOGDEBUG, "%s - received key %2x duration %d (rep:%d size:%d)", __FUNCTION__, key.iButton, key.iDuration, m_configuration.iButtonRepeatRateMs, m_buttonQueue.size());
+ 
+   CSingleLock lock(m_critSection);
+   // avoid the queue getting too long
+   if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
++  {
++    CLog::Log(LOGDEBUG, "%s - discarded key %2x", __FUNCTION__, key.iButton);
+     return;
++  }
+   if (m_configuration.iButtonRepeatRateMs == 0 && key.iDuration > 0)
+   {
+     if (m_currentButton.iButton == key.iButton && m_currentButton.iDuration == 0)
+@@ -814,6 +817,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+       if (m_bHasButton)
+         m_currentButton.iDuration = key.iDuration;
+       // ignore this one, since it's already been handled by xbmc
++      CLog::Log(LOGDEBUG, "%s - ignored key %2x", __FUNCTION__, key.iButton);
+       return;
+     }
+     // if we received a keypress with a duration set, try to find the same one without a duration set, and replace it
+@@ -824,6 +828,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+         if ((*it).iDuration == 0)
+         {
+           // replace this entry
++          CLog::Log(LOGDEBUG, "%s - replaced key %2x", __FUNCTION__, key.iButton);
+           (*it).iDuration = key.iDuration;
+           return;
+         }
+@@ -833,6 +838,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+     }
+   }
+ 
++  CLog::Log(LOGDEBUG, "%s - added key %2x", __FUNCTION__, key.iButton);
+   m_buttonQueue.push_back(key);
+ }
+ 
+
+From 936021227644bc0cc6dd86127f740237155c1bf3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 26 Apr 2014 17:27:52 +0100
-Subject: [PATCH 02/62] [cec] Don't suspend pi on tv switch off - it can't wake
+Subject: [PATCH 05/61] [cec] Don't suspend pi on tv switch off - it can't wake
  up
 
 ---
@@ -106,136 +212,10 @@ index 02b1a9ed6fce1986bd864bba09a9df0621f9e041..54f9b70cfd5c8c82ceb99932e1b3e325
      <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
      <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />
 
-From ab59b9542257461e117a238bab492e54fff7908c Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Thu, 21 Apr 2016 16:49:02 +0100
-Subject: [PATCH 03/62] Revert "[settings] remove show EXIF picture information
- setting"
-
-This reverts commit e7d90188436b6966eff23fd695e1a9d18f4af1b4.
----
- addons/resource.language.en_gb/resources/strings.po | 10 ++++++++++
- system/settings/settings.xml                        |  5 +++++
- xbmc/pictures/GUIWindowPictures.cpp                 |  2 +-
- xbmc/pictures/PictureInfoLoader.cpp                 |  8 ++++++--
- xbmc/pictures/PictureInfoLoader.h                   |  1 +
- xbmc/settings/Settings.cpp                          |  1 +
- xbmc/settings/Settings.h                            |  1 +
- 7 files changed, 25 insertions(+), 3 deletions(-)
-
-diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index 15745a792a5a28c79c19effc4d9037e842535da6..dbd80f07e305ad99a29d90211a7596b8bb5cedec 100644
---- a/addons/resource.language.en_gb/resources/strings.po
-+++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19729,3 +19729,13 @@ msgstr ""
- msgctxt "#38052"
- msgid "Remote button press release time (ms)"
- msgstr ""
-+
-+#. Description of setting "Pictures -> Show EXIF picture information" with label #38207
-+#: system/settings/settings.xml
-+msgctxt "#38207"
-+msgid "Show EXIF picture information"
-+msgstr ""
-+
-+msgctxt "#38208"
-+msgid "If EXIF information exists (date, time, camera used, etc.), it will be displayed."
-+msgstr ""
-diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index c3804da9625186f5651a8d8be0edcedd8a2b255b..63613fc13acfd66476a880f8ebe9047a53837a33 100644
---- a/system/settings/settings.xml
-+++ b/system/settings/settings.xml
-@@ -1172,6 +1172,11 @@
-     </category>
-     <category id="pictures" label="14217" help="38109">
-       <group id="1" label="744">
-+        <setting id="pictures.usetags" type="boolean" label="38207" help="38208">
-+          <level>0</level>
-+          <default>true</default>
-+          <control type="toggle" />
-+        </setting>
-         <setting id="pictures.generatethumbs" type="boolean" label="13360" help="36307">
-           <level>0</level>
-           <default>true</default>
-diff --git a/xbmc/pictures/GUIWindowPictures.cpp b/xbmc/pictures/GUIWindowPictures.cpp
-index 4b5ec502a49d5116cafd53441a6d823be0da6b54..072639baae58479ec7d746f96634de069ee87e34 100644
---- a/xbmc/pictures/GUIWindowPictures.cpp
-+++ b/xbmc/pictures/GUIWindowPictures.cpp
-@@ -203,7 +203,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
-     if (StringUtils::EqualsNoCase(items[i]->GetLabel(), "folder.jpg"))
-       items.Remove(i);
- 
--  if (items.GetFolderCount() == items.Size())
-+  if (items.GetFolderCount() == items.Size() || !CSettings::GetInstance().GetBool(CSettings::SETTING_PICTURES_USETAGS))
-     return;
- 
-   // Start the music info loader thread
-diff --git a/xbmc/pictures/PictureInfoLoader.cpp b/xbmc/pictures/PictureInfoLoader.cpp
-index dd3347277c75c5e63a4a4db9af9cc46605bb5ea9..05304f9fc44285d5577f2056625cceb15347ae57 100644
---- a/xbmc/pictures/PictureInfoLoader.cpp
-+++ b/xbmc/pictures/PictureInfoLoader.cpp
-@@ -43,6 +43,7 @@ void CPictureInfoLoader::OnLoaderStart()
-   m_mapFileItems->SetFastLookup(true);
- 
-   m_tagReads = 0;
-+  m_loadTags = CSettings::GetInstance().GetBool(CSettings::SETTING_PICTURES_USETAGS);
- 
-   if (m_pProgressCallback)
-     m_pProgressCallback->SetProgressMax(m_pVecItems->GetFileCount());
-@@ -87,8 +88,11 @@ bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
-   if (pItem->HasPictureInfoTag())
-     return false;
- 
--  pItem->GetPictureInfoTag()->Load(pItem->GetPath());
--  m_tagReads++;
-+  if (m_loadTags)
-+  { // Nothing found, load tag from file
-+    pItem->GetPictureInfoTag()->Load(pItem->GetPath());
-+    m_tagReads++;
-+  }
- 
-   return true;
- }
-diff --git a/xbmc/pictures/PictureInfoLoader.h b/xbmc/pictures/PictureInfoLoader.h
-index 000b54fe1bb1dd1963edd5cf208ea318a5a5499d..2a022ff0ff66d237f0ebd12092c7b5ce8244a511 100644
---- a/xbmc/pictures/PictureInfoLoader.h
-+++ b/xbmc/pictures/PictureInfoLoader.h
-@@ -39,5 +39,6 @@ protected:
- 
-   CFileItemList* m_mapFileItems;
-   unsigned int m_tagReads;
-+  bool m_loadTags;
- };
- 
-diff --git a/xbmc/settings/Settings.cpp b/xbmc/settings/Settings.cpp
-index 9940b6aac87971d7024c1c925846b4dac1ca98a0..6e13ba61b99217d95c1ad423131221869be6036b 100644
---- a/xbmc/settings/Settings.cpp
-+++ b/xbmc/settings/Settings.cpp
-@@ -296,6 +296,7 @@ const std::string CSettings::SETTING_AUDIOCDS_SETTINGS = "audiocds.settings";
- const std::string CSettings::SETTING_AUDIOCDS_EJECTONRIP = "audiocds.ejectonrip";
- const std::string CSettings::SETTING_MYMUSIC_SONGTHUMBINVIS = "mymusic.songthumbinvis";
- const std::string CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW = "mymusic.defaultlibview";
-+const std::string CSettings::SETTING_PICTURES_USETAGS = "pictures.usetags";
- const std::string CSettings::SETTING_PICTURES_GENERATETHUMBS = "pictures.generatethumbs";
- const std::string CSettings::SETTING_PICTURES_SHOWVIDEOS = "pictures.showvideos";
- const std::string CSettings::SETTING_PICTURES_DISPLAYRESOLUTION = "pictures.displayresolution";
-diff --git a/xbmc/settings/Settings.h b/xbmc/settings/Settings.h
-index 482f61db8aab70aff4013fee2f1c73a5b5a9b4a9..269a3a741340d60354037166c3b03ddfdd36cf01 100644
---- a/xbmc/settings/Settings.h
-+++ b/xbmc/settings/Settings.h
-@@ -253,6 +253,7 @@ public:
-   static const std::string SETTING_AUDIOCDS_EJECTONRIP;
-   static const std::string SETTING_MYMUSIC_SONGTHUMBINVIS;
-   static const std::string SETTING_MYMUSIC_DEFAULTLIBVIEW;
-+  static const std::string SETTING_PICTURES_USETAGS;
-   static const std::string SETTING_PICTURES_GENERATETHUMBS;
-   static const std::string SETTING_PICTURES_SHOWVIDEOS;
-   static const std::string SETTING_PICTURES_DISPLAYRESOLUTION;
-
-From 2b1ad46b2dbde48ef0c82dbd4cb28af3708dc2d6 Mon Sep 17 00:00:00 2001
+From 8e32b803ba38bf71a865bd7c05af6b41d3e941e4 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 7 Apr 2014 18:19:32 +0100
-Subject: [PATCH 04/62] [rbp/omxplayer] When opening a stream don't try to
+Subject: [PATCH 06/61] [rbp/omxplayer] When opening a stream don't try to
  update gui so often
 
 ---
@@ -259,36 +239,10 @@ index c8fe0706d128b3c67a4000894129ae0fa08bb223..8a5916299575661743131b921a27a76f
          dialog->ProcessRenderLoop(false);
          if (allowCancel && dialog->IsCanceled())
 
-From 5980fa48550e82458fc62fb501a7bc7190569cb4 Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Sat, 8 Mar 2014 15:36:06 +0000
-Subject: [PATCH 05/62] [hifiberry] Hack: force it to be recognised as IEC958
- capable to enable passthrough options
-
----
- xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp | 4 ++++
- 1 file changed, 4 insertions(+)
-
-diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
-index d66993a09583d8f9f54f5f97c18fbba45dddee9b..3c0b691860ace57e0a25f01013df01a5ca4f62f5 100644
---- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
-+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
-@@ -1351,6 +1351,10 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
-     if (snd_card_get_name(cardNr, &cardName) == 0)
-       info.m_displayName = cardName;
- 
-+    // hack: hifiberry digi doesn't correctly report as iec958 device. Needs fixing in kernel driver
-+    if (info.m_displayName == "snd_rpi_hifiberry_digi")
-+      info.m_deviceType = AE_DEVTYPE_IEC958;
-+
-     if (info.m_deviceType == AE_DEVTYPE_HDMI && info.m_displayName.size() > 5 &&
-         info.m_displayName.substr(info.m_displayName.size()-5) == " HDMI")
-     {
-
-From 6387bb9ea57ef7c7e203e0b043139ff26103df22 Mon Sep 17 00:00:00 2001
+From 6c3aae494d21e0232eb7901787c613cf5ad2c4dc Mon Sep 17 00:00:00 2001
 From: Ben Avison <bavison@riscosopen.org>
 Date: Thu, 1 May 2014 16:28:39 +0100
-Subject: [PATCH 06/62] Improved file buffering in CArchive
+Subject: [PATCH 07/61] Improved file buffering in CArchive
 
 Even though memcpy is typically inlined by the compiler into byte/word loads
 and stores (at least for release builds), the frequency with which 1, 2 and 4
@@ -348,10 +302,10 @@ index 23cac2759fb10d532da56fa75c5528c5589e9010..89d31d4db1afa7340ed8cd51a7a9fa7a
      }
  
 
-From ebdbce3d440c74755bf071fc064c96bbab9abc78 Mon Sep 17 00:00:00 2001
+From 860ce7f03c0fd6f1cfb53a979dcabdb124badc83 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 10 Aug 2014 16:45:16 +0100
-Subject: [PATCH 07/62] filesystem: Make support of browsing into archives
+Subject: [PATCH 08/61] filesystem: Make support of browsing into archives
  optional
 
 The ability to browse, scan and play content in archives can cause problems on low powered/low memory devices.
@@ -370,10 +324,10 @@ We'll let people who don't use archives disable it manually
  4 files changed, 26 insertions(+), 2 deletions(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index dbd80f07e305ad99a29d90211a7596b8bb5cedec..ecea05ac43622f75034c60cc3b2bd16859065a80 100644
+index 84c2f8a56787242c050be5d6a18cf560c6761b53..422cfca63529a5bda36ad986bb0d55a6f94cddb3 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19371,6 +19371,15 @@ msgstr ""
+@@ -20042,6 +20042,15 @@ msgstr ""
  #: system/settings/rbp.xml
  msgctxt "#38010"
  msgid "GPU accelerated"
@@ -410,29 +364,29 @@ index 62e9c8ed2199f8c57a640b06b0216ee4c8f0ca1e..e8b0d3d472b02fd161a4b51e957b9129
 +  </section>
  </settings>
 diff --git a/xbmc/Util.cpp b/xbmc/Util.cpp
-index c3567941192c724f2600494a8d7e355584b57b52..da1508dcedbd196789988d895e64548a08439d8f 100644
+index f2d69da28ce36209ace7391ed607bc85983520ac..c3fd0e2b3277a0a29de9b7c6861b796a9f198aee 100644
 --- a/xbmc/Util.cpp
 +++ b/xbmc/Util.cpp
-@@ -1899,7 +1899,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
+@@ -1900,7 +1900,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
      URIUtils::RemoveExtension(strCandidate);
      if (StringUtils::StartsWithNoCase(strCandidate, videoName))
      {
 -      if (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath()))
-+      if (CSettings::GetInstance().GetBool("filelists.browsearchives") && (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())))
++      if (CServiceBroker::GetSettings().GetBool("filelists.browsearchives") && (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())))
          CUtil::ScanArchiveForAssociatedItems(pItem->GetPath(), "", item_exts, associatedFiles);
        else
        {
-@@ -1909,7 +1909,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
+@@ -1910,7 +1910,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
      }
      else
      {
 -      if (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath()))
-+      if (CSettings::GetInstance().GetBool("filelists.browsearchives") && (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())))
++      if (CServiceBroker::GetSettings().GetBool("filelists.browsearchives") && (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())))
          CUtil::ScanArchiveForAssociatedItems(pItem->GetPath(), videoName, item_exts, associatedFiles);
      }
    }
 diff --git a/xbmc/filesystem/FileDirectoryFactory.cpp b/xbmc/filesystem/FileDirectoryFactory.cpp
-index a0fd0a9011e71f4af1535110c696b6ea5c4b37db..688b71a297c7c617c6764bfe6be157d727eb49d3 100644
+index 36fd7bb6358497abf80494620341def8ff991996..9c1b6bf975afee8b6a3d8784ed19af0367455f46 100644
 --- a/xbmc/filesystem/FileDirectoryFactory.cpp
 +++ b/xbmc/filesystem/FileDirectoryFactory.cpp
 @@ -40,6 +40,7 @@
@@ -443,16 +397,16 @@ index a0fd0a9011e71f4af1535110c696b6ea5c4b37db..688b71a297c7c617c6764bfe6be157d7
  #include "FileItem.h"
  #include "utils/StringUtils.h"
  #include "URL.h"
-@@ -116,6 +117,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
+@@ -148,6 +149,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
      return NULL;
    }
  #endif
-+  if (CSettings::GetInstance().GetBool("filelists.browsearchives"))
++  if (CServiceBroker::GetSettings().GetBool("filelists.browsearchives"))
 +  {
    if (url.IsFileType("zip"))
    {
      CURL zipURL = URIUtils::CreateArchivePath("zip", url);
-@@ -189,6 +192,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
+@@ -221,6 +224,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
      }
      return NULL;
    }
@@ -461,10 +415,10 @@ index a0fd0a9011e71f4af1535110c696b6ea5c4b37db..688b71a297c7c617c6764bfe6be157d7
    {
      CURL xbtUrl = URIUtils::CreateArchivePath("xbt", url);
 
-From 2f0e7984f47266b6b5fd6a4e14ee8f2a8e9f011c Mon Sep 17 00:00:00 2001
+From 6684363aca4c0f6374230a726dbb9c6fd8afb0a3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 27 Oct 2014 13:06:57 +0000
-Subject: [PATCH 08/62] [rbp] Make cachemembuffersize default depend on memory
+Subject: [PATCH 09/61] [rbp] Make cachemembuffersize default depend on memory
  size
 
 ---
@@ -474,18 +428,18 @@ Subject: [PATCH 08/62] [rbp] Make cachemembuffersize default depend on memory
  3 files changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/xbmc/linux/RBP.cpp b/xbmc/linux/RBP.cpp
-index 571bf9f1ae64ae6d2d80a4aaca1a164f5178bf98..5a6f780517cff0c31f1c40e5e95445d448eb2297 100644
+index 356d64b0b16e4b543abbdbb11f4beacd0b715334..c073dc28db9abc24025909e2d91b7ce49201f4ea 100644
 --- a/xbmc/linux/RBP.cpp
 +++ b/xbmc/linux/RBP.cpp
-@@ -23,6 +23,7 @@
- 
+@@ -24,6 +24,7 @@
  #include <assert.h>
+ #include "ServiceBroker.h"
  #include "settings/Settings.h"
 +#include "settings/AdvancedSettings.h"
  #include "utils/log.h"
  
  #include "cores/omxplayer/OMXImage.h"
-@@ -58,6 +59,12 @@ CRBP::~CRBP()
+@@ -59,6 +60,12 @@ CRBP::~CRBP()
    delete m_DllBcmHost;
  }
  
@@ -498,7 +452,7 @@ index 571bf9f1ae64ae6d2d80a4aaca1a164f5178bf98..5a6f780517cff0c31f1c40e5e95445d4
  bool CRBP::Initialize()
  {
    CSingleLock lock(m_critSection);
-@@ -97,6 +104,8 @@ bool CRBP::Initialize()
+@@ -98,6 +105,8 @@ bool CRBP::Initialize()
    if (!m_gui_resolution_limit)
      m_gui_resolution_limit = m_gpu_mem < 128 ? 720:1080;
  
@@ -507,7 +461,7 @@ index 571bf9f1ae64ae6d2d80a4aaca1a164f5178bf98..5a6f780517cff0c31f1c40e5e95445d4
    g_OMXImage.Initialize();
    m_omx_image_init = true;
    return true;
-@@ -109,6 +118,7 @@ void CRBP::LogFirmwareVerison()
+@@ -110,6 +119,7 @@ void CRBP::LogFirmwareVerison()
    response[sizeof(response) - 1] = '\0';
    CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s", response);
    CLog::Log(LOGNOTICE, "ARM mem: %dMB GPU mem: %dMB MPG2:%d WVC1:%d", m_arm_mem, m_gpu_mem, m_codec_mpg2_enabled, m_codec_wvc1_enabled);
@@ -516,10 +470,10 @@ index 571bf9f1ae64ae6d2d80a4aaca1a164f5178bf98..5a6f780517cff0c31f1c40e5e95445d4
    response[sizeof(response) - 1] = '\0';
    CLog::Log(LOGNOTICE, "Config:\n%s", response);
 diff --git a/xbmc/linux/RBP.h b/xbmc/linux/RBP.h
-index a35a509a91483f13e2cf0e688fc7e9528f254290..fffa5182126159f6dfcf750b21fa0464e229e545 100644
+index eff631d24cd7b072fd601f8f6a35ff0ae67bad4c..26a2a4bd74b54288282b534c5de7d59d6ccec7f5 100644
 --- a/xbmc/linux/RBP.h
 +++ b/xbmc/linux/RBP.h
-@@ -62,6 +62,7 @@ public:
+@@ -61,6 +61,7 @@ public:
    ~CRBP();
  
    bool Initialize();
@@ -528,7 +482,7 @@ index a35a509a91483f13e2cf0e688fc7e9528f254290..fffa5182126159f6dfcf750b21fa0464
    void Deinitialize();
    int GetArmMem() { return m_arm_mem; }
 diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index cc37998f0c9edfb38cf609666374cfa96530bf8f..3891a7ed34acb3489a860678d56a8ec049890f6e 100644
+index 5634ed111a6b7b19fb81acb9a81b58109ef40395..4ebc890a52995ca761effad6c30d41cb25b5bdb8 100644
 --- a/xbmc/settings/AdvancedSettings.cpp
 +++ b/xbmc/settings/AdvancedSettings.cpp
 @@ -50,6 +50,9 @@
@@ -543,7 +497,7 @@ index cc37998f0c9edfb38cf609666374cfa96530bf8f..3891a7ed34acb3489a860678d56a8ec0
  using namespace XFILE;
 @@ -355,7 +358,12 @@ void CAdvancedSettings::Initialize()
    m_bPVRAutoScanIconsUserSet       = false;
-   m_iPVRNumericChannelSwitchTimeout = 1000;
+   m_iPVRNumericChannelSwitchTimeout = 2000;
  
 +#ifdef TARGET_RASPBERRY_PI
 +  // want default to be memory dependent, but interface to gpu not available yet, so set in RBP.cpp
@@ -566,10 +520,10 @@ index cc37998f0c9edfb38cf609666374cfa96530bf8f..3891a7ed34acb3489a860678d56a8ec0
  }
  
 
-From c84536e65bc489172be3a852a9db7496615e7ec2 Mon Sep 17 00:00:00 2001
+From 6a176a9762cd72d283741df798325e7784965a07 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 30 May 2014 14:58:43 +0100
-Subject: [PATCH 09/62] [settings] Experiment: Report DESKTOP resolution in
+Subject: [PATCH 10/61] [settings] Experiment: Report DESKTOP resolution in
  video settings
 
 ---
@@ -577,10 +531,10 @@ Subject: [PATCH 09/62] [settings] Experiment: Report DESKTOP resolution in
  1 file changed, 3 insertions(+)
 
 diff --git a/xbmc/settings/DisplaySettings.cpp b/xbmc/settings/DisplaySettings.cpp
-index ef95bc286fa982790248bad26da3c3e00c1da002..da69c6960867621d4ebe9267929664d973d00beb 100644
+index 0f0f3549bb4e68fcbdf73976c43e300791fabc6b..b6a9adacc7872487b25331dff16cc5a302cb3e15 100644
 --- a/xbmc/settings/DisplaySettings.cpp
 +++ b/xbmc/settings/DisplaySettings.cpp
-@@ -704,6 +704,9 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const CSetting *setting,
+@@ -705,6 +705,9 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const CSetting *setting,
      std::vector<RESOLUTION_WHR> resolutions = g_Windowing.ScreenResolutions(info.iScreen, info.fRefreshRate);
      for (std::vector<RESOLUTION_WHR>::const_iterator resolution = resolutions.begin(); resolution != resolutions.end(); ++resolution)
      {
@@ -591,10 +545,10 @@ index ef95bc286fa982790248bad26da3c3e00c1da002..da69c6960867621d4ebe9267929664d9
          StringUtils::Format("%dx%d%s", resolution->width, resolution->height,
                              ModeFlagsToString(resolution->flags, false).c_str()),
 
-From 7f0028ec330b751c0c006ab2b496c5aeb6f67ac3 Mon Sep 17 00:00:00 2001
+From a5364b603a71e2bf7fbed939a9431cde214a3fa9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 24 Sep 2014 23:13:52 +0100
-Subject: [PATCH 10/62] [audio] Add settings option to boost centre channel
+Subject: [PATCH 11/61] [audio] Add settings option to boost centre channel
  when downmixing
 
 This allows a dB volume increase to be added to centre channel.
@@ -606,16 +560,16 @@ Should work with Pi Sink (dvdplayer/paplayer) and omxplayer
 ---
  addons/resource.language.en_gb/resources/strings.po       | 15 +++++++++++++++
  system/settings/settings.xml                              | 12 ++++++++++++
- .../Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp           |  7 +++++++
- .../AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp   |  6 ++++++
+ .../Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp           |  8 ++++++++
+ .../AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp   |  7 +++++++
  xbmc/cores/omxplayer/OMXAudio.cpp                         |  6 ++++++
- 5 files changed, 46 insertions(+)
+ 5 files changed, 48 insertions(+)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index ecea05ac43622f75034c60cc3b2bd16859065a80..de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb 100644
+index 422cfca63529a5bda36ad986bb0d55a6f94cddb3..08ed7022ad0c07ca71abe1e6d018e9b1b48a29c6 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19591,6 +19591,21 @@ msgstr ""
+@@ -20262,6 +20262,21 @@ msgstr ""
  
  #empty strings from id 38062 to 38099
  
@@ -638,10 +592,10 @@ index ecea05ac43622f75034c60cc3b2bd16859065a80..de5eb0dd99700c0bdc7c3409c1b63f1c
  #: system/settings/settings.xml
  msgctxt "#38100"
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 63613fc13acfd66476a880f8ebe9047a53837a33..9ce9e725aec4d8ed000200342a2a99f3bc34a749 100644
+index 9060fbc5eafe3726ab33649273aad9e05980f64a..b0d103cba5bcdd1d7bece68bc983ab37b0133dbb 100644
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
-@@ -2358,6 +2358,18 @@
+@@ -2491,6 +2491,18 @@
            </dependencies>
            <control type="toggle" />
          </setting>
@@ -661,22 +615,23 @@ index 63613fc13acfd66476a880f8ebe9047a53837a33..9ce9e725aec4d8ed000200342a2a99f3
            <requirement>HAS_AE_QUALITY_LEVELS</requirement>
            <level>2</level>
 diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
-index af5bf93116543bd282953b01d0c5bcef93bb3a84..d7165dedd242abdfa7c0607eee332451c3187298 100644
+index af5bf93116543bd282953b01d0c5bcef93bb3a84..80aecbd496ac021b1a02c10ef9432a4c22e54bfa 100644
 --- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
 +++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
-@@ -20,6 +20,7 @@
+@@ -20,6 +20,8 @@
  
  #include "cores/AudioEngine/Utils/AEUtil.h"
  #include "ActiveAEResampleFFMPEG.h"
++#include "ServiceBroker.h"
 +#include "settings/Settings.h"
  #include "utils/log.h"
  
  extern "C" {
-@@ -104,6 +105,12 @@ bool CActiveAEResampleFFMPEG::Init(uint64_t dst_chan_layout, int dst_channels, i
+@@ -104,6 +106,12 @@ bool CActiveAEResampleFFMPEG::Init(uint64_t dst_chan_layout, int dst_channels, i
    {
       av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
    }
-+  int boost_center = CSettings::GetInstance().GetInt("audiooutput.boostcenter");
++  int boost_center = CServiceBroker::GetSettings().GetInt("audiooutput.boostcenter");
 +  if (boost_center)
 +  {
 +    float gain = pow(10.0f, ((float)(-3 + boost_center))/20.0f);
@@ -686,14 +641,22 @@ index af5bf93116543bd282953b01d0c5bcef93bb3a84..d7165dedd242abdfa7c0607eee332451
    if (remapLayout)
    {
 diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
-index 78071493fca4756c6741d7085e35cbe2f27038e6..698a6ae1e2bc0cc9256caec42c0dcfb0893301b5 100644
+index 78071493fca4756c6741d7085e35cbe2f27038e6..9b9d1a736c974eab37bdd85e6553dfe69b438847 100644
 --- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
 +++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
-@@ -164,6 +164,12 @@ bool CActiveAEResamplePi::Init(uint64_t dst_chan_layout, int dst_channels, int d
+@@ -25,6 +25,7 @@
+ 
+ #include "cores/AudioEngine/Utils/AEUtil.h"
+ #include "ActiveAEResamplePi.h"
++#include "ServiceBroker.h"
+ #include "settings/Settings.h"
+ #include "utils/log.h"
+ #include "linux/RBP.h"
+@@ -164,6 +165,12 @@ bool CActiveAEResamplePi::Init(uint64_t dst_chan_layout, int dst_channels, int d
    {
      av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
    }
-+  int boost_center = CSettings::GetInstance().GetInt("audiooutput.boostcenter");
++  int boost_center = CServiceBroker::GetSettings().GetInt("audiooutput.boostcenter");
 +  if (boost_center)
 +  {
 +    float gain = pow(10.0f, ((float)(-3 + boost_center))/20.0f);
@@ -703,14 +666,14 @@ index 78071493fca4756c6741d7085e35cbe2f27038e6..698a6ae1e2bc0cc9256caec42c0dcfb0
    if (remapLayout)
    {
 diff --git a/xbmc/cores/omxplayer/OMXAudio.cpp b/xbmc/cores/omxplayer/OMXAudio.cpp
-index f16b822ed7b4aebe18b5d339b3f71ee66e97c23f..993d4b33a294e88c2c004b7943895ba55558c2d0 100644
+index fcec25db0c48b4d4ec7b329b19538a73d0b53efd..ae048e0d144e174020a6f567112f9829e3ac0c8b 100644
 --- a/xbmc/cores/omxplayer/OMXAudio.cpp
 +++ b/xbmc/cores/omxplayer/OMXAudio.cpp
-@@ -633,6 +633,12 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
+@@ -632,6 +632,12 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
      {
         av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
      }
-+    int boost_center = CSettings::GetInstance().GetInt("audiooutput.boostcenter");
++    int boost_center = CServiceBroker::GetSettings().GetInt("audiooutput.boostcenter");
 +    if (boost_center)
 +    {
 +      float gain = pow(10.0f, ((float)(-3 + boost_center))/20.0f);
@@ -720,10 +683,10 @@ index f16b822ed7b4aebe18b5d339b3f71ee66e97c23f..993d4b33a294e88c2c004b7943895ba5
      // stereo upmix
      if (upmix && m_src_channels == 2 && m_dst_channels > 2)
 
-From 970ba6a8671460e469240cf5113d574ea44905cc Mon Sep 17 00:00:00 2001
+From 9452a5e86e3e3eb493d148a08b74d5c6cbe0b1ed Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 27 Oct 2014 15:23:51 +0000
-Subject: [PATCH 11/62] [rbp] Default extract thumbnails to false
+Subject: [PATCH 12/61] [rbp] Default extract thumbnails to false
 
 It can take 80 seconds for a single file on a Pi. It can cause crashes with out-of-memory errors.
 It genereates a lot of support issues. Best to default to disabled and let users enable it if they must
@@ -749,10 +712,10 @@ index e8b0d3d472b02fd161a4b51e957b9129e3cb9792..289dc55ec41aa44848519a05f8ee1ccc
      </category>
    </section>
 
-From 9fecb172939f96a23cacafe2e40cbd462cfa9da3 Mon Sep 17 00:00:00 2001
+From 622ddbce6c89ad6dbdc98bfd7920339c1d63aaec Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 27 Nov 2014 16:31:56 +0000
-Subject: [PATCH 12/62] [languageinvoker] Reduce priority of python threads
+Subject: [PATCH 13/61] [languageinvoker] Reduce priority of python threads
 
 ---
  xbmc/interfaces/generic/LanguageInvokerThread.cpp | 5 +++++
@@ -775,10 +738,10 @@ index fcdd0633f30cd9595ae6cc4ed293677cdcb1f422..16f0c8916b5e0a9e90973d194cf2ebd1
  }
  
 
-From d9dc2c7f2616bc989bd550ee5a7ac7a47b5d43ae Mon Sep 17 00:00:00 2001
+From 6879b004e34fa05c4eeb9a46f97f2814299afcb1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 29 Nov 2014 15:25:16 +0000
-Subject: [PATCH 13/62] [rbp] hack: wait for splash to complete before changing
+Subject: [PATCH 14/61] [rbp] hack: wait for splash to complete before changing
  hdmi mode
 
 ---
@@ -786,10 +749,10 @@ Subject: [PATCH 13/62] [rbp] hack: wait for splash to complete before changing
  1 file changed, 52 insertions(+)
 
 diff --git a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
-index ee297700f8583dbb15cbe53baf8c887b36bd2ea0..bbe501d40c5e101f1d0d64b8b59b1928ae12d52f 100644
+index 6ec0f110ca748c1ca305b255e2f1a0413b40c1ad..d1a7de58dea31dba3864828bd268292d53945b3d 100644
 --- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
 +++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
-@@ -32,6 +32,9 @@
+@@ -33,6 +33,9 @@
  #include "guilib/StereoscopicsManager.h"
  #include "rendering/RenderSystem.h"
  #include <cassert>
@@ -799,7 +762,7 @@ index ee297700f8583dbb15cbe53baf8c887b36bd2ea0..bbe501d40c5e101f1d0d64b8b59b1928
  
  #ifndef __VIDEOCORE4__
  #define __VIDEOCORE4__
-@@ -221,12 +224,61 @@ int CEGLNativeTypeRaspberryPI::AddUniqueResolution(RESOLUTION_INFO &res, std::ve
+@@ -222,12 +225,61 @@ int CEGLNativeTypeRaspberryPI::AddUniqueResolution(RESOLUTION_INFO &res, std::ve
  }
  #endif
  
@@ -858,14 +821,14 @@ index ee297700f8583dbb15cbe53baf8c887b36bd2ea0..bbe501d40c5e101f1d0d64b8b59b1928
 +  while (proc_find("hello_video.bin") >= 0)
 +    Sleep(100);
 +
-   DestroyDispmaxWindow();
+   DestroyDispmanxWindow();
  
    RENDER_STEREO_MODE stereo_mode = g_graphicsContext.GetStereoMode();
 
-From 8f2d2d8618a4051fdeedfc528a21fc0657614d9e Mon Sep 17 00:00:00 2001
+From 0c32e3aab26ebcd6cf5cc116f195df3d372a2d1e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 11 Dec 2014 17:00:57 +0000
-Subject: [PATCH 14/62] Fix for UI not showing both extractflags and
+Subject: [PATCH 15/61] Fix for UI not showing both extractflags and
  extractthumb
 
 ---
@@ -874,10 +837,10 @@ Subject: [PATCH 14/62] Fix for UI not showing both extractflags and
  2 files changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb..ae3aa10aa65beac6689f129d60056cadf8a5b5c1 100644
+index 08ed7022ad0c07ca71abe1e6d018e9b1b48a29c6..b52e18a39cc14e0712b44baa8a2e0068e5292d8c 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -12451,7 +12451,7 @@ msgstr ""
+@@ -12880,7 +12880,7 @@ msgstr ""
  
  #: system/settings/settings.xml
  msgctxt "#20433"
@@ -886,7 +849,7 @@ index de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb..ae3aa10aa65beac6689f129d60056cad
  msgstr ""
  
  #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
-@@ -17011,7 +17011,7 @@ msgstr ""
+@@ -17685,7 +17685,7 @@ msgstr ""
  #. Description of setting with label #20433 "Extract thumbnails and video information"
  #: system/settings/settings.xml
  msgctxt "#36178"
@@ -895,7 +858,7 @@ index de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb..ae3aa10aa65beac6689f129d60056cad
  msgstr ""
  
  #. Description of setting with label #20419 "Replace file names with library titles"
-@@ -17023,7 +17023,7 @@ msgstr ""
+@@ -17697,7 +17697,7 @@ msgstr ""
  #. Description of setting with label #20433 "Extract thumbnails and video information"
  #: system/settings/settings.xml
  msgctxt "#36180"
@@ -904,16 +867,16 @@ index de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb..ae3aa10aa65beac6689f129d60056cad
  msgstr ""
  
  #: system/settings/settings.xml
-@@ -19763,3 +19763,7 @@ msgstr ""
- msgctxt "#38208"
- msgid "If EXIF information exists (date, time, camera used, etc.), it will be displayed."
+@@ -20460,3 +20460,7 @@ msgstr ""
+ msgctxt "#38052"
+ msgid "Remote button press release time (ms)"
  msgstr ""
 +
 +msgctxt "#38190"
 +msgid "Extract thumbnails from video files"
 +msgstr ""
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 9ce9e725aec4d8ed000200342a2a99f3bc34a749..326ffbd0f08428c3b4a95208134253feeabf1b1f 100644
+index b0d103cba5bcdd1d7bece68bc983ab37b0133dbb..38a772b4e5f59cdd30293850752a761dbe532177 100644
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
 @@ -969,8 +969,8 @@
@@ -928,10 +891,10 @@ index 9ce9e725aec4d8ed000200342a2a99f3bc34a749..326ffbd0f08428c3b4a95208134253fe
            <control type="toggle" />
          </setting>
 
-From 2d8206baa4bb9229a75e71a3de87628d60e006e5 Mon Sep 17 00:00:00 2001
+From 945f62a3d2e45b1af550fa67a136eb042b0c0db3 Mon Sep 17 00:00:00 2001
 From: anaconda <anaconda@menakite.eu>
 Date: Thu, 11 Sep 2014 21:30:43 +0200
-Subject: [PATCH 15/62] Disable autoscrolling while on screensaver and while
+Subject: [PATCH 16/61] Disable autoscrolling while on screensaver and while
  opening streams.
 
 ---
@@ -944,10 +907,10 @@ Subject: [PATCH 15/62] Disable autoscrolling while on screensaver and while
  6 files changed, 24 insertions(+), 3 deletions(-)
 
 diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
-index 620366e4bcb8593484bc205af4c33fc13dab924a..cf77c3dbb84b86c755ee792294760c5c4c38742d 100644
+index 8b812302f7cd460ca709e551d10be212dfaa2561..b441de35eca9c988eb10f83c3aaf12f618b0c743 100644
 --- a/xbmc/Application.cpp
 +++ b/xbmc/Application.cpp
-@@ -5215,3 +5215,13 @@ bool CApplication::NotifyActionListeners(const CAction &action) const
+@@ -5260,3 +5260,13 @@ bool CApplication::NotifyActionListeners(const CAction &action) const
    
    return false;
  }
@@ -962,10 +925,10 @@ index 620366e4bcb8593484bc205af4c33fc13dab924a..cf77c3dbb84b86c755ee792294760c5c
 +  return onBlackDimScreenSaver || openingStreams;
 +}
 diff --git a/xbmc/Application.h b/xbmc/Application.h
-index 580fdce5476312c83c82bec07f48b3eaf8fe9797..e04788e1e3574aa5ecf9b14490fe1fd967ce8ec9 100644
+index 59a1ec96b24014b4bc3cc6a7e0d4aa345958eaf8..c50a56f4254c88a9f69a156aec2967bdc6315330 100644
 --- a/xbmc/Application.h
 +++ b/xbmc/Application.h
-@@ -392,6 +392,8 @@ public:
+@@ -382,6 +382,8 @@ public:
     */
    void UnregisterActionListener(IActionListener *listener);
  
@@ -1062,10 +1025,10 @@ index d7bc1c5ba6067af9a460589920367288c640a915..ac766293f1c47c7f145cb46f6b152144
        if (m_lastRenderTime)
          m_autoScrollDelayTime += currentTime - m_lastRenderTime;
 
-From 8a1f8bb315f494840e8b5807f257463c57532fd6 Mon Sep 17 00:00:00 2001
+From b3ce0b2a61e0093047dd19d9608d365adc851dc5 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 13 Dec 2014 18:35:20 +0000
-Subject: [PATCH 16/62] [demuxer] Avoid memcpy on every demuxer packet
+Subject: [PATCH 17/61] [demuxer] Avoid memcpy on every demuxer packet
 
 Avoids an unnecessary memcpy on every demuxer packet which for
 high bitrate videos can be significant.
@@ -1076,10 +1039,10 @@ high bitrate videos can be significant.
  3 files changed, 21 insertions(+), 6 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 33d1e5ab627d8099018190699f3b532c2b1f3b08..e015e65dea43e7b682b704edb7f468b63b8c2ac5 100644
+index a00a362239df1f7d99e3bf13a41a58e5d0567e02..e9a1645acbdb2dd2fbf3c1eaee9ef1401fe9bfd7 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -921,7 +921,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -922,7 +922,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
            {
              if(m_pkt.pkt.stream_index == (int)m_pFormatContext->programs[m_program]->stream_index[i])
              {
@@ -1088,7 +1051,7 @@ index 33d1e5ab627d8099018190699f3b532c2b1f3b08..e015e65dea43e7b682b704edb7f468b6
                break;
              }
            }
-@@ -930,7 +930,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -931,7 +931,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
              bReturnEmpty = true;
          }
          else
@@ -1097,7 +1060,7 @@ index 33d1e5ab627d8099018190699f3b532c2b1f3b08..e015e65dea43e7b682b704edb7f468b6
        }
        else
          bReturnEmpty = true;
-@@ -960,9 +960,13 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -961,9 +961,13 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
          // copy contents into our own packet
          pPacket->iSize = m_pkt.pkt.size;
  
@@ -1113,7 +1076,7 @@ index 33d1e5ab627d8099018190699f3b532c2b1f3b08..e015e65dea43e7b682b704edb7f468b6
  
          pPacket->pts = ConvertTimestamp(m_pkt.pkt.pts, stream->time_base.den, stream->time_base.num);
          pPacket->dts = ConvertTimestamp(m_pkt.pkt.dts, stream->time_base.den, stream->time_base.num);
-@@ -1016,7 +1020,10 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -1017,7 +1021,10 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
          pPacket->iStreamId = m_pkt.pkt.stream_index;
        }
        m_pkt.result = -1;
@@ -1147,10 +1110,10 @@ index 4f471188c133deb91516311f0082e8741d9dee79..22805781c4d5a957d10fdf74ffa34387
    int dispTime;
  } DemuxPacket;
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
-index df0f35bd49c65b302de4ccd110d859e8b881ea5f..b4b591ae4c4dd4fb0b36d4d00fedca966f86000f 100644
+index 403d75fe905f02dcc46a9bd1798ca6c8fc0ccc4e..66774e4d299790059db8ed99fb060e2b3e91cef4 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
-@@ -39,7 +39,12 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
+@@ -36,7 +36,12 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
    if (pPacket)
    {
      try {
@@ -1165,10 +1128,10 @@ index df0f35bd49c65b302de4ccd110d859e8b881ea5f..b4b591ae4c4dd4fb0b36d4d00fedca96
      }
      catch(...) {
 
-From 83250abe1869bc07d70466de8bb6f9d6342aec7c Mon Sep 17 00:00:00 2001
+From 2f124999ab254f276d6f53874c819e3e2e0eb351 Mon Sep 17 00:00:00 2001
 From: anaconda <anaconda@menakite.eu>
 Date: Wed, 25 Feb 2015 18:22:21 +0100
-Subject: [PATCH 17/62] Load OSD dialogs on startup.
+Subject: [PATCH 18/61] Load OSD dialogs on startup.
 
 Fixes skipped frames the first time they're loaded in memory on less powered
 devices, like a Raspberry Pi, when using DVDPlayer.
@@ -1183,19 +1146,19 @@ See http://forum.kodi.tv/showthread.php?tid=211501&pid=1938811#pid1938811
  6 files changed, 10 insertions(+), 4 deletions(-)
 
 diff --git a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
-index 1beb8560a1030f6198b22f5d9c082a27dd85d8a8..ca7c90b0c4a7fc34a31fe6dcf787b8980d28df71 100644
+index 4450583494e483afdeec610b489a9fe75944e054..28ed83f59ba1db07fc64d3c1fbcdc2acc7c1ad82 100644
 --- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
 +++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
-@@ -49,6 +49,7 @@ using namespace KODI::MESSAGING;
- CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD() :
-     CGUIDialog(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml")
+@@ -45,6 +45,7 @@ CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD() :
+     CGUIDialog(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml"),
+     CPVRChannelNumberInputHandler(1000)
  {
 +  m_loadType = LOAD_ON_GUI_INIT;
    m_vecItems = new CFileItemList;
  }
  
 diff --git a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
-index 8b472435e26e455249637faf5120055b415fc49e..be1f64d552161f8a86a5c5d89c1bc23328574fb6 100644
+index 99a75175638c66968b7fe61a9dc973de64edd9fe..81355ff55f92f47378a986ac7ff2c0cd52296f9e 100644
 --- a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
 +++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
 @@ -36,6 +36,7 @@ using namespace PVR;
@@ -1207,10 +1170,10 @@ index 8b472435e26e455249637faf5120055b415fc49e..be1f64d552161f8a86a5c5d89c1bc233
  }
  
 diff --git a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
-index eb67552344f59b8857b16c882c29e3fa62bed75c..f31572b34d376e70a35003a8c2e175b45daf8070 100644
+index ac501f769d648b669c4363a824fa4a751744555f..0a0cf76f254b85212bd5777b26e8872651bffece 100644
 --- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
 +++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
-@@ -68,7 +68,9 @@ CGUIDialogAudioSubtitleSettings::CGUIDialogAudioSubtitleSettings()
+@@ -69,7 +69,9 @@ CGUIDialogAudioSubtitleSettings::CGUIDialogAudioSubtitleSettings()
    : CGUIDialogSettingsManualBase(WINDOW_DIALOG_AUDIO_OSD_SETTINGS, "DialogSettings.xml"),
      m_passthrough(false),
      m_dspEnabled(false)
@@ -1222,10 +1185,10 @@ index eb67552344f59b8857b16c882c29e3fa62bed75c..f31572b34d376e70a35003a8c2e175b4
  CGUIDialogAudioSubtitleSettings::~CGUIDialogAudioSubtitleSettings()
  { }
 diff --git a/xbmc/video/dialogs/GUIDialogSubtitles.cpp b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
-index 398558e4d5d0cae30ee1c73e2b70e3b2f787e8fc..4e8a9b1e307a89d3a7b68402e2ff11b57e7dccd4 100644
+index 09ac499df555ea9231d6d486df11eb3a6a5265af..72da62e76337663f44ef8d5fc5c890bea1213ab3 100644
 --- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
 +++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
-@@ -103,7 +103,7 @@ CGUIDialogSubtitles::CGUIDialogSubtitles(void)
+@@ -104,7 +104,7 @@ CGUIDialogSubtitles::CGUIDialogSubtitles(void)
      , m_pausedOnRun(false)
      , m_updateSubsList(false)
  {
@@ -1248,10 +1211,10 @@ index e498e1fd476d9ab5300bb00bc39946a22cfd93cb..a6648d016b07e2eb3e52f8d927697cc5
  
  CGUIDialogVideoOSD::~CGUIDialogVideoOSD(void)
 diff --git a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
-index 0534828dd85520134f7a6890e43a873e223062c1..5a86dfc1e2a54c8fe8d82cb75b612d8e1a0fd2a7 100644
+index 7f10c52223c7a02471dcd3bc6d13da59b076a198..072c7be73f352ad00219594bb5ce0c3939f9c540 100644
 --- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 +++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
-@@ -66,7 +66,9 @@
+@@ -67,7 +67,9 @@
  CGUIDialogVideoSettings::CGUIDialogVideoSettings()
      : CGUIDialogSettingsManualBase(WINDOW_DIALOG_VIDEO_OSD_SETTINGS, "DialogSettings.xml"),
        m_viewModeChanged(false)
@@ -1263,10 +1226,10 @@ index 0534828dd85520134f7a6890e43a873e223062c1..5a86dfc1e2a54c8fe8d82cb75b612d8e
  CGUIDialogVideoSettings::~CGUIDialogVideoSettings()
  { }
 
-From c75aecfa32c369f2728247347c4edd34c3cd5e6a Mon Sep 17 00:00:00 2001
+From 3ba695ea73dcc0850680542d6f22e8135315ea67 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 14 Apr 2015 20:51:14 +0100
-Subject: [PATCH 18/62] [gui] Also limit GUI updates when in non full-screen
+Subject: [PATCH 19/61] [gui] Also limit GUI updates when in non full-screen
  video mode
 
 ---
@@ -1274,19 +1237,19 @@ Subject: [PATCH 18/62] [gui] Also limit GUI updates when in non full-screen
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
-index cf77c3dbb84b86c755ee792294760c5c4c38742d..adbfef5f32d3d205f2410e1aabbd8325dd90f8e2 100644
+index b441de35eca9c988eb10f83c3aaf12f618b0c743..b2566f85f77b185c3f90a26f5eff000d09a2ccf9 100644
 --- a/xbmc/Application.cpp
 +++ b/xbmc/Application.cpp
-@@ -2762,7 +2762,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
+@@ -2761,7 +2761,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
  #if defined(TARGET_RASPBERRY_PI) || defined(HAS_IMXVPU)
      // This code reduces rendering fps of the GUI layer when playing videos in fullscreen mode
      // it makes only sense on architectures with multiple layers
 -    if (g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback() && m_pPlayer->IsRenderingVideoLayer())
 +    if (m_pPlayer->IsPlayingVideo() && !m_pPlayer->IsPausedPlayback() && m_pPlayer->IsRenderingVideoLayer())
-       fps = CSettings::GetInstance().GetInt(CSettings::SETTING_VIDEOPLAYER_LIMITGUIUPDATE);
+       fps = m_ServiceManager->GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_LIMITGUIUPDATE);
  #endif
  
-@@ -2775,6 +2775,8 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
+@@ -2774,6 +2774,8 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
      {
        if (!m_skipGuiRender)
          g_windowManager.Process(CTimeUtils::GetFrameTime());
@@ -1296,10 +1259,10 @@ index cf77c3dbb84b86c755ee792294760c5c4c38742d..adbfef5f32d3d205f2410e1aabbd8325
      g_windowManager.FrameMove();
    }
 
-From 6bbda4d7e81f32b2e046e81fc7ea3d810b117eae Mon Sep 17 00:00:00 2001
+From 91b4807e4f26d5d479a2bc83b9d607bda4b93505 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 May 2015 23:58:06 +0100
-Subject: [PATCH 19/62] [screensaver] Leave GUI contents available for
+Subject: [PATCH 20/61] [screensaver] Leave GUI contents available for
  screensaver
 
 ---
@@ -1307,10 +1270,10 @@ Subject: [PATCH 19/62] [screensaver] Leave GUI contents available for
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/xbmc/guilib/GUIWindowManager.cpp b/xbmc/guilib/GUIWindowManager.cpp
-index 5808f7ed1e94d68ead7305ba6d284edd4df12bdd..2a3b7f16531c9822e79c77efabdd30acdaa2a3c9 100644
+index 77ab06e490beded56258826c91da5ee69cd55ed8..f0af5bc1e4d0e7b4e736a39fef06fbf7a37a6e93 100644
 --- a/xbmc/guilib/GUIWindowManager.cpp
 +++ b/xbmc/guilib/GUIWindowManager.cpp
-@@ -795,7 +795,16 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
+@@ -818,7 +818,16 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
    int currentWindow = GetActiveWindow();
    CGUIWindow *pWindow = GetWindow(currentWindow);
    if (pWindow)
@@ -1329,10 +1292,10 @@ index 5808f7ed1e94d68ead7305ba6d284edd4df12bdd..2a3b7f16531c9822e79c77efabdd30ac
  
    // Add window to the history list (we must do this before we activate it,
 
-From cb881f3dae6d748dcc06616d5937a7f5c806a3a6 Mon Sep 17 00:00:00 2001
+From 3143d4021d23da5afe2d05218f8a8f486b6ea217 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 6 Jun 2015 18:43:57 +0100
-Subject: [PATCH 20/62] ffmpeg: Automatic switch to software decode for GMC
+Subject: [PATCH 21/61] ffmpeg: Automatic switch to software decode for GMC
  with more than one warp point
 
 ---
@@ -1437,10 +1400,10 @@ index 5c2976278eb5ec5b8b4a4f9f9c7174b164ab5201..dde29adf425e54f54e4104b3370352db
  ./configure --prefix=$FFMPEG_PREFIX \
  	--extra-version="kodi-${VERSION}" \
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-index ff3729bde30c0e46de67c4df9b01ee5846c181ee..822b7bf75f2e732b5eed8687403d0eda503fa641 100644
+index 0976d9fb361324ca25224535c6a7c23c3b50bba1..4f5de0341b344c77a12c936f4f573c2911c0bb7b 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-@@ -47,6 +47,10 @@
+@@ -45,6 +45,10 @@
  
  #include "linux/RBP.h"
  
@@ -1451,9 +1414,9 @@ index ff3729bde30c0e46de67c4df9b01ee5846c181ee..822b7bf75f2e732b5eed8687403d0eda
  using namespace KODI::MESSAGING;
  
  #define CLASSNAME "CMMALVideoBuffer"
-@@ -367,6 +371,8 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+@@ -365,6 +369,8 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
    // we always qualify even if DVDFactoryCodec does this too.
-   if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
+   if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
      return false;
 +  if (hints.workaround_bugs & FF_BUG_GMC_UNSUPPORTED)
 +    return false;
@@ -1461,30 +1424,30 @@ index ff3729bde30c0e46de67c4df9b01ee5846c181ee..822b7bf75f2e732b5eed8687403d0eda
    std::list<EINTERLACEMETHOD> deintMethods;
    deintMethods.push_back(EINTERLACEMETHOD::VS_INTERLACEMETHOD_AUTO);
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
-index 3bb003b634c83d2c1b0ecd12b53027950e58be99..24341dc23e97e86e1b20b255548573c88e02f064 100644
+index f2a5349d329ba4ce9886db41b7dc6c5aca0f00b1..a201efed7f3a591ebbe65106eb75e95264cd4a3f 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
-@@ -157,6 +157,7 @@ public:
-     type = STREAM_VIDEO;
+@@ -154,6 +154,7 @@ public:
      iOrientation = 0;
      iBitsPerPixel = 0;
+     iBitRate = 0;
 +    workaround_bugs = 0;
    }
  
    virtual ~CDemuxStreamVideo() {}
-@@ -171,6 +172,7 @@ public:
-   int iOrientation; // orientation of the video in degress counter clockwise
+@@ -169,6 +170,7 @@ public:
    int iBitsPerPixel;
+   int iBitRate;
    std::string stereo_mode; // expected stereo mode
 +  int workaround_bugs; // info for decoder
  };
  
  class CDemuxStreamAudio : public CDemuxStream
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index e015e65dea43e7b682b704edb7f468b63b8c2ac5..54a18c669a058b705e0276cb7e14522ae6cd04ae 100644
+index e9a1645acbdb2dd2fbf3c1eaee9ef1401fe9bfd7..b485ad23e6309647db2bc489ed6bfda60cf506a1 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -1416,7 +1416,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1418,7 +1418,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
          if (!stereoMode.empty())
            st->stereo_mode = stereoMode;
  
@@ -1522,11 +1485,11 @@ index e59c84c32ff6f108b52955523321f37bd3885986..28dbdd344473338762927f5f2d014252
    else if(  right.type == STREAM_SUBTITLE )
    {
 diff --git a/xbmc/cores/VideoPlayer/DVDStreamInfo.h b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
-index f14170850673ebf746df0acf8f5cf5977feae684..85e402bb4e1ddd61bdb657802cc7347c95b9a302 100644
+index b087a110ad2cd4df00702133607ab117c87f552e..12c251e0feaf59bd9498d9cc63e3e3b9d8bb0dd8 100644
 --- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
 +++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
-@@ -73,6 +73,7 @@ public:
-   int orientation; // orientation of the video in degress counter clockwise
+@@ -69,6 +69,7 @@ public:
+   int orientation; // orientation of the video in degrees counter clockwise
    int bitsperpixel;
    std::string stereo_mode; // stereoscopic 3d mode
 +  int workaround_bugs; // info for decoder
@@ -1534,10 +1497,10 @@ index f14170850673ebf746df0acf8f5cf5977feae684..85e402bb4e1ddd61bdb657802cc7347c
    // AUDIO
    int channels;
 diff --git a/xbmc/cores/omxplayer/OMXHelper.cpp b/xbmc/cores/omxplayer/OMXHelper.cpp
-index f135d423c0ca76fd70e79ae5b7d035f0cb79fc75..d9b576bc46055fdab1c134e5f2c63cd4989d015c 100644
+index d7210ac180edf28024fc205385a75275f0c87330..4f5dedd05745ec918e8e683a329a526f981a9be6 100644
 --- a/xbmc/cores/omxplayer/OMXHelper.cpp
 +++ b/xbmc/cores/omxplayer/OMXHelper.cpp
-@@ -30,6 +30,10 @@
+@@ -31,6 +31,10 @@
  #include "cores/omxplayer/OMXPlayerVideo.h"
  #include "threads/SystemClock.h"
  
@@ -1548,7 +1511,7 @@ index f135d423c0ca76fd70e79ae5b7d035f0cb79fc75..d9b576bc46055fdab1c134e5f2c63cd4
  #define PREDICATE_RETURN(lh, rh) \
    do { \
      if((lh) != (rh)) \
-@@ -81,7 +85,9 @@ bool OMXPlayerUnsuitable(bool m_HasVideo, bool m_HasAudio, CDVDDemux* m_pDemuxer
+@@ -82,7 +86,9 @@ bool OMXPlayerUnsuitable(bool m_HasVideo, bool m_HasAudio, CDVDDemux* m_pDemuxer
        CDVDStreamInfo hint(*stream, true);
  
        bool supported = false;
@@ -1560,10 +1523,10 @@ index f135d423c0ca76fd70e79ae5b7d035f0cb79fc75..d9b576bc46055fdab1c134e5f2c63cd4
        else if ((hint.codec == AV_CODEC_ID_VC1 || hint.codec == AV_CODEC_ID_WMV3) && g_RBP.GetCodecWvc1())
          supported = true;
 
-From b5b121249287c4d102d61ae0aafa05f40e79af44 Mon Sep 17 00:00:00 2001
+From 4d326bcbd6ab3cf8367902d13db2b80fd8ecd4fe Mon Sep 17 00:00:00 2001
 From: Claudio-Sjo <Claudio.Porfiri@gmail.com>
 Date: Mon, 16 Feb 2015 14:51:26 +0100
-Subject: [PATCH 21/62] - allow reads < CDIO_CD_FRAMESIZE_RAW by using a buffer
+Subject: [PATCH 22/61] - allow reads < CDIO_CD_FRAMESIZE_RAW by using a buffer
  - fixes #15794
 
 ---
@@ -1755,10 +1718,10 @@ index 0427af4534bfe59a343f0518c7f4242d93299836..e99236294fa8b9b613e465a8ecaf3ad3
    lsn_t m_lsnCurrent; // Position inside the track in logical sector number
    lsn_t m_lsnEnd;   // End of m_iTrack in logical sector number
 
-From 2a304750b765450dfb217e6a51ceeeb2eeb79741 Mon Sep 17 00:00:00 2001
+From aaa6b66b127dcd1fb041f49c5fed39479a32fca7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 24 Jun 2016 19:38:13 +0100
-Subject: [PATCH 22/62] codecoverlay: Include codec name in overlay
+Subject: [PATCH 23/61] codecoverlay: Include codec name in overlay
 
 ---
  xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp | 4 ++++
@@ -1769,13 +1732,13 @@ Subject: [PATCH 22/62] codecoverlay: Include codec name in overlay
  5 files changed, 17 insertions(+), 5 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
-index f822935ab7fc919128db53f70a6c4eb84d9759bc..9db3a9cc91fd5f9b194d6c1aa66aa02121164c29 100644
+index a40c6191e5e0e403790bbd05d6b5cded773f54c8..1f184e78d28a7430bca7d4f39de1f49adf33b56c 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
-@@ -210,6 +210,10 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
+@@ -211,6 +211,10 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
    std::ostringstream s;
    s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "%";
-   s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)GetAudioBitrate() / 1024.0;
+   s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)m_audioStats.GetBitrate() / 1024.0;
 +  s << ", ac:"   << m_processInfo.GetAudioDecoderName().c_str();
 +  if (!m_info.passthrough)
 +    s << ", chan:" << m_processInfo.GetAudioChannels().c_str();
@@ -1784,10 +1747,10 @@ index f822935ab7fc919128db53f70a6c4eb84d9759bc..9db3a9cc91fd5f9b194d6c1aa66aa021
    //print the inverse of the resample ratio, since that makes more sense
    //if the resample ratio is 0.5, then we're playing twice as fast
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-index 89db27cce079e3e273050f2fa71f941f21b8280b..903f0d83527d9088ff1bf0ba056f357f6abfda81 100644
+index 5298963d58bb976a2bbd608a8dbc8e079a5bef62..d4920ac30216fb295a16b70ddff887e2077ee196 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-@@ -895,10 +895,13 @@ int CVideoPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
+@@ -896,10 +896,13 @@ int CVideoPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
  
  std::string CVideoPlayerVideo::GetPlayerInfo()
  {
@@ -1803,10 +1766,10 @@ index 89db27cce079e3e273050f2fa71f941f21b8280b..903f0d83527d9088ff1bf0ba056f357f
    s << ", skip:" << m_renderManager.GetSkippedFrames();
  
 diff --git a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
-index 1e5d2b98bbef15b47994c3e4735873a9946b58c7..d43350fa0eefb5960475a02c1327efc24d138e0f 100644
+index 968724e81d473a4bf8d4a0456be69f05e1a54812..c593c2fed0ce967f3d0b9fb5cf37b1026504b3a5 100644
 --- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
 +++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
-@@ -659,6 +659,10 @@ std::string OMXPlayerAudio::GetPlayerInfo()
+@@ -657,6 +657,10 @@ std::string OMXPlayerAudio::GetPlayerInfo()
    std::ostringstream s;
    s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel() + MathUtils::round_int(100.0/8.0*GetCacheTime())) << "%";
    s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)GetAudioBitrate() / 1024.0;
@@ -1818,10 +1781,10 @@ index 1e5d2b98bbef15b47994c3e4735873a9946b58c7..d43350fa0eefb5960475a02c1327efc2
    return s.str();
  }
 diff --git a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
-index a4b663d43d5b626e351256a1dd10650a282b494c..f6fb241dfec9269f4e501248de4dc83d5fdc2d3a 100644
+index b2c435bb2bc3f458d63be7249069531a954c6b9e..d308e44e26baae1a56127b55b987c28c384a9b63 100644
 --- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
 +++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
-@@ -593,12 +593,14 @@ void OMXPlayerVideo::SetSpeed(int speed)
+@@ -592,12 +592,14 @@ void OMXPlayerVideo::SetSpeed(int speed)
  
  std::string OMXPlayerVideo::GetPlayerInfo()
  {
@@ -1852,10 +1815,10 @@ index 0df7e72cc9d1947173c2bac5e72eb09976b51aa5..b5050081c360d29b1b478c27e6b88291
    double                    m_iSubtitleDelay;
    bool                      m_bRenderSubs;
 
-From 9ebfa6f23b211491275577d8022c4f83b5171ba4 Mon Sep 17 00:00:00 2001
+From a49d6d2194d7702abe261d6d074592dcbccab467 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Tue, 8 Mar 2016 21:20:58 +0300
-Subject: [PATCH 23/62] [DebugInfo] Add cpu usage info.
+Subject: [PATCH 24/61] [DebugInfo] Add cpu usage info.
 
 ---
  .../VideoPlayer/VideoRenderers/DebugRenderer.cpp   | 56 ++++++++--------------
@@ -1992,7 +1955,7 @@ index 85aefaace73994730f7d2bdff9de85c79e99b2a2..8005a13bc220be0c5c596d276197c11e
  };
 \ No newline at end of file
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
-index 17c428cb28018707d7422f344191b218903ab29b..8626a1b449ff0963089f6a7ad191a6c99512521a 100644
+index 5230c6d2c9b20bfa6390b0da1b06ae9045580972..5feee388bb3a433ea6a35b29e587ab6447c089a5 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
 @@ -24,6 +24,7 @@
@@ -2003,7 +1966,7 @@ index 17c428cb28018707d7422f344191b218903ab29b..8626a1b449ff0963089f6a7ad191a6c9
  #include "utils/log.h"
  #include "utils/StringUtils.h"
  #include "windowing/WindowingFactory.h"
-@@ -926,7 +927,7 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
+@@ -929,7 +930,7 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
  
      if (m_renderDebug)
      {
@@ -2012,7 +1975,7 @@ index 17c428cb28018707d7422f344191b218903ab29b..8626a1b449ff0963089f6a7ad191a6c9
  
        m_playerPort->GetDebugInfo(audio, video, player);
  
-@@ -940,8 +941,10 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
+@@ -943,8 +944,10 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
                                       missedvblanks,
                                       clockspeed * 100);
        }
@@ -2025,10 +1988,10 @@ index 17c428cb28018707d7422f344191b218903ab29b..8626a1b449ff0963089f6a7ad191a6c9
  
        m_debugTimer.Set(1000);
 
-From 37fedb68b098941bbdc5ace022806c75c908caf6 Mon Sep 17 00:00:00 2001
+From fad68b0c2e047c354a69586317d04474aa3ee3bc Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 22 May 2015 13:56:29 +0100
-Subject: [PATCH 24/62] ffmpeg: Allow neon to be enabled in unified builds
+Subject: [PATCH 25/61] ffmpeg: Allow neon to be enabled in unified builds
 
 ---
  tools/depends/target/ffmpeg/Makefile | 4 ++++
@@ -2051,10 +2014,10 @@ index 8dd14cdfd053f142f386b6dee1fc0b21bb1f8d93..b5f38a458dfb341c43089e07afded153
  ifeq ($(OS), linux)
    ffmpg_config += --target-os=$(OS) --cpu=$(CPU)
 
-From 2bfb7a3ff98dd858389dd3d064d8a3dc52a72af8 Mon Sep 17 00:00:00 2001
+From cb18faf29fa126a70d6c705823198231e8da1757 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 27 Feb 2015 14:37:27 +0000
-Subject: [PATCH 25/62] ffmpeg: Add some upstream HEVC optimisations
+Subject: [PATCH 26/61] ffmpeg: Add some upstream HEVC optimisations
 
 ---
  tools/depends/target/ffmpeg/Makefile               |    6 +-
@@ -5852,10 +5815,10 @@ index 0000000000000000000000000000000000000000..5e8e07d407f045fc99554f0f061d1e81
 +2.5.0
 +
 
-From 56a954cfc65e5f4f2f2e7a506ef303b853eedb81 Mon Sep 17 00:00:00 2001
+From 7e8be9ec3979f4a986ca3caddbd104648a665975 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 7 May 2015 14:04:18 +0100
-Subject: [PATCH 26/62] [ffmpeg] Add GPU acceleration to hevc
+Subject: [PATCH 27/61] [ffmpeg] Add GPU acceleration to hevc
 
 ---
  tools/depends/target/ffmpeg/Makefile               |     4 +-
@@ -44041,10 +44004,10 @@ index 0000000000000000000000000000000000000000..e172ebf157aebffe1ae50b4a2b25fd71
 +2.7.4
 +
 
-From 8e5e6f713dc181bc3f3b4bfb728d11aca00c846e Mon Sep 17 00:00:00 2001
+From fc9a7b66a195da7562af2bdcc353ad92e3a9a07a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 12 Jan 2016 16:29:57 +0000
-Subject: [PATCH 27/62] ffmpeg: Add cabac opimisations for hevc
+Subject: [PATCH 28/61] ffmpeg: Add cabac opimisations for hevc
 
 ---
  .../0001-Squashed-commit-of-the-following.patch    | 2179 ++++++++++++++++++++
@@ -46289,10 +46252,10 @@ index d6856dbd4fb4957ace700cbc08332223c01938f6..a61357f14cb2139e8125ae04684bed1b
  
  make -j ${BUILDTHREADS} 
 
-From 74ed08120dcf15fe8429da268d7dd63711e7fc48 Mon Sep 17 00:00:00 2001
+From 77973371178aaa12f3adba74a84d258795ff5c78 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 16 Sep 2015 19:05:12 +0100
-Subject: [PATCH 28/62] [3d] Make MVC a valid 3D filename tag
+Subject: [PATCH 29/61] [3d] Make MVC a valid 3D filename tag
 
 ---
  xbmc/guilib/StereoscopicsManager.cpp | 9 +++++++++
@@ -46301,10 +46264,10 @@ Subject: [PATCH 28/62] [3d] Make MVC a valid 3D filename tag
  3 files changed, 12 insertions(+)
 
 diff --git a/xbmc/guilib/StereoscopicsManager.cpp b/xbmc/guilib/StereoscopicsManager.cpp
-index b34873cba6534086ae243326550385867a03256a..1443acaf0f25df458ae49766e13dd0323454f2eb 100644
+index 299d0ba62f4dbb6bc8d5632e19288f165333cc3c..618e6f4f0d6e792e0d0d60edfad2d59e3805ff7c 100644
 --- a/xbmc/guilib/StereoscopicsManager.cpp
 +++ b/xbmc/guilib/StereoscopicsManager.cpp
-@@ -197,6 +197,15 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
+@@ -198,6 +198,15 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
    if (re.RegFind(searchString) > -1)
      stereoMode = "top_bottom";
  
@@ -46321,7 +46284,7 @@ index b34873cba6534086ae243326550385867a03256a..1443acaf0f25df458ae49766e13dd032
  }
  
 diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index 3891a7ed34acb3489a860678d56a8ec049890f6e..974305ff329eb6999c908d5e05d723f93137ae33 100644
+index 4ebc890a52995ca761effad6c30d41cb25b5bdb8..c728dd652d323fb5f0882b7dbd2887fd59dfe0e2 100644
 --- a/xbmc/settings/AdvancedSettings.cpp
 +++ b/xbmc/settings/AdvancedSettings.cpp
 @@ -402,6 +402,7 @@ void CAdvancedSettings::Initialize()
@@ -46341,10 +46304,10 @@ index 3891a7ed34acb3489a860678d56a8ec049890f6e..974305ff329eb6999c908d5e05d723f9
      XMLUtils::GetFloat(pElement, "audiodelayrange", m_videoAudioDelayRange, 10, 600);
      XMLUtils::GetString(pElement, "defaultplayer", m_videoDefaultPlayer);
 diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
-index fc526d11c3a78bc74125429120e29bf295bd3b16..6b0e3b8cf9e3ff40e6af758c54fe7eefb89a131c 100644
+index 64d42f8bdce59d3c7752657e3fe483733e88eda6..faa91950e9546855d71beef4ee96aa33a1318f24 100644
 --- a/xbmc/settings/AdvancedSettings.h
 +++ b/xbmc/settings/AdvancedSettings.h
-@@ -372,6 +372,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
+@@ -373,6 +373,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
      std::string m_stereoscopicregex_3d;
      std::string m_stereoscopicregex_sbs;
      std::string m_stereoscopicregex_tab;
@@ -46353,20 +46316,20 @@ index fc526d11c3a78bc74125429120e29bf295bd3b16..6b0e3b8cf9e3ff40e6af758c54fe7eef
      bool m_useDisplayControlHWStereo;
  
 
-From 4c051282f501f503dd7fffa2c5de404c7f226bf5 Mon Sep 17 00:00:00 2001
+From 0ab5fb723afa7d98dca44bf1934f79a3c57c65ed Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 5 Oct 2015 14:58:05 +0100
-Subject: [PATCH 29/62] [3d] Swap top/bottom sides of GUI
+Subject: [PATCH 30/61] [3d] Swap top/bottom sides of GUI
 
 ---
  xbmc/guilib/GraphicContext.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/guilib/GraphicContext.cpp b/xbmc/guilib/GraphicContext.cpp
-index 3706e4d80b3b31da4c5be0a1b21f36e59d2910f2..e170b3fb05279ffa316794dbce1d4f9dc5697bd0 100644
+index 6b65632fdfcf6278a44e90f61ddb018f2a98763c..80a7809beffa1a03ee41d6ab862ec075c68fed5d 100644
 --- a/xbmc/guilib/GraphicContext.cpp
 +++ b/xbmc/guilib/GraphicContext.cpp
-@@ -266,7 +266,7 @@ CPoint CGraphicContext::StereoCorrection(const CPoint &point) const
+@@ -267,7 +267,7 @@ CPoint CGraphicContext::StereoCorrection(const CPoint &point) const
    {
      const RESOLUTION_INFO info = GetResInfo();
  
@@ -46376,10 +46339,10 @@ index 3706e4d80b3b31da4c5be0a1b21f36e59d2910f2..e170b3fb05279ffa316794dbce1d4f9d
    }
    if(m_stereoMode == RENDER_STEREO_MODE_SPLIT_VERTICAL)
 
-From f29ad40c8e501bebc8aa27133b3197ed9b7314dc Mon Sep 17 00:00:00 2001
+From 8b51ad77c3bfd6a2610c8d22f69d43472f60c6a1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 11 Oct 2015 20:51:37 +0100
-Subject: [PATCH 30/62] Revert "Revert "Disable extra logging by default""
+Subject: [PATCH 31/61] Revert "Revert "Disable extra logging by default""
 
 This reverts commit a880554325be187b877cd8f0e2b338e7267da636.
 ---
@@ -46387,10 +46350,10 @@ This reverts commit a880554325be187b877cd8f0e2b338e7267da636.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 326ffbd0f08428c3b4a95208134253feeabf1b1f..22dcff1c06577055f84c3d2c2fda73cfa16c53d4 100644
+index 38a772b4e5f59cdd30293850752a761dbe532177..068ca2d519cb7537e0d3ad05c83d47d341a34250 100644
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
-@@ -2822,12 +2822,12 @@
+@@ -2967,12 +2967,12 @@
          </setting>
          <setting id="debug.extralogging" type="boolean" label="666" help="36394">
            <level>1</level>
@@ -46406,10 +46369,10 @@ index 326ffbd0f08428c3b4a95208134253feeabf1b1f..22dcff1c06577055f84c3d2c2fda73cf
              <options>loggingcomponents</options>
              <delimiter>,</delimiter>
 
-From 27644a4501775081bd9d7e70c3dc327b2edf5575 Mon Sep 17 00:00:00 2001
+From a09f9dc59e0d42a32a98fdf89ee84282a327d8dd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 21 Dec 2015 22:17:25 +0000
-Subject: [PATCH 31/62] [omximage] Fall back to arm jpeg encode/decode when gpu
+Subject: [PATCH 32/61] [omximage] Fall back to arm jpeg encode/decode when gpu
  is busy
 
 ---
@@ -46418,10 +46381,10 @@ Subject: [PATCH 31/62] [omximage] Fall back to arm jpeg encode/decode when gpu
  2 files changed, 48 insertions(+), 9 deletions(-)
 
 diff --git a/xbmc/cores/omxplayer/OMXImage.cpp b/xbmc/cores/omxplayer/OMXImage.cpp
-index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20a72d762d 100644
+index c16f3d626ac749d17e2896474ee06be7acdded5f..bfc0440998b69f3f998378ea665246a63448fec8 100644
 --- a/xbmc/cores/omxplayer/OMXImage.cpp
 +++ b/xbmc/cores/omxplayer/OMXImage.cpp
-@@ -57,12 +57,17 @@ static XbmcThreads::ConditionVariable g_count_cond;
+@@ -56,12 +56,17 @@ static XbmcThreads::ConditionVariable g_count_cond;
  static CCriticalSection               g_count_lock;
  static int g_count_val;
  
@@ -46440,7 +46403,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
  }
  
  static void limit_calls_leave()
-@@ -112,6 +117,9 @@ bool COMXImage::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int w
+@@ -111,6 +116,9 @@ bool COMXImage::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int w
        unsigned int format, unsigned int pitch, const std::string& destFile)
  {
    COMXImageEnc omxImageEnc;
@@ -46450,7 +46413,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    bool ret = omxImageEnc.CreateThumbnailFromSurface(buffer, width, height, format, pitch, destFile);
    if (!ret)
      CLog::Log(LOGNOTICE, "%s: unable to create thumbnail %s %dx%d", __func__, destFile.c_str(), width, height);
-@@ -205,6 +213,8 @@ bool COMXImage::CreateThumb(const std::string& srcFile, unsigned int maxHeight,
+@@ -204,6 +212,8 @@ bool COMXImage::CreateThumb(const std::string& srcFile, unsigned int maxHeight,
    bool okay = false;
    COMXImageFile file;
    COMXImageReEnc reenc;
@@ -46459,7 +46422,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    void *pDestBuffer;
    unsigned int nDestSize;
    int orientation = additional_info == "flipped" ? 1:0;
-@@ -310,6 +320,9 @@ bool COMXImage::DecodeJpegToTexture(COMXImageFile *file, unsigned int width, uns
+@@ -309,6 +319,9 @@ bool COMXImage::DecodeJpegToTexture(COMXImageFile *file, unsigned int width, uns
    bool ret = false;
    COMXTexture omx_image;
  
@@ -46469,7 +46432,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    struct textureinfo *tex = new struct textureinfo;
    if (!tex)
      return NULL;
-@@ -924,7 +937,7 @@ bool COMXImageFile::ReadFile(const std::string& inputFile, int orientation)
+@@ -923,7 +936,7 @@ bool COMXImageFile::ReadFile(const std::string& inputFile, int orientation)
  
  COMXImageDec::COMXImageDec()
  {
@@ -46478,7 +46441,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    m_decoded_buffer = NULL;
    OMX_INIT_STRUCTURE(m_decoded_format);
    m_success = false;
-@@ -936,7 +949,8 @@ COMXImageDec::~COMXImageDec()
+@@ -935,7 +948,8 @@ COMXImageDec::~COMXImageDec()
  
    OMX_INIT_STRUCTURE(m_decoded_format);
    m_decoded_buffer = NULL;
@@ -46488,7 +46451,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
  }
  
  void COMXImageDec::Close()
-@@ -1086,6 +1100,9 @@ bool COMXImageDec::HandlePortSettingChange(unsigned int resize_width, unsigned i
+@@ -1085,6 +1099,9 @@ bool COMXImageDec::HandlePortSettingChange(unsigned int resize_width, unsigned i
  
  bool COMXImageDec::Decode(const uint8_t *demuxer_content, unsigned demuxer_bytes, unsigned width, unsigned height, unsigned stride, void *pixels)
  {
@@ -46498,7 +46461,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    CSingleLock lock(m_OMXSection);
    OMX_ERRORTYPE omx_err = OMX_ErrorNone;
    OMX_BUFFERHEADERTYPE *omx_buffer = NULL;
-@@ -1223,7 +1240,7 @@ bool COMXImageDec::Decode(const uint8_t *demuxer_content, unsigned demuxer_bytes
+@@ -1222,7 +1239,7 @@ bool COMXImageDec::Decode(const uint8_t *demuxer_content, unsigned demuxer_bytes
  
  COMXImageEnc::COMXImageEnc()
  {
@@ -46507,7 +46470,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    CSingleLock lock(m_OMXSection);
    OMX_INIT_STRUCTURE(m_encoded_format);
    m_encoded_buffer = NULL;
-@@ -1247,11 +1264,15 @@ COMXImageEnc::~COMXImageEnc()
+@@ -1246,11 +1263,15 @@ COMXImageEnc::~COMXImageEnc()
        m_omx_encoder.Deinitialize();
      }
    }
@@ -46524,7 +46487,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    CSingleLock lock(m_OMXSection);
  
    unsigned int demuxer_bytes = 0;
-@@ -1432,6 +1453,9 @@ bool COMXImageEnc::Encode(unsigned char *buffer, int size, unsigned width, unsig
+@@ -1431,6 +1452,9 @@ bool COMXImageEnc::Encode(unsigned char *buffer, int size, unsigned width, unsig
  bool COMXImageEnc::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int width, unsigned int height,
      unsigned int format, unsigned int pitch, const std::string& destFile)
  {
@@ -46534,7 +46497,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    if(format != XB_FMT_A8R8G8B8 || !buffer)
    {
      CLog::Log(LOGDEBUG, "%s::%s : %s failed format=0x%x\n", CLASSNAME, __func__, destFile.c_str(), format);
-@@ -1465,7 +1489,7 @@ bool COMXImageEnc::CreateThumbnailFromSurface(unsigned char* buffer, unsigned in
+@@ -1464,7 +1488,7 @@ bool COMXImageEnc::CreateThumbnailFromSurface(unsigned char* buffer, unsigned in
  
  COMXImageReEnc::COMXImageReEnc()
  {
@@ -46543,7 +46506,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    m_encoded_buffer = NULL;
    m_pDestBuffer = NULL;
    m_nDestAllocSize = 0;
-@@ -1479,7 +1503,8 @@ COMXImageReEnc::~COMXImageReEnc()
+@@ -1478,7 +1502,8 @@ COMXImageReEnc::~COMXImageReEnc()
      free (m_pDestBuffer);
    m_pDestBuffer = NULL;
    m_nDestAllocSize = 0;
@@ -46553,7 +46516,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
  }
  
  void COMXImageReEnc::Close()
-@@ -1771,6 +1796,9 @@ bool COMXImageReEnc::HandlePortSettingChange(unsigned int resize_width, unsigned
+@@ -1770,6 +1795,9 @@ bool COMXImageReEnc::HandlePortSettingChange(unsigned int resize_width, unsigned
  
  bool COMXImageReEnc::ReEncode(COMXImageFile &srcFile, unsigned int maxWidth, unsigned int maxHeight, void * &pDestBuffer, unsigned int &nDestSize)
  {
@@ -46563,7 +46526,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    CSingleLock lock(m_OMXSection);
    OMX_ERRORTYPE omx_err = OMX_ErrorNone;
  
-@@ -1943,14 +1971,15 @@ bool COMXImageReEnc::ReEncode(COMXImageFile &srcFile, unsigned int maxWidth, uns
+@@ -1942,14 +1970,15 @@ bool COMXImageReEnc::ReEncode(COMXImageFile &srcFile, unsigned int maxWidth, uns
  
  COMXTexture::COMXTexture()
  {
@@ -46581,7 +46544,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
  }
  
  void COMXTexture::Close()
-@@ -2134,6 +2163,9 @@ bool COMXTexture::HandlePortSettingChange(unsigned int resize_width, unsigned in
+@@ -2133,6 +2162,9 @@ bool COMXTexture::HandlePortSettingChange(unsigned int resize_width, unsigned in
  
  bool COMXTexture::Decode(const uint8_t *demuxer_content, unsigned demuxer_bytes, unsigned int width, unsigned int height, void *egl_image)
  {
@@ -46592,7 +46555,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    OMX_ERRORTYPE omx_err = OMX_ErrorNone;
  
 diff --git a/xbmc/cores/omxplayer/OMXImage.h b/xbmc/cores/omxplayer/OMXImage.h
-index a93aa82663903fb1bf712058c2e259290ee742e6..6f38dbc7e5cc721c59a3633935f08218eb1dd169 100644
+index e44fb6ef0ba5fd011fdfc6771c946ffcfb8d581c..f1febd69aaa3522d252802ca00b6746022be41c6 100644
 --- a/xbmc/cores/omxplayer/OMXImage.h
 +++ b/xbmc/cores/omxplayer/OMXImage.h
 @@ -133,6 +133,7 @@ protected:
@@ -46652,10 +46615,10 @@ index a93aa82663903fb1bf712058c2e259290ee742e6..6f38dbc7e5cc721c59a3633935f08218
  
  extern COMXImage g_OMXImage;
 
-From 7d8d250f20930ac4d8684579b45c122f80b19bdd Mon Sep 17 00:00:00 2001
+From 51006cbbf493f5441929a0e44f476ec4088d0bf1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Dec 2015 13:31:14 +0000
-Subject: [PATCH 32/62] [mmalcodec] Fail to open when width is invalid. Can
+Subject: [PATCH 33/61] [mmalcodec] Fail to open when width is invalid. Can
  happen with mpegts files
 
 ---
@@ -46663,24 +46626,24 @@ Subject: [PATCH 32/62] [mmalcodec] Fail to open when width is invalid. Can
  1 file changed, 3 insertions(+)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-index 822b7bf75f2e732b5eed8687403d0eda503fa641..c43952d4d29b42f3a5c7605573294568f79ca010 100644
+index 4f5de0341b344c77a12c936f4f573c2911c0bb7b..4f07113ade696aa4bbefb2dd2a2e17d5f12e9ab9 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-@@ -368,6 +368,9 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+@@ -366,6 +366,9 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-     CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d renderer:%p", CLASSNAME, __func__, CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL), hints.software, hints.width, hints.height, options.m_opaque_pointer);
+     CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d renderer:%p", CLASSNAME, __func__, CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL), hints.software, hints.width, hints.height, options.m_opaque_pointer);
  
 +  // This occurs at start of m2ts files before streams have been fully identified - just ignore
 +  if (!hints.width)
 +    return false;
    // we always qualify even if DVDFactoryCodec does this too.
-   if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
+   if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
      return false;
 
-From d458533c19e59c92917de490a1214fd883f59ab2 Mon Sep 17 00:00:00 2001
+From c13c8baae03db8c4a669215a468e00eb555dc723 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 19 Sep 2014 11:54:49 +0100
-Subject: [PATCH 33/62] [videoplayer/rbp] Add pi specific option to maintain
+Subject: [PATCH 34/61] [videoplayer/rbp] Add pi specific option to maintain
  vsync with pll adjustment
 
 New A/V sync option in settings/video/playback to do "Adjust PLL".
@@ -46702,10 +46665,10 @@ or drop/dupe audio packets which is normally required.
  12 files changed, 143 insertions(+), 21 deletions(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index ae3aa10aa65beac6689f129d60056cadf8a5b5c1..7c7969d381bf15ac1ba2fd8f16e463f6b12fe4c3 100644
+index b52e18a39cc14e0712b44baa8a2e0068e5292d8c..a4607cfa2f6c41e2cc0a7b8fa8ee257a917be0c3 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19767,3 +19767,35 @@ msgstr ""
+@@ -20464,3 +20464,35 @@ msgstr ""
  msgctxt "#38190"
  msgid "Extract thumbnails from video files"
  msgstr ""
@@ -46767,10 +46730,10 @@ index 289dc55ec41aa44848519a05f8ee1ccc72740085..2572e25753712186f69390965ee1448b
        <group id="3">
          <setting id="audiooutput.ac3transcode" help="37024">
 diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
-index f5671b8dfb03216301d936ae3b08bfc3e8225729..68399ab14faf813bd195d2fdf03a4a376307b4cd 100644
+index 61787f99f95dbf3d637b62185d1496909d7ee0a6..b77b6098c7138157817567de471ded718b204227 100644
 --- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
 +++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
-@@ -363,11 +363,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
+@@ -364,11 +364,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
            m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::APPFOCUSED, msg->data, sizeof(bool));
            return;
          case CActiveAEControlProtocol::STREAMRESAMPLEMODE:
@@ -46786,7 +46749,7 @@ index f5671b8dfb03216301d936ae3b08bfc3e8225729..68399ab14faf813bd195d2fdf03a4a37
              par->stream->m_resampleIntegral = 0.0;
            }
            return;
-@@ -2456,7 +2457,14 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
+@@ -2457,7 +2458,14 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
    {
      if (stream->m_processingBuffers)
      {
@@ -46802,7 +46765,7 @@ index f5671b8dfb03216301d936ae3b08bfc3e8225729..68399ab14faf813bd195d2fdf03a4a37
      }
    }
    else if (stream->m_processingBuffers)
-@@ -3322,13 +3330,14 @@ void CActiveAE::SetStreamResampleRatio(CActiveAEStream *stream, double ratio)
+@@ -3323,13 +3331,14 @@ void CActiveAE::SetStreamResampleRatio(CActiveAEStream *stream, double ratio)
                                       &msg, sizeof(MsgStreamParameter));
  }
  
@@ -46822,7 +46785,7 @@ index f5671b8dfb03216301d936ae3b08bfc3e8225729..68399ab14faf813bd195d2fdf03a4a37
  
  void CActiveAE::SetStreamFFmpegInfo(CActiveAEStream *stream, int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type)
 diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
-index e29eb5719a2e24562a16180e53b2decd955e50a5..e2d3a6824ca0dc93fb08f3374c745ac1dcc63db3 100644
+index 77fc01a24e56298348148b501cd47e41d8d5cad5..c46ef0227b70cd6a2e1c8c327f5c0b2f76353260 100644
 --- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
 +++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
 @@ -177,6 +177,13 @@ struct MsgStreamFFmpegInfo
@@ -46947,7 +46910,7 @@ index 531dedc71f8b342d1556518e1fb7cb051f334e88..80ab096a417d53fcdf7703d11437f92d
    double m_clockSpeed;
    enum AVMatrixEncoding m_matrixEncoding;
 diff --git a/xbmc/cores/AudioEngine/Interfaces/AEStream.h b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
-index 533f6715d4e39215942d9ddd59f1242336daf32d..9e33493fd1a9f252162b8aa982609f161532d8ac 100644
+index dc50f8c82cb6831756e8344784f97e158692c780..02038f09fbcb7e4ac41e32c7c06a936cd16a2175 100644
 --- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
 +++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
 @@ -41,6 +41,14 @@ public:
@@ -46975,7 +46938,7 @@ index 533f6715d4e39215942d9ddd59f1242336daf32d..9e33493fd1a9f252162b8aa982609f16
    /**
     * Registers the audio callback to call with each block of data, this is used by Audio Visualizations
 diff --git a/xbmc/cores/VideoPlayer/DVDAudio.cpp b/xbmc/cores/VideoPlayer/DVDAudio.cpp
-index 2dd9b3689a37874a8199ff6edf64ba0b26d8c69f..8a7c2a7d86422bf7573d00a1f9d3084367ff19aa 100644
+index de1ad64523c3c9799ca24a86fce0dfec459366db..c3312daaf15ceed0072d640d2d49dc0a47128a9b 100644
 --- a/xbmc/cores/VideoPlayer/DVDAudio.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDAudio.cpp
 @@ -313,12 +313,12 @@ double CDVDAudio::GetResampleRatio()
@@ -46994,10 +46957,10 @@ index 2dd9b3689a37874a8199ff6edf64ba0b26d8c69f..8a7c2a7d86422bf7573d00a1f9d30843
  }
  
 diff --git a/xbmc/cores/VideoPlayer/DVDAudio.h b/xbmc/cores/VideoPlayer/DVDAudio.h
-index 81882a1a3828e3f95df26c1bd88c061d3b994b44..ed6974b1155a7272f3ef5bfed3f749674b831b93 100644
+index 0bbd2968b4e219aee04a31333b17981cd61b7dbc..a400677a782143a085daac0df22756a6cb8bb148 100644
 --- a/xbmc/cores/VideoPlayer/DVDAudio.h
 +++ b/xbmc/cores/VideoPlayer/DVDAudio.h
-@@ -61,7 +61,7 @@ public:
+@@ -58,7 +58,7 @@ public:
    double GetSyncError();
    void SetSyncErrorCorrection(double correction);
    double GetResampleRatio();
@@ -47007,18 +46970,18 @@ index 81882a1a3828e3f95df26c1bd88c061d3b994b44..ed6974b1155a7272f3ef5bfed3f74967
    void Drain();
    void AbortAddPackets();
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
-index 9db3a9cc91fd5f9b194d6c1aa66aa02121164c29..56170f48cda417554c57b2adf934c2df58a23abf 100644
+index 1f184e78d28a7430bca7d4f39de1f49adf33b56c..3b2ac69ae174d76d83ed55cdc999afaa90f0ee39 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
-@@ -96,6 +96,7 @@ bool CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints)
-   bool allowpassthrough = !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
+@@ -97,6 +97,7 @@ bool CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints)
+   bool allowpassthrough = !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
    if (hints.realtime)
      allowpassthrough = false;
-+  allowpassthrough |= CSettings::GetInstance().GetInt("audiooutput.plladjust") > 0;
++  allowpassthrough |= CServiceBroker::GetSettings().GetInt("audiooutput.plladjust") > 0;
    CDVDAudioCodec* codec = CDVDFactoryCodec::CreateAudioCodec(hints, m_processInfo, allowpassthrough, m_processInfo.AllowDTSHDDecode());
    if(!codec)
    {
-@@ -217,8 +218,12 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
+@@ -218,8 +219,12 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
  
    //print the inverse of the resample ratio, since that makes more sense
    //if the resample ratio is 0.5, then we're playing twice as fast
@@ -47031,12 +46994,12 @@ index 9db3a9cc91fd5f9b194d6c1aa66aa02121164c29..56170f48cda417554c57b2adf934c2df
  
    s << ", att:" << std::fixed << std::setprecision(1) << log(GetCurrentAttenuation()) * 20.0f << " dB";
  
-@@ -541,10 +546,12 @@ void CVideoPlayerAudio::SetSyncType(bool passthrough)
+@@ -542,10 +547,12 @@ void CVideoPlayerAudio::SetSyncType(bool passthrough)
      int synctype = (m_synctype >= 0 && m_synctype <= 1) ? m_synctype : 2;
      CLog::Log(LOGDEBUG, "CVideoPlayerAudio:: synctype set to %i: %s", m_synctype, synctypes[synctype]);
      m_prevsynctype = m_synctype;
 +    const float plladjusts[] = { 0.0f, 0.00001f, 0.0001f, 0.001f, 0.01f };
-+    float plladjust = plladjusts[CSettings::GetInstance().GetInt("audiooutput.plladjust")];
++    float plladjust = plladjusts[CServiceBroker::GetSettings().GetInt("audiooutput.plladjust")];
      if (m_synctype == SYNC_RESAMPLE)
 -      m_dvdAudio.SetResampleMode(1);
 +      m_dvdAudio.SetResampleMode(1, plladjust);
@@ -47046,19 +47009,19 @@ index 9db3a9cc91fd5f9b194d6c1aa66aa02121164c29..56170f48cda417554c57b2adf934c2df
    }
  }
  
-@@ -602,6 +609,7 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
-   bool allowpassthrough = !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
+@@ -603,6 +610,7 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
+   bool allowpassthrough = !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
    if (m_streaminfo.realtime)
      allowpassthrough = false;
-+  allowpassthrough |= CSettings::GetInstance().GetInt("audiooutput.plladjust") > 0;
++  allowpassthrough |= CServiceBroker::GetSettings().GetInt("audiooutput.plladjust") > 0;
    CDVDAudioCodec *codec = CDVDFactoryCodec::CreateAudioCodec(m_streaminfo, m_processInfo, allowpassthrough, m_processInfo.AllowDTSHDDecode());
    if (!codec || codec->NeedPassthrough() == m_pAudioCodec->NeedPassthrough()) {
      // passthrough state has not changed
 diff --git a/xbmc/linux/RBP.cpp b/xbmc/linux/RBP.cpp
-index 5a6f780517cff0c31f1c40e5e95445d448eb2297..6e8529001b1a464b4547a846f553d98f5bc0b6c0 100644
+index c073dc28db9abc24025909e2d91b7ce49201f4ea..e4bff70c0b8bc934e55fb8e68c6d5e35ce92c66f 100644
 --- a/xbmc/linux/RBP.cpp
 +++ b/xbmc/linux/RBP.cpp
-@@ -46,6 +46,8 @@ CRBP::CRBP()
+@@ -47,6 +47,8 @@ CRBP::CRBP()
    m_DllBcmHost      = new DllBcmHost();
    m_OMX             = new COMXCore();
    m_display = DISPMANX_NO_HANDLE;
@@ -47067,7 +47030,7 @@ index 5a6f780517cff0c31f1c40e5e95445d448eb2297..6e8529001b1a464b4547a846f553d98f
    m_mb = mbox_open();
    vcsm_init();
    m_vsync_count = 0;
-@@ -153,6 +155,8 @@ void CRBP::CloseDisplay(DISPMANX_DISPLAY_HANDLE_T display)
+@@ -154,6 +156,8 @@ void CRBP::CloseDisplay(DISPMANX_DISPLAY_HANDLE_T display)
    assert(s == 0);
    vc_dispmanx_display_close(m_display);
    m_display = DISPMANX_NO_HANDLE;
@@ -47076,7 +47039,7 @@ index 5a6f780517cff0c31f1c40e5e95445d448eb2297..6e8529001b1a464b4547a846f553d98f
  }
  
  void CRBP::GetDisplaySize(int &width, int &height)
-@@ -366,4 +370,20 @@ void CGPUMEM::Flush()
+@@ -367,4 +371,20 @@ void CGPUMEM::Flush()
    vcsm_clean_invalid( &iocache );
  }
  
@@ -47098,10 +47061,10 @@ index 5a6f780517cff0c31f1c40e5e95445d448eb2297..6e8529001b1a464b4547a846f553d98f
 +
  #endif
 diff --git a/xbmc/linux/RBP.h b/xbmc/linux/RBP.h
-index fffa5182126159f6dfcf750b21fa0464e229e545..815d758e7086d73b4d4eb16849fdbb509a3c251d 100644
+index 26a2a4bd74b54288282b534c5de7d59d6ccec7f5..79e676b1dee78f808a359dbee781fa80cf9be82e 100644
 --- a/xbmc/linux/RBP.h
 +++ b/xbmc/linux/RBP.h
-@@ -82,6 +82,8 @@ public:
+@@ -81,6 +81,8 @@ public:
    uint32_t WaitVsync(uint32_t target = ~0U);
    void VSyncCallback();
    int GetMBox() { return m_mb; }
@@ -47110,7 +47073,7 @@ index fffa5182126159f6dfcf750b21fa0464e229e545..815d758e7086d73b4d4eb16849fdbb50
  
  private:
    DllBcmHost *m_DllBcmHost;
-@@ -103,6 +105,9 @@ private:
+@@ -102,6 +104,9 @@ private:
    CCriticalSection m_critSection;
  
    int m_mb;
@@ -47121,10 +47084,10 @@ index fffa5182126159f6dfcf750b21fa0464e229e545..815d758e7086d73b4d4eb16849fdbb50
  
  extern CRBP g_RBP;
 
-From 5798c44c892111b789e14fb89e15dec6e8a5dcb4 Mon Sep 17 00:00:00 2001
+From efbb569ea1c6f060f1745c0a25b242210523d8ee Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 7 May 2015 15:35:43 +0100
-Subject: [PATCH 34/62] rbp: Support zero copy interface with hevc acceleration
+Subject: [PATCH 35/61] rbp: Support zero copy interface with hevc acceleration
 
 ---
  xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp | 9 +++++++++
@@ -47132,10 +47095,10 @@ Subject: [PATCH 34/62] rbp: Support zero copy interface with hevc acceleration
  2 files changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-index 4129d3d6a77ce1a3f15bad045746970f6e640ea6..619515c9411172261d8f0bef24c5d679c35e5d7d 100644
+index 8b59b1825c4fdee83ec4afc13403126153f8071d..c4eda5a2c78db1f6acc9ed59938ea3f42262d8fe 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-@@ -368,6 +368,15 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
+@@ -366,6 +366,15 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
      if (tryhw && m_decoderState == STATE_NONE)
      {
        m_decoderState = STATE_HW_SINGLE;
@@ -47152,7 +47115,7 @@ index 4129d3d6a77ce1a3f15bad045746970f6e640ea6..619515c9411172261d8f0bef24c5d679
      else
      {
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
-index 77ae3273bc8e224fe6c193300ccef32fb7fbafe1..c0b3f19f2ef9cdef9adf00cf81154803b12feb4f 100644
+index 3b6307725d938aae12f093b2691f3b9bf8373fe7..689ed0fddcc05175857e4cc57f23092ab9b81ddc 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
 @@ -296,8 +296,9 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture
@@ -47168,10 +47131,10 @@ index 77ae3273bc8e224fe6c193300ccef32fb7fbafe1..c0b3f19f2ef9cdef9adf00cf81154803
    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
      CLog::Log(LOGDEBUG, "%s::%s - mmal:%p dts:%.3f pts:%.3f buf:%p gpu:%p", CLASSNAME, __FUNCTION__, picture->MMALBuffer->mmal_buffer, 1e-6*picture->dts, 1e-6*picture->pts, picture->MMALBuffer, gmem);
 
-From 0a99bc0eb1d4a036f4df0d9f88c0f8bb3c6b0e6d Mon Sep 17 00:00:00 2001
+From 876a171ddf8444e3ddf017f3543abca1d06d9882 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 16 May 2015 18:26:04 +0100
-Subject: [PATCH 35/62] ffmpeg: use upstream mvc patches
+Subject: [PATCH 36/61] ffmpeg: use upstream mvc patches
 
 ---
  ...vcodec-add-h264_mvc-codec-id-and-profiles.patch |  68 ++++++++++++
@@ -47481,10 +47444,10 @@ index 0000000000000000000000000000000000000000..b39480ad098b9cd0882fcf75b96afb1b
 +2.7.4
 +
 
-From 7d4ef5a5e251a218f9609c0e2bb0cb7d3093f8b9 Mon Sep 17 00:00:00 2001
+From 407309dc8fcd7db189227af64b01f75337316d61 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Fri, 29 Jan 2016 17:18:50 +0300
-Subject: [PATCH 36/62] [win32] Settings: Added setting to enable/disable MVC
+Subject: [PATCH 37/61] [win32] Settings: Added setting to enable/disable MVC
  decoder.
 
 ---
@@ -47514,10 +47477,10 @@ index a017d30c24232fb01220b87b29398403b8ed9662..2fcee72a64e8b701c8e895143410bbe9
      <category id="display">
        <group id="1">
 
-From 492201a86d20da77a664e197a42f4a32945420be Mon Sep 17 00:00:00 2001
+From 35a4f32d2bf49501c2bb47d897f300de64f74fab Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Wed, 20 Jan 2016 17:02:16 +0300
-Subject: [PATCH 37/62] [VideoPlayer] DemuxFFmpeg: Properly demuxing h264_mvc
+Subject: [PATCH 38/61] [VideoPlayer] DemuxFFmpeg: Properly demuxing h264_mvc
  streams.
 
 ---
@@ -47525,7 +47488,7 @@ Subject: [PATCH 37/62] [VideoPlayer] DemuxFFmpeg: Properly demuxing h264_mvc
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff815cc74433 100644
+index b485ad23e6309647db2bc489ed6bfda60cf506a1..50889977723cf3857216d68100fe0b3575253c92 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 @@ -25,6 +25,7 @@
@@ -47536,7 +47499,7 @@ index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff81
  #include "DVDClock.h" // for DVD_TIME_BASE
  #include "DVDDemuxUtils.h"
  #include "DVDInputStreams/DVDInputStream.h"
-@@ -1355,6 +1356,15 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1356,6 +1357,15 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
        }
      case AVMEDIA_TYPE_VIDEO:
        {
@@ -47552,7 +47515,7 @@ index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff81
          CDemuxStreamVideoFFmpeg* st = new CDemuxStreamVideoFFmpeg(this, pStream);
          stream = st;
          if(strcmp(m_pFormatContext->iformat->name, "flv") == 0)
-@@ -1363,7 +1373,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1364,7 +1374,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
            st->bVFR = false;
  
          // never trust pts in avi files with h264.
@@ -47561,7 +47524,7 @@ index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff81
            st->bPTSInvalid = true;
  
  #if defined(AVFORMAT_HAS_STREAM_GET_R_FRAME_RATE)
-@@ -1434,6 +1444,17 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1436,6 +1446,17 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
          if (av_dict_get(pStream->metadata, "title", NULL, 0))
            st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
  
@@ -47580,10 +47543,10 @@ index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff81
        }
      case AVMEDIA_TYPE_DATA:
 
-From f32639c9513373f4c25dac7d9697f8c04760a7c8 Mon Sep 17 00:00:00 2001
+From 99c0ebc7b145c9b17bb6e3f4a765c9f7e018afd3 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Thu, 25 Feb 2016 11:21:25 +0300
-Subject: [PATCH 38/62] [Stereo3D] Added block_lr and block_rl to supported
+Subject: [PATCH 39/61] [Stereo3D] Added block_lr and block_rl to supported
  modes.
 
 ---
@@ -47607,10 +47570,10 @@ index 24b1b10519467cbbfd96f7048efaf49aab7700cc..49f7f7ca7e144a259f6d06bd11cd97aa
      return convert[mode];
    }
 diff --git a/xbmc/guilib/StereoscopicsManager.cpp b/xbmc/guilib/StereoscopicsManager.cpp
-index 1443acaf0f25df458ae49766e13dd0323454f2eb..6aaa82f4d883b8cae0ccdedf6c5a6814e7aaa720 100644
+index 618e6f4f0d6e792e0d0d60edfad2d59e3805ff7c..041324c51977ce880ab365a16f1ac366c79e369c 100644
 --- a/xbmc/guilib/StereoscopicsManager.cpp
 +++ b/xbmc/guilib/StereoscopicsManager.cpp
-@@ -70,8 +70,10 @@ static const struct StereoModeMap VideoModeToGuiModeMap[] =
+@@ -71,8 +71,10 @@ static const struct StereoModeMap VideoModeToGuiModeMap[] =
    { "anaglyph_cyan_red",        RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN },
    { "anaglyph_green_magenta",   RENDER_STEREO_MODE_ANAGLYPH_GREEN_MAGENTA },
    { "anaglyph_yellow_blue",     RENDER_STEREO_MODE_ANAGLYPH_YELLOW_BLUE },
@@ -47623,7 +47586,7 @@ index 1443acaf0f25df458ae49766e13dd0323454f2eb..6aaa82f4d883b8cae0ccdedf6c5a6814
    {}
  };
  
-@@ -310,7 +312,7 @@ int CStereoscopicsManager::ConvertVideoToGuiStereoMode(const std::string &mode)
+@@ -311,7 +313,7 @@ int CStereoscopicsManager::ConvertVideoToGuiStereoMode(const std::string &mode)
    size_t i = 0;
    while (VideoModeToGuiModeMap[i].name)
    {
@@ -47633,20 +47596,20 @@ index 1443acaf0f25df458ae49766e13dd0323454f2eb..6aaa82f4d883b8cae0ccdedf6c5a6814
      i++;
    }
 
-From 653902ed14aa61b97188eb1ce3bcfa47bc95046e Mon Sep 17 00:00:00 2001
+From 2990091f969247e6c2b958a2415b9437d7096682 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Sat, 23 Jan 2016 10:21:32 +0300
-Subject: [PATCH 39/62] [VideoPlayer] Fix possible wrong aspect.
+Subject: [PATCH 40/61] [VideoPlayer] Fix possible wrong aspect.
 
 ---
  xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-index 903f0d83527d9088ff1bf0ba056f357f6abfda81..a5a33d34c70892cde77ad4d8f3cb65fdd9703081 100644
+index d4920ac30216fb295a16b70ddff887e2077ee196..4f0e2cb561b5453217e961921049486dcd0636b3 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-@@ -181,7 +181,7 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
+@@ -182,7 +182,7 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
    }
  
    // use aspect in stream if available
@@ -47656,10 +47619,10 @@ index 903f0d83527d9088ff1bf0ba056f357f6abfda81..a5a33d34c70892cde77ad4d8f3cb65fd
    else
      m_fForcedAspectRatio = 0.0;
 
-From bb360aef2259c1ac131f9829726f42aaf7ddde8e Mon Sep 17 00:00:00 2001
+From be0b130b5ae5b0a4830711303e6166e5093f1dc2 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Fri, 22 Jan 2016 18:18:33 +0300
-Subject: [PATCH 40/62] [VideoPlayer] DemuxFFmpeg: ssif remux
+Subject: [PATCH 41/61] [VideoPlayer] DemuxFFmpeg: ssif remux
 
 ---
  xbmc/cores/VideoPlayer/DVDDemuxers/CMakeLists.txt  |   2 +
@@ -47667,9 +47630,8 @@ Subject: [PATCH 40/62] [VideoPlayer] DemuxFFmpeg: ssif remux
  .../cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h |   2 +
  .../VideoPlayer/DVDDemuxers/DemuxStreamSSIF.cpp    | 156 +++++++++++++++++++++
  .../VideoPlayer/DVDDemuxers/DemuxStreamSSIF.h      |  49 +++++++
- xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in     |   1 +
  xbmc/settings/AdvancedSettings.cpp                 |   2 +-
- 7 files changed, 251 insertions(+), 8 deletions(-)
+ 6 files changed, 250 insertions(+), 8 deletions(-)
  create mode 100644 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxStreamSSIF.cpp
  create mode 100644 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxStreamSSIF.h
 
@@ -47694,10 +47656,10 @@ index 63776b1333bb66483303e44d6ebe60f3cd7e14d7..156ec2021002d9d7a355db2f0dcf099a
              DVDDemuxUtils.h
              DVDDemuxVobsub.h
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89278ce67e 100644
+index 50889977723cf3857216d68100fe0b3575253c92..bd3bd7490c35c487cca232e28a71ba207be74990 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -166,6 +166,7 @@ CDVDDemuxFFmpeg::CDVDDemuxFFmpeg() : CDVDDemux()
+@@ -167,6 +167,7 @@ CDVDDemuxFFmpeg::CDVDDemuxFFmpeg() : CDVDDemux()
    m_currentPts = DVD_NOPTS_VALUE;
    m_bMatroska = false;
    m_bAVI = false;
@@ -47705,7 +47667,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
    m_speed = DVD_PLAYSPEED_NORMAL;
    m_program = UINT_MAX;
    m_pkt.result = -1;
-@@ -553,6 +554,8 @@ void CDVDDemuxFFmpeg::Dispose()
+@@ -554,6 +555,8 @@ void CDVDDemuxFFmpeg::Dispose()
    m_pkt.result = -1;
    av_packet_unref(&m_pkt.pkt);
  
@@ -47714,7 +47676,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
    if (m_pFormatContext)
    {
      for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
-@@ -606,6 +609,9 @@ void CDVDDemuxFFmpeg::Flush()
+@@ -607,6 +610,9 @@ void CDVDDemuxFFmpeg::Flush()
  
    m_displayTime = 0;
    m_dtsAtDisplayTime = DVD_NOPTS_VALUE;
@@ -47724,7 +47686,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
  }
  
  void CDVDDemuxFFmpeg::Abort()
-@@ -878,7 +884,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -879,7 +885,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
      {
        Flush();
      }
@@ -47735,7 +47697,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
      {
        // update streams
        CreateStreams(m_program);
-@@ -906,6 +914,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -907,6 +915,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
  
        m_pkt.result = -1;
        av_packet_unref(&m_pkt.pkt);
@@ -47745,7 +47707,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
      }
      else
      {
-@@ -915,7 +926,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -916,7 +927,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
  
        if (IsVideoReady())
        {
@@ -47756,7 +47718,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
          {
            /* check so packet belongs to selected program */
            for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
-@@ -1064,6 +1077,15 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -1065,6 +1078,15 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
          stream = AddStream(pPacket->iStreamId);
        }
      }
@@ -47772,7 +47734,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
      if (!stream)
      {
        CLog::Log(LOGERROR, "CDVDDemuxFFmpeg::AddStream - internal error, stream is null");
-@@ -1093,6 +1115,9 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
+@@ -1094,6 +1116,9 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
    m_pkt.result = -1;
    av_packet_unref(&m_pkt.pkt);
  
@@ -47782,7 +47744,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
    CDVDInputStream::IPosTime* ist = m_pInput->GetIPosTime();
    if (ist)
    {
-@@ -1173,6 +1198,9 @@ bool CDVDDemuxFFmpeg::SeekByte(int64_t pos)
+@@ -1174,6 +1199,9 @@ bool CDVDDemuxFFmpeg::SeekByte(int64_t pos)
    m_pkt.result = -1;
    av_packet_unref(&m_pkt.pkt);
  
@@ -47792,7 +47754,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
    return (ret >= 0);
  }
  
-@@ -1358,11 +1386,12 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1359,11 +1387,12 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
        {
          if (pStream->codec->codec_id == AV_CODEC_ID_H264_MVC)
          {
@@ -47808,7 +47770,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
            break;
          }
          CDemuxStreamVideoFFmpeg* st = new CDemuxStreamVideoFFmpeg(this, pStream);
-@@ -1448,7 +1477,11 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1450,7 +1479,11 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
          {
            if (CDVDCodecUtils::IsH264AnnexB(m_pFormatContext->iformat->name, pStream))
            {
@@ -47821,7 +47783,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
            }
            else if (CDVDCodecUtils::ProcessH264MVCExtradata(pStream->codec->extradata, pStream->codec->extradata_size))
            {
-@@ -1560,7 +1593,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1562,7 +1595,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
      if (langTag)
        strncpy(stream->language, langTag->value, 3);
  
@@ -47831,7 +47793,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
        stream->ExtraSize = pStream->codec->extradata_size;
        stream->ExtraData = new uint8_t[pStream->codec->extradata_size];
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
-index 0bc498e8e387c7ff0aef065832c121d1367454aa..85ce39ee858992a5f095cdf6b4d35398c7ce7dcc 100644
+index 73d536cc06710eab654f05fbc3e011d0c86c6a8b..364675293f73d40d4390b0d64e240df2432e082a 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
 @@ -21,6 +21,7 @@
@@ -47842,7 +47804,7 @@ index 0bc498e8e387c7ff0aef065832c121d1367454aa..85ce39ee858992a5f095cdf6b4d35398
  #include "threads/CriticalSection.h"
  #include "threads/SystemClock.h"
  #include <map>
-@@ -152,6 +153,7 @@ protected:
+@@ -146,6 +147,7 @@ protected:
    double   m_currentPts; // used for stream length estimation
    bool     m_bMatroska;
    bool     m_bAVI;
@@ -48067,20 +48029,8 @@ index 0000000000000000000000000000000000000000..1dafdc58db3f9cb5eac032c591942439
 +  int m_h264StreamId = 0;
 +  int m_mvcStreamId = 0;
 +};
-diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-index e4f8aed0af96fe0dceec4d8517087742f2c7df81..30076937bd084936571abf0e6eeecf5ad916c7b3 100644
---- a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-@@ -10,6 +10,7 @@ SRCS += DVDDemuxUtils.cpp
- SRCS += DVDDemuxVobsub.cpp
- SRCS += DVDDemuxCC.cpp
- SRCS += DVDFactoryDemuxer.cpp
-+SRCS += DemuxStreamSSIF.cpp
- 
- LIB = DVDDemuxers.a
- 
 diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index 974305ff329eb6999c908d5e05d723f93137ae33..985ecf9722141d78471c00e90da15bfad931462a 100644
+index c728dd652d323fb5f0882b7dbd2887fd59dfe0e2..aff4a915c7a129772f4d2272fff386067c578bce 100644
 --- a/xbmc/settings/AdvancedSettings.cpp
 +++ b/xbmc/settings/AdvancedSettings.cpp
 @@ -391,7 +391,7 @@ void CAdvancedSettings::Initialize()
@@ -48093,10 +48043,10 @@ index 974305ff329eb6999c908d5e05d723f93137ae33..985ecf9722141d78471c00e90da15bfa
    m_discStubExtensions = ".disc";
    // internal music extensions
 
-From d5804f4eeee51ca51afea69ff07b5afcd17ed8d9 Mon Sep 17 00:00:00 2001
+From f618079224e4f2a8d178622bcff33de9ed96b9d9 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Tue, 23 Feb 2016 16:02:46 +0300
-Subject: [PATCH 41/62] [3DBD] Added support of 3D-BluRay playback.
+Subject: [PATCH 42/61] [3DBD] Added support of 3D-BluRay playback.
 
 ---
  lib/DllLibbluray.h                                 |   8 +
@@ -48106,10 +48056,9 @@ Subject: [PATCH 41/62] [3DBD] Added support of 3D-BluRay playback.
  xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMVC.h      |  57 +++++
  .../VideoPlayer/DVDDemuxers/DemuxStreamSSIF.cpp    |  40 +++-
  .../VideoPlayer/DVDDemuxers/DemuxStreamSSIF.h      |  12 +-
- xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in     |   1 +
  .../DVDInputStreams/DVDInputStreamBluray.cpp       | 159 ++++++++++--
  .../DVDInputStreams/DVDInputStreamBluray.h         |  20 ++
- 10 files changed, 581 insertions(+), 35 deletions(-)
+ 9 files changed, 580 insertions(+), 35 deletions(-)
  create mode 100644 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMVC.cpp
  create mode 100644 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMVC.h
 
@@ -48174,7 +48123,7 @@ index 156ec2021002d9d7a355db2f0dcf099aabb1db48..87d27b666f703743bb0170252cf1190d
              DVDDemuxUtils.h
              DVDDemuxVobsub.h
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e7971139356 100644
+index bd3bd7490c35c487cca232e28a71ba207be74990..b80f44994dfbc9f4cac37f9cad7926c0d32371e2 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 @@ -27,6 +27,7 @@
@@ -48185,7 +48134,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
  #include "DVDDemuxUtils.h"
  #include "DVDInputStreams/DVDInputStream.h"
  #include "DVDInputStreams/DVDInputStreamFFmpeg.h"
-@@ -503,6 +504,16 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
+@@ -504,6 +505,16 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
  
    UpdateCurrentPTS();
  
@@ -48202,7 +48151,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
    // in case of mpegts and we have not seen pat/pmt, defer creation of streams
    if (!skipCreateStreams || m_pFormatContext->nb_programs > 0)
    {
-@@ -884,9 +895,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -885,9 +896,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
      {
        Flush();
      }
@@ -48213,7 +48162,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
      {
        // update streams
        CreateStreams(m_program);
-@@ -927,8 +936,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -928,8 +937,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
        if (IsVideoReady())
        {
          // libavformat is confused by the interleaved SSIF.
@@ -48223,7 +48172,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
          {
            /* check so packet belongs to selected program */
            for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
-@@ -1079,10 +1087,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -1080,10 +1088,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
      }
      if (stream && m_pSSIF)
      {
@@ -48235,7 +48184,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
        if (stream->type == STREAM_DATA && stream->codec == AV_CODEC_ID_H264_MVC && pPacket->iSize)
          stream = GetStream(pPacket->iStreamId);
      }
-@@ -1481,6 +1486,29 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1483,6 +1488,29 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
              {
                m_pSSIF->SetH264StreamId(streamIdx);
                pStream->codec->codec_tag = MKTAG('A', 'M', 'V', 'C');
@@ -48265,7 +48214,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
              }
            }
            else if (CDVDCodecUtils::ProcessH264MVCExtradata(pStream->codec->extradata, pStream->codec->extradata_size))
-@@ -1804,6 +1832,11 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
+@@ -1806,6 +1834,11 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
  
  bool CDVDDemuxFFmpeg::IsProgramChange()
  {
@@ -48725,20 +48674,8 @@ index 1dafdc58db3f9cb5eac032c591942439117e13c4..508e9debd3e6679a1433842a65649fa6
 +  int m_h264StreamId = -1;
 +  int m_mvcStreamId = -1;
  };
-diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-index 30076937bd084936571abf0e6eeecf5ad916c7b3..0359426b85683a4c3a80ef0e0d52f7a79564daaa 100644
---- a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-@@ -11,6 +11,7 @@ SRCS += DVDDemuxVobsub.cpp
- SRCS += DVDDemuxCC.cpp
- SRCS += DVDFactoryDemuxer.cpp
- SRCS += DemuxStreamSSIF.cpp
-+SRCS += DVDDemuxMVC.cpp
- 
- LIB = DVDDemuxers.a
- 
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319e3f770c0 100644
+index 55bc91384500f64f6cc4242514aa3104393de2cb..a2c59b137ebdb7a44aea4fe1216eb9a2f43c048c 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 @@ -26,6 +26,8 @@
@@ -48749,8 +48686,8 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
 +#include "DVDDemuxers/DemuxMVC.h"
  #include "settings/Settings.h"
  #include "LangInfo.h"
- #include "utils/log.h"
-@@ -231,10 +233,8 @@ bool CDVDInputStreamBluray::IsEOF()
+ #include "ServiceBroker.h"
+@@ -232,10 +234,8 @@ bool CDVDInputStreamBluray::IsEOF()
  
  BLURAY_TITLE_INFO* CDVDInputStreamBluray::GetTitleLongest()
  {
@@ -48762,7 +48699,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    {
      BLURAY_TITLE_INFO *t = m_dll->bd_get_title_info(m_bd, i, 0);
      if(!t)
-@@ -326,6 +326,7 @@ bool CDVDInputStreamBluray::Open()
+@@ -327,6 +327,7 @@ bool CDVDInputStreamBluray::Open()
      return false;
    }
  
@@ -48770,7 +48707,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    const BLURAY_DISC_INFO *disc_info;
  
    disc_info = m_dll->bd_get_disc_info(m_bd);
-@@ -349,6 +350,7 @@ bool CDVDInputStreamBluray::Open()
+@@ -350,6 +351,7 @@ bool CDVDInputStreamBluray::Open()
      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::Open - BD+ detected        : %d", disc_info->bdplus_detected);
      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::Open - libbdplus detected  : %d", disc_info->libbdplus_detected);
      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::Open - BD+ handled         : %d", disc_info->bdplus_handled);
@@ -48778,15 +48715,15 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    }
    else
      CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - BluRay not detected");
-@@ -365,6 +367,7 @@ bool CDVDInputStreamBluray::Open()
+@@ -366,6 +368,7 @@ bool CDVDInputStreamBluray::Open()
      return false;
    }
  
 +  m_nTitles = m_dll->bd_get_titles(m_bd, TITLES_RELEVANT, 0);
-   int mode = CSettings::GetInstance().GetInt(CSettings::SETTING_DISC_PLAYBACK);
+   int mode = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_DISC_PLAYBACK);
  
    if (URIUtils::HasExtension(filename, ".mpls"))
-@@ -393,18 +396,17 @@ bool CDVDInputStreamBluray::Open()
+@@ -394,18 +397,17 @@ bool CDVDInputStreamBluray::Open()
        m_title = GetTitleLongest();
    }
  
@@ -48809,7 +48746,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
      if(m_dll->bd_play(m_bd) <= 0)
      {
        CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed play disk %s", strPath.c_str());
-@@ -419,21 +421,25 @@ bool CDVDInputStreamBluray::Open()
+@@ -420,21 +422,25 @@ bool CDVDInputStreamBluray::Open()
        CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed to get title info");
        return false;
      }
@@ -48830,7 +48767,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    return true;
  }
  
- // close file and reset everyting
+ // close file and reset everything
  void CDVDInputStreamBluray::Close()
  {
 +  CloseMVCDemux();
@@ -48838,7 +48775,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    if (!m_dll)
      return;
    if(m_title)
-@@ -449,7 +455,7 @@ void CDVDInputStreamBluray::Close()
+@@ -450,7 +456,7 @@ void CDVDInputStreamBluray::Close()
  
  void CDVDInputStreamBluray::ProcessEvent() {
  
@@ -48847,7 +48784,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    switch (m_event.event) {
  
    case BD_EVENT_ERROR:
-@@ -514,15 +520,17 @@ void CDVDInputStreamBluray::ProcessEvent() {
+@@ -515,15 +521,17 @@ void CDVDInputStreamBluray::ProcessEvent() {
      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PLAYLIST %d",
          m_event.param);
      m_playlist = m_event.param;
@@ -48868,7 +48805,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
      break;
  
    case BD_EVENT_CHAPTER:
-@@ -601,14 +609,20 @@ void CDVDInputStreamBluray::ProcessEvent() {
+@@ -602,14 +610,20 @@ void CDVDInputStreamBluray::ProcessEvent() {
  
    /* event has been consumed */
    m_event.event = BD_EVENT_NONE;
@@ -48890,7 +48827,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
      do {
  
        if(m_hold == HOLD_HELD)
-@@ -658,10 +672,14 @@ int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
+@@ -659,10 +673,14 @@ int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
  
      } while(result == 0);
  
@@ -48907,7 +48844,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
  }
  
  static uint8_t  clamp(double v)
-@@ -909,8 +927,12 @@ bool CDVDInputStreamBluray::PosTime(int ms)
+@@ -910,8 +928,12 @@ bool CDVDInputStreamBluray::PosTime(int ms)
  {
    if(m_dll->bd_seek_time(m_bd, ms * 90) < 0)
      return false;
@@ -48922,7 +48859,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
  }
  
  int CDVDInputStreamBluray::GetChapterCount()
-@@ -933,8 +955,12 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
+@@ -934,8 +956,12 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
  {
    if(m_title && m_dll->bd_seek_chapter(m_bd, ch-1) < 0)
      return false;
@@ -48937,7 +48874,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
  }
  
  int64_t CDVDInputStreamBluray::GetChapterPos(int ch)
-@@ -1132,6 +1158,95 @@ bool CDVDInputStreamBluray::HasMenu()
+@@ -1133,6 +1159,95 @@ bool CDVDInputStreamBluray::HasMenu()
    return m_navmode;
  }
  
@@ -49032,7 +48969,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
 +
  void CDVDInputStreamBluray::SetupPlayerSettings()
  {
-   int region = CSettings::GetInstance().GetInt(CSettings::SETTING_BLURAY_PLAYERREGION);
+   int region = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_BLURAY_PLAYERREGION);
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
 index b967a85e6557e42a7f1235cdd804d5a0263b866f..561fb5cd4f971bc9ee4f41218a60bb3d5bc5625f 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -49086,10 +49023,10 @@ index b967a85e6557e42a7f1235cdd804d5a0263b866f..561fb5cd4f971bc9ee4f41218a60bb3d
    typedef std::shared_ptr<CDVDOverlayImage> SOverlay;
    typedef std::list<SOverlay>                 SOverlays;
 
-From ba23ff0a3563eb2bf120bf5b7b068120112448a8 Mon Sep 17 00:00:00 2001
+From a766c02769cc6506ec0d6392e4bd73b73ee1aa62 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Fri, 11 Mar 2016 16:58:53 +0300
-Subject: [PATCH 42/62] [VideoPlayer] HasVideo returns true if video stream
+Subject: [PATCH 43/61] [VideoPlayer] HasVideo returns true if video stream
  exists. This don't allow start visualization if audio is opened before video.
 
 ---
@@ -49097,10 +49034,10 @@ Subject: [PATCH 42/62] [VideoPlayer] HasVideo returns true if video stream
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayer.cpp b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-index dded334532841911a34d75808c3c350709d881f7..b9b0d866fe112d291a8d80a8269c3f572d254447 100644
+index 5945d06dea8af5ea841e58a0268e09ecd8d7d494..6e7edd237c9184bd8e812a72b18f48213c1f797e 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-@@ -3115,7 +3115,7 @@ void CVideoPlayer::Pause()
+@@ -3119,7 +3119,7 @@ void CVideoPlayer::Pause()
  
  bool CVideoPlayer::HasVideo() const
  {
@@ -49110,10 +49047,10 @@ index dded334532841911a34d75808c3c350709d881f7..b9b0d866fe112d291a8d80a8269c3f57
  
  bool CVideoPlayer::HasAudio() const
 
-From 6faee73797c05d2c8140c6c11c7eace3231ea20e Mon Sep 17 00:00:00 2001
+From c4eb7e656ed6b4c6a2325ec1d3d201a5a3ed15d1 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Thu, 10 Mar 2016 18:11:33 +0300
-Subject: [PATCH 43/62] fixup! Revert supporting crappy tab/sbs subtitles. this
+Subject: [PATCH 44/61] fixup! Revert supporting crappy tab/sbs subtitles. this
  fixes regular subtitles.
 
 ---
@@ -49150,10 +49087,10 @@ index 3a080d06c90b0762482816928642e6de7810b539..a8323f419e404037c4e5fb4d78fa1b45
      CDVDOverlayImage* overlay = new CDVDOverlayImage();
  
 
-From b9eb944c52a9e09bfa084f4bd8f8862f13ec6f7e Mon Sep 17 00:00:00 2001
+From a05d3dd9a2a8e28ac2e36a0e0b8dd270edfbaf70 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Thu, 7 Apr 2016 17:28:50 +0300
-Subject: [PATCH 44/62] [VideoPlayer] Disable reading extension stream from
+Subject: [PATCH 45/61] [VideoPlayer] Disable reading extension stream from
  input stream if decoder doesn't support it.
 
 ---
@@ -49186,10 +49123,10 @@ index a2da9de4375939f3711c594dc854b9a533c755b4..8101b6eeff0341a94736df7ee815dd4c
    CProcessInfo &m_processInfo;
  };
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index b7e5081bc0fc32eaaae42d894a288e7971139356..6ea1a19173e36d49f7391b6f350c8ae3173db7ff 100644
+index b80f44994dfbc9f4cac37f9cad7926c0d32371e2..99ad8f34770b175b0ac9d92c75d7b409d51b5fec 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -504,14 +504,14 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
+@@ -505,14 +505,14 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
  
    UpdateCurrentPTS();
  
@@ -49208,7 +49145,7 @@ index b7e5081bc0fc32eaaae42d894a288e7971139356..6ea1a19173e36d49f7391b6f350c8ae3
      }
    }
    // in case of mpegts and we have not seen pat/pmt, defer creation of streams
-@@ -1488,13 +1488,13 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1490,13 +1490,13 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
                pStream->codec->codec_tag = MKTAG('A', 'M', 'V', 'C');
  
                AVStream* mvcStream = nullptr;
@@ -49281,7 +49218,7 @@ index 508e9debd3e6679a1433842a65649fa68ead76ec..26cd97dddcae208afacfb241e96b4935
    std::queue<DemuxPacket*> m_MVCqueue;
    int m_h264StreamId = -1;
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
-index 932f0e4093c836453b07932df9075afc6f6e5ae5..7aee35cef8f42d080882e4bdd20a4a9ed234a8c2 100644
+index 3377d3f282d4e8cdeb10339e1aded5e3eb1edf1a..8e94436051e7b04ec11560057ecd64c5d08a7bcd 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
 @@ -57,6 +57,7 @@ namespace XFILE
@@ -49310,10 +49247,10 @@ index 932f0e4093c836453b07932df9075afc6f6e5ae5..7aee35cef8f42d080882e4bdd20a4a9e
    {
      NEXTSTREAM_NONE,
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-index ad2c65ba5b80c5ac5d055d621a1e8319e3f770c0..74e8e1fc2da66d3c98a5bab04faa2f6bf16539ff 100644
+index a2c59b137ebdb7a44aea4fe1216eb9a2f43c048c..cdc9039729993c5cd7d3af0b8ee8e5fc28a4a158 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-@@ -617,6 +617,13 @@ void CDVDInputStreamBluray::ProcessEvent() {
+@@ -618,6 +618,13 @@ void CDVDInputStreamBluray::ProcessEvent() {
    }
  }
  
@@ -49327,7 +49264,7 @@ index ad2c65ba5b80c5ac5d055d621a1e8319e3f770c0..74e8e1fc2da66d3c98a5bab04faa2f6b
  int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
  {
    int result = 0;
-@@ -1165,7 +1172,7 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
+@@ -1166,7 +1173,7 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
    
    m_title = m_dll->bd_get_playlist_info(m_bd, playitem, m_angle);
  
@@ -49371,7 +49308,7 @@ index 561fb5cd4f971bc9ee4f41218a60bb3d5bc5625f..f70657c9e31fb2460d12910c635dba51
  
    typedef std::shared_ptr<CDVDOverlayImage> SOverlay;
 diff --git a/xbmc/cores/VideoPlayer/IVideoPlayer.h b/xbmc/cores/VideoPlayer/IVideoPlayer.h
-index 0b676c9b611fe956f1aa721013412e41ff5b62f6..6762e733848d1298a75a862b0aaf81aa5690537d 100644
+index 689798245ca48676af7c34a3e3565ea70ebcf309..d076c118f0877be6e5adb79c75606dce7870487c 100644
 --- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
 +++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
 @@ -111,6 +111,7 @@ public:
@@ -49383,10 +49320,10 @@ index 0b676c9b611fe956f1aa721013412e41ff5b62f6..6762e733848d1298a75a862b0aaf81aa
  
  class CDVDAudioCodec;
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayer.cpp b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-index b9b0d866fe112d291a8d80a8269c3f572d254447..d74c03d1ef7e0146a57964376dbff190876a8598 100644
+index 6e7edd237c9184bd8e812a72b18f48213c1f797e..aca33a7e75c604eb292a669a44bfecbffda9b9b1 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-@@ -3891,6 +3891,10 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
+@@ -3895,6 +3895,10 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
      if (!player->OpenStream(hint))
        return false;
  
@@ -49410,10 +49347,10 @@ index 0d4100e58e9db7e5035bcf9ae23b0147f80cec8f..69570153f0810a5840f3780c7a6681a1
    // classes
    CDVDOverlayContainer* m_pOverlayContainer;
 
-From a5dcb2315b90a4868559d51964f9d59b69901773 Mon Sep 17 00:00:00 2001
+From 5f5c668483d88c37f2e652a599f0bd8211fede8d Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Fri, 16 Sep 2016 11:37:48 +0300
-Subject: [PATCH 45/62] [Settings] move SETTING_VIDEOPLAYER_SUPPORTMVC from
+Subject: [PATCH 46/61] [Settings] move SETTING_VIDEOPLAYER_SUPPORTMVC from
  platform settings to common settings.
 
 ---
@@ -49443,7 +49380,7 @@ index 2572e25753712186f69390965ee1448bff3fadd5..7098edf32dff8c00e192229c3ffb060b
    </section>
    <section id="media">
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 22dcff1c06577055f84c3d2c2fda73cfa16c53d4..eb610a8aaa795d2caeaf2ab12bcf61b1148524b4 100644
+index 068ca2d519cb7537e0d3ad05c83d47d341a34250..23b96cbb2463d6b4072b0f9333e0def0aaa446e1 100644
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
 @@ -343,6 +343,12 @@
@@ -49482,15 +49419,15 @@ index 2fcee72a64e8b701c8e895143410bbe9fd617356..a017d30c24232fb01220b87b29398403
      <category id="display">
        <group id="1">
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-index 74e8e1fc2da66d3c98a5bab04faa2f6bf16539ff..7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822 100644
+index cdc9039729993c5cd7d3af0b8ee8e5fc28a4a158..e1f0240124bf7777b755f5a39cbb32e354dabd50 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-@@ -1172,7 +1172,7 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
+@@ -1173,7 +1173,7 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
    
    m_title = m_dll->bd_get_playlist_info(m_bd, playitem, m_angle);
  
 -  if (CSettings::GetInstance().GetBool("videoplayer.supportmvc") && !m_bMVCDisabled)
-+  if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC) && !m_bMVCDisabled)
++  if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC) && !m_bMVCDisabled)
    {
      MPLS_PL * mpls = m_dll->bd_get_title_mpls(m_bd);
      if (mpls)
@@ -49509,10 +49446,10 @@ index 6b1f2b6d757354d6065c2862b44dfb47184a1dcc..9163ec85bd0feb48a698a025d9870bf4
    m_simpleConditions.insert("have_lcms2");
  #endif
 
-From b5a7b94739f0da0c2de4e33a3fff027c412d93f6 Mon Sep 17 00:00:00 2001
+From 6b0b450bf2127f3acd8c0fda67bb4227ea5c666b Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Fri, 4 Nov 2016 22:56:56 +0300
-Subject: [PATCH 46/62] [VideoPlayer] SSIF: fix for corner case when mvc stream
+Subject: [PATCH 47/61] [VideoPlayer] SSIF: fix for corner case when mvc stream
  is switched before the last packet is read from previous stream.
 
 ---
@@ -49524,10 +49461,10 @@ Subject: [PATCH 46/62] [VideoPlayer] SSIF: fix for corner case when mvc stream
  5 files changed, 45 insertions(+), 10 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 6ea1a19173e36d49f7391b6f350c8ae3173db7ff..9149698884c8ae6a23649abbaa0e659587dfe982 100644
+index 99ad8f34770b175b0ac9d92c75d7b409d51b5fec..179a287d1cec04686b30fdee1ef8f1770b0f9f8d 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -1120,9 +1120,6 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
+@@ -1121,9 +1121,6 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
    m_pkt.result = -1;
    av_packet_unref(&m_pkt.pkt);
  
@@ -49537,7 +49474,7 @@ index 6ea1a19173e36d49f7391b6f350c8ae3173db7ff..9149698884c8ae6a23649abbaa0e6595
    CDVDInputStream::IPosTime* ist = m_pInput->GetIPosTime();
    if (ist)
    {
-@@ -1136,6 +1133,8 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
+@@ -1137,6 +1134,8 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
  
      return true;
    }
@@ -49569,7 +49506,7 @@ index 7c8719ce40e725e27b7551250398022a1f1a4fc6..c675e31f731bc6afb8aabc37bbb5495a
 +  return true;
  }
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
-index 7aee35cef8f42d080882e4bdd20a4a9ed234a8c2..ea138f95bac915a946800f6bc7b964bd928e1a89 100644
+index 8e94436051e7b04ec11560057ecd64c5d08a7bcd..1637be9496814b6129c349ffeccd7450a8a62aca 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
 @@ -140,6 +140,7 @@ public:
@@ -49581,10 +49518,10 @@ index 7aee35cef8f42d080882e4bdd20a4a9ed234a8c2..ea138f95bac915a946800f6bc7b964bd
  
    enum ENextStream
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952fa9a5f261 100644
+index e1f0240124bf7777b755f5a39cbb32e354dabd50..aaba0e70c3ac2bf2f93046be5139b15ab3e613c0 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-@@ -48,6 +48,7 @@
+@@ -49,6 +49,7 @@
  #endif
  
  #define LIBBLURAY_BYTESEEK 0
@@ -49592,7 +49529,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
  
  using namespace XFILE;
  
-@@ -432,6 +433,8 @@ bool CDVDInputStreamBluray::Open()
+@@ -433,6 +434,8 @@ bool CDVDInputStreamBluray::Open()
    while (m_dll->bd_get_event(m_bd, &m_event))
      ProcessEvent();
  
@@ -49601,7 +49538,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
    return true;
  }
  
-@@ -610,10 +613,14 @@ void CDVDInputStreamBluray::ProcessEvent() {
+@@ -611,10 +614,14 @@ void CDVDInputStreamBluray::ProcessEvent() {
    /* event has been consumed */
    m_event.event = BD_EVENT_NONE;
  
@@ -49619,7 +49556,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
    }
  }
  
-@@ -935,10 +942,15 @@ bool CDVDInputStreamBluray::PosTime(int ms)
+@@ -936,10 +943,15 @@ bool CDVDInputStreamBluray::PosTime(int ms)
    if(m_dll->bd_seek_time(m_bd, ms * 90) < 0)
      return false;
  
@@ -49636,7 +49573,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
    return true;
  }
  
-@@ -963,10 +975,15 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
+@@ -964,10 +976,15 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
    if(m_title && m_dll->bd_seek_chapter(m_bd, ch-1) < 0)
      return false;
  
@@ -49653,7 +49590,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
    return true;
  }
  
-@@ -1196,6 +1213,18 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
+@@ -1197,6 +1214,18 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
    return true;
  }
  
@@ -49701,17 +49638,17 @@ index f70657c9e31fb2460d12910c635dba5163282e74..a11ec77903d2a9b2c68106a8e2301af9
    typedef std::shared_ptr<CDVDOverlayImage> SOverlay;
    typedef std::list<SOverlay>                 SOverlays;
 
-From 68303efd88570df113b4e6d4816255f671ff02ef Mon Sep 17 00:00:00 2001
+From 7db6b6f6183ddef5f8eaea8cddd2237375ea8808 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Tue, 23 Feb 2016 16:01:08 +0300
-Subject: [PATCH 47/62] [libbluray] bump libbluray to 0.9.2-mvc.
+Subject: [PATCH 48/61] [libbluray] bump libbluray to 0.9.2-mvc.
 
 ---
  project/BuildDependencies/scripts/0_package.list | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/project/BuildDependencies/scripts/0_package.list b/project/BuildDependencies/scripts/0_package.list
-index e6c608023a46d377ef520bf23e9863ee0350d980..f8db70ab3861835f33f0e4be79cf3d193093a45f 100644
+index 3f7112408c343b9da967e340ba069c447e91809f..3be6ce2f8362e3f5eb834971936827911abdbebe 100644
 --- a/project/BuildDependencies/scripts/0_package.list
 +++ b/project/BuildDependencies/scripts/0_package.list
 @@ -17,7 +17,7 @@ freetype-2.6.3-win32-vc140.7z
@@ -49721,13 +49658,13 @@ index e6c608023a46d377ef520bf23e9863ee0350d980..f8db70ab3861835f33f0e4be79cf3d19
 -libbluray-0.9.3-win32-vc140.7z
 +libbluray-0.9.2-mvc-win32-vc120.7z
  libcdio-0.9.3-win32-vc140.7z
- libcec-4.0.0-win32-vc140-2.7z
+ libcec-4.0.1-win32-vc140-2.7z
  libfribidi-0.19.2-win32.7z
 
-From 535c34fdcb4be388fa3554b364f3dcaebac7ef19 Mon Sep 17 00:00:00 2001
+From c91ccfd0efc0858195d640f396702cde1b0eb703 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 29 Feb 2016 17:00:50 +0000
-Subject: [PATCH 48/62] libbluray: Bump to Nevcairie's v0.9.2
+Subject: [PATCH 49/61] libbluray: Bump to Nevcairie's v0.9.2
 
 This includes 3D support
 ---
@@ -51384,10 +51321,10 @@ index 0000000000000000000000000000000000000000..5ef0124e35c9d81143921a328e272220
 + 
 +     return fp;
 
-From 10e05003e7721f2e77e20c286b1849c22ef1e5f6 Mon Sep 17 00:00:00 2001
+From 589b1b580b156086f6c3c484a2cccb0dac6bb9b3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 6 Mar 2016 12:54:59 +0000
-Subject: [PATCH 49/62] mvc: Automatically enable stereo mode
+Subject: [PATCH 50/61] mvc: Automatically enable stereo mode
 
 ---
  xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp | 6 +++++-
@@ -51395,10 +51332,10 @@ Subject: [PATCH 49/62] mvc: Automatically enable stereo mode
  2 files changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-index c43952d4d29b42f3a5c7605573294568f79ca010..68459e35bc2cda048c150c7079fb30eb0ffb823c 100644
+index 4f07113ade696aa4bbefb2dd2a2e17d5f12e9ab9..ce4a849a71468ab89c16cd6e5207a88ee22567c4 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-@@ -403,13 +403,17 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+@@ -401,13 +401,17 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
    switch (hints.codec)
    {
      case AV_CODEC_ID_H264:
@@ -51406,9 +51343,9 @@ index c43952d4d29b42f3a5c7605573294568f79ca010..68459e35bc2cda048c150c7079fb30eb
        // H.264
        m_codingType = MMAL_ENCODING_H264;
        m_pFormatName = "mmal-h264";
--      if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
+-      if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
 +      if ((hints.codec_tag == MKTAG('M', 'V', 'C', '1') || hints.codec_tag == MKTAG('A', 'M', 'V', 'C')) &&
-+        CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
++        CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
        {
          m_codingType = MMAL_ENCODING_MVC;
          m_pFormatName= "mmal-mvc";
@@ -51418,10 +51355,10 @@ index c43952d4d29b42f3a5c7605573294568f79ca010..68459e35bc2cda048c150c7079fb30eb
      break;
      case AV_CODEC_ID_H263:
 diff --git a/xbmc/cores/omxplayer/OMXVideo.cpp b/xbmc/cores/omxplayer/OMXVideo.cpp
-index 311dd6689236d660919c4c4483c51dca2752514a..536332c43e22ccb229e72b88518e54dd8a23ac41 100644
+index 2e26a6eef7335a5d0baf39313434ac786c66631b..c6aceaadd0a73d170b4024ea5ab54442197bbc5a 100644
 --- a/xbmc/cores/omxplayer/OMXVideo.cpp
 +++ b/xbmc/cores/omxplayer/OMXVideo.cpp
-@@ -398,6 +398,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
+@@ -397,6 +397,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
    switch (hints.codec)
    {
      case AV_CODEC_ID_H264:
@@ -51429,13 +51366,13 @@ index 311dd6689236d660919c4c4483c51dca2752514a..536332c43e22ccb229e72b88518e54dd
      {
        switch(hints.profile)
        {
-@@ -434,10 +435,13 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
+@@ -433,10 +434,13 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
            break;
        }
      }
--    if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
+-    if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
 +    if ((hints.codec_tag == MKTAG('M', 'V', 'C', '1') || hints.codec_tag == MKTAG('A', 'M', 'V', 'C')) &&
-+      CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
++      CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
      {
        m_codingType = OMX_VIDEO_CodingMVC;
        m_video_codec_name = "omx-mvc";
@@ -51445,10 +51382,10 @@ index 311dd6689236d660919c4c4483c51dca2752514a..536332c43e22ccb229e72b88518e54dd
      break;
      case AV_CODEC_ID_MPEG4:
 
-From 1707fe3577c485f641a9b44974bdd72658f2ba05 Mon Sep 17 00:00:00 2001
+From 1194161559a1433e3c10e0a00873ecf7aaccb97f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 24 Mar 2016 13:02:58 +0000
-Subject: [PATCH 50/62] ffmpeg: mvc: fix for pixelation from packets with no
+Subject: [PATCH 51/61] ffmpeg: mvc: fix for pixelation from packets with no
  pts/dts
 
 ---
@@ -51510,36 +51447,31 @@ index 7e97e4d91a443d46d933df528763422ff5e8f4fa..d4f279fd4f2ceb260698cd6fedb124ba
  	cd $(PLATFORM);\
  	CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" \
 
-From 0043ac6433c7b39bbf2eb1da01b83ffc491faf07 Mon Sep 17 00:00:00 2001
+From 6cb54f2a61ece80aac8c12d8aa39cf4633e755d5 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 11 Nov 2016 15:53:53 +0000
-Subject: [PATCH 51/62] stereoscopicmanager: fixups for rbp
+Subject: [PATCH 52/61] stereoscopicmanager: fixups for rbp
 
 ---
  xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp | 61 ++++++++++++++++++++++
  xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.h   |  4 ++
  .../VideoPlayer/DVDCodecs/Video/MMALCodec.cpp      |  9 +++-
  xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h |  1 +
- xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in     |  2 +-
  xbmc/cores/omxplayer/OMXPlayerVideo.cpp            |  5 ++
  xbmc/cores/omxplayer/OMXPlayerVideo.h              |  1 +
  xbmc/cores/omxplayer/OMXVideo.cpp                  |  2 +-
  xbmc/guilib/StereoscopicsManager.cpp               |  3 ++
- 9 files changed, 84 insertions(+), 4 deletions(-)
+ 8 files changed, 83 insertions(+), 3 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
-index ac4e063460a39888a1a1113aab37b74cbf0a0766..0d88acfb85333e88b3774144499eb4421abc4566 100644
+index 02fb028daace723fca008a19c1160113b958103f..10e05249cde619a9f5d229fe0ac45b6561236c72 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
-@@ -24,6 +24,7 @@
+@@ -24,9 +24,11 @@
  #include "utils/log.h"
  #include "cores/FFmpeg.h"
  #include "Util.h"
 +#include <assert.h>
- 
- #ifdef TARGET_WINDOWS
- #pragma comment(lib, "avcodec.lib")
-@@ -37,6 +38,7 @@
  
  extern "C" {
  #include "libswscale/swscale.h"
@@ -51547,7 +51479,7 @@ index ac4e063460a39888a1a1113aab37b74cbf0a0766..0d88acfb85333e88b3774144499eb442
  }
  
  // allocate a new picture (AV_PIX_FMT_YUV420P)
-@@ -402,6 +404,65 @@ double CDVDCodecUtils::NormalizeFrameduration(double frameduration, bool *match)
+@@ -392,6 +394,65 @@ double CDVDCodecUtils::NormalizeFrameduration(double frameduration, bool *match)
    }
  }
  
@@ -51636,26 +51568,26 @@ index 361c96623660305fc393273b1eaea4db096c417d..8ec50bbf79e9e163ccae25e30f3a40bf
    static AVPixelFormat PixfmtFromEFormat(ERenderFormat format);
  };
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-index 68459e35bc2cda048c150c7079fb30eb0ffb823c..dca872373080156100618d58d9782e2461fa2648 100644
+index ce4a849a71468ab89c16cd6e5207a88ee22567c4..4ad4c169034c492f67c5efe68212ad1a772a8d7c 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-@@ -362,6 +362,11 @@ bool CMMALVideo::SendCodecConfigData()
+@@ -360,6 +360,11 @@ bool CMMALVideo::SendCodecConfigData()
    return true;
  }
  
 +bool CMMALVideo::SupportsExtention()
 +{
-+  return CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC);
++  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC);
 +}
 +
  bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
  {
    CSingleLock lock(m_sharedSection);
-@@ -408,12 +413,12 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+@@ -406,12 +411,12 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
        m_codingType = MMAL_ENCODING_H264;
        m_pFormatName = "mmal-h264";
        if ((hints.codec_tag == MKTAG('M', 'V', 'C', '1') || hints.codec_tag == MKTAG('A', 'M', 'V', 'C')) &&
--        CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
+-        CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
 +          SupportsExtention())
        {
          m_codingType = MMAL_ENCODING_MVC;
@@ -51678,30 +51610,17 @@ index baff1f031149da5d669536711cc0057b2db078e3..1e49f09574c2a93b938d5eb405ebcb06
  
    // MMAL decoder callback routines.
    void dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
-diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-index 0359426b85683a4c3a80ef0e0d52f7a79564daaa..7d19ec3c56fdea514628d27cf36e641707be030f 100644
---- a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-@@ -11,7 +11,7 @@ SRCS += DVDDemuxVobsub.cpp
- SRCS += DVDDemuxCC.cpp
- SRCS += DVDFactoryDemuxer.cpp
- SRCS += DemuxStreamSSIF.cpp
--SRCS += DVDDemuxMVC.cpp
-+SRCS += DemuxMVC.cpp
- 
- LIB = DVDDemuxers.a
- 
 diff --git a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
-index f6fb241dfec9269f4e501248de4dc83d5fdc2d3a..58ad6672e3351edbec537ad5b142ff14cb7389ea 100644
+index d308e44e26baae1a56127b55b987c28c384a9b63..57f0076714ec0c3a2b66d21870bd9644cbfe6ff6 100644
 --- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
 +++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
-@@ -111,6 +111,11 @@ OMXPlayerVideo::~OMXPlayerVideo()
+@@ -110,6 +110,11 @@ OMXPlayerVideo::~OMXPlayerVideo()
    CloseStream(false);
  }
  
 +bool OMXPlayerVideo::SupportsExtention() const
 +{
-+  return CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC);
++  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC);
 +}
 +
  bool OMXPlayerVideo::OpenStream(CDVDStreamInfo &hints)
@@ -51720,10 +51639,10 @@ index b5050081c360d29b1b478c27e6b88291e20ecdac..c880fa6bbb128b99f8a5393056586821
    void CloseStream(bool bWaitForBuffers);
    void Output(double pts, bool bDropPacket);
 diff --git a/xbmc/cores/omxplayer/OMXVideo.cpp b/xbmc/cores/omxplayer/OMXVideo.cpp
-index 536332c43e22ccb229e72b88518e54dd8a23ac41..39bc0530cecd54ae8c3a5481c92f1a6a18a4d9c5 100644
+index c6aceaadd0a73d170b4024ea5ab54442197bbc5a..ea11757bfc7ab3ebfbd5b46176c4a91097b765c4 100644
 --- a/xbmc/cores/omxplayer/OMXVideo.cpp
 +++ b/xbmc/cores/omxplayer/OMXVideo.cpp
-@@ -441,7 +441,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
+@@ -440,7 +440,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
        m_codingType = OMX_VIDEO_CodingMVC;
        m_video_codec_name = "omx-mvc";
        if (hints.stereo_mode == "mono")
@@ -51733,10 +51652,10 @@ index 536332c43e22ccb229e72b88518e54dd8a23ac41..39bc0530cecd54ae8c3a5481c92f1a6a
      break;
      case AV_CODEC_ID_MPEG4:
 diff --git a/xbmc/guilib/StereoscopicsManager.cpp b/xbmc/guilib/StereoscopicsManager.cpp
-index 6aaa82f4d883b8cae0ccdedf6c5a6814e7aaa720..cc929b599125a44ac128713fd4331782d9931791 100644
+index 041324c51977ce880ab365a16f1ac366c79e369c..7d5999245939c0d9e27a110008e0f2747ca3b696 100644
 --- a/xbmc/guilib/StereoscopicsManager.cpp
 +++ b/xbmc/guilib/StereoscopicsManager.cpp
-@@ -70,10 +70,13 @@ static const struct StereoModeMap VideoModeToGuiModeMap[] =
+@@ -71,10 +71,13 @@ static const struct StereoModeMap VideoModeToGuiModeMap[] =
    { "anaglyph_cyan_red",        RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN },
    { "anaglyph_green_magenta",   RENDER_STEREO_MODE_ANAGLYPH_GREEN_MAGENTA },
    { "anaglyph_yellow_blue",     RENDER_STEREO_MODE_ANAGLYPH_YELLOW_BLUE },
@@ -51751,10 +51670,10 @@ index 6aaa82f4d883b8cae0ccdedf6c5a6814e7aaa720..cc929b599125a44ac128713fd4331782
  };
  
 
-From 56bda93bf04b76e40175db4eebfe7fa26585b90b Mon Sep 17 00:00:00 2001
+From 6c576963fab8be163c237cd54678767eb413b7cd Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Thu, 10 Mar 2016 18:11:33 +0300
-Subject: [PATCH 52/62] fixup! Revert supporting crappy tab/sbs subtitles. this
+Subject: [PATCH 53/61] fixup! Revert supporting crappy tab/sbs subtitles. this
  fixes regular subtitles.
 
 ---
@@ -51774,10 +51693,10 @@ index a8323f419e404037c4e5fb4d78fa1b45409337a7..7c0b70777556ac7694e7fc511cd4bb18
    }
  
 
-From 40f9ac9217dbe0a5f3ea5d7e8f6b36f79d9455fe Mon Sep 17 00:00:00 2001
+From 7cc401c109aa894d9ee749cdd4ab4a5ed871d8e0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 26 Nov 2016 18:24:18 +0000
-Subject: [PATCH 53/62] DemuxMVC: fixup after SeekTime API change
+Subject: [PATCH 54/61] DemuxMVC: fixup after SeekTime API change
 
 ---
  xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMVC.cpp | 2 +-
@@ -51811,91 +51730,37 @@ index bbb836a61344689a83af68c821c05c212a86b097..54f91a02391368fbfbb4d669c003f425
    virtual int GetStreamLength() { return 0; };
    virtual CDemuxStream* GetStream(int iStreamId) const override { return nullptr; };
 
-From 07af63a05c028937005d37d901c1e3be4aaa8784 Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Mon, 3 Nov 2014 23:17:46 +0000
-Subject: [PATCH 54/62] [cec] Don't discard buttons when repeat mode is enabled
+From 13f6754f8a6695d6c04422545b7a5219ece815b3 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Tue, 22 Mar 2016 09:51:52 +0100
+Subject: [PATCH 55/61] python: use kodi provided cert if available
 
 ---
- xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 5 ++++-
- 1 file changed, 4 insertions(+), 1 deletion(-)
+ xbmc/interfaces/python/XBPython.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
-diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-index 30367a3fde956090afdca9930fa52e829f35046f..febacb3b7964eab3b8615a6a807e0f27d911b4da 100644
---- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-@@ -803,7 +803,10 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
-   CLog::Log(LOGDEBUG, "%s - received key %2x duration %d", __FUNCTION__, key.iButton, key.iDuration);
+diff --git a/xbmc/interfaces/python/XBPython.cpp b/xbmc/interfaces/python/XBPython.cpp
+index cd6033a9f16233aeec3fcb2c4d3144c3b31f1ac5..e55e336fd9e434a3840fd99c99cc5a3381f818fd 100644
+--- a/xbmc/interfaces/python/XBPython.cpp
++++ b/xbmc/interfaces/python/XBPython.cpp
+@@ -591,6 +591,12 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
+     CEnvironment::putenv(buf);
+ #endif
  
-   CSingleLock lock(m_critSection);
--  if (key.iDuration > 0)
-+  // avoid the queue getting too long
-+  if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
-+    return;
-+  if (m_configuration.iButtonRepeatRateMs == 0 && key.iDuration > 0)
-   {
-     if (m_currentButton.iButton == key.iButton && m_currentButton.iDuration == 0)
-     {
++#if !defined(TARGET_WINDOWS)
++    // use Kodi provided cert if available
++    if (XFILE::CFile::Exists("special://xbmc/system/certs/cacert.pem"))
++      setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
++#endif
++
+     if (PyEval_ThreadsInitialized())
+       PyEval_AcquireLock();
+     else
 
-From 4066e9289576eb4def863476331d73d081f9ac85 Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Tue, 4 Nov 2014 18:50:00 +0000
-Subject: [PATCH 55/62] [cec] Temp - more logging
-
----
- xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 8 +++++++-
- 1 file changed, 7 insertions(+), 1 deletion(-)
-
-diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-index febacb3b7964eab3b8615a6a807e0f27d911b4da..52d6e6a7ab68ce91faf5a3881b23ea7adde96cb8 100644
---- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-@@ -800,12 +800,15 @@ void CPeripheralCecAdapter::GetNextKey(void)
- 
- void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
- {
--  CLog::Log(LOGDEBUG, "%s - received key %2x duration %d", __FUNCTION__, key.iButton, key.iDuration);
-+  CLog::Log(LOGDEBUG, "%s - received key %2x duration %d (rep:%d size:%d)", __FUNCTION__, key.iButton, key.iDuration, m_configuration.iButtonRepeatRateMs, m_buttonQueue.size());
- 
-   CSingleLock lock(m_critSection);
-   // avoid the queue getting too long
-   if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
-+  {
-+    CLog::Log(LOGDEBUG, "%s - discarded key %2x", __FUNCTION__, key.iButton);
-     return;
-+  }
-   if (m_configuration.iButtonRepeatRateMs == 0 && key.iDuration > 0)
-   {
-     if (m_currentButton.iButton == key.iButton && m_currentButton.iDuration == 0)
-@@ -814,6 +817,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
-       if (m_bHasButton)
-         m_currentButton.iDuration = key.iDuration;
-       // ignore this one, since it's already been handled by xbmc
-+      CLog::Log(LOGDEBUG, "%s - ignored key %2x", __FUNCTION__, key.iButton);
-       return;
-     }
-     // if we received a keypress with a duration set, try to find the same one without a duration set, and replace it
-@@ -824,6 +828,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
-         if ((*it).iDuration == 0)
-         {
-           // replace this entry
-+          CLog::Log(LOGDEBUG, "%s - replaced key %2x", __FUNCTION__, key.iButton);
-           (*it).iDuration = key.iDuration;
-           return;
-         }
-@@ -833,6 +838,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
-     }
-   }
- 
-+  CLog::Log(LOGDEBUG, "%s - added key %2x", __FUNCTION__, key.iButton);
-   m_buttonQueue.push_back(key);
- }
- 
-
-From 9771f5dd741a349b93481848ea2be760106755bc Mon Sep 17 00:00:00 2001
+From 73d68e4bda6d8083c8a4753e2356015c540a63dd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 25 May 2016 18:31:17 +0100
-Subject: [PATCH 56/62] rbp: Hard code the number of buffers to improve audio
+Subject: [PATCH 56/61] rbp: Hard code the number of buffers to improve audio
  sync
 
 ---
@@ -51921,15 +51786,15 @@ index 7098edf32dff8c00e192229c3ffb060be6a42482..0ce6735e11fabd1d07a4860b9d985a4e
      <category id="audio">
        <group id="1">
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
-index 8626a1b449ff0963089f6a7ad191a6c99512521a..53fc987b4ebb0555a804477bfb5b1d8443a98bcd 100644
+index 5feee388bb3a433ea6a35b29e587ab6447c089a5..5d2071ee724fb2f7ba04f96832c89de52d9354f2 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
-@@ -1067,7 +1067,11 @@ void CRenderManager::UpdateDisplayLatency()
+@@ -1070,7 +1070,11 @@ void CRenderManager::UpdateDisplayLatency()
      refresh = 0; // No idea about refresh rate when windowed, just get the default latency
    m_displayLatency = (double) g_advancedSettings.GetDisplayLatency(refresh);
  
 +#ifdef TARGET_RASPBERRY_PI
-+  int buffers = CSettings::GetInstance().GetBool("videoplayer.usedisplayasclock") ? 1:2;
++  int buffers = CServiceBroker::GetSettings().GetBool("videoplayer.usedisplayasclock") ? 1:2;
 +#else
    int buffers = g_Windowing.NoOfBuffers();
 +#endif
@@ -51937,10 +51802,10 @@ index 8626a1b449ff0963089f6a7ad191a6c99512521a..53fc987b4ebb0555a804477bfb5b1d84
  
  }
 
-From 77b9beb43349ae1335090f53d2a4d4f08aff928e Mon Sep 17 00:00:00 2001
+From bbda95f3c3cc2384033ff525f8d384a876c16a5f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 4 Jul 2016 18:30:03 +0100
-Subject: [PATCH 57/62] rbp: Update the GL libs to new naming scheme
+Subject: [PATCH 57/61] rbp: Update the GL libs to new naming scheme
 
 As the opensource mesa GL library is getting more usable, the name collision wih the firmware GL driver is causing issues.
 As such we are renaming the firmware GL driver to avoid this.
@@ -51948,28 +51813,14 @@ As such we are renaming the firmware GL driver to avoid this.
 The new names are libbrcmEGL.so and libbrcmGLESv2.so. Both will be supported for some time, but the original name
 will be dropped at some point
 ---
- configure.ac                             | 2 +-
- project/cmake/modules/FindOpenGLES.cmake | 6 +++---
- tools/depends/configure.ac               | 2 +-
- 3 files changed, 5 insertions(+), 5 deletions(-)
+ cmake/modules/FindOpenGLES.cmake | 6 +++---
+ tools/depends/configure.ac       | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/configure.ac b/configure.ac
-index d2186cbda52213aa85b5734b6c8f45a69e5e2e20..75e264b24629480880d4ea758c25db26c754bc9b 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -949,7 +949,7 @@ if test "$use_gles" = "yes"; then
-       AC_DEFINE([HAVE_LIBEGL],[1],["Define to 1 if you have the `EGL' library (-lEGL)."])
-       AC_DEFINE([HAVE_LIBGLESV2],[1],["Define to 1 if you have the `GLESv2' library (-lGLESv2)."])
-       AC_MSG_RESULT(== WARNING: OpenGLES support is assumed.)
--      LIBS="$LIBS -lEGL -lGLESv2 -lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
-+      LIBS="$LIBS -lbrcmEGL -lbrcmGLESv2 -lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
-     else
-       AC_CHECK_LIB([EGL],   [main],, AC_MSG_ERROR($missing_library))
-       AC_CHECK_LIB([GLESv2],[main],, AC_MSG_ERROR($missing_library))
-diff --git a/project/cmake/modules/FindOpenGLES.cmake b/project/cmake/modules/FindOpenGLES.cmake
+diff --git a/cmake/modules/FindOpenGLES.cmake b/cmake/modules/FindOpenGLES.cmake
 index ab06f968b3e314fca1ae001139f687dce9a5098b..87f1faa248b91a2e50758b23c0b9e5b09e4a69ff 100644
---- a/project/cmake/modules/FindOpenGLES.cmake
-+++ b/project/cmake/modules/FindOpenGLES.cmake
+--- a/cmake/modules/FindOpenGLES.cmake
++++ b/cmake/modules/FindOpenGLES.cmake
 @@ -13,7 +13,7 @@
  find_package(EMBEDDED)
  
@@ -51992,7 +51843,7 @@ index ab06f968b3e314fca1ae001139f687dce9a5098b..87f1faa248b91a2e50758b23c0b9e5b0
  else()
    find_library(OPENGLES_gl_LIBRARY NAMES OpenGLES
 diff --git a/tools/depends/configure.ac b/tools/depends/configure.ac
-index 3626ea5204eb561dc1ae0b64c6bb7253d2ec59ec..100ff3178bafe7434bd5456100b5bb7189a5378d 100644
+index ac2ac3cf689ec0eb68877d4149c9d3f856e9145c..1c8fd284c2d59170003f274d2c0cec04dd4c2118 100644
 --- a/tools/depends/configure.ac
 +++ b/tools/depends/configure.ac
 @@ -433,7 +433,7 @@ if test "$target_platform" = "raspberry-pi" ; then
@@ -52005,20 +51856,20 @@ index 3626ea5204eb561dc1ae0b64c6bb7253d2ec59ec..100ff3178bafe7434bd5456100b5bb71
  fi
  
 
-From 16d9562395384270f1dca8ef062d0048b08ca2dc Mon Sep 17 00:00:00 2001
+From 4ca1a69b69e4aac2f1063abffb5c3b819d8fea2f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 28 Jun 2016 14:46:01 +0100
-Subject: [PATCH 58/62] ffmpeg: hacky fix for files with GMC
+Subject: [PATCH 58/61] ffmpeg: hacky fix for files with GMC
 
 ---
  xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 9149698884c8ae6a23649abbaa0e659587dfe982..84d515e9e2df6a4c1c448a52a42f4675deab7991 100644
+index 179a287d1cec04686b30fdee1ef8f1770b0f9f8d..1453fb7f281609598e57afdc5e162f5ebfbbecd3 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -1458,8 +1458,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1460,8 +1460,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
            stereoMode = GetStereoModeFromMetadata(m_pFormatContext->metadata);
          if (!stereoMode.empty())
            st->stereo_mode = stereoMode;
@@ -52030,10 +51881,10 @@ index 9149698884c8ae6a23649abbaa0e659587dfe982..84d515e9e2df6a4c1c448a52a42f4675
          {
            if (pStream->codec->codec_id == AV_CODEC_ID_PROBE)
 
-From 7d20983a4ed4a55b9e465ae121dc621a4527464a Mon Sep 17 00:00:00 2001
+From 32bd86312d3629acf595f6356f641e55523cc8cd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 19 Jul 2016 20:39:18 +0100
-Subject: [PATCH 59/62] mmalrender: Add sharpness control
+Subject: [PATCH 59/61] mmalrender: Add sharpness control
 
 ---
  addons/resource.language.en_gb/resources/strings.po         |  2 +-
@@ -52042,10 +51893,10 @@ Subject: [PATCH 59/62] mmalrender: Add sharpness control
  3 files changed, 14 insertions(+), 2 deletions(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index 7c7969d381bf15ac1ba2fd8f16e463f6b12fe4c3..45cf0830ea6079a0f2ad22792f2497c5ad53b625 100644
+index a4607cfa2f6c41e2cc0a7b8fa8ee257a917be0c3..e8620bc41a530f0393e154010716e1eba899581e 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -8694,7 +8694,7 @@ msgstr ""
+@@ -8739,7 +8739,7 @@ msgstr ""
  
  #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
  msgctxt "#16313"
@@ -52055,7 +51906,7 @@ index 7c7969d381bf15ac1ba2fd8f16e463f6b12fe4c3..45cf0830ea6079a0f2ad22792f2497c5
  
  #empty string with id 16314
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
-index 84953d116610e9fd262de968ffe26d6063a9193b..f5f0f0d01227b3b4dcebb4a22a54dbcaac2d5ee9 100644
+index 213c46345d5eebc4046619821526f6684db131dd..a234de11322599e042febd9a4945dd150dac3921 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
 @@ -411,6 +411,7 @@ CMMALRenderer::CMMALRenderer() : CThread("MMALRenderer"), m_processThread(this,
@@ -52105,20 +51956,20 @@ index e0e6f7c0e0546013ca74265aef54704fd332f8e4..69eae6cbef0131d20dc979dcb35915cd
    CCriticalSection m_sharedSection;
    MMAL_COMPONENT_T *m_vout;
 
-From 4767086e68edac21dc112be1262e38c5c83d1aea Mon Sep 17 00:00:00 2001
+From c43bd26a8d45cca4fdad21e8fce5cc890e224589 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 14 Oct 2016 15:37:53 +0100
-Subject: [PATCH 60/62] MMALFFMpeg: Report as SW decode in codec overlay info
+Subject: [PATCH 60/61] MMALFFMpeg: Report as SW decode in codec overlay info
 
 ---
  xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-index 619515c9411172261d8f0bef24c5d679c35e5d7d..b31c984c0a507891f2754146a4c62802f0096505 100644
+index c4eda5a2c78db1f6acc9ed59938ea3f42262d8fe..a5e14e6ec5ff9a78e7342b30109e68ed8d81a54b 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-@@ -579,7 +579,7 @@ void CDVDVideoCodecFFmpeg::UpdateName()
+@@ -577,7 +577,7 @@ void CDVDVideoCodecFFmpeg::UpdateName()
    if(m_pHardware)
      m_name += "-" + m_pHardware->Name();
  
@@ -52128,156 +51979,28 @@ index 619515c9411172261d8f0bef24c5d679c35e5d7d..b31c984c0a507891f2754146a4c62802
    CLog::Log(LOGDEBUG, "CDVDVideoCodecFFmpeg - Updated codec: %s", m_name.c_str());
  }
 
-From bc4cb4cb7618aecf4735f783e5ef97f0cae72d83 Mon Sep 17 00:00:00 2001
+From 211c99d6161b48b242ccc183db380e7ce2710fa0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
-Date: Mon, 7 Nov 2016 18:28:01 +0000
-Subject: [PATCH 61/62] advancedsettings: Add option to set cache size on
- libass
+Date: Thu, 1 Dec 2016 17:06:01 +0000
+Subject: [PATCH 61/61] MMALRender: Allow advanced deinterlace with software
+ decode
 
-E.g to set total cache size in libass to 32M
-
-<advancedsettings>
-    <libasscache>32</libasscache>
-</advancedsettings>
-
-When unset it defaults to 192M
+Uses YUV420 directly which improves performance.
+Requires updated firmware
 ---
- xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp | 3 +++
- xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h            | 3 +++
- xbmc/settings/AdvancedSettings.cpp                         | 5 +++++
- xbmc/settings/AdvancedSettings.h                           | 2 ++
- 4 files changed, 13 insertions(+)
+ xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
-index 0f5e1ace4c85f65a0ab5dbd8e6f1c2715d60467d..7a236080bc96466d34e14b9b0d82ba4084276abd 100644
---- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
-+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
-@@ -28,6 +28,7 @@
- #include "utils/StringUtils.h"
- #include "threads/SingleLock.h"
- #include "guilib/GraphicContext.h"
-+#include "settings/AdvancedSettings.h"
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+index a234de11322599e042febd9a4945dd150dac3921..6d71b09c4badb5c3e2ef8f57b94014f43a285e32 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+@@ -1370,7 +1370,7 @@ bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uin
+     m_deint_output->format->es->video.crop.height = height;
+     m_deint_output->format->es->video.width = ALIGN_UP(width, 32);
+     m_deint_output->format->es->video.height = ALIGN_UP(height, 16);
+-    m_deint_output->format->encoding = advanced_deinterlace ? MMAL_ENCODING_YUVUV128 : MMAL_ENCODING_I420;
++    m_deint_output->format->encoding = advanced_deinterlace && encoding == MMAL_ENCODING_OPAQUE ? MMAL_ENCODING_YUVUV128 : MMAL_ENCODING_I420;
  
- static void libass_log(int level, const char *fmt, va_list args, void *data)
- {
-@@ -75,6 +76,8 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
-   if(!m_renderer)
-     return;
- 
-+  m_dll.ass_set_cache_limits(m_renderer, 0, g_advancedSettings.m_libAssCache);
-+
-   //Setting default font to the Arial in \media\fonts (used if FontConfig fails)
-   strPath = URIUtils::AddFileToFolder("special://home/media/Fonts/", CSettings::GetInstance().GetString(CSettings::SETTING_SUBTITLES_FONT));
-   if (!XFILE::CFile::Exists(strPath))
-diff --git a/xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h b/xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h
-index f9de4f15e7c612d69ef46e7cad870ecb61afaec3..b5303fd100f1a930eb5c010a951932064d5190c4 100644
---- a/xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h
-+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h
-@@ -64,6 +64,7 @@ public:
-   virtual void ass_set_message_cb(ASS_Library *priv
-                                 , void (*msg_cb)(int level, const char *fmt, va_list args, void *data)
-                                 , void *data)=0;
-+  virtual void ass_set_cache_limits(ASS_Renderer *render_priv, int glyph_max, int bitmap_max)=0;
- };
- 
- class DllLibass : public DllDynamic, DllLibassInterface
-@@ -91,6 +92,7 @@ class DllLibass : public DllDynamic, DllLibassInterface
-   DEFINE_METHOD5(void, ass_process_chunk, (ASS_Track* p1, char* p2, int p3, long long p4, long long p5))
-   DEFINE_METHOD3(void, ass_process_codec_private, (ASS_Track* p1, char* p2, int p3))
-   DEFINE_METHOD3(void, ass_set_message_cb, (ASS_Library* p1, void (*p2)(int level, const char *fmt, va_list args, void *data), void* p3))
-+  DEFINE_METHOD3(void, ass_set_cache_limits, (ASS_Renderer *p1, int p2, int p3))
-   BEGIN_METHOD_RESOLVE()
-     RESOLVE_METHOD(ass_set_extract_fonts)
-     RESOLVE_METHOD(ass_set_fonts_dir)
-@@ -114,5 +116,6 @@ class DllLibass : public DllDynamic, DllLibassInterface
-     RESOLVE_METHOD(ass_process_chunk)
-     RESOLVE_METHOD(ass_process_codec_private)
-     RESOLVE_METHOD(ass_set_message_cb)
-+    RESOLVE_METHOD(ass_set_cache_limits)
-   END_METHOD_RESOLVE()
- };
-diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index 985ecf9722141d78471c00e90da15bfad931462a..a33581ba02a26110105a2d0ae810d96c410efbf1 100644
---- a/xbmc/settings/AdvancedSettings.cpp
-+++ b/xbmc/settings/AdvancedSettings.cpp
-@@ -364,6 +364,8 @@ void CAdvancedSettings::Initialize()
- #else
-   m_cacheMemSize = 1024 * 1024 * 20;
- #endif
-+  m_libAssCache = 0;
-+
-   m_cacheBufferMode = CACHE_BUFFER_MODE_INTERNET; // Default (buffer all internet streams/filesystems)
-   // the following setting determines the readRate of a player data
-   // as multiply of the default data read rate
-@@ -1026,6 +1028,9 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
-   XMLUtils::GetFloat(pRootElement, "controllerdeadzone", m_controllerDeadzone, 0.0f, 1.0f);
-   XMLUtils::GetUInt(pRootElement, "fanartres", m_fanartRes, 0, 1080);
-   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 1080);
-+
-+  XMLUtils::GetUInt(pRootElement, "libasscache", m_libAssCache, 0, 1024);
-+
-   if (XMLUtils::GetString(pRootElement, "imagescalingalgorithm", tmp))
-     m_imageScalingAlgorithm = CPictureScalingAlgorithm::FromString(tmp);
-   XMLUtils::GetBoolean(pRootElement, "playlistasfolders", m_playlistAsFolders);
-diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
-index 6b0e3b8cf9e3ff40e6af758c54fe7eefb89a131c..35bf38719f0eaaa5ac29e9495480ae97f6aceca7 100644
---- a/xbmc/settings/AdvancedSettings.h
-+++ b/xbmc/settings/AdvancedSettings.h
-@@ -345,6 +345,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
-     unsigned int m_cacheBufferMode;
-     float m_cacheReadFactor;
- 
-+    unsigned int m_libAssCache;
-+
-     bool m_jsonOutputCompact;
-     unsigned int m_jsonTcpPort;
- 
-
-From 567ad87b2bdbf86ae8540720c58716fd4f3ac46b Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Sun, 13 Nov 2016 20:30:15 +0000
-Subject: [PATCH 62/62] [rbp] Experimental limit libass cache size depending on
- arm memory size
-
----
- xbmc/linux/RBP.cpp                 | 4 +++-
- xbmc/settings/AdvancedSettings.cpp | 2 ++
- 2 files changed, 5 insertions(+), 1 deletion(-)
-
-diff --git a/xbmc/linux/RBP.cpp b/xbmc/linux/RBP.cpp
-index 6e8529001b1a464b4547a846f553d98f5bc0b6c0..238eba372af2cbab11d7543c857ee47640901d13 100644
---- a/xbmc/linux/RBP.cpp
-+++ b/xbmc/linux/RBP.cpp
-@@ -65,6 +65,8 @@ void CRBP::InitializeSettings()
- {
-   if (m_initialized && g_advancedSettings.m_cacheMemSize == ~0U)
-     g_advancedSettings.m_cacheMemSize = m_arm_mem < 256 ? 1024 * 1024 * 2 : 1024 * 1024 * 20;
-+  if (m_initialized && g_advancedSettings.m_libAssCache == ~0U)
-+    g_advancedSettings.m_libAssCache = m_arm_mem < 256 ? 21 : m_arm_mem < 512 ? 42 : 96;
- }
- 
- bool CRBP::Initialize()
-@@ -120,7 +122,7 @@ void CRBP::LogFirmwareVerison()
-   response[sizeof(response) - 1] = '\0';
-   CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s", response);
-   CLog::Log(LOGNOTICE, "ARM mem: %dMB GPU mem: %dMB MPG2:%d WVC1:%d", m_arm_mem, m_gpu_mem, m_codec_mpg2_enabled, m_codec_wvc1_enabled);
--  CLog::Log(LOGNOTICE, "cache.memorysize: %dMB",  g_advancedSettings.m_cacheMemSize >> 20);
-+  CLog::Log(LOGNOTICE, "cache.memorysize: %dMB libass.cache: %dMB",  g_advancedSettings.m_cacheMemSize >> 20, g_advancedSettings.m_libAssCache);
-   m_DllBcmHost->vc_gencmd(response, sizeof response, "get_config int");
-   response[sizeof(response) - 1] = '\0';
-   CLog::Log(LOGNOTICE, "Config:\n%s", response);
-diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index a33581ba02a26110105a2d0ae810d96c410efbf1..d70e2cf3113bbe0dad60dfc7accc8d77f7f30c30 100644
---- a/xbmc/settings/AdvancedSettings.cpp
-+++ b/xbmc/settings/AdvancedSettings.cpp
-@@ -361,8 +361,10 @@ void CAdvancedSettings::Initialize()
- #ifdef TARGET_RASPBERRY_PI
-   // want default to be memory dependent, but interface to gpu not available yet, so set in RBP.cpp
-   m_cacheMemSize = ~0;
-+  m_libAssCache = ~0;
- #else
-   m_cacheMemSize = 1024 * 1024 * 20;
-+  m_libAssCache = 0;
- #endif
-   m_libAssCache = 0;
- 
+     status = mmal_port_format_commit(m_deint_output);
+     if (status != MMAL_SUCCESS)

--- a/projects/RPi2/patches/kodi/kodi-001-backport.patch
+++ b/projects/RPi2/patches/kodi/kodi-001-backport.patch
@@ -1,21 +1,51 @@
-From 011217b8d0ead7798bb0a7933a2c2994aab577e6 Mon Sep 17 00:00:00 2001
+From 3aab63db40b8d90327f35c4dd001a17add816142 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Mon, 19 Dec 2016 13:28:26 +0000
+Subject: [PATCH 01/61] [cec] Drop CEC_DOUBLE_TAP_TIMEOUT_MS_OLD code
+
+Kodi won't even build with libcec 3, so supporting a libcec 2.2 setting is of no value
+---
+ xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+index 54dc37e751ba4ec50cfa922cfe4c0b1fd354e3cd..73872e3c6126bf4a4e8b998491f87a35dcbdaceb 100644
+--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
++++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+@@ -1391,13 +1391,8 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
+   m_configuration.bPowerOffOnStandby = iStandbyAction == LOCALISED_ID_SUSPEND ? 1 : 0;
+   m_bShutdownOnStandby = iStandbyAction == LOCALISED_ID_POWEROFF;
+ 
+-#if defined(CEC_DOUBLE_TAP_TIMEOUT_MS_OLD)
+-  // double tap prevention timeout in ms. libCEC uses 50ms units for this in 2.2.0, so divide by 50
+-  m_configuration.iDoubleTapTimeout50Ms = GetSettingInt("double_tap_timeout_ms") / 50;
+-#else
+-  // backwards compatibility. will be removed once the next major release of libCEC is out
++  // double tap prevention timeout in ms
+   m_configuration.iDoubleTapTimeoutMs = GetSettingInt("double_tap_timeout_ms");
+-#endif
+ 
+   if (GetSettingBool("pause_playback_on_deactivate"))
+   {
+
+From 17d64855f20bbe87109cc1c92f8780316a20e3b0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 28 Oct 2014 00:19:40 +0000
-Subject: [PATCH 01/62] [cec] Add settings for configuring button repeats
+Subject: [PATCH 02/61] [cec] Add settings for configuring button repeats
 
 ---
  addons/resource.language.en_gb/resources/strings.po | 15 +++++++++++++++
  system/peripherals.xml                              |  4 +++-
- xbmc/peripherals/devices/PeripheralCecAdapter.cpp   | 16 ++++++++++++++++
- 3 files changed, 34 insertions(+), 1 deletion(-)
+ xbmc/peripherals/devices/PeripheralCecAdapter.cpp   | 11 +++++++++++
+ 3 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index abfc92bd5a9f1da9e2eed758a90416ce2d369e3b..15745a792a5a28c79c19effc4d9037e842535da6 100644
+index a3fc777c7d0a5b7549ca94b6721d84309050d4d6..84c2f8a56787242c050be5d6a18cf560c6761b53 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19714,3 +19714,18 @@ msgstr ""
- msgctxt "#39010"
- msgid "Select sort method"
+@@ -20421,3 +20421,18 @@ msgstr ""
+ msgctxt "#39014"
+ msgid "Would you also like to remove all related data (e.g. settings) of this add-on?"
  msgstr ""
 +
 +#: system/peripherals.xml
@@ -48,20 +78,15 @@ index d5704b249c3065b2980dc92c7c81dc7b384187bc..02b1a9ed6fce1986bd864bba09a9df06
  
    <peripheral vendor_product="2548:1001,2548:1002" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">
 diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-index d032ffd707fee5eec035e90bdf618530f7215c37..30367a3fde956090afdca9930fa52e829f35046f 100644
+index 73872e3c6126bf4a4e8b998491f87a35dcbdaceb..92c901e044aeb7b9bece17636ffe89c05648814f 100644
 --- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
 +++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-@@ -1296,6 +1296,20 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
+@@ -1296,6 +1296,15 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
    m_configuration.bActivateSource = config.bActivateSource;
    bChanged |= SetSetting("activate_source", m_configuration.bActivateSource == 1);
  
-+#if defined(CEC_DOUBLE_TAP_TIMEOUT_MS_OLD)
-+  m_configuration.iDoubleTapTimeout50Ms = config.iDoubleTapTimeout50Ms;
-+  bChanged |= SetSetting("double_tap_timeout_ms", (int)m_configuration.iDoubleTapTimeout50Ms * 50);
-+#else
 +  m_configuration.iDoubleTapTimeoutMs = config.iDoubleTapTimeoutMs;
 +  bChanged |= SetSetting("double_tap_timeout_ms", (int)m_configuration.iDoubleTapTimeoutMs);
-+#endif
 +
 +  m_configuration.iButtonRepeatRateMs = config.iButtonRepeatRateMs;
 +  bChanged |= SetSetting("button_repeat_rate_ms", (int)m_configuration.iButtonRepeatRateMs);
@@ -72,20 +97,101 @@ index d032ffd707fee5eec035e90bdf618530f7215c37..30367a3fde956090afdca9930fa52e82
    m_configuration.bPowerOffOnStandby = config.bPowerOffOnStandby;
  
    m_configuration.iFirmwareVersion = config.iFirmwareVersion;
-@@ -1398,6 +1412,8 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
-   // backwards compatibility. will be removed once the next major release of libCEC is out
+@@ -1393,6 +1402,8 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
+ 
+   // double tap prevention timeout in ms
    m_configuration.iDoubleTapTimeoutMs = GetSettingInt("double_tap_timeout_ms");
- #endif
 +  m_configuration.iButtonRepeatRateMs = GetSettingInt("button_repeat_rate_ms");
 +  m_configuration.iButtonReleaseDelayMs = GetSettingInt("button_release_delay_ms");
  
    if (GetSettingBool("pause_playback_on_deactivate"))
    {
 
-From 59f1631775f719f712048fc123bc6c36632a166b Mon Sep 17 00:00:00 2001
+From f2b97946dc5e44ed1099ef5274ce58f5f13ce163 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Mon, 3 Nov 2014 23:17:46 +0000
+Subject: [PATCH 03/61] [cec] Don't discard buttons when repeat mode is enabled
+
+---
+ xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+index 92c901e044aeb7b9bece17636ffe89c05648814f..da99db975e994c0e1d9d9b420f3ad92c6ed91eb6 100644
+--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
++++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+@@ -803,7 +803,10 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+   CLog::Log(LOGDEBUG, "%s - received key %2x duration %d", __FUNCTION__, key.iButton, key.iDuration);
+ 
+   CSingleLock lock(m_critSection);
+-  if (key.iDuration > 0)
++  // avoid the queue getting too long
++  if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
++    return;
++  if (m_configuration.iButtonRepeatRateMs == 0 && key.iDuration > 0)
+   {
+     if (m_currentButton.iButton == key.iButton && m_currentButton.iDuration == 0)
+     {
+
+From dc99fc2cb0b6216574d7f9b28713f26e18559858 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Tue, 4 Nov 2014 18:50:00 +0000
+Subject: [PATCH 04/61] [cec] Temp - more logging
+
+---
+ xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+index da99db975e994c0e1d9d9b420f3ad92c6ed91eb6..9114cec72ccaf16afa1e50d13b238c9ca0dee30d 100644
+--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
++++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+@@ -800,12 +800,15 @@ void CPeripheralCecAdapter::GetNextKey(void)
+ 
+ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+ {
+-  CLog::Log(LOGDEBUG, "%s - received key %2x duration %d", __FUNCTION__, key.iButton, key.iDuration);
++  CLog::Log(LOGDEBUG, "%s - received key %2x duration %d (rep:%d size:%d)", __FUNCTION__, key.iButton, key.iDuration, m_configuration.iButtonRepeatRateMs, m_buttonQueue.size());
+ 
+   CSingleLock lock(m_critSection);
+   // avoid the queue getting too long
+   if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
++  {
++    CLog::Log(LOGDEBUG, "%s - discarded key %2x", __FUNCTION__, key.iButton);
+     return;
++  }
+   if (m_configuration.iButtonRepeatRateMs == 0 && key.iDuration > 0)
+   {
+     if (m_currentButton.iButton == key.iButton && m_currentButton.iDuration == 0)
+@@ -814,6 +817,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+       if (m_bHasButton)
+         m_currentButton.iDuration = key.iDuration;
+       // ignore this one, since it's already been handled by xbmc
++      CLog::Log(LOGDEBUG, "%s - ignored key %2x", __FUNCTION__, key.iButton);
+       return;
+     }
+     // if we received a keypress with a duration set, try to find the same one without a duration set, and replace it
+@@ -824,6 +828,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+         if ((*it).iDuration == 0)
+         {
+           // replace this entry
++          CLog::Log(LOGDEBUG, "%s - replaced key %2x", __FUNCTION__, key.iButton);
+           (*it).iDuration = key.iDuration;
+           return;
+         }
+@@ -833,6 +838,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
+     }
+   }
+ 
++  CLog::Log(LOGDEBUG, "%s - added key %2x", __FUNCTION__, key.iButton);
+   m_buttonQueue.push_back(key);
+ }
+ 
+
+From 936021227644bc0cc6dd86127f740237155c1bf3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 26 Apr 2014 17:27:52 +0100
-Subject: [PATCH 02/62] [cec] Don't suspend pi on tv switch off - it can't wake
+Subject: [PATCH 05/61] [cec] Don't suspend pi on tv switch off - it can't wake
  up
 
 ---
@@ -106,136 +212,10 @@ index 02b1a9ed6fce1986bd864bba09a9df0621f9e041..54f9b70cfd5c8c82ceb99932e1b3e325
      <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
      <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />
 
-From ab59b9542257461e117a238bab492e54fff7908c Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Thu, 21 Apr 2016 16:49:02 +0100
-Subject: [PATCH 03/62] Revert "[settings] remove show EXIF picture information
- setting"
-
-This reverts commit e7d90188436b6966eff23fd695e1a9d18f4af1b4.
----
- addons/resource.language.en_gb/resources/strings.po | 10 ++++++++++
- system/settings/settings.xml                        |  5 +++++
- xbmc/pictures/GUIWindowPictures.cpp                 |  2 +-
- xbmc/pictures/PictureInfoLoader.cpp                 |  8 ++++++--
- xbmc/pictures/PictureInfoLoader.h                   |  1 +
- xbmc/settings/Settings.cpp                          |  1 +
- xbmc/settings/Settings.h                            |  1 +
- 7 files changed, 25 insertions(+), 3 deletions(-)
-
-diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index 15745a792a5a28c79c19effc4d9037e842535da6..dbd80f07e305ad99a29d90211a7596b8bb5cedec 100644
---- a/addons/resource.language.en_gb/resources/strings.po
-+++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19729,3 +19729,13 @@ msgstr ""
- msgctxt "#38052"
- msgid "Remote button press release time (ms)"
- msgstr ""
-+
-+#. Description of setting "Pictures -> Show EXIF picture information" with label #38207
-+#: system/settings/settings.xml
-+msgctxt "#38207"
-+msgid "Show EXIF picture information"
-+msgstr ""
-+
-+msgctxt "#38208"
-+msgid "If EXIF information exists (date, time, camera used, etc.), it will be displayed."
-+msgstr ""
-diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index c3804da9625186f5651a8d8be0edcedd8a2b255b..63613fc13acfd66476a880f8ebe9047a53837a33 100644
---- a/system/settings/settings.xml
-+++ b/system/settings/settings.xml
-@@ -1172,6 +1172,11 @@
-     </category>
-     <category id="pictures" label="14217" help="38109">
-       <group id="1" label="744">
-+        <setting id="pictures.usetags" type="boolean" label="38207" help="38208">
-+          <level>0</level>
-+          <default>true</default>
-+          <control type="toggle" />
-+        </setting>
-         <setting id="pictures.generatethumbs" type="boolean" label="13360" help="36307">
-           <level>0</level>
-           <default>true</default>
-diff --git a/xbmc/pictures/GUIWindowPictures.cpp b/xbmc/pictures/GUIWindowPictures.cpp
-index 4b5ec502a49d5116cafd53441a6d823be0da6b54..072639baae58479ec7d746f96634de069ee87e34 100644
---- a/xbmc/pictures/GUIWindowPictures.cpp
-+++ b/xbmc/pictures/GUIWindowPictures.cpp
-@@ -203,7 +203,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
-     if (StringUtils::EqualsNoCase(items[i]->GetLabel(), "folder.jpg"))
-       items.Remove(i);
- 
--  if (items.GetFolderCount() == items.Size())
-+  if (items.GetFolderCount() == items.Size() || !CSettings::GetInstance().GetBool(CSettings::SETTING_PICTURES_USETAGS))
-     return;
- 
-   // Start the music info loader thread
-diff --git a/xbmc/pictures/PictureInfoLoader.cpp b/xbmc/pictures/PictureInfoLoader.cpp
-index dd3347277c75c5e63a4a4db9af9cc46605bb5ea9..05304f9fc44285d5577f2056625cceb15347ae57 100644
---- a/xbmc/pictures/PictureInfoLoader.cpp
-+++ b/xbmc/pictures/PictureInfoLoader.cpp
-@@ -43,6 +43,7 @@ void CPictureInfoLoader::OnLoaderStart()
-   m_mapFileItems->SetFastLookup(true);
- 
-   m_tagReads = 0;
-+  m_loadTags = CSettings::GetInstance().GetBool(CSettings::SETTING_PICTURES_USETAGS);
- 
-   if (m_pProgressCallback)
-     m_pProgressCallback->SetProgressMax(m_pVecItems->GetFileCount());
-@@ -87,8 +88,11 @@ bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
-   if (pItem->HasPictureInfoTag())
-     return false;
- 
--  pItem->GetPictureInfoTag()->Load(pItem->GetPath());
--  m_tagReads++;
-+  if (m_loadTags)
-+  { // Nothing found, load tag from file
-+    pItem->GetPictureInfoTag()->Load(pItem->GetPath());
-+    m_tagReads++;
-+  }
- 
-   return true;
- }
-diff --git a/xbmc/pictures/PictureInfoLoader.h b/xbmc/pictures/PictureInfoLoader.h
-index 000b54fe1bb1dd1963edd5cf208ea318a5a5499d..2a022ff0ff66d237f0ebd12092c7b5ce8244a511 100644
---- a/xbmc/pictures/PictureInfoLoader.h
-+++ b/xbmc/pictures/PictureInfoLoader.h
-@@ -39,5 +39,6 @@ protected:
- 
-   CFileItemList* m_mapFileItems;
-   unsigned int m_tagReads;
-+  bool m_loadTags;
- };
- 
-diff --git a/xbmc/settings/Settings.cpp b/xbmc/settings/Settings.cpp
-index 9940b6aac87971d7024c1c925846b4dac1ca98a0..6e13ba61b99217d95c1ad423131221869be6036b 100644
---- a/xbmc/settings/Settings.cpp
-+++ b/xbmc/settings/Settings.cpp
-@@ -296,6 +296,7 @@ const std::string CSettings::SETTING_AUDIOCDS_SETTINGS = "audiocds.settings";
- const std::string CSettings::SETTING_AUDIOCDS_EJECTONRIP = "audiocds.ejectonrip";
- const std::string CSettings::SETTING_MYMUSIC_SONGTHUMBINVIS = "mymusic.songthumbinvis";
- const std::string CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW = "mymusic.defaultlibview";
-+const std::string CSettings::SETTING_PICTURES_USETAGS = "pictures.usetags";
- const std::string CSettings::SETTING_PICTURES_GENERATETHUMBS = "pictures.generatethumbs";
- const std::string CSettings::SETTING_PICTURES_SHOWVIDEOS = "pictures.showvideos";
- const std::string CSettings::SETTING_PICTURES_DISPLAYRESOLUTION = "pictures.displayresolution";
-diff --git a/xbmc/settings/Settings.h b/xbmc/settings/Settings.h
-index 482f61db8aab70aff4013fee2f1c73a5b5a9b4a9..269a3a741340d60354037166c3b03ddfdd36cf01 100644
---- a/xbmc/settings/Settings.h
-+++ b/xbmc/settings/Settings.h
-@@ -253,6 +253,7 @@ public:
-   static const std::string SETTING_AUDIOCDS_EJECTONRIP;
-   static const std::string SETTING_MYMUSIC_SONGTHUMBINVIS;
-   static const std::string SETTING_MYMUSIC_DEFAULTLIBVIEW;
-+  static const std::string SETTING_PICTURES_USETAGS;
-   static const std::string SETTING_PICTURES_GENERATETHUMBS;
-   static const std::string SETTING_PICTURES_SHOWVIDEOS;
-   static const std::string SETTING_PICTURES_DISPLAYRESOLUTION;
-
-From 2b1ad46b2dbde48ef0c82dbd4cb28af3708dc2d6 Mon Sep 17 00:00:00 2001
+From 8e32b803ba38bf71a865bd7c05af6b41d3e941e4 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 7 Apr 2014 18:19:32 +0100
-Subject: [PATCH 04/62] [rbp/omxplayer] When opening a stream don't try to
+Subject: [PATCH 06/61] [rbp/omxplayer] When opening a stream don't try to
  update gui so often
 
 ---
@@ -259,36 +239,10 @@ index c8fe0706d128b3c67a4000894129ae0fa08bb223..8a5916299575661743131b921a27a76f
          dialog->ProcessRenderLoop(false);
          if (allowCancel && dialog->IsCanceled())
 
-From 5980fa48550e82458fc62fb501a7bc7190569cb4 Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Sat, 8 Mar 2014 15:36:06 +0000
-Subject: [PATCH 05/62] [hifiberry] Hack: force it to be recognised as IEC958
- capable to enable passthrough options
-
----
- xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp | 4 ++++
- 1 file changed, 4 insertions(+)
-
-diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
-index d66993a09583d8f9f54f5f97c18fbba45dddee9b..3c0b691860ace57e0a25f01013df01a5ca4f62f5 100644
---- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
-+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
-@@ -1351,6 +1351,10 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
-     if (snd_card_get_name(cardNr, &cardName) == 0)
-       info.m_displayName = cardName;
- 
-+    // hack: hifiberry digi doesn't correctly report as iec958 device. Needs fixing in kernel driver
-+    if (info.m_displayName == "snd_rpi_hifiberry_digi")
-+      info.m_deviceType = AE_DEVTYPE_IEC958;
-+
-     if (info.m_deviceType == AE_DEVTYPE_HDMI && info.m_displayName.size() > 5 &&
-         info.m_displayName.substr(info.m_displayName.size()-5) == " HDMI")
-     {
-
-From 6387bb9ea57ef7c7e203e0b043139ff26103df22 Mon Sep 17 00:00:00 2001
+From 6c3aae494d21e0232eb7901787c613cf5ad2c4dc Mon Sep 17 00:00:00 2001
 From: Ben Avison <bavison@riscosopen.org>
 Date: Thu, 1 May 2014 16:28:39 +0100
-Subject: [PATCH 06/62] Improved file buffering in CArchive
+Subject: [PATCH 07/61] Improved file buffering in CArchive
 
 Even though memcpy is typically inlined by the compiler into byte/word loads
 and stores (at least for release builds), the frequency with which 1, 2 and 4
@@ -348,10 +302,10 @@ index 23cac2759fb10d532da56fa75c5528c5589e9010..89d31d4db1afa7340ed8cd51a7a9fa7a
      }
  
 
-From ebdbce3d440c74755bf071fc064c96bbab9abc78 Mon Sep 17 00:00:00 2001
+From 860ce7f03c0fd6f1cfb53a979dcabdb124badc83 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 10 Aug 2014 16:45:16 +0100
-Subject: [PATCH 07/62] filesystem: Make support of browsing into archives
+Subject: [PATCH 08/61] filesystem: Make support of browsing into archives
  optional
 
 The ability to browse, scan and play content in archives can cause problems on low powered/low memory devices.
@@ -370,10 +324,10 @@ We'll let people who don't use archives disable it manually
  4 files changed, 26 insertions(+), 2 deletions(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index dbd80f07e305ad99a29d90211a7596b8bb5cedec..ecea05ac43622f75034c60cc3b2bd16859065a80 100644
+index 84c2f8a56787242c050be5d6a18cf560c6761b53..422cfca63529a5bda36ad986bb0d55a6f94cddb3 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19371,6 +19371,15 @@ msgstr ""
+@@ -20042,6 +20042,15 @@ msgstr ""
  #: system/settings/rbp.xml
  msgctxt "#38010"
  msgid "GPU accelerated"
@@ -410,29 +364,29 @@ index 62e9c8ed2199f8c57a640b06b0216ee4c8f0ca1e..e8b0d3d472b02fd161a4b51e957b9129
 +  </section>
  </settings>
 diff --git a/xbmc/Util.cpp b/xbmc/Util.cpp
-index c3567941192c724f2600494a8d7e355584b57b52..da1508dcedbd196789988d895e64548a08439d8f 100644
+index f2d69da28ce36209ace7391ed607bc85983520ac..c3fd0e2b3277a0a29de9b7c6861b796a9f198aee 100644
 --- a/xbmc/Util.cpp
 +++ b/xbmc/Util.cpp
-@@ -1899,7 +1899,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
+@@ -1900,7 +1900,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
      URIUtils::RemoveExtension(strCandidate);
      if (StringUtils::StartsWithNoCase(strCandidate, videoName))
      {
 -      if (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath()))
-+      if (CSettings::GetInstance().GetBool("filelists.browsearchives") && (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())))
++      if (CServiceBroker::GetSettings().GetBool("filelists.browsearchives") && (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())))
          CUtil::ScanArchiveForAssociatedItems(pItem->GetPath(), "", item_exts, associatedFiles);
        else
        {
-@@ -1909,7 +1909,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
+@@ -1910,7 +1910,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
      }
      else
      {
 -      if (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath()))
-+      if (CSettings::GetInstance().GetBool("filelists.browsearchives") && (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())))
++      if (CServiceBroker::GetSettings().GetBool("filelists.browsearchives") && (URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())))
          CUtil::ScanArchiveForAssociatedItems(pItem->GetPath(), videoName, item_exts, associatedFiles);
      }
    }
 diff --git a/xbmc/filesystem/FileDirectoryFactory.cpp b/xbmc/filesystem/FileDirectoryFactory.cpp
-index a0fd0a9011e71f4af1535110c696b6ea5c4b37db..688b71a297c7c617c6764bfe6be157d727eb49d3 100644
+index 36fd7bb6358497abf80494620341def8ff991996..9c1b6bf975afee8b6a3d8784ed19af0367455f46 100644
 --- a/xbmc/filesystem/FileDirectoryFactory.cpp
 +++ b/xbmc/filesystem/FileDirectoryFactory.cpp
 @@ -40,6 +40,7 @@
@@ -443,16 +397,16 @@ index a0fd0a9011e71f4af1535110c696b6ea5c4b37db..688b71a297c7c617c6764bfe6be157d7
  #include "FileItem.h"
  #include "utils/StringUtils.h"
  #include "URL.h"
-@@ -116,6 +117,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
+@@ -148,6 +149,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
      return NULL;
    }
  #endif
-+  if (CSettings::GetInstance().GetBool("filelists.browsearchives"))
++  if (CServiceBroker::GetSettings().GetBool("filelists.browsearchives"))
 +  {
    if (url.IsFileType("zip"))
    {
      CURL zipURL = URIUtils::CreateArchivePath("zip", url);
-@@ -189,6 +192,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
+@@ -221,6 +224,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
      }
      return NULL;
    }
@@ -461,10 +415,10 @@ index a0fd0a9011e71f4af1535110c696b6ea5c4b37db..688b71a297c7c617c6764bfe6be157d7
    {
      CURL xbtUrl = URIUtils::CreateArchivePath("xbt", url);
 
-From 2f0e7984f47266b6b5fd6a4e14ee8f2a8e9f011c Mon Sep 17 00:00:00 2001
+From 6684363aca4c0f6374230a726dbb9c6fd8afb0a3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 27 Oct 2014 13:06:57 +0000
-Subject: [PATCH 08/62] [rbp] Make cachemembuffersize default depend on memory
+Subject: [PATCH 09/61] [rbp] Make cachemembuffersize default depend on memory
  size
 
 ---
@@ -474,18 +428,18 @@ Subject: [PATCH 08/62] [rbp] Make cachemembuffersize default depend on memory
  3 files changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/xbmc/linux/RBP.cpp b/xbmc/linux/RBP.cpp
-index 571bf9f1ae64ae6d2d80a4aaca1a164f5178bf98..5a6f780517cff0c31f1c40e5e95445d448eb2297 100644
+index 356d64b0b16e4b543abbdbb11f4beacd0b715334..c073dc28db9abc24025909e2d91b7ce49201f4ea 100644
 --- a/xbmc/linux/RBP.cpp
 +++ b/xbmc/linux/RBP.cpp
-@@ -23,6 +23,7 @@
- 
+@@ -24,6 +24,7 @@
  #include <assert.h>
+ #include "ServiceBroker.h"
  #include "settings/Settings.h"
 +#include "settings/AdvancedSettings.h"
  #include "utils/log.h"
  
  #include "cores/omxplayer/OMXImage.h"
-@@ -58,6 +59,12 @@ CRBP::~CRBP()
+@@ -59,6 +60,12 @@ CRBP::~CRBP()
    delete m_DllBcmHost;
  }
  
@@ -498,7 +452,7 @@ index 571bf9f1ae64ae6d2d80a4aaca1a164f5178bf98..5a6f780517cff0c31f1c40e5e95445d4
  bool CRBP::Initialize()
  {
    CSingleLock lock(m_critSection);
-@@ -97,6 +104,8 @@ bool CRBP::Initialize()
+@@ -98,6 +105,8 @@ bool CRBP::Initialize()
    if (!m_gui_resolution_limit)
      m_gui_resolution_limit = m_gpu_mem < 128 ? 720:1080;
  
@@ -507,7 +461,7 @@ index 571bf9f1ae64ae6d2d80a4aaca1a164f5178bf98..5a6f780517cff0c31f1c40e5e95445d4
    g_OMXImage.Initialize();
    m_omx_image_init = true;
    return true;
-@@ -109,6 +118,7 @@ void CRBP::LogFirmwareVerison()
+@@ -110,6 +119,7 @@ void CRBP::LogFirmwareVerison()
    response[sizeof(response) - 1] = '\0';
    CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s", response);
    CLog::Log(LOGNOTICE, "ARM mem: %dMB GPU mem: %dMB MPG2:%d WVC1:%d", m_arm_mem, m_gpu_mem, m_codec_mpg2_enabled, m_codec_wvc1_enabled);
@@ -516,10 +470,10 @@ index 571bf9f1ae64ae6d2d80a4aaca1a164f5178bf98..5a6f780517cff0c31f1c40e5e95445d4
    response[sizeof(response) - 1] = '\0';
    CLog::Log(LOGNOTICE, "Config:\n%s", response);
 diff --git a/xbmc/linux/RBP.h b/xbmc/linux/RBP.h
-index a35a509a91483f13e2cf0e688fc7e9528f254290..fffa5182126159f6dfcf750b21fa0464e229e545 100644
+index eff631d24cd7b072fd601f8f6a35ff0ae67bad4c..26a2a4bd74b54288282b534c5de7d59d6ccec7f5 100644
 --- a/xbmc/linux/RBP.h
 +++ b/xbmc/linux/RBP.h
-@@ -62,6 +62,7 @@ public:
+@@ -61,6 +61,7 @@ public:
    ~CRBP();
  
    bool Initialize();
@@ -528,7 +482,7 @@ index a35a509a91483f13e2cf0e688fc7e9528f254290..fffa5182126159f6dfcf750b21fa0464
    void Deinitialize();
    int GetArmMem() { return m_arm_mem; }
 diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index cc37998f0c9edfb38cf609666374cfa96530bf8f..3891a7ed34acb3489a860678d56a8ec049890f6e 100644
+index 5634ed111a6b7b19fb81acb9a81b58109ef40395..4ebc890a52995ca761effad6c30d41cb25b5bdb8 100644
 --- a/xbmc/settings/AdvancedSettings.cpp
 +++ b/xbmc/settings/AdvancedSettings.cpp
 @@ -50,6 +50,9 @@
@@ -543,7 +497,7 @@ index cc37998f0c9edfb38cf609666374cfa96530bf8f..3891a7ed34acb3489a860678d56a8ec0
  using namespace XFILE;
 @@ -355,7 +358,12 @@ void CAdvancedSettings::Initialize()
    m_bPVRAutoScanIconsUserSet       = false;
-   m_iPVRNumericChannelSwitchTimeout = 1000;
+   m_iPVRNumericChannelSwitchTimeout = 2000;
  
 +#ifdef TARGET_RASPBERRY_PI
 +  // want default to be memory dependent, but interface to gpu not available yet, so set in RBP.cpp
@@ -566,10 +520,10 @@ index cc37998f0c9edfb38cf609666374cfa96530bf8f..3891a7ed34acb3489a860678d56a8ec0
  }
  
 
-From c84536e65bc489172be3a852a9db7496615e7ec2 Mon Sep 17 00:00:00 2001
+From 6a176a9762cd72d283741df798325e7784965a07 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 30 May 2014 14:58:43 +0100
-Subject: [PATCH 09/62] [settings] Experiment: Report DESKTOP resolution in
+Subject: [PATCH 10/61] [settings] Experiment: Report DESKTOP resolution in
  video settings
 
 ---
@@ -577,10 +531,10 @@ Subject: [PATCH 09/62] [settings] Experiment: Report DESKTOP resolution in
  1 file changed, 3 insertions(+)
 
 diff --git a/xbmc/settings/DisplaySettings.cpp b/xbmc/settings/DisplaySettings.cpp
-index ef95bc286fa982790248bad26da3c3e00c1da002..da69c6960867621d4ebe9267929664d973d00beb 100644
+index 0f0f3549bb4e68fcbdf73976c43e300791fabc6b..b6a9adacc7872487b25331dff16cc5a302cb3e15 100644
 --- a/xbmc/settings/DisplaySettings.cpp
 +++ b/xbmc/settings/DisplaySettings.cpp
-@@ -704,6 +704,9 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const CSetting *setting,
+@@ -705,6 +705,9 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const CSetting *setting,
      std::vector<RESOLUTION_WHR> resolutions = g_Windowing.ScreenResolutions(info.iScreen, info.fRefreshRate);
      for (std::vector<RESOLUTION_WHR>::const_iterator resolution = resolutions.begin(); resolution != resolutions.end(); ++resolution)
      {
@@ -591,10 +545,10 @@ index ef95bc286fa982790248bad26da3c3e00c1da002..da69c6960867621d4ebe9267929664d9
          StringUtils::Format("%dx%d%s", resolution->width, resolution->height,
                              ModeFlagsToString(resolution->flags, false).c_str()),
 
-From 7f0028ec330b751c0c006ab2b496c5aeb6f67ac3 Mon Sep 17 00:00:00 2001
+From a5364b603a71e2bf7fbed939a9431cde214a3fa9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 24 Sep 2014 23:13:52 +0100
-Subject: [PATCH 10/62] [audio] Add settings option to boost centre channel
+Subject: [PATCH 11/61] [audio] Add settings option to boost centre channel
  when downmixing
 
 This allows a dB volume increase to be added to centre channel.
@@ -606,16 +560,16 @@ Should work with Pi Sink (dvdplayer/paplayer) and omxplayer
 ---
  addons/resource.language.en_gb/resources/strings.po       | 15 +++++++++++++++
  system/settings/settings.xml                              | 12 ++++++++++++
- .../Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp           |  7 +++++++
- .../AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp   |  6 ++++++
+ .../Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp           |  8 ++++++++
+ .../AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp   |  7 +++++++
  xbmc/cores/omxplayer/OMXAudio.cpp                         |  6 ++++++
- 5 files changed, 46 insertions(+)
+ 5 files changed, 48 insertions(+)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index ecea05ac43622f75034c60cc3b2bd16859065a80..de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb 100644
+index 422cfca63529a5bda36ad986bb0d55a6f94cddb3..08ed7022ad0c07ca71abe1e6d018e9b1b48a29c6 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19591,6 +19591,21 @@ msgstr ""
+@@ -20262,6 +20262,21 @@ msgstr ""
  
  #empty strings from id 38062 to 38099
  
@@ -638,10 +592,10 @@ index ecea05ac43622f75034c60cc3b2bd16859065a80..de5eb0dd99700c0bdc7c3409c1b63f1c
  #: system/settings/settings.xml
  msgctxt "#38100"
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 63613fc13acfd66476a880f8ebe9047a53837a33..9ce9e725aec4d8ed000200342a2a99f3bc34a749 100644
+index 9060fbc5eafe3726ab33649273aad9e05980f64a..b0d103cba5bcdd1d7bece68bc983ab37b0133dbb 100644
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
-@@ -2358,6 +2358,18 @@
+@@ -2491,6 +2491,18 @@
            </dependencies>
            <control type="toggle" />
          </setting>
@@ -661,22 +615,23 @@ index 63613fc13acfd66476a880f8ebe9047a53837a33..9ce9e725aec4d8ed000200342a2a99f3
            <requirement>HAS_AE_QUALITY_LEVELS</requirement>
            <level>2</level>
 diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
-index af5bf93116543bd282953b01d0c5bcef93bb3a84..d7165dedd242abdfa7c0607eee332451c3187298 100644
+index af5bf93116543bd282953b01d0c5bcef93bb3a84..80aecbd496ac021b1a02c10ef9432a4c22e54bfa 100644
 --- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
 +++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
-@@ -20,6 +20,7 @@
+@@ -20,6 +20,8 @@
  
  #include "cores/AudioEngine/Utils/AEUtil.h"
  #include "ActiveAEResampleFFMPEG.h"
++#include "ServiceBroker.h"
 +#include "settings/Settings.h"
  #include "utils/log.h"
  
  extern "C" {
-@@ -104,6 +105,12 @@ bool CActiveAEResampleFFMPEG::Init(uint64_t dst_chan_layout, int dst_channels, i
+@@ -104,6 +106,12 @@ bool CActiveAEResampleFFMPEG::Init(uint64_t dst_chan_layout, int dst_channels, i
    {
       av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
    }
-+  int boost_center = CSettings::GetInstance().GetInt("audiooutput.boostcenter");
++  int boost_center = CServiceBroker::GetSettings().GetInt("audiooutput.boostcenter");
 +  if (boost_center)
 +  {
 +    float gain = pow(10.0f, ((float)(-3 + boost_center))/20.0f);
@@ -686,14 +641,22 @@ index af5bf93116543bd282953b01d0c5bcef93bb3a84..d7165dedd242abdfa7c0607eee332451
    if (remapLayout)
    {
 diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
-index 78071493fca4756c6741d7085e35cbe2f27038e6..698a6ae1e2bc0cc9256caec42c0dcfb0893301b5 100644
+index 78071493fca4756c6741d7085e35cbe2f27038e6..9b9d1a736c974eab37bdd85e6553dfe69b438847 100644
 --- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
 +++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
-@@ -164,6 +164,12 @@ bool CActiveAEResamplePi::Init(uint64_t dst_chan_layout, int dst_channels, int d
+@@ -25,6 +25,7 @@
+ 
+ #include "cores/AudioEngine/Utils/AEUtil.h"
+ #include "ActiveAEResamplePi.h"
++#include "ServiceBroker.h"
+ #include "settings/Settings.h"
+ #include "utils/log.h"
+ #include "linux/RBP.h"
+@@ -164,6 +165,12 @@ bool CActiveAEResamplePi::Init(uint64_t dst_chan_layout, int dst_channels, int d
    {
      av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
    }
-+  int boost_center = CSettings::GetInstance().GetInt("audiooutput.boostcenter");
++  int boost_center = CServiceBroker::GetSettings().GetInt("audiooutput.boostcenter");
 +  if (boost_center)
 +  {
 +    float gain = pow(10.0f, ((float)(-3 + boost_center))/20.0f);
@@ -703,14 +666,14 @@ index 78071493fca4756c6741d7085e35cbe2f27038e6..698a6ae1e2bc0cc9256caec42c0dcfb0
    if (remapLayout)
    {
 diff --git a/xbmc/cores/omxplayer/OMXAudio.cpp b/xbmc/cores/omxplayer/OMXAudio.cpp
-index f16b822ed7b4aebe18b5d339b3f71ee66e97c23f..993d4b33a294e88c2c004b7943895ba55558c2d0 100644
+index fcec25db0c48b4d4ec7b329b19538a73d0b53efd..ae048e0d144e174020a6f567112f9829e3ac0c8b 100644
 --- a/xbmc/cores/omxplayer/OMXAudio.cpp
 +++ b/xbmc/cores/omxplayer/OMXAudio.cpp
-@@ -633,6 +633,12 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
+@@ -632,6 +632,12 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
      {
         av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
      }
-+    int boost_center = CSettings::GetInstance().GetInt("audiooutput.boostcenter");
++    int boost_center = CServiceBroker::GetSettings().GetInt("audiooutput.boostcenter");
 +    if (boost_center)
 +    {
 +      float gain = pow(10.0f, ((float)(-3 + boost_center))/20.0f);
@@ -720,10 +683,10 @@ index f16b822ed7b4aebe18b5d339b3f71ee66e97c23f..993d4b33a294e88c2c004b7943895ba5
      // stereo upmix
      if (upmix && m_src_channels == 2 && m_dst_channels > 2)
 
-From 970ba6a8671460e469240cf5113d574ea44905cc Mon Sep 17 00:00:00 2001
+From 9452a5e86e3e3eb493d148a08b74d5c6cbe0b1ed Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 27 Oct 2014 15:23:51 +0000
-Subject: [PATCH 11/62] [rbp] Default extract thumbnails to false
+Subject: [PATCH 12/61] [rbp] Default extract thumbnails to false
 
 It can take 80 seconds for a single file on a Pi. It can cause crashes with out-of-memory errors.
 It genereates a lot of support issues. Best to default to disabled and let users enable it if they must
@@ -749,10 +712,10 @@ index e8b0d3d472b02fd161a4b51e957b9129e3cb9792..289dc55ec41aa44848519a05f8ee1ccc
      </category>
    </section>
 
-From 9fecb172939f96a23cacafe2e40cbd462cfa9da3 Mon Sep 17 00:00:00 2001
+From 622ddbce6c89ad6dbdc98bfd7920339c1d63aaec Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 27 Nov 2014 16:31:56 +0000
-Subject: [PATCH 12/62] [languageinvoker] Reduce priority of python threads
+Subject: [PATCH 13/61] [languageinvoker] Reduce priority of python threads
 
 ---
  xbmc/interfaces/generic/LanguageInvokerThread.cpp | 5 +++++
@@ -775,10 +738,10 @@ index fcdd0633f30cd9595ae6cc4ed293677cdcb1f422..16f0c8916b5e0a9e90973d194cf2ebd1
  }
  
 
-From d9dc2c7f2616bc989bd550ee5a7ac7a47b5d43ae Mon Sep 17 00:00:00 2001
+From 6879b004e34fa05c4eeb9a46f97f2814299afcb1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 29 Nov 2014 15:25:16 +0000
-Subject: [PATCH 13/62] [rbp] hack: wait for splash to complete before changing
+Subject: [PATCH 14/61] [rbp] hack: wait for splash to complete before changing
  hdmi mode
 
 ---
@@ -786,10 +749,10 @@ Subject: [PATCH 13/62] [rbp] hack: wait for splash to complete before changing
  1 file changed, 52 insertions(+)
 
 diff --git a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
-index ee297700f8583dbb15cbe53baf8c887b36bd2ea0..bbe501d40c5e101f1d0d64b8b59b1928ae12d52f 100644
+index 6ec0f110ca748c1ca305b255e2f1a0413b40c1ad..d1a7de58dea31dba3864828bd268292d53945b3d 100644
 --- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
 +++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
-@@ -32,6 +32,9 @@
+@@ -33,6 +33,9 @@
  #include "guilib/StereoscopicsManager.h"
  #include "rendering/RenderSystem.h"
  #include <cassert>
@@ -799,7 +762,7 @@ index ee297700f8583dbb15cbe53baf8c887b36bd2ea0..bbe501d40c5e101f1d0d64b8b59b1928
  
  #ifndef __VIDEOCORE4__
  #define __VIDEOCORE4__
-@@ -221,12 +224,61 @@ int CEGLNativeTypeRaspberryPI::AddUniqueResolution(RESOLUTION_INFO &res, std::ve
+@@ -222,12 +225,61 @@ int CEGLNativeTypeRaspberryPI::AddUniqueResolution(RESOLUTION_INFO &res, std::ve
  }
  #endif
  
@@ -858,14 +821,14 @@ index ee297700f8583dbb15cbe53baf8c887b36bd2ea0..bbe501d40c5e101f1d0d64b8b59b1928
 +  while (proc_find("hello_video.bin") >= 0)
 +    Sleep(100);
 +
-   DestroyDispmaxWindow();
+   DestroyDispmanxWindow();
  
    RENDER_STEREO_MODE stereo_mode = g_graphicsContext.GetStereoMode();
 
-From 8f2d2d8618a4051fdeedfc528a21fc0657614d9e Mon Sep 17 00:00:00 2001
+From 0c32e3aab26ebcd6cf5cc116f195df3d372a2d1e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 11 Dec 2014 17:00:57 +0000
-Subject: [PATCH 14/62] Fix for UI not showing both extractflags and
+Subject: [PATCH 15/61] Fix for UI not showing both extractflags and
  extractthumb
 
 ---
@@ -874,10 +837,10 @@ Subject: [PATCH 14/62] Fix for UI not showing both extractflags and
  2 files changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb..ae3aa10aa65beac6689f129d60056cadf8a5b5c1 100644
+index 08ed7022ad0c07ca71abe1e6d018e9b1b48a29c6..b52e18a39cc14e0712b44baa8a2e0068e5292d8c 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -12451,7 +12451,7 @@ msgstr ""
+@@ -12880,7 +12880,7 @@ msgstr ""
  
  #: system/settings/settings.xml
  msgctxt "#20433"
@@ -886,7 +849,7 @@ index de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb..ae3aa10aa65beac6689f129d60056cad
  msgstr ""
  
  #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
-@@ -17011,7 +17011,7 @@ msgstr ""
+@@ -17685,7 +17685,7 @@ msgstr ""
  #. Description of setting with label #20433 "Extract thumbnails and video information"
  #: system/settings/settings.xml
  msgctxt "#36178"
@@ -895,7 +858,7 @@ index de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb..ae3aa10aa65beac6689f129d60056cad
  msgstr ""
  
  #. Description of setting with label #20419 "Replace file names with library titles"
-@@ -17023,7 +17023,7 @@ msgstr ""
+@@ -17697,7 +17697,7 @@ msgstr ""
  #. Description of setting with label #20433 "Extract thumbnails and video information"
  #: system/settings/settings.xml
  msgctxt "#36180"
@@ -904,16 +867,16 @@ index de5eb0dd99700c0bdc7c3409c1b63f1c01c650bb..ae3aa10aa65beac6689f129d60056cad
  msgstr ""
  
  #: system/settings/settings.xml
-@@ -19763,3 +19763,7 @@ msgstr ""
- msgctxt "#38208"
- msgid "If EXIF information exists (date, time, camera used, etc.), it will be displayed."
+@@ -20460,3 +20460,7 @@ msgstr ""
+ msgctxt "#38052"
+ msgid "Remote button press release time (ms)"
  msgstr ""
 +
 +msgctxt "#38190"
 +msgid "Extract thumbnails from video files"
 +msgstr ""
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 9ce9e725aec4d8ed000200342a2a99f3bc34a749..326ffbd0f08428c3b4a95208134253feeabf1b1f 100644
+index b0d103cba5bcdd1d7bece68bc983ab37b0133dbb..38a772b4e5f59cdd30293850752a761dbe532177 100644
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
 @@ -969,8 +969,8 @@
@@ -928,10 +891,10 @@ index 9ce9e725aec4d8ed000200342a2a99f3bc34a749..326ffbd0f08428c3b4a95208134253fe
            <control type="toggle" />
          </setting>
 
-From 2d8206baa4bb9229a75e71a3de87628d60e006e5 Mon Sep 17 00:00:00 2001
+From 945f62a3d2e45b1af550fa67a136eb042b0c0db3 Mon Sep 17 00:00:00 2001
 From: anaconda <anaconda@menakite.eu>
 Date: Thu, 11 Sep 2014 21:30:43 +0200
-Subject: [PATCH 15/62] Disable autoscrolling while on screensaver and while
+Subject: [PATCH 16/61] Disable autoscrolling while on screensaver and while
  opening streams.
 
 ---
@@ -944,10 +907,10 @@ Subject: [PATCH 15/62] Disable autoscrolling while on screensaver and while
  6 files changed, 24 insertions(+), 3 deletions(-)
 
 diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
-index 620366e4bcb8593484bc205af4c33fc13dab924a..cf77c3dbb84b86c755ee792294760c5c4c38742d 100644
+index 8b812302f7cd460ca709e551d10be212dfaa2561..b441de35eca9c988eb10f83c3aaf12f618b0c743 100644
 --- a/xbmc/Application.cpp
 +++ b/xbmc/Application.cpp
-@@ -5215,3 +5215,13 @@ bool CApplication::NotifyActionListeners(const CAction &action) const
+@@ -5260,3 +5260,13 @@ bool CApplication::NotifyActionListeners(const CAction &action) const
    
    return false;
  }
@@ -962,10 +925,10 @@ index 620366e4bcb8593484bc205af4c33fc13dab924a..cf77c3dbb84b86c755ee792294760c5c
 +  return onBlackDimScreenSaver || openingStreams;
 +}
 diff --git a/xbmc/Application.h b/xbmc/Application.h
-index 580fdce5476312c83c82bec07f48b3eaf8fe9797..e04788e1e3574aa5ecf9b14490fe1fd967ce8ec9 100644
+index 59a1ec96b24014b4bc3cc6a7e0d4aa345958eaf8..c50a56f4254c88a9f69a156aec2967bdc6315330 100644
 --- a/xbmc/Application.h
 +++ b/xbmc/Application.h
-@@ -392,6 +392,8 @@ public:
+@@ -382,6 +382,8 @@ public:
     */
    void UnregisterActionListener(IActionListener *listener);
  
@@ -1062,10 +1025,10 @@ index d7bc1c5ba6067af9a460589920367288c640a915..ac766293f1c47c7f145cb46f6b152144
        if (m_lastRenderTime)
          m_autoScrollDelayTime += currentTime - m_lastRenderTime;
 
-From 8a1f8bb315f494840e8b5807f257463c57532fd6 Mon Sep 17 00:00:00 2001
+From b3ce0b2a61e0093047dd19d9608d365adc851dc5 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 13 Dec 2014 18:35:20 +0000
-Subject: [PATCH 16/62] [demuxer] Avoid memcpy on every demuxer packet
+Subject: [PATCH 17/61] [demuxer] Avoid memcpy on every demuxer packet
 
 Avoids an unnecessary memcpy on every demuxer packet which for
 high bitrate videos can be significant.
@@ -1076,10 +1039,10 @@ high bitrate videos can be significant.
  3 files changed, 21 insertions(+), 6 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 33d1e5ab627d8099018190699f3b532c2b1f3b08..e015e65dea43e7b682b704edb7f468b63b8c2ac5 100644
+index a00a362239df1f7d99e3bf13a41a58e5d0567e02..e9a1645acbdb2dd2fbf3c1eaee9ef1401fe9bfd7 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -921,7 +921,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -922,7 +922,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
            {
              if(m_pkt.pkt.stream_index == (int)m_pFormatContext->programs[m_program]->stream_index[i])
              {
@@ -1088,7 +1051,7 @@ index 33d1e5ab627d8099018190699f3b532c2b1f3b08..e015e65dea43e7b682b704edb7f468b6
                break;
              }
            }
-@@ -930,7 +930,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -931,7 +931,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
              bReturnEmpty = true;
          }
          else
@@ -1097,7 +1060,7 @@ index 33d1e5ab627d8099018190699f3b532c2b1f3b08..e015e65dea43e7b682b704edb7f468b6
        }
        else
          bReturnEmpty = true;
-@@ -960,9 +960,13 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -961,9 +961,13 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
          // copy contents into our own packet
          pPacket->iSize = m_pkt.pkt.size;
  
@@ -1113,7 +1076,7 @@ index 33d1e5ab627d8099018190699f3b532c2b1f3b08..e015e65dea43e7b682b704edb7f468b6
  
          pPacket->pts = ConvertTimestamp(m_pkt.pkt.pts, stream->time_base.den, stream->time_base.num);
          pPacket->dts = ConvertTimestamp(m_pkt.pkt.dts, stream->time_base.den, stream->time_base.num);
-@@ -1016,7 +1020,10 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -1017,7 +1021,10 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
          pPacket->iStreamId = m_pkt.pkt.stream_index;
        }
        m_pkt.result = -1;
@@ -1147,10 +1110,10 @@ index 4f471188c133deb91516311f0082e8741d9dee79..22805781c4d5a957d10fdf74ffa34387
    int dispTime;
  } DemuxPacket;
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
-index df0f35bd49c65b302de4ccd110d859e8b881ea5f..b4b591ae4c4dd4fb0b36d4d00fedca966f86000f 100644
+index 403d75fe905f02dcc46a9bd1798ca6c8fc0ccc4e..66774e4d299790059db8ed99fb060e2b3e91cef4 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
-@@ -39,7 +39,12 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
+@@ -36,7 +36,12 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
    if (pPacket)
    {
      try {
@@ -1165,10 +1128,10 @@ index df0f35bd49c65b302de4ccd110d859e8b881ea5f..b4b591ae4c4dd4fb0b36d4d00fedca96
      }
      catch(...) {
 
-From 83250abe1869bc07d70466de8bb6f9d6342aec7c Mon Sep 17 00:00:00 2001
+From 2f124999ab254f276d6f53874c819e3e2e0eb351 Mon Sep 17 00:00:00 2001
 From: anaconda <anaconda@menakite.eu>
 Date: Wed, 25 Feb 2015 18:22:21 +0100
-Subject: [PATCH 17/62] Load OSD dialogs on startup.
+Subject: [PATCH 18/61] Load OSD dialogs on startup.
 
 Fixes skipped frames the first time they're loaded in memory on less powered
 devices, like a Raspberry Pi, when using DVDPlayer.
@@ -1183,19 +1146,19 @@ See http://forum.kodi.tv/showthread.php?tid=211501&pid=1938811#pid1938811
  6 files changed, 10 insertions(+), 4 deletions(-)
 
 diff --git a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
-index 1beb8560a1030f6198b22f5d9c082a27dd85d8a8..ca7c90b0c4a7fc34a31fe6dcf787b8980d28df71 100644
+index 4450583494e483afdeec610b489a9fe75944e054..28ed83f59ba1db07fc64d3c1fbcdc2acc7c1ad82 100644
 --- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
 +++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
-@@ -49,6 +49,7 @@ using namespace KODI::MESSAGING;
- CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD() :
-     CGUIDialog(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml")
+@@ -45,6 +45,7 @@ CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD() :
+     CGUIDialog(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml"),
+     CPVRChannelNumberInputHandler(1000)
  {
 +  m_loadType = LOAD_ON_GUI_INIT;
    m_vecItems = new CFileItemList;
  }
  
 diff --git a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
-index 8b472435e26e455249637faf5120055b415fc49e..be1f64d552161f8a86a5c5d89c1bc23328574fb6 100644
+index 99a75175638c66968b7fe61a9dc973de64edd9fe..81355ff55f92f47378a986ac7ff2c0cd52296f9e 100644
 --- a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
 +++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
 @@ -36,6 +36,7 @@ using namespace PVR;
@@ -1207,10 +1170,10 @@ index 8b472435e26e455249637faf5120055b415fc49e..be1f64d552161f8a86a5c5d89c1bc233
  }
  
 diff --git a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
-index eb67552344f59b8857b16c882c29e3fa62bed75c..f31572b34d376e70a35003a8c2e175b45daf8070 100644
+index ac501f769d648b669c4363a824fa4a751744555f..0a0cf76f254b85212bd5777b26e8872651bffece 100644
 --- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
 +++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
-@@ -68,7 +68,9 @@ CGUIDialogAudioSubtitleSettings::CGUIDialogAudioSubtitleSettings()
+@@ -69,7 +69,9 @@ CGUIDialogAudioSubtitleSettings::CGUIDialogAudioSubtitleSettings()
    : CGUIDialogSettingsManualBase(WINDOW_DIALOG_AUDIO_OSD_SETTINGS, "DialogSettings.xml"),
      m_passthrough(false),
      m_dspEnabled(false)
@@ -1222,10 +1185,10 @@ index eb67552344f59b8857b16c882c29e3fa62bed75c..f31572b34d376e70a35003a8c2e175b4
  CGUIDialogAudioSubtitleSettings::~CGUIDialogAudioSubtitleSettings()
  { }
 diff --git a/xbmc/video/dialogs/GUIDialogSubtitles.cpp b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
-index 398558e4d5d0cae30ee1c73e2b70e3b2f787e8fc..4e8a9b1e307a89d3a7b68402e2ff11b57e7dccd4 100644
+index 09ac499df555ea9231d6d486df11eb3a6a5265af..72da62e76337663f44ef8d5fc5c890bea1213ab3 100644
 --- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
 +++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
-@@ -103,7 +103,7 @@ CGUIDialogSubtitles::CGUIDialogSubtitles(void)
+@@ -104,7 +104,7 @@ CGUIDialogSubtitles::CGUIDialogSubtitles(void)
      , m_pausedOnRun(false)
      , m_updateSubsList(false)
  {
@@ -1248,10 +1211,10 @@ index e498e1fd476d9ab5300bb00bc39946a22cfd93cb..a6648d016b07e2eb3e52f8d927697cc5
  
  CGUIDialogVideoOSD::~CGUIDialogVideoOSD(void)
 diff --git a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
-index 0534828dd85520134f7a6890e43a873e223062c1..5a86dfc1e2a54c8fe8d82cb75b612d8e1a0fd2a7 100644
+index 7f10c52223c7a02471dcd3bc6d13da59b076a198..072c7be73f352ad00219594bb5ce0c3939f9c540 100644
 --- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 +++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
-@@ -66,7 +66,9 @@
+@@ -67,7 +67,9 @@
  CGUIDialogVideoSettings::CGUIDialogVideoSettings()
      : CGUIDialogSettingsManualBase(WINDOW_DIALOG_VIDEO_OSD_SETTINGS, "DialogSettings.xml"),
        m_viewModeChanged(false)
@@ -1263,10 +1226,10 @@ index 0534828dd85520134f7a6890e43a873e223062c1..5a86dfc1e2a54c8fe8d82cb75b612d8e
  CGUIDialogVideoSettings::~CGUIDialogVideoSettings()
  { }
 
-From c75aecfa32c369f2728247347c4edd34c3cd5e6a Mon Sep 17 00:00:00 2001
+From 3ba695ea73dcc0850680542d6f22e8135315ea67 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 14 Apr 2015 20:51:14 +0100
-Subject: [PATCH 18/62] [gui] Also limit GUI updates when in non full-screen
+Subject: [PATCH 19/61] [gui] Also limit GUI updates when in non full-screen
  video mode
 
 ---
@@ -1274,19 +1237,19 @@ Subject: [PATCH 18/62] [gui] Also limit GUI updates when in non full-screen
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
-index cf77c3dbb84b86c755ee792294760c5c4c38742d..adbfef5f32d3d205f2410e1aabbd8325dd90f8e2 100644
+index b441de35eca9c988eb10f83c3aaf12f618b0c743..b2566f85f77b185c3f90a26f5eff000d09a2ccf9 100644
 --- a/xbmc/Application.cpp
 +++ b/xbmc/Application.cpp
-@@ -2762,7 +2762,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
+@@ -2761,7 +2761,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
  #if defined(TARGET_RASPBERRY_PI) || defined(HAS_IMXVPU)
      // This code reduces rendering fps of the GUI layer when playing videos in fullscreen mode
      // it makes only sense on architectures with multiple layers
 -    if (g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback() && m_pPlayer->IsRenderingVideoLayer())
 +    if (m_pPlayer->IsPlayingVideo() && !m_pPlayer->IsPausedPlayback() && m_pPlayer->IsRenderingVideoLayer())
-       fps = CSettings::GetInstance().GetInt(CSettings::SETTING_VIDEOPLAYER_LIMITGUIUPDATE);
+       fps = m_ServiceManager->GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_LIMITGUIUPDATE);
  #endif
  
-@@ -2775,6 +2775,8 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
+@@ -2774,6 +2774,8 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
      {
        if (!m_skipGuiRender)
          g_windowManager.Process(CTimeUtils::GetFrameTime());
@@ -1296,10 +1259,10 @@ index cf77c3dbb84b86c755ee792294760c5c4c38742d..adbfef5f32d3d205f2410e1aabbd8325
      g_windowManager.FrameMove();
    }
 
-From 6bbda4d7e81f32b2e046e81fc7ea3d810b117eae Mon Sep 17 00:00:00 2001
+From 91b4807e4f26d5d479a2bc83b9d607bda4b93505 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 May 2015 23:58:06 +0100
-Subject: [PATCH 19/62] [screensaver] Leave GUI contents available for
+Subject: [PATCH 20/61] [screensaver] Leave GUI contents available for
  screensaver
 
 ---
@@ -1307,10 +1270,10 @@ Subject: [PATCH 19/62] [screensaver] Leave GUI contents available for
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/xbmc/guilib/GUIWindowManager.cpp b/xbmc/guilib/GUIWindowManager.cpp
-index 5808f7ed1e94d68ead7305ba6d284edd4df12bdd..2a3b7f16531c9822e79c77efabdd30acdaa2a3c9 100644
+index 77ab06e490beded56258826c91da5ee69cd55ed8..f0af5bc1e4d0e7b4e736a39fef06fbf7a37a6e93 100644
 --- a/xbmc/guilib/GUIWindowManager.cpp
 +++ b/xbmc/guilib/GUIWindowManager.cpp
-@@ -795,7 +795,16 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
+@@ -818,7 +818,16 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
    int currentWindow = GetActiveWindow();
    CGUIWindow *pWindow = GetWindow(currentWindow);
    if (pWindow)
@@ -1329,10 +1292,10 @@ index 5808f7ed1e94d68ead7305ba6d284edd4df12bdd..2a3b7f16531c9822e79c77efabdd30ac
  
    // Add window to the history list (we must do this before we activate it,
 
-From cb881f3dae6d748dcc06616d5937a7f5c806a3a6 Mon Sep 17 00:00:00 2001
+From 3143d4021d23da5afe2d05218f8a8f486b6ea217 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 6 Jun 2015 18:43:57 +0100
-Subject: [PATCH 20/62] ffmpeg: Automatic switch to software decode for GMC
+Subject: [PATCH 21/61] ffmpeg: Automatic switch to software decode for GMC
  with more than one warp point
 
 ---
@@ -1437,10 +1400,10 @@ index 5c2976278eb5ec5b8b4a4f9f9c7174b164ab5201..dde29adf425e54f54e4104b3370352db
  ./configure --prefix=$FFMPEG_PREFIX \
  	--extra-version="kodi-${VERSION}" \
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-index ff3729bde30c0e46de67c4df9b01ee5846c181ee..822b7bf75f2e732b5eed8687403d0eda503fa641 100644
+index 0976d9fb361324ca25224535c6a7c23c3b50bba1..4f5de0341b344c77a12c936f4f573c2911c0bb7b 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-@@ -47,6 +47,10 @@
+@@ -45,6 +45,10 @@
  
  #include "linux/RBP.h"
  
@@ -1451,9 +1414,9 @@ index ff3729bde30c0e46de67c4df9b01ee5846c181ee..822b7bf75f2e732b5eed8687403d0eda
  using namespace KODI::MESSAGING;
  
  #define CLASSNAME "CMMALVideoBuffer"
-@@ -367,6 +371,8 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+@@ -365,6 +369,8 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
    // we always qualify even if DVDFactoryCodec does this too.
-   if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
+   if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
      return false;
 +  if (hints.workaround_bugs & FF_BUG_GMC_UNSUPPORTED)
 +    return false;
@@ -1461,30 +1424,30 @@ index ff3729bde30c0e46de67c4df9b01ee5846c181ee..822b7bf75f2e732b5eed8687403d0eda
    std::list<EINTERLACEMETHOD> deintMethods;
    deintMethods.push_back(EINTERLACEMETHOD::VS_INTERLACEMETHOD_AUTO);
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
-index 3bb003b634c83d2c1b0ecd12b53027950e58be99..24341dc23e97e86e1b20b255548573c88e02f064 100644
+index f2a5349d329ba4ce9886db41b7dc6c5aca0f00b1..a201efed7f3a591ebbe65106eb75e95264cd4a3f 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
-@@ -157,6 +157,7 @@ public:
-     type = STREAM_VIDEO;
+@@ -154,6 +154,7 @@ public:
      iOrientation = 0;
      iBitsPerPixel = 0;
+     iBitRate = 0;
 +    workaround_bugs = 0;
    }
  
    virtual ~CDemuxStreamVideo() {}
-@@ -171,6 +172,7 @@ public:
-   int iOrientation; // orientation of the video in degress counter clockwise
+@@ -169,6 +170,7 @@ public:
    int iBitsPerPixel;
+   int iBitRate;
    std::string stereo_mode; // expected stereo mode
 +  int workaround_bugs; // info for decoder
  };
  
  class CDemuxStreamAudio : public CDemuxStream
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index e015e65dea43e7b682b704edb7f468b63b8c2ac5..54a18c669a058b705e0276cb7e14522ae6cd04ae 100644
+index e9a1645acbdb2dd2fbf3c1eaee9ef1401fe9bfd7..b485ad23e6309647db2bc489ed6bfda60cf506a1 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -1416,7 +1416,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1418,7 +1418,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
          if (!stereoMode.empty())
            st->stereo_mode = stereoMode;
  
@@ -1522,11 +1485,11 @@ index e59c84c32ff6f108b52955523321f37bd3885986..28dbdd344473338762927f5f2d014252
    else if(  right.type == STREAM_SUBTITLE )
    {
 diff --git a/xbmc/cores/VideoPlayer/DVDStreamInfo.h b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
-index f14170850673ebf746df0acf8f5cf5977feae684..85e402bb4e1ddd61bdb657802cc7347c95b9a302 100644
+index b087a110ad2cd4df00702133607ab117c87f552e..12c251e0feaf59bd9498d9cc63e3e3b9d8bb0dd8 100644
 --- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
 +++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
-@@ -73,6 +73,7 @@ public:
-   int orientation; // orientation of the video in degress counter clockwise
+@@ -69,6 +69,7 @@ public:
+   int orientation; // orientation of the video in degrees counter clockwise
    int bitsperpixel;
    std::string stereo_mode; // stereoscopic 3d mode
 +  int workaround_bugs; // info for decoder
@@ -1534,10 +1497,10 @@ index f14170850673ebf746df0acf8f5cf5977feae684..85e402bb4e1ddd61bdb657802cc7347c
    // AUDIO
    int channels;
 diff --git a/xbmc/cores/omxplayer/OMXHelper.cpp b/xbmc/cores/omxplayer/OMXHelper.cpp
-index f135d423c0ca76fd70e79ae5b7d035f0cb79fc75..d9b576bc46055fdab1c134e5f2c63cd4989d015c 100644
+index d7210ac180edf28024fc205385a75275f0c87330..4f5dedd05745ec918e8e683a329a526f981a9be6 100644
 --- a/xbmc/cores/omxplayer/OMXHelper.cpp
 +++ b/xbmc/cores/omxplayer/OMXHelper.cpp
-@@ -30,6 +30,10 @@
+@@ -31,6 +31,10 @@
  #include "cores/omxplayer/OMXPlayerVideo.h"
  #include "threads/SystemClock.h"
  
@@ -1548,7 +1511,7 @@ index f135d423c0ca76fd70e79ae5b7d035f0cb79fc75..d9b576bc46055fdab1c134e5f2c63cd4
  #define PREDICATE_RETURN(lh, rh) \
    do { \
      if((lh) != (rh)) \
-@@ -81,7 +85,9 @@ bool OMXPlayerUnsuitable(bool m_HasVideo, bool m_HasAudio, CDVDDemux* m_pDemuxer
+@@ -82,7 +86,9 @@ bool OMXPlayerUnsuitable(bool m_HasVideo, bool m_HasAudio, CDVDDemux* m_pDemuxer
        CDVDStreamInfo hint(*stream, true);
  
        bool supported = false;
@@ -1560,10 +1523,10 @@ index f135d423c0ca76fd70e79ae5b7d035f0cb79fc75..d9b576bc46055fdab1c134e5f2c63cd4
        else if ((hint.codec == AV_CODEC_ID_VC1 || hint.codec == AV_CODEC_ID_WMV3) && g_RBP.GetCodecWvc1())
          supported = true;
 
-From b5b121249287c4d102d61ae0aafa05f40e79af44 Mon Sep 17 00:00:00 2001
+From 4d326bcbd6ab3cf8367902d13db2b80fd8ecd4fe Mon Sep 17 00:00:00 2001
 From: Claudio-Sjo <Claudio.Porfiri@gmail.com>
 Date: Mon, 16 Feb 2015 14:51:26 +0100
-Subject: [PATCH 21/62] - allow reads < CDIO_CD_FRAMESIZE_RAW by using a buffer
+Subject: [PATCH 22/61] - allow reads < CDIO_CD_FRAMESIZE_RAW by using a buffer
  - fixes #15794
 
 ---
@@ -1755,10 +1718,10 @@ index 0427af4534bfe59a343f0518c7f4242d93299836..e99236294fa8b9b613e465a8ecaf3ad3
    lsn_t m_lsnCurrent; // Position inside the track in logical sector number
    lsn_t m_lsnEnd;   // End of m_iTrack in logical sector number
 
-From 2a304750b765450dfb217e6a51ceeeb2eeb79741 Mon Sep 17 00:00:00 2001
+From aaa6b66b127dcd1fb041f49c5fed39479a32fca7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 24 Jun 2016 19:38:13 +0100
-Subject: [PATCH 22/62] codecoverlay: Include codec name in overlay
+Subject: [PATCH 23/61] codecoverlay: Include codec name in overlay
 
 ---
  xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp | 4 ++++
@@ -1769,13 +1732,13 @@ Subject: [PATCH 22/62] codecoverlay: Include codec name in overlay
  5 files changed, 17 insertions(+), 5 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
-index f822935ab7fc919128db53f70a6c4eb84d9759bc..9db3a9cc91fd5f9b194d6c1aa66aa02121164c29 100644
+index a40c6191e5e0e403790bbd05d6b5cded773f54c8..1f184e78d28a7430bca7d4f39de1f49adf33b56c 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
-@@ -210,6 +210,10 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
+@@ -211,6 +211,10 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
    std::ostringstream s;
    s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "%";
-   s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)GetAudioBitrate() / 1024.0;
+   s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)m_audioStats.GetBitrate() / 1024.0;
 +  s << ", ac:"   << m_processInfo.GetAudioDecoderName().c_str();
 +  if (!m_info.passthrough)
 +    s << ", chan:" << m_processInfo.GetAudioChannels().c_str();
@@ -1784,10 +1747,10 @@ index f822935ab7fc919128db53f70a6c4eb84d9759bc..9db3a9cc91fd5f9b194d6c1aa66aa021
    //print the inverse of the resample ratio, since that makes more sense
    //if the resample ratio is 0.5, then we're playing twice as fast
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-index 89db27cce079e3e273050f2fa71f941f21b8280b..903f0d83527d9088ff1bf0ba056f357f6abfda81 100644
+index 5298963d58bb976a2bbd608a8dbc8e079a5bef62..d4920ac30216fb295a16b70ddff887e2077ee196 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-@@ -895,10 +895,13 @@ int CVideoPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
+@@ -896,10 +896,13 @@ int CVideoPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
  
  std::string CVideoPlayerVideo::GetPlayerInfo()
  {
@@ -1803,10 +1766,10 @@ index 89db27cce079e3e273050f2fa71f941f21b8280b..903f0d83527d9088ff1bf0ba056f357f
    s << ", skip:" << m_renderManager.GetSkippedFrames();
  
 diff --git a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
-index 1e5d2b98bbef15b47994c3e4735873a9946b58c7..d43350fa0eefb5960475a02c1327efc24d138e0f 100644
+index 968724e81d473a4bf8d4a0456be69f05e1a54812..c593c2fed0ce967f3d0b9fb5cf37b1026504b3a5 100644
 --- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
 +++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
-@@ -659,6 +659,10 @@ std::string OMXPlayerAudio::GetPlayerInfo()
+@@ -657,6 +657,10 @@ std::string OMXPlayerAudio::GetPlayerInfo()
    std::ostringstream s;
    s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel() + MathUtils::round_int(100.0/8.0*GetCacheTime())) << "%";
    s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)GetAudioBitrate() / 1024.0;
@@ -1818,10 +1781,10 @@ index 1e5d2b98bbef15b47994c3e4735873a9946b58c7..d43350fa0eefb5960475a02c1327efc2
    return s.str();
  }
 diff --git a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
-index a4b663d43d5b626e351256a1dd10650a282b494c..f6fb241dfec9269f4e501248de4dc83d5fdc2d3a 100644
+index b2c435bb2bc3f458d63be7249069531a954c6b9e..d308e44e26baae1a56127b55b987c28c384a9b63 100644
 --- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
 +++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
-@@ -593,12 +593,14 @@ void OMXPlayerVideo::SetSpeed(int speed)
+@@ -592,12 +592,14 @@ void OMXPlayerVideo::SetSpeed(int speed)
  
  std::string OMXPlayerVideo::GetPlayerInfo()
  {
@@ -1852,10 +1815,10 @@ index 0df7e72cc9d1947173c2bac5e72eb09976b51aa5..b5050081c360d29b1b478c27e6b88291
    double                    m_iSubtitleDelay;
    bool                      m_bRenderSubs;
 
-From 9ebfa6f23b211491275577d8022c4f83b5171ba4 Mon Sep 17 00:00:00 2001
+From a49d6d2194d7702abe261d6d074592dcbccab467 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Tue, 8 Mar 2016 21:20:58 +0300
-Subject: [PATCH 23/62] [DebugInfo] Add cpu usage info.
+Subject: [PATCH 24/61] [DebugInfo] Add cpu usage info.
 
 ---
  .../VideoPlayer/VideoRenderers/DebugRenderer.cpp   | 56 ++++++++--------------
@@ -1992,7 +1955,7 @@ index 85aefaace73994730f7d2bdff9de85c79e99b2a2..8005a13bc220be0c5c596d276197c11e
  };
 \ No newline at end of file
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
-index 17c428cb28018707d7422f344191b218903ab29b..8626a1b449ff0963089f6a7ad191a6c99512521a 100644
+index 5230c6d2c9b20bfa6390b0da1b06ae9045580972..5feee388bb3a433ea6a35b29e587ab6447c089a5 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
 @@ -24,6 +24,7 @@
@@ -2003,7 +1966,7 @@ index 17c428cb28018707d7422f344191b218903ab29b..8626a1b449ff0963089f6a7ad191a6c9
  #include "utils/log.h"
  #include "utils/StringUtils.h"
  #include "windowing/WindowingFactory.h"
-@@ -926,7 +927,7 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
+@@ -929,7 +930,7 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
  
      if (m_renderDebug)
      {
@@ -2012,7 +1975,7 @@ index 17c428cb28018707d7422f344191b218903ab29b..8626a1b449ff0963089f6a7ad191a6c9
  
        m_playerPort->GetDebugInfo(audio, video, player);
  
-@@ -940,8 +941,10 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
+@@ -943,8 +944,10 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
                                       missedvblanks,
                                       clockspeed * 100);
        }
@@ -2025,10 +1988,10 @@ index 17c428cb28018707d7422f344191b218903ab29b..8626a1b449ff0963089f6a7ad191a6c9
  
        m_debugTimer.Set(1000);
 
-From 37fedb68b098941bbdc5ace022806c75c908caf6 Mon Sep 17 00:00:00 2001
+From fad68b0c2e047c354a69586317d04474aa3ee3bc Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 22 May 2015 13:56:29 +0100
-Subject: [PATCH 24/62] ffmpeg: Allow neon to be enabled in unified builds
+Subject: [PATCH 25/61] ffmpeg: Allow neon to be enabled in unified builds
 
 ---
  tools/depends/target/ffmpeg/Makefile | 4 ++++
@@ -2051,10 +2014,10 @@ index 8dd14cdfd053f142f386b6dee1fc0b21bb1f8d93..b5f38a458dfb341c43089e07afded153
  ifeq ($(OS), linux)
    ffmpg_config += --target-os=$(OS) --cpu=$(CPU)
 
-From 2bfb7a3ff98dd858389dd3d064d8a3dc52a72af8 Mon Sep 17 00:00:00 2001
+From cb18faf29fa126a70d6c705823198231e8da1757 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 27 Feb 2015 14:37:27 +0000
-Subject: [PATCH 25/62] ffmpeg: Add some upstream HEVC optimisations
+Subject: [PATCH 26/61] ffmpeg: Add some upstream HEVC optimisations
 
 ---
  tools/depends/target/ffmpeg/Makefile               |    6 +-
@@ -5852,10 +5815,10 @@ index 0000000000000000000000000000000000000000..5e8e07d407f045fc99554f0f061d1e81
 +2.5.0
 +
 
-From 56a954cfc65e5f4f2f2e7a506ef303b853eedb81 Mon Sep 17 00:00:00 2001
+From 7e8be9ec3979f4a986ca3caddbd104648a665975 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 7 May 2015 14:04:18 +0100
-Subject: [PATCH 26/62] [ffmpeg] Add GPU acceleration to hevc
+Subject: [PATCH 27/61] [ffmpeg] Add GPU acceleration to hevc
 
 ---
  tools/depends/target/ffmpeg/Makefile               |     4 +-
@@ -44041,10 +44004,10 @@ index 0000000000000000000000000000000000000000..e172ebf157aebffe1ae50b4a2b25fd71
 +2.7.4
 +
 
-From 8e5e6f713dc181bc3f3b4bfb728d11aca00c846e Mon Sep 17 00:00:00 2001
+From fc9a7b66a195da7562af2bdcc353ad92e3a9a07a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 12 Jan 2016 16:29:57 +0000
-Subject: [PATCH 27/62] ffmpeg: Add cabac opimisations for hevc
+Subject: [PATCH 28/61] ffmpeg: Add cabac opimisations for hevc
 
 ---
  .../0001-Squashed-commit-of-the-following.patch    | 2179 ++++++++++++++++++++
@@ -46289,10 +46252,10 @@ index d6856dbd4fb4957ace700cbc08332223c01938f6..a61357f14cb2139e8125ae04684bed1b
  
  make -j ${BUILDTHREADS} 
 
-From 74ed08120dcf15fe8429da268d7dd63711e7fc48 Mon Sep 17 00:00:00 2001
+From 77973371178aaa12f3adba74a84d258795ff5c78 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 16 Sep 2015 19:05:12 +0100
-Subject: [PATCH 28/62] [3d] Make MVC a valid 3D filename tag
+Subject: [PATCH 29/61] [3d] Make MVC a valid 3D filename tag
 
 ---
  xbmc/guilib/StereoscopicsManager.cpp | 9 +++++++++
@@ -46301,10 +46264,10 @@ Subject: [PATCH 28/62] [3d] Make MVC a valid 3D filename tag
  3 files changed, 12 insertions(+)
 
 diff --git a/xbmc/guilib/StereoscopicsManager.cpp b/xbmc/guilib/StereoscopicsManager.cpp
-index b34873cba6534086ae243326550385867a03256a..1443acaf0f25df458ae49766e13dd0323454f2eb 100644
+index 299d0ba62f4dbb6bc8d5632e19288f165333cc3c..618e6f4f0d6e792e0d0d60edfad2d59e3805ff7c 100644
 --- a/xbmc/guilib/StereoscopicsManager.cpp
 +++ b/xbmc/guilib/StereoscopicsManager.cpp
-@@ -197,6 +197,15 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
+@@ -198,6 +198,15 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
    if (re.RegFind(searchString) > -1)
      stereoMode = "top_bottom";
  
@@ -46321,7 +46284,7 @@ index b34873cba6534086ae243326550385867a03256a..1443acaf0f25df458ae49766e13dd032
  }
  
 diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index 3891a7ed34acb3489a860678d56a8ec049890f6e..974305ff329eb6999c908d5e05d723f93137ae33 100644
+index 4ebc890a52995ca761effad6c30d41cb25b5bdb8..c728dd652d323fb5f0882b7dbd2887fd59dfe0e2 100644
 --- a/xbmc/settings/AdvancedSettings.cpp
 +++ b/xbmc/settings/AdvancedSettings.cpp
 @@ -402,6 +402,7 @@ void CAdvancedSettings::Initialize()
@@ -46341,10 +46304,10 @@ index 3891a7ed34acb3489a860678d56a8ec049890f6e..974305ff329eb6999c908d5e05d723f9
      XMLUtils::GetFloat(pElement, "audiodelayrange", m_videoAudioDelayRange, 10, 600);
      XMLUtils::GetString(pElement, "defaultplayer", m_videoDefaultPlayer);
 diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
-index fc526d11c3a78bc74125429120e29bf295bd3b16..6b0e3b8cf9e3ff40e6af758c54fe7eefb89a131c 100644
+index 64d42f8bdce59d3c7752657e3fe483733e88eda6..faa91950e9546855d71beef4ee96aa33a1318f24 100644
 --- a/xbmc/settings/AdvancedSettings.h
 +++ b/xbmc/settings/AdvancedSettings.h
-@@ -372,6 +372,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
+@@ -373,6 +373,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
      std::string m_stereoscopicregex_3d;
      std::string m_stereoscopicregex_sbs;
      std::string m_stereoscopicregex_tab;
@@ -46353,20 +46316,20 @@ index fc526d11c3a78bc74125429120e29bf295bd3b16..6b0e3b8cf9e3ff40e6af758c54fe7eef
      bool m_useDisplayControlHWStereo;
  
 
-From 4c051282f501f503dd7fffa2c5de404c7f226bf5 Mon Sep 17 00:00:00 2001
+From 0ab5fb723afa7d98dca44bf1934f79a3c57c65ed Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 5 Oct 2015 14:58:05 +0100
-Subject: [PATCH 29/62] [3d] Swap top/bottom sides of GUI
+Subject: [PATCH 30/61] [3d] Swap top/bottom sides of GUI
 
 ---
  xbmc/guilib/GraphicContext.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/guilib/GraphicContext.cpp b/xbmc/guilib/GraphicContext.cpp
-index 3706e4d80b3b31da4c5be0a1b21f36e59d2910f2..e170b3fb05279ffa316794dbce1d4f9dc5697bd0 100644
+index 6b65632fdfcf6278a44e90f61ddb018f2a98763c..80a7809beffa1a03ee41d6ab862ec075c68fed5d 100644
 --- a/xbmc/guilib/GraphicContext.cpp
 +++ b/xbmc/guilib/GraphicContext.cpp
-@@ -266,7 +266,7 @@ CPoint CGraphicContext::StereoCorrection(const CPoint &point) const
+@@ -267,7 +267,7 @@ CPoint CGraphicContext::StereoCorrection(const CPoint &point) const
    {
      const RESOLUTION_INFO info = GetResInfo();
  
@@ -46376,10 +46339,10 @@ index 3706e4d80b3b31da4c5be0a1b21f36e59d2910f2..e170b3fb05279ffa316794dbce1d4f9d
    }
    if(m_stereoMode == RENDER_STEREO_MODE_SPLIT_VERTICAL)
 
-From f29ad40c8e501bebc8aa27133b3197ed9b7314dc Mon Sep 17 00:00:00 2001
+From 8b51ad77c3bfd6a2610c8d22f69d43472f60c6a1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 11 Oct 2015 20:51:37 +0100
-Subject: [PATCH 30/62] Revert "Revert "Disable extra logging by default""
+Subject: [PATCH 31/61] Revert "Revert "Disable extra logging by default""
 
 This reverts commit a880554325be187b877cd8f0e2b338e7267da636.
 ---
@@ -46387,10 +46350,10 @@ This reverts commit a880554325be187b877cd8f0e2b338e7267da636.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 326ffbd0f08428c3b4a95208134253feeabf1b1f..22dcff1c06577055f84c3d2c2fda73cfa16c53d4 100644
+index 38a772b4e5f59cdd30293850752a761dbe532177..068ca2d519cb7537e0d3ad05c83d47d341a34250 100644
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
-@@ -2822,12 +2822,12 @@
+@@ -2967,12 +2967,12 @@
          </setting>
          <setting id="debug.extralogging" type="boolean" label="666" help="36394">
            <level>1</level>
@@ -46406,10 +46369,10 @@ index 326ffbd0f08428c3b4a95208134253feeabf1b1f..22dcff1c06577055f84c3d2c2fda73cf
              <options>loggingcomponents</options>
              <delimiter>,</delimiter>
 
-From 27644a4501775081bd9d7e70c3dc327b2edf5575 Mon Sep 17 00:00:00 2001
+From a09f9dc59e0d42a32a98fdf89ee84282a327d8dd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 21 Dec 2015 22:17:25 +0000
-Subject: [PATCH 31/62] [omximage] Fall back to arm jpeg encode/decode when gpu
+Subject: [PATCH 32/61] [omximage] Fall back to arm jpeg encode/decode when gpu
  is busy
 
 ---
@@ -46418,10 +46381,10 @@ Subject: [PATCH 31/62] [omximage] Fall back to arm jpeg encode/decode when gpu
  2 files changed, 48 insertions(+), 9 deletions(-)
 
 diff --git a/xbmc/cores/omxplayer/OMXImage.cpp b/xbmc/cores/omxplayer/OMXImage.cpp
-index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20a72d762d 100644
+index c16f3d626ac749d17e2896474ee06be7acdded5f..bfc0440998b69f3f998378ea665246a63448fec8 100644
 --- a/xbmc/cores/omxplayer/OMXImage.cpp
 +++ b/xbmc/cores/omxplayer/OMXImage.cpp
-@@ -57,12 +57,17 @@ static XbmcThreads::ConditionVariable g_count_cond;
+@@ -56,12 +56,17 @@ static XbmcThreads::ConditionVariable g_count_cond;
  static CCriticalSection               g_count_lock;
  static int g_count_val;
  
@@ -46440,7 +46403,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
  }
  
  static void limit_calls_leave()
-@@ -112,6 +117,9 @@ bool COMXImage::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int w
+@@ -111,6 +116,9 @@ bool COMXImage::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int w
        unsigned int format, unsigned int pitch, const std::string& destFile)
  {
    COMXImageEnc omxImageEnc;
@@ -46450,7 +46413,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    bool ret = omxImageEnc.CreateThumbnailFromSurface(buffer, width, height, format, pitch, destFile);
    if (!ret)
      CLog::Log(LOGNOTICE, "%s: unable to create thumbnail %s %dx%d", __func__, destFile.c_str(), width, height);
-@@ -205,6 +213,8 @@ bool COMXImage::CreateThumb(const std::string& srcFile, unsigned int maxHeight,
+@@ -204,6 +212,8 @@ bool COMXImage::CreateThumb(const std::string& srcFile, unsigned int maxHeight,
    bool okay = false;
    COMXImageFile file;
    COMXImageReEnc reenc;
@@ -46459,7 +46422,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    void *pDestBuffer;
    unsigned int nDestSize;
    int orientation = additional_info == "flipped" ? 1:0;
-@@ -310,6 +320,9 @@ bool COMXImage::DecodeJpegToTexture(COMXImageFile *file, unsigned int width, uns
+@@ -309,6 +319,9 @@ bool COMXImage::DecodeJpegToTexture(COMXImageFile *file, unsigned int width, uns
    bool ret = false;
    COMXTexture omx_image;
  
@@ -46469,7 +46432,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    struct textureinfo *tex = new struct textureinfo;
    if (!tex)
      return NULL;
-@@ -924,7 +937,7 @@ bool COMXImageFile::ReadFile(const std::string& inputFile, int orientation)
+@@ -923,7 +936,7 @@ bool COMXImageFile::ReadFile(const std::string& inputFile, int orientation)
  
  COMXImageDec::COMXImageDec()
  {
@@ -46478,7 +46441,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    m_decoded_buffer = NULL;
    OMX_INIT_STRUCTURE(m_decoded_format);
    m_success = false;
-@@ -936,7 +949,8 @@ COMXImageDec::~COMXImageDec()
+@@ -935,7 +948,8 @@ COMXImageDec::~COMXImageDec()
  
    OMX_INIT_STRUCTURE(m_decoded_format);
    m_decoded_buffer = NULL;
@@ -46488,7 +46451,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
  }
  
  void COMXImageDec::Close()
-@@ -1086,6 +1100,9 @@ bool COMXImageDec::HandlePortSettingChange(unsigned int resize_width, unsigned i
+@@ -1085,6 +1099,9 @@ bool COMXImageDec::HandlePortSettingChange(unsigned int resize_width, unsigned i
  
  bool COMXImageDec::Decode(const uint8_t *demuxer_content, unsigned demuxer_bytes, unsigned width, unsigned height, unsigned stride, void *pixels)
  {
@@ -46498,7 +46461,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    CSingleLock lock(m_OMXSection);
    OMX_ERRORTYPE omx_err = OMX_ErrorNone;
    OMX_BUFFERHEADERTYPE *omx_buffer = NULL;
-@@ -1223,7 +1240,7 @@ bool COMXImageDec::Decode(const uint8_t *demuxer_content, unsigned demuxer_bytes
+@@ -1222,7 +1239,7 @@ bool COMXImageDec::Decode(const uint8_t *demuxer_content, unsigned demuxer_bytes
  
  COMXImageEnc::COMXImageEnc()
  {
@@ -46507,7 +46470,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    CSingleLock lock(m_OMXSection);
    OMX_INIT_STRUCTURE(m_encoded_format);
    m_encoded_buffer = NULL;
-@@ -1247,11 +1264,15 @@ COMXImageEnc::~COMXImageEnc()
+@@ -1246,11 +1263,15 @@ COMXImageEnc::~COMXImageEnc()
        m_omx_encoder.Deinitialize();
      }
    }
@@ -46524,7 +46487,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    CSingleLock lock(m_OMXSection);
  
    unsigned int demuxer_bytes = 0;
-@@ -1432,6 +1453,9 @@ bool COMXImageEnc::Encode(unsigned char *buffer, int size, unsigned width, unsig
+@@ -1431,6 +1452,9 @@ bool COMXImageEnc::Encode(unsigned char *buffer, int size, unsigned width, unsig
  bool COMXImageEnc::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int width, unsigned int height,
      unsigned int format, unsigned int pitch, const std::string& destFile)
  {
@@ -46534,7 +46497,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    if(format != XB_FMT_A8R8G8B8 || !buffer)
    {
      CLog::Log(LOGDEBUG, "%s::%s : %s failed format=0x%x\n", CLASSNAME, __func__, destFile.c_str(), format);
-@@ -1465,7 +1489,7 @@ bool COMXImageEnc::CreateThumbnailFromSurface(unsigned char* buffer, unsigned in
+@@ -1464,7 +1488,7 @@ bool COMXImageEnc::CreateThumbnailFromSurface(unsigned char* buffer, unsigned in
  
  COMXImageReEnc::COMXImageReEnc()
  {
@@ -46543,7 +46506,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    m_encoded_buffer = NULL;
    m_pDestBuffer = NULL;
    m_nDestAllocSize = 0;
-@@ -1479,7 +1503,8 @@ COMXImageReEnc::~COMXImageReEnc()
+@@ -1478,7 +1502,8 @@ COMXImageReEnc::~COMXImageReEnc()
      free (m_pDestBuffer);
    m_pDestBuffer = NULL;
    m_nDestAllocSize = 0;
@@ -46553,7 +46516,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
  }
  
  void COMXImageReEnc::Close()
-@@ -1771,6 +1796,9 @@ bool COMXImageReEnc::HandlePortSettingChange(unsigned int resize_width, unsigned
+@@ -1770,6 +1795,9 @@ bool COMXImageReEnc::HandlePortSettingChange(unsigned int resize_width, unsigned
  
  bool COMXImageReEnc::ReEncode(COMXImageFile &srcFile, unsigned int maxWidth, unsigned int maxHeight, void * &pDestBuffer, unsigned int &nDestSize)
  {
@@ -46563,7 +46526,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    CSingleLock lock(m_OMXSection);
    OMX_ERRORTYPE omx_err = OMX_ErrorNone;
  
-@@ -1943,14 +1971,15 @@ bool COMXImageReEnc::ReEncode(COMXImageFile &srcFile, unsigned int maxWidth, uns
+@@ -1942,14 +1970,15 @@ bool COMXImageReEnc::ReEncode(COMXImageFile &srcFile, unsigned int maxWidth, uns
  
  COMXTexture::COMXTexture()
  {
@@ -46581,7 +46544,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
  }
  
  void COMXTexture::Close()
-@@ -2134,6 +2163,9 @@ bool COMXTexture::HandlePortSettingChange(unsigned int resize_width, unsigned in
+@@ -2133,6 +2162,9 @@ bool COMXTexture::HandlePortSettingChange(unsigned int resize_width, unsigned in
  
  bool COMXTexture::Decode(const uint8_t *demuxer_content, unsigned demuxer_bytes, unsigned int width, unsigned int height, void *egl_image)
  {
@@ -46592,7 +46555,7 @@ index d2560aa78980e44d5f2d1483bce976cb83353502..e16dbf00b8d8192df4c6e946a48d8f20
    OMX_ERRORTYPE omx_err = OMX_ErrorNone;
  
 diff --git a/xbmc/cores/omxplayer/OMXImage.h b/xbmc/cores/omxplayer/OMXImage.h
-index a93aa82663903fb1bf712058c2e259290ee742e6..6f38dbc7e5cc721c59a3633935f08218eb1dd169 100644
+index e44fb6ef0ba5fd011fdfc6771c946ffcfb8d581c..f1febd69aaa3522d252802ca00b6746022be41c6 100644
 --- a/xbmc/cores/omxplayer/OMXImage.h
 +++ b/xbmc/cores/omxplayer/OMXImage.h
 @@ -133,6 +133,7 @@ protected:
@@ -46652,10 +46615,10 @@ index a93aa82663903fb1bf712058c2e259290ee742e6..6f38dbc7e5cc721c59a3633935f08218
  
  extern COMXImage g_OMXImage;
 
-From 7d8d250f20930ac4d8684579b45c122f80b19bdd Mon Sep 17 00:00:00 2001
+From 51006cbbf493f5441929a0e44f476ec4088d0bf1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Dec 2015 13:31:14 +0000
-Subject: [PATCH 32/62] [mmalcodec] Fail to open when width is invalid. Can
+Subject: [PATCH 33/61] [mmalcodec] Fail to open when width is invalid. Can
  happen with mpegts files
 
 ---
@@ -46663,24 +46626,24 @@ Subject: [PATCH 32/62] [mmalcodec] Fail to open when width is invalid. Can
  1 file changed, 3 insertions(+)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-index 822b7bf75f2e732b5eed8687403d0eda503fa641..c43952d4d29b42f3a5c7605573294568f79ca010 100644
+index 4f5de0341b344c77a12c936f4f573c2911c0bb7b..4f07113ade696aa4bbefb2dd2a2e17d5f12e9ab9 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-@@ -368,6 +368,9 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+@@ -366,6 +366,9 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-     CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d renderer:%p", CLASSNAME, __func__, CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL), hints.software, hints.width, hints.height, options.m_opaque_pointer);
+     CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d renderer:%p", CLASSNAME, __func__, CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL), hints.software, hints.width, hints.height, options.m_opaque_pointer);
  
 +  // This occurs at start of m2ts files before streams have been fully identified - just ignore
 +  if (!hints.width)
 +    return false;
    // we always qualify even if DVDFactoryCodec does this too.
-   if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
+   if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
      return false;
 
-From d458533c19e59c92917de490a1214fd883f59ab2 Mon Sep 17 00:00:00 2001
+From c13c8baae03db8c4a669215a468e00eb555dc723 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 19 Sep 2014 11:54:49 +0100
-Subject: [PATCH 33/62] [videoplayer/rbp] Add pi specific option to maintain
+Subject: [PATCH 34/61] [videoplayer/rbp] Add pi specific option to maintain
  vsync with pll adjustment
 
 New A/V sync option in settings/video/playback to do "Adjust PLL".
@@ -46702,10 +46665,10 @@ or drop/dupe audio packets which is normally required.
  12 files changed, 143 insertions(+), 21 deletions(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index ae3aa10aa65beac6689f129d60056cadf8a5b5c1..7c7969d381bf15ac1ba2fd8f16e463f6b12fe4c3 100644
+index b52e18a39cc14e0712b44baa8a2e0068e5292d8c..a4607cfa2f6c41e2cc0a7b8fa8ee257a917be0c3 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -19767,3 +19767,35 @@ msgstr ""
+@@ -20464,3 +20464,35 @@ msgstr ""
  msgctxt "#38190"
  msgid "Extract thumbnails from video files"
  msgstr ""
@@ -46767,10 +46730,10 @@ index 289dc55ec41aa44848519a05f8ee1ccc72740085..2572e25753712186f69390965ee1448b
        <group id="3">
          <setting id="audiooutput.ac3transcode" help="37024">
 diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
-index f5671b8dfb03216301d936ae3b08bfc3e8225729..68399ab14faf813bd195d2fdf03a4a376307b4cd 100644
+index 61787f99f95dbf3d637b62185d1496909d7ee0a6..b77b6098c7138157817567de471ded718b204227 100644
 --- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
 +++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
-@@ -363,11 +363,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
+@@ -364,11 +364,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
            m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::APPFOCUSED, msg->data, sizeof(bool));
            return;
          case CActiveAEControlProtocol::STREAMRESAMPLEMODE:
@@ -46786,7 +46749,7 @@ index f5671b8dfb03216301d936ae3b08bfc3e8225729..68399ab14faf813bd195d2fdf03a4a37
              par->stream->m_resampleIntegral = 0.0;
            }
            return;
-@@ -2456,7 +2457,14 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
+@@ -2457,7 +2458,14 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
    {
      if (stream->m_processingBuffers)
      {
@@ -46802,7 +46765,7 @@ index f5671b8dfb03216301d936ae3b08bfc3e8225729..68399ab14faf813bd195d2fdf03a4a37
      }
    }
    else if (stream->m_processingBuffers)
-@@ -3322,13 +3330,14 @@ void CActiveAE::SetStreamResampleRatio(CActiveAEStream *stream, double ratio)
+@@ -3323,13 +3331,14 @@ void CActiveAE::SetStreamResampleRatio(CActiveAEStream *stream, double ratio)
                                       &msg, sizeof(MsgStreamParameter));
  }
  
@@ -46822,7 +46785,7 @@ index f5671b8dfb03216301d936ae3b08bfc3e8225729..68399ab14faf813bd195d2fdf03a4a37
  
  void CActiveAE::SetStreamFFmpegInfo(CActiveAEStream *stream, int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type)
 diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
-index e29eb5719a2e24562a16180e53b2decd955e50a5..e2d3a6824ca0dc93fb08f3374c745ac1dcc63db3 100644
+index 77fc01a24e56298348148b501cd47e41d8d5cad5..c46ef0227b70cd6a2e1c8c327f5c0b2f76353260 100644
 --- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
 +++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
 @@ -177,6 +177,13 @@ struct MsgStreamFFmpegInfo
@@ -46947,7 +46910,7 @@ index 531dedc71f8b342d1556518e1fb7cb051f334e88..80ab096a417d53fcdf7703d11437f92d
    double m_clockSpeed;
    enum AVMatrixEncoding m_matrixEncoding;
 diff --git a/xbmc/cores/AudioEngine/Interfaces/AEStream.h b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
-index 533f6715d4e39215942d9ddd59f1242336daf32d..9e33493fd1a9f252162b8aa982609f161532d8ac 100644
+index dc50f8c82cb6831756e8344784f97e158692c780..02038f09fbcb7e4ac41e32c7c06a936cd16a2175 100644
 --- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
 +++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
 @@ -41,6 +41,14 @@ public:
@@ -46975,7 +46938,7 @@ index 533f6715d4e39215942d9ddd59f1242336daf32d..9e33493fd1a9f252162b8aa982609f16
    /**
     * Registers the audio callback to call with each block of data, this is used by Audio Visualizations
 diff --git a/xbmc/cores/VideoPlayer/DVDAudio.cpp b/xbmc/cores/VideoPlayer/DVDAudio.cpp
-index 2dd9b3689a37874a8199ff6edf64ba0b26d8c69f..8a7c2a7d86422bf7573d00a1f9d3084367ff19aa 100644
+index de1ad64523c3c9799ca24a86fce0dfec459366db..c3312daaf15ceed0072d640d2d49dc0a47128a9b 100644
 --- a/xbmc/cores/VideoPlayer/DVDAudio.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDAudio.cpp
 @@ -313,12 +313,12 @@ double CDVDAudio::GetResampleRatio()
@@ -46994,10 +46957,10 @@ index 2dd9b3689a37874a8199ff6edf64ba0b26d8c69f..8a7c2a7d86422bf7573d00a1f9d30843
  }
  
 diff --git a/xbmc/cores/VideoPlayer/DVDAudio.h b/xbmc/cores/VideoPlayer/DVDAudio.h
-index 81882a1a3828e3f95df26c1bd88c061d3b994b44..ed6974b1155a7272f3ef5bfed3f749674b831b93 100644
+index 0bbd2968b4e219aee04a31333b17981cd61b7dbc..a400677a782143a085daac0df22756a6cb8bb148 100644
 --- a/xbmc/cores/VideoPlayer/DVDAudio.h
 +++ b/xbmc/cores/VideoPlayer/DVDAudio.h
-@@ -61,7 +61,7 @@ public:
+@@ -58,7 +58,7 @@ public:
    double GetSyncError();
    void SetSyncErrorCorrection(double correction);
    double GetResampleRatio();
@@ -47007,18 +46970,18 @@ index 81882a1a3828e3f95df26c1bd88c061d3b994b44..ed6974b1155a7272f3ef5bfed3f74967
    void Drain();
    void AbortAddPackets();
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
-index 9db3a9cc91fd5f9b194d6c1aa66aa02121164c29..56170f48cda417554c57b2adf934c2df58a23abf 100644
+index 1f184e78d28a7430bca7d4f39de1f49adf33b56c..3b2ac69ae174d76d83ed55cdc999afaa90f0ee39 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
-@@ -96,6 +96,7 @@ bool CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints)
-   bool allowpassthrough = !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
+@@ -97,6 +97,7 @@ bool CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints)
+   bool allowpassthrough = !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
    if (hints.realtime)
      allowpassthrough = false;
-+  allowpassthrough |= CSettings::GetInstance().GetInt("audiooutput.plladjust") > 0;
++  allowpassthrough |= CServiceBroker::GetSettings().GetInt("audiooutput.plladjust") > 0;
    CDVDAudioCodec* codec = CDVDFactoryCodec::CreateAudioCodec(hints, m_processInfo, allowpassthrough, m_processInfo.AllowDTSHDDecode());
    if(!codec)
    {
-@@ -217,8 +218,12 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
+@@ -218,8 +219,12 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
  
    //print the inverse of the resample ratio, since that makes more sense
    //if the resample ratio is 0.5, then we're playing twice as fast
@@ -47031,12 +46994,12 @@ index 9db3a9cc91fd5f9b194d6c1aa66aa02121164c29..56170f48cda417554c57b2adf934c2df
  
    s << ", att:" << std::fixed << std::setprecision(1) << log(GetCurrentAttenuation()) * 20.0f << " dB";
  
-@@ -541,10 +546,12 @@ void CVideoPlayerAudio::SetSyncType(bool passthrough)
+@@ -542,10 +547,12 @@ void CVideoPlayerAudio::SetSyncType(bool passthrough)
      int synctype = (m_synctype >= 0 && m_synctype <= 1) ? m_synctype : 2;
      CLog::Log(LOGDEBUG, "CVideoPlayerAudio:: synctype set to %i: %s", m_synctype, synctypes[synctype]);
      m_prevsynctype = m_synctype;
 +    const float plladjusts[] = { 0.0f, 0.00001f, 0.0001f, 0.001f, 0.01f };
-+    float plladjust = plladjusts[CSettings::GetInstance().GetInt("audiooutput.plladjust")];
++    float plladjust = plladjusts[CServiceBroker::GetSettings().GetInt("audiooutput.plladjust")];
      if (m_synctype == SYNC_RESAMPLE)
 -      m_dvdAudio.SetResampleMode(1);
 +      m_dvdAudio.SetResampleMode(1, plladjust);
@@ -47046,19 +47009,19 @@ index 9db3a9cc91fd5f9b194d6c1aa66aa02121164c29..56170f48cda417554c57b2adf934c2df
    }
  }
  
-@@ -602,6 +609,7 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
-   bool allowpassthrough = !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
+@@ -603,6 +610,7 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
+   bool allowpassthrough = !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
    if (m_streaminfo.realtime)
      allowpassthrough = false;
-+  allowpassthrough |= CSettings::GetInstance().GetInt("audiooutput.plladjust") > 0;
++  allowpassthrough |= CServiceBroker::GetSettings().GetInt("audiooutput.plladjust") > 0;
    CDVDAudioCodec *codec = CDVDFactoryCodec::CreateAudioCodec(m_streaminfo, m_processInfo, allowpassthrough, m_processInfo.AllowDTSHDDecode());
    if (!codec || codec->NeedPassthrough() == m_pAudioCodec->NeedPassthrough()) {
      // passthrough state has not changed
 diff --git a/xbmc/linux/RBP.cpp b/xbmc/linux/RBP.cpp
-index 5a6f780517cff0c31f1c40e5e95445d448eb2297..6e8529001b1a464b4547a846f553d98f5bc0b6c0 100644
+index c073dc28db9abc24025909e2d91b7ce49201f4ea..e4bff70c0b8bc934e55fb8e68c6d5e35ce92c66f 100644
 --- a/xbmc/linux/RBP.cpp
 +++ b/xbmc/linux/RBP.cpp
-@@ -46,6 +46,8 @@ CRBP::CRBP()
+@@ -47,6 +47,8 @@ CRBP::CRBP()
    m_DllBcmHost      = new DllBcmHost();
    m_OMX             = new COMXCore();
    m_display = DISPMANX_NO_HANDLE;
@@ -47067,7 +47030,7 @@ index 5a6f780517cff0c31f1c40e5e95445d448eb2297..6e8529001b1a464b4547a846f553d98f
    m_mb = mbox_open();
    vcsm_init();
    m_vsync_count = 0;
-@@ -153,6 +155,8 @@ void CRBP::CloseDisplay(DISPMANX_DISPLAY_HANDLE_T display)
+@@ -154,6 +156,8 @@ void CRBP::CloseDisplay(DISPMANX_DISPLAY_HANDLE_T display)
    assert(s == 0);
    vc_dispmanx_display_close(m_display);
    m_display = DISPMANX_NO_HANDLE;
@@ -47076,7 +47039,7 @@ index 5a6f780517cff0c31f1c40e5e95445d448eb2297..6e8529001b1a464b4547a846f553d98f
  }
  
  void CRBP::GetDisplaySize(int &width, int &height)
-@@ -366,4 +370,20 @@ void CGPUMEM::Flush()
+@@ -367,4 +371,20 @@ void CGPUMEM::Flush()
    vcsm_clean_invalid( &iocache );
  }
  
@@ -47098,10 +47061,10 @@ index 5a6f780517cff0c31f1c40e5e95445d448eb2297..6e8529001b1a464b4547a846f553d98f
 +
  #endif
 diff --git a/xbmc/linux/RBP.h b/xbmc/linux/RBP.h
-index fffa5182126159f6dfcf750b21fa0464e229e545..815d758e7086d73b4d4eb16849fdbb509a3c251d 100644
+index 26a2a4bd74b54288282b534c5de7d59d6ccec7f5..79e676b1dee78f808a359dbee781fa80cf9be82e 100644
 --- a/xbmc/linux/RBP.h
 +++ b/xbmc/linux/RBP.h
-@@ -82,6 +82,8 @@ public:
+@@ -81,6 +81,8 @@ public:
    uint32_t WaitVsync(uint32_t target = ~0U);
    void VSyncCallback();
    int GetMBox() { return m_mb; }
@@ -47110,7 +47073,7 @@ index fffa5182126159f6dfcf750b21fa0464e229e545..815d758e7086d73b4d4eb16849fdbb50
  
  private:
    DllBcmHost *m_DllBcmHost;
-@@ -103,6 +105,9 @@ private:
+@@ -102,6 +104,9 @@ private:
    CCriticalSection m_critSection;
  
    int m_mb;
@@ -47121,10 +47084,10 @@ index fffa5182126159f6dfcf750b21fa0464e229e545..815d758e7086d73b4d4eb16849fdbb50
  
  extern CRBP g_RBP;
 
-From 5798c44c892111b789e14fb89e15dec6e8a5dcb4 Mon Sep 17 00:00:00 2001
+From efbb569ea1c6f060f1745c0a25b242210523d8ee Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 7 May 2015 15:35:43 +0100
-Subject: [PATCH 34/62] rbp: Support zero copy interface with hevc acceleration
+Subject: [PATCH 35/61] rbp: Support zero copy interface with hevc acceleration
 
 ---
  xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp | 9 +++++++++
@@ -47132,10 +47095,10 @@ Subject: [PATCH 34/62] rbp: Support zero copy interface with hevc acceleration
  2 files changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-index 4129d3d6a77ce1a3f15bad045746970f6e640ea6..619515c9411172261d8f0bef24c5d679c35e5d7d 100644
+index 8b59b1825c4fdee83ec4afc13403126153f8071d..c4eda5a2c78db1f6acc9ed59938ea3f42262d8fe 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-@@ -368,6 +368,15 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
+@@ -366,6 +366,15 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
      if (tryhw && m_decoderState == STATE_NONE)
      {
        m_decoderState = STATE_HW_SINGLE;
@@ -47152,7 +47115,7 @@ index 4129d3d6a77ce1a3f15bad045746970f6e640ea6..619515c9411172261d8f0bef24c5d679
      else
      {
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
-index 77ae3273bc8e224fe6c193300ccef32fb7fbafe1..c0b3f19f2ef9cdef9adf00cf81154803b12feb4f 100644
+index 3b6307725d938aae12f093b2691f3b9bf8373fe7..689ed0fddcc05175857e4cc57f23092ab9b81ddc 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
 @@ -296,8 +296,9 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture
@@ -47168,10 +47131,10 @@ index 77ae3273bc8e224fe6c193300ccef32fb7fbafe1..c0b3f19f2ef9cdef9adf00cf81154803
    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
      CLog::Log(LOGDEBUG, "%s::%s - mmal:%p dts:%.3f pts:%.3f buf:%p gpu:%p", CLASSNAME, __FUNCTION__, picture->MMALBuffer->mmal_buffer, 1e-6*picture->dts, 1e-6*picture->pts, picture->MMALBuffer, gmem);
 
-From 0a99bc0eb1d4a036f4df0d9f88c0f8bb3c6b0e6d Mon Sep 17 00:00:00 2001
+From 876a171ddf8444e3ddf017f3543abca1d06d9882 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 16 May 2015 18:26:04 +0100
-Subject: [PATCH 35/62] ffmpeg: use upstream mvc patches
+Subject: [PATCH 36/61] ffmpeg: use upstream mvc patches
 
 ---
  ...vcodec-add-h264_mvc-codec-id-and-profiles.patch |  68 ++++++++++++
@@ -47481,10 +47444,10 @@ index 0000000000000000000000000000000000000000..b39480ad098b9cd0882fcf75b96afb1b
 +2.7.4
 +
 
-From 7d4ef5a5e251a218f9609c0e2bb0cb7d3093f8b9 Mon Sep 17 00:00:00 2001
+From 407309dc8fcd7db189227af64b01f75337316d61 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Fri, 29 Jan 2016 17:18:50 +0300
-Subject: [PATCH 36/62] [win32] Settings: Added setting to enable/disable MVC
+Subject: [PATCH 37/61] [win32] Settings: Added setting to enable/disable MVC
  decoder.
 
 ---
@@ -47514,10 +47477,10 @@ index a017d30c24232fb01220b87b29398403b8ed9662..2fcee72a64e8b701c8e895143410bbe9
      <category id="display">
        <group id="1">
 
-From 492201a86d20da77a664e197a42f4a32945420be Mon Sep 17 00:00:00 2001
+From 35a4f32d2bf49501c2bb47d897f300de64f74fab Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Wed, 20 Jan 2016 17:02:16 +0300
-Subject: [PATCH 37/62] [VideoPlayer] DemuxFFmpeg: Properly demuxing h264_mvc
+Subject: [PATCH 38/61] [VideoPlayer] DemuxFFmpeg: Properly demuxing h264_mvc
  streams.
 
 ---
@@ -47525,7 +47488,7 @@ Subject: [PATCH 37/62] [VideoPlayer] DemuxFFmpeg: Properly demuxing h264_mvc
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff815cc74433 100644
+index b485ad23e6309647db2bc489ed6bfda60cf506a1..50889977723cf3857216d68100fe0b3575253c92 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 @@ -25,6 +25,7 @@
@@ -47536,7 +47499,7 @@ index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff81
  #include "DVDClock.h" // for DVD_TIME_BASE
  #include "DVDDemuxUtils.h"
  #include "DVDInputStreams/DVDInputStream.h"
-@@ -1355,6 +1356,15 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1356,6 +1357,15 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
        }
      case AVMEDIA_TYPE_VIDEO:
        {
@@ -47552,7 +47515,7 @@ index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff81
          CDemuxStreamVideoFFmpeg* st = new CDemuxStreamVideoFFmpeg(this, pStream);
          stream = st;
          if(strcmp(m_pFormatContext->iformat->name, "flv") == 0)
-@@ -1363,7 +1373,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1364,7 +1374,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
            st->bVFR = false;
  
          // never trust pts in avi files with h264.
@@ -47561,7 +47524,7 @@ index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff81
            st->bPTSInvalid = true;
  
  #if defined(AVFORMAT_HAS_STREAM_GET_R_FRAME_RATE)
-@@ -1434,6 +1444,17 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1436,6 +1446,17 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
          if (av_dict_get(pStream->metadata, "title", NULL, 0))
            st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
  
@@ -47580,10 +47543,10 @@ index 54a18c669a058b705e0276cb7e14522ae6cd04ae..55431978dcfabee8da95e2e76292ff81
        }
      case AVMEDIA_TYPE_DATA:
 
-From f32639c9513373f4c25dac7d9697f8c04760a7c8 Mon Sep 17 00:00:00 2001
+From 99c0ebc7b145c9b17bb6e3f4a765c9f7e018afd3 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Thu, 25 Feb 2016 11:21:25 +0300
-Subject: [PATCH 38/62] [Stereo3D] Added block_lr and block_rl to supported
+Subject: [PATCH 39/61] [Stereo3D] Added block_lr and block_rl to supported
  modes.
 
 ---
@@ -47607,10 +47570,10 @@ index 24b1b10519467cbbfd96f7048efaf49aab7700cc..49f7f7ca7e144a259f6d06bd11cd97aa
      return convert[mode];
    }
 diff --git a/xbmc/guilib/StereoscopicsManager.cpp b/xbmc/guilib/StereoscopicsManager.cpp
-index 1443acaf0f25df458ae49766e13dd0323454f2eb..6aaa82f4d883b8cae0ccdedf6c5a6814e7aaa720 100644
+index 618e6f4f0d6e792e0d0d60edfad2d59e3805ff7c..041324c51977ce880ab365a16f1ac366c79e369c 100644
 --- a/xbmc/guilib/StereoscopicsManager.cpp
 +++ b/xbmc/guilib/StereoscopicsManager.cpp
-@@ -70,8 +70,10 @@ static const struct StereoModeMap VideoModeToGuiModeMap[] =
+@@ -71,8 +71,10 @@ static const struct StereoModeMap VideoModeToGuiModeMap[] =
    { "anaglyph_cyan_red",        RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN },
    { "anaglyph_green_magenta",   RENDER_STEREO_MODE_ANAGLYPH_GREEN_MAGENTA },
    { "anaglyph_yellow_blue",     RENDER_STEREO_MODE_ANAGLYPH_YELLOW_BLUE },
@@ -47623,7 +47586,7 @@ index 1443acaf0f25df458ae49766e13dd0323454f2eb..6aaa82f4d883b8cae0ccdedf6c5a6814
    {}
  };
  
-@@ -310,7 +312,7 @@ int CStereoscopicsManager::ConvertVideoToGuiStereoMode(const std::string &mode)
+@@ -311,7 +313,7 @@ int CStereoscopicsManager::ConvertVideoToGuiStereoMode(const std::string &mode)
    size_t i = 0;
    while (VideoModeToGuiModeMap[i].name)
    {
@@ -47633,20 +47596,20 @@ index 1443acaf0f25df458ae49766e13dd0323454f2eb..6aaa82f4d883b8cae0ccdedf6c5a6814
      i++;
    }
 
-From 653902ed14aa61b97188eb1ce3bcfa47bc95046e Mon Sep 17 00:00:00 2001
+From 2990091f969247e6c2b958a2415b9437d7096682 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Sat, 23 Jan 2016 10:21:32 +0300
-Subject: [PATCH 39/62] [VideoPlayer] Fix possible wrong aspect.
+Subject: [PATCH 40/61] [VideoPlayer] Fix possible wrong aspect.
 
 ---
  xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-index 903f0d83527d9088ff1bf0ba056f357f6abfda81..a5a33d34c70892cde77ad4d8f3cb65fdd9703081 100644
+index d4920ac30216fb295a16b70ddff887e2077ee196..4f0e2cb561b5453217e961921049486dcd0636b3 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-@@ -181,7 +181,7 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
+@@ -182,7 +182,7 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
    }
  
    // use aspect in stream if available
@@ -47656,10 +47619,10 @@ index 903f0d83527d9088ff1bf0ba056f357f6abfda81..a5a33d34c70892cde77ad4d8f3cb65fd
    else
      m_fForcedAspectRatio = 0.0;
 
-From bb360aef2259c1ac131f9829726f42aaf7ddde8e Mon Sep 17 00:00:00 2001
+From be0b130b5ae5b0a4830711303e6166e5093f1dc2 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Fri, 22 Jan 2016 18:18:33 +0300
-Subject: [PATCH 40/62] [VideoPlayer] DemuxFFmpeg: ssif remux
+Subject: [PATCH 41/61] [VideoPlayer] DemuxFFmpeg: ssif remux
 
 ---
  xbmc/cores/VideoPlayer/DVDDemuxers/CMakeLists.txt  |   2 +
@@ -47667,9 +47630,8 @@ Subject: [PATCH 40/62] [VideoPlayer] DemuxFFmpeg: ssif remux
  .../cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h |   2 +
  .../VideoPlayer/DVDDemuxers/DemuxStreamSSIF.cpp    | 156 +++++++++++++++++++++
  .../VideoPlayer/DVDDemuxers/DemuxStreamSSIF.h      |  49 +++++++
- xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in     |   1 +
  xbmc/settings/AdvancedSettings.cpp                 |   2 +-
- 7 files changed, 251 insertions(+), 8 deletions(-)
+ 6 files changed, 250 insertions(+), 8 deletions(-)
  create mode 100644 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxStreamSSIF.cpp
  create mode 100644 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxStreamSSIF.h
 
@@ -47694,10 +47656,10 @@ index 63776b1333bb66483303e44d6ebe60f3cd7e14d7..156ec2021002d9d7a355db2f0dcf099a
              DVDDemuxUtils.h
              DVDDemuxVobsub.h
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89278ce67e 100644
+index 50889977723cf3857216d68100fe0b3575253c92..bd3bd7490c35c487cca232e28a71ba207be74990 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -166,6 +166,7 @@ CDVDDemuxFFmpeg::CDVDDemuxFFmpeg() : CDVDDemux()
+@@ -167,6 +167,7 @@ CDVDDemuxFFmpeg::CDVDDemuxFFmpeg() : CDVDDemux()
    m_currentPts = DVD_NOPTS_VALUE;
    m_bMatroska = false;
    m_bAVI = false;
@@ -47705,7 +47667,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
    m_speed = DVD_PLAYSPEED_NORMAL;
    m_program = UINT_MAX;
    m_pkt.result = -1;
-@@ -553,6 +554,8 @@ void CDVDDemuxFFmpeg::Dispose()
+@@ -554,6 +555,8 @@ void CDVDDemuxFFmpeg::Dispose()
    m_pkt.result = -1;
    av_packet_unref(&m_pkt.pkt);
  
@@ -47714,7 +47676,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
    if (m_pFormatContext)
    {
      for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
-@@ -606,6 +609,9 @@ void CDVDDemuxFFmpeg::Flush()
+@@ -607,6 +610,9 @@ void CDVDDemuxFFmpeg::Flush()
  
    m_displayTime = 0;
    m_dtsAtDisplayTime = DVD_NOPTS_VALUE;
@@ -47724,7 +47686,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
  }
  
  void CDVDDemuxFFmpeg::Abort()
-@@ -878,7 +884,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -879,7 +885,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
      {
        Flush();
      }
@@ -47735,7 +47697,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
      {
        // update streams
        CreateStreams(m_program);
-@@ -906,6 +914,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -907,6 +915,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
  
        m_pkt.result = -1;
        av_packet_unref(&m_pkt.pkt);
@@ -47745,7 +47707,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
      }
      else
      {
-@@ -915,7 +926,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -916,7 +927,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
  
        if (IsVideoReady())
        {
@@ -47756,7 +47718,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
          {
            /* check so packet belongs to selected program */
            for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
-@@ -1064,6 +1077,15 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -1065,6 +1078,15 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
          stream = AddStream(pPacket->iStreamId);
        }
      }
@@ -47772,7 +47734,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
      if (!stream)
      {
        CLog::Log(LOGERROR, "CDVDDemuxFFmpeg::AddStream - internal error, stream is null");
-@@ -1093,6 +1115,9 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
+@@ -1094,6 +1116,9 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
    m_pkt.result = -1;
    av_packet_unref(&m_pkt.pkt);
  
@@ -47782,7 +47744,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
    CDVDInputStream::IPosTime* ist = m_pInput->GetIPosTime();
    if (ist)
    {
-@@ -1173,6 +1198,9 @@ bool CDVDDemuxFFmpeg::SeekByte(int64_t pos)
+@@ -1174,6 +1199,9 @@ bool CDVDDemuxFFmpeg::SeekByte(int64_t pos)
    m_pkt.result = -1;
    av_packet_unref(&m_pkt.pkt);
  
@@ -47792,7 +47754,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
    return (ret >= 0);
  }
  
-@@ -1358,11 +1386,12 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1359,11 +1387,12 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
        {
          if (pStream->codec->codec_id == AV_CODEC_ID_H264_MVC)
          {
@@ -47808,7 +47770,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
            break;
          }
          CDemuxStreamVideoFFmpeg* st = new CDemuxStreamVideoFFmpeg(this, pStream);
-@@ -1448,7 +1477,11 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1450,7 +1479,11 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
          {
            if (CDVDCodecUtils::IsH264AnnexB(m_pFormatContext->iformat->name, pStream))
            {
@@ -47821,7 +47783,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
            }
            else if (CDVDCodecUtils::ProcessH264MVCExtradata(pStream->codec->extradata, pStream->codec->extradata_size))
            {
-@@ -1560,7 +1593,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1562,7 +1595,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
      if (langTag)
        strncpy(stream->language, langTag->value, 3);
  
@@ -47831,7 +47793,7 @@ index 55431978dcfabee8da95e2e76292ff815cc74433..6df586ac1f2d00e55307358228a4be89
        stream->ExtraSize = pStream->codec->extradata_size;
        stream->ExtraData = new uint8_t[pStream->codec->extradata_size];
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
-index 0bc498e8e387c7ff0aef065832c121d1367454aa..85ce39ee858992a5f095cdf6b4d35398c7ce7dcc 100644
+index 73d536cc06710eab654f05fbc3e011d0c86c6a8b..364675293f73d40d4390b0d64e240df2432e082a 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
 @@ -21,6 +21,7 @@
@@ -47842,7 +47804,7 @@ index 0bc498e8e387c7ff0aef065832c121d1367454aa..85ce39ee858992a5f095cdf6b4d35398
  #include "threads/CriticalSection.h"
  #include "threads/SystemClock.h"
  #include <map>
-@@ -152,6 +153,7 @@ protected:
+@@ -146,6 +147,7 @@ protected:
    double   m_currentPts; // used for stream length estimation
    bool     m_bMatroska;
    bool     m_bAVI;
@@ -48067,20 +48029,8 @@ index 0000000000000000000000000000000000000000..1dafdc58db3f9cb5eac032c591942439
 +  int m_h264StreamId = 0;
 +  int m_mvcStreamId = 0;
 +};
-diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-index e4f8aed0af96fe0dceec4d8517087742f2c7df81..30076937bd084936571abf0e6eeecf5ad916c7b3 100644
---- a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-@@ -10,6 +10,7 @@ SRCS += DVDDemuxUtils.cpp
- SRCS += DVDDemuxVobsub.cpp
- SRCS += DVDDemuxCC.cpp
- SRCS += DVDFactoryDemuxer.cpp
-+SRCS += DemuxStreamSSIF.cpp
- 
- LIB = DVDDemuxers.a
- 
 diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index 974305ff329eb6999c908d5e05d723f93137ae33..985ecf9722141d78471c00e90da15bfad931462a 100644
+index c728dd652d323fb5f0882b7dbd2887fd59dfe0e2..aff4a915c7a129772f4d2272fff386067c578bce 100644
 --- a/xbmc/settings/AdvancedSettings.cpp
 +++ b/xbmc/settings/AdvancedSettings.cpp
 @@ -391,7 +391,7 @@ void CAdvancedSettings::Initialize()
@@ -48093,10 +48043,10 @@ index 974305ff329eb6999c908d5e05d723f93137ae33..985ecf9722141d78471c00e90da15bfa
    m_discStubExtensions = ".disc";
    // internal music extensions
 
-From d5804f4eeee51ca51afea69ff07b5afcd17ed8d9 Mon Sep 17 00:00:00 2001
+From f618079224e4f2a8d178622bcff33de9ed96b9d9 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Tue, 23 Feb 2016 16:02:46 +0300
-Subject: [PATCH 41/62] [3DBD] Added support of 3D-BluRay playback.
+Subject: [PATCH 42/61] [3DBD] Added support of 3D-BluRay playback.
 
 ---
  lib/DllLibbluray.h                                 |   8 +
@@ -48106,10 +48056,9 @@ Subject: [PATCH 41/62] [3DBD] Added support of 3D-BluRay playback.
  xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMVC.h      |  57 +++++
  .../VideoPlayer/DVDDemuxers/DemuxStreamSSIF.cpp    |  40 +++-
  .../VideoPlayer/DVDDemuxers/DemuxStreamSSIF.h      |  12 +-
- xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in     |   1 +
  .../DVDInputStreams/DVDInputStreamBluray.cpp       | 159 ++++++++++--
  .../DVDInputStreams/DVDInputStreamBluray.h         |  20 ++
- 10 files changed, 581 insertions(+), 35 deletions(-)
+ 9 files changed, 580 insertions(+), 35 deletions(-)
  create mode 100644 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMVC.cpp
  create mode 100644 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMVC.h
 
@@ -48174,7 +48123,7 @@ index 156ec2021002d9d7a355db2f0dcf099aabb1db48..87d27b666f703743bb0170252cf1190d
              DVDDemuxUtils.h
              DVDDemuxVobsub.h
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e7971139356 100644
+index bd3bd7490c35c487cca232e28a71ba207be74990..b80f44994dfbc9f4cac37f9cad7926c0d32371e2 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 @@ -27,6 +27,7 @@
@@ -48185,7 +48134,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
  #include "DVDDemuxUtils.h"
  #include "DVDInputStreams/DVDInputStream.h"
  #include "DVDInputStreams/DVDInputStreamFFmpeg.h"
-@@ -503,6 +504,16 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
+@@ -504,6 +505,16 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
  
    UpdateCurrentPTS();
  
@@ -48202,7 +48151,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
    // in case of mpegts and we have not seen pat/pmt, defer creation of streams
    if (!skipCreateStreams || m_pFormatContext->nb_programs > 0)
    {
-@@ -884,9 +895,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -885,9 +896,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
      {
        Flush();
      }
@@ -48213,7 +48162,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
      {
        // update streams
        CreateStreams(m_program);
-@@ -927,8 +936,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -928,8 +937,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
        if (IsVideoReady())
        {
          // libavformat is confused by the interleaved SSIF.
@@ -48223,7 +48172,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
          {
            /* check so packet belongs to selected program */
            for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
-@@ -1079,10 +1087,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
+@@ -1080,10 +1088,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
      }
      if (stream && m_pSSIF)
      {
@@ -48235,7 +48184,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
        if (stream->type == STREAM_DATA && stream->codec == AV_CODEC_ID_H264_MVC && pPacket->iSize)
          stream = GetStream(pPacket->iStreamId);
      }
-@@ -1481,6 +1486,29 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1483,6 +1488,29 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
              {
                m_pSSIF->SetH264StreamId(streamIdx);
                pStream->codec->codec_tag = MKTAG('A', 'M', 'V', 'C');
@@ -48265,7 +48214,7 @@ index 6df586ac1f2d00e55307358228a4be89278ce67e..b7e5081bc0fc32eaaae42d894a288e79
              }
            }
            else if (CDVDCodecUtils::ProcessH264MVCExtradata(pStream->codec->extradata, pStream->codec->extradata_size))
-@@ -1804,6 +1832,11 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
+@@ -1806,6 +1834,11 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
  
  bool CDVDDemuxFFmpeg::IsProgramChange()
  {
@@ -48725,20 +48674,8 @@ index 1dafdc58db3f9cb5eac032c591942439117e13c4..508e9debd3e6679a1433842a65649fa6
 +  int m_h264StreamId = -1;
 +  int m_mvcStreamId = -1;
  };
-diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-index 30076937bd084936571abf0e6eeecf5ad916c7b3..0359426b85683a4c3a80ef0e0d52f7a79564daaa 100644
---- a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-@@ -11,6 +11,7 @@ SRCS += DVDDemuxVobsub.cpp
- SRCS += DVDDemuxCC.cpp
- SRCS += DVDFactoryDemuxer.cpp
- SRCS += DemuxStreamSSIF.cpp
-+SRCS += DVDDemuxMVC.cpp
- 
- LIB = DVDDemuxers.a
- 
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319e3f770c0 100644
+index 55bc91384500f64f6cc4242514aa3104393de2cb..a2c59b137ebdb7a44aea4fe1216eb9a2f43c048c 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 @@ -26,6 +26,8 @@
@@ -48749,8 +48686,8 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
 +#include "DVDDemuxers/DemuxMVC.h"
  #include "settings/Settings.h"
  #include "LangInfo.h"
- #include "utils/log.h"
-@@ -231,10 +233,8 @@ bool CDVDInputStreamBluray::IsEOF()
+ #include "ServiceBroker.h"
+@@ -232,10 +234,8 @@ bool CDVDInputStreamBluray::IsEOF()
  
  BLURAY_TITLE_INFO* CDVDInputStreamBluray::GetTitleLongest()
  {
@@ -48762,7 +48699,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    {
      BLURAY_TITLE_INFO *t = m_dll->bd_get_title_info(m_bd, i, 0);
      if(!t)
-@@ -326,6 +326,7 @@ bool CDVDInputStreamBluray::Open()
+@@ -327,6 +327,7 @@ bool CDVDInputStreamBluray::Open()
      return false;
    }
  
@@ -48770,7 +48707,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    const BLURAY_DISC_INFO *disc_info;
  
    disc_info = m_dll->bd_get_disc_info(m_bd);
-@@ -349,6 +350,7 @@ bool CDVDInputStreamBluray::Open()
+@@ -350,6 +351,7 @@ bool CDVDInputStreamBluray::Open()
      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::Open - BD+ detected        : %d", disc_info->bdplus_detected);
      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::Open - libbdplus detected  : %d", disc_info->libbdplus_detected);
      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::Open - BD+ handled         : %d", disc_info->bdplus_handled);
@@ -48778,15 +48715,15 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    }
    else
      CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - BluRay not detected");
-@@ -365,6 +367,7 @@ bool CDVDInputStreamBluray::Open()
+@@ -366,6 +368,7 @@ bool CDVDInputStreamBluray::Open()
      return false;
    }
  
 +  m_nTitles = m_dll->bd_get_titles(m_bd, TITLES_RELEVANT, 0);
-   int mode = CSettings::GetInstance().GetInt(CSettings::SETTING_DISC_PLAYBACK);
+   int mode = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_DISC_PLAYBACK);
  
    if (URIUtils::HasExtension(filename, ".mpls"))
-@@ -393,18 +396,17 @@ bool CDVDInputStreamBluray::Open()
+@@ -394,18 +397,17 @@ bool CDVDInputStreamBluray::Open()
        m_title = GetTitleLongest();
    }
  
@@ -48809,7 +48746,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
      if(m_dll->bd_play(m_bd) <= 0)
      {
        CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed play disk %s", strPath.c_str());
-@@ -419,21 +421,25 @@ bool CDVDInputStreamBluray::Open()
+@@ -420,21 +422,25 @@ bool CDVDInputStreamBluray::Open()
        CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed to get title info");
        return false;
      }
@@ -48830,7 +48767,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    return true;
  }
  
- // close file and reset everyting
+ // close file and reset everything
  void CDVDInputStreamBluray::Close()
  {
 +  CloseMVCDemux();
@@ -48838,7 +48775,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    if (!m_dll)
      return;
    if(m_title)
-@@ -449,7 +455,7 @@ void CDVDInputStreamBluray::Close()
+@@ -450,7 +456,7 @@ void CDVDInputStreamBluray::Close()
  
  void CDVDInputStreamBluray::ProcessEvent() {
  
@@ -48847,7 +48784,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
    switch (m_event.event) {
  
    case BD_EVENT_ERROR:
-@@ -514,15 +520,17 @@ void CDVDInputStreamBluray::ProcessEvent() {
+@@ -515,15 +521,17 @@ void CDVDInputStreamBluray::ProcessEvent() {
      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PLAYLIST %d",
          m_event.param);
      m_playlist = m_event.param;
@@ -48868,7 +48805,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
      break;
  
    case BD_EVENT_CHAPTER:
-@@ -601,14 +609,20 @@ void CDVDInputStreamBluray::ProcessEvent() {
+@@ -602,14 +610,20 @@ void CDVDInputStreamBluray::ProcessEvent() {
  
    /* event has been consumed */
    m_event.event = BD_EVENT_NONE;
@@ -48890,7 +48827,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
      do {
  
        if(m_hold == HOLD_HELD)
-@@ -658,10 +672,14 @@ int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
+@@ -659,10 +673,14 @@ int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
  
      } while(result == 0);
  
@@ -48907,7 +48844,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
  }
  
  static uint8_t  clamp(double v)
-@@ -909,8 +927,12 @@ bool CDVDInputStreamBluray::PosTime(int ms)
+@@ -910,8 +928,12 @@ bool CDVDInputStreamBluray::PosTime(int ms)
  {
    if(m_dll->bd_seek_time(m_bd, ms * 90) < 0)
      return false;
@@ -48922,7 +48859,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
  }
  
  int CDVDInputStreamBluray::GetChapterCount()
-@@ -933,8 +955,12 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
+@@ -934,8 +956,12 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
  {
    if(m_title && m_dll->bd_seek_chapter(m_bd, ch-1) < 0)
      return false;
@@ -48937,7 +48874,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
  }
  
  int64_t CDVDInputStreamBluray::GetChapterPos(int ch)
-@@ -1132,6 +1158,95 @@ bool CDVDInputStreamBluray::HasMenu()
+@@ -1133,6 +1159,95 @@ bool CDVDInputStreamBluray::HasMenu()
    return m_navmode;
  }
  
@@ -49032,7 +48969,7 @@ index 6ccd9a8c00fdc5175df3ecbb3a5d30dc93e319ab..ad2c65ba5b80c5ac5d055d621a1e8319
 +
  void CDVDInputStreamBluray::SetupPlayerSettings()
  {
-   int region = CSettings::GetInstance().GetInt(CSettings::SETTING_BLURAY_PLAYERREGION);
+   int region = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_BLURAY_PLAYERREGION);
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
 index b967a85e6557e42a7f1235cdd804d5a0263b866f..561fb5cd4f971bc9ee4f41218a60bb3d5bc5625f 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -49086,10 +49023,10 @@ index b967a85e6557e42a7f1235cdd804d5a0263b866f..561fb5cd4f971bc9ee4f41218a60bb3d
    typedef std::shared_ptr<CDVDOverlayImage> SOverlay;
    typedef std::list<SOverlay>                 SOverlays;
 
-From ba23ff0a3563eb2bf120bf5b7b068120112448a8 Mon Sep 17 00:00:00 2001
+From a766c02769cc6506ec0d6392e4bd73b73ee1aa62 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Fri, 11 Mar 2016 16:58:53 +0300
-Subject: [PATCH 42/62] [VideoPlayer] HasVideo returns true if video stream
+Subject: [PATCH 43/61] [VideoPlayer] HasVideo returns true if video stream
  exists. This don't allow start visualization if audio is opened before video.
 
 ---
@@ -49097,10 +49034,10 @@ Subject: [PATCH 42/62] [VideoPlayer] HasVideo returns true if video stream
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayer.cpp b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-index dded334532841911a34d75808c3c350709d881f7..b9b0d866fe112d291a8d80a8269c3f572d254447 100644
+index 5945d06dea8af5ea841e58a0268e09ecd8d7d494..6e7edd237c9184bd8e812a72b18f48213c1f797e 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-@@ -3115,7 +3115,7 @@ void CVideoPlayer::Pause()
+@@ -3119,7 +3119,7 @@ void CVideoPlayer::Pause()
  
  bool CVideoPlayer::HasVideo() const
  {
@@ -49110,10 +49047,10 @@ index dded334532841911a34d75808c3c350709d881f7..b9b0d866fe112d291a8d80a8269c3f57
  
  bool CVideoPlayer::HasAudio() const
 
-From 6faee73797c05d2c8140c6c11c7eace3231ea20e Mon Sep 17 00:00:00 2001
+From c4eb7e656ed6b4c6a2325ec1d3d201a5a3ed15d1 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Thu, 10 Mar 2016 18:11:33 +0300
-Subject: [PATCH 43/62] fixup! Revert supporting crappy tab/sbs subtitles. this
+Subject: [PATCH 44/61] fixup! Revert supporting crappy tab/sbs subtitles. this
  fixes regular subtitles.
 
 ---
@@ -49150,10 +49087,10 @@ index 3a080d06c90b0762482816928642e6de7810b539..a8323f419e404037c4e5fb4d78fa1b45
      CDVDOverlayImage* overlay = new CDVDOverlayImage();
  
 
-From b9eb944c52a9e09bfa084f4bd8f8862f13ec6f7e Mon Sep 17 00:00:00 2001
+From a05d3dd9a2a8e28ac2e36a0e0b8dd270edfbaf70 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Thu, 7 Apr 2016 17:28:50 +0300
-Subject: [PATCH 44/62] [VideoPlayer] Disable reading extension stream from
+Subject: [PATCH 45/61] [VideoPlayer] Disable reading extension stream from
  input stream if decoder doesn't support it.
 
 ---
@@ -49186,10 +49123,10 @@ index a2da9de4375939f3711c594dc854b9a533c755b4..8101b6eeff0341a94736df7ee815dd4c
    CProcessInfo &m_processInfo;
  };
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index b7e5081bc0fc32eaaae42d894a288e7971139356..6ea1a19173e36d49f7391b6f350c8ae3173db7ff 100644
+index b80f44994dfbc9f4cac37f9cad7926c0d32371e2..99ad8f34770b175b0ac9d92c75d7b409d51b5fec 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -504,14 +504,14 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
+@@ -505,14 +505,14 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
  
    UpdateCurrentPTS();
  
@@ -49208,7 +49145,7 @@ index b7e5081bc0fc32eaaae42d894a288e7971139356..6ea1a19173e36d49f7391b6f350c8ae3
      }
    }
    // in case of mpegts and we have not seen pat/pmt, defer creation of streams
-@@ -1488,13 +1488,13 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1490,13 +1490,13 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
                pStream->codec->codec_tag = MKTAG('A', 'M', 'V', 'C');
  
                AVStream* mvcStream = nullptr;
@@ -49281,7 +49218,7 @@ index 508e9debd3e6679a1433842a65649fa68ead76ec..26cd97dddcae208afacfb241e96b4935
    std::queue<DemuxPacket*> m_MVCqueue;
    int m_h264StreamId = -1;
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
-index 932f0e4093c836453b07932df9075afc6f6e5ae5..7aee35cef8f42d080882e4bdd20a4a9ed234a8c2 100644
+index 3377d3f282d4e8cdeb10339e1aded5e3eb1edf1a..8e94436051e7b04ec11560057ecd64c5d08a7bcd 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
 @@ -57,6 +57,7 @@ namespace XFILE
@@ -49310,10 +49247,10 @@ index 932f0e4093c836453b07932df9075afc6f6e5ae5..7aee35cef8f42d080882e4bdd20a4a9e
    {
      NEXTSTREAM_NONE,
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-index ad2c65ba5b80c5ac5d055d621a1e8319e3f770c0..74e8e1fc2da66d3c98a5bab04faa2f6bf16539ff 100644
+index a2c59b137ebdb7a44aea4fe1216eb9a2f43c048c..cdc9039729993c5cd7d3af0b8ee8e5fc28a4a158 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-@@ -617,6 +617,13 @@ void CDVDInputStreamBluray::ProcessEvent() {
+@@ -618,6 +618,13 @@ void CDVDInputStreamBluray::ProcessEvent() {
    }
  }
  
@@ -49327,7 +49264,7 @@ index ad2c65ba5b80c5ac5d055d621a1e8319e3f770c0..74e8e1fc2da66d3c98a5bab04faa2f6b
  int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
  {
    int result = 0;
-@@ -1165,7 +1172,7 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
+@@ -1166,7 +1173,7 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
    
    m_title = m_dll->bd_get_playlist_info(m_bd, playitem, m_angle);
  
@@ -49371,7 +49308,7 @@ index 561fb5cd4f971bc9ee4f41218a60bb3d5bc5625f..f70657c9e31fb2460d12910c635dba51
  
    typedef std::shared_ptr<CDVDOverlayImage> SOverlay;
 diff --git a/xbmc/cores/VideoPlayer/IVideoPlayer.h b/xbmc/cores/VideoPlayer/IVideoPlayer.h
-index 0b676c9b611fe956f1aa721013412e41ff5b62f6..6762e733848d1298a75a862b0aaf81aa5690537d 100644
+index 689798245ca48676af7c34a3e3565ea70ebcf309..d076c118f0877be6e5adb79c75606dce7870487c 100644
 --- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
 +++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
 @@ -111,6 +111,7 @@ public:
@@ -49383,10 +49320,10 @@ index 0b676c9b611fe956f1aa721013412e41ff5b62f6..6762e733848d1298a75a862b0aaf81aa
  
  class CDVDAudioCodec;
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayer.cpp b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-index b9b0d866fe112d291a8d80a8269c3f572d254447..d74c03d1ef7e0146a57964376dbff190876a8598 100644
+index 6e7edd237c9184bd8e812a72b18f48213c1f797e..aca33a7e75c604eb292a669a44bfecbffda9b9b1 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-@@ -3891,6 +3891,10 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
+@@ -3895,6 +3895,10 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
      if (!player->OpenStream(hint))
        return false;
  
@@ -49410,10 +49347,10 @@ index 0d4100e58e9db7e5035bcf9ae23b0147f80cec8f..69570153f0810a5840f3780c7a6681a1
    // classes
    CDVDOverlayContainer* m_pOverlayContainer;
 
-From a5dcb2315b90a4868559d51964f9d59b69901773 Mon Sep 17 00:00:00 2001
+From 5f5c668483d88c37f2e652a599f0bd8211fede8d Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Fri, 16 Sep 2016 11:37:48 +0300
-Subject: [PATCH 45/62] [Settings] move SETTING_VIDEOPLAYER_SUPPORTMVC from
+Subject: [PATCH 46/61] [Settings] move SETTING_VIDEOPLAYER_SUPPORTMVC from
  platform settings to common settings.
 
 ---
@@ -49443,7 +49380,7 @@ index 2572e25753712186f69390965ee1448bff3fadd5..7098edf32dff8c00e192229c3ffb060b
    </section>
    <section id="media">
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index 22dcff1c06577055f84c3d2c2fda73cfa16c53d4..eb610a8aaa795d2caeaf2ab12bcf61b1148524b4 100644
+index 068ca2d519cb7537e0d3ad05c83d47d341a34250..23b96cbb2463d6b4072b0f9333e0def0aaa446e1 100644
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
 @@ -343,6 +343,12 @@
@@ -49482,15 +49419,15 @@ index 2fcee72a64e8b701c8e895143410bbe9fd617356..a017d30c24232fb01220b87b29398403
      <category id="display">
        <group id="1">
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-index 74e8e1fc2da66d3c98a5bab04faa2f6bf16539ff..7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822 100644
+index cdc9039729993c5cd7d3af0b8ee8e5fc28a4a158..e1f0240124bf7777b755f5a39cbb32e354dabd50 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-@@ -1172,7 +1172,7 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
+@@ -1173,7 +1173,7 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
    
    m_title = m_dll->bd_get_playlist_info(m_bd, playitem, m_angle);
  
 -  if (CSettings::GetInstance().GetBool("videoplayer.supportmvc") && !m_bMVCDisabled)
-+  if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC) && !m_bMVCDisabled)
++  if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC) && !m_bMVCDisabled)
    {
      MPLS_PL * mpls = m_dll->bd_get_title_mpls(m_bd);
      if (mpls)
@@ -49509,10 +49446,10 @@ index 6b1f2b6d757354d6065c2862b44dfb47184a1dcc..9163ec85bd0feb48a698a025d9870bf4
    m_simpleConditions.insert("have_lcms2");
  #endif
 
-From b5a7b94739f0da0c2de4e33a3fff027c412d93f6 Mon Sep 17 00:00:00 2001
+From 6b0b450bf2127f3acd8c0fda67bb4227ea5c666b Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Fri, 4 Nov 2016 22:56:56 +0300
-Subject: [PATCH 46/62] [VideoPlayer] SSIF: fix for corner case when mvc stream
+Subject: [PATCH 47/61] [VideoPlayer] SSIF: fix for corner case when mvc stream
  is switched before the last packet is read from previous stream.
 
 ---
@@ -49524,10 +49461,10 @@ Subject: [PATCH 46/62] [VideoPlayer] SSIF: fix for corner case when mvc stream
  5 files changed, 45 insertions(+), 10 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 6ea1a19173e36d49f7391b6f350c8ae3173db7ff..9149698884c8ae6a23649abbaa0e659587dfe982 100644
+index 99ad8f34770b175b0ac9d92c75d7b409d51b5fec..179a287d1cec04686b30fdee1ef8f1770b0f9f8d 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -1120,9 +1120,6 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
+@@ -1121,9 +1121,6 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
    m_pkt.result = -1;
    av_packet_unref(&m_pkt.pkt);
  
@@ -49537,7 +49474,7 @@ index 6ea1a19173e36d49f7391b6f350c8ae3173db7ff..9149698884c8ae6a23649abbaa0e6595
    CDVDInputStream::IPosTime* ist = m_pInput->GetIPosTime();
    if (ist)
    {
-@@ -1136,6 +1133,8 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
+@@ -1137,6 +1134,8 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
  
      return true;
    }
@@ -49569,7 +49506,7 @@ index 7c8719ce40e725e27b7551250398022a1f1a4fc6..c675e31f731bc6afb8aabc37bbb5495a
 +  return true;
  }
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
-index 7aee35cef8f42d080882e4bdd20a4a9ed234a8c2..ea138f95bac915a946800f6bc7b964bd928e1a89 100644
+index 8e94436051e7b04ec11560057ecd64c5d08a7bcd..1637be9496814b6129c349ffeccd7450a8a62aca 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
 @@ -140,6 +140,7 @@ public:
@@ -49581,10 +49518,10 @@ index 7aee35cef8f42d080882e4bdd20a4a9ed234a8c2..ea138f95bac915a946800f6bc7b964bd
  
    enum ENextStream
 diff --git a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952fa9a5f261 100644
+index e1f0240124bf7777b755f5a39cbb32e354dabd50..aaba0e70c3ac2bf2f93046be5139b15ab3e613c0 100644
 --- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
-@@ -48,6 +48,7 @@
+@@ -49,6 +49,7 @@
  #endif
  
  #define LIBBLURAY_BYTESEEK 0
@@ -49592,7 +49529,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
  
  using namespace XFILE;
  
-@@ -432,6 +433,8 @@ bool CDVDInputStreamBluray::Open()
+@@ -433,6 +434,8 @@ bool CDVDInputStreamBluray::Open()
    while (m_dll->bd_get_event(m_bd, &m_event))
      ProcessEvent();
  
@@ -49601,7 +49538,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
    return true;
  }
  
-@@ -610,10 +613,14 @@ void CDVDInputStreamBluray::ProcessEvent() {
+@@ -611,10 +614,14 @@ void CDVDInputStreamBluray::ProcessEvent() {
    /* event has been consumed */
    m_event.event = BD_EVENT_NONE;
  
@@ -49619,7 +49556,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
    }
  }
  
-@@ -935,10 +942,15 @@ bool CDVDInputStreamBluray::PosTime(int ms)
+@@ -936,10 +943,15 @@ bool CDVDInputStreamBluray::PosTime(int ms)
    if(m_dll->bd_seek_time(m_bd, ms * 90) < 0)
      return false;
  
@@ -49636,7 +49573,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
    return true;
  }
  
-@@ -963,10 +975,15 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
+@@ -964,10 +976,15 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
    if(m_title && m_dll->bd_seek_chapter(m_bd, ch-1) < 0)
      return false;
  
@@ -49653,7 +49590,7 @@ index 7dd85f0173bd636f4f5ae6e7fc43b3064e2ff822..23053d7f8ebf494c7b35bf41bcf9952f
    return true;
  }
  
-@@ -1196,6 +1213,18 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
+@@ -1197,6 +1214,18 @@ bool CDVDInputStreamBluray::ProcessItem(int playitem)
    return true;
  }
  
@@ -49701,17 +49638,17 @@ index f70657c9e31fb2460d12910c635dba5163282e74..a11ec77903d2a9b2c68106a8e2301af9
    typedef std::shared_ptr<CDVDOverlayImage> SOverlay;
    typedef std::list<SOverlay>                 SOverlays;
 
-From 68303efd88570df113b4e6d4816255f671ff02ef Mon Sep 17 00:00:00 2001
+From 7db6b6f6183ddef5f8eaea8cddd2237375ea8808 Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <afedchin@ruswizards.com>
 Date: Tue, 23 Feb 2016 16:01:08 +0300
-Subject: [PATCH 47/62] [libbluray] bump libbluray to 0.9.2-mvc.
+Subject: [PATCH 48/61] [libbluray] bump libbluray to 0.9.2-mvc.
 
 ---
  project/BuildDependencies/scripts/0_package.list | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/project/BuildDependencies/scripts/0_package.list b/project/BuildDependencies/scripts/0_package.list
-index e6c608023a46d377ef520bf23e9863ee0350d980..f8db70ab3861835f33f0e4be79cf3d193093a45f 100644
+index 3f7112408c343b9da967e340ba069c447e91809f..3be6ce2f8362e3f5eb834971936827911abdbebe 100644
 --- a/project/BuildDependencies/scripts/0_package.list
 +++ b/project/BuildDependencies/scripts/0_package.list
 @@ -17,7 +17,7 @@ freetype-2.6.3-win32-vc140.7z
@@ -49721,13 +49658,13 @@ index e6c608023a46d377ef520bf23e9863ee0350d980..f8db70ab3861835f33f0e4be79cf3d19
 -libbluray-0.9.3-win32-vc140.7z
 +libbluray-0.9.2-mvc-win32-vc120.7z
  libcdio-0.9.3-win32-vc140.7z
- libcec-4.0.0-win32-vc140-2.7z
+ libcec-4.0.1-win32-vc140-2.7z
  libfribidi-0.19.2-win32.7z
 
-From 535c34fdcb4be388fa3554b364f3dcaebac7ef19 Mon Sep 17 00:00:00 2001
+From c91ccfd0efc0858195d640f396702cde1b0eb703 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 29 Feb 2016 17:00:50 +0000
-Subject: [PATCH 48/62] libbluray: Bump to Nevcairie's v0.9.2
+Subject: [PATCH 49/61] libbluray: Bump to Nevcairie's v0.9.2
 
 This includes 3D support
 ---
@@ -51384,10 +51321,10 @@ index 0000000000000000000000000000000000000000..5ef0124e35c9d81143921a328e272220
 + 
 +     return fp;
 
-From 10e05003e7721f2e77e20c286b1849c22ef1e5f6 Mon Sep 17 00:00:00 2001
+From 589b1b580b156086f6c3c484a2cccb0dac6bb9b3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 6 Mar 2016 12:54:59 +0000
-Subject: [PATCH 49/62] mvc: Automatically enable stereo mode
+Subject: [PATCH 50/61] mvc: Automatically enable stereo mode
 
 ---
  xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp | 6 +++++-
@@ -51395,10 +51332,10 @@ Subject: [PATCH 49/62] mvc: Automatically enable stereo mode
  2 files changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-index c43952d4d29b42f3a5c7605573294568f79ca010..68459e35bc2cda048c150c7079fb30eb0ffb823c 100644
+index 4f07113ade696aa4bbefb2dd2a2e17d5f12e9ab9..ce4a849a71468ab89c16cd6e5207a88ee22567c4 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-@@ -403,13 +403,17 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+@@ -401,13 +401,17 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
    switch (hints.codec)
    {
      case AV_CODEC_ID_H264:
@@ -51406,9 +51343,9 @@ index c43952d4d29b42f3a5c7605573294568f79ca010..68459e35bc2cda048c150c7079fb30eb
        // H.264
        m_codingType = MMAL_ENCODING_H264;
        m_pFormatName = "mmal-h264";
--      if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
+-      if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
 +      if ((hints.codec_tag == MKTAG('M', 'V', 'C', '1') || hints.codec_tag == MKTAG('A', 'M', 'V', 'C')) &&
-+        CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
++        CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
        {
          m_codingType = MMAL_ENCODING_MVC;
          m_pFormatName= "mmal-mvc";
@@ -51418,10 +51355,10 @@ index c43952d4d29b42f3a5c7605573294568f79ca010..68459e35bc2cda048c150c7079fb30eb
      break;
      case AV_CODEC_ID_H263:
 diff --git a/xbmc/cores/omxplayer/OMXVideo.cpp b/xbmc/cores/omxplayer/OMXVideo.cpp
-index 311dd6689236d660919c4c4483c51dca2752514a..536332c43e22ccb229e72b88518e54dd8a23ac41 100644
+index 2e26a6eef7335a5d0baf39313434ac786c66631b..c6aceaadd0a73d170b4024ea5ab54442197bbc5a 100644
 --- a/xbmc/cores/omxplayer/OMXVideo.cpp
 +++ b/xbmc/cores/omxplayer/OMXVideo.cpp
-@@ -398,6 +398,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
+@@ -397,6 +397,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
    switch (hints.codec)
    {
      case AV_CODEC_ID_H264:
@@ -51429,13 +51366,13 @@ index 311dd6689236d660919c4c4483c51dca2752514a..536332c43e22ccb229e72b88518e54dd
      {
        switch(hints.profile)
        {
-@@ -434,10 +435,13 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
+@@ -433,10 +434,13 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
            break;
        }
      }
--    if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
+-    if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
 +    if ((hints.codec_tag == MKTAG('M', 'V', 'C', '1') || hints.codec_tag == MKTAG('A', 'M', 'V', 'C')) &&
-+      CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
++      CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
      {
        m_codingType = OMX_VIDEO_CodingMVC;
        m_video_codec_name = "omx-mvc";
@@ -51445,10 +51382,10 @@ index 311dd6689236d660919c4c4483c51dca2752514a..536332c43e22ccb229e72b88518e54dd
      break;
      case AV_CODEC_ID_MPEG4:
 
-From 1707fe3577c485f641a9b44974bdd72658f2ba05 Mon Sep 17 00:00:00 2001
+From 1194161559a1433e3c10e0a00873ecf7aaccb97f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 24 Mar 2016 13:02:58 +0000
-Subject: [PATCH 50/62] ffmpeg: mvc: fix for pixelation from packets with no
+Subject: [PATCH 51/61] ffmpeg: mvc: fix for pixelation from packets with no
  pts/dts
 
 ---
@@ -51510,36 +51447,31 @@ index 7e97e4d91a443d46d933df528763422ff5e8f4fa..d4f279fd4f2ceb260698cd6fedb124ba
  	cd $(PLATFORM);\
  	CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" \
 
-From 0043ac6433c7b39bbf2eb1da01b83ffc491faf07 Mon Sep 17 00:00:00 2001
+From 6cb54f2a61ece80aac8c12d8aa39cf4633e755d5 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 11 Nov 2016 15:53:53 +0000
-Subject: [PATCH 51/62] stereoscopicmanager: fixups for rbp
+Subject: [PATCH 52/61] stereoscopicmanager: fixups for rbp
 
 ---
  xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp | 61 ++++++++++++++++++++++
  xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.h   |  4 ++
  .../VideoPlayer/DVDCodecs/Video/MMALCodec.cpp      |  9 +++-
  xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h |  1 +
- xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in     |  2 +-
  xbmc/cores/omxplayer/OMXPlayerVideo.cpp            |  5 ++
  xbmc/cores/omxplayer/OMXPlayerVideo.h              |  1 +
  xbmc/cores/omxplayer/OMXVideo.cpp                  |  2 +-
  xbmc/guilib/StereoscopicsManager.cpp               |  3 ++
- 9 files changed, 84 insertions(+), 4 deletions(-)
+ 8 files changed, 83 insertions(+), 3 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
-index ac4e063460a39888a1a1113aab37b74cbf0a0766..0d88acfb85333e88b3774144499eb4421abc4566 100644
+index 02fb028daace723fca008a19c1160113b958103f..10e05249cde619a9f5d229fe0ac45b6561236c72 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
-@@ -24,6 +24,7 @@
+@@ -24,9 +24,11 @@
  #include "utils/log.h"
  #include "cores/FFmpeg.h"
  #include "Util.h"
 +#include <assert.h>
- 
- #ifdef TARGET_WINDOWS
- #pragma comment(lib, "avcodec.lib")
-@@ -37,6 +38,7 @@
  
  extern "C" {
  #include "libswscale/swscale.h"
@@ -51547,7 +51479,7 @@ index ac4e063460a39888a1a1113aab37b74cbf0a0766..0d88acfb85333e88b3774144499eb442
  }
  
  // allocate a new picture (AV_PIX_FMT_YUV420P)
-@@ -402,6 +404,65 @@ double CDVDCodecUtils::NormalizeFrameduration(double frameduration, bool *match)
+@@ -392,6 +394,65 @@ double CDVDCodecUtils::NormalizeFrameduration(double frameduration, bool *match)
    }
  }
  
@@ -51636,26 +51568,26 @@ index 361c96623660305fc393273b1eaea4db096c417d..8ec50bbf79e9e163ccae25e30f3a40bf
    static AVPixelFormat PixfmtFromEFormat(ERenderFormat format);
  };
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-index 68459e35bc2cda048c150c7079fb30eb0ffb823c..dca872373080156100618d58d9782e2461fa2648 100644
+index ce4a849a71468ab89c16cd6e5207a88ee22567c4..4ad4c169034c492f67c5efe68212ad1a772a8d7c 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
-@@ -362,6 +362,11 @@ bool CMMALVideo::SendCodecConfigData()
+@@ -360,6 +360,11 @@ bool CMMALVideo::SendCodecConfigData()
    return true;
  }
  
 +bool CMMALVideo::SupportsExtention()
 +{
-+  return CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC);
++  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC);
 +}
 +
  bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
  {
    CSingleLock lock(m_sharedSection);
-@@ -408,12 +413,12 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+@@ -406,12 +411,12 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
        m_codingType = MMAL_ENCODING_H264;
        m_pFormatName = "mmal-h264";
        if ((hints.codec_tag == MKTAG('M', 'V', 'C', '1') || hints.codec_tag == MKTAG('A', 'M', 'V', 'C')) &&
--        CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
+-        CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))
 +          SupportsExtention())
        {
          m_codingType = MMAL_ENCODING_MVC;
@@ -51678,30 +51610,17 @@ index baff1f031149da5d669536711cc0057b2db078e3..1e49f09574c2a93b938d5eb405ebcb06
  
    // MMAL decoder callback routines.
    void dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
-diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-index 0359426b85683a4c3a80ef0e0d52f7a79564daaa..7d19ec3c56fdea514628d27cf36e641707be030f 100644
---- a/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/Makefile.in
-@@ -11,7 +11,7 @@ SRCS += DVDDemuxVobsub.cpp
- SRCS += DVDDemuxCC.cpp
- SRCS += DVDFactoryDemuxer.cpp
- SRCS += DemuxStreamSSIF.cpp
--SRCS += DVDDemuxMVC.cpp
-+SRCS += DemuxMVC.cpp
- 
- LIB = DVDDemuxers.a
- 
 diff --git a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
-index f6fb241dfec9269f4e501248de4dc83d5fdc2d3a..58ad6672e3351edbec537ad5b142ff14cb7389ea 100644
+index d308e44e26baae1a56127b55b987c28c384a9b63..57f0076714ec0c3a2b66d21870bd9644cbfe6ff6 100644
 --- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
 +++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
-@@ -111,6 +111,11 @@ OMXPlayerVideo::~OMXPlayerVideo()
+@@ -110,6 +110,11 @@ OMXPlayerVideo::~OMXPlayerVideo()
    CloseStream(false);
  }
  
 +bool OMXPlayerVideo::SupportsExtention() const
 +{
-+  return CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC);
++  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC);
 +}
 +
  bool OMXPlayerVideo::OpenStream(CDVDStreamInfo &hints)
@@ -51720,10 +51639,10 @@ index b5050081c360d29b1b478c27e6b88291e20ecdac..c880fa6bbb128b99f8a5393056586821
    void CloseStream(bool bWaitForBuffers);
    void Output(double pts, bool bDropPacket);
 diff --git a/xbmc/cores/omxplayer/OMXVideo.cpp b/xbmc/cores/omxplayer/OMXVideo.cpp
-index 536332c43e22ccb229e72b88518e54dd8a23ac41..39bc0530cecd54ae8c3a5481c92f1a6a18a4d9c5 100644
+index c6aceaadd0a73d170b4024ea5ab54442197bbc5a..ea11757bfc7ab3ebfbd5b46176c4a91097b765c4 100644
 --- a/xbmc/cores/omxplayer/OMXVideo.cpp
 +++ b/xbmc/cores/omxplayer/OMXVideo.cpp
-@@ -441,7 +441,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
+@@ -440,7 +440,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
        m_codingType = OMX_VIDEO_CodingMVC;
        m_video_codec_name = "omx-mvc";
        if (hints.stereo_mode == "mono")
@@ -51733,10 +51652,10 @@ index 536332c43e22ccb229e72b88518e54dd8a23ac41..39bc0530cecd54ae8c3a5481c92f1a6a
      break;
      case AV_CODEC_ID_MPEG4:
 diff --git a/xbmc/guilib/StereoscopicsManager.cpp b/xbmc/guilib/StereoscopicsManager.cpp
-index 6aaa82f4d883b8cae0ccdedf6c5a6814e7aaa720..cc929b599125a44ac128713fd4331782d9931791 100644
+index 041324c51977ce880ab365a16f1ac366c79e369c..7d5999245939c0d9e27a110008e0f2747ca3b696 100644
 --- a/xbmc/guilib/StereoscopicsManager.cpp
 +++ b/xbmc/guilib/StereoscopicsManager.cpp
-@@ -70,10 +70,13 @@ static const struct StereoModeMap VideoModeToGuiModeMap[] =
+@@ -71,10 +71,13 @@ static const struct StereoModeMap VideoModeToGuiModeMap[] =
    { "anaglyph_cyan_red",        RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN },
    { "anaglyph_green_magenta",   RENDER_STEREO_MODE_ANAGLYPH_GREEN_MAGENTA },
    { "anaglyph_yellow_blue",     RENDER_STEREO_MODE_ANAGLYPH_YELLOW_BLUE },
@@ -51751,10 +51670,10 @@ index 6aaa82f4d883b8cae0ccdedf6c5a6814e7aaa720..cc929b599125a44ac128713fd4331782
  };
  
 
-From 56bda93bf04b76e40175db4eebfe7fa26585b90b Mon Sep 17 00:00:00 2001
+From 6c576963fab8be163c237cd54678767eb413b7cd Mon Sep 17 00:00:00 2001
 From: Anton Fedchin <anightik@gmail.com>
 Date: Thu, 10 Mar 2016 18:11:33 +0300
-Subject: [PATCH 52/62] fixup! Revert supporting crappy tab/sbs subtitles. this
+Subject: [PATCH 53/61] fixup! Revert supporting crappy tab/sbs subtitles. this
  fixes regular subtitles.
 
 ---
@@ -51774,10 +51693,10 @@ index a8323f419e404037c4e5fb4d78fa1b45409337a7..7c0b70777556ac7694e7fc511cd4bb18
    }
  
 
-From 40f9ac9217dbe0a5f3ea5d7e8f6b36f79d9455fe Mon Sep 17 00:00:00 2001
+From 7cc401c109aa894d9ee749cdd4ab4a5ed871d8e0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 26 Nov 2016 18:24:18 +0000
-Subject: [PATCH 53/62] DemuxMVC: fixup after SeekTime API change
+Subject: [PATCH 54/61] DemuxMVC: fixup after SeekTime API change
 
 ---
  xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMVC.cpp | 2 +-
@@ -51811,91 +51730,37 @@ index bbb836a61344689a83af68c821c05c212a86b097..54f91a02391368fbfbb4d669c003f425
    virtual int GetStreamLength() { return 0; };
    virtual CDemuxStream* GetStream(int iStreamId) const override { return nullptr; };
 
-From 07af63a05c028937005d37d901c1e3be4aaa8784 Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Mon, 3 Nov 2014 23:17:46 +0000
-Subject: [PATCH 54/62] [cec] Don't discard buttons when repeat mode is enabled
+From 13f6754f8a6695d6c04422545b7a5219ece815b3 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Tue, 22 Mar 2016 09:51:52 +0100
+Subject: [PATCH 55/61] python: use kodi provided cert if available
 
 ---
- xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 5 ++++-
- 1 file changed, 4 insertions(+), 1 deletion(-)
+ xbmc/interfaces/python/XBPython.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
-diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-index 30367a3fde956090afdca9930fa52e829f35046f..febacb3b7964eab3b8615a6a807e0f27d911b4da 100644
---- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-@@ -803,7 +803,10 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
-   CLog::Log(LOGDEBUG, "%s - received key %2x duration %d", __FUNCTION__, key.iButton, key.iDuration);
+diff --git a/xbmc/interfaces/python/XBPython.cpp b/xbmc/interfaces/python/XBPython.cpp
+index cd6033a9f16233aeec3fcb2c4d3144c3b31f1ac5..e55e336fd9e434a3840fd99c99cc5a3381f818fd 100644
+--- a/xbmc/interfaces/python/XBPython.cpp
++++ b/xbmc/interfaces/python/XBPython.cpp
+@@ -591,6 +591,12 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
+     CEnvironment::putenv(buf);
+ #endif
  
-   CSingleLock lock(m_critSection);
--  if (key.iDuration > 0)
-+  // avoid the queue getting too long
-+  if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
-+    return;
-+  if (m_configuration.iButtonRepeatRateMs == 0 && key.iDuration > 0)
-   {
-     if (m_currentButton.iButton == key.iButton && m_currentButton.iDuration == 0)
-     {
++#if !defined(TARGET_WINDOWS)
++    // use Kodi provided cert if available
++    if (XFILE::CFile::Exists("special://xbmc/system/certs/cacert.pem"))
++      setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
++#endif
++
+     if (PyEval_ThreadsInitialized())
+       PyEval_AcquireLock();
+     else
 
-From 4066e9289576eb4def863476331d73d081f9ac85 Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Tue, 4 Nov 2014 18:50:00 +0000
-Subject: [PATCH 55/62] [cec] Temp - more logging
-
----
- xbmc/peripherals/devices/PeripheralCecAdapter.cpp | 8 +++++++-
- 1 file changed, 7 insertions(+), 1 deletion(-)
-
-diff --git a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-index febacb3b7964eab3b8615a6a807e0f27d911b4da..52d6e6a7ab68ce91faf5a3881b23ea7adde96cb8 100644
---- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-@@ -800,12 +800,15 @@ void CPeripheralCecAdapter::GetNextKey(void)
- 
- void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
- {
--  CLog::Log(LOGDEBUG, "%s - received key %2x duration %d", __FUNCTION__, key.iButton, key.iDuration);
-+  CLog::Log(LOGDEBUG, "%s - received key %2x duration %d (rep:%d size:%d)", __FUNCTION__, key.iButton, key.iDuration, m_configuration.iButtonRepeatRateMs, m_buttonQueue.size());
- 
-   CSingleLock lock(m_critSection);
-   // avoid the queue getting too long
-   if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
-+  {
-+    CLog::Log(LOGDEBUG, "%s - discarded key %2x", __FUNCTION__, key.iButton);
-     return;
-+  }
-   if (m_configuration.iButtonRepeatRateMs == 0 && key.iDuration > 0)
-   {
-     if (m_currentButton.iButton == key.iButton && m_currentButton.iDuration == 0)
-@@ -814,6 +817,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
-       if (m_bHasButton)
-         m_currentButton.iDuration = key.iDuration;
-       // ignore this one, since it's already been handled by xbmc
-+      CLog::Log(LOGDEBUG, "%s - ignored key %2x", __FUNCTION__, key.iButton);
-       return;
-     }
-     // if we received a keypress with a duration set, try to find the same one without a duration set, and replace it
-@@ -824,6 +828,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
-         if ((*it).iDuration == 0)
-         {
-           // replace this entry
-+          CLog::Log(LOGDEBUG, "%s - replaced key %2x", __FUNCTION__, key.iButton);
-           (*it).iDuration = key.iDuration;
-           return;
-         }
-@@ -833,6 +838,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress &key)
-     }
-   }
- 
-+  CLog::Log(LOGDEBUG, "%s - added key %2x", __FUNCTION__, key.iButton);
-   m_buttonQueue.push_back(key);
- }
- 
-
-From 9771f5dd741a349b93481848ea2be760106755bc Mon Sep 17 00:00:00 2001
+From 73d68e4bda6d8083c8a4753e2356015c540a63dd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 25 May 2016 18:31:17 +0100
-Subject: [PATCH 56/62] rbp: Hard code the number of buffers to improve audio
+Subject: [PATCH 56/61] rbp: Hard code the number of buffers to improve audio
  sync
 
 ---
@@ -51921,15 +51786,15 @@ index 7098edf32dff8c00e192229c3ffb060be6a42482..0ce6735e11fabd1d07a4860b9d985a4e
      <category id="audio">
        <group id="1">
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
-index 8626a1b449ff0963089f6a7ad191a6c99512521a..53fc987b4ebb0555a804477bfb5b1d8443a98bcd 100644
+index 5feee388bb3a433ea6a35b29e587ab6447c089a5..5d2071ee724fb2f7ba04f96832c89de52d9354f2 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
-@@ -1067,7 +1067,11 @@ void CRenderManager::UpdateDisplayLatency()
+@@ -1070,7 +1070,11 @@ void CRenderManager::UpdateDisplayLatency()
      refresh = 0; // No idea about refresh rate when windowed, just get the default latency
    m_displayLatency = (double) g_advancedSettings.GetDisplayLatency(refresh);
  
 +#ifdef TARGET_RASPBERRY_PI
-+  int buffers = CSettings::GetInstance().GetBool("videoplayer.usedisplayasclock") ? 1:2;
++  int buffers = CServiceBroker::GetSettings().GetBool("videoplayer.usedisplayasclock") ? 1:2;
 +#else
    int buffers = g_Windowing.NoOfBuffers();
 +#endif
@@ -51937,10 +51802,10 @@ index 8626a1b449ff0963089f6a7ad191a6c99512521a..53fc987b4ebb0555a804477bfb5b1d84
  
  }
 
-From 77b9beb43349ae1335090f53d2a4d4f08aff928e Mon Sep 17 00:00:00 2001
+From bbda95f3c3cc2384033ff525f8d384a876c16a5f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 4 Jul 2016 18:30:03 +0100
-Subject: [PATCH 57/62] rbp: Update the GL libs to new naming scheme
+Subject: [PATCH 57/61] rbp: Update the GL libs to new naming scheme
 
 As the opensource mesa GL library is getting more usable, the name collision wih the firmware GL driver is causing issues.
 As such we are renaming the firmware GL driver to avoid this.
@@ -51948,28 +51813,14 @@ As such we are renaming the firmware GL driver to avoid this.
 The new names are libbrcmEGL.so and libbrcmGLESv2.so. Both will be supported for some time, but the original name
 will be dropped at some point
 ---
- configure.ac                             | 2 +-
- project/cmake/modules/FindOpenGLES.cmake | 6 +++---
- tools/depends/configure.ac               | 2 +-
- 3 files changed, 5 insertions(+), 5 deletions(-)
+ cmake/modules/FindOpenGLES.cmake | 6 +++---
+ tools/depends/configure.ac       | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/configure.ac b/configure.ac
-index d2186cbda52213aa85b5734b6c8f45a69e5e2e20..75e264b24629480880d4ea758c25db26c754bc9b 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -949,7 +949,7 @@ if test "$use_gles" = "yes"; then
-       AC_DEFINE([HAVE_LIBEGL],[1],["Define to 1 if you have the `EGL' library (-lEGL)."])
-       AC_DEFINE([HAVE_LIBGLESV2],[1],["Define to 1 if you have the `GLESv2' library (-lGLESv2)."])
-       AC_MSG_RESULT(== WARNING: OpenGLES support is assumed.)
--      LIBS="$LIBS -lEGL -lGLESv2 -lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
-+      LIBS="$LIBS -lbrcmEGL -lbrcmGLESv2 -lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
-     else
-       AC_CHECK_LIB([EGL],   [main],, AC_MSG_ERROR($missing_library))
-       AC_CHECK_LIB([GLESv2],[main],, AC_MSG_ERROR($missing_library))
-diff --git a/project/cmake/modules/FindOpenGLES.cmake b/project/cmake/modules/FindOpenGLES.cmake
+diff --git a/cmake/modules/FindOpenGLES.cmake b/cmake/modules/FindOpenGLES.cmake
 index ab06f968b3e314fca1ae001139f687dce9a5098b..87f1faa248b91a2e50758b23c0b9e5b09e4a69ff 100644
---- a/project/cmake/modules/FindOpenGLES.cmake
-+++ b/project/cmake/modules/FindOpenGLES.cmake
+--- a/cmake/modules/FindOpenGLES.cmake
++++ b/cmake/modules/FindOpenGLES.cmake
 @@ -13,7 +13,7 @@
  find_package(EMBEDDED)
  
@@ -51992,7 +51843,7 @@ index ab06f968b3e314fca1ae001139f687dce9a5098b..87f1faa248b91a2e50758b23c0b9e5b0
  else()
    find_library(OPENGLES_gl_LIBRARY NAMES OpenGLES
 diff --git a/tools/depends/configure.ac b/tools/depends/configure.ac
-index 3626ea5204eb561dc1ae0b64c6bb7253d2ec59ec..100ff3178bafe7434bd5456100b5bb7189a5378d 100644
+index ac2ac3cf689ec0eb68877d4149c9d3f856e9145c..1c8fd284c2d59170003f274d2c0cec04dd4c2118 100644
 --- a/tools/depends/configure.ac
 +++ b/tools/depends/configure.ac
 @@ -433,7 +433,7 @@ if test "$target_platform" = "raspberry-pi" ; then
@@ -52005,20 +51856,20 @@ index 3626ea5204eb561dc1ae0b64c6bb7253d2ec59ec..100ff3178bafe7434bd5456100b5bb71
  fi
  
 
-From 16d9562395384270f1dca8ef062d0048b08ca2dc Mon Sep 17 00:00:00 2001
+From 4ca1a69b69e4aac2f1063abffb5c3b819d8fea2f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 28 Jun 2016 14:46:01 +0100
-Subject: [PATCH 58/62] ffmpeg: hacky fix for files with GMC
+Subject: [PATCH 58/61] ffmpeg: hacky fix for files with GMC
 
 ---
  xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-index 9149698884c8ae6a23649abbaa0e659587dfe982..84d515e9e2df6a4c1c448a52a42f4675deab7991 100644
+index 179a287d1cec04686b30fdee1ef8f1770b0f9f8d..1453fb7f281609598e57afdc5e162f5ebfbbecd3 100644
 --- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
-@@ -1458,8 +1458,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+@@ -1460,8 +1460,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
            stereoMode = GetStereoModeFromMetadata(m_pFormatContext->metadata);
          if (!stereoMode.empty())
            st->stereo_mode = stereoMode;
@@ -52030,10 +51881,10 @@ index 9149698884c8ae6a23649abbaa0e659587dfe982..84d515e9e2df6a4c1c448a52a42f4675
          {
            if (pStream->codec->codec_id == AV_CODEC_ID_PROBE)
 
-From 7d20983a4ed4a55b9e465ae121dc621a4527464a Mon Sep 17 00:00:00 2001
+From 32bd86312d3629acf595f6356f641e55523cc8cd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 19 Jul 2016 20:39:18 +0100
-Subject: [PATCH 59/62] mmalrender: Add sharpness control
+Subject: [PATCH 59/61] mmalrender: Add sharpness control
 
 ---
  addons/resource.language.en_gb/resources/strings.po         |  2 +-
@@ -52042,10 +51893,10 @@ Subject: [PATCH 59/62] mmalrender: Add sharpness control
  3 files changed, 14 insertions(+), 2 deletions(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index 7c7969d381bf15ac1ba2fd8f16e463f6b12fe4c3..45cf0830ea6079a0f2ad22792f2497c5ad53b625 100644
+index a4607cfa2f6c41e2cc0a7b8fa8ee257a917be0c3..e8620bc41a530f0393e154010716e1eba899581e 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -8694,7 +8694,7 @@ msgstr ""
+@@ -8739,7 +8739,7 @@ msgstr ""
  
  #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
  msgctxt "#16313"
@@ -52055,7 +51906,7 @@ index 7c7969d381bf15ac1ba2fd8f16e463f6b12fe4c3..45cf0830ea6079a0f2ad22792f2497c5
  
  #empty string with id 16314
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
-index 84953d116610e9fd262de968ffe26d6063a9193b..f5f0f0d01227b3b4dcebb4a22a54dbcaac2d5ee9 100644
+index 213c46345d5eebc4046619821526f6684db131dd..a234de11322599e042febd9a4945dd150dac3921 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
 @@ -411,6 +411,7 @@ CMMALRenderer::CMMALRenderer() : CThread("MMALRenderer"), m_processThread(this,
@@ -52105,20 +51956,20 @@ index e0e6f7c0e0546013ca74265aef54704fd332f8e4..69eae6cbef0131d20dc979dcb35915cd
    CCriticalSection m_sharedSection;
    MMAL_COMPONENT_T *m_vout;
 
-From 4767086e68edac21dc112be1262e38c5c83d1aea Mon Sep 17 00:00:00 2001
+From c43bd26a8d45cca4fdad21e8fce5cc890e224589 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 14 Oct 2016 15:37:53 +0100
-Subject: [PATCH 60/62] MMALFFMpeg: Report as SW decode in codec overlay info
+Subject: [PATCH 60/61] MMALFFMpeg: Report as SW decode in codec overlay info
 
 ---
  xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-index 619515c9411172261d8f0bef24c5d679c35e5d7d..b31c984c0a507891f2754146a4c62802f0096505 100644
+index c4eda5a2c78db1f6acc9ed59938ea3f42262d8fe..a5e14e6ec5ff9a78e7342b30109e68ed8d81a54b 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-@@ -579,7 +579,7 @@ void CDVDVideoCodecFFmpeg::UpdateName()
+@@ -577,7 +577,7 @@ void CDVDVideoCodecFFmpeg::UpdateName()
    if(m_pHardware)
      m_name += "-" + m_pHardware->Name();
  
@@ -52128,156 +51979,28 @@ index 619515c9411172261d8f0bef24c5d679c35e5d7d..b31c984c0a507891f2754146a4c62802
    CLog::Log(LOGDEBUG, "CDVDVideoCodecFFmpeg - Updated codec: %s", m_name.c_str());
  }
 
-From bc4cb4cb7618aecf4735f783e5ef97f0cae72d83 Mon Sep 17 00:00:00 2001
+From 211c99d6161b48b242ccc183db380e7ce2710fa0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
-Date: Mon, 7 Nov 2016 18:28:01 +0000
-Subject: [PATCH 61/62] advancedsettings: Add option to set cache size on
- libass
+Date: Thu, 1 Dec 2016 17:06:01 +0000
+Subject: [PATCH 61/61] MMALRender: Allow advanced deinterlace with software
+ decode
 
-E.g to set total cache size in libass to 32M
-
-<advancedsettings>
-    <libasscache>32</libasscache>
-</advancedsettings>
-
-When unset it defaults to 192M
+Uses YUV420 directly which improves performance.
+Requires updated firmware
 ---
- xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp | 3 +++
- xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h            | 3 +++
- xbmc/settings/AdvancedSettings.cpp                         | 5 +++++
- xbmc/settings/AdvancedSettings.h                           | 2 ++
- 4 files changed, 13 insertions(+)
+ xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
-index 0f5e1ace4c85f65a0ab5dbd8e6f1c2715d60467d..7a236080bc96466d34e14b9b0d82ba4084276abd 100644
---- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
-+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
-@@ -28,6 +28,7 @@
- #include "utils/StringUtils.h"
- #include "threads/SingleLock.h"
- #include "guilib/GraphicContext.h"
-+#include "settings/AdvancedSettings.h"
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+index a234de11322599e042febd9a4945dd150dac3921..6d71b09c4badb5c3e2ef8f57b94014f43a285e32 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+@@ -1370,7 +1370,7 @@ bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uin
+     m_deint_output->format->es->video.crop.height = height;
+     m_deint_output->format->es->video.width = ALIGN_UP(width, 32);
+     m_deint_output->format->es->video.height = ALIGN_UP(height, 16);
+-    m_deint_output->format->encoding = advanced_deinterlace ? MMAL_ENCODING_YUVUV128 : MMAL_ENCODING_I420;
++    m_deint_output->format->encoding = advanced_deinterlace && encoding == MMAL_ENCODING_OPAQUE ? MMAL_ENCODING_YUVUV128 : MMAL_ENCODING_I420;
  
- static void libass_log(int level, const char *fmt, va_list args, void *data)
- {
-@@ -75,6 +76,8 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
-   if(!m_renderer)
-     return;
- 
-+  m_dll.ass_set_cache_limits(m_renderer, 0, g_advancedSettings.m_libAssCache);
-+
-   //Setting default font to the Arial in \media\fonts (used if FontConfig fails)
-   strPath = URIUtils::AddFileToFolder("special://home/media/Fonts/", CSettings::GetInstance().GetString(CSettings::SETTING_SUBTITLES_FONT));
-   if (!XFILE::CFile::Exists(strPath))
-diff --git a/xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h b/xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h
-index f9de4f15e7c612d69ef46e7cad870ecb61afaec3..b5303fd100f1a930eb5c010a951932064d5190c4 100644
---- a/xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h
-+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DllLibass.h
-@@ -64,6 +64,7 @@ public:
-   virtual void ass_set_message_cb(ASS_Library *priv
-                                 , void (*msg_cb)(int level, const char *fmt, va_list args, void *data)
-                                 , void *data)=0;
-+  virtual void ass_set_cache_limits(ASS_Renderer *render_priv, int glyph_max, int bitmap_max)=0;
- };
- 
- class DllLibass : public DllDynamic, DllLibassInterface
-@@ -91,6 +92,7 @@ class DllLibass : public DllDynamic, DllLibassInterface
-   DEFINE_METHOD5(void, ass_process_chunk, (ASS_Track* p1, char* p2, int p3, long long p4, long long p5))
-   DEFINE_METHOD3(void, ass_process_codec_private, (ASS_Track* p1, char* p2, int p3))
-   DEFINE_METHOD3(void, ass_set_message_cb, (ASS_Library* p1, void (*p2)(int level, const char *fmt, va_list args, void *data), void* p3))
-+  DEFINE_METHOD3(void, ass_set_cache_limits, (ASS_Renderer *p1, int p2, int p3))
-   BEGIN_METHOD_RESOLVE()
-     RESOLVE_METHOD(ass_set_extract_fonts)
-     RESOLVE_METHOD(ass_set_fonts_dir)
-@@ -114,5 +116,6 @@ class DllLibass : public DllDynamic, DllLibassInterface
-     RESOLVE_METHOD(ass_process_chunk)
-     RESOLVE_METHOD(ass_process_codec_private)
-     RESOLVE_METHOD(ass_set_message_cb)
-+    RESOLVE_METHOD(ass_set_cache_limits)
-   END_METHOD_RESOLVE()
- };
-diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index 985ecf9722141d78471c00e90da15bfad931462a..a33581ba02a26110105a2d0ae810d96c410efbf1 100644
---- a/xbmc/settings/AdvancedSettings.cpp
-+++ b/xbmc/settings/AdvancedSettings.cpp
-@@ -364,6 +364,8 @@ void CAdvancedSettings::Initialize()
- #else
-   m_cacheMemSize = 1024 * 1024 * 20;
- #endif
-+  m_libAssCache = 0;
-+
-   m_cacheBufferMode = CACHE_BUFFER_MODE_INTERNET; // Default (buffer all internet streams/filesystems)
-   // the following setting determines the readRate of a player data
-   // as multiply of the default data read rate
-@@ -1026,6 +1028,9 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
-   XMLUtils::GetFloat(pRootElement, "controllerdeadzone", m_controllerDeadzone, 0.0f, 1.0f);
-   XMLUtils::GetUInt(pRootElement, "fanartres", m_fanartRes, 0, 1080);
-   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 1080);
-+
-+  XMLUtils::GetUInt(pRootElement, "libasscache", m_libAssCache, 0, 1024);
-+
-   if (XMLUtils::GetString(pRootElement, "imagescalingalgorithm", tmp))
-     m_imageScalingAlgorithm = CPictureScalingAlgorithm::FromString(tmp);
-   XMLUtils::GetBoolean(pRootElement, "playlistasfolders", m_playlistAsFolders);
-diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
-index 6b0e3b8cf9e3ff40e6af758c54fe7eefb89a131c..35bf38719f0eaaa5ac29e9495480ae97f6aceca7 100644
---- a/xbmc/settings/AdvancedSettings.h
-+++ b/xbmc/settings/AdvancedSettings.h
-@@ -345,6 +345,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
-     unsigned int m_cacheBufferMode;
-     float m_cacheReadFactor;
- 
-+    unsigned int m_libAssCache;
-+
-     bool m_jsonOutputCompact;
-     unsigned int m_jsonTcpPort;
- 
-
-From 567ad87b2bdbf86ae8540720c58716fd4f3ac46b Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Sun, 13 Nov 2016 20:30:15 +0000
-Subject: [PATCH 62/62] [rbp] Experimental limit libass cache size depending on
- arm memory size
-
----
- xbmc/linux/RBP.cpp                 | 4 +++-
- xbmc/settings/AdvancedSettings.cpp | 2 ++
- 2 files changed, 5 insertions(+), 1 deletion(-)
-
-diff --git a/xbmc/linux/RBP.cpp b/xbmc/linux/RBP.cpp
-index 6e8529001b1a464b4547a846f553d98f5bc0b6c0..238eba372af2cbab11d7543c857ee47640901d13 100644
---- a/xbmc/linux/RBP.cpp
-+++ b/xbmc/linux/RBP.cpp
-@@ -65,6 +65,8 @@ void CRBP::InitializeSettings()
- {
-   if (m_initialized && g_advancedSettings.m_cacheMemSize == ~0U)
-     g_advancedSettings.m_cacheMemSize = m_arm_mem < 256 ? 1024 * 1024 * 2 : 1024 * 1024 * 20;
-+  if (m_initialized && g_advancedSettings.m_libAssCache == ~0U)
-+    g_advancedSettings.m_libAssCache = m_arm_mem < 256 ? 21 : m_arm_mem < 512 ? 42 : 96;
- }
- 
- bool CRBP::Initialize()
-@@ -120,7 +122,7 @@ void CRBP::LogFirmwareVerison()
-   response[sizeof(response) - 1] = '\0';
-   CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s", response);
-   CLog::Log(LOGNOTICE, "ARM mem: %dMB GPU mem: %dMB MPG2:%d WVC1:%d", m_arm_mem, m_gpu_mem, m_codec_mpg2_enabled, m_codec_wvc1_enabled);
--  CLog::Log(LOGNOTICE, "cache.memorysize: %dMB",  g_advancedSettings.m_cacheMemSize >> 20);
-+  CLog::Log(LOGNOTICE, "cache.memorysize: %dMB libass.cache: %dMB",  g_advancedSettings.m_cacheMemSize >> 20, g_advancedSettings.m_libAssCache);
-   m_DllBcmHost->vc_gencmd(response, sizeof response, "get_config int");
-   response[sizeof(response) - 1] = '\0';
-   CLog::Log(LOGNOTICE, "Config:\n%s", response);
-diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index a33581ba02a26110105a2d0ae810d96c410efbf1..d70e2cf3113bbe0dad60dfc7accc8d77f7f30c30 100644
---- a/xbmc/settings/AdvancedSettings.cpp
-+++ b/xbmc/settings/AdvancedSettings.cpp
-@@ -361,8 +361,10 @@ void CAdvancedSettings::Initialize()
- #ifdef TARGET_RASPBERRY_PI
-   // want default to be memory dependent, but interface to gpu not available yet, so set in RBP.cpp
-   m_cacheMemSize = ~0;
-+  m_libAssCache = ~0;
- #else
-   m_cacheMemSize = 1024 * 1024 * 20;
-+  m_libAssCache = 0;
- #endif
-   m_libAssCache = 0;
- 
+     status = mmal_port_format_commit(m_deint_output);
+     if (status != MMAL_SUCCESS)


### PR DESCRIPTION
I'd have included this in PR1186 had I know the "Do not merge"/"WIP" labels were going to be ignored! :wink:

This update will at least mean Kodi 18a1 should build (particularly on RPi), and maybe even the add-ons too.