### PR TITLE
ssv6xxx-aml: fix firmware paths

### DIFF
--- a/packages/linux-drivers/amlogic/ssv6xxx-aml/patches/ssv6xxx-aml-001-fix-build-and-firmware-path.patch
+++ b/packages/linux-drivers/amlogic/ssv6xxx-aml/patches/ssv6xxx-aml-001-fix-build-and-firmware-path.patch
@@ -41,7 +41,7 @@ index 6c3a823..9c623a0 100755
  ##################################################
 
 -firmware_path = /system/etc/wifi/ssv6051/
-+firmware_path = /usr/lib/firmware/
++firmware_path = /usr/lib/firmware/ssv6051/
 
  ############################################################
  # MAC address
@@ -80,7 +80,7 @@ index ff4305e..375827f 100755
  MODULE_DESCRIPTION("Shared library for SSV wireless LAN cards.");
  MODULE_LICENSE("Dual BSD/GPL");
 -static char *stacfgpath = NULL;
-+static char *stacfgpath = "/usr/lib/firmware/ssv6051-wifi.cfg";
++static char *stacfgpath = "/usr/lib/firmware/ssv6051/ssv6051-wifi.cfg";
  EXPORT_SYMBOL(stacfgpath);
  module_param(stacfgpath, charp, 0000);
  MODULE_PARM_DESC(stacfgpath, "Get path of sta cfg");


### PR DESCRIPTION
This PR fixes the firmware paths for people with ssv6* WiFi chips  