### PR TITLE
OC2,WH,WP2: Allow updates between aarch64 and arm

### DIFF
--- a/projects/Odroid_C2/filesystem/usr/share/bootloader/canupdate.sh
+++ b/projects/Odroid_C2/filesystem/usr/share/bootloader/canupdate.sh
@@ -1,0 +1,7 @@
+# Allow upgrades between aarch64 and arm
+PROJECT="Odroid_C2"
+if [ "$1" = "${PROJECT}.aarch64" ] || [ "$1" = "${PROJECT}.arm" ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/projects/WeTek_Hub/filesystem/usr/share/bootloader/canupdate.sh
+++ b/projects/WeTek_Hub/filesystem/usr/share/bootloader/canupdate.sh
@@ -1,0 +1,7 @@
+# Allow upgrades between aarch64 and arm
+PROJECT="WeTek_Hub"
+if [ "$1" = "${PROJECT}.aarch64" ] || [ "$1" = "${PROJECT}.arm" ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/projects/WeTek_Play_2/filesystem/usr/share/bootloader/canupdate.sh
+++ b/projects/WeTek_Play_2/filesystem/usr/share/bootloader/canupdate.sh
@@ -1,0 +1,7 @@
+# Allow upgrades between aarch64 and arm
+PROJECT="WeTek_Play_2"
+if [ "$1" = "${PROJECT}.aarch64" ] || [ "$1" = "${PROJECT}.arm" ]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
Adding a canupdate scripts so we can switch between aarch64 and arm on Odroid_C2, WeTek_Hub, WP2. This will be required once the decision is made to switch to 32bit userspace.