### PR TITLE
amlogic: Set colorspace to avoid no HDMI signal with non-4K output modes

### DIFF
--- a/projects/Amlogic/initramfs/platform_init
+++ b/projects/Amlogic/initramfs/platform_init
@@ -51,6 +51,9 @@ if [ -z "$BOOT_IMAGE" -o -z "$boot" -o -z "$disk" ]; then
   echo "$cmdline" > /proc/cmdline
 fi
 
+# Set colorspace to avoid no HDMI signal with non-4K output modes
+echo 422,8bit > /sys/class/amhdmitx/amhdmitx0/attr
+
 # Enable HDMI output if cable is connected and not already enabled by u-boot
 if [ "$(cat /sys/class/amhdmitx/amhdmitx0/hpd_state)" != "0" ] && [ "$display_mode" != "$hdmimode" ]; then
   echo "$hdmimode" > /sys/class/display/mode

--- a/projects/WeTek_Hub/initramfs/platform_init
+++ b/projects/WeTek_Hub/initramfs/platform_init
@@ -28,6 +28,9 @@ for arg in $(cat /proc/cmdline); do
   esac
 done
 
+# Set colorspace to avoid no HDMI signal with non-4K output modes
+echo 422,8bit > /sys/class/amhdmitx/amhdmitx0/attr
+
 # Enable first framebuffer
 echo 0 > /sys/class/graphics/fb0/blank
 

--- a/projects/WeTek_Play_2/initramfs/platform_init
+++ b/projects/WeTek_Play_2/initramfs/platform_init
@@ -28,6 +28,9 @@ for arg in $(cat /proc/cmdline); do
   esac
 done
 
+# Set colorspace to avoid no HDMI signal with non-4K output modes
+echo 422,8bit > /sys/class/amhdmitx/amhdmitx0/attr
+
 # Enable first framebuffer
 echo 0 > /sys/class/graphics/fb0/blank
 


### PR DESCRIPTION
Amlogic devices with the latest "Nougat" kernel will output no HDMI signal if incorrect mode/attr combination is provided. Since Kodi doesn't support setting attr, set it to the most universal value that would allow Kodi to set any output resolution.