### PR TITLE
buildsystem: simplify SIMD support (neon/mmx/sse/sse2)

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -15,7 +15,7 @@
       TARGET_VARIANT=armv8-a
       TARGET_ABI=eabi
       TARGET_EXTRA_FLAGS="-mcpu=${TARGET_CPU}${TARGET_CPU_FLAGS}"
-      SIMD_SUPPORT="yes"
+      TARGET_FEATURES+=" neon"
       ;;
   esac
 

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -29,28 +29,27 @@
       TARGET_ABI=eabi
       TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
-      SIMD_SUPPORT="no"
       ;;
     cortex-a7|cortex-a15|cortex-a17|cortex-a15.cortex-a7|cortex-a17.cortex-a7)
       TARGET_SUBARCH=armv7ve
       TARGET_ABI=eabi
       TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
-      SIMD_SUPPORT="yes"
+      TARGET_FEATURES+=" neon"
       ;;
     cortex-a5|cortex-a8|cortex-a9)
       TARGET_SUBARCH=armv7-a
       TARGET_ABI=eabi
       TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
-      SIMD_SUPPORT="yes"
+      TARGET_FEATURES+=" neon"
       ;;
     cortex-a53|cortex-a72.cortex-a53)
       TARGET_SUBARCH=armv8-a
       TARGET_ABI=eabi
       TARGET_EXTRA_FLAGS="-mcpu=${TARGET_CPU}"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
-      SIMD_SUPPORT="yes"
+      TARGET_FEATURES+=" neon"
       ;;
   esac
 

--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -14,4 +14,4 @@
   TARGET_LDFLAGS="-march=$TARGET_CPU -m64"
 
 # build with SIMD support ( yes / no )
-  SIMD_SUPPORT="yes"
+  TARGET_FEATURES+=" mmx sse sse2"

--- a/config/show_config
+++ b/config/show_config
@@ -15,7 +15,7 @@ show_config() {
   config_message="$config_message\n - CPU (ARCH):\t\t\t\t $TARGET_CPU ($TARGET_ARCH)"
   config_message="$config_message\n - FLOAT:\t\t\t\t $TARGET_FLOAT"
   config_message="$config_message\n - FPU:\t\t\t\t\t $TARGET_FPU"
-  config_message="$config_message\n - SIMD support:\t\t\t $SIMD_SUPPORT"
+  config_message="$config_message\n - CPU features:\t\t\t $TARGET_FEATURES"
   config_message="$config_message\n - LTO (Link Time Optimization) support: $LTO_SUPPORT"
   config_message="$config_message\n - GOLD (Google Linker) Support:\t $GOLD_SUPPORT"
   config_message="$config_message\n - LLVM support:\t\t\t $LLVM_SUPPORT"

--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -38,7 +38,7 @@ PKG_CONFIGURE_OPTS_HOST="--enable-static \
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --with-jpeg8"
 
-if [ "$SIMD_SUPPORT" = "no" ]; then
+if ! target_has_feature "(neon|sse)"; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --without-simd"
 fi
 

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -20,7 +20,7 @@
         #
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+fp+simd"
-        TARGET_FEATURES="64bit neon"
+        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -29,7 +29,7 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
-        TARGET_FEATURES="32bit neon"
+        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -50,7 +50,6 @@
 
   # Project CFLAGS
     PROJECT_CFLAGS="-mmmx -msse -msse2 -mfpmath=sse"
-    TARGET_FEATURES+=" mmx sse sse2"
 
   # SquashFS compression method (gzip / lzo / xz)
     SQUASHFS_COMPRESSION="gzip"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -38,11 +38,10 @@
 
         if [ "$DEVICE" = "RPi" -o "$DEVICE" = "Slice" ]; then
           TARGET_FPU="vfp"
-          TARGET_FEATURES="32bit"
         elif [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ]; then
           TARGET_FPU="neon-vfpv4"
-          TARGET_FEATURES="32bit neon"
         fi
+        TARGET_FEATURES="32bit"
 
         ;;
     esac

--- a/projects/Rockchip/devices/MiQi/options
+++ b/projects/Rockchip/devices/MiQi/options
@@ -9,7 +9,7 @@
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a17"
         TARGET_FPU="neon-vfpv4"
-        TARGET_FEATURES="32bit neon"
+        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Rockchip/devices/RK3328/options
+++ b/projects/Rockchip/devices/RK3328/options
@@ -8,7 +8,7 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+crypto"
-        TARGET_FEATURES="64bit neon"
+        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -17,7 +17,7 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
-        TARGET_FEATURES="32bit neon"
+        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -8,7 +8,7 @@
       aarch64)
         TARGET_CPU="cortex-a72.cortex-a53"
         TARGET_CPU_FLAGS="+crc+crypto"
-        TARGET_FEATURES="64bit neon"
+        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -17,7 +17,7 @@
         TARGET_CPU="cortex-a72.cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
-        TARGET_FEATURES="32bit neon"
+        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Rockchip/devices/TinkerBoard/options
+++ b/projects/Rockchip/devices/TinkerBoard/options
@@ -9,7 +9,7 @@
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a17"
         TARGET_FPU="neon-vfpv4"
-        TARGET_FEATURES="32bit neon"
+        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -32,7 +32,7 @@
         # vfpv3xd vfpv3xd-fp16 neon neon-fp16 vfpv4 vfpv4-d16 fpv4-sp-d16
         # neon-vfpv4.
         TARGET_FPU="neon-fp16"
-        TARGET_FEATURES="32bit neon"
+        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -32,7 +32,7 @@
         # vfpv3xd vfpv3xd-fp16 neon neon-fp16 vfpv4 vfpv4-d16 fpv4-sp-d16
         # neon-vfpv4.
         TARGET_FPU="neon-fp16"
-        TARGET_FEATURES="32bit neon"
+        TARGET_FEATURES="32bit"
         ;;
     esac
 


### PR DESCRIPTION
`neon` and `mmx/sse/sse2` should be defined by the CPU, not the project or device.

This also drops the variable `SIMD_SUPPORT`.