### PR TITLE
scripts/mkimage: align partitions to 4MiB

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -195,4 +195,4 @@
 # Default size of system partition, in MB, eg. 512
   SYSTEM_SIZE=512
 # Default system partition offset, in sectors, eg. 2048
-  SYSTEM_PART_START=2048
+  SYSTEM_PART_START=8192

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -188,8 +188,8 @@ do_install_quick() {
         fi
 
         partsize_system_start=$PARTSIZE_SYSTEM_OFFSET
-        partsize_system_end=$(((PARTSIZE_SYSTEM * 1024 * 1024 / 512) + partsize_system_start))
-        partsize_storage_start=$((partsize_system_end + 2048))
+        partsize_system_end=$(((PARTSIZE_SYSTEM * 1024 * 1024 / 512) + partsize_system_start - 1))
+        partsize_storage_start=$((partsize_system_end + 1))
         partsize_storage_end=-1024
 
         msg_progress_install "10" "Creating partition on $INSTALL_DEVICE"
@@ -200,7 +200,7 @@ do_install_quick() {
         fi
 
         msg_progress_install "13" "Creating partition on $INSTALL_DEVICE"
-        parted -s $INSTALL_DEVICE unit s mkpart primary ext2 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
+        parted -s $INSTALL_DEVICE unit s mkpart primary ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
 
         msg_progress_install "16" "Setup bootflag on partition 1 of $INSTALL_DEVICE"
         parted -s $INSTALL_DEVICE set 1 boot on >> $LOGFILE 2>&1

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -34,7 +34,9 @@
 
   STORAGE_SIZE=32 # STORAGE_SIZE must be >= 32 !
 
-  DISK_SIZE=$(( $SYSTEM_SIZE + $STORAGE_SIZE + 4 ))
+  DISK_START_PADDING=$(( ($SYSTEM_PART_START + 2048 - 1) / 2048 ))
+  DISK_GPT_PADDING=1
+  DISK_SIZE=$(( $DISK_START_PADDING + $SYSTEM_SIZE + $STORAGE_SIZE + $DISK_GPT_PADDING ))
   DISK="$TARGET_IMG/$IMAGE_NAME.img"
 
 # functions
@@ -79,7 +81,7 @@ trap cleanup SIGINT
 
 # create part1
   echo "image: creating part1..."
-  SYSTEM_PART_END=$(( ($SYSTEM_SIZE * 1024 * 1024 / 512) + $SYSTEM_PART_START ))
+  SYSTEM_PART_END=$(( $SYSTEM_PART_START + ($SYSTEM_SIZE * 1024 * 1024 / 512) - 1 ))
   parted -s "$DISK" -a min unit s mkpart primary fat32 $SYSTEM_PART_START $SYSTEM_PART_END
   if [ "$BOOTLOADER" = "syslinux" ]; then
     parted -s "$DISK" set 1 legacy_boot on
@@ -89,8 +91,8 @@ trap cleanup SIGINT
   sync
 # create part2
   echo "image: creating part2..."
-  STORAGE_PART_START=$(( $SYSTEM_PART_END + 2048 ))
-  STORAGE_PART_END=$(( $STORAGE_PART_START + (( $STORAGE_SIZE * 1024 * 1024 / 512 )) ))
+  STORAGE_PART_START=$(( $SYSTEM_PART_END + 1 ))
+  STORAGE_PART_END=$(( $STORAGE_PART_START + ($STORAGE_SIZE * 1024 * 1024 / 512) - 1 ))
   parted -s "$DISK" -a min unit s mkpart primary ext4 $STORAGE_PART_START $STORAGE_PART_END
   sync
 


### PR DESCRIPTION
This PR changes partition alignments from 1MiB to 4MiB that is the recommended alignment for sd-cards.

The following changes have been made:
- Start of system partition is moved to 4MiB instead of 1MiB
- Size of system/storage partition is reduced by 1 sector to make them perfectly aligned
- The ~1MiB between system and storage partition is removed
- Calculation of the disk image size now depend on the start position of the system partition

Before:

```
Disk LibreELEC-RPi2.arm-8.0.0.img: 1122304s
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags:

Number  Start     End       Size      Type     File system  Flags
 1      2048s     1050624s  1048577s  primary  fat16        boot, lba
 2      1052672s  1118208s  65537s    primary  ext4
```

```
Disk LibreELEC-Generic.x86_64-8.0.0.img: 1122304s
Sector size (logical/physical): 512B/512B
Partition Table: gpt
Disk Flags:

Number  Start     End       Size      File system  Name     Flags
 1      2048s     1050624s  1048577s  fat16        primary  legacy_boot, msftdata
 2      1052672s  1118208s  65537s    ext4         primary
```

After:

```
Disk LibreELEC-RPi2.arm-8.0.0-align.img: 1124352s
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags:

Number  Start     End       Size      Type     File system  Flags
 1      8192s     1056767s  1048576s  primary  fat16        boot, lba
 2      1056768s  1122303s  65536s    primary  ext4
```

```
Disk LibreELEC-Generic.x86_64-8.0.0-align.img: 1124352s
Sector size (logical/physical): 512B/512B
Partition Table: gpt
Disk Flags:

Number  Start     End       Size      File system  Name     Flags
 1      8192s     1056767s  1048576s  fat16        primary  legacy_boot, msftdata
 2      1056768s  1122303s  65536s    ext4         primary
```

This have been tested with LE8 on Generic/RPi2 with different upgrade and run/live combos.