### PR TITLE
mkimage: tweak uboot wording to match other messages

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -254,7 +254,7 @@ EOF
     elif [ -f $PROJECT_DIR/$PROJECT/bootloader/mkimage ]; then
       . $PROJECT_DIR/$PROJECT/bootloader/mkimage
     else
-      echo "No specific mkimage script found. u-boot will not be written"
+      echo "image: skipping u-boot. no mkimage script found"
     fi
 
     echo "image: copying files to part1..."


### PR DESCRIPTION
This tweaks the uboot message wording to align (literally) with the other messages that run before and after it when making the image. OCD at its finest :)