### PR TITLE
kodi: hide ADSP settings

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -81,4 +81,12 @@
     </category>
   </section>
 
+  <section id="system">
+    <category id="audio">
+      <group id="4">
+        <visible>false</visible>
+      </group>
+    </category>
+  </section>
+
 </settings>

--- a/packages/mediacenter/kodi/patches/kodi-999.99-ADSP-hack.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99-ADSP-hack.patch
@@ -1,0 +1,22 @@
+From ad23989222e80d18343cca113c1d8aa3fd3ac199 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Tue, 17 Jan 2017 21:05:26 +0000
+Subject: [PATCH] ADSP: Hack - disable
+
+---
+ xbmc/ServiceManager.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/ServiceManager.cpp b/xbmc/ServiceManager.cpp
+index 091c9a3..22b1910 100644
+--- a/xbmc/ServiceManager.cpp
++++ b/xbmc/ServiceManager.cpp
+@@ -87,7 +87,7 @@ bool CServiceManager::Init2()
+ 
+ bool CServiceManager::Init3()
+ {
+-  m_ADSPManager->Init();
++  //m_ADSPManager->Init();
+   m_PVRManager->Init();
+   m_contextMenuManager->Init();
+   m_gameServices->Init();

--- a/tools/RPi/rpi-kodi-rebase.sh
+++ b/tools/RPi/rpi-kodi-rebase.sh
@@ -5,6 +5,7 @@ TODO=$1
 # Drop commits not used
 DROP_COMMITS="
 UNSTABLE\: This is a placeholder\. Commits after this point are considered experimental\.
+ADSP: Hack - disable
 "
 
 IFS=$'\n'


### PR DESCRIPTION
See thread: https://forum.libreelec.tv/thread-4606-post-37112.html#pid37112

This will hide the entire ADSP settings group in LE 8.0.1.

Instead of this:
![s1](http://i.imgur.com/ep7wIUk.png)

there will be this:
![s2](http://i.imgur.com/pdVDe8S.png)

If "audio DSP processing" has already been enabled in an earlier release, users will have to go back to a previous release that allowed the ADSP setting to be enabled/disabled (ie. 8.0.0, 7.95.x beta or 7.90.xxx alpha) in order to disable the now hidden setting.

Or they can edit `guisettings.xml` and set `<dspaddonsenabled>false</dspaddonsenabled>`.

About the only other option that comes to mind is to force `dspaddonsenabled` disabled via a `sed` in `kodi-config.sh`, which isn't great. Any better options, preferably that don't involve patching Kodi?