### PR TITLE
Package Updates: intel-vaapi-driver, libva and libva-utils to 1.8.3

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libva-utils"
-PKG_VERSION="1.8.2"
-PKG_SHA256="038cc320d6403a626d78a50aad6c8b70a13f2359cea1e0cf0ab773773135bf4c"
+PKG_VERSION="1.8.3"
+PKG_SHA256="c59de4fb6f1021c435b3f49e2410760692324ee5bb464c716d674fcb626a7e03"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"

--- a/packages/multimedia/intel-vaapi-driver/package.mk
+++ b/packages/multimedia/intel-vaapi-driver/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="intel-vaapi-driver"
-PKG_VERSION="1.8.2"
-PKG_SHA256="866cdf9974911e58b0d3a2cade29dbe7b5b68836e142cf092b99db68e366b702"
+PKG_VERSION="1.8.3"
+PKG_SHA256="54411d9e579300ed63f8b9b06152a1a9ec95b7699507d7ffa014cd7b2aeaff6f"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libva"
-PKG_VERSION="1.8.2"
-PKG_SHA256="9ed3e3ddc8f47a715d4c6ec366beb21c83fc4e8a3d4d39a811baff76f0a0cede"
+PKG_VERSION="1.8.3"
+PKG_SHA256="56ee129deba99b06eb4a8d4f746b117c5d1dc2ec5b7a0bfc06971fca1598ab9b"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
FYI the current dev version of intel-vaapi-driver includes a crash when resuming VC-1 content - could be a Kodi bug though: https://forum.kodi.tv/showthread.php?tid=307033&pid=2636351#pid2636351

Bug is not present in 1.8.3, so lets get on to this version and deal with the crash later.