### PR TITLE
mesa: bump to 13.0.6

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="mesa"
-PKG_VERSION="13.0.3"
+PKG_VERSION="13.0.6"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"


### PR DESCRIPTION
Only critial issue/bug fixes here

https://www.mesa3d.org/relnotes/13.0.4.html
https://www.mesa3d.org/relnotes/13.0.5.html
https://www.mesa3d.org/relnotes/13.0.6.html

All changes described:
New features
"None" !

some fixes related with kodi
Bug 99158 - vdpau segfaults and gpu locks with kodi on R9285

label please: LE8
for LE9 we using mesa 17.0.x