### PR TITLE
bluetooth-audio: add needed strings.po header, version 102

### DIFF
--- a/packages/addons/service/bluetooth-audio/changelog.txt
+++ b/packages/addons/service/bluetooth-audio/changelog.txt
@@ -1,3 +1,6 @@
+102
+- Add strings.po header
+
 101
 - Fix log errors
 

--- a/packages/addons/service/bluetooth-audio/package.mk
+++ b/packages/addons/service/bluetooth-audio/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="bluetooth-audio"
 PKG_VERSION="0"
-PKG_REV="101"
+PKG_REV="102"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""

--- a/packages/addons/service/bluetooth-audio/source/resources/language/English/strings.po
+++ b/packages/addons/service/bluetooth-audio/source/resources/language/English/strings.po
@@ -2,6 +2,14 @@
 # Addon Name: bluetooth-audio
 # Addon id: service.bluetooth-audio
 
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 msgctxt "#30000"
 msgid "Settings"
 msgstr ""


### PR DESCRIPTION
Kodi refuses to load strings.po without it:

```
ERROR: POParser: unable to read PO file header from file: /storage/.kodi/addons/service.bluetooth-audio/resources/language/English/strings.po
```
Completes #1942