### PR TITLE
kodi: add backport to fix addon cache

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.01-create-archive-cache.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.01-create-archive-cache.patch
@@ -1,0 +1,28 @@
+From bf68ee5438cb0e1343e7a6c35df35e7a4fb36223 Mon Sep 17 00:00:00 2001
+From: Shani-08 <Shani-08@users.noreply.github.com>
+Date: Sat, 28 Jan 2017 23:21:30 +0000
+Subject: [PATCH] create archive_cache if not exists
+
+---
+ xbmc/Application.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
+index c6ef0c0..13d2cfa 100644
+--- a/xbmc/Application.cpp
++++ b/xbmc/Application.cpp
+@@ -1076,10 +1076,10 @@ void CApplication::CreateUserDirs() const
+ 
+   //Let's clear our archive cache before starting up anything more
+   auto archiveCachePath = CSpecialProtocol::TranslatePath("special://temp/archive_cache/");
+-  if (CDirectory::RemoveRecursive(archiveCachePath))
+-    CDirectory::Create(archiveCachePath);
+-  else
+-    CLog::Log(LOGWARNING, "Failed to remove the archive cache at %s", archiveCachePath.c_str());
++  if (CDirectory::Exists(archiveCachePath))
++    if (!CDirectory::RemoveRecursive(archiveCachePath))
++      CLog::Log(LOGWARNING, "Failed to remove the archive cache at %s", archiveCachePath.c_str());
++  CDirectory::Create(archiveCachePath);
+ 
+ }
+ 


### PR DESCRIPTION
`Add-on caching doesn't work without that directory so playback stopping and list repopulating will be slow.`

it builds (no runtime test because no idea how to reproduce)

@popcornmix could tell more