### PR TITLE
hyperion: fix protobuf cmake patch

### DIFF
--- a/packages/addons/service/hyperion/patches/hyperion-0003-fix-protobuf-cmake.patch
+++ b/packages/addons/service/hyperion/patches/hyperion-0003-fix-protobuf-cmake.patch
@@ -1,7 +1,8 @@
-diff -Naur a/dependencies/CMakeLists.txt b/dependencies/CMakeLists.txt
---- a/dependencies/CMakeLists.txt	2016-09-06 13:58:55.000000000 -0700
-+++ b/dependencies/CMakeLists.txt	2016-11-09 23:25:20.458835732 -0800
-@@ -15,7 +15,7 @@
+diff --git a/dependencies/CMakeLists.txt b/dependencies/CMakeLists.txt
+index fe3d463..6ae8760 100644
+--- a/dependencies/CMakeLists.txt
++++ b/dependencies/CMakeLists.txt
+@@ -16,7 +16,7 @@ set(USE_SYSTEM_PROTO_LIBS OFF CACHE BOOL "use protobuf library from system")
  
  if (USE_SYSTEM_PROTO_LIBS)
  	find_package(Protobuf REQUIRED)
@@ -10,84 +11,42 @@ diff -Naur a/dependencies/CMakeLists.txt b/dependencies/CMakeLists.txt
  else ()
  	set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared protobuf library")
  	add_subdirectory(external/protobuf)
-@@ -38,79 +38,4 @@
- 	set(PROTOBUF_PROTOC_EXECUTABLE ${PROTOBUF_PROTOC_EXECUTABLE} PARENT_SCOPE)
+@@ -31,15 +31,15 @@ else ()
+ 	endif()
+ 
+ 	# define the include for the protobuf library at the parent scope
+-	set(PROTOBUF_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/external/protobuf/src")
+-	set(PROTOBUF_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIRS} PARENT_SCOPE)
++	set(Protobuf_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/external/protobuf/src")
++	set(Protobuf_INCLUDE_DIRS ${Protobuf_INCLUDE_DIRS} PARENT_SCOPE)
+ 
+ 	# define the protoc executable at the parent scope
+-	get_property(PROTOBUF_PROTOC_EXECUTABLE TARGET protoc_compiler PROPERTY LOCATION)
+-	set(PROTOBUF_PROTOC_EXECUTABLE ${PROTOBUF_PROTOC_EXECUTABLE} PARENT_SCOPE)
++	get_property(Protobuf_PROTOC_EXECUTABLE TARGET protoc_compiler PROPERTY LOCATION)
++	set(Protobuf_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE} PARENT_SCOPE)
  endif()
  
 -message(STATUS "Using protobuf compiler: " ${PROTOBUF_PROTOC_EXECUTABLE})
--
--#=============================================================================
--# Copyright 2009 Kitware, Inc.
--# Copyright 2009-2011 Philip Lowman <philip@yhbt.com>
--# Copyright 2008 Esben Mose Hansen, Ange Optimization ApS
--#
--# Distributed under the OSI-approved BSD License (the "License");
--# see accompanying file Copyright.txt for details.
--#
--# This software is distributed WITHOUT ANY WARRANTY; without even the
--# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
--# See the License for more information.
--#=============================================================================
--# (To distribute this file outside of CMake, substitute the full
--#  License text for the above reference.)
--function(PROTOBUF_GENERATE_CPP SRCS HDRS)
--	if(NOT ARGN)
--		message(SEND_ERROR "Error: PROTOBUF_GENERATE_CPP() called without any proto files")
--		return()
--	endif()
--
--	if(PROTOBUF_GENERATE_CPP_APPEND_PATH)
--		# Create an include path for each file specified
--		foreach(FIL ${ARGN})
--			get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
--			get_filename_component(ABS_PATH ${ABS_FIL} PATH)
--			list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
--			if(${_contains_already} EQUAL -1)
--				list(APPEND _protobuf_include_path -I ${ABS_PATH})
--			endif()
--		endforeach()
--	else()
--		set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
--	endif()
--
--	if(DEFINED PROTOBUF_IMPORT_DIRS)
--		foreach(DIR ${PROTOBUF_IMPORT_DIRS})
--			get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
--			list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
--			if(${_contains_already} EQUAL -1)
--				list(APPEND _protobuf_include_path -I ${ABS_PATH})
--			endif()
--		endforeach()
--	endif()
--
--	if(CMAKE_CROSSCOMPILING OR USE_SYSTEM_PROTO_LIBS)
--		set(PROTOC_DEPENDENCY ${PROTOBUF_PROTOC_EXECUTABLE})
--	else()
--		set(PROTOC_DEPENDENCY protoc_compiler)
--	endif()
--
--	set(${SRCS})
--	set(${HDRS})
--	foreach(FIL ${ARGN})
--		get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
--		get_filename_component(FIL_WE ${FIL} NAME_WE)
--
--		list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc")
--		list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h")
--
--		add_custom_command(
--			OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc"
--				   "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
--			COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
--			ARGS --cpp_out ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
--			DEPENDS ${ABS_FIL} ${PROTOC_DEPENDENCY}
--			COMMENT "Running C++ protocol buffer compiler on ${FIL}"
--			VERBATIM
--		)
--	endforeach()
--
--	set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
--	set(${SRCS} ${${SRCS}} PARENT_SCOPE)
--	set(${HDRS} ${${HDRS}} PARENT_SCOPE)
--endfunction()
 +message(STATUS "Using protobuf compiler: " ${Protobuf_PROTOC_EXECUTABLE})
+ 
+ #=============================================================================
+ # Copyright 2009 Kitware, Inc.
+@@ -86,7 +86,7 @@ function(PROTOBUF_GENERATE_CPP SRCS HDRS)
+ 	endif()
+ 
+ 	if(CMAKE_CROSSCOMPILING OR USE_SYSTEM_PROTO_LIBS)
+-		set(PROTOC_DEPENDENCY ${PROTOBUF_PROTOC_EXECUTABLE})
++		set(PROTOC_DEPENDENCY ${Protobuf_PROTOC_EXECUTABLE})
+ 	else()
+ 		set(PROTOC_DEPENDENCY protoc_compiler)
+ 	endif()
+@@ -103,7 +103,7 @@ function(PROTOBUF_GENERATE_CPP SRCS HDRS)
+ 		add_custom_command(
+ 			OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc"
+ 				   "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
+-			COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
++			COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+ 			ARGS --cpp_out ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
+ 			DEPENDS ${ABS_FIL} ${PROTOC_DEPENDENCY}
+ 			COMMENT "Running C++ protocol buffer compiler on ${FIL}"


### PR DESCRIPTION
On a clean build I can't seem to build hyperion for Odroid_C2 (I haven't tested others).

> 
> [ 72%] Building CXX object libsrc/protoserver/CMakeFiles/protoserver.dir/home/ray/tmp_LE/LibreELEC.tv/build.LibreELEC-Odroid_C2.arm-9.0-devel/hyperion-1c21232/libsrc/protoserver/message.pb.cc.o
> armv8a-libreelec-linux-gnueabi-g++-7.2.0: error: /home/ray/tmp_LE/LibreELEC.tv/build.LibreELEC-Odroid_C2.arm-9.0-devel/hyperion-1c21232/.armv8a-libreelec-linux-gnueabi/libsrc/protoserver/home/ray/tmp_LE/LibreELEC.tv/build.LibreELEC-Odroid_C2.arm-9.0-devel/hyperion-1c21232/libsrc/protoserver/message.pb.cc: No such file or directory
> armv8a-libreelec-linux-gnueabi-g++-7.2.0: fatal error: no input files
> compilation terminated.
> make[2]: *** [libsrc/protoserver/CMakeFiles/protoserver.dir/build.make:279: libsrc/protoserver/CMakeFiles/protoserver.dir/home/ray/tmp_LE/LibreELEC.tv/build.LibreELEC-Odroid_C2.arm-9.0-devel/hyperion-1c21232/libsrc/protoserver/message.pb.cc.o] Error 1
> make[2]: *** Waiting for unfinished jobs....
