### PR TITLE
scripts/get: add support for downloads to prefer mirror

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -71,11 +71,21 @@ unset LD_LIBRARY_PATH
 
 rm -f $STAMP_URL $STAMP_SHA
 
+# Prefer downloads from our mirror to avoid downloading junk if upstream is now a
+# redirect to a holding page (somtimes the case when building out of a legacy branch)
+if [ "${PREFER_PACKAGE_MIRROR}" == "yes" ]; then
+  _URL1="$PACKAGE_MIRROR"
+  _URL2="$PKG_URL"
+else
+  _URL1="$PKG_URL"
+  _URL2="$PACKAGE_MIRROR"
+fi
+
 NBWGET=10
 while [ $NBWGET -gt 0 ]; do
   rm -f $PACKAGE
 
-  if $WGET_CMD "$PKG_URL" || $WGET_CMD "$PACKAGE_MIRROR"; then
+  if $WGET_CMD "${_URL1}" || $WGET_CMD "${_URL2}"; then
     CALC_SHA256="$(sha256sum $PACKAGE | cut -d" " -f1)"
 
     [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" == "${CALC_SHA256}" ] && break


### PR DESCRIPTION
This is a bit of a hack, and won't bear fruit for a while, but bear with me.

So I'm building a branch from early 2016 into a fresh LibreELEC repository and the build fails due to a corrupt `cpu-firmware` tarball - the 2016 [fedorahosted.org](https://git.fedorahosted.org/cgit/microcode_ctl.git/snapshot/5e23731.tar.xz) url is no longer valid and now redirects to an HTML page, which is what we then download as a `tar.xz`.

Even though we have a usable `cpu-firmware` package tarball on our mirror, the `download-tool` won't help me as it will just try to download the same upstream tarball (ie. HTML file), only accessing the mirror whenever the upstream file is not available (and thanks to the fedora redirect, our naiive `get` script believes the tarball is still available).

We could enhance the `get` script to validate/verify the downloads, but I suspect/believe this may be more trouble than it's worth.

As a quick fix, this change instead favours our mirror when mass populating the sources directory when using the `download-tool`. If a file is missing from our mirror only then will we access the upstream source. Downloads that take place during a build will be unaffected and continue to prioritise the upstream source.