### PR TITLE
Addons are duplicating shared objects by not preserving links during zip.

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -130,7 +130,7 @@ pack_addon() {
     fi
     cd $ADDON_BUILD
     echo "*** compressing Addon $PKG_ADDON_ID ... ***"
-    zip -rq $PKG_ADDON_ID-$ADDONVER.zip $PKG_ADDON_ID;
+    zip -rqy $PKG_ADDON_ID-$ADDONVER.zip $PKG_ADDON_ID;
     cd - &>/dev/null
 
     mkdir -p $ADDON_INSTALL_DIR


### PR DESCRIPTION
This could save some space but might also break some addons. Needs testing.