### PR TITLE
enable ccache with linaro aarch64 toolchain

### DIFF
--- a/packages/lang/gcc-linaro-aarch64-linux-gnu/package.mk
+++ b/packages/lang/gcc-linaro-aarch64-linux-gnu/package.mk
@@ -24,6 +24,7 @@ PKG_LICENSE="GPL"
 PKG_SITE=""
 PKG_URL="https://releases.linaro.org/components/toolchain/binaries/7.1-2017.08/aarch64-linux-gnu/gcc-linaro-${PKG_VERSION}-x86_64_aarch64-linux-gnu.tar.xz"
 PKG_SOURCE_DIR="gcc-linaro-${PKG_VERSION}-x86_64_aarch64-linux-gnu"
+PKG_DEPENDS_HOST="ccache:host"
 PKG_SECTION="lang"
 PKG_SHORTDESC="Linaro Aarch64 GNU Linux Binary Toolchain"
 PKG_TOOLCHAIN="manual"
@@ -31,4 +32,23 @@ PKG_TOOLCHAIN="manual"
 makeinstall_host() {
   mkdir -p $TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/
     cp -a * $TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu
+
+  # wrap gcc and g++ with ccache like in gcc package.mk
+  PKG_GCC_PREFIX="$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/aarch64-linux-gnu-"
+
+  cp "${PKG_GCC_PREFIX}gcc" "${PKG_GCC_PREFIX}gcc.real"
+cat > "${PKG_GCC_PREFIX}gcc" << EOF
+#!/bin/sh
+$TOOLCHAIN/bin/ccache ${PKG_GCC_PREFIX}gcc.real "\$@"
+EOF
+
+  chmod +x "${PKG_GCC_PREFIX}gcc"
+
+  cp "${PKG_GCC_PREFIX}g++" "${PKG_GCC_PREFIX}g++.real"
+cat > "${PKG_GCC_PREFIX}g++" << EOF
+#!/bin/sh
+$TOOLCHAIN/bin/ccache ${PKG_GCC_PREFIX}g++.real "\$@"
+EOF
+
+  chmod +x "${PKG_GCC_PREFIX}g++"
 }


### PR DESCRIPTION
Currently the linaro aarch64 toolchain, which is used to compile the 64bit kernel on split 64/32bit projects, is used without ccache. This leads to rather long build times when the kernel needs to be recompiled.

So wrap the linaro gcc and g++ compilers with ccache, like we do in our gcc cross compiler package.

So far I've only tested this with the ROCK64 build where kernel rebuilds, even with ccache, are still a lot slower than eg for RPi2 - probably because the rockchip kernel build forks python for every file to be compiled (scripts/gcc-wrapper.py in the rockchip 4.4 kernel tree).