### PR TITLE
moonlight: update addon

### DIFF
--- a/packages/addons/addon-depends/moonlight-common-c/package.mk
+++ b/packages/addons/addon-depends/moonlight-common-c/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="moonlight-common-c"
-PKG_VERSION="f6ae7fc"
-PKG_SHA256="36cc8ddb03d248730ee57e936e133fb642e61589cc294da7ee7c8bed30ba8c18"
+PKG_VERSION="c4692a5"
+PKG_SHA256="9add55e53436d9f78c1dd88c5a4e3932d30922609e3f6ac6a007a635aa82f209"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/moonlight-stream/moonlight-common-c"

--- a/packages/addons/addon-depends/moonlight-embedded/package.mk
+++ b/packages/addons/addon-depends/moonlight-embedded/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="moonlight-embedded"
-PKG_VERSION="a4b6de1"
-PKG_SHA256="54c53f0f6abcd49aadd065e6a5cdd1bff1ca5b8c6461fff2dc220d9465f487ce"
+PKG_VERSION="dcda1a5"
+PKG_SHA256="b0fead77d77a6ffa73488ead2564ecba43d5c6ac397d5a751ef687f5fb42f29d"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/irtimmer/moonlight-embedded"

--- a/packages/addons/script/moonlight/changelog.txt
+++ b/packages/addons/script/moonlight/changelog.txt
@@ -1,3 +1,9 @@
+109
+- updated moonlight-embedded and moonlight-common-c
+
+108
+- update to moonlight-4d94439
+
 107
 - updated moonlight-embedded and moonlight-common-c
 

--- a/packages/addons/script/moonlight/package.mk
+++ b/packages/addons/script/moonlight/package.mk
@@ -20,7 +20,7 @@ PKG_NAME="moonlight"
 PKG_VERSION="4d94439"
 PKG_SHA256="5190f9c3a0fd17c7c8f0de8c2509f4749a2f399b7dc4d1402dd55c6f351260b2"
 PKG_VERSION_NUMBER="2.2.2"
-PKG_REV="108"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/dead/script.moonlight"
@@ -57,8 +57,8 @@ addon() {
     cp -P $(get_build_dir moonlight-embedded)/.$TARGET_NAME/moonlight $ADDON_BUILD/$PKG_ADDON_ID/bin
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/lib
-    cp $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libgamestream/libgamestream.so.2 $ADDON_BUILD/$PKG_ADDON_ID/lib
-    cp $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libgamestream/libmoonlight-common.so.2 $ADDON_BUILD/$PKG_ADDON_ID/lib
+    cp $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libgamestream/libgamestream.so.2.4.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
+    cp $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libgamestream/libmoonlight-common.so.2.4.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
 
     if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
       cp -P $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libmoonlight-pi.so $ADDON_BUILD/$PKG_ADDON_ID/lib


### PR DESCRIPTION
Update moonlight addon.

Fixes build error of moonlight-embedded for WeTek Core and WeTek Play 1 projects:
```
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found CURL: /var/lib/jenkins/LE/build2/workspace/Addons/Category/script/moonlight/build.LibreELEC-WeTek_Core.arm-9.0-devel/toolchain/armv7a-libreelec-linux-gnueabi/sysroot/usr/lib/libcurl.so (found version "7.58.0") 
-- Found OpenSSL: /var/lib/jenkins/LE/build2/workspace/Addons/Category/script/moonlight/build.LibreELEC-WeTek_Core.arm-9.0-devel/toolchain/armv7a-libreelec-linux-gnueabi/sysroot/usr/lib/libcrypto.so (found suitable version "1.0.2n", minimum required is "1.0.2") 
-- Found EXPAT: /var/lib/jenkins/LE/build2/workspace/Addons/Category/script/moonlight/build.LibreELEC-WeTek_Core.arm-9.0-devel/toolchain/armv7a-libreelec-linux-gnueabi/sysroot/usr/lib/libexpat.so (found version "2.2.5") 
-- Checking for module 'avahi-client'
--   Found avahi-client, version 0.7
-- Checking for module 'libenet'
--   Found libenet, version 1.3.13
CMake Error at CMakeLists.txt:156 (message):
 No video output available
```