### PR TITLE
userconfig: overwrite our sample files

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -196,6 +196,7 @@ post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin/systemd-machine-id-setup
   mkdir -p $INSTALL/usr/bin
   cp $PKG_DIR/scripts/systemd-machine-id-setup $INSTALL/usr/bin
+  cp $PKG_DIR/scripts/userconfig-setup $INSTALL/usr/bin
 
   # provide 'halt', 'shutdown', 'reboot' & co.
   mkdir -p $INSTALL/usr/sbin

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -1,0 +1,26 @@
+#!/bin/sh
+################################################################################
+#      This file is part of LibreELEC - http://www.libreelec.tv
+#      Copyright (C) 2017 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+# Remove those sample files that we manage
+for sample in $(find /storage/.config -name '*.sample' 2>/dev/null); do
+  [ -f /usr/config/${sample:16} ] && rm -f ${sample}
+done
+
+# Copy config files, but don't overwrite - this should replace our sample files
+false | cp -iRp /usr/config/* /storage/.config/ &>/dev/null

--- a/packages/sysutils/systemd/system.d/userconfig.service
+++ b/packages/sysutils/systemd/system.d/userconfig.service
@@ -5,7 +5,7 @@ After=systemd-tmpfiles-setup.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "false | cp -iR /usr/config/* /storage/.config/ &>/dev/null"
+ExecStart=/usr/bin/userconfig-setup
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
If we change our sample config files (for example, see samba4 bump) then we don't overwrite any existing conf.sample file. This results in upgrading users having out of date (and possibly erroneous or problem causing) sample config files.

This change will remove those sample config files we maintain, before updating `/storage/.config` with new files.