### PR TITLE
Fix international keyboard input for Linux input layer

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-995.11-fix-keyboard-input.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.11-fix-keyboard-input.patch
@@ -1,0 +1,33 @@
+diff --git a/xbmc/input/linux/LinuxInputDevices.cpp b/xbmc/input/linux/LinuxInputDevices.cpp
+index adb1602..d0d6314 100644
+--- a/xbmc/input/linux/LinuxInputDevices.cpp
++++ b/xbmc/input/linux/LinuxInputDevices.cpp
+@@ -370,7 +370,7 @@ int CLinuxInputDevice::KeyboardGetSymbol(unsigned short value)
+     case 0x7f:
+       return XBMCK_BACKSPACE;
+     case 0xa4:
+-      return XBMCK_EURO; /* euro currency sign */
++      return 0x20ac; /* euro currency sign */
+     default:
+       return index;
+     }
+@@ -444,6 +444,7 @@ XBMCMod CLinuxInputDevice::UpdateModifiers(XBMC_Event& devt)
+     case XBMCK_RALT: modifier = XBMCKMOD_RALT; break;
+     case XBMCK_LMETA: modifier = XBMCKMOD_LMETA; break;
+     case XBMCK_RMETA: modifier = XBMCKMOD_RMETA; break;
++    case XBMCK_MODE: modifier = XBMCKMOD_RALT; break;
+     default: break;
+   }
+ 
+@@ -565,10 +566,7 @@ bool CLinuxInputDevice::KeyEvent(const struct input_event& levt, XBMC_Event& dev
+       if (keyMapValue != XBMCK_UNKNOWN)
+       {
+         devt.key.keysym.sym = (XBMCKey) keyMapValue;
+-        if (keyMapValue > 0 && keyMapValue < 127)
+-        {
+-          devt.key.keysym.unicode = devt.key.keysym.sym;
+-        }
++        devt.key.keysym.unicode = devt.key.keysym.sym;
+       }
+     }
+   }


### PR DESCRIPTION
Fix keyboard input for international keyboard layouts/keymaps when using plain Linux input layer (e.g. Raspberry Pi):

- allow input of unicode characters
- map mode key ('Alt Gr') to right Alt key
- fix euro currency sign

Further details within upstream pull request: https://github.com/xbmc/xbmc/pull/12762

Creating a pull request here in case you want to add this to current/previous releases or in case this does not get accepted upstream.