### PR TITLE
tools/docker: add python

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop python \
     g++ xfonts-utils xfonts-utils xfonts-utils xsltproc default-jre-headless \
     libc6-dev libncurses5-dev \
     u-boot-tools \


### PR DESCRIPTION
This PR adds python to the docker container to fix building of images with the recent `meson` change, see #2153 for details