### PR TITLE
Rockchip: fix building aarch64

### DIFF
--- a/packages/devel/binutils/patches/binutils-02-PR22764.patch
+++ b/packages/devel/binutils/patches/binutils-02-PR22764.patch
@@ -1,0 +1,143 @@
+From b01452b1d44a586f4ecf5cf02ffc0643e4962324 Mon Sep 17 00:00:00 2001
+From: Renlin Li <renlin.li@arm.com>
+Date: Sat, 3 Feb 2018 13:18:17 +0000
+Subject: [PATCH] [PR22764][LD][AARCH64]Allow R_AARCH64_ABS16 and
+ R_AARCH64_ABS32 against absolution symbol or undefine symbol in shared
+ object.
+
+backport from mainline
+
+bfd/
+
+2018-02-05  Renlin Li  <renlin.li@arm.com>
+
+	PR ld/22764
+	* elfnn-aarch64.c (elfNN_aarch64_check_relocs): Relax the
+	R_AARCH64_ABS32 and R_AARCH64_ABS16 for absolute symbol. Apply the
+	check for writeable section as well.
+
+ld/
+
+2018-02-05  Renlin Li  <renlin.li@arm.com>
+
+	PR ld/22764
+	* testsuite/ld-aarch64/emit-relocs-258.s: Define symbol as an address.
+	* testsuite/ld-aarch64/emit-relocs-259.s: Likewise.
+	* testsuite/ld-aarch64/aarch64-elf.exp: Run new test.
+	* testsuite/ld-aarch64/pr22764.s: New.
+	* testsuite/ld-aarch64/pr22764.d: New.
+---
+ bfd/ChangeLog                             |  7 +++++++
+ bfd/elfnn-aarch64.c                       | 15 ++++++++++++---
+ ld/ChangeLog                              |  8 ++++++++
+ ld/testsuite/ld-aarch64/aarch64-elf.exp   |  1 +
+ ld/testsuite/ld-aarch64/emit-relocs-258.s |  3 ++-
+ ld/testsuite/ld-aarch64/emit-relocs-259.s |  3 ++-
+ ld/testsuite/ld-aarch64/pr22764.d         | 18 ++++++++++++++++++
+ ld/testsuite/ld-aarch64/pr22764.s         |  6 ++++++
+ 8 files changed, 56 insertions(+), 5 deletions(-)
+ create mode 100644 ld/testsuite/ld-aarch64/pr22764.d
+ create mode 100644 ld/testsuite/ld-aarch64/pr22764.s
+
+diff --git a/bfd/elfnn-aarch64.c b/bfd/elfnn-aarch64.c
+index d5711e0..9731882 100644
+--- a/bfd/elfnn-aarch64.c
++++ b/bfd/elfnn-aarch64.c
+@@ -7074,10 +7074,19 @@ elfNN_aarch64_check_relocs (bfd *abfd, struct bfd_link_info *info,
+ #if ARCH_SIZE == 64
+ 	case BFD_RELOC_AARCH64_32:
+ #endif
+-	  if (bfd_link_pic (info)
+-	      && (sec->flags & SEC_ALLOC) != 0
+-	      && (sec->flags & SEC_READONLY) != 0)
++	  if (bfd_link_pic (info) && (sec->flags & SEC_ALLOC) != 0)
+ 	    {
++	      if (h != NULL
++		  /* This is an absolute symbol.  It represents a value instead
++		     of an address.  */
++		  && ((h->root.type == bfd_link_hash_defined
++		       && bfd_is_abs_section (h->root.u.def.section))
++		      /* This is an undefined symbol.  */
++		      || h->root.type == bfd_link_hash_undefined))
++		break;
++
++	      /* For local symbols, defined global symbols in a non-ABS section,
++		 it is assumed that the value is an address.  */
+ 	      int howto_index = bfd_r_type - BFD_RELOC_AARCH64_RELOC_START;
+ 	      _bfd_error_handler
+ 		/* xgettext:c-format */
+diff --git a/ld/testsuite/ld-aarch64/aarch64-elf.exp b/ld/testsuite/ld-aarch64/aarch64-elf.exp
+index f310893..d766f37 100644
+--- a/ld/testsuite/ld-aarch64/aarch64-elf.exp
++++ b/ld/testsuite/ld-aarch64/aarch64-elf.exp
+@@ -275,6 +275,7 @@ run_dump_test "pr17415"
+ run_dump_test_lp64 "tprel_g2_overflow"
+ run_dump_test "tprel_add_lo12_overflow"
+ run_dump_test "protected-data"
++run_dump_test_lp64 "pr22764"
+ 
+ # ifunc tests
+ run_dump_test "ifunc-1"
+diff --git a/ld/testsuite/ld-aarch64/emit-relocs-258.s b/ld/testsuite/ld-aarch64/emit-relocs-258.s
+index f724776..87bb657 100644
+--- a/ld/testsuite/ld-aarch64/emit-relocs-258.s
++++ b/ld/testsuite/ld-aarch64/emit-relocs-258.s
+@@ -1,5 +1,6 @@
++.global dummy
+ .text
+-
++dummy:
+   ldr x0, .L1
+ 
+ .L1:
+diff --git a/ld/testsuite/ld-aarch64/emit-relocs-259.s b/ld/testsuite/ld-aarch64/emit-relocs-259.s
+index 7e1ba3c..0977c9d 100644
+--- a/ld/testsuite/ld-aarch64/emit-relocs-259.s
++++ b/ld/testsuite/ld-aarch64/emit-relocs-259.s
+@@ -1,5 +1,6 @@
++.global dummy
+ .text
+-
++dummy:
+   ldr x0, .L1
+ 
+ .L1:
+diff --git a/ld/testsuite/ld-aarch64/pr22764.d b/ld/testsuite/ld-aarch64/pr22764.d
+new file mode 100644
+index 0000000..997519f
+--- /dev/null
++++ b/ld/testsuite/ld-aarch64/pr22764.d
+@@ -0,0 +1,18 @@
++#source: pr22764.s
++#ld: -shared -T relocs.ld -defsym sym_abs1=0x1 -defsym sym_abs2=0x2 -defsym sym_abs3=0x3 -e0 --emit-relocs
++#notarget: aarch64_be-*-*
++#objdump: -dr
++#...
++
++Disassembly of section \.text:
++
++0000000000010000 \<\.text\>:
++   10000:	d503201f 	nop
++	...
++			10004: R_AARCH64_ABS64	sym_abs1
++   1000c:	00000002 	\.word	0x00000002
++			1000c: R_AARCH64_ABS32	sym_abs2
++   10010:	0003      	\.short	0x0003
++			10010: R_AARCH64_ABS16	sym_abs3
++   10012:	0000      	\.short	0x0000
++   10014:	d503201f 	nop
+diff --git a/ld/testsuite/ld-aarch64/pr22764.s b/ld/testsuite/ld-aarch64/pr22764.s
+new file mode 100644
+index 0000000..25e36b4
+--- /dev/null
++++ b/ld/testsuite/ld-aarch64/pr22764.s
+@@ -0,0 +1,6 @@
++  .text
++  nop
++  .xword sym_abs1
++  .word sym_abs2
++  .short sym_abs3
++  nop
+-- 
+2.9.3
+

--- a/projects/Rockchip/README.md
+++ b/projects/Rockchip/README.md
@@ -11,6 +11,7 @@ This project is for Rockchip SoC devices
 **RK3328**
 * [PINE64 ROCK64](devices/RK3328)
 * [Popcorn Hour RockBox](devices/RK3328)
+* [Popcorn Hour Transformer](devices/RK3328)
 * [Firefly ROC-RK3328-CC](devices/RK3328)
 
 **RK3399**

--- a/projects/Rockchip/patches/linux/rockchip-4.4/linux-0001-rockchip.patch
+++ b/projects/Rockchip/patches/linux/rockchip-4.4/linux-0001-rockchip.patch
@@ -642,3 +642,63 @@ index 48c46f4b25ae..8086940664b4 100644
  
  	/*
  	 * The Designware IP uses a different byte format from standard
+
+From ba31c3d5eb595d9b5266e1a52df6e71c1557d14d Mon Sep 17 00:00:00 2001
+From: David Carrillo-Cisneros <davidcc@google.com>
+Date: Tue, 18 Jul 2017 18:18:37 -0700
+Subject: [PATCH] UPSTREAM: perf tools: Add EXCLUDE_EXTLIBS and EXTRA_PERFLIBS
+ to makefile
+
+The goal is to allow users to override linking of libraries that
+were automatically added to PERFLIBS.
+
+EXCLUDE_EXTLIBS contains linker flags to be removed from LIBS
+while EXTRA_PERFLIBS contains linker flags to be added.
+
+My use case is to force certain library to be build statically,
+e.g. for libelf:
+
+  EXCLUDE_EXTLIBS=-lelf EXTRA_PERFLIBS=path/libelf.a
+
+Signed-off-by: David Carrillo-Cisneros <davidcc@google.com>
+Acked-by: Jiri Olsa <jolsa@kernel.org>
+Cc: Alexander Shishkin <alexander.shishkin@linux.intel.com>
+Cc: Elena Reshetova <elena.reshetova@intel.com>
+Cc: Kees Kook <keescook@chromium.org>
+Cc: Paul Turner <pjt@google.com>
+Cc: Stephane Eranian <eranian@google.com>
+Cc: Sudeep Holla <sudeep.holla@arm.com>
+Cc: Wang Nan <wangnan0@huawei.com>
+Link: http://lkml.kernel.org/r/20170719011839.99399-3-davidcc@google.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+(cherry picked from commit cb281fea4b0a326d2a2104f8ffae2b6895c561fd)
+---
+ tools/perf/Makefile.perf | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/tools/perf/Makefile.perf b/tools/perf/Makefile.perf
+index fb1c9ddc3478..9b3b9bd50d54 100644
+--- a/tools/perf/Makefile.perf
++++ b/tools/perf/Makefile.perf
+@@ -33,6 +33,11 @@ include config/utilities.mak
+ #
+ # Define EXTRA_CFLAGS=-m64 or EXTRA_CFLAGS=-m32 as appropriate for cross-builds.
+ #
++# Define EXCLUDE_EXTLIBS=-lmylib to exclude libmylib from the auto-generated
++# EXTLIBS.
++#
++# Define EXTRA_PERFLIBS to pass extra libraries to PERFLIBS.
++#
+ # Define NO_DWARF if you do not want debug-info analysis feature at all.
+ #
+ # Define WERROR=0 to disable treating any warnings as errors.
+@@ -289,7 +294,8 @@ ifdef ASCIIDOC8
+   export ASCIIDOC8
+ endif
+ 
+-LIBS = -Wl,--whole-archive $(PERFLIBS) -Wl,--no-whole-archive -Wl,--start-group $(EXTLIBS) -Wl,--end-group
++EXTLIBS := $(call filter-out,$(EXCLUDE_EXTLIBS),$(EXTLIBS))
++LIBS = -Wl,--whole-archive $(PERFLIBS) $(EXTRA_PERFLIBS) -Wl,--no-whole-archive -Wl,--start-group $(EXTLIBS) -Wl,--end-group
+ 
+ export INSTALL SHELL_PATH
+ 


### PR DESCRIPTION
This PR includes fixups for building aarch64, fixup commits to be squashed on next rebase.
Also includes binutils patch from #2525, to be dropped on next rebase.