### PR TITLE
buildystem: Cleanup fixes

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -298,22 +298,22 @@ post_makeinstall_target() {
   mkdir -p $INSTALL/usr/share/kodi/system/settings
 
   $PKG_DIR/scripts/xml_merge.py $PKG_DIR/config/guisettings.xml \
-                                $PROJECT_DIR/$PROJECT/kodi/guisettings.xml
+                                $PROJECT_DIR/$PROJECT/kodi/guisettings.xml \
                                 $PROJECT_DIR/$PROJECT/devices/$DEVICE/kodi/guisettings.xml \
                                 > $INSTALL/usr/share/kodi/config/guisettings.xml
 
   $PKG_DIR/scripts/xml_merge.py $PKG_DIR/config/sources.xml \
-                                $PROJECT_DIR/$PROJECT/kodi/sources.xml
+                                $PROJECT_DIR/$PROJECT/kodi/sources.xml \
                                 $PROJECT_DIR/$PROJECT/devices/$DEVICE/kodi/sources.xml \
                                 > $INSTALL/usr/share/kodi/config/sources.xml
 
   $PKG_DIR/scripts/xml_merge.py $PKG_DIR/config/advancedsettings.xml \
-                                $PROJECT_DIR/$PROJECT/kodi/advancedsettings.xml
+                                $PROJECT_DIR/$PROJECT/kodi/advancedsettings.xml \
                                 $PROJECT_DIR/$PROJECT/devices/$DEVICE/kodi/advancedsettings.xml \
                                 > $INSTALL/usr/share/kodi/system/advancedsettings.xml
 
   $PKG_DIR/scripts/xml_merge.py $PKG_DIR/config/appliance.xml \
-                                $PROJECT_DIR/$PROJECT/kodi/appliance.xml
+                                $PROJECT_DIR/$PROJECT/kodi/appliance.xml \
                                 $PROJECT_DIR/$PROJECT/devices/$DEVICE/kodi/appliance.xml \
                                 > $INSTALL/usr/share/kodi/system/settings/appliance.xml
 

--- a/packages/mediacenter/kodi/scripts/xml_merge.py
+++ b/packages/mediacenter/kodi/scripts/xml_merge.py
@@ -2,15 +2,25 @@
 
 # taken from http://stackoverflow.com/a/14879370 with minor modifications
 
+from __future__ import print_function
 import os
 import sys
 import xml.dom.minidom
 from xml.etree import ElementTree as et
 
+def printerr(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
 class XMLCombiner(object):
     def __init__(self, filenames):
-        assert len(filenames) > 0, 'No filenames!'
-        self.roots = [et.parse(f).getroot() for f in filenames]
+        if len(filenames) == 0:
+          raise Exception('No filenames!')
+
+        try:
+          self.roots = [et.parse(f).getroot() for f in filenames]
+        except xml.etree.ElementTree.ParseError:
+          printerr("ERROR: Unable to parse XML file %s" % f)
+          raise
 
     def prettyPrint(self, etree_xml):
         minidom = xml.dom.minidom.parseString(et.tostring(etree_xml))
@@ -38,14 +48,8 @@ class XMLCombiner(object):
                     one.append(el)
 
 if __name__ == '__main__':
-    try:
-        r = XMLCombiner([sys.argv[1], sys.argv[2], sys.argv[3]]).combine()
-    except IOError:
-        try:
-            r = XMLCombiner([sys.argv[1], sys.argv[2]]).combine()
-        except IOError:
-            try:
-                r = XMLCombiner([sys.argv[1], sys.argv[3]]).combine()
-            except IOError:
-                r = XMLCombiner([sys.argv[1]]).combine()
+    xmlfiles = [file for file in sys.argv[1:] if os.path.exists(file)]
+
+    r = XMLCombiner(xmlfiles).combine()
+
     print(r)


### PR DESCRIPTION
Cleanup some remaining build issues.

I've amended `xml_merge.py` to...
- Use any number of inputs
- Any input file that doesn't exist won't be read, so no need to silently handle `IOError`s
- Any input file that cannot be parsed will print the name of the file to `stderr` before re-raising the exception
- Raise exception when there are no input files instead of assert (which can be disabled at compile time)