### PR TITLE
buildsystem: avoid if/then/else boiler plate when accessing hierarchy [RFC]

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -228,7 +228,7 @@ get_pkg_directory() {
 get_pkg_variable() {
   if [ -n "$1" -a -n "$2" ] ; then
     cd $ROOT
-    . config/options $1
+    . config/options $1 &>/dev/null
     echo "${!2}"
   fi
 }
@@ -244,6 +244,64 @@ listcontains() {
 
 target_has_feature() {
   listcontains "$TARGET_FEATURES" "$1"
+}
+
+# find path for matching file or directory, searching standard directory hierarchy, using optional default
+# if a path is located it will be set in FOUND_PATH and exit code will be 0.
+find_path() {
+  local test_func="$1" search="$2" default="$3"
+  local dir match wildcard=0 ftype
+
+  # support wildcard matches
+  [[ $search =~ \* || $search =~ \? ]] && wildcard=1
+
+  [ "$test_func" = "-f" ] && ftype="file" || ftype="dir"
+
+  for dir in $PROJECT_DIR/$PROJECT/devices/$DEVICE/packages/$PKG_NAME \
+             $PROJECT_DIR/$PROJECT/devices/$DEVICE \
+             $PROJECT_DIR/$PROJECT/packages/$PKG_NAME \
+             $PROJECT_DIR/$PROJECT \
+             $DISTRO_DIR/$DISTRO/packages/$PKG_NAME \
+             $DISTRO_DIR/$DISTRO \
+             $PKG_DIR \
+             ; do
+    # ignore directories with missing DEVICE or PKG_NAME components
+    [[ $dir =~ /packages/$ ]] && continue
+    [[ $dir =~ /devices/$ ]] && continue
+    [[ $dir =~ /devices//packages/$PKG_NAME$ ]] && continue
+
+    if [ $wildcard -eq 1 ]; then
+      ls $dir/$search 1>/dev/null 2>&1 && match="$dir/$search" && break
+    else
+      [ $test_func "$dir/$search" ] && match="$dir/$search" && break
+    fi
+  done
+
+  if [ -z "$match" -a -n "$default" ]; then
+    if [[ $default =~ \* || $default =~ \? ]]; then
+      ls $default 1>/dev/null 2>&1 && match="$default"
+    else
+      [ $test_func "$default" ] && match="$default"
+    fi
+  fi
+
+  if [ -n "$match" ]; then
+    FOUND_PATH="$match"
+    [ "${VERBOSE_FIND_PATH,,}" = "yes" ] && echo "find_path: Searching for $ftype: \"$search\", found: \"$FOUND_PATH\"" >&2
+    return 0
+  else
+    unset FOUND_PATH
+    [ "${VERBOSE_FIND_PATH,,}" = "yes" ] && echo "find_path: Searching for $ftype: \"$search\" - not found" >&2
+    return 1
+  fi
+}
+
+find_file_path() {
+  find_path -f "$1" "$2"
+}
+
+find_dir_path() {
+  find_path -d "$1" "$2"
 }
 
 install_binary_addon() {

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -143,17 +143,11 @@ post_makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/samba
     cp $PKG_DIR/scripts/samba-config $INSTALL/usr/lib/samba
 
-  mkdir -p $INSTALL/etc/samba
-  if [ -n "$DEVICE" -a -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/smb.conf ]; then
-    cp $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/smb.conf $INSTALL/etc/samba
-  elif [ -f $PROJECT_DIR/$PROJECT/config/smb.conf ]; then
-    cp $PROJECT_DIR/$PROJECT/config/smb.conf $INSTALL/etc/samba
-  elif [ -f $DISTRO_DIR/$DISTRO/config/smb.conf ]; then
-    cp $DISTRO_DIR/$DISTRO/config/smb.conf $INSTALL/etc/samba
-  else
-    cp $PKG_DIR/config/smb.conf $INSTALL/etc/samba
+  if find_file_path config/smb.conf; then
+    mkdir -p $INSTALL/etc/samba
+      cp ${FOUND_PATH} $INSTALL/etc/samba
     mkdir -p $INSTALL/usr/config
-      cp $PKG_DIR/config/smb.conf $INSTALL/usr/config/samba.conf.sample
+      cp $INSTALL/etc/samba/smb.conf $INSTALL/usr/config/samba.conf.sample
   fi
 
   if [ "$DEVTOOLS" = "yes" ]; then

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -53,18 +53,6 @@ if [ "$NFS_SUPPORT" = yes ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET rpcbind"
 fi
 
-if [ -f $PROJECT_DIR/$PROJECT/busybox/busybox-target.conf ]; then
-  BUSYBOX_CFG_FILE_TARGET=$PROJECT_DIR/$PROJECT/busybox/busybox-target.conf
-else
-  BUSYBOX_CFG_FILE_TARGET=$PKG_DIR/config/busybox-target.conf
-fi
-
-if [ -f $PROJECT_DIR/$PROJECT/busybox/busybox-init.conf ]; then
-  BUSYBOX_CFG_FILE_INIT=$PROJECT_DIR/$PROJECT/busybox/busybox-init.conf
-else
-  BUSYBOX_CFG_FILE_INIT=$PKG_DIR/config/busybox-init.conf
-fi
-
 pre_build_target() {
   mkdir -p $PKG_BUILD/.$TARGET_NAME
   cp -RP $PKG_BUILD/* $PKG_BUILD/.$TARGET_NAME
@@ -92,7 +80,8 @@ configure_host() {
 
 configure_target() {
   cd $PKG_BUILD/.$TARGET_NAME
-    cp $BUSYBOX_CFG_FILE_TARGET .config
+    find_file_path config/busybox-target.conf
+    cp $FOUND_PATH .config
 
     # set install dir
     sed -i -e "s|^CONFIG_PREFIX=.*$|CONFIG_PREFIX=\"$INSTALL/usr\"|" .config
@@ -129,7 +118,8 @@ configure_target() {
 
 configure_init() {
   cd $PKG_BUILD/.$TARGET_NAME-init
-    cp $BUSYBOX_CFG_FILE_INIT .config
+    find_file_path config/busybox-init.conf
+    cp $FOUND_PATH .config
 
     # set install dir
     sed -i -e "s|^CONFIG_PREFIX=.*$|CONFIG_PREFIX=\"$INSTALL/usr\"|" .config
@@ -234,12 +224,8 @@ makeinstall_init() {
     touch $INSTALL/etc/fstab
     ln -sf /proc/self/mounts $INSTALL/etc/mtab
 
-  if [ -n "$DEVICE" -a -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/initramfs/platform_init ]; then
-    cp $PROJECT_DIR/$PROJECT/devices/$DEVICE/initramfs/platform_init $INSTALL
-  elif [ -f $PROJECT_DIR/$PROJECT/initramfs/platform_init ]; then
-    cp $PROJECT_DIR/$PROJECT/initramfs/platform_init $INSTALL
-  fi
-  if [ -f $INSTALL/platform_init ]; then
+  if find_file_path initramfs/platform_init; then
+    cp ${FOUND_PATH} $INSTALL
     chmod 755 $INSTALL/platform_init
   fi
 

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -36,29 +36,10 @@ makeinstall_target() {
     cp -PRv fixup_x.dat $INSTALL/usr/share/bootloader/fixup.dat
     cp -PRv start_x.elf $INSTALL/usr/share/bootloader/start.elf
 
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/dt-blob.bin ]; then
-      cp -PRv $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/dt-blob.bin $INSTALL/usr/share/bootloader
-    fi
+    find_file_path config/dt-blob.bin && cp -PRv $FOUND_PATH $INSTALL/usr/share/bootloader
 
     cp -PRv $PKG_DIR/scripts/update.sh $INSTALL/usr/share/bootloader
 
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/distroconfig.txt ]; then
-      cp -PRv $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/distroconfig.txt $INSTALL/usr/share/bootloader
-    elif [ -f $PROJECT_DIR/$PROJECT/config/distroconfig.txt ]; then
-      cp -PRv $PROJECT_DIR/$PROJECT/config/distroconfig.txt $INSTALL/usr/share/bootloader
-    elif [ -f $DISTRO_DIR/$DISTRO/config/distroconfig.txt ]; then
-      cp -PRv $DISTRO_DIR/$DISTRO/config/distroconfig.txt $INSTALL/usr/share/bootloader
-    else
-      cp -PRv $PKG_DIR/files/3rdparty/bootloader/distroconfig.txt $INSTALL/usr/share/bootloader
-    fi
-
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/config.txt ]; then
-      cp -PRv $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/config.txt $INSTALL/usr/share/bootloader
-    elif [ -f $PROJECT_DIR/$PROJECT/config/config.txt ]; then
-      cp -PRv $PROJECT_DIR/$PROJECT/config/config.txt $INSTALL/usr/share/bootloader
-    elif [ -f $DISTRO_DIR/$DISTRO/config/config.txt ]; then
-      cp -PRv $DISTRO_DIR/$DISTRO/config/config.txt $INSTALL/usr/share/bootloader
-    else
-      cp -PRv $PKG_DIR/files/3rdparty/bootloader/config.txt $INSTALL/usr/share/bootloader
-    fi
+    find_file_path config/distroconfig.txt $PKG_DIR/files/3rdparty/bootloader/distroconfig.txt && cp -PRv ${FOUND_PATH} $INSTALL/usr/share/bootloader
+    find_file_path config/config.txt $PKG_DIR/files/3rdparty/bootloader/config.txt && cp -PRv ${FOUND_PATH} $INSTALL/usr/share/bootloader
 }

--- a/packages/tools/installer/package.mk
+++ b/packages/tools/installer/package.mk
@@ -35,11 +35,8 @@ post_install() {
         -i  $INSTALL/usr/bin/installer
 
   mkdir -p $INSTALL/etc
-    if [ -f $PROJECT_DIR/$PROJECT/installer/installer.conf ]; then
-      cp $PROJECT_DIR/$PROJECT/installer/installer.conf $INSTALL/etc
-    else
-      cp $PKG_DIR/config/installer.conf $INSTALL/etc
-    fi
+    find_file_path config/installer.conf
+    cp ${FOUND_PATH} $INSTALL/etc
     sed -e "s/@SYSTEM_SIZE@/$SYSTEM_SIZE/g" \
         -e "s/@SYSTEM_PART_START@/$SYSTEM_PART_START/g" \
         -e "s/@EXTLINUX_PARAMETERS@/$EXTLINUX_PARAMETERS/g" \

--- a/packages/tools/plymouth-lite/package.mk
+++ b/packages/tools/plymouth-lite/package.mk
@@ -43,17 +43,6 @@ makeinstall_init() {
     cp ply-image $INSTALL/usr/bin
 
   mkdir -p $INSTALL/splash
-    if [ -f $PROJECT_DIR/$PROJECT/splash/splash.conf ]; then
-      cp $PROJECT_DIR/$PROJECT/splash/splash.conf $INSTALL/splash
-      cp $PROJECT_DIR/$PROJECT/splash/*.png $INSTALL/splash
-    elif ls $PROJECT_DIR/$PROJECT/splash/splash-*.png 1>/dev/null 2>&1; then
-      cp $PROJECT_DIR/$PROJECT/splash/splash-*.png $INSTALL/splash
-    elif [ -f $DISTRO_DIR/$DISTRO/splash/splash.conf ]; then
-      cp $DISTRO_DIR/$DISTRO/splash/splash.conf $INSTALL/splash
-      cp $DISTRO_DIR/$DISTRO/splash/*.png $INSTALL/splash
-    elif ls $DISTRO_DIR/$DISTRO/splash/splash-*.png 1>/dev/null 2>&1; then
-      cp $DISTRO_DIR/$DISTRO/splash/splash-*.png $INSTALL/splash
-    else
-      cp $PKG_DIR/splash/splash-*.png $INSTALL/splash
-    fi
+    find_file_path splash/splash.conf && cp ${FOUND_PATH} $INSTALL/splash
+    find_file_path "splash/splash-*.png" && cp ${FOUND_PATH} $INSTALL/splash
 }

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -55,27 +55,15 @@ makeinstall_target() {
 
     # Only install u-boot.img et al when building a board specific image
     if [ -n "$UBOOT_SYSTEM" ]; then
-      if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/install ]; then
-        . $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/install
-      elif [ -f $PROJECT_DIR/$PROJECT/bootloader/install ]; then
-        . $PROJECT_DIR/$PROJECT/bootloader/install
-      fi
+      find_file_path bootloader/install && . ${FOUND_PATH}
     fi
 
     # Always install the update script
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/update.sh ]; then
-      cp -av $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/update.sh $INSTALL/usr/share/bootloader
-    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/update.sh ]; then
-      cp -av $PROJECT_DIR/$PROJECT/bootloader/update.sh $INSTALL/usr/share/bootloader
-    fi
+    find_file_path bootloader/update.sh && cp -av ${FOUND_PATH} $INSTALL/usr/share/bootloader
 
     # Always install the canupdate script
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/canupdate.sh ]; then
-      cp -av $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/canupdate.sh $INSTALL/usr/share/bootloader
-    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/canupdate.sh ]; then
-      cp -av $PROJECT_DIR/$PROJECT/bootloader/canupdate.sh $INSTALL/usr/share/bootloader
-    fi
-    if [ -f $INSTALL/usr/share/bootloader/canupdate.sh ]; then
+    if find_file_path bootloader/canupdate.sh; then
+      cp -av ${FOUND_PATH} $INSTALL/usr/share/bootloader
       sed -e "s/@PROJECT@/${DEVICE:-$PROJECT}/g" \
           -i $INSTALL/usr/share/bootloader/canupdate.sh
     fi

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -156,11 +156,8 @@ post_makeinstall_target() {
   fi
 
   mkdir -p $INSTALL/etc/X11
-    if [ -f $PROJECT_DIR/$PROJECT/xorg/xorg.conf ]; then
-      cp $PROJECT_DIR/$PROJECT/xorg/xorg.conf $INSTALL/etc/X11
-    elif [ -f $PKG_DIR/config/xorg.conf ]; then
-      cp $PKG_DIR/config/xorg.conf $INSTALL/etc/X11
-    fi
+    find_file_path config/xorg.conf &&
+      cp $FOUND_PATH $INSTALL/etc/X11
 
   if [ ! "$DEVTOOLS" = yes ]; then
     rm -rf $INSTALL/usr/bin/cvt

--- a/projects/Amlogic/devices/LePotato/packages/u-boot/package.mk
+++ b/projects/Amlogic/devices/LePotato/packages/u-boot/package.mk
@@ -48,26 +48,13 @@ makeinstall_target() {
   mkdir -p $INSTALL/usr/share/bootloader
 
     # Only install u-boot.img et al when building a board specific image
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/install ]; then
-      . $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/install
-    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/install ]; then
-      . $PROJECT_DIR/$PROJECT/bootloader/install
-    fi
+    find_file_path bootloader/install && . ${FOUND_PATH}
 
     # Always install the update script
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/update.sh ]; then
-      cp -av $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/update.sh $INSTALL/usr/share/bootloader
-    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/update.sh ]; then
-      cp -av $PROJECT_DIR/$PROJECT/bootloader/update.sh $INSTALL/usr/share/bootloader
-    fi
+    find_file_path bootloader/update.sh && cp -av ${FOUND_PATH} $INSTALL/usr/share/bootloader
 
     cp $PKG_BUILD/fip/u-boot.bin.sd.bin $INSTALL/usr/share/bootloader/u-boot
 
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/boot.ini ]; then
-      cp -av $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/boot.ini $INSTALL/usr/share/bootloader
-    fi
-
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/config.ini ]; then
-      cp -av $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/config.ini $INSTALL/usr/share/bootloader
-    fi
+    find_file_path bootloader/boot.ini && cp -av ${FOUND_PATH} $INSTALL/usr/share/bootloader
+    find_file_path bootloader/config.ini && cp -av ${FOUND_PATH} $INSTALL/usr/share/bootloader
 }

--- a/scripts/image
+++ b/scripts/image
@@ -283,15 +283,9 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
       cp -R $BOOTLOADER_DIR/files/* $RELEASE_DIR
     fi
 
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/release ]; then
-      echo "Running $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/release"
-      . $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/release
-    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/release ]; then
-      echo "Running $PROJECT_DIR/$PROJECT/bootloader/release"
-      . $PROJECT_DIR/$PROJECT/bootloader/release
-    elif [ -f $BOOTLOADER_DIR/release ]; then
-      echo "Running $BOOTLOADER_DIR/release"
-      . $BOOTLOADER_DIR/release
+    if find_file_path bootloader/release $BOOTLOADER_DIR/release; then
+      echo "Running $FOUND_PATH"
+      . $FOUND_PATH
     fi
   fi
 

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -249,10 +249,8 @@ EOF
       mcopy -s "$LE_TMP"/extlinux ::
     fi
 
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage ]; then
-      . $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage
-    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/mkimage ]; then
-      . $PROJECT_DIR/$PROJECT/bootloader/mkimage
+    if find_file_path bootloader/mkimage; then
+      . ${FOUND_PATH}
     else
       echo "No specific mkimage script found. u-boot will not be written"
     fi


### PR DESCRIPTION
This is something that's been bugging me for a while.

Currently we use this pattern which is repeated (with minor changes) in several places:
```
  if [ -n "$DEVICE" -a -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/blah.conf ]; then
    cp $PROJECT_DIR/$PROJECT/devices/$DEVICE/config/blah.conf $INSTALL/etc
  elif [ -f $PROJECT_DIR/$PROJECT/config/blah.conf ]; then
    cp $PROJECT_DIR/$PROJECT/config/blah.conf $INSTALL/etc
  elif [ -f $DISTRO_DIR/$DISTRO/config/blah.conf ]; then
    cp $DISTRO_DIR/$DISTRO/config/blah.conf $INSTALL/etc
  else
    cp $PKG_DIR/config/blah.conf $INSTALL/etc
  fi
```

I think it would be better to use a helper function that takes care of locating the file or directory within the standard repo hierarchy (ie. project/device -> project -> distribution -> pkg etc.) so that the package doesn't have to care where the file is or might be, and packages can care less about projects, projects/devices, distros etc.

This change will eliminate almost all of this repeated code, while ensuring consistency whenever dealing with files and directories within the "standard repo hierarchy".

In terms of consistency, take this example in `buysbox`:
```
if [ -f $PROJECT_DIR/$PROJECT/busybox/busybox-target.conf ]; then
  BUSYBOX_CFG_FILE_TARGET=$PROJECT_DIR/$PROJECT/busybox/busybox-target.conf
else
  BUSYBOX_CFG_FILE_TARGET=$PKG_DIR/config/busybox-target.conf
fi
```
The project-specific config file is not being searched for in `$PROJECT_DIR/$PROJECT/packages/busybox/config` which I would argue is a more appropriate location than `$PROJECT_DIR/$PROJECT/busybox`.

With this change we will use the same hierarchy in `$PROJECT_DIR` (and `$PROJECT/devices/$DEVICE` and `$DISTRO_DIR/$DISTRO`) that is used in `$PKG_DIR`, which should help avoid confusion and errors.

In the `busybox` case, the config file (if ever created) could be located in:
```
$PROJECT_DIR/$PROJECT/packages/busybox/config/busybox-target.conf
```
which is analogous to the package directory location:
```
$PKG_DIR/config/busybox-target.conf
```

`installer` is updated in a similar way to `busybox`.

Another slight change is to `plymouth-lite` which now installs only `splash-*.png` images - image using any other name are ignored. By changing the logic for `plymouth-lite` it's also now possible to install a project specific config file, while continuing to use the standard distribution splash images.

`samba` will now install `samba.conf.sample` regardless of where `smb.conf` is found (see [comment](https://github.com/LibreELEC/LibreELEC.tv/pull/2328#discussion_r163250761)).

Some packages (eg. `xorg-server`, `u-boot`, `busybox`, etc.) were only searching in two or three locations (eg. `$PROJECT` and `$PKG_DIR`) but now they will be searching in all of the "standard" locations (including `$DISTRO`), which may have unexepected consequences if a config file is ever added in a location that wasn't being searched prior to this change. I don't think this is a problem - it just means we need to be more careful/aware of where we put files.

I've implemented the function in a slightly unusual way, in that it sets a global variable with the found path rather than echoing the found path (if no path is found the variable is left unset). This is to avoid using a temporary variable at the call site, or calling the function twice (once to determine if the path exists with `-n "$(find_file_path ...)"`, and then again to process the path - each time forking a new process).

I've added optional logging whenever `find_path` is executed. I've made it optional as junk echoed while sourcing a package may be unexpected by some scripts, eg. `repo-tool`. Enable logging with `VERBOSE_FIND_PATH=yes` on the command line (or in `$HOME/.libreelec/options`).