### PR TITLE
openssl/heimdal: Security fixes

### DIFF
--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="heimdal"
-PKG_VERSION="7.4.0"
-PKG_SHA256="b1d5c19989ad9f2cd8038c1d7c3e8f2bc227f79a1fa4eb0ade42cab4a40637ab"
+PKG_VERSION="7.5.0"
+PKG_SHA256="ad67fef994dc2268fb0b1a8164b39330d184f425057867485a178e9785a7f35a"
 PKG_ARCH="any"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="http://www.h5l.org/"

--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="openssl"
-PKG_VERSION="1.0.2l"
-PKG_SHA256="ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c"
+PKG_VERSION="1.0.2n"
+PKG_SHA256="370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.openssl.org"


### PR DESCRIPTION
openssl 1.0.2n: https://www.openssl.org/news/secadv/20171207.txt
heimdal 7.5.0: https://github.com/heimdal/heimdal/issues/353 ([CVE-2017-17439](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17439))