### PR TITLE
linux: cp project and device device tree, silence errors

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -141,8 +141,20 @@ post_patch() {
   fi
 
   # install extra dts files
-  cp -v projects/$PROJECT/devices/$DEVICE/config/*-overlay.dts $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/overlays/ || :
-  cp -v projects/$PROJECT/devices/$DEVICE/config/dt-blob.dts $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/ || :
+  for f in $PROJECT_DIR/$PROJECT/config/*-overlay.dts; do
+    [ -f "$f" ] && cp -v $f $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/overlays
+  done
+  if [ -f $PROJECT_DIR/$PROJECT/config/dt-blob.dts ]; then
+    cp -v $PROJECT_DIR/$PROJECT/config/dt-blob.dts $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts
+  fi
+  if [ -n "$DEVICE" ]; then
+    for f in $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/*-overlay.dts; do
+      [ -f "$f" ] && cp -v $f $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/overlays
+    done
+    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/dt-blob.dts ]; then
+      cp -v $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/dt-blob.dts $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts
+    fi
+  fi
 }
 
 makeinstall_host() {


### PR DESCRIPTION
This gets rid of the following errors when building the kernel:
```
cp: cannot stat 'projects/Generic/devices//config/*-overlay.dts': No such file or directory
cp: cannot stat 'projects/Generic/devices//config/dt-blob.dts': No such file or directory
```

Currently the only projects or devices with dts files are Slice and Slice3:
```
projects/RPi/devices/Slice/config/dt-blob.dts
projects/RPi/devices/Slice/config/ws2812-overlay.dts
projects/RPi/devices/Slice/config/slice-overlay.dts
projects/RPi/devices/Slice3/config/dt-blob.dts
projects/RPi/devices/Slice3/config/ws2812-overlay.dts
projects/RPi/devices/Slice3/config/slice-overlay.dts
```

With this PR we:
1. Silence the errors when no dts files are present
2. Add support for "common" project-level dts files
3. Avoid accessing the devices directory when $DEVICE is not defined

Perhaps this is overkill for a largely cosmetic issue, but #2 above might prove useful.