### PR TITLE
samba: don't restart smbd in samba-autoshare

### DIFF
--- a/packages/network/samba/scripts/samba-autoshare
+++ b/packages/network/samba/scripts/samba-autoshare
@@ -21,6 +21,8 @@ if [ -f /storage/.cache/services/samba.conf ]; then
   . /storage/.cache/services/samba.conf
 
   if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
-    systemctl restart smbd.service
+    /usr/lib/samba/samba-config
+    /usr/lib/samba/smbd-config
+    [ -f /run/samba/smbd.pid ] && pkill -HUP smbd
   fi
 fi


### PR DESCRIPTION
The samba-autoshare script that takes care of sharing mounted drives restarts smbd every time udevil mounts a disk. This can lead to a Samba restart frenzy on boot with several connected disks. This is unnecessary as Samba does not need to be restarted to pick up changes to shares in smb.conf.

This PR modifies samba-autoshare to simply regenerate the configuration (samba-config) and then extend the configuration according to LE settings (smbd-config).