### PR TITLE
[RFC] iptables: Add default net filters

### DIFF
--- a/packages/network/iptables/config/README
+++ b/packages/network/iptables/config/README
@@ -1,0 +1,17 @@
+To create your own set of Netfilters you can save your rules in:
+
+/storage/.config/iptables/rules.v4 for ipv4
+/storage/.config/iptables/rules.v6 for ipv6
+
+To modify tables, edit with nano then save with:
+
+iptables-save /storage/.config/iptables/rules.v4
+ip6tables-save /storage/.config/iptables/rules.v6
+
+To disable iptables use the following command:
+
+systemctl mask iptables
+
+To enable iptables again:
+
+systemctl unmask iptables

--- a/packages/network/iptables/config/home.v4
+++ b/packages/network/iptables/config/home.v4
@@ -1,0 +1,44 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+:DOCKER-USER - [0:0]
+:private-subnets - [0:0]
+-A INPUT -i lo -j ACCEPT
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -i tether -p udp -m conntrack --ctstate NEW -j ACCEPT
+-A INPUT -j private-subnets
+-A FORWARD -i tether -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A FORWARD -o tether -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-USER -j private-subnets
+-A private-subnets -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A private-subnets -s 10.0.0.0/8 -i eth+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 172.16.0.0/12 -i eth+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 192.168.0.0/16 -i eth+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 10.0.0.0/8 -i en+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 172.16.0.0/12 -i en+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 192.168.0.0/16 -i en+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 10.0.0.0/8 -i wl+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 172.16.0.0/12 -i wl+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 192.168.0.0/16 -i wl+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 10.0.0.0/8 -i tether -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 172.16.0.0/12 -i tether -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 192.168.0.0/16 -i tether -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 10.0.0.0/8 -i docker+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 172.16.0.0/12 -i docker+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s 192.168.0.0/16 -i docker+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -j REJECT --reject-with icmp-port-unreachable
+COMMIT
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT

--- a/packages/network/iptables/config/home.v6
+++ b/packages/network/iptables/config/home.v6
@@ -1,0 +1,34 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+:DOCKER-USER - [0:0]
+:private-subnets - [0:0]
+-A INPUT -i lo -j ACCEPT
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -i tether -p udp -m conntrack --ctstate NEW -j ACCEPT
+-A INPUT -j private-subnets
+-A FORWARD -i tether -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A FORWARD -o tether -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-USER -j private-subnets
+-A private-subnets -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A private-subnets -s fc00::/7 -i eth+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s fc00::/7 -i en+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s fc00::/7 -i wl+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s fc00::/7 -i tether -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -s fc00::/7 -i docker+ -m conntrack --ctstate NEW -j ACCEPT
+-A private-subnets -j REJECT --reject-with icmp6-port-unreachable
+COMMIT
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT

--- a/packages/network/iptables/config/public.v4
+++ b/packages/network/iptables/config/public.v4
@@ -1,0 +1,31 @@
+# Netfilter rules for public "untrusted" networks
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+:DOCKER-USER - [0:0]
+-A INPUT -i lo -j ACCEPT
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+# Allow tethered Wifi AP
+-A INPUT -i tether -p udp -m conntrack --ctstate NEW -j ACCEPT
+-A INPUT -i tether -s 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 -m conntrack --ctstate NEW -j ACCEPT
+-A FORWARD -i tether -s 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 -m conntrack --ctstate NEW -j ACCEPT
+-A FORWARD -i tether -s 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+-A FORWARD -o tether -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+# Block DOCKER
+-A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
+-A DOCKER-USER -j REJECT --reject-with icmp-port-unreachable
+COMMIT

--- a/packages/network/iptables/config/public.v6
+++ b/packages/network/iptables/config/public.v6
@@ -1,0 +1,30 @@
+# Netfilter Rules for trusted home networks.
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+:DOCKER-USER - [0:0]
+-A INPUT -i lo -j ACCEPT
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+# Allow tethered Wifi AP
+-A INPUT -i tether -p udp -m conntrack --ctstate NEW -j ACCEPT
+-A INPUT -i tether -s fc00::/7 -m conntrack --ctstate NEW -j ACCEPT
+-A FORWARD -i tether -s fc00::/7 -m conntrack --ctstate NEW -j ACCEPT
+-A FORWARD -i tether -s fc00::/7 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+-A FORWARD -o tether -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+-A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-USER -j REJECT --reject-with icmp6-port-unreachable
+COMMIT

--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -30,3 +30,20 @@ PKG_LONGDESC="Iptables is used to set up, maintain, and inspect the tables of IP
 PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="--with-kernel=$(kernel_path)"
+
+
+post_makeinstall_target() {
+  mkdir -p $INSTALL/usr/config/iptables/
+    cp -PR $PKG_DIR/config/README $INSTALL/usr/config/iptables/
+
+  mkdir -p $INSTALL/etc/iptables/
+    cp -PR $PKG_DIR/config/* $INSTALL/etc/iptables/
+
+  mkdir -p $INSTALL/usr/lib/libreelec
+    cp $PKG_DIR/scripts/iptables_helper $INSTALL/usr/lib/libreelec
+}
+
+post_install() {
+  enable_service iptables.service
+}
+

--- a/packages/network/iptables/scripts/iptables_helper
+++ b/packages/network/iptables/scripts/iptables_helper
@@ -1,0 +1,105 @@
+#!/bin/sh -
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+IPTABLES4="/usr/sbin/iptables"
+IPTABLES6="/usr/sbin/ip6tables"
+IPTABLES_CMDS="$IPTABLES4 $IPTABLES6"
+PUBLIC_RULES="/etc/iptables/public.v"
+HOME_RULES="/etc/iptables/home.v"
+CUSTOM_RULES="/storage/.config/iptables/rules.v"
+
+check_docker() {
+    if [ "`/usr/bin/systemctl is-active docker.service`" == "active" ]; then
+	/usr/bin/systemctl restart docker
+    fi
+}
+
+check_tether() {
+    if [ -n "`/usr/bin/connmanctl technologies|grep 'Tethering = True'`" ]; then
+	/usr/bin/connmanctl tether wifi off
+	sleep 1
+	/usr/bin/connmanctl tether wifi on
+    fi
+}
+
+flush() {
+  for cmd in $IPTABLES_CMDS; do
+    $cmd -F
+    $cmd -X
+    $cmd -t nat -F
+    $cmd -t nat -X
+    $cmd -t mangle -F
+    $cmd -t mangle -X
+    $cmd -P INPUT ACCEPT
+    $cmd -P FORWARD ACCEPT
+    $cmd -P OUTPUT ACCEPT
+  done
+  check_docker
+  check_tether
+}
+
+enable() {
+  for cmd in $IPTABLES_CMDS; do
+    case "$cmd" in
+      *6*) 
+         rules="$RULES6"
+	 ipv="6"
+	 ;;
+        *) 
+         rules="$RULES4"
+	 ipv="4"
+	 ;;
+    esac
+    if [ -e "$rules" ]; then
+      "$cmd-restore" "$rules" 
+    fi
+  done
+  check_docker
+  check_tether
+}
+
+if [ "$1" = "enable" ]; then
+  case "${RULES}" in
+    "none") 
+       flush
+       ;;
+    "public") 
+       RULES4="${PUBLIC_RULES}4"
+       RULES6="${PUBLIC_RULES}6"
+       ;;
+    "home") 
+       RULES4="${HOME_RULES}4"
+       RULES6="${HOME_RULES}6"
+       ;;
+    "custom") 
+       RULES4="${CUSTOM_RULES}4"
+       RULES6="${CUSTOM_RULES}6"
+       ;;
+    *) 
+       exit 1
+       ;;
+  esac
+  enable
+elif [ "$1" = "disable" ]; then
+  flush
+else
+  exit 1
+fi
+
+exit 0

--- a/packages/network/iptables/system.d/iptables.service
+++ b/packages/network/iptables/system.d/iptables.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=IPTABLES Packet Filtering
+ConditionPathExists=/usr/lib/libreelec/iptables_helper
+ConditionPathExists=/storage/.cache/services/iptables.conf
+Before=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/storage/.cache/services/iptables.conf
+ExecStart=/usr/lib/libreelec/iptables_helper enable
+ExecReload=/usr/lib/libreelec/iptables_helper enable
+ExecStop=/usr/lib/libreelec/iptables_helper disable
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Default: Only allow private subnets
Don't overwrite rules from docker or connman wifi tether

An example how to turn on/off through LE Settings addon is available here: 
https://github.com/Raybuntu/service.libreelec.settings/commit/d3e19e7a902ecda4f6060a4abb3f016337461640
I can PR that too if we decide to this get's accepted. Filters are disabled by default and need to be enabled through LE settings addon.

Docker is restarted when the rules are reloaded or flushed otherwise it would break network connectivity in docker. Same for wifi tethering.

I have been using these rules in my community builds for a few months (enabled by default) without hearing any complaints about broken networks. I've just reworked the scripts a little bit the last few days so it will require some testing before it can be merged.