### PR TITLE
openssl: update to openssl-1.0.2o [backport]

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="openssl"
-PKG_VERSION="1.0.2l"
+PKG_VERSION="1.0.2o"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"


### PR DESCRIPTION
1.0.2m: https://www.openssl.org/news/secadv/20171102.txt
1.0.2n: https://www.openssl.org/news/secadv/20171207.txt
1.0.2o: https://mta.openssl.org/pipermail/openssl-announce/2018-March/000119.html

No must-have fixes, but brings us up to date and should be low-risk, but close if not wanted.