### PR TITLE
e2fsprogs: avoid installing read-only files into the toolchain

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -72,7 +72,7 @@ pre_make_host() {
 }
 
 post_makeinstall_target() {
-  make -C lib/et DESTDIR=$SYSROOT_PREFIX install
+  make -C lib/et LIBMODE=644 DESTDIR=$SYSROOT_PREFIX install
 
   rm -rf $INSTALL/usr/sbin/badblocks
   rm -rf $INSTALL/usr/sbin/blkid
@@ -109,7 +109,7 @@ make_host() {
 }
 
 makeinstall_host() {
-  make -C lib/et install
-  make -C lib/ext2fs install
+  make -C lib/et LIBMODE=644 install
+  make -C lib/ext2fs LIBMODE=644 install
 }
 


### PR DESCRIPTION
As requested: https://github.com/LibreELEC/LibreELEC.tv/pull/1685#issuecomment-308092350

I don't consider this strictly necessary, but shouldn't do any harm.