### PR TITLE
fix perf build

### DIFF
--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -52,6 +52,10 @@ PKG_CONFIGURE_OPTS_TARGET="bash_cv_have_mbstate_t=set \
                            --enable-libssp \
                            --disable-werror"
 
+makeinstall_target() {
+  make DESTDIR=$INSTALL install
+}
+
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/share/gdb/python
 }

--- a/packages/debug/libunwind/package.mk
+++ b/packages/debug/libunwind/package.mk
@@ -29,3 +29,7 @@ PKG_LONGDESC="library to determine the call-chain of a program"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
 			   --disable-shared"
+
+makeinstall_target() {
+  make DESTDIR=$SYSROOT_PREFIX install
+}

--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -50,6 +50,8 @@ PKG_CONFIGURE_OPTS_TARGET="--target=$TARGET_NAME \
                          --with-lib-path=$SYSROOT_PREFIX/lib:$SYSROOT_PREFIX/usr/lib \
                          --without-ppl \
                          --without-cloog \
+                         --enable-static \
+                         --disable-shared \
                          --disable-werror \
                          --disable-multilib \
                          --disable-libada \
@@ -79,10 +81,12 @@ makeinstall_host() {
 
 make_target() {
   make configure-host
-  make -C libiberty libiberty.a
+  make -C libiberty
+  make -C bfd
 }
 
 makeinstall_target() {
   mkdir -p $SYSROOT_PREFIX/usr/lib
     cp libiberty/libiberty.a $SYSROOT_PREFIX/usr/lib
+  make DESTDIR="$SYSROOT_PREFIX" -C bfd install
 }

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -164,6 +164,20 @@ make_target() {
 
   if [ "$PKG_BUILD_PERF" = "yes" ] ; then
     ( cd tools/perf
+
+      # arch specific perf build args
+      case "$TARGET_ARCH" in
+        x86_64)
+          PERF_BUILD_ARGS="ARCH=x86"
+          ;;
+        aarch64)
+          PERF_BUILD_ARGS="ARCH=arm64"
+          ;;
+        *)
+          PERF_BUILD_ARGS="ARCH=$TARGET_ARCH"
+          ;;
+      esac
+
       WERROR=0 \
       NO_LIBPERL=1 \
       NO_LIBPYTHON=1 \
@@ -173,9 +187,11 @@ make_target() {
       NO_LIBAUDIT=1 \
       NO_LZMA=1 \
       NO_SDT=1 \
-      LDFLAGS="-ldw -ldwfl -lebl -lelf -ldl -lz" \
+      LDFLAGS="$LDFLAGS -ldw -ldwfl -lebl -lelf -ldl -lz" \
       EXTRA_PERFLIBS="-lebl" \
-        make
+      CROSS_COMPILE="$TARGET_PREFIX" \
+      JOBS="$CONCURRENCY_MAKE_LEVEL" \
+        make $PERF_BUILD_ARGS
       mkdir -p $INSTALL/usr/bin
         cp perf $INSTALL/usr/bin
     )

--- a/packages/linux/patches/default/linux-999-no-lzma-in-x86-perf-build.patch
+++ b/packages/linux/patches/default/linux-999-no-lzma-in-x86-perf-build.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/perf/Makefile.config b/tools/perf/Makefile.config
+index 0294bfb6c5f8..153036bbed7e 100644
+--- a/tools/perf/Makefile.config
++++ b/tools/perf/Makefile.config
+@@ -35,7 +35,7 @@ ifeq ($(SRCARCH),x86)
+   ifeq (${IS_64_BIT}, 1)
+     CFLAGS += -DHAVE_ARCH_X86_64_SUPPORT -DHAVE_SYSCALL_TABLE -I$(OUTPUT)arch/x86/include/generated
+     ARCH_INCLUDE = ../../arch/x86/lib/memcpy_64.S ../../arch/x86/lib/memset_64.S
+-    LIBUNWIND_LIBS = -lunwind-x86_64 -lunwind -llzma
++    LIBUNWIND_LIBS = -lunwind-x86_64 -lunwind
+     $(call detected,CONFIG_X86_64)
+   else
+     LIBUNWIND_LIBS = -lunwind-x86 -llzma -lunwind


### PR DESCRIPTION
perf crosscompilation should be performed like for linux kernel, i.e. by specifying ARCH and CROSS_COMPILE. The initial version accidentally dropped LDFLAGS, add these back in.

On x86_64 the upstream Makefile adds -llzma to the libunwind libs, patch this out as we don't build lzma in LE.

Also cleanup libunwind package.mk so that headers and static libs are only installed to sysroot