### PR TITLE
dtc: change url and use correct file type

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -17,11 +17,11 @@
 ################################################################################
 
 PKG_NAME="dtc"
-PKG_VERSION="1.4.2"
+PKG_VERSION="1.4.4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="https://git.kernel.org/cgit/utils/dtc/dtc.git"
-PKG_URL="https://git.kernel.org/cgit/utils/dtc/dtc.git/snapshot/$PKG_VERSION.tar.xz"
+PKG_SITE="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/"
+PKG_URL="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/$PKG_VERSION.tar.gz"
 PKG_SOURCE_DIR="$PKG_VERSION"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="tools"


### PR DESCRIPTION
even if tar.xz is requested it is redirected to tar.gz
fixes as described https://forum.libreelec.tv/thread-7906-post-47449.html