### PR TITLE
activate swap for all projects

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -158,13 +158,13 @@
   INITRAMFS_PARTED_SUPPORT="no"
 
 # build with swap support (yes / no)
-  SWAP_SUPPORT="no"
+  SWAP_SUPPORT="yes"
 
 # swap support enabled per default (yes / no)
   SWAP_ENABLED_DEFAULT="no"
 
 # swapfile size if SWAP_SUPPORT=yes in MB
-  SWAPFILESIZE="256"
+  SWAPFILESIZE="128"
 
 # build with installer (yes / no)
   INSTALLER_SUPPORT="yes"

--- a/projects/Odroid_C2/options
+++ b/projects/Odroid_C2/options
@@ -112,15 +112,6 @@
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="no"
 
-  # build with swap support (yes / no)
-    SWAP_SUPPORT="no"
-
-  # swap support enabled per default (yes / no)
-    SWAP_ENABLED_DEFAULT="no"
-
-  # swapfile size if SWAP_SUPPORT=yes in MB
-    SWAPFILESIZE="128"
-
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -140,15 +140,6 @@ fi
   # build and install ATV IR remote support (yes / no)
     ATVCLIENT_SUPPORT="no"
 
-  # build with swap support (yes / no)
-    SWAP_SUPPORT="yes"
-
-  # swap support enabled per default (yes / no)
-    SWAP_ENABLED_DEFAULT="no"
-
-  # swapfile size if SWAP_SUPPORT=yes in MB
-    SWAPFILESIZE="128"
-
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 

--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -130,15 +130,6 @@
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="yes"
 
-  # build with swap support (yes / no)
-    SWAP_SUPPORT="no"
-
-  # swap support enabled per default (yes / no)
-    SWAP_ENABLED_DEFAULT="no"
-
-  # swapfile size if SWAP_SUPPORT=yes in MB
-    SWAPFILESIZE="128"
-
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 

--- a/projects/WeTek_Hub/options
+++ b/projects/WeTek_Hub/options
@@ -118,15 +118,6 @@
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="no"
 
-  # build with swap support (yes / no)
-    SWAP_SUPPORT="no"
-
-  # swap support enabled per default (yes / no)
-    SWAP_ENABLED_DEFAULT="no"
-
-  # swapfile size if SWAP_SUPPORT=yes in MB
-    SWAPFILESIZE="128"
-
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -124,15 +124,6 @@
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="yes"
 
-  # build with swap support (yes / no)
-    SWAP_SUPPORT="no"
-
-  # swap support enabled per default (yes / no)
-    SWAP_ENABLED_DEFAULT="no"
-
-  # swapfile size if SWAP_SUPPORT=yes in MB
-    SWAPFILESIZE="128"
-
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 

--- a/projects/WeTek_Play_2/options
+++ b/projects/WeTek_Play_2/options
@@ -118,15 +118,6 @@
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="yes"
 
-  # build with swap support (yes / no)
-    SWAP_SUPPORT="no"
-
-  # swap support enabled per default (yes / no)
-    SWAP_ENABLED_DEFAULT="no"
-
-  # swapfile size if SWAP_SUPPORT=yes in MB
-    SWAPFILESIZE="128"
-
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 

--- a/projects/imx6/options
+++ b/projects/imx6/options
@@ -126,15 +126,6 @@
   # build and install ATV IR remote support (yes / no)
     ATVCLIENT_SUPPORT="no"
 
-  # build with swap support (yes / no)
-    SWAP_SUPPORT="no"
-
-  # swap support enabled per default (yes / no)
-    SWAP_ENABLED_DEFAULT="no"
-
-  # swapfile size if SWAP_SUPPORT=yes in MB
-    SWAPFILESIZE="128"
-
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 


### PR DESCRIPTION
Currently we only build RPiX with swap support and all other platforms not.
This PR removes from the projects the swap options and activate swap for all devices at distribution options.

opinions ?
@codesnake @MilhouseVH @lrusak @vpeter4 