### PR TITLE
init: make break after behaviour really break after

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -62,6 +62,8 @@
 
   LIVE="no"
 
+  BREAK_TRIPPED="no"
+
   # Get a serial number if present (eg. RPi) otherwise use MAC address from eth0
   MACHINE_UID="$(cat /proc/cpuinfo | awk '/^Serial/{s=$3; gsub ("^0*","",s); print s}')"
   [ -z "$MACHINE_UID" ] && MACHINE_UID="$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d :)"
@@ -182,7 +184,7 @@
   }
 
   debug_shell() {
-    echo "### Starting debugging shell... type  exit  to quit ###"
+    echo "### Starting debugging shell for boot step: $BOOT_STEP... type  exit  to quit ###"
 
     showcursor
 
@@ -197,12 +199,17 @@
   }
 
   break_after() {
-    # Start debug shell after boot step $1
-    case $BREAK in
-      all|*$1*)
-        debug_shell
-        ;;
-    esac
+    # Start debug shell after boot step $1, and all subsequent steps
+    if [ $BREAK_TRIPPED == yes ]; then
+      debug_shell
+    else
+      case $BREAK in
+        all|*$1*)
+          BREAK_TRIPPED=yes
+          debug_shell
+          ;;
+      esac
+    fi
   }
 
   # Mount handlers


### PR DESCRIPTION
Just a small change to the `init` "break after" procedure.

Whenever `debugging break=$step` is configured, the `init` process will drop into a debug shell _after_ $step, eg. after `load_splash`.

However, once you exit from $step, the boot procedure will continue to completion even if you wanted to debug a subsequent step.

This change now means that once you have reached $step and dropped into the debug shell, all subsequent steps will also break and drop into the debug shell. This gives more control over the `init` boot process once $step is reached.

Note that if the debug shell is entered because of an error, the existing boot-to-completion behaviour is unchanged.

In addition, the current boot step has been added to the debug shell message so that users will know where they are in the boot process... handy if using `break=all`.