### PR TITLE
distro-tool: ignore package output

### DIFF
--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -808,7 +808,7 @@ generate_work_worker() {
     while read -r package_name; do
       [ ${PROGRESS} == yes ] && progress ${pcount}
 
-      source config/options ${package_name} 2>/dev/null || true
+      source config/options ${package_name} &>/dev/null || true
 
       if [ -n "${revision}" ]; then
         PKG_URL="${PKG_URL/${PKG_VERSION}/${revision}}"


### PR DESCRIPTION
Some packages, such as [game.libretro.pcsx-rearmed](https://github.com/LibreELEC/LibreELEC.tv/blob/c863ecc017a06f314af5d21c95059f45d91b1d28/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk#L38), may output text when the package is sourced which corrupts the json data structure being generated by `distro-tool`. Ignore all such text.