### PR TITLE
e2fsprogs: avoid installing read-only files into the toolchain

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -107,8 +107,8 @@ make_host() {
 }
 
 makeinstall_host() {
-  make -C lib/et DESTDIR=$(pwd)/.install install
-  make -C lib/ext2fs DESTDIR=$(pwd)/.install install
+  make -C lib/et LIBMODE=644 DESTDIR=$(pwd)/.install install
+  make -C lib/ext2fs LIBMODE=644 DESTDIR=$(pwd)/.install install
 
   rm -fr $(pwd)/.install/bin
   rm -fr $(pwd)/.install/usr/share

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -113,6 +113,6 @@ makeinstall_host() {
   rm -fr $(pwd)/.install/bin
   rm -fr $(pwd)/.install/usr/share
 
-  cp -Pa $(pwd)/.install/usr/* $ROOT/$TOOLCHAIN
+  cp -fPa $(pwd)/.install/usr/* $ROOT/$TOOLCHAIN
 }
 


### PR DESCRIPTION
See comment: https://github.com/LibreELEC/LibreELEC.tv/commit/0d882738873e16e761f52fb57f160eacc7848492#commitcomment-22479431

This is an alternative fix to the original https://github.com/LibreELEC/LibreELEC.tv/pull/1187

At the moment this is only a temporary fix, as with the bump to 1.43.4 in #1628 this change isn't required at all, unless we don't like having read-only files in the toolchain in which case we should add `LIBMODE=666` to `master` too.

@vpeter4 are you able to test this? I currently don't have any `libreelec-8.0` branches and am a bit pushed for time - thanks.