### PR TITLE
mpd: update to 0.20.13

### DIFF
--- a/packages/addons/addon-depends/libmpdclient/package.mk
+++ b/packages/addons/addon-depends/libmpdclient/package.mk
@@ -1,0 +1,29 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libmpdclient"
+PKG_VERSION="2.13"
+PKG_SHA256="e1583fbcae89ad543a6cc44caeaf16b31e709831f5b7eac4413f78c54a21db95"
+PKG_ARCH="any"
+PKG_LICENSE="BSD-3c"
+PKG_SITE="https://www.musicpd.org"
+PKG_URL="https://github.com/MusicPlayerDaemon/libmpdclient/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="service"
+PKG_SHORTDESC="is a C library which implements the Music Player Daemon protocol"
+PKG_LONGDESC="is a C library which implements the Music Player Daemon protocol"

--- a/packages/addons/service/mpd/changelog.txt
+++ b/packages/addons/service/mpd/changelog.txt
@@ -1,3 +1,7 @@
+104
+- update mpd to 0.20.13
+- build with more features
+
 103
 - update mpd to 0.20.9
 

--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -1,32 +1,32 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
 #
-#  This Program is free software; you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2, or (at your option)
-#  any later version.
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
 #
-#  This Program is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.tv; see the file COPYING.  If not, write to
-#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
-#  http://www.gnu.org/copyleft/gpl.html
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="mpd"
-PKG_VERSION="0.20.9"
-PKG_SHA256="cd77a2869e32354b004cc6b34fcb0bee56114caa2d9ed862aaa8071441e34eb7"
-PKG_REV="103"
+PKG_VERSION="0.20.13"
+PKG_SHA256="46c1c534d80a52de00263e8ef43a6011ff9d765232443749539ef26b1b48ff40"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"
 PKG_URL="http://www.musicpd.org/download/${PKG_NAME}/${PKG_VERSION%.*}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain boost glib ffmpeg libmad libogg flac faad2 curl alsa-lib yajl libid3tag lame"
+PKG_DEPENDS_TARGET="toolchain alsa-lib boost curl faad2 ffmpeg flac glib lame libcdio libiconv libid3tag \
+                    libmad libmpdclient libsamplerate libvorbis libnfs libogg opus pulseaudio samba yajl"
 PKG_SECTION="service.multimedia"
 PKG_SHORTDESC="Music Player Daemon (MPD): a free and open Music Player Server"
 PKG_LONGDESC="Music Player Daemon ($PKG_VERSION) is a flexible and powerful server-side application for playing music"
@@ -36,61 +36,84 @@ PKG_ADDON_NAME="Music Player Daemon (MPD)"
 PKG_ADDON_TYPE="xbmc.service"
 
 pre_configure_target() {
-  export LIBS="$LIBS -logg -lFLAC"
+  export LIBS="$LIBS -logg -lFLAC -ldl"
 }
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-alsa \
-             --disable-roar \
-             --disable-ao \
-             --disable-audiofile \
-             --disable-bzip2 \
-             --disable-cdio-paranoia \
-             --enable-curl \
-             --disable-smbclient \
-             --disable-soup \
-             --disable-debug \
-             --disable-documentation \
-             --disable-ffado \
-             --enable-ffmpeg \
-             --disable-fluidsynth \
-             --disable-gme \
-             --enable-httpd-output \
-             --enable-id3 \
-             --disable-jack \
-             --disable-lastfm \
-             --disable-despotify \
-             --disable-soundcloud \
-             --enable-lame-encoder \
-             --disable-libwrap \
-             --disable-lsr \
-             --enable-mad \
-             --disable-mikmod\
-             --disable-mms \
-             --disable-modplug \
-             --disable-mpg123 \
-             --disable-mvp \
-             --disable-openal \
-             --disable-oss \
-             --disable-pipe-output \
-             --disable-pulse \
-             --disable-recorder-output \
-             --disable-sidplay \
-             --disable-shout \
-             --disable-sndfile \
-             --disable-solaris-output \
-             --disable-sqlite \
-             --disable-systemd-daemon \
-             --disable-test \
-             --disable-twolame-encoder \
-             --disable-zzip \
-             --with-zeroconf=no \
-             --disable-icu"
+PKG_CONFIGURE_OPTS_TARGET=" \
+  --enable-aac \
+  --disable-adplug \
+  --enable-alsa \
+  --disable-ao \
+  --disable-audiofile \
+  --enable-bzip2 \
+  --disable-cdio-paranoia \
+  --enable-cue \
+  --enable-curl \
+  --enable-database \
+  --disable-debug \
+  --disable-documentation \
+  --enable-expat \
+  --enable-ffmpeg \
+  --enable-flac \
+  --disable-fluidsynth \
+  --disable-gme \
+  --disable-haiku \
+  --enable-httpd-output \
+  --enable-iconv \
+  --disable-icu \
+  --enable-id3 \
+  --enable-iso9660 \
+  --disable-jack \
+  --enable-lame-encoder \
+  --enable-libmpdclient \
+  --disable-libwrap \
+  --enable-lsr \
+  --enable-mad \
+  --disable-mikmod\
+  --disable-mms \
+  --disable-modplug \
+  --disable-mpc \
+  --disable-mpg123 \
+  --enable-nfs \
+  --disable-openal \
+  --enable-opus \
+  --disable-oss \
+  --enable-pipe-output \
+  --enable-pulse \
+  --disable-recorder-output \
+  --disable-roar \
+  --disable-shout \
+  --disable-shine-encoder \
+  --disable-sidplay \
+  --enable-smbclient \
+  --enable-sndfile \
+  --disable-sndio \
+  --disable-solaris-output \
+  --enable-soundcloud \
+  --enable-soxr \
+  --enable-sqlite \
+  --disable-syslog \
+  --disable-systemd-daemon \
+  --disable-test \
+  --disable-twolame-encoder \
+  --disable-upnp \
+  --enable-vorbis \
+  --enable-vorbis-encoder \
+  --disable-wavpack \
+  --enable-webdav \
+  --disable-wildmidi \
+  --enable-zlib \
+  --with-zeroconf=no"
 
 makeinstall_target() {
-  : # nop
+  :
 }
 
 addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin
   cp -P $PKG_BUILD/.$TARGET_NAME/src/mpd $ADDON_BUILD/$PKG_ADDON_ID/bin
+
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/lib
+  cp -p $(get_build_dir libmpdclient)/.install_pkg/usr/lib/libmpdclient.so $ADDON_BUILD/$PKG_ADDON_ID/lib
+  cp -p $(get_build_dir libmpdclient)/.install_pkg/usr/lib/libmpdclient.so.2 $ADDON_BUILD/$PKG_ADDON_ID/lib
 }


### PR DESCRIPTION
this reworks and updates mpd
- due the mpd build system a lot options are "auto" and the actually addon build was **heavily** differing between clean build and "normal" build -> changed to static values to allow reproduce able builds
- activated every feature we have already at the toolchain
- update to 0.20.13