### PR TITLE
RPi: update firmware to 756dd85 (stable)

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="b2420fc"
+PKG_VERSION="756dd85"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="b2420fc"
+PKG_VERSION="756dd85"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"


### PR DESCRIPTION
Latest "stable" RPi firmware for libreelec-8.2. This includes the CEC button fix tested [here](https://forum.kodi.tv/showthread.php?tid=280408&pid=2646517#pid2646517).