### PR TITLE
Python2: remove some, add some

### DIFF
--- a/packages/lang/Python2/package.mk
+++ b/packages/lang/Python2/package.mk
@@ -113,11 +113,12 @@ makeinstall_target() {
 }
 
 post_makeinstall_target() {
-  for dir in bsddb idlelib lib-tk lib2to3 msilib pydoc_data test unittest; do
+  for dir in bsddb ensurepip idlelib lib-tk lib2to3 msilib pydoc_data test unittest; do
     rm -rf $INSTALL/usr/lib/python*/$dir
   done
 
   rm -rf $INSTALL/usr/lib/python*/config
+  rm -rf $INSTALL/usr/lib/python*/distutils/command/wininst*.exe
   rm -rf $INSTALL/usr/bin/2to3
   rm -rf $INSTALL/usr/bin/idle
   rm -rf $INSTALL/usr/bin/pydoc

--- a/packages/lang/Python2/package.mk
+++ b/packages/lang/Python2/package.mk
@@ -113,12 +113,13 @@ makeinstall_target() {
 }
 
 post_makeinstall_target() {
-  for dir in bsddb ensurepip idlelib lib-tk lib2to3 msilib pydoc_data test unittest; do
+  for dir in bsddb ensurepip idlelib lib-tk msilib pydoc_data test unittest; do
     rm -rf $INSTALL/usr/lib/python*/$dir
   done
 
   rm -rf $INSTALL/usr/lib/python*/config
   rm -rf $INSTALL/usr/lib/python*/distutils/command/wininst*.exe
+  rm -rf $INSTALL/usr/lib/python*/lib2to3/tests
   rm -rf $INSTALL/usr/bin/2to3
   rm -rf $INSTALL/usr/bin/idle
   rm -rf $INSTALL/usr/bin/pydoc


### PR DESCRIPTION
ensurepip is unlikely to be useful (read-only site-packages directory, no compiler, etc)
wininst*.exe files are useless on Linux

lib2to3 is however useful a standard Python package.
lib2to3.tests are not installed.

Commits are intentionally split, so they can be reviewed/accepted separately.

Similar changes may apply to Python3.