### PR TITLE
intel-ucode: update to intel-ucode-20171117

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20170707"
-PKG_SHA256="4fd44769bf52a7ac11e90651a307aa6e56ca6e1a814e50d750ba8207973bee93"
+PKG_VERSION="20171117"
+PKG_SHA256="93bd1da9fa58ece0016702e657f708b7e496e56da637a3fe9a6d21f1d6f524dc"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"
-PKG_URL="https://downloadmirror.intel.com/26925/eng/microcode-${PKG_VERSION}.tgz"
+PKG_URL="https://downloadmirror.intel.com/27337/eng/microcode-${PKG_VERSION}.tgz"
 PKG_DEPENDS_HOST="toolchain"
 PKG_DEPENDS_TARGET="toolchain intel-ucode:host"
 PKG_SECTION="linux-firmware"


### PR DESCRIPTION
Latest microcode firmware update from the peddler of insecure microprocessors.

From the release notes it's mostly fixes for new processors:
```
Intel Processor Microcode Package for Linux
20171117 Release

-- New Platforms --
CFL U0 (06-9e-0a:22) 70
CFL B0 (06-9e-0b:2) 72
SKX H0 (06-55-04:b7) 2000035
GLK B0 (06-7a-01:1) 1e
APL Bx (06-5c-09:3) 2c
-- Updates --
KBL Y0 (06-8e-0a:c0) 66->70
-- Removed files --
SKX H0 (06-55-04:97) 2000022
```

No specific bug fixes are mentioned in the changelog, so one can only guess...

https://downloadcenter.intel.com/download/27337/Linux-Processor-Microcode-Data-File
  