### PR TITLE
RPi: temporarily add kodi PR13594

### DIFF
--- a/projects/RPi/patches/kodi/kodi-0100-temp-add-pr13594.patch
+++ b/projects/RPi/patches/kodi/kodi-0100-temp-add-pr13594.patch
@@ -1,0 +1,52 @@
+From 73fc8d7461e50426c20036e97a28af6fc974cbb9 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Mon, 26 Feb 2018 20:58:08 +0000
+Subject: [PATCH] DVDVideoCodec: Initialise VideoPicture fields to zero
+
+After the memset on VideoPicture was removed we are now accessing
+uninitialised class members, e.g. pts and dts
+
+This caused stalls on start of playback and wild values in
+a/v: offset.
+
+Make sure they are initialised.
+---
+ xbmc/cores/VideoPlayer/DVDFileInfo.cpp      | 5 +++--
+ xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp | 1 +
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+index 1350dcf9c2aa..cb7b8bc682d5 100644
+--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
++++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+@@ -216,8 +216,8 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
+       if (pDemuxer->SeekTime(nSeekTo, true))
+       {
+         CDVDVideoCodec::VCReturn iDecoderState = CDVDVideoCodec::VC_NONE;
+-        VideoPicture picture = {};
+-
++        VideoPicture picture;
++        picture.Reset();
+         // num streams * 160 frames, should get a valid frame, if not abort.
+         int abort_index = pDemuxer->GetNrOfStreams() * 160;
+         do
+@@ -240,6 +240,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
+           iDecoderState = CDVDVideoCodec::VC_NONE;
+           while (iDecoderState == CDVDVideoCodec::VC_NONE)
+           {
++            picture.Reset();
+             iDecoderState = pVideoCodec->GetPicture(&picture);
+           }
+ 
+diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+index b547d17cb27a..b8a7797ba0b6 100644
+--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
++++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+@@ -317,6 +317,7 @@ void CVideoPlayerVideo::Process()
+   int iDropDirective;
+   bool onlyPrioMsgs = false;
+ 
++  m_picture.Reset();
+   m_videoStats.Start();
+   m_droppingStats.Reset();
+   m_iDroppedFrames = 0;


### PR DESCRIPTION
This PR has been in included in Milhouse builds for a while, without it Netflix is unusable on RPi.

So temporarily add it until it's either merged upstream or a proper fix for the playback issues is found
see kodi PR for details https://github.com/xbmc/xbmc/pull/13594