### PR TITLE
Compile kernel on 64/32 split archs without redefining TARGET_PREFIX

### DIFF
--- a/config/path
+++ b/config/path
@@ -37,6 +37,13 @@ SYSROOT_PREFIX=$TOOLCHAIN/$TARGET_NAME/sysroot
 LIB_PREFIX=$SYSROOT_PREFIX/usr
 TARGET_PREFIX=$TOOLCHAIN/bin/$TARGET_NAME-
 
+# use linaro toolchain on 64/32 split builds
+if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
+  TARGET_KERNEL_PREFIX=$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/aarch64-linux-gnu-
+else
+  TARGET_KERNEL_PREFIX=$TARGET_PREFIX
+fi
+
 FAKEROOT_SCRIPT=$BUILD/.fakeroot
 
 if [ -z "$INSTALL" ]; then

--- a/packages/linux-drivers/RTL8188EU/package.mk
+++ b/packages/linux-drivers/RTL8188EU/package.mk
@@ -40,7 +40,7 @@ make_target() {
   make V=1 \
        ARCH=$TARGET_KERNEL_ARCH \
        KSRC=$(kernel_path) \
-       CROSS_COMPILE=$TARGET_PREFIX \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
        CONFIG_POWER_SAVING=n
 }
 

--- a/packages/linux-drivers/RTL8192CU/package.mk
+++ b/packages/linux-drivers/RTL8192CU/package.mk
@@ -39,7 +39,7 @@ make_target() {
   make V=1 \
        ARCH=$TARGET_KERNEL_ARCH \
        KSRC=$(kernel_path) \
-       CROSS_COMPILE=$TARGET_PREFIX \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
        CONFIG_POWER_SAVING=n
 }
 

--- a/packages/linux-drivers/RTL8192DU/package.mk
+++ b/packages/linux-drivers/RTL8192DU/package.mk
@@ -39,7 +39,7 @@ make_target() {
   make V=1 \
        ARCH=$TARGET_KERNEL_ARCH \
        KSRC=$(kernel_path) \
-       CROSS_COMPILE=$TARGET_PREFIX \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
        CONFIG_POWER_SAVING=n
 }
 

--- a/packages/linux-drivers/RTL8192EU/package.mk
+++ b/packages/linux-drivers/RTL8192EU/package.mk
@@ -39,7 +39,7 @@ make_target() {
   make V=1 \
        ARCH=$TARGET_KERNEL_ARCH \
        KSRC=$(kernel_path) \
-       CROSS_COMPILE=$TARGET_PREFIX \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
        CONFIG_POWER_SAVING=n \
        USER_EXTRA_CFLAGS="-Wno-error=date-time"
 }

--- a/packages/linux-drivers/RTL8812AU/package.mk
+++ b/packages/linux-drivers/RTL8812AU/package.mk
@@ -39,7 +39,7 @@ make_target() {
   make V=1 \
        ARCH=$TARGET_KERNEL_ARCH \
        KSRC=$(kernel_path) \
-       CROSS_COMPILE=$TARGET_PREFIX \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
        CONFIG_POWER_SAVING=n
 }
 

--- a/packages/linux-drivers/amlogic/RTL8188EU-aml/package.mk
+++ b/packages/linux-drivers/amlogic/RTL8188EU-aml/package.mk
@@ -42,7 +42,7 @@ make_target() {
   LDFLAGS="" make -C $(kernel_path) M=$PKG_BUILD/rtl8xxx_EU \
     ARCH=$TARGET_KERNEL_ARCH \
     KSRC=$(kernel_path) \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     USER_EXTRA_CFLAGS="-fgnu89-inline"
 }
 

--- a/packages/linux-drivers/amlogic/RTL8189ES-aml/package.mk
+++ b/packages/linux-drivers/amlogic/RTL8189ES-aml/package.mk
@@ -46,7 +46,7 @@ make_target() {
   make -C $(kernel_path) M=$PKG_BUILD/rtl8189ES \
     ARCH=$TARGET_KERNEL_ARCH \
     KSRC=$(kernel_path) \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     USER_EXTRA_CFLAGS="-fgnu89-inline"
 }
 

--- a/packages/linux-drivers/amlogic/RTL8189FS-aml/package.mk
+++ b/packages/linux-drivers/amlogic/RTL8189FS-aml/package.mk
@@ -46,7 +46,7 @@ make_target() {
   make -C $(kernel_path) M=$PKG_BUILD/rtl8189FS \
     ARCH=$TARGET_KERNEL_ARCH \
     KSRC=$(kernel_path) \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     USER_EXTRA_CFLAGS="-fgnu89-inline"
 }
 

--- a/packages/linux-drivers/amlogic/RTL8723BS-aml/package.mk
+++ b/packages/linux-drivers/amlogic/RTL8723BS-aml/package.mk
@@ -46,7 +46,7 @@ make_target() {
   make -C $(kernel_path) M=$PKG_BUILD/rtl8723BS \
     ARCH=$TARGET_KERNEL_ARCH \
     KSRC=$(kernel_path) \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     USER_EXTRA_CFLAGS="-fgnu89-inline"
 }
 

--- a/packages/linux-drivers/amlogic/RTL8723DS-aml/package.mk
+++ b/packages/linux-drivers/amlogic/RTL8723DS-aml/package.mk
@@ -46,7 +46,7 @@ make_target() {
   make -C $(kernel_path) M=$PKG_BUILD/rtl8723DS \
     ARCH=$TARGET_KERNEL_ARCH \
     KSRC=$(kernel_path) \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     USER_EXTRA_CFLAGS="-fgnu89-inline"
 }
 

--- a/packages/linux-drivers/amlogic/RTL8822BU-aml/package.mk
+++ b/packages/linux-drivers/amlogic/RTL8822BU-aml/package.mk
@@ -46,7 +46,7 @@ make_target() {
   make -C $(kernel_path) M=$PKG_BUILD/rtl8822BU \
     ARCH=$TARGET_KERNEL_ARCH \
     KSRC=$(kernel_path) \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     USER_EXTRA_CFLAGS="-fgnu89-inline"
 }
 

--- a/packages/linux-drivers/amlogic/ap6xxx-aml/package.mk
+++ b/packages/linux-drivers/amlogic/ap6xxx-aml/package.mk
@@ -39,7 +39,7 @@ pre_make_target() {
 make_target() {
   make -C $(kernel_path) M=$PKG_BUILD/bcmdhd.1.363.59.144.x.cn \
     ARCH=$TARGET_KERNEL_ARCH \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     CONFIG_BCMDHD_DISABLE_WOWLAN=y
 }
 

--- a/packages/linux-drivers/amlogic/mt7601u-aml/package.mk
+++ b/packages/linux-drivers/amlogic/mt7601u-aml/package.mk
@@ -39,7 +39,7 @@ pre_make_target() {
 make_target() {
   make -C $(kernel_path) M=$PKG_BUILD \
     ARCH=$TARGET_KERNEL_ARCH \
-    CROSS_COMPILE=$TARGET_PREFIX
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX
 }
 
 makeinstall_target() {

--- a/packages/linux-drivers/amlogic/mt7603u-aml/package.mk
+++ b/packages/linux-drivers/amlogic/mt7603u-aml/package.mk
@@ -39,7 +39,7 @@ pre_make_target() {
 make_target() {
   make LINUX_SRC=$(kernel_path) \
     ARCH=$TARGET_KERNEL_ARCH \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     RT28xx_DIR=$PKG_BUILD \
     -f $PKG_BUILD/Makefile
 }

--- a/packages/linux-drivers/amlogic/qca9377-aml/package.mk
+++ b/packages/linux-drivers/amlogic/qca9377-aml/package.mk
@@ -45,7 +45,7 @@ pre_make_target() {
 make_target() {
   make KERNEL_SRC="$(kernel_path)" \
     ARCH=$TARGET_KERNEL_ARCH \
-    CROSS_COMPILE=$TARGET_PREFIX \
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
     CONFIG_CLD_HL_SDIO_CORE=y
 }
 

--- a/packages/linux-drivers/amlogic/ssv6xxx-aml/package.mk
+++ b/packages/linux-drivers/amlogic/ssv6xxx-aml/package.mk
@@ -51,7 +51,7 @@ make_target() {
     cp Makefile.android Makefile
     sed -i 's,PLATFORMS =,PLATFORMS = '"$PLATFORM"',g' Makefile
     make module SSV_ARCH="$TARGET_KERNEL_ARCH" \
-      SSV_CROSS="$TARGET_PREFIX" \
+      SSV_CROSS="$TARGET_KERNEL_PREFIX" \
       SSV_KERNEL_PATH="$(kernel_path)"
 }
 

--- a/packages/linux-drivers/brcmap6xxx-aml/package.mk
+++ b/packages/linux-drivers/brcmap6xxx-aml/package.mk
@@ -36,7 +36,7 @@ make_target() {
   LDFLAGS="" make V=1 \
     -C $(kernel_path) M=$PKG_BUILD/bcmdhd_1_201_59_x \
     ARCH=$TARGET_KERNEL_ARCH \
-    CROSS_COMPILE=$TARGET_PREFIX
+    CROSS_COMPILE=$TARGET_KERNEL_PREFIX
 }
 
 makeinstall_target() {

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -59,11 +59,8 @@ PKG_KERNEL_CFG_FILE=$(kernel_config_path)
 if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
   PKG_DEPENDS_HOST="$PKG_DEPENDS_HOST gcc-linaro-aarch64-linux-gnu:host"
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET gcc-linaro-aarch64-linux-gnu:host"
-  PKG_TARGET_PREFIX=$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/aarch64-linux-gnu-
   HEADERS_ARCH=$TARGET_ARCH
   PKG_BUILD_PERF="no"
-else
-  PKG_TARGET_PREFIX=$TARGET_PREFIX
 fi
 
 if [ "$DEVTOOLS" = "yes" -a "$PKG_BUILD_PERF" != "no" ] && grep -q ^CONFIG_PERF_EVENTS= $PKG_KERNEL_CFG_FILE ; then
@@ -85,7 +82,7 @@ post_patch() {
   sed -i -e "s|^HOSTCC[[:space:]]*=.*$|HOSTCC = $TOOLCHAIN/bin/host-gcc|" \
          -e "s|^HOSTCXX[[:space:]]*=.*$|HOSTCXX = $TOOLCHAIN/bin/host-g++|" \
          -e "s|^ARCH[[:space:]]*?=.*$|ARCH = $TARGET_KERNEL_ARCH|" \
-         -e "s|^CROSS_COMPILE[[:space:]]*?=.*$|CROSS_COMPILE = $PKG_TARGET_PREFIX|" \
+         -e "s|^CROSS_COMPILE[[:space:]]*?=.*$|CROSS_COMPILE = $TARGET_KERNEL_PREFIX|" \
          $PKG_BUILD/Makefile
 
   cp $PKG_KERNEL_CFG_FILE $PKG_BUILD/.config

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -44,9 +44,9 @@ make_target() {
     echo "UBOOT_SYSTEM must be set to build an image"
     echo "see './scripts/uboot_helper' for more information"
   else
-    CROSS_COMPILE="$TARGET_PREFIX" LDFLAGS="" ARCH=arm make mrproper
-    CROSS_COMPILE="$TARGET_PREFIX" LDFLAGS="" ARCH=arm make $($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM config)
-    CROSS_COMPILE="$TARGET_PREFIX" LDFLAGS="" ARCH=arm make HOSTCC="$HOST_CC" HOSTSTRIP="true"
+    CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm make mrproper
+    CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm make $($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM config)
+    CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm make HOSTCC="$HOST_CC" HOSTSTRIP="true"
   fi
 }
 

--- a/scripts/build
+++ b/scripts/build
@@ -213,13 +213,6 @@ if [ "$(type -t configure_package)" = "function" ]; then
   configure_package
 fi
 
-if [ "$PKG_IS_KERNEL_PKG" = "yes" ]; then
-  if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
-    TARGET_PREFIX=$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/aarch64-linux-gnu-
-    STRIP=${TARGET_PREFIX}strip
-  fi
-fi
-
 # build dependencies, only when PKG_DEPENDS_? is filled
 unset _pkg_depends
 case "$TARGET" in

--- a/scripts/image
+++ b/scripts/image
@@ -230,11 +230,8 @@ find $INSTALL/usr/lib/kernel-overlays/base/lib/modules/$MODVER/ -name *.ko | \
 $TOOLCHAIN/bin/depmod -b $INSTALL/usr/lib/kernel-overlays/base -a -e -F "$BUILD/linux-$(kernel_version)/System.map" $MODVER
 
 # strip kernel modules
-if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
-  STRIP=$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/aarch64-linux-gnu-strip
-fi
 for MOD in `find $INSTALL/usr/lib/kernel-overlays/ -type f -name *.ko`; do
-  $STRIP --strip-debug $MOD
+  ${TARGET_KERNEL_PREFIX}strip --strip-debug $MOD
 done
 
 # symlink overlayed modules to /usr/lib/modules


### PR DESCRIPTION
Cross compiling the linux kernel and u-boot is normally done via setting appropriate ARCH and CROSS_COMPILE options (which the LE buildsystem already does).

It's therefore not necessary to redefine TARGET_PREFIX in scripts/build

Just add TARGET_KERNEL_PREFIX (defaulting to TARGET_PREFIX on non-split arch builds) in addition to the already existing TARGET_KERNEL_ARCH and use that for compiling kernel, kernel-modules and u-boot

Note: with these changes PKG_IS_KERNEL_PKG becomes an unused marker and can probably be dropped, but I left it intact for now