### PR TITLE
kodi: safe mode [RFC]

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="85b86d4"
-PKG_SHA256="944f0984f96234e81ae79a595942d830c9554b39c8be8ca287a3c4ff8930c695"
+PKG_VERSION="057ab16"
+PKG_SHA256="dac3e653a5348e3dcd229399343e7a78fa9123e1c721c2a2117d43967f354354"
 PKG_ARCH="any"
 PKG_LICENSE="prop."
 PKG_SITE="https://libreelec.tv"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -265,7 +265,13 @@ post_makeinstall_target() {
 
   mkdir -p $INSTALL/usr/lib/kodi
     cp $PKG_DIR/scripts/kodi-config $INSTALL/usr/lib/kodi
+    cp $PKG_DIR/scripts/kodi-safe-mode $INSTALL/usr/lib/kodi
     cp $PKG_DIR/scripts/kodi.sh $INSTALL/usr/lib/kodi
+
+    # Configure safe mode triggers - default 5 restarts within 900 seconds/15 minutes
+    $SED -e "s|@KODI_MAX_RESTARTS@|${KODI_MAX_RESTARTS:-5}|g" \
+         -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
+         -i $INSTALL/usr/lib/kodi/kodi.sh
 
   mkdir -p $INSTALL/usr/sbin
     cp $PKG_DIR/scripts/service-addon-wrapper $INSTALL/usr/sbin

--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -17,28 +17,35 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
+KODI_ROOT=$HOME/.kodi
+
+BOOT_STATE="$(cat $HOME/.config/boot.status 2>/dev/null)"
 
 # hack: make addon-bins executable
 # done in kodi on addon install. but just in case..
-chmod +x /storage/.kodi/addons/*/bin/*
+chmod +x $KODI_ROOT/addons/*/bin/* 2>/dev/null
 
 # hack: update RSSnews.xml in userdata
-if [ -f /storage/.kodi/userdata/RssFeeds.xml ]; then
+if [ -f $KODI_ROOT/userdata/RssFeeds.xml ]; then
   sed -e "s,http://libreelec.tv/news?format=feed&type=rss,http://feeds.libreelec.tv/news,g" \
-      -i /storage/.kodi/userdata/RssFeeds.xml
+      -i $KODI_ROOT/userdata/RssFeeds.xml
 fi
 
 # setup Kodi sources
-if [ ! -f $HOME/.kodi/userdata/sources.xml ]; then
+if [ ! -f $KODI_ROOT/userdata/sources.xml ]; then
   if [ -f /usr/share/kodi/config/sources.xml ]; then
-    cp /usr/share/kodi/config/sources.xml $HOME/.kodi/userdata
+    cp /usr/share/kodi/config/sources.xml $KODI_ROOT/userdata
   fi
 fi
 
 # common setup guisettings
-if [ ! -f $HOME/.kodi/userdata/guisettings.xml ] ; then
+if [ ! -f $KODI_ROOT/userdata/guisettings.xml ] ; then
   if [ -f /usr/share/kodi/config/guisettings.xml ]; then
-    cp /usr/share/kodi/config/guisettings.xml $HOME/.kodi/userdata
+    cp /usr/share/kodi/config/guisettings.xml $KODI_ROOT/userdata
+  fi
+  if [ "$BOOT_STATE" = "SAFE" ]; then
+    [ ! -f $KODI_ROOT/userdata/guisettings.xml ] && echo '<settings version="2"></settings>' > $KODI_ROOT/userdata/guisettings.xml
+    xmlstarlet ed --omit-decl --inplace -s settings -t elem -n setting -v "maroon" -i settings/setting -t attr -n id -v lookandfeel.skincolors $KODI_ROOT/userdata/guisettings.xml
   fi
 fi
 

--- a/packages/mediacenter/kodi/scripts/kodi-safe-mode
+++ b/packages/mediacenter/kodi/scripts/kodi-safe-mode
@@ -1,0 +1,49 @@
+#!/bin/sh
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+KODI_ROOT=$HOME/.kodi
+
+KODI_ROOT_FAILED=$KODI_ROOT.FAILED
+BOOT_STATUS=$HOME/.config/boot.status
+
+process_boot_status()
+{
+  BOOT_STATE="$(cat $BOOT_STATUS 2>/dev/null)"
+
+  if [ "${BOOT_STATE}" = "SAFE" ]; then
+    if [ ! -d $KODI_ROOT_FAILED ]; then
+      # entering safe mode - rename failed .kodi, and restart with clean .kodi
+      mv $KODI_ROOT $KODI_ROOT_FAILED
+      reboot
+    else
+      # exiting safe mode - restore failed .kodi
+      rm -fr $KODI_ROOT
+      mv $KODI_ROOT_FAILED $KODI_ROOT
+      echo "OK" > $BOOT_STATUS
+    fi
+  else
+    echo "OK" > $BOOT_STATUS
+  fi
+
+  return 0
+}
+
+process_boot_status
+
+exit 0

--- a/packages/mediacenter/kodi/system.d/kodi.service
+++ b/packages/mediacenter/kodi/system.d/kodi.service
@@ -16,6 +16,7 @@ EnvironmentFile=-/run/libreelec/debug/kodi.conf
 ExecStartPre=-/usr/lib/kodi/kodi-config
 ExecStart=/usr/lib/kodi/kodi.sh --standalone -fs $KODI_ARGS $KODI_DEBUG
 ExecStop=/bin/kill -TERM $MAINPID
+ExecStopPost=-/usr/lib/kodi/kodi-safe-mode
 TimeoutStopSec=5
 Restart=always
 RestartSec=2

--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -40,6 +40,11 @@ if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
   done
 fi
 
+# Allow access to a "failed" (safe mode) Kodi installation
+if [ -d /storage/.kodi.FAILED ]; then
+  echo -e "[Kodi-Failed]\n  path = /storage/.kodi.FAILED\n  available = yes\n  browsable = yes\n  public = yes\n  writable = yes\n" >> $SMB_CONF
+fi
+
 ADD_CONFIG=
 
 # If workgroup is not set, don't set it - who knows, user may know better.


### PR DESCRIPTION
As nobody wanted to discuss this on Slack...

With the move to automatic updates enabled by default, I have a sneaking suspicion this may lead to an increase in the number of systems that enter a Kodi crash loop due to duff addons after the upgrade, particularly after a major upgrade.

To mitigate this, I present to you... safe mode.

By default after 5 crashes within 15 minutes (both configurable in `options`: `KODI_MAX_RESTARTS` and `KODI_MAX_SECONDS`) "safe mode" will restart LibreELEC with a temporary _clean_ `.kodi` folder.

The original (and crash-causing) `.kodi` folder will be renamed `.kodi.FAILED`. In the `Logfiles` Samba folder an extra archive with `-FAILED` suffix will be created with the logs from the failed Kodi folder.

"Safe mode" (identifiable as it uses the red background for the default Estuary skin) should now give the user time to enable Samba and/or ssh, and perform any type of investigation required to determine the cause of the crash loop, including potentially downgrading to the previous version of LibreELEC.

To return to their original `.kodi` folder they simply need to reboot. Obviously if the cause of the crash has not been resolved then they'll quickly find themselves back in "safe mode".

Users can disable "safe mode" entirely by creating `/storage/.config/safemode.disable`.

There's probably a cleaner/better/neater solution for this that involves additional systemd services and dependencies, in which case consider this nothing more than a proof of concept for anyone that wishes to go that route. And if this isn't wanted, then we can close it.

These commits have been in my test builds for the past week.

----
A simple way to test this PR as follows:

1. `systemctl stop kodi`
2. `cd /storage/.kodi`
3. `mv userdata userdata.bak`
4. `touch userdata`
5. `reboot`

Kodi will now crash on start, entering a "restart loop".

After 5 restarts Kodi should enter "safe mode" with a red background, allowing the cause of the crash to be investigated and fixed.

To resolve the issue, connect and...
1. `cd .kodi.FAILED`
2. `rm userdata`
3. `mv userdata.bak userdata`
4. `reboot`
