### PR TITLE
[8.2] backport fuse: don't run /usr/sbin/update-rc.d on install

### DIFF
--- a/packages/sysutils/fuse/patches/fuse-0002-dont-run-update-rc.d.patch
+++ b/packages/sysutils/fuse/patches/fuse-0002-dont-run-update-rc.d.patch
@@ -1,0 +1,13 @@
+--- a/util/Makefile.in	2017-06-23 22:47:36.762827097 +0200
++++ b/util/Makefile.in	2017-06-23 22:47:47.358852950 +0200
+@@ -734,10 +734,6 @@
+ 	$(INSTALL_PROGRAM) $(builddir)/mount.fuse $(DESTDIR)$(MOUNT_FUSE_PATH)/mount.fuse
+ 	$(MKDIR_P) $(DESTDIR)$(INIT_D_PATH)
+ 	$(INSTALL_SCRIPT) $(srcdir)/init_script $(DESTDIR)$(INIT_D_PATH)/fuse
+-	@if test -x /usr/sbin/update-rc.d; then \
+-		echo "/usr/sbin/update-rc.d fuse start 34 S . start 41 0 6 . || true"; \
+-		/usr/sbin/update-rc.d fuse start 34 S . start 41 0 6 . || true; \
+-	fi
+ 
+ install-data-local:
+ 	$(MKDIR_P) $(DESTDIR)$(UDEV_RULES_PATH)


### PR DESCRIPTION
backport of #1718 