### PR TITLE
LibreELEC Repo bumps: service.libreelec.settings and brcmfmac_sdio-firmware-rpi

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="13edcc7"
-PKG_SHA256="b68626c02afc40763d183324a51922f7d990e40bc015b2ded25e65621c43c0ad"
+PKG_VERSION="c0d516c"
+PKG_SHA256="3d1d110d9454ce894217d870ec8f1a2c5b8deac15e7365fa487dc0c1fb698402"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"

--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="c8ec6f6"
-PKG_SHA256="68e15de5fcef147bca0dbeb7eea15401cfb04549d2611857c666d717f10fa297"
+PKG_VERSION="d658777"
+PKG_SHA256="f8a337bb833d8c67ab28f7d7882812570897fc81bfa876c0316ece6e91a44b43"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
`service.libreelec.settings`:

* Corrects use of sprunge.us with ix.io in Help messages (reported on Team Kodi slack).

`brcmfmac_sdio-firmware-rpi`:

* Update with latest RPi3/ZeroWH WiFi firmware after [successful testing](https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=203508)