### PR TITLE
libdvbcsa: update to aae3d0c

### DIFF
--- a/packages/addons/addon-depends/libdvbcsa/package.mk
+++ b/packages/addons/addon-depends/libdvbcsa/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libdvbcsa"
-PKG_VERSION="4ce8be8"
+PKG_VERSION="aae3d0c"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.videolan.org/developers/libdvbcsa.html"


### PR DESCRIPTION
I've made some performance improvements since 4ce8be8.

To run tests, copy `.../build.LibreELEC-.../libdvbcsa-XXXXXXX/test` directory to the target device and run
```
./testenc && ./testdec && ./testbsops && ./testbitslice && seq 10 | xargs -n1 ./benchbitslice
```

It would be nice if someone could run benchmarks on AArch64 to make sure `--enable-uint64` is still faster than `--enable-neon` (see the comment in `package.mk`).