### PR TITLE
brcmfmac_sdio-firmware-rpi: Consolidate firmware files

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="0.1"
-PKG_SHA256="266cc4e6ab1cfb6be15b038fb8d2a276a712de2c2286b75e4ecbdf3b44fd5166"
+PKG_VERSION="0.2"
+PKG_SHA256="c5c8fe1801362cd0817d98c82f8e9eb06c2f64b96a5233770f1cc054cfcaa9a9"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"

--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/scripts/rpi-btuart
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/scripts/rpi-btuart
@@ -1,11 +1,18 @@
-#!/bin/bash
+#!/bin/sh
+
+HCIATTACH=/usr/bin/hciattach
+SERIAL=$(awk '/^Serial/{ print $3 }' /proc/cpuinfo)
+B1=${SERIAL:10:2}
+B2=${SERIAL:12:2}
+B3=${SERIAL:14:2}
+BDADDR=$(printf b8:27:eb:%02x:%02x:%02x $((0x$B1 ^ 0xaa)) $((0x$B2 ^ 0xaa)) $((0x$B3 ^ 0xaa)))
 
 if [ "$(cat /proc/device-tree/aliases/uart0)" = "$(cat /proc/device-tree/aliases/serial1)" ] ; then
   if [ "$(wc -c /proc/device-tree/soc/gpio@7e200000/uart0_pins/brcm\,pins | cut -f 1 -d ' ')" = "16" ] ; then
-    /usr/bin/hciattach /dev/serial1 bcm43xx 3000000 flow -
+    $HCIATTACH /dev/serial1 bcm43xx 3000000 flow - $BDADDR
   else
-    /usr/bin/hciattach /dev/serial1 bcm43xx 921600 noflow -
+    $HCIATTACH /dev/serial1 bcm43xx 921600 noflow - $BDADDR
   fi
 else
-  /usr/bin/hciattach /dev/serial1 bcm43xx 460800 noflow -
+  $HCIATTACH /dev/serial1 bcm43xx 460800 noflow - $BDADDR
 fi

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -68,4 +68,7 @@ makeinstall_target() {
       done
     done < ${fwlist}
   done
+
+  # The following file is installed by brcmfmac_sdio-firmware-rpi
+  rm -fr $FW_TARGET_DIR/brcm/brcmfmac43430-sdio.bin
 }

--- a/packages/linux-firmware/wlan-firmware/package.mk
+++ b/packages/linux-firmware/wlan-firmware/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="wlan-firmware"
-PKG_VERSION="25d0c93"
-PKG_SHA256="ceb6e5db32c4d56587d8b74961a8ac7cf8269eaa0d21748a35cf2f878140078f"
+PKG_VERSION="34a47d9"
+PKG_SHA256="91dc9af5689cd7275723d6b825e5c3d800b7b8149e031a24e48556e030f63af8"
 PKG_ARCH="any"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/wlan-firmware"


### PR DESCRIPTION
Currently we install:

`BCM43430A1.hcd` from `brcmfmac_sdio-firmware-rpi`
`brcmfmac43430-sdio.bin` from `kernel-firmware`
`brcmfmac43430-sdio.txt` from `wlan-firmware`

This is crazy, particularly as we need to install updated brcmfmac43430-sdio.{bin,txt} (see [here](https://github.com/raspberrypi/linux/issues/1342#issuecomment-321221748)) but pulling the files from `kernel-firmware` (a repo not under our control) means that is more difficult to do - yes, we could binary patch it...

Now, all three files will be installed from `brcmfmac_sdio-firmware-rpi`.

This PR depends on https://github.com/LibreELEC/wlan-firmware/pull/4 (I'll update this once it is merged).

The change to `kernel-firmware` is a hack, but the best I could think of right now.

If any non-RPi0/RPi3 platforms require `brcmfmac43430-sdio.{bin,txt}` then this PR is wrong, as we will only be installing these files for RPi/RPi2.

This can be backported to libreelec-8.2.