### PR TITLE
buildsystem: cleanups, use sha256sum for stamp function

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -509,10 +509,10 @@ build_with_debug() {
     [ "${PKG_NAME}" = "debug" ] && return 0
 
     # Build addons with debug if we're building the mediacenter with debug
-    [ "${PKG_IS_ADDON}" == "yes" ] && listcontains "${_DEBUG_DEPENDS_LIST}" "${MEDIACENTER}" && return 0
+    [ "${PKG_IS_ADDON}" = "yes" ] && listcontains "${_DEBUG_DEPENDS_LIST}" "${MEDIACENTER}" && return 0
 
     # Build kernel packages with debug if we're building the kernel with debug
-    [ "${PKG_IS_KERNEL_PKG}" == "yes" ] && listcontains "${_DEBUG_DEPENDS_LIST}" "linux" && return 0
+    [ "${PKG_IS_KERNEL_PKG}" = "yes" ] && listcontains "${_DEBUG_DEPENDS_LIST}" "linux" && return 0
 
     # Build this package with debug if it's a resolved dependency
     listcontains "${_DEBUG_DEPENDS_LIST}" "${PKG_NAME}" && return 0
@@ -896,7 +896,7 @@ debug_strip() {
 print_color() {
   local clr_name="$1" clr_text="$2" clr_actual
 
-  if [ "$DISABLE_COLORS" == "yes" ]; then
+  if [ "$DISABLE_COLORS" = "yes" ]; then
     [ $# -eq 2 ] && echo -en "${clr_text}"
     return 0
   fi

--- a/config/functions
+++ b/config/functions
@@ -322,6 +322,14 @@ get_pkg_variable() {
   fi
 }
 
+calculate_stamp() {
+  local stamp
+  stamp="$PKG_DIR $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
+  [ -n "$DEVICE" ] && stamp+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
+  [ -n "$PKG_NEED_UNPACK" ] && stamp+=" $PKG_NEED_UNPACK"
+  find ${stamp} -exec sha256sum {} \; 2>/dev/null | sed "s/ ${ROOT//\//\\/}\// /" | sort | sha256sum | cut -d" " -f1
+}
+
 # return 0 if $2 in space-separated list $1, otherwise return 1
 listcontains() {
   if [ -n "$1" -a -n "$2" ]; then

--- a/packages/lang/Python2/package.mk
+++ b/packages/lang/Python2/package.mk
@@ -88,6 +88,10 @@ makeinstall_host() {
        install
 }
 
+post_makeinstall_host() {
+  rm -fr $PKG_BUILD/.$HOST_NAME/build/temp.*
+}
+
 pre_configure_target() {
   export PYTHON_FOR_BUILD=$TOOLCHAIN/bin/python
 }
@@ -114,6 +118,8 @@ makeinstall_target() {
 }
 
 post_makeinstall_target() {
+  rm -fr $PKG_BUILD/.$TARGET_NAME/build/temp.*
+
   for dir in bsddb idlelib lib-tk lib2to3 msilib pydoc_data test unittest; do
     rm -rf $INSTALL/usr/lib/python*/$dir
   done

--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -114,10 +114,14 @@ post_makeinstall_host() {
   rm -f $TOOLCHAIN/bin/pyvenv
   rm -f $TOOLCHAIN/bin/pydoc*
 
+  rm -fr $PKG_BUILD/.$HOST_NAME/build/temp.*
+
   cp $PKG_BUILD/Tools/scripts/reindent.py $TOOLCHAIN/lib/$PKG_PYTHON_VERSION
 }
 
 post_makeinstall_target() {
+  rm -fr $PKG_BUILD/.$TARGET_NAME/build/temp.*
+
   PKG_INSTALL_PATH_LIB=$INSTALL/usr/lib/$PKG_PYTHON_VERSION
 
   for dir in config compiler sysconfigdata lib-dynload/sysconfigdata lib2to3 test; do

--- a/scripts/build
+++ b/scripts/build
@@ -65,13 +65,10 @@ STAMP=$STAMPS/$PACKAGE_NAME/build_$TARGET
 
 $SCRIPTS/unpack $PACKAGE_NAME
 
-STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
-[ -n "$DEVICE" ] && STAMP_DEPENDS="$STAMP_DEPENDS $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
-
 if [ -f $STAMP ] ; then
   . $STAMP
-  PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
-  if [ ! "$PKG_DEEPMD5" = "$STAMP_PKG_DEEPMD5" ] ; then
+  PKG_DEEPHASH=$(calculate_stamp)
+  if [ ! "$PKG_DEEPHASH" = "$STAMP_PKG_DEEPHASH" ] ; then
     rm -f $STAMP
   fi
 
@@ -240,8 +237,8 @@ export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 # virtual packages dont must be build, they only contains dependencies, so dont go further here
 if [ "$PKG_SECTION" = "virtual" ]; then
-  PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
-  for i in PKG_NAME PKG_DEEPMD5 BUILD_WITH_DEBUG; do
+  PKG_DEEPHASH=$(calculate_stamp)
+  for i in PKG_NAME PKG_DEEPHASH BUILD_WITH_DEBUG; do
     echo "STAMP_$i=\"${!i}\"" >> $STAMP
   done
 
@@ -560,8 +557,8 @@ for i in `find $SYSROOT_PREFIX/usr/lib/ -name "*.la" 2>/dev/null`; do \
   $SED "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $i; \
 done
 
-PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
-for i in PKG_NAME PKG_DEEPMD5 BUILD_WITH_DEBUG; do
+PKG_DEEPHASH=$(calculate_stamp)
+for i in PKG_NAME PKG_DEEPHASH BUILD_WITH_DEBUG; do
   echo "STAMP_$i=\"${!i}\"" >> $STAMP
 done
 

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -57,8 +57,8 @@ get_yes_no()
 {
   local ans
   read -p "Would you like to install the needed tools ? (y/n) " ans
-  [ "${ans,,}" == "y" ] && return 0
-  [ "${ans,,}" == "yes" ] && return 0
+  [ "${ans,,}" = "y" ] && return 0
+  [ "${ans,,}" = "yes" ] && return 0
   return 1
 }
 

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -180,7 +180,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     fi
   fi
 
-  if [ ! "$PKG_NAME" == "configtools" ] ; then
+  if [ ! "$PKG_NAME" = "configtools" ] ; then
     for config in `find $PKG_BUILD -name config.guess | sed 's/config.guess//'`; do
       printf "%${BUILD_INDENT}c $(print_color CLR_FIXCONFIG "FIXCONFIG")   $config\n" ' '
 

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -36,17 +36,14 @@ STAMP=$PKG_BUILD/.libreelec-unpack
 
 mkdir -p $BUILD
 
-STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
-[ -n "$DEVICE" ] && STAMP_DEPENDS="$STAMP_DEPENDS $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
-
 # Perform a wildcard match on the package to ensure old versions are cleaned too
-PKG_DEEPMD5=
+PKG_DEEPHASH=
 for i in $BUILD/$1-*; do
   if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
     . "$i/.libreelec-unpack"
     if [ "$STAMP_PKG_NAME" = "$1" ]; then
-      [ -z "${PKG_DEEPMD5}" ] && PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
-      if [ ! "$PKG_DEEPMD5" = "$STAMP_PKG_DEEPMD5" ] ; then
+      [ -z "${PKG_DEEPHASH}" ] && PKG_DEEPHASH=$(calculate_stamp)
+      if [ ! "$PKG_DEEPHASH" = "$STAMP_PKG_DEEPHASH" ] ; then
         $SCRIPTS/clean $1
       fi
     fi
@@ -200,8 +197,8 @@ if [ "$PKG_SECTION" != "virtual" ]; then
 
   rm -f $STAMPS/$1/build_*
 
-  PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
-  for i in PKG_NAME PKG_DEEPMD5; do
+  PKG_DEEPHASH=$(calculate_stamp)
+  for i in PKG_NAME PKG_DEEPHASH; do
     echo "STAMP_$i=\"${!i}\"" >> $STAMP
   done
 fi


### PR DESCRIPTION
Clean builds required (as this will change all the stamps).

The Python changes remove junk left in the build directories.

Stamp generation is ripe for a function, and using a better hashing function is now trivial.

`==` works fine, but we use `=`.