### PR TITLE
Allwinner: Enable thermal driver and  DVFS

### DIFF
--- a/projects/Allwinner/linux/linux.arm.conf
+++ b/projects/Allwinner/linux/linux.arm.conf
@@ -146,6 +146,7 @@ CONFIG_RD_GZIP=y
 # CONFIG_RD_XZ is not set
 # CONFIG_RD_LZO is not set
 # CONFIG_RD_LZ4 is not set
+CONFIG_INITRAMFS_COMPRESSION=".gz"
 CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE=y
 # CONFIG_CC_OPTIMIZE_FOR_SIZE is not set
 CONFIG_SYSCTL=y
@@ -620,9 +621,9 @@ CONFIG_CPU_FREQ_GOV_COMMON=y
 # CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE is not set
 # CONFIG_CPU_FREQ_DEFAULT_GOV_POWERSAVE is not set
 # CONFIG_CPU_FREQ_DEFAULT_GOV_USERSPACE is not set
-CONFIG_CPU_FREQ_DEFAULT_GOV_ONDEMAND=y
+# CONFIG_CPU_FREQ_DEFAULT_GOV_ONDEMAND is not set
 # CONFIG_CPU_FREQ_DEFAULT_GOV_CONSERVATIVE is not set
-# CONFIG_CPU_FREQ_DEFAULT_GOV_SCHEDUTIL is not set
+CONFIG_CPU_FREQ_DEFAULT_GOV_SCHEDUTIL=y
 CONFIG_CPU_FREQ_GOV_PERFORMANCE=y
 CONFIG_CPU_FREQ_GOV_POWERSAVE=y
 # CONFIG_CPU_FREQ_GOV_USERSPACE is not set
@@ -1554,6 +1555,7 @@ CONFIG_INPUT_EVDEV=y
 # Input Device Drivers
 #
 CONFIG_INPUT_KEYBOARD=y
+# CONFIG_KEYBOARD_ADC is not set
 # CONFIG_KEYBOARD_ADP5588 is not set
 # CONFIG_KEYBOARD_ADP5589 is not set
 CONFIG_KEYBOARD_ATKBD=y
@@ -1585,65 +1587,7 @@ CONFIG_KEYBOARD_SUN4I_LRADC=y
 # CONFIG_INPUT_MOUSE is not set
 # CONFIG_INPUT_JOYSTICK is not set
 # CONFIG_INPUT_TABLET is not set
-CONFIG_INPUT_TOUCHSCREEN=y
-CONFIG_TOUCHSCREEN_PROPERTIES=y
-# CONFIG_TOUCHSCREEN_ADS7846 is not set
-# CONFIG_TOUCHSCREEN_AD7877 is not set
-# CONFIG_TOUCHSCREEN_AD7879 is not set
-# CONFIG_TOUCHSCREEN_AR1021_I2C is not set
-# CONFIG_TOUCHSCREEN_ATMEL_MXT is not set
-# CONFIG_TOUCHSCREEN_AUO_PIXCIR is not set
-# CONFIG_TOUCHSCREEN_BU21013 is not set
-# CONFIG_TOUCHSCREEN_CHIPONE_ICN8318 is not set
-# CONFIG_TOUCHSCREEN_CY8CTMG110 is not set
-# CONFIG_TOUCHSCREEN_CYTTSP_CORE is not set
-# CONFIG_TOUCHSCREEN_CYTTSP4_CORE is not set
-# CONFIG_TOUCHSCREEN_DYNAPRO is not set
-# CONFIG_TOUCHSCREEN_HAMPSHIRE is not set
-# CONFIG_TOUCHSCREEN_EETI is not set
-# CONFIG_TOUCHSCREEN_EGALAX is not set
-# CONFIG_TOUCHSCREEN_EGALAX_SERIAL is not set
-# CONFIG_TOUCHSCREEN_FUJITSU is not set
-# CONFIG_TOUCHSCREEN_GOODIX is not set
-# CONFIG_TOUCHSCREEN_ILI210X is not set
-# CONFIG_TOUCHSCREEN_GUNZE is not set
-# CONFIG_TOUCHSCREEN_EKTF2127 is not set
-# CONFIG_TOUCHSCREEN_ELAN is not set
-# CONFIG_TOUCHSCREEN_ELO is not set
-# CONFIG_TOUCHSCREEN_WACOM_W8001 is not set
-# CONFIG_TOUCHSCREEN_WACOM_I2C is not set
-# CONFIG_TOUCHSCREEN_MAX11801 is not set
-# CONFIG_TOUCHSCREEN_MCS5000 is not set
-# CONFIG_TOUCHSCREEN_MMS114 is not set
-# CONFIG_TOUCHSCREEN_MELFAS_MIP4 is not set
-# CONFIG_TOUCHSCREEN_MTOUCH is not set
-# CONFIG_TOUCHSCREEN_IMX6UL_TSC is not set
-# CONFIG_TOUCHSCREEN_INEXIO is not set
-# CONFIG_TOUCHSCREEN_MK712 is not set
-# CONFIG_TOUCHSCREEN_PENMOUNT is not set
-# CONFIG_TOUCHSCREEN_EDT_FT5X06 is not set
-# CONFIG_TOUCHSCREEN_TOUCHRIGHT is not set
-# CONFIG_TOUCHSCREEN_TOUCHWIN is not set
-# CONFIG_TOUCHSCREEN_PIXCIR is not set
-# CONFIG_TOUCHSCREEN_WDT87XX_I2C is not set
-# CONFIG_TOUCHSCREEN_USB_COMPOSITE is not set
-# CONFIG_TOUCHSCREEN_TOUCHIT213 is not set
-# CONFIG_TOUCHSCREEN_TSC_SERIO is not set
-# CONFIG_TOUCHSCREEN_TSC2004 is not set
-# CONFIG_TOUCHSCREEN_TSC2005 is not set
-# CONFIG_TOUCHSCREEN_TSC2007 is not set
-# CONFIG_TOUCHSCREEN_RM_TS is not set
-# CONFIG_TOUCHSCREEN_SILEAD is not set
-# CONFIG_TOUCHSCREEN_SIS_I2C is not set
-# CONFIG_TOUCHSCREEN_ST1232 is not set
-# CONFIG_TOUCHSCREEN_STMFTS is not set
-CONFIG_TOUCHSCREEN_SUN4I=y
-# CONFIG_TOUCHSCREEN_SURFACE3_SPI is not set
-# CONFIG_TOUCHSCREEN_SX8654 is not set
-# CONFIG_TOUCHSCREEN_TPS6507X is not set
-# CONFIG_TOUCHSCREEN_ZET6223 is not set
-# CONFIG_TOUCHSCREEN_ZFORCE is not set
-# CONFIG_TOUCHSCREEN_ROHM_BU21023 is not set
+# CONFIG_INPUT_TOUCHSCREEN is not set
 CONFIG_INPUT_MISC=y
 # CONFIG_INPUT_AD714X is not set
 # CONFIG_INPUT_ATMEL_CAPTOUCH is not set
@@ -1948,13 +1892,17 @@ CONFIG_GPIO_SYSFS=y
 CONFIG_POWER_SUPPLY=y
 # CONFIG_POWER_SUPPLY_DEBUG is not set
 # CONFIG_PDA_POWER is not set
+# CONFIG_GENERIC_ADC_BATTERY is not set
 # CONFIG_TEST_POWER is not set
 # CONFIG_BATTERY_DS2780 is not set
 # CONFIG_BATTERY_DS2781 is not set
 # CONFIG_BATTERY_DS2782 is not set
+# CONFIG_BATTERY_LEGO_EV3 is not set
 # CONFIG_BATTERY_SBS is not set
 # CONFIG_CHARGER_SBS is not set
 # CONFIG_BATTERY_BQ27XXX is not set
+# CONFIG_AXP20X_POWER is not set
+# CONFIG_AXP288_FUEL_GAUGE is not set
 # CONFIG_BATTERY_MAX17040 is not set
 # CONFIG_BATTERY_MAX17042 is not set
 # CONFIG_CHARGER_ISP1704 is not set
@@ -2009,6 +1957,7 @@ CONFIG_HWMON=y
 # CONFIG_SENSORS_G762 is not set
 # CONFIG_SENSORS_GPIO_FAN is not set
 # CONFIG_SENSORS_HIH6130 is not set
+# CONFIG_SENSORS_IIO_HWMON is not set
 # CONFIG_SENSORS_IT87 is not set
 # CONFIG_SENSORS_JC42 is not set
 # CONFIG_SENSORS_POWR1220 is not set
@@ -2115,16 +2064,17 @@ CONFIG_THERMAL_DEFAULT_GOV_STEP_WISE=y
 CONFIG_THERMAL_GOV_STEP_WISE=y
 # CONFIG_THERMAL_GOV_BANG_BANG is not set
 # CONFIG_THERMAL_GOV_USER_SPACE is not set
-# CONFIG_THERMAL_GOV_POWER_ALLOCATOR is not set
+CONFIG_THERMAL_GOV_POWER_ALLOCATOR=y
 CONFIG_CPU_THERMAL=y
-# CONFIG_CLOCK_THERMAL is not set
-# CONFIG_DEVFREQ_THERMAL is not set
+CONFIG_CLOCK_THERMAL=y
+CONFIG_DEVFREQ_THERMAL=y
 # CONFIG_THERMAL_EMULATION is not set
 # CONFIG_QORIQ_THERMAL is not set
 
 #
 # ACPI INT340X thermal drivers
 #
+CONFIG_GENERIC_ADC_THERMAL=y
 CONFIG_WATCHDOG=y
 CONFIG_WATCHDOG_CORE=y
 # CONFIG_WATCHDOG_NOWAYOUT is not set
@@ -2182,6 +2132,7 @@ CONFIG_BCMA_BLOCKIO=y
 #
 CONFIG_MFD_CORE=y
 # CONFIG_MFD_ACT8945A is not set
+CONFIG_MFD_SUN4I_GPADC=y
 # CONFIG_MFD_AS3711 is not set
 # CONFIG_MFD_AS3722 is not set
 # CONFIG_PMIC_ADP5520 is not set
@@ -2310,6 +2261,7 @@ CONFIG_REGULATOR_GPIO=y
 # CONFIG_REGULATOR_PV88080 is not set
 # CONFIG_REGULATOR_PV88090 is not set
 # CONFIG_REGULATOR_PWM is not set
+CONFIG_REGULATOR_SY8106A=y
 # CONFIG_REGULATOR_TPS51632 is not set
 # CONFIG_REGULATOR_TPS62360 is not set
 # CONFIG_REGULATOR_TPS65023 is not set
@@ -3349,7 +3301,7 @@ CONFIG_DEVFREQ_GOV_SIMPLE_ONDEMAND=y
 CONFIG_DEVFREQ_GOV_PERFORMANCE=y
 CONFIG_DEVFREQ_GOV_POWERSAVE=y
 CONFIG_DEVFREQ_GOV_USERSPACE=y
-# CONFIG_DEVFREQ_GOV_PASSIVE is not set
+CONFIG_DEVFREQ_GOV_PASSIVE=y
 
 #
 # DEVFREQ Drivers
@@ -3360,6 +3312,7 @@ CONFIG_EXTCON=y
 #
 # Extcon Device Drivers
 #
+# CONFIG_EXTCON_ADC_JACK is not set
 # CONFIG_EXTCON_AXP288 is not set
 # CONFIG_EXTCON_GPIO is not set
 # CONFIG_EXTCON_MAX3355 is not set
@@ -3367,7 +3320,319 @@ CONFIG_EXTCON=y
 # CONFIG_EXTCON_SM5502 is not set
 # CONFIG_EXTCON_USB_GPIO is not set
 # CONFIG_MEMORY is not set
-# CONFIG_IIO is not set
+CONFIG_IIO=y
+CONFIG_IIO_BUFFER=y
+# CONFIG_IIO_BUFFER_CB is not set
+# CONFIG_IIO_KFIFO_BUF is not set
+CONFIG_IIO_CONFIGFS=y
+# CONFIG_IIO_TRIGGER is not set
+# CONFIG_IIO_SW_DEVICE is not set
+CONFIG_IIO_SW_TRIGGER=y
+
+#
+# Accelerometers
+#
+# CONFIG_ADXL345_I2C is not set
+# CONFIG_ADXL345_SPI is not set
+# CONFIG_BMA180 is not set
+# CONFIG_BMA220 is not set
+# CONFIG_BMC150_ACCEL is not set
+# CONFIG_DA280 is not set
+# CONFIG_DA311 is not set
+# CONFIG_DMARD06 is not set
+# CONFIG_DMARD09 is not set
+# CONFIG_DMARD10 is not set
+# CONFIG_IIO_ST_ACCEL_3AXIS is not set
+# CONFIG_KXSD9 is not set
+# CONFIG_KXCJK1013 is not set
+# CONFIG_MC3230 is not set
+# CONFIG_MMA7455_I2C is not set
+# CONFIG_MMA7455_SPI is not set
+# CONFIG_MMA7660 is not set
+# CONFIG_MMA8452 is not set
+# CONFIG_MMA9551 is not set
+# CONFIG_MMA9553 is not set
+# CONFIG_MXC4005 is not set
+# CONFIG_MXC6255 is not set
+# CONFIG_SCA3000 is not set
+# CONFIG_STK8312 is not set
+# CONFIG_STK8BA50 is not set
+
+#
+# Analog to digital converters
+#
+# CONFIG_AD7266 is not set
+# CONFIG_AD7291 is not set
+# CONFIG_AD7298 is not set
+# CONFIG_AD7476 is not set
+# CONFIG_AD7766 is not set
+# CONFIG_AD7791 is not set
+# CONFIG_AD7793 is not set
+# CONFIG_AD7887 is not set
+# CONFIG_AD7923 is not set
+# CONFIG_AD799X is not set
+# CONFIG_AXP20X_ADC is not set
+# CONFIG_AXP288_ADC is not set
+# CONFIG_CC10001_ADC is not set
+# CONFIG_ENVELOPE_DETECTOR is not set
+# CONFIG_HI8435 is not set
+# CONFIG_HX711 is not set
+# CONFIG_INA2XX_ADC is not set
+# CONFIG_LTC2485 is not set
+# CONFIG_LTC2497 is not set
+# CONFIG_MAX1027 is not set
+# CONFIG_MAX11100 is not set
+# CONFIG_MAX1118 is not set
+# CONFIG_MAX1363 is not set
+# CONFIG_MAX9611 is not set
+# CONFIG_MCP320X is not set
+# CONFIG_MCP3422 is not set
+# CONFIG_NAU7802 is not set
+CONFIG_SUN4I_GPADC=y
+# CONFIG_TI_ADC081C is not set
+# CONFIG_TI_ADC0832 is not set
+# CONFIG_TI_ADC084S021 is not set
+# CONFIG_TI_ADC12138 is not set
+# CONFIG_TI_ADC108S102 is not set
+# CONFIG_TI_ADC128S052 is not set
+# CONFIG_TI_ADC161S626 is not set
+# CONFIG_TI_ADS1015 is not set
+# CONFIG_TI_ADS7950 is not set
+# CONFIG_TI_ADS8688 is not set
+# CONFIG_TI_TLC4541 is not set
+# CONFIG_VF610_ADC is not set
+
+#
+# Amplifiers
+#
+# CONFIG_AD8366 is not set
+
+#
+# Chemical Sensors
+#
+# CONFIG_ATLAS_PH_SENSOR is not set
+# CONFIG_IAQCORE is not set
+# CONFIG_VZ89X is not set
+
+#
+# Hid Sensor IIO Common
+#
+
+#
+# SSP Sensor Common
+#
+# CONFIG_IIO_SSP_SENSORHUB is not set
+
+#
+# Counters
+#
+
+#
+# Digital to analog converters
+#
+# CONFIG_AD5064 is not set
+# CONFIG_AD5360 is not set
+# CONFIG_AD5380 is not set
+# CONFIG_AD5421 is not set
+# CONFIG_AD5446 is not set
+# CONFIG_AD5449 is not set
+# CONFIG_AD5592R is not set
+# CONFIG_AD5593R is not set
+# CONFIG_AD5504 is not set
+# CONFIG_AD5624R_SPI is not set
+# CONFIG_LTC2632 is not set
+# CONFIG_AD5686 is not set
+# CONFIG_AD5755 is not set
+# CONFIG_AD5761 is not set
+# CONFIG_AD5764 is not set
+# CONFIG_AD5791 is not set
+# CONFIG_AD7303 is not set
+# CONFIG_AD8801 is not set
+# CONFIG_DPOT_DAC is not set
+# CONFIG_M62332 is not set
+# CONFIG_MAX517 is not set
+# CONFIG_MAX5821 is not set
+# CONFIG_MCP4725 is not set
+# CONFIG_MCP4922 is not set
+# CONFIG_VF610_DAC is not set
+
+#
+# IIO dummy driver
+#
+
+#
+# Frequency Synthesizers DDS/PLL
+#
+
+#
+# Clock Generator/Distribution
+#
+# CONFIG_AD9523 is not set
+
+#
+# Phase-Locked Loop (PLL) frequency synthesizers
+#
+# CONFIG_ADF4350 is not set
+
+#
+# Digital gyroscope sensors
+#
+# CONFIG_ADIS16080 is not set
+# CONFIG_ADIS16130 is not set
+# CONFIG_ADIS16136 is not set
+# CONFIG_ADIS16260 is not set
+# CONFIG_ADXRS450 is not set
+# CONFIG_BMG160 is not set
+# CONFIG_MPU3050_I2C is not set
+# CONFIG_IIO_ST_GYRO_3AXIS is not set
+# CONFIG_ITG3200 is not set
+
+#
+# Health Sensors
+#
+
+#
+# Heart Rate Monitors
+#
+# CONFIG_AFE4403 is not set
+# CONFIG_AFE4404 is not set
+# CONFIG_MAX30100 is not set
+# CONFIG_MAX30102 is not set
+
+#
+# Humidity sensors
+#
+# CONFIG_AM2315 is not set
+# CONFIG_DHT11 is not set
+# CONFIG_HDC100X is not set
+# CONFIG_HTS221 is not set
+# CONFIG_HTU21 is not set
+# CONFIG_SI7005 is not set
+# CONFIG_SI7020 is not set
+
+#
+# Inertial measurement units
+#
+# CONFIG_ADIS16400 is not set
+# CONFIG_ADIS16480 is not set
+# CONFIG_BMI160_I2C is not set
+# CONFIG_BMI160_SPI is not set
+# CONFIG_KMX61 is not set
+# CONFIG_INV_MPU6050_SPI is not set
+# CONFIG_IIO_ST_LSM6DSX is not set
+
+#
+# Light sensors
+#
+# CONFIG_ADJD_S311 is not set
+# CONFIG_AL3320A is not set
+# CONFIG_APDS9300 is not set
+# CONFIG_APDS9960 is not set
+# CONFIG_BH1750 is not set
+# CONFIG_BH1780 is not set
+# CONFIG_CM32181 is not set
+# CONFIG_CM3232 is not set
+# CONFIG_CM3323 is not set
+# CONFIG_CM3605 is not set
+# CONFIG_CM36651 is not set
+# CONFIG_GP2AP020A00F is not set
+# CONFIG_SENSORS_ISL29018 is not set
+# CONFIG_SENSORS_ISL29028 is not set
+# CONFIG_ISL29125 is not set
+# CONFIG_JSA1212 is not set
+# CONFIG_RPR0521 is not set
+# CONFIG_LTR501 is not set
+# CONFIG_MAX44000 is not set
+# CONFIG_OPT3001 is not set
+# CONFIG_PA12203001 is not set
+# CONFIG_SI1145 is not set
+# CONFIG_STK3310 is not set
+# CONFIG_TCS3414 is not set
+# CONFIG_TCS3472 is not set
+# CONFIG_SENSORS_TSL2563 is not set
+# CONFIG_TSL2583 is not set
+# CONFIG_TSL4531 is not set
+# CONFIG_US5182D is not set
+# CONFIG_VCNL4000 is not set
+# CONFIG_VEML6070 is not set
+# CONFIG_VL6180 is not set
+
+#
+# Magnetometer sensors
+#
+# CONFIG_AK8974 is not set
+# CONFIG_AK8975 is not set
+# CONFIG_AK09911 is not set
+# CONFIG_BMC150_MAGN_I2C is not set
+# CONFIG_BMC150_MAGN_SPI is not set
+# CONFIG_MAG3110 is not set
+# CONFIG_MMC35240 is not set
+# CONFIG_IIO_ST_MAGN_3AXIS is not set
+# CONFIG_SENSORS_HMC5843_I2C is not set
+# CONFIG_SENSORS_HMC5843_SPI is not set
+
+#
+# Multiplexers
+#
+# CONFIG_IIO_MUX is not set
+
+#
+# Inclinometer sensors
+#
+
+#
+# Digital potentiometers
+#
+# CONFIG_DS1803 is not set
+# CONFIG_MAX5481 is not set
+# CONFIG_MAX5487 is not set
+# CONFIG_MCP4131 is not set
+# CONFIG_MCP4531 is not set
+# CONFIG_TPL0102 is not set
+
+#
+# Digital potentiostats
+#
+# CONFIG_LMP91000 is not set
+
+#
+# Pressure sensors
+#
+# CONFIG_ABP060MG is not set
+# CONFIG_BMP280 is not set
+# CONFIG_HP03 is not set
+# CONFIG_MPL115_I2C is not set
+# CONFIG_MPL115_SPI is not set
+# CONFIG_MPL3115 is not set
+# CONFIG_MS5611 is not set
+# CONFIG_MS5637 is not set
+# CONFIG_IIO_ST_PRESS is not set
+# CONFIG_T5403 is not set
+# CONFIG_HP206C is not set
+# CONFIG_ZPA2326 is not set
+
+#
+# Lightning sensors
+#
+# CONFIG_AS3935 is not set
+
+#
+# Proximity and distance sensors
+#
+# CONFIG_LIDAR_LITE_V2 is not set
+# CONFIG_SRF04 is not set
+# CONFIG_SX9500 is not set
+# CONFIG_SRF08 is not set
+
+#
+# Temperature sensors
+#
+# CONFIG_MAXIM_THERMOCOUPLE is not set
+# CONFIG_MLX90614 is not set
+# CONFIG_TMP006 is not set
+# CONFIG_TMP007 is not set
+# CONFIG_TSYS01 is not set
+# CONFIG_TSYS02D is not set
 CONFIG_PWM=y
 CONFIG_PWM_SYSFS=y
 # CONFIG_PWM_FSL_FTM is not set
@@ -3403,6 +3668,7 @@ CONFIG_PHY_SUN9I_USB=y
 # CONFIG_BCM_KONA_USB2_PHY is not set
 # CONFIG_PHY_PXA_28NM_HSIC is not set
 # CONFIG_PHY_PXA_28NM_USB2 is not set
+# CONFIG_PHY_CPCAP_USB is not set
 # CONFIG_POWERCAP is not set
 # CONFIG_MCB is not set
 

--- a/projects/Allwinner/patches/linux/07-1-add-H3-H5-DE2-DT-nodes.patch
+++ b/projects/Allwinner/patches/linux/07-1-add-H3-H5-DE2-DT-nodes.patch
@@ -1,32 +1,20 @@
-From ef9ca67d03cd6b18c03f69cd0141d63a672bc330 Mon Sep 17 00:00:00 2001
-From: Icenowy Zheng <icenowy@aosc.io>
-Date: Tue, 1 Aug 2017 21:12:58 +0800
-Subject: [PATCH] ARM: sun8i: h3: add display engine pipeline barebone
-
-As we have already the support for the DE2 on Allwinner H3, add the
-display engine pipeline device tree nodes to its DTSI file.
-
-The H5 pipeline has some differences and will be enabled later.
-
-Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
----
- arch/arm/boot/dts/sun8i-h3.dtsi | 170 ++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 170 insertions(+)
-
-diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
-index b36f9f423c39d..75ad7b65a7fcd 100644
---- a/arch/arm/boot/dts/sun8i-h3.dtsi
-+++ b/arch/arm/boot/dts/sun8i-h3.dtsi
-@@ -41,6 +41,8 @@
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index 11240a83..ccde3a00 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -40,9 +40,11 @@
+  *     OTHER DEALINGS IN THE SOFTWARE.
   */
  
- #include "sunxi-h3-h5.dtsi"
 +#include <dt-bindings/clock/sun8i-de2.h>
+ #include <dt-bindings/clock/sun8i-h3-ccu.h>
+ #include <dt-bindings/clock/sun8i-r-ccu.h>
+ #include <dt-bindings/interrupt-controller/arm-gic.h>
 +#include <dt-bindings/reset/sun8i-de2.h>
+ #include <dt-bindings/reset/sun8i-h3-ccu.h>
+ #include <dt-bindings/reset/sun8i-r-ccu.h>
  
- / {
- 	cpus {
-@@ -72,6 +74,174 @@
+@@ -79,12 +81,98 @@
  		};
  	};
  
@@ -37,9 +25,14 @@ index b36f9f423c39d..75ad7b65a7fcd 100644
 +		status = "disabled";
 +	};
 +
-+	soc {
+ 	soc {
+ 		compatible = "simple-bus";
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 		ranges;
+ 
 +		display_clocks: clock@1000000 {
-+			compatible = "allwinner,sun8i-a83t-de2-clk";
++			/* compatible is in per SoC .dtsi file */
 +			reg = <0x01000000 0x100000>;
 +			clocks = <&ccu CLK_BUS_DE>,
 +				 <&ccu CLK_DE>;
@@ -92,7 +85,7 @@ index b36f9f423c39d..75ad7b65a7fcd 100644
 +				 <&display_clocks CLK_MIXER1>;
 +			clock-names = "bus",
 +				      "mod";
-+			resets = <&display_clocks RST_WB>;
++			/* resets is in per SoC .dtsi file */
 +			status = "disabled";
 +
 +			ports {
@@ -117,6 +110,13 @@ index b36f9f423c39d..75ad7b65a7fcd 100644
 +			};
 +		};
 +
+ 		syscon: syscon@1c00000 {
+ 			compatible = "allwinner,sun8i-h3-system-controller",
+ 				"syscon";
+@@ -100,6 +188,86 @@
+ 			#dma-cells = <1>;
+ 		};
+ 
 +		tcon0: lcd-controller@1c0c000 {
 +			compatible = "allwinner,sun8i-h3-tcon";
 +			reg = <0x01c0c000 0x1000>;
@@ -196,8 +196,7 @@ index b36f9f423c39d..75ad7b65a7fcd 100644
 +				};
 +			};
 +		};
-+	};
 +
- 	timer {
- 		compatible = "arm,armv7-timer";
- 		interrupts = <GIC_PPI 13 (GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+ 		mmc0: mmc@01c0f000 {
+ 			/* compatible and clocks are in per SoC .dtsi file */
+ 			reg = <0x01c0f000 0x1000>;

--- a/projects/Allwinner/patches/linux/07-2-add-H3-DE2-DT-nodes.patch
+++ b/projects/Allwinner/patches/linux/07-2-add-H3-DE2-DT-nodes.patch
@@ -1,0 +1,19 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
+index b36f9f42..b2896427 100644
+--- a/arch/arm/boot/dts/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/sun8i-h3.dtsi
+@@ -85,6 +85,14 @@
+ 	compatible = "allwinner,sun8i-h3-ccu";
+ };
+ 
++&display_clocks {
++	compatible = "allwinner,sun8i-a83t-de2-clk";
++};
++
++&mixer1 {
++	resets = <&display_clocks RST_WB>;
++};
++
+ &mmc0 {
+ 	compatible = "allwinner,sun7i-a20-mmc";
+ 	clocks = <&ccu CLK_BUS_MMC0>,

--- a/projects/Allwinner/patches/linux/13-dw-hdmi-add-DT-nodes.patch
+++ b/projects/Allwinner/patches/linux/13-dw-hdmi-add-DT-nodes.patch
@@ -1,24 +1,8 @@
-From dac5aed0eb680ea0c3de541a3bc06398b52ba5fa Mon Sep 17 00:00:00 2001
-From: Icenowy Zheng <icenowy@aosc.io>
-Date: Tue, 1 Aug 2017 21:13:03 +0800
-Subject: [PATCH] ARM: sun8i: h3: Add DesignWare HDMI controller node
-
-The H3 SoC has a DesignWare HDMI controller with some Allwinner-specific
-glue.
-
-Add the related device nodes.
-
-Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
-Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
----
- arch/arm/boot/dts/sun8i-h3.dtsi | 41 +++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 41 insertions(+)
-
-diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
-index 75ad7b65a7fcd..e0fbab75aca10 100644
---- a/arch/arm/boot/dts/sun8i-h3.dtsi
-+++ b/arch/arm/boot/dts/sun8i-h3.dtsi
-@@ -97,6 +97,42 @@
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index ccde3a00..44ae22a9 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -109,6 +109,42 @@
  			assigned-clock-rates = <432000000>;
  		};
  
@@ -61,7 +45,7 @@ index 75ad7b65a7fcd..e0fbab75aca10 100644
  		mixer0: mixer@1100000 {
  			compatible = "allwinner,sun8i-h3-de2-mixer0";
  			reg = <0x01100000 0x100000>;
-@@ -197,6 +233,11 @@
+@@ -224,6 +260,11 @@
  					#address-cells = <1>;
  					#size-cells = <0>;
  					reg = <1>;

--- a/projects/Allwinner/patches/linux/16-H3-add-HDMI-sound-nodes.patch
+++ b/projects/Allwinner/patches/linux/16-H3-add-HDMI-sound-nodes.patch
@@ -1,18 +1,31 @@
-From 7cb1a6f881abdd1c39ec020d997aa665461f354e Mon Sep 17 00:00:00 2001
-From: Jernej Skrabec <jernej.skrabec@siol.net>
-Date: Tue, 5 Sep 2017 22:05:25 +0200
-Subject: [PATCH] ARM: sun8i: h3: Add nodes for HDMI audio
-
-Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
----
- arch/arm/boot/dts/sun8i-h3.dtsi | 30 ++++++++++++++++++++++++++++++
- 1 file changed, 30 insertions(+)
-
-diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
-index e0fbab75aca10..a698ab23bec03 100644
---- a/arch/arm/boot/dts/sun8i-h3.dtsi
-+++ b/arch/arm/boot/dts/sun8i-h3.dtsi
-@@ -98,6 +98,7 @@
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index 8aa2befc..d3d70eac 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -53,6 +53,22 @@
+ 	#address-cells = <1>;
+ 	#size-cells = <1>;
+ 
++	sound_hdmi: sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,name = "allwinner,hdmi";
++		simple-audio-card,mclk-fs = <256>;
++		status = "disabled";
++
++		simple-audio-card,codec {
++			sound-dai = <&hdmi>;
++		};
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s2>;
++		};
++	};
++
+ 	clocks {
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+@@ -110,6 +126,7 @@
  		};
  
  		hdmi: hdmi@1ee0000 {
@@ -20,8 +33,8 @@ index e0fbab75aca10..a698ab23bec03 100644
  			compatible = "allwinner,sun8i-h3-dw-hdmi";
  			reg = <0x01ee0000 0x10000>,
  			      <0x01ef0000 0x10000>;
-@@ -133,6 +134,19 @@
- 			};
+@@ -685,6 +702,19 @@
+ 			status = "disabled";
  		};
  
 +		i2s2: i2s@1c22800 {
@@ -37,29 +50,6 @@ index e0fbab75aca10..a698ab23bec03 100644
 +			status = "disabled";
 +		};
 +
- 		mixer0: mixer@1100000 {
- 			compatible = "allwinner,sun8i-h3-de2-mixer0";
- 			reg = <0x01100000 0x100000>;
-@@ -197,6 +211,22 @@
- 			};
- 		};
- 
-+		sound_hdmi: sound {
-+			compatible = "simple-audio-card";
-+			simple-audio-card,format = "i2s";
-+			simple-audio-card,name = "allwinner,hdmi";
-+			simple-audio-card,mclk-fs = <256>;
-+			status = "disabled";
-+
-+			simple-audio-card,codec {
-+				sound-dai = <&hdmi>;
-+			};
-+
-+			simple-audio-card,cpu {
-+				sound-dai = <&i2s2>;
-+			};
-+		};
-+
- 		tcon0: lcd-controller@1c0c000 {
- 			compatible = "allwinner,sun8i-h3-tcon";
- 			reg = <0x01c0c000 0x1000>;
+ 		codec: codec@01c22c00 {
+ 			#sound-dai-cells = <0>;
+ 			compatible = "allwinner,sun8i-h3-codec";

--- a/projects/Allwinner/patches/linux/24-sun4i-gpadc-iio-add-H3-CPU-thermal-zone.patch
+++ b/projects/Allwinner/patches/linux/24-sun4i-gpadc-iio-add-H3-CPU-thermal-zone.patch
@@ -1,8 +1,16 @@
 diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
-index efe3a8e4f2af..551efecaab5d 100644
+index b36f9f423..0ad8e3e80 100644
 --- a/arch/arm/boot/dts/sun8i-h3.dtsi
 +++ b/arch/arm/boot/dts/sun8i-h3.dtsi
-@@ -125,6 +125,15 @@
+@@ -41,6 +41,7 @@
+  */
+ 
+ #include "sunxi-h3-h5.dtsi"
++#include <dt-bindings/thermal/thermal.h>
+ 
+ / {
+ 	cpus {
+@@ -72,6 +73,80 @@
  		};
  	};
  
@@ -12,6 +20,71 @@ index efe3a8e4f2af..551efecaab5d 100644
 +			polling-delay-passive = <250>;
 +			polling-delay = <1000>;
 +			thermal-sensors = <&ths>;
++
++			trips {
++				cpu_warm: cpu_warm {
++					temperature = <65000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_hot_pre: cpu_hot_pre {
++					temperature = <70000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_hot: cpu_hot {
++					temperature = <75000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_very_hot_pre: cpu_very_hot_pre {
++					temperature = <85000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_very_hot: cpu_very_hot {
++					temperature = <90000>;
++					hysteresis = <2000>;
++					type = "passive";
++				};
++
++				cpu_crit: cpu_crit {
++					temperature = <105000>;
++					hysteresis = <2000>;
++					type = "critical";
++				};
++			};
++
++			cooling-maps {
++				cpu_warm_limit_cpu {
++					trip = <&cpu_warm>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT 2>;
++				};
++
++				cpu_hot_pre_limit_cpu {
++					trip = <&cpu_hot_pre>;
++					cooling-device = <&cpu0 2 3>;
++				};
++
++				cpu_hot_limit_cpu {
++					trip = <&cpu_hot>;
++					cooling-device = <&cpu0 3 4>;
++				};
++
++				cpu_very_hot_pre_limit_cpu {
++					trip = <&cpu_very_hot>;
++					cooling-device = <&cpu0 5 6>;
++				};
++
++				cpu_very_hot_limit_cpu {
++					trip = <&cpu_very_hot>;
++					cooling-device = <&cpu0 7 THERMAL_NO_LIMIT>;
++				};
++			};
 +		};
 +	};
 +

--- a/projects/Allwinner/patches/linux/39-rename-s_twi-pinctrl-functions.patch
+++ b/projects/Allwinner/patches/linux/39-rename-s_twi-pinctrl-functions.patch
@@ -1,0 +1,83 @@
+From 059b07989e091f003f2d6adea37a54cd377471d4 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Sun, 30 Jul 2017 13:36:18 +0800
+Subject: pinctrl: sunxi: rename R_PIO i2c pin function name
+
+The I2C pin functions in R_PIO used to be named "s_twi".
+
+As we usually use the name "i2c" instead of "twi" in the mainline
+kernel, change these names to "s_i2c" for consistency.
+
+The "s_twi" functions are not yet referenced by any device trees in
+mainline kernel so I think it's safe to change the name.
+
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+Reviewed-by: Chen-Yu Tsai <wens@csie.org>
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/sunxi/pinctrl-sun6i-a31-r.c | 4 ++--
+ drivers/pinctrl/sunxi/pinctrl-sun8i-a23-r.c | 4 ++--
+ drivers/pinctrl/sunxi/pinctrl-sun8i-h3-r.c  | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/pinctrl/sunxi/pinctrl-sun6i-a31-r.c b/drivers/pinctrl/sunxi/pinctrl-sun6i-a31-r.c
+index a22bd88..c96a361 100644
+--- a/drivers/pinctrl/sunxi/pinctrl-sun6i-a31-r.c
++++ b/drivers/pinctrl/sunxi/pinctrl-sun6i-a31-r.c
+@@ -25,12 +25,12 @@ static const struct sunxi_desc_pin sun6i_a31_r_pins[] = {
+ 	SUNXI_PIN(SUNXI_PINCTRL_PIN(L, 0),
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+ 		  SUNXI_FUNCTION(0x1, "gpio_out"),
+-		  SUNXI_FUNCTION(0x2, "s_twi"),		/* SCK */
++		  SUNXI_FUNCTION(0x2, "s_i2c"),		/* SCK */
+ 		  SUNXI_FUNCTION(0x3, "s_p2wi")),	/* SCK */
+ 	SUNXI_PIN(SUNXI_PINCTRL_PIN(L, 1),
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+ 		  SUNXI_FUNCTION(0x1, "gpio_out"),
+-		  SUNXI_FUNCTION(0x2, "s_twi"),		/* SDA */
++		  SUNXI_FUNCTION(0x2, "s_i2c"),		/* SDA */
+ 		  SUNXI_FUNCTION(0x3, "s_p2wi")),	/* SDA */
+ 	SUNXI_PIN(SUNXI_PINCTRL_PIN(L, 2),
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+diff --git a/drivers/pinctrl/sunxi/pinctrl-sun8i-a23-r.c b/drivers/pinctrl/sunxi/pinctrl-sun8i-a23-r.c
+index 2292e05..5789e9e 100644
+--- a/drivers/pinctrl/sunxi/pinctrl-sun8i-a23-r.c
++++ b/drivers/pinctrl/sunxi/pinctrl-sun8i-a23-r.c
+@@ -29,13 +29,13 @@ static const struct sunxi_desc_pin sun8i_a23_r_pins[] = {
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+ 		  SUNXI_FUNCTION(0x1, "gpio_out"),
+ 		  SUNXI_FUNCTION(0x2, "s_rsb"),		/* SCK */
+-		  SUNXI_FUNCTION(0x3, "s_twi"),		/* SCK */
++		  SUNXI_FUNCTION(0x3, "s_i2c"),		/* SCK */
+ 		  SUNXI_FUNCTION_IRQ_BANK(0x4, 0, 0)),	/* PL_EINT0 */
+ 	SUNXI_PIN(SUNXI_PINCTRL_PIN(L, 1),
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+ 		  SUNXI_FUNCTION(0x1, "gpio_out"),
+ 		  SUNXI_FUNCTION(0x2, "s_rsb"),		/* SDA */
+-		  SUNXI_FUNCTION(0x3, "s_twi"),		/* SDA */
++		  SUNXI_FUNCTION(0x3, "s_i2c"),		/* SDA */
+ 		  SUNXI_FUNCTION_IRQ_BANK(0x4, 0, 1)),	/* PL_EINT1 */
+ 	SUNXI_PIN(SUNXI_PINCTRL_PIN(L, 2),
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+diff --git a/drivers/pinctrl/sunxi/pinctrl-sun8i-h3-r.c b/drivers/pinctrl/sunxi/pinctrl-sun8i-h3-r.c
+index 686ec21..ebfd9a2 100644
+--- a/drivers/pinctrl/sunxi/pinctrl-sun8i-h3-r.c
++++ b/drivers/pinctrl/sunxi/pinctrl-sun8i-h3-r.c
+@@ -20,12 +20,12 @@ static const struct sunxi_desc_pin sun8i_h3_r_pins[] = {
+ 	SUNXI_PIN(SUNXI_PINCTRL_PIN(L, 0),
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+ 		  SUNXI_FUNCTION(0x1, "gpio_out"),
+-		  SUNXI_FUNCTION(0x2, "s_twi"),         /* SCK */
++		  SUNXI_FUNCTION(0x2, "s_i2c"),         /* SCK */
+ 		  SUNXI_FUNCTION_IRQ_BANK(0x6, 0, 0)),	/* PL_EINT0 */
+ 	SUNXI_PIN(SUNXI_PINCTRL_PIN(L, 1),
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+ 		  SUNXI_FUNCTION(0x1, "gpio_out"),
+-		  SUNXI_FUNCTION(0x2, "s_twi"),         /* SDA */
++		  SUNXI_FUNCTION(0x2, "s_i2c"),         /* SDA */
+ 		  SUNXI_FUNCTION_IRQ_BANK(0x6, 0, 1)),	/* PL_EINT1 */
+ 	SUNXI_PIN(SUNXI_PINCTRL_PIN(L, 2),
+ 		  SUNXI_FUNCTION(0x0, "gpio_in"),
+-- 
+cgit v1.1
+

--- a/projects/Allwinner/patches/linux/40-add-SY8106A-regulator-driver.patch
+++ b/projects/Allwinner/patches/linux/40-add-SY8106A-regulator-driver.patch
@@ -1,0 +1,236 @@
+From e9807e63fec81bab15b2e8be714d802966ea6425 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Sat, 25 Jun 2016 02:13:50 +0200
+Subject: [PATCH 39/87] regulator: add support for SY8106A regulator
+
+SY8106A is an I2C attached single output regulator made by Silergy Corp,
+which is used on several Allwinner H3/H5 SBCs to control the power
+supply of the ARM cores.
+
+Add a driver for it.
+
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+[Icenowy: Change commit message, remove enable/disable code, add default
+ ramp_delay]
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+---
+ drivers/regulator/Kconfig             |   8 +-
+ drivers/regulator/Makefile            |   2 +-
+ drivers/regulator/sy8106a-regulator.c | 164 ++++++++++++++++++++++++++++++++++
+ 3 files changed, 172 insertions(+), 2 deletions(-)
+ create mode 100644 drivers/regulator/sy8106a-regulator.c
+
+diff --git a/drivers/regulator/Kconfig b/drivers/regulator/Kconfig
+index 99b9362331b5..1efa73e18d07 100644
+--- a/drivers/regulator/Kconfig
++++ b/drivers/regulator/Kconfig
+@@ -764,6 +764,13 @@ config REGULATOR_STW481X_VMMC
+ 	  This driver supports the internal VMMC regulator in the STw481x
+ 	  PMIC chips.
+ 
++config REGULATOR_SY8106A
++	tristate "Silergy SY8106A regulator"
++	depends on I2C && (OF || COMPILE_TEST)
++	select REGMAP_I2C
++	help
++	  This driver supports SY8106A single output regulator.
++
+ config REGULATOR_TPS51632
+ 	tristate "TI TPS51632 Power Regulator"
+ 	depends on I2C
+@@ -938,4 +945,3 @@ config REGULATOR_WM8994
+ 	  WM8994 CODEC.
+ 
+ endif
+-
+diff --git a/drivers/regulator/Makefile b/drivers/regulator/Makefile
+index 95b1e86ae692..f5120252f86a 100644
+--- a/drivers/regulator/Makefile
++++ b/drivers/regulator/Makefile
+@@ -95,6 +95,7 @@ obj-$(CONFIG_REGULATOR_S2MPS11) += s2mps11.o
+ obj-$(CONFIG_REGULATOR_S5M8767) += s5m8767.o
+ obj-$(CONFIG_REGULATOR_SKY81452) += sky81452-regulator.o
+ obj-$(CONFIG_REGULATOR_STW481X_VMMC) += stw481x-vmmc.o
++obj-$(CONFIG_REGULATOR_SY8106A) += sy8106a-regulator.o
+ obj-$(CONFIG_REGULATOR_TI_ABB) += ti-abb-regulator.o
+ obj-$(CONFIG_REGULATOR_TPS6105X) += tps6105x-regulator.o
+ obj-$(CONFIG_REGULATOR_TPS62360) += tps62360-regulator.o
+@@ -120,5 +121,4 @@ obj-$(CONFIG_REGULATOR_WM8350) += wm8350-regulator.o
+ obj-$(CONFIG_REGULATOR_WM8400) += wm8400-regulator.o
+ obj-$(CONFIG_REGULATOR_WM8994) += wm8994-regulator.o
+ 
+-
+ ccflags-$(CONFIG_REGULATOR_DEBUG) += -DDEBUG
+diff --git a/drivers/regulator/sy8106a-regulator.c b/drivers/regulator/sy8106a-regulator.c
+new file mode 100644
+index 000000000000..4babc95894e7
+--- /dev/null
++++ b/drivers/regulator/sy8106a-regulator.c
+@@ -0,0 +1,164 @@
++/*
++ * sy8106a-regulator.c - Regulator device driver for SY8106A
++ *
++ * Copyright (C) 2016 Ondřej Jirman <megous@megous.com>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ */
++
++#include <linux/err.h>
++#include <linux/i2c.h>
++#include <linux/module.h>
++#include <linux/regmap.h>
++#include <linux/regulator/driver.h>
++#include <linux/regulator/of_regulator.h>
++
++#define SY8106A_REG_VOUT1_SEL		0x01
++#define SY8106A_REG_VOUT_COM		0x02
++#define SY8106A_REG_VOUT1_SEL_MASK	0x7f
++#define SY8106A_DISABLE_REG		BIT(0)
++#define SY8106A_GO_BIT			BIT(7)
++
++struct sy8106a {
++	struct regulator_dev *rdev;
++	struct regmap *regmap;
++};
++
++static const struct regmap_config sy8106a_regmap_config = {
++	.reg_bits = 8,
++	.val_bits = 8,
++};
++
++static int sy8106a_set_voltage_sel(struct regulator_dev *rdev, unsigned int sel)
++{
++	/* We use our set_voltage_sel in order to avoid unnecessary I2C
++	 * chatter, because the regulator_get_voltage_sel_regmap using
++	 * apply_bit would perform 4 unnecessary transfers instead of one,
++	 * increasing the chance of error.
++	 */
++	return regmap_write(rdev->regmap, rdev->desc->vsel_reg,
++			    sel | SY8106A_GO_BIT);
++}
++
++static const struct regulator_ops sy8106a_ops = {
++	.set_voltage_sel = sy8106a_set_voltage_sel,
++	.set_voltage_time_sel = regulator_set_voltage_time_sel,
++	.get_voltage_sel = regulator_get_voltage_sel_regmap,
++	.list_voltage = regulator_list_voltage_linear,
++	/* Enabling/disabling the regulator is not yet implemented */
++};
++
++/* Default limits measured in millivolts and milliamps */
++#define SY8106A_MIN_MV		680
++#define SY8106A_MAX_MV		1950
++#define SY8106A_STEP_MV		10
++
++static const struct regulator_desc sy8106a_reg = {
++	.name = "SY8106A",
++	.id = 0,
++	.ops = &sy8106a_ops,
++	.type = REGULATOR_VOLTAGE,
++	.n_voltages = ((SY8106A_MAX_MV - SY8106A_MIN_MV) / SY8106A_STEP_MV) + 1,
++	.min_uV = (SY8106A_MIN_MV * 1000),
++	.uV_step = (SY8106A_STEP_MV * 1000),
++	.vsel_reg = SY8106A_REG_VOUT1_SEL,
++	.vsel_mask = SY8106A_REG_VOUT1_SEL_MASK,
++	/*
++	 * This ramp_delay is a conservative default value which works on
++	 * H3/H5 boards VDD-CPUX situations.
++	 */
++	.ramp_delay = 200,
++	.owner = THIS_MODULE,
++};
++
++/*
++ * I2C driver interface functions
++ */
++static int sy8106a_i2c_probe(struct i2c_client *i2c,
++			    const struct i2c_device_id *id)
++{
++	struct sy8106a *chip;
++	struct device *dev = &i2c->dev;
++	struct regulator_dev *rdev = NULL;
++	struct regulator_config config = { };
++	unsigned int selector;
++	int error;
++
++	chip = devm_kzalloc(&i2c->dev, sizeof(struct sy8106a), GFP_KERNEL);
++	if (!chip)
++		return -ENOMEM;
++
++	chip->regmap = devm_regmap_init_i2c(i2c, &sy8106a_regmap_config);
++	if (IS_ERR(chip->regmap)) {
++		error = PTR_ERR(chip->regmap);
++		dev_err(&i2c->dev, "Failed to allocate register map: %d\n",
++			error);
++		return error;
++	}
++
++	config.dev = &i2c->dev;
++	config.regmap = chip->regmap;
++	config.driver_data = chip;
++
++	config.of_node = dev->of_node;
++	config.init_data = of_get_regulator_init_data(dev, dev->of_node,
++						      &sy8106a_reg);
++
++	if (!config.init_data)
++		return -ENOMEM;
++
++	/* Probe regulator */
++	error = regmap_read(chip->regmap, SY8106A_REG_VOUT1_SEL, &selector);
++	if (error) {
++		dev_err(&i2c->dev, "Failed to read voltage at probe time: %d\n", error);
++		return error;
++	}
++
++	rdev = devm_regulator_register(&i2c->dev, &sy8106a_reg, &config);
++	if (IS_ERR(rdev)) {
++		error = PTR_ERR(rdev);
++		dev_err(&i2c->dev, "Failed to register SY8106A regulator: %d\n", error);
++		return error;
++	}
++
++	chip->rdev = rdev;
++
++	i2c_set_clientdata(i2c, chip);
++
++	return 0;
++}
++
++static const struct of_device_id sy8106a_i2c_of_match[] = {
++	{ .compatible = "silergy,sy8106a" },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, sy8106a_i2c_of_match);
++
++static const struct i2c_device_id sy8106a_i2c_id[] = {
++	{ "sy8106a", 0 },
++	{ },
++};
++MODULE_DEVICE_TABLE(i2c, sy8106a_i2c_id);
++
++static struct i2c_driver sy8106a_regulator_driver = {
++	.driver = {
++		.name = "sy8106a",
++		.of_match_table	= of_match_ptr(sy8106a_i2c_of_match),
++	},
++	.probe = sy8106a_i2c_probe,
++	.id_table = sy8106a_i2c_id,
++};
++
++module_i2c_driver(sy8106a_regulator_driver);
++
++MODULE_AUTHOR("Ondřej Jirman <megous@megous.com>");
++MODULE_DESCRIPTION("Regulator device driver for Silergy SY8106A");
++MODULE_LICENSE("GPL v2");
+-- 
+2.13.5
+

--- a/projects/Allwinner/patches/linux/41-h3-h5-Add-r_i2c-controller.patch
+++ b/projects/Allwinner/patches/linux/41-h3-h5-Add-r_i2c-controller.patch
@@ -1,0 +1,45 @@
+From cb4faa1940f5a33c2406c03476cf37ccc32f1997 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Sun, 26 Feb 2017 16:09:28 +0100
+Subject: [PATCH 41/87] ARM: sunxi: h3/h5: Add r_i2c I2C controller
+
+Allwinner H3/H5 SoCs have an I2C controller at PL GPIO bank.
+
+Add support for it in the device tree.
+
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+[Icenowy: Change to use r_ccu and change pinmux node name]
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+Reviewed-by: Chen-Yu Tsai <wens@csie.org>
+---
+ arch/arm/boot/dts/sunxi-h3-h5.dtsi | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index 3a5f2aad7449..19fb71d29159 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -624,6 +624,20 @@
+ 			status = "disabled";
+ 		};
+ 
++		r_i2c: i2c@01f02400 {
++			compatible = "allwinner,sun6i-a31-i2c";
++			reg = <0x01f02400 0x400>;
++			interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&r_i2c_pins>;
++			clocks = <&r_ccu CLK_APB0_I2C>;
++			clock-frequency = <100000>;
++			resets = <&r_ccu RST_APB0_I2C>;
++			status = "disabled";
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++
+ 		r_pio: pinctrl@01f02c00 {
+ 			compatible = "allwinner,sun8i-h3-r-pinctrl";
+ 			reg = <0x01f02c00 0x400>;
+-- 
+2.13.5
+

--- a/projects/Allwinner/patches/linux/42-h3-h5-Add-r_i2c-pins.patch
+++ b/projects/Allwinner/patches/linux/42-h3-h5-Add-r_i2c-pins.patch
@@ -1,0 +1,35 @@
+From a741524891ac224a94817133c549adfc260ea3a4 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Sun, 26 Feb 2017 16:08:34 +0100
+Subject: [PATCH 40/87] ARM: sunxi: h3/h5: Add r_i2c pinmux node
+
+H3/H5 SoCs contain an I2C controller optionally available
+on the PL0 and PL1 pins. This patch adds pinmux configuration
+for this controller.
+
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+[Icenowy: change commit message, node name and function name]
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+---
+ arch/arm/boot/dts/sunxi-h3-h5.dtsi | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index d38282b9e5d4..3a5f2aad7449 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -639,6 +639,11 @@
+ 				pins = "PL11";
+ 				function = "s_cir_rx";
+ 			};
++
++			r_i2c_pins: r-i2c {
++				pins = "PL0", "PL1";
++				function = "s_i2c";
++			};
+ 		};
+ 	};
+ };
+-- 
+2.13.5
+

--- a/projects/Allwinner/patches/linux/43-H3-cpux-allow-set-parent.patch
+++ b/projects/Allwinner/patches/linux/43-H3-cpux-allow-set-parent.patch
@@ -1,0 +1,36 @@
+From 14663856bae0502be3efa0bff5506507b1e8af26 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Sun, 9 Apr 2017 02:10:34 +0800
+Subject: [PATCH 43/87] clk: sunxi-ng: allow set parent clock (PLL_CPUX) for
+ CPUX clock on H3
+
+The CPUX clock, which is the main clock of the ARM core on Allwinner H3,
+can be adjusted by changing the frequency of the PLL_CPUX clock.
+
+Allowing setting parent clock for the CPUX clock, thus the PLL_CPUX
+clock can be adjusted when adjusting the CPUX clock.
+
+Fixes: 0577e4853bfb ("clk: sunxi-ng: Add H3 clocks")
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+Reviewed-by: Chen-Yu Tsai <wens@csie.org>
+Acked-by: Stephen Boyd <sboyd@codeaurora.org>
+---
+ drivers/clk/sunxi-ng/ccu-sun8i-h3.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+index b886ebc55eaa..8321d2167cc3 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
++++ b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+@@ -135,7 +135,7 @@ static SUNXI_CCU_NM_WITH_FRAC_GATE_LOCK(pll_de_clk, "pll-de",
+ static const char * const cpux_parents[] = { "osc32k", "osc24M",
+ 					     "pll-cpux" , "pll-cpux" };
+ static SUNXI_CCU_MUX(cpux_clk, "cpux", cpux_parents,
+-		     0x050, 16, 2, CLK_IS_CRITICAL);
++		     0x050, 16, 2, CLK_IS_CRITICAL | CLK_SET_RATE_PARENT);
+ 
+ static SUNXI_CCU_M(axi_clk, "axi", "cpux", 0x050, 0, 2, 0);
+ 
+-- 
+2.13.5
+

--- a/projects/Allwinner/patches/linux/44-H3-clk-cpu-use-pll-notifier.patch
+++ b/projects/Allwinner/patches/linux/44-H3-clk-cpu-use-pll-notifier.patch
@@ -1,0 +1,52 @@
+From 33a54161aeee56fbf78b0222fd24ad9846dca269 Mon Sep 17 00:00:00 2001
+From: Chen-Yu Tsai <wens@csie.org>
+Date: Thu, 13 Apr 2017 10:13:54 +0800
+Subject: [PATCH 42/87] clk: sunxi-ng: h3: gate then ungate PLL CPU clk after
+ rate change
+
+This patch utilizes the new PLL clk notifier to gate then ungate the
+PLL CPU clock after rate changes. This should prevent any system hangs
+resulting from cpufreq changes to the clk.
+
+Fixes: 0577e4853bfb ("clk: sunxi-ng: Add H3 clocks")
+
+Reported-by: Ondrej Jirman <megous@megous.com>
+Signed-off-by: Chen-Yu Tsai <wens@csie.org>
+Tested-by: Icenowy Zheng <icenowy@aosc.io>
+Acked-by: Stephen Boyd <sboyd@codeaurora.org>
+---
+ drivers/clk/sunxi-ng/ccu-sun8i-h3.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+index 552a1ff3f4fc..b886ebc55eaa 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
++++ b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+@@ -1103,6 +1103,13 @@ static const struct sunxi_ccu_desc sun50i_h5_ccu_desc = {
+ 	.num_resets	= ARRAY_SIZE(sun50i_h5_ccu_resets),
+ };
+ 
++static struct ccu_pll_nb sun8i_h3_pll_cpu_nb = {
++	.common	= &pll_cpux_clk.common,
++	/* copy from pll_cpux_clk */
++	.enable	= BIT(31),
++	.lock	= BIT(28),
++};
++
+ static struct ccu_mux_nb sun8i_h3_cpu_nb = {
+ 	.common		= &cpux_clk.common,
+ 	.cm		= &cpux_clk.mux,
+@@ -1130,6 +1137,10 @@ static void __init sunxi_h3_h5_ccu_init(struct device_node *node,
+ 
+ 	sunxi_ccu_probe(node, reg, desc);
+ 
++	/* Gate then ungate PLL CPU after any rate changes */
++	ccu_pll_notifier_register(&sun8i_h3_pll_cpu_nb);
++
++	/* Reparent CPU during PLL CPU rate changes */
+ 	ccu_mux_notifier_register(pll_cpux_clk.common.hw.clk,
+ 				  &sun8i_h3_cpu_nb);
+ }
+-- 
+2.13.5
+

--- a/projects/Allwinner/patches/linux/45-add-h3-cpu-OPP-table.patch
+++ b/projects/Allwinner/patches/linux/45-add-h3-cpu-OPP-table.patch
@@ -1,0 +1,76 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
+index b36f9f42..de8cfb13 100644
+--- a/arch/arm/boot/dts/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/sun8i-h3.dtsi
+@@ -43,6 +43,71 @@
+ #include "sunxi-h3-h5.dtsi"
+ 
+ / {
++	cpu_opp_table: opp_table {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		opp@240000000 {
++			opp-hz = /bits/ 64 <240000000>;
++			opp-microvolt = <980000 980000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@480000000 {
++			opp-hz = /bits/ 64 <480000000>;
++			opp-microvolt = <980000 980000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@648000000 {
++			opp-hz = /bits/ 64 <648000000>;
++			opp-microvolt = <1000000 1000000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <1020000 1020000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@912000000 {
++			opp-hz = /bits/ 64 <912000000>;
++			opp-microvolt = <1040000 1040000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@960000000 {
++			opp-hz = /bits/ 64 <960000000>;
++			opp-microvolt = <1080000 1080000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <1140000 1140000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@1104000000 {
++			opp-hz = /bits/ 64 <1104000000>;
++			opp-microvolt = <1180000 1180000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <1240000 1240000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp@1296000000 {
++			opp-hz = /bits/ 64 <1296000000>;
++			opp-microvolt = <1320000 1320000 1320000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++	};
++
+ 	cpus {
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;

--- a/projects/Allwinner/patches/linux/46-H3-add-opp-table-to-cpu.patch
+++ b/projects/Allwinner/patches/linux/46-H3-add-opp-table-to-cpu.patch
@@ -1,0 +1,56 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
+index b36f9f42..02bbe834 100644
+--- a/arch/arm/boot/dts/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/sun8i-h3.dtsi
+@@ -47,28 +47,36 @@
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 
+-		cpu@0 {
++		cpu0: cpu@0 {
+ 			compatible = "arm,cortex-a7";
+ 			device_type = "cpu";
+ 			reg = <0>;
++			clocks = <&ccu CLK_CPUX>;
++			clock-names = "cpu";
++			operating-points-v2 = <&cpu_opp_table>;
++			cpu-supply = <&reg_cpu_fallback>;
++			#cooling-cells = <2>;
+ 		};
+ 
+ 		cpu@1 {
+ 			compatible = "arm,cortex-a7";
+ 			device_type = "cpu";
+ 			reg = <1>;
++			operating-points-v2 = <&cpu_opp_table>;
+ 		};
+ 
+ 		cpu@2 {
+ 			compatible = "arm,cortex-a7";
+ 			device_type = "cpu";
+ 			reg = <2>;
++			operating-points-v2 = <&cpu_opp_table>;
+ 		};
+ 
+ 		cpu@3 {
+ 			compatible = "arm,cortex-a7";
+ 			device_type = "cpu";
+ 			reg = <3>;
++			operating-points-v2 = <&cpu_opp_table>;
+ 		};
+ 	};
+ 
+@@ -79,6 +87,13 @@
+ 			     <GIC_PPI 11 (GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+ 			     <GIC_PPI 10 (GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>;
+ 	};
++
++	reg_cpu_fallback: reg_cpu_fallback  {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd-cpux-dummy";
++		regulator-min-microvolt = <1200000>;
++		regulator-max-microvolt = <1200000>;
++	};
+ };
+ 
+ &ccu {

--- a/projects/Allwinner/patches/linux/47-01-enable-dvfs-opi-zero.patch
+++ b/projects/Allwinner/patches/linux/47-01-enable-dvfs-opi-zero.patch
@@ -1,0 +1,39 @@
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+index b1502df7..ebab9f6c 100644
+--- a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+@@ -87,6 +87,23 @@
+ 		gpio = <&pio 0 20 GPIO_ACTIVE_HIGH>;
+ 	};
+ 
++	reg_sy8113b: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
++		enable-active-high;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++
+ 	wifi_pwrseq: wifi_pwrseq {
+ 		compatible = "mmc-pwrseq-simple";
+ 		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
+@@ -94,6 +111,10 @@
+ 	};
+ };
+ 
++&cpu0 {
++	cpu-supply = <&reg_sy8113b>;
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };

--- a/projects/Allwinner/patches/linux/47-02-enable-dvfs-opi-one.patch
+++ b/projects/Allwinner/patches/linux/47-02-enable-dvfs-opi-one.patch
@@ -1,0 +1,32 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
+index 5fea430e..7d7d339e 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
+@@ -87,6 +87,27 @@
+ 			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
+ 		};
+ 	};
++
++	reg_sy8113b: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
++		enable-active-high;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_sy8113b>;
+ };
+ 
+ &ehci0 {

--- a/projects/Allwinner/patches/linux/47-03-enable-dvfs-opi-pc.patch
+++ b/projects/Allwinner/patches/linux/47-03-enable-dvfs-opi-pc.patch
@@ -1,0 +1,36 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+index 1a044b17..0732d8c0 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+@@ -97,6 +97,10 @@
+ 	status = "okay";
+ };
+ 
++&cpu0 {
++	cpu-supply = <&reg_sy8106a>;
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };
+@@ -152,6 +156,20 @@
+ 	};
+ };
+ 
++&r_i2c {
++	status = "okay";
++
++	reg_sy8106a: regulator@65 {
++		compatible = "silergy,sy8106a";
++		reg = <0x65>;
++		regulator-name = "vdd-cpux";
++		regulator-min-microvolt = <1000000>;
++		regulator-max-microvolt = <1400000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++};
++
+ &r_pio {
+ 	leds_r_opc: led_pins@0 {
+ 		pins = "PL10";

--- a/projects/Allwinner/patches/linux/47-04-enable-dvfs-opi-2.patch
+++ b/projects/Allwinner/patches/linux/47-04-enable-dvfs-opi-2.patch
@@ -1,0 +1,36 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-2.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-2.dts
+index 8ff71b1b..7f4b2d42 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-2.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-2.dts
+@@ -113,6 +113,10 @@
+ 	status = "okay";
+ };
+ 
++&cpu0 {
++	cpu-supply = <&reg_sy8106a>;
++};
++
+ &ehci1 {
+ 	status = "okay";
+ };
+@@ -158,6 +162,20 @@
+ 	};
+ };
+ 
++&r_i2c {
++	status = "okay";
++
++	reg_sy8106a: regulator@65 {
++		compatible = "silergy,sy8106a";
++		reg = <0x65>;
++		regulator-name = "vdd-cpux";
++		regulator-min-microvolt = <1000000>;
++		regulator-max-microvolt = <1400000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++};
++
+ &r_pio {
+ 	leds_r_opc: led_pins@0 {
+ 		pins = "PL10";

--- a/projects/Allwinner/patches/linux/47-05-enable-dvfs-opi-lite.patch
+++ b/projects/Allwinner/patches/linux/47-05-enable-dvfs-opi-lite.patch
@@ -1,0 +1,32 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-lite.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-lite.dts
+index 9b47a0de..2db259ed 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-lite.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-lite.dts
+@@ -89,6 +89,27 @@
+ 			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
+ 		};
+ 	};
++
++	reg_sy8113b: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
++		enable-active-high;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_sy8113b>;
+ };
+ 
+ &ehci1 {

--- a/projects/Allwinner/patches/linux/48-cpufreq-dt-auto-create-platdev.patch
+++ b/projects/Allwinner/patches/linux/48-cpufreq-dt-auto-create-platdev.patch
@@ -1,0 +1,115 @@
+From edeec420de2407618de097977e76b572d9de1bcf Mon Sep 17 00:00:00 2001
+From: Viresh Kumar <viresh.kumar@linaro.org>
+Date: Wed, 16 Aug 2017 11:07:27 +0530
+Subject: cpufreq: dt-platdev: Automatically create cpufreq device with OPP v2
+
+The initial idea of creating the cpufreq-dt-platdev.c file was to keep a
+list of platforms that use the "operating-points" (V1) bindings and
+create cpufreq device for them only, as we weren't sure which platforms
+would want the device to get created automatically as some had their own
+cpufreq drivers as well, or wanted to initialize cpufreq after doing
+some stuff from platform code.
+
+But that wasn't the case with platforms using "operating-points-v2"
+property. We wanted the device to get created automatically without the
+need of adding them to the whitelist. Though, we will still have some
+exceptions where we don't want to create the device automatically.
+
+Rename the earlier platform list as *whitelist* and create a new
+*blacklist* as well.
+
+The cpufreq-dt device will get created if:
+- The platform is there in the whitelist OR
+- The platform has "operating-points-v2" property in CPU0's DT node and
+  isn't part of the blacklist .
+
+Reported-by: Geert Uytterhoeven <geert@linux-m68k.org>
+Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>
+Tested-by: Simon Horman <horms+renesas@verge.net.au>
+Reviewed-by: Masahiro Yamada <yamada.masahiro@socionext.com>
+Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+---
+ drivers/cpufreq/cpufreq-dt-platdev.c | 45 ++++++++++++++++++++++++++++++++----
+ 1 file changed, 40 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/cpufreq/cpufreq-dt-platdev.c b/drivers/cpufreq/cpufreq-dt-platdev.c
+index 8b88768..7c67a6c 100644
+--- a/drivers/cpufreq/cpufreq-dt-platdev.c
++++ b/drivers/cpufreq/cpufreq-dt-platdev.c
+@@ -9,11 +9,16 @@
+ 
+ #include <linux/err.h>
+ #include <linux/of.h>
++#include <linux/of_device.h>
+ #include <linux/platform_device.h>
+ 
+ #include "cpufreq-dt.h"
+ 
+-static const struct of_device_id machines[] __initconst = {
++/*
++ * Machines for which the cpufreq device is *always* created, mostly used for
++ * platforms using "operating-points" (V1) property.
++ */
++static const struct of_device_id whitelist[] __initconst = {
+ 	{ .compatible = "allwinner,sun4i-a10", },
+ 	{ .compatible = "allwinner,sun5i-a10s", },
+ 	{ .compatible = "allwinner,sun5i-a13", },
+@@ -107,21 +112,51 @@ static const struct of_device_id machines[] __initconst = {
+ 	{ }
+ };
+ 
++/*
++ * Machines for which the cpufreq device is *not* created, mostly used for
++ * platforms using "operating-points-v2" property.
++ */
++static const struct of_device_id blacklist[] __initconst = {
++	{ }
++};
++
++static bool __init cpu0_node_has_opp_v2_prop(void)
++{
++	struct device_node *np = of_cpu_device_node_get(0);
++	bool ret = false;
++
++	if (of_get_property(np, "operating-points-v2", NULL))
++		ret = true;
++
++	of_node_put(np);
++	return ret;
++}
++
+ static int __init cpufreq_dt_platdev_init(void)
+ {
+ 	struct device_node *np = of_find_node_by_path("/");
+ 	const struct of_device_id *match;
++	const void *data = NULL;
+ 
+ 	if (!np)
+ 		return -ENODEV;
+ 
+-	match = of_match_node(machines, np);
++	match = of_match_node(whitelist, np);
++	if (match) {
++		data = match->data;
++		goto create_pdev;
++	}
++
++	if (cpu0_node_has_opp_v2_prop() && !of_match_node(blacklist, np))
++		goto create_pdev;
++
+ 	of_node_put(np);
+-	if (!match)
+-		return -ENODEV;
++	return -ENODEV;
+ 
++create_pdev:
++	of_node_put(np);
+ 	return PTR_ERR_OR_ZERO(platform_device_register_data(NULL, "cpufreq-dt",
+-			       -1, match->data,
++			       -1, data,
+ 			       sizeof(struct cpufreq_dt_platform_data)));
+ }
+ device_initcall(cpufreq_dt_platdev_init);
+-- 
+cgit v1.1
+

--- a/projects/Allwinner/patches/linux/49-h3-add-mali-gpu-node.patch
+++ b/projects/Allwinner/patches/linux/49-h3-add-mali-gpu-node.patch
@@ -1,23 +1,8 @@
-From 77e91b470e7753e53a3c62959e601f16623f1888 Mon Sep 17 00:00:00 2001
-From: Icenowy Zheng <icenowy@aosc.io>
-Date: Tue, 1 Aug 2017 22:18:41 +0800
-Subject: [PATCH] ARM: sun8i: h3: add Mali device node
-
-Allwinner H3 SoC has a Mali-400MP2 GPU.
-
-Add its device node.
-
-Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
----
- arch/arm/boot/dts/sun8i-h3.dtsi | 41 +++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 41 insertions(+)
-
-diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
-index cd38d7e04606f..173d9d4f89837 100644
---- a/arch/arm/boot/dts/sun8i-h3.dtsi
-+++ b/arch/arm/boot/dts/sun8i-h3.dtsi
-@@ -81,6 +81,20 @@
- 		status = "disabled";
+diff -Nur a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
+--- a/arch/arm/boot/dts/sun8i-h3.dtsi	2017-10-11 21:11:11.000000000 +0200
++++ b/arch/arm/boot/dts/sun8i-h3.dtsi	2017-10-11 21:15:52.765304966 +0200
+@@ -151,6 +151,20 @@
+ 		io-channels = <&ths>;
  	};
  
 +	reserved-memory {
@@ -35,12 +20,13 @@ index cd38d7e04606f..173d9d4f89837 100644
 +	};
 +
  	soc {
- 		display_clocks: clock@1000000 {
- 			compatible = "allwinner,sun8i-a83t-de2-clk";
-@@ -246,6 +260,33 @@
- 			};
+ 		ths: thermal-sensor@1c25000 {
+ 			compatible = "allwinner,sun8i-h3-ths";
+@@ -161,6 +175,33 @@
+ 			#thermal-sensor-cells = <0>;
+ 			#io-channel-cells = <0>;
  		};
- 
++
 +		mali: gpu@1c40000 {
 +			compatible = "allwinner,sun8i-h3-mali",
 +				     "allwinner,sun7i-a20-mali", "arm,mali-400";
@@ -67,7 +53,6 @@ index cd38d7e04606f..173d9d4f89837 100644
 +			assigned-clocks = <&ccu CLK_GPU>;
 +			assigned-clock-rates = <384000000>;
 +		};
-+
- 		hdmi: hdmi@1ee0000 {
- 			compatible = "allwinner,h3-dw-hdmi";
- 			reg = <0x01ee0000 0x10000>,
+ 	};
+ 
+ 	thermal-zones {


### PR DESCRIPTION
This PR allows H3 SoC to achieve full performance since it can throttle based on SoC temperature. Till now it worked at fixed frequency which was set at 1 GHz instead of 1.296 GHz for safety reasons.

Unfortunately, I had to update some unrelated patches due to DT merge conflicts.