### PR TITLE
Make build work under WSL (Windows services for Linux)

### DIFF
--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -32,4 +32,5 @@ PKG_SECTION="toolchain/devel"
 PKG_SHORTDESC="fakeroot: provides a fake root environment by means of LD_PRELOAD and SYSV IPC (or TCP) trickery."
 PKG_LONGDESC="fakeroot provides a fake root environment by means of LD_PRELOAD and SYSV IPC (or TCP) trickery."
 
-PKG_CONFIGURE_OPTS_HOST="--with-gnu-ld"
+#Use tcp instead of ipc in order to make it work with WSL
+PKG_CONFIGURE_OPTS_HOST="--with-gnu-ld --with-ipc=tcp"

--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -65,6 +65,10 @@ configure_host() {
 
 makeinstall_host() {
   make INSTALL_PREFIX=$TOOLCHAIN install_sw
+  WSL=$(grep Microsoft /proc/version)
+  if [ ! -z "$WSL" ]; then
+    execstack -c $TOOLCHAIN/lib/libcrypto.so*  
+  fi
 }
 
 pre_configure_target() {

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -122,6 +122,13 @@ case "$DISTRO" in
       ;;
 esac
 
+# On WSL the stackexec flag need to be removed from openssl
+WSL=$(grep Microsoft /proc/version)
+if [ ! -z "$WSL" ]; then
+	deps+=(execstack)
+	deps_pkg+=(execstack)
+fi
+
 # project specific dependencies
 if [ -n "$EXTRA_DEPS" ] ; then
   deps+=($EXTRA_DEPS)


### PR DESCRIPTION
In order to avoid using a VM under Windows for building LibreElec, I figured out that actually
only a few changes are required to make it work with WSL (Windows services for Linux).
Tested with Debian running on WSL

- fakeroot: Use tcp instead of ipc as it is still not implemented in WSL
- openssl: Clear execstack bit on libcrypto after host build when running on WSL
- checkdeps: Add execstack to dependencies if WSL is detected (Checking for "Microsoft" in /proc/version)