### PR TITLE
scripts/mkimage: rename gpt partitions and use generated serial number

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -342,7 +342,6 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
       BOOTLOADER="$BOOTLOADER" \
       KERNEL_NAME="$KERNEL_NAME" \
       RELEASE_DIR=$RELEASE_DIR \
-      UUID_SYSTEM="$(uuidgen)" \
       UUID_STORAGE="$(uuidgen)" \
       UBOOT_SYSTEM="$UBOOT_SYSTEM" \
       EXTRA_CMDLINE="$EXTRA_CMDLINE" \

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -32,6 +32,12 @@
     exit 1
   fi
 
+  if [ "$BOOTLOADER" = "syslinux" ]; then
+    DISK_LABEL=gpt
+  else
+    DISK_LABEL=msdos
+  fi
+
   STORAGE_SIZE=32 # STORAGE_SIZE must be >= 32 !
 
   DISK_START_PADDING=$(( ($SYSTEM_PART_START + 2048 - 1) / 2048 ))
@@ -71,21 +77,18 @@ trap cleanup SIGINT
   dd if=/dev/zero of="$DISK" bs=1M count="$DISK_SIZE" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
 
 # write a disklabel
-  echo "image: creating partition table..."
-  if [ "$BOOTLOADER" = "syslinux" ]; then
-    parted -s "$DISK" mklabel gpt
-  else
-    parted -s "$DISK" mklabel msdos
-  fi
+  echo "image: creating $DISK_LABEL partition table..."
+  parted -s "$DISK" mklabel $DISK_LABEL
   sync
 
 # create part1
   echo "image: creating part1..."
   SYSTEM_PART_END=$(( $SYSTEM_PART_START + ($SYSTEM_SIZE * 1024 * 1024 / 512) - 1 ))
-  parted -s "$DISK" -a min unit s mkpart primary fat32 $SYSTEM_PART_START $SYSTEM_PART_END
-  if [ "$BOOTLOADER" = "syslinux" ]; then
+  if [ "$DISK_LABEL" = "gpt" ]; then
+    parted -s "$DISK" -a min unit s mkpart system fat32 $SYSTEM_PART_START $SYSTEM_PART_END
     parted -s "$DISK" set 1 legacy_boot on
   else
+    parted -s "$DISK" -a min unit s mkpart primary fat32 $SYSTEM_PART_START $SYSTEM_PART_END
     parted -s "$DISK" set 1 boot on
   fi
   sync
@@ -94,7 +97,11 @@ trap cleanup SIGINT
   echo "image: creating part2..."
   STORAGE_PART_START=$(( $SYSTEM_PART_END + 1 ))
   STORAGE_PART_END=$(( $STORAGE_PART_START + ($STORAGE_SIZE * 1024 * 1024 / 512) - 1 ))
-  parted -s "$DISK" -a min unit s mkpart primary ext4 $STORAGE_PART_START $STORAGE_PART_END
+  if [ "$DISK_LABEL" = "gpt" ]; then
+    parted -s "$DISK" -a min unit s mkpart storage ext4 $STORAGE_PART_START $STORAGE_PART_END
+  else
+    parted -s "$DISK" -a min unit s mkpart primary ext4 $STORAGE_PART_START $STORAGE_PART_END
+  fi
   sync
 
 if [ "$BOOTLOADER" = "syslinux" ]; then

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -118,10 +118,8 @@ fi
   alias mcopy="mcopy -i $DISK@@$OFFSET"
   alias mmd="mmd -i $DISK@@$OFFSET"
 
-  if [ "$BOOTLOADER" = "syslinux" ]; then
+  if [ "$BOOTLOADER" = "syslinux" -o "$BOOTLOADER" = "bcm2835-bootloader" -o "$BOOTLOADER" = "u-boot" ]; then
     mformat -v "$FAT_VOLUME_LABEL" -N "$FAT_SERIAL_NUMBER" ::
-  elif [ "$BOOTLOADER" = "bcm2835-bootloader" -o "$BOOTLOADER" = "u-boot" ]; then
-    mformat -v "$FAT_VOLUME_LABEL" ::
   fi
   sync
 


### PR DESCRIPTION
This PR renames the gpt partitions both named `primary` to `system` and `storage` (cosmetic change).
It also changes to use the pre-generated serial number for the system partition for all bootloaders (not just `syslinux`) and drops the unused `UUID_SYSTEM` variable.