### PR TITLE
tvheadend42: update to 4.2.2-75

### DIFF
--- a/packages/addons/service/tvheadend42/changelog.txt
+++ b/packages/addons/service/tvheadend42/changelog.txt
@@ -1,5 +1,5 @@
 111
-- update to Tvheadend 4.2.2-32
+- update to Tvheadend 4.2.2-75
 
 110
 - added tv_grab_file support for compressed files (gz bz2 xz)

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="tvheadend42"
-PKG_VERSION="76dbc3e"
-PKG_VERSION_NUMBER="4.2.2-32"
+PKG_VERSION="a84adb2"
+PKG_VERSION_NUMBER="4.2.2-75"
 PKG_REV="111"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
to be in sync with 8.2 (no rev bump because master addons wasn't build at all)