### PR TITLE
scripts/create_addon: fix debug_strip

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -118,6 +118,8 @@ pack_addon() {
        -e "s|@PKG_ADDON_SCREENSHOT@|$PKG_ADDON_SCREENSHOT|g" \
        -i $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
 
+  debug_strip $ADDON_BUILD/$PKG_ADDON_ID
+
   if [ "$2" != "-test" ] ; then
     ADDON_INSTALL_DIR="$TARGET/$ADDONS/$ADDON_VERSION/${DEVICE:-$PROJECT}/$TARGET_ARCH/$PKG_ADDON_ID"
     if [ -f $ADDON_INSTALL_DIR/$PKG_ADDON_ID-$ADDONVER.zip ] ; then
@@ -169,13 +171,12 @@ if [ "$PKG_IS_ADDON" = "yes" ] ; then
 
   if [ "$(type -t addon)" = "function" ]; then
     addon
-    debug_strip $ADDON_BUILD/$PKG_ADDON_ID
   else
     echo "*** unsupported package format. please convert your package ***"
     exit 1
   fi
 
-  # HACK for packages tat provide multiple addons like screensavers.rsxs
+  # HACK for packages that provide multiple addons like screensavers.rsxs
   # addon's addon() in package.mk should take care for exporting
   # MULTI_ADDONS="addon.boo1 addon.boo2 addon.boo3"
   if [ -n "$MULTI_ADDONS" ] ; then


### PR DESCRIPTION
fixes
```
PROJECT=Odroid_C2 ARCH=aarch64 ./scripts/create_addon imon-mce
  CREATE ADDON  (Odroid_C2/aarch64) imon-mce
find: '/builddir/addons/imon-mce/driver.remote.imon-mce': No such file or directory
*** WARNING: driver.remote.imon-mce-8.2.100.zip already exists. not overwriting it ***
```
and

```
PROJECT=Generic ARCH=x86_64 ./scripts/create_addon screensavers.rsxs
  CREATE ADDON  (Generic/x86_64) screensavers.rsxs
find: '/builddir/addons/screensavers.rsxs/screensavers.rsxs': No such file or directory
```