### PR TITLE
config/functions: fix bash-4.4 issue, and empty 2nd param behaviour

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -529,7 +529,7 @@ print_color() {
   local clr_name="$1" clr_text="$2" clr_actual
 
   if [ "$DISABLE_COLORS" == "yes" ]; then
-    [ -n "${clr_text}" ] && echo -en "${clr_text}"
+    [ $# -eq 2 ] && echo -en "${clr_text}"
     return 0
   fi
 
@@ -541,9 +541,9 @@ print_color() {
   # Otherwise if $clr_name isn't defined, or doesn't exist, then use
   # standard colours.
   #
-  if [ -n "${clr_actual}" -a -z "${!clr_actual}" ]; then
+  if [[ -n "${clr_actual}" ]] && [[ -z "${!clr_actual}" ]]; then
     clr_actual="${clr_name}"
-  elif [ -z "${clr_actual}" -o -z "${!clr_actual}" ]; then
+  elif [[ -z "${clr_actual}" ]] || [[ -z "${!clr_actual}" ]]; then
     case "${clr_name}" in
       CLR_ERROR)        clr_actual="boldred";;
       CLR_WARNING)      clr_actual="boldred";;
@@ -567,7 +567,7 @@ print_color() {
     esac
   fi
 
-  if [ -n "${clr_text}" ]; then
+  if [ $# -eq 2 ]; then
     echo -en "${!clr_actual}${clr_text}${endcolor}"
   else
     echo -en "${!clr_actual}"


### PR DESCRIPTION
This addresses two issues:

1. Fixes the issue raised by @InuSasha https://github.com/LibreELEC/LibreELEC.tv/pull/1871#issuecomment-322473439

Apparently bash-4.4 behaves differently to bash-4.3. Splitting the conditions into two tests resolves the issue.

2. If `print_colour CLR_INSTALL ""` is ever used then the `${endcolor}` wouldn't be output which may not be intended. Therefore, change the test to the number of arguments (there's probably other ways of skinning this cat).

@InuSasha can you confirm this is good for you?