### PR TITLE
ArchLinux openjdk and libjson-perl

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -34,6 +34,11 @@ test_libjson-perl()
   perl -MJSON -e 'exit(0);' 2>/dev/null
 }
 
+test_perl-json()
+{
+  test_libjson-perl
+}
+
 if  [ -f /etc/lsb-release ]; then
   DISTRO=$(grep DISTRIB_ID /etc/lsb-release | cut -d "=" -f 2 | tr A-Z a-z)
 fi

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -63,7 +63,7 @@ case "$DISTRO" in
       ;;
     arch)
       deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java"
-      deps_pkg="$deps_pkg g++ xorg-mkfontscale xorg-mkfontdir xorg-bdftopcf libxslt java-runtime-common"
+      deps_pkg="$deps_pkg g++ xorg-mkfontscale xorg-mkfontdir xorg-bdftopcf libxslt java-runtime-common jdk8-openjdk"
       ;;
     opensuse)
       deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java"
@@ -78,7 +78,14 @@ esac
 
 if ! test_libjson-perl; then
   files="$files perl/JSON.pm"
-  files_pkg="$files_pkg libjson-perl"
+  case "$DISTRO" in
+    arch)
+      files_pkg="$files_pkg perl-json"
+      ;;
+    *)
+      files_pkg="$files_pkg libjson-perl"
+      ;;
+    esac
 fi
 
 # project specific dependencies


### PR DESCRIPTION
openjdk should be added to deps_pkg:
https://www.archlinux.org/packages/extra/x86_64/jdk8-openjdk/

libjson-perl does not exist on ArchLinux, but perl-json does:
https://www.archlinux.org/packages/community/any/perl-json/