### PR TITLE
xf86-video-amdgpu: instruct xorg to load the amdgpu driver

### DIFF
--- a/packages/x11/driver/xf86-video-amdgpu/package.mk
+++ b/packages/x11/driver/xf86-video-amdgpu/package.mk
@@ -35,4 +35,6 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-udev \
 
 post_makeinstall_target() {
   rm -r $INSTALL/usr/share
+  mkdir -p $INSTALL/etc/X11
+    cp $PKG_BUILD/conf/10-amdgpu.conf $INSTALL/etc/X11/xorg-amdgpu.conf
 }


### PR DESCRIPTION
... for devices managed by the amdgpu kernel driver

Without the configuration the X radeon or modesettings driver may be loaded resulting in errors up to freezing system.