### PR TITLE
systemd: fix systemd-tmpfiles-setup

### DIFF
--- a/packages/sysutils/busybox/tmpfiles.d/z_01_busybox.conf
+++ b/packages/sysutils/busybox/tmpfiles.d/z_01_busybox.conf
@@ -16,7 +16,6 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-d    /var/lock                 0755 root root - -
 d    /var/media                0755 root root - -
 
 f    /var/run/utmp             1777 root root - -

--- a/packages/sysutils/tz/system.d/tz-data.service
+++ b/packages/sysutils/tz/system.d/tz-data.service
@@ -2,13 +2,12 @@
 Description=Setup Timezone data
 DefaultDependencies=no
 Before=systemd-udevd.service
-After=var.mount
+After=var.mount systemd-tmpfiles-setup.service
 
 [Service]
 Type=oneshot
 Environment=TIMEZONE=UTC
 EnvironmentFile=-/storage/.cache/timezone
-ExecStartPre=/bin/mkdir -p /var/run
 ExecStart=/bin/ln -sf /usr/share/zoneinfo/${TIMEZONE} /var/run/localtime
 RemainAfterExit=yes
 StartLimitInterval=0


### PR DESCRIPTION
See #2303 for background.

`tz-data` is creating `/var/run` before `systemd-tmpfiles-setup` is executed, which prevents the symbolic link `/var/run` (to `../run`, in the file `var.conf` from `systemd`) from being created. Chaos ensues, breaking `avahi`/`nss-mdns` communication, and possibly others.

The `busybox` config creates `/var/lock` which is already created by `legacy.conf` (from the `systemd` package), and consequently a warning message is being logged. Drop the second `/var/lock`, lose the warning message.