### PR TITLE
linux: fix post_patch which may end with exit code == 1 if no overlay…

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -133,11 +133,11 @@ post_patch() {
 
   # install extra dts files
   for f in $PROJECT_DIR/$PROJECT/config/*-overlay.dts; do
-    [ -f "$f" ] && cp -v $f $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/overlays
+    [ -f "$f" ] && cp -v $f $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/overlays || true
   done
   if [ -n "$DEVICE" ]; then
     for f in $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/*-overlay.dts; do
-      [ -f "$f" ] && cp -v $f $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/overlays
+      [ -f "$f" ] && cp -v $f $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/overlays || true
     done
   fi
 }


### PR DESCRIPTION
…s to cp

See comment: https://github.com/LibreELEC/LibreELEC.tv/pull/1709/files#r125338806

This ensures that `post_patch()` will succeed even if no dts files are copied.