### PR TITLE
bluetooth-audio: fix log errors

### DIFF
--- a/packages/addons/service/bluetooth-audio/changelog.txt
+++ b/packages/addons/service/bluetooth-audio/changelog.txt
@@ -1,2 +1,5 @@
+101
+- Fix log errors
+
 100
 - Initial release

--- a/packages/addons/service/bluetooth-audio/package.mk
+++ b/packages/addons/service/bluetooth-audio/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="bluetooth-audio"
 PKG_VERSION="0"
-PKG_REV="100"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""

--- a/packages/addons/service/bluetooth-audio/source/default.py
+++ b/packages/addons/service/bluetooth-audio/source/default.py
@@ -17,6 +17,7 @@
 ################################################################################
 
 import dbus
+import dbus.mainloop.glib
 import gobject
 import json
 import threading
@@ -107,6 +108,7 @@ class BluetoothAudioClient(object):
 
   def _setup_bus(self):
 
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
     self._bus = dbus.SystemBus()
 
   def _setup_signals(self):

--- a/packages/addons/service/bluetooth-audio/source/resources/language/English/strings.po
+++ b/packages/addons/service/bluetooth-audio/source/resources/language/English/strings.po
@@ -2,6 +2,15 @@
 # Addon Name: bluetooth-audio
 # Addon id: service.bluetooth-audio
 
+msgid ""
+msgstr ""
+
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 msgctxt "#30000"
 msgid "Settings"
 msgstr ""


### PR DESCRIPTION
On LE8:

```
ERROR: POParser: unable to read PO file header from file: /storage/.kodi/addons/service.bluetooth-audio/resources/language/English/strings.po
```

and

``` 
ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.RuntimeError'>
                                            Error Contents: To make asynchronous calls, receive signals or export objects, D-Bus connections must be attached to a main loop by passing mainloop=... to the constructor or calling dbus.set_default_main_loop(...)
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/service.bluetooth-audio/default.py", line 185, in <module>
                                                client = BluetoothAudioClient()
                                              File "/storage/.kodi/addons/service.bluetooth-audio/default.py", line 88, in __init__
                                                self._setup_signals()
                                              File "/storage/.kodi/addons/service.bluetooth-audio/default.py", line 118, in _setup_signals
                                                member_keyword='signal')
                                              File "/usr/lib/python2.7/site-packages/dbus/bus.py", line 148, in add_signal_receiver
                                              File "/usr/lib/python2.7/site-packages/dbus/connection.py", line 400, in add_signal_receiver
                                            RuntimeError: To make asynchronous calls, receive signals or export objects, D-Bus connections must be attached to a main loop by passing mainloop=... to the constructor or calling dbus.set_default_main_loop(...)
                                            -->End of Python script error report<--
```