### PR TITLE
lirc: fix install location of python-package

### DIFF
--- a/packages/sysutils/lirc/package.mk
+++ b/packages/sysutils/lirc/package.mk
@@ -40,6 +40,7 @@ pre_configure_target() {
   export HAVE_WORKING_POLL=yes
   export HAVE_UINPUT=yes
   export PYTHON=:
+  export PYTHON_VERSION=2.7
   if [ -e ${SYSROOT_PREFIX}/usr/include/linux/input-event-codes.h ] ; then
     export DEVINPUT_HEADER=${SYSROOT_PREFIX}/usr/include/linux/input-event-codes.h
   else


### PR DESCRIPTION
without lirc-python package is installed under /usr/lib/python instead of /usr/lib/python2.7
ping @HiassofT 

(leads to problems, when building libxcb after lirc)