### PR TITLE
update for Kodi 18 settings.xml changes

### DIFF
--- a/packages/addons/service/tvheadend42/source/bin/tv_grab_file
+++ b/packages/addons/service/tvheadend42/source/bin/tv_grab_file
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 ################################################################################
-#      This file is part of LibreELEC - https://LibreELEC.tv
-#      Copyright (C) 2016 Team LibreELEC
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #
 #  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -24,10 +24,18 @@ then
 
   ADDON_HOME="$HOME/.kodi/userdata/addon_data/service.tvheadend42"
   ADDON_SETTINGS="$ADDON_HOME/settings.xml"
-  XMLTV_TYPE=`grep XMLTV_TYPE $ADDON_SETTINGS | awk '{print $3 }' | sed -e "s,value=,," -e "s,\",,g"`
-  XMLTV_LOCATION_FILE=`grep XMLTV_LOCATION_FILE $ADDON_SETTINGS | awk '{print $3 }' | sed -e "s,value=,," -e "s,\",,g"`
-  XMLTV_LOCATION_WEB=`grep XMLTV_LOCATION_WEB $ADDON_SETTINGS | awk '{print $3 }' | sed -e "s,value=,," -e "s,\",,g"`
-  XMLTV_LOCATION_SCRIPT=`grep XMLTV_LOCATION_SCRIPT $ADDON_SETTINGS | awk '{print $3 }' | sed -e "s,value=,," -e "s,\",,g"`
+  XML_SETTINGS_VER="$(xmlstarlet sel -t -m settings -v @version $ADDON_SETTINGS)"
+  if [ "$XML_SETTINGS_VER" = "2" ]; then
+    XMLTV_TYPE="$(xmlstarlet sel -t -v '/settings/setting[@id="XMLTV_TYPE"]' $ADDON_SETTINGS)"
+    XMLTV_LOCATION_FILE="$(xmlstarlet sel -t -v '/settings/setting[@id="XMLTV_LOCATION_FILE"]' $ADDON_SETTINGS)"
+    XMLTV_LOCATION_WEB="$(xmlstarlet sel -t -v '/settings/setting[@id="XMLTV_LOCATION_WEB"]' $ADDON_SETTINGS)"
+    XMLTV_LOCATION_SCRIPT="$(xmlstarlet sel -t -v '/settings/setting[@id="XMLTV_LOCATION_SCRIPT"]' $ADDON_SETTINGS)"
+  else
+    XMLTV_TYPE="$(xmlstarlet sel -t -m '/settings/setting[@id="XMLTV_TYPE"]' -v @value $ADDON_SETTINGS)"
+    XMLTV_LOCATION_FILE="$(xmlstarlet sel -t -m '/settings/setting[@id="XMLTV_LOCATION_FILE"]' -v @value $ADDON_SETTINGS)"
+    XMLTV_LOCATION_WEB="$(xmlstarlet sel -t -m '/settings/setting[@id="XMLTV_LOCATION_WEB"]' -v @value $ADDON_SETTINGS)"
+    XMLTV_LOCATION_SCRIPT="$(xmlstarlet sel -t -m '/settings/setting[@id="XMLTV_LOCATION_SCRIPT"]' -v @value $ADDON_SETTINGS)"
+  fi
 
   if [ "$XMLTV_TYPE" = "FILE" ]; then
     case "$XMLTV_LOCATION_FILE" in


### PR DESCRIPTION
Kodi 18 settings.xml changes break the current Tvheadend tv_grab_file function - this updates the tv_grab_file grep to match the changes.