### PR TITLE
systemd: persist persistent timer stamps

### DIFF
--- a/packages/sysutils/systemd/patches/systemd-0200-persist-persistent-timer-stamps.patch
+++ b/packages/sysutils/systemd/patches/systemd-0200-persist-persistent-timer-stamps.patch
@@ -1,0 +1,30 @@
+From c1bcb16c35724404d30fab53017b757c886e9ab7 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Mon, 8 Jan 2018 13:46:51 +0000
+Subject: [PATCH] timers: use a persistent filesystem for persistent timers
+
+---
+ src/core/timer.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/core/timer.c b/src/core/timer.c
+index 03935ee..bfd5c02 100644
+--- a/src/core/timer.c
++++ b/src/core/timer.c
+@@ -154,11 +154,11 @@ static int timer_setup_persistent(Timer *t) {
+ 
+         if (MANAGER_IS_SYSTEM(UNIT(t)->manager)) {
+ 
+-                r = unit_require_mounts_for(UNIT(t), "/var/lib/systemd/timers", UNIT_DEPENDENCY_FILE);
++                r = unit_require_mounts_for(UNIT(t), "/storage/.cache/systemd/timers", UNIT_DEPENDENCY_FILE);
+                 if (r < 0)
+                         return r;
+ 
+-                t->stamp_path = strappend("/var/lib/systemd/timers/stamp-", UNIT(t)->id);
++                t->stamp_path = strappend("/storage/.cache/systemd/timers/stamp-", UNIT(t)->id);
+         } else {
+                 const char *e;
+ 
+-- 
+2.14.1
+


### PR DESCRIPTION
The need for this change became evident when testing #2399.

Each time a persistent timer is run it updates it's stamp file in `/var/lib/systemd/timers` so that when the system is rebooted it can correctly recalculate the next trigger time relative to the last time the timer triggered.

Since `/var` is not persistent in LibreELEC, the persistent timers will have no stamp from previous runs so when rebooting, the trigger for a weekly timer will always be calculated as +1 week from "now", rather than +1 week from when it last ran (which may have been 6 days ago, so the timer should run tomorrow, not next week).

Without this change, some timers may never trigger unless the system is left up for weeks/months.

This does cause an issue with systems without real time clocks, as by default persistent timers will be loaded when the date/time is not set correctly, resulting in:
```
Dec 14 22:09:58 LibreELEC systemd[1]: fstrim.timer: Not using persistent file timestamp Mon 2018-01-08 14:03:51 UTC as it is in the future.
```
With this PR systems without an RTC will continue to calculate the next trigger relative to the system date (once the date/time is set).

About the only solution for this might be to ensure the persistent timer is not loaded until the network is available - but that's a timer configuration issue.
  