### PR TITLE
netbsd-curses: change to dynamic building

### DIFF
--- a/packages/devel/netbsd-curses/package.mk
+++ b/packages/devel/netbsd-curses/package.mk
@@ -32,9 +32,10 @@ pre_make_target() {
 }
 
 make_target() {
-  make HOSTCC="$HOST_CC" PREFIX=/usr all-static
+  make HOSTCC="$HOST_CC" PREFIX=/usr all-dynamic
 }
 
 makeinstall_target() {
-  make HOSTCC="$HOST_CC" PREFIX=$SYSROOT_PREFIX/usr install-static
+  make PREFIX=$SYSROOT_PREFIX/usr install-dynamic
+  make PREFIX=$INSTALL/usr install-dynamic
 }


### PR DESCRIPTION
change to dynamic building (and update to latest), the change based at work from @escalade 
- this fixes building of mc that is broken with netbsd-curses > 0.2.0