### PR TITLE
meson: update to 0.45

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -79,27 +79,6 @@ setup_toolchain() {
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)"  >> $CMAKE_CONF
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"  >> $CMAKE_CONF
       fi
-      export MESON_CONF=$TOOLCHAIN/etc/meson-$TARGET_NAME.conf
-      if [ ! -f $MESON_CONF ] ; then
-        mkdir -p $TOOLCHAIN/etc
-        echo "[binaries]" >> $MESON_CONF
-        echo "c = '$CC'" >> $MESON_CONF
-        echo "cpp = '$CXX'" >> $MESON_CONF
-        echo "ar = '$AR'" >> $MESON_CONF
-        echo "strip = '$STRIP'" >> $MESON_CONF
-        echo "pkgconfig = '$PKG_CONFIG'" >> $MESON_CONF
-        echo "" >> $MESON_CONF
-        echo "[host_machine]" >> $MESON_CONF
-        echo "system = 'linux'" >> $MESON_CONF
-        echo "cpu_family = '$TARGET_ARCH'" >> $MESON_CONF
-        echo "cpu = '$TARGET_SUBARCH'" >> $MESON_CONF
-        echo "endian = 'little'" >> $MESON_CONF
-        echo "" >> $MESON_CONF
-        echo "[properties]" >> $MESON_CONF
-        echo "root = '$SYSROOT_PREFIX/usr'" >> $MESON_CONF
-        python -c "import os; print('c_args = {}'.format([x for x in os.getenv('CFLAGS').split()]))" >> $MESON_CONF
-        python -c "import os; print('c_link_args = {}'.format([x for x in os.getenv('LDFLAGS').split()]))" >> $MESON_CONF
-      fi
       export HOST_CC="$TOOLCHAIN/bin/host-gcc"
       export HOST_CXX="$TOOLCHAIN/bin/host-g++"
       export HOSTCC="$HOST_CC"
@@ -152,27 +131,6 @@ setup_toolchain() {
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)" >> $CMAKE_CONF
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)" >> $CMAKE_CONF
       fi
-      export MESON_CONF=$TOOLCHAIN/etc/meson-$HOST_NAME.conf
-      if [ ! -f $MESON_CONF ] ; then
-        mkdir -p $TOOLCHAIN/etc
-        echo "[binaries]" >> $MESON_CONF
-        echo "c = '$CC'" >> $MESON_CONF
-        echo "cpp = '$CXX'" >> $MESON_CONF
-        echo "ar = '$AR'" >> $MESON_CONF
-        echo "strip = '$STRIP'" >> $MESON_CONF
-        echo "pkgconfig = '$PKG_CONFIG'" >> $MESON_CONF
-        echo "" >> $MESON_CONF
-        echo "[host_machine]" >> $MESON_CONF
-        echo "system = 'linux'" >> $MESON_CONF
-        echo "cpu_family = '$TARGET_ARCH'" >> $MESON_CONF
-        echo "cpu = '$TARGET_SUBARCH'" >> $MESON_CONF
-        echo "endian = 'big'" >> $MESON_CONF
-        echo ""	>> $MESON_CONF
-        echo "[properties]" >> $MESON_CONF
-        echo "root = '$TOOLCHAIN'" >> $MESON_CONF
-        python -c "import os; print('c_args = {}'.format([x for x in os.getenv('CFLAGS').split()]))" >> $MESON_CONF
-        python -c "import os; print('c_link_args = {}'.format([x for x in os.getenv('LDFLAGS').split()]))" >> $MESON_CONF
-      fi
       export HOST_CC="$CC"
       export HOST_CXX="$CXX"
       export HOSTCC="$CC"
@@ -186,6 +144,37 @@ setup_toolchain() {
       export _python_exec_prefix=/
       ;;
   esac
+}
+
+create_meson_conf() {
+  local endian root conf
+  case "$1" in
+    target|init)    endian="little"
+                    root="$SYSROOT_PREFIX/usr"
+                    ;;
+    host|bootstrap) endian="big"
+                    root="$TOOLCHAIN"
+                    ;;
+  esac
+
+  conf=$2
+  echo "[binaries]" > $conf
+  echo "c = '$CC'" >> $conf
+  echo "cpp = '$CXX'" >> $conf
+  echo "ar = '$AR'" >> $conf
+  echo "strip = '$STRIP'" >> $conf
+  echo "pkgconfig = '$PKG_CONFIG'" >> $conf
+  echo "" >> $conf
+  echo "[host_machine]" >> $conf
+  echo "system = 'linux'" >> $conf
+  echo "cpu_family = '$TARGET_ARCH'" >> $conf
+  echo "cpu = '$TARGET_SUBARCH'" >> $conf
+  echo "endian = '$endian'" >> $conf
+  echo "" >> $conf
+  echo "[properties]" >> $conf
+  echo "root = '$root'" >> $conf
+  python -c "import os; print('c_args = {}'.format([x for x in os.getenv('CFLAGS').split()]))" >> $conf
+  python -c "import os; print('c_link_args = {}'.format([x for x in os.getenv('LDFLAGS').split()]))" >> $conf
 }
 
 # unset all PKG_* vars apart from those exported by setup_toolchain, then set default values

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="meson"
-PKG_VERSION="0.44.0"
-PKG_SHA256="50f9b12b77272ef6ab064d26b7e06667f07fa9f931e6a20942bba2216ba4281b"
+PKG_VERSION="0.45.0"
+PKG_SHA256="3455abbc30a3fbd9cc8abb6d5fcdc42ce618665b95ac2c3ad7792a4a6ba47ce4"
 PKG_ARCH="any"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -106,10 +106,6 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
 pre_configure_target() {
   export CFLAGS="$CFLAGS -fno-schedule-insns -fno-schedule-insns2"
   export LC_ALL=en_US.UTF-8
-
-  # meson needs a host compiler and it's detected through the environment. meh.
-  export CC="$HOST_CC"
-  export CXX="$HOST_CXX"
 }
 
 post_makeinstall_target() {

--- a/scripts/build
+++ b/scripts/build
@@ -174,8 +174,7 @@ TARGET_MESON_OPTS="--prefix=/usr \
                    --libdir=/usr/lib \
                    --libexecdir=/usr/lib \
                    --localstatedir=/var \
-                   --buildtype=$MESON_BUILD_TYPE \
-                   --cross-file=$MESON_CONF"
+                   --buildtype=$MESON_BUILD_TYPE"
 
 # configure HOST build defaults
 HOST_CONFIGURE_OPTS="--host=$HOST_NAME \
@@ -200,8 +199,7 @@ HOST_MESON_OPTS="--prefix=$TOOLCHAIN \
                  --libdir=$TOOLCHAIN/lib \
                  --libexecdir=$TOOLCHAIN/lib \
                  --localstatedir=$TOOLCHAIN/var \
-                 --buildtype=plain \
-                 --cross-file=$MESON_CONF"
+                 --buildtype=plain"
 
 # configure INIT build defaults
 INIT_CONFIGURE_OPTS="$TARGET_CONFIGURE_OPTS"
@@ -321,23 +319,15 @@ cd $PKG_BUILD
 
 if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" -o -f "$PKG_MESON_SCRIPT" ]; then
   case "$TARGET" in
-    "target")
-      mkdir -p .$TARGET_NAME
-      cd .$TARGET_NAME
-      ;;
-    "host")
-      mkdir -p .$HOST_NAME
-      cd .$HOST_NAME
-      ;;
-    "init")
-      mkdir -p .$TARGET_NAME-$TARGET
-      cd .$TARGET_NAME-$TARGET
-      ;;
-    "bootstrap")
-      mkdir -p .$HOST_NAME-$TARGET
-      cd .$HOST_NAME-$TARGET
-      ;;
+    "target")    PKG_REAL_BUILD="$PKG_BUILD/.$TARGET_NAME" ;;
+    "host")      PKG_REAL_BUILD="$PKG_BUILD/.$HOST_NAME" ;;
+    "init")      PKG_REAL_BUILD="$PKG_BUILD/.$TARGET_NAME-$TARGET" ;;
+    "bootstrap") PKG_REAL_BUILD="$PKG_BUILD/.$HOST_NAME-$TARGET" ;;
   esac
+  mkdir -p $PKG_REAL_BUILD
+  cd $PKG_REAL_BUILD
+  
+  MESON_CONF="$PKG_REAL_BUILD/meson.conf"
 fi
 
 # configure
@@ -350,20 +340,24 @@ else
   case "$PKG_TOOLCHAIN:$TARGET" in
     # meson builds
     "meson:target")
-      echo "Executing (target): meson $TARGET_MESON_OPTS $PKG_MESON_OPTS_TARGET $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
-      CC="$HOST_CC" CXX="$HOST_CXX" meson $TARGET_MESON_OPTS $PKG_MESON_OPTS_TARGET $(dirname $PKG_MESON_SCRIPT)
+      create_meson_conf $TARGET $MESON_CONF
+      echo "Executing (target): meson $TARGET_MESON_OPTS --cross-file=$MESON_CONF $PKG_MESON_OPTS_TARGET $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
+      CC="$HOST_CC" CXX="$HOST_CXX" meson $TARGET_MESON_OPTS --cross-file=$MESON_CONF $PKG_MESON_OPTS_TARGET $(dirname $PKG_MESON_SCRIPT)
       ;;
     "meson:host")
-      echo "Executing (host): meson $HOST_MESON_OPTS $PKG_MESON_OPTS_HOST $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
-      meson $HOST_MESON_OPTS $PKG_MESON_OPTS_HOST $(dirname $PKG_MESON_SCRIPT)
+      create_meson_conf $TARGET $MESON_CONF
+      echo "Executing (host): meson $HOST_MESON_OPTS --cross-file=$MESON_CONF $PKG_MESON_OPTS_HOST $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
+      meson $HOST_MESON_OPTS --cross-file=$MESON_CONF $PKG_MESON_OPTS_HOST $(dirname $PKG_MESON_SCRIPT)
       ;;
     "meson:init")
-      echo "Executing (init): meson $INIT_MESON_OPTS $PKG_MESON_OPTS_INIT $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
-      meson $INIT_MESON_OPTS $PKG_MESON_OPTS_INIT $(dirname $PKG_MESON_SCRIPT)
+      create_meson_conf $TARGET $MESON_CONF
+      echo "Executing (init): meson $INIT_MESON_OPTS --cross-file=$MESON_CONF $PKG_MESON_OPTS_INIT $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
+      meson $INIT_MESON_OPTS --cross-file=$MESON_CONF $PKG_MESON_OPTS_INIT $(dirname $PKG_MESON_SCRIPT)
       ;;
     "meson:bootstrap")
-      echo "Executing (bootstrap): meson $BOOTSTRAP_MESON_OPTS $PKG_MESON_OPTS_BOOTSTRAP $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
-      meson $BOOTSTRAP_MESON_OPTS $PKG_MESON_OPTS_BOOTSTRAP $(dirname $PKG_MESON_SCRIPT)
+      create_meson_conf $TARGET $MESON_CONF
+      echo "Executing (bootstrap): meson $BOOTSTRAP_MESON_OPTS --cross-file=$MESON_CONF $PKG_MESON_OPTS_BOOTSTRAP $(dirname $PKG_MESON_SCRIPT)" | tr -s " "
+      meson $BOOTSTRAP_MESON_OPTS --cross-file=$MESON_CONF $PKG_MESON_OPTS_BOOTSTRAP $(dirname $PKG_MESON_SCRIPT)
       ;;
 
     # cmake builds with ninja


### PR DESCRIPTION
- generate cross-file per package, needed since https://github.com/mesonbuild/meson/pull/1807 was merged. build-flags can used like in cmake and configure, now.