### PR TITLE
RPi: build brcmfmac_sdio-firmware-rpi for Pi0W [backport]

### DIFF
--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -112,7 +112,7 @@
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="misc-firmware wlan-firmware dvb-firmware"
+    FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware-rpi"
 
   # build and install ATV IR remote support (yes / no)
     ATVCLIENT_SUPPORT="no"


### PR DESCRIPTION
Backport of #1418.