### PR TITLE
projects/Amlogic: update.sh fix and cleanup

### DIFF
--- a/projects/Amlogic/bootloader/update.sh
+++ b/projects/Amlogic/bootloader/update.sh
@@ -38,7 +38,7 @@ fi
 for arg in $(cat /proc/cmdline); do
   case $arg in
     boot=*)
-      echo "*** updating BOOT partition label ..."
+      echo "Updating BOOT partition label..."
       boot="${arg#*=}"
       case $boot in
         /dev/mmc*)
@@ -62,7 +62,7 @@ for arg in $(cat /proc/cmdline); do
       fi
 
       if [ -f "$UPDATE_DTB_SOURCE" ] ; then
-        echo "*** updating device tree from $UPDATE_DTB_SOURCE ..."
+        echo "Updating device tree from $UPDATE_DTB_SOURCE..."
         case $boot in
           /dev/system)
             dd if=/dev/zero of=/dev/dtb bs=256k count=1 status=none
@@ -79,7 +79,7 @@ for arg in $(cat /proc/cmdline); do
         if [ -f $all_dtb ] ; then
           dtb=$(basename $all_dtb)
           if [ -f $SYSTEM_ROOT/usr/share/bootloader/$dtb ]; then
-            echo "*** updating Device Tree Blob: $dtb ..."
+            echo "Updating $dtb..."
             mount -o rw,remount $BOOT_ROOT
             cp -p $SYSTEM_ROOT/usr/share/bootloader/$dtb $BOOT_ROOT
           fi
@@ -87,7 +87,7 @@ for arg in $(cat /proc/cmdline); do
       done
       ;;
     disk=*)
-      echo "*** updating DISK partition label ..."
+      echo "Updating DISK partition label..."
       disk="${arg#*=}"
       case $disk in
         /dev/mmc*)
@@ -108,25 +108,25 @@ if [ -d $BOOT_ROOT/device_trees ]; then
 fi
 
 if [ -f $SYSTEM_ROOT/usr/share/bootloader/boot.ini ]; then
-  echo "*** updating boot.ini ..."
+  echo "Updating boot.ini..."
   mount -o rw,remount $BOOT_ROOT
   cp -p $SYSTEM_ROOT/usr/share/bootloader/boot.ini $BOOT_ROOT/boot.ini
   if [ -f $SYSTEM_ROOT/usr/share/bootloader/config.ini ]; then
     if [ ! -f $BOOT_ROOT/config.ini ]; then
-      echo "*** creating config.ini ..."
+      echo "Creating config.ini..."
       cp -p $SYSTEM_ROOT/usr/share/bootloader/config.ini $BOOT_ROOT/config.ini
     fi
   fi
 fi
 
 if [ -f $SYSTEM_ROOT/usr/share/bootloader/boot-logo.bmp.gz ]; then
-  echo "*** updating boot logo ..."
+  echo "Updating boot logo..."
   mount -o rw,remount $BOOT_ROOT
   cp -p $SYSTEM_ROOT/usr/share/bootloader/boot-logo.bmp.gz $BOOT_ROOT
 fi
 
 if [ -f $SYSTEM_ROOT/usr/share/bootloader/u-boot -a ! -e /dev/system -a ! -e /dev/boot ]; then
-  echo "*** updating u-boot on: $BOOT_DISK ..."
+  echo "Updating u-boot on: $BOOT_DISK..."
   dd if=$SYSTEM_ROOT/usr/share/bootloader/u-boot of=$BOOT_DISK conv=fsync bs=1 count=112 status=none
   dd if=$SYSTEM_ROOT/usr/share/bootloader/u-boot of=$BOOT_DISK conv=fsync bs=512 skip=1 seek=1 status=none
 fi

--- a/projects/Amlogic/bootloader/update.sh
+++ b/projects/Amlogic/bootloader/update.sh
@@ -75,12 +75,14 @@ for arg in $(cat /proc/cmdline); do
         esac
       fi
 
-      for all_dtb in /flash/*.dtb /flash/DTB; do
-        dtb=$(basename $all_dtb)
-        if [ -f $SYSTEM_ROOT/usr/share/bootloader/$dtb ]; then
-          echo "*** updating Device Tree Blob: $dtb ..."
-          mount -o rw,remount $BOOT_ROOT
-          cp -p $SYSTEM_ROOT/usr/share/bootloader/$dtb $BOOT_ROOT
+      for all_dtb in /flash/*.dtb ; do
+        if [ -f $all_dtb ] ; then
+          dtb=$(basename $all_dtb)
+          if [ -f $SYSTEM_ROOT/usr/share/bootloader/$dtb ]; then
+            echo "*** updating Device Tree Blob: $dtb ..."
+            mount -o rw,remount $BOOT_ROOT
+            cp -p $SYSTEM_ROOT/usr/share/bootloader/$dtb $BOOT_ROOT
+          fi
         fi
       done
       ;;

--- a/projects/Amlogic/bootloader/update.sh
+++ b/projects/Amlogic/bootloader/update.sh
@@ -35,6 +35,8 @@ if [ -z "$BOOT_DISK" ]; then
   esac
 fi
 
+mount -o rw,remount $BOOT_ROOT
+
 for arg in $(cat /proc/cmdline); do
   case $arg in
     boot=*)
@@ -69,7 +71,6 @@ for arg in $(cat /proc/cmdline); do
             dd if="$UPDATE_DTB_SOURCE" of=/dev/dtb bs=256k status=none
             ;;
           /dev/mmc*|LABEL=*)
-            mount -o rw,remount $BOOT_ROOT
             cp -f "$UPDATE_DTB_SOURCE" "$BOOT_ROOT/dtb.img"
             ;;
         esac
@@ -80,7 +81,6 @@ for arg in $(cat /proc/cmdline); do
           dtb=$(basename $all_dtb)
           if [ -f $SYSTEM_ROOT/usr/share/bootloader/$dtb ]; then
             echo "Updating $dtb..."
-            mount -o rw,remount $BOOT_ROOT
             cp -p $SYSTEM_ROOT/usr/share/bootloader/$dtb $BOOT_ROOT
           fi
         fi
@@ -102,14 +102,12 @@ for arg in $(cat /proc/cmdline); do
 done
 
 if [ -d $BOOT_ROOT/device_trees ]; then
-  mount -o rw,remount $BOOT_ROOT
   rm $BOOT_ROOT/device_trees/*.dtb
   cp -p $SYSTEM_ROOT/usr/share/bootloader/*.dtb $BOOT_ROOT/device_trees/
 fi
 
 if [ -f $SYSTEM_ROOT/usr/share/bootloader/boot.ini ]; then
   echo "Updating boot.ini..."
-  mount -o rw,remount $BOOT_ROOT
   cp -p $SYSTEM_ROOT/usr/share/bootloader/boot.ini $BOOT_ROOT/boot.ini
   if [ -f $SYSTEM_ROOT/usr/share/bootloader/config.ini ]; then
     if [ ! -f $BOOT_ROOT/config.ini ]; then
@@ -121,7 +119,6 @@ fi
 
 if [ -f $SYSTEM_ROOT/usr/share/bootloader/boot-logo.bmp.gz ]; then
   echo "Updating boot logo..."
-  mount -o rw,remount $BOOT_ROOT
   cp -p $SYSTEM_ROOT/usr/share/bootloader/boot-logo.bmp.gz $BOOT_ROOT
 fi
 
@@ -130,3 +127,5 @@ if [ -f $SYSTEM_ROOT/usr/share/bootloader/u-boot -a ! -e /dev/system -a ! -e /de
   dd if=$SYSTEM_ROOT/usr/share/bootloader/u-boot of=$BOOT_DISK conv=fsync bs=1 count=112 status=none
   dd if=$SYSTEM_ROOT/usr/share/bootloader/u-boot of=$BOOT_DISK conv=fsync bs=512 skip=1 seek=1 status=none
 fi
+
+mount -o ro,remount $BOOT_ROOT


### PR DESCRIPTION
If there is no file matching `/flash/*.dtb` wildcard, the loop will proceed with `all_dtb="/flash/*.dtb"`, causing erratic behaviour in next script steps. Fix this by checking if  exists before proceeding.