### PR TITLE
functions: add helper function to locate linux config

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -182,6 +182,35 @@ kernel_version() {
   get_pkg_version linux
 }
 
+kernel_config_path() {
+  local cfg pkg_linux_dir pkg_linux_version config_name
+
+  # avoid infinite recursion if this is called by linux
+  if [ "$PKG_NAME" = "linux" ]; then
+    pkg_linux_version="$PKG_VERSION"
+    pkg_linux_dir="$PKG_DIR"
+  else
+    pkg_linux_version="$(get_pkg_version linux)"
+    pkg_linux_dir="$(get_pkg_directory linux)"
+  fi
+
+  config_name="linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf"
+
+  for cfg in $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/$pkg_linux_version/$config_name \
+             $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/$LINUX/$config_name \
+             $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/$config_name \
+             $PROJECT_DIR/$PROJECT/linux/$pkg_linux_version/$config_name \
+             $PROJECT_DIR/$PROJECT/linux/$LINUX/$config_name \
+             $PROJECT_DIR/$PROJECT/linux/$config_name \
+             $pkg_linux_dir/config/$pkg_linux_version/$config_name \
+             $pkg_linux_dir/config/$LINUX/$config_name \
+             $pkg_linux_dir/config/$config_name \
+             ; do
+    [[ $cfg =~ /devices//linux/ ]] && continue
+    [ -f "$cfg" ] && echo "$cfg" && break
+  done
+}
+
 # get kernel module dir
 get_module_dir() {
   if [ -n "${_CACHED_KERNEL_MODULE_DIR}" ]; then

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,32 +29,6 @@ PKG_SHORTDESC="linux26: The Linux kernel 2.6 precompiled kernel binary image and
 PKG_LONGDESC="This package contains a precompiled kernel image and the modules."
 PKG_IS_KERNEL_PKG="yes"
 
-PKG_CFG_FILE="$PKG_NAME.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf"
-if [ -n "$DEVICE" -a -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/$PKG_NAME/$PKG_VERSION/$PKG_CFG_FILE ]; then
-  PKG_KERNEL_CFG_FILE=$PROJECT_DIR/$PROJECT/devices/$DEVICE/$PKG_NAME/$PKG_VERSION/$PKG_CFG_FILE
-elif [ -n "$DEVICE" -a -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/$PKG_NAME/$LINUX/$PKG_CFG_FILE ]; then
-  PKG_KERNEL_CFG_FILE=$PROJECT_DIR/$PROJECT/devices/$DEVICE/$PKG_NAME/$LINUX/$PKG_CFG_FILE
-elif [ -n "$DEVICE" -a -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/$PKG_NAME/$PKG_CFG_FILE ]; then
-  PKG_KERNEL_CFG_FILE=$PROJECT_DIR/$PROJECT/devices/$DEVICE/$PKG_NAME/$PKG_CFG_FILE
-elif [ -f $PROJECT_DIR/$PROJECT/$PKG_NAME/$PKG_VERSION/$PKG_CFG_FILE ]; then
-  PKG_KERNEL_CFG_FILE=$PROJECT_DIR/$PROJECT/$PKG_NAME/$PKG_VERSION/$PKG_CFG_FILE
-elif [ -f $PROJECT_DIR/$PROJECT/$PKG_NAME/$LINUX/$PKG_CFG_FILE ]; then
-  PKG_KERNEL_CFG_FILE=$PROJECT_DIR/$PROJECT/$PKG_NAME/$LINUX/$PKG_CFG_FILE
-elif [ -f $PROJECT_DIR/$PROJECT/$PKG_NAME/$PKG_CFG_FILE ]; then
-  PKG_KERNEL_CFG_FILE=$PROJECT_DIR/$PROJECT/$PKG_NAME/$PKG_CFG_FILE
-elif [ -f $PKG_DIR/config/$PKG_VERSION/$PKG_CFG_FILE ]; then
-  PKG_KERNEL_CFG_FILE=$PKG_DIR/config/$PKG_VERSION/$PKG_CFG_FILE
-elif [ -f $PKG_DIR/config/$LINUX/$PKG_CFG_FILE ]; then
-  PKG_KERNEL_CFG_FILE=$PKG_DIR/config/$LINUX/$PKG_CFG_FILE
-else
-  PKG_KERNEL_CFG_FILE=$PKG_DIR/config/$PKG_CFG_FILE
-fi
-
-if [ "$DEVTOOLS" = "yes" ] && grep -q ^CONFIG_PERF_EVENTS= $PKG_KERNEL_CFG_FILE ; then
-  PKG_BUILD_PERF="yes"
-  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET binutils elfutils libunwind zlib openssl"
-fi
-
 case "$LINUX" in
   amlogic-3.10)
     PKG_VERSION="02fdb27"
@@ -79,6 +53,13 @@ case "$LINUX" in
     PKG_PATCH_DIRS="default"
     ;;
 esac
+
+PKG_KERNEL_CFG_FILE=$(kernel_config_path)
+
+if [ "$DEVTOOLS" = "yes" ] && grep -q ^CONFIG_PERF_EVENTS= $PKG_KERNEL_CFG_FILE ; then
+  PKG_BUILD_PERF="yes"
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET binutils elfutils libunwind zlib openssl"
+fi
 
 if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
   PKG_DEPENDS_HOST="$PKG_DEPENDS_HOST gcc-linaro-aarch64-linux-gnu:host"


### PR DESCRIPTION
As per title.

@HiassofT I realised while updating the linux package for this change (sorry for not noticing before!) that the $PKG_VERSION is needed to correctly determine the config path, and so `$(kernel_config_path)` must be called after we have set PKG_VERSION in the `case` statement.

This isn't a problem with #2480 as we don't currently have any PKG_VERSION-specific config paths, but could be in future, hence moving to after the `case` statement which sets PKG_VERSION.