### PR TITLE
kodi: use sane artistseparators default

### DIFF
--- a/packages/mediacenter/kodi/config/advancedsettings.xml
+++ b/packages/mediacenter/kodi/config/advancedsettings.xml
@@ -4,4 +4,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>


### PR DESCRIPTION
Current kodi default leads to wrong import if artist name
include colons. See http://trac.kodi.tv/ticket/17401