### PR TITLE
linux: update to linux-4.11.8

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="0f315f8"
+PKG_VERSION="715f2d9"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -59,7 +59,7 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.11.6"
+    PKG_VERSION="4.11.7"
     PKG_URL="http://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -59,7 +59,7 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.11.4"
+    PKG_VERSION="4.11.5"
     PKG_URL="http://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -59,7 +59,7 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.11.5"
+    PKG_VERSION="4.11.6"
     PKG_URL="http://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -59,7 +59,7 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.11.7"
+    PKG_VERSION="4.11.8"
     PKG_URL="http://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="0f315f8"
+PKG_VERSION="715f2d9"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,4 +1,4 @@
-From 7baa3c49eab2220f7fdf302ae9b9e4c3c0b70687 Mon Sep 17 00:00:00 2001
+From 5c12c71e15d873719ed0f038559d39e653682ae3 Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
 Subject: [PATCH 001/167] smsx95xx: fix crimes against truesize
@@ -48,7 +48,7 @@ index 5f19fb0f025d9449d0ba20958610e0d1f083f032..ed28f1c3e1d0f2559a62a1c289937944
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From 03f2e08c0e10118247935c95aad7b39c1ca83cd7 Mon Sep 17 00:00:00 2001
+From c641f517b009d7c619065b91379424c9f0812e4a Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
 Subject: [PATCH 002/167] smsc95xx: Experimental: Enable turbo_mode and
@@ -94,7 +94,7 @@ index ed28f1c3e1d0f2559a62a1c28993794497730c5d..f758e122c65685799d4aeeb1c3e6ca81
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From d624b2e76eb46571ff165a3cc62b4b8d5d635743 Mon Sep 17 00:00:00 2001
+From 67dfbca41e10ac2df4baf2f81dfbf5b2fee51a5d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
 Subject: [PATCH 003/167] Allow mac address to be set in smsc95xx
@@ -193,7 +193,7 @@ index f758e122c65685799d4aeeb1c3e6ca81df0d7980..f6661e388f6e801c1b88e48a3b71407b
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From b29b5174e2ca1d6524646aa6d6709189a4129a2e Mon Sep 17 00:00:00 2001
+From 8e5ce5c2c49e594ec843e8647ab5bf7ffdd49b77 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
 Subject: [PATCH 004/167] Protect __release_resource against resources without
@@ -224,7 +224,7 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From 373eddf307d58a53540b0313687251276befb1d3 Mon Sep 17 00:00:00 2001
+From 04c16ef82ad368b5e9732f65c975cba21a0059af Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
 Subject: [PATCH 005/167] mm: Remove the PFN busy warning
@@ -252,7 +252,7 @@ index a2019fc9d94df3af9cf2c5ce1a476949c6822efc..5e6e1815923f212f5c1b1d1a213b0b12
  		goto done;
  	}
 
-From aaa48f01d091d62e65857c260111fac14742501b Mon Sep 17 00:00:00 2001
+From 4d4a2d65910b4c64cb5779850b674b26aa81adc8 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
 Subject: [PATCH 006/167] irq-bcm2836: Prevent spurious interrupts, and trap
@@ -282,7 +282,7 @@ index e7463e3c08143acae3e8cc5682f918c6a0b07ebd..a8db33b50ad9ff83d284fa54fe4d3b65
  #endif
  	} else if (stat) {
 
-From 6c1a31e3d3e3fba337fd2d51c9014e5a8bfefe33 Mon Sep 17 00:00:00 2001
+From d947bf2f9b8138106885cd07fc508ea580697cac Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:33:30 +0000
 Subject: [PATCH 007/167] irq-bcm2836: Avoid "Invalid trigger warning"
@@ -309,7 +309,7 @@ index a8db33b50ad9ff83d284fa54fe4d3b65f859df0f..c4e151451cf8c8ebde5225515eac2786
  
  static void
 
-From c564e80bb06dde3e3ffe6171452003538b2be384 Mon Sep 17 00:00:00 2001
+From 29bd8d457817796427be50bcb2d30759bb5ef266 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
 Subject: [PATCH 008/167] irqchip: bcm2835: Add FIQ support
@@ -441,7 +441,7 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 98ce0d733463bb5b6ac8022c5f2717d521d8edb9 Mon Sep 17 00:00:00 2001
+From 7b49d4c1670d1c63c10cd4aa765243433b2bffd9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
 Subject: [PATCH 009/167] irqchip: irq-bcm2835: Add 2836 FIQ support
@@ -543,7 +543,7 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From 32fd76ce4f758d4c26cd473a4e472e9676a3f4c3 Mon Sep 17 00:00:00 2001
+From daa91a8da856b616dc79e15ffbf5e20cb662900d Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
 Subject: [PATCH 010/167] spidev: Add "spidev" compatible string to silence
@@ -567,7 +567,7 @@ index 9e2e099baf8ca5cc6510912a36d4ca03daeb8273..e59640942826db2ea14d0bde0ff5ab22
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 17d89ed0279820828d256cdc60f71b45c83d0dd2 Mon Sep 17 00:00:00 2001
+From ab14ef24bc5123ebaad44e20db0015cee49bc2de Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 3 Jan 2017 18:25:01 +0000
 Subject: [PATCH 011/167] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
@@ -864,7 +864,7 @@ index 85d0091128644c446aed878e87769e82c77c3ebf..4f2621272bfd5cbc0d691d2fabe89e2e
  	if (IS_ERR(pc->pctl_dev)) {
  		gpiochip_remove(&pc->gpio_chip);
 
-From 681444a836eab379725531bc601d99a64ee8c644 Mon Sep 17 00:00:00 2001
+From 029c1cd3ac2439ba71f0b7d9c8635649ab015df2 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
 Subject: [PATCH 012/167] pinctrl-bcm2835: Set base to 0 give expected gpio
@@ -889,7 +889,7 @@ index 4f2621272bfd5cbc0d691d2fabe89e2ee428d6db..5b7cb4c415e19f98e25b221ab0ad36b6
  	.can_sleep = false,
  };
 
-From fbd5d48adc6ad35dd45dae4fc92d54ca576213d0 Mon Sep 17 00:00:00 2001
+From 1b69006d0051412024dabd3e6fff04de0d1fc7e1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
 Subject: [PATCH 013/167] pinctrl-bcm2835: Only request the interrupts listed
@@ -919,7 +919,7 @@ index 5b7cb4c415e19f98e25b221ab0ad36b6885dae4c..6351fe7f8e314ac5ebb102dd20847b38
  		pc->irq_data[i].irqgroup = i;
  
 
-From 664cd981bb024b3d3d7878321f3fb13fe42d6181 Mon Sep 17 00:00:00 2001
+From d6fb9a63771b8fb6667e738ddbb607ac18406d94 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
 Subject: [PATCH 014/167] spi-bcm2835: Support pin groups other than 7-11
@@ -1003,7 +1003,7 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From 708b5a91581c0c3e7f76ca3bbf10e314794f5df2 Mon Sep 17 00:00:00 2001
+From abc1b085874fbe548854bfb91e2e2a1f85d3be27 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
 Subject: [PATCH 015/167] spi-bcm2835: Disable forced software CS
@@ -1040,7 +1040,7 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From e16568ce8a006ae0681d0f941de34c644208a62b Mon Sep 17 00:00:00 2001
+From f82e839db63bdc1977a030193bc105da1f17ec46 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
 Subject: [PATCH 016/167] spi-bcm2835: Remove unused code
@@ -1131,7 +1131,7 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From 672f7cb467c7bfeb0f3c442f3f67886d802763da Mon Sep 17 00:00:00 2001
+From f14d0451987390c71dba8816e84c382532b14aeb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
 Subject: [PATCH 017/167] ARM: bcm2835: Set Serial number and Revision
@@ -1187,7 +1187,7 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 4c7de422286d313371a8ba49c59462f9f98c7944 Mon Sep 17 00:00:00 2001
+From 26f81392d52047e01e18dc63ca6c165a0b58a06a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
 Subject: [PATCH 018/167] dmaengine: bcm2835: Load driver early and support
@@ -1293,7 +1293,7 @@ index 6204cc32d09c5096df8aec304c3c37b3bcb6be44..599c218dc8a73172dd4bd4a058fc8f95
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From b301879417013478ccf445fcaa3982a29eab783f Mon Sep 17 00:00:00 2001
+From 49b06a42fbb3bca0c3428319059f73e956a682d9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
 Subject: [PATCH 019/167] firmware: Updated mailbox header
@@ -1357,7 +1357,7 @@ index cb979ad90401e299344dd5fae38d09c489d8bd58..30fb37fe175df604a738258a2a632bca
  	RPI_FIRMWARE_VCHIQ_INIT =                             0x00048010,
  
 
-From 30e6770f20c7b014179b2809bb66c28ef6380bec Mon Sep 17 00:00:00 2001
+From a60743bd35b08be3b2505137215e03d9d11710e5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
 Subject: [PATCH 020/167] rtc: Add SPI alias for pcf2123 driver
@@ -1380,7 +1380,7 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From f266d67e0d2f13af2c51ffe675241909f6ab9074 Mon Sep 17 00:00:00 2001
+From 5d48547824fb8eb439b91927478e9a474f2783c0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
 Subject: [PATCH 021/167] watchdog: bcm2835: Support setting reboot partition
@@ -1485,7 +1485,7 @@ index b339e0e67b4c1275fd4992fea4f1e24c0575b783..26b7177573fac2af1cd4ab5488d2686f
  
  static int bcm2835_wdt_probe(struct platform_device *pdev)
 
-From f1270fb2826b3fd5eb1dc29f4286e6a78d533a8c Mon Sep 17 00:00:00 2001
+From 3f6ae6fdcf8f2b6830db3f3d185171c2665db871 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
 Subject: [PATCH 022/167] reboot: Use power off rather than busy spinning when
@@ -1511,7 +1511,7 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From 384a51189b673e007547f71ea6b3b42568ea5dbf Mon Sep 17 00:00:00 2001
+From a15b3dd745985d1389643812bde82a9dbf73c802 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
 Subject: [PATCH 023/167] bcm: Make RASPBERRYPI_POWER depend on PM
@@ -1533,7 +1533,7 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 4fdeefd728501eefb1b7e73730f5cfa17abbb4f0 Mon Sep 17 00:00:00 2001
+From 00d5533d597de4071696a3603a506980c443c81a Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
 Subject: [PATCH 024/167] Register the clocks early during the boot process, so
@@ -1581,7 +1581,7 @@ index 02585387061967ac9408e18ac1bce67e9e9414c0..283d2de45e4f29406d01f24ab1cae3f9
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From aa1d520f85e0815cc82c953e7b219d96a669556e Mon Sep 17 00:00:00 2001
+From 3d1b46566d56af094cafae7d7fc16798d55d8fb8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
 Subject: [PATCH 025/167] bcm2835-rng: Avoid initialising if already enabled
@@ -1610,7 +1610,7 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From 9893d64c9abbdda2550cdf7c3ca0fcd8f6f785d8 Mon Sep 17 00:00:00 2001
+From d09450d8643488571b6f78321758c0ff5e2b080c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
 Subject: [PATCH 026/167] kbuild: Ignore dtco targets when filtering symbols
@@ -1633,7 +1633,7 @@ index afe3fd3af1e40616857b3e6c425be632c1fa2667..b2bbad417f0c4499a5f49081c8f996b9
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From b7bcc989b44ad827fb975940953463298d21cbc2 Mon Sep 17 00:00:00 2001
+From c367f05abd557c548a8c0a990a4695b39efd2b64 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
 Subject: [PATCH 027/167] BCM2835_DT: Fix I2S register map
@@ -1674,7 +1674,7 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From ee08fac8506b74be35668fc595430fd24ff1522c Mon Sep 17 00:00:00 2001
+From 066f21a0c158bdc6a034105bc32c70f2130de080 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
 Subject: [PATCH 028/167] clk-bcm2835: Mark used PLLs and dividers CRITICAL
@@ -1705,7 +1705,7 @@ index 283d2de45e4f29406d01f24ab1cae3f9f879234a..85df8c74a309f0b877ef65f1c55b086f
  	divider->data = data;
  
 
-From 44c195fe84a18f02540e8da3d28e06b3643bf39c Mon Sep 17 00:00:00 2001
+From 1dca5a61db59275810ccd1fef1d804f7e0da4c53 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
 Subject: [PATCH 029/167] clk-bcm2835: Add claim-clocks property
@@ -1810,7 +1810,7 @@ index 85df8c74a309f0b877ef65f1c55b086f1bb774a1..eec6735505c074c0a76ae647bf0e1bb6
  	       sizeof(cprman_parent_names));
  	of_clk_parent_fill(dev->of_node, cprman->real_parent_names,
 
-From 08b23055bd6ab16ba948c37fc989a6aba02c4821 Mon Sep 17 00:00:00 2001
+From 01c1e8a1e842582bf9962fbea559bfd7923f411a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:06:53 +0000
 Subject: [PATCH 030/167] clk-bcm2835: Correct the prediv logic
@@ -1840,7 +1840,7 @@ index eec6735505c074c0a76ae647bf0e1bb68ab3a488..e0d28add45efdf70d1eba590282a3a26
  	return bcm2835_pll_rate_from_divisors(parent_rate, ndiv, fdiv, pdiv);
  }
 
-From d59d4fb05c4f64fdc87846011c5ceb18ecdb0379 Mon Sep 17 00:00:00 2001
+From aee179f3899409952b9cda1a2165c6ae8d99064f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 6 Mar 2017 09:06:18 +0000
 Subject: [PATCH 031/167] clk-bcm2835: Read max core clock from firmware
@@ -1958,7 +1958,7 @@ index e0d28add45efdf70d1eba590282a3a2654af328d..39f72da6ba1f6ec6ec41d5dc1bf46344
  	for (i = 0;
  	     !of_property_read_u32_index(pdev->dev.of_node, "claim-clocks",
 
-From 7ed6ab6b763d3bb44ca40adb206a453c1217d6a9 Mon Sep 17 00:00:00 2001
+From 5470d573445cc0979f676c56531d8b5fe372f55f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:36:44 +0000
 Subject: [PATCH 032/167] sound: Demote deferral errors to INFO level
@@ -1996,7 +1996,7 @@ index 98d60f471c5d705d383c5edca4850bd8facdd030..d2da3077fd980c846c1c86697f73c342
  			goto _err_defer;
  		}
 
-From 8b986501ea40202e4ad21b16971040449b6f17fe Mon Sep 17 00:00:00 2001
+From 1067c4056a6a9873f88954d8eb0addcbd3b2f1a8 Mon Sep 17 00:00:00 2001
 From: Claggy3 <stephen.maclagan@hotmail.com>
 Date: Sat, 11 Feb 2017 14:00:30 +0000
 Subject: [PATCH 033/167] Update vfpmodule.c
@@ -2136,7 +2136,7 @@ index a71a48e71fffa8626fe90106815376c44bbe679b..d6c0a5a0a5ae3510db3ace5e3f5d3410
  	/*
  	 * Save the userland NEON/VFP state. Under UP,
 
-From 4e190b76ff149cfe97efff189ff4fa3146934027 Mon Sep 17 00:00:00 2001
+From c04e30090d6422997479fa6c7f576e332fbadd78 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 21:13:24 +1100
 Subject: [PATCH 034/167] ASoC: bcm2835_i2s.c: relax the ch2 register setting
@@ -2160,7 +2160,7 @@ index 6ba20498202ed36906b52096893a88867a79269f..56df7d8a43d0aac055a91b0d24aca8e1
  		format |= BCM2835_I2S_CH1(BCM2835_I2S_CHPOS(ch1pos));
  		format |= BCM2835_I2S_CH2(BCM2835_I2S_CHPOS(ch2pos));
 
-From 02f0b303dadf31d0433db4f1329cce2dcd3a8bee Mon Sep 17 00:00:00 2001
+From 70288a422cf169d3ef240329e2aa0edc106ad1b5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
 Subject: [PATCH 035/167] i2c: bcm2835: Add debug support
@@ -2352,7 +2352,7 @@ index cd07a69e2e9355540442785f95e90823b05c9d10..47167f403cc8329bd811b47c7011c299
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From d1351f408db7182432d27590de027ea482d9ef74 Mon Sep 17 00:00:00 2001
+From 055d19df21df1471a912d73c4f2c70cd58e2f1b3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
 Subject: [PATCH 036/167] Main bcm2708/bcm2709 linux port
@@ -2543,7 +2543,7 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 081442ac4aa226981d6814b75f9329736f68fb42 Mon Sep 17 00:00:00 2001
+From e7eef2e6c3ae5c142cf6345f2b17e10bc6130ec5 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
 Subject: [PATCH 037/167] Add dwc_otg driver
@@ -63611,7 +63611,7 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 5f235132e77d4251ad694cd75e6164fa079d4e23 Mon Sep 17 00:00:00 2001
+From 7e014ce4ddcf25147816c1aeebcaed53548c050a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 10 May 2017 12:47:46 +0100
 Subject: [PATCH 038/167] dwcotg: Allow to build without FIQ on ARM64
@@ -63635,7 +63635,7 @@ index ed0cd59de37e8f47369f86dba751c78933722abc..53aedbe9727ca5c34e46f5cf998f14c7
  	  The Synopsis DWC controller is a dual-role
  	  host/peripheral/OTG ("On The Go") USB controllers.
 
-From e6a4e07d22a55bd269de1f7b91efca1c808392ad Mon Sep 17 00:00:00 2001
+From 05a7ff745705366e6328f471dd4a299b5e977817 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
 Subject: [PATCH 039/167] bcm2708 framebuffer driver
@@ -67097,7 +67097,7 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From 7ae2f418cce005eb19b8b210cde3fe5a4dc92572 Mon Sep 17 00:00:00 2001
+From c095a159c0c01b7980106616f2d0e14e332c5f78 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
 Subject: [PATCH 040/167] dmaengine: Add support for BCM2708
@@ -67731,7 +67731,7 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From b1e182ca7e688b34bd7db0271e9d7105f05f3c61 Mon Sep 17 00:00:00 2001
+From 3db6d962acebf71b2b0bfd9a8500b7668b4d072e Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
 Subject: [PATCH 041/167] MMC: added alternative MMC driver
@@ -69456,7 +69456,7 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From 50b110ad6f1d531a3d3e0ed0eed3b99105b17c0a Mon Sep 17 00:00:00 2001
+From 84876ef9145df2d10d91e11383e9b2d5ec5e45c5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
 Subject: [PATCH 042/167] Adding bcm2835-sdhost driver, and an overlay to
@@ -71855,7 +71855,7 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 909784349b372fb9e258394bf5b738e9606f16b8 Mon Sep 17 00:00:00 2001
+From d86263a65f1c57991aaa203ef39a775bfe652ed3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
 Subject: [PATCH 043/167] vc_mem: Add vc_mem driver for querying firmware
@@ -72383,7 +72383,7 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From b9d829114299c97836e2392e3cc7d88fa9d2cc3b Mon Sep 17 00:00:00 2001
+From eab4336a5d6fb9c89cb927d2d4f6f36d544a44d6 Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
 Subject: [PATCH 044/167] vcsm: VideoCore shared memory service for BCM2835
@@ -76823,7 +76823,7 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From 2680bf2a4274d0e8c4641c76803e14af1a4f6517 Mon Sep 17 00:00:00 2001
+From bd80393dae846a13767e30c46b890d27bbd22b9e Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
 Subject: [PATCH 045/167] Add /dev/gpiomem device for rootless user GPIO access
@@ -77134,7 +77134,7 @@ index 0000000000000000000000000000000000000000..f5e7f1ba8fb6f18dee77fad06a17480c
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From b2d4d8e9a43a1e8d4a5860f3ee2a12dfda71a71b Mon Sep 17 00:00:00 2001
+From 102c24664e96946c4f7b7f475905f3ca6a040942 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
 Subject: [PATCH 046/167] Add SMI driver
@@ -79088,7 +79088,7 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From 05116148c7263a117d3a61d8d58b59d73e8550b5 Mon Sep 17 00:00:00 2001
+From ca07554ddfefb186e28a50ef95a3436b807725c2 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
 Subject: [PATCH 047/167] MISC: bcm2835: smi: use clock manager and fix reload
@@ -79261,7 +79261,7 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 477c2c1d0cb377f8e98c227797274f0233f2c6c8 Mon Sep 17 00:00:00 2001
+From 16c7f19a003be2dc718532059452ef0d81ba14cf Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
 Subject: [PATCH 048/167] Add SMI NAND driver
@@ -79629,7 +79629,7 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From a6199124ff8cce277349c17fab6dea100a22b27f Mon Sep 17 00:00:00 2001
+From f9b68fa8d5029486f4624e6611a292d0b4a86d85 Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
 Subject: [PATCH 049/167] lirc: added support for RaspberryPi GPIO
@@ -80495,7 +80495,7 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From 8837697d0a331c5d0bf5116ef174f8ec5ea1dae7 Mon Sep 17 00:00:00 2001
+From 997227cc203e81823ae1a185c97ddca01f005e58 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
 Subject: [PATCH 050/167] Add cpufreq driver
@@ -80765,7 +80765,7 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 179c5c9c0a72eb6552dd4d7ef64d1821520f8d76 Mon Sep 17 00:00:00 2001
+From daf97b0f1446589b4d374fb0c5cfe84ba04c9f07 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
 Subject: [PATCH 051/167] Added hwmon/thermal driver for reporting core
@@ -80934,7 +80934,7 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From 531fcde2e4e7dedcd1d8e5b07bd21c5e543dca37 Mon Sep 17 00:00:00 2001
+From c44881a00ad2a3542f2eba44579f1ab5aa289a55 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
 Subject: [PATCH 052/167] Add Chris Boot's i2c driver
@@ -81602,7 +81602,7 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 1c01f9c2268055abf3cc1d765a346038db0912f1 Mon Sep 17 00:00:00 2001
+From 04b1439de7d0c602e374e2a695b8bc77d3c4209c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
 Subject: [PATCH 053/167] char: broadcom: Add vcio module
@@ -81830,7 +81830,7 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From ce0242da08e94db465c2f23685b41607467f5ac9 Mon Sep 17 00:00:00 2001
+From 15989dc7541cd3c17e0f2de12f7375b9a40aaf68 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
 Subject: [PATCH 054/167] firmware: bcm2835: Support ARCH_BCM270x
@@ -81916,7 +81916,7 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From d342d8f317929a3ac6ac9b409a237499d5a798bf Mon Sep 17 00:00:00 2001
+From 6c2fe8d12a02b8d82d9ae701e5591abbda429262 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
 Subject: [PATCH 055/167] scripts: Add mkknlimg and knlinfo scripts from tools
@@ -82439,7 +82439,7 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 07861071c5d6a6c5742626acbabb3c77b9ca8004 Mon Sep 17 00:00:00 2001
+From c9764f4f1e267144f1ddb357f16c82a20b048966 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
 Subject: [PATCH 056/167] BCM2708: Add core Device Tree support
@@ -93741,7 +93741,7 @@ index 7234e61e7ce370a775ec6981b391b6d102a01770..1b53cd59e4875d388e4974a3399d5f07
  
  # Bzip2
 
-From c115b5c6807f04f4b92b05cc86dc3f0a17212bdf Mon Sep 17 00:00:00 2001
+From 897eed917d69246ceaf588488dbb03963478eb54 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
 Subject: [PATCH 057/167] BCM270x_DT: Add pwr_led, and the required "input"
@@ -93920,7 +93920,7 @@ index 38c0bd7ca1074af234d516275791d05f945ce1f0..2f026646d24bad617c73aa79db30c9aa
  	/* set_brightness_work / blink_timer flags, atomic, private. */
  	unsigned long		work_flags;
 
-From 736f22c6312254a82104b90d9d07f79da7dce290 Mon Sep 17 00:00:00 2001
+From 732b19be3e3ca3be8242916c2711ea199017c429 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
 Subject: [PATCH 058/167] fbdev: add FBIOCOPYAREA ioctl
@@ -94175,7 +94175,7 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From cd20f1468770e26ce84c2300c72d22afed6067a5 Mon Sep 17 00:00:00 2001
+From 6d367e3c7bd9672506c5e5d67676b08d67a0245c Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
 Subject: [PATCH 059/167] Speed up console framebuffer imageblit function
@@ -94387,7 +94387,7 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From 889a149a9b3ff0fde024f47d233913f6722c32b3 Mon Sep 17 00:00:00 2001
+From 3c7d95f40383f80b11627d973c37e825db05731b Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
 Subject: [PATCH 060/167] enabling the realtime clock 1-wire chip DS1307 and
@@ -94640,7 +94640,7 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From 341fd02643774889ec433de1dc183d52774e8e6e Mon Sep 17 00:00:00 2001
+From fa04bb44e45779d0d57435cd7298fcbc3706b760 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
 Subject: [PATCH 061/167] hid: Reduce default mouse polling interval to 60Hz
@@ -94679,7 +94679,7 @@ index 961bc6fdd2d908835fa9a07d169a4746fb44189d..c595188a1156a27aa79f111d81636b6d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From 120adec9d51a49a923ea2298c584e32d81db35f7 Mon Sep 17 00:00:00 2001
+From b2dc3015c2edc24aec61c4be7b84847a2c3119dd Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
 Subject: [PATCH 062/167] rpi-ft5406: Add touchscreen driver for pi LCD display
@@ -95040,7 +95040,7 @@ index 30fb37fe175df604a738258a2a632bca3bfff33f..4a3d79d3b48eb483a4e4bf498f617515
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From f6d4f727ca4a4d14fb8f17567f0a2bfa662d6140 Mon Sep 17 00:00:00 2001
+From 0f9d67a98c6dcacb62b46a5bc5e1640e56a3c9ea Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
 Subject: [PATCH 063/167] Improve __copy_to_user and __copy_from_user
@@ -96618,7 +96618,7 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From 35f2a98ce5c95ac5920f88a9935a53fc3443b452 Mon Sep 17 00:00:00 2001
+From 1915b0fddcd3f7a47b0e693ff497fae994b3523c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
 Subject: [PATCH 064/167] gpio-poweroff: Allow it to work on Raspberry Pi
@@ -96656,7 +96656,7 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From f9fa2d348680082117a1fdf1bb79ba1cae721bb9 Mon Sep 17 00:00:00 2001
+From 768c040156763cab2aa5e8868c1dcd9983d4d325 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
 Subject: [PATCH 065/167] mfd: Add Raspberry Pi Sense HAT core driver
@@ -97524,7 +97524,7 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 423c8100d60affbd48c457e57955909b67c9f8b9 Mon Sep 17 00:00:00 2001
+From 350c9ae02bbf7ed36cdbac9a142a9b7a9fa11f66 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
 Subject: [PATCH 066/167] ASoC: Add support for HifiBerry DAC
@@ -97702,7 +97702,7 @@ index 0000000000000000000000000000000000000000..ee9f133953544629282631e5ef3f73fe
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 4541f0420a0907822f07f19579e7c98ed8eb31cf Mon Sep 17 00:00:00 2001
+From 6c47d9c1de688692b239a24af326c41b29a119e1 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
 Subject: [PATCH 067/167] ASoC: Add support for Rpi-DAC
@@ -97989,7 +97989,7 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From d7f6fadf9144b6a107886ada2a24d37e4ac778ba Mon Sep 17 00:00:00 2001
+From dc34f4dadcb3ba02cb66ac1fe0bc7cca3820bc79 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
 Subject: [PATCH 068/167] ASoC: wm8804: Implement MCLK configuration options,
@@ -98041,7 +98041,7 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From 08d9a617c70bbf304162528bdb2b354b57d73b56 Mon Sep 17 00:00:00 2001
+From cd2150f00dd92834b0a44d990d55fd063abe034e Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
 Subject: [PATCH 069/167] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
@@ -98388,7 +98388,7 @@ index 0000000000000000000000000000000000000000..7620dd02de40b6d644ff038b445d375d
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 482327a2f5f8ebde72df26fe6d7e106deb20dea6 Mon Sep 17 00:00:00 2001
+From eeaae798ffbf13c35173bfa011364cc0055d076e Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
 Subject: [PATCH 070/167] Add IQaudIO Sound Card support for Raspberry Pi
@@ -98726,7 +98726,7 @@ index 0000000000000000000000000000000000000000..1ee4097c846376666775272ed692ca33
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 8a025c470d6837159afc9745f2aca3e56f37c6b6 Mon Sep 17 00:00:00 2001
+From 601fb2c44d7ad00754ed2b5746d9f9144c71eebe Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
 Subject: [PATCH 071/167] Added support for HiFiBerry DAC+
@@ -99359,7 +99359,7 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From 8e80f75d88d95b5c33eecde75588de8c3895345e Mon Sep 17 00:00:00 2001
+From 35c12db459a12c1481e28b62feece2192fea5fa9 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
 Subject: [PATCH 072/167] Added driver for HiFiBerry Amp amplifier add-on board
@@ -100197,7 +100197,7 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 7f42c9601a1460e1842bf68bb5dda837cbf466cc Mon Sep 17 00:00:00 2001
+From 46349f2bd2e39a806d53d65af63ee1e1f3eb8784 Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
 Subject: [PATCH 073/167] Update ds1307 driver for device-tree support
@@ -100227,7 +100227,7 @@ index 4ad97be480430babc3321075f2739114eaad8f04..2ac1c265dc9cea56a5949eb537949a1f
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From f3e31913fb12076dc9ef5276309cc45e1fabef51 Mon Sep 17 00:00:00 2001
+From 68e7e25acf1f49e3b5ca6cd311fb35adfc656af3 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
 Subject: [PATCH 074/167] Add driver for rpi-proto
@@ -100445,7 +100445,7 @@ index 0000000000000000000000000000000000000000..fadbfade100228aaafabb0d3bdf35c01
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 9df5a22847cb998671c0944ce278db8927445ff0 Mon Sep 17 00:00:00 2001
+From 46d66b7f3be32394e810c41d575d53ecc853d57e Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
 Subject: [PATCH 075/167] RaspiDAC3 support
@@ -100691,7 +100691,7 @@ index 0000000000000000000000000000000000000000..ad2b5b89bc8213dc2e277306ef50d6e3
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From 8db91f8258d55216d465cc4172f3e74a5864e831 Mon Sep 17 00:00:00 2001
+From 4c3a063245a55b72e81339a3a55f35a7b0549c1f Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
 Subject: [PATCH 076/167] Add Support for JustBoom Audio boards
@@ -101150,7 +101150,7 @@ index 0000000000000000000000000000000000000000..909cf8928f2f4313982316f9c5b8a709
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From cff0ea60385d53808797dceb63b24cfba63d8266 Mon Sep 17 00:00:00 2001
+From 9dfb099e44b1a1aeb59c1773ba3dc44be6edff40 Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
 Subject: [PATCH 077/167] ARM: adau1977-adc: Add basic machine driver for
@@ -101335,7 +101335,7 @@ index 0000000000000000000000000000000000000000..f3d7e5db7bb912e1d7ca6f8e8d42df5f
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From b75774af8630b0d522b58c63dda95c003afd8c4d Mon Sep 17 00:00:00 2001
+From 2ac64705f0a22ffe20b88e3bfca31d21efab68dd Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
 Subject: [PATCH 078/167] New AudioInjector.net Pi soundcard with low jitter
@@ -101589,7 +101589,7 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 0ae26cbf8c5398d4beddf36877feaaf6c731640e Mon Sep 17 00:00:00 2001
+From 51843ec949302798b427742123e6111d2b57d481 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
 Subject: [PATCH 079/167] Add IQAudIO Digi WM8804 board support
@@ -101892,7 +101892,7 @@ index 0000000000000000000000000000000000000000..33aa2be8a43a12a12cfb5d844dd9732c
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 6540759002e73a890d45fef76a69890c9517d001 Mon Sep 17 00:00:00 2001
+From 8035396df401691640734035e9f0b4ebcea025ef Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
 Subject: [PATCH 080/167] New driver for RRA DigiDAC1 soundcard using WM8741 +
@@ -102368,7 +102368,7 @@ index 0000000000000000000000000000000000000000..f200688bb4ae32b90a0ced555aed94b0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From d031fa0d7b6f81ebb6569e8349018b5a78b071f1 Mon Sep 17 00:00:00 2001
+From f490b01916b8f82ee9fabd2f91187edc4c22a8bc Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
 Subject: [PATCH 081/167] Add support for Dion Audio LOCO DAC-AMP HAT
@@ -102544,7 +102544,7 @@ index 0000000000000000000000000000000000000000..65e03741d349a2dc5bd91f69855ea952
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From cf0ffeca41fee940cbfea5ab210d02e3a589e3c6 Mon Sep 17 00:00:00 2001
+From f872c6bbf4288dded96166ba6cfeac81e4a014cc Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
 Subject: [PATCH 082/167] Allo Piano DAC boards: Initial 2 channel (stereo)
@@ -102754,7 +102754,7 @@ index 0000000000000000000000000000000000000000..eaf50fb6dbca1970ae1c6f8662088b0f
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 47ff419aff86173707854f0d30272d9085ac5d2e Mon Sep 17 00:00:00 2001
+From a0b990fb9de3cc1c668ebf60f2342bdcbd675fd3 Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
 Subject: [PATCH 083/167] Support for Blokas Labs pisound board
@@ -103956,7 +103956,7 @@ index 0000000000000000000000000000000000000000..06ff1e53dc9d860946965b6303577762
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From b3cd29b517b80b88ae173408f4b94c5cb03ef2c1 Mon Sep 17 00:00:00 2001
+From b18cdd6c80f5daa80daf2fd009225bb87cee7c0b Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 22 Jan 2017 12:49:37 +0100
 Subject: [PATCH 084/167] ASoC: Add driver for Cirrus Logic Audio Card
@@ -105024,7 +105024,7 @@ index 0000000000000000000000000000000000000000..ac8651ddff7bd3701dffe22c7fb88352
 +MODULE_DESCRIPTION("ASoC driver for Cirrus Logic Audio Card");
 +MODULE_LICENSE("GPL");
 
-From 13e703007020d35b99bce051103df210605ce3a0 Mon Sep 17 00:00:00 2001
+From 4751b4139c832a5839ac0a2fa9b74b028270b9ca Mon Sep 17 00:00:00 2001
 From: Miquel <miquelblauw@hotmail.com>
 Date: Fri, 24 Feb 2017 20:51:06 +0100
 Subject: [PATCH 085/167] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
@@ -105221,7 +105221,7 @@ index 0000000000000000000000000000000000000000..a009c49477972a9832175d86f201b035
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO-V2");
 +MODULE_LICENSE("GPL v2");
 
-From 085b8a6b22489e1ca17b453ac038cbb059a8c2f3 Mon Sep 17 00:00:00 2001
+From d19ab62409f4f8ea58f12cbe27c5cf5fc22294d7 Mon Sep 17 00:00:00 2001
 From: Fe-Pi <fe-pi@cox.net>
 Date: Wed, 1 Mar 2017 04:42:43 -0700
 Subject: [PATCH 086/167] Add support for Fe-Pi audio sound card. (#1867)
@@ -105438,7 +105438,7 @@ index 0000000000000000000000000000000000000000..015b56fd73cc36be5b5eecd17548fd03
 +MODULE_DESCRIPTION("ASoC Driver for Fe-Pi Audio");
 +MODULE_LICENSE("GPL v2");
 
-From f7d705034138b4ec264404e9c5b7ed8b67a5369f Mon Sep 17 00:00:00 2001
+From 1f8846e5d06751c55cc69592705eb4d9cd027ae0 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 20:04:13 +1100
 Subject: [PATCH 087/167] Add support for the AudioInjector.net Octo sound card
@@ -105781,7 +105781,7 @@ index 0000000000000000000000000000000000000000..9effea725798640887755dfa688da453
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:audioinjector-octo-soundcard");
 
-From edbb4bc8990af45a4a3468772e4c435916c769e1 Mon Sep 17 00:00:00 2001
+From d0d0da10a7c0ae1b2a54f993da524008d1a37c45 Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
 Subject: [PATCH 088/167] rpi_display: add backlight driver and overlay
@@ -105953,7 +105953,7 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 86bae806b98daf5896f5e2536169dc315da7d5ac Mon Sep 17 00:00:00 2001
+From 2661ac69c895775db1357272d2d74be52e19ddac Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
 Subject: [PATCH 089/167] bcm2835-virtgpio: Virtual GPIO driver
@@ -106230,7 +106230,7 @@ index 4a3d79d3b48eb483a4e4bf498f617515e3ad158f..5f34e1257117fb48013c9926a8a223d6
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 305ff41d7e62f603a6ae07e5cbfaafbf1259f09c Mon Sep 17 00:00:00 2001
+From 9c24d668c5e30c26b44d07b6e2a45b309538f3fc Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Mon, 20 Feb 2017 17:01:21 +0000
 Subject: [PATCH 090/167] bcm2835-gpio-exp: Driver for GPIO expander via
@@ -106561,7 +106561,7 @@ index 5f34e1257117fb48013c9926a8a223d64a598ab7..c819c21b0158a59c1308882e5a40e3f3
  	/* Dispmanx TAGS */
  	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,
 
-From ba14863b8ffba55a0e850e1baf742f1cc81f461a Mon Sep 17 00:00:00 2001
+From 3898c6d8095e4701aa1f4b69ca254914c0711864 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
 Subject: [PATCH 091/167] amba_pl011: Don't use DT aliases for numbering
@@ -106593,7 +106593,7 @@ index f2503d862f3aee25396ef002ba69968896316779..a85e81245004e928fc52ec59044e151b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From e3396edd19d3a1104ef38acfea057c02017d7213 Mon Sep 17 00:00:00 2001
+From c087afaedb9ee07996d0c12e641434ac9dbf4950 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:07:39 +0000
 Subject: [PATCH 092/167] amba_pl011: Round input clock up
@@ -106682,7 +106682,7 @@ index a85e81245004e928fc52ec59044e151b7f183496..380d2c2e19ae3720924e906261b487ad
  /* unregisters the driver also if no more ports are left */
  static void pl011_unregister_port(struct uart_amba_port *uap)
 
-From f86774023e35e89bd38bf7dd602f483e5ecaab79 Mon Sep 17 00:00:00 2001
+From 64218850b7cb509d11e86b58a49539a6c53c7099 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
 Subject: [PATCH 093/167] OF: DT-Overlay configfs interface
@@ -107117,7 +107117,7 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From ec8e585ace9f560a72baec01bf56cfa8c13797cf Mon Sep 17 00:00:00 2001
+From 016d0d19f60b0b348c40db9222addc6b1cdd539e Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
 Subject: [PATCH 094/167] brcm: adds support for BCM43341 wifi
@@ -107271,7 +107271,7 @@ index 65689469c5a12e2fcfd6123ca584944da79ec184..4886dc29ad36705210bed20757ce09ed
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_43362_CHIP_ID, 0xFFFFFFFE, 43362),
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_4339_CHIP_ID, 0xFFFFFFFF, 4339),
 
-From 7591b981df69c497fb743678d28602029340c7fd Mon Sep 17 00:00:00 2001
+From 2aad0ee970091db61263df3d27049ced5681afdd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Feb 2017 15:26:13 +0000
 Subject: [PATCH 095/167] brcmfmac: Mute expected startup 'errors'
@@ -107313,7 +107313,7 @@ index 6221b046bca44211e2dfac24119097f7ac09e829..634602e0c44f91da06db7aa803dbee69
  	/* locate firmware version number for ethtool */
  	ptr = strrchr(buf, ' ') + 1;
 
-From b152a60b1a115e948d7d41aeee5cf020404e8ae0 Mon Sep 17 00:00:00 2001
+From 453b9d90f6205f219f7b0691f3e412220e5fb80f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
 Subject: [PATCH 096/167] hci_h5: Don't send conf_req when ACTIVE
@@ -107339,7 +107339,7 @@ index 90d0456b67446bcc624fab4b1542c4eaf21531b1..f9adeac3bbba6418dcca298c55706356
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From 71ae35b5158addcd1212846a7f21007c6fbd8e11 Mon Sep 17 00:00:00 2001
+From bb741ee72fab8110b2b7f86410fc72d2b136b93e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
 Subject: [PATCH 097/167] config: Add default configs
@@ -109990,7 +109990,7 @@ index 0000000000000000000000000000000000000000..046f3e8757ef0f794c802171690528d3
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From e1c2dd2f25fbe0894052e55ed76a06fe34f66596 Mon Sep 17 00:00:00 2001
+From 2364962b28dddcc0144d2c62860d7ed2075b6a4e Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
 Subject: [PATCH 098/167] Add arm64 configuration and device tree differences.
@@ -111408,7 +111408,7 @@ index 0000000000000000000000000000000000000000..e6b09fafa27eed2b762e3d53b55041f7
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2835_VCHIQ=n
 
-From 6a99ce4838c49f3647570b3ad1aacc2cafca5cab Mon Sep 17 00:00:00 2001
+From fae11dca73c9f1eea033f56db6bfb3eb7c5e4fb5 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
 Subject: [PATCH 099/167] raspberrypi-firmware: Define the MBOX channel in the
@@ -111433,7 +111433,7 @@ index c819c21b0158a59c1308882e5a40e3f3fe73cbdf..de2a3dcd562beb752266eaf0070e5586
  
  enum rpi_firmware_property_status {
 
-From 0aaa5d8506326b0ae0cbcd7b4a506042fe92624a Mon Sep 17 00:00:00 2001
+From af0f8e2ef109c170c66ae9f0de8c93154d2c7fe7 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
 Subject: [PATCH 100/167] raspberrypi-firmware: Export the general transaction
@@ -111480,7 +111480,7 @@ index de2a3dcd562beb752266eaf0070e55861d553f5f..dc7fd58afd5dddebf9b17065bb069a1d
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 22ad8746250c19da0e947b71f8c062b5a79c9dad Mon Sep 17 00:00:00 2001
+From a3ab74df0b65591f541035a5ca7dace7d79d5daa Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
 Subject: [PATCH 101/167] ARM64: Make it work again on 4.9 (#1790)
@@ -111887,7 +111887,7 @@ index e6b09fafa27eed2b762e3d53b55041f793683d27..c7e891d72969a388d9b135a36dbfc9c9
  CONFIG_LIBCRC32C=y
 -CONFIG_BCM2835_VCHIQ=n
 
-From 4d2147d24dba3f03f3df8c85f64a5c41e913fd3b Mon Sep 17 00:00:00 2001
+From 822051fd7fcc52f4b0273de82a030b5433b594b8 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:10:07 -0800
 Subject: [PATCH 102/167] ARM64: Enable HDMI audio and vc04_services in
@@ -111919,7 +111919,7 @@ index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..4b90f9b64abe9f089ba56b13d5a00de3
  CONFIG_BCM2835_MBOX=y
  # CONFIG_IOMMU_SUPPORT is not set
 
-From 37ffd804f5315afc60cbf54f51b330415725e863 Mon Sep 17 00:00:00 2001
+From 4bc0881ff82d0bec522c040a51d7e268c816f1e3 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:14:03 -0800
 Subject: [PATCH 103/167] ARM64: Run bcmrpi3_defconfig through savedefconfig.
@@ -111967,7 +111967,7 @@ index 4b90f9b64abe9f089ba56b13d5a00de33343bfb9..dac962ca1634662ce7d966f1ffb53b5b
  CONFIG_FB_TFT_AGM1264K_FL=m
  CONFIG_FB_TFT_BD663474=m
 
-From 7c154e23f4fc414763ce2d51a44ab325658a1e1d Mon Sep 17 00:00:00 2001
+From 32647dca98827a401ac14566795a628c4af0f3d2 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 02:54:26 -0800
 Subject: [PATCH 104/167] ARM64: Enable Kernel Address Space Randomization
@@ -112002,7 +112002,7 @@ index dac962ca1634662ce7d966f1ffb53b5bfa27c506..aae33b4b3c3e736ea7cd3ca242158ad6
  CONFIG_BINFMT_MISC=y
  CONFIG_COMPAT=y
 
-From 69bfe478cc79277ce1f11f1456ae991f5ae79c0b Mon Sep 17 00:00:00 2001
+From 7b3d71daad3c62e616587e8af9236dbc860fef68 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sun, 15 Jan 2017 07:31:59 -0800
 Subject: [PATCH 105/167] ARM64: Enable RTL8187/RTL8192CU wifi in build config
@@ -112030,7 +112030,7 @@ index aae33b4b3c3e736ea7cd3ca242158ad6ba558aff..b7d762df19b85e369a32cd823dfd0621
  CONFIG_ZD1211RW=m
  CONFIG_MAC80211_HWSIM=m
 
-From 10f859daf0a0059aed1fb3d88688dbe625520b15 Mon Sep 17 00:00:00 2001
+From 1a3409201cc75dc0b54ca4fe9182b743a895a5b0 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:33:51 -0800
 Subject: [PATCH 106/167] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
@@ -112376,7 +112376,7 @@ index 6b2c7d0c93f36a63863ff4b0ecc1f3eab77e058b..d7b700ff17821ad1944e36721fe6b2db
  /** The OS page size */
  #define DWC_OS_PAGE_SIZE	PAGE_SIZE
 
-From 41d21a6a58cab0d7caf148eb57b6e7e6e23fa97e Mon Sep 17 00:00:00 2001
+From 25d48b2467ce86b0db108004f1a1c60b4389b8b3 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:43:57 -0800
 Subject: [PATCH 107/167] ARM64: Round-Robin dispatch IRQs between CPUs.
@@ -112453,7 +112453,7 @@ index c4e151451cf8c8ebde5225515eac2786d6f61d46..9a7ee04ee0d9b7aa734cf3159ed59c19
  	.name		= "bcm2836-gpu",
  	.irq_mask	= bcm2836_arm_irqchip_mask_gpu_irq,
 
-From d652b5d461f97868a482c7c217a2095f49c68e08 Mon Sep 17 00:00:00 2001
+From 5a0978e7b7ed5f4a09844a2eaa07f6beecbf54a5 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:45:03 -0800
 Subject: [PATCH 108/167] ARM64: Enable DWC_OTG Driver In ARM64 Build
@@ -112477,7 +112477,7 @@ index b7d762df19b85e369a32cd823dfd062145bdefa7..4d85c231c5ea0244e1b05fb4a5e3c8fd
  CONFIG_USB_STORAGE=y
  CONFIG_USB_STORAGE_REALTEK=m
 
-From 31de8e6310d6111511e9a21bef03316e02f7a72d Mon Sep 17 00:00:00 2001
+From 7bf84cad99e6de2015d7d1cd9d5f813c7c5ae62c Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 11 Feb 2017 01:18:31 -0800
 Subject: [PATCH 109/167] ARM64: Force hardware emulation of deprecated
@@ -112508,7 +112508,7 @@ index f0e6d717885b1fcf3b22f64c10c38f19c25f809d..0cb830d30fb6d2bd26ab572efe893649
  	case INSN_OBSOLETE:
  		insn->current_mode = INSN_UNDEF;
 
-From 44e4e9406bfd765806fd648469264356af5093a0 Mon Sep 17 00:00:00 2001
+From 15515740c16eb20d1d89a4efc5c53a756c58a231 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 10 Feb 2017 17:57:08 -0800
 Subject: [PATCH 110/167] build/arm64: Add rules for .dtbo files for dts
@@ -112536,7 +112536,7 @@ index b9a4a934ca057623e0ea436fd9b2c7c0f675fced..54e3c38d6fd877827541cdc798de035c
  
  dtbs: prepare scripts
 
-From 59db18ff3839475d96254f51cb162ac35068e710 Mon Sep 17 00:00:00 2001
+From 23bd41475d2a7d788d1171fc9e11956cba854a2d Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
 Subject: [PATCH 111/167] clk: bcm2835: Mark GPIO clocks enabled at boot as
@@ -112577,7 +112577,7 @@ index 39f72da6ba1f6ec6ec41d5dc1bf46344aab008da..fe3298b54cdfb96bd90fb4f39e13921d
  	 * rate changes on at least of the parents.
  	 */
 
-From 670c2eb63b26e5c71cbcd86c15010d24f7cb849f Mon Sep 17 00:00:00 2001
+From 1d5cb12d2cc3a59fcdc3005ddae656ec47560aa1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
 Subject: [PATCH 112/167] pinctrl-bcm2835: Fix interrupt handling for GPIOs
@@ -112613,7 +112613,7 @@ index 6351fe7f8e314ac5ebb102dd20847b383fd5b857..28745af5aadf3cb91fa7ff39118385c3
  	},
  };
 
-From 875b0b42ffc54c9fd7376547a08a4eb2594a6a45 Mon Sep 17 00:00:00 2001
+From e447f049231af08c2a2bf3e433e385c17310a295 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Tue, 7 Mar 2017 12:18:20 +0000
 Subject: [PATCH 113/167] BCM270X_DT: Invert Pi3 power LED to match fw change
@@ -112642,7 +112642,7 @@ index 616cfd5c7094596b497101e8feca25e25e77c3e8..9f001bccb8261563dcddd8dec94b056b
  };
  
 
-From 26127d1b8fd41a6c0b5cbecb90a560293847bf12 Mon Sep 17 00:00:00 2001
+From dc0ef56c76ec77f19774bd87d02791428725209d Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Tue, 14 Mar 2017 14:23:06 +0000
 Subject: [PATCH 114/167] bcm2835-gpio-exp: Copy/paste error adding base twice
@@ -112671,7 +112671,7 @@ index 681a91492d4c33bdfd42416e069218e8611cc4d9..d68adafaee4ad406f45f4ff0d6b7c1ad
  	set.state = val;	/* Output state */
  
 
-From 59705e7e200369cf3475837f81284b8ae81e14bd Mon Sep 17 00:00:00 2001
+From f247dc9dd557c00ef74fa5a76452bf8b3fde6387 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 17 Mar 2017 13:40:41 +0000
 Subject: [PATCH 115/167] config: disable MMC driver temporarily for now.
@@ -112709,7 +112709,7 @@ index 046f3e8757ef0f794c802171690528d31fee9deb..f2e0a58a96c8550f110c5940bf65f4d0
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 5892e952fcaeb9532dfd34fad22c9532ec1ba1fd Mon Sep 17 00:00:00 2001
+From e134093f1b0dc9db64780e9e5b0aa482c2aa8cec Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Mar 2017 12:24:41 +0000
 Subject: [PATCH 116/167] config: Make spidev a loadable module
@@ -112752,7 +112752,7 @@ index f2e0a58a96c8550f110c5940bf65f4d022cc4548..9eb7084f440c8aac0c6257ee678007c2
  CONFIG_PPS_CLIENT_LDISC=m
  CONFIG_PPS_CLIENT_GPIO=m
 
-From 113a60000a97ee17f54ebb2c25c7a68e2d2f88f4 Mon Sep 17 00:00:00 2001
+From 63aa7786fcb6828e7ac09cd8528e509bb97d4583 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 10:06:56 +0000
 Subject: [PATCH 117/167] ASoC: Add prompt for ICS43432 codec
@@ -112780,7 +112780,7 @@ index 55812b0b884cf4fc4e86680b11fedd11c863db7a..428dc05edbb99f50560b7f89e45501c5
  config SND_SOC_INNO_RK3036
  	tristate "Inno codec driver for RK3036 SoC"
 
-From 6712820f29857d3d6ea6ea12af114c27dcdc9a82 Mon Sep 17 00:00:00 2001
+From 7f5f873ff31e5fb9db89bd8870097df6b30c4660 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 16:34:46 +0000
 Subject: [PATCH 118/167] bcm2835-aux: Add aux interrupt controller
@@ -112947,7 +112947,7 @@ index bd750cf2238d61489811e7d7bd3b5f9950ed53c8..41e0702fae4692221980b0d02aed1ba6
  			       BCM2835_AUX_CLOCK_COUNT, GFP_KERNEL);
  	if (!onecell)
 
-From 70245b73b3cebef57c34ea42f2f85d7917ab5d2c Mon Sep 17 00:00:00 2001
+From 9156f46b682e9fc3ca1cdcac4eddc74a3cc21529 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 17:08:44 +0000
 Subject: [PATCH 119/167] BCM270X_DT: Enable AUX interrupt controller in DT
@@ -113003,7 +113003,7 @@ index 72cb9dc60ca9ad9aa2813972a299c50dcea7cd89..ca47b23ffbcd06063e0fb7072dc8a843
  			#address-cells = <1>;
  			#size-cells = <0>;
 
-From 73c46b347dfec071259b176959635e6027881a8f Mon Sep 17 00:00:00 2001
+From a420a0f881e0bdddc932e1896617b995d94f1554 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 27 Mar 2017 17:40:45 +0100
 Subject: [PATCH 120/167] mkknlimg: Find some more downstream-only strings
@@ -113037,7 +113037,7 @@ index 60206de7fa9a49bd027c635306674a29a568652f..84be2593ec1de8f97b0167ff06b3e05d
  
  my $res = try_extract($kernel_file, $tmpfile1);
 
-From 5ef0615ade9e194f7f1e959bf36f484b0f48d0d6 Mon Sep 17 00:00:00 2001
+From d3106d8e495216d8bf7a46b2d811d70b9e4e36ac Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 29 Apr 2016 10:32:17 -0700
 Subject: [PATCH 121/167] mmc: read mmc alias from device tree
@@ -113097,7 +113097,7 @@ index 3f8c85d5aa094b43666904c7dbbe5e62c9763c19..4dbd0e8e27a496bfbe67d188cf795ecc
  		kfree(host);
  		return NULL;
 
-From 3e37913a6d6d4dcd12144a08686ecbaf6c29db52 Mon Sep 17 00:00:00 2001
+From 95a2ced7b7f1b026f65774bda9eb0f8354fc376c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 14:30:42 +0100
 Subject: [PATCH 122/167] BCM270X_DT: Add numbered aliases for SD/MMC devices
@@ -113131,7 +113131,7 @@ index ef14e9ac6cd2092efb1681682dd2d3c52b8abfd5..693d4c04a36d2a7883cc3d8916bf0efb
  		i2c2 = &i2c2;
  		usb = &usb;
 
-From c820d3b8890e84d8205903a6570e2b5877b18a0f Mon Sep 17 00:00:00 2001
+From b50f9e35579e3bf6d12600a829a86490a52522ff Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 14:28:53 +0100
 Subject: [PATCH 123/167] config: Re-enable the bcm2835-mmc driver
@@ -113171,7 +113171,7 @@ index 9eb7084f440c8aac0c6257ee678007c23990a8ae..021c38a909e71baa135cbcd4f3fb80fa
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 7c57e289610aada9dd11f06ec05d800ea8c286cc Mon Sep 17 00:00:00 2001
+From 8501c30eb81d960b40f460d312e97e1159659bb2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
 Subject: [PATCH 124/167] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
@@ -113316,7 +113316,7 @@ index 77e61e0a216a2728dd5cfecf55299402ac03c384..d12e8ddd22cb96e38b30f1ac3f9a6bd0
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From 579317a8a0f0ff3a68688c85bdbeb3c85de41df7 Mon Sep 17 00:00:00 2001
+From db5da975a0bf7185c7f6a51810e9ea815fcfa31a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 16:08:29 +0100
 Subject: [PATCH 125/167] bcm2835-sdhost: mmc_card_blockaddr fix
@@ -113346,7 +113346,7 @@ index a9bc79bfdbb71807819dfe2d8f1651445997f92a..9c6f199a7830959f31012d86bc1f8b1a
  
  #define SDCMD  0x00 /* Command to SD card              - 16 R/W */
 
-From 0d19738d8eea0321f939357cc70ba32ee6a3a4e6 Mon Sep 17 00:00:00 2001
+From 3d219aa58aa896aa50adde7bec595da7955e07bb Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Mar 2017 12:30:37 +0000
 Subject: [PATCH 126/167] thermal: Compatible strings for bcm2836, bcm2837
@@ -113381,7 +113381,7 @@ index c63fb9f9d143e19612a18fe530c7b2b3518a22a4..25b78c3eac1503fbc9e679b963a6284b
  };
  MODULE_DEVICE_TABLE(of, bcm2835_thermal_of_match_table);
 
-From 127f28c7277f067f08e894d1ace0c5cbe61de0a9 Mon Sep 17 00:00:00 2001
+From 6f1ad85309eaf28bd2168682de3a66ab47899553 Mon Sep 17 00:00:00 2001
 From: John Greb <h3x4m3r0n@gmail.com>
 Date: Wed, 8 Mar 2017 15:12:29 +0000
 Subject: [PATCH 127/167] Match dwc2 device-tree fifo sizes to the hardware
@@ -113415,7 +113415,7 @@ index 527abc9f0ddf71f4dc7d58336d87684c931cc2f3..265a16bab008453edba198cf2366c423
  	};
  };
 
-From c09840140d70b4a9475749af75d04fe5634cbc37 Mon Sep 17 00:00:00 2001
+From 70bb3413b8944b08da15d34059ea0a963164e0b8 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Mar 2017 09:10:05 +0000
 Subject: [PATCH 128/167] BCM270X_DT: Add lm75 to i2c-sensor overlay
@@ -113481,7 +113481,7 @@ index 31bda8da4cb6a56bfe493a81b918900995fb0589..606b2d5012abf2e85712be631c42ea40
  	};
  };
 
-From d769ba4e419c55e8db2fcfa3eb9bc56b0f4d6663 Mon Sep 17 00:00:00 2001
+From 590770ef0843d12b901f8f07c7c7d29f9aa5c26c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 28 Mar 2017 14:22:20 +0100
 Subject: [PATCH 129/167] BCM270X_DT: Allow multiple instances of w1-gpio
@@ -113549,7 +113549,7 @@ index 66a98f6c9601f51483f27803995bec772bb3350e..ef8bfbcabdb31231075d5c281df3b38b
  				<&w1_pins>,"brcm,pins:4";
  		pullup =        <&w1>,"rpi,parasitic-power:0";
 
-From 5e3fe022ba21852fc61703df08d1858c95589144 Mon Sep 17 00:00:00 2001
+From 8d1f96f986847b560bceccc5029cc1c21804a71b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 28 Mar 2017 17:41:30 +0100
 Subject: [PATCH 130/167] leds-gpio: Remove stray assignment to brightness_set
@@ -113578,7 +113578,7 @@ index 934cdb1d7bc7f12a4fb06a5c458ad76727c7b7c7..a4df27f6af35ba7f7b34c2a4b7b22ee7
  	if (template->default_state == LEDS_GPIO_DEFSTATE_KEEP) {
  		state = gpiod_get_value_cansleep(led_dat->gpiod);
 
-From 84edfb6f829d6f211c7cc6be0230bc96dcc9d399 Mon Sep 17 00:00:00 2001
+From d067c0c2a34c35cf3f8fe144bae466b86fd94f8d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 29 Mar 2017 17:41:04 +0100
 Subject: [PATCH 131/167] config: Add back MMC_BCM2835_DMA
@@ -113613,7 +113613,7 @@ index 021c38a909e71baa135cbcd4f3fb80fad2151647..a8fc96ef674be476d10e59aef2367def
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 33a2018a06dad4113ca21e63f576dd668e11f1b3 Mon Sep 17 00:00:00 2001
+From 24f1bd381cb568f0361410e4fc393d0b4ad3729b Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 27 Mar 2017 22:26:49 +1100
 Subject: [PATCH 132/167] AudioInjector Octo: sample rates, regulators, reset
@@ -113782,7 +113782,7 @@ index 9effea725798640887755dfa688da45338718afc..dcf403ab37639ba79e38278d7e4b1ade
  			dai->cpu_dai_name = NULL;
  			dai->cpu_of_node = i2s_node;
 
-From 401fef0840482b77ee26b830c804f9419609229c Mon Sep 17 00:00:00 2001
+From 4563b740a1775f20895275bb343741710a0d27b9 Mon Sep 17 00:00:00 2001
 From: Peter Malkin <petermalkin@google.com>
 Date: Mon, 27 Mar 2017 16:38:21 -0700
 Subject: [PATCH 133/167] Driver support for Google voiceHAT soundcard.
@@ -114290,7 +114290,7 @@ index 0000000000000000000000000000000000000000..225854b8e5298b3c3018f59a49404354
 +MODULE_DESCRIPTION("ASoC Driver for Google voiceHAT SoundCard");
 +MODULE_LICENSE("GPL v2");
 
-From 968ca119e73e43594edf471731b079198446b993 Mon Sep 17 00:00:00 2001
+From 6f5fcd9cde937ad09823ffd3583c48ddb90a9a7f Mon Sep 17 00:00:00 2001
 From: Raashid Muhammed <raashidmuhammed@zilogic.com>
 Date: Mon, 27 Mar 2017 12:35:00 +0530
 Subject: [PATCH 134/167] Add support for Allo Piano DAC 2.1 plus add-on board
@@ -114921,7 +114921,7 @@ index 0000000000000000000000000000000000000000..f66f42abadbd5f9d3fe000676e8297ed
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC Plus");
 +MODULE_LICENSE("GPL v2");
 
-From 1db880f99f0d6f2d6c79c573d4d1cce4ecbf5bf2 Mon Sep 17 00:00:00 2001
+From 87c28d425feb0dd759fa1ff4c4b9a28385587b22 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Tue, 28 Mar 2017 20:04:42 +0530
 Subject: [PATCH 135/167]  Add support for Allo Boss DAC add-on board for
@@ -115654,7 +115654,7 @@ index 0000000000000000000000000000000000000000..c080e31065d99ab309ab3bdf41a44adf
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Boss DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 04447270e54117f6a755475c20d82ef9ca74c278 Mon Sep 17 00:00:00 2001
+From ceac552b42e3ae688c1176b41f2cb4c39cfd8a72 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar C <babusubashchandar@zilogic.com>
 Date: Thu, 30 Mar 2017 20:17:27 +0530
 Subject: [PATCH 136/167] Add support for new clock rate and mute gpios.
@@ -116310,7 +116310,7 @@ index c080e31065d99ab309ab3bdf41a44adfdd8f8039..203ab76c7045b081578e23bda1099dd1
  }
  
 
-From fffda44e8aa9c34aa97aba8e3e73f5edb2090fa8 Mon Sep 17 00:00:00 2001
+From 2606e13d66a5cd155a7653c32af66ee1b2521c2b Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Sat, 1 Apr 2017 00:46:52 +0530
 Subject: [PATCH 137/167] Add clock changes and mute gpios (#1938)
@@ -117006,7 +117006,7 @@ index f66f42abadbd5f9d3fe000676e8297ed91630e47..56e43f98846b41e487b3089813f7edc3
  }
  
 
-From bffcfaebe38fe0536efbf99e99c12b0bdb9e0852 Mon Sep 17 00:00:00 2001
+From 8b2e21fe2de822475aa39325280951455dfd8731 Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Fri, 14 Apr 2017 10:43:57 +0100
 Subject: [PATCH 138/167] This is the driver for Sony CXD2880 DVB-T2/T tuner +
@@ -133141,7 +133141,7 @@ index 0000000000000000000000000000000000000000..82e122349055be817eb74ed5bbcd7560
 +MODULE_AUTHOR("Sony Semiconductor Solutions Corporation");
 +MODULE_LICENSE("GPL v2");
 
-From 72dbe38b3901cb87a4afa39d1bb6e0daadfcd6ba Mon Sep 17 00:00:00 2001
+From 2a5a2d16d766043fa700d43c9ed219835a637738 Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Thu, 22 Dec 2016 15:34:12 +0900
 Subject: [PATCH 139/167] BCM2708: Add Raspberry Pi TV HAT Device Tree Support
@@ -133240,7 +133240,7 @@ index 0000000000000000000000000000000000000000..a68f6f793d8efd8b2e2adf9f2fb6426f
 +
 +};
 
-From cbb3e1bc374411fff711fc756d0894336c13e8fb Mon Sep 17 00:00:00 2001
+From 094d6cf8471f986844cd45597a9d4a9fa9693eac Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 27 Apr 2017 16:24:34 +0100
 Subject: [PATCH 140/167] dwc_otg: make nak_holdoff work as intended with empty
@@ -133327,7 +133327,7 @@ index c2dff94e8e6edd22e4427aaa1eac7aad972cb6bd..85a6d431ca54b47dc10573aa72d1ad69
  	} else {
  		uint16_t frame_number = dwc_otg_hcd_get_frame_number(hcd);
 
-From 49b2334e5f1e16b1334bda3d9dbe8b4b88052720 Mon Sep 17 00:00:00 2001
+From 32a759fb0026ed01f854c15bac764749b3c383a3 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Tue, 2 May 2017 16:31:15 +0100
 Subject: [PATCH 141/167] dwc_otg: fix split transaction data toggle handling
@@ -133418,7 +133418,7 @@ index 608e036be2c9484465ab836de70129335d3d2d96..718a1accc0c219a1764ce53d291de6a2
  	}
  	qtd = DWC_CIRCLEQ_FIRST(&hc->qh->qtd_list);
 
-From 32bd61c2297094871cc1c8163d047db3a48122bf Mon Sep 17 00:00:00 2001
+From b0e211d51b97bb0b0c46f1e0cf567699914da16c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 2 May 2017 16:36:05 +0100
 Subject: [PATCH 142/167] vcsm: Treat EBUSY as success rather than SIGBUS
@@ -133459,7 +133459,7 @@ index fd71d9fbb400d71bb8cfb8672080e7c3053e3ae9..fd2ca788dcd56b1702454d71b7bedd42
  	}
  }
 
-From 039580d0684483d053e29b41a9fd4219bba2d585 Mon Sep 17 00:00:00 2001
+From 65f6bd67e61eec92f97ca354f8462c9880389d89 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 4 May 2017 12:58:11 +0100
 Subject: [PATCH 143/167] fiq_fsm: Use correct states when starting isoc OUT
@@ -133499,7 +133499,7 @@ index 9304279592cb5b388086ef91cb52f1e9f94868ce..208252645c09d1d17bf07673989f91b7
  				break;
  			}
 
-From 4526db8e6a009963b42b723ea384fa1d265d6484 Mon Sep 17 00:00:00 2001
+From c0abcd3fb304c30294706b422319861e258f7afd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 4 May 2017 17:38:22 +0100
 Subject: [PATCH 144/167] bcm2708_fb: Avoid firmware mbox call in vc_mem_copy
@@ -133566,7 +133566,7 @@ index 53c5a0bdadb4be9251affdabed66305842a08e72..612293cf9f1bd93ad2f2aefdd7ca0f5e
  	if (ret == 0) {
  		platform_set_drvdata(dev, fb);
 
-From 8176dbf0215cc87c628ec96e8e34707b58c278cb Mon Sep 17 00:00:00 2001
+From 03ccda56eddbd9501265ea55c1c955d313f4bd7b Mon Sep 17 00:00:00 2001
 From: Nisar Sayed <Nisar.Sayed@microchip.com>
 Date: Tue, 9 May 2017 18:51:42 +0100
 Subject: [PATCH 145/167] According to RFC 2460, IPv6 UDP calculated checksum
@@ -133614,7 +133614,7 @@ index f6661e388f6e801c1b88e48a3b71407bd70cf56e..b84e98508b5d97165b68dfc30240950e
  	smsc95xx_init_mac_address(dev);
  
 
-From 14ffbd99b328c0f4545b95ca8c04b8994f6fa7b2 Mon Sep 17 00:00:00 2001
+From 6a464629fd4e7d854ab3e66169a705944d2f0e97 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
 Subject: [PATCH 146/167] drm/vc4: Add a mode for using the closed firmware for
@@ -134384,7 +134384,7 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From b7cc89b2349612b060a54adf0faf9c0fe4922be3 Mon Sep 17 00:00:00 2001
+From 048a522722c63fe014dcce9a1906fa95b7ba9437 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:09:18 -0800
 Subject: [PATCH 147/167] drm/vc4: Name the primary and cursor planes in fkms.
@@ -134411,7 +134411,7 @@ index d18a1dae51a2275846c9826b5bf1ba57ae97b55c..e49ce68b607a7ffc2329e3235362f3bc
  	if (type == DRM_PLANE_TYPE_PRIMARY) {
  		vc4_plane->fbinfo =
 
-From b631ef32bba533b6d25405d33747f8608b30492a Mon Sep 17 00:00:00 2001
+From f8be62c1ec31a841a39536d0189f15ca40ae37b6 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:10:09 -0800
 Subject: [PATCH 148/167] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
@@ -134484,7 +134484,7 @@ index e49ce68b607a7ffc2329e3235362f3bc21ed5cbb..dbf065677202fbebf8e3a0cffbe880aa
  				    RPI_FIRMWARE_SET_CURSOR_STATE,
  				    &packet_state,
 
-From c42a2ad6472d2d0d825132fe11866208b80584c5 Mon Sep 17 00:00:00 2001
+From 5d0e3e63c06ec2294eb1ba586141a44fd9cbc268 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 2 Feb 2017 09:42:18 -0800
 Subject: [PATCH 149/167] drm/vc4: Fix sending of page flip completion events
@@ -134529,7 +134529,7 @@ index dbf065677202fbebf8e3a0cffbe880aa42daef3f..da818a207bfa639b8cea48d94bcf4566
  
  static void vc4_crtc_handle_page_flip(struct vc4_crtc *vc4_crtc)
 
-From 271a34305c7c0a7bdf4072b173b603caf8bd8adf Mon Sep 17 00:00:00 2001
+From b7a7588c154acfdb7b13ba1c1a18de1d12c4e3c7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 10 May 2017 21:39:45 +0100
 Subject: [PATCH 150/167] squash: vc4_firmware_kms fixups
@@ -134582,7 +134582,7 @@ index da818a207bfa639b8cea48d94bcf4566f97db816..35425063cca47a33936c4853f7cc320c
  	vc4_encoder = devm_kzalloc(dev, sizeof(*vc4_encoder), GFP_KERNEL);
  	if (!vc4_encoder)
 
-From 6f2ab38465072781998b3c4b0cfcae2eba606ef8 Mon Sep 17 00:00:00 2001
+From 1f72706946d43c4d89513c3a6442e9cfe5260cbc Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 18 Apr 2017 21:43:46 +0100
 Subject: [PATCH 151/167] vc4_fkms: Apply firmware overscan offset to hardware
@@ -134642,7 +134642,7 @@ index 35425063cca47a33936c4853f7cc320c3630fdb2..ca03b85f27d8c0966acd977cba9c758d
  
  	return 0;
 
-From 7183c5d23e82452db2a23704ee65eadc66c9d852 Mon Sep 17 00:00:00 2001
+From 2ec3e4cea1750aede2e4d2cec17ad9bc21e3c650 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 11 May 2017 16:58:16 +0100
 Subject: [PATCH 152/167] BCM270X_DT: Tidy up mmc, sdhost, sdio overlays
@@ -134754,7 +134754,7 @@ index 398bd812c716c9e472fbac5aba4fe882114c65d1..215d5e3e8a8ca4363457fed1f7425427
  			};
  		};
 
-From 92e7702f73cdcf1ccea4907f71fa493359f7b895 Mon Sep 17 00:00:00 2001
+From a18a3e0611a2fe8b9b1ac177edab8c4ce85def1e Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 12 May 2017 12:24:00 +0100
 Subject: [PATCH 153/167] dwc_otg: fix several potential crash sources
@@ -134953,7 +134953,7 @@ index 718a1accc0c219a1764ce53d291de6a2b6f93608..cf23baaa388562b5843be4cfa6c206cb
  		release_channel(hcd, hc, qtd, DWC_OTG_HC_XFER_URB_COMPLETE);
  		break;
 
-From 0058d8f8af3ebc341a25c78686550a734aeab7dd Mon Sep 17 00:00:00 2001
+From 761462fbf1ebd37d7b581aa20fd24bb4aff6589b Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 15 May 2017 14:27:48 +0100
 Subject: [PATCH 154/167] dwc_otg: delete hcd->channel_lock
@@ -135108,7 +135108,7 @@ index cf23baaa388562b5843be4cfa6c206cbdc4e780d..a4355afc77b68718fdaba6c5d4be257d
  
  	/* Try to queue more transfers now that there's a free channel. */
 
-From cfd62ee1ebf568d72147f4ba5505c9aad8dbddf6 Mon Sep 17 00:00:00 2001
+From 4694034104e5542406a128cc6ef058ac95b54958 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 15 May 2017 14:51:42 +0100
 Subject: [PATCH 155/167] dwc_otg: remove unnecessary dma-mode channel halts on
@@ -135179,7 +135179,7 @@ index 5ec991624c7865901b22ea01b9f2c58c8535ecfd..a2dc6337836b2719f4c954edeeb2a713
  
  	if(fiq_enable) {
 
-From 4cb2783298e13c606f4fc10aa88fc66980f474d8 Mon Sep 17 00:00:00 2001
+From 8cb36e1754cfda4fd4f2000a17e8a246bddfd8ca Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 15 May 2017 16:40:05 +0100
 Subject: [PATCH 156/167] config: Add CONFIG_TOUCHSCREEN_GOODIX
@@ -135214,7 +135214,7 @@ index db6589288b6abd6b76b934de07e8976456e14e61..88072e3b55eb230be44f6d23012428ed
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From 28ea7b393f6047e773587bf1734bf9f9ada6b463 Mon Sep 17 00:00:00 2001
+From d32b0b40b5d6758592ceb154da1f4d869927862c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 18 May 2017 11:40:43 +0100
 Subject: [PATCH 157/167] config: Add FB_TFT_ST7789V module
@@ -135249,7 +135249,7 @@ index 88072e3b55eb230be44f6d23012428eda3de3453..65e3676b48ab0c0f54375ecf875fc255
  CONFIG_FB_TFT_TLS8204=m
  CONFIG_FB_TFT_UC1701=m
 
-From 0e8a99712c47e5d244ab87c687de855542261821 Mon Sep 17 00:00:00 2001
+From d805fb1553b8ba6168699a617a5acac24ecbe58f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 15:58:00 +0100
 Subject: [PATCH 158/167] config: Add CONFIG_TOUCHSCREEN_EDT_FT5X06
@@ -135284,7 +135284,7 @@ index 65e3676b48ab0c0f54375ecf875fc2552c457e09..7381eeba83ecd4a2c956ab2093ece4f8
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From 3ce401c21146acae756a5a81c7a6b2ec6c198d4c Mon Sep 17 00:00:00 2001
+From f4e79e5ba3ce4974a4db3697f7c855fc93e250ee Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 19:34:52 +0100
 Subject: [PATCH 159/167] config: Add CONFIG_I2C_ROBOTFUZZ_OSIF
@@ -135319,7 +135319,7 @@ index 7381eeba83ecd4a2c956ab2093ece4f8a57c6ea4..35dc0b5084256f2ae755703edc3eb67c
  CONFIG_SPI_BCM2835=m
  CONFIG_SPI_BCM2835AUX=m
 
-From 631bf1eb38b2f5c46e076ef3f62ffb437ee396f3 Mon Sep 17 00:00:00 2001
+From 809ab8b48d77eb825b0881f5df249fd348054cad Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 26 Apr 2017 17:28:47 +0100
 Subject: [PATCH 160/167] clk: bcm2835: Limit PCM clock to OSC and PLLD_PER
@@ -135367,7 +135367,7 @@ index fe3298b54cdfb96bd90fb4f39e13921d2e1d4356..c24b4defb2b046e4ecdc109befc2b224
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
  		.name = "pwm",
 
-From e30dc97742d503d1daf3aa8f4384f7cccb13faf6 Mon Sep 17 00:00:00 2001
+From a385a1e7109c0760f732d784bc85a972aa943d20 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 22 May 2017 13:56:41 +0100
 Subject: [PATCH 161/167] clk: bcm2835: Minimise clock jitter for PCM clock
@@ -135495,7 +135495,7 @@ index c24b4defb2b046e4ecdc109befc2b22497060647..db3ba74acf78f4dfec0d2206b58bc7c3
  		.tcnt_mux = 23),
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
 
-From 843fd0d168d8a71b460ff66cd86ddaa4ef2a782d Mon Sep 17 00:00:00 2001
+From 4377d65420d8750356067c02c434cca7b9f59d7c Mon Sep 17 00:00:00 2001
 From: Bilal Amarni <bamarni@users.noreply.github.com>
 Date: Wed, 24 May 2017 10:52:50 +0200
 Subject: [PATCH 162/167] [ARM64] enable drivers for GPIO expander and vcio
@@ -135526,7 +135526,7 @@ index 4d85c231c5ea0244e1b05fb4a5e3c8fd3e651ddf..9dcb58a519d041fadae99c81a7bda621
  CONFIG_GPIO_ARIZONA=m
  CONFIG_GPIO_STMPE=y
 
-From 2d13aa5520b8a72f9285f8b54c8928c720f4f141 Mon Sep 17 00:00:00 2001
+From 15373a5ae4e9d17516073b3a94e36f0acf9179f4 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 25 May 2017 16:04:53 +0100
 Subject: [PATCH 163/167] dwc_otg: make periodic scheduling behave properly for
@@ -135700,7 +135700,7 @@ index 85a6d431ca54b47dc10573aa72d1ad69d06f2e36..4b1dd9de99e9e08b2e006fb5f8a7ef92
  	status = check_max_xfer_size(hcd, qh);
  	if (status) {
 
-From 324204d6eee47da7bfdc602ce610c54b5f09dfc5 Mon Sep 17 00:00:00 2001
+From 0719f747334a2195b072413a6c5f7a8be9449d69 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 19 May 2017 16:07:23 +0100
 Subject: [PATCH 164/167] serial: 8250: Add CAP_MINI, set for bcm2835aux
@@ -135776,7 +135776,7 @@ index 579706d36f5c77382cc289d55c2e6290143d6b1d..27e4a15fbe009e45270b5eaf3698bcfd
  
  	baud = serial8250_get_baud_rate(port, termios, old);
 
-From 8f7ff727e2c99c231d14e4d19cee3e734a762cd5 Mon Sep 17 00:00:00 2001
+From c2f38a410bc7565480e863c90e34a4d50a0dacd3 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 26 May 2017 12:50:31 +0100
 Subject: [PATCH 165/167] dwc_otg: fiq_fsm: Make isochronous compatibility
@@ -135843,7 +135843,7 @@ index 38bf5fc792d32352f9e208e0e90f968599b9bc31..71834cf365e67d7ad995bba7869216c4
  			return 1;
  		}
 
-From 04b7125da8fd030cb851051f17b905fbf4810e2a Mon Sep 17 00:00:00 2001
+From d37e96e634d278491534a971c7f2fbd168093e3e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Jun 2017 13:05:43 +0100
 Subject: [PATCH 166/167] config: Add CONFIG_CAN_GS_USB
@@ -135878,7 +135878,7 @@ index 35dc0b5084256f2ae755703edc3eb67cab0759ec..42163e2c0b5d5666d49793ac4e074d22
  CONFIG_IRLAN=m
  CONFIG_IRNET=m
 
-From f1a70f5c80f70e8bb6a687a8ca0372ba11e048d1 Mon Sep 17 00:00:00 2001
+From 389a9e2b2099f8fc61c87e88270fe0297f9d60d0 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 12 Jun 2017 16:10:03 +0100
 Subject: [PATCH 167/167] dwc_otg: add module parameter int_ep_interval_min

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,7 +1,7 @@
-From 5c12c71e15d873719ed0f038559d39e653682ae3 Mon Sep 17 00:00:00 2001
+From 9f4bcfaf88fb7d7482a0e2e0dc5b2606873e3e72 Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
-Subject: [PATCH 001/167] smsx95xx: fix crimes against truesize
+Subject: [PATCH 001/171] smsx95xx: fix crimes against truesize
 
 smsc95xx is adjusting truesize when it shouldn't, and following a recent patch from Eric this is now triggering warnings.
 
@@ -48,10 +48,10 @@ index 5f19fb0f025d9449d0ba20958610e0d1f083f032..ed28f1c3e1d0f2559a62a1c289937944
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From c641f517b009d7c619065b91379424c9f0812e4a Mon Sep 17 00:00:00 2001
+From 73eb4f5a44372e7d1301842c685246748304477f Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
-Subject: [PATCH 002/167] smsc95xx: Experimental: Enable turbo_mode and
+Subject: [PATCH 002/171] smsc95xx: Experimental: Enable turbo_mode and
  packetsize=2560 by default
 
 See: http://forum.kodi.tv/showthread.php?tid=285288
@@ -94,10 +94,10 @@ index ed28f1c3e1d0f2559a62a1c28993794497730c5d..f758e122c65685799d4aeeb1c3e6ca81
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From 67dfbca41e10ac2df4baf2f81dfbf5b2fee51a5d Mon Sep 17 00:00:00 2001
+From 9f6d12e8e82fd53c8ce7329f2c538b9afbc6b26a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
-Subject: [PATCH 003/167] Allow mac address to be set in smsc95xx
+Subject: [PATCH 003/171] Allow mac address to be set in smsc95xx
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -193,10 +193,10 @@ index f758e122c65685799d4aeeb1c3e6ca81df0d7980..f6661e388f6e801c1b88e48a3b71407b
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From 8e5ce5c2c49e594ec843e8647ab5bf7ffdd49b77 Mon Sep 17 00:00:00 2001
+From 90eb28f957697e0d85aa624330c4c2eaed7aeb70 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
-Subject: [PATCH 004/167] Protect __release_resource against resources without
+Subject: [PATCH 004/171] Protect __release_resource against resources without
  parents
 
 Without this patch, removing a device tree overlay can crash here.
@@ -224,10 +224,10 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From 04c16ef82ad368b5e9732f65c975cba21a0059af Mon Sep 17 00:00:00 2001
+From 4d7d99990bbf9f06394ea214b19b25c8466e6671 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
-Subject: [PATCH 005/167] mm: Remove the PFN busy warning
+Subject: [PATCH 005/171] mm: Remove the PFN busy warning
 
 See commit dae803e165a11bc88ca8dbc07a11077caf97bbcb -- the warning is
 expected sometimes when using CMA.  However, that commit still spams
@@ -252,10 +252,10 @@ index a2019fc9d94df3af9cf2c5ce1a476949c6822efc..5e6e1815923f212f5c1b1d1a213b0b12
  		goto done;
  	}
 
-From 4d4a2d65910b4c64cb5779850b674b26aa81adc8 Mon Sep 17 00:00:00 2001
+From e852f6820e51a41df5b3c0c1a8fce6b76fae5b64 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
-Subject: [PATCH 006/167] irq-bcm2836: Prevent spurious interrupts, and trap
+Subject: [PATCH 006/171] irq-bcm2836: Prevent spurious interrupts, and trap
  them early
 
 The old arch-specific IRQ macros included a dsb to ensure the
@@ -282,10 +282,10 @@ index e7463e3c08143acae3e8cc5682f918c6a0b07ebd..a8db33b50ad9ff83d284fa54fe4d3b65
  #endif
  	} else if (stat) {
 
-From d947bf2f9b8138106885cd07fc508ea580697cac Mon Sep 17 00:00:00 2001
+From 383730cb01a4413436800649cfd080639cd23e17 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:33:30 +0000
-Subject: [PATCH 007/167] irq-bcm2836: Avoid "Invalid trigger warning"
+Subject: [PATCH 007/171] irq-bcm2836: Avoid "Invalid trigger warning"
 
 Initialise the level for each IRQ to avoid a warning from the
 arm arch timer code.
@@ -309,10 +309,10 @@ index a8db33b50ad9ff83d284fa54fe4d3b65f859df0f..c4e151451cf8c8ebde5225515eac2786
  
  static void
 
-From 29bd8d457817796427be50bcb2d30759bb5ef266 Mon Sep 17 00:00:00 2001
+From ee7fbe0b1b3cb5c008e07c9b178f1ba7303a49d4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
-Subject: [PATCH 008/167] irqchip: bcm2835: Add FIQ support
+Subject: [PATCH 008/171] irqchip: bcm2835: Add FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -441,10 +441,10 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 7b49d4c1670d1c63c10cd4aa765243433b2bffd9 Mon Sep 17 00:00:00 2001
+From d4f56f6ee1534fa523bf768c8a4d1c10050a97c8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
-Subject: [PATCH 009/167] irqchip: irq-bcm2835: Add 2836 FIQ support
+Subject: [PATCH 009/171] irqchip: irq-bcm2835: Add 2836 FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -543,10 +543,10 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From daa91a8da856b616dc79e15ffbf5e20cb662900d Mon Sep 17 00:00:00 2001
+From a9a2111798d8d75ba8c1b8515dc4fefd4bdea748 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
-Subject: [PATCH 010/167] spidev: Add "spidev" compatible string to silence
+Subject: [PATCH 010/171] spidev: Add "spidev" compatible string to silence
  warning
 
 See: https://github.com/raspberrypi/linux/issues/1054
@@ -567,10 +567,10 @@ index 9e2e099baf8ca5cc6510912a36d4ca03daeb8273..e59640942826db2ea14d0bde0ff5ab22
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From ab14ef24bc5123ebaad44e20db0015cee49bc2de Mon Sep 17 00:00:00 2001
+From 5a1b50c94479bbd68c2bac1479366f8697d50133 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 3 Jan 2017 18:25:01 +0000
-Subject: [PATCH 011/167] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
+Subject: [PATCH 011/171] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
 
 This reverts commit 85ae9e512f437cd09bf61564bdba29ab88bab3e3.
 ---
@@ -864,10 +864,10 @@ index 85d0091128644c446aed878e87769e82c77c3ebf..4f2621272bfd5cbc0d691d2fabe89e2e
  	if (IS_ERR(pc->pctl_dev)) {
  		gpiochip_remove(&pc->gpio_chip);
 
-From 029c1cd3ac2439ba71f0b7d9c8635649ab015df2 Mon Sep 17 00:00:00 2001
+From 169a3521049fb20f8e11a5fd98b7c1906af9ecc4 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
-Subject: [PATCH 012/167] pinctrl-bcm2835: Set base to 0 give expected gpio
+Subject: [PATCH 012/171] pinctrl-bcm2835: Set base to 0 give expected gpio
  numbering
 
 Signed-off-by: Noralf Tronnes <notro@tronnes.org>
@@ -889,10 +889,10 @@ index 4f2621272bfd5cbc0d691d2fabe89e2ee428d6db..5b7cb4c415e19f98e25b221ab0ad36b6
  	.can_sleep = false,
  };
 
-From 1b69006d0051412024dabd3e6fff04de0d1fc7e1 Mon Sep 17 00:00:00 2001
+From 36d5db9421c98fccacd2f3c8adf45052795f6482 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
-Subject: [PATCH 013/167] pinctrl-bcm2835: Only request the interrupts listed
+Subject: [PATCH 013/171] pinctrl-bcm2835: Only request the interrupts listed
  in the DTB
 
 Although the GPIO controller can generate three interrupts (four counting
@@ -919,10 +919,10 @@ index 5b7cb4c415e19f98e25b221ab0ad36b6885dae4c..6351fe7f8e314ac5ebb102dd20847b38
  		pc->irq_data[i].irqgroup = i;
  
 
-From d6fb9a63771b8fb6667e738ddbb607ac18406d94 Mon Sep 17 00:00:00 2001
+From ddc19d645d675519430ff2b2d77b8ea0f83bf3ee Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
-Subject: [PATCH 014/167] spi-bcm2835: Support pin groups other than 7-11
+Subject: [PATCH 014/171] spi-bcm2835: Support pin groups other than 7-11
 
 The spi-bcm2835 driver automatically uses GPIO chip-selects due to
 some unreliability of the native ones. In doing so it chooses the
@@ -1003,10 +1003,10 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From abc1b085874fbe548854bfb91e2e2a1f85d3be27 Mon Sep 17 00:00:00 2001
+From a5181c9d51f1cbbdd023a4d6e5451402c060e645 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
-Subject: [PATCH 015/167] spi-bcm2835: Disable forced software CS
+Subject: [PATCH 015/171] spi-bcm2835: Disable forced software CS
 
 Select software CS in bcm2708_common.dtsi, and disable the automatic
 conversion in the driver to allow hardware CS to be re-enabled with an
@@ -1040,10 +1040,10 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From f82e839db63bdc1977a030193bc105da1f17ec46 Mon Sep 17 00:00:00 2001
+From 6be7ee0d758dd9d73779fe0f770a141d92e7b9eb Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
-Subject: [PATCH 016/167] spi-bcm2835: Remove unused code
+Subject: [PATCH 016/171] spi-bcm2835: Remove unused code
 
 ---
  drivers/spi/spi-bcm2835.c | 61 -----------------------------------------------
@@ -1131,10 +1131,10 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From f14d0451987390c71dba8816e84c382532b14aeb Mon Sep 17 00:00:00 2001
+From be2af68d09a92abbeeeefee5c2fe55fec3358f4b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
-Subject: [PATCH 017/167] ARM: bcm2835: Set Serial number and Revision
+Subject: [PATCH 017/171] ARM: bcm2835: Set Serial number and Revision
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1187,10 +1187,10 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 26f81392d52047e01e18dc63ca6c165a0b58a06a Mon Sep 17 00:00:00 2001
+From 6afc5e2016e0cb91115f5354a54c7c96611aa317 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
-Subject: [PATCH 018/167] dmaengine: bcm2835: Load driver early and support
+Subject: [PATCH 018/171] dmaengine: bcm2835: Load driver early and support
  legacy API
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -1293,10 +1293,10 @@ index 6204cc32d09c5096df8aec304c3c37b3bcb6be44..599c218dc8a73172dd4bd4a058fc8f95
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From 49b06a42fbb3bca0c3428319059f73e956a682d9 Mon Sep 17 00:00:00 2001
+From e40bd4d0489713ddd54ccd78a6afd9e01cee25e0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
-Subject: [PATCH 019/167] firmware: Updated mailbox header
+Subject: [PATCH 019/171] firmware: Updated mailbox header
 
 ---
  include/soc/bcm2835/raspberrypi-firmware.h | 9 +++++++++
@@ -1357,10 +1357,10 @@ index cb979ad90401e299344dd5fae38d09c489d8bd58..30fb37fe175df604a738258a2a632bca
  	RPI_FIRMWARE_VCHIQ_INIT =                             0x00048010,
  
 
-From a60743bd35b08be3b2505137215e03d9d11710e5 Mon Sep 17 00:00:00 2001
+From 04eb0cbe52172443643b4b173489ea43efa48bda Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
-Subject: [PATCH 020/167] rtc: Add SPI alias for pcf2123 driver
+Subject: [PATCH 020/171] rtc: Add SPI alias for pcf2123 driver
 
 Without this alias, Device Tree won't cause the driver
 to be loaded.
@@ -1380,10 +1380,10 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From 5d48547824fb8eb439b91927478e9a474f2783c0 Mon Sep 17 00:00:00 2001
+From fe941bec362a8c4cf04d3fed394b9be7ab9b57c8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
-Subject: [PATCH 021/167] watchdog: bcm2835: Support setting reboot partition
+Subject: [PATCH 021/171] watchdog: bcm2835: Support setting reboot partition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1485,10 +1485,10 @@ index b339e0e67b4c1275fd4992fea4f1e24c0575b783..26b7177573fac2af1cd4ab5488d2686f
  
  static int bcm2835_wdt_probe(struct platform_device *pdev)
 
-From 3f6ae6fdcf8f2b6830db3f3d185171c2665db871 Mon Sep 17 00:00:00 2001
+From 06616677a99da49c0cdafa60ca692580433eb61f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
-Subject: [PATCH 022/167] reboot: Use power off rather than busy spinning when
+Subject: [PATCH 022/171] reboot: Use power off rather than busy spinning when
  halt is requested
 
 ---
@@ -1511,10 +1511,10 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From a15b3dd745985d1389643812bde82a9dbf73c802 Mon Sep 17 00:00:00 2001
+From ac4cff5fc1568c862ac47c4f99cb2d737adad6b1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
-Subject: [PATCH 023/167] bcm: Make RASPBERRYPI_POWER depend on PM
+Subject: [PATCH 023/171] bcm: Make RASPBERRYPI_POWER depend on PM
 
 ---
  drivers/soc/bcm/Kconfig | 1 +
@@ -1533,10 +1533,10 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 00d5533d597de4071696a3603a506980c443c81a Mon Sep 17 00:00:00 2001
+From 20165bad9a227e1d61b5320cbd51ddfb5966abc1 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
-Subject: [PATCH 024/167] Register the clocks early during the boot process, so
+Subject: [PATCH 024/171] Register the clocks early during the boot process, so
  that special/critical clocks can get enabled early on in the boot process
  avoiding the risk of disabling a clock, pll_divider or pll when a claiming
  driver fails to install propperly - maybe it needs to defer.
@@ -1581,10 +1581,10 @@ index 02585387061967ac9408e18ac1bce67e9e9414c0..283d2de45e4f29406d01f24ab1cae3f9
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From 3d1b46566d56af094cafae7d7fc16798d55d8fb8 Mon Sep 17 00:00:00 2001
+From 52e76525dc86f891740d139cecfc20a05d8c306c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
-Subject: [PATCH 025/167] bcm2835-rng: Avoid initialising if already enabled
+Subject: [PATCH 025/171] bcm2835-rng: Avoid initialising if already enabled
 
 Avoids the 0x40000 cycles of warmup again if firmware has already used it
 ---
@@ -1610,10 +1610,10 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From d09450d8643488571b6f78321758c0ff5e2b080c Mon Sep 17 00:00:00 2001
+From 5890a859bb364d879f69c625b395707b7e9cc9c1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
-Subject: [PATCH 026/167] kbuild: Ignore dtco targets when filtering symbols
+Subject: [PATCH 026/171] kbuild: Ignore dtco targets when filtering symbols
 
 ---
  scripts/Kbuild.include | 2 +-
@@ -1633,10 +1633,10 @@ index afe3fd3af1e40616857b3e6c425be632c1fa2667..b2bbad417f0c4499a5f49081c8f996b9
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From c367f05abd557c548a8c0a990a4695b39efd2b64 Mon Sep 17 00:00:00 2001
+From e89e7387d451185cad49c3d05bd7a786d3dcaf80 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
-Subject: [PATCH 027/167] BCM2835_DT: Fix I2S register map
+Subject: [PATCH 027/171] BCM2835_DT: Fix I2S register map
 
 ---
  Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.txt   | 4 ++--
@@ -1674,10 +1674,10 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From 066f21a0c158bdc6a034105bc32c70f2130de080 Mon Sep 17 00:00:00 2001
+From 2d5a6632d0a883e0e9124eff13b84ced3c46168a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
-Subject: [PATCH 028/167] clk-bcm2835: Mark used PLLs and dividers CRITICAL
+Subject: [PATCH 028/171] clk-bcm2835: Mark used PLLs and dividers CRITICAL
 
 The VPU configures and relies on several PLLs and dividers. Mark all
 enabled dividers and their PLLs as CRITICAL to prevent the kernel from
@@ -1705,10 +1705,10 @@ index 283d2de45e4f29406d01f24ab1cae3f9f879234a..85df8c74a309f0b877ef65f1c55b086f
  	divider->data = data;
  
 
-From 1dca5a61db59275810ccd1fef1d804f7e0da4c53 Mon Sep 17 00:00:00 2001
+From 9fa6b741e08679f1805028d50e9c38a60b89ee21 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
-Subject: [PATCH 029/167] clk-bcm2835: Add claim-clocks property
+Subject: [PATCH 029/171] clk-bcm2835: Add claim-clocks property
 
 The claim-clocks property can be used to prevent PLLs and dividers
 from being marked as critical. It contains a vector of clock IDs,
@@ -1810,10 +1810,10 @@ index 85df8c74a309f0b877ef65f1c55b086f1bb774a1..eec6735505c074c0a76ae647bf0e1bb6
  	       sizeof(cprman_parent_names));
  	of_clk_parent_fill(dev->of_node, cprman->real_parent_names,
 
-From 01c1e8a1e842582bf9962fbea559bfd7923f411a Mon Sep 17 00:00:00 2001
+From bff9dbfc12561664cff553463303d4ec41bd9dc2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:06:53 +0000
-Subject: [PATCH 030/167] clk-bcm2835: Correct the prediv logic
+Subject: [PATCH 030/171] clk-bcm2835: Correct the prediv logic
 
 If a clock has the prediv flag set, both the integer and fractional
 parts must be scaled when calculating the resulting frequency.
@@ -1840,10 +1840,10 @@ index eec6735505c074c0a76ae647bf0e1bb68ab3a488..e0d28add45efdf70d1eba590282a3a26
  	return bcm2835_pll_rate_from_divisors(parent_rate, ndiv, fdiv, pdiv);
  }
 
-From aee179f3899409952b9cda1a2165c6ae8d99064f Mon Sep 17 00:00:00 2001
+From c37e021f28098d3d66fd929a8f1bce7deff89676 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 6 Mar 2017 09:06:18 +0000
-Subject: [PATCH 031/167] clk-bcm2835: Read max core clock from firmware
+Subject: [PATCH 031/171] clk-bcm2835: Read max core clock from firmware
 
 The VPU is responsible for managing the core clock, usually under
 direction from the bcm2835-cpufreq driver but not via the clk-bcm2835
@@ -1958,10 +1958,10 @@ index e0d28add45efdf70d1eba590282a3a2654af328d..39f72da6ba1f6ec6ec41d5dc1bf46344
  	for (i = 0;
  	     !of_property_read_u32_index(pdev->dev.of_node, "claim-clocks",
 
-From 5470d573445cc0979f676c56531d8b5fe372f55f Mon Sep 17 00:00:00 2001
+From dd3213ad2acff725fbf24f9967ea2942ffaca090 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:36:44 +0000
-Subject: [PATCH 032/167] sound: Demote deferral errors to INFO level
+Subject: [PATCH 032/171] sound: Demote deferral errors to INFO level
 
 At present there is no mechanism to specify driver load order,
 which can lead to deferrals and repeated retries until successful.
@@ -1996,10 +1996,10 @@ index 98d60f471c5d705d383c5edca4850bd8facdd030..d2da3077fd980c846c1c86697f73c342
  			goto _err_defer;
  		}
 
-From 1067c4056a6a9873f88954d8eb0addcbd3b2f1a8 Mon Sep 17 00:00:00 2001
+From ebf1e68dfa306e6bad06bf9f3365a685c089784a Mon Sep 17 00:00:00 2001
 From: Claggy3 <stephen.maclagan@hotmail.com>
 Date: Sat, 11 Feb 2017 14:00:30 +0000
-Subject: [PATCH 033/167] Update vfpmodule.c
+Subject: [PATCH 033/171] Update vfpmodule.c
 
 Christopher Alexander Tobias Schulze - May 2, 2015, 11:57 a.m.
 This patch fixes a problem with VFP state save and restore related
@@ -2136,10 +2136,10 @@ index a71a48e71fffa8626fe90106815376c44bbe679b..d6c0a5a0a5ae3510db3ace5e3f5d3410
  	/*
  	 * Save the userland NEON/VFP state. Under UP,
 
-From c04e30090d6422997479fa6c7f576e332fbadd78 Mon Sep 17 00:00:00 2001
+From 397e51264a8de9fcad23803dbb7278d66e8eb51d Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 21:13:24 +1100
-Subject: [PATCH 034/167] ASoC: bcm2835_i2s.c: relax the ch2 register setting
+Subject: [PATCH 034/171] ASoC: bcm2835_i2s.c: relax the ch2 register setting
  for 8 channels
 
 This patch allows ch2 registers to be set for 8 channels of audio.
@@ -2160,10 +2160,10 @@ index 6ba20498202ed36906b52096893a88867a79269f..56df7d8a43d0aac055a91b0d24aca8e1
  		format |= BCM2835_I2S_CH1(BCM2835_I2S_CHPOS(ch1pos));
  		format |= BCM2835_I2S_CH2(BCM2835_I2S_CHPOS(ch2pos));
 
-From 70288a422cf169d3ef240329e2aa0edc106ad1b5 Mon Sep 17 00:00:00 2001
+From b9c8b9c7eba40161a98f4fa4fb384ca46009baeb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
-Subject: [PATCH 035/167] i2c: bcm2835: Add debug support
+Subject: [PATCH 035/171] i2c: bcm2835: Add debug support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -2352,10 +2352,10 @@ index cd07a69e2e9355540442785f95e90823b05c9d10..47167f403cc8329bd811b47c7011c299
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 055d19df21df1471a912d73c4f2c70cd58e2f1b3 Mon Sep 17 00:00:00 2001
+From 1a0c9496e02f19a88eee0f470ff2814d8c60904c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
-Subject: [PATCH 036/167] Main bcm2708/bcm2709 linux port
+Subject: [PATCH 036/171] Main bcm2708/bcm2709 linux port
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -2543,10 +2543,10 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From e7eef2e6c3ae5c142cf6345f2b17e10bc6130ec5 Mon Sep 17 00:00:00 2001
+From 766153167e1130f24ccc5f06deb8f4d9acfc276a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
-Subject: [PATCH 037/167] Add dwc_otg driver
+Subject: [PATCH 037/171] Add dwc_otg driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -3254,10 +3254,10 @@ index bd3e0c5a6db25e7a162d922c6508de1ad0b68025..15c80079c97bb9eeec478932af88a293
  	return i;
  }
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index f77a4ebde7d576e9f0fa8a71a13650cd0873dc99..9142813b330302456316b0b80d7e186789e05cf9 100644
+index b8bb20d7acdb9f1480009605f10e2f5ae4045ec9..155d360a98b0db439d5d0e4e2997accfb8475eaf 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
-@@ -5036,7 +5036,7 @@ static void port_event(struct usb_hub *hub, int port1)
+@@ -5042,7 +5042,7 @@ static void port_event(struct usb_hub *hub, int port1)
  	if (portchange & USB_PORT_STAT_C_OVERCURRENT) {
  		u16 status = 0, unused;
  
@@ -63611,10 +63611,10 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 7e014ce4ddcf25147816c1aeebcaed53548c050a Mon Sep 17 00:00:00 2001
+From 099f6533cb330282c2e6d154d519cbceafeef381 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 10 May 2017 12:47:46 +0100
-Subject: [PATCH 038/167] dwcotg: Allow to build without FIQ on ARM64
+Subject: [PATCH 038/171] dwcotg: Allow to build without FIQ on ARM64
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -63635,10 +63635,10 @@ index ed0cd59de37e8f47369f86dba751c78933722abc..53aedbe9727ca5c34e46f5cf998f14c7
  	  The Synopsis DWC controller is a dual-role
  	  host/peripheral/OTG ("On The Go") USB controllers.
 
-From 05a7ff745705366e6328f471dd4a299b5e977817 Mon Sep 17 00:00:00 2001
+From 807f842c2901a4aad5197b20221479c4c558a7df Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
-Subject: [PATCH 039/167] bcm2708 framebuffer driver
+Subject: [PATCH 039/171] bcm2708 framebuffer driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -67097,10 +67097,10 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From c095a159c0c01b7980106616f2d0e14e332c5f78 Mon Sep 17 00:00:00 2001
+From 31742a1c0b4e9627d065b79c52aeb37a29a77606 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
-Subject: [PATCH 040/167] dmaengine: Add support for BCM2708
+Subject: [PATCH 040/171] dmaengine: Add support for BCM2708
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -67731,10 +67731,10 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From 3db6d962acebf71b2b0bfd9a8500b7668b4d072e Mon Sep 17 00:00:00 2001
+From 51b369b9e39440f61467619c10070b57fb50a2d4 Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
-Subject: [PATCH 041/167] MMC: added alternative MMC driver
+Subject: [PATCH 041/171] MMC: added alternative MMC driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -69456,10 +69456,10 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From 84876ef9145df2d10d91e11383e9b2d5ec5e45c5 Mon Sep 17 00:00:00 2001
+From 207aeb3d8efa1b48bcb86cd39e1133532dba7415 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
-Subject: [PATCH 042/167] Adding bcm2835-sdhost driver, and an overlay to
+Subject: [PATCH 042/171] Adding bcm2835-sdhost driver, and an overlay to
  enable it
 
 BCM2835 has two SD card interfaces. This driver uses the other one.
@@ -71855,10 +71855,10 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From d86263a65f1c57991aaa203ef39a775bfe652ed3 Mon Sep 17 00:00:00 2001
+From 784b39ac9e00cffaf7d1dd0199d19d39d2ae5f4f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
-Subject: [PATCH 043/167] vc_mem: Add vc_mem driver for querying firmware
+Subject: [PATCH 043/171] vc_mem: Add vc_mem driver for querying firmware
  memory addresses
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -72383,10 +72383,10 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From eab4336a5d6fb9c89cb927d2d4f6f36d544a44d6 Mon Sep 17 00:00:00 2001
+From 47b8b2ed8d7500a1c3c5500d0fa936b713861ebd Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
-Subject: [PATCH 044/167] vcsm: VideoCore shared memory service for BCM2835
+Subject: [PATCH 044/171] vcsm: VideoCore shared memory service for BCM2835
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -76823,10 +76823,10 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From bd80393dae846a13767e30c46b890d27bbd22b9e Mon Sep 17 00:00:00 2001
+From e4642f6be0fb7adf5a4d0c9146c8f129154cdc0c Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
-Subject: [PATCH 045/167] Add /dev/gpiomem device for rootless user GPIO access
+Subject: [PATCH 045/171] Add /dev/gpiomem device for rootless user GPIO access
 
 Signed-off-by: Luke Wren <luke@raspberrypi.org>
 
@@ -77134,10 +77134,10 @@ index 0000000000000000000000000000000000000000..f5e7f1ba8fb6f18dee77fad06a17480c
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From 102c24664e96946c4f7b7f475905f3ca6a040942 Mon Sep 17 00:00:00 2001
+From 1bde0307d490d7032e555454e2196c6625f0effb Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
-Subject: [PATCH 046/167] Add SMI driver
+Subject: [PATCH 046/171] Add SMI driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -79088,10 +79088,10 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From ca07554ddfefb186e28a50ef95a3436b807725c2 Mon Sep 17 00:00:00 2001
+From 55f9017cc8d3d0dad08492f27c080c61c5cc1ba1 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
-Subject: [PATCH 047/167] MISC: bcm2835: smi: use clock manager and fix reload
+Subject: [PATCH 047/171] MISC: bcm2835: smi: use clock manager and fix reload
  issues
 
 Use clock manager instead of self-made clockmanager.
@@ -79261,10 +79261,10 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 16c7f19a003be2dc718532059452ef0d81ba14cf Mon Sep 17 00:00:00 2001
+From 42d54408e1e53196e6a9bbb35b3571062ce3f689 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
-Subject: [PATCH 048/167] Add SMI NAND driver
+Subject: [PATCH 048/171] Add SMI NAND driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -79629,10 +79629,10 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From f9b68fa8d5029486f4624e6611a292d0b4a86d85 Mon Sep 17 00:00:00 2001
+From da161d66dc81f6af6e16e98e20bc33b6ca11aa6c Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
-Subject: [PATCH 049/167] lirc: added support for RaspberryPi GPIO
+Subject: [PATCH 049/171] lirc: added support for RaspberryPi GPIO
 
 lirc_rpi: Use read_current_timer to determine transmitter delay. Thanks to jjmz and others
 See: https://github.com/raspberrypi/linux/issues/525
@@ -80495,10 +80495,10 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From 997227cc203e81823ae1a185c97ddca01f005e58 Mon Sep 17 00:00:00 2001
+From 9715abe862796db1a2f11137345e39aed1b46957 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
-Subject: [PATCH 050/167] Add cpufreq driver
+Subject: [PATCH 050/171] Add cpufreq driver
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -80765,10 +80765,10 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From daf97b0f1446589b4d374fb0c5cfe84ba04c9f07 Mon Sep 17 00:00:00 2001
+From 1acda3fe2b67892af043f6dd4fd2bb482d291e9c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
-Subject: [PATCH 051/167] Added hwmon/thermal driver for reporting core
+Subject: [PATCH 051/171] Added hwmon/thermal driver for reporting core
  temperature. Thanks Dorian
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -80934,10 +80934,10 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From c44881a00ad2a3542f2eba44579f1ab5aa289a55 Mon Sep 17 00:00:00 2001
+From c42c6d235fdcdea18687b6f7521c95582acd1fc7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
-Subject: [PATCH 052/167] Add Chris Boot's i2c driver
+Subject: [PATCH 052/171] Add Chris Boot's i2c driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81602,10 +81602,10 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 04b1439de7d0c602e374e2a695b8bc77d3c4209c Mon Sep 17 00:00:00 2001
+From 9318c94ea4a1a8dd6cb158f575bad26379c7c6b0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
-Subject: [PATCH 053/167] char: broadcom: Add vcio module
+Subject: [PATCH 053/171] char: broadcom: Add vcio module
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81830,10 +81830,10 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 15989dc7541cd3c17e0f2de12f7375b9a40aaf68 Mon Sep 17 00:00:00 2001
+From 0feb20c42250b95ea9b8dfb93096fbd924f3d080 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
-Subject: [PATCH 054/167] firmware: bcm2835: Support ARCH_BCM270x
+Subject: [PATCH 054/171] firmware: bcm2835: Support ARCH_BCM270x
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81916,10 +81916,10 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From 6c2fe8d12a02b8d82d9ae701e5591abbda429262 Mon Sep 17 00:00:00 2001
+From 166c632d4f11df7311430ee30124ea5c9314c209 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
-Subject: [PATCH 055/167] scripts: Add mkknlimg and knlinfo scripts from tools
+Subject: [PATCH 055/171] scripts: Add mkknlimg and knlinfo scripts from tools
  repo
 
 The Raspberry Pi firmware looks for a trailer on the kernel image to
@@ -82439,10 +82439,10 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From c9764f4f1e267144f1ddb357f16c82a20b048966 Mon Sep 17 00:00:00 2001
+From 97fb096adeb5c636b831f4d499a913241b3df8e9 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
-Subject: [PATCH 056/167] BCM2708: Add core Device Tree support
+Subject: [PATCH 056/171] BCM2708: Add core Device Tree support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -93741,10 +93741,10 @@ index 7234e61e7ce370a775ec6981b391b6d102a01770..1b53cd59e4875d388e4974a3399d5f07
  
  # Bzip2
 
-From 897eed917d69246ceaf588488dbb03963478eb54 Mon Sep 17 00:00:00 2001
+From d3c4ebda08aaf675cbe5607e39b33b47efbce139 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
-Subject: [PATCH 057/167] BCM270x_DT: Add pwr_led, and the required "input"
+Subject: [PATCH 057/171] BCM270x_DT: Add pwr_led, and the required "input"
  trigger
 
 The "input" trigger makes the associated GPIO an input.  This is to support
@@ -93920,10 +93920,10 @@ index 38c0bd7ca1074af234d516275791d05f945ce1f0..2f026646d24bad617c73aa79db30c9aa
  	/* set_brightness_work / blink_timer flags, atomic, private. */
  	unsigned long		work_flags;
 
-From 732b19be3e3ca3be8242916c2711ea199017c429 Mon Sep 17 00:00:00 2001
+From 00418aff54926084a83b0423228b5f6ed96ccc56 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
-Subject: [PATCH 058/167] fbdev: add FBIOCOPYAREA ioctl
+Subject: [PATCH 058/171] fbdev: add FBIOCOPYAREA ioctl
 
 Based on the patch authored by Ali Gholami Rudi at
     https://lkml.org/lkml/2009/7/13/153
@@ -94175,10 +94175,10 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From 6d367e3c7bd9672506c5e5d67676b08d67a0245c Mon Sep 17 00:00:00 2001
+From a6ab96596117c628f9b873fd84b50aa527bcead6 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
-Subject: [PATCH 059/167] Speed up console framebuffer imageblit function
+Subject: [PATCH 059/171] Speed up console framebuffer imageblit function
 
 Especially on platforms with a slower CPU but a relatively high
 framebuffer fill bandwidth, like current ARM devices, the existing
@@ -94387,10 +94387,10 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From 3c7d95f40383f80b11627d973c37e825db05731b Mon Sep 17 00:00:00 2001
+From bf05b1e210af413b46aa63d628626f3731f7e67b Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
-Subject: [PATCH 060/167] enabling the realtime clock 1-wire chip DS1307 and
+Subject: [PATCH 060/171] enabling the realtime clock 1-wire chip DS1307 and
  1-wire on GPIO4 (as a module)
 
 1-wire: Add support for configuring pin for w1-gpio kernel module
@@ -94640,10 +94640,10 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From fa04bb44e45779d0d57435cd7298fcbc3706b760 Mon Sep 17 00:00:00 2001
+From f6f9bcaf6565728d6a8e9eb98ff4468d7234ed21 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
-Subject: [PATCH 061/167] hid: Reduce default mouse polling interval to 60Hz
+Subject: [PATCH 061/171] hid: Reduce default mouse polling interval to 60Hz
 
 Reduces overhead when using X
 ---
@@ -94679,10 +94679,10 @@ index 961bc6fdd2d908835fa9a07d169a4746fb44189d..c595188a1156a27aa79f111d81636b6d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From b2dc3015c2edc24aec61c4be7b84847a2c3119dd Mon Sep 17 00:00:00 2001
+From 0bd63fc6a07fbd2a5d5549a5073d724a566d0e51 Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
-Subject: [PATCH 062/167] rpi-ft5406: Add touchscreen driver for pi LCD display
+Subject: [PATCH 062/171] rpi-ft5406: Add touchscreen driver for pi LCD display
 
 Fix driver detection failure Check that the buffer response is non-zero meaning the touchscreen was detected
 
@@ -95040,10 +95040,10 @@ index 30fb37fe175df604a738258a2a632bca3bfff33f..4a3d79d3b48eb483a4e4bf498f617515
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 0f9d67a98c6dcacb62b46a5bc5e1640e56a3c9ea Mon Sep 17 00:00:00 2001
+From 48a8e542f959273af5435ae7942fccf52a61cd50 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
-Subject: [PATCH 063/167] Improve __copy_to_user and __copy_from_user
+Subject: [PATCH 063/171] Improve __copy_to_user and __copy_from_user
  performance
 
 Provide a __copy_from_user that uses memcpy. On BCM2708, use
@@ -96618,10 +96618,10 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From 1915b0fddcd3f7a47b0e693ff497fae994b3523c Mon Sep 17 00:00:00 2001
+From ca70b1695c4b6198eece1f4983d1ad6377f590d1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
-Subject: [PATCH 064/167] gpio-poweroff: Allow it to work on Raspberry Pi
+Subject: [PATCH 064/171] gpio-poweroff: Allow it to work on Raspberry Pi
 
 The Raspberry Pi firmware manages the power-down and reboot
 process. To do this it installs a pm_power_off handler, causing
@@ -96656,10 +96656,10 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From 768c040156763cab2aa5e8868c1dcd9983d4d325 Mon Sep 17 00:00:00 2001
+From da30283cb5ad63c6dd03d30111dc9f60b2daef9b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
-Subject: [PATCH 065/167] mfd: Add Raspberry Pi Sense HAT core driver
+Subject: [PATCH 065/171] mfd: Add Raspberry Pi Sense HAT core driver
 
 ---
  drivers/input/joystick/Kconfig           |   8 +
@@ -97524,10 +97524,10 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 350c9ae02bbf7ed36cdbac9a142a9b7a9fa11f66 Mon Sep 17 00:00:00 2001
+From 223d629c5c467ff0e4645205336f6565990b725c Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
-Subject: [PATCH 066/167] ASoC: Add support for HifiBerry DAC
+Subject: [PATCH 066/171] ASoC: Add support for HifiBerry DAC
 
 This adds a machine driver for the HifiBerry DAC.
 It is a sound card that can
@@ -97702,10 +97702,10 @@ index 0000000000000000000000000000000000000000..ee9f133953544629282631e5ef3f73fe
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 6c47d9c1de688692b239a24af326c41b29a119e1 Mon Sep 17 00:00:00 2001
+From 299dc0759a56ee0981345e13d76b23f0e3cbe8ef Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
-Subject: [PATCH 067/167] ASoC: Add support for Rpi-DAC
+Subject: [PATCH 067/171] ASoC: Add support for Rpi-DAC
 
 ---
  sound/soc/bcm/Kconfig       |   7 +++
@@ -97989,10 +97989,10 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From dc34f4dadcb3ba02cb66ac1fe0bc7cca3820bc79 Mon Sep 17 00:00:00 2001
+From 152d520349070daabb52a0584a61e6181c7c666d Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
-Subject: [PATCH 068/167] ASoC: wm8804: Implement MCLK configuration options,
+Subject: [PATCH 068/171] ASoC: wm8804: Implement MCLK configuration options,
  add 32bit support WM8804 can run with PLL frequencies of 256xfs and 128xfs
  for most sample rates. At 192kHz only 128xfs is supported. The existing
  driver selects 128xfs automatically for some lower samples rates. By using an
@@ -98041,10 +98041,10 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From cd2150f00dd92834b0a44d990d55fd063abe034e Mon Sep 17 00:00:00 2001
+From 09a3db19b8a52e2d5c5b46b01679124cf8ba9c01 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
-Subject: [PATCH 069/167] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
+Subject: [PATCH 069/171] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
  based on the patched WM8804 driver.
 
 Signed-off-by: Daniel Matuschek <daniel@matuschek.net>
@@ -98388,10 +98388,10 @@ index 0000000000000000000000000000000000000000..7620dd02de40b6d644ff038b445d375d
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From eeaae798ffbf13c35173bfa011364cc0055d076e Mon Sep 17 00:00:00 2001
+From f5348aedf74aac384ec9e9598f2589e7f2652d8f Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
-Subject: [PATCH 070/167] Add IQaudIO Sound Card support for Raspberry Pi
+Subject: [PATCH 070/171] Add IQaudIO Sound Card support for Raspberry Pi
 
 Set a limit of 0dB on Digital Volume Control
 
@@ -98726,10 +98726,10 @@ index 0000000000000000000000000000000000000000..1ee4097c846376666775272ed692ca33
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 601fb2c44d7ad00754ed2b5746d9f9144c71eebe Mon Sep 17 00:00:00 2001
+From 591ef155aceef6c96a340aa992c5e80984a28863 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
-Subject: [PATCH 071/167] Added support for HiFiBerry DAC+
+Subject: [PATCH 071/171] Added support for HiFiBerry DAC+
 
 The driver is based on the HiFiBerry DAC driver. However HiFiBerry DAC+ uses
 a different codec chip (PCM5122), therefore a new driver is necessary.
@@ -99359,10 +99359,10 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From 35c12db459a12c1481e28b62feece2192fea5fa9 Mon Sep 17 00:00:00 2001
+From 14b30c445a06a7a9e2595a38254fb9dfad285a48 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
-Subject: [PATCH 072/167] Added driver for HiFiBerry Amp amplifier add-on board
+Subject: [PATCH 072/171] Added driver for HiFiBerry Amp amplifier add-on board
 
 The driver contains a low-level hardware driver for the TAS5713 and the
 drivers for the Raspberry Pi I2S subsystem.
@@ -100197,10 +100197,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 46349f2bd2e39a806d53d65af63ee1e1f3eb8784 Mon Sep 17 00:00:00 2001
+From bf4c59be1c0796076caff442675a4d1bf04839f5 Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
-Subject: [PATCH 073/167] Update ds1307 driver for device-tree support
+Subject: [PATCH 073/171] Update ds1307 driver for device-tree support
 
 Signed-off-by: Ryan Coe <bluemrp9@gmail.com>
 ---
@@ -100227,10 +100227,10 @@ index 4ad97be480430babc3321075f2739114eaad8f04..2ac1c265dc9cea56a5949eb537949a1f
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From 68e7e25acf1f49e3b5ca6cd311fb35adfc656af3 Mon Sep 17 00:00:00 2001
+From f22a4632aaabdf1b8db855be1f60931aff8be9d3 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
-Subject: [PATCH 074/167] Add driver for rpi-proto
+Subject: [PATCH 074/171] Add driver for rpi-proto
 
 Forward port of 3.10.x driver from https://github.com/koalo
 We are using a custom board and would like to use rpi 3.18.x
@@ -100445,10 +100445,10 @@ index 0000000000000000000000000000000000000000..fadbfade100228aaafabb0d3bdf35c01
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 46d66b7f3be32394e810c41d575d53ecc853d57e Mon Sep 17 00:00:00 2001
+From 503222b36d56570d972347dbe6b333bc036f7f45 Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
-Subject: [PATCH 075/167] RaspiDAC3 support
+Subject: [PATCH 075/171] RaspiDAC3 support
 
 Signed-off-by: Jan Grulich <jan@grulich.eu>
 
@@ -100691,10 +100691,10 @@ index 0000000000000000000000000000000000000000..ad2b5b89bc8213dc2e277306ef50d6e3
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From 4c3a063245a55b72e81339a3a55f35a7b0549c1f Mon Sep 17 00:00:00 2001
+From 71748f0748c3609e0d7bffc54c00ff7ebb7af413 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
-Subject: [PATCH 076/167] Add Support for JustBoom Audio boards
+Subject: [PATCH 076/171] Add Support for JustBoom Audio boards
 
 justboom-dac: Adjust for ALSA API change
 
@@ -101150,10 +101150,10 @@ index 0000000000000000000000000000000000000000..909cf8928f2f4313982316f9c5b8a709
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From 9dfb099e44b1a1aeb59c1773ba3dc44be6edff40 Mon Sep 17 00:00:00 2001
+From fac66a36ca3017768df7e25346fd9a69d3dea5dc Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
-Subject: [PATCH 077/167] ARM: adau1977-adc: Add basic machine driver for
+Subject: [PATCH 077/171] ARM: adau1977-adc: Add basic machine driver for
  adau1977 codec driver.
 
 This commit adds basic support for the codec usage including: Device tree overlay,
@@ -101335,10 +101335,10 @@ index 0000000000000000000000000000000000000000..f3d7e5db7bb912e1d7ca6f8e8d42df5f
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From 2ac64705f0a22ffe20b88e3bfca31d21efab68dd Mon Sep 17 00:00:00 2001
+From 627877f748135ba0f27762680fed7b9a332949aa Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
-Subject: [PATCH 078/167] New AudioInjector.net Pi soundcard with low jitter
+Subject: [PATCH 078/171] New AudioInjector.net Pi soundcard with low jitter
  audio in and out.
 
 Contains the sound/soc/bcm ALSA machine driver and necessary alterations to the Kconfig and Makefile.
@@ -101589,10 +101589,10 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 51843ec949302798b427742123e6111d2b57d481 Mon Sep 17 00:00:00 2001
+From 0767bab3fafca528813de9a225f0acefb09898ec Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
-Subject: [PATCH 079/167] Add IQAudIO Digi WM8804 board support
+Subject: [PATCH 079/171] Add IQAudIO Digi WM8804 board support
 
 Support IQAudIO Digi board with iqaudio_digi machine driver and
  iqaudio-digi-wm8804-audio overlay.
@@ -101892,10 +101892,10 @@ index 0000000000000000000000000000000000000000..33aa2be8a43a12a12cfb5d844dd9732c
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 8035396df401691640734035e9f0b4ebcea025ef Mon Sep 17 00:00:00 2001
+From 0ec2957c10f92fa13b16413dbde1d8003808e15d Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
-Subject: [PATCH 080/167] New driver for RRA DigiDAC1 soundcard using WM8741 +
+Subject: [PATCH 080/171] New driver for RRA DigiDAC1 soundcard using WM8741 +
  WM8804
 
 ---
@@ -102368,10 +102368,10 @@ index 0000000000000000000000000000000000000000..f200688bb4ae32b90a0ced555aed94b0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From f490b01916b8f82ee9fabd2f91187edc4c22a8bc Mon Sep 17 00:00:00 2001
+From e73b9e80d592b38e1bc10367393f34296d04038f Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
-Subject: [PATCH 081/167] Add support for Dion Audio LOCO DAC-AMP HAT
+Subject: [PATCH 081/171] Add support for Dion Audio LOCO DAC-AMP HAT
 
 Using dedicated machine driver and pcm5102a codec driver.
 
@@ -102544,10 +102544,10 @@ index 0000000000000000000000000000000000000000..65e03741d349a2dc5bd91f69855ea952
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From f872c6bbf4288dded96166ba6cfeac81e4a014cc Mon Sep 17 00:00:00 2001
+From aa137adbefd902a4c3a163bdc994ac549e99c7cf Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
-Subject: [PATCH 082/167] Allo Piano DAC boards: Initial 2 channel (stereo)
+Subject: [PATCH 082/171] Allo Piano DAC boards: Initial 2 channel (stereo)
  support (#1645)
 
 Add initial 2 channel (stereo) support for Allo Piano DAC (2.0/2.1) boards,
@@ -102754,10 +102754,10 @@ index 0000000000000000000000000000000000000000..eaf50fb6dbca1970ae1c6f8662088b0f
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From a0b990fb9de3cc1c668ebf60f2342bdcbd675fd3 Mon Sep 17 00:00:00 2001
+From 5606eb490bbc82643871848ff4f42bc5b53512af Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
-Subject: [PATCH 083/167] Support for Blokas Labs pisound board
+Subject: [PATCH 083/171] Support for Blokas Labs pisound board
 
 Pisound dynamic overlay (#1760)
 
@@ -103956,10 +103956,10 @@ index 0000000000000000000000000000000000000000..06ff1e53dc9d860946965b6303577762
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From b18cdd6c80f5daa80daf2fd009225bb87cee7c0b Mon Sep 17 00:00:00 2001
+From 861256898473adf45265ba77351b4c452345455a Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 22 Jan 2017 12:49:37 +0100
-Subject: [PATCH 084/167] ASoC: Add driver for Cirrus Logic Audio Card
+Subject: [PATCH 084/171] ASoC: Add driver for Cirrus Logic Audio Card
 
 Note: due to problems with deferred probing of regulators
 the following softdep should be added to a modprobe.d file
@@ -105024,10 +105024,10 @@ index 0000000000000000000000000000000000000000..ac8651ddff7bd3701dffe22c7fb88352
 +MODULE_DESCRIPTION("ASoC driver for Cirrus Logic Audio Card");
 +MODULE_LICENSE("GPL");
 
-From 4751b4139c832a5839ac0a2fa9b74b028270b9ca Mon Sep 17 00:00:00 2001
+From 3ee4b5d2e76eb4fbb087656bb2745b2995999090 Mon Sep 17 00:00:00 2001
 From: Miquel <miquelblauw@hotmail.com>
 Date: Fri, 24 Feb 2017 20:51:06 +0100
-Subject: [PATCH 085/167] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
+Subject: [PATCH 085/171] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
 
 Signed-off-by: Miquel Blauw <info@dionaudio.nl>
 ---
@@ -105221,10 +105221,10 @@ index 0000000000000000000000000000000000000000..a009c49477972a9832175d86f201b035
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO-V2");
 +MODULE_LICENSE("GPL v2");
 
-From d19ab62409f4f8ea58f12cbe27c5cf5fc22294d7 Mon Sep 17 00:00:00 2001
+From 94c04760404bb3128e9f3dbf75770f1575635bf7 Mon Sep 17 00:00:00 2001
 From: Fe-Pi <fe-pi@cox.net>
 Date: Wed, 1 Mar 2017 04:42:43 -0700
-Subject: [PATCH 086/167] Add support for Fe-Pi audio sound card. (#1867)
+Subject: [PATCH 086/171] Add support for Fe-Pi audio sound card. (#1867)
 
 Fe-Pi Audio Sound Card is based on NXP SGTL5000 codec.
 Mechanical specification of the board is the same the Raspberry Pi Zero.
@@ -105438,10 +105438,10 @@ index 0000000000000000000000000000000000000000..015b56fd73cc36be5b5eecd17548fd03
 +MODULE_DESCRIPTION("ASoC Driver for Fe-Pi Audio");
 +MODULE_LICENSE("GPL v2");
 
-From 1f8846e5d06751c55cc69592705eb4d9cd027ae0 Mon Sep 17 00:00:00 2001
+From d4bccfb06982afe2bf4a9e72b876a2217dd70a52 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 20:04:13 +1100
-Subject: [PATCH 087/167] Add support for the AudioInjector.net Octo sound card
+Subject: [PATCH 087/171] Add support for the AudioInjector.net Octo sound card
 
 ---
  sound/soc/bcm/Kconfig                        |   7 +
@@ -105781,10 +105781,10 @@ index 0000000000000000000000000000000000000000..9effea725798640887755dfa688da453
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:audioinjector-octo-soundcard");
 
-From d0d0da10a7c0ae1b2a54f993da524008d1a37c45 Mon Sep 17 00:00:00 2001
+From 9144f062edb98ad04532ce6177daa0ffb0e99bf4 Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
-Subject: [PATCH 088/167] rpi_display: add backlight driver and overlay
+Subject: [PATCH 088/171] rpi_display: add backlight driver and overlay
 
 Add a mailbox-driven backlight controller for the Raspberry Pi DSI
 touchscreen display. Requires updated GPU firmware to recognise the
@@ -105953,10 +105953,10 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 2661ac69c895775db1357272d2d74be52e19ddac Mon Sep 17 00:00:00 2001
+From d89fa28c2773caea1c0b45c0f6c069ddf70c520e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
-Subject: [PATCH 089/167] bcm2835-virtgpio: Virtual GPIO driver
+Subject: [PATCH 089/171] bcm2835-virtgpio: Virtual GPIO driver
 
 Add a virtual GPIO driver that uses the firmware mailbox interface to
 request that the VPU toggles LEDs.
@@ -106230,10 +106230,10 @@ index 4a3d79d3b48eb483a4e4bf498f617515e3ad158f..5f34e1257117fb48013c9926a8a223d6
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 9c24d668c5e30c26b44d07b6e2a45b309538f3fc Mon Sep 17 00:00:00 2001
+From d98896369e1af9b5c148a30daf19c170448bdbf4 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Mon, 20 Feb 2017 17:01:21 +0000
-Subject: [PATCH 090/167] bcm2835-gpio-exp: Driver for GPIO expander via
+Subject: [PATCH 090/171] bcm2835-gpio-exp: Driver for GPIO expander via
  mailbox service
 
 Pi3 and Compute Module 3 have a GPIO expander that the
@@ -106561,10 +106561,10 @@ index 5f34e1257117fb48013c9926a8a223d64a598ab7..c819c21b0158a59c1308882e5a40e3f3
  	/* Dispmanx TAGS */
  	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,
 
-From 3898c6d8095e4701aa1f4b69ca254914c0711864 Mon Sep 17 00:00:00 2001
+From 84e5030709abd2887e7897eec953b02f4b1b78a3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
-Subject: [PATCH 091/167] amba_pl011: Don't use DT aliases for numbering
+Subject: [PATCH 091/171] amba_pl011: Don't use DT aliases for numbering
 
 The pl011 driver looks for DT aliases of the form "serial<n>",
 and if found uses <n> as the device ID. This can cause
@@ -106593,10 +106593,10 @@ index f2503d862f3aee25396ef002ba69968896316779..a85e81245004e928fc52ec59044e151b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From c087afaedb9ee07996d0c12e641434ac9dbf4950 Mon Sep 17 00:00:00 2001
+From dd93fd68bfffc46553cb79f38b42bf0fd525ca2b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:07:39 +0000
-Subject: [PATCH 092/167] amba_pl011: Round input clock up
+Subject: [PATCH 092/171] amba_pl011: Round input clock up
 
 The UART clock is initialised to be as close to the requested
 frequency as possible without exceeding it. Now that there is a
@@ -106682,10 +106682,10 @@ index a85e81245004e928fc52ec59044e151b7f183496..380d2c2e19ae3720924e906261b487ad
  /* unregisters the driver also if no more ports are left */
  static void pl011_unregister_port(struct uart_amba_port *uap)
 
-From 64218850b7cb509d11e86b58a49539a6c53c7099 Mon Sep 17 00:00:00 2001
+From 962af1199b7ec81d845f263dfc27bb9911c14c56 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
-Subject: [PATCH 093/167] OF: DT-Overlay configfs interface
+Subject: [PATCH 093/171] OF: DT-Overlay configfs interface
 
 This is a port of Pantelis Antoniou's v3 port that makes use of the
 new upstreamed configfs support for binary attributes.
@@ -107117,10 +107117,10 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From 016d0d19f60b0b348c40db9222addc6b1cdd539e Mon Sep 17 00:00:00 2001
+From de39cf0268bb22f1f6c952a0537fb51af5d889c0 Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
-Subject: [PATCH 094/167] brcm: adds support for BCM43341 wifi
+Subject: [PATCH 094/171] brcm: adds support for BCM43341 wifi
 
 brcmfmac: Disable power management
 
@@ -107271,10 +107271,10 @@ index 65689469c5a12e2fcfd6123ca584944da79ec184..4886dc29ad36705210bed20757ce09ed
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_43362_CHIP_ID, 0xFFFFFFFE, 43362),
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_4339_CHIP_ID, 0xFFFFFFFF, 4339),
 
-From 2aad0ee970091db61263df3d27049ced5681afdd Mon Sep 17 00:00:00 2001
+From 80d54a2586e101406b76fdae07e31e2d35467b9f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Feb 2017 15:26:13 +0000
-Subject: [PATCH 095/167] brcmfmac: Mute expected startup 'errors'
+Subject: [PATCH 095/171] brcmfmac: Mute expected startup 'errors'
 
 The brcmfmac WiFi driver always complains about the '00' country code
 and the firmware version is reported as an error. Modify the driver to
@@ -107313,10 +107313,10 @@ index 6221b046bca44211e2dfac24119097f7ac09e829..634602e0c44f91da06db7aa803dbee69
  	/* locate firmware version number for ethtool */
  	ptr = strrchr(buf, ' ') + 1;
 
-From 453b9d90f6205f219f7b0691f3e412220e5fb80f Mon Sep 17 00:00:00 2001
+From 4db572f84537780cdbf0cbf40ef7fc02f1c29908 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
-Subject: [PATCH 096/167] hci_h5: Don't send conf_req when ACTIVE
+Subject: [PATCH 096/171] hci_h5: Don't send conf_req when ACTIVE
 
 Without this patch, a modem and kernel can continuously bombard each
 other with conf_req and conf_rsp messages, in a demented game of tag.
@@ -107339,10 +107339,10 @@ index 90d0456b67446bcc624fab4b1542c4eaf21531b1..f9adeac3bbba6418dcca298c55706356
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From bb741ee72fab8110b2b7f86410fc72d2b136b93e Mon Sep 17 00:00:00 2001
+From 2cb6326bbbbeedfb1dabeb21ae2355733a302de2 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
-Subject: [PATCH 097/167] config: Add default configs
+Subject: [PATCH 097/171] config: Add default configs
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1309 +++++++++++++++++++++++++++++++++++
@@ -109990,10 +109990,10 @@ index 0000000000000000000000000000000000000000..046f3e8757ef0f794c802171690528d3
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 2364962b28dddcc0144d2c62860d7ed2075b6a4e Mon Sep 17 00:00:00 2001
+From 0ecb4c6a19ad119b66a9f4143f0e47d085b28f5a Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
-Subject: [PATCH 098/167] Add arm64 configuration and device tree differences.
+Subject: [PATCH 098/171] Add arm64 configuration and device tree differences.
  Disable MMC_BCM2835_SDHOST and MMC_BCM2835 since these drivers are crashing
  at the moment.
 
@@ -111408,10 +111408,10 @@ index 0000000000000000000000000000000000000000..e6b09fafa27eed2b762e3d53b55041f7
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2835_VCHIQ=n
 
-From fae11dca73c9f1eea033f56db6bfb3eb7c5e4fb5 Mon Sep 17 00:00:00 2001
+From 6b3c1dacb978cb9e48f53f11038535f67b46f2a0 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
-Subject: [PATCH 099/167] raspberrypi-firmware: Define the MBOX channel in the
+Subject: [PATCH 099/171] raspberrypi-firmware: Define the MBOX channel in the
  header.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -111433,10 +111433,10 @@ index c819c21b0158a59c1308882e5a40e3f3fe73cbdf..de2a3dcd562beb752266eaf0070e5586
  
  enum rpi_firmware_property_status {
 
-From af0f8e2ef109c170c66ae9f0de8c93154d2c7fe7 Mon Sep 17 00:00:00 2001
+From 99ed5d793a23275b6aa69c4862a5f020bb947f2c Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
-Subject: [PATCH 100/167] raspberrypi-firmware: Export the general transaction
+Subject: [PATCH 100/171] raspberrypi-firmware: Export the general transaction
  function.
 
 The vc4-firmware-kms module is going to be doing the MBOX FB call.
@@ -111480,10 +111480,10 @@ index de2a3dcd562beb752266eaf0070e55861d553f5f..dc7fd58afd5dddebf9b17065bb069a1d
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From a3ab74df0b65591f541035a5ca7dace7d79d5daa Mon Sep 17 00:00:00 2001
+From 656faa05b83945975ffff3b374272ba2ebf2b2c3 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
-Subject: [PATCH 101/167] ARM64: Make it work again on 4.9 (#1790)
+Subject: [PATCH 101/171] ARM64: Make it work again on 4.9 (#1790)
 
 * Invoke the dtc compiler with the same options used in arm mode.
 * ARM64 now uses the bcm2835 platform just like ARM32.
@@ -111887,10 +111887,10 @@ index e6b09fafa27eed2b762e3d53b55041f793683d27..c7e891d72969a388d9b135a36dbfc9c9
  CONFIG_LIBCRC32C=y
 -CONFIG_BCM2835_VCHIQ=n
 
-From 822051fd7fcc52f4b0273de82a030b5433b594b8 Mon Sep 17 00:00:00 2001
+From 03a9fbe000404d610849fd607fd9ff0adc80b093 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:10:07 -0800
-Subject: [PATCH 102/167] ARM64: Enable HDMI audio and vc04_services in
+Subject: [PATCH 102/171] ARM64: Enable HDMI audio and vc04_services in
  bcmrpi3_defconfig
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
@@ -111919,10 +111919,10 @@ index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..4b90f9b64abe9f089ba56b13d5a00de3
  CONFIG_BCM2835_MBOX=y
  # CONFIG_IOMMU_SUPPORT is not set
 
-From 4bc0881ff82d0bec522c040a51d7e268c816f1e3 Mon Sep 17 00:00:00 2001
+From ea026b171a3cecd96f99333f23ea66ed9e3b743f Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:14:03 -0800
-Subject: [PATCH 103/167] ARM64: Run bcmrpi3_defconfig through savedefconfig.
+Subject: [PATCH 103/171] ARM64: Run bcmrpi3_defconfig through savedefconfig.
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
 ---
@@ -111967,10 +111967,10 @@ index 4b90f9b64abe9f089ba56b13d5a00de33343bfb9..dac962ca1634662ce7d966f1ffb53b5b
  CONFIG_FB_TFT_AGM1264K_FL=m
  CONFIG_FB_TFT_BD663474=m
 
-From 32647dca98827a401ac14566795a628c4af0f3d2 Mon Sep 17 00:00:00 2001
+From f4fb370608bdb9ab10d2ac970bd10b9520e7b92e Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 02:54:26 -0800
-Subject: [PATCH 104/167] ARM64: Enable Kernel Address Space Randomization
+Subject: [PATCH 104/171] ARM64: Enable Kernel Address Space Randomization
  (#1792)
 
 Randomization allows the mapping between virtual addresses and physical
@@ -112002,10 +112002,10 @@ index dac962ca1634662ce7d966f1ffb53b5bfa27c506..aae33b4b3c3e736ea7cd3ca242158ad6
  CONFIG_BINFMT_MISC=y
  CONFIG_COMPAT=y
 
-From 7b3d71daad3c62e616587e8af9236dbc860fef68 Mon Sep 17 00:00:00 2001
+From f5353f5db03a3c7426a73f3f3ae08b5d9853386d Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sun, 15 Jan 2017 07:31:59 -0800
-Subject: [PATCH 105/167] ARM64: Enable RTL8187/RTL8192CU wifi in build config
+Subject: [PATCH 105/171] ARM64: Enable RTL8187/RTL8192CU wifi in build config
 
 These drivers build now, so they can be enabled back
 in the build configuration just like they are for
@@ -112030,10 +112030,10 @@ index aae33b4b3c3e736ea7cd3ca242158ad6ba558aff..b7d762df19b85e369a32cd823dfd0621
  CONFIG_ZD1211RW=m
  CONFIG_MAC80211_HWSIM=m
 
-From 1a3409201cc75dc0b54ca4fe9182b743a895a5b0 Mon Sep 17 00:00:00 2001
+From b6a6db72bb0747e257f76d2b34a49545d782e5c3 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:33:51 -0800
-Subject: [PATCH 106/167] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
+Subject: [PATCH 106/171] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
 
 In ARM64, the FIQ mechanism used by this driver is not current
 implemented.   As a workaround, reqular IRQ is used instead
@@ -112376,10 +112376,10 @@ index 6b2c7d0c93f36a63863ff4b0ecc1f3eab77e058b..d7b700ff17821ad1944e36721fe6b2db
  /** The OS page size */
  #define DWC_OS_PAGE_SIZE	PAGE_SIZE
 
-From 25d48b2467ce86b0db108004f1a1c60b4389b8b3 Mon Sep 17 00:00:00 2001
+From 9d7234a88150305ba7a07188325cb78db5329a3e Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:43:57 -0800
-Subject: [PATCH 107/167] ARM64: Round-Robin dispatch IRQs between CPUs.
+Subject: [PATCH 107/171] ARM64: Round-Robin dispatch IRQs between CPUs.
 
 IRQ-CPU mapping is round robined on ARM64 to increase
 concurrency and allow multiple interrupts to be serviced
@@ -112453,10 +112453,10 @@ index c4e151451cf8c8ebde5225515eac2786d6f61d46..9a7ee04ee0d9b7aa734cf3159ed59c19
  	.name		= "bcm2836-gpu",
  	.irq_mask	= bcm2836_arm_irqchip_mask_gpu_irq,
 
-From 5a0978e7b7ed5f4a09844a2eaa07f6beecbf54a5 Mon Sep 17 00:00:00 2001
+From 290301822f954f1f531e2e3975544fc97f7877d7 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:45:03 -0800
-Subject: [PATCH 108/167] ARM64: Enable DWC_OTG Driver In ARM64 Build
+Subject: [PATCH 108/171] ARM64: Enable DWC_OTG Driver In ARM64 Build
  Config(bcmrpi3_defconfig)
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
@@ -112477,10 +112477,10 @@ index b7d762df19b85e369a32cd823dfd062145bdefa7..4d85c231c5ea0244e1b05fb4a5e3c8fd
  CONFIG_USB_STORAGE=y
  CONFIG_USB_STORAGE_REALTEK=m
 
-From 7bf84cad99e6de2015d7d1cd9d5f813c7c5ae62c Mon Sep 17 00:00:00 2001
+From 97692cb98965c89dfefc2d133127acc9bdfdcc44 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 11 Feb 2017 01:18:31 -0800
-Subject: [PATCH 109/167] ARM64: Force hardware emulation of deprecated
+Subject: [PATCH 109/171] ARM64: Force hardware emulation of deprecated
  instructions.
 
 ---
@@ -112508,10 +112508,10 @@ index f0e6d717885b1fcf3b22f64c10c38f19c25f809d..0cb830d30fb6d2bd26ab572efe893649
  	case INSN_OBSOLETE:
  		insn->current_mode = INSN_UNDEF;
 
-From 15515740c16eb20d1d89a4efc5c53a756c58a231 Mon Sep 17 00:00:00 2001
+From 5e6c3630b017d11396e65af6f4083721c228405a Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 10 Feb 2017 17:57:08 -0800
-Subject: [PATCH 110/167] build/arm64: Add rules for .dtbo files for dts
+Subject: [PATCH 110/171] build/arm64: Add rules for .dtbo files for dts
  overlays
 
 We now create overlays as .dtbo files.
@@ -112536,10 +112536,10 @@ index b9a4a934ca057623e0ea436fd9b2c7c0f675fced..54e3c38d6fd877827541cdc798de035c
  
  dtbs: prepare scripts
 
-From 23bd41475d2a7d788d1171fc9e11956cba854a2d Mon Sep 17 00:00:00 2001
+From b6ae009bfdc608fd4105b5cf8162074edc702d13 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
-Subject: [PATCH 111/167] clk: bcm2835: Mark GPIO clocks enabled at boot as
+Subject: [PATCH 111/171] clk: bcm2835: Mark GPIO clocks enabled at boot as
  critical.
 
 These divide off of PLLD_PER and are used for the ethernet and wifi
@@ -112577,10 +112577,10 @@ index 39f72da6ba1f6ec6ec41d5dc1bf46344aab008da..fe3298b54cdfb96bd90fb4f39e13921d
  	 * rate changes on at least of the parents.
  	 */
 
-From 1d5cb12d2cc3a59fcdc3005ddae656ec47560aa1 Mon Sep 17 00:00:00 2001
+From 241c0141b0f64afc072bfcd16ad836dfc9c15950 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
-Subject: [PATCH 112/167] pinctrl-bcm2835: Fix interrupt handling for GPIOs
+Subject: [PATCH 112/171] pinctrl-bcm2835: Fix interrupt handling for GPIOs
  28-31 and 46-53
 
 Contrary to the documentation, the BCM2835 GPIO controller actually has
@@ -112613,10 +112613,10 @@ index 6351fe7f8e314ac5ebb102dd20847b383fd5b857..28745af5aadf3cb91fa7ff39118385c3
  	},
  };
 
-From e447f049231af08c2a2bf3e433e385c17310a295 Mon Sep 17 00:00:00 2001
+From 2815293f575d6f7f8db0d58c6becf969c7ebcc08 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Tue, 7 Mar 2017 12:18:20 +0000
-Subject: [PATCH 113/167] BCM270X_DT: Invert Pi3 power LED to match fw change
+Subject: [PATCH 113/171] BCM270X_DT: Invert Pi3 power LED to match fw change
 
 Firmware expgpio driver reworked due to complaint over
 hotplug detect.
@@ -112642,10 +112642,10 @@ index 616cfd5c7094596b497101e8feca25e25e77c3e8..9f001bccb8261563dcddd8dec94b056b
  };
  
 
-From dc0ef56c76ec77f19774bd87d02791428725209d Mon Sep 17 00:00:00 2001
+From 7ae5699f83642001f71b566fd5102022356ebdb8 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Tue, 14 Mar 2017 14:23:06 +0000
-Subject: [PATCH 114/167] bcm2835-gpio-exp: Copy/paste error adding base twice
+Subject: [PATCH 114/171] bcm2835-gpio-exp: Copy/paste error adding base twice
 
 brcmexp_gpio_set was adding gpio->gc.base to the offset
 twice, so passing an invalid number to the mailbox service.
@@ -112671,10 +112671,10 @@ index 681a91492d4c33bdfd42416e069218e8611cc4d9..d68adafaee4ad406f45f4ff0d6b7c1ad
  	set.state = val;	/* Output state */
  
 
-From f247dc9dd557c00ef74fa5a76452bf8b3fde6387 Mon Sep 17 00:00:00 2001
+From 5ca294f7f07267334376c1a3f2c7ab01a575101e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 17 Mar 2017 13:40:41 +0000
-Subject: [PATCH 115/167] config: disable MMC driver temporarily for now.
+Subject: [PATCH 115/171] config: disable MMC driver temporarily for now.
 
 Currently causes a breakage to sdhost driver. However when MMC is disabled Pi3 wifi will not work
 ---
@@ -112709,10 +112709,10 @@ index 046f3e8757ef0f794c802171690528d31fee9deb..f2e0a58a96c8550f110c5940bf65f4d0
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From e134093f1b0dc9db64780e9e5b0aa482c2aa8cec Mon Sep 17 00:00:00 2001
+From 14c8ba45aaf497ea88c1614093b5615d12daf16b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Mar 2017 12:24:41 +0000
-Subject: [PATCH 116/167] config: Make spidev a loadable module
+Subject: [PATCH 116/171] config: Make spidev a loadable module
 
 spidev isn't required early in the boot process, and not all users
 need it (spi_bcm2835 is a module), so make it a loadable module.
@@ -112752,10 +112752,10 @@ index f2e0a58a96c8550f110c5940bf65f4d022cc4548..9eb7084f440c8aac0c6257ee678007c2
  CONFIG_PPS_CLIENT_LDISC=m
  CONFIG_PPS_CLIENT_GPIO=m
 
-From 63aa7786fcb6828e7ac09cd8528e509bb97d4583 Mon Sep 17 00:00:00 2001
+From f94bf42edfa6eeb6b9ad2df77a7bc0a04ad58bbc Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 10:06:56 +0000
-Subject: [PATCH 117/167] ASoC: Add prompt for ICS43432 codec
+Subject: [PATCH 117/171] ASoC: Add prompt for ICS43432 codec
 
 Without a prompt string, a config setting can't be included in a
 defconfig. Give CONFIG_SND_SOC_ICS43432 a prompt so that Pi soundcards
@@ -112780,10 +112780,10 @@ index 55812b0b884cf4fc4e86680b11fedd11c863db7a..428dc05edbb99f50560b7f89e45501c5
  config SND_SOC_INNO_RK3036
  	tristate "Inno codec driver for RK3036 SoC"
 
-From 7f5f873ff31e5fb9db89bd8870097df6b30c4660 Mon Sep 17 00:00:00 2001
+From a3ec153fb9c893283426a031ef842aad06216542 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 16:34:46 +0000
-Subject: [PATCH 118/167] bcm2835-aux: Add aux interrupt controller
+Subject: [PATCH 118/171] bcm2835-aux: Add aux interrupt controller
 
 The AUX block has a shared interrupt line with a register indicating
 which devices have active IRQs. Expose this as a nested interrupt
@@ -112947,10 +112947,10 @@ index bd750cf2238d61489811e7d7bd3b5f9950ed53c8..41e0702fae4692221980b0d02aed1ba6
  			       BCM2835_AUX_CLOCK_COUNT, GFP_KERNEL);
  	if (!onecell)
 
-From 9156f46b682e9fc3ca1cdcac4eddc74a3cc21529 Mon Sep 17 00:00:00 2001
+From 0269e0943f1a94d54e90fe4d8f8acfd4d6f66c1e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 17:08:44 +0000
-Subject: [PATCH 119/167] BCM270X_DT: Enable AUX interrupt controller in DT
+Subject: [PATCH 119/171] BCM270X_DT: Enable AUX interrupt controller in DT
 
 See: https://github.com/raspberrypi/linux/issues/1484
      https://github.com/raspberrypi/linux/issues/1573
@@ -113003,10 +113003,10 @@ index 72cb9dc60ca9ad9aa2813972a299c50dcea7cd89..ca47b23ffbcd06063e0fb7072dc8a843
  			#address-cells = <1>;
  			#size-cells = <0>;
 
-From a420a0f881e0bdddc932e1896617b995d94f1554 Mon Sep 17 00:00:00 2001
+From 3fa19808abc3076f201e792fd733040cc0a4b115 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 27 Mar 2017 17:40:45 +0100
-Subject: [PATCH 120/167] mkknlimg: Find some more downstream-only strings
+Subject: [PATCH 120/171] mkknlimg: Find some more downstream-only strings
 
 See: https://github.com/raspberrypi/linux/issues/1920
 
@@ -113037,10 +113037,10 @@ index 60206de7fa9a49bd027c635306674a29a568652f..84be2593ec1de8f97b0167ff06b3e05d
  
  my $res = try_extract($kernel_file, $tmpfile1);
 
-From d3106d8e495216d8bf7a46b2d811d70b9e4e36ac Mon Sep 17 00:00:00 2001
+From 3ff525adc078b3438dc3415096d3ce2678d7e760 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 29 Apr 2016 10:32:17 -0700
-Subject: [PATCH 121/167] mmc: read mmc alias from device tree
+Subject: [PATCH 121/171] mmc: read mmc alias from device tree
 
 To get the SD/MMC host device ID, read the alias from the device
 tree.
@@ -113097,10 +113097,10 @@ index 3f8c85d5aa094b43666904c7dbbe5e62c9763c19..4dbd0e8e27a496bfbe67d188cf795ecc
  		kfree(host);
  		return NULL;
 
-From 95a2ced7b7f1b026f65774bda9eb0f8354fc376c Mon Sep 17 00:00:00 2001
+From 82fd0d70e5d7fbfb8f2936d559cde24711e3f847 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 14:30:42 +0100
-Subject: [PATCH 122/167] BCM270X_DT: Add numbered aliases for SD/MMC devices
+Subject: [PATCH 122/171] BCM270X_DT: Add numbered aliases for SD/MMC devices
 
 In order to force a specific ID assignment to SD/MMC devices, add
 numbered aliases to the DT: sdhost -> mmc0, mmc -> mmc1
@@ -113131,10 +113131,10 @@ index ef14e9ac6cd2092efb1681682dd2d3c52b8abfd5..693d4c04a36d2a7883cc3d8916bf0efb
  		i2c2 = &i2c2;
  		usb = &usb;
 
-From b50f9e35579e3bf6d12600a829a86490a52522ff Mon Sep 17 00:00:00 2001
+From 4628aba0bb1eec04bbbb19265d2de670100d26ca Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 14:28:53 +0100
-Subject: [PATCH 123/167] config: Re-enable the bcm2835-mmc driver
+Subject: [PATCH 123/171] config: Re-enable the bcm2835-mmc driver
 
 With the patch to assign mmc device IDs based on DT aliases and
 appropriate aliases in the rpi DTBs, it is now safe to re-enable
@@ -113171,10 +113171,10 @@ index 9eb7084f440c8aac0c6257ee678007c23990a8ae..021c38a909e71baa135cbcd4f3fb80fa
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 8501c30eb81d960b40f460d312e97e1159659bb2 Mon Sep 17 00:00:00 2001
+From ec10142e1836924f04aca120cc3ba66f1bb89663 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
-Subject: [PATCH 124/167] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
+Subject: [PATCH 124/171] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
 
 Some SD cards have been found that corrupt data when small blocks
 are erased. Add a quirk to indicate that ERASE should not be used,
@@ -113316,10 +113316,10 @@ index 77e61e0a216a2728dd5cfecf55299402ac03c384..d12e8ddd22cb96e38b30f1ac3f9a6bd0
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From db5da975a0bf7185c7f6a51810e9ea815fcfa31a Mon Sep 17 00:00:00 2001
+From e707f97c58d059d4e5a1996b2bef3ee022da8026 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 16:08:29 +0100
-Subject: [PATCH 125/167] bcm2835-sdhost: mmc_card_blockaddr fix
+Subject: [PATCH 125/171] bcm2835-sdhost: mmc_card_blockaddr fix
 
 Get the definition of mmc_card_blockaddr from drivers/mmc/core/card.h.
 
@@ -113346,10 +113346,10 @@ index a9bc79bfdbb71807819dfe2d8f1651445997f92a..9c6f199a7830959f31012d86bc1f8b1a
  
  #define SDCMD  0x00 /* Command to SD card              - 16 R/W */
 
-From 3d219aa58aa896aa50adde7bec595da7955e07bb Mon Sep 17 00:00:00 2001
+From c547af664b4e16c1c397acb5d76eda91a9c7cbf9 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Mar 2017 12:30:37 +0000
-Subject: [PATCH 126/167] thermal: Compatible strings for bcm2836, bcm2837
+Subject: [PATCH 126/171] thermal: Compatible strings for bcm2836, bcm2837
 
 The upstream dt-bindings documentation for bcm2835-thermal (which
 exists even though the driver isn't upstreamed) says to use
@@ -113381,10 +113381,10 @@ index c63fb9f9d143e19612a18fe530c7b2b3518a22a4..25b78c3eac1503fbc9e679b963a6284b
  };
  MODULE_DEVICE_TABLE(of, bcm2835_thermal_of_match_table);
 
-From 6f1ad85309eaf28bd2168682de3a66ab47899553 Mon Sep 17 00:00:00 2001
+From 8e79c5261d30297c43fd2bf884a8e838e7263814 Mon Sep 17 00:00:00 2001
 From: John Greb <h3x4m3r0n@gmail.com>
 Date: Wed, 8 Mar 2017 15:12:29 +0000
-Subject: [PATCH 127/167] Match dwc2 device-tree fifo sizes to the hardware
+Subject: [PATCH 127/171] Match dwc2 device-tree fifo sizes to the hardware
  values.
 
 Since commit aa381a7259c3f53727bcaa8c5f9359e940a0e3fd was reverted with 3fa9538539ac737096c81f3315a14670b1609092 the g-tx-fifo-size array in the device-tree needs to match the preset values in the bcm2835.
@@ -113415,10 +113415,10 @@ index 527abc9f0ddf71f4dc7d58336d87684c931cc2f3..265a16bab008453edba198cf2366c423
  	};
  };
 
-From 70bb3413b8944b08da15d34059ea0a963164e0b8 Mon Sep 17 00:00:00 2001
+From 01d1abbe42b8ead8b482990506c4750f9f6430ec Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Mar 2017 09:10:05 +0000
-Subject: [PATCH 128/167] BCM270X_DT: Add lm75 to i2c-sensor overlay
+Subject: [PATCH 128/171] BCM270X_DT: Add lm75 to i2c-sensor overlay
 
 See: https://www.raspberrypi.org/forums/viewtopic.php?f=107&t=177236
 
@@ -113481,10 +113481,10 @@ index 31bda8da4cb6a56bfe493a81b918900995fb0589..606b2d5012abf2e85712be631c42ea40
  	};
  };
 
-From 590770ef0843d12b901f8f07c7c7d29f9aa5c26c Mon Sep 17 00:00:00 2001
+From f70722aa6365aef4b09cab09e537bf0416da5ecc Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 28 Mar 2017 14:22:20 +0100
-Subject: [PATCH 129/167] BCM270X_DT: Allow multiple instances of w1-gpio
+Subject: [PATCH 129/171] BCM270X_DT: Allow multiple instances of w1-gpio
  overlays
 
 Upcoming firmware will modify the address portion of node names when
@@ -113549,10 +113549,10 @@ index 66a98f6c9601f51483f27803995bec772bb3350e..ef8bfbcabdb31231075d5c281df3b38b
  				<&w1_pins>,"brcm,pins:4";
  		pullup =        <&w1>,"rpi,parasitic-power:0";
 
-From 8d1f96f986847b560bceccc5029cc1c21804a71b Mon Sep 17 00:00:00 2001
+From 7e0019f9817602186aa21d656c355abf8bc9b680 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 28 Mar 2017 17:41:30 +0100
-Subject: [PATCH 130/167] leds-gpio: Remove stray assignment to brightness_set
+Subject: [PATCH 130/171] leds-gpio: Remove stray assignment to brightness_set
 
 The brightness_set method is intended for use cases that must not
 block, and can only be used if the GPIO provider can never sleep.
@@ -113578,10 +113578,10 @@ index 934cdb1d7bc7f12a4fb06a5c458ad76727c7b7c7..a4df27f6af35ba7f7b34c2a4b7b22ee7
  	if (template->default_state == LEDS_GPIO_DEFSTATE_KEEP) {
  		state = gpiod_get_value_cansleep(led_dat->gpiod);
 
-From d067c0c2a34c35cf3f8fe144bae466b86fd94f8d Mon Sep 17 00:00:00 2001
+From 7849bfc329c346636d14a921549ef9ac728176e1 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 29 Mar 2017 17:41:04 +0100
-Subject: [PATCH 131/167] config: Add back MMC_BCM2835_DMA
+Subject: [PATCH 131/171] config: Add back MMC_BCM2835_DMA
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -113613,10 +113613,10 @@ index 021c38a909e71baa135cbcd4f3fb80fad2151647..a8fc96ef674be476d10e59aef2367def
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 24f1bd381cb568f0361410e4fc393d0b4ad3729b Mon Sep 17 00:00:00 2001
+From 695b025defd3a8e14a4467ad04ef2a31eed1100e Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 27 Mar 2017 22:26:49 +1100
-Subject: [PATCH 132/167] AudioInjector Octo: sample rates, regulators, reset
+Subject: [PATCH 132/171] AudioInjector Octo: sample rates, regulators, reset
 
 This patch adds new sample rates to the Audioinjector Octo sound card. The
 new supported rates are (in kHz) :
@@ -113782,10 +113782,10 @@ index 9effea725798640887755dfa688da45338718afc..dcf403ab37639ba79e38278d7e4b1ade
  			dai->cpu_dai_name = NULL;
  			dai->cpu_of_node = i2s_node;
 
-From 4563b740a1775f20895275bb343741710a0d27b9 Mon Sep 17 00:00:00 2001
+From 8004ce831e5f275d429b087f555e1c8c3661509f Mon Sep 17 00:00:00 2001
 From: Peter Malkin <petermalkin@google.com>
 Date: Mon, 27 Mar 2017 16:38:21 -0700
-Subject: [PATCH 133/167] Driver support for Google voiceHAT soundcard.
+Subject: [PATCH 133/171] Driver support for Google voiceHAT soundcard.
 
 ---
  arch/arm/boot/dts/overlays/Makefile                |   1 +
@@ -114290,10 +114290,10 @@ index 0000000000000000000000000000000000000000..225854b8e5298b3c3018f59a49404354
 +MODULE_DESCRIPTION("ASoC Driver for Google voiceHAT SoundCard");
 +MODULE_LICENSE("GPL v2");
 
-From 6f5fcd9cde937ad09823ffd3583c48ddb90a9a7f Mon Sep 17 00:00:00 2001
+From a2b21d4aa50adbaa2525b009e32add438de5a5dd Mon Sep 17 00:00:00 2001
 From: Raashid Muhammed <raashidmuhammed@zilogic.com>
 Date: Mon, 27 Mar 2017 12:35:00 +0530
-Subject: [PATCH 134/167] Add support for Allo Piano DAC 2.1 plus add-on board
+Subject: [PATCH 134/171] Add support for Allo Piano DAC 2.1 plus add-on board
  for Raspberry Pi.
 
 The Piano DAC 2.1 has support for 4 channels with subwoofer.
@@ -114921,10 +114921,10 @@ index 0000000000000000000000000000000000000000..f66f42abadbd5f9d3fe000676e8297ed
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC Plus");
 +MODULE_LICENSE("GPL v2");
 
-From 87c28d425feb0dd759fa1ff4c4b9a28385587b22 Mon Sep 17 00:00:00 2001
+From 95832c1ae0d6ae2743cb8a5895b1a09bf12c9170 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Tue, 28 Mar 2017 20:04:42 +0530
-Subject: [PATCH 135/167]  Add support for Allo Boss DAC add-on board for
+Subject: [PATCH 135/171]  Add support for Allo Boss DAC add-on board for
  Raspberry Pi.  (#1924)
 
 Signed-off-by: Baswaraj K <jaikumar@cem-solutions.net>
@@ -115654,10 +115654,10 @@ index 0000000000000000000000000000000000000000..c080e31065d99ab309ab3bdf41a44adf
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Boss DAC");
 +MODULE_LICENSE("GPL v2");
 
-From ceac552b42e3ae688c1176b41f2cb4c39cfd8a72 Mon Sep 17 00:00:00 2001
+From 909b934489770252ab2b079dbe109406e53cd491 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar C <babusubashchandar@zilogic.com>
 Date: Thu, 30 Mar 2017 20:17:27 +0530
-Subject: [PATCH 136/167] Add support for new clock rate and mute gpios.
+Subject: [PATCH 136/171] Add support for new clock rate and mute gpios.
 
 Signed-off-by: Baswaraj K <jaikumar@cem-solutions.net>
 Reviewed-by: Deepak <deepak@zilogic.com>
@@ -116310,10 +116310,10 @@ index c080e31065d99ab309ab3bdf41a44adfdd8f8039..203ab76c7045b081578e23bda1099dd1
  }
  
 
-From 2606e13d66a5cd155a7653c32af66ee1b2521c2b Mon Sep 17 00:00:00 2001
+From 2ad19b5956a7caaa1b832c2eaf75ac37863ec588 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Sat, 1 Apr 2017 00:46:52 +0530
-Subject: [PATCH 137/167] Add clock changes and mute gpios (#1938)
+Subject: [PATCH 137/171] Add clock changes and mute gpios (#1938)
 
 Also improve code style and adhere to ALSA coding conventions.
 
@@ -117006,10 +117006,10 @@ index f66f42abadbd5f9d3fe000676e8297ed91630e47..56e43f98846b41e487b3089813f7edc3
  }
  
 
-From 8b2e21fe2de822475aa39325280951455dfd8731 Mon Sep 17 00:00:00 2001
+From a0800c1c55410ad79f81402389c6eb55a9454880 Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Fri, 14 Apr 2017 10:43:57 +0100
-Subject: [PATCH 138/167] This is the driver for Sony CXD2880 DVB-T2/T tuner +
+Subject: [PATCH 138/171] This is the driver for Sony CXD2880 DVB-T2/T tuner +
  demodulator. It includes the CXD2880 driver and the CXD2880 SPI adapter. The
  current CXD2880 driver version is 1.4.1 - 1.0.1 released on April 13, 2017.
 
@@ -133141,10 +133141,10 @@ index 0000000000000000000000000000000000000000..82e122349055be817eb74ed5bbcd7560
 +MODULE_AUTHOR("Sony Semiconductor Solutions Corporation");
 +MODULE_LICENSE("GPL v2");
 
-From 2a5a2d16d766043fa700d43c9ed219835a637738 Mon Sep 17 00:00:00 2001
+From 118ee7b54ed7e60ab5a45f52dc79c98c2c2574ff Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Thu, 22 Dec 2016 15:34:12 +0900
-Subject: [PATCH 139/167] BCM2708: Add Raspberry Pi TV HAT Device Tree Support
+Subject: [PATCH 139/171] BCM2708: Add Raspberry Pi TV HAT Device Tree Support
 
 This is an EXAMPLE CODE of Raspberry Pi TV HAT device tree overlay.
 Although this is not a part of our release code, it has been used to verify
@@ -133240,10 +133240,10 @@ index 0000000000000000000000000000000000000000..a68f6f793d8efd8b2e2adf9f2fb6426f
 +
 +};
 
-From 094d6cf8471f986844cd45597a9d4a9fa9693eac Mon Sep 17 00:00:00 2001
+From dc7bc73461bbf0d8d69ee7e6a6b6d643c4eef41f Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 27 Apr 2017 16:24:34 +0100
-Subject: [PATCH 140/167] dwc_otg: make nak_holdoff work as intended with empty
+Subject: [PATCH 140/171] dwc_otg: make nak_holdoff work as intended with empty
  queues
 
 If URBs reading from non-periodic split endpoints were dequeued and
@@ -133327,10 +133327,10 @@ index c2dff94e8e6edd22e4427aaa1eac7aad972cb6bd..85a6d431ca54b47dc10573aa72d1ad69
  	} else {
  		uint16_t frame_number = dwc_otg_hcd_get_frame_number(hcd);
 
-From 32a759fb0026ed01f854c15bac764749b3c383a3 Mon Sep 17 00:00:00 2001
+From dbb7c94d4dd9ab1337852c943802b09d8f1b84e9 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Tue, 2 May 2017 16:31:15 +0100
-Subject: [PATCH 141/167] dwc_otg: fix split transaction data toggle handling
+Subject: [PATCH 141/171] dwc_otg: fix split transaction data toggle handling
  around dequeues
 
 See https://github.com/raspberrypi/linux/issues/1709
@@ -133418,10 +133418,10 @@ index 608e036be2c9484465ab836de70129335d3d2d96..718a1accc0c219a1764ce53d291de6a2
  	}
  	qtd = DWC_CIRCLEQ_FIRST(&hc->qh->qtd_list);
 
-From b0e211d51b97bb0b0c46f1e0cf567699914da16c Mon Sep 17 00:00:00 2001
+From 87dbc1dc00d5e87332f5e811cdce6fe542a2ff1a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 2 May 2017 16:36:05 +0100
-Subject: [PATCH 142/167] vcsm: Treat EBUSY as success rather than SIGBUS
+Subject: [PATCH 142/171] vcsm: Treat EBUSY as success rather than SIGBUS
 
 Currently if two cores access the same page concurrently one will return VM_FAULT_NOPAGE
 and the other VM_FAULT_SIGBUS crashing the user code.
@@ -133459,10 +133459,10 @@ index fd71d9fbb400d71bb8cfb8672080e7c3053e3ae9..fd2ca788dcd56b1702454d71b7bedd42
  	}
  }
 
-From 65f6bd67e61eec92f97ca354f8462c9880389d89 Mon Sep 17 00:00:00 2001
+From 5a03196dc49290693a4155ac5814e733d93ab513 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 4 May 2017 12:58:11 +0100
-Subject: [PATCH 143/167] fiq_fsm: Use correct states when starting isoc OUT
+Subject: [PATCH 143/171] fiq_fsm: Use correct states when starting isoc OUT
  transfers
 
 In fiq_fsm_start_next_periodic() if an isochronous OUT transfer
@@ -133499,10 +133499,10 @@ index 9304279592cb5b388086ef91cb52f1e9f94868ce..208252645c09d1d17bf07673989f91b7
  				break;
  			}
 
-From c0abcd3fb304c30294706b422319861e258f7afd Mon Sep 17 00:00:00 2001
+From 481f3e02b0ebdc2ab24a63e0bf237925693ea99c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 4 May 2017 17:38:22 +0100
-Subject: [PATCH 144/167] bcm2708_fb: Avoid firmware mbox call in vc_mem_copy
+Subject: [PATCH 144/171] bcm2708_fb: Avoid firmware mbox call in vc_mem_copy
 
 If firmware has locked up it is useful to get vcdbg log out without a firmware mbox response.
 Issue the mbox call at probe time instead.
@@ -133566,10 +133566,10 @@ index 53c5a0bdadb4be9251affdabed66305842a08e72..612293cf9f1bd93ad2f2aefdd7ca0f5e
  	if (ret == 0) {
  		platform_set_drvdata(dev, fb);
 
-From 03ccda56eddbd9501265ea55c1c955d313f4bd7b Mon Sep 17 00:00:00 2001
+From 873b13316af82fbb66b438fb7eb3185c025f9c44 Mon Sep 17 00:00:00 2001
 From: Nisar Sayed <Nisar.Sayed@microchip.com>
 Date: Tue, 9 May 2017 18:51:42 +0100
-Subject: [PATCH 145/167] According to RFC 2460, IPv6 UDP calculated checksum
+Subject: [PATCH 145/171] According to RFC 2460, IPv6 UDP calculated checksum
  yields a result of zero must be changed to 0xffff, however this feature is
  not supported by smsc95xx family hence enable csum offload only for IPv4
  TCP/UDP packets.
@@ -133614,10 +133614,10 @@ index f6661e388f6e801c1b88e48a3b71407bd70cf56e..b84e98508b5d97165b68dfc30240950e
  	smsc95xx_init_mac_address(dev);
  
 
-From 6a464629fd4e7d854ab3e66169a705944d2f0e97 Mon Sep 17 00:00:00 2001
+From 882c018a70a9d89d637c85d57430edef3f225b4f Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
-Subject: [PATCH 146/167] drm/vc4: Add a mode for using the closed firmware for
+Subject: [PATCH 146/171] drm/vc4: Add a mode for using the closed firmware for
  display.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -134384,10 +134384,10 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From 048a522722c63fe014dcce9a1906fa95b7ba9437 Mon Sep 17 00:00:00 2001
+From 597b78668965869b9745d1537028b462a5984d87 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:09:18 -0800
-Subject: [PATCH 147/167] drm/vc4: Name the primary and cursor planes in fkms.
+Subject: [PATCH 147/171] drm/vc4: Name the primary and cursor planes in fkms.
 
 This makes debugging nicer, compared to trying to remember what the
 IDs are.
@@ -134411,10 +134411,10 @@ index d18a1dae51a2275846c9826b5bf1ba57ae97b55c..e49ce68b607a7ffc2329e3235362f3bc
  	if (type == DRM_PLANE_TYPE_PRIMARY) {
  		vc4_plane->fbinfo =
 
-From f8be62c1ec31a841a39536d0189f15ca40ae37b6 Mon Sep 17 00:00:00 2001
+From 1d674cb73d219d7873c3946e3e10d7e8563f4f01 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:10:09 -0800
-Subject: [PATCH 148/167] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
+Subject: [PATCH 148/171] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
  fkms.
 
 Trying to debug weston on fkms involved figuring out what calls I was
@@ -134484,10 +134484,10 @@ index e49ce68b607a7ffc2329e3235362f3bc21ed5cbb..dbf065677202fbebf8e3a0cffbe880aa
  				    RPI_FIRMWARE_SET_CURSOR_STATE,
  				    &packet_state,
 
-From 5d0e3e63c06ec2294eb1ba586141a44fd9cbc268 Mon Sep 17 00:00:00 2001
+From f136b40e94b3a0b029e72e8f4a61f240ac3a12c6 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 2 Feb 2017 09:42:18 -0800
-Subject: [PATCH 149/167] drm/vc4: Fix sending of page flip completion events
+Subject: [PATCH 149/171] drm/vc4: Fix sending of page flip completion events
  in FKMS mode.
 
 In the rewrite of vc4_crtc.c for fkms, I dropped the part of the
@@ -134529,10 +134529,10 @@ index dbf065677202fbebf8e3a0cffbe880aa42daef3f..da818a207bfa639b8cea48d94bcf4566
  
  static void vc4_crtc_handle_page_flip(struct vc4_crtc *vc4_crtc)
 
-From b7a7588c154acfdb7b13ba1c1a18de1d12c4e3c7 Mon Sep 17 00:00:00 2001
+From 6386e2cc0770fc30ebe631e5fe78a387791c227c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 10 May 2017 21:39:45 +0100
-Subject: [PATCH 150/167] squash: vc4_firmware_kms fixups
+Subject: [PATCH 150/171] squash: vc4_firmware_kms fixups
 
 ---
  drivers/gpu/drm/vc4/vc4_crtc.c         | 2 ++
@@ -134582,10 +134582,10 @@ index da818a207bfa639b8cea48d94bcf4566f97db816..35425063cca47a33936c4853f7cc320c
  	vc4_encoder = devm_kzalloc(dev, sizeof(*vc4_encoder), GFP_KERNEL);
  	if (!vc4_encoder)
 
-From 1f72706946d43c4d89513c3a6442e9cfe5260cbc Mon Sep 17 00:00:00 2001
+From 0e396fc2b7dc7ea6f4404783dfbe65a770d1eb29 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 18 Apr 2017 21:43:46 +0100
-Subject: [PATCH 151/167] vc4_fkms: Apply firmware overscan offset to hardware
+Subject: [PATCH 151/171] vc4_fkms: Apply firmware overscan offset to hardware
  cursor
 
 ---
@@ -134642,10 +134642,10 @@ index 35425063cca47a33936c4853f7cc320c3630fdb2..ca03b85f27d8c0966acd977cba9c758d
  
  	return 0;
 
-From 2ec3e4cea1750aede2e4d2cec17ad9bc21e3c650 Mon Sep 17 00:00:00 2001
+From 0fceaad5762e6023035ecb323380fd003ab53174 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 11 May 2017 16:58:16 +0100
-Subject: [PATCH 152/167] BCM270X_DT: Tidy up mmc, sdhost, sdio overlays
+Subject: [PATCH 152/171] BCM270X_DT: Tidy up mmc, sdhost, sdio overlays
 
 The mmc, sdhost, sdio and sdio-1bit overlays had a few
 anachronisms and oddities which were overdue for fixing.
@@ -134754,10 +134754,10 @@ index 398bd812c716c9e472fbac5aba4fe882114c65d1..215d5e3e8a8ca4363457fed1f7425427
  			};
  		};
 
-From a18a3e0611a2fe8b9b1ac177edab8c4ce85def1e Mon Sep 17 00:00:00 2001
+From 6548e104a4224e41e29b22cb89932fd413926675 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 12 May 2017 12:24:00 +0100
-Subject: [PATCH 153/167] dwc_otg: fix several potential crash sources
+Subject: [PATCH 153/171] dwc_otg: fix several potential crash sources
 
 On root port disconnect events, the host driver state is cleared and
 in-progress host channels are forcibly stopped. This doesn't play
@@ -134953,10 +134953,10 @@ index 718a1accc0c219a1764ce53d291de6a2b6f93608..cf23baaa388562b5843be4cfa6c206cb
  		release_channel(hcd, hc, qtd, DWC_OTG_HC_XFER_URB_COMPLETE);
  		break;
 
-From 761462fbf1ebd37d7b581aa20fd24bb4aff6589b Mon Sep 17 00:00:00 2001
+From 80bb1c61832795e116abcda1b4c93125ce13fdfa Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 15 May 2017 14:27:48 +0100
-Subject: [PATCH 154/167] dwc_otg: delete hcd->channel_lock
+Subject: [PATCH 154/171] dwc_otg: delete hcd->channel_lock
 
 The lock serves no purpose as it is only held while the HCD spinlock
 is already being held.
@@ -135108,10 +135108,10 @@ index cf23baaa388562b5843be4cfa6c206cbdc4e780d..a4355afc77b68718fdaba6c5d4be257d
  
  	/* Try to queue more transfers now that there's a free channel. */
 
-From 4694034104e5542406a128cc6ef058ac95b54958 Mon Sep 17 00:00:00 2001
+From 523848c3700eafdb7ec8b82457f7308665d299e7 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 15 May 2017 14:51:42 +0100
-Subject: [PATCH 155/167] dwc_otg: remove unnecessary dma-mode channel halts on
+Subject: [PATCH 155/171] dwc_otg: remove unnecessary dma-mode channel halts on
  disconnect interrupt
 
 Host channels are already halted in kill_urbs_in_qh_list() with the
@@ -135179,10 +135179,10 @@ index 5ec991624c7865901b22ea01b9f2c58c8535ecfd..a2dc6337836b2719f4c954edeeb2a713
  
  	if(fiq_enable) {
 
-From 8cb36e1754cfda4fd4f2000a17e8a246bddfd8ca Mon Sep 17 00:00:00 2001
+From 297eb7a2f5757418ec39b04aa5791bfdd714c971 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 15 May 2017 16:40:05 +0100
-Subject: [PATCH 156/167] config: Add CONFIG_TOUCHSCREEN_GOODIX
+Subject: [PATCH 156/171] config: Add CONFIG_TOUCHSCREEN_GOODIX
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135214,10 +135214,10 @@ index db6589288b6abd6b76b934de07e8976456e14e61..88072e3b55eb230be44f6d23012428ed
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From d32b0b40b5d6758592ceb154da1f4d869927862c Mon Sep 17 00:00:00 2001
+From b1f660b2c014bb5a77cbefe4ffbae5d88d57abc4 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 18 May 2017 11:40:43 +0100
-Subject: [PATCH 157/167] config: Add FB_TFT_ST7789V module
+Subject: [PATCH 157/171] config: Add FB_TFT_ST7789V module
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135249,10 +135249,10 @@ index 88072e3b55eb230be44f6d23012428eda3de3453..65e3676b48ab0c0f54375ecf875fc255
  CONFIG_FB_TFT_TLS8204=m
  CONFIG_FB_TFT_UC1701=m
 
-From d805fb1553b8ba6168699a617a5acac24ecbe58f Mon Sep 17 00:00:00 2001
+From 6505b60bf9601733aed7184a0205a966b3ededb2 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 15:58:00 +0100
-Subject: [PATCH 158/167] config: Add CONFIG_TOUCHSCREEN_EDT_FT5X06
+Subject: [PATCH 158/171] config: Add CONFIG_TOUCHSCREEN_EDT_FT5X06
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135284,10 +135284,10 @@ index 65e3676b48ab0c0f54375ecf875fc2552c457e09..7381eeba83ecd4a2c956ab2093ece4f8
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From f4e79e5ba3ce4974a4db3697f7c855fc93e250ee Mon Sep 17 00:00:00 2001
+From 8702d28309ec581a0e6ec270e1020c288dce6a4a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 19:34:52 +0100
-Subject: [PATCH 159/167] config: Add CONFIG_I2C_ROBOTFUZZ_OSIF
+Subject: [PATCH 159/171] config: Add CONFIG_I2C_ROBOTFUZZ_OSIF
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135319,10 +135319,10 @@ index 7381eeba83ecd4a2c956ab2093ece4f8a57c6ea4..35dc0b5084256f2ae755703edc3eb67c
  CONFIG_SPI_BCM2835=m
  CONFIG_SPI_BCM2835AUX=m
 
-From 809ab8b48d77eb825b0881f5df249fd348054cad Mon Sep 17 00:00:00 2001
+From 9a5ba71c617b2339b9d3a7cf2a8dcdb9220d993e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 26 Apr 2017 17:28:47 +0100
-Subject: [PATCH 160/167] clk: bcm2835: Limit PCM clock to OSC and PLLD_PER
+Subject: [PATCH 160/171] clk: bcm2835: Limit PCM clock to OSC and PLLD_PER
 
 It is unwise to use sources other than the oscillator and PLLD_PER for
 the PCM peripheral (and perhaps others - TBD) because their rate can
@@ -135367,10 +135367,10 @@ index fe3298b54cdfb96bd90fb4f39e13921d2e1d4356..c24b4defb2b046e4ecdc109befc2b224
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
  		.name = "pwm",
 
-From a385a1e7109c0760f732d784bc85a972aa943d20 Mon Sep 17 00:00:00 2001
+From eb91038876e5b8ea21fe5c722a53c90b84fd669c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 22 May 2017 13:56:41 +0100
-Subject: [PATCH 161/167] clk: bcm2835: Minimise clock jitter for PCM clock
+Subject: [PATCH 161/171] clk: bcm2835: Minimise clock jitter for PCM clock
 
 Fractional clock dividers generate accurate average frequencies but
 with jitter, particularly when the integer divisor is small.
@@ -135495,10 +135495,10 @@ index c24b4defb2b046e4ecdc109befc2b22497060647..db3ba74acf78f4dfec0d2206b58bc7c3
  		.tcnt_mux = 23),
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
 
-From 4377d65420d8750356067c02c434cca7b9f59d7c Mon Sep 17 00:00:00 2001
+From 25c08cb6f790a25985f14f46292cacc451793ae1 Mon Sep 17 00:00:00 2001
 From: Bilal Amarni <bamarni@users.noreply.github.com>
 Date: Wed, 24 May 2017 10:52:50 +0200
-Subject: [PATCH 162/167] [ARM64] enable drivers for GPIO expander and vcio
+Subject: [PATCH 162/171] [ARM64] enable drivers for GPIO expander and vcio
 
 ---
  arch/arm64/configs/bcmrpi3_defconfig | 3 +++
@@ -135526,10 +135526,10 @@ index 4d85c231c5ea0244e1b05fb4a5e3c8fd3e651ddf..9dcb58a519d041fadae99c81a7bda621
  CONFIG_GPIO_ARIZONA=m
  CONFIG_GPIO_STMPE=y
 
-From 15373a5ae4e9d17516073b3a94e36f0acf9179f4 Mon Sep 17 00:00:00 2001
+From 7fcb73309c8da7bdffc0da81703820274250da94 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 25 May 2017 16:04:53 +0100
-Subject: [PATCH 163/167] dwc_otg: make periodic scheduling behave properly for
+Subject: [PATCH 163/171] dwc_otg: make periodic scheduling behave properly for
  FS buses
 
 If the root port is in full-speed mode, transfer times at 12mbit/s
@@ -135700,10 +135700,10 @@ index 85a6d431ca54b47dc10573aa72d1ad69d06f2e36..4b1dd9de99e9e08b2e006fb5f8a7ef92
  	status = check_max_xfer_size(hcd, qh);
  	if (status) {
 
-From 0719f747334a2195b072413a6c5f7a8be9449d69 Mon Sep 17 00:00:00 2001
+From 4201ae911e3fc243ced0d648ab9f3e8d2c287b9b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 19 May 2017 16:07:23 +0100
-Subject: [PATCH 164/167] serial: 8250: Add CAP_MINI, set for bcm2835aux
+Subject: [PATCH 164/171] serial: 8250: Add CAP_MINI, set for bcm2835aux
 
 commit d087e7a991f1f61ee2c07db1be7c5cc2aa373f5d upstream.
 
@@ -135776,10 +135776,10 @@ index 579706d36f5c77382cc289d55c2e6290143d6b1d..27e4a15fbe009e45270b5eaf3698bcfd
  
  	baud = serial8250_get_baud_rate(port, termios, old);
 
-From c2f38a410bc7565480e863c90e34a4d50a0dacd3 Mon Sep 17 00:00:00 2001
+From afb451150986c1b7854f526fd919043eb01134b7 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 26 May 2017 12:50:31 +0100
-Subject: [PATCH 165/167] dwc_otg: fiq_fsm: Make isochronous compatibility
+Subject: [PATCH 165/171] dwc_otg: fiq_fsm: Make isochronous compatibility
  checks work properly
 
 Get rid of the spammy printk and local pointer mangling.
@@ -135843,10 +135843,10 @@ index 38bf5fc792d32352f9e208e0e90f968599b9bc31..71834cf365e67d7ad995bba7869216c4
  			return 1;
  		}
 
-From d37e96e634d278491534a971c7f2fbd168093e3e Mon Sep 17 00:00:00 2001
+From 14df180772a0bef3633aadd589781d2e37707398 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Jun 2017 13:05:43 +0100
-Subject: [PATCH 166/167] config: Add CONFIG_CAN_GS_USB
+Subject: [PATCH 166/171] config: Add CONFIG_CAN_GS_USB
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135878,10 +135878,10 @@ index 35dc0b5084256f2ae755703edc3eb67cab0759ec..42163e2c0b5d5666d49793ac4e074d22
  CONFIG_IRLAN=m
  CONFIG_IRNET=m
 
-From 389a9e2b2099f8fc61c87e88270fe0297f9d60d0 Mon Sep 17 00:00:00 2001
+From 04274e60c3a1e4ecd900a6a9fc1627dfc5738ed1 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 12 Jun 2017 16:10:03 +0100
-Subject: [PATCH 167/167] dwc_otg: add module parameter int_ep_interval_min
+Subject: [PATCH 167/171] dwc_otg: add module parameter int_ep_interval_min
 
 Add a module parameter (defaulting to ignored) that clamps the polling rate
 of high-speed Interrupt endpoints to a minimum microframe interval.
@@ -135962,3 +135962,378 @@ index 4b1dd9de99e9e08b2e006fb5f8a7ef92f20c2553..fe8e8f841f03660c2ad49ab8e66193be
  	}
  
  	DWC_DEBUGPL(DBG_HCD, "DWC OTG HCD QH Initialized\n");
+
+From ba67d8bc9e08c0ab6c262472ce7173285fbead81 Mon Sep 17 00:00:00 2001
+From: P33M <p33m@github.com>
+Date: Tue, 20 Jun 2017 13:44:01 +0100
+Subject: [PATCH 168/171] dwc_otg: fiq_fsm: Add non-periodic TT exclusivity
+ constraints
+
+Certain hub types do not discriminate between pipe direction (IN or OUT)
+when considering non-periodic transfers. Therefore these hubs get confused
+if multiple transfers are issued in different directions with the same
+device address and endpoint number.
+
+Constrain queuing non-periodic split transactions so they are performed
+serially in such cases.
+
+Related: https://github.com/raspberrypi/linux/issues/2024
+---
+ drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c | 32 ++++++++++++++++++
+ drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h |  2 ++
+ drivers/usb/host/dwc_otg/dwc_otg_hcd.c     | 53 ++++++++++++++++++++++++++++--
+ 3 files changed, 85 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
+index 208252645c09d1d17bf07673989f91b7f4b3ef7a..0163e9cf620ba58df36a872b82cea92734baada6 100644
+--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
++++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
+@@ -191,6 +191,32 @@ static void notrace fiq_fsm_setup_csplit(struct fiq_state *st, int n)
+ 	mb();
+ }
+ 
++/**
++ * fiq_fsm_restart_np_pending() - Restart a single non-periodic contended transfer
++ * @st: Pointer to the channel's state
++ * @num_channels: Total number of host channels
++ * @orig_channel: Channel index of completed transfer
++ *
++ * In the case where an IN and OUT transfer are simultaneously scheduled to the
++ * same device/EP, inadequate hub implementations will misbehave. Once the first
++ * transfer is complete, a pending non-periodic split can then be issued.
++ */
++static void notrace fiq_fsm_restart_np_pending(struct fiq_state *st, int num_channels, int orig_channel)
++{
++	int i;
++	int dev_addr = st->channel[orig_channel].hcchar_copy.b.devaddr;
++	int ep_num = st->channel[orig_channel].hcchar_copy.b.epnum;
++	for (i = 0; i < num_channels; i++) {
++		if (st->channel[i].fsm == FIQ_NP_SSPLIT_PENDING &&
++			st->channel[i].hcchar_copy.b.devaddr == dev_addr &&
++			st->channel[i].hcchar_copy.b.epnum == ep_num) {
++			st->channel[i].fsm = FIQ_NP_SSPLIT_STARTED;
++			fiq_fsm_restart_channel(st, i, 0);
++			break;
++		}
++	}
++}
++
+ static inline int notrace fiq_get_xfer_len(struct fiq_state *st, int n)
+ {
+ 	/* The xfersize register is a bit wonky. For IN transfers, it decrements by the packet size. */
+@@ -870,6 +896,9 @@ static int notrace noinline fiq_fsm_do_hcintr(struct fiq_state *state, int num_c
+ 				st->fsm = FIQ_NP_SPLIT_HS_ABORTED;
+ 			}
+ 		}
++		if (st->fsm != FIQ_NP_IN_CSPLIT_RETRY) {
++			fiq_fsm_restart_np_pending(state, num_channels, n);
++		}
+ 		break;
+ 
+ 	case FIQ_NP_OUT_CSPLIT_RETRY:
+@@ -919,6 +948,9 @@ static int notrace noinline fiq_fsm_do_hcintr(struct fiq_state *state, int num_c
+ 				st->fsm = FIQ_NP_SPLIT_HS_ABORTED;
+ 			}
+ 		}
++		if (st->fsm != FIQ_NP_OUT_CSPLIT_RETRY) {
++			fiq_fsm_restart_np_pending(state, num_channels, n);
++		}
+ 		break;
+ 
+ 	/* Periodic split states (except isoc out) */
+diff --git a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
+index 0a1ddf3f89f45ca75b8880722fbc22cbdc9f4a2f..ed088f34f210e9a337ab9b80fff0cf9e9b0241ea 100644
+--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
++++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
+@@ -178,6 +178,8 @@ enum fiq_fsm_state {
+ 	/* Nonperiodic state groups */
+ 	FIQ_NP_SSPLIT_STARTED = 1,
+ 	FIQ_NP_SSPLIT_RETRY = 2,
++	/* TT contention - working around hub bugs */
++	FIQ_NP_SSPLIT_PENDING = 33,
+ 	FIQ_NP_OUT_CSPLIT_RETRY = 3,
+ 	FIQ_NP_IN_CSPLIT_RETRY = 4,
+ 	FIQ_NP_SPLIT_DONE = 5,
+diff --git a/drivers/usb/host/dwc_otg/dwc_otg_hcd.c b/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
+index 71834cf365e67d7ad995bba7869216c4091c3a74..7710370b30363e3170bf9bf522597c5f41dfb908 100644
+--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
++++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
+@@ -1572,6 +1572,45 @@ int fiq_fsm_setup_periodic_dma(dwc_otg_hcd_t *hcd, struct fiq_channel_state *st,
+ 	}
+ }
+ 
++/**
++ * fiq_fsm_np_tt_contended() - Avoid performing contended non-periodic transfers
++ * @hcd: Pointer to the dwc_otg_hcd struct
++ * @qh: Pointer to the endpoint's queue head
++ *
++ * Certain hub chips don't differentiate between IN and OUT non-periodic pipes
++ * with the same endpoint number. If transfers get completed out of order
++ * (disregarding the direction token) then the hub can lock up
++ * or return erroneous responses.
++ *
++ * Returns 1 if initiating the transfer would cause contention, 0 otherwise.
++ */
++int fiq_fsm_np_tt_contended(dwc_otg_hcd_t *hcd, dwc_otg_qh_t *qh)
++{
++	int i;
++	struct fiq_channel_state *st;
++	int dev_addr = qh->channel->dev_addr;
++	int ep_num = qh->channel->ep_num;
++	for (i = 0; i < hcd->core_if->core_params->host_channels; i++) {
++		if (i == qh->channel->hc_num)
++			continue;
++		st = &hcd->fiq_state->channel[i];
++		switch (st->fsm) {
++		case FIQ_NP_SSPLIT_STARTED:
++		case FIQ_NP_SSPLIT_RETRY:
++		case FIQ_NP_SSPLIT_PENDING:
++		case FIQ_NP_OUT_CSPLIT_RETRY:
++		case FIQ_NP_IN_CSPLIT_RETRY:
++			if (st->hcchar_copy.b.devaddr == dev_addr &&
++				st->hcchar_copy.b.epnum == ep_num)
++				return 1;
++			break;
++		default:
++			break;
++		}
++	}
++	return 0;
++}
++
+ /*
+  * Pushing a periodic request into the queue near the EOF1 point
+  * in a microframe causes erroneous behaviour (frmovrun) interrupt.
+@@ -1894,7 +1933,12 @@ int fiq_fsm_queue_split_transaction(dwc_otg_hcd_t *hcd, dwc_otg_qh_t *qh)
+ 	switch (hc->ep_type) {
+ 		case UE_CONTROL:
+ 		case UE_BULK:
+-			st->fsm = FIQ_NP_SSPLIT_STARTED;
++			if (fiq_fsm_np_tt_contended(hcd, qh)) {
++				st->fsm = FIQ_NP_SSPLIT_PENDING;
++				start_immediate = 0;
++			} else {
++				st->fsm = FIQ_NP_SSPLIT_STARTED;
++			}
+ 			break;
+ 		case UE_ISOCHRONOUS:
+ 			if (hc->ep_is_in) {
+@@ -1918,7 +1962,12 @@ int fiq_fsm_queue_split_transaction(dwc_otg_hcd_t *hcd, dwc_otg_qh_t *qh)
+ 			break;
+ 		case UE_INTERRUPT:
+ 			if (fiq_fsm_mask & 0x8) {
+-				st->fsm = FIQ_NP_SSPLIT_STARTED;
++				if (fiq_fsm_np_tt_contended(hcd, qh)) {
++					st->fsm = FIQ_NP_SSPLIT_PENDING;
++					start_immediate = 0;
++				} else {
++					st->fsm = FIQ_NP_SSPLIT_STARTED;
++				}
+ 			} else if (start_immediate) {
+ 					st->fsm = FIQ_PER_SSPLIT_STARTED;
+ 			} else {
+
+From a21e464b62fba11fd1b4950adccae3fc9e8a4b83 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Wed, 21 Jun 2017 17:19:04 +0100
+Subject: [PATCH 169/171] serial: 8250: Fix THRE flag usage for CAP_MINI
+
+The BCM2835 MINI UART has non-standard THRE semantics. Conventionally
+the bit means that the FIFO is empty (although there may still be a
+byte in the transmit register), but on 2835 it indicates that the FIFO
+is not empty. This causes interrupts after every byte is transmitted,
+with the FIFO providing some interrupt latency tolerance.
+
+A consequence of this difference is that the usual strategy of writing
+multiple bytes into the TX FIFO after checking THRE once is unsafe.
+In the worst case of 7 bytes in the FIFO, writing 8 bytes loses all
+but the first since by then the FIFO is full.
+
+There is an HFIFO ("Hidden FIFO") bit which is almost what is needed,
+but it only adds more bytes while both THRE and TEMT are set, i.e.
+when the TX side is completely idle. This is unnecessarily pessimistic.
+
+Add a new special case, predicated on CAP_MINI, that loops until THRE
+is no longer set. With this change, the FIFO fills quickly but
+subsequent writes are paced by the transmission rate.
+
+See: https://github.com/raspberrypi/linux/issues/1855
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ drivers/tty/serial/8250/8250_port.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
+index 27e4a15fbe009e45270b5eaf3698bcfd0baaa1e3..75fcdfdf86df13564247885ade1fd9f04b0039eb 100644
+--- a/drivers/tty/serial/8250/8250_port.c
++++ b/drivers/tty/serial/8250/8250_port.c
+@@ -1764,6 +1764,10 @@ void serial8250_tx_chars(struct uart_8250_port *up)
+ 		if ((up->capabilities & UART_CAP_HFIFO) &&
+ 		    (serial_in(up, UART_LSR) & BOTH_EMPTY) != BOTH_EMPTY)
+ 			break;
++		/* The BCM2835 MINI UART THRE bit is really a not-full bit. */
++		if ((up->capabilities & UART_CAP_MINI) &&
++		    !(serial_in(up, UART_LSR) & UART_LSR_THRE))
++			break;
+ 	} while (--count > 0);
+ 
+ 	if (uart_circ_chars_pending(xmit) < WAKEUP_CHARS)
+
+From af9eed0ca99afcc926d18290afb6a42cbe81bc72 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Fri, 26 May 2017 13:03:41 +0100
+Subject: [PATCH 170/171] BCM270X_DT: Add midi-uart1 overlay
+
+Add a scaler to the ttyS0 clock so that requesting 38400 baud results
+in an approximately 31250 baud signal. This is analagous to
+midi-uart0, except for ttyS0, which may be useful on Pi3 and also
+may avoid an issue with ttyAMA0 failing to synchronise to an active
+data stream.
+
+See: https://www.raspberrypi.org/forums/viewtopic.php?f=107&t=183860
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ arch/arm/boot/dts/overlays/Makefile               |  1 +
+ arch/arm/boot/dts/overlays/README                 |  7 ++++
+ arch/arm/boot/dts/overlays/midi-uart1-overlay.dts | 43 +++++++++++++++++++++++
+ 3 files changed, 51 insertions(+)
+ create mode 100644 arch/arm/boot/dts/overlays/midi-uart1-overlay.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index e2f66a55dc5afe13d690c2c17827054ac94b7168..e0ff5793f124fce73732e175bfca424f0a97b632 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -56,6 +56,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	mcp2515-can1.dtbo \
+ 	mcp3008.dtbo \
+ 	midi-uart0.dtbo \
++	midi-uart1.dtbo \
+ 	mmc.dtbo \
+ 	mz61581.dtbo \
+ 	pi3-act-led.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/README b/arch/arm/boot/dts/overlays/README
+index e2a803e5180cf78d67b6723cfd2f6d3b2b54e53b..ec9e7b1941678796facf625b3770c20ed0b15b25 100644
+--- a/arch/arm/boot/dts/overlays/README
++++ b/arch/arm/boot/dts/overlays/README
+@@ -864,6 +864,13 @@ Load:   dtoverlay=midi-uart0
+ Params: <None>
+ 
+ 
++Name:   midi-uart1
++Info:   Configures UART1 (ttyS0) so that a requested 38.4kbaud actually gets
++        31.25kbaud, the frequency required for MIDI
++Load:   dtoverlay=midi-uart1
++Params: <None>
++
++
+ Name:   mmc
+ Info:   Selects the bcm2835-mmc SD/MMC driver, optionally with overclock
+ Load:   dtoverlay=mmc,<param>=<val>
+diff --git a/arch/arm/boot/dts/overlays/midi-uart1-overlay.dts b/arch/arm/boot/dts/overlays/midi-uart1-overlay.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..e0bc410acbff3a7a175dd5d53b3ab0d0802e8239
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/midi-uart1-overlay.dts
+@@ -0,0 +1,43 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/clock/bcm2835-aux.h>
++
++/*
++ * Fake a higher clock rate to get a larger divisor, and thereby a lower
++ * baudrate. The real clock is 48MHz, which we scale so that requesting
++ * 38.4kHz results in an actual 31.25kHz.
++ *
++ *   48000000*38400/31250 = 58982400
++ */
++
++/{
++	compatible = "brcm,bcm2835";
++
++	fragment@0 {
++		target-path = "/clocks";
++		__overlay__ {
++			midi_clk: clock@5 {
++				compatible = "fixed-factor-clock";
++				#clock-cells = <0>;
++				clocks = <&aux BCM2835_AUX_CLOCK_UART>;
++				clock-mult = <38400>;
++				clock-div  = <31250>;
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&uart1>;
++		__overlay__ {
++			clocks = <&midi_clk>;
++		};
++	};
++
++	fragment@2 {
++		target = <&aux>;
++		__overlay__ {
++			clock-output-names = "aux_uart", "aux_spi1", "aux_spi2";
++		};
++	};
++};
+
+From 6d8363ed357948a0a218871f5d5a0d9fe37f238f Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Sat, 20 May 2017 22:10:14 +0100
+Subject: [PATCH 171/171] overlays: README: remove vestigial SDIO parameters
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ arch/arm/boot/dts/overlays/README | 24 ++----------------------
+ 1 file changed, 2 insertions(+), 22 deletions(-)
+
+diff --git a/arch/arm/boot/dts/overlays/README b/arch/arm/boot/dts/overlays/README
+index ec9e7b1941678796facf625b3770c20ed0b15b25..499cd1920fd373702cfbc9f6e0fcaebca8a47cfc 100644
+--- a/arch/arm/boot/dts/overlays/README
++++ b/arch/arm/boot/dts/overlays/README
+@@ -1203,19 +1203,9 @@ Name:   sdio
+ Info:   Selects the bcm2835-sdhost SD/MMC driver, optionally with overclock,
+         and enables SDIO via GPIOs 22-27.
+ Load:   dtoverlay=sdio,<param>=<val>
+-Params: overclock_50            SD Clock (in MHz) to use when the MMC framework
+-                                requests 50MHz
+-
+-        sdio_overclock          SDIO Clock (in MHz) to use when the MMC
++Params: sdio_overclock          SDIO Clock (in MHz) to use when the MMC
+                                 framework requests 50MHz
+ 
+-        force_pio               Disable DMA support (default off)
+-
+-        pio_limit               Number of blocks above which to use DMA
+-                                (default 1)
+-
+-        debug                   Enable debug output (default off)
+-
+         poll_once               Disable SDIO-device polling every second
+                                 (default on: polling once at boot-time)
+ 
+@@ -1226,19 +1216,9 @@ Name:   sdio-1bit
+ Info:   Selects the bcm2835-sdhost SD/MMC driver, optionally with overclock,
+         and enables 1-bit SDIO via GPIOs 22-25.
+ Load:   dtoverlay=sdio-1bit,<param>=<val>
+-Params: overclock_50            SD Clock (in MHz) to use when the MMC framework
+-                                requests 50MHz
+-
+-        sdio_overclock          SDIO Clock (in MHz) to use when the MMC
++Params: sdio_overclock          SDIO Clock (in MHz) to use when the MMC
+                                 framework requests 50MHz
+ 
+-        force_pio               Disable DMA support (default off)
+-
+-        pio_limit               Number of blocks above which to use DMA
+-                                (default 1)
+-
+-        debug                   Enable debug output (default off)
+-
+         poll_once               Disable SDIO-device polling every second
+                                 (default on: polling once at boot-time)
+ 

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,7 +1,7 @@
-From 9f4bcfaf88fb7d7482a0e2e0dc5b2606873e3e72 Mon Sep 17 00:00:00 2001
+From cba37f230efcd867e7ac6b1309793ff5f581cc5f Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
-Subject: [PATCH 001/171] smsx95xx: fix crimes against truesize
+Subject: [PATCH 001/172] smsx95xx: fix crimes against truesize
 
 smsc95xx is adjusting truesize when it shouldn't, and following a recent patch from Eric this is now triggering warnings.
 
@@ -48,10 +48,10 @@ index 5f19fb0f025d9449d0ba20958610e0d1f083f032..ed28f1c3e1d0f2559a62a1c289937944
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From 73eb4f5a44372e7d1301842c685246748304477f Mon Sep 17 00:00:00 2001
+From 2dc4097eaeb9ba3c9f7a514811f5cc79398f5fe6 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
-Subject: [PATCH 002/171] smsc95xx: Experimental: Enable turbo_mode and
+Subject: [PATCH 002/172] smsc95xx: Experimental: Enable turbo_mode and
  packetsize=2560 by default
 
 See: http://forum.kodi.tv/showthread.php?tid=285288
@@ -94,10 +94,10 @@ index ed28f1c3e1d0f2559a62a1c28993794497730c5d..f758e122c65685799d4aeeb1c3e6ca81
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From 9f6d12e8e82fd53c8ce7329f2c538b9afbc6b26a Mon Sep 17 00:00:00 2001
+From 4d8007b449783b04155b896263f742cc54743948 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
-Subject: [PATCH 003/171] Allow mac address to be set in smsc95xx
+Subject: [PATCH 003/172] Allow mac address to be set in smsc95xx
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -193,10 +193,10 @@ index f758e122c65685799d4aeeb1c3e6ca81df0d7980..f6661e388f6e801c1b88e48a3b71407b
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From 90eb28f957697e0d85aa624330c4c2eaed7aeb70 Mon Sep 17 00:00:00 2001
+From 700d38a66aaa4f20af7818a059e7f4cabfa24c86 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
-Subject: [PATCH 004/171] Protect __release_resource against resources without
+Subject: [PATCH 004/172] Protect __release_resource against resources without
  parents
 
 Without this patch, removing a device tree overlay can crash here.
@@ -224,10 +224,10 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From 4d7d99990bbf9f06394ea214b19b25c8466e6671 Mon Sep 17 00:00:00 2001
+From 102ee6f78e7aa38ec04c25fc1530e00504334d1b Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
-Subject: [PATCH 005/171] mm: Remove the PFN busy warning
+Subject: [PATCH 005/172] mm: Remove the PFN busy warning
 
 See commit dae803e165a11bc88ca8dbc07a11077caf97bbcb -- the warning is
 expected sometimes when using CMA.  However, that commit still spams
@@ -252,10 +252,10 @@ index a2019fc9d94df3af9cf2c5ce1a476949c6822efc..5e6e1815923f212f5c1b1d1a213b0b12
  		goto done;
  	}
 
-From e852f6820e51a41df5b3c0c1a8fce6b76fae5b64 Mon Sep 17 00:00:00 2001
+From fcfddcbc752d9065ad8c43d0a5881cbe7f906dbd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
-Subject: [PATCH 006/171] irq-bcm2836: Prevent spurious interrupts, and trap
+Subject: [PATCH 006/172] irq-bcm2836: Prevent spurious interrupts, and trap
  them early
 
 The old arch-specific IRQ macros included a dsb to ensure the
@@ -282,10 +282,10 @@ index e7463e3c08143acae3e8cc5682f918c6a0b07ebd..a8db33b50ad9ff83d284fa54fe4d3b65
  #endif
  	} else if (stat) {
 
-From 383730cb01a4413436800649cfd080639cd23e17 Mon Sep 17 00:00:00 2001
+From b716b6ffd6eca8049f6547df1bb5b9745ea51193 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:33:30 +0000
-Subject: [PATCH 007/171] irq-bcm2836: Avoid "Invalid trigger warning"
+Subject: [PATCH 007/172] irq-bcm2836: Avoid "Invalid trigger warning"
 
 Initialise the level for each IRQ to avoid a warning from the
 arm arch timer code.
@@ -309,10 +309,10 @@ index a8db33b50ad9ff83d284fa54fe4d3b65f859df0f..c4e151451cf8c8ebde5225515eac2786
  
  static void
 
-From ee7fbe0b1b3cb5c008e07c9b178f1ba7303a49d4 Mon Sep 17 00:00:00 2001
+From 55b7aa30f466410b52b5de588b445fcb8030777b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
-Subject: [PATCH 008/171] irqchip: bcm2835: Add FIQ support
+Subject: [PATCH 008/172] irqchip: bcm2835: Add FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -441,10 +441,10 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From d4f56f6ee1534fa523bf768c8a4d1c10050a97c8 Mon Sep 17 00:00:00 2001
+From 0d922c798dadc5d8ae3648105f21a6baeefcb980 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
-Subject: [PATCH 009/171] irqchip: irq-bcm2835: Add 2836 FIQ support
+Subject: [PATCH 009/172] irqchip: irq-bcm2835: Add 2836 FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -543,10 +543,10 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From a9a2111798d8d75ba8c1b8515dc4fefd4bdea748 Mon Sep 17 00:00:00 2001
+From c519361f3ebec20f711b41fa0f0c42369805b01e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
-Subject: [PATCH 010/171] spidev: Add "spidev" compatible string to silence
+Subject: [PATCH 010/172] spidev: Add "spidev" compatible string to silence
  warning
 
 See: https://github.com/raspberrypi/linux/issues/1054
@@ -567,10 +567,10 @@ index 9e2e099baf8ca5cc6510912a36d4ca03daeb8273..e59640942826db2ea14d0bde0ff5ab22
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 5a1b50c94479bbd68c2bac1479366f8697d50133 Mon Sep 17 00:00:00 2001
+From b9e6762dc65b5d7d0a653c9b0b9c250fa20710b9 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 3 Jan 2017 18:25:01 +0000
-Subject: [PATCH 011/171] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
+Subject: [PATCH 011/172] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
 
 This reverts commit 85ae9e512f437cd09bf61564bdba29ab88bab3e3.
 ---
@@ -864,10 +864,10 @@ index 85d0091128644c446aed878e87769e82c77c3ebf..4f2621272bfd5cbc0d691d2fabe89e2e
  	if (IS_ERR(pc->pctl_dev)) {
  		gpiochip_remove(&pc->gpio_chip);
 
-From 169a3521049fb20f8e11a5fd98b7c1906af9ecc4 Mon Sep 17 00:00:00 2001
+From ba702187e249b8c0675b3581e0dfb33f3def4492 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
-Subject: [PATCH 012/171] pinctrl-bcm2835: Set base to 0 give expected gpio
+Subject: [PATCH 012/172] pinctrl-bcm2835: Set base to 0 give expected gpio
  numbering
 
 Signed-off-by: Noralf Tronnes <notro@tronnes.org>
@@ -889,10 +889,10 @@ index 4f2621272bfd5cbc0d691d2fabe89e2ee428d6db..5b7cb4c415e19f98e25b221ab0ad36b6
  	.can_sleep = false,
  };
 
-From 36d5db9421c98fccacd2f3c8adf45052795f6482 Mon Sep 17 00:00:00 2001
+From be5d6f213e3595bff42a015b70a6053a3954386c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
-Subject: [PATCH 013/171] pinctrl-bcm2835: Only request the interrupts listed
+Subject: [PATCH 013/172] pinctrl-bcm2835: Only request the interrupts listed
  in the DTB
 
 Although the GPIO controller can generate three interrupts (four counting
@@ -919,10 +919,10 @@ index 5b7cb4c415e19f98e25b221ab0ad36b6885dae4c..6351fe7f8e314ac5ebb102dd20847b38
  		pc->irq_data[i].irqgroup = i;
  
 
-From ddc19d645d675519430ff2b2d77b8ea0f83bf3ee Mon Sep 17 00:00:00 2001
+From d7e18cba30297793f22ddeeeda7adbdb2d92281d Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
-Subject: [PATCH 014/171] spi-bcm2835: Support pin groups other than 7-11
+Subject: [PATCH 014/172] spi-bcm2835: Support pin groups other than 7-11
 
 The spi-bcm2835 driver automatically uses GPIO chip-selects due to
 some unreliability of the native ones. In doing so it chooses the
@@ -1003,10 +1003,10 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From a5181c9d51f1cbbdd023a4d6e5451402c060e645 Mon Sep 17 00:00:00 2001
+From 70e2fcaa3ab012133ca158a0d4754f4614efe767 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
-Subject: [PATCH 015/171] spi-bcm2835: Disable forced software CS
+Subject: [PATCH 015/172] spi-bcm2835: Disable forced software CS
 
 Select software CS in bcm2708_common.dtsi, and disable the automatic
 conversion in the driver to allow hardware CS to be re-enabled with an
@@ -1040,10 +1040,10 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From 6be7ee0d758dd9d73779fe0f770a141d92e7b9eb Mon Sep 17 00:00:00 2001
+From e3d3419354f85b19f215b0993d9172f81dc3c035 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
-Subject: [PATCH 016/171] spi-bcm2835: Remove unused code
+Subject: [PATCH 016/172] spi-bcm2835: Remove unused code
 
 ---
  drivers/spi/spi-bcm2835.c | 61 -----------------------------------------------
@@ -1131,10 +1131,10 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From be2af68d09a92abbeeeefee5c2fe55fec3358f4b Mon Sep 17 00:00:00 2001
+From 1a1347be71be4328bf59c65a6cd55aff43e51929 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
-Subject: [PATCH 017/171] ARM: bcm2835: Set Serial number and Revision
+Subject: [PATCH 017/172] ARM: bcm2835: Set Serial number and Revision
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1187,10 +1187,10 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 6afc5e2016e0cb91115f5354a54c7c96611aa317 Mon Sep 17 00:00:00 2001
+From 745a7ff6fea65b6b780daa60e2ef45b1c2564e6e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
-Subject: [PATCH 018/171] dmaengine: bcm2835: Load driver early and support
+Subject: [PATCH 018/172] dmaengine: bcm2835: Load driver early and support
  legacy API
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -1293,10 +1293,10 @@ index 6204cc32d09c5096df8aec304c3c37b3bcb6be44..599c218dc8a73172dd4bd4a058fc8f95
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From e40bd4d0489713ddd54ccd78a6afd9e01cee25e0 Mon Sep 17 00:00:00 2001
+From 2dadc180b9bf8701d235a191417b4158240f01b0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
-Subject: [PATCH 019/171] firmware: Updated mailbox header
+Subject: [PATCH 019/172] firmware: Updated mailbox header
 
 ---
  include/soc/bcm2835/raspberrypi-firmware.h | 9 +++++++++
@@ -1357,10 +1357,10 @@ index cb979ad90401e299344dd5fae38d09c489d8bd58..30fb37fe175df604a738258a2a632bca
  	RPI_FIRMWARE_VCHIQ_INIT =                             0x00048010,
  
 
-From 04eb0cbe52172443643b4b173489ea43efa48bda Mon Sep 17 00:00:00 2001
+From 7504e04d9fef1209e784da04c4bbc51106bcc9c2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
-Subject: [PATCH 020/171] rtc: Add SPI alias for pcf2123 driver
+Subject: [PATCH 020/172] rtc: Add SPI alias for pcf2123 driver
 
 Without this alias, Device Tree won't cause the driver
 to be loaded.
@@ -1380,10 +1380,10 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From fe941bec362a8c4cf04d3fed394b9be7ab9b57c8 Mon Sep 17 00:00:00 2001
+From eaf9c7c12759e84330190ac0a93ce8e5ae44163b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
-Subject: [PATCH 021/171] watchdog: bcm2835: Support setting reboot partition
+Subject: [PATCH 021/172] watchdog: bcm2835: Support setting reboot partition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1485,10 +1485,10 @@ index b339e0e67b4c1275fd4992fea4f1e24c0575b783..26b7177573fac2af1cd4ab5488d2686f
  
  static int bcm2835_wdt_probe(struct platform_device *pdev)
 
-From 06616677a99da49c0cdafa60ca692580433eb61f Mon Sep 17 00:00:00 2001
+From e2198aafb79e38240a2a30dff5553739852a9cf4 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
-Subject: [PATCH 022/171] reboot: Use power off rather than busy spinning when
+Subject: [PATCH 022/172] reboot: Use power off rather than busy spinning when
  halt is requested
 
 ---
@@ -1511,10 +1511,10 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From ac4cff5fc1568c862ac47c4f99cb2d737adad6b1 Mon Sep 17 00:00:00 2001
+From 79a5defcd581e2ccf204fa176edec988e29b0c4b Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
-Subject: [PATCH 023/171] bcm: Make RASPBERRYPI_POWER depend on PM
+Subject: [PATCH 023/172] bcm: Make RASPBERRYPI_POWER depend on PM
 
 ---
  drivers/soc/bcm/Kconfig | 1 +
@@ -1533,10 +1533,10 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 20165bad9a227e1d61b5320cbd51ddfb5966abc1 Mon Sep 17 00:00:00 2001
+From ffb58ee3a7eaa2c088344b17411d84af020cd3c1 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
-Subject: [PATCH 024/171] Register the clocks early during the boot process, so
+Subject: [PATCH 024/172] Register the clocks early during the boot process, so
  that special/critical clocks can get enabled early on in the boot process
  avoiding the risk of disabling a clock, pll_divider or pll when a claiming
  driver fails to install propperly - maybe it needs to defer.
@@ -1581,10 +1581,10 @@ index 02585387061967ac9408e18ac1bce67e9e9414c0..283d2de45e4f29406d01f24ab1cae3f9
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From 52e76525dc86f891740d139cecfc20a05d8c306c Mon Sep 17 00:00:00 2001
+From 221fd24597ec8ba97659ee9d3ce39db77a1b3066 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
-Subject: [PATCH 025/171] bcm2835-rng: Avoid initialising if already enabled
+Subject: [PATCH 025/172] bcm2835-rng: Avoid initialising if already enabled
 
 Avoids the 0x40000 cycles of warmup again if firmware has already used it
 ---
@@ -1610,10 +1610,10 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From 5890a859bb364d879f69c625b395707b7e9cc9c1 Mon Sep 17 00:00:00 2001
+From e1369707aee4eb098a285253f8e293a138cd605c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
-Subject: [PATCH 026/171] kbuild: Ignore dtco targets when filtering symbols
+Subject: [PATCH 026/172] kbuild: Ignore dtco targets when filtering symbols
 
 ---
  scripts/Kbuild.include | 2 +-
@@ -1633,10 +1633,10 @@ index afe3fd3af1e40616857b3e6c425be632c1fa2667..b2bbad417f0c4499a5f49081c8f996b9
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From e89e7387d451185cad49c3d05bd7a786d3dcaf80 Mon Sep 17 00:00:00 2001
+From 846bad9fc71bf6d60c13cf32b0df010bc309bf6c Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
-Subject: [PATCH 027/171] BCM2835_DT: Fix I2S register map
+Subject: [PATCH 027/172] BCM2835_DT: Fix I2S register map
 
 ---
  Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.txt   | 4 ++--
@@ -1674,10 +1674,10 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From 2d5a6632d0a883e0e9124eff13b84ced3c46168a Mon Sep 17 00:00:00 2001
+From b022ddef4dc371f3886d064513e072a068b39024 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
-Subject: [PATCH 028/171] clk-bcm2835: Mark used PLLs and dividers CRITICAL
+Subject: [PATCH 028/172] clk-bcm2835: Mark used PLLs and dividers CRITICAL
 
 The VPU configures and relies on several PLLs and dividers. Mark all
 enabled dividers and their PLLs as CRITICAL to prevent the kernel from
@@ -1705,10 +1705,10 @@ index 283d2de45e4f29406d01f24ab1cae3f9f879234a..85df8c74a309f0b877ef65f1c55b086f
  	divider->data = data;
  
 
-From 9fa6b741e08679f1805028d50e9c38a60b89ee21 Mon Sep 17 00:00:00 2001
+From 79604af2e2d2d0599db57bdfe31c0f43476893e7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
-Subject: [PATCH 029/171] clk-bcm2835: Add claim-clocks property
+Subject: [PATCH 029/172] clk-bcm2835: Add claim-clocks property
 
 The claim-clocks property can be used to prevent PLLs and dividers
 from being marked as critical. It contains a vector of clock IDs,
@@ -1810,10 +1810,10 @@ index 85df8c74a309f0b877ef65f1c55b086f1bb774a1..eec6735505c074c0a76ae647bf0e1bb6
  	       sizeof(cprman_parent_names));
  	of_clk_parent_fill(dev->of_node, cprman->real_parent_names,
 
-From bff9dbfc12561664cff553463303d4ec41bd9dc2 Mon Sep 17 00:00:00 2001
+From 8453d4b710d2c5428354bd6aa8e6e3e48deed5bf Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:06:53 +0000
-Subject: [PATCH 030/171] clk-bcm2835: Correct the prediv logic
+Subject: [PATCH 030/172] clk-bcm2835: Correct the prediv logic
 
 If a clock has the prediv flag set, both the integer and fractional
 parts must be scaled when calculating the resulting frequency.
@@ -1840,10 +1840,10 @@ index eec6735505c074c0a76ae647bf0e1bb68ab3a488..e0d28add45efdf70d1eba590282a3a26
  	return bcm2835_pll_rate_from_divisors(parent_rate, ndiv, fdiv, pdiv);
  }
 
-From c37e021f28098d3d66fd929a8f1bce7deff89676 Mon Sep 17 00:00:00 2001
+From aafd6807e821bd7512e60d567cf5952d5380ce3c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 6 Mar 2017 09:06:18 +0000
-Subject: [PATCH 031/171] clk-bcm2835: Read max core clock from firmware
+Subject: [PATCH 031/172] clk-bcm2835: Read max core clock from firmware
 
 The VPU is responsible for managing the core clock, usually under
 direction from the bcm2835-cpufreq driver but not via the clk-bcm2835
@@ -1958,10 +1958,10 @@ index e0d28add45efdf70d1eba590282a3a2654af328d..39f72da6ba1f6ec6ec41d5dc1bf46344
  	for (i = 0;
  	     !of_property_read_u32_index(pdev->dev.of_node, "claim-clocks",
 
-From dd3213ad2acff725fbf24f9967ea2942ffaca090 Mon Sep 17 00:00:00 2001
+From 7cc5a0f803b064d2fed550b2030e2072536a7695 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:36:44 +0000
-Subject: [PATCH 032/171] sound: Demote deferral errors to INFO level
+Subject: [PATCH 032/172] sound: Demote deferral errors to INFO level
 
 At present there is no mechanism to specify driver load order,
 which can lead to deferrals and repeated retries until successful.
@@ -1996,10 +1996,10 @@ index 98d60f471c5d705d383c5edca4850bd8facdd030..d2da3077fd980c846c1c86697f73c342
  			goto _err_defer;
  		}
 
-From ebf1e68dfa306e6bad06bf9f3365a685c089784a Mon Sep 17 00:00:00 2001
+From 99f6ed1efd99cad3e64cc4a6862ee9e16aa02abb Mon Sep 17 00:00:00 2001
 From: Claggy3 <stephen.maclagan@hotmail.com>
 Date: Sat, 11 Feb 2017 14:00:30 +0000
-Subject: [PATCH 033/171] Update vfpmodule.c
+Subject: [PATCH 033/172] Update vfpmodule.c
 
 Christopher Alexander Tobias Schulze - May 2, 2015, 11:57 a.m.
 This patch fixes a problem with VFP state save and restore related
@@ -2136,10 +2136,10 @@ index a71a48e71fffa8626fe90106815376c44bbe679b..d6c0a5a0a5ae3510db3ace5e3f5d3410
  	/*
  	 * Save the userland NEON/VFP state. Under UP,
 
-From 397e51264a8de9fcad23803dbb7278d66e8eb51d Mon Sep 17 00:00:00 2001
+From 7889e94b155370906965095bafff5070ce00cb00 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 21:13:24 +1100
-Subject: [PATCH 034/171] ASoC: bcm2835_i2s.c: relax the ch2 register setting
+Subject: [PATCH 034/172] ASoC: bcm2835_i2s.c: relax the ch2 register setting
  for 8 channels
 
 This patch allows ch2 registers to be set for 8 channels of audio.
@@ -2160,10 +2160,10 @@ index 6ba20498202ed36906b52096893a88867a79269f..56df7d8a43d0aac055a91b0d24aca8e1
  		format |= BCM2835_I2S_CH1(BCM2835_I2S_CHPOS(ch1pos));
  		format |= BCM2835_I2S_CH2(BCM2835_I2S_CHPOS(ch2pos));
 
-From b9c8b9c7eba40161a98f4fa4fb384ca46009baeb Mon Sep 17 00:00:00 2001
+From ff5fd2722bd82c609ee1e119608862fe4e1f1e6d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
-Subject: [PATCH 035/171] i2c: bcm2835: Add debug support
+Subject: [PATCH 035/172] i2c: bcm2835: Add debug support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -2352,10 +2352,10 @@ index cd07a69e2e9355540442785f95e90823b05c9d10..47167f403cc8329bd811b47c7011c299
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 1a0c9496e02f19a88eee0f470ff2814d8c60904c Mon Sep 17 00:00:00 2001
+From 351b6dfc0c8a7de8a1832b8d9ada59592ce6714b Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
-Subject: [PATCH 036/171] Main bcm2708/bcm2709 linux port
+Subject: [PATCH 036/172] Main bcm2708/bcm2709 linux port
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -2543,10 +2543,10 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 766153167e1130f24ccc5f06deb8f4d9acfc276a Mon Sep 17 00:00:00 2001
+From 9389b85099a6d066ecd540c8b4124d9703bda346 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
-Subject: [PATCH 037/171] Add dwc_otg driver
+Subject: [PATCH 037/172] Add dwc_otg driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -63611,10 +63611,10 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 099f6533cb330282c2e6d154d519cbceafeef381 Mon Sep 17 00:00:00 2001
+From 20dbadf99cf8a4cf36f7fc95e2d18035646f4c63 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 10 May 2017 12:47:46 +0100
-Subject: [PATCH 038/171] dwcotg: Allow to build without FIQ on ARM64
+Subject: [PATCH 038/172] dwcotg: Allow to build without FIQ on ARM64
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -63635,10 +63635,10 @@ index ed0cd59de37e8f47369f86dba751c78933722abc..53aedbe9727ca5c34e46f5cf998f14c7
  	  The Synopsis DWC controller is a dual-role
  	  host/peripheral/OTG ("On The Go") USB controllers.
 
-From 807f842c2901a4aad5197b20221479c4c558a7df Mon Sep 17 00:00:00 2001
+From 6eff19baa84da7dff8b5d94956ffb1daa5ab8269 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
-Subject: [PATCH 039/171] bcm2708 framebuffer driver
+Subject: [PATCH 039/172] bcm2708 framebuffer driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -67097,10 +67097,10 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From 31742a1c0b4e9627d065b79c52aeb37a29a77606 Mon Sep 17 00:00:00 2001
+From d4139c87ae0676d41e2b883b17dd4703a629d7c8 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
-Subject: [PATCH 040/171] dmaengine: Add support for BCM2708
+Subject: [PATCH 040/172] dmaengine: Add support for BCM2708
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -67731,10 +67731,10 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From 51b369b9e39440f61467619c10070b57fb50a2d4 Mon Sep 17 00:00:00 2001
+From 0d7ff352109f3c2b9c6525844ff19f02b1b0978b Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
-Subject: [PATCH 041/171] MMC: added alternative MMC driver
+Subject: [PATCH 041/172] MMC: added alternative MMC driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -69456,10 +69456,10 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From 207aeb3d8efa1b48bcb86cd39e1133532dba7415 Mon Sep 17 00:00:00 2001
+From 14d4f4323856f88122f75b597088622a50873b70 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
-Subject: [PATCH 042/171] Adding bcm2835-sdhost driver, and an overlay to
+Subject: [PATCH 042/172] Adding bcm2835-sdhost driver, and an overlay to
  enable it
 
 BCM2835 has two SD card interfaces. This driver uses the other one.
@@ -71855,10 +71855,10 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 784b39ac9e00cffaf7d1dd0199d19d39d2ae5f4f Mon Sep 17 00:00:00 2001
+From 6f48d98726c00a1e2da54dbe5484766094c83424 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
-Subject: [PATCH 043/171] vc_mem: Add vc_mem driver for querying firmware
+Subject: [PATCH 043/172] vc_mem: Add vc_mem driver for querying firmware
  memory addresses
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -72383,10 +72383,10 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From 47b8b2ed8d7500a1c3c5500d0fa936b713861ebd Mon Sep 17 00:00:00 2001
+From 13d0bd6e14e868d08b54e60239dcbe73d560a111 Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
-Subject: [PATCH 044/171] vcsm: VideoCore shared memory service for BCM2835
+Subject: [PATCH 044/172] vcsm: VideoCore shared memory service for BCM2835
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -76823,10 +76823,10 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From e4642f6be0fb7adf5a4d0c9146c8f129154cdc0c Mon Sep 17 00:00:00 2001
+From 19e3234988742e80780c0ac74ea9683aa878f7e9 Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
-Subject: [PATCH 045/171] Add /dev/gpiomem device for rootless user GPIO access
+Subject: [PATCH 045/172] Add /dev/gpiomem device for rootless user GPIO access
 
 Signed-off-by: Luke Wren <luke@raspberrypi.org>
 
@@ -77134,10 +77134,10 @@ index 0000000000000000000000000000000000000000..f5e7f1ba8fb6f18dee77fad06a17480c
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From 1bde0307d490d7032e555454e2196c6625f0effb Mon Sep 17 00:00:00 2001
+From 9cca281c0fa998d7e52c4b5a41080497fce07426 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
-Subject: [PATCH 046/171] Add SMI driver
+Subject: [PATCH 046/172] Add SMI driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -79088,10 +79088,10 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From 55f9017cc8d3d0dad08492f27c080c61c5cc1ba1 Mon Sep 17 00:00:00 2001
+From cc402171edc8698bb38b2cde8c25d31952d13402 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
-Subject: [PATCH 047/171] MISC: bcm2835: smi: use clock manager and fix reload
+Subject: [PATCH 047/172] MISC: bcm2835: smi: use clock manager and fix reload
  issues
 
 Use clock manager instead of self-made clockmanager.
@@ -79261,10 +79261,10 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 42d54408e1e53196e6a9bbb35b3571062ce3f689 Mon Sep 17 00:00:00 2001
+From d4d2301c3e4d2526cd4e41a3aa3631bff1d7dc0a Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
-Subject: [PATCH 048/171] Add SMI NAND driver
+Subject: [PATCH 048/172] Add SMI NAND driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -79629,10 +79629,10 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From da161d66dc81f6af6e16e98e20bc33b6ca11aa6c Mon Sep 17 00:00:00 2001
+From 965f519ed5bc722708734c3920286cfc3b218fdc Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
-Subject: [PATCH 049/171] lirc: added support for RaspberryPi GPIO
+Subject: [PATCH 049/172] lirc: added support for RaspberryPi GPIO
 
 lirc_rpi: Use read_current_timer to determine transmitter delay. Thanks to jjmz and others
 See: https://github.com/raspberrypi/linux/issues/525
@@ -80495,10 +80495,10 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From 9715abe862796db1a2f11137345e39aed1b46957 Mon Sep 17 00:00:00 2001
+From 23c0798c89d295f8e3aea50becb10a27d672c281 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
-Subject: [PATCH 050/171] Add cpufreq driver
+Subject: [PATCH 050/172] Add cpufreq driver
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -80765,10 +80765,10 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 1acda3fe2b67892af043f6dd4fd2bb482d291e9c Mon Sep 17 00:00:00 2001
+From 0943c506c42919dbb505fb8d358c0d501f9271ee Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
-Subject: [PATCH 051/171] Added hwmon/thermal driver for reporting core
+Subject: [PATCH 051/172] Added hwmon/thermal driver for reporting core
  temperature. Thanks Dorian
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -80934,10 +80934,10 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From c42c6d235fdcdea18687b6f7521c95582acd1fc7 Mon Sep 17 00:00:00 2001
+From f6008f4b4ce90204371b2e2bfc8e8c9ac561e4e8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
-Subject: [PATCH 052/171] Add Chris Boot's i2c driver
+Subject: [PATCH 052/172] Add Chris Boot's i2c driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81602,10 +81602,10 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 9318c94ea4a1a8dd6cb158f575bad26379c7c6b0 Mon Sep 17 00:00:00 2001
+From ef19a1fb6d320698c954dc3198cb66a98520e6f9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
-Subject: [PATCH 053/171] char: broadcom: Add vcio module
+Subject: [PATCH 053/172] char: broadcom: Add vcio module
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81830,10 +81830,10 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 0feb20c42250b95ea9b8dfb93096fbd924f3d080 Mon Sep 17 00:00:00 2001
+From 7cacac3072868cce466f7a98f397a2be2aecd4cb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
-Subject: [PATCH 054/171] firmware: bcm2835: Support ARCH_BCM270x
+Subject: [PATCH 054/172] firmware: bcm2835: Support ARCH_BCM270x
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81916,10 +81916,10 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From 166c632d4f11df7311430ee30124ea5c9314c209 Mon Sep 17 00:00:00 2001
+From 95a558dd017a654f4e6e2f2df0323f799d66de03 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
-Subject: [PATCH 055/171] scripts: Add mkknlimg and knlinfo scripts from tools
+Subject: [PATCH 055/172] scripts: Add mkknlimg and knlinfo scripts from tools
  repo
 
 The Raspberry Pi firmware looks for a trailer on the kernel image to
@@ -82439,10 +82439,10 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 97fb096adeb5c636b831f4d499a913241b3df8e9 Mon Sep 17 00:00:00 2001
+From a7f1ffdee86153fc696f5ce431e3ba96fa9c4c72 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
-Subject: [PATCH 056/171] BCM2708: Add core Device Tree support
+Subject: [PATCH 056/172] BCM2708: Add core Device Tree support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -93741,10 +93741,10 @@ index 7234e61e7ce370a775ec6981b391b6d102a01770..1b53cd59e4875d388e4974a3399d5f07
  
  # Bzip2
 
-From d3c4ebda08aaf675cbe5607e39b33b47efbce139 Mon Sep 17 00:00:00 2001
+From d149970fa36b92a17a489f3750e73b13064d0d55 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
-Subject: [PATCH 057/171] BCM270x_DT: Add pwr_led, and the required "input"
+Subject: [PATCH 057/172] BCM270x_DT: Add pwr_led, and the required "input"
  trigger
 
 The "input" trigger makes the associated GPIO an input.  This is to support
@@ -93920,10 +93920,10 @@ index 38c0bd7ca1074af234d516275791d05f945ce1f0..2f026646d24bad617c73aa79db30c9aa
  	/* set_brightness_work / blink_timer flags, atomic, private. */
  	unsigned long		work_flags;
 
-From 00418aff54926084a83b0423228b5f6ed96ccc56 Mon Sep 17 00:00:00 2001
+From 74ad535336548b33116d1d8bd48bf14b76a79b46 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
-Subject: [PATCH 058/171] fbdev: add FBIOCOPYAREA ioctl
+Subject: [PATCH 058/172] fbdev: add FBIOCOPYAREA ioctl
 
 Based on the patch authored by Ali Gholami Rudi at
     https://lkml.org/lkml/2009/7/13/153
@@ -94175,10 +94175,10 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From a6ab96596117c628f9b873fd84b50aa527bcead6 Mon Sep 17 00:00:00 2001
+From 4a3349de06fe25730ad85697eabcb82ba0f9da64 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
-Subject: [PATCH 059/171] Speed up console framebuffer imageblit function
+Subject: [PATCH 059/172] Speed up console framebuffer imageblit function
 
 Especially on platforms with a slower CPU but a relatively high
 framebuffer fill bandwidth, like current ARM devices, the existing
@@ -94387,10 +94387,10 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From bf05b1e210af413b46aa63d628626f3731f7e67b Mon Sep 17 00:00:00 2001
+From 62ddb449a6eda9797476d7a0cc4f8fb8632dfddf Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
-Subject: [PATCH 060/171] enabling the realtime clock 1-wire chip DS1307 and
+Subject: [PATCH 060/172] enabling the realtime clock 1-wire chip DS1307 and
  1-wire on GPIO4 (as a module)
 
 1-wire: Add support for configuring pin for w1-gpio kernel module
@@ -94640,10 +94640,10 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From f6f9bcaf6565728d6a8e9eb98ff4468d7234ed21 Mon Sep 17 00:00:00 2001
+From 0f7c19950b6d1df4e50978f68f863566f0a49cdc Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
-Subject: [PATCH 061/171] hid: Reduce default mouse polling interval to 60Hz
+Subject: [PATCH 061/172] hid: Reduce default mouse polling interval to 60Hz
 
 Reduces overhead when using X
 ---
@@ -94679,10 +94679,10 @@ index 961bc6fdd2d908835fa9a07d169a4746fb44189d..c595188a1156a27aa79f111d81636b6d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From 0bd63fc6a07fbd2a5d5549a5073d724a566d0e51 Mon Sep 17 00:00:00 2001
+From 4ed9ed7a6d49f5f4767fbc3e0b76c6d7b7dcf9bd Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
-Subject: [PATCH 062/171] rpi-ft5406: Add touchscreen driver for pi LCD display
+Subject: [PATCH 062/172] rpi-ft5406: Add touchscreen driver for pi LCD display
 
 Fix driver detection failure Check that the buffer response is non-zero meaning the touchscreen was detected
 
@@ -95040,10 +95040,10 @@ index 30fb37fe175df604a738258a2a632bca3bfff33f..4a3d79d3b48eb483a4e4bf498f617515
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 48a8e542f959273af5435ae7942fccf52a61cd50 Mon Sep 17 00:00:00 2001
+From c62a6314f7bebb3a8cdf1409ce24a10b95d0b6c5 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
-Subject: [PATCH 063/171] Improve __copy_to_user and __copy_from_user
+Subject: [PATCH 063/172] Improve __copy_to_user and __copy_from_user
  performance
 
 Provide a __copy_from_user that uses memcpy. On BCM2708, use
@@ -96618,10 +96618,10 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From ca70b1695c4b6198eece1f4983d1ad6377f590d1 Mon Sep 17 00:00:00 2001
+From 6e290f07e08bbcba58d280cbfd08c6edc254017f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
-Subject: [PATCH 064/171] gpio-poweroff: Allow it to work on Raspberry Pi
+Subject: [PATCH 064/172] gpio-poweroff: Allow it to work on Raspberry Pi
 
 The Raspberry Pi firmware manages the power-down and reboot
 process. To do this it installs a pm_power_off handler, causing
@@ -96656,10 +96656,10 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From da30283cb5ad63c6dd03d30111dc9f60b2daef9b Mon Sep 17 00:00:00 2001
+From 6d7c6199e669d7fd82a9636505ea69047afcff2d Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
-Subject: [PATCH 065/171] mfd: Add Raspberry Pi Sense HAT core driver
+Subject: [PATCH 065/172] mfd: Add Raspberry Pi Sense HAT core driver
 
 ---
  drivers/input/joystick/Kconfig           |   8 +
@@ -97524,10 +97524,10 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 223d629c5c467ff0e4645205336f6565990b725c Mon Sep 17 00:00:00 2001
+From 782e8a825497cc9241209086f8926c494064ae99 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
-Subject: [PATCH 066/171] ASoC: Add support for HifiBerry DAC
+Subject: [PATCH 066/172] ASoC: Add support for HifiBerry DAC
 
 This adds a machine driver for the HifiBerry DAC.
 It is a sound card that can
@@ -97702,10 +97702,10 @@ index 0000000000000000000000000000000000000000..ee9f133953544629282631e5ef3f73fe
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 299dc0759a56ee0981345e13d76b23f0e3cbe8ef Mon Sep 17 00:00:00 2001
+From aa777e5e25ea7346a8a685f0b1987f0313406d54 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
-Subject: [PATCH 067/171] ASoC: Add support for Rpi-DAC
+Subject: [PATCH 067/172] ASoC: Add support for Rpi-DAC
 
 ---
  sound/soc/bcm/Kconfig       |   7 +++
@@ -97989,10 +97989,10 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From 152d520349070daabb52a0584a61e6181c7c666d Mon Sep 17 00:00:00 2001
+From e199dc943984763ef3c06587b05e74476b4e00ed Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
-Subject: [PATCH 068/171] ASoC: wm8804: Implement MCLK configuration options,
+Subject: [PATCH 068/172] ASoC: wm8804: Implement MCLK configuration options,
  add 32bit support WM8804 can run with PLL frequencies of 256xfs and 128xfs
  for most sample rates. At 192kHz only 128xfs is supported. The existing
  driver selects 128xfs automatically for some lower samples rates. By using an
@@ -98041,10 +98041,10 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From 09a3db19b8a52e2d5c5b46b01679124cf8ba9c01 Mon Sep 17 00:00:00 2001
+From ef15e4bb0e7eef3e15a02c10cc456bcaf2b8cc7b Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
-Subject: [PATCH 069/171] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
+Subject: [PATCH 069/172] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
  based on the patched WM8804 driver.
 
 Signed-off-by: Daniel Matuschek <daniel@matuschek.net>
@@ -98388,10 +98388,10 @@ index 0000000000000000000000000000000000000000..7620dd02de40b6d644ff038b445d375d
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From f5348aedf74aac384ec9e9598f2589e7f2652d8f Mon Sep 17 00:00:00 2001
+From 84ca2f1f288d5be9d01a92d3dad1aff4a4989417 Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
-Subject: [PATCH 070/171] Add IQaudIO Sound Card support for Raspberry Pi
+Subject: [PATCH 070/172] Add IQaudIO Sound Card support for Raspberry Pi
 
 Set a limit of 0dB on Digital Volume Control
 
@@ -98726,10 +98726,10 @@ index 0000000000000000000000000000000000000000..1ee4097c846376666775272ed692ca33
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 591ef155aceef6c96a340aa992c5e80984a28863 Mon Sep 17 00:00:00 2001
+From 1179904e04673805fe64e7f757ecaa5b5109f8ba Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
-Subject: [PATCH 071/171] Added support for HiFiBerry DAC+
+Subject: [PATCH 071/172] Added support for HiFiBerry DAC+
 
 The driver is based on the HiFiBerry DAC driver. However HiFiBerry DAC+ uses
 a different codec chip (PCM5122), therefore a new driver is necessary.
@@ -99359,10 +99359,10 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From 14b30c445a06a7a9e2595a38254fb9dfad285a48 Mon Sep 17 00:00:00 2001
+From e9c272ddb7aa2307fa2a8b175289562c0e4a4d66 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
-Subject: [PATCH 072/171] Added driver for HiFiBerry Amp amplifier add-on board
+Subject: [PATCH 072/172] Added driver for HiFiBerry Amp amplifier add-on board
 
 The driver contains a low-level hardware driver for the TAS5713 and the
 drivers for the Raspberry Pi I2S subsystem.
@@ -100197,10 +100197,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From bf4c59be1c0796076caff442675a4d1bf04839f5 Mon Sep 17 00:00:00 2001
+From 0b88e9f7ccbfcbc6d7e7dc226787012e9bc712bd Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
-Subject: [PATCH 073/171] Update ds1307 driver for device-tree support
+Subject: [PATCH 073/172] Update ds1307 driver for device-tree support
 
 Signed-off-by: Ryan Coe <bluemrp9@gmail.com>
 ---
@@ -100227,10 +100227,10 @@ index 4ad97be480430babc3321075f2739114eaad8f04..2ac1c265dc9cea56a5949eb537949a1f
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From f22a4632aaabdf1b8db855be1f60931aff8be9d3 Mon Sep 17 00:00:00 2001
+From c20bd956bd7c7f81788c1ca52ba6877b593c5962 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
-Subject: [PATCH 074/171] Add driver for rpi-proto
+Subject: [PATCH 074/172] Add driver for rpi-proto
 
 Forward port of 3.10.x driver from https://github.com/koalo
 We are using a custom board and would like to use rpi 3.18.x
@@ -100445,10 +100445,10 @@ index 0000000000000000000000000000000000000000..fadbfade100228aaafabb0d3bdf35c01
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 503222b36d56570d972347dbe6b333bc036f7f45 Mon Sep 17 00:00:00 2001
+From 4daa4a346865a02049dbba9de4f7dbf165827f14 Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
-Subject: [PATCH 075/171] RaspiDAC3 support
+Subject: [PATCH 075/172] RaspiDAC3 support
 
 Signed-off-by: Jan Grulich <jan@grulich.eu>
 
@@ -100691,10 +100691,10 @@ index 0000000000000000000000000000000000000000..ad2b5b89bc8213dc2e277306ef50d6e3
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From 71748f0748c3609e0d7bffc54c00ff7ebb7af413 Mon Sep 17 00:00:00 2001
+From 4c5033c3011845dd9fc997251baff644988fa639 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
-Subject: [PATCH 076/171] Add Support for JustBoom Audio boards
+Subject: [PATCH 076/172] Add Support for JustBoom Audio boards
 
 justboom-dac: Adjust for ALSA API change
 
@@ -101150,10 +101150,10 @@ index 0000000000000000000000000000000000000000..909cf8928f2f4313982316f9c5b8a709
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From fac66a36ca3017768df7e25346fd9a69d3dea5dc Mon Sep 17 00:00:00 2001
+From 47203585a01cb33ed17880bab137f3578a90f62f Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
-Subject: [PATCH 077/171] ARM: adau1977-adc: Add basic machine driver for
+Subject: [PATCH 077/172] ARM: adau1977-adc: Add basic machine driver for
  adau1977 codec driver.
 
 This commit adds basic support for the codec usage including: Device tree overlay,
@@ -101335,10 +101335,10 @@ index 0000000000000000000000000000000000000000..f3d7e5db7bb912e1d7ca6f8e8d42df5f
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From 627877f748135ba0f27762680fed7b9a332949aa Mon Sep 17 00:00:00 2001
+From 1a6f4c5742473c754f028789e7a8add9b5cc99a4 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
-Subject: [PATCH 078/171] New AudioInjector.net Pi soundcard with low jitter
+Subject: [PATCH 078/172] New AudioInjector.net Pi soundcard with low jitter
  audio in and out.
 
 Contains the sound/soc/bcm ALSA machine driver and necessary alterations to the Kconfig and Makefile.
@@ -101589,10 +101589,10 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 0767bab3fafca528813de9a225f0acefb09898ec Mon Sep 17 00:00:00 2001
+From 89e63d5a68a55f0f80ef4cc6796140e3032ba514 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
-Subject: [PATCH 079/171] Add IQAudIO Digi WM8804 board support
+Subject: [PATCH 079/172] Add IQAudIO Digi WM8804 board support
 
 Support IQAudIO Digi board with iqaudio_digi machine driver and
  iqaudio-digi-wm8804-audio overlay.
@@ -101892,10 +101892,10 @@ index 0000000000000000000000000000000000000000..33aa2be8a43a12a12cfb5d844dd9732c
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 0ec2957c10f92fa13b16413dbde1d8003808e15d Mon Sep 17 00:00:00 2001
+From 931f5ef2db9f20c590f2336fb45e9f1c1e06a4b8 Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
-Subject: [PATCH 080/171] New driver for RRA DigiDAC1 soundcard using WM8741 +
+Subject: [PATCH 080/172] New driver for RRA DigiDAC1 soundcard using WM8741 +
  WM8804
 
 ---
@@ -102368,10 +102368,10 @@ index 0000000000000000000000000000000000000000..f200688bb4ae32b90a0ced555aed94b0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From e73b9e80d592b38e1bc10367393f34296d04038f Mon Sep 17 00:00:00 2001
+From d8410ff5810f2031d9609575d1abbf796a37e5b4 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
-Subject: [PATCH 081/171] Add support for Dion Audio LOCO DAC-AMP HAT
+Subject: [PATCH 081/172] Add support for Dion Audio LOCO DAC-AMP HAT
 
 Using dedicated machine driver and pcm5102a codec driver.
 
@@ -102544,10 +102544,10 @@ index 0000000000000000000000000000000000000000..65e03741d349a2dc5bd91f69855ea952
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From aa137adbefd902a4c3a163bdc994ac549e99c7cf Mon Sep 17 00:00:00 2001
+From af1317eb8df0560f05515cfe808ce5b071db748d Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
-Subject: [PATCH 082/171] Allo Piano DAC boards: Initial 2 channel (stereo)
+Subject: [PATCH 082/172] Allo Piano DAC boards: Initial 2 channel (stereo)
  support (#1645)
 
 Add initial 2 channel (stereo) support for Allo Piano DAC (2.0/2.1) boards,
@@ -102754,10 +102754,10 @@ index 0000000000000000000000000000000000000000..eaf50fb6dbca1970ae1c6f8662088b0f
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 5606eb490bbc82643871848ff4f42bc5b53512af Mon Sep 17 00:00:00 2001
+From 35c8b0bf87ce7be86810af72aa3495de4c16867e Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
-Subject: [PATCH 083/171] Support for Blokas Labs pisound board
+Subject: [PATCH 083/172] Support for Blokas Labs pisound board
 
 Pisound dynamic overlay (#1760)
 
@@ -103956,10 +103956,10 @@ index 0000000000000000000000000000000000000000..06ff1e53dc9d860946965b6303577762
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From 861256898473adf45265ba77351b4c452345455a Mon Sep 17 00:00:00 2001
+From 86a4993d6547875cb6a4877714e9f43eeee57ef4 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 22 Jan 2017 12:49:37 +0100
-Subject: [PATCH 084/171] ASoC: Add driver for Cirrus Logic Audio Card
+Subject: [PATCH 084/172] ASoC: Add driver for Cirrus Logic Audio Card
 
 Note: due to problems with deferred probing of regulators
 the following softdep should be added to a modprobe.d file
@@ -105024,10 +105024,10 @@ index 0000000000000000000000000000000000000000..ac8651ddff7bd3701dffe22c7fb88352
 +MODULE_DESCRIPTION("ASoC driver for Cirrus Logic Audio Card");
 +MODULE_LICENSE("GPL");
 
-From 3ee4b5d2e76eb4fbb087656bb2745b2995999090 Mon Sep 17 00:00:00 2001
+From 380db971c26af4f64fbc3476be9646b4a2d282db Mon Sep 17 00:00:00 2001
 From: Miquel <miquelblauw@hotmail.com>
 Date: Fri, 24 Feb 2017 20:51:06 +0100
-Subject: [PATCH 085/171] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
+Subject: [PATCH 085/172] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
 
 Signed-off-by: Miquel Blauw <info@dionaudio.nl>
 ---
@@ -105221,10 +105221,10 @@ index 0000000000000000000000000000000000000000..a009c49477972a9832175d86f201b035
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO-V2");
 +MODULE_LICENSE("GPL v2");
 
-From 94c04760404bb3128e9f3dbf75770f1575635bf7 Mon Sep 17 00:00:00 2001
+From ad3fcef7140156ac6fc06849c592a7483780fe8a Mon Sep 17 00:00:00 2001
 From: Fe-Pi <fe-pi@cox.net>
 Date: Wed, 1 Mar 2017 04:42:43 -0700
-Subject: [PATCH 086/171] Add support for Fe-Pi audio sound card. (#1867)
+Subject: [PATCH 086/172] Add support for Fe-Pi audio sound card. (#1867)
 
 Fe-Pi Audio Sound Card is based on NXP SGTL5000 codec.
 Mechanical specification of the board is the same the Raspberry Pi Zero.
@@ -105438,10 +105438,10 @@ index 0000000000000000000000000000000000000000..015b56fd73cc36be5b5eecd17548fd03
 +MODULE_DESCRIPTION("ASoC Driver for Fe-Pi Audio");
 +MODULE_LICENSE("GPL v2");
 
-From d4bccfb06982afe2bf4a9e72b876a2217dd70a52 Mon Sep 17 00:00:00 2001
+From c62facc1d4f9bbb81bb8f7478e71776be80208d5 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 20:04:13 +1100
-Subject: [PATCH 087/171] Add support for the AudioInjector.net Octo sound card
+Subject: [PATCH 087/172] Add support for the AudioInjector.net Octo sound card
 
 ---
  sound/soc/bcm/Kconfig                        |   7 +
@@ -105781,10 +105781,10 @@ index 0000000000000000000000000000000000000000..9effea725798640887755dfa688da453
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:audioinjector-octo-soundcard");
 
-From 9144f062edb98ad04532ce6177daa0ffb0e99bf4 Mon Sep 17 00:00:00 2001
+From af6ad3dafb31058d93f00e11e39d13bd691c2cd6 Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
-Subject: [PATCH 088/171] rpi_display: add backlight driver and overlay
+Subject: [PATCH 088/172] rpi_display: add backlight driver and overlay
 
 Add a mailbox-driven backlight controller for the Raspberry Pi DSI
 touchscreen display. Requires updated GPU firmware to recognise the
@@ -105953,10 +105953,10 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From d89fa28c2773caea1c0b45c0f6c069ddf70c520e Mon Sep 17 00:00:00 2001
+From 2cd78573346e3036d623c85c6866b3b9af69671e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
-Subject: [PATCH 089/171] bcm2835-virtgpio: Virtual GPIO driver
+Subject: [PATCH 089/172] bcm2835-virtgpio: Virtual GPIO driver
 
 Add a virtual GPIO driver that uses the firmware mailbox interface to
 request that the VPU toggles LEDs.
@@ -106230,10 +106230,10 @@ index 4a3d79d3b48eb483a4e4bf498f617515e3ad158f..5f34e1257117fb48013c9926a8a223d6
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From d98896369e1af9b5c148a30daf19c170448bdbf4 Mon Sep 17 00:00:00 2001
+From 0b304c39ab00e62b9d78fed0e617ec2f0a965f0c Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Mon, 20 Feb 2017 17:01:21 +0000
-Subject: [PATCH 090/171] bcm2835-gpio-exp: Driver for GPIO expander via
+Subject: [PATCH 090/172] bcm2835-gpio-exp: Driver for GPIO expander via
  mailbox service
 
 Pi3 and Compute Module 3 have a GPIO expander that the
@@ -106561,10 +106561,10 @@ index 5f34e1257117fb48013c9926a8a223d64a598ab7..c819c21b0158a59c1308882e5a40e3f3
  	/* Dispmanx TAGS */
  	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,
 
-From 84e5030709abd2887e7897eec953b02f4b1b78a3 Mon Sep 17 00:00:00 2001
+From 6883c7d1af3a91c7671e40e22d3f5e7ac755da2b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
-Subject: [PATCH 091/171] amba_pl011: Don't use DT aliases for numbering
+Subject: [PATCH 091/172] amba_pl011: Don't use DT aliases for numbering
 
 The pl011 driver looks for DT aliases of the form "serial<n>",
 and if found uses <n> as the device ID. This can cause
@@ -106593,10 +106593,10 @@ index f2503d862f3aee25396ef002ba69968896316779..a85e81245004e928fc52ec59044e151b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From dd93fd68bfffc46553cb79f38b42bf0fd525ca2b Mon Sep 17 00:00:00 2001
+From a9fa6f6084d6d6e40072b2c3b58929579b469ae4 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:07:39 +0000
-Subject: [PATCH 092/171] amba_pl011: Round input clock up
+Subject: [PATCH 092/172] amba_pl011: Round input clock up
 
 The UART clock is initialised to be as close to the requested
 frequency as possible without exceeding it. Now that there is a
@@ -106682,10 +106682,10 @@ index a85e81245004e928fc52ec59044e151b7f183496..380d2c2e19ae3720924e906261b487ad
  /* unregisters the driver also if no more ports are left */
  static void pl011_unregister_port(struct uart_amba_port *uap)
 
-From 962af1199b7ec81d845f263dfc27bb9911c14c56 Mon Sep 17 00:00:00 2001
+From 0781c225a5b632975bdd64f9f3537d8d26066bb4 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
-Subject: [PATCH 093/171] OF: DT-Overlay configfs interface
+Subject: [PATCH 093/172] OF: DT-Overlay configfs interface
 
 This is a port of Pantelis Antoniou's v3 port that makes use of the
 new upstreamed configfs support for binary attributes.
@@ -107117,10 +107117,10 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From de39cf0268bb22f1f6c952a0537fb51af5d889c0 Mon Sep 17 00:00:00 2001
+From 0fb35dff05c9853a5b16b129b13f54483633a340 Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
-Subject: [PATCH 094/171] brcm: adds support for BCM43341 wifi
+Subject: [PATCH 094/172] brcm: adds support for BCM43341 wifi
 
 brcmfmac: Disable power management
 
@@ -107250,7 +107250,7 @@ index 33b133f7e63aad3b5a6bb14018fd461ec4fb90c6..6221b046bca44211e2dfac24119097f7
  MODULE_PARM_DESC(roamoff, "Do not use internal roaming engine");
  
 diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
-index 65689469c5a12e2fcfd6123ca584944da79ec184..4886dc29ad36705210bed20757ce09edadbd4262 100644
+index 67bff5b8cd6067de4eaa9458b16f8da6ec6eb885..7a8d881a3c5aa7c633e3e557c8860874dd3ec544 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/sdio.c
 @@ -604,6 +604,7 @@ BRCMF_FW_NVRAM_DEF(4329, "brcmfmac4329-sdio.bin", "brcmfmac4329-sdio.txt");
@@ -107271,10 +107271,10 @@ index 65689469c5a12e2fcfd6123ca584944da79ec184..4886dc29ad36705210bed20757ce09ed
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_43362_CHIP_ID, 0xFFFFFFFE, 43362),
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_4339_CHIP_ID, 0xFFFFFFFF, 4339),
 
-From 80d54a2586e101406b76fdae07e31e2d35467b9f Mon Sep 17 00:00:00 2001
+From 0e1d7d754372551210b66d9b34e9d61ca656377a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Feb 2017 15:26:13 +0000
-Subject: [PATCH 095/171] brcmfmac: Mute expected startup 'errors'
+Subject: [PATCH 095/172] brcmfmac: Mute expected startup 'errors'
 
 The brcmfmac WiFi driver always complains about the '00' country code
 and the firmware version is reported as an error. Modify the driver to
@@ -107313,10 +107313,10 @@ index 6221b046bca44211e2dfac24119097f7ac09e829..634602e0c44f91da06db7aa803dbee69
  	/* locate firmware version number for ethtool */
  	ptr = strrchr(buf, ' ') + 1;
 
-From 4db572f84537780cdbf0cbf40ef7fc02f1c29908 Mon Sep 17 00:00:00 2001
+From 19f79219bdb68af3efeabca3bbcaebb2e402f8ad Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
-Subject: [PATCH 096/171] hci_h5: Don't send conf_req when ACTIVE
+Subject: [PATCH 096/172] hci_h5: Don't send conf_req when ACTIVE
 
 Without this patch, a modem and kernel can continuously bombard each
 other with conf_req and conf_rsp messages, in a demented game of tag.
@@ -107339,10 +107339,10 @@ index 90d0456b67446bcc624fab4b1542c4eaf21531b1..f9adeac3bbba6418dcca298c55706356
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From 2cb6326bbbbeedfb1dabeb21ae2355733a302de2 Mon Sep 17 00:00:00 2001
+From 5810ea5ae3fa9f869b555794605e61455e8fd98b Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
-Subject: [PATCH 097/171] config: Add default configs
+Subject: [PATCH 097/172] config: Add default configs
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1309 +++++++++++++++++++++++++++++++++++
@@ -109990,10 +109990,10 @@ index 0000000000000000000000000000000000000000..046f3e8757ef0f794c802171690528d3
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 0ecb4c6a19ad119b66a9f4143f0e47d085b28f5a Mon Sep 17 00:00:00 2001
+From a551dbb12fe75c9978a2a713c0a66712e55a7d56 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
-Subject: [PATCH 098/171] Add arm64 configuration and device tree differences.
+Subject: [PATCH 098/172] Add arm64 configuration and device tree differences.
  Disable MMC_BCM2835_SDHOST and MMC_BCM2835 since these drivers are crashing
  at the moment.
 
@@ -111408,10 +111408,10 @@ index 0000000000000000000000000000000000000000..e6b09fafa27eed2b762e3d53b55041f7
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2835_VCHIQ=n
 
-From 6b3c1dacb978cb9e48f53f11038535f67b46f2a0 Mon Sep 17 00:00:00 2001
+From bd84783a61fbfdcaeb269c63095b364a1c3aff62 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
-Subject: [PATCH 099/171] raspberrypi-firmware: Define the MBOX channel in the
+Subject: [PATCH 099/172] raspberrypi-firmware: Define the MBOX channel in the
  header.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -111433,10 +111433,10 @@ index c819c21b0158a59c1308882e5a40e3f3fe73cbdf..de2a3dcd562beb752266eaf0070e5586
  
  enum rpi_firmware_property_status {
 
-From 99ed5d793a23275b6aa69c4862a5f020bb947f2c Mon Sep 17 00:00:00 2001
+From 0d801aeace86547fc7ab719f21dfbf20d352757c Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
-Subject: [PATCH 100/171] raspberrypi-firmware: Export the general transaction
+Subject: [PATCH 100/172] raspberrypi-firmware: Export the general transaction
  function.
 
 The vc4-firmware-kms module is going to be doing the MBOX FB call.
@@ -111480,10 +111480,10 @@ index de2a3dcd562beb752266eaf0070e55861d553f5f..dc7fd58afd5dddebf9b17065bb069a1d
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 656faa05b83945975ffff3b374272ba2ebf2b2c3 Mon Sep 17 00:00:00 2001
+From 811a7eaaf352f2d6ff6835497ce37f5e64a406b0 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
-Subject: [PATCH 101/171] ARM64: Make it work again on 4.9 (#1790)
+Subject: [PATCH 101/172] ARM64: Make it work again on 4.9 (#1790)
 
 * Invoke the dtc compiler with the same options used in arm mode.
 * ARM64 now uses the bcm2835 platform just like ARM32.
@@ -111887,10 +111887,10 @@ index e6b09fafa27eed2b762e3d53b55041f793683d27..c7e891d72969a388d9b135a36dbfc9c9
  CONFIG_LIBCRC32C=y
 -CONFIG_BCM2835_VCHIQ=n
 
-From 03a9fbe000404d610849fd607fd9ff0adc80b093 Mon Sep 17 00:00:00 2001
+From d70bfbe00aaba533fb9f2c531f510c89f0479eb7 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:10:07 -0800
-Subject: [PATCH 102/171] ARM64: Enable HDMI audio and vc04_services in
+Subject: [PATCH 102/172] ARM64: Enable HDMI audio and vc04_services in
  bcmrpi3_defconfig
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
@@ -111919,10 +111919,10 @@ index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..4b90f9b64abe9f089ba56b13d5a00de3
  CONFIG_BCM2835_MBOX=y
  # CONFIG_IOMMU_SUPPORT is not set
 
-From ea026b171a3cecd96f99333f23ea66ed9e3b743f Mon Sep 17 00:00:00 2001
+From 3bba53d05b7e2b8a9646c6ab4966039b6db8ab3a Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:14:03 -0800
-Subject: [PATCH 103/171] ARM64: Run bcmrpi3_defconfig through savedefconfig.
+Subject: [PATCH 103/172] ARM64: Run bcmrpi3_defconfig through savedefconfig.
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
 ---
@@ -111967,10 +111967,10 @@ index 4b90f9b64abe9f089ba56b13d5a00de33343bfb9..dac962ca1634662ce7d966f1ffb53b5b
  CONFIG_FB_TFT_AGM1264K_FL=m
  CONFIG_FB_TFT_BD663474=m
 
-From f4fb370608bdb9ab10d2ac970bd10b9520e7b92e Mon Sep 17 00:00:00 2001
+From 20ef4d26489383e581e2036fc5a1f73a8116d080 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 02:54:26 -0800
-Subject: [PATCH 104/171] ARM64: Enable Kernel Address Space Randomization
+Subject: [PATCH 104/172] ARM64: Enable Kernel Address Space Randomization
  (#1792)
 
 Randomization allows the mapping between virtual addresses and physical
@@ -112002,10 +112002,10 @@ index dac962ca1634662ce7d966f1ffb53b5bfa27c506..aae33b4b3c3e736ea7cd3ca242158ad6
  CONFIG_BINFMT_MISC=y
  CONFIG_COMPAT=y
 
-From f5353f5db03a3c7426a73f3f3ae08b5d9853386d Mon Sep 17 00:00:00 2001
+From 6fc513f155903c9578406263408ca1bd0ec5cbc3 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sun, 15 Jan 2017 07:31:59 -0800
-Subject: [PATCH 105/171] ARM64: Enable RTL8187/RTL8192CU wifi in build config
+Subject: [PATCH 105/172] ARM64: Enable RTL8187/RTL8192CU wifi in build config
 
 These drivers build now, so they can be enabled back
 in the build configuration just like they are for
@@ -112030,10 +112030,10 @@ index aae33b4b3c3e736ea7cd3ca242158ad6ba558aff..b7d762df19b85e369a32cd823dfd0621
  CONFIG_ZD1211RW=m
  CONFIG_MAC80211_HWSIM=m
 
-From b6a6db72bb0747e257f76d2b34a49545d782e5c3 Mon Sep 17 00:00:00 2001
+From 5e1602b536e71d81cefa1e438e6b6f5733ddcc2c Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:33:51 -0800
-Subject: [PATCH 106/171] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
+Subject: [PATCH 106/172] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
 
 In ARM64, the FIQ mechanism used by this driver is not current
 implemented.   As a workaround, reqular IRQ is used instead
@@ -112376,10 +112376,10 @@ index 6b2c7d0c93f36a63863ff4b0ecc1f3eab77e058b..d7b700ff17821ad1944e36721fe6b2db
  /** The OS page size */
  #define DWC_OS_PAGE_SIZE	PAGE_SIZE
 
-From 9d7234a88150305ba7a07188325cb78db5329a3e Mon Sep 17 00:00:00 2001
+From 2d199ab26441d46278125d73b106594703afe8ae Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:43:57 -0800
-Subject: [PATCH 107/171] ARM64: Round-Robin dispatch IRQs between CPUs.
+Subject: [PATCH 107/172] ARM64: Round-Robin dispatch IRQs between CPUs.
 
 IRQ-CPU mapping is round robined on ARM64 to increase
 concurrency and allow multiple interrupts to be serviced
@@ -112453,10 +112453,10 @@ index c4e151451cf8c8ebde5225515eac2786d6f61d46..9a7ee04ee0d9b7aa734cf3159ed59c19
  	.name		= "bcm2836-gpu",
  	.irq_mask	= bcm2836_arm_irqchip_mask_gpu_irq,
 
-From 290301822f954f1f531e2e3975544fc97f7877d7 Mon Sep 17 00:00:00 2001
+From adf92e16091278926830b3d7a96d9a9a44241331 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:45:03 -0800
-Subject: [PATCH 108/171] ARM64: Enable DWC_OTG Driver In ARM64 Build
+Subject: [PATCH 108/172] ARM64: Enable DWC_OTG Driver In ARM64 Build
  Config(bcmrpi3_defconfig)
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
@@ -112477,10 +112477,10 @@ index b7d762df19b85e369a32cd823dfd062145bdefa7..4d85c231c5ea0244e1b05fb4a5e3c8fd
  CONFIG_USB_STORAGE=y
  CONFIG_USB_STORAGE_REALTEK=m
 
-From 97692cb98965c89dfefc2d133127acc9bdfdcc44 Mon Sep 17 00:00:00 2001
+From 7538b323ead0a1543b3fb2566fdff2c866eb67b4 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 11 Feb 2017 01:18:31 -0800
-Subject: [PATCH 109/171] ARM64: Force hardware emulation of deprecated
+Subject: [PATCH 109/172] ARM64: Force hardware emulation of deprecated
  instructions.
 
 ---
@@ -112508,10 +112508,10 @@ index f0e6d717885b1fcf3b22f64c10c38f19c25f809d..0cb830d30fb6d2bd26ab572efe893649
  	case INSN_OBSOLETE:
  		insn->current_mode = INSN_UNDEF;
 
-From 5e6c3630b017d11396e65af6f4083721c228405a Mon Sep 17 00:00:00 2001
+From c01103bc6e2b06dad90bd7c4bf3c8a461bd7b661 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 10 Feb 2017 17:57:08 -0800
-Subject: [PATCH 110/171] build/arm64: Add rules for .dtbo files for dts
+Subject: [PATCH 110/172] build/arm64: Add rules for .dtbo files for dts
  overlays
 
 We now create overlays as .dtbo files.
@@ -112536,10 +112536,10 @@ index b9a4a934ca057623e0ea436fd9b2c7c0f675fced..54e3c38d6fd877827541cdc798de035c
  
  dtbs: prepare scripts
 
-From b6ae009bfdc608fd4105b5cf8162074edc702d13 Mon Sep 17 00:00:00 2001
+From 890b4b429c8571bc18e48f0e5c6ebdc3998c5c90 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
-Subject: [PATCH 111/171] clk: bcm2835: Mark GPIO clocks enabled at boot as
+Subject: [PATCH 111/172] clk: bcm2835: Mark GPIO clocks enabled at boot as
  critical.
 
 These divide off of PLLD_PER and are used for the ethernet and wifi
@@ -112577,10 +112577,10 @@ index 39f72da6ba1f6ec6ec41d5dc1bf46344aab008da..fe3298b54cdfb96bd90fb4f39e13921d
  	 * rate changes on at least of the parents.
  	 */
 
-From 241c0141b0f64afc072bfcd16ad836dfc9c15950 Mon Sep 17 00:00:00 2001
+From 7e6372d06c365e9413f8011db1535d77799b993a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
-Subject: [PATCH 112/171] pinctrl-bcm2835: Fix interrupt handling for GPIOs
+Subject: [PATCH 112/172] pinctrl-bcm2835: Fix interrupt handling for GPIOs
  28-31 and 46-53
 
 Contrary to the documentation, the BCM2835 GPIO controller actually has
@@ -112613,10 +112613,10 @@ index 6351fe7f8e314ac5ebb102dd20847b383fd5b857..28745af5aadf3cb91fa7ff39118385c3
  	},
  };
 
-From 2815293f575d6f7f8db0d58c6becf969c7ebcc08 Mon Sep 17 00:00:00 2001
+From 85e8d3328539d595c0d18c97acde2a5e93a6ccc6 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Tue, 7 Mar 2017 12:18:20 +0000
-Subject: [PATCH 113/171] BCM270X_DT: Invert Pi3 power LED to match fw change
+Subject: [PATCH 113/172] BCM270X_DT: Invert Pi3 power LED to match fw change
 
 Firmware expgpio driver reworked due to complaint over
 hotplug detect.
@@ -112642,10 +112642,10 @@ index 616cfd5c7094596b497101e8feca25e25e77c3e8..9f001bccb8261563dcddd8dec94b056b
  };
  
 
-From 7ae5699f83642001f71b566fd5102022356ebdb8 Mon Sep 17 00:00:00 2001
+From 00ff88c7d3653e002c2d0c4557b2786cedc46468 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Tue, 14 Mar 2017 14:23:06 +0000
-Subject: [PATCH 114/171] bcm2835-gpio-exp: Copy/paste error adding base twice
+Subject: [PATCH 114/172] bcm2835-gpio-exp: Copy/paste error adding base twice
 
 brcmexp_gpio_set was adding gpio->gc.base to the offset
 twice, so passing an invalid number to the mailbox service.
@@ -112671,10 +112671,10 @@ index 681a91492d4c33bdfd42416e069218e8611cc4d9..d68adafaee4ad406f45f4ff0d6b7c1ad
  	set.state = val;	/* Output state */
  
 
-From 5ca294f7f07267334376c1a3f2c7ab01a575101e Mon Sep 17 00:00:00 2001
+From 41c5f24ed441bd19580c99c6762452df772aeb30 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 17 Mar 2017 13:40:41 +0000
-Subject: [PATCH 115/171] config: disable MMC driver temporarily for now.
+Subject: [PATCH 115/172] config: disable MMC driver temporarily for now.
 
 Currently causes a breakage to sdhost driver. However when MMC is disabled Pi3 wifi will not work
 ---
@@ -112709,10 +112709,10 @@ index 046f3e8757ef0f794c802171690528d31fee9deb..f2e0a58a96c8550f110c5940bf65f4d0
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 14c8ba45aaf497ea88c1614093b5615d12daf16b Mon Sep 17 00:00:00 2001
+From c4db25eb1c034f1932b667c503d9c800de76bfab Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Mar 2017 12:24:41 +0000
-Subject: [PATCH 116/171] config: Make spidev a loadable module
+Subject: [PATCH 116/172] config: Make spidev a loadable module
 
 spidev isn't required early in the boot process, and not all users
 need it (spi_bcm2835 is a module), so make it a loadable module.
@@ -112752,10 +112752,10 @@ index f2e0a58a96c8550f110c5940bf65f4d022cc4548..9eb7084f440c8aac0c6257ee678007c2
  CONFIG_PPS_CLIENT_LDISC=m
  CONFIG_PPS_CLIENT_GPIO=m
 
-From f94bf42edfa6eeb6b9ad2df77a7bc0a04ad58bbc Mon Sep 17 00:00:00 2001
+From 5558f85d30e7e162bfa8dfb6620ec2a6b3e82867 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 10:06:56 +0000
-Subject: [PATCH 117/171] ASoC: Add prompt for ICS43432 codec
+Subject: [PATCH 117/172] ASoC: Add prompt for ICS43432 codec
 
 Without a prompt string, a config setting can't be included in a
 defconfig. Give CONFIG_SND_SOC_ICS43432 a prompt so that Pi soundcards
@@ -112780,10 +112780,10 @@ index 55812b0b884cf4fc4e86680b11fedd11c863db7a..428dc05edbb99f50560b7f89e45501c5
  config SND_SOC_INNO_RK3036
  	tristate "Inno codec driver for RK3036 SoC"
 
-From a3ec153fb9c893283426a031ef842aad06216542 Mon Sep 17 00:00:00 2001
+From e514545a7e7c05bb3a9c4fae28339298f643ad87 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 16:34:46 +0000
-Subject: [PATCH 118/171] bcm2835-aux: Add aux interrupt controller
+Subject: [PATCH 118/172] bcm2835-aux: Add aux interrupt controller
 
 The AUX block has a shared interrupt line with a register indicating
 which devices have active IRQs. Expose this as a nested interrupt
@@ -112947,10 +112947,10 @@ index bd750cf2238d61489811e7d7bd3b5f9950ed53c8..41e0702fae4692221980b0d02aed1ba6
  			       BCM2835_AUX_CLOCK_COUNT, GFP_KERNEL);
  	if (!onecell)
 
-From 0269e0943f1a94d54e90fe4d8f8acfd4d6f66c1e Mon Sep 17 00:00:00 2001
+From f8f06d01bd6cbb2ac3857c3a8977afda187a6d54 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 17:08:44 +0000
-Subject: [PATCH 119/171] BCM270X_DT: Enable AUX interrupt controller in DT
+Subject: [PATCH 119/172] BCM270X_DT: Enable AUX interrupt controller in DT
 
 See: https://github.com/raspberrypi/linux/issues/1484
      https://github.com/raspberrypi/linux/issues/1573
@@ -113003,10 +113003,10 @@ index 72cb9dc60ca9ad9aa2813972a299c50dcea7cd89..ca47b23ffbcd06063e0fb7072dc8a843
  			#address-cells = <1>;
  			#size-cells = <0>;
 
-From 3fa19808abc3076f201e792fd733040cc0a4b115 Mon Sep 17 00:00:00 2001
+From ee9a3fa1b93ba7a3a645b09b6fc48d54d4cc9b5b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 27 Mar 2017 17:40:45 +0100
-Subject: [PATCH 120/171] mkknlimg: Find some more downstream-only strings
+Subject: [PATCH 120/172] mkknlimg: Find some more downstream-only strings
 
 See: https://github.com/raspberrypi/linux/issues/1920
 
@@ -113037,10 +113037,10 @@ index 60206de7fa9a49bd027c635306674a29a568652f..84be2593ec1de8f97b0167ff06b3e05d
  
  my $res = try_extract($kernel_file, $tmpfile1);
 
-From 3ff525adc078b3438dc3415096d3ce2678d7e760 Mon Sep 17 00:00:00 2001
+From 3b5bf4492bd9d9bf1b61fb2f2e4f498cecf96832 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 29 Apr 2016 10:32:17 -0700
-Subject: [PATCH 121/171] mmc: read mmc alias from device tree
+Subject: [PATCH 121/172] mmc: read mmc alias from device tree
 
 To get the SD/MMC host device ID, read the alias from the device
 tree.
@@ -113097,10 +113097,10 @@ index 3f8c85d5aa094b43666904c7dbbe5e62c9763c19..4dbd0e8e27a496bfbe67d188cf795ecc
  		kfree(host);
  		return NULL;
 
-From 82fd0d70e5d7fbfb8f2936d559cde24711e3f847 Mon Sep 17 00:00:00 2001
+From de493463c9380c44a19090b8cc12c6eeaa24715f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 14:30:42 +0100
-Subject: [PATCH 122/171] BCM270X_DT: Add numbered aliases for SD/MMC devices
+Subject: [PATCH 122/172] BCM270X_DT: Add numbered aliases for SD/MMC devices
 
 In order to force a specific ID assignment to SD/MMC devices, add
 numbered aliases to the DT: sdhost -> mmc0, mmc -> mmc1
@@ -113131,10 +113131,10 @@ index ef14e9ac6cd2092efb1681682dd2d3c52b8abfd5..693d4c04a36d2a7883cc3d8916bf0efb
  		i2c2 = &i2c2;
  		usb = &usb;
 
-From 4628aba0bb1eec04bbbb19265d2de670100d26ca Mon Sep 17 00:00:00 2001
+From 027e783b2d7ca83d723abd27b58d62cfcdddc0d3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 14:28:53 +0100
-Subject: [PATCH 123/171] config: Re-enable the bcm2835-mmc driver
+Subject: [PATCH 123/172] config: Re-enable the bcm2835-mmc driver
 
 With the patch to assign mmc device IDs based on DT aliases and
 appropriate aliases in the rpi DTBs, it is now safe to re-enable
@@ -113171,10 +113171,10 @@ index 9eb7084f440c8aac0c6257ee678007c23990a8ae..021c38a909e71baa135cbcd4f3fb80fa
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From ec10142e1836924f04aca120cc3ba66f1bb89663 Mon Sep 17 00:00:00 2001
+From d754e1c0827d8049e241ba3a5c5afa3e79572daf Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
-Subject: [PATCH 124/171] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
+Subject: [PATCH 124/172] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
 
 Some SD cards have been found that corrupt data when small blocks
 are erased. Add a quirk to indicate that ERASE should not be used,
@@ -113316,10 +113316,10 @@ index 77e61e0a216a2728dd5cfecf55299402ac03c384..d12e8ddd22cb96e38b30f1ac3f9a6bd0
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From e707f97c58d059d4e5a1996b2bef3ee022da8026 Mon Sep 17 00:00:00 2001
+From 758190815bc43f023ba7a6f1d6c85f0d46625283 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 16:08:29 +0100
-Subject: [PATCH 125/171] bcm2835-sdhost: mmc_card_blockaddr fix
+Subject: [PATCH 125/172] bcm2835-sdhost: mmc_card_blockaddr fix
 
 Get the definition of mmc_card_blockaddr from drivers/mmc/core/card.h.
 
@@ -113346,10 +113346,10 @@ index a9bc79bfdbb71807819dfe2d8f1651445997f92a..9c6f199a7830959f31012d86bc1f8b1a
  
  #define SDCMD  0x00 /* Command to SD card              - 16 R/W */
 
-From c547af664b4e16c1c397acb5d76eda91a9c7cbf9 Mon Sep 17 00:00:00 2001
+From 74cb319edfe7f5bf1008bdcc3b9fbfbabc98c9bf Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Mar 2017 12:30:37 +0000
-Subject: [PATCH 126/171] thermal: Compatible strings for bcm2836, bcm2837
+Subject: [PATCH 126/172] thermal: Compatible strings for bcm2836, bcm2837
 
 The upstream dt-bindings documentation for bcm2835-thermal (which
 exists even though the driver isn't upstreamed) says to use
@@ -113381,10 +113381,10 @@ index c63fb9f9d143e19612a18fe530c7b2b3518a22a4..25b78c3eac1503fbc9e679b963a6284b
  };
  MODULE_DEVICE_TABLE(of, bcm2835_thermal_of_match_table);
 
-From 8e79c5261d30297c43fd2bf884a8e838e7263814 Mon Sep 17 00:00:00 2001
+From c7eedcd7d64d05f4d018dafe00d517ece05f5f6e Mon Sep 17 00:00:00 2001
 From: John Greb <h3x4m3r0n@gmail.com>
 Date: Wed, 8 Mar 2017 15:12:29 +0000
-Subject: [PATCH 127/171] Match dwc2 device-tree fifo sizes to the hardware
+Subject: [PATCH 127/172] Match dwc2 device-tree fifo sizes to the hardware
  values.
 
 Since commit aa381a7259c3f53727bcaa8c5f9359e940a0e3fd was reverted with 3fa9538539ac737096c81f3315a14670b1609092 the g-tx-fifo-size array in the device-tree needs to match the preset values in the bcm2835.
@@ -113415,10 +113415,10 @@ index 527abc9f0ddf71f4dc7d58336d87684c931cc2f3..265a16bab008453edba198cf2366c423
  	};
  };
 
-From 01d1abbe42b8ead8b482990506c4750f9f6430ec Mon Sep 17 00:00:00 2001
+From f2e17d82ca7da53d7fde536bbbe9f9188ac110f5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Mar 2017 09:10:05 +0000
-Subject: [PATCH 128/171] BCM270X_DT: Add lm75 to i2c-sensor overlay
+Subject: [PATCH 128/172] BCM270X_DT: Add lm75 to i2c-sensor overlay
 
 See: https://www.raspberrypi.org/forums/viewtopic.php?f=107&t=177236
 
@@ -113481,10 +113481,10 @@ index 31bda8da4cb6a56bfe493a81b918900995fb0589..606b2d5012abf2e85712be631c42ea40
  	};
  };
 
-From f70722aa6365aef4b09cab09e537bf0416da5ecc Mon Sep 17 00:00:00 2001
+From 8393cb664ff68d3a9de0f064693837824c5c31d8 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 28 Mar 2017 14:22:20 +0100
-Subject: [PATCH 129/171] BCM270X_DT: Allow multiple instances of w1-gpio
+Subject: [PATCH 129/172] BCM270X_DT: Allow multiple instances of w1-gpio
  overlays
 
 Upcoming firmware will modify the address portion of node names when
@@ -113549,10 +113549,10 @@ index 66a98f6c9601f51483f27803995bec772bb3350e..ef8bfbcabdb31231075d5c281df3b38b
  				<&w1_pins>,"brcm,pins:4";
  		pullup =        <&w1>,"rpi,parasitic-power:0";
 
-From 7e0019f9817602186aa21d656c355abf8bc9b680 Mon Sep 17 00:00:00 2001
+From 0092cb58dfed191609ae355a3a74141887b08968 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 28 Mar 2017 17:41:30 +0100
-Subject: [PATCH 130/171] leds-gpio: Remove stray assignment to brightness_set
+Subject: [PATCH 130/172] leds-gpio: Remove stray assignment to brightness_set
 
 The brightness_set method is intended for use cases that must not
 block, and can only be used if the GPIO provider can never sleep.
@@ -113578,10 +113578,10 @@ index 934cdb1d7bc7f12a4fb06a5c458ad76727c7b7c7..a4df27f6af35ba7f7b34c2a4b7b22ee7
  	if (template->default_state == LEDS_GPIO_DEFSTATE_KEEP) {
  		state = gpiod_get_value_cansleep(led_dat->gpiod);
 
-From 7849bfc329c346636d14a921549ef9ac728176e1 Mon Sep 17 00:00:00 2001
+From 3893ba12c306f0b3f825b1807511710eb1a75569 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 29 Mar 2017 17:41:04 +0100
-Subject: [PATCH 131/171] config: Add back MMC_BCM2835_DMA
+Subject: [PATCH 131/172] config: Add back MMC_BCM2835_DMA
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -113613,10 +113613,10 @@ index 021c38a909e71baa135cbcd4f3fb80fad2151647..a8fc96ef674be476d10e59aef2367def
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 695b025defd3a8e14a4467ad04ef2a31eed1100e Mon Sep 17 00:00:00 2001
+From 94bb9d5ae6d9c793e0fa21848f5d6ed5a03409ee Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 27 Mar 2017 22:26:49 +1100
-Subject: [PATCH 132/171] AudioInjector Octo: sample rates, regulators, reset
+Subject: [PATCH 132/172] AudioInjector Octo: sample rates, regulators, reset
 
 This patch adds new sample rates to the Audioinjector Octo sound card. The
 new supported rates are (in kHz) :
@@ -113782,10 +113782,10 @@ index 9effea725798640887755dfa688da45338718afc..dcf403ab37639ba79e38278d7e4b1ade
  			dai->cpu_dai_name = NULL;
  			dai->cpu_of_node = i2s_node;
 
-From 8004ce831e5f275d429b087f555e1c8c3661509f Mon Sep 17 00:00:00 2001
+From 687d1794246c421abc961b3bc7ce8fe7e480859a Mon Sep 17 00:00:00 2001
 From: Peter Malkin <petermalkin@google.com>
 Date: Mon, 27 Mar 2017 16:38:21 -0700
-Subject: [PATCH 133/171] Driver support for Google voiceHAT soundcard.
+Subject: [PATCH 133/172] Driver support for Google voiceHAT soundcard.
 
 ---
  arch/arm/boot/dts/overlays/Makefile                |   1 +
@@ -114290,10 +114290,10 @@ index 0000000000000000000000000000000000000000..225854b8e5298b3c3018f59a49404354
 +MODULE_DESCRIPTION("ASoC Driver for Google voiceHAT SoundCard");
 +MODULE_LICENSE("GPL v2");
 
-From a2b21d4aa50adbaa2525b009e32add438de5a5dd Mon Sep 17 00:00:00 2001
+From f16c6b3d8a141d85437778f20f04188d992ced14 Mon Sep 17 00:00:00 2001
 From: Raashid Muhammed <raashidmuhammed@zilogic.com>
 Date: Mon, 27 Mar 2017 12:35:00 +0530
-Subject: [PATCH 134/171] Add support for Allo Piano DAC 2.1 plus add-on board
+Subject: [PATCH 134/172] Add support for Allo Piano DAC 2.1 plus add-on board
  for Raspberry Pi.
 
 The Piano DAC 2.1 has support for 4 channels with subwoofer.
@@ -114921,10 +114921,10 @@ index 0000000000000000000000000000000000000000..f66f42abadbd5f9d3fe000676e8297ed
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC Plus");
 +MODULE_LICENSE("GPL v2");
 
-From 95832c1ae0d6ae2743cb8a5895b1a09bf12c9170 Mon Sep 17 00:00:00 2001
+From c28e97c50140a28a2f06563625802365afa390d6 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Tue, 28 Mar 2017 20:04:42 +0530
-Subject: [PATCH 135/171]  Add support for Allo Boss DAC add-on board for
+Subject: [PATCH 135/172]  Add support for Allo Boss DAC add-on board for
  Raspberry Pi.  (#1924)
 
 Signed-off-by: Baswaraj K <jaikumar@cem-solutions.net>
@@ -115654,10 +115654,10 @@ index 0000000000000000000000000000000000000000..c080e31065d99ab309ab3bdf41a44adf
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Boss DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 909b934489770252ab2b079dbe109406e53cd491 Mon Sep 17 00:00:00 2001
+From 4dc6f3e5e6e020df2c5c0bf2c9e752c1a2c1d957 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar C <babusubashchandar@zilogic.com>
 Date: Thu, 30 Mar 2017 20:17:27 +0530
-Subject: [PATCH 136/171] Add support for new clock rate and mute gpios.
+Subject: [PATCH 136/172] Add support for new clock rate and mute gpios.
 
 Signed-off-by: Baswaraj K <jaikumar@cem-solutions.net>
 Reviewed-by: Deepak <deepak@zilogic.com>
@@ -116310,10 +116310,10 @@ index c080e31065d99ab309ab3bdf41a44adfdd8f8039..203ab76c7045b081578e23bda1099dd1
  }
  
 
-From 2ad19b5956a7caaa1b832c2eaf75ac37863ec588 Mon Sep 17 00:00:00 2001
+From 9ff1331c6674eef77c2fc80168fa437bff57d13d Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Sat, 1 Apr 2017 00:46:52 +0530
-Subject: [PATCH 137/171] Add clock changes and mute gpios (#1938)
+Subject: [PATCH 137/172] Add clock changes and mute gpios (#1938)
 
 Also improve code style and adhere to ALSA coding conventions.
 
@@ -117006,10 +117006,10 @@ index f66f42abadbd5f9d3fe000676e8297ed91630e47..56e43f98846b41e487b3089813f7edc3
  }
  
 
-From a0800c1c55410ad79f81402389c6eb55a9454880 Mon Sep 17 00:00:00 2001
+From 24f108aa48ad6fc8137fb00708f4cb18997b4514 Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Fri, 14 Apr 2017 10:43:57 +0100
-Subject: [PATCH 138/171] This is the driver for Sony CXD2880 DVB-T2/T tuner +
+Subject: [PATCH 138/172] This is the driver for Sony CXD2880 DVB-T2/T tuner +
  demodulator. It includes the CXD2880 driver and the CXD2880 SPI adapter. The
  current CXD2880 driver version is 1.4.1 - 1.0.1 released on April 13, 2017.
 
@@ -133141,10 +133141,10 @@ index 0000000000000000000000000000000000000000..82e122349055be817eb74ed5bbcd7560
 +MODULE_AUTHOR("Sony Semiconductor Solutions Corporation");
 +MODULE_LICENSE("GPL v2");
 
-From 118ee7b54ed7e60ab5a45f52dc79c98c2c2574ff Mon Sep 17 00:00:00 2001
+From 1e4175db6d09052808f1fd6a8a6a7610c0f5aadb Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Thu, 22 Dec 2016 15:34:12 +0900
-Subject: [PATCH 139/171] BCM2708: Add Raspberry Pi TV HAT Device Tree Support
+Subject: [PATCH 139/172] BCM2708: Add Raspberry Pi TV HAT Device Tree Support
 
 This is an EXAMPLE CODE of Raspberry Pi TV HAT device tree overlay.
 Although this is not a part of our release code, it has been used to verify
@@ -133240,10 +133240,10 @@ index 0000000000000000000000000000000000000000..a68f6f793d8efd8b2e2adf9f2fb6426f
 +
 +};
 
-From dc7bc73461bbf0d8d69ee7e6a6b6d643c4eef41f Mon Sep 17 00:00:00 2001
+From 9a9a93cab06c2571740a004c4238c6a2aab56016 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 27 Apr 2017 16:24:34 +0100
-Subject: [PATCH 140/171] dwc_otg: make nak_holdoff work as intended with empty
+Subject: [PATCH 140/172] dwc_otg: make nak_holdoff work as intended with empty
  queues
 
 If URBs reading from non-periodic split endpoints were dequeued and
@@ -133327,10 +133327,10 @@ index c2dff94e8e6edd22e4427aaa1eac7aad972cb6bd..85a6d431ca54b47dc10573aa72d1ad69
  	} else {
  		uint16_t frame_number = dwc_otg_hcd_get_frame_number(hcd);
 
-From dbb7c94d4dd9ab1337852c943802b09d8f1b84e9 Mon Sep 17 00:00:00 2001
+From f4b142374898c6f6aeaca7ad90a82abdcfbb1df6 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Tue, 2 May 2017 16:31:15 +0100
-Subject: [PATCH 141/171] dwc_otg: fix split transaction data toggle handling
+Subject: [PATCH 141/172] dwc_otg: fix split transaction data toggle handling
  around dequeues
 
 See https://github.com/raspberrypi/linux/issues/1709
@@ -133418,10 +133418,10 @@ index 608e036be2c9484465ab836de70129335d3d2d96..718a1accc0c219a1764ce53d291de6a2
  	}
  	qtd = DWC_CIRCLEQ_FIRST(&hc->qh->qtd_list);
 
-From 87dbc1dc00d5e87332f5e811cdce6fe542a2ff1a Mon Sep 17 00:00:00 2001
+From ca137e4bade0c311e3955975dc18246c7285662c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 2 May 2017 16:36:05 +0100
-Subject: [PATCH 142/171] vcsm: Treat EBUSY as success rather than SIGBUS
+Subject: [PATCH 142/172] vcsm: Treat EBUSY as success rather than SIGBUS
 
 Currently if two cores access the same page concurrently one will return VM_FAULT_NOPAGE
 and the other VM_FAULT_SIGBUS crashing the user code.
@@ -133459,10 +133459,10 @@ index fd71d9fbb400d71bb8cfb8672080e7c3053e3ae9..fd2ca788dcd56b1702454d71b7bedd42
  	}
  }
 
-From 5a03196dc49290693a4155ac5814e733d93ab513 Mon Sep 17 00:00:00 2001
+From eb690d20f1fd7664b6c5ed931cd197456dab45ef Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 4 May 2017 12:58:11 +0100
-Subject: [PATCH 143/171] fiq_fsm: Use correct states when starting isoc OUT
+Subject: [PATCH 143/172] fiq_fsm: Use correct states when starting isoc OUT
  transfers
 
 In fiq_fsm_start_next_periodic() if an isochronous OUT transfer
@@ -133499,10 +133499,10 @@ index 9304279592cb5b388086ef91cb52f1e9f94868ce..208252645c09d1d17bf07673989f91b7
  				break;
  			}
 
-From 481f3e02b0ebdc2ab24a63e0bf237925693ea99c Mon Sep 17 00:00:00 2001
+From 44a7c4af43695b567ec9785cf471082ee001aed3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 4 May 2017 17:38:22 +0100
-Subject: [PATCH 144/171] bcm2708_fb: Avoid firmware mbox call in vc_mem_copy
+Subject: [PATCH 144/172] bcm2708_fb: Avoid firmware mbox call in vc_mem_copy
 
 If firmware has locked up it is useful to get vcdbg log out without a firmware mbox response.
 Issue the mbox call at probe time instead.
@@ -133566,10 +133566,10 @@ index 53c5a0bdadb4be9251affdabed66305842a08e72..612293cf9f1bd93ad2f2aefdd7ca0f5e
  	if (ret == 0) {
  		platform_set_drvdata(dev, fb);
 
-From 873b13316af82fbb66b438fb7eb3185c025f9c44 Mon Sep 17 00:00:00 2001
+From 6ac17568d6d7fc48ea49dfba566a10a0bbd05271 Mon Sep 17 00:00:00 2001
 From: Nisar Sayed <Nisar.Sayed@microchip.com>
 Date: Tue, 9 May 2017 18:51:42 +0100
-Subject: [PATCH 145/171] According to RFC 2460, IPv6 UDP calculated checksum
+Subject: [PATCH 145/172] According to RFC 2460, IPv6 UDP calculated checksum
  yields a result of zero must be changed to 0xffff, however this feature is
  not supported by smsc95xx family hence enable csum offload only for IPv4
  TCP/UDP packets.
@@ -133614,10 +133614,10 @@ index f6661e388f6e801c1b88e48a3b71407bd70cf56e..b84e98508b5d97165b68dfc30240950e
  	smsc95xx_init_mac_address(dev);
  
 
-From 882c018a70a9d89d637c85d57430edef3f225b4f Mon Sep 17 00:00:00 2001
+From 3425f056ca79301488d6184a61f6d108892e68b6 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
-Subject: [PATCH 146/171] drm/vc4: Add a mode for using the closed firmware for
+Subject: [PATCH 146/172] drm/vc4: Add a mode for using the closed firmware for
  display.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -134384,10 +134384,10 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From 597b78668965869b9745d1537028b462a5984d87 Mon Sep 17 00:00:00 2001
+From 4be853077c76b8a7776e7a608e1b2c7d6055e342 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:09:18 -0800
-Subject: [PATCH 147/171] drm/vc4: Name the primary and cursor planes in fkms.
+Subject: [PATCH 147/172] drm/vc4: Name the primary and cursor planes in fkms.
 
 This makes debugging nicer, compared to trying to remember what the
 IDs are.
@@ -134411,10 +134411,10 @@ index d18a1dae51a2275846c9826b5bf1ba57ae97b55c..e49ce68b607a7ffc2329e3235362f3bc
  	if (type == DRM_PLANE_TYPE_PRIMARY) {
  		vc4_plane->fbinfo =
 
-From 1d674cb73d219d7873c3946e3e10d7e8563f4f01 Mon Sep 17 00:00:00 2001
+From e797d289edae4870a0aaa8baa05f80c1be884f8d Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:10:09 -0800
-Subject: [PATCH 148/171] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
+Subject: [PATCH 148/172] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
  fkms.
 
 Trying to debug weston on fkms involved figuring out what calls I was
@@ -134484,10 +134484,10 @@ index e49ce68b607a7ffc2329e3235362f3bc21ed5cbb..dbf065677202fbebf8e3a0cffbe880aa
  				    RPI_FIRMWARE_SET_CURSOR_STATE,
  				    &packet_state,
 
-From f136b40e94b3a0b029e72e8f4a61f240ac3a12c6 Mon Sep 17 00:00:00 2001
+From 9148b1c7ce23d4fa3a5057a91e02e4b0bff7c525 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 2 Feb 2017 09:42:18 -0800
-Subject: [PATCH 149/171] drm/vc4: Fix sending of page flip completion events
+Subject: [PATCH 149/172] drm/vc4: Fix sending of page flip completion events
  in FKMS mode.
 
 In the rewrite of vc4_crtc.c for fkms, I dropped the part of the
@@ -134529,10 +134529,10 @@ index dbf065677202fbebf8e3a0cffbe880aa42daef3f..da818a207bfa639b8cea48d94bcf4566
  
  static void vc4_crtc_handle_page_flip(struct vc4_crtc *vc4_crtc)
 
-From 6386e2cc0770fc30ebe631e5fe78a387791c227c Mon Sep 17 00:00:00 2001
+From 0540b101f2da15af96b5e9234cb4e1f283e09e78 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 10 May 2017 21:39:45 +0100
-Subject: [PATCH 150/171] squash: vc4_firmware_kms fixups
+Subject: [PATCH 150/172] squash: vc4_firmware_kms fixups
 
 ---
  drivers/gpu/drm/vc4/vc4_crtc.c         | 2 ++
@@ -134582,10 +134582,10 @@ index da818a207bfa639b8cea48d94bcf4566f97db816..35425063cca47a33936c4853f7cc320c
  	vc4_encoder = devm_kzalloc(dev, sizeof(*vc4_encoder), GFP_KERNEL);
  	if (!vc4_encoder)
 
-From 0e396fc2b7dc7ea6f4404783dfbe65a770d1eb29 Mon Sep 17 00:00:00 2001
+From 7ee56a9ee94280a1a1a6e9edcfdc4dcf6ca81585 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 18 Apr 2017 21:43:46 +0100
-Subject: [PATCH 151/171] vc4_fkms: Apply firmware overscan offset to hardware
+Subject: [PATCH 151/172] vc4_fkms: Apply firmware overscan offset to hardware
  cursor
 
 ---
@@ -134642,10 +134642,10 @@ index 35425063cca47a33936c4853f7cc320c3630fdb2..ca03b85f27d8c0966acd977cba9c758d
  
  	return 0;
 
-From 0fceaad5762e6023035ecb323380fd003ab53174 Mon Sep 17 00:00:00 2001
+From 88e2042ef7dcf2a32ec9e1a355a25c63c560dec0 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 11 May 2017 16:58:16 +0100
-Subject: [PATCH 152/171] BCM270X_DT: Tidy up mmc, sdhost, sdio overlays
+Subject: [PATCH 152/172] BCM270X_DT: Tidy up mmc, sdhost, sdio overlays
 
 The mmc, sdhost, sdio and sdio-1bit overlays had a few
 anachronisms and oddities which were overdue for fixing.
@@ -134754,10 +134754,10 @@ index 398bd812c716c9e472fbac5aba4fe882114c65d1..215d5e3e8a8ca4363457fed1f7425427
  			};
  		};
 
-From 6548e104a4224e41e29b22cb89932fd413926675 Mon Sep 17 00:00:00 2001
+From 7784b743c7e929ea26b83a13c1e180e52827cdb5 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 12 May 2017 12:24:00 +0100
-Subject: [PATCH 153/171] dwc_otg: fix several potential crash sources
+Subject: [PATCH 153/172] dwc_otg: fix several potential crash sources
 
 On root port disconnect events, the host driver state is cleared and
 in-progress host channels are forcibly stopped. This doesn't play
@@ -134953,10 +134953,10 @@ index 718a1accc0c219a1764ce53d291de6a2b6f93608..cf23baaa388562b5843be4cfa6c206cb
  		release_channel(hcd, hc, qtd, DWC_OTG_HC_XFER_URB_COMPLETE);
  		break;
 
-From 80bb1c61832795e116abcda1b4c93125ce13fdfa Mon Sep 17 00:00:00 2001
+From 76d7aa0e6d46f620ac36060d0c846d7e42bf18a9 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 15 May 2017 14:27:48 +0100
-Subject: [PATCH 154/171] dwc_otg: delete hcd->channel_lock
+Subject: [PATCH 154/172] dwc_otg: delete hcd->channel_lock
 
 The lock serves no purpose as it is only held while the HCD spinlock
 is already being held.
@@ -135108,10 +135108,10 @@ index cf23baaa388562b5843be4cfa6c206cbdc4e780d..a4355afc77b68718fdaba6c5d4be257d
  
  	/* Try to queue more transfers now that there's a free channel. */
 
-From 523848c3700eafdb7ec8b82457f7308665d299e7 Mon Sep 17 00:00:00 2001
+From eedb48614ec36ce3d191cdb4aa74767646c53282 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 15 May 2017 14:51:42 +0100
-Subject: [PATCH 155/171] dwc_otg: remove unnecessary dma-mode channel halts on
+Subject: [PATCH 155/172] dwc_otg: remove unnecessary dma-mode channel halts on
  disconnect interrupt
 
 Host channels are already halted in kill_urbs_in_qh_list() with the
@@ -135179,10 +135179,10 @@ index 5ec991624c7865901b22ea01b9f2c58c8535ecfd..a2dc6337836b2719f4c954edeeb2a713
  
  	if(fiq_enable) {
 
-From 297eb7a2f5757418ec39b04aa5791bfdd714c971 Mon Sep 17 00:00:00 2001
+From 002051d57fb0537ebccdb784070389a5f27de98c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 15 May 2017 16:40:05 +0100
-Subject: [PATCH 156/171] config: Add CONFIG_TOUCHSCREEN_GOODIX
+Subject: [PATCH 156/172] config: Add CONFIG_TOUCHSCREEN_GOODIX
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135214,10 +135214,10 @@ index db6589288b6abd6b76b934de07e8976456e14e61..88072e3b55eb230be44f6d23012428ed
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From b1f660b2c014bb5a77cbefe4ffbae5d88d57abc4 Mon Sep 17 00:00:00 2001
+From d3a5bd8d79aeece0a911f9bda45e434217b83a81 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 18 May 2017 11:40:43 +0100
-Subject: [PATCH 157/171] config: Add FB_TFT_ST7789V module
+Subject: [PATCH 157/172] config: Add FB_TFT_ST7789V module
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135249,10 +135249,10 @@ index 88072e3b55eb230be44f6d23012428eda3de3453..65e3676b48ab0c0f54375ecf875fc255
  CONFIG_FB_TFT_TLS8204=m
  CONFIG_FB_TFT_UC1701=m
 
-From 6505b60bf9601733aed7184a0205a966b3ededb2 Mon Sep 17 00:00:00 2001
+From 93dd57a675c6e4c12cef6eeaa2a051741431db00 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 15:58:00 +0100
-Subject: [PATCH 158/171] config: Add CONFIG_TOUCHSCREEN_EDT_FT5X06
+Subject: [PATCH 158/172] config: Add CONFIG_TOUCHSCREEN_EDT_FT5X06
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135284,10 +135284,10 @@ index 65e3676b48ab0c0f54375ecf875fc2552c457e09..7381eeba83ecd4a2c956ab2093ece4f8
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From 8702d28309ec581a0e6ec270e1020c288dce6a4a Mon Sep 17 00:00:00 2001
+From cf356b0957eade219b6c4b2563d1f743d0205f30 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 19:34:52 +0100
-Subject: [PATCH 159/171] config: Add CONFIG_I2C_ROBOTFUZZ_OSIF
+Subject: [PATCH 159/172] config: Add CONFIG_I2C_ROBOTFUZZ_OSIF
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135319,10 +135319,10 @@ index 7381eeba83ecd4a2c956ab2093ece4f8a57c6ea4..35dc0b5084256f2ae755703edc3eb67c
  CONFIG_SPI_BCM2835=m
  CONFIG_SPI_BCM2835AUX=m
 
-From 9a5ba71c617b2339b9d3a7cf2a8dcdb9220d993e Mon Sep 17 00:00:00 2001
+From 8d94511815d1d2f25ab827ef7f4fa1710a676827 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 26 Apr 2017 17:28:47 +0100
-Subject: [PATCH 160/171] clk: bcm2835: Limit PCM clock to OSC and PLLD_PER
+Subject: [PATCH 160/172] clk: bcm2835: Limit PCM clock to OSC and PLLD_PER
 
 It is unwise to use sources other than the oscillator and PLLD_PER for
 the PCM peripheral (and perhaps others - TBD) because their rate can
@@ -135367,10 +135367,10 @@ index fe3298b54cdfb96bd90fb4f39e13921d2e1d4356..c24b4defb2b046e4ecdc109befc2b224
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
  		.name = "pwm",
 
-From eb91038876e5b8ea21fe5c722a53c90b84fd669c Mon Sep 17 00:00:00 2001
+From 06629f6b2a9357463afdf7681e83b24b30f1de83 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 22 May 2017 13:56:41 +0100
-Subject: [PATCH 161/171] clk: bcm2835: Minimise clock jitter for PCM clock
+Subject: [PATCH 161/172] clk: bcm2835: Minimise clock jitter for PCM clock
 
 Fractional clock dividers generate accurate average frequencies but
 with jitter, particularly when the integer divisor is small.
@@ -135495,10 +135495,10 @@ index c24b4defb2b046e4ecdc109befc2b22497060647..db3ba74acf78f4dfec0d2206b58bc7c3
  		.tcnt_mux = 23),
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
 
-From 25c08cb6f790a25985f14f46292cacc451793ae1 Mon Sep 17 00:00:00 2001
+From 0d2e6008beebe5809d638cd94d4c81d93a30f09f Mon Sep 17 00:00:00 2001
 From: Bilal Amarni <bamarni@users.noreply.github.com>
 Date: Wed, 24 May 2017 10:52:50 +0200
-Subject: [PATCH 162/171] [ARM64] enable drivers for GPIO expander and vcio
+Subject: [PATCH 162/172] [ARM64] enable drivers for GPIO expander and vcio
 
 ---
  arch/arm64/configs/bcmrpi3_defconfig | 3 +++
@@ -135526,10 +135526,10 @@ index 4d85c231c5ea0244e1b05fb4a5e3c8fd3e651ddf..9dcb58a519d041fadae99c81a7bda621
  CONFIG_GPIO_ARIZONA=m
  CONFIG_GPIO_STMPE=y
 
-From 7fcb73309c8da7bdffc0da81703820274250da94 Mon Sep 17 00:00:00 2001
+From 32f61ae52b810d1e32d2bfc482bf4f54bd5228bf Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 25 May 2017 16:04:53 +0100
-Subject: [PATCH 163/171] dwc_otg: make periodic scheduling behave properly for
+Subject: [PATCH 163/172] dwc_otg: make periodic scheduling behave properly for
  FS buses
 
 If the root port is in full-speed mode, transfer times at 12mbit/s
@@ -135700,10 +135700,10 @@ index 85a6d431ca54b47dc10573aa72d1ad69d06f2e36..4b1dd9de99e9e08b2e006fb5f8a7ef92
  	status = check_max_xfer_size(hcd, qh);
  	if (status) {
 
-From 4201ae911e3fc243ced0d648ab9f3e8d2c287b9b Mon Sep 17 00:00:00 2001
+From ffaefcb1ed2c66bba942aadb32158e4f1b908a7e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 19 May 2017 16:07:23 +0100
-Subject: [PATCH 164/171] serial: 8250: Add CAP_MINI, set for bcm2835aux
+Subject: [PATCH 164/172] serial: 8250: Add CAP_MINI, set for bcm2835aux
 
 commit d087e7a991f1f61ee2c07db1be7c5cc2aa373f5d upstream.
 
@@ -135776,10 +135776,10 @@ index 579706d36f5c77382cc289d55c2e6290143d6b1d..27e4a15fbe009e45270b5eaf3698bcfd
  
  	baud = serial8250_get_baud_rate(port, termios, old);
 
-From afb451150986c1b7854f526fd919043eb01134b7 Mon Sep 17 00:00:00 2001
+From 5db9df6f41bcf4d2eb4f408813874eef920fd2be Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 26 May 2017 12:50:31 +0100
-Subject: [PATCH 165/171] dwc_otg: fiq_fsm: Make isochronous compatibility
+Subject: [PATCH 165/172] dwc_otg: fiq_fsm: Make isochronous compatibility
  checks work properly
 
 Get rid of the spammy printk and local pointer mangling.
@@ -135843,10 +135843,10 @@ index 38bf5fc792d32352f9e208e0e90f968599b9bc31..71834cf365e67d7ad995bba7869216c4
  			return 1;
  		}
 
-From 14df180772a0bef3633aadd589781d2e37707398 Mon Sep 17 00:00:00 2001
+From d947638dc39f3b6f9d5c51a8bf2e519d00c710bc Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Jun 2017 13:05:43 +0100
-Subject: [PATCH 166/171] config: Add CONFIG_CAN_GS_USB
+Subject: [PATCH 166/172] config: Add CONFIG_CAN_GS_USB
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135878,10 +135878,10 @@ index 35dc0b5084256f2ae755703edc3eb67cab0759ec..42163e2c0b5d5666d49793ac4e074d22
  CONFIG_IRLAN=m
  CONFIG_IRNET=m
 
-From 04274e60c3a1e4ecd900a6a9fc1627dfc5738ed1 Mon Sep 17 00:00:00 2001
+From cc0475b17bb70e8e31afe0606ae80f541f2c867d Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 12 Jun 2017 16:10:03 +0100
-Subject: [PATCH 167/171] dwc_otg: add module parameter int_ep_interval_min
+Subject: [PATCH 167/172] dwc_otg: add module parameter int_ep_interval_min
 
 Add a module parameter (defaulting to ignored) that clamps the polling rate
 of high-speed Interrupt endpoints to a minimum microframe interval.
@@ -135963,10 +135963,10 @@ index 4b1dd9de99e9e08b2e006fb5f8a7ef92f20c2553..fe8e8f841f03660c2ad49ab8e66193be
  
  	DWC_DEBUGPL(DBG_HCD, "DWC OTG HCD QH Initialized\n");
 
-From ba67d8bc9e08c0ab6c262472ce7173285fbead81 Mon Sep 17 00:00:00 2001
+From 4917be8ff475c3d37583307dc6c750e7f65fbddf Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Tue, 20 Jun 2017 13:44:01 +0100
-Subject: [PATCH 168/171] dwc_otg: fiq_fsm: Add non-periodic TT exclusivity
+Subject: [PATCH 168/172] dwc_otg: fiq_fsm: Add non-periodic TT exclusivity
  constraints
 
 Certain hub types do not discriminate between pipe direction (IN or OUT)
@@ -136133,10 +136133,10 @@ index 71834cf365e67d7ad995bba7869216c4091c3a74..7710370b30363e3170bf9bf522597c5f
  					st->fsm = FIQ_PER_SSPLIT_STARTED;
  			} else {
 
-From a21e464b62fba11fd1b4950adccae3fc9e8a4b83 Mon Sep 17 00:00:00 2001
+From 84b828e90f67bc9354565fc1689faf578cc79b1b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 21 Jun 2017 17:19:04 +0100
-Subject: [PATCH 169/171] serial: 8250: Fix THRE flag usage for CAP_MINI
+Subject: [PATCH 169/172] serial: 8250: Fix THRE flag usage for CAP_MINI
 
 The BCM2835 MINI UART has non-standard THRE semantics. Conventionally
 the bit means that the FIFO is empty (although there may still be a
@@ -136180,10 +136180,10 @@ index 27e4a15fbe009e45270b5eaf3698bcfd0baaa1e3..75fcdfdf86df13564247885ade1fd9f0
  
  	if (uart_circ_chars_pending(xmit) < WAKEUP_CHARS)
 
-From af9eed0ca99afcc926d18290afb6a42cbe81bc72 Mon Sep 17 00:00:00 2001
+From 73ee4a166ba9a1221b8c3256be9e3d7b20eefe4d Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 26 May 2017 13:03:41 +0100
-Subject: [PATCH 170/171] BCM270X_DT: Add midi-uart1 overlay
+Subject: [PATCH 170/172] BCM270X_DT: Add midi-uart1 overlay
 
 Add a scaler to the ttyS0 clock so that requesting 38400 baud results
 in an approximately 31250 baud signal. This is analagous to
@@ -136281,10 +136281,10 @@ index 0000000000000000000000000000000000000000..e0bc410acbff3a7a175dd5d53b3ab0d0
 +	};
 +};
 
-From 6d8363ed357948a0a218871f5d5a0d9fe37f238f Mon Sep 17 00:00:00 2001
+From e564b20aa2f38b8079866c0511c1bb2e401b4a5e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Sat, 20 May 2017 22:10:14 +0100
-Subject: [PATCH 171/171] overlays: README: remove vestigial SDIO parameters
+Subject: [PATCH 171/172] overlays: README: remove vestigial SDIO parameters
 
 Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 ---
@@ -136337,3 +136337,36 @@ index ec9e7b1941678796facf625b3770c20ed0b15b25..499cd1920fd373702cfbc9f6e0fcaebc
          poll_once               Disable SDIO-device polling every second
                                  (default on: polling once at boot-time)
  
+
+From 109416816930d801991e1098cbd62ab2bcc8c99c Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Tue, 27 Jun 2017 15:07:14 +0100
+Subject: [PATCH 172/172] SQUASH: mmc: Apply ERASE_BROKEN quirks correctly
+
+Squash with: mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+---
+ drivers/mmc/core/quirks.h | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/mmc/core/quirks.h b/drivers/mmc/core/quirks.h
+index 05c8d7381fff5ae88531129d9a5ddd554bddb43e..c9d5d644688c1509d7febcff0322fbaba0a842d6 100644
+--- a/drivers/mmc/core/quirks.h
++++ b/drivers/mmc/core/quirks.h
+@@ -94,12 +94,9 @@ static const struct mmc_fixup mmc_blk_fixups[] = {
+ 	 *  On some Kingston SD cards, multiple erases of less than 64
+ 	 *  sectors can cause corruption.
+ 	 */
+-	MMC_FIXUP("SD16G", 0x41, 0x3432, add_quirk_mmc,
+-		  MMC_QUIRK_ERASE_BROKEN),
+-	MMC_FIXUP("SD32G", 0x41, 0x3432, add_quirk_mmc,
+-		  MMC_QUIRK_ERASE_BROKEN),
+-	MMC_FIXUP("SD64G", 0x41, 0x3432, add_quirk_mmc,
+-		  MMC_QUIRK_ERASE_BROKEN),
++	MMC_FIXUP("SD16G", 0x41, 0x3432, add_quirk, MMC_QUIRK_ERASE_BROKEN),
++	MMC_FIXUP("SD32G", 0x41, 0x3432, add_quirk, MMC_QUIRK_ERASE_BROKEN),
++	MMC_FIXUP("SD64G", 0x41, 0x3432, add_quirk, MMC_QUIRK_ERASE_BROKEN),
+ 
+ 	END_FIXUP
+ };

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,7 +1,7 @@
-From eec8e82e0a53f77804f6ee7eb7ccee8f12ba5c86 Mon Sep 17 00:00:00 2001
+From 7baa3c49eab2220f7fdf302ae9b9e4c3c0b70687 Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
-Subject: [PATCH 001/165] smsx95xx: fix crimes against truesize
+Subject: [PATCH 001/167] smsx95xx: fix crimes against truesize
 
 smsc95xx is adjusting truesize when it shouldn't, and following a recent patch from Eric this is now triggering warnings.
 
@@ -48,10 +48,10 @@ index 5f19fb0f025d9449d0ba20958610e0d1f083f032..ed28f1c3e1d0f2559a62a1c289937944
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From 4d6cc78075b1d8ec8459a0e43cadc2b48f236fa5 Mon Sep 17 00:00:00 2001
+From 03f2e08c0e10118247935c95aad7b39c1ca83cd7 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
-Subject: [PATCH 002/165] smsc95xx: Experimental: Enable turbo_mode and
+Subject: [PATCH 002/167] smsc95xx: Experimental: Enable turbo_mode and
  packetsize=2560 by default
 
 See: http://forum.kodi.tv/showthread.php?tid=285288
@@ -94,10 +94,10 @@ index ed28f1c3e1d0f2559a62a1c28993794497730c5d..f758e122c65685799d4aeeb1c3e6ca81
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From dd6af616b01ce5699d358823f650d0de1dfbcef8 Mon Sep 17 00:00:00 2001
+From d624b2e76eb46571ff165a3cc62b4b8d5d635743 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
-Subject: [PATCH 003/165] Allow mac address to be set in smsc95xx
+Subject: [PATCH 003/167] Allow mac address to be set in smsc95xx
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -193,10 +193,10 @@ index f758e122c65685799d4aeeb1c3e6ca81df0d7980..f6661e388f6e801c1b88e48a3b71407b
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From ed0782cf4d891b3dc1258345c6350fd06abe4e20 Mon Sep 17 00:00:00 2001
+From b29b5174e2ca1d6524646aa6d6709189a4129a2e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
-Subject: [PATCH 004/165] Protect __release_resource against resources without
+Subject: [PATCH 004/167] Protect __release_resource against resources without
  parents
 
 Without this patch, removing a device tree overlay can crash here.
@@ -224,10 +224,10 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From 2cb589e38b396476f7e52e7f91d11f2845000a3c Mon Sep 17 00:00:00 2001
+From 373eddf307d58a53540b0313687251276befb1d3 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
-Subject: [PATCH 005/165] mm: Remove the PFN busy warning
+Subject: [PATCH 005/167] mm: Remove the PFN busy warning
 
 See commit dae803e165a11bc88ca8dbc07a11077caf97bbcb -- the warning is
 expected sometimes when using CMA.  However, that commit still spams
@@ -252,10 +252,10 @@ index a2019fc9d94df3af9cf2c5ce1a476949c6822efc..5e6e1815923f212f5c1b1d1a213b0b12
  		goto done;
  	}
 
-From 100f8ee402a67c4f9bae7712676bbdd437a579b4 Mon Sep 17 00:00:00 2001
+From aaa48f01d091d62e65857c260111fac14742501b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
-Subject: [PATCH 006/165] irq-bcm2836: Prevent spurious interrupts, and trap
+Subject: [PATCH 006/167] irq-bcm2836: Prevent spurious interrupts, and trap
  them early
 
 The old arch-specific IRQ macros included a dsb to ensure the
@@ -282,10 +282,10 @@ index e7463e3c08143acae3e8cc5682f918c6a0b07ebd..a8db33b50ad9ff83d284fa54fe4d3b65
  #endif
  	} else if (stat) {
 
-From 7d209d07c090d5ba5beef2005ca0f6774cef60d7 Mon Sep 17 00:00:00 2001
+From 6c1a31e3d3e3fba337fd2d51c9014e5a8bfefe33 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:33:30 +0000
-Subject: [PATCH 007/165] irq-bcm2836: Avoid "Invalid trigger warning"
+Subject: [PATCH 007/167] irq-bcm2836: Avoid "Invalid trigger warning"
 
 Initialise the level for each IRQ to avoid a warning from the
 arm arch timer code.
@@ -309,10 +309,10 @@ index a8db33b50ad9ff83d284fa54fe4d3b65f859df0f..c4e151451cf8c8ebde5225515eac2786
  
  static void
 
-From 29d04709a67f6ecd03869b4aae4bb1b1539c873d Mon Sep 17 00:00:00 2001
+From c564e80bb06dde3e3ffe6171452003538b2be384 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
-Subject: [PATCH 008/165] irqchip: bcm2835: Add FIQ support
+Subject: [PATCH 008/167] irqchip: bcm2835: Add FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -441,10 +441,10 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From e7d7541eeb53185497ecf9d5f355c7c734fe6434 Mon Sep 17 00:00:00 2001
+From 98ce0d733463bb5b6ac8022c5f2717d521d8edb9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
-Subject: [PATCH 009/165] irqchip: irq-bcm2835: Add 2836 FIQ support
+Subject: [PATCH 009/167] irqchip: irq-bcm2835: Add 2836 FIQ support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -543,10 +543,10 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From 612f126b64884a5e0f5e73b7c236093b4d56612f Mon Sep 17 00:00:00 2001
+From 32fd76ce4f758d4c26cd473a4e472e9676a3f4c3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
-Subject: [PATCH 010/165] spidev: Add "spidev" compatible string to silence
+Subject: [PATCH 010/167] spidev: Add "spidev" compatible string to silence
  warning
 
 See: https://github.com/raspberrypi/linux/issues/1054
@@ -567,10 +567,10 @@ index 9e2e099baf8ca5cc6510912a36d4ca03daeb8273..e59640942826db2ea14d0bde0ff5ab22
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 5b78423b2e1540634810dac47b48a3d27a83e365 Mon Sep 17 00:00:00 2001
+From 17d89ed0279820828d256cdc60f71b45c83d0dd2 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 3 Jan 2017 18:25:01 +0000
-Subject: [PATCH 011/165] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
+Subject: [PATCH 011/167] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
 
 This reverts commit 85ae9e512f437cd09bf61564bdba29ab88bab3e3.
 ---
@@ -864,10 +864,10 @@ index 85d0091128644c446aed878e87769e82c77c3ebf..4f2621272bfd5cbc0d691d2fabe89e2e
  	if (IS_ERR(pc->pctl_dev)) {
  		gpiochip_remove(&pc->gpio_chip);
 
-From 0578c862453c7aef2e013996ccf5d3aa9e277793 Mon Sep 17 00:00:00 2001
+From 681444a836eab379725531bc601d99a64ee8c644 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
-Subject: [PATCH 012/165] pinctrl-bcm2835: Set base to 0 give expected gpio
+Subject: [PATCH 012/167] pinctrl-bcm2835: Set base to 0 give expected gpio
  numbering
 
 Signed-off-by: Noralf Tronnes <notro@tronnes.org>
@@ -889,10 +889,10 @@ index 4f2621272bfd5cbc0d691d2fabe89e2ee428d6db..5b7cb4c415e19f98e25b221ab0ad36b6
  	.can_sleep = false,
  };
 
-From 90aa0aad83456a4fa846525d06a4359a95e2bdaa Mon Sep 17 00:00:00 2001
+From fbd5d48adc6ad35dd45dae4fc92d54ca576213d0 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
-Subject: [PATCH 013/165] pinctrl-bcm2835: Only request the interrupts listed
+Subject: [PATCH 013/167] pinctrl-bcm2835: Only request the interrupts listed
  in the DTB
 
 Although the GPIO controller can generate three interrupts (four counting
@@ -919,10 +919,10 @@ index 5b7cb4c415e19f98e25b221ab0ad36b6885dae4c..6351fe7f8e314ac5ebb102dd20847b38
  		pc->irq_data[i].irqgroup = i;
  
 
-From d51cfb02233abe9c3ccedaffb8332cd0e77ea6c1 Mon Sep 17 00:00:00 2001
+From 664cd981bb024b3d3d7878321f3fb13fe42d6181 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
-Subject: [PATCH 014/165] spi-bcm2835: Support pin groups other than 7-11
+Subject: [PATCH 014/167] spi-bcm2835: Support pin groups other than 7-11
 
 The spi-bcm2835 driver automatically uses GPIO chip-selects due to
 some unreliability of the native ones. In doing so it chooses the
@@ -1003,10 +1003,10 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From a4aea453b3234e99b5400c631595cc2b1263c016 Mon Sep 17 00:00:00 2001
+From 708b5a91581c0c3e7f76ca3bbf10e314794f5df2 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
-Subject: [PATCH 015/165] spi-bcm2835: Disable forced software CS
+Subject: [PATCH 015/167] spi-bcm2835: Disable forced software CS
 
 Select software CS in bcm2708_common.dtsi, and disable the automatic
 conversion in the driver to allow hardware CS to be re-enabled with an
@@ -1040,10 +1040,10 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From 2188eefb05bfce482654b99c81a5ed2c09ddeba4 Mon Sep 17 00:00:00 2001
+From e16568ce8a006ae0681d0f941de34c644208a62b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
-Subject: [PATCH 016/165] spi-bcm2835: Remove unused code
+Subject: [PATCH 016/167] spi-bcm2835: Remove unused code
 
 ---
  drivers/spi/spi-bcm2835.c | 61 -----------------------------------------------
@@ -1131,10 +1131,10 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From d5045f96098752f22cc453bfb16e08e7883e832d Mon Sep 17 00:00:00 2001
+From 672f7cb467c7bfeb0f3c442f3f67886d802763da Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
-Subject: [PATCH 017/165] ARM: bcm2835: Set Serial number and Revision
+Subject: [PATCH 017/167] ARM: bcm2835: Set Serial number and Revision
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1187,10 +1187,10 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From fafa0aece974e67ed438e7071e1121afebd49897 Mon Sep 17 00:00:00 2001
+From 4c7de422286d313371a8ba49c59462f9f98c7944 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
-Subject: [PATCH 018/165] dmaengine: bcm2835: Load driver early and support
+Subject: [PATCH 018/167] dmaengine: bcm2835: Load driver early and support
  legacy API
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -1293,10 +1293,10 @@ index 6204cc32d09c5096df8aec304c3c37b3bcb6be44..599c218dc8a73172dd4bd4a058fc8f95
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From b535bf90b53b6bc8a2565781dc8855dfd30494c3 Mon Sep 17 00:00:00 2001
+From b301879417013478ccf445fcaa3982a29eab783f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
-Subject: [PATCH 019/165] firmware: Updated mailbox header
+Subject: [PATCH 019/167] firmware: Updated mailbox header
 
 ---
  include/soc/bcm2835/raspberrypi-firmware.h | 9 +++++++++
@@ -1357,10 +1357,10 @@ index cb979ad90401e299344dd5fae38d09c489d8bd58..30fb37fe175df604a738258a2a632bca
  	RPI_FIRMWARE_VCHIQ_INIT =                             0x00048010,
  
 
-From 4f0de8a823dd84a85feec56f089c846fd7655921 Mon Sep 17 00:00:00 2001
+From 30e6770f20c7b014179b2809bb66c28ef6380bec Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
-Subject: [PATCH 020/165] rtc: Add SPI alias for pcf2123 driver
+Subject: [PATCH 020/167] rtc: Add SPI alias for pcf2123 driver
 
 Without this alias, Device Tree won't cause the driver
 to be loaded.
@@ -1380,10 +1380,10 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From 3d6b467733ba028155f18a08fd7363a8af229b46 Mon Sep 17 00:00:00 2001
+From f266d67e0d2f13af2c51ffe675241909f6ab9074 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
-Subject: [PATCH 021/165] watchdog: bcm2835: Support setting reboot partition
+Subject: [PATCH 021/167] watchdog: bcm2835: Support setting reboot partition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -1485,10 +1485,10 @@ index b339e0e67b4c1275fd4992fea4f1e24c0575b783..26b7177573fac2af1cd4ab5488d2686f
  
  static int bcm2835_wdt_probe(struct platform_device *pdev)
 
-From b6ff9a72e22a51449da7f429ef7c1c711dfce429 Mon Sep 17 00:00:00 2001
+From f1270fb2826b3fd5eb1dc29f4286e6a78d533a8c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
-Subject: [PATCH 022/165] reboot: Use power off rather than busy spinning when
+Subject: [PATCH 022/167] reboot: Use power off rather than busy spinning when
  halt is requested
 
 ---
@@ -1511,10 +1511,10 @@ index 3fa867a2aae672755c6ce6448f4148c989dbf964..80dca8dcd6709034b643c6a3f35729e0
  
  /*
 
-From 2aeffd4676df97117a35fab502a02460e7626c36 Mon Sep 17 00:00:00 2001
+From 384a51189b673e007547f71ea6b3b42568ea5dbf Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
-Subject: [PATCH 023/165] bcm: Make RASPBERRYPI_POWER depend on PM
+Subject: [PATCH 023/167] bcm: Make RASPBERRYPI_POWER depend on PM
 
 ---
  drivers/soc/bcm/Kconfig | 1 +
@@ -1533,10 +1533,10 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 5497f9742cad18a9da304bb8955ef1649c86c12a Mon Sep 17 00:00:00 2001
+From 4fdeefd728501eefb1b7e73730f5cfa17abbb4f0 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
-Subject: [PATCH 024/165] Register the clocks early during the boot process, so
+Subject: [PATCH 024/167] Register the clocks early during the boot process, so
  that special/critical clocks can get enabled early on in the boot process
  avoiding the risk of disabling a clock, pll_divider or pll when a claiming
  driver fails to install propperly - maybe it needs to defer.
@@ -1581,10 +1581,10 @@ index 02585387061967ac9408e18ac1bce67e9e9414c0..283d2de45e4f29406d01f24ab1cae3f9
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From f346bb7359bb9ba8fe1b7d0b5aa4e7ff9be41a80 Mon Sep 17 00:00:00 2001
+From aa1d520f85e0815cc82c953e7b219d96a669556e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
-Subject: [PATCH 025/165] bcm2835-rng: Avoid initialising if already enabled
+Subject: [PATCH 025/167] bcm2835-rng: Avoid initialising if already enabled
 
 Avoids the 0x40000 cycles of warmup again if firmware has already used it
 ---
@@ -1610,10 +1610,10 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From c49f43e929fdf7b13e8ec2f977a8b29d24fb954c Mon Sep 17 00:00:00 2001
+From 9893d64c9abbdda2550cdf7c3ca0fcd8f6f785d8 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
-Subject: [PATCH 026/165] kbuild: Ignore dtco targets when filtering symbols
+Subject: [PATCH 026/167] kbuild: Ignore dtco targets when filtering symbols
 
 ---
  scripts/Kbuild.include | 2 +-
@@ -1633,10 +1633,10 @@ index afe3fd3af1e40616857b3e6c425be632c1fa2667..b2bbad417f0c4499a5f49081c8f996b9
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From 50da0852aa6b9a510915c81336ac77b57f63421e Mon Sep 17 00:00:00 2001
+From b7bcc989b44ad827fb975940953463298d21cbc2 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
-Subject: [PATCH 027/165] BCM2835_DT: Fix I2S register map
+Subject: [PATCH 027/167] BCM2835_DT: Fix I2S register map
 
 ---
  Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.txt   | 4 ++--
@@ -1674,10 +1674,10 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From 2f491a058d51e143fc7abee21bcfae31b70f3d65 Mon Sep 17 00:00:00 2001
+From ee08fac8506b74be35668fc595430fd24ff1522c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
-Subject: [PATCH 028/165] clk-bcm2835: Mark used PLLs and dividers CRITICAL
+Subject: [PATCH 028/167] clk-bcm2835: Mark used PLLs and dividers CRITICAL
 
 The VPU configures and relies on several PLLs and dividers. Mark all
 enabled dividers and their PLLs as CRITICAL to prevent the kernel from
@@ -1705,10 +1705,10 @@ index 283d2de45e4f29406d01f24ab1cae3f9f879234a..85df8c74a309f0b877ef65f1c55b086f
  	divider->data = data;
  
 
-From 960974f9595315af7d9001558e0d1719dc81788c Mon Sep 17 00:00:00 2001
+From 44c195fe84a18f02540e8da3d28e06b3643bf39c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
-Subject: [PATCH 029/165] clk-bcm2835: Add claim-clocks property
+Subject: [PATCH 029/167] clk-bcm2835: Add claim-clocks property
 
 The claim-clocks property can be used to prevent PLLs and dividers
 from being marked as critical. It contains a vector of clock IDs,
@@ -1810,10 +1810,10 @@ index 85df8c74a309f0b877ef65f1c55b086f1bb774a1..eec6735505c074c0a76ae647bf0e1bb6
  	       sizeof(cprman_parent_names));
  	of_clk_parent_fill(dev->of_node, cprman->real_parent_names,
 
-From 0cf68f6c976dcd94fdc5e9dfcb85514815419a35 Mon Sep 17 00:00:00 2001
+From 08b23055bd6ab16ba948c37fc989a6aba02c4821 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:06:53 +0000
-Subject: [PATCH 030/165] clk-bcm2835: Correct the prediv logic
+Subject: [PATCH 030/167] clk-bcm2835: Correct the prediv logic
 
 If a clock has the prediv flag set, both the integer and fractional
 parts must be scaled when calculating the resulting frequency.
@@ -1840,10 +1840,10 @@ index eec6735505c074c0a76ae647bf0e1bb68ab3a488..e0d28add45efdf70d1eba590282a3a26
  	return bcm2835_pll_rate_from_divisors(parent_rate, ndiv, fdiv, pdiv);
  }
 
-From e99b65bd772d6e42b107a3b149b19d50e3033c41 Mon Sep 17 00:00:00 2001
+From d59d4fb05c4f64fdc87846011c5ceb18ecdb0379 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 6 Mar 2017 09:06:18 +0000
-Subject: [PATCH 031/165] clk-bcm2835: Read max core clock from firmware
+Subject: [PATCH 031/167] clk-bcm2835: Read max core clock from firmware
 
 The VPU is responsible for managing the core clock, usually under
 direction from the bcm2835-cpufreq driver but not via the clk-bcm2835
@@ -1958,10 +1958,10 @@ index e0d28add45efdf70d1eba590282a3a2654af328d..39f72da6ba1f6ec6ec41d5dc1bf46344
  	for (i = 0;
  	     !of_property_read_u32_index(pdev->dev.of_node, "claim-clocks",
 
-From 0c7a2453f1ef27ec31327e904aad8c2bdb6972f6 Mon Sep 17 00:00:00 2001
+From 7ed6ab6b763d3bb44ca40adb206a453c1217d6a9 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:36:44 +0000
-Subject: [PATCH 032/165] sound: Demote deferral errors to INFO level
+Subject: [PATCH 032/167] sound: Demote deferral errors to INFO level
 
 At present there is no mechanism to specify driver load order,
 which can lead to deferrals and repeated retries until successful.
@@ -1974,7 +1974,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/sound/soc/soc-core.c b/sound/soc/soc-core.c
-index 2722bb0c557310d97816cfa7857b24d7c9bd4948..c32d3c31f34fc12195baf873a507d0b46f5c8ba8 100644
+index 98d60f471c5d705d383c5edca4850bd8facdd030..d2da3077fd980c846c1c86697f73c342b981485f 100644
 --- a/sound/soc/soc-core.c
 +++ b/sound/soc/soc-core.c
 @@ -1057,7 +1057,7 @@ static int soc_bind_dai_link(struct snd_soc_card *card,
@@ -1996,10 +1996,10 @@ index 2722bb0c557310d97816cfa7857b24d7c9bd4948..c32d3c31f34fc12195baf873a507d0b4
  			goto _err_defer;
  		}
 
-From 459069a0909aa7b61395af8d77098a0a411cfbc0 Mon Sep 17 00:00:00 2001
+From 8b986501ea40202e4ad21b16971040449b6f17fe Mon Sep 17 00:00:00 2001
 From: Claggy3 <stephen.maclagan@hotmail.com>
 Date: Sat, 11 Feb 2017 14:00:30 +0000
-Subject: [PATCH 033/165] Update vfpmodule.c
+Subject: [PATCH 033/167] Update vfpmodule.c
 
 Christopher Alexander Tobias Schulze - May 2, 2015, 11:57 a.m.
 This patch fixes a problem with VFP state save and restore related
@@ -2136,10 +2136,10 @@ index a71a48e71fffa8626fe90106815376c44bbe679b..d6c0a5a0a5ae3510db3ace5e3f5d3410
  	/*
  	 * Save the userland NEON/VFP state. Under UP,
 
-From b6ed390ff9842f76496a66acb76526eb0e9788b3 Mon Sep 17 00:00:00 2001
+From 4e190b76ff149cfe97efff189ff4fa3146934027 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 21:13:24 +1100
-Subject: [PATCH 034/165] ASoC: bcm2835_i2s.c: relax the ch2 register setting
+Subject: [PATCH 034/167] ASoC: bcm2835_i2s.c: relax the ch2 register setting
  for 8 channels
 
 This patch allows ch2 registers to be set for 8 channels of audio.
@@ -2160,10 +2160,10 @@ index 6ba20498202ed36906b52096893a88867a79269f..56df7d8a43d0aac055a91b0d24aca8e1
  		format |= BCM2835_I2S_CH1(BCM2835_I2S_CHPOS(ch1pos));
  		format |= BCM2835_I2S_CH2(BCM2835_I2S_CHPOS(ch2pos));
 
-From 71504630ad77c40ba0a67c9b540b427ce5d54c43 Mon Sep 17 00:00:00 2001
+From 02f0b303dadf31d0433db4f1329cce2dcd3a8bee Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
-Subject: [PATCH 035/165] i2c: bcm2835: Add debug support
+Subject: [PATCH 035/167] i2c: bcm2835: Add debug support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -2352,10 +2352,10 @@ index cd07a69e2e9355540442785f95e90823b05c9d10..47167f403cc8329bd811b47c7011c299
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 17d3865ea90a1ee124a0e3a64f00c4d448322591 Mon Sep 17 00:00:00 2001
+From d1351f408db7182432d27590de027ea482d9ef74 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
-Subject: [PATCH 036/165] Main bcm2708/bcm2709 linux port
+Subject: [PATCH 036/167] Main bcm2708/bcm2709 linux port
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -2543,10 +2543,10 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 620d2f432aa96efd2f8dcc812b7fc5f8f241123a Mon Sep 17 00:00:00 2001
+From 081442ac4aa226981d6814b75f9329736f68fb42 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
-Subject: [PATCH 037/165] Add dwc_otg driver
+Subject: [PATCH 037/167] Add dwc_otg driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -63611,10 +63611,10 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 87d5ff0f1d9a318cb39e7537e1fa54c9b9f08bb0 Mon Sep 17 00:00:00 2001
+From 5f235132e77d4251ad694cd75e6164fa079d4e23 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 10 May 2017 12:47:46 +0100
-Subject: [PATCH 038/165] dwcotg: Allow to build without FIQ on ARM64
+Subject: [PATCH 038/167] dwcotg: Allow to build without FIQ on ARM64
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -63635,10 +63635,10 @@ index ed0cd59de37e8f47369f86dba751c78933722abc..53aedbe9727ca5c34e46f5cf998f14c7
  	  The Synopsis DWC controller is a dual-role
  	  host/peripheral/OTG ("On The Go") USB controllers.
 
-From cada4595e9a1d65906bc17d1c99fb5780db953ce Mon Sep 17 00:00:00 2001
+From e6a4e07d22a55bd269de1f7b91efca1c808392ad Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
-Subject: [PATCH 039/165] bcm2708 framebuffer driver
+Subject: [PATCH 039/167] bcm2708 framebuffer driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -67097,10 +67097,10 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From 283d3214cafb02aa9fa108d097c3a543ef7804a1 Mon Sep 17 00:00:00 2001
+From 7ae2f418cce005eb19b8b210cde3fe5a4dc92572 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
-Subject: [PATCH 040/165] dmaengine: Add support for BCM2708
+Subject: [PATCH 040/167] dmaengine: Add support for BCM2708
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -67731,10 +67731,10 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From a5a47d3afb09bdd8ca71d041f2d353cfb1ada9a4 Mon Sep 17 00:00:00 2001
+From b1e182ca7e688b34bd7db0271e9d7105f05f3c61 Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
-Subject: [PATCH 041/165] MMC: added alternative MMC driver
+Subject: [PATCH 041/167] MMC: added alternative MMC driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -69456,10 +69456,10 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From 77af5cd04e4661813eeea9e3fbf9a1b3670e449c Mon Sep 17 00:00:00 2001
+From 50b110ad6f1d531a3d3e0ed0eed3b99105b17c0a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
-Subject: [PATCH 042/165] Adding bcm2835-sdhost driver, and an overlay to
+Subject: [PATCH 042/167] Adding bcm2835-sdhost driver, and an overlay to
  enable it
 
 BCM2835 has two SD card interfaces. This driver uses the other one.
@@ -71855,10 +71855,10 @@ index 0000000000000000000000000000000000000000..a9bc79bfdbb71807819dfe2d8f165144
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From e8e26b13ffabd5f0cd7a41d9dcf74fa830eb0301 Mon Sep 17 00:00:00 2001
+From 909784349b372fb9e258394bf5b738e9606f16b8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
-Subject: [PATCH 043/165] vc_mem: Add vc_mem driver for querying firmware
+Subject: [PATCH 043/167] vc_mem: Add vc_mem driver for querying firmware
  memory addresses
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -72383,10 +72383,10 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From 6f1fd408d70ead65d08c7dec9652c609cffa36c1 Mon Sep 17 00:00:00 2001
+From b9d829114299c97836e2392e3cc7d88fa9d2cc3b Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
-Subject: [PATCH 044/165] vcsm: VideoCore shared memory service for BCM2835
+Subject: [PATCH 044/167] vcsm: VideoCore shared memory service for BCM2835
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -76823,10 +76823,10 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From a9db5311f8bb4d8e98dbc0bdf9b11355cd1ac2c0 Mon Sep 17 00:00:00 2001
+From 2680bf2a4274d0e8c4641c76803e14af1a4f6517 Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
-Subject: [PATCH 045/165] Add /dev/gpiomem device for rootless user GPIO access
+Subject: [PATCH 045/167] Add /dev/gpiomem device for rootless user GPIO access
 
 Signed-off-by: Luke Wren <luke@raspberrypi.org>
 
@@ -77134,10 +77134,10 @@ index 0000000000000000000000000000000000000000..f5e7f1ba8fb6f18dee77fad06a17480c
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From b80eb5aed096c03128cc352589904395d4412dc9 Mon Sep 17 00:00:00 2001
+From b2d4d8e9a43a1e8d4a5860f3ee2a12dfda71a71b Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
-Subject: [PATCH 046/165] Add SMI driver
+Subject: [PATCH 046/167] Add SMI driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -79088,10 +79088,10 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From ed1271f9bdf6d76e0cfee8c8b0a36359aaa98a8d Mon Sep 17 00:00:00 2001
+From 05116148c7263a117d3a61d8d58b59d73e8550b5 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
-Subject: [PATCH 047/165] MISC: bcm2835: smi: use clock manager and fix reload
+Subject: [PATCH 047/167] MISC: bcm2835: smi: use clock manager and fix reload
  issues
 
 Use clock manager instead of self-made clockmanager.
@@ -79261,10 +79261,10 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 304eafe4049385c58b42dcfdbef18cc9fca2a98e Mon Sep 17 00:00:00 2001
+From 477c2c1d0cb377f8e98c227797274f0233f2c6c8 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
-Subject: [PATCH 048/165] Add SMI NAND driver
+Subject: [PATCH 048/167] Add SMI NAND driver
 
 Signed-off-by: Luke Wren <wren6991@gmail.com>
 ---
@@ -79629,10 +79629,10 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From 361deb5cddea99fac7f43cab2fdb408efd9d910c Mon Sep 17 00:00:00 2001
+From a6199124ff8cce277349c17fab6dea100a22b27f Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
-Subject: [PATCH 049/165] lirc: added support for RaspberryPi GPIO
+Subject: [PATCH 049/167] lirc: added support for RaspberryPi GPIO
 
 lirc_rpi: Use read_current_timer to determine transmitter delay. Thanks to jjmz and others
 See: https://github.com/raspberrypi/linux/issues/525
@@ -80495,10 +80495,10 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From 22b652cf091213d42d68bc030e327de206541581 Mon Sep 17 00:00:00 2001
+From 8837697d0a331c5d0bf5116ef174f8ec5ea1dae7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
-Subject: [PATCH 050/165] Add cpufreq driver
+Subject: [PATCH 050/167] Add cpufreq driver
 
 Signed-off-by: popcornmix <popcornmix@gmail.com>
 ---
@@ -80765,10 +80765,10 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 0944045dd011420aadd23ca441f7ddfe312a82ef Mon Sep 17 00:00:00 2001
+From 179c5c9c0a72eb6552dd4d7ef64d1821520f8d76 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
-Subject: [PATCH 051/165] Added hwmon/thermal driver for reporting core
+Subject: [PATCH 051/167] Added hwmon/thermal driver for reporting core
  temperature. Thanks Dorian
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -80934,10 +80934,10 @@ index 0000000000000000000000000000000000000000..c63fb9f9d143e19612a18fe530c7b2b3
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From 3f9efad37966f2c1b6ff738e046c0176a192cce7 Mon Sep 17 00:00:00 2001
+From 531fcde2e4e7dedcd1d8e5b07bd21c5e543dca37 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
-Subject: [PATCH 052/165] Add Chris Boot's i2c driver
+Subject: [PATCH 052/167] Add Chris Boot's i2c driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81602,10 +81602,10 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 8876c932d6563079055f340a31d84b827d405c3d Mon Sep 17 00:00:00 2001
+From 1c01f9c2268055abf3cc1d765a346038db0912f1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
-Subject: [PATCH 053/165] char: broadcom: Add vcio module
+Subject: [PATCH 053/167] char: broadcom: Add vcio module
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81830,10 +81830,10 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 1dfdb36a2391125d8fafa49ea19813f135fe1053 Mon Sep 17 00:00:00 2001
+From ce0242da08e94db465c2f23685b41607467f5ac9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
-Subject: [PATCH 054/165] firmware: bcm2835: Support ARCH_BCM270x
+Subject: [PATCH 054/167] firmware: bcm2835: Support ARCH_BCM270x
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -81916,10 +81916,10 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From c6605ccd47162385d7a23dbbdf405dace67904ab Mon Sep 17 00:00:00 2001
+From d342d8f317929a3ac6ac9b409a237499d5a798bf Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
-Subject: [PATCH 055/165] scripts: Add mkknlimg and knlinfo scripts from tools
+Subject: [PATCH 055/167] scripts: Add mkknlimg and knlinfo scripts from tools
  repo
 
 The Raspberry Pi firmware looks for a trailer on the kernel image to
@@ -82439,10 +82439,10 @@ index 0000000000000000000000000000000000000000..60206de7fa9a49bd027c635306674a29
 +	return $trailer;
 +}
 
-From 70c91958bd15ee39b973b2ac6540dbdde55f2e51 Mon Sep 17 00:00:00 2001
+From 07861071c5d6a6c5742626acbabb3c77b9ca8004 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
-Subject: [PATCH 056/165] BCM2708: Add core Device Tree support
+Subject: [PATCH 056/167] BCM2708: Add core Device Tree support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -93741,10 +93741,10 @@ index 7234e61e7ce370a775ec6981b391b6d102a01770..1b53cd59e4875d388e4974a3399d5f07
  
  # Bzip2
 
-From 86e429ede242de1e764cfcaf0a81bf7970745da7 Mon Sep 17 00:00:00 2001
+From c115b5c6807f04f4b92b05cc86dc3f0a17212bdf Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
-Subject: [PATCH 057/165] BCM270x_DT: Add pwr_led, and the required "input"
+Subject: [PATCH 057/167] BCM270x_DT: Add pwr_led, and the required "input"
  trigger
 
 The "input" trigger makes the associated GPIO an input.  This is to support
@@ -93920,10 +93920,10 @@ index 38c0bd7ca1074af234d516275791d05f945ce1f0..2f026646d24bad617c73aa79db30c9aa
  	/* set_brightness_work / blink_timer flags, atomic, private. */
  	unsigned long		work_flags;
 
-From 217263cee115ee506f81005c377199f0fc8a924e Mon Sep 17 00:00:00 2001
+From 736f22c6312254a82104b90d9d07f79da7dce290 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
-Subject: [PATCH 058/165] fbdev: add FBIOCOPYAREA ioctl
+Subject: [PATCH 058/167] fbdev: add FBIOCOPYAREA ioctl
 
 Based on the patch authored by Ali Gholami Rudi at
     https://lkml.org/lkml/2009/7/13/153
@@ -94175,10 +94175,10 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From a6204ae1aa4ec42e8712b978bb1861d6a86a7579 Mon Sep 17 00:00:00 2001
+From cd20f1468770e26ce84c2300c72d22afed6067a5 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
-Subject: [PATCH 059/165] Speed up console framebuffer imageblit function
+Subject: [PATCH 059/167] Speed up console framebuffer imageblit function
 
 Especially on platforms with a slower CPU but a relatively high
 framebuffer fill bandwidth, like current ARM devices, the existing
@@ -94387,10 +94387,10 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From f1700c6ad46b4119d0fb8266ebc281fd7f41a252 Mon Sep 17 00:00:00 2001
+From 889a149a9b3ff0fde024f47d233913f6722c32b3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
-Subject: [PATCH 060/165] enabling the realtime clock 1-wire chip DS1307 and
+Subject: [PATCH 060/167] enabling the realtime clock 1-wire chip DS1307 and
  1-wire on GPIO4 (as a module)
 
 1-wire: Add support for configuring pin for w1-gpio kernel module
@@ -94640,10 +94640,10 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From 1d79f813e2a452b627e0959a3dae26d5fc546df2 Mon Sep 17 00:00:00 2001
+From 341fd02643774889ec433de1dc183d52774e8e6e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
-Subject: [PATCH 061/165] hid: Reduce default mouse polling interval to 60Hz
+Subject: [PATCH 061/167] hid: Reduce default mouse polling interval to 60Hz
 
 Reduces overhead when using X
 ---
@@ -94679,10 +94679,10 @@ index 961bc6fdd2d908835fa9a07d169a4746fb44189d..c595188a1156a27aa79f111d81636b6d
  		ret = -ENOMEM;
  		if (usb_endpoint_dir_in(endpoint)) {
 
-From 79655397b4bbc80f8d05ff0fddd3f98f19950eba Mon Sep 17 00:00:00 2001
+From 120adec9d51a49a923ea2298c584e32d81db35f7 Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
-Subject: [PATCH 062/165] rpi-ft5406: Add touchscreen driver for pi LCD display
+Subject: [PATCH 062/167] rpi-ft5406: Add touchscreen driver for pi LCD display
 
 Fix driver detection failure Check that the buffer response is non-zero meaning the touchscreen was detected
 
@@ -95040,10 +95040,10 @@ index 30fb37fe175df604a738258a2a632bca3bfff33f..4a3d79d3b48eb483a4e4bf498f617515
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 5818708586c901f066d91d8b56ad0cb77bbf4690 Mon Sep 17 00:00:00 2001
+From f6d4f727ca4a4d14fb8f17567f0a2bfa662d6140 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
-Subject: [PATCH 063/165] Improve __copy_to_user and __copy_from_user
+Subject: [PATCH 063/167] Improve __copy_to_user and __copy_from_user
  performance
 
 Provide a __copy_from_user that uses memcpy. On BCM2708, use
@@ -96618,10 +96618,10 @@ index 333dc3c2e5ffbb2c5ab8fcfb6115b6162643cf20..46b787a6474ffa857da9b663948863ec
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From 6b1b3a3ef75add34389b359f40c1940fc7cd63fe Mon Sep 17 00:00:00 2001
+From 35f2a98ce5c95ac5920f88a9935a53fc3443b452 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
-Subject: [PATCH 064/165] gpio-poweroff: Allow it to work on Raspberry Pi
+Subject: [PATCH 064/167] gpio-poweroff: Allow it to work on Raspberry Pi
 
 The Raspberry Pi firmware manages the power-down and reboot
 process. To do this it installs a pm_power_off handler, causing
@@ -96656,10 +96656,10 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From f314149d428e7a455693fc1083dbec50946deea2 Mon Sep 17 00:00:00 2001
+From f9fa2d348680082117a1fdf1bb79ba1cae721bb9 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
-Subject: [PATCH 065/165] mfd: Add Raspberry Pi Sense HAT core driver
+Subject: [PATCH 065/167] mfd: Add Raspberry Pi Sense HAT core driver
 
 ---
  drivers/input/joystick/Kconfig           |   8 +
@@ -97524,10 +97524,10 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From 49bcd5a2235a3263cb1eadcc2c8341bbb5ced3f7 Mon Sep 17 00:00:00 2001
+From 423c8100d60affbd48c457e57955909b67c9f8b9 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
-Subject: [PATCH 066/165] ASoC: Add support for HifiBerry DAC
+Subject: [PATCH 066/167] ASoC: Add support for HifiBerry DAC
 
 This adds a machine driver for the HifiBerry DAC.
 It is a sound card that can
@@ -97702,10 +97702,10 @@ index 0000000000000000000000000000000000000000..ee9f133953544629282631e5ef3f73fe
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 1bda67aead6bdf783fba311a76a8c7bc89998f1e Mon Sep 17 00:00:00 2001
+From 4541f0420a0907822f07f19579e7c98ed8eb31cf Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
-Subject: [PATCH 067/165] ASoC: Add support for Rpi-DAC
+Subject: [PATCH 067/167] ASoC: Add support for Rpi-DAC
 
 ---
  sound/soc/bcm/Kconfig       |   7 +++
@@ -97989,10 +97989,10 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From 1b6f27f9343dde5378cc30d5ac8e6d5188b6434d Mon Sep 17 00:00:00 2001
+From d7f6fadf9144b6a107886ada2a24d37e4ac778ba Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
-Subject: [PATCH 068/165] ASoC: wm8804: Implement MCLK configuration options,
+Subject: [PATCH 068/167] ASoC: wm8804: Implement MCLK configuration options,
  add 32bit support WM8804 can run with PLL frequencies of 256xfs and 128xfs
  for most sample rates. At 192kHz only 128xfs is supported. The existing
  driver selects 128xfs automatically for some lower samples rates. By using an
@@ -98041,10 +98041,10 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From 4203d8a7ecc11940a0ee32e252a4e8eb1e300be9 Mon Sep 17 00:00:00 2001
+From 08d9a617c70bbf304162528bdb2b354b57d73b56 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
-Subject: [PATCH 069/165] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
+Subject: [PATCH 069/167] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
  based on the patched WM8804 driver.
 
 Signed-off-by: Daniel Matuschek <daniel@matuschek.net>
@@ -98388,10 +98388,10 @@ index 0000000000000000000000000000000000000000..7620dd02de40b6d644ff038b445d375d
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From ec2fa327814dd534f249f561f4b7733474018e08 Mon Sep 17 00:00:00 2001
+From 482327a2f5f8ebde72df26fe6d7e106deb20dea6 Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
-Subject: [PATCH 070/165] Add IQaudIO Sound Card support for Raspberry Pi
+Subject: [PATCH 070/167] Add IQaudIO Sound Card support for Raspberry Pi
 
 Set a limit of 0dB on Digital Volume Control
 
@@ -98726,10 +98726,10 @@ index 0000000000000000000000000000000000000000..1ee4097c846376666775272ed692ca33
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 98d8d9f0157769a6accc0f9a97c0858c049ce420 Mon Sep 17 00:00:00 2001
+From 8a025c470d6837159afc9745f2aca3e56f37c6b6 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
-Subject: [PATCH 071/165] Added support for HiFiBerry DAC+
+Subject: [PATCH 071/167] Added support for HiFiBerry DAC+
 
 The driver is based on the HiFiBerry DAC driver. However HiFiBerry DAC+ uses
 a different codec chip (PCM5122), therefore a new driver is necessary.
@@ -99359,10 +99359,10 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From 7bb18adf89ee8b0c875e00b2656258e81e8cfb46 Mon Sep 17 00:00:00 2001
+From 8e80f75d88d95b5c33eecde75588de8c3895345e Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
-Subject: [PATCH 072/165] Added driver for HiFiBerry Amp amplifier add-on board
+Subject: [PATCH 072/167] Added driver for HiFiBerry Amp amplifier add-on board
 
 The driver contains a low-level hardware driver for the TAS5713 and the
 drivers for the Raspberry Pi I2S subsystem.
@@ -100197,10 +100197,10 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From 4a149107af657bdcc1af318bf22aa07d81575bd2 Mon Sep 17 00:00:00 2001
+From 7f42c9601a1460e1842bf68bb5dda837cbf466cc Mon Sep 17 00:00:00 2001
 From: Ryan Coe <bluemrp9@gmail.com>
 Date: Sat, 31 Jan 2015 18:25:49 -0700
-Subject: [PATCH 073/165] Update ds1307 driver for device-tree support
+Subject: [PATCH 073/167] Update ds1307 driver for device-tree support
 
 Signed-off-by: Ryan Coe <bluemrp9@gmail.com>
 ---
@@ -100227,10 +100227,10 @@ index 4ad97be480430babc3321075f2739114eaad8f04..2ac1c265dc9cea56a5949eb537949a1f
  	.driver = {
  		.name	= "rtc-ds1307",
 
-From d386b7729bf018e7af5d2c9d97d9cae64b7ca7ed Mon Sep 17 00:00:00 2001
+From f3e31913fb12076dc9ef5276309cc45e1fabef51 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
-Subject: [PATCH 074/165] Add driver for rpi-proto
+Subject: [PATCH 074/167] Add driver for rpi-proto
 
 Forward port of 3.10.x driver from https://github.com/koalo
 We are using a custom board and would like to use rpi 3.18.x
@@ -100445,10 +100445,10 @@ index 0000000000000000000000000000000000000000..fadbfade100228aaafabb0d3bdf35c01
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 50df58347caf99a91c63ec69fbabc478c05be006 Mon Sep 17 00:00:00 2001
+From 9df5a22847cb998671c0944ce278db8927445ff0 Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
-Subject: [PATCH 075/165] RaspiDAC3 support
+Subject: [PATCH 075/167] RaspiDAC3 support
 
 Signed-off-by: Jan Grulich <jan@grulich.eu>
 
@@ -100691,10 +100691,10 @@ index 0000000000000000000000000000000000000000..ad2b5b89bc8213dc2e277306ef50d6e3
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From 01d97e660859bbaf61ec25005d26327106eb7c1b Mon Sep 17 00:00:00 2001
+From 8db91f8258d55216d465cc4172f3e74a5864e831 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
-Subject: [PATCH 076/165] Add Support for JustBoom Audio boards
+Subject: [PATCH 076/167] Add Support for JustBoom Audio boards
 
 justboom-dac: Adjust for ALSA API change
 
@@ -101150,10 +101150,10 @@ index 0000000000000000000000000000000000000000..909cf8928f2f4313982316f9c5b8a709
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From ac95f6f251a9c713127de621c82fda3e232ae663 Mon Sep 17 00:00:00 2001
+From cff0ea60385d53808797dceb63b24cfba63d8266 Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
-Subject: [PATCH 077/165] ARM: adau1977-adc: Add basic machine driver for
+Subject: [PATCH 077/167] ARM: adau1977-adc: Add basic machine driver for
  adau1977 codec driver.
 
 This commit adds basic support for the codec usage including: Device tree overlay,
@@ -101335,10 +101335,10 @@ index 0000000000000000000000000000000000000000..f3d7e5db7bb912e1d7ca6f8e8d42df5f
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From f18cd7471ca951c2b19a6078d27d7e3401aa6e11 Mon Sep 17 00:00:00 2001
+From b75774af8630b0d522b58c63dda95c003afd8c4d Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
-Subject: [PATCH 078/165] New AudioInjector.net Pi soundcard with low jitter
+Subject: [PATCH 078/167] New AudioInjector.net Pi soundcard with low jitter
  audio in and out.
 
 Contains the sound/soc/bcm ALSA machine driver and necessary alterations to the Kconfig and Makefile.
@@ -101589,10 +101589,10 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 16b653a5097cd5a1c04febf4bc0f5e3bd362b4e5 Mon Sep 17 00:00:00 2001
+From 0ae26cbf8c5398d4beddf36877feaaf6c731640e Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
-Subject: [PATCH 079/165] Add IQAudIO Digi WM8804 board support
+Subject: [PATCH 079/167] Add IQAudIO Digi WM8804 board support
 
 Support IQAudIO Digi board with iqaudio_digi machine driver and
  iqaudio-digi-wm8804-audio overlay.
@@ -101892,10 +101892,10 @@ index 0000000000000000000000000000000000000000..33aa2be8a43a12a12cfb5d844dd9732c
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From b6dae67e4cad0b02c1a96724fb64a582050b28d1 Mon Sep 17 00:00:00 2001
+From 6540759002e73a890d45fef76a69890c9517d001 Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
-Subject: [PATCH 080/165] New driver for RRA DigiDAC1 soundcard using WM8741 +
+Subject: [PATCH 080/167] New driver for RRA DigiDAC1 soundcard using WM8741 +
  WM8804
 
 ---
@@ -102368,10 +102368,10 @@ index 0000000000000000000000000000000000000000..f200688bb4ae32b90a0ced555aed94b0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From 70c86519d56cecf0d2a737618d38473cbb3e244c Mon Sep 17 00:00:00 2001
+From d031fa0d7b6f81ebb6569e8349018b5a78b071f1 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
-Subject: [PATCH 081/165] Add support for Dion Audio LOCO DAC-AMP HAT
+Subject: [PATCH 081/167] Add support for Dion Audio LOCO DAC-AMP HAT
 
 Using dedicated machine driver and pcm5102a codec driver.
 
@@ -102544,10 +102544,10 @@ index 0000000000000000000000000000000000000000..65e03741d349a2dc5bd91f69855ea952
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From e1693ecb2428bbfed103e59500c4b4025e4c7812 Mon Sep 17 00:00:00 2001
+From cf0ffeca41fee940cbfea5ab210d02e3a589e3c6 Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
-Subject: [PATCH 082/165] Allo Piano DAC boards: Initial 2 channel (stereo)
+Subject: [PATCH 082/167] Allo Piano DAC boards: Initial 2 channel (stereo)
  support (#1645)
 
 Add initial 2 channel (stereo) support for Allo Piano DAC (2.0/2.1) boards,
@@ -102754,10 +102754,10 @@ index 0000000000000000000000000000000000000000..eaf50fb6dbca1970ae1c6f8662088b0f
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From b995663e0332cb0daa1463dba5f64619ae94ffcb Mon Sep 17 00:00:00 2001
+From 47ff419aff86173707854f0d30272d9085ac5d2e Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
-Subject: [PATCH 083/165] Support for Blokas Labs pisound board
+Subject: [PATCH 083/167] Support for Blokas Labs pisound board
 
 Pisound dynamic overlay (#1760)
 
@@ -103956,10 +103956,10 @@ index 0000000000000000000000000000000000000000..06ff1e53dc9d860946965b6303577762
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From e77c3d78825e40c441047887d354f7525a19a611 Mon Sep 17 00:00:00 2001
+From b3cd29b517b80b88ae173408f4b94c5cb03ef2c1 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 22 Jan 2017 12:49:37 +0100
-Subject: [PATCH 084/165] ASoC: Add driver for Cirrus Logic Audio Card
+Subject: [PATCH 084/167] ASoC: Add driver for Cirrus Logic Audio Card
 
 Note: due to problems with deferred probing of regulators
 the following softdep should be added to a modprobe.d file
@@ -105024,10 +105024,10 @@ index 0000000000000000000000000000000000000000..ac8651ddff7bd3701dffe22c7fb88352
 +MODULE_DESCRIPTION("ASoC driver for Cirrus Logic Audio Card");
 +MODULE_LICENSE("GPL");
 
-From 64a469b73e0b90f821ef39c74e683a5ddac3f8f0 Mon Sep 17 00:00:00 2001
+From 13e703007020d35b99bce051103df210605ce3a0 Mon Sep 17 00:00:00 2001
 From: Miquel <miquelblauw@hotmail.com>
 Date: Fri, 24 Feb 2017 20:51:06 +0100
-Subject: [PATCH 085/165] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
+Subject: [PATCH 085/167] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
 
 Signed-off-by: Miquel Blauw <info@dionaudio.nl>
 ---
@@ -105221,10 +105221,10 @@ index 0000000000000000000000000000000000000000..a009c49477972a9832175d86f201b035
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO-V2");
 +MODULE_LICENSE("GPL v2");
 
-From a6bdc87e9ccb8f8cd1973767c81610720b0da45f Mon Sep 17 00:00:00 2001
+From 085b8a6b22489e1ca17b453ac038cbb059a8c2f3 Mon Sep 17 00:00:00 2001
 From: Fe-Pi <fe-pi@cox.net>
 Date: Wed, 1 Mar 2017 04:42:43 -0700
-Subject: [PATCH 086/165] Add support for Fe-Pi audio sound card. (#1867)
+Subject: [PATCH 086/167] Add support for Fe-Pi audio sound card. (#1867)
 
 Fe-Pi Audio Sound Card is based on NXP SGTL5000 codec.
 Mechanical specification of the board is the same the Raspberry Pi Zero.
@@ -105438,10 +105438,10 @@ index 0000000000000000000000000000000000000000..015b56fd73cc36be5b5eecd17548fd03
 +MODULE_DESCRIPTION("ASoC Driver for Fe-Pi Audio");
 +MODULE_LICENSE("GPL v2");
 
-From 70d336fd5ba0a544056a791c279983ab7da6036d Mon Sep 17 00:00:00 2001
+From f7d705034138b4ec264404e9c5b7ed8b67a5369f Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 20:04:13 +1100
-Subject: [PATCH 087/165] Add support for the AudioInjector.net Octo sound card
+Subject: [PATCH 087/167] Add support for the AudioInjector.net Octo sound card
 
 ---
  sound/soc/bcm/Kconfig                        |   7 +
@@ -105781,10 +105781,10 @@ index 0000000000000000000000000000000000000000..9effea725798640887755dfa688da453
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:audioinjector-octo-soundcard");
 
-From f68eb19ebf3a0566d9d80bbb055a8bc28e073b7b Mon Sep 17 00:00:00 2001
+From edbb4bc8990af45a4a3468772e4c435916c769e1 Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
-Subject: [PATCH 088/165] rpi_display: add backlight driver and overlay
+Subject: [PATCH 088/167] rpi_display: add backlight driver and overlay
 
 Add a mailbox-driven backlight controller for the Raspberry Pi DSI
 touchscreen display. Requires updated GPU firmware to recognise the
@@ -105953,10 +105953,10 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 0fb6a814bc3b9507464eb8a046adf37a30debc3e Mon Sep 17 00:00:00 2001
+From 86bae806b98daf5896f5e2536169dc315da7d5ac Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
-Subject: [PATCH 089/165] bcm2835-virtgpio: Virtual GPIO driver
+Subject: [PATCH 089/167] bcm2835-virtgpio: Virtual GPIO driver
 
 Add a virtual GPIO driver that uses the firmware mailbox interface to
 request that the VPU toggles LEDs.
@@ -106230,10 +106230,10 @@ index 4a3d79d3b48eb483a4e4bf498f617515e3ad158f..5f34e1257117fb48013c9926a8a223d6
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 0fa4ceb300a845b20a199b3dae01047477736c13 Mon Sep 17 00:00:00 2001
+From 305ff41d7e62f603a6ae07e5cbfaafbf1259f09c Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Mon, 20 Feb 2017 17:01:21 +0000
-Subject: [PATCH 090/165] bcm2835-gpio-exp: Driver for GPIO expander via
+Subject: [PATCH 090/167] bcm2835-gpio-exp: Driver for GPIO expander via
  mailbox service
 
 Pi3 and Compute Module 3 have a GPIO expander that the
@@ -106561,10 +106561,10 @@ index 5f34e1257117fb48013c9926a8a223d64a598ab7..c819c21b0158a59c1308882e5a40e3f3
  	/* Dispmanx TAGS */
  	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,
 
-From d73039233e0664fa7d0207d2ad318891d3cb4872 Mon Sep 17 00:00:00 2001
+From ba14863b8ffba55a0e850e1baf742f1cc81f461a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
-Subject: [PATCH 091/165] amba_pl011: Don't use DT aliases for numbering
+Subject: [PATCH 091/167] amba_pl011: Don't use DT aliases for numbering
 
 The pl011 driver looks for DT aliases of the form "serial<n>",
 and if found uses <n> as the device ID. This can cause
@@ -106593,10 +106593,10 @@ index f2503d862f3aee25396ef002ba69968896316779..a85e81245004e928fc52ec59044e151b
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From 8a8978e045b1b1a2553f467e461914348d9478c6 Mon Sep 17 00:00:00 2001
+From e3396edd19d3a1104ef38acfea057c02017d7213 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:07:39 +0000
-Subject: [PATCH 092/165] amba_pl011: Round input clock up
+Subject: [PATCH 092/167] amba_pl011: Round input clock up
 
 The UART clock is initialised to be as close to the requested
 frequency as possible without exceeding it. Now that there is a
@@ -106682,10 +106682,10 @@ index a85e81245004e928fc52ec59044e151b7f183496..380d2c2e19ae3720924e906261b487ad
  /* unregisters the driver also if no more ports are left */
  static void pl011_unregister_port(struct uart_amba_port *uap)
 
-From 74c653d482da42e6aba7f99cc823b2d01dc02aaa Mon Sep 17 00:00:00 2001
+From f86774023e35e89bd38bf7dd602f483e5ecaab79 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
-Subject: [PATCH 093/165] OF: DT-Overlay configfs interface
+Subject: [PATCH 093/167] OF: DT-Overlay configfs interface
 
 This is a port of Pantelis Antoniou's v3 port that makes use of the
 new upstreamed configfs support for binary attributes.
@@ -107117,10 +107117,10 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From effcd07f73d479a6511ee68707de719220e99823 Mon Sep 17 00:00:00 2001
+From ec8e585ace9f560a72baec01bf56cfa8c13797cf Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
-Subject: [PATCH 094/165] brcm: adds support for BCM43341 wifi
+Subject: [PATCH 094/167] brcm: adds support for BCM43341 wifi
 
 brcmfmac: Disable power management
 
@@ -107271,10 +107271,10 @@ index 65689469c5a12e2fcfd6123ca584944da79ec184..4886dc29ad36705210bed20757ce09ed
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_43362_CHIP_ID, 0xFFFFFFFE, 43362),
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_4339_CHIP_ID, 0xFFFFFFFF, 4339),
 
-From 1320537ec6b1f68a2d2c98a5a021af072bfe52b4 Mon Sep 17 00:00:00 2001
+From 7591b981df69c497fb743678d28602029340c7fd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Feb 2017 15:26:13 +0000
-Subject: [PATCH 095/165] brcmfmac: Mute expected startup 'errors'
+Subject: [PATCH 095/167] brcmfmac: Mute expected startup 'errors'
 
 The brcmfmac WiFi driver always complains about the '00' country code
 and the firmware version is reported as an error. Modify the driver to
@@ -107313,10 +107313,10 @@ index 6221b046bca44211e2dfac24119097f7ac09e829..634602e0c44f91da06db7aa803dbee69
  	/* locate firmware version number for ethtool */
  	ptr = strrchr(buf, ' ') + 1;
 
-From cc7b61dbf910489fbc3eafab91dc3885b04e6121 Mon Sep 17 00:00:00 2001
+From b152a60b1a115e948d7d41aeee5cf020404e8ae0 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
-Subject: [PATCH 096/165] hci_h5: Don't send conf_req when ACTIVE
+Subject: [PATCH 096/167] hci_h5: Don't send conf_req when ACTIVE
 
 Without this patch, a modem and kernel can continuously bombard each
 other with conf_req and conf_rsp messages, in a demented game of tag.
@@ -107339,10 +107339,10 @@ index 90d0456b67446bcc624fab4b1542c4eaf21531b1..f9adeac3bbba6418dcca298c55706356
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From 74f96671805d1329a6f032906d2671c2a678e053 Mon Sep 17 00:00:00 2001
+From 71ae35b5158addcd1212846a7f21007c6fbd8e11 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
-Subject: [PATCH 097/165] config: Add default configs
+Subject: [PATCH 097/167] config: Add default configs
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1309 +++++++++++++++++++++++++++++++++++
@@ -109990,10 +109990,10 @@ index 0000000000000000000000000000000000000000..046f3e8757ef0f794c802171690528d3
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 7108a6c4ae059e0eb29be9b135245bf3f2d09840 Mon Sep 17 00:00:00 2001
+From e1c2dd2f25fbe0894052e55ed76a06fe34f66596 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
-Subject: [PATCH 098/165] Add arm64 configuration and device tree differences.
+Subject: [PATCH 098/167] Add arm64 configuration and device tree differences.
  Disable MMC_BCM2835_SDHOST and MMC_BCM2835 since these drivers are crashing
  at the moment.
 
@@ -111408,10 +111408,10 @@ index 0000000000000000000000000000000000000000..e6b09fafa27eed2b762e3d53b55041f7
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2835_VCHIQ=n
 
-From b90de4bf27dc5f62e60dad127169218c6d830649 Mon Sep 17 00:00:00 2001
+From 6a99ce4838c49f3647570b3ad1aacc2cafca5cab Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
-Subject: [PATCH 099/165] raspberrypi-firmware: Define the MBOX channel in the
+Subject: [PATCH 099/167] raspberrypi-firmware: Define the MBOX channel in the
  header.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -111433,10 +111433,10 @@ index c819c21b0158a59c1308882e5a40e3f3fe73cbdf..de2a3dcd562beb752266eaf0070e5586
  
  enum rpi_firmware_property_status {
 
-From fbcb1aa2507b4d4b0e47310e79c16ced1d3c36c2 Mon Sep 17 00:00:00 2001
+From 0aaa5d8506326b0ae0cbcd7b4a506042fe92624a Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
-Subject: [PATCH 100/165] raspberrypi-firmware: Export the general transaction
+Subject: [PATCH 100/167] raspberrypi-firmware: Export the general transaction
  function.
 
 The vc4-firmware-kms module is going to be doing the MBOX FB call.
@@ -111480,10 +111480,10 @@ index de2a3dcd562beb752266eaf0070e55861d553f5f..dc7fd58afd5dddebf9b17065bb069a1d
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From b1ee95c4f890ff8efedd86c367d8e33133eb6dcd Mon Sep 17 00:00:00 2001
+From 22ad8746250c19da0e947b71f8c062b5a79c9dad Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
-Subject: [PATCH 101/165] ARM64: Make it work again on 4.9 (#1790)
+Subject: [PATCH 101/167] ARM64: Make it work again on 4.9 (#1790)
 
 * Invoke the dtc compiler with the same options used in arm mode.
 * ARM64 now uses the bcm2835 platform just like ARM32.
@@ -111887,10 +111887,10 @@ index e6b09fafa27eed2b762e3d53b55041f793683d27..c7e891d72969a388d9b135a36dbfc9c9
  CONFIG_LIBCRC32C=y
 -CONFIG_BCM2835_VCHIQ=n
 
-From 6d08a630ee3d0f12214ebc127b923e7b45143d5b Mon Sep 17 00:00:00 2001
+From 4d2147d24dba3f03f3df8c85f64a5c41e913fd3b Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:10:07 -0800
-Subject: [PATCH 102/165] ARM64: Enable HDMI audio and vc04_services in
+Subject: [PATCH 102/167] ARM64: Enable HDMI audio and vc04_services in
  bcmrpi3_defconfig
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
@@ -111919,10 +111919,10 @@ index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..4b90f9b64abe9f089ba56b13d5a00de3
  CONFIG_BCM2835_MBOX=y
  # CONFIG_IOMMU_SUPPORT is not set
 
-From d53026029509dbe88b1b77064fbeb5d4a2537a28 Mon Sep 17 00:00:00 2001
+From 37ffd804f5315afc60cbf54f51b330415725e863 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:14:03 -0800
-Subject: [PATCH 103/165] ARM64: Run bcmrpi3_defconfig through savedefconfig.
+Subject: [PATCH 103/167] ARM64: Run bcmrpi3_defconfig through savedefconfig.
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
 ---
@@ -111967,10 +111967,10 @@ index 4b90f9b64abe9f089ba56b13d5a00de33343bfb9..dac962ca1634662ce7d966f1ffb53b5b
  CONFIG_FB_TFT_AGM1264K_FL=m
  CONFIG_FB_TFT_BD663474=m
 
-From bf7dcc1e405a45a9fff42eccb14725ce6f7f1a5b Mon Sep 17 00:00:00 2001
+From 7c154e23f4fc414763ce2d51a44ab325658a1e1d Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 02:54:26 -0800
-Subject: [PATCH 104/165] ARM64: Enable Kernel Address Space Randomization
+Subject: [PATCH 104/167] ARM64: Enable Kernel Address Space Randomization
  (#1792)
 
 Randomization allows the mapping between virtual addresses and physical
@@ -112002,10 +112002,10 @@ index dac962ca1634662ce7d966f1ffb53b5bfa27c506..aae33b4b3c3e736ea7cd3ca242158ad6
  CONFIG_BINFMT_MISC=y
  CONFIG_COMPAT=y
 
-From f887a82633699721d6bf9b19e321ee5b8afccee3 Mon Sep 17 00:00:00 2001
+From 69bfe478cc79277ce1f11f1456ae991f5ae79c0b Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sun, 15 Jan 2017 07:31:59 -0800
-Subject: [PATCH 105/165] ARM64: Enable RTL8187/RTL8192CU wifi in build config
+Subject: [PATCH 105/167] ARM64: Enable RTL8187/RTL8192CU wifi in build config
 
 These drivers build now, so they can be enabled back
 in the build configuration just like they are for
@@ -112030,10 +112030,10 @@ index aae33b4b3c3e736ea7cd3ca242158ad6ba558aff..b7d762df19b85e369a32cd823dfd0621
  CONFIG_ZD1211RW=m
  CONFIG_MAC80211_HWSIM=m
 
-From 763f1f03048de2c892e60be3c36142386744eba9 Mon Sep 17 00:00:00 2001
+From 10f859daf0a0059aed1fb3d88688dbe625520b15 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:33:51 -0800
-Subject: [PATCH 106/165] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
+Subject: [PATCH 106/167] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
 
 In ARM64, the FIQ mechanism used by this driver is not current
 implemented.   As a workaround, reqular IRQ is used instead
@@ -112376,10 +112376,10 @@ index 6b2c7d0c93f36a63863ff4b0ecc1f3eab77e058b..d7b700ff17821ad1944e36721fe6b2db
  /** The OS page size */
  #define DWC_OS_PAGE_SIZE	PAGE_SIZE
 
-From 407532599b884cc5524844efe873f76e291183a9 Mon Sep 17 00:00:00 2001
+From 41d21a6a58cab0d7caf148eb57b6e7e6e23fa97e Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:43:57 -0800
-Subject: [PATCH 107/165] ARM64: Round-Robin dispatch IRQs between CPUs.
+Subject: [PATCH 107/167] ARM64: Round-Robin dispatch IRQs between CPUs.
 
 IRQ-CPU mapping is round robined on ARM64 to increase
 concurrency and allow multiple interrupts to be serviced
@@ -112453,10 +112453,10 @@ index c4e151451cf8c8ebde5225515eac2786d6f61d46..9a7ee04ee0d9b7aa734cf3159ed59c19
  	.name		= "bcm2836-gpu",
  	.irq_mask	= bcm2836_arm_irqchip_mask_gpu_irq,
 
-From ee5f155c70f0b5cf2582896f7a728229a082b2b2 Mon Sep 17 00:00:00 2001
+From d652b5d461f97868a482c7c217a2095f49c68e08 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:45:03 -0800
-Subject: [PATCH 108/165] ARM64: Enable DWC_OTG Driver In ARM64 Build
+Subject: [PATCH 108/167] ARM64: Enable DWC_OTG Driver In ARM64 Build
  Config(bcmrpi3_defconfig)
 
 Signed-off-by: Michael Zoran <mzoran@crowfest.net>
@@ -112477,10 +112477,10 @@ index b7d762df19b85e369a32cd823dfd062145bdefa7..4d85c231c5ea0244e1b05fb4a5e3c8fd
  CONFIG_USB_STORAGE=y
  CONFIG_USB_STORAGE_REALTEK=m
 
-From 2c94c421e3c873bc0addf7a67b5ff0eaeae84e9d Mon Sep 17 00:00:00 2001
+From 31de8e6310d6111511e9a21bef03316e02f7a72d Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 11 Feb 2017 01:18:31 -0800
-Subject: [PATCH 109/165] ARM64: Force hardware emulation of deprecated
+Subject: [PATCH 109/167] ARM64: Force hardware emulation of deprecated
  instructions.
 
 ---
@@ -112508,10 +112508,10 @@ index f0e6d717885b1fcf3b22f64c10c38f19c25f809d..0cb830d30fb6d2bd26ab572efe893649
  	case INSN_OBSOLETE:
  		insn->current_mode = INSN_UNDEF;
 
-From d1316547f577d065c35731dc77ea0ce490dbf9ff Mon Sep 17 00:00:00 2001
+From 44e4e9406bfd765806fd648469264356af5093a0 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 10 Feb 2017 17:57:08 -0800
-Subject: [PATCH 110/165] build/arm64: Add rules for .dtbo files for dts
+Subject: [PATCH 110/167] build/arm64: Add rules for .dtbo files for dts
  overlays
 
 We now create overlays as .dtbo files.
@@ -112536,10 +112536,10 @@ index b9a4a934ca057623e0ea436fd9b2c7c0f675fced..54e3c38d6fd877827541cdc798de035c
  
  dtbs: prepare scripts
 
-From 4a20e8d76e9a40c89826b5c941d262bf8b2b5b72 Mon Sep 17 00:00:00 2001
+From 59db18ff3839475d96254f51cb162ac35068e710 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
-Subject: [PATCH 111/165] clk: bcm2835: Mark GPIO clocks enabled at boot as
+Subject: [PATCH 111/167] clk: bcm2835: Mark GPIO clocks enabled at boot as
  critical.
 
 These divide off of PLLD_PER and are used for the ethernet and wifi
@@ -112577,10 +112577,10 @@ index 39f72da6ba1f6ec6ec41d5dc1bf46344aab008da..fe3298b54cdfb96bd90fb4f39e13921d
  	 * rate changes on at least of the parents.
  	 */
 
-From fee1a777a468454a1a0c17e9a82a343e85d82d51 Mon Sep 17 00:00:00 2001
+From 670c2eb63b26e5c71cbcd86c15010d24f7cb849f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
-Subject: [PATCH 112/165] pinctrl-bcm2835: Fix interrupt handling for GPIOs
+Subject: [PATCH 112/167] pinctrl-bcm2835: Fix interrupt handling for GPIOs
  28-31 and 46-53
 
 Contrary to the documentation, the BCM2835 GPIO controller actually has
@@ -112613,10 +112613,10 @@ index 6351fe7f8e314ac5ebb102dd20847b383fd5b857..28745af5aadf3cb91fa7ff39118385c3
  	},
  };
 
-From c7ce6e634f4a0d1b3d0d1d166713180902839087 Mon Sep 17 00:00:00 2001
+From 875b0b42ffc54c9fd7376547a08a4eb2594a6a45 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Tue, 7 Mar 2017 12:18:20 +0000
-Subject: [PATCH 113/165] BCM270X_DT: Invert Pi3 power LED to match fw change
+Subject: [PATCH 113/167] BCM270X_DT: Invert Pi3 power LED to match fw change
 
 Firmware expgpio driver reworked due to complaint over
 hotplug detect.
@@ -112642,10 +112642,10 @@ index 616cfd5c7094596b497101e8feca25e25e77c3e8..9f001bccb8261563dcddd8dec94b056b
  };
  
 
-From 75f8b9a38b6624dde4b999cbc83bbe19130739a4 Mon Sep 17 00:00:00 2001
+From 26127d1b8fd41a6c0b5cbecb90a560293847bf12 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Tue, 14 Mar 2017 14:23:06 +0000
-Subject: [PATCH 114/165] bcm2835-gpio-exp: Copy/paste error adding base twice
+Subject: [PATCH 114/167] bcm2835-gpio-exp: Copy/paste error adding base twice
 
 brcmexp_gpio_set was adding gpio->gc.base to the offset
 twice, so passing an invalid number to the mailbox service.
@@ -112671,10 +112671,10 @@ index 681a91492d4c33bdfd42416e069218e8611cc4d9..d68adafaee4ad406f45f4ff0d6b7c1ad
  	set.state = val;	/* Output state */
  
 
-From d24c80387cf67b7ffcbcc639565e96ce7c356463 Mon Sep 17 00:00:00 2001
+From 59705e7e200369cf3475837f81284b8ae81e14bd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 17 Mar 2017 13:40:41 +0000
-Subject: [PATCH 115/165] config: disable MMC driver temporarily for now.
+Subject: [PATCH 115/167] config: disable MMC driver temporarily for now.
 
 Currently causes a breakage to sdhost driver. However when MMC is disabled Pi3 wifi will not work
 ---
@@ -112709,10 +112709,10 @@ index 046f3e8757ef0f794c802171690528d31fee9deb..f2e0a58a96c8550f110c5940bf65f4d0
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 96f2d1a55e0bdb62f286b18e8f5e461da921babc Mon Sep 17 00:00:00 2001
+From 5892e952fcaeb9532dfd34fad22c9532ec1ba1fd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Mar 2017 12:24:41 +0000
-Subject: [PATCH 116/165] config: Make spidev a loadable module
+Subject: [PATCH 116/167] config: Make spidev a loadable module
 
 spidev isn't required early in the boot process, and not all users
 need it (spi_bcm2835 is a module), so make it a loadable module.
@@ -112752,10 +112752,10 @@ index f2e0a58a96c8550f110c5940bf65f4d022cc4548..9eb7084f440c8aac0c6257ee678007c2
  CONFIG_PPS_CLIENT_LDISC=m
  CONFIG_PPS_CLIENT_GPIO=m
 
-From cff63b8e6aae76ad600b7dc0a46b9f409ebff536 Mon Sep 17 00:00:00 2001
+From 113a60000a97ee17f54ebb2c25c7a68e2d2f88f4 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 10:06:56 +0000
-Subject: [PATCH 117/165] ASoC: Add prompt for ICS43432 codec
+Subject: [PATCH 117/167] ASoC: Add prompt for ICS43432 codec
 
 Without a prompt string, a config setting can't be included in a
 defconfig. Give CONFIG_SND_SOC_ICS43432 a prompt so that Pi soundcards
@@ -112780,10 +112780,10 @@ index 55812b0b884cf4fc4e86680b11fedd11c863db7a..428dc05edbb99f50560b7f89e45501c5
  config SND_SOC_INNO_RK3036
  	tristate "Inno codec driver for RK3036 SoC"
 
-From 38ce30a9437d8a22e0f8fbbcc6770802861a3b0d Mon Sep 17 00:00:00 2001
+From 6712820f29857d3d6ea6ea12af114c27dcdc9a82 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 16:34:46 +0000
-Subject: [PATCH 118/165] bcm2835-aux: Add aux interrupt controller
+Subject: [PATCH 118/167] bcm2835-aux: Add aux interrupt controller
 
 The AUX block has a shared interrupt line with a register indicating
 which devices have active IRQs. Expose this as a nested interrupt
@@ -112947,10 +112947,10 @@ index bd750cf2238d61489811e7d7bd3b5f9950ed53c8..41e0702fae4692221980b0d02aed1ba6
  			       BCM2835_AUX_CLOCK_COUNT, GFP_KERNEL);
  	if (!onecell)
 
-From aefd0ad73439c7f093795d1a0c5729dcf55f0bf4 Mon Sep 17 00:00:00 2001
+From 70245b73b3cebef57c34ea42f2f85d7917ab5d2c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 17:08:44 +0000
-Subject: [PATCH 119/165] BCM270X_DT: Enable AUX interrupt controller in DT
+Subject: [PATCH 119/167] BCM270X_DT: Enable AUX interrupt controller in DT
 
 See: https://github.com/raspberrypi/linux/issues/1484
      https://github.com/raspberrypi/linux/issues/1573
@@ -113003,10 +113003,10 @@ index 72cb9dc60ca9ad9aa2813972a299c50dcea7cd89..ca47b23ffbcd06063e0fb7072dc8a843
  			#address-cells = <1>;
  			#size-cells = <0>;
 
-From 9483134d159f1a7fa177df11bbb4f1d797c572eb Mon Sep 17 00:00:00 2001
+From 73c46b347dfec071259b176959635e6027881a8f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 27 Mar 2017 17:40:45 +0100
-Subject: [PATCH 120/165] mkknlimg: Find some more downstream-only strings
+Subject: [PATCH 120/167] mkknlimg: Find some more downstream-only strings
 
 See: https://github.com/raspberrypi/linux/issues/1920
 
@@ -113037,10 +113037,10 @@ index 60206de7fa9a49bd027c635306674a29a568652f..84be2593ec1de8f97b0167ff06b3e05d
  
  my $res = try_extract($kernel_file, $tmpfile1);
 
-From a410a7341c5993a2d7fa70a7608d2a5e51ed7023 Mon Sep 17 00:00:00 2001
+From 5ef0615ade9e194f7f1e959bf36f484b0f48d0d6 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 29 Apr 2016 10:32:17 -0700
-Subject: [PATCH 121/165] mmc: read mmc alias from device tree
+Subject: [PATCH 121/167] mmc: read mmc alias from device tree
 
 To get the SD/MMC host device ID, read the alias from the device
 tree.
@@ -113097,10 +113097,10 @@ index 3f8c85d5aa094b43666904c7dbbe5e62c9763c19..4dbd0e8e27a496bfbe67d188cf795ecc
  		kfree(host);
  		return NULL;
 
-From 3bc30d8fa9cee67d3dc95bba2822c043ede22fff Mon Sep 17 00:00:00 2001
+From 3e37913a6d6d4dcd12144a08686ecbaf6c29db52 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 14:30:42 +0100
-Subject: [PATCH 122/165] BCM270X_DT: Add numbered aliases for SD/MMC devices
+Subject: [PATCH 122/167] BCM270X_DT: Add numbered aliases for SD/MMC devices
 
 In order to force a specific ID assignment to SD/MMC devices, add
 numbered aliases to the DT: sdhost -> mmc0, mmc -> mmc1
@@ -113131,10 +113131,10 @@ index ef14e9ac6cd2092efb1681682dd2d3c52b8abfd5..693d4c04a36d2a7883cc3d8916bf0efb
  		i2c2 = &i2c2;
  		usb = &usb;
 
-From 314cc6a4ff0bee2460656e652230c96bb3a2365f Mon Sep 17 00:00:00 2001
+From c820d3b8890e84d8205903a6570e2b5877b18a0f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 14:28:53 +0100
-Subject: [PATCH 123/165] config: Re-enable the bcm2835-mmc driver
+Subject: [PATCH 123/167] config: Re-enable the bcm2835-mmc driver
 
 With the patch to assign mmc device IDs based on DT aliases and
 appropriate aliases in the rpi DTBs, it is now safe to re-enable
@@ -113171,10 +113171,10 @@ index 9eb7084f440c8aac0c6257ee678007c23990a8ae..021c38a909e71baa135cbcd4f3fb80fa
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 9b1b3ce0dc7c7f27cef3dba25ad955cb22194360 Mon Sep 17 00:00:00 2001
+From 7c57e289610aada9dd11f06ec05d800ea8c286cc Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
-Subject: [PATCH 124/165] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
+Subject: [PATCH 124/167] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
 
 Some SD cards have been found that corrupt data when small blocks
 are erased. Add a quirk to indicate that ERASE should not be used,
@@ -113316,10 +113316,10 @@ index 77e61e0a216a2728dd5cfecf55299402ac03c384..d12e8ddd22cb96e38b30f1ac3f9a6bd0
   	unsigned int		erase_shift;	/* if erase unit is power 2 */
   	unsigned int		pref_erase;	/* in sectors */
 
-From dc28578444c1a6061b5b2e955ea6c72dded34d79 Mon Sep 17 00:00:00 2001
+From 579317a8a0f0ff3a68688c85bdbeb3c85de41df7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 29 Mar 2017 16:08:29 +0100
-Subject: [PATCH 125/165] bcm2835-sdhost: mmc_card_blockaddr fix
+Subject: [PATCH 125/167] bcm2835-sdhost: mmc_card_blockaddr fix
 
 Get the definition of mmc_card_blockaddr from drivers/mmc/core/card.h.
 
@@ -113346,10 +113346,10 @@ index a9bc79bfdbb71807819dfe2d8f1651445997f92a..9c6f199a7830959f31012d86bc1f8b1a
  
  #define SDCMD  0x00 /* Command to SD card              - 16 R/W */
 
-From a490d319e2a4b625f43ef951e813ef7e55a61ece Mon Sep 17 00:00:00 2001
+From 0d19738d8eea0321f939357cc70ba32ee6a3a4e6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Mar 2017 12:30:37 +0000
-Subject: [PATCH 126/165] thermal: Compatible strings for bcm2836, bcm2837
+Subject: [PATCH 126/167] thermal: Compatible strings for bcm2836, bcm2837
 
 The upstream dt-bindings documentation for bcm2835-thermal (which
 exists even though the driver isn't upstreamed) says to use
@@ -113381,10 +113381,10 @@ index c63fb9f9d143e19612a18fe530c7b2b3518a22a4..25b78c3eac1503fbc9e679b963a6284b
  };
  MODULE_DEVICE_TABLE(of, bcm2835_thermal_of_match_table);
 
-From f5e7579e3e30c30aa51c2656fb5b14c4340632db Mon Sep 17 00:00:00 2001
+From 127f28c7277f067f08e894d1ace0c5cbe61de0a9 Mon Sep 17 00:00:00 2001
 From: John Greb <h3x4m3r0n@gmail.com>
 Date: Wed, 8 Mar 2017 15:12:29 +0000
-Subject: [PATCH 127/165] Match dwc2 device-tree fifo sizes to the hardware
+Subject: [PATCH 127/167] Match dwc2 device-tree fifo sizes to the hardware
  values.
 
 Since commit aa381a7259c3f53727bcaa8c5f9359e940a0e3fd was reverted with 3fa9538539ac737096c81f3315a14670b1609092 the g-tx-fifo-size array in the device-tree needs to match the preset values in the bcm2835.
@@ -113415,10 +113415,10 @@ index 527abc9f0ddf71f4dc7d58336d87684c931cc2f3..265a16bab008453edba198cf2366c423
  	};
  };
 
-From 57ef2ba796633d357d715589a6e6aa1caf0102b7 Mon Sep 17 00:00:00 2001
+From c09840140d70b4a9475749af75d04fe5634cbc37 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Mar 2017 09:10:05 +0000
-Subject: [PATCH 128/165] BCM270X_DT: Add lm75 to i2c-sensor overlay
+Subject: [PATCH 128/167] BCM270X_DT: Add lm75 to i2c-sensor overlay
 
 See: https://www.raspberrypi.org/forums/viewtopic.php?f=107&t=177236
 
@@ -113481,10 +113481,10 @@ index 31bda8da4cb6a56bfe493a81b918900995fb0589..606b2d5012abf2e85712be631c42ea40
  	};
  };
 
-From 918e0a02e223d772231d38cc2548001ada0786ca Mon Sep 17 00:00:00 2001
+From d769ba4e419c55e8db2fcfa3eb9bc56b0f4d6663 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 28 Mar 2017 14:22:20 +0100
-Subject: [PATCH 129/165] BCM270X_DT: Allow multiple instances of w1-gpio
+Subject: [PATCH 129/167] BCM270X_DT: Allow multiple instances of w1-gpio
  overlays
 
 Upcoming firmware will modify the address portion of node names when
@@ -113549,10 +113549,10 @@ index 66a98f6c9601f51483f27803995bec772bb3350e..ef8bfbcabdb31231075d5c281df3b38b
  				<&w1_pins>,"brcm,pins:4";
  		pullup =        <&w1>,"rpi,parasitic-power:0";
 
-From 6b1c9efba585009739f685193ec574217cc09844 Mon Sep 17 00:00:00 2001
+From 5e3fe022ba21852fc61703df08d1858c95589144 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 28 Mar 2017 17:41:30 +0100
-Subject: [PATCH 130/165] leds-gpio: Remove stray assignment to brightness_set
+Subject: [PATCH 130/167] leds-gpio: Remove stray assignment to brightness_set
 
 The brightness_set method is intended for use cases that must not
 block, and can only be used if the GPIO provider can never sleep.
@@ -113578,10 +113578,10 @@ index 934cdb1d7bc7f12a4fb06a5c458ad76727c7b7c7..a4df27f6af35ba7f7b34c2a4b7b22ee7
  	if (template->default_state == LEDS_GPIO_DEFSTATE_KEEP) {
  		state = gpiod_get_value_cansleep(led_dat->gpiod);
 
-From 230abfd651ae2522ea9d93f5c7b11a601039d350 Mon Sep 17 00:00:00 2001
+From 84edfb6f829d6f211c7cc6be0230bc96dcc9d399 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 29 Mar 2017 17:41:04 +0100
-Subject: [PATCH 131/165] config: Add back MMC_BCM2835_DMA
+Subject: [PATCH 131/167] config: Add back MMC_BCM2835_DMA
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -113613,10 +113613,10 @@ index 021c38a909e71baa135cbcd4f3fb80fad2151647..a8fc96ef674be476d10e59aef2367def
  CONFIG_MMC_SDHCI=y
  CONFIG_MMC_SDHCI_PLTFM=y
 
-From 9f138eaa1f13ec6cfa8038041be38b866c5ec041 Mon Sep 17 00:00:00 2001
+From 33a2018a06dad4113ca21e63f576dd668e11f1b3 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 27 Mar 2017 22:26:49 +1100
-Subject: [PATCH 132/165] AudioInjector Octo: sample rates, regulators, reset
+Subject: [PATCH 132/167] AudioInjector Octo: sample rates, regulators, reset
 
 This patch adds new sample rates to the Audioinjector Octo sound card. The
 new supported rates are (in kHz) :
@@ -113782,10 +113782,10 @@ index 9effea725798640887755dfa688da45338718afc..dcf403ab37639ba79e38278d7e4b1ade
  			dai->cpu_dai_name = NULL;
  			dai->cpu_of_node = i2s_node;
 
-From d70d42d5abbda9774fc9111950c64c5f802c4216 Mon Sep 17 00:00:00 2001
+From 401fef0840482b77ee26b830c804f9419609229c Mon Sep 17 00:00:00 2001
 From: Peter Malkin <petermalkin@google.com>
 Date: Mon, 27 Mar 2017 16:38:21 -0700
-Subject: [PATCH 133/165] Driver support for Google voiceHAT soundcard.
+Subject: [PATCH 133/167] Driver support for Google voiceHAT soundcard.
 
 ---
  arch/arm/boot/dts/overlays/Makefile                |   1 +
@@ -114290,10 +114290,10 @@ index 0000000000000000000000000000000000000000..225854b8e5298b3c3018f59a49404354
 +MODULE_DESCRIPTION("ASoC Driver for Google voiceHAT SoundCard");
 +MODULE_LICENSE("GPL v2");
 
-From 9f310cc4f5cfde4c6ff8326feb26f3b2c20f4e97 Mon Sep 17 00:00:00 2001
+From 968ca119e73e43594edf471731b079198446b993 Mon Sep 17 00:00:00 2001
 From: Raashid Muhammed <raashidmuhammed@zilogic.com>
 Date: Mon, 27 Mar 2017 12:35:00 +0530
-Subject: [PATCH 134/165] Add support for Allo Piano DAC 2.1 plus add-on board
+Subject: [PATCH 134/167] Add support for Allo Piano DAC 2.1 plus add-on board
  for Raspberry Pi.
 
 The Piano DAC 2.1 has support for 4 channels with subwoofer.
@@ -114921,10 +114921,10 @@ index 0000000000000000000000000000000000000000..f66f42abadbd5f9d3fe000676e8297ed
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC Plus");
 +MODULE_LICENSE("GPL v2");
 
-From 4ef968342060e85928c03805c3d746039378edc2 Mon Sep 17 00:00:00 2001
+From 1db880f99f0d6f2d6c79c573d4d1cce4ecbf5bf2 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Tue, 28 Mar 2017 20:04:42 +0530
-Subject: [PATCH 135/165]  Add support for Allo Boss DAC add-on board for
+Subject: [PATCH 135/167]  Add support for Allo Boss DAC add-on board for
  Raspberry Pi.  (#1924)
 
 Signed-off-by: Baswaraj K <jaikumar@cem-solutions.net>
@@ -115654,10 +115654,10 @@ index 0000000000000000000000000000000000000000..c080e31065d99ab309ab3bdf41a44adf
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Boss DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 2a42e7fae332b63d97c8bd47367d0398116eeee7 Mon Sep 17 00:00:00 2001
+From 04447270e54117f6a755475c20d82ef9ca74c278 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar C <babusubashchandar@zilogic.com>
 Date: Thu, 30 Mar 2017 20:17:27 +0530
-Subject: [PATCH 136/165] Add support for new clock rate and mute gpios.
+Subject: [PATCH 136/167] Add support for new clock rate and mute gpios.
 
 Signed-off-by: Baswaraj K <jaikumar@cem-solutions.net>
 Reviewed-by: Deepak <deepak@zilogic.com>
@@ -116310,10 +116310,10 @@ index c080e31065d99ab309ab3bdf41a44adfdd8f8039..203ab76c7045b081578e23bda1099dd1
  }
  
 
-From b44b82a8f0206c77c6b632faf0ed627c08c2c464 Mon Sep 17 00:00:00 2001
+From fffda44e8aa9c34aa97aba8e3e73f5edb2090fa8 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Sat, 1 Apr 2017 00:46:52 +0530
-Subject: [PATCH 137/165] Add clock changes and mute gpios (#1938)
+Subject: [PATCH 137/167] Add clock changes and mute gpios (#1938)
 
 Also improve code style and adhere to ALSA coding conventions.
 
@@ -117006,10 +117006,10 @@ index f66f42abadbd5f9d3fe000676e8297ed91630e47..56e43f98846b41e487b3089813f7edc3
  }
  
 
-From 1264d706e16346c126b08c6b1e29d122a2f1496c Mon Sep 17 00:00:00 2001
+From bffcfaebe38fe0536efbf99e99c12b0bdb9e0852 Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Fri, 14 Apr 2017 10:43:57 +0100
-Subject: [PATCH 138/165] This is the driver for Sony CXD2880 DVB-T2/T tuner +
+Subject: [PATCH 138/167] This is the driver for Sony CXD2880 DVB-T2/T tuner +
  demodulator. It includes the CXD2880 driver and the CXD2880 SPI adapter. The
  current CXD2880 driver version is 1.4.1 - 1.0.1 released on April 13, 2017.
 
@@ -133141,10 +133141,10 @@ index 0000000000000000000000000000000000000000..82e122349055be817eb74ed5bbcd7560
 +MODULE_AUTHOR("Sony Semiconductor Solutions Corporation");
 +MODULE_LICENSE("GPL v2");
 
-From 79d8d433d4c86597de41706ef58ba6b75ff76ecf Mon Sep 17 00:00:00 2001
+From 72dbe38b3901cb87a4afa39d1bb6e0daadfcd6ba Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Thu, 22 Dec 2016 15:34:12 +0900
-Subject: [PATCH 139/165] BCM2708: Add Raspberry Pi TV HAT Device Tree Support
+Subject: [PATCH 139/167] BCM2708: Add Raspberry Pi TV HAT Device Tree Support
 
 This is an EXAMPLE CODE of Raspberry Pi TV HAT device tree overlay.
 Although this is not a part of our release code, it has been used to verify
@@ -133240,10 +133240,10 @@ index 0000000000000000000000000000000000000000..a68f6f793d8efd8b2e2adf9f2fb6426f
 +
 +};
 
-From 1c76190ebca5746f6e6b8e50e2cc3265d72a5c5c Mon Sep 17 00:00:00 2001
+From cbb3e1bc374411fff711fc756d0894336c13e8fb Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 27 Apr 2017 16:24:34 +0100
-Subject: [PATCH 140/165] dwc_otg: make nak_holdoff work as intended with empty
+Subject: [PATCH 140/167] dwc_otg: make nak_holdoff work as intended with empty
  queues
 
 If URBs reading from non-periodic split endpoints were dequeued and
@@ -133327,10 +133327,10 @@ index c2dff94e8e6edd22e4427aaa1eac7aad972cb6bd..85a6d431ca54b47dc10573aa72d1ad69
  	} else {
  		uint16_t frame_number = dwc_otg_hcd_get_frame_number(hcd);
 
-From dc7df0e8583992a9bfd5bf494800cbca37ac823f Mon Sep 17 00:00:00 2001
+From 49b2334e5f1e16b1334bda3d9dbe8b4b88052720 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Tue, 2 May 2017 16:31:15 +0100
-Subject: [PATCH 141/165] dwc_otg: fix split transaction data toggle handling
+Subject: [PATCH 141/167] dwc_otg: fix split transaction data toggle handling
  around dequeues
 
 See https://github.com/raspberrypi/linux/issues/1709
@@ -133418,10 +133418,10 @@ index 608e036be2c9484465ab836de70129335d3d2d96..718a1accc0c219a1764ce53d291de6a2
  	}
  	qtd = DWC_CIRCLEQ_FIRST(&hc->qh->qtd_list);
 
-From 415467640d5ad5ec32bd1292995dd3e4c2b5e412 Mon Sep 17 00:00:00 2001
+From 32bd61c2297094871cc1c8163d047db3a48122bf Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 2 May 2017 16:36:05 +0100
-Subject: [PATCH 142/165] vcsm: Treat EBUSY as success rather than SIGBUS
+Subject: [PATCH 142/167] vcsm: Treat EBUSY as success rather than SIGBUS
 
 Currently if two cores access the same page concurrently one will return VM_FAULT_NOPAGE
 and the other VM_FAULT_SIGBUS crashing the user code.
@@ -133459,10 +133459,10 @@ index fd71d9fbb400d71bb8cfb8672080e7c3053e3ae9..fd2ca788dcd56b1702454d71b7bedd42
  	}
  }
 
-From 86773aa7d30014a4976566d01278c02ccd8de19b Mon Sep 17 00:00:00 2001
+From 039580d0684483d053e29b41a9fd4219bba2d585 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 4 May 2017 12:58:11 +0100
-Subject: [PATCH 143/165] fiq_fsm: Use correct states when starting isoc OUT
+Subject: [PATCH 143/167] fiq_fsm: Use correct states when starting isoc OUT
  transfers
 
 In fiq_fsm_start_next_periodic() if an isochronous OUT transfer
@@ -133499,10 +133499,10 @@ index 9304279592cb5b388086ef91cb52f1e9f94868ce..208252645c09d1d17bf07673989f91b7
  				break;
  			}
 
-From 79dff587b5aa18748b62070d8124dfa06f84856d Mon Sep 17 00:00:00 2001
+From 4526db8e6a009963b42b723ea384fa1d265d6484 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 4 May 2017 17:38:22 +0100
-Subject: [PATCH 144/165] bcm2708_fb: Avoid firmware mbox call in vc_mem_copy
+Subject: [PATCH 144/167] bcm2708_fb: Avoid firmware mbox call in vc_mem_copy
 
 If firmware has locked up it is useful to get vcdbg log out without a firmware mbox response.
 Issue the mbox call at probe time instead.
@@ -133566,10 +133566,10 @@ index 53c5a0bdadb4be9251affdabed66305842a08e72..612293cf9f1bd93ad2f2aefdd7ca0f5e
  	if (ret == 0) {
  		platform_set_drvdata(dev, fb);
 
-From ef237d3d91ba7ff5c991561fcb02106c3fb5ea48 Mon Sep 17 00:00:00 2001
+From 8176dbf0215cc87c628ec96e8e34707b58c278cb Mon Sep 17 00:00:00 2001
 From: Nisar Sayed <Nisar.Sayed@microchip.com>
 Date: Tue, 9 May 2017 18:51:42 +0100
-Subject: [PATCH 145/165] According to RFC 2460, IPv6 UDP calculated checksum
+Subject: [PATCH 145/167] According to RFC 2460, IPv6 UDP calculated checksum
  yields a result of zero must be changed to 0xffff, however this feature is
  not supported by smsc95xx family hence enable csum offload only for IPv4
  TCP/UDP packets.
@@ -133614,10 +133614,10 @@ index f6661e388f6e801c1b88e48a3b71407bd70cf56e..b84e98508b5d97165b68dfc30240950e
  	smsc95xx_init_mac_address(dev);
  
 
-From cbab0a0f8479d691dad18ad093b830773940a53e Mon Sep 17 00:00:00 2001
+From 14ffbd99b328c0f4545b95ca8c04b8994f6fa7b2 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
-Subject: [PATCH 146/165] drm/vc4: Add a mode for using the closed firmware for
+Subject: [PATCH 146/167] drm/vc4: Add a mode for using the closed firmware for
  display.
 
 Signed-off-by: Eric Anholt <eric@anholt.net>
@@ -134384,10 +134384,10 @@ index 0000000000000000000000000000000000000000..d18a1dae51a2275846c9826b5bf1ba57
 +	},
 +};
 
-From 9ab72e1fe7d0178f89b6e5f2e1d28a22fe2dead9 Mon Sep 17 00:00:00 2001
+From b7cc89b2349612b060a54adf0faf9c0fe4922be3 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:09:18 -0800
-Subject: [PATCH 147/165] drm/vc4: Name the primary and cursor planes in fkms.
+Subject: [PATCH 147/167] drm/vc4: Name the primary and cursor planes in fkms.
 
 This makes debugging nicer, compared to trying to remember what the
 IDs are.
@@ -134411,10 +134411,10 @@ index d18a1dae51a2275846c9826b5bf1ba57ae97b55c..e49ce68b607a7ffc2329e3235362f3bc
  	if (type == DRM_PLANE_TYPE_PRIMARY) {
  		vc4_plane->fbinfo =
 
-From 8f4a88cdf13682bb527a8a4348b45af537723ed9 Mon Sep 17 00:00:00 2001
+From b631ef32bba533b6d25405d33747f8608b30492a Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:10:09 -0800
-Subject: [PATCH 148/165] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
+Subject: [PATCH 148/167] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
  fkms.
 
 Trying to debug weston on fkms involved figuring out what calls I was
@@ -134484,10 +134484,10 @@ index e49ce68b607a7ffc2329e3235362f3bc21ed5cbb..dbf065677202fbebf8e3a0cffbe880aa
  				    RPI_FIRMWARE_SET_CURSOR_STATE,
  				    &packet_state,
 
-From eb8450cbd90b185b2c8454b9b169af0ae518b996 Mon Sep 17 00:00:00 2001
+From c42a2ad6472d2d0d825132fe11866208b80584c5 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 2 Feb 2017 09:42:18 -0800
-Subject: [PATCH 149/165] drm/vc4: Fix sending of page flip completion events
+Subject: [PATCH 149/167] drm/vc4: Fix sending of page flip completion events
  in FKMS mode.
 
 In the rewrite of vc4_crtc.c for fkms, I dropped the part of the
@@ -134529,10 +134529,10 @@ index dbf065677202fbebf8e3a0cffbe880aa42daef3f..da818a207bfa639b8cea48d94bcf4566
  
  static void vc4_crtc_handle_page_flip(struct vc4_crtc *vc4_crtc)
 
-From 37d49e37d1e667467d5ab024e259839665949967 Mon Sep 17 00:00:00 2001
+From 271a34305c7c0a7bdf4072b173b603caf8bd8adf Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 10 May 2017 21:39:45 +0100
-Subject: [PATCH 150/165] squash: vc4_firmware_kms fixups
+Subject: [PATCH 150/167] squash: vc4_firmware_kms fixups
 
 ---
  drivers/gpu/drm/vc4/vc4_crtc.c         | 2 ++
@@ -134582,10 +134582,10 @@ index da818a207bfa639b8cea48d94bcf4566f97db816..35425063cca47a33936c4853f7cc320c
  	vc4_encoder = devm_kzalloc(dev, sizeof(*vc4_encoder), GFP_KERNEL);
  	if (!vc4_encoder)
 
-From a1a1c64c65f30f6bd6ac9cc191314656716f9722 Mon Sep 17 00:00:00 2001
+From 6f2ab38465072781998b3c4b0cfcae2eba606ef8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 18 Apr 2017 21:43:46 +0100
-Subject: [PATCH 151/165] vc4_fkms: Apply firmware overscan offset to hardware
+Subject: [PATCH 151/167] vc4_fkms: Apply firmware overscan offset to hardware
  cursor
 
 ---
@@ -134642,10 +134642,10 @@ index 35425063cca47a33936c4853f7cc320c3630fdb2..ca03b85f27d8c0966acd977cba9c758d
  
  	return 0;
 
-From d1df3da3aeb7d9ca4c544f92b64daf7885ce1c2c Mon Sep 17 00:00:00 2001
+From 7183c5d23e82452db2a23704ee65eadc66c9d852 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 11 May 2017 16:58:16 +0100
-Subject: [PATCH 152/165] BCM270X_DT: Tidy up mmc, sdhost, sdio overlays
+Subject: [PATCH 152/167] BCM270X_DT: Tidy up mmc, sdhost, sdio overlays
 
 The mmc, sdhost, sdio and sdio-1bit overlays had a few
 anachronisms and oddities which were overdue for fixing.
@@ -134754,10 +134754,10 @@ index 398bd812c716c9e472fbac5aba4fe882114c65d1..215d5e3e8a8ca4363457fed1f7425427
  			};
  		};
 
-From 3d075ae0ebb40409adcd8b7a8c72f0c7e3e2aa0e Mon Sep 17 00:00:00 2001
+From 92e7702f73cdcf1ccea4907f71fa493359f7b895 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 12 May 2017 12:24:00 +0100
-Subject: [PATCH 153/165] dwc_otg: fix several potential crash sources
+Subject: [PATCH 153/167] dwc_otg: fix several potential crash sources
 
 On root port disconnect events, the host driver state is cleared and
 in-progress host channels are forcibly stopped. This doesn't play
@@ -134953,10 +134953,10 @@ index 718a1accc0c219a1764ce53d291de6a2b6f93608..cf23baaa388562b5843be4cfa6c206cb
  		release_channel(hcd, hc, qtd, DWC_OTG_HC_XFER_URB_COMPLETE);
  		break;
 
-From 68be9076e548897ace4b352c5de07e0e06e98647 Mon Sep 17 00:00:00 2001
+From 0058d8f8af3ebc341a25c78686550a734aeab7dd Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 15 May 2017 14:27:48 +0100
-Subject: [PATCH 154/165] dwc_otg: delete hcd->channel_lock
+Subject: [PATCH 154/167] dwc_otg: delete hcd->channel_lock
 
 The lock serves no purpose as it is only held while the HCD spinlock
 is already being held.
@@ -135108,10 +135108,10 @@ index cf23baaa388562b5843be4cfa6c206cbdc4e780d..a4355afc77b68718fdaba6c5d4be257d
  
  	/* Try to queue more transfers now that there's a free channel. */
 
-From 6a4e96243d237ccb48c533af77829c80c46b3575 Mon Sep 17 00:00:00 2001
+From cfd62ee1ebf568d72147f4ba5505c9aad8dbddf6 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 15 May 2017 14:51:42 +0100
-Subject: [PATCH 155/165] dwc_otg: remove unnecessary dma-mode channel halts on
+Subject: [PATCH 155/167] dwc_otg: remove unnecessary dma-mode channel halts on
  disconnect interrupt
 
 Host channels are already halted in kill_urbs_in_qh_list() with the
@@ -135179,10 +135179,10 @@ index 5ec991624c7865901b22ea01b9f2c58c8535ecfd..a2dc6337836b2719f4c954edeeb2a713
  
  	if(fiq_enable) {
 
-From 0be3655e1ef6461e38ef31ecdf35cfd99e44e3ac Mon Sep 17 00:00:00 2001
+From 4cb2783298e13c606f4fc10aa88fc66980f474d8 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 15 May 2017 16:40:05 +0100
-Subject: [PATCH 156/165] config: Add CONFIG_TOUCHSCREEN_GOODIX
+Subject: [PATCH 156/167] config: Add CONFIG_TOUCHSCREEN_GOODIX
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135214,10 +135214,10 @@ index db6589288b6abd6b76b934de07e8976456e14e61..88072e3b55eb230be44f6d23012428ed
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From ec225ab9eb5f50e990f33514fb42201d663b2032 Mon Sep 17 00:00:00 2001
+From 28ea7b393f6047e773587bf1734bf9f9ada6b463 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 18 May 2017 11:40:43 +0100
-Subject: [PATCH 157/165] config: Add FB_TFT_ST7789V module
+Subject: [PATCH 157/167] config: Add FB_TFT_ST7789V module
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135249,10 +135249,10 @@ index 88072e3b55eb230be44f6d23012428eda3de3453..65e3676b48ab0c0f54375ecf875fc255
  CONFIG_FB_TFT_TLS8204=m
  CONFIG_FB_TFT_UC1701=m
 
-From 48b3930f538bbf573de3308159989b9f0901f639 Mon Sep 17 00:00:00 2001
+From 0e8a99712c47e5d244ab87c687de855542261821 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 15:58:00 +0100
-Subject: [PATCH 158/165] config: Add CONFIG_TOUCHSCREEN_EDT_FT5X06
+Subject: [PATCH 158/167] config: Add CONFIG_TOUCHSCREEN_EDT_FT5X06
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135284,10 +135284,10 @@ index 65e3676b48ab0c0f54375ecf875fc2552c457e09..7381eeba83ecd4a2c956ab2093ece4f8
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From 07ec924f089da1e85958e82c77323d294ecb79b2 Mon Sep 17 00:00:00 2001
+From 3ce401c21146acae756a5a81c7a6b2ec6c198d4c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 19:34:52 +0100
-Subject: [PATCH 159/165] config: Add CONFIG_I2C_ROBOTFUZZ_OSIF
+Subject: [PATCH 159/167] config: Add CONFIG_I2C_ROBOTFUZZ_OSIF
 
 ---
  arch/arm/configs/bcm2709_defconfig | 1 +
@@ -135319,10 +135319,10 @@ index 7381eeba83ecd4a2c956ab2093ece4f8a57c6ea4..35dc0b5084256f2ae755703edc3eb67c
  CONFIG_SPI_BCM2835=m
  CONFIG_SPI_BCM2835AUX=m
 
-From 37db614838890f9d3851fd8a44231a2e1aa4bd61 Mon Sep 17 00:00:00 2001
+From 631bf1eb38b2f5c46e076ef3f62ffb437ee396f3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 26 Apr 2017 17:28:47 +0100
-Subject: [PATCH 160/165] clk: bcm2835: Limit PCM clock to OSC and PLLD_PER
+Subject: [PATCH 160/167] clk: bcm2835: Limit PCM clock to OSC and PLLD_PER
 
 It is unwise to use sources other than the oscillator and PLLD_PER for
 the PCM peripheral (and perhaps others - TBD) because their rate can
@@ -135367,10 +135367,10 @@ index fe3298b54cdfb96bd90fb4f39e13921d2e1d4356..c24b4defb2b046e4ecdc109befc2b224
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
  		.name = "pwm",
 
-From 621ee8308fbc211d0813037897daa8dff325812b Mon Sep 17 00:00:00 2001
+From e30dc97742d503d1daf3aa8f4384f7cccb13faf6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 22 May 2017 13:56:41 +0100
-Subject: [PATCH 161/165] clk: bcm2835: Minimise clock jitter for PCM clock
+Subject: [PATCH 161/167] clk: bcm2835: Minimise clock jitter for PCM clock
 
 Fractional clock dividers generate accurate average frequencies but
 with jitter, particularly when the integer divisor is small.
@@ -135495,10 +135495,10 @@ index c24b4defb2b046e4ecdc109befc2b22497060647..db3ba74acf78f4dfec0d2206b58bc7c3
  		.tcnt_mux = 23),
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
 
-From 55047cb2049b576b353dee6de20f5c6b0e66fff5 Mon Sep 17 00:00:00 2001
+From 843fd0d168d8a71b460ff66cd86ddaa4ef2a782d Mon Sep 17 00:00:00 2001
 From: Bilal Amarni <bamarni@users.noreply.github.com>
 Date: Wed, 24 May 2017 10:52:50 +0200
-Subject: [PATCH 162/165] [ARM64] enable drivers for GPIO expander and vcio
+Subject: [PATCH 162/167] [ARM64] enable drivers for GPIO expander and vcio
 
 ---
  arch/arm64/configs/bcmrpi3_defconfig | 3 +++
@@ -135526,10 +135526,10 @@ index 4d85c231c5ea0244e1b05fb4a5e3c8fd3e651ddf..9dcb58a519d041fadae99c81a7bda621
  CONFIG_GPIO_ARIZONA=m
  CONFIG_GPIO_STMPE=y
 
-From 447e78fed3772de6db4653f68df6d7ac512476a3 Mon Sep 17 00:00:00 2001
+From 2d13aa5520b8a72f9285f8b54c8928c720f4f141 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 25 May 2017 16:04:53 +0100
-Subject: [PATCH 163/165] dwc_otg: make periodic scheduling behave properly for
+Subject: [PATCH 163/167] dwc_otg: make periodic scheduling behave properly for
  FS buses
 
 If the root port is in full-speed mode, transfer times at 12mbit/s
@@ -135700,10 +135700,10 @@ index 85a6d431ca54b47dc10573aa72d1ad69d06f2e36..4b1dd9de99e9e08b2e006fb5f8a7ef92
  	status = check_max_xfer_size(hcd, qh);
  	if (status) {
 
-From 081070763c748cf66b954b430e3021e221bffe0c Mon Sep 17 00:00:00 2001
+From 324204d6eee47da7bfdc602ce610c54b5f09dfc5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 19 May 2017 16:07:23 +0100
-Subject: [PATCH 164/165] serial: 8250: Add CAP_MINI, set for bcm2835aux
+Subject: [PATCH 164/167] serial: 8250: Add CAP_MINI, set for bcm2835aux
 
 commit d087e7a991f1f61ee2c07db1be7c5cc2aa373f5d upstream.
 
@@ -135759,10 +135759,10 @@ index e10f1244409b344b850ffbbd4af5757a66c875f1..a23c7da42ea81342efc26fb35a92a69d
  	data->uart.port.regshift = 2;
  	data->uart.port.type = PORT_16550;
 diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
-index 4c26d15ad7d91602aec507b881e6950119587f44..0d12bbe6ce4e9665fef9c3fb0b64d4c4095117bd 100644
+index 579706d36f5c77382cc289d55c2e6290143d6b1d..27e4a15fbe009e45270b5eaf3698bcfd0baaa1e3 100644
 --- a/drivers/tty/serial/8250/8250_port.c
 +++ b/drivers/tty/serial/8250/8250_port.c
-@@ -2584,6 +2584,12 @@ serial8250_do_set_termios(struct uart_port *port, struct ktermios *termios,
+@@ -2585,6 +2585,12 @@ serial8250_do_set_termios(struct uart_port *port, struct ktermios *termios,
  	unsigned long flags;
  	unsigned int baud, quot, frac = 0;
  
@@ -135776,10 +135776,10 @@ index 4c26d15ad7d91602aec507b881e6950119587f44..0d12bbe6ce4e9665fef9c3fb0b64d4c4
  
  	baud = serial8250_get_baud_rate(port, termios, old);
 
-From 6a6634d22a77d1e7628ce664eec7bc319772f588 Mon Sep 17 00:00:00 2001
+From 8f7ff727e2c99c231d14e4d19cee3e734a762cd5 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 26 May 2017 12:50:31 +0100
-Subject: [PATCH 165/165] dwc_otg: fiq_fsm: Make isochronous compatibility
+Subject: [PATCH 165/167] dwc_otg: fiq_fsm: Make isochronous compatibility
  checks work properly
 
 Get rid of the spammy printk and local pointer mangling.
@@ -135842,3 +135842,123 @@ index 38bf5fc792d32352f9e208e0e90f968599b9bc31..71834cf365e67d7ad995bba7869216c4
  			}
  			return 1;
  		}
+
+From 04b7125da8fd030cb851051f17b905fbf4810e2a Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Mon, 12 Jun 2017 13:05:43 +0100
+Subject: [PATCH 166/167] config: Add CONFIG_CAN_GS_USB
+
+---
+ arch/arm/configs/bcm2709_defconfig | 1 +
+ arch/arm/configs/bcmrpi_defconfig  | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/arch/arm/configs/bcm2709_defconfig b/arch/arm/configs/bcm2709_defconfig
+index 12157f209bc0a503c1bc3f04224784451c03f964..b59062ce3d980c8b2612722c9d1b7ccc2dab4c7d 100644
+--- a/arch/arm/configs/bcm2709_defconfig
++++ b/arch/arm/configs/bcm2709_defconfig
+@@ -359,6 +359,7 @@ CONFIG_CAN=m
+ CONFIG_CAN_VCAN=m
+ CONFIG_CAN_SLCAN=m
+ CONFIG_CAN_MCP251X=m
++CONFIG_CAN_GS_USB=m
+ CONFIG_IRDA=m
+ CONFIG_IRLAN=m
+ CONFIG_IRNET=m
+diff --git a/arch/arm/configs/bcmrpi_defconfig b/arch/arm/configs/bcmrpi_defconfig
+index 35dc0b5084256f2ae755703edc3eb67cab0759ec..42163e2c0b5d5666d49793ac4e074d22cc59c286 100644
+--- a/arch/arm/configs/bcmrpi_defconfig
++++ b/arch/arm/configs/bcmrpi_defconfig
+@@ -355,6 +355,7 @@ CONFIG_CAN=m
+ CONFIG_CAN_VCAN=m
+ CONFIG_CAN_SLCAN=m
+ CONFIG_CAN_MCP251X=m
++CONFIG_CAN_GS_USB=m
+ CONFIG_IRDA=m
+ CONFIG_IRLAN=m
+ CONFIG_IRNET=m
+
+From f1a70f5c80f70e8bb6a687a8ca0372ba11e048d1 Mon Sep 17 00:00:00 2001
+From: P33M <p33m@github.com>
+Date: Mon, 12 Jun 2017 16:10:03 +0100
+Subject: [PATCH 167/167] dwc_otg: add module parameter int_ep_interval_min
+
+Add a module parameter (defaulting to ignored) that clamps the polling rate
+of high-speed Interrupt endpoints to a minimum microframe interval.
+
+The parameter is modifiable at runtime as it is used when activating new
+endpoints (such as on device connect).
+---
+ drivers/usb/host/dwc_otg/dwc_otg_driver.c    |  6 +++++-
+ drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c | 25 ++++++++++++-------------
+ 2 files changed, 17 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/usb/host/dwc_otg/dwc_otg_driver.c b/drivers/usb/host/dwc_otg/dwc_otg_driver.c
+index cb060a7179a3eec791506ed2779b553cad9841b0..95943e07528276b26b51ea2d57a1f433f280aaef 100644
+--- a/drivers/usb/host/dwc_otg/dwc_otg_driver.c
++++ b/drivers/usb/host/dwc_otg/dwc_otg_driver.c
+@@ -249,6 +249,7 @@ uint16_t nak_holdoff = 8;
+ 
+ unsigned short fiq_fsm_mask = 0x0F;
+ 
++unsigned short int_ep_interval_min = 0;
+ /**
+  * This function shows the Driver Version.
+  */
+@@ -1398,7 +1399,10 @@ MODULE_PARM_DESC(fiq_fsm_mask, "Bitmask of transactions to perform in the FIQ.\n
+ 					"Bit 1 : Periodic split transactions\n"
+ 					"Bit 2 : High-speed multi-transfer isochronous\n"
+ 					"All other bits should be set 0.");
+-
++module_param(int_ep_interval_min, ushort, 0644);
++MODULE_PARM_DESC(int_ep_interval_min, "Clamp high-speed Interrupt endpoints to a minimum polling interval.\n"
++					"0..1 = Use endpoint default\n"
++					"2..n = Minimum interval n microframes. Use powers of 2.\n");
+ 
+ /** @page "Module Parameters"
+  *
+diff --git a/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c b/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
+index 4b1dd9de99e9e08b2e006fb5f8a7ef92f20c2553..fe8e8f841f03660c2ad49ab8e66193bec62558d3 100644
+--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
++++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
+@@ -43,6 +43,7 @@
+ #include "dwc_otg_regs.h"
+ 
+ extern bool microframe_schedule;
++extern unsigned short int_ep_interval_min;
+ 
+ /**
+  * Free each QTD in the QH's QTD-list then free the QH.  QH should already be
+@@ -218,21 +219,19 @@ void qh_init(dwc_otg_hcd_t * hcd, dwc_otg_qh_t * qh, dwc_otg_hcd_urb_t * urb)
+ 						    SCHEDULE_SLOP);
+ 		qh->interval = urb->interval;
+ 
+-#if 0
+-		/* Increase interrupt polling rate for debugging. */
+-		if (qh->ep_type == UE_INTERRUPT) {
+-			qh->interval = 8;
+-		}
+-#endif
+ 		hprt.d32 = DWC_READ_REG32(hcd->core_if->host_if->hprt0);
+-		if ((hprt.b.prtspd == DWC_HPRT0_PRTSPD_HIGH_SPEED) &&
+-		    ((dev_speed == USB_SPEED_LOW) ||
+-		     (dev_speed == USB_SPEED_FULL))) {
+-			qh->interval *= 8;
+-			qh->sched_frame |= 0x7;
+-			qh->start_split_frame = qh->sched_frame;
++		if (hprt.b.prtspd == DWC_HPRT0_PRTSPD_HIGH_SPEED) {
++			if (dev_speed == USB_SPEED_LOW ||
++					dev_speed == USB_SPEED_FULL) {
++				qh->interval *= 8;
++				qh->sched_frame |= 0x7;
++				qh->start_split_frame = qh->sched_frame;
++			} else if (int_ep_interval_min >= 2 &&
++					qh->interval < int_ep_interval_min &&
++					qh->ep_type == UE_INTERRUPT) {
++				qh->interval = int_ep_interval_min;
++			}
+ 		}
+-
+ 	}
+ 
+ 	DWC_DEBUGPL(DBG_HCD, "DWC OTG HCD QH Initialized\n");


### PR DESCRIPTION
Merge this at 4.11.8 (perhaps in a week or two, depending on when .7 and .8 appear).

4.11.5 changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.11.5
4.11.6 changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.11.6
4.11.7 changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.11.7
4.11.8 changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.11.8
