### PR TITLE
projects/Amlogic: fstrim all trimmable mounts

### DIFF
--- a/projects/Amlogic/filesystem/usr/lib/systemd/system/fstrim.service
+++ b/projects/Amlogic/filesystem/usr/lib/systemd/system/fstrim.service
@@ -1,9 +1,9 @@
 [Unit]
-Description=fstrim storage partition
+Description=Apply TRIM on all trimmable mounts
 
 [Service]
 Type=simple
-ExecStart=[ -f /flash/kernel.img ]  || /usr/sbin/fstrim /storage
+ExecStart=-/usr/sbin/fstrim -a -v
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
With fstrim from util-linux we can use one command to trim all trimmable mounts. Use it and simplify the service.