### PR TITLE
tvheadend_42: tv_grab_file support compressed xmltv

### DIFF
--- a/packages/addons/service/tvheadend42/source/bin/tv_grab_file
+++ b/packages/addons/service/tvheadend42/source/bin/tv_grab_file
@@ -30,7 +30,7 @@ then
   XMLTV_LOCATION_SCRIPT=`grep XMLTV_LOCATION_SCRIPT $ADDON_SETTINGS | awk '{print $3 }' | sed -e "s,value=,," -e "s,\",,g"`
 
   if [ "$XMLTV_TYPE" = "FILE" ]; then
-    cat "$XMLTV_LOCATION_FILE"
+    zcat -f "$XMLTV_LOCATION_FILE"
     exit 0
   elif [ "$XMLTV_TYPE" = "SCRIPT" ]; then
     if [ -e "$XMLTV_LOCATION_SCRIPT" ] ; then

--- a/packages/addons/service/tvheadend42/source/bin/tv_grab_file
+++ b/packages/addons/service/tvheadend42/source/bin/tv_grab_file
@@ -30,7 +30,14 @@ then
   XMLTV_LOCATION_SCRIPT=`grep XMLTV_LOCATION_SCRIPT $ADDON_SETTINGS | awk '{print $3 }' | sed -e "s,value=,," -e "s,\",,g"`
 
   if [ "$XMLTV_TYPE" = "FILE" ]; then
-    zcat -f "$XMLTV_LOCATION_FILE"
+    case "$XMLTV_LOCATION_FILE" in
+    *.gz | *.bz2 | *.xz)
+        zcat "$XMLTV_LOCATION_FILE"
+        ;;
+    *)
+        cat "$XMLTV_LOCATION_FILE"
+        ;;
+    esac
     exit 0
   elif [ "$XMLTV_TYPE" = "SCRIPT" ]; then
     if [ -e "$XMLTV_LOCATION_SCRIPT" ] ; then


### PR DESCRIPTION
LibreELEC supports Kodinerds repo, so i think the rytec epg downloader plugin is supported too. This is imho the best xmltv service, but it downloads xml lists in .gz format and tv_grab_file isn't able to list them. This pr lets tv_grab_file to act the same way to compressed (only formats recognized by gzip, indeed) and uncompressed lists, so original behavior is preserved