### PR TITLE
samba: fix link issues when rebuilding

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -83,6 +83,7 @@ PKG_CONFIGURE_OPTS="--prefix=/usr \
                     --without-gpgme \
                     --without-iconv \
                     --without-ldap \
+                    --without-libarchive \
                     --without-pam \
                     --without-pie \
                     --without-regedit \


### PR DESCRIPTION
Add `--without-libarchive` otherwise `samba` auto detects `archive.h` (added by `libarchive` when building `vfs.archive`) and, when rebuilding `samba`, it then builds `libarchive` support which pulls in `openssl` and `bzip2` dependencies, which fail during linking as the libraries are not found (missing `-lcrypto -lbz2`). 

A clean build of `samba` succeeds because `archive.h` doesn't exist at the time `samba` is first built, but a rebuild will fail after `libarchive` is built.

With this PR, `samba` will rebuild without failing.