### PR TITLE
buildsystem: save/load build config, simplify clean and build --all

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -765,6 +765,22 @@ check_path() {
   fi
 }
 
+load_build_config() {
+  if [ -d "${1}" -a -f ${1}/.build.conf ]; then
+    source ${1}/.build.conf
+    return 0
+  fi
+  return 1
+}
+
+save_build_config() {
+  local var
+  rm -f ${BUILD}/.build.conf
+  for var in PROJECT DEVICE ARCH DEBUG BUILD_SUFFIX; do
+    echo "export ${var}=\"${!var}\"" >> ${BUILD}/.build.conf
+  done
+}
+
 check_config() {
   dashes="==========================="
   if [ ! -d $PROJECT_DIR/$PROJECT ]; then

--- a/scripts/build
+++ b/scripts/build
@@ -20,6 +20,15 @@
 
 . config/options $1
 
+if [ "$1" = "--all" ]; then
+  if [ ! -z "$2" ]; then
+    for build_dir in $(ls -1d ${ROOT}/build.*); do
+      load_build_config ${build_dir} && ./scripts/build $2
+    done
+  fi
+  exit 0
+fi
+
 if [ -z "$1" ]; then
   echo "usage: $0 package_name[:<host|target|init|bootstrap>]"
   exit 1

--- a/scripts/clean
+++ b/scripts/clean
@@ -48,14 +48,8 @@ clean_package() {
 
 if [ "$1" = "--all" ]; then
   if [ ! -z "$2" ]; then
-    for PROJECT in $(ls -1 projects); do
-      for archfile in projects/$PROJECT/linux/linux.*.conf; do
-        if [ ! -f "$archfile" ]; then
-          archfile="$(ls -1 projects/$PROJECT/linux/*/linux.*.conf | head -1)"
-        fi
-        ARCH=`echo $archfile | sed -n '$s/\.conf//;$s/.*\.//p'`
-        PROJECT=$PROJECT ARCH=$ARCH ./scripts/clean $2
-      done
+    for build_dir in $(ls -1d ${ROOT}/build.*); do
+      load_build_config "${build_dir}" && ./scripts/clean $2
     done
   fi
 else

--- a/scripts/image
+++ b/scripts/image
@@ -25,6 +25,8 @@ unset _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL _DEBUG_DEPENDS_LIST _DEBUG_PACK
 . config/show_config
 show_config
 
+save_build_config
+
 setup_toolchain target
 
 $SCRIPTS/checkdeps


### PR DESCRIPTION
Following on from #2516, this is an attempt to save some "state" within each build directory so that it doesn't have to be parsed from the build directory name which isn't going to be reliable/easy in every case.

Have I missed anything (any variables, reasons why this won't work)?

It's not perfect, I realise it's possible to rebuild with different DEBUG values each time, so the presence of DEBUG is somewhat informational and probably shouldn't be relied upon, but would represent the last value used.

The config is only saved when executing `scripts/image` - not sure if this is going to be a problem with addons. I can't imagine anyone builds the main image exclusively using `scripts/build`.