### PR TITLE
kodi: switch to using find to avoid argument limit

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi.sh
+++ b/packages/mediacenter/kodi/scripts/kodi.sh
@@ -91,7 +91,7 @@ if command_exists gdb; then
 fi
 
 # clean up any stale cores. just in case
-rm -f /storage/.cache/cores/*
+find /storage/.cache/cores -type f -delete
 
 # clean zero-byte database files that prevent migration/startup
 for file in /storage/.kodi/userdata/Database/*.db; do


### PR DESCRIPTION
Reported in forum: https://forum.libreelec.tv/thread/9995-libreelec-8-1-1-black-screen-with-mouse-pointer/?postID=63793#post63793

From `journalctl`:
```
Sep 23 10:30:58 LibreELEC kodi.sh[619]: /usr/lib/kodi/kodi.sh: line 94: rm: Argument list too long
```

Problem is due to 34694 core files:
```
-rw-------    1 root     root       8654848 Aug  7 14:35 core.!storage!.kodi!addons!plugin.audio.spotify!resources!lib!spotty!x86-linux!spotty-x86_64.1502130943.727
-rw-------    1 root     root       8654848 Aug  7 14:36 core.!storage!.kodi!addons!plugin.audio.spotify!resources!lib!spotty!x86-linux!spotty-x86_64.1502130974.823
-rw-------    1 root     root      10752000 Aug  7 14:37 core.!storage!.kodi!addons!plugin.audio.spotify!resources!lib!spotty!x86-linux!spotty-x86_64.1502131044.900
-rw-------    1 root     root      10752000 Aug  7 14:37 core.!storage!.kodi!addons!plugin.audio.spotify!resources!lib!spotty!x86-linux!spotty-x86_64.1502131055.910
-rw-------    1 root     root      10752000 Aug  7 14:38 core.!storage!.kodi!addons!plugin.audio.spotify!resources!lib!spotty!x86-linux!spotty-x86_64.1502131094.951
```
etc.

Obviously the Spotify plugin has a problem, but we should handle cleaning up the cores folder better than we currently do.