### PR TITLE
imx6/linux: add timeout on idle for gpio-ir-recv

### DIFF
--- a/projects/imx6/patches/linux/3.14-sr/linux-020-gpio-ir-recv-add-timeout-on-idle.patch
+++ b/projects/imx6/patches/linux/3.14-sr/linux-020-gpio-ir-recv-add-timeout-on-idle.patch
@@ -1,0 +1,120 @@
+From 3fb136f3392dfb2530fd490718b0652f1001b36b Mon Sep 17 00:00:00 2001
+From: Eric Nelson <eric@nelint.com>
+Date: Wed, 23 Sep 2015 11:07:08 -0300
+Subject: [PATCH] [media] rc: gpio-ir-recv: add timeout on idle
+
+Many decoders require a trailing space (period without IR illumination)
+to be delivered before completing a decode.
+
+Since the gpio-ir-recv driver only delivers events on gpio transitions,
+a single IR symbol (caused by a quick touch on an IR remote) will not
+be properly decoded without the use of a timer to flush the tail end
+state of the IR receiver.
+
+This patch initializes and uses a timer and the timeout field of rcdev
+to complete the stream and allow decode.
+
+The timeout can be overridden through the use of the LIRC_SET_REC_TIMEOUT
+ioctl.
+
+Signed-off-by: Eric Nelson <eric@nelint.com>
+Acked-by: Sean Young <sean@mess.org>
+Signed-off-by: Mauro Carvalho Chehab <mchehab@osg.samsung.com>
+---
+ drivers/media/rc/gpio-ir-recv.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/drivers/media/rc/gpio-ir-recv.c b/drivers/media/rc/gpio-ir-recv.c
+index 6050de1..5b63b1f 100644
+--- a/drivers/media/rc/gpio-ir-recv.c
++++ b/drivers/media/rc/gpio-ir-recv.c
+@@ -30,6 +30,7 @@ struct gpio_rc_dev {
+ 	struct rc_dev *rcdev;
+ 	int gpio_nr;
+ 	bool active_low;
++	struct timer_list flush_timer;
+ };
+ 
+ #ifdef CONFIG_OF
+@@ -93,12 +94,26 @@ static irqreturn_t gpio_ir_recv_irq(int irq, void *dev_id)
+ 	if (rc < 0)
+ 		goto err_get_value;
+ 
++	mod_timer(&gpio_dev->flush_timer,
++		  jiffies + nsecs_to_jiffies(gpio_dev->rcdev->timeout));
++
+ 	ir_raw_event_handle(gpio_dev->rcdev);
+ 
+ err_get_value:
+ 	return IRQ_HANDLED;
+ }
+ 
++static void flush_timer(unsigned long arg)
++{
++	struct gpio_rc_dev *gpio_dev = (struct gpio_rc_dev *)arg;
++	DEFINE_IR_RAW_EVENT(ev);
++
++	ev.timeout = true;
++	ev.duration = gpio_dev->rcdev->timeout;
++	ir_raw_event_store(gpio_dev->rcdev, &ev);
++	ir_raw_event_handle(gpio_dev->rcdev);
++}
++
+ static int gpio_ir_recv_probe(struct platform_device *pdev)
+ {
+ 	struct gpio_rc_dev *gpio_dev;
+@@ -144,6 +159,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
+ 	rcdev->input_id.version = 0x0100;
+ 	rcdev->dev.parent = &pdev->dev;
+ 	rcdev->driver_name = GPIO_IR_DRIVER_NAME;
++	rcdev->min_timeout = 0;
++	rcdev->timeout = IR_DEFAULT_TIMEOUT;
++	rcdev->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
+ 	if (pdata->allowed_protos)
+ 		rcdev->allowed_protocols = pdata->allowed_protos;
+ 	else
+@@ -154,6 +172,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
+ 	gpio_dev->gpio_nr = pdata->gpio_nr;
+ 	gpio_dev->active_low = pdata->active_low;
+ 
++	setup_timer(&gpio_dev->flush_timer, flush_timer,
++		    (unsigned long)gpio_dev);
++
+ 	rc = gpio_request(pdata->gpio_nr, "gpio-ir-recv");
+ 	if (rc < 0)
+ 		goto err_gpio_request;
+@@ -196,6 +217,7 @@ static int gpio_ir_recv_remove(struct platform_device *pdev)
+ 	struct gpio_rc_dev *gpio_dev = platform_get_drvdata(pdev);
+ 
+ 	free_irq(gpio_to_irq(gpio_dev->gpio_nr), gpio_dev);
++	del_timer_sync(&gpio_dev->flush_timer);
+ 	rc_unregister_device(gpio_dev->rcdev);
+ 	gpio_free(gpio_dev->gpio_nr);
+ 	kfree(gpio_dev);
+
+
+From f3331b8d48456a8113abbaf1985a0ca50e4d17a3 Mon Sep 17 00:00:00 2001
+From: Eric Nelson <eric@nelint.com>
+Date: Sat, 3 Oct 2015 08:18:50 -0700
+Subject: [PATCH] [media] rc-core: define a default timeout for drivers
+
+A default timeout value of 125 ms should work for all decoders.
+
+Declare a constant to help standardize its' use.
+
+Signed-off-by: Eric Nelson <eric@nelint.com>
+Signed-off-by: Mauro Carvalho Chehab <mchehab@osg.samsung.com>
+---
+ include/media/rc-core.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/include/media/rc-core.h
++++ b/include/media/rc-core.h
+@@ -239,6 +239,7 @@ static inline void init_ir_raw_event(str
+ 	memset(ev, 0, sizeof(*ev));
+ }
+ 
++#define IR_DEFAULT_TIMEOUT	MS_TO_NS(125)
+ #define IR_MAX_DURATION         0xFFFFFFFF      /* a bit more than 4 seconds */
+ #define US_TO_NS(usec)		((usec) * 1000)
+ #define MS_TO_US(msec)		((msec) * 1000)

--- a/projects/imx6/patches/linux/4.4-xbian/linux-020-gpio-ir-recv-add-timeout-on-idle.patch
+++ b/projects/imx6/patches/linux/4.4-xbian/linux-020-gpio-ir-recv-add-timeout-on-idle.patch
@@ -1,0 +1,120 @@
+From 3fb136f3392dfb2530fd490718b0652f1001b36b Mon Sep 17 00:00:00 2001
+From: Eric Nelson <eric@nelint.com>
+Date: Wed, 23 Sep 2015 11:07:08 -0300
+Subject: [PATCH] [media] rc: gpio-ir-recv: add timeout on idle
+
+Many decoders require a trailing space (period without IR illumination)
+to be delivered before completing a decode.
+
+Since the gpio-ir-recv driver only delivers events on gpio transitions,
+a single IR symbol (caused by a quick touch on an IR remote) will not
+be properly decoded without the use of a timer to flush the tail end
+state of the IR receiver.
+
+This patch initializes and uses a timer and the timeout field of rcdev
+to complete the stream and allow decode.
+
+The timeout can be overridden through the use of the LIRC_SET_REC_TIMEOUT
+ioctl.
+
+Signed-off-by: Eric Nelson <eric@nelint.com>
+Acked-by: Sean Young <sean@mess.org>
+Signed-off-by: Mauro Carvalho Chehab <mchehab@osg.samsung.com>
+---
+ drivers/media/rc/gpio-ir-recv.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/drivers/media/rc/gpio-ir-recv.c b/drivers/media/rc/gpio-ir-recv.c
+index 6050de1..5b63b1f 100644
+--- a/drivers/media/rc/gpio-ir-recv.c
++++ b/drivers/media/rc/gpio-ir-recv.c
+@@ -30,6 +30,7 @@ struct gpio_rc_dev {
+ 	struct rc_dev *rcdev;
+ 	int gpio_nr;
+ 	bool active_low;
++	struct timer_list flush_timer;
+ };
+ 
+ #ifdef CONFIG_OF
+@@ -93,12 +94,26 @@ static irqreturn_t gpio_ir_recv_irq(int irq, void *dev_id)
+ 	if (rc < 0)
+ 		goto err_get_value;
+ 
++	mod_timer(&gpio_dev->flush_timer,
++		  jiffies + nsecs_to_jiffies(gpio_dev->rcdev->timeout));
++
+ 	ir_raw_event_handle(gpio_dev->rcdev);
+ 
+ err_get_value:
+ 	return IRQ_HANDLED;
+ }
+ 
++static void flush_timer(unsigned long arg)
++{
++	struct gpio_rc_dev *gpio_dev = (struct gpio_rc_dev *)arg;
++	DEFINE_IR_RAW_EVENT(ev);
++
++	ev.timeout = true;
++	ev.duration = gpio_dev->rcdev->timeout;
++	ir_raw_event_store(gpio_dev->rcdev, &ev);
++	ir_raw_event_handle(gpio_dev->rcdev);
++}
++
+ static int gpio_ir_recv_probe(struct platform_device *pdev)
+ {
+ 	struct gpio_rc_dev *gpio_dev;
+@@ -144,6 +159,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
+ 	rcdev->input_id.version = 0x0100;
+ 	rcdev->dev.parent = &pdev->dev;
+ 	rcdev->driver_name = GPIO_IR_DRIVER_NAME;
++	rcdev->min_timeout = 0;
++	rcdev->timeout = IR_DEFAULT_TIMEOUT;
++	rcdev->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
+ 	if (pdata->allowed_protos)
+ 		rcdev->allowed_protocols = pdata->allowed_protos;
+ 	else
+@@ -154,6 +172,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
+ 	gpio_dev->gpio_nr = pdata->gpio_nr;
+ 	gpio_dev->active_low = pdata->active_low;
+ 
++	setup_timer(&gpio_dev->flush_timer, flush_timer,
++		    (unsigned long)gpio_dev);
++
+ 	rc = gpio_request(pdata->gpio_nr, "gpio-ir-recv");
+ 	if (rc < 0)
+ 		goto err_gpio_request;
+@@ -196,6 +217,7 @@ static int gpio_ir_recv_remove(struct platform_device *pdev)
+ 	struct gpio_rc_dev *gpio_dev = platform_get_drvdata(pdev);
+ 
+ 	free_irq(gpio_to_irq(gpio_dev->gpio_nr), gpio_dev);
++	del_timer_sync(&gpio_dev->flush_timer);
+ 	rc_unregister_device(gpio_dev->rcdev);
+ 	gpio_free(gpio_dev->gpio_nr);
+ 	kfree(gpio_dev);
+
+
+From f3331b8d48456a8113abbaf1985a0ca50e4d17a3 Mon Sep 17 00:00:00 2001
+From: Eric Nelson <eric@nelint.com>
+Date: Sat, 3 Oct 2015 08:18:50 -0700
+Subject: [PATCH] [media] rc-core: define a default timeout for drivers
+
+A default timeout value of 125 ms should work for all decoders.
+
+Declare a constant to help standardize its' use.
+
+Signed-off-by: Eric Nelson <eric@nelint.com>
+Signed-off-by: Mauro Carvalho Chehab <mchehab@osg.samsung.com>
+---
+ include/media/rc-core.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/include/media/rc-core.h
++++ b/include/media/rc-core.h
+@@ -239,6 +239,7 @@ static inline void init_ir_raw_event(str
+ 	memset(ev, 0, sizeof(*ev));
+ }
+ 
++#define IR_DEFAULT_TIMEOUT	MS_TO_NS(125)
+ #define IR_MAX_DURATION         500000000	/* 500 ms */
+ #define US_TO_NS(usec)		((usec) * 1000)
+ #define MS_TO_US(msec)		((msec) * 1000)


### PR DESCRIPTION
fixes Logitech Harmony One and probably others
https://forum.libreelec.tv/thread-4813.html