### PR TITLE
Backport of #1372 (Update WeTek proprietary DVB modules to wetekdvb-20170116)

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wetekdvb"
-PKG_VERSION="20161127"
+PKG_VERSION="20170116"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.wetek.com/"


### PR DESCRIPTION
Backport of #1372.