### PR TITLE
NOOBS: shorten partition labels, change tar filename [backport]

### DIFF
--- a/config/noobs/partitions.json
+++ b/config/noobs/partitions.json
@@ -1,7 +1,7 @@
 {
   "partitions": [
     {
-      "label":                     "@DISTRONAME@_@PROJECT@_System",
+      "label":                     "System",
       "filesystem_type":           "FAT",
       "partition_size_nominal":    @SYSTEM_SIZE@,
       "want_maximised":            false,
@@ -9,7 +9,7 @@
       "mkfs_options":              ""
     },
     {
-      "label":                     "@DISTRONAME@_@PROJECT@_Storage",
+      "label":                     "Storage",
       "filesystem_type":           "ext4",
       "partition_size_nominal":    512,
       "want_maximised":            true,

--- a/scripts/image
+++ b/scripts/image
@@ -424,6 +424,8 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
     popd > /dev/null
 
   elif [ "$1" = "noobs" ]; then
+    echo "Creating \"$1\" release tarball..."
+
     RELEASE_DIR="$TARGET_IMG/${IMAGE_NAME}-$1"
 
     # create release dir
@@ -507,12 +509,12 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
     mkdir -p $RELEASE_DIR/${DISTRONAME}_${PROJECT}/Storage
 
     # remove an previous created release tarball
-    rm -rf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/${DISTRONAME}_${PROJECT}_System.tar.xz
-    rm -rf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/${DISTRONAME}_${PROJECT}_Storage.tar.xz
+    rm -rf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/System.tar.xz
+    rm -rf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/Storage.tar.xz
 
     # create filesystem tarballs
-    tar cJf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/${DISTRONAME}_${PROJECT}_System.tar.xz -C $RELEASE_DIR/${DISTRONAME}_${PROJECT}/System/ .
-    tar cJf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/${DISTRONAME}_${PROJECT}_Storage.tar.xz -C $RELEASE_DIR/${DISTRONAME}_${PROJECT}/Storage/ .
+    tar cJf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/System.tar.xz -C $RELEASE_DIR/${DISTRONAME}_${PROJECT}/System/ .
+    tar cJf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/Storage.tar.xz -C $RELEASE_DIR/${DISTRONAME}_${PROJECT}/Storage/ .
 
     # remove an filesystem dirs
     rm -rf $RELEASE_DIR/${DISTRONAME}_${PROJECT}/System


### PR DESCRIPTION
Limited backport of #2243.

Once implemented, create duplicates of the new tarfiles using the old tar filenames until the [upstream json](https://downloads.raspberrypi.org/os_list_v3.json) file is updated.