### PR TITLE
scripts/get: avoid flip-flopping downloads

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -21,7 +21,7 @@
 . config/options $1
 
 _get_file_already_downloaded() {
-  [ ! -f $PACKAGE ] && return 1
+  [ ! -f $PACKAGE -o ! -f $STAMP_URL -o ! -f $STAMP_SHA ] && return 1
   [ -n "${PKG_SHA256}" -a "$(cat $STAMP_SHA 2>/dev/null)" != "${PKG_SHA256}" ] && return 1
   return 0
 }

--- a/scripts/get
+++ b/scripts/get
@@ -21,12 +21,9 @@
 . config/options $1
 
 _get_file_already_downloaded() {
-  if [ -f $PACKAGE ]; then
-    if [ "$(cat $STAMP_URL 2>/dev/null)" == "${PKG_URL}" ]; then
-      [ -z "${PKG_SHA256}" -o "$(cat $STAMP_SHA 2>/dev/null)" == "${PKG_SHA256}" ] && return 0
-    fi
-  fi
-  return 1
+  [ ! -f $PACKAGE ] && return 1
+  [ -n "${PKG_SHA256}" -a "$(cat $STAMP_SHA 2>/dev/null)" != "${PKG_SHA256}" ] && return 1
+  return 0
 }
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
This addresses an issue with package downloads when building different versions of LibreELEC from a single repository, or using a shared `sources` folder maintained outside of the LibreELEC repository (in order to save space and/or due to limited internet bandwidth).

This mainly affects packages downloaded from `$DISTRO_SRC` as this will evaluate to a different url for `devel` than it will for `8.2.1` or `9.0` etc., even though the downloaded packages may be identical. However it can also affect packages that have been updated to use an alternative `PKG_URL` in master (but not a different version) which hasn't been backported to an older branch - although the packages may be identical they will be repeatedly downloaded each time the "other" branch is built due to the different url. This is particularly painful if you have limited internet bandwidth.

This change will currently only be of benefit to master as this branch includes `PKG_SHA256` support, which should be sufficient to reliably determine if the currently downloaded package (regardless of where it was downloaded from) is the same as the required package.

There's nothing we can do for older branches due to the lack of `PKG_SHA256` support as the only available comparison is `PKG_URL` and it's this value that is changing from one build to the next (so no need to backport).