### PR TITLE
GNU screen color fixes

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/screen/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/screen/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="screen"
-PKG_VERSION="4.3.1"
+PKG_VERSION="4.5.1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/screen/"

--- a/packages/addons/addon-depends/system-tools-depends/screen/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/screen/package.mk
@@ -29,6 +29,7 @@ PKG_LONGDESC="screen is a terminal multiplexor that runs several separate screen
 PKG_AUTORECONF="no"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_utempter_h=no \
+                           --enable-colors256 \
                            --disable-pam \
                            --disable-use-locale \
                            --disable-telnet \

--- a/packages/addons/addon-depends/system-tools-depends/screen/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/screen/package.mk
@@ -35,6 +35,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_utempter_h=no \
                            --disable-socket-dir"
 
 pre_configure_target() {
+  CFLAGS="$CFLAGS -DTERMINFO"
   export LDFLAGS=`echo $LDFLAGS | sed -e "s|-Wl,--as-needed||"`
 
 # screen fails to build in subdirs

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,6 @@
+106
+- Bump screen, fix colors issue
+
 104
 - Bump file package
 

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION=""
-PKG_REV="105"
+PKG_REV="106"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""


### PR DESCRIPTION
This PR fixes the issue when only eight basic colors (0-7) are displayed regardless of TERM setting. It's netbsd-curses specific and is caused by a wrong configure decision made while cross-compiling. This PR also enables 256 color support and updates to the recent stable version.