### PR TITLE
settings: bump LE settings add-on to 9.0.0

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="042c6c2"
+PKG_VERSION="ca96ddd"
 PKG_ARCH="any"
 PKG_LICENSE="prop."
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
Use updated methods of starting/stopping lircd after #1320 lirc changes