### PR TITLE
imx6/kodi: set default scan order to 'top field first' for MBAFF AVC …

### DIFF
--- a/projects/imx6/patches/kodi/kodi-050-from-openbricks.patch
+++ b/projects/imx6/patches/kodi/kodi-050-from-openbricks.patch
@@ -1428,6 +1428,38 @@ index 5167bd2..bd15091 100644
 
 
 ==============================================================
+file 0046-IMXCODEC-Default-to-top-field-first-for-AVC-files-us.patch
+==============================================================
+
+From ea3d1ccc147395f5655580c187235b533811c043 Mon Sep 17 00:00:00 2001
+From: Rudi <r.ihle@s-t.de>
+Date: Fri, 10 Mar 2017 23:40:01 +0100
+Subject: [PATCH] IMXCODEC: Default to 'top field first' for AVC files using
+ MBAFF
+
+---
+ xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+index 9436d4e..933d4d5 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+@@ -1162,7 +1162,8 @@ bool CIMXCodec::GetPicture(DVDVideoPicture* pDvdVideoPicture)
+       m_warnOnce = false;
+       CLog::Log(LOGWARNING, "Interlaced content reported by VPU, but full frames detected - Please turn off deinterlacing manually.");
+     }
+-    else if (pBuffer->GetFieldType() == VPU_FIELD_TB || pBuffer->GetFieldType() == VPU_FIELD_TOP)
++
++    if (pBuffer->GetFieldType() != VPU_FIELD_BT && pBuffer->GetFieldType() != VPU_FIELD_BOTTOM)
+       pDvdVideoPicture->iFlags |= DVP_FLAG_TOP_FIELD_FIRST;
+ 
+     pDvdVideoPicture->iFlags |= DVP_FLAG_INTERLACED;
+-- 
+2.7.4
+
+
+==============================================================
 file 400-Boost-Center-Audio-Channel-on-Downmixing.patch
 ==============================================================
 


### PR DESCRIPTION
…files

fixes deinterlace when scan order is not explicitly  set
https://forum.libreelec.tv/thread-5849.html