### PR TITLE
[RFC] projects/Amlogic: don't allow booting from internal for S905/S912

### DIFF
--- a/projects/Amlogic/initramfs/platform_init
+++ b/projects/Amlogic/initramfs/platform_init
@@ -45,7 +45,7 @@ if [ -z "$BOOT_IMAGE" -o -z "$boot" -o -z "$disk" ]; then
   cmdline=$(cat /proc/cmdline)
   if [ -n "$bootfromext" ]; then
     cmdline="$cmdline BOOT_IMAGE=kernel.img boot=LABEL=LIBREELEC disk=LABEL=STORAGE"
-  else
+  elif [ -b /dev/instaboot ]; then
     cmdline="$cmdline BOOT_IMAGE=/dev/boot boot=/dev/system disk=/dev/data"
   fi
   echo "$cmdline" > /proc/cmdline


### PR DESCRIPTION
I'm not sure how this PR will be received so thoughts would be welcome.

In community releases installing LE to internal eMMC/NAND has been supported for some time however this has created many problems over time.

As this feature will not be supported in official LE releases (of which I agree) this PR is intended to prevent users who try to install LE to internal via hacks or other methods from booting so this could be construed as controversial however I believe it would save problem posts on the forums in the future.

Booting from external devices is not effected and Wetek users can still boot from internal, this PR is only intended to effect S905/S912 builds.

Support for Odroid C2 would need to be added and other devices will need to be tested, LePotato/KVIM etc...