### PR TITLE
LibreELEC 7.0 addon fixes

### DIFF
--- a/packages/addons/addon-depends/bash/package.mk
+++ b/packages/addons/addon-depends/bash/package.mk
@@ -37,7 +37,3 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --enable-readline \
                            --without-bash-malloc \
                            --with-installed-readline"
-
-pre_configure_target() {
-  export LIBS="-lterminfo"
-}

--- a/packages/addons/addon-depends/moonlight-embedded/patches/moonlight-embedded-0002-Revert-Update-libCEC-compatibility-to-version-4.0.patch
+++ b/packages/addons/addon-depends/moonlight-embedded/patches/moonlight-embedded-0002-Revert-Update-libCEC-compatibility-to-version-4.0.patch
@@ -1,0 +1,67 @@
+From 4b17f9f51e010c14ada13fba3ec93cc7ca4a25d3 Mon Sep 17 00:00:00 2001
+From: kszaq <kszaquitto@gmail.com>
+Date: Tue, 7 Feb 2017 21:21:21 +0100
+Subject: [PATCH] Revert "Update libCEC compatibility to version 4.0"
+
+This reverts commit 90bfcdcc4da4178b0fd6c6013947006cd1c07377.
+---
+ src/input/cec.c                 | 2 +-
+ third_party/libcec/ceccloader.h | 8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/input/cec.c b/src/input/cec.c
+index 1a50d81..8c3892e 100644
+--- a/src/input/cec.c
++++ b/src/input/cec.c
+@@ -77,7 +77,7 @@ void cec_init() {
+   libcecc_reset_configuration(&g_config);
+   g_config.clientVersion = LIBCEC_VERSION_CURRENT;
+   g_config.bActivateSource = 0;
+-  g_callbacks.keyPress = &on_cec_keypress;
++  g_callbacks.CBCecKeyPress = &on_cec_keypress;
+   g_config.callbacks = &g_callbacks;
+   snprintf(g_config.strDeviceName, sizeof(g_config.strDeviceName), "Moonlight");
+   g_config.callbacks = &g_callbacks;
+diff --git a/third_party/libcec/ceccloader.h b/third_party/libcec/ceccloader.h
+index 2f8f760..1ae0c2a 100644
+--- a/third_party/libcec/ceccloader.h
++++ b/third_party/libcec/ceccloader.h
+@@ -84,7 +84,7 @@ typedef struct {
+   int                                 (CDECL *set_osd_string)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iLogicalAddress, CEC_NAMESPACE cec_display_control duration, const char* strMessage);
+   int                                 (CDECL *switch_monitoring)(libcec_connection_t connection, int bEnable);
+   CEC_NAMESPACE cec_version           (CDECL *get_device_cec_version)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iLogicalAddress);
+-  int                                 (CDECL *get_device_menu_language)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iLogicalAddress, CEC_NAMESPACE cec_menu_language language);
++  int                                 (CDECL *get_device_menu_language)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iLogicalAddress, CEC_NAMESPACE cec_menu_language* language);
+   uint64_t                            (CDECL *get_device_vendor_id)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iLogicalAddress);
+   uint16_t                            (CDECL *get_device_physical_address)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iLogicalAddress);
+   CEC_NAMESPACE cec_logical_address   (CDECL *get_active_source)(libcec_connection_t connection);
+@@ -100,7 +100,7 @@ typedef struct {
+   int                                 (CDECL *mute_audio)(libcec_connection_t connection, int bSendRelease);
+   int                                 (CDECL *send_keypress)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iDestination, CEC_NAMESPACE cec_user_control_code key, int bWait);
+   int                                 (CDECL *send_key_release)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iDestination, int bWait);
+-  int                                 (CDECL *get_device_osd_name)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iAddress, CEC_NAMESPACE cec_osd_name name);
++  CEC_NAMESPACE cec_osd_name          (CDECL *get_device_osd_name)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iAddress);
+   int                                 (CDECL *set_stream_path_logical)(libcec_connection_t connection, CEC_NAMESPACE cec_logical_address iAddress);
+   int                                 (CDECL *set_stream_path_physical)(libcec_connection_t connection, uint16_t iPhysicalAddress);
+   CEC_NAMESPACE cec_logical_addresses (CDECL *get_logical_addresses)(libcec_connection_t connection);
+@@ -161,7 +161,7 @@ static int libcecc_resolve_all(void* lib, libcec_interface_t* iface)
+   _libcecc_resolve(lib, iface->set_osd_string,                "libcec_set_osd_string",                int(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address, CEC_NAMESPACE cec_display_control, const char*));
+   _libcecc_resolve(lib, iface->switch_monitoring,             "libcec_switch_monitoring",             int(CDECL *)(libcec_connection_t, int));
+   _libcecc_resolve(lib, iface->get_device_cec_version,        "libcec_get_device_cec_version",        CEC_NAMESPACE cec_version(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address));
+-  _libcecc_resolve(lib, iface->get_device_menu_language,      "libcec_get_device_menu_language",      int(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address, CEC_NAMESPACE cec_menu_language));
++  _libcecc_resolve(lib, iface->get_device_menu_language,      "libcec_get_device_menu_language",      int(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address, CEC_NAMESPACE cec_menu_language*));
+   _libcecc_resolve(lib, iface->get_device_vendor_id,          "libcec_get_device_vendor_id",          uint64_t(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address));
+   _libcecc_resolve(lib, iface->get_device_physical_address,   "libcec_get_device_physical_address",   uint16_t(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address));
+   _libcecc_resolve(lib, iface->get_active_source,             "libcec_get_active_source",             CEC_NAMESPACE cec_logical_address(CDECL *)(libcec_connection_t));
+@@ -177,7 +177,7 @@ static int libcecc_resolve_all(void* lib, libcec_interface_t* iface)
+   _libcecc_resolve(lib, iface->mute_audio,                    "libcec_mute_audio",                    int(CDECL *)(libcec_connection_t, int));
+   _libcecc_resolve(lib, iface->send_keypress,                 "libcec_send_keypress",                 int(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address, CEC_NAMESPACE cec_user_control_code, int));
+   _libcecc_resolve(lib, iface->send_key_release,              "libcec_send_key_release",              int(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address, int));
+-  _libcecc_resolve(lib, iface->get_device_osd_name,           "libcec_get_device_osd_name",           int(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address, CEC_NAMESPACE cec_osd_name));
++  _libcecc_resolve(lib, iface->get_device_osd_name,           "libcec_get_device_osd_name",           CEC_NAMESPACE cec_osd_name(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address));
+   _libcecc_resolve(lib, iface->set_stream_path_logical,       "libcec_set_stream_path_logical",       int(CDECL *)(libcec_connection_t, CEC_NAMESPACE cec_logical_address));
+   _libcecc_resolve(lib, iface->set_stream_path_physical,      "libcec_set_stream_path_physical",      int(CDECL *)(libcec_connection_t, uint16_t));
+   _libcecc_resolve(lib, iface->get_logical_addresses,         "libcec_get_logical_addresses",         CEC_NAMESPACE cec_logical_addresses(CDECL *)(libcec_connection_t));
+-- 
+1.8.3.1
+

--- a/packages/addons/driver/sapphire/package.mk
+++ b/packages/addons/driver/sapphire/package.mk
@@ -33,7 +33,7 @@ PKG_AUTORECONF="no"
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Sapphire Remote Driver"
 PKG_ADDON_TYPE="xbmc.service"
-PKG_ADDON_REPOVERSION="8.0"
+PKG_ADDON_REPOVERSION="7.0"
 
 if [ -f $SYSROOT_PREFIX/usr/include/linux/input-event-codes.h ]; then
   INPUT_H="$SYSROOT_PREFIX/usr/include/linux/input-event-codes.h"

--- a/packages/addons/driver/sapphire/package.mk
+++ b/packages/addons/driver/sapphire/package.mk
@@ -41,8 +41,15 @@ else
   INPUT_H="$SYSROOT_PREFIX/usr/include/linux/input.h"
 fi
 
+pre_make_target() {
+  unset LDFLAGS
+}
+
 make_target() {
-  KVER=$(kernel_version) KDIR=$(kernel_path) INPUT_H=$INPUT_H make
+  make V=1 \
+       KVER=$(kernel_version) \
+       KDIR=$(kernel_path) \
+       INPUT_H=$INPUT_H
 }
 
 post_make_target() {


### PR DESCRIPTION
This PR fixes building of **moonlight-embedded** after a recent bump, enables **sapphire** addon for 7.0 and fixes **bash** building without netbsd-curses.