### PR TITLE
hauppauge: fix broken patch

### DIFF
--- a/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-302-AML-amlogic-video-dev.patch
+++ b/packages/linux-driver-addons/dvb/hauppauge/sources/backports/linux-302-AML-amlogic-video-dev.patch
@@ -9,11 +9,15 @@
  endif # MEDIA_SUPPORT
 --- a/drivers/media/Makefile
 +++ b/drivers/media/Makefile
-@@ -39,3 +39,4 @@ obj-y += rc/
- obj-y += common/ platform/ pci/ usb/ mmc/ firewire/ spi/
- obj-$(CONFIG_VIDEO_DEV) += radio/
+@@ -25,7 +25,7 @@
+ obj-y += rc/
  
+ obj-$(CONFIG_CEC_CORE) += cec/
+-
 +obj-y += amlogic/
+ #
+ # Finally, merge the drivers that require the core
+ #
 --- /dev/null
 +++ b/drivers/media/amlogic/Kconfig
 @@ -0,0 +1,8 @@


### PR DESCRIPTION
fixes broken patch after #2451
patch didn't apply at all
```
patch -s -f -N -p1 -i ../backports/linux-302-AML-amlogic-video-dev.patch
1 out of 1 hunk FAILED
```

I had forgotten to add this to https://github.com/LibreELEC/LibreELEC.tv/pull/2532