### PR TITLE
Revert "projects/Amlogic: include wetekdvb with S905 builds"

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -33,7 +33,6 @@ PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
   device=${DEVICE:-$PROJECT}
-  [ $device = "S905" ] && device=WeTek_Play_2
   for overlay_dir in driver/$device/*/; do
     overlay_dir=`basename $overlay_dir`
     mkdir -p $INSTALL/$(get_full_module_dir $overlay_dir)/$PKG_NAME

--- a/projects/Amlogic/devices/S905/options
+++ b/projects/Amlogic/devices/S905/options
@@ -7,7 +7,7 @@
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS ap6xxx-aml mt7601u-aml mt7603u-aml \
                         qca9377-aml RTL8189ES-aml RTL8189FS-aml RTL8723BS-aml \
-                        RTL8723DS-aml RTL8822BU-aml ssv6xxx-aml fd628-aml wetekdvb \
+                        RTL8723DS-aml RTL8822BU-aml ssv6xxx-aml fd628-aml \
                         avl6862-aml"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)


### PR DESCRIPTION
This reverts commit 3e9f8d0970bfaedf20b05681d38642d7f66154b5.

Including is pointless for 2 reasons:
* only WP2 uses this module and there already is device-specific build for it
* it conflicts with avl6862-aml