### PR TITLE
build system: avoid "boldwhite" color [le82]

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -182,7 +182,7 @@ if [ ! -f $STAMP ]; then
       done
     fi
 
-    printf "%${BUILD_INDENT}c ${boldyellow}BUILD${endcolor}    $PACKAGE_NAME ${boldwhite}($TARGET)${endcolor}\n" ' '>&$SILENT_OUT
+    printf "%${BUILD_INDENT}c ${boldyellow}BUILD${endcolor}    $PACKAGE_NAME ${yellow}($TARGET)${endcolor}\n" ' '>&$SILENT_OUT
     export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
     if [ "$PKG_AUTORECONF" = yes ]; then

--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ fi
 
 $SCRIPTS/build $@
 
-printf "%${BUILD_INDENT}c ${boldgreen}INSTALL${endcolor}    $PACKAGE_NAME ${boldwhite}($TARGET)${endcolor}\n" ' '>&$SILENT_OUT
+printf "%${BUILD_INDENT}c ${boldgreen}INSTALL${endcolor}    $PACKAGE_NAME ${yellow}($TARGET)${endcolor}\n" ' '>&$SILENT_OUT
 export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 if [ "$TARGET" = target ] ; then

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -172,7 +172,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     fi
 
     if [ -f "$i" ]; then
-      printf "%${BUILD_INDENT}c ${boldgreen}APPLY PATCH${endcolor} ${boldwhite}${PATCH_DESC}${endcolor}   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
+      printf "%${BUILD_INDENT}c ${boldgreen}APPLY PATCH${endcolor} ${yellow}${PATCH_DESC}${endcolor}   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
       if [ -n "$(grep -E '^GIT binary patch$' $i)" ]; then
         cat $i | git apply --directory=`echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 --verbose --whitespace=nowarn --unsafe-paths >&$VERBOSE_OUT
       else


### PR DESCRIPTION
White text is invisible on terminal with white background.

Backport of #1869