### PR TITLE
brcmfmac_sdio-firmware-rpi: Consolidate firmware files [Backport]

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="0.1"
+PKG_VERSION="0.2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"

--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/scripts/rpi-btuart
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/scripts/rpi-btuart
@@ -1,11 +1,18 @@
-#!/bin/bash
+#!/bin/sh
+
+HCIATTACH=/usr/bin/hciattach
+SERIAL=$(awk '/^Serial/{ print $3 }' /proc/cpuinfo)
+B1=${SERIAL:10:2}
+B2=${SERIAL:12:2}
+B3=${SERIAL:14:2}
+BDADDR=$(printf b8:27:eb:%02x:%02x:%02x $((0x$B1 ^ 0xaa)) $((0x$B2 ^ 0xaa)) $((0x$B3 ^ 0xaa)))
 
 if [ "$(cat /proc/device-tree/aliases/uart0)" = "$(cat /proc/device-tree/aliases/serial1)" ] ; then
   if [ "$(wc -c /proc/device-tree/soc/gpio@7e200000/uart0_pins/brcm\,pins | cut -f 1 -d ' ')" = "16" ] ; then
-    /usr/bin/hciattach /dev/serial1 bcm43xx 3000000 flow -
+    $HCIATTACH /dev/serial1 bcm43xx 3000000 flow - $BDADDR
   else
-    /usr/bin/hciattach /dev/serial1 bcm43xx 921600 noflow -
+    $HCIATTACH /dev/serial1 bcm43xx 921600 noflow - $BDADDR
   fi
 else
-  /usr/bin/hciattach /dev/serial1 bcm43xx 460800 noflow -
+  $HCIATTACH /dev/serial1 bcm43xx 460800 noflow - $BDADDR
 fi

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -67,4 +67,7 @@ makeinstall_target() {
       done
     done < ${fwlist}
   done
+
+  # The following file is installed by brcmfmac_sdio-firmware-rpi
+  rm -fr $FW_TARGET_DIR/brcm/brcmfmac43430-sdio.bin
 }

--- a/packages/linux-firmware/wlan-firmware/package.mk
+++ b/packages/linux-firmware/wlan-firmware/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wlan-firmware"
-PKG_VERSION="25d0c93"
+PKG_VERSION="34a47d9"
 PKG_ARCH="any"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/wlan-firmware"


### PR DESCRIPTION
Backport of #1922 

Dependent on https://github.com/LibreELEC/wlan-firmware/pull/4