### PR TITLE
config/path: addons need kodi

### DIFF
--- a/config/path
+++ b/config/path
@@ -79,6 +79,7 @@ SED="sed -i"
   PKG_LONGDESC=""
   PKG_IS_ADDON="no"
   PKG_PATCH_DIRS=""
+  PKG_NEED_UNPACK=""
 
   if [ -n "$1" ]; then
     _PKG_ROOT_NAME=${1%:*}
@@ -141,6 +142,7 @@ SED="sed -i"
 
   if [ "$PKG_IS_ADDON" = "yes" ] ; then
     [ -z $PKG_SECTION ] && PKG_ADDON_ID="$PKG_NAME" || PKG_ADDON_ID="`echo $PKG_SECTION | sed 's,/,.,g'`.$PKG_NAME"
+    PKG_NEED_UNPACK="${PKG_NEED_UNPACK} $(get_pkg_directory $MEDIACENTER)"
   fi
 
   # Automatically set PKG_SOURCE_NAME unless it is already defined.


### PR DESCRIPTION
Automatically add $MEDIACENTER (ie. `kodi`) to PKG_NEED_UNPACK for addons so that whenever `kodi` is bumped the add-ons will be automatically cleaned prior to building.

Could be backported if required.