### PR TITLE
[LE 8.2] WeTek Play, WeTek Core, WeTek Hub, WeTek Play 2: add support for WeTek Pro Remote

### DIFF
--- a/packages/sysutils/amremote/scripts/remote-config
+++ b/packages/sysutils/amremote/scripts/remote-config
@@ -25,6 +25,9 @@ if [ -f /storage/.config/remote.conf ]; then
   /usr/bin/remotecfg /storage/.config/remote.conf
 elif [ -f /etc/amremote/remote.conf ]; then
   /usr/bin/remotecfg /etc/amremote/remote.conf
+  if [ -f /etc/amremote/remote1.conf ]; then
+    /usr/bin/remotecfg /etc/amremote/remote1.conf
+  fi
 elif [ "$LSUSB_RET" = 0 ]; then
   /usr/bin/remotecfg /etc/amremote/wetek.conf
 elif [ "$LSUSB_RET" = 1 ]; then

--- a/projects/WeTek_Core/filesystem/etc/amremote/remote1.conf
+++ b/projects/WeTek_Core/filesystem/etc/amremote/remote1.conf
@@ -1,0 +1,82 @@
+#*********************************************************************************************************
+#this file is configuration for each factory remote device
+# 	work_mode	  0 :software mode  1 :hardware mode
+#	repeat_enable	  0 :disable repeat 1 :enable repeat
+#
+#	factory_code      each device has it's unique factory code.
+#			  pattern:custom_code(16bit)+index_code(16bit)
+#			  examble: 0xff000001 = 0xff00(custom cod)  0001 (index)
+#
+#	release_delay	  unit:ms.release will report from kernel to user layer after this period of time
+#			  from press or repeat triggered.
+#
+#	debug_enable      0 :debug disable  1 :debug disable
+#
+# SW MODE:
+#	bit_count	  how many bits in each frame
+#	tw_leader_act	  time window for leader active
+#	tw_bit0		  time window for bit0 time.
+#	tw_bit1		  time window for bit1 time
+#	tw_repeat_leader  time window for repeat leader
+# REG
+#	reg_base_gen	  set value for PREG_IR_DEC_BASE_GEN
+#	reg_control	  set value for PREG_IR_DEC_CONTROL
+#	reg_leader_act	  set value for PREG_IR_DEC_LEADER_ACTIVE
+#	reg_leader_idle	  set value for PREG_IR_DEC_LEADER_IDLE
+#	reg_repeat_leader set value for PREG_IR_DEC_REPEAT_IDLE
+#	reg_bit0_time	  set value for PREG_IR_DEC_BIT0_TIME
+#*************************************************************************************************************
+# WeTek Pro Remote
+factory_infcode = 1
+factory_code	= 0xfe010001
+work_mode  	= 0
+repeat_enable	= 1
+repeat_delay	= 40
+repeat_peroid	= 39
+release_delay	= 121
+debug_enable 	= 1
+
+key_begin
+    0x0c 116 # power
+    0x2a 398 # red
+    0x2b 399 # green
+    0x2c 400 # yellow
+    0x2d 401 # blue
+    0x11 168 # rewind
+    0x12 164 # play/pause
+    0x13 208 # fast forward
+    0x14 167 # record
+    0x17 139 # menu
+    0x1a 15  # app switch
+    0x29 102 # home
+    0x1d 158 # back
+    0x0f 370 # subtitles
+    0x27 113 # volume mute
+    0x10 388 # teletext
+    0x0b 366 # recordings
+    0x28 358 # info
+    0x0a 218 # share
+    0x22 103 # up
+    0x23 108 # down
+    0x24 105 # left
+    0x25 106 # right
+    0x26 28  # ok
+    0x1e 115 # volume up
+    0x1f 114 # volume down
+    0x20 104 # channel up
+    0x21 109 # channel down
+    0x01 2 # 1
+    0x02 3 # 2
+    0x03 4 # 3
+    0x04 5 # 4
+    0x05 6 # 5
+    0x06 7 # 6
+    0x07 8 # 7
+    0x08 9 # 8
+    0x09 10 # 9
+    0x00 11 # 0
+    0x4b 448 # factory red
+    0x4d 449 # factory green
+    0x50 450 # factory yellow
+    0x51 451 # factory blue
+key_end

--- a/projects/WeTek_Hub/patches/linux/wetek_pro_remote.patch
+++ b/projects/WeTek_Hub/patches/linux/wetek_pro_remote.patch
@@ -1,0 +1,59 @@
+diff --git a/drivers/media/rc/keymaps/rc-wetek-hub.c b/drivers/media/rc/keymaps/rc-wetek-hub.c
+index 0955ecfcb77..0da1b237b09 100644
+--- a/drivers/media/rc/keymaps/rc-wetek-hub.c
++++ b/drivers/media/rc/keymaps/rc-wetek-hub.c
+@@ -12,6 +12,7 @@
+ #include <linux/module.h>
+ 
+ static struct rc_map_table wetek_hub[] = {
++	// WeTek Hub remote
+ 	{ 0x77f1, KEY_POWER },
+ 	{ 0x77f2, KEY_HOME },
+ 	{ 0x77f3, KEY_MUTE },
+@@ -24,6 +25,46 @@ static struct rc_map_table wetek_hub[] = {
+ 	{ 0x77fa, KEY_MENU },
+ 	{ 0x77fb, KEY_VOLUMEUP },
+ 	{ 0x77fc, KEY_VOLUMEDOWN },
++
++	// WeTek Pro Remote
++	{ 0x010c, KEY_POWER },
++	{ 0x012a, KEY_RED },
++	{ 0x012b, KEY_GREEN },
++	{ 0x012c, KEY_YELLOW },
++	{ 0x012d, KEY_BLUE },
++	{ 0x0111, KEY_REWIND },
++	{ 0x0112, KEY_PLAYPAUSE },
++	{ 0x0113, KEY_FASTFORWARD },
++	{ 0x0114, KEY_RECORD },
++	{ 0x0117, KEY_MENU },
++	{ 0x011a, KEY_TAB },
++	{ 0x0129, KEY_HOME },
++	{ 0x011d, KEY_BACK },
++	{ 0x010F, KEY_SUBTITLE },
++	{ 0x0127, KEY_MUTE },
++	{ 0x0110, KEY_TEXT },
++	{ 0x010b, KEY_PVR },
++	{ 0x0128, KEY_INFO },
++	{ 0x010a, KEY_CONNECT },
++	{ 0x0122, KEY_UP },
++	{ 0x0123, KEY_DOWN },
++	{ 0x0124, KEY_LEFT },
++	{ 0x0125, KEY_RIGHT },
++	{ 0x0126, KEY_OK },
++	{ 0x011e, KEY_VOLUMEUP },
++	{ 0x011f, KEY_VOLUMEDOWN },
++	{ 0x0120, KEY_PAGEUP },
++	{ 0x0121, KEY_PAGEDOWN },
++	{ 0x0101, KEY_1 },
++	{ 0x0102, KEY_2 },
++	{ 0x0103, KEY_3 },
++	{ 0x0104, KEY_4 },
++	{ 0x0105, KEY_5 },
++	{ 0x0106, KEY_6 },
++	{ 0x0107, KEY_7 },
++	{ 0x0108, KEY_8 },
++	{ 0x0109, KEY_9 },
++	{ 0x0100, KEY_0 },
+ };
+ 
+ static struct rc_map_list wetek_hub_map = {

--- a/projects/WeTek_Play/filesystem/etc/amremote/remote1.conf
+++ b/projects/WeTek_Play/filesystem/etc/amremote/remote1.conf
@@ -1,0 +1,82 @@
+#*********************************************************************************************************
+#this file is configuration for each factory remote device
+# 	work_mode	  0 :software mode  1 :hardware mode
+#	repeat_enable	  0 :disable repeat 1 :enable repeat
+#
+#	factory_code      each device has it's unique factory code.
+#			  pattern:custom_code(16bit)+index_code(16bit)
+#			  examble: 0xff000001 = 0xff00(custom cod)  0001 (index)
+#
+#	release_delay	  unit:ms.release will report from kernel to user layer after this period of time
+#			  from press or repeat triggered.
+#
+#	debug_enable      0 :debug disable  1 :debug disable
+#
+# SW MODE:
+#	bit_count	  how many bits in each frame
+#	tw_leader_act	  time window for leader active
+#	tw_bit0		  time window for bit0 time.
+#	tw_bit1		  time window for bit1 time
+#	tw_repeat_leader  time window for repeat leader
+# REG
+#	reg_base_gen	  set value for PREG_IR_DEC_BASE_GEN
+#	reg_control	  set value for PREG_IR_DEC_CONTROL
+#	reg_leader_act	  set value for PREG_IR_DEC_LEADER_ACTIVE
+#	reg_leader_idle	  set value for PREG_IR_DEC_LEADER_IDLE
+#	reg_repeat_leader set value for PREG_IR_DEC_REPEAT_IDLE
+#	reg_bit0_time	  set value for PREG_IR_DEC_BIT0_TIME
+#*************************************************************************************************************
+# WeTek Pro Remote
+factory_infcode = 1
+factory_code	= 0xfe010001
+work_mode  	= 0
+repeat_enable	= 1
+repeat_delay	= 40
+repeat_peroid	= 39
+release_delay	= 121
+debug_enable 	= 1
+
+key_begin
+    0x0c 116 # power
+    0x2a 398 # red
+    0x2b 399 # green
+    0x2c 400 # yellow
+    0x2d 401 # blue
+    0x11 168 # rewind
+    0x12 164 # play/pause
+    0x13 208 # fast forward
+    0x14 167 # record
+    0x17 139 # menu
+    0x1a 15  # app switch
+    0x29 102 # home
+    0x1d 158 # back
+    0x0f 370 # subtitles
+    0x27 113 # volume mute
+    0x10 388 # teletext
+    0x0b 366 # recordings
+    0x28 358 # info
+    0x0a 218 # share
+    0x22 103 # up
+    0x23 108 # down
+    0x24 105 # left
+    0x25 106 # right
+    0x26 28  # ok
+    0x1e 115 # volume up
+    0x1f 114 # volume down
+    0x20 104 # channel up
+    0x21 109 # channel down
+    0x01 2 # 1
+    0x02 3 # 2
+    0x03 4 # 3
+    0x04 5 # 4
+    0x05 6 # 5
+    0x06 7 # 6
+    0x07 8 # 7
+    0x08 9 # 8
+    0x09 10 # 9
+    0x00 11 # 0
+    0x4b 448 # factory red
+    0x4d 449 # factory green
+    0x50 450 # factory yellow
+    0x51 451 # factory blue
+key_end

--- a/projects/WeTek_Play_2/filesystem/etc/amremote/remote1.conf
+++ b/projects/WeTek_Play_2/filesystem/etc/amremote/remote1.conf
@@ -1,0 +1,82 @@
+#*********************************************************************************************************
+#this file is configuration for each factory remote device
+# 	work_mode	  0 :software mode  1 :hardware mode
+#	repeat_enable	  0 :disable repeat 1 :enable repeat
+#
+#	factory_code      each device has it's unique factory code.
+#			  pattern:custom_code(16bit)+index_code(16bit)
+#			  examble: 0xff000001 = 0xff00(custom cod)  0001 (index)
+#
+#	release_delay	  unit:ms.release will report from kernel to user layer after this period of time
+#			  from press or repeat triggered.
+#
+#	debug_enable      0 :debug disable  1 :debug disable
+#
+# SW MODE:
+#	bit_count	  how many bits in each frame
+#	tw_leader_act	  time window for leader active
+#	tw_bit0		  time window for bit0 time.
+#	tw_bit1		  time window for bit1 time
+#	tw_repeat_leader  time window for repeat leader
+# REG
+#	reg_base_gen	  set value for PREG_IR_DEC_BASE_GEN
+#	reg_control	  set value for PREG_IR_DEC_CONTROL
+#	reg_leader_act	  set value for PREG_IR_DEC_LEADER_ACTIVE
+#	reg_leader_idle	  set value for PREG_IR_DEC_LEADER_IDLE
+#	reg_repeat_leader set value for PREG_IR_DEC_REPEAT_IDLE
+#	reg_bit0_time	  set value for PREG_IR_DEC_BIT0_TIME
+#*************************************************************************************************************
+# WeTek Pro Remote
+factory_infcode = 1
+factory_code	= 0xfe010001
+work_mode  	= 0
+repeat_enable	= 1
+repeat_delay	= 40
+repeat_peroid	= 39
+release_delay	= 121
+debug_enable 	= 1
+
+key_begin
+    0x0c 116 # power
+    0x2a 398 # red
+    0x2b 399 # green
+    0x2c 400 # yellow
+    0x2d 401 # blue
+    0x11 168 # rewind
+    0x12 164 # play/pause
+    0x13 208 # fast forward
+    0x14 167 # record
+    0x17 139 # menu
+    0x1a 15  # app switch
+    0x29 102 # home
+    0x1d 158 # back
+    0x0f 370 # subtitles
+    0x27 113 # volume mute
+    0x10 388 # teletext
+    0x0b 366 # recordings
+    0x28 358 # info
+    0x0a 218 # share
+    0x22 103 # up
+    0x23 108 # down
+    0x24 105 # left
+    0x25 106 # right
+    0x26 28  # ok
+    0x1e 115 # volume up
+    0x1f 114 # volume down
+    0x20 104 # channel up
+    0x21 109 # channel down
+    0x01 2 # 1
+    0x02 3 # 2
+    0x03 4 # 3
+    0x04 5 # 4
+    0x05 6 # 5
+    0x06 7 # 6
+    0x07 8 # 7
+    0x08 9 # 8
+    0x09 10 # 9
+    0x00 11 # 0
+    0x4b 448 # factory red
+    0x4d 449 # factory green
+    0x50 450 # factory yellow
+    0x51 451 # factory blue
+key_end


### PR DESCRIPTION
Add support for WeTek Pro Remote (https://wetek.com/ww/en/product/pro-remote) to WeTek Play, WeTek Core, WeTek Hub , and WeTek Play 2 projects.