### PR TITLE
Amlogic/Odroid_C2: Add device specific audio conf

### DIFF
--- a/projects/Amlogic/devices/Odroid_C2/filesystem/usr/share/alsa/cards/AML-M8AUDIO.conf
+++ b/projects/Amlogic/devices/Odroid_C2/filesystem/usr/share/alsa/cards/AML-M8AUDIO.conf
@@ -1,0 +1,43 @@
+#
+# Configuration for Amlogic M8 Audio
+#
+
+AML-M8AUDIO.pcm.default {
+	@args [ CARD ]
+	@args.CARD { type string }
+	type hw
+	card $CARD
+	device 0
+	format S32_LE
+}
+
+<confdir:pcm/hdmi.conf>
+
+AML-M8AUDIO.pcm.hdmi.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+		device 1
+		format S16_LE
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				interface MIXER
+				name "IEC958 Playback Default"
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+}


### PR DESCRIPTION
I've noticed some audio issues since we moved C2 to Amlogic. PR restores the previous Audio conf for C2.