### PR TITLE
init: fix offset calculation after busybox fdisk change

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -876,7 +876,7 @@
       losetup $LOOP $IMG_FILE
 
       # check for MBR partititon
-      OFFSET=$(fdisk -u -l $LOOP 2>/dev/null | awk '/^[ ]*Device/{part=1; next}; part{if ($2 == "*") {print $3} else {print $2} ; exit}')
+      OFFSET=$(fdisk -u -l $LOOP 2>/dev/null | awk '/^[ ]*Device/{part=1; next}; part{if ($2 == "*") {print $5} else {print $4} ; exit}')
       if [ -z "$OFFSET" ]; then
         # check for GPT partititon
         OFFSET=$(fdisk -u -l $LOOP 2>/dev/null | awk '/^Number/{part=1; next}; part{print $2; exit}')


### PR DESCRIPTION
After https://github.com/mirror/busybox/commit/607f2b404e992174d7c5956d11e8f35f78d2701f in busybox 1.26.0 the output of `fdisk -u -l` for MBR-based partitions is changed with 2 extra columns causing the OFFSET calculation to be incorrect, resulting in partitions that fail to mount (`Invalid argument`, see https://github.com/Raybuntu/LibreELEC.tv/issues/39).

Before (MBR partitions):
```
Disk /dev/loop0: 575 MB, 575668224 bytes
4 heads, 32 sectors/track, 8784 cylinders, total 1124352 sectors
Units = sectors of 1 * 512 = 512 bytes

      Device Boot      Start         End      Blocks  Id System
/dev/loop0p1   *        8192     1056767      524288   c Win95 FAT32 (LBA)
/dev/loop0p2         1056768     1122303       32768  83 Linux
```
After: (MBR partitions)
```
Disk /dev/loop0: 549 MB, 575668224 bytes, 1124352 sectors
8784 cylinders, 4 heads, 32 sectors/track
Units: sectors of 1 * 512 = 512 bytes

Device     Boot StartCHS    EndCHS        StartLBA     EndLBA    Sectors  Size Id Type
/dev/loop0p1 *  64,0,1      1023,3,32         8192    1056767    1048576  512M  c Win95 FAT32 (LBA)
/dev/loop0p2    1023,3,32   1023,3,32      1056768    1122303      65536 32.0M 83 Linux
```

There is no need to change the GPT offset calculation.

Before (GPT partitions):
```
Found valid GPT with protective MBR; using GPT

Disk /dev/loop0: 1124352 sectors,  549M
Logical sector size: 512
Disk identifier (GUID): 2934c8e2-dfbc-49b8-93a6-ff769ab9c7c7
Partition table holds up to 128 entries
First usable sector is 34, last usable sector is 1124318

Number  Start (sector)    End (sector)  Size Name
     1            8192         1056767  512M system
     2         1056768         1122303 32.0M storage
```
After (GPT partitions):
```
Found valid GPT with protective MBR; using GPT

Disk /dev/loop0: 1124352 sectors,  549M
Logical sector size: 512
Disk identifier (GUID): 2934c8e2-dfbc-49b8-93a6-ff769ab9c7c7
Partition table holds up to 128 entries
First usable sector is 34, last usable sector is 1124318

Number  Start (sector)    End (sector)  Size       Code  Name
   1            8192         1056767        512M   0700  system
   2         1056768         1122303       32.0M   0700  storage
```