### PR TITLE
gcc-linaro-aarch64-linux-gnu: update to 7.2-2017.11

### DIFF
--- a/packages/lang/gcc-linaro-aarch64-linux-gnu/package.mk
+++ b/packages/lang/gcc-linaro-aarch64-linux-gnu/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="gcc-linaro-aarch64-linux-gnu"
-PKG_VERSION="7.1.1-2017.08"
-PKG_SHA256="cc61203bb1bab9b51e9631dce803be7c00b814577fd7a118113a83448bf6a833"
+PKG_VERSION="7.2.1-2017.11"
+PKG_SHA256="20181f828e1075f1a493947ff91e82dd578ce9f8638fbdfc39e24b62857d8f8d"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""
-PKG_URL="https://releases.linaro.org/components/toolchain/binaries/7.1-2017.08/aarch64-linux-gnu/gcc-linaro-${PKG_VERSION}-x86_64_aarch64-linux-gnu.tar.xz"
+PKG_URL="https://releases.linaro.org/components/toolchain/binaries/7.2-2017.11/aarch64-linux-gnu/gcc-linaro-${PKG_VERSION}-x86_64_aarch64-linux-gnu.tar.xz"
 PKG_SOURCE_DIR="gcc-linaro-${PKG_VERSION}-x86_64_aarch64-linux-gnu"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_SECTION="lang"


### PR DESCRIPTION
I need to test this new toolchain first on AML on RK.