### PR TITLE
wetekdvb: load the module conditionally

### DIFF
--- a/packages/linux-drivers/wetekdvb/modules-load.d/wetekdvb.conf
+++ b/packages/linux-drivers/wetekdvb/modules-load.d/wetekdvb.conf
@@ -1,1 +1,0 @@
-wetekdvb

--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -43,3 +43,7 @@ makeinstall_target() {
   mkdir -p $INSTALL/$(get_full_firmware_dir)
     cp firmware/* $INSTALL/$(get_full_firmware_dir)
 }
+
+post_install() {
+  enable_service wetekdvb.service
+}

--- a/packages/linux-drivers/wetekdvb/system.d/wetekdvb.service
+++ b/packages/linux-drivers/wetekdvb/system.d/wetekdvb.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=WeTek DVB module loader
+ConditionPathExists=/proc/device-tree/dvb/dev_name
+After=kernel-overlays.service
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c '[ `cat /proc/device-tree/dvb/dev_name` = "wetek-dvb" ] && /sbin/modprobe wetekdvb'
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This PR is to fix the issue identified in #2575, as wetekdvb is included in the S905 image it should only be loaded conditionally.