### PR TITLE
/etc/shadow: fix file permissions

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -369,15 +369,16 @@ add_user() {
     echo "$1:x:$3:$4:$5:$6:$7" >> ${INSTALL}/etc/passwd
   fi
 
-  touch ${INSTALL}/usr/config/shadow
-  ln -sf /storage/.config/shadow ${INSTALL}/etc/shadow
+  mkdir -p ${INSTALL}/usr/cache
+  touch ${INSTALL}/usr/cache/shadow
+  ln -sf /storage/.cache/shadow ${INSTALL}/etc/shadow
 
   PASSWORD="$2"
   if [ "$PASSWORD" = "x" ]; then
     PASSWORD="*"
   fi
-  if ! grep -q "^$1:" ${INSTALL}/usr/config/shadow; then
-    echo "$1:$PASSWORD:::::::" >> ${INSTALL}/usr/config/shadow
+  if ! grep -q "^$1:" ${INSTALL}/usr/cache/shadow; then
+    echo "$1:$PASSWORD:::::::" >> ${INSTALL}/usr/cache/shadow
   fi
 }
 

--- a/config/functions
+++ b/config/functions
@@ -365,7 +365,7 @@ add_user() {
   # Usage: add_user "username" "password" "userid" "groupid" "description" "home" "shell"
   mkdir -p ${INSTALL}/etc
   touch ${INSTALL}/etc/passwd
-  if [ -z "`grep "$1:" ${INSTALL}/etc/passwd`" ]; then
+  if ! grep -q "^$1:" ${INSTALL}/etc/passwd; then
     echo "$1:x:$3:$4:$5:$6:$7" >> ${INSTALL}/etc/passwd
   fi
 
@@ -376,7 +376,7 @@ add_user() {
   if [ "$PASSWORD" = "x" ]; then
     PASSWORD="*"
   fi
-  if [ -z "`grep "$1:" ${INSTALL}/usr/config/shadow`" ]; then
+  if ! grep -q "^$1:" ${INSTALL}/usr/config/shadow; then
     echo "$1:$PASSWORD:::::::" >> ${INSTALL}/usr/config/shadow
   fi
 }

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -196,7 +196,7 @@ post_install() {
   ROOT_PWD="`$TOOLCHAIN/bin/cryptpw -m sha512 $ROOT_PASSWORD`"
 
   echo "chmod 4755 $INSTALL/usr/bin/busybox" >> $FAKEROOT_SCRIPT
-  echo "chmod 000 $INSTALL/etc/shadow" >> $FAKEROOT_SCRIPT
+  echo "chmod 000 $INSTALL/usr/config/shadow" >> $FAKEROOT_SCRIPT
 
   add_user root "$ROOT_PWD" 0 0 "Root User" "/storage" "/bin/sh"
   add_group root 0

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -196,7 +196,7 @@ post_install() {
   ROOT_PWD="`$TOOLCHAIN/bin/cryptpw -m sha512 $ROOT_PASSWORD`"
 
   echo "chmod 4755 $INSTALL/usr/bin/busybox" >> $FAKEROOT_SCRIPT
-  echo "chmod 000 $INSTALL/usr/config/shadow" >> $FAKEROOT_SCRIPT
+  echo "chmod 000 $INSTALL/usr/cache/shadow" >> $FAKEROOT_SCRIPT
 
   add_user root "$ROOT_PWD" 0 0 "Root User" "/storage" "/bin/sh"
   add_group root 0

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -202,6 +202,7 @@ post_makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
   cp $PKG_DIR/scripts/systemd-machine-id-setup $INSTALL/usr/bin
   cp $PKG_DIR/scripts/userconfig-setup $INSTALL/usr/bin
+  cp $PKG_DIR/scripts/usercache-setup $INSTALL/usr/bin
 
   mkdir -p $INSTALL/usr/sbin
   cp $PKG_DIR/scripts/kernel-overlays-setup $INSTALL/usr/sbin
@@ -255,6 +256,7 @@ post_install() {
   enable_service machine-id.service
   enable_service debugconfig.service
   enable_service userconfig.service
+  enable_service usercache.service
   enable_service kernel-overlays.service
   enable_service hwdb.service
 }

--- a/packages/sysutils/systemd/scripts/usercache-setup
+++ b/packages/sysutils/systemd/scripts/usercache-setup
@@ -1,0 +1,33 @@
+#!/bin/sh
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+# Copy cache files, but don't overwrite
+false | cp -iRp /usr/cache/* /storage/.cache/ &>/dev/null
+
+# Merge default and custom shadow file details
+if [ -f /storage/.cache/shadow -a -f /usr/cache/shadow ]; then
+  # Get existing root details (possibly user defined)
+  userroot="$(grep "^root:" /storage/.cache/shadow)"
+
+  # Overwrite users shadow file with default details, but replacing root with any existing value
+  [ -n "${userroot}" ] && sed -e "s ^root:.* ${userroot} " /usr/cache/shadow >/storage/.cache/shadow
+
+  # Make sure we have the correct permission
+  chmod 000 /storage/.cache/shadow
+fi

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -24,3 +24,5 @@ done
 
 # Copy config files, but don't overwrite - this should replace our sample files
 false | cp -iRp /usr/config/* /storage/.config/ &>/dev/null
+
+[ -f /storage/.config/shadow ] && chmod 000 /storage/.config/shadow || true

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -1,7 +1,7 @@
 #!/bin/sh
 ################################################################################
-#      This file is part of LibreELEC - http://www.libreelec.tv
-#      Copyright (C) 2017 Team LibreELEC
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
 #
 #  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -24,5 +24,3 @@ done
 
 # Copy config files, but don't overwrite - this should replace our sample files
 false | cp -iRp /usr/config/* /storage/.config/ &>/dev/null
-
-[ -f /storage/.config/shadow ] && chmod 000 /storage/.config/shadow || true

--- a/packages/sysutils/systemd/system.d/usercache.service
+++ b/packages/sysutils/systemd/system.d/usercache.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Setup User cache dir
+DefaultDependencies=no
+After=systemd-tmpfiles-setup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/usercache-setup
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
1) Now that `/etc/shadow` is a symbolic link to `/storage/.config/shadow` the correct file to `chmod 000` in the image is `/usr/config/shadow`. This also avoids the following warning when running `fakeroot`:
```
chmod: cannot operate on dangling symlink '/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/image/system/etc/shadow'
```

2) Ensure that `/storage/.config/shadow` always has the correct `000` file permission.