### PR TITLE
glibc: fix perl

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -31,7 +31,7 @@ PKG_LONGDESC="The Glibc package contains the main C library. This library provid
 PKG_AUTORECONF="no"
 
 PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
-                           ac_cv_path_PERL= \
+                           ac_cv_path_PERL=no \
                            ac_cv_prog_MAKEINFO= \
                            --libexecdir=/usr/lib/glibc \
                            --cache-file=config.cache \


### PR DESCRIPTION
I noticed the following error in the build logs:

```
/home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-9.0-devel/glibc-2.26/configure: line 5542: -V:apiversion: command not found
```

The relevant code in `configure` is:
```
   5541 if test "$PERL" != no &&
   5542    (eval `$PERL -V:apiversion`; test `expr "$apiversion" \< 5` -ne 0); then
   5543   PERL=no
   5544 fi
```

The value of `$PERL` is being set from:

https://github.com/LibreELEC/LibreELEC.tv/blob/298a1c251059c24c8a4732312b896e5f17841f4c/packages/devel/glibc/package.mk#L34

which results in `$PERL` being initially blank, which is != `no`, and consequently `configure` tries to execute `-V:apiversion` as a command, before setting `PERL=no`.

@CvH: needed by libreelec-8.2 too.