### PR TITLE
linux: rebuild when config or patches changes

### DIFF
--- a/config/options
+++ b/config/options
@@ -58,8 +58,9 @@ PROJECT_DIR="$ROOT/projects"
    . $PROJECT_DIR/$PROJECT/devices/$DEVICE/options
  fi
 
-LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf $ROOT/packages/linux/package.mk"
-[ "$TARGET_ARCH" = "x86_64" ] && LINUX_DEPENDS+=" $ROOT/packages/linux-firmware/intel-ucode/package.mk $ROOT/packages/linux-firmware/x86-firmware/package.mk"
+LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux $PROJECT_DIR/$PROJECT/patches/linux $ROOT/packages/linux"
+[ -n "$DEVICE" ] && LINUX_DEPENDS+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/linux"
+[ "$TARGET_ARCH" = "x86_64" ] && LINUX_DEPENDS+=" $ROOT/packages/linux-firmware/intel-ucode $ROOT/packages/linux-firmware/kernel-firmware"
 
 # Need to point to your actual cc
 # If you have ccache installed, take care that LOCAL_CC don't point to it


### PR DESCRIPTION
This PR changes `LINUX_DEPENDS` to include entire `$PROJECT/linux` and `$PROJECT/devices/$DEVICE/linux` path instead of just `linux/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf`, linux package supports lots of different config file paths, see https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/linux/package.mk#L75-L94

This is originating from `rockchip` branch where linux configs is located in a subfolder at `projects/Rockchip/linux/rockchip-4.4/linux.*.conf`

A small negative side effect of this change is that changing any file in the config file path will trigger linux and modules rebuild.