### PR TITLE
Cleanup  path for SOURCES and allow SOURCES and TARGET to be defined …

### DIFF
--- a/config/path
+++ b/config/path
@@ -6,9 +6,9 @@ set -e
   CONFIG=config
   SCRIPTS=scripts
   PACKAGES=packages
-  SOURCES=sources
+  SOURCES=${SOURCES_DIR:-$ROOT/sources}
   BUILD_BASE=build
-  TARGET=target
+  TARGET_IMG=${TARGET_DIR:-$ROOT/target}
   ADDONS=addons
 
 # include ARCH specific options
@@ -28,7 +28,6 @@ if [ -n "$BUILD_SUFFIX" ]; then
   BUILD=$BUILD-$BUILD_SUFFIX
 fi
 
-TARGET_IMG=$ROOT/$TARGET
 TARGET_ADDONS="$TARGET_IMG/$ADDONS/$ADDON_PATH"
 ADDON_BUILD="$BUILD/$ADDONS/$1"
 STAMPS_NOARCH=.stamps

--- a/packages/addons/service/emby/package.mk
+++ b/packages/addons/service/emby/package.mk
@@ -41,7 +41,7 @@ unpack() {
 
 addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/Emby.Mono
-  unzip -q $ROOT/$SOURCES/$PKG_NAME/$PKG_SOURCE_NAME \
+  unzip -q $SOURCES/$PKG_NAME/$PKG_SOURCE_NAME \
         -d $ADDON_BUILD/$PKG_ADDON_ID/Emby.Mono
 
   sed -i 's/libMagickWand-6./libMagickWand-7./g' \

--- a/packages/linux-firmware/firmware-imx/package.mk
+++ b/packages/linux-firmware/firmware-imx/package.mk
@@ -32,7 +32,7 @@ PKG_TOOLCHAIN="manual"
 unpack() {
   mkdir -p $BUILD
     cd $BUILD
-    sh $ROOT/$SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.bin --auto-accept
+    sh $SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.bin --auto-accept
 }
 
 makeinstall_target() {

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -90,7 +90,7 @@ fi
 
 if [ "$KODI_DVDCSS_SUPPORT" = yes ]; then
   KODI_DVDCSS="-DENABLE_DVDCSS=ON \
-               -DLIBDVDCSS_URL=$ROOT/$SOURCES/libdvdcss/libdvdcss-$(get_pkg_version libdvdcss).tar.gz"
+               -DLIBDVDCSS_URL=$SOURCES/libdvdcss/libdvdcss-$(get_pkg_version libdvdcss).tar.gz"
 else
   KODI_DVDCSS="-DENABLE_DVDCSS=OFF"
 fi
@@ -202,8 +202,8 @@ if [ ! "$KODIPLAYER_DRIVER" = default ]; then
 fi
 
 KODI_LIBDVD="$KODI_DVDCSS \
-             -DLIBDVDNAV_URL=$ROOT/$SOURCES/libdvdnav/libdvdnav-$(get_pkg_version libdvdnav).tar.gz \
-             -DLIBDVDREAD_URL=$ROOT/$SOURCES/libdvdread/libdvdread-$(get_pkg_version libdvdread).tar.gz"
+             -DLIBDVDNAV_URL=$SOURCES/libdvdnav/libdvdnav-$(get_pkg_version libdvdnav).tar.gz \
+             -DLIBDVDREAD_URL=$SOURCES/libdvdread/libdvdread-$(get_pkg_version libdvdread).tar.gz"
 
 PKG_CMAKE_OPTS_TARGET="-DNATIVEPREFIX=$TOOLCHAIN \
                        -DWITH_TEXTUREPACKER=$TOOLCHAIN/bin/TexturePacker \

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -46,7 +46,7 @@ pack_addon() {
   scripts/install_addon $PKG_NAME $PKG_ADDON_ID || exit
 
   if [ "$2" != "-test" ] ; then
-    ADDON_INSTALL_DIR="$TARGET/$ADDONS/$ADDON_VERSION/${DEVICE:-$PROJECT}/$TARGET_ARCH/$PKG_ADDON_ID"
+    ADDON_INSTALL_DIR="$TARGET_IMG/$ADDONS/$ADDON_VERSION/${DEVICE:-$PROJECT}/$TARGET_ARCH/$PKG_ADDON_ID"
     ADDONVER="$(xmlstarlet sel -t -v "/addon/@version" $ADDON_BUILD/$PKG_ADDON_ID/addon.xml)"
 
     if [ -f $ADDON_INSTALL_DIR/$PKG_ADDON_ID-$ADDONVER.zip ] ; then
@@ -87,7 +87,7 @@ pack_addon() {
 }
 
 if [ "$PKG_IS_ADDON" = "yes" ] ; then
-  setup_toolchain $TARGET
+  setup_toolchain target 
 
   $SCRIPTS/build $@
 


### PR DESCRIPTION
Cleanup for SOURCES where directory was absolute in packages
Allow user to define SOURCES at CLI to specify their own directory for sources
Allow user to define TARGET at CLI to specify their own directory where images and add-ons will be saved to