### PR TITLE
re-add patch for AE minimal sample rate

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.99-ae-settings-samplerate.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99-ae-settings-samplerate.patch
@@ -1,0 +1,74 @@
+From aabc63419df8aa69f156afdafb28820c3c9ccdc7 Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Sat, 1 Nov 2014 12:44:54 +0100
+Subject: [PATCH] AdvancedSettings: Add minimalSampleRate to ActiveAE cause of
+ broken AVRs out there
+
+---
+ xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp | 8 ++++++++
+ xbmc/settings/AdvancedSettings.cpp                   | 3 +++
+ xbmc/settings/AdvancedSettings.h                     | 2 ++
+ 3 files changed, 13 insertions(+)
+
+diff --git a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+index bf7e439..1687bad 100644
+--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
++++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+@@ -28,6 +28,7 @@ using namespace ActiveAE;
+ #include "cores/AudioEngine/Encoders/AEEncoderFFmpeg.h"
+ 
+ #include "settings/Settings.h"
++#include "settings/AdvancedSettings.h"
+ #include "windowing/WindowingFactory.h"
+ 
+ #define MAX_CACHE_LEVEL 0.5   // total cache time of stream in seconds
+@@ -1504,6 +1505,13 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
+       format.m_channelLayout = AE_CH_LAYOUT_2_0;
+     }
+ 
++    // OpenELEC workaround to define a minimum sample Rate for broken AVRs
++    if (format.m_sampleRate < g_advancedSettings.m_minimumSampleRate)
++    {
++      format.m_sampleRate = g_advancedSettings.m_minimumSampleRate;
++      CLog::Log(LOGDEBUG, "CActiveAE::MinimumSampleRate - Forced by use to samplerate %d", format.m_sampleRate);
++    }
++
+     if (m_settings.config == AE_CONFIG_FIXED)
+     {
+       format.m_sampleRate = m_settings.samplerate;
+diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
+index c4fa298..35728e4 100644
+--- a/xbmc/settings/AdvancedSettings.cpp
++++ b/xbmc/settings/AdvancedSettings.cpp
+@@ -108,6 +108,8 @@ void CAdvancedSettings::Initialize()
+     return;
+ 
+   m_audioHeadRoom = 0;
++  // OpenELEC workaround for broken AVRs
++  m_minimumSampleRate = 8000;
+   m_ac3Gain = 12.0f;
+   m_audioApplyDrc = -1.0f;
+   m_dvdplayerIgnoreDTSinWAV = false;
+@@ -464,6 +466,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
+   {
+     XMLUtils::GetFloat(pElement, "ac3downmixgain", m_ac3Gain, -96.0f, 96.0f);
+     XMLUtils::GetInt(pElement, "headroom", m_audioHeadRoom, 0, 12);
++    XMLUtils::GetInt(pElement, "minimumsamplerate", m_minimumSampleRate, 8000, 192000);
+     XMLUtils::GetString(pElement, "defaultplayer", m_audioDefaultPlayer);
+     // 101 on purpose - can be used to never automark as watched
+     XMLUtils::GetFloat(pElement, "playcountminimumpercent", m_audioPlayCountMinimumPercent, 0.0f, 101.0f);
+diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
+index b0b4df1..7137614 100644
+--- a/xbmc/settings/AdvancedSettings.h
++++ b/xbmc/settings/AdvancedSettings.h
+@@ -140,6 +140,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
+     static void SettingOptionsLoggingComponentsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
+ 
+     int m_audioHeadRoom;
++    // OpenELEC workaround for minimum sample Rate
++    int m_minimumSampleRate;
+     float m_ac3Gain;
+     std::string m_audioDefaultPlayer;
+     float m_audioPlayCountMinimumPercent;
+-- 
+2.1.4


### PR DESCRIPTION
workaround to define a minimum sample Rate for broken AVRs

Confirmed by user from forum that patch helped them and again got sound on AVR
Tested on LE8