### PR TITLE
chromium-addon: libva-vdpau-driver libraries, now under /usr/lib/dri instea…

### DIFF
--- a/packages/addons/browser/chromium/package.mk
+++ b/packages/addons/browser/chromium/package.mk
@@ -172,7 +172,7 @@ addon() {
   cp -PL $(get_build_dir libexif)/.install_pkg/usr/lib/* $ADDON_BUILD/$PKG_ADDON_ID/lib
 
   # libva-vdpau-driver
-  cp -PL $(get_build_dir libva-vdpau-driver)/.install_pkg/usr/lib/va/*.so $ADDON_BUILD/$PKG_ADDON_ID/lib
+  cp -PL $(get_build_dir libva-vdpau-driver)/.install_pkg/usr/lib/dri/*.so $ADDON_BUILD/$PKG_ADDON_ID/lib
 
   # unclutter
   cp -P $(get_build_dir unclutter)/.install_pkg/usr/bin/unclutter $ADDON_BUILD/$PKG_ADDON_ID/bin


### PR DESCRIPTION
…d of /usr/lib/va