### PR TITLE
build: set ARCH if not set

### DIFF
--- a/config/options
+++ b/config/options
@@ -21,6 +21,7 @@ fi
 # default is x86_64
 if [ -z "$ARCH" ]; then
   TARGET_ARCH="x86_64"
+  ARCH="x86_64"
 else
   TARGET_ARCH="$ARCH"
 fi


### PR DESCRIPTION
without tvheadend42 addon is failing
replace https://github.com/LibreELEC/LibreELEC.tv/pull/1671