### PR TITLE
util-linux: add --without-ncursesw to config

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -48,6 +48,7 @@ UTILLINUX_CONFIG_DEFAULT="--disable-gtk-doc \
                           --without-audit \
                           --without-udev \
                           --without-ncurses \
+                          --without-ncursesw \
                           --without-readline \
                           --without-slang \
                           --without-tinfo \


### PR DESCRIPTION
On our main build server I see failures with util-linux 2.31 related to it finding some ncurses libs and maybe not respecting the `--without-ncurses` switch. Looking at the commits between 2.30 which works fine and 2.31 which does not; reverting [https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/commit/?id=87c26ce5b689abe1b52181f98ef3c9eb1b1a5165](url) "fixes" the issue, e.g. with the patch:

```
checking for armv7ve-libreelec-linux-gnueabi-ncursesw6-config... no
checking for ncursesw6-config... no
checking for armv7ve-libreelec-linux-gnueabi-ncursesw5-config... no
checking for ncursesw5-config... ncursesw5-config
checking ncursesw/ncurses.h usability... no
checking ncursesw/ncurses.h presence... no
checking for ncursesw/ncurses.h... no
checking ncursesw/term.h usability... no
checking ncursesw/term.h presence... no
checking for ncursesw/term.h... no
```
and without it (ncurses things found):
```
checking for armv7ve-libreelec-linux-gnueabi-ncursesw6-config... no
checking for ncursesw6-config... no
checking for armv7ve-libreelec-linux-gnueabi-ncursesw5-config... no
checking for ncursesw5-config... ncursesw5-config
checking ncursesw/ncurses.h usability... no
checking ncursesw/ncurses.h presence... no
checking for ncursesw/ncurses.h... no
checking ncursesw/term.h usability... no
checking ncursesw/term.h presence... no
checking for ncursesw/term.h... no
checking ncurses.h usability... yes
checking ncurses.h presence... yes
checking for ncurses.h... yes
checking term.h usability... yes
checking term.h presence... yes
checking for term.h... yes
checking for use_default_colors in -lncursesw... no
checking for resizeterm in -lncursesw... no
```
I'm submitting the PR in the hope that someone who understands compile stuff can spot the issue and come up with a better fix - consider it a placeholder