### PR TITLE
glibc update to 2.26

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="glibc"
-PKG_VERSION="2.25"
-PKG_SHA256="067bd9bb3390e79aa45911537d13c3721f1d9d3769931a30c2681bfee66f23a0"
+PKG_VERSION="2.26"
+PKG_SHA256="e54e0a934cd2bc94429be79da5e9385898d2306b9eaf3c92d5a77af96190f6bd"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/libc/"
@@ -50,6 +50,7 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --without-cvs \
                            --without-gd \
                            --enable-obsolete-rpc \
+                           --enable-obsolete-nsl \
                            --disable-build-nscd \
                            --disable-nscd \
                            --enable-lock-elision \

--- a/packages/lang/gcc/patches/gcc-0001-Use-stack_t-instead-of-struct-sigaltstack.patch
+++ b/packages/lang/gcc/patches/gcc-0001-Use-stack_t-instead-of-struct-sigaltstack.patch
@@ -1,0 +1,160 @@
+From 4c07606bb77bbd30f02adb947d480516da3fa3f7 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 11 Jun 2017 10:09:13 -0700
+Subject: [PATCH] libsanitizer: Use stack_t instead of struct sigaltstack
+
+Upstream-Status: Submitted
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libsanitizer/sanitizer_common/sanitizer_linux.cc                    | 4 ++--
+ libsanitizer/sanitizer_common/sanitizer_linux.h                     | 6 +++---
+ .../sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc        | 3 ++-
+ 3 files changed, 7 insertions(+), 6 deletions(-)
+
+Index: gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_linux.cc
+===================================================================
+--- gcc-7.1.0.orig/libsanitizer/sanitizer_common/sanitizer_linux.cc
++++ gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_linux.cc
+@@ -14,6 +14,10 @@
+ 
+ #if SANITIZER_FREEBSD || SANITIZER_LINUX
+ 
++#if !SANITIZER_ANDROID
++#include <sys/signal.h>
++#endif
++
+ #include "sanitizer_common.h"
+ #include "sanitizer_flags.h"
+ #include "sanitizer_internal_defs.h"
+@@ -71,10 +75,6 @@ extern "C" {
+ extern char **environ;  // provided by crt1
+ #endif  // SANITIZER_FREEBSD
+ 
+-#if !SANITIZER_ANDROID
+-#include <sys/signal.h>
+-#endif
+-
+ #if SANITIZER_LINUX
+ // <linux/time.h>
+ struct kernel_timeval {
+@@ -605,8 +605,8 @@ uptr internal_prctl(int option, uptr arg
+ }
+ #endif
+ 
+-uptr internal_sigaltstack(const struct sigaltstack *ss,
+-                         struct sigaltstack *oss) {
++uptr internal_sigaltstack(const stack_t *ss,
++                         stack_t *oss) {
+   return internal_syscall(SYSCALL(sigaltstack), (uptr)ss, (uptr)oss);
+ }
+ 
+Index: gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_linux.h
+===================================================================
+--- gcc-7.1.0.orig/libsanitizer/sanitizer_common/sanitizer_linux.h
++++ gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_linux.h
+@@ -19,7 +19,10 @@
+ #include "sanitizer_platform_limits_posix.h"
+ 
+ struct link_map;  // Opaque type returned by dlopen().
+-struct sigaltstack;
++
++#ifndef __stack_t_defined
++struct stack_t;
++#endif
+ 
+ namespace __sanitizer {
+ // Dirent structure for getdents(). Note that this structure is different from
+@@ -28,8 +31,8 @@ struct linux_dirent;
+ 
+ // Syscall wrappers.
+ uptr internal_getdents(fd_t fd, struct linux_dirent *dirp, unsigned int count);
+-uptr internal_sigaltstack(const struct sigaltstack* ss,
+-                          struct sigaltstack* oss);
++uptr internal_sigaltstack(const stack_t* ss,
++                          stack_t* oss);
+ uptr internal_sigprocmask(int how, __sanitizer_sigset_t *set,
+     __sanitizer_sigset_t *oldset);
+ 
+Index: gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc
+===================================================================
+--- gcc-7.1.0.orig/libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc
++++ gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cc
+@@ -16,6 +16,7 @@
+                         defined(__aarch64__) || defined(__powerpc64__) || \
+                         defined(__s390__))
+ 
++#include <signal.h>
+ #include "sanitizer_stoptheworld.h"
+ 
+ #include "sanitizer_platform_limits_posix.h"
+@@ -273,7 +274,7 @@ static int TracerThread(void* argument)
+ 
+   // Alternate stack for signal handling.
+   InternalScopedBuffer<char> handler_stack_memory(kHandlerStackSize);
+-  struct sigaltstack handler_stack;
++  stack_t handler_stack;
+   internal_memset(&handler_stack, 0, sizeof(handler_stack));
+   handler_stack.ss_sp = handler_stack_memory.data();
+   handler_stack.ss_size = kHandlerStackSize;
+Index: gcc-7.1.0/libsanitizer/tsan/tsan_platform_linux.cc
+===================================================================
+--- gcc-7.1.0.orig/libsanitizer/tsan/tsan_platform_linux.cc
++++ gcc-7.1.0/libsanitizer/tsan/tsan_platform_linux.cc
+@@ -14,6 +14,7 @@
+ #include "sanitizer_common/sanitizer_platform.h"
+ #if SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
++#include <signal.h>
+ #include "sanitizer_common/sanitizer_common.h"
+ #include "sanitizer_common/sanitizer_libc.h"
+ #include "sanitizer_common/sanitizer_linux.h"
+@@ -28,7 +29,6 @@
+ 
+ #include <fcntl.h>
+ #include <pthread.h>
+-#include <signal.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -287,7 +287,7 @@ void InitializePlatform() {
+ int ExtractResolvFDs(void *state, int *fds, int nfd) {
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+   int cnt = 0;
+-  __res_state *statp = (__res_state*)state;
++  res_state statp = (res_state)state;
+   for (int i = 0; i < MAXNS && cnt < nfd; i++) {
+     if (statp->_u._ext.nsaddrs[i] && statp->_u._ext.nssocks[i] != -1)
+       fds[cnt++] = statp->_u._ext.nssocks[i];
+Index: gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_linux_libcdep.cc
+===================================================================
+--- gcc-7.1.0.orig/libsanitizer/sanitizer_common/sanitizer_linux_libcdep.cc
++++ gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_linux_libcdep.cc
+@@ -14,6 +14,7 @@
+ 
+ #if SANITIZER_FREEBSD || SANITIZER_LINUX
+ 
++#include <signal.h>
+ #include "sanitizer_allocator_internal.h"
+ #include "sanitizer_atomic.h"
+ #include "sanitizer_common.h"
+@@ -30,7 +31,6 @@
+ 
+ #include <link.h>
+ #include <pthread.h>
+-#include <signal.h>
+ #include <sys/resource.h>
+ #include <syslog.h>
+ 
+Index: gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cc
+===================================================================
+--- gcc-7.1.0.orig/libsanitizer/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cc
++++ gcc-7.1.0/libsanitizer/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cc
+@@ -12,6 +12,7 @@
+ 
+ #include "sanitizer_platform.h"
+ #if SANITIZER_POSIX
++#include <signal.h>
+ #include "sanitizer_allocator_internal.h"
+ #include "sanitizer_common.h"
+ #include "sanitizer_flags.h"

--- a/packages/lang/gcc/patches/gcc-0002-replace-struct-ucontext-with-ucontext_t.patch
+++ b/packages/lang/gcc/patches/gcc-0002-replace-struct-ucontext-with-ucontext_t.patch
@@ -1,0 +1,149 @@
+From 7b3cb36ab07d0c36b500bb5d0548b190d4b5a9f6 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 28 Jun 2017 00:25:57 -0700
+Subject: [PATCH 50/50] replace struct ucontext with ucontext_t
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libgcc/config/aarch64/linux-unwind.h | 2 +-
+ libgcc/config/alpha/linux-unwind.h   | 2 +-
+ libgcc/config/bfin/linux-unwind.h    | 2 +-
+ libgcc/config/i386/linux-unwind.h    | 4 ++--
+ libgcc/config/pa/linux-unwind.h      | 2 +-
+ libgcc/config/riscv/linux-unwind.h   | 2 +-
+ libgcc/config/sh/linux-unwind.h      | 2 +-
+ libgcc/config/tilepro/linux-unwind.h | 2 +-
+ libgcc/config/xtensa/linux-unwind.h  | 2 +-
+ 9 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/libgcc/config/aarch64/linux-unwind.h b/libgcc/config/aarch64/linux-unwind.h
+index d5d6980442f..d46d5f53be3 100644
+--- a/libgcc/config/aarch64/linux-unwind.h
++++ b/libgcc/config/aarch64/linux-unwind.h
+@@ -55,7 +55,7 @@ aarch64_fallback_frame_state (struct _Unwind_Context *context,
+   struct rt_sigframe
+   {
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+   };
+ 
+   struct rt_sigframe *rt_;
+diff --git a/libgcc/config/alpha/linux-unwind.h b/libgcc/config/alpha/linux-unwind.h
+index a91a5f4fe26..7202516581d 100644
+--- a/libgcc/config/alpha/linux-unwind.h
++++ b/libgcc/config/alpha/linux-unwind.h
+@@ -51,7 +51,7 @@ alpha_fallback_frame_state (struct _Unwind_Context *context,
+     {
+       struct rt_sigframe {
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+       sc = &rt_->uc.uc_mcontext;
+     }
+diff --git a/libgcc/config/bfin/linux-unwind.h b/libgcc/config/bfin/linux-unwind.h
+index 9412c7652b8..37e9feb6965 100644
+--- a/libgcc/config/bfin/linux-unwind.h
++++ b/libgcc/config/bfin/linux-unwind.h
+@@ -52,7 +52,7 @@ bfin_fallback_frame_state (struct _Unwind_Context *context,
+ 	void *puc;
+ 	char retcode[8];
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+ 
+       /* The void * cast is necessary to avoid an aliasing warning.
+diff --git a/libgcc/config/i386/linux-unwind.h b/libgcc/config/i386/linux-unwind.h
+index b1d5040a687..2009ad72260 100644
+--- a/libgcc/config/i386/linux-unwind.h
++++ b/libgcc/config/i386/linux-unwind.h
+@@ -58,7 +58,7 @@ x86_64_fallback_frame_state (struct _Unwind_Context *context,
+   if (*(unsigned char *)(pc+0) == 0x48
+       && *(unsigned long long *)(pc+1) == RT_SIGRETURN_SYSCALL)
+     {
+-      struct ucontext *uc_ = context->cfa;
++      ucontext_t *uc_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+          The aliasing warning is correct, but should not be a problem
+          because it does not alias anything.  */
+@@ -138,7 +138,7 @@ x86_fallback_frame_state (struct _Unwind_Context *context,
+ 	siginfo_t *pinfo;
+ 	void *puc;
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+          The aliasing warning is correct, but should not be a problem
+diff --git a/libgcc/config/pa/linux-unwind.h b/libgcc/config/pa/linux-unwind.h
+index 580c18dad69..c2c3409bcc1 100644
+--- a/libgcc/config/pa/linux-unwind.h
++++ b/libgcc/config/pa/linux-unwind.h
+@@ -80,7 +80,7 @@ pa32_fallback_frame_state (struct _Unwind_Context *context,
+   struct sigcontext *sc;
+   struct rt_sigframe {
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+   } *frame;
+ 
+   /* rt_sigreturn trampoline:
+diff --git a/libgcc/config/riscv/linux-unwind.h b/libgcc/config/riscv/linux-unwind.h
+index a051a2869d4..1c8aeff7ef0 100644
+--- a/libgcc/config/riscv/linux-unwind.h
++++ b/libgcc/config/riscv/linux-unwind.h
+@@ -42,7 +42,7 @@ riscv_fallback_frame_state (struct _Unwind_Context *context,
+   struct rt_sigframe
+   {
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+   };
+ 
+   struct rt_sigframe *rt_;
+diff --git a/libgcc/config/sh/linux-unwind.h b/libgcc/config/sh/linux-unwind.h
+index 1038caeb5c3..a8c98220282 100644
+--- a/libgcc/config/sh/linux-unwind.h
++++ b/libgcc/config/sh/linux-unwind.h
+@@ -82,7 +82,7 @@ sh_fallback_frame_state (struct _Unwind_Context *context,
+     {
+       struct rt_sigframe {
+ 	siginfo_t info;
+-	struct ucontext uc;
++	ucontext_t uc;
+       } *rt_ = context->cfa;
+       /* The void * cast is necessary to avoid an aliasing warning.
+          The aliasing warning is correct, but should not be a problem
+diff --git a/libgcc/config/tilepro/linux-unwind.h b/libgcc/config/tilepro/linux-unwind.h
+index a8dc4405715..dba3b410279 100644
+--- a/libgcc/config/tilepro/linux-unwind.h
++++ b/libgcc/config/tilepro/linux-unwind.h
+@@ -61,7 +61,7 @@ tile_fallback_frame_state (struct _Unwind_Context *context,
+   struct rt_sigframe {
+     unsigned char save_area[C_ABI_SAVE_AREA_SIZE];
+     siginfo_t info;
+-    struct ucontext uc;
++    ucontext_t uc;
+   } *rt_;
+ 
+   /* Return if this is not a signal handler.  */
+diff --git a/libgcc/config/xtensa/linux-unwind.h b/libgcc/config/xtensa/linux-unwind.h
+index 67c272820d0..b37b8b31bbf 100644
+--- a/libgcc/config/xtensa/linux-unwind.h
++++ b/libgcc/config/xtensa/linux-unwind.h
+@@ -67,7 +67,7 @@ xtensa_fallback_frame_state (struct _Unwind_Context *context,
+ 
+   struct rt_sigframe {
+     siginfo_t info;
+-    struct ucontext uc;
++    struct ucontext_t uc;
+   } *rt_;
+ 
+   /* movi a2, __NR_rt_sigreturn; syscall */
+-- 
+2.13.2
+

--- a/packages/network/libtirpc/package.mk
+++ b/packages/network/libtirpc/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libtirpc"
-PKG_VERSION="1.0.1"
-PKG_SHA256="5156974f31be7ccbc8ab1de37c4739af6d9d42c87b1d5caf4835dda75fcbb89e"
+PKG_VERSION="1.0.2"
+PKG_SHA256="723c5ce92706cbb601a8db09110df1b4b69391643158f20ff587e20e7c5f90f5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://sourceforge.net/projects/libtirpc/"

--- a/packages/network/libtirpc/patches/libtirpc-0001-include-missing-stdint.h.patch
+++ b/packages/network/libtirpc/patches/libtirpc-0001-include-missing-stdint.h.patch
@@ -1,0 +1,11 @@
+diff -Naur a/src/xdr_sizeof.c b/src/xdr_sizeof.c
+--- a/src/xdr_sizeof.c	2017-07-05 08:02:23.000000000 -0700
++++ b/src/xdr_sizeof.c	2017-08-02 16:37:31.839143976 -0700
+@@ -39,6 +39,7 @@
+ #include <rpc/xdr.h>
+ #include <sys/types.h>
+ #include <stdlib.h>
++#include <stdint.h>
+ #include "un-namespace.h"
+ 
+ /* ARGSUSED */

--- a/packages/sysutils/systemd/patches/systemd-0003-remove-xlocale.h.patch
+++ b/packages/sysutils/systemd/patches/systemd-0003-remove-xlocale.h.patch
@@ -1,0 +1,27 @@
+From 0c50b8332092178378257c2de800fb6b6b4a8706 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 3 Jul 2017 08:45:04 -0700
+Subject: [PATCH] parse-util: Do not include unneeded xlocale.h
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+Upstream-Status: Backport [ partial https://github.com/systemd/systemd/commit/284d1cd0a12cad96a5ea61d1afb0dd677dbd147e]
+
+ src/basic/parse-util.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/basic/parse-util.c b/src/basic/parse-util.c
+index c98815b9b..a0eb45805 100644
+--- a/src/basic/parse-util.c
+ b/src/basic/parse-util.c
+@@ -23,7 +23,6 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <xlocale.h>
+ 
+ #include "alloc-util.h"
+ #include "extract-word.h"
+-- 
+2.13.2
+


### PR DESCRIPTION
this is for after #1664 as the gcc patches are for gcc 7.1.0