### PR TITLE
WeTek_Hub/WeTek_Play_2: disable meson PWM support

### DIFF
--- a/projects/WeTek_Hub/linux/linux.aarch64.conf
+++ b/projects/WeTek_Hub/linux/linux.aarch64.conf
@@ -828,6 +828,7 @@ CONFIG_I2C_AML=y
 # CONFIG_I2C_SW_AML is not set
 # CONFIG_BCM2079X_I2C is not set
 # CONFIG_AML_PWM is not set
+# CONFIG_MESON_PWM is not set
 
 #
 # HDMI TX Support

--- a/projects/WeTek_Play_2/linux/linux.aarch64.conf
+++ b/projects/WeTek_Play_2/linux/linux.aarch64.conf
@@ -828,6 +828,7 @@ CONFIG_I2C_AML=y
 # CONFIG_I2C_SW_AML is not set
 # CONFIG_BCM2079X_I2C is not set
 # CONFIG_AML_PWM is not set
+# CONFIG_MESON_PWM is not set
 
 #
 # HDMI TX Support


### PR DESCRIPTION
Hub / Play2 does not need PWM support. The C2 however does.

Companion PR to:
https://github.com/LibreELEC/LibreELEC.tv/pull/1339
