### PR TITLE
LibCEC bump. Fixes serious issue for some TVs.

### DIFF
--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libcec"
-PKG_VERSION="5250931"
+PKG_VERSION="3953f8d"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libcec.pulse-eight.com/"


### PR DESCRIPTION
Bug in 4.0.1 version prevents to wake up on some TVs. Details can be found
here: https://forum.libreelec.tv/thread/7114-wake-from-suspend-cec.
Positive feedback on 3953f8d reports problem is fixed there.