### PR TITLE
libamcodec: don't build amadec

### DIFF
--- a/packages/multimedia/libamcodec/package.mk
+++ b/packages/multimedia/libamcodec/package.mk
@@ -37,19 +37,16 @@ PKG_SECTION="multimedia"
 PKG_SHORTDESC="libamcodec: Interface library for Amlogic media codecs"
 PKG_LONGDESC="libamplayer: Interface library for Amlogic media codecs"
 
-make_target() {
-  make -C amavutils CC="$CC" PREFIX="$SYSROOT_PREFIX/usr"
-  mkdir -p $SYSROOT_PREFIX/usr/lib
-  cp -PR amavutils/*.so $SYSROOT_PREFIX/usr/lib
+post_unpack() {
+  sed -e "s|-lamadec||g" -i $PKG_BUILD/amcodec/Makefile
+}
 
-  make -C amadec CC="$CC" PREFIX="$SYSROOT_PREFIX/usr" CROSS_PREFIX="$TARGET_PREFIX" install
-  make -C amcodec CC="$CC" HEADERS_DIR="$SYSROOT_PREFIX/usr/include/amcodec" PREFIX="$SYSROOT_PREFIX/usr" CROSS_PREFIX="$TARGET_PREFIX" install
+make_target() {
+  mkdir -p $SYSROOT_PREFIX/usr/lib
+  make -C amcodec HEADERS_DIR="$SYSROOT_PREFIX/usr/include/amcodec" PREFIX="$SYSROOT_PREFIX/usr" install
 }
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib
-  cp -PR amavutils/*.so $INSTALL/usr/lib
-
-  make -C amadec PREFIX="$INSTALL/usr" install
   make -C amcodec HEADERS_DIR="$INSTALL/usr/include/amcodec" PREFIX="$INSTALL/usr" install
 }


### PR DESCRIPTION
We only need libamcodec for Kodi, other libs are useless.

Cherry-picked from seo's TB, thanks!