### PR TITLE
net-snmp: correct errant $ROOT usage

### DIFF
--- a/packages/addons/service/net-snmp/package.mk
+++ b/packages/addons/service/net-snmp/package.mk
@@ -61,7 +61,7 @@ make_target() {
 }
 
 makeinstall_target() {
-  make install INSTALL_PREFIX=$ROOT/$PKG_BUILD/.$TARGET_NAME
+  make install INSTALL_PREFIX=$PKG_BUILD/.$TARGET_NAME
 }
 
 addon() {


### PR DESCRIPTION
This corrects things being staged in the wrong location during build. Thanks @MilhouseVH 