### PR TITLE
TUF dependencies

### DIFF
--- a/packages/addons/addon-depends/python/cffi/package.mk
+++ b/packages/addons/addon-depends/python/cffi/package.mk
@@ -1,0 +1,33 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="cffi"
+PKG_VERSION="1.11.2"
+PKG_SHA256="ab87dd91c0c4073758d07334c1e5f712ce8fe48f007b86f8238773963ee700a6"
+PKG_LICENSE="MIT"
+PKG_SITE="http://cffi.readthedocs.io/"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_HOST="libffi:host"
+PKG_DEPENDS_TARGET="cffi:host libffi"
+PKG_LONGDESC="Foreign Function Interface for Python calling C code"
+
+PKG_IS_PYTHON="yes"
+
+pre_make_host() {
+  unset _python_exec_prefix _python_prefix _python_sysroot
+}

--- a/packages/addons/addon-depends/python/le_tuf/package.mk
+++ b/packages/addons/addon-depends/python/le_tuf/package.mk
@@ -1,0 +1,68 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="le_tuf"
+PKG_VERSION="1"
+PKG_LICENSE="GPLv2"
+PKG_DEPENDS_TARGET="cffi libsodium"
+PKG_LONGDESC="The Update Framework for LibreELEC"
+
+PKG_IS_PYTHON="yes"
+
+pre_make_target() {
+  export LDSHARED="-pthread"
+  export SODIUM_INSTALL="system"
+
+  touch dummy.py
+
+  cat << EOF > setup.py
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(name='$PKG_NAME',
+      version='$PKG_VERSION',
+      description='$PKG_LONGDESC',
+      author='Team LibreELEC',
+      url=' https://libreelec.tv',
+      py_modules = ['dummy'],
+      install_requires=[
+          "PyNaCl==1.1.2",
+          "asn1crypto==0.23.0",
+          "cryptography==2.1.3",
+          "enum34==1.1.6",
+          "idna==2.6",
+          "ipaddress==1.0.18",
+          "iso8601==0.1.12",
+          "natsort==5.1.0",
+          "pycryptodome==3.4.7",
+          "securesystemslib==0.10.7",
+          "six==1.11.0",
+          "tuf==0.10.0",
+        ],
+      dependency_links = [
+          "https://github.com/secure-systems-lab/securesystemslib/zipball/f7f51ac#egg=securesystemslib-0.10.7"
+        ],
+     )
+EOF
+}
+
+post_make_target() {
+  cp -r "$(get_build_dir cffi)"/.install_pkg/lib/*.egg \
+        "$INSTALL/lib"
+}

--- a/packages/addons/addon-depends/python/libsodium/package.mk
+++ b/packages/addons/addon-depends/python/libsodium/package.mk
@@ -1,0 +1,31 @@
+###############################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libsodium"
+PKG_VERSION="1.0.13"
+PKG_SHA256="83c3017600bf18b349bfcf97cb8bf07e97ee2793743e860a83a0f08a2c251593"
+PKG_LICENSE="ISC"
+PKG_SITE="https://libsodium.org/"
+PKG_URL="https://github.com/jedisct1/libsodium/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Sodium is a modern, easy-to-use software library for encryption, decryption, signatures, password hashing and more."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"

--- a/scripts/build
+++ b/scripts/build
@@ -209,6 +209,11 @@ if [ ! -f $STAMP ]; then
       fi
     fi
 
+    if [ "$PKG_IS_PYTHON" = "yes" ]; then
+      PKG_DEPENDS_HOST="toolchain distutilscross:host $PKG_DEPENDS_HOST"
+      PKG_DEPENDS_TARGET="toolchain distutilscross:host Python2 $PKG_DEPENDS_TARGET"
+    fi
+
     if [ "$TARGET" = "target" ]; then
       for p in $PKG_DEPENDS_TARGET; do
         $SCRIPTS/build $p
@@ -374,11 +379,29 @@ if [ ! -f $STAMP ]; then
         fi
       else
         if [ "$TARGET" = "target" ]; then
-          echo "Executing (target): make $PKG_MAKE_OPTS_TARGET" | tr -s " "
-          make $PKG_MAKE_OPTS_TARGET
+          if [ "$PKG_IS_PYTHON" = "yes" ]; then
+            echo "Executing (target): python setup.py build $PKG_PYTHON_OPTS_TARGET" | tr -s " "
+            mkdir -p ".$TARGET_NAME"
+            cd ".$TARGET_NAME"
+            cp -r ../* .
+            export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include -L$SYSROOT_PREFIX/usr/lib"
+            export LDSHARED="$CC -shared $LDSHARED"
+            export PYTHONXCPREFIX="$SYSROOT_PREFIX/usr"
+            mkdir -p "$INSTALL/lib"
+            PYTHONPATH="$INSTALL/lib" python setup.py easy_install \
+              --always-unzip \
+              --install-dir "$INSTALL/lib" \
+              --script-dir "$INSTALL/bin"\
+              .
+          else
+            echo "Executing (target): make $PKG_MAKE_OPTS_TARGET" | tr -s " "
+            make $PKG_MAKE_OPTS_TARGET
+          fi
         elif [ "$TARGET" = "host" ]; then
-          echo "Executing (host): make $PKG_MAKE_OPTS_HOST" | tr -s " "
-          make $PKG_MAKE_OPTS_HOST
+          if [ "$PKG_IS_PYTHON" != "yes" ]; then
+            echo "Executing (host): make $PKG_MAKE_OPTS_HOST" | tr -s " "
+            make $PKG_MAKE_OPTS_HOST
+          fi
         elif [ "$TARGET" = "init" ]; then
           echo "Executing (init): make $PKG_MAKE_OPTS_INIT" | tr -s " "
           make $PKG_MAKE_OPTS_INIT
@@ -410,10 +433,26 @@ if [ ! -f $STAMP ]; then
         fi
       else
         if [ "$TARGET" = "target" ]; then
-          $MAKEINSTALL $PKG_MAKEINSTALL_OPTS_TARGET
-          make install DESTDIR=$INSTALL $PKG_MAKEINSTALL_OPTS_TARGET
+          if [ "$PKG_IS_PYTHON" = "yes" ]; then
+            find $INSTALL/lib -name "*.py" -exec rm -rf "{}" ";"
+            for egg in "$INSTALL"/lib/*.egg; do
+              echo "Installed $(basename $egg)"
+            done
+          else
+            $MAKEINSTALL $PKG_MAKEINSTALL_OPTS_TARGET
+            make install DESTDIR=$INSTALL $PKG_MAKEINSTALL_OPTS_TARGET
+          fi
         elif [ "$TARGET" = "host" ]; then
-          make install $PKG_MAKEINSTALL_OPTS_HOST
+          if [ "$PKG_IS_PYTHON" = "yes" ]; then
+            mkdir -p ".$HOST_NAME"
+            cd ".$HOST_NAME"
+            cp -r ../* .
+            export LDSHARED="$CC -shared $LDSHARED"
+            python setup.py build
+            python setup.py install
+          else
+            make install $PKG_MAKEINSTALL_OPTS_HOST
+          fi
         elif [ "$TARGET" = "init" ]; then
           make install DESTDIR=$INSTALL $PKG_MAKEINSTALL_OPTS_INIT
         elif [ "$TARGET" = "bootstrap" ]; then


### PR DESCRIPTION
@Raybuntu 
Here is an alternative for TUF dependencies. Python dependencies are found in "$(get_build_dir le_tuf)/.install_pkg/lib/python)". You know where to find libsodium.

It will be possible to add securesystemslib through setup.py of le_tuf and thus remove the securesystemslib package when https://github.com/secure-systems-lab/securesystemslib/commit/d60b1c1ea5bb8678f6b2badf95298d9ad69ea3c9#diff-2eeaed663bd0d25b7e608891384b7298 is released.

It is not possible to simplify cffi, but hey, this is how it works.

Full version control of Python packages is possible through setup.py of le_tuf (I updated cryptography to 2.1.1).

This considerably reduces the number of packages to maintain.

I hope you will find the time to confirm this works. Thank you in advance.