### PR TITLE
settings: bump to fix backup free-space calc

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="2ef3940"
+PKG_VERSION="12c5f24"
 PKG_ARCH="any"
 PKG_LICENSE="prop."
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
This resolves an issue with the free space calculation for backups