### PR TITLE
linux: enable SMB211 as default for CIFS

### DIFF
--- a/packages/linux/patches/linux-020_default_SMB211_for_CIFS.patch
+++ b/packages/linux/patches/linux-020_default_SMB211_for_CIFS.patch
@@ -1,0 +1,17 @@
+diff --git a/fs/cifs/connect.c b/fs/cifs/connect.c
+index d95744d..3b75c7e 100644
+--- a/fs/cifs/connect.c
++++ b/fs/cifs/connect.c
+@@ -1270,9 +1270,9 @@ cifs_parse_mount_options(const char *mountdata, const char *devname,
+ 
+ 	vol->actimeo = CIFS_DEF_ACTIMEO;
+ 
+-	/* FIXME: add autonegotiation -- for now, SMB1 is default */
+-	vol->ops = &smb1_operations;
+-	vol->vals = &smb1_values;
++	/* FIXME: add autonegotiation -- for now, SMB2.1 is default */
++	vol->ops = &smb21_operations;
++	vol->vals = &smb21_values;
+ 
+ 	vol->echo_interval = SMB_ECHO_INTERVAL_DEFAULT;
+


### PR DESCRIPTION
This is a temporary libreelec-8.2-only fix that rounds out the recent Samba changes and brings CIFS up to par with the Samba server (min protocol=SMB2).

The patch applies cleanly on all kernels (v4 and v3), but I've only built and tested v4.x (RPi/RPi2/Generic) so other platform maintainers **please test**.

Kernel 4.14 may  have [protocol auto-negotiation](https://patchwork.kernel.org/patch/9932955/), but that's unlikely to be supported by v3.x kernels in which case this patch may have to be adapted for v3.x kernels in LE9. Maybe one of the v3.x platform maintainers would like to contribute that fix.