### PR TITLE
giflib: don't export reallocarray function

### DIFF
--- a/packages/graphics/giflib/patches/giflib-01-fix-reallocarray-exception.patch
+++ b/packages/graphics/giflib/patches/giflib-01-fix-reallocarray-exception.patch
@@ -1,0 +1,34 @@
+--- a/lib/dgif_lib.c
++++ b/lib/dgif_lib.c
+@@ -23,6 +23,8 @@
+ #include "gif_lib.h"
+ #include "gif_lib_private.h"
+ 
++extern void *reallocarray(void *optr, size_t nmemb, size_t size);
++
+ /* compose unsigned little endian value */
+ #define UNSIGNED_LITTLE_ENDIAN(lo, hi)	((lo) | ((hi) << 8))
+ 
+--- a/lib/gif_lib.h
++++ b/lib/gif_lib.h
+@@ -244,9 +244,6 @@
+                                      GifPixelType ColorTransIn2[]);
+ extern int GifBitSize(int n);
+ 
+-extern void *
+-reallocarray(void *optr, size_t nmemb, size_t size);
+-
+ /******************************************************************************
+  Support for the in-core structures allocation (slurp mode).              
+ ******************************************************************************/
+--- a/lib/gifalloc.c
++++ b/lib/gifalloc.c
+@@ -10,6 +10,8 @@
+ 
+ #include "gif_lib.h"
+ 
++extern void *reallocarray(void *optr, size_t nmemb, size_t size);
++
+ #define MAX(x, y)    (((x) > (y)) ? (x) : (y))
+ 
+ /******************************************************************************


### PR DESCRIPTION
See https://github.com/xbmc/xbmc/pull/13015 for details.