### PR TITLE
udev: cleanup

### DIFF
--- a/packages/network/ethtool/udev.d/99-wakeup-eth.rules
+++ b/packages/network/ethtool/udev.d/99-wakeup-eth.rules
@@ -21,7 +21,7 @@ ACTION!="add|change", GOTO="end"
 SUBSYSTEM!="net", GOTO="end"
 ENV{INTERFACE}!="eth*", GOTO="end"
 
-RUN+="/bin/sh -c 'echo enabled >/sys/class/net/$env{INTERFACE}/device/power/wakeup' "
+TEST=="/sys/class/net/$env{INTERFACE}/device/power/wakeup", RUN+="/bin/sh -c 'echo enabled >/sys/class/net/$env{INTERFACE}/device/power/wakeup'"
 RUN+="/usr/sbin/ethtool -s $env{INTERFACE} wol g"
 
 LABEL="end"

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -143,6 +143,11 @@ post_makeinstall_target() {
   # remove Network adaper renaming rule, this is confusing
   rm -rf $INSTALL/usr/lib/udev/rules.d/80-net-setup-link.rules
 
+  # remove the uaccess rules as we don't build systemd with ACL (see https://github.com/systemd/systemd/issues/4107)
+  rm -rf $INSTALL/usr/lib/udev/rules.d/70-uaccess.rules
+  rm -rf $INSTALL/usr/lib/udev/rules.d/71-seat.rules
+  rm -rf $INSTALL/usr/lib/udev/rules.d/73-seat-late.rules
+
   # remove debug-shell.service, we install our own
   rm -rf $INSTALL/usr/lib/systemd/system/debug-shell.service
 

--- a/packages/sysutils/udevil/udev.d/95-udevil-mount.rules
+++ b/packages/sysutils/udevil/udev.d/95-udevil-mount.rules
@@ -16,7 +16,7 @@ GOTO="exit"
 
 # mount or umount for hdds
 LABEL="harddisk"
-ACTION=="add", RUN+="/usr/bin/systemctl restart udevil-mount@/dev/%k.service"
+ACTION=="add", PROGRAM="/usr/bin/sh -c '/usr/bin/grep -E ^/dev/%k\  /proc/mounts || true'", RESULT=="", RUN+="/usr/bin/systemctl restart udevil-mount@/dev/%k.service"
 ACTION=="remove", RUN+="/usr/bin/systemctl stop udevil-mount@/dev/%k.service"
 GOTO="exit"
 

--- a/packages/tools/hdparm/udev.d/61-cdrom.rules
+++ b/packages/tools/hdparm/udev.d/61-cdrom.rules
@@ -19,6 +19,9 @@
 # only do anything on block devices which are not removed
 ACTION!="add|change", GOTO="cdrom_end"
 
+# /dev/sr, /dev/sr_mod, /dev/srcutree are not valid
+KERNEL=="sr|sr_mod|srcutree", GOTO="cdrom_end"
+
 # set CDROM speed
 KERNEL=="sr*", RUN+="/sbin/hdparm -E8 /dev/%k"
 


### PR DESCRIPTION
This is largely cosmetic, removing some annoyances, but might have a slight performance benefit - I don't think there will be any drawbacks.


#### udevil-mount: avoid mounting already mounted partitions

This change avoids mounting the `/flash` and `/storage` partitions through `udevil` when they have already been mounted by `init`. 

The following is the boot sequence on an RPi system with `/flash` and `/storage` on `/dev/mmcblk0p[1,2]`, and a third `Images` parition on `/dev/sda1` that is to be auto-shared by Samba.

```
Jul 07 20:23:55 rpi22 systemd[1]: Starting Udevil mount service...
Jul 07 20:23:55 rpi22 systemd[1]: Starting Udevil mount service...
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba SMB Daemon...
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba NMB Daemon...
Jul 07 20:23:55 rpi22 udevil[538]: udevil: denied 92: device /dev/mmcblk0p2 is already mounted (or specify mount point)
Jul 07 20:23:55 rpi22 udevil[537]: udevil: denied 92: device /dev/mmcblk0p1 is already mounted (or specify mount point)
Jul 07 20:23:55 rpi22 systemd[1]: Starting Udevil mount service...
Jul 07 20:23:55 rpi22 systemd[1]: Stopped Samba SMB Daemon.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba Configuration...
Jul 07 20:23:55 rpi22 systemd[1]: Started Samba Configuration.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba SMB Daemon...
Jul 07 20:23:55 rpi22 udevil[569]: Mounted /dev/sda1 at /media/Images
Jul 07 20:23:55 rpi22 systemd[1]: Stopped Samba SMB Daemon.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba Configuration...
Jul 07 20:23:55 rpi22 systemd[1]: Started Samba Configuration.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba SMB Daemon...
Jul 07 20:23:56 rpi22 systemd[1]: Started Samba NMB Daemon.
Jul 07 20:23:56 rpi22 systemd[1]: Started Samba SMB Daemon.
Jul 07 20:23:56 rpi22 systemd[1]: Started Udevil mount service.
Jul 07 20:23:56 rpi22 systemd[1]: Started Udevil mount service.
Jul 07 20:23:56 rpi22 systemd[1]: Started Udevil mount service.
```

Apart from one less error message per `/flash` and `/storage` partition, the more significant benefit is that we will no longer restart `smbd`/`samba-config`/`nmbd` after each attempted mount (even when unsuccesful), particularly as `/flash` and `/storage` will not even be [auto-shared](https://github.com/LibreELEC/LibreELEC.tv/blob/7661973437f9a33a4ea1aeeeb6c2d9cca91c3083/packages/network/samba/scripts/smbd-config#L29-L35) by Samba.

#### hdparm: stop trying set speed on invalid optical devices

```
Jul 07 20:23:54 LibreELEC systemd-udevd[250]: Process '/sbin/hdparm -E8 /dev/sr' failed with exit code 2.
Jul 07 20:23:54 LibreELEC systemd-udevd[256]: Process '/sbin/hdparm -E8 /dev/srcutree' failed with exit code 2.
Jul 07 20:23:54 LibreELEC systemd-udevd[266]: Process '/sbin/hdparm -E8 /dev/sr_mod' failed with exit code 2.
```

`/dev/sr`, `/dev/srcutree` and `/dev/sr_mod` are not valid optical devices so don't try to set their speed.

To be honest, I'm not entirely sure where these events are coming from but I've tested with an optical device that succesfully mounts as `/dev/sr0`.

#### ethtool: don't enable wakeup when unsupported

On RPi[1,2,3]:
```
Jul 07 20:23:54 rpi22 systemd-udevd[267]: Process '/bin/sh -c 'echo enabled >/sys/class/net/eth0/device/power/wakeup' ' failed with exit code 1.
```

If the sysfs entry doesn't exist, don't try and write to it...

#### systemd: remove uaccess rules as we don't build with ACL

```
Jul 07 20:23:54 LibreELEC systemd-udevd[249]: Invalid rule /usr/lib/udev/rules.d/73-seat-late.rules:15: RUN{builtin}: 'uaccess' unknown
```

https://github.com/systemd/systemd/issues/4107
https://bugzilla.redhat.com/show_bug.cgi?id=1207203
https://forum.manjaro.org/t/openrc-and-73-seat-late-rules-why-deleting-it-was-a-good-thing/24599
https://github.com/elogind/elogind/issues/10

There's no point including `uaccess` rules without ACL.


#### Before this PR:

```
Jul 07 20:23:53 LibreELEC systemd[1]: Started udev Coldplug all Devices.
Jul 07 20:23:54 LibreELEC systemd[1]: Starting udev Kernel Device Manager...
Jul 07 20:23:54 LibreELEC systemd-udevd[248]: Invalid rule /usr/lib/udev/rules.d/73-seat-late.rules:15: RUN{builtin}: 'uaccess' unknown
Jul 07 20:23:54 LibreELEC systemd[1]: Started udev Kernel Device Manager.
Jul 07 20:23:54 LibreELEC systemd-udevd[257]: Process '/sbin/hdparm -E8 /dev/sr_mod' failed with exit code 2.
Jul 07 20:23:54 LibreELEC systemd-udevd[268]: Process '/sbin/hdparm -E8 /dev/sr' failed with exit code 2.
Jul 07 20:23:54 LibreELEC systemd-udevd[263]: Process '/sbin/hdparm -E8 /dev/srcutree' failed with exit code 2.
Jul 07 20:23:54 LibreELEC systemd-udevd[257]: Process '/bin/sh -c 'echo enabled >/sys/class/net/eth0/device/power/wakeup' ' failed with exit code 1.
Jul 07 20:23:55 rpi22 systemd[1]: Created slice system-udevil\x2dmount.slice.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Udevil mount service...
Jul 07 20:23:55 rpi22 systemd[1]: Starting Udevil mount service...
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba SMB Daemon...
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba NMB Daemon...
Jul 07 20:23:55 rpi22 udevil[538]: udevil: denied 92: device /dev/mmcblk0p2 is already mounted (or specify mount point)
Jul 07 20:23:55 rpi22 udevil[537]: udevil: denied 92: device /dev/mmcblk0p1 is already mounted (or specify mount point)
Jul 07 20:23:55 rpi22 systemd[1]: Starting Udevil mount service...
Jul 07 20:23:55 rpi22 systemd[1]: Stopped Samba SMB Daemon.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba Configuration...
Jul 07 20:23:55 rpi22 systemd[1]: Started Samba Configuration.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba SMB Daemon...
Jul 07 20:23:55 rpi22 udevil[569]: Mounted /dev/sda1 at /media/Images
Jul 07 20:23:55 rpi22 systemd[1]: Stopped Samba SMB Daemon.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba Configuration...
Jul 07 20:23:55 rpi22 systemd[1]: Started Samba Configuration.
Jul 07 20:23:55 rpi22 systemd[1]: Starting Samba SMB Daemon...
Jul 07 20:23:56 rpi22 systemd[1]: Started Samba NMB Daemon.
Jul 07 20:23:56 rpi22 systemd[1]: Started Samba SMB Daemon.
Jul 07 20:23:56 rpi22 systemd[1]: Started Udevil mount service.
Jul 07 20:23:56 rpi22 systemd[1]: Started Udevil mount service.
Jul 07 20:23:56 rpi22 systemd[1]: Started Udevil mount service.
```

#### After this PR:
```
Jul 16 22:57:27 LibreELEC systemd[1]: Started udev Coldplug all Devices.
Jul 16 22:57:28 LibreELEC systemd[1]: Starting udev Kernel Device Manager...
Jul 16 22:57:28 LibreELEC systemd[1]: Started udev Kernel Device Manager.
Jul 16 22:57:29 rpi22 systemd[1]: Created slice system-udevil\x2dmount.slice.
Jul 16 22:57:29 rpi22 systemd[1]: Starting Udevil mount service...
Jul 16 22:57:29 rpi22 systemd[1]: Starting Samba SMB Daemon...
Jul 16 22:57:29 rpi22 systemd[1]: Starting Samba NMB Daemon...
Jul 16 22:57:29 rpi22 udevil[468]: Mounted /dev/sda1 at /media/Images
Jul 16 22:57:29 rpi22 systemd[1]: Stopped Samba SMB Daemon.
Jul 16 22:57:29 rpi22 systemd[1]: Starting Samba Configuration...
Jul 16 22:57:29 rpi22 systemd[1]: Started Samba Configuration.
Jul 16 22:57:29 rpi22 systemd[1]: Starting Samba SMB Daemon...
Jul 16 22:57:29 rpi22 systemd[1]: Started Samba NMB Daemon.
Jul 16 22:57:30 rpi22 systemd[1]: Started Samba SMB Daemon.
Jul 16 22:57:30 rpi22 systemd[1]: Started Udevil mount service.
```