### PR TITLE
busybox: add upstream patch to fix umount from systemd

### DIFF
--- a/packages/sysutils/busybox/patches/busybox-01-umount-ignore-c.patch
+++ b/packages/sysutils/busybox/patches/busybox-01-umount-ignore-c.patch
@@ -1,0 +1,23 @@
+
+Signed-off-by: Shawn Landden <slandden at gmail.com>
+---
+ util-linux/umount.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/util-linux/umount.c b/util-linux/umount.c
+index a6405dfcc..b45cd8a6b 100644
+--- a/util-linux/umount.c
++++ b/util-linux/umount.c
+@@ -81,8 +81,8 @@ static struct mntent *getmntent_r(FILE* stream, struct mntent* result,
+ }
+ #endif
+ 
+-/* ignored: -v -t -i */
+-#define OPTION_STRING           "fldnra" "vt:i"
++/* ignored: -c -v -t -i */
++#define OPTION_STRING           "fldnra" "cvt:i"
+ #define OPT_FORCE               (1 << 0) // Same as MNT_FORCE
+ #define OPT_LAZY                (1 << 1) // Same as MNT_DETACH
+ #define OPT_FREELOOP            (1 << 2)
+-- 
+2.14.1


### PR DESCRIPTION
This fixes the shutdown bug for unmounting `/tmp` at shutdown

a bug report was filled upstream https://github.com/systemd/systemd/issues/7786

I'd like to wait to hear back to see what to do.