### PR TITLE
kernel-firmware: restore ath9k_htc firmware for TP-LINK WN821N/WN822N…

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -3,8 +3,9 @@ ath3k-1.fw
 rtl_bt/*_fw.bin
 
 # WLAN firmwares
-ath10k/*
 ath6k/*
+ath9k_htc/*
+ath10k/*
 brcm/*
 libertas/*
 mrvl/*


### PR DESCRIPTION
… USB WLAN

Reported on [forum](https://forum.kodi.tv/showthread.php?tid=298461&pid=2612970#pid2612970) and confirmed working once firmware included.

Backport coming up.