### PR TITLE
busybox: prevent weak root passwords

### DIFF
--- a/packages/sysutils/busybox/patches/busybox-06-prevent-root-weak-passwd.patch
+++ b/packages/sysutils/busybox/patches/busybox-06-prevent-root-weak-passwd.patch
@@ -1,0 +1,10 @@
+--- a/loginutils/passwd.c
++++ b/loginutils/passwd.c
+@@ -72,7 +72,6 @@ static char* new_password(const struct p
+ 	newp = xstrdup(newp); /* we are going to bb_ask_stdin() again, so save it */
+ 	if (ENABLE_FEATURE_PASSWD_WEAK_CHECK
+ 	 && obscure(orig, newp, pw)
+-	 && myuid != 0
+ 	) {
+ 		goto err_ret; /* non-root is not allowed to have weak passwd */
+ 	}


### PR DESCRIPTION
Busybox allows root to have a null password but our default (and correct) ssh config does not allow null passwords. This means users can set a null password and lock themselves out of the console requiring /storage/.cache/shadow to be deleted (via Kodi file manager) and the box rebooted to regain access. In poking this we discovered busybox 'weak password' checking is not applied to the root user; a warning is shown but it can be ignored. This patch removes the exemption so root (our only user) is treated the same as a normal non-root user.

Original source: http://lists.infradead.org/pipermail/lede-dev/2017-February/006032.html