### PR TITLE
librespot: fix default.py, move fifo to /var/run/librespot

### DIFF
--- a/packages/addons/service/librespot/changelog.txt
+++ b/packages/addons/service/librespot/changelog.txt
@@ -1,3 +1,7 @@
+108
+- Correct bug which prevented disabling the service from Kodi
+- Place named pipe in /var/run/librespot
+
 107
 - Update to ddfc28f
 

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -20,7 +20,7 @@
 PKG_NAME="librespot"
 PKG_VERSION="ddfc28f"
 PKG_SHA256="df22baaa609f4feb249b2144c710764f05f0b8be29a4ae6ca369a40970e56d4f"
-PKG_REV="107"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/plietar/$PKG_NAME/"

--- a/packages/addons/service/librespot/source/bin/librespot.start
+++ b/packages/addons/service/librespot/source/bin/librespot.start
@@ -119,6 +119,6 @@ if [ -z "$(pactl list short modules | grep source=$LS_SINK.monitor)" ]; then
     destination_ip=127.0.0.1 port="$LS_PORT" source_ip=127.0.0.1 > /dev/null
 fi
 
-export LS_FIFO="$ADDON_DIR/rc"
+export LS_FIFO="/var/run/librespot"
 
 eval $LIBRESPOT


### PR DESCRIPTION
This addresses issues reported by users in the forum:
- unable to disable addon from Kodi
- unable to complete backup