### PR TITLE
RTL8188EU: update to c5113ff

### DIFF
--- a/packages/linux-drivers/RTL8188EU/package.mk
+++ b/packages/linux-drivers/RTL8188EU/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="RTL8188EU"
-PKG_VERSION="18a5f33"
-PKG_SHA256="d03002573b6322d3d6b4b6646db2d8bb916715798e5202756bac31a9a9d15d08"
+PKG_VERSION="c5113ff"
+PKG_SHA256="c80bdf4740696eb2b903089efbb913b218c2f71a5c791dc91e43dd578528a440"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 # realtek: PKG_SITE="http://www.realtek.com.tw/downloads/downloadsView.aspx?Langid=1&PFid=48&Level=5&Conn=4&ProdID=274&DownTypeID=3&GetDown=false&Downloads=true"


### PR DESCRIPTION
RTL8188EU: update to c5113ff
Add TP-Link TL-WN722N v2
Fix buffer overrun warning

See changes at [lwfinger repository](https://github.com/lwfinger/rtl8188eu/compare/18a5f33b60e25bee0b4eea05bc91ba48611505c5...c5113ffec0e7081b1facc1f809e4d03e5d60e9d4)