### PR TITLE
update retroplayer add-ons and emulation packages

### DIFF
--- a/packages/emulation/libretro-2048/package.mk
+++ b/packages/emulation/libretro-2048/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-2048"
-PKG_VERSION="a40238a"
-PKG_SHA256="7d39dbf3541f7c9f2b415844c82c0f9cfcd820b8422f19a91d0af59a4c31decf"
+PKG_VERSION="6b6451b"
+PKG_SHA256="843dcd7d88b6bf8092d1e3c48ddbde0dceefe12200b6f52b31d05448eeee491a"
 PKG_ARCH="any"
 PKG_LICENSE="Public domain"
 PKG_SITE="https://github.com/libretro/libretro-2048"

--- a/packages/emulation/libretro-4do/package.mk
+++ b/packages/emulation/libretro-4do/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-4do"
-PKG_VERSION="5f3804f"
-PKG_SHA256="7cca3185facc3b108c66469fb5922a1d7ee4672763cf4277f055689598d92914"
+PKG_VERSION="12eba56"
+PKG_SHA256="1aee495919d1cc0f71f965c1d6fc61a548cad36f1826aaf52207c0650dbf2886"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://github.com/libretro/4do-libretro"

--- a/packages/emulation/libretro-beetle-bsnes/package.mk
+++ b/packages/emulation/libretro-beetle-bsnes/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-bsnes"
-PKG_VERSION="9baf065"
-PKG_SHA256="8f815875d3853f1e19ae0d9332941934ab9137a53f27d53fd07dcf53f939d100"
+PKG_VERSION="df62d15"
+PKG_SHA256="68ab3eaccbc39ffc7457945c8eea81a4fba02d385d0561336d189deb21f2013e"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-bsnes-libretro"

--- a/packages/emulation/libretro-beetle-lynx/package.mk
+++ b/packages/emulation/libretro-beetle-lynx/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-lynx"
-PKG_VERSION="bed327e"
-PKG_SHA256="4c0c2f4c13dc602b6812e26924b168e9814f8d4b865652a1758b3b459766135c"
+PKG_VERSION="4e9a4f2"
+PKG_SHA256="420397ab0bf29cc9405d5361b0ca2346ae81ec4365c4df8934d2cdd550c8d545"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-lynx-libretro"

--- a/packages/emulation/libretro-beetle-ngp/package.mk
+++ b/packages/emulation/libretro-beetle-ngp/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-ngp"
-PKG_VERSION="024d3ec"
-PKG_SHA256="bdf596f08dfa9b6a02bdced744b26683406d620303f21c61831e4a7765d4adcc"
+PKG_VERSION="9e33e1b"
+PKG_SHA256="8f08d0390afb7ef515ccbd64c90f2e00c60629c868fb953078d38a39608eef0c"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-ngp-libretro"

--- a/packages/emulation/libretro-beetle-pce-fast/package.mk
+++ b/packages/emulation/libretro-beetle-pce-fast/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-pce-fast"
-PKG_VERSION="7d908c1"
-PKG_SHA256="0c4ea2197cf5c6b28fec5466d0a3f0f16b5156bb5d5f954ce87003525659d87c"
+PKG_VERSION="20105f7"
+PKG_SHA256="044e629c56c8f8320ca61ee6e4bc7cc980590f68e3a8f1896ab6a2c17235cd66"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-pce-fast-libretro"

--- a/packages/emulation/libretro-beetle-pcfx/package.mk
+++ b/packages/emulation/libretro-beetle-pcfx/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-pcfx"
-PKG_VERSION="149d2a0"
-PKG_SHA256="2215ebacd07c5054e5aba8b16bd9ccc23ba9bd94b149e9e39e2e8b7fffceb541"
+PKG_VERSION="11be243"
+PKG_SHA256="ae020825ca7f50686daad87ab68a20a11ffc1d8b96b662308b512a607ad34b37"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-pcfx-libretro"

--- a/packages/emulation/libretro-beetle-psx/package.mk
+++ b/packages/emulation/libretro-beetle-psx/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-psx"
-PKG_VERSION="8a0e087"
-PKG_SHA256="abb74ded08fc501abe868a5240ce73b8e1ced46d516f0c8052e362ed9b700475"
+PKG_VERSION="80a21f2"
+PKG_SHA256="e889b55fc3b42821244819c4a93bf33419b89e08bb0d3d39b7fa5f537062c2cf"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-psx-libretro"

--- a/packages/emulation/libretro-beetle-saturn/package.mk
+++ b/packages/emulation/libretro-beetle-saturn/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-saturn"
-PKG_VERSION="092dae3"
-PKG_SHA256="cf17912226912ffea0d59060c097d50e338fb06df069322abedd6a8eca5cc649"
+PKG_VERSION="672ef1c"
+PKG_SHA256="465f7c59b01dbe191aa17e596cc521a2eee0c64b3eca512503f7ca8cd3228f57"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/beetle-saturn-libretro"

--- a/packages/emulation/libretro-beetle-vb/package.mk
+++ b/packages/emulation/libretro-beetle-vb/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-vb"
-PKG_VERSION="9c683c2"
-PKG_SHA256="749efc530e5b9872a2df720e3ab94955752926083c981af5bd24bfb38bbf668c"
+PKG_VERSION="857a4b2"
+PKG_SHA256="e07200e798b1cacc27f2f3327b1a4607381704da5b3bba4801987f7a7ef02433"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-vb-libretro"

--- a/packages/emulation/libretro-beetle-wswan/package.mk
+++ b/packages/emulation/libretro-beetle-wswan/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-beetle-wswan"
-PKG_VERSION="3d6e700"
-PKG_SHA256="23584a6348d254e62bc770ac9232e8c24c238890970ba81051bbbefd8cb0f5b3"
+PKG_VERSION="93459f9"
+PKG_SHA256="5bafa89b4473d96ef358a21145399100067ef22300187e1beef6c7cfa4677dff"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-wswan-libretro"

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-bluemsx"
-PKG_VERSION="8268f7f"
-PKG_SHA256="7d78d09ca65857f56fcfa85dde56cd9e32d68828fdd74d7496d901401991de33"
+PKG_VERSION="997643b"
+PKG_SHA256="187bcc77c2f99dbef6b88a0f41d9c45926f39339daa34f511c535b9da0f9f6ab"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/blueMSX-libretro"

--- a/packages/emulation/libretro-bnes/package.mk
+++ b/packages/emulation/libretro-bnes/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-bnes"
-PKG_VERSION="b3b740f"
-PKG_SHA256="62612bf544fcfbc87a2f469f9ec5be7ee9d2fcf76bed5e59143a7cb48bd4ae93"
+PKG_VERSION="cbdf063"
+PKG_SHA256="6487b856769ce29228d3693629f3663a8e8183fe061a21cfc1501bc0b25f2f9d"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/bnes-libretro"

--- a/packages/emulation/libretro-bsnes-mercury-accuracy/package.mk
+++ b/packages/emulation/libretro-bsnes-mercury-accuracy/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-bsnes-mercury-accuracy"
-PKG_VERSION="fea594b"
-PKG_SHA256="b0548de126597999c6c42c5290cd6a10ad32de1aefa00b6a5ba4b172f01ab530"
+PKG_VERSION="2aa1bc1"
+PKG_SHA256="c273137807ae1308dd76bfd5cb1639ab8ebf4a74f0857e082468bba871d0ad00"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/bsnes-mercury"

--- a/packages/emulation/libretro-bsnes-mercury-balanced/package.mk
+++ b/packages/emulation/libretro-bsnes-mercury-balanced/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-bsnes-mercury-balanced"
-PKG_VERSION="fea594b"
-PKG_SHA256="b0548de126597999c6c42c5290cd6a10ad32de1aefa00b6a5ba4b172f01ab530"
+PKG_VERSION="2aa1bc1"
+PKG_SHA256="c273137807ae1308dd76bfd5cb1639ab8ebf4a74f0857e082468bba871d0ad00"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/bsnes-mercury"

--- a/packages/emulation/libretro-bsnes-mercury-performance/package.mk
+++ b/packages/emulation/libretro-bsnes-mercury-performance/package.mk
@@ -17,9 +17,10 @@
 ################################################################################
 
 PKG_NAME="libretro-bsnes-mercury-performance"
-PKG_VERSION="fea594b"
-PKG_SHA256="b0548de126597999c6c42c5290cd6a10ad32de1aefa00b6a5ba4b172f01ab530"
-PKG_ARCH="any"
+PKG_VERSION="2aa1bc1"
+PKG_SHA256="c273137807ae1308dd76bfd5cb1639ab8ebf4a74f0857e082468bba871d0ad00"
+# currently broken
+PKG_ARCH="none"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/bsnes-mercury"
 PKG_URL="https://github.com/libretro/bsnes-mercury/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-craft/package.mk
+++ b/packages/emulation/libretro-craft/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-craft"
-PKG_VERSION="7dc449e"
-PKG_SHA256="595380372530bd8b1b5116d62a25c2aa546d226887944d1f56bfeb311e6b9f08"
+PKG_VERSION="7421f79"
+PKG_SHA256="bea0743bddd8e1d91584a89ff4a6bbca4d9e54547181f833403569321b3ab319"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/Craft"

--- a/packages/emulation/libretro-desmume/package.mk
+++ b/packages/emulation/libretro-desmume/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-desmume"
-PKG_VERSION="9464582"
-PKG_SHA256="706af70135e1a33845d1b24163b9ab496f61219c958598d90d2283f6b4ee79b9"
+PKG_VERSION="1dd58e4"
+PKG_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/desmume"

--- a/packages/emulation/libretro-fbalpha/package.mk
+++ b/packages/emulation/libretro-fbalpha/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-fbalpha"
-PKG_VERSION="529a485"
-PKG_SHA256="64a04771e616611562b047d9cd8c04e6f9100640d281960d82783a7682706792"
+PKG_VERSION="2ff7108"
+PKG_SHA256="1f39822a4632172c8b5b2719af340d45e6f9408afd007b574ee95022e3d8a649"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/fbalpha"

--- a/packages/emulation/libretro-fceumm/package.mk
+++ b/packages/emulation/libretro-fceumm/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-fceumm"
-PKG_VERSION="166573c"
-PKG_SHA256="6f735097bcf02da42a264fef12179b8d33f1be3919e3c5d35c35439208221c7a"
+PKG_VERSION="9ad88b9"
+PKG_SHA256="2ab114203f43041feebccc94634a1cf3ca72aab8b7817e3563eee84e6e40d74b"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-fceumm"

--- a/packages/emulation/libretro-fmsx/package.mk
+++ b/packages/emulation/libretro-fmsx/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-fmsx"
-PKG_VERSION="7d19e66"
-PKG_SHA256="3bd047889ac95bf0d19a2abd07b96422a5a329d017c4eb6cd65999fe8200bacb"
+PKG_VERSION="3ad7ded"
+PKG_SHA256="c4082ee8974b2d01e131aa6511f8ad4e8a1769744904614484cfb4c507532b00"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/fmsx-libretro"

--- a/packages/emulation/libretro-fuse/package.mk
+++ b/packages/emulation/libretro-fuse/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-fuse"
-PKG_VERSION="a990e57"
-PKG_SHA256="3d23f9498e5a2aba54ea797074dc5c99bee4747886a0b37a08846e18f7aea823"
+PKG_VERSION="58ec13f"
+PKG_SHA256="bdb762cf33c7884c085c6f109145486e149bb7d132779c0133d90e85ea79e467"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/fuse-libretro"

--- a/packages/emulation/libretro-gambatte/package.mk
+++ b/packages/emulation/libretro-gambatte/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-gambatte"
-PKG_VERSION="b1b25eb"
-PKG_SHA256="b2386f4cf7a098e3d3be20f53613a997d4beb33d943d8642c884516176a97ddc"
+PKG_VERSION="22894d5"
+PKG_SHA256="4461a2ea4d9b61745c5abfab2b122ad52a5f58fba5ac8f401ce874f29b9bc304"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/gambatte-libretro"

--- a/packages/emulation/libretro-genplus/package.mk
+++ b/packages/emulation/libretro-genplus/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-genplus"
-PKG_VERSION="7176e8a"
-PKG_SHA256="7284f4eb67fecd26f7f878871505126ed939a9709bbb14a12433ffe2ff648d5d"
+PKG_VERSION="6ba9e05"
+PKG_SHA256="51efda2061d483824bc71c91537dfbfc3edb006cda339bc4c50fc4fc7f93d599"
 PKG_ARCH="any"
 PKG_LICENSE="Modified BSD / LGPLv2.1"
 PKG_SITE="https://github.com/libretro/Genesis-Plus-GX"
@@ -35,6 +35,7 @@ PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="GENPLUS_LIB"
 
 make_target() {
+  strip_lto
   make -f Makefile.libretro
 }
 

--- a/packages/emulation/libretro-gw/package.mk
+++ b/packages/emulation/libretro-gw/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-gw"
-PKG_VERSION="8f054a1"
-PKG_SHA256="15aea9d03e68600c739faa91cc0b7270290983cc6afc5d86e17ae38adf5abdde"
+PKG_VERSION="9962b03"
+PKG_SHA256="fc10aaa0caf3e44e3bc73388bb014618e1829a0edd6979cc4181776b3e9e770f"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/gw-libretro"

--- a/packages/emulation/libretro-handy/package.mk
+++ b/packages/emulation/libretro-handy/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-handy"
-PKG_VERSION="b055dc6"
-PKG_SHA256="3d680936f02ae2763794a5aca92c95112979330b45434fb4f866fdf1dfc8d97d"
+PKG_VERSION="a3d88fe"
+PKG_SHA256="2f73151d53d866a0ef64cf1e7d24f9fb41483fe26fd22d0ee8a3e012aafe2e19"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-handy"

--- a/packages/emulation/libretro-hatari/package.mk
+++ b/packages/emulation/libretro-hatari/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-hatari"
-PKG_VERSION="c19b7105"
-PKG_SHA256="590de28ee47d15a01ec12a3735b377c54651e49a7b0e29dcabac0d5984c8ac65"
+PKG_VERSION="eb3271d3"
+PKG_SHA256="dcc02b09524b02ae6110c409d3d22dd09013c858c08e9706fd2e29e8a11080a1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/hatari"

--- a/packages/emulation/libretro-mame/package.mk
+++ b/packages/emulation/libretro-mame/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-mame"
-PKG_VERSION="ae98d8cfeb"
-PKG_SHA256="de3ddce9da62905d59d51132fa5c872337ccbb201376d2f3556324b006092a22"
+PKG_VERSION="bee25da1dc"
+PKG_SHA256="95ac6c1455eba1dd2f1239516962dfbe9d33cd5bb4c506a1e53df0c2ea65f824"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mame"

--- a/packages/emulation/libretro-meteor/package.mk
+++ b/packages/emulation/libretro-meteor/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-meteor"
-PKG_VERSION="bcb6235"
-PKG_SHA256="6684fdd2fe893aa735b5bc4f252f2822c71097cb7eb47994fe2246b9121f0fe1"
+PKG_VERSION="a052776"
+PKG_SHA256="7960a7b57bac84ee34cc76fbc6545fe5feb10c8cf2fe97b971a3c69791e59765"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/meteor-libretro"

--- a/packages/emulation/libretro-mgba/package.mk
+++ b/packages/emulation/libretro-mgba/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-mgba"
-PKG_VERSION="05e2ff4d"
-PKG_SHA256="cf30fc7946a3aafa4c44c41249a016b89d42f5cf974ecb65e805fb7c2b5dcc4c"
+PKG_VERSION="848e95f6"
+PKG_SHA256="6d6e80967c2dfdc59bd5e685381071f9f61c0f0e5800655040664bd32ceceb2e"
 PKG_ARCH="any"
 PKG_LICENSE="MPL 2.0"
 PKG_SITE="https://github.com/libretro/mgba"

--- a/packages/emulation/libretro-mrboom/package.mk
+++ b/packages/emulation/libretro-mrboom/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-mrboom"
-PKG_VERSION="4161fbf"
-PKG_SHA256="3651bcbdcb3e70eccc3c8bf43f2b90173bb128cac489e0aebda48ab34cd33c1d"
+PKG_VERSION="fac770a"
+PKG_SHA256="17bef20db2b433610e09675c069df7d7383a011e7a4443d1a832258435a6b5d0"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/mrboom-libretro"

--- a/packages/emulation/libretro-nestopia/package.mk
+++ b/packages/emulation/libretro-nestopia/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-nestopia"
-PKG_VERSION="ef33882"
-PKG_SHA256="effeb87eb446afee44fa372976801e0b85f38a84aa2bb1944dbaf41caf62f3c6"
+PKG_VERSION="14329a3"
+PKG_SHA256="6c2d01a7bf75ec021e957be2e2bdad181001c0d9796d5370423a5c547b3c3e1a"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/nestopia"
@@ -35,7 +35,6 @@ PKG_LIBPATH="libretro/$PKG_LIBNAME"
 PKG_LIBVAR="NESTOPIA_LIB"
 
 post_unpack() {
-  rm $PKG_BUILD/CMakeLists.txt
   rm $PKG_BUILD/configure.ac
 }
 

--- a/packages/emulation/libretro-nx/package.mk
+++ b/packages/emulation/libretro-nx/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-nx"
-PKG_VERSION="3826092"
-PKG_SHA256="493d55f48d0009b67e34962f55f9faa40afc5fd142cdb6ee05c5f326b950ff01"
+PKG_VERSION="0d935ba"
+PKG_SHA256="dd71342ab3313b7ce8c0b1d2df4042099b62fcbe116c6efa30186bfe94219bb0"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/nxengine-libretro"

--- a/packages/emulation/libretro-o2em/package.mk
+++ b/packages/emulation/libretro-o2em/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-o2em"
-PKG_VERSION="c3dbcfa"
-PKG_SHA256="6fc616041c228d251c2d5c67cfbac78c123e28e9937e1ee89a3c31770560c968"
+PKG_VERSION="84586bb"
+PKG_SHA256="4e48d0a2b1b483646105583059eba0c87d60e76d1dff41084f7335d5fc4ba88b"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-o2em"

--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-pcsx-rearmed"
-PKG_VERSION="ec665d1"
-PKG_SHA256="57f345feba92b79ccc42cdc6f0e2dfc41d79b10e0101c1224c6ebfd0b77c283c"
+PKG_VERSION="ea4f438"
+PKG_SHA256="5701f95baa8af35c2bd6cae85652c91a91ec340a1d7509efd25ac1d8913d9b74"
 PKG_ARCH="arm"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/pcsx_rearmed"

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-picodrive"
-PKG_VERSION="e768a4d"
-PKG_SHA256="8982d382a6ccb36acc4ef7846e30a60c81b6f1c75f539bf019ce122b2256e893"
+PKG_VERSION="4ad0087"
+PKG_SHA256="3c86fc54f3c6bc7642d5c7da4e19a6b52b3f4b756c6a81c9b531e08c3e88ba55"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/picodrive"

--- a/packages/emulation/libretro-ppsspp/package.mk
+++ b/packages/emulation/libretro-ppsspp/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-ppsspp"
-PKG_VERSION="5f7bcf7"
-PKG_SHA256="09e61300c05705b1f98e1b575e44d366e5a243cc3be97b3a09ad420581459f87"
+PKG_VERSION="9145287"
+PKG_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-ppsspp"

--- a/packages/emulation/libretro-prboom/package.mk
+++ b/packages/emulation/libretro-prboom/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-prboom"
-PKG_VERSION="a907bcc"
-PKG_SHA256="cac3fe2d630e1d1c285850ad63c40d6a681dd1eccbef37ad85eed0dbdb7c8f6c"
+PKG_VERSION="494885c"
+PKG_SHA256="c49921bce3588b2775aed4f65dc014c0e68be2eb6014ea2e2e2eed23940f44da"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-prboom"

--- a/packages/emulation/libretro-prosystem/package.mk
+++ b/packages/emulation/libretro-prosystem/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-prosystem"
-PKG_VERSION="9e1baaa"
-PKG_SHA256="20c704cbd2d4d72487564136a3de6eea790ccf27a33229f5d0178578f8040dd5"
+PKG_VERSION="71a2d1d"
+PKG_SHA256="f9484505b156bb509828e33861a90cfb8e9e9ebdca27016192da80bf217a9595"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/prosystem-libretro"

--- a/packages/emulation/libretro-quicknes/package.mk
+++ b/packages/emulation/libretro-quicknes/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-quicknes"
-PKG_VERSION="8c4f63a"
-PKG_SHA256="dfc239aff871aa2d43eca86ba63007c6cfee8f93c8e2a9766fc9538fb86d256d"
+PKG_VERSION="b4598fd"
+PKG_SHA256="4334c12e39c041b4a766cd93543681da1418971c93aad73777ad3e97d367a44c"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/QuickNES_Core"

--- a/packages/emulation/libretro-reicast/package.mk
+++ b/packages/emulation/libretro-reicast/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-reicast"
-PKG_VERSION="74c4ddf"
-PKG_SHA256="6a0d8e07cc6ba2babcd0524c78b27b88f3757054e6940ed0bed5530963c6313c"
+PKG_VERSION="fff2eb2"
+PKG_SHA256="257eaaac13f723568b76629fda89c2e7c87b2ecd59c0b29bb2e1c230e572f9c2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/reicast-emulator"

--- a/packages/emulation/libretro-scummvm/package.mk
+++ b/packages/emulation/libretro-scummvm/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-scummvm"
-PKG_VERSION="6345d9a9aa"
-PKG_SHA256="bec6ff9b77591a52ed7ede23ced272b543b007bfe862e86d1ccadc45d7168d39"
+PKG_VERSION="93d1ca12b6"
+PKG_SHA256="5a39e30bda47fe6b71e3f7ef05e91eda20dea001f7ebbe47b5a7579fadaf8178"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/scummvm"

--- a/packages/emulation/libretro-snes9x/package.mk
+++ b/packages/emulation/libretro-snes9x/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-snes9x"
-PKG_VERSION="18b5fee"
-PKG_SHA256="a6cb8f0371d161477c74ec473cb2d1eaa2facb5321ef76223fa2f7f69d5e0ebf"
+PKG_VERSION="2a15fe2"
+PKG_SHA256="0cce10b7feb213fa2c4f7c885379eaecabd25edb07ec94487450b75ee276fea5"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/snes9x"

--- a/packages/emulation/libretro-snes9x2002/package.mk
+++ b/packages/emulation/libretro-snes9x2002/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-snes9x2002"
-PKG_VERSION="077f38e"
-PKG_SHA256="cc66c25df3a524fc68e8e0eec3367ac49961422eab713c430181d2494a246787"
+PKG_VERSION="d8084b0"
+PKG_SHA256="4b4da7d7edc84948f7282e621efb25b82c7a749c3352a8e15f5af2159191cb08"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/snes9x2002"

--- a/packages/emulation/libretro-snes9x2010/package.mk
+++ b/packages/emulation/libretro-snes9x2010/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-snes9x2010"
-PKG_VERSION="48eebbb"
-PKG_SHA256="2dca9ab4696457939b6b0e180c449676150e884bb6f2546f14ab5164171ca72e"
+PKG_VERSION="b9be098"
+PKG_SHA256="d7474d6c2bba537d0e373ea4fb71d78e6aaf50ddaddf2e0ef9bf5c12f84be93b"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/snes9x2010"

--- a/packages/emulation/libretro-stella/package.mk
+++ b/packages/emulation/libretro-stella/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-stella"
-PKG_VERSION="dec8e55"
-PKG_SHA256="6a974685201039e547b7b898404d5a3dd05d2cec5c32be234b76aceca1f0c882"
+PKG_VERSION="3a79356"
+PKG_SHA256="a0f62116b9521f6b65f995f147e1bdb485dba6a6547e5ca15c58556f93c648f9"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/stella-libretro"

--- a/packages/emulation/libretro-tgbdual/package.mk
+++ b/packages/emulation/libretro-tgbdual/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-tgbdual"
-PKG_VERSION="4e111be"
-PKG_SHA256="d16d9fd374519d32b3bbfd9a526aba31f137f194a95c0abe20632dad3fa59600"
+PKG_VERSION="e1f8348"
+PKG_SHA256="8eeb4585f527613bf87f91881a858a572b02683a6b953c3b8b46012289d112fe"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/tgbdual-libretro"

--- a/packages/emulation/libretro-tyrquake/package.mk
+++ b/packages/emulation/libretro-tyrquake/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-tyrquake"
-PKG_VERSION="6124474"
-PKG_SHA256="0480863d4a3c5261015e2b9446e1ea090abc2dbad2647511e2da85a5c4a9f291"
+PKG_VERSION="f13e368"
+PKG_SHA256="b70b9a3181e17851f2056c95a42de7c4ccd704e78abbe6cfb218d071c594d02b"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/tyrquake"

--- a/packages/emulation/libretro-vba-next/package.mk
+++ b/packages/emulation/libretro-vba-next/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-vba-next"
-PKG_VERSION="6b4bbcb"
-PKG_SHA256="bfe16b0c51cdd485efd29ead679caee2c6b2da670f28f3d63886c503531d5a5c"
+PKG_VERSION="34e02e2"
+PKG_SHA256="b33da0433ba89570211565c0e9e8fd2f66a3393e82fce843705c89f72fa9d1f9"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vba-next"

--- a/packages/emulation/libretro-vecx/package.mk
+++ b/packages/emulation/libretro-vecx/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-vecx"
-PKG_VERSION="849e27d"
-PKG_SHA256="2d0d28ae79c2f03e2fe2a4acbb8f46e5d6a7966ee90a4930eaf9fca52bde00d3"
+PKG_VERSION="b78b3d1"
+PKG_SHA256="f44e5bdcb2b717cea28ae51edcb6f5057e717c38c923f5384f64923823f522b4"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-vecx"

--- a/packages/emulation/libretro-virtualjaguar/package.mk
+++ b/packages/emulation/libretro-virtualjaguar/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-virtualjaguar"
-PKG_VERSION="9b9ab23"
-PKG_SHA256="32038693c34939f44bfef4a0fa69e9f852fb556583c46d946baf90d16774dd78"
+PKG_VERSION="48739c2"
+PKG_SHA256="2fb3763ad7e23102968fea639f7dd1ec2f17e16be89d9bd90d826f3272cd1f80"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/virtualjaguar-libretro"

--- a/packages/emulation/libretro-yabause/package.mk
+++ b/packages/emulation/libretro-yabause/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="libretro-yabause"
-PKG_VERSION="c55eef9"
-PKG_SHA256="d445a71486fc485498b54fb58299cab6019b5d17ef458cf179aef253b1c2ead0"
+PKG_VERSION="3c1f22e"
+PKG_SHA256="267229662a6ca5f28b14ee8cb78949459e178fb27410ba40a962b10914c078e5"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/yabause"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.2048"
-PKG_VERSION="0201962"
-PKG_SHA256="0f781e3f79ed30ea3b0a66d4a3c387a480b22a0497250680350303ceb5a5ac84"
-PKG_REV="104"
+PKG_VERSION="22c1e8a"
+PKG_SHA256="915bcae4a400fa08a39fd79beeccc256cde11aa288e1371b6fb27ff56154502d"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.2048"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.4do/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.4do/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.4do"
-PKG_VERSION="401299a"
-PKG_SHA256="29eab3714d2ee051b04c4ad9ec14c6dca378d8b2fd8807551a087046ee16f7bf"
-PKG_REV="104"
+PKG_VERSION="d51afc5"
+PKG_SHA256="ad37ec87a0d0d891fc75858329841dcf1725689fb8964f6e1767241b8a9edf7f"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.4do"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-bsnes"
-PKG_VERSION="00d5f21"
-PKG_SHA256="4d1b1ea06f724c1b91d64f57fba37f6be27f0664f911baf0134444f5d0a92ea7"
-PKG_REV="103"
+PKG_VERSION="2f03b47"
+PKG_SHA256="9d973e38ba41902e1cd17cf914fca8a700ca75383cf3de2471f91cb10dbbd150"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-bsnes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-gba"
-PKG_VERSION="000cac3"
-PKG_SHA256="9304e821b5d4cff3e588ab077410fe7f727a486fb8decfc64fa9cb1c0a49262d"
-PKG_REV="104"
+PKG_VERSION="df02528"
+PKG_SHA256="3f4c57991187ae921db8df01ba2767bed04a42089c1a2f7b87eeb15b3a31bde5"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-gba"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-lynx"
-PKG_VERSION="2fbafe1"
-PKG_SHA256="e1083d1f4026457d5842c6bface15804361bb8cbdd939ab1e90a32a39bb66e51"
-PKG_REV="104"
+PKG_VERSION="0d1c89b"
+PKG_SHA256="f520b0c1f4320343e9f82aba053b4d12ad1c6210b2b0f96bb28ecbd69f17f7af"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-lynx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-ngp"
-PKG_VERSION="3a801b3"
-PKG_SHA256="37832b8cd6b12d67c680f10f5deaf85973f91222c691b1552a23ef2a64b16efb"
-PKG_REV="104"
+PKG_VERSION="94378ba"
+PKG_SHA256="189d3316ce1f08124aaacc7e97645a1d0b7302c613a02c2bcf82ba0e22b661c6"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-ngp"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-pce-fast"
-PKG_VERSION="411d954"
-PKG_SHA256="67745121a4377eda414f3dd7f045a80e5184deb8d42caad8ecc2e99983d6d647"
-PKG_REV="104"
+PKG_VERSION="2e0e463"
+PKG_SHA256="f3f5d4c913c04ec90216278547cabaebb608264a6d5f9e8126f27e6d6e3483a4"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-pce-fast"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-pcfx"
-PKG_VERSION="744e232"
-PKG_SHA256="39d5de08175e6e21a732a360b16a92107ce0721230226f3600c6083d7c05e7b0"
-PKG_REV="104"
+PKG_VERSION="727c3f8"
+PKG_SHA256="9b269fe7db99271084880abcc4072bcf83493a48672cd16b33d5d5a085306c36"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-pcfx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-psx"
-PKG_VERSION="3fd255a"
-PKG_SHA256="29abf56d013e2d20541b8beb8bb511cd8650e20fce1b7d5111e0ab841511c22e"
-PKG_REV="104"
+PKG_VERSION="8327779"
+PKG_SHA256="c54c10cb23ac5541e18fd45ac38ae5088989052b402c934d7ddef041f9e0eeb2"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-psx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-saturn"
-PKG_VERSION="72999fb"
-PKG_SHA256="8be901699b8d663b720e0a690b61879382e52eba5cc044625cdbe9850bc4d651"
-PKG_REV="104"
+PKG_VERSION="d1094ab"
+PKG_SHA256="8f7a1964b3de959404bcecd1878165c32513c2257bbbf1151389360752900eae"
+PKG_REV="105"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-supergrafx"
-PKG_VERSION="a554dd5"
-PKG_SHA256="38c081b3baab23ef603c11f08669ee13df293687840ea609f4ad07d1a2650e49"
-PKG_REV="104"
+PKG_VERSION="3e7b1ae"
+PKG_SHA256="9fff047dca05d86e4be012f5ecd9022e2861b53fa5a50b37e9eb675825536bbe"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-supergrafx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-vb"
-PKG_VERSION="7adb0ef"
-PKG_SHA256="cc5a1896f2bf31fd8cddbc0349aaed0d5881b982e0daddba03f6d310b546131a"
-PKG_REV="104"
+PKG_VERSION="1160f9c"
+PKG_SHA256="6b9219b9a8220b7e7a6dc1888b8122b6222696bbadfec59fbe4b7cdb10114fb5"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-vb"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.beetle-wswan"
-PKG_VERSION="7be4ad8"
-PKG_SHA256="925c27dcb1c712b0fe2419fbefe248087589e0df7b14badeed71e35ca32c4d92"
-PKG_REV="104"
+PKG_VERSION="f21ef1d"
+PKG_SHA256="46bf4e6388d844d28a6c7a72908acdfa47bf41a35b3ff2ce2efdf94c9ec13e07"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-wswan"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bluemsx"
-PKG_VERSION="e10bf33"
-PKG_SHA256="3f1c885eab212367c1b1bcdf73bfb9e7bf5ea6cb2eb7c46bbd495332f97e583d"
-PKG_REV="104"
+PKG_VERSION="53c181c"
+PKG_SHA256="7a751e5bf8e5ccbb2a6dde5778503d8a853b70f359f569c69d1cbe52cb83291b"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bluemsx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bnes"
-PKG_VERSION="dc3e9ac"
-PKG_SHA256="eb9c5e77b55e24426e06930984eb985b278a1ee37e6a833d75ed8d5f96a0ee92"
-PKG_REV="103"
+PKG_VERSION="e8e1f0a"
+PKG_SHA256="735f856b85502cc197cb4f700bf0741018de5779f6a3e6f921a766e8d7dfccf7"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bnes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-accuracy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-accuracy/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bsnes-mercury-accuracy"
-PKG_VERSION="f1fe5f1"
-PKG_SHA256="1d574d582674043e31801a51a4604257c6f9ae224994114a60274f8c7bbb5fae"
-PKG_REV="104"
+PKG_VERSION="a3f04e3"
+PKG_SHA256="7fb5a919a8369a9b35ef4a9e8c41d9435711252dfdff9d783a7c4abbe493dcfe"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-accuracy"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-balanced/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-balanced/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bsnes-mercury-balanced"
-PKG_VERSION="093fe75"
-PKG_SHA256="9ea1b678d51e0c0370696ebad195701ee90dc7424fe8417eb1428510d725c539"
-PKG_REV="104"
+PKG_VERSION="434bf44"
+PKG_SHA256="3e0e73ee2802aba228401647ef1a85e1398d0407874c90932cc0c849e2d31d51"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-balanced"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
@@ -17,10 +17,11 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bsnes-mercury-performance"
-PKG_VERSION="7b869fe"
-PKG_SHA256="77258758cbb4f52814394275945e64264e442c27c46c79eaadd6bb3b2b63cf4d"
-PKG_REV="104"
-PKG_ARCH="any"
+PKG_VERSION="969d80d"
+PKG_SHA256="f7c7774aa7391e591c40f59505d2b6ea16e769f4d70486f8be0b7e05bc028f82"
+PKG_REV="105"
+# currently broken
+PKG_ARCH="none"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-performance"
 PKG_URL="https://github.com/kodi-game/game.libretro.bsnes-mercury-performance/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.cap32"
-PKG_VERSION="eb8d1f0"
-PKG_SHA256="8cd82c768197ed74144f0f79e345e0bb48edaa7e7d9bfe0e5a2ab1fd13289045"
-PKG_REV="104"
+PKG_VERSION="b416bee"
+PKG_SHA256="a60a317a9551d2c471185d20ca61b77c8e645ad7a2bdc115c5e0351813519a96"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.cap32"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.craft/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.craft/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.craft"
-PKG_VERSION="0201962"
+PKG_VERSION="22c1e8a"
 PKG_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-PKG_REV="104"
+PKG_REV="105"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.desmume/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.desmume/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.desmume"
-PKG_VERSION="45311f8"
-PKG_SHA256="7d053f7f553f7ce7e7a02563396bff42c1015bf7e48a01a0078fa721b96f2507"
-PKG_REV="103"
+PKG_VERSION="c533d3c"
+PKG_SHA256="730a0025fbce3eddb2154834b6397d3afc160607afb49beffc97036aa734c96b"
+PKG_REV="104"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.dinothawr"
-PKG_VERSION="9c32d62"
-PKG_SHA256="46f3dba93a88b8e5f350d693521a1abb154553670c68c5baf1a31ba3840a1260"
-PKG_REV="104"
+PKG_VERSION="59c452b"
+PKG_SHA256="a9d1c29f2104cd9db2eb47cbf9fc30cb0a6a940a8e17c68c7a12e3de049f7ff8"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.dinothawr"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.dosbox"
-PKG_VERSION="c06c754"
-PKG_SHA256="75f711cd54f3f662673b9e1e2e51c31e99bcc7cb8d384b762a544f04a67239cf"
-PKG_REV="104"
+PKG_VERSION="b579067"
+PKG_SHA256="da5fafe44d571259ad22444b527d9a9ddea18fc90216b115abcd2d7b3ed7eebd"
+PKG_REV="105"
 PKG_ARCH="none"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.dosbox"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fbalpha/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fbalpha/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.fbalpha"
-PKG_VERSION="af65220"
-PKG_SHA256="c6dd28e96d2f003c4b118f2768ce55d59804ff04599c24a2c8f0ba0e303b65ea"
-PKG_REV="104"
+PKG_VERSION="3a35932"
+PKG_SHA256="4fd9bdde84076f5b71f966c772a70eba4ddfe62324e031b291c47492453db7f5"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fbalpha"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.fceumm"
-PKG_VERSION="d813cb3"
-PKG_SHA256="874f91bbc737aa047143a840058da012e6875bc6c42c1f7b1229f15bff3edd51"
-PKG_REV="104"
+PKG_VERSION="6f76c0f"
+PKG_SHA256="1e40821b3122f068f438dfffca65d33c7adb275e6831b9c586f081517b2d4646"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fceumm"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.fmsx"
-PKG_VERSION="8acc192"
-PKG_SHA256="a6f86206ea3b3414d69a856f307a5a1bdf39499a731cd0e229214d42e0b33ddc"
-PKG_REV="104"
+PKG_VERSION="9aa88f5"
+PKG_SHA256="d65ed887d03231d08ab93bed8ff82d7da8e13b81a2ae328a4c904e5ad6f853cd"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fmsx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.fuse"
-PKG_VERSION="6a412a1"
-PKG_SHA256="6136d9c24bcd419cb130cf205ee301ba318a8afa6b2bca71e25da3a67643f793"
-PKG_REV="104"
+PKG_VERSION="9c586d2"
+PKG_SHA256="2eae423558334ddb92e09c09fb4faa617b14eb6d0bb5cc44d284931f2531cb48"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fuse"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.gambatte"
-PKG_VERSION="37e643d"
-PKG_SHA256="ffc0b9b361e66b8215eaaf3a43b56b7fac8ba0fb8e7c0e8b0314ea93fffccb95"
-PKG_REV="104"
+PKG_VERSION="3f9e208"
+PKG_SHA256="1af5511066723041c0b2c430bdbedf628ddddb7dbb7008c24776c77462f58fba"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.gambatte"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.genplus"
-PKG_VERSION="104a3b1"
-PKG_SHA256="707b41ae20bf0c60aa3868244e85ccfbf331aefa5c63d5be5e675992f5d940f9"
-PKG_REV="104"
+PKG_VERSION="697c45b"
+PKG_SHA256="fa5a26f55e61f8cb3ad817978fb599c129eccd7aedce25ef497dfd50e804e372"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.genplus"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.gw"
-PKG_VERSION="5a85076"
-PKG_SHA256="9b839eb7353f9d39ac4cc5ddef7de2ddec8373728cdc08357682697e2345105d"
-PKG_REV="103"
+PKG_VERSION="cba1b14"
+PKG_SHA256="11eeb30d6af89958e77eff36d52e39949e5e42af9d5564418c5eddc0ca144c13"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.gw"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.handy"
-PKG_VERSION="7b8136a"
-PKG_SHA256="2a86fc020ebb4f9a946185374532933c64750e86ccf0c7e1e619bfe40ce7b1e0"
-PKG_REV="104"
+PKG_VERSION="fa3a8de"
+PKG_SHA256="6fd8be22395033f051860e1fbf0e44b830c071296c781cc2ca45152fcebaf877"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.handy"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.hatari"
-PKG_VERSION="2fcd831"
-PKG_SHA256="9c8a25965482b7b750d1e2bf2c650f43e2de21af8367acf7f2a41c5b2c945796"
-PKG_REV="104"
+PKG_VERSION="f549b95"
+PKG_SHA256="72c3a2e31e4f3bc0c93c02bfe1a96337795cbfb89c0651f229671930ded233dd"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.hatari"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.mame"
-PKG_VERSION="634efda"
-PKG_SHA256="e861ea65bd73631e23620834d99daa0165d2c8168ada25206dd3b2614ac5b508"
-PKG_REV="103"
+PKG_VERSION="2fde70a"
+PKG_SHA256="32b0633ec28166a17554c98172d0cc384d2ada744d7a675368d70b89edf4a60a"
+PKG_REV="104"
 # broken
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.meteor/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.meteor/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.meteor"
-PKG_VERSION="c37d3e6"
-PKG_SHA256="65ee9cd9e222c0eb904ffdae543dddb3395f2503a702145758c797b7661dea71"
-PKG_REV="103"
+PKG_VERSION="babdc5a"
+PKG_SHA256="a996f4c0565611f477ccdc7687e531afe0541e3d85c9a809a41e0061d9863afb"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.meteor"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.mgba"
-PKG_VERSION="b8cbebf"
-PKG_SHA256="89f6b80d902f38594b38fecdd75e3d2eab5cab548a9c9e11020cb9088312f287"
-PKG_REV="104"
+PKG_VERSION="852c528"
+PKG_SHA256="c7c908f7de6acab3f5e95f08f43edb8aaad6c047d0cacff8830e798f3f8ae3c6"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mgba"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.mrboom"
-PKG_VERSION="62ec3c9"
-PKG_SHA256="16b4fb81ad9b38ee5fdc8b303a4eb960e149fb77de02ddb0d14770458182dc3c"
-PKG_REV="104"
+PKG_VERSION="076c7ab"
+PKG_SHA256="5ddcc6f131177d4413ced1f1786ee231738241569f36398ebedec3775b4150a5"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mrboom"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.mupen64plus"
-PKG_VERSION="3945e8f"
-PKG_SHA256="513f2da95ed2a16dca9de18df94f0930577bbe527461384404f85c40563df590"
-PKG_REV="104"
+PKG_VERSION="044f830"
+PKG_SHA256="734b50202dff54a34ca5221f8011e425e759f9ca181ec0f0ed2d2fd84dada3ef"
+PKG_REV="105"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.nestopia"
-PKG_VERSION="6e4abac"
-PKG_SHA256="66a24b546b53cd863a25ddfb9813eab55c658cc6ffcd19a264e1aaf7d7357826"
-PKG_REV="104"
+PKG_VERSION="047b89c"
+PKG_SHA256="80641a62f787bbd396b659b004892e698319a6528166a32b1189a51b4f53e9e4"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.nestopia"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.nx"
-PKG_VERSION="33762ff"
-PKG_SHA256="06c2070d2c980000c81fbfadf3ac234c9c5876144fc043d9d7837888fecf47c0"
-PKG_REV="104"
+PKG_VERSION="71dce12"
+PKG_SHA256="00c04527e0faa9945a7fad8cba1d9341811396dbf9df48be78915339c81d42bf"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.nx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.o2em"
-PKG_VERSION="c2210f4"
-PKG_SHA256="0ef791e803d57f9c14d3ee512ed17a331d039da410bb22729e9a737810bafd39"
-PKG_REV="104"
+PKG_VERSION="e0c4381"
+PKG_SHA256="5b561956691e99e2629014d54b3ba531f1c43f19b63a66f91381a5e0e50762b2"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.o2em"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.pcsx-rearmed"
-PKG_VERSION="c757a2c"
-PKG_SHA256="3f2e6de7601da547a234b21e1d34d849abbb3d3ddb359602970a681d938e95e2"
-PKG_REV="104"
+PKG_VERSION="a7485c1"
+PKG_SHA256="179299489593f8080d17b724b0b9b2ee6c647ac60553158b9286520121509f74"
+PKG_REV="105"
 # neon optimizations make it only useful for arm
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.picodrive"
-PKG_VERSION="78e46a2"
-PKG_SHA256="67e0a452be2f05ca34e3396bba8d2abbb2e72932fb2988672a09fd68283dedd2"
-PKG_REV="104"
+PKG_VERSION="50d842d"
+PKG_SHA256="7cc0f0726c8b1367e842906454d791db8ccb82033d7d2d621c813ab84a842dcc"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.picodrive"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.ppsspp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.ppsspp/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.ppsspp"
-PKG_VERSION="90f965e"
-PKG_SHA256="24c80b2ea101e887a603539cd2fb9c56edfce6287cf64c9d2c1436e95eb71b57"
-PKG_REV="103"
+PKG_VERSION="e75aa69"
+PKG_SHA256="dbad2dc8d266f045f46293c875714d21d8d500ca4634710dae8b70a2b3324d3f"
+PKG_REV="104"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.prboom"
-PKG_VERSION="83ccbe0"
-PKG_SHA256="d884668a7b6659ffcbc09376514095aa45f29c42b32158ff1dce7b498b11487f"
-PKG_REV="104"
+PKG_VERSION="cfbcecb"
+PKG_SHA256="35802df2f9d1d1fa8f016a3f56dd0249f1a1917b5d3a71f3d26518cf414481ef"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.prboom"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.prosystem"
-PKG_VERSION="68e7822"
-PKG_SHA256="4f772018175042b8a70e138a013e4ae203da6f76678d9a72d3619b9a90a62b53"
-PKG_REV="104"
+PKG_VERSION="7a22855"
+PKG_SHA256="e0b21769eb80bc35b208b4a3812cbefd7127d6198525a304708faf6cc1342801"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.prosystem"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.quicknes"
-PKG_VERSION="45901f0"
-PKG_SHA256="fc583961e850c007cad4d71f96a559b8970be33477f46582f292a30cf96bfff2"
-PKG_REV="104"
+PKG_VERSION="bec9b79"
+PKG_SHA256="f52d21f1b207afd52c9f68c59bb15207c8c06940cbf26f3955c901c977e7e59b"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.quicknes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.reicast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.reicast/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.reicast"
-PKG_VERSION="eb757ee"
-PKG_SHA256="22607be634b8954ad517fa507a817ecd71053d2f6b4e6b79c2e80969fbe20f18"
-PKG_REV="104"
+PKG_VERSION="93941de"
+PKG_SHA256="ee781feff5e2955f43c60c1b65f49eafce2142221ebe31aa1098eb833b88b9fa"
+PKG_REV="105"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.scummvm"
-PKG_VERSION="972c98c"
-PKG_SHA256="e217b0c1700c1d5b61b08e45650630d559225be41b8bd50ff8107ac8567a1127"
-PKG_REV="104"
+PKG_VERSION="c454250"
+PKG_SHA256="bb41d4c66e8c43802bd6c7f63cd934ddfca2133a1ef775e6e5b668b49d494d9a"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.scummvm"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.snes9x"
-PKG_VERSION="4b1c02b"
-PKG_SHA256="1be0e03b7e2fd44b2ba2d7c96d1a93ea15b0503f5109022a80f7ca6f836c1e57"
-PKG_REV="104"
+PKG_VERSION="6c5308a"
+PKG_SHA256="1f63d0f774c502a1a9c2f2e2f59253b0b86244d56fb8eed4dab2f879ab628aae"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.snes9x"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2002/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2002/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.snes9x2002"
-PKG_VERSION="c5a7a64"
-PKG_SHA256="4906c256680c7c0584c5f95c4d7f721ab13320fb5be8614d746ef6a134599870"
-PKG_REV="103"
+PKG_VERSION="755e132"
+PKG_SHA256="e4762c7783f12b4e78d007f76b16df50d3e333d01b9f3f4c4cfd5508afc9a093"
+PKG_REV="104"
 # neon optimizations make it only useful for arm
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2010/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2010/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.snes9x2010"
-PKG_VERSION="60eef8e"
-PKG_SHA256="a7ae3546c118fe376ea62a5600fba79b3cf8af8fc4f33824674e15b475c1ea3b"
-PKG_REV="104"
+PKG_VERSION="48f86c9"
+PKG_SHA256="70f41a1f914445e70a67440ee8cfb9d045f7e42dd2123faab687fdbb65763d45"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.snes9x2010"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.stella"
-PKG_VERSION="a6d75e0"
-PKG_SHA256="02efd7e09a6fa426247fb3f308481798f8c5a54395c98cce9d47f6118bd7d625"
-PKG_REV="104"
+PKG_VERSION="d053a35"
+PKG_SHA256="f34aa753458826b7a0ce0d16a8750eed78630c1325c55f0c6266cdc96c837412"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.stella"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.tgbdual"
-PKG_VERSION="144f2af"
-PKG_SHA256="d3246ac4b2ee2ed03651c21faa1c4d19cc2ffa211d0ff3f7f9acda1c0ca1344c"
-PKG_REV="104"
+PKG_VERSION="60718ec"
+PKG_SHA256="4385460e6b398545aa3ceff29355f3ee14512c99688dba898d771f0840d94b04"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.tgbdual"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.tyrquake"
-PKG_VERSION="c3d45b3"
-PKG_SHA256="357c2c10bb74d9129632ebac017977366ca235b912f156402845b89dacf4eb57"
-PKG_REV="104"
+PKG_VERSION="bbc3ec8"
+PKG_SHA256="3dd01954f84410bc86c414518466b0876a124fed1ef8581020bca4a8d1a92947"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.tyrquake"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vba-next/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vba-next/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.vba-next"
-PKG_VERSION="3ff5c66"
-PKG_SHA256="a6c8a8b9eefb62b962649b31a9418f15537ef309164317fb3bd7d17714fa891d"
-PKG_REV="104"
+PKG_VERSION="36fcec5"
+PKG_SHA256="31713deb9d1bc01fcb7eee245464d90f960543aa017f1c9d30aca0fefd04de0f"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vba-next"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.vbam"
-PKG_VERSION="271ce5a"
-PKG_SHA256="cf52f9ec691a3c6f7472eb0b80304daed36c447b73622a0d5ba685fa8707ce55"
-PKG_REV="104"
+PKG_VERSION="1701ab5"
+PKG_SHA256="dc0d9c13ad96e17a5e6c5ec5a94eaf19270b014f929bc2cad69fccd82d0c3772"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vbam"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.vecx"
-PKG_VERSION="b793fee"
-PKG_SHA256="7f1d49b1f9aaef77a84b5e1839f3a9e6d67aed0ffad51bf8eea34e83b75733e6"
-PKG_REV="104"
+PKG_VERSION="7599497"
+PKG_SHA256="95e318e399a238a46ecb741d3070366f31638288e875bb6300e0186dd0caaec7"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vecx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.virtualjaguar"
-PKG_VERSION="01d7278"
-PKG_SHA256="f4bc084822ae32696945288d22c7a382e548729fd9e7be99c2e2105b2e2bfb98"
-PKG_REV="104"
+PKG_VERSION="f296035"
+PKG_SHA256="4ba0b702bcfc8adc03f51408c13f55f27ed17e673a9a4f7dc2f60e1a29ecb329"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.virtualjaguar"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro.yabause"
-PKG_VERSION="a51496a"
-PKG_SHA256="11cbf481e962e659d3f3e924e437d5694d7a1f1add9c310eb8f58d30cfab840e"
-PKG_REV="104"
+PKG_VERSION="acd854e"
+PKG_SHA256="757a502387437fd272ed046e3abd9a15eed1b4b5114f106c808c6c230be54a86"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.yabause"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="game.libretro"
-PKG_VERSION="3ef63b7"
-PKG_SHA256="7a52710984e976b733f087e3d6cdf3e3cb6f6de5e3546778f8c399b5d117e8d3"
-PKG_REV="105"
+PKG_VERSION="4ef6ffb"
+PKG_SHA256="7b6d964f369b860b564aa98c9a0d10f3009fe81bbb2783cafb165c2dc17a582c"
+PKG_REV="106"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro"


### PR DESCRIPTION
built and pushed for RPi2 and Generic

libretro-bsnes-mercury-performance didn't want to build so I've disabled it for now