### PR TITLE
createlog: bring sanity to kodi log order

### DIFF
--- a/packages/sysutils/busybox/scripts/createlog
+++ b/packages/sysutils/busybox/scripts/createlog
@@ -24,7 +24,7 @@ DATE=`date -u +%Y-%m-%d-%H.%M.%S`
 BASEDIR="/tmp"
 LOGDIR="log-$DATE"
 RELEASE="`cat /etc/release`"
-GIT="`cat /etc/issue |grep git`"
+GIT="`cat /etc/issue | grep git`"
 
 getlog_cmd() {
   if command -v $1 >/dev/null; then
@@ -74,8 +74,24 @@ rm -rf $BASEDIR/$LOGDIR
 mkdir -p $BASEDIR/$LOGDIR
 
 # kodi.log
+  KODI_LOG_DIR=/storage/.kodi/temp
+
   LOGFILE="01_KODI.log"
-  for i in `find /storage/.kodi/temp/ -type f -name "*.log"`; do
+  for i in kodi.log kodi.old.log; do
+    [ -f ${KODI_LOG_DIR}/${i} ] && getlog_cmd cat ${KODI_LOG_DIR}/$i
+  done
+
+  LOGFILE="01_KODI_CRASH.log"
+  for i in `find ${KODI_LOG_DIR} -type f -name "kodi_crashlog_*.log" | sort -r`; do
+    getlog_cmd cat $i
+  done
+
+  LOGFILE="01_KODI_OTHER.log"
+  for i in `find ${KODI_LOG_DIR} -type f -name "*.log" | sort`; do
+    iname="${i#${KODI_LOG_DIR}/}"
+    [ ${iname} == kodi.log ] && continue
+    [ ${iname} == kodi.old.log ] && continue
+    [ "${iname#kodi_crashlog_}" != "${iname}" ] && continue
     getlog_cmd cat $i
   done
 


### PR DESCRIPTION
This is something that's annoyed me for quite some time.

The log files included in `Logfiles/01_KODI.log` (zip) are in a pretty much random order, and as it contains all of the log files from the `.kodi/temp` directory it makes locating the latest `kodi.log` and/or latest `kodi_crashlog_*.log` a somewhat frustrating experience (to the point where I'd rather not deal with `01_KODI.log` at all).

This change brings order to the log files present in the zip:

`01_KODI.log`: `kodi.log` (first) followed by `kodi.old.log`
`01_KODI_CRASH.log`: `kodi_crashlog_*.log` (descending filename, ie. latest first)
`01_KODI_OTHER.log`: any other log files that may be present in `.kodi/temp` (ascending filename)

@chewitt: I can backport this if needed.