### PR TITLE
release: initial backports and updates for LE 8.2.3

### DIFF
--- a/packages/linux-drivers/intel_nuc_led/package.mk
+++ b/packages/linux-drivers/intel_nuc_led/package.mk
@@ -1,0 +1,45 @@
+################################################################################
+#      This file is part of LibreELEC - https://LibreELEC.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="intel_nuc_led"
+PKG_VERSION="fedb38e"
+PKG_ARCH="x86_64"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/milesp20/intel_nuc_led/"
+PKG_URL="https://github.com/milesp20/intel_nuc_led/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Intel NUC7i[x]BN and NUC6CAY LED Control for Linux"
+PKG_LONGDESC="Intel NUC7i[x]BN and NUC6CAY LED Control for Linux"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make KDIR=$(kernel_path)
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/modules/$(get_module_dir)/$PKG_NAME
+    cp *.ko $INSTALL/usr/lib/modules/$(get_module_dir)/$PKG_NAME
+}

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -69,5 +69,6 @@ makeinstall_target() {
   done
 
   # The following file is installed by brcmfmac_sdio-firmware-rpi
-  rm -fr $FW_TARGET_DIR/brcm/brcmfmac43430-sdio.bin
+  rm -fr $FW_TARGET_DIR/brcm/brcmfmac43430*-sdio.bin
+  rm -fr $FW_TARGET_DIR/brcm/brcmfmac43455*-sdio.bin
 }

--- a/packages/linux-firmware/wlan-firmware/package.mk
+++ b/packages/linux-firmware/wlan-firmware/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wlan-firmware"
-PKG_VERSION="34a47d9"
+PKG_VERSION="cfc1842"
 PKG_ARCH="any"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/wlan-firmware"

--- a/packages/linux/patches/default-rpi/linux-999-revert-softirq-let-ksoftirqd-do-its-job.patch
+++ b/packages/linux/patches/default-rpi/linux-999-revert-softirq-let-ksoftirqd-do-its-job.patch
@@ -1,0 +1,54 @@
+From 3364d0056328b93fb10ab929ae99933af9e304ad Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Thu, 4 Jan 2018 19:56:05 +0000
+Subject: [PATCH] Revert "softirq: Let ksoftirqd do its job"
+
+See: https://forum.libreelec.tv/thread/4235-dvb-issue-since-le-switched-to-kernel-4-9-x/?postID=75965#post75965
+---
+ kernel/softirq.c | 16 +---------------
+ 1 file changed, 1 insertion(+), 15 deletions(-)
+
+diff --git a/kernel/softirq.c b/kernel/softirq.c
+index 4e09821..58bb6f6 100644
+--- a/kernel/softirq.c
++++ b/kernel/softirq.c
+@@ -77,17 +77,6 @@ static void wakeup_softirqd(void)
+ 		wake_up_process(tsk);
+ }
+ 
+-/*
+- * If ksoftirqd is scheduled, we do not want to process pending softirqs
+- * right now. Let ksoftirqd handle this at its own rate, to get fairness.
+- */
+-static bool ksoftirqd_running(void)
+-{
+-	struct task_struct *tsk = __this_cpu_read(ksoftirqd);
+-
+-	return tsk && (tsk->state == TASK_RUNNING);
+-}
+-
+ /*
+  * preempt_count and SOFTIRQ_OFFSET usage:
+  * - preempt_count is changed by SOFTIRQ_OFFSET on entering or leaving
+@@ -324,7 +313,7 @@ asmlinkage __visible void do_softirq(void)
+ 
+ 	pending = local_softirq_pending();
+ 
+-	if (pending && !ksoftirqd_running())
++	if (pending)
+ 		do_softirq_own_stack();
+ 
+ 	local_irq_restore(flags);
+@@ -351,9 +340,6 @@ void irq_enter(void)
+ 
+ static inline void invoke_softirq(void)
+ {
+-	if (ksoftirqd_running())
+-		return;
+-
+ 	if (!force_irqthreads) {
+ #ifdef CONFIG_HAVE_IRQ_EXIT_ON_IRQ_STACK
+ 		/*
+-- 
+2.14.1
+

--- a/packages/linux/patches/default/linux-999-revert-softirq-let-ksoftirqd-do-its-job.patch
+++ b/packages/linux/patches/default/linux-999-revert-softirq-let-ksoftirqd-do-its-job.patch
@@ -1,0 +1,54 @@
+From 3364d0056328b93fb10ab929ae99933af9e304ad Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Thu, 4 Jan 2018 19:56:05 +0000
+Subject: [PATCH] Revert "softirq: Let ksoftirqd do its job"
+
+See: https://forum.libreelec.tv/thread/4235-dvb-issue-since-le-switched-to-kernel-4-9-x/?postID=75965#post75965
+---
+ kernel/softirq.c | 16 +---------------
+ 1 file changed, 1 insertion(+), 15 deletions(-)
+
+diff --git a/kernel/softirq.c b/kernel/softirq.c
+index 4e09821..58bb6f6 100644
+--- a/kernel/softirq.c
++++ b/kernel/softirq.c
+@@ -77,17 +77,6 @@ static void wakeup_softirqd(void)
+ 		wake_up_process(tsk);
+ }
+ 
+-/*
+- * If ksoftirqd is scheduled, we do not want to process pending softirqs
+- * right now. Let ksoftirqd handle this at its own rate, to get fairness.
+- */
+-static bool ksoftirqd_running(void)
+-{
+-	struct task_struct *tsk = __this_cpu_read(ksoftirqd);
+-
+-	return tsk && (tsk->state == TASK_RUNNING);
+-}
+-
+ /*
+  * preempt_count and SOFTIRQ_OFFSET usage:
+  * - preempt_count is changed by SOFTIRQ_OFFSET on entering or leaving
+@@ -324,7 +313,7 @@ asmlinkage __visible void do_softirq(void)
+ 
+ 	pending = local_softirq_pending();
+ 
+-	if (pending && !ksoftirqd_running())
++	if (pending)
+ 		do_softirq_own_stack();
+ 
+ 	local_irq_restore(flags);
+@@ -351,9 +340,6 @@ void irq_enter(void)
+ 
+ static inline void invoke_softirq(void)
+ {
+-	if (ksoftirqd_running())
+-		return;
+-
+ 	if (!force_irqthreads) {
+ #ifdef CONFIG_HAVE_IRQ_EXIT_ON_IRQ_STACK
+ 		/*
+-- 
+2.14.1
+

--- a/packages/linux/patches/default/linux-999.20-i915-pm-Be-less-agressive-with-clockfreq-changes-on-Bay-Trail.patch
+++ b/packages/linux/patches/default/linux-999.20-i915-pm-Be-less-agressive-with-clockfreq-changes-on-Bay-Trail.patch
@@ -1,0 +1,89 @@
+From 28ad70a06fb84fe63cd036970db2561b2fd1562b Mon Sep 17 00:00:00 2001
+From: Hans de Goede <hdegoede@redhat.com>
+Date: Sun, 5 Nov 2017 16:51:23 +0100
+Subject: [PATCH v3 1/2] i915: pm: Be less agressive with clockfreq changes on
+ Bay Trail
+
+Bay Trail devices are known to hang when changing the frequency often,
+this is discussed in great length in:
+https://bugzilla.kernel.org/show_bug.cgi?id=109051
+
+Commit 6067a27d1f01 ("drm/i915: Avoid tweaking evaluation thresholds
+on Baytrail v3") is an attempt to workaround this. Several users in
+bko109051 report that an earlier version of this patch, v1:
+https://bugzilla.kernel.org/attachment.cgi?id=251471
+
+Works better for them and they still see hangs with the merged v3.
+
+Comparing the 2 versions shows that they are indeed not equivalent,
+v1 not only skips writing the GEN6_RP* registers from valleyview_set_rps,
+as v3 does. It also contained these modifications to i915_irq.c:
+
+     if (pm_iir & GEN6_PM_RP_DOWN_EI_EXPIRED) {
+         if (!vlv_c0_above(dev_priv,
+                   &dev_priv->rps.down_ei, &now,
+-                  dev_priv->rps.down_threshold))
++                  VLV_RP_DOWN_EI_THRESHOLD))
+             events |= GEN6_PM_RP_DOWN_THRESHOLD;
+         dev_priv->rps.down_ei = now;
+     }
+
+     if (pm_iir & GEN6_PM_RP_UP_EI_EXPIRED) {
+         if (vlv_c0_above(dev_priv,
+                  &dev_priv->rps.up_ei, &now,
+-                 dev_priv->rps.up_threshold))
++                 VLV_RP_UP_EI_THRESHOLD))
+             events |= GEN6_PM_RP_UP_THRESHOLD;
+         dev_priv->rps.up_ei = now;
+     }
+
+Which use less aggressive up/down thresholds, which results in less
+GEN6_PM_RP_*_THRESHOLD events and thus in less calls to intel_set_rps() ->
+valleyview_set_rps() -> vlv_punit_write(PUNIT_REG_GPU_FREQ_REQ).
+With the last call being the likely cause of the hang.
+
+This commit hardcodes the threshold_up and _down values for Bay Trail to
+less aggressive values, reducing the amount of clock frequency changes,
+thus avoiding the hangs some people are still seeing with the merged fix.
+
+Buglink: https://bugzilla.kernel.org/show_bug.cgi?id=109051
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+---
+ drivers/gpu/drm/i915/i915_reg.h | 3 +++
+ drivers/gpu/drm/i915/intel_pm.c | 5 ++++-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_reg.h b/drivers/gpu/drm/i915/i915_reg.h
+index 68a58cce6ab1..2561af075ebb 100644
+--- a/drivers/gpu/drm/i915/i915_reg.h
++++ b/drivers/gpu/drm/i915/i915_reg.h
+@@ -1355,6 +1355,9 @@ enum i915_power_well_id {
+ #define 	VLV_BIAS_CPU_125_SOC_875 (6 << 2)
+ #define 	CHV_BIAS_CPU_50_SOC_50 (3 << 2)
+ 
++#define VLV_RP_UP_EI_THRESHOLD			90
++#define VLV_RP_DOWN_EI_THRESHOLD		70
++
+ /* vlv2 north clock has */
+ #define CCK_FUSE_REG				0x8
+ #define  CCK_FUSE_HPLL_FREQ_MASK		0x3
+diff --git a/drivers/gpu/drm/i915/intel_pm.c b/drivers/gpu/drm/i915/intel_pm.c
+index 01966b89be14..177b6caa0a38 100644
+--- a/drivers/gpu/drm/i915/intel_pm.c
++++ b/drivers/gpu/drm/i915/intel_pm.c
+@@ -6096,8 +6096,11 @@ static void gen6_set_rps_thresholds(struct drm_i915_private *dev_priv, u8 val)
+ 	/* When byt can survive without system hang with dynamic
+ 	 * sw freq adjustments, this restriction can be lifted.
+ 	 */
+-	if (IS_VALLEYVIEW(dev_priv))
++	if (IS_VALLEYVIEW(dev_priv)) {
++		threshold_up = VLV_RP_UP_EI_THRESHOLD;
++		threshold_down = VLV_RP_DOWN_EI_THRESHOLD;
+ 		goto skip_hw_write;
++	}
+ 
+ 	I915_WRITE(GEN6_RP_UP_EI,
+ 		   GT_INTERVAL_FROM_US(dev_priv, ei_up));
+-- 
+2.14.3
+

--- a/packages/linux/patches/default/linux-999.21-intel_idle:-Disable-C6N-and-C6S-on-Bay-Trail.patch
+++ b/packages/linux/patches/default/linux-999.21-intel_idle:-Disable-C6N-and-C6S-on-Bay-Trail.patch
@@ -1,0 +1,53 @@
+From 945d0eb39d8920854c72ecb743c07d54b738cf7f Mon Sep 17 00:00:00 2001
+From: Hans de Goede <hdegoede@redhat.com>
+Date: Thu, 9 Nov 2017 14:21:24 +0100
+Subject: [PATCH v3 2/2] intel_idle: Disable C6N and C6S on Bay Trail
+
+It seems that Bay Trail SoCs sometimes have issues waking from C6,
+a lot of users even report Bay Trail devices only being stable
+when passing intel_idle.max_cstate=1 to the kernel.
+
+This commits disables the C6 states while leaving the C7 states
+available so that the cores can still reach deep sleep states.
+
+There are several indicators that this is part of the solution for
+all the users who need to pass intel_idle.max_cstate=1:
+
+1) The "VLP52 EOI Transactions May Not be Sent if Software
+   Enters Core C6 During an Interrupt Service Routine" errata.
+
+2) Several users who need intel_idle.max_cstate=1 indicate in bko109051
+   (which has over 800 comments!) that using a shell script which
+   disables C6N and C6S through sysfs allows them to remove
+   intel_idle.max_cstate=1 and still have a stable system which does
+   use the C7 states for power-saving.
+
+BugLink: https://bugzilla.kernel.org/show_bug.cgi?id=109051
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+---
+ drivers/idle/intel_idle.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/idle/intel_idle.c b/drivers/idle/intel_idle.c
+index 5dc7ea4b6bc4..fe05984c9e81 100644
+--- a/drivers/idle/intel_idle.c
++++ b/drivers/idle/intel_idle.c
+@@ -221,6 +221,7 @@ static struct cpuidle_state byt_cstates[] = {
+ 		.flags = MWAIT2flg(0x58) | CPUIDLE_FLAG_TLB_FLUSHED,
+ 		.exit_latency = 300,
+ 		.target_residency = 275,
++		.disabled = true,
+ 		.enter = &intel_idle,
+ 		.enter_s2idle = intel_idle_s2idle, },
+ 	{
+@@ -229,6 +230,7 @@ static struct cpuidle_state byt_cstates[] = {
+ 		.flags = MWAIT2flg(0x52) | CPUIDLE_FLAG_TLB_FLUSHED,
+ 		.exit_latency = 500,
+ 		.target_residency = 560,
++		.disabled = true,
+ 		.enter = &intel_idle,
+ 		.enter_s2idle = intel_idle_s2idle, },
+ 	{
+-- 
+2.14.3
+

--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="12c5f24"
+PKG_VERSION="f3bf1f2"
 PKG_ARCH="any"
 PKG_LICENSE="prop."
 PKG_SITE="https://libreelec.tv"

--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -60,117 +60,117 @@
   allocation roundup size = 0
 
 # Using the following configurations as a template allows you to add
-# writable shares of disks and paths under /storage
+# writeable shares of disks and paths under /storage
 
 [Update]
   path = /storage/.update
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/.update
 
 [Videos]
   path = /storage/videos
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/videos
 
 [Music]
   path = /storage/music
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/music
 
 [TV Shows]
   path = /storage/tvshows
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/tvshows
 
 [Recordings]
   path = /storage/recordings
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/recordings
 
 [Downloads]
   path = /storage/downloads
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/downloads
 
 [Pictures]
   path = /storage/pictures
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/pictures
 
 [Emulators]
   path = /storage/emulators
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/emulators
 
 [Configfiles]
   path = /storage/.config
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/.config
 
 [Userdata]
   path = /storage/.kodi/userdata
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/.kodi/userdata
 
 [Screenshots]
   path = /storage/screenshots
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/screenshots
 
 [Logfiles]
   path = /storage/logfiles
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/logfiles
   root preexec = createlog
 
 [Backup]
   path = /storage/backup
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/backup
 
 [Picons]
   path = /storage/picons
   available = yes
-  browsable = yes
+  browseable = yes
   public = yes
-  writable = yes
+  writeable = yes
   root preexec = mkdir -p /storage/picons/tvh /storage/picons/vdr

--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -38,7 +38,7 @@ if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
   for dir in /media/* ; do
     if [ -d "$dir" ] ; then
       name=$(basename "$dir")
-      echo -e "[$name]\n  path = $dir\n  available = yes\n  browsable = yes\n  public = yes\n  writable = yes\n" >> $SMB_CONF
+      echo -e "[$name]\n  path = $dir\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_CONF
     fi
   done
 fi

--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -30,6 +30,9 @@ SAMBA_MAXPROTOCOL=SMB3
 
 . /storage/.cache/services/samba.conf
 
+# fixup synonyms
+sed -i 's/browsable/browseable/g; s/writable/writeable/g' $SMB_CONF
+
 # handle external drives
 if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
   for dir in /media/* ; do

--- a/packages/sysutils/busybox/scripts/pastebinit
+++ b/packages/sysutils/busybox/scripts/pastebinit
@@ -1,26 +1,25 @@
 #!/bin/sh
 
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-#
-# wrapper for curl, posting to the sprunge.us pastebin
-# reads from stdin if called without an argument
-#
-
-cat "$@" | curl -F 'sprunge=<-' http://sprunge.us
+if [ -n "${PASTEUSR}" -a "${PASTEPWD}" ]; then
+  cat "$@" | curl -F 'f:1=<-' ${PASTEUSR}:${PASTEPWD}@ix.io
+else
+  cat "$@" | curl -F 'f:1=<-' http://ix.io
+fi

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -85,4 +85,4 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm_sta media_build"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm_sta media_build intel_nuc_led"


### PR DESCRIPTION
I wasn't planning to make another LE 8.2 release but the Leia Alpha milestone has moved to April and the demise of sprunge.us is complicating support in the forums. As we're doing a release we can cherry-pick some other low-risk changes that solve problems, e.g. the kernel softirq change revert to resolve USB/DVB issues since 4.9 kernel, and recent Intel Baytrail fixes.

NB: I have no plan to look at the mess of spectre/meltdown changes because the patches require proper testing and the issue is moot on LE where the console access needed to exploit means you are already the root user.

I'll leave the PR open for a few days in case other staff have changes to pick/include.