### PR TITLE
nss: fix build in docker container

### DIFF
--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -40,10 +40,11 @@ make_host() {
   make clean || true
   rm -rf $PKG_BUILD/dist
 
+  INCLUDES="-I$TOOLCHAIN/include" \
   make BUILD_OPT=1 USE_64=1 \
      PREFIX=$TOOLCHAIN \
      NSPR_INCLUDE_DIR=$TOOLCHAIN/include/nspr \
-     USE_SYSTEM_ZLIB=1 ZLIB_LIBS=-lz \
+     USE_SYSTEM_ZLIB=1 ZLIB_LIBS="-lz -L$TOOLCHAIN/lib" \
      SKIP_SHLIBSIGN=1 \
      NSS_TESTS="dummy" \
      CC=$CC LDFLAGS="$LDFLAGS -L$TOOLCHAIN/lib" \


### PR DESCRIPTION
This PR fixes building `nss:host` inside the xenial docker container, unsure if this is a proper fix.

Build stops with `ssl3con.c:38:18: fatal error: zlib.h: No such file or directory` in docker container since it does not have `zlib1g-dev` package installed.

@LongChair @InuSasha please test if this also work on your hosts.