### PR TITLE
libva-utils: initial package

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -1,6 +1,6 @@
 ################################################################################
 #      This file is part of LibreELEC - https://libreelec.tv
-#      Copyright (C) 2016 Team LibreELEC
+#      Copyright (C) 2016-present Team LibreELEC
 #
 #  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -1,0 +1,44 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libva-utils"
+PKG_VERSION="1.8.1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/01org/libva-utils"
+PKG_URL="https://github.com/01org/libva-utils/releases/download/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.bz2"
+PKG_SECTION="debug"
+PKG_SHORTDESC="Libva-utils is a collection of tests for VA-API (VIdeo Acceleration API)"
+PKG_LONGDESC="Libva-utils is a collection of tests for VA-API (VIdeo Acceleration API)"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+if [ "$DISPLAYSERVER" = "x11" ]; then
+  PKG_DEPENDS_TARGET="toolchain libva libdrm libX11"
+  DISPLAYSERVER_LIBVA="--enable-x11"
+else
+  PKG_DEPENDS_TARGET="toolchain libva libdrm"
+  DISPLAYSERVER_LIBVA="--disable-x11"
+fi
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-silent-rules \
+                           --enable-drm \
+                           $DISPLAYSERVER_LIBVA \
+                           --disable-wayland \
+                           --disable-tests"

--- a/packages/virtual/debug/package.mk
+++ b/packages/virtual/debug/package.mk
@@ -37,6 +37,10 @@ if [ "$VDPAU_SUPPORT" = "yes" -a "$DISPLAYSERVER" = "x11" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET vdpauinfo"
 fi
 
+if [ "$VAAPI_SUPPORT" = "yes" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libva-utils"
+fi
+
 if [ "$DEBUG" = "yes" -a "$VALGRIND" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET valgrind"
 fi


### PR DESCRIPTION
ping @MilhouseVH and @piotrasd 

The change to intel-vaapi-driver moved vainfo to libva-utils