### PR TITLE
Upgrade Nvidia driver to v381.22

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -20,7 +20,7 @@ PKG_NAME="xf86-video-nvidia"
 # Remember to run "python packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py" and commit changes to
 # "packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules" whenever bumping version.
 # Host may require installation of python-lxml and python-requests packages.
-PKG_VERSION="375.66"
+PKG_VERSION="381.22"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.nvidia.com/"


### PR DESCRIPTION
This is the last current stable driver for Linux: http://www.geforce.com/drivers/results/118524

This add support for 10 series Nvidia graphic cards.

Currently, I have a "No screen found" error on boot with a GT 1030 card.

I'm compiling the project to show if this fix the issue.

Could this update be pushed on a new bugfix release?

Note: I did run the `python packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py` command but nothing changed. It seems the cards are already registered.