### PR TITLE
projects/Amlogic: S905: compile/install aml-s9xx-device-trees

### DIFF
--- a/projects/Amlogic/devices/S905/options
+++ b/projects/Amlogic/devices/S905/options
@@ -7,4 +7,4 @@
   # additional packages to install:
   # Space separated list is supported,
   # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
-    ADDITIONAL_PACKAGES="u-boot-tools-aml"
+    ADDITIONAL_PACKAGES="aml-s9xx-device-trees u-boot-tools-aml"

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/package.mk
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/package.mk
@@ -1,0 +1,68 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="aml-s9xx-device-trees"
+PKG_VERSION="097d287"
+PKG_SHA256=""
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kszaq/s905-device-trees"
+PKG_URL=""
+PKG_SOURCE_DIR="s905-device-trees-$PKG_VERSION*"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_TOOLCHAIN="manual"
+
+EXTRA_TREES=(gxbb_p201.dtb gxl_p212_1g.dtb gxl_p212_2g.dtb gxbb_p200_1G_wetek_hub.dtb gxbb_p200_2G_wetek_play_2.dtb gxm_q200_2g.dtb gxm_q201_1g.dtb gxm_q201_2g.dtb)
+
+make_target() {
+  pushd $BUILD/linux-$(kernel_version) > /dev/null
+
+  mkdir -p $TARGET_IMG
+
+  DTB_LIST=""
+
+  # Complete device trees
+  for f in $PKG_BUILD/*.dts; do
+    DTB_NAME="$(basename $f .dts).dtb"
+    cp -f $f arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/
+    DTB_LIST="$DTB_LIST $DTB_NAME"
+  done
+
+  # Kernel-tree trees
+  for f in ${EXTRA_TREES[@]}; do
+    DTB_LIST="$DTB_LIST $f"
+
+    LE_DT_ID="${f/.dtb/}"
+    SOURCE_FILE="arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/$LE_DT_ID.dts"
+    # Remove "le-dt-id" if exists
+    sed -i "/le-dt-id/d" $SOURCE_FILE
+    # Add "le-dtb-id"
+    echo -e "/ {\n\tle-dt-id = \"$LE_DT_ID\";\n};" >> $SOURCE_FILE
+  done
+
+  # Compile device trees
+  LDFLAGS="" make $DTB_LIST
+  mv arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/*.dtb $PKG_BUILD
+
+  popd > /dev/null
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/share/bootloader
+    cp -PR $PKG_BUILD/*.dtb $INSTALL/usr/share/bootloader
+}

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_100M.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_100M.dts
@@ -1,0 +1,14 @@
+#include "gxbb_p200.dts"
+
+/{
+	le-dt-id = "gxbb_p200_1G_100M";
+	ethmac: ethernet@0xc9410000 {
+		compatible = "amlogic, gxbb-rmii-dwmac";
+		phy-mode= "rmii";
+		mc_val = <0x1800>;
+	};
+
+	sdio {
+		interrupts = <	0 216 4>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_100M_RealtekWiFi.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_100M_RealtekWiFi.dts
@@ -1,0 +1,28 @@
+#include "gxbb_p200.dts"
+
+/{
+	le-dt-id = "gxbb_p200_1G_100M_RealtekWiFi";
+	ethmac: ethernet@0xc9410000 {
+		compatible = "amlogic, gxbb-rmii-dwmac";
+		phy-mode= "rmii";
+		mc_val = <0x1800>;
+	};
+
+	/delete-node/ bt-dev;
+
+	wifi {
+		irq_trigger_type = "GPIO_IRQ_HIGH";
+		/delete-property/ dhd_static_buf;
+		power_on_pin2 = <&gpio	   GPIOX_20	   GPIO_ACTIVE_HIGH>;
+	};
+
+	sdio {
+		interrupts = <	0 216 4>;
+	};
+
+	dwc2_a {
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		/delete-property/ gpio-vbus-power;
+		/delete-property/ gpios;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_1Gbit.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_1Gbit.dts
@@ -1,0 +1,5 @@
+#include "gxbb_p200.dts"
+
+/{
+	le-dt-id = "gxbb_p200_1G_1Gbit";
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_1Gbit_RealtekWiFi.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_1Gbit_RealtekWiFi.dts
@@ -1,0 +1,17 @@
+#include "gxbb_p200.dts"
+
+/{
+	le-dt-id = "gxbb_p200_1G_1Gbit_RealtekWiFi";
+	/delete-node/ bt-dev;
+
+	wifi {
+		irq_trigger_type = "GPIO_IRQ_HIGH";
+		/delete-property/ dhd_static_buf;
+		power_on_pin2 = <&gpio	   GPIOX_20	   GPIO_ACTIVE_HIGH>;
+	};
+
+	sdio {
+		interrupts = <	0 216 4>;
+	};
+
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_mxq_pro_4k.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_1G_mxq_pro_4k.dts
@@ -1,0 +1,34 @@
+#include "gxbb_p200.dts"
+
+/{
+	le-dt-id = "gxbb_p200_1G_mxq_pro_4k";
+	ethmac: ethernet@0xc9410000 {
+		compatible = "amlogic, gxbb-rmii-dwmac";
+		phy-mode= "rmii";
+		mc_val = <0x1800>;
+	};
+
+	/delete-node/ bt-dev;
+
+	wifi {
+		irq_trigger_type = "GPIO_IRQ_HIGH";
+		/delete-property/ dhd_static_buf;
+		power_on_pin2 = <&gpio	   GPIOX_20	   GPIO_ACTIVE_HIGH>;
+	};
+
+	sdio {
+		interrupts = <	0 216 4>;
+	};
+
+	partitions: partitions {
+		system:system {
+			size = <0x0 0x50000000>;
+		};
+	};
+
+	dwc2_a {
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		/delete-property/ gpio-vbus-power;
+		/delete-property/ gpios;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_100M.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_100M.dts
@@ -1,0 +1,14 @@
+#include "gxbb_p200_2G.dts"
+
+/{
+	le-dt-id = "gxbb_p200_2G_100M";
+	ethmac: ethernet@0xc9410000 {
+		compatible = "amlogic, gxbb-rmii-dwmac";
+		phy-mode= "rmii";
+		mc_val = <0x1800>;
+	};
+
+	sdio {
+		interrupts = <	0 216 4>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_100M_RealtekWiFi.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_100M_RealtekWiFi.dts
@@ -1,0 +1,28 @@
+#include "gxbb_p200_2G.dts"
+
+/{
+	le-dt-id = "gxbb_p200_2G_100M_RealtekWiFi";
+	ethmac: ethernet@0xc9410000 {
+		compatible = "amlogic, gxbb-rmii-dwmac";
+		phy-mode= "rmii";
+		mc_val = <0x1800>;
+	};
+
+	/delete-node/ bt-dev;
+
+	wifi {
+		irq_trigger_type = "GPIO_IRQ_HIGH";
+		/delete-property/ dhd_static_buf;
+		power_on_pin2 = <&gpio	   GPIOX_20	   GPIO_ACTIVE_HIGH>;
+	};
+
+	sdio {
+		interrupts = <	0 216 4>;
+	};
+
+	dwc2_a {
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		/delete-property/ gpio-vbus-power;
+		/delete-property/ gpios;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_1Gbit.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_1Gbit.dts
@@ -1,0 +1,5 @@
+#include "gxbb_p200_2G.dts"
+
+/{
+	le-dt-id = "gxbb_p200_2G_1Gbit";
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_1Gbit_OTG_Port.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_1Gbit_OTG_Port.dts
@@ -1,0 +1,11 @@
+#include "gxbb_p200_2G.dts"
+
+/{
+	le-dt-id = "gxbb_p200_2G_1Gbit_OTG_Port";
+	dwc2_a {
+		port-type = <0>;	/** 0: otg, 1: host, 2: slave */
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		gpio-vbus-power = "GPIOY_15";
+		gpios = <&gpio	   GPIOY_15	   GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_1Gbit_RealtekWiFi.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_1Gbit_RealtekWiFi.dts
@@ -1,0 +1,17 @@
+#include "gxbb_p200_2G.dts"
+
+/{
+	le-dt-id = "gxbb_p200_2G_1Gbit_RealtekWiFi";
+	/delete-node/ bt-dev;
+
+	wifi {
+		irq_trigger_type = "GPIO_IRQ_HIGH";
+		/delete-property/ dhd_static_buf;
+		power_on_pin2 = <&gpio	   GPIOX_20	   GPIO_ACTIVE_HIGH>;
+	};
+
+	sdio {
+		interrupts = <	0 216 4>;
+	};
+
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_m8s+_k3_pro.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_m8s+_k3_pro.dts
@@ -1,0 +1,19 @@
+#include "gxbb_p200.dts"
+
+/{
+	le-dt-id = "gxbb_p200_2G_m8s+_k3_pro";
+	memory@00000000 {
+		linux,usable-memory = <0x0 0x1000000 0x0 0x7f000000>;
+	};
+
+	wifi {
+		interrupt_pin = <&gpio	   GPIOX_11	   GPIO_ACTIVE_HIGH>;
+		power_on_pin = <&gpio	   GPIOX_10	   GPIO_ACTIVE_HIGH>;
+	};
+
+	dwc2_a {
+		/delete-property/ gpio-vbus-power;
+		/delete-property/ gpios;
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_minix_neo_u1.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_2G_minix_neo_u1.dts
@@ -1,0 +1,87 @@
+#include "gxbb_p200_2G.dts"
+
+/{
+	le-dt-id = "gxbb_p200_2G_minix_neo_u1";
+	rtc {
+		status = "disabled";
+	};
+
+	sd {
+		sd { 
+			voltage =   <&gpio_ao	GPIOAO_5	 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	amhdmitx: amhdmitx {
+		pwr-ctrl = <&pwr_ctrl>;
+	};
+	
+	pwr_ctrl: pwr_ctrl {
+		pwr_5v_on = <&gpio	   GPIOY_5	   GPIO_ACTIVE_HIGH>;
+		PWR_STBY_PWREN = <&gpio	   GPIOY_7	   GPIO_ACTIVE_HIGH>;
+	};
+
+	dwc2_a {
+		port-type = <0>;	/** 0: otg, 1: host, 2: slave */
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		gpio-vbus-power = "GPIOY_3";
+		gpios = <&gpio	   GPIOY_3	   GPIO_ACTIVE_HIGH>;
+		gpio-h = <&gpio	   GPIOY_4	   GPIO_ACTIVE_LOW>;
+	};
+
+	dummy_codec:dummy{
+		status = "disabled";
+	};
+
+	aml_m8_snd {
+		mute_gpio-gpios = <&gpio GPIOY_11 0>;
+
+		codec0: codec0 {
+			sound-dai = <&es8323>;
+		};
+	};
+
+	adc_keypad{
+		status = "disabled";
+	};
+};
+
+&i2c_a {
+	status = "okay";
+	es8323: es8323@10 {
+		#sound-dai-cells = <0>;
+		compatible = "es, es8323";
+		reg = <0x10>;
+	};
+/*p200_2g: audio chip, ok*/
+};
+
+&i2c_b {
+	status = "okay";
+
+	rtc_hym8563{
+		compatible = "amlogic, rtc_hym8563";					  /** for driver probe, must have  */
+		dev_name = "rtc_hym8563";
+		status = "okay";		 
+		reg = <0x51>;									 /** device i2c address, must have		*/
+		interrupts = <0 64 1>;
+		gpio-rtc-irq = <&gpio	   GPIOY_6	   GPIO_ACTIVE_HIGH>;
+	};
+
+	minix_mcu {
+		compatible = "amlogic,minix_mcu";
+		status = "okay";
+		reg = <0x15>;
+	};
+
+	minix_mcu_isp{
+		compatible = "amlogic,minix_mcu_isp";
+		reg = <0x35>;
+	};
+};
+
+&pinmux {
+	audio_spdif_pins:audio_pin1{
+		amlogic,setmask=<1 0x10200>;	/*spdif_out*/
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_k1_plus.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_k1_plus.dts
@@ -1,0 +1,84 @@
+#include "gxbb_p200.dts"
+
+/{
+	le-dt-id = "gxbb_p200_k1_plus";
+	ethmac: ethernet@0xc9410000 {
+		compatible = "amlogic, gxbb-rmii-dwmac";
+		phy-mode= "rmii";
+		mc_val = <0x1800>;
+	};
+
+	/delete-node/ bt-dev;
+
+	wifi {
+		irq_trigger_type = "GPIO_IRQ_HIGH";
+		/delete-property/ dhd_static_buf;
+		power_on_pin2 = <&gpio	   GPIOX_20	   GPIO_ACTIVE_HIGH>;
+	};
+
+	sdio {
+		interrupts = <	0 216 4>;
+	};
+
+	dwc2_a {
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		/delete-property/ gpio-vbus-power;
+		/delete-property/ gpios;
+	};
+
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "dvb";
+		status = "okay";
+		fec_reset_gpio-gpios = <&gpio GPIOY_13 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIOY_11 GPIO_ACTIVE_LOW>;
+		//"parallel","serial","disable"
+		ts0 = "parallel";
+		ts0_control = <0>;
+		ts0_invert = <0>;
+		pinctrl-names = "p_ts0", "s_ts0";
+		pinctrl-0 = <&dvb_p_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts0_pins>;
+		resets = <&clock GCLK_IDX_DEMUX
+				&clock GCLK_IDX_ASYNC_FIFO
+				&clock GCLK_IDX_AHB_ARB0
+				&clock GCLK_IDX_HIU_PARSER_TOP>;
+		reset-names = "demux", "asyncfifo", "ahbarb0", "uparsertop";
+	};
+
+	dvbfe {
+		compatible = "amlogic,dvbfe";
+		//dev_name = "avl6211";
+		status = "okay";
+		dtv_demod0 = "Avl6211";
+		dtv_demod0_i2c_adap_id = <1>;
+		dtv_demod0_i2c_addr = <0xC0>;
+		dtv_demod0_reset_value = <0>;
+		//dtv_demod0_reset_gpio = <&gpio GPIOY_13 GPIO_ACTIVE_HIGH>;
+		dtv_demod0_reset_gpio-gpios = <&gpio GPIOY_13 GPIO_ACTIVE_LOW>;
+		dtv_demod0_power_gpio-gpios = <&gpio GPIOY_11 GPIO_ACTIVE_LOW>;
+		fe0_dtv_demod = <0>;
+		fe0_ts = <0>;
+		fe0_dev = <0>;
+	};
+};
+
+&i2c_a {
+	status = "okay";
+};
+
+&i2c_b {
+	status = "okay";
+};
+
+&i2c_c {
+	status = "okay";
+};
+
+&i2c_d {
+	status = "okay";
+};
+ 
+&i2c_slave {
+	status = "disabled";
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_k2_pro.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p200_k2_pro.dts
@@ -1,0 +1,76 @@
+#include "gxbb_p200_2G.dts"
+
+/{
+	le-dt-id = "gxbb_p200_k2_pro";
+	ethmac: ethernet@0xc9410000 {
+		compatible = "amlogic, gxbb-rmii-dwmac";
+		phy-mode= "rmii";
+		mc_val = <0x1800>;
+	};
+
+	emmc {
+		interrupts = <	0 218 4>;
+	};
+
+	dwc2_a {
+		port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+		gpio-vbus-power = "GPIODV_15";
+		gpios = <&gpio       GPIODV_15       GPIO_ACTIVE_HIGH>;
+	};
+
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "dvb";
+		status = "okay";
+		fec_reset_gpio-gpios = <&gpio GPIOY_13 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIOY_11 GPIO_ACTIVE_LOW>;
+		//"parallel","serial","disable"
+		ts0 = "parallel";
+		ts0_control = <0>;
+		ts0_invert = <0>;
+		pinctrl-names = "p_ts0", "s_ts0";
+		pinctrl-0 = <&dvb_p_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts0_pins>;
+		resets = <&clock GCLK_IDX_DEMUX
+				&clock GCLK_IDX_ASYNC_FIFO
+				&clock GCLK_IDX_AHB_ARB0
+				&clock GCLK_IDX_HIU_PARSER_TOP>;
+		reset-names = "demux", "asyncfifo", "ahbarb0", "uparsertop";
+	};
+
+	dvbfe {
+		compatible = "amlogic,dvbfe";
+		//dev_name = "avl6211";
+		status = "okay";
+		dtv_demod0 = "Avl6211";
+		dtv_demod0_i2c_adap_id = <1>;
+		dtv_demod0_i2c_addr = <0xC0>;
+		dtv_demod0_reset_value = <0>;
+		//dtv_demod0_reset_gpio = <&gpio GPIOY_13 GPIO_ACTIVE_HIGH>;
+		dtv_demod0_reset_gpio-gpios = <&gpio GPIOY_13 GPIO_ACTIVE_LOW>;
+		dtv_demod0_power_gpio-gpios = <&gpio GPIOY_11 GPIO_ACTIVE_LOW>;
+		fe0_dtv_demod = <0>;
+		fe0_ts = <0>;
+		fe0_dev = <0>;
+	};
+};
+
+&i2c_a {
+	status = "okay";
+};
+
+&i2c_b {
+	status = "okay";
+};
+
+&i2c_c {
+	status = "okay";
+};
+
+&i2c_d {
+	status = "okay";
+};
+ 
+&i2c_slave {
+	status = "disabled";
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p201_2G.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxbb_p201_2G.dts
@@ -1,0 +1,9 @@
+#include "gxbb_p201.dts"
+
+/{
+	le-dt-id = "gxbb_p201_2G";
+	memory@00000000 {
+		device_type = "memory";
+		linux,usable-memory = <0x0 0x1000000 0x0 0x7f000000>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_coowell_v5.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_coowell_v5.dts
@@ -1,0 +1,15 @@
+#include "gxl_p212_1g.dts"
+
+/ {
+	le-dt-id = "gxl_p212_1g_coowell_v5";
+	nand {
+		status = "okay";
+	};
+
+	partitions:partitions {
+		system:system {
+			size = <0x0 0x60000000>;
+		};
+	};
+
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_lepotato.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_lepotato.dts
@@ -1,0 +1,26 @@
+#include "gxl_p212_1g.dts"
+
+/ {
+	le-dt-id = "gxl_p212_1g_lepotato";
+	leds: gpio_leds {
+		compatible = "gpio-leds";
+
+		system {
+			label = "librecomputer:system-status";
+			gpios = <&gpio GPIODV_24 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+			panic-indicator;
+		};
+
+		blue {
+			label = "librecomputer:blue";
+			gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	gpio_keypad {
+		status = "disabled";
+	};
+
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_nand.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_nand.dts
@@ -1,0 +1,8 @@
+#include "gxl_p212_1g.dts"
+
+/ {
+	le-dt-id = "gxl_p212_1g_nand";
+	nand {
+		status = "okay";
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_slowemmc.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_slowemmc.dts
@@ -1,0 +1,10 @@
+#include "gxl_p212_1g.dts"
+
+/{
+	le-dt-id = "gxl_p212_1g_slowemmc";
+	emmc {
+		emmc {
+			caps2 = "MMC_CAP2_HS200";
+		};
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_tx3mini.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_1g_tx3mini.dts
@@ -1,0 +1,13 @@
+#include "gxl_p212_1g.dts"
+
+/ {
+	le-dt-id = "gxl_p212_1g_tx3mini";
+	fd628_dev {
+		compatible = "amlogic,fd628_dev";
+		status = "okay";
+		fd628_gpio_clk = <&gpio GPIODV_27 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_dat = <&gpio GPIODV_26 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_stb = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
+	};
+
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_kvim.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_kvim.dts
@@ -1,0 +1,53 @@
+#include "gxl_p212_2g.dts"
+
+/{
+	le-dt-id = "gxl_p212_2g_kvim";
+	amlogic-dt-id = "kvim";
+
+	sysled {
+		led_gpio = <&gpio_ao GPIOAO_9 GPIO_ACTIVE_HIGH>;
+	};
+
+	ethmac: ethernet@0xc9410000 {
+		/delete-property/ pinctrl-names;
+		/delete-property/ pinctrl-0;
+	};
+
+	rtc {
+		status = "disabled";
+	};
+
+	uart_AO_B: serial@c81004e0 {
+		status = "okay";
+	};
+
+	dwc2_a {
+		controller-type = <2>; /** 0: normal, 1: otg+dwc3 host only, 2: otg+dwc3 device only*/
+	};
+
+	aml_m8_snd {
+		/delete-property/ mute_gpio-gpios;
+		/delete-property/ pinctrl-0;
+	};
+	
+	adc_keypad{
+		compatible = "amlogic, adc_keypad";
+		status = "okay";
+		key_name = "home";
+		key_num = <1>;
+		key_code = <300>;
+		key_chan = <0>;
+		key_val = <10>;
+		key_tolerance = <40>;
+	};
+};
+
+&i2c_b {
+	status = "okay";
+	rtc_hym8563{
+			compatible = "amlogic, rtc_hym8563";
+			dev_name = "rtc_hym8563";
+			status = "okay";
+			reg = <0x51>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_lepotato.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_lepotato.dts
@@ -1,0 +1,26 @@
+#include "gxl_p212_2g.dts"
+
+/ {
+	le-dt-id = "gxl_p212_2g_lepotato";
+	leds: gpio_leds {
+		compatible = "gpio-leds";
+
+		system {
+			label = "librecomputer:system-status";
+			gpios = <&gpio GPIODV_24 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+			panic-indicator;
+		};
+
+		blue {
+			label = "librecomputer:blue";
+			gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	gpio_keypad {
+		status = "disabled";
+	};
+
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_nand.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_nand.dts
@@ -1,0 +1,8 @@
+#include "gxl_p212_1g.dts"
+
+/ {
+	le-dt-id = "gxl_p212_2g_nand";
+	nand {
+		status = "okay";
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_slowemmc.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_slowemmc.dts
@@ -1,0 +1,10 @@
+#include "gxl_p212_2g.dts"
+
+/{
+	le-dt-id = "gxl_p212_2g_slowemmc";
+	emmc {
+		emmc {
+			caps2 = "MMC_CAP2_HS200";
+		};
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_tx3mini.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_2g_tx3mini.dts
@@ -1,0 +1,13 @@
+#include "gxl_p212_2g.dts"
+
+/ {
+	le-dt-id = "gxl_p212_2g_tx3mini";
+	fd628_dev {
+		compatible = "amlogic,fd628_dev";
+		status = "okay";
+		fd628_gpio_clk = <&gpio GPIODV_27 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_dat = <&gpio GPIODV_26 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_stb = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
+	};
+
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_3g.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p212_3g.dts
@@ -1,0 +1,10 @@
+#include "gxl_p212_2g.dts"
+
+/{
+	le-dt-id = "gxl_p212_3g";
+	amlogic-dt-id = "gxl_p212_3g";
+
+	memory@00000000 {
+		linux,usable-memory = <0x0 0x100000 0x0 0xbf000000>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p230_k1_pro.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p230_k1_pro.dts
@@ -1,0 +1,77 @@
+#include "gxl_p230_2g.dts"
+
+/{
+	le-dt-id = "gxl_p230_k1_pro";
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "dvb";
+		ts0 = "parallel";
+		ts0_control = <0x0>;
+		ts0_invert = <0x0>;
+		fec_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIODV_11 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "p_ts0", "s_ts0", "s_ts1";
+		pinctrl-0 = <&dvb_p_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts0_pins>;
+		pinctrl-2 = <&dvb_s_ts1_pins>;
+		resets = <&clock GCLK_IDX_DEMUX &clock GCLK_IDX_ASYNC_FIFO &clock GCLK_IDX_AHB_ARB0 &clock GCLK_IDX_HIU_PARSER_TOP>;
+		reset-names = "demux", "asyncfifo", "ahbarb0", "uparsertop";
+	};
+
+	dvbfe {
+		compatible = "amlogic,dvbfe";
+		//dev_name = "dvbfe";
+		status = "okay";
+		dtv_demod0 = "Avl6211";
+		dtv_demod0_i2c_adap_id = <2>;
+		dtv_demod0_i2c_addr = <0x60>;
+		dtv_demod0_reset_value = <0>;
+		dtv_demod0_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_LOW>;
+		dtv_demod0_power_gpio-gpios = <&gpio GPIODV_14 GPIO_ACTIVE_LOW>;
+		fe0_dtv_demod = <0>;
+		fe0_ts = <0>;
+		fe0_dev = <0>;
+	};
+};
+
+&pinmux {
+	dvb_p_ts0_pins:dvb_p_ts0_pins {
+		amlogic,setmask = <0x2 0x1f>;
+		amlogic,clrmask = <0x3 0x787 0x2 0xff000400>;
+		amlogic,pins = "GPIODV_0", "GPIODV_1", "GPIODV_2", "GPIODV_3", "GPIODV_4", "GPIODV_5", "GPIODV_6", "GPIODV_7", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts0_pins:dvb_s_ts0_pins {
+		amlogic,setmask = <0x2 0x17>;
+		amlogic,clrmask = <0x3 0x584 0x2 0x7000000 0x1 0x100>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts1_pins:dvb_s_ts1_pins {
+		amlogic,setmask = <0x3 0x17>;
+		amlogic,clrmask = <0x2 0xf0000 0x1 0x7>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dtv_params_pin:dtv_params_pin {
+		amlogic,clrmask = <0x1 0x38000000 0x3 0x80>;
+		amlogic,pins = "GPIODV_13", "GPIODV_14", "GPIODV_15";
+	};
+
+};
+
+&i2c_a {
+	status = "okay";
+};
+
+&i2c_b {
+	status = "okay";
+};
+
+&i2c_c {
+	status = "okay";
+};
+
+&i2c_d {
+	status = "okay";
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p231_1g_dvb.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p231_1g_dvb.dts
@@ -1,0 +1,77 @@
+#include "gxl_p231_1g.dts"
+
+/{
+	le-dt-id = "gxl_p231_1g_dvb";
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "dvb";
+		ts0 = "parallel";
+		ts0_control = <0x0>;
+		ts0_invert = <0x0>;
+		fec_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIODV_11 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "p_ts0", "s_ts0", "s_ts1";
+		pinctrl-0 = <&dvb_p_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts0_pins>;
+		pinctrl-2 = <&dvb_s_ts1_pins>;
+		resets = <&clock GCLK_IDX_DEMUX &clock GCLK_IDX_ASYNC_FIFO &clock GCLK_IDX_AHB_ARB0 &clock GCLK_IDX_HIU_PARSER_TOP>;
+		reset-names = "demux", "asyncfifo", "ahbarb0", "uparsertop";
+	};
+
+	dvbfe {
+		compatible = "amlogic,dvbfe";
+		//dev_name = "dvbfe";
+		status = "okay";
+		dtv_demod0 = "Avl6211";
+		dtv_demod0_i2c_adap_id = <2>;
+		dtv_demod0_i2c_addr = <0x60>;
+		dtv_demod0_reset_value = <0>;
+		dtv_demod0_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_LOW>;
+		dtv_demod0_power_gpio-gpios = <&gpio GPIODV_14 GPIO_ACTIVE_LOW>;
+		fe0_dtv_demod = <0>;
+		fe0_ts = <0>;
+		fe0_dev = <0>;
+	};
+};
+
+&pinmux {
+	dvb_p_ts0_pins:dvb_p_ts0_pins {
+		amlogic,setmask = <0x2 0x1f>;
+		amlogic,clrmask = <0x3 0x787 0x2 0xff000400>;
+		amlogic,pins = "GPIODV_0", "GPIODV_1", "GPIODV_2", "GPIODV_3", "GPIODV_4", "GPIODV_5", "GPIODV_6", "GPIODV_7", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts0_pins:dvb_s_ts0_pins {
+		amlogic,setmask = <0x2 0x17>;
+		amlogic,clrmask = <0x3 0x584 0x2 0x7000000 0x1 0x100>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts1_pins:dvb_s_ts1_pins {
+		amlogic,setmask = <0x3 0x17>;
+		amlogic,clrmask = <0x2 0xf0000 0x1 0x7>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dtv_params_pin:dtv_params_pin {
+		amlogic,clrmask = <0x1 0x38000000 0x3 0x80>;
+		amlogic,pins = "GPIODV_13", "GPIODV_14", "GPIODV_15";
+	};
+
+};
+
+&i2c_a {
+	status = "okay";
+};
+
+&i2c_b {
+	status = "okay";
+};
+
+&i2c_c {
+	status = "okay";
+};
+
+&i2c_d {
+	status = "okay";
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p231_2g_dvb.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxl_p231_2g_dvb.dts
@@ -1,0 +1,77 @@
+#include "gxl_p231_2g.dts"
+
+/{
+	le-dt-id = "gxl_p231_2g_dvb";
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "dvb";
+		ts0 = "parallel";
+		ts0_control = <0x0>;
+		ts0_invert = <0x0>;
+		fec_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIODV_11 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "p_ts0", "s_ts0", "s_ts1";
+		pinctrl-0 = <&dvb_p_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts0_pins>;
+		pinctrl-2 = <&dvb_s_ts1_pins>;
+		resets = <&clock GCLK_IDX_DEMUX &clock GCLK_IDX_ASYNC_FIFO &clock GCLK_IDX_AHB_ARB0 &clock GCLK_IDX_HIU_PARSER_TOP>;
+		reset-names = "demux", "asyncfifo", "ahbarb0", "uparsertop";
+	};
+
+	dvbfe {
+		compatible = "amlogic,dvbfe";
+		//dev_name = "dvbfe";
+		status = "okay";
+		dtv_demod0 = "Avl6211";
+		dtv_demod0_i2c_adap_id = <2>;
+		dtv_demod0_i2c_addr = <0x60>;
+		dtv_demod0_reset_value = <0>;
+		dtv_demod0_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_LOW>;
+		dtv_demod0_power_gpio-gpios = <&gpio GPIODV_14 GPIO_ACTIVE_LOW>;
+		fe0_dtv_demod = <0>;
+		fe0_ts = <0>;
+		fe0_dev = <0>;
+	};
+};
+
+&pinmux {
+	dvb_p_ts0_pins:dvb_p_ts0_pins {
+		amlogic,setmask = <0x2 0x1f>;
+		amlogic,clrmask = <0x3 0x787 0x2 0xff000400>;
+		amlogic,pins = "GPIODV_0", "GPIODV_1", "GPIODV_2", "GPIODV_3", "GPIODV_4", "GPIODV_5", "GPIODV_6", "GPIODV_7", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts0_pins:dvb_s_ts0_pins {
+		amlogic,setmask = <0x2 0x17>;
+		amlogic,clrmask = <0x3 0x584 0x2 0x7000000 0x1 0x100>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts1_pins:dvb_s_ts1_pins {
+		amlogic,setmask = <0x3 0x17>;
+		amlogic,clrmask = <0x2 0xf0000 0x1 0x7>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dtv_params_pin:dtv_params_pin {
+		amlogic,clrmask = <0x1 0x38000000 0x3 0x80>;
+		amlogic,pins = "GPIODV_13", "GPIODV_14", "GPIODV_15";
+	};
+
+};
+
+&i2c_a {
+	status = "okay";
+};
+
+&i2c_b {
+	status = "okay";
+};
+
+&i2c_c {
+	status = "okay";
+};
+
+&i2c_d {
+	status = "okay";
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_kvim2.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_kvim2.dts
@@ -1,0 +1,128 @@
+#include "gxm_q200_2g.dts"
+
+/{
+	le-dt-id = "gxm_kvim2";
+	compatible = "kvim";
+	amlogic-dt-id = "kvim";
+
+	memory@00000000 {
+		/delete-property/ linux,usable-memory;
+		linux,usable-memory-2g = <0x0 0x00100000 0x0 0x7ff00000>;
+		linux,usable-memory-3g = <0x0 0x00100000 0x0 0xbff00000>;
+	};
+
+	sysled {
+		led_gpio = <&gpio_ao GPIOAO_9 GPIO_ACTIVE_HIGH>;
+	};
+
+	fan {
+		compatible = "fanctl";
+		fan_ctl0 = <&gpio GPIODV_14 GPIO_ACTIVE_HIGH>;
+		fan_ctl1 = <&gpio GPIODV_15 GPIO_ACTIVE_HIGH>;
+		trig_temp_level0 = <50>;
+		trig_temp_level1 = <60>;
+		trig_temp_level2 = <70>;
+	};
+
+	meson-fb {
+		/delete-property/ logo_addr;
+		logo_addr_2g = "0x7d851000";
+		logo_addr_3g = "0xbd851000"; /*ion base + fb0 memory size for uboot logo osd1*/
+	};
+
+	uart_AO_B: serial@c81004e0 {
+		status = "okay";
+	};
+	
+	dwc2_a {
+		controller-type = <2>; /** 0: normal, 1: otg+dwc3 host only, 2: otg+dwc3 device only*/
+	};
+	adc_keypad{
+		compatible = "amlogic, adc_keypad";
+		status = "okay";
+		key_name = "home";
+		key_num = <1>;
+		key_code = <102>;
+		key_chan = <0>;
+		key_val = <10>;
+		key_tolerance = <40>;
+	};
+
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "dvb";
+		ts0 = "parallel";
+		ts0_control = <0x0>;
+		ts0_invert = <0x0>;
+		fec_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIODV_11 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "p_ts0", "s_ts0", "s_ts1";
+		pinctrl-0 = <&dvb_p_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts0_pins>;
+		pinctrl-2 = <&dvb_s_ts1_pins>;
+		resets = <&clock GCLK_IDX_DEMUX &clock GCLK_IDX_ASYNC_FIFO &clock GCLK_IDX_AHB_ARB0 &clock GCLK_IDX_HIU_PARSER_TOP>;
+		reset-names = "demux", "asyncfifo", "ahbarb0", "uparsertop";
+	};
+
+	dvbfe {
+		compatible = "amlogic,dvbfe";
+		//dev_name = "dvbfe";
+		status = "okay";
+		dtv_demod0 = "Avl6211";
+		dtv_demod0_i2c_adap_id = <2>;
+		dtv_demod0_i2c_addr = <0x60>;
+ 		dtv_demod0_reset_value = <0>;
+		dtv_demod0_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_LOW>;
+		dtv_demod0_power_gpio-gpios = <&gpio GPIODV_14 GPIO_ACTIVE_LOW>;
+		fe0_dtv_demod = <0>;
+		fe0_ts = <0>;
+		fe0_dev = <0>;
+	};
+};
+
+&i2c_a {
+	status = "okay";
+};
+
+&i2c_b {
+	status = "okay";
+	rtc_hym8563{
+			compatible = "amlogic, rtc_hym8563";
+			dev_name = "rtc_hym8563";
+			status = "okay";
+		reg = <0x51>;
+	};
+};
+
+&i2c_c {
+	status = "okay";
+};
+
+&i2c_d {
+	status = "okay";
+};
+
+&pinmux {
+	dvb_p_ts0_pins:dvb_p_ts0_pins {
+		amlogic,setmask = <0x2 0x1f>;
+		amlogic,clrmask = <0x3 0x787 0x2 0xff000400>;
+		amlogic,pins = "GPIODV_0", "GPIODV_1", "GPIODV_2", "GPIODV_3", "GPIODV_4", "GPIODV_5", "GPIODV_6", "GPIODV_7", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts0_pins:dvb_s_ts0_pins {
+		amlogic,setmask = <0x2 0x17>;
+		amlogic,clrmask = <0x3 0x584 0x2 0x7000000 0x1 0x100>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts1_pins:dvb_s_ts1_pins {
+		amlogic,setmask = <0x3 0x17>;
+		amlogic,clrmask = <0x2 0xf0000 0x1 0x7>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dtv_params_pin:dtv_params_pin {
+		amlogic,clrmask = <0x1 0x38000000 0x3 0x80>;
+		amlogic,pins = "GPIODV_13", "GPIODV_14", "GPIODV_15";
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q200_1g.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q200_1g.dts
@@ -1,0 +1,8 @@
+#include "gxm_q200_2g.dts"
+
+/{
+	le-dt-id = "gxm_q200_1g";
+ 	memory@00000000 {
+		linux,usable-memory = <0x0 0x100000 0x0 0x3f000000>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q200_2g_minix_neo_u9.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q200_2g_minix_neo_u9.dts
@@ -1,0 +1,79 @@
+#include "gxm_q200_2g.dts"
+
+/{
+	le-dt-id = "gxm_q200_2g_minix_neo_u9";
+	sysled {
+		led_gpio = <&gpio GPIOAO_9 GPIO_ACTIVE_HIGH>;
+	};
+
+	rtc {
+		status = "disabled";
+	};
+
+	partitions:partitions {
+		system:system {
+			size = <0x0 0x80000000>;
+		};
+	};
+
+	unifykey {
+		keysn_8:key_8 {
+			key-type = "sha1";
+		};
+	};
+
+	amhdmitx: amhdmitx {
+		pwr-ctrl = <&pwr_ctrl>;
+	};
+
+	pwr_ctrl: pwr_ctrl{
+		pwr_5v_on = <&gpio	   GPIODV_7	   GPIO_ACTIVE_HIGH>;
+		PWR_STBY_PWREN = <&gpio	   GPIODV_4	   GPIO_ACTIVE_HIGH>;
+		vol_switch = <&gpio GPIOH_5 GPIO_ACTIVE_HIGH>;
+	};
+
+	amlogic_codec:t9015 {
+		status = "disable";
+	};
+
+	aml_m8_snd {
+		mute_gpio-gpios = <&gpio GPIODV_22 0>;
+
+		codec0: codec0 {
+			sound-dai = <&es8323>;
+		};
+	};
+};
+
+&i2c_a {
+	status = "okay";
+	es8323: es8323@10 {
+		#sound-dai-cells = <0>;
+		compatible = "es, es8323";
+		reg = <0x10>;
+	};
+};
+
+&i2c_b {
+	status = "okay";
+	
+	rtc_hym8563 {
+		compatible = "amlogic, rtc_hym8563";
+		dev_name = "rtc_hym8563";
+		status = "okay";
+		reg = <0x51>;
+		interrupts = <0 64 1>;
+		gpio-rtc-irq = <&gpio	   GPIODV_3	   GPIO_ACTIVE_HIGH>;
+	};
+
+	minix_mcu{
+		compatible = "amlogic,minix_mcu";
+		status = "okay";
+		reg = <0x15>;
+	};
+
+	minix_mcu_isp{
+		compatible = "amlogic,minix_mcu_isp";
+		reg = <0x35>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q200_3g.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q200_3g.dts
@@ -1,0 +1,8 @@
+#include "gxm_q200_2g.dts"
+
+/{
+	le-dt-id = "gxm_q200_3g";
+	memory@00000000 {
+		linux,usable-memory = <0x0 0x100000 0x0 0xbf000000>;
+	};
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q200_k3_pro.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q200_k3_pro.dts
@@ -1,0 +1,84 @@
+#include "gxm_q200_2g.dts"
+
+/{
+	le-dt-id = "gxm_q200_k3_pro";
+	memory@00000000 {
+		linux,usable-memory = <0x0 0x100000 0x0 0xbf000000>;
+	};
+
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "dvb";
+		ts0 = "parallel";
+		ts0_control = <0x0>;
+		ts0_invert = <0x0>;
+		fec_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIODV_11 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "p_ts0", "s_ts0", "s_ts1";
+		pinctrl-0 = <&dvb_p_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts0_pins>;
+		pinctrl-2 = <&dvb_s_ts1_pins>;
+		resets = <&clock GCLK_IDX_DEMUX &clock GCLK_IDX_ASYNC_FIFO &clock GCLK_IDX_AHB_ARB0 &clock GCLK_IDX_HIU_PARSER_TOP>;
+		reset-names = "demux", "asyncfifo", "ahbarb0", "uparsertop";
+	};
+
+	dvbfe {
+		compatible = "amlogic,dvbfe";
+		//dev_name = "dvbfe";
+		status = "okay";
+		dtv_demod0 = "Avl6211";
+		dtv_demod0_i2c_adap_id = <2>;
+		dtv_demod0_i2c_addr = <0x60>;
+		dtv_demod0_reset_value = <0>;
+		dtv_demod0_reset_gpio-gpios = <&gpio GPIODV_13 GPIO_ACTIVE_LOW>;
+		dtv_demod0_power_gpio-gpios = <&gpio GPIODV_14 GPIO_ACTIVE_LOW>;
+		fe0_dtv_demod = <0>;
+		fe0_ts = <0>;
+		fe0_dev = <0>;
+	};
+};
+
+&pinmux {
+	dvb_p_ts0_pins:dvb_p_ts0_pins {
+		amlogic,setmask = <0x2 0x1f>;
+		amlogic,clrmask = <0x3 0x787 0x2 0xff000400>;
+		amlogic,pins = "GPIODV_0", "GPIODV_1", "GPIODV_2", "GPIODV_3", "GPIODV_4", "GPIODV_5", "GPIODV_6", "GPIODV_7", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts0_pins:dvb_s_ts0_pins {
+		amlogic,setmask = <0x2 0x17>;
+		amlogic,clrmask = <0x3 0x584 0x2 0x7000000 0x1 0x100>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dvb_s_ts1_pins:dvb_s_ts1_pins {
+		amlogic,setmask = <0x3 0x17>;
+		amlogic,clrmask = <0x2 0xf0000 0x1 0x7>;
+		amlogic,pins = "GPIODV_0", "GPIODV_8", "GPIODV_9", "GPIODV_10";
+	};
+
+	dtv_params_pin:dtv_params_pin {
+		amlogic,clrmask = <0x1 0x38000000 0x3 0x80>;
+		amlogic,pins = "GPIODV_13", "GPIODV_14", "GPIODV_15";
+	};
+};
+
+&i2c_a {
+	status = "okay";
+};
+
+&i2c_b {
+	status = "okay";
+};
+
+&i2c_c {
+	status = "okay";
+};
+
+&i2c_d {
+	status = "okay";
+};
+
+&efuse {
+	status = "ok";
+};

--- a/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q201_3g.dts
+++ b/projects/Amlogic/packages/aml-s9xx-device-trees/sources/gxm_q201_3g.dts
@@ -1,0 +1,8 @@
+#include "gxm_q201_2g.dts"
+
+/{
+	le-dt-id = "gxm_q201_3g";
+	memory@00000000 {
+		linux,usable-memory = <0x0 0x100000 0x0 0xbf000000>;
+	};
+};


### PR DESCRIPTION
This package contains overlays for various device dtb's for the Generic S905/S912 build.

It allows for easier modification and also supports updating via update.sh.