### PR TITLE
linux: add dw-hdmi overflow patch from 4.17-rc1

### DIFF
--- a/projects/Amlogic_GX/patches/linux/0002-dw-hdmi-Fix-overflow-workaround-for-Amlogic-Meson-GX-SoCs.patch
+++ b/projects/Amlogic_GX/patches/linux/0002-dw-hdmi-Fix-overflow-workaround-for-Amlogic-Meson-GX-SoCs.patch
@@ -1,0 +1,22 @@
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index a38db40..f5018f9 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -1637,6 +1637,8 @@ static void dw_hdmi_clear_overflow(struct dw_hdmi *hdmi)
+ 	 * (and possibly on the platform). So far only i.MX6Q (v1.30a) and
+ 	 * i.MX6DL (v1.31a) have been identified as needing the workaround, with
+ 	 * 4 and 1 iterations respectively.
++	 * The Amlogic Meson GX SoCs (v2.01a) have been identifies as needing
++	 * the workaround with a single iteration.
+ 	 */
+ 
+ 	switch (hdmi->version) {
+@@ -1644,6 +1646,7 @@ static void dw_hdmi_clear_overflow(struct dw_hdmi *hdmi)
+ 		count = 4;
+ 		break;
+ 	case 0x131a:
++	case 0x201a:
+ 		count = 1;
+ 		break;
+ 	default:
+


### PR DESCRIPTION
adding https://patchwork.freedesktop.org/patch/206458/ until 4.17 kernel