### PR TITLE
Fix fd628.service syntax error + Fix small bug in fd628-aml driver.

### DIFF
--- a/packages/linux-drivers/amlogic/fd628-aml/package.mk
+++ b/packages/linux-drivers/amlogic/fd628-aml/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="fd628-aml"
-PKG_VERSION="4c4cc6e"
-PKG_SHA256="c52780595c1e72cbe153011a54f6f3b946e9c77d5e13f4dd48ad70cce7905a43"
+PKG_VERSION="8047f2e"
+PKG_SHA256="168b9ae9df56834462a68654fb204468a4c8df31ce2b88d654fdff378e5eacda"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/arthur-liberman/linux_fd628"

--- a/packages/linux-drivers/amlogic/fd628-aml/system.d/fd628.service
+++ b/packages/linux-drivers/amlogic/fd628-aml/system.d/fd628.service
@@ -6,8 +6,8 @@ ConditionPathExists=/storage/.config/vfd.conf
 [Service]
 Type=oneshot
 EnvironmentFile=/storage/.config/vfd.conf
-ExecStart=/bin/sh -c '[ `cat /proc/device-tree/le-vfd/compatible` = "le,vfd" ] && /sbin/modprobe aml_fd628 vfd_gpio_clk=${vfd_gpio_clk} vfd_gpio_dat=${vfd_gpio_dat} vfd_gpio_stb=${vfd_gpio_stb} vfd_chars=${vfd_chars} vfd_dot_bits=${vfd_dot_bits} vfd_display_type=${vfd_display_type}
-ExecStart=/bin/sh -c '[ `cat /proc/device-tree/le-vfd/compatible` = "le,vfd" ] && /usr/sbin/FD628Service
+ExecStart=/bin/sh -c '[ `cat /proc/device-tree/le-vfd/compatible` = "le,vfd" ] && /sbin/modprobe aml_fd628 vfd_gpio_clk=${vfd_gpio_clk} vfd_gpio_dat=${vfd_gpio_dat} vfd_gpio_stb=${vfd_gpio_stb} vfd_chars=${vfd_chars} vfd_dot_bits=${vfd_dot_bits} vfd_display_type=${vfd_display_type}'
+ExecStart=/bin/sh -c '[ `cat /proc/device-tree/le-vfd/compatible` = "le,vfd" ] && /usr/sbin/FD628Service'
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
There was a typo (missing closing ') in the service file and without this PR the service won't start.
In addition there was a bug in the driver that would cause an exception during modprobe, which is now fixed, and therefore I bumped it up.