### PR TITLE
samba: validate samba user config and don't use if legacy or incompatible

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -1,21 +1,21 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2009-2017 Stephan Raue (stephan@openelec.tv)
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
-# samba.conf
+# samba.conf v4 (do not remove)
 
 # This configuration file allows you to customize the samba shares
 # available from your machine

--- a/packages/network/samba/scripts/samba-config
+++ b/packages/network/samba/scripts/samba-config
@@ -21,8 +21,27 @@ SMB_USERCONF="/storage/.config/samba.conf"
 SMB_DEFCONF="/etc/samba/smb.conf"
 SMB_CONF="/run/samba/smb.conf"
 
-mkdir -p /run/samba
-  if [ -f $SMB_USERCONF ]; then
+SMB_USERCONF_IS_VALID=no
+SMB_CONFIG_VERSION=4
+
+# If user config is based on legacy OpenELEC, or old version (or no version)
+# then don't use it, and log a warning.
+if [ -f $SMB_USERCONF ]; then
+  SMB_IS_LEGACY="$(awk 'NR <= 2 && /This file is part of OpenELEC/{ print }' $SMB_USERCONF)"
+  SMB_THIS_VER="$(awk '/^# samba.conf v[0-9\.]*/{ print substr($3,2); exit }' $SMB_USERCONF)"
+  if [ -n "${SMB_IS_LEGACY}" ]; then
+    echo "WARNING: Ignoring user config $SMB_USERCONF due to incompatibility [Old style OpenELEC]"
+  elif [ -z "${SMB_THIS_VER}" ]; then
+    echo "WARNING: Ignoring user config $SMB_USERCONF due to incompatibility [version is unknown or invalid]"
+  elif [ ${SMB_THIS_VER} !=  ${SMB_CONFIG_VERSION} ]; then
+    echo "WARNING: Ignoring user config $SMB_USERCONF due to incompatibility [version ${SMB_THIS_VER} is not the required version $SMB_CONFIG_VERSION]"
+  else
+    SMB_USERCONF_IS_VALID=yes
+  fi
+fi
+
+mkdir -p $(dirname $SMB_CONF)
+  if [ $SMB_USERCONF_IS_VALID = yes ]; then
     cp $SMB_USERCONF $SMB_CONF
   else
     cp $SMB_DEFCONF $SMB_CONF


### PR DESCRIPTION
OK, so this should help us avoid the repeated "samba doesn't work" issues when upgrading to 8.2.

Now, we'll ignore the current custom `/storage/.config/samba.conf` (and log a warning in the system log) if either of the following is true:
1) we find `This file is part of OpenELEC` in the second line
2) the embedded version number is missing, invalid, or not what we require

In future if we need to go through this again, then we simply bump `SMB_CONFIG_VERSION` to a new higher value and set the same version in `packages/network/samba/config/smb.conf`, and job done. Users with older/incompatible custom configs will start using the stock config - ie. will have a working Samba server - until they update their config again.

The downside of  this change does mean that users that have already gone through the process of upgrading their custom config while beta testing 8.1.x will have to update their config once more.

Will backport if no objections/concerns.