### PR TITLE
config/options: check if the effective uid is root (and bail if so)

### DIFF
--- a/config/options
+++ b/config/options
@@ -1,3 +1,9 @@
+# Do not build as root. Ever.
+if [[ $EUID -eq 0 ]]; then
+  echo "Building as the root user is NOT supported. Use a regular user account for the build." 1>&2
+  exit 1
+fi
+
 # set default language for buildsystem
   export LC_ALL=C
 


### PR DESCRIPTION
This prevents anyone building as `root`, which runs the risk of trashing a system given that a cross-compiling build system wants to overwrite the host files at every opportunity (and will, if being run as `root`).