### PR TITLE
tools/update_binary-addons: ignore game.* addons

### DIFF
--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
@@ -128,6 +128,9 @@ for addontxt in $KODI_DIR/cmake/addons/bootstrap/repositories/*-addons.txt ; do
   git_clone $ADDONREPO master $ADDONS.git $GIT_HASH
   for addon in $ADDONS.git/*.*/ ; do
     ADDON=$(basename $addon)
+
+    [[ ${ADDON} =~ ^game.* ]] && continue # ignore game.* addons - handled by update_retroplayer-addons
+
     REPO=$(cat $addon/$ADDON.txt | awk '{print $2}')
     GIT_HASH=$(cat $addon/$ADDON.txt | awk '{print $3}')
     PKG_NAME="$ADDON"
@@ -166,6 +169,8 @@ done
 
 # finally, any other unofficial addons
 for ADDON in $(ls -1 ../../packages/mediacenter/kodi-binary-addons); do
+  [[ ${ADDON} =~ ^game.* ]] && continue # ignore game.* addons - handled by update_retroplayer-addons
+
   # ignore already processed addons
   echo -e "${PROCESSED}" | grep -qE "^${ADDON}$" && continue
 


### PR DESCRIPTION
Just a quick hack to ignore `game.*` addons when updating binary addons.