### PR TITLE
 buildsystem: add support for building extra packages specified in project or device options

### DIFF
--- a/config/show_config
+++ b/config/show_config
@@ -110,6 +110,9 @@ show_config() {
   fi
   config_message="$config_message\n - UDevil support:\t\t\t $UDEVIL"
   config_message="$config_message\n - Installer support:\t\t\t $INSTALLER_SUPPORT"
+  for config_package in $ADDITIONAL_PACKAGES; do
+    config_message="$config_message\n - Include package:\t\t\t $config_package"
+  done
 
   # Misc. Filesystems
 

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -165,6 +165,11 @@
 # swapfile size if SWAP_SUPPORT=yes in MB
   SWAPFILESIZE="128"
 
+# additional packages to install:
+# Space separated list is supported,
+# e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
+  ADDITIONAL_PACKAGES=""
+
 # build with installer (yes / no)
   INSTALLER_SUPPORT="yes"
 

--- a/packages/virtual/misc-packages/package.mk
+++ b/packages/virtual/misc-packages/package.mk
@@ -1,0 +1,28 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="misc-packages"
+PKG_VERSION=""
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://libreelec.tv"
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain $ADDITIONAL_PACKAGES"
+PKG_SECTION="virtual"
+PKG_SHORTDESC="misc-packages: Metapackage for miscellaneous packages"
+PKG_LONGDESC="misc-packages: Metapackage for miscellaneous packages"

--- a/projects/Amlogic/devices/S905/options
+++ b/projects/Amlogic/devices/S905/options
@@ -3,3 +3,8 @@
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS gpu-aml"
+
+  # additional packages to install:
+  # Space separated list is supported,
+  # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
+    ADDITIONAL_PACKAGES="u-boot-tools-aml"

--- a/scripts/image
+++ b/scripts/image
@@ -182,6 +182,9 @@ $SCRIPTS/install network
 # Remote support
 [ "$REMOTE_SUPPORT" = "yes" ] && $SCRIPTS/install remote
 
+# Install miscellaneous packages
+$SCRIPTS/install misc-packages
+
 # Virtual image creation support
 [ "$PROJECT" = "Generic" ] && $SCRIPTS/install virtual
 


### PR DESCRIPTION
As the title says, we have a couple of packages in projects/Amlogic (only 1 listed at present) that are required to be built.

As can be seen this has been added to the end of packages/virtual/debug/package.mk as this is the very last point in the build system that packages are compiled before an image is created.

I'm open to suggestions if anybody thinks this could or should be placed elsewhere.