### PR TITLE
Update WeTek proprietary DVB modules to wetekdvb-20170404

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wetekdvb"
-PKG_VERSION="20170116"
+PKG_VERSION="20170404"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.wetek.com/"


### PR DESCRIPTION
Update DVB drivers for WeTek Play and WeTek Play 2 to wetekdvb-20170404.