### PR TITLE
samba: update to samba-4.6.8

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="samba"
-PKG_VERSION="4.6.7"
-PKG_SHA256="9ef24393de08390f236cabccd6a420b5cea304e959cbf1a99ff317325db3ddfa"
+PKG_VERSION="4.6.8"
+PKG_SHA256="581deeb2543f5cedcb556cb950d0e82690d9f0cd33811d76624502ca0c32575d"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"


### PR DESCRIPTION
This is a security release in order to address the following defects:

*  [CVE-2017-12150](https://www.samba.org/samba/security/CVE-2017-12150.html) (SMB1/2/3 connections may not require signing where they should)
*  [CVE-2017-12151](https://www.samba.org/samba/security/CVE-2017-12151.html) (SMB3 connections don't keep encryption across DFS redirects)
*  [CVE-2017-12163](https://www.samba.org/samba/security/CVE-2017-12163.html) (Server memory information leak over SMB1)

Release Notes: https://www.samba.org/samba/history/samba-4.6.8.html