### PR TITLE
Rockchip: u-boot and rkmpp update

### DIFF
--- a/packages/multimedia/rkmpp/package.mk
+++ b/packages/multimedia/rkmpp/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="rkmpp"
-PKG_VERSION="1d67fec"
-PKG_SHA256="d4e2224547792f548c845e3eb8e1252e7f16edf8f52807f29e60230023b27a88"
+PKG_VERSION="c6594ae"
+PKG_SHA256="981f7bc04677ff5135cea92e9926d5521ed38b359514d3405dd8f01c9295d147"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/rockchip-linux/mpp"

--- a/packages/multimedia/rkmpp/patches/rkmpp-0001-mpp-retrieve-available-input-packet-free-slots.patch
+++ b/packages/multimedia/rkmpp/patches/rkmpp-0001-mpp-retrieve-available-input-packet-free-slots.patch
@@ -1,4 +1,4 @@
-From ea45edab94c03bb48fe0cb9af971b9757de8dd3b Mon Sep 17 00:00:00 2001
+From 0d5fc7b20b6997418935b422b3704b1a90ad584b Mon Sep 17 00:00:00 2001
 From: LongChair <LongChair@hotmail.com>
 Date: Wed, 26 Apr 2017 11:45:37 +0200
 Subject: [PATCH 1/2] [mpp]: retrieve available input packet free slots
@@ -15,23 +15,23 @@ Reviewed-by: ayaka <ayaka@soulik.info>
 Signed-off-by: Randy Li <randy.li@rock-chips.com>
 ---
  inc/rk_mpi_cmd.h |  1 +
- mpp/mpp.cpp      | 11 ++++++++---
- 2 files changed, 9 insertions(+), 3 deletions(-)
+ mpp/mpp.cpp      | 13 +++++++++----
+ 2 files changed, 10 insertions(+), 4 deletions(-)
 
 diff --git a/inc/rk_mpi_cmd.h b/inc/rk_mpi_cmd.h
-index b67b65dd..0eaa328d 100644
+index 3f2c8d71..a9c58563 100644
 --- a/inc/rk_mpi_cmd.h
 +++ b/inc/rk_mpi_cmd.h
-@@ -96,6 +96,7 @@ typedef enum {
+@@ -97,6 +97,7 @@ typedef enum {
      MPP_DEC_SET_VC1_EXTRA_DATA,
      MPP_DEC_SET_OUTPUT_FORMAT,
-     MPP_DEC_CHANGE_HARD_MODE,
+     MPP_DEC_SET_DISABLE_ERROR,          /* When set it will disable sw/hw error (H.264 / H.265) */
 +    MPP_DEC_GET_FREE_PACKET_SLOT_COUNT,
      MPP_DEC_CMD_END,
  
      MPP_ENC_CMD_BASE                    = CMD_MODULE_CODEC | CMD_CTX_ID_ENC,
 diff --git a/mpp/mpp.cpp b/mpp/mpp.cpp
-index ffbd28a7..385f6183 100644
+index 164cd60d..1357d1a0 100644
 --- a/mpp/mpp.cpp
 +++ b/mpp/mpp.cpp
 @@ -33,6 +33,7 @@
@@ -62,10 +62,12 @@ index ffbd28a7..385f6183 100644
          MppPacket pkt;
          if (MPP_OK != mpp_packet_copy_init(&pkt, packet))
              return MPP_NOK;
-@@ -746,6 +747,10 @@ MPP_RET Mpp::control_dec(MpiCmd cmd, MppParam param)
-     case MPP_DEC_SET_OUTPUT_FORMAT: {
+@@ -742,7 +743,11 @@ MPP_RET Mpp::control_dec(MpiCmd cmd, MppParam param)
+     case MPP_DEC_SET_OUTPUT_FORMAT:
+     case MPP_DEC_SET_DISABLE_ERROR: {
          ret = mpp_dec_control(mDec, cmd, param);
-     } break;
+-    }
++    } break;
 +    case MPP_DEC_GET_FREE_PACKET_SLOT_COUNT: {
 +        *((RK_S32 *)param) = MPP_MAX_INPUT_PACKETS - mPackets->list_size();
 +         ret = MPP_OK;

--- a/packages/multimedia/rkmpp/patches/rkmpp-0002-fix-32-bit-mmap-issue-on-64-bit-kernels.patch
+++ b/packages/multimedia/rkmpp/patches/rkmpp-0002-fix-32-bit-mmap-issue-on-64-bit-kernels.patch
@@ -1,4 +1,4 @@
-From 263a0e974131ca0806dd93199f092e62fb9f5544 Mon Sep 17 00:00:00 2001
+From ccb2128ace5c069ec1b904cc621bacaf82498929 Mon Sep 17 00:00:00 2001
 From: Jakob Unterwurzacher <jakob.unterwurzacher@theobroma-systems.com>
 Date: Mon, 29 May 2017 14:08:43 +0200
 Subject: [PATCH 2/2] fix 32-bit mmap issue on 64-bit kernels

--- a/projects/Rockchip/README.md
+++ b/projects/Rockchip/README.md
@@ -9,6 +9,12 @@ This project is for Rockchip SoC devices
 * [mqmaker MiQi](devices/MiQi)
 * [Popcorn Hour RockBox](devices/RockBox)
 
+**My single-board computer is not listed, will it be added in the future?**<br />
+If your single-board computer uses a current generation SoC listed on http://opensource.rock-chips.com/wiki_Main_Page the odds are in your favor.
+
+**My Android device is not listed, will it be added in the future?**<br />
+You may have luck if your device vendor is open source friendly, otherwise keep using Android for best support.
+
 ## Links
 
 * https://github.com/rockchip-linux

--- a/projects/Rockchip/bootloader/install
+++ b/projects/Rockchip/bootloader/install
@@ -19,8 +19,8 @@
 PKG_RKBIN="$(get_build_dir rkbin)"
 
 case "$UBOOT_SYSTEM" in
-  rk3288)
-    PKG_DATAFILE="spl/u-boot-spl-dtb.bin"
+  rk3036)
+    PKG_DATAFILE="spl/u-boot-spl-nodtb.bin"
     PKG_LOADER="u-boot-dtb.bin"
     ;;
   rk3328)
@@ -32,6 +32,10 @@ case "$UBOOT_SYSTEM" in
     PKG_DATAFILE="$PKG_RKBIN/rk33/rk3399_ddr_800MHz_v1.08.bin"
     PKG_LOADER="$PKG_RKBIN/rk33/rk3399_miniloader_v1.06.bin"
     PKG_BL31="$PKG_RKBIN/rk33/rk3399_bl31_v1.00.elf"
+    ;;
+  *)
+    PKG_DATAFILE="spl/u-boot-spl-dtb.bin"
+    PKG_LOADER="u-boot-dtb.bin"
     ;;
 esac
 

--- a/projects/Rockchip/packages/u-boot/package.mk
+++ b/projects/Rockchip/packages/u-boot/package.mk
@@ -18,8 +18,8 @@
 ################################################################################
 
 PKG_NAME="u-boot"
-PKG_VERSION="6592d3d"
-PKG_SHA256="c1a1d3ea85dc685a038c6816eb588d5999b03d53767292232470041e466d17a7"
+PKG_VERSION="5ecf0ee"
+PKG_SHA256="fba1d26583d446a5bbb5713fe37848e05b546d125384c2c2d2883414d61b7cad"
 PKG_ARCH="arm aarch64"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"
 PKG_URL="https://github.com/rockchip-linux/u-boot/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
This PR updates `u-boot` to latest vendor version fixing a boot issue with rk3328 in my last PR.
The u-boot install-script also adds support for more SoCs using a default `PKG_DATAFILE` and `PKG_LOADER`.

`rkmpp` was also updated to latest version, it contains some changes/fixes to the h264 decoder.

Finally a short notice about what type of devices is more likely to work was added to the Rockchip project `README.md`.