### PR TITLE
projectM: remove glew [LE9]

### DIFF
--- a/packages/graphics/libprojectM/patches/libprojectM-hacky-removal-of-glew-spiff.patch
+++ b/packages/graphics/libprojectM/patches/libprojectM-hacky-removal-of-glew-spiff.patch
@@ -1,0 +1,61 @@
+From 8d450df7830744201f4527a275989124ce1f48f2 Mon Sep 17 00:00:00 2001
+From: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
+Date: Thu, 19 Jan 2017 11:23:38 +0100
+Subject: [PATCH] hacky removal of glew
+
+---
+ CMakeLists.txt   | 3 ++-
+ Renderer/FBO.cpp | 4 ++--
+ Renderer/FBO.hpp | 5 ++++-
+ 3 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5d8e90e..3492101 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,7 +42,8 @@ SET(GLEW_SOURCES glew.h glew.c)
+ SET(GLEW_LINK_TARGETS )
+ else(USE_NATIVE_GLEW)
+ SET(GLEW_SOURCES )
+-SET (GLEW_LINK_TARGETS GLEW)
++#SET (GLEW_LINK_TARGETS GLEW)
++SET (GLEW_LINK_TARGETS)
+ endif(USE_NATIVE_GLEW)
+ 
+ SET(projectM_SOURCES projectM.cpp PCM.cpp Preset.cpp fftsg.cpp KeyHandler.cpp
+diff --git a/Renderer/FBO.cpp b/Renderer/FBO.cpp
+index 97e482a..20f50dd 100755
+--- a/Renderer/FBO.cpp
++++ b/Renderer/FBO.cpp
+@@ -97,10 +97,10 @@ RenderTarget::RenderTarget(int texsize, int width, int height) : useFBO(false) {
+    this->texsize = texsize;
+ 
+ #ifdef USE_FBO
+-   glewInit();
++   //glewInit();
+       // Forceably disable FBO if user requested it but the video card / driver lacks
+       // the appropraite frame buffer extension.
+-      if (useFBO = glewIsSupported("GL_EXT_framebuffer_object"))
++      if (useFBO = 1)//glewIsSupported("GL_EXT_framebuffer_object"))
+ 	{	 
+ 
+ 	  GLuint   fb,  depth_rb, rgba_tex,  other_tex;
+diff --git a/Renderer/FBO.hpp b/Renderer/FBO.hpp
+index e79954d..3844f24 100755
+--- a/Renderer/FBO.hpp
++++ b/Renderer/FBO.hpp
+@@ -32,7 +32,10 @@
+ #ifdef USE_NATIVE_GLEW
+ #include "glew.h"
+ #else
+-#include <GL/glew.h>
++//#include <GL/glew.h>
++#define GL_GLEXT_PROTOTYPES
++#include <GL/gl.h>
++#include <GL/glext.h>
+ #endif
+ #endif
+ 
+-- 
+2.7.4
+

--- a/packages/mediacenter/kodi-binary-addons/visualization.projectm/patches/visualization.projectm-03-remove-glew-spiff.patch
+++ b/packages/mediacenter/kodi-binary-addons/visualization.projectm/patches/visualization.projectm-03-remove-glew-spiff.patch
@@ -1,0 +1,47 @@
+From 6e83396c8360a8457af4d5348a852b6f333ac29f Mon Sep 17 00:00:00 2001
+From: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
+Date: Wed, 18 Jan 2017 12:33:09 +0100
+Subject: [PATCH] remove glew
+
+---
+ CMakeLists.txt | 3 ++-
+ src/Main.cpp   | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b323a82..56348b1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,7 @@ find_package(p8-platform REQUIRED)
+ find_package(OpenGL REQUIRED)
+ 
+ if(NOT APPLE)
+-  find_package(GLEW REQUIRED)
++  #find_package(GLEW REQUIRED)
+   set(EXTRA_INCLUDES ${GLEW_INCLUDE_DIR})
+   set(EXTRA_LIBRARIES ${GLEW_LIBRARIES})
+ endif()
+@@ -28,6 +28,7 @@ set(INCLUDES ${OpenGL_INCLUDE_DIR}
+              ${PROJECTM_INCLUDE_DIRS})
+ 
+ set(DEPLIBS ${OPENGL_LIBRARIES}
++  #${GLEW_LIBRARIES}
+             ${EXTRA_LIBRARIES}
+             ${PROJECTM_LIBS}
+             ${extra_libs})
+diff --git a/src/Main.cpp b/src/Main.cpp
+index e9e1345..ae1042e 100644
+--- a/src/Main.cpp
++++ b/src/Main.cpp
+@@ -59,7 +59,7 @@ d4rk@xbmc.org
+ #include <threads/mutex.h>
+ 
+ #if !defined(__APPLE__)
+-#include <GL/glew.h>
++#include <GL/gl.h>
+ #endif
+ 
+ #include "libprojectM/projectM.hpp"
+-- 
+2.7.4
+


### PR DESCRIPTION
Same as #1378, but for master.

This allows us to build projectM again (many thanks @notspiff!)

We can update to libprojectM 2.1.0 in future (there's currently a problem loading the 2.1.0-based add-on) but having this PR at least fixes the current build issue.