### PR TITLE
backport of #1457 kodi: use sane artistseparators default

### DIFF
--- a/packages/mediacenter/kodi/config/advancedsettings.xml
+++ b/packages/mediacenter/kodi/config/advancedsettings.xml
@@ -17,4 +17,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>

--- a/projects/RPi/kodi/advancedsettings.xml
+++ b/projects/RPi/kodi/advancedsettings.xml
@@ -9,4 +9,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>

--- a/projects/RPi2/kodi/advancedsettings.xml
+++ b/projects/RPi2/kodi/advancedsettings.xml
@@ -9,4 +9,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>

--- a/projects/WeTek_Core/kodi/advancedsettings.xml
+++ b/projects/WeTek_Core/kodi/advancedsettings.xml
@@ -6,4 +6,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>

--- a/projects/WeTek_Hub/kodi/advancedsettings.xml
+++ b/projects/WeTek_Hub/kodi/advancedsettings.xml
@@ -6,4 +6,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>

--- a/projects/WeTek_Play/kodi/advancedsettings.xml
+++ b/projects/WeTek_Play/kodi/advancedsettings.xml
@@ -6,4 +6,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>

--- a/projects/WeTek_Play_2/kodi/advancedsettings.xml
+++ b/projects/WeTek_Play_2/kodi/advancedsettings.xml
@@ -6,4 +6,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>

--- a/projects/imx6/kodi/advancedsettings.xml
+++ b/projects/imx6/kodi/advancedsettings.xml
@@ -5,4 +5,10 @@
   <samba>
     <clienttimeout>30</clienttimeout>
   </samba>
+  <musiclibrary>
+    <artistseparators>
+      <separator> feat. </separator>
+      <separator> ft. </separator>
+    </artistseparators>
+  </musiclibrary>
 </advancedsettings>


### PR DESCRIPTION
Current kodi default leads to wrong import if artist name
include colons. See http://trac.kodi.tv/ticket/17401