### PR TITLE
[8.2] dvb-apps: fix compilation with current perl versions

### DIFF
--- a/packages/addons/addon-depends/dvb-tools-depends/dvb-apps/package.mk
+++ b/packages/addons/addon-depends/dvb-tools-depends/dvb-apps/package.mk
@@ -29,3 +29,7 @@ PKG_SECTION="tools"
 PKG_SHORTDESC="Digitial Video Broadcasting (DVB) applications"
 PKG_LONGDESC="Applications and utilities geared towards the initial setup, testing and operation of an DVB device supporting the DVB-S, DVB-C, DVB-T, and ATSC standards."
 PKG_AUTORECONF="no"
+
+pre_make_target() {
+  export PERL_USE_UNSAFE_INC=1
+}


### PR DESCRIPTION
Newer versions of perl no longer include the current directory
in the default include path which causes dvb-apps compilation to fail.

Fix this by setting the PERL_USE_UNSAFE_INC environment variable
to restore the previous behavior.

See https://perldoc.perl.org/perldelta.html#Removal-of-the-current-directory-(%22.%22)-from-%40INC
for details about the perl change