### PR TITLE
mesa/xf86-video-intel: bump to 17.3.2/028c946

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="mesa"
-PKG_VERSION="17.3.0"
-PKG_SHA256="29a0a3a6c39990d491a1a58ed5c692e596b3bfc6c01d0b45e0b787116c50c6d9"
+PKG_VERSION="17.3.2"
+PKG_SHA256="e2844a13f2d6f8f24bee65804a51c42d8dc6ae9c36cff7ee61d0940e796d64c6"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="xf86-video-intel"
-PKG_VERSION="028c946"
-PKG_SHA256="f868f6dad81d8c220755c5cbb343463be1f6e44343c334ac1954a48061fd7063"
+PKG_VERSION="26f5406"
+PKG_SHA256="8393ec70f45e9a243de7e6d085b1fa02aa3933c8ac9c72ccd83ce2d890052a5d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="http://intellinuxgraphics.org/"


### PR DESCRIPTION
xf86-video-intel adds Coffeelake support, various sna fixes.