### PR TITLE
fix lirc cross-compilation and non-working left/right keys

### DIFF
--- a/packages/sysutils/eventlircd/system.d/eventlircd.service
+++ b/packages/sysutils/eventlircd/system.d/eventlircd.service
@@ -2,7 +2,7 @@
 Description=Eventlirc server daemon
 
 [Service]
-ExecStart=/usr/sbin/eventlircd -f --evmap=/etc/eventlircd.d --socket=/run/lirc/lircd --release=_UP
+ExecStart=/usr/sbin/eventlircd -f --evmap=/etc/eventlircd.d --socket=/run/lirc/lircd
 KillMode=process
 TimeoutStopSec=1s
 

--- a/packages/sysutils/lirc/package.mk
+++ b/packages/sysutils/lirc/package.mk
@@ -37,6 +37,12 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_forkpty=no \
                            --with-gnu-ld \
                            --without-x"
 
+pre_configure_target() {
+  # patch lirc-make-devinput to use target kernel include
+  sed -e "s|/usr/include/linux/|${SYSROOT_PREFIX}/usr/include/linux/|g" \
+      -i ${ROOT}/${PKG_BUILD}/tools/lirc-make-devinput
+}
+
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/lib/systemd
   rm -rf $INSTALL/lib

--- a/packages/sysutils/lirc/scripts/lircd_helper
+++ b/packages/sysutils/lirc/scripts/lircd_helper
@@ -36,7 +36,7 @@ case "$ACTION" in
       LIRCD_CONFIG="--driver=$DRIVER --device=/dev/$DEVICE"
       LIRCD_CONFIG="$LIRCD_CONFIG --output=/run/lirc/lircd-$DEVICE"
       LIRCD_CONFIG="$LIRCD_CONFIG --pidfile=/run/lirc/lircd-$DEVICE.pid"
-      LIRCD_CONFIG="$LIRCD_CONFIG --release=_UP"
+      LIRCD_CONFIG="$LIRCD_CONFIG --release=_LIRCUP"
 
       if [ -e "/storage/.config/lircd.conf" ]; then
         LIRCD_CONFIG="$LIRCD_CONFIG /storage/.config/lircd.conf"

--- a/packages/sysutils/lirc/system.d/lircd-uinput@.service
+++ b/packages/sysutils/lirc/system.d/lircd-uinput@.service
@@ -4,7 +4,7 @@ Description=lircd-uinput with %I
 ConditionPathExists=/storage/.cache/services/lircd.conf
 
 [Service]
-ExecStart=/usr/sbin/lircd-uinput /run/lirc/lircd-%I
+ExecStart=/usr/sbin/lircd-uinput --release=_LIRCUP /run/lirc/lircd-%I
 Slice=system-lircd.slice
 Restart=on-failure
 RestartSec=2


### PR DESCRIPTION
don't merge yet, please review and test

Since diagonal key support was added in kernel 4.7 via commit https://github.com/torvalds/linux/commit/488326947cd1f038da8d2c9068a0d07b913b7983 using the default release suffix of _UP for transporting key-up events from lircd to lircd.-uinput is broken.

KEY_LEFT_UP and KEY_RIGHT_UP are now valid keycodes and lircd-uinput will interpret them differently (diagonal-key-down instead of left/right key up) leading to non-working left/right keys. See for example this irw output: https://forum.libreelec.tv/thread-4413-post-31915.html#pid31915

This problem went unnoticed so far because of another issue: during cross-compilation the lirc build picked up the linux include with valid keycodes from the build host instead of the target. So when compiling on a system with older userspace kernel headers installed lircd-uinput worked as before because it didn't know about KEY_LEFT/RIGHT_UP. But when compiling on a system with newer userspace kernel headers installed realase handling of left/right keys broke.

The first commit fixes lircd->lircd-uinput communication by using a different suffix.

The second commit tries to fix lirc cross-compilation:

During a normal (non-cross) build lib/input_map.inc and lib/lirc/input_map.inc in the source folder will be automatically regenerated matching the keycodes from /usr/ijnclude/linux/input-event-codes.h (or /usr/include/linux/input.h on older kernels). This part of the Makefile is nasty, though, when build is started from the object folder input_map.inc will end up there. The build seems to pick it up fine (instead of the one(s) in the source folder), but still it's not nice to have 2 different input_map.inc files sitting around.

I've fixed this by disabling automatic regeneration of input_map.inc during make and doing it manually in package.mk instead.

For removing the build-host-include issue there are 2 options: either patch the lirc-make-devinput script to point it to the target includes or add a parameter to the lirc-make-devinput, pointing it to the location of the kernel include (the input-event-codes.h). I choose the first approach, although it's a little nasty to patch files it'll still work if the script is called from the lirc build so it's more robust. Also it's a little bit easier, otherwise I we might have to re-implement the input-event-code.h->input.h fallback in package.mk.

The third commit disables generation of LIRC release events in eventlircd. Kodi doesn't seem to handle them (they just show up in the logs) and since _UP is now ambiguous we'd have to use another suffix for kodi anyways..