### PR TITLE
imx6/linux: export symbol used by gpio-ir-recv (forward port of #1494)

### DIFF
--- a/projects/imx6/patches/linux/3.14-sr/linux-020-gpio-ir-recv-add-timeout-on-idle.patch
+++ b/projects/imx6/patches/linux/3.14-sr/linux-020-gpio-ir-recv-add-timeout-on-idle.patch
@@ -71,7 +71,7 @@ index 6050de1..5b63b1f 100644
 +	rcdev->timeout = IR_DEFAULT_TIMEOUT;
 +	rcdev->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
  	if (pdata->allowed_protos)
- 		rcdev->allowed_protocols = pdata->allowed_protos;
+ 		rcdev->allowed_protos = pdata->allowed_protos;
  	else
 @@ -154,6 +172,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
  	gpio_dev->gpio_nr = pdata->gpio_nr;
@@ -110,7 +110,7 @@ Signed-off-by: Mauro Carvalho Chehab <mchehab@osg.samsung.com>
 
 --- a/include/media/rc-core.h
 +++ b/include/media/rc-core.h
-@@ -239,6 +239,7 @@ static inline void init_ir_raw_event(str
+@@ -194,6 +194,7 @@ static inline void init_ir_raw_event(str
  	memset(ev, 0, sizeof(*ev));
  }
  
@@ -118,3 +118,29 @@ Signed-off-by: Mauro Carvalho Chehab <mchehab@osg.samsung.com>
  #define IR_MAX_DURATION         0xFFFFFFFF      /* a bit more than 4 seconds */
  #define US_TO_NS(usec)		((usec) * 1000)
  #define MS_TO_US(msec)		((msec) * 1000)
+
+
+From e9da7a4b685413c72c12320cb5b03cb5d5cb536a Mon Sep 17 00:00:00 2001
+From: Peter Vicman <peter.vicman@gmail.com>
+Date: Mon, 27 Mar 2017 18:55:18 +0200
+Subject: [PATCH] export symbol nsecs_to_jiffies used by gpio-ir-recv
+
+---
+ kernel/time.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/time.c b/kernel/time.c
+index f60ffd0..d54d6db 100644
+--- a/kernel/time.c
++++ b/kernel/time.c
+@@ -704,6 +704,7 @@ unsigned long nsecs_to_jiffies(u64 n)
+ {
+ 	return (unsigned long)nsecs_to_jiffies64(n);
+ }
++EXPORT_SYMBOL(nsecs_to_jiffies);
+ 
+ /*
+  * Add two timespec values and do a safety check for overflow.
+-- 
+2.7.4
+


### PR DESCRIPTION
just to make project happy