### PR TITLE
samba: use documented browseable/writeable properties not synonyms

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -60,117 +60,117 @@
   allocation roundup size = 0
 
 # Using the following configurations as a template allows you to add
-# writable shares of disks and paths under /storage
+# writeable shares of disks and paths under /storage
 
 [Update]
   path = /storage/.update
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/.update
 
 [Videos]
   path = /storage/videos
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/videos
 
 [Music]
   path = /storage/music
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/music
 
 [TV Shows]
   path = /storage/tvshows
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/tvshows
 
 [Recordings]
   path = /storage/recordings
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/recordings
 
 [Downloads]
   path = /storage/downloads
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/downloads
 
 [Pictures]
   path = /storage/pictures
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/pictures
 
 [Emulators]
   path = /storage/emulators
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/emulators
 
 [Configfiles]
   path = /storage/.config
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/.config
 
 [Userdata]
   path = /storage/.kodi/userdata
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/.kodi/userdata
 
 [Screenshots]
   path = /storage/screenshots
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/screenshots
 
 [Logfiles]
   path = /storage/logfiles
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/logfiles
   root preexec = createlog
 
 [Backup]
   path = /storage/backup
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/backup
 
 [Picons]
   path = /storage/picons
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/picons/tvh /storage/picons/vdr

--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -30,6 +30,9 @@ SAMBA_MAXPROTOCOL=SMB3
 
 . /storage/.cache/services/samba.conf
 
+# fixup synonyms
+sed -i 's/browsable/browseable/g; s/writable/writeable/g' $SMB_CONF
+
 # handle external drives
 if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
   for dir in /media/* ; do

--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -35,14 +35,14 @@ if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
   for dir in /media/* ; do
     if [ -d "$dir" ] ; then
       name=$(basename "$dir")
-      echo -e "[$name]\n  path = $dir\n  available = yes\n  browsable = yes\n  public = yes\n  writable = yes\n" >> $SMB_CONF
+      echo -e "[$name]\n  path = $dir\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_CONF
     fi
   done
 fi
 
 # Allow access to a "failed" (safe mode) Kodi installation
 if [ -d /storage/.kodi.FAILED ]; then
-  echo -e "[Kodi-Failed]\n  path = /storage/.kodi.FAILED\n  available = yes\n  browsable = yes\n  public = yes\n  writable = yes\n" >> $SMB_CONF
+  echo -e "[Kodi-Failed]\n  path = /storage/.kodi.FAILED\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_CONF
 fi
 
 ADD_CONFIG=


### PR DESCRIPTION
Not entirely sure if this is worthwhile, but it came up in [the forum](https://forum.libreelec.tv/thread/10667-cannot-connect-to-smb-after-updating-to-8-2-1-how-do-i-roll-back/?postID=77279#post77279).

We use `browseable` and `writeable` (with `e` - British English?) in the `[global]` section, but the version without `e` (`browsable`/`writable`) in the share sections. Fortunately both are valid, with or without the `e`, so this is just a cosmetic issue.

I see no good reason not to be consistent, so I'm adding the missing `e` since the properties with `e` are the documented properties in smb.conf man pages (see forum link - the properties without `e` are just synonyms, so maybe added later due to this being a common misspelling?)

The second commit replaces the synonyms with the documented properties when used in any custom config.