### PR TITLE
peripheral.joystick: fix JOYSTICK_SUPPORT build option

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -228,7 +228,6 @@ PKG_CMAKE_OPTS_TARGET="-DNATIVEPREFIX=$ROOT/$TOOLCHAIN \
                        $KODI_OPENMAX \
                        $KODI_VDPAU \
                        $KODI_VAAPI \
-                       $KODI_JOYSTICK \
                        $KODI_CEC \
                        $KODI_XORG \
                        $KODI_SAMBA \

--- a/packages/virtual/mediacenter/package.mk
+++ b/packages/virtual/mediacenter/package.mk
@@ -43,6 +43,10 @@ if [ "$MEDIACENTER" = "kodi" ]; then
                                           pycrypto"
 # other packages
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET LibreELEC-settings \
-                                          xmlstarlet \
-                                          peripheral.joystick"
+                                          xmlstarlet"
+  
+  if [ "$JOYSTICK_SUPPORT" = "yes" ]; then
+    PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET peripheral.joystick"
+  fi
+
 fi


### PR DESCRIPTION
Fix for joystick support option. It currently does nothing. Also removed kodi joystick build option. As far as I can tell $KODI_JOYSTICK goes unset and I can't see any joystick support build options in kodi's cmakelist anyway.