### PR TITLE
buildsystem: enable custom colours (or none at all)

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -525,6 +525,55 @@ debug_strip() {
   fi
 }
 
+print_color() {
+  local clr_name="$1" clr_text="$2" clr_actual
+
+  if [ "$DISABLE_COLORS" == "yes" ]; then
+    [ -n "${clr_text}" ] && echo -en "${clr_text}"
+    return 0
+  fi
+
+  clr_actual="${!clr_name}"
+
+  # If $clr_name isn't another colour variable (boldgreen etc.), then
+  # assume it's an actual colour escape sequence.
+  #
+  # Otherwise if $clr_name isn't defined, or doesn't exist, then use
+  # standard colours.
+  #
+  if [ -n "${clr_actual}" -a -z "${!clr_actual}" ]; then
+    clr_actual="${clr_name}"
+  elif [ -z "${clr_actual}" -o -z "${!clr_actual}" ]; then
+    case "${clr_name}" in
+      CLR_ERROR)        clr_actual="boldred";;
+      CLR_WARNING)      clr_actual="boldred";;
+      CLR_WARNING_DIM)  clr_actual="red";;
+
+      CLR_APPLY_PATCH)  clr_actual="boldgreen";;
+      CLR_AUTORECONF)   clr_actual="boldmagenta";;
+      CLR_BUILD)        clr_actual="boldyellow";;
+      CLR_CLEAN)        clr_actual="boldred";;
+      CLR_FIXCONFIG)    clr_actual="boldyellow";;
+      CLR_GET)          clr_actual="boldcyan";;
+      CLR_INFO)         clr_actual="boldgreen";;
+      CLR_INSTALL)      clr_actual="boldgreen";;
+      CLR_PATCH_DESC)   clr_actual="boldwhite";;
+      CLR_TARGET)       clr_actual="boldwhite";;
+      CLR_UNPACK)       clr_actual="boldcyan";;
+
+      CLR_ENDCOLOR)     clr_actual="endcolor";;
+
+      *)                clr_actual="endcolor";;
+    esac
+  fi
+
+  if [ -n "${clr_text}" ]; then
+    echo -en "${!clr_actual}${clr_text}${endcolor}"
+  else
+    echo -en "${!clr_actual}"
+  fi
+}
+
 # Use distribution functions if any
 if [ -f "distributions/$DISTRO/config/functions" ]; then
   . distributions/$DISTRO/config/functions

--- a/config/path
+++ b/config/path
@@ -211,6 +211,7 @@ fi
 BUILD_INDENT_SIZE=4
 
 # define colors
+if [ "$DISABLE_COLORS" != "yes" ]; then
   black="\e[0;30m"
   boldblack="\e[1;30m"
   red="\e[0;31m"
@@ -228,6 +229,7 @@ BUILD_INDENT_SIZE=4
   white="\e[0;37m"
   boldwhite="\e[1;37m"
   endcolor="\e[0m"
+fi
 
 # multilib? nah
 unset CONFIG_SITE

--- a/scripts/autoreconf
+++ b/scripts/autoreconf
@@ -30,7 +30,7 @@ if [ ! -f $PKG_BUILD/.autoreconf-done ] ; then
   touch $PKG_BUILD/NEWS $PKG_BUILD/AUTHORS $PKG_BUILD/ChangeLog
   mkdir -p $PKG_BUILD/m4
 
-  printf "%${BUILD_INDENT}c ${boldmagenta}AUTORECONF${endcolor}   $1\n" ' '>&$SILENT_OUT
+  printf "%${BUILD_INDENT}c $(print_color CLR_AUTORECONF "AUTORECONF")   $1\n" ' '>&$SILENT_OUT
   export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
   do_autoreconf $PKG_BUILD

--- a/scripts/build
+++ b/scripts/build
@@ -26,7 +26,7 @@ if [ -z "$1" ]; then
 fi
 
 if [ ! -f $PKG_DIR/package.mk ]; then
-  printf "${boldred}$1: no package.mk file found${endcolor}\n"
+  printf "$(print_color CLR_ERROR "$1: no package.mk file found")\n"
   exit 1
 fi
 
@@ -182,7 +182,7 @@ if [ ! -f $STAMP ]; then
       done
     fi
 
-    printf "%${BUILD_INDENT}c ${boldyellow}BUILD${endcolor}    $PACKAGE_NAME ${boldwhite}($TARGET)${endcolor}\n" ' '>&$SILENT_OUT
+    printf "%${BUILD_INDENT}c $(print_color CLR_BUILD "BUILD")    $PACKAGE_NAME $(print_color CLR_TARGET "($TARGET)")\n" ' '>&$SILENT_OUT
     export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
     if [ "$PKG_AUTORECONF" = yes ]; then

--- a/scripts/clean
+++ b/scripts/clean
@@ -21,7 +21,7 @@
 . config/options $1
 
 clean_package() {
-  printf "%${BUILD_INDENT}c ${boldred}CLEAN${endcolor}    $1\n" ' '>&$SILENT_OUT
+  printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "CLEAN")    $1\n" ' '>&$SILENT_OUT
   export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
   if [ "$CLEAN_SOURCES" = true ]; then
@@ -34,7 +34,7 @@ clean_package() {
     if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
       . "$i/.libreelec-unpack"
       if [ "$STAMP_PKG_NAME" = "$1" ]; then
-        printf "%${BUILD_INDENT}c ${boldred}*${endcolor} ${red}Removing $i ...${endcolor}\n" ' '>&$SILENT_OUT
+        printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "*") $(print_color CLR_WARNING_DIM "Removing $i ...")\n" ' '>&$SILENT_OUT
         rm -rf $i
       fi
     else

--- a/scripts/get
+++ b/scripts/get
@@ -63,7 +63,7 @@ done
 _get_file_already_downloaded $1 && exit 0
 
 # At this point, we need to download something...
-printf "%${BUILD_INDENT}c ${boldcyan}GET${endcolor}      $1\n" ' '>&$SILENT_OUT
+printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      $1\n" ' '>&$SILENT_OUT
 export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
@@ -80,7 +80,7 @@ while [ $NBWGET -gt 0 ]; do
 
     [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" == "${CALC_SHA256}" ] && break
 
-    printf "%${BUILD_INDENT}c ${boldred}WARNING${endcolor} Incorrect checksum calculated on downloaded file: got ${CALC_SHA256}, wanted ${PKG_SHA256}\n\n" ' '>&$SILENT_OUT
+    printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "WARNING") Incorrect checksum calculated on downloaded file: got ${CALC_SHA256}, wanted ${PKG_SHA256}\n\n" ' '>&$SILENT_OUT
   fi
   NBWGET=$((NBWGET - 1))
 done
@@ -89,7 +89,7 @@ if [ $NBWGET -eq 0 ]; then
   echo -e "\nCant't get $1 sources : $PKG_URL\n Try later !!"
   exit 1
 else
-  printf "%${BUILD_INDENT}c ${boldgreen}INFO${endcolor} Calculated checksum: ${CALC_SHA256}\n\n" ' '>&$SILENT_OUT
+  printf "%${BUILD_INDENT}c $(print_color CLR_INFO "INFO") Calculated checksum: ${CALC_SHA256}\n\n" ' '>&$SILENT_OUT
   echo "${PKG_URL}" > $STAMP_URL
   echo "${CALC_SHA256}" > $STAMP_SHA
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -49,13 +49,13 @@ if [ -n "$PKG_ARCH" -a ! "$PKG_ARCH" = "any" ]; then
 fi
 
 if [ ! -f $PKG_DIR/package.mk ]; then
-  printf "${boldred}${PACKAGE_NAME}: no package.mk file found${endcolor}\n"
+  printf "$(print_color CLR_ERROR "${PACKAGE_NAME}: no package.mk file found")\n"
   exit 1
 fi
 
 $SCRIPTS/build $@
 
-printf "%${BUILD_INDENT}c ${boldgreen}INSTALL${endcolor}    $PACKAGE_NAME ${boldwhite}($TARGET)${endcolor}\n" ' '>&$SILENT_OUT
+printf "%${BUILD_INDENT}c $(print_color CLR_INSTALL "INSTALL")    $PACKAGE_NAME $(print_color CLR_TARGET "($TARGET)")\n" ' '>&$SILENT_OUT
 export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 if [ "$TARGET" = target ] ; then

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -26,7 +26,7 @@ if [ -z "$1" ]; then
 fi
 
 if [ ! -f $PKG_DIR/package.mk ]; then
-  printf "${boldred}$1: no package.mk file found${endcolor}\n"
+  printf "$(print_color CLR_ERROR "$1: no package.mk file found")\n"
   exit 1
 fi
 
@@ -61,7 +61,7 @@ fi
 [ -f "$STAMP" ] && exit 0
 
 if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
-  printf "%${BUILD_INDENT}c ${boldcyan}UNPACK${endcolor}   $1\n" ' '>&$SILENT_OUT
+  printf "%${BUILD_INDENT}c $(print_color CLR_UNPACK "UNPACK")   $1\n" ' '>&$SILENT_OUT
   export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
   # unset functions
@@ -172,7 +172,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     fi
 
     if [ -f "$i" ]; then
-      printf "%${BUILD_INDENT}c ${boldgreen}APPLY PATCH${endcolor} ${boldwhite}${PATCH_DESC}${endcolor}   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
+      printf "%${BUILD_INDENT}c $(print_color CLR_APPLY_PATCH "APPLY PATCH") $(print_color CLR_PATCH_DESC "${PATCH_DESC}")   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
       if [ -n "$(grep -E '^GIT binary patch$' $i)" ]; then
         cat $i | git apply --directory=`echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 --verbose --whitespace=nowarn --unsafe-paths >&$VERBOSE_OUT
       else
@@ -187,7 +187,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
 
   if [ ! "$PKG_NAME" == "configtools" ] ; then
     for config in `find $PKG_BUILD -name config.guess | sed 's/config.guess//'`; do
-      printf "%${BUILD_INDENT}c ${boldyellow}FIXCONFIG${endcolor}   $config\n" ' '
+      printf "%${BUILD_INDENT}c $(print_color CLR_FIXCONFIG "FIXCONFIG")   $config\n" ' '
 
       [ -f "$config/config.guess" -a -f $TOOLCHAIN/configtools/config.guess ] && \
         cp -f $TOOLCHAIN/configtools/config.guess $config


### PR DESCRIPTION
This change is inspired by #1869 (which can be closed).

#### How this works:

1. Add your custom colour options to `$HOME/.libreelec/options`

2. Default colours are:
```
  CLR_ERROR=boldred
  CLR_WARNING=boldred
  CLR_WARNING_DIM=red
  CLR_APPLY_PATCH=boldgreen
  CLR_AUTORECONF=boldmagenta
  CLR_BUILD=boldyellow
  CLR_CLEAN=boldred
  CLR_FIXCONFIG=boldyellow
  CLR_GET=boldcyan
  CLR_INFO=boldgreen
  CLR_INSTALL=boldgreen
  CLR_PATCH_DESC=boldwhite
  CLR_TARGET=boldwhite
  CLR_UNPACK=boldcyan
```

3. Change any colour by associating with an existing colour or a direct escape sequence:
```
CLR_INSTALL=boldblue
CLR_TARGET=boldyellow
```
![s1](http://i.imgur.com/mjZ20QR.png)
```
yellowonred="\e[33;41m"
CLR_INSTALL=yellowonred
CLR_TARGET="\e[7;32m" #reverse green
```
![s2](http://i.imgur.com/ZxW4xXX.png)

4. Disable all colours by adding `DISABLE_COLORS=yes`

![s3](http://i.imgur.com/FGzgk7h.png)

I'll submit a backport if this is accepted.