### PR TITLE
repo tool: fixes for DEVICE support

### DIFF
--- a/tools/repo-tool
+++ b/tools/repo-tool
@@ -69,7 +69,7 @@ update_addons_xml() {
 
 touch_addons_xml() {
   for PROJECT in $(ls -1 projects); do
-    if [ -p "$projects/$PROJECT/devices" ]; then
+    if [ -d "projects/$PROJECT/devices" ]; then
       for DEVICE in $(ls -1 projects/$PROJECT/devices); do
         for archfile in projects/$PROJECT/devices/$DEVICE/linux/linux.*.conf; do
           ARCH=`echo $archfile | sed -n '$s/\.conf//;$s/.*\.//p'`


### PR DESCRIPTION
The test for the device directory was wrong and Slice, Slice3 weren't handled as devices