### PR TITLE
emulation: Replace DEVICE and PROJECT variables with TARGET_CPU

### DIFF
--- a/packages/emulation/libretro-beetle-pcfx/package.mk
+++ b/packages/emulation/libretro-beetle-pcfx/package.mk
@@ -34,28 +34,21 @@ PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="BEETLE-PCFX_LIB"
 
 make_target() {
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make platform=armv6-hardfloat
-          ;;
-        RPi2)
-          make platform=armv7-neon-hardfloat
-          ;;
-      esac
+  case $TARGET_CPU in
+    arm1176jzf-s)
+      make platform=armv6-hardfloat
       ;;
-    imx6)
-      make platform=armv7-cortexa9-neon-hardfloat
+    cortex-a7)
+      make platform=armv7-neon-hardfloat
       ;;
-    WeTek_Play|WeTek_Core|Odroid_C2|WeTek_Hub|WeTek_Play_2)
+    cortex-a9|cortex-a53|cortex-a17)
       if [ "$TARGET_ARCH" = "aarch64" ]; then
         make platform=aarch64
       else
         make platform=armv7-cortexa9-neon-hardfloat
       fi
       ;;
-    Generic)
+    x86-64)
       make
       ;;
   esac

--- a/packages/emulation/libretro-craft/package.mk
+++ b/packages/emulation/libretro-craft/package.mk
@@ -40,29 +40,28 @@ pre_configure_target() {
 }
 
 make_target() {
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make -f Makefile.libretro platform=rpi
-          ;;
-        RPi2)
-          make -f Makefile.libretro platform=rpi2
-          ;;
-      esac
-      ;;
-    imx6)
-      make -f Makefile.libretro platform=imx6
-      ;;
-    WeTek_Play|WeTek_Core|Odroid_C2|WeTek_Hub|WeTek_Play_2)
-      if [ "$TARGET_ARCH" = "aarch64" ]; then
-        make -f Makefile.libretro platform=aarch64
-      else
-        make -f Makefile.libretro platform=armv7-neon-gles-cortex-a9
-      fi
+
+  if [ -z "$DEVICE" ]; then
+    PKG_DEVICE_NAME=$PROJECT
+  else
+    PKG_DEVICE_NAME=$DEVICE
+  fi
+
+  case $PKG_DEVICE_NAME in
+    RPi|RPi2)
+      make -f Makefile.libretro platform=${PKG_DEVICE_NAME,,}
       ;;
     Generic)
       make -f Makefile.libretro
+      ;;
+    *)
+      if [ "$TARGET_CPU" = "cortex-a9" ] || [ "$TARGET_CPU" = "cortex-a53" ] || [ "$TARGET_CPU" = "cortex-a17" ]; then
+        if [ "$TARGET_ARCH" = "aarch64" ]; then
+          make -f Makefile.libretro platform=aarch64
+        else
+          make -f Makefile.libretro platform=armv7-neon-gles-cortex-a9
+        fi
+      fi
       ;;
   esac
 }

--- a/packages/emulation/libretro-desmume/package.mk
+++ b/packages/emulation/libretro-desmume/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="libretro wrapper for desmume NDS emulator."
 PKG_LONGDESC="libretro wrapper for desmume NDS emulator."
+PKG_TOOLCHAIN="make"
 
 PKG_LIBNAME="desmume_libretro.so"
 PKG_LIBPATH="desmume/$PKG_LIBNAME"

--- a/packages/emulation/libretro-desmume/package.mk
+++ b/packages/emulation/libretro-desmume/package.mk
@@ -17,32 +17,32 @@
 ################################################################################
 
 PKG_NAME="libretro-desmume"
-PKG_VERSION="1dd58e4"
-PKG_SHA256="0cc647defbbfbe0995e4dfe825e5bf67345ad1f9d8e7e29cdb94c32032c490c4"
+PKG_VERSION="9464582"
+PKG_SHA256="706af70135e1a33845d1b24163b9ab496f61219c958598d90d2283f6b4ee79b9"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
-PKG_SITE="https://github.com/libretro/desmume-libretro"
-PKG_URL="https://github.com/libretro/desmume-libretro/archive/$PKG_VERSION.tar.gz"
-PKG_SOURCE_DIR="desmume-libretro-$PKG_VERSION*"
+PKG_SITE="https://github.com/libretro/desmume"
+PKG_URL="https://github.com/libretro/desmume/archive/$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="desmume-$PKG_VERSION*"
 PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="libretro wrapper for desmume NDS emulator."
 PKG_LONGDESC="libretro wrapper for desmume NDS emulator."
 
 PKG_LIBNAME="desmume_libretro.so"
-PKG_LIBPATH="$PKG_LIBNAME"
+PKG_LIBPATH="desmume/$PKG_LIBNAME"
 PKG_LIBVAR="DESMUME_LIB"
 
 make_target() {
   case $TARGET_CPU in
     arm1176jzf-s)
-      make -f Makefile.libretro platform=armv6-hardfloat-$TARGET_CPU
+      make -C desmume -f Makefile.libretro platform=armv6-hardfloat-$TARGET_CPU
       ;;
     cortex-a7|cortex-a9)
-      make -f Makefile.libretro platform=armv7-neon-hardfloat-$TARGET_CPU
+      make -C desmume -f Makefile.libretro platform=armv7-neon-hardfloat-$TARGET_CPU
       ;;
     x86-64)
-      make -f Makefile.libretro
+      make -C desmume -f Makefile.libretro
       ;;
   esac
 }

--- a/packages/emulation/libretro-desmume/package.mk
+++ b/packages/emulation/libretro-desmume/package.mk
@@ -34,24 +34,14 @@ PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="DESMUME_LIB"
 
 make_target() {
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make -f Makefile.libretro platform=armv6-hardfloat-arm1176jzf-s
-          ;;
-        RPi2)
-          make -f Makefile.libretro platform=armv7-neon-hardfloat-cortex-a7
-          ;;
-      esac
+  case $TARGET_CPU in
+    arm1176jzf-s)
+      make -f Makefile.libretro platform=armv6-hardfloat-$TARGET_CPU
       ;;
-    imx6)
-      make -f Makefile.libretro platform=armv7-neon-hardfloat-cortex-a9
+    cortex-a7|cortex-a9)
+      make -f Makefile.libretro platform=armv7-neon-hardfloat-$TARGET_CPU
       ;;
-    WeTek_Play|WeTek_Core)
-      make -f Makefile.libretro platform=armv7-neon-hardfloat-cortex-a9
-      ;;
-    Generic)
+    x86-64)
       make -f Makefile.libretro
       ;;
   esac

--- a/packages/emulation/libretro-mame2010/package.mk
+++ b/packages/emulation/libretro-mame2010/package.mk
@@ -41,28 +41,21 @@ pre_make_target() {
 }
 
 make_target() {
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make platform=armv6-hardfloat-arm1176jzf-s
-          ;;
-        RPi2)
-          make platform=armv7-neon-hardfloat-cortex-a7
-          ;;
-      esac
+  case $TARGET_CPU in
+    arm1176jzf-s)
+      make platform=armv6-hardfloat-$TARGET_CPU
       ;;
-    imx6)
-      make platform=armv7-neon-hardfloat-cortex-a9
+    cortex-a7|cortex-a9)
+      make platform=armv7-neon-hardfloat-$TARGET_CPU
       ;;
-    WeTek_Play|WeTek_Core|Odroid_C2|WeTek_Hub|WeTek_Play_2)
+    cortex-a53|cortex-a17)
       if [ "$TARGET_ARCH" = "aarch64" ]; then
         make platform=aarch64
       else
         make platform=armv7-neon-hardfloat-cortex-a9
       fi
       ;;
-    Generic)
+    x86-64)
       make
       ;;
   esac

--- a/packages/emulation/libretro-mame2014/package.mk
+++ b/packages/emulation/libretro-mame2014/package.mk
@@ -41,28 +41,21 @@ pre_make_target() {
 }
 
 make_target() {
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make platform=armv6-hardfloat-arm1176jzf-s
-          ;;
-        RPi2)
-          make platform=armv7-neon-hardfloat-cortex-a7
-          ;;
-      esac
+  case $TARGET_CPU in
+    arm1176jzf-s)
+      make platform=armv6-hardfloat-$TARGET_CPU
       ;;
-    imx6)
-      make platform=armv7-neon-hardfloat-cortex-a9
+    cortex-a7|cortex-a9)
+      make platform=armv7-neon-hardfloat-$TARGET_CPU
       ;;
-    WeTek_Play|WeTek_Core|Odroid_C2|WeTek_Hub|WeTek_Play_2)
+    cortex-a53|cortex-a17)
       if [ "$TARGET_ARCH" = "aarch64" ]; then
         make platform=aarch64
       else
         make platform=armv7-neon-hardfloat-cortex-a9
       fi
       ;;
-    Generic)
+    x86-64)
       make
       ;;
   esac

--- a/packages/emulation/libretro-mupen64plus/package.mk
+++ b/packages/emulation/libretro-mupen64plus/package.mk
@@ -34,29 +34,32 @@ PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="MUPEN64PLUS_LIB"
 
 make_target() {
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make platform=rpi
-          ;;
-        RPi2)
-          make platform=rpi2
-          ;;
-      esac
-      ;;
-    imx6)
-      make platform=imx6
-      ;;
-    WeTek_Play|WeTek_Core|Odroid_C2|WeTek_Hub|WeTek_Play_2)
-      if [ "$TARGET_ARCH" = "aarch64" ]; then
-        make platform=aarch64
-      else
-        make platform=armv7-neon-gles-cortex-a9
-      fi
+
+  if target_has_feature neon; then
+    export HAVE_NEON=1
+  fi
+
+  if [ -z "$DEVICE" ]; then
+    PKG_DEVICE_NAME=$PROJECT
+  else
+    PKG_DEVICE_NAME=$DEVICE
+  fi
+
+  case $PKG_DEVICE_NAME in
+    RPi|RPi2)
+      make platform=${PKG_DEVICE_NAME,,}
       ;;
     Generic)
       make WITH_DYNAREC=x86_64
+      ;;
+    *)
+      if [ "$TARGET_CPU" = "cortex-a9" ] || [ "$TARGET_CPU" = "cortex-a53" ] || [ "$TARGET_CPU" = "cortex-a17" ]; then
+        if [ "$TARGET_ARCH" = "aarch64" ]; then
+          make platform=aarch64
+        else
+          make WITH_DYNAREC=arm 
+        fi
+      fi
       ;;
   esac
 }

--- a/packages/emulation/libretro-mupen64plus/package.mk
+++ b/packages/emulation/libretro-mupen64plus/package.mk
@@ -57,7 +57,7 @@ make_target() {
         if [ "$TARGET_ARCH" = "aarch64" ]; then
           make platform=aarch64
         else
-          make WITH_DYNAREC=arm 
+          make platform=linux-gles FORCE_GLES=1 WITH_DYNAREC=arm
         fi
       fi
       ;;

--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -40,28 +40,21 @@ pre_make_target() {
 
 make_target() {
   cd $PKG_BUILD
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make -f Makefile.libretro platform=armv6-hardfloat-arm1176jzf-s
-          ;;
-        RPi2)
-          make -f Makefile.libretro platform=armv7-neon-hardfloat-cortex-a7
-          ;;
-      esac
+  
+  if target_has_feature neon; then
+    export HAVE_NEON=1
+   else
+    export HAVE_NEON=0
+  fi
+  
+  case $TARGET_ARCH in
+    aarch64)
+      make -f Makefile.libretro platform=aarch64
       ;;
-    imx6)
-      make -f Makefile.libretro platform=armv7-neon-hardfloat-cortex-a9
+    arm)
+      make -f Makefile.libretro USE_DYNAREC=1
       ;;
-    WeTek_Play|WeTek_Core|Odroid_C2|WeTek_Hub|WeTek_Play_2)
-      if [ "$TARGET_ARCH" = "aarch64" ]; then
-        make -f Makefile.libretro platform=aarch64
-      else
-        make -f Makefile.libretro platform=armv7-neon-hardfloat-cortex-a9
-      fi
-      ;;
-    Generic)
+    x86-64)
       make -f Makefile.libretro
       ;;
   esac

--- a/packages/emulation/libretro-ppsspp/package.mk
+++ b/packages/emulation/libretro-ppsspp/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="A PSP emulator for Android, Windows, Mac, Linux and Blackberry 10, written in C++."
 PKG_LONGDESC="A PSP emulator for Android, Windows, Mac, Linux and Blackberry 10, written in C++."
+PKG_TOOLCHAIN="make"
 
 PKG_LIBNAME="ppsspp_libretro.so"
 PKG_LIBPATH="libretro/$PKG_LIBNAME"

--- a/packages/emulation/libretro-ppsspp/package.mk
+++ b/packages/emulation/libretro-ppsspp/package.mk
@@ -45,24 +45,14 @@ pre_make_target() {
 }
 
 make_target() {
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make -C libretro platform=armv6-gles-hardfloat-arm1176jzf-s
-          ;;
-        RPi2)
-          make -C libretro platform=armv7-neon-gles-hardfloat-cortex-a7
-          ;;
-      esac
+  case $TARGET_CPU in
+    arm1176jzf-s)
+      make -C libretro platform=armv6-gles-hardfloat-$TARGET_CPU
       ;;
-    imx6)
-      make -C libretro platform=armv7-neon-gles-hardfloat-cortex-a9
+    cortex-a7|cortex-a9)
+      make -C libretro platform=armv7-neon-gles-hardfloat-$TARGET_CPU
       ;;
-    WeTek_Play|WeTek_Core)
-      make -C libretro platform=armv7-neon-gles-hardfloat-cortex-a9
-      ;;
-    Generic)
+    x86-64)
       make -C libretro
       ;;
   esac

--- a/packages/emulation/libretro-ppsspp/package.mk
+++ b/packages/emulation/libretro-ppsspp/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-ppsspp"
-PKG_VERSION="9145287"
-PKG_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+PKG_VERSION="5f7bcf7"
+PKG_SHA256="09e61300c05705b1f98e1b575e44d366e5a243cc3be97b3a09ad420581459f87"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-ppsspp"
@@ -45,17 +45,27 @@ pre_make_target() {
 }
 
 make_target() {
-  case $TARGET_CPU in
-    arm1176jzf-s)
-      make -C libretro platform=armv6-gles-hardfloat-$TARGET_CPU
-      ;;
-    cortex-a7|cortex-a9)
-      make -C libretro platform=armv7-neon-gles-hardfloat-$TARGET_CPU
-      ;;
-    x86-64)
-      make -C libretro
-      ;;
-  esac
+  if [ -z "$DEVICE" ]; then
+    PKG_DEVICE_NAME=$PROJECT
+  else
+    PKG_DEVICE_NAME=$DEVICE
+  fi
+  
+  if [ "$PKG_DEVICE_NAME" = "RPi" ]; then
+    make -C libretro platform=${DEVICE,,}
+  else
+    case $TARGET_CPU in
+      arm1176jzf-s)
+        make -C libretro CC=$CC CXX=$CXX platform=armv6-gles-hardfloat-$TARGET_CPU
+        ;;
+      cortex-a7|cortex-a9)
+        make -C libretro CC=$CC CXX=$CXX platform=armv7-neon-gles-hardfloat-$TARGET_CPU
+        ;;
+      x86-64)
+        make -C libretro CC=$CC CXX=$CXX
+        ;;
+    esac
+  fi
 }
 
 makeinstall_target() {

--- a/packages/emulation/libretro-ppsspp/patches/libretro-ppsspp-0004-ffmeg-build.patch
+++ b/packages/emulation/libretro-ppsspp/patches/libretro-ppsspp-0004-ffmeg-build.patch
@@ -1,0 +1,15 @@
+--- a/Core/HLE/sceMpeg.cpp
++++ b/Core/HLE/sceMpeg.cpp
+@@ -768,10 +768,10 @@
+ 	// GE_CMODE_16BIT_ABGR5551 <--> AV_PIX_FMT_BGR555LE;
+ 	// GE_CMODE_16BIT_ABGR4444 <--> AV_PIX_FMT_BGR444LE;
+ 	// GE_CMODE_32BIT_ABGR8888 <--> AV_PIX_FMT_RGBA;
+-	pmp_want_pix_fmt = PIX_FMT_RGBA;
++	pmp_want_pix_fmt = AV_PIX_FMT_RGBA;
+ 
+ 	// Create H264 video codec
+-	AVCodec * pmp_Codec = avcodec_find_decoder(CODEC_ID_H264);
++	AVCodec * pmp_Codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+ 	if (pmp_Codec == NULL){
+ 		ERROR_LOG(ME, "Can not find H264 codec, please update ffmpeg");
+ 		return false;

--- a/packages/emulation/libretro-reicast/package.mk
+++ b/packages/emulation/libretro-reicast/package.mk
@@ -34,27 +34,21 @@ PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="REICAST_LIB"
 
 make_target() {
-  case $PROJECT in
-    RPi)
-      case $DEVICE in
-        RPi)
-          make platform=armv6-hardfloat-arm1176jzf-s
-          ;;
-        RPi2)
-          make platform=rpi2
-          ;;
-      esac
-      ;;
-    imx6)
-      make platform=armv7-neon-hardfloat-cortex-a9
-      ;;
-    WeTek_Play|WeTek_Core)
-      make platform=armv7-neon-hardfloat-cortex-a9
-      ;;
-    Generic)
-      make
-      ;;
-  esac
+  if [ "$DEVICE" = "RPi2" ]; then
+    make platform=${DEVICE,,}
+  else
+    case $TARGET_CPU in
+      arm1176jzf-s)
+        make platform=armv6-hardfloat-$TARGET_CPU
+        ;;
+      cortex-a7|cortex-a9)
+        make platform=armv7-neon-hardfloat-$TARGET_CPU
+        ;;
+      x86-64)
+        make
+        ;;
+    esac
+  fi
 }
 
 makeinstall_target() {

--- a/packages/emulation/libretro-reicast/package.mk
+++ b/packages/emulation/libretro-reicast/package.mk
@@ -39,10 +39,10 @@ make_target() {
   else
     case $TARGET_CPU in
       arm1176jzf-s)
-        make platform=armv6-hardfloat-$TARGET_CPU
+        make platform=arm FORCE_GLES=1
         ;;
       cortex-a7|cortex-a9)
-        make platform=armv7-neon-hardfloat-$TARGET_CPU
+        make platform=armv7-neon-hardfloat-$TARGET_CPU FORCE_GLES=1
         ;;
       x86-64)
         make


### PR DESCRIPTION
This PR change the DEVICE and PROJECT case with and equivalent code using TARGET_CPU

The idea is maintain the same functionality, only **cortex-a17** has been added.

~~Please DON'T MERGE, I'm trying to understand why on my environment~~ the following packages not compile:

- ~~libretro-mupen64plus~~
- ~~libretro-desmume~~
- ~~libretro-ppsspp~~
- libretro-reicast

~~I have reverted my changes on libretro-mupen64plus and still failing, I'm not sure if is a error on my environment or a real issue with the packages.~~ libretro-mupen64plus fixed.

~~libretro-ppsspp gives me a 404 downloading the code from github, maybe is a temporal issue.~~
 
This PR supersede the commit 92f993cce5b0d82d2c31113cd3994791c0c962e4 from #2116 

I have added a few lines of code to avoid the nested PROJECT and DEVICE cases of two packages.

```
  if [ -z "$DEVICE" ]; then
    DEVICE_NAME=$PROJECT
  else
    DEVICE_NAME=$DEVICE
  fi
```

Maybe a similar code can be added in the build process to simplify code like the PR  #2125 or other nested PROJECT and DEVICE cases. Use this approach should reduce the impact of future reorganisations of devices/projects.