### PR TITLE
Add support for FD628 display 

### DIFF
--- a/packages/linux-drivers/amlogic/fd628-aml/package.mk
+++ b/packages/linux-drivers/amlogic/fd628-aml/package.mk
@@ -1,0 +1,55 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="fd628-aml"
+PKG_VERSION="f8bd53c"
+PKG_SHA256="cf117c8512d7ecf624e1fd8c4a72264c17927637d8e9b191c0a611163a0a2b8f"
+PKG_ARCH="arm aarch64"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/tanixbox/tx3mini_linux_fd628"
+PKG_URL="https://github.com/tanixbox/tx3mini_linux_fd628/archive/$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="tx3mini_linux_fd628-$PKG_VERSION*"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_SECTION="driver"
+PKG_SHORTDESC="fd628-aml: Driver for Amlogic FD628 display"
+PKG_LONGDESC="fd628-aml: Driver for Amlogic FD628 display"
+
+PKG_TOOLCHAIN="manual"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make -C $(kernel_path) M=$PKG_BUILD/driver
+
+  make FD628Service
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+    find $PKG_BUILD/ -name \*.ko -not -path '*/\.*' -exec cp {} $INSTALL/$(get_full_module_dir)/$PKG_NAME \;
+
+  mkdir -p $INSTALL/usr/sbin
+    cp -P FD628Service $INSTALL/usr/sbin
+}
+
+post_install() {
+  enable_service fd628.service
+}

--- a/packages/linux-drivers/amlogic/fd628-aml/sources/Makefile
+++ b/packages/linux-drivers/amlogic/fd628-aml/sources/Makefile
@@ -1,0 +1,6 @@
+default:
+	obj-m += driver/aml_fd628.o
+	$(MAKE) modules
+
+FD628Service: FD628Service.c
+	$(CC) $(CFLAGS) -Wall -w -o $@ $^ -lm -lpthread

--- a/packages/linux-drivers/amlogic/fd628-aml/system.d/fd628.service
+++ b/packages/linux-drivers/amlogic/fd628-aml/system.d/fd628.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Amlogic FD628 Service
+ConditionPathExists=/proc/device-tree/fd628_dev
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/modprobe aml_fd628
+ExecStart=/usr/sbin/FD628Service
+RemainAfterExit=yes
+
+[Install]
+WantedBy=basic.target

--- a/projects/Amlogic/devices/S905/options
+++ b/projects/Amlogic/devices/S905/options
@@ -2,7 +2,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS gpu-aml"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS gpu-aml fd628-aml"
 
   # additional packages to install:
   # Space separated list is supported,


### PR DESCRIPTION
This PR adds support for the FD628 display in some S905 devices. This driver and the associated service is dependent on fd628_dev existing in the device tree (dts) for it to work.

Tested on Tanix TX3 mini

Todo:
- [ ] Add service to light up additional icons