### PR TITLE
Bump ffmpeg to 3.1.9-Krypton-17.4 [le82]

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="ffmpeg"
 # Current branch is: release/3.1-xbmc
-PKG_VERSION="33c167d"
+PKG_VERSION="f58e5b9"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"


### PR DESCRIPTION
Successfully tested on generic.