### PR TITLE
LibreELEC-settings: update to b13dbf3

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -17,10 +17,10 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="057ab16"
-PKG_SHA256="dac3e653a5348e3dcd229399343e7a78fa9123e1c721c2a2117d43967f354354"
+PKG_VERSION="b13dbf3"
+PKG_SHA256="ca9622bbeac2c5fa4d2e362b653de41502e9a584d73c1026f1e46ea5b0e571a5"
 PKG_ARCH="any"
-PKG_LICENSE="prop."
+PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"
 PKG_SOURCE_DIR="service.libreelec.settings-$PKG_VERSION*"


### PR DESCRIPTION
Update to recent version. Also fix for PKG_LICENSE. According to https://github.com/LibreELEC/service.libreelec.settings/blob/master/COPYING the package is GPL not proprietary.