### PR TITLE
bluez: update to bluez-5.47

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="bluez"
-PKG_VERSION="5.45"
-PKG_SHA256="4cacb00703a6bc149cb09502257d321597d43952374a16f3558766ffa85364e9"
+PKG_VERSION="5.47"
+PKG_SHA256="cf75bf7cd5d564f21cc4a2bd01d5c39ce425397335fd47d9bbe43af0a58342c8"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"

--- a/packages/network/bluez/patches/bluez-12_sixaxis-add-support-for-setting-SDP-record.patch
+++ b/packages/network/bluez/patches/bluez-12_sixaxis-add-support-for-setting-SDP-record.patch
@@ -29,7 +29,7 @@ index 3ef0340..859aa3c 100644
 +	if (!rec)
 +		return;
 +
-+	req = browse_request_new(device, NULL);
++	req = browse_request_new(device, BROWSE_SDP, NULL);
 +	if (!req)
 +		return;
 +
@@ -46,7 +46,7 @@ index 3ef0340..859aa3c 100644
 +	g_dbus_emit_property_changed(dbus_conn, req->device->path,
 +						DEVICE_INTERFACE, "UUIDs");
 +
-+	device_svc_resolved(device, device->bdaddr_type, 0);
++	device_svc_resolved(device, BROWSE_SDP, device->bdaddr_type, 0);
 +}
 +
  const sdp_record_t *btd_device_get_record(struct btd_device *device,


### PR DESCRIPTION
Fixes BlueBorne/CVE-2017-1000250

5.46 [announcement](http://www.bluez.org/release-of-bluez-5-46) / [changelog](https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/ChangeLog?id=46f47fc8a1683100c7d08200f420fbb41a3a6754)
5.47 [announcement](http://www.bluez.org/release-of-bluez-5-47) / [changelog](https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/ChangeLog?id=d139fd866241fe0d99b5e430f937c8d6160cc7dd)

Not really sure about the `BROWSE_SDP` change - the only other browse type is `BROWSE_GATT`, in which case `BROWSE_SDP` seemed the logical choice...

`BROWSE_SDP`/`BROWSE_GATT` parameters added [here](https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/src/device.c?id=5252296b725ef159992be5372f60721bd9adca48), as a fix for this [change](https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/src/device.c?id=006213cf4d231ce66de273e96619474bd516359b).