### PR TITLE
kodi: set MALLOC_MMAP_THRESHOLD_=524288 for 64bit cpus

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -45,3 +45,7 @@ fi
 KODI_ARGS="--lircdev /run/lirc/lircd"
 
 echo "KODI_ARGS=\"$KODI_ARGS\"" > /run/libreelec/kodi.conf
+
+if [ "$(uname -m)" = "x86_64" -o "$(uname -m)" = "aarch64" ]; then
+  echo "MALLOC_MMAP_THRESHOLD_=524288" >> /run/libreelec/kodi.conf
+fi


### PR DESCRIPTION
This fixes the "memleak" (not actually a memleak) issue on 64bit systems. It's actually a memory fragmentation issue.

see, https://github.com/xbmc/xbmc/pull/11620
and, https://bugzilla.redhat.com/show_bug.cgi?id=843478