### PR TITLE
imx6: update RTL8812AU patch

### DIFF
--- a/projects/imx6/patches/RTL8812AU/RTL8812AU-010-compile-3.14.patch
+++ b/projects/imx6/patches/RTL8812AU/RTL8812AU-010-compile-3.14.patch
@@ -1,8 +1,8 @@
 diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
-index 492bb1a..e52134d 100644
+index 5895645..a5b195c 100644
 --- a/os_dep/linux/ioctl_cfg80211.c
 +++ b/os_dep/linux/ioctl_cfg80211.c
-@@ -649,20 +649,16 @@ void rtw_cfg80211_ibss_indicate_connect(_adapter *padapter)
+@@ -613,20 +613,16 @@ void rtw_cfg80211_ibss_indicate_connect(_adapter *padapter)
  	struct wlan_network  *cur_network = &(pmlmepriv->cur_network);
  	struct wireless_dev *pwdev = padapter->rtw_wdev;
  	struct cfg80211_bss *bss = NULL;
@@ -12,21 +12,21 @@ index 492bb1a..e52134d 100644
  	struct ieee80211_channel *notify_channel;
 -#endif
  
- 	DBG_871X(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
+ 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
  
--#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))	
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))
  	freq = rtw_ch2freq(cur_network->network.Configuration.DSConfig);
  
  	if (0)
- 		DBG_871X("chan: %d, freq: %d\n", cur_network->network.Configuration.DSConfig, freq);
+ 		RTW_INFO("chan: %d, freq: %d\n", cur_network->network.Configuration.DSConfig, freq);
 -#endif
  
- 	if (pwdev->iftype != NL80211_IFTYPE_ADHOC) 
- 	{
-@@ -713,12 +709,8 @@ void rtw_cfg80211_ibss_indicate_connect(_adapter *padapter)
- 			DBG_871X_LEVEL(_drv_always_, FUNC_ADPT_FMT" BSS not found !!\n", FUNC_ADPT_ARG(padapter));
+ 	if (pwdev->iftype != NL80211_IFTYPE_ADHOC)
+ 		return;
+@@ -669,12 +665,8 @@ void rtw_cfg80211_ibss_indicate_connect(_adapter *padapter)
+ 			RTW_PRINT(FUNC_ADPT_FMT" BSS not found !!\n", FUNC_ADPT_ARG(padapter));
  	}
- 	//notify cfg80211 that device joined an IBSS
+ 	/* notify cfg80211 that device joined an IBSS */
 -#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))
  	notify_channel = ieee80211_get_channel(wiphy, freq);
  	cfg80211_ibss_joined(padapter->pnetdev, cur_network->network.MacAddress, notify_channel, GFP_ATOMIC);


### PR DESCRIPTION
Fixes imx6 patch for v5.1.5 driver.

Backport is in #1823