### PR TITLE
fd628-aml: update driver source to support multiple devices

### DIFF
--- a/packages/linux-drivers/amlogic/fd628-aml/package.mk
+++ b/packages/linux-drivers/amlogic/fd628-aml/package.mk
@@ -17,13 +17,13 @@
 ################################################################################
 
 PKG_NAME="fd628-aml"
-PKG_VERSION="f8bd53c"
-PKG_SHA256="cf117c8512d7ecf624e1fd8c4a72264c17927637d8e9b191c0a611163a0a2b8f"
+PKG_VERSION="6993a86"
+PKG_SHA256="5eb30d485d23c9be427528b3604d564565194f759281677c2b1b66419e6edc15"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/tanixbox/tx3mini_linux_fd628"
-PKG_URL="https://github.com/tanixbox/tx3mini_linux_fd628/archive/$PKG_VERSION.tar.gz"
-PKG_SOURCE_DIR="tx3mini_linux_fd628-$PKG_VERSION*"
+PKG_URL="https://github.com/arthur-liberman/linux_fd628/archive/$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="linux_fd628-$PKG_VERSION*"
 PKG_DEPENDS_TARGET="toolchain linux"
 PKG_NEED_UNPACK="$LINUX_DEPENDS"
 PKG_SECTION="driver"


### PR DESCRIPTION
This PR is to update the source URL for the FD628 VFD driver, one of the forum users has modified the original Tanix source to make the driver compatible with multiple devices via changes to the device tree sources.

Tested and confirmed working on 3 devices so far.

Tanix TX3 Mini S905W
Sunvell T95M S905X
Vorke Z6 S912

@kszaq @Raybuntu @arthur-liberman