### PR TITLE
Revert "scripts/mkimage: use helper function"

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -249,8 +249,10 @@ EOF
       mcopy -s "$LE_TMP"/extlinux ::
     fi
 
-    if find_file_path bootloader/mkimage; then
-      . ${FOUND_PATH}
+    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage ]; then
+      . $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage
+    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/mkimage ]; then
+      . $PROJECT_DIR/$PROJECT/bootloader/mkimage
     else
       echo "No specific mkimage script found. u-boot will not be written"
     fi


### PR DESCRIPTION
This reverts commit 7793bea2e9d47d979bf830c15c657c456aead2bb.

`scripts/mkimage` doesn't actually source `config/options` so doesn't have access to any helper functions and now fails with:
```
scripts/mkimage: line 252: find_file_path: command not found
```

Sourcing `config/options` may overwrite one or more of the environment variables used by `scripts/mkimage`, making it a risky proposition.

Reverting this change is the simplest/safest option.

Thanks/apologies @kszaq!