### PR TITLE
systemd: remote+ is not a joystick

### DIFF
--- a/packages/sysutils/systemd/udev.d/60-not-joysticks.rules
+++ b/packages/sysutils/systemd/udev.d/60-not-joysticks.rules
@@ -1,1 +1,2 @@
 SUBSYSTEM=="input", ATTRS{name}=="aml_keypad", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{name}=="Remote+", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""


### PR DESCRIPTION
Fix for usb airmouse remote+, not all buttons work without this

https://forum.libreelec.tv/thread/2722-8-0-2c-libreelec-8-0-builds-for-ki-plus-kii-pro-ki-pro/?postID=69043#post69043