### PR TITLE
systemd: Fix a failure in systemd-sysctl during a startup of systemd-236

### DIFF
--- a/packages/sysutils/systemd/patches/systemd-0101-backport-sysctl-use-raw-file_descriptor-in-sysctl_write.patch
+++ b/packages/sysutils/systemd/patches/systemd-0101-backport-sysctl-use-raw-file_descriptor-in-sysctl_write.patch
@@ -1,0 +1,58 @@
+From c2ae95a71d8ceb5e7d7b766569044439ef0bad6b Mon Sep 17 00:00:00 2001
+From: Mike Gilbert <floppym@gentoo.org>
+Date: Wed, 27 Dec 2017 16:59:04 -0500
+Subject: [PATCH] sysctl: use raw file descriptor in sysctl_write
+
+The kernel returns specific error codes which may be lost if we use the
+libc buffered io functions.
+
+Fixes: https://github.com/systemd/systemd/issues/7744
+---
+ src/shared/sysctl-util.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/sysctl-util.c b/src/shared/sysctl-util.c
+index 189580e3ed..0bc81aaa56 100644
+--- a/src/shared/sysctl-util.c
++++ b/src/shared/sysctl-util.c
+@@ -18,9 +18,13 @@
+   along with systemd; If not, see <http://www.gnu.org/licenses/>.
+ ***/
+ 
++#include <errno.h>
++#include <fcntl.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <unistd.h>
+ 
++#include "fd-util.h"
+ #include "fileio.h"
+ #include "log.h"
+ #include "macro.h"
+@@ -53,6 +57,7 @@ char *sysctl_normalize(char *s) {
+ 
+ int sysctl_write(const char *property, const char *value) {
+         char *p;
++        _cleanup_close_ int fd = -1;
+ 
+         assert(property);
+         assert(value);
+@@ -60,7 +65,17 @@ int sysctl_write(const char *property, const char *value) {
+         log_debug("Setting '%s' to '%s'", property, value);
+ 
+         p = strjoina("/proc/sys/", property);
+-        return write_string_file(p, value, WRITE_STRING_FILE_DISABLE_BUFFER);
++        fd = open(p, O_WRONLY|O_CLOEXEC);
++        if (fd < 0)
++                return -errno;
++
++        if (!endswith(value, "\n"))
++                value = strjoina(value, "\n");
++
++        if (write(fd, value, strlen(value)) < 0)
++                return -errno;
++
++        return 0;
+ }
+ 
+ int sysctl_read(const char *property, char **content) {


### PR DESCRIPTION
Backport a patch to fix a failure in systemd-sysctl during a startup of systemd-236.

On WeTek Hub and WeTek Play 2 systemd-sysctl fails to start with the following errors:
```
Jan 01 02:00:22 LibreELEC systemd-sysctl[2665]: Couldn't write '1' to 'fs/protected_hardlinks': Input/output error
Jan 01 02:00:22 LibreELEC systemd-sysctl[2665]: Couldn't write '1' to 'fs/protected_symlinks': Input/output error
Jan 01 02:00:22 LibreELEC systemd-sysctl[2665]: Couldn't write '0' to 'dev/cdrom/lock': Input/output error
Jan 01 02:00:22 LibreELEC systemd-sysctl[2665]: Couldn't write '0' to 'dev/cdrom/autoclose': Input/output error
Jan 01 02:00:22 LibreELEC systemd-sysctl[2665]: Couldn't write '16384' to 'vm/min_free_kbytes': Input/output error
Jan 01 02:00:22 LibreELEC systemd-sysctl[2665]: Couldn't write '1' to 'net/ipv4/tcp_no_metrics_save': Input/output error
Jan 01 02:00:22 LibreELEC systemd-sysctl[2665]: Couldn't write '10' to 'vm/swappiness': Input/output error
Jan 01 02:00:22 LibreELEC systemd[1]: systemd-sysctl.service: Main process exited, code=exited, status=1/FAILURE
Jan 01 02:00:22 LibreELEC systemd[1]: systemd-sysctl.service: Failed with result 'exit-code'.
Jan 01 02:00:22 LibreELEC systemd[1]: Failed to start Apply Kernel Variables.
```
The patch in this PR fixes the issue.
