### PR TITLE
Addon stripping improvements

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -507,7 +507,7 @@ show_config() {
 # strip
 debug_strip() {
   if [ ! "$DEBUG" = yes ]; then
-    find $* -type f -executable | xargs $STRIP 1>/dev/null || :
+    find $* -type f -executable | xargs $STRIP 2>/dev/null || :
   fi
 }
 

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -167,6 +167,7 @@ if [ "$PKG_IS_ADDON" = "yes" ] ; then
 
   if [ "$(type -t addon)" = "function" ]; then
     addon
+    debug_strip $ADDON_BUILD/$PKG_ADDON_ID
   else
     echo "*** unsupported package format. please convert your package ***"
     exit 1

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -158,6 +158,8 @@ pack_addon() {
 }
 
 if [ "$PKG_IS_ADDON" = "yes" ] ; then
+  setup_toolchain $TARGET
+
   $SCRIPTS/build $@
 
   printf  "%${BUILD_INDENT}c CREATE ADDON  ($PROJECT/$TARGET_ARCH) $1\n" ' '>&$SILENT_OUT


### PR DESCRIPTION
This PR makes build system strip all executables in addons we create to shave off some unnecessary MBs from binaries. This removes the need to add `debug_strip` in each addon's `package.mk`.

I also added a fix for stripping addon if we want to re-create a ZIP without rebuilding.

These changes are included in my community 8.0 builds and so far no issues reported.