### PR TITLE
util-linux: fix typo in blkid patch

### DIFF
--- a/packages/sysutils/util-linux/patches/util-linux-blkid_swapon_mkfs_uuidgen.patch
+++ b/packages/sysutils/util-linux/patches/util-linux-blkid_swapon_mkfs_uuidgen.patch
@@ -10,7 +10,7 @@ diff -Naur a/configure.ac b/configure.ac
 +  AS_HELP_STRING([--disable-uuidgen], [do not build uuidgen]),
 +  [], [UL_DEFAULT_ENABLE([uuidgen], [check])]
 +)
-+UL_BUILD_INIT([uuidgen]])
++UL_BUILD_INIT([uuidgen])
  UL_REQUIRES_BUILD([uuidgen], [libuuid])
  AM_CONDITIONAL([BUILD_UUIDGEN], [test "x$build_uuidgen" = xyes])
  


### PR DESCRIPTION
While building `util-linux` I noticed the following error is being silently ignored:

```
checking for ncursesw5-config... no
checking for ncursesw... no
checking for initscr in -lncursesw... no
/home/neil/projects/scratch/alternates/xLibreELEC.tv/build.LibreELEC-Generic.x86_64-8.2-devel/util-linux-2.31/configure: line 23338: build_uuidgen]=yes: command not found
checking for unshare... yes
checking for setns... yes
```

The typo in the patch results in the following being written to `configure`, which is obviously garbage:
```
  23335   if test "x$enable_uuidgen]" = xno; then
  23336    build_uuidgen]=no
  23337 else
  23338    build_uuidgen]=yes
  23339 fi
```

@CvH can you update #2186 with this fix. Unfortunately it's not the cause of our 8.2/17.10 woes. :(