### PR TITLE
packages/linux: Update Amlogic kernel to 3.10-de626d8

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,7 +29,7 @@ PKG_SHORTDESC="linux26: The Linux kernel 2.6 precompiled kernel binary image and
 PKG_LONGDESC="This package contains a precompiled kernel image and the modules."
 case "$LINUX" in
   amlogic-3.10)
-    PKG_VERSION="1261cae"
+    PKG_VERSION="de626d8"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_DIR="$PKG_NAME-amlogic-$PKG_VERSION*"
     PKG_PATCH_DIRS="amlogic-3.10"


### PR DESCRIPTION
Update Amlogic kernel to 3.10-de626d8.

The updated kernel contains an important fix to improve playback of the videos with fractional FPS.
