### PR TITLE
buildsystem: more optimisations

### DIFF
--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -6,7 +6,7 @@
 # determine architecture's family
   TARGET_SUBARCH=x86_64
 
-  TARGET_GCC_ARCH=$(echo $TARGET_SUBARCH | sed -e "s,-,,")
+  TARGET_GCC_ARCH="${TARGET_SUBARCH/-/}"
   TARGET_KERNEL_ARCH=x86
 
 # setup ARCH specific *FLAGS

--- a/config/functions
+++ b/config/functions
@@ -171,6 +171,11 @@ get_pkg_variable() {
   fi
 }
 
+# return 0 if $2 in space-separated list $1, otherwise return 1
+listcontains() {
+  [[ ${1} =~ (^|[[:space:]])${2}($|[[:space:]]) ]] && return 0 || return 1
+}
+
 install_binary_addon() {
   local addon_name="$1" addon_id="$2" addon_so
 

--- a/config/optimize
+++ b/config/optimize
@@ -31,7 +31,7 @@ HOST_CPPFLAGS=""
 HOST_CFLAGS="-O2 -Wall -pipe -I$TOOLCHAIN/include"
 HOST_CXXFLAGS="$HOST_CFLAGS"
 HOST_LDFLAGS="-Wl,-rpath,$TOOLCHAIN/lib -L$TOOLCHAIN/lib"
-HOST_LIBDIR="$TOOLCHAIN/lib"
+HOST_INCDIR="$TOOLCHAIN/include /usr/include"
 
 # work around Ubuntu default C*FLAGS 
 # see https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-Wformat_-Wformat-security
@@ -39,35 +39,40 @@ HOST_CFLAGS="$HOST_CFLAGS -Wno-format-security"
 HOST_CXXFLAGS="$HOST_CXXFLAGS -Wno-format-security" 
 
 # add distro specific library dirs
+if [ -z "$HOST_LIBDIR" ]; then
+  HOST_LIBDIR="$TOOLCHAIN/lib"
+
   # ubuntu/debian specific "multiarch support"
-    FAMILY_TRIPLET=$(echo $HOST_NAME | sed -e "s,$(uname -m),$(uname -i),")
-    if [ -d /lib/$FAMILY_TRIPLET ]; then
-      HOST_LIBDIR="$HOST_LIBDIR /lib/$FAMILY_TRIPLET"
-    fi
-    if [ -d /usr/lib/$FAMILY_TRIPLET ]; then
-      HOST_LIBDIR="$HOST_LIBDIR /usr/lib/$FAMILY_TRIPLET"
-    fi
+  MACHINE_HARDWARE_NAME="$(uname -m)"
+  MACHINE_HARDWARE_PLATFORM="$(uname -i)"
+  FAMILY_TRIPLET=${HOST_NAME/${MACHINE_HARDWARE_NAME}/${MACHINE_HARDWARE_PLATFORM}}
+  if [ -d /lib/$FAMILY_TRIPLET ]; then
+    HOST_LIBDIR="$HOST_LIBDIR /lib/$FAMILY_TRIPLET"
+  fi
+  if [ -d /usr/lib/$FAMILY_TRIPLET ]; then
+    HOST_LIBDIR="$HOST_LIBDIR /usr/lib/$FAMILY_TRIPLET"
+  fi
 
   # default multiarch support
-    case "`uname -m`" in
-      i*86)
-        if [ -d /lib32 ]; then
-          HOST_LIBDIR="$HOST_LIBDIR /lib32"
-        fi
-        if [ -d /usr/lib32 ]; then
-          HOST_LIBDIR="$HOST_LIBDIR /usr/lib32"
-        fi
-      ;;
-      x86_64)
-        if [ -d /lib64 ]; then
-          HOST_LIBDIR="$HOST_LIBDIR /lib64"
-        fi
-        if [ -d /usr/lib64 ]; then
-          HOST_LIBDIR="$HOST_LIBDIR /usr/lib64"
-        fi
-      ;;
-    esac
+  case "${MACHINE_HARDWARE_NAME}" in
+    i*86)
+      if [ -d /lib32 ]; then
+        HOST_LIBDIR="$HOST_LIBDIR /lib32"
+      fi
+      if [ -d /usr/lib32 ]; then
+        HOST_LIBDIR="$HOST_LIBDIR /usr/lib32"
+      fi
+    ;;
+    x86_64)
+      if [ -d /lib64 ]; then
+        HOST_LIBDIR="$HOST_LIBDIR /lib64"
+      fi
+      if [ -d /usr/lib64 ]; then
+        HOST_LIBDIR="$HOST_LIBDIR /usr/lib64"
+      fi
+    ;;
+  esac
 
   # default dirs
-    HOST_LIBDIR="$HOST_LIBDIR /lib /usr/lib"
-    HOST_INCDIR="$TOOLCHAIN/include /usr/include"
+  export HOST_LIBDIR="$HOST_LIBDIR /lib /usr/lib"
+fi

--- a/config/options
+++ b/config/options
@@ -25,7 +25,7 @@ else
   TARGET_ARCH="$ARCH"
 fi
 
-ROOT=`pwd`
+ROOT="${PWD}"
 DISTRO_DIR="$ROOT/distributions"
 PROJECT_DIR="$ROOT/projects"
 LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux/linux.$TARGET_ARCH.conf $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/linux.$TARGET_ARCH.conf $ROOT/packages/linux/package.mk"
@@ -56,7 +56,7 @@ LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux/linux.$TARGET_ARCH.conf $PROJECT_DIR/
 
 # Need to point to your actual cc
 # If you have ccache installed, take care that LOCAL_CC don't point to it
-  LOCAL_CC=`which gcc`
+  [ -z "${LOCAL_CC}" ] && export LOCAL_CC="$(which gcc)"
 
 if [ -z "$LOCAL_CC" ] ; then
   echo "***** Please install gcc *****"
@@ -65,7 +65,7 @@ fi
 
 # Need to point to your actual g++
 # If you have ccache installed, take care that LOCAL_CXX don't point to it
-  LOCAL_CXX=`which g++`
+  [ -z "${LOCAL_CXX}" ] && export LOCAL_CXX="$(which g++)"
 
 # verbose compilation mode (yes/no)
   VERBOSE="yes"

--- a/config/options
+++ b/config/options
@@ -73,9 +73,7 @@ fi
 # Concurrency make level (-j option)
 #  Try value 1 (default) to 4 on single CPU computer, or more on
 #  multi-processor computer (like hyperthreading SMP CPU)
-  if test -z "${CONCURRENCY_MAKE_LEVEL}"; then
-    CONCURRENCY_MAKE_LEVEL=`cat /proc/cpuinfo | grep -c '^processor[[:cntrl:]]*:'`
-  fi
+  [ -z "${CONCURRENCY_MAKE_LEVEL}" ] && export CONCURRENCY_MAKE_LEVEL=$(grep -c '^processor[[:cntrl:]]*:' /proc/cpuinfo)
 
 # cache size for ccache
 # Set the maximum size of the files stored in the cache. You can specify a

--- a/config/path
+++ b/config/path
@@ -16,7 +16,7 @@ set -e
     . config/arch.$TARGET_ARCH
   fi
 
-HOST_NAME=`$LOCAL_CC -dumpmachine`
+[ -z "${HOST_NAME}" ] && export HOST_NAME="$($LOCAL_CC -dumpmachine)"
 TARGET_NAME=$TARGET_GCC_ARCH-libreelec-linux-gnu${TARGET_ABI}
 
 BUILD=$ROOT/$BUILD_BASE.$DISTRONAME-${DEVICE:-$PROJECT}.$TARGET_ARCH-$LIBREELEC_VERSION
@@ -134,7 +134,7 @@ unset LD_LIBRARY_PATH
       echo "$PKG_URL"
       exit 1
     fi
-    PKG_SOURCE_NAME="$(basename "$PKG_URL")"
+    PKG_SOURCE_NAME="${PKG_URL##*/}"
     case $PKG_SOURCE_NAME in
       ${PKG_NAME}-${PKG_VERSION}.*)
         PKG_SOURCE_NAME=$PKG_SOURCE_NAME

--- a/config/path
+++ b/config/path
@@ -118,7 +118,7 @@ unset LD_LIBRARY_PATH
   fi
 
   if [ "$PKG_IS_ADDON" = "yes" ] ; then
-    [ -z $PKG_SECTION ] && PKG_ADDON_ID="$PKG_NAME" || PKG_ADDON_ID="`echo $PKG_SECTION | sed 's,/,.,g'`.$PKG_NAME"
+    [ -z $PKG_SECTION ] && PKG_ADDON_ID="$PKG_NAME" || PKG_ADDON_ID="${PKG_SECTION//\//.}.$PKG_NAME"
     PKG_NEED_UNPACK="${PKG_NEED_UNPACK} $(get_pkg_directory $MEDIACENTER)"
   fi
 

--- a/packages/virtual/virtual/package.mk
+++ b/packages/virtual/virtual/package.mk
@@ -32,8 +32,4 @@ PKG_AUTORECONF="no"
 
 get_graphicdrivers
 
-for drv in $GRAPHIC_DRIVERS; do
-  if [ "$drv" = "vmware" ]; then
-    PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET open-vm-tools"
-  fi
-done
+listcontains "$GRAPHIC_DRIVERS" "vmware" && PKG_DEPENDS_TARGET+=" open-vm-tools"

--- a/scripts/build
+++ b/scripts/build
@@ -31,15 +31,18 @@ if [ ! -f $PKG_DIR/package.mk ]; then
 fi
 
 # set defaults
-  PKG_CONFIGURE_SCRIPT=""
-  PKG_MAKE_OPTS=""
-  PKG_MAKEINSTALL_OPTS=""
+PKG_CONFIGURE_SCRIPT=""
+PKG_MAKE_OPTS=""
+PKG_MAKEINSTALL_OPTS=""
 
-  PACKAGE_NAME=$(echo $1 | awk -F : '{print $1}')
-  TARGET=$(echo $1 | awk -F : '{print $2}')
-  if [ -z "$TARGET" ]; then
-    TARGET="target"
-  fi
+if [ "${1//:/}" != "${1}" ]; then
+  PACKAGE_NAME="${1%:*}"
+  TARGET="${1#*:}"
+else
+  PACKAGE_NAME=$1
+  TARGET=
+fi
+[ -z "$TARGET" ] && TARGET="target"
 
 if [ -n "$PKG_ARCH" -a ! "$PKG_ARCH" = "any" ]; then
   echo "$PKG_ARCH" | grep -q "$TARGET_ARCH" || exit 0

--- a/scripts/install
+++ b/scripts/install
@@ -32,11 +32,14 @@ if [ -z "$INSTALL" ] ; then
 fi
 
 # set defaults
-PACKAGE_NAME=$(echo $1 | awk -F : '{print $1}')
-TARGET=$(echo $1 | awk -F : '{print $2}')
-if [ -z "$TARGET" ]; then
-  TARGET="target"
+if [ "${1//:/}" != "${1}" ]; then
+  PACKAGE_NAME="${1%:*}"
+  TARGET="${1#*:}"
+else
+  PACKAGE_NAME=$1
+  TARGET=
 fi
+[ -z "$TARGET" ] && TARGET="target"
 
 STAMP=$STAMPS_INSTALL/$PACKAGE_NAME/install_$TARGET
 mkdir -p $STAMPS_INSTALL/$PACKAGE_NAME

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -25,11 +25,14 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-  PACKAGE_NAME=$(echo $1 | awk -F : '{print $1}')
-  TARGET=$(echo $1 | awk -F : '{print $2}')
-  if [ -z "$TARGET" ]; then
-    TARGET="target"
-  fi
+if [ "${1//:/}" != "${1}" ]; then
+  PACKAGE_NAME="${1%:*}"
+  TARGET="${1#*:}"
+else
+  PACKAGE_NAME=$1
+  TARGET=
+fi
+[ -z "$TARGET" ] && TARGET="target"
 
 if [ -n "$PKG_ARCH" -a ! "$PKG_ARCH" = "any" ]; then
   echo "$PKG_ARCH" | grep -q "$TARGET_ARCH" || exit 0


### PR DESCRIPTION
Another small round of buildsystem optimisations, this time eliminating about 22 sub-process/forks per call to `config/options <packagename>` (which is executed at least 3 times per package).

Using the same test script from [#2072](https://github.com/LibreELEC/LibreELEC.tv/pull/2072#issuecomment-334957175), the following results were obtained (AMD FX-8350).

Before:
```
ELAPSED: 142 seconds, 557 packages x3 (LOOP #1)
ELAPSED: 144 seconds, 557 packages x3 (LOOP #2)
ELAPSED: 145 seconds, 557 packages x3 (LOOP #3)
ELAPSED: 146 seconds, 557 packages x3 (LOOP #4)
ELAPSED: 145 seconds, 557 packages x3 (LOOP #5)
```

After:
```
ELAPSED: 76 seconds, 557 packages x3 (LOOP #1)
ELAPSED: 78 seconds, 557 packages x3 (LOOP #2)
ELAPSED: 77 seconds, 557 packages x3 (LOOP #3)
ELAPSED: 78 seconds, 557 packages x3 (LOOP #4)
ELAPSED: 79 seconds, 557 packages x3 (LOOP #5)
```

So, a worthwhile improvement.

The general idea is to avoid using external binaries when shell built-ins can be used instead, and to export variables that are "expensive" to acquire and that don't change over the lifetime of the build (eg. `HOST_NAME`).

This has been tested with clean RPi/RPi2/Generic builds.
