### PR TITLE
lirc: don't install python scripts

### DIFF
--- a/packages/sysutils/lirc/patches/lirc-0100-disable-python.patch
+++ b/packages/sysutils/lirc/patches/lirc-0100-disable-python.patch
@@ -1,8 +1,28 @@
 diff --git a/Makefile.am b/Makefile.am
-index ba7150c..609b050 100644
+index aafb4e8c..f33a0c19 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -39,7 +39,7 @@ if WITH_SYSTEMDSYSTEMUNITDIR
+@@ -5,7 +5,9 @@ ACLOCAL_AMFLAGS         = -I m4
+ AUTOMAKE_OPTIONS        = 1.5 check-news dist-bzip2 -Wno-portability \
+                           subdir-objects
+ 
++if HAVE_PYTHON
+ include                 pylint.mak
++endif
+ 
+ GIT_COMMIT      = $(shell git log -1 --pretty=format:%h || echo UNKNOWN)
+ GIT_DATE        = $(shell git log -1 --pretty=format:%cd || echo UNKNOWN)
+@@ -34,13 +36,17 @@ MANTAINERCLEANFILES     = config.sub install-sh depcomp py-compile \
+ AM_DISTCHECK_CONFIGURE_FLAGS = \
+     --with-systemdsystemunitdir=$${dc_install_base}/lib/systemd/system
+ 
++if HAVE_PYTHON
+ BUILT_SOURCES           = paths.h python-pkg/lirc/config.py python-pkg/VERSION
++else
++BUILT_SOURCES           = paths.h
++endif
+ 
+ if WITH_SYSTEMDSYSTEMUNITDIR
      SYSTEMD_DIR         = systemd
  endif
  
@@ -11,7 +31,7 @@ index ba7150c..609b050 100644
  
  if INSTALL_ETC
  
-@@ -60,6 +60,7 @@ endif
+@@ -61,6 +67,7 @@ endif
  
  dist_doc_DATA           = VERSION
  
@@ -19,7 +39,7 @@ index ba7150c..609b050 100644
  nodist_pkgdata_DATA     = $(PYTHON_TARBALL)
  
  pkgconfigdir            = $(libdir)/pkgconfig
-@@ -133,6 +134,8 @@ all-local:
+@@ -134,6 +141,8 @@ all-local:
  	    $(if $(VERBOSE),,-q) build
  endif
  
@@ -28,8 +48,24 @@ index ba7150c..609b050 100644
  install-data-hook:
  	$(SED) -i -e '/^plugindir/s|/usr/lib|$(libdir)|' \
  	    $(DESTDIR)$(lirc_confdir)/lirc_options.conf
+@@ -167,6 +176,7 @@ fix-version: .phony
+ 	$(SED) -i '/DATE/s/=.*/="$(GIT_DATE)"/' $(distdir)/VERSION
+ 	$(SED) -i '/REFS/s|=.*|="$(GIT_REFS)"|' $(distdir)/VERSION
+ 
++if HAVE_PYTHON
+ $(abs_builddir)/python-pkg/setup.py:
+ 	cp -ar $(top_srcdir)/python-pkg  $(abs_builddir)
+ 	chmod -R u+w  python-pkg
+@@ -190,6 +200,7 @@ python-pkg/lirc/config.py: Makefile  $(abs_builddir)/python-pkg/setup.py
+ 	@echo 'DOCDIR = "$(docdir)"' >>$@
+ 	@echo 'MODINFO = "$(MODINFO)"' >>$@
+ 	@echo 'VERSION = "$(VERSION)"' >>$@
++endif
+ 
+ paths.h: Makefile
+ 	@echo "#ifndef PATHS_H"          >paths.h
 diff --git a/configure.ac b/configure.ac
-index 4268e31..b43904c 100644
+index 321a61f7..016813c1 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -43,7 +43,8 @@ AC_CHECK_PROG([DOXYGEN],[doxygen],[yes],[no])
@@ -50,3 +86,33 @@ index 4268e31..b43904c 100644
  AX_REPORT_CONDITIONAL([HAVE_PYTHON35])
  
  echo
+diff --git a/tools/Makefile.am b/tools/Makefile.am
+index abfb9911..8aff1cff 100644
+--- a/tools/Makefile.am
++++ b/tools/Makefile.am
+@@ -71,12 +71,17 @@ xmode2_SOURCES          = xmode2.cpp
+ xmode2_LDADD            = @X_LIBS@ @X_PRE_LIBS@ -lX11 @X_EXTRA_LIBS@ \
+                           $(LIRC_LIBS)
+ 
++if HAVE_PYTHON
+ dist_bin_SCRIPTS        = lirc-config-tool lirc-init-db
++else
++dist_bin_SCRIPTS	=
++endif
+ 
+ if HAVE_DEVINPUT
+ dist_bin_SCRIPTS        += lirc-make-devinput
+ endif
+ 
++if HAVE_PYTHON
+ dist_bin_SCRIPTS        += pronto2lirc irdb-get irtext2udp
+ dist_sbin_SCRIPTS       = lircd-setup
+ dist_noinst_SCRIPTS     = make_rel_symlink.py check_configs.py
+@@ -121,6 +126,7 @@ install-data-hook:
+ 	$(PYTHON) $(srcdir)/make_rel_symlink.py \
+ 	    $(DESTDIR)/$(pkgdatadir)/configs \
+ 	        $(DESTDIR)/$(setupdir)/configs
++endif
+ 
+ uninstall-hook:
+ 	rm -f $(DESTDIR)/$(bindir)/lirc-setup \


### PR DESCRIPTION
Lirc python scripts need python 3 or newer (ideally 3.5) so won't work in LE.

Don't install them in the target image and sysroot to avoid build conflicts. See #2040