### PR TITLE
RTL8192EU: Update to new branch

### DIFF
--- a/packages/linux-drivers/RTL8192EU/package.mk
+++ b/packages/linux-drivers/RTL8192EU/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="RTL8192EU"
-PKG_VERSION="c23c613"
+PKG_VERSION="192bad4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/Mange/rtl8192eu-linux-driver"


### PR DESCRIPTION
Update from v4.3.1.1_11320.20140505 to v4.4.1

Backport of #1973 & #1984
