### PR TITLE
add lan951x-led-ctl

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/lan951x-led-ctl/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/lan951x-led-ctl/package.mk
@@ -1,6 +1,6 @@
 ################################################################################
 #      This file is part of LibreELEC - https://libreelec.tv
-#      Copyright (C) 2016 Team LibreELEC
+#      Copyright (C) 2016-present Team LibreELEC
 #
 #  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/packages/addons/addon-depends/rpi-tools-depends/lan951x-led-ctl/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/lan951x-led-ctl/package.mk
@@ -1,0 +1,41 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="lan951x-led-ctl"
+PKG_VERSION="0291b91"
+PKG_ARCH="arm"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/dradermacher/lan951x-led-ctl"
+PKG_URL="https://github.com/dradermacher/lan951x-led-ctl/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libusb"
+PKG_SECTION="rpi-tools"
+PKG_SHORTDESC="Control LEDs connected to LAN9512/LAN9514 ethernet USB controllers"
+PKG_LONGDESC="Control LEDs connected to LAN9512/LAN9514 ethernet USB controllers"
+PKG_AUTORECONF="no"
+
+make_target() {
+  $CC -std=c11 -I./include -Wall -Wstrict-prototypes -Wconversion \
+      -Wmissing-prototypes -Wshadow -Wextra -Wunused \
+      $CFLAGS -lusb-1.0 $LDFLAGS -o lan951x-led-ctl src/lan951x-led-ctl.c
+
+  $STRIP lan951x-led-ctl
+}
+
+makeinstall_target() {
+  : # nop
+}

--- a/packages/addons/tools/rpi-tools/package.mk
+++ b/packages/addons/tools/rpi-tools/package.mk
@@ -18,15 +18,15 @@
 
 PKG_NAME="rpi-tools"
 PKG_VERSION=""
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE=""
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain RPi.GPIO picamera gpiozero"
+PKG_DEPENDS_TARGET="toolchain RPi.GPIO picamera gpiozero lan951x-led-ctl"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of tools and programs for use on the Raspberry Pi"
-PKG_LONGDESC="This bundle currently includes RPi.GPIO, picamera, gpiozero python modules"
+PKG_LONGDESC="This bundle currently includes RPi.GPIO, picamera, gpiozero lan951x-led-ctl"
 PKG_DISCAIMER="Raspberry Pi is a trademark of the Raspberry Pi Foundation http://www.raspberrypi.org"
 
 PKG_IS_ADDON="yes"
@@ -49,4 +49,7 @@ addon() {
     cp -P $BCM2835_DIR/hardfp/opt/vc/bin/raspiyuv $ADDON_BUILD/$PKG_ADDON_ID/bin
     cp -P $BCM2835_DIR/hardfp/opt/vc/bin/raspivid $ADDON_BUILD/$PKG_ADDON_ID/bin
     cp -P $BCM2835_DIR/hardfp/opt/vc/bin/raspividyuv $ADDON_BUILD/$PKG_ADDON_ID/bin
+
+  # lan951x-led-ctl
+    cp -P $(get_build_dir lan951x-led-ctl)/lan951x-led-ctl $ADDON_BUILD/$PKG_ADDON_ID/bin
 }


### PR DESCRIPTION
adds the ability to turn off the rpi lan leds

test build here, http://lrusak.libreelec.tv/public/lan951x-led-ctl