### PR TITLE
[LE9] samba: fix misleading "file exists" message on login error

### DIFF
--- a/packages/network/samba/patches/samba-953-backport-misleading-file-exists-fix.patch
+++ b/packages/network/samba/patches/samba-953-backport-misleading-file-exists-fix.patch
@@ -1,0 +1,41 @@
+From 7470b9b18af282a742929d3fc90f4be5520428a1 Mon Sep 17 00:00:00 2001
+From: David Mulder <dmulder@suse.com>
+Date: Thu, 2 Nov 2017 08:25:11 -0600
+Subject: [PATCH] smbc_opendir should not return EEXIST with invalid login
+ credentials
+
+Signed-off-by: David Mulder <dmulder@suse.com>
+
+Reviewed-by: Andreas Schneider <asn@samba.org>
+Reviewed-by: Jim McDonough <jmcd@samba.org>
+
+Autobuild-User(master): Jim McDonough <jmcd@samba.org>
+Autobuild-Date(master): Thu Nov  9 01:49:06 CET 2017 on sn-devel-144
+---
+ source3/libsmb/libsmb_server.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source3/libsmb/libsmb_server.c b/source3/libsmb/libsmb_server.c
+index b0e5926fa65..93b9e800910 100644
+--- a/source3/libsmb/libsmb_server.c
++++ b/source3/libsmb/libsmb_server.c
+@@ -351,8 +351,8 @@ SMBC_server_internal(TALLOC_CTX *ctx,
+ 						  "?????",
+ 						  *pp_password);
+ 			if (!NT_STATUS_IS_OK(status)) {
+-                                errno = map_errno_from_nt_status(status);
+                                 cli_shutdown(srv->cli);
++                                errno = map_errno_from_nt_status(status);
+ 				srv->cli = NULL;
+                                 smbc_getFunctionRemoveCachedServer(context)(context,
+                                                                             srv);
+@@ -562,8 +562,8 @@ SMBC_server_internal(TALLOC_CTX *ctx,
+ 
+ 	status = cli_tree_connect_creds(c, share, "?????", creds);
+ 	if (!NT_STATUS_IS_OK(status)) {
+-		errno = map_errno_from_nt_status(status);
+ 		cli_shutdown(c);
++		errno = map_errno_from_nt_status(status);
+ 		return NULL;
+ 	}
+ 


### PR DESCRIPTION
not runtime tested yet