### PR TITLE
peripheral.joystick: revert package bump

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="69c9e5f"
+PKG_VERSION="eeb6fec"
 PKG_REV="0"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
revert to krypton release instead of master (Leia)