### PR TITLE
libcec: disable git depends

### DIFF
--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -32,7 +32,8 @@ PKG_AUTORECONF="no"
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=1 \
                        -DCMAKE_INSTALL_LIBDIR:STRING=lib \
                        -DCMAKE_INSTALL_LIBDIR_NOARCH:STRING=lib \
-                       -DHAVE_IMX_API=0"
+                       -DHAVE_IMX_API=0 \
+                       -DHAVE_GIT_BIN=0"
 
 if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET bcm2835-driver"


### PR DESCRIPTION
disable git depends to fix Jenkins

before
```
-- git found: fatal: No tags can describe 'b1073d3db040416a7a099b16174cff1a4e77061a'.
Try --always, or create some tags.
...
-- lib info: git revision: fatal: No tags can describe 'b1073d3db040416a7a099b16174cff1a4e77061a'.
Try --always, or create some tags., compiled on Wed Nov 22 by jenkins@buildbox on Linux 4.4.0-81-generic (x86_64)

```

after
```
-- lib info:  compiled on Wed Nov 22 by jenkins@buildbox on Linux 4.4.0-81-generic (x86_64)
```