### PR TITLE
e2fsprogs: do not build fuse2fs

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -62,6 +62,7 @@ PKG_CONFIGURE_OPTS_TARGET="BUILD_CC=$HOST_CC \
                            --disable-uuidd \
                            --disable-nls \
                            --disable-rpath \
+                           --disable-fuse2fs \
                            --with-gnu-ld"
 
 PKG_CONFIGURE_OPTS_INIT="$PKG_CONFIGURE_OPTS_TARGET"


### PR DESCRIPTION
As mentioned on Slack, clean builds do not build and install the `fuse2fs` binary.

However, if `e2fsprogs` is ever rebuilt then `fuse2fs` will be automatically enabled by `configure` whenever `fuse.h` is detected, and then `fuse2fs` will be built and installed.

`fuse.h` is installed by the `fuse` package which is built near the end of the build long after `e2fsprogs` (it's needed by `fuse-exfat` in order to create the image).

So a clean build will not include `fuse2fs`, but a later incremental build that rebuilds `e2fsprogs` will contain `fuse2fs`.

In order to remove this uncertainty from the build, this PR explicitly disables `fuse2fs`.