### PR TITLE
brcmfmac_sdio-firmware-rpi: Implement Raspbian udev rules and btuart

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -38,6 +38,12 @@ makeinstall_target() {
   DESTDIR=$INSTALL/usr ./install
 }
 
+post_makeinstall_target() {
+  # Install rpi btuart script to bring up Bluetooth
+  mkdir -p $INSTALL/usr/bin
+    cp -P $PKG_DIR/scripts/rpi-btuart $INSTALL/usr/bin
+}
+
 post_install() {
   enable_service brcmfmac_sdio-firmware.service
 }

--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/scripts/rpi-btuart
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/scripts/rpi-btuart
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "$(cat /proc/device-tree/aliases/uart0)" = "$(cat /proc/device-tree/aliases/serial1)" ] ; then
+  if [ "$(wc -c /proc/device-tree/soc/gpio@7e200000/uart0_pins/brcm\,pins | cut -f 1 -d ' ')" = "16" ] ; then
+    /usr/bin/hciattach /dev/serial1 bcm43xx 3000000 flow -
+  else
+    /usr/bin/hciattach /dev/serial1 bcm43xx 921600 noflow -
+  fi
+else
+  /usr/bin/hciattach /dev/serial1 bcm43xx 460800 noflow -
+fi

--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/system.d/brcmfmac_sdio-firmware.service
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/system.d/brcmfmac_sdio-firmware.service
@@ -1,13 +1,12 @@
 [Unit]
 Description=Broadcom sdio firmware update for BCM43430A1
-ConditionPathExists=/dev/ttyAMA0
-ConditionPathExists=/proc/device-tree/soc/gpio@7e200000/bt_pins
+ConditionPathExists=/dev/serial1
 After=network.target
 
 [Service]
 Type=simple
 RemainAfterExit=yes
-ExecStart=/usr/bin/hciattach /dev/ttyAMA0 bcm43xx 921600 noflow -
+ExecStart=/usr/bin/rpi-btuart
 
 [Install]
 WantedBy=network.target

--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/udev.d/90-rpi-add-serial.rules
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/udev.d/90-rpi-add-serial.rules
@@ -1,0 +1,21 @@
+KERNEL=="ttyAMA[01]", PROGRAM="/bin/sh -c '\
+        ALIASES=/proc/device-tree/aliases; \
+        if [ $(cat $ALIASES/uart0) = $(cat $ALIASES/serial0) ]; then \
+            echo 0;\
+        elif [ $(cat $ALIASES/uart0) = $(cat $ALIASES/serial1) ]; then \
+            echo 1; \
+        else \
+            exit 1; \
+        fi\
+    '", SYMLINK+="serial%c"
+
+KERNEL=="ttyS0", PROGRAM="/bin/sh -c '\
+        ALIASES=/proc/device-tree/aliases; \
+        if [ $(cat $ALIASES/uart1) = $(cat $ALIASES/serial0) ]; then \
+            echo 0; \
+        elif [ $(cat $ALIASES/uart1) = $(cat $ALIASES/serial1) ]; then \
+            echo 1; \
+        else \
+            exit 1; \
+        fi \
+    '", SYMLINK+="serial%c"


### PR DESCRIPTION
As mentioned by @popcornmix:
> @pelwell suggested using the /usr/bin/btuart from latest raspbian. It looks like this: http://paste.debian.net/917481/
> Basically Pi0W now has flow  control on BT uart, so can run a bit faster. But there are two uarts and they can be swapped in config.txt if you need the "better" one for other purposes, so this also handles that case.
>
> The raspbian btuart should work for Pi0w and Pi3, and also when uarts have been swapped in config.txt.

The udev.d rule adds the correct /dev/serial1 device, which is then used by `rpi-btuart` to bring up Bluetooth.

Thanks @popcornmix & @pelwell.