### PR TITLE
pastebinit: switch to ix.io

### DIFF
--- a/packages/sysutils/busybox/scripts/pastebinit
+++ b/packages/sysutils/busybox/scripts/pastebinit
@@ -1,26 +1,25 @@
 #!/bin/sh
 
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-#
-# wrapper for curl, posting to the sprunge.us pastebin
-# reads from stdin if called without an argument
-#
-
-cat "$@" | curl -F 'sprunge=<-' http://sprunge.us
+if [ -n "${PASTEUSR}" -a "${PASTEPWD}" ]; then
+  cat "$@" | curl -F 'f:1=<-' ${PASTEUSR}:${PASTEPWD}@ix.io
+else
+  cat "$@" | curl -F 'f:1=<-' http://ix.io
+fi


### PR DESCRIPTION
The author of sprunge.us [recommends](https://github.com/rupa/sprunge/issues/35#issuecomment-169486002) moving to ix.io.

The sprunge.us developer appears to have no interest in resolving the ongoing availability issues, and is not showing any interest in addressing the bugs in the code which mean [only 50% of the id space](https://github.com/rupa/sprunge/issues/29) will ever be used, and sprunge.us will become slower as the [id space is filled](https://github.com/rupa/sprunge/issues/38) eventually spinning forever (note that due to the reduced id space it's actually 36^4 not 62^4).

Switching to ix.io may not be a long term solution, but using something other than sprunge.us is necessary at least in the short term until we decide on a more suitable long term replacement.

This may be too late for 8.2.2, but it would be safe to backport.