### PR TITLE
glibc: add UTF-8 support

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -181,6 +181,9 @@
 # cron support (yes / no)
   CRON_SUPPORT="yes"
 
+# Locales to install. format: "locale.charmap" (eg. de_DE.UTF-8)
+  GLIBC_LOCALES="en_US.UTF-8"
+
 # Distribution Specific source location
   DISTRO_MIRROR="http://sources.libreelec.tv/mirror"
   DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -134,6 +134,17 @@ post_makeinstall_target() {
 
 # remove locales and charmaps
   rm -rf $INSTALL/usr/share/i18n/charmaps
+  if [ -n "$GLIBC_LOCALES" ]; then
+    mkdir -p $INSTALL/usr/lib/locale
+    for locale in $GLIBC_LOCALES; do
+      echo ">>> install inputfile $(echo $locale | cut -f1 -d ".") with charmap $(echo $locale | cut -f2 -d ".") as $locale <<<"
+      I18NPATH=../localedata \
+      $ROOT/$TOOLCHAIN/bin/localedef \
+        -i ../localedata/locales/$(echo $locale | cut -f1 -d ".") \
+        -f ../localedata/charmaps/$(echo $locale | cut -f2 -d ".") \
+        $locale --prefix=$INSTALL
+    done
+  fi
 
 # add UTF-8 charmap for Generic (charmap is needed for installer)
   if [ "$PROJECT" = "Generic" ]; then


### PR DESCRIPTION
LibreELEC does currently not support UTF-8, whereas OpenELEC does.
This pull request merely includes corresponding OpenELEC code, for discussion.
It has neither been tested, nor optimized (eg, current Generic ships gzip-ed charmaps).