### PR TITLE
Fix perl/JSON.pm dependency on OpenSUSE and CentOS

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -39,6 +39,11 @@ test_perl-json()
   test_libjson-perl
 }
 
+test_perl-JSON()
+{
+  test_libjson-perl
+}
+
 if  [ -f /etc/lsb-release ]; then
   DISTRO=$(grep DISTRIB_ID /etc/lsb-release | cut -d "=" -f 2 | tr A-Z a-z)
 fi
@@ -86,6 +91,9 @@ if ! test_libjson-perl; then
   case "$DISTRO" in
     arch)
       files_pkg="$files_pkg perl-json"
+      ;;
+    fedora|centos|rhel|opensuse)
+      files_pkg="$files_pkg perl-JSON"
       ;;
     *)
       files_pkg="$files_pkg libjson-perl"


### PR DESCRIPTION
In OpenSuSE and CentOS perl/JSON.pm provided by package perl-JSON