### PR TITLE
add addon broken support to addon building

### DIFF
--- a/config/addon/xbmc.broken.xml
+++ b/config/addon/xbmc.broken.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="@PKG_ADDON_ID@"
+       name="@ADDON_NAME@"
+       version="@ADDON_VERSION@"
+       provider-name="@PROVIDER_NAME@">
+  <requires>
+    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
+    <import addon="xbmc.python" version="2.1.0"/>
+@REQUIRES@
+  </requires>
+  <extension point="xbmc.service" library="default.py">
+    <provides>@PKG_ADDON_PROVIDES@</provides>
+  </extension>
+  <extension point="xbmc.addon.metadata">
+    <summary>@PKG_SHORTDESC@</summary>
+    <description>
+@PKG_LONGDESC@
+    </description>
+    <disclaimer>
+@PKG_DISCLAIMER@
+    </disclaimer>
+    <broken>
+@PKG_ADDON_BROKEN@
+    </broken>
+    <platform>all</platform>
+    <news>
+@PKG_ADDON_NEWS@
+    </news>
+    <assets>
+      <icon>resources/icon.png</icon>
+      <fanart>resources/fanart.png</fanart>
+@PKG_ADDON_SCREENSHOT@
+    </assets>
+  </extension>
+</addon>

--- a/packages/addons/service/tvheadend/package.mk
+++ b/packages/addons/service/tvheadend/package.mk
@@ -1,0 +1,48 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="tvheadend"
+PKG_VERSION="1.0"
+PKG_REV="100"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE=""
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="service"
+PKG_SHORTDESC="Add-on removed"
+PKG_LONGDESC="Add-on removed"
+PKG_AUTORECONF="no"
+
+PKG_ADDON_BROKEN="Tvheadend 4.0 is no longer maintained and has been superseded by Tvheadend 4.2."
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_NAME="Tvheadend Server 4.0"
+PKG_ADDON_TYPE="xbmc.broken"
+
+make_target() {
+  :
+}
+
+makeinstall_target() {
+  :
+}
+
+addon() {
+  :
+}

--- a/scripts/install_addon
+++ b/scripts/install_addon
@@ -79,10 +79,12 @@ PROVIDER_NAME="Team LibreELEC"
 if [ ! -z "$PKG_MAINTAINER" ] ; then
   PROVIDER_NAME="$PKG_MAINTAINER"
 fi
+
 ADDON_NAME="$PKG_NAME"
 if [ ! -z "$PKG_ADDON_NAME" ] ; then
   ADDON_NAME="$PKG_ADDON_NAME"
 fi
+
 $SED -e "s|@PKG_ADDON_ID@|$PKG_ADDON_ID|g" \
      -e "s|@ADDON_NAME@|$ADDON_NAME|g" \
      -e "s|@ADDON_VERSION@|$ADDON_VERSION.$PKG_REV|g" \
@@ -94,6 +96,7 @@ $SED -e "s|@PKG_ADDON_ID@|$PKG_ADDON_ID|g" \
      -e "s|@PROVIDER_NAME@|$PROVIDER_NAME|g" \
      -e "s|@PKG_ADDON_PROVIDES@|$PKG_ADDON_PROVIDES|g" \
      -e "s|@PKG_ADDON_SCREENSHOT@|$PKG_ADDON_SCREENSHOT|g" \
+     -e "s|@PKG_ADDON_BROKEN@|$PKG_ADDON_BROKEN|g" \
      -i $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
 
 debug_strip $ADDON_BUILD/$PKG_ADDON_ID


### PR DESCRIPTION
- adds the possibility to mark an addon as broken

it is required to fill in some reason
`PKG_ADDON_BROKEN="some description why it is broken"`
and change the `PKG_ADDON_TYPE` to
`PKG_ADDON_TYPE="xbmc.broken"`

tried to add this without disturbing the other addons (as the usage is a corner case)

- added Tvh 4.0 "stub" package that marks Tvh 4.0 as broken at our repo

- support for kodi binary addons is not included yet