### PR TITLE
misc-firmware: change repo and update to 0ed3d22

### DIFF
--- a/packages/linux-firmware/misc-firmware/package.mk
+++ b/packages/linux-firmware/misc-firmware/package.mk
@@ -17,11 +17,11 @@
 ################################################################################
 
 PKG_NAME="misc-firmware"
-PKG_VERSION="0.0.17"
+PKG_VERSION="0ed3d22"
 PKG_ARCH="any"
 PKG_LICENSE="Free-to-use"
-PKG_SITE="https://github.com/OpenELEC/misc-firmware"
-PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_SITE="https://github.com/LibreELEC/misc-firmware"
+PKG_URL="https://github.com/LibreELEC/misc-firmware/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="firmware"
 PKG_SHORTDESC="misc-firmware: firmwares for various drivers"


### PR DESCRIPTION
This corrects various missing BT firmware issues for users switching to LE 8.0.x. Other changes are planned for master (and misc-firmware repo) so no forward-port required.