### PR TITLE
firmware: install wifi firmware from linux-firmware, cleanup wlan-fir…

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -1,3 +1,13 @@
 ar3k/*
 ath3k-1.fw
 rtl_bt/*_fw.bin
+
+# WLAN firmwares
+ath10k/*
+ath6k/*
+brcm/*
+libertas/*
+mrvl/*
+mwl8k/*
+mwlwifi/*
+rtlwifi/*

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="b141345"
+PKG_VERSION="df40d15"
 PKG_ARCH="any"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"

--- a/packages/linux-firmware/wlan-firmware/package.mk
+++ b/packages/linux-firmware/wlan-firmware/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wlan-firmware"
-PKG_VERSION="cf02ad3"
+PKG_VERSION="25d0c93"
 PKG_ARCH="any"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/wlan-firmware"


### PR DESCRIPTION
…mware

This PR depends on https://github.com/LibreELEC/wlan-firmware/pull/3

(Note: Although I refer to `linux-firmware` this is the name of the upstream repo, as due to a conflict we refer to it as `kernel-firmware`)

The following files are present in `wlan-firmware/firmware` but not `linux-firmware`:
```
3826.arm
b43/*
brcm/bcm4329-fullmac-4.txt
brcm/brcmfmac4329-sdio.txt
brcm/brcmfmac4330-sdio.txt
brcm/brcmfmac43430-sdio.txt
brcm/LICENCE.broadcom_bcm43xx
isl3886pci
isl3886usb
isl3887usb
libertas/lbtf_usb.bin
libertas/LICENCE.libertas
mwl8k/LICENCE.mwl8k
rtlwifi/LICENCE.rtlwifi_firmware.txt
rtlwifi/rtl8192dufw.bin
rtlwifi/rtl8192dufw_wol.bin
ti-connectivity/LICENCE.ti-connectivity
ti-connectivity/wl1271-nvs-ap.bin
zd1201/*
zd1211/*
```

Of these, I've retained the following in `wlan-firmware`:
```
b43/*

brcm/LICENCE.broadcom_bcm43xx
brcm/brcmfmac4329-sdio.txt
brcm/brcmfmac4330-sdio.txt
brcm/bcm4329-fullmac-4.txt
brcm/brcmfmac43430-sdio.txt

RTL8192E/*

rtlwifi/LICENCE.rtlwifi_firmware.txt
rtlwifi/rtl8192dufw_wol.bin
rtlwifi/rtl8192dufw.bin
```

while all other files in `wlan-firmware` have been removed - please shout if any files should be reinstated.

The `brcm/*.txt` files are the NVRAM files for the matching firmwares, which are not present in `linux-firmware` (however the firmware is).

The `ti-connectivity/*` and `ath9k_htc/*` firmwares, although present in `linux-firmware`, will no longer be installed.

Based on md5 hashes and file creation time stamps, the vast majority of files in `linux-firmware` are the same as the corresponding file in `wlan-firmware`, and/or newer.

There are some exceptions - the following files are both different and older in `linux-firmware` than the corresponding files in `wlan-firmware`:
```
brcm/brcmfmac43430-sdio.bin
brcm/brcmfmac43340-sdio.bin
mrvl/sd8887_uapsta.bin
mrvl/pcie8897_uapsta.bin
mrvl/sd8897_uapsta.bin
ath10k/QCA6174/hw2.1/firmware-5.bin
ath10k/QCA988X/hw2.0/notice_ath10k_firmware-5.txt
ath10k/QCA988X/hw2.0/firmware-5.bin
```

However when testing `brcm/brcmfmac43340-sdio.bin` (RPi3 WiFI/BT), it appears the version in `linux-firmware` is actually more recent:

`brcm/brcmfmac43340-sdio.bin` from `wlan-firmware`:
```
[    4.712203] usbcore: registered new interface driver brcmfmac
[    5.004925] brcmfmac: Firmware version = wl0: May 27 2016 00:13:38 version 7.45.41.26 (r640327) FWID 01-df77e4a7
```

`brcm/brcmfmac43340-sdio.bin` from `linux-firmware`:
```
[    4.910131] usbcore: registered new interface driver brcmfmac
[    5.163231] brcmfmac: Firmware version = wl0: Aug 29 2016 20:48:16 version 7.45.41.26 (r640327) FWID 01-4527cfab
```

After this change, the following new files will be installed for all projects:
```
ath10k/QCA4019/hw1.0/board-2.bin
ath10k/QCA4019/hw1.0/firmware-5.bin
ath10k/QCA4019/hw1.0/notice_ath10k_firmware-5.txt
ath10k/QCA6174/hw2.1/board-2.bin
ath10k/QCA6174/hw3.0/board-2.bin
ath10k/QCA9377/hw1.0/board-2.bin
ath10k/QCA9377/hw1.0/board.bin
ath10k/QCA9377/hw1.0/firmware-5.bin
ath10k/QCA9377/hw1.0/notice_ath10k_firmware-5.txt
ath10k/QCA9887/hw1.0/board.bin
ath10k/QCA9887/hw1.0/firmware-5.bin
ath10k/QCA9887/hw1.0/notice_ath10k_firmware-5.txt
ath10k/QCA9888/hw2.0/board-2.bin
ath10k/QCA9888/hw2.0/firmware-5.bin
ath10k/QCA9888/hw2.0/notice_ath10k_firmware-5.txt
ath10k/QCA9984/hw1.0/board-2.bin
ath10k/QCA9984/hw1.0/firmware-5.bin
ath10k/QCA9984/hw1.0/notice_ath10k_firmware-5.txt
brcm/brcmfmac4356-sdio.bin
brcm/brcmfmac4358-pcie.bin
mrvl/pcie8997_wlan_v4.bin
mrvl/pcieuart8997_combo_v4.bin
mrvl/pcieusb8997_combo_v4.bin
rtlwifi/rtl8723befw_36.bin
rtlwifi/rtl8723bs_ap_wowlan.bin
rtlwifi/rtl8723bs_bt.bin
rtlwifi/rtl8723bs_nic.bin
rtlwifi/rtl8723bs_wowlan.bin
rtlwifi/rtl8821aefw_29.bin
```

and the following files will no longer be installed:
```
3826.arm
agere_ap_fw.bin
agere_sta_fw.bin
ar5523.bin
ar7010_1_1.fw
ar7010.fw
ar9170-1.fw
ar9170-2.fw
ar9271.fw
ath9k_htc/htc_7010-1.4.0.fw
ath9k_htc/htc_9271-1.4.0.fw
carl9170-1.fw
htc_7010.fw
htc_9271.fw
isl3886pci
isl3886usb
isl3887usb
libertas/lbtf_usb.bin
libertas/LICENCE.libertas
LICENCE.agere
LICENCE.ralink-firmware.txt
LICENCE.via_vt6656
LICENSE
mt7601u.bin
mt7650.bin
mwl8k/LICENCE.mwl8k
rt2561.bin
rt2561s.bin
rt2661.bin
rt2860.bin
rt2870.bin
rt3071.bin
rt3290.bin
rt73.bin
ti-connectivity/LICENCE.ti-connectivity
ti-connectivity/TIInit_7.2.31.bts
ti-connectivity/wl1251-fw.bin
ti-connectivity/wl1251-nvs.bin
ti-connectivity/wl1271-fw-2.bin
ti-connectivity/wl1271-fw-ap.bin
ti-connectivity/wl1271-fw.bin
ti-connectivity/wl1271-nvs-ap.bin
ti-connectivity/wl127x-fw-3.bin
ti-connectivity/wl127x-fw-4-mr.bin
ti-connectivity/wl127x-fw-4-plt.bin
ti-connectivity/wl127x-fw-4-sr.bin
ti-connectivity/wl127x-fw-5-mr.bin
ti-connectivity/wl127x-fw-5-plt.bin
ti-connectivity/wl127x-fw-5-sr.bin
ti-connectivity/wl127x-fw-plt-3.bin
ti-connectivity/wl127x-nvs.bin
ti-connectivity/wl128x-fw-3.bin
ti-connectivity/wl128x-fw-4-mr.bin
ti-connectivity/wl128x-fw-4-plt.bin
ti-connectivity/wl128x-fw-4-sr.bin
ti-connectivity/wl128x-fw-5-mr.bin
ti-connectivity/wl128x-fw-5-plt.bin
ti-connectivity/wl128x-fw-5-sr.bin
ti-connectivity/wl128x-fw-ap.bin
ti-connectivity/wl128x-fw.bin
ti-connectivity/wl128x-fw-plt-3.bin
ti-connectivity/wl128x-nvs.bin
ti-connectivity/wl18xx-fw-2.bin
ti-connectivity/wl18xx-fw-3.bin
ti-connectivity/wl18xx-fw-4.bin
ti-connectivity/wl18xx-fw.bin
vntwusb.fw
zd1201/zd1201-ap.fw
zd1201/zd1201.fw
zd1211/COPYING
zd1211/README
zd1211/WS11Ub.h
zd1211/WS11UPh.h
zd1211/WS11UPhm.h
zd1211/WS11UPhR.h
zd1211/WS11UPhR_Turbo.h
zd1211/WS11Ur.h
zd1211/zd1211b_ub
zd1211/zd1211b_uph
zd1211/zd1211b_uphm
zd1211/zd1211b_uphr
zd1211/zd1211b_ur
zd1211/zd1211_ub
zd1211/zd1211_uph
zd1211/zd1211_uphm
zd1211/zd1211_uphr
zd1211/zd1211_ur
```

In many cases the source of the files in `wlan-firmware` is not known, and may in fact have been `linux-firmware`, but due to the manual nature of curating this repository it is rarely updated.

Bumping to a new version of `linux-firmware` on the other hand is trivial, and will update all firmwares automatically.

This change results in a 4.3MB reduction in file sizes (based on uncompressed file sizes) in the resulting image.