### PR TITLE
Amlogic related package bumps

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -33,8 +33,8 @@ PKG_PATCH_DIRS="$LINUX"
 
 case "$LINUX" in
   amlogic-3.10)
-    PKG_VERSION="02fdb27efcb2940b819fec90d9fb333a57ab9900"
-    PKG_SHA256="a4c6a5759ad754109357c1283665498c23796c985fec0b50b18be25f96cf8465"
+    PKG_VERSION="95ba9d626c0fce672caa296f5911ab9190881642"
+    PKG_SHA256="df34b086993fd3552efae92d84d28990a61a1ca79a8703a4b64241ab80e3b6db"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_DIR="linux-amlogic-$PKG_VERSION"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -41,8 +41,8 @@ case "$LINUX" in
     PKG_BUILD_PERF="no"
     ;;
   amlogic-3.14)
-    PKG_VERSION="9c63c24324096d5e03db59c6621521cab671db79"
-    PKG_SHA256="ca5c17921e554c75a63dd91f400ceaee3657d2b485db93909754891d68ea19d2"
+    PKG_VERSION="29941550f05282411c00c437b4c18bb5c6319d63"
+    PKG_SHA256="c97da3b9cd3d34432e69aeaa740076afee977b9ed7c0d0a8475f3f019288dd36"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_DIR="linux-amlogic-$PKG_VERSION"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host"

--- a/projects/Amlogic/packages/device-trees-amlogic/package.mk
+++ b/projects/Amlogic/packages/device-trees-amlogic/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="device-trees-amlogic"
-PKG_VERSION="be9bfb7"
-PKG_SHA256="f2bed01aef8067c1cc91ad0a83ed6fd6a753b964970bc01a165214743fcae561"
+PKG_VERSION="30c9d42"
+PKG_SHA256="bcbcd81abab242afaf439ff4d3b92039f2dba97ce0986285627e19e58f1c47d4"
 PKG_LICENSE="GPL"
 PKG_URL="https://github.com/LibreELEC/device-trees-amlogic/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"


### PR DESCRIPTION
As the title says

amlogic-3.10 bump contains wetek play 1 dtb update
amlogic-3.14 bump contains dtb updates for latest vfd driver
device-trees-amlogic contains dtb updates for latest vfd driver