### PR TITLE
Correcting VendorID for TP-Link T4U v2

### DIFF
--- a/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-01-add_new_cards.patch
+++ b/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-01-add_new_cards.patch
@@ -5,7 +5,7 @@
  	{USB_DEVICE(0x2357, 0x0101),.driver_info = RTL8812}, /* TP-Link - T4U */
  	{USB_DEVICE(0x2357, 0x0103),.driver_info = RTL8812}, /* TP-Link - T4UH */
 +	/*=== Patched ID ===*/
-+	{USB_DEVICE(0x050D, 0x010d),.driver_info = RTL8812}, /* TP-Link - T4U v2 */
++	{USB_DEVICE(0x2357, 0x010d),.driver_info = RTL8812}, /* TP-Link - T4U v2 */
 +	{USB_DEVICE(0x050D, 0x1109),.driver_info = RTL8812}, /* Belkin F9L1109 - SerComm */
 +	{USB_DEVICE(0x20F4, 0x805B),.driver_info = RTL8812}, /* TRENDnet - Cameo */
 +	{USB_DEVICE(0x148F, 0x9097),.driver_info = RTL8812}, /* Amped Wireless ACA1 */


### PR DESCRIPTION
As discussed in https://forum.libreelec.tv/thread/7057-tplink-archer-t4u-v2-ac1300-issue/?postID=46614, this change was once tested with the correct VendorID, but two codes were mixed up while creating the pull request. The correct USB ID for the TP-Link T4U is 2357:010d.