### PR TITLE
imx6/options: unify linux version strings and simplify it's usage …

### DIFF
--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -22,13 +22,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libcec.pulse-eight.com/"
 PKG_URL="https://github.com/Pulse-Eight/libcec/archive/$PKG_VERSION.tar.gz"
-if [ "$PROJECT" = "imx6" ]; then
-  if [ "$LINUX_VERSION" = "sr-3.14" ]; then
-    PKG_PATCH_DIRS="3.14-sr"
-  else
-    PKG_PATCH_DIRS="4.4-xbian"
-  fi
-fi
+[ "$PROJECT" = "imx6" ] && PKG_PATCH_DIRS="${LINUX#imx6-}"
 PKG_DEPENDS_TARGET="toolchain systemd lockdev p8-platform"
 PKG_SECTION="system"
 PKG_SHORTDESC="libCEC is an open-source dual licensed library designed for communicating with the Pulse-Eight USB - CEC Adaptor"

--- a/packages/graphics/imx-gpu-viv/package.mk
+++ b/packages/graphics/imx-gpu-viv/package.mk
@@ -62,7 +62,7 @@ makeinstall_target() {
              g2d/usr/lib/libg2d*.so*"
 
   # missing in 5.0.11.p7.4-hfp
-  if [ "$LINUX" = "imx6-3.14-sr" ]; then
+  if [ "$PKG_VERSION" = "5.0.11.p4.5-hfp" ]; then
     LIBS_COPY="$LIBS_COPY \
                gpu-core/usr/lib/libGAL_egl.fb.so \
                gpu-core/usr/lib/libGAL_egl.so*"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -130,15 +130,6 @@ post_patch() {
     sed -i -e "s|^CONFIG_ISCSI_IBFT_FIND=.*$|# CONFIG_ISCSI_IBFT_FIND is not set|" $PKG_BUILD/.config
     sed -i -e "s|^CONFIG_ISCSI_IBFT=.*$|# CONFIG_ISCSI_IBFT is not set|" $PKG_BUILD/.config
   fi
-
-  # enable different libcec version for imx6 project with kernel 4.4
-  # using customized kernel driver
-  if [ "$PROJECT" = "imx6" ]; then
-    if [ "$LIBCEC_TYPE" = "xbian" -a "$LINUX" = "imx6-4.4-xbian" ]; then
-      sed -i -e "s|# CONFIG_MXC_HDMI_CEC is not set|CONFIG_MXC_HDMI_CEC=y|" $PKG_BUILD/.config
-      sed -i -e "s|CONFIG_MXC_HDMI_CEC_SR=y||" $PKG_BUILD/.config
-    fi
-  fi
 }
 
 makeinstall_host() {

--- a/projects/imx6/linux/4.4-xbian/linux.arm.conf
+++ b/projects/imx6/linux/4.4-xbian/linux.arm.conf
@@ -5874,8 +5874,7 @@ CONFIG_MXC_VPU=y
 #
 # MXC HDMI CEC (Consumer Electronics Control) support
 #
-# CONFIG_MXC_HDMI_CEC is not set
-CONFIG_MXC_HDMI_CEC_SR=y
+CONFIG_MXC_HDMI_CEC=y
 
 #
 # MXC MIPI Support

--- a/projects/imx6/options
+++ b/projects/imx6/options
@@ -50,20 +50,23 @@
 
   # Kernel to use.
   # default is 4.4 from xbian
-    if [ "$LINUX_VERSION" = "sr-3.14" ]; then
-      LINUX="imx6-3.14-sr"
+    if [ "$LINUX_VERSION" = "3.14-sr" ]; then
+      LINUX="imx6-$LINUX_VERSION"
 
       # OpenGL-ES implementation to use
       OPENGLES="imx-gpu-viv"
-    elif [ "$LINUX_VERSION" = "xbian-4.8" ]; then
-      LINUX="imx6-4.8-xbian"
-      LIBCEC_TYPE="xbian"
+    elif [ "$LINUX_VERSION" = "4.8-xbian" ]; then
+      LINUX="imx6-$LINUX_VERSION"
+
+      # OpenGL-ES implementation to use
+      OPENGLES="gpu-viv-bin-mx6q"
+    elif [ "$LINUX_VERSION" = "4.10-xbian" ]; then
+      LINUX="imx6-$LINUX_VERSION"
 
       # OpenGL-ES implementation to use
       OPENGLES="gpu-viv-bin-mx6q"
     else
       LINUX="imx6-4.4-xbian"
-      LIBCEC_TYPE="xbian"
 
       # OpenGL-ES implementation to use
       OPENGLES="imx-gpu-viv"


### PR DESCRIPTION
…[backport of #1633]

Variable LINUX_VERSION now took value '3.14-sr' to build imx6 project with 3.14 kernel from solidrun.