### PR TITLE
systemd: meson-remote is not a joystick

### DIFF
--- a/packages/sysutils/systemd/udev.d/60-not-joysticks.rules
+++ b/packages/sysutils/systemd/udev.d/60-not-joysticks.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="input", ATTRS{name}=="aml_keypad", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""


### PR DESCRIPTION
In systemd 235 meson-remote is marked as a joystick in 60-input-id.rules which makes it impossible to use WP2 remote in Kodi. 