### PR TITLE
scripts/checkdeps: add python

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -60,29 +60,29 @@ files_pkg="libc6-dev libncurses5-dev"
 
 case "$DISTRO" in
     fedora|centos|rhel)
-      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java"
-      deps_pkg="$deps_pkg gcc-c++ xorg-x11-font-utils xorg-x11-font-utils xorg-x11-font-utils libxslt java-1.7.0-openjdk"
+      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java python"
+      deps_pkg="$deps_pkg gcc-c++ xorg-x11-font-utils xorg-x11-font-utils xorg-x11-font-utils libxslt java-1.7.0-openjdk python2"
       [[ ! `rpm -qa glibc-static` ]] && deps="$deps glibc-static" && deps_pkg="$deps_pkg glibc-static"
       [[ ! `rpm -qa libstdc++-static` ]] && deps="$deps libstdc++-static" && deps_pkg="$deps_pkg libstdc++-static"
       files_pkg="glibc-headers ncurses-devel"
       ;;
     gentoo)
-      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java"
-      deps_pkg="$deps_pkg gcc[cxx] mkfontscale mkfontdir bdftopcf libxslt virtual/jre"
+      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java python"
+      deps_pkg="$deps_pkg gcc[cxx] mkfontscale mkfontdir bdftopcf libxslt virtual/jre python"
       files_pkg="glibc ncurses"
       ;;
     arch)
-      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java"
-      deps_pkg="$deps_pkg g++ xorg-mkfontscale xorg-mkfontdir xorg-bdftopcf libxslt java-runtime-common jdk8-openjdk"
+      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java python"
+      deps_pkg="$deps_pkg g++ xorg-mkfontscale xorg-mkfontdir xorg-bdftopcf libxslt java-runtime-common jdk8-openjdk python2"
       ;;
     opensuse)
-      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java"
-      deps_pkg="$deps_pkg gcc-c++ mkfontscale mkfontdir bdftopcf libxslt-tools java-1_8_0-openjdk"
+      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java python"
+      deps_pkg="$deps_pkg gcc-c++ mkfontscale mkfontdir bdftopcf libxslt-tools java-1_8_0-openjdk python"
       [[ ! `rpm -qa glibc-devel-static` ]] && deps="$deps glibc-devel-static" && deps_pkg="$deps_pkg glibc-devel-static"
       ;;
     *)
-      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java"
-      deps_pkg="$deps_pkg g++ xfonts-utils xfonts-utils xfonts-utils xsltproc default-jre"
+      deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java python"
+      deps_pkg="$deps_pkg g++ xfonts-utils xfonts-utils xfonts-utils xsltproc default-jre python"
       ;;
 esac
 


### PR DESCRIPTION
With the `meson` change we now have a dependency on `python` before any packages (including our own `Python2`) are built: https://github.com/LibreELEC/LibreELEC.tv/blob/2a530ac2ce455d19351fa5bfb03b0cce8f521208/config/functions#L60

Consequently on a system without `python` (eg. an Ubuntu Xenial Docker), the build will fail with an error.
```
config/functions: line 60: python: command not found
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 127
```

Adding `python` to `scripts/checkdeps` will avoid this issue.