### PR TITLE
brcmfmac_sdio-firmware-aml: Fix install of binaries

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-aml/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-aml/package.mk
@@ -30,5 +30,5 @@ PKG_LONGDESC="Firmware for Broadcom Bluetooth devices used in some Amlogic based
 PKG_AUTORECONF="no"
 
 makeinstall_target() {
-  DESTDIR=$INSTALL/$(get_kernel_overlay_dir) make install
+  DESTDIR=$INSTALL FWDIR=$INSTALL/$(get_kernel_overlay_dir) make install
 }

--- a/packages/linux-firmware/brcmfmac_sdio-firmware-aml/patches/brcmfmac_sdio-firmware-aml-0001-install-firmware-to-FWDIR.patch
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-aml/patches/brcmfmac_sdio-firmware-aml-0001-install-firmware-to-FWDIR.patch
@@ -1,0 +1,14 @@
+diff -Naur brcmfmac_sdio-firmware-aml-0.1.orig/Makefile brcmfmac_sdio-firmware-aml-0.1/Makefile
+--- brcmfmac_sdio-firmware-aml-0.1.orig/Makefile	2014-10-07 23:00:34.000000000 +0200
++++ brcmfmac_sdio-firmware-aml-0.1/Makefile	2017-11-09 11:52:47.102781882 +0100
+@@ -15,8 +15,8 @@
+ install:
+ 	mkdir -p $(DESTDIR)/usr/bin
+ 	cp -P $(PROG) $(DESTDIR)/usr/bin
+-	mkdir -p $(DESTDIR)/lib/firmware
+-	cp -PR firmware/brcm $(DESTDIR)/lib/firmware/
++	mkdir -p $(FWDIR)/lib/firmware
++	cp -PR firmware/brcm $(FWDIR)/lib/firmware/
+ 
+ clean:
+ 	rm -f $(PROG)


### PR DESCRIPTION
brcm_patchram_plus was installed under /usr/lib/kernel-overlays/base/usr/bin which breaks BT on WP2.