### PR TITLE
projects/Amlogic: kodi hdmi monitor service

### DIFF
--- a/projects/Amlogic/filesystem/usr/lib/systemd/system/kodi-aml-hdmimonitor.service
+++ b/projects/Amlogic/filesystem/usr/lib/systemd/system/kodi-aml-hdmimonitor.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Kodi Amlogic HDMI connection monitor
+After=kodi.service
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/kodi-aml-hdmimonitor.sh
+
+[Install]
+WantedBy=kodi.target

--- a/projects/Amlogic/filesystem/usr/sbin/kodi-aml-hdmimonitor.sh
+++ b/projects/Amlogic/filesystem/usr/sbin/kodi-aml-hdmimonitor.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+HDMI_UNPLUGGED=0
+while :; do
+  ! grep -q . /sys/class/amhdmitx/amhdmitx0/disp_cap &&
+    grep -q 0 /sys/class/amhdmitx/amhdmitx0/hpd_state &&
+    HDMI_UNPLUGGED=1 && sleep 2 && continue ||
+  break
+done
+[ $HDMI_UNPLUGGED = 1 ] && systemctl restart kodi


### PR DESCRIPTION
There is a race condition within Kodi on AML where if a user fails to turn their TV on before LE is booted then they are unable to probe for resolutions as some TV's will not send EDID data whilst in standby.

This service waits for the TV to become available and then restarts Kodi so the resolutions can be correctly probed and saved to the the config file