### PR TITLE
kernel-firmware: band aid additions for libreelec-8.2

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -12,3 +12,12 @@ mrvl/*
 mwl8k/*
 mwlwifi/*
 rtlwifi/*
+
+ar5523.bin
+carl9170-1.fw
+htc_7010.fw
+htc_9271.fw
+mt7601u.bin
+rt2870.bin
+rt73.bin
+vntwusb.fw

--- a/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
@@ -4,3 +4,10 @@ intel/fw_sst_*.bin*
 intel/ibt-*.{ddc,sfi,bseq}
 intel/IntcSST2.bin
 rtl_nic/*.fw
+
+ctefx.bin
+lbtf_usb.bin
+rt2561.bin
+rt2561s.bin
+rt2661.bin
+rt2860.bin


### PR DESCRIPTION
This adds a few firmwares that are referenced by kernel modules we build.

In particular it adds the two htc firmwares found in the root needed by WeTek hardware (thanks @hiassoft), and the rt2870.bin firmware needed by various Ralink chipsets [[1](https://forum.kodi.tv/showthread.php?pid=2625135#pid2625135)][[2](https://forum.kodi.tv/showthread.php?tid=298461&pid=2625272#pid2625272)]

This is an interim solution to a more thorough LE9 cleanup in #1848.