### PR TITLE
buildsystem: add support for pre_apply_patch hook

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -650,6 +650,7 @@ print_color() {
       CLR_INFO)         clr_actual="boldgreen";;
       CLR_INSTALL)      clr_actual="boldgreen";;
       CLR_PATCH_DESC)   clr_actual="boldwhite";;
+      CLR_SKIP_PATCH)   clr_actual="boldyellow";;
       CLR_TARGET)       clr_actual="boldwhite";;
       CLR_UNPACK)       clr_actual="boldcyan";;
 

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -69,6 +69,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
   unset -f unpack
   unset -f post_unpack
   unset -f pre_patch
+  unset -f pre_apply_patch
   unset -f post_patch
 
   . $PKG_DIR/package.mk
@@ -168,6 +169,18 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     fi
 
     if [ -f "$i" ]; then
+      # if a pre_apply_patch hook is defined, pass it the path to this patch
+      # relative to the build root - if it returns 0, skip applying the patch
+      if [ "$(type -t pre_apply_patch)" = "function" ]; then
+        PATCH_PATH="${i#$ROOT/}"
+        ! pre_apply_patch || {
+          unset PATCH_PATH
+          printf "%${BUILD_INDENT}c $(print_color CLR_SKIP_PATCH "SKIP PATCH") $(print_color CLR_PATCH_DESC "${PATCH_DESC}")   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
+          continue
+        }
+        unset PATCH_PATH
+      fi
+
       printf "%${BUILD_INDENT}c $(print_color CLR_APPLY_PATCH "APPLY PATCH") $(print_color CLR_PATCH_DESC "${PATCH_DESC}")   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
       if grep -qE '^GIT binary patch$|^rename from|^rename to' $i; then
         cat $i | git apply --directory=`echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 --verbose --whitespace=nowarn --unsafe-paths >&$VERBOSE_OUT


### PR DESCRIPTION
This arose as a quick fix for `RPi` builds following PR #2382 (now fixed in PR #2473), but maybe it'd be useful more broadly.

The logic for applying patches in `scripts/unpack` is quite complex: there are patch directories per package, per package version, per architecture, per project, per device, and various combinations of each. However, it's not very easy to tell the build system to *skip* a particular patch based on arbitrary criteria. For instance, to apply several directories' worth of patches to a package's source code for all builds with the exception of one patch for `DEVICE=RPi2` builds would involve duplicating patches across a huge number of directories, which would quickly become unmaintainable.

This PR adds a new hook function, `pre_apply_patch`, designed for optional use in `package.mk` files. When the function is defined, it is called once before each patch is applied, with the (relative) path to the patch stored in `PATCH_PATH`. A decision on whether to apply the patch can be taken by returning either 0 (apply) or any other value (don't apply) from this function.* For example, the scenario I described above could be implemented as follows in `package.mk`:

```sh
pre_apply_patch() {
  # don't apply x.patch for RPi2 builds
  [ "$DEVICE" = "RPi2" -a "$PATCH_PATH" = "packages/whatever/patches/default/x.patch" ] && return 0
}
```

No changes to (and, most importantly, no duplication of) the patch files themselves would then be necessary.

----

\* I realise this is an inversion of the "0 = success, non-zero = failure" tradition, but it's the easiest way to avoid having to return 0 by default at the end of every `pre_apply_patch` hook, which would undoubtedly be easy to forget.