### PR TITLE
busybox: don't build parallel

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -52,6 +52,9 @@ if [ "$NFS_SUPPORT" = yes ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET rpcbind"
 fi
 
+# dont build parallel
+MAKEFLAGS=-j1
+
 pre_build_target() {
   mkdir -p $PKG_BUILD/.$TARGET_NAME
   cp -RP $PKG_BUILD/* $PKG_BUILD/.$TARGET_NAME

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -40,7 +40,6 @@ PKG_MAKE_OPTS_INIT="ARCH=$TARGET_ARCH \
                     HOSTCC=$HOST_CC \
                     CROSS_COMPILE=$TARGET_PREFIX \
                     KBUILD_VERBOSE=1 \
-                    MAKEFLAGS="-j1" \
                     install"
 
 # nano text editor


### PR DESCRIPTION
I hit this issue when building `busybox` (host)
```
  gcc -Wp,-MD,libpwdgrp/.uidgid_get.o.d   -std=gnu99 -Iinclude -Ilibbb  -include include/autoconf.h -D_GNU_SOURCE -DNDEBUG -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D"BB_VER=KBUILD_STR(1.28.1)" -O2 -Wall -pipe -I/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-WeTek_Play.arm-9.0-devel-systemd-glibc226/toolchain/include -Wno-format-security -Wall -Wshadow -Wwrite-strings -Wundef -Wstrict-prototypes -Wunused -Wunused-parameter -Wunused-function -Wunused-value -Wmissing-prototypes -Wmissing-declarations -Wno-format-security -Wdeclaration-after-statement -Wold-style-definition -fno-builtin-strlen -finline-limit=0 -fomit-frame-pointer -ffunction-sections -fdata-sections -fno-guess-branch-probability -funsigned-char -static-libgcc -falign-functions=1 -falign-jumps=1 -falign-labels=1 -falign-loops=1 -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-builtin-printf -Os     -D"KBUILD_STR(s)=#s" -D"KBUILD_BASENAME=KBUILD_STR(uidgid_get)"  -D"KBUILD_MODNAME=KBUILD_STR(uidgid_get)" -c -o libpwdgrp/uidgid_get.o libpwdgrp/uidgid_get.c
libbb/appletlib.c: In function 'find_applet_by_name':
libbb/appletlib.c:203:5: warning: "KNOWN_APPNAME_OFFSETS" is not defined, evaluates to 0 [-Wundef]
 #if KNOWN_APPNAME_OFFSETS <= 0
     ^~~~~~~~~~~~~~~~~~~~~
libbb/appletlib.c:204:8: error: 'NUM_APPLETS' undeclared (first use in this function); did you mean 'PF_APPLETALK'?
  max = NUM_APPLETS;
        ^~~~~~~~~~~
        PF_APPLETALK
libbb/appletlib.c:204:8: note: each undeclared identifier is reported only once for each function it appears in
libbb/appletlib.c: At top level:
libbb/appletlib.c:905:6: warning: "NUM_APPLETS" is not defined, evaluates to 0 [-Wundef]
 # if NUM_APPLETS > 0
      ^~~~~~~~~~~
libbb/appletlib.c: In function 'run_applet_and_exit':
libbb/appletlib.c:953:7: warning: "NUM_APPLETS" is not defined, evaluates to 0 [-Wundef]
 #  if NUM_APPLETS > 0
       ^~~~~~~~~~~
libbb/appletlib.c: In function 'main':
libbb/appletlib.c:1061:7: error: 'NUM_APPLETS' undeclared (first use in this function); did you mean 'PF_APPLETALK'?
   if (NUM_APPLETS > 1)
       ^~~~~~~~~~~
       PF_APPLETALK
make[2]: *** [scripts/Makefile.build:197: libbb/appletlib.o] Error 1
```

I'm reverting the original attempt to fix this as it needs to be applied to init, host and target.