### PR TITLE
tvheadend42: manage dtv scan tables through package

### DIFF
--- a/packages/addons/addon-depends/tvh-dtv-scan-tables/package.mk
+++ b/packages/addons/addon-depends/tvh-dtv-scan-tables/package.mk
@@ -1,0 +1,30 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="tvh-dtv-scan-tables"
+PKG_VERSION="7af1ed5"
+PKG_SHA256="000f1301e3b67c14ceae535ece4e5af6fe7c6f7436bac8e09deffb92f8c6fd3b"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.tvheadend.org"
+PKG_URL="https://github.com/tvheadend/dtv-scan-tables/archive/$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="dtv-scan-tables-${PKG_VERSION}*"
+PKG_SHORTDESC="Tvheadend DTV scan tables"
+PKG_LONGDESC="Tvheadend DTV scan tables"
+PKG_TOOLCHAIN="manual"
+

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -20,13 +20,13 @@ PKG_NAME="tvheadend42"
 PKG_VERSION="ceaf330"
 PKG_SHA256="c6b3b366136d9e86630cb2ebd2cab823448d0eeb02ef15e72bc0accd8dc9d923"
 PKG_VERSION_NUMBER="4.2.4-23"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"
 PKG_URL="https://github.com/tvheadend/tvheadend/archive/$PKG_VERSION.tar.gz"
 PKG_SOURCE_DIR="tvheadend-${PKG_VERSION}*"
-PKG_DEPENDS_TARGET="toolchain avahi curl dvb-apps ffmpegx libdvbcsa libiconv openssl pngquant:host Python2:host"
+PKG_DEPENDS_TARGET="toolchain avahi curl dvb-apps ffmpegx libdvbcsa libiconv openssl pngquant:host Python2:host tvh-dtv-scan-tables"
 PKG_SECTION="service"
 PKG_SHORTDESC="Tvheadend: a TV streaming server for Linux"
 PKG_LONGDESC="Tvheadend ($PKG_VERSION_NUMBER): is a TV streaming server for Linux supporting DVB-S/S2, DVB-C, DVB-T/T2, IPTV, SAT>IP, ATSC and ISDB-T"
@@ -91,6 +91,7 @@ post_unpack() {
 }
 
 pre_configure_target() {
+  cp -a $(get_build_dir tvh-dtv-scan-tables) $PKG_BUILD/data/dvb-scan
 # fails to build in subdirs
   cd $PKG_BUILD
   rm -rf .$TARGET_NAME

--- a/packages/addons/service/tvheadend42/patches/tvheadend42-001-dont-download-scan-tables.patch
+++ b/packages/addons/service/tvheadend42/patches/tvheadend42-001-dont-download-scan-tables.patch
@@ -1,0 +1,47 @@
+diff --git a/Makefile b/Makefile
+index 963c8ac..e1ac7e3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -731,7 +731,6 @@ clean:
+ .PHONY: distclean
+ distclean: clean
+ 	rm -rf ${ROOTDIR}/build.*
+-	rm -rf ${ROOTDIR}/data/dvb-scan
+ 	rm -f ${ROOTDIR}/.config.mk
+ 
+ # Create version
+@@ -877,9 +876,6 @@ ffmpeg_rebuild:
+ 
+ # linuxdvb git tree
+ $(ROOTDIR)/data/dvb-scan/.stamp:
+-	@echo "Receiving data/dvb-scan from https://github.com/tvheadend/dtv-scan-tables.git#tvheadend"
+-	@rm -rf $(ROOTDIR)/data/dvb-scan/*
+-	@$(ROOTDIR)/support/getmuxlist $(ROOTDIR)/data/dvb-scan
+ 	@touch $@
+ 
+ .PHONY: check_dvb_scan
+diff --git a/configure b/configure
+index 58c951c..86080c4 100755
+--- a/configure
++++ b/configure
+@@ -647,18 +647,8 @@ if enabled_or_auto imagecache; then
+ fi
+ 
+ #
+-# DVB scan
+-#
+-if enabled dvbscan; then
+-  printf "${TAB}" "fetching dvb-scan files ..."
+-  "${ROOTDIR}/support/getmuxlist"
+-  if [ $? -ne 0 ]; then
+-    echo "fail"
+-    check_bin git || echo "FATAL: git binary not found (install the git package)"
+-    die "Failed to fetch dvb-scan data (use --disable-dvbscan)"
+-  fi
+-  echo "ok"
+-fi
++# DVB scan is managed via external package and always enabled
++#
+ 
+ #
+ # epoll


### PR DESCRIPTION
Currently tvheadend git clones the head of dtv-scan-tables repository on each (re)build into it's build dir.

This creates unnecessary traffic and makes the build non-reproducible (since the head of dvb-scan-tables can change between builds) and error-prone - builds can fail if github is temporarily down.

So dtv-scan-tables via an addon-depends package and simply copy it over to the tvheadend build dir during builds

Note: this is only compile-tested so far