### PR TITLE
glibc: re-enable programs, remove those we don't want

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -111,12 +111,27 @@ echo "libdir=/usr/lib" >> configparms
 echo "slibdir=/usr/lib" >> configparms
 echo "sbindir=/usr/bin" >> configparms
 echo "rootsbindir=/usr/bin" >> configparms
-echo "build-programs=no" >> configparms
+echo "build-programs=yes" >> configparms
+
+GLIBC_INCLUDE_BIN="getent ldd locale"
 }
 
 post_makeinstall_target() {
 # we are linking against ld.so, so symlink
   ln -sf $(basename $INSTALL/usr/lib/ld-*.so) $INSTALL/usr/lib/ld.so
+
+# cleanup
+# remove any programs we don't want/need, keeping only those we want
+  for f in $(find $INSTALL/usr/bin -type f); do
+    fb="$(basename "${f}")"
+    for ib in $GLIBC_INCLUDE_BIN; do
+      if [ "${ib}" == "${fb}" ]; then
+        fb=
+        break
+      fi
+    done
+    [ -n "${fb}" ] && rm -rf ${f}
+  done
 
   rm -rf $INSTALL/usr/lib/audit
   rm -rf $INSTALL/usr/lib/glibc


### PR DESCRIPTION
This restores `ldd`, `getent` and `locale` after they were dropped by #1616, as they're kinda useful...

I've used a simple nested loop, for simplicity. I could have used something more fancy such as:
```
  findignore=
  for gib in $GLIBC_INCLUDE_BIN; do
    findignore+=" -not -name ${gib}"
  done
  find $INSTALL/usr/bin -type f ${findignore} -delete
```
but from a scalability point of view I didn't want to get into a situation where we might be calling `find` with a large number of `-not foo` arguments (even if that is unlikely) and maybe hit some sort of limit.

So, simple is best.

The combined uncompressed size of these 3 binaries is: 55KB (RPi/RPi2) and 69KB (Generic)