### PR TITLE
projects/imx6: init terminal with reset command in console service

### DIFF
--- a/projects/imx6/filesystem/usr/lib/systemd/system/serial-console.service
+++ b/projects/imx6/filesystem/usr/lib/systemd/system/serial-console.service
@@ -6,7 +6,7 @@ ConditionKernelCommandLine=console=ttymxc0,115200
 [Service]
 WorkingDirectory=/storage
 Environment="ENV=/etc/profile"
-ExecStartPre=/bin/sh -c 'echo -en "\033[?25h"'
+ExecStartPre=/bin/reset
 ExecStart=/bin/sh
 Restart=always
 RestartSec=0


### PR DESCRIPTION
sometimes terminal is not initialized properly (no cursor visible)