### PR TITLE
config/options: LINUX_DEPENDS not observing correct kernel config whe…

### DIFF
--- a/config/options
+++ b/config/options
@@ -28,8 +28,6 @@ fi
 ROOT="${PWD}"
 DISTRO_DIR="$ROOT/distributions"
 PROJECT_DIR="$ROOT/projects"
-LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux/linux.$TARGET_ARCH.conf $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/linux.$TARGET_ARCH.conf $ROOT/packages/linux/package.mk"
-[ "$TARGET_ARCH" = "x86_64" ] && LINUX_DEPENDS+=" $ROOT/packages/linux-firmware/intel-ucode/package.mk $ROOT/packages/linux-firmware/x86-firmware/package.mk"
 
 # include versioning
   . config/version
@@ -53,6 +51,9 @@ LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux/linux.$TARGET_ARCH.conf $PROJECT_DIR/
  if [ -f "$PROJECT_DIR/$PROJECT/devices/$DEVICE/options" ]; then
    . $PROJECT_DIR/$PROJECT/devices/$DEVICE/options
  fi
+
+LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf $ROOT/packages/linux/package.mk"
+[ "$TARGET_ARCH" = "x86_64" ] && LINUX_DEPENDS+=" $ROOT/packages/linux-firmware/intel-ucode/package.mk $ROOT/packages/linux-firmware/x86-firmware/package.mk"
 
 # Need to point to your actual cc
 # If you have ccache installed, take care that LOCAL_CC don't point to it


### PR DESCRIPTION
…n TARGET_PATCH_ARCH in effect

This only affects:
```
Odroid_C2
WeTek_Hub
WeTek_Play_2
```

When building these systems for `ARCH=arm` the kernel config is still named `linux.aarch64.conf` and not `linux.arm.conf`.

Since `TARGET_PATCH_ARCH` is set in `project/options` the determination of `LINUX_DEPENDS` now has to happen after all the `options` have been sourced.

To be honest I'd like `LINUX_DEPENDS` to consider the content of the whole `packages/linux` folder (ie. including all patches) rather than just specific files (ie. `package.mk`). As of now, if a kernel patch is added or modified then any dependent packages that are dependent on the kernel source code/version/configuration will **NOT** be automatically cleaned and rebuilt. The only problem is that we don't know until the `linux` package is sourced which patches the kernel is using so considering the whole folder is a bit of a sledgehammer, but still preferable to ignoring patches entirely.