### PR TITLE
LE8: RPi/RPi2: re-enable lirc_xbox driver

### DIFF
--- a/projects/RPi/linux/linux.arm.conf
+++ b/projects/RPi/linux/linux.arm.conf
@@ -3452,7 +3452,7 @@ CONFIG_LIRC_RPI=m
 # CONFIG_LIRC_SASEM is not set
 # CONFIG_LIRC_SERIAL is not set
 # CONFIG_LIRC_SIR is not set
-# CONFIG_LIRC_XBOX is not set
+CONFIG_LIRC_XBOX=m
 # CONFIG_LIRC_ZILOG is not set
 
 #

--- a/projects/RPi2/linux/linux.arm.conf
+++ b/projects/RPi2/linux/linux.arm.conf
@@ -3545,7 +3545,7 @@ CONFIG_LIRC_RPI=m
 # CONFIG_LIRC_SASEM is not set
 # CONFIG_LIRC_SERIAL is not set
 # CONFIG_LIRC_SIR is not set
-# CONFIG_LIRC_XBOX is not set
+CONFIG_LIRC_XBOX=m
 # CONFIG_LIRC_ZILOG is not set
 
 #


### PR DESCRIPTION
driver was (accidentally?) disabled when upgrading from kernel 4.4 to 4.6 in commit 012fd9bca0864ec8b88e80facab7b244f6ae2216