### PR TITLE
linux: Update hash for Amlogic 3.14 kernel

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -35,7 +35,7 @@ case "$LINUX" in
     PKG_PATCH_DIRS="amlogic-3.10"
     ;;
   amlogic-3.14)
-    PKG_VERSION="33aa3be"
+    PKG_VERSION="6697519"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_DIR="$PKG_NAME-amlogic-$PKG_VERSION*"
     PKG_PATCH_DIRS="amlogic-3.14"


### PR DESCRIPTION
Includes various fixes:
meson-ir: Better response for orig. WH and Hardkernel remote
stmmac: Fix a rare ethernet network outage on WP2 (possibly others too)
various compat ioctl fixes when using 64bit kernel and 32bit userspace
