### PR TITLE
kernel-firmware: cleanup pt2

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -1,14 +1,17 @@
-ar3k/*
-ath3k-1.fw
-rtl_bt/*_fw.bin
+#aarch64
+htc_7010.fw
+htc_9271.fw
 
-# WLAN firmwares
-ath6k/*
+ath3k-1.fw
+ar5523.bin
+carl9170-1.fw
+mt7601u.bin
+rt2870.bin
+rt73.bin
+vntwusb.fw
+
+ath6k/AR6004/hw1.?/bdata.bin
 ath9k_htc/*
-ath10k/*
 brcm/*
-libertas/*
-mrvl/*
-mwl8k/*
-mwlwifi/*
+rtl_bt/*_fw.bin
 rtlwifi/*

--- a/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
@@ -1,6 +1,10 @@
-e100/*_ucode.bin
+ctefx.bin
+lbtf_usb.bin
+rt2561.bin
+rt2561s.bin
+rt2661.bin
+rt2860.bin
 intel/dsp_fw_{bxtn,glk,kbl,release}.bin
 intel/fw_sst_*.bin*
 intel/ibt-*.{ddc,sfi,bseq}
 intel/IntcSST2.bin
-rtl_nic/*.fw

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -157,7 +157,7 @@ pre_make_target() {
   if [ "$TARGET_ARCH" = "x86_64" ]; then
     # copy some extra firmware to linux tree
     mkdir -p $PKG_BUILD/external-firmware
-      cp -a $(get_build_dir kernel-firmware)/{amdgpu,amd-ucode,i915,radeon,rtl_nic} $PKG_BUILD/external-firmware
+      cp -a $(get_build_dir kernel-firmware)/{amdgpu,amd-ucode,i915,radeon,e100,rtl_nic} $PKG_BUILD/external-firmware
 
     cp -a $(get_build_dir intel-ucode)/intel-ucode $PKG_BUILD/external-firmware
 

--- a/projects/imx6/kernel-firmware/firmwares/any.dat
+++ b/projects/imx6/kernel-firmware/firmwares/any.dat
@@ -1,0 +1,15 @@
+rsi_91x.fw
+f2255usb.bin
+
+mts_mt9234mu.fw
+mts_mt9234zba.fw
+
+wil6210.brd
+wil6210.fw
+
+ti-connectivity/wl1251-fw.bin
+ti-connectivity/wl1251-nvs.bin
+ti-connectivity/wl12{7,8}x-fw-{4,5}{,-mr,-plt,-sr}.bin
+ti-connectivity/wl1271-nvs.bin
+
+mrvl/{sd,usb}*.bin


### PR DESCRIPTION
This is another attempt at only installing the firmware we actually need/use.

The changes in this PR are based on an analysis of kernel modules (all projects) and the information reported by `modinfo`. While not 100% reliable, it's a start and did identify some firmwares we need but were not including.

Firmwares that are now dropped - ie. `mwl8k`, `mwlwifi`, `ath6k`, `ath10k`, `libertas` - do not appear to be used by any kernel modules.

The `e100` firmwares should be in `initrd`, as they're used mostly by PRO/100 PCI adapters (this only adds 1.5KB).

`rtl_nic` is already included in `initrd`, and doesn't need to be included a second time in the image (at least, I don't think it does...)

`mrvl`, `ti-connectivity` and a handful of other firmwares are only used by the `imx6` 4.4-xbian kernel.

These changes result in a 20MB (uncompressed) reduction in image size (based on RPi/RPi2/Generic).