### PR TITLE
RPi: add alsa card conf for IQAudIODigi to enable passthrough

### DIFF
--- a/projects/RPi/filesystem/usr/share/alsa/cards/IQAudIODigi.conf
+++ b/projects/RPi/filesystem/usr/share/alsa/cards/IQAudIODigi.conf
@@ -1,0 +1,24 @@
+<confdir:pcm/iec958.conf>
+IQAudIODigi.pcm.iec958.0 {
+    @args [ CARD AES0 AES1 AES2 AES3 ]
+    @args.CARD {
+        type string
+    }
+    @args.AES0 {
+        type integer
+    }
+    @args.AES1 {
+        type integer
+    }
+    @args.AES2 {
+        type integer
+    }
+    @args.AES3 {
+        type integer
+    }
+    type hooks
+    slave.pcm {
+        type hw
+        card $CARD
+    }
+}


### PR DESCRIPTION
This should fix this: https://forum.libreelec.tv/thread/9889-iqaudio-pi-digi-passthrough-not-available/

Wait for confirmation if fix is correct before merging