### PR TITLE
 linux: update to linux-4.13.12 

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="478d637"
-PKG_SHA256="35954bcd8568b057195c72bbc645d3f74a7201c83486359ce6a29482018706ce"
+PKG_VERSION="008700b"
+PKG_SHA256="840f94f383f1c252f840906a190b58ad2fb174716f2cfed5f83b4ad47a4c1f74"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -66,8 +66,8 @@ case "$LINUX" in
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan irqbalanced"
     ;;
   *)
-    PKG_VERSION="4.13.11"
-    PKG_SHA256="a4bf7238d6b1256052243462096f3cf8cca5af058928c41a6c3122264e14f4ef"
+    PKG_VERSION="4.13.12"
+    PKG_SHA256="bf98065bf0e3aa5af379d0808f157be48ca4e452a55468fc4ce814b17cf9de74"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="478d637"
-PKG_SHA256="d4bc570248d053efa23f8007a154116fdd9053841513e5a59f2cfb1586b42fbb"
+PKG_VERSION="008700b"
+PKG_SHA256="f96620ad3e1d682ff0a15b12f7f0f0bda0e0b8d3802eb948ee7e8202355edb46"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/projects/RPi/patches/linux/linux-01-RPi_support.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support.patch
@@ -1,4 +1,4 @@
-From 245c3dfb655ace373af1e83c917233080269be2c Mon Sep 17 00:00:00 2001
+From 6de11925d24bc10497a476e2a412b143f8342a12 Mon Sep 17 00:00:00 2001
 From: Steve Glendinning <steve.glendinning@smsc.com>
 Date: Thu, 19 Feb 2015 18:47:12 +0000
 Subject: [PATCH 001/141] smsx95xx: fix crimes against truesize
@@ -48,7 +48,7 @@ index 340c13484e5cc7dd5001577b7522d5a4318bd5b6..7d3d98f0405ad948f9ab3e035a70e15c
  			usbnet_skb_return(dev, ax_skb);
  		}
 
-From 5d10bf46b58c1dbd7496345b9ad6577037a0e77a Mon Sep 17 00:00:00 2001
+From d45d4ac0adf3a9ef20b947ef5561e644dbcd0588 Mon Sep 17 00:00:00 2001
 From: Sam Nazarko <email@samnazarko.co.uk>
 Date: Fri, 1 Apr 2016 17:27:21 +0100
 Subject: [PATCH 002/141] smsc95xx: Experimental: Enable turbo_mode and
@@ -94,7 +94,7 @@ index 7d3d98f0405ad948f9ab3e035a70e15c667e4fa1..8d34e517db08d895e6135f785c42bf63
  
  	netif_dbg(dev, ifup, dev->net, "rx_urb_size=%ld\n",
 
-From acb77a14d1a219e45a64e6f74ec7b932194c980a Mon Sep 17 00:00:00 2001
+From 027723e2dad0ea6dde59c07e91bca00ea1877736 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 26 Mar 2013 17:26:38 +0000
 Subject: [PATCH 003/141] Allow mac address to be set in smsc95xx
@@ -193,7 +193,7 @@ index 8d34e517db08d895e6135f785c42bf639671815c..5df7e105c41532c3185e46ee54f43a37
  	eth_hw_addr_random(dev->net);
  	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 
-From 144c74bace4c1ed44d01e06e7ddf869b587ce9f7 Mon Sep 17 00:00:00 2001
+From c1d64b379842ba1444d01c895297ac5b5cc980eb Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 13 Mar 2015 12:43:36 +0000
 Subject: [PATCH 004/141] Protect __release_resource against resources without
@@ -224,7 +224,7 @@ index 9b5f04404152c296af3a96132f27cfc80ffa9af9..f8a9af6e6b915812be2ba2c1c2b40106
  	for (;;) {
  		tmp = *p;
 
-From 06c7e83d19da5ab708949c68f1d36b5439195cac Mon Sep 17 00:00:00 2001
+From c2fd20c54cb6925a811f60285e9f85b5ff6f3a08 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 4 Dec 2015 17:41:50 +0000
 Subject: [PATCH 005/141] irq-bcm2836: Prevent spurious interrupts, and trap
@@ -254,7 +254,7 @@ index e7463e3c08143acae3e8cc5682f918c6a0b07ebd..a8db33b50ad9ff83d284fa54fe4d3b65
  #endif
  	} else if (stat) {
 
-From e2ec5616434fae99b36ab0cfb22af72a6cc63482 Mon Sep 17 00:00:00 2001
+From d8c5c99e76d1a3b8f8d76dc37f7dff46dd38a8b3 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:33:30 +0000
 Subject: [PATCH 006/141] irq-bcm2836: Avoid "Invalid trigger warning"
@@ -281,7 +281,7 @@ index a8db33b50ad9ff83d284fa54fe4d3b65f859df0f..c4e151451cf8c8ebde5225515eac2786
  
  static void
 
-From 30e146231da7051eb97032870503909ebfa753e3 Mon Sep 17 00:00:00 2001
+From 090cf3193ec1f62d846da29763867047af985d89 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 12 Jun 2015 19:01:05 +0200
 Subject: [PATCH 007/141] irqchip: bcm2835: Add FIQ support
@@ -413,7 +413,7 @@ index 44d7c38dde479d771f3552e914bf8c1c1f5019f7..42ff5e6a8e0d532f5b60a1e7af7cc4d9
  }
  
 
-From 8f7319e105dda1fc288545641639e9550abf7787 Mon Sep 17 00:00:00 2001
+From be07b11df6009bfa349572edec26e6da596dfc1e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 23 Oct 2015 16:26:55 +0200
 Subject: [PATCH 008/141] irqchip: irq-bcm2835: Add 2836 FIQ support
@@ -515,7 +515,7 @@ index 42ff5e6a8e0d532f5b60a1e7af7cc4d941bd5008..eccf6ed025299cb480884f5bcbe77abf
  	for (b = 0; b < NR_BANKS; b++) {
  		for (i = 0; i < bank_irqs[b]; i++) {
 
-From 6506287ee263421d21181d95c2d8d2f18c3dcb5f Mon Sep 17 00:00:00 2001
+From c199f9463e698ce33ba575abc5e9e3f28b161c76 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 8 May 2017 16:43:40 +0100
 Subject: [PATCH 009/141] irq_bcm2836: Send event when onlining sleeping cores
@@ -554,7 +554,7 @@ index c4e151451cf8c8ebde5225515eac2786d6f61d46..bee4d2d2ebacc3233423bb9d825e076b
  }
  
 
-From b69943974c440472bee5b57cb6bb203cd29e1a3f Mon Sep 17 00:00:00 2001
+From f876e6c9734f4ca21614366dd879f29be4378aa6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 14 Jul 2015 10:26:09 +0100
 Subject: [PATCH 010/141] spidev: Add "spidev" compatible string to silence
@@ -578,7 +578,7 @@ index cda10719d1d1b21b32866d2b79363faa461ab8e1..4f3779d3aa0960640506725bde918075
  };
  MODULE_DEVICE_TABLE(of, spidev_dt_ids);
 
-From 43dd690520dd76025d8046c518725a289a4b20cd Mon Sep 17 00:00:00 2001
+From 2ddcadf6a46363e20a969c2e9eea6bb6f381d2ff Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 3 Jan 2017 18:25:01 +0000
 Subject: [PATCH 011/141] Revert "pinctrl: bcm2835: switch to GPIOLIB_IRQCHIP"
@@ -880,7 +880,7 @@ index 230883168e99a1a3fecc7916ef0a7e0de7e8b3f1..ff3789a11b3c36b922b9d08035abb638
  	if (IS_ERR(pc->pctl_dev)) {
  		gpiochip_remove(&pc->gpio_chip);
 
-From 7eb17e54c39ec66f1bbd1f15c01862bdf60e12f8 Mon Sep 17 00:00:00 2001
+From 1b0c13f7d7a1bf5ee2c73899b7acd23ca8455e2e Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Thu, 10 Jul 2014 13:59:47 +0200
 Subject: [PATCH 012/141] pinctrl-bcm2835: Set base to 0 give expected gpio
@@ -905,7 +905,7 @@ index ff3789a11b3c36b922b9d08035abb638187c2f5a..d2b537572095c86576f78536f737c102
  	.can_sleep = false,
  };
 
-From ef10128616736d379822a7d54a032946a596963f Mon Sep 17 00:00:00 2001
+From 9135377adf88bf84777dba222e96c7af65bd21ef Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 26 Feb 2015 09:58:22 +0000
 Subject: [PATCH 013/141] pinctrl-bcm2835: Only request the interrupts listed
@@ -935,7 +935,7 @@ index d2b537572095c86576f78536f737c102487f99f4..a9d480df32562defbf8be0faf0a39bfe
  		pc->irq_data[i].irqgroup = i;
  
 
-From 22bccf44373b7151c0b9f6d7b9ae703e1e51996f Mon Sep 17 00:00:00 2001
+From 4489235b313694be4bf4dfbe1440af47cc245d3c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Jun 2015 14:10:44 +0100
 Subject: [PATCH 014/141] spi-bcm2835: Support pin groups other than 7-11
@@ -1019,7 +1019,7 @@ index f35cc10772f6670397ea923ad30158270dd68578..5dfe20ffc2866fa6789825016c585175
  	/* and set up the "mode" and level */
  	dev_info(&spi->dev, "setting up native-CS%i as GPIO %i\n",
 
-From c6de0ddbad61ae0bf1df8b07e3a89a9c8419ae01 Mon Sep 17 00:00:00 2001
+From 360455a32a51fd8e9cb633e5a27d2d1b0bae4a5b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 1 Jul 2016 22:09:24 +0100
 Subject: [PATCH 015/141] spi-bcm2835: Disable forced software CS
@@ -1056,7 +1056,7 @@ index 5dfe20ffc2866fa6789825016c585175a29705b6..8493474d286f7a1ac6454a22c61c8c2c
  	return 0;
  }
 
-From fe85471bb5cbbe9053cd239e7a72e8add8f95208 Mon Sep 17 00:00:00 2001
+From 4ccd1b7de3eb897d4a1deb43cd57f58fc61e20e4 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 8 Nov 2016 21:35:38 +0000
 Subject: [PATCH 016/141] spi-bcm2835: Remove unused code
@@ -1147,7 +1147,7 @@ index 8493474d286f7a1ac6454a22c61c8c2cef9121bf..33d75ad38a7f77d085321ace9101900a
  }
  
 
-From 4cdd8620c80776769220b950fe467b4504a67201 Mon Sep 17 00:00:00 2001
+From 954b463e6167afffd769d66f3bbbfd2cdfaeed2e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Wed, 3 Jun 2015 12:26:13 +0200
 Subject: [PATCH 017/141] ARM: bcm2835: Set Serial number and Revision
@@ -1203,7 +1203,7 @@ index 0c1edfc98696da0e0bb7f4a18cdfbcdd27a9795d..8f152266ba9b470df2eaaed9ebcf158e
  
  static const char * const bcm2835_compat[] = {
 
-From 03be724ce9fbc3263f771af0065c0b6accb42c32 Mon Sep 17 00:00:00 2001
+From e25a3c68d2dcf060325b4e3e04d23bb8ce8969ef Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Sat, 3 Oct 2015 22:22:55 +0200
 Subject: [PATCH 018/141] dmaengine: bcm2835: Load driver early and support
@@ -1309,7 +1309,7 @@ index 6204cc32d09c5096df8aec304c3c37b3bcb6be44..599c218dc8a73172dd4bd4a058fc8f95
  MODULE_ALIAS("platform:bcm2835-dma");
  MODULE_DESCRIPTION("BCM2835 DMA engine driver");
 
-From f8750522608d2bb8a38533128e24c27910fcc08e Mon Sep 17 00:00:00 2001
+From bd4fbea8f3da63636c740f2b5fe880102430e51d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 25 Jan 2016 17:25:12 +0000
 Subject: [PATCH 019/141] firmware: Updated mailbox header
@@ -1373,7 +1373,7 @@ index cb979ad90401e299344dd5fae38d09c489d8bd58..30fb37fe175df604a738258a2a632bca
  	RPI_FIRMWARE_VCHIQ_INIT =                             0x00048010,
  
 
-From 75eb8c7f861c539c9995414dbe8604b5107f6538 Mon Sep 17 00:00:00 2001
+From 207e3bbaf9f20fcdc1066574c36d97eae8eae30f Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 15 Jun 2016 16:48:41 +0100
 Subject: [PATCH 020/141] rtc: Add SPI alias for pcf2123 driver
@@ -1396,7 +1396,7 @@ index 8895f77726e8da5444afcd602dceff8f25a9b3fd..1833b8853ceb0e6147cceb93a00e558c
  MODULE_LICENSE("GPL");
 +MODULE_ALIAS("spi:rtc-pcf2123");
 
-From fe8c9e33775bd7505b8201300dca1918dc556fc7 Mon Sep 17 00:00:00 2001
+From aef72557c930118b10171089a9817e966b7f1ce2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 7 Oct 2016 16:50:59 +0200
 Subject: [PATCH 021/141] watchdog: bcm2835: Support setting reboot partition
@@ -1501,7 +1501,7 @@ index b339e0e67b4c1275fd4992fea4f1e24c0575b783..26b7177573fac2af1cd4ab5488d2686f
  
  static int bcm2835_wdt_probe(struct platform_device *pdev)
 
-From 683035a56e92244bec9564320eec046045c0ef6b Mon Sep 17 00:00:00 2001
+From f1b24e918ce1d73b22446651b3cfaebff5bb2620 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 5 Apr 2016 19:40:12 +0100
 Subject: [PATCH 022/141] reboot: Use power off rather than busy spinning when
@@ -1527,7 +1527,7 @@ index 3b2aa9a9fe268d45335f781c4aa22cf573753a1b..0180d89a34af45c56243fe0f17fbe209
  
  /*
 
-From 110ee2898f567bc9a64fc492f1a2080e1058a24a Mon Sep 17 00:00:00 2001
+From 017df3c9c02cc0d5c55fd56950c45f246a95ae04 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 9 Nov 2016 13:02:52 +0000
 Subject: [PATCH 023/141] bcm: Make RASPBERRYPI_POWER depend on PM
@@ -1549,7 +1549,7 @@ index 49f1e2a75d614bc21db152327c7b425ae2504f8d..dccd2374ed00631abd441e3e9d78ee74
  	help
  	  This enables support for the RPi power domains which can be enabled
 
-From 2b6b23b0c0766f3fcb4a46d978008fdabef1ec65 Mon Sep 17 00:00:00 2001
+From 23defc0d2fac17743a6071482764c77dc2049d73 Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Fri, 2 Sep 2016 16:45:27 +0100
 Subject: [PATCH 024/141] Register the clocks early during the boot process, so
@@ -1597,7 +1597,7 @@ index 58ce6af8452db9ca8b4d3c380a06e448919f6a8d..11d89d106026f15719ea25047d6f357b
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("BCM2835 clock driver");
 
-From cc76c0912740dc2c9605a796c095ec9097bbba99 Mon Sep 17 00:00:00 2001
+From ed813d5b13e1cc6ec024af70390cfeba5f688826 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 6 Dec 2016 17:05:39 +0000
 Subject: [PATCH 025/141] bcm2835-rng: Avoid initialising if already enabled
@@ -1626,7 +1626,7 @@ index 574211a495491d9d6021dcaefe4274a63ed02055..e66c0fca8c6090e32f72796c0877a1cf
  	err = hwrng_register(&bcm2835_rng_ops);
  	if (err) {
 
-From eae2bcd2fbd4f147a48c515ca01928c1c3c939a9 Mon Sep 17 00:00:00 2001
+From 2ab2e50b7cc3f6829fee25b2c3dc9418fa0bf8ad Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 24 Aug 2016 16:28:44 +0100
 Subject: [PATCH 026/141] kbuild: Ignore dtco targets when filtering symbols
@@ -1649,7 +1649,7 @@ index 9ffd3dda3889c56a7a72229bed21ff5c49d62856..00da6c9bacbf33334233e22ca5209ade
  	esac | tr ";" "\n" | sed -rn 's/^.*=== __KSYM_(.*) ===.*$$/KSYM_\1/p'
  
 
-From adf46450f408df70530035a1d366ad80b69626df Mon Sep 17 00:00:00 2001
+From f4df6f0110c72e23425985b6010358f6e355e266 Mon Sep 17 00:00:00 2001
 From: Robert Tiemann <rtie@gmx.de>
 Date: Mon, 20 Jul 2015 11:01:25 +0200
 Subject: [PATCH 027/141] BCM2835_DT: Fix I2S register map
@@ -1690,7 +1690,7 @@ index 65783de0aedf3da79adc36fd077b7a89954ddb6b..a89fe4220fdc3f26f75ee66daf187554
  	dmas = <&dma 2>,
  	       <&dma 3>;
 
-From 690ce96ee7d02d289a9bbc3603e2c53bda120db1 Mon Sep 17 00:00:00 2001
+From 02ae10f1e05fba1ae9c67b0d7332a800f7ecaea8 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
 Subject: [PATCH 028/141] clk-bcm2835: Mark used PLLs and dividers CRITICAL
@@ -1721,7 +1721,7 @@ index 11d89d106026f15719ea25047d6f357b4bfcb2c5..fe8f5d65f2749cb3ddc878df61664826
  	divider->data = data;
  
 
-From e6b82f04da0f29538f82231bda08b9f7a2bb1101 Mon Sep 17 00:00:00 2001
+From 14bb86fef6b6f78fd051deeea3c163b0bf9a916c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 13 Feb 2017 17:20:08 +0000
 Subject: [PATCH 029/141] clk-bcm2835: Add claim-clocks property
@@ -1826,7 +1826,7 @@ index fe8f5d65f2749cb3ddc878df616648267441e0ee..92b5e0f5145b32d3bfc3592fe381e8be
  	       sizeof(cprman_parent_names));
  	of_clk_parent_fill(dev->of_node, cprman->real_parent_names,
 
-From a8a02e43d10d1829a7ce5012e79966e7a031b9a1 Mon Sep 17 00:00:00 2001
+From 7e02583de0be15be365c6dfb6c90a5fad7cfa34b Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 6 Mar 2017 09:06:18 +0000
 Subject: [PATCH 030/141] clk-bcm2835: Read max core clock from firmware
@@ -1944,7 +1944,7 @@ index 92b5e0f5145b32d3bfc3592fe381e8be3cd90c72..336f8c9c44325d0a94e591a8557f7af2
  	for (i = 0;
  	     !of_property_read_u32_index(pdev->dev.of_node, "claim-clocks",
 
-From 068a2d0adf12722b800ae6397db6e4d9da04d869 Mon Sep 17 00:00:00 2001
+From 2c7248994981d9fd9d6d7fb84d8ecf6f196fa3e2 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Mon, 9 May 2016 17:28:18 -0700
 Subject: [PATCH 031/141] clk: bcm2835: Mark GPIO clocks enabled at boot as
@@ -1968,10 +1968,11 @@ diff --git a/drivers/clk/bcm/clk-bcm2835.c b/drivers/clk/bcm/clk-bcm2835.c
 index 336f8c9c44325d0a94e591a8557f7af246adc857..caa05e5ad0b7b5cd683e04fb3591a3dfcb40823f 100644
 --- a/drivers/clk/bcm/clk-bcm2835.c
 +++ b/drivers/clk/bcm/clk-bcm2835.c
-@@ -1484,6 +1484,15 @@ static struct clk_hw *bcm2835_register_clock(struct bcm2835_cprman *cprman,
+@@ -1483,6 +1483,15 @@ static struct clk_hw *bcm2835_register_clock(struct bcm2835_cprman *cprman,
+ 	init.name = data->name;
  	init.flags = data->flags | CLK_IGNORE_UNUSED;
  
- 	/*
++	/*
 +	 * Some GPIO clocks for ethernet/wifi PLLs are marked as
 +	 * critical (since some platforms use them), but if the
 +	 * firmware didn't have them turned on then they clearly
@@ -1980,12 +1981,11 @@ index 336f8c9c44325d0a94e591a8557f7af246adc857..caa05e5ad0b7b5cd683e04fb3591a3df
 +	if ((cprman_read(cprman, data->ctl_reg) & CM_ENABLE) == 0)
 +		init.flags &= ~CLK_IS_CRITICAL;
 +
-+	/*
+ 	/*
  	 * Pass the CLK_SET_RATE_PARENT flag if we are allowed to propagate
  	 * rate changes on at least of the parents.
- 	 */
 
-From c1ed40ee38abc1f5fda6456199634762a1313912 Mon Sep 17 00:00:00 2001
+From 088d0eabf924eb6ce4001e165800765b227fa195 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 9 Feb 2017 14:36:44 +0000
 Subject: [PATCH 032/141] sound: Demote deferral errors to INFO level
@@ -2023,7 +2023,7 @@ index 13c875e2392a40ec5651d7c12a28b9ac9f3aab85..23d56057e49b5ff6b6c3c352c150fee8
  			goto _err_defer;
  		}
 
-From 3521e94d820402a8c6fb3fd21974f82cf7fdc3e1 Mon Sep 17 00:00:00 2001
+From dce88aeb39bbce0167eac223802c12e246bc9183 Mon Sep 17 00:00:00 2001
 From: Claggy3 <stephen.maclagan@hotmail.com>
 Date: Sat, 11 Feb 2017 14:00:30 +0000
 Subject: [PATCH 033/141] Update vfpmodule.c
@@ -2163,7 +2163,7 @@ index a71a48e71fffa8626fe90106815376c44bbe679b..d6c0a5a0a5ae3510db3ace5e3f5d3410
  	/*
  	 * Save the userland NEON/VFP state. Under UP,
 
-From 6add31cdd9316d28d237ee3196fd79eb05f9b21b Mon Sep 17 00:00:00 2001
+From 91de2e3cd0518e2cab800f3beaa85d61af19d7d2 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 21:13:24 +1100
 Subject: [PATCH 034/141] ASoC: bcm2835_i2s.c: relax the ch2 register setting
@@ -2187,7 +2187,7 @@ index 6ba20498202ed36906b52096893a88867a79269f..56df7d8a43d0aac055a91b0d24aca8e1
  		format |= BCM2835_I2S_CH1(BCM2835_I2S_CHPOS(ch1pos));
  		format |= BCM2835_I2S_CH2(BCM2835_I2S_CHPOS(ch2pos));
 
-From 3cffb9d68a8364c5cf3e593e427f824691574f34 Mon Sep 17 00:00:00 2001
+From d3acd23b45f75dafee644962f5cead4f850a45d3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Tue, 1 Nov 2016 15:15:41 +0100
 Subject: [PATCH 035/141] i2c: bcm2835: Add debug support
@@ -2379,7 +2379,7 @@ index cd07a69e2e9355540442785f95e90823b05c9d10..47167f403cc8329bd811b47c7011c299
  	if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
  		return -EREMOTEIO;
 
-From 1e8263a0e1d4c3efe447d71b5cdf409441977b74 Mon Sep 17 00:00:00 2001
+From 1eed7178de5f39dde64ae19998bb9b7b514563d6 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 18 Dec 2014 16:07:15 -0800
 Subject: [PATCH 036/141] mm: Remove the PFN busy warning
@@ -2407,7 +2407,7 @@ index 1423da8dd16f5bdc83e20ddf6665b2022a9a6492..6ce930c02160d55dc4eee1e7197a5efa
  		goto done;
  	}
 
-From 79d56d659c529ec0817b07b5b11f79a2a62a5471 Mon Sep 17 00:00:00 2001
+From 8e5606822154ec2efe996d577a8a4b2403763771 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 10:06:56 +0000
 Subject: [PATCH 037/141] ASoC: Add prompt for ICS43432 codec
@@ -2435,7 +2435,7 @@ index 6c78b0b49b8145c24740d93c4174c059d91ddae9..d6450d5fc144737f967b8e00678baa9b
  config SND_SOC_INNO_RK3036
  	tristate "Inno codec driver for RK3036 SoC"
 
-From 4e11d3a961ff7e0b7a19b91c55c935194a84d7b7 Mon Sep 17 00:00:00 2001
+From 4ac0a57c84b437c249338104698ba7b19f9b1bcd Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sun, 12 May 2013 12:24:19 +0100
 Subject: [PATCH 038/141] Main bcm2708/bcm2709 linux port
@@ -2626,7 +2626,7 @@ index cfb4b4496dd9f61362dea012176c146120fada07..d9c6c217c4d6a2408abe2665bf7f2700
  MODULE_AUTHOR("Lubomir Rintel <lkundrak@v3.sk>");
  MODULE_DESCRIPTION("BCM2835 mailbox IPC driver");
 
-From d4663e172aecd63a4eebf516b74bd4b4fb9f650e Mon Sep 17 00:00:00 2001
+From 328e67e310cac366278ac949d8493f98e03add84 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 1 May 2013 19:46:17 +0100
 Subject: [PATCH 039/141] Add dwc_otg driver
@@ -63903,7 +63903,7 @@ index 0000000000000000000000000000000000000000..cdc9963176e5a4a0d5250613b61e26c5
 +test_main();
 +0;
 
-From 61aab6d681c2787466af7c15b940a79e2717991d Mon Sep 17 00:00:00 2001
+From aa71d8897033183c388b5f1fb2a4f2db651ebf7c Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 17:06:34 +0100
 Subject: [PATCH 040/141] bcm2708 framebuffer driver
@@ -67365,7 +67365,7 @@ index 3c14e43b82fefe1d32f591d1b2f61d2cd28d0fa8..7626beb6a5bb8df601ddf0f6e6909d1f
 +0 0 0  0 0 0  0 0 0  0 0 0  0 0 0  0 0 0
 +0 0 0  0 0 0  0 0 0
 
-From 8548f0a91755ef868a769442fce9f9eaf2af16a6 Mon Sep 17 00:00:00 2001
+From bb5eb313ac5aba441a90f3ef9560bd7df042c08d Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 14:22:53 +0100
 Subject: [PATCH 041/141] dmaengine: Add support for BCM2708
@@ -67999,7 +67999,7 @@ index 0000000000000000000000000000000000000000..c5bfff2765be4606077e6c8af73040ec
 +
 +#endif /* _PLAT_BCM2708_DMA_H */
 
-From 66bc061c524e737e9cc41477e6bc8acdf34c4263 Mon Sep 17 00:00:00 2001
+From e318469f64f5f4e5d91fb056be77ddf9d46d8a5c Mon Sep 17 00:00:00 2001
 From: gellert <gellert@raspberrypi.org>
 Date: Fri, 15 Aug 2014 16:35:06 +0100
 Subject: [PATCH 042/141] MMC: added alternative MMC driver
@@ -69882,7 +69882,7 @@ index 46c73e97e61f08a41d9753079345f5965caebbc5..388c551ed11e9d06ea1c25b6553d47a8
  
  	unsigned int		erase_size;	/* erase size in sectors */
 
-From 4f5e8ef9c0f5d3646b15af322e67695cb1220700 Mon Sep 17 00:00:00 2001
+From e55e301b8ef832560bbce755d963b984c237e2ed Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Mar 2015 17:49:47 +0000
 Subject: [PATCH 043/141] Adding bcm2835-sdhost driver, and an overlay to
@@ -72291,7 +72291,7 @@ index 0000000000000000000000000000000000000000..9c6f199a7830959f31012d86bc1f8b1a
 +MODULE_LICENSE("GPL v2");
 +MODULE_AUTHOR("Phil Elwell");
 
-From 6a2d8891abdb755d29c0742563eb47e8f21e15cf Mon Sep 17 00:00:00 2001
+From c989a502868b6e9ee88a31dddd8c9ff20304a0fc Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 28 Oct 2016 15:36:43 +0100
 Subject: [PATCH 044/141] vc_mem: Add vc_mem driver for querying firmware
@@ -72819,7 +72819,7 @@ index 0000000000000000000000000000000000000000..20a475377eb3078ea1ecaef2b24efc35
 +
 +#endif  /* _VC_MEM_H */
 
-From d084f06adecbc542d5342cde23e87526c1e9b947 Mon Sep 17 00:00:00 2001
+From 92506c289d5eb00ef43e614de2a4348133dbdfb8 Mon Sep 17 00:00:00 2001
 From: Tim Gover <tgover@broadcom.com>
 Date: Tue, 22 Jul 2014 15:41:04 +0100
 Subject: [PATCH 045/141] vcsm: VideoCore shared memory service for BCM2835
@@ -77696,7 +77696,7 @@ index 0000000000000000000000000000000000000000..b75729d762f25aace133f7a008633b40
 +
 +#endif /* __VMCS_SM_IOCTL_H__INCLUDED__ */
 
-From 2594d6a4a309d19c4eef315570af18658bda2548 Mon Sep 17 00:00:00 2001
+From 111c3d7fc014716ddc0110003d9645be273dbebe Mon Sep 17 00:00:00 2001
 From: Luke Wren <luke@raspberrypi.org>
 Date: Fri, 21 Aug 2015 23:14:48 +0100
 Subject: [PATCH 046/141] Add /dev/gpiomem device for rootless user GPIO access
@@ -78007,7 +78007,7 @@ index 0000000000000000000000000000000000000000..f5e7f1ba8fb6f18dee77fad06a17480c
 +MODULE_DESCRIPTION("gpiomem driver for accessing GPIO from userspace");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From 1d43e3dadfbd455d023b8399f1ca6b914f599120 Mon Sep 17 00:00:00 2001
+From 12413f7c0d6585191c90d250f1cc2ff4a5bf9157 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:14:45 +0100
 Subject: [PATCH 047/141] Add SMI driver
@@ -79961,7 +79961,7 @@ index 0000000000000000000000000000000000000000..ee3a75edfc033eeb0d90a687ffb68b10
 +
 +#endif /* BCM2835_SMI_H */
 
-From eb4e2376abea5ddf3d1217209ae3bca4d1d19592 Mon Sep 17 00:00:00 2001
+From a733e21bbf80060b7dc4cbedf67180ab48add72b Mon Sep 17 00:00:00 2001
 From: Martin Sperl <kernel@martin.sperl.org>
 Date: Tue, 26 Apr 2016 14:59:21 +0000
 Subject: [PATCH 048/141] MISC: bcm2835: smi: use clock manager and fix reload
@@ -79998,7 +79998,7 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	dma_addr_t smi_regs_busaddr;
  
  	struct dma_chan *dma_chan;
-@@ -72,8 +73,7 @@ struct bcm2835_smi_instance {
+@@ -72,50 +73,13 @@ struct bcm2835_smi_instance {
  
  	struct scatterlist buffer_sgl;
  
@@ -80008,10 +80008,11 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  
  	/* Sometimes we are called into in an atomic context (e.g. by
  	   JFFS2 + MTD) so we can't use a mutex */
-@@ -82,42 +82,6 @@ struct bcm2835_smi_instance {
+ 	spinlock_t transaction_lock;
+ };
  
- /****************************************************************************
- *
+-/****************************************************************************
+-*
 -*   SMI clock manager setup
 -*
 -***************************************************************************/
@@ -80046,11 +80047,9 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
 -	       CM_SMI_CTL_ENAB, CM_SMI_CTL);
 -}
 -
--/****************************************************************************
--*
- *   SMI peripheral setup
+ /****************************************************************************
  *
- ***************************************************************************/
+ *   SMI peripheral setup
 @@ -894,42 +858,40 @@ static int bcm2835_smi_probe(struct platform_device *pdev)
  	struct device_node *node = dev->of_node;
  	struct resource *ioresource;
@@ -80134,7 +80133,7 @@ index 63a4ea08b9930a3a31a985f0a1d969b488ed49ec..1261540703127d1d63b9f3c87042c6e5
  	return 0;
  }
 
-From 68dfd4c6eefb075c176b273f3cad08800e0e17f3 Mon Sep 17 00:00:00 2001
+From 1902668fe6bb2be2c72f9ec340cfe95682607cc6 Mon Sep 17 00:00:00 2001
 From: Luke Wren <wren6991@gmail.com>
 Date: Sat, 5 Sep 2015 01:16:10 +0100
 Subject: [PATCH 049/141] Add SMI NAND driver
@@ -80502,7 +80501,7 @@ index 0000000000000000000000000000000000000000..02adda6da18bd0ba9ab19a104975b79d
 +	("Driver for NAND chips using Broadcom Secondary Memory Interface");
 +MODULE_AUTHOR("Luke Wren <luke@raspberrypi.org>");
 
-From 9ed13e00f2cb8c5250c1eb19dadbd8a29ed5996d Mon Sep 17 00:00:00 2001
+From d1a1fdae06e40a2ce7c195bd30fae3fb6db1f361 Mon Sep 17 00:00:00 2001
 From: Aron Szabo <aron@aron.ws>
 Date: Sat, 16 Jun 2012 12:15:55 +0200
 Subject: [PATCH 050/141] lirc: added support for RaspberryPi GPIO
@@ -81365,7 +81364,7 @@ index 0000000000000000000000000000000000000000..fb69624ccef00ddbdccf8256d6baf1b1
 +
 +#endif
 
-From 5f9c824c6f013b9b04677d8ddf35257bbe1daa06 Mon Sep 17 00:00:00 2001
+From 28e6f0fb9665d3c90e2e03cf023fb19b6a62dd9a Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 3 Jul 2013 00:49:20 +0100
 Subject: [PATCH 051/141] Add cpufreq driver
@@ -81632,7 +81631,7 @@ index 0000000000000000000000000000000000000000..99345969b0e4d651fd9033d67de2febb
 +module_init(bcm2835_cpufreq_module_init);
 +module_exit(bcm2835_cpufreq_module_exit);
 
-From 1241e979ef4f7c2cadf2650e2a4cbac3a599f05c Mon Sep 17 00:00:00 2001
+From 1cc147f1cf205f70c271099c7ea564887c6e5d12 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 17 Jun 2015 15:44:08 +0100
 Subject: [PATCH 052/141] Add Chris Boot's i2c driver
@@ -82300,7 +82299,7 @@ index 0000000000000000000000000000000000000000..962f2e5c7455d91bf32925d785f5f16b
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:" DRV_NAME);
 
-From f27e8288a3f937ee165ee3e0c93945151fe85fb9 Mon Sep 17 00:00:00 2001
+From 4810d8b27fc3f42aa36085f07e43a3905e2ae79d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:27:06 +0200
 Subject: [PATCH 053/141] char: broadcom: Add vcio module
@@ -82528,7 +82527,7 @@ index 0000000000000000000000000000000000000000..c19bc2075c77879563ef5e59038b5a14
 +MODULE_DESCRIPTION("Mailbox userspace access");
 +MODULE_LICENSE("GPL");
 
-From d8d3c31b927c9801fa2dc82666dc9acdf40a342b Mon Sep 17 00:00:00 2001
+From 1f28609cab527b4554e295055d265c002399b257 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Noralf=20Tr=C3=B8nnes?= <noralf@tronnes.org>
 Date: Fri, 26 Jun 2015 14:25:01 +0200
 Subject: [PATCH 054/141] firmware: bcm2835: Support ARCH_BCM270x
@@ -82614,7 +82613,7 @@ index dd506cd3a5b874f9e1acd07efb8cd151bb6145d1..3f070bd38a91511c986e3fb114b15bd4
  MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
  MODULE_DESCRIPTION("Raspberry Pi firmware driver");
 
-From 22794c17bac67ae140e982dcf1ce2dd8fa6bbfa0 Mon Sep 17 00:00:00 2001
+From 9b50dc066b99a7f6682c2a455e164f5d4d94d226 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Mon, 11 May 2015 09:00:42 +0100
 Subject: [PATCH 055/141] scripts: Add mkknlimg and knlinfo scripts from tools
@@ -83144,7 +83143,7 @@ index 0000000000000000000000000000000000000000..84be2593ec1de8f97b0167ff06b3e05d
 +	return $trailer;
 +}
 
-From fb8b788b3b7368a61407baa3629bee24ac18f657 Mon Sep 17 00:00:00 2001
+From 2faf220f8a809f5733550ecce459a151fcb37758 Mon Sep 17 00:00:00 2001
 From: notro <notro@tronnes.org>
 Date: Wed, 9 Jul 2014 14:46:08 +0200
 Subject: [PATCH 056/141] BCM2708: Add core Device Tree support
@@ -95384,7 +95383,7 @@ index 58c05e5d9870b6c18a72da7dc44ff3112994946d..9842523b225a88505d796cc689c04f40
  
  # Bzip2
 
-From a1f6dd8c3c7cc951ab41ee4777d2ff77f64bf0c2 Mon Sep 17 00:00:00 2001
+From 86946be806589d04dae539c657f93137e14b9f5a Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Feb 2015 13:50:57 +0000
 Subject: [PATCH 057/141] BCM270x_DT: Add pwr_led, and the required "input"
@@ -95562,7 +95561,7 @@ index 64c56d454f7df9f864a5242ce4212df586f66886..3fd74c8737871cb56f0355c858fc135e
  	/* set_brightness_work / blink_timer flags, atomic, private. */
  	unsigned long		work_flags;
 
-From 05b4c05aff60efa806cb943499cbfef4a79de102 Mon Sep 17 00:00:00 2001
+From d3303dfa22bbf70a5081c555c31a6446dabf5bd0 Mon Sep 17 00:00:00 2001
 From: Siarhei Siamashka <siarhei.siamashka@gmail.com>
 Date: Mon, 17 Jun 2013 13:32:11 +0300
 Subject: [PATCH 058/141] fbdev: add FBIOCOPYAREA ioctl
@@ -95833,7 +95832,7 @@ index fb795c3b3c178ad3cd7c9e9e4547ffd492bac181..703fa8a70574323abe2fb32599254582
  	__u32 dx;	/* screen-relative */
  	__u32 dy;
 
-From c1d568048ee4dc2bca506452acbb78bd4d50071c Mon Sep 17 00:00:00 2001
+From 984f4d6b20744ee5131a5f2deed422ac13a5dd30 Mon Sep 17 00:00:00 2001
 From: Harm Hanemaaijer <fgenfb@yahoo.com>
 Date: Thu, 20 Jun 2013 20:21:39 +0200
 Subject: [PATCH 059/141] Speed up console framebuffer imageblit function
@@ -96045,7 +96044,7 @@ index a2bb276a8b2463eee98eb237c4647bc00cd93601..436494fba15abecb400ef28688466faf
  					start_index, pitch_index);
  	} else
 
-From 1eb52cc057f3e2edb0a81a3a22fc1cfb42607bac Mon Sep 17 00:00:00 2001
+From d0140191f8e11e66d9ff99d5fbb142d3565a047d Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 May 2013 11:46:50 +0100
 Subject: [PATCH 060/141] enabling the realtime clock 1-wire chip DS1307 and
@@ -96298,7 +96297,7 @@ index 90cbe7e65059f6b604a87c6bf39cd9bbeae7684c..a52be51ee0a5511a75d4eaa8dacaec5e
  		u8, w1_slave_found_callback);
  };
 
-From 7875ae99fedbfad3dd7941ad6325e4009ae8609c Mon Sep 17 00:00:00 2001
+From ff6a8453190f2023de295e4639f1f5ede7908bd3 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 14 Jul 2014 22:02:09 +0100
 Subject: [PATCH 061/141] hid: Reduce default mouse polling interval to 60Hz
@@ -96333,7 +96332,7 @@ index 3f11b02f9857648ba27138f39823a4017fb93d2f..09a81a447dd64887f6dbd8ec8dc40264
  			break;
  		case HID_GD_JOYSTICK:
 
-From 90e521dee13fbc3009b980a74b7954b2a62b83e4 Mon Sep 17 00:00:00 2001
+From c8c27d39caa433b1fa0b4a913f59489018948e41 Mon Sep 17 00:00:00 2001
 From: Gordon Hollingworth <gordon@raspberrypi.org>
 Date: Tue, 12 May 2015 14:47:56 +0100
 Subject: [PATCH 062/141] rpi-ft5406: Add touchscreen driver for pi LCD display
@@ -96694,7 +96693,7 @@ index 30fb37fe175df604a738258a2a632bca3bfff33f..4a3d79d3b48eb483a4e4bf498f617515
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From bf2f74c25f99411bd350c053a2cee2401d5387f6 Mon Sep 17 00:00:00 2001
+From c733fbac6dca6fa12e37db95d110865d9d825424 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 28 Nov 2016 16:50:04 +0000
 Subject: [PATCH 063/141] Improve __copy_to_user and __copy_from_user
@@ -98272,7 +98271,7 @@ index 17ec37811c32f09126ed42753037e055c5cec115..c08f81812d0d56a0d90c1eb6777d0622
  	bool "Broadcom BCM63xx DSL SoC"
  	depends on ARCH_MULTI_V7
 
-From 6c256aa41a3c785e93576b01677611895bb9c3aa Mon Sep 17 00:00:00 2001
+From f54933f6973fa352c66578db182eb7f64af873a6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 25 Jun 2015 12:16:11 +0100
 Subject: [PATCH 064/141] gpio-poweroff: Allow it to work on Raspberry Pi
@@ -98310,7 +98309,7 @@ index be3d81ff51cc3f510d85e4eed7a52960e51e7bc1..a030ae9fb1fca325061c093696e82186
  			"%s: pm_power_off function already registered",
  		       __func__);
 
-From b4741110c97f285226becebb0bcb0b3b6a8924c3 Mon Sep 17 00:00:00 2001
+From 797061d81434e672ead9c54effcb79e6eec6dc1c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <pelwell@users.noreply.github.com>
 Date: Tue, 14 Jul 2015 14:32:47 +0100
 Subject: [PATCH 065/141] mfd: Add Raspberry Pi Sense HAT core driver
@@ -99178,7 +99177,7 @@ index 0000000000000000000000000000000000000000..56196dc2af10e464a1e3f98b028dca1c
 +
 +#endif
 
-From f26d5e24f00aa94c67c1dac6d9da84aeeea82b5c Mon Sep 17 00:00:00 2001
+From 3ce31fd5a14116f27a76ac503735a01e4e530b86 Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Fri, 22 Nov 2013 19:19:08 +0100
 Subject: [PATCH 066/141] ASoC: Add support for HifiBerry DAC
@@ -99356,7 +99355,7 @@ index 0000000000000000000000000000000000000000..ee9f133953544629282631e5ef3f73fe
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry DAC");
 +MODULE_LICENSE("GPL v2");
 
-From f41995bc00ed91cbaa2d4a33b3023c491a774bec Mon Sep 17 00:00:00 2001
+From db1564ce98a26a395577e7f9f3b35ce1b4c97ffd Mon Sep 17 00:00:00 2001
 From: Florian Meier <florian.meier@koalo.de>
 Date: Mon, 25 Jan 2016 15:48:59 +0000
 Subject: [PATCH 067/141] ASoC: Add support for Rpi-DAC
@@ -99643,7 +99642,7 @@ index 0000000000000000000000000000000000000000..afe1b419582aa40c4b2729d242bb13cd
 +MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");
 +MODULE_LICENSE("GPL v2");
 
-From 64ab40820c57f50db4c2fec733a3692d029e26a8 Mon Sep 17 00:00:00 2001
+From 8f1c611d40f2ad9b76852700f81a8cbe519a55d3 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:41:23 +0100
 Subject: [PATCH 068/141] ASoC: wm8804: Implement MCLK configuration options,
@@ -99695,7 +99694,7 @@ index af95d648265b3e92e345101542b332aee35191d4..513f56ba132929662802d15cdc653af3
  	.component_driver = {
  		.dapm_widgets		= wm8804_dapm_widgets,
 
-From cb6f6e11dfb9c953158c648986df2653326aaadf Mon Sep 17 00:00:00 2001
+From a004700318a459f2d28b8c5694d68516a1752b45 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Wed, 15 Jan 2014 21:42:08 +0100
 Subject: [PATCH 069/141] ASoC: BCM:Add support for HiFiBerry Digi. Driver is
@@ -100042,7 +100041,7 @@ index 0000000000000000000000000000000000000000..7620dd02de40b6d644ff038b445d375d
 +MODULE_DESCRIPTION("ASoC Driver for HifiBerry Digi");
 +MODULE_LICENSE("GPL v2");
 
-From ddb53cca4e7b38abb48cd883a96ffbe4cb5e2218 Mon Sep 17 00:00:00 2001
+From 246cf713c6dcc2032b2649cb6bdcffb9ce38ae85 Mon Sep 17 00:00:00 2001
 From: Gordon Garrity <gordon@iqaudio.com>
 Date: Sat, 8 Mar 2014 16:56:57 +0000
 Subject: [PATCH 070/141] Add IQaudIO Sound Card support for Raspberry Pi
@@ -100380,7 +100379,7 @@ index 0000000000000000000000000000000000000000..1ee4097c846376666775272ed692ca33
 +MODULE_DESCRIPTION("ASoC Driver for IQAudio DAC");
 +MODULE_LICENSE("GPL v2");
 
-From ddb0e2296fda152e9d7c8815cc823ddfd50db905 Mon Sep 17 00:00:00 2001
+From 877380ee08a9d3f3932138d7607ca5f4221664d4 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 10:06:56 +0200
 Subject: [PATCH 071/141] Added support for HiFiBerry DAC+
@@ -101013,7 +101012,7 @@ index 72b19e62f6267698aea45d2410d616d91c1825cb..c6839ef6e16754ed9de2698507b8986a
  		dev_err(dev, "No LRCLK?\n");
  		return -EINVAL;
 
-From d1a5bcf5be08bea236165e23e5270c91175e4dcb Mon Sep 17 00:00:00 2001
+From 33fdb7bf7af5131b6ae20794f3a9cf07cb48e1d0 Mon Sep 17 00:00:00 2001
 From: Daniel Matuschek <info@crazy-audio.com>
 Date: Mon, 4 Aug 2014 11:09:58 +0200
 Subject: [PATCH 072/141] Added driver for HiFiBerry Amp amplifier add-on board
@@ -101851,7 +101850,7 @@ index 0000000000000000000000000000000000000000..8f019e04898754d2f87e9630137be9e8
 +
 +#endif  /* _TAS5713_H */
 
-From dac8c1a750cf830307b850d00ce3acbd782da037 Mon Sep 17 00:00:00 2001
+From 9557ebc44e73d6791c145e355b7eb97f862d1119 Mon Sep 17 00:00:00 2001
 From: Waldemar Brodkorb <wbrodkorb@conet.de>
 Date: Wed, 25 Mar 2015 09:26:17 +0100
 Subject: [PATCH 073/141] Add driver for rpi-proto
@@ -102069,7 +102068,7 @@ index 0000000000000000000000000000000000000000..fadbfade100228aaafabb0d3bdf35c01
 +MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
 +MODULE_LICENSE("GPL");
 
-From 18a9efe08db0afce7ad63be121c5b2dbdcee880d Mon Sep 17 00:00:00 2001
+From 8b3006e31ae33c4d39b93e075c65a7d4fbe95277 Mon Sep 17 00:00:00 2001
 From: Jan Grulich <jan@grulich.eu>
 Date: Mon, 24 Aug 2015 16:03:47 +0100
 Subject: [PATCH 074/141] RaspiDAC3 support
@@ -102315,7 +102314,7 @@ index 0000000000000000000000000000000000000000..ad2b5b89bc8213dc2e277306ef50d6e3
 +MODULE_DESCRIPTION("ASoC Driver for RaspiDAC Rev.3x");
 +MODULE_LICENSE("GPL v2");
 
-From e26208d29a124ab7db98a4e95d394c37709c2ab0 Mon Sep 17 00:00:00 2001
+From 6d57a413806b3150cc9894dd4c8192319aa8eeaa Mon Sep 17 00:00:00 2001
 From: Aaron Shaw <shawaj@gmail.com>
 Date: Thu, 7 Apr 2016 21:26:21 +0100
 Subject: [PATCH 075/141] Add Support for JustBoom Audio boards
@@ -102774,7 +102773,7 @@ index 0000000000000000000000000000000000000000..909cf8928f2f4313982316f9c5b8a709
 +MODULE_DESCRIPTION("ASoC Driver for JustBoom PI Digi HAT Sound Card");
 +MODULE_LICENSE("GPL v2");
 
-From 3559b63e5433838255424aa870e46b0159786cfe Mon Sep 17 00:00:00 2001
+From ebd70332a9ece5208278c7936a9b507bd1ebf3c5 Mon Sep 17 00:00:00 2001
 From: Andrey Grodzovsky <andrey2805@gmail.com>
 Date: Tue, 3 May 2016 22:10:59 -0400
 Subject: [PATCH 076/141] ARM: adau1977-adc: Add basic machine driver for
@@ -102959,7 +102958,7 @@ index 0000000000000000000000000000000000000000..f3d7e5db7bb912e1d7ca6f8e8d42df5f
 +MODULE_DESCRIPTION("ASoC Driver for ADAU1977 ADC");
 +MODULE_LICENSE("GPL v2");
 
-From 38a4c5d23f89aa8c9d28ba2882031e79de277a96 Mon Sep 17 00:00:00 2001
+From 9f65384e00ea39e820ed948feaeca3a0e12206da Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Mon, 16 May 2016 21:36:31 +1000
 Subject: [PATCH 077/141] New AudioInjector.net Pi soundcard with low jitter
@@ -103213,7 +103212,7 @@ index 0000000000000000000000000000000000000000..491906bbf446826e55dd843f28e4860f
 +MODULE_ALIAS("platform:audioinjector-pi-soundcard");
 +
 
-From e9bdfa36f7a44f8c10b3b30ab95d62bf0d7f9d5e Mon Sep 17 00:00:00 2001
+From e7e73c9651fb2125128ac2f34a7de5ac842a98a5 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Thu, 30 Jun 2016 18:38:42 +0100
 Subject: [PATCH 078/141] Add IQAudIO Digi WM8804 board support
@@ -103516,7 +103515,7 @@ index 0000000000000000000000000000000000000000..33aa2be8a43a12a12cfb5d844dd9732c
 +MODULE_DESCRIPTION("ASoC Driver for IQAudIO WM8804 Digi");
 +MODULE_LICENSE("GPL v2");
 
-From 2b0b168f730c1c846f4aee0e953439edda4434f1 Mon Sep 17 00:00:00 2001
+From 35a84531b8d8a1ee71d3198c66ebd59498974790 Mon Sep 17 00:00:00 2001
 From: escalator2015 <jmtasende@gmail.com>
 Date: Tue, 24 May 2016 16:20:09 +0100
 Subject: [PATCH 079/141] New driver for RRA DigiDAC1 soundcard using WM8741 +
@@ -103992,7 +103991,7 @@ index 0000000000000000000000000000000000000000..f200688bb4ae32b90a0ced555aed94b0
 +MODULE_DESCRIPTION("ASoC Driver for RRA DigiDAC1");
 +MODULE_LICENSE("GPL v2");
 
-From 98e519d17a8742530d0d93c9d2d482c503e6e3f7 Mon Sep 17 00:00:00 2001
+From ca05c15cc5ddfc826aae37b48ba0401310e3d314 Mon Sep 17 00:00:00 2001
 From: DigitalDreamtime <clive.messer@digitaldreamtime.co.uk>
 Date: Sat, 2 Jul 2016 16:26:19 +0100
 Subject: [PATCH 080/141] Add support for Dion Audio LOCO DAC-AMP HAT
@@ -104168,7 +104167,7 @@ index 0000000000000000000000000000000000000000..65e03741d349a2dc5bd91f69855ea952
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO");
 +MODULE_LICENSE("GPL v2");
 
-From dacd32eb665fe5efcab2b3715b0aa489d66ec1a1 Mon Sep 17 00:00:00 2001
+From bc990d78e32a758bfff686728793e178171d1a8d Mon Sep 17 00:00:00 2001
 From: Clive Messer <clive.m.messer@gmail.com>
 Date: Mon, 19 Sep 2016 14:01:04 +0100
 Subject: [PATCH 081/141] Allo Piano DAC boards: Initial 2 channel (stereo)
@@ -104378,7 +104377,7 @@ index 0000000000000000000000000000000000000000..eaf50fb6dbca1970ae1c6f8662088b0f
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC");
 +MODULE_LICENSE("GPL v2");
 
-From f643ef81fa66178e4044cbd33ad3b6a76bc5e9b5 Mon Sep 17 00:00:00 2001
+From 17862c6e995d2902d88995ed8b5ea99ff41e1d09 Mon Sep 17 00:00:00 2001
 From: Raashid Muhammed <raashidmuhammed@zilogic.com>
 Date: Mon, 27 Mar 2017 12:35:00 +0530
 Subject: [PATCH 082/141] Add support for Allo Piano DAC 2.1 plus add-on board
@@ -105250,7 +105249,7 @@ index 0000000000000000000000000000000000000000..d4e99e3c6a383d92fb0cf9e8c1cd1e76
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Piano DAC Plus");
 +MODULE_LICENSE("GPL v2");
 
-From 425d9804f5d892c23503150963af3358e228cce0 Mon Sep 17 00:00:00 2001
+From beb77f395943696f2d5febb75669d8cadd09bf4c Mon Sep 17 00:00:00 2001
 From: BabuSubashChandar <babuenir@gmail.com>
 Date: Tue, 28 Mar 2017 20:04:42 +0530
 Subject: [PATCH 083/141] Add support for Allo Boss DAC add-on board for
@@ -105956,7 +105955,7 @@ index 0000000000000000000000000000000000000000..203ab76c7045b081578e23bda1099dd1
 +MODULE_DESCRIPTION("ALSA ASoC Machine Driver for Allo Boss DAC");
 +MODULE_LICENSE("GPL v2");
 
-From c947a7abc90fb675ccfc842893355d60bc1b4ce4 Mon Sep 17 00:00:00 2001
+From f989d40bceecb45c6072cb6142effd98028351a3 Mon Sep 17 00:00:00 2001
 From: gtrainavicius <gtrainavicius@users.noreply.github.com>
 Date: Sun, 23 Oct 2016 12:06:53 +0300
 Subject: [PATCH 084/141] Support for Blokas Labs pisound board
@@ -107158,7 +107157,7 @@ index 0000000000000000000000000000000000000000..06ff1e53dc9d860946965b6303577762
 +MODULE_DESCRIPTION("ASoC Driver for pisound, http://blokas.io/pisound");
 +MODULE_LICENSE("GPL v2");
 
-From 4b7afad58258f7ec0d55972b0555a4e5ce3a4aa8 Mon Sep 17 00:00:00 2001
+From 80b3c0ec0906e14d1e865081e3d42e6234e5e9da Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 22 Jan 2017 12:49:37 +0100
 Subject: [PATCH 085/141] ASoC: Add driver for Cirrus Logic Audio Card
@@ -108226,7 +108225,7 @@ index 0000000000000000000000000000000000000000..ac8651ddff7bd3701dffe22c7fb88352
 +MODULE_DESCRIPTION("ASoC driver for Cirrus Logic Audio Card");
 +MODULE_LICENSE("GPL");
 
-From 0c2d1f8f681410eed05b7f2faedfa9f2c7ef53e6 Mon Sep 17 00:00:00 2001
+From 7cf7e4442c3ccdbe4a65eec113dcd2abd111a984 Mon Sep 17 00:00:00 2001
 From: Miquel <miquelblauw@hotmail.com>
 Date: Fri, 24 Feb 2017 20:51:06 +0100
 Subject: [PATCH 086/141] sound: Support for Dion Audio LOCO-V2 DAC-AMP HAT
@@ -108424,7 +108423,7 @@ index 0000000000000000000000000000000000000000..a009c49477972a9832175d86f201b035
 +MODULE_DESCRIPTION("ASoC Driver for DionAudio LOCO-V2");
 +MODULE_LICENSE("GPL v2");
 
-From 5823e6e01e39f09e458197dcb7540719c3dc3dff Mon Sep 17 00:00:00 2001
+From 70a3748c51fc84dce0dd435804425486fc7ebf5a Mon Sep 17 00:00:00 2001
 From: Fe-Pi <fe-pi@cox.net>
 Date: Wed, 1 Mar 2017 04:42:43 -0700
 Subject: [PATCH 087/141] Add support for Fe-Pi audio sound card. (#1867)
@@ -108641,7 +108640,7 @@ index 0000000000000000000000000000000000000000..015b56fd73cc36be5b5eecd17548fd03
 +MODULE_DESCRIPTION("ASoC Driver for Fe-Pi Audio");
 +MODULE_LICENSE("GPL v2");
 
-From 52d14b39c710fdb4a480461def51c9b3576290e1 Mon Sep 17 00:00:00 2001
+From 19602b062b0a8769cb0a3af381bdbca3f3147dd9 Mon Sep 17 00:00:00 2001
 From: Matt Flax <flatmax@flatmax.org>
 Date: Wed, 8 Mar 2017 20:04:13 +1100
 Subject: [PATCH 088/141] Add support for the AudioInjector.net Octo sound card
@@ -109053,7 +109052,7 @@ index 0000000000000000000000000000000000000000..5e79f4eff93a21ed3495c77a90f73525
 +MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:audioinjector-octo-soundcard");
 
-From 1d29ce33b052fad83c5406bb7ff2e5635b8684c5 Mon Sep 17 00:00:00 2001
+From 651e4bc97a4fea4554a8a69771c47cda702634c5 Mon Sep 17 00:00:00 2001
 From: Peter Malkin <petermalkin@google.com>
 Date: Mon, 27 Mar 2017 16:38:21 -0700
 Subject: [PATCH 089/141] Driver support for Google voiceHAT soundcard.
@@ -109447,7 +109446,7 @@ index 0000000000000000000000000000000000000000..225854b8e5298b3c3018f59a49404354
 +MODULE_DESCRIPTION("ASoC Driver for Google voiceHAT SoundCard");
 +MODULE_LICENSE("GPL v2");
 
-From fc169a6484455ff5ce770042c00b6c541cfa54db Mon Sep 17 00:00:00 2001
+From f7a318c4721c96464a119c2d9c1c1894c46fe8c2 Mon Sep 17 00:00:00 2001
 From: sandeepal <alsandeep@cem-solutions.net>
 Date: Fri, 2 Jun 2017 18:59:46 +0530
 Subject: [PATCH 090/141] Allo Digione Driver (#2048)
@@ -109772,7 +109771,7 @@ index 0000000000000000000000000000000000000000..e3664e44c699d0102120ecf99e8b780a
 +MODULE_DESCRIPTION("ASoC Driver for Allo DigiOne");
 +MODULE_LICENSE("GPL v2");
 
-From 83dfd2c3cea8630162f4a537d0a893603abc1c72 Mon Sep 17 00:00:00 2001
+From 1d438c59b6e685fc19d9f4a3eb08b38fbee1e367 Mon Sep 17 00:00:00 2001
 From: P33M <P33M@github.com>
 Date: Wed, 21 Oct 2015 14:55:21 +0100
 Subject: [PATCH 091/141] rpi_display: add backlight driver and overlay
@@ -109944,7 +109943,7 @@ index 0000000000000000000000000000000000000000..14a0d9b037395497c1fdae2961feccd5
 +MODULE_DESCRIPTION("Raspberry Pi mailbox based Backlight Driver");
 +MODULE_LICENSE("GPL");
 
-From 171b956267cfc19b9ef3d8f1652f3a3b09d20354 Mon Sep 17 00:00:00 2001
+From 7c3e2a35d3f9851c79bbc82fb6b719cf8449b300 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 23 Feb 2016 19:56:04 +0000
 Subject: [PATCH 092/141] bcm2835-virtgpio: Virtual GPIO driver
@@ -110221,7 +110220,7 @@ index 4a3d79d3b48eb483a4e4bf498f617515e3ad158f..5f34e1257117fb48013c9926a8a223d6
  	RPI_FIRMWARE_FRAMEBUFFER_SET_BACKLIGHT =              0x0004800f,
  
 
-From 3dd06f3e439822235b9a2e8a1217f92d85961d48 Mon Sep 17 00:00:00 2001
+From f1dc253695cd922849a235148038e095f50f8074 Mon Sep 17 00:00:00 2001
 From: Dave Stevenson <dave.stevenson@raspberrypi.org>
 Date: Mon, 20 Feb 2017 17:01:21 +0000
 Subject: [PATCH 093/141] bcm2835-gpio-exp: Driver for GPIO expander via
@@ -110550,7 +110549,7 @@ index 5f34e1257117fb48013c9926a8a223d64a598ab7..c819c21b0158a59c1308882e5a40e3f3
  	/* Dispmanx TAGS */
  	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,
 
-From af6cac4c838d7917d04f78181b77db2ad4e2ac71 Mon Sep 17 00:00:00 2001
+From 55d9a63fab52cc747d5b5e3b955e8a988377df59 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 23 Feb 2016 17:26:48 +0000
 Subject: [PATCH 094/141] amba_pl011: Don't use DT aliases for numbering
@@ -110582,7 +110581,7 @@ index 1888d168a41c87c605962da2605df8ab1c02bd20..e22b9e79836a6aeef4c8f9fb618b9595
  	uap->old_cr = 0;
  	uap->port.dev = dev;
 
-From 67000cd5afa0d402e93c64a4cbf448ec7953fee3 Mon Sep 17 00:00:00 2001
+From 29d550986979cd49a6d570c95a42742c1d3315c8 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 1 Mar 2017 16:07:39 +0000
 Subject: [PATCH 095/141] amba_pl011: Round input clock up
@@ -110671,7 +110670,7 @@ index e22b9e79836a6aeef4c8f9fb618b9595c551500f..4b815abbf9913075885ee60f4d9ad49d
  /* unregisters the driver also if no more ports are left */
  static void pl011_unregister_port(struct uart_amba_port *uap)
 
-From b6f72792072751c0cfeb9ebc94bb5af0449a0fd9 Mon Sep 17 00:00:00 2001
+From 57b717e8f418d8e47178863d3ff2ef868d848d71 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Date: Wed, 3 Dec 2014 13:23:28 +0200
 Subject: [PATCH 096/141] OF: DT-Overlay configfs interface
@@ -111106,7 +111105,7 @@ index 0000000000000000000000000000000000000000..0037e6868a6cda8706c88194c6a4454b
 +}
 +late_initcall(of_cfs_init);
 
-From 9d65f4edecc9d390d45420760d84bb3af4a9b521 Mon Sep 17 00:00:00 2001
+From c441550077d07993b0618e7644f1089156075388 Mon Sep 17 00:00:00 2001
 From: Cheong2K <cheong@redbear.cc>
 Date: Fri, 26 Feb 2016 18:20:10 +0800
 Subject: [PATCH 097/141] brcm: adds support for BCM43341 wifi
@@ -111241,7 +111240,7 @@ index f3556122c6ace17c419e13023057861957a507fa..f8d4647016a1cde3d51dd43da07a46ce
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_43362_CHIP_ID, 0xFFFFFFFE, 43362),
  	BRCMF_FW_NVRAM_ENTRY(BRCM_CC_4339_CHIP_ID, 0xFFFFFFFF, 4339),
 
-From da01f1c1a3e86cdbb0fcfef0e8a10d4a07951a09 Mon Sep 17 00:00:00 2001
+From f9c932ae59cf634d03c685e01173786e6920254c Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 17 Feb 2017 15:26:13 +0000
 Subject: [PATCH 098/141] brcmfmac: Mute expected startup 'errors'
@@ -111268,7 +111267,7 @@ index 2145343c18c91f6a43543eb42ca7bbc7a37f14b5..0f7b4e6b5ee3485806cd93873f00af34
  				  req->alpha2[0], req->alpha2[1]);
  			return;
 
-From ef996c5f4c7f1797775b39c97e35092a25348987 Mon Sep 17 00:00:00 2001
+From 85ac30b12971d40fe19c3862835153adf6954a29 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 17 Dec 2015 13:37:07 +0000
 Subject: [PATCH 099/141] hci_h5: Don't send conf_req when ACTIVE
@@ -111294,7 +111293,7 @@ index c0e4e26dc30d7c3c6a771b7b86df88c8cf763646..7308287259eedcaf229f8a496a0e3826
  		if (H5_HDR_LEN(hdr) > 2)
  			h5->tx_win = (data[2] & 0x07);
 
-From be5b8d2e564ff578a8aa5a6168ba91098818a703 Mon Sep 17 00:00:00 2001
+From 1ca8064ea543110a35d1b07e6fc915be7d77997f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Mon, 13 Apr 2015 17:16:29 +0100
 Subject: [PATCH 100/141] config: Add default configs
@@ -113976,7 +113975,7 @@ index 0000000000000000000000000000000000000000..e0dd8723047ff488e81a03ef42fdbc68
 +CONFIG_CRC_ITU_T=y
 +CONFIG_LIBCRC32C=y
 
-From 92e87f9fd94fbf36928def93f38bb289023da4ca Mon Sep 17 00:00:00 2001
+From 08c925b2cfa77030d4f2d50be0e42ec209946035 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Wed, 24 Aug 2016 03:35:56 -0700
 Subject: [PATCH 101/141] Add arm64 configuration and device tree differences.
@@ -115393,7 +115392,7 @@ index 0000000000000000000000000000000000000000..e6b09fafa27eed2b762e3d53b55041f7
 +CONFIG_LIBCRC32C=y
 +CONFIG_BCM2835_VCHIQ=n
 
-From b887e9f2286c27368efc2e286efb1fcb3de47801 Mon Sep 17 00:00:00 2001
+From c62cf79d89d5f49c655363319e327963fdcdcf8c Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 07:07:08 -0800
 Subject: [PATCH 102/141] ARM64: Make it work again on 4.9 (#1790)
@@ -115808,7 +115807,7 @@ index e6b09fafa27eed2b762e3d53b55041f793683d27..c7e891d72969a388d9b135a36dbfc9c9
  CONFIG_LIBCRC32C=y
 -CONFIG_BCM2835_VCHIQ=n
 
-From 4499c34fae92f772f30c70d80fb1ecf0fb9ee93e Mon Sep 17 00:00:00 2001
+From ba38501645198c41aea01109c4862fa8ed8a0dfa Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:10:07 -0800
 Subject: [PATCH 103/141] ARM64: Enable HDMI audio and vc04_services in
@@ -115840,7 +115839,7 @@ index c7e891d72969a388d9b135a36dbfc9c9cb609bf8..4b90f9b64abe9f089ba56b13d5a00de3
  CONFIG_BCM2835_MBOX=y
  # CONFIG_IOMMU_SUPPORT is not set
 
-From d139932dc76e7e13fe6c7de21bec17aaf903bb64 Mon Sep 17 00:00:00 2001
+From f01da3f1f0424f6a94e3d418d56de1d4c86ff41d Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Thu, 12 Jan 2017 19:14:03 -0800
 Subject: [PATCH 104/141] ARM64: Run bcmrpi3_defconfig through savedefconfig.
@@ -115888,7 +115887,7 @@ index 4b90f9b64abe9f089ba56b13d5a00de33343bfb9..dac962ca1634662ce7d966f1ffb53b5b
  CONFIG_FB_TFT_AGM1264K_FL=m
  CONFIG_FB_TFT_BD663474=m
 
-From 001e66c1d148a8d7853967ebdbe501ecb96f236d Mon Sep 17 00:00:00 2001
+From 086f50d3b9ec61e72e0092c4b02d8f357a82a046 Mon Sep 17 00:00:00 2001
 From: Electron752 <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 02:54:26 -0800
 Subject: [PATCH 105/141] ARM64: Enable Kernel Address Space Randomization
@@ -115923,7 +115922,7 @@ index dac962ca1634662ce7d966f1ffb53b5bfa27c506..aae33b4b3c3e736ea7cd3ca242158ad6
  CONFIG_BINFMT_MISC=y
  CONFIG_COMPAT=y
 
-From 9db260b084b34e6f6750658f4a99c1caf7499553 Mon Sep 17 00:00:00 2001
+From 0c800d3880547518a9a0cc7e3277352a6e1be211 Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sun, 15 Jan 2017 07:31:59 -0800
 Subject: [PATCH 106/141] ARM64: Enable RTL8187/RTL8192CU wifi in build config
@@ -115951,7 +115950,7 @@ index aae33b4b3c3e736ea7cd3ca242158ad6ba558aff..b7d762df19b85e369a32cd823dfd0621
  CONFIG_ZD1211RW=m
  CONFIG_MAC80211_HWSIM=m
 
-From a00566ff4cf95af664ba667eac8f6e4ce05d763f Mon Sep 17 00:00:00 2001
+From 366517d4fd021773bd181ea36e6c0d1214c19d4c Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:33:51 -0800
 Subject: [PATCH 107/141] ARM64/DWC_OTG: Port dwc_otg driver to ARM64
@@ -116297,7 +116296,7 @@ index 6b2c7d0c93f36a63863ff4b0ecc1f3eab77e058b..d7b700ff17821ad1944e36721fe6b2db
  /** The OS page size */
  #define DWC_OS_PAGE_SIZE	PAGE_SIZE
 
-From 63235dc9d451725b0f7836051881e18b3bc29e1e Mon Sep 17 00:00:00 2001
+From 3f05b3ba450f7bfdbbfa2c515f38a5311761286f Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:43:57 -0800
 Subject: [PATCH 108/141] ARM64: Round-Robin dispatch IRQs between CPUs.
@@ -116374,7 +116373,7 @@ index bee4d2d2ebacc3233423bb9d825e076b9f52fccd..014f13f89eb896f5cfc75ed9891787d0
  	.name		= "bcm2836-gpu",
  	.irq_mask	= bcm2836_arm_irqchip_mask_gpu_irq,
 
-From daa5ac7e76378343fe8210d7609bdf7a7ff0ee78 Mon Sep 17 00:00:00 2001
+From f0968164c996caed39b9e544d972a0eeb2731d1b Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 14 Jan 2017 21:45:03 -0800
 Subject: [PATCH 109/141] ARM64: Enable DWC_OTG Driver In ARM64 Build
@@ -116398,7 +116397,7 @@ index b7d762df19b85e369a32cd823dfd062145bdefa7..4d85c231c5ea0244e1b05fb4a5e3c8fd
  CONFIG_USB_STORAGE=y
  CONFIG_USB_STORAGE_REALTEK=m
 
-From 607c327ebdc91428ae2dd15c25fe3c95d8923c43 Mon Sep 17 00:00:00 2001
+From 737a139cb9490755119ed4ccd358f300fc0899ec Mon Sep 17 00:00:00 2001
 From: Michael Zoran <mzoran@crowfest.net>
 Date: Sat, 11 Feb 2017 01:18:31 -0800
 Subject: [PATCH 110/141] ARM64: Force hardware emulation of deprecated
@@ -116429,7 +116428,7 @@ index d06fbe4cd38d7423c900aff64b0e728f995478d3..877b7c90f9555203d5d55d739359a256
  	case INSN_OBSOLETE:
  		insn->current_mode = INSN_UNDEF;
 
-From f1d963486e25c8aef14c96b95982b97ff132020d Mon Sep 17 00:00:00 2001
+From 32228ccbf850bb539c248dab1d14fa27d2e122b4 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 10 Feb 2017 17:57:08 -0800
 Subject: [PATCH 111/141] build/arm64: Add rules for .dtbo files for dts
@@ -116457,7 +116456,7 @@ index 9b41f1e3b1a039cd45fe842e10abff0181186fdf..dc2859b8eed168ed52e95c503e7a5ce3
  
  dtbs: prepare scripts
 
-From ae86a0aad670f9b7aed0b42ce0bc6674d63ae81e Mon Sep 17 00:00:00 2001
+From 84e252f93b0cd1333f3f6c9f89814b3d17e5979c Mon Sep 17 00:00:00 2001
 From: Bilal Amarni <bamarni@users.noreply.github.com>
 Date: Wed, 24 May 2017 10:52:50 +0200
 Subject: [PATCH 112/141] enable drivers for GPIO expander and vcio
@@ -116488,7 +116487,7 @@ index 4d85c231c5ea0244e1b05fb4a5e3c8fd3e651ddf..9dcb58a519d041fadae99c81a7bda621
  CONFIG_GPIO_ARIZONA=m
  CONFIG_GPIO_STMPE=y
 
-From 6924039cdf0e4bc1b340bb946f152991f0dc6975 Mon Sep 17 00:00:00 2001
+From 0b96f2468a908e64ff44fb3d2468b38af2575413 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 24 Feb 2015 13:40:50 +0000
 Subject: [PATCH 113/141] pinctrl-bcm2835: Fix interrupt handling for GPIOs
@@ -116524,7 +116523,7 @@ index a9d480df32562defbf8be0faf0a39bfe06ff71f9..18c92bae3b2e7e9f8208ca0d4487b08b
  		.suppress_bind_attrs = true,
  	},
 
-From 95ef1dd5af4042416a5526da44aa25e0059d3e17 Mon Sep 17 00:00:00 2001
+From ba7fe0a7a99aa0924ff2ac8f489850ab332145e6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Thu, 23 Mar 2017 16:34:46 +0000
 Subject: [PATCH 114/141] bcm2835-aux: Add aux interrupt controller
@@ -116691,7 +116690,7 @@ index bd750cf2238d61489811e7d7bd3b5f9950ed53c8..41e0702fae4692221980b0d02aed1ba6
  			       BCM2835_AUX_CLOCK_COUNT, GFP_KERNEL);
  	if (!onecell)
 
-From 594456fc3272fcb9d3ceaf28c84cc4bc7084712b Mon Sep 17 00:00:00 2001
+From 0e4c49c2495458a575208494bfb8c3a8b54c6849 Mon Sep 17 00:00:00 2001
 From: Yasunari Takiguchi <Yasunari.Takiguchi@sony.com>
 Date: Fri, 14 Apr 2017 10:43:57 +0100
 Subject: [PATCH 115/141] This is the driver for Sony CXD2880 DVB-T2/T tuner +
@@ -132826,7 +132825,7 @@ index 0000000000000000000000000000000000000000..82e122349055be817eb74ed5bbcd7560
 +MODULE_AUTHOR("Sony Semiconductor Solutions Corporation");
 +MODULE_LICENSE("GPL v2");
 
-From db51716343cefd6f77071eaeb4559da1b8f8f1cc Mon Sep 17 00:00:00 2001
+From 68a3e778be324567b50b3b4bc9abd7adaeb35e66 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:18:09 +0100
 Subject: [PATCH 116/141] raspberrypi-firmware: Define the MBOX channel in the
@@ -132851,7 +132850,7 @@ index c819c21b0158a59c1308882e5a40e3f3fe73cbdf..de2a3dcd562beb752266eaf0070e5586
  
  enum rpi_firmware_property_status {
 
-From 0a6110f57a0ecb066f54d6f063f9ca2fd2ce1117 Mon Sep 17 00:00:00 2001
+From c6b8eaaf21a8e7f66b7fd9a966c07a4d3cf39d6f Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 09:16:19 +0100
 Subject: [PATCH 117/141] raspberrypi-firmware: Export the general transaction
@@ -132898,7 +132897,7 @@ index de2a3dcd562beb752266eaf0070e55861d553f5f..dc7fd58afd5dddebf9b17065bb069a1d
  
  #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */
 
-From e23ca063387d2d9241065a13b2343e904ea50a91 Mon Sep 17 00:00:00 2001
+From 30062d17f93e241c846248229b4ab2f6e4f5d414 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 14 Sep 2016 08:39:33 +0100
 Subject: [PATCH 118/141] drm/vc4: Add a mode for using the closed firmware for
@@ -133673,7 +133672,7 @@ index 0000000000000000000000000000000000000000..7dd233eed677c1689492ab95bc864753
 +	},
 +};
 
-From ec6d1bed9fcc9d01b62cd7fa81d17dd20ac42afe Mon Sep 17 00:00:00 2001
+From 5260aad4aa125f4db1355f69dc596b46911801ca Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:09:18 -0800
 Subject: [PATCH 119/141] drm/vc4: Name the primary and cursor planes in fkms.
@@ -133700,7 +133699,7 @@ index 7dd233eed677c1689492ab95bc86475330d2d63b..e6097046fb25361bc61d657083d95b63
  	if (type == DRM_PLANE_TYPE_PRIMARY) {
  		vc4_plane->fbinfo =
 
-From 86f4997a0b8b0ef8f6ef95741aa6d8edebe25947 Mon Sep 17 00:00:00 2001
+From f31486910dbff2f32895588952e8c495c0ebf107 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Wed, 1 Feb 2017 17:10:09 -0800
 Subject: [PATCH 120/141] drm/vc4: Add DRM_DEBUG_ATOMIC for the insides of
@@ -133773,7 +133772,7 @@ index e6097046fb25361bc61d657083d95b634232aabc..72d0b9cffe3d2997d69040c46f4aee11
  				    RPI_FIRMWARE_SET_CURSOR_STATE,
  				    &packet_state,
 
-From a693fd31839cafad9ffcb9c1c7dd7211762f3d64 Mon Sep 17 00:00:00 2001
+From a790c5ae91644fad644e16b716474fbedeab9b84 Mon Sep 17 00:00:00 2001
 From: Eric Anholt <eric@anholt.net>
 Date: Thu, 2 Feb 2017 09:42:18 -0800
 Subject: [PATCH 121/141] drm/vc4: Fix sending of page flip completion events
@@ -133818,7 +133817,7 @@ index 72d0b9cffe3d2997d69040c46f4aee11e22aa213..185f9bd3c1b2d47d0c1fc5293db4199b
  
  static void vc4_crtc_handle_page_flip(struct vc4_crtc *vc4_crtc)
 
-From f1bce2ca88558b901bbce51966f5e564a2f46505 Mon Sep 17 00:00:00 2001
+From dc2a35a31551f5a26d5c3d2ee97edcc704abebf0 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 18 Apr 2017 21:43:46 +0100
 Subject: [PATCH 122/141] vc4_fkms: Apply firmware overscan offset to hardware
@@ -133878,7 +133877,7 @@ index 185f9bd3c1b2d47d0c1fc5293db4199bd8963023..072f377b7423ee603d73ace2bf6d620f
  
  	return 0;
 
-From e6218018846b19767ca7951766b40a6b1ef93bd1 Mon Sep 17 00:00:00 2001
+From 2bb81282b687227a03ef1c8b2a6653bfa0a378cb Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 7 May 2017 11:34:26 +0200
 Subject: [PATCH 123/141] ASoC: bcm2835: Add support for TDM modes
@@ -134283,7 +134282,7 @@ index 56df7d8a43d0aac055a91b0d24aca8e1b4e308e4..dcacf7f83c9371df539a788ea33fedcf
  	dev->dev = &pdev->dev;
  	dev_set_drvdata(&pdev->dev, dev);
 
-From 9dc57a4395849527390c1e5a018e5c70d860d976 Mon Sep 17 00:00:00 2001
+From d0094dbf0b7521f529c609595224543e80c72266 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 7 May 2017 15:30:50 +0200
 Subject: [PATCH 124/141] ASoC: bcm2835: Support left/right justified and DSP
@@ -134418,10 +134417,11 @@ index dcacf7f83c9371df539a788ea33fedcf97d64690..3a706fda4f39e42efbe12f19d87af9b1
  		return -EINVAL;
  	}
  
-@@ -443,6 +497,15 @@ static int bcm2835_i2s_hw_params(struct snd_pcm_substream *substream,
+@@ -442,6 +496,15 @@ static int bcm2835_i2s_hw_params(struct snd_pcm_substream *substream,
+ 	bcm2835_i2s_calc_channel_pos(&tx_ch1_pos, &tx_ch2_pos,
  		tx_mask, slot_width, data_delay, odd_slot_offset);
  
- 	/*
++	/*
 +	 * Transmitting data immediately after frame start, eg
 +	 * in left-justified or DSP mode A, only works stable
 +	 * if bcm2835 is the frame clock master.
@@ -134430,10 +134430,9 @@ index dcacf7f83c9371df539a788ea33fedcf97d64690..3a706fda4f39e42efbe12f19d87af9b1
 +		dev_warn(dev->dev,
 +			"Unstable slave config detected, L/R may be swapped");
 +
-+	/*
+ 	/*
  	 * Set format for both streams.
  	 * We cannot set another frame length
- 	 * (and therefore word length) anyway,
 @@ -472,62 +535,38 @@ static int bcm2835_i2s_hw_params(struct snd_pcm_substream *substream,
  	mode |= BCM2835_I2S_FLEN(frame_length - 1);
  	mode |= BCM2835_I2S_FSLEN(framesync_length);
@@ -134532,7 +134531,7 @@ index dcacf7f83c9371df539a788ea33fedcf97d64690..3a706fda4f39e42efbe12f19d87af9b1
  }
  
 
-From cd72adaa850fad3d2ca67cd5bd73179b8041a701 Mon Sep 17 00:00:00 2001
+From c4b2defda9becf52d1a3582bdcfee0df8a5090b9 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 7 May 2017 16:19:54 +0200
 Subject: [PATCH 125/141] ASoC: bcm2835: Support additional samplerates up to
@@ -134578,7 +134577,7 @@ index 3a706fda4f39e42efbe12f19d87af9b100a348a5..43f5715a0d5dda851731ecf7ff27e76c
  				| SNDRV_PCM_FMTBIT_S24_LE
  				| SNDRV_PCM_FMTBIT_S32_LE
 
-From 45ccca28b4883ca89975e95c9cb4246700159cf3 Mon Sep 17 00:00:00 2001
+From 5dddc572352ecc458b7214ac62f12d992c87c794 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 7 May 2017 16:24:57 +0200
 Subject: [PATCH 126/141] ASoC: bcm2835: Enforce full symmetry
@@ -134617,7 +134616,7 @@ index 43f5715a0d5dda851731ecf7ff27e76c48fb6e57..2e449d7173fcecbcd647f90a26bd58b6
  
  static bool bcm2835_i2s_volatile_reg(struct device *dev, unsigned int reg)
 
-From a0aec790665714a3a987707cee56c1c46a2afa83 Mon Sep 17 00:00:00 2001
+From 0740274e27e88bb287b8223b5b889435d0ceb76e Mon Sep 17 00:00:00 2001
 From: Andrei Gherzan <andrei@gherzan.com>
 Date: Mon, 5 Jun 2017 16:40:38 +0100
 Subject: [PATCH 127/141] dma-bcm2708: Fix module compilation of
@@ -134663,7 +134662,7 @@ index c5bfff2765be4606077e6c8af73040ec13ee8974..6ca874d332a8bc666b1c9576ac51f479
  
  #endif /* _PLAT_BCM2708_DMA_H */
 
-From fdc93fc46a3d456fc7f32194d2b54c53ff437d4c Mon Sep 17 00:00:00 2001
+From 55dc0b1788ece54b929932c457912ff540075b92 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 25 Aug 2017 19:18:13 +0100
 Subject: [PATCH 128/141] cache: export clean and invalidate
@@ -134718,7 +134717,7 @@ index de78109d002db1a5e7c94a6c1bc8bb94161d07b8..4c850aa3af2b2439fced4e130441329a
  	sub	r3, r2, #1
  	bic	r0, r0, r3
 
-From 8c9b33ee88bae54c35a46450a92d8fa69b79eef8 Mon Sep 17 00:00:00 2001
+From e3caf67429b7c11fba451738c563ca801b3e8175 Mon Sep 17 00:00:00 2001
 From: Dan Pasanen <dan.pasanen@gmail.com>
 Date: Wed, 20 Sep 2017 10:17:41 -0500
 Subject: [PATCH 129/141] vcsm: fix multi-platform build
@@ -134748,7 +134747,7 @@ index 034ae2f27f870621af9f49453501f1cde051f32a..b7814d67500b98fcd6f376d526a3d4a4
  {
  	0,
 
-From d62521ea924946cef0afdb40d9661a4d6b84ce9e Mon Sep 17 00:00:00 2001
+From 29dca8ea50ebdd8e635e816459bd69c95fb67a48 Mon Sep 17 00:00:00 2001
 From: Dan Pasanen <dan.pasanen@gmail.com>
 Date: Thu, 21 Sep 2017 09:55:42 -0500
 Subject: [PATCH 130/141] arm: partially revert
@@ -134856,7 +134855,7 @@ index 054b491ff7649ca067ff821770aec80a4da42102..70e8b7d3443467ae9595924f1a9d043b
  EXPORT_SYMBOL(cpu_cache);
  #endif
 
-From 0b2eb857e0e3d1431d971ab64b7472d3251c7757 Mon Sep 17 00:00:00 2001
+From fe042ab04d5a1297d25266c3b3a711b582d95355 Mon Sep 17 00:00:00 2001
 From: Dan Pasanen <dan.pasanen@gmail.com>
 Date: Thu, 21 Sep 2017 09:57:44 -0500
 Subject: [PATCH 131/141] vcsm: add macros for cache functions
@@ -134912,7 +134911,7 @@ index b7814d67500b98fcd6f376d526a3d4a4b84fd152..32763bd01e2e3831778fbcd1066df3cb
  			}
  		}
 
-From 2104fb668729c1d4bf8b2b2883afa8f5b4f4ffd3 Mon Sep 17 00:00:00 2001
+From 18ff5210574ca27d767414e0e7b8dc8eb9d22f5b Mon Sep 17 00:00:00 2001
 From: Dan Pasanen <dan.pasanen@gmail.com>
 Date: Thu, 21 Sep 2017 07:41:02 -0500
 Subject: [PATCH 132/141] vcsm: use dma APIs for cache functions
@@ -134986,7 +134985,7 @@ index 32763bd01e2e3831778fbcd1066df3cbf582235d..cfa4ff747de2a96e03dab995aa54fc80
  					if ((op->invalidate_mode & ~3) != 0) {
  						ret = -EINVAL;
 
-From b8a0ecd87e0b3b7401ac6abf3c61c38cbe530511 Mon Sep 17 00:00:00 2001
+From e206c6b41927a6822dfd128d49096b40f55ea976 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 29 Sep 2017 16:15:01 +0100
 Subject: [PATCH 133/141] vcsm: Fix up macros to avoid breaking numbers used by
@@ -135012,7 +135011,7 @@ index e50fd8eaecef7a3c8451c040ffc3888cc37e28fc..4f120421c2d11f7ae46752c38b073a4d
  /* Allocate a shared memory handle and block. */
  int vc_sm_alloc(struct vc_sm_alloc_t *alloc, int *handle);
 
-From ef3142ee3dc67a5bbcb0271ddd483b9d83e30648 Mon Sep 17 00:00:00 2001
+From 9dc6e559a6ddff5f26a9904c72d6ceaeddc63e02 Mon Sep 17 00:00:00 2001
 From: Chung-Hsien Hsu <cnhu@cypress.com>
 Date: Sun, 14 May 2017 20:11:05 -0500
 Subject: [PATCH 134/141] brcmfmac: add CLM download support
@@ -135443,7 +135442,7 @@ index 0eea48e73331d57297099266b1725df2be35a565..f00016f804ac98995369c1e68586a86d
  
  static int brcmf_usb_bus_setup(struct brcmf_usbdev_info *devinfo)
 
-From 48408dc078e6a5511802bb4f43e74bc76d7d2c07 Mon Sep 17 00:00:00 2001
+From bf11d4af021941640f2ec81c8f969e54a77a1ae6 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 6 Oct 2017 13:23:32 +0100
 Subject: [PATCH 135/141] brcmfmac: request_firmware_direct is quieter
@@ -135471,7 +135470,7 @@ index f0309e039592ba6e388084a13f052c03f99cf1ef..b5889360da96096775db6425337a7215
  		if (err == -ENOENT)
  			return 0;
 
-From 5dbbb177374325a3f592c366cbe96df87540b4b7 Mon Sep 17 00:00:00 2001
+From cbca1f278fde1e93587d31f4fedd1c6d8d8c56d4 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 29 Sep 2017 10:32:19 +0100
 Subject: [PATCH 136/141] amba_pl011: Add cts-event-workaround DT property
@@ -135540,7 +135539,7 @@ index 4b815abbf9913075885ee60f4d9ad49d89ec96b2..8c6e495b74ca61b8ff8ee79bc6e9d84d
  	uap->vendor = vendor;
  	uap->fifosize = vendor->get_fifosize(dev);
 
-From ae2c161021ce0b1a8f78166cbfa166b639f7bbf9 Mon Sep 17 00:00:00 2001
+From 9a5d096b453b500c43bcc620d65f6291d3ab8289 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Fri, 29 Sep 2017 10:32:19 +0100
 Subject: [PATCH 137/141] amba_pl011: Insert mb() for correct FIFO handling
@@ -135570,7 +135569,7 @@ index 8c6e495b74ca61b8ff8ee79bc6e9d84d572b990a..f6428446dfc0eb060d18c119d065d85e
  
  	return true;
 
-From 4f89ed84e4767a9c10d00c899a03c515d4953411 Mon Sep 17 00:00:00 2001
+From 38056f59f1a1715e9a81a07701a0d048eadf31bd Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 11 Oct 2017 13:48:04 +0100
 Subject: [PATCH 138/141] amba-pl011: Report AUTOCTS capability to framework
@@ -135616,7 +135615,7 @@ index f6428446dfc0eb060d18c119d065d85ee6fea18c..aa661160a87330f013879e56a2da2ed6
  
  	if (uap->vendor->oversampling) {
 
-From c77df3ba51d392d38e20d815f294e32175ed7030 Mon Sep 17 00:00:00 2001
+From f2e17c0bae33523d6bf1e67f85eae5c7eb4f5749 Mon Sep 17 00:00:00 2001
 From: neilneil2000 <31366098+neilneil2000@users.noreply.github.com>
 Date: Thu, 12 Oct 2017 17:29:43 +0100
 Subject: [PATCH 139/141] GPIO and gpio-poweroff clarifications
@@ -135653,7 +135652,7 @@ index e6d777a601c91d192bc5713f9a73e1a2d4d708ef..b34c9a9f115b4d7ac81ef4d9417beaad
  Params: gpiopin                 GPIO for signalling (default 26)
  
 
-From d9744ee6ebe941c515ed88e0d50e89d29c247de6 Mon Sep 17 00:00:00 2001
+From 9bce93d61ea0f3f3c29fc7ed05881695bdac63c1 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Tue, 17 Oct 2017 17:17:20 +0100
 Subject: [PATCH 140/141] config: Add CONFIG_USB_LAN78XX=m
@@ -135689,7 +135688,7 @@ index e0dd8723047ff488e81a03ef42fdbc68c43dc721..e85544974de7de68309ba8ca7ae9f8d3
  CONFIG_USB_NET_AX8817X=m
  CONFIG_USB_NET_AX88179_178A=m
 
-From 6ac7b404eca1d164a9ea8afc34ce8233e36f5c79 Mon Sep 17 00:00:00 2001
+From 82cd6d277d1c95163a2e1b832fe395677b9cdd6d Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.org>
 Date: Wed, 25 Oct 2017 09:20:56 +0100
 Subject: [PATCH 141/141] scripts: Update mkknlimg, just in case


### PR DESCRIPTION
This should be the last 4.13.y bump before the switch to 4.14.0.

Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.13.12