### PR TITLE
imx6/linux: limit ethernet speed to 100mbits which works reliable ...

### DIFF
--- a/projects/imx6/bootloader/uEnv-matrix.txt
+++ b/projects/imx6/bootloader/uEnv-matrix.txt
@@ -11,7 +11,10 @@ console_arg=quiet morequiet
 # enable debugging (kodi debug)
 #debugging_arg=debugging
 
+# enable gigabit speed instead of 100mbit
+#enable_giga_arg=fec.disable_giga=0
+
 zImage=/KERNEL
 bootfile=/KERNEL
-mmcargs=setenv bootargs "boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 ${ssh_arg} ${console_arg} ${debugging_arg} video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32 dmfc=3 consoleblank=0"
+mmcargs=setenv bootargs "boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 ${ssh_arg} ${console_arg} ${debugging_arg} ${enable_giga_arg} video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32 dmfc=3 consoleblank=0"
 uenvcmd=if test -n $ethaddr; then true; else setenv ethaddr 1E:ED:19:27:1A:B2; fi

--- a/projects/imx6/bootloader/uEnv-udoo.txt
+++ b/projects/imx6/bootloader/uEnv-udoo.txt
@@ -1,5 +1,4 @@
-
-# enable only one video section
+# enable only one video output
 
 # HDMI
 video=mxcfb0:dev=hdmi,1920x1080M@60,bpp=32
@@ -27,6 +26,9 @@ console_arg=quiet morequiet
 # enable debugging (kodi debug)
 #debugging_arg=debugging
 
+# enable gigabit speed instead of 100mbit
+#enable_giga_arg=fec.disable_giga=0
+
 zImage=/KERNEL
 bootfile=/KERNEL
-mmcargs=setenv bootargs boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 ${ssh_arg} ${console_arg} ${debugging_arg} video=${video} dmfc=3 consoleblank=0
+mmcargs=setenv bootargs boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 ${ssh_arg} ${console_arg} ${debugging_arg} ${enable_giga_arg} video=${video} dmfc=3 consoleblank=0

--- a/projects/imx6/bootloader/uEnv.txt
+++ b/projects/imx6/bootloader/uEnv.txt
@@ -11,6 +11,12 @@ console_arg=quiet morequiet
 # enable debugging (kodi debug)
 #debugging_arg=debugging
 
+# overwrite dtb file
+#fdt_file=imx6q-cubox-i.dtb
+
+# enable gigabit speed instead of 100mbit
+#enable_giga_arg=fec.disable_giga=0
+
 zImage=/KERNEL
 bootfile=/KERNEL
-mmcargs=setenv bootargs "boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 ${ssh_arg} ${console_arg} ${debugging_arg} video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32 dmfc=3 consoleblank=0"
+mmcargs=setenv bootargs "boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 ${ssh_arg} ${console_arg} ${debugging_arg} ${enable_giga_arg} video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32 dmfc=3 consoleblank=0"

--- a/projects/imx6/patches/linux/3.14-sr/linux-410-limit-eth-speed-100mbits.patch
+++ b/projects/imx6/patches/linux/3.14-sr/linux-410-limit-eth-speed-100mbits.patch
@@ -1,0 +1,55 @@
+From a868ebd7d7e9ee8dc97b41ac89e5fa8d8cfc65d7 Mon Sep 17 00:00:00 2001
+From: Peter Vicman <peter.vicman@gmail.com>
+Date: Wed, 9 May 2017 20:18:07 +0200
+Subject: [PATCH] limit eth speed 100mbits
+
+default ethernet speed is set to 100mbits which works reliable
+
+to enable gigabit speed module parameter via kernel command line
+must be set in form fec.disable_giga=0
+
+based on https://github.com/boundarydevices/linux-imx6/commit/aef0deef3c95aa0daf4fa5d082cca4ed2057c65f
+ 
+---
+ drivers/net/ethernet/freescale/fec_main.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/freescale/fec_main.c b/drivers/net/ethernet/freescale/fec_main.c
+index 716fcb1..af01828 100644
+--- a/drivers/net/ethernet/freescale/fec_main.c
++++ b/drivers/net/ethernet/freescale/fec_main.c
+@@ -140,6 +140,10 @@ static unsigned char macaddr[ETH_ALEN];
+ module_param_array(macaddr, byte, NULL, 0);
+ MODULE_PARM_DESC(macaddr, "FEC Ethernet MAC address");
+ 
++static int disable_giga = 1;
++module_param(disable_giga, int, 0644);
++MODULE_PARM_DESC(disable_giga, "disable gigabit speeds");
++
+ #if defined(CONFIG_M5272)
+ /*
+  * Some hardware gets it MAC address out of local flash memory.
+@@ -1948,15 +1952,18 @@ static int fec_enet_mii_probe(struct net
+ 	}
+ 
+ 	/* mask with MAC supported features */
+-	if (fep->quirks & FEC_QUIRK_HAS_GBIT) {
++	if (!disable_giga && (fep->quirks & FEC_QUIRK_HAS_GBIT)) {
++		netdev_info(ndev, "set 1000mbps\n");
+ 		phy_dev->supported &= PHY_GBIT_FEATURES;
+ 		phy_dev->supported &= ~SUPPORTED_1000baseT_Half;
+ #if !defined(CONFIG_M5272)
+ 		phy_dev->supported |= SUPPORTED_Pause;
+ #endif
+ 	}
+-	else
++	else {
++		netdev_info(ndev, "set 100mbps\n");
+ 		phy_dev->supported &= PHY_BASIC_FEATURES;
++	}
+ 
+ 	phy_dev->advertising = phy_dev->supported;
+ 
+-- 
+2.7.4
+

--- a/projects/imx6/patches/linux/4.4-xbian/linux-410-limit-eth-speed-100mbits.patch
+++ b/projects/imx6/patches/linux/4.4-xbian/linux-410-limit-eth-speed-100mbits.patch
@@ -1,0 +1,55 @@
+From a868ebd7d7e9ee8dc97b41ac89e5fa8d8cfc65d7 Mon Sep 17 00:00:00 2001
+From: Peter Vicman <peter.vicman@gmail.com>
+Date: Wed, 9 May 2017 20:18:07 +0200
+Subject: [PATCH] limit eth speed 100mbits
+
+default ethernet speed is set to 100mbits which works reliable
+
+to enable gigabit speed module parameter via kernel command line
+must be set in form fec.disable_giga=0
+
+based on https://github.com/boundarydevices/linux-imx6/commit/aef0deef3c95aa0daf4fa5d082cca4ed2057c65f
+ 
+---
+ drivers/net/ethernet/freescale/fec_main.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/freescale/fec_main.c b/drivers/net/ethernet/freescale/fec_main.c
+index 716fcb1..af01828 100644
+--- a/drivers/net/ethernet/freescale/fec_main.c
++++ b/drivers/net/ethernet/freescale/fec_main.c
+@@ -142,6 +142,10 @@ static unsigned char macaddr[ETH_ALEN];
+ module_param_array(macaddr, byte, NULL, 0);
+ MODULE_PARM_DESC(macaddr, "FEC Ethernet MAC address");
+ 
++static int disable_giga = 1;
++module_param(disable_giga, int, 0644);
++MODULE_PARM_DESC(disable_giga, "disable gigabit speeds");
++
+ #if defined(CONFIG_M5272)
+ /*
+  * Some hardware gets it MAC address out of local flash memory.
+@@ -1973,15 +1977,18 @@ static int fec_enet_mii_probe(struct net
+ 	}
+ 
+ 	/* mask with MAC supported features */
+-	if (fep->quirks & FEC_QUIRK_HAS_GBIT) {
++	if (!disable_giga && (fep->quirks & FEC_QUIRK_HAS_GBIT)) {
++		netdev_info(ndev, "set 1000mbps\n");
+ 		phy_dev->supported &= PHY_GBIT_FEATURES;
+ 		phy_dev->supported &= ~SUPPORTED_1000baseT_Half;
+ #if !defined(CONFIG_M5272)
+ 		phy_dev->supported |= SUPPORTED_Pause;
+ #endif
+ 	}
+-	else
++	else {
++		netdev_info(ndev, "set 100mbps\n");
+ 		phy_dev->supported &= PHY_BASIC_FEATURES;
++	}
+ 
+ 	phy_dev->advertising = phy_dev->supported;
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
… [backport of #1617]

to enable gigabit speed module parameter via kernel command line
must be set in form fec.disable_giga=0