### PR TITLE
buildsystem: add BUILD_FLAG support

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1,4 +1,44 @@
 setup_toolchain() {
+  # lto flag
+  if flag_enabled "lto" "$LTO_SUPPORT" "only-disable"; then
+    export TARGET_CFLAGS+=" $CFLAGS_OPTIM_LTO"
+    export TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_LTO"
+    export TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO"
+  fi
+
+  # gold flag
+  if flag_enabled "gold" "$GOLD_SUPPORT" "only-disable"; then
+    export TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_GOLD"
+  fi
+
+  # position-independent code
+  if flag_enabled "pic" "no"; then
+    export TARGET_CFLAGS+=" $CFLAGS_OPTIM_PIC"
+    export TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_PIC"
+    export TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_PIC"
+  fi
+  if flag_enabled "pic:host" "no"; then
+    export HOST_CFLAGS+=" $CFLAGS_OPTIM_PIC"
+    export HOST_CXXFLAGS+=" $CXXFLAGS_OPTIM_PIC"
+    export HOST_LDFLAGS+=" $LDFLAGS_OPTIM_PIC"
+  fi
+
+  # hardening support
+  if flag_enabled "hardening" "$HARDENING_SUPPORT"; then
+    export TARGET_CFLAGS+=" $CFLAGS_OPTIM_HARDENING"
+    export TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_HARDENING"
+    export TARGET_CFLAGS+=" $CPPFLAGS_OPTIM_HARDENING"
+    export TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_HARDENING"
+  fi
+
+  # parallel
+  if ! flag_enabled "parallel" "yes"; then
+    NINJA_OPTS="$NINJA_OPTS -j1"
+    export MAKEFLAGS="-j1"
+  else
+    export MAKEFLAGS="-j$CONCURRENCY_MAKE_LEVEL"
+  fi
+
   case "$1" in
     target|init)
       export DESTIMAGE="target"
@@ -316,6 +356,37 @@ listremoveitem() {
   # Use array word splitting to squash spaces
   tmp_array=(${data})
   echo "${tmp_array[@]}"
+}
+
+# check if a flag is enabled
+# $1: flag-name, $2: default (yes/no), $3: ingenious check (none,only-disable,only-enable)
+# set variable PKG_[FLAG]_[HOST/TARGET]_ENABLED=(yes/no)
+# return 0 if flag is enabled, otherwise 1
+flag_enabled() {
+  # make flag name upper case and replace hyphen with underscore, to use as variable name
+  local flag_name=${1^^}
+  [[ $flag_name =~ : ]] || flag_name+="_TARGET"
+  flag_name="PKG_${flag_name//[:-]/_}_ENABLED"
+
+  # check flag
+  if [ -n "${PKG_BUILD_FLAGS}" ] && listcontains "${PKG_BUILD_FLAGS}" "[+]?$1"; then
+    if [ "${3:none}" = "only-disable" ]; then
+      echo "ERROR: $1 can not enable via PKG_BUILD_FLAGS (found in $PKG_NAME)"
+      exit 1
+    fi
+    declare ${flag_name}="yes"
+    return 0
+  elif [ "$2" = "yes" ] && ! listcontains "${PKG_BUILD_FLAGS}" "-$1"; then
+    declare ${flag_name}="yes"
+    return 0
+  else
+    if [ "${3:none}" = "only-enable" ]; then
+      echo "ERROR: $1 can not disable via PKG_BUILD_FLAGS (found in $PKG_NAME)"
+      exit 1
+    fi
+    declare ${flag_name}="no"
+    return 1
+  fi
 }
 
 target_has_feature() {
@@ -660,26 +731,6 @@ do_autoreconf() {
     fi
     $AUTORECONF $@
   fi
-}
-
-strip_lto() {
-  # strip out LTO optimization from *FLAGS
-  if [ -n "$GCC_OPTIM_LTO" ] ; then
-    CFLAGS=`echo $CFLAGS | sed -e "s|$GCC_OPTIM_LTO||g"`
-    CXXFLAGS=`echo $CXXFLAGS | sed -e "s|$GCC_OPTIM_LTO||g"`
-    TARGET_CFLAGS=`echo $TARGET_CFLAGS | sed -e "s|$GCC_OPTIM_LTO||g"`
-    TARGET_CXXFLAGS=`echo $TARGET_CXXFLAGS | sed -e "s|$GCC_OPTIM_LTO||g"`
-  fi
-  if [ -n "$LD_OPTIM_LTO" ] ; then
-    LDFLAGS=`echo $LDFLAGS | sed -e "s|$LD_OPTIM_LTO||g"`
-    TARGET_LDFLAGS=`echo $TARGET_LDFLAGS | sed -e "s|$LD_OPTIM_LTO||g"`
-  fi
-}
-
-strip_gold() {
-  # strip out usage from GOLD linker
-  LDFLAGS=`echo $LDFLAGS | sed -e "s|-fuse-ld=gold||g"`
-  TARGET_LDFLAGS=`echo $TARGET_LDFLAGS | sed -e "s|-fuse-ld=gold||g"`
 }
 
 fix_module_depends() {

--- a/config/functions
+++ b/config/functions
@@ -1,34 +1,34 @@
 setup_toolchain() {
   # lto flag
   if flag_enabled "lto" "$LTO_SUPPORT" "only-disable"; then
-    export TARGET_CFLAGS+=" $CFLAGS_OPTIM_LTO"
-    export TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_LTO"
-    export TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO"
+    TARGET_CFLAGS+=" $CFLAGS_OPTIM_LTO"
+    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_LTO"
+    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO"
   fi
 
   # gold flag
   if flag_enabled "gold" "$GOLD_SUPPORT" "only-disable"; then
-    export TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_GOLD"
+    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_GOLD"
   fi
 
   # position-independent code
   if flag_enabled "pic" "no"; then
-    export TARGET_CFLAGS+=" $CFLAGS_OPTIM_PIC"
-    export TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_PIC"
-    export TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_PIC"
+    TARGET_CFLAGS+=" $CFLAGS_OPTIM_PIC"
+    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_PIC"
+    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_PIC"
   fi
   if flag_enabled "pic:host" "no"; then
-    export HOST_CFLAGS+=" $CFLAGS_OPTIM_PIC"
-    export HOST_CXXFLAGS+=" $CXXFLAGS_OPTIM_PIC"
-    export HOST_LDFLAGS+=" $LDFLAGS_OPTIM_PIC"
+    HOST_CFLAGS+=" $CFLAGS_OPTIM_PIC"
+    HOST_CXXFLAGS+=" $CXXFLAGS_OPTIM_PIC"
+    HOST_LDFLAGS+=" $LDFLAGS_OPTIM_PIC"
   fi
 
   # hardening support
   if flag_enabled "hardening" "$HARDENING_SUPPORT"; then
-    export TARGET_CFLAGS+=" $CFLAGS_OPTIM_HARDENING"
-    export TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_HARDENING"
-    export TARGET_CFLAGS+=" $CPPFLAGS_OPTIM_HARDENING"
-    export TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_HARDENING"
+    TARGET_CFLAGS+=" $CFLAGS_OPTIM_HARDENING"
+    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_HARDENING"
+    TARGET_CFLAGS+=" $CPPFLAGS_OPTIM_HARDENING"
+    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_HARDENING"
   fi
 
   # parallel

--- a/config/optimize
+++ b/config/optimize
@@ -1,15 +1,6 @@
 GCC_OPTIM="-Os"
 LD_OPTIM="-Wl,--as-needed"
 
-if [ "$LTO_SUPPORT" = yes ];then
-  GCC_OPTIM_LTO="-flto -ffat-lto-objects"
-  LD_OPTIM_LTO="-fuse-linker-plugin -flto"
-fi
-
-if [ "$GOLD_SUPPORT" = yes ];then
-  LD_OPTIM_GOLD="-fuse-ld=gold"
-fi
-
 if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
   TARGET_CFLAGS="$TARGET_CFLAGS -ggdb"
   TARGET_CXXFLAGS="$TARGET_CXXFLAGS -ggdb"
@@ -20,10 +11,12 @@ else
   TARGET_LDFLAGS="$TARGET_LDFLAGS"
 fi
 
-TARGET_CPPFLAGS=
-TARGET_CFLAGS="$TARGET_CFLAGS -Wall -pipe $GCC_OPTIM $GCC_OPTIM_LTO $PROJECT_CFLAGS"
+NINJA_OPTS=""
+
+TARGET_CPPFLAGS=""
+TARGET_CFLAGS="$TARGET_CFLAGS -Wall -pipe $GCC_OPTIM $PROJECT_CFLAGS"
 TARGET_CXXFLAGS="$TARGET_CFLAGS"
-TARGET_LDFLAGS="$TARGET_LDFLAGS $LD_OPTIM $LD_OPTIM_GOLD $LD_OPTIM_LTO"
+TARGET_LDFLAGS="$TARGET_LDFLAGS $LD_OPTIM"
 TARGET_LIBDIR="$SYSROOT_PREFIX/lib $SYSROOT_PREFIX/usr/lib"
 TARGET_INCDIR="$SYSROOT_PREFIX/include $SYSROOT_PREFIX/usr/include"
 
@@ -37,6 +30,26 @@ HOST_INCDIR="$TOOLCHAIN/include /usr/include"
 # see https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-Wformat_-Wformat-security
 HOST_CFLAGS="$HOST_CFLAGS -Wno-format-security"
 HOST_CXXFLAGS="$HOST_CXXFLAGS -Wno-format-security" 
+
+# lto flags
+CFLAGS_OPTIM_LTO="-flto -ffat-lto-objects"
+CXXFLAGS_OPTIM_LTO="-flto -ffat-lto-objects"
+LDFLAGS_OPTIM_LTO="-fuse-linker-plugin -flto"
+
+# gold flags
+LDFLAGS_OPTIM_GOLD="-fuse-ld=gold"
+
+# position-independent code
+CFLAGS_OPTIM_PIC="-fPIC -DPIC"
+CXXFLAGS_OPTIM_PIC="-fPIC -DPIC"
+LDFLAGS_OPTIM_PIC="-fPIC"
+
+# hardening support
+# TODO: basiclly copied from debian 9, should adjust for LE
+CFLAGS_OPTIM_HARDENING="-fstack-protector-strong -Wformat -Werror=format-security -fPIE"
+CXXFLAGS_OPTIM_HARDENING="-fstack-protector-strong -Wformat -Werror=format-security -fPIE"
+CPPFLAGS_OPTIM_HARDENING="-D_FORTIFY_SOURCE=2"
+LDFLAGS_OPTIM_HARDENING="-Wl,-z,relro -Wl,-z,now"
 
 # add distro specific library dirs
 if [ -z "$HOST_LIBDIR" ]; then

--- a/config/path
+++ b/config/path
@@ -134,7 +134,6 @@ XORG_PATH_DRIVERS=/usr/lib/xorg/modules/drivers
 if [ -z "$CCACHE_DIR" ]; then
   export CCACHE_DIR=$BUILD/.ccache
 fi
-export MAKEFLAGS=-j$CONCURRENCY_MAKE_LEVEL
 
 if [[ -z "$PATH" || ( "$PATH" != "$TOOLCHAIN/bin:$TOOLCHAIN/sbin" && "$PATH" = "${PATH#$TOOLCHAIN/bin:$TOOLCHAIN/sbin:}" ) ]]; then
   export PATH="$TOOLCHAIN/bin:$TOOLCHAIN/sbin${PATH:+":$PATH"}"

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -4,6 +4,9 @@
 # GOLD (Google Linker) support
   GOLD_SUPPORT="yes"
 
+# HARDENING (security relevant linker and compiler flags) support
+  HARDENING_SUPPORT="no"
+
 # Name of the Distro to build (full name, without special characters)
   DISTRONAME="LibreELEC"
 

--- a/packages/addons/addon-depends/atk/package.mk
+++ b/packages/addons/addon-depends/atk/package.mk
@@ -30,10 +30,7 @@ PKG_SECTION="accessibility"
 PKG_SHORTDESC="ATK - Accessibility Toolkit"
 PKG_LONGDESC="ATK provides the set of accessibility interfaces that are implemented by other toolkits and applications. Using the ATK interfaces, accessibility tools have full access to view and control running applications."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
                            --disable-rebuilds --enable-introspection=no"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/addons/addon-depends/cxxtools/package.mk
+++ b/packages/addons/addon-depends/cxxtools/package.mk
@@ -28,15 +28,10 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="python/web"
 PKG_SHORTDESC="cxxtools: a collection of general-purpose C++ classes"
 PKG_LONGDESC="Cxxtools is a collection of general-purpose C++ classes"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_HOST="--disable-demos --with-atomictype=pthread --disable-unittest"
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --disable-demos --with-atomictype=pthread --disable-unittest"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC"
-  CXXFLAGS="$CXXFLAGS -fPIC"
-  LDFLAGS="$LDFLAGS -fPIC"
-}
 
 post_makeinstall_host() {
   rm -rf $TOOLCHAIN/bin/cxxtools-config

--- a/packages/addons/addon-depends/enca/package.mk
+++ b/packages/addons/addon-depends/enca/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="devel"
 PKG_SHORTDESC="enca: detects the encoding of text files, on the basis of knowledge of their language."
 PKG_LONGDESC="Enca detects the encoding of text files, on the basis of knowledge of their language. It can also convert them to other encodings, allowing you to recode files without knowing their current encoding. It supports most of Central and East European languages, and a few Unicode variants, independently on language."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_MAKEINSTALL_OPTS_TARGET="-C lib"
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_file__dev_random=yes \
@@ -40,10 +41,6 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_file__dev_random=yes \
                            --without-librecode \
                            --disable-rpath \
                            --with-gnu-ld"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 pre_make_target() {
   make CC="$HOST_CC" \

--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -27,6 +27,8 @@ PKG_SOURCE_DIR="FFmpeg-n${PKG_VERSION}"
 PKG_DEPENDS_TARGET="toolchain bzip2 fdk-aac libvorbis openssl opus x264 x265 zlib"
 PKG_SECTION="multimedia"
 PKG_LONGDESC="FFmpegx is an complete FFmpeg build to support encoding and decoding"
+# ffmpeg builds better with these options
+PKG_BUILD_FLAGS="-gold -lto"
 
 # Dependencies
 get_graphicdrivers
@@ -47,10 +49,6 @@ fi
 pre_configure_target() {
   cd $PKG_BUILD
   rm -rf .$TARGET_NAME
-
-# ffmpeg builds better with these options
-  strip_gold
-  strip_lto
 
   if [ "$KODIPLAYER_DRIVER" == "bcm2835-driver" ]; then
     CFLAGS="-DRPI=1 -I$SYSROOT_PREFIX/usr/include/IL -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux $CFLAGS"

--- a/packages/addons/addon-depends/jasper/package.mk
+++ b/packages/addons/addon-depends/jasper/package.mk
@@ -27,12 +27,9 @@ PKG_DEPENDS_TARGET="toolchain libjpeg-turbo"
 PKG_SECTION="graphics"
 PKG_SHORTDESC="jasper: JPEG-2000 Part-1 standard (i.e., ISO/IEC 15444-1) implementation"
 PKG_LONGDESC="This distribution contains the public release of the an open-source implementation of the ISO/IEC 15444-1 also known as JPEG-2000 standard for image compression."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin

--- a/packages/addons/addon-depends/libdvbcsa/package.mk
+++ b/packages/addons/addon-depends/libdvbcsa/package.mk
@@ -29,6 +29,8 @@ PKG_SECTION="lib"
 PKG_SHORTDESC="libdvbcsa is a free implementation of the DVB Common Scrambling Algorithm - DVB/CSA - with encryption and decryption capabilities"
 PKG_LONGDESC="libdvbcsa is a free implementation of the DVB Common Scrambling Algorithm - DVB/CSA - with encryption and decryption capabilities"
 PKG_TOOLCHAIN="autotools"
+# libdvbcsa is a bit faster without LTO, and tests will fail with gcc-5.x
+PKG_BUILD_FLAGS="-lto +pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static --with-sysroot=$SYSROOT_PREFIX"
 
@@ -43,10 +45,3 @@ elif [ "$TARGET_ARCH" = x86_64  ]; then
     PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-uint64"
   fi
 fi
-
-pre_configure_target() {
-# libdvbcsa is a bit faster without LTO, and tests will fail with gcc-5.x
-  strip_lto
-
-  export CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/addons/addon-depends/multimedia-tools-depends/tstools/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/tstools/package.mk
@@ -29,9 +29,10 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="tools"
 PKG_SHORTDESC="command line tools for working with MPEG data"
 PKG_LONGDESC="This is a set of cross-platform command line tools for working with MPEG data."
+PKG_BUILD_FLAGS="-parallel"
 
 make_target() {
-  make -j1 CROSS_COMPILE=$TARGET_PREFIX
+  make CROSS_COMPILE=$TARGET_PREFIX
 }
 
 makeinstall_target() {

--- a/packages/addons/addon-depends/network-tools-depends/iw/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/iw/package.mk
@@ -27,11 +27,10 @@ PKG_DEPENDS_TARGET="toolchain libnl"
 PKG_SECTION="tools"
 PKG_SHORTDESC="iw is a new nl80211 based CLI configuration utility for wireless devices"
 PKG_LONGDESC="iw is a new nl80211 based CLI configuration utility for wireless devices. It supports all new drivers that have been added to the kernel recently."
+# iw fails at runtime with lto enabled
+PKG_BUILD_FLAGS="-lto"
 
 pre_configure_target() {
-  # iw fails at runtime with lto enabled
-  strip_lto
-
   export LDFLAGS="$LDFLAGS -pthread"
 }
 

--- a/packages/addons/addon-depends/network-tools-depends/udpxy/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/udpxy/package.mk
@@ -28,10 +28,10 @@ PKG_SECTION="tools"
 PKG_SHORTDESC="udpxy is a UDP-to-HTTP multicast traffic relay daemon"
 PKG_LONGDESC="udpxy is a UDP-to-HTTP multicast traffic relay daemon"
 PKG_DISCLAIMER="this is an unofficial addon. please don't ask for support in openelec forum / irc channel"
+# fails to build with gcc 4.9 + lto
+PKG_BUILD_FLAGS="-lto"
 
 pre_configure_target() {
-  # fails to build with gcc 4.9 + lto
-  strip_lto
   CFLAGS="$CFLAGS -Wno-error=unused-const-variable"
 }
 

--- a/packages/addons/addon-depends/network-tools-depends/wireless_tools/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/wireless_tools/package.mk
@@ -28,11 +28,8 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="debug/tools"
 PKG_SHORTDESC="wireless-tools: tools allowing to manipulate the Wireless Extensions"
 PKG_LONGDESC="The Wireless Tools (WT) is a set of tools allowing to manipulate the Wireless Extensions. They use a textual interface and are rather crude, but aim to support the full Wireless Extension. There are many other tools you can use with Wireless Extensions, however Wireless Tools is the reference implementation."
-
-pre_configure_Target() {
-  # wireless_tools fails to build on some systems with LTO enabled
-  strip_lto
-}
+# wireless_tools fails to build on some systems with LTO enabled
+PKG_BUILD_FLAGS="-lto"
 
 make_target() {
   make PREFIX=/usr CC="$CC" AR="$AR" \

--- a/packages/addons/addon-depends/system-tools-depends/depends/efivar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/efivar/package.mk
@@ -29,13 +29,13 @@ PKG_DEPENDS_TARGET="toolchain efivar:host"
 PKG_SECTION="tools"
 PKG_SHORTDESC="evivar: maniulate EFI Variables"
 PKG_LONGDESC="Tools and library to manipulate EFI variables."
+PKG_BUILD_FLAGS="-lto"
 
 make_host() {
   make -C src/ makeguids
 }
 
 make_target() {
-  strip_lto
   make -C src/ libefivar.a efivar-guids.h efivar.h
 }
 

--- a/packages/addons/addon-depends/system-tools-depends/efibootmgr/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/efibootmgr/package.mk
@@ -28,9 +28,9 @@ PKG_DEPENDS_TARGET="toolchain efivar pciutils zlib"
 PKG_SECTION="tools"
 PKG_SHORTDESC="EFI Boot Manager"
 PKG_LONGDESC="This is a Linux user-space application to modify the Intel Extensible Firmware Interface (EFI) Boot Manager configuration. This application can create and destroy boot entries, change the boot order, change the next running boot option, and more."
+PKG_BUILD_FLAGS="-lto"
 
 pre_make_target() {
-  strip_lto
   export EXTRA_CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include -I$SYSROOT_PREFIX/usr/include/efivar -fgnu89-inline"
   export LDFLAGS="$LDFLAGS -L$SYSROOT_PREFIX/usr/lib -ludev -ldl"
 }

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-live/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-live/package.mk
@@ -30,11 +30,10 @@ PKG_SECTION="multimedia"
 PKG_SHORTDESC="vdr-live: the LIVE Interactive VDR Environment/"
 PKG_LONGDESC="vdr-live allows a comfortable operation of VDR and some of its plugins trough a web interface"
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="+pic"
 
 pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-  export CXXFLAGS="$CXXFLAGS -fPIC"
-  export LDFLAGS="$LDFLAGS -fPIC -L$SYSROOT_PREFIX/usr/lib/iconv"
+  export LDFLAGS="$LDFLAGS -L$SYSROOT_PREFIX/usr/lib/iconv"
 }
 
 make_target() {

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/package.mk
@@ -30,12 +30,7 @@ PKG_SECTION="multimedia"
 PKG_SHORTDESC="Performs a channel scans for DVB-T, DVB-C and DVB-S"
 PKG_LONGDESC="Performs a channel scans for DVB-T, DVB-C and DVB-S"
 PKG_TOOLCHAIN="manual"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-  export CXXFLAGS="$CXXFLAGS -fPIC"
-  export LDFLAGS="$LDFLAGS -fPIC"
-}
+PKG_BUILD_FLAGS="+pic"
 
 make_target() {
   VDR_DIR=$(get_build_dir vdr)

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscancontrol/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscancontrol/package.mk
@@ -30,12 +30,7 @@ PKG_SECTION="multimedia"
 PKG_SHORTDESC="Adds menu entry for wirbelscan at VDR."
 PKG_LONGDESC="Adds menu entry for wirbelscan at VDR."
 PKG_TOOLCHAIN="manual"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-  export CXXFLAGS="$CXXFLAGS -fPIC"
-  export LDFLAGS="$LDFLAGS -fPIC"
-}
+PKG_BUILD_FLAGS="+pic"
 
 pre_build_target() {
   WIRBELSCAN_DIR=$(get_build_dir vdr-plugin-wirbelscan)

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
@@ -29,11 +29,10 @@ PKG_SECTION="multimedia"
 PKG_SHORTDESC="xmltv2vdr imports data in xmltv format"
 PKG_LONGDESC="xmltv2vdr imports data in xmltv format"
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="+pic"
 
 pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-  export CXXFLAGS="$CXXFLAGS -fPIC -Wno-narrowing"
-  export LDFLAGS="$LDFLAGS -fPIC"
+  export CXXFLAGS="$CXXFLAGS -Wno-narrowing"
   export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv -lpcre -lpcrecpp"
 }
 

--- a/packages/addons/browser/chromium/package.mk
+++ b/packages/addons/browser/chromium/package.mk
@@ -32,6 +32,7 @@ PKG_SECTION="browser"
 PKG_SHORTDESC="Chromium Browser: the open-source web browser from Google"
 PKG_LONGDESC="Chromium Browser ($PKG_VERSION): the open-source web browser from Google"
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Chromium"
@@ -53,7 +54,6 @@ make_host() {
 }
 
 make_target() {
-  strip_lto
   export LDFLAGS="$LDFLAGS -ludev"
   export LD=$CXX
 

--- a/packages/addons/service/lcdd/package.mk
+++ b/packages/addons/service/lcdd/package.mk
@@ -30,6 +30,7 @@ PKG_SECTION="service"
 PKG_SHORTDESC="LCDproc: Software to display system information from your Linux/*BSD box on a LCD"
 PKG_LONGDESC="LCDproc ($PKG_VERSION) is a piece of software that displays real-time system information from your Linux/*BSD box on a LCD. The server supports several serial devices: Matrix Orbital, Crystal Fontz, Bayrad, LB216, LCDM001 (kernelconcepts.de), Wirz-SLI, Cwlinux(.com) and PIC-an-LCD; and some devices connected to the LPT port: HD44780, STV5730, T6963, SED1520 and SED1330. Various clients are available that display things like CPU load, system load, memory usage, uptime, and a lot more."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="-parallel"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="LCDproc"
@@ -43,11 +44,6 @@ PKG_CONFIGURE_OPTS_TARGET="--with-ft-prefix=$SYSROOT_PREFIX/usr \
                            --disable-libpng \
                            --enable-drivers=all \
                            --enable-seamless-hbars"
-
-pre_make_target() {
-  # dont build parallel
-    MAKEFLAGS=-j1
-}
 
 addon() {
   drivers="none|$(cat $PKG_BUILD/.$TARGET_NAME/config.log | sed -n "s|^DRIVERS=' \(.*\)'|\1|p" | sed "s|.so||g" | tr ' ' '|')"

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -30,6 +30,7 @@ PKG_SECTION="service"
 PKG_SHORTDESC="Librespot: play Spotify through LibreELEC using a Spotify app as a remote"
 PKG_LONGDESC="Librespot ($PKG_VERSION) plays Spotify through LibreELEC using the open source librespot library using a Spotify app as a remote."
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Librespot"
@@ -39,7 +40,6 @@ PKG_MAINTAINER="Anton Voyl (awiouy)"
 configure_target() {
   . "$TOOLCHAIN/.cargo/env"
   export PKG_CONFIG_ALLOW_CROSS=0
-  strip_lto
 }
 
 make_target() {

--- a/packages/addons/tools/mono/package.mk
+++ b/packages/addons/tools/mono/package.mk
@@ -30,6 +30,7 @@ PKG_SECTION="tools"
 PKG_SHORTDESC="Mono: a cross platform, open source .NET framework"
 PKG_LONGDESC="Mono ($PKG_VERSION) is a software platform designed to allow developers to easily create cross platform applications part of the .NET Foundation"
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Mono"
@@ -59,7 +60,6 @@ makeinstall_host() {
 
 configure_target() {
   cp -PR ../* .
-  strip_lto
   ./configure $options --host=$TARGET_NAME \
                        --disable-mcs-build
 }

--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -28,6 +28,8 @@ PKG_SECTION="audio"
 PKG_SHORTDESC="alsa-lib: Advanced Linux Sound Architecture library"
 PKG_LONGDESC="ALSA (Advanced Linux Sound Architecture) is the next generation Linux Sound API. It provides much finer (->better) access to the sound hardware, has a unbeatable mixer API and supports stuff like multi channel hardware, digital outs and ins, uninterleaved sound data access, and an oss emulation layer (for the old applications). It is the prefered API for professional sound apps under Linux."
 PKG_TOOLCHAIN="autotools"
+# alsa-lib fails building with LTO support
+PKG_BUILD_FLAGS="-lto +pic"
 
 if build_with_debug; then
   ALSA_DEBUG=--with-debug
@@ -40,13 +42,6 @@ PKG_CONFIGURE_OPTS_TARGET="--with-plugindir=/usr/lib/alsa \
                            --disable-python \
                            $ALSA_DEBUG \
                            --disable-dependency-tracking"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-
-  # alsa-lib fails building with LTO support
-    strip_lto
-}
 
 post_configure_target() {
   sed -i 's/.*PKGLIBDIR.*/#define PKGLIBDIR ""/' include/config.h

--- a/packages/audio/flac/package.mk
+++ b/packages/audio/flac/package.mk
@@ -28,6 +28,8 @@ PKG_SECTION="audio"
 PKG_SHORTDESC="flac: An Free Lossless Audio Codec"
 PKG_LONGDESC="Grossly oversimplified, FLAC is similar to MP3, but lossless, meaning that audio is compressed in FLAC without throwing away any information. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio."
 PKG_TOOLCHAIN="autotools"
+# flac-1.3.1 dont build with LTO support
+PKG_BUILD_FLAGS="-lto +pic"
 
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
@@ -47,13 +49,6 @@ if target_has_feature sse; then
 else
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --disable-sse"
 fi
-
-pre_configure_target() {
-  # flac-1.3.1 dont build with LTO support
-  strip_lto
-
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin

--- a/packages/audio/lame/package.mk
+++ b/packages/audio/lame/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_SHORTDESC="lame: LAME Ain't an Mp3 Encoder"
 PKG_LONGDESC="LAME originally stood for LAME Ain't an Mp3 Encoder. The goal of the LAME project is to use the open source model to improve the psycho acoustics, noise shaping and speed of MP3. Another goal of the LAME project is to use these improvements for the basis of a patent free audio compression codec for the GNU project."
+PKG_BUILD_FLAGS="-parallel"
 
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
@@ -47,8 +48,3 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --with-gnu-ld \
                            --with-fileio=lame \
                            GTK_CONFIG=no"
-
-post_make_target() {
-  # dont build parallel
-    MAKEFLAGS=-j1
-}

--- a/packages/audio/libcdio/package.mk
+++ b/packages/audio/libcdio/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_SHORTDESC="libcdio: A CD-ROM reading and control library"
 PKG_LONGDESC="This library is to encapsulate CD-ROM reading and control. Applications wishing to be oblivious of the OS- and device-dependant properties of a CD-ROM can use this library. Some support for disk image types like BIN/CUE and NRG is available, so applications that use this library also have the ability to read disc images as though they were CD's."
+PKG_BUILD_FLAGS="+pic"
 
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-cxx \
@@ -46,10 +47,6 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-cxx \
                            --without-iso-read \
                            --without-libiconv-prefix \
                            --with-gnu-ld"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin

--- a/packages/audio/libvorbis/package.mk
+++ b/packages/audio/libvorbis/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="audio"
 PKG_SHORTDESC="libvorbis: Lossless audio compression tools using the ogg-vorbis algorithms"
 PKG_LONGDESC="Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format for mid to high quality (8kHz-48.0kHz, 16+ bit, polyphonic) audio and music at fixed and variable bitrates from 16 to 128 kbps/channel. This places Vorbis in the same competitive class as audio representations such as MPEG-4 (AAC), and similar to, but higher performance than MPEG-1/2 audio layer 3, MPEG-4 audio (TwinVQ), WMA and PAC."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
@@ -35,7 +36,3 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
                            --disable-oggtest \
                            --disable-docs \
                            --disable-examples"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/audio/sbc/package.mk
+++ b/packages/audio/sbc/package.mk
@@ -27,12 +27,9 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="network"
 PKG_SHORTDESC="sbc: standalone SBC library"
 PKG_LONGDESC="standalone SBC library"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \
                            --disable-tools \
                            --disable-tester"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/audio/soxr/package.mk
+++ b/packages/audio/soxr/package.mk
@@ -28,12 +28,9 @@ PKG_DEPENDS_TARGET="toolchain cmake:host"
 PKG_SECTION="audio"
 PKG_SHORTDESC="soxr: a library which performs one-dimensional sample-rate conversion."
 PKG_LONGDESC="The SoX Resampler library performs one-dimensional sample-rate conversion. it may be used, for example, to resample PCM-encoded audio."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DHAVE_WORDS_BIGENDIAN_EXITCODE=1 \
                        -DBUILD_TESTS=0 \
                        -DBUILD_EXAMPLES=1 \
                        -DBUILD_SHARED_LIBS=OFF"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/compress/bzip2/package.mk
+++ b/packages/compress/bzip2/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="compress"
 PKG_SHORTDESC="bzip2 data compressor"
 PKG_LONGDESC="bzip2 is a freely available, patent free (see below), high-quality data compressor. It typically compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical compressors), whilst being around twice as fast at compression and six times faster at decompression."
+PKG_BUILD_FLAGS="+pic +pic:host"
 
 pre_build_host() {
   mkdir -p $PKG_BUILD/.$HOST_NAME
@@ -36,7 +37,7 @@ pre_build_host() {
 
 make_host() {
   cd $PKG_BUILD/.$HOST_NAME
-  make -f Makefile-libbz2_so CC=$HOST_CC CFLAGS="$CFLAGS -fPIC -DPIC"
+  make -f Makefile-libbz2_so CC=$HOST_CC CFLAGS="$CFLAGS"
 }
 
 makeinstall_host() {
@@ -54,7 +55,7 @@ pre_make_target() {
 }
 
 make_target() {
-  make -f Makefile-libbz2_so CC=$CC CFLAGS="$CFLAGS -fPIC -DPIC"
+  make -f Makefile-libbz2_so CC=$CC CFLAGS="$CFLAGS"
 }
 
 post_make_target() {

--- a/packages/databases/mysql/package.mk
+++ b/packages/databases/mysql/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain zlib ncurses openssl boost mysql:host"
 PKG_SECTION="database"
 PKG_SHORTDESC="mysql: A database server"
 PKG_LONGDESC="MySQL is a SQL (Structured Query Language) database server. SQL is the most popular database language in the world. MySQL is a client server implementation that consists of a server daemon mysqld and many different client programs/libraries."
+build_with_debug && [ "$TARGET_ARCH" = "aarch64" ] && PKG_BUILD_FLAGS="-lto"
 
 post_unpack() {
   sed -i 's|GET_TARGET_PROPERTY(LIBMYSQL_OS_OUTPUT_NAME libmysql OUTPUT_NAME)|SET(LIBMYSQL_OS_OUTPUT_NAME "mysqlclient")|' $PKG_BUILD/scripts/CMakeLists.txt
@@ -54,12 +55,6 @@ PKG_CMAKE_OPTS_HOST="-DCMAKE_BUILD_TYPE=Release \
                      -DLOCAL_BOOST_DIR=$(get_build_dir boost) \
                      -DWITH_UNIT_TESTS=OFF \
                      -DWITH_ZLIB=bundled"
-
-if build_with_debug && [ "$TARGET_ARCH" = aarch64 ]; then
-  pre_configure_target() {
-    strip_lto
-  }
-fi
 
 make_host() {
   ninja comp_err

--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -27,6 +27,8 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="database"
 PKG_SHORTDESC="sqlite: An Embeddable SQL Database Engine"
 PKG_LONGDESC="SQLite is a C library that implements an embeddable SQL database engine. Programs that link with the SQLite library can have SQL database access without running a separate RDBMS process. The distribution comes with a standalone command-line access program (sqlite) that can be used to administer an SQLite database and which serves as an example of how to use the SQLite library. SQLite is not a client library used to connect to a big database server. SQLite is the server. The SQLite library reads and writes directly to and from the database files on disk."
+# libsqlite3.a(sqlite3.o): requires dynamic R_X86_64_PC32 reloc against 'sqlite3_stricmp' which may overflow at runtime
+PKG_BUILD_FLAGS="+pic +pic:host -parallel"
 
 # sqlite fails to compile with fast-math link time optimization.
   CFLAGS=`echo $CFLAGS | sed -e "s|-Ofast|-O3|g"`
@@ -58,14 +60,6 @@ PKG_LONGDESC="SQLite is a C library that implements an embeddable SQL database e
 # sqlite3_config(SQLITE_CONFIG_MMAP_SIZE) call, or at run-time using the
 # mmap_size pragma.
   CFLAGS="$CFLAGS -DSQLITE_TEMP_STORE=3 -DSQLITE_DEFAULT_MMAP_SIZE=268435456"
-
-# libsqlite3.a(sqlite3.o): requires dynamic R_X86_64_PC32 reloc against 'sqlite3_stricmp' which may overflow at runtime
-  CFLAGS="$CFLAGS -fPIC"
-
-pre_make_target() {
-  # dont build parallel
-  MAKEFLAGS=-j1
-}
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -27,14 +27,11 @@ PKG_DEPENDS_TARGET="toolchain zlib ncurses expat"
 PKG_SECTION="debug"
 PKG_SHORTDESC="gdb: The GNU Debugger"
 PKG_LONGDESC="The purpose of a debugger such as GDB is to allow you to see what is going on ``inside'' another program while it executes--or what another program was doing at the moment it crashed."
+# gdb could fail on runtime if build with LTO support
+PKG_BUILD_FLAGS="-lto"
 
 CC_FOR_BUILD="$HOST_CC"
 CFLAGS_FOR_BUILD="$HOST_CFLAGS"
-
-pre_configure_target() {
-  # gdb could fail on runtime if build with LTO support
-    strip_lto
-}
 
 PKG_CONFIGURE_OPTS_TARGET="bash_cv_have_mbstate_t=set \
                            --disable-shared \

--- a/packages/debug/valgrind/package.mk
+++ b/packages/debug/valgrind/package.mk
@@ -27,13 +27,10 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="debug"
 PKG_SHORTDESC="A tool to help find memory-management problems in programs"
 PKG_LONGDESC="A tool to help find memory-management problems in programs"
+PKG_BUILD_FLAGS="-lto"
 
 if [ "$TARGET_ARCH" = "arm" ]; then
   PKG_CONFIGURE_OPTS_TARGET="--enable-only32bit"
 elif [ "$TARGET_ARCH" = "aarch64" -o "$TARGET_ARCH" = "x86_64" ]; then
   PKG_CONFIGURE_OPTS_TARGET="--enable-only64bit"
 fi
-
-pre_configure_target() {
-  strip_lto
-}

--- a/packages/devel/arm-mem/package.mk
+++ b/packages/devel/arm-mem/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_INIT="toolchain arm-mem"
 PKG_SECTION="devel"
 PKG_SHORTDESC="arm-mem: ARM-accelerated versions of selected functions from string.h"
 PKG_LONGDESC="arm-mem is a ARM-accelerated versions of selected functions from string.h"
+PKG_BUILD_FLAGS="+pic"
 
 if [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ] ; then
   PKG_LIB_ARM_MEM="libarmmem-v7l.so"
@@ -39,7 +40,6 @@ PKG_MAKE_OPTS_TARGET="$PKG_LIB_ARM_MEM"
 
 pre_make_target() {
   export CROSS_COMPILE=$TARGET_PREFIX
-  export CFLAGS="$CFLAGS -fPIC"
 }
 
 make_init() {

--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -26,6 +26,7 @@ PKG_SOURCE_DIR="${PKG_NAME}_${PKG_VERSION}"
 PKG_DEPENDS_TARGET="toolchain boost:host Python2 zlib bzip2"
 PKG_LONGDESC="boost: Peer-reviewed STL style libraries for C++"
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="+pic"
 
 make_host() {
   cd tools/build/src/engine
@@ -38,8 +39,8 @@ makeinstall_host() {
 }
 
 pre_configure_target() {
-  export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/$PKG_PYTHON_VERSION -fPIC"
-  export CXXFLAGS="$CXXFLAGS -I$SYSROOT_PREFIX/usr/include/$PKG_PYTHON_VERSION -fPIC"
+  export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/$PKG_PYTHON_VERSION"
+  export CXXFLAGS="$CXXFLAGS -I$SYSROOT_PREFIX/usr/include/$PKG_PYTHON_VERSION"
 }
 
 configure_target() {

--- a/packages/devel/dbus-glib/package.mk
+++ b/packages/devel/dbus-glib/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="devel"
 PKG_SHORTDESC="dbus-glib: A message bus system"
 PKG_LONGDESC="D-BUS is a message bus, used for sending messages between applications. Conceptually, it fits somewhere in between raw sockets and CORBA in terms of complexity."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_have_abstract_sockets=yes \
                            ac_cv_func_posix_getpwnam_r=yes \
@@ -37,10 +38,6 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_have_abstract_sockets=yes \
                            --disable-tests \
                            --disable-bash-completion \
                            --enable-asserts=no"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin/dbus-binding-tool

--- a/packages/devel/elfutils/package.mk
+++ b/packages/devel/elfutils/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="devel"
 PKG_SHORTDESC="elfutils: collection of utilities to handle ELF objects"
 PKG_LONGDESC="Elfutils is a collection of utilities, including eu-ld (a linker), eu-nm (for listing symbols from object files), eu-size (for listing the section sizes of an object or archive file), eu-strip (for discarding symbols), eu-readelf (to see the raw ELF file structures), and eu-elflint (to check for well-formed ELF files)."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="utrace_cv_cc_biarch=false \
                            --disable-werror \
@@ -36,10 +37,6 @@ PKG_CONFIGURE_OPTS_TARGET="utrace_cv_cc_biarch=false \
                            --with-zlib \
                            --without-bzlib \
                            --without-lzma"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 make_target() {
   make V=1 -C libelf libelf.a

--- a/packages/devel/fribidi/package.mk
+++ b/packages/devel/fribidi/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="devel"
 PKG_SHORTDESC="fribidi: The Bidirectional Algorithm library"
 PKG_LONGDESC="The library implements all of the algorithm as described in the Unicode Standard Annex #9, The Bidirectional Algorithm, http://www.unicode.org/unicode/reports/tr9/. FriBidi is exhautively tested against Bidi Reference Code, and due to our best knowledge, does not contain any conformance bugs."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
                            --enable-static \
@@ -40,7 +41,6 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
 
 pre_configure_target() {
   export CFLAGS="$CFLAGS -DFRIBIDI_CHUNK_SIZE=4080"
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
 }
 
 post_makeinstall_target() {

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_INIT="glibc"
 PKG_SECTION="toolchain/devel"
 PKG_SHORTDESC="glibc: The GNU C library"
 PKG_LONGDESC="The Glibc package contains the main C library. This library provides the basic routines for allocating memory, searching directories, opening and closing files, reading and writing files, string handling, pattern matching, arithmetic, and so on."
+PKG_BUILD_FLAGS="-lto -gold"
 
 PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            ac_cv_path_PERL=no \
@@ -69,12 +70,6 @@ pre_build_target() {
 }
 
 pre_configure_target() {
-# Fails to compile with GCC's link time optimization.
-  strip_lto
-
-# glibc dont support GOLD linker.
-  strip_gold
-
 # Filter out some problematic *FLAGS
   export CFLAGS=`echo $CFLAGS | sed -e "s|-ffast-math||g"`
   export CFLAGS=`echo $CFLAGS | sed -e "s|-Ofast|-O2|g"`

--- a/packages/devel/gmp/package.mk
+++ b/packages/devel/gmp/package.mk
@@ -27,10 +27,10 @@ PKG_DEPENDS_HOST="ccache:host"
 PKG_SECTION="devel"
 PKG_SHORTDESC="gmp: The GNU MP (multiple precision arithmetic) library"
 PKG_LONGDESC="GNU MP is a library for arbitrary precision arithmetic, operating on signed integers, rational numbers, and floating point numbers. It has a rich set of functions, and the functions have a regular interface. GNU MP is designed to be as fast as possible, both for small operands and for huge operands. The speed is achieved by using fullwords as the basic arithmetic type, by using fast algorithms, by carefully optimized assembly code for the most common inner loops for a lots of CPUs, and by a general emphasis on speed (instead of simplicity or elegance). The speed of GNU MP is believed to be faster than any other similar library. The advantage for GNU MP increases with the operand sizes for certain operations, since GNU MP in many cases has asymptotically faster algorithms."
+PKG_BUILD_FLAGS="+pic:host"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-cxx --enable-static --disable-shared"
 
 pre_configure_host() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
   export CPPFLAGS="$CPPFLAGS -fexceptions"
 }

--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -29,8 +29,7 @@ PKG_SECTION="devel"
 PKG_SHORTDESC="heimdal: Kerberos 5, PKIX, CMS, GSS-API, SPNEGO, NTLM, Digest-MD5 and, SASL implementation."
 PKG_LONGDESC="Heimdal is an implementation of Kerberos 5 (and some more stuff) largely written in Sweden (which was important when we started writing it, less so now). It is freely available under a three clause BSD style license. "
 PKG_TOOLCHAIN="autotools"
-
-MAKEFLAGS="-j1"
+PKG_BUILD_FLAGS="-parallel"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared \
                          --without-openldap \

--- a/packages/devel/libftdi1/package.mk
+++ b/packages/devel/libftdi1/package.mk
@@ -27,16 +27,13 @@ PKG_DEPENDS_TARGET="toolchain libusb"
 PKG_SECTION="devel"
 PKG_SHORTDESC="libFTDI is an open source library to talk to FTDI chips"
 PKG_LONGDESC="libFTDI is an open source library to talk to FTDI chips"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DSTATICLIBS=ON \
                        -DDOCUMENTATION=FALSE \
                        -DEXAMPLES=FALSE \
                        -DFTDIPP=FALSE \
                        -DPYTHON_BINDINGS=FALSE"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 makeinstall_target() {
   mkdir -p $SYSROOT_PREFIX/usr/include/libftdi1

--- a/packages/devel/libirman/package.mk
+++ b/packages/devel/libirman/package.mk
@@ -28,12 +28,9 @@ PKG_SECTION="system"
 PKG_SHORTDESC="libirman library for lircd"
 PKG_LONGDESC="libirman library for lircd"
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-swtest"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin

--- a/packages/devel/lockdev/package.mk
+++ b/packages/devel/lockdev/package.mk
@@ -28,12 +28,9 @@ PKG_SECTION="system"
 PKG_SHORTDESC="lockdev: Manage character and block device lockfiles."
 PKG_LONGDESC="lockdev manages character and block device lockfiles."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr

--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -27,6 +27,8 @@ PKG_DEPENDS_TARGET="toolchain zlib"
 PKG_SECTION="devel"
 PKG_SHORTDESC="ncurses: The ncurses (new curses) library"
 PKG_LONGDESC="The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0, and more. It uses terminfo format, supports pads and color and multiple highlights and forms characters and function-key mapping, and has all the other SYSV-curses enhancements over BSD curses."
+# causes some segmentation fault's (dialog) when compiled with gcc's link time optimization.
+PKG_BUILD_FLAGS="-lto +pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--without-ada \
                            --without-cxx \
@@ -72,12 +74,6 @@ PKG_CONFIGURE_OPTS_TARGET="--without-ada \
                            --disable-warnings \
                            --disable-home-terminfo \
                            --disable-assertions"
-
-pre_configure_target() {
-  # causes some segmentation fault's (dialog) when compiled with gcc's link time optimization.
-  strip_lto
-    CFLAGS="$CFLAGS -fPIC"
-}
 
 post_makeinstall_target() {
   cp misc/ncurses-config $TOOLCHAIN/bin

--- a/packages/devel/pcre/package.mk
+++ b/packages/devel/pcre/package.mk
@@ -29,6 +29,7 @@ PKG_SECTION="devel"
 PKG_SHORTDESC="pcre: Perl Compatible Regulat Expressions"
 PKG_LONGDESC="The PCRE library is a set of functions that implement regular expression pattern matching using the same syntax and semantics as Perl 5. PCRE has its own native API, as well as a set of wrapper functions that correspond to the POSIX regular expression API. The PCRE library is free, even for building commercial software."
 PKG_TOOLCHAIN="configure"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_HOST="--prefix=$TOOLCHAIN \
              --enable-static \
@@ -42,12 +43,6 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
              --enable-pcre16 \
              --enable-unicode-properties \
              --with-gnu-ld"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC"
-  CXXFLAGS="$CXXFLAGS -fPIC"
-  LDFLAGS="$LDFLAGS -fPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin

--- a/packages/devel/readline/package.mk
+++ b/packages/devel/readline/package.mk
@@ -27,15 +27,12 @@ PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_SECTION="devel"
 PKG_SHORTDESC="readline: The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in."
 PKG_LONGDESC="The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="bash_cv_wcwidth_broken=no \
                            --disable-shared \
                            --enable-static \
                            --with-curses"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/share/readline

--- a/packages/devel/slang/package.mk
+++ b/packages/devel/slang/package.mk
@@ -27,10 +27,9 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="devel"
 PKG_SHORTDESC="slang: multi-platform programmer's library designed to allow a developer to create robust multi-platform software."
 PKG_LONGDESC="S-Lang is a multi-platform programmer's library designed to allow a developer to create robust multi-platform software. It provides facilities required by interactive applications such as display/screen management, keyboard input, keymaps, and so on. The most exciting feature of the library is the slang interpreter that may be easily embedded into a program to make it extensible. While the emphasis has always been on the embedded nature of the interpreter, it may also be used in a stand-alone fashion through the use of slsh, which is part of the S-Lang distribution."
+PKG_BUILD_FLAGS="-parallel"
 
 PKG_CONFIGURE_OPTS_TARGET="--without-onig"
-
-MAKEFLAGS=-j1
 
 pre_configure_target() {
  # slang fails to build in subdirs

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -28,14 +28,11 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.bluemsx: BlueMSX for Kodi"
 PKG_LONGDESC="game.libretro.bluemsx: BlueMSX for Kodi"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="bluemsx_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="BLUEMSX_LIB"
-
-pre_make_target() {
-  strip_lto
-}
 
 make_target() {
   make -f Makefile.libretro

--- a/packages/emulation/libretro-dosbox/package.mk
+++ b/packages/emulation/libretro-dosbox/package.mk
@@ -28,17 +28,13 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.dosbox: DOSBox for Kodi"
 PKG_LONGDESC="game.libretro.dosbox: DOSBox for Kodi"
+PKG_BUILD_FLAGS="-lto +pic"
 
 PKG_LIBNAME="dosbox_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="DOSBOX_LIB"
 
-pre_make_target() {
-  strip_lto
-}
-
 make_target() {
-  CFLAGS="$CFLAGS -fPIC"
   make -f Makefile.libretro
 }
 

--- a/packages/emulation/libretro-fbalpha/package.mk
+++ b/packages/emulation/libretro-fbalpha/package.mk
@@ -29,15 +29,12 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.fba: fba for Kodi"
 PKG_LONGDESC="game.libretro.fba: fba for Kodi"
 PKG_TOOLCHAIN="manual"
+# linking takes too long with lto
+PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="fbalpha_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="FBALPHA_LIB"
-
-pre_make_target() {
-  # linking takes too long with lto
-  strip_lto
-}
 
 make_target() {
   make -f makefile.libretro

--- a/packages/emulation/libretro-genplus/package.mk
+++ b/packages/emulation/libretro-genplus/package.mk
@@ -29,13 +29,13 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.genplus: Genesis Plus GX for Kodi"
 PKG_LONGDESC="game.libretro.genplus: Genesis Plus GX for Kodi"
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="genesis_plus_gx_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="GENPLUS_LIB"
 
 make_target() {
-  strip_lto
   make -f Makefile.libretro
 }
 

--- a/packages/emulation/libretro-mame/package.mk
+++ b/packages/emulation/libretro-mame/package.mk
@@ -28,15 +28,11 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.mame: MAME for Kodi"
 PKG_LONGDESC="game.libretro.mame: MAME for Kodi"
+PKG_BUILD_FLAGS="-gold -lto"
 
 PKG_LIBNAME="mame_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="MAME_LIB"
-
-pre_make_target() {
-  strip_lto
-  strip_gold
-}
 
 make_target() {
   make -f Makefile.libretro

--- a/packages/emulation/libretro-mame2000/package.mk
+++ b/packages/emulation/libretro-mame2000/package.mk
@@ -28,14 +28,11 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="2000 version of MAME (0.37b5) for libretro"
 PKG_LONGDESC="2000 version of MAME (0.37b5) for libretro"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="mame2000_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="MAME2000_LIB"
-
-configure_target() {
-  strip_lto
-}
 
 make_target() {
   if [ "$TARGET_ARCH" = "arm" ]; then

--- a/packages/emulation/libretro-mame2010/package.mk
+++ b/packages/emulation/libretro-mame2010/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="Late 2010 version of MAME (0.139) for libretro"
 PKG_LONGDESC="Late 2010 version of MAME (0.139) for libretro"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="mame2010_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
@@ -37,7 +38,6 @@ pre_make_target() {
   export CFLAGS="$CFLAGS -fpermissive"
   export CXXFLAGS="$CXXFLAGS -fpermissive"
   export LD="$CXX"
-  strip_lto
 }
 
 make_target() {

--- a/packages/emulation/libretro-mame2014/package.mk
+++ b/packages/emulation/libretro-mame2014/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="Late 2014/Early 2015 version of MAME (0.159-ish) for libretro"
 PKG_LONGDESC="Late 2014/Early 2015 version of MAME (0.159-ish) for libretro"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="mame2014_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
@@ -37,7 +38,6 @@ pre_make_target() {
   export REALCC=$CC
   export CC=$CXX
   export LD=$CXX
-  strip_lto
 }
 
 make_target() {

--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -29,14 +29,11 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.pcsx-rearmed: PCSX Rearmed for Kodi"
 PKG_LONGDESC="game.libretro.pcsx-rearmed: PCSX Rearmed for Kodi"
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-gold"
 
 PKG_LIBNAME="pcsx_rearmed_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="PCSX-REARMED_LIB"
-
-pre_make_target() {
-  strip_gold
-}
 
 make_target() {
   cd $PKG_BUILD

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -30,6 +30,7 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="Fast MegaDrive/MegaCD/32X emulator"
 PKG_LONGDESC="Fast MegaDrive/MegaCD/32X emulator"
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-gold"
 
 PKG_LIBNAME="picodrive_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
@@ -55,10 +56,6 @@ pre_configure_target() {
   # fails to build in subdirs
   cd $PKG_BUILD
   rm -rf .$TARGET_NAME
-}
-
-configure_target() {
-  strip_gold
 }
 
 make_target() {

--- a/packages/emulation/libretro-ppsspp/package.mk
+++ b/packages/emulation/libretro-ppsspp/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="A PSP emulator for Android, Windows, Mac, Linux and Blackberry 10, written in C++."
 PKG_LONGDESC="A PSP emulator for Android, Windows, Mac, Linux and Blackberry 10, written in C++."
 PKG_TOOLCHAIN="make"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="ppsspp_libretro.so"
 PKG_LIBPATH="libretro/$PKG_LIBNAME"
@@ -42,7 +43,6 @@ pre_configure_target() {
 pre_make_target() {
   export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads"
   export CXXFLAGS="$CXXFLAGS -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads"
-  strip_lto
 }
 
 make_target() {

--- a/packages/emulation/libretro-scummvm/package.mk
+++ b/packages/emulation/libretro-scummvm/package.mk
@@ -29,14 +29,11 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.scummvm: scummvm for Kodi"
 PKG_LONGDESC="game.libretro.scummvm: scummvm for Kodi"
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="scummvm_libretro.so"
 PKG_LIBPATH="backends/platform/libretro/build/$PKG_LIBNAME"
 PKG_LIBVAR="SCUMMVM_LIB"
-
-pre_configure_target() {
-  strip_lto
-}
 
 make_target() {
   cd $PKG_BUILD

--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -29,6 +29,7 @@ PKG_SECTION="graphics"
 PKG_SHORTDESC="libjpeg-turbo: a high-speed version of libjpeg for x86 and x86-64 processors which uses SIMD instructions (MMX, SSE2, etc.) to accelerate baseline JPEG compression and decompression."
 PKG_LONGDESC="libjpeg-turbo is a high-speed version of libjpeg for x86 and x86-64 processors which uses SIMD instructions (MMX, SSE2, etc.) to accelerate baseline JPEG compression and decompression. libjpeg-turbo is generally 2-4x as fast as the unmodified version of libjpeg, all else being equal."
 PKG_TOOLCHAIN="configure"
+PKG_BUILD_FLAGS="+pic +pic:host"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-static \
                          --disable-shared \
@@ -36,14 +37,6 @@ PKG_CONFIGURE_OPTS_HOST="--enable-static \
                          --without-simd"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --with-jpeg8"
-
-pre_configure_host() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-}
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 if [ "$SIMD_SUPPORT" = "no" ]; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --without-simd"

--- a/packages/graphics/libpng/package.mk
+++ b/packages/graphics/libpng/package.mk
@@ -29,6 +29,7 @@ PKG_SECTION="graphics"
 PKG_SHORTDESC="libpng: Portable Network Graphics (PNG) Reference Library"
 PKG_LONGDESC="PNG (Portable Network Graphics) is an extensible file format for the lossless, portable, well-compressed storage of raster images. PNG provides a patent-free replacement for GIF and can also replace many common uses of TIFF. Indexed-color, grayscale, and truecolor images are supported, plus an optional alpha channel. Sample depths range from 1 to 16 bits."
 PKG_TOOLCHAIN="configure"
+PKG_BUILD_FLAGS="+pic +pic:host"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_lib_z_zlibVersion=yes \
                            --enable-static \
@@ -37,12 +38,10 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_lib_z_zlibVersion=yes \
 PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared"
 
 pre_configure_host() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
   export CPPFLAGS="$CPPFLAGS -I$TOOLCHAIN/include"
 }
 
 pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
   export CPPFLAGS="$CPPFLAGS -I$SYSROOT_PREFIX/usr/include"
 }
 

--- a/packages/graphics/soil/package.mk
+++ b/packages/graphics/soil/package.mk
@@ -27,10 +27,10 @@ PKG_DEPENDS_TARGET="toolchain mesa"
 PKG_SECTION="graphics"
 PKG_SHORTDESC="A tiny C lib primarily for loading textures into OpenGL"
 PKG_LONGDESC="A tiny C lib primarily for loading textures into OpenGL"
+PKG_BUILD_FLAGS="+pic"
 
 pre_make_target() {
   sed "s/1.07-20071110/$PKG_VERSION/" -i Makefile
-  export CFLAGS="$CFLAGS -fPIC"
 }
 
 pre_makeinstall_target() {

--- a/packages/graphics/tiff/package.mk
+++ b/packages/graphics/tiff/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain libjpeg-turbo zlib"
 PKG_SECTION="graphics"
 PKG_SHORTDESC="libtiff: A library for reading and writing TIFF files"
 PKG_LONGDESC="libtiff is a library for reading and writing data files encoded with the Tag Image File format, Revision 6.0 (or revision 5.0 or revision 4.0). This file format is suit- able for archiving multi-color and monochromatic image data."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \
@@ -38,11 +39,6 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --with-jpeg-include-dir=$SYSROOT_PREFIX/usr/include \
                            --without-x \
                            --with-gl=no"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-  export CXXFLAGS="$CXXFLAGS -fPIC -DPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin

--- a/packages/lang/Python2/package.mk
+++ b/packages/lang/Python2/package.mk
@@ -31,6 +31,7 @@ PKG_SHORTDESC="python2: The Python2 programming language"
 PKG_LONGDESC="Python2 is an interpreted object-oriented programming language, and is often compared with Tcl, Perl, Java or Scheme."
 
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="-parallel"
 
 PKG_PY_DISABLED_MODULES="_tkinter nis gdbm bsddb ossaudiodev"
 
@@ -81,7 +82,7 @@ make_host() {
 }
 
 makeinstall_host() {
-  make -j1 PYTHON_MODULES_INCLUDE="$HOST_INCDIR" \
+  make PYTHON_MODULES_INCLUDE="$HOST_INCDIR" \
        PYTHON_MODULES_LIB="$HOST_LIBDIR" \
        PYTHON_DISABLE_MODULES="readline _curses _curses_panel $PKG_PY_DISABLED_MODULES" \
        install
@@ -92,20 +93,20 @@ pre_configure_target() {
 }
 
 make_target() {
-  make  -j1 CC="$CC" LDFLAGS="$TARGET_LDFLAGS -L." \
+  make  CC="$CC" LDFLAGS="$TARGET_LDFLAGS -L." \
         PYTHON_DISABLE_MODULES="$PKG_PY_DISABLED_MODULES" \
         PYTHON_MODULES_INCLUDE="$TARGET_INCDIR" \
         PYTHON_MODULES_LIB="$TARGET_LIBDIR"
 }
 
 makeinstall_target() {
-  make  -j1 CC="$CC" DESTDIR=$SYSROOT_PREFIX \
+  make  CC="$CC" DESTDIR=$SYSROOT_PREFIX \
         PYTHON_DISABLE_MODULES="$PKG_PY_DISABLED_MODULES" \
         PYTHON_MODULES_INCLUDE="$TARGET_INCDIR" \
         PYTHON_MODULES_LIB="$TARGET_LIBDIR" \
         install
 
-  make  -j1 CC="$CC" DESTDIR=$INSTALL \
+  make  CC="$CC" DESTDIR=$INSTALL \
         PYTHON_DISABLE_MODULES="$PKG_PY_DISABLED_MODULES" \
         PYTHON_MODULES_INCLUDE="$TARGET_INCDIR" \
         PYTHON_MODULES_LIB="$TARGET_LIBDIR" \

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -28,6 +28,8 @@ PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python2 
 PKG_SECTION="mediacenter"
 PKG_SHORTDESC="kodi: Kodi Mediacenter"
 PKG_LONGDESC="Kodi Media Center (which was formerly named Xbox Media Center or XBMC) is a free and open source cross-platform media player and home entertainment system software with a 10-foot user interface designed for the living-room TV. Its graphical user interface allows the user to easily manage video, photos, podcasts, and music from a computer, optical disk, local network, and the internet using a remote control."
+# Single threaded LTO is very slow so rely on Kodi for LTO support
+PKG_BUILD_FLAGS="-lto"
 
 get_graphicdrivers
 
@@ -246,9 +248,6 @@ PKG_CMAKE_OPTS_TARGET="-DNATIVEPREFIX=$TOOLCHAIN \
                        $KODI_PLAYER"
 
 pre_configure_target() {
-  # Single threaded LTO is very slow so rely on Kodi for LTO support
-  strip_lto
-
   export LIBS="$LIBS -lncurses"
 }
 

--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="multimedia"
 PKG_SHORTDESC="SDL2: A cross-platform Graphic API"
 PKG_LONGDESC="Simple DirectMedia Layer is a cross-platform multimedia library designed to provide fast access to the graphics framebuffer and audio device. It is used by MPEG playback software, emulators, and many popular games, including the award winning Linux port of 'Civilization: Call To Power.' Simple DirectMedia Layer supports Linux, Win32, BeOS, MacOS, Solaris, IRIX, and FreeBSD."
 PKG_TOOLCHAIN="configure"
+PKG_BUILD_FLAGS="-parallel"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static \
                            --enable-libc \
@@ -104,11 +105,6 @@ if [ "$PULSEAUDIO_SUPPORT" = yes ]; then
 else
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --disable-pulseaudio --disable-pulseaudio-shared"
 fi
-
-pre_make_target() {
-# dont build parallel
-  MAKEFLAGS=-j1
-}
 
 post_makeinstall_target() {
   $SED "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/bin/sdl2-config

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -29,6 +29,7 @@ PKG_DEPENDS_TARGET="toolchain yasm:host zlib bzip2 openssl speex"
 PKG_SECTION="multimedia"
 PKG_SHORTDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
 PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
+PKG_BUILD_FLAGS="-gold -lto"
 
 # Dependencies
 get_graphicdrivers
@@ -82,12 +83,6 @@ fi
 pre_configure_target() {
   cd $PKG_BUILD
   rm -rf .$TARGET_NAME
-
-# ffmpeg fails building for x86_64 with LTO support
-  strip_lto
-
-# ffmpeg fails running with GOLD support
-  strip_gold
 
   if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
     CFLAGS="-I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux $CFLAGS"

--- a/packages/multimedia/rtmpdump/package.mk
+++ b/packages/multimedia/rtmpdump/package.mk
@@ -27,8 +27,7 @@ PKG_DEPENDS_TARGET="toolchain zlib openssl"
 PKG_SECTION="multimedia"
 PKG_SHORTDESC="rtmpdump: a toolkit for RTMP streams."
 PKG_LONGDESC="rtmpdump is a toolkit for RTMP streams. All forms of RTMP are supported, including rtmp://, rtmpt://, rtmpe://, rtmpte://, and rtmps://."
-
-MAKEFLAGS="-j1"
+PKG_BUILD_FLAGS="+pic -parallel"
 
 make_target() {
   make prefix=/usr \
@@ -41,7 +40,7 @@ make_target() {
        SHARED=no \
        CRYPTO="OPENSSL" \
        OPT="" \
-       XCFLAGS="$CFLAGS -fPIC" \
+       XCFLAGS="$CFLAGS" \
        XLDFLAGS="$LDFLAGS" \
        XLIBS="-lm"
 }
@@ -58,7 +57,7 @@ makeinstall_target() {
        SHARED=no \
        CRYPTO="OPENSSL" \
        OPT="" \
-       XCFLAGS="$CFLAGS -fPIC" \
+       XCFLAGS="$CFLAGS" \
        XLDFLAGS="$LDFLAGS" \
        XLIBS="-lm" \
        install
@@ -74,7 +73,7 @@ makeinstall_target() {
        SHARED=no \
        CRYPTO="OPENSSL" \
        OPT="" \
-       XCFLAGS="$CFLAGS -FPIC" \
+       XCFLAGS="$CFLAGS" \
        XLDFLAGS="$LDFLAGS" \
        XLIBS="-lm" \
        install

--- a/packages/network/libdnet/package.mk
+++ b/packages/network/libdnet/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="network"
 PKG_SHORTDESC="A simplified, portable interface to several low-level networking routines"
 PKG_LONGDESC="A simplified, portable interface to several low-level networking routines"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_strlcat=no \
                            ac_cv_func_strlcpy=no \
@@ -35,7 +36,6 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_strlcat=no \
                            --without-python"
 
 pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC"
   sed "s|@prefix@|$SYSROOT_PREFIX/usr|g" -i $PKG_BUILD/dnet-config.in
 }
 

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -28,6 +28,7 @@ PKG_NEED_UNPACK="$(get_pkg_directory heimdal) $(get_pkg_directory e2fsprogs)"
 PKG_SECTION="network"
 PKG_SHORTDESC="samba: The free SMB / CIFS fileserver and client"
 PKG_LONGDESC="Samba is a SMB server that runs on Unix and other operating systems. It allows these operating systems (currently Unix, Netware, OS/2 and AmigaDOS) to act as a file and print server for SMB and CIFS clients. There are many Lan-Manager compatible clients such as LanManager for DOS, Windows for Workgroups, Windows NT, Windows 95, Linux smbfs, OS/2, Pathworks and more."
+PKG_BUILD_FLAGS="-gold"
 
 PKG_MAKE_OPTS_TARGET="V=1"
 
@@ -105,15 +106,13 @@ pre_configure_target() {
 # samba uses its own build directory
   cd $PKG_BUILD
     rm -rf .$TARGET_NAME
-# samba fails to build with gold support
-  strip_gold
 
 # work around link issues
   export LDFLAGS="$LDFLAGS -lreadline"
 
 # support 64-bit offsets and seeks on 32-bit platforms
   if [ "$TARGET_ARCH" = "arm" ]; then
-    export CFLAGS+="-D_FILE_OFFSET_BITS=64 -D_OFF_T_DEFINED_ -Doff_t=off64_t -Dlseek=lseek64"
+    export CFLAGS+=" -D_FILE_OFFSET_BITS=64 -D_OFF_T_DEFINED_ -Doff_t=off64_t -Dlseek=lseek64"
   fi
 }
 

--- a/packages/python/system/simplejson/package.mk
+++ b/packages/python/system/simplejson/package.mk
@@ -28,9 +28,9 @@ PKG_SECTION="python/system"
 PKG_SHORTDESC="simplejson: a simple, fast, complete, correct and extensible JSON <http://json.org> encoder and decoder for Python 2.5+."
 PKG_LONGDESC="simplejson is a simple, fast, complete, correct and extensible JSON <http://json.org> encoder and decoder for Python 2.5+. It is pure Python code with no dependencies, but includes an optional C extension for a serious speed boost."
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-lto"
 
 pre_make_target() {
-  strip_lto
   export PYTHONXCPREFIX="$SYSROOT_PREFIX/usr"
 }
 

--- a/packages/security/libgcrypt/package.mk
+++ b/packages/security/libgcrypt/package.mk
@@ -28,6 +28,9 @@ PKG_SECTION="security"
 PKG_SHORTDESC="libgcrypt: General purpose cryptographic library"
 PKG_LONGDESC="Libgcrypt is a general purpose cryptographic library based on the code from GnuPG. It provides functions for all cryptographic building blocks: symmetric ciphers, hash algorithms, MACs, public key algorithms, large integer functions, random numbers and a lot of supporting functions."
 PKG_TOOLCHAIN="autotools"
+# libgcrypt-1.7.x fails to build with LTO support
+# see for example https://bugs.gentoo.org/show_bug.cgi?id=581114
+PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            ac_cv_sys_symbol_underscore=no \
@@ -35,12 +38,6 @@ PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            --with-gnu-ld \
                            --with-libgpg-error-prefix=$SYSROOT_PREFIX/usr \
                            --disable-doc"
-
-pre_configure_target() {
-  # libgcrypt-1.7.x fails to build with LTO support
-  # see for example https://bugs.gentoo.org/show_bug.cgi?id=581114
-    strip_lto
-}
 
 post_makeinstall_target() {
   sed -e "s:\(['= ]\)\"/usr:\\1\"$SYSROOT_PREFIX/usr:g" -i src/$PKG_NAME-config

--- a/packages/security/nspr/package.mk
+++ b/packages/security/nspr/package.mk
@@ -29,8 +29,7 @@ PKG_SECTION="security"
 PKG_SHORTDESC="Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc like functions"
 PKG_LONGDESC="Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc like functions"
 PKG_TOOLCHAIN="configure"
-
-MAKEFLAGS=-j1
+PKG_BUILD_FLAGS="-parallel"
 
 if [ "$TARGET_ARCH" = "x86_64" ] ; then
   TARGET_USE_64="--enable-64bit"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -31,8 +31,7 @@ PKG_SECTION="security"
 PKG_SHORTDESC="The Network Security Services (NSS) package is a set of libraries designed to support cross-platform development of security-enabled client and server applications"
 PKG_LONGDESC="The Network Security Services (NSS) package is a set of libraries designed to support cross-platform development of security-enabled client and server applications"
 PKG_TOOLCHAIN="manual"
-
-MAKEFLAGS=-j1
+PKG_BUILD_FLAGS="-parallel"
 
 make_host() {
   cd $PKG_BUILD/nss

--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="security"
 PKG_SHORTDESC="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security"
 PKG_LONGDESC="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security"
+PKG_BUILD_FLAGS="-parallel"
 
 PKG_CONFIGURE_OPTS_SHARED="--openssldir=/etc/ssl \
                            --libdir=lib \

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -29,6 +29,8 @@ PKG_DEPENDS_INIT="toolchain"
 PKG_SECTION="system"
 PKG_SHORTDESC="BusyBox: The Swiss Army Knife of Embedded Linux"
 PKG_LONGDESC="BusyBox combines tiny versions of many common UNIX utilities into a single small executable. It provides replacements for most of the utilities you usually find in GNU fileutils, shellutils, etc. The utilities in BusyBox generally have fewer options than their full-featured GNU cousins; however, the options that are included provide the expected functionality and behave very much like their GNU counterparts. BusyBox provides a fairly complete environment for any small or embedded system."
+# busybox fails to build with GOLD support enabled with binutils-2.25
+PKG_BUILD_FLAGS="-parallel -gold"
 
 PKG_MAKE_OPTS_HOST="ARCH=$TARGET_ARCH CROSS_COMPILE= KBUILD_VERBOSE=1 install"
 PKG_MAKE_OPTS_TARGET="ARCH=$TARGET_ARCH \
@@ -51,9 +53,6 @@ PKG_MAKE_OPTS_INIT="ARCH=$TARGET_ARCH \
 if [ "$NFS_SUPPORT" = yes ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET rpcbind"
 fi
-
-# dont build parallel
-MAKEFLAGS=-j1
 
 pre_build_target() {
   mkdir -p $PKG_BUILD/.$TARGET_NAME
@@ -111,9 +110,6 @@ configure_target() {
     CFLAGS=`echo $CFLAGS | sed -e "s|-Ofast|-Os|"`
     CFLAGS=`echo $CFLAGS | sed -e "s|-O.|-Os|"`
 
-    # busybox fails to build with GOLD support enabled with binutils-2.25
-    strip_gold
-
     LDFLAGS="$LDFLAGS -fwhole-program"
 
     make oldconfig
@@ -130,9 +126,6 @@ configure_init() {
     # optimize for size
     CFLAGS=`echo $CFLAGS | sed -e "s|-Ofast|-Os|"`
     CFLAGS=`echo $CFLAGS | sed -e "s|-O.|-Os|"`
-
-    # busybox fails to build with GOLD support enabled with binutils-2.25
-    strip_gold
 
     LDFLAGS="$LDFLAGS -fwhole-program"
 

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_INIT="toolchain"
 PKG_SECTION="tools"
 PKG_SHORTDESC="e2fsprogs: Utilities for use with the ext2 filesystem"
 PKG_LONGDESC="The filesystem utilities for the EXT2 filesystem, including e2fsck, mke2fs, dumpe2fs, fsck, and others."
+PKG_BUILD_FLAGS="-parallel"
 
 if [ "$HFSTOOLS" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET diskdev_cmds"
@@ -63,10 +64,6 @@ PKG_CONFIGURE_OPTS_TARGET="BUILD_CC=$HOST_CC \
 
 PKG_CONFIGURE_OPTS_INIT="$PKG_CONFIGURE_OPTS_TARGET"
 
-pre_make_host() {
-  # dont build parallel
-  MAKEFLAGS=-j1
-}
 
 post_makeinstall_target() {
   make -C lib/et LIBMODE=644 DESTDIR=$SYSROOT_PREFIX install

--- a/packages/sysutils/fuse/package.mk
+++ b/packages/sysutils/fuse/package.mk
@@ -27,6 +27,8 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="system"
 PKG_SHORTDESC="fuse: A simple user-space filesystem interface for Linux"
 PKG_LONGDESC="FUSE provides a simple interface for userspace programs to export a virtual filesystem to the Linux kernel. FUSE also aims to provide a secure method for non privileged users to create and mount their own filesystem implementations."
+# fuse fails to build with GOLD linker on gcc-4.9
+PKG_BUILD_FLAGS="-gold"
 
 PKG_CONFIGURE_OPTS_TARGET="MOUNT_FUSE_PATH=/usr/sbin \
                            --enable-lib \
@@ -35,11 +37,6 @@ PKG_CONFIGURE_OPTS_TARGET="MOUNT_FUSE_PATH=/usr/sbin \
                            --enable-mtab \
                            --disable-rpath \
                            --with-gnu-ld"
-
-pre_configure_target() {
-# fuse fails to build with GOLD linker on gcc-4.9
-  strip_gold
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/etc/init.d

--- a/packages/sysutils/libevdev/package.mk
+++ b/packages/sysutils/libevdev/package.mk
@@ -27,12 +27,9 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="system"
 PKG_SHORTDESC="libevdev: a wrapper library for evdev devices."
 PKG_LONGDESC="libevdev is a wrapper library for evdev devices. it moves the common tasks when dealing with evdev devices into a library and provides a library interface to the callers, thus avoiding erroneous ioctls, etc."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-shared --disable-static"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin

--- a/packages/sysutils/libusb/package.mk
+++ b/packages/sysutils/libusb/package.mk
@@ -27,6 +27,8 @@ PKG_DEPENDS_TARGET="toolchain systemd"
 PKG_SECTION="system"
 PKG_SHORTDESC="libusb: OS independent USB device access"
 PKG_LONGDESC="The libusb project's aim is to create a Library for use by user level applications to USB devices regardless of OS."
+#libusb sometimes fails to build if building paralell
+PKG_BUILD_FLAGS="-parallel"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-shared \
             --enable-static \
@@ -34,8 +36,3 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-shared \
             --disable-debug-log \
             --enable-udev \
             --disable-examples-build"
-
-pre_configure_target () {
-  #libusb sometimes fails to build if building paralell
-  export MAKEFLAGS=-j1
-}

--- a/packages/textproc/jsoncpp/package.mk
+++ b/packages/textproc/jsoncpp/package.mk
@@ -28,9 +28,6 @@ PKG_SECTION="multimedia"
 PKG_SHORTDESC="A C++ library for interacting with JSON."
 PKG_LONGDESC="A C++ library for interacting with JSON."
 PKG_TOOLCHAIN="cmake"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DJSONCPP_WITH_TESTS=OFF"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/textproc/tinyxml/package.mk
+++ b/packages/textproc/tinyxml/package.mk
@@ -28,12 +28,9 @@ PKG_SECTION="textproc"
 PKG_SHORTDESC="tinyxml: XML parser library"
 PKG_LONGDESC="TinyXML is a simple, small, C++ XML parser that can be easily integrating into other programs."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --with-pic"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr

--- a/packages/textproc/tinyxml2/package.mk
+++ b/packages/textproc/tinyxml2/package.mk
@@ -27,12 +27,9 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="textproc"
 PKG_SHORTDESC="tinyxml2: XML parser library"
 PKG_LONGDESC="TinyXML2 is a simple, small, C++ XML parser that can be easily integrating into other programs."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=off -DBUILD_STATIC_LIBS=on"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr

--- a/packages/tools/grub/package.mk
+++ b/packages/tools/grub/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="tools"
 PKG_SHORTDESC="GNU GRUB is a Multiboot boot loader."
 PKG_LONGDESC="GNU GRUB is a Multiboot boot loader that was derived from GRUB, the GRand Unified Bootloader, which was originally designed and implemented by Erich Stefan Boleyn"
 PKG_TOOLCHAIN="configure"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="--target=i386-pc-linux \
                            --disable-nls \
@@ -40,7 +41,6 @@ PKG_CONFIGURE_OPTS_TARGET="--target=i386-pc-linux \
 
 pre_configure_target() {
   unset CPP
-  strip_lto
   cd $PKG_BUILD
      ./autogen.sh
 }

--- a/packages/tools/populatefs/package.mk
+++ b/packages/tools/populatefs/package.mk
@@ -27,9 +27,10 @@ PKG_DEPENDS_HOST="e2fsprogs:host"
 PKG_SECTION="tools"
 PKG_SHORTDESC="populatefs: Tool for replacing genext2fs when creating ext4 images"
 PKG_LONGDESC="populatefs: Tool for replacing genext2fs when creating ext4 images"
+PKG_BUILD_FLAGS="+pic:host"
 
 make_host() {
-  make EXTRA_LIBS="-lcom_err -lpthread" CFLAGS="$CFLAGS -fPIC"
+  make EXTRA_LIBS="-lcom_err -lpthread"
 }
 
 makeinstall_host() {

--- a/packages/wayland/mtdev/package.mk
+++ b/packages/wayland/mtdev/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="wayland"
 PKG_SHORTDESC="The mtdev is a stand-alone library which transforms all variants of kernel MT events to the slotted type B protocol."
 PKG_LONGDESC="The mtdev is a stand-alone library which transforms all variants of kernel MT events to the slotted type B protocol. The events put into mtdev may be from any MT device, specifically type A without contact tracking, type A with contact tracking, or type B with contact tracking. See the kernel documentation for further details."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/wayland/wayland/package.mk
+++ b/packages/wayland/wayland/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_HOST="libffi:host expat:host libxml2:host"
 PKG_SECTION="wayland"
 PKG_SHORTDESC="a display server protocol"
 PKG_LONGDESC="a display server protocol"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-shared \
                          --disable-static \
@@ -42,10 +43,6 @@ PKG_CONFIGURE_OPTS_TARGET="--with-sysroot=$SYSROOT_PREFIX \
                            --enable-libraries \
                            --disable-documentation \
                            --with-gnu-ld"
-
-pre_configure_target() {
-  strip_lto
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin

--- a/packages/wayland/weston/package.mk
+++ b/packages/wayland/weston/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain wayland-protocols libdrm libxkbcommon libinput cai
 PKG_SECTION="wayland"
 PKG_SHORTDESC="Reference implementation of a Wayland compositor"
 PKG_LONGDESC="Reference implementation of a Wayland compositor"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="CFLAGS=-DMESA_EGL_NO_X11_HEADERS \
                            LIBS=-lturbojpeg \
@@ -47,10 +48,6 @@ PKG_CONFIGURE_OPTS_TARGET="CFLAGS=-DMESA_EGL_NO_X11_HEADERS \
                            --disable-fullscreen-shell \
                            --disable-demo-clients-install \
                            --enable-systemd-notify"
-
-pre_configure_target() {
-  strip_lto
-}
 
 post_makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/weston

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -29,6 +29,8 @@ PKG_SECTION="x11/driver"
 PKG_SHORTDESC="xf86-video-intel: The Xorg driver for Intel video chips"
 PKG_LONGDESC="The Xorg driver for Intel i810, i815, 830M, 845G, 852GM, 855GM, 865G, 915G, 915GM and 965G video chips."
 PKG_TOOLCHAIN="autotools"
+# xf86-video-intel is broken enough. dont link with LTO
+PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-backlight \
                            --disable-backlight-helper \
@@ -51,11 +53,6 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-backlight \
                            --disable-async-swap \
                            --with-default-dri=2 \
                            --with-xorg-module-dir=$XORG_PATH_MODULES"
-
-pre_configure_target() {
-# xf86-video-intel is broken enough. dont link with LTO
-  strip_lto
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/share/polkit-1

--- a/packages/x11/lib/libXau/package.mk
+++ b/packages/x11/lib/libXau/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros xproto"
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libXau: X authorization file management libary"
 PKG_LONGDESC="X authorization file management libary"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --enable-xthreads"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}

--- a/packages/x11/lib/libXcomposite/package.mk
+++ b/packages/x11/lib/libXcomposite/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros compositeproto fixesproto libXfixes li
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libxcomposite: X Composite Library"
 PKG_LONGDESC="X Composite Library"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/x11/lib/libXdamage/package.mk
+++ b/packages/x11/lib/libXdamage/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros damageproto fixesproto libX11 libXfixe
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libXdamage: X11 damaged region extension library"
 PKG_LONGDESC="LibXdamage provides an X Window System client interface to the DAMAGE extension to the X protocol. The Damage extension provides for notification of when on-screen regions have been 'damaged' (altered)."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/x11/lib/libXfixes/package.mk
+++ b/packages/x11/lib/libXfixes/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros fixesproto libX11"
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libxfixes: X Fixes Library"
 PKG_LONGDESC="X Fixes Library"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/x11/lib/libXmu/package.mk
+++ b/packages/x11/lib/libXmu/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros xextproto libXext libX11 libXt"
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libxmu: X11 miscellaneous utility library"
 PKG_LONGDESC="LibXmu provides a set of miscellaneous utility convenience functions for X libraries to use."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --with-gnu-ld --without-xmlto"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}

--- a/packages/x11/lib/libXrender/package.mk
+++ b/packages/x11/lib/libXrender/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros renderproto libX11"
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libxrender: X Rendering Extension client library"
 PKG_LONGDESC="The X Rendering Extension (Render) introduces digital image composition as the foundation of a new rendering model within the X Window System. Rendering geometric figures is accomplished by client-side tesselation into either triangles or trapezoids."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --enable-malloc0returnsnull"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC"
-}

--- a/packages/x11/lib/libXxf86vm/package.mk
+++ b/packages/x11/lib/libXxf86vm/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros xf86vidmodeproto libX11 libXext"
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libxxf86vm: Extension library for the XFree86-VidMode X extension"
 PKG_LONGDESC="The libxxf86vm provides an interface to the server extension XFree86-VidModeExtension which allows the video modes to be queried and adjusted dynamically and mode switching to be controlled."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --enable-malloc0returnsnull"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}

--- a/packages/x11/lib/libfontenc/package.mk
+++ b/packages/x11/lib/libfontenc/package.mk
@@ -27,9 +27,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros xproto zlib font-util"
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libfontenc: X11 font encoding library"
 PKG_LONGDESC="Libfontenc is a library which helps font libraries portably determine and deal with different encodings of fonts."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
-pre_configure_target() {
-  export CFLAGS="$CFLAGS -fPIC -DPIC"
-}

--- a/packages/x11/lib/libxcb/package.mk
+++ b/packages/x11/lib/libxcb/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain util-macros Python2:host xcb-proto libpthread-stub
 PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libxcb: X C-language Bindings library"
 PKG_LONGDESC="X C-language Bindings library."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
                            --disable-screensaver \
@@ -40,6 +41,4 @@ pre_configure_target() {
 
   PKG_CONFIG="$PKG_CONFIG --define-variable=pythondir=$PYTHON_TOOLCHAIN_PATH"
   PKG_CONFIG="$PKG_CONFIG --define-variable=xcbincludedir=$SYSROOT_PREFIX/usr/share/xcb"
-
-  CFLAGS="$CFLAGS -fPIC -DPIC"
 }

--- a/packages/x11/lib/libxshmfence/package.mk
+++ b/packages/x11/lib/libxshmfence/package.mk
@@ -28,9 +28,6 @@ PKG_SECTION="x11/lib"
 PKG_SHORTDESC="libxshmfence: Shared memory 'SyncFence' synchronization primitive."
 PKG_LONGDESC="libxshmfence is the Shared memory 'SyncFence' synchronization primitive."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
-pre_configure_target() {
-  CFLAGS="$CFLAGS -fPIC -DPIC"
-}

--- a/scripts/build
+++ b/scripts/build
@@ -436,19 +436,19 @@ else
     # ninja based builds
     "meson:target"|"cmake:target"|"ninja:target")
       echo "Executing (target): ninja $PKG_MAKE_OPTS_TARGET" | tr -s " "
-      ninja $PKG_MAKE_OPTS_TARGET
+      ninja $NINJA_OPTS $PKG_MAKE_OPTS_TARGET
       ;;
     "meson:host"|"cmake:host"|"ninja:host")
       echo "Executing (host): ninja $PKG_MAKE_OPTS_HOST" | tr -s " "
-      ninja $PKG_MAKE_OPTS_HOST
+      ninja $NINJA_OPTS $PKG_MAKE_OPTS_HOST
       ;;
     "meson:init"|"cmake:init"|"ninja:init")
       echo "Executing (init): ninja $PKG_MAKE_OPTS_INIT" | tr -s " "
-      ninja $PKG_MAKE_OPTS_INIT
+      ninja $NINJA_OPTS $PKG_MAKE_OPTS_INIT
       ;;
     "meson:bootstrap"|"cmake:bootstrap"|"ninja:bootstrap")
       echo "Executing (bootstrap): ninja $PKG_MAKE_OPTS_BOOTSTRAP" | tr -s " "
-      ninja $PKG_MAKE_OPTS_BOOTSTRAP
+      ninja $NINJA_OPTS $PKG_MAKE_OPTS_BOOTSTRAP
       ;;
 
     # make based builds


### PR DESCRIPTION
add new variable PKG_BUILD_FLAGS, which control some common build options.
example: `PKG_BUILD_FLAGS="-lto +pic -parallel"`
- lto/gold: replace strip_lto/strip_gold (only for target)
- pic: add flag for PIC compiler feature (only for target)
- parallel: usable to stop build parallel (`-parallel` please no double not ;) )
- hardening: for later usage to add security build options (initial copy from debian 9, only for target)

build tests are actual running

`-fPIC` is often used, i will replace these, if this is approved