### PR TITLE
tz-data: adjust dependency so that it doesn't create /var/run [backport]

### DIFF
--- a/packages/sysutils/tz/system.d/tz-data.service
+++ b/packages/sysutils/tz/system.d/tz-data.service
@@ -2,13 +2,12 @@
 Description=Setup Timezone data
 DefaultDependencies=no
 Before=systemd-udevd.service
-After=var.mount
+After=var.mount systemd-tmpfiles-setup.service
 
 [Service]
 Type=oneshot
 Environment=TIMEZONE=UTC
 EnvironmentFile=-/storage/.cache/timezone
-ExecStartPre=/bin/mkdir -p /var/run
 ExecStart=/bin/ln -sf /usr/share/zoneinfo/${TIMEZONE} /var/run/localtime
 RemainAfterExit=yes
 StartLimitInterval=0


### PR DESCRIPTION
Just in case, this is a partial backport of #2308: only the `/var/run` change is needed, as the `/var/lock` issue doesn't affect libreelec-8.2.