### PR TITLE
fixed libcap build error

### DIFF
--- a/packages/devel/libcap/package.mk
+++ b/packages/devel/libcap/package.mk
@@ -32,7 +32,7 @@ PKG_LONGDESC="As of Linux 2.2.0, the power of the superuser has been partitioned
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
-post_unpack() {
+post_patch() {
   mkdir -p $PKG_BUILD/.$HOST_NAME
   cp -r $PKG_BUILD/* $PKG_BUILD/.$HOST_NAME
   mkdir -p $PKG_BUILD/.$TARGET_NAME 

--- a/packages/devel/libcap/patches/libcap-001-gperf-3.1-fix.patch
+++ b/packages/devel/libcap/patches/libcap-001-gperf-3.1-fix.patch
@@ -1,0 +1,31 @@
+From 13992f56d80c0ee20e08f99b8e8ff37d63e65f9d Mon Sep 17 00:00:00 2001
+From: Mike Gilbert <floppym@gentoo.org>
+Date: Mon, 16 Jan 2017 12:09:35 -0500
+Subject: [PATCH] Fix build with gperf-3.1
+
+gperf-3.1 lookup functions take a size_t instead of unsigned int.
+
+To resolve this:
+
+1. Pass --includes to gperf so that size_t is defined.
+2. Remove __cap_lookup_name declaration.
+---
+ libcap/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcap/Makefile b/libcap/Makefile
+index d189777..634a042 100644
+--- a/libcap/Makefile
++++ b/libcap/Makefile
+@@ -41,7 +41,7 @@ cap_names.h: _makenames
+ 	./_makenames > cap_names.h
+ 
+ $(GPERF_OUTPUT): cap_names.list.h
+-	perl -e 'print "struct __cap_token_s { const char *name; int index; };\n%{\nconst struct __cap_token_s *__cap_lookup_name(const char *, unsigned int);\n%}\n%%\n"; while ($$l = <>) { $$l =~ s/[\{\"]//g; $$l =~ s/\}.*// ; print $$l; }' < $< | gperf --ignore-case --language=ANSI-C --readonly --null-strings --global-table --hash-function-name=__cap_hash_name --lookup-function-name="__cap_lookup_name" -c -t -m20 $(INDENT) > $@
++	perl -e 'print "struct __cap_token_s { const char *name; int index; };\n%%\n"; while ($$l = <>) { $$l =~ s/[\{\"]//g; $$l =~ s/\}.*// ; print $$l; }' < $< | gperf --ignore-case --language=ANSI-C --includes --readonly --null-strings --global-table --hash-function-name=__cap_hash_name --lookup-function-name="__cap_lookup_name" -c -t -m20 $(INDENT) > $@
+ 
+ cap_names.list.h: Makefile $(KERNEL_HEADERS)/linux/capability.h
+ 	@echo "=> making $@ from $(KERNEL_HEADERS)/linux/capability.h"
+-- 
+2.11.0
+

--- a/packages/sysutils/systemd/patches/systemd-0007-gperf-lookup-function-signature.patch
+++ b/packages/sysutils/systemd/patches/systemd-0007-gperf-lookup-function-signature.patch
@@ -1,0 +1,267 @@
+diff --git a/configure.ac b/configure.ac
+index 1928e65..5c639e3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -258,6 +258,28 @@ AC_CHECK_SIZEOF(rlim_t,,[
+        #include <sys/resource.h>
+ ])
+ 
++GPERF_TEST="$(echo foo,bar | ${GPERF} -L ANSI-C)"
++
++AC_COMPILE_IFELSE(
++        [AC_LANG_PROGRAM([
++                #include <string.h>
++                const char * in_word_set(const char *, size_t);
++                $GPERF_TEST]
++        )],
++        [GPERF_LEN_TYPE=size_t],
++        [AC_COMPILE_IFELSE(
++                [AC_LANG_PROGRAM([
++                        #include <string.h>
++                        const char * in_word_set(const char *, unsigned);
++                        $GPERF_TEST]
++                )],
++                [GPERF_LEN_TYPE=unsigned],
++                [AC_MSG_ERROR([** unable to determine gperf len type])]
++        )]
++)
++
++AC_DEFINE_UNQUOTED([GPERF_LEN_TYPE], [$GPERF_LEN_TYPE], [gperf len type])
++
+ # ------------------------------------------------------------------------------
+ # we use python to build the man page index
+ have_python=no
+diff --git a/src/basic/af-list.c b/src/basic/af-list.c
+index 3fac9c5..4b291d1 100644
+--- a/src/basic/af-list.c
++++ b/src/basic/af-list.c
+@@ -23,7 +23,7 @@
+ #include "af-list.h"
+ #include "macro.h"
+ 
+-static const struct af_name* lookup_af(register const char *str, register unsigned int len);
++static const struct af_name* lookup_af(register const char *str, register GPERF_LEN_TYPE len);
+ 
+ #include "af-from-name.h"
+ #include "af-to-name.h"
+diff --git a/src/basic/arphrd-list.c b/src/basic/arphrd-list.c
+index 6792d1e..2d598dc 100644
+--- a/src/basic/arphrd-list.c
++++ b/src/basic/arphrd-list.c
+@@ -23,7 +23,7 @@
+ #include "arphrd-list.h"
+ #include "macro.h"
+ 
+-static const struct arphrd_name* lookup_arphrd(register const char *str, register unsigned int len);
++static const struct arphrd_name* lookup_arphrd(register const char *str, register GPERF_LEN_TYPE len);
+ 
+ #include "arphrd-from-name.h"
+ #include "arphrd-to-name.h"
+diff --git a/src/basic/cap-list.c b/src/basic/cap-list.c
+index 3e773a0..d68cc78 100644
+--- a/src/basic/cap-list.c
++++ b/src/basic/cap-list.c
+@@ -26,7 +26,7 @@
+ #include "parse-util.h"
+ #include "util.h"
+ 
+-static const struct capability_name* lookup_capability(register const char *str, register unsigned int len);
++static const struct capability_name* lookup_capability(register const char *str, register GPERF_LEN_TYPE len);
+ 
+ #include "cap-from-name.h"
+ #include "cap-to-name.h"
+diff --git a/src/basic/errno-list.c b/src/basic/errno-list.c
+index 31b66ba..c6a01ee 100644
+--- a/src/basic/errno-list.c
++++ b/src/basic/errno-list.c
+@@ -23,7 +23,7 @@
+ #include "macro.h"
+ 
+ static const struct errno_name* lookup_errno(register const char *str,
+-                                             register unsigned int len);
++                                             register GPERF_LEN_TYPE len);
+ 
+ #include "errno-from-name.h"
+ #include "errno-to-name.h"
+diff --git a/src/core/load-fragment.h b/src/core/load-fragment.h
+index 1cff815..e782197 100644
+--- a/src/core/load-fragment.h
++++ b/src/core/load-fragment.h
+@@ -119,7 +119,7 @@ int config_parse_user_group_strv(const char *unit, const char *filename, unsigne
+ int config_parse_restrict_namespaces(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+ 
+ /* gperf prototypes */
+-const struct ConfigPerfItem* load_fragment_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* load_fragment_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ extern const char load_fragment_gperf_nulstr[];
+ 
+ typedef enum Disabled {
+diff --git a/src/journal/journald-server.h b/src/journal/journald-server.h
+index de1c48f..716e758 100644
+--- a/src/journal/journald-server.h
++++ b/src/journal/journald-server.h
+@@ -179,7 +179,7 @@ void server_dispatch_message(Server *s, struct iovec *iovec, unsigned n, unsigne
+ void server_driver_message(Server *s, sd_id128_t message_id, const char *format, ...) _printf_(3,0) _sentinel_;
+ 
+ /* gperf lookup function */
+-const struct ConfigPerfItem* journald_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* journald_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ int config_parse_storage(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+ 
+diff --git a/src/login/logind.h b/src/login/logind.h
+index 086fa1e..7556ee2 100644
+--- a/src/login/logind.h
++++ b/src/login/logind.h
+@@ -182,7 +182,7 @@ int manager_unit_is_active(Manager *manager, const char *unit);
+ int manager_job_is_active(Manager *manager, const char *path);
+ 
+ /* gperf lookup function */
+-const struct ConfigPerfItem* logind_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* logind_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ int manager_set_lid_switch_ignore(Manager *m, usec_t until);
+ 
+diff --git a/src/network/networkd-conf.h b/src/network/networkd-conf.h
+index c7bfb42..00ddb76 100644
+--- a/src/network/networkd-conf.h
++++ b/src/network/networkd-conf.h
+@@ -23,7 +23,7 @@
+ 
+ int manager_parse_config_file(Manager *m);
+ 
+-const struct ConfigPerfItem* networkd_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* networkd_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ int config_parse_duid_type(
+                 const char *unit,
+diff --git a/src/network/networkd-netdev.h b/src/network/networkd-netdev.h
+index 70ff947..37c7431 100644
+--- a/src/network/networkd-netdev.h
++++ b/src/network/networkd-netdev.h
+@@ -175,7 +175,7 @@ NetDevKind netdev_kind_from_string(const char *d) _pure_;
+ int config_parse_netdev_kind(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+ 
+ /* gperf */
+-const struct ConfigPerfItem* network_netdev_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* network_netdev_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ /* Macros which append INTERFACE= to the message */
+ 
+diff --git a/src/network/networkd-network.h b/src/network/networkd-network.h
+index 11ff34b..e39127b 100644
+--- a/src/network/networkd-network.h
++++ b/src/network/networkd-network.h
+@@ -236,7 +236,7 @@ int config_parse_dhcp_route_table(const char *unit, const char *filename, unsign
+ /* Legacy IPv4LL support */
+ int config_parse_ipv4ll(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+ 
+-const struct ConfigPerfItem* network_network_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* network_network_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ extern const sd_bus_vtable network_vtable[];
+ 
+diff --git a/src/nspawn/nspawn-settings.h b/src/nspawn/nspawn-settings.h
+index 231e6d7..4ae34f8 100644
+--- a/src/nspawn/nspawn-settings.h
++++ b/src/nspawn/nspawn-settings.h
+@@ -103,7 +103,7 @@ bool settings_private_network(Settings *s);
+ 
+ DEFINE_TRIVIAL_CLEANUP_FUNC(Settings*, settings_free);
+ 
+-const struct ConfigPerfItem* nspawn_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* nspawn_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ int config_parse_capability(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+ int config_parse_id128(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+diff --git a/src/resolve/dns-type.c b/src/resolve/dns-type.c
+index aaf5ed6..d89ae28 100644
+--- a/src/resolve/dns-type.c
++++ b/src/resolve/dns-type.c
+@@ -29,7 +29,7 @@ typedef const struct {
+ } dns_type;
+ 
+ static const struct dns_type_name *
+-lookup_dns_type (register const char *str, register unsigned int len);
++lookup_dns_type (register const char *str, register GPERF_LEN_TYPE len);
+ 
+ #include "dns_type-from-name.h"
+ #include "dns_type-to-name.h"
+diff --git a/src/resolve/resolved-conf.h b/src/resolve/resolved-conf.h
+index fc425a3..8184d6c 100644
+--- a/src/resolve/resolved-conf.h
++++ b/src/resolve/resolved-conf.h
+@@ -41,7 +41,7 @@ int manager_parse_search_domains_and_warn(Manager *m, const char *string);
+ int manager_add_dns_server_by_string(Manager *m, DnsServerType type, const char *word);
+ int manager_parse_dns_server_string_and_warn(Manager *m, DnsServerType type, const char *string);
+ 
+-const struct ConfigPerfItem* resolved_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* resolved_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ int config_parse_dns_servers(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+ int config_parse_search_domains(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+diff --git a/src/test/test-af-list.c b/src/test/test-af-list.c
+index aeaa092..e247913 100644
+--- a/src/test/test-af-list.c
++++ b/src/test/test-af-list.c
+@@ -24,7 +24,7 @@
+ #include "string-util.h"
+ #include "util.h"
+ 
+-static const struct af_name* lookup_af(register const char *str, register unsigned int len);
++static const struct af_name* lookup_af(register const char *str, register GPERF_LEN_TYPE len);
+ 
+ #include "af-from-name.h"
+ #include "af-list.h"
+diff --git a/src/test/test-arphrd-list.c b/src/test/test-arphrd-list.c
+index f3989ad..8f4f342 100644
+--- a/src/test/test-arphrd-list.c
++++ b/src/test/test-arphrd-list.c
+@@ -24,7 +24,7 @@
+ #include "string-util.h"
+ #include "util.h"
+ 
+-static const struct arphrd_name* lookup_arphrd(register const char *str, register unsigned int len);
++static const struct arphrd_name* lookup_arphrd(register const char *str, register GPERF_LEN_TYPE len);
+ 
+ #include "arphrd-from-name.h"
+ #include "arphrd-list.h"
+diff --git a/src/timesync/timesyncd-conf.h b/src/timesync/timesyncd-conf.h
+index cba0724..0280697 100644
+--- a/src/timesync/timesyncd-conf.h
++++ b/src/timesync/timesyncd-conf.h
+@@ -22,7 +22,7 @@
+ #include "conf-parser.h"
+ #include "timesyncd-manager.h"
+ 
+-const struct ConfigPerfItem* timesyncd_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* timesyncd_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ int manager_parse_server_string(Manager *m, ServerType type, const char *string);
+ 
+diff --git a/src/udev/net/link-config.h b/src/udev/net/link-config.h
+index 91cc035..b0d8ceb 100644
+--- a/src/udev/net/link-config.h
++++ b/src/udev/net/link-config.h
+@@ -93,7 +93,7 @@ const char *mac_policy_to_string(MACPolicy p) _const_;
+ MACPolicy mac_policy_from_string(const char *p) _pure_;
+ 
+ /* gperf lookup function */
+-const struct ConfigPerfItem* link_config_gperf_lookup(const char *key, unsigned length);
++const struct ConfigPerfItem* link_config_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
+ 
+ int config_parse_mac_policy(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+ int config_parse_name_policy(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
+diff --git a/src/udev/udev-builtin-keyboard.c b/src/udev/udev-builtin-keyboard.c
+index aa10bea..0902411 100644
+--- a/src/udev/udev-builtin-keyboard.c
++++ b/src/udev/udev-builtin-keyboard.c
+@@ -29,7 +29,7 @@
+ #include "string-util.h"
+ #include "udev.h"
+ 
+-static const struct key *keyboard_lookup_key(const char *str, unsigned len);
++static const struct key *keyboard_lookup_key(const char *str, GPERF_LEN_TYPE len);
+ #include "keyboard-keys-from-name.h"
+ 
+ static int install_force_release(struct udev_device *dev, const unsigned *release, unsigned release_count) {


### PR DESCRIPTION
I noticed, that it's impossible to build from current master branch due to libcap build error. I found [this thread](https://forum.libreelec.tv/thread-5168.html) with solution, but author of this solution didn't make pull request. I made pull request instead of him. Can you apply these patches to your upstream?