### PR TITLE
linux: update to linux-4.12.10

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -65,7 +65,7 @@ case "$LINUX" in
   *)
     PKG_VERSION="4.12.9"
     PKG_SHA256="690439175c9dfbb90159bdc4b24cf10011675392264764f2031eb19ce0a1649c"
-    PKG_URL="http://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
+    PKG_URL="https://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;
 esac

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -63,8 +63,8 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.12.9"
-    PKG_SHA256="690439175c9dfbb90159bdc4b24cf10011675392264764f2031eb19ce0a1649c"
+    PKG_VERSION="4.12.10"
+    PKG_SHA256="c0fbf7b7fdd518a6e731fc7a6f0d9ade0840f553007dd414a223eb4a83a7a684"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,4 +1,4 @@
-From 60daaca019d6547bafdbe68f49a1c319a8314d96 Mon Sep 17 00:00:00 2001
+From e7020b24780500375c972138247088055aa58c4b Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
 Subject: [PATCH 001/182] smsx95xx: fix crimes against truesize
@@ -48,7 +48,7 @@ index 2dfca96a63b60283b89efab676932a711024a499..88843b36182f0f12175df06e3a6fb55a
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From 3237e5699975a690d46125d271c52b9a5e207ed0 Mon Sep 17 00:00:00 2001
+From fd8078bf456f4a629db67188df72fbee0416d6cb Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
 Subject: [PATCH 002/182] smsc95xx: Experimental: Enable turbo_mode and
@@ -94,7 +94,7 @@ index 88843b36182f0f12175df06e3a6fb55a3a8f47e5..27813c57707c4b001646a26d8b1174a0
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From ce631b3a4f49408c3336da30d8204ac50b9fd963 Mon Sep 17 00:00:00 2001
+From 754b366ed8cdaecaed19c1a094a41e920a2b96c0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
 Subject: [PATCH 003/182] Allow mac address to be set in smsc95xx
@@ -193,7 +193,7 @@ index 27813c57707c4b001646a26d8b1174a0162c55ec..fac7a5f8642030a7dca7807e6c4808ea
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From ce95c515a0f9398d4813be6ecba562fd4bb43356 Mon Sep 17 00:00:00 2001
+From aa1545cb558dcc4b3c137cc656ee357a2b1767dc Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
 Subject: [PATCH 004/182] Protect __release_resource against resources without
@@ -224,7 +224,7 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From a1523be81be0e7add48b0da9e649fc99c29057f2 Mon Sep 17 00:00:00 2001
+From a618e7e996d6c5087d1517da68f932a5dc658fc7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
 Subject: [PATCH 005/182] irq-bcm2836: Prevent spurious interrupts, and trap
@@ -254,7 +254,7 @@ index e7463e3c08143acae3e8cc5682f918c6a0b07ebd..a8db33b50ad9ff83d284fa54fe4d3b65
  #endif
  	} else if (stat) {
 
-From 6473a846ce9cf03db58f95667b3fa8d8758639c7 Mon Sep 17 00:00:00 2001
+From 022796eab9a09bf12dd5404c3eabaf37b36cd1b5 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:33:30 +0000
 Subject: [PATCH 006/182] irq-bcm2836: Avoid "Invalid trigger warning"
@@ -281,7 +281,7 @@ index a8db33b50ad9ff83d284fa54fe4d3b65f859df0f..c4e151451cf8c8ebde5225515eac2786
  
  static void
 
-From f21622cbca97a106394a65a4edb7e154db34649d Mon Sep 17 00:00:00 2001
+From 12c2f7e3338c01594e7dcdb05db8ae733111cc80 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
 Subject: [PATCH 007/182] irqchip: bcm2835: Add FIQ support
@@ -413,7 +413,7 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 1c1a74f6279ce17eab4197e0783e3b469223415e Mon Sep 17 00:00:00 2001
+From a745cf6f6ce8cc37a228150d8983a631c33f3e70 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
 Subject: [PATCH 008/182] irqchip: irq-bcm2835: Add 2836 FIQ support
@@ -515,7 +515,7 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From f29338e45f540430f4d1e03c7dc72fe913438faf Mon Sep 17 00:00:00 2001
+From f03f6711ed354be82a29bde663e136f91cae06d7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
 Subject: [PATCH 009/182] spidev: Add "spidev" compatible string to silence
@@ -539,7 +539,7 @@ index 9a2a79a871ba009fcfa8b7e2b52002c8845d94ce..4ffd24e8c50fd0df03cbb1257448c202
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From e8a1d78ca0157824f219ac45319193bf8108c5ce Mon Sep 17 00:00:00 2001
+From 4c0319e5819cd8b9eb1e48de563a6fd59c066e0a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 3 Jan 2017 18:25:01 +0000
 Subject: [PATCH 010/182] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
@@ -836,7 +836,7 @@ index 85d0091128644c446aed878e87769e82c77c3ebf..4f2621272bfd5cbc0d691d2fabe89e2e
  	if (IS_ERR(pc->pctl_dev)) {
  		gpiochip_remove(&pc->gpio_chip);
 
-From caa52dc534697693e173a40b5e6694bc46f9e97b Mon Sep 17 00:00:00 2001
+From a4dab864d1e7a785b18d5d4d506eaf7d06425c7a Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
 Subject: [PATCH 011/182] pinctrl-bcm2835: Set base to 0 give expected gpio
@@ -861,7 +861,7 @@ index 4f2621272bfd5cbc0d691d2fabe89e2ee428d6db..5b7cb4c415e19f98e25b221ab0ad36b6
  	.can_sleep = false,
  };
 
-From 42fe50269f828e4144efbb8ecfd5329a78b34c44 Mon Sep 17 00:00:00 2001
+From 6df4cff6a8e94703ca627adc2f943321e3ea0969 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
 Subject: [PATCH 012/182] pinctrl-bcm2835: Only request the interrupts listed
@@ -891,7 +891,7 @@ index 5b7cb4c415e19f98e25b221ab0ad36b6885dae4c..6351fe7f8e314ac5ebb102dd20847b38
  		pc->irq_data[i].irqgroup = i;
  
 
-From 9bd1202aa5df6ce977a481026d36dd0f31cf300e Mon Sep 17 00:00:00 2001
+From fe43d165977361c7b2d98fe93aa41fcc33c99c1c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
 Subject: [PATCH 013/182] spi-bcm2835: Support pin groups other than 7-11
@@ -975,7 +975,7 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From c6d57fbf7fd351af43e211dc18bd04bfe0be7d43 Mon Sep 17 00:00:00 2001
+From 7214b43fc991e7ef4b3b56d12ab7ab003f31cd0d Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
 Subject: [PATCH 014/182] spi-bcm2835: Disable forced software CS
@@ -1012,7 +1012,7 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From 9dbb4db2f31a97a7587182324b0ff673ecfab7a2 Mon Sep 17 00:00:00 2001
+From f78bff7020532940b368564ea48a0a114cfac1ee Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
 Subject: [PATCH 015/182] spi-bcm2835: Remove unused code
@@ -1103,7 +1103,7 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From 9771768da1aec6eb4f13ce608bc79c299670807a Mon Sep 17 00:00:00 2001
+From a6cfafab03908b3b35138577d87a963f2b212591 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
 Subject: [PATCH 016/182] ARM: bcm2835: Set Serial number and Revision
@@ -1159,7 +1159,7 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From c6896ccea012aeb279a7ae00f55a334000313d2d Mon Sep 17 00:00:00 2001
+From 71725bea016ffa191726b4fbbdc4258bcaf24f81 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
 Subject: [PATCH 017/182] dmaengine: bcm2835: Load driver early and support
@@ -1265,7 +1265,7 @@ index 6204cc32d09c5096df8aec304c3c37b3bcb6be44..599c218dc8a73172dd4bd4a058fc8f95
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From efe0bd25e23b81a5b1809e8063db8e1e2225e744 Mon Sep 17 00:00:00 2001
+From 03794c14df1aa67fe5e9b51811a82370a1f65f1b Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
 Subject: [PATCH 018/182] firmware: Updated mailbox header
@@ -1329,7 +1329,7 @@ index cb979ad90401e299344dd5fae38d09c489d8bd58..30fb37fe175df604a738258a2a632bca
  	RPI_FIRMWARE_VCHIQ_INIT =                             0x00048010,
  
 
-From f2d2aea44f42e73d0dbfbe2ef98b10d0e1945810 Mon Sep 17 00:00:00 2001
+From 9b55d46fa8ac0eafb124377953eaef5adf4bb99b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
 Subject: [PATCH 019/182] rtc: Add SPI alias for pcf2123 driver
@@ -1352,7 +1352,7 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From 56ce42071b8b6eea28ffab346bbbd1cbbcb68a3d Mon Sep 17 00:00:00 2001
+From d8456ed75a8b4d4470be6d8998070b97d332d113 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
 Subject: [PATCH 020/182] watchdog: bcm2835: Support setting reboot partition
@@ -1457,7 +1457,7 @@ index b339e0e67b4c1275fd4992fea4f1e24c0575b783..26b7177573fac2af1cd4ab5488d2686f
  
  static int bcm2835_wdt_probe(struct platform_device *pdev)
 
-From 58df7e252efa8fe809a29ad643f92f312ed034f1 Mon Sep 17 00:00:00 2001
+From 305ac65c07738f149a25ad9aee34561b25dfa3cf Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
 Subject: [PATCH 021/182] reboot: Use power off rather than busy spinning when
@@ -1483,7 +1483,7 @@ index 3b2aa9a9fe268d45335f781c4aa22cf573753a1b..0180d89a34af45c56243fe0f17fbe209
  
  /*
 
-From fd89a560ebb8037580c125724ed5364b09efb1b3 Mon Sep 17 00:00:00 2001
+From 6cfa7a1f23f6a73a955164fe54e120afe3dbb7fb Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
 Subject: [PATCH 022/182] bcm: Make RASPBERRYPI_POWER depend on PM
@@ -1505,7 +1505,7 @@ index a39b0d58ddd0fdf0ac1cc7295f8aafb12546e226..e037a6dd79d1881a09e3ca9115782709
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 90476f6f4fb2c0ac47774adb9c8db0c2a15ef624 Mon Sep 17 00:00:00 2001
+From b8f81dd611ee33a79c700970d69a86ecaefc3ab7 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
 Subject: [PATCH 023/182] Register the clocks early during the boot process, so
@@ -1553,7 +1553,7 @@ index 02585387061967ac9408e18ac1bce67e9e9414c0..283d2de45e4f29406d01f24ab1cae3f9
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From 67a1dac6aea666cbf65040e1746ba2c465d712e8 Mon Sep 17 00:00:00 2001
+From e519df686e7afa70cfa2eceb3e331ca433fbc813 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
 Subject: [PATCH 024/182] bcm2835-rng: Avoid initialising if already enabled
@@ -1582,7 +1582,7 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From 4be74e2db5889c9364c35b8b7e6e92b3596c1c8f Mon Sep 17 00:00:00 2001
+From 8fdb6f08f8b87828454f6acdc62afd6c29a9bcf3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
 Subject: [PATCH 025/182] kbuild: Ignore dtco targets when filtering symbols
@@ -1605,7 +1605,7 @@ index 61f87a99bf0a1c512e572d3cbdcf4b4b5d7ae785..0a5e36778eacf7dc589486f8bc8033f5
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From 1129d313485edba157233217c74e2d533173cbac Mon Sep 17 00:00:00 2001
+From 452cecc4d170acf3d45787a985e9a2b2f8eeee1a Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
 Subject: [PATCH 026/182] BCM2835_DT: Fix I2S register map
@@ -1646,7 +1646,7 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From b6d64f6dc79e21322526fc48ab5b6cd0d631c750 Mon Sep 17 00:00:00 2001
+From c52b9697ecb9464bc5a716ba2e7b914657fc2eef Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
 Subject: [PATCH 027/182] clk-bcm2835: Mark used PLLs and dividers CRITICAL
@@ -1677,7 +1677,7 @@ index 283d2de45e4f29406d01f24ab1cae3f9f879234a..85df8c74a309f0b877ef65f1c55b086f
  	divider->data = data;
  
 
-From fbb141c4319fbdf5d49246a0d3b0d6f5105daa98 Mon Sep 17 00:00:00 2001
+From 3e94335d1cece712bd0045710021070470154969 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
 Subject: [PATCH 028/182] clk-bcm2835: Add claim-clocks property
@@ -1782,7 +1782,7 @@ index 85df8c74a309f0b877ef65f1c55b086f1bb774a1..eec6735505c074c0a76ae647bf0e1bb6
  	       sizeof(cprman_parent_names));
  	of_clk_parent_fill(dev->of_node, cprman->real_parent_names,
 
-From 8a9b8630302a1cdba890c8e4d7e0f0b885672855 Mon Sep 17 00:00:00 2001
+From 5e272818d0d6e991539c9ee109e56b54025ee280 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:06:53 +0000
 Subject: [PATCH 029/182] clk-bcm2835: Correct the prediv logic
@@ -1812,7 +1812,7 @@ index eec6735505c074c0a76ae647bf0e1bb68ab3a488..e0d28add45efdf70d1eba590282a3a26
  	return bcm2835_pll_rate_from_divisors(parent_rate, ndiv, fdiv, pdiv);
  }
 
-From 18ef046c047bdefb5f7721ccb6920f08e5379c56 Mon Sep 17 00:00:00 2001
+From f5a16a8fb01d7c2cd638a055d9afe3ae3dddb794 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 6 Mar 2017 09:06:18 +0000
 Subject: [PATCH 030/182] clk-bcm2835: Read max core clock from firmware
@@ -1930,7 +1930,7 @@ index e0d28add45efdf70d1eba590282a3a2654af328d..39f72da6ba1f6ec6ec41d5dc1bf46344
  	for (i = 0;
  	     !of_property_read_u32_index(pdev->dev.of_node, "claim-clocks",
 
-From fb7e40f68c04dab2355d91bb12babc6f3eac3f93 Mon Sep 17 00:00:00 2001
+From c930b7730ea7578e2018fcc0f5c07bb817750359 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:36:44 +0000
 Subject: [PATCH 031/182] sound: Demote deferral errors to INFO level
@@ -1968,7 +1968,7 @@ index d05acc8eed1fdc1f24cba7282bc61bcb3471c084..5578e501505fe86eb67d5b066854a13d
  			goto _err_defer;
  		}
 
-From 754bd320941bc0bca32cf4bce8b5fbc00f47da34 Mon Sep 17 00:00:00 2001
+From 10a2b9fb6cf4df6e5535ac1ac549246c246d83d8 Mon Sep 17 00:00:00 2001
 From: Claggy3 <stephen.maclagan@hotmail.com>
 Date: Sat, 11 Feb 2017 14:00:30 +0000
 Subject: [PATCH 032/182] Update vfpmodule.c
@@ -2108,7 +2108,7 @@ index a71a48e71fffa8626fe90106815376c44bbe679b..d6c0a5a0a5ae3510db3ace5e3f5d3410
  	/*
  	 * Save the userland NEON/VFP state. Under UP,
 
-From 755f450130cafde8c208d6a362da31506795964a Mon Sep 17 00:00:00 2001
+From 26aaa96bf4172683bd89cd917b1149353ea46e8c Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 21:13:24 +1100
 Subject: [PATCH 033/182] ASoC: bcm2835_i2s.c: relax the ch2 register setting
@@ -2132,7 +2132,7 @@ index 6ba20498202ed36906b52096893a88867a79269f..56df7d8a43d0aac055a91b0d24aca8e1
  		format |= BCM2835_I2S_CH1(BCM2835_I2S_CHPOS(ch1pos));
  		format |= BCM2835_I2S_CH2(BCM2835_I2S_CHPOS(ch2pos));
 
-From c875764497acb1842d8cef504175f25fda9aa25f Mon Sep 17 00:00:00 2001
+From 775c3769de0434b75e7d7a64a7f59f338bc66cd6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
 Subject: [PATCH 034/182] i2c: bcm2835: Add debug support
@@ -2324,7 +2324,7 @@ index cd07a69e2e9355540442785f95e90823b05c9d10..47167f403cc8329bd811b47c7011c299
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From fd52262df6666258b142075e44266514d81cb59e Mon Sep 17 00:00:00 2001
+From 01365a6ff2c33a7dda749737a1c9409b7c9e9733 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
 Subject: [PATCH 035/182] Main bcm2708/bcm2709 linux port
@@ -2515,7 +2515,7 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From 97533fa9e8c282238b8d81b61a48907f1ba08906 Mon Sep 17 00:00:00 2001
+From ffaf5284269a2ea08eb0c619f07dda20d045e115 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
 Subject: [PATCH 036/182] Add dwc_otg driver
@@ -63660,7 +63660,7 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From d6a62cbf93112d518af434a3627b4b5616ff57cf Mon Sep 17 00:00:00 2001
+From 0b5bc5756490961ea211a13f28368b1223099db0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
 Subject: [PATCH 037/182] bcm2708 framebuffer driver
@@ -67122,7 +67122,7 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From b96cc5f64752cc5d69a3990c4f69481960c4241b Mon Sep 17 00:00:00 2001
+From 2ecd6ae9c68dc7a6b1bbf3b5221ac3f61062da9c Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
 Subject: [PATCH 038/182] dmaengine: Add support for BCM2708
@@ -67756,7 +67756,7 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From 4e1bd4f24a1e1c29aec90f92cd08bf85f59bf8d0 Mon Sep 17 00:00:00 2001
+From 35449131350b7b78178f9bd9d9c8abb38f7a026d Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
 Subject: [PATCH 039/182] MMC: added alternative MMC driver
@@ -69481,7 +69481,7 @@ index 0000000000000000000000000000000000000000..4fe8d1fe44578fbefcd48f8c327ba3d0
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Gellert Weisz");
 
-From b57c2dbd22926dbe1f74b04802371ff92642bbcf Mon Sep 17 00:00:00 2001
+From f892acb1edb4b852a97a1d84c76c28b9f94ac22f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
 Subject: [PATCH 040/182] Adding bcm2835-sdhost driver, and an overlay to
@@ -71890,7 +71890,7 @@ index 0000000000000000000000000000000000000000..9c6f199a7830959f31012d86bc1f8b1a
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 5a66d1744bf765f29dedd9eba347c4926b7735cb Mon Sep 17 00:00:00 2001
+From c28fc345b2a39c0015d5820651912933a0ba0153 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
 Subject: [PATCH 041/182] vc_mem: Add vc_mem driver for querying firmware
@@ -72418,7 +72418,7 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From 297d9b74cc3f8f0538020d3ff67eca24dfee9896 Mon Sep 17 00:00:00 2001
+From 816157aab70bf7b49e04427a89fdb40ee3f81397 Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
 Subject: [PATCH 042/182] vcsm: VideoCore shared memory service for BCM2835
@@ -76876,7 +76876,7 @@ index 0000000000000000000000000000000000000000..334f36d0d697b047df2922b5f2db67f3
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From b4ee8e20894b8b490d76fb69f8e64b9a25c6d7b9 Mon Sep 17 00:00:00 2001
+From 437ac4dc30bed54a99410ea2d72d233126a78202 Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
 Subject: [PATCH 043/182] Add /dev/gpiomem device for rootless user GPIO access
@@ -77187,7 +77187,7 @@ index 0000000000000000000000000000000000000000..f5e7f1ba8fb6f18dee77fad06a17480c
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From 7c446ed20400f211fcc9c49a5fc77f0806831e7f Mon Sep 17 00:00:00 2001
+From 8ade5a64014e0b294abeece8e93fb19a20f3a2aa Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
 Subject: [PATCH 044/182] Add SMI driver
@@ -79141,7 +79141,7 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From cd842447e08106d8b2a0dd379327c1f5818e2d2b Mon Sep 17 00:00:00 2001
+From b776bf76a543c0c3506ffb0ab1df17a779120901 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
 Subject: [PATCH 045/182] MISC: bcm2835: smi: use clock manager and fix reload
@@ -79314,7 +79314,7 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From cf57c3333df4f917f776943c4dacdd3136a6b886 Mon Sep 17 00:00:00 2001
+From f225c0ebb2640c49305e7c9b1d225baec630a384 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
 Subject: [PATCH 046/182] Add SMI NAND driver
@@ -79682,7 +79682,7 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From fa78e6578d18ae59225d91eb42cde42d9e25fa3a Mon Sep 17 00:00:00 2001
+From ad848b93a52cc89078238a40e8c3f0e37d769c45 Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
 Subject: [PATCH 047/182] lirc: added support for RaspberryPi GPIO
@@ -80546,7 +80546,7 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From e363bdbf98fc1e32e682f2f3064c93215a479a4e Mon Sep 17 00:00:00 2001
+From 966d0c0904402e79cec621ee30effee9eb0fe457 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
 Subject: [PATCH 048/182] Add cpufreq driver
@@ -80816,7 +80816,7 @@ index 0000000000000000000000000000000000000000..414fbdc10dfbfc6e4bb47870a7af3fd5
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 5d174c02e73c78c92c5afe6f24aa9ff5d0f30637 Mon Sep 17 00:00:00 2001
+From 0e8335d9592b8bbbbc0236c8264c85312c2cd9eb Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 19:24:24 +0000
 Subject: [PATCH 049/182] Added hwmon/thermal driver for reporting core
@@ -81002,7 +81002,7 @@ index 0000000000000000000000000000000000000000..25b78c3eac1503fbc9e679b963a6284b
 +MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
 +MODULE_LICENSE("GPL");
 
-From 6b63a95a01a16a3deec6f4e2da8a38500744554d Mon Sep 17 00:00:00 2001
+From 3b7605120ffa5253651d023ed0a38da30f8f0ecc Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
 Subject: [PATCH 050/182] Add Chris Boot's i2c driver
@@ -81670,7 +81670,7 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From 22a8f9698de48bd3d6b10ac7f43528a3c34c27fa Mon Sep 17 00:00:00 2001
+From b96feb9d31d2ed7cdfde2357f8f81687489bf26d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
 Subject: [PATCH 051/182] char: broadcom: Add vcio module
@@ -81898,7 +81898,7 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From 0c0a74575058729f2a80c6e732336ac6604fbec2 Mon Sep 17 00:00:00 2001
+From 23dad2d91a71cf3ed98628a4d86ff875c29c2997 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
 Subject: [PATCH 052/182] firmware: bcm2835: Support ARCH_BCM270x
@@ -81984,7 +81984,7 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From 387e01eb746c0f60211a67b97bc3aacac7f4d14e Mon Sep 17 00:00:00 2001
+From 893cd86a5853a6caa53c2e266eda5de408db02eb Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
 Subject: [PATCH 053/182] scripts: Add mkknlimg and knlinfo scripts from tools
@@ -82514,7 +82514,7 @@ index 0000000000000000000000000000000000000000..84be2593ec1de8f97b0167ff06b3e05d
 +	return $trailer;
 +}
 
-From 7aadb94bfc66371f9b6fe935b02abc847bb05f31 Mon Sep 17 00:00:00 2001
+From 101ed8228d13dd8fec880bcc585bb3f4fcccc2a1 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
 Subject: [PATCH 054/182] BCM2708: Add core Device Tree support
@@ -93962,7 +93962,7 @@ index 58c05e5d9870b6c18a72da7dc44ff3112994946d..9842523b225a88505d796cc689c04f40
  
  # Bzip2
 
-From 22d87129074f86493e9404d175f1d765ee276f95 Mon Sep 17 00:00:00 2001
+From adf83bfba5336794728189a1faebffe6f162965d Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
 Subject: [PATCH 055/182] BCM270x_DT: Add pwr_led, and the required "input"
@@ -94140,7 +94140,7 @@ index 64c56d454f7df9f864a5242ce4212df586f66886..3fd74c8737871cb56f0355c858fc135e
  	/* set_brightness_work / blink_timer flags, atomic, private. */
  	unsigned long		work_flags;
 
-From e11f33c3c840fb2c6b5adb442946f65b4192b20c Mon Sep 17 00:00:00 2001
+From b540a0f18904aab16da58ff0908e37eb3c1146e9 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
 Subject: [PATCH 056/182] fbdev: add FBIOCOPYAREA ioctl
@@ -94411,7 +94411,7 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From bfce562a8722518d593165063cf3ccf0b1927c7f Mon Sep 17 00:00:00 2001
+From 1580dd9978c755205391458c3cba226683ea6aae Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
 Subject: [PATCH 057/182] Speed up console framebuffer imageblit function
@@ -94623,7 +94623,7 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From 7ce792d07a5b5ec6e453554a00318d3bfc237cec Mon Sep 17 00:00:00 2001
+From 8ea6d6b2b606a340f466fd1afeb7580466ed1fbe Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
 Subject: [PATCH 058/182] enabling the realtime clock 1-wire chip DS1307 and
@@ -94876,7 +94876,7 @@ index d58594a3232492e33f1dd4babd3798b03e0f0203..feae94256256316fd9d850c3d83325af
  	unsigned int ext_pullup_enable_pin;
  	unsigned int pullup_duration;
 
-From f4ad26b49544ccf783d471a4eb36919c88793d4f Mon Sep 17 00:00:00 2001
+From aa1a15742a7e32f50892517826a138ea4aea72f7 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
 Subject: [PATCH 059/182] hid: Reduce default mouse polling interval to 60Hz
@@ -94911,7 +94911,7 @@ index 83772fa7d92a6f6178cd3a4a5c0fea28350040b5..3f4a7e34b3f775e712b1b4d6afe27a2a
  			break;
  		case HID_GD_JOYSTICK:
 
-From 868c83d92acecb9284aad4e39b3e25b61b4598cd Mon Sep 17 00:00:00 2001
+From 425e8ca78b6337f05e4e83d036c60c526d07f503 Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
 Subject: [PATCH 060/182] rpi-ft5406: Add touchscreen driver for pi LCD display
@@ -95272,7 +95272,7 @@ index 30fb37fe175df604a738258a2a632bca3bfff33f..4a3d79d3b48eb483a4e4bf498f617515
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From bcaad92b7fc9663e80e01615a6b78ec8c6638494 Mon Sep 17 00:00:00 2001
+From cd6b610057e338b64f5dcbd36ed82aa05b9d0757 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
 Subject: [PATCH 061/182] Improve __copy_to_user and __copy_from_user
@@ -96850,7 +96850,7 @@ index 567601148318bf4a5fbc581d6c9881d9e190c409..45ea7866761a71470bd335f6f37ea603
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From c600e0663a01c7170c8c95676778d4052e7ee4cf Mon Sep 17 00:00:00 2001
+From 6309f490258b30746b0af7735dfffeaf9cb4084a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
 Subject: [PATCH 062/182] gpio-poweroff: Allow it to work on Raspberry Pi
@@ -96888,7 +96888,7 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From 8aae4381045b2972d58a69262e483a51f91df2f3 Mon Sep 17 00:00:00 2001
+From 541969a397eeef6bc5134a6653c36b4fa080a072 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
 Subject: [PATCH 063/182] mfd: Add Raspberry Pi Sense HAT core driver
@@ -97756,7 +97756,7 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From ff1c16f22f44f7354064eca759890cab84dd42c3 Mon Sep 17 00:00:00 2001
+From 4218c1b43513e72e405c05bb7c71b4e9d7c7397b Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
 Subject: [PATCH 064/182] ASoC: Add support for HifiBerry DAC
@@ -97934,7 +97934,7 @@ index 0000000000000000000000000000000000000000..ee9f133953544629282631e5ef3f73fe
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From acea370d43f5950a2b31598f778958d73548d6df Mon Sep 17 00:00:00 2001
+From 4f1de9c899e4c394d7da4342a970d6abe2bd16e0 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
 Subject: [PATCH 065/182] ASoC: Add support for Rpi-DAC
@@ -98221,7 +98221,7 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From c3afa38b80c5140c3dd5c1927cdf30112852f5e7 Mon Sep 17 00:00:00 2001
+From c6abce8490f1281d971758305264e407d8edb89f Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
 Subject: [PATCH 066/182] ASoC: wm8804: Implement MCLK configuration options,
@@ -98273,7 +98273,7 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From e52084686b1472912c68db3734255c1028c19f27 Mon Sep 17 00:00:00 2001
+From 159800a71e96dd578c507475e3cf23bf6d211cf0 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
 Subject: [PATCH 067/182] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
@@ -98620,7 +98620,7 @@ index 0000000000000000000000000000000000000000..7620dd02de40b6d644ff038b445d375d
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 69bd69b6303fb7f77d44fb5b3ea89a57d405676e Mon Sep 17 00:00:00 2001
+From 816de5611317d603d75b8814322be9940043e6a8 Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
 Subject: [PATCH 068/182] Add IQaudIO Sound Card support for Raspberry Pi
@@ -98958,7 +98958,7 @@ index 0000000000000000000000000000000000000000..1ee4097c846376666775272ed692ca33
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From 07738977cd5a7b4df6a0ec3a8c318ddbcd447e43 Mon Sep 17 00:00:00 2001
+From 16e2898cac88f6447cc0b1062b9905f84daa03e9 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
 Subject: [PATCH 069/182] Added support for HiFiBerry DAC+
@@ -99591,7 +99591,7 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From d4bd382cf8edb374632f98171c352bd584b5a2b5 Mon Sep 17 00:00:00 2001
+From 6d9c2850cd7cc7c969a90c95c057f78b113b41ea Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
 Subject: [PATCH 070/182] Added driver for HiFiBerry Amp amplifier add-on board
@@ -100429,7 +100429,7 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From b76db0c8d46c80dfc64f3843f8811bb51a5494ac Mon Sep 17 00:00:00 2001
+From 44b5788f078cb269b426ae793d25feac84860050 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
 Subject: [PATCH 071/182] Add driver for rpi-proto
@@ -100647,7 +100647,7 @@ index 0000000000000000000000000000000000000000..fadbfade100228aaafabb0d3bdf35c01
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 4d78beede63cf3a595c363bf3511fe09a0f84854 Mon Sep 17 00:00:00 2001
+From 5ae7684d43a43812cc32ea4aabb725c3fad8003b Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
 Subject: [PATCH 072/182] RaspiDAC3 support
@@ -100893,7 +100893,7 @@ index 0000000000000000000000000000000000000000..ad2b5b89bc8213dc2e277306ef50d6e3
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From 83e7c8781a42d93e8918649dbb1024607774b8d8 Mon Sep 17 00:00:00 2001
+From be939d448017fd78a8a265b6f9cd55ad5a623338 Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
 Subject: [PATCH 073/182] Add Support for JustBoom Audio boards
@@ -101352,7 +101352,7 @@ index 0000000000000000000000000000000000000000..909cf8928f2f4313982316f9c5b8a709
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From 56ddb6217397745ec099e07042ca9254796670d2 Mon Sep 17 00:00:00 2001
+From c960a4cb6eb039e15253e415bb261200e6500409 Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
 Subject: [PATCH 074/182] ARM: adau1977-adc: Add basic machine driver for
@@ -101537,7 +101537,7 @@ index 0000000000000000000000000000000000000000..f3d7e5db7bb912e1d7ca6f8e8d42df5f
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From 71874c2547e6f7859783349a5f08853311b54b2d Mon Sep 17 00:00:00 2001
+From a90648803cb0b5e3a1c01e948ccc8477e34dd24d Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
 Subject: [PATCH 075/182] New AudioInjector.net Pi soundcard with low jitter
@@ -101791,7 +101791,7 @@ index 0000000000000000000000000000000000000000..ef54e0f07ea03f59e9957b5d98f3e7fd
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From 40b5d53f4661103aef022623605d3ce077bbe7c9 Mon Sep 17 00:00:00 2001
+From c7c5dedbcc5519a04b912597b0e3075147797643 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
 Subject: [PATCH 076/182] Add IQAudIO Digi WM8804 board support
@@ -102094,7 +102094,7 @@ index 0000000000000000000000000000000000000000..33aa2be8a43a12a12cfb5d844dd9732c
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From f3e555f8b4a51cd51eba8ed34793133664c0005e Mon Sep 17 00:00:00 2001
+From 9337de555017fc37c14f621a139e74d772849f88 Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
 Subject: [PATCH 077/182] New driver for RRA DigiDAC1 soundcard using WM8741 +
@@ -102570,7 +102570,7 @@ index 0000000000000000000000000000000000000000..f200688bb4ae32b90a0ced555aed94b0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From d6b59500bd121c6998dbbd8ea75a7e6d41f6a52d Mon Sep 17 00:00:00 2001
+From 1f557e3d561ca953a783836ec08af4fb6d825f3e Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
 Subject: [PATCH 078/182] Add support for Dion Audio LOCO DAC-AMP HAT
@@ -102746,7 +102746,7 @@ index 0000000000000000000000000000000000000000..65e03741d349a2dc5bd91f69855ea952
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From 0b952028480d2f5283eced08b000b3b59590eb70 Mon Sep 17 00:00:00 2001
+From a1f614820d8980eb90f9f2c86a099c311d7331b2 Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
 Subject: [PATCH 079/182] Allo Piano DAC boards: Initial 2 channel (stereo)
@@ -102956,7 +102956,7 @@ index 0000000000000000000000000000000000000000..eaf50fb6dbca1970ae1c6f8662088b0f
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From b017d95ae3a93a0bf75d9ccc1f7a25f521963644 Mon Sep 17 00:00:00 2001
+From cd4e9755c76be301b6cff05a1d060670f26f5338 Mon Sep 17 00:00:00 2001
 From: Raashid Muhammed <raashidmuhammed@zilogic.com>
 Date: Mon, 27 Mar 2017 12:35:00 +0530
 Subject: [PATCH 080/182] Add support for Allo Piano DAC 2.1 plus add-on board
@@ -103704,7 +103704,7 @@ index 0000000000000000000000000000000000000000..56e43f98846b41e487b3089813f7edc3
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC Plus");
 +MODULE_LICENSE("GPL v2");
 
-From bc4db3b4daeac0df191372546a5bafe9b3e0d6e5 Mon Sep 17 00:00:00 2001
+From dd4fb655193b79eedd7693d2db6b05f185dee152 Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Tue, 28 Mar 2017 20:04:42 +0530
 Subject: [PATCH 081/182]  Add support for Allo Boss DAC add-on board for
@@ -104410,7 +104410,7 @@ index 0000000000000000000000000000000000000000..203ab76c7045b081578e23bda1099dd1
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Boss DAC");
 +MODULE_LICENSE("GPL v2");
 
-From fe7eb9fe1195c71d91976750ab68567a8fe8f6fc Mon Sep 17 00:00:00 2001
+From 9a0afd959fc4efc1b557101ebd850bfe1bebe580 Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
 Subject: [PATCH 082/182] Support for Blokas Labs pisound board
@@ -105612,7 +105612,7 @@ index 0000000000000000000000000000000000000000..06ff1e53dc9d860946965b6303577762
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From db6bcfa2ed277739f96a5ed8af060c9c5f297479 Mon Sep 17 00:00:00 2001
+From 8f0d84774601fefdbf7be3288e9708d9c6b3729d Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 22 Jan 2017 12:49:37 +0100
 Subject: [PATCH 083/182] ASoC: Add driver for Cirrus Logic Audio Card
@@ -106680,7 +106680,7 @@ index 0000000000000000000000000000000000000000..ac8651ddff7bd3701dffe22c7fb88352
 +MODULE_DESCRIPTION("ASoC driver for Cirrus Logic Audio Card");
 +MODULE_LICENSE("GPL");
 
-From 286edbffaa15216436ff2964c9743b40b823182b Mon Sep 17 00:00:00 2001
+From 9909ce1d26ddbc5b4b6fda51b0181d47a026d6ca Mon Sep 17 00:00:00 2001
 From: Miquel <miquelblauw@hotmail.com>
 Date: Fri, 24 Feb 2017 20:51:06 +0100
 Subject: [PATCH 084/182] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
@@ -106878,7 +106878,7 @@ index 0000000000000000000000000000000000000000..a009c49477972a9832175d86f201b035
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO-V2");
 +MODULE_LICENSE("GPL v2");
 
-From c1941cee0ea765961836c7aba9d9faefb9b3e159 Mon Sep 17 00:00:00 2001
+From a0b8d996de0829fa945c47c5955f208d84f96ba9 Mon Sep 17 00:00:00 2001
 From: Fe-Pi <fe-pi@cox.net>
 Date: Wed, 1 Mar 2017 04:42:43 -0700
 Subject: [PATCH 085/182] Add support for Fe-Pi audio sound card. (#1867)
@@ -107095,7 +107095,7 @@ index 0000000000000000000000000000000000000000..015b56fd73cc36be5b5eecd17548fd03
 +MODULE_DESCRIPTION("ASoC Driver for Fe-Pi Audio");
 +MODULE_LICENSE("GPL v2");
 
-From d612360d3b21e316d319b34a57569c0155772e56 Mon Sep 17 00:00:00 2001
+From 35eba045e1c2009b5f0f25f4ceef53f26bc6c966 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 20:04:13 +1100
 Subject: [PATCH 086/182] Add support for the AudioInjector.net Octo sound card
@@ -107500,7 +107500,7 @@ index 0000000000000000000000000000000000000000..dcf403ab37639ba79e38278d7e4b1ade
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:audioinjector-octo-soundcard");
 
-From 321e4c569fadfab0f088b239ea1cc085650d4fa7 Mon Sep 17 00:00:00 2001
+From cef0c090fb585e98fefc78e20ec355c3c890b15d Mon Sep 17 00:00:00 2001
 From: Peter Malkin <petermalkin@google.com>
 Date: Mon, 27 Mar 2017 16:38:21 -0700
 Subject: [PATCH 087/182] Driver support for Google voiceHAT soundcard.
@@ -107894,7 +107894,7 @@ index 0000000000000000000000000000000000000000..225854b8e5298b3c3018f59a49404354
 +MODULE_DESCRIPTION("ASoC Driver for Google voiceHAT SoundCard");
 +MODULE_LICENSE("GPL v2");
 
-From fb8164c045f830ac20aad2c7954434b3b62d02fb Mon Sep 17 00:00:00 2001
+From fda0494d55c54860e8945f6c97f0d0d86dcbd1d8 Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
 Subject: [PATCH 088/182] rpi_display: add backlight driver and overlay
@@ -108066,7 +108066,7 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 625404cc0c263328f23d5b87731b7407f987ed9b Mon Sep 17 00:00:00 2001
+From 2a3f570360be1b04b5dfe12b1b29d91655156637 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
 Subject: [PATCH 089/182] bcm2835-virtgpio: Virtual GPIO driver
@@ -108343,7 +108343,7 @@ index 4a3d79d3b48eb483a4e4bf498f617515e3ad158f..5f34e1257117fb48013c9926a8a223d6
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 4d35090fc2138462c434a13119e346b2d35d0149 Mon Sep 17 00:00:00 2001
+From 35a5ab0d580a4c9f3fd6b57709d04532ed21591e Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Mon, 20 Feb 2017 17:01:21 +0000
 Subject: [PATCH 090/182] bcm2835-gpio-exp: Driver for GPIO expander via
@@ -108672,7 +108672,7 @@ index 5f34e1257117fb48013c9926a8a223d64a598ab7..c819c21b0158a59c1308882e5a40e3f3
  	/* Dispmanx TAGS */
  	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,
 
-From 3c1bffa6c85acebdddd2c4ec84a7a27e15a679e1 Mon Sep 17 00:00:00 2001
+From 704ad316489ab8641794a5c73d6d00596f7e4ea1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
 Subject: [PATCH 091/182] amba_pl011: Don't use DT aliases for numbering
@@ -108704,7 +108704,7 @@ index 8a857bb34fbb26c6d60784d3fe7576730a9aa5b3..0afd6f3ee7e8d021d6e324915af4dc7c
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From a7a957756b9ab7bc7aca5ee2c8abdffd04fe6563 Mon Sep 17 00:00:00 2001
+From 1f402a4b7d58cbdfdb457e7b76120a256a8406ec Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:07:39 +0000
 Subject: [PATCH 092/182] amba_pl011: Round input clock up
@@ -108793,7 +108793,7 @@ index 0afd6f3ee7e8d021d6e324915af4dc7c7db56083..be4aa91bac66982b1fd9a13e9f971b3b
  /* unregisters the driver also if no more ports are left */
  static void pl011_unregister_port(struct uart_amba_port *uap)
 
-From 92e16d450d7c8ac02ba9bdddd31cdc2f7ae6887a Mon Sep 17 00:00:00 2001
+From d88f73aa20921b38f619ec71e85b8d564307fd66 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
 Subject: [PATCH 093/182] OF: DT-Overlay configfs interface
@@ -109228,7 +109228,7 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From 3555a084fa522248f481f5f3801b154474aa1796 Mon Sep 17 00:00:00 2001
+From 898a2611afcbdbd1d83323eb129e800b56facf7a Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
 Subject: [PATCH 094/182] brcm: adds support for BCM43341 wifi
@@ -109382,7 +109382,7 @@ index d44f59ef4f72b3324aa3deedf8746e10cf1cccc7..cb5292ede39c5f1e97df2a18d4883848
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_43362_CHIP_ID, 0xFFFFFFFE, 43362),
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_4339_CHIP_ID, 0xFFFFFFFF, 4339),
 
-From b61167b09c8d718ac3a582e9a3adb678cad4a883 Mon Sep 17 00:00:00 2001
+From 85c2e8241b19c3cf050db2d39c3fb8c0a7dfbb26 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Feb 2017 15:26:13 +0000
 Subject: [PATCH 095/182] brcmfmac: Mute expected startup 'errors'
@@ -109409,7 +109409,7 @@ index bc78593a611b6704aa88cc280cdaccd0873fc102..604744f7af9bd465822a93276088c96c
  				  req->alpha2[0], req->alpha2[1]);
  			return;
 
-From 10f43417739024ffba9a5bc4b07dd147fb70ccf4 Mon Sep 17 00:00:00 2001
+From b07cb43e5789dcd3132ae69e787fc21741ae1bd4 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
 Subject: [PATCH 096/182] hci_h5: Don't send conf_req when ACTIVE
@@ -109435,7 +109435,7 @@ index 90d0456b67446bcc624fab4b1542c4eaf21531b1..f9adeac3bbba6418dcca298c55706356
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From b4b3499526ebbd3d24eadd2ec913c467bcdb409e Mon Sep 17 00:00:00 2001
+From b6728373e9a39d3d9ce2f60e3a542fbe30bc0d2a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
 Subject: [PATCH 097/182] config: Add default configs
@@ -112096,7 +112096,7 @@ index 0000000000000000000000000000000000000000..ace19d6f5bc04091130bd28b65ce25e8
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 62ad425a9e74d4f4c0d3d0a2281dab6bfba83c20 Mon Sep 17 00:00:00 2001
+From 8d21124570759a5ddfcfd79e7dafcaa5fee2163e Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
 Subject: [PATCH 098/182] Add arm64 configuration and device tree differences.
@@ -113513,7 +113513,7 @@ index 0000000000000000000000000000000000000000..e6b09fafa27eed2b762e3d53b55041f7
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2835_VCHIQ=n
 
-From c1327de6924c6d98519be6fc3351226acdddcad3 Mon Sep 17 00:00:00 2001
+From e1286004648afdf27a288c63830f47c64f00cdc0 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
 Subject: [PATCH 099/182] ARM64: Make it work again on 4.9 (#1790)
@@ -113919,7 +113919,7 @@ index e6b09fafa27eed2b762e3d53b55041f793683d27..c7e891d72969a388d9b135a36dbfc9c9
  CONFIG_LIBCRC32C=y
 -CONFIG_BCM2835_VCHIQ=n
 
-From fd94a5a7a55d7ac3831068d2d25d0adea8e8b52e Mon Sep 17 00:00:00 2001
+From 82ebb7015a2b8fc363762bb91b7332b36e43e25c Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:10:07 -0800
 Subject: [PATCH 100/182] ARM64: Enable HDMI audio and vc04_services in
@@ -113951,7 +113951,7 @@ index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..4b90f9b64abe9f089ba56b13d5a00de3
  CONFIG_BCM2835_MBOX=y
  # CONFIG_IOMMU_SUPPORT is not set
 
-From f98d8f936cdcbdfdd98482ffb84991cb99565862 Mon Sep 17 00:00:00 2001
+From 731471747b225abe56aa2617b91d915bcdad960d Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:14:03 -0800
 Subject: [PATCH 101/182] ARM64: Run bcmrpi3_defconfig through savedefconfig.
@@ -113999,7 +113999,7 @@ index 4b90f9b64abe9f089ba56b13d5a00de33343bfb9..dac962ca1634662ce7d966f1ffb53b5b
  CONFIG_FB_TFT_AGM1264K_FL=m
  CONFIG_FB_TFT_BD663474=m
 
-From aabceddd02aea50f66772f90b81d779696981a31 Mon Sep 17 00:00:00 2001
+From 6561432023612c50111ea665610ee5ff518c3d13 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 02:54:26 -0800
 Subject: [PATCH 102/182] ARM64: Enable Kernel Address Space Randomization
@@ -114034,7 +114034,7 @@ index dac962ca1634662ce7d966f1ffb53b5bfa27c506..aae33b4b3c3e736ea7cd3ca242158ad6
  CONFIG_BINFMT_MISC=y
  CONFIG_COMPAT=y
 
-From 67f96718eb3ede2f1f16d6729fb30411eaa537bb Mon Sep 17 00:00:00 2001
+From f9bb220b11c15b23c5b0234b0f1cde421ce2b5d1 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sun, 15 Jan 2017 07:31:59 -0800
 Subject: [PATCH 103/182] ARM64: Enable RTL8187/RTL8192CU wifi in build config
@@ -114062,7 +114062,7 @@ index aae33b4b3c3e736ea7cd3ca242158ad6ba558aff..b7d762df19b85e369a32cd823dfd0621
  CONFIG_ZD1211RW=m
  CONFIG_MAC80211_HWSIM=m
 
-From 5ef2e3fd092c7a9464cc5873060a92507904fe7d Mon Sep 17 00:00:00 2001
+From 7298ccfc5a58dde0d059da7d6ca6bdbe10dfbdbe Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:33:51 -0800
 Subject: [PATCH 104/182] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
@@ -114408,7 +114408,7 @@ index 6b2c7d0c93f36a63863ff4b0ecc1f3eab77e058b..d7b700ff17821ad1944e36721fe6b2db
  /** The OS page size */
  #define DWC_OS_PAGE_SIZE	PAGE_SIZE
 
-From 0b06afa392932e72cab69b92f019e12224106aca Mon Sep 17 00:00:00 2001
+From dad6a3f181c1dd9fc408dfc93d78885fd58d2d95 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:43:57 -0800
 Subject: [PATCH 105/182] ARM64: Round-Robin dispatch IRQs between CPUs.
@@ -114485,7 +114485,7 @@ index c4e151451cf8c8ebde5225515eac2786d6f61d46..9a7ee04ee0d9b7aa734cf3159ed59c19
  	.name		= "bcm2836-gpu",
  	.irq_mask	= bcm2836_arm_irqchip_mask_gpu_irq,
 
-From 61a0bdbf07077b314ad8f98101c61905e28c7f07 Mon Sep 17 00:00:00 2001
+From 27322d934b5f80d6ea7202c6d7c9a627e2e262b3 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:45:03 -0800
 Subject: [PATCH 106/182] ARM64: Enable DWC_OTG Driver In ARM64 Build
@@ -114509,7 +114509,7 @@ index b7d762df19b85e369a32cd823dfd062145bdefa7..4d85c231c5ea0244e1b05fb4a5e3c8fd
  CONFIG_USB_STORAGE=y
  CONFIG_USB_STORAGE_REALTEK=m
 
-From 53ec579e86710d01d83aa621c32ccc3c9b4e8b23 Mon Sep 17 00:00:00 2001
+From 3b8d1aad4d19d029fe4ab422e63daaa7c139deda Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 11 Feb 2017 01:18:31 -0800
 Subject: [PATCH 107/182] ARM64: Force hardware emulation of deprecated
@@ -114540,7 +114540,7 @@ index f0e6d717885b1fcf3b22f64c10c38f19c25f809d..0cb830d30fb6d2bd26ab572efe893649
  	case INSN_OBSOLETE:
  		insn->current_mode = INSN_UNDEF;
 
-From c14587d836213b44843bb4c943fe6b479b1730b7 Mon Sep 17 00:00:00 2001
+From 8765d2329f57658fcdc8209e750469e0d1f9391f Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 10 Feb 2017 17:57:08 -0800
 Subject: [PATCH 108/182] build/arm64: Add rules for .dtbo files for dts
@@ -114568,7 +114568,7 @@ index f839ecd919f934c54a73d8e9f8179aff3d3cba26..a4010b3cc8ef11d449bcff8018522667
  
  dtbs: prepare scripts
 
-From ed71346196f2efa5f59c9ea304c5fe94e6946c1c Mon Sep 17 00:00:00 2001
+From 5ec381bbc4c688c56042e072095cb4cf67d7bb3e Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
 Subject: [PATCH 109/182] clk: bcm2835: Mark GPIO clocks enabled at boot as
@@ -114609,7 +114609,7 @@ index 39f72da6ba1f6ec6ec41d5dc1bf46344aab008da..fe3298b54cdfb96bd90fb4f39e13921d
  	 * rate changes on at least of the parents.
  	 */
 
-From df3933cf579c254542483bbb39fc206abda3ba44 Mon Sep 17 00:00:00 2001
+From 391b9b0a15c51e502e1b8023b0c5c65f89294b73 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
 Subject: [PATCH 110/182] pinctrl-bcm2835: Fix interrupt handling for GPIOs
@@ -114645,7 +114645,7 @@ index 6351fe7f8e314ac5ebb102dd20847b383fd5b857..28745af5aadf3cb91fa7ff39118385c3
  	},
  };
 
-From 86fe7a94b3ec729e0eac3e019b41995eaf332b26 Mon Sep 17 00:00:00 2001
+From babdfe14ce80f5477816088e4d6c4e302b277f4b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 10:06:56 +0000
 Subject: [PATCH 111/182] ASoC: Add prompt for ICS43432 codec
@@ -114673,7 +114673,7 @@ index adf3b7b75e303430d6a03a2b457d389596f39c1a..ba4a36dd0196e8eece5e22ad6717c189
  config SND_SOC_INNO_RK3036
  	tristate "Inno codec driver for RK3036 SoC"
 
-From 19f3100424b06dc9d387fab9b511c64e9e72fa81 Mon Sep 17 00:00:00 2001
+From d5b8463d49a5cf2d060ddf08cc922f48bb984061 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 16:34:46 +0000
 Subject: [PATCH 112/182] bcm2835-aux: Add aux interrupt controller
@@ -114840,7 +114840,7 @@ index bd750cf2238d61489811e7d7bd3b5f9950ed53c8..41e0702fae4692221980b0d02aed1ba6
  			       BCM2835_AUX_CLOCK_COUNT, GFP_KERNEL);
  	if (!onecell)
 
-From ecff100d10f4ebb7da2b0fb1b01b63481724666c Mon Sep 17 00:00:00 2001
+From 0787d170d85ae09031a7bdadbe8fb7a129a8b54c Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 29 Apr 2016 10:32:17 -0700
 Subject: [PATCH 113/182] mmc: read mmc alias from device tree
@@ -114900,7 +114900,7 @@ index 88fa03142e923c67967f7b51e0a90a32ae1cb6a6..393bb77d829d5da5556e2ef14a247042
  		kfree(host);
  		return NULL;
 
-From b654e4bd1ed371c3b02df46a7ec802f324a36948 Mon Sep 17 00:00:00 2001
+From d3d84f6b1fb9fce0ee8b579a6b22e42d696eef94 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 May 2016 12:50:33 +0100
 Subject: [PATCH 114/182] mmc: Add MMC_QUIRK_ERASE_BROKEN for some cards
@@ -115043,7 +115043,7 @@ index aad015e0152b7f1d32f92c500825b723498d1be9..d44a9c84a90a02388c05a427814fb8fc
  
  	unsigned int		erase_size;	/* erase size in sectors */
 
-From 8da446215b91e332378564d6f87878430d195dfe Mon Sep 17 00:00:00 2001
+From 3dd03b1a654105ca30262e963036fd4b802ebec5 Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Fri, 14 Apr 2017 10:43:57 +0100
 Subject: [PATCH 115/182] This is the driver for Sony CXD2880 DVB-T2/T tuner +
@@ -131178,7 +131178,7 @@ index 0000000000000000000000000000000000000000..82e122349055be817eb74ed5bbcd7560
 +MODULE_AUTHOR("Sony Semiconductor Solutions Corporation");
 +MODULE_LICENSE("GPL v2");
 
-From 845387abb930055cadf40c28fe78ed5b209a37b6 Mon Sep 17 00:00:00 2001
+From 063874ff960b151af80cf8550100aa45014025b4 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
 Subject: [PATCH 116/182] raspberrypi-firmware: Define the MBOX channel in the
@@ -131203,7 +131203,7 @@ index c819c21b0158a59c1308882e5a40e3f3fe73cbdf..de2a3dcd562beb752266eaf0070e5586
  
  enum rpi_firmware_property_status {
 
-From ae6523d3383095dedc66c70e0e70e0fa9a429f42 Mon Sep 17 00:00:00 2001
+From e175a55217ca3300c3ed7f4bb271c0be57262281 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
 Subject: [PATCH 117/182] raspberrypi-firmware: Export the general transaction
@@ -131250,7 +131250,7 @@ index de2a3dcd562beb752266eaf0070e55861d553f5f..dc7fd58afd5dddebf9b17065bb069a1d
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From 37b829d36d9777b8068c16588f966e5f71434e41 Mon Sep 17 00:00:00 2001
+From 03154ab3a7a5ef1616f0a1bed6a57ffa9eafb9c6 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
 Subject: [PATCH 118/182] drm/vc4: Add a mode for using the closed firmware for
@@ -132026,7 +132026,7 @@ index 0000000000000000000000000000000000000000..1e09980c61a91246156c4ab661c03779
 +	},
 +};
 
-From d9dce30c54aae0a04a1674ff49676176372a6d06 Mon Sep 17 00:00:00 2001
+From 21e716390413f65f68ca484d06be7bdd2fed7365 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:09:18 -0800
 Subject: [PATCH 119/182] drm/vc4: Name the primary and cursor planes in fkms.
@@ -132053,7 +132053,7 @@ index 1e09980c61a91246156c4ab661c03779baa1fc97..174a2f90c5bd78798ed47cca243b68a9
  	if (type == DRM_PLANE_TYPE_PRIMARY) {
  		vc4_plane->fbinfo =
 
-From 5f10d2d55e86c00f9a161bff905adcb26208e917 Mon Sep 17 00:00:00 2001
+From ad1a570e5b884a2ae945a362f1b7d185d1857a2d Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:10:09 -0800
 Subject: [PATCH 120/182] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
@@ -132126,7 +132126,7 @@ index 174a2f90c5bd78798ed47cca243b68a968e6e735..611a3c6d622deb9b511fe70c363d201b
  				    RPI_FIRMWARE_SET_CURSOR_STATE,
  				    &packet_state,
 
-From f5d4f341ea89a456ba22522e180b234f916484ae Mon Sep 17 00:00:00 2001
+From 05cdf193ab637ad967732757b3f4d3ad080bf9c8 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 2 Feb 2017 09:42:18 -0800
 Subject: [PATCH 121/182] drm/vc4: Fix sending of page flip completion events
@@ -132171,7 +132171,7 @@ index 611a3c6d622deb9b511fe70c363d201b091c414a..eb97443533c5a8fb5e142541adb1165b
  
  static void vc4_crtc_handle_page_flip(struct vc4_crtc *vc4_crtc)
 
-From 69baa1c10e5a115437d3d42d78df1b153d10e6cc Mon Sep 17 00:00:00 2001
+From d3263e3306d760d1308523bd080c43bfb371882f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 18 Apr 2017 21:43:46 +0100
 Subject: [PATCH 122/182] vc4_fkms: Apply firmware overscan offset to hardware
@@ -132231,7 +132231,7 @@ index eb97443533c5a8fb5e142541adb1165b55e32aea..aa0ab7bcd904b775f64045c4d5baf39a
  
  	return 0;
 
-From c7f2e43ee67ecb456be1695dad4a3d0116d2ea7a Mon Sep 17 00:00:00 2001
+From e425879c4cfe5b16a2e3b8040b874f2569758fcc Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 15 May 2017 09:28:36 -0700
 Subject: [PATCH 123/182] drm/vc4: Mark the device as active when enabling
@@ -132260,7 +132260,7 @@ index 7cc346ad9b0baed63701d1fae8f0306aa7713129..c82326ff994d03719a66d42f8f9ac0e2
  	pm_runtime_set_autosuspend_delay(dev, 40); /* a little over 2 frames. */
  	pm_runtime_enable(dev);
 
-From c186caa85e25f28d751d3942f943ccb533e23da1 Mon Sep 17 00:00:00 2001
+From 220773b419dc77c0614f1f06395b367a6c5a615b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 16 May 2017 14:39:49 +0100
 Subject: [PATCH 124/182] mmc: Change downstream MMC driver CONFIG option
@@ -132311,7 +132311,7 @@ index f4b8951af214fd0b0392d4fb38b29a0b41c7340e..d352fabf6b61c803fef3e10f974214bf
  obj-$(CONFIG_MMC_WBSD)		+= wbsd.o
  obj-$(CONFIG_MMC_AU1X)		+= au1xmmc.o
 
-From cf8aae78dfe7e0b26d1346751f1da6730eb59a45 Mon Sep 17 00:00:00 2001
+From 3ecc22b427a0f5793da56769863e389b71821a03 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 19:34:52 +0100
 Subject: [PATCH 125/182] config: Add CONFIG_I2C_ROBOTFUZZ_OSIF
@@ -132346,7 +132346,7 @@ index ace19d6f5bc04091130bd28b65ce25e863117a43..17952377907afac28fd982ca2f910206
  CONFIG_SPI_BCM2835=m
  CONFIG_SPI_BCM2835AUX=m
 
-From d5dcb3231cba06bf16932a6801bfd3cbfb6d23e3 Mon Sep 17 00:00:00 2001
+From 6ef7e423df8169313f8b70aa7cc41ed79cee103e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Thu, 18 May 2017 11:40:43 +0100
 Subject: [PATCH 126/182] config: Add FB_TFT_ST7789V module
@@ -132381,7 +132381,7 @@ index 17952377907afac28fd982ca2f9102067a062d6e..ef7bfc431c43eec6deb7c52e8cdac317
  CONFIG_FB_TFT_TLS8204=m
  CONFIG_FB_TFT_UC1701=m
 
-From 622ab82c516b0a293be9edef926f7b475881adf0 Mon Sep 17 00:00:00 2001
+From 6f5d09d36183bc1157e5bfd02459600e1dabdd66 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 18 May 2017 15:36:46 +0100
 Subject: [PATCH 127/182] staging: bcm2835-audio: Fix memory corruption
@@ -132419,7 +132419,7 @@ index 5f3d8f2339e34834d11edfa8de1d5819e3e32b4f..89f96f3c02805f4114ec9b488e18d00e
  	return ret;
  }
 
-From 1a93bb0eeffabfdb48dd5ec6bee4f1c32d188ad9 Mon Sep 17 00:00:00 2001
+From 38fbeabecdec09e74e65c74cdb4966bb0b6b6b0f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 15 May 2017 16:40:05 +0100
 Subject: [PATCH 128/182] config: Add CONFIG_TOUCHSCREEN_GOODIX
@@ -132454,7 +132454,7 @@ index ef7bfc431c43eec6deb7c52e8cdac31794ccccbe..573cbd71ca0990b7a7e48fa3bbc98eec
  CONFIG_TOUCHSCREEN_RPI_FT5406=m
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
 
-From d5961c5aa8da0599800f956032126f181b082c5f Mon Sep 17 00:00:00 2001
+From 7c9b8bdb3290317c3ea47ae5e944bfcf1e2c32fd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 16 May 2017 15:58:00 +0100
 Subject: [PATCH 129/182] config: Add CONFIG_TOUCHSCREEN_EDT_FT5X06
@@ -132489,7 +132489,7 @@ index 573cbd71ca0990b7a7e48fa3bbc98eec2d3d776f..6c4d62cdea7e4ed642e265861c6f1c1a
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
  CONFIG_TOUCHSCREEN_STMPE=m
 
-From 21c3c05d928e59a1bbf20b220feb4b890e07a0e1 Mon Sep 17 00:00:00 2001
+From b0b768fb98adb90a6c071b60beb34d28605715b2 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 22 May 2017 13:35:28 +0100
 Subject: [PATCH 130/182] config: Add CONFIG_IPV6_SIT_6RD
@@ -132524,7 +132524,7 @@ index 6c4d62cdea7e4ed642e265861c6f1c1a964e331c..676dfebfbab8f1cba521bc032b8d2137
  CONFIG_IPV6_MULTIPLE_TABLES=y
  CONFIG_IPV6_SUBTREES=y
 
-From 7f26cc8424dae22c01c612f1012657d0270c9f15 Mon Sep 17 00:00:00 2001
+From 52ed32e80094b3ae61ac8dfa71f33708c2dec6ce Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 22 May 2017 15:28:27 +0100
 Subject: [PATCH 131/182] config: Add CONFIG_IPV6_ROUTE_INFO
@@ -132559,7 +132559,7 @@ index 676dfebfbab8f1cba521bc032b8d21371c38abfa..4ae560370a972b9c56e8af38a537b1db
  CONFIG_INET6_ESP=m
  CONFIG_INET6_IPCOMP=m
 
-From a6e774f1d857bac8ad667b4f2847332c83d02bd6 Mon Sep 17 00:00:00 2001
+From ba57c3d94b12c1d42fb053729a768c8ea20a650a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 26 Apr 2017 17:28:47 +0100
 Subject: [PATCH 132/182] clk: bcm2835: Limit PCM clock to OSC and PLLD_PER
@@ -132607,7 +132607,7 @@ index fe3298b54cdfb96bd90fb4f39e13921d2e1d4356..c24b4defb2b046e4ecdc109befc2b224
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
  		.name = "pwm",
 
-From fef1de6afbe297708f0b6d4731a6ab6a7820f1a1 Mon Sep 17 00:00:00 2001
+From d4f3e3903c2d467a0c1dab4e17fc153c83bcb170 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 22 May 2017 13:56:41 +0100
 Subject: [PATCH 133/182] clk: bcm2835: Minimise clock jitter for PCM clock
@@ -132735,7 +132735,7 @@ index c24b4defb2b046e4ecdc109befc2b22497060647..db3ba74acf78f4dfec0d2206b58bc7c3
  		.tcnt_mux = 23),
  	[BCM2835_CLOCK_PWM]	= REGISTER_PER_CLK(
 
-From fe57b0bb2a19c0819a679c2afd0b485c136b93aa Mon Sep 17 00:00:00 2001
+From b67a47a57c995108badf15adfff961021edb927e Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Thu, 25 May 2017 16:04:53 +0100
 Subject: [PATCH 134/182] dwc_otg: make periodic scheduling behave properly for
@@ -132909,7 +132909,7 @@ index 85a6d431ca54b47dc10573aa72d1ad69d06f2e36..4b1dd9de99e9e08b2e006fb5f8a7ef92
  	status = check_max_xfer_size(hcd, qh);
  	if (status) {
 
-From 8a8049e2226f9107b0f281dbcd206cfde69bce90 Mon Sep 17 00:00:00 2001
+From 7472fd53804ddcb4efe8a59215160224310b2d6b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 19 May 2017 16:07:23 +0100
 Subject: [PATCH 135/182] serial: 8250: Add CAP_MINI, set for bcm2835aux
@@ -132985,7 +132985,7 @@ index 68fd045a7025047726860547ecd661b95d61ac80..af954e278d78002cc5d07086dcc69608
  
  	baud = serial8250_get_baud_rate(port, termios, old);
 
-From 2c62b145c3a3cd1fa1950bf0ffe639254e1a7216 Mon Sep 17 00:00:00 2001
+From d8415b8d62b470f159aaf92e4e411665d7975f9a Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Fri, 26 May 2017 12:50:31 +0100
 Subject: [PATCH 136/182] dwc_otg: fiq_fsm: Make isochronous compatibility
@@ -133052,7 +133052,7 @@ index 38bf5fc792d32352f9e208e0e90f968599b9bc31..71834cf365e67d7ad995bba7869216c4
  			return 1;
  		}
 
-From dc7cdbfb0750e8a33ea7e0c5cbf2737036a50257 Mon Sep 17 00:00:00 2001
+From 0c1e07dd58ec4f2e47e594e9818260e871259c7e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 12 Jun 2017 13:05:43 +0100
 Subject: [PATCH 137/182] config: Add CONFIG_CAN_GS_USB
@@ -133087,7 +133087,7 @@ index 4ae560370a972b9c56e8af38a537b1dbebd5488a..8894ef2ed78968ea56d83d56ba4d770b
  CONFIG_IRLAN=m
  CONFIG_IRNET=m
 
-From 1bb2f08764771f45b44d99eaa248d2acf8cd5a39 Mon Sep 17 00:00:00 2001
+From e4242be20343a0b92a4b6d776a7d504e31603853 Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Mon, 12 Jun 2017 16:10:03 +0100
 Subject: [PATCH 138/182] dwc_otg: add module parameter int_ep_interval_min
@@ -133172,7 +133172,7 @@ index 4b1dd9de99e9e08b2e006fb5f8a7ef92f20c2553..fe8e8f841f03660c2ad49ab8e66193be
  
  	DWC_DEBUGPL(DBG_HCD, "DWC OTG HCD QH Initialized\n");
 
-From 77a71c11d882f751e004817b2d95cf857778a215 Mon Sep 17 00:00:00 2001
+From 3e3083b088a1502bedc9a842e88abbd28c270bfb Mon Sep 17 00:00:00 2001
 From: P33M <p33m@github.com>
 Date: Tue, 20 Jun 2017 13:44:01 +0100
 Subject: [PATCH 139/182] dwc_otg: fiq_fsm: Add non-periodic TT exclusivity
@@ -133342,7 +133342,7 @@ index 71834cf365e67d7ad995bba7869216c4091c3a74..7710370b30363e3170bf9bf522597c5f
  					st->fsm = FIQ_PER_SSPLIT_STARTED;
  			} else {
 
-From b94ba074c2c4ac547769103c2baa41660c295c37 Mon Sep 17 00:00:00 2001
+From 7bc88d4246d2a4230b5bd0e13191eb256807b17e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 21 Jun 2017 17:19:04 +0100
 Subject: [PATCH 140/182] serial: 8250: Fix THRE flag usage for CAP_MINI
@@ -133389,7 +133389,7 @@ index af954e278d78002cc5d07086dcc69608ac3019ee..877b1a848b5a44e196cab5bfd435467b
  
  	if (uart_circ_chars_pending(xmit) < WAKEUP_CHARS)
 
-From db2d611cdf654eaa37745bede877346dc112f85d Mon Sep 17 00:00:00 2001
+From 780249e09382ec7e024f2645d4300114c3dff9dc Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 26 May 2017 13:03:41 +0100
 Subject: [PATCH 141/182] BCM270X_DT: Add midi-uart1 overlay
@@ -133490,7 +133490,7 @@ index 0000000000000000000000000000000000000000..e0bc410acbff3a7a175dd5d53b3ab0d0
 +	};
 +};
 
-From 7ee03bbf8868563b9bb1c5a0c2b87a4bdd524a6e Mon Sep 17 00:00:00 2001
+From a4927c9bd018b3d4723f80784020834b72e4d655 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Sat, 20 May 2017 22:10:14 +0100
 Subject: [PATCH 142/182] overlays: README: remove vestigial SDIO parameters
@@ -133547,7 +133547,7 @@ index ec9e7b1941678796facf625b3770c20ed0b15b25..499cd1920fd373702cfbc9f6e0fcaebc
                                  (default on: polling once at boot-time)
  
 
-From 078d547847bdfae0f6e021acb6d45a8f57161d9d Mon Sep 17 00:00:00 2001
+From a053bc0f778966305cfb843b77847d85f7e8a8b7 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 27 Jun 2017 15:07:14 +0100
 Subject: [PATCH 143/182] SQUASH: mmc: Apply ERASE_BROKEN quirks correctly
@@ -133580,7 +133580,7 @@ index 05c8d7381fff5ae88531129d9a5ddd554bddb43e..c9d5d644688c1509d7febcff0322fbab
  	END_FIXUP
  };
 
-From a15e784c1d57cb54ee7e13a36a9ef793c0a4d784 Mon Sep 17 00:00:00 2001
+From d0b6109e2a461b616084ae8bf6a0f87e58530148 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 7 May 2017 11:34:26 +0200
 Subject: [PATCH 144/182] ASoC: bcm2835: Add support for TDM modes
@@ -133985,7 +133985,7 @@ index 56df7d8a43d0aac055a91b0d24aca8e1b4e308e4..dcacf7f83c9371df539a788ea33fedcf
  	dev->dev = &pdev->dev;
  	dev_set_drvdata(&pdev->dev, dev);
 
-From a85ef01210201396ad32e24eef9b11a46ab2f49e Mon Sep 17 00:00:00 2001
+From 3f1cda57c94fb4034d022543687145b7a3c6347c Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 7 May 2017 15:30:50 +0200
 Subject: [PATCH 145/182] ASoC: bcm2835: Support left/right justified and DSP
@@ -134234,7 +134234,7 @@ index dcacf7f83c9371df539a788ea33fedcf97d64690..3a706fda4f39e42efbe12f19d87af9b1
  }
  
 
-From f9fe9ff221224d76892f41301c55b633aaebf637 Mon Sep 17 00:00:00 2001
+From 12dd142e73aa44692c7d0d29a8ef07dba0c5acb9 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 7 May 2017 16:19:54 +0200
 Subject: [PATCH 146/182] ASoC: bcm2835: Support additional samplerates up to
@@ -134280,7 +134280,7 @@ index 3a706fda4f39e42efbe12f19d87af9b100a348a5..43f5715a0d5dda851731ecf7ff27e76c
  				| SNDRV_PCM_FMTBIT_S24_LE
  				| SNDRV_PCM_FMTBIT_S32_LE
 
-From 8bf3e213eca2f7484d46cb26c5a68b9f564b1cdd Mon Sep 17 00:00:00 2001
+From e8eb5e7e58f0460ee5f7f74da0b4d93c0de93558 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 7 May 2017 16:24:57 +0200
 Subject: [PATCH 147/182] ASoC: bcm2835: Enforce full symmetry
@@ -134319,7 +134319,7 @@ index 43f5715a0d5dda851731ecf7ff27e76c48fb6e57..2e449d7173fcecbcd647f90a26bd58b6
  
  static bool bcm2835_i2s_volatile_reg(struct device *dev, unsigned int reg)
 
-From 77e7afa0c067b035c1889557769a25a4d02dfad0 Mon Sep 17 00:00:00 2001
+From 2c598ba743a6f93523ba434b720d20cdf1f950fc Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Thu, 6 Jul 2017 18:52:16 +0200
 Subject: [PATCH 148/182] config: add missing arizona regulator modules
@@ -134372,7 +134372,7 @@ index 8894ef2ed78968ea56d83d56ba4d770b45bba5c2..7362d1a6e5759e45ebef3ba84a4454b8
  CONFIG_MEDIA_CAMERA_SUPPORT=y
  CONFIG_MEDIA_ANALOG_TV_SUPPORT=y
 
-From a6ff8b7100afb58283833352df58d84ed3f22982 Mon Sep 17 00:00:00 2001
+From 44ca069a828c9358be7f0118a50400adcceadaff Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Tue, 4 Apr 2017 19:20:59 +1000
 Subject: [PATCH 149/182] Audioinjector : make the octo and pi sound cards have
@@ -134412,7 +134412,7 @@ index ef54e0f07ea03f59e9957b5d98f3e7fdc998e469..491906bbf446826e55dd843f28e4860f
  		.of_match_table = audioinjector_pi_soundcard_of_match,
         },
 
-From cedc1e1770860971cc5dde0afcba4767e6026244 Mon Sep 17 00:00:00 2001
+From 6f0c00e5065857e3ffc45fdcd6f78510a2464130 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Tue, 4 Apr 2017 19:23:04 +1000
 Subject: [PATCH 150/182] Audioinjector octo : Make the playback and capture
@@ -134438,7 +134438,7 @@ index 49115c8e20ce1a2ba5a99feb8983a1cafb052ca2..5e79f4eff93a21ed3495c77a90f73525
  };
  
 
-From 093220f0f2228e78cc46d852e548b9bce8568d21 Mon Sep 17 00:00:00 2001
+From 541b4c8716a811bc735341846620e6d09009c113 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Sun, 23 Apr 2017 19:36:53 +0100
 Subject: [PATCH 151/182] BCM270X_DT: Add bme280 and bmp180 to i2c-sensor
@@ -134515,7 +134515,7 @@ index 606b2d5012abf2e85712be631c42ea40a0b512c5..e23e34b32a0a8927c14203d7384e8008
  		lm75 = <&lm75>,"status";
  		lm75addr = <&lm75>,"reg:0";
 
-From b0f918db744f5795bd5366d2339691fce8c3a9e4 Mon Sep 17 00:00:00 2001
+From 2b19c5aff14b1d71dbf1336fee242b63caae883c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Sun, 23 Apr 2017 19:38:06 +0100
 Subject: [PATCH 152/182] config: Add CONFIG_BMP280 (and CONFIG_BMP280_I2C)
@@ -134551,7 +134551,7 @@ index 7362d1a6e5759e45ebef3ba84a4454b86e69a901..fab31f0fed0ec068e5249f4cebc34e48
  CONFIG_PWM_PCA9685=m
  CONFIG_RASPBERRYPI_FIRMWARE=y
 
-From 0f75a7323eb92cd58b53f851402c5f94923c440d Mon Sep 17 00:00:00 2001
+From 6f96eb72babea0f3104a7b67f3b69329c3f70862 Mon Sep 17 00:00:00 2001
 From: Scott Ellis <scott@jumpnowtek.com>
 Date: Tue, 25 Apr 2017 10:46:09 -0400
 Subject: [PATCH 153/182] config: Enable TI TMP102 temp sensor module
@@ -134587,7 +134587,7 @@ index fab31f0fed0ec068e5249f4cebc34e48cfd29759..91a5234a5884f24f1a656d297a3d9064
  CONFIG_BCM2835_THERMAL=y
  CONFIG_WATCHDOG=y
 
-From 03de987537e1a63a692023e06d710035bff0f2de Mon Sep 17 00:00:00 2001
+From 42b637ac1940f5163bd481f7e4ead72a8abb0075 Mon Sep 17 00:00:00 2001
 From: Scott Ellis <scott@jumpnowtek.com>
 Date: Tue, 25 Apr 2017 13:05:42 -0400
 Subject: [PATCH 154/182] BCM270X_DT: Add tmp102 to i2c sensor overlay
@@ -134670,7 +134670,7 @@ index e23e34b32a0a8927c14203d7384e800878627347..e86a13f92c3f75c14fa4425cdfb081d6
  	};
  };
 
-From 7aa3d35245dc76a438285fea482de1f3f9e7c700 Mon Sep 17 00:00:00 2001
+From ddcba1946d96f2ad384460fd19bf5730572f5a0b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 8 May 2017 16:43:40 +0100
 Subject: [PATCH 155/182] irq_bcm2836: Send event when onlining sleeping cores
@@ -134709,7 +134709,7 @@ index 9a7ee04ee0d9b7aa734cf3159ed59c19a338de0d..014f13f89eb896f5cfc75ed9891787d0
  }
  
 
-From 79c3dcdd6e75023be565a75549d8012db0e39743 Mon Sep 17 00:00:00 2001
+From 08d93f1131a9f21a3f6e97b08ddbe2888059de91 Mon Sep 17 00:00:00 2001
 From: Ahmet Inan <inan@distec.de>
 Date: Mon, 15 May 2017 17:10:53 +0200
 Subject: [PATCH 156/182] overlays: Add Goodix overlay
@@ -134809,7 +134809,7 @@ index 0000000000000000000000000000000000000000..084f74042ed6379ebd9281374d5391a7
 +	};
 +};
 
-From 6cb23e0b23a95c24154ad2532771596187abb8b0 Mon Sep 17 00:00:00 2001
+From bde03e214c39600d80181cf4e1e36cfeeddb388a Mon Sep 17 00:00:00 2001
 From: chenzhiwo <chenzhiwo@139.com>
 Date: Wed, 17 May 2017 16:34:57 +0800
 Subject: [PATCH 157/182] Add device tree overlay for GPIO connected rotary
@@ -134904,7 +134904,7 @@ index 0000000000000000000000000000000000000000..c0c6bccff60cc15d9a9bf59d2c7cba41
 +	};  
 +};
 
-From 473dcc942c6a7464751566b8fb9f0197317ecff2 Mon Sep 17 00:00:00 2001
+From 9497dc5aa2fed5a7667e64aaeaf92c5b1dd71b62 Mon Sep 17 00:00:00 2001
 From: Anton Onishchenko <tony.o.developer@gmail.com>
 Date: Tue, 23 May 2017 18:55:46 +0300
 Subject: [PATCH 158/182] mpu6050 device tree overlay (#2031)
@@ -135022,7 +135022,7 @@ index 91a5234a5884f24f1a656d297a3d906429477b5d..2a28b012696a955f4d275a9e0a9fa3e1
  CONFIG_PWM_BCM2835=m
  CONFIG_PWM_PCA9685=m
 
-From 1bae7614fc06d65b07b7ca8896032eaadc6187c9 Mon Sep 17 00:00:00 2001
+From 1e2d6b3c7812ce7acf462c9f948f41bc30de11a6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 31 May 2017 09:33:55 +0100
 Subject: [PATCH 159/182] config: Adding SENSOR_JC42
@@ -135065,7 +135065,7 @@ index 2a28b012696a955f4d275a9e0a9fa3e155e4a3c6..706bd883dd345a8ad32d30386f7dcf11
  CONFIG_SENSORS_SHT21=m
  CONFIG_SENSORS_SHTC1=m
 
-From 65a7780ef737ddea6127848967b7f03a0cc19052 Mon Sep 17 00:00:00 2001
+From 299575b9297073769135faa0b54ed488d0616bd4 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 31 May 2017 15:27:39 +0100
 Subject: [PATCH 160/182] BCM270X_DT: Improve i2c-sensor and i2c-rtc overlay
@@ -135433,7 +135433,7 @@ index e86a13f92c3f75c14fa4425cdfb081d6795ff76a..d2f0008addfadac8f6ed774a6e4f3f97
  	};
  };
 
-From bb3216dabc2f6850f5c7a7a3dd68ff5b7aadfa32 Mon Sep 17 00:00:00 2001
+From b974ffbae4dc33de81acbfd49513672b41e083a2 Mon Sep 17 00:00:00 2001
 From: Stefan Tatschner <rumpelsepp@sevenbyte.org>
 Date: Mon, 29 May 2017 21:46:16 +0200
 Subject: [PATCH 161/182] Add device tree config for htu21
@@ -135518,7 +135518,7 @@ index d2f0008addfadac8f6ed774a6e4f3f97871c0d61..17c27e3b666a7a83619471b50c63bb93
  	};
  };
 
-From d3b2fb185f77f74a5b209698313827f59f85eceb Mon Sep 17 00:00:00 2001
+From 9720a2e4851ef590c787322c04cb8e0f8bed2b5f Mon Sep 17 00:00:00 2001
 From: sandeepal <alsandeep@cem-solutions.net>
 Date: Fri, 2 Jun 2017 18:59:46 +0530
 Subject: [PATCH 162/182] Allo Digione Driver (#2048)
@@ -135952,7 +135952,7 @@ index 0000000000000000000000000000000000000000..e3664e44c699d0102120ecf99e8b780a
 +MODULE_DESCRIPTION("ASoC Driver for Allo DigiOne");
 +MODULE_LICENSE("GPL v2");
 
-From 73a8b2633ca8baf3e561da1e4d623d2c9150f763 Mon Sep 17 00:00:00 2001
+From c38583a2a02d30d934c69a87852737a27520b848 Mon Sep 17 00:00:00 2001
 From: Andrei Gherzan <andrei@gherzan.com>
 Date: Mon, 5 Jun 2017 16:40:38 +0100
 Subject: [PATCH 163/182] dma-bcm2708: Fix module compilation of
@@ -135998,7 +135998,7 @@ index c5bfff2765be4606077e6c8af73040ec13ee8974..6ca874d332a8bc666b1c9576ac51f479
  
  #endif /* _PLAT_BCM2708_DMA_H */
 
-From 18005ba6ecb2984e33bcffc97ef84568afc11fe1 Mon Sep 17 00:00:00 2001
+From 9eb7da638879009bb727cc2fbe9ed1a1c9b81f16 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 20 Jun 2017 17:51:47 +0100
 Subject: [PATCH 164/182] bcm2835-cpufreq: Change licence to GPLv2
@@ -136054,7 +136054,7 @@ index 414fbdc10dfbfc6e4bb47870a7af3fd5780f9c9a..99345969b0e4d651fd9033d67de2febb
  /* ---------- INCLUDES ---------- */
  #include <linux/kernel.h>
 
-From e22fb4cd4c293f33543dd7eb4fc1498bb4ed73f2 Mon Sep 17 00:00:00 2001
+From b7cc8da9ebd95a9e9d889b01306dc3e4b1a7df23 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 21 Jun 2017 09:03:51 -0700
 Subject: [PATCH 165/182] bcm2708: Drop CMA alignment from FKMS mode as well.
@@ -136113,7 +136113,7 @@ index 95a595a35cb4fbb707bf4b18161f6a46860aa4ae..36fbf6c8c2e612a6dc5aa02d77cc8173
  	};
  
 
-From df5d582271e1f0555465a736c73a567bdde746a9 Mon Sep 17 00:00:00 2001
+From 712bb5ff809745e185b170086b4feada4f5f86ab Mon Sep 17 00:00:00 2001
 From: Steve Conner <connermcsteve@gmail.com>
 Date: Thu, 29 Jun 2017 15:56:19 +0100
 Subject: [PATCH 166/182] New i2c-rtc-gpio device overlay (#2092)
@@ -136380,7 +136380,7 @@ index 0000000000000000000000000000000000000000..8415e6081428fba9a47682964174fc02
 +	};
 +};
 
-From 5cc977fc58b49534d68b0f6e33347676f904c4b3 Mon Sep 17 00:00:00 2001
+From c7100a0d0402e9d7019d32d23e78f798eb8090ff Mon Sep 17 00:00:00 2001
 From: Allo <sparky-dev@allo.com>
 Date: Mon, 3 Jul 2017 15:45:20 +0530
 Subject: [PATCH 167/182] PianoPlus: Dual Mono & Dual Stereo features added
@@ -136672,7 +136672,7 @@ index 56e43f98846b41e487b3089813f7edc3c08517eb..d4e99e3c6a383d92fb0cf9e8c1cd1e76
  }
  
 
-From 728c8629dd3e78eb32f8c0f84b177c55c90f17cd Mon Sep 17 00:00:00 2001
+From da04f160d96aef70c8a079820e291228c2ce73c2 Mon Sep 17 00:00:00 2001
 From: Matthijs Kooijman <matthijs@stdin.nl>
 Date: Sun, 9 Jul 2017 15:15:22 +0200
 Subject: [PATCH 168/182] overlays: Add gpio-shutdown overlay (#2103)
@@ -136831,7 +136831,7 @@ index 0000000000000000000000000000000000000000..863fb395c8539734b658682b900e1fbd
 +
 +};
 
-From 3ff3b2c2901070ef8fbf8ec183cb4eeb1be46c19 Mon Sep 17 00:00:00 2001
+From 7f878318d2fd13f7c20bbf0eb77155158db0e7b5 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <github@hias.horus.com>
 Date: Mon, 10 Jul 2017 11:05:17 +0200
 Subject: [PATCH 169/182] config: enable generic S/PDIF codec drivers (#2104)
@@ -136891,7 +136891,7 @@ index cead8c64336bb4ce9656bb20384069917695852d..7c1be0e035105724a7774ac59e5195a0
  CONFIG_SND_SIMPLE_CARD=m
  CONFIG_HIDRAW=y
 
-From a7ced3aeb668ddda9570c231040e112632641575 Mon Sep 17 00:00:00 2001
+From 063bb68b013d9704babe8fc9e1d29e7a2392baad Mon Sep 17 00:00:00 2001
 From: Bilal Amarni <bamarni@users.noreply.github.com>
 Date: Wed, 24 May 2017 10:52:50 +0200
 Subject: [PATCH 170/182] [ARM64] enable drivers for GPIO expander and vcio
@@ -136922,7 +136922,7 @@ index 4d85c231c5ea0244e1b05fb4a5e3c8fd3e651ddf..9dcb58a519d041fadae99c81a7bda621
  CONFIG_GPIO_ARIZONA=m
  CONFIG_GPIO_STMPE=y
 
-From 7564b74454702a04c7ef6a572fd68c0f486837a3 Mon Sep 17 00:00:00 2001
+From c970296be34ece8a59f7878c4a932a8a44fb6149 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 14 Jul 2017 12:59:55 +0100
 Subject: [PATCH 171/182] bcm2835-mmc: Fix DMA usage
@@ -136960,7 +136960,7 @@ index 4fe8d1fe44578fbefcd48f8c327ba3d03f3d0a2a..981db05de1ff52a83550e41ab362eecf
  	}
  #endif
 
-From 2f4b4961815f6569f4d76c04821cce15ed42019f Mon Sep 17 00:00:00 2001
+From b8a06dd0a2e98a1b3407b4f393aa397e00298ac0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 17 Jul 2017 16:54:06 +0100
 Subject: [PATCH 172/182] Revert "bcm2835-mmc: Fix DMA usage"
@@ -136993,7 +136993,7 @@ index 981db05de1ff52a83550e41ab362eecf99cafa29..4fe8d1fe44578fbefcd48f8c327ba3d0
  	}
  #endif
 
-From 197f606831c120910fdbd7cee642c4d470071ed9 Mon Sep 17 00:00:00 2001
+From cd2e07e0f968678876bf7dc5d9334c30b4d444ce Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 18 Jul 2017 15:30:48 +0100
 Subject: [PATCH 173/182] bcm2835-mmc: Prevent DMA race condition
@@ -137063,7 +137063,7 @@ index 4fe8d1fe44578fbefcd48f8c327ba3d03f3d0a2a..031ec56eee1a3dbc01cf31259e6d0d55
  
  static void bcm2835_mmc_finish_command(struct bcm2835_host *host)
 
-From fd714f757c45bd66b3deb838f3e964c74b891d27 Mon Sep 17 00:00:00 2001
+From 7b8413a277df119fd6af9a03cf47f746673e4f1e Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 19 Jul 2017 14:50:49 +0100
 Subject: [PATCH 174/182] Revert "Revert "bcm2835-mmc: Fix DMA usage""
@@ -137096,7 +137096,7 @@ index 031ec56eee1a3dbc01cf31259e6d0d555b6543b7..c4a5e992c6fb4a40b933239350ed4bfc
  	}
  #endif
 
-From ab156ff547ee52ae7f8eb8a39770d0e6f2101f40 Mon Sep 17 00:00:00 2001
+From 38e5fcbe47320ee23670e408f291d0aea4df5eee Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 19 Jul 2017 15:43:05 +0100
 Subject: [PATCH 175/182] config: Add CONFIG_W1_SLAVE_DS2438
@@ -137134,7 +137134,7 @@ index 7c1be0e035105724a7774ac59e5195a098b51796..5cb81c879eb0e1e1c369f284ccd41b80
  CONFIG_W1_SLAVE_DS2780=m
  CONFIG_W1_SLAVE_DS2781=m
 
-From defe621c6149a546650c4144bfb98541f4d75b56 Mon Sep 17 00:00:00 2001
+From c027775f7fe5e3c024634455423ed488d8705cd7 Mon Sep 17 00:00:00 2001
 From: Conn <connogriofa@gmail.com>
 Date: Mon, 17 Jul 2017 03:25:43 +0100
 Subject: [PATCH 176/182] config: enhance DualShock3 controller support
@@ -137186,7 +137186,7 @@ index 5cb81c879eb0e1e1c369f284ccd41b80bb1e44ce..3cd9dca829e6820ae9be35e4abe5ebc6
  CONFIG_HID_SUNPLUS=m
  CONFIG_HID_GREENASIA=m
 
-From 3b57f7af3018b1404b169ffb3ae228548299fe05 Mon Sep 17 00:00:00 2001
+From 132cb9a87179d6d83ebd0f8c6f2b8986e7ca052a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 19 Jul 2017 15:20:50 +0100
 Subject: [PATCH 177/182] overlays: i2c1-bcm2708: Don't overwrite i2c1 pins
@@ -137234,7 +137234,7 @@ index e303b9c61c82a28eab7b48f6b085661574d5a849..7c69047bcd88a5c900dddd08e60ad075
     };
  };
 
-From 6d647ec0ae4af93ccf0471f3897d226b06325222 Mon Sep 17 00:00:00 2001
+From 1a62daf4001a59e1316d3b57b6716c4d7ee62011 Mon Sep 17 00:00:00 2001
 From: James Hughes <james.hughes@raspberrypi.org>
 Date: Fri, 21 Jul 2017 09:55:12 +0100
 Subject: [PATCH 178/182] Sets the BCDC priority to constant 0
@@ -137263,7 +137263,7 @@ index 9f2d0b0cf6e5c452ad85a3caef58cf16a8cdad46..b009f3083490c2bc2733424f08f81b9f
  	h->data_offset = offset;
  	BCDC_SET_IF_IDX(h, ifidx);
 
-From ebe2fa57cd6bd8462009fcae00753592b47e4821 Mon Sep 17 00:00:00 2001
+From 33e5a0c3ab840dfd40cb9a5f21383413eba73b2b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Sven=20K=C3=B6hler?= <sven.koehler@gmail.com>
 Date: Mon, 7 Aug 2017 18:49:20 +0200
 Subject: [PATCH 179/182] Fix dependencies broken since driver was renamed
@@ -137286,7 +137286,7 @@ index e577d20963bcb1f61756d5d7050328b967b522d4..324da890a83a43fdf2f8ac3621bfde78
  	default 2
  	help
 
-From df672fb43edb2cfcb1c8ae4ce7e766e78a45dedc Mon Sep 17 00:00:00 2001
+From aa829acaee2bedfde36429797b55bdf314bc3590 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
 Subject: [PATCH 180/182] mm: Remove the PFN busy warning
@@ -137301,10 +137301,10 @@ Signed-off-by: Eric Anholt <eric@anholt.net>
  1 file changed, 2 deletions(-)
 
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 4d16ef9d42a97b51b294f496927cf5c3fd1a6040..e51f3fc70c3fc212c66a5cc7ec43ea104ed25fea 100644
+index f553b3a6eca84e71ca1839fb05a890199ed988f6..8af333f67ffe21d0a055a564012cc55a06b684a2 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
-@@ -7571,8 +7571,6 @@ int alloc_contig_range(unsigned long start, unsigned long end,
+@@ -7587,8 +7587,6 @@ int alloc_contig_range(unsigned long start, unsigned long end,
  
  	/* Make sure the range is really isolated. */
  	if (test_pages_isolated(outer_start, end, false)) {
@@ -137314,7 +137314,7 @@ index 4d16ef9d42a97b51b294f496927cf5c3fd1a6040..e51f3fc70c3fc212c66a5cc7ec43ea10
  		goto done;
  	}
 
-From b5f58bf80b0e2945cee41ad45ea5ea0228aa5685 Mon Sep 17 00:00:00 2001
+From ad29738bf03f21dd97fd06c9b70c736e376e10cd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 25 Aug 2017 19:18:13 +0100
 Subject: [PATCH 181/182] cache: export clean and invalidate
@@ -137369,7 +137369,7 @@ index de78109d002db1a5e7c94a6c1bc8bb94161d07b8..4c850aa3af2b2439fced4e130441329a
  	sub	r3, r2, #1
  	bic	r0, r0, r3
 
-From 24f0e45bb8c33dcf4db92592369ea4c0570f9a6f Mon Sep 17 00:00:00 2001
+From 0f263d4df966ff0612408432511df2db2fa7d933 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 25 Aug 2017 19:18:26 +0100
 Subject: [PATCH 182/182] vcsm: Provide new ioctl to clean/invalidate a 2D


### PR DESCRIPTION
Merge target: 4.12.14 (or when 4.13.0 is released, whichever is first?)

Edit: As 4.13 is now available, this can go in as-is.

4.12.10 changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.12.10