### PR TITLE
dtc: don't build libfdt for target

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -32,7 +32,7 @@ PKG_LONGDESC="The Device Tree Compiler"
 PKG_AUTORECONF="no"
 
 PKG_MAKE_OPTS_HOST="dtc libfdt"
-PKG_MAKE_OPTS_TARGET="dtc libfdt"
+PKG_MAKE_OPTS_TARGET="dtc"
 
 makeinstall_host() {
   mkdir -p $TOOLCHAIN/bin


### PR DESCRIPTION
not needed