### PR TITLE
samba: fix interleaved config generation/modification

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -142,6 +142,8 @@ post_makeinstall_target() {
 
   mkdir -p $INSTALL/usr/lib/samba
     cp $PKG_DIR/scripts/samba-config $INSTALL/usr/lib/samba
+    cp $PKG_DIR/scripts/smbd-config $INSTALL/usr/lib/samba
+    cp $PKG_DIR/scripts/samba-autoshare $INSTALL/usr/lib/samba
 
   if find_file_path config/smb.conf; then
     mkdir -p $INSTALL/etc/samba
@@ -166,10 +168,6 @@ post_makeinstall_target() {
 
     mkdir -p $INSTALL/usr/share/services
       cp -P $PKG_DIR/default.d/*.conf $INSTALL/usr/share/services
-
-    mkdir -p $INSTALL/usr/lib/samba
-      cp $PKG_DIR/scripts/samba-autoshare $INSTALL/usr/lib/samba
-      cp $PKG_DIR/scripts/smbd-config $INSTALL/usr/lib/samba
   fi
 }
 

--- a/packages/network/samba/scripts/samba-autoshare
+++ b/packages/network/samba/scripts/samba-autoshare
@@ -22,7 +22,6 @@ if [ -f /storage/.cache/services/samba.conf ]; then
 
   if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
     /usr/lib/samba/samba-config
-    /usr/lib/samba/smbd-config
     [ -f /run/samba/smbd.pid ] && pkill -HUP smbd
   fi
 fi

--- a/packages/network/samba/scripts/samba-config
+++ b/packages/network/samba/scripts/samba-config
@@ -46,3 +46,10 @@ mkdir -p $(dirname $SMB_CONF)
   else
     cp $SMB_DEFCONF $SMB_CONF
   fi
+
+# Generate smb.conf, unless disabled
+if [ ! -f /storage/.cache/services/samba.disabled ]; then
+  /usr/lib/samba/smbd-config
+fi
+
+exit 0

--- a/packages/network/samba/system.d.opt/nmbd.service
+++ b/packages/network/samba/system.d.opt/nmbd.service
@@ -3,7 +3,7 @@ Description=Samba NMB Daemon
 After=network.target samba-config.service
 ConditionPathExists=!/storage/.cache/services/samba.disabled
 ConditionPathExists=/run/samba/smb.conf
-Requires=samba-config.service
+Wants=samba-config.service
 
 [Service]
 Type=forking

--- a/packages/network/samba/system.d.opt/smbd.service
+++ b/packages/network/samba/system.d.opt/smbd.service
@@ -9,7 +9,6 @@ Wants=samba-config.service
 Type=forking
 PIDFile=/run/samba/smbd.pid
 LimitNOFILE=16384
-ExecStartPre=/usr/lib/samba/smbd-config
 ExecStart=/usr/sbin/smbd
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=1s

--- a/packages/network/samba/system.d.opt/smbd.service
+++ b/packages/network/samba/system.d.opt/smbd.service
@@ -3,7 +3,7 @@ Description=Samba SMB Daemon
 After=network.target samba-config.service
 ConditionPathExists=!/storage/.cache/services/samba.disabled
 ConditionPathExists=/run/samba/smb.conf
-Requires=samba-config.service
+Wants=samba-config.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
When booting with external storage already attached, there's a race condition caused by `samba-autoshare` which is started by `udevil-mount`.

`samba-config` is executed as soon as `sysinit.target` is reached - this will create `/run/samba/smb.conf`.

`udevil-mount` will subsequently execute `samba-autoshare` which unconditionally executes `samba-config` overwriting `/run/samba/smb.conf`, followed by `smbd-config` that adds `workgroup`. `server min protocol`, `server max protocol` and the auto shares, to `/run/samba/smb.conf`.

Samba is then started (starting `nmbd` and `smbd`) and both these units require `samba-config`, however `samba-config` has already been started after reaching `sysinit-target` so systemd does not start this unit again. Consequently when `smbd-config` is executed by `smbd` as `ExecStartPre=`, it inserts duplicate entries for `server min protocol`, `server max protocol`, and duplicates auto-share sections, into `/run/samba/smb.conf`.

What we have is this sequence...

* `sysinit.target` reached
  * Execute `samba-config` (creating `/run/samba/smb.conf`)

* Start: `udevil-mount`
  * Execute `samba-autoshare`
    * Calls  `samba-config` (overwriting `/run/samba/smb.conf`)
    * Calls `smbd-config` (inserts `workgroup`, `min protocol`, `max protocol`, and shares)
  * Started: `udevil-mount`

* Start: `nmbd`
  * Has `Requires=samba-config` but already satisfied by `sysinit-target`
  * Started: `nmbd`
  
* Start: `smbd`
  * Has `Requires=samba-config` but already satisfied by `sysinit-target`
  * Execute `smbd-config` (inserting `workgroup`, `min protocol`, `max protocol`, and shares *again*)
  * Started: `smbd`

Boiling it down, the calls to `samba-config` and `smbd-config` are interleaved:

* `samba-config` (`sysinit-target`, creates /run/samba/smb.conf)
* `samba-config` (`samba-autoshare`, overwrites /run/samba/smb.conf)
* `smbd-config`  (`samba-autoshare`, insert workgroup etc.)
* `smbd-config`  (`smbd`, insert workgroup etc. *again*)

This PR collapses `samba-config`/`smbd-config` into a single indivisible call.