### PR TITLE
busybox: revert dd fsync change which makes no sense

### DIFF
--- a/packages/sysutils/busybox/patches/busybox-04-revert-dd-fsync-change.patch
+++ b/packages/sysutils/busybox/patches/busybox-04-revert-dd-fsync-change.patch
@@ -1,0 +1,34 @@
+From 0a61b6174d86fd0300be7cd4fa0b47ff12735958 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Tue, 8 Aug 2017 22:25:03 +0100
+Subject: [PATCH] Revert "dd: call fsync() only once before exiting if
+ conv=fsync is specified"
+
+This reverts commit dba0dc1999bb1e8bfe64607e2a9385cda361fcb7.
+---
+ coreutils/dd.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/coreutils/dd.c b/coreutils/dd.c
+index d302f35..bf0c4ab 100644
+--- a/coreutils/dd.c
++++ b/coreutils/dd.c
+@@ -531,11 +531,11 @@ int dd_main(int argc UNUSED_PARAM, char **argv)
+ 			if (write_and_stats(ibuf, n, obs, outfile))
+ 				goto out_status;
+ 		}
+-	}
+ 
+-	if (G.flags & FLAG_FSYNC) {
+-		if (fsync(ofd) < 0)
+-			goto die_outfile;
++		if (G.flags & FLAG_FSYNC) {
++			if (fsync(ofd) < 0)
++				goto die_outfile;
++		}
+ 	}
+ 
+ 	if (ENABLE_FEATURE_DD_IBS_OBS && oc) {
+-- 
+2.7.4
+


### PR DESCRIPTION
This [change](https://git.busybox.net/busybox/commit/?id=dba0dc1999bb1e8bfe64607e2a9385cda361fcb7) (introduced in 1.27.0) makes no sense - if anyone wanted to perform a single sync they would do that with `dd && sync` without changing the entire behaviour of `conv=fsync`.

Following this change in `busybox`, the upgrade progress indicators are useless as `dd bs=1M conv=fsync` no longer performs a sync every 1MB - there are now long delays where there is no progress, and then the progress jumps to 50% and finally 100% as the entire transfer is synced at the end (rather than at regular intervals **during** the transfer prior to `busybox` 1.27.0).

I've opened a bug: https://bugs.busybox.net/show_bug.cgi?id=10191

Apologies for not catching this sooner, I had assumed my SD card was on the fritz...!