### PR TITLE
Amlogic u-boot: fix order of PKG_URL and PKG_VERSION

### DIFF
--- a/projects/Amlogic/packages/u-boot/package.mk
+++ b/projects/Amlogic/packages/u-boot/package.mk
@@ -27,18 +27,18 @@ PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems, us
 
 case "$DEVICE" in
   "Odroid_C2")
-    PKG_URL="https://github.com/hardkernel/u-boot/archive/$PKG_VERSION.tar.gz"
     PKG_VERSION="6e4e886"
+    PKG_URL="https://github.com/hardkernel/u-boot/archive/$PKG_VERSION.tar.gz"
     PKG_SHA256="0d05829e07e226d1acbc6b23ff038d6c92fa3ed738ddc28703d51987c0fab3bb"
     ;;
   "KVIM"*)
-    PKG_URL="https://github.com/khadas/u-boot/archive/$PKG_VERSION.tar.gz"
     PKG_VERSION="ffc14fc"
+    PKG_URL="https://github.com/khadas/u-boot/archive/$PKG_VERSION.tar.gz"
     PKG_SHA256="1326126ca7962d314cb522d95e657dbf71966e74c84fb093181910f9e4f2c1fa"
     ;;
   "LePotato")
-    PKG_URL="https://github.com/BayLibre/u-boot/archive/$PKG_VERSION.tar.gz"
     PKG_VERSION="a43076c"
+    PKG_URL="https://github.com/BayLibre/u-boot/archive/$PKG_VERSION.tar.gz"
     PKG_SHA256="0ae5fd97ba86fcd6cc7b2722580745a0ddbf651ffa0cc0bd188a05a9b668373f"
     ;;
   *)


### PR DESCRIPTION
in case `PKG_VERSION` is set **after** `PKG_URL`, `PKG_VERSION="0.0invalid"` at the time of setting `PKG_URL`.

From IRC:
```
09:10 < jazz> hi there
09:11 < jazz> is LE git head building fine ? i get a problem with u-boot sources (0.0invalid.tar.gz)
09:13 < vpeter> jazz: Which project?
09:20 < jazz> odroid c2
09:20 < jazz> vpeter:
09:28 < jazz> project amlogic, device odroid_c2
09:30 < jazz> vpeter: wget https://github.com/hardkernel/u-boot/archive/0.0invalid.tar.gz returns a 404
09:37 < vudiq> jazz: could it be because PKG_VERSION is set AFTER PKG_URL?
09:37 < vudiq> https://github.com/LibreELEC/LibreELEC.tv/blob/master/projects/Amlogic/packages/u-boot/package.mk#L29
09:37 < vudiq> the order of PKG_URL and PKG_VERSION should be swapped, imho
09:39 < vudiq> try to change it locally (projects/Amlogic/packages/u-boot/package.mk) and build again
09:45 < vudiq> like this: https://github.com/ToKe79/LibreELEC.tv/commit/9c76dbc3a244030f385a0f53a15ded8d450d0ade
09:48 < jazz> vudiq: thanks, it worked.
```