### PR TITLE
scripts/unpack: use git apply whenever patch includes a renamed file

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -173,7 +173,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
 
     if [ -f "$i" ]; then
       printf "%${BUILD_INDENT}c $(print_color CLR_APPLY_PATCH "APPLY PATCH") $(print_color CLR_PATCH_DESC "${PATCH_DESC}")   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
-      if [ -n "$(grep -E '^GIT binary patch$' $i)" ]; then
+      if grep -qE '^GIT binary patch$|^rename from|^rename to' $i; then
         cat $i | git apply --directory=`echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 --verbose --whitespace=nowarn --unsafe-paths >&$VERBOSE_OUT
       else
         cat $i | patch -d `echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 >&$VERBOSE_OUT


### PR DESCRIPTION
Renaming (moving) a file is something that `git` supports when patching, but GNU `patch` does not, consequently complex git-based patches that move/rename (but don't otherwise change) files cannot be applied by the LibreELEC patching process. This addresses that issue.
