### PR TITLE
Change default system partition size to 1GB

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -197,6 +197,6 @@
   ADDON_URL="$ADDON_SERVER_URL/$ADDON_PATH"
 
 # Default size of system partition, in MB, eg. 512
-  SYSTEM_SIZE=512
+  SYSTEM_SIZE=1024
 # Default system partition offset, in sectors, eg. 2048
   SYSTEM_PART_START=8192


### PR DESCRIPTION
Current RPi2 master debug builds are almost 400MB in size:
```
-rw-r--r-- 1 hias hias  15M Feb 12 13:00 LibreELEC-RPi2.arm-9.0-devel-20180212125835-r28074-g729efcd77a.kernel
-rw-r--r-- 1 hias hias 363M Feb 12 13:00 LibreELEC-RPi2.arm-9.0-devel-20180212125835-r28074-g729efcd77a.system
-rw-r--r-- 1 hias hias 382M Feb 12 13:00 LibreELEC-RPi2.arm-9.0-devel-20180212125835-r28074-g729efcd77a.tar
```
And with valgrind included they we are already above 400MB:
```
-rw-r--r-- 1 hias hias  15M Feb 12 13:07 LibreELEC-RPi2.arm-9.0-devel-20180212130551-r28074-g729efcd77a.kernel
-rw-r--r-- 1 hias hias 396M Feb 12 13:08 LibreELEC-RPi2.arm-9.0-devel-20180212130551-r28074-g729efcd77a.system
-rw-r--r-- 1 hias hias 415M Feb 12 13:08 LibreELEC-RPi2.arm-9.0-devel-20180212130551-r28074-g729efcd77a.tar
```

This means we are getting near the current 512MB default size and in the future it could get problematic for users to run debug builds.

As SD cards smaller than 16GB are getting rare and USB pendrives and SSDs of that size are a thing of the past better bump the system partition size to 1GB before this can become a problem