### PR TITLE
init: recover from a failed upgrade

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -779,8 +779,16 @@
       return 0
     fi
 
-    # remove temporary folder if exist from previous run
-    rm -fr "$UPDATE_DIR/.tmp" &>/dev/null
+    if [ -d $UPDATE_DIR/.tmp ]; then
+      echo "Failed update detected - performing recovery."
+      echo ""
+      do_cleanup
+      StartProgress countdown "Normal startup in 10s... " 10 "NOW"
+      return 0
+    fi
+
+    mkdir -p $UPDATE_DIR/.tmp &>/dev/null
+    sync
 
     echo "UPGRADE IN PROGRESS"
     echo ""
@@ -793,7 +801,6 @@
       echo "Found new .tar archive"
       UPDATE_FILENAME="$UPDATE_TAR"
       StartProgress spinner "Extracting contents of archive... "
-        mkdir -p $UPDATE_DIR/.tmp &>/dev/null
         tar -xf "$UPDATE_TAR" -C $UPDATE_DIR/.tmp 1>/dev/null 2>/tmp/tarresult.txt || TARRESULT="1"
 
       if [ "${TARRESULT}" -eq "0" ]; then


### PR DESCRIPTION
In the event of a failed upgrade, the user will be dumped into the debug shell. If they have a keyboard and know what they're doing, they can manage their way out of the situation, but most users will power cycle the machine. And when the machine boots, it will find the upgrade files, and repeat the upgrade (and fail, etc.)

This change will use the `/storage/update/.tmp` folder as a marker that an upgrade is already in progress, and if found it will clean the files and continue with a normal boot. So in the case where the user power cycles their machine, on the next boot LibreELEC will start more or less cleanly.