### PR TITLE
Odroid_C2/u-boot: Make LG CEC (Simplink) wakeup work

### DIFF
--- a/projects/Odroid_C2/patches/u-boot/u-boot-0003-update_cec_simplink_wakeup.patch
+++ b/projects/Odroid_C2/patches/u-boot/u-boot-0003-update_cec_simplink_wakeup.patch
@@ -1,0 +1,54 @@
+From 4afa1ca1f37bc084c2805f76372dc6a47e2d971a Mon Sep 17 00:00:00 2001
+From: Radostan Riedel <raybuntu@googlemail.com>
+Date: Sun, 30 Apr 2017 15:48:53 +0200
+Subject: [PATCH 1/1] CEC: make wakeup work with LG simplink
+
+---
+ .../cpu/armv8/gxb/firmware/scp_task/hdmi_cec_arc.c | 24 ++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/arch/arm/cpu/armv8/gxb/firmware/scp_task/hdmi_cec_arc.c b/arch/arm/cpu/armv8/gxb/firmware/scp_task/hdmi_cec_arc.c
+index 7d397cac8b..8a3423b7cc 100644
+--- a/arch/arm/cpu/armv8/gxb/firmware/scp_task/hdmi_cec_arc.c
++++ b/arch/arm/cpu/armv8/gxb/firmware/scp_task/hdmi_cec_arc.c
+@@ -359,6 +359,18 @@ static void cec_get_version(unsigned char initiator)
+ 	cec_triggle_tx(msg, 3);
+ }
+ 
++void cec_send_simplink_init_ack(void)
++{
++	unsigned char msg[4];
++
++	msg[0] = ((cec_msg.log_addr & 0xf) << 4) | CEC_TV_ADDR;
++	msg[1] = CEC_OC_VENDOR_COMMAND;
++	msg[2] = 0x2;
++	msg[3] = 0x5;
++
++	cec_triggle_tx(msg, 4);
++}
++
+ static unsigned int cec_handle_message(void)
+ {
+ 	unsigned char initiator = (cec_msg.msg[0] >> 4) & 0xf;
+@@ -388,6 +400,18 @@ static unsigned int cec_handle_message(void)
+ 		cec_device_vendor_id();
+ 		break;
+ 	case CEC_OC_VENDOR_COMMAND:
++		if (cec_msg.msg_len < 3)
++			break;
++		if (directly_addressed) {
++			if (cec_msg.msg[2] == 0x1) { // SL INIT
++				cec_send_simplink_init_ack(); // SL INIT ACK
++			}
++			if ((cec_msg.msg[2] == 0x3) || // SL POWER ON
++				(cec_msg.msg[2] == 0x4) || // SL CONNECT REQUEST
++				(cec_msg.msg[2] == 0xb)) { // SL RECONNECT REQUEST
++				cec_msg.cec_power = 0x1;
++			}
++		}
+ 	case CEC_OC_VENDOR_COMMAND_WITH_ID:
+ 		break;
+ 	case CEC_OC_GIVE_OSD_NAME:
+-- 
+2.11.0
+


### PR DESCRIPTION
Using this Patch a LG TV can wake up an Odroid C2 using Simplink Vendor CEC commands. 
I wasn't able to test it myself but thanks to odroid forum user "Jacobo" for providing Logs and doing tests on actual LG hardware I'm sure it's working.
I can create a LE8 backport if necessary.