### PR TITLE
pvr.mythtv: change url, bump to 8db66ca (5.10.0)

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="08d609b"
+PKG_VERSION="8db66ca"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.kodi.tv"
-PKG_URL="https://github.com/kodi-pvr/pvr.mythtv/archive/$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/janbar/pvr.mythtv"
+PKG_URL="https://github.com/janbar/pvr.mythtv/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION=""
 PKG_SHORTDESC="pvr.mythtv"


### PR DESCRIPTION
See comment: https://github.com/kodi-pvr/pvr.mythtv/issues/105#issuecomment-275841712

This PR gets us on the correct upstream report - the kodi-pvr/pvr.mythtv repo is dead.