### PR TITLE
projects/Amlogic: don't build wetek dvb driver

### DIFF
--- a/projects/Amlogic/linux/linux.aarch64.conf
+++ b/projects/Amlogic/linux/linux.aarch64.conf
@@ -1186,7 +1186,7 @@ CONFIG_GXBB_SUSPEND=y
 #
 # WeTek Play driver
 #
-CONFIG_WETEK=m
+# CONFIG_WETEK is not set
 
 #
 # MESON MHU mailbox Support


### PR DESCRIPTION
There is no device with wetek dvb tuner in Amlogic  project.