### PR TITLE
slice: patch bcm2708-rpi.dtsi so emmc uses /dev/mmcblk0

### DIFF
--- a/projects/RPi/devices/Slice/patches/linux/linux-999.99-slice-mmc-aliases.patch
+++ b/projects/RPi/devices/Slice/patches/linux/linux-999.99-slice-mmc-aliases.patch
@@ -1,0 +1,20 @@
+--- a/arch/arm/boot/dts/bcm2708-rpi.dtsi	2017-11-18 04:56:28.149405247 +0000
++++ b/arch/arm/boot/dts/bcm2708-rpi.dtsi	2017-11-18 05:35:40.265159491 +0000
+@@ -21,7 +21,7 @@
+ 		gpio = &gpio;
+ 		uart0 = &uart0;
+ 		sdhost = &sdhost;
+-		mmc0 = &sdhost;
++		mmc1 = &sdhost;
+ 		i2s = &i2s;
+ 		spi0 = &spi0;
+ 		i2c0 = &i2c0;
+@@ -29,7 +29,7 @@
+ 		spi1 = &spi1;
+ 		spi2 = &spi2;
+ 		mmc = &mmc;
+-		mmc1 = &mmc;
++		mmc0 = &mmc;
+ 		i2c1 = &i2c1;
+ 		i2c2 = &i2c2;
+ 		usb = &usb;

--- a/projects/RPi/devices/Slice3/patches/linux/linux-999.99-slice-mmc-aliases.patch
+++ b/projects/RPi/devices/Slice3/patches/linux/linux-999.99-slice-mmc-aliases.patch
@@ -1,0 +1,20 @@
+--- a/arch/arm/boot/dts/bcm2708-rpi.dtsi	2017-11-18 04:56:28.149405247 +0000
++++ b/arch/arm/boot/dts/bcm2708-rpi.dtsi	2017-11-18 05:35:40.265159491 +0000
+@@ -21,7 +21,7 @@
+ 		gpio = &gpio;
+ 		uart0 = &uart0;
+ 		sdhost = &sdhost;
+-		mmc0 = &sdhost;
++		mmc1 = &sdhost;
+ 		i2s = &i2s;
+ 		spi0 = &spi0;
+ 		i2c0 = &i2c0;
+@@ -29,7 +29,7 @@
+ 		spi1 = &spi1;
+ 		spi2 = &spi2;
+ 		mmc = &mmc;
+-		mmc1 = &mmc;
++		mmc0 = &mmc;
+ 		i2c1 = &i2c1;
+ 		i2c2 = &i2c2;
+ 		usb = &usb;


### PR DESCRIPTION
This ensures the emmc storage on the CM3 uses /dev/mmcblk0 else it becomes /dev/mmcblk1 in recent kernels which causes boot failure after updating to LE9.0 due to cmdline.txt containing hard references to /dev/mmcblk0. I'm still asking questions to Pi kernel people to see if there's a way to change the aliases through the Slice dts file so we can avoid the patch, but for now, this works.