### PR TITLE
wetekdvb: Use older WeTek proprietary DVB modules if building for WP1

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -17,7 +17,14 @@
 ################################################################################
 
 PKG_NAME="wetekdvb"
-PKG_VERSION="20170404"
+case "$PROJECT" in
+  WeTek_Play)
+    PKG_VERSION="20170116"
+    ;;
+  *)
+    PKG_VERSION="20170404"
+    ;;
+esac
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.wetek.com/"


### PR DESCRIPTION
Rebase of 34de01dfa552ac391485044a169a81c2511ad194 - use older wetekdvb for WP1 project