### PR TITLE
LE 8.2: aml: Make updates faster

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -440,7 +440,7 @@
 
     if [ -f "$UPDATE_DIR/$2" -a -b "$3" ]; then
       StartProgress spinner "Updating $1... "
-        result="$(dd if="$UPDATE_DIR/$2" of="$3" conv=fsync 2>&1)"
+        result="$(dd if="$UPDATE_DIR/$2" of="$3" 2>&1)"
         StopProgress "done"
       echo "${result}"
     fi


### PR DESCRIPTION
Do not use dd option conv=fsync when updating kernel on a block device.

Makes updates much faster for NAND installations on Amlogic-based devices.

Backport of #1768.