### PR TITLE
v4l-utils: update to 1.12.2 and fix streamzap keytable

### DIFF
--- a/packages/sysutils/v4l-utils/package.mk
+++ b/packages/sysutils/v4l-utils/package.mk
@@ -19,7 +19,7 @@
 # with 1.0.0 repeat delay is broken. test on upgrade
 
 PKG_NAME="v4l-utils"
-PKG_VERSION="1.8.1"
+PKG_VERSION="1.12.2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://linuxtv.org/"

--- a/packages/sysutils/v4l-utils/patches/v4l-utils-24-fix-streamzap-keymap.patch
+++ b/packages/sysutils/v4l-utils/patches/v4l-utils-24-fix-streamzap-keymap.patch
@@ -1,0 +1,10 @@
+diff --git a/utils/keytable/rc_keymaps/streamzap b/utils/keytable/rc_keymaps/streamzap
+index 3512cd8..1619459 100644
+--- a/utils/keytable/rc_keymaps/streamzap
++++ b/utils/keytable/rc_keymaps/streamzap
+@@ -1,4 +1,4 @@
+-# table streamzap, type: RC5_SZ
++# table streamzap, type: rc-5-sz
+ 0x28c0 KEY_NUMERIC_0
+ 0x28c1 KEY_NUMERIC_1
+ 0x28c2 KEY_NUMERIC_2


### PR DESCRIPTION
This should hopefully fix the streamzap issue reported here:
https://forum.libreelec.tv/thread-4873-post-34116.html

@MilhouseVH could you include that in your x86 build?