### PR TITLE
[LE 9.0] mkimage: Fix an issue when device tree image is not included into SD card images for WeTek devices

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -263,6 +263,11 @@ EOF
     mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
     mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
 
+    # copy Amlogic device tree image
+    if [ -f "$RELEASE_DIR/3rdparty/bootloader/dtb.img" ]; then
+      mcopy $RELEASE_DIR/3rdparty/bootloader/dtb.img ::
+    fi
+
 elif [ "$BOOTLOADER" = "u-boot" ]; then
   echo "to make an image using u-boot UBOOT_SYSTEM must be set"
   cleanup


### PR DESCRIPTION
Fix an issue when device tree image is not included into SD card images for WeTek devices.

The issue was introduced by 5da14cfce52adb1113977d8945b2923c91c8b8f1.