### PR TITLE
add -J flag to limit race condition during build step

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -40,6 +40,7 @@ PKG_MAKE_OPTS_INIT="ARCH=$TARGET_ARCH \
                     HOSTCC=$HOST_CC \
                     CROSS_COMPILE=$TARGET_PREFIX \
                     KBUILD_VERBOSE=1 \
+                    MAKEFLAGS="-j1" \
                     install"
 
 # nano text editor


### PR DESCRIPTION
We've been restricted to building projects with low concurrency make level due to race conditions when building busybox. This forces busy box to build with concurrency make level of 1 while the rest of the project can be built with a different level.