### PR TITLE
Ncurses: update to latest master

### DIFF
--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="ncurses"
-PKG_VERSION="6.0-20170812"
+PKG_VERSION="6.0-20171007"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -122,11 +122,12 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     for patch_dir in $PKG_PATCH_DIRS; do
       [ -d $PKG_DIR/patches/$patch_dir ] && PATCH_DIRS_PKG="$PATCH_DIRS_PKG $PKG_DIR/patches/$patch_dir/*.patch"
       [ -d $PROJECT_DIR/$PROJECT/patches/$PKG_NAME/$patch_dir ] && PATCH_DIRS_PRJ="$PATCH_DIRS_PRJ $PROJECT_DIR/$PROJECT/patches/$PKG_NAME/$patch_dir/*.patch"
+      [ -d $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME/$patch_dir ] && PATCH_DIRS_PRJ="$PATCH_DIRS_PRJ $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME/$patch_dir/*.patch"
     done
   fi
 
-  for i in $PKG_DIR/patches/$PKG_NAME-*.patch \
-           $PKG_DIR/patches/$PATCH_ARCH/$PKG_NAME-*.patch \
+  for i in $PKG_DIR/patches/*.patch \
+           $PKG_DIR/patches/$PATCH_ARCH/*.patch \
            $PATCH_DIRS_PKG \
            $PKG_DIR/patches/$PKG_VERSION/*.patch \
            $PKG_DIR/patches/$PKG_VERSION/$PATCH_ARCH/*.patch \
@@ -157,6 +158,8 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     else
       if [[ "$thisdir" =~ ^$PKG_DIR/.* ]]; then
         PATCH_DESC="(common - $(basename "$thisdir"))"
+      elif [[ "$thisdir" =~ ^$PROJECT_DIR/.*/devices/.* ]]; then
+        PATCH_DESC="(device - $(basename "$thisdir"))"
       elif [[ "$thisdir" =~ ^$PROJECT_DIR/.* ]]; then
         PATCH_DESC="(project - $(basename "$thisdir"))"
       else


### PR DESCRIPTION
With the reintroduction of ncurses (version 20170812), i noticed artifacts especially using mc over ssh. Building version 20171007 i no longer notice these artifacts, so i think it's safe to update the package.mk (Caution, i tested only with mc 4.8.19 on two different openSUSE desktops connected via ssh to my htpc)