### PR TITLE
scripts/build: fix meson cross-compiling

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -339,7 +339,7 @@ else
     # meson builds
     "meson:target")
       echo "Executing (target): meson $TARGET_MESON_OPTS $PKG_MESON_OPTS_TARGET $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
-      meson $TARGET_MESON_OPTS $PKG_MESON_OPTS_TARGET $(dirname $PKG_MESON_SCRIPT)
+      CC="$HOST_CC" CXX="$HOST_CXX" meson $TARGET_MESON_OPTS $PKG_MESON_OPTS_TARGET $(dirname $PKG_MESON_SCRIPT)
       ;;
     "meson:host")
       echo "Executing (host): meson $HOST_MESON_OPTS $PKG_MESON_OPTS_HOST $(dirname $PKG_MESON_SCRIPT)" | tr -s " "


### PR DESCRIPTION
fixed meson build system usage while cross compiling

on behave of @Kwiboo 
@lrusak pls have a look, fixed it for me

Without meson is not able to cross compile packages for different archs and creates errors like

```
Traceback (most recent call last):
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/mesonmain.py", line 353, in run
    app.generate()
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/mesonmain.py", line 148, in generate
    self._generate(env)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/mesonmain.py", line 188, in _generate
    intr = interpreter.Interpreter(b, g)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreter.py", line 1338, in __init__
    self.parse_project()
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreterbase.py", line 134, in parse_project
    self.evaluate_codeblock(self.ast, end=1)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreterbase.py", line 170, in evaluate_codeblock
    raise e
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreterbase.py", line 164, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreterbase.py", line 175, in evaluate_statement
    return self.function_call(cur)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreterbase.py", line 385, in function_call
    return self.funcs[func_name](node, self.flatten(posargs), kwargs)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreterbase.py", line 55, in wrapped
    return f(self, node, args, kwargs)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreterbase.py", line 77, in wrapped
    return f(s, node_or_state, args, kwargs)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreter.py", line 1789, in func_project
    self.add_languages(proj_langs, True)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreter.py", line 1906, in add_languages
    (comp, cross_comp) = self.detect_compilers(lang, need_cross_compiler)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/interpreter.py", line 1875, in detect_compilers
    comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/compilers/c.py", line 235, in sanity_check
    return self.sanity_check_impl(work_dir, environment, 'sanitycheckc.c', code)
  File "/builddir/toolchain/lib/python3.6/site-packages/meson-0.42.1-py3.6.egg/mesonbuild/compilers/c.py", line 228, in sanity_check_impl
    pe = subprocess.Popen(cmdlist)
  File "/builddir/toolchain/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/builddir/toolchain/lib/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 8] Exec format error: '/builddir/libmpdclient-2.13/.armv7ve-libreelec-linux-gnueabi/meson-private/sanitycheckc.exe'
```