### PR TITLE
RTL8192EU: Revert delete to maintain compatibility with AmLogic Kernel

### DIFF
--- a/packages/linux-drivers/RTL8192EU/patches/RTL8192EU-0101-gcc-5.patch
+++ b/packages/linux-drivers/RTL8192EU/patches/RTL8192EU-0101-gcc-5.patch
@@ -1,0 +1,25 @@
+diff -Naur a/include/ieee80211.h b/include/ieee80211.h
+--- a/include/ieee80211.h
++++ b/include/ieee80211.h
+@@ -1314,18 +1314,18 @@
+ (((Addr[2]) & 0xff) == 0xff) && (((Addr[3]) & 0xff) == 0xff) && (((Addr[4]) & 0xff) == 0xff) && \
+ (((Addr[5]) & 0xff) == 0xff))
+ #else
+-extern __inline int is_multicast_mac_addr(const u8 *addr)
++static __inline int is_multicast_mac_addr(const u8 *addr)
+ {
+         return ((addr[0] != 0xff) && (0x01 & addr[0]));
+ }
+ 
+-extern __inline int is_broadcast_mac_addr(const u8 *addr)
++static __inline int is_broadcast_mac_addr(const u8 *addr)
+ {
+ 	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
+ 		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
+ }
+ 
+-extern __inline int is_zero_mac_addr(const u8 *addr)
++static __inline int is_zero_mac_addr(const u8 *addr)
+ {
+ 	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
+ 		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));


### PR DESCRIPTION
Fix error caused by #1973 on S905 builds like WeTek_Play_2

If the patch is related to one especific kernel mabye made sense move it to 
projects/[device]/patches/RTL8192EU/*.patch