### PR TITLE
Emulation support for cortex-a72.cortex-a53

### DIFF
--- a/packages/emulation/libretro-beetle-pcfx/package.mk
+++ b/packages/emulation/libretro-beetle-pcfx/package.mk
@@ -41,7 +41,7 @@ make_target() {
     cortex-a7)
       make platform=armv7-neon-hardfloat
       ;;
-    cortex-a9|cortex-a53|cortex-a17)
+    cortex-a9|*cortex-a53|cortex-a17)
       if [ "$TARGET_ARCH" = "aarch64" ]; then
         make platform=aarch64
       else

--- a/packages/emulation/libretro-craft/package.mk
+++ b/packages/emulation/libretro-craft/package.mk
@@ -55,7 +55,7 @@ make_target() {
       make -f Makefile.libretro
       ;;
     *)
-      if [ "$TARGET_CPU" = "cortex-a9" ] || [ "$TARGET_CPU" = "cortex-a53" ] || [ "$TARGET_CPU" = "cortex-a17" ]; then
+      if [[ "$TARGET_CPU" = "cortex-a9" ]] || [[ "$TARGET_CPU" = *"cortex-a53" ]] || [[ "$TARGET_CPU" = "cortex-a17" ]]; then
         if [ "$TARGET_ARCH" = "aarch64" ]; then
           make -f Makefile.libretro platform=aarch64
         else

--- a/packages/emulation/libretro-mame2010/package.mk
+++ b/packages/emulation/libretro-mame2010/package.mk
@@ -48,7 +48,7 @@ make_target() {
     cortex-a7|cortex-a9)
       make platform=armv7-neon-hardfloat-$TARGET_CPU
       ;;
-    cortex-a53|cortex-a17)
+    *cortex-a53|cortex-a17)
       if [ "$TARGET_ARCH" = "aarch64" ]; then
         make platform=aarch64
       else

--- a/packages/emulation/libretro-mame2014/package.mk
+++ b/packages/emulation/libretro-mame2014/package.mk
@@ -48,7 +48,7 @@ make_target() {
     cortex-a7|cortex-a9)
       make platform=armv7-neon-hardfloat-$TARGET_CPU
       ;;
-    cortex-a53|cortex-a17)
+    *cortex-a53|cortex-a17)
       if [ "$TARGET_ARCH" = "aarch64" ]; then
         make platform=aarch64
       else

--- a/packages/emulation/libretro-mupen64plus/package.mk
+++ b/packages/emulation/libretro-mupen64plus/package.mk
@@ -53,7 +53,7 @@ make_target() {
       make WITH_DYNAREC=x86_64
       ;;
     *)
-      if [ "$TARGET_CPU" = "cortex-a9" ] || [ "$TARGET_CPU" = "cortex-a53" ] || [ "$TARGET_CPU" = "cortex-a17" ]; then
+      if [[ "$TARGET_CPU" = "cortex-a9" ]] || [[ "$TARGET_CPU" = *"cortex-a53" ]] || [[ "$TARGET_CPU" = "cortex-a17" ]]; then
         if [ "$TARGET_ARCH" = "aarch64" ]; then
           make platform=aarch64
         else


### PR DESCRIPTION
This is necessary to build emulation packages for RK3399 devices.