### PR TITLE
dvb-tools addon bump

### DIFF
--- a/packages/addons/addon-depends/dvb-tools-depends/depends/bitstream/package.mk
+++ b/packages/addons/addon-depends/dvb-tools-depends/depends/bitstream/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="bitstream"
-PKG_VERSION="1.2"
-PKG_SHA256="ccfbb438711606de1fad881b58c8f134e2d82b4d53a88ea48f2d1bcb49ca5ad2"
+PKG_VERSION="1.3"
+PKG_SHA256="f8a90b0ae517ccb295760317f7809ff097ae220ef75b05b0fc2b813debc4a8b7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.videolan.org"

--- a/packages/addons/addon-depends/dvb-tools-depends/dvblast/package.mk
+++ b/packages/addons/addon-depends/dvb-tools-depends/dvblast/package.mk
@@ -1,41 +1,38 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
 #
-#  This Program is free software; you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2, or (at your option)
-#  any later version.
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
 #
-#  This Program is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.tv; see the file COPYING.  If not, write to
-#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
-#  http://www.gnu.org/copyleft/gpl.html
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="dvblast"
-PKG_VERSION="3.1"
-PKG_SHA256="3159e8666a3b1822aeccd01684bdcad712a0da88d758bef6b7e2c396f27fd3e0"
+PKG_VERSION="77cfaa8"
+PKG_SHA256="b78eaec73addb328384bf8acb93a1b6a6334f4fa47914f98b91b4cd4fc00b639"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.videolan.org"
-PKG_URL="http://downloads.videolan.org/pub/videolan/dvblast/${PKG_VERSION}/dvblast-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.videolan.org/projects/dvblast.html"
+PKG_URL="http://repo.or.cz/dvblast.git/snapshot/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain bitstream libev"
 PKG_SECTION="tools"
 PKG_SHORTDESC="DVBlast is a simple and powerful MPEG-2/TS demux and streaming application"
 PKG_LONGDESC="DVBlast is a simple and powerful MPEG-2/TS demux and streaming application"
-
-MAKEFLAGS="V=1"
 
 pre_configure_target() {
   export LDFLAGS="$LDFLAGS -lm"
 }
 
 makeinstall_target() {
-  : # nop
+ :
 }

--- a/packages/addons/addon-depends/dvb-tools-depends/mumudvb/package.mk
+++ b/packages/addons/addon-depends/dvb-tools-depends/mumudvb/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="mumudvb"
-PKG_VERSION="596f7db"
-PKG_SHA256="4848f61831aa4d000b5e024439acab6e06aab4dd16a950ae18275cbeb11e2c84"
+PKG_VERSION="a09373d"
+PKG_SHA256="66ef8f11a0e5795cd6408e33581a95de88a76d499e8a0d41f34880295d346efa"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mumudvb.net/"

--- a/packages/addons/addon-depends/dvb-tools-depends/w_scan/package.mk
+++ b/packages/addons/addon-depends/dvb-tools-depends/w_scan/package.mk
@@ -31,7 +31,7 @@ PKG_TOOLCHAIN="autotools"
 
 # aml 3.14 is meh
 pre_configure_target() {
-if [ "$TARGET_ARCH" = "aarch64" ]; then
+if [ $LINUX = "amlogic-3.14" -o $LINUX = "amlogic-3.10" ]; then
   sed -i 's/DVB_HEADER=0/DVB_HEADER=1/g' $PKG_BUILD/configure*
   sed -i 's/HAS_DVB_API5=0/HAS_DVB_API5=1/g' $PKG_BUILD/configure*
 fi

--- a/packages/addons/tools/dvb-tools/changelog.txt
+++ b/packages/addons/tools/dvb-tools/changelog.txt
@@ -1,5 +1,8 @@
 104
 - remove dvb-fe-tool, it's already included in the image
+- updated MuMuDVB to a09373d
+- update dvblast to 77cfaa8
+
 103
 - added blindscan-s2
 - added dvbsnoop

--- a/packages/addons/tools/dvb-tools/package.mk
+++ b/packages/addons/tools/dvb-tools/package.mk
@@ -17,11 +17,11 @@
 ################################################################################
 
 PKG_NAME="dvb-tools"
-PKG_VERSION=""
+PKG_VERSION="1.0"
 PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE=""
+PKG_SITE="https://libreelec.tv"
 PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"

--- a/packages/addons/tools/dvb-tools/source/default.py
+++ b/packages/addons/tools/dvb-tools/source/default.py
@@ -1,6 +1,6 @@
 ################################################################################
 #      This file is part of LibreELEC - https://libreelec.tv
-#      Copyright (C) 2016 Team LibreELEC
+#      Copyright (C) 2016-present Team LibreELEC
 #
 #  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
follow up pr for https://github.com/LibreELEC/LibreELEC.tv/pull/2460
- dvblast includes current upstream version and fixes HEVC, pkg url was switched to git mirror as the upstream url won't allow download with wget (https://code.videolan.org/videolan/dvblast)
- w_scan was changed to refelect changes at our build system (@Raybuntu should work I guess?)
