### PR TITLE
buildsystem: add TARGET_FEATURES

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -191,7 +191,15 @@ get_pkg_variable() {
 
 # return 0 if $2 in space-separated list $1, otherwise return 1
 listcontains() {
-  [[ ${1} =~ (^|[[:space:]])${2}($|[[:space:]]) ]] && return 0 || return 1
+  if [ -n "$1" -a -n "$2" ]; then
+    [[ ${1} =~ (^|[[:space:]])${2}($|[[:space:]]) ]] && return 0 || return 1
+  else
+    return 1
+  fi
+}
+
+target_has_feature() {
+  listcontains "$TARGET_FEATURES" "$1"
 }
 
 install_binary_addon() {

--- a/packages/addons/addon-depends/libdvbcsa/package.mk
+++ b/packages/addons/addon-depends/libdvbcsa/package.mk
@@ -32,14 +32,12 @@ PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static --with-sysroot=$SYSROOT_PREFIX"
 
-if echo "$TARGET_FPU" | grep -q '^neon'; then
-  PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-neon"
-elif [ "$TARGET_ARCH" = aarch64 ]; then
+if target_has_feature neon; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-neon"
 elif [ "$TARGET_ARCH" = x86_64  ]; then
-  if echo "$PROJECT_CFLAGS" | grep -q '\-mssse3'; then
+  if target_has_feature ssse3; then
     PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-ssse3"
-  elif echo "$PROJECT_CFLAGS" | grep -q '\-msse2'; then
+  elif target_has_feature sse2; then
     PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-sse2"
   else
     PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-uint64"

--- a/packages/audio/flac/package.mk
+++ b/packages/audio/flac/package.mk
@@ -42,7 +42,7 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --with-ogg=$SYSROOT_PREFIX/usr \
                            --with-gnu-ld"
 
-if [ $TARGET_ARCH = "x86_64" ]; then
+if target_has_feature sse; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-sse"
 else
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --disable-sse"

--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -44,7 +44,7 @@ else
 fi
 
 # PulseAudio fails to build on aarch64 when NEON is enabled, so don't enable NEON for aarch64 until upstream supports it
-if echo "$TARGET_FPU" | grep -q '^neon'; then
+if [ "$TARGET_ARCH" = "arm" ] && target_has_feature neon; then
   PULSEAUDIO_NEON="--enable-neon-opt"
 else
   PULSEAUDIO_NEON="--disable-neon-opt"

--- a/packages/emulation/libretro-dinothawr/package.mk
+++ b/packages/emulation/libretro-dinothawr/package.mk
@@ -36,7 +36,7 @@ PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="DINOTHAWR_LIB"
 
 pre_make_target() {
-  if echo "$TARGET_FPU" | grep -q '^neon'; then
+  if target_has_feature neon; then
     export HAVE_NEON=1
   fi
 }

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -34,7 +34,7 @@ PKG_AUTORECONF="no"
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.gameclient"
 
-if [ "$DEVICE" == "RPi" ]; then
-  echo "RPi doesn't support neon"
+if ! target_has_feature neon; then
+  echo "${DEVICE:-${PROJECT}} doesn't support neon"
   exit 0
 fi

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -154,7 +154,7 @@ else
   KODI_SSH="-DENABLE_SSH=OFF"
 fi
 
-if echo "$TARGET_FPU" | grep -q '^neon' || [[ "$TARGET_ARCH" = "aarch64" ]]; then
+if target_has_feature neon; then
   KODI_NEON="-DENABLE_NEON=ON"
 else
   KODI_NEON="-DENABLE_NEON=OFF"

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -67,7 +67,7 @@ case "$TARGET_ARCH" in
     ;;
 esac
 
-if echo "$TARGET_FPU" | grep -q '^neon' || [[ "$TARGET_ARCH" = "aarch64" ]]; then
+if target_has_feature neon; then
   FFMPEG_FPU="--enable-neon"
 else
   FFMPEG_FPU="--disable-neon"

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -11,6 +11,7 @@
         # (Intel CPUs)  atom core2 nocona
         #
         TARGET_CPU="x86-64"
+        TARGET_FEATURES="64bit"
         ;;
     esac
 
@@ -46,6 +47,7 @@
 
   # Project CFLAGS
     PROJECT_CFLAGS="-mmmx -msse -msse2 -mfpmath=sse"
+    TARGET_FEATURES+=" mmx sse sse2"
 
   # SquashFS compression method (gzip / lzo / xz)
     SQUASHFS_COMPRESSION="gzip"

--- a/projects/Odroid_C2/options
+++ b/projects/Odroid_C2/options
@@ -20,6 +20,7 @@
         #
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+fp+simd"
+        TARGET_FEATURES="64bit neon"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -28,6 +29,7 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
+        TARGET_FEATURES="32bit neon"
         ;;
     esac
 

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -38,8 +38,10 @@
 
         if [ "$DEVICE" = "RPi" -o "$DEVICE" = "Slice" ]; then
           TARGET_FPU="vfp"
+          TARGET_FEATURES="32bit"
         elif [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ]; then
           TARGET_FPU="neon-vfpv4"
+          TARGET_FEATURES="32bit neon"
         fi
 
         ;;

--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -32,6 +32,7 @@
         # vfpv3xd vfpv3xd-fp16 neon neon-fp16 vfpv4 vfpv4-d16 fpv4-sp-d16
         # neon-vfpv4.
         TARGET_FPU="neon-fp16"
+        TARGET_FEATURES="32bit neon"
         ;;
     esac
 

--- a/projects/WeTek_Hub/options
+++ b/projects/WeTek_Hub/options
@@ -20,6 +20,7 @@
         #
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+fp+simd"
+        TARGET_FEATURES="64bit neon"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -28,6 +29,7 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
+        TARGET_FEATURES="32bit neon"
         ;;
     esac
 

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -32,6 +32,7 @@
         # vfpv3xd vfpv3xd-fp16 neon neon-fp16 vfpv4 vfpv4-d16 fpv4-sp-d16
         # neon-vfpv4.
         TARGET_FPU="neon-fp16"
+        TARGET_FEATURES="32bit neon"
         ;;
     esac
 

--- a/projects/WeTek_Play_2/options
+++ b/projects/WeTek_Play_2/options
@@ -20,6 +20,7 @@
         #
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+fp+simd"
+        TARGET_FEATURES="64bit neon"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -28,6 +29,7 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
+        TARGET_FEATURES="32bit neon"
         ;;
     esac
 

--- a/projects/imx6/options
+++ b/projects/imx6/options
@@ -9,6 +9,7 @@
         TARGET_CPU="cortex-a9"
         TARGET_FLOAT="hard"
         TARGET_FPU="neon"
+        TARGET_FEATURES="32bit neon"
         ;;
     esac
 


### PR DESCRIPTION
This implements a generic, reliable and extensible solution when testing for specific hardware features.

`arm` (but not `RPi`/`Slice`) and `aarch64` all now have `neon` support.

`Generic` has `mmx`, `sse2` and `sse3`.

I've added `32bit` and `64bit` as a "feature" in case this ever needs to be determined.

In future we could add endian (little/big) if this is ever needed.