### PR TITLE
scripts/create_addon: add-on overwrite support

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -49,9 +49,13 @@ pack_addon() {
     ADDON_INSTALL_DIR="$TARGET_IMG/$ADDONS/$ADDON_VERSION/${DEVICE:-$PROJECT}/$TARGET_ARCH/$PKG_ADDON_ID"
     ADDONVER="$(xmlstarlet sel -t -v "/addon/@version" $ADDON_BUILD/$PKG_ADDON_ID/addon.xml)"
 
-    if [ -f $ADDON_INSTALL_DIR/$PKG_ADDON_ID-$ADDONVER.zip ] ; then
-      echo "*** WARNING: $PKG_ADDON_ID-$ADDONVER.zip already exists. not overwriting it ***"
-      return 0
+    if [ -f $ADDON_INSTALL_DIR/$PKG_ADDON_ID-$ADDONVER.zip ]; then
+      if [ "$ADDON_OVERWRITE" = "yes" ]; then
+        rm $ADDON_INSTALL_DIR/$PKG_ADDON_ID-$ADDONVER.zip
+      else
+        echo "*** WARNING: $PKG_ADDON_ID-$ADDONVER.zip already exists. not overwriting it ***"
+        return 0
+      fi
     fi
     cd $ADDON_BUILD
     echo "*** compressing Addon $PKG_ADDON_ID ... ***"


### PR DESCRIPTION
`PROJECT=Generic ARCH=x86_64 ADDON_OVERWRITE=yes scripts/create_addon abc`
overwrites addon.zip instead of abort with a warning