### PR TITLE
Amlogic: support  for AVL6862 DVB driver

### DIFF
--- a/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-01-add-AML-specific-to-backports.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-01-add-AML-specific-to-backports.patch
@@ -1,7 +1,7 @@
 diff -Naur a/backports/backports.txt b/backports/backports.txt
 --- a/backports/backports.txt	2017-12-30 22:14:58.000000000 +0200
 +++ b/backports/backports.txt	2018-02-23 13:50:01.327967293 +0200
-@@ -21,6 +21,10 @@
+@@ -21,6 +21,12 @@
  
  # All supported versions need those patches
  [9.255.255]
@@ -9,6 +9,8 @@ diff -Naur a/backports/backports.txt b/backports/backports.txt
 +add linux-302-AML-amlogic-video-dev.patch
 +add linux-303-AML-meson-ir.patch
 +add linux-304-AML-wetekplay.patch
++add linux-305-AML-dmx_h.patch
++add linux-306-AML-build-dvb-avl.patch
  add api_version.patch
  add pr_fmt.patch
  add debug.patch

--- a/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-04-AML-hacks.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-04-AML-hacks.patch
@@ -1,7 +1,7 @@
 diff -Naur a/linux/Makefile b/linux/Makefile
 --- a/linux/Makefile	2017-12-30 22:01:38.000000000 +0200
 +++ b/linux/Makefile	2018-02-23 13:25:54.025763853 +0200
-@@ -112,6 +112,17 @@
+@@ -112,6 +112,21 @@
  
  untar: linux-media.tar.bz2
  	tar xfj linux-media.tar.bz2
@@ -15,6 +15,10 @@ diff -Naur a/linux/Makefile b/linux/Makefile
 +
 +	# Copy WeTek Play DVB driver
 +	cp -a "$(SRCDIR)/drivers/amlogic/wetek" "drivers/media/amlogic"
++
++	# Copy dvb-avl driver
++	cp -a $(SRCDIR)/drivers/amlogic/dvb-avl "drivers/media"
++	echo "obj-y += dvb-avl/" >> "drivers/media/Makefile"
 +
  	-rm -f .patches_applied .linked_dir .git_log.md5
  

--- a/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-05-compat_h-fix.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-05-compat_h-fix.patch
@@ -1,0 +1,11 @@
+--- a/v4l/compat.h
++++ b/v4l/compat.h
+@@ -1456,7 +1456,6 @@ 
+ #endif
+ 
+ #ifdef NEED_SMP_MB_AFTER_ATOMIC
+-#define smp_mb__after_atomic smp_mb__after_clear_bit
+ #endif
+ 
+ #ifdef NEED_DEVM_KMALLOC_ARRAY
+

--- a/packages/linux-driver-addons/dvb/crazycat/sources/backports/linux-305-AML-dmx_h.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/sources/backports/linux-305-AML-dmx_h.patch
@@ -1,0 +1,24 @@
+--- a/include/uapi/linux/dvb/dmx.h	2017-01-23 18:15:29.000000000 +0100
++++ b/include/uapi/linux/dvb/dmx.h	2017-02-08 14:12:07.802477417 +0100
+@@ -197,6 +197,20 @@
+ 	__u32           flags;
+ };
+ 
++typedef enum dmx_source {
++	DMX_SOURCE_FRONT0 = 0,
++	DMX_SOURCE_FRONT1,
++	DMX_SOURCE_FRONT2,
++	DMX_SOURCE_FRONT3,
++	DMX_SOURCE_DVR0   = 16,
++	DMX_SOURCE_DVR1,
++	DMX_SOURCE_DVR2,
++	DMX_SOURCE_DVR3,
++	DMX_SOURCE_FRONT0_OFFSET = 100,
++	DMX_SOURCE_FRONT1_OFFSET,
++	DMX_SOURCE_FRONT2_OFFSET
++} dmx_source_t;
++
+ /**
+  * struct dmx_stc - Stores System Time Counter (STC) information.
+  *
+--

--- a/packages/linux-driver-addons/dvb/crazycat/sources/backports/linux-306-AML-build-dvb-avl.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/sources/backports/linux-306-AML-build-dvb-avl.patch
@@ -1,0 +1,39 @@
+--- a/drivers/media/dvb-avl/aml_dmx.c	2017-12-10 19:34:57.000000000 +0100
++++ b/drivers/media/dvb-avl/aml_dmx.c	2017-12-12 12:55:21.255063140 +0100
+@@ -547,7 +547,7 @@
+ 	struct dvb_demux_feed *feed = dmx->channel[f->chan_id].feed;
+ 
+ 	if (feed && feed->cb.sec)
+-		feed->cb.sec(p, sec_len, NULL, 0, f->filter, DMX_OK);
++		feed->cb.sec(p, sec_len, NULL, 0, f->filter);
+ }
+ 
+ static void hardware_match_section(struct aml_dmx *dmx,
+@@ -968,7 +968,7 @@
+ 		if (dmx->channel[2].feed && dmx->channel[2].feed->cb.ts) {
+ 			dmx->channel[2].feed->cb.ts(buffer1_virt, len1,
+ 						buffer2_virt, len2,
+-						&dmx->channel[2].feed->feed.ts, DMX_OK);
++						&dmx->channel[2].feed->feed.ts);
+ 		}
+ 	}
+ 	WRITE_MPEG_REG(PARSER_SUB_RP, rd_ptr);
+@@ -1167,7 +1167,7 @@
+ 			channel->dvr_feed->cb.ts(
+ 					(u8 *)afifo->pages+afifo->buf_read*size,
+ 					cnt*size, NULL, 0,
+-					&channel->dvr_feed->feed.ts, DMX_OK);
++					&channel->dvr_feed->feed.ts);
+ 		afifo->buf_read = 0;
+ 	}
+ 
+@@ -1186,7 +1186,7 @@
+ 			channel->dvr_feed->cb.ts(
+ 					(u8 *)afifo->pages+afifo->buf_read*size,
+ 					cnt*size, NULL, 0,
+-					&channel->dvr_feed->feed.ts, DMX_OK);
++					&channel->dvr_feed->feed.ts);
+ 		afifo->buf_read = afifo->buf_toggle;
+ 	}
+ 
+--

--- a/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
+++ b/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
@@ -54,5 +54,11 @@ unpack() {
     if [ $LINUX = "amlogic-3.14" ]; then
       cp -a "$(kernel_path)/drivers/amlogic/wetek" "$PKG_BUILD/drivers/media/amlogic"
     fi
+
+    # Copy avl6862 driver
+    cp -a $(kernel_path)/drivers/amlogic/dvb-avl "$PKG_BUILD/drivers/media"
+    if listcontains "$ADDITIONAL_DRIVERS" "avl6862-aml"; then
+      echo "obj-y += dvb-aml/" >> "$PKG_BUILD/drivers/media/Makefile"
+    fi
   fi
 }

--- a/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-01-add-AML-specific-to-backports.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-01-add-AML-specific-to-backports.patch
@@ -1,7 +1,7 @@
 diff -Naur a/backports/backports.txt b/backports/backports.txt
 --- a/backports/backports.txt	2017-12-30 22:14:58.000000000 +0200
 +++ b/backports/backports.txt	2018-02-23 13:50:01.327967293 +0200
-@@ -21,6 +21,10 @@
+@@ -21,6 +21,12 @@
  
  # All supported versions need those patches
  [9.255.255]
@@ -9,6 +9,8 @@ diff -Naur a/backports/backports.txt b/backports/backports.txt
 +add linux-302-AML-amlogic-video-dev.patch
 +add linux-303-AML-meson-ir.patch
 +add linux-304-AML-wetekplay.patch
++add linux-305-AML-dmx_h.patch
++add linux-306-AML-build-dvb-avl.patch
  add api_version.patch
  add pr_fmt.patch
  add debug.patch

--- a/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-05-compat_h-fix.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-05-compat_h-fix.patch
@@ -1,0 +1,11 @@
+--- a/v4l/compat.h
++++ b/v4l/compat.h
+@@ -1456,7 +1456,6 @@ 
+ #endif
+ 
+ #ifdef NEED_SMP_MB_AFTER_ATOMIC
+-#define smp_mb__after_atomic smp_mb__after_clear_bit
+ #endif
+ 
+ #ifdef NEED_DEVM_KMALLOC_ARRAY
+

--- a/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-305-AML-dmx_h.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-305-AML-dmx_h.patch
@@ -1,0 +1,24 @@
+--- a/include/uapi/linux/dvb/dmx.h	2017-01-23 18:15:29.000000000 +0100
++++ b/include/uapi/linux/dvb/dmx.h	2017-02-08 14:12:07.802477417 +0100
+@@ -197,6 +197,20 @@
+ 	__u32           flags;
+ };
+ 
++typedef enum dmx_source {
++	DMX_SOURCE_FRONT0 = 0,
++	DMX_SOURCE_FRONT1,
++	DMX_SOURCE_FRONT2,
++	DMX_SOURCE_FRONT3,
++	DMX_SOURCE_DVR0   = 16,
++	DMX_SOURCE_DVR1,
++	DMX_SOURCE_DVR2,
++	DMX_SOURCE_DVR3,
++	DMX_SOURCE_FRONT0_OFFSET = 100,
++	DMX_SOURCE_FRONT1_OFFSET,
++	DMX_SOURCE_FRONT2_OFFSET
++} dmx_source_t;
++
+ /**
+  * struct dmx_stc - Stores System Time Counter (STC) information.
+  *
+--

--- a/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-306-AML-build-dvb-avl.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-306-AML-build-dvb-avl.patch
@@ -1,0 +1,39 @@
+--- a/drivers/media/dvb-avl/aml_dmx.c	2017-12-10 19:34:57.000000000 +0100
++++ b/drivers/media/dvb-avl/aml_dmx.c	2017-12-12 12:55:21.255063140 +0100
+@@ -547,7 +547,7 @@
+ 	struct dvb_demux_feed *feed = dmx->channel[f->chan_id].feed;
+ 
+ 	if (feed && feed->cb.sec)
+-		feed->cb.sec(p, sec_len, NULL, 0, f->filter, DMX_OK);
++		feed->cb.sec(p, sec_len, NULL, 0, f->filter);
+ }
+ 
+ static void hardware_match_section(struct aml_dmx *dmx,
+@@ -968,7 +968,7 @@
+ 		if (dmx->channel[2].feed && dmx->channel[2].feed->cb.ts) {
+ 			dmx->channel[2].feed->cb.ts(buffer1_virt, len1,
+ 						buffer2_virt, len2,
+-						&dmx->channel[2].feed->feed.ts, DMX_OK);
++						&dmx->channel[2].feed->feed.ts);
+ 		}
+ 	}
+ 	WRITE_MPEG_REG(PARSER_SUB_RP, rd_ptr);
+@@ -1167,7 +1167,7 @@
+ 			channel->dvr_feed->cb.ts(
+ 					(u8 *)afifo->pages+afifo->buf_read*size,
+ 					cnt*size, NULL, 0,
+-					&channel->dvr_feed->feed.ts, DMX_OK);
++					&channel->dvr_feed->feed.ts);
+ 		afifo->buf_read = 0;
+ 	}
+ 
+@@ -1186,7 +1186,7 @@
+ 			channel->dvr_feed->cb.ts(
+ 					(u8 *)afifo->pages+afifo->buf_read*size,
+ 					cnt*size, NULL, 0,
+-					&channel->dvr_feed->feed.ts, DMX_OK);
++					&channel->dvr_feed->feed.ts);
+ 		afifo->buf_read = afifo->buf_toggle;
+ 	}
+ 
+--

--- a/packages/linux-drivers/amlogic/avl6862-aml/package.mk
+++ b/packages/linux-drivers/amlogic/avl6862-aml/package.mk
@@ -1,0 +1,32 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2017-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="avl6862-aml"
+PKG_VERSION="1.0"
+PKG_ARCH="arm aarch64"
+PKG_LICENSE="GPL"
+PKG_SITE="https://libreelec.tv"
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="virtual"
+PKG_SHORTDESC="avl6862-aml: Internal DVB tuner driver for Amlogic devices developed by afl1"
+PKG_LONGDESC="avl6862-aml: Internal DVB tuner driver for Amlogic devices developed by afl1"
+
+post_install() {
+  enable_service amlogic-dvb.service
+}

--- a/packages/linux-drivers/amlogic/avl6862-aml/system.d/amlogic-dvb.service
+++ b/packages/linux-drivers/amlogic/avl6862-aml/system.d/amlogic-dvb.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Amlogic DVB module loader
+ConditionPathExists=/proc/device-tree/dvbfe/dtv_demod0
+After=kernel-overlays.service
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c '[ `cat /proc/device-tree/dvbfe/dtv_demod0` = "Avl6211" ] && /sbin/modprobe aml_fe'
+
+[Install]
+WantedBy=basic.target

--- a/projects/Amlogic/devices/S905/options
+++ b/projects/Amlogic/devices/S905/options
@@ -7,7 +7,8 @@
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS ap6xxx-aml mt7601u-aml mt7603u-aml \
                         qca9377-aml RTL8189ES-aml RTL8189FS-aml RTL8723BS-aml \
-                        RTL8723DS-aml RTL8822BU-aml ssv6xxx-aml fd628-aml wetekdvb"
+                        RTL8723DS-aml RTL8822BU-aml ssv6xxx-aml fd628-aml wetekdvb \
+                        avl6862-aml"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/Amlogic/devices/S912/options
+++ b/projects/Amlogic/devices/S912/options
@@ -16,7 +16,8 @@
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS ap6xxx-aml mt7601u-aml mt7603u-aml \
                         qca9377-aml RTL8189ES-aml RTL8189FS-aml \
-                        RTL8723BS-aml RTL8723DS-aml RTL8822BU-aml ssv6xxx-aml fd628-aml"
+                        RTL8723BS-aml RTL8723DS-aml RTL8822BU-aml ssv6xxx-aml fd628-aml \
+                        avl6862-aml"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,


### PR DESCRIPTION
This PR introduces support for internal dvb in WP2 and Mecool K-series boxes.