### PR TITLE
Alternative for TUF support

### DIFF
--- a/packages/lang/Python2/patches/Python-2.7.14-017-easy_install.patch
+++ b/packages/lang/Python2/patches/Python-2.7.14-017-easy_install.patch
@@ -1,0 +1,19 @@
+diff -Naur Python-2.7.14-orig/Lib/distutils/cmd.py Python-2.7.14/Lib/distutils/cmd.py
+--- Python-2.7.14-orig/Lib/distutils/cmd.py	2017-09-16 19:38:35.000000000 +0200
++++ Python-2.7.14/Lib/distutils/cmd.py	2017-12-15 13:18:26.271636584 +0100
+@@ -52,10 +52,11 @@
+         initializer and depends on the actual command being
+         instantiated.
+         """
+-        # late import because of mutual dependence between these classes
+-        from distutils.dist import Distribution
+-
+-        if not isinstance(dist, Distribution):
++        # From https://bugs.python.org/issue23102
++        # dist should quack like a Distribution (duck-typing avoids a
++        # circular dependency and hopefully ameliorates trouble due to
++        # setuptools having monkey patched distutils modules).
++        if not hasattr(dist, 'get_requires'):
+             raise TypeError, "dist must be a Distribution instance"
+         if self.__class__ is Command:
+             raise RuntimeError, "Command is an abstract class"

--- a/packages/python/devel/cffi/package.mk
+++ b/packages/python/devel/cffi/package.mk
@@ -1,0 +1,29 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="cffi"
+PKG_VERSION="1.11.2"
+PKG_SHA256="ab87dd91c0c4073758d07334c1e5f712ce8fe48f007b86f8238773963ee700a6"
+PKG_LICENSE="MIT"
+PKG_SITE="http://cffi.readthedocs.io/"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_HOST="libffi:host pycparser:host"
+PKG_DEPENDS_TARGET="cffi:host libffi"
+PKG_LONGDESC="Foreign Function Interface for Python calling C code"
+
+PKG_TOOLCHAIN="python"

--- a/packages/python/devel/pycparser/package.mk
+++ b/packages/python/devel/pycparser/package.mk
@@ -1,0 +1,27 @@
+################################################################################
+#      This file is part of LibreELEC - http://www.libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="pycparser"
+PKG_VERSION="2.18"
+PKG_SHA256="99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
+PKG_LICENSE="BSD"
+PKG_SITE="http://pypi.python.org/pypi/pycparser"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_LONGDESC="C parser in Python"
+
+PKG_TOOLCHAIN="python"

--- a/packages/python/security/asn1crypto/package.mk
+++ b/packages/python/security/asn1crypto/package.mk
@@ -1,0 +1,27 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="asn1crypto"
+PKG_VERSION="0.23.0"
+PKG_SHA256="884b5ba3d9b442c1729f67981d3ddeb85a1d7dbd35199000a0bc8d077548352d"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/wbond/asn1crypto"
+PKG_URL="https://github.com/wbond/$PKG_NAME/archive/$PKG_VERSION.tar.gz"
+PKG_LONGDESC="Python ASN.1 library with a focus on performance and a pythonic API"
+
+PKG_TOOLCHAIN="python"

--- a/packages/python/security/cryptography/package.mk
+++ b/packages/python/security/cryptography/package.mk
@@ -1,0 +1,32 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="cryptography"
+PKG_VERSION="2.1.4"
+PKG_SHA256="9b8c169526aaf45f851f9324b2786abd4bc875db72333981eb0d22b11cd49e65"
+PKG_LICENSE="ALv2"
+PKG_SITE="https://cryptography.io"
+PKG_URL="https://github.com/pyca/$PKG_NAME/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="asn1crypto cffi enum34 idna ipaddress six"
+PKG_LONGDESC="cryptography is a package designed to expose cryptographic primitives and recipes to Python developers"
+
+PKG_TOOLCHAIN="python"
+
+pre_make_target() {
+  export CC="$CC -pthread"
+}

--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -17,41 +17,17 @@
 ################################################################################
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.4.5"
-PKG_SHA256="be84544eadc2bb71d4ace39e4984ed2990111f053f24267a07afb4b4e1e5428f"
-PKG_ARCH="any"
+PKG_VERSION="3.4.7"
+PKG_SHA256="18d8dfe31bf0cb53d58694903e526be68f3cf48e6e3c6dfbbc1e7042b1693af7"
 PKG_LICENSE="BSD"
-PKG_SITE="https://pypi.python.org/pypi/pycryptodome"
+PKG_SITE="https://www.pycryptodome.org/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain Python2 distutilscross:host"
-PKG_SECTION="python/security"
-PKG_SHORTDESC="Cryptographic library for Python"
-PKG_LONGDESC="PyCryptodome is a self-contained Python package of low-level cryptographic primitives."
-PKG_TOOLCHAIN="manual"
+PKG_LONGDESC="PyCryptodome is a self-contained Python package of low-level cryptographic primitives"
 
-pre_configure_target() {
-  cd $PKG_BUILD
-  rm -rf .$TARGET_NAME
-
-  export PYTHONXCPREFIX="$SYSROOT_PREFIX/usr"
-  export LDSHARED="$CC -shared"
-}
-
-make_target() {
-  python setup.py build --cross-compile
-}
-
-makeinstall_target() {
-  python setup.py install --root=$INSTALL --prefix=/usr
-
-  # Remove SelfTest bloat
-  find $INSTALL -type d -name SelfTest -exec rm -fr "{}" \; 2>/dev/null || true
-  find $INSTALL -name SOURCES.txt -exec sed -i "/\/SelfTest\//d;" "{}" \;
-
-  # Create Cryptodome as an alternative namespace to Crypto (Kodi addons may use either)
-  ln -sf /usr/lib/$PKG_PYTHON_VERSION/site-packages/Crypto $INSTALL/usr/lib/$PKG_PYTHON_VERSION/site-packages/Cryptodome
-}
+PKG_TOOLCHAIN="python"
 
 post_makeinstall_target() {
-  find $INSTALL/usr/lib -name "*.py" -exec rm -rf "{}" ";"
+  rm -rf $_pythonpath/pycryptodome-*.egg/Crypto/SelfTest
+  ln -sfr $_pythonpath/pycryptodome-*.egg/Crypto \
+          $_pythonpath/Cryptodome
 }

--- a/packages/python/security/pynacl/package.mk
+++ b/packages/python/security/pynacl/package.mk
@@ -1,0 +1,32 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="pynacl"
+PKG_VERSION="1.2.1"
+PKG_SHA256="00ac0c2bfaa087de634a73a4e348f535f69c386fabf762adb4841728b5fe88b1"
+PKG_LICENSE="ALv2"
+PKG_SITE="https://pynacl.readthedocs.io/"
+PKG_URL="https://github.com/pyca/$PKG_NAME/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="cffi libsodium six"
+PKG_LONGDESC="Python binding to the Networking and Cryptography (NaCl) library"
+
+PKG_TOOLCHAIN="python"
+
+pre_make_target() {
+  export SODIUM_INSTALL="system"
+}

--- a/packages/python/security/securesystemslib/package.mk
+++ b/packages/python/security/securesystemslib/package.mk
@@ -1,0 +1,28 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="securesystemslib"
+PKG_VERSION="0.10.8"
+PKG_SHA256="9edaae8a33a5b00bde02473de320a77ca6a5982f37085b020c1dac96a9668674"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/secure-systems-lab/securesystemslib"
+PKG_URL="https://github.com/secure-systems-lab/$PKG_NAME/archive/v$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="cryptography pynacl pycryptodome six"
+PKG_LONGDESC="Cryptographic and general-purpose routines for Secure Systems Lab projects at NYU"
+
+PKG_TOOLCHAIN="python"

--- a/packages/python/security/tuf/package.mk
+++ b/packages/python/security/tuf/package.mk
@@ -1,0 +1,28 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="tuf"
+PKG_VERSION="0.10.1"
+PKG_SHA256="8f5f4a93e36ea1ddeb8c11cd31ecdf1324ac8e64261418468bfc9f1f970bf572"
+PKG_LICENSE="ALv2"
+PKG_SITE="https://www.updateframework.com"
+PKG_URL="https://github.com/theupdateframework/$PKG_NAME/archive/v$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="iso8601 securesystemslib six"
+PKG_LONGDESC="A framework for securing software update systems"
+
+PKG_TOOLCHAIN="python"

--- a/packages/python/system/enum34/package.mk
+++ b/packages/python/system/enum34/package.mk
@@ -19,18 +19,10 @@
 PKG_NAME="enum34"
 PKG_VERSION="1.1.6"
 PKG_SHA256="b09c7f7ee925e600bd4efaa5fef49919eacdbdfd5a52e0696c5d03010cffb9ec"
-PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="https://bitbucket.org/stoneleaf/enum34"
 PKG_URL="https://bitbucket.org/stoneleaf/$PKG_NAME/get/$PKG_VERSION.tar.bz2"
 PKG_SOURCE_DIR="stoneleaf-enum34-*"
-PKG_DEPENDS_TARGET="toolchain Python2 distutilscross:host"
-PKG_PRIORITY="optional"
-PKG_SECTION="python"
-PKG_SHORTDESC="Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
 PKG_LONGDESC="Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
-PKG_TOOLCHAIN="manual"
 
-make_target() {
-  python setup.py build
-}
+PKG_TOOLCHAIN="python"

--- a/packages/python/system/idna/package.mk
+++ b/packages/python/system/idna/package.mk
@@ -1,0 +1,27 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="idna"
+PKG_VERSION="2.6"
+PKG_SHA256="53c722c4b7908dfdf2e5db2b79982f1084494db7b34fd31ff6a296e9fddfceaa"
+PKG_LICENSE="BSD"
+PKG_SITE="https://github.com/kjd/idna"
+PKG_URL="https://github.com/kjd/$PKG_NAME/archive/v$PKG_VERSION.tar.gz"
+PKG_LONGDESC="Internationalized Domain Names for Python (IDNA 2008 and UTS #46)"
+
+PKG_TOOLCHAIN="python"

--- a/packages/python/system/ipaddress/package.mk
+++ b/packages/python/system/ipaddress/package.mk
@@ -1,0 +1,27 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="ipaddress"
+PKG_VERSION="1.0.18"
+PKG_SHA256="8ddc806938a3ee874ca0a738247c68ba255f734dd3d930e33264f3408952bcd5"
+PKG_LICENSE="PSF"
+PKG_SITE="https://github.com/phihag/ipaddress"
+PKG_URL="https://github.com/phihag/$PKG_NAME/archive/v$PKG_VERSION.tar.gz"
+PKG_LONGDESC="Python 3.3's ipaddress for older Python versions"
+
+PKG_TOOLCHAIN="python"

--- a/packages/python/system/iso8601/package.mk
+++ b/packages/python/system/iso8601/package.mk
@@ -1,0 +1,28 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="iso8601"
+PKG_VERSION="0.1.12"
+PKG_SHA256="75ae5e019abc14e52b4a57c1aab2a436f8ec6942c8be7a4934d2e4fcbfbf3bae"
+PKG_LICENSE="MIT"
+PKG_SITE="https://bitbucket.org/micktwomey/pyiso8601"
+PKG_URL="https://bitbucket.org/micktwomey/pyiso8601/get/$PKG_VERSION.tar.bz2"
+PKG_SOURCE_DIR="micktwomey-pyiso8601-*"
+PKG_LONGDESC="Simple module to parse ISO 8601 dates"
+
+PKG_TOOLCHAIN="python"

--- a/packages/python/system/six/package.mk
+++ b/packages/python/system/six/package.mk
@@ -1,0 +1,27 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="six"
+PKG_VERSION="1.11.0"
+PKG_SHA256="927dc6fcfccd4e32e1ce161a20bf8cda39d8c9d5f7a845774486907178f69bd4"
+PKG_LICENSE="MIT"
+PKG_SITE="http://pypi.python.org/pypi/six"
+PKG_URL="https://github.com/benjaminp/$PKG_NAME/archive/$PKG_VERSION.tar.gz"
+PKG_LONGDESC="Python 2 and 3 compatibility utilities"
+
+PKG_TOOLCHAIN="python"

--- a/packages/security/libsodium/package.mk
+++ b/packages/security/libsodium/package.mk
@@ -1,0 +1,30 @@
+###############################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libsodium"
+PKG_VERSION="1.0.16"
+PKG_SHA256="0c14604bbeab2e82a803215d65c3b6e74bb28291aaee6236d65c699ccfe1a98c"
+PKG_LICENSE="ISC"
+PKG_SITE="https://libsodium.org/"
+PKG_URL="https://github.com/jedisct1/libsodium/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Sodium is a modern, easy-to-use software library for encryption, decryption, signatures, password hashing and more."
+
+PKG_TOOLCHAIN="autotools"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"

--- a/packages/virtual/mediacenter/package.mk
+++ b/packages/virtual/mediacenter/package.mk
@@ -37,7 +37,7 @@ if [ "$MEDIACENTER" = "kodi" ]; then
 # some python stuff needed for various addons
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET Pillow \
                                           simplejson \
-                                          pycryptodome"
+                                          tuf"
 # other packages
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET LibreELEC-settings \
                                           xmlstarlet"

--- a/scripts/build
+++ b/scripts/build
@@ -213,6 +213,13 @@ if [ "$PKG_IS_KERNEL_PKG" = "yes" ]; then
   fi
 fi
 
+if [ "$PKG_TOOLCHAIN" = "python" ]; then
+  [ -z "$PKG_PYTHON" ] && PKG_PYTHON="2"
+  _python="$TOOLCHAIN/bin/python$PKG_PYTHON"
+  PKG_DEPENDS_HOST="toolchain distutilscross:host $PKG_DEPENDS_HOST"
+  PKG_DEPENDS_TARGET="toolchain distutilscross:host Python$PKG_PYTHON $PKG_DEPENDS_TARGET"
+fi
+
 # build dependencies, only when PKG_DEPENDS_? is filled
 unset _pkg_depends
 case "$TARGET" in
@@ -284,7 +291,7 @@ if [ -z "$PKG_TOOLCHAIN" -o "$PKG_TOOLCHAIN" = "auto" ]; then
   fi
   _auto_toolchain=" (auto-detect)"
 fi
-if ! listcontains "meson cmake cmake-make configure ninja make autotools manual" "$PKG_TOOLCHAIN"; then
+if ! listcontains "meson cmake cmake-make configure ninja make autotools manual python" "$PKG_TOOLCHAIN"; then
   printf "$(print_color bold-red "ERROR:") unknown toolchain $PKG_TOOLCHAIN"
   exit 1
 fi
@@ -456,6 +463,26 @@ else
       echo "Executing (bootstrap): make $PKG_MAKE_OPTS_BOOTSTRAP" | tr -s " "
       make $PKG_MAKE_OPTS_BOOTSTRAP
       ;;
+
+    # python based build
+    "python:host")
+      echo "Executing (host): $_python setup.py build --build-base .$HOST_NAME" | tr -s " "
+      export LDSHARED="$CC -shared $LDSHARED"
+      $_python setup.py build --build-base .$HOST_NAME
+      ;;
+    "python:target")
+      echo "Executing (target): $_python setup.py easy_install --build-directory=$PKG_BUILD/.$TARGET_NAME $_python_deps --prefix=$INSTALL/usr ." | tr -s " "
+      export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include -L$SYSROOT_PREFIX/usr/lib"
+      export LDSHARED="$CC -shared $LDSHARED"
+      export PYTHONXCPREFIX="$SYSROOT_PREFIX/usr"
+      _pythonpath="$INSTALL/usr/lib/$(readlink $_python)/site-packages"
+      mkdir -p $_pythonpath
+      [ "$PKG_PYTHON_DEPS" != "yes" ] && _python_deps="--no-deps"
+      PYTHONPATH="$PYTHONPATH:$_pythonpath" $_python setup.py easy_install --build-directory=$PKG_BUILD/.$TARGET_NAME $_python_deps --prefix=$INSTALL/usr .
+      find "$INSTALL/usr" -name "*.py" -exec rm -rf "{}" ";"
+      find "$INSTALL/usr" -name "*.egg" -type f -exec zip -dq {} "*.exe" "*.py" ";"
+      mv $_pythonpath/easy-install.pth $_pythonpath/$PKG_NAME-$PKG_VERSION.pth
+      ;;
   esac
 fi
 if [ "$(type -t post_make_$TARGET)" = "function" ]; then
@@ -498,6 +525,12 @@ else
       ;;
     "configure:bootstrap"|"cmake-make:bootstrap"|"autotools:bootstrap"|"make:bootstrap")
       make install $PKG_MAKEINSTALL_OPTS_BOOTSTRAP
+      ;;
+
+    # python based build
+    "python:host")
+      echo "Executing (host): $_python setup.py build --build-base .$HOST_NAME install --root=/ --prefix=$TOOLCHAIN" | tr -s " "
+      $_python setup.py build --build-base .$HOST_NAME install --root=/ --prefix=$TOOLCHAIN
       ;;
   esac
 fi


### PR DESCRIPTION
This is an alternative to #2132 which depends on #2277.

This builds all the Python packages required for TUF, including pycryptodome.

Build will systematically produce the same Python packages, unless package versions are updated.
Build will break if an inconsistent set of package versions is specified.
If a package is updated to a version which adds new requirements which are not specified, the highest version of the new requirements will silently be built.