### PR TITLE
projects/Amlogic: include wetekdvb with S905 builds

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -33,6 +33,7 @@ PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
   device=${DEVICE:-$PROJECT}
+  [ $device="S905" ] && device=WeTek_Play_2
   for overlay_dir in driver/$device/*/; do
     overlay_dir=`basename $overlay_dir`
     mkdir -p $INSTALL/$(get_full_module_dir $overlay_dir)/$PKG_NAME

--- a/projects/Amlogic/devices/S905/options
+++ b/projects/Amlogic/devices/S905/options
@@ -6,8 +6,8 @@
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS ap6xxx-aml mt7601u-aml mt7603u-aml \
-                        qca9377-aml RTL8189ES-aml RTL8189FS-aml \
-                        RTL8723BS-aml RTL8723DS-aml RTL8822BU-aml ssv6xxx-aml fd628-aml"
+                        qca9377-aml RTL8189ES-aml RTL8189FS-aml RTL8723BS-aml \
+                        RTL8723DS-aml RTL8822BU-aml ssv6xxx-aml fd628-aml wetekdvb"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,


### PR DESCRIPTION
This PR adds the driver & firmware for wetek dvb into the generic S905 builds.