### PR TITLE
device-trees-amlogic updates

### DIFF
--- a/projects/Amlogic/packages/device-trees-amlogic/package.mk
+++ b/projects/Amlogic/packages/device-trees-amlogic/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="device-trees-amlogic"
-PKG_VERSION="8a3cfc7"
-PKG_SHA256="377e43f346680ae93bb08120fefaa291ce9e4e7cc2947aae0aeba674d46674b8"
+PKG_VERSION="be9bfb7"
+PKG_SHA256="f2bed01aef8067c1cc91ad0a83ed6fd6a753b964970bc01a165214743fcae561"
 PKG_LICENSE="GPL"
 PKG_URL="https://github.com/LibreELEC/device-trees-amlogic/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"

--- a/projects/Amlogic/packages/device-trees-amlogic/package.mk
+++ b/projects/Amlogic/packages/device-trees-amlogic/package.mk
@@ -30,7 +30,7 @@ make_target() {
   pushd $BUILD/linux-$(kernel_version) > /dev/null
 
   # Device trees already present in kernel tree we want to include
-  EXTRA_TREES=(gxbb_p201 gxl_p212_1g gxl_p212_2g gxm_q200_2g gxm_q201_1g gxm_q201_2g gxl_p281_1g)
+  EXTRA_TREES=(gxbb_p201 gxl_p212_1g gxl_p212_2g gxm_q200_2g gxm_q201_1g gxm_q201_2g gxl_p281_1g gxbb_p200_1G_wetek_hub gxbb_p200_2G_wetek_play_2)
 
   # Add trees to the list
   for f in ${EXTRA_TREES[@]}; do


### PR DESCRIPTION
Bump package to latest revision and also include wetek device trees in S905 image