### PR TITLE
[RFC] Update Amlogic Mali driver to r7p0

### DIFF
--- a/packages/graphics/opengl-meson/package.mk
+++ b/packages/graphics/opengl-meson/package.mk
@@ -30,9 +30,11 @@ case $MESON_FAMILY in
     ;;
   gxbb)
     if [ "$TARGET_ARCH" = "arm" ]; then
-      PKG_VERSION="8-r5p1-01rel0-armhf"
+      PKG_VERSION="8-r7p0-01rel0-armhf"
+      PKG_SHA256="d79526d849c2cc0c513335b7f78b9ea568c04d241af3a8c4636298a3ae4c9211"
     else
-      PKG_VERSION="gxbb-r5p1-01rel0"
+      PKG_VERSION="gxbb-r7p0-01rel0"
+      PKG_SHA256="9391b7a6863b5d34105e6ba2cc06a489eed0ca3f0b80aa3c2aa3dddebda7b747"
     fi
 ;;
 esac

--- a/packages/linux-drivers/gpu-aml/package.mk
+++ b/packages/linux-drivers/gpu-aml/package.mk
@@ -32,7 +32,7 @@ PKG_LONGDESC="gpu-aml: Linux drivers for Mali GPUs found in Amlogic Meson SoCs"
 PKG_TOOLCHAIN="manual"
 PKG_IS_KERNEL_PKG="yes"
 
-PKG_UTGARD_VERSION="r5p1"
+PKG_UTGARD_VERSION="r7p0"
 PKG_UTGARD_BUILD_DIR="$PKG_BUILD/utgard/$PKG_UTGARD_VERSION"
 PKG_MIDGARD_VERSION="r16p0"
 PKG_MIDGARD_BUILD_DIR="$PKG_BUILD/midgard/$PKG_MIDGARD_VERSION/kernel/drivers/gpu/arm/midgard"

--- a/packages/linux/patches/amlogic-3.14/linux-001-PR94.patch
+++ b/packages/linux/patches/amlogic-3.14/linux-001-PR94.patch
@@ -1,0 +1,92 @@
+From 4e1f6f11f977764a12390ad3ca88abfe75d2b1b4 Mon Sep 17 00:00:00 2001
+From: kszaq <kszaquitto@gmail.com>
+Date: Thu, 1 Feb 2018 22:00:38 +0100
+Subject: [PATCH 1/2] drivers/amlogic/display/osd: fix getting parameters from
+ dt
+
+If property is not found, we should not set parameter according to prop_idx as it may have been got from previous dt parameter.
+---
+ drivers/amlogic/display/osd/osd_fb.c | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/amlogic/display/osd/osd_fb.c b/drivers/amlogic/display/osd/osd_fb.c
+index 3c1f831ea1da..93b326badd85 100644
+--- a/drivers/amlogic/display/osd/osd_fb.c
++++ b/drivers/amlogic/display/osd/osd_fb.c
+@@ -2514,13 +2514,15 @@ static int osd_probe(struct platform_device *pdev)
+ 
+ 	/* get meson-fb resource from dt */
+ 	prop = of_get_property(pdev->dev.of_node, "scale_mode", NULL);
+-	if (prop)
++	if (prop) {
+ 		prop_idx = of_read_ulong(prop, 1);
+-	osd_set_free_scale_mode_hw(DEV_OSD0, prop_idx);
++		osd_set_free_scale_mode_hw(DEV_OSD0, prop_idx);
++	}
+ 	prop = of_get_property(pdev->dev.of_node, "4k2k_fb", NULL);
+-	if (prop)
++	if (prop) {
+ 		prop_idx = of_read_ulong(prop, 1);
+-	osd_set_4k2k_fb_mode_hw(prop_idx);
++		osd_set_4k2k_fb_mode_hw(prop_idx);
++	}
+ 	/* get default display mode from dt */
+ 	ret = of_property_read_string(pdev->dev.of_node,
+ 		"display_mode_default", &str);
+@@ -2529,9 +2531,10 @@ static int osd_probe(struct platform_device *pdev)
+ 	else
+ 		current_mode = vmode_name_to_mode(str);
+ 	prop = of_get_property(pdev->dev.of_node, "pxp_mode", NULL);
+-	if (prop)
++	if (prop) {
+ 		prop_idx = of_read_ulong(prop, 1);
+-	osd_set_pxp_mode(prop_idx);
++		osd_set_pxp_mode(prop_idx);
++	}
+ 
+ 	prop = of_get_property(pdev->dev.of_node, "ddr_urgent", NULL);
+ 	if (prop) {
+
+From a7d7f8bafe152837bbdf1950863a32c9dda53b9b Mon Sep 17 00:00:00 2001
+From: kszaq <kszaquitto@gmail.com>
+Date: Thu, 1 Feb 2018 22:06:44 +0100
+Subject: [PATCH 2/2] drivers/amlogic/display: don't do vsync on pan, do it on
+ FBIO_WAITFORVSYNC
+
+More recent Mali drivers use FBIO_WAITFORVSYNC and we should use osd_wait_vsync_hw() there as osd_wait_vsync_event() may not hit vsync.
+
+At the same time we shouldn't do vsync on pan as this waits for second vysnc event and decreases frame rate by half.
+
+This is the same implementation as for Odroid-C2:
+https://github.com/hardkernel/linux/commit/01d61cd
+https://github.com/hardkernel/linux/blob/01d61cd/drivers/amlogic/display/osd/osd_fb.c#L990
+---
+ drivers/amlogic/display/osd/osd_fb.c | 2 +-
+ drivers/amlogic/display/osd/osd_hw.c | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/amlogic/display/osd/osd_fb.c b/drivers/amlogic/display/osd/osd_fb.c
+index 93b326badd85..64caebf8676c 100644
+--- a/drivers/amlogic/display/osd/osd_fb.c
++++ b/drivers/amlogic/display/osd/osd_fb.c
+@@ -916,7 +916,7 @@ static int osd_ioctl(struct fb_info *info, unsigned int cmd, unsigned long arg)
+ 			break;
+ 		}
+ 	case FBIO_WAITFORVSYNC:
+-		osd_wait_vsync_event();
++		osd_wait_vsync_hw();
+ 		ret = copy_to_user(argp, &ret, sizeof(u32));
+ 		break;
+ 	default:
+diff --git a/drivers/amlogic/display/osd/osd_hw.c b/drivers/amlogic/display/osd/osd_hw.c
+index 1040a57bafb4..1e70ce8577d6 100644
+--- a/drivers/amlogic/display/osd/osd_hw.c
++++ b/drivers/amlogic/display/osd/osd_hw.c
+@@ -2296,7 +2296,6 @@ void osd_pan_display_hw(u32 index, unsigned int xoffset, unsigned int yoffset)
+ 		osd_hw.pandata[index].y_start += diff_y;
+ 		osd_hw.pandata[index].y_end   += diff_y;
+ 		add_to_update_list(index, DISP_GEOMETRY);
+-		osd_wait_vsync_hw();
+ 	}
+ #ifdef CONFIG_AM_FB_EXT
+ 	osd_ext_clone_pan(index);

--- a/projects/Amlogic/devices/S912/patches/linux/linux-0001-Revert-drivers-amlogic-display-don-t-do-vsync-on-pan.patch
+++ b/projects/Amlogic/devices/S912/patches/linux/linux-0001-Revert-drivers-amlogic-display-don-t-do-vsync-on-pan.patch
@@ -1,0 +1,40 @@
+From d98e6e6ae84b0103770d01c88f262c4da6c2b442 Mon Sep 17 00:00:00 2001
+From: kszaq <kszaquitto@gmail.com>
+Date: Sat, 3 Feb 2018 21:41:56 +0100
+Subject: [PATCH] Revert "drivers/amlogic/display: don't do vsync on pan, do it
+ on FBIO_WAITFORVSYNC"
+
+This reverts commit a7d7f8bafe152837bbdf1950863a32c9dda53b9b.
+---
+ drivers/amlogic/display/osd/osd_fb.c | 2 +-
+ drivers/amlogic/display/osd/osd_hw.c | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/amlogic/display/osd/osd_fb.c b/drivers/amlogic/display/osd/osd_fb.c
+index 64caebf..93b326b 100644
+--- a/drivers/amlogic/display/osd/osd_fb.c
++++ b/drivers/amlogic/display/osd/osd_fb.c
+@@ -916,7 +916,7 @@ static int osd_ioctl(struct fb_info *info, unsigned int cmd, unsigned long arg)
+ 			break;
+ 		}
+ 	case FBIO_WAITFORVSYNC:
+-		osd_wait_vsync_hw();
++		osd_wait_vsync_event();
+ 		ret = copy_to_user(argp, &ret, sizeof(u32));
+ 		break;
+ 	default:
+diff --git a/drivers/amlogic/display/osd/osd_hw.c b/drivers/amlogic/display/osd/osd_hw.c
+index 1e70ce8..1040a57 100644
+--- a/drivers/amlogic/display/osd/osd_hw.c
++++ b/drivers/amlogic/display/osd/osd_hw.c
+@@ -2296,6 +2296,7 @@ void osd_pan_display_hw(u32 index, unsigned int xoffset, unsigned int yoffset)
+ 		osd_hw.pandata[index].y_start += diff_y;
+ 		osd_hw.pandata[index].y_end   += diff_y;
+ 		add_to_update_list(index, DISP_GEOMETRY);
++		osd_wait_vsync_hw();
+ 	}
+ #ifdef CONFIG_AM_FB_EXT
+ 	osd_ext_clone_pan(index);
+-- 
+2.7.4
+


### PR DESCRIPTION
The reason for this PR is to test the r7p0 Mali drivers for Amlogic S9xx. It consists of:
- updated kernel driver
- updated userspace library
- kernel PR patch https://github.com/LibreELEC/linux-amlogic/pull/94 that should be dropped in favour of merging the PR and bumping the kernel

The main difference is that a wait on vsync was performed on every `FBIO_PAN_DISPLAY` with r5p1 driver whereas more recent driver uses `FBIO_WAITFORVSYNC`. From a user perspective the GUI animations are a bit smoother.