### PR TITLE
u-boot: add support for project specific version and more

### DIFF
--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -71,4 +71,15 @@ makeinstall_target() {
     elif [ -f $PROJECT_DIR/$PROJECT/bootloader/update.sh ]; then
       cp -av $PROJECT_DIR/$PROJECT/bootloader/update.sh $INSTALL/usr/share/bootloader
     fi
+
+    # Always install the canupdate script
+    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/canupdate.sh ]; then
+      cp -av $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/canupdate.sh $INSTALL/usr/share/bootloader
+    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/canupdate.sh ]; then
+      cp -av $PROJECT_DIR/$PROJECT/bootloader/canupdate.sh $INSTALL/usr/share/bootloader
+    fi
+    if [ -f $INSTALL/usr/share/bootloader/canupdate.sh ]; then
+      sed -e "s/@PROJECT@/${DEVICE:-$PROJECT}/g" \
+          -i $INSTALL/usr/share/bootloader/canupdate.sh
+    fi
 }

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -18,12 +18,9 @@
 ################################################################################
 
 PKG_NAME="u-boot"
-PKG_VERSION="2017.09"
-PKG_SHA256="b2d15f2cf5f72e706025cde73d67247c6da8cd35f7e10891eefe7d9095089744"
 PKG_ARCH="arm aarch64"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"
-PKG_URL="ftp://ftp.denx.de/pub/u-boot/u-boot-$PKG_VERSION.tar.bz2"
-PKG_SOURCE_DIR="u-boot-$PKG_VERSION"
+PKG_SOURCE_DIR="u-boot-$PKG_VERSION*"
 PKG_DEPENDS_TARGET="toolchain dtc:host"
 PKG_LICENSE="GPL"
 PKG_SECTION="tools"
@@ -33,6 +30,14 @@ PKG_IS_KERNEL_PKG="yes"
 
 PKG_NEED_UNPACK="$PROJECT_DIR/$PROJECT/bootloader"
 [ -n "$DEVICE" ] && PKG_NEED_UNPACK+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader"
+
+case "$PROJECT" in
+  *)
+    PKG_VERSION="2017.09"
+    PKG_SHA256="b2d15f2cf5f72e706025cde73d67247c6da8cd35f7e10891eefe7d9095089744"
+    PKG_URL="http://ftp.denx.de/pub/u-boot/u-boot-$PKG_VERSION.tar.bz2"
+    ;;
+esac
 
 make_host() {
   make mrproper

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -31,6 +31,9 @@ PKG_SHORTDESC="u-boot: Universal Bootloader project"
 PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems, used as the default boot loader by several board vendors. It is intended to be easy to port and to debug, and runs on many supported architectures, including PPC, ARM, MIPS, x86, m68k, NIOS, and Microblaze."
 PKG_IS_KERNEL_PKG="yes"
 
+PKG_NEED_UNPACK="$PROJECT_DIR/$PROJECT/bootloader"
+[ -n "$DEVICE" ] && PKG_NEED_UNPACK+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader"
+
 make_host() {
   make mrproper
   make dummy_x86_config


### PR DESCRIPTION
This PR adds support for installing a `canupdate.sh` script, rebuilds package if `bootloader` content changes and adds support for project specific u-boot version and depends.

See https://github.com/Kwiboo/LibreELEC.tv/commit/becdb06540774441d41c5a275e5869f27c8b9212 for an example of how project specific version can be used instead of the project specific u-boot package on Rockchip.
(Rockchip is still not fully ready to use mainline u-boot+spl on rk3328/rk3399 in u-boot 2018.01)

This should not change anything for current projects beside using `http` instead of `ftp` to get the default u-boot version.