### PR TITLE
binutils: add patch to fix aarch64 ld regression

### DIFF
--- a/packages/devel/binutils/patches/binutils-02-PR22764.patch
+++ b/packages/devel/binutils/patches/binutils-02-PR22764.patch
@@ -1,0 +1,143 @@
+From b01452b1d44a586f4ecf5cf02ffc0643e4962324 Mon Sep 17 00:00:00 2001
+From: Renlin Li <renlin.li@arm.com>
+Date: Sat, 3 Feb 2018 13:18:17 +0000
+Subject: [PATCH] [PR22764][LD][AARCH64]Allow R_AARCH64_ABS16 and
+ R_AARCH64_ABS32 against absolution symbol or undefine symbol in shared
+ object.
+
+backport from mainline
+
+bfd/
+
+2018-02-05  Renlin Li  <renlin.li@arm.com>
+
+	PR ld/22764
+	* elfnn-aarch64.c (elfNN_aarch64_check_relocs): Relax the
+	R_AARCH64_ABS32 and R_AARCH64_ABS16 for absolute symbol. Apply the
+	check for writeable section as well.
+
+ld/
+
+2018-02-05  Renlin Li  <renlin.li@arm.com>
+
+	PR ld/22764
+	* testsuite/ld-aarch64/emit-relocs-258.s: Define symbol as an address.
+	* testsuite/ld-aarch64/emit-relocs-259.s: Likewise.
+	* testsuite/ld-aarch64/aarch64-elf.exp: Run new test.
+	* testsuite/ld-aarch64/pr22764.s: New.
+	* testsuite/ld-aarch64/pr22764.d: New.
+---
+ bfd/ChangeLog                             |  7 +++++++
+ bfd/elfnn-aarch64.c                       | 15 ++++++++++++---
+ ld/ChangeLog                              |  8 ++++++++
+ ld/testsuite/ld-aarch64/aarch64-elf.exp   |  1 +
+ ld/testsuite/ld-aarch64/emit-relocs-258.s |  3 ++-
+ ld/testsuite/ld-aarch64/emit-relocs-259.s |  3 ++-
+ ld/testsuite/ld-aarch64/pr22764.d         | 18 ++++++++++++++++++
+ ld/testsuite/ld-aarch64/pr22764.s         |  6 ++++++
+ 8 files changed, 56 insertions(+), 5 deletions(-)
+ create mode 100644 ld/testsuite/ld-aarch64/pr22764.d
+ create mode 100644 ld/testsuite/ld-aarch64/pr22764.s
+
+diff --git a/bfd/elfnn-aarch64.c b/bfd/elfnn-aarch64.c
+index d5711e0..9731882 100644
+--- a/bfd/elfnn-aarch64.c
++++ b/bfd/elfnn-aarch64.c
+@@ -7074,10 +7074,19 @@ elfNN_aarch64_check_relocs (bfd *abfd, struct bfd_link_info *info,
+ #if ARCH_SIZE == 64
+ 	case BFD_RELOC_AARCH64_32:
+ #endif
+-	  if (bfd_link_pic (info)
+-	      && (sec->flags & SEC_ALLOC) != 0
+-	      && (sec->flags & SEC_READONLY) != 0)
++	  if (bfd_link_pic (info) && (sec->flags & SEC_ALLOC) != 0)
+ 	    {
++	      if (h != NULL
++		  /* This is an absolute symbol.  It represents a value instead
++		     of an address.  */
++		  && ((h->root.type == bfd_link_hash_defined
++		       && bfd_is_abs_section (h->root.u.def.section))
++		      /* This is an undefined symbol.  */
++		      || h->root.type == bfd_link_hash_undefined))
++		break;
++
++	      /* For local symbols, defined global symbols in a non-ABS section,
++		 it is assumed that the value is an address.  */
+ 	      int howto_index = bfd_r_type - BFD_RELOC_AARCH64_RELOC_START;
+ 	      _bfd_error_handler
+ 		/* xgettext:c-format */
+diff --git a/ld/testsuite/ld-aarch64/aarch64-elf.exp b/ld/testsuite/ld-aarch64/aarch64-elf.exp
+index f310893..d766f37 100644
+--- a/ld/testsuite/ld-aarch64/aarch64-elf.exp
++++ b/ld/testsuite/ld-aarch64/aarch64-elf.exp
+@@ -275,6 +275,7 @@ run_dump_test "pr17415"
+ run_dump_test_lp64 "tprel_g2_overflow"
+ run_dump_test "tprel_add_lo12_overflow"
+ run_dump_test "protected-data"
++run_dump_test_lp64 "pr22764"
+ 
+ # ifunc tests
+ run_dump_test "ifunc-1"
+diff --git a/ld/testsuite/ld-aarch64/emit-relocs-258.s b/ld/testsuite/ld-aarch64/emit-relocs-258.s
+index f724776..87bb657 100644
+--- a/ld/testsuite/ld-aarch64/emit-relocs-258.s
++++ b/ld/testsuite/ld-aarch64/emit-relocs-258.s
+@@ -1,5 +1,6 @@
++.global dummy
+ .text
+-
++dummy:
+   ldr x0, .L1
+ 
+ .L1:
+diff --git a/ld/testsuite/ld-aarch64/emit-relocs-259.s b/ld/testsuite/ld-aarch64/emit-relocs-259.s
+index 7e1ba3c..0977c9d 100644
+--- a/ld/testsuite/ld-aarch64/emit-relocs-259.s
++++ b/ld/testsuite/ld-aarch64/emit-relocs-259.s
+@@ -1,5 +1,6 @@
++.global dummy
+ .text
+-
++dummy:
+   ldr x0, .L1
+ 
+ .L1:
+diff --git a/ld/testsuite/ld-aarch64/pr22764.d b/ld/testsuite/ld-aarch64/pr22764.d
+new file mode 100644
+index 0000000..997519f
+--- /dev/null
++++ b/ld/testsuite/ld-aarch64/pr22764.d
+@@ -0,0 +1,18 @@
++#source: pr22764.s
++#ld: -shared -T relocs.ld -defsym sym_abs1=0x1 -defsym sym_abs2=0x2 -defsym sym_abs3=0x3 -e0 --emit-relocs
++#notarget: aarch64_be-*-*
++#objdump: -dr
++#...
++
++Disassembly of section \.text:
++
++0000000000010000 \<\.text\>:
++   10000:	d503201f 	nop
++	...
++			10004: R_AARCH64_ABS64	sym_abs1
++   1000c:	00000002 	\.word	0x00000002
++			1000c: R_AARCH64_ABS32	sym_abs2
++   10010:	0003      	\.short	0x0003
++			10010: R_AARCH64_ABS16	sym_abs3
++   10012:	0000      	\.short	0x0000
++   10014:	d503201f 	nop
+diff --git a/ld/testsuite/ld-aarch64/pr22764.s b/ld/testsuite/ld-aarch64/pr22764.s
+new file mode 100644
+index 0000000..25e36b4
+--- /dev/null
++++ b/ld/testsuite/ld-aarch64/pr22764.s
+@@ -0,0 +1,6 @@
++  .text
++  nop
++  .xword sym_abs1
++  .word sym_abs2
++  .short sym_abs3
++  nop
+-- 
+2.9.3
+


### PR DESCRIPTION
This PR adds a patch to fix a ld regression on aarch64, fixes building aarch64 `u-boot` on `rockchip` branch.

Patch is taken from `binutils-2_30-branch` with the changes to `ChangeLog`-files removed to make it apply.

Bug report: https://sourceware.org/bugzilla/show_bug.cgi?id=22764
Fix commit: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commitdiff;h=b01452b1d44a586f4ecf5cf02ffc0643e4962324