### PR TITLE
kodi: skip one lirc repeat event

### DIFF
--- a/packages/mediacenter/kodi/config/advancedsettings.xml
+++ b/packages/mediacenter/kodi/config/advancedsettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
-  <remotedelay>0</remotedelay>
+  <remotedelay>1</remotedelay>
   <cputempcommand>cputemp</cputempcommand>
   <gputempcommand>gputemp</gputempcommand>
   <video>

--- a/projects/RPi/kodi/advancedsettings.xml
+++ b/projects/RPi/kodi/advancedsettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
-  <remotedelay>0</remotedelay>
+  <remotedelay>1</remotedelay>
 
   <fanartres>720</fanartres>
   <imageres>540</imageres>

--- a/projects/RPi2/kodi/advancedsettings.xml
+++ b/projects/RPi2/kodi/advancedsettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
-  <remotedelay>0</remotedelay>
+  <remotedelay>1</remotedelay>
 
   <fanartres>720</fanartres>
   <imageres>540</imageres>

--- a/projects/WeTek_Core/kodi/advancedsettings.xml
+++ b/projects/WeTek_Core/kodi/advancedsettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
-  <remotedelay>0</remotedelay>
+  <remotedelay>1</remotedelay>
 
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/projects/WeTek_Hub/kodi/advancedsettings.xml
+++ b/projects/WeTek_Hub/kodi/advancedsettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
-  <remotedelay>0</remotedelay>
+  <remotedelay>1</remotedelay>
 
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/projects/WeTek_Play/kodi/advancedsettings.xml
+++ b/projects/WeTek_Play/kodi/advancedsettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
-  <remotedelay>0</remotedelay>
+  <remotedelay>1</remotedelay>
 
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/projects/WeTek_Play_2/kodi/advancedsettings.xml
+++ b/projects/WeTek_Play_2/kodi/advancedsettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
-  <remotedelay>0</remotedelay>
+  <remotedelay>1</remotedelay>
 
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/projects/imx6/kodi/advancedsettings.xml
+++ b/projects/imx6/kodi/advancedsettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <advancedsettings>
   <showexitbutton>false</showexitbutton>
-  <remotedelay>0</remotedelay>
+  <remotedelay>1</remotedelay>
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>


### PR DESCRIPTION
This PR fixes an edge case for Harmony remotes configured to send 3 command repeats (sync to the current state of #1327)