### PR TITLE
kodi: remove rss hack

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -25,12 +25,6 @@ BOOT_STATE="$(cat $HOME/.config/boot.status 2>/dev/null)"
 # done in kodi on addon install. but just in case..
 chmod +x $KODI_ROOT/addons/*/bin/* 2>/dev/null
 
-# hack: update RSSnews.xml in userdata
-if [ -f $KODI_ROOT/userdata/RssFeeds.xml ]; then
-  sed -e "s,http://libreelec.tv/news?format=feed&type=rss,http://feeds.libreelec.tv/news,g" \
-      -i $KODI_ROOT/userdata/RssFeeds.xml
-fi
-
 # setup Kodi sources
 if [ ! -f $KODI_ROOT/userdata/sources.xml ]; then
   if [ -f /usr/share/kodi/config/sources.xml ]; then


### PR DESCRIPTION
No idea about the porpouse of that hack but this looks rather dead code. 
Also `http://libreelec.tv/news?format=feed&type=rss` or `http://feeds.libreelec.tv/news` were never a valid source of rss in the past.