### PR TITLE
DVB patches AML

### DIFF
--- a/projects/Odroid_C2/patches/linux/revert_default_dvb_core.patch
+++ b/projects/Odroid_C2/patches/linux/revert_default_dvb_core.patch
@@ -1,0 +1,3024 @@
+diff --git a/drivers/media/dvb-core/demux.h b/drivers/media/dvb-core/demux.h
+index db46a78..833191bc 100644
+--- a/drivers/media/dvb-core/demux.h
++++ b/drivers/media/dvb-core/demux.h
+@@ -83,46 +83,6 @@ enum dmx_success {
+ #define TS_DEMUX        8   /* in case TS_PACKET is set, send the TS to
+ 			       the demux device, not to the dvr device */
+ 
+-/* PES type for filters which write to built-in decoder */
+-/* these should be kept identical to the types in dmx.h */
+-
+-enum dmx_ts_pes_e {
+-	/* also send packets to decoder (if it exists) */
+-	DMX_TS_PES_AUDIO0,
+-	DMX_TS_PES_VIDEO0,
+-	DMX_TS_PES_TELETEXT0,
+-	DMX_TS_PES_SUBTITLE0,
+-	DMX_TS_PES_PCR0,
+-
+-	DMX_TS_PES_AUDIO1,
+-	DMX_TS_PES_VIDEO1,
+-	DMX_TS_PES_TELETEXT1,
+-	DMX_TS_PES_SUBTITLE1,
+-	DMX_TS_PES_PCR1,
+-
+-	DMX_TS_PES_AUDIO2,
+-	DMX_TS_PES_VIDEO2,
+-	DMX_TS_PES_TELETEXT2,
+-	DMX_TS_PES_SUBTITLE2,
+-	DMX_TS_PES_PCR2,
+-
+-	DMX_TS_PES_AUDIO3,
+-	DMX_TS_PES_VIDEO3,
+-	DMX_TS_PES_TELETEXT3,
+-	DMX_TS_PES_SUBTITLE3,
+-	DMX_TS_PES_PCR3,
+-
+-	DMX_TS_PES_OTHER
+-};
+-
+-
+-#define DMX_TS_PES_AUDIO    DMX_TS_PES_AUDIO0
+-#define DMX_TS_PES_VIDEO    DMX_TS_PES_VIDEO0
+-#define DMX_TS_PES_TELETEXT DMX_TS_PES_TELETEXT0
+-#define DMX_TS_PES_SUBTITLE DMX_TS_PES_SUBTITLE0
+-#define DMX_TS_PES_PCR      DMX_TS_PES_PCR0
+-
+-
+ struct dmx_ts_feed {
+ 	int is_filtering; /* Set to non-zero when filtering in progress */
+ 	struct dmx_demux *parent; /* Back-pointer */
+@@ -246,37 +206,35 @@ struct dmx_demux {
+ 	u32 capabilities;            /* Bitfield of capability flags */
+ 	struct dmx_frontend* frontend;    /* Front-end connected to the demux */
+ 	void* priv;                  /* Pointer to private data of the API client */
+-	int (*open)(struct dmx_demux *demux);
+-	int (*close)(struct dmx_demux *demux);
+-	int (*write)(struct dmx_demux *demux,
+-					const char __user *buf, size_t count);
+-	int (*allocate_ts_feed)(struct dmx_demux *demux,
+-				 struct dmx_ts_feed **feed,
++	int (*open) (struct dmx_demux* demux);
++	int (*close) (struct dmx_demux* demux);
++	int (*write) (struct dmx_demux* demux, const char __user *buf, size_t count);
++	int (*allocate_ts_feed) (struct dmx_demux* demux,
++				 struct dmx_ts_feed** feed,
+ 				 dmx_ts_cb callback);
+-	int (*release_ts_feed)(struct dmx_demux *demux,
++	int (*release_ts_feed) (struct dmx_demux* demux,
+ 				struct dmx_ts_feed* feed);
+-	int (*allocate_section_feed)(struct dmx_demux *demux,
+-				      struct dmx_section_feed **feed,
++	int (*allocate_section_feed) (struct dmx_demux* demux,
++				      struct dmx_section_feed** feed,
+ 				      dmx_section_cb callback);
+-	int (*release_section_feed)(struct dmx_demux *demux,
+-				     struct dmx_section_feed *feed);
+-	int (*add_frontend)(struct dmx_demux *demux,
+-			     struct dmx_frontend *frontend);
+-	int (*remove_frontend)(struct dmx_demux *demux,
+-				struct dmx_frontend *frontend);
+-	struct list_head* (*get_frontends)(struct dmx_demux *demux);
+-	int (*connect_frontend)(struct dmx_demux *demux,
+-				 struct dmx_frontend *frontend);
+-	int (*disconnect_frontend)(struct dmx_demux *demux);
++	int (*release_section_feed) (struct dmx_demux* demux,
++				     struct dmx_section_feed* feed);
++	int (*add_frontend) (struct dmx_demux* demux,
++			     struct dmx_frontend* frontend);
++	int (*remove_frontend) (struct dmx_demux* demux,
++				struct dmx_frontend* frontend);
++	struct list_head* (*get_frontends) (struct dmx_demux* demux);
++	int (*connect_frontend) (struct dmx_demux* demux,
++				 struct dmx_frontend* frontend);
++	int (*disconnect_frontend) (struct dmx_demux* demux);
+ 
+-	int (*get_pes_pids)(struct dmx_demux *demux, u16 *pids);
++	int (*get_pes_pids) (struct dmx_demux* demux, u16 *pids);
+ 
+-	int (*get_caps)(struct dmx_demux *demux, struct dmx_caps *caps);
++	int (*get_caps) (struct dmx_demux* demux, struct dmx_caps *caps);
+ 
+-	int (*set_source)(struct dmx_demux *demux,
+-				const enum dmx_source_t *src);
++	int (*set_source) (struct dmx_demux* demux, const dmx_source_t *src);
+ 
+-	int (*get_stc)(struct dmx_demux *demux, unsigned int num,
++	int (*get_stc) (struct dmx_demux* demux, unsigned int num,
+ 			u64 *stc, unsigned int *base);
+ };
+ 
+diff --git a/drivers/media/dvb-core/dmxdev.c b/drivers/media/dvb-core/dmxdev.c
+index 8959f71..c0363f1 100644
+--- a/drivers/media/dvb-core/dmxdev.c
++++ b/drivers/media/dvb-core/dmxdev.c
+@@ -51,7 +51,6 @@ static int dvb_dmxdev_buffer_write(struct dvb_ringbuffer *buf,
+ 	free = dvb_ringbuffer_free(buf);
+ 	if (len > free) {
+ 		dprintk("dmxdev: buffer overflow\n");
+-		pr_err("dmxdev: buffer overflow, bs=%zd\n", buf->size);
+ 		return -EOVERFLOW;
+ 	}
+ 
+@@ -207,8 +206,6 @@ static int dvb_dvr_release(struct inode *inode, struct file *file)
+ 	/* TODO */
+ 	dvbdev->users--;
+ 	if (dvbdev->users == 1 && dmxdev->exit == 1) {
+-		fops_put(file->f_op);
+-		file->f_op = NULL;
+ 		mutex_unlock(&dmxdev->mutex);
+ 		wake_up(&dvbdev->wait_queue);
+ 	} else
+@@ -563,7 +560,7 @@ static int dvb_dmxdev_start_feed(struct dmxdev *dmxdev,
+ {
+ 	struct timespec timeout = { 0 };
+ 	struct dmx_pes_filter_params *para = &filter->params.pes;
+-	enum dmx_output_t otype;
++	dmx_output_t otype;
+ 	int ret;
+ 	int ts_type;
+ 	enum dmx_ts_pes ts_pes;
+@@ -788,7 +785,7 @@ static int dvb_dmxdev_filter_free(struct dmxdev *dmxdev,
+ 	return 0;
+ }
+ 
+-static inline void invert_mode(struct dmx_filter *filter)
++static inline void invert_mode(dmx_filter_t *filter)
+ {
+ 	int i;
+ 
+@@ -1121,8 +1118,6 @@ static int dvb_demux_release(struct inode *inode, struct file *file)
+ 	mutex_lock(&dmxdev->mutex);
+ 	dmxdev->dvbdev->users--;
+ 	if(dmxdev->dvbdev->users==1 && dmxdev->exit==1) {
+-		fops_put(file->f_op);
+-		file->f_op = NULL;
+ 		mutex_unlock(&dmxdev->mutex);
+ 		wake_up(&dmxdev->dvbdev->wait_queue);
+ 	} else
+@@ -1131,17 +1126,6 @@ static int dvb_demux_release(struct inode *inode, struct file *file)
+ 	return ret;
+ }
+ 
+-#ifdef CONFIG_COMPAT
+-static long dvb_demux_compat_ioctl(struct file *filp,
+-			unsigned int cmd, unsigned long args)
+-{
+-	unsigned long ret;
+-	args = (unsigned long)compat_ptr(args);
+-	ret = dvb_demux_ioctl(filp, cmd, args);
+-	return ret;
+-}
+-#endif
+-
+ static const struct file_operations dvb_demux_fops = {
+ 	.owner = THIS_MODULE,
+ 	.read = dvb_demux_read,
+@@ -1150,9 +1134,6 @@ static const struct file_operations dvb_demux_fops = {
+ 	.release = dvb_demux_release,
+ 	.poll = dvb_demux_poll,
+ 	.llseek = default_llseek,
+-#ifdef CONFIG_COMPAT
+-	.compat_ioctl	= dvb_demux_compat_ioctl,
+-#endif
+ };
+ 
+ static struct dvb_device dvbdev_demux = {
+@@ -1214,18 +1195,6 @@ static unsigned int dvb_dvr_poll(struct file *file, poll_table *wait)
+ 	return mask;
+ }
+ 
+-#ifdef CONFIG_COMPAT
+-static long dvb_dvr_compat_ioctl(struct file *filp,
+-			unsigned int cmd, unsigned long args)
+-{
+-	unsigned long ret;
+-
+-	args = (unsigned long)compat_ptr(args);
+-	ret = dvb_dvr_ioctl(filp, cmd, args);
+-	return ret;
+-}
+-#endif
+-
+ static const struct file_operations dvb_dvr_fops = {
+ 	.owner = THIS_MODULE,
+ 	.read = dvb_dvr_read,
+@@ -1235,9 +1204,6 @@ static const struct file_operations dvb_dvr_fops = {
+ 	.release = dvb_dvr_release,
+ 	.poll = dvb_dvr_poll,
+ 	.llseek = default_llseek,
+-#ifdef CONFIG_COMPAT
+-	.compat_ioctl	= dvb_dvr_compat_ioctl,
+-#endif
+ };
+ 
+ static struct dvb_device dvbdev_dvr = {
+diff --git a/drivers/media/dvb-core/dvb_demux.c b/drivers/media/dvb-core/dvb_demux.c
+index 3485655..6c7ff0c 100644
+--- a/drivers/media/dvb-core/dvb_demux.c
++++ b/drivers/media/dvb-core/dvb_demux.c
+@@ -435,7 +435,7 @@ static void dvb_dmx_swfilter_packet(struct dvb_demux *demux, const u8 *buf)
+ 		dprintk_tscheck("TEI detected. "
+ 				"PID=0x%x data1=0x%x\n",
+ 				pid, buf[1]);
+-		/* data in this packet cant be trusted - drop it unless
++		/* data in this packet can't be trusted - drop it unless
+ 		 * module option dvb_demux_feed_err_pkts is set */
+ 		if (!dvb_demux_feed_err_pkts)
+ 			return;
+@@ -476,7 +476,9 @@ static void dvb_dmx_swfilter_packet(struct dvb_demux *demux, const u8 *buf)
+ void dvb_dmx_swfilter_packets(struct dvb_demux *demux, const u8 *buf,
+ 			      size_t count)
+ {
+-	spin_lock(&demux->lock);
++	unsigned long flags;
++
++	spin_lock_irqsave(&demux->lock, flags);
+ 
+ 	while (count--) {
+ 		if (buf[0] == 0x47)
+@@ -484,7 +486,7 @@ void dvb_dmx_swfilter_packets(struct dvb_demux *demux, const u8 *buf,
+ 		buf += 188;
+ 	}
+ 
+-	spin_unlock(&demux->lock);
++	spin_unlock_irqrestore(&demux->lock, flags);
+ }
+ 
+ EXPORT_SYMBOL(dvb_dmx_swfilter_packets);
+@@ -519,8 +521,9 @@ static inline void _dvb_dmx_swfilter(struct dvb_demux *demux, const u8 *buf,
+ {
+ 	int p = 0, i, j;
+ 	const u8 *q;
++	unsigned long flags;
+ 
+-	spin_lock(&demux->lock);
++	spin_lock_irqsave(&demux->lock, flags);
+ 
+ 	if (demux->tsbufp) { /* tsbuf[0] is now 0x47. */
+ 		i = demux->tsbufp;
+@@ -564,7 +567,7 @@ static inline void _dvb_dmx_swfilter(struct dvb_demux *demux, const u8 *buf,
+ 	}
+ 
+ bailout:
+-	spin_unlock(&demux->lock);
++	spin_unlock_irqrestore(&demux->lock, flags);
+ }
+ 
+ void dvb_dmx_swfilter(struct dvb_demux *demux, const u8 *buf, size_t count)
+@@ -581,11 +584,13 @@ EXPORT_SYMBOL(dvb_dmx_swfilter_204);
+ 
+ void dvb_dmx_swfilter_raw(struct dvb_demux *demux, const u8 *buf, size_t count)
+ {
+-	spin_lock(&demux->lock);
++	unsigned long flags;
++
++	spin_lock_irqsave(&demux->lock, flags);
+ 
+ 	demux->feed->cb.ts(buf, count, NULL, 0, &demux->feed->feed.ts, DMX_OK);
+ 
+-	spin_unlock(&demux->lock);
++	spin_unlock_irqrestore(&demux->lock, flags);
+ }
+ EXPORT_SYMBOL(dvb_dmx_swfilter_raw);
+ 
+@@ -1027,8 +1032,13 @@ static int dmx_section_feed_release_filter(struct dmx_section_feed *feed,
+ 		return -EINVAL;
+ 	}
+ 
+-	if (feed->is_filtering)
++	if (feed->is_filtering) {
++		/* release dvbdmx->mutex as far as it is
++		   acquired by stop_filtering() itself */
++		mutex_unlock(&dvbdmx->mutex);
+ 		feed->stop_filtering(feed);
++		mutex_lock(&dvbdmx->mutex);
++	}
+ 
+ 	spin_lock_irq(&dvbdmx->lock);
+ 	f = dvbdmxfeed->filter;
+diff --git a/drivers/media/dvb-core/dvb_frontend.c b/drivers/media/dvb-core/dvb_frontend.c
+index ec3d417..1f925e8 100644
+--- a/drivers/media/dvb-core/dvb_frontend.c
++++ b/drivers/media/dvb-core/dvb_frontend.c
+@@ -52,10 +52,6 @@ static int dvb_force_auto_inversion;
+ static int dvb_override_tune_delay;
+ static int dvb_powerdown_on_sleep = 1;
+ static int dvb_mfe_wait_time = 5;
+-static int dvb_afc_debug;
+-static int disable_set_frotend_param;
+-static int dvb_dtv_debug;
+-
+ 
+ module_param_named(frontend_debug, dvb_frontend_debug, int, 0644);
+ MODULE_PARM_DESC(frontend_debug, "Turn on/off frontend core debugging (default:off).");
+@@ -69,19 +65,6 @@ module_param(dvb_powerdown_on_sleep, int, 0644);
+ MODULE_PARM_DESC(dvb_powerdown_on_sleep, "0: do not power down, 1: turn LNB voltage off on sleep (default)");
+ module_param(dvb_mfe_wait_time, int, 0644);
+ MODULE_PARM_DESC(dvb_mfe_wait_time, "Wait up to <mfe_wait_time> seconds on open() for multi-frontend to become available (default:5 seconds)");
+-module_param(dvb_afc_debug, int, 0644);
+-MODULE_PARM_DESC(dvb_afc_debug, "vb_afc_debug");
+-module_param(disable_set_frotend_param, int, 0644);
+-MODULE_PARM_DESC(disable_set_frotend_param, "disable_set_frotend_param");
+-module_param(dvb_dtv_debug, int, 0644);
+-MODULE_PARM_DESC(dvb_dtv_debug, "vb_afc_debug");
+-
+-#define dprintk(a...)\
+-		do {\
+-			if (dvb_frontend_debug)\
+-				printk(a);\
+-		} while (0)
+-/*#define dtvprintk if (dvb_dtv_debug) printk*/
+ 
+ #define FESTATE_IDLE 1
+ #define FESTATE_RETUNE 2
+@@ -118,21 +101,14 @@ MODULE_PARM_DESC(dvb_dtv_debug, "vb_afc_debug");
+ #define DVB_FE_DEVICE_REMOVED	2
+ 
+ static DEFINE_MUTEX(frontend_mutex);
+-/*extern unsigned int jiffies_to_msecs(const unsigned long j);*/
+-int jiffiestime;
+-/*define LOCK_TIMEOUT 2000*/
+-static int LOCK_TIMEOUT = 2000;
+ 
+ struct dvb_frontend_private {
++
+ 	/* thread/frontend values */
+ 	struct dvb_device *dvbdev;
+-	struct dvb_frontend_parameters parameters_in;
+ 	struct dvb_frontend_parameters parameters_out;
+ 	struct dvb_fe_events events;
+ 	struct semaphore sem;
+-	struct dvbsx_blindscan_events blindscan_events;
+-	struct semaphore blindscan_sem;
+-	bool in_blindscan;
+ 	struct list_head list_head;
+ 	wait_queue_head_t wait_queue;
+ 	struct task_struct *thread;
+@@ -146,12 +122,6 @@ struct dvb_frontend_private {
+ 	int tone;
+ 	int voltage;
+ 
+-	/*set_frontend ops async support*/
+-	wait_queue_head_t setfrontendasync_wait_queue;
+-	unsigned int setfrontendasync_wakeup;
+-	unsigned int setfrontendasync_needwakeup;
+-	unsigned int setfrontendasync_interruptwakeup;
+-
+ 	/* swzigzag values */
+ 	unsigned int state;
+ 	unsigned int bending;
+@@ -166,7 +136,6 @@ struct dvb_frontend_private {
+ 	int quality;
+ 	unsigned int check_wrapped;
+ 	enum dvbfe_search algo_status;
+-	int user_delay;
+ };
+ 
+ static void dvb_frontend_wakeup(struct dvb_frontend *fe);
+@@ -191,7 +160,6 @@ enum dvbv3_emulation_type {
+ 	DVBV3_QAM,
+ 	DVBV3_OFDM,
+ 	DVBV3_ATSC,
+-	DVBV3_ANALOG
+ };
+ 
+ static enum dvbv3_emulation_type dvbv3_type(u32 delivery_system)
+@@ -215,8 +183,6 @@ static enum dvbv3_emulation_type dvbv3_type(u32 delivery_system)
+ 	case SYS_ATSCMH:
+ 	case SYS_DVBC_ANNEX_B:
+ 		return DVBV3_ATSC;
+-	case SYS_ANALOG:
+-		return DVBV3_ANALOG;
+ 	case SYS_UNDEFINED:
+ 	case SYS_ISDBC:
+ 	case SYS_DVBH:
+@@ -241,13 +207,9 @@ static void dvb_frontend_add_event(struct dvb_frontend *fe, fe_status_t status)
+ 
+ 	dev_dbg(fe->dvb->device, "%s:\n", __func__);
+ 
+-	if (fe->dtv_property_cache.delivery_system == SYS_ANALOG) {
+-		if ((status & FE_HAS_LOCK) && has_get_frontend(fe))
+-			dtv_get_frontend(fe, &fepriv->parameters_out);
+-	} else{
+-		if (/*(status & FE_HAS_LOCK) && */has_get_frontend(fe))
+-			dtv_get_frontend(fe, &fepriv->parameters_out);
+-	}
++	if ((status & FE_HAS_LOCK) && has_get_frontend(fe))
++		dtv_get_frontend(fe, &fepriv->parameters_out);
++
+ 	mutex_lock(&events->mtx);
+ 
+ 	wp = (events->eventw + 1) % MAX_EVENT;
+@@ -259,6 +221,7 @@ static void dvb_frontend_add_event(struct dvb_frontend *fe, fe_status_t status)
+ 	e = &events->events[events->eventw];
+ 	e->status = status;
+ 	e->parameters = fepriv->parameters_out;
++
+ 	events->eventw = wp;
+ 
+ 	mutex_unlock(&events->mtx);
+@@ -290,7 +253,7 @@ static int dvb_frontend_get_event(struct dvb_frontend *fe,
+ 		ret = wait_event_interruptible (events->wait_queue,
+ 						events->eventw != events->eventr);
+ 
+-		if (down_interruptible(&fepriv->sem))
++		if (down_interruptible (&fepriv->sem))
+ 			return -ERESTARTSYS;
+ 
+ 		if (ret < 0)
+@@ -305,95 +268,6 @@ static int dvb_frontend_get_event(struct dvb_frontend *fe,
+ 	return 0;
+ }
+ 
+-static void dvbsx_blindscan_add_event(struct dvb_frontend *fe,
+-					struct dvbsx_blindscanevent *pbsevent)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-	struct dvbsx_blindscan_events *events = &fepriv->blindscan_events;
+-	struct dvbsx_blindscanevent *e;
+-	int wp;
+-
+-	dprintk("%s\n", __func__);
+-
+-	if (mutex_lock_interruptible(&events->mtx))
+-		return;
+-
+-	wp = (events->eventw + 1) % MAX_BLINDSCAN_EVENT;
+-
+-	if (wp == events->eventr) {
+-		events->overflow = 1;
+-		events->eventr = (events->eventr + 1) % MAX_BLINDSCAN_EVENT;
+-	}
+-
+-	e = &events->events[events->eventw];
+-
+-	memcpy(e, pbsevent, sizeof(struct dvbsx_blindscanevent));
+-
+-	events->eventw = wp;
+-
+-	mutex_unlock(&events->mtx);
+-
+-	wake_up_interruptible(&events->wait_queue);
+-}
+-
+-static int dvbsx_blindscan_get_event(struct dvb_frontend *fe,
+-				struct dvbsx_blindscanevent *event , int flags)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-	struct dvbsx_blindscan_events *events = &fepriv->blindscan_events;
+-
+-	dprintk("%s\n", __func__);
+-
+-	if (events->overflow) {
+-		events->overflow = 0;
+-		return -EOVERFLOW;
+-	}
+-
+-	if (events->eventw == events->eventr) {
+-		int ret;
+-
+-		if (flags & O_NONBLOCK)
+-			return -EWOULDBLOCK;
+-
+-		up(&fepriv->blindscan_sem);
+-
+-		ret = wait_event_interruptible_timeout(events->wait_queue,
+-				events->eventw != events->eventr,
+-				fe->ops.blindscan_ops.info.bspara.timeout * HZ);
+-
+-		if (down_interruptible(&fepriv->blindscan_sem))
+-			return -ERESTARTSYS;
+-
+-		if (ret < 0)
+-			return ret;
+-	}
+-
+-	if (mutex_lock_interruptible(&events->mtx))
+-		return -ERESTARTSYS;
+-
+-	memcpy(event, &events->events[events->eventr],
+-		sizeof(struct dvbsx_blindscanevent));
+-
+-	events->eventr = (events->eventr + 1) % MAX_BLINDSCAN_EVENT;
+-
+-	mutex_unlock(&events->mtx);
+-
+-	return 0;
+-}
+-
+-static int dvbsx_blindscan_event_callback(struct dvb_frontend *fe,
+-					struct dvbsx_blindscanevent *pbsevent)
+-{
+-	dprintk("%s\n", __func__);
+-
+-	if ((!fe) || (!pbsevent))
+-		return -1;
+-
+-	dvbsx_blindscan_add_event(fe, pbsevent);
+-
+-	return 0;
+-}
+-
+ static void dvb_frontend_clear_events(struct dvb_frontend *fe)
+ {
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+@@ -460,7 +334,6 @@ static int dvb_frontend_swzigzag_autotune(struct dvb_frontend *fe, int check_wra
+ 	int autoinversion;
+ 	int ready = 0;
+ 	int fe_set_err = 0;
+-	int time = 0;
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+ 	struct dtv_frontend_properties *c = &fe->dtv_property_cache, tmp;
+ 	int original_inversion = c->inversion;
+@@ -539,13 +412,8 @@ static int dvb_frontend_swzigzag_autotune(struct dvb_frontend *fe, int check_wra
+ 	if (autoinversion)
+ 		c->inversion = fepriv->inversion;
+ 	tmp = *c;
+-	time = jiffies_to_msecs(jiffies)-jiffiestime;
+-	dprintk("2---auto tune,time is %d\n", time);
+-	if (fe->ops.set_frontend && (time >= LOCK_TIMEOUT)) {
++	if (fe->ops.set_frontend)
+ 		fe_set_err = fe->ops.set_frontend(fe);
+-		jiffiestime = jiffies_to_msecs(jiffies);
+-	}
+-	fepriv->parameters_out = fepriv->parameters_in;
+ 	*c = tmp;
+ 	if (fe_set_err < 0) {
+ 		fepriv->state = FESTATE_ERROR;
+@@ -559,35 +427,12 @@ static int dvb_frontend_swzigzag_autotune(struct dvb_frontend *fe, int check_wra
+ 	return 0;
+ }
+ 
+-/*
+-*#if 0
+-*#if (defined CONFIG_AM_SI2176)
+-*int si2176_get_strength(void);
+-*#endif
+-*#if ((defined CONFIG_AM_SI2177) || (defined CONFIG_AM_SI2157))
+-*int si2177_get_strength(void);
+-*#endif
+-*#endif
+-*/
+-
+ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
+ {
+-	fe_status_t s;
+-	int retval;
+-	int time;
+-	int dtmb_status, i, has_singal;
++	fe_status_t s = 0;
++	int retval = 0;
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+ 	struct dtv_frontend_properties *c = &fe->dtv_property_cache, tmp;
+-#if (((defined CONFIG_AM_SI2176) || (defined CONFIG_AM_SI2177)\
+-	|| (defined CONFIG_AM_SI2157)) && (defined CONFIG_AM_M6_DEMOD))
+-	int strength;
+-#endif
+-#if (defined CONFIG_AM_M6_DEMOD)
+-	int newcount;
+-	int count;
+-	count = 0;
+-#endif
+-	s = retval = time = 0;
+ 
+ 	/* if we've got no parameters, just keep idling */
+ 	if (fepriv->state & FESTATE_IDLE) {
+@@ -619,16 +464,7 @@ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
+ 	} else {
+ 		if (fe->ops.read_status)
+ 			fe->ops.read_status(fe, &s);
+-			time = jiffies_to_msecs(jiffies)-jiffiestime;
+-		dprintk("read status,time is %d,s is %d,status is %d\n",
+-			time, s, fepriv->status);
+-		if (((s != fepriv->status) && (time >= LOCK_TIMEOUT)) ||
+-			((s != fepriv->status) &&
+-			(s == (FE_HAS_LOCK|FE_HAS_SIGNAL|
+-			FE_HAS_CARRIER|FE_HAS_VITERBI|FE_HAS_SYNC)))) {
+-				dev_dbg(fe->dvb->device,
+-					"event s=%d,fepriv->status is %d\n",
+-					s, fepriv->status);
++		if (s != fepriv->status) {
+ 			dvb_frontend_add_event(fe, s);
+ 			fepriv->status = s;
+ 		}
+@@ -646,188 +482,7 @@ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
+ 		}
+ 		return;
+ 	}
+-/*auto_mode qam   201306-rsj*/
+-#if (defined CONFIG_AM_M6_DEMOD)
+-/*dvbc auto qam*/
+-	if (c->modulation == QAM_AUTO) {
+-		while ((dvbc_get_status() <= 3) && (count <= 20)) {
+-			msleep(30);
+-			if (count == 20) {
+-				fe->ops.read_status(fe, &s);
+-				dev_dbg(fe->dvb->device,
+-				"event s=%d,fepriv->status is %d\n",
+-				s, fepriv->status);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-			}
+-			count++;
+-		}
+-		count = 0;
+-		while ((dvbc_get_status() > 3) &&
+-			(dvbc_get_status() != 5) && (count < 5)) {
+-			if (count == 0)
+-				c->modulation = QAM_64;
+-			else if (count == 1)
+-				c->modulation = QAM_256;
+-			else if (count == 2)
+-				c->modulation = QAM_128;
+-			else if (count == 3)
+-				c->modulation = QAM_16;
+-			else
+-				c->modulation = QAM_32;
+-
+-			if (fe->ops.set_qam_mode)
+-				fe->ops.set_qam_mode(fe);
+-			for (newcount = 0; newcount < 6; newcount++) {
+-				if (dvbc_get_status() == 5)
+-					break;
+-				msleep(50);
+-			}
+-	newcount = 0;
+-			count++;
+-			if (dvbc_get_status() == 5) {
+-				if (fe->ops.read_status)
+-					fe->ops.read_status(fe, &s);
+-
+-				if (((s != fepriv->status) &&
+-					(s == (FE_HAS_LOCK|FE_HAS_SIGNAL|
+-					FE_HAS_CARRIER|FE_HAS_VITERBI|
+-					FE_HAS_SYNC)))) {
+-					dev_dbg(fe->dvb->device,
+-						"event s=%d,fepriv->status is %d\n",
+-						s, fepriv->status);
+-					dvb_frontend_add_event(fe, s);
+-					fepriv->status = s;
+-					break;
+-				}
+-			}
+-
+-		}
+-	} else if (c->modulation == QAM_AUTO) {
+-		/*fepriv->parameters_out = fepriv->parameters_in;*/
+-		msleep(100);
+-		#if (defined CONFIG_AM_SI2176)
+-		strength = fe->ops.tuner_ops.get_strength(fe)-256;
+-		if (strength <= (-85)) {
+-			s = 32;
+-			dev_dbg(fe->dvb->device,
+-				"5-strength is %d\n", strength);
+-			if (s != fepriv->status) {
+-				dev_dbg(fe->dvb->device,
+-				"5event s=%d,fepriv->status is %d!\n",
+-				s, fepriv->status);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				jiffiestime = jiffies_to_msecs(jiffies);
+-			}
+-			return;
+-
+-		}
+-		#elif ((defined CONFIG_AM_SI2177) || (defined CONFIG_AM_SI2157))
+-		strength = fe->ops.tuner_ops.get_strength(fe)-256;
+-		if (strength <= (-85)) {
+-			s = 32;
+-			dev_dbg(fe->dvb->device,
+-				"5-strength is %d\n", strength);
+-			if (s != fepriv->nstatus) {
+-				dev_dbg(fe->dvb->device,
+-				"event s=%d,fepriv->status is %d\n",
+-				s, fepriv->status);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				jiffiestime = jiffies_to_msecs(jiffies);
+-			}
+-			return;
+-
+-		}
+-		#endif
+-		while (((atsc_read_iqr_reg()>>16) != 0x1f) && (count < 2)) {
+-			if (count == 0) {
+-				/*if (fe->ops.set_frontend)*/
+-			/*fe->ops.set_frontend(fe, &fepriv->parameters_in);*/
+-			}
+-			/*fepriv->parameters_in.u.vsb.modulation=QAM_256;*/
+-			else if (count == 1) {
+-				c->modulation = QAM_64;
+-				if (fe->ops.set_qam_mode)
+-					fe->ops.set_qam_mode(fe);
+-			}
+-			for (newcount = 0; newcount < 10; newcount++) {
+-				if ((atsc_read_iqr_reg()>>16) == 0x1f)
+-					break;
+-				msleep(50);
+-			}
+-			newcount = 0;
+-			count++;
+-		if ((atsc_read_iqr_reg()>>16) == 0x1f) {
+-			if (fe->ops.read_status)
+-				fe->ops.read_status(fe, &s);
+-			if (((s != fepriv->status) &&
+-				(s == (FE_HAS_LOCK|FE_HAS_SIGNAL|
+-				FE_HAS_CARRIER|FE_HAS_VITERBI|
+-				FE_HAS_SYNC)))) {
+-				dev_dbg(fe->dvb->device,
+-					"event s=%d,fepriv->status is %d!\n",
+-					s, fepriv->status);
+-				dev_dbg(fe->dvb->device,
+-					"fepriv-frequency is %d\n",
+-					fepriv->parameters_in.frequency);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				jiffiestime = jiffies_to_msecs(jiffies);
+-				return;
+-			}
+-		}
+-		if ((count == 2) &&
+-			((atsc_read_iqr_reg()>>16) != 0x1f)) {
+-			if (fe->ops.read_status)
+-				fe->ops.read_status(fe, &s);
+-			if (s != fepriv->status) {
+-				dev_dbg(fe->dvb->device,
+-					"event s=%d,fepriv->status is %d!!\n",
+-					s, fepriv->status);
+-				dev_dbg(fe->dvb->device,
+-					"fepriv->parameters_in.frequency is %d\n",
+-				fepriv->parameters_in.frequency);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				jiffiestime = jiffies_to_msecs(jiffies);
+-				return;
+-			}
+-		}
+-		}
+-
+-	}
+ 
+-
+-#endif
+-#if 1
+-	/*signal_detec dtmb   201512-rsj*/
+-		if (fe->ops.read_dtmb_fsm) {
+-			LOCK_TIMEOUT = 10000;
+-			has_singal = 0;
+-			msleep(100);
+-			fe->ops.read_dtmb_fsm(fe, &dtmb_status);
+-			for (i = 0 ; i < 8 ; i++) {
+-				if (((dtmb_status >> (i*4)) & 0xf) > 4) {
+-					/*has signal*/
+-				/*	dprintk("has signal\n");*/
+-					has_singal = 1;
+-				}
+-			}
+-			dprintk("[DTV]has_singal is %d\n", has_singal);
+-			if (has_singal == 0) {
+-				s = FE_TIMEDOUT;
+-			dprintk(
+-						"event s=%d,fepriv->status is %d\n",
+-						s, fepriv->status);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				return;
+-			}
+-		}
+-
+-#endif
+ 	/* if we are tuned already, check we're still locked */
+ 	if (fepriv->state & FESTATE_TUNED) {
+ 		dvb_frontend_swzigzag_update_delay(fepriv, s & FE_HAS_LOCK);
+@@ -870,13 +525,8 @@ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
+ 	}
+ 
+ 	/* fast zigzag. */
+-	if ((fepriv->state & FESTATE_SEARCHING_FAST) ||
+-		(fepriv->state & FESTATE_RETUNE)) {
+-		if (fepriv->state & FESTATE_SEARCHING_FAST)
+-			/*if not lock signal ,then wait 25 jiffies*/
+-			fepriv->delay = fepriv->min_delay + HZ / 5;
+-		else
+-			fepriv->delay = fepriv->min_delay;
++	if ((fepriv->state & FESTATE_SEARCHING_FAST) || (fepriv->state & FESTATE_RETUNE)) {
++		fepriv->delay = fepriv->min_delay;
+ 
+ 		/* perform a tune */
+ 		retval = dvb_frontend_swzigzag_autotune(fe,
+@@ -949,11 +599,11 @@ static int dvb_frontend_thread(void *data)
+ {
+ 	struct dvb_frontend *fe = data;
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-	unsigned long timeout;
+ 	fe_status_t s;
+ 	enum dvbfe_algo algo;
+ 
+-	struct dvb_frontend_parameters *params = NULL;
++	bool re_tune = false;
++	bool semheld = false;
+ 
+ 	dev_dbg(fe->dvb->device, "%s:\n", __func__);
+ 
+@@ -970,13 +620,15 @@ static int dvb_frontend_thread(void *data)
+ 	while (1) {
+ 		up(&fepriv->sem);	    /* is locked when we enter the thread... */
+ restart:
+-		timeout = wait_event_interruptible_timeout(fepriv->wait_queue,
++		wait_event_interruptible_timeout(fepriv->wait_queue,
+ 			dvb_frontend_should_wakeup(fe) || kthread_should_stop()
+ 				|| freezing(current),
+ 			fepriv->delay);
+ 
+ 		if (kthread_should_stop() || dvb_frontend_is_exiting(fe)) {
+ 			/* got signal or quitting */
++			if (!down_interruptible(&fepriv->sem))
++				semheld = true;
+ 			fepriv->exit = DVB_FE_NORMAL_EXIT;
+ 			break;
+ 		}
+@@ -1001,25 +653,18 @@ restart:
+ 			algo = fe->ops.get_frontend_algo(fe);
+ 			switch (algo) {
+ 			case DVBFE_ALGO_HW:
+-				dev_dbg(fe->dvb->device,
+-				"%s: Frontend ALGO = DVBFE_ALGO_HW\n",
+-				__func__);
++				dev_dbg(fe->dvb->device, "%s: Frontend ALGO = DVBFE_ALGO_HW\n", __func__);
+ 
+ 				if (fepriv->state & FESTATE_RETUNE) {
+-					dprintk(
+-					"%s:Retune requested,FESTATE_RETUNE\n",
+-					__func__);
+-					params = &fepriv->parameters_in;
++					dev_dbg(fe->dvb->device, "%s: Retune requested, FESTATE_RETUNE\n", __func__);
++					re_tune = true;
+ 					fepriv->state = FESTATE_TUNED;
++				} else {
++					re_tune = false;
+ 				}
+ 
+ 				if (fe->ops.tune)
+-					fe->ops.tune(fe,
+-						params,
+-						fepriv->tune_mode_flags,
+-						&fepriv->delay, &s);
+-				if (params)
+-					fepriv->parameters_out = *params;
++					fe->ops.tune(fe, re_tune, fepriv->tune_mode_flags, &fepriv->delay, &s);
+ 
+ 				if (s != fepriv->status && !(fepriv->tune_mode_flags & FE_TUNE_MODE_ONESHOT)) {
+ 					dev_dbg(fe->dvb->device, "%s: state changed, adding current state\n", __func__);
+@@ -1038,36 +683,26 @@ restart:
+ 					fepriv->state = FESTATE_TUNED;
+ 				}
+ 				/* Case where we are going to search for a carrier
+-				 * User asked us to retune again
+-				 *for some reason, possibly
++				 * User asked us to retune again for some reason, possibly
+ 				 * requesting a search with a new set of parameters
+ 				 */
+ 				if (fepriv->algo_status & DVBFE_ALGO_SEARCH_AGAIN) {
+ 					if (fe->ops.search) {
+ 						fepriv->algo_status = fe->ops.search(fe);
+-				/* We did do a search as was requested,
+-				*the flags are now unset as well and has
+-				* the flags wrt to search.
+-				*/
++						/* We did do a search as was requested, the flags are
++						 * now unset as well and has the flags wrt to search.
++						 */
+ 					} else {
+-						fepriv->algo_status &=
+-						~DVBFE_ALGO_SEARCH_AGAIN;
++						fepriv->algo_status &= ~DVBFE_ALGO_SEARCH_AGAIN;
+ 					}
+ 				}
+ 				/* Track the carrier if the search was successful */
+-				if (fepriv->algo_status
+-					== DVBFE_ALGO_SEARCH_SUCCESS) {
+-					if (fe->ops.track)
+-						fe->ops.track(fe,
+-						&fepriv->parameters_in);
+-					s = FE_HAS_LOCK;
+-				} else {
+-			/*fepriv->algo_status |= DVBFE_ALGO_SEARCH_AGAIN;*/
++				if (fepriv->algo_status != DVBFE_ALGO_SEARCH_SUCCESS) {
++					fepriv->algo_status |= DVBFE_ALGO_SEARCH_AGAIN;
+ 					fepriv->delay = HZ / 2;
+-					s = FE_TIMEDOUT;
+ 				}
+ 				dtv_property_legacy_params_sync(fe, &fepriv->parameters_out);
+-				/*fe->ops.read_status(fe, &s);*/
++				fe->ops.read_status(fe, &s);
+ 				if (s != fepriv->status) {
+ 					dvb_frontend_add_event(fe, s); /* update event list */
+ 					fepriv->status = s;
+@@ -1109,6 +744,8 @@ restart:
+ 		fepriv->exit = DVB_FE_NO_EXIT;
+ 	mb();
+ 
++	if (semheld)
++		up(&fepriv->sem);
+ 	dvb_frontend_wakeup(fe);
+ 	return 0;
+ }
+@@ -1197,7 +834,7 @@ static int dvb_frontend_start(struct dvb_frontend *fe)
+ 
+ 	if (signal_pending(current))
+ 		return -EINTR;
+-	if (down_interruptible(&fepriv->sem))
++	if (down_interruptible (&fepriv->sem))
+ 		return -EINTR;
+ 
+ 	fepriv->state = FESTATE_IDLE;
+@@ -1339,128 +976,6 @@ static int dvb_frontend_clear_cache(struct dvb_frontend *fe)
+ 	return 0;
+ }
+ 
+-static int dvb_frontend_asyncshouldwakeup(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	dprintk("%s:%d\n", __func__, fepriv->setfrontendasync_wakeup);
+-
+-	return fepriv->setfrontendasync_wakeup;
+-}
+-
+-static int dvb_frontend_asyncnotbusy(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	dprintk("%s:%d\n", __func__, fepriv->setfrontendasync_needwakeup);
+-
+-	return !fepriv->setfrontendasync_needwakeup;
+-}
+-
+-static void dvb_frontend_asyncwakeup(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	if (!fe)
+-		return;
+-
+-	if (!fe->ops.asyncinfo.set_frontend_asyncenable)
+-		return;
+-
+-
+-	dprintk("%s:%d\n", __func__, fepriv->setfrontendasync_needwakeup);
+-
+-	if (fepriv->setfrontendasync_needwakeup) {
+-		fepriv->setfrontendasync_wakeup = 1;
+-		wake_up_interruptible(&fepriv->setfrontendasync_wait_queue);
+-
+-		up(&fepriv->sem);
+-		wait_event_interruptible(fepriv->setfrontendasync_wait_queue,
+-						dvb_frontend_asyncnotbusy(fe));
+-		if (down_interruptible(&fepriv->sem))
+-			return;
+-	}
+-}
+-
+-static int dvb_frontend_asyncpreproc(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	if (!fe)
+-		return -1;
+-
+-	if (!fe->ops.asyncinfo.set_frontend_asyncenable)
+-		return -1;
+-
+-	fepriv->setfrontendasync_needwakeup = 1;
+-	fepriv->setfrontendasync_wakeup = 0;
+-
+-	dprintk("%s:%d\n", __func__, fepriv->setfrontendasync_needwakeup);
+-
+-	/*enable other frontend ops run*/
+-	up(&fepriv->sem);
+-
+-	return 0;
+-}
+-
+-static int dvb_frontend_asyncwait(struct dvb_frontend *fe, u32 ms_timeout)
+-{
+-	int ret = 0;
+-	unsigned long wait_ret = 0;
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	if (!fe)
+-		return -1;
+-
+-	if (!fe->ops.asyncinfo.set_frontend_asyncenable)
+-		return -1;
+-
+-	wait_ret = wait_event_interruptible_timeout
+-			(fepriv->setfrontendasync_wait_queue,
+-			dvb_frontend_asyncshouldwakeup(fe),
+-			ms_timeout * HZ / 1000);
+-
+-	dprintk("%s:%d/%ld\n", __func__, ms_timeout, wait_ret);
+-
+-	if (wait_ret > 0)
+-		ret = 1;
+-	else if (wait_ret == 0)
+-		ret = 0;
+-
+-	return ret;
+-}
+-
+-static int dvb_frontend_asyncpostproc(struct dvb_frontend *fe,
+-					int asyncwait_ret)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	if (!fe)
+-		return -1;
+-
+-	if (!fe->ops.asyncinfo.set_frontend_asyncenable)
+-		return -1;
+-
+-	if (down_interruptible(&fepriv->sem))
+-		return -1;
+-
+-	fepriv->setfrontendasync_needwakeup = 0;
+-
+-	wake_up_interruptible(&fepriv->setfrontendasync_wait_queue);
+-
+-	if (asyncwait_ret > 0)
+-		fepriv->setfrontendasync_interruptwakeup = 1;
+-	else if (asyncwait_ret == 0)
+-		fepriv->setfrontendasync_interruptwakeup = 0;
+-	else
+-		fepriv->setfrontendasync_interruptwakeup = 0;
+-	dprintk("%s:%d/%d\n", __func__,
+-		asyncwait_ret,
+-		fepriv->setfrontendasync_needwakeup);
+-
+-	return 0;
+-}
+-
+ #define _DTV_CMD(n, s, b) \
+ [n] = { \
+ 	.name = #n, \
+@@ -1632,7 +1147,6 @@ static int dtv_property_cache_sync(struct dvb_frontend *fe,
+ 		c->transmission_mode = p->u.ofdm.transmission_mode;
+ 		c->guard_interval = p->u.ofdm.guard_interval;
+ 		c->hierarchy = p->u.ofdm.hierarchy_information;
+-		c->ofdm_mode = p->u.ofdm.ofdm_mode;
+ 		break;
+ 	case DVBV3_ATSC:
+ 		dev_dbg(fe->dvb->device, "%s: Preparing ATSC req\n", __func__);
+@@ -1644,14 +1158,6 @@ static int dtv_property_cache_sync(struct dvb_frontend *fe,
+ 		else
+ 			c->delivery_system = SYS_DVBC_ANNEX_B;
+ 		break;
+-	case DVBV3_ANALOG:
+-		c->analog.soundsys  = p->u.analog.soundsys;
+-		c->analog.audmode   = p->u.analog.audmode;
+-		c->analog.std       = p->u.analog.std;
+-		c->analog.flag      = p->u.analog.flag;
+-		c->analog.afc_range = p->u.analog.afc_range;
+-		c->analog.reserved  = p->u.analog.reserved;
+-		break;
+ 	case DVBV3_UNKNOWN:
+ 		dev_err(fe->dvb->device,
+ 				"%s: doesn't know how to handle a DVBv3 call to delivery system %i\n",
+@@ -1672,7 +1178,7 @@ static int dtv_property_legacy_params_sync(struct dvb_frontend *fe,
+ 
+ 	p->frequency = c->frequency;
+ 	p->inversion = c->inversion;
+-	/*dtvprintk("[get frontend]p is %d\n", p->frequency);*/
++
+ 	switch (dvbv3_type(c->delivery_system)) {
+ 	case DVBV3_UNKNOWN:
+ 		dev_err(fe->dvb->device,
+@@ -1721,21 +1227,11 @@ static int dtv_property_legacy_params_sync(struct dvb_frontend *fe,
+ 		p->u.ofdm.transmission_mode = c->transmission_mode;
+ 		p->u.ofdm.guard_interval = c->guard_interval;
+ 		p->u.ofdm.hierarchy_information = c->hierarchy;
+-		p->u.ofdm.ofdm_mode = c->ofdm_mode;
+ 		break;
+ 	case DVBV3_ATSC:
+ 		dev_dbg(fe->dvb->device, "%s: Preparing VSB req\n", __func__);
+ 		p->u.vsb.modulation = c->modulation;
+ 		break;
+-	case DVBV3_ANALOG:
+-		p->u.analog.soundsys = c->analog.soundsys;
+-		p->u.analog.audmode  = c->analog.audmode;
+-		p->u.analog.std      = c->analog.std;
+-		p->u.analog.flag     = c->analog.flag;
+-		p->u.analog.afc_range = c->analog.afc_range;
+-		p->u.analog.reserved = c->analog.reserved;
+-		break;
+-
+ 	}
+ 	return 0;
+ }
+@@ -2007,14 +1503,8 @@ static bool is_dvbv3_delsys(u32 delsys)
+ {
+ 	bool status;
+ 
+-	status = (delsys == SYS_DVBT) ||
+-		(delsys == SYS_DVBC_ANNEX_A) ||
+-		(delsys == SYS_DVBS) ||
+-		(delsys == SYS_ATSC) ||
+-		(delsys == SYS_DTMB) ||
+-		(delsys == SYS_ISDBT) ||
+-		(delsys == SYS_ANALOG) ||
+-		(delsys == SYS_DVBS2);
++	status = (delsys == SYS_DVBT) || (delsys == SYS_DVBC_ANNEX_A) ||
++		 (delsys == SYS_DVBS) || (delsys == SYS_ATSC);
+ 
+ 	return status;
+ }
+@@ -2409,38 +1899,10 @@ static int dvb_frontend_ioctl(struct file *file,
+ 	struct dtv_frontend_properties *c = &fe->dtv_property_cache;
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+ 	int err = -EOPNOTSUPP;
+-	int need_lock = 1;
+-	int need_blindscan = 0;
+ 
+ 	dev_dbg(fe->dvb->device, "%s: (%d)\n", __func__, _IOC_NR(cmd));
+-	if (fepriv->exit != DVB_FE_NO_EXIT)
+-		return -ENODEV;
+-
+-	if ((file->f_flags & O_ACCMODE) == O_RDONLY &&
+-	    (_IOC_DIR(cmd) != _IOC_READ || cmd == FE_GET_EVENT ||
+-	     cmd == FE_DISEQC_RECV_SLAVE_REPLY))
+-		return -EPERM;
+-
+-	if (cmd == FE_READ_STATUS ||
+-			cmd == FE_READ_BER ||
+-			cmd == FE_READ_SIGNAL_STRENGTH ||
+-			cmd == FE_READ_SNR ||
+-			cmd == FE_READ_UNCORRECTED_BLOCKS ||
+-			cmd == FE_GET_FRONTEND ||
+-			cmd == FE_READ_AFC ||
+-			cmd == FE_SET_BLINDSCAN ||
+-			cmd == FE_GET_BLINDSCANEVENT ||
+-			cmd == FE_SET_BLINDSCANCANCEl)
+-		need_lock = 0;
+-
+-	if (cmd == FE_SET_BLINDSCAN ||
+-			cmd == FE_GET_BLINDSCANEVENT ||
+-			cmd == FE_SET_BLINDSCANCANCEl)
+-		need_blindscan = 1;
+-
+-	if (need_lock)
+-		if (down_interruptible(&fepriv->sem))
+-			return -ERESTARTSYS;
++	if (down_interruptible(&fepriv->sem))
++		return -ERESTARTSYS;
+ 
+ 	if (fepriv->exit != DVB_FE_NO_EXIT) {
+ 		up(&fepriv->sem);
+@@ -2454,14 +1916,6 @@ static int dvb_frontend_ioctl(struct file *file,
+ 		return -EPERM;
+ 	}
+ 
+-	if (need_blindscan)
+-		if (down_interruptible(&fepriv->blindscan_sem))
+-			return -ERESTARTSYS;
+-
+-	if (cmd == FE_SET_FRONTEND ||
+-			cmd == FE_SET_MODE)
+-		dvb_frontend_asyncwakeup(fe);
+-
+ 	if ((cmd == FE_SET_PROPERTY) || (cmd == FE_GET_PROPERTY))
+ 		err = dvb_frontend_ioctl_properties(file, cmd, parg);
+ 	else {
+@@ -2469,12 +1923,7 @@ static int dvb_frontend_ioctl(struct file *file,
+ 		err = dvb_frontend_ioctl_legacy(file, cmd, parg);
+ 	}
+ 
+-	if (need_blindscan)
+-		up(&fepriv->blindscan_sem);
+-
+-	if (need_lock)
+-		up(&fepriv->sem);
+-
++	up(&fepriv->sem);
+ 	return err;
+ }
+ 
+@@ -2509,18 +1958,12 @@ static int dvb_frontend_ioctl_properties(struct file *file,
+ 			err = -ENOMEM;
+ 			goto out;
+ 		}
+-#ifdef CONFIG_COMPAT
+-		if (copy_from_user(tvp, compat_ptr((unsigned long)tvps->props),
+-				tvps->num * sizeof(struct dtv_property))) {
+-			err = -EFAULT;
+-			goto out;
+-		}
+-#else
++
+ 		if (copy_from_user(tvp, tvps->props, tvps->num * sizeof(struct dtv_property))) {
+ 			err = -EFAULT;
+ 			goto out;
+ 		}
+-#endif
++
+ 		for (i = 0; i < tvps->num; i++) {
+ 			err = dtv_property_process_set(fe, tvp + i, file);
+ 			if (err < 0)
+@@ -2548,18 +1991,12 @@ static int dvb_frontend_ioctl_properties(struct file *file,
+ 			err = -ENOMEM;
+ 			goto out;
+ 		}
+-#ifdef CONFIG_COMPAT
+-		if (copy_from_user(tvp, compat_ptr((unsigned long)tvps->props),
+-				tvps->num * sizeof(struct dtv_property))) {
+-			err = -EFAULT;
+-			goto out;
+-		}
+-#else
++
+ 		if (copy_from_user(tvp, tvps->props, tvps->num * sizeof(struct dtv_property))) {
+ 			err = -EFAULT;
+ 			goto out;
+ 		}
+-#endif
++
+ 		/*
+ 		 * Fills the cache out struct with the cache contents, plus
+ 		 * the data retrieved from get_frontend, if the frontend
+@@ -2576,18 +2013,11 @@ static int dvb_frontend_ioctl_properties(struct file *file,
+ 				goto out;
+ 			(tvp + i)->result = err;
+ 		}
+-#ifdef CONFIG_COMPAT
+-		if (copy_to_user(compat_ptr((unsigned long)tvps->props), tvp,
+-				tvps->num * sizeof(struct dtv_property))) {
+-			err = -EFAULT;
+-			goto out;
+-		}
+-#else
++
+ 		if (copy_to_user(tvps->props, tvp, tvps->num * sizeof(struct dtv_property))) {
+ 			err = -EFAULT;
+ 			goto out;
+ 		}
+-#endif
+ 
+ 	} else
+ 		err = -EOPNOTSUPP;
+@@ -2603,7 +2033,6 @@ static int dtv_set_frontend(struct dvb_frontend *fe)
+ 	struct dtv_frontend_properties *c = &fe->dtv_property_cache;
+ 	struct dvb_frontend_tune_settings fetunesettings;
+ 	u32 rolloff = 0;
+-	dev_dbg(fe->dvb->device, "dtv_set_frontend\n");
+ 
+ 	if (dvb_frontend_check_parameters(fe) < 0)
+ 		return -EINVAL;
+@@ -2678,18 +2107,16 @@ static int dtv_set_frontend(struct dvb_frontend *fe)
+ 		case SYS_DVBC_ANNEX_A:
+ 		case SYS_DVBC_ANNEX_C:
+ 			fepriv->min_delay = HZ / 20;
+-			fepriv->step_size = 0;
+-			fepriv->max_drift = 0;
++			fepriv->step_size = c->symbol_rate / 16000;
++			fepriv->max_drift = c->symbol_rate / 2000;
+ 			break;
+ 		case SYS_DVBT:
+ 		case SYS_DVBT2:
+ 		case SYS_ISDBT:
+ 		case SYS_DTMB:
+ 			fepriv->min_delay = HZ / 20;
+-			/*fe->ops.info.frequency_stepsize * 2;*/
+-			fepriv->step_size = 0;
+-			/*(fe->ops.info.frequency_stepsize * 2) + 1;*/
+-			fepriv->max_drift = 0;
++			fepriv->step_size = fe->ops.info.frequency_stepsize * 2;
++			fepriv->max_drift = (fe->ops.info.frequency_stepsize * 2) + 1;
+ 			break;
+ 		default:
+ 			/*
+@@ -2709,18 +2136,10 @@ static int dtv_set_frontend(struct dvb_frontend *fe)
+ 
+ 	/* Request the search algorithm to search */
+ 	fepriv->algo_status |= DVBFE_ALGO_SEARCH_AGAIN;
+-	if (c->delivery_system == SYS_ANALOG &&
+-		(c->analog.flag & ANALOG_FLAG_ENABLE_AFC)) {
+-		/*dvb_frontend_add_event(fe, 0); */
+-		dvb_frontend_clear_events(fe);
+-		dvb_frontend_wakeup(fe);
+-	} else if (fe->ops.set_frontend) {
+-		fe->ops.set_frontend(fe);
+-		if (c->delivery_system != SYS_ANALOG)
+-			dvb_frontend_clear_events(fe);
+-			dvb_frontend_add_event(fe, 0);
+-			dvb_frontend_wakeup(fe);
+-	}
++
++	dvb_frontend_clear_events(fe);
++	dvb_frontend_add_event(fe, 0);
++	dvb_frontend_wakeup(fe);
+ 	fepriv->status = 0;
+ 
+ 	return 0;
+@@ -2906,10 +2325,7 @@ static int dvb_frontend_ioctl_legacy(struct file *file,
+ 			int i;
+ 			u8 last = 1;
+ 			if (dvb_frontend_debug)
+-				dev_dbg(fe->dvb->device,
+-				"%s switch command: 0x%04lx\n",
+-				__func__,
+-				swcmd);
++				printk("%s switch command: 0x%04lx\n", __func__, swcmd);
+ 			do_gettimeofday(&nexttime);
+ 			if (dvb_frontend_debug)
+ 				tv[0] = nexttime;
+@@ -2932,12 +2348,10 @@ static int dvb_frontend_ioctl_legacy(struct file *file,
+ 					dvb_frontend_sleep_until(&nexttime, 8000);
+ 			}
+ 			if (dvb_frontend_debug) {
+-				dev_dbg(fe->dvb->device, "%s(%d): switch delay (should be 32k followed by all 8k\n",
++				printk("%s(%d): switch delay (should be 32k followed by all 8k\n",
+ 					__func__, fe->dvb->num);
+ 				for (i = 1; i < 10; i++)
+-					dev_dbg(fe->dvb->device,
+-					"%d: %d\n", i,
+-					timeval_usec_diff(tv[i-1] , tv[i]));
++					printk("%d: %d\n", i, timeval_usec_diff(tv[i-1] , tv[i]));
+ 			}
+ 			err = 0;
+ 			fepriv->state = FESTATE_DISEQC;
+@@ -2956,19 +2370,15 @@ static int dvb_frontend_ioctl_legacy(struct file *file,
+ 		break;
+ 
+ 	case FE_SET_FRONTEND:
+-		if (disable_set_frotend_param)
+-			break;
+-		dev_dbg(fe->dvb->device, "FE_SET_FRONTEND\n");
+ 		err = dvbv3_set_delivery_system(fe);
+ 		if (err)
+ 			break;
++
+ 		err = dtv_property_cache_sync(fe, c, parg);
+ 		if (err)
+ 			break;
+-		jiffiestime = jiffies_to_msecs(jiffies);
+ 		err = dtv_set_frontend(fe);
+ 		break;
+-
+ 	case FE_GET_EVENT:
+ 		err = dvb_frontend_get_event (fe, parg, file->f_flags);
+ 		break;
+@@ -2981,164 +2391,6 @@ static int dvb_frontend_ioctl_legacy(struct file *file,
+ 		fepriv->tune_mode_flags = (unsigned long) parg;
+ 		err = 0;
+ 		break;
+-
+-	case FE_SET_DELAY:
+-		fepriv->user_delay = (long)parg;
+-		err = 0;
+-		break;
+-
+-	case FE_SET_MODE:
+-		/*
+-		    set thread idle to avoid unnecessary EVT notification.
+-		    potential calls due to the EVT/s
+-		    may destroy the internal info.
+-		*/
+-		fepriv->state = FESTATE_IDLE;
+-
+-		if (fe->ops.set_mode) {
+-			err = fe->ops.set_mode(fe, (long)parg);
+-			if (err == 0) {
+-				switch ((long)parg) {
+-				case FE_QPSK:
+-					/*DVBV3_QPSK;*/
+-					c->delivery_system = SYS_DVBS2;
+-					break;
+-				case FE_QAM:
+-					/*DVBV3_QAM;*/
+-					c->delivery_system = SYS_DVBC_ANNEX_A;
+-					break;
+-				case FE_OFDM:
+-					/*DVBV3_OFDM;*/
+-					c->delivery_system = SYS_DVBT;
+-					break;
+-				case FE_ATSC:
+-					/*DVBV3_ATSC;*/
+-					c->delivery_system = SYS_ATSC;
+-					break;
+-				case FE_ANALOG:
+-					/*DVBV3_ANALOG;*/
+-					c->delivery_system = SYS_ANALOG;
+-					break;
+-				case FE_DTMB:
+-					/*DVBV3_OFDM;*/
+-					c->delivery_system = SYS_DTMB;
+-					break;
+-				case FE_ISDBT:
+-					/*DVBV3_OFDM;*/
+-					c->delivery_system = SYS_ISDBT;
+-					break;
+-				}
+-			}
+-		}
+-		break;
+-
+-	case FE_READ_TS:
+-		if (fe->ops.read_ts)
+-			err = fe->ops.read_ts(fe, (int *)parg);
+-		break;
+-	case FE_FINE_TUNE:
+-		if (fe->ops.tuner_ops.fine_tune) {
+-			err =
+-			fe->ops.tuner_ops.fine_tune(fe, *((int *)parg));
+-		}
+-		break;
+-	case FE_READ_TUNER_STATUS:
+-		if (fe->ops.tuner_ops.get_tuner_status) {
+-			struct tuner_status_s parm_status = {0};
+-			struct tuner_status_s *tmsp = parg;
+-			err =
+-			fe->ops.tuner_ops.get_tuner_status(fe, &parm_status);
+-			memcpy(tmsp, &parm_status,
+-				sizeof(struct tuner_status_s));
+-		}
+-		break;
+-	case FE_READ_ANALOG_STATUS:
+-		if (fe->ops.analog_ops.get_atv_status) {
+-			struct atv_status_s atv_stats = {0};
+-			struct atv_status_s *tmap = parg;
+-			err = fe->ops.analog_ops.get_atv_status(fe, &atv_stats);
+-			memcpy(tmap, &atv_stats, sizeof(struct atv_status_s));
+-		}
+-		break;
+-	case FE_READ_SD_STATUS:
+-		if (fe->ops.analog_ops.get_sd_status) {
+-			struct sound_status_s sound_sts = {0};
+-			err = fe->ops.analog_ops.get_sd_status(fe, &sound_sts);
+-			memcpy(parg, &sound_sts, sizeof(struct sound_status_s));
+-		}
+-		break;
+-	case FE_SET_PARAM_BOX:
+-		if (fe->ops.tuner_ops.set_config) {
+-			struct tuner_param_s tuner_parm = {0};
+-			memcpy(&tuner_parm, parg, sizeof(struct tuner_param_s));
+-			err = fe->ops.tuner_ops.set_config(fe, &tuner_parm);
+-			memcpy(parg, &tuner_parm, sizeof(struct tuner_param_s));
+-		}
+-		break;
+-
+-	case  FE_SET_BLINDSCAN:
+-		memcpy(&(fe->ops.blindscan_ops.info.bspara),
+-			parg, sizeof(struct dvbsx_blindscanpara));
+-
+-		dprintk("FE_SET_BLINDSCAN %d %d %d %d %d %d %d\n",
+-			fe->ops.blindscan_ops.info.bspara.minfrequency,
+-			fe->ops.blindscan_ops.info.bspara.maxfrequency,
+-			fe->ops.blindscan_ops.info.bspara.minSymbolRate,
+-			fe->ops.blindscan_ops.info.bspara.maxSymbolRate,
+-			fe->ops.blindscan_ops.info.bspara.frequencyRange,
+-			fe->ops.blindscan_ops.info.bspara.frequencyStep,
+-			fe->ops.blindscan_ops.info.bspara.timeout);
+-
+-		/*register*/
+-		fe->ops.blindscan_ops.info.blindscan_callback
+-			= dvbsx_blindscan_event_callback;
+-
+-		fepriv->in_blindscan = true;
+-
+-		if (fe->ops.blindscan_ops.blindscan_scan)
+-			err = fe->ops.blindscan_ops.blindscan_scan(fe,
+-				 &(fe->ops.blindscan_ops.info.bspara));
+-		break;
+-
+-	case  FE_GET_BLINDSCANEVENT:
+-		{
+-		struct dvbsx_blindscanevent *p_tmp_bsevent = NULL;
+-		err = dvbsx_blindscan_get_event(fe,
+-			(struct dvbsx_blindscanevent *)parg,
+-			file->f_flags);
+-
+-		p_tmp_bsevent = (struct dvbsx_blindscanevent *)parg;
+-
+-		dprintk("FE_GET_BLINDSCANEVENT status:%d\n",
+-			p_tmp_bsevent->status);
+-		if (p_tmp_bsevent->status == BLINDSCAN_UPDATESTARTFREQ) {
+-			dprintk("start freq %d\n",
+-			p_tmp_bsevent->u.m_uistartfreq_khz);
+-		} else if (p_tmp_bsevent->status == BLINDSCAN_UPDATEPROCESS) {
+-			dprintk("process %d\n", p_tmp_bsevent->u.m_uiprogress);
+-		} else if (p_tmp_bsevent->status
+-				== BLINDSCAN_UPDATERESULTFREQ) {
+-			dprintk("result freq %d symb %d\n",
+-			p_tmp_bsevent->u.parameters.frequency,
+-			p_tmp_bsevent->u.parameters.u.qpsk.symbol_rate);
+-		}
+-		}
+-		break;
+-
+-	case  FE_SET_BLINDSCANCANCEl:
+-		dprintk("FE_SET_BLINDSCANCANCEl\n");
+-
+-
+-		if (fe->ops.blindscan_ops.blindscan_cancel)
+-			err = fe->ops.blindscan_ops.blindscan_cancel(fe);
+-
+-		fepriv->in_blindscan = false;
+-
+-		/*unregister*/
+-		fe->ops.blindscan_ops.info.blindscan_callback = NULL;
+-
+-		break;
+-
+ 	}
+ 
+ 	return err;
+@@ -3240,8 +2492,6 @@ static int dvb_frontend_open(struct inode *inode, struct file *file)
+ 
+ 		/*  empty event queue */
+ 		fepriv->events.eventr = fepriv->events.eventw = 0;
+-		fepriv->blindscan_events.eventr
+-		= fepriv->blindscan_events.eventw = 0;
+ 	}
+ 
+ 	if (adapter->mfe_shared)
+@@ -3286,18 +2536,6 @@ static int dvb_frontend_release(struct inode *inode, struct file *file)
+ 	return ret;
+ }
+ 
+-#ifdef CONFIG_COMPAT
+-static long dvb_frontend_compat_ioctl(struct file *filp,
+-			unsigned int cmd, unsigned long args)
+-{
+-	unsigned long ret;
+-
+-	args = (unsigned long)compat_ptr(args);
+-	ret = dvb_generic_ioctl(filp, cmd, args);
+-	return ret;
+-}
+-#endif
+-
+ static const struct file_operations dvb_frontend_fops = {
+ 	.owner		= THIS_MODULE,
+ 	.unlocked_ioctl	= dvb_generic_ioctl,
+@@ -3305,10 +2543,6 @@ static const struct file_operations dvb_frontend_fops = {
+ 	.open		= dvb_frontend_open,
+ 	.release	= dvb_frontend_release,
+ 	.llseek		= noop_llseek,
+-#ifdef CONFIG_COMPAT
+-	.compat_ioctl	= dvb_frontend_compat_ioctl,
+-#endif
+-
+ };
+ 
+ int dvb_frontend_suspend(struct dvb_frontend *fe)
+@@ -3349,31 +2583,6 @@ int dvb_frontend_resume(struct dvb_frontend *fe)
+ }
+ EXPORT_SYMBOL(dvb_frontend_resume);
+ 
+-
+-static ssize_t dvbc_lock_show(struct class *cls,
+-				struct class_attribute *attr,
+-				char *buf)
+-{
+-	return sprintf(buf, "dvbc_autoflags: %s\n", LOCK_TIMEOUT?"on":"off");
+-}
+-static ssize_t dvbc_lock_store(struct class *cls,
+-				struct class_attribute *attr,
+-				const char *buf,
+-				size_t count)
+-{
+-	/*int mode = simple_strtol(buf, 0, 16);*/
+-	int mode = 0;
+-	count = kstrtol(buf, 0, (long *)&mode);
+-	LOCK_TIMEOUT = mode;
+-	return count;
+-
+-}
+-
+-static CLASS_ATTR(lock_time, 0644, dvbc_lock_show, dvbc_lock_store);
+-
+-struct class *tongfang_clsp;
+-#define LOCK_DEVICE_NAME  "tongfang"
+-
+ int dvb_register_frontend(struct dvb_adapter* dvb,
+ 			  struct dvb_frontend* fe)
+ {
+@@ -3386,7 +2595,6 @@ int dvb_register_frontend(struct dvb_adapter* dvb,
+ 		.kernel_ioctl = dvb_frontend_ioctl
+ 	};
+ 
+-	int ret;
+ 	dev_dbg(dvb->device, "%s:\n", __func__);
+ 
+ 	if (mutex_lock_interruptible(&frontend_mutex))
+@@ -3400,44 +2608,19 @@ int dvb_register_frontend(struct dvb_adapter* dvb,
+ 	fepriv = fe->frontend_priv;
+ 
+ 	sema_init(&fepriv->sem, 1);
+-	sema_init(&fepriv->blindscan_sem, 1);
+-	init_waitqueue_head(&fepriv->wait_queue);
+-	init_waitqueue_head(&fepriv->events.wait_queue);
+-	init_waitqueue_head(&fepriv->blindscan_events.wait_queue);
++	init_waitqueue_head (&fepriv->wait_queue);
++	init_waitqueue_head (&fepriv->events.wait_queue);
+ 	mutex_init(&fepriv->events.mtx);
+-	mutex_init(&fepriv->blindscan_events.mtx);
+ 	fe->dvb = dvb;
+ 	fepriv->inversion = INVERSION_OFF;
+ 
+-	init_waitqueue_head(&fepriv->setfrontendasync_wait_queue);
+-	fepriv->setfrontendasync_wakeup = 0;
+-	fepriv->setfrontendasync_needwakeup = 0;
+-	fepriv->setfrontendasync_interruptwakeup = 0;
+-
+-	fe->ops.asyncinfo.set_frontend_asyncpreproc = dvb_frontend_asyncpreproc;
+-	fe->ops.asyncinfo.set_frontend_asyncwait = dvb_frontend_asyncwait;
+-	fe->ops.asyncinfo.set_frontend_asyncpostproc
+-	= dvb_frontend_asyncpostproc;
+-
+ 	dev_info(fe->dvb->device,
+ 			"DVB: registering adapter %i frontend %i (%s)...\n",
+ 			fe->dvb->num, fe->id, fe->ops.info.name);
+ 
+ 	dvb_register_device (fe->dvb, &fepriv->dvbdev, &dvbdev_template,
+ 			     fe, DVB_DEVICE_FRONTEND);
+-	dev_dbg(fe->dvb->device, "For tongfang\n");
+-	ret = 0;
+-	tongfang_clsp = class_create(THIS_MODULE, LOCK_DEVICE_NAME);
+-	if (!tongfang_clsp) {
+-		dev_dbg(fe->dvb->device,
+-		"[tongfang]%s:create class error.\n", __func__);
+-		return PTR_ERR(tongfang_clsp);
+-	}
+-	ret = class_create_file(tongfang_clsp, &class_attr_lock_time);
+-	if (ret) {
+-		/* printk("[tongfang]%s create
+-		class file error.\n", __func__); */
+-	}
++
+ 	/*
+ 	 * Initialize the cache to the proper values according with the
+ 	 * first supported delivery system (ops->delsys[0])
+@@ -3466,8 +2649,6 @@ int dvb_unregister_frontend(struct dvb_frontend* fe)
+ 
+ 	mutex_lock(&frontend_mutex);
+ 	dvb_unregister_device (fepriv->dvbdev);
+-	class_remove_file(tongfang_clsp, &class_attr_lock_time);
+-	class_destroy(tongfang_clsp);
+ 
+ 	/* fe is invalid now */
+ 	kfree(fepriv);
+@@ -3513,17 +2694,3 @@ void dvb_frontend_detach(struct dvb_frontend* fe)
+ }
+ #endif
+ EXPORT_SYMBOL(dvb_frontend_detach);
+-
+-void dvb_frontend_retune(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	fepriv->state = FESTATE_RETUNE;
+-
+-	fepriv->algo_status |= DVBFE_ALGO_SEARCH_AGAIN;
+-
+-	dvb_frontend_wakeup(fe);
+-	fepriv->status = 0;
+-}
+-EXPORT_SYMBOL(dvb_frontend_retune);
+-
+diff --git a/drivers/media/dvb-core/dvb_frontend.h b/drivers/media/dvb-core/dvb_frontend.h
+index 70ea290..371b6ca 100644
+--- a/drivers/media/dvb-core/dvb_frontend.h
++++ b/drivers/media/dvb-core/dvb_frontend.h
+@@ -38,7 +38,6 @@
+ #include <linux/mutex.h>
+ #include <linux/slab.h>
+ 
+-#include <linux/dvb/aml_demod.h>
+ #include <linux/dvb/frontend.h>
+ 
+ #include "dvbdev.h"
+@@ -49,11 +48,6 @@
+  */
+ #define MAX_DELSYS	8
+ 
+-#if (defined CONFIG_AM_M6_DEMOD)
+-extern u32 dvbc_get_status(void);
+-extern unsigned long atsc_read_iqr_reg(void);
+-#endif
+-
+ struct dvb_frontend_tune_settings {
+ 	int min_delay_ms;
+ 	int step_size;
+@@ -77,16 +71,8 @@ struct dvb_tuner_info {
+ struct analog_parameters {
+ 	unsigned int frequency;
+ 	unsigned int mode;
+-	unsigned int soundsys;/* A2,BTSC/EIAJ/NICAM */
+ 	unsigned int audmode;
+-	unsigned int lock_range;
+-	unsigned int leap_step;
+ 	u64 std;
+-	/*for amlatvdemod*/
+-	unsigned int tuner_id;
+-	unsigned int if_freq;
+-	unsigned int if_inv;
+-	unsigned int reserved;
+ };
+ 
+ enum dvbfe_modcod {
+@@ -232,21 +218,14 @@ struct dvb_tuner_ops {
+ 
+ #define TUNER_STATUS_LOCKED 1
+ #define TUNER_STATUS_STEREO 2
+-	int (*get_status)(struct dvb_frontend *fe, void *status);
+-	void (*get_pll_status)(struct dvb_frontend *fe, void *status);
++	int (*get_status)(struct dvb_frontend *fe, u32 *status);
+ 	int (*get_rf_strength)(struct dvb_frontend *fe, u16 *strength);
+ 	int (*get_afc)(struct dvb_frontend *fe, s32 *afc);
+-	int (*get_snr)(struct dvb_frontend *fe);
+ 
+ 	/** These are provided separately from set_params in order to facilitate silicon
+ 	 * tuners which require sophisticated tuning loops, controlling each parameter separately. */
+ 	int (*set_frequency)(struct dvb_frontend *fe, u32 frequency);
+ 	int (*set_bandwidth)(struct dvb_frontend *fe, u32 bandwidth);
+-	int (*set_tuner)(struct dvb_frontend *fe,
+-		struct aml_demod_sta *demod_sta,
+-		struct aml_demod_i2c *demod_i2c,
+-		struct aml_tuner_sys *tuner_sys);
+-	int (*get_strength)(struct dvb_frontend *fe);
+ 
+ 	/*
+ 	 * These are provided separately from set_params in order to facilitate silicon
+@@ -254,12 +233,6 @@ struct dvb_tuner_ops {
+ 	 */
+ 	int (*set_state)(struct dvb_frontend *fe, enum tuner_param param, struct tuner_state *state);
+ 	int (*get_state)(struct dvb_frontend *fe, enum tuner_param param, struct tuner_state *state);
+-	/*add function to get tuner status*/
+-	int (*get_tuner_status)(struct dvb_frontend *fe,
+-				struct tuner_status_s *tuner_status);
+-	/* add special fine tune function */
+-	int (*fine_tune)(struct dvb_frontend *fe,
+-				int offset_khz);
+ };
+ 
+ struct analog_demod_info {
+@@ -272,12 +245,8 @@ struct analog_demod_ops {
+ 
+ 	void (*set_params)(struct dvb_frontend *fe,
+ 			   struct analog_parameters *params);
+-	int (*has_signal)(struct dvb_frontend *fe, u16 *signal);
+-	int (*get_afc)(struct dvb_frontend *fe, s32 *afc);
+-	int (*is_stereo)(struct dvb_frontend *fe);
+-	int (*get_snr)(struct dvb_frontend *fe);
+-	int (*get_status)(struct dvb_frontend *fe, void *status);
+-	void (*get_pll_status)(struct dvb_frontend *fe, void *status);
++	int  (*has_signal)(struct dvb_frontend *fe, u16 *signal);
++	int  (*get_afc)(struct dvb_frontend *fe, s32 *afc);
+ 	void (*tuner_status)(struct dvb_frontend *fe);
+ 	void (*standby)(struct dvb_frontend *fe);
+ 	void (*release)(struct dvb_frontend *fe);
+@@ -285,42 +254,10 @@ struct analog_demod_ops {
+ 
+ 	/** This is to allow setting tuner-specific configuration */
+ 	int (*set_config)(struct dvb_frontend *fe, void *priv_cfg);
+-	/* add function to get atv_demod & stereo_demod status */
+-	int (*get_atv_status)(struct dvb_frontend *fe,
+-				struct atv_status_s *atv_status);
+-	int (*get_sd_status)(struct dvb_frontend *fe,
+-				struct sound_status_s *sd_status);
+ };
+ 
+ struct dtv_frontend_properties;
+ 
+-struct dvbsx_blindscan_info {
+-	/* timeout of get blindscan event */
+-	struct dvbsx_blindscanpara bspara;
+-	int (*blindscan_callback)(struct dvb_frontend *fe,
+-				  struct dvbsx_blindscanevent *pbsevent);
+-};
+-
+-struct dvbsx_blindscan_ops {
+-	struct dvbsx_blindscan_info info;
+-
+-	/*
+-	 *  These are provided start and stop blindscan
+-	 */
+-	int (*blindscan_scan)(struct dvb_frontend *fe,
+-			      struct dvbsx_blindscanpara *pbspara);
+-	int (*blindscan_cancel)(struct dvb_frontend *fe);
+-};
+-
+-struct dvb_frontend_asyncinfo {
+-	int set_frontend_asyncenable;
+-	int (*set_frontend_asyncpreproc)(struct dvb_frontend *fe);
+-	/*return value = 1 interrupt, = 0 timeout,  = -1 error*/
+-	int (*set_frontend_asyncwait)(struct dvb_frontend *fe, u32 timeout);
+-	int (*set_frontend_asyncpostproc)(struct dvb_frontend *fe,
+-					  int asyncwait_ret);
+-};
+-
+ struct dvb_frontend_ops {
+ 
+ 	struct dvb_frontend_info info;
+@@ -330,13 +267,13 @@ struct dvb_frontend_ops {
+ 	void (*release)(struct dvb_frontend* fe);
+ 	void (*release_sec)(struct dvb_frontend* fe);
+ 
+-	int (*init)(struct dvb_frontend *fe);
+-	int (*sleep)(struct dvb_frontend *fe);
++	int (*init)(struct dvb_frontend* fe);
++	int (*sleep)(struct dvb_frontend* fe);
+ 
+-	int (*write)(struct dvb_frontend *fe, const u8 buf[], int len);
++	int (*write)(struct dvb_frontend* fe, const u8 buf[], int len);
+ 
+ 	/* if this is set, it overrides the default swzigzag */
+-	int (*tune)(struct dvb_frontend *fe,
++	int (*tune)(struct dvb_frontend* fe,
+ 		    bool re_tune,
+ 		    unsigned int mode_flags,
+ 		    unsigned int *delay,
+@@ -346,23 +283,20 @@ struct dvb_frontend_ops {
+ 
+ 	/* these two are only used for the swzigzag code */
+ 	int (*set_frontend)(struct dvb_frontend *fe);
+-	int (*get_tune_settings)(struct dvb_frontend *fe,
+-				 struct dvb_frontend_tune_settings *settings);
++	int (*get_tune_settings)(struct dvb_frontend* fe, struct dvb_frontend_tune_settings* settings);
++
+ 	int (*get_frontend)(struct dvb_frontend *fe);
+ 
+-	int (*read_status)(struct dvb_frontend *fe, fe_status_t *status);
+-	int (*read_ber)(struct dvb_frontend *fe, u32 *ber);
+-	int (*read_signal_strength)(struct dvb_frontend *fe, u16 *strength);
+-	int (*read_snr)(struct dvb_frontend *fe, u16 *snr);
+-	int (*read_ucblocks)(struct dvb_frontend *fe, u32 *ucblocks);
+-	int (*set_qam_mode)(struct dvb_frontend *fe);
+-	int (*diseqc_reset_overload)(struct dvb_frontend *fe);
+-	int (*diseqc_send_master_cmd)(struct dvb_frontend *fe,
+-				      struct dvb_diseqc_master_cmd *cmd);
+-	int (*diseqc_recv_slave_reply)(struct dvb_frontend *fe,
+-				       struct dvb_diseqc_slave_reply *reply);
+-	int (*diseqc_send_burst)(struct dvb_frontend *fe,
+-				 fe_sec_mini_cmd_t minicmd);
++	int (*read_status)(struct dvb_frontend* fe, fe_status_t* status);
++	int (*read_ber)(struct dvb_frontend* fe, u32* ber);
++	int (*read_signal_strength)(struct dvb_frontend* fe, u16* strength);
++	int (*read_snr)(struct dvb_frontend* fe, u16* snr);
++	int (*read_ucblocks)(struct dvb_frontend* fe, u32* ucblocks);
++
++	int (*diseqc_reset_overload)(struct dvb_frontend* fe);
++	int (*diseqc_send_master_cmd)(struct dvb_frontend* fe, struct dvb_diseqc_master_cmd* cmd);
++	int (*diseqc_recv_slave_reply)(struct dvb_frontend* fe, struct dvb_diseqc_slave_reply* reply);
++	int (*diseqc_send_burst)(struct dvb_frontend* fe, fe_sec_mini_cmd_t minicmd);
+ 	int (*set_tone)(struct dvb_frontend* fe, fe_sec_tone_mode_t tone);
+ 	int (*set_voltage)(struct dvb_frontend* fe, fe_sec_voltage_t voltage);
+ 	int (*enable_high_lnb_voltage)(struct dvb_frontend* fe, long arg);
+@@ -375,23 +309,15 @@ struct dvb_frontend_ops {
+ 	 * tuning algorithms, rather than a simple swzigzag
+ 	 */
+ 	enum dvbfe_search (*search)(struct dvb_frontend *fe);
+-	int (*track)(struct dvb_frontend *fe,
+-		     struct dvb_frontend_parameters *p);
++
+ 	struct dvb_tuner_ops tuner_ops;
+ 	struct analog_demod_ops analog_ops;
+ 
+-	int (*set_property)(struct dvb_frontend *fe, struct dtv_property *tvp);
+-	int (*get_property)(struct dvb_frontend *fe, struct dtv_property *tvp);
+-
+-	struct dvbsx_blindscan_ops blindscan_ops;
+-
+-	int (*set_mode)(struct dvb_frontend *fe, fe_type_t type);
+-	int (*read_ts)(struct dvb_frontend *fe, int *ts);
+-	int (*read_dtmb_fsm)(struct dvb_frontend *fe, u32 *fsm_status);
+-
+-	struct dvb_frontend_asyncinfo asyncinfo;
++	int (*set_property)(struct dvb_frontend* fe, struct dtv_property* tvp);
++	int (*get_property)(struct dvb_frontend* fe, struct dtv_property* tvp);
+ };
+ 
++#ifdef __DVB_CORE__
+ #define MAX_EVENT 8
+ 
+ struct dvb_fe_events {
+@@ -402,17 +328,7 @@ struct dvb_fe_events {
+ 	wait_queue_head_t	  wait_queue;
+ 	struct mutex		  mtx;
+ };
+-
+-#define MAX_BLINDSCAN_EVENT 32
+-
+-struct dvbsx_blindscan_events {
+-	struct dvbsx_blindscanevent events[MAX_BLINDSCAN_EVENT];
+-	int			  eventw;
+-	int			  eventr;
+-	int			  overflow;
+-	wait_queue_head_t	  wait_queue;
+-	struct mutex		  mtx;
+-};
++#endif
+ 
+ struct dtv_frontend_properties {
+ 
+@@ -428,7 +344,7 @@ struct dtv_frontend_properties {
+ 	fe_code_rate_t		fec_inner;
+ 	fe_transmit_mode_t	transmission_mode;
+ 	u32			bandwidth_hz;	/* 0 = AUTO */
+-	fe_guard_interval_t guard_interval;
++	fe_guard_interval_t	guard_interval;
+ 	fe_hierarchy_t		hierarchy;
+ 	u32			symbol_rate;
+ 	fe_code_rate_t		code_rate_HP;
+@@ -437,8 +353,6 @@ struct dtv_frontend_properties {
+ 	fe_pilot_t		pilot;
+ 	fe_rolloff_t		rolloff;
+ 
+-	enum fe_ofdm_mode      ofdm_mode;
+-
+ 	fe_delivery_system_t	delivery_system;
+ 
+ 	enum fe_interleaving	interleaving;
+@@ -460,11 +374,6 @@ struct dtv_frontend_properties {
+ 	/* Multistream specifics */
+ 	u32			stream_id;
+ 
+-	u32         dvbt2_plp_id;
+-
+-	/* Analog specifics */
+-	struct dvb_analog_parameters analog;
+-	struct dvb_analog_parameters param;
+ 	/* ATSC-MH specifics */
+ 	u8			atscmh_fic_ver;
+ 	u8			atscmh_parade_id;
+diff --git a/drivers/media/dvb-core/dvbdev.c b/drivers/media/dvb-core/dvbdev.c
+index dbffaa0..983db75 100644
+--- a/drivers/media/dvb-core/dvbdev.c
++++ b/drivers/media/dvb-core/dvbdev.c
+@@ -47,7 +47,7 @@ static DEFINE_MUTEX(dvbdev_register_lock);
+ 
+ static const char * const dnames[] = {
+ 	"video", "audio", "sec", "frontend", "demux", "dvr", "ca",
+-	"net", "osd", "dsc"
++	"net", "osd"
+ };
+ 
+ #ifdef CONFIG_DVB_DYNAMIC_MINORS
+@@ -74,22 +74,15 @@ static int dvb_device_open(struct inode *inode, struct file *file)
+ 
+ 	if (dvbdev && dvbdev->fops) {
+ 		int err = 0;
+-		const struct file_operations *old_fops;
++		const struct file_operations *new_fops;
+ 
+-		file->private_data = dvbdev;
+-		old_fops = file->f_op;
+-		file->f_op = fops_get(dvbdev->fops);
+-		if (file->f_op == NULL) {
+-			file->f_op = old_fops;
++		new_fops = fops_get(dvbdev->fops);
++		if (!new_fops)
+ 			goto fail;
+-		}
++		file->private_data = dvbdev;
++		replace_fops(file, new_fops);
+ 		if (file->f_op->open)
+ 			err = file->f_op->open(inode,file);
+-		if (err) {
+-			fops_put(file->f_op);
+-			file->f_op = fops_get(old_fops);
+-		}
+-		fops_put(old_fops);
+ 		up_read(&minor_rwsem);
+ 		mutex_unlock(&dvbdev_mutex);
+ 		return err;
+diff --git a/drivers/media/dvb-core/dvbdev.h b/drivers/media/dvb-core/dvbdev.h
+index d2bee9c..93a9470 100644
+--- a/drivers/media/dvb-core/dvbdev.h
++++ b/drivers/media/dvb-core/dvbdev.h
+@@ -47,7 +47,6 @@
+ #define DVB_DEVICE_CA         6
+ #define DVB_DEVICE_NET        7
+ #define DVB_DEVICE_OSD        8
+-#define DVB_DEVICE_DSC        9
+ 
+ #define DVB_DEFINE_MOD_OPT_ADAPTER_NR(adapter_nr) \
+ 	static short adapter_nr[] = \
+diff --git a/include/uapi/linux/dvb/aml_demod.h b/include/uapi/linux/dvb/aml_demod.h
+deleted file mode 100644
+index 96990a5..0000000
+--- a/include/uapi/linux/dvb/aml_demod.h
++++ /dev/null
+@@ -1,214 +0,0 @@
+-#ifndef AML_DEMOD_H
+-#define AML_DEMOD_H
+-#ifndef CONFIG_AM_DEMOD_FPGA_VER
+-#define CONFIG_AM_DEMOD_FPGA_VER
+-#endif				/*CONFIG_AM_DEMOD_FPGA_VER */
+-
+-/*#include <linux/types.h>*/
+-#define u8_t u8
+-#define u16_t u16
+-#define u32_t u32
+-#define u64_t u64
+-
+-struct aml_demod_i2c {
+-	u8_t tuner;		/*type */
+-	u8_t addr;		/*slave addr */
+-	u32_t scl_oe;
+-	u32_t scl_out;
+-	u32_t scl_in;
+-	u8_t scl_bit;
+-	u32_t sda_oe;
+-	u32_t sda_out;
+-	u32_t sda_in;
+-	u8_t sda_bit;
+-	u8_t udelay;		/*us */
+-	u8_t retries;
+-	u8_t debug;		/*1:debug */
+-	u8_t tmp;		/*spare */
+-	u8_t i2c_id;
+-	void *i2c_priv;
+-};
+-
+-struct aml_tuner_sys {
+-	u8_t mode;
+-	u8_t amp;
+-	u8_t if_agc_speed;
+-	u32_t ch_freq;
+-	u32_t if_freq;
+-	u32_t rssi;
+-	u32_t delay;
+-	u8_t bandwith;
+-};
+-
+-struct aml_demod_sys {
+-	u8_t clk_en;		/* 1:on */
+-	u8_t clk_src;		/*2 bits */
+-	u8_t clk_div;		/*7 bits */
+-	u8_t pll_n;		/*5 bits */
+-	u16_t pll_m;		/*9 bits */
+-	u8_t pll_od;		/*7 bits */
+-	u8_t pll_sys_xd;	/*5 bits */
+-	u8_t pll_adc_xd;	/*5 bits */
+-	u8_t agc_sel;		/*pin mux */
+-	u8_t adc_en;		/*1:on */
+-	u8_t debug;		/*1:debug */
+-	u32_t i2c;		/*pointer */
+-	u32_t adc_clk;
+-	u32_t demod_clk;
+-};
+-
+-struct aml_demod_sts {
+-	u32_t ch_sts;
+-	u32_t freq_off;		/*Hz */
+-	u32_t ch_pow;
+-	u32_t ch_snr;
+-	u32_t ch_ber;
+-	u32_t ch_per;
+-	u32_t symb_rate;
+-	u32_t dat0;
+-	u32_t dat1;
+-};
+-
+-struct aml_demod_sta {
+-	u8_t clk_en;		/*on/off */
+-	u8_t adc_en;		/*on/off */
+-	u32_t clk_freq;		/*kHz */
+-	u32_t adc_freq;		/*kHz */
+-	u8_t dvb_mode;		/*dvb-t/c mode */
+-	u8_t ch_mode;		/* 16,32,..,256QAM or 2K,4K,8K */
+-	u8_t agc_mode;		/*if, rf or both. */
+-	u8_t tuner;		/*type */
+-	u32_t ch_freq;		/*kHz */
+-	u16_t ch_if;		/*kHz */
+-	u16_t ch_bw;		/*kHz */
+-	u16_t symb_rate;	/*kHz */
+-	u8_t debug;
+-	u8_t tmp;
+-	u32_t sts;		/*pointer */
+-	u8_t spectrum;
+-};
+-
+-struct aml_demod_dvbc {
+-	u8_t mode;
+-	u8_t tmp;
+-	u16_t symb_rate;
+-	u32_t ch_freq;
+-	u32_t dat0;
+-	u32_t dat1;
+-};
+-
+-struct aml_demod_dvbt {
+-	u8_t bw;
+-	u8_t sr;
+-	u8_t ifreq;
+-	u8_t agc_mode;
+-	u32_t ch_freq;
+-	u32_t dat0;
+-	u32_t dat1;
+-	u32_t layer;
+-
+-};
+-
+-struct aml_demod_dtmb {
+-	u8_t bw;
+-	u8_t sr;
+-	u8_t ifreq;
+-	u8_t agc_mode;
+-	u32_t ch_freq;
+-	u32_t dat0;
+-	u32_t dat1;
+-	u32_t mode;
+-
+-};
+-
+-struct aml_demod_atsc {
+-	u8_t bw;
+-	u8_t sr;
+-	u8_t ifreq;
+-	u8_t agc_mode;
+-	u32_t ch_freq;
+-	u32_t dat0;
+-	u32_t dat1;
+-	u32_t mode;
+-
+-};
+-
+-struct aml_demod_mem {
+-	u32_t addr;
+-	u32_t dat;
+-
+-};
+-
+-struct aml_cap_data {
+-	u32_t cap_addr;
+-	u32_t cap_size;
+-	u32_t cap_afifo;
+-	char  *cap_dev_name;
+-};
+-
+-struct aml_demod_reg {
+-	u8_t mode;
+-	u8_t rw;		/* 0: read, 1: write. */
+-	u32_t addr;
+-	u32_t val;
+-/*	u32_t val_high;*/
+-};
+-
+-struct aml_demod_regs {
+-	u8_t mode;
+-	u8_t rw;		/* 0: read, 1: write. */
+-	u32_t addr;
+-	u32_t addr_len;
+-	u32_t n;
+-	u32_t vals[1];		/*[mode i2c]: write:n*u32_t, read:n*u8_t */
+-};
+-struct fpga_m1_sdio {
+-	unsigned long addr;
+-	unsigned long byte_count;
+-	unsigned char *data_buf;
+-};
+-
+-#define AML_DEMOD_SET_SYS        _IOW('D',  0, struct aml_demod_sys)
+-#define AML_DEMOD_GET_SYS        _IOR('D',  1, struct aml_demod_sys)
+-#define AML_DEMOD_TEST           _IOR('D',  2, u32_t)
+-#define AML_DEMOD_TURN_ON        _IOR('D',  3, u32_t)
+-#define AML_DEMOD_TURN_OFF       _IOR('D',  4, u32_t)
+-#define AML_DEMOD_SET_TUNER      _IOW('D',  5, struct aml_tuner_sys)
+-#define AML_DEMOD_GET_RSSI       _IOR('D',  6, struct aml_tuner_sys)
+-
+-#define AML_DEMOD_DVBC_SET_CH    _IOW('D', 10, struct aml_demod_dvbc)
+-#define AML_DEMOD_DVBC_GET_CH    _IOR('D', 11, struct aml_demod_dvbc)
+-#define AML_DEMOD_DVBC_TEST      _IOR('D', 12, u32_t)
+-
+-#define AML_DEMOD_DVBT_SET_CH    _IOW('D', 20, struct aml_demod_dvbt)
+-#define AML_DEMOD_DVBT_GET_CH    _IOR('D', 21, struct aml_demod_dvbt)
+-#define AML_DEMOD_DVBT_TEST      _IOR('D', 22, u32_t)
+-
+-#define AML_DEMOD_DTMB_SET_CH    _IOW('D', 50, struct aml_demod_dtmb)
+-#define AML_DEMOD_DTMB_GET_CH    _IOR('D', 51, struct aml_demod_dtmb)
+-#define AML_DEMOD_DTMB_TEST      _IOR('D', 52, u32_t)
+-
+-#define AML_DEMOD_ATSC_SET_CH    _IOW('D', 60, struct aml_demod_atsc)
+-#define AML_DEMOD_ATSC_GET_CH    _IOR('D', 61, struct aml_demod_atsc)
+-#define AML_DEMOD_ATSC_TEST      _IOR('D', 62, u32_t)
+-#define AML_DEMOD_ATSC_IRQ       _IOR('D', 63, u32_t)
+-
+-#define AML_DEMOD_RESET_MEM		  _IOR('D', 70, u32_t)
+-#define	AML_DEMOD_READ_MEM		  _IOR('D', 71, u32_t)
+-#define AML_DEMOD_SET_MEM		  _IOR('D', 72, struct aml_demod_mem)
+-
+-#define AML_DEMOD_SET_REG        _IOW('D', 30, struct aml_demod_reg)
+-#define AML_DEMOD_GET_REG        _IOR('D', 31, struct aml_demod_reg)
+-/* #define AML_DEMOD_SET_REGS        _IOW('D', 32, struct aml_demod_regs)*/
+-/*#define AML_DEMOD_GET_REGS        _IOR('D', 33, struct aml_demod_regs)*/
+-#define FPGA2M1_SDIO_WR_DDR      _IOW('D', 40, struct fpga_m1_sdio)
+-#define FPGA2M1_SDIO_RD_DDR      _IOR('D', 41, struct fpga_m1_sdio)
+-#define FPGA2M1_SDIO_INIT        _IO('D', 42)
+-#define FPGA2M1_SDIO_EXIT        _IO('D', 43)
+-
+-int read_memory_to_file(struct aml_cap_data *cap);
+-int read_reg(int addr);
+-void wait_capture(int cap_cur_addr, int depth_MB, int start);
+-int cap_adc_data(struct aml_cap_data *cap);
+-
+-#endif				/* AML_DEMOD_H */
+diff --git a/include/uapi/linux/dvb/dmx.h b/include/uapi/linux/dvb/dmx.h
+index 029400a..b4fb650 100644
+--- a/include/uapi/linux/dvb/dmx.h
++++ b/include/uapi/linux/dvb/dmx.h
+@@ -29,25 +29,30 @@
+ #include <time.h>
+ #endif
+ 
++
+ #define DMX_FILTER_SIZE 16
+ 
+-enum dmx_output_t {
+-	DMX_OUT_DECODER,	/* Streaming directly to decoder. */
+-	DMX_OUT_TAP,		/* Output going to a memory buffer */
+-	/* (to be retrieved via the read command). */
+-	DMX_OUT_TS_TAP,		/* Output multiplexed into a new TS  */
+-	/* (to be retrieved by reading from the */
+-	/* logical DVR device).                 */
+-	DMX_OUT_TSDEMUX_TAP	/* Like TS_TAP but retrieved */
+-	/*from the DMX device */
+-};
++typedef enum
++{
++	DMX_OUT_DECODER, /* Streaming directly to decoder. */
++	DMX_OUT_TAP,     /* Output going to a memory buffer */
++			 /* (to be retrieved via the read command).*/
++	DMX_OUT_TS_TAP,  /* Output multiplexed into a new TS  */
++			 /* (to be retrieved by reading from the */
++			 /* logical DVR device).                 */
++	DMX_OUT_TSDEMUX_TAP /* Like TS_TAP but retrieved from the DMX device */
++} dmx_output_t;
+ 
+-enum dmx_input_t {
+-	DMX_IN_FRONTEND,	/* Input from a front-end device.  */
+-	DMX_IN_DVR		/* Input from the logical DVR device.  */
+-};
+ 
+-enum dmx_ts_pes {
++typedef enum
++{
++	DMX_IN_FRONTEND, /* Input from a front-end device.  */
++	DMX_IN_DVR       /* Input from the logical DVR device.  */
++} dmx_input_t;
++
++
++typedef enum dmx_ts_pes
++{
+ 	DMX_PES_AUDIO0,
+ 	DMX_PES_VIDEO0,
+ 	DMX_PES_TELETEXT0,
+@@ -73,7 +78,7 @@ enum dmx_ts_pes {
+ 	DMX_PES_PCR3,
+ 
+ 	DMX_PES_OTHER
+-};
++} dmx_pes_type_t;
+ 
+ #define DMX_PES_AUDIO    DMX_PES_AUDIO0
+ #define DMX_PES_VIDEO    DMX_PES_VIDEO0
+@@ -81,31 +86,35 @@ enum dmx_ts_pes {
+ #define DMX_PES_SUBTITLE DMX_PES_SUBTITLE0
+ #define DMX_PES_PCR      DMX_PES_PCR0
+ 
+-struct dmx_filter {
+-	__u8 filter[DMX_FILTER_SIZE];
+-	__u8 mask[DMX_FILTER_SIZE];
+-	__u8 mode[DMX_FILTER_SIZE];
+-};
+ 
+-struct dmx_sct_filter_params {
+-	__u16 pid;
+-	struct dmx_filter filter;
+-	__u32 timeout;
+-	__u32 flags;
++typedef struct dmx_filter
++{
++	__u8  filter[DMX_FILTER_SIZE];
++	__u8  mask[DMX_FILTER_SIZE];
++	__u8  mode[DMX_FILTER_SIZE];
++} dmx_filter_t;
++
++
++struct dmx_sct_filter_params
++{
++	__u16          pid;
++	dmx_filter_t   filter;
++	__u32          timeout;
++	__u32          flags;
+ #define DMX_CHECK_CRC       1
+ #define DMX_ONESHOT         2
+ #define DMX_IMMEDIATE_START 4
+ #define DMX_KERNEL_CLIENT   0x8000
+-#define DMX_USE_SWFILTER    0x100
+-
+ };
+ 
+-struct dmx_pes_filter_params {
+-	__u16 pid;
+-	enum dmx_input_t input;
+-	enum dmx_output_t output;
+-	enum dmx_ts_pes pes_type;
+-	__u32 flags;
++
++struct dmx_pes_filter_params
++{
++	__u16          pid;
++	dmx_input_t    input;
++	dmx_output_t   output;
++	dmx_pes_type_t pes_type;
++	__u32          flags;
+ };
+ 
+ typedef struct dmx_caps {
+@@ -113,19 +122,16 @@ typedef struct dmx_caps {
+ 	int num_decoders;
+ } dmx_caps_t;
+ 
+-enum dmx_source_t {
++typedef enum {
+ 	DMX_SOURCE_FRONT0 = 0,
+ 	DMX_SOURCE_FRONT1,
+ 	DMX_SOURCE_FRONT2,
+ 	DMX_SOURCE_FRONT3,
+-	DMX_SOURCE_DVR0 = 16,
++	DMX_SOURCE_DVR0   = 16,
+ 	DMX_SOURCE_DVR1,
+ 	DMX_SOURCE_DVR2,
+-	DMX_SOURCE_DVR3,
+-	DMX_SOURCE_FRONT0_OFFSET = 100,
+-	DMX_SOURCE_FRONT1_OFFSET,
+-	DMX_SOURCE_FRONT2_OFFSET
+-};
++	DMX_SOURCE_DVR3
++} dmx_source_t;
+ 
+ struct dmx_stc {
+ 	unsigned int num;	/* input : which STC? 0..N */
+@@ -133,6 +139,7 @@ struct dmx_stc {
+ 	__u64 stc;		/* output: stc in 'base'*90 kHz units */
+ };
+ 
++
+ #define DMX_START                _IO('o', 41)
+ #define DMX_STOP                 _IO('o', 42)
+ #define DMX_SET_FILTER           _IOW('o', 43, struct dmx_sct_filter_params)
+@@ -140,7 +147,7 @@ struct dmx_stc {
+ #define DMX_SET_BUFFER_SIZE      _IO('o', 45)
+ #define DMX_GET_PES_PIDS         _IOR('o', 47, __u16[5])
+ #define DMX_GET_CAPS             _IOR('o', 48, dmx_caps_t)
+-#define DMX_SET_SOURCE           _IOW('o', 49, enum dmx_source_t)
++#define DMX_SET_SOURCE           _IOW('o', 49, dmx_source_t)
+ #define DMX_GET_STC              _IOWR('o', 50, struct dmx_stc)
+ #define DMX_ADD_PID              _IOW('o', 51, __u16)
+ #define DMX_REMOVE_PID           _IOW('o', 52, __u16)
+diff --git a/include/uapi/linux/dvb/frontend.h b/include/uapi/linux/dvb/frontend.h
+index 9f9e75b..c56d77c 100644
+--- a/include/uapi/linux/dvb/frontend.h
++++ b/include/uapi/linux/dvb/frontend.h
+@@ -27,115 +27,101 @@
+ #define _DVBFRONTEND_H_
+ 
+ #include <linux/types.h>
+-#include <linux/videodev2.h>
+ 
+ typedef enum fe_type {
+ 	FE_QPSK,
+ 	FE_QAM,
+ 	FE_OFDM,
+-	FE_ATSC,
+-	FE_ANALOG,
+-	FE_DTMB,
+-	FE_ISDBT
++	FE_ATSC
+ } fe_type_t;
+ 
+-enum fe_layer {
+-	Layer_A_B_C,
+-	Layer_A,
+-	Layer_B,
+-	Layer_C,
+-};
+ 
+-enum fe_caps {
+-	FE_IS_STUPID = 0,
+-	FE_CAN_INVERSION_AUTO = 0x1,
+-	FE_CAN_FEC_1_2 = 0x2,
+-	FE_CAN_FEC_2_3 = 0x4,
+-	FE_CAN_FEC_3_4 = 0x8,
+-	FE_CAN_FEC_4_5 = 0x10,
+-	FE_CAN_FEC_5_6 = 0x20,
+-	FE_CAN_FEC_6_7 = 0x40,
+-	FE_CAN_FEC_7_8 = 0x80,
+-	FE_CAN_FEC_8_9 = 0x100,
+-	FE_CAN_FEC_AUTO = 0x200,
+-	FE_CAN_QPSK = 0x400,
+-	FE_CAN_QAM_16 = 0x800,
+-	FE_CAN_QAM_32 = 0x1000,
+-	FE_CAN_QAM_64 = 0x2000,
+-	FE_CAN_QAM_128 = 0x4000,
+-	FE_CAN_QAM_256 = 0x8000,
+-	FE_CAN_QAM_AUTO = 0x10000,
+-	FE_CAN_TRANSMISSION_MODE_AUTO = 0x20000,
+-	FE_CAN_BANDWIDTH_AUTO = 0x40000,
+-	FE_CAN_GUARD_INTERVAL_AUTO = 0x80000,
+-	FE_CAN_HIERARCHY_AUTO = 0x100000,
+-	FE_CAN_8VSB = 0x200000,
+-	FE_CAN_16VSB = 0x400000,
+-	FE_HAS_EXTENDED_CAPS = 0x800000,	/* We need more bitspace for*/
+-						/* newer APIs, indicate this. */
+-	FE_CAN_MULTISTREAM = 0x4000000,	/* frontend supports */
+-					/*multistream filtering */
+-	FE_CAN_TURBO_FEC = 0x8000000,	/* frontend supports */
+-					/*"turbo fec modulation" */
+-	FE_CAN_2G_MODULATION = 0x10000000,	/* frontend supports */
+-				/*"2nd generation modulation" (DVB-S2) */
+-	FE_NEEDS_BENDING = 0x20000000,	/* not supported anymore, don't */
+-				/*use (frontend requires frequency bending) */
+-	FE_CAN_RECOVER = 0x40000000,	/* frontend can recover from */
+-					/*a cable unplug automatically */
+-	FE_CAN_MUTE_TS = 0x80000000	/* frontend can stop */
+-					/*spurious TS data output */
+-};
++typedef enum fe_caps {
++	FE_IS_STUPID			= 0,
++	FE_CAN_INVERSION_AUTO		= 0x1,
++	FE_CAN_FEC_1_2			= 0x2,
++	FE_CAN_FEC_2_3			= 0x4,
++	FE_CAN_FEC_3_4			= 0x8,
++	FE_CAN_FEC_4_5			= 0x10,
++	FE_CAN_FEC_5_6			= 0x20,
++	FE_CAN_FEC_6_7			= 0x40,
++	FE_CAN_FEC_7_8			= 0x80,
++	FE_CAN_FEC_8_9			= 0x100,
++	FE_CAN_FEC_AUTO			= 0x200,
++	FE_CAN_QPSK			= 0x400,
++	FE_CAN_QAM_16			= 0x800,
++	FE_CAN_QAM_32			= 0x1000,
++	FE_CAN_QAM_64			= 0x2000,
++	FE_CAN_QAM_128			= 0x4000,
++	FE_CAN_QAM_256			= 0x8000,
++	FE_CAN_QAM_AUTO			= 0x10000,
++	FE_CAN_TRANSMISSION_MODE_AUTO	= 0x20000,
++	FE_CAN_BANDWIDTH_AUTO		= 0x40000,
++	FE_CAN_GUARD_INTERVAL_AUTO	= 0x80000,
++	FE_CAN_HIERARCHY_AUTO		= 0x100000,
++	FE_CAN_8VSB			= 0x200000,
++	FE_CAN_16VSB			= 0x400000,
++	FE_HAS_EXTENDED_CAPS		= 0x800000,   /* We need more bitspace for newer APIs, indicate this. */
++	FE_CAN_MULTISTREAM		= 0x4000000,  /* frontend supports multistream filtering */
++	FE_CAN_TURBO_FEC		= 0x8000000,  /* frontend supports "turbo fec modulation" */
++	FE_CAN_2G_MODULATION		= 0x10000000, /* frontend supports "2nd generation modulation" (DVB-S2) */
++	FE_NEEDS_BENDING		= 0x20000000, /* not supported anymore, don't use (frontend requires frequency bending) */
++	FE_CAN_RECOVER			= 0x40000000, /* frontend can recover from a cable unplug automatically */
++	FE_CAN_MUTE_TS			= 0x80000000  /* frontend can stop spurious TS data output */
++} fe_caps_t;
+ 
+-#define FE_CAN_3_LAYER FE_CAN_MULTISTREAM
+ 
+ struct dvb_frontend_info {
+-	char name[128];
+-	/* DEPRECATED. Use DTV_ENUM_DELSYS instead */
+-	enum fe_type type;
+-	__u32 frequency_min;
+-	__u32 frequency_max;
+-	__u32 frequency_stepsize;
+-	__u32 frequency_tolerance;
+-	__u32 symbol_rate_min;
+-	__u32 symbol_rate_max;
+-	__u32 symbol_rate_tolerance;	/* ppm */
+-	__u32 notifier_delay;	/* DEPRECATED */
+-	enum fe_caps caps;
++	char       name[128];
++	fe_type_t  type;			/* DEPRECATED. Use DTV_ENUM_DELSYS instead */
++	__u32      frequency_min;
++	__u32      frequency_max;
++	__u32      frequency_stepsize;
++	__u32      frequency_tolerance;
++	__u32      symbol_rate_min;
++	__u32      symbol_rate_max;
++	__u32      symbol_rate_tolerance;	/* ppm */
++	__u32      notifier_delay;		/* DEPRECATED */
++	fe_caps_t  caps;
+ };
+ 
++
+ /**
+  *  Check out the DiSEqC bus spec available on http://www.eutelsat.org/ for
+  *  the meaning of this struct...
+  */
+ struct dvb_diseqc_master_cmd {
+-	__u8 msg[6];		/*  { framing, address, command, data [3] } */
+-	__u8 msg_len;		/*  valid values are 3...6  */
++	__u8 msg [6];	/*  { framing, address, command, data [3] } */
++	__u8 msg_len;	/*  valid values are 3...6  */
+ };
+ 
++
+ struct dvb_diseqc_slave_reply {
+-	__u8 msg[4];		/*  { framing, data [3] } */
+-	__u8 msg_len;		/*  valid values are 0...4, 0 means no msg  */
+-	int timeout;		/*  return from ioctl after timeout ms with */
+-};				/*  errorcode when no message was received  */
++	__u8 msg [4];	/*  { framing, data [3] } */
++	__u8 msg_len;	/*  valid values are 0...4, 0 means no msg  */
++	int  timeout;	/*  return from ioctl after timeout ms with */
++};			/*  errorcode when no message was received  */
++
+ 
+ typedef enum fe_sec_voltage {
+ 	SEC_VOLTAGE_13,
+ 	SEC_VOLTAGE_18,
+-	SEC_VOLTAGE_OFF,
+-	SEC_VOLTAGE_ON		/*for ISDBT antenna control */
++	SEC_VOLTAGE_OFF
+ } fe_sec_voltage_t;
+ 
++
+ typedef enum fe_sec_tone_mode {
+ 	SEC_TONE_ON,
+ 	SEC_TONE_OFF
+ } fe_sec_tone_mode_t;
+ 
++
+ typedef enum fe_sec_mini_cmd {
+ 	SEC_MINI_A,
+ 	SEC_MINI_B
+ } fe_sec_mini_cmd_t;
+ 
++
+ /**
+  * enum fe_status - enumerates the possible frontend status
+  * @FE_HAS_SIGNAL:	found something above the noise level
+@@ -149,15 +135,14 @@ typedef enum fe_sec_mini_cmd {
+  */
+ 
+ typedef enum fe_status {
+-	FE_HAS_SIGNAL = 0x01,	/* found something above the noise level */
+-	FE_HAS_CARRIER = 0x02,	/* found a DVB signal  */
+-	FE_HAS_VITERBI = 0x04,	/* FEC is stable  */
+-	FE_HAS_SYNC = 0x08,	/* found sync bytes  */
+-	FE_HAS_LOCK = 0x10,	/* everything's working... */
+-	FE_TIMEDOUT = 0x20,	/* no lock within the last ~2 seconds */
+-	FE_REINIT = 0x40	/* frontend was reinitialized,  */
+-} fe_status_t;			/* application is recommended to reset */
+-				  /* DiSEqC, tone and parameters */
++	FE_HAS_SIGNAL		= 0x01,
++	FE_HAS_CARRIER		= 0x02,
++	FE_HAS_VITERBI		= 0x04,
++	FE_HAS_SYNC		= 0x08,
++	FE_HAS_LOCK		= 0x10,
++	FE_TIMEDOUT		= 0x20,
++	FE_REINIT		= 0x40,
++} fe_status_t;
+ 
+ typedef enum fe_spectral_inversion {
+ 	INVERSION_OFF,
+@@ -165,6 +150,7 @@ typedef enum fe_spectral_inversion {
+ 	INVERSION_AUTO
+ } fe_spectral_inversion_t;
+ 
++
+ typedef enum fe_code_rate {
+ 	FEC_NONE = 0,
+ 	FEC_1_2,
+@@ -181,6 +167,7 @@ typedef enum fe_code_rate {
+ 	FEC_2_5,
+ } fe_code_rate_t;
+ 
++
+ typedef enum fe_modulation {
+ 	QPSK,
+ 	QAM_16,
+@@ -210,8 +197,8 @@ typedef enum fe_transmit_mode {
+ 	TRANSMISSION_MODE_C3780,
+ } fe_transmit_mode_t;
+ 
+-/*#if defined(__DVB_CORE__) || !defined (__KERNEL__)*/
+-enum fe_bandwidth {
++#if defined(__DVB_CORE__) || !defined (__KERNEL__)
++typedef enum fe_bandwidth {
+ 	BANDWIDTH_8_MHZ,
+ 	BANDWIDTH_7_MHZ,
+ 	BANDWIDTH_6_MHZ,
+@@ -219,8 +206,8 @@ enum fe_bandwidth {
+ 	BANDWIDTH_5_MHZ,
+ 	BANDWIDTH_10_MHZ,
+ 	BANDWIDTH_1_712_MHZ,
+-};
+-/*#endif*/
++} fe_bandwidth_t;
++#endif
+ 
+ typedef enum fe_guard_interval {
+ 	GUARD_INTERVAL_1_32,
+@@ -236,6 +223,7 @@ typedef enum fe_guard_interval {
+ 	GUARD_INTERVAL_PN945,
+ } fe_guard_interval_t;
+ 
++
+ typedef enum fe_hierarchy {
+ 	HIERARCHY_NONE,
+ 	HIERARCHY_1,
+@@ -251,70 +239,42 @@ enum fe_interleaving {
+ 	INTERLEAVING_720,
+ };
+ 
+-enum fe_ofdm_mode {
+-	OFDM_DVBT,
+-	OFDM_DVBT2,
+-};
+-
+-/*#if defined(__DVB_CORE__) || !defined (__KERNEL__)*/
++#if defined(__DVB_CORE__) || !defined (__KERNEL__)
+ struct dvb_qpsk_parameters {
+-	__u32 symbol_rate;	/* symbol rate in Symbols per second */
+-	/* forward error correction (see above) */
+-	enum fe_code_rate fec_inner;
++	__u32		symbol_rate;  /* symbol rate in Symbols per second */
++	fe_code_rate_t	fec_inner;    /* forward error correction (see above) */
+ };
+ 
+ struct dvb_qam_parameters {
+-	/* symbol rate in Symbols per second */
+-	__u32 symbol_rate;
+-	/* forward error correction (see above) */
+-	enum fe_code_rate fec_inner;
+-	/* modulation type (see above) */
+-	enum fe_modulation modulation;
++	__u32		symbol_rate; /* symbol rate in Symbols per second */
++	fe_code_rate_t	fec_inner;   /* forward error correction (see above) */
++	fe_modulation_t	modulation;  /* modulation type (see above) */
+ };
+ 
+ struct dvb_vsb_parameters {
+-	enum fe_modulation modulation;	/* modulation type (see above) */
++	fe_modulation_t	modulation;  /* modulation type (see above) */
+ };
+ 
+ struct dvb_ofdm_parameters {
+-	enum fe_bandwidth bandwidth;
+-	/* high priority stream code rate */
+-	enum fe_code_rate code_rate_HP;
+-	/* low priority stream code rate */
+-	enum fe_code_rate code_rate_LP;
+-	/* modulation type (see above) */
+-	enum fe_modulation constellation;
+-	enum fe_transmit_mode transmission_mode;
+-	enum fe_guard_interval guard_interval;
+-	enum fe_hierarchy hierarchy_information;
+-	enum fe_ofdm_mode ofdm_mode;
++	fe_bandwidth_t      bandwidth;
++	fe_code_rate_t      code_rate_HP;  /* high priority stream code rate */
++	fe_code_rate_t      code_rate_LP;  /* low priority stream code rate */
++	fe_modulation_t     constellation; /* modulation type (see above) */
++	fe_transmit_mode_t  transmission_mode;
++	fe_guard_interval_t guard_interval;
++	fe_hierarchy_t      hierarchy_information;
+ };
+ 
+-#define ANALOG_FLAG_ENABLE_AFC                 0X00000001
+-#define  ANALOG_FLAG_MANUL_SCAN                0x00000011
+-struct dvb_analog_parameters {
+-	/*V4L2_TUNER_MODE_MONO,V4L2_TUNER_MODE_STEREO,
+-	   V4L2_TUNER_MODE_LANG2,V4L2_TUNER_MODE_SAP,
+-	   V4L2_TUNER_MODE_LANG1,V4L2_TUNER_MODE_LANG1_LANG2 */
+-	unsigned int audmode;
+-	unsigned int soundsys;	/*A2,BTSC,EIAJ,NICAM */
+-	v4l2_std_id std;
+-	unsigned int flag;
+-	unsigned int afc_range;
+-	unsigned int reserved;
+-};
+ 
+ struct dvb_frontend_parameters {
+-	/* (absolute) frequency in Hz for QAM/OFDM/ATSC */
+-	__u32 frequency;
+-	/* intermediate frequency in kHz for QPSK */
++	__u32 frequency;     /* (absolute) frequency in Hz for QAM/OFDM/ATSC */
++			     /* intermediate frequency in kHz for QPSK */
+ 	fe_spectral_inversion_t inversion;
+ 	union {
+ 		struct dvb_qpsk_parameters qpsk;
+-		struct dvb_qam_parameters qam;
++		struct dvb_qam_parameters  qam;
+ 		struct dvb_ofdm_parameters ofdm;
+ 		struct dvb_vsb_parameters vsb;
+-		struct dvb_analog_parameters analog;
+ 	} u;
+ };
+ 
+@@ -322,7 +282,7 @@ struct dvb_frontend_event {
+ 	fe_status_t status;
+ 	struct dvb_frontend_parameters parameters;
+ };
+-/*#endif*/
++#endif
+ 
+ /* S2API Commands */
+ #define DTV_UNDEFINED		0
+@@ -385,8 +345,6 @@ struct dvb_frontend_event {
+ 
+ #define DTV_ENUM_DELSYS		44
+ 
+-#define DTV_DVBT2_PLP_ID    DTV_DVBT2_PLP_ID_LEGACY
+-
+ /* ATSC-MH */
+ #define DTV_ATSCMH_FIC_VER		45
+ #define DTV_ATSCMH_PARADE_ID		46
+@@ -417,9 +375,7 @@ struct dvb_frontend_event {
+ #define DTV_STAT_ERROR_BLOCK_COUNT	68
+ #define DTV_STAT_TOTAL_BLOCK_COUNT	69
+ 
+-#define DTV_DVBT2_DATA_PLPS	70
+-
+-#define DTV_MAX_COMMAND	DTV_DVBT2_DATA_PLPS
++#define DTV_MAX_COMMAND		DTV_STAT_TOTAL_BLOCK_COUNT
+ 
+ typedef enum fe_pilot {
+ 	PILOT_ON,
+@@ -428,7 +384,7 @@ typedef enum fe_pilot {
+ } fe_pilot_t;
+ 
+ typedef enum fe_rolloff {
+-	ROLLOFF_35,		/* Implied value in DVB-S, default for DVB-S2 */
++	ROLLOFF_35, /* Implied value in DVB-S, default for DVB-S2 */
+ 	ROLLOFF_20,
+ 	ROLLOFF_25,
+ 	ROLLOFF_AUTO,
+@@ -452,59 +408,58 @@ typedef enum fe_delivery_system {
+ 	SYS_CMMB,
+ 	SYS_DAB,
+ 	SYS_DVBT2,
+-	SYS_ANALOG,
+ 	SYS_TURBO,
+-	SYS_DVBC_ANNEX_C
++	SYS_DVBC_ANNEX_C,
+ } fe_delivery_system_t;
+ 
+ /* backward compatibility */
+ #define SYS_DVBC_ANNEX_AC	SYS_DVBC_ANNEX_A
+-#define SYS_DMBTH SYS_DTMB	/* DMB-TH is legacy name, use DTMB instead */
++#define SYS_DMBTH SYS_DTMB /* DMB-TH is legacy name, use DTMB instead */
+ 
+ /* ATSC-MH */
+ 
+ enum atscmh_sccc_block_mode {
+-	ATSCMH_SCCC_BLK_SEP = 0,
+-	ATSCMH_SCCC_BLK_COMB = 1,
+-	ATSCMH_SCCC_BLK_RES = 2,
++	ATSCMH_SCCC_BLK_SEP      = 0,
++	ATSCMH_SCCC_BLK_COMB     = 1,
++	ATSCMH_SCCC_BLK_RES      = 2,
+ };
+ 
+ enum atscmh_sccc_code_mode {
+-	ATSCMH_SCCC_CODE_HLF = 0,
+-	ATSCMH_SCCC_CODE_QTR = 1,
+-	ATSCMH_SCCC_CODE_RES = 2,
++	ATSCMH_SCCC_CODE_HLF     = 0,
++	ATSCMH_SCCC_CODE_QTR     = 1,
++	ATSCMH_SCCC_CODE_RES     = 2,
+ };
+ 
+ enum atscmh_rs_frame_ensemble {
+-	ATSCMH_RSFRAME_ENS_PRI = 0,
+-	ATSCMH_RSFRAME_ENS_SEC = 1,
++	ATSCMH_RSFRAME_ENS_PRI   = 0,
++	ATSCMH_RSFRAME_ENS_SEC   = 1,
+ };
+ 
+ enum atscmh_rs_frame_mode {
+-	ATSCMH_RSFRAME_PRI_ONLY = 0,
+-	ATSCMH_RSFRAME_PRI_SEC = 1,
+-	ATSCMH_RSFRAME_RES = 2,
++	ATSCMH_RSFRAME_PRI_ONLY  = 0,
++	ATSCMH_RSFRAME_PRI_SEC   = 1,
++	ATSCMH_RSFRAME_RES       = 2,
+ };
+ 
+ enum atscmh_rs_code_mode {
+-	ATSCMH_RSCODE_211_187 = 0,
+-	ATSCMH_RSCODE_223_187 = 1,
+-	ATSCMH_RSCODE_235_187 = 2,
+-	ATSCMH_RSCODE_RES = 3,
++	ATSCMH_RSCODE_211_187    = 0,
++	ATSCMH_RSCODE_223_187    = 1,
++	ATSCMH_RSCODE_235_187    = 2,
++	ATSCMH_RSCODE_RES        = 3,
+ };
+ 
+ #define NO_STREAM_ID_FILTER	(~0U)
+ #define LNA_AUTO                (~0U)
+ 
+ struct dtv_cmds_h {
+-	char *name;		/* A display name for debugging purposes */
++	char	*name;		/* A display name for debugging purposes */
+ 
+-	__u32 cmd;		/* A unique ID */
++	__u32	cmd;		/* A unique ID */
+ 
+ 	/* Flags */
+-	__u32 set:1;		/* Either a set or get property */
+-	__u32 buffer:1;		/* Does this property use the buffer? */
+-	__u32 reserved:30;	/* Align */
++	__u32	set:1;		/* Either a set or get property */
++	__u32	buffer:1;	/* Does this property use the buffer? */
++	__u32	reserved:30;	/* Align */
+ };
+ 
+ /**
+@@ -558,13 +513,14 @@ enum fecap_scale_params {
+  *	u.st.len = 4;
+  */
+ struct dtv_stats {
+-	__u8 scale;		/* enum fecap_scale_params type */
++	__u8 scale;	/* enum fecap_scale_params type */
+ 	union {
+ 		__u64 uvalue;	/* for counters and relative scales */
+ 		__s64 svalue;	/* for 0.0001 dB measures */
+ 	};
+ } __attribute__ ((packed));
+ 
++
+ #define MAX_DTV_STATS   4
+ 
+ struct dtv_fe_stats {
+@@ -584,7 +540,6 @@ struct dtv_property {
+ 			__u32 reserved1[3];
+ 			void *reserved2;
+ 		} buffer;
+-		__u32 reserved[14];
+ 	} u;
+ 	int result;
+ } __attribute__ ((packed));
+@@ -594,113 +549,12 @@ struct dtv_property {
+ 
+ struct dtv_properties {
+ 	__u32 num;
+-	union {
+-		struct dtv_property *props;
+-		__u64 reserved;
+-	};
+-};
+-/* for atv */
+-struct tuner_status_s {
+-	unsigned int frequency;
+-	unsigned int rssi;
+-	unsigned char mode;	/*dtv:0 or atv:1 */
+-	unsigned char tuner_locked;	/*notlocked:0,locked:1 */
+-	union {
+-		void *ressrved;
+-		__u64 reserved1;
+-	};
+-};
+-
+-struct atv_status_s {
+-	unsigned char atv_lock;	/*notlocked:0,locked 1 */
+-	v4l2_std_id std;
+-	unsigned int audmode;
+-	int snr;
+-	int afc;
+-	union {
+-		void *resrvred;
+-		__u64 reserved1;
+-	};
+-};
+-
+-struct sound_status_s {
+-	/*A2DK/A2BG/NICAM BG/NICAM DK/BTSC/EIAJ */
+-	unsigned short sound_sys;
+-	unsigned short sound_mode;	/*SETERO/DUAL/MONO/SAP */
+-	union {
+-		void *resrvred;
+-		__u64 reserved1;
+-	};
+-};
+-enum tuner_param_cmd_e {
+-	TUNER_CMD_AUDIO_MUTE = 0x0000,
+-	/*0x0001 */
+-	TUNER_CMD_AUDIO_ON,
+-	TUNER_CMD_TUNER_POWER_ON,
+-	TUNER_CMD_TUNER_POWER_DOWN,
+-	TUNER_CMD_SET_VOLUME,
+-	TUNER_CMD_SET_LEAP_SETP_SIZE,
+-	TUNER_CMD_GET_MONO_MODE,
+-	TUNER_CMD_SET_BEST_LOCK_RANGE,
+-	TUNER_CMD_GET_BEST_LOCK_RANGE,
+-	TUNER_CMD_SET_CVBS_AMP_OUT,
+-	TUNER_CMD_GET_CVBS_AMP_OUT,
+-	TUNER_CMD_NULL,
+-};
+-/*parameter for set param box*/
+-struct tuner_param_s {
+-	enum tuner_param_cmd_e cmd;
+-	unsigned int parm;
+-	unsigned int resvred;
++	struct dtv_property *props;
+ };
+ 
+ #define FE_SET_PROPERTY		   _IOW('o', 82, struct dtv_properties)
+ #define FE_GET_PROPERTY		   _IOR('o', 83, struct dtv_properties)
+ 
+-/* Satellite blind scan settings */
+-struct dvbsx_blindscanpara {
+-	/* minimum tuner frequency in kHz */
+-	__u32 minfrequency;
+-	/* maximum tuner frequency in kHz */
+-	__u32 maxfrequency;
+-	/* minimum symbol rate in sym/sec */
+-	__u32 minSymbolRate;
+-	/* maximum symbol rate in sym/sec */
+-	__u32 maxSymbolRate;
+-	/* search range in kHz. freq -/+freqRange will be searched */
+-	__u32 frequencyRange;
+-	/* tuner step frequency in kHz */
+-	__u32 frequencyStep;
+-	/* blindscan event timeout */
+-	__s32 timeout;
+-};
+-
+-/* Satellite blind scan status */
+-enum dvbsx_blindscanstatus {
+-	BLINDSCAN_NONEDO,
+-	BLINDSCAN_UPDATESTARTFREQ,
+-	BLINDSCAN_UPDATEPROCESS,
+-	BLINDSCAN_UPDATERESULTFREQ
+-};
+-
+-/* Satellite blind scan event */
+-struct dvbsx_blindscanevent {
+-	enum dvbsx_blindscanstatus status;
+-	union {
+-		__u16 m_uiprogress;
+-		/* The percentage completion of the blind scan procedure.
+-		   A value of 100 indicates that the blind scan is finished. */
+-		__u32 m_uistartfreq_khz;
+-		/* The start scan frequency in units of kHz.
+-		   The minimum value depends on the tuner specification. */
+-		struct dvb_frontend_parameters parameters;
+-		/* Blind scan channel info. */
+-	} u;
+-};
+-
+-#define FE_SET_BLINDSCAN	_IOW('o', 84, struct dvbsx_blindscanpara)
+-#define FE_GET_BLINDSCANEVENT	_IOR('o', 85, struct dvbsx_blindscanevent)
+-#define FE_SET_BLINDSCANCANCEl	_IO('o', 86)
+ 
+ /**
+  * When set, this flag will disable any zigzagging or other "normal" tuning
+@@ -711,38 +565,29 @@ struct dvbsx_blindscanevent {
+  */
+ #define FE_TUNE_MODE_ONESHOT 0x01
+ 
++
+ #define FE_GET_INFO		   _IOR('o', 61, struct dvb_frontend_info)
+ 
+ #define FE_DISEQC_RESET_OVERLOAD   _IO('o', 62)
+ #define FE_DISEQC_SEND_MASTER_CMD  _IOW('o', 63, struct dvb_diseqc_master_cmd)
+ #define FE_DISEQC_RECV_SLAVE_REPLY _IOR('o', 64, struct dvb_diseqc_slave_reply)
+-#define FE_DISEQC_SEND_BURST       _IO('o', 65)	/* fe_sec_mini_cmd_t */
++#define FE_DISEQC_SEND_BURST       _IO('o', 65)  /* fe_sec_mini_cmd_t */
+ 
+-#define FE_SET_TONE		   _IO('o', 66)	/* fe_sec_tone_mode_t */
+-#define FE_SET_VOLTAGE		   _IO('o', 67)	/* fe_sec_voltage_t */
+-#define FE_ENABLE_HIGH_LNB_VOLTAGE _IO('o', 68)	/* int */
++#define FE_SET_TONE		   _IO('o', 66)  /* fe_sec_tone_mode_t */
++#define FE_SET_VOLTAGE		   _IO('o', 67)  /* fe_sec_voltage_t */
++#define FE_ENABLE_HIGH_LNB_VOLTAGE _IO('o', 68)  /* int */
+ 
+ #define FE_READ_STATUS		   _IOR('o', 69, fe_status_t)
+ #define FE_READ_BER		   _IOR('o', 70, __u32)
+ #define FE_READ_SIGNAL_STRENGTH    _IOR('o', 71, __u16)
+ #define FE_READ_SNR		   _IOR('o', 72, __u16)
+ #define FE_READ_UNCORRECTED_BLOCKS _IOR('o', 73, __u32)
++
+ #define FE_SET_FRONTEND		   _IOW('o', 76, struct dvb_frontend_parameters)
+ #define FE_GET_FRONTEND		   _IOR('o', 77, struct dvb_frontend_parameters)
+-#define FE_SET_FRONTEND_TUNE_MODE  _IO('o', 81)	/* unsigned int */
++#define FE_SET_FRONTEND_TUNE_MODE  _IO('o', 81) /* unsigned int */
+ #define FE_GET_EVENT		   _IOR('o', 78, struct dvb_frontend_event)
+ 
+-#define FE_DISHNETWORK_SEND_LEGACY_CMD _IO('o', 80)	/* unsigned int */
+-
+-#define FE_SET_DELAY               _IO('o', 100)
++#define FE_DISHNETWORK_SEND_LEGACY_CMD _IO('o', 80) /* unsigned int */
+ 
+-#define FE_SET_MODE                _IO('o', 90)
+-#define FE_READ_AFC                _IOR('o', 91, __u32)
+-#define FE_FINE_TUNE               _IOW('o', 92, __u32)
+-#define FE_READ_TUNER_STATUS       _IOR('o', 93, struct tuner_status_s)
+-#define FE_READ_ANALOG_STATUS      _IOR('o', 94, struct atv_status_s)
+-#define FE_READ_SD_STATUS          _IOR('o', 95, struct sound_status_s)
+-#define FE_READ_TS                 _IOR('o', 96, int)
+-/*set & get the tuner parameters only atv*/
+-#define FE_SET_PARAM_BOX           _IOWR('o', 97, struct tuner_param_s)
+ #endif /*_DVBFRONTEND_H_*/

--- a/projects/WeTek_Hub/patches/linux/revert_default_dvb_core.patch
+++ b/projects/WeTek_Hub/patches/linux/revert_default_dvb_core.patch
@@ -1,0 +1,3024 @@
+diff --git a/drivers/media/dvb-core/demux.h b/drivers/media/dvb-core/demux.h
+index db46a78..833191bc 100644
+--- a/drivers/media/dvb-core/demux.h
++++ b/drivers/media/dvb-core/demux.h
+@@ -83,46 +83,6 @@ enum dmx_success {
+ #define TS_DEMUX        8   /* in case TS_PACKET is set, send the TS to
+ 			       the demux device, not to the dvr device */
+ 
+-/* PES type for filters which write to built-in decoder */
+-/* these should be kept identical to the types in dmx.h */
+-
+-enum dmx_ts_pes_e {
+-	/* also send packets to decoder (if it exists) */
+-	DMX_TS_PES_AUDIO0,
+-	DMX_TS_PES_VIDEO0,
+-	DMX_TS_PES_TELETEXT0,
+-	DMX_TS_PES_SUBTITLE0,
+-	DMX_TS_PES_PCR0,
+-
+-	DMX_TS_PES_AUDIO1,
+-	DMX_TS_PES_VIDEO1,
+-	DMX_TS_PES_TELETEXT1,
+-	DMX_TS_PES_SUBTITLE1,
+-	DMX_TS_PES_PCR1,
+-
+-	DMX_TS_PES_AUDIO2,
+-	DMX_TS_PES_VIDEO2,
+-	DMX_TS_PES_TELETEXT2,
+-	DMX_TS_PES_SUBTITLE2,
+-	DMX_TS_PES_PCR2,
+-
+-	DMX_TS_PES_AUDIO3,
+-	DMX_TS_PES_VIDEO3,
+-	DMX_TS_PES_TELETEXT3,
+-	DMX_TS_PES_SUBTITLE3,
+-	DMX_TS_PES_PCR3,
+-
+-	DMX_TS_PES_OTHER
+-};
+-
+-
+-#define DMX_TS_PES_AUDIO    DMX_TS_PES_AUDIO0
+-#define DMX_TS_PES_VIDEO    DMX_TS_PES_VIDEO0
+-#define DMX_TS_PES_TELETEXT DMX_TS_PES_TELETEXT0
+-#define DMX_TS_PES_SUBTITLE DMX_TS_PES_SUBTITLE0
+-#define DMX_TS_PES_PCR      DMX_TS_PES_PCR0
+-
+-
+ struct dmx_ts_feed {
+ 	int is_filtering; /* Set to non-zero when filtering in progress */
+ 	struct dmx_demux *parent; /* Back-pointer */
+@@ -246,37 +206,35 @@ struct dmx_demux {
+ 	u32 capabilities;            /* Bitfield of capability flags */
+ 	struct dmx_frontend* frontend;    /* Front-end connected to the demux */
+ 	void* priv;                  /* Pointer to private data of the API client */
+-	int (*open)(struct dmx_demux *demux);
+-	int (*close)(struct dmx_demux *demux);
+-	int (*write)(struct dmx_demux *demux,
+-					const char __user *buf, size_t count);
+-	int (*allocate_ts_feed)(struct dmx_demux *demux,
+-				 struct dmx_ts_feed **feed,
++	int (*open) (struct dmx_demux* demux);
++	int (*close) (struct dmx_demux* demux);
++	int (*write) (struct dmx_demux* demux, const char __user *buf, size_t count);
++	int (*allocate_ts_feed) (struct dmx_demux* demux,
++				 struct dmx_ts_feed** feed,
+ 				 dmx_ts_cb callback);
+-	int (*release_ts_feed)(struct dmx_demux *demux,
++	int (*release_ts_feed) (struct dmx_demux* demux,
+ 				struct dmx_ts_feed* feed);
+-	int (*allocate_section_feed)(struct dmx_demux *demux,
+-				      struct dmx_section_feed **feed,
++	int (*allocate_section_feed) (struct dmx_demux* demux,
++				      struct dmx_section_feed** feed,
+ 				      dmx_section_cb callback);
+-	int (*release_section_feed)(struct dmx_demux *demux,
+-				     struct dmx_section_feed *feed);
+-	int (*add_frontend)(struct dmx_demux *demux,
+-			     struct dmx_frontend *frontend);
+-	int (*remove_frontend)(struct dmx_demux *demux,
+-				struct dmx_frontend *frontend);
+-	struct list_head* (*get_frontends)(struct dmx_demux *demux);
+-	int (*connect_frontend)(struct dmx_demux *demux,
+-				 struct dmx_frontend *frontend);
+-	int (*disconnect_frontend)(struct dmx_demux *demux);
++	int (*release_section_feed) (struct dmx_demux* demux,
++				     struct dmx_section_feed* feed);
++	int (*add_frontend) (struct dmx_demux* demux,
++			     struct dmx_frontend* frontend);
++	int (*remove_frontend) (struct dmx_demux* demux,
++				struct dmx_frontend* frontend);
++	struct list_head* (*get_frontends) (struct dmx_demux* demux);
++	int (*connect_frontend) (struct dmx_demux* demux,
++				 struct dmx_frontend* frontend);
++	int (*disconnect_frontend) (struct dmx_demux* demux);
+ 
+-	int (*get_pes_pids)(struct dmx_demux *demux, u16 *pids);
++	int (*get_pes_pids) (struct dmx_demux* demux, u16 *pids);
+ 
+-	int (*get_caps)(struct dmx_demux *demux, struct dmx_caps *caps);
++	int (*get_caps) (struct dmx_demux* demux, struct dmx_caps *caps);
+ 
+-	int (*set_source)(struct dmx_demux *demux,
+-				const enum dmx_source_t *src);
++	int (*set_source) (struct dmx_demux* demux, const dmx_source_t *src);
+ 
+-	int (*get_stc)(struct dmx_demux *demux, unsigned int num,
++	int (*get_stc) (struct dmx_demux* demux, unsigned int num,
+ 			u64 *stc, unsigned int *base);
+ };
+ 
+diff --git a/drivers/media/dvb-core/dmxdev.c b/drivers/media/dvb-core/dmxdev.c
+index 8959f71..c0363f1 100644
+--- a/drivers/media/dvb-core/dmxdev.c
++++ b/drivers/media/dvb-core/dmxdev.c
+@@ -51,7 +51,6 @@ static int dvb_dmxdev_buffer_write(struct dvb_ringbuffer *buf,
+ 	free = dvb_ringbuffer_free(buf);
+ 	if (len > free) {
+ 		dprintk("dmxdev: buffer overflow\n");
+-		pr_err("dmxdev: buffer overflow, bs=%zd\n", buf->size);
+ 		return -EOVERFLOW;
+ 	}
+ 
+@@ -207,8 +206,6 @@ static int dvb_dvr_release(struct inode *inode, struct file *file)
+ 	/* TODO */
+ 	dvbdev->users--;
+ 	if (dvbdev->users == 1 && dmxdev->exit == 1) {
+-		fops_put(file->f_op);
+-		file->f_op = NULL;
+ 		mutex_unlock(&dmxdev->mutex);
+ 		wake_up(&dvbdev->wait_queue);
+ 	} else
+@@ -563,7 +560,7 @@ static int dvb_dmxdev_start_feed(struct dmxdev *dmxdev,
+ {
+ 	struct timespec timeout = { 0 };
+ 	struct dmx_pes_filter_params *para = &filter->params.pes;
+-	enum dmx_output_t otype;
++	dmx_output_t otype;
+ 	int ret;
+ 	int ts_type;
+ 	enum dmx_ts_pes ts_pes;
+@@ -788,7 +785,7 @@ static int dvb_dmxdev_filter_free(struct dmxdev *dmxdev,
+ 	return 0;
+ }
+ 
+-static inline void invert_mode(struct dmx_filter *filter)
++static inline void invert_mode(dmx_filter_t *filter)
+ {
+ 	int i;
+ 
+@@ -1121,8 +1118,6 @@ static int dvb_demux_release(struct inode *inode, struct file *file)
+ 	mutex_lock(&dmxdev->mutex);
+ 	dmxdev->dvbdev->users--;
+ 	if(dmxdev->dvbdev->users==1 && dmxdev->exit==1) {
+-		fops_put(file->f_op);
+-		file->f_op = NULL;
+ 		mutex_unlock(&dmxdev->mutex);
+ 		wake_up(&dmxdev->dvbdev->wait_queue);
+ 	} else
+@@ -1131,17 +1126,6 @@ static int dvb_demux_release(struct inode *inode, struct file *file)
+ 	return ret;
+ }
+ 
+-#ifdef CONFIG_COMPAT
+-static long dvb_demux_compat_ioctl(struct file *filp,
+-			unsigned int cmd, unsigned long args)
+-{
+-	unsigned long ret;
+-	args = (unsigned long)compat_ptr(args);
+-	ret = dvb_demux_ioctl(filp, cmd, args);
+-	return ret;
+-}
+-#endif
+-
+ static const struct file_operations dvb_demux_fops = {
+ 	.owner = THIS_MODULE,
+ 	.read = dvb_demux_read,
+@@ -1150,9 +1134,6 @@ static const struct file_operations dvb_demux_fops = {
+ 	.release = dvb_demux_release,
+ 	.poll = dvb_demux_poll,
+ 	.llseek = default_llseek,
+-#ifdef CONFIG_COMPAT
+-	.compat_ioctl	= dvb_demux_compat_ioctl,
+-#endif
+ };
+ 
+ static struct dvb_device dvbdev_demux = {
+@@ -1214,18 +1195,6 @@ static unsigned int dvb_dvr_poll(struct file *file, poll_table *wait)
+ 	return mask;
+ }
+ 
+-#ifdef CONFIG_COMPAT
+-static long dvb_dvr_compat_ioctl(struct file *filp,
+-			unsigned int cmd, unsigned long args)
+-{
+-	unsigned long ret;
+-
+-	args = (unsigned long)compat_ptr(args);
+-	ret = dvb_dvr_ioctl(filp, cmd, args);
+-	return ret;
+-}
+-#endif
+-
+ static const struct file_operations dvb_dvr_fops = {
+ 	.owner = THIS_MODULE,
+ 	.read = dvb_dvr_read,
+@@ -1235,9 +1204,6 @@ static const struct file_operations dvb_dvr_fops = {
+ 	.release = dvb_dvr_release,
+ 	.poll = dvb_dvr_poll,
+ 	.llseek = default_llseek,
+-#ifdef CONFIG_COMPAT
+-	.compat_ioctl	= dvb_dvr_compat_ioctl,
+-#endif
+ };
+ 
+ static struct dvb_device dvbdev_dvr = {
+diff --git a/drivers/media/dvb-core/dvb_demux.c b/drivers/media/dvb-core/dvb_demux.c
+index 3485655..6c7ff0c 100644
+--- a/drivers/media/dvb-core/dvb_demux.c
++++ b/drivers/media/dvb-core/dvb_demux.c
+@@ -435,7 +435,7 @@ static void dvb_dmx_swfilter_packet(struct dvb_demux *demux, const u8 *buf)
+ 		dprintk_tscheck("TEI detected. "
+ 				"PID=0x%x data1=0x%x\n",
+ 				pid, buf[1]);
+-		/* data in this packet cant be trusted - drop it unless
++		/* data in this packet can't be trusted - drop it unless
+ 		 * module option dvb_demux_feed_err_pkts is set */
+ 		if (!dvb_demux_feed_err_pkts)
+ 			return;
+@@ -476,7 +476,9 @@ static void dvb_dmx_swfilter_packet(struct dvb_demux *demux, const u8 *buf)
+ void dvb_dmx_swfilter_packets(struct dvb_demux *demux, const u8 *buf,
+ 			      size_t count)
+ {
+-	spin_lock(&demux->lock);
++	unsigned long flags;
++
++	spin_lock_irqsave(&demux->lock, flags);
+ 
+ 	while (count--) {
+ 		if (buf[0] == 0x47)
+@@ -484,7 +486,7 @@ void dvb_dmx_swfilter_packets(struct dvb_demux *demux, const u8 *buf,
+ 		buf += 188;
+ 	}
+ 
+-	spin_unlock(&demux->lock);
++	spin_unlock_irqrestore(&demux->lock, flags);
+ }
+ 
+ EXPORT_SYMBOL(dvb_dmx_swfilter_packets);
+@@ -519,8 +521,9 @@ static inline void _dvb_dmx_swfilter(struct dvb_demux *demux, const u8 *buf,
+ {
+ 	int p = 0, i, j;
+ 	const u8 *q;
++	unsigned long flags;
+ 
+-	spin_lock(&demux->lock);
++	spin_lock_irqsave(&demux->lock, flags);
+ 
+ 	if (demux->tsbufp) { /* tsbuf[0] is now 0x47. */
+ 		i = demux->tsbufp;
+@@ -564,7 +567,7 @@ static inline void _dvb_dmx_swfilter(struct dvb_demux *demux, const u8 *buf,
+ 	}
+ 
+ bailout:
+-	spin_unlock(&demux->lock);
++	spin_unlock_irqrestore(&demux->lock, flags);
+ }
+ 
+ void dvb_dmx_swfilter(struct dvb_demux *demux, const u8 *buf, size_t count)
+@@ -581,11 +584,13 @@ EXPORT_SYMBOL(dvb_dmx_swfilter_204);
+ 
+ void dvb_dmx_swfilter_raw(struct dvb_demux *demux, const u8 *buf, size_t count)
+ {
+-	spin_lock(&demux->lock);
++	unsigned long flags;
++
++	spin_lock_irqsave(&demux->lock, flags);
+ 
+ 	demux->feed->cb.ts(buf, count, NULL, 0, &demux->feed->feed.ts, DMX_OK);
+ 
+-	spin_unlock(&demux->lock);
++	spin_unlock_irqrestore(&demux->lock, flags);
+ }
+ EXPORT_SYMBOL(dvb_dmx_swfilter_raw);
+ 
+@@ -1027,8 +1032,13 @@ static int dmx_section_feed_release_filter(struct dmx_section_feed *feed,
+ 		return -EINVAL;
+ 	}
+ 
+-	if (feed->is_filtering)
++	if (feed->is_filtering) {
++		/* release dvbdmx->mutex as far as it is
++		   acquired by stop_filtering() itself */
++		mutex_unlock(&dvbdmx->mutex);
+ 		feed->stop_filtering(feed);
++		mutex_lock(&dvbdmx->mutex);
++	}
+ 
+ 	spin_lock_irq(&dvbdmx->lock);
+ 	f = dvbdmxfeed->filter;
+diff --git a/drivers/media/dvb-core/dvb_frontend.c b/drivers/media/dvb-core/dvb_frontend.c
+index ec3d417..1f925e8 100644
+--- a/drivers/media/dvb-core/dvb_frontend.c
++++ b/drivers/media/dvb-core/dvb_frontend.c
+@@ -52,10 +52,6 @@ static int dvb_force_auto_inversion;
+ static int dvb_override_tune_delay;
+ static int dvb_powerdown_on_sleep = 1;
+ static int dvb_mfe_wait_time = 5;
+-static int dvb_afc_debug;
+-static int disable_set_frotend_param;
+-static int dvb_dtv_debug;
+-
+ 
+ module_param_named(frontend_debug, dvb_frontend_debug, int, 0644);
+ MODULE_PARM_DESC(frontend_debug, "Turn on/off frontend core debugging (default:off).");
+@@ -69,19 +65,6 @@ module_param(dvb_powerdown_on_sleep, int, 0644);
+ MODULE_PARM_DESC(dvb_powerdown_on_sleep, "0: do not power down, 1: turn LNB voltage off on sleep (default)");
+ module_param(dvb_mfe_wait_time, int, 0644);
+ MODULE_PARM_DESC(dvb_mfe_wait_time, "Wait up to <mfe_wait_time> seconds on open() for multi-frontend to become available (default:5 seconds)");
+-module_param(dvb_afc_debug, int, 0644);
+-MODULE_PARM_DESC(dvb_afc_debug, "vb_afc_debug");
+-module_param(disable_set_frotend_param, int, 0644);
+-MODULE_PARM_DESC(disable_set_frotend_param, "disable_set_frotend_param");
+-module_param(dvb_dtv_debug, int, 0644);
+-MODULE_PARM_DESC(dvb_dtv_debug, "vb_afc_debug");
+-
+-#define dprintk(a...)\
+-		do {\
+-			if (dvb_frontend_debug)\
+-				printk(a);\
+-		} while (0)
+-/*#define dtvprintk if (dvb_dtv_debug) printk*/
+ 
+ #define FESTATE_IDLE 1
+ #define FESTATE_RETUNE 2
+@@ -118,21 +101,14 @@ MODULE_PARM_DESC(dvb_dtv_debug, "vb_afc_debug");
+ #define DVB_FE_DEVICE_REMOVED	2
+ 
+ static DEFINE_MUTEX(frontend_mutex);
+-/*extern unsigned int jiffies_to_msecs(const unsigned long j);*/
+-int jiffiestime;
+-/*define LOCK_TIMEOUT 2000*/
+-static int LOCK_TIMEOUT = 2000;
+ 
+ struct dvb_frontend_private {
++
+ 	/* thread/frontend values */
+ 	struct dvb_device *dvbdev;
+-	struct dvb_frontend_parameters parameters_in;
+ 	struct dvb_frontend_parameters parameters_out;
+ 	struct dvb_fe_events events;
+ 	struct semaphore sem;
+-	struct dvbsx_blindscan_events blindscan_events;
+-	struct semaphore blindscan_sem;
+-	bool in_blindscan;
+ 	struct list_head list_head;
+ 	wait_queue_head_t wait_queue;
+ 	struct task_struct *thread;
+@@ -146,12 +122,6 @@ struct dvb_frontend_private {
+ 	int tone;
+ 	int voltage;
+ 
+-	/*set_frontend ops async support*/
+-	wait_queue_head_t setfrontendasync_wait_queue;
+-	unsigned int setfrontendasync_wakeup;
+-	unsigned int setfrontendasync_needwakeup;
+-	unsigned int setfrontendasync_interruptwakeup;
+-
+ 	/* swzigzag values */
+ 	unsigned int state;
+ 	unsigned int bending;
+@@ -166,7 +136,6 @@ struct dvb_frontend_private {
+ 	int quality;
+ 	unsigned int check_wrapped;
+ 	enum dvbfe_search algo_status;
+-	int user_delay;
+ };
+ 
+ static void dvb_frontend_wakeup(struct dvb_frontend *fe);
+@@ -191,7 +160,6 @@ enum dvbv3_emulation_type {
+ 	DVBV3_QAM,
+ 	DVBV3_OFDM,
+ 	DVBV3_ATSC,
+-	DVBV3_ANALOG
+ };
+ 
+ static enum dvbv3_emulation_type dvbv3_type(u32 delivery_system)
+@@ -215,8 +183,6 @@ static enum dvbv3_emulation_type dvbv3_type(u32 delivery_system)
+ 	case SYS_ATSCMH:
+ 	case SYS_DVBC_ANNEX_B:
+ 		return DVBV3_ATSC;
+-	case SYS_ANALOG:
+-		return DVBV3_ANALOG;
+ 	case SYS_UNDEFINED:
+ 	case SYS_ISDBC:
+ 	case SYS_DVBH:
+@@ -241,13 +207,9 @@ static void dvb_frontend_add_event(struct dvb_frontend *fe, fe_status_t status)
+ 
+ 	dev_dbg(fe->dvb->device, "%s:\n", __func__);
+ 
+-	if (fe->dtv_property_cache.delivery_system == SYS_ANALOG) {
+-		if ((status & FE_HAS_LOCK) && has_get_frontend(fe))
+-			dtv_get_frontend(fe, &fepriv->parameters_out);
+-	} else{
+-		if (/*(status & FE_HAS_LOCK) && */has_get_frontend(fe))
+-			dtv_get_frontend(fe, &fepriv->parameters_out);
+-	}
++	if ((status & FE_HAS_LOCK) && has_get_frontend(fe))
++		dtv_get_frontend(fe, &fepriv->parameters_out);
++
+ 	mutex_lock(&events->mtx);
+ 
+ 	wp = (events->eventw + 1) % MAX_EVENT;
+@@ -259,6 +221,7 @@ static void dvb_frontend_add_event(struct dvb_frontend *fe, fe_status_t status)
+ 	e = &events->events[events->eventw];
+ 	e->status = status;
+ 	e->parameters = fepriv->parameters_out;
++
+ 	events->eventw = wp;
+ 
+ 	mutex_unlock(&events->mtx);
+@@ -290,7 +253,7 @@ static int dvb_frontend_get_event(struct dvb_frontend *fe,
+ 		ret = wait_event_interruptible (events->wait_queue,
+ 						events->eventw != events->eventr);
+ 
+-		if (down_interruptible(&fepriv->sem))
++		if (down_interruptible (&fepriv->sem))
+ 			return -ERESTARTSYS;
+ 
+ 		if (ret < 0)
+@@ -305,95 +268,6 @@ static int dvb_frontend_get_event(struct dvb_frontend *fe,
+ 	return 0;
+ }
+ 
+-static void dvbsx_blindscan_add_event(struct dvb_frontend *fe,
+-					struct dvbsx_blindscanevent *pbsevent)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-	struct dvbsx_blindscan_events *events = &fepriv->blindscan_events;
+-	struct dvbsx_blindscanevent *e;
+-	int wp;
+-
+-	dprintk("%s\n", __func__);
+-
+-	if (mutex_lock_interruptible(&events->mtx))
+-		return;
+-
+-	wp = (events->eventw + 1) % MAX_BLINDSCAN_EVENT;
+-
+-	if (wp == events->eventr) {
+-		events->overflow = 1;
+-		events->eventr = (events->eventr + 1) % MAX_BLINDSCAN_EVENT;
+-	}
+-
+-	e = &events->events[events->eventw];
+-
+-	memcpy(e, pbsevent, sizeof(struct dvbsx_blindscanevent));
+-
+-	events->eventw = wp;
+-
+-	mutex_unlock(&events->mtx);
+-
+-	wake_up_interruptible(&events->wait_queue);
+-}
+-
+-static int dvbsx_blindscan_get_event(struct dvb_frontend *fe,
+-				struct dvbsx_blindscanevent *event , int flags)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-	struct dvbsx_blindscan_events *events = &fepriv->blindscan_events;
+-
+-	dprintk("%s\n", __func__);
+-
+-	if (events->overflow) {
+-		events->overflow = 0;
+-		return -EOVERFLOW;
+-	}
+-
+-	if (events->eventw == events->eventr) {
+-		int ret;
+-
+-		if (flags & O_NONBLOCK)
+-			return -EWOULDBLOCK;
+-
+-		up(&fepriv->blindscan_sem);
+-
+-		ret = wait_event_interruptible_timeout(events->wait_queue,
+-				events->eventw != events->eventr,
+-				fe->ops.blindscan_ops.info.bspara.timeout * HZ);
+-
+-		if (down_interruptible(&fepriv->blindscan_sem))
+-			return -ERESTARTSYS;
+-
+-		if (ret < 0)
+-			return ret;
+-	}
+-
+-	if (mutex_lock_interruptible(&events->mtx))
+-		return -ERESTARTSYS;
+-
+-	memcpy(event, &events->events[events->eventr],
+-		sizeof(struct dvbsx_blindscanevent));
+-
+-	events->eventr = (events->eventr + 1) % MAX_BLINDSCAN_EVENT;
+-
+-	mutex_unlock(&events->mtx);
+-
+-	return 0;
+-}
+-
+-static int dvbsx_blindscan_event_callback(struct dvb_frontend *fe,
+-					struct dvbsx_blindscanevent *pbsevent)
+-{
+-	dprintk("%s\n", __func__);
+-
+-	if ((!fe) || (!pbsevent))
+-		return -1;
+-
+-	dvbsx_blindscan_add_event(fe, pbsevent);
+-
+-	return 0;
+-}
+-
+ static void dvb_frontend_clear_events(struct dvb_frontend *fe)
+ {
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+@@ -460,7 +334,6 @@ static int dvb_frontend_swzigzag_autotune(struct dvb_frontend *fe, int check_wra
+ 	int autoinversion;
+ 	int ready = 0;
+ 	int fe_set_err = 0;
+-	int time = 0;
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+ 	struct dtv_frontend_properties *c = &fe->dtv_property_cache, tmp;
+ 	int original_inversion = c->inversion;
+@@ -539,13 +412,8 @@ static int dvb_frontend_swzigzag_autotune(struct dvb_frontend *fe, int check_wra
+ 	if (autoinversion)
+ 		c->inversion = fepriv->inversion;
+ 	tmp = *c;
+-	time = jiffies_to_msecs(jiffies)-jiffiestime;
+-	dprintk("2---auto tune,time is %d\n", time);
+-	if (fe->ops.set_frontend && (time >= LOCK_TIMEOUT)) {
++	if (fe->ops.set_frontend)
+ 		fe_set_err = fe->ops.set_frontend(fe);
+-		jiffiestime = jiffies_to_msecs(jiffies);
+-	}
+-	fepriv->parameters_out = fepriv->parameters_in;
+ 	*c = tmp;
+ 	if (fe_set_err < 0) {
+ 		fepriv->state = FESTATE_ERROR;
+@@ -559,35 +427,12 @@ static int dvb_frontend_swzigzag_autotune(struct dvb_frontend *fe, int check_wra
+ 	return 0;
+ }
+ 
+-/*
+-*#if 0
+-*#if (defined CONFIG_AM_SI2176)
+-*int si2176_get_strength(void);
+-*#endif
+-*#if ((defined CONFIG_AM_SI2177) || (defined CONFIG_AM_SI2157))
+-*int si2177_get_strength(void);
+-*#endif
+-*#endif
+-*/
+-
+ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
+ {
+-	fe_status_t s;
+-	int retval;
+-	int time;
+-	int dtmb_status, i, has_singal;
++	fe_status_t s = 0;
++	int retval = 0;
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+ 	struct dtv_frontend_properties *c = &fe->dtv_property_cache, tmp;
+-#if (((defined CONFIG_AM_SI2176) || (defined CONFIG_AM_SI2177)\
+-	|| (defined CONFIG_AM_SI2157)) && (defined CONFIG_AM_M6_DEMOD))
+-	int strength;
+-#endif
+-#if (defined CONFIG_AM_M6_DEMOD)
+-	int newcount;
+-	int count;
+-	count = 0;
+-#endif
+-	s = retval = time = 0;
+ 
+ 	/* if we've got no parameters, just keep idling */
+ 	if (fepriv->state & FESTATE_IDLE) {
+@@ -619,16 +464,7 @@ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
+ 	} else {
+ 		if (fe->ops.read_status)
+ 			fe->ops.read_status(fe, &s);
+-			time = jiffies_to_msecs(jiffies)-jiffiestime;
+-		dprintk("read status,time is %d,s is %d,status is %d\n",
+-			time, s, fepriv->status);
+-		if (((s != fepriv->status) && (time >= LOCK_TIMEOUT)) ||
+-			((s != fepriv->status) &&
+-			(s == (FE_HAS_LOCK|FE_HAS_SIGNAL|
+-			FE_HAS_CARRIER|FE_HAS_VITERBI|FE_HAS_SYNC)))) {
+-				dev_dbg(fe->dvb->device,
+-					"event s=%d,fepriv->status is %d\n",
+-					s, fepriv->status);
++		if (s != fepriv->status) {
+ 			dvb_frontend_add_event(fe, s);
+ 			fepriv->status = s;
+ 		}
+@@ -646,188 +482,7 @@ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
+ 		}
+ 		return;
+ 	}
+-/*auto_mode qam   201306-rsj*/
+-#if (defined CONFIG_AM_M6_DEMOD)
+-/*dvbc auto qam*/
+-	if (c->modulation == QAM_AUTO) {
+-		while ((dvbc_get_status() <= 3) && (count <= 20)) {
+-			msleep(30);
+-			if (count == 20) {
+-				fe->ops.read_status(fe, &s);
+-				dev_dbg(fe->dvb->device,
+-				"event s=%d,fepriv->status is %d\n",
+-				s, fepriv->status);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-			}
+-			count++;
+-		}
+-		count = 0;
+-		while ((dvbc_get_status() > 3) &&
+-			(dvbc_get_status() != 5) && (count < 5)) {
+-			if (count == 0)
+-				c->modulation = QAM_64;
+-			else if (count == 1)
+-				c->modulation = QAM_256;
+-			else if (count == 2)
+-				c->modulation = QAM_128;
+-			else if (count == 3)
+-				c->modulation = QAM_16;
+-			else
+-				c->modulation = QAM_32;
+-
+-			if (fe->ops.set_qam_mode)
+-				fe->ops.set_qam_mode(fe);
+-			for (newcount = 0; newcount < 6; newcount++) {
+-				if (dvbc_get_status() == 5)
+-					break;
+-				msleep(50);
+-			}
+-	newcount = 0;
+-			count++;
+-			if (dvbc_get_status() == 5) {
+-				if (fe->ops.read_status)
+-					fe->ops.read_status(fe, &s);
+-
+-				if (((s != fepriv->status) &&
+-					(s == (FE_HAS_LOCK|FE_HAS_SIGNAL|
+-					FE_HAS_CARRIER|FE_HAS_VITERBI|
+-					FE_HAS_SYNC)))) {
+-					dev_dbg(fe->dvb->device,
+-						"event s=%d,fepriv->status is %d\n",
+-						s, fepriv->status);
+-					dvb_frontend_add_event(fe, s);
+-					fepriv->status = s;
+-					break;
+-				}
+-			}
+-
+-		}
+-	} else if (c->modulation == QAM_AUTO) {
+-		/*fepriv->parameters_out = fepriv->parameters_in;*/
+-		msleep(100);
+-		#if (defined CONFIG_AM_SI2176)
+-		strength = fe->ops.tuner_ops.get_strength(fe)-256;
+-		if (strength <= (-85)) {
+-			s = 32;
+-			dev_dbg(fe->dvb->device,
+-				"5-strength is %d\n", strength);
+-			if (s != fepriv->status) {
+-				dev_dbg(fe->dvb->device,
+-				"5event s=%d,fepriv->status is %d!\n",
+-				s, fepriv->status);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				jiffiestime = jiffies_to_msecs(jiffies);
+-			}
+-			return;
+-
+-		}
+-		#elif ((defined CONFIG_AM_SI2177) || (defined CONFIG_AM_SI2157))
+-		strength = fe->ops.tuner_ops.get_strength(fe)-256;
+-		if (strength <= (-85)) {
+-			s = 32;
+-			dev_dbg(fe->dvb->device,
+-				"5-strength is %d\n", strength);
+-			if (s != fepriv->nstatus) {
+-				dev_dbg(fe->dvb->device,
+-				"event s=%d,fepriv->status is %d\n",
+-				s, fepriv->status);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				jiffiestime = jiffies_to_msecs(jiffies);
+-			}
+-			return;
+-
+-		}
+-		#endif
+-		while (((atsc_read_iqr_reg()>>16) != 0x1f) && (count < 2)) {
+-			if (count == 0) {
+-				/*if (fe->ops.set_frontend)*/
+-			/*fe->ops.set_frontend(fe, &fepriv->parameters_in);*/
+-			}
+-			/*fepriv->parameters_in.u.vsb.modulation=QAM_256;*/
+-			else if (count == 1) {
+-				c->modulation = QAM_64;
+-				if (fe->ops.set_qam_mode)
+-					fe->ops.set_qam_mode(fe);
+-			}
+-			for (newcount = 0; newcount < 10; newcount++) {
+-				if ((atsc_read_iqr_reg()>>16) == 0x1f)
+-					break;
+-				msleep(50);
+-			}
+-			newcount = 0;
+-			count++;
+-		if ((atsc_read_iqr_reg()>>16) == 0x1f) {
+-			if (fe->ops.read_status)
+-				fe->ops.read_status(fe, &s);
+-			if (((s != fepriv->status) &&
+-				(s == (FE_HAS_LOCK|FE_HAS_SIGNAL|
+-				FE_HAS_CARRIER|FE_HAS_VITERBI|
+-				FE_HAS_SYNC)))) {
+-				dev_dbg(fe->dvb->device,
+-					"event s=%d,fepriv->status is %d!\n",
+-					s, fepriv->status);
+-				dev_dbg(fe->dvb->device,
+-					"fepriv-frequency is %d\n",
+-					fepriv->parameters_in.frequency);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				jiffiestime = jiffies_to_msecs(jiffies);
+-				return;
+-			}
+-		}
+-		if ((count == 2) &&
+-			((atsc_read_iqr_reg()>>16) != 0x1f)) {
+-			if (fe->ops.read_status)
+-				fe->ops.read_status(fe, &s);
+-			if (s != fepriv->status) {
+-				dev_dbg(fe->dvb->device,
+-					"event s=%d,fepriv->status is %d!!\n",
+-					s, fepriv->status);
+-				dev_dbg(fe->dvb->device,
+-					"fepriv->parameters_in.frequency is %d\n",
+-				fepriv->parameters_in.frequency);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				jiffiestime = jiffies_to_msecs(jiffies);
+-				return;
+-			}
+-		}
+-		}
+-
+-	}
+ 
+-
+-#endif
+-#if 1
+-	/*signal_detec dtmb   201512-rsj*/
+-		if (fe->ops.read_dtmb_fsm) {
+-			LOCK_TIMEOUT = 10000;
+-			has_singal = 0;
+-			msleep(100);
+-			fe->ops.read_dtmb_fsm(fe, &dtmb_status);
+-			for (i = 0 ; i < 8 ; i++) {
+-				if (((dtmb_status >> (i*4)) & 0xf) > 4) {
+-					/*has signal*/
+-				/*	dprintk("has signal\n");*/
+-					has_singal = 1;
+-				}
+-			}
+-			dprintk("[DTV]has_singal is %d\n", has_singal);
+-			if (has_singal == 0) {
+-				s = FE_TIMEDOUT;
+-			dprintk(
+-						"event s=%d,fepriv->status is %d\n",
+-						s, fepriv->status);
+-				dvb_frontend_add_event(fe, s);
+-				fepriv->status = s;
+-				return;
+-			}
+-		}
+-
+-#endif
+ 	/* if we are tuned already, check we're still locked */
+ 	if (fepriv->state & FESTATE_TUNED) {
+ 		dvb_frontend_swzigzag_update_delay(fepriv, s & FE_HAS_LOCK);
+@@ -870,13 +525,8 @@ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
+ 	}
+ 
+ 	/* fast zigzag. */
+-	if ((fepriv->state & FESTATE_SEARCHING_FAST) ||
+-		(fepriv->state & FESTATE_RETUNE)) {
+-		if (fepriv->state & FESTATE_SEARCHING_FAST)
+-			/*if not lock signal ,then wait 25 jiffies*/
+-			fepriv->delay = fepriv->min_delay + HZ / 5;
+-		else
+-			fepriv->delay = fepriv->min_delay;
++	if ((fepriv->state & FESTATE_SEARCHING_FAST) || (fepriv->state & FESTATE_RETUNE)) {
++		fepriv->delay = fepriv->min_delay;
+ 
+ 		/* perform a tune */
+ 		retval = dvb_frontend_swzigzag_autotune(fe,
+@@ -949,11 +599,11 @@ static int dvb_frontend_thread(void *data)
+ {
+ 	struct dvb_frontend *fe = data;
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-	unsigned long timeout;
+ 	fe_status_t s;
+ 	enum dvbfe_algo algo;
+ 
+-	struct dvb_frontend_parameters *params = NULL;
++	bool re_tune = false;
++	bool semheld = false;
+ 
+ 	dev_dbg(fe->dvb->device, "%s:\n", __func__);
+ 
+@@ -970,13 +620,15 @@ static int dvb_frontend_thread(void *data)
+ 	while (1) {
+ 		up(&fepriv->sem);	    /* is locked when we enter the thread... */
+ restart:
+-		timeout = wait_event_interruptible_timeout(fepriv->wait_queue,
++		wait_event_interruptible_timeout(fepriv->wait_queue,
+ 			dvb_frontend_should_wakeup(fe) || kthread_should_stop()
+ 				|| freezing(current),
+ 			fepriv->delay);
+ 
+ 		if (kthread_should_stop() || dvb_frontend_is_exiting(fe)) {
+ 			/* got signal or quitting */
++			if (!down_interruptible(&fepriv->sem))
++				semheld = true;
+ 			fepriv->exit = DVB_FE_NORMAL_EXIT;
+ 			break;
+ 		}
+@@ -1001,25 +653,18 @@ restart:
+ 			algo = fe->ops.get_frontend_algo(fe);
+ 			switch (algo) {
+ 			case DVBFE_ALGO_HW:
+-				dev_dbg(fe->dvb->device,
+-				"%s: Frontend ALGO = DVBFE_ALGO_HW\n",
+-				__func__);
++				dev_dbg(fe->dvb->device, "%s: Frontend ALGO = DVBFE_ALGO_HW\n", __func__);
+ 
+ 				if (fepriv->state & FESTATE_RETUNE) {
+-					dprintk(
+-					"%s:Retune requested,FESTATE_RETUNE\n",
+-					__func__);
+-					params = &fepriv->parameters_in;
++					dev_dbg(fe->dvb->device, "%s: Retune requested, FESTATE_RETUNE\n", __func__);
++					re_tune = true;
+ 					fepriv->state = FESTATE_TUNED;
++				} else {
++					re_tune = false;
+ 				}
+ 
+ 				if (fe->ops.tune)
+-					fe->ops.tune(fe,
+-						params,
+-						fepriv->tune_mode_flags,
+-						&fepriv->delay, &s);
+-				if (params)
+-					fepriv->parameters_out = *params;
++					fe->ops.tune(fe, re_tune, fepriv->tune_mode_flags, &fepriv->delay, &s);
+ 
+ 				if (s != fepriv->status && !(fepriv->tune_mode_flags & FE_TUNE_MODE_ONESHOT)) {
+ 					dev_dbg(fe->dvb->device, "%s: state changed, adding current state\n", __func__);
+@@ -1038,36 +683,26 @@ restart:
+ 					fepriv->state = FESTATE_TUNED;
+ 				}
+ 				/* Case where we are going to search for a carrier
+-				 * User asked us to retune again
+-				 *for some reason, possibly
++				 * User asked us to retune again for some reason, possibly
+ 				 * requesting a search with a new set of parameters
+ 				 */
+ 				if (fepriv->algo_status & DVBFE_ALGO_SEARCH_AGAIN) {
+ 					if (fe->ops.search) {
+ 						fepriv->algo_status = fe->ops.search(fe);
+-				/* We did do a search as was requested,
+-				*the flags are now unset as well and has
+-				* the flags wrt to search.
+-				*/
++						/* We did do a search as was requested, the flags are
++						 * now unset as well and has the flags wrt to search.
++						 */
+ 					} else {
+-						fepriv->algo_status &=
+-						~DVBFE_ALGO_SEARCH_AGAIN;
++						fepriv->algo_status &= ~DVBFE_ALGO_SEARCH_AGAIN;
+ 					}
+ 				}
+ 				/* Track the carrier if the search was successful */
+-				if (fepriv->algo_status
+-					== DVBFE_ALGO_SEARCH_SUCCESS) {
+-					if (fe->ops.track)
+-						fe->ops.track(fe,
+-						&fepriv->parameters_in);
+-					s = FE_HAS_LOCK;
+-				} else {
+-			/*fepriv->algo_status |= DVBFE_ALGO_SEARCH_AGAIN;*/
++				if (fepriv->algo_status != DVBFE_ALGO_SEARCH_SUCCESS) {
++					fepriv->algo_status |= DVBFE_ALGO_SEARCH_AGAIN;
+ 					fepriv->delay = HZ / 2;
+-					s = FE_TIMEDOUT;
+ 				}
+ 				dtv_property_legacy_params_sync(fe, &fepriv->parameters_out);
+-				/*fe->ops.read_status(fe, &s);*/
++				fe->ops.read_status(fe, &s);
+ 				if (s != fepriv->status) {
+ 					dvb_frontend_add_event(fe, s); /* update event list */
+ 					fepriv->status = s;
+@@ -1109,6 +744,8 @@ restart:
+ 		fepriv->exit = DVB_FE_NO_EXIT;
+ 	mb();
+ 
++	if (semheld)
++		up(&fepriv->sem);
+ 	dvb_frontend_wakeup(fe);
+ 	return 0;
+ }
+@@ -1197,7 +834,7 @@ static int dvb_frontend_start(struct dvb_frontend *fe)
+ 
+ 	if (signal_pending(current))
+ 		return -EINTR;
+-	if (down_interruptible(&fepriv->sem))
++	if (down_interruptible (&fepriv->sem))
+ 		return -EINTR;
+ 
+ 	fepriv->state = FESTATE_IDLE;
+@@ -1339,128 +976,6 @@ static int dvb_frontend_clear_cache(struct dvb_frontend *fe)
+ 	return 0;
+ }
+ 
+-static int dvb_frontend_asyncshouldwakeup(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	dprintk("%s:%d\n", __func__, fepriv->setfrontendasync_wakeup);
+-
+-	return fepriv->setfrontendasync_wakeup;
+-}
+-
+-static int dvb_frontend_asyncnotbusy(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	dprintk("%s:%d\n", __func__, fepriv->setfrontendasync_needwakeup);
+-
+-	return !fepriv->setfrontendasync_needwakeup;
+-}
+-
+-static void dvb_frontend_asyncwakeup(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	if (!fe)
+-		return;
+-
+-	if (!fe->ops.asyncinfo.set_frontend_asyncenable)
+-		return;
+-
+-
+-	dprintk("%s:%d\n", __func__, fepriv->setfrontendasync_needwakeup);
+-
+-	if (fepriv->setfrontendasync_needwakeup) {
+-		fepriv->setfrontendasync_wakeup = 1;
+-		wake_up_interruptible(&fepriv->setfrontendasync_wait_queue);
+-
+-		up(&fepriv->sem);
+-		wait_event_interruptible(fepriv->setfrontendasync_wait_queue,
+-						dvb_frontend_asyncnotbusy(fe));
+-		if (down_interruptible(&fepriv->sem))
+-			return;
+-	}
+-}
+-
+-static int dvb_frontend_asyncpreproc(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	if (!fe)
+-		return -1;
+-
+-	if (!fe->ops.asyncinfo.set_frontend_asyncenable)
+-		return -1;
+-
+-	fepriv->setfrontendasync_needwakeup = 1;
+-	fepriv->setfrontendasync_wakeup = 0;
+-
+-	dprintk("%s:%d\n", __func__, fepriv->setfrontendasync_needwakeup);
+-
+-	/*enable other frontend ops run*/
+-	up(&fepriv->sem);
+-
+-	return 0;
+-}
+-
+-static int dvb_frontend_asyncwait(struct dvb_frontend *fe, u32 ms_timeout)
+-{
+-	int ret = 0;
+-	unsigned long wait_ret = 0;
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	if (!fe)
+-		return -1;
+-
+-	if (!fe->ops.asyncinfo.set_frontend_asyncenable)
+-		return -1;
+-
+-	wait_ret = wait_event_interruptible_timeout
+-			(fepriv->setfrontendasync_wait_queue,
+-			dvb_frontend_asyncshouldwakeup(fe),
+-			ms_timeout * HZ / 1000);
+-
+-	dprintk("%s:%d/%ld\n", __func__, ms_timeout, wait_ret);
+-
+-	if (wait_ret > 0)
+-		ret = 1;
+-	else if (wait_ret == 0)
+-		ret = 0;
+-
+-	return ret;
+-}
+-
+-static int dvb_frontend_asyncpostproc(struct dvb_frontend *fe,
+-					int asyncwait_ret)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	if (!fe)
+-		return -1;
+-
+-	if (!fe->ops.asyncinfo.set_frontend_asyncenable)
+-		return -1;
+-
+-	if (down_interruptible(&fepriv->sem))
+-		return -1;
+-
+-	fepriv->setfrontendasync_needwakeup = 0;
+-
+-	wake_up_interruptible(&fepriv->setfrontendasync_wait_queue);
+-
+-	if (asyncwait_ret > 0)
+-		fepriv->setfrontendasync_interruptwakeup = 1;
+-	else if (asyncwait_ret == 0)
+-		fepriv->setfrontendasync_interruptwakeup = 0;
+-	else
+-		fepriv->setfrontendasync_interruptwakeup = 0;
+-	dprintk("%s:%d/%d\n", __func__,
+-		asyncwait_ret,
+-		fepriv->setfrontendasync_needwakeup);
+-
+-	return 0;
+-}
+-
+ #define _DTV_CMD(n, s, b) \
+ [n] = { \
+ 	.name = #n, \
+@@ -1632,7 +1147,6 @@ static int dtv_property_cache_sync(struct dvb_frontend *fe,
+ 		c->transmission_mode = p->u.ofdm.transmission_mode;
+ 		c->guard_interval = p->u.ofdm.guard_interval;
+ 		c->hierarchy = p->u.ofdm.hierarchy_information;
+-		c->ofdm_mode = p->u.ofdm.ofdm_mode;
+ 		break;
+ 	case DVBV3_ATSC:
+ 		dev_dbg(fe->dvb->device, "%s: Preparing ATSC req\n", __func__);
+@@ -1644,14 +1158,6 @@ static int dtv_property_cache_sync(struct dvb_frontend *fe,
+ 		else
+ 			c->delivery_system = SYS_DVBC_ANNEX_B;
+ 		break;
+-	case DVBV3_ANALOG:
+-		c->analog.soundsys  = p->u.analog.soundsys;
+-		c->analog.audmode   = p->u.analog.audmode;
+-		c->analog.std       = p->u.analog.std;
+-		c->analog.flag      = p->u.analog.flag;
+-		c->analog.afc_range = p->u.analog.afc_range;
+-		c->analog.reserved  = p->u.analog.reserved;
+-		break;
+ 	case DVBV3_UNKNOWN:
+ 		dev_err(fe->dvb->device,
+ 				"%s: doesn't know how to handle a DVBv3 call to delivery system %i\n",
+@@ -1672,7 +1178,7 @@ static int dtv_property_legacy_params_sync(struct dvb_frontend *fe,
+ 
+ 	p->frequency = c->frequency;
+ 	p->inversion = c->inversion;
+-	/*dtvprintk("[get frontend]p is %d\n", p->frequency);*/
++
+ 	switch (dvbv3_type(c->delivery_system)) {
+ 	case DVBV3_UNKNOWN:
+ 		dev_err(fe->dvb->device,
+@@ -1721,21 +1227,11 @@ static int dtv_property_legacy_params_sync(struct dvb_frontend *fe,
+ 		p->u.ofdm.transmission_mode = c->transmission_mode;
+ 		p->u.ofdm.guard_interval = c->guard_interval;
+ 		p->u.ofdm.hierarchy_information = c->hierarchy;
+-		p->u.ofdm.ofdm_mode = c->ofdm_mode;
+ 		break;
+ 	case DVBV3_ATSC:
+ 		dev_dbg(fe->dvb->device, "%s: Preparing VSB req\n", __func__);
+ 		p->u.vsb.modulation = c->modulation;
+ 		break;
+-	case DVBV3_ANALOG:
+-		p->u.analog.soundsys = c->analog.soundsys;
+-		p->u.analog.audmode  = c->analog.audmode;
+-		p->u.analog.std      = c->analog.std;
+-		p->u.analog.flag     = c->analog.flag;
+-		p->u.analog.afc_range = c->analog.afc_range;
+-		p->u.analog.reserved = c->analog.reserved;
+-		break;
+-
+ 	}
+ 	return 0;
+ }
+@@ -2007,14 +1503,8 @@ static bool is_dvbv3_delsys(u32 delsys)
+ {
+ 	bool status;
+ 
+-	status = (delsys == SYS_DVBT) ||
+-		(delsys == SYS_DVBC_ANNEX_A) ||
+-		(delsys == SYS_DVBS) ||
+-		(delsys == SYS_ATSC) ||
+-		(delsys == SYS_DTMB) ||
+-		(delsys == SYS_ISDBT) ||
+-		(delsys == SYS_ANALOG) ||
+-		(delsys == SYS_DVBS2);
++	status = (delsys == SYS_DVBT) || (delsys == SYS_DVBC_ANNEX_A) ||
++		 (delsys == SYS_DVBS) || (delsys == SYS_ATSC);
+ 
+ 	return status;
+ }
+@@ -2409,38 +1899,10 @@ static int dvb_frontend_ioctl(struct file *file,
+ 	struct dtv_frontend_properties *c = &fe->dtv_property_cache;
+ 	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+ 	int err = -EOPNOTSUPP;
+-	int need_lock = 1;
+-	int need_blindscan = 0;
+ 
+ 	dev_dbg(fe->dvb->device, "%s: (%d)\n", __func__, _IOC_NR(cmd));
+-	if (fepriv->exit != DVB_FE_NO_EXIT)
+-		return -ENODEV;
+-
+-	if ((file->f_flags & O_ACCMODE) == O_RDONLY &&
+-	    (_IOC_DIR(cmd) != _IOC_READ || cmd == FE_GET_EVENT ||
+-	     cmd == FE_DISEQC_RECV_SLAVE_REPLY))
+-		return -EPERM;
+-
+-	if (cmd == FE_READ_STATUS ||
+-			cmd == FE_READ_BER ||
+-			cmd == FE_READ_SIGNAL_STRENGTH ||
+-			cmd == FE_READ_SNR ||
+-			cmd == FE_READ_UNCORRECTED_BLOCKS ||
+-			cmd == FE_GET_FRONTEND ||
+-			cmd == FE_READ_AFC ||
+-			cmd == FE_SET_BLINDSCAN ||
+-			cmd == FE_GET_BLINDSCANEVENT ||
+-			cmd == FE_SET_BLINDSCANCANCEl)
+-		need_lock = 0;
+-
+-	if (cmd == FE_SET_BLINDSCAN ||
+-			cmd == FE_GET_BLINDSCANEVENT ||
+-			cmd == FE_SET_BLINDSCANCANCEl)
+-		need_blindscan = 1;
+-
+-	if (need_lock)
+-		if (down_interruptible(&fepriv->sem))
+-			return -ERESTARTSYS;
++	if (down_interruptible(&fepriv->sem))
++		return -ERESTARTSYS;
+ 
+ 	if (fepriv->exit != DVB_FE_NO_EXIT) {
+ 		up(&fepriv->sem);
+@@ -2454,14 +1916,6 @@ static int dvb_frontend_ioctl(struct file *file,
+ 		return -EPERM;
+ 	}
+ 
+-	if (need_blindscan)
+-		if (down_interruptible(&fepriv->blindscan_sem))
+-			return -ERESTARTSYS;
+-
+-	if (cmd == FE_SET_FRONTEND ||
+-			cmd == FE_SET_MODE)
+-		dvb_frontend_asyncwakeup(fe);
+-
+ 	if ((cmd == FE_SET_PROPERTY) || (cmd == FE_GET_PROPERTY))
+ 		err = dvb_frontend_ioctl_properties(file, cmd, parg);
+ 	else {
+@@ -2469,12 +1923,7 @@ static int dvb_frontend_ioctl(struct file *file,
+ 		err = dvb_frontend_ioctl_legacy(file, cmd, parg);
+ 	}
+ 
+-	if (need_blindscan)
+-		up(&fepriv->blindscan_sem);
+-
+-	if (need_lock)
+-		up(&fepriv->sem);
+-
++	up(&fepriv->sem);
+ 	return err;
+ }
+ 
+@@ -2509,18 +1958,12 @@ static int dvb_frontend_ioctl_properties(struct file *file,
+ 			err = -ENOMEM;
+ 			goto out;
+ 		}
+-#ifdef CONFIG_COMPAT
+-		if (copy_from_user(tvp, compat_ptr((unsigned long)tvps->props),
+-				tvps->num * sizeof(struct dtv_property))) {
+-			err = -EFAULT;
+-			goto out;
+-		}
+-#else
++
+ 		if (copy_from_user(tvp, tvps->props, tvps->num * sizeof(struct dtv_property))) {
+ 			err = -EFAULT;
+ 			goto out;
+ 		}
+-#endif
++
+ 		for (i = 0; i < tvps->num; i++) {
+ 			err = dtv_property_process_set(fe, tvp + i, file);
+ 			if (err < 0)
+@@ -2548,18 +1991,12 @@ static int dvb_frontend_ioctl_properties(struct file *file,
+ 			err = -ENOMEM;
+ 			goto out;
+ 		}
+-#ifdef CONFIG_COMPAT
+-		if (copy_from_user(tvp, compat_ptr((unsigned long)tvps->props),
+-				tvps->num * sizeof(struct dtv_property))) {
+-			err = -EFAULT;
+-			goto out;
+-		}
+-#else
++
+ 		if (copy_from_user(tvp, tvps->props, tvps->num * sizeof(struct dtv_property))) {
+ 			err = -EFAULT;
+ 			goto out;
+ 		}
+-#endif
++
+ 		/*
+ 		 * Fills the cache out struct with the cache contents, plus
+ 		 * the data retrieved from get_frontend, if the frontend
+@@ -2576,18 +2013,11 @@ static int dvb_frontend_ioctl_properties(struct file *file,
+ 				goto out;
+ 			(tvp + i)->result = err;
+ 		}
+-#ifdef CONFIG_COMPAT
+-		if (copy_to_user(compat_ptr((unsigned long)tvps->props), tvp,
+-				tvps->num * sizeof(struct dtv_property))) {
+-			err = -EFAULT;
+-			goto out;
+-		}
+-#else
++
+ 		if (copy_to_user(tvps->props, tvp, tvps->num * sizeof(struct dtv_property))) {
+ 			err = -EFAULT;
+ 			goto out;
+ 		}
+-#endif
+ 
+ 	} else
+ 		err = -EOPNOTSUPP;
+@@ -2603,7 +2033,6 @@ static int dtv_set_frontend(struct dvb_frontend *fe)
+ 	struct dtv_frontend_properties *c = &fe->dtv_property_cache;
+ 	struct dvb_frontend_tune_settings fetunesettings;
+ 	u32 rolloff = 0;
+-	dev_dbg(fe->dvb->device, "dtv_set_frontend\n");
+ 
+ 	if (dvb_frontend_check_parameters(fe) < 0)
+ 		return -EINVAL;
+@@ -2678,18 +2107,16 @@ static int dtv_set_frontend(struct dvb_frontend *fe)
+ 		case SYS_DVBC_ANNEX_A:
+ 		case SYS_DVBC_ANNEX_C:
+ 			fepriv->min_delay = HZ / 20;
+-			fepriv->step_size = 0;
+-			fepriv->max_drift = 0;
++			fepriv->step_size = c->symbol_rate / 16000;
++			fepriv->max_drift = c->symbol_rate / 2000;
+ 			break;
+ 		case SYS_DVBT:
+ 		case SYS_DVBT2:
+ 		case SYS_ISDBT:
+ 		case SYS_DTMB:
+ 			fepriv->min_delay = HZ / 20;
+-			/*fe->ops.info.frequency_stepsize * 2;*/
+-			fepriv->step_size = 0;
+-			/*(fe->ops.info.frequency_stepsize * 2) + 1;*/
+-			fepriv->max_drift = 0;
++			fepriv->step_size = fe->ops.info.frequency_stepsize * 2;
++			fepriv->max_drift = (fe->ops.info.frequency_stepsize * 2) + 1;
+ 			break;
+ 		default:
+ 			/*
+@@ -2709,18 +2136,10 @@ static int dtv_set_frontend(struct dvb_frontend *fe)
+ 
+ 	/* Request the search algorithm to search */
+ 	fepriv->algo_status |= DVBFE_ALGO_SEARCH_AGAIN;
+-	if (c->delivery_system == SYS_ANALOG &&
+-		(c->analog.flag & ANALOG_FLAG_ENABLE_AFC)) {
+-		/*dvb_frontend_add_event(fe, 0); */
+-		dvb_frontend_clear_events(fe);
+-		dvb_frontend_wakeup(fe);
+-	} else if (fe->ops.set_frontend) {
+-		fe->ops.set_frontend(fe);
+-		if (c->delivery_system != SYS_ANALOG)
+-			dvb_frontend_clear_events(fe);
+-			dvb_frontend_add_event(fe, 0);
+-			dvb_frontend_wakeup(fe);
+-	}
++
++	dvb_frontend_clear_events(fe);
++	dvb_frontend_add_event(fe, 0);
++	dvb_frontend_wakeup(fe);
+ 	fepriv->status = 0;
+ 
+ 	return 0;
+@@ -2906,10 +2325,7 @@ static int dvb_frontend_ioctl_legacy(struct file *file,
+ 			int i;
+ 			u8 last = 1;
+ 			if (dvb_frontend_debug)
+-				dev_dbg(fe->dvb->device,
+-				"%s switch command: 0x%04lx\n",
+-				__func__,
+-				swcmd);
++				printk("%s switch command: 0x%04lx\n", __func__, swcmd);
+ 			do_gettimeofday(&nexttime);
+ 			if (dvb_frontend_debug)
+ 				tv[0] = nexttime;
+@@ -2932,12 +2348,10 @@ static int dvb_frontend_ioctl_legacy(struct file *file,
+ 					dvb_frontend_sleep_until(&nexttime, 8000);
+ 			}
+ 			if (dvb_frontend_debug) {
+-				dev_dbg(fe->dvb->device, "%s(%d): switch delay (should be 32k followed by all 8k\n",
++				printk("%s(%d): switch delay (should be 32k followed by all 8k\n",
+ 					__func__, fe->dvb->num);
+ 				for (i = 1; i < 10; i++)
+-					dev_dbg(fe->dvb->device,
+-					"%d: %d\n", i,
+-					timeval_usec_diff(tv[i-1] , tv[i]));
++					printk("%d: %d\n", i, timeval_usec_diff(tv[i-1] , tv[i]));
+ 			}
+ 			err = 0;
+ 			fepriv->state = FESTATE_DISEQC;
+@@ -2956,19 +2370,15 @@ static int dvb_frontend_ioctl_legacy(struct file *file,
+ 		break;
+ 
+ 	case FE_SET_FRONTEND:
+-		if (disable_set_frotend_param)
+-			break;
+-		dev_dbg(fe->dvb->device, "FE_SET_FRONTEND\n");
+ 		err = dvbv3_set_delivery_system(fe);
+ 		if (err)
+ 			break;
++
+ 		err = dtv_property_cache_sync(fe, c, parg);
+ 		if (err)
+ 			break;
+-		jiffiestime = jiffies_to_msecs(jiffies);
+ 		err = dtv_set_frontend(fe);
+ 		break;
+-
+ 	case FE_GET_EVENT:
+ 		err = dvb_frontend_get_event (fe, parg, file->f_flags);
+ 		break;
+@@ -2981,164 +2391,6 @@ static int dvb_frontend_ioctl_legacy(struct file *file,
+ 		fepriv->tune_mode_flags = (unsigned long) parg;
+ 		err = 0;
+ 		break;
+-
+-	case FE_SET_DELAY:
+-		fepriv->user_delay = (long)parg;
+-		err = 0;
+-		break;
+-
+-	case FE_SET_MODE:
+-		/*
+-		    set thread idle to avoid unnecessary EVT notification.
+-		    potential calls due to the EVT/s
+-		    may destroy the internal info.
+-		*/
+-		fepriv->state = FESTATE_IDLE;
+-
+-		if (fe->ops.set_mode) {
+-			err = fe->ops.set_mode(fe, (long)parg);
+-			if (err == 0) {
+-				switch ((long)parg) {
+-				case FE_QPSK:
+-					/*DVBV3_QPSK;*/
+-					c->delivery_system = SYS_DVBS2;
+-					break;
+-				case FE_QAM:
+-					/*DVBV3_QAM;*/
+-					c->delivery_system = SYS_DVBC_ANNEX_A;
+-					break;
+-				case FE_OFDM:
+-					/*DVBV3_OFDM;*/
+-					c->delivery_system = SYS_DVBT;
+-					break;
+-				case FE_ATSC:
+-					/*DVBV3_ATSC;*/
+-					c->delivery_system = SYS_ATSC;
+-					break;
+-				case FE_ANALOG:
+-					/*DVBV3_ANALOG;*/
+-					c->delivery_system = SYS_ANALOG;
+-					break;
+-				case FE_DTMB:
+-					/*DVBV3_OFDM;*/
+-					c->delivery_system = SYS_DTMB;
+-					break;
+-				case FE_ISDBT:
+-					/*DVBV3_OFDM;*/
+-					c->delivery_system = SYS_ISDBT;
+-					break;
+-				}
+-			}
+-		}
+-		break;
+-
+-	case FE_READ_TS:
+-		if (fe->ops.read_ts)
+-			err = fe->ops.read_ts(fe, (int *)parg);
+-		break;
+-	case FE_FINE_TUNE:
+-		if (fe->ops.tuner_ops.fine_tune) {
+-			err =
+-			fe->ops.tuner_ops.fine_tune(fe, *((int *)parg));
+-		}
+-		break;
+-	case FE_READ_TUNER_STATUS:
+-		if (fe->ops.tuner_ops.get_tuner_status) {
+-			struct tuner_status_s parm_status = {0};
+-			struct tuner_status_s *tmsp = parg;
+-			err =
+-			fe->ops.tuner_ops.get_tuner_status(fe, &parm_status);
+-			memcpy(tmsp, &parm_status,
+-				sizeof(struct tuner_status_s));
+-		}
+-		break;
+-	case FE_READ_ANALOG_STATUS:
+-		if (fe->ops.analog_ops.get_atv_status) {
+-			struct atv_status_s atv_stats = {0};
+-			struct atv_status_s *tmap = parg;
+-			err = fe->ops.analog_ops.get_atv_status(fe, &atv_stats);
+-			memcpy(tmap, &atv_stats, sizeof(struct atv_status_s));
+-		}
+-		break;
+-	case FE_READ_SD_STATUS:
+-		if (fe->ops.analog_ops.get_sd_status) {
+-			struct sound_status_s sound_sts = {0};
+-			err = fe->ops.analog_ops.get_sd_status(fe, &sound_sts);
+-			memcpy(parg, &sound_sts, sizeof(struct sound_status_s));
+-		}
+-		break;
+-	case FE_SET_PARAM_BOX:
+-		if (fe->ops.tuner_ops.set_config) {
+-			struct tuner_param_s tuner_parm = {0};
+-			memcpy(&tuner_parm, parg, sizeof(struct tuner_param_s));
+-			err = fe->ops.tuner_ops.set_config(fe, &tuner_parm);
+-			memcpy(parg, &tuner_parm, sizeof(struct tuner_param_s));
+-		}
+-		break;
+-
+-	case  FE_SET_BLINDSCAN:
+-		memcpy(&(fe->ops.blindscan_ops.info.bspara),
+-			parg, sizeof(struct dvbsx_blindscanpara));
+-
+-		dprintk("FE_SET_BLINDSCAN %d %d %d %d %d %d %d\n",
+-			fe->ops.blindscan_ops.info.bspara.minfrequency,
+-			fe->ops.blindscan_ops.info.bspara.maxfrequency,
+-			fe->ops.blindscan_ops.info.bspara.minSymbolRate,
+-			fe->ops.blindscan_ops.info.bspara.maxSymbolRate,
+-			fe->ops.blindscan_ops.info.bspara.frequencyRange,
+-			fe->ops.blindscan_ops.info.bspara.frequencyStep,
+-			fe->ops.blindscan_ops.info.bspara.timeout);
+-
+-		/*register*/
+-		fe->ops.blindscan_ops.info.blindscan_callback
+-			= dvbsx_blindscan_event_callback;
+-
+-		fepriv->in_blindscan = true;
+-
+-		if (fe->ops.blindscan_ops.blindscan_scan)
+-			err = fe->ops.blindscan_ops.blindscan_scan(fe,
+-				 &(fe->ops.blindscan_ops.info.bspara));
+-		break;
+-
+-	case  FE_GET_BLINDSCANEVENT:
+-		{
+-		struct dvbsx_blindscanevent *p_tmp_bsevent = NULL;
+-		err = dvbsx_blindscan_get_event(fe,
+-			(struct dvbsx_blindscanevent *)parg,
+-			file->f_flags);
+-
+-		p_tmp_bsevent = (struct dvbsx_blindscanevent *)parg;
+-
+-		dprintk("FE_GET_BLINDSCANEVENT status:%d\n",
+-			p_tmp_bsevent->status);
+-		if (p_tmp_bsevent->status == BLINDSCAN_UPDATESTARTFREQ) {
+-			dprintk("start freq %d\n",
+-			p_tmp_bsevent->u.m_uistartfreq_khz);
+-		} else if (p_tmp_bsevent->status == BLINDSCAN_UPDATEPROCESS) {
+-			dprintk("process %d\n", p_tmp_bsevent->u.m_uiprogress);
+-		} else if (p_tmp_bsevent->status
+-				== BLINDSCAN_UPDATERESULTFREQ) {
+-			dprintk("result freq %d symb %d\n",
+-			p_tmp_bsevent->u.parameters.frequency,
+-			p_tmp_bsevent->u.parameters.u.qpsk.symbol_rate);
+-		}
+-		}
+-		break;
+-
+-	case  FE_SET_BLINDSCANCANCEl:
+-		dprintk("FE_SET_BLINDSCANCANCEl\n");
+-
+-
+-		if (fe->ops.blindscan_ops.blindscan_cancel)
+-			err = fe->ops.blindscan_ops.blindscan_cancel(fe);
+-
+-		fepriv->in_blindscan = false;
+-
+-		/*unregister*/
+-		fe->ops.blindscan_ops.info.blindscan_callback = NULL;
+-
+-		break;
+-
+ 	}
+ 
+ 	return err;
+@@ -3240,8 +2492,6 @@ static int dvb_frontend_open(struct inode *inode, struct file *file)
+ 
+ 		/*  empty event queue */
+ 		fepriv->events.eventr = fepriv->events.eventw = 0;
+-		fepriv->blindscan_events.eventr
+-		= fepriv->blindscan_events.eventw = 0;
+ 	}
+ 
+ 	if (adapter->mfe_shared)
+@@ -3286,18 +2536,6 @@ static int dvb_frontend_release(struct inode *inode, struct file *file)
+ 	return ret;
+ }
+ 
+-#ifdef CONFIG_COMPAT
+-static long dvb_frontend_compat_ioctl(struct file *filp,
+-			unsigned int cmd, unsigned long args)
+-{
+-	unsigned long ret;
+-
+-	args = (unsigned long)compat_ptr(args);
+-	ret = dvb_generic_ioctl(filp, cmd, args);
+-	return ret;
+-}
+-#endif
+-
+ static const struct file_operations dvb_frontend_fops = {
+ 	.owner		= THIS_MODULE,
+ 	.unlocked_ioctl	= dvb_generic_ioctl,
+@@ -3305,10 +2543,6 @@ static const struct file_operations dvb_frontend_fops = {
+ 	.open		= dvb_frontend_open,
+ 	.release	= dvb_frontend_release,
+ 	.llseek		= noop_llseek,
+-#ifdef CONFIG_COMPAT
+-	.compat_ioctl	= dvb_frontend_compat_ioctl,
+-#endif
+-
+ };
+ 
+ int dvb_frontend_suspend(struct dvb_frontend *fe)
+@@ -3349,31 +2583,6 @@ int dvb_frontend_resume(struct dvb_frontend *fe)
+ }
+ EXPORT_SYMBOL(dvb_frontend_resume);
+ 
+-
+-static ssize_t dvbc_lock_show(struct class *cls,
+-				struct class_attribute *attr,
+-				char *buf)
+-{
+-	return sprintf(buf, "dvbc_autoflags: %s\n", LOCK_TIMEOUT?"on":"off");
+-}
+-static ssize_t dvbc_lock_store(struct class *cls,
+-				struct class_attribute *attr,
+-				const char *buf,
+-				size_t count)
+-{
+-	/*int mode = simple_strtol(buf, 0, 16);*/
+-	int mode = 0;
+-	count = kstrtol(buf, 0, (long *)&mode);
+-	LOCK_TIMEOUT = mode;
+-	return count;
+-
+-}
+-
+-static CLASS_ATTR(lock_time, 0644, dvbc_lock_show, dvbc_lock_store);
+-
+-struct class *tongfang_clsp;
+-#define LOCK_DEVICE_NAME  "tongfang"
+-
+ int dvb_register_frontend(struct dvb_adapter* dvb,
+ 			  struct dvb_frontend* fe)
+ {
+@@ -3386,7 +2595,6 @@ int dvb_register_frontend(struct dvb_adapter* dvb,
+ 		.kernel_ioctl = dvb_frontend_ioctl
+ 	};
+ 
+-	int ret;
+ 	dev_dbg(dvb->device, "%s:\n", __func__);
+ 
+ 	if (mutex_lock_interruptible(&frontend_mutex))
+@@ -3400,44 +2608,19 @@ int dvb_register_frontend(struct dvb_adapter* dvb,
+ 	fepriv = fe->frontend_priv;
+ 
+ 	sema_init(&fepriv->sem, 1);
+-	sema_init(&fepriv->blindscan_sem, 1);
+-	init_waitqueue_head(&fepriv->wait_queue);
+-	init_waitqueue_head(&fepriv->events.wait_queue);
+-	init_waitqueue_head(&fepriv->blindscan_events.wait_queue);
++	init_waitqueue_head (&fepriv->wait_queue);
++	init_waitqueue_head (&fepriv->events.wait_queue);
+ 	mutex_init(&fepriv->events.mtx);
+-	mutex_init(&fepriv->blindscan_events.mtx);
+ 	fe->dvb = dvb;
+ 	fepriv->inversion = INVERSION_OFF;
+ 
+-	init_waitqueue_head(&fepriv->setfrontendasync_wait_queue);
+-	fepriv->setfrontendasync_wakeup = 0;
+-	fepriv->setfrontendasync_needwakeup = 0;
+-	fepriv->setfrontendasync_interruptwakeup = 0;
+-
+-	fe->ops.asyncinfo.set_frontend_asyncpreproc = dvb_frontend_asyncpreproc;
+-	fe->ops.asyncinfo.set_frontend_asyncwait = dvb_frontend_asyncwait;
+-	fe->ops.asyncinfo.set_frontend_asyncpostproc
+-	= dvb_frontend_asyncpostproc;
+-
+ 	dev_info(fe->dvb->device,
+ 			"DVB: registering adapter %i frontend %i (%s)...\n",
+ 			fe->dvb->num, fe->id, fe->ops.info.name);
+ 
+ 	dvb_register_device (fe->dvb, &fepriv->dvbdev, &dvbdev_template,
+ 			     fe, DVB_DEVICE_FRONTEND);
+-	dev_dbg(fe->dvb->device, "For tongfang\n");
+-	ret = 0;
+-	tongfang_clsp = class_create(THIS_MODULE, LOCK_DEVICE_NAME);
+-	if (!tongfang_clsp) {
+-		dev_dbg(fe->dvb->device,
+-		"[tongfang]%s:create class error.\n", __func__);
+-		return PTR_ERR(tongfang_clsp);
+-	}
+-	ret = class_create_file(tongfang_clsp, &class_attr_lock_time);
+-	if (ret) {
+-		/* printk("[tongfang]%s create
+-		class file error.\n", __func__); */
+-	}
++
+ 	/*
+ 	 * Initialize the cache to the proper values according with the
+ 	 * first supported delivery system (ops->delsys[0])
+@@ -3466,8 +2649,6 @@ int dvb_unregister_frontend(struct dvb_frontend* fe)
+ 
+ 	mutex_lock(&frontend_mutex);
+ 	dvb_unregister_device (fepriv->dvbdev);
+-	class_remove_file(tongfang_clsp, &class_attr_lock_time);
+-	class_destroy(tongfang_clsp);
+ 
+ 	/* fe is invalid now */
+ 	kfree(fepriv);
+@@ -3513,17 +2694,3 @@ void dvb_frontend_detach(struct dvb_frontend* fe)
+ }
+ #endif
+ EXPORT_SYMBOL(dvb_frontend_detach);
+-
+-void dvb_frontend_retune(struct dvb_frontend *fe)
+-{
+-	struct dvb_frontend_private *fepriv = fe->frontend_priv;
+-
+-	fepriv->state = FESTATE_RETUNE;
+-
+-	fepriv->algo_status |= DVBFE_ALGO_SEARCH_AGAIN;
+-
+-	dvb_frontend_wakeup(fe);
+-	fepriv->status = 0;
+-}
+-EXPORT_SYMBOL(dvb_frontend_retune);
+-
+diff --git a/drivers/media/dvb-core/dvb_frontend.h b/drivers/media/dvb-core/dvb_frontend.h
+index 70ea290..371b6ca 100644
+--- a/drivers/media/dvb-core/dvb_frontend.h
++++ b/drivers/media/dvb-core/dvb_frontend.h
+@@ -38,7 +38,6 @@
+ #include <linux/mutex.h>
+ #include <linux/slab.h>
+ 
+-#include <linux/dvb/aml_demod.h>
+ #include <linux/dvb/frontend.h>
+ 
+ #include "dvbdev.h"
+@@ -49,11 +48,6 @@
+  */
+ #define MAX_DELSYS	8
+ 
+-#if (defined CONFIG_AM_M6_DEMOD)
+-extern u32 dvbc_get_status(void);
+-extern unsigned long atsc_read_iqr_reg(void);
+-#endif
+-
+ struct dvb_frontend_tune_settings {
+ 	int min_delay_ms;
+ 	int step_size;
+@@ -77,16 +71,8 @@ struct dvb_tuner_info {
+ struct analog_parameters {
+ 	unsigned int frequency;
+ 	unsigned int mode;
+-	unsigned int soundsys;/* A2,BTSC/EIAJ/NICAM */
+ 	unsigned int audmode;
+-	unsigned int lock_range;
+-	unsigned int leap_step;
+ 	u64 std;
+-	/*for amlatvdemod*/
+-	unsigned int tuner_id;
+-	unsigned int if_freq;
+-	unsigned int if_inv;
+-	unsigned int reserved;
+ };
+ 
+ enum dvbfe_modcod {
+@@ -232,21 +218,14 @@ struct dvb_tuner_ops {
+ 
+ #define TUNER_STATUS_LOCKED 1
+ #define TUNER_STATUS_STEREO 2
+-	int (*get_status)(struct dvb_frontend *fe, void *status);
+-	void (*get_pll_status)(struct dvb_frontend *fe, void *status);
++	int (*get_status)(struct dvb_frontend *fe, u32 *status);
+ 	int (*get_rf_strength)(struct dvb_frontend *fe, u16 *strength);
+ 	int (*get_afc)(struct dvb_frontend *fe, s32 *afc);
+-	int (*get_snr)(struct dvb_frontend *fe);
+ 
+ 	/** These are provided separately from set_params in order to facilitate silicon
+ 	 * tuners which require sophisticated tuning loops, controlling each parameter separately. */
+ 	int (*set_frequency)(struct dvb_frontend *fe, u32 frequency);
+ 	int (*set_bandwidth)(struct dvb_frontend *fe, u32 bandwidth);
+-	int (*set_tuner)(struct dvb_frontend *fe,
+-		struct aml_demod_sta *demod_sta,
+-		struct aml_demod_i2c *demod_i2c,
+-		struct aml_tuner_sys *tuner_sys);
+-	int (*get_strength)(struct dvb_frontend *fe);
+ 
+ 	/*
+ 	 * These are provided separately from set_params in order to facilitate silicon
+@@ -254,12 +233,6 @@ struct dvb_tuner_ops {
+ 	 */
+ 	int (*set_state)(struct dvb_frontend *fe, enum tuner_param param, struct tuner_state *state);
+ 	int (*get_state)(struct dvb_frontend *fe, enum tuner_param param, struct tuner_state *state);
+-	/*add function to get tuner status*/
+-	int (*get_tuner_status)(struct dvb_frontend *fe,
+-				struct tuner_status_s *tuner_status);
+-	/* add special fine tune function */
+-	int (*fine_tune)(struct dvb_frontend *fe,
+-				int offset_khz);
+ };
+ 
+ struct analog_demod_info {
+@@ -272,12 +245,8 @@ struct analog_demod_ops {
+ 
+ 	void (*set_params)(struct dvb_frontend *fe,
+ 			   struct analog_parameters *params);
+-	int (*has_signal)(struct dvb_frontend *fe, u16 *signal);
+-	int (*get_afc)(struct dvb_frontend *fe, s32 *afc);
+-	int (*is_stereo)(struct dvb_frontend *fe);
+-	int (*get_snr)(struct dvb_frontend *fe);
+-	int (*get_status)(struct dvb_frontend *fe, void *status);
+-	void (*get_pll_status)(struct dvb_frontend *fe, void *status);
++	int  (*has_signal)(struct dvb_frontend *fe, u16 *signal);
++	int  (*get_afc)(struct dvb_frontend *fe, s32 *afc);
+ 	void (*tuner_status)(struct dvb_frontend *fe);
+ 	void (*standby)(struct dvb_frontend *fe);
+ 	void (*release)(struct dvb_frontend *fe);
+@@ -285,42 +254,10 @@ struct analog_demod_ops {
+ 
+ 	/** This is to allow setting tuner-specific configuration */
+ 	int (*set_config)(struct dvb_frontend *fe, void *priv_cfg);
+-	/* add function to get atv_demod & stereo_demod status */
+-	int (*get_atv_status)(struct dvb_frontend *fe,
+-				struct atv_status_s *atv_status);
+-	int (*get_sd_status)(struct dvb_frontend *fe,
+-				struct sound_status_s *sd_status);
+ };
+ 
+ struct dtv_frontend_properties;
+ 
+-struct dvbsx_blindscan_info {
+-	/* timeout of get blindscan event */
+-	struct dvbsx_blindscanpara bspara;
+-	int (*blindscan_callback)(struct dvb_frontend *fe,
+-				  struct dvbsx_blindscanevent *pbsevent);
+-};
+-
+-struct dvbsx_blindscan_ops {
+-	struct dvbsx_blindscan_info info;
+-
+-	/*
+-	 *  These are provided start and stop blindscan
+-	 */
+-	int (*blindscan_scan)(struct dvb_frontend *fe,
+-			      struct dvbsx_blindscanpara *pbspara);
+-	int (*blindscan_cancel)(struct dvb_frontend *fe);
+-};
+-
+-struct dvb_frontend_asyncinfo {
+-	int set_frontend_asyncenable;
+-	int (*set_frontend_asyncpreproc)(struct dvb_frontend *fe);
+-	/*return value = 1 interrupt, = 0 timeout,  = -1 error*/
+-	int (*set_frontend_asyncwait)(struct dvb_frontend *fe, u32 timeout);
+-	int (*set_frontend_asyncpostproc)(struct dvb_frontend *fe,
+-					  int asyncwait_ret);
+-};
+-
+ struct dvb_frontend_ops {
+ 
+ 	struct dvb_frontend_info info;
+@@ -330,13 +267,13 @@ struct dvb_frontend_ops {
+ 	void (*release)(struct dvb_frontend* fe);
+ 	void (*release_sec)(struct dvb_frontend* fe);
+ 
+-	int (*init)(struct dvb_frontend *fe);
+-	int (*sleep)(struct dvb_frontend *fe);
++	int (*init)(struct dvb_frontend* fe);
++	int (*sleep)(struct dvb_frontend* fe);
+ 
+-	int (*write)(struct dvb_frontend *fe, const u8 buf[], int len);
++	int (*write)(struct dvb_frontend* fe, const u8 buf[], int len);
+ 
+ 	/* if this is set, it overrides the default swzigzag */
+-	int (*tune)(struct dvb_frontend *fe,
++	int (*tune)(struct dvb_frontend* fe,
+ 		    bool re_tune,
+ 		    unsigned int mode_flags,
+ 		    unsigned int *delay,
+@@ -346,23 +283,20 @@ struct dvb_frontend_ops {
+ 
+ 	/* these two are only used for the swzigzag code */
+ 	int (*set_frontend)(struct dvb_frontend *fe);
+-	int (*get_tune_settings)(struct dvb_frontend *fe,
+-				 struct dvb_frontend_tune_settings *settings);
++	int (*get_tune_settings)(struct dvb_frontend* fe, struct dvb_frontend_tune_settings* settings);
++
+ 	int (*get_frontend)(struct dvb_frontend *fe);
+ 
+-	int (*read_status)(struct dvb_frontend *fe, fe_status_t *status);
+-	int (*read_ber)(struct dvb_frontend *fe, u32 *ber);
+-	int (*read_signal_strength)(struct dvb_frontend *fe, u16 *strength);
+-	int (*read_snr)(struct dvb_frontend *fe, u16 *snr);
+-	int (*read_ucblocks)(struct dvb_frontend *fe, u32 *ucblocks);
+-	int (*set_qam_mode)(struct dvb_frontend *fe);
+-	int (*diseqc_reset_overload)(struct dvb_frontend *fe);
+-	int (*diseqc_send_master_cmd)(struct dvb_frontend *fe,
+-				      struct dvb_diseqc_master_cmd *cmd);
+-	int (*diseqc_recv_slave_reply)(struct dvb_frontend *fe,
+-				       struct dvb_diseqc_slave_reply *reply);
+-	int (*diseqc_send_burst)(struct dvb_frontend *fe,
+-				 fe_sec_mini_cmd_t minicmd);
++	int (*read_status)(struct dvb_frontend* fe, fe_status_t* status);
++	int (*read_ber)(struct dvb_frontend* fe, u32* ber);
++	int (*read_signal_strength)(struct dvb_frontend* fe, u16* strength);
++	int (*read_snr)(struct dvb_frontend* fe, u16* snr);
++	int (*read_ucblocks)(struct dvb_frontend* fe, u32* ucblocks);
++
++	int (*diseqc_reset_overload)(struct dvb_frontend* fe);
++	int (*diseqc_send_master_cmd)(struct dvb_frontend* fe, struct dvb_diseqc_master_cmd* cmd);
++	int (*diseqc_recv_slave_reply)(struct dvb_frontend* fe, struct dvb_diseqc_slave_reply* reply);
++	int (*diseqc_send_burst)(struct dvb_frontend* fe, fe_sec_mini_cmd_t minicmd);
+ 	int (*set_tone)(struct dvb_frontend* fe, fe_sec_tone_mode_t tone);
+ 	int (*set_voltage)(struct dvb_frontend* fe, fe_sec_voltage_t voltage);
+ 	int (*enable_high_lnb_voltage)(struct dvb_frontend* fe, long arg);
+@@ -375,23 +309,15 @@ struct dvb_frontend_ops {
+ 	 * tuning algorithms, rather than a simple swzigzag
+ 	 */
+ 	enum dvbfe_search (*search)(struct dvb_frontend *fe);
+-	int (*track)(struct dvb_frontend *fe,
+-		     struct dvb_frontend_parameters *p);
++
+ 	struct dvb_tuner_ops tuner_ops;
+ 	struct analog_demod_ops analog_ops;
+ 
+-	int (*set_property)(struct dvb_frontend *fe, struct dtv_property *tvp);
+-	int (*get_property)(struct dvb_frontend *fe, struct dtv_property *tvp);
+-
+-	struct dvbsx_blindscan_ops blindscan_ops;
+-
+-	int (*set_mode)(struct dvb_frontend *fe, fe_type_t type);
+-	int (*read_ts)(struct dvb_frontend *fe, int *ts);
+-	int (*read_dtmb_fsm)(struct dvb_frontend *fe, u32 *fsm_status);
+-
+-	struct dvb_frontend_asyncinfo asyncinfo;
++	int (*set_property)(struct dvb_frontend* fe, struct dtv_property* tvp);
++	int (*get_property)(struct dvb_frontend* fe, struct dtv_property* tvp);
+ };
+ 
++#ifdef __DVB_CORE__
+ #define MAX_EVENT 8
+ 
+ struct dvb_fe_events {
+@@ -402,17 +328,7 @@ struct dvb_fe_events {
+ 	wait_queue_head_t	  wait_queue;
+ 	struct mutex		  mtx;
+ };
+-
+-#define MAX_BLINDSCAN_EVENT 32
+-
+-struct dvbsx_blindscan_events {
+-	struct dvbsx_blindscanevent events[MAX_BLINDSCAN_EVENT];
+-	int			  eventw;
+-	int			  eventr;
+-	int			  overflow;
+-	wait_queue_head_t	  wait_queue;
+-	struct mutex		  mtx;
+-};
++#endif
+ 
+ struct dtv_frontend_properties {
+ 
+@@ -428,7 +344,7 @@ struct dtv_frontend_properties {
+ 	fe_code_rate_t		fec_inner;
+ 	fe_transmit_mode_t	transmission_mode;
+ 	u32			bandwidth_hz;	/* 0 = AUTO */
+-	fe_guard_interval_t guard_interval;
++	fe_guard_interval_t	guard_interval;
+ 	fe_hierarchy_t		hierarchy;
+ 	u32			symbol_rate;
+ 	fe_code_rate_t		code_rate_HP;
+@@ -437,8 +353,6 @@ struct dtv_frontend_properties {
+ 	fe_pilot_t		pilot;
+ 	fe_rolloff_t		rolloff;
+ 
+-	enum fe_ofdm_mode      ofdm_mode;
+-
+ 	fe_delivery_system_t	delivery_system;
+ 
+ 	enum fe_interleaving	interleaving;
+@@ -460,11 +374,6 @@ struct dtv_frontend_properties {
+ 	/* Multistream specifics */
+ 	u32			stream_id;
+ 
+-	u32         dvbt2_plp_id;
+-
+-	/* Analog specifics */
+-	struct dvb_analog_parameters analog;
+-	struct dvb_analog_parameters param;
+ 	/* ATSC-MH specifics */
+ 	u8			atscmh_fic_ver;
+ 	u8			atscmh_parade_id;
+diff --git a/drivers/media/dvb-core/dvbdev.c b/drivers/media/dvb-core/dvbdev.c
+index dbffaa0..983db75 100644
+--- a/drivers/media/dvb-core/dvbdev.c
++++ b/drivers/media/dvb-core/dvbdev.c
+@@ -47,7 +47,7 @@ static DEFINE_MUTEX(dvbdev_register_lock);
+ 
+ static const char * const dnames[] = {
+ 	"video", "audio", "sec", "frontend", "demux", "dvr", "ca",
+-	"net", "osd", "dsc"
++	"net", "osd"
+ };
+ 
+ #ifdef CONFIG_DVB_DYNAMIC_MINORS
+@@ -74,22 +74,15 @@ static int dvb_device_open(struct inode *inode, struct file *file)
+ 
+ 	if (dvbdev && dvbdev->fops) {
+ 		int err = 0;
+-		const struct file_operations *old_fops;
++		const struct file_operations *new_fops;
+ 
+-		file->private_data = dvbdev;
+-		old_fops = file->f_op;
+-		file->f_op = fops_get(dvbdev->fops);
+-		if (file->f_op == NULL) {
+-			file->f_op = old_fops;
++		new_fops = fops_get(dvbdev->fops);
++		if (!new_fops)
+ 			goto fail;
+-		}
++		file->private_data = dvbdev;
++		replace_fops(file, new_fops);
+ 		if (file->f_op->open)
+ 			err = file->f_op->open(inode,file);
+-		if (err) {
+-			fops_put(file->f_op);
+-			file->f_op = fops_get(old_fops);
+-		}
+-		fops_put(old_fops);
+ 		up_read(&minor_rwsem);
+ 		mutex_unlock(&dvbdev_mutex);
+ 		return err;
+diff --git a/drivers/media/dvb-core/dvbdev.h b/drivers/media/dvb-core/dvbdev.h
+index d2bee9c..93a9470 100644
+--- a/drivers/media/dvb-core/dvbdev.h
++++ b/drivers/media/dvb-core/dvbdev.h
+@@ -47,7 +47,6 @@
+ #define DVB_DEVICE_CA         6
+ #define DVB_DEVICE_NET        7
+ #define DVB_DEVICE_OSD        8
+-#define DVB_DEVICE_DSC        9
+ 
+ #define DVB_DEFINE_MOD_OPT_ADAPTER_NR(adapter_nr) \
+ 	static short adapter_nr[] = \
+diff --git a/include/uapi/linux/dvb/aml_demod.h b/include/uapi/linux/dvb/aml_demod.h
+deleted file mode 100644
+index 96990a5..0000000
+--- a/include/uapi/linux/dvb/aml_demod.h
++++ /dev/null
+@@ -1,214 +0,0 @@
+-#ifndef AML_DEMOD_H
+-#define AML_DEMOD_H
+-#ifndef CONFIG_AM_DEMOD_FPGA_VER
+-#define CONFIG_AM_DEMOD_FPGA_VER
+-#endif				/*CONFIG_AM_DEMOD_FPGA_VER */
+-
+-/*#include <linux/types.h>*/
+-#define u8_t u8
+-#define u16_t u16
+-#define u32_t u32
+-#define u64_t u64
+-
+-struct aml_demod_i2c {
+-	u8_t tuner;		/*type */
+-	u8_t addr;		/*slave addr */
+-	u32_t scl_oe;
+-	u32_t scl_out;
+-	u32_t scl_in;
+-	u8_t scl_bit;
+-	u32_t sda_oe;
+-	u32_t sda_out;
+-	u32_t sda_in;
+-	u8_t sda_bit;
+-	u8_t udelay;		/*us */
+-	u8_t retries;
+-	u8_t debug;		/*1:debug */
+-	u8_t tmp;		/*spare */
+-	u8_t i2c_id;
+-	void *i2c_priv;
+-};
+-
+-struct aml_tuner_sys {
+-	u8_t mode;
+-	u8_t amp;
+-	u8_t if_agc_speed;
+-	u32_t ch_freq;
+-	u32_t if_freq;
+-	u32_t rssi;
+-	u32_t delay;
+-	u8_t bandwith;
+-};
+-
+-struct aml_demod_sys {
+-	u8_t clk_en;		/* 1:on */
+-	u8_t clk_src;		/*2 bits */
+-	u8_t clk_div;		/*7 bits */
+-	u8_t pll_n;		/*5 bits */
+-	u16_t pll_m;		/*9 bits */
+-	u8_t pll_od;		/*7 bits */
+-	u8_t pll_sys_xd;	/*5 bits */
+-	u8_t pll_adc_xd;	/*5 bits */
+-	u8_t agc_sel;		/*pin mux */
+-	u8_t adc_en;		/*1:on */
+-	u8_t debug;		/*1:debug */
+-	u32_t i2c;		/*pointer */
+-	u32_t adc_clk;
+-	u32_t demod_clk;
+-};
+-
+-struct aml_demod_sts {
+-	u32_t ch_sts;
+-	u32_t freq_off;		/*Hz */
+-	u32_t ch_pow;
+-	u32_t ch_snr;
+-	u32_t ch_ber;
+-	u32_t ch_per;
+-	u32_t symb_rate;
+-	u32_t dat0;
+-	u32_t dat1;
+-};
+-
+-struct aml_demod_sta {
+-	u8_t clk_en;		/*on/off */
+-	u8_t adc_en;		/*on/off */
+-	u32_t clk_freq;		/*kHz */
+-	u32_t adc_freq;		/*kHz */
+-	u8_t dvb_mode;		/*dvb-t/c mode */
+-	u8_t ch_mode;		/* 16,32,..,256QAM or 2K,4K,8K */
+-	u8_t agc_mode;		/*if, rf or both. */
+-	u8_t tuner;		/*type */
+-	u32_t ch_freq;		/*kHz */
+-	u16_t ch_if;		/*kHz */
+-	u16_t ch_bw;		/*kHz */
+-	u16_t symb_rate;	/*kHz */
+-	u8_t debug;
+-	u8_t tmp;
+-	u32_t sts;		/*pointer */
+-	u8_t spectrum;
+-};
+-
+-struct aml_demod_dvbc {
+-	u8_t mode;
+-	u8_t tmp;
+-	u16_t symb_rate;
+-	u32_t ch_freq;
+-	u32_t dat0;
+-	u32_t dat1;
+-};
+-
+-struct aml_demod_dvbt {
+-	u8_t bw;
+-	u8_t sr;
+-	u8_t ifreq;
+-	u8_t agc_mode;
+-	u32_t ch_freq;
+-	u32_t dat0;
+-	u32_t dat1;
+-	u32_t layer;
+-
+-};
+-
+-struct aml_demod_dtmb {
+-	u8_t bw;
+-	u8_t sr;
+-	u8_t ifreq;
+-	u8_t agc_mode;
+-	u32_t ch_freq;
+-	u32_t dat0;
+-	u32_t dat1;
+-	u32_t mode;
+-
+-};
+-
+-struct aml_demod_atsc {
+-	u8_t bw;
+-	u8_t sr;
+-	u8_t ifreq;
+-	u8_t agc_mode;
+-	u32_t ch_freq;
+-	u32_t dat0;
+-	u32_t dat1;
+-	u32_t mode;
+-
+-};
+-
+-struct aml_demod_mem {
+-	u32_t addr;
+-	u32_t dat;
+-
+-};
+-
+-struct aml_cap_data {
+-	u32_t cap_addr;
+-	u32_t cap_size;
+-	u32_t cap_afifo;
+-	char  *cap_dev_name;
+-};
+-
+-struct aml_demod_reg {
+-	u8_t mode;
+-	u8_t rw;		/* 0: read, 1: write. */
+-	u32_t addr;
+-	u32_t val;
+-/*	u32_t val_high;*/
+-};
+-
+-struct aml_demod_regs {
+-	u8_t mode;
+-	u8_t rw;		/* 0: read, 1: write. */
+-	u32_t addr;
+-	u32_t addr_len;
+-	u32_t n;
+-	u32_t vals[1];		/*[mode i2c]: write:n*u32_t, read:n*u8_t */
+-};
+-struct fpga_m1_sdio {
+-	unsigned long addr;
+-	unsigned long byte_count;
+-	unsigned char *data_buf;
+-};
+-
+-#define AML_DEMOD_SET_SYS        _IOW('D',  0, struct aml_demod_sys)
+-#define AML_DEMOD_GET_SYS        _IOR('D',  1, struct aml_demod_sys)
+-#define AML_DEMOD_TEST           _IOR('D',  2, u32_t)
+-#define AML_DEMOD_TURN_ON        _IOR('D',  3, u32_t)
+-#define AML_DEMOD_TURN_OFF       _IOR('D',  4, u32_t)
+-#define AML_DEMOD_SET_TUNER      _IOW('D',  5, struct aml_tuner_sys)
+-#define AML_DEMOD_GET_RSSI       _IOR('D',  6, struct aml_tuner_sys)
+-
+-#define AML_DEMOD_DVBC_SET_CH    _IOW('D', 10, struct aml_demod_dvbc)
+-#define AML_DEMOD_DVBC_GET_CH    _IOR('D', 11, struct aml_demod_dvbc)
+-#define AML_DEMOD_DVBC_TEST      _IOR('D', 12, u32_t)
+-
+-#define AML_DEMOD_DVBT_SET_CH    _IOW('D', 20, struct aml_demod_dvbt)
+-#define AML_DEMOD_DVBT_GET_CH    _IOR('D', 21, struct aml_demod_dvbt)
+-#define AML_DEMOD_DVBT_TEST      _IOR('D', 22, u32_t)
+-
+-#define AML_DEMOD_DTMB_SET_CH    _IOW('D', 50, struct aml_demod_dtmb)
+-#define AML_DEMOD_DTMB_GET_CH    _IOR('D', 51, struct aml_demod_dtmb)
+-#define AML_DEMOD_DTMB_TEST      _IOR('D', 52, u32_t)
+-
+-#define AML_DEMOD_ATSC_SET_CH    _IOW('D', 60, struct aml_demod_atsc)
+-#define AML_DEMOD_ATSC_GET_CH    _IOR('D', 61, struct aml_demod_atsc)
+-#define AML_DEMOD_ATSC_TEST      _IOR('D', 62, u32_t)
+-#define AML_DEMOD_ATSC_IRQ       _IOR('D', 63, u32_t)
+-
+-#define AML_DEMOD_RESET_MEM		  _IOR('D', 70, u32_t)
+-#define	AML_DEMOD_READ_MEM		  _IOR('D', 71, u32_t)
+-#define AML_DEMOD_SET_MEM		  _IOR('D', 72, struct aml_demod_mem)
+-
+-#define AML_DEMOD_SET_REG        _IOW('D', 30, struct aml_demod_reg)
+-#define AML_DEMOD_GET_REG        _IOR('D', 31, struct aml_demod_reg)
+-/* #define AML_DEMOD_SET_REGS        _IOW('D', 32, struct aml_demod_regs)*/
+-/*#define AML_DEMOD_GET_REGS        _IOR('D', 33, struct aml_demod_regs)*/
+-#define FPGA2M1_SDIO_WR_DDR      _IOW('D', 40, struct fpga_m1_sdio)
+-#define FPGA2M1_SDIO_RD_DDR      _IOR('D', 41, struct fpga_m1_sdio)
+-#define FPGA2M1_SDIO_INIT        _IO('D', 42)
+-#define FPGA2M1_SDIO_EXIT        _IO('D', 43)
+-
+-int read_memory_to_file(struct aml_cap_data *cap);
+-int read_reg(int addr);
+-void wait_capture(int cap_cur_addr, int depth_MB, int start);
+-int cap_adc_data(struct aml_cap_data *cap);
+-
+-#endif				/* AML_DEMOD_H */
+diff --git a/include/uapi/linux/dvb/dmx.h b/include/uapi/linux/dvb/dmx.h
+index 029400a..b4fb650 100644
+--- a/include/uapi/linux/dvb/dmx.h
++++ b/include/uapi/linux/dvb/dmx.h
+@@ -29,25 +29,30 @@
+ #include <time.h>
+ #endif
+ 
++
+ #define DMX_FILTER_SIZE 16
+ 
+-enum dmx_output_t {
+-	DMX_OUT_DECODER,	/* Streaming directly to decoder. */
+-	DMX_OUT_TAP,		/* Output going to a memory buffer */
+-	/* (to be retrieved via the read command). */
+-	DMX_OUT_TS_TAP,		/* Output multiplexed into a new TS  */
+-	/* (to be retrieved by reading from the */
+-	/* logical DVR device).                 */
+-	DMX_OUT_TSDEMUX_TAP	/* Like TS_TAP but retrieved */
+-	/*from the DMX device */
+-};
++typedef enum
++{
++	DMX_OUT_DECODER, /* Streaming directly to decoder. */
++	DMX_OUT_TAP,     /* Output going to a memory buffer */
++			 /* (to be retrieved via the read command).*/
++	DMX_OUT_TS_TAP,  /* Output multiplexed into a new TS  */
++			 /* (to be retrieved by reading from the */
++			 /* logical DVR device).                 */
++	DMX_OUT_TSDEMUX_TAP /* Like TS_TAP but retrieved from the DMX device */
++} dmx_output_t;
+ 
+-enum dmx_input_t {
+-	DMX_IN_FRONTEND,	/* Input from a front-end device.  */
+-	DMX_IN_DVR		/* Input from the logical DVR device.  */
+-};
+ 
+-enum dmx_ts_pes {
++typedef enum
++{
++	DMX_IN_FRONTEND, /* Input from a front-end device.  */
++	DMX_IN_DVR       /* Input from the logical DVR device.  */
++} dmx_input_t;
++
++
++typedef enum dmx_ts_pes
++{
+ 	DMX_PES_AUDIO0,
+ 	DMX_PES_VIDEO0,
+ 	DMX_PES_TELETEXT0,
+@@ -73,7 +78,7 @@ enum dmx_ts_pes {
+ 	DMX_PES_PCR3,
+ 
+ 	DMX_PES_OTHER
+-};
++} dmx_pes_type_t;
+ 
+ #define DMX_PES_AUDIO    DMX_PES_AUDIO0
+ #define DMX_PES_VIDEO    DMX_PES_VIDEO0
+@@ -81,31 +86,35 @@ enum dmx_ts_pes {
+ #define DMX_PES_SUBTITLE DMX_PES_SUBTITLE0
+ #define DMX_PES_PCR      DMX_PES_PCR0
+ 
+-struct dmx_filter {
+-	__u8 filter[DMX_FILTER_SIZE];
+-	__u8 mask[DMX_FILTER_SIZE];
+-	__u8 mode[DMX_FILTER_SIZE];
+-};
+ 
+-struct dmx_sct_filter_params {
+-	__u16 pid;
+-	struct dmx_filter filter;
+-	__u32 timeout;
+-	__u32 flags;
++typedef struct dmx_filter
++{
++	__u8  filter[DMX_FILTER_SIZE];
++	__u8  mask[DMX_FILTER_SIZE];
++	__u8  mode[DMX_FILTER_SIZE];
++} dmx_filter_t;
++
++
++struct dmx_sct_filter_params
++{
++	__u16          pid;
++	dmx_filter_t   filter;
++	__u32          timeout;
++	__u32          flags;
+ #define DMX_CHECK_CRC       1
+ #define DMX_ONESHOT         2
+ #define DMX_IMMEDIATE_START 4
+ #define DMX_KERNEL_CLIENT   0x8000
+-#define DMX_USE_SWFILTER    0x100
+-
+ };
+ 
+-struct dmx_pes_filter_params {
+-	__u16 pid;
+-	enum dmx_input_t input;
+-	enum dmx_output_t output;
+-	enum dmx_ts_pes pes_type;
+-	__u32 flags;
++
++struct dmx_pes_filter_params
++{
++	__u16          pid;
++	dmx_input_t    input;
++	dmx_output_t   output;
++	dmx_pes_type_t pes_type;
++	__u32          flags;
+ };
+ 
+ typedef struct dmx_caps {
+@@ -113,19 +122,16 @@ typedef struct dmx_caps {
+ 	int num_decoders;
+ } dmx_caps_t;
+ 
+-enum dmx_source_t {
++typedef enum {
+ 	DMX_SOURCE_FRONT0 = 0,
+ 	DMX_SOURCE_FRONT1,
+ 	DMX_SOURCE_FRONT2,
+ 	DMX_SOURCE_FRONT3,
+-	DMX_SOURCE_DVR0 = 16,
++	DMX_SOURCE_DVR0   = 16,
+ 	DMX_SOURCE_DVR1,
+ 	DMX_SOURCE_DVR2,
+-	DMX_SOURCE_DVR3,
+-	DMX_SOURCE_FRONT0_OFFSET = 100,
+-	DMX_SOURCE_FRONT1_OFFSET,
+-	DMX_SOURCE_FRONT2_OFFSET
+-};
++	DMX_SOURCE_DVR3
++} dmx_source_t;
+ 
+ struct dmx_stc {
+ 	unsigned int num;	/* input : which STC? 0..N */
+@@ -133,6 +139,7 @@ struct dmx_stc {
+ 	__u64 stc;		/* output: stc in 'base'*90 kHz units */
+ };
+ 
++
+ #define DMX_START                _IO('o', 41)
+ #define DMX_STOP                 _IO('o', 42)
+ #define DMX_SET_FILTER           _IOW('o', 43, struct dmx_sct_filter_params)
+@@ -140,7 +147,7 @@ struct dmx_stc {
+ #define DMX_SET_BUFFER_SIZE      _IO('o', 45)
+ #define DMX_GET_PES_PIDS         _IOR('o', 47, __u16[5])
+ #define DMX_GET_CAPS             _IOR('o', 48, dmx_caps_t)
+-#define DMX_SET_SOURCE           _IOW('o', 49, enum dmx_source_t)
++#define DMX_SET_SOURCE           _IOW('o', 49, dmx_source_t)
+ #define DMX_GET_STC              _IOWR('o', 50, struct dmx_stc)
+ #define DMX_ADD_PID              _IOW('o', 51, __u16)
+ #define DMX_REMOVE_PID           _IOW('o', 52, __u16)
+diff --git a/include/uapi/linux/dvb/frontend.h b/include/uapi/linux/dvb/frontend.h
+index 9f9e75b..c56d77c 100644
+--- a/include/uapi/linux/dvb/frontend.h
++++ b/include/uapi/linux/dvb/frontend.h
+@@ -27,115 +27,101 @@
+ #define _DVBFRONTEND_H_
+ 
+ #include <linux/types.h>
+-#include <linux/videodev2.h>
+ 
+ typedef enum fe_type {
+ 	FE_QPSK,
+ 	FE_QAM,
+ 	FE_OFDM,
+-	FE_ATSC,
+-	FE_ANALOG,
+-	FE_DTMB,
+-	FE_ISDBT
++	FE_ATSC
+ } fe_type_t;
+ 
+-enum fe_layer {
+-	Layer_A_B_C,
+-	Layer_A,
+-	Layer_B,
+-	Layer_C,
+-};
+ 
+-enum fe_caps {
+-	FE_IS_STUPID = 0,
+-	FE_CAN_INVERSION_AUTO = 0x1,
+-	FE_CAN_FEC_1_2 = 0x2,
+-	FE_CAN_FEC_2_3 = 0x4,
+-	FE_CAN_FEC_3_4 = 0x8,
+-	FE_CAN_FEC_4_5 = 0x10,
+-	FE_CAN_FEC_5_6 = 0x20,
+-	FE_CAN_FEC_6_7 = 0x40,
+-	FE_CAN_FEC_7_8 = 0x80,
+-	FE_CAN_FEC_8_9 = 0x100,
+-	FE_CAN_FEC_AUTO = 0x200,
+-	FE_CAN_QPSK = 0x400,
+-	FE_CAN_QAM_16 = 0x800,
+-	FE_CAN_QAM_32 = 0x1000,
+-	FE_CAN_QAM_64 = 0x2000,
+-	FE_CAN_QAM_128 = 0x4000,
+-	FE_CAN_QAM_256 = 0x8000,
+-	FE_CAN_QAM_AUTO = 0x10000,
+-	FE_CAN_TRANSMISSION_MODE_AUTO = 0x20000,
+-	FE_CAN_BANDWIDTH_AUTO = 0x40000,
+-	FE_CAN_GUARD_INTERVAL_AUTO = 0x80000,
+-	FE_CAN_HIERARCHY_AUTO = 0x100000,
+-	FE_CAN_8VSB = 0x200000,
+-	FE_CAN_16VSB = 0x400000,
+-	FE_HAS_EXTENDED_CAPS = 0x800000,	/* We need more bitspace for*/
+-						/* newer APIs, indicate this. */
+-	FE_CAN_MULTISTREAM = 0x4000000,	/* frontend supports */
+-					/*multistream filtering */
+-	FE_CAN_TURBO_FEC = 0x8000000,	/* frontend supports */
+-					/*"turbo fec modulation" */
+-	FE_CAN_2G_MODULATION = 0x10000000,	/* frontend supports */
+-				/*"2nd generation modulation" (DVB-S2) */
+-	FE_NEEDS_BENDING = 0x20000000,	/* not supported anymore, don't */
+-				/*use (frontend requires frequency bending) */
+-	FE_CAN_RECOVER = 0x40000000,	/* frontend can recover from */
+-					/*a cable unplug automatically */
+-	FE_CAN_MUTE_TS = 0x80000000	/* frontend can stop */
+-					/*spurious TS data output */
+-};
++typedef enum fe_caps {
++	FE_IS_STUPID			= 0,
++	FE_CAN_INVERSION_AUTO		= 0x1,
++	FE_CAN_FEC_1_2			= 0x2,
++	FE_CAN_FEC_2_3			= 0x4,
++	FE_CAN_FEC_3_4			= 0x8,
++	FE_CAN_FEC_4_5			= 0x10,
++	FE_CAN_FEC_5_6			= 0x20,
++	FE_CAN_FEC_6_7			= 0x40,
++	FE_CAN_FEC_7_8			= 0x80,
++	FE_CAN_FEC_8_9			= 0x100,
++	FE_CAN_FEC_AUTO			= 0x200,
++	FE_CAN_QPSK			= 0x400,
++	FE_CAN_QAM_16			= 0x800,
++	FE_CAN_QAM_32			= 0x1000,
++	FE_CAN_QAM_64			= 0x2000,
++	FE_CAN_QAM_128			= 0x4000,
++	FE_CAN_QAM_256			= 0x8000,
++	FE_CAN_QAM_AUTO			= 0x10000,
++	FE_CAN_TRANSMISSION_MODE_AUTO	= 0x20000,
++	FE_CAN_BANDWIDTH_AUTO		= 0x40000,
++	FE_CAN_GUARD_INTERVAL_AUTO	= 0x80000,
++	FE_CAN_HIERARCHY_AUTO		= 0x100000,
++	FE_CAN_8VSB			= 0x200000,
++	FE_CAN_16VSB			= 0x400000,
++	FE_HAS_EXTENDED_CAPS		= 0x800000,   /* We need more bitspace for newer APIs, indicate this. */
++	FE_CAN_MULTISTREAM		= 0x4000000,  /* frontend supports multistream filtering */
++	FE_CAN_TURBO_FEC		= 0x8000000,  /* frontend supports "turbo fec modulation" */
++	FE_CAN_2G_MODULATION		= 0x10000000, /* frontend supports "2nd generation modulation" (DVB-S2) */
++	FE_NEEDS_BENDING		= 0x20000000, /* not supported anymore, don't use (frontend requires frequency bending) */
++	FE_CAN_RECOVER			= 0x40000000, /* frontend can recover from a cable unplug automatically */
++	FE_CAN_MUTE_TS			= 0x80000000  /* frontend can stop spurious TS data output */
++} fe_caps_t;
+ 
+-#define FE_CAN_3_LAYER FE_CAN_MULTISTREAM
+ 
+ struct dvb_frontend_info {
+-	char name[128];
+-	/* DEPRECATED. Use DTV_ENUM_DELSYS instead */
+-	enum fe_type type;
+-	__u32 frequency_min;
+-	__u32 frequency_max;
+-	__u32 frequency_stepsize;
+-	__u32 frequency_tolerance;
+-	__u32 symbol_rate_min;
+-	__u32 symbol_rate_max;
+-	__u32 symbol_rate_tolerance;	/* ppm */
+-	__u32 notifier_delay;	/* DEPRECATED */
+-	enum fe_caps caps;
++	char       name[128];
++	fe_type_t  type;			/* DEPRECATED. Use DTV_ENUM_DELSYS instead */
++	__u32      frequency_min;
++	__u32      frequency_max;
++	__u32      frequency_stepsize;
++	__u32      frequency_tolerance;
++	__u32      symbol_rate_min;
++	__u32      symbol_rate_max;
++	__u32      symbol_rate_tolerance;	/* ppm */
++	__u32      notifier_delay;		/* DEPRECATED */
++	fe_caps_t  caps;
+ };
+ 
++
+ /**
+  *  Check out the DiSEqC bus spec available on http://www.eutelsat.org/ for
+  *  the meaning of this struct...
+  */
+ struct dvb_diseqc_master_cmd {
+-	__u8 msg[6];		/*  { framing, address, command, data [3] } */
+-	__u8 msg_len;		/*  valid values are 3...6  */
++	__u8 msg [6];	/*  { framing, address, command, data [3] } */
++	__u8 msg_len;	/*  valid values are 3...6  */
+ };
+ 
++
+ struct dvb_diseqc_slave_reply {
+-	__u8 msg[4];		/*  { framing, data [3] } */
+-	__u8 msg_len;		/*  valid values are 0...4, 0 means no msg  */
+-	int timeout;		/*  return from ioctl after timeout ms with */
+-};				/*  errorcode when no message was received  */
++	__u8 msg [4];	/*  { framing, data [3] } */
++	__u8 msg_len;	/*  valid values are 0...4, 0 means no msg  */
++	int  timeout;	/*  return from ioctl after timeout ms with */
++};			/*  errorcode when no message was received  */
++
+ 
+ typedef enum fe_sec_voltage {
+ 	SEC_VOLTAGE_13,
+ 	SEC_VOLTAGE_18,
+-	SEC_VOLTAGE_OFF,
+-	SEC_VOLTAGE_ON		/*for ISDBT antenna control */
++	SEC_VOLTAGE_OFF
+ } fe_sec_voltage_t;
+ 
++
+ typedef enum fe_sec_tone_mode {
+ 	SEC_TONE_ON,
+ 	SEC_TONE_OFF
+ } fe_sec_tone_mode_t;
+ 
++
+ typedef enum fe_sec_mini_cmd {
+ 	SEC_MINI_A,
+ 	SEC_MINI_B
+ } fe_sec_mini_cmd_t;
+ 
++
+ /**
+  * enum fe_status - enumerates the possible frontend status
+  * @FE_HAS_SIGNAL:	found something above the noise level
+@@ -149,15 +135,14 @@ typedef enum fe_sec_mini_cmd {
+  */
+ 
+ typedef enum fe_status {
+-	FE_HAS_SIGNAL = 0x01,	/* found something above the noise level */
+-	FE_HAS_CARRIER = 0x02,	/* found a DVB signal  */
+-	FE_HAS_VITERBI = 0x04,	/* FEC is stable  */
+-	FE_HAS_SYNC = 0x08,	/* found sync bytes  */
+-	FE_HAS_LOCK = 0x10,	/* everything's working... */
+-	FE_TIMEDOUT = 0x20,	/* no lock within the last ~2 seconds */
+-	FE_REINIT = 0x40	/* frontend was reinitialized,  */
+-} fe_status_t;			/* application is recommended to reset */
+-				  /* DiSEqC, tone and parameters */
++	FE_HAS_SIGNAL		= 0x01,
++	FE_HAS_CARRIER		= 0x02,
++	FE_HAS_VITERBI		= 0x04,
++	FE_HAS_SYNC		= 0x08,
++	FE_HAS_LOCK		= 0x10,
++	FE_TIMEDOUT		= 0x20,
++	FE_REINIT		= 0x40,
++} fe_status_t;
+ 
+ typedef enum fe_spectral_inversion {
+ 	INVERSION_OFF,
+@@ -165,6 +150,7 @@ typedef enum fe_spectral_inversion {
+ 	INVERSION_AUTO
+ } fe_spectral_inversion_t;
+ 
++
+ typedef enum fe_code_rate {
+ 	FEC_NONE = 0,
+ 	FEC_1_2,
+@@ -181,6 +167,7 @@ typedef enum fe_code_rate {
+ 	FEC_2_5,
+ } fe_code_rate_t;
+ 
++
+ typedef enum fe_modulation {
+ 	QPSK,
+ 	QAM_16,
+@@ -210,8 +197,8 @@ typedef enum fe_transmit_mode {
+ 	TRANSMISSION_MODE_C3780,
+ } fe_transmit_mode_t;
+ 
+-/*#if defined(__DVB_CORE__) || !defined (__KERNEL__)*/
+-enum fe_bandwidth {
++#if defined(__DVB_CORE__) || !defined (__KERNEL__)
++typedef enum fe_bandwidth {
+ 	BANDWIDTH_8_MHZ,
+ 	BANDWIDTH_7_MHZ,
+ 	BANDWIDTH_6_MHZ,
+@@ -219,8 +206,8 @@ enum fe_bandwidth {
+ 	BANDWIDTH_5_MHZ,
+ 	BANDWIDTH_10_MHZ,
+ 	BANDWIDTH_1_712_MHZ,
+-};
+-/*#endif*/
++} fe_bandwidth_t;
++#endif
+ 
+ typedef enum fe_guard_interval {
+ 	GUARD_INTERVAL_1_32,
+@@ -236,6 +223,7 @@ typedef enum fe_guard_interval {
+ 	GUARD_INTERVAL_PN945,
+ } fe_guard_interval_t;
+ 
++
+ typedef enum fe_hierarchy {
+ 	HIERARCHY_NONE,
+ 	HIERARCHY_1,
+@@ -251,70 +239,42 @@ enum fe_interleaving {
+ 	INTERLEAVING_720,
+ };
+ 
+-enum fe_ofdm_mode {
+-	OFDM_DVBT,
+-	OFDM_DVBT2,
+-};
+-
+-/*#if defined(__DVB_CORE__) || !defined (__KERNEL__)*/
++#if defined(__DVB_CORE__) || !defined (__KERNEL__)
+ struct dvb_qpsk_parameters {
+-	__u32 symbol_rate;	/* symbol rate in Symbols per second */
+-	/* forward error correction (see above) */
+-	enum fe_code_rate fec_inner;
++	__u32		symbol_rate;  /* symbol rate in Symbols per second */
++	fe_code_rate_t	fec_inner;    /* forward error correction (see above) */
+ };
+ 
+ struct dvb_qam_parameters {
+-	/* symbol rate in Symbols per second */
+-	__u32 symbol_rate;
+-	/* forward error correction (see above) */
+-	enum fe_code_rate fec_inner;
+-	/* modulation type (see above) */
+-	enum fe_modulation modulation;
++	__u32		symbol_rate; /* symbol rate in Symbols per second */
++	fe_code_rate_t	fec_inner;   /* forward error correction (see above) */
++	fe_modulation_t	modulation;  /* modulation type (see above) */
+ };
+ 
+ struct dvb_vsb_parameters {
+-	enum fe_modulation modulation;	/* modulation type (see above) */
++	fe_modulation_t	modulation;  /* modulation type (see above) */
+ };
+ 
+ struct dvb_ofdm_parameters {
+-	enum fe_bandwidth bandwidth;
+-	/* high priority stream code rate */
+-	enum fe_code_rate code_rate_HP;
+-	/* low priority stream code rate */
+-	enum fe_code_rate code_rate_LP;
+-	/* modulation type (see above) */
+-	enum fe_modulation constellation;
+-	enum fe_transmit_mode transmission_mode;
+-	enum fe_guard_interval guard_interval;
+-	enum fe_hierarchy hierarchy_information;
+-	enum fe_ofdm_mode ofdm_mode;
++	fe_bandwidth_t      bandwidth;
++	fe_code_rate_t      code_rate_HP;  /* high priority stream code rate */
++	fe_code_rate_t      code_rate_LP;  /* low priority stream code rate */
++	fe_modulation_t     constellation; /* modulation type (see above) */
++	fe_transmit_mode_t  transmission_mode;
++	fe_guard_interval_t guard_interval;
++	fe_hierarchy_t      hierarchy_information;
+ };
+ 
+-#define ANALOG_FLAG_ENABLE_AFC                 0X00000001
+-#define  ANALOG_FLAG_MANUL_SCAN                0x00000011
+-struct dvb_analog_parameters {
+-	/*V4L2_TUNER_MODE_MONO,V4L2_TUNER_MODE_STEREO,
+-	   V4L2_TUNER_MODE_LANG2,V4L2_TUNER_MODE_SAP,
+-	   V4L2_TUNER_MODE_LANG1,V4L2_TUNER_MODE_LANG1_LANG2 */
+-	unsigned int audmode;
+-	unsigned int soundsys;	/*A2,BTSC,EIAJ,NICAM */
+-	v4l2_std_id std;
+-	unsigned int flag;
+-	unsigned int afc_range;
+-	unsigned int reserved;
+-};
+ 
+ struct dvb_frontend_parameters {
+-	/* (absolute) frequency in Hz for QAM/OFDM/ATSC */
+-	__u32 frequency;
+-	/* intermediate frequency in kHz for QPSK */
++	__u32 frequency;     /* (absolute) frequency in Hz for QAM/OFDM/ATSC */
++			     /* intermediate frequency in kHz for QPSK */
+ 	fe_spectral_inversion_t inversion;
+ 	union {
+ 		struct dvb_qpsk_parameters qpsk;
+-		struct dvb_qam_parameters qam;
++		struct dvb_qam_parameters  qam;
+ 		struct dvb_ofdm_parameters ofdm;
+ 		struct dvb_vsb_parameters vsb;
+-		struct dvb_analog_parameters analog;
+ 	} u;
+ };
+ 
+@@ -322,7 +282,7 @@ struct dvb_frontend_event {
+ 	fe_status_t status;
+ 	struct dvb_frontend_parameters parameters;
+ };
+-/*#endif*/
++#endif
+ 
+ /* S2API Commands */
+ #define DTV_UNDEFINED		0
+@@ -385,8 +345,6 @@ struct dvb_frontend_event {
+ 
+ #define DTV_ENUM_DELSYS		44
+ 
+-#define DTV_DVBT2_PLP_ID    DTV_DVBT2_PLP_ID_LEGACY
+-
+ /* ATSC-MH */
+ #define DTV_ATSCMH_FIC_VER		45
+ #define DTV_ATSCMH_PARADE_ID		46
+@@ -417,9 +375,7 @@ struct dvb_frontend_event {
+ #define DTV_STAT_ERROR_BLOCK_COUNT	68
+ #define DTV_STAT_TOTAL_BLOCK_COUNT	69
+ 
+-#define DTV_DVBT2_DATA_PLPS	70
+-
+-#define DTV_MAX_COMMAND	DTV_DVBT2_DATA_PLPS
++#define DTV_MAX_COMMAND		DTV_STAT_TOTAL_BLOCK_COUNT
+ 
+ typedef enum fe_pilot {
+ 	PILOT_ON,
+@@ -428,7 +384,7 @@ typedef enum fe_pilot {
+ } fe_pilot_t;
+ 
+ typedef enum fe_rolloff {
+-	ROLLOFF_35,		/* Implied value in DVB-S, default for DVB-S2 */
++	ROLLOFF_35, /* Implied value in DVB-S, default for DVB-S2 */
+ 	ROLLOFF_20,
+ 	ROLLOFF_25,
+ 	ROLLOFF_AUTO,
+@@ -452,59 +408,58 @@ typedef enum fe_delivery_system {
+ 	SYS_CMMB,
+ 	SYS_DAB,
+ 	SYS_DVBT2,
+-	SYS_ANALOG,
+ 	SYS_TURBO,
+-	SYS_DVBC_ANNEX_C
++	SYS_DVBC_ANNEX_C,
+ } fe_delivery_system_t;
+ 
+ /* backward compatibility */
+ #define SYS_DVBC_ANNEX_AC	SYS_DVBC_ANNEX_A
+-#define SYS_DMBTH SYS_DTMB	/* DMB-TH is legacy name, use DTMB instead */
++#define SYS_DMBTH SYS_DTMB /* DMB-TH is legacy name, use DTMB instead */
+ 
+ /* ATSC-MH */
+ 
+ enum atscmh_sccc_block_mode {
+-	ATSCMH_SCCC_BLK_SEP = 0,
+-	ATSCMH_SCCC_BLK_COMB = 1,
+-	ATSCMH_SCCC_BLK_RES = 2,
++	ATSCMH_SCCC_BLK_SEP      = 0,
++	ATSCMH_SCCC_BLK_COMB     = 1,
++	ATSCMH_SCCC_BLK_RES      = 2,
+ };
+ 
+ enum atscmh_sccc_code_mode {
+-	ATSCMH_SCCC_CODE_HLF = 0,
+-	ATSCMH_SCCC_CODE_QTR = 1,
+-	ATSCMH_SCCC_CODE_RES = 2,
++	ATSCMH_SCCC_CODE_HLF     = 0,
++	ATSCMH_SCCC_CODE_QTR     = 1,
++	ATSCMH_SCCC_CODE_RES     = 2,
+ };
+ 
+ enum atscmh_rs_frame_ensemble {
+-	ATSCMH_RSFRAME_ENS_PRI = 0,
+-	ATSCMH_RSFRAME_ENS_SEC = 1,
++	ATSCMH_RSFRAME_ENS_PRI   = 0,
++	ATSCMH_RSFRAME_ENS_SEC   = 1,
+ };
+ 
+ enum atscmh_rs_frame_mode {
+-	ATSCMH_RSFRAME_PRI_ONLY = 0,
+-	ATSCMH_RSFRAME_PRI_SEC = 1,
+-	ATSCMH_RSFRAME_RES = 2,
++	ATSCMH_RSFRAME_PRI_ONLY  = 0,
++	ATSCMH_RSFRAME_PRI_SEC   = 1,
++	ATSCMH_RSFRAME_RES       = 2,
+ };
+ 
+ enum atscmh_rs_code_mode {
+-	ATSCMH_RSCODE_211_187 = 0,
+-	ATSCMH_RSCODE_223_187 = 1,
+-	ATSCMH_RSCODE_235_187 = 2,
+-	ATSCMH_RSCODE_RES = 3,
++	ATSCMH_RSCODE_211_187    = 0,
++	ATSCMH_RSCODE_223_187    = 1,
++	ATSCMH_RSCODE_235_187    = 2,
++	ATSCMH_RSCODE_RES        = 3,
+ };
+ 
+ #define NO_STREAM_ID_FILTER	(~0U)
+ #define LNA_AUTO                (~0U)
+ 
+ struct dtv_cmds_h {
+-	char *name;		/* A display name for debugging purposes */
++	char	*name;		/* A display name for debugging purposes */
+ 
+-	__u32 cmd;		/* A unique ID */
++	__u32	cmd;		/* A unique ID */
+ 
+ 	/* Flags */
+-	__u32 set:1;		/* Either a set or get property */
+-	__u32 buffer:1;		/* Does this property use the buffer? */
+-	__u32 reserved:30;	/* Align */
++	__u32	set:1;		/* Either a set or get property */
++	__u32	buffer:1;	/* Does this property use the buffer? */
++	__u32	reserved:30;	/* Align */
+ };
+ 
+ /**
+@@ -558,13 +513,14 @@ enum fecap_scale_params {
+  *	u.st.len = 4;
+  */
+ struct dtv_stats {
+-	__u8 scale;		/* enum fecap_scale_params type */
++	__u8 scale;	/* enum fecap_scale_params type */
+ 	union {
+ 		__u64 uvalue;	/* for counters and relative scales */
+ 		__s64 svalue;	/* for 0.0001 dB measures */
+ 	};
+ } __attribute__ ((packed));
+ 
++
+ #define MAX_DTV_STATS   4
+ 
+ struct dtv_fe_stats {
+@@ -584,7 +540,6 @@ struct dtv_property {
+ 			__u32 reserved1[3];
+ 			void *reserved2;
+ 		} buffer;
+-		__u32 reserved[14];
+ 	} u;
+ 	int result;
+ } __attribute__ ((packed));
+@@ -594,113 +549,12 @@ struct dtv_property {
+ 
+ struct dtv_properties {
+ 	__u32 num;
+-	union {
+-		struct dtv_property *props;
+-		__u64 reserved;
+-	};
+-};
+-/* for atv */
+-struct tuner_status_s {
+-	unsigned int frequency;
+-	unsigned int rssi;
+-	unsigned char mode;	/*dtv:0 or atv:1 */
+-	unsigned char tuner_locked;	/*notlocked:0,locked:1 */
+-	union {
+-		void *ressrved;
+-		__u64 reserved1;
+-	};
+-};
+-
+-struct atv_status_s {
+-	unsigned char atv_lock;	/*notlocked:0,locked 1 */
+-	v4l2_std_id std;
+-	unsigned int audmode;
+-	int snr;
+-	int afc;
+-	union {
+-		void *resrvred;
+-		__u64 reserved1;
+-	};
+-};
+-
+-struct sound_status_s {
+-	/*A2DK/A2BG/NICAM BG/NICAM DK/BTSC/EIAJ */
+-	unsigned short sound_sys;
+-	unsigned short sound_mode;	/*SETERO/DUAL/MONO/SAP */
+-	union {
+-		void *resrvred;
+-		__u64 reserved1;
+-	};
+-};
+-enum tuner_param_cmd_e {
+-	TUNER_CMD_AUDIO_MUTE = 0x0000,
+-	/*0x0001 */
+-	TUNER_CMD_AUDIO_ON,
+-	TUNER_CMD_TUNER_POWER_ON,
+-	TUNER_CMD_TUNER_POWER_DOWN,
+-	TUNER_CMD_SET_VOLUME,
+-	TUNER_CMD_SET_LEAP_SETP_SIZE,
+-	TUNER_CMD_GET_MONO_MODE,
+-	TUNER_CMD_SET_BEST_LOCK_RANGE,
+-	TUNER_CMD_GET_BEST_LOCK_RANGE,
+-	TUNER_CMD_SET_CVBS_AMP_OUT,
+-	TUNER_CMD_GET_CVBS_AMP_OUT,
+-	TUNER_CMD_NULL,
+-};
+-/*parameter for set param box*/
+-struct tuner_param_s {
+-	enum tuner_param_cmd_e cmd;
+-	unsigned int parm;
+-	unsigned int resvred;
++	struct dtv_property *props;
+ };
+ 
+ #define FE_SET_PROPERTY		   _IOW('o', 82, struct dtv_properties)
+ #define FE_GET_PROPERTY		   _IOR('o', 83, struct dtv_properties)
+ 
+-/* Satellite blind scan settings */
+-struct dvbsx_blindscanpara {
+-	/* minimum tuner frequency in kHz */
+-	__u32 minfrequency;
+-	/* maximum tuner frequency in kHz */
+-	__u32 maxfrequency;
+-	/* minimum symbol rate in sym/sec */
+-	__u32 minSymbolRate;
+-	/* maximum symbol rate in sym/sec */
+-	__u32 maxSymbolRate;
+-	/* search range in kHz. freq -/+freqRange will be searched */
+-	__u32 frequencyRange;
+-	/* tuner step frequency in kHz */
+-	__u32 frequencyStep;
+-	/* blindscan event timeout */
+-	__s32 timeout;
+-};
+-
+-/* Satellite blind scan status */
+-enum dvbsx_blindscanstatus {
+-	BLINDSCAN_NONEDO,
+-	BLINDSCAN_UPDATESTARTFREQ,
+-	BLINDSCAN_UPDATEPROCESS,
+-	BLINDSCAN_UPDATERESULTFREQ
+-};
+-
+-/* Satellite blind scan event */
+-struct dvbsx_blindscanevent {
+-	enum dvbsx_blindscanstatus status;
+-	union {
+-		__u16 m_uiprogress;
+-		/* The percentage completion of the blind scan procedure.
+-		   A value of 100 indicates that the blind scan is finished. */
+-		__u32 m_uistartfreq_khz;
+-		/* The start scan frequency in units of kHz.
+-		   The minimum value depends on the tuner specification. */
+-		struct dvb_frontend_parameters parameters;
+-		/* Blind scan channel info. */
+-	} u;
+-};
+-
+-#define FE_SET_BLINDSCAN	_IOW('o', 84, struct dvbsx_blindscanpara)
+-#define FE_GET_BLINDSCANEVENT	_IOR('o', 85, struct dvbsx_blindscanevent)
+-#define FE_SET_BLINDSCANCANCEl	_IO('o', 86)
+ 
+ /**
+  * When set, this flag will disable any zigzagging or other "normal" tuning
+@@ -711,38 +565,29 @@ struct dvbsx_blindscanevent {
+  */
+ #define FE_TUNE_MODE_ONESHOT 0x01
+ 
++
+ #define FE_GET_INFO		   _IOR('o', 61, struct dvb_frontend_info)
+ 
+ #define FE_DISEQC_RESET_OVERLOAD   _IO('o', 62)
+ #define FE_DISEQC_SEND_MASTER_CMD  _IOW('o', 63, struct dvb_diseqc_master_cmd)
+ #define FE_DISEQC_RECV_SLAVE_REPLY _IOR('o', 64, struct dvb_diseqc_slave_reply)
+-#define FE_DISEQC_SEND_BURST       _IO('o', 65)	/* fe_sec_mini_cmd_t */
++#define FE_DISEQC_SEND_BURST       _IO('o', 65)  /* fe_sec_mini_cmd_t */
+ 
+-#define FE_SET_TONE		   _IO('o', 66)	/* fe_sec_tone_mode_t */
+-#define FE_SET_VOLTAGE		   _IO('o', 67)	/* fe_sec_voltage_t */
+-#define FE_ENABLE_HIGH_LNB_VOLTAGE _IO('o', 68)	/* int */
++#define FE_SET_TONE		   _IO('o', 66)  /* fe_sec_tone_mode_t */
++#define FE_SET_VOLTAGE		   _IO('o', 67)  /* fe_sec_voltage_t */
++#define FE_ENABLE_HIGH_LNB_VOLTAGE _IO('o', 68)  /* int */
+ 
+ #define FE_READ_STATUS		   _IOR('o', 69, fe_status_t)
+ #define FE_READ_BER		   _IOR('o', 70, __u32)
+ #define FE_READ_SIGNAL_STRENGTH    _IOR('o', 71, __u16)
+ #define FE_READ_SNR		   _IOR('o', 72, __u16)
+ #define FE_READ_UNCORRECTED_BLOCKS _IOR('o', 73, __u32)
++
+ #define FE_SET_FRONTEND		   _IOW('o', 76, struct dvb_frontend_parameters)
+ #define FE_GET_FRONTEND		   _IOR('o', 77, struct dvb_frontend_parameters)
+-#define FE_SET_FRONTEND_TUNE_MODE  _IO('o', 81)	/* unsigned int */
++#define FE_SET_FRONTEND_TUNE_MODE  _IO('o', 81) /* unsigned int */
+ #define FE_GET_EVENT		   _IOR('o', 78, struct dvb_frontend_event)
+ 
+-#define FE_DISHNETWORK_SEND_LEGACY_CMD _IO('o', 80)	/* unsigned int */
+-
+-#define FE_SET_DELAY               _IO('o', 100)
++#define FE_DISHNETWORK_SEND_LEGACY_CMD _IO('o', 80) /* unsigned int */
+ 
+-#define FE_SET_MODE                _IO('o', 90)
+-#define FE_READ_AFC                _IOR('o', 91, __u32)
+-#define FE_FINE_TUNE               _IOW('o', 92, __u32)
+-#define FE_READ_TUNER_STATUS       _IOR('o', 93, struct tuner_status_s)
+-#define FE_READ_ANALOG_STATUS      _IOR('o', 94, struct atv_status_s)
+-#define FE_READ_SD_STATUS          _IOR('o', 95, struct sound_status_s)
+-#define FE_READ_TS                 _IOR('o', 96, int)
+-/*set & get the tuner parameters only atv*/
+-#define FE_SET_PARAM_BOX           _IOWR('o', 97, struct tuner_param_s)
+ #endif /*_DVBFRONTEND_H_*/


### PR DESCRIPTION
that adds the WP2 dvb patches to the Odroid and WH and streamline the projects
- fixes building of mumudvb (that need dvb5 headers)

@kszaq @codesnake @Raybuntu objections ? (instead of adding it as patch at the projects merge at kernel?)