### PR TITLE
scripts: add an option to define, compile and add autoscript files to SD card image

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -259,6 +259,12 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
 
   RELEASE_DIR="target/$IMAGE_NAME"
 
+  if [ -n "$DEVICE" -a -d "$PROJECT_DIR/$PROJECT/devices/$DEVICE/install" ]; then
+    INSTALL_SRC_DIR="$PROJECT_DIR/$PROJECT/devices/$DEVICE/install"
+  else
+    INSTALL_SRC_DIR="$PROJECT_DIR/$PROJECT/install"
+  fi
+
   # cleanup
   rm -rf $RELEASE_DIR
 
@@ -337,8 +343,10 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
       DISTRO="$DISTRO" \
       TARGET_IMG="$TARGET_IMG" \
       IMAGE_NAME="$IMAGE_NAME" \
+      INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
       BOOTLOADER="$BOOTLOADER" \
       KERNEL_NAME="$KERNEL_NAME" \
+      TARGET_KERNEL_ARCH="$TARGET_KERNEL_ARCH" \
       RELEASE_DIR=$RELEASE_DIR \
       UUID_STORAGE="$(uuidgen)" \
       UBOOT_SYSTEM="$UBOOT_SYSTEM" \
@@ -356,7 +364,6 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
   if [ "$1" = "amlpkg" ]; then
     echo "Creating Amlogic ZIP update package"
 
-    INSTALL_SRC_DIR="$PROJECT_DIR/$PROJECT/install"
     AML_PKG_DIR="$RELEASE_DIR/ampl-pkg"
 
     # create package directory

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -263,6 +263,15 @@ EOF
     mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
     mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
 
+    # generate autoscript files for Amlogic devices and add them to SD card image
+    for src in $INSTALL_SRC_DIR/*autoscript.src ; do
+      if [ -e "$src" ] ; then
+        AUTOSCRIPT_DEST="$LE_TMP/$(basename $src .src)"
+        $TOOLCHAIN/bin/mkimage -A $TARGET_KERNEL_ARCH -O linux -T script -C none -d "$src" "$AUTOSCR_DEST" > /dev/null
+        mcopy "$AUTOSCR_DEST" ::
+      fi
+    done
+
 elif [ "$BOOTLOADER" = "u-boot" ]; then
   echo "to make an image using u-boot UBOOT_SYSTEM must be set"
   cleanup


### PR DESCRIPTION
Currently projects for WeTek devices have `aml_autoscript` in binary format. This patch allows to include them as source files and compile during system image creation - for easier modification and clarity.

Please @codesnake @Raybuntu and @adamg-xda have a look.