### PR TITLE
 scripts/unpack: apply more patches

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -125,8 +125,8 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     done
   fi
 
-  for i in $PKG_DIR/patches/$PKG_NAME-*.patch \
-           $PKG_DIR/patches/$PATCH_ARCH/$PKG_NAME-*.patch \
+  for i in $PKG_DIR/patches/*.patch \
+           $PKG_DIR/patches/$PATCH_ARCH/*.patch \
            $PATCH_DIRS_PKG \
            $PKG_DIR/patches/$PKG_VERSION/*.patch \
            $PKG_DIR/patches/$PKG_VERSION/$PATCH_ARCH/*.patch \

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -122,6 +122,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     for patch_dir in $PKG_PATCH_DIRS; do
       [ -d $PKG_DIR/patches/$patch_dir ] && PATCH_DIRS_PKG="$PATCH_DIRS_PKG $PKG_DIR/patches/$patch_dir/*.patch"
       [ -d $PROJECT_DIR/$PROJECT/patches/$PKG_NAME/$patch_dir ] && PATCH_DIRS_PRJ="$PATCH_DIRS_PRJ $PROJECT_DIR/$PROJECT/patches/$PKG_NAME/$patch_dir/*.patch"
+      [ -d $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME/$patch_dir ] && PATCH_DIRS_PRJ="$PATCH_DIRS_PRJ $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME/$patch_dir/*.patch"
     done
   fi
 
@@ -157,6 +158,8 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     else
       if [[ "$thisdir" =~ ^$PKG_DIR/.* ]]; then
         PATCH_DESC="(common - $(basename "$thisdir"))"
+      elif [[ "$thisdir" =~ ^$PROJECT_DIR/.*/devices/.* ]]; then
+        PATCH_DESC="(device - $(basename "$thisdir"))"
       elif [[ "$thisdir" =~ ^$PROJECT_DIR/.* ]]; then
         PATCH_DESC="(project - $(basename "$thisdir"))"
       else


### PR DESCRIPTION
This PR changes the unpack script to apply `*.patch` instead of `$PKG_NAME-*.patch` inside the package specific `patches` folder (same as all other patch locations).
Allows for OpenPHT to reuse kodi patches by using a symlink to `kodi`, see https://github.com/Kwiboo/LibreELEC.tv/commit/0d4455dc4f5d208b76715ffb30d9cdde0fc61bc5.

It also adds support for having device specific `PKG_PATCH_DIRS` patches, useful for a project that supports multiple `LINUX` versions (rockchip-4.4 and rockchip-4.14).