### PR TITLE
samba: short term fix for samba3 exploit

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -56,6 +56,9 @@
 
   allocation roundup size = 0
 
+  # workaround for exploit CVE-2017-7494
+  nt pipe support = no
+
 # Using the following configurations as a template allows you to add
 # writable shares of disks and paths under /storage
 


### PR DESCRIPTION
Exploit: https://www.samba.org/samba/security/CVE-2017-7494.html

@chewitt adding this just in case you want it, as there's no better solution until we bump to Samba4.

Feel free to close it. If you do pick it, I've added option to my FreeNAS server with Samba 3.6.12 and not seen any ill effect, but worth testing all the same.