### PR TITLE
wetekdvb: fix an issue when the device variable always evaluates to WeTek_Play_2

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -33,7 +33,7 @@ PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
   device=${DEVICE:-$PROJECT}
-  [ $device="S905" ] && device=WeTek_Play_2
+  [ $device = "S905" ] && device=WeTek_Play_2
   for overlay_dir in driver/$device/*/; do
     overlay_dir=`basename $overlay_dir`
     mkdir -p $INSTALL/$(get_full_module_dir $overlay_dir)/$PKG_NAME


### PR DESCRIPTION
Fix an issue when the device variable always evaluates to WeTek_Play_2 causing drivers for WeTek Play 2 to be copied for WeTek Play 1.