### PR TITLE
kodi: fix appliance.xml merge and more

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -24,6 +24,13 @@
         </setting>
       </group>
     </category>
+    <category id="logging">
+      <group id="1">
+        <setting id="debug.screenshotpath">
+          <default>/storage/screenshots/</default>
+        </setting>
+      </group>
+    </category>
   </section>
 
   <section id="services">

--- a/packages/mediacenter/kodi/config/guisettings.xml
+++ b/packages/mediacenter/kodi/config/guisettings.xml
@@ -1,7 +1,4 @@
 <settings>
-  <debug>
-    <screenshotpath pathversion="1">/storage/screenshots/</screenshotpath>
-  </debug>
   <general>
     <settinglevel>2</settinglevel>
   </general>

--- a/packages/mediacenter/kodi/scripts/xml_merge.py
+++ b/packages/mediacenter/kodi/scripts/xml_merge.py
@@ -11,6 +11,10 @@ from xml.etree import ElementTree as et
 def printerr(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
+class hashabledict(dict):
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))
+
 class XMLCombiner(object):
     def __init__(self, filenames):
         if len(filenames) == 0:
@@ -32,19 +36,19 @@ class XMLCombiner(object):
         return self.prettyPrint(self.roots[0])
 
     def combine_element(self, one, other):
-        mapping = {el.tag: el for el in one}
+        mapping = {(el.tag, hashabledict(el.attrib)): el for el in one}
         for el in other:
             if len(el) == 0:
                 try:
-                    mapping[el.tag].text = el.text
+                    mapping[(el.tag, hashabledict(el.attrib))].text = el.text
                 except KeyError:
-                    mapping[el.tag] = el
+                    mapping[(el.tag, hashabledict(el.attrib))] = el
                     one.append(el)
             else:
                 try:
-                    self.combine_element(mapping[el.tag], el)
+                    self.combine_element(mapping[(el.tag, hashabledict(el.attrib))], el)
                 except KeyError:
-                    mapping[el.tag] = el
+                    mapping[(el.tag, hashabledict(el.attrib))] = el
                     one.append(el)
 
 if __name__ == '__main__':

--- a/projects/imx6/kodi/guisettings.xml
+++ b/projects/imx6/kodi/guisettings.xml
@@ -1,10 +1,4 @@
 <settings>
-  <debug>
-    <screenshotpath pathversion="1">/storage/screenshots/</screenshotpath>
-  </debug>
-  <general>
-    <settinglevel>3</settinglevel>
-  </general>
   <audiooutput>
     <audiodevice>ALSA:hdmi:CARD=imxhdmisoc,DEV=0</audiodevice>
   </audiooutput>


### PR DESCRIPTION
This PR fixes merging of `appliance.xml` using the `xml_merge.py` script by including attributes when finding a matching element.

Also moves default `debug.screenshotpath` from `guisettings.xml` to `appliance.xml`, makes the value reset correctly when you select `Reset above settings to default`.

Finally removes inconsistent default `settinglevel` use by the imx6 project compared to all other projects.