### PR TITLE
nss/nspr: include in main image [rfc]

### DIFF
--- a/packages/addons/addon-depends/nss/package.mk
+++ b/packages/addons/addon-depends/nss/package.mk
@@ -55,6 +55,7 @@ make_target() {
   [ "$TARGET_ARCH" = "x86_64" ] && TARGET_USE_64="USE_64=1"
 
   make BUILD_OPT=1 $TARGET_USE_64 \
+     NSS_USE_SYSTEM_SQLITE=1 \
      NSPR_INCLUDE_DIR=$SYSROOT_PREFIX/usr/include/nspr \
      USE_SYSTEM_ZLIB=1 ZLIB_LIBS=-lz \
      OS_TEST=$TARGET_ARCH \

--- a/packages/addons/addon-depends/nss/package.mk
+++ b/packages/addons/addon-depends/nss/package.mk
@@ -58,6 +58,7 @@ make_target() {
      NSS_USE_SYSTEM_SQLITE=1 \
      NSPR_INCLUDE_DIR=$SYSROOT_PREFIX/usr/include/nspr \
      USE_SYSTEM_ZLIB=1 ZLIB_LIBS=-lz \
+     SKIP_SHLIBSIGN=1 \
      OS_TEST=$TARGET_ARCH \
      NSS_TESTS="dummy" \
      NSINSTALL=$TOOLCHAIN/bin/nsinstall \

--- a/packages/addons/addon-depends/nss/package.mk
+++ b/packages/addons/addon-depends/nss/package.mk
@@ -36,9 +36,7 @@ MAKEFLAGS=-j1
 make_host() {
   cd $PKG_BUILD/nss
 
-  [ "$TARGET_ARCH" = "x86_64" ] && export USE_64=1
-
-  make -C coreconf/nsinstall
+  make USE_64=1 -C coreconf/nsinstall
 }
 
 makeinstall_host() {

--- a/packages/addons/addon-depends/nss/package.mk
+++ b/packages/addons/addon-depends/nss/package.mk
@@ -73,4 +73,7 @@ makeinstall_target() {
   mkdir -p $SYSROOT_PREFIX/usr/include/nss
   cp -RL dist/{public,private}/nss/* $SYSROOT_PREFIX/usr/include/nss
   cp -L dist/Linux*/lib/pkgconfig/nss.pc $SYSROOT_PREFIX/usr/lib/pkgconfig
+
+  mkdir -p .install_pkg/usr/lib
+    cp -PL dist/Linux*/lib/*.so .install_pkg/usr/lib
 }

--- a/packages/addons/addon-depends/nss/patches/nss-04-skip_shlibsign.patch
+++ b/packages/addons/addon-depends/nss/patches/nss-04-skip_shlibsign.patch
@@ -1,0 +1,12 @@
+diff -Naur nss-3.29.5.orig/nss/cmd/shlibsign/Makefile nss-3.29.5/nss/cmd/shlibsign/Makefile
+--- nss-3.29.5.orig/nss/cmd/shlibsign/Makefile	2017-09-08 10:56:01.663876686 +0200
++++ nss-3.29.5/nss/cmd/shlibsign/Makefile	2017-09-08 10:57:19.659306831 +0200
+@@ -95,5 +95,7 @@
+     endif
+ endif
+ 
+-libs install :: $(CHECKLOC)
++ifndef SKIP_SHLIBSIGN
++	libs install :: $(CHECKLOC)
++endif
+ 

--- a/packages/addons/addon-depends/nss/patches/nss-05-disable_host_cflags.patch
+++ b/packages/addons/addon-depends/nss/patches/nss-05-disable_host_cflags.patch
@@ -1,0 +1,12 @@
+diff -Naur nss-3.29.5.orig/nspr/config/autoconf.mk.in nss-3.29.5/nspr/config/autoconf.mk.in
+--- nss-3.29.5.orig/nspr/config/autoconf.mk.in	2017-09-08 11:03:27.572619156 +0200
++++ nss-3.29.5/nspr/config/autoconf.mk.in	2017-09-08 11:03:41.100520343 +0200
+@@ -104,7 +104,7 @@
+ RESOLVE_LINK_SYMBOLS = @RESOLVE_LINK_SYMBOLS@
+ 
+ HOST_CC		= @HOST_CC@
+-HOST_CFLAGS	= @HOST_CFLAGS@
++#HOST_CFLAGS	= @HOST_CFLAGS@
+ HOST_LDFLAGS	= @HOST_LDFLAGS@
+ 
+ DEFINES		= @DEFINES@ @DEFS@

--- a/packages/addons/browser/chromium/package.mk
+++ b/packages/addons/browser/chromium/package.mk
@@ -161,12 +161,6 @@ addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/gdk-pixbuf-modules
   cp -PL $(get_build_dir gdk-pixbuf)/.install_pkg/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/* $ADDON_BUILD/$PKG_ADDON_ID/gdk-pixbuf-modules
 
-  # nss
-  cp -PL $(get_build_dir nss)/dist/Linux*OPT.OBJ/lib/*.so $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # nspr
-  cp -PL $(get_build_dir nspr)/.install_pkg/usr/lib/*.so $ADDON_BUILD/$PKG_ADDON_ID/lib
-
   # libexif
   cp -PL $(get_build_dir libexif)/.install_pkg/usr/lib/* $ADDON_BUILD/$PKG_ADDON_ID/lib
 

--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -29,6 +29,10 @@ PKG_LONGDESC="inputstream.adaptive"
 
 PKG_IS_ADDON="yes"
 
+if [ "$TARGET_ARCH" = "x86_64" ] || [ "$TARGET_ARCH" = "arm" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET nss"
+fi
+
 addon() {
   install_binary_addon $PKG_ADDON_ID
 

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -39,3 +39,8 @@ fi
 if [ "$OPENVPN_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET openvpn"
 fi
+
+# nss needed by inputstream.adaptive, chromium etc.
+if [ "$TARGET_ARCH" = "x86_64" ] || [ "$TARGET_ARCH" = "arm" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET nss"
+fi


### PR DESCRIPTION
This builds nss and nspr as part of the main image, for x86. The packages are based on the existing add versions (which are now removed), but bumped to latest versions (thanks @InuSasha).

The libraries created by `nss` and `nspr` are required by `chromium` and `inputstream.adaptive` addons (in the case of the latter, they're required by `libwidevinecdm.so`).

This PR adds `nss` as a dependency of kodi, when building for x86_64. It also builds `nss` using the system Sqlite3 library which avoids `nss` installing a version of `libsqlite3.so` that can't be linked by kodi (and thus causing Kodi to fail).

The additional libraries add about 4MB to the final SYSTEM size.

There may be better ways of doing this, perhaps a dedicated `nss`/`nspr` addon, if anyone wants to have a go at that.