### PR TITLE
build system: use DISK_SIZE in bytes for ovf template

### DIFF
--- a/projects/Generic/config/ovf.template
+++ b/projects/Generic/config/ovf.template
@@ -6,7 +6,7 @@ xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemS
   </References>
   <DiskSection>
     <Info>Virtual disk information</Info>
-    <Disk ovf:capacity="548" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="disk" ovf:fileRef="file" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+    <Disk ovf:capacity="@DISK_SIZE@" ovf:diskId="disk" ovf:fileRef="file" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
   </DiskSection>
   <NetworkSection>
     <Info>The list of logical networks</Info>

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -295,7 +295,7 @@ fi # bootloader
   if [ "$PROJECT" = "Generic" ]; then
     echo "image: creating open virtual appliance..."
     qemu-img convert -O vmdk -o subformat=streamOptimized "$DISK" "$DISK.vmdk"
-    sed -e "s,@DISTRO@,$DISTRO,g" -e "s,@DISK@,$(basename $DISK),g" -e "s,@DISK_SIZE@,$(ls -l $DISK.vmdk | awk '{print $5}'),g" $PROJECT_DIR/$PROJECT/config/ovf.template > $DISK.ovf
+    sed -e "s,@DISTRO@,$DISTRO,g" -e "s,@DISK@,$(basename $DISK),g" -e "s,@DISK_SIZE@,$(($DISK_SIZE*1024*1024)),g" $PROJECT_DIR/$PROJECT/config/ovf.template > $DISK.ovf
     tar -C $TARGET_IMG -cf $DISK.ova $(basename $DISK).ovf $(basename $DISK).vmdk
     echo "image: cleaning up..."
     rm $DISK.vmdk $DISK.ovf


### PR DESCRIPTION
Fix VMware CapacitySize mismatch error upon import of OVA into VMware Player/Workstation/Fusion.

I've tested with Player 12.

Can someone verify with Fusion?