### PR TITLE
gpu-aml: Do not use Mali Utilization

### DIFF
--- a/packages/linux-drivers/gpu-aml/patches/gpu-aml-0001-dont-use-mali-utilization.patch
+++ b/packages/linux-drivers/gpu-aml/patches/gpu-aml-0001-dont-use-mali-utilization.patch
@@ -1,0 +1,13 @@
+diff --git a/mali/Kbuild.orig b/mali/Kbuild
+index 7cc2225..4813c2f 100755
+--- a/mali/Kbuild.orig
++++ b/mali/Kbuild
+@@ -56,7 +56,7 @@ ifeq ($(CONFIG_MALI_DVFS),y)
+     USING_GPU_UTILIZATION=0
+     USING_DVFS=1
+ else
+-    USING_GPU_UTILIZATION=1
++    USING_GPU_UTILIZATION=0
+     USING_DVFS=0
+ endif
+ PROFILING_SKIP_PP_JOBS ?= 0


### PR DESCRIPTION
This settings turns off any scaling for Mali cores/frequency. The effect of this is smooth Kodi GUI operation without a need to set turbo mode in driver parameter or device tree.

Users reported smoother GUI with UTILIZATION = 0 and Mali operating at 500MHz than with UTILIZATION = 1 and Mali at 666MHz.

It's also worth to note that `USING_GPU_UTILIZATION ?= 0` is default setting in Mali driver source code from ARM.