### PR TITLE
chromium: security fix to 63.0.3239.108

### DIFF
--- a/packages/addons/browser/chromium/changelog.txt
+++ b/packages/addons/browser/chromium/changelog.txt
@@ -1,20 +1,26 @@
-8.1.106
+108
+- Security Update to 63.0.3239.108
+
+107
+- Update to 63.0.3239.84
+
+106
 - Update to 55.0.2883.75
 
-8.1.105
+105
 - Update to 55.0.2883.44
 
-8.0.104
+104
 - Update to 53.0.2785.92
 
-8.0.103
+103
 - add xdotool
 
-8.0.102
+102
 - add unclutter
 
-7.0.101
+101
 - update to version 50.0.2661.75
 
-7.0.100
+100
 - initial LibreELEC release

--- a/packages/addons/browser/chromium/package.mk
+++ b/packages/addons/browser/chromium/package.mk
@@ -19,9 +19,9 @@
 ################################################################################
 
 PKG_NAME="chromium"
-PKG_VERSION="63.0.3239.84"
-PKG_SHA256="6de2754dfc333675ae6a67ae13c95666009b35c84f847b058edbf312e42fa3af"
-PKG_REV="107.009"
+PKG_VERSION="63.0.3239.108"
+PKG_SHA256="47d80798194da78bdd519b7ce012425b13cf89d6eb287e22a34342a245c31a2b"
+PKG_REV="108"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Mixed"
 PKG_SITE="http://www.chromium.org/Home"


### PR DESCRIPTION
CVE-2017-15429

builds fine,
no runtime tests, yet.