### PR TITLE
kernel-firmware: add ar3k firmware for Asus Chromebook M004U

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
@@ -4,6 +4,7 @@ rt2561.bin
 rt2561s.bin
 rt2661.bin
 rt2860.bin
+ar3k/*.dfu
 intel/dsp_fw_{bxtn,glk,kbl,release}.bin
 intel/fw_sst_*.bin*
 intel/ibt-*.{ddc,sfi,bseq}


### PR DESCRIPTION
Reported here: https://forum.kodi.tv/showthread.php?tid=298462&pid=2645455#pid2645455
```
[    3.672332] usb 1-4: Direct firmware load for ar3k/AthrBT_0x11020000.dfu failed with error -2
[    3.672338] Bluetooth: Patch file not found ar3k/AthrBT_0x11020000.dfu
[    3.672339] Bluetooth: Loading patch file failed
[    3.672349] ath3k: probe of 1-4:1.0 failed with error -2
[    3.672392] usbcore: registered new interface driver ath3k
[    3.675236] usbcore: registered new interface driver btusb
```
Confirmed fixed here: https://forum.kodi.tv/showthread.php?tid=298462&pid=2646777#pid2646777

~~Will backport.~~ Backport not necessary, ar3k [already included](https://github.com/LibreELEC/LibreELEC.tv/blob/libreelec-8.2/packages/linux-firmware/kernel-firmware/firmwares/any.dat#L1).