### PR TITLE
boost: fix python config

### DIFF
--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -50,6 +50,8 @@ configure_target() {
 
   echo "using gcc : `$CC -v 2>&1  | tail -n 1 |awk '{print $3}'` : $CC  : <compileflags>\"$CFLAGS\" <linkflags>\"$LDFLAGS\" ;" \
     > tools/build/src/user-config.jam
+  echo "using python : ${PKG_PYTHON_VERSION/#python} : $TOOLCHAIN : $SYSROOT_PREFIX/usr/include : $SYSROOT_PREFIX/usr/lib ;" \
+    >> tools/build/src/user-config.jam
 }
 
 makeinstall_target() {


### PR DESCRIPTION
This fixes building boost for me on fedora. The problem is that boost picks up the system `/usr/include/python` path.

This was introduced in https://github.com/LibreELEC/LibreELEC.tv/commit/195aef26928306978beee19ce4c2710a1a981f69