### PR TITLE
bcm2835-driver : make versionned symlinks for EGL / GLES

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -54,7 +54,9 @@ makeinstall_target() {
   mkdir -p $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/*.so $INSTALL/usr/lib
     ln -sf /usr/lib/libbrcmEGL.so $INSTALL/usr/lib/libEGL.so
+    ln -sf /usr/lib/libbrcmEGL.so $INSTALL/usr/lib/libEGL.so.1
     ln -sf /usr/lib/libbrcmGLESv2.so $INSTALL/usr/lib/libGLESv2.so
+    ln -sf /usr/lib/libbrcmGLESv2.so $INSTALL/usr/lib/libGLESv2.so.2
 
 # some usefull debug tools
   mkdir -p $INSTALL/usr/bin


### PR DESCRIPTION
This adds the creation of the versioned links to the RPi Graphics driver similar to what mesa does.

Actually some Qt plugins seems to dynamically load some libraries and they refer to the versioned links which are also standard.
