### PR TITLE
u-boot: added option to compile mkimage for host

### DIFF
--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -31,6 +31,12 @@ PKG_SHORTDESC="u-boot: Universal Bootloader project"
 PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems, used as the default boot loader by several board vendors. It is intended to be easy to port and to debug, and runs on many supported architectures, including PPC, ARM, MIPS, x86, m68k, NIOS, and Microblaze."
 PKG_IS_KERNEL_PKG="yes"
 
+make_host() {
+  make mrproper
+  make dummy_x86_config
+  make tools-only
+}
+
 make_target() {
   if [ -z "$UBOOT_SYSTEM" ]; then
     echo "UBOOT_SYSTEM must be set to build an image"
@@ -40,6 +46,11 @@ make_target() {
     CROSS_COMPILE="$TARGET_PREFIX" LDFLAGS="" ARCH=arm make $($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM config)
     CROSS_COMPILE="$TARGET_PREFIX" LDFLAGS="" ARCH=arm make HOSTCC="$HOST_CC" HOSTSTRIP="true"
   fi
+}
+
+makeinstall_host() {
+  mkdir -p $TOOLCHAIN/bin
+    cp tools/mkimage $TOOLCHAIN/bin
 }
 
 makeinstall_target() {

--- a/packages/tools/u-boot/sources/configs/dummy_x86_defconfig
+++ b/packages/tools/u-boot/sources/configs/dummy_x86_defconfig
@@ -1,0 +1,1 @@
+CONFIG_X86=y


### PR DESCRIPTION
This is for kszaq's PR #2261 as mkimage is missing from the toolchain directory

A suitable location for invoking the install of the package will need to be decided