### PR TITLE
scripts: revert changes that led to accumulation of old packages

### DIFF
--- a/scripts/clean
+++ b/scripts/clean
@@ -29,6 +29,7 @@ clean_package() {
     return
   fi
 
+  # Use a wilcard here to remove all versions of the package
   for i in $BUILD/$1-*; do
     if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
       . "$i/.libreelec-unpack"

--- a/scripts/clean
+++ b/scripts/clean
@@ -29,21 +29,19 @@ clean_package() {
     return
   fi
 
-  STAMP=$PKG_BUILD/.libreelec-unpack
-
-  if [ -d "$PKG_BUILD" ]; then
-    if [ -f "$STAMP" ] ; then
-      . "$STAMP"
+  for i in $BUILD/$1-*; do
+    if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
+      . "$i/.libreelec-unpack"
       if [ "$STAMP_PKG_NAME" = "$1" ]; then
-        printf "%${BUILD_INDENT}c ${boldred}*${endcolor} ${red}Removing $PKG_BUILD ...${endcolor}\n" ' '>&$SILENT_OUT
-        rm -rf "$PKG_BUILD"
+        printf "%${BUILD_INDENT}c ${boldred}*${endcolor} ${red}Removing $i ...${endcolor}\n" ' '>&$SILENT_OUT
+        rm -rf $i
       fi
     else
       # force clean if no stamp found (previous unpack failed)
-      printf "%${BUILD_INDENT}c * Removing $PKG_BUILD ...\n" ' '>&$SILENT_OUT
-      rm -rf "$PKG_BUILD"
+      printf "%${BUILD_INDENT}c * Removing $i ...\n" ' '>&$SILENT_OUT
+      rm -rf $i
     fi
-  fi
+  done
   rm -f $STAMPS/$1/build_*
 }
 

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -40,11 +40,12 @@ STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME
 [ -n "$DEVICE" ] && STAMP_DEPENDS="$STAMP_DEPENDS $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
 
 # Perform a wildcard match on the package to ensure old versions are cleaned too
+PKG_DEEPMD5=
 for i in $BUILD/$1-*; do
   if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
     . "$i/.libreelec-unpack"
     if [ "$STAMP_PKG_NAME" = "$1" ]; then
-      PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
+      [ -z "${PKG_DEEPMD5}" ] && PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
       if [ ! "$PKG_DEEPMD5" = "$STAMP_PKG_DEEPMD5" ] ; then
         $SCRIPTS/clean $1
       fi

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -39,9 +39,9 @@ mkdir -p $BUILD
 STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
 [ -n "$DEVICE" ] && STAMP_DEPENDS="$STAMP_DEPENDS $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
 
-if [ -d "$PKG_BUILD" ]; then
-  if [ -f "$STAMP" ] ; then
-    . "$STAMP"
+for i in $BUILD/$1-*; do
+  if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
+    . "$i/.libreelec-unpack"
     if [ "$STAMP_PKG_NAME" = "$1" ]; then
       PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
       if [ ! "$PKG_DEEPMD5" = "$STAMP_PKG_DEEPMD5" ] ; then
@@ -49,7 +49,7 @@ if [ -d "$PKG_BUILD" ]; then
       fi
     fi
   fi
-fi
+done
 
 if [ -d "$PKG_BUILD" -a ! -f "$STAMP" ]; then
   # stale pkg build dir

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -39,6 +39,7 @@ mkdir -p $BUILD
 STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
 [ -n "$DEVICE" ] && STAMP_DEPENDS="$STAMP_DEPENDS $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
 
+# Perform a wildcard match on the package to ensure old versions are cleaned too
 for i in $BUILD/$1-*; do
   if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
     . "$i/.libreelec-unpack"


### PR DESCRIPTION
When a package version is bumped this change allowed the old package to remain in the build directory.

Although undesirable (and unintended), normally this wouldn't be a huge problem unless performing a wildcard copy as in the case of [bcm2835-bootloader/release](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/tools/bcm2835-bootloader/release#L24).

Reverting this change restores the original behaviour which is correct (now that I fully understand why it's doing what it is/was doing!)

Thanks and apologies to @HiassofT and [indri](https://forum.libreelec.tv/thread-6541-post-41055.html) :)

(No need for a backport, these changes are LE9 only)