### PR TITLE
uboot_helper: fix dtb name for odroid-c2

### DIFF
--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -10,7 +10,7 @@ devices = {
   },
   'Amlogic_GX' : {
     'OdroidC2' : {
-      'odroid-c2' : { 'dtb' : 'meson-gxbb-odroid-c2.dtb', 'config' : 'odroid-c2_defconfig' },
+      'odroid-c2' : { 'dtb' : 'meson-gxbb-odroidc2.dtb', 'config' : 'odroid-c2_defconfig' },
     },
     'P212' : {
       'p212' : { 'dtb' : 'meson-gxl-s905x-p212.dtb', 'config' : 'p212_defconfig' },


### PR DESCRIPTION
The dtb name for Odroid-C2 was wrong in the uboot_helper script, this fixes the mkimage.