### PR TITLE
scripts/image: print depmod errors

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -229,7 +229,7 @@ fi
 MODVER=$(basename $(ls -d $INSTALL/usr/lib/modules/*))
 find $INSTALL/usr/lib/modules/$MODVER/ -name *.ko | \
   sed -e "s,$INSTALL/usr/lib/modules/$MODVER/,," > $INSTALL/usr/lib/modules/$MODVER/modules.order
-$TOOLCHAIN/bin/depmod -b $INSTALL/usr $MODVER 2> /dev/null
+$TOOLCHAIN/bin/depmod -b $INSTALL/usr -a -e -F "$BUILD/linux-$(kernel_version)/System.map" $MODVER
 
 # strip kernel modules
 for MOD in `find $INSTALL/usr/lib/modules/ -type f -name *.ko`; do


### PR DESCRIPTION
Print depmod errors so that we can see unresolved symbols when building. This is handy when including out-of-tree drivers, e.g. `media_build`. If a symbol cannot be resolved, the module is non-functional and we should fix it, not ship it.