### PR TITLE
boost: update to 1.65.1, add chrono, date_time, python and random

### DIFF
--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -17,20 +17,14 @@
 ################################################################################
 
 PKG_NAME="boost"
-PKG_VERSION="1_61_0"
-PKG_SHA256="a547bd06c2fd9a71ba1d169d9cf0339da7ebf4753849a8f7d6fdb8feee99b640"
-PKG_ARCH="any"
+PKG_VERSION="1_65_1"
+PKG_SHA256="9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.boost.org/"
-PKG_URL="$SOURCEFORGE_SRC/boost/boost/1.61.0/${PKG_NAME}_${PKG_VERSION}.tar.bz2"
+PKG_URL="$SOURCEFORGE_SRC/boost/boost/1.65.1/${PKG_NAME}_${PKG_VERSION}.tar.bz2"
 PKG_SOURCE_DIR="${PKG_NAME}_${PKG_VERSION}"
-PKG_DEPENDS_HOST=""
-PKG_DEPENDS_TARGET="toolchain boost:host Python:host zlib bzip2"
-PKG_SECTION="devel"
-PKG_SHORTDESC="boost: Peer-reviewed STL style libraries for C++"
-PKG_LONGDESC="Boost provides free peer-reviewed portable C++ source libraries. The emphasis is on libraries which work well with the C++ Standard Library. One goal is to establish existing practice and provide reference implementations so that the Boost libraries are suitable for eventual standardization. Some of the libraries have already been proposed for inclusion in the C++ Standards Committee's upcoming C++ Standard Library Technical Report."
-
-PKG_IS_ADDON="no"
+PKG_DEPENDS_TARGET="toolchain boost:host Python zlib bzip2"
+PKG_LONGDESC="boost: Peer-reviewed STL style libraries for C++"
 PKG_AUTORECONF="no"
 
 make_host() {
@@ -44,34 +38,38 @@ makeinstall_host() {
 }
 
 pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-  export CXXFLAGS="$CXXFLAGS -fPIC"
-  export LDFLAGS="$LDFLAGS -fPIC"
+  export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/python2.7 -fPIC"
+  export CXXFLAGS="$CXXFLAGS -I$SYSROOT_PREFIX/usr/include/python2.7 -fPIC"
 }
 
 configure_target() {
   sh bootstrap.sh --prefix=/usr \
                   --with-bjam=$TOOLCHAIN/bin/bjam \
                   --with-python=$TOOLCHAIN/bin/python \
+                  --with-python-root=$SYSROOT_PREFIX/usr
 
   echo "using gcc : `$CC -v 2>&1  | tail -n 1 |awk '{print $3}'` : $CC  : <compileflags>\"$CFLAGS\" <linkflags>\"$LDFLAGS\" ;" \
     > tools/build/src/user-config.jam
 }
 
 make_target() {
-  : # nothing todo, we use makeinstall_target()
+  :
 }
 
 makeinstall_target() {
-  $TOOLCHAIN/bin/bjam -d2 --toolset=gcc link=static \
-                                --prefix=$SYSROOT_PREFIX/usr \
-                                --ignore-site-config \
-                                --layout=system \
-                                --with-thread \
-                                --with-iostreams \
-                                --with-system \
-                                --with-serialization \
-                                --with-filesystem \
-                                --with-regex -sICU_PATH="$SYSROOT_PREFIX/usr" \
-                                install
+  $TOOLCHAIN/bin/bjam -d2 --ignore-site-config \
+                          --layout=system \
+                          --prefix=$SYSROOT_PREFIX/usr \
+                          --toolset=gcc link=static \
+                          --with-chrono \
+                          --with-date_time \
+                          --with-filesystem \
+                          --with-iostreams \
+                          --with-python \
+                          --with-random \
+                          --with-regex -sICU_PATH="$SYSROOT_PREFIX/usr" \
+                          --with-serialization \
+                          --with-system \
+                          --with-thread \
+                          install
 }


### PR DESCRIPTION
This updates boost and adds chrono, date_time, python and random static libraries, which prove useful to build add-ons. mpd and mysql, which depend on boost, clean build successfully.