### PR TITLE
moonlight: fix libraries

### DIFF
--- a/config/addon/xbmc.service.pluginsource.xml
+++ b/config/addon/xbmc.service.pluginsource.xml
@@ -11,7 +11,8 @@
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>@PKG_ADDON_PROVIDES@</provides>
   </extension>
-  <extension point="xbmc.service">
+  <extension point="xbmc.service" library="service.py">
+    <provides>@PKG_ADDON_PROVIDES@</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
     <summary>@PKG_SHORTDESC@</summary>

--- a/packages/addons/script/moonlight/package.mk
+++ b/packages/addons/script/moonlight/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="moonlight"
-PKG_VERSION="4d94439"
-PKG_SHA256="5190f9c3a0fd17c7c8f0de8c2509f4749a2f399b7dc4d1402dd55c6f351260b2"
+PKG_VERSION="29f4511"
+PKG_SHA256="7bb7ed08345fde16a8aefb35ed6fca898ff83f0f45d1c2850b17ee7f1a7e84fc"
 PKG_VERSION_NUMBER="2.2.2"
 PKG_REV="109"
 PKG_ARCH="any"
@@ -40,7 +40,6 @@ PKG_ADDON_PROVIDES="executable"
 post_unpack() {
   # don't use the files from the script
   rm $PKG_BUILD/script.moonlight/icon.png
-  rm $PKG_BUILD/script.moonlight/changelog.txt
 }
 
 addon() {
@@ -50,15 +49,12 @@ addon() {
     # use our own changelog.txt
     cp $PKG_DIR/changelog.txt $ADDON_BUILD/$PKG_ADDON_ID
 
-    # let's use our addon.xml instead
-    rm $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
-
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin
     cp -P $(get_build_dir moonlight-embedded)/.$TARGET_NAME/moonlight $ADDON_BUILD/$PKG_ADDON_ID/bin
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/lib
-    cp $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libgamestream/libgamestream.so.2.4.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
-    cp $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libgamestream/libmoonlight-common.so.2.4.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
+    cp $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libgamestream/libgamestream.so.3 $ADDON_BUILD/$PKG_ADDON_ID/lib
+    cp $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libgamestream/libmoonlight-common.so.3 $ADDON_BUILD/$PKG_ADDON_ID/lib
 
     if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
       cp -P $(get_build_dir moonlight-embedded)/.$TARGET_NAME/libmoonlight-pi.so $ADDON_BUILD/$PKG_ADDON_ID/lib


### PR DESCRIPTION
this fixes moonlight binary to have at least the correct libraries and was reported working from shell, the moonlight kodi script is still half/full broken

I opened an issue https://github.com/dead/script.moonlight/issues/60 maybe this get fixed upstream some day. This pr fixes the most obvious problems and ensures, at least, it working from shell.