### PR TITLE
config: bump version to 8.2.0.1 for RPi HEVC respin

### DIFF
--- a/config/version
+++ b/config/version
@@ -1,5 +1,5 @@
 # VERSION: set full version, use "devel" for development version
-  LIBREELEC_VERSION="8.2.0"
+  LIBREELEC_VERSION="8.2.0.1"
 
 # OS_VERSION: OS Version
   OS_VERSION="8.2"


### PR DESCRIPTION
The plan is to release a simple 8.2.0.1 respin for RPi and Slice images once a fix for the HEVC issue has been figured out.