### PR TITLE
eventlircd: use default initial-repeat delay for gpio-rc-recv

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -194,16 +194,9 @@ ENV{eventlircd_evmap}="osmc_rf.evmap"
 
 LABEL="end-usb"
 
-# Automatically set Delayrate to 200ms to avoid double keypresses with
-# gpio-rc-recv
-  DRIVERS=="gpio-rc-recv", \
-    RUN+="/usr/bin/ir-keytable --delay=200 --device=$devnode", \
-    GOTO="end-keytable"
-
 # Set default delays (1000ms for first repeat, to avoid multiple keypresses).
   RUN+="/usr/bin/ir-keytable --delay=1000 --device=$devnode"
 
-LABEL="end-keytable"
 #-------------------------------------------------------------------------------
 # Ask eventlircd to handle Bluetooth HID devices that show up as event devices
 # and are known to be remote controls. For simplicity, the event map file names


### PR DESCRIPTION
It's almost impossible to do a single button press if buttons are set to repeat after 200ms.

gpio-ir-recv is working fine on RPi2 with the default settings (500ms kernel default or 1000ms as setup by the eventlircd udev rule), so no need to treat gpio-ir-recv differently than all other IR receivers.