### PR TITLE
build system: drop .img extension for the open virtual appliance [backport]

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -89,6 +89,7 @@ trap cleanup SIGINT
     parted -s "$DISK" set 1 boot on
   fi
   sync
+
 # create part2
   echo "image: creating part2..."
   STORAGE_PART_START=$(( $SYSTEM_PART_END + 1 ))
@@ -184,7 +185,7 @@ EOF
     mcopy $RELEASE_DIR/3rdparty/bootloader/start.elf ::
     mcopy $RELEASE_DIR/3rdparty/bootloader/config.txt ::
     mcopy $RELEASE_DIR/3rdparty/bootloader/distroconfig.txt ::
- 
+
     if [ -f $RELEASE_DIR/3rdparty/bootloader/dt-blob.bin ]; then
       mcopy $RELEASE_DIR/3rdparty/bootloader/dt-blob.bin ::
     fi
@@ -282,7 +283,6 @@ fi # bootloader
   echo "image: merging part2 back to image..."
   dd if="$LE_TMP/part2.ext4" of="$DISK" bs=512 seek="$STORAGE_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
 
-
 # extract part1 from image to run fsck
   echo "image: extracting part1 from image..."
   SYSTEM_PART_COUNT=$(( $SYSTEM_PART_END - $SYSTEM_PART_START + 1 ))
@@ -291,15 +291,34 @@ fi # bootloader
   echo "image: checking filesystem on part1..."
   fsck -n $LE_TMP/part1.fat >"$SAVE_ERROR" 2>&1 || show_error
 
-# create virtual images
+# create virtual image
   if [ "$PROJECT" = "Generic" ]; then
     echo "image: creating open virtual appliance..."
-    qemu-img convert -O vmdk -o subformat=streamOptimized "$DISK" "$DISK.vmdk"
-    sed -e "s,@DISTRO@,$DISTRO,g" -e "s,@DISK@,$(basename $DISK),g" -e "s,@DISK_SIZE@,$(($DISK_SIZE*1024*1024)),g" $PROJECT_DIR/$PROJECT/config/ovf.template > $DISK.ovf
-    tar -C $TARGET_IMG -cf $DISK.ova $(basename $DISK).ovf $(basename $DISK).vmdk
+    # duplicate $DISK so anything we do to it directly doesn't effect original
+    dd if="$DISK" of="${DISK/img/tmp}" bs=1M >"$SAVE_ERROR" 2>&1 || show_error
+    # change syslinux default to 'run'
+    echo "image: modifying fs on part1 for open virtual appliance..."
+    sed -i "/DEFAULT/ s/installer/run/" "$LE_TMP"/syslinux.cfg
+    # FIXME: an unalias should work here, but it does not; call mcopy directly
+    $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/syslinux.cfg ::/EFI/BOOT
+    $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/syslinux.cfg ::
+    sync
+    # merge modified part1 back to tmp disk image
+    echo "image: merging part1 back to open virtual appliance..."
+    dd if="$LE_TMP/part1.fat" of="${DISK/img/tmp}" bs=512 seek="$SYSTEM_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
+    # create vmdk from tmp $DISK
+    qemu-img convert -O vmdk -o subformat=streamOptimized "${DISK/img/tmp}" "${DISK/img/vmdk}"
+    # generate ovf from template
+    sed -e "s,@DISTRO@,$DISTRO,g" -e "s,@DISK@,$(basename ${DISK/.img}),g" \
+        -e "s,@DISK_SIZE@,$(($DISK_SIZE*1024*1024)),g" \
+        $PROJECT_DIR/$PROJECT/config/ovf.template > ${DISK/img/ovf}
+    # combine ovf and vmdk into official ova
+    tar -C $TARGET_IMG -cf ${DISK/img/ova} $(basename ${DISK/img/ovf}) $(basename ${DISK/img/vmdk})
     echo "image: cleaning up..."
-    rm $DISK.vmdk $DISK.ovf
-    [ -n "$SUDO_USER" ] && chown $SUDO_USER: $DISK.ova
+    # remove tmp $DISK, vmdk and ovf
+    rm ${DISK/img/tmp} ${DISK/img/vmdk} ${DISK/img/ovf}
+    # set owner
+    [ -n "$SUDO_USER" ] && chown $SUDO_USER: ${DISK/img/ova}
   fi
 
 # gzip


### PR DESCRIPTION
* drop .img extension for the open virtual appliance (cosmetic)
* change the default syslinux entry from installer to run for the open virtual appliance

Tested with VMware Player 12

Images
Branches
* master: [LibreELEC-Generic.x86_64-9.0-devel-20170816083248-r26711-g6a2d35ac4.ova](https://zalaare.freeddns.org/junkbin/LibreELEC-Generic.x86_64-9.0-devel-20170816083248-r26711-g6a2d35ac4.ova)
* libreelec-8.2 [LibreELEC-Generic.x86_64-8.2-devel-20170816085022-r25993-g8366a8f51.ova](https://zalaare.freeddns.org/junkbin/LibreELEC-Generic.x86_64-8.2-devel-20170816085022-r25993-g8366a8f51.ova)