### PR TITLE
scripts/create_addon: simplify PROJECT selection, support DEVICE

### DIFF
--- a/packages/addons/service/slice/package.mk
+++ b/packages/addons/service/slice/package.mk
@@ -31,7 +31,7 @@ PKG_AUTORECONF="no"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Slice"
-PKG_ADDON_PROJECTS="RPi"
+PKG_ADDON_PROJECTS="Slice Slice3"
 PKG_ADDON_TYPE="xbmc.service"
 
 make_target() {

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -31,13 +31,8 @@ if [ -n "$PKG_ARCH" -a ! "$PKG_ARCH" = "any" ]; then
 fi
 
 if [ -n "$PKG_ADDON_PROJECTS" -a ! "$PKG_ADDON_PROJECTS" = "any" ]; then
-  for _PROJECT in $PKG_ADDON_PROJECTS ; do
-    if [ "$_PROJECT" = "$PROJECT" ] ; then
-      PROJECT_SUPPORTED="yes"
-    fi
-  done
-  if [ ! "$PROJECT_SUPPORTED" = "yes" ] ; then
-    echo "*** ERROR: $PKG_ADDON_ID: '$PROJECT' not supported ***"
+  if ! listcontains "${PKG_ADDON_PROJECTS}" "${DEVICE:-${PROJECT}}"; then
+    echo "*** ERROR: $PKG_ADDON_ID: '${DEVICE:-${PROJECT}}' not supported ***"
     exit 0
   fi
 fi


### PR DESCRIPTION
With the old code, any addon that is for RPi2 but not RPi, would not build as the PROJECT=RPi, eg. [audiodecoder.usf](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk#L35) which has:
```
PKG_ADDON_PROJECTS="Generic Nvidia_Legacy RPi2 imx6 WeTek_Play"
```
and scripts/create_addon would then claim that RPi2 is not supported.

Similarly, [service/slice](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/addons/service/slice/package.mk#L34) has:
```
PKG_ADDON_PROJECTS="RPi"
```
which will work with the old code, building for all RPi-based devices, but I don't know if this is intended. Consequently I've updated this package with the correct device codes, which will now mean it won't build for RPi and RPi2.