### PR TITLE
samba: allow access to addons folder

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -174,3 +174,11 @@
   public = yes
   writable = yes
   root preexec = mkdir -p /storage/picons/tvh /storage/picons/vdr
+
+[Addons]
+  path = /storage/.kodi/addons
+  available = yes
+  browsable = yes
+  public = yes
+  writable = yes
+  root preexec = mkdir -p /storage/.kodi/addons


### PR DESCRIPTION
Allow access to /storage/.kodi/addons

Useful for plugin/theme developers, userdata is already accessible so I don't see why this isn't