### PR TITLE
samba/heimdal: update to samba-4.6.6 and heimdal-7.4.0

### DIFF
--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="heimdal"
-PKG_VERSION="7.1.0"
-PKG_SHA256="6fb321e54ae9eabc437f17087808e82fd52b91891308c92e27225712a68a8561"
+PKG_VERSION="7.4.0"
+PKG_SHA256="b1d5c19989ad9f2cd8038c1d7c3e8f2bc227f79a1fa4eb0ade42cab4a40637ab"
 PKG_ARCH="any"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="http://www.h5l.org/"
@@ -45,6 +45,7 @@ PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared \
                          --without-libedit \
                          --without-hesiod \
                          --without-x \
+                         --with-db-type-preference= \
                          --disable-heimdal-documentation"
 
 makeinstall_host() {

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="samba"
-PKG_VERSION="4.6.5"
-PKG_SHA256="c06901e1d318b425b8c3ecea3ef23a91e7371312a9ea7adbf34fb8eb42ca3b84"
+PKG_VERSION="4.6.6"
+PKG_SHA256="fc31c809f7d85ae30f2b7dcddcb8404201b626047458cb5f2b743d4f6f3f1a8e"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"


### PR DESCRIPTION
Update Samba and Heimdal with fix for the latest security vulnerability.

https://www.h5l.org/advisories.html?show=2017-07-11

CVE-2017-11103 ([Orpheus' Lyre](https://www.orpheus-lyre.info/) mutual authentication validation bypass)