### PR TITLE
Add a possibility to create multi-image device tree blobs for Amlogic

### DIFF
--- a/packages/tools/aml-dtbtools/package.mk
+++ b/packages/tools/aml-dtbtools/package.mk
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="aml-dtbtools"
+PKG_VERSION="cce100f"
+PKG_SHA256="8bcaa83fcc9e85c9c04930e7411447d96a97da0809c5ecd9af91c8b554133c41"
+PKG_ARCH="any"
+PKG_LICENSE="free"
+PKG_SITE="https://github.com/Wilhansen/aml-dtbtools"
+PKG_URL="https://github.com/Wilhansen/aml-dtbtools/archive/${PKG_VERSION}.tar.gz"
+PKG_SECTION="tools"
+PKG_SHORTDESC="AML DTB Tools"
+PKG_LONGDESC="AML DTB Tools"
+
+PKG_MAKE_OPTS_HOST="dtbTool"
+
+makeinstall_host() {
+  mkdir -p $TOOLCHAIN/bin
+    cp dtbTool $TOOLCHAIN/bin
+}

--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -57,9 +57,6 @@
   # Build Android kernel image using mkbootimg
     BUILD_ANDROID_BOOTIMG="yes"
 
-  # Additional options to be passed to Android mkbootimg
-    ANDROID_BOOTIMG_OPTIONS="--second arch/arm/boot/dts/amlogic/meson8m2_wetek_core.dtb"
-
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)
     KERNEL_MAKE_EXTRACMD=""
 

--- a/projects/WeTek_Hub/options
+++ b/projects/WeTek_Hub/options
@@ -55,7 +55,7 @@
     BUILD_ANDROID_BOOTIMG="yes"
 
   # Additional options to be passed to Android mkbootimg
-    ANDROID_BOOTIMG_OPTIONS="--second arch/arm64/boot/dts/amlogic/gxbb_p200_1G_wetek_hub.dtb --base 0x0 --kernel_offset 0x1080000"
+    ANDROID_BOOTIMG_OPTIONS="--base 0x0 --kernel_offset 0x1080000"
 
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)
     KERNEL_MAKE_EXTRACMD=""

--- a/projects/WeTek_Play_2/options
+++ b/projects/WeTek_Play_2/options
@@ -55,7 +55,7 @@
     BUILD_ANDROID_BOOTIMG="yes"
 
   # Additional options to be passed to Android mkbootimg
-    ANDROID_BOOTIMG_OPTIONS="--second arch/arm64/boot/dts/amlogic/gxbb_p200_2G_wetek_play_2.dtb --base 0x0 --kernel_offset 0x1080000"
+    ANDROID_BOOTIMG_OPTIONS="--base 0x0 --kernel_offset 0x1080000"
 
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)
     KERNEL_MAKE_EXTRACMD=""


### PR DESCRIPTION
This is useful if a few devices need to be supported by one project. 

If there is only one device tree created from `KERNEL_UBOOT_EXTRA_TARGET` it is appended as-is, e.g. without multidtb tool header.