### PR TITLE
Backport for LE8: WeTek_Play_2: Remap buttons in remote.conf

### DIFF
--- a/projects/WeTek_Play_2/filesystem/etc/amremote/remote.conf
+++ b/projects/WeTek_Play_2/filesystem/etc/amremote/remote.conf
@@ -51,35 +51,35 @@ mouse_end
 
 key_begin
     0x02 116 # power
-    0x46 88 # 2nd power button (F12, ends WeTV)
+    0x46 88  # 2nd power button (F12, ends WeTV)
     0x10 113 # volume mute
-    0x22 2 # 1
-    0x23 3 # 2
-    0x24 4 # 3
-    0x25 5 # 4
-    0x26 6 # 5
-    0x27 7 # 6
-    0x28 8 # 7
-    0x29 9 # 8
-    0x30 10 # 9
-    0x71 14 # delete
-    0x21 11 # 0
-    0x72 87 # capslock (mapped as F11)
+    0x22 2   # 1
+    0x23 3   # 2
+    0x24 4   # 3
+    0x25 5   # 4
+    0x26 6   # 5
+    0x27 7   # 6
+    0x28 8   # 7
+    0x29 9   # 8
+    0x30 10  # 9
+    0x71 14  # delete
+    0x21 11  # 0
+    0x72 58  # caps lock
     0x48 127 # menu
     0x03 102 # home
     0x61 158 # back
-    0x83 580 # app_switch
-    0x77 373 # assist
+    0x83 139 # app_switch (mapped as KEY_MENU)
+    0x77 138 # assist (mapped as KEY_HELP)
     0x50 103 # up
     0x4b 108 # down
     0x4c 105 # left
     0x4d 106 # right
-    0x47 28 # ok
+    0x47 28  # ok
     0x44 115 # volume up
     0x43 114 # volume down
-    0x41 402 # channel up
-    0x42 403 # channel down
-    0x4f 64 # * (mapped as f6)
+    0x41 104 # channel up (mapped as PageUp)
+    0x42 109 # channel down (mapped as PageDown)
+    0x4f 85  # *
     0x82 388 # teletext
     0x73 398 # red
     0x74 399 # green
@@ -96,35 +96,35 @@ key_end
 
 repeat_key_begin
     0x02 116 # power
-    0x46 88 # 2nd power button (F12, ends WeTV)
+    0x46 88  # 2nd power button (F12, ends WeTV)
     0x10 113 # volume mute
-    0x22 2 # 1
-    0x23 3 # 2
-    0x24 4 # 3
-    0x25 5 # 4
-    0x26 6 # 5
-    0x27 7 # 6
-    0x28 8 # 7
-    0x29 9 # 8
-    0x30 10 # 9
-    0x71 14 # delete
-    0x21 11 # 0
-    0x72 58 # caps lock
+    0x22 2   # 1
+    0x23 3   # 2
+    0x24 4   # 3
+    0x25 5   # 4
+    0x26 6   # 5
+    0x27 7   # 6
+    0x28 8   # 7
+    0x29 9   # 8
+    0x30 10  # 9
+    0x71 14  # delete
+    0x21 11  # 0
+    0x72 58  # caps lock
     0x48 127 # menu
     0x03 102 # home
     0x61 158 # back
-    0x83 580 # app_switch
-    0x77 373 # assist
+    0x83 139 # app_switch (mapped as KEY_MENU)
+    0x77 138 # assist (mapped as KEY_HELP)
     0x50 103 # up
     0x4b 108 # down
     0x4c 105 # left
     0x4d 106 # right
-    0x47 353 # ok
+    0x47 28  # ok
     0x44 115 # volume up
     0x43 114 # volume down
-    0x41 402 # channel up
-    0x42 403 # channel down
-    0x4f 64 # * (mapped as f6)
+    0x41 104 # channel up (mapped as PageUp)
+    0x42 109 # channel down (mapped as PageDown)
+    0x4f 85  # *
     0x82 388 # teletext
     0x73 398 # red
     0x74 399 # green


### PR DESCRIPTION
work by @Raybuntu this was already in master:
https://github.com/LibreELEC/LibreELEC.tv/commit/5df86b714d26f832675c8f0b08f21ff87a468228