### PR TITLE
adafruit-libraries: include SSD1306 library

### DIFF
--- a/packages/addons/addon-depends/adafruit-libraries-depends/Adafruit_Python_SSD1306/package.mk
+++ b/packages/addons/addon-depends/adafruit-libraries-depends/Adafruit_Python_SSD1306/package.mk
@@ -1,0 +1,38 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="Adafruit_Python_SSD1306"
+PKG_VERSION="b7eccd1"
+PKG_SHA256="eb9d6a1387557681d5f86dbdaa4acd96de74aeccbad57bae647c6da947f9e044"
+PKG_ARCH="any"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/adafruit/${PKG_NAME}"
+PKG_URL="https://github.com/adafruit/${PKG_NAME}/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain Python distutilscross:host"
+PKG_SECTION="python"
+PKG_SHORTDESC="Adafruit Python SSD1306 Library"
+PKG_LONGDESC="SSD1306 oled driver library for 'monochrome' 128x64 and 128x32 OLEDs."
+PKG_AUTORECONF="no"
+
+make_target() {
+  : # nop
+}
+
+makeinstall_target() {
+  : # nop
+}

--- a/packages/addons/libraries/adafruit-libraries/changelog.txt
+++ b/packages/addons/libraries/adafruit-libraries/changelog.txt
@@ -1,3 +1,6 @@
+104
+- include SSD1306 library
+
 103
   updated libraries:
   - Adafruit Python ADS1x15 Library

--- a/packages/addons/libraries/adafruit-libraries/package.mk
+++ b/packages/addons/libraries/adafruit-libraries/package.mk
@@ -1,6 +1,6 @@
 ################################################################################
 #      This file is part of LibreELEC - https://libreelec.tv
-#      Copyright (C) 2016 Team LibreELEC
+#      Copyright (C) 2016-present Team LibreELEC
 #
 #  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -18,16 +18,16 @@
 
 PKG_NAME="adafruit-libraries"
 PKG_VERSION=""
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_ADDON_PROJECTS="RPi RPi2"
 PKG_LICENSE="MIT"
 PKG_SITE=""
 PKG_URL=""
-PKG_DEPENDS_TARGET="Adafruit_Python_ADS1x15 Adafruit_Python_ADXL345 Adafruit_Python_BMP Adafruit_Python_CharLCD Adafruit_Python_DHT Adafruit_Python_GPIO Adafruit_Python_LED_Backpack Adafruit_Python_LSM303 Adafruit_Python_MCP3008 Adafruit_Python_MCP4725 Adafruit_Python_PCA9685 Adafruit_Python_PureIO Adafruit_Python_SI1145 Adafruit_Python_TCS34725 Adafruit_Python_VCNL40xx Adafruit_Python_WS2801"
+PKG_DEPENDS_TARGET="Adafruit_Python_ADS1x15 Adafruit_Python_ADXL345 Adafruit_Python_BMP Adafruit_Python_CharLCD Adafruit_Python_DHT Adafruit_Python_GPIO Adafruit_Python_LED_Backpack Adafruit_Python_LSM303 Adafruit_Python_MCP3008 Adafruit_Python_MCP4725 Adafruit_Python_PCA9685 Adafruit_Python_PureIO Adafruit_Python_SI1145 Adafruit_Python_SSD1306 Adafruit_Python_TCS34725 Adafruit_Python_VCNL40xx Adafruit_Python_WS2801"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of libraries from Adafruit"
-PKG_LONGDESC="This bundle currently includes Adafruit_ADS1x15, Adafruit_ADXL345, Adafruit_BMP, Adafruit_CharLCD, Adafruit_DHT, Adafruit_GPIO, Adafruit_LED_Backpack, Adafruit_LSM303, Adafruit_MCP3008, Adafruit_MCP4725, Adafruit_PCA9685, Adafruit_PureIO, Adafruit_SI1145 Adafruit_TCS34725, Adafruit_VCNL40xx and Adafruit_WS2801 python modules"
+PKG_LONGDESC="This bundle currently includes Adafruit_ADS1x15, Adafruit_ADXL345, Adafruit_BMP, Adafruit_CharLCD, Adafruit_DHT, Adafruit_GPIO, Adafruit_LED_Backpack, Adafruit_LSM303, Adafruit_MCP3008, Adafruit_MCP4725, Adafruit_PCA9685, Adafruit_PureIO, Adafruit_SI1145, Adafruit_SSD1306, Adafruit_TCS34725, Adafruit_VCNL40xx and Adafruit_WS2801 python modules"
 PKG_AUTORECONF="no"
 
 PKG_IS_ADDON="yes"
@@ -50,6 +50,7 @@ addon() {
     cp -PR $(get_build_dir Adafruit_Python_PCA9685)/Adafruit_PCA9685           $ADDON_BUILD/$PKG_ADDON_ID/lib/
     cp -PR $(get_build_dir Adafruit_Python_PureIO)/Adafruit_PureIO             $ADDON_BUILD/$PKG_ADDON_ID/lib/
     cp -PR $(get_build_dir Adafruit_Python_SI1145)/SI1145                      $ADDON_BUILD/$PKG_ADDON_ID/lib/
+    cp -PR $(get_build_dir Adafruit_Python_SSD1306)/Adafruit_SSD1306           $ADDON_BUILD/$PKG_ADDON_ID/lib/
     cp -PR $(get_build_dir Adafruit_Python_TCS34725)/Adafruit_TCS34725         $ADDON_BUILD/$PKG_ADDON_ID/lib/
     cp -PR $(get_build_dir Adafruit_Python_VCNL40xx)/Adafruit_VCNL40xx         $ADDON_BUILD/$PKG_ADDON_ID/lib/
     cp -PR $(get_build_dir Adafruit_Python_WS2801)/Adafruit_WS2801             $ADDON_BUILD/$PKG_ADDON_ID/lib/


### PR DESCRIPTION
@InuSasha I can't test this nor did I have any clue about it, so pls have a look (it compiles at least)
as "requested" at the forum https://forum.libreelec.tv/thread/9576-compile-libreelec-with-adafruit-python-ssd1306/