### PR TITLE
linux: bump Amlogic 3.14 kernel to c8c32b4

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -35,7 +35,7 @@ case "$LINUX" in
     PKG_PATCH_DIRS="amlogic-3.10"
     ;;
   amlogic-3.14)
-    PKG_VERSION="f6f2e4c"
+    PKG_VERSION="c8c32b4"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_DIR="$PKG_NAME-amlogic-$PKG_VERSION*"
     PKG_PATCH_DIRS="amlogic-3.14"


### PR DESCRIPTION
This provides the fix for the bluebourne kernel vulnerability and fixes the IR remote on Hub/C2 after recent RC core changes.