### PR TITLE
dtc: build fdtput and fdtget

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -46,6 +46,10 @@ post_makeinstall_host() {
   touch $TOOLCHAIN/lib/$PKG_PYTHON_VERSION/site-packages/pylibfdt/__init__.py
 }
 
+pre_make_target() {
+  make clean BIN=
+}
+
 makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
   mkdir -p $INSTALL/usr/lib

--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -31,12 +31,12 @@ PKG_SHORTDESC="The Device Tree Compiler"
 PKG_LONGDESC="The Device Tree Compiler"
 
 PKG_MAKE_OPTS_HOST="dtc libfdt"
-PKG_MAKE_OPTS_TARGET="dtc libfdt"
+PKG_MAKE_OPTS_TARGET="dtc fdtput fdtget libfdt"
 
 makeinstall_host() {
   mkdir -p $TOOLCHAIN/bin
     cp -P $PKG_BUILD/dtc $TOOLCHAIN/bin
-    cp -P $PKG_BUILD/libfdt/libfdt.so $TOOLCHAIN/lib
+    cp -P $PKG_BUILD/libfdt/libfdt.so $TOOLCHAIN/lib/
 }
 
 post_makeinstall_host() {
@@ -48,5 +48,9 @@ post_makeinstall_host() {
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
+  mkdir -p $INSTALL/usr/lib
     cp -P $PKG_BUILD/dtc $INSTALL/usr/bin
+    cp -P $PKG_BUILD/fdtput $INSTALL/usr/bin/
+    cp -P $PKG_BUILD/fdtget $INSTALL/usr/bin/
+    cp -P $PKG_BUILD/libfdt/libfdt.so $INSTALL/usr/lib/
 }


### PR DESCRIPTION
I cherry-picked the change from Raybuntu's LE fork. It adds building `fdtget` and `fdtput` tools useful to modify device trees in-place.