### PR TITLE
mysql: update to mysql-5.7.20

### DIFF
--- a/packages/databases/mysql/package.mk
+++ b/packages/databases/mysql/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="mysql"
-PKG_VERSION="5.7.18"
-PKG_SHA256="0b5d71ed608656cd8181d3bb0434d3e36bac192899038dbdddf5a7594aaea1a2"
+PKG_VERSION="5.7.20"
+PKG_SHA256="5397549bb7c238f396c123db2df4cad2191b11adf8986de7fe63bff8e2786487"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.mysql.com"


### PR DESCRIPTION
5.7.18 is no longer available for download (although we have it on our mirror).  