### PR TITLE
kodi: disable using debug fission

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -222,6 +222,7 @@ PKG_CMAKE_OPTS_TARGET="-DNATIVEPREFIX=$TOOLCHAIN \
                        -DENABLE_LIRC=ON \
                        -DENABLE_EVENTCLIENTS=ON \
                        -DENABLE_LDGOLD=ON \
+                       -DENABLE_DEBUGFISSION=OFF \
                        $KODI_ARCH \
                        $KODI_OPENMAX \
                        $KODI_VDPAU \


### PR DESCRIPTION
debug fission uses -gsplit-dwarf which creates separate .dwo debug files that live in the build directory. We don't want this. We want to include all the debug symbols in the build when we do a debug build.