### PR TITLE
WeTek Play 2: Add support for crazycat and hauppauge driver addons

### DIFF
--- a/packages/linux-driver-addons/dvb/crazycat/config/usb.config
+++ b/packages/linux-driver-addons/dvb/crazycat/config/usb.config
@@ -592,3 +592,8 @@ CONFIG_MISC_DEVICES=y
 #
 CONFIG_ALTERA_STAPL=m
 # CONFIG_STAGING is not set
+
+#
+# WeTek Play driver
+#
+CONFIG_WETEK=m

--- a/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-01-add-AML-specific-to-backports.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-01-add-AML-specific-to-backports.patch
@@ -1,12 +1,14 @@
---- a/backports/backports.txt
-+++ b/backports/backports.txt
-@@ -21,6 +21,9 @@
+diff -Naur a/backports/backports.txt b/backports/backports.txt
+--- a/backports/backports.txt	2017-12-30 22:14:58.000000000 +0200
++++ b/backports/backports.txt	2018-02-23 13:50:01.327967293 +0200
+@@ -21,6 +21,10 @@
  
  # All supported versions need those patches
  [9.255.255]
 +add linux-301-AML-videobuf-resource.patch
 +add linux-302-AML-amlogic-video-dev.patch
 +add linux-303-AML-meson-ir.patch
++add linux-304-AML-wetekplay.patch
  add api_version.patch
  add pr_fmt.patch
  add debug.patch

--- a/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-04-AML-hacks.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/patches/amlogic/driver.dvb.crazycat-04-AML-hacks.patch
@@ -1,6 +1,7 @@
---- a/linux/Makefile
-+++ b/linux/Makefile
-@@ -112,6 +112,13 @@
+diff -Naur a/linux/Makefile b/linux/Makefile
+--- a/linux/Makefile	2017-12-30 22:01:38.000000000 +0200
++++ b/linux/Makefile	2018-02-23 13:25:54.025763853 +0200
+@@ -112,6 +112,17 @@
  
  untar: linux-media.tar.bz2
  	tar xfj linux-media.tar.bz2
@@ -11,6 +12,10 @@
 +	# Copy videobuf-res module
 +	cp -a "$(SRCDIR)/drivers/media/v4l2-core/videobuf-res.c" "drivers/media/v4l2-core/"
 +	cp -a "$(SRCDIR)/include/media/videobuf-res.h" "include/media/"
++
++	# Copy WeTek Play DVB driver
++	cp -a "$(SRCDIR)/drivers/amlogic/wetek" "drivers/media/amlogic"
++
  	-rm -f .patches_applied .linked_dir .git_log.md5
  
  clean:

--- a/packages/linux-driver-addons/dvb/crazycat/sources/backports/linux-304-AML-wetekplay.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/sources/backports/linux-304-AML-wetekplay.patch
@@ -1,0 +1,21 @@
+diff --git a/drivers/media/amlogic/Kconfig b/drivers/media/amlogic/Kconfig
+index 5203702..7af18b7 100644
+--- a/drivers/media/amlogic/Kconfig
++++ b/drivers/media/amlogic/Kconfig
+@@ -5,4 +5,6 @@ menu "Amlogic Device Drivers"
+ 
+ source "drivers/media/amlogic/video_dev/Kconfig"
+ 
++source "drivers/media/amlogic/wetek/Kconfig"
++
+ endmenu
+diff --git a/drivers/media/amlogic/Makefile b/drivers/media/amlogic/Makefile
+index 049cb81..99bbb31 100644
+--- a/drivers/media/amlogic/Makefile
++++ b/drivers/media/amlogic/Makefile
+@@ -3,3 +3,5 @@
+ ##########################################
+ 
+ obj-$(CONFIG_V4L_AMLOGIC_VIDEO) += video_dev/
++
++obj-$(CONFIG_WETEK) += wetek/

--- a/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
+++ b/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
@@ -49,5 +49,10 @@ unpack() {
     # Copy videobuf-res module
     cp -a "$(kernel_path)/drivers/media/v4l2-core/videobuf-res.c" "$PKG_BUILD/drivers/media/v4l2-core/"
     cp -a "$(kernel_path)/include/media/videobuf-res.h" "$PKG_BUILD/include/media/"
+
+    # Copy WeTek Play DVB driver
+    if [ $LINUX = "amlogic-3.14" ]; then
+      cp -a "$(kernel_path)/drivers/amlogic/wetek" "$PKG_BUILD/drivers/media/amlogic"
+    fi
   fi
 }

--- a/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-01-add-AML-specific-to-backports.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/patches/amlogic/driver.dvb.hauppauge-01-add-AML-specific-to-backports.patch
@@ -1,12 +1,14 @@
---- a/backports/backports.txt
-+++ b/backports/backports.txt
-@@ -21,6 +21,9 @@
+diff -Naur a/backports/backports.txt b/backports/backports.txt
+--- a/backports/backports.txt	2017-12-30 22:14:58.000000000 +0200
++++ b/backports/backports.txt	2018-02-23 13:50:01.327967293 +0200
+@@ -21,6 +21,10 @@
  
  # All supported versions need those patches
  [9.255.255]
 +add linux-301-AML-videobuf-resource.patch
 +add linux-302-AML-amlogic-video-dev.patch
 +add linux-303-AML-meson-ir.patch
++add linux-304-AML-wetekplay.patch
  add api_version.patch
  add pr_fmt.patch
  add debug.patch

--- a/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-304-AML-wetekplay.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-304-AML-wetekplay.patch
@@ -1,0 +1,21 @@
+diff --git a/drivers/media/amlogic/Kconfig b/drivers/media/amlogic/Kconfig
+index 5203702..7af18b7 100644
+--- a/drivers/media/amlogic/Kconfig
++++ b/drivers/media/amlogic/Kconfig
+@@ -5,4 +5,6 @@ menu "Amlogic Device Drivers"
+ 
+ source "drivers/media/amlogic/video_dev/Kconfig"
+ 
++source "drivers/media/amlogic/wetek/Kconfig"
++
+ endmenu
+diff --git a/drivers/media/amlogic/Makefile b/drivers/media/amlogic/Makefile
+index 049cb81..99bbb31 100644
+--- a/drivers/media/amlogic/Makefile
++++ b/drivers/media/amlogic/Makefile
+@@ -3,3 +3,5 @@
+ ##########################################
+ 
+ obj-$(CONFIG_V4L_AMLOGIC_VIDEO) += video_dev/
++
++obj-$(CONFIG_WETEK) += wetek/

--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="wetekdvb"
-PKG_VERSION="20171219"
-PKG_SHA256="973ae6c3997a24904d36aa2b2fc9ff92f2ff13339d0e52210f78a6307932c917"
+PKG_VERSION="20180222"
+PKG_SHA256="9deb42ede05082279da971edf1ec0133c0f5da6edcae9d69c04f022fc91c7d6c"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.wetek.com/"
@@ -32,12 +32,12 @@ PKG_IS_KERNEL_PKG="yes"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
-  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
-  if [ "$DEVICE" = "WeTek_Play_2" ]; then
-    cp driver/wetekdvb_play2.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME/wetekdvb.ko
-  else
-    cp driver/wetekdvb.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME
-  fi
+  device=${DEVICE:-$PROJECT}
+  for overlay_dir in driver/$device/*/; do
+    overlay_dir=`basename $overlay_dir`
+    mkdir -p $INSTALL/$(get_full_module_dir $overlay_dir)/$PKG_NAME
+    cp driver/$device/$overlay_dir/wetekdvb.ko $INSTALL/$(get_full_module_dir $overlay_dir)/$PKG_NAME
+  done
 
   mkdir -p $INSTALL/$(get_full_firmware_dir)
     cp firmware/* $INSTALL/$(get_full_firmware_dir)

--- a/projects/Amlogic/devices/WeTek_Play_2/options
+++ b/projects/Amlogic/devices/WeTek_Play_2/options
@@ -11,11 +11,3 @@
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
     FIRMWARE="$FIRMWARE brcmfmac_sdio-firmware-aml"
-
-  # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
-
-  # driver addons to install:
-  # for a list of additinoal drivers see packages/linux-driver-addons
-  # Space separated list is supported,
-    DRIVER_ADDONS=""


### PR DESCRIPTION
Add wetekdvb modules for WeTek Play 2 built with crazycat and hauppauge headers.

Enable support for crazycat and hauppauge in WeTek Play 2 project.