### PR TITLE
emby: update to 3.2.5

### DIFF
--- a/packages/addons/addon-depends/emby-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/emby-depends/ffmpegx/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="ffmpegx"
 PKG_VERSION="libreelec"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"

--- a/packages/addons/addon-depends/emby-depends/imagemagick/package.mk
+++ b/packages/addons/addon-depends/emby-depends/imagemagick/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="imagemagick"
-PKG_VERSION="6.9.6-7"
+PKG_VERSION="7.0.5-0"
 PKG_ARCH="any"
 PKG_LICENSE="http://www.imagemagick.org/script/license.php"
 PKG_SITE="http://www.imagemagick.org/"

--- a/packages/addons/addon-depends/emby-depends/x264/package.mk
+++ b/packages/addons/addon-depends/emby-depends/x264/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="x264"
-PKG_VERSION="snapshot-20161203-2245-stable"
+PKG_VERSION="snapshot-20170228-2245-stable"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.videolan.org/developers/x264.html"

--- a/packages/addons/service/emby/changelog.txt
+++ b/packages/addons/service/emby/changelog.txt
@@ -1,3 +1,7 @@
+111
+- Updated to version 3.2.5
+- Rebuilt libx264, ffmpegx and imagemagick
+
 110
 - Rebuild ffmpegx with libx264
 

--- a/packages/addons/service/emby/package.mk
+++ b/packages/addons/service/emby/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="emby"
-PKG_VERSION="3.0.8500"
-PKG_REV="110"
+PKG_VERSION="3.2.5"
+PKG_REV="111"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://emby.media"
@@ -52,7 +52,7 @@ addon() {
         -d $ADDON_BUILD/$PKG_ADDON_ID/Emby.Mono
 
   sed -i 's/libsqlite3.so/libsqlite3.so.0/g' \
-      $ADDON_BUILD/$PKG_ADDON_ID/Emby.Mono/System.Data.SQLite.dll.config
+      $ADDON_BUILD/$PKG_ADDON_ID/Emby.Mono/SQLitePCLRaw.provider.sqlite3.dll.config
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin
   cp -L $(get_build_dir ffmpegx)/.install_pkg/usr/local/bin/ffmpegx  \
@@ -60,7 +60,7 @@ addon() {
         $ADDON_BUILD/$PKG_ADDON_ID/bin/
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -L $(get_build_dir imagemagick)/.install_pkg/usr/lib/libMagickCore-6.Q8.so.2 \
-        $(get_build_dir imagemagick)/.install_pkg/usr/lib/libMagickWand-6.Q8.so   \
+  cp -L $(get_build_dir imagemagick)/.install_pkg/usr/lib/libMagickCore-7.Q8.so.2 \
+        $(get_build_dir imagemagick)/.install_pkg/usr/lib/libMagickWand-7.Q8.so   \
         $ADDON_BUILD/$PKG_ADDON_ID/lib/
 }

--- a/packages/addons/tools/mono/changelog.txt
+++ b/packages/addons/tools/mono/changelog.txt
@@ -1,3 +1,6 @@
+8.0.102
+- Update to 4.8.0.495
+
 8.0.101
 - Update to 4.2.1.102
 - Build static for all projects and architectures

--- a/packages/addons/tools/mono/package.mk
+++ b/packages/addons/tools/mono/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="mono"
-PKG_VERSION="4.2.1.102"
-PKG_REV="101"
+PKG_VERSION="4.8.0.495"
+PKG_REV="102"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.mono-project.com"


### PR DESCRIPTION
Emby 3.2.5 requires Mono >= 4.6
Mono 4.8.0.495 builds for and runs on RPi2 (Emby, WebGrabPlus and other addons run)
Updated ffmpegx, imagemagick and x264