### PR TITLE
Libcec: Fix LG tv always changing input

### DIFF
--- a/packages/devel/libcec/patches/libcec-002-PR390.patch
+++ b/packages/devel/libcec/patches/libcec-002-PR390.patch
@@ -1,0 +1,24 @@
+From c1efce96275218f8b82bbb4ac9a467966a4f5530 Mon Sep 17 00:00:00 2001
+From: maart84 <1885039+maart84@users.noreply.github.com>
+Date: Wed, 13 Dec 2017 22:46:46 +0100
+Subject: [PATCH] Fix LG TV  always changing input when turned on
+
+This fixes the issue that LG TV's from 2012 always change input to libreelec.
+see https://github.com/Pulse-Eight/libcec/pull/390
+---
+ src/libcec/implementations/SLCommandHandler.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libcec/implementations/SLCommandHandler.cpp b/src/libcec/implementations/SLCommandHandler.cpp
+index dbdd01ce..83e78bd8 100644
+--- a/src/libcec/implementations/SLCommandHandler.cpp
++++ b/src/libcec/implementations/SLCommandHandler.cpp
+@@ -129,7 +129,7 @@ int CSLCommandHandler::HandleVendorCommand(const cec_command &command)
+   else if (command.parameters.size == 1 &&
+       command.parameters[0] == SL_COMMAND_REQUEST_RECONNECT)
+   {
+-    HandleVendorCommandPowerOn(command);
++    HandleVendorCommandPowerOnStatus(command);
+     return COMMAND_HANDLED;
+   }
+   else if (command.parameters.size == 1 &&


### PR DESCRIPTION
This patch fixes the 2012 (and apparently newer) LG tv's changing input to libreelec whenever the TV is switched on.
see https://github.com/Pulse-Eight/libcec/pull/390 for more info