### PR TITLE
Update Nvidia Drivers to 381.22 and add suport for GT 1030

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -20,7 +20,7 @@ PKG_NAME="xf86-video-nvidia"
 # Remember to run "python packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py" and commit changes to
 # "packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules" whenever bumping version.
 # Host may require installation of python-lxml and python-requests packages.
-PKG_VERSION="375.66"
+PKG_VERSION="381.22"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.nvidia.com/"

--- a/packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules
+++ b/packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules
@@ -351,6 +351,7 @@ ATTRS{device}=="0x1c8d", GOTO="configure_nvidia"
 ATTRS{device}=="0x1cb1", GOTO="configure_nvidia"
 ATTRS{device}=="0x1cb2", GOTO="configure_nvidia"
 ATTRS{device}=="0x1cb3", GOTO="configure_nvidia"
+ATTRS{device}=="0x1d01", GOTO="configure_nvidia"
 GOTO="configure_nvidia-legacy"
 
 LABEL="configure_nvidia"


### PR DESCRIPTION
In order to use LibreELEC with Nvidia GT 1030, drivers at version 381.22 or higher are needed.

Also, since card detection isn't working as intended because the HTML page used to generate the rules is missing the GT 1030 id I have added it manually.

This driver has been tested using escapade's build with the device fixes in the second commit on a computer with a GT 1030 where it worked flawlessly.