### PR TITLE
distro-tool: fixup after server migration

### DIFF
--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -21,7 +21,7 @@ set -e
 [ -z "${DEBUG_LOG}" ] && DEBUG_LOG=/tmp/distro-tool.log
 
 LIBREELEC_DIR=$HOME/LibreELEC.tv
-TARGET_DIR=/community/sources
+TARGET_DIR=$HOME/sources
 DOWNLOAD_DIR=$HOME/download
 REVISION=
 PACKAGE=
@@ -691,7 +691,7 @@ Usage: $(basename $0) -d|--download <path> [-t|--target <path>] [-l|--libreelec 
 
 Options:
   -d, --download:     Directory path into which new package files will be downloaded - default is $HOME/download[1]
-  -t, --target:       Directory path for existing packages that are to be refreshed, default is /community/sources[2]
+  -t, --target:       Directory path for existing packages that are to be refreshed, default is $HOME/sources[2]
   -l, --libreelec:    LibreELEC.tv repo, default is ${HOME}/LibreELEC.tv
   -m, --mirror:       Target is mirror not source - mirror uses a hierarchical per-package folder structure
   -s, --source:       Target is source not mirror - source uses a flattened file structure. Default is mirror
@@ -893,10 +893,10 @@ end_progress() {
 
 exec_worker_prog() {
   echo "${PYTHON_PROG}" >/tmp/distro-tool.py
-  python /tmp/distro-tool.py "${DOWNLOAD_DIR}" "${TARGET_DIR}" "${DISTRO_SOURCE}" "${DISTRO_MIRROR}" \
-                             "${IS_MIRROR}" "${IGNORE_ERRORS}" "${DRY_RUN}" "${CHECK_NEWER}" \
-                             "${PROGRESS}" "${WORKER_THREADS}" "${GIT_USERNAME}" "${GIT_PASSWORD}" \
-                             "${CHECK_FILTER_CLASS}" "${CHECK_FILTER_TYPE}" "${VERBOSE}"
+  python3 /tmp/distro-tool.py "${DOWNLOAD_DIR}" "${TARGET_DIR}" "${DISTRO_SOURCE}" "${DISTRO_MIRROR}" \
+                              "${IS_MIRROR}" "${IGNORE_ERRORS}" "${DRY_RUN}" "${CHECK_NEWER}" \
+                              "${PROGRESS}" "${WORKER_THREADS}" "${GIT_USERNAME}" "${GIT_PASSWORD}" \
+                              "${CHECK_FILTER_CLASS}" "${CHECK_FILTER_TYPE}" "${VERBOSE}"
   rm -f /tmp/distro-tool.py
 }
 


### PR DESCRIPTION
Default to $HOME/sources sym link which points to wherever tarballs are stored.
No `python` sym link on sources server, only `python3`.
