### PR TITLE
distro-tool: add project package support

### DIFF
--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -726,7 +726,7 @@ get_libreelec_branch() {
 get_libreelec_option() {
   local variable="$1"
   cd $LIBREELEC_DIR
-  . config/options
+  source config/options ""
   echo "${!variable}"
 }
 
@@ -759,13 +759,18 @@ generate_work() {
   # Generate workload using multiple threads
   init_progress
 
-  tcount=0
-  while [ : ]; do
-    tcount=$((tcount + 1))
-    [ ${tcount} -gt ${WORKER_MAX} ] && break
-    generate_work_worker ${pcount} ${tcount} ${revision} &
-  done
-  wait
+  (
+    cd $LIBREELEC_DIR
+    source config/options ""
+
+    tcount=0
+    while [ : ]; do
+      tcount=$((tcount + 1))
+      [ ${tcount} -gt ${WORKER_MAX} ] && break
+      generate_work_worker ${pcount} ${tcount} ${revision} &
+    done
+    wait
+  )
 
   end_progress
 

--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -792,7 +792,7 @@ generate_work_worker() {
   local pcount=$1 worker="$2" revision="$3"
   local workfile_i="$(printf "%s.%02d" "${WORKFILES_I}" ${worker})"
   local workfile_o="$(printf "%s.%02d" "${WORKFILES_O}" ${worker})"
-  local wanted_vars="PKG_NAME PKG_VERSION PKG_URL PKG_SHA256 PKG_SECTION PKG_IS_ADDON PKG_SOURCE_NAME"
+  local wanted_vars="PKG_NAME PKG_VERSION PKG_URL PKG_SHA256 PKG_DIR PKG_SECTION PKG_IS_ADDON PKG_SOURCE_NAME"
   local package_name var comma PKG_URL PKG_SOURCE_NAME PKG_VERSION PKG_IS_ADDON
 
   [ -f "${workfile_i}" ] || return 0
@@ -809,6 +809,7 @@ generate_work_worker() {
       [ ${PROGRESS} == yes ] && progress ${pcount}
 
       source config/options ${package_name} &>/dev/null || true
+      [ -z "${PKG_DIR}" ] && continue
 
       if [ -n "${revision}" ]; then
         PKG_URL="${PKG_URL/${PKG_VERSION}/${revision}}"
@@ -859,9 +860,9 @@ get_packages() {
   cd $LIBREELEC_DIR
 
   if [ -n "${package_name}" ]; then
-    basename $(dirname $(find packages -path "*/${package_name}/*" -name package.mk) 2>/dev/null) 2>/dev/null
+    basename $(dirname $(find packages projects/${PROJECT} -path "*/${package_name}/*" -name package.mk) 2>/dev/null | head -1) 2>/dev/null
   else
-    find packages -name package.mk -exec bash -c get_package_path "{}" \; | sort -k1 | cut -d' ' -f1
+    find packages projects/${PROJECT} -name package.mk -exec bash -c get_package_path "{}" \; | cut -d' ' -f1 | sort -u
   fi
   return 0
 }


### PR DESCRIPTION
Just a small tweak that includes the `projects/$PROJECT` folder when generating the list of packages to process, otherwise packages that exist only in the project folder (and have no global equivalent) would never be processed. Example:
```
projects/Odroid_C2/gcc-linaro-arm-eabi
projects/Odroid_C2/packages/gcc-linaro-aarch64-elf`
```

----

We should probably cron a `distro-tool` run at least once a week. Running it against different branches (eg. `libreelec-8.2`) is also possible - just switch branch on the source LibreELEC.tv repository before running the script.

In order to process all project packages, and also any global packages with project-specific logic (ie. `PKG_URL`/`PKG_VERSION` selection, as in `packages/linux`), it will require running for all project/arch that we support.

`DEVICE` is in most cases irrelevant as we don't support device-specific packages, but is required by `config/options` and may be relevant if any packages (project or global) include device specific logic (ie. a `PKG_URL` or `PKG_VERSION` is determined based on `$DEVICE`).

Running the script for all `PROJECT`/`ARCH`/`DEVICE`/`etc.` should do no harm - it will just take longer.

Automated runs do not need to check for newer versions (which is time consuming).

For example:
```
PROJECT=Generic ARCH=x86_64 tools/distro-tool --notnewer --all
PROJECT=RPi ARCH=arm DEVICE=RPi tools/distro-tool --notnewer --all
PROJECT=Odroid_C2 ARCH=??? tools/distro-tool --notnewer --all
PROJECT=S905 ARCH=??? tools/distro-tool --notnewer --all
```
etc. (??? means I don't know what ARCH these projects use)