### PR TITLE
Set the stream type to Audio.

### DIFF
--- a/packages/addons/service/librespot/source/default.py
+++ b/packages/addons/service/librespot/source/default.py
@@ -99,10 +99,11 @@ class Player(xbmc.Player):
    def onPlayBackStopped(self):
       systemctl('restart')
 
-   def play(self):
+   def play(self, artist, track):
       if not self.isPlaying() and xbmcaddon.Addon().getSetting('ls_O') == 'Kodi':
          suspendSink('0')
          listitem = xbmcgui.ListItem(xbmcaddon.Addon().getAddonInfo('name'))
+         listitem.addStreamInfo('audio',{'codec': 'mp3'})
          listitem.setArt({'thumb': xbmcaddon.Addon().getAddonInfo('icon')})
          super(Player, self).play(self.ITEM, listitem)
          del listitem


### PR DESCRIPTION
Used by 3rd party software (ie: domoticz,...) to get status of Kodi, without that
kodi isn't seen as playing.