### PR TITLE
linux: add ath10k sdio patches

### DIFF
--- a/projects/Amlogic_GX/patches/linux/0050-ath10k-add-inlined-wrappers-for-htt-tx-ops.patch
+++ b/projects/Amlogic_GX/patches/linux/0050-ath10k-add-inlined-wrappers-for-htt-tx-ops.patch
@@ -1,0 +1,157 @@
+From acddcc50ddc41eaa44574de071d63400faeea9c0 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:27:59 +0100
+Subject: [PATCH] ath10k: add inlined wrappers for htt tx ops
+
+These wrappers makes the HTT ops align better with the HIF ops
+(where similar wrappers are used).
+
+It also makes it easier for a target to have unsupported ops
+(by letting the corresponding function pointer be NULL).
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt.c    |  4 +--
+ drivers/net/wireless/ath/ath10k/htt.h    | 51 ++++++++++++++++++++++++++++++++
+ drivers/net/wireless/ath/ath10k/htt_tx.c | 12 ++++----
+ drivers/net/wireless/ath/ath10k/mac.c    |  2 +-
+ 4 files changed, 60 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt.c b/drivers/net/wireless/ath/ath10k/htt.c
+index 625198dea18b..21a67f82f037 100644
+--- a/drivers/net/wireless/ath/ath10k/htt.c
++++ b/drivers/net/wireless/ath/ath10k/htt.c
+@@ -257,11 +257,11 @@ int ath10k_htt_setup(struct ath10k_htt *htt)
+ 		return status;
+ 	}
+ 
+-	status = htt->tx_ops->htt_send_frag_desc_bank_cfg(htt);
++	status = ath10k_htt_send_frag_desc_bank_cfg(htt);
+ 	if (status)
+ 		return status;
+ 
+-	status = htt->tx_ops->htt_send_rx_ring_cfg(htt);
++	status = ath10k_htt_send_rx_ring_cfg(htt);
+ 	if (status) {
+ 		ath10k_warn(ar, "failed to setup rx ring: %d\n",
+ 			    status);
+diff --git a/drivers/net/wireless/ath/ath10k/htt.h b/drivers/net/wireless/ath/ath10k/htt.h
+index 8cc2a8b278e4..c76f6daafe70 100644
+--- a/drivers/net/wireless/ath/ath10k/htt.h
++++ b/drivers/net/wireless/ath/ath10k/htt.h
+@@ -1848,6 +1848,57 @@ struct ath10k_htt_tx_ops {
+ 	void (*htt_free_txbuff)(struct ath10k_htt *htt);
+ };
+ 
++static inline int ath10k_htt_send_rx_ring_cfg(struct ath10k_htt *htt)
++{
++	if (!htt->tx_ops->htt_send_rx_ring_cfg)
++		return -EOPNOTSUPP;
++
++	return htt->tx_ops->htt_send_rx_ring_cfg(htt);
++}
++
++static inline int ath10k_htt_send_frag_desc_bank_cfg(struct ath10k_htt *htt)
++{
++	if (!htt->tx_ops->htt_send_frag_desc_bank_cfg)
++		return -EOPNOTSUPP;
++
++	return htt->tx_ops->htt_send_frag_desc_bank_cfg(htt);
++}
++
++static inline int ath10k_htt_alloc_frag_desc(struct ath10k_htt *htt)
++{
++	if (!htt->tx_ops->htt_alloc_frag_desc)
++		return -EOPNOTSUPP;
++
++	return htt->tx_ops->htt_alloc_frag_desc(htt);
++}
++
++static inline void ath10k_htt_free_frag_desc(struct ath10k_htt *htt)
++{
++	if (htt->tx_ops->htt_free_frag_desc)
++		htt->tx_ops->htt_free_frag_desc(htt);
++}
++
++static inline int ath10k_htt_tx(struct ath10k_htt *htt,
++				enum ath10k_hw_txrx_mode txmode,
++				struct sk_buff *msdu)
++{
++	return htt->tx_ops->htt_tx(htt, txmode, msdu);
++}
++
++static inline int ath10k_htt_alloc_txbuff(struct ath10k_htt *htt)
++{
++	if (!htt->tx_ops->htt_alloc_txbuff)
++		return -EOPNOTSUPP;
++
++	return htt->tx_ops->htt_alloc_txbuff(htt);
++}
++
++static inline void ath10k_htt_free_txbuff(struct ath10k_htt *htt)
++{
++	if (htt->tx_ops->htt_free_txbuff)
++		htt->tx_ops->htt_free_txbuff(htt);
++}
++
+ struct ath10k_htt_rx_ops {
+ 	size_t (*htt_get_rx_ring_size)(struct ath10k_htt *htt);
+ 	void (*htt_config_paddrs_ring)(struct ath10k_htt *htt, void *vaddr);
+diff --git a/drivers/net/wireless/ath/ath10k/htt_tx.c b/drivers/net/wireless/ath/ath10k/htt_tx.c
+index d334b7be1fea..a086958c39b6 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_tx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_tx.c
+@@ -443,13 +443,13 @@ static int ath10k_htt_tx_alloc_buf(struct ath10k_htt *htt)
+ 	struct ath10k *ar = htt->ar;
+ 	int ret;
+ 
+-	ret = htt->tx_ops->htt_alloc_txbuff(htt);
++	ret = ath10k_htt_alloc_txbuff(htt);
+ 	if (ret) {
+ 		ath10k_err(ar, "failed to alloc cont tx buffer: %d\n", ret);
+ 		return ret;
+ 	}
+ 
+-	ret = htt->tx_ops->htt_alloc_frag_desc(htt);
++	ret = ath10k_htt_alloc_frag_desc(htt);
+ 	if (ret) {
+ 		ath10k_err(ar, "failed to alloc cont frag desc: %d\n", ret);
+ 		goto free_txbuf;
+@@ -473,10 +473,10 @@ static int ath10k_htt_tx_alloc_buf(struct ath10k_htt *htt)
+ 	ath10k_htt_tx_free_txq(htt);
+ 
+ free_frag_desc:
+-	htt->tx_ops->htt_free_frag_desc(htt);
++	ath10k_htt_free_frag_desc(htt);
+ 
+ free_txbuf:
+-	htt->tx_ops->htt_free_txbuff(htt);
++	ath10k_htt_free_txbuff(htt);
+ 
+ 	return ret;
+ }
+@@ -530,9 +530,9 @@ void ath10k_htt_tx_destroy(struct ath10k_htt *htt)
+ 	if (!htt->tx_mem_allocated)
+ 		return;
+ 
+-	htt->tx_ops->htt_free_txbuff(htt);
++	ath10k_htt_free_txbuff(htt);
+ 	ath10k_htt_tx_free_txq(htt);
+-	htt->tx_ops->htt_free_frag_desc(htt);
++	ath10k_htt_free_frag_desc(htt);
+ 	ath10k_htt_tx_free_txdone_fifo(htt);
+ 	htt->tx_mem_allocated = false;
+ }
+diff --git a/drivers/net/wireless/ath/ath10k/mac.c b/drivers/net/wireless/ath/ath10k/mac.c
+index ebb3f1b046f3..dcf6574f217c 100644
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -3597,7 +3597,7 @@ static int ath10k_mac_tx_submit(struct ath10k *ar,
+ 
+ 	switch (txpath) {
+ 	case ATH10K_MAC_TX_HTT:
+-		ret = htt->tx_ops->htt_tx(htt, txmode, skb);
++		ret = ath10k_htt_tx(htt, txmode, skb);
+ 		break;
+ 	case ATH10K_MAC_TX_HTT_MGMT:
+ 		ret = ath10k_htt_mgmt_tx(htt, skb);

--- a/projects/Amlogic_GX/patches/linux/0051-ath10k-add-inlined-wrappers-for-htt-rx-ops.patch
+++ b/projects/Amlogic_GX/patches/linux/0051-ath10k-add-inlined-wrappers-for-htt-rx-ops.patch
@@ -1,0 +1,119 @@
+From 80042412c66776b141ee4b060247a0c30c202b76 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:27:59 +0100
+Subject: [PATCH] ath10k: add inlined wrappers for htt rx ops
+
+Added for the same reason as the TX wrappers.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt.h    | 37 ++++++++++++++++++++++++++++++++
+ drivers/net/wireless/ath/ath10k/htt_rx.c | 14 ++++++------
+ 2 files changed, 44 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt.h b/drivers/net/wireless/ath/ath10k/htt.h
+index c76f6daafe70..3fa1be7749b2 100644
+--- a/drivers/net/wireless/ath/ath10k/htt.h
++++ b/drivers/net/wireless/ath/ath10k/htt.h
+@@ -1908,6 +1908,43 @@ struct ath10k_htt_rx_ops {
+ 	void (*htt_reset_paddrs_ring)(struct ath10k_htt *htt, int idx);
+ };
+ 
++static inline size_t ath10k_htt_get_rx_ring_size(struct ath10k_htt *htt)
++{
++	if (!htt->rx_ops->htt_get_rx_ring_size)
++		return 0;
++
++	return htt->rx_ops->htt_get_rx_ring_size(htt);
++}
++
++static inline void ath10k_htt_config_paddrs_ring(struct ath10k_htt *htt,
++						 void *vaddr)
++{
++	if (htt->rx_ops->htt_config_paddrs_ring)
++		htt->rx_ops->htt_config_paddrs_ring(htt, vaddr);
++}
++
++static inline void ath10k_htt_set_paddrs_ring(struct ath10k_htt *htt,
++					      dma_addr_t paddr,
++					      int idx)
++{
++	if (htt->rx_ops->htt_set_paddrs_ring)
++		htt->rx_ops->htt_set_paddrs_ring(htt, paddr, idx);
++}
++
++static inline void *ath10k_htt_get_vaddr_ring(struct ath10k_htt *htt)
++{
++	if (!htt->rx_ops->htt_get_vaddr_ring)
++		return NULL;
++
++	return htt->rx_ops->htt_get_vaddr_ring(htt);
++}
++
++static inline void ath10k_htt_reset_paddrs_ring(struct ath10k_htt *htt, int idx)
++{
++	if (htt->rx_ops->htt_reset_paddrs_ring)
++		htt->rx_ops->htt_reset_paddrs_ring(htt, idx);
++}
++
+ #define RX_HTT_HDR_STATUS_LEN 64
+ 
+ /* This structure layout is programmed via rx ring setup
+diff --git a/drivers/net/wireless/ath/ath10k/htt_rx.c b/drivers/net/wireless/ath/ath10k/htt_rx.c
+index 6d96f9560950..7b3d6bf015c7 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_rx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_rx.c
+@@ -180,7 +180,7 @@ static int __ath10k_htt_rx_ring_fill_n(struct ath10k_htt *htt, int num)
+ 		rxcb = ATH10K_SKB_RXCB(skb);
+ 		rxcb->paddr = paddr;
+ 		htt->rx_ring.netbufs_ring[idx] = skb;
+-		htt->rx_ops->htt_set_paddrs_ring(htt, paddr, idx);
++		ath10k_htt_set_paddrs_ring(htt, paddr, idx);
+ 		htt->rx_ring.fill_cnt++;
+ 
+ 		if (htt->rx_ring.in_ord_rx) {
+@@ -285,8 +285,8 @@ void ath10k_htt_rx_free(struct ath10k_htt *htt)
+ 	ath10k_htt_rx_ring_free(htt);
+ 
+ 	dma_free_coherent(htt->ar->dev,
+-			  htt->rx_ops->htt_get_rx_ring_size(htt),
+-			  htt->rx_ops->htt_get_vaddr_ring(htt),
++			  ath10k_htt_get_rx_ring_size(htt),
++			  ath10k_htt_get_vaddr_ring(htt),
+ 			  htt->rx_ring.base_paddr);
+ 
+ 	dma_free_coherent(htt->ar->dev,
+@@ -313,7 +313,7 @@ static inline struct sk_buff *ath10k_htt_rx_netbuf_pop(struct ath10k_htt *htt)
+ 	idx = htt->rx_ring.sw_rd_idx.msdu_payld;
+ 	msdu = htt->rx_ring.netbufs_ring[idx];
+ 	htt->rx_ring.netbufs_ring[idx] = NULL;
+-	htt->rx_ops->htt_reset_paddrs_ring(htt, idx);
++	ath10k_htt_reset_paddrs_ring(htt, idx);
+ 
+ 	idx++;
+ 	idx &= htt->rx_ring.size_mask;
+@@ -585,13 +585,13 @@ int ath10k_htt_rx_alloc(struct ath10k_htt *htt)
+ 	if (!htt->rx_ring.netbufs_ring)
+ 		goto err_netbuf;
+ 
+-	size = htt->rx_ops->htt_get_rx_ring_size(htt);
++	size = ath10k_htt_get_rx_ring_size(htt);
+ 
+ 	vaddr_ring = dma_alloc_coherent(htt->ar->dev, size, &paddr, GFP_KERNEL);
+ 	if (!vaddr_ring)
+ 		goto err_dma_ring;
+ 
+-	htt->rx_ops->htt_config_paddrs_ring(htt, vaddr_ring);
++	ath10k_htt_config_paddrs_ring(htt, vaddr_ring);
+ 	htt->rx_ring.base_paddr = paddr;
+ 
+ 	vaddr = dma_alloc_coherent(htt->ar->dev,
+@@ -625,7 +625,7 @@ int ath10k_htt_rx_alloc(struct ath10k_htt *htt)
+ 
+ err_dma_idx:
+ 	dma_free_coherent(htt->ar->dev,
+-			  htt->rx_ops->htt_get_rx_ring_size(htt),
++			  ath10k_htt_get_rx_ring_size(htt),
+ 			  vaddr_ring,
+ 			  htt->rx_ring.base_paddr);
+ err_dma_ring:

--- a/projects/Amlogic_GX/patches/linux/0052-ath10k-add-struct-ath10k_bus_params.patch
+++ b/projects/Amlogic_GX/patches/linux/0052-ath10k-add-struct-ath10k_bus_params.patch
@@ -1,0 +1,178 @@
+From 12c98541e981d1513b5a5e85a3e1b42c6b6e6564 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:00 +0100
+Subject: [PATCH] ath10k: add struct ath10k_bus_params
+
+This struct is used as argument to ath10k_core_register in order to
+make it easier to add more bus parameters in the future.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/ahb.c  |  8 ++++----
+ drivers/net/wireless/ath/ath10k/core.c |  5 +++--
+ drivers/net/wireless/ath/ath10k/core.h |  7 ++++++-
+ drivers/net/wireless/ath/ath10k/pci.c  | 12 ++++++------
+ drivers/net/wireless/ath/ath10k/sdio.c |  7 ++++---
+ drivers/net/wireless/ath/ath10k/usb.c  |  6 +++---
+ 6 files changed, 26 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/ahb.c b/drivers/net/wireless/ath/ath10k/ahb.c
+index 35d10490f6c3..6f902f355fca 100644
+--- a/drivers/net/wireless/ath/ath10k/ahb.c
++++ b/drivers/net/wireless/ath/ath10k/ahb.c
+@@ -758,7 +758,7 @@ static int ath10k_ahb_probe(struct platform_device *pdev)
+ 	enum ath10k_hw_rev hw_rev;
+ 	size_t size;
+ 	int ret;
+-	u32 chip_id;
++	struct ath10k_bus_params bus_params;
+ 
+ 	of_id = of_match_device(ath10k_ahb_of_match, &pdev->dev);
+ 	if (!of_id) {
+@@ -814,14 +814,14 @@ static int ath10k_ahb_probe(struct platform_device *pdev)
+ 
+ 	ath10k_pci_ce_deinit(ar);
+ 
+-	chip_id = ath10k_ahb_soc_read32(ar, SOC_CHIP_ID_ADDRESS);
+-	if (chip_id == 0xffffffff) {
++	bus_params.chip_id = ath10k_ahb_soc_read32(ar, SOC_CHIP_ID_ADDRESS);
++	if (bus_params.chip_id == 0xffffffff) {
+ 		ath10k_err(ar, "failed to get chip id\n");
+ 		ret = -ENODEV;
+ 		goto err_halt_device;
+ 	}
+ 
+-	ret = ath10k_core_register(ar, chip_id);
++	ret = ath10k_core_register(ar, &bus_params);
+ 	if (ret) {
+ 		ath10k_err(ar, "failed to register driver core: %d\n", ret);
+ 		goto err_halt_device;
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index f3ec13b80b20..bf25246c6a2a 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -2638,9 +2638,10 @@ static void ath10k_core_register_work(struct work_struct *work)
+ 	return;
+ }
+ 
+-int ath10k_core_register(struct ath10k *ar, u32 chip_id)
++int ath10k_core_register(struct ath10k *ar,
++			 const struct ath10k_bus_params *bus_params)
+ {
+-	ar->chip_id = chip_id;
++	ar->chip_id = bus_params->chip_id;
+ 	queue_work(ar->workqueue, &ar->register_work);
+ 
+ 	return 0;
+diff --git a/drivers/net/wireless/ath/ath10k/core.h b/drivers/net/wireless/ath/ath10k/core.h
+index fe6b30356d3b..f2e851d91170 100644
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -769,6 +769,10 @@ struct ath10k_per_peer_tx_stats {
+ 	u32	reserved2;
+ };
+ 
++struct ath10k_bus_params {
++	u32 chip_id;
++};
++
+ struct ath10k {
+ 	struct ath_common ath_common;
+ 	struct ieee80211_hw *hw;
+@@ -1049,7 +1053,8 @@ int ath10k_core_start(struct ath10k *ar, enum ath10k_firmware_mode mode,
+ 		      const struct ath10k_fw_components *fw_components);
+ int ath10k_wait_for_suspend(struct ath10k *ar, u32 suspend_opt);
+ void ath10k_core_stop(struct ath10k *ar);
+-int ath10k_core_register(struct ath10k *ar, u32 chip_id);
++int ath10k_core_register(struct ath10k *ar,
++			 const struct ath10k_bus_params *bus_params);
+ void ath10k_core_unregister(struct ath10k *ar);
+ 
+ #endif /* _CORE_H_ */
+diff --git a/drivers/net/wireless/ath/ath10k/pci.c b/drivers/net/wireless/ath/ath10k/pci.c
+index 1b266cd0c2ec..c72de9444305 100644
+--- a/drivers/net/wireless/ath/ath10k/pci.c
++++ b/drivers/net/wireless/ath/ath10k/pci.c
+@@ -3422,7 +3422,7 @@ static int ath10k_pci_probe(struct pci_dev *pdev,
+ 	struct ath10k *ar;
+ 	struct ath10k_pci *ar_pci;
+ 	enum ath10k_hw_rev hw_rev;
+-	u32 chip_id;
++	struct ath10k_bus_params bus_params;
+ 	bool pci_ps;
+ 	int (*pci_soft_reset)(struct ath10k *ar);
+ 	int (*pci_hard_reset)(struct ath10k *ar);
+@@ -3558,19 +3558,19 @@ static int ath10k_pci_probe(struct pci_dev *pdev,
+ 		goto err_free_irq;
+ 	}
+ 
+-	chip_id = ath10k_pci_soc_read32(ar, SOC_CHIP_ID_ADDRESS);
+-	if (chip_id == 0xffffffff) {
++	bus_params.chip_id = ath10k_pci_soc_read32(ar, SOC_CHIP_ID_ADDRESS);
++	if (bus_params.chip_id == 0xffffffff) {
+ 		ath10k_err(ar, "failed to get chip id\n");
+ 		goto err_free_irq;
+ 	}
+ 
+-	if (!ath10k_pci_chip_is_supported(pdev->device, chip_id)) {
++	if (!ath10k_pci_chip_is_supported(pdev->device, bus_params.chip_id)) {
+ 		ath10k_err(ar, "device %04x with chip_id %08x isn't supported\n",
+-			   pdev->device, chip_id);
++			   pdev->device, bus_params.chip_id);
+ 		goto err_free_irq;
+ 	}
+ 
+-	ret = ath10k_core_register(ar, chip_id);
++	ret = ath10k_core_register(ar, &bus_params);
+ 	if (ret) {
+ 		ath10k_err(ar, "failed to register driver core: %d\n", ret);
+ 		goto err_free_irq;
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.c b/drivers/net/wireless/ath/ath10k/sdio.c
+index 03a69e5b1116..03dc748317f8 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.c
++++ b/drivers/net/wireless/ath/ath10k/sdio.c
+@@ -1931,7 +1931,8 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 	struct ath10k_sdio *ar_sdio;
+ 	struct ath10k *ar;
+ 	enum ath10k_hw_rev hw_rev;
+-	u32 chip_id, dev_id_base;
++	u32 dev_id_base;
++	struct ath10k_bus_params bus_params;
+ 	int ret, i;
+ 
+ 	/* Assumption: All SDIO based chipsets (so far) are QCA6174 based.
+@@ -2026,8 +2027,8 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 	}
+ 
+ 	/* TODO: don't know yet how to get chip_id with SDIO */
+-	chip_id = 0;
+-	ret = ath10k_core_register(ar, chip_id);
++	bus_params.chip_id = 0;
++	ret = ath10k_core_register(ar, &bus_params);
+ 	if (ret) {
+ 		ath10k_err(ar, "failed to register driver core: %d\n", ret);
+ 		goto err_free_wq;
+diff --git a/drivers/net/wireless/ath/ath10k/usb.c b/drivers/net/wireless/ath/ath10k/usb.c
+index d4803ff5a78a..275e00bafcb1 100644
+--- a/drivers/net/wireless/ath/ath10k/usb.c
++++ b/drivers/net/wireless/ath/ath10k/usb.c
+@@ -983,7 +983,7 @@ static int ath10k_usb_probe(struct usb_interface *interface,
+ 	struct usb_device *dev = interface_to_usbdev(interface);
+ 	int ret, vendor_id, product_id;
+ 	enum ath10k_hw_rev hw_rev;
+-	u32 chip_id;
++	struct ath10k_bus_params bus_params;
+ 
+ 	/* Assumption: All USB based chipsets (so far) are QCA9377 based.
+ 	 * If there will be newer chipsets that does not use the hw reg
+@@ -1017,8 +1017,8 @@ static int ath10k_usb_probe(struct usb_interface *interface,
+ 	ar->id.device = product_id;
+ 
+ 	/* TODO: don't know yet how to get chip_id with USB */
+-	chip_id = 0;
+-	ret = ath10k_core_register(ar, chip_id);
++	bus_params.chip_id = 0;
++	ret = ath10k_core_register(ar, &bus_params);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to register driver core: %d\n", ret);
+ 		goto err;

--- a/projects/Amlogic_GX/patches/linux/0053-ath10k-high-latency-detection.patch
+++ b/projects/Amlogic_GX/patches/linux/0053-ath10k-high-latency-detection.patch
@@ -1,0 +1,100 @@
+From 5668231ae1984220c58a3bc53197f4058fd75dc3 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:01 +0100
+Subject: [PATCH] ath10k: high_latency detection
+
+Add is_high_latency parameter to struct ath10k_bus_params.
+
+The setup of high latency chips is sometimes different than
+for chips using low latency interfaces.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/ahb.c  | 1 +
+ drivers/net/wireless/ath/ath10k/core.c | 1 +
+ drivers/net/wireless/ath/ath10k/core.h | 2 ++
+ drivers/net/wireless/ath/ath10k/pci.c  | 1 +
+ drivers/net/wireless/ath/ath10k/sdio.c | 1 +
+ drivers/net/wireless/ath/ath10k/usb.c  | 1 +
+ 6 files changed, 7 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/ahb.c b/drivers/net/wireless/ath/ath10k/ahb.c
+index 6f902f355fca..b342f3393e2c 100644
+--- a/drivers/net/wireless/ath/ath10k/ahb.c
++++ b/drivers/net/wireless/ath/ath10k/ahb.c
+@@ -814,6 +814,7 @@ static int ath10k_ahb_probe(struct platform_device *pdev)
+ 
+ 	ath10k_pci_ce_deinit(ar);
+ 
++	bus_params.is_high_latency = false;
+ 	bus_params.chip_id = ath10k_ahb_soc_read32(ar, SOC_CHIP_ID_ADDRESS);
+ 	if (bus_params.chip_id == 0xffffffff) {
+ 		ath10k_err(ar, "failed to get chip id\n");
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index bf25246c6a2a..4877ef31d477 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -2642,6 +2642,7 @@ int ath10k_core_register(struct ath10k *ar,
+ 			 const struct ath10k_bus_params *bus_params)
+ {
+ 	ar->chip_id = bus_params->chip_id;
++	ar->is_high_latency = bus_params->is_high_latency;
+ 	queue_work(ar->workqueue, &ar->register_work);
+ 
+ 	return 0;
+diff --git a/drivers/net/wireless/ath/ath10k/core.h b/drivers/net/wireless/ath/ath10k/core.h
+index f2e851d91170..17827ce3752d 100644
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -771,6 +771,7 @@ struct ath10k_per_peer_tx_stats {
+ 
+ struct ath10k_bus_params {
+ 	u32 chip_id;
++	bool is_high_latency;
+ };
+ 
+ struct ath10k {
+@@ -783,6 +784,7 @@ struct ath10k {
+ 	enum ath10k_hw_rev hw_rev;
+ 	u16 dev_id;
+ 	u32 chip_id;
++	bool is_high_latency;
+ 	u32 target_version;
+ 	u8 fw_version_major;
+ 	u32 fw_version_minor;
+diff --git a/drivers/net/wireless/ath/ath10k/pci.c b/drivers/net/wireless/ath/ath10k/pci.c
+index c72de9444305..9525e5d4df06 100644
+--- a/drivers/net/wireless/ath/ath10k/pci.c
++++ b/drivers/net/wireless/ath/ath10k/pci.c
+@@ -3558,6 +3558,7 @@ static int ath10k_pci_probe(struct pci_dev *pdev,
+ 		goto err_free_irq;
+ 	}
+ 
++	bus_params.is_high_latency = false;
+ 	bus_params.chip_id = ath10k_pci_soc_read32(ar, SOC_CHIP_ID_ADDRESS);
+ 	if (bus_params.chip_id == 0xffffffff) {
+ 		ath10k_err(ar, "failed to get chip id\n");
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.c b/drivers/net/wireless/ath/ath10k/sdio.c
+index 03dc748317f8..f0f1b2b8c7a7 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.c
++++ b/drivers/net/wireless/ath/ath10k/sdio.c
+@@ -2026,6 +2026,7 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 		goto err_free_wq;
+ 	}
+ 
++	bus_params.is_high_latency = true;
+ 	/* TODO: don't know yet how to get chip_id with SDIO */
+ 	bus_params.chip_id = 0;
+ 	ret = ath10k_core_register(ar, &bus_params);
+diff --git a/drivers/net/wireless/ath/ath10k/usb.c b/drivers/net/wireless/ath/ath10k/usb.c
+index 275e00bafcb1..3b330e9607aa 100644
+--- a/drivers/net/wireless/ath/ath10k/usb.c
++++ b/drivers/net/wireless/ath/ath10k/usb.c
+@@ -1016,6 +1016,7 @@ static int ath10k_usb_probe(struct usb_interface *interface,
+ 	ar->id.vendor = vendor_id;
+ 	ar->id.device = product_id;
+ 
++	bus_params.is_high_latency = true;
+ 	/* TODO: don't know yet how to get chip_id with USB */
+ 	bus_params.chip_id = 0;
+ 	ret = ath10k_core_register(ar, &bus_params);

--- a/projects/Amlogic_GX/patches/linux/0054-ath10k-add-bus-type-check-in-ath10k_init_hw_params.patch
+++ b/projects/Amlogic_GX/patches/linux/0054-ath10k-add-bus-type-check-in-ath10k_init_hw_params.patch
@@ -1,0 +1,183 @@
+From c2fd2857c3c34ba8923696dfc6b645bc48eef689 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:01 +0100
+Subject: [PATCH] ath10k: add bus type check in ath10k_init_hw_params
+
+The bus type is used together with the other hw parameters
+to find a matching entry in ath10k_hw_params_list for the device.
+
+This is necessary since HL devices can have the same dev_id and
+target_version as a corresponding LL device (same chipset) and
+yet use a totally different configuration.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c | 16 +++++++++++++++-
+ drivers/net/wireless/ath/ath10k/core.h |  8 --------
+ drivers/net/wireless/ath/ath10k/hw.h   |  9 +++++++++
+ 3 files changed, 24 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 4877ef31d477..2c4e1b8cd448 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -64,6 +64,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA988X_HW_2_0_VERSION,
+ 		.dev_id = QCA988X_2_0_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca988x hw2.0",
+ 		.patch_load_addr = QCA988X_HW_2_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+@@ -122,6 +123,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA9887_HW_1_0_VERSION,
+ 		.dev_id = QCA9887_1_0_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca9887 hw1.0",
+ 		.patch_load_addr = QCA9887_HW_1_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+@@ -151,6 +153,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA6174_HW_2_1_VERSION,
+ 		.dev_id = QCA6164_2_1_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca6164 hw2.1",
+ 		.patch_load_addr = QCA6174_HW_2_1_PATCH_LOAD_ADDR,
+ 		.uart_pin = 6,
+@@ -179,6 +182,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA6174_HW_2_1_VERSION,
+ 		.dev_id = QCA6174_2_1_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca6174 hw2.1",
+ 		.patch_load_addr = QCA6174_HW_2_1_PATCH_LOAD_ADDR,
+ 		.uart_pin = 6,
+@@ -207,6 +211,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA6174_HW_3_0_VERSION,
+ 		.dev_id = QCA6174_2_1_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca6174 hw3.0",
+ 		.patch_load_addr = QCA6174_HW_3_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 6,
+@@ -235,6 +240,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA6174_HW_3_2_VERSION,
+ 		.dev_id = QCA6174_2_1_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca6174 hw3.2",
+ 		.patch_load_addr = QCA6174_HW_3_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 6,
+@@ -266,6 +272,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA99X0_HW_2_0_DEV_VERSION,
+ 		.dev_id = QCA99X0_2_0_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca99x0 hw2.0",
+ 		.patch_load_addr = QCA99X0_HW_2_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+@@ -300,6 +307,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA9984_HW_1_0_DEV_VERSION,
+ 		.dev_id = QCA9984_1_0_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca9984/qca9994 hw1.0",
+ 		.patch_load_addr = QCA9984_HW_1_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+@@ -339,6 +347,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA9888_HW_2_0_DEV_VERSION,
+ 		.dev_id = QCA9888_2_0_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca9888 hw2.0",
+ 		.patch_load_addr = QCA9888_HW_2_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+@@ -377,6 +386,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA9377_HW_1_0_DEV_VERSION,
+ 		.dev_id = QCA9377_1_0_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca9377 hw1.0",
+ 		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 6,
+@@ -405,6 +415,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA9377_HW_1_1_DEV_VERSION,
+ 		.dev_id = QCA9377_1_0_DEVICE_ID,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "qca9377 hw1.1",
+ 		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 6,
+@@ -435,6 +446,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA4019_HW_1_0_DEV_VERSION,
+ 		.dev_id = 0,
++		.bus = ATH10K_BUS_AHB,
+ 		.name = "qca4019 hw1.0",
+ 		.patch_load_addr = QCA4019_HW_1_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+@@ -470,6 +482,7 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = WCN3990_HW_1_0_DEV_VERSION,
+ 		.dev_id = 0,
++		.bus = ATH10K_BUS_PCI,
+ 		.name = "wcn3990 hw1.0",
+ 		.continuous_frag_desc = true,
+ 		.tx_chain_mask = 0x7,
+@@ -1819,7 +1832,8 @@ static int ath10k_init_hw_params(struct ath10k *ar)
+ 	for (i = 0; i < ARRAY_SIZE(ath10k_hw_params_list); i++) {
+ 		hw_params = &ath10k_hw_params_list[i];
+ 
+-		if (hw_params->id == ar->target_version &&
++		if (hw_params->bus == ar->hif.bus &&
++		    hw_params->id == ar->target_version &&
+ 		    hw_params->dev_id == ar->dev_id)
+ 			break;
+ 	}
+diff --git a/drivers/net/wireless/ath/ath10k/core.h b/drivers/net/wireless/ath/ath10k/core.h
+index 17827ce3752d..32cfa14d3053 100644
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -87,14 +87,6 @@
+ 
+ struct ath10k;
+ 
+-enum ath10k_bus {
+-	ATH10K_BUS_PCI,
+-	ATH10K_BUS_AHB,
+-	ATH10K_BUS_SDIO,
+-	ATH10K_BUS_USB,
+-	ATH10K_BUS_SNOC,
+-};
+-
+ static inline const char *ath10k_bus_str(enum ath10k_bus bus)
+ {
+ 	switch (bus) {
+diff --git a/drivers/net/wireless/ath/ath10k/hw.h b/drivers/net/wireless/ath/ath10k/hw.h
+index 413b1b4321f7..f37e2d9ba2f8 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -20,6 +20,14 @@
+ 
+ #include "targaddrs.h"
+ 
++enum ath10k_bus {
++	ATH10K_BUS_PCI,
++	ATH10K_BUS_AHB,
++	ATH10K_BUS_SDIO,
++	ATH10K_BUS_USB,
++	ATH10K_BUS_SNOC,
++};
++
+ #define ATH10K_FW_DIR			"ath10k"
+ 
+ #define QCA988X_2_0_DEVICE_ID_UBNT   (0x11ac)
+@@ -492,6 +500,7 @@ struct ath10k_hw_clk_params {
+ struct ath10k_hw_params {
+ 	u32 id;
+ 	u16 dev_id;
++	enum ath10k_bus bus;
+ 	const char *name;
+ 	u32 patch_load_addr;
+ 	int uart_pin;

--- a/projects/Amlogic_GX/patches/linux/0055-ath10k-per-target-config-of-max_num_peers.patch
+++ b/projects/Amlogic_GX/patches/linux/0055-ath10k-per-target-config-of-max_num_peers.patch
@@ -1,0 +1,119 @@
+From 78510113a50686bdd073a89463da5491ba05b7b0 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:02 +0100
+Subject: [PATCH] ath10k: per target config of max_num_peers
+
+This patch makes sure the value of max_num_peers matches
+num_peers in hw_params (if set to a non zero value).
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c    | 17 ++++++++++++-----
+ drivers/net/wireless/ath/ath10k/hw.h      |  3 +++
+ drivers/net/wireless/ath/ath10k/wmi-tlv.c |  3 +--
+ 3 files changed, 16 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 2c4e1b8cd448..c9096e43954c 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -1934,6 +1934,7 @@ static void ath10k_core_set_coverage_class_work(struct work_struct *work)
+ static int ath10k_core_init_firmware_features(struct ath10k *ar)
+ {
+ 	struct ath10k_fw_file *fw_file = &ar->normal_mode_fw.fw_file;
++	int max_num_peers;
+ 
+ 	if (test_bit(ATH10K_FW_FEATURE_WMI_10_2, fw_file->fw_features) &&
+ 	    !test_bit(ATH10K_FW_FEATURE_WMI_10X, fw_file->fw_features)) {
+@@ -2013,7 +2014,7 @@ static int ath10k_core_init_firmware_features(struct ath10k *ar)
+ 
+ 	switch (fw_file->wmi_op_version) {
+ 	case ATH10K_FW_WMI_OP_VERSION_MAIN:
+-		ar->max_num_peers = TARGET_NUM_PEERS;
++		max_num_peers = TARGET_NUM_PEERS;
+ 		ar->max_num_stations = TARGET_NUM_STATIONS;
+ 		ar->max_num_vdevs = TARGET_NUM_VDEVS;
+ 		ar->htt.max_num_pending_tx = TARGET_NUM_MSDU_DESC;
+@@ -2025,10 +2026,10 @@ static int ath10k_core_init_firmware_features(struct ath10k *ar)
+ 	case ATH10K_FW_WMI_OP_VERSION_10_2:
+ 	case ATH10K_FW_WMI_OP_VERSION_10_2_4:
+ 		if (ath10k_peer_stats_enabled(ar)) {
+-			ar->max_num_peers = TARGET_10X_TX_STATS_NUM_PEERS;
++			max_num_peers = TARGET_10X_TX_STATS_NUM_PEERS;
+ 			ar->max_num_stations = TARGET_10X_TX_STATS_NUM_STATIONS;
+ 		} else {
+-			ar->max_num_peers = TARGET_10X_NUM_PEERS;
++			max_num_peers = TARGET_10X_NUM_PEERS;
+ 			ar->max_num_stations = TARGET_10X_NUM_STATIONS;
+ 		}
+ 		ar->max_num_vdevs = TARGET_10X_NUM_VDEVS;
+@@ -2037,7 +2038,7 @@ static int ath10k_core_init_firmware_features(struct ath10k *ar)
+ 		ar->max_spatial_stream = WMI_MAX_SPATIAL_STREAM;
+ 		break;
+ 	case ATH10K_FW_WMI_OP_VERSION_TLV:
+-		ar->max_num_peers = TARGET_TLV_NUM_PEERS;
++		max_num_peers = TARGET_TLV_NUM_PEERS;
+ 		ar->max_num_stations = TARGET_TLV_NUM_STATIONS;
+ 		ar->max_num_vdevs = TARGET_TLV_NUM_VDEVS;
+ 		ar->max_num_tdls_vdevs = TARGET_TLV_NUM_TDLS_VDEVS;
+@@ -2048,7 +2049,7 @@ static int ath10k_core_init_firmware_features(struct ath10k *ar)
+ 		ar->max_spatial_stream = WMI_MAX_SPATIAL_STREAM;
+ 		break;
+ 	case ATH10K_FW_WMI_OP_VERSION_10_4:
+-		ar->max_num_peers = TARGET_10_4_NUM_PEERS;
++		max_num_peers = TARGET_10_4_NUM_PEERS;
+ 		ar->max_num_stations = TARGET_10_4_NUM_STATIONS;
+ 		ar->num_active_peers = TARGET_10_4_ACTIVE_PEERS;
+ 		ar->max_num_vdevs = TARGET_10_4_NUM_VDEVS;
+@@ -2066,10 +2067,16 @@ static int ath10k_core_init_firmware_features(struct ath10k *ar)
+ 		break;
+ 	case ATH10K_FW_WMI_OP_VERSION_UNSET:
+ 	case ATH10K_FW_WMI_OP_VERSION_MAX:
++	default:
+ 		WARN_ON(1);
+ 		return -EINVAL;
+ 	}
+ 
++	if (ar->hw_params.num_peers)
++		ar->max_num_peers = ar->hw_params.num_peers;
++	else
++		ar->max_num_peers = max_num_peers;
++
+ 	/* Backwards compatibility for firmwares without
+ 	 * ATH10K_FW_IE_HTT_OP_VERSION.
+ 	 */
+diff --git a/drivers/net/wireless/ath/ath10k/hw.h b/drivers/net/wireless/ath/ath10k/hw.h
+index f37e2d9ba2f8..cae8ec40537d 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -693,6 +693,9 @@ ath10k_rx_desc_get_l3_pad_bytes(struct ath10k_hw_params *hw,
+ #define TARGET_HL_10_TLV_AST_SKID_LIMIT		6
+ #define TARGET_HL_10_TLV_NUM_WDS_ENTRIES	2
+ 
++/* Target specific defines for QCA9377 high latency firmware */
++#define TARGET_QCA9377_HL_NUM_PEERS		15
++
+ /* Diagnostic Window */
+ #define CE_DIAG_PIPE	7
+ 
+diff --git a/drivers/net/wireless/ath/ath10k/wmi-tlv.c b/drivers/net/wireless/ath/ath10k/wmi-tlv.c
+index ae77a007ae07..6b58bcbb36c1 100644
+--- a/drivers/net/wireless/ath/ath10k/wmi-tlv.c
++++ b/drivers/net/wireless/ath/ath10k/wmi-tlv.c
+@@ -1439,7 +1439,6 @@ static struct sk_buff *ath10k_wmi_tlv_op_gen_init(struct ath10k *ar)
+ 	cmd->num_host_mem_chunks = __cpu_to_le32(ar->wmi.num_mem_chunks);
+ 
+ 	cfg->num_vdevs = __cpu_to_le32(TARGET_TLV_NUM_VDEVS);
+-
+ 	cfg->num_peers = __cpu_to_le32(ar->hw_params.num_peers);
+ 	cfg->ast_skid_limit = __cpu_to_le32(ar->hw_params.ast_skid_limit);
+ 	cfg->num_wds_entries = __cpu_to_le32(ar->hw_params.num_wds_entries);
+@@ -1453,7 +1452,7 @@ static struct sk_buff *ath10k_wmi_tlv_op_gen_init(struct ath10k *ar)
+ 	}
+ 
+ 	cfg->num_peer_keys = __cpu_to_le32(2);
+-	cfg->num_tids = __cpu_to_le32(TARGET_TLV_NUM_TIDS);
++	cfg->num_tids = __cpu_to_le32(ar->hw_params.num_peers * 2);
+ 	cfg->tx_chain_mask = __cpu_to_le32(0x7);
+ 	cfg->rx_chain_mask = __cpu_to_le32(0x7);
+ 	cfg->rx_timeout_pri[0] = __cpu_to_le32(0x64);

--- a/projects/Amlogic_GX/patches/linux/0056-ath10k-DMA-related-fixes-for-high-latency-devices.patch
+++ b/projects/Amlogic_GX/patches/linux/0056-ath10k-DMA-related-fixes-for-high-latency-devices.patch
@@ -1,0 +1,88 @@
+From ba027450e02a2ebee4b02ed710410a4647a2a63a Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:03 +0100
+Subject: [PATCH] ath10k: DMA related fixes for high latency devices
+
+Several DMA related functions (such as the dma_map_xxx functions)
+are not used with high latency devices and don't need to be invoked
+in this case.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htc.c    | 19 ++++++++++++-------
+ drivers/net/wireless/ath/ath10k/htt_tx.c |  3 ++-
+ drivers/net/wireless/ath/ath10k/txrx.c   |  3 ++-
+ 3 files changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htc.c b/drivers/net/wireless/ath/ath10k/htc.c
+index 492dc5b4bbf2..dd69345f911e 100644
+--- a/drivers/net/wireless/ath/ath10k/htc.c
++++ b/drivers/net/wireless/ath/ath10k/htc.c
+@@ -53,7 +53,8 @@ static inline void ath10k_htc_restore_tx_skb(struct ath10k_htc *htc,
+ {
+ 	struct ath10k_skb_cb *skb_cb = ATH10K_SKB_CB(skb);
+ 
+-	dma_unmap_single(htc->ar->dev, skb_cb->paddr, skb->len, DMA_TO_DEVICE);
++	if (!htc->ar->is_high_latency)
++		dma_unmap_single(htc->ar->dev, skb_cb->paddr, skb->len, DMA_TO_DEVICE);
+ 	skb_pull(skb, sizeof(struct ath10k_htc_hdr));
+ }
+ 
+@@ -137,11 +138,14 @@ int ath10k_htc_send(struct ath10k_htc *htc,
+ 	ath10k_htc_prepare_tx_skb(ep, skb);
+ 
+ 	skb_cb->eid = eid;
+-	skb_cb->paddr = dma_map_single(dev, skb->data, skb->len, DMA_TO_DEVICE);
+-	ret = dma_mapping_error(dev, skb_cb->paddr);
+-	if (ret) {
+-		ret = -EIO;
+-		goto err_credits;
++	if (!ar->is_high_latency) {
++		skb_cb->paddr = dma_map_single(dev, skb->data, skb->len,
++					       DMA_TO_DEVICE);
++		ret = dma_mapping_error(dev, skb_cb->paddr);
++		if (ret) {
++			ret = -EIO;
++			goto err_credits;
++		}
+ 	}
+ 
+ 	sg_item.transfer_id = ep->eid;
+@@ -157,7 +161,8 @@ int ath10k_htc_send(struct ath10k_htc *htc,
+ 	return 0;
+ 
+ err_unmap:
+-	dma_unmap_single(dev, skb_cb->paddr, skb->len, DMA_TO_DEVICE);
++	if (!ar->is_high_latency)
++		dma_unmap_single(dev, skb_cb->paddr, skb->len, DMA_TO_DEVICE);
+ err_credits:
+ 	if (ep->tx_credit_flow_enabled) {
+ 		spin_lock_bh(&htc->tx_lock);
+diff --git a/drivers/net/wireless/ath/ath10k/htt_tx.c b/drivers/net/wireless/ath/ath10k/htt_tx.c
+index a086958c39b6..4d0bfb47d162 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_tx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_tx.c
+@@ -1125,7 +1125,8 @@ int ath10k_htt_mgmt_tx(struct ath10k_htt *htt, struct sk_buff *msdu)
+ 	return 0;
+ 
+ err_unmap_msdu:
+-	dma_unmap_single(dev, skb_cb->paddr, msdu->len, DMA_TO_DEVICE);
++	if (!ar->is_high_latency)
++		dma_unmap_single(dev, skb_cb->paddr, msdu->len, DMA_TO_DEVICE);
+ err_free_txdesc:
+ 	dev_kfree_skb_any(txdesc);
+ err_free_msdu_id:
+diff --git a/drivers/net/wireless/ath/ath10k/txrx.c b/drivers/net/wireless/ath/ath10k/txrx.c
+index 5b3b021526ab..febc3eb93fbd 100644
+--- a/drivers/net/wireless/ath/ath10k/txrx.c
++++ b/drivers/net/wireless/ath/ath10k/txrx.c
+@@ -94,7 +94,8 @@ int ath10k_txrx_tx_unref(struct ath10k_htt *htt,
+ 		wake_up(&htt->empty_tx_wq);
+ 	spin_unlock_bh(&htt->tx_lock);
+ 
+-	dma_unmap_single(dev, skb_cb->paddr, msdu->len, DMA_TO_DEVICE);
++	if (!ar->is_high_latency)
++		dma_unmap_single(dev, skb_cb->paddr, msdu->len, DMA_TO_DEVICE);
+ 
+ 	ath10k_report_offchan_tx(htt->ar, msdu);
+ 

--- a/projects/Amlogic_GX/patches/linux/0057-ath10k-various-fixes-for-high-latency-devices.patch
+++ b/projects/Amlogic_GX/patches/linux/0057-ath10k-various-fixes-for-high-latency-devices.patch
@@ -1,0 +1,41 @@
+From 2409a70149040a42246b4bf914d18324524376cb Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:03 +0100
+Subject: [PATCH] ath10k: various fixes for high latency devices
+
+A few execution paths are not applicable for high latency
+devices and can be skipped.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt_rx.c | 3 ++-
+ drivers/net/wireless/ath/ath10k/txrx.c   | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt_rx.c b/drivers/net/wireless/ath/ath10k/htt_rx.c
+index 7b3d6bf015c7..1432d5b3e9d3 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_rx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_rx.c
+@@ -2686,7 +2686,8 @@ bool ath10k_htt_t2h_msg_handler(struct ath10k *ar, struct sk_buff *skb)
+ 		break;
+ 	}
+ 	case HTT_T2H_MSG_TYPE_TX_COMPL_IND:
+-		ath10k_htt_rx_tx_compl_ind(htt->ar, skb);
++		if (!ar->is_high_latency)
++			ath10k_htt_rx_tx_compl_ind(htt->ar, skb);
+ 		break;
+ 	case HTT_T2H_MSG_TYPE_SEC_IND: {
+ 		struct ath10k *ar = htt->ar;
+diff --git a/drivers/net/wireless/ath/ath10k/txrx.c b/drivers/net/wireless/ath/ath10k/txrx.c
+index febc3eb93fbd..a151abe5e97b 100644
+--- a/drivers/net/wireless/ath/ath10k/txrx.c
++++ b/drivers/net/wireless/ath/ath10k/txrx.c
+@@ -90,7 +90,7 @@ int ath10k_txrx_tx_unref(struct ath10k_htt *htt,
+ 
+ 	ath10k_htt_tx_free_msdu_id(htt, tx_done->msdu_id);
+ 	ath10k_htt_tx_dec_pending(htt);
+-	if (htt->num_pending_tx == 0)
++	if (!ar->is_high_latency && (htt->num_pending_tx == 0))
+ 		wake_up(&htt->empty_tx_wq);
+ 	spin_unlock_bh(&htt->tx_lock);
+ 

--- a/projects/Amlogic_GX/patches/linux/0058-ath10k-add-start_once-support.patch
+++ b/projects/Amlogic_GX/patches/linux/0058-ath10k-add-start_once-support.patch
@@ -1,0 +1,103 @@
+From 2d25ef0098359a13c9daec3eae360ca07af88890 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:04 +0100
+Subject: [PATCH] ath10k: add start_once support
+
+Add possibility to configure the driver to only start target once.
+This can reduce startup time of SDIO devices significantly since
+loading the firmware can take a substantial amount of time.
+
+The patch is also necessary for high latency devices in general
+since it does not seem to be possible to rerun the BMI phase
+(fw upload) without power-cycling the device.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c | 19 +++++++++++++++----
+ drivers/net/wireless/ath/ath10k/core.h |  2 ++
+ drivers/net/wireless/ath/ath10k/hw.h   |  6 ++++++
+ 3 files changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index c9096e43954c..247eeca7085f 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -2159,6 +2159,9 @@ int ath10k_core_start(struct ath10k *ar, enum ath10k_firmware_mode mode,
+ 	int status;
+ 	u32 val;
+ 
++	if (ar->is_started && ar->hw_params.start_once)
++		return 0;
++
+ 	lockdep_assert_held(&ar->conf_mutex);
+ 
+ 	clear_bit(ATH10K_FLAG_CRASH_FLUSH, &ar->dev_flags);
+@@ -2393,6 +2396,7 @@ int ath10k_core_start(struct ath10k *ar, enum ath10k_firmware_mode mode,
+ 	if (status)
+ 		goto err_hif_stop;
+ 
++	ar->is_started = true;
+ 	return 0;
+ 
+ err_hif_stop:
+@@ -2445,6 +2449,7 @@ void ath10k_core_stop(struct ath10k *ar)
+ 	ath10k_htt_tx_stop(&ar->htt);
+ 	ath10k_htt_rx_free(&ar->htt);
+ 	ath10k_wmi_detach(ar);
++	ar->is_started = false;
+ }
+ EXPORT_SYMBOL(ath10k_core_stop);
+ 
+@@ -2574,12 +2579,18 @@ static int ath10k_core_probe_fw(struct ath10k *ar)
+ 		goto err_unlock;
+ 	}
+ 
+-	ath10k_debug_print_boot_info(ar);
+-	ath10k_core_stop(ar);
++	/* Leave target running if hw_params.start_once is set */
++	if (ar->hw_params.start_once) {
++		mutex_unlock(&ar->conf_mutex);
++	} else {
++		ath10k_debug_print_boot_info(ar);
++		ath10k_core_stop(ar);
+ 
+-	mutex_unlock(&ar->conf_mutex);
++		mutex_unlock(&ar->conf_mutex);
++
++		ath10k_hif_power_down(ar);
++	}
+ 
+-	ath10k_hif_power_down(ar);
+ 	return 0;
+ 
+ err_unlock:
+diff --git a/drivers/net/wireless/ath/ath10k/core.h b/drivers/net/wireless/ath/ath10k/core.h
+index 32cfa14d3053..ed96f9ef5209 100644
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -798,6 +798,8 @@ struct ath10k {
+ 
+ 	bool p2p;
+ 
++	bool is_started;
++
+ 	struct {
+ 		enum ath10k_bus bus;
+ 		const struct ath10k_hif_ops *ops;
+diff --git a/drivers/net/wireless/ath/ath10k/hw.h b/drivers/net/wireless/ath/ath10k/hw.h
+index cae8ec40537d..f4bb82092aca 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -577,6 +577,12 @@ struct ath10k_hw_params {
+ 
+ 	/* Target rx ring fill level */
+ 	u32 rx_ring_fill_level;
++
++	/* Specifies whether or not the device should be started once.
++	 * If set, the device will be started once by the early fw probe
++	 * and it will not be terminated afterwards.
++	 */
++	bool start_once;
+ };
+ 
+ struct htt_rx_desc;

--- a/projects/Amlogic_GX/patches/linux/0059-ath10k-add-HTT-TX-HL-ops.patch
+++ b/projects/Amlogic_GX/patches/linux/0059-ath10k-add-HTT-TX-HL-ops.patch
@@ -1,0 +1,35 @@
+From 2b81983f4a8f80b53ac7ac12e16bf35d7e777613 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:05 +0100
+Subject: [PATCH] ath10k: add HTT TX HL ops
+
+Initial HTT TX ops for high latency devices.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt_tx.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt_tx.c b/drivers/net/wireless/ath/ath10k/htt_tx.c
+index 4d0bfb47d162..321f131e417d 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_tx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_tx.c
+@@ -1565,11 +1565,17 @@ static const struct ath10k_htt_tx_ops htt_tx_ops_64 = {
+ 	.htt_free_txbuff = ath10k_htt_tx_free_cont_txbuf_64,
+ };
+ 
++static const struct ath10k_htt_tx_ops htt_tx_ops_hl = {
++	.htt_send_frag_desc_bank_cfg = ath10k_htt_send_frag_desc_bank_cfg_32,
++};
++
+ void ath10k_htt_set_tx_ops(struct ath10k_htt *htt)
+ {
+ 	struct ath10k *ar = htt->ar;
+ 
+-	if (ar->hw_params.target_64bit)
++	if (ar->is_high_latency)
++		htt->tx_ops = &htt_tx_ops_hl;
++	else if (ar->hw_params.target_64bit)
+ 		htt->tx_ops = &htt_tx_ops_64;
+ 	else
+ 		htt->tx_ops = &htt_tx_ops_32;

--- a/projects/Amlogic_GX/patches/linux/0060-ath10k-add-HTT-RX-HL-ops.patch
+++ b/projects/Amlogic_GX/patches/linux/0060-ath10k-add-HTT-RX-HL-ops.patch
@@ -1,0 +1,34 @@
+From 3b770a11b23b01dcd4c18978ffef228190014f71 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:06 +0100
+Subject: [PATCH] ath10k: add HTT RX HL ops
+
+Initial (empty) HTT RX ops for high latency devices.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt_rx.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt_rx.c b/drivers/net/wireless/ath/ath10k/htt_rx.c
+index 1432d5b3e9d3..f7d071ca8b76 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_rx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_rx.c
+@@ -2917,11 +2917,16 @@ static const struct ath10k_htt_rx_ops htt_rx_ops_64 = {
+ 	.htt_reset_paddrs_ring = ath10k_htt_reset_paddrs_ring_64,
+ };
+ 
++static const struct ath10k_htt_rx_ops htt_rx_ops_hl = {
++};
++
+ void ath10k_htt_set_rx_ops(struct ath10k_htt *htt)
+ {
+ 	struct ath10k *ar = htt->ar;
+ 
+-	if (ar->hw_params.target_64bit)
++	if (ar->is_high_latency)
++		htt->rx_ops = &htt_rx_ops_hl;
++	else if (ar->hw_params.target_64bit)
+ 		htt->rx_ops = &htt_rx_ops_64;
+ 	else
+ 		htt->rx_ops = &htt_rx_ops_32;

--- a/projects/Amlogic_GX/patches/linux/0061-ath10k-htt-RX-ring-config-HL-support.patch
+++ b/projects/Amlogic_GX/patches/linux/0061-ath10k-htt-RX-ring-config-HL-support.patch
@@ -1,0 +1,87 @@
+From aa3ea278ed9d52d5395de8dd44f190fc1c943600 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:06 +0100
+Subject: [PATCH] ath10k: htt: RX ring config HL support
+
+Special HTT RX ring config message used by high latency
+devices.
+
+The main difference between HL and LL is that HL devices
+do not use shared memory between device and host and thus,
+no host paddr's are added to the RX config message.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt_tx.c | 52 ++++++++++++++++++++++++++++++++
+ 1 file changed, 52 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt_tx.c b/drivers/net/wireless/ath/ath10k/htt_tx.c
+index 321f131e417d..1f6470de7b8d 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_tx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_tx.c
+@@ -934,6 +934,57 @@ static int ath10k_htt_send_rx_ring_cfg_64(struct ath10k_htt *htt)
+ 	return 0;
+ }
+ 
++static int ath10k_htt_send_rx_ring_cfg_hl(struct ath10k_htt *htt)
++{
++	struct ath10k *ar = htt->ar;
++	struct sk_buff *skb;
++	struct htt_cmd *cmd;
++	struct htt_rx_ring_setup_ring32 *ring;
++	const int num_rx_ring = 1;
++	u16 flags;
++	int len;
++	int ret;
++
++	/*
++	 * the HW expects the buffer to be an integral number of 4-byte
++	 * "words"
++	 */
++	BUILD_BUG_ON(!IS_ALIGNED(HTT_RX_BUF_SIZE, 4));
++	BUILD_BUG_ON((HTT_RX_BUF_SIZE & HTT_MAX_CACHE_LINE_SIZE_MASK) != 0);
++
++	len = sizeof(cmd->hdr) + sizeof(cmd->rx_setup_32.hdr)
++	    + (sizeof(*ring) * num_rx_ring);
++	skb = ath10k_htc_alloc_skb(ar, len);
++	if (!skb)
++		return -ENOMEM;
++
++	skb_put(skb, len);
++
++	cmd = (struct htt_cmd *)skb->data;
++	ring = &cmd->rx_setup_32.rings[0];
++
++	cmd->hdr.msg_type = HTT_H2T_MSG_TYPE_RX_RING_CFG;
++	cmd->rx_setup_32.hdr.num_rings = 1;
++
++	flags = 0;
++	flags |= HTT_RX_RING_FLAGS_MSDU_PAYLOAD;
++	flags |= HTT_RX_RING_FLAGS_UNICAST_RX;
++	flags |= HTT_RX_RING_FLAGS_MULTICAST_RX;
++
++	memset(ring, 0, sizeof(*ring));
++	ring->rx_ring_len = __cpu_to_le16(HTT_RX_RING_SIZE_MIN);
++	ring->rx_ring_bufsize = __cpu_to_le16(HTT_RX_BUF_SIZE);
++	ring->flags = __cpu_to_le16(flags);
++
++	ret = ath10k_htc_send(&htt->ar->htc, htt->eid, skb);
++	if (ret) {
++		dev_kfree_skb_any(skb);
++		return ret;
++	}
++
++	return 0;
++}
++
+ int ath10k_htt_h2t_aggr_cfg_msg(struct ath10k_htt *htt,
+ 				u8 max_subfrms_ampdu,
+ 				u8 max_subfrms_amsdu)
+@@ -1566,6 +1617,7 @@ static const struct ath10k_htt_tx_ops htt_tx_ops_64 = {
+ };
+ 
+ static const struct ath10k_htt_tx_ops htt_tx_ops_hl = {
++	.htt_send_rx_ring_cfg = ath10k_htt_send_rx_ring_cfg_hl,
+ 	.htt_send_frag_desc_bank_cfg = ath10k_htt_send_frag_desc_bank_cfg_32,
+ };
+ 

--- a/projects/Amlogic_GX/patches/linux/0062-ath10k-htt-High-latency-TX-support.patch
+++ b/projects/Amlogic_GX/patches/linux/0062-ath10k-htt-High-latency-TX-support.patch
@@ -1,0 +1,130 @@
+From 8ee8babaf4b2383dac425db3fa6652e19d5f6580 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:07 +0100
+Subject: [PATCH] ath10k: htt: High latency TX support
+
+Add HTT TX function for HL interfaces.
+Intended for SDIO and USB.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt_tx.c | 92 ++++++++++++++++++++++++++++++++
+ 1 file changed, 92 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt_tx.c b/drivers/net/wireless/ath/ath10k/htt_tx.c
+index 1f6470de7b8d..7ea27454ef3f 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_tx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_tx.c
+@@ -495,6 +495,9 @@ int ath10k_htt_tx_start(struct ath10k_htt *htt)
+ 	if (htt->tx_mem_allocated)
+ 		return 0;
+ 
++	if (ar->is_high_latency)
++		return 0;
++
+ 	ret = ath10k_htt_tx_alloc_buf(htt);
+ 	if (ret)
+ 		goto free_idr_pending_tx;
+@@ -1188,6 +1191,94 @@ int ath10k_htt_mgmt_tx(struct ath10k_htt *htt, struct sk_buff *msdu)
+ 	return res;
+ }
+ 
++#define HTT_TX_HL_NEEDED_HEADROOM \
++	(unsigned int)(sizeof(struct htt_cmd_hdr) + \
++	sizeof(struct htt_data_tx_desc) + \
++	sizeof(struct ath10k_htc_hdr))
++
++static int ath10k_htt_tx_hl(struct ath10k_htt *htt, enum ath10k_hw_txrx_mode txmode,
++			    struct sk_buff *msdu)
++{
++	struct ath10k *ar = htt->ar;
++	int res, data_len;
++	struct htt_cmd_hdr *cmd_hdr;
++	struct htt_data_tx_desc *tx_desc;
++	struct ath10k_skb_cb *skb_cb = ATH10K_SKB_CB(msdu);
++	struct sk_buff *tmp_skb;
++	bool is_eth = (txmode == ATH10K_HW_TXRX_ETHERNET);
++	u8 vdev_id = ath10k_htt_tx_get_vdev_id(ar, msdu);
++	u8 tid = ath10k_htt_tx_get_tid(msdu, is_eth);
++	u8 flags0 = 0;
++	u16 flags1 = 0;
++
++	data_len = msdu->len;
++
++	switch (txmode) {
++	case ATH10K_HW_TXRX_RAW:
++	case ATH10K_HW_TXRX_NATIVE_WIFI:
++		flags0 |= HTT_DATA_TX_DESC_FLAGS0_MAC_HDR_PRESENT;
++		/* fall through */
++	case ATH10K_HW_TXRX_ETHERNET:
++		flags0 |= SM(txmode, HTT_DATA_TX_DESC_FLAGS0_PKT_TYPE);
++		break;
++	case ATH10K_HW_TXRX_MGMT:
++		flags0 |= SM(ATH10K_HW_TXRX_MGMT,
++			     HTT_DATA_TX_DESC_FLAGS0_PKT_TYPE);
++		flags0 |= HTT_DATA_TX_DESC_FLAGS0_MAC_HDR_PRESENT;
++		break;
++	}
++
++	if (skb_cb->flags & ATH10K_SKB_F_NO_HWCRYPT)
++		flags0 |= HTT_DATA_TX_DESC_FLAGS0_NO_ENCRYPT;
++
++	flags1 |= SM((u16)vdev_id, HTT_DATA_TX_DESC_FLAGS1_VDEV_ID);
++	flags1 |= SM((u16)tid, HTT_DATA_TX_DESC_FLAGS1_EXT_TID);
++	if (msdu->ip_summed == CHECKSUM_PARTIAL &&
++	    !test_bit(ATH10K_FLAG_RAW_MODE, &ar->dev_flags)) {
++		flags1 |= HTT_DATA_TX_DESC_FLAGS1_CKSUM_L3_OFFLOAD;
++		flags1 |= HTT_DATA_TX_DESC_FLAGS1_CKSUM_L4_OFFLOAD;
++	}
++
++	/* Prepend the HTT header and TX desc struct to the data message
++	 * and realloc the skb if it does not have enough headroom.
++	 */
++	if (skb_headroom(msdu) < HTT_TX_HL_NEEDED_HEADROOM) {
++		tmp_skb = msdu;
++
++		ath10k_dbg(htt->ar, ATH10K_DBG_HTT,
++			   "Not enough headroom in skb. Current headroom: %u, needed: %u. Reallocating...\n",
++			   skb_headroom(msdu), HTT_TX_HL_NEEDED_HEADROOM);
++		msdu = skb_realloc_headroom(msdu, HTT_TX_HL_NEEDED_HEADROOM);
++		kfree_skb(tmp_skb);
++		if (!msdu) {
++			ath10k_warn(htt->ar, "htt hl tx: Unable to realloc skb!\n");
++			res = -ENOMEM;
++			goto out;
++		}
++	}
++
++	skb_push(msdu, sizeof(*cmd_hdr));
++	skb_push(msdu, sizeof(*tx_desc));
++	cmd_hdr = (struct htt_cmd_hdr *)msdu->data;
++	tx_desc = (struct htt_data_tx_desc *)(msdu->data + sizeof(*cmd_hdr));
++
++	cmd_hdr->msg_type = HTT_H2T_MSG_TYPE_TX_FRM;
++	tx_desc->flags0 = flags0;
++	tx_desc->flags1 = __cpu_to_le16(flags1);
++	tx_desc->len = __cpu_to_le16(data_len);
++	tx_desc->id = 0;
++	tx_desc->frags_paddr = 0; /* always zero */
++	/* Initialize peer_id to INVALID_PEER because this is NOT
++	 * Reinjection path
++	 */
++	tx_desc->peerid = __cpu_to_le32(HTT_INVALID_PEERID);
++
++	res = ath10k_htc_send(&htt->ar->htc, htt->eid, msdu);
++
++out:
++	return res;
++}
++
+ static int ath10k_htt_tx_32(struct ath10k_htt *htt,
+ 			    enum ath10k_hw_txrx_mode txmode,
+ 			    struct sk_buff *msdu)
+@@ -1619,6 +1710,7 @@ static const struct ath10k_htt_tx_ops htt_tx_ops_64 = {
+ static const struct ath10k_htt_tx_ops htt_tx_ops_hl = {
+ 	.htt_send_rx_ring_cfg = ath10k_htt_send_rx_ring_cfg_hl,
+ 	.htt_send_frag_desc_bank_cfg = ath10k_htt_send_frag_desc_bank_cfg_32,
++	.htt_tx = ath10k_htt_tx_hl,
+ };
+ 
+ void ath10k_htt_set_tx_ops(struct ath10k_htt *htt)

--- a/projects/Amlogic_GX/patches/linux/0063-ath10k-htt-High-latency-RX-support.patch
+++ b/projects/Amlogic_GX/patches/linux/0063-ath10k-htt-High-latency-RX-support.patch
@@ -1,0 +1,301 @@
+From 630aefcda6e276794aafc5f85dc70a0ca4b993ce Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:08 +0100
+Subject: [PATCH] ath10k: htt: High latency RX support
+
+Special HTT RX handling for high latency interfaces.
+
+Since no DMA physical addresses are used in the RX ring
+config message (this is not supported by the high latency
+devices), no RX ring is allocated.
+All RX skb's are allocated by the driver and passed directly
+to mac80211 in the HTT RX indication handler.
+
+A nice side effect of this is that no huge buffer will be
+allocated with dma_alloc_coherent. On embedded systems with
+limited memory resources, the allocation of the RX ring is
+prone to fail.
+
+Some tweaks made to "make it work":
+
+Removal of protected bit in 802.11 header frame control field.
+The chipset seems to do hw decryption but the frame_control
+protected bit is still set.
+
+This is necessary for mac80211 not to drop the frame.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt.h     |  47 +++++++++++
+ drivers/net/wireless/ath/ath10k/htt_rx.c  | 126 +++++++++++++++++++++++++++++-
+ drivers/net/wireless/ath/ath10k/rx_desc.h |  15 ++++
+ 3 files changed, 185 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt.h b/drivers/net/wireless/ath/ath10k/htt.h
+index 3fa1be7749b2..e5fb8e0155b6 100644
+--- a/drivers/net/wireless/ath/ath10k/htt.h
++++ b/drivers/net/wireless/ath/ath10k/htt.h
+@@ -699,6 +699,15 @@ struct htt_rx_indication {
+ 	struct htt_rx_indication_mpdu_range mpdu_ranges[0];
+ } __packed;
+ 
++/* High latency version of the RX indication */
++struct htt_rx_indication_hl {
++	struct htt_rx_indication_hdr hdr;
++	struct htt_rx_indication_ppdu ppdu;
++	struct htt_rx_indication_prefix prefix;
++	struct fw_rx_desc_hl fw_desc;
++	struct htt_rx_indication_mpdu_range mpdu_ranges[0];
++} __packed;
++
+ static inline struct htt_rx_indication_mpdu_range *
+ 		htt_rx_ind_get_mpdu_ranges(struct htt_rx_indication *rx_ind)
+ {
+@@ -711,6 +720,18 @@ static inline struct htt_rx_indication_mpdu_range *
+ 	return ptr;
+ }
+ 
++static inline struct htt_rx_indication_mpdu_range *
++	htt_rx_ind_get_mpdu_ranges_hl(struct htt_rx_indication_hl *rx_ind)
++{
++	void *ptr = rx_ind;
++
++	ptr += sizeof(rx_ind->hdr)
++	     + sizeof(rx_ind->ppdu)
++	     + sizeof(rx_ind->prefix)
++	     + sizeof(rx_ind->fw_desc);
++	return ptr;
++}
++
+ enum htt_rx_flush_mpdu_status {
+ 	HTT_RX_FLUSH_MPDU_DISCARD = 0,
+ 	HTT_RX_FLUSH_MPDU_REORDER = 1,
+@@ -1621,6 +1642,7 @@ struct htt_resp {
+ 		struct htt_mgmt_tx_completion mgmt_tx_completion;
+ 		struct htt_data_tx_completion data_tx_completion;
+ 		struct htt_rx_indication rx_ind;
++		struct htt_rx_indication_hl rx_ind_hl;
+ 		struct htt_rx_fragment_indication rx_frag_ind;
+ 		struct htt_rx_peer_map peer_map;
+ 		struct htt_rx_peer_unmap peer_unmap;
+@@ -1973,6 +1995,31 @@ struct htt_rx_desc {
+ 	u8 msdu_payload[0];
+ };
+ 
++#define HTT_RX_DESC_HL_INFO_SEQ_NUM_MASK           0x00000fff
++#define HTT_RX_DESC_HL_INFO_SEQ_NUM_LSB            0
++#define HTT_RX_DESC_HL_INFO_ENCRYPTED_MASK         0x00001000
++#define HTT_RX_DESC_HL_INFO_ENCRYPTED_LSB          12
++#define HTT_RX_DESC_HL_INFO_CHAN_INFO_PRESENT_MASK 0x00002000
++#define HTT_RX_DESC_HL_INFO_CHAN_INFO_PRESENT_LSB  13
++#define HTT_RX_DESC_HL_INFO_MCAST_BCAST_MASK       0x00008000
++#define HTT_RX_DESC_HL_INFO_MCAST_BCAST_LSB        15
++#define HTT_RX_DESC_HL_INFO_FRAGMENT_MASK          0x00010000
++#define HTT_RX_DESC_HL_INFO_FRAGMENT_LSB           16
++#define HTT_RX_DESC_HL_INFO_KEY_ID_OCT_MASK        0x01fe0000
++#define HTT_RX_DESC_HL_INFO_KEY_ID_OCT_LSB         17
++
++struct htt_rx_desc_base_hl {
++	__le32 info; /* HTT_RX_DESC_HL_INFO_ */
++};
++
++struct htt_rx_chan_info {
++	__le16 primary_chan_center_freq_mhz;
++	__le16 contig_chan1_center_freq_mhz;
++	__le16 contig_chan2_center_freq_mhz;
++	u8 phy_mode;
++	u8 reserved;
++} __packed;
++
+ #define HTT_RX_DESC_ALIGN 8
+ 
+ #define HTT_MAC_ADDR_LEN 6
+diff --git a/drivers/net/wireless/ath/ath10k/htt_rx.c b/drivers/net/wireless/ath/ath10k/htt_rx.c
+index f7d071ca8b76..3e0273ea9ad0 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_rx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_rx.c
+@@ -263,6 +263,9 @@ int ath10k_htt_rx_ring_refill(struct ath10k *ar)
+ 	struct ath10k_htt *htt = &ar->htt;
+ 	int ret;
+ 
++	if (ar->is_high_latency)
++		return 0;
++
+ 	spin_lock_bh(&htt->rx_ring.lock);
+ 	ret = ath10k_htt_rx_ring_fill_n(htt, (htt->rx_ring.fill_level -
+ 					      htt->rx_ring.fill_cnt));
+@@ -276,6 +279,9 @@ int ath10k_htt_rx_ring_refill(struct ath10k *ar)
+ 
+ void ath10k_htt_rx_free(struct ath10k_htt *htt)
+ {
++	if (htt->ar->is_high_latency)
++		return;
++
+ 	del_timer_sync(&htt->rx_ring.refill_retry_timer);
+ 
+ 	skb_queue_purge(&htt->rx_msdus_q);
+@@ -565,6 +571,9 @@ int ath10k_htt_rx_alloc(struct ath10k_htt *htt)
+ 	size_t size;
+ 	struct timer_list *timer = &htt->rx_ring.refill_retry_timer;
+ 
++	if (ar->is_high_latency)
++		return 0;
++
+ 	htt->rx_confused = false;
+ 
+ 	/* XXX: The fill level could be changed during runtime in response to
+@@ -1794,8 +1803,114 @@ static int ath10k_htt_rx_handle_amsdu(struct ath10k_htt *htt)
+ 	return 0;
+ }
+ 
+-static void ath10k_htt_rx_proc_rx_ind(struct ath10k_htt *htt,
+-				      struct htt_rx_indication *rx)
++static bool ath10k_htt_rx_proc_rx_ind_hl(struct ath10k_htt *htt,
++					 struct htt_rx_indication_hl *rx,
++					 struct sk_buff *skb)
++{
++	struct ath10k *ar = htt->ar;
++	struct ath10k_peer *peer;
++	struct htt_rx_indication_mpdu_range *mpdu_ranges;
++	struct fw_rx_desc_hl *fw_desc;
++	struct ieee80211_hdr *hdr;
++	struct ieee80211_rx_status *rx_status;
++	u16 peer_id;
++	u8 rx_desc_len;
++	int num_mpdu_ranges;
++	size_t tot_hdr_len;
++	struct ieee80211_channel *ch;
++
++	peer_id = __le16_to_cpu(rx->hdr.peer_id);
++
++	peer = ath10k_peer_find_by_id(ar, peer_id);
++	if (!peer)
++		ath10k_warn(ar, "Got RX ind from invalid peer: %u\n", peer_id);
++
++	num_mpdu_ranges = MS(__le32_to_cpu(rx->hdr.info1),
++			     HTT_RX_INDICATION_INFO1_NUM_MPDU_RANGES);
++	mpdu_ranges = htt_rx_ind_get_mpdu_ranges_hl(rx);
++	fw_desc = &rx->fw_desc;
++	rx_desc_len = fw_desc->len;
++
++	/* I have not yet seen any case where num_mpdu_ranges > 1.
++	 * qcacld does not seem handle that case either, so we introduce the
++	 * same limitiation here as well.
++	 */
++	if (num_mpdu_ranges > 1)
++		ath10k_warn(ar,
++			    "Unsupported number of MPDU ranges: %d, ignoring all but the first\n",
++			    num_mpdu_ranges);
++
++	if (mpdu_ranges->mpdu_range_status !=
++	    HTT_RX_IND_MPDU_STATUS_OK) {
++		ath10k_warn(ar, "MPDU range status: %d\n",
++			    mpdu_ranges->mpdu_range_status);
++		goto err;
++	}
++
++	/* Strip off all headers before the MAC header before delivery to
++	 * mac80211
++	 */
++	tot_hdr_len = sizeof(struct htt_resp_hdr) + sizeof(rx->hdr) +
++		      sizeof(rx->ppdu) + sizeof(rx->prefix) +
++		      sizeof(rx->fw_desc) +
++		      sizeof(*mpdu_ranges) * num_mpdu_ranges + rx_desc_len;
++	skb_pull(skb, tot_hdr_len);
++
++	hdr = (struct ieee80211_hdr *)skb->data;
++	rx_status = IEEE80211_SKB_RXCB(skb);
++	rx_status->chains |= BIT(0);
++	rx_status->signal = ATH10K_DEFAULT_NOISE_FLOOR +
++			    rx->ppdu.combined_rssi;
++	rx_status->flag &= ~RX_FLAG_NO_SIGNAL_VAL;
++
++	spin_lock_bh(&ar->data_lock);
++	ch = ar->scan_channel;
++	if (!ch)
++		ch = ar->rx_channel;
++	if (!ch)
++		ch = ath10k_htt_rx_h_any_channel(ar);
++	if (!ch)
++		ch = ar->tgt_oper_chan;
++	spin_unlock_bh(&ar->data_lock);
++
++	if (ch) {
++		rx_status->band = ch->band;
++		rx_status->freq = ch->center_freq;
++	}
++	if (rx->fw_desc.flags & FW_RX_DESC_FLAGS_LAST_MSDU)
++		rx_status->flag &= ~RX_FLAG_AMSDU_MORE;
++	else
++		rx_status->flag |= RX_FLAG_AMSDU_MORE;
++
++	/* Not entirely sure about this, but all frames from the chipset has
++	 * the protected flag set even though they have already been decrypted.
++	 * Unmasking this flag is necessary in order for mac80211 not to drop
++	 * the frame.
++	 * TODO: Verify this is always the case or find out a way to check
++	 * if there has been hw decryption.
++	 */
++	if (ieee80211_has_protected(hdr->frame_control)) {
++		hdr->frame_control &= ~__cpu_to_le16(IEEE80211_FCTL_PROTECTED);
++		rx_status->flag |= RX_FLAG_DECRYPTED |
++				   RX_FLAG_IV_STRIPPED |
++				   RX_FLAG_MMIC_STRIPPED;
++	}
++
++	ieee80211_rx_ni(ar->hw, skb);
++
++	/* We have delivered the skb to the upper layers (mac80211) so we
++	 * must not free it.
++	 */
++	return false;
++err:
++	/* Tell the caller that it must free the skb since we have not
++	 * consumed it
++	 */
++	return true;
++}
++
++static void ath10k_htt_rx_proc_rx_ind_ll(struct ath10k_htt *htt,
++					 struct htt_rx_indication *rx)
+ {
+ 	struct ath10k *ar = htt->ar;
+ 	struct htt_rx_indication_mpdu_range *mpdu_ranges;
+@@ -2641,7 +2756,12 @@ bool ath10k_htt_t2h_msg_handler(struct ath10k *ar, struct sk_buff *skb)
+ 		break;
+ 	}
+ 	case HTT_T2H_MSG_TYPE_RX_IND:
+-		ath10k_htt_rx_proc_rx_ind(htt, &resp->rx_ind);
++		if (ar->is_high_latency)
++			return ath10k_htt_rx_proc_rx_ind_hl(htt,
++							    &resp->rx_ind_hl,
++							    skb);
++		else
++			ath10k_htt_rx_proc_rx_ind_ll(htt, &resp->rx_ind);
+ 		break;
+ 	case HTT_T2H_MSG_TYPE_PEER_MAP: {
+ 		struct htt_peer_map_event ev = {
+diff --git a/drivers/net/wireless/ath/ath10k/rx_desc.h b/drivers/net/wireless/ath/ath10k/rx_desc.h
+index 545deb6d7af1..72cdf8c7245c 100644
+--- a/drivers/net/wireless/ath/ath10k/rx_desc.h
++++ b/drivers/net/wireless/ath/ath10k/rx_desc.h
+@@ -1275,4 +1275,19 @@ struct fw_rx_desc_base {
+ 	u8 info0;
+ } __packed;
+ 
++#define FW_RX_DESC_FLAGS_FIRST_MSDU (1 << 0)
++#define FW_RX_DESC_FLAGS_LAST_MSDU  (1 << 1)
++#define FW_RX_DESC_C3_FAILED        (1 << 2)
++#define FW_RX_DESC_C4_FAILED        (1 << 3)
++#define FW_RX_DESC_IPV6             (1 << 4)
++#define FW_RX_DESC_TCP              (1 << 5)
++#define FW_RX_DESC_UDP              (1 << 6)
++
++struct fw_rx_desc_hl {
++	u8 info0;
++	u8 version;
++	u8 len;
++	u8 flags;
++} __packed;
++
+ #endif /* _RX_DESC_H_ */

--- a/projects/Amlogic_GX/patches/linux/0064-ath10k-wmi-disable-softirqs-while-calling-ieee80211_rx.patch
+++ b/projects/Amlogic_GX/patches/linux/0064-ath10k-wmi-disable-softirqs-while-calling-ieee80211_rx.patch
@@ -1,0 +1,32 @@
+From a64b6142da03f1a612f19580360c352816406933 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:08 +0100
+Subject: [PATCH] ath10k: wmi: disable softirq's while calling ieee80211_rx
+
+This is done in order not to trig the below warning in
+ieee80211_rx_napi:
+
+WARN_ON_ONCE(softirq_count() == 0);
+
+ieee80211_rx_napi requires that softirq's are disabled during
+execution.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/wmi.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/wmi.c b/drivers/net/wireless/ath/ath10k/wmi.c
+index 58dc2189ba49..3a81d106789d 100644
+--- a/drivers/net/wireless/ath/ath10k/wmi.c
++++ b/drivers/net/wireless/ath/ath10k/wmi.c
+@@ -2409,7 +2409,8 @@ int ath10k_wmi_event_mgmt_rx(struct ath10k *ar, struct sk_buff *skb)
+ 		   status->freq, status->band, status->signal,
+ 		   status->rate_idx);
+ 
+-	ieee80211_rx(ar->hw, skb);
++	ieee80211_rx_ni(ar->hw, skb);
++
+ 	return 0;
+ }
+ 

--- a/projects/Amlogic_GX/patches/linux/0065-ath10k-remove-htt-pending-TX-count-for-high-latency.patch
+++ b/projects/Amlogic_GX/patches/linux/0065-ath10k-remove-htt-pending-TX-count-for-high-latency.patch
@@ -1,0 +1,41 @@
+From 55c2e6a6a064fbf1b23b6ec87955ae5cc16742d1 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:09 +0100
+Subject: [PATCH] ath10k: remove htt pending TX count for high latency
+
+High latency chipsets does not seem to send any
+HTT_T2H_MSG_TYPE_TX_COMPL_IND for outgoing frames.
+
+This means that htt->num_pending_tx will never be
+decremented and we will eventually hit the maximum
+limit. All outgoing packets will then be discarded.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/htt_tx.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt_tx.c b/drivers/net/wireless/ath/ath10k/htt_tx.c
+index 7ea27454ef3f..0c14fb3b7181 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_tx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_tx.c
+@@ -153,6 +153,9 @@ void ath10k_htt_tx_txq_update(struct ieee80211_hw *hw,
+ 
+ void ath10k_htt_tx_dec_pending(struct ath10k_htt *htt)
+ {
++	if (htt->ar->is_high_latency)
++		return;
++
+ 	lockdep_assert_held(&htt->tx_lock);
+ 
+ 	htt->num_pending_tx--;
+@@ -162,6 +165,9 @@ void ath10k_htt_tx_dec_pending(struct ath10k_htt *htt)
+ 
+ int ath10k_htt_tx_inc_pending(struct ath10k_htt *htt)
+ {
++	if (htt->ar->is_high_latency)
++		return 0;
++
+ 	lockdep_assert_held(&htt->tx_lock);
+ 
+ 	if (htt->num_pending_tx >= htt->max_num_pending_tx)

--- a/projects/Amlogic_GX/patches/linux/0066-ath10k-add-QCA9377-usb-hw_param-item.patch
+++ b/projects/Amlogic_GX/patches/linux/0066-ath10k-add-QCA9377-usb-hw_param-item.patch
@@ -1,0 +1,60 @@
+From 8905f7a541600e6c6aeea2e44fec7d07ce721512 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:10 +0100
+Subject: [PATCH] ath10k: add QCA9377 usb hw_param item
+
+Hardware parameters for QCA9377 usb devices.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c | 24 ++++++++++++++++++++++++
+ drivers/net/wireless/ath/ath10k/hw.h   |  1 +
+ 2 files changed, 25 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 247eeca7085f..d49fd9aa7552 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -443,6 +443,30 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 		.target_64bit = false,
+ 		.rx_ring_fill_level = HTT_RX_RING_FILL_LEVEL,
+ 	},
++	{
++		.id = QCA9377_HW_1_1_DEV_VERSION,
++		.dev_id = QCA9377_1_0_DEVICE_ID,
++		.bus = ATH10K_BUS_USB,
++		.name = "qca9377 hw1.1 usb",
++		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
++		.uart_pin = 6,
++		.otp_exe_param = 0,
++		.channel_counters_freq_hz = 88000,
++		.max_probe_resp_desc_thres = 0,
++		.cal_data_len = 8124,
++		.fw = {
++			.dir = QCA9377_HW_1_0_FW_DIR,
++			.board = QCA9377_HW_1_0_BOARD_DATA_FILE_USB,
++			.board_size = QCA9377_BOARD_DATA_SZ,
++			.board_ext_size = QCA9377_BOARD_EXT_DATA_SZ,
++		},
++		.hw_ops = &qca988x_ops,
++		.decap_align_bytes = 4,
++		.start_once = true,
++		.num_peers = TARGET_QCA9377_HL_NUM_PEERS,
++		.ast_skid_limit = 0x10,
++		.num_wds_entries = 0x20,
++	},
+ 	{
+ 		.id = QCA4019_HW_1_0_DEV_VERSION,
+ 		.dev_id = 0,
+diff --git a/drivers/net/wireless/ath/ath10k/hw.h b/drivers/net/wireless/ath/ath10k/hw.h
+index f4bb82092aca..44b10580369d 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -129,6 +129,7 @@ enum qca9377_chip_id_rev {
+ /* QCA9377 1.0 definitions */
+ #define QCA9377_HW_1_0_FW_DIR          ATH10K_FW_DIR "/QCA9377/hw1.0"
+ #define QCA9377_HW_1_0_BOARD_DATA_FILE "board.bin"
++#define QCA9377_HW_1_0_BOARD_DATA_FILE_USB "board-usb.bin"
+ #define QCA9377_HW_1_0_PATCH_LOAD_ADDR	0x1234
+ 
+ /* QCA4019 1.0 definitions */

--- a/projects/Amlogic_GX/patches/linux/0067-ath10k-add-QCA9377-sdio-hw_param-item.patch
+++ b/projects/Amlogic_GX/patches/linux/0067-ath10k-add-QCA9377-sdio-hw_param-item.patch
@@ -1,0 +1,62 @@
+From ffd1a56a9e2683a98a301ba6b2def7c4515a5698 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:10 +0100
+Subject: [PATCH] ath10k: add QCA9377 sdio hw_param item
+
+Hardware parameters for QCA9377 sdio devices.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c | 26 ++++++++++++++++++++++++++
+ drivers/net/wireless/ath/ath10k/hw.h   |  1 +
+ 2 files changed, 27 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index d49fd9aa7552..0a5ebdbe1c79 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -467,6 +467,32 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 		.ast_skid_limit = 0x10,
+ 		.num_wds_entries = 0x20,
+ 	},
++	{
++		.id = QCA9377_HW_1_1_DEV_VERSION,
++		.dev_id = QCA9377_1_0_DEVICE_ID,
++		.bus = ATH10K_BUS_SDIO,
++		.name = "qca9377 hw1.1 sdio",
++		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
++		.uart_pin = 19,
++		.otp_exe_param = 0,
++		.channel_counters_freq_hz = 88000,
++		.max_probe_resp_desc_thres = 0,
++		.cal_data_len = 8124,
++		.fw = {
++			.dir = QCA9377_HW_1_0_FW_DIR,
++			.board = QCA9377_HW_1_0_BOARD_DATA_FILE_SDIO,
++			.board_size = QCA9377_BOARD_DATA_SZ,
++			.board_ext_size = QCA9377_BOARD_EXT_DATA_SZ,
++		},
++		.hw_ops = &qca6174_ops,
++		.hw_clk = qca6174_clk,
++		.target_cpu_freq = 176000000,
++		.decap_align_bytes = 4,
++		.start_once = true,
++		.num_peers = TARGET_QCA9377_HL_NUM_PEERS,
++		.ast_skid_limit = 0x10,
++		.num_wds_entries = 0x20,
++	},
+ 	{
+ 		.id = QCA4019_HW_1_0_DEV_VERSION,
+ 		.dev_id = 0,
+diff --git a/drivers/net/wireless/ath/ath10k/hw.h b/drivers/net/wireless/ath/ath10k/hw.h
+index 44b10580369d..96f80932a644 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -130,6 +130,7 @@ enum qca9377_chip_id_rev {
+ #define QCA9377_HW_1_0_FW_DIR          ATH10K_FW_DIR "/QCA9377/hw1.0"
+ #define QCA9377_HW_1_0_BOARD_DATA_FILE "board.bin"
+ #define QCA9377_HW_1_0_BOARD_DATA_FILE_USB "board-usb.bin"
++#define QCA9377_HW_1_0_BOARD_DATA_FILE_SDIO "board-sdio.bin"
+ #define QCA9377_HW_1_0_PATCH_LOAD_ADDR	0x1234
+ 
+ /* QCA4019 1.0 definitions */

--- a/projects/Amlogic_GX/patches/linux/0068-ath10k-sdio-htt-data-transfer-fixes.patch
+++ b/projects/Amlogic_GX/patches/linux/0068-ath10k-sdio-htt-data-transfer-fixes.patch
@@ -1,0 +1,147 @@
+From 0fde8a60d1cebaec50989f3290eac1286d7da94e Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:11 +0100
+Subject: [PATCH] ath10k_sdio: sdio htt data transfer fixes
+
+The ath10k sdio firmware does not allow transmitting packets with the
+reduced tx completion HI_ACS option. sdio firmware uses 1544 as
+alternate credit size, which is not big enough for the maximum sized
+mac80211 frames. Disable both these HI_ACS flags for SDIO.
+
+Transmit completion for SDIO is similar to PCIe, via the T2H message
+HTT_T2H_MSG_TYPE_TX_COMPL_IND.  Modify the high latency path to allow
+SDIO modules to use the htt transmit completion path. This differs from
+the high latency path taken by the USB devices.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c   | 20 +++++++++++++++++---
+ drivers/net/wireless/ath/ath10k/htt_rx.c |  6 ++++--
+ drivers/net/wireless/ath/ath10k/htt_tx.c | 22 ++++++++++++++++++----
+ 3 files changed, 39 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 0a5ebdbe1c79..b2bbf4e4e4fb 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -625,11 +625,25 @@ static void ath10k_init_sdio(struct ath10k *ar)
+ 	ath10k_bmi_write32(ar, hi_mbox_isr_yield_limit, 99);
+ 	ath10k_bmi_read32(ar, hi_acs_flags, &param);
+ 
+-	param |= (HI_ACS_FLAGS_SDIO_SWAP_MAILBOX_SET |
+-		  HI_ACS_FLAGS_SDIO_REDUCE_TX_COMPL_SET |
+-		  HI_ACS_FLAGS_ALT_DATA_CREDIT_SIZE);
++	/* Data transfer is not initiated, when reduced Tx completion
++	 * is used for SDIO. disable it until fixed
++	 */
++	param &= ~HI_ACS_FLAGS_SDIO_REDUCE_TX_COMPL_SET;
++
++	/* Alternate credit size of 1544 as used by SDIO firmware is
++	 * not big enough for mac80211 / native wifi frames. disable it
++	 */
++	param &= ~HI_ACS_FLAGS_ALT_DATA_CREDIT_SIZE;
+ 
++	param |= HI_ACS_FLAGS_SDIO_SWAP_MAILBOX_SET;
+ 	ath10k_bmi_write32(ar, hi_acs_flags, param);
++
++	/* Explicitly set fwlog prints to zero as target may turn it on
++	 * based on scratch registers.
++	 */
++	ath10k_bmi_read32(ar, hi_option_flag, &param);
++	param |= HI_OPTION_DISABLE_DBGLOG;
++	ath10k_bmi_write32(ar, hi_option_flag, param);
+ }
+ 
+ static int ath10k_init_configure_target(struct ath10k *ar)
+diff --git a/drivers/net/wireless/ath/ath10k/htt_rx.c b/drivers/net/wireless/ath/ath10k/htt_rx.c
+index 3e0273ea9ad0..3f8d22de548d 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_rx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_rx.c
+@@ -1975,7 +1975,9 @@ static void ath10k_htt_rx_tx_compl_ind(struct ath10k *ar,
+ 		 *  Note that with only one concurrent reader and one concurrent
+ 		 *  writer, you don't need extra locking to use these macro.
+ 		 */
+-		if (!kfifo_put(&htt->txdone_fifo, tx_done)) {
++		if (ar->hif.bus == ATH10K_BUS_SDIO) {
++			ath10k_txrx_tx_unref(htt, &tx_done);
++		} else if (!kfifo_put(&htt->txdone_fifo, tx_done)) {
+ 			ath10k_warn(ar, "txdone fifo overrun, msdu_id %d status %d\n",
+ 				    tx_done.msdu_id, tx_done.status);
+ 			ath10k_txrx_tx_unref(htt, &tx_done);
+@@ -2806,7 +2808,7 @@ bool ath10k_htt_t2h_msg_handler(struct ath10k *ar, struct sk_buff *skb)
+ 		break;
+ 	}
+ 	case HTT_T2H_MSG_TYPE_TX_COMPL_IND:
+-		if (!ar->is_high_latency)
++		if (!(ar->hif.bus == ATH10K_BUS_USB))
+ 			ath10k_htt_rx_tx_compl_ind(htt->ar, skb);
+ 		break;
+ 	case HTT_T2H_MSG_TYPE_SEC_IND: {
+diff --git a/drivers/net/wireless/ath/ath10k/htt_tx.c b/drivers/net/wireless/ath/ath10k/htt_tx.c
+index 0c14fb3b7181..707aec878962 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_tx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_tx.c
+@@ -153,7 +153,7 @@ void ath10k_htt_tx_txq_update(struct ieee80211_hw *hw,
+ 
+ void ath10k_htt_tx_dec_pending(struct ath10k_htt *htt)
+ {
+-	if (htt->ar->is_high_latency)
++	if (htt->ar->hif.bus == ATH10K_BUS_USB)
+ 		return;
+ 
+ 	lockdep_assert_held(&htt->tx_lock);
+@@ -165,7 +165,7 @@ void ath10k_htt_tx_dec_pending(struct ath10k_htt *htt)
+ 
+ int ath10k_htt_tx_inc_pending(struct ath10k_htt *htt)
+ {
+-	if (htt->ar->is_high_latency)
++	if (htt->ar->hif.bus == ATH10K_BUS_USB)
+ 		return 0;
+ 
+ 	lockdep_assert_held(&htt->tx_lock);
+@@ -560,7 +560,8 @@ void ath10k_htt_tx_free(struct ath10k_htt *htt)
+ 
+ void ath10k_htt_htc_tx_complete(struct ath10k *ar, struct sk_buff *skb)
+ {
+-	dev_kfree_skb_any(skb);
++	if (!(ar->hif.bus == ATH10K_BUS_SDIO))
++		dev_kfree_skb_any(skb);
+ }
+ 
+ void ath10k_htt_hif_tx_complete(struct ath10k *ar, struct sk_buff *skb)
+@@ -1216,6 +1217,7 @@ static int ath10k_htt_tx_hl(struct ath10k_htt *htt, enum ath10k_hw_txrx_mode txm
+ 	u8 tid = ath10k_htt_tx_get_tid(msdu, is_eth);
+ 	u8 flags0 = 0;
+ 	u16 flags1 = 0;
++	u16 msdu_id = 0;
+ 
+ 	data_len = msdu->len;
+ 
+@@ -1263,6 +1265,18 @@ static int ath10k_htt_tx_hl(struct ath10k_htt *htt, enum ath10k_hw_txrx_mode txm
+ 		}
+ 	}
+ 
++	if (ar->hif.bus == ATH10K_BUS_SDIO) {
++		flags1 |= HTT_DATA_TX_DESC_FLAGS1_POSTPONED;
++		spin_lock_bh(&htt->tx_lock);
++		res = ath10k_htt_tx_alloc_msdu_id(htt, msdu);
++		spin_unlock_bh(&htt->tx_lock);
++		if (res < 0) {
++			ath10k_err(ar, "msdu_id allocation failed %d\n", res);
++			goto out;
++		}
++		msdu_id = res;
++	}
++
+ 	skb_push(msdu, sizeof(*cmd_hdr));
+ 	skb_push(msdu, sizeof(*tx_desc));
+ 	cmd_hdr = (struct htt_cmd_hdr *)msdu->data;
+@@ -1272,7 +1286,7 @@ static int ath10k_htt_tx_hl(struct ath10k_htt *htt, enum ath10k_hw_txrx_mode txm
+ 	tx_desc->flags0 = flags0;
+ 	tx_desc->flags1 = __cpu_to_le16(flags1);
+ 	tx_desc->len = __cpu_to_le16(data_len);
+-	tx_desc->id = 0;
++	tx_desc->id = __cpu_to_le16(msdu_id);
+ 	tx_desc->frags_paddr = 0; /* always zero */
+ 	/* Initialize peer_id to INVALID_PEER because this is NOT
+ 	 * Reinjection path

--- a/projects/Amlogic_GX/patches/linux/0069-ath10k-wb396-reference-card-fix.patch
+++ b/projects/Amlogic_GX/patches/linux/0069-ath10k-wb396-reference-card-fix.patch
@@ -1,0 +1,35 @@
+From 679fabb83c6c35cd1df3d91892c7623105b64538 Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:12 +0100
+Subject: [PATCH] ath10k_sdio: wb396 reference card fix
+
+The QCA9377-3 WB396 sdio reference card does not get initialized
+due to the conflict in uart gpio pins. This fix is not required
+for other QCA9377 sdio cards.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index b2bbf4e4e4fb..9beaef809801 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -1862,8 +1862,15 @@ static int ath10k_init_uart(struct ath10k *ar)
+ 		return ret;
+ 	}
+ 
+-	if (!uart_print)
++	if (!uart_print) {
++		/* Hack: override dbg TX pin to avoid side effects of default
++		 * GPIO_6 in QCA9377 WB396 reference card
++		 */
++		if (ar->hif.bus == ATH10K_BUS_SDIO)
++			ath10k_bmi_write32(ar, hi_dbg_uart_txpin,
++					   ar->hw_params.uart_pin);
+ 		return 0;
++	}
+ 
+ 	ret = ath10k_bmi_write32(ar, hi_dbg_uart_txpin, ar->hw_params.uart_pin);
+ 	if (ret) {

--- a/projects/Amlogic_GX/patches/linux/0070-ath10k-DMA-bounce-buffers-for-read-write.patch
+++ b/projects/Amlogic_GX/patches/linux/0070-ath10k-DMA-bounce-buffers-for-read-write.patch
@@ -1,0 +1,183 @@
+From ed1c1d060188824f1f5dcb285b2d3cc5210b89e6 Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:12 +0100
+Subject: [PATCH] ath10k_sdio: DMA bounce buffers for read write
+
+Some SD host controllers still need bounce buffers for SDIO data
+transfers. While the transfers worked fine on x86 platforms,
+this is found to be required for i.MX6 based systems.
+
+Changes are similar to and derived from the ath6kl sdio driver.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/sdio.c | 59 ++++++++++++++++++++++++++++++++--
+ drivers/net/wireless/ath/ath10k/sdio.h |  5 +++
+ 2 files changed, 61 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.c b/drivers/net/wireless/ath/ath10k/sdio.c
+index f0f1b2b8c7a7..584a4cb8282d 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.c
++++ b/drivers/net/wireless/ath/ath10k/sdio.c
+@@ -34,8 +34,20 @@
+ #include "trace.h"
+ #include "sdio.h"
+ 
++#define ATH10K_SDIO_DMA_BUF_SIZE	(32 * 1024)
++
+ /* inlined helper functions */
+ 
++/* Macro to check if DMA buffer is WORD-aligned and DMA-able.
++ * Most host controllers assume the buffer is DMA'able and will
++ * bug-check otherwise (i.e. buffers on the stack). virt_addr_valid
++ * check fails on stack memory.
++ */
++static inline bool buf_needs_bounce(const u8 *buf)
++{
++	return ((unsigned long)buf & 0x3) || !virt_addr_valid(buf);
++}
++
+ static inline int ath10k_sdio_calc_txrx_padded_len(struct ath10k_sdio *ar_sdio,
+ 						   size_t len)
+ {
+@@ -303,15 +315,29 @@ static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf, size_t len)
+ {
+ 	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+ 	struct sdio_func *func = ar_sdio->func;
++	bool bounced = false;
++	u8 *tbuf = NULL;
+ 	int ret;
+ 
++	if (buf_needs_bounce(buf)) {
++		if (!ar_sdio->dma_buffer)
++			return -ENOMEM;
++		mutex_lock(&ar_sdio->dma_buffer_mutex);
++		tbuf = ar_sdio->dma_buffer;
++		bounced = true;
++	} else {
++		tbuf = buf;
++	}
++
+ 	sdio_claim_host(func);
+ 
+-	ret = sdio_memcpy_fromio(func, buf, addr, len);
++	ret = sdio_memcpy_fromio(func, tbuf, addr, len);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to read from address 0x%x: %d\n",
+ 			    addr, ret);
+ 		goto out;
++	} else if (bounced) {
++		memcpy(buf, tbuf, len);
+ 	}
+ 
+ 	ath10k_dbg(ar, ATH10K_DBG_SDIO, "sdio read addr 0x%x buf 0x%p len %zu\n",
+@@ -320,6 +346,8 @@ static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf, size_t len)
+ 
+ out:
+ 	sdio_release_host(func);
++	if (bounced)
++		mutex_unlock(&ar_sdio->dma_buffer_mutex);
+ 
+ 	return ret;
+ }
+@@ -328,14 +356,27 @@ static int ath10k_sdio_write(struct ath10k *ar, u32 addr, const void *buf, size_
+ {
+ 	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+ 	struct sdio_func *func = ar_sdio->func;
++	bool bounced = false;
++	u8 *tbuf = NULL;
+ 	int ret;
+ 
++	if (buf_needs_bounce(buf)) {
++		if (!ar_sdio->dma_buffer)
++			return -ENOMEM;
++		mutex_lock(&ar_sdio->dma_buffer_mutex);
++		tbuf = ar_sdio->dma_buffer;
++		memcpy(tbuf, buf, len);
++		bounced = true;
++	} else {
++		tbuf = (u8 *)buf;
++	}
++
+ 	sdio_claim_host(func);
+ 
+ 	/* For some reason toio() doesn't have const for the buffer, need
+ 	 * an ugly hack to workaround that.
+ 	 */
+-	ret = sdio_memcpy_toio(func, addr, (void *)buf, len);
++	ret = sdio_memcpy_toio(func, addr, (void *)tbuf, len);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to write to address 0x%x: %d\n",
+ 			    addr, ret);
+@@ -348,6 +389,8 @@ static int ath10k_sdio_write(struct ath10k *ar, u32 addr, const void *buf, size_
+ 
+ out:
+ 	sdio_release_host(func);
++	if (bounced)
++		mutex_unlock(&ar_sdio->dma_buffer_mutex);
+ 
+ 	return ret;
+ }
+@@ -1979,6 +2022,12 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 		goto err_free_en_reg;
+ 	}
+ 
++	ar_sdio->dma_buffer = kzalloc(ATH10K_SDIO_DMA_BUF_SIZE, GFP_KERNEL);
++	if (!ar_sdio->dma_buffer) {
++		ret = -ENOMEM;
++		goto err_free_bmi_buf;
++	}
++
+ 	ar_sdio->func = func;
+ 	sdio_set_drvdata(func, ar_sdio);
+ 
+@@ -1988,6 +2037,7 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 	spin_lock_init(&ar_sdio->lock);
+ 	spin_lock_init(&ar_sdio->wr_async_lock);
+ 	mutex_init(&ar_sdio->irq_data.mtx);
++	mutex_init(&ar_sdio->dma_buffer_mutex);
+ 
+ 	INIT_LIST_HEAD(&ar_sdio->bus_req_freeq);
+ 	INIT_LIST_HEAD(&ar_sdio->wr_asyncq);
+@@ -1996,7 +2046,7 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 	ar_sdio->workqueue = create_singlethread_workqueue("ath10k_sdio_wq");
+ 	if (!ar_sdio->workqueue) {
+ 		ret = -ENOMEM;
+-		goto err_free_bmi_buf;
++		goto err_dma;
+ 	}
+ 
+ 	for (i = 0; i < ATH10K_SDIO_BUS_REQUEST_MAX_NUM; i++)
+@@ -2042,6 +2092,8 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 
+ err_free_wq:
+ 	destroy_workqueue(ar_sdio->workqueue);
++err_dma:
++	kfree(ar_sdio->dma_buffer);
+ err_free_bmi_buf:
+ 	kfree(ar_sdio->bmi_buf);
+ err_free_en_reg:
+@@ -2067,6 +2119,7 @@ static void ath10k_sdio_remove(struct sdio_func *func)
+ 	cancel_work_sync(&ar_sdio->wr_async_work);
+ 	ath10k_core_unregister(ar);
+ 	ath10k_core_destroy(ar);
++	kfree(ar_sdio->dma_buffer);
+ }
+ 
+ static const struct sdio_device_id ath10k_sdio_devices[] = {
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.h b/drivers/net/wireless/ath/ath10k/sdio.h
+index 4ff7b545293b..718b8b71c818 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.h
++++ b/drivers/net/wireless/ath/ath10k/sdio.h
+@@ -207,6 +207,11 @@ struct ath10k_sdio {
+ 	struct ath10k *ar;
+ 	struct ath10k_sdio_irq_data irq_data;
+ 
++	u8 *dma_buffer;
++
++	/* protects access to dma_buffer */
++	struct mutex dma_buffer_mutex;
++
+ 	/* temporary buffer for BMI requests */
+ 	u8 *bmi_buf;
+ 

--- a/projects/Amlogic_GX/patches/linux/0071-ath10k-reduce-transmit-msdu-count.patch
+++ b/projects/Amlogic_GX/patches/linux/0071-ath10k-reduce-transmit-msdu-count.patch
@@ -1,0 +1,59 @@
+From c57d0e8c511334a0129e25b78492c93222f5fd9b Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:13 +0100
+Subject: [PATCH] ath10k_sdio: reduce transmit msdu count
+
+Reduce the transmit MSDU count for SDIO, to match with the descriptors
+as used by the firmware. This also acts as a high watermark level for
+transmit. Too many packets to the firmware results in transmit overflow
+interrupt.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c    | 6 +++++-
+ drivers/net/wireless/ath/ath10k/hw.h      | 1 +
+ drivers/net/wireless/ath/ath10k/wmi-tlv.c | 2 +-
+ 3 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 9beaef809801..18a6163e2647 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -2113,7 +2113,11 @@ static int ath10k_core_init_firmware_features(struct ath10k *ar)
+ 		ar->max_num_stations = TARGET_TLV_NUM_STATIONS;
+ 		ar->max_num_vdevs = TARGET_TLV_NUM_VDEVS;
+ 		ar->max_num_tdls_vdevs = TARGET_TLV_NUM_TDLS_VDEVS;
+-		ar->htt.max_num_pending_tx = TARGET_TLV_NUM_MSDU_DESC;
++		if (ar->hif.bus == ATH10K_BUS_SDIO)
++			ar->htt.max_num_pending_tx =
++				TARGET_TLV_NUM_MSDU_DESC_HL;
++		else
++			ar->htt.max_num_pending_tx = TARGET_TLV_NUM_MSDU_DESC;
+ 		ar->wow.max_num_patterns = TARGET_TLV_NUM_WOW_PATTERNS;
+ 		ar->fw_stats_req_mask = WMI_STAT_PDEV | WMI_STAT_VDEV |
+ 			WMI_STAT_PEER;
+diff --git a/drivers/net/wireless/ath/ath10k/hw.h b/drivers/net/wireless/ath/ath10k/hw.h
+index 96f80932a644..0d800367d804 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -694,6 +694,7 @@ ath10k_rx_desc_get_l3_pad_bytes(struct ath10k_hw_params *hw,
+ #define TARGET_TLV_NUM_TDLS_VDEVS		1
+ #define TARGET_TLV_NUM_TIDS			((TARGET_TLV_NUM_PEERS) * 2)
+ #define TARGET_TLV_NUM_MSDU_DESC		(1024 + 32)
++#define TARGET_TLV_NUM_MSDU_DESC_HL		64
+ #define TARGET_TLV_NUM_WOW_PATTERNS		22
+ 
+ /* Target specific defines for WMI-HL-1.0 firmware */
+diff --git a/drivers/net/wireless/ath/ath10k/wmi-tlv.c b/drivers/net/wireless/ath/ath10k/wmi-tlv.c
+index 6b58bcbb36c1..7b2159fdb3f5 100644
+--- a/drivers/net/wireless/ath/ath10k/wmi-tlv.c
++++ b/drivers/net/wireless/ath/ath10k/wmi-tlv.c
+@@ -1473,7 +1473,7 @@ static struct sk_buff *ath10k_wmi_tlv_op_gen_init(struct ath10k *ar)
+ 	cfg->rx_skip_defrag_timeout_dup_detection_check = __cpu_to_le32(0);
+ 	cfg->vow_config = __cpu_to_le32(0);
+ 	cfg->gtk_offload_max_vdev = __cpu_to_le32(2);
+-	cfg->num_msdu_desc = __cpu_to_le32(TARGET_TLV_NUM_MSDU_DESC);
++	cfg->num_msdu_desc = __cpu_to_le32(ar->htt.max_num_pending_tx);
+ 	cfg->max_frag_entries = __cpu_to_le32(2);
+ 	cfg->num_tdls_vdevs = __cpu_to_le32(TARGET_TLV_NUM_TDLS_VDEVS);
+ 	cfg->num_tdls_conn_table_entries = __cpu_to_le32(0x20);

--- a/projects/Amlogic_GX/patches/linux/0072-ath10k-use-clean-packet-headers.patch
+++ b/projects/Amlogic_GX/patches/linux/0072-ath10k-use-clean-packet-headers.patch
@@ -1,0 +1,51 @@
+From 7834a294c7299a6bb4f6911174a5b83bdff7ad75 Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:14 +0100
+Subject: [PATCH] ath10k_sdio: use clean packet headers
+
+HTC header carries junk values that may be interpreted by the firmware
+differently. Enable credit update only if flow control is enabled for
+the corresponding endpoint.
+
+PLL clock setting sequence does not mask the PLL_CONTROL
+register value. Side effect of not masking the values is not known as
+the entire pll clock setting sequence is undocumented.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/htc.c | 4 +++-
+ drivers/net/wireless/ath/ath10k/hw.c  | 2 ++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htc.c b/drivers/net/wireless/ath/ath10k/htc.c
+index dd69345f911e..ea8e3eff35dc 100644
+--- a/drivers/net/wireless/ath/ath10k/htc.c
++++ b/drivers/net/wireless/ath/ath10k/htc.c
+@@ -84,11 +84,13 @@ static void ath10k_htc_prepare_tx_skb(struct ath10k_htc_ep *ep,
+ 	struct ath10k_htc_hdr *hdr;
+ 
+ 	hdr = (struct ath10k_htc_hdr *)skb->data;
++	memset(hdr, 0, sizeof(struct ath10k_htc_hdr));
+ 
+ 	hdr->eid = ep->eid;
+ 	hdr->len = __cpu_to_le16(skb->len - sizeof(*hdr));
+ 	hdr->flags = 0;
+-	hdr->flags |= ATH10K_HTC_FLAG_NEED_CREDIT_UPDATE;
++	if (ep->tx_credit_flow_enabled)
++		hdr->flags |= ATH10K_HTC_FLAG_NEED_CREDIT_UPDATE;
+ 
+ 	spin_lock_bh(&ep->htc->tx_lock);
+ 	hdr->seq_no = ep->seq_no++;
+diff --git a/drivers/net/wireless/ath/ath10k/hw.c b/drivers/net/wireless/ath/ath10k/hw.c
+index 497ac33e0fbf..46110ff4efe5 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.c
++++ b/drivers/net/wireless/ath/ath10k/hw.c
+@@ -817,6 +817,8 @@ static int ath10k_hw_qca6174_enable_pll_clock(struct ath10k *ar)
+ 	if (ret)
+ 		return -EINVAL;
+ 
++	reg_val &= ~(WLAN_PLL_CONTROL_REFDIV_MASK | WLAN_PLL_CONTROL_DIV_MASK |
++		     WLAN_PLL_CONTROL_NOPWD_MASK);
+ 	reg_val |= (SM(hw_clk->refdiv, WLAN_PLL_CONTROL_REFDIV) |
+ 		    SM(hw_clk->div, WLAN_PLL_CONTROL_DIV) |
+ 		    SM(1, WLAN_PLL_CONTROL_NOPWD));

--- a/projects/Amlogic_GX/patches/linux/0073-ath10k-high-latency-fixes-for-beacon-buffer.patch
+++ b/projects/Amlogic_GX/patches/linux/0073-ath10k-high-latency-fixes-for-beacon-buffer.patch
@@ -1,0 +1,71 @@
+From d4e80224d4bb9551e528e1fc7637d6b62bdc4436 Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:14 +0100
+Subject: [PATCH] ath10k_sdio: high latency fixes for beacon buffer
+
+Beacon buffer for high latency devices does not use dma. other similar
+buffer allocation methods in the driver have already been modified for
+high latency path. Fix the beacon buffer allocation left out in the
+earlier high latency changes.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/mac.c | 31 +++++++++++++++++++++++--------
+ 1 file changed, 23 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/mac.c b/drivers/net/wireless/ath/ath10k/mac.c
+index dcf6574f217c..17e99d776d44 100644
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -944,8 +944,12 @@ static void ath10k_mac_vif_beacon_cleanup(struct ath10k_vif *arvif)
+ 	ath10k_mac_vif_beacon_free(arvif);
+ 
+ 	if (arvif->beacon_buf) {
+-		dma_free_coherent(ar->dev, IEEE80211_MAX_FRAME_LEN,
+-				  arvif->beacon_buf, arvif->beacon_paddr);
++		if (ar->is_high_latency)
++			kfree(arvif->beacon_buf);
++		else
++			dma_free_coherent(ar->dev, IEEE80211_MAX_FRAME_LEN,
++					  arvif->beacon_buf,
++					  arvif->beacon_paddr);
+ 		arvif->beacon_buf = NULL;
+ 	}
+ }
+@@ -5051,10 +5055,17 @@ static int ath10k_add_interface(struct ieee80211_hw *hw,
+ 	if (vif->type == NL80211_IFTYPE_ADHOC ||
+ 	    vif->type == NL80211_IFTYPE_MESH_POINT ||
+ 	    vif->type == NL80211_IFTYPE_AP) {
+-		arvif->beacon_buf = dma_zalloc_coherent(ar->dev,
+-							IEEE80211_MAX_FRAME_LEN,
+-							&arvif->beacon_paddr,
+-							GFP_ATOMIC);
++		if (ar->is_high_latency) {
++			arvif->beacon_buf = kmalloc(IEEE80211_MAX_FRAME_LEN,
++						    GFP_KERNEL);
++			arvif->beacon_paddr = (dma_addr_t)arvif->beacon_buf;
++		} else {
++			arvif->beacon_buf =
++				dma_zalloc_coherent(ar->dev,
++						    IEEE80211_MAX_FRAME_LEN,
++						    &arvif->beacon_paddr,
++						    GFP_ATOMIC);
++		}
+ 		if (!arvif->beacon_buf) {
+ 			ret = -ENOMEM;
+ 			ath10k_warn(ar, "failed to allocate beacon buffer: %d\n",
+@@ -5243,8 +5254,12 @@ static int ath10k_add_interface(struct ieee80211_hw *hw,
+ 
+ err:
+ 	if (arvif->beacon_buf) {
+-		dma_free_coherent(ar->dev, IEEE80211_MAX_FRAME_LEN,
+-				  arvif->beacon_buf, arvif->beacon_paddr);
++		if (ar->is_high_latency)
++			kfree(arvif->beacon_buf);
++		else
++			dma_free_coherent(ar->dev, IEEE80211_MAX_FRAME_LEN,
++					  arvif->beacon_buf,
++					  arvif->beacon_paddr);
+ 		arvif->beacon_buf = NULL;
+ 	}
+ 

--- a/projects/Amlogic_GX/patches/linux/0074-ath10k-fix-rssi-indication.patch
+++ b/projects/Amlogic_GX/patches/linux/0074-ath10k-fix-rssi-indication.patch
@@ -1,0 +1,38 @@
+From 26b7b9517a07ecae18d8bcb23d399b1c3bfbc670 Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:15 +0100
+Subject: [PATCH] ath10k_sdio: fix rssi indication
+
+Receive descriptor of sdio device does not include the rssi. notify
+mac80211 accordingly. Without the fix, the rssi value indicated by
+iw changes between the actual value and -95.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/htt_rx.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htt_rx.c b/drivers/net/wireless/ath/ath10k/htt_rx.c
+index 3f8d22de548d..246149bf000e 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_rx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_rx.c
+@@ -1859,9 +1859,16 @@ static bool ath10k_htt_rx_proc_rx_ind_hl(struct ath10k_htt *htt,
+ 	hdr = (struct ieee80211_hdr *)skb->data;
+ 	rx_status = IEEE80211_SKB_RXCB(skb);
+ 	rx_status->chains |= BIT(0);
+-	rx_status->signal = ATH10K_DEFAULT_NOISE_FLOOR +
+-			    rx->ppdu.combined_rssi;
+-	rx_status->flag &= ~RX_FLAG_NO_SIGNAL_VAL;
++
++	if (ar->hif.bus == ATH10K_BUS_SDIO) {
++		/* SDIO firmware does not provide signal */
++		rx_status->signal = 0;
++		rx_status->flag |= RX_FLAG_NO_SIGNAL_VAL;
++	} else {
++		rx_status->signal = ATH10K_DEFAULT_NOISE_FLOOR +
++			rx->ppdu.combined_rssi;
++		rx_status->flag &= ~RX_FLAG_NO_SIGNAL_VAL;
++	}
+ 
+ 	spin_lock_bh(&ar->data_lock);
+ 	ch = ar->scan_channel;

--- a/projects/Amlogic_GX/patches/linux/0075-ath10k-common-read-write.patch
+++ b/projects/Amlogic_GX/patches/linux/0075-ath10k-common-read-write.patch
@@ -1,0 +1,372 @@
+From df8f8559b7ae01cc08952eaac22457891fdbd8f4 Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:16 +0100
+Subject: [PATCH] ath10k_sdio: common read write
+
+convert different read write functions in sdio hif to bring it under a
+single read-write path. This helps in having a common dma bounce buffer
+implementation. Also helps in address modification that is required
+specific to change in certain mbox addresses of sdio_write.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/sdio.c | 131 ++++++++++++++++-----------------
+ 1 file changed, 64 insertions(+), 67 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.c b/drivers/net/wireless/ath/ath10k/sdio.c
+index 584a4cb8282d..cc2cacbda7aa 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.c
++++ b/drivers/net/wireless/ath/ath10k/sdio.c
+@@ -36,6 +36,11 @@
+ 
+ #define ATH10K_SDIO_DMA_BUF_SIZE	(32 * 1024)
+ 
++static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf,
++			    u32 len, bool incr);
++static int ath10k_sdio_write(struct ath10k *ar, u32 addr, const void *buf,
++			     u32 len, bool incr);
++
+ /* inlined helper functions */
+ 
+ /* Macro to check if DMA buffer is WORD-aligned and DMA-able.
+@@ -152,6 +157,7 @@ static int ath10k_sdio_config(struct ath10k *ar)
+ 	struct sdio_func *func = ar_sdio->func;
+ 	unsigned char byte, asyncintdelay = 2;
+ 	int ret;
++	u32 addr;
+ 
+ 	ath10k_dbg(ar, ATH10K_DBG_BOOT, "sdio configuration\n");
+ 
+@@ -180,9 +186,8 @@ static int ath10k_sdio_config(struct ath10k *ar)
+ 		 CCCR_SDIO_DRIVER_STRENGTH_ENABLE_C |
+ 		 CCCR_SDIO_DRIVER_STRENGTH_ENABLE_D);
+ 
+-	ret = ath10k_sdio_func0_cmd52_wr_byte(func->card,
+-					      CCCR_SDIO_DRIVER_STRENGTH_ENABLE_ADDR,
+-					      byte);
++	addr = CCCR_SDIO_DRIVER_STRENGTH_ENABLE_ADDR,
++	ret = ath10k_sdio_func0_cmd52_wr_byte(func->card, addr, byte);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to enable driver strength: %d\n", ret);
+ 		goto out;
+@@ -233,13 +238,16 @@ static int ath10k_sdio_config(struct ath10k *ar)
+ 
+ static int ath10k_sdio_write32(struct ath10k *ar, u32 addr, u32 val)
+ {
+-	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+-	struct sdio_func *func = ar_sdio->func;
++	__le32 *buf;
+ 	int ret;
+ 
+-	sdio_claim_host(func);
++	buf = kzalloc(sizeof(*buf), GFP_KERNEL);
++	if (!buf)
++		return -ENOMEM;
+ 
+-	sdio_writel(func, val, addr, &ret);
++	*buf = cpu_to_le32(val);
++
++	ret = ath10k_sdio_write(ar, addr, &val, sizeof(val), true);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to write 0x%x to address 0x%x: %d\n",
+ 			    val, addr, ret);
+@@ -250,15 +258,13 @@ static int ath10k_sdio_write32(struct ath10k *ar, u32 addr, u32 val)
+ 		   addr, val);
+ 
+ out:
+-	sdio_release_host(func);
++	kfree(buf);
+ 
+ 	return ret;
+ }
+ 
+ static int ath10k_sdio_writesb32(struct ath10k *ar, u32 addr, u32 val)
+ {
+-	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+-	struct sdio_func *func = ar_sdio->func;
+ 	__le32 *buf;
+ 	int ret;
+ 
+@@ -268,9 +274,7 @@ static int ath10k_sdio_writesb32(struct ath10k *ar, u32 addr, u32 val)
+ 
+ 	*buf = cpu_to_le32(val);
+ 
+-	sdio_claim_host(func);
+-
+-	ret = sdio_writesb(func, addr, buf, sizeof(*buf));
++	ret = ath10k_sdio_write(ar, addr, buf, sizeof(*buf), false);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to write value 0x%x to fixed sb address 0x%x: %d\n",
+ 			    val, addr, ret);
+@@ -281,8 +285,6 @@ static int ath10k_sdio_writesb32(struct ath10k *ar, u32 addr, u32 val)
+ 		   addr, val);
+ 
+ out:
+-	sdio_release_host(func);
+-
+ 	kfree(buf);
+ 
+ 	return ret;
+@@ -290,28 +292,33 @@ static int ath10k_sdio_writesb32(struct ath10k *ar, u32 addr, u32 val)
+ 
+ static int ath10k_sdio_read32(struct ath10k *ar, u32 addr, u32 *val)
+ {
+-	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+-	struct sdio_func *func = ar_sdio->func;
++	__le32 *buf;
+ 	int ret;
+ 
+-	sdio_claim_host(func);
+-	*val = sdio_readl(func, addr, &ret);
++	buf = kzalloc(sizeof(*buf), GFP_KERNEL);
++	if (!buf)
++		return -ENOMEM;
++
++	ret = ath10k_sdio_read(ar, addr, buf, sizeof(*val), true);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to read from address 0x%x: %d\n",
+ 			    addr, ret);
+ 		goto out;
+ 	}
+ 
++	*val = le32_to_cpu(*buf);
++
+ 	ath10k_dbg(ar, ATH10K_DBG_SDIO, "sdio read32 addr 0x%x val 0x%x\n",
+ 		   addr, *val);
+ 
+ out:
+-	sdio_release_host(func);
++	kfree(buf);
+ 
+ 	return ret;
+ }
+ 
+-static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf, size_t len)
++static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf,
++			    size_t len, bool incr)
+ {
+ 	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+ 	struct sdio_func *func = ar_sdio->func;
+@@ -330,8 +337,12 @@ static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf, size_t len)
+ 	}
+ 
+ 	sdio_claim_host(func);
++	if (incr)
++		ret = sdio_memcpy_fromio(func, tbuf, addr, len);
++	else
++		ret = sdio_readsb(func, tbuf, addr, len);
++	sdio_release_host(func);
+ 
+-	ret = sdio_memcpy_fromio(func, tbuf, addr, len);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to read from address 0x%x: %d\n",
+ 			    addr, ret);
+@@ -345,14 +356,14 @@ static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf, size_t len)
+ 	ath10k_dbg_dump(ar, ATH10K_DBG_SDIO_DUMP, NULL, "sdio read ", buf, len);
+ 
+ out:
+-	sdio_release_host(func);
+ 	if (bounced)
+ 		mutex_unlock(&ar_sdio->dma_buffer_mutex);
+ 
+ 	return ret;
+ }
+ 
+-static int ath10k_sdio_write(struct ath10k *ar, u32 addr, const void *buf, size_t len)
++static int ath10k_sdio_write(struct ath10k *ar, u32 addr, const void *buf,
++			     size_t len, bool incr)
+ {
+ 	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+ 	struct sdio_func *func = ar_sdio->func;
+@@ -371,12 +382,18 @@ static int ath10k_sdio_write(struct ath10k *ar, u32 addr, const void *buf, size_
+ 		tbuf = (u8 *)buf;
+ 	}
+ 
++	if (addr == ar_sdio->mbox_info.htc_addr)
++		addr += (ATH10K_HIF_MBOX_WIDTH - len);
++
+ 	sdio_claim_host(func);
+ 
+ 	/* For some reason toio() doesn't have const for the buffer, need
+ 	 * an ugly hack to workaround that.
+ 	 */
+-	ret = sdio_memcpy_toio(func, addr, (void *)tbuf, len);
++	if (incr)
++		ret = sdio_memcpy_toio(func, addr, (void *)tbuf, len);
++	else
++		ret = sdio_writesb(func, addr, tbuf, len);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to write to address 0x%x: %d\n",
+ 			    addr, ret);
+@@ -389,39 +406,13 @@ static int ath10k_sdio_write(struct ath10k *ar, u32 addr, const void *buf, size_
+ 
+ out:
+ 	sdio_release_host(func);
++
+ 	if (bounced)
+ 		mutex_unlock(&ar_sdio->dma_buffer_mutex);
+ 
+ 	return ret;
+ }
+ 
+-static int ath10k_sdio_readsb(struct ath10k *ar, u32 addr, void *buf, size_t len)
+-{
+-	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+-	struct sdio_func *func = ar_sdio->func;
+-	int ret;
+-
+-	sdio_claim_host(func);
+-
+-	len = round_down(len, ar_sdio->mbox_info.block_size);
+-
+-	ret = sdio_readsb(func, buf, addr, len);
+-	if (ret) {
+-		ath10k_warn(ar, "failed to read from fixed (sb) address 0x%x: %d\n",
+-			    addr, ret);
+-		goto out;
+-	}
+-
+-	ath10k_dbg(ar, ATH10K_DBG_SDIO, "sdio readsb addr 0x%x buf 0x%p len %zu\n",
+-		   addr, buf, len);
+-	ath10k_dbg_dump(ar, ATH10K_DBG_SDIO_DUMP, NULL, "sdio readsb ", buf, len);
+-
+-out:
+-	sdio_release_host(func);
+-
+-	return ret;
+-}
+-
+ /* HIF mbox functions */
+ 
+ static int ath10k_sdio_mbox_rx_process_packet(struct ath10k *ar,
+@@ -671,8 +662,8 @@ static int ath10k_sdio_mbox_rx_packet(struct ath10k *ar,
+ 	struct sk_buff *skb = pkt->skb;
+ 	int ret;
+ 
+-	ret = ath10k_sdio_readsb(ar, ar_sdio->mbox_info.htc_addr,
+-				 skb->data, pkt->alloc_len);
++	ret = ath10k_sdio_read(ar, ar_sdio->mbox_info.htc_addr,
++			       skb->data, pkt->alloc_len, false);
+ 	pkt->status = ret;
+ 	if (!ret)
+ 		skb_put(skb, pkt->act_len);
+@@ -932,7 +923,7 @@ static int ath10k_sdio_mbox_read_int_status(struct ath10k *ar,
+ 	 * registers and the lookahead registers.
+ 	 */
+ 	ret = ath10k_sdio_read(ar, MBOX_HOST_INT_STATUS_ADDRESS,
+-			       irq_proc_reg, sizeof(*irq_proc_reg));
++			       irq_proc_reg, sizeof(*irq_proc_reg), true);
+ 	if (ret)
+ 		goto out;
+ 
+@@ -1177,7 +1168,8 @@ static int ath10k_sdio_bmi_exchange_msg(struct ath10k *ar,
+ 		addr = ar_sdio->mbox_info.htc_addr;
+ 
+ 		memcpy(ar_sdio->bmi_buf, req, req_len);
+-		ret = ath10k_sdio_write(ar, addr, ar_sdio->bmi_buf, req_len);
++		ret = ath10k_sdio_write(ar, addr, ar_sdio->bmi_buf, req_len,
++					true);
+ 		if (ret) {
+ 			ath10k_warn(ar,
+ 				    "unable to send the bmi data to the device: %d\n",
+@@ -1241,7 +1233,7 @@ static int ath10k_sdio_bmi_exchange_msg(struct ath10k *ar,
+ 
+ 	/* We always read from the start of the mbox address */
+ 	addr = ar_sdio->mbox_info.htc_addr;
+-	ret = ath10k_sdio_read(ar, addr, ar_sdio->bmi_buf, *resp_len);
++	ret = ath10k_sdio_read(ar, addr, ar_sdio->bmi_buf, *resp_len, true);
+ 	if (ret) {
+ 		ath10k_warn(ar,
+ 			    "unable to read the bmi data from the device: %d\n",
+@@ -1298,7 +1290,7 @@ static void __ath10k_sdio_write_async(struct ath10k *ar,
+ 	int ret;
+ 
+ 	skb = req->skb;
+-	ret = ath10k_sdio_write(ar, req->address, skb->data, skb->len);
++	ret = ath10k_sdio_write(ar, req->address, skb->data, skb->len, true);
+ 	if (ret)
+ 		ath10k_warn(ar, "failed to write skb to 0x%x asynchronously: %d",
+ 			    req->address, ret);
+@@ -1405,7 +1397,7 @@ static int ath10k_sdio_hif_disable_intrs(struct ath10k *ar)
+ 
+ 	memset(regs, 0, sizeof(*regs));
+ 	ret = ath10k_sdio_write(ar, MBOX_INT_STATUS_ENABLE_ADDRESS,
+-				&regs->int_status_en, sizeof(*regs));
++				&regs->int_status_en, sizeof(*regs), true);
+ 	if (ret)
+ 		ath10k_warn(ar, "unable to disable sdio interrupts: %d\n", ret);
+ 
+@@ -1540,7 +1532,7 @@ static int ath10k_sdio_hif_enable_intrs(struct ath10k *ar)
+ 			   ATH10K_SDIO_TARGET_DEBUG_INTR_MASK);
+ 
+ 	ret = ath10k_sdio_write(ar, MBOX_INT_STATUS_ENABLE_ADDRESS,
+-				&regs->int_status_en, sizeof(*regs));
++				&regs->int_status_en, sizeof(*regs), true);
+ 	if (ret)
+ 		ath10k_warn(ar,
+ 			    "failed to update mbox interrupt status register : %d\n",
+@@ -1555,7 +1547,8 @@ static int ath10k_sdio_hif_set_mbox_sleep(struct ath10k *ar, bool enable_sleep)
+ 	u32 val;
+ 	int ret;
+ 
+-	ret = ath10k_sdio_read32(ar, ATH10K_FIFO_TIMEOUT_AND_CHIP_CONTROL, &val);
++	ret = ath10k_sdio_read32(ar, ATH10K_FIFO_TIMEOUT_AND_CHIP_CONTROL,
++				 &val);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to read fifo/chip control register: %d\n",
+ 			    ret);
+@@ -1567,7 +1560,8 @@ static int ath10k_sdio_hif_set_mbox_sleep(struct ath10k *ar, bool enable_sleep)
+ 	else
+ 		val |= ATH10K_FIFO_TIMEOUT_AND_CHIP_CONTROL_DISABLE_SLEEP_ON;
+ 
+-	ret = ath10k_sdio_write32(ar, ATH10K_FIFO_TIMEOUT_AND_CHIP_CONTROL, val);
++	ret = ath10k_sdio_write32(ar, ATH10K_FIFO_TIMEOUT_AND_CHIP_CONTROL,
++				  val);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to write to FIFO_TIMEOUT_AND_CHIP_CONTROL: %d",
+ 			    ret);
+@@ -1587,12 +1581,14 @@ static int ath10k_sdio_hif_diag_read(struct ath10k *ar, u32 address, void *buf,
+ 	/* set window register to start read cycle */
+ 	ret = ath10k_sdio_write32(ar, MBOX_WINDOW_READ_ADDR_ADDRESS, address);
+ 	if (ret) {
+-		ath10k_warn(ar, "failed to set mbox window read address: %d", ret);
++		ath10k_warn(ar, "failed to set mbox window read address: %d",
++			    ret);
+ 		return ret;
+ 	}
+ 
+ 	/* read the data */
+-	ret = ath10k_sdio_read(ar, MBOX_WINDOW_DATA_ADDRESS, buf, buf_len);
++	ret = ath10k_sdio_read(ar, MBOX_WINDOW_DATA_ADDRESS, buf, buf_len,
++			       true);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to read from mbox window data address: %d\n",
+ 			    ret);
+@@ -1630,7 +1626,8 @@ static int ath10k_sdio_hif_diag_write_mem(struct ath10k *ar, u32 address,
+ 	int ret;
+ 
+ 	/* set write data */
+-	ret = ath10k_sdio_write(ar, MBOX_WINDOW_DATA_ADDRESS, data, nbytes);
++	ret = ath10k_sdio_write(ar, MBOX_WINDOW_DATA_ADDRESS, data, nbytes,
++				true);
+ 	if (ret) {
+ 		ath10k_warn(ar,
+ 			    "failed to write 0x%p to mbox window data address: %d\n",
+@@ -1641,7 +1638,7 @@ static int ath10k_sdio_hif_diag_write_mem(struct ath10k *ar, u32 address,
+ 	/* set window register, which starts the write cycle */
+ 	ret = ath10k_sdio_write32(ar, MBOX_WINDOW_WRITE_ADDR_ADDRESS, address);
+ 	if (ret) {
+-		ath10k_warn(ar, "failed to set mbox window write address: %d", ret);
++		ath10k_warn(ar, "failed to set mbox window register: %d", ret);
+ 		return ret;
+ 	}
+ 
+@@ -1691,7 +1688,7 @@ static int ath10k_sdio_hif_start(struct ath10k *ar)
+ 
+ 	ret = ath10k_sdio_hif_diag_read32(ar, addr, &val);
+ 	if (ret) {
+-		ath10k_warn(ar, "unable to read hi_acs_flags address: %d\n", ret);
++		ath10k_warn(ar, "unable to read hi_acs_flags : %d\n", ret);
+ 		return ret;
+ 	}
+ 

--- a/projects/Amlogic_GX/patches/linux/0076-ath10k-virtual-scatter-gather-for-receive.patch
+++ b/projects/Amlogic_GX/patches/linux/0076-ath10k-virtual-scatter-gather-for-receive.patch
@@ -1,0 +1,330 @@
+From 4223399ab836b3975bb8a3e27467ce1344db5be5 Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:16 +0100
+Subject: [PATCH] ath10k_sdio: virtual scatter gather for receive
+
+The existing implementation of initiating multiple sdio transfers for
+receive bundling is slowing down the receive speed. Combining the
+transfers using a scatter gather method would be ideal. This results in
+significant performance improvement.
+
+Since the sg implementation for sdio transfers are not reliable due to
+buffer start and size alignment, a virtual scatter gather implementation
+is used.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/htc.h  |   1 +
+ drivers/net/wireless/ath/ath10k/sdio.c | 122 ++++++++++++++++++++++++---------
+ drivers/net/wireless/ath/ath10k/sdio.h |   5 +-
+ 3 files changed, 93 insertions(+), 35 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/htc.h b/drivers/net/wireless/ath/ath10k/htc.h
+index a2f8814b3e53..d1856c0cff1a 100644
+--- a/drivers/net/wireless/ath/ath10k/htc.h
++++ b/drivers/net/wireless/ath/ath10k/htc.h
+@@ -58,6 +58,7 @@ enum ath10k_htc_tx_flags {
+ };
+ 
+ enum ath10k_htc_rx_flags {
++	ATH10K_HTC_FLAGS_RECV_1MORE_BLOCK = 0x01,
+ 	ATH10K_HTC_FLAG_TRAILER_PRESENT = 0x02,
+ 	ATH10K_HTC_FLAG_BUNDLE_MASK     = 0xF0
+ };
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.c b/drivers/net/wireless/ath/ath10k/sdio.c
+index cc2cacbda7aa..2c2632c25a38 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.c
++++ b/drivers/net/wireless/ath/ath10k/sdio.c
+@@ -35,6 +35,7 @@
+ #include "sdio.h"
+ 
+ #define ATH10K_SDIO_DMA_BUF_SIZE	(32 * 1024)
++#define ATH10K_SDIO_VSG_BUF_SIZE	(32 * 1024)
+ 
+ static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf,
+ 			    u32 len, bool incr);
+@@ -430,6 +431,7 @@ static int ath10k_sdio_mbox_rx_process_packet(struct ath10k *ar,
+ 	int ret;
+ 
+ 	payload_len = le16_to_cpu(htc_hdr->len);
++	skb->len = payload_len + sizeof(struct ath10k_htc_hdr);
+ 
+ 	if (trailer_present) {
+ 		trailer = skb->data + sizeof(*htc_hdr) +
+@@ -468,12 +470,13 @@ static int ath10k_sdio_mbox_rx_process_packets(struct ath10k *ar,
+ 	enum ath10k_htc_ep_id id;
+ 	int ret, i, *n_lookahead_local;
+ 	u32 *lookaheads_local;
++	int lookahd_idx = 0;
+ 
+ 	for (i = 0; i < ar_sdio->n_rx_pkts; i++) {
+ 		lookaheads_local = lookaheads;
+ 		n_lookahead_local = n_lookahead;
+ 
+-		id = ((struct ath10k_htc_hdr *)&lookaheads[i])->eid;
++		id = ((struct ath10k_htc_hdr *)&lookaheads[lookahd_idx++])->eid;
+ 
+ 		if (id >= ATH10K_HTC_EP_COUNT) {
+ 			ath10k_warn(ar, "invalid endpoint in look-ahead: %d\n",
+@@ -496,6 +499,7 @@ static int ath10k_sdio_mbox_rx_process_packets(struct ath10k *ar,
+ 			/* Only read lookahead's from RX trailers
+ 			 * for the last packet in a bundle.
+ 			 */
++			lookahd_idx--;
+ 			lookaheads_local = NULL;
+ 			n_lookahead_local = NULL;
+ 		}
+@@ -529,11 +533,11 @@ static int ath10k_sdio_mbox_rx_process_packets(struct ath10k *ar,
+ 	return ret;
+ }
+ 
+-static int ath10k_sdio_mbox_alloc_pkt_bundle(struct ath10k *ar,
+-					     struct ath10k_sdio_rx_data *rx_pkts,
+-					     struct ath10k_htc_hdr *htc_hdr,
+-					     size_t full_len, size_t act_len,
+-					     size_t *bndl_cnt)
++static int ath10k_sdio_mbox_alloc_bundle(struct ath10k *ar,
++					 struct ath10k_sdio_rx_data *rx_pkts,
++					 struct ath10k_htc_hdr *htc_hdr,
++					 size_t full_len, size_t act_len,
++					 size_t *bndl_cnt)
+ {
+ 	int ret, i;
+ 
+@@ -574,6 +578,7 @@ static int ath10k_sdio_mbox_rx_alloc(struct ath10k *ar,
+ 	size_t full_len, act_len;
+ 	bool last_in_bundle;
+ 	int ret, i;
++	int pkt_cnt = 0;
+ 
+ 	if (n_lookaheads > ATH10K_SDIO_MAX_RX_MSGS) {
+ 		ath10k_warn(ar,
+@@ -616,16 +621,22 @@ static int ath10k_sdio_mbox_rx_alloc(struct ath10k *ar,
+ 			 * optimally fetched as a full bundle.
+ 			 */
+ 			size_t bndl_cnt;
+-
+-			ret = ath10k_sdio_mbox_alloc_pkt_bundle(ar,
+-								&ar_sdio->rx_pkts[i],
+-								htc_hdr,
+-								full_len,
+-								act_len,
+-								&bndl_cnt);
+-
+-			n_lookaheads += bndl_cnt;
+-			i += bndl_cnt;
++			struct ath10k_sdio_rx_data *rx_pkts =
++				&ar_sdio->rx_pkts[pkt_cnt];
++
++			ret = ath10k_sdio_mbox_alloc_bundle(ar,
++							    rx_pkts,
++							    htc_hdr,
++							    full_len,
++							    act_len,
++							    &bndl_cnt);
++
++			if (ret) {
++				ath10k_warn(ar, "alloc_bundle error %d\n", ret);
++				goto err;
++			}
++
++			pkt_cnt += bndl_cnt;
+ 			/*Next buffer will be the last in the bundle */
+ 			last_in_bundle = true;
+ 		}
+@@ -634,14 +645,18 @@ static int ath10k_sdio_mbox_rx_alloc(struct ath10k *ar,
+ 		 * ATH10K_HTC_FLAG_BUNDLE_MASK flag set, all bundled
+ 		 * packet skb's have been allocated in the previous step.
+ 		 */
+-		ret = ath10k_sdio_mbox_alloc_rx_pkt(&ar_sdio->rx_pkts[i],
++		if (htc_hdr->flags & ATH10K_HTC_FLAGS_RECV_1MORE_BLOCK)
++			full_len += ATH10K_HIF_MBOX_BLOCK_SIZE;
++
++		ret = ath10k_sdio_mbox_alloc_rx_pkt(&ar_sdio->rx_pkts[pkt_cnt],
+ 						    act_len,
+ 						    full_len,
+ 						    last_in_bundle,
+ 						    last_in_bundle);
++		pkt_cnt++;
+ 	}
+ 
+-	ar_sdio->n_rx_pkts = i;
++	ar_sdio->n_rx_pkts = pkt_cnt;
+ 
+ 	return 0;
+ 
+@@ -655,41 +670,71 @@ static int ath10k_sdio_mbox_rx_alloc(struct ath10k *ar,
+ 	return ret;
+ }
+ 
+-static int ath10k_sdio_mbox_rx_packet(struct ath10k *ar,
+-				      struct ath10k_sdio_rx_data *pkt)
++static int ath10k_sdio_mbox_rx_fetch(struct ath10k *ar)
+ {
+ 	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
+-	struct sk_buff *skb = pkt->skb;
++	struct ath10k_sdio_rx_data *pkt = &ar_sdio->rx_pkts[0];
++	struct sk_buff *skb;
+ 	int ret;
+ 
++	skb = pkt->skb;
+ 	ret = ath10k_sdio_read(ar, ar_sdio->mbox_info.htc_addr,
+ 			       skb->data, pkt->alloc_len, false);
+-	pkt->status = ret;
+-	if (!ret)
++	if (ret) {
++		ar_sdio->n_rx_pkts = 0;
++		ath10k_sdio_mbox_free_rx_pkt(pkt);
++	} else {
++		pkt->status = ret;
+ 		skb_put(skb, pkt->act_len);
++	}
+ 
+ 	return ret;
+ }
+ 
+-static int ath10k_sdio_mbox_rx_fetch(struct ath10k *ar)
++static int ath10k_sdio_mbox_rx_fetch_bundle(struct ath10k *ar)
+ {
+ 	struct ath10k_sdio *ar_sdio = ath10k_sdio_priv(ar);
++	struct ath10k_sdio_rx_data *pkt;
+ 	int ret, i;
++	u32 pkt_offset, virt_pkt_len;
+ 
++	virt_pkt_len = 0;
+ 	for (i = 0; i < ar_sdio->n_rx_pkts; i++) {
+-		ret = ath10k_sdio_mbox_rx_packet(ar,
+-						 &ar_sdio->rx_pkts[i]);
+-		if (ret)
++		virt_pkt_len += ar_sdio->rx_pkts[i].alloc_len;
++	}
++	if (virt_pkt_len < ATH10K_SDIO_DMA_BUF_SIZE) {
++		ret = ath10k_sdio_read(ar, ar_sdio->mbox_info.htc_addr,
++				       ar_sdio->vsg_buffer, virt_pkt_len,
++				       false);
++		if (ret) {
++			i = 0;
+ 			goto err;
++		}
++	} else {
++		ath10k_err(ar, "size exceeding limit %d\n", virt_pkt_len);
++	}
++
++	pkt_offset = 0;
++	for (i = 0; i < ar_sdio->n_rx_pkts; i++) {
++		struct sk_buff *skb = ar_sdio->rx_pkts[i].skb;
++
++		pkt = &ar_sdio->rx_pkts[i];
++		memcpy(skb->data, ar_sdio->vsg_buffer + pkt_offset,
++		       pkt->alloc_len);
++		pkt->status = 0;
++		skb_put(skb, pkt->act_len);
++		pkt_offset += pkt->alloc_len;
+ 	}
+ 
+ 	return 0;
+ 
+ err:
+ 	/* Free all packets that was not successfully fetched. */
+-	for (; i < ar_sdio->n_rx_pkts; i++)
++	for (i = 0; i < ar_sdio->n_rx_pkts; i++)
+ 		ath10k_sdio_mbox_free_rx_pkt(&ar_sdio->rx_pkts[i]);
+ 
++	ar_sdio->n_rx_pkts = 0;
++
+ 	return ret;
+ }
+ 
+@@ -732,7 +777,10 @@ static int ath10k_sdio_mbox_rxmsg_pending_handler(struct ath10k *ar,
+ 			 */
+ 			*done = false;
+ 
+-		ret = ath10k_sdio_mbox_rx_fetch(ar);
++		if (ar_sdio->n_rx_pkts > 1)
++			ret = ath10k_sdio_mbox_rx_fetch_bundle(ar);
++		else
++			ret = ath10k_sdio_mbox_rx_fetch(ar);
+ 
+ 		/* Process fetched packets. This will potentially update
+ 		 * n_lookaheads depending on if the packets contain lookahead
+@@ -1136,7 +1184,7 @@ static int ath10k_sdio_bmi_get_rx_lookahead(struct ath10k *ar)
+ 					 MBOX_HOST_INT_STATUS_ADDRESS,
+ 					 &rx_word);
+ 		if (ret) {
+-			ath10k_warn(ar, "unable to read RX_LOOKAHEAD_VALID: %d\n", ret);
++			ath10k_warn(ar, "unable to read rx_lookahd: %d\n", ret);
+ 			return ret;
+ 		}
+ 
+@@ -1480,7 +1528,7 @@ static int ath10k_sdio_hif_tx_sg(struct ath10k *ar, u8 pipe_id,
+ 		skb = items[i].transfer_context;
+ 		padded_len = ath10k_sdio_calc_txrx_padded_len(ar_sdio,
+ 							      skb->len);
+-		skb_trim(skb, padded_len);
++		skb->len = padded_len;
+ 
+ 		/* Write TX data to the end of the mbox address space */
+ 		address = ar_sdio->mbox_addr[eid] + ar_sdio->mbox_size[eid] -
+@@ -1508,7 +1556,8 @@ static int ath10k_sdio_hif_enable_intrs(struct ath10k *ar)
+ 	/* Enable all but CPU interrupts */
+ 	regs->int_status_en = FIELD_PREP(MBOX_INT_STATUS_ENABLE_ERROR_MASK, 1) |
+ 			      FIELD_PREP(MBOX_INT_STATUS_ENABLE_CPU_MASK, 1) |
+-			      FIELD_PREP(MBOX_INT_STATUS_ENABLE_COUNTER_MASK, 1);
++			      FIELD_PREP(MBOX_INT_STATUS_ENABLE_COUNTER_MASK,
++					 1);
+ 
+ 	/* NOTE: There are some cases where HIF can do detection of
+ 	 * pending mbox messages which is disabled now.
+@@ -2025,6 +2074,12 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 		goto err_free_bmi_buf;
+ 	}
+ 
++	ar_sdio->vsg_buffer = kzalloc(ATH10K_SDIO_VSG_BUF_SIZE, GFP_KERNEL);
++	if (!ar_sdio->vsg_buffer) {
++		ret = -ENOMEM;
++		goto err_free_bmi_buf;
++	}
++
+ 	ar_sdio->func = func;
+ 	sdio_set_drvdata(func, ar_sdio);
+ 
+@@ -2083,7 +2138,7 @@ static int ath10k_sdio_probe(struct sdio_func *func,
+ 	}
+ 
+ 	/* TODO: remove this once SDIO support is fully implemented */
+-	ath10k_warn(ar, "WARNING: ath10k SDIO support is incomplete, don't expect anything to work!\n");
++	ath10k_warn(ar, "WARNING: ath10k SDIO support is experimental\n");
+ 
+ 	return 0;
+ 
+@@ -2117,6 +2172,7 @@ static void ath10k_sdio_remove(struct sdio_func *func)
+ 	ath10k_core_unregister(ar);
+ 	ath10k_core_destroy(ar);
+ 	kfree(ar_sdio->dma_buffer);
++	kfree(ar_sdio->vsg_buffer);
+ }
+ 
+ static const struct sdio_device_id ath10k_sdio_devices[] = {
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.h b/drivers/net/wireless/ath/ath10k/sdio.h
+index 718b8b71c818..8b6a86a7a7fc 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.h
++++ b/drivers/net/wireless/ath/ath10k/sdio.h
+@@ -149,8 +149,8 @@ struct ath10k_sdio_irq_proc_regs {
+ 	u8 rx_lookahead_valid;
+ 	u8 host_int_status2;
+ 	u8 gmbox_rx_avail;
+-	__le32 rx_lookahead[2];
+-	__le32 rx_gmbox_lookahead_alias[2];
++	__le32 rx_lookahead[2 * ATH10K_HIF_MBOX_NUM_MAX];
++	__le32 int_status_enable;
+ };
+ 
+ struct ath10k_sdio_irq_enable_regs {
+@@ -207,6 +207,7 @@ struct ath10k_sdio {
+ 	struct ath10k *ar;
+ 	struct ath10k_sdio_irq_data irq_data;
+ 
++	u8 *vsg_buffer;
+ 	u8 *dma_buffer;
+ 
+ 	/* protects access to dma_buffer */

--- a/projects/Amlogic_GX/patches/linux/0077-ath10k-hif-start-once-addition.patch
+++ b/projects/Amlogic_GX/patches/linux/0077-ath10k-hif-start-once-addition.patch
@@ -1,0 +1,31 @@
+From 9b5247e142538e41e3aaf1be594338aa424e2a4a Mon Sep 17 00:00:00 2001
+From: Alagu Sankar <alagusankar@silex-india.com>
+Date: Sun, 25 Feb 2018 21:28:17 +0100
+Subject: [PATCH] ath10k_sdio: hif start once addition
+
+sdio hif interface uses the start_once optimization to avoid unnecessary
+firmware downloading. simulate hif_stop in sdio as core_stop does not
+handle this due to start_once optimization.
+
+Signed-off-by: Alagu Sankar <alagusankar@silex-india.com>
+---
+ drivers/net/wireless/ath/ath10k/sdio.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.c b/drivers/net/wireless/ath/ath10k/sdio.c
+index 2c2632c25a38..5321b5d5ac41 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.c
++++ b/drivers/net/wireless/ath/ath10k/sdio.c
+@@ -2171,6 +2171,12 @@ static void ath10k_sdio_remove(struct sdio_func *func)
+ 	cancel_work_sync(&ar_sdio->wr_async_work);
+ 	ath10k_core_unregister(ar);
+ 	ath10k_core_destroy(ar);
++
++	if (ar->is_started && ar->hw_params.start_once) {
++		ath10k_hif_stop(ar);
++		ath10k_hif_power_down(ar);
++	}
++
+ 	kfree(ar_sdio->dma_buffer);
+ 	kfree(ar_sdio->vsg_buffer);
+ }

--- a/projects/Amlogic_GX/patches/linux/0078-ath10k-fix-type-mismatch-in-func-prototype.patch
+++ b/projects/Amlogic_GX/patches/linux/0078-ath10k-fix-type-mismatch-in-func-prototype.patch
@@ -1,0 +1,26 @@
+From 68382b1b00b2bc24b1de2d9e58869bc54e2d1816 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:18 +0100
+Subject: [PATCH] ath10k: sdio: fix type mismatch in func prototype
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/sdio.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/sdio.c b/drivers/net/wireless/ath/ath10k/sdio.c
+index 5321b5d5ac41..c364c0d8be03 100644
+--- a/drivers/net/wireless/ath/ath10k/sdio.c
++++ b/drivers/net/wireless/ath/ath10k/sdio.c
+@@ -38,9 +38,9 @@
+ #define ATH10K_SDIO_VSG_BUF_SIZE	(32 * 1024)
+ 
+ static int ath10k_sdio_read(struct ath10k *ar, u32 addr, void *buf,
+-			    u32 len, bool incr);
++			    size_t len, bool incr);
+ static int ath10k_sdio_write(struct ath10k *ar, u32 addr, const void *buf,
+-			     u32 len, bool incr);
++			     size_t len, bool incr);
+ 
+ /* inlined helper functions */
+ 

--- a/projects/Amlogic_GX/patches/linux/0079-ath10k-add-sparklan-usb-support.patch
+++ b/projects/Amlogic_GX/patches/linux/0079-ath10k-add-sparklan-usb-support.patch
@@ -1,0 +1,89 @@
+From 05ddf5b10b0a7abb2c9d54ed4d8dd0a89f5a4bca Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Sun, 25 Feb 2018 21:28:19 +0100
+Subject: [PATCH] ath10k: usb: add sparklan usb support
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c | 24 ++++++++++++++++++++++++
+ drivers/net/wireless/ath/ath10k/hw.h   | 19 ++++++++++---------
+ drivers/net/wireless/ath/ath10k/usb.c  |  1 +
+ 3 files changed, 35 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 18a6163e2647..c1f0873e4333 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -467,6 +467,30 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 		.ast_skid_limit = 0x10,
+ 		.num_wds_entries = 0x20,
+ 	},
++	{
++		.id = QCA9377_HW_1_1_DEV_VERSION,
++		.dev_id = SPARKLAN_WPEQ_160N_DEVICE_ID,
++		.bus = ATH10K_BUS_USB,
++		.name = "qca9377 hw1.1 SparkLAN WPEQ-160ACN",
++		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
++		.uart_pin = 6,
++		.otp_exe_param = 0,
++		.channel_counters_freq_hz = 88000,
++		.max_probe_resp_desc_thres = 0,
++		.cal_data_len = 8124,
++		.fw = {
++			.dir = QCA9377_HW_1_0_FW_DIR,
++			.board = QCA9377_HW_1_0_BOARD_DATA_FILE_USB,
++			.board_size = QCA9377_BOARD_DATA_SZ,
++			.board_ext_size = QCA9377_BOARD_EXT_DATA_SZ,
++		},
++		.hw_ops = &qca988x_ops,
++		.decap_align_bytes = 4,
++		.start_once = true,
++		.num_peers = TARGET_QCA9377_HL_NUM_PEERS,
++		.ast_skid_limit = 0x10,
++		.num_wds_entries = 0x20,
++	},
+ 	{
+ 		.id = QCA9377_HW_1_1_DEV_VERSION,
+ 		.dev_id = QCA9377_1_0_DEVICE_ID,
+diff --git a/drivers/net/wireless/ath/ath10k/hw.h b/drivers/net/wireless/ath/ath10k/hw.h
+index 0d800367d804..e89250fdadd6 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -30,15 +30,16 @@ enum ath10k_bus {
+ 
+ #define ATH10K_FW_DIR			"ath10k"
+ 
+-#define QCA988X_2_0_DEVICE_ID_UBNT   (0x11ac)
+-#define QCA988X_2_0_DEVICE_ID   (0x003c)
+-#define QCA6164_2_1_DEVICE_ID   (0x0041)
+-#define QCA6174_2_1_DEVICE_ID   (0x003e)
+-#define QCA99X0_2_0_DEVICE_ID   (0x0040)
+-#define QCA9888_2_0_DEVICE_ID	(0x0056)
+-#define QCA9984_1_0_DEVICE_ID	(0x0046)
+-#define QCA9377_1_0_DEVICE_ID   (0x0042)
+-#define QCA9887_1_0_DEVICE_ID   (0x0050)
++#define QCA988X_2_0_DEVICE_ID_UBNT	(0x11ac)
++#define QCA988X_2_0_DEVICE_ID		(0x003c)
++#define QCA6164_2_1_DEVICE_ID		(0x0041)
++#define QCA6174_2_1_DEVICE_ID		(0x003e)
++#define QCA99X0_2_0_DEVICE_ID		(0x0040)
++#define QCA9888_2_0_DEVICE_ID		(0x0056)
++#define QCA9984_1_0_DEVICE_ID		(0x0046)
++#define QCA9377_1_0_DEVICE_ID		(0x0042)
++#define QCA9887_1_0_DEVICE_ID		(0x0050)
++#define SPARKLAN_WPEQ_160N_DEVICE_ID	(0x9378)
+ 
+ /* QCA988X 1.0 definitions (unsupported) */
+ #define QCA988X_HW_1_0_CHIP_ID_REV	0x0
+diff --git a/drivers/net/wireless/ath/ath10k/usb.c b/drivers/net/wireless/ath/ath10k/usb.c
+index 3b330e9607aa..28e185b56f29 100644
+--- a/drivers/net/wireless/ath/ath10k/usb.c
++++ b/drivers/net/wireless/ath/ath10k/usb.c
+@@ -1084,6 +1084,7 @@ static int ath10k_usb_pm_resume(struct usb_interface *interface)
+ /* table of devices that work with this driver */
+ static struct usb_device_id ath10k_usb_ids[] = {
+ 	{USB_DEVICE(0x13b1, 0x0042)}, /* Linksys WUSB6100M */
++	{USB_DEVICE(0x0cf3, 0x9378)}, /* SparkLAN WPEQ-160ACN */
+ 	{ /* Terminating entry */ },
+ };
+ 


### PR DESCRIPTION
This patch series adds ath10k sdio support to the mainline kernel - patches are still being tweaked for upstreaming in 4.17 or 4.18. Not fully tested yet, so merge blocked.