### PR TITLE
input: change input repeat config

### DIFF
--- a/packages/mediacenter/kodi/config/advancedsettings.xml
+++ b/packages/mediacenter/kodi/config/advancedsettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
+  <remotedelay>0</remotedelay>
   <cputempcommand>cputemp</cputempcommand>
   <gputempcommand>gputemp</gputempcommand>
   <video>

--- a/packages/mediacenter/kodi/patches/kodi-999.99-PR11663.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99-PR11663.patch
@@ -1,0 +1,22 @@
+From adecb3af2e3eb5a2715e6f1264fe3047dd209318 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 12 Feb 2017 16:31:29 +0100
+Subject: [PATCH] [settings] change allowed remotedelay range to inlcude zero
+
+---
+ xbmc/settings/AdvancedSettings.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
+index cc37998..1c00eda 100644
+--- a/xbmc/settings/AdvancedSettings.cpp
++++ b/xbmc/settings/AdvancedSettings.cpp
+@@ -1010,7 +1010,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
+     }
+   }
+ 
+-  XMLUtils::GetInt(pRootElement, "remotedelay", m_remoteDelay, 1, 20);
++  XMLUtils::GetInt(pRootElement, "remotedelay", m_remoteDelay, 0, 20);
+   XMLUtils::GetFloat(pRootElement, "controllerdeadzone", m_controllerDeadzone, 0.0f, 1.0f);
+   XMLUtils::GetUInt(pRootElement, "fanartres", m_fanartRes, 0, 1080);
+   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 1080);

--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -194,9 +194,6 @@ ENV{eventlircd_evmap}="osmc_rf.evmap"
 
 LABEL="end-usb"
 
-# Set default delays (1000ms for first repeat, to avoid multiple keypresses).
-  RUN+="/usr/bin/ir-keytable --delay=1000 --device=$devnode"
-
 #-------------------------------------------------------------------------------
 # Ask eventlircd to handle Bluetooth HID devices that show up as event devices
 # and are known to be remote controls. For simplicity, the event map file names

--- a/packages/sysutils/v4l-utils/udev.d/70-input-repeat.rules
+++ b/packages/sysutils/v4l-utils/udev.d/70-input-repeat.rules
@@ -1,0 +1,18 @@
+ACTION=="add", SUBSYSTEM=="input", KERNEL=="event[0-9]*", GOTO="start"
+GOTO="end"
+LABEL="start"
+
+# don't change eventlircd device settings
+ATTRS{name}=="eventlircd", GOTO="end"
+
+# don't change settings of rc remotes
+SUBSYSTEMS=="rc", GOTO="end"
+
+# set default repeat delay to 500ms like rc remotes
+RUN+="/usr/bin/ir-keytable --delay=500 --device=$devnode"
+
+# make lircd-uinput use same repeat period like keyboards in kodi
+ATTRS{name}=="lircd-uinput", \
+  RUN+="/usr/bin/ir-keytable --period=80 --device=$devnode"
+
+LABEL="end"

--- a/projects/RPi/kodi/advancedsettings.xml
+++ b/projects/RPi/kodi/advancedsettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
+  <remotedelay>0</remotedelay>
 
   <fanartres>720</fanartres>
   <imageres>540</imageres>

--- a/projects/RPi2/kodi/advancedsettings.xml
+++ b/projects/RPi2/kodi/advancedsettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
+  <remotedelay>0</remotedelay>
 
   <fanartres>720</fanartres>
   <imageres>540</imageres>

--- a/projects/WeTek_Core/kodi/advancedsettings.xml
+++ b/projects/WeTek_Core/kodi/advancedsettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
+  <remotedelay>0</remotedelay>
 
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/projects/WeTek_Hub/kodi/advancedsettings.xml
+++ b/projects/WeTek_Hub/kodi/advancedsettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
+  <remotedelay>0</remotedelay>
 
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/projects/WeTek_Play/kodi/advancedsettings.xml
+++ b/projects/WeTek_Play/kodi/advancedsettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
+  <remotedelay>0</remotedelay>
 
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/projects/WeTek_Play_2/kodi/advancedsettings.xml
+++ b/projects/WeTek_Play_2/kodi/advancedsettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
+  <remotedelay>0</remotedelay>
 
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/projects/imx6/kodi/advancedsettings.xml
+++ b/projects/imx6/kodi/advancedsettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
+  <remotedelay>0</remotedelay>
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>


### PR DESCRIPTION
This PR changes the repeat delay and period for all LIRC remotes to match what Kodi sets for keyboards.

Currently `98-eventlircd.rules` sets the delay to 1000ms and the kernel sets the period to 33ms.
This is a too long delay and a too short period in my opinion.

~Copy the file to `/storage/.config/udev.rules.d/99-lircd-uinput.rules` and modify it to try with different delay/periods (after a reboot)~