### PR TITLE
Update fd628 kodi add-on to support new driver device name.

### DIFF
--- a/packages/addons/service/fd628/sources/resources/lib/fd628dev.py
+++ b/packages/addons/service/fd628/sources/resources/lib/fd628dev.py
@@ -20,7 +20,7 @@ import os
 import struct
 from fd628utils import *
 
-_led_cmd = '/sys/class/leds/fd628_dev/led_cmd'
+_led_cmd = '/sys/class/leds/le-vfd/led_cmd'
 
 class fd628Dev:
 	def __init__(self):

--- a/packages/addons/service/fd628/sources/resources/lib/service.py
+++ b/packages/addons/service/fd628/sources/resources/lib/service.py
@@ -46,8 +46,8 @@ class fd628Addon():
 		self._monitor = monitor
 		self._monitor.setSettingsChangedCallback(self)
 		self._settings = fd628settings.fd628Settings()
-		self._vfdon = '/sys/class/leds/fd628_dev/led_on'
-		self._vfdoff = '/sys/class/leds/fd628_dev/led_off'
+		self._vfdon = '/sys/class/leds/le-vfd/led_on'
+		self._vfdoff = '/sys/class/leds/le-vfd/led_off'
 		self._rlock = threading.RLock()
 
 	def run(self):


### PR DESCRIPTION
Sorry for the mess and the consecutive PRs on something that should've been just one.
This PR fixes the Kodi FD628 Service add-on to work with the new driver.