### PR TITLE
aarch64/neon: update neon checks in ffmpeg and pulseaudio

### DIFF
--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -46,7 +46,8 @@ else
   PULSEAUDIO_AVAHI="--disable-avahi"
 fi
 
-if [ "$TARGET_FPU" = "neon" -o "$TARGET_FPU" = "neon-fp16" -o "$TARGET_FPU" = "neon-vfpv4" ]; then
+# PulseAudio fails to build on aarch64 when NEON is enabled, so don't enable NEON for aarch64 until upstream supports it
+if echo "$TARGET_FPU" | grep -q '^neon'; then
   PULSEAUDIO_NEON="--enable-neon-opt"
 else
   PULSEAUDIO_NEON="--disable-neon-opt"

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -68,14 +68,11 @@ case "$TARGET_ARCH" in
     ;;
 esac
 
-case "$TARGET_FPU" in
-  neon*)
-    FFMPEG_FPU="--enable-neon"
-    ;;
-  *)
-    FFMPEG_FPU="--disable-neon"
-    ;;
-esac
+if echo "$TARGET_FPU" | grep -q '^neon' || [[ "$TARGET_ARCH" = "aarch64" ]]; then
+  FFMPEG_FPU="--enable-neon"
+else
+  FFMPEG_FPU="--disable-neon"
+fi
 
 if [ "$DISPLAYSERVER" = "x11" ]; then
   FFMPEG_X11GRAB="--enable-indev=x11grab_xcb"


### PR DESCRIPTION
ffmpeg-3.3 includes new support that depends on NEON which isn't being enabled on aarch64, so the ffmpeg build fails:
```
LD      ffmpeg_g
libavcodec/libavcodec.so: undefined reference to `ff_vp9_copy64_aarch64'
libavcodec/libavcodec.so: undefined reference to `ff_idctdsp_init_aarch64'
libavcodec/libavcodec.so: undefined reference to `ff_vp9_copy32_aarch64'
libavcodec/libavcodec.so: undefined reference to `ff_vp9_copy128_aarch64'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:136: ffmpeg_g] Error 1
make[1]: Leaving directory '/home/neil/projects/LibreELEC.tv/build.LibreELEC-WeTek_Play_2.aarch64-9.0-devel/ffmpeg-eb0819c'
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 2
```

PulseAudio-10.0 will fail to build with NEON enabled on aarch64:
```
checking whether the linker accepts -Wl,--no-undefined... yes
checking whether /home/neil/projects/LibreELEC.tv/build.LibreELEC-WeTek_Play_2.aarch64-9.0-devel/toolchain/bin/aarch64-libreelec-linux-gnueabi-gcc knows __sync_bool_compare_and_swap()... yes
configure: error: *** Compiler does not support -mfpu=neon or CFLAGS override -mfpu
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 1
```
This seems to be an [upstream issue](https://github.com/pulseaudio/pulseaudio/blob/61860e7cebd55b6bf95169cd5c65f31316bcebdc/configure.ac#L348-L374).

For now I've just updated the test to be consistent with usage elsewhere (ffmpeg, libdvbcsa), but without the aarch64 test and left a comment about aarch64 build failure.