### PR TITLE
ffmpeg: fix an issue in HEVC patch

### DIFF
--- a/packages/multimedia/ffmpeg/patches/ffmpeg-99.1001-pfcd_hevc_optimisations.patch
+++ b/packages/multimedia/ffmpeg/patches/ffmpeg-99.1001-pfcd_hevc_optimisations.patch
@@ -29153,7 +29153,7 @@ index 0000000000..b8bfad915e
 +#include "rpi_sand_fn_pw.h"
 +#undef PW
 +
-+#if defined(HAVE_NEON) && defined(__arm__)
++#if HAVE_NEON && ARCH_ARM
 +void rpi_sand128b_stripe_to_8_10(uint8_t * dest, const uint8_t * src1, const uint8_t * src2, unsigned int lines);
 +#endif
 +
@@ -29199,7 +29199,7 @@ index 0000000000..b8bfad915e
 +    // We make no effort to copy an exact width - round up to nearest src stripe
 +    // as we will always have storage in dest for that
 +
-+#if defined(HAVE_NEON) && defined(__arm__)
++#if HAVE_NEON && ARCH_ARM
 +    if (shr == 3 && src_stride1 == 128) {
 +        for (j = 0; j + n < w; j += dst_stride1) {
 +            uint8_t * d = dst + j * dst_stride2;


### PR DESCRIPTION
Fix an issue in HEVC patch caused by #2121, which leads to inclusion of ARM NEON code even when NEON is disabled.