### PR TITLE
[LE8] Fix IR decoder modules not loading automatically

### DIFF
--- a/packages/linux-drivers/media_build/patches/media_build-02-add-to-backports.patch
+++ b/packages/linux-drivers/media_build/patches/media_build-02-add-to-backports.patch
@@ -1,6 +1,6 @@
 --- a/backports/backports.txt
 +++ b/backports/backports.txt
-@@ -25,6 +25,14 @@
+@@ -25,6 +25,15 @@
  add pr_fmt.patch
  add debug.patch
  add drx39xxj.patch
@@ -11,6 +11,7 @@
 +add linux-054-nuvoton_revert_d7b290a1056c5564eec8a1b169c6e84ff3.6.114c13.patch
 +add linux-057-Removed-MCE-customer-code-restriction-in-rc6-decode.patch
 +add linux-062-imon_pad_ignore_diagonal.patch
++add linux-063-fix-rc-raw-decoder-loading.patch
 +add linux-240-pctv452e_kernel_oops_in_4.9.patch
 
  [4.8.255]

--- a/packages/linux-drivers/media_build/sources/backports/linux-063-fix-rc-raw-decoder-loading.patch
+++ b/packages/linux-drivers/media_build/sources/backports/linux-063-fix-rc-raw-decoder-loading.patch
@@ -1,0 +1,46 @@
+From d13ee07f431c94ea72320ea4136e75ebeaee98c1 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Fri, 3 Mar 2017 10:27:44 +0100
+Subject: [PATCH] backport: rc: raw decoder for keymap protocol is not loaded
+ on register
+
+see http://www.spinics.net/lists/linux-media/msg111651.html
+---
+ drivers/media/rc/rc-main.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
+index dedaf38..9a397da 100644
+--- a/drivers/media/rc/rc-main.c
++++ b/drivers/media/rc/rc-main.c
+@@ -1441,6 +1441,7 @@ int rc_register_device(struct rc_dev *dev)
+ 	int attr = 0;
+ 	int minor;
+ 	int rc;
++	u64 rc_type;
+ 
+ 	if (!dev || !dev->map_name)
+ 		return -EINVAL;
+@@ -1526,14 +1527,18 @@ int rc_register_device(struct rc_dev *dev)
+ 			goto out_input;
+ 	}
+ 
++	rc_type = BIT_ULL(rc_map->rc_type);
++
+ 	if (dev->change_protocol) {
+-		u64 rc_type = (1ll << rc_map->rc_type);
+ 		rc = dev->change_protocol(dev, &rc_type);
+ 		if (rc < 0)
+ 			goto out_raw;
+ 		dev->enabled_protocols = rc_type;
+ 	}
+ 
++	if (dev->driver_type == RC_DRIVER_IR_RAW)
++		ir_raw_load_modules(&rc_type);
++
+ 	/* Allow the RC sysfs nodes to be accessible */
+ 	atomic_set(&dev->initialized, 1);
+ 
+-- 
+2.1.4
+

--- a/packages/linux/patches/default/linux-063-fix-rc-raw-decoder-loading.patch
+++ b/packages/linux/patches/default/linux-063-fix-rc-raw-decoder-loading.patch
@@ -1,0 +1,46 @@
+From d13ee07f431c94ea72320ea4136e75ebeaee98c1 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Fri, 3 Mar 2017 10:27:44 +0100
+Subject: [PATCH] backport: rc: raw decoder for keymap protocol is not loaded
+ on register
+
+see http://www.spinics.net/lists/linux-media/msg111651.html
+---
+ drivers/media/rc/rc-main.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
+index dedaf38..9a397da 100644
+--- a/drivers/media/rc/rc-main.c
++++ b/drivers/media/rc/rc-main.c
+@@ -1441,6 +1441,7 @@ int rc_register_device(struct rc_dev *dev)
+ 	int attr = 0;
+ 	int minor;
+ 	int rc;
++	u64 rc_type;
+ 
+ 	if (!dev || !dev->map_name)
+ 		return -EINVAL;
+@@ -1526,14 +1527,18 @@ int rc_register_device(struct rc_dev *dev)
+ 			goto out_input;
+ 	}
+ 
++	rc_type = BIT_ULL(rc_map->rc_type);
++
+ 	if (dev->change_protocol) {
+-		u64 rc_type = (1ll << rc_map->rc_type);
+ 		rc = dev->change_protocol(dev, &rc_type);
+ 		if (rc < 0)
+ 			goto out_raw;
+ 		dev->enabled_protocols = rc_type;
+ 	}
+ 
++	if (dev->driver_type == RC_DRIVER_IR_RAW)
++		ir_raw_load_modules(&rc_type);
++
+ 	/* Allow the RC sysfs nodes to be accessible */
+ 	atomic_set(&dev->initialized, 1);
+ 
+-- 
+2.1.4
+


### PR DESCRIPTION
The fix was just added to the media/fixes tree and should land in stable kernels in the near future.