### PR TITLE
Amlogic: Enable Hauppauge dvb driver addon

### DIFF
--- a/packages/linux-driver-addons/dvb/hauppauge/package.mk
+++ b/packages/linux-driver-addons/dvb/hauppauge/package.mk
@@ -19,6 +19,7 @@
 PKG_NAME="hauppauge"
 PKG_VERSION="f5a5e5e"
 PKG_SHA256="6a3167c9990fa96838f4746861edb4d4e656739ea08d4f993e54becb9f2e9ab2"
+PKG_REV="100"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://git.linuxtv.org/media_build.git"
@@ -30,10 +31,15 @@ PKG_SECTION="driver.dvb"
 PKG_LONGDESC="DVB drivers for Hauppauge"
 
 PKG_IS_ADDON="yes"
+PKG_IS_KERNEL_PKG="yes"
 PKG_ADDON_IS_STANDALONE="yes"
 PKG_ADDON_NAME="DVB drivers for Hauppauge"
 PKG_ADDON_TYPE="xbmc.service"
 PKG_ADDON_VERSION="${ADDON_VERSION}.${PKG_REV}"
+
+if [ $LINUX = "amlogic-3.14" -o $LINUX = "amlogic-3.10" ]; then
+  PKG_PATCH_DIRS="amlogic"
+fi
 
 pre_make_target() {
   export KERNEL_VER=$(get_module_dir)

--- a/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-01-add-AML-specific-to-backports.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-01-add-AML-specific-to-backports.patch
@@ -1,0 +1,12 @@
+--- a/backports/backports.txt
++++ b/backports/backports.txt
+@@ -27,6 +25,9 @@ add api_version.patch
+ add drx39xxj.patch
+ add temp_revert.patch
+ add hauppauge.patch
++add linux-301-AML-videobuf-resource.patch
++add linux-302-AML-amlogic-video-dev.patch
++add linux-303-AML-meson-ir.patch
+ 
+ [4.10.255]
+ add v4.10_sched_signal.patch

--- a/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-02-media_build-fix.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-02-media_build-fix.patch
@@ -1,0 +1,46 @@
+diff --git a/v4l/compat.h b/v4l/compat.h
+index 1696726..0765fcc 100644
+--- a/v4l/compat.h
++++ b/v4l/compat.h
+@@ -1588,7 +1588,7 @@ static inline __s32 sign_extend32(__u32 value, int index)
+ #endif
+ 
+ #ifdef NEED_WRITEL_RELAXED
+-#define writel_relaxed writel
++// #define writel_relaxed writel
+ #endif
+ 
+ #ifdef NEED_GET_USER_PAGES_UNLOCKED
+diff --git a/v4l/versions.txt b/v4l/versions.txt
+index d110820..5391d5b 100644
+--- a/v4l/versions.txt
++++ b/v4l/versions.txt
+@@ -1,6 +1,8 @@
+ # Use this for stuff for drivers that don't compile
+ [9.255.255]
++VIDEO_S5C73M3
++VIDEO_IMX274
+ INTEL_ATOMISP
+ VIDEO_DW9714
+ 
+ [4.13.0]
+@@ -94,7 +96,6 @@ VIDEO_OV5645
+ [3.6.0]
+ # needs include/linux/sizes.h
+ VIDEO_M5MOLS
+-VIDEO_S5C73M3
+ # needs dma_mmap_coherent and sg_alloc_table_from_pages.
+ VIDEOBUF2_DMA_CONTIG 
+ 
+--- a/v4l/scripts/make_config_compat.pl	2017-12-03 20:47:44.000000000 +0100
++++ b/v4l/scripts/make_config_compat.pl	2017-12-09 01:25:44.250345535 +0100
+@@ -700,7 +700,7 @@
+ 	check_files_for_func("to_of_node", "NEED_TO_OF_NODE", "include/linux/of.h");
+ 	check_files_for_func("is_of_node", "NEED_IS_OF_NODE", "include/linux/of.h");
+ 	check_files_for_func("skb_put_data", "NEED_SKB_PUT_DATA", "include/linux/skbuff.h");
+-	check_files_for_func("pm_runtime_get_if_in_use", "NEED_PM_RUNTIME_GET", "include/linux/pm_runtime.h");
++#	check_files_for_func("pm_runtime_get_if_in_use", "NEED_PM_RUNTIME_GET", "include/linux/pm_runtime.h");
+ 	check_files_for_func("KEY_APPSELECT", "NEED_KEY_APPSELECT", "include/uapi/linux/input-event-codes.h");
+ 	check_files_for_func("PCI_DEVICE_SUB", "NEED_PCI_DEVICE_SUB", "include/linux/pci.h");
+ 	check_files_for_func("annotate_reachable", "NEED_ANNOTATE_REACHABLE", "include/linux/compiler.h");
+--

--- a/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-03-media_build-frame_vector_workaround.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-03-media_build-frame_vector_workaround.patch
@@ -1,0 +1,14 @@
+diff --git a/v4l/Makefile b/v4l/Makefile
+index 04027c2..02edc70 100644
+--- a/v4l/Makefile
++++ b/v4l/Makefile
+@@ -92,9 +92,6 @@ ifneq ($(filter $(no-makefile-media-targets), $(MAKECMDGOALS)),)
+ endif
+ 
+ makefile-mm := 1
+-ifeq ($(wildcard ../linux/mm/frame_vector.c),)
+-	makefile-mm := 0
+-endif
+ 
+ # If version not yet detected, we can't create/have these files yet
+ ifeq ($(KERNELRELEASE),)

--- a/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-04-AML-hacks.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-04-AML-hacks.patch
@@ -1,0 +1,17 @@
+diff -Naur crazycat-2017-11-13.orig/linux/Makefile crazycat-2017-11-13/linux/Makefile
+--- a/v4l/Makefile	2017-12-03 20:47:44.000000000 +0100
++++ b/v4l/Makefile	2017-12-20 09:48:15.516826488 +0100
+@@ -371,6 +371,12 @@
+ 	./scripts/fix_kconfig.pl
+ 
+ stagingconfig:: $(obj)/.version
++	mkdir -p ../linux/drivers/media/amlogic/
++	# Copy amlvideodri module
++	cp -a "$(SRCDIR)/drivers/amlogic/video_dev" "../linux/drivers/media/amlogic"
++	sed -i 's,common/,,g; s,"trace/,",g' `find "../linux/drivers/media/amlogic/video_dev/" -type f`
++	# Copy videobuf-res module
++	cp -a "$(SRCDIR)/drivers/media/v4l2-core/videobuf-res.c" "../linux/drivers/media/v4l2-core/"
+ 	@$(MAKE) -C ../linux apply_patches
+ 	./scripts/make_kconfig.pl $(OUTDIR) $(SRCDIR) 1 1
+ 	./scripts/fix_kconfig.pl
+--

--- a/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-05-compat_h-fix.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-05-compat_h-fix.patch
@@ -1,0 +1,11 @@
+--- a/v4l/compat.h
++++ b/v4l/compat.h
+@@ -1456,7 +1456,6 @@ 
+ #endif
+ 
+ #ifdef NEED_SMP_MB_AFTER_ATOMIC
+-#define smp_mb__after_atomic smp_mb__after_clear_bit
+ #endif
+ 
+ #ifdef NEED_DEVM_KMALLOC_ARRAY
+

--- a/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-301-AML-videobuf-resource.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-301-AML-videobuf-resource.patch
@@ -1,0 +1,25 @@
+diff -Naur a/drivers/media/v4l2-core/Kconfig b/drivers/media/v4l2-core/Kconfig
+--- a/drivers/media/v4l2-core/Kconfig	2017-01-23 18:15:27.000000000 +0100
++++ b/drivers/media/v4l2-core/Kconfig	2017-04-26 20:41:40.645650738 +0200
+@@ -73,6 +73,10 @@
+ 	depends on HAS_DMA
+ 	select VIDEOBUF_GEN
+ 
++config VIDEOBUF_RESOURCE
++	select VIDEOBUF_GEN
++	tristate
++
+ config VIDEOBUF_DVB
+ 	tristate
+ 	select VIDEOBUF_GEN
+diff -Naur a/drivers/media/v4l2-core/Makefile b/drivers/media/v4l2-core/Makefile
+--- a/drivers/media/v4l2-core/Makefile	2017-01-23 18:15:27.000000000 +0100
++++ b/drivers/media/v4l2-core/Makefile	2017-04-26 20:25:05.615327055 +0200
+@@ -33,6 +33,7 @@
+ obj-$(CONFIG_VIDEOBUF_DMA_CONTIG) += videobuf-dma-contig.o
+ obj-$(CONFIG_VIDEOBUF_VMALLOC) += videobuf-vmalloc.o
+ obj-$(CONFIG_VIDEOBUF_DVB) += videobuf-dvb.o
++obj-$(CONFIG_VIDEOBUF_RESOURCE) += videobuf-res.o
+ 
+ obj-$(CONFIG_VIDEOBUF2_CORE) += videobuf2-core.o videobuf2-v4l2.o
+ obj-$(CONFIG_VIDEOBUF2_MEMOPS) += videobuf2-memops.o

--- a/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-302-AML-amlogic-video-dev.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-302-AML-amlogic-video-dev.patch
@@ -1,0 +1,45 @@
+diff --git a/drivers/media/Kconfig b/drivers/media/Kconfig
+index 3512316..26f73fe 100644
+--- a/drivers/media/Kconfig
++++ b/drivers/media/Kconfig
+@@ -235,5 +235,6 @@ source "drivers/media/i2c/Kconfig"
+ source "drivers/media/spi/Kconfig"
+ source "drivers/media/tuners/Kconfig"
+ source "drivers/media/dvb-frontends/Kconfig"
++source "drivers/media/amlogic/Kconfig"
+ 
+ endif # MEDIA_SUPPORT
+diff --git a/drivers/media/Makefile b/drivers/media/Makefile
+index d87ccb8..e30c645 100644
+--- a/drivers/media/Makefile
++++ b/drivers/media/Makefile
+@@ -34,3 +34,4 @@ obj-y += rc/
+ obj-y += common/ platform/ pci/ usb/ mmc/ firewire/ spi/
+ obj-$(CONFIG_VIDEO_DEV) += radio/
+ 
++obj-y += amlogic/
+diff --git a/drivers/media/amlogic/Kconfig b/drivers/media/amlogic/Kconfig
+new file mode 100644
+index 0000000..5203702
+--- /dev/null
++++ b/drivers/media/amlogic/Kconfig
+@@ -0,0 +1,8 @@
++#
++# Amlogic driver configuration
++#
++menu "Amlogic Device Drivers"
++
++source "drivers/media/amlogic/video_dev/Kconfig"
++
++endmenu
+diff --git a/drivers/media/amlogic/Makefile b/drivers/media/amlogic/Makefile
+new file mode 100644
+index 0000000..049cb81
+--- /dev/null
++++ b/drivers/media/amlogic/Makefile
+@@ -0,0 +1,5 @@
++##########################################
++########## Amlogic Drivers ###############
++##########################################
++
++obj-$(CONFIG_V4L_AMLOGIC_VIDEO) += video_dev/

--- a/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-303-AML-meson-ir.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-303-AML-meson-ir.patch
@@ -1,0 +1,47 @@
+diff -Naur a/drivers/media/rc/Kconfig b/drivers/media/rc/Kconfig
+--- a/drivers/media/rc/Kconfig	2017-01-23 18:15:27.000000000 +0100
++++ b/drivers/media/rc/Kconfig	2017-04-26 11:38:26.462658281 +0200
+@@ -227,7 +227,6 @@
+ config IR_MESON
+ 	tristate "Amlogic Meson IR remote receiver"
+ 	depends on RC_CORE
+-	depends on ARCH_MESON || COMPILE_TEST
+ 	---help---
+ 	   Say Y if you want to use the IR remote receiver available
+ 	   on Amlogic Meson SoCs.
+diff -Naur a/drivers/media/rc/meson-ir.c b/drivers/media/rc/meson-ir.c
+--- a/drivers/media/rc/meson-ir.c	2017-01-23 18:15:27.000000000 +0100
++++ b/drivers/media/rc/meson-ir.c	2017-04-26 11:41:08.501085408 +0200
+@@ -20,6 +20,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/spinlock.h>
+ #include <linux/bitfield.h>
++#include <linux/pinctrl/consumer.h>
+ 
+ #include <media/rc-core.h>
+ 
+@@ -113,6 +114,7 @@
+ 	const char *map_name;
+ 	struct meson_ir *ir;
+ 	int irq, ret;
++	struct pinctrl *pinctrl;
+ 
+ 	ir = devm_kzalloc(dev, sizeof(struct meson_ir), GFP_KERNEL);
+ 	if (!ir)
+@@ -159,6 +161,15 @@
+ 		return ret;
+ 	}
+ 
++	if (of_get_property(node, "pinctrl-names", NULL)) {
++		pinctrl = devm_pinctrl_get_select_default(dev);
++		if (IS_ERR(pinctrl)) {
++			dev_err(dev, "failed to get pinctrl\n");
++			ret = PTR_ERR(pinctrl);
++			return ret;
++		}
++	}
++
+ 	ret = devm_request_irq(dev, irq, meson_ir_irq, 0, NULL, ir);
+ 	if (ret) {
+ 		dev_err(dev, "failed to request irq\n");
+


### PR DESCRIPTION
This PR enable building Hauppauge dvb drivers addon for Amlogic devices and is complementary to @Raybuntu PR2405.