### PR TITLE
 buildsystem: add python toolchain 

### DIFF
--- a/packages/lang/Python2/patches/Python-2.7.14-017-easy_install.patch
+++ b/packages/lang/Python2/patches/Python-2.7.14-017-easy_install.patch
@@ -1,0 +1,19 @@
+diff -Naur Python-2.7.14-orig/Lib/distutils/cmd.py Python-2.7.14/Lib/distutils/cmd.py
+--- Python-2.7.14-orig/Lib/distutils/cmd.py	2017-09-16 19:38:35.000000000 +0200
++++ Python-2.7.14/Lib/distutils/cmd.py	2017-12-15 13:18:26.271636584 +0100
+@@ -52,10 +52,11 @@
+         initializer and depends on the actual command being
+         instantiated.
+         """
+-        # late import because of mutual dependence between these classes
+-        from distutils.dist import Distribution
+-
+-        if not isinstance(dist, Distribution):
++        # From https://bugs.python.org/issue23102
++        # dist should quack like a Distribution (duck-typing avoids a
++        # circular dependency and hopefully ameliorates trouble due to
++        # setuptools having monkey patched distutils modules).
++        if not hasattr(dist, 'get_requires'):
+             raise TypeError, "dist must be a Distribution instance"
+         if self.__class__ is Command:
+             raise RuntimeError, "Command is an abstract class"

--- a/scripts/build
+++ b/scripts/build
@@ -213,6 +213,13 @@ if [ "$PKG_IS_KERNEL_PKG" = "yes" ]; then
   fi
 fi
 
+if [ "$PKG_TOOLCHAIN" = "python" ]; then
+  [ -z "$PKG_PYTHON" ] && PKG_PYTHON="2"
+  _python="$TOOLCHAIN/bin/python$PKG_PYTHON"
+  PKG_DEPENDS_HOST="toolchain distutilscross:host $PKG_DEPENDS_HOST"
+  PKG_DEPENDS_TARGET="toolchain distutilscross:host Python$PKG_PYTHON $PKG_DEPENDS_TARGET"
+fi
+
 # build dependencies, only when PKG_DEPENDS_? is filled
 unset _pkg_depends
 case "$TARGET" in
@@ -284,7 +291,7 @@ if [ -z "$PKG_TOOLCHAIN" -o "$PKG_TOOLCHAIN" = "auto" ]; then
   fi
   _auto_toolchain=" (auto-detect)"
 fi
-if ! listcontains "meson cmake cmake-make configure ninja make autotools manual" "$PKG_TOOLCHAIN"; then
+if ! listcontains "meson cmake cmake-make configure ninja make autotools manual python" "$PKG_TOOLCHAIN"; then
   printf "$(print_color bold-red "ERROR:") unknown toolchain $PKG_TOOLCHAIN"
   exit 1
 fi
@@ -456,6 +463,26 @@ else
       echo "Executing (bootstrap): make $PKG_MAKE_OPTS_BOOTSTRAP" | tr -s " "
       make $PKG_MAKE_OPTS_BOOTSTRAP
       ;;
+
+    # python based build
+    "python:host")
+      echo "Executing (host): $_python setup.py build --build-base .$HOST_NAME" | tr -s " "
+      export LDSHARED="$CC -shared $LDSHARED"
+      $_python setup.py build --build-base .$HOST_NAME
+      ;;
+    "python:target")
+      echo "Executing (target): $_python setup.py easy_install --build-directory=$PKG_BUILD/.$TARGET_NAME $_python_deps --prefix=$INSTALL/usr ." | tr -s " "
+      export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include -L$SYSROOT_PREFIX/usr/lib"
+      export LDSHARED="$CC -shared $LDSHARED"
+      export PYTHONXCPREFIX="$SYSROOT_PREFIX/usr"
+      _pythonpath="$INSTALL/usr/lib/$(readlink $_python)/site-packages"
+      mkdir -p $_pythonpath
+      [ "$PKG_PYTHON_DEPS" != "yes" ] && _python_deps="--no-deps"
+      PYTHONPATH="$PYTHONPATH:$_pythonpath" $_python setup.py easy_install --build-directory=$PKG_BUILD/.$TARGET_NAME $_python_deps --prefix=$INSTALL/usr .
+      find "$INSTALL/usr" -name "*.py" -exec rm -rf "{}" ";"
+      find "$INSTALL/usr" -name "*.egg" -type f -exec zip -dq {} "*.exe" "*.py" ";"
+      mv $_pythonpath/easy-install.pth $_pythonpath/$PKG_NAME-$PKG_VERSION.pth
+      ;;
   esac
 fi
 if [ "$(type -t post_make_$TARGET)" = "function" ]; then
@@ -498,6 +525,12 @@ else
       ;;
     "configure:bootstrap"|"cmake-make:bootstrap"|"autotools:bootstrap"|"make:bootstrap")
       make install $PKG_MAKEINSTALL_OPTS_BOOTSTRAP
+      ;;
+
+    # python based build
+    "python:host")
+      echo "Executing (host): $_python setup.py build --build-base .$HOST_NAME install --root=/ --prefix=$TOOLCHAIN" | tr -s " "
+      $_python setup.py build --build-base .$HOST_NAME install --root=/ --prefix=$TOOLCHAIN
       ;;
   esac
 fi


### PR DESCRIPTION
This adds the python2 toolchain to the amazing buildsystem rework by @InuSasha 
This toolchain is not auto-detected, optional and allows to easily build bundled pinned Python packages.
cffi is provided as a sample, see my tree for others. This could be used to build TUF or other Python dependencies.
I hope it will make it this time.