### PR TITLE
add config scripts for RPi Wolfson/Cirrus Logic audio card

### DIFF
--- a/packages/audio/rpi-cirrus-config/config/rpi-cirrus-config.sh.sample
+++ b/packages/audio/rpi-cirrus-config/config/rpi-cirrus-config.sh.sample
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Sample user config script to setup Cirrus Logic Audio Card
+
+# load helper functions and definitions
+. /usr/lib/alsa/rpi-cirrus-functions.sh
+
+# enable output to S/PDIF, line out and headset out
+playback_to_spdif
+playback_to_lineout
+playback_to_headset
+
+# disable noise gate - this can cut off the first few ms of playback
+mixer 'Noise Gate Switch' off
+
+# Uncomment this line to enable output to speakers
+# playback_to_speakers
+
+# example: mix line in and headset in into line out using a high-pass filter
+# - line in gain is set to +8dB
+# - headset in gain is set to +20dB
+# - line in and headset in are mixed together in the filter, each using
+#   a gain of -3dB (volume 29). line in uses input 1, headset in input 2
+# - first input of line out is connected to audio signal from RPi/Kodi,
+#   using a -3dB gain
+# - second input of line out is connected to output of the filter
+#
+# mixer "${line_out} Digital Switch" off	# mute output
+# setup_line_in 8
+# setup_headset_in 20
+# setup_filter "High-Pass" "240,3"
+# set_mixer $filter_signals $line_in_signals 29 1
+# set_mixer $filter_signals $headset_in_signals 29 2
+# set_mixer $line_out_signals $rpi_out_signals 29 1
+# set_mixer $line_out_signals $filter_signals 29 2
+# mixer "${line_out} Digital Switch" on		# unmute output

--- a/packages/audio/rpi-cirrus-config/modprobe.d/rpi-cirrus.conf
+++ b/packages/audio/rpi-cirrus-config/modprobe.d/rpi-cirrus.conf
@@ -1,0 +1,1 @@
+softdep arizona-spi pre: arizona-ldo1

--- a/packages/audio/rpi-cirrus-config/package.mk
+++ b/packages/audio/rpi-cirrus-config/package.mk
@@ -1,0 +1,46 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-2017 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="rpi-cirrus-config"
+PKG_VERSION="0.0.1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/HiassofT/rpi-cirrus-config"
+PKG_URL="https://github.com/HiassofT/rpi-cirrus-config/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="alsa-utils"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Config scripts for the Wolfson/Cirrus Logic audio card"
+PKG_LONGDESC="Config scripts for the Wolfson/Cirrus Logic audio card"
+
+make_target() {
+ : #
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/udev
+  install -m 0755 $PKG_DIR/scripts/rpi-cirrus-config $INSTALL/usr/lib/udev/rpi-cirrus-config
+
+  mkdir -p $INSTALL/usr/share/alsa/cards
+  cp alsa/RPiCirrus.conf $INSTALL/usr/share/alsa/cards
+
+  mkdir -p $INSTALL/usr/lib/alsa
+  cp mixer-scripts/rpi-cirrus-functions.sh $INSTALL/usr/lib/alsa
+
+  mkdir -p $INSTALL/usr/config
+  cp -PR $PKG_DIR/config/* $INSTALL/usr/config
+}

--- a/packages/audio/rpi-cirrus-config/scripts/rpi-cirrus-config
+++ b/packages/audio/rpi-cirrus-config/scripts/rpi-cirrus-config
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# setup default mixer settings for Cirrus Logic Audio Card
+
+. /etc/profile
+
+if [ -f $HOME/.config/sound.conf ] ; then
+    alsactl restore -f $HOME/.config/sound.conf
+else
+    if [ -r $HOME/.config/rpi-cirrus-config.sh ] ; then
+        progress "Setting up Cirrus Logic Audio Card with user config"
+        sh $HOME/.config/rpi-cirrus-config.sh
+    else
+        progress "Setting up Cirrus Logic Audio Card"
+
+        # load helper functions and definitions
+        . /usr/lib/alsa/rpi-cirrus-functions.sh
+
+        playback_to_spdif
+        playback_to_lineout
+        playback_to_headset
+        mixer 'Noise Gate Switch' off
+    fi
+fi

--- a/packages/audio/rpi-cirrus-config/udev.d/90-alsa-restore.rules
+++ b/packages/audio/rpi-cirrus-config/udev.d/90-alsa-restore.rules
@@ -1,0 +1,32 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+# When a sound device is detected, restore the volume settings
+SUBSYSTEM=="sound", KERNEL=="controlC*", NAME="snd/%k", ACTION=="add", GOTO="alsa_restore_go"
+GOTO="alsa_restore_end"
+
+LABEL="alsa_restore_go"
+
+# Separate config-script for RPi-Cirrus card
+DRIVERS=="snd-rpi-cirrus", RUN+="rpi-cirrus-config", GOTO="alsa_restore_end"
+
+# Default config-script for all other cards
+RUN+="soundconfig %k"
+
+LABEL="alsa_restore_end"
+

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -140,4 +140,4 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS media_build"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS media_build rpi-cirrus-config"

--- a/projects/RPi2/options
+++ b/projects/RPi2/options
@@ -136,4 +136,4 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS media_build"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS media_build rpi-cirrus-config"


### PR DESCRIPTION
don't merge yet, needs RPi kernel bump.

The driver for the Wolfson/Cirrus card has recently been included in the rpi kernel, this PR adds the necessary ALSA config (ALSA card conf and mixer settings) so that it is set up correctly and can work out-of-the-box.

The kernel config change is idendical to https://github.com/MilhouseVH/LibreELEC.tv/commit/88bb3e69aeebf9bf187910169d8a844d1365b35f "RBP: Sync options with upstream", so add either of these.

@MilhouseVH could you add this PR to your builds instead of "RBP: Sync options with upstream"?