### PR TITLE
kodi: correct URL in service addon wrapper header

### DIFF
--- a/packages/mediacenter/kodi/scripts/service-addon-wrapper
+++ b/packages/mediacenter/kodi/scripts/service-addon-wrapper
@@ -1,6 +1,6 @@
 #!/bin/sh
 ################################################################################
-#      This file is part of LibreELEC - https://www.libreelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
 #      Copyright (C) 2017-present Team LibreELEC
 #
 #  LibreELEC is free software: you can redistribute it and/or modify


### PR DESCRIPTION
change from https://www.libreelec.tv to https://libreelec.tv