### PR TITLE
heimdal: Disable OTP

### DIFF
--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -43,6 +43,7 @@ PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared \
                          --without-libedit \
                          --without-hesiod \
                          --without-x \
+                         --disable-otp \
                          --with-db-type-preference= \
                          --disable-heimdal-documentation"
 


### PR DESCRIPTION
Building OTP is broken on ArchLinux and it seems it is not needed
anyway.

@MilhouseVH is it safe to disable OTP?