### PR TITLE
Fix parsing settings.xml in oe_setup_addon

### DIFF
--- a/packages/mediacenter/kodi/profile.d/00-addons.conf
+++ b/packages/mediacenter/kodi/profile.d/00-addons.conf
@@ -1,19 +1,20 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
 #      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#      Copyright (C) 2017-present Team LibreELEC
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 # addons profile.d/*.profile
@@ -41,7 +42,15 @@ oe_setup_addon() {
     fi
 
     # parse config
-    [ -f "$DEF" ] && eval $(cat "$DEF" | awk -F\" '{print $2"=\""$4"\""}' | sed '/^=/d')
-    [ -f "$CUR" ] && eval $(cat "$CUR" | awk -F\" '{print $2"=\""$4"\""}' | sed '/^=/d')
+    for xml_file in "$DEF" "$CUR"; do
+      if [ -f "$xml_file" ]; then
+        XML_SETTINGS_VER="$(xmlstarlet sel -t -m settings -v @version $xml_file)"
+        if [ "$XML_SETTINGS_VER" = "2" ]; then
+          eval $(xmlstarlet sel -t -m settings/setting -v @id -o "=\"" -v . -o "\"" -n "$xml_file")
+        else
+          eval $(xmlstarlet sel -t -m settings -m setting -v @id -o "=\"" -v @value -o "\"" -n "$xml_file")
+        fi
+      fi
+    done
   fi
 }


### PR DESCRIPTION
When running linuxserver.io docker addons in Kodi 18 you can change the settings in Kodi but the script is ignoring it because that awk/sed hack is failing on with settings version 2.

Uses xmlstarlet. I copied it from @vpeter4 https://github.com/LibreELEC/LibreELEC.tv/pull/2147

Tested on Odroid C2 LE9.