### PR TITLE
util-linux: Add systemd service, timer for fstrim

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -107,4 +107,5 @@ post_install () {
   if [ "$SWAP_SUPPORT" = "yes" ]; then
     enable_service swap.service
   fi
+  enable_service fstrim.timer
 }

--- a/packages/sysutils/util-linux/system.d/fstrim.service
+++ b/packages/sysutils/util-linux/system.d/fstrim.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Discard unused blocks
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/fstrim -av

--- a/packages/sysutils/util-linux/system.d/fstrim.timer
+++ b/packages/sysutils/util-linux/system.d/fstrim.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Discard unused blocks once a week
+
+[Timer]
+OnCalendar=weekly
+AccuracySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/projects/Amlogic/filesystem/usr/lib/systemd/system/fstrim.service
+++ b/projects/Amlogic/filesystem/usr/lib/systemd/system/fstrim.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Apply TRIM on all trimmable mounts
-
-[Service]
-Type=simple
-ExecStart=-/usr/sbin/fstrim -a -v
-
-[Install]
-WantedBy=basic.target


### PR DESCRIPTION
These are the upstream fstrim.service, fstrim.timer. It's easier to just add those than to build util-linux "--with-systemd".
I don't have drives to test.  