### PR TITLE
backport of #1321 (linux-amlogic: update to 83803a1)

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -35,7 +35,7 @@ case "$LINUX" in
     PKG_PATCH_DIRS="amlogic-3.10"
     ;;
   amlogic-3.14)
-    PKG_VERSION="33aa3be"
+    PKG_VERSION="83803a1"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_DIR="$PKG_NAME-amlogic-$PKG_VERSION*"
     PKG_PATCH_DIRS="amlogic-3.14"


### PR DESCRIPTION
backport of #1321 