### PR TITLE
Package Updates: Various x86-related packages

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libva-utils"
-PKG_VERSION="1.8.3"
-PKG_SHA256="c59de4fb6f1021c435b3f49e2410760692324ee5bb464c716d674fcb626a7e03"
+PKG_VERSION="2.0.0"
+PKG_SHA256="a921df31311d8f49d2e392a5fc2a068d79f89aeb588309fbff24365310dbc5f6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -18,8 +18,8 @@
 ################################################################################
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.82"
-PKG_SHA256="43fa2dbd422d6d41ac141272cc9855360ce4d08c7cf7f2c7bb55dfe449c4ce1c"
+PKG_VERSION="2.4.85"
+PKG_SHA256="64e4cd87eaee38ae60b2984ef02b66159b9bdd33030040db2a04339cf15f6173"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://dri.freedesktop.org"

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="mesa"
-PKG_VERSION="17.2.2"
-PKG_SHA256="cf522244d6a5a1ecde3fc00e7c96935253fe22f808f064cab98be6f3faa65782"
+PKG_VERSION="17.2.3"
+PKG_SHA256="a0b0ec8f7b24dd044d7ab30a8c7e6d3767521e245f88d4ed5dd93315dc56f837"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"

--- a/packages/multimedia/intel-vaapi-driver/package.mk
+++ b/packages/multimedia/intel-vaapi-driver/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="intel-vaapi-driver"
-PKG_VERSION="1.8.3"
-PKG_SHA256="54411d9e579300ed63f8b9b06152a1a9ec95b7699507d7ffa014cd7b2aeaff6f"
+PKG_VERSION="2.0.0"
+PKG_SHA256="10f6b0a91f34715d8d4d9a9e0fb3cc0afe5fcf85355db1272bd5fff31522f469"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libva"
-PKG_VERSION="1.8.3"
-PKG_SHA256="56ee129deba99b06eb4a8d4f746b117c5d1dc2ec5b7a0bfc06971fca1598ab9b"
+PKG_VERSION="2.0.0"
+PKG_SHA256="bb0601f9a209e60d8d0b867067323661a7816ff429021441b775452b8589e533"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -25,8 +25,8 @@
 #   there: http://forum.xbmc.org/showthread.php?tid=177557
 
 PKG_NAME="curl"
-PKG_VERSION="7.54.0"
-PKG_SHA256="f50ebaf43c507fa7cc32be4b8108fa8bbd0f5022e90794388f3c7694a302ff06"
+PKG_VERSION="7.56.1"
+PKG_SHA256="2594670367875e7d87b0f129b5e4690150780884d90244ba0fe3e74a778b5f90"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="http://curl.haxx.se"

--- a/packages/x11/data/xkeyboard-config/package.mk
+++ b/packages/x11/data/xkeyboard-config/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="xkeyboard-config"
-PKG_VERSION="2.20"
-PKG_SHA256="d1bfc72553c4e3ef1cd6f13eec0488cf940498b612ab8a0b362e7090c94bc134"
+PKG_VERSION="2.22"
+PKG_SHA256="deaec9989fbc443358b43864437b7b6d39caff07890a4a8055105ce9fcaa59bd"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"

--- a/packages/x11/driver/xf86-input-libinput/package.mk
+++ b/packages/x11/driver/xf86-input-libinput/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="xf86-input-libinput"
-PKG_VERSION="0.25.1"
-PKG_SHA256="489f7d591c9ef08463d4966e61f7c6ea433f5fcbb9f5370fb621da639a84c7e0"
+PKG_VERSION="0.26.0"
+PKG_SHA256="abca558fc2226f295691f1cf3412d4c0edeaa439f677ca25b5c9fab310d2387b"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libinput/"

--- a/packages/x11/lib/libXfont2/package.mk
+++ b/packages/x11/lib/libXfont2/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libXfont2"
-PKG_VERSION="2.0.1"
-PKG_SHA256="e9fbbb475ddd171b3a6a54b989cbade1f6f874fc35d505ebc5be426bc6e4db7e"
+PKG_VERSION="2.0.2"
+PKG_SHA256="94088d3b87f7d42c7116d9adaad155859e93330c6e47f5989f2de600b9a6c111"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"

--- a/packages/x11/lib/libpciaccess/package.mk
+++ b/packages/x11/lib/libpciaccess/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libpciaccess"
-PKG_VERSION="0.13.5"
-PKG_SHA256="752c54e9b3c311b4347cb50aea8566fa48eab274346ea8a06f7f15de3240b999"
+PKG_VERSION="0.14"
+PKG_SHA256="3df543e12afd41fea8eac817e48cbfde5aed8817b81670a4e9e493bb2f5bf2a4"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://freedesktop.org"

--- a/packages/x11/other/fontconfig/package.mk
+++ b/packages/x11/other/fontconfig/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="fontconfig"
-PKG_VERSION="2.12.4"
-PKG_SHA256="fd5a6a663f4c4a00e196523902626654dd0c4a78686cbc6e472f338e50fdf806"
+PKG_VERSION="2.12.6"
+PKG_SHA256="064b9ebf060c9e77011733ac9dc0e2ce92870b574cca2405e11f5353a683c334"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.fontconfig.org"
@@ -42,6 +42,9 @@ pre_configure_target() {
   CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-O3|-O2|"`
   CFLAGS="$CFLAGS -I$PKG_BUILD"
   CXXFLAGS="$CXXFLAGS -I$PKG_BUILD"
+
+  # Delete this as a workaround https://bugs.freedesktop.org/show_bug.cgi?id=101280
+  rm -f $PKG_BUILD/src/fcobjshash.h
 }
 
 post_makeinstall_target() {


### PR DESCRIPTION
Release notes:

| Package | Version | Announce |
| ---- | ---- | ---- |
| intel-vaapi-driver | 2.0.0 | [2.0.0](https://github.com/01org/intel-vaapi-driver/releases/tag/2.0.0) |
| libva | 2.0.0 | [2.0.0](https://github.com/01org/libva/releases/tag/2.0.0) |
| libva-utils | 2.0.0 | [2.0.0](https://github.com/01org/libva-utils/releases/tag/2.0.0) |
| mesa | 17.2.3 | [17.2.3](https://www.mesa3d.org/relnotes/17.2.3.html) |
| libdrm | 2.4.85 | [2.4.84](https://lists.x.org/archives/xorg-announce/2017-October/002815.html), [2.4.83](https://lists.x.org/archives/xorg-announce/2017-August/002804.html) |
| libXfont2 | 2.0.2 | [2.0.2](https://lists.x.org/archives/xorg-announce/2017-October/002813.html) |
| libpciaccess | 0.14 | [0.14](https://lists.x.org/archives/xorg-announce/2017-October/002817.html) |
| xkeyboard-config | 2.22 | [2.22](https://lists.x.org/archives/xorg-announce/2017-October/002811.html), [2.21](https://lists.x.org/archives/xorg-announce/2017-May/002800.html) |
| fontconfig | 2.12.6 | [2.12.6](https://www.freedesktop.org/software/fontconfig/release/ChangeLog-2.12.6), [2.12.5](https://www.freedesktop.org/software/fontconfig/release/ChangeLog-2.12.5) |
| xf86-input-libinput | 0.26.0 | [0.26.0](https://lists.x.org/archives/xorg-announce/2017-September/002807.html) |
| curl | 7.56.1 | [7.56.1](https://curl.haxx.se/changes.html#7_56_1), [7.56.0](https://curl.haxx.se/changes.html#7_56_0), [7.55.1](https://curl.haxx.se/changes.html#7_55_1), [7.55.0](https://curl.haxx.se/changes.html#7_55_0), [7.54.1](https://curl.haxx.se/changes.html#7_54_1) |

Build and run-time tested OK on Sjylake NUC + Revo 3700 with ION2.