### PR TITLE
samba: make SMB3_11 the default protocol, don't force in kodi

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -42,6 +42,14 @@
         </setting>
       </group>
     </category>
+
+    <category id="smb">
+      <group id="2">
+        <setting id="smb.maxprotocol">
+          <default>0</default>
+        </setting>
+      </group>
+    </category>
   </section>
 
   <section id="pvr">

--- a/packages/network/samba/patches/samba-951-backport-SMB3_11-default.patch
+++ b/packages/network/samba/patches/samba-951-backport-SMB3_11-default.patch
@@ -1,0 +1,55 @@
+From 1199907cbe2f003a7df6f56e6cf3878d0732344d Mon Sep 17 00:00:00 2001
+From: Stefan Metzmacher <metze@samba.org>
+Date: Mon, 26 Jun 2017 10:00:53 +0200
+Subject: [PATCH] param: change the effective default for "client max protocol"
+ to the latest supported protocol
+
+Currently it's SMB3_11.
+
+Signed-off-by: Stefan Metzmacher <metze@samba.org>
+Reviewed-by: Andrew Bartlett <abartlet@samba.org>
+---
+ docs-xml/smbdotconf/protocol/clientmaxprotocol.xml | 2 +-
+ lib/param/loadparm.c                               | 2 +-
+ source3/param/loadparm.c                           | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/docs-xml/smbdotconf/protocol/clientmaxprotocol.xml b/docs-xml/smbdotconf/protocol/clientmaxprotocol.xml
+index 0131331b876..eba18bfb80a 100644
+--- a/docs-xml/smbdotconf/protocol/clientmaxprotocol.xml
++++ b/docs-xml/smbdotconf/protocol/clientmaxprotocol.xml
+@@ -79,7 +79,7 @@
+     negotiation phase in the SMB protocol takes care of choosing 
+     the appropriate protocol.</para>
+ 
+-    <para>The value <constant>default</constant> refers to <constant>NT1</constant>.</para>
++    <para>The value <constant>default</constant> refers to <constant>SMB3_11</constant>.</para>
+ 
+     <para>IPC$ connections for DCERPC e.g. in winbindd, are handled by the
+     <smbconfoption name="client ipc max protocol"/> option.</para>
+diff --git a/lib/param/loadparm.c b/lib/param/loadparm.c
+index 9f32d7b27b0..3ceea50b279 100644
+--- a/lib/param/loadparm.c
++++ b/lib/param/loadparm.c
+@@ -3401,7 +3401,7 @@ int lpcfg_client_max_protocol(struct loadparm_context *lp_ctx)
+ {
+ 	int client_max_protocol = lpcfg__client_max_protocol(lp_ctx);
+ 	if (client_max_protocol == PROTOCOL_DEFAULT) {
+-		return PROTOCOL_NT1;
++		return PROTOCOL_LATEST;
+ 	}
+ 	return client_max_protocol;
+ }
+diff --git a/source3/param/loadparm.c b/source3/param/loadparm.c
+index 91fa85ea7b0..8f0cf5e6e03 100644
+--- a/source3/param/loadparm.c
++++ b/source3/param/loadparm.c
+@@ -4543,7 +4543,7 @@ int lp_client_max_protocol(void)
+ {
+ 	int client_max_protocol = lp__client_max_protocol();
+ 	if (client_max_protocol == PROTOCOL_DEFAULT) {
+-		return PROTOCOL_NT1;
++		return PROTOCOL_LATEST;
+ 	}
+ 	return client_max_protocol;
+ }


### PR DESCRIPTION
Drop the Samba patch when Samba 4.7 arrives.

The `appliance.xml` change depends on https://github.com/xbmc/xbmc/pull/12110 so don't merge this PR until we've bumped to a version of Kodi that includes PR12110.