### PR TITLE
LE8 backport of #1489 lirc: also support lirc devices from the rc subsystem

### DIFF
--- a/packages/sysutils/lirc/udev.d/98-lircd.rules
+++ b/packages/sysutils/lirc/udev.d/98-lircd.rules
@@ -11,6 +11,7 @@ KERNEL=="lirc[0-9]*",   SUBSYSTEM=="lirc", SUBSYSTEMS=="i2c", GOTO="begin"
 KERNEL=="lirc[0-9]*",   SUBSYSTEM=="lirc", SUBSYSTEMS=="usb", GOTO="begin"
 KERNEL=="lirc[0-9]*",   SUBSYSTEM=="lirc", SUBSYSTEMS=="platform", GOTO="begin"
 KERNEL=="lirc[0-9]*",   SUBSYSTEM=="lirc", SUBSYSTEMS=="pnp", GOTO="begin"
+KERNEL=="lirc[0-9]*",   SUBSYSTEM=="lirc", SUBSYSTEMS=="rc", GOTO="begin"
 GOTO="end"
 LABEL="begin"
 


### PR DESCRIPTION
see https://forum.libreelec.tv/thread-6724.html