### PR TITLE
Fix Cinergy S2 USB Rev.4

### DIFF
--- a/packages/linux-drivers/media_build/sources/backports/linux-265-fix-for-kernel-4.11-cinergy-s2-dual-support.patch
+++ b/packages/linux-drivers/media_build/sources/backports/linux-265-fix-for-kernel-4.11-cinergy-s2-dual-support.patch
@@ -11,12 +11,7 @@ diff --git a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw21
 index aee9182..e06f60e 100644
 --- a/drivers/media/usb/dvb-usb/dw2102.c
 +++ b/drivers/media/usb/dvb-usb/dw2102.c
-@@ -1761,13 +1761,14 @@ enum dw2102_table_entry {
- 	TEVII_S632,
- 	TERRATEC_CINERGY_S2_R2,
- 	TERRATEC_CINERGY_S2_R3,
--	TERRATEC_CINERGY_S2_R4,
- 	GOTVIEW_SAT_HD,
+@@ -1766,8 +1766,10 @@ enum dw2102_table_entry {
  	GENIATECH_T220,
  	GENIATECH_T220A,
  	TECHNOTREND_S2_4600,
@@ -27,15 +22,7 @@ index aee9182..e06f60e 100644
  	TEVII_S662
  };
  
-@@ -1791,7 +1792,6 @@ static struct usb_device_id dw2102_table[] = {
- 	[TEVII_S632] = {USB_DEVICE(0x9022, USB_PID_TEVII_S632)},
- 	[TERRATEC_CINERGY_S2_R2] = {USB_DEVICE(USB_VID_TERRATEC, USB_PID_TERRATEC_CINERGY_S2_R2)},
- 	[TERRATEC_CINERGY_S2_R3] = {USB_DEVICE(USB_VID_TERRATEC, USB_PID_TERRATEC_CINERGY_S2_R3)},
--	[TERRATEC_CINERGY_S2_R4] = {USB_DEVICE(USB_VID_TERRATEC, USB_PID_TERRATEC_CINERGY_S2_R4)},
- 	[GOTVIEW_SAT_HD] = {USB_DEVICE(0x1FE1, USB_PID_GOTVIEW_SAT_HD)},
- 	[GENIATECH_T220] = {USB_DEVICE(0x1f4d, 0xD220)},
- 	[GENIATECH_T220A] = {USB_DEVICE(0x0572, 0xC686)},
-@@ -1799,6 +1799,8 @@ static struct usb_device_id dw2102_table[] = {
+@@ -1799,6 +1800,8 @@ static struct usb_device_id dw2102_table[] = {
  		USB_PID_TECHNOTREND_CONNECT_S2_4600)},
  	[TEVII_S482_1] = {USB_DEVICE(0x9022, 0xd483)},
  	[TEVII_S482_2] = {USB_DEVICE(0x9022, 0xd484)},
@@ -44,27 +31,7 @@ index aee9182..e06f60e 100644
  	[TEVII_S662] = {USB_DEVICE(0x9022, USB_PID_TEVII_S662)},
  	{ }
  };
-@@ -2208,7 +2210,7 @@ static struct dvb_usb_device_properties su3000_properties = {
- 		}},
- 		}
- 	},
--	.num_device_descs = 7,
-+	.num_device_descs = 6,
- 	.devices = {
- 		{ "SU3000HD DVB-S USB2.0",
- 			{ &dw2102_table[GENIATECH_SU3000], NULL },
-@@ -2234,10 +2236,6 @@ static struct dvb_usb_device_properties su3000_properties = {
- 			{ &dw2102_table[TERRATEC_CINERGY_S2_R3], NULL },
- 			{ NULL },
- 		},
--		{ "Terratec Cinergy S2 USB HD Rev.4",
--			{ &dw2102_table[TERRATEC_CINERGY_S2_R4], NULL },
--			{ NULL },
--		},
- 	}
- };
- 
-@@ -2445,6 +2443,59 @@ static struct dvb_usb_device_properties tevii_properties = {
+@@ -2445,6 +2447,59 @@ static struct dvb_usb_device_properties tevii_properties = {
  	}
  };
  


### PR DESCRIPTION
This restores support for Cinergy S2 USB Rev.4 DVB-S2 tuner. Now Cinergy S2 USB Rev.4 is working, and the new tuners added by this patch should be working as well. The modification only reverts the removal of the lines needed to support my tuner.

This is the first time I submit a pull request, so maybe I made something wrong in the process. I hope it can be reviewed and merged, so I and anyone using this tuner can return to official builds again.