### PR TITLE
backport of #1350 (docker: enable journald buildtag)

### DIFF
--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,6 @@
+8.1.114
+- Enable journald buildtag
+
 8.1.113
 - Update to docker 1.13.1
 - Update to golang 1.7.5

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="docker"
 PKG_VERSION="1.13.1"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_ADDON_PROJECTS="Generic RPi RPi2 imx6 WeTek_Hub WeTek_Play_2 Odroid_C2"
 PKG_LICENSE="ASL"
@@ -39,7 +39,8 @@ configure_target() {
                            autogen \
                            exclude_graphdriver_devicemapper \
                            exclude_graphdriver_aufs \
-                           exclude_graphdriver_btrfs"
+                           exclude_graphdriver_btrfs \
+                           journald"
 
   case $TARGET_ARCH in
     x86_64)


### PR DESCRIPTION
backport of #1350 