### PR TITLE
disable media_build in official releases

### DIFF
--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -85,4 +85,4 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm_sta media_build intel_nuc_led"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm_sta intel_nuc_led"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -158,7 +158,7 @@ fi
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS media_build rpi-cirrus-config"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS rpi-cirrus-config"
 
   if [ "$DEVICE" = "Slice" -o "$DEVICE" = "Slice3" ]; then
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS slice-drivers"


### PR DESCRIPTION
media_build has been causing too much instability and breakage in the official LibreELEC builds. Furthermore it should be considered unsuitable for inclusion in official stable builds for a number of reasons:

- media_build maintainers warn you to use it in production systems
- The patches are sourced from a 3rd-party repo (not official media_tree) and replace the core linux subsystems rc, v4l, dvb with random development versions, typically at a pre-kernel-merge-window state.
- As there's no stable support from that repo any burden on adding fixes (eg during kernel rc stabilization) is put onto us.
- By the time a new kernel is released the in-kernel drivers are usually ahead of the ones from media_build - and include bugfixes.not present in the media_build code
- Bumping to a new kernel means we have to bump media_build as well, again leading to mostly untested bleeding-edge code being pulled in
- The way media_build is integrated into the LibreELEC buildsystem makes it hard to detect errors during compile-time, like the lirc_rpi breakage which only showed up during runtime

Bugfixes and out-of-tree DVB drivers should be added in the usual way instead, using backport patches and separate driver packages instead - which only contain the relevant driver patches, backported to the currently supported kernel(s).

Alternatively community builders can still choose to include media_build in their builds, at their own risk.

Please note that this PR doesn't remove media_build from the LibreELEC tree, it only disables it in the official projects so it doesn't get built by default. Centralized media_build support for community builders can still be provided through the LibreELEC tree.