### PR TITLE
systemd: enable hostnamed and add patch to fix systemd-analyze plot

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -69,7 +69,7 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dcoredump=false \
                        -Dresolve=false \
                        -Dlogind=true \
-                       -Dhostnamed=false \
+                       -Dhostnamed=true \
                        -Dlocaled=false \
                        -Dmachined=false \
                        -Dnetworkd=false \

--- a/packages/sysutils/systemd/patches/systemd-0100-backport-systemd-analyze-plot-fix.patch
+++ b/packages/sysutils/systemd/patches/systemd-0100-backport-systemd-analyze-plot-fix.patch
@@ -1,0 +1,43 @@
+From 1ddef8584afe34d0bb8f2629f360bcd02a7e0690 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Mon, 18 Dec 2017 10:12:59 +0100
+Subject: [PATCH] analyze: use normal bus connection for "plot" verb
+
+We need to connect to hostnamed, so a private bus connection is no good.
+It'd be simpler to use the normal bus connection unconditionally, but
+that'd mean that e.g. systemd-analyze set-log-level might not work in
+emergency mode. So let's keep trying to use the private connection except
+for "plot".
+
+Fixes #7667.
+---
+ src/analyze/analyze.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/analyze/analyze.c b/src/analyze/analyze.c
+index d45c1dc496..7f35b04c31 100644
+--- a/src/analyze/analyze.c
++++ b/src/analyze/analyze.c
+@@ -130,6 +130,13 @@ struct host_info {
+         char *architecture;
+ };
+ 
++static int acquire_bus(bool need_full_bus, sd_bus **bus) {
++        if (need_full_bus)
++                return bus_connect_transport(arg_transport, arg_host, arg_user, bus);
++        else
++                return bus_connect_transport_systemd(arg_transport, arg_host, arg_user, bus);
++}
++
+ static int bus_get_uint64_property(sd_bus *bus, const char *path, const char *interface, const char *property, uint64_t *val) {
+         _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
+         int r;
+@@ -1688,7 +1695,7 @@ int main(int argc, char *argv[]) {
+         else {
+                 _cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
+ 
+-                r = bus_connect_transport_systemd(arg_transport, arg_host, arg_user, &bus);
++                r = acquire_bus(streq_ptr(argv[optind], "plot"), &bus);
+                 if (r < 0) {
+                         log_error_errno(r, "Failed to create bus connection: %m");
+                         goto finish;


### PR DESCRIPTION
Since systemd 235 systemd-analyze plot stopped working, it needs systemd-hostnamed and an upstream patch (which can be dropped on 237 systemd bump).

Running systemd-analyze plot on systemd 235 and 236 gives the following error:
```
Failed to get host information from systemd: Unknown object '/org/freedesktop/hostname1'.
```
Enabling systemd-hostnamed is not enough, it still results in the same error - see https://github.com/systemd/systemd/issues/7667

With systemd-hostnamed enabled plus upstream commit https://github.com/systemd/systemd/commit/bf0e0a4df2d41a5631811f7db6b6c1c866c3ed80 systemd-analyze plot works fine.

Using the commit without enabling hostnamed doesn't work, then we get this error
```
Failed to get host information from systemd: The name org.freedesktop.hostname1 was not provided by any .service files
```

@lrusak does this look OK to you or do you have a better idea?