### PR TITLE
shadow: detect corrupt content

### DIFF
--- a/packages/sysutils/systemd/scripts/usercache-setup
+++ b/packages/sysutils/systemd/scripts/usercache-setup
@@ -25,8 +25,13 @@ if [ -f /storage/.cache/shadow -a -f /usr/cache/shadow ]; then
   # Get existing root details (possibly user defined)
   userroot="$(grep "^root:" /storage/.cache/shadow)"
 
-  # Overwrite users shadow file with default details, but replacing root with any existing value
-  [ -n "${userroot}" ] && sed -e "s ^root:.* ${userroot} " /usr/cache/shadow >/storage/.cache/shadow
+  # Overwrite users shadow file with default details, replacing root with any existing value
+  # If current file is garbage (ie. missing root) then replace it
+  if [ -n "${userroot}" ]; then
+    sed -e "s ^root:.* ${userroot} " /usr/cache/shadow >/storage/.cache/shadow
+  else
+    cp -fp /usr/cache/shadow /storage/.cache/shadow
+  fi
 
   # Make sure we have the correct permission
   chmod 000 /storage/.cache/shadow


### PR DESCRIPTION
If the `/storage/.cache/shadow` file contains garbage (ie. is missing the entry for `root`), then it will not be overwritten with default details.

Now it will.