### PR TITLE
kodi: make it possible to use 352 khz and 384 khz with S/PDIF

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.18-PR12783-spdif-rates.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.18-PR12783-spdif-rates.patch
@@ -1,0 +1,58 @@
+From 9eb00725944eb12abc096dce3de475af29a65886 Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Sat, 9 Sep 2017 06:41:52 +0200
+Subject: [PATCH 1/2] Language: Add description for SPDIF 352.8 and 384 khz
+
+---
+ addons/resource.language.en_gb/resources/strings.po | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
+index 0d0a2afbd1e6..eaa22308a95e 100644
+--- a/addons/resource.language.en_gb/resources/strings.po
++++ b/addons/resource.language.en_gb/resources/strings.po
+@@ -16383,8 +16383,20 @@ msgctxt "#34128"
+ msgid "192.0"
+ msgstr ""
+ 
++#. SPDIF max sampling rate
++#: system/settings/settings.xml
++msgctxt "#34129"
++msgid "352.8"
++msgstr ""
++
++#. SPDIF max sampling rate
++#: system/settings/settings.xml
++msgctxt "#34130"
++msgid "384.0"
++msgstr ""
++
+ #empty strings from id 34129 to 34200
+-#34129-34200 reserved for future use
++#34131-34200 reserved for future use
+ 
+ #: xbmc/PlayListPlayer.cpp
+ msgctxt "#34201"
+
+From 03b4396b466ea7c19e70313619c75577b3dd250a Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Sat, 9 Sep 2017 06:42:13 +0200
+Subject: [PATCH 2/2] Settings: Make 352.8 khz and 384 khz available for SPDIF
+
+---
+ system/settings/settings.xml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/system/settings/settings.xml b/system/settings/settings.xml
+index 763ab04833bf..7b011c2211a7 100755
+--- a/system/settings/settings.xml
++++ b/system/settings/settings.xml
+@@ -2580,6 +2580,8 @@
+               <option label="34126">88200</option>
+               <option label="34127">96000</option>
+               <option label="34128">192000</option>
++              <option label="34129">352800</option>
++              <option label="34130">384000</option>
+             </options>
+           </constraints>
+           <control type="list" format="integer" />


### PR DESCRIPTION
adding patch to extend the rates usable with S/PDIF as per https://forum.libreelec.tv/thread/9823-solved-audio-output-device-192khz-to-384khz-sampling-rates