### PR TITLE
updated getedid script because of an issue

### DIFF
--- a/packages/sysutils/busybox/scripts/getedid
+++ b/packages/sysutils/busybox/scripts/getedid
@@ -227,7 +227,7 @@ nvidia() {
   
   # set port and uncomment lines
   sed -i "s/#    Option         \"ConnectedMonitor\" \"DFP-0\"/    Option         \"ConnectedMonitor\" \"$nv_port\"/g" /storage/.config/xorg.conf
-  sed -i "s/#    Option         \"CustomEDID\" \"DFP-0:\/storage\/.config\/edid.bin\"/    Option         \"CustomEDID\" \"\"$nv_port\":\/storage\/.config\/edid.bin\"/g" /storage/.config/xorg.conf
+  sed -i "s/#    Option         \"CustomEDID\" \"DFP-0:\/storage\/.config\/edid.bin\"/    Option         \"CustomEDID\" \"$nv_port:\/storage\/.config\/edid.bin\"/g" /storage/.config/xorg.conf
   sed -i "s/#    Option         \"IgnoreEDID\" \"false\"/    Option         \"IgnoreEDID\" \"false\"/g" /storage/.config/xorg.conf
   sed -i "s/#    Option         \"UseEDID\" \"true\"/    Option         \"UseEDID\" \"true\"/g" /storage/.config/xorg.conf
 


### PR DESCRIPTION
Seen a user at IRC and he has shown his xorg.conf where the specific line looks like:

Option         "CustomEDID" ""DFP-1":/storage/.config/edid.bin"

So there's a `"` too much in front of the "DFP-1" which should now be fixed.