### PR TITLE
misc: cleanup items for 8.2.0

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -18,7 +18,6 @@
 
 PKG_NAME="ffmpegx"
 PKG_VERSION="3.4"
-PKG_SHA256="2865712ead48b9e5939c1eb23c409c8f1d60e49bc6434ca489271ea677c81adc"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="audiodecoder.asap"
-PKG_VERSION="6c13ee6"
+PKG_VERSION="e56a821"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="audiodecoder.upse"
-PKG_VERSION="de58ded"
+PKG_VERSION="23a5430"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="audiodecoder.usf"
-PKG_VERSION="99c17c9"
+PKG_VERSION="c7fa708"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="audiodecoder.wsr"
-PKG_VERSION="ac3e274"
+PKG_VERSION="746fcbb"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -70,10 +70,12 @@ if [ "$SAMBA_SECURE" == "true" -a ! "$SAMBA_USERNAME" == "" -a ! "$SAMBA_PASSWOR
   sed -e 's|^.[ \t]*.public.=.*|  public = no |' \
       -e 's|^.[ \t]*.username map.=.*||' \
       -e 's|^.[ \t]*.security.=.*|  security = user\n  username map = /run/samba/samba.map|' \
+      -e 's|^.[ \t]*.map.to.guest.=.*|  map to guest = Never|' \
       -i $SMB_CONF
 else
   sed -e 's|^.[ \t]*.public.=.*|  public = yes |' \
       -e 's|^.[ \t]*.username map.=.*||' \
       -e 's|^.[ \t]*.security.=.*|  security = user|' \
+      -e 's|^.[ \t]*.map.to.guest.=.*|  map to guest = Bad User|' \
       -i $SMB_CONF
 fi


### PR DESCRIPTION
These add-ons have not been correctly forked with a Krypton branch so the update script finds HEAD which pulls in updates for Leia that break compile. I doubt there will be many updates for these going forwards, but we need to be careful - vis.shadertoy also fails for the same reason.