### PR TITLE
linux: build perf on all kernels except amlogic-3.x

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -37,6 +37,7 @@ case "$LINUX" in
     PKG_SOURCE_DIR="$PKG_NAME-amlogic-$PKG_VERSION*"
     PKG_PATCH_DIRS="amlogic-3.10"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host"
+    PKG_BUILD_PERF="no"
     ;;
   amlogic-3.14)
     PKG_VERSION="9c63c24"
@@ -45,6 +46,7 @@ case "$LINUX" in
     PKG_SOURCE_DIR="$PKG_NAME-amlogic-$PKG_VERSION*"
     PKG_PATCH_DIRS="amlogic-3.14"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host"
+    PKG_BUILD_PERF="no"
     ;;
   rockchip-4.4)
     PKG_VERSION="eae92ae2"
@@ -67,7 +69,6 @@ if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
   PKG_DEPENDS_HOST="$PKG_DEPENDS_HOST gcc-linaro-aarch64-linux-gnu:host"
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET gcc-linaro-aarch64-linux-gnu:host"
   HEADERS_ARCH=$TARGET_ARCH
-  PKG_BUILD_PERF="no"
 fi
 
 if [ "$DEVTOOLS" = "yes" -a "$PKG_BUILD_PERF" != "no" ] && grep -q ^CONFIG_PERF_EVENTS= $PKG_KERNEL_CFG_FILE ; then


### PR DESCRIPTION
Since 64/32 split arch compilation problems have been resolved and rockchip-4.4 kernel received the required perf patch it's now safe to enable perf on 4.4 and newer kernels.

None of the current AML projects with 3.x kernels have CONFIG_PERF_EVENTS set so perf won't be built there. But since this may change in the future and perf compilation hasn't been tested with these old kernels (and quite certainly will fail), disable perf for these kernel trees.

I've compile+runtime tested this on Rock64