### PR TITLE
virtual: avoid exiting with failure code

### DIFF
--- a/packages/virtual/virtual/package.mk
+++ b/packages/virtual/virtual/package.mk
@@ -30,4 +30,4 @@ PKG_AUTORECONF="no"
 
 get_graphicdrivers
 
-listcontains "$GRAPHIC_DRIVERS" "vmware" && PKG_DEPENDS_TARGET+=" open-vm-tools"
+listcontains "$GRAPHIC_DRIVERS" "vmware" && PKG_DEPENDS_TARGET+=" open-vm-tools" || true


### PR DESCRIPTION
When `vmware` is not enabled, the build system will bail out because the package finishes with exit code == 1, which is interpreted by `set -e` in `config/path` as an error condition.

Ping @LongChair 
