### PR TITLE
scripts/mkimage: add label to disk partition as well

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -70,6 +70,7 @@ trap cleanup SIGINT
   FAT_SERIAL_NUMBER="${UUID_1}${UUID_2}"
   UUID_SYSTEM="${UUID_1}-${UUID_2}"
   FAT_VOLUME_LABEL="LIBREELEC"
+  STORAGE_VOLUME_LABEL="STORAGE"
 
 # create an image
   echo
@@ -276,7 +277,7 @@ fi # bootloader
 # create filesystem on part2
   echo "image: creating filesystem on part2..."
   mke2fs -F -q -t ext4 -m 0 "$LE_TMP/part2.ext4"
-  tune2fs -U $UUID_STORAGE "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+  tune2fs -L "$STORAGE_VOLUME_LABEL" -U $UUID_STORAGE "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
   e2fsck -n "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
   sync
 


### PR DESCRIPTION
This patch adds `LIBREELEC_DISK` label to user data partition. This is required to allow Amlogic devices boot from USB drives. Possibly useful for other devices as well.