### PR TITLE
xf86-video-nvidia: update to xf86-video-nvidia-390.42

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -20,8 +20,8 @@ PKG_NAME="xf86-video-nvidia"
 # Remember to run "python packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py" and commit changes to
 # "packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules" whenever bumping version.
 # Host may require installation of python-lxml and python-requests packages.
-PKG_VERSION="390.25"
-PKG_SHA256="02263bc81b66e68fc8224447b249f4f0ca4ae201c467e236d917be2fe187f3d6"
+PKG_VERSION="390.42"
+PKG_SHA256="5f242cf0f7f4dcc45759eee3b4973191114842fe7c146c5ae7a12a2ebea394aa"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.nvidia.com/"


### PR DESCRIPTION
Announcement: [driver](http://www.nvidia.com/Download/driverResults.aspx/131853/en-us)

Fixes a regression.