### PR TITLE
 u-boot: allow using latest version

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -17,27 +17,38 @@
 ################################################################################
 
 PKG_NAME="dtc"
-PKG_VERSION="1.4.4"
-PKG_SHA256="2d1226634d71655466ebbd090d2873068c4918fbd5c433b91ead8ad08b9a5843"
+PKG_VERSION="1.4.5"
+PKG_SHA256="cfb9394690ebec1e4f942ee0c3b863b660eb0c4ef85bab19429f30c3469a3415"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/"
 PKG_URL="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/$PKG_VERSION.tar.gz"
 PKG_SOURCE_DIR="$PKG_VERSION"
+PKG_DEPENDS_HOST="Python:host swig:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="tools"
 PKG_SHORTDESC="The Device Tree Compiler"
 PKG_LONGDESC="The Device Tree Compiler"
 PKG_AUTORECONF="no"
 
-PKG_MAKE_OPTS_TARGET="dtc"
+PKG_MAKE_OPTS_TARGET="dtc libfdt"
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
     cp -P $PKG_BUILD/dtc $INSTALL/usr/bin
 }
 
+PKG_MAKE_OPTS_HOST="dtc libfdt"
+
 makeinstall_host() {
   mkdir -p $TOOLCHAIN/bin
     cp -P $PKG_BUILD/dtc $TOOLCHAIN/bin
+    cp -P $PKG_BUILD/libfdt/libfdt.so $TOOLCHAIN/lib
+}
+
+post_makeinstall_host() {
+  python ./pylibfdt/setup.py build_ext --inplace
+  python ./pylibfdt/setup.py install --prefix=$TOOLCHAIN
+
+  touch $TOOLCHAIN/lib/python2.7/site-packages/pylibfdt/__init__.py
 }

--- a/packages/tools/dtc/patches/dtc-0001-libfdt-soname-version.patch
+++ b/packages/tools/dtc/patches/dtc-0001-libfdt-soname-version.patch
@@ -1,0 +1,12 @@
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2017-03-09 16:17:23.000000000 -0800
++++ b/Makefile	2017-05-31 16:04:29.052439734 -0700
+@@ -134,7 +134,7 @@
+ LIBFDT_objdir = libfdt
+ LIBFDT_srcdir = libfdt
+ LIBFDT_archive = $(LIBFDT_objdir)/libfdt.a
+-LIBFDT_lib = $(LIBFDT_objdir)/libfdt-$(DTC_VERSION).$(SHAREDLIB_EXT)
++LIBFDT_lib = $(LIBFDT_objdir)/libfdt.$(SHAREDLIB_EXT)
+ LIBFDT_include = $(addprefix $(LIBFDT_srcdir)/,$(LIBFDT_INCLUDES))
+ LIBFDT_version = $(addprefix $(LIBFDT_srcdir)/,$(LIBFDT_VERSION))
+ 

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -33,6 +33,12 @@ elif [ "$UBOOT_VERSION" = "hardkernel" ]; then
   PKG_SITE="https://github.com/hardkernel/u-boot"
   PKG_URL="https://github.com/hardkernel/u-boot/archive/$PKG_VERSION.tar.gz"
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET gcc-linaro-aarch64-elf:host gcc-linaro-arm-eabi:host"
+elif [ "$UBOOT_VERSION" = "default" ]; then
+  PKG_VERSION="2017.09"
+  PKG_SITE=""
+  PKG_URL="ftp://ftp.denx.de/pub/u-boot/u-boot-$PKG_VERSION.tar.bz2"
+  PKG_SOURCE_DIR="u-boot-$PKG_VERSION"
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET dtc:host"
 else
   exit 0
 fi
@@ -61,7 +67,9 @@ pre_configure_target() {
   MAKEFLAGS=-j1
 
 # copy compiler-gcc5.h to compiler-gcc6. for fake building
+if [ -f include/linux/compiler-gcc5.h ]; then
   cp include/linux/compiler-gcc5.h include/linux/compiler-gcc6.h
+fi
 }
 
 make_target() {

--- a/packages/tools/u-boot/patches/2017.09/u-boot-0001-dont-build-libfdt.patch
+++ b/packages/tools/u-boot/patches/2017.09/u-boot-0001-dont-build-libfdt.patch
@@ -1,0 +1,38 @@
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2017-09-11 11:10:40.000000000 -0700
++++ b/Makefile	2017-10-03 13:41:57.992106628 -0700
+@@ -1379,7 +1379,7 @@
+ 	$(call filechk,timestamp.h)
+ 
+ checkbinman: tools
+-	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools $(PYTHON) )); then \
++	@if ! ( echo 'from pylibfdt import libfdt' | ( python )); then \
+ 		echo >&2; \
+ 		echo >&2 '*** binman needs the Python libfdt library.'; \
+ 		echo >&2 '*** Either install it on your system, or try:'; \
+diff -Naur a/tools/dtoc/fdt.py b/tools/dtoc/fdt.py
+--- a/tools/dtoc/fdt.py	2017-09-11 11:10:40.000000000 -0700
++++ b/tools/dtoc/fdt.py	2017-10-03 13:42:18.398306028 -0700
+@@ -10,7 +10,7 @@
+ import sys
+ 
+ import fdt_util
+-import libfdt
++from pylibfdt import libfdt
+ 
+ # This deals with a device tree, presenting it as an assortment of Node and
+ # Prop objects, representing nodes and properties, respectively. This file
+diff -Naur a/tools/Makefile b/tools/Makefile
+--- a/tools/Makefile	2017-09-11 11:10:40.000000000 -0700
++++ b/tools/Makefile	2017-10-03 13:42:33.286451519 -0700
+@@ -232,10 +232,6 @@
+ 
+ always := $(hostprogs-y)
+ 
+-# Build a libfdt Python module if swig is available
+-# Use 'sudo apt-get install swig libpython-dev' to enable this
+-always += $(if $(shell which swig 2> /dev/null),_libfdt.so)
+-
+ # Generated LCD/video logo
+ LOGO_H = $(objtree)/include/bmp_logo.h
+ LOGO_DATA_H = $(objtree)/include/bmp_logo_data.h


### PR DESCRIPTION
I use mainline u-boot for my cubox. so I wanted to PR with the option to build it.

@vpeter4 please test with this. It works great with my cubox i4 I'm not sure if it has support for your other imx6 devices like the tbs matrix and others.