### PR TITLE
v4l-utils: fix sending scancodes with ir-ctl

### DIFF
--- a/packages/sysutils/v4l-utils/patches/v4l-utils-02-irctl-fix-multiple-scancodes.patch
+++ b/packages/sysutils/v4l-utils/patches/v4l-utils-02-irctl-fix-multiple-scancodes.patch
@@ -1,0 +1,176 @@
+From c3d7ae58a87018b39f0cca9a49c4a7b553135b22 Mon Sep 17 00:00:00 2001
+From: Sean Young <sean@mess.org>
+Date: Wed, 29 Nov 2017 17:08:04 +0000
+Subject: [PATCH 1/2] ir-ctl: fix multiple scancodes in one file
+
+A file with contents:
+
+scancode sony12:0x100015
+space 25000
+scancode sony12:0x100015
+
+Will produce bogus results.
+
+Reported-by: Matthias Reichl <hias@horus.com>
+Tested-by: Matthias Reichl <hias@horus.com>
+Signed-off-by: Sean Young <sean@mess.org>
+---
+ utils/ir-ctl/ir-ctl.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/utils/ir-ctl/ir-ctl.c b/utils/ir-ctl/ir-ctl.c
+index 544ad3415..8538ec5db 100644
+--- a/utils/ir-ctl/ir-ctl.c
++++ b/utils/ir-ctl/ir-ctl.c
+@@ -230,8 +230,8 @@ static struct file *read_file(const char *fname)
+ 			char *scancodestr;
+ 
+ 			if (!expect_pulse) {
+-				fprintf(stderr, _("error: %s:%d: space must precede scancode\n"), fname, lineno);
+-				return NULL;
++				f->buf[len++] = IR_DEFAULT_TIMEOUT;
++				expect_pulse = true;
+ 			}
+ 
+ 			scancodestr = strchr(p, ':');
+@@ -268,7 +268,8 @@ static struct file *read_file(const char *fname)
+ 			else
+ 				f->carrier = carrier;
+ 
+-			len += protocol_encode(proto, scancode, f->buf);
++			len += protocol_encode(proto, scancode, f->buf + len);
++			expect_pulse = false;
+ 			continue;
+ 		}
+ 
+-- 
+2.11.0
+
+
+From 26eca33b62f988ecbc4df8134ebdef20f9f75c97 Mon Sep 17 00:00:00 2001
+From: Sean Young <sean@mess.org>
+Date: Wed, 29 Nov 2017 17:54:32 +0000
+Subject: [PATCH 2/2] ir-ctl: set the gap between scancodes or files
+
+Between sending multiple scancodes or pulse space files, there is
+a gap of 125 milliseconds. Allow this to be set.
+
+Tested-by: Matthias Reichl <hias@horus.com>
+Signed-off-by: Sean Young <sean@mess.org>
+---
+ utils/ir-ctl/ir-ctl.1.in |  6 +++++-
+ utils/ir-ctl/ir-ctl.c    | 18 +++++++++++++-----
+ 2 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/utils/ir-ctl/ir-ctl.1.in b/utils/ir-ctl/ir-ctl.1.in
+index 05550fb12..641b11152 100644
+--- a/utils/ir-ctl/ir-ctl.1.in
++++ b/utils/ir-ctl/ir-ctl.1.in
+@@ -93,6 +93,10 @@ Comma separated list of emitters to use for sending. The first emitter is
+ number 1. Some devices only support enabling one emitter (the winbond-cir
+ driver).
+ .TP
++\fB\-g\fR, \fB\-\-gap\fR=\fIGAP\fR
++Set the gap between scancodes or the gap between files when multiple files
++are specified on the command line. The default is 125000 microseconds.
++.TP
+ \fB\-?\fR, \fB\-\-help\fR
+ Prints the help message
+ .TP
+@@ -220,7 +224,7 @@ To send the pulse and space file \fBplay\fR on emitter 3:
+ .br
+ 	\fBir\-ctl \-e 3 \-\-send=play\fR
+ .PP
+-To send the rc-5 hauppuage '1' scancode:
++To send the rc-5 hauppauge '1' scancode:
+ .br
+ 	\fBir\-ctl \-S rc5:0x1e01
+ .PP
+diff --git a/utils/ir-ctl/ir-ctl.c b/utils/ir-ctl/ir-ctl.c
+index 8538ec5db..6fb05b1aa 100644
+--- a/utils/ir-ctl/ir-ctl.c
++++ b/utils/ir-ctl/ir-ctl.c
+@@ -82,6 +82,7 @@ struct arguments {
+ 	int wideband;
+ 	unsigned carrier_low, carrier_high;
+ 	unsigned timeout;
++	unsigned gap;
+ 	int carrier_reports;
+ 	int timeout_reports;
+ 	unsigned carrier;
+@@ -111,6 +112,7 @@ static const struct argp_option options[] = {
+ 	{ "carrier",	'c',	N_("CARRIER"),	0,	N_("set send carrier") },
+ 	{ "duty-cycle",	'D',	N_("DUTY"),	0,	N_("set duty cycle") },
+ 	{ "emitters",	'e',	N_("EMITTERS"),	0,	N_("set send emitters") },
++	{ "gap",	'g',	N_("GAP"),	0,	N_("set gap between files or scancodes") },
+ 	{ }
+ };
+ 
+@@ -130,6 +132,7 @@ static const char doc[] = N_(
+ 	"  CARRIER  - the carrier frequency to use for sending\n"
+ 	"  DUTY     - the duty cycle to use for sending\n"
+ 	"  EMITTERS - comma separated list of emitters to use for sending, e.g. 1,2\n"
++	"  GAP      - gap between pulse and files or scancodes in microseconds\n"
+ 	"  RANGE    - set range of accepted carrier frequencies, e.g. 20000-40000\n"
+ 	"  TIMEOUT  - set length of space before recording stops in microseconds\n"
+ 	"  SCANCODE - protocol:scancode, e.g. nec:0xa814\n\n"
+@@ -185,7 +188,7 @@ static unsigned parse_emitters(char *p)
+ 	return emit;
+ }
+ 
+-static struct file *read_file(const char *fname)
++static struct file *read_file(struct arguments *args, const char *fname)
+ {
+ 	bool expect_pulse = true;
+ 	int lineno = 0, lastspace = 0;
+@@ -230,7 +233,7 @@ static struct file *read_file(const char *fname)
+ 			char *scancodestr;
+ 
+ 			if (!expect_pulse) {
+-				f->buf[len++] = IR_DEFAULT_TIMEOUT;
++				f->buf[len++] = args->gap;
+ 				expect_pulse = true;
+ 			}
+ 
+@@ -486,6 +489,11 @@ static error_t parse_opt(int k, char *arg, struct argp_state *state)
+ 		if (arguments->emitters == 0)
+ 			argp_error(state, _("cannot parse emitters `%s'"), arg);
+ 		break;
++	case 'g':
++		arguments->gap = strtoint(arg, "");
++		if (arguments->gap == 0)
++			argp_error(state, _("cannot parse gap `%s'"), arg);
++		break;
+ 	case 'D':
+ 		arguments->duty = strtoint(arg, "%");
+ 		if (arguments->duty == 0 || arguments->duty >= 100)
+@@ -494,7 +502,7 @@ static error_t parse_opt(int k, char *arg, struct argp_state *state)
+ 	case 's':
+ 		if (arguments->record || arguments->features)
+ 			argp_error(state, _("send can not be combined with record or features option"));
+-		s = read_file(arg);
++		s = read_file(arguments, arg);
+ 		if (s == NULL)
+ 			exit(EX_DATAERR);
+ 
+@@ -884,7 +892,7 @@ err:
+ 
+ int main(int argc, char *argv[])
+ {
+-	struct arguments args = {};
++	struct arguments args = { .gap = IR_DEFAULT_TIMEOUT };
+ 
+ #ifdef ENABLE_NLS
+         setlocale (LC_ALL, "");
+@@ -912,7 +920,7 @@ int main(int argc, char *argv[])
+ 	while (s) {
+ 		struct file *next = s->next;
+ 		if (s != args.send)
+-			usleep(IR_DEFAULT_TIMEOUT);
++			usleep(args.gap);
+ 
+ 		rc = lirc_send(&args, fd, features, s);
+ 		if (rc) {
+-- 
+2.11.0
+

--- a/packages/sysutils/v4l-utils/patches/v4l-utils-03-irctl-fix-rc6-on-32bit.patch
+++ b/packages/sysutils/v4l-utils/patches/v4l-utils-03-irctl-fix-rc6-on-32bit.patch
@@ -1,0 +1,29 @@
+From 9a20a75e132e26f6c49971f9818c6fad053875f2 Mon Sep 17 00:00:00 2001
+From: Sean Young <sean@mess.org>
+Date: Wed, 2 Aug 2017 11:47:23 -0400
+Subject: [PATCH] ir-ctl: "ir-ctl -S rc6_mce:0x800f0410" does not work on
+ 32-bit
+
+0x800f0410 does not fit in 32-bit signed long.
+
+Signed-off-by: Sean Young <sean@mess.org>
+---
+ utils/ir-ctl/ir-ctl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utils/ir-ctl/ir-ctl.c b/utils/ir-ctl/ir-ctl.c
+index 3d66063af..562a05da3 100644
+--- a/utils/ir-ctl/ir-ctl.c
++++ b/utils/ir-ctl/ir-ctl.c
+@@ -152,7 +152,7 @@ static int strtoint(const char *p, const char *unit)
+ static bool strtoscancode(const char *p, unsigned *ret)
+ {
+ 	char *end;
+-	long arg = strtol(p, &end, 0);
++	long long arg = strtoll(p, &end, 0);
+ 	if (end == NULL || end[0] != 0)
+ 		return false;
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
- fix sending multiple scancodes with configurable gap
- fix sending rc6 scancodes on 32bit platforms

Patches are backported from v4l-utils master branch

Signed-off-by: Matthias Reichl <hias@horus.com>