### PR TITLE
config/functions: call show_distro_config

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -539,6 +539,10 @@ show_config() {
   config_message="$config_message\n - Default Skin:\t\t\t $SKIN_DEFAULT"
   config_message="$config_message\n - Include extra fonts:\t\t\t $KODI_EXTRA_FONTS"
 
+  if [ "$(type -t show_distro_config)" = "function" ]; then
+    show_distro_config
+  fi
+
   config_message="$config_message\n"
   config_message="$config_message\n $dashes$dashes$dashes"
   config_message="$config_message\n End Configuration for $DISTRONAME"


### PR DESCRIPTION
This PR adds a call to a `show_distro_config` function for showing distribution specific configuration when running `make image`.

Example of usage:
https://github.com/Kwiboo/LibreELEC.tv/blob/openpht-2.0-rockchip/distributions/OpenPHT/config/functions#L11-L28
```
...

 OpenPHT configuration:
 ======================================================
 - OpenPHT branch:                       openpht-2.0
 - OpenPHT repository:                   git@github.com:Kwiboo/OpenPHTv2.git
 - OpenPHT-Settings repository:          https://github.com/RasPlex/service.openelec.settings.git
 - OpenPHT gitrev:                       5f956509fbb2d1fe1f81db9962022dc4ac391d74
 - OpenPHT version:                      2.0.0.0-5f956509

 Image configuration:
 ======================================================
 - Image version:                        2.0.0.0-5f956509
 - Image name:                           OpenPHT-Embedded-2.0.0.0-5f956509-ROCK64.aarch64

 =================================================================================
 End Configuration for OpenPHT-Embedded
 =================================================================================
```