### PR TITLE
kernel-firmware: update to kernel-firmware-7f93c9d

### DIFF
--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="5d98692"
-PKG_SHA256="eb1635c6494507826d630ba94731e581cb0f63fbfe6af4d5de7dbf42d047a605"
+PKG_VERSION="7f93c9d"
+PKG_SHA256="917bb5a48294e83769f5ee17340eabc936e549ce1b0ae5df14cdd00d4c6940f2"
 PKG_ARCH="any"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"


### PR DESCRIPTION
It turns out the Intel Bluetooth 9260/9560/8260/8265 firmwares in the last bump [are corrupt](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=e4252cf670f33410a35d1bf604ac5f35dc211c4d) and missing the binary firmware files.

The original commits have been reverted and binary files re-applied.

This bump also adds support for the the CYW4373 SDIO and USB firmware files (brcmfmac4373-sdio.bin and brcmfmac4373.bin).