### PR TITLE
kodi: cleanup redundant sysinfo for AML aarch64

### DIFF
--- a/packages/mediacenter/kodi/patches/aarch64/kodi-0007-improve-sysinfo-for-AML-aarch64.patch
+++ b/packages/mediacenter/kodi/patches/aarch64/kodi-0007-improve-sysinfo-for-AML-aarch64.patch
@@ -1,0 +1,45 @@
+From 454ea9da7f909e66a676213423360552f988dd66 Mon Sep 17 00:00:00 2001
+From: Jamie Coldhill <wrxtasy@amnet.net.au>
+Date: Wed, 15 Feb 2017 12:09:58 +0800
+Subject: [PATCH] kodi: cleanup redundant sysinfo for AML aarch64
+
+---
+ xbmc/windows/GUIWindowSystemInfo.cpp | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/xbmc/windows/GUIWindowSystemInfo.cpp b/xbmc/windows/GUIWindowSystemInfo.cpp
+index 93e9f74..59f6c52 100644
+--- a/xbmc/windows/GUIWindowSystemInfo.cpp
++++ b/xbmc/windows/GUIWindowSystemInfo.cpp
+@@ -109,7 +109,6 @@ void CGUIWindowSystemInfo::FrameMove()
+     SetControlLabel(i++, "%s %s", 13283, SYSTEM_OS_VERSION_INFO);
+     SetControlLabel(i++, "%s: %s", 12390, SYSTEM_UPTIME);
+     SetControlLabel(i++, "%s: %s", 12394, SYSTEM_TOTALUPTIME);
+-    SetControlLabel(i++, "%s: %s", 12395, SYSTEM_BATTERY_LEVEL);
+   }
+ 
+   else if (m_section == CONTROL_BT_STORAGE)
+@@ -157,17 +156,15 @@ void CGUIWindowSystemInfo::FrameMove()
+   {
+     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20160));
+     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUModel());
+-#if defined(__arm__) && defined(TARGET_LINUX)
+-    SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUBogoMips());
++#if (defined(__arm__) || defined(__aarch64__)) && defined(TARGET_LINUX)
+     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUHardware());
+     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPURevision());
+-    SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUSerial());
+ #endif
+     SetControlLabel(i++, "%s %s", 22011, SYSTEM_CPU_TEMPERATURE);
+-#if (!defined(__arm__) && !defined(__aarch64__)) || defined(TARGET_RASPBERRY_PI)
++#if !(defined(__arm__) || defined(__aarch64__)) || defined(TARGET_RASPBERRY_PI)
+     SetControlLabel(i++, "%s %s", 13284, SYSTEM_CPUFREQUENCY);
+ #endif
+-#if !(defined(__arm__) && defined(TARGET_LINUX))
++#if !((defined(__arm__) || defined(__aarch64__)) && defined(TARGET_LINUX))
+     SetControlLabel(i++, "%s %s", 13271, SYSTEM_CPU_USAGE);
+ #endif
+     i++;  // empty line
+-- 
+2.7.4
+


### PR DESCRIPTION
The Kodi sysinfo screen is showing either N/A or info that is not relevant for AML aarch64 and the common linux-amlogic Kernel we use.

Remove redundant info and tidy up.

DNS Servers left in this PR. 
Upstreaming this will run into problems for other aarch64 platforms like the nVIDIA Shield.