### PR TITLE
backport of #1286 (kodi: set MALLOC_MMAP_THRESHOLD_=524288 for 64bit cpus)

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -45,3 +45,7 @@ fi
 KODI_ARGS="--lircdev /run/lirc/lircd"
 
 echo "KODI_ARGS=\"$KODI_ARGS\"" > /run/libreelec/kodi.conf
+
+if [ "$(uname -m)" = "x86_64" -o "$(uname -m)" = "aarch64" ]; then
+  echo "MALLOC_MMAP_THRESHOLD_=524288" >> /run/libreelec/kodi.conf
+fi


### PR DESCRIPTION
backport of #1286 