### PR TITLE
bump arm-mem and valgrind

### DIFF
--- a/packages/debug/valgrind/package.mk
+++ b/packages/debug/valgrind/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="valgrind"
-PKG_VERSION="3.12.0"
-PKG_SHA256="67ca4395b2527247780f36148b084f5743a68ab0c850cb43e4a5b4b012cf76a1"
+PKG_VERSION="3.13.0"
+PKG_SHA256="d76680ef03f00cd5e970bbdcd4e57fb1f6df7d2e2c071635ef2be74790190c3b"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://valgrind.org/"
-PKG_URL="http://valgrind.org/downloads/$PKG_NAME-$PKG_VERSION.tar.bz2"
+PKG_URL="ftp://sourceware.org/pub/valgrind/$PKG_NAME-$PKG_VERSION.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="debug"
 PKG_SHORTDESC="A tool to help find memory-management problems in programs"

--- a/packages/devel/arm-mem/package.mk
+++ b/packages/devel/arm-mem/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="arm-mem"
-PKG_VERSION="3aee5f4"
-PKG_SHA256="c7ac6fea60c01d34e71b24065b65ad6fbef42b9b702a226a22fe4a0caff33382"
+PKG_VERSION="a3277ce"
+PKG_SHA256="f571bbc43e3670c8f52447eb885f0c561ed039bcfb692678681899d7df13b165"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/bavison/arm-mem"
@@ -29,7 +29,13 @@ PKG_SECTION="devel"
 PKG_SHORTDESC="arm-mem: ARM-accelerated versions of selected functions from string.h"
 PKG_LONGDESC="arm-mem is a ARM-accelerated versions of selected functions from string.h"
 
-PKG_MAKE_OPTS_TARGET="libarmmem.so"
+if [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ] ; then
+  PKG_LIB_ARM_MEM="libarmmem-v7l.so"
+else
+  PKG_LIB_ARM_MEM="libarmmem-v6l.so"
+fi
+
+PKG_MAKE_OPTS_TARGET="$PKG_LIB_ARM_MEM"
 
 pre_make_target() {
   export CROSS_COMPILE=$TARGET_PREFIX
@@ -42,16 +48,16 @@ make_init() {
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib
-    cp -P libarmmem.so $INSTALL/usr/lib
+    cp -P $PKG_LIB_ARM_MEM $INSTALL/usr/lib
 
   mkdir -p $INSTALL/etc
-    echo "/usr/lib/libarmmem.so" >> $INSTALL/etc/ld.so.preload
+    echo "/usr/lib/$PKG_LIB_ARM_MEM" >> $INSTALL/etc/ld.so.preload
 }
 
 makeinstall_init() {
   mkdir -p $INSTALL/usr/lib
-    cp -P libarmmem.so $INSTALL/usr/lib
+    cp -P $PKG_LIB_ARM_MEM $INSTALL/usr/lib
 
   mkdir -p $INSTALL/etc
-    echo "/usr/lib/libarmmem.so" >> $INSTALL/etc/ld.so.preload
+    echo "/usr/lib/$PKG_LIB_ARM_MEM" >> $INSTALL/etc/ld.so.preload
 }


### PR DESCRIPTION
new arm-mem library contains a fix so that it can be used with valgrind on RPi2/3. It also contains optimized memset for armv7 which can be beneficial for RPi2/3

valgrind 3.13.0 fixes unhandled instructions on RPi2/3, it's now runs on RPi2/3 fine (it won't compile on RPi1, but so didn't 3.12.0)
