### PR TITLE
scripts/mkimage: use uuid for partitions on RPi

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -193,7 +193,7 @@ elif [ "$BOOTLOADER" = "bcm2835-bootloader" ]; then
   # create bootloader configuration
     echo "image: creating bootloader configuration..."
     cat << EOF > "$LE_TMP"/cmdline.txt
-boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 quiet $EXTRA_CMDLINE
+boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet $EXTRA_CMDLINE
 EOF
 
     mcopy "$LE_TMP/cmdline.txt" ::


### PR DESCRIPTION
not sure why this wasn't ever converted before.