### PR TITLE
scripts/image: support periodic image names

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -38,19 +38,22 @@ $SCRIPTS/build kmod:host
 $SCRIPTS/build mtools:host
 $SCRIPTS/build populatefs:host
 
-BUILD_DATE=`date +%Y%m%d%H%M%S`
-
-GIT_HASH=$(git rev-parse HEAD)
+if [ -n "$CUSTOM_GIT_HASH" ]; then
+  GIT_HASH="$CUSTOM_GIT_HASH"
+else
+  GIT_HASH=$(git rev-parse HEAD)
+fi
 
 if [ "$LIBREELEC_VERSION" = "devel" ]; then
-  if ! GIT_BUILD=$(git rev-list --count HEAD 2>/dev/null)
-  then
-    GIT_BUILD=$(git rev-list HEAD | wc -l)
-  fi
-  GIT_ABBREV=$(git log -1 --pretty=format:%h)
+  GIT_ABBREV=${GIT_HASH:0:7}
   DEVEL_VERSION=$LIBREELEC_VERSION
-  LIBREELEC_VERSION=$LIBREELEC_VERSION-$BUILD_DATE-r$GIT_BUILD-g$GIT_ABBREV
-  echo "$LIBREELEC_VERSION" > $BUILD/BUILD_FILENAME
+  case "$BUILD_PERIODIC" in
+    nightly) LIBREELEC_VERSION=nightly-$(date +%Y%m%d)-$GIT_ABBREV;;
+    daily)   LIBREELEC_VERSION=daily-$(date +%Y%j)-$GIT_ABBREV;;
+    weekly)  LIBREELEC_VERSION=weekly-$(date +%G%V)-$GIT_ABBREV;;
+    monthly) LIBREELEC_VERSION=monthly-$(date +%Y%m)-$GIT_ABBREV;;
+    *)       LIBREELEC_VERSION=devel-$(date +%Y%m%d%H%M%S)-$GIT_ABBREV;;
+  esac
 fi
 
 # Get origin url, fix git:// and git@github.com: urls if necessary
@@ -64,10 +67,6 @@ fi
 
 if [ -n "$CUSTOM_VERSION" ]; then
   LIBREELEC_VERSION="$CUSTOM_VERSION"
-fi
-
-if [ -n "$CUSTOM_GIT_HASH" ]; then
-  GIT_HASH="$CUSTOM_GIT_HASH"
 fi
 
 LIBREELEC_ARCH="${DEVICE:-$PROJECT}.$TARGET_ARCH"
@@ -89,6 +88,8 @@ fi
 if [ -n "$IMAGE_SUFFIX" ]; then
   IMAGE_NAME="$IMAGE_NAME-$IMAGE_SUFFIX"
 fi
+
+echo "$IMAGE_NAME" > $BUILD/BUILD_FILENAME
 
 # setup fakeroot
 rm -rf $FAKEROOT_SCRIPT   # remove $FAKEROOT_SCRIPT if it exist


### PR DESCRIPTION
This PR adds support for using periodic naming of nightly/daily/weekly/monthly `devel` images.
It also drops the revision count from the image name of `devel` images for consistent naming.
`CUSTOM_GIT_HASH` will be used instead for `git rev-parse HEAD` in image name if supplied.
The `$BUILD/BUILD_FILENAME` file now contains the full `$IMAGE_NAME` instead of just `$LIBREELEC_VERSION`.

Use `BUILD_PERIODIC=nightly/daily/weekly/monthly` to use the periodic naming.

Example
```
LibreELEC-RK3328.arm-9.0-devel-20180422165943-a80c9bb.tar
LibreELEC-RK3328.arm-9.0-nightly-20180422-a80c9bb.tar
LibreELEC-RK3328.arm-9.0-daily-2018112-a80c9bb.tar
LibreELEC-RK3328.arm-9.0-weekly-201816-a80c9bb.tar
LibreELEC-RK3328.arm-9.0-monthly-201804-a80c9bb.tar
```

`UBOOT_SYSTEM` images
```
LibreELEC-RK3328.arm-9.0-devel-20180422165943-a80c9bb-rock64.img.gz
LibreELEC-RK3328.arm-9.0-nightly-20180422-a80c9bb-rock64.img.gz
LibreELEC-RK3328.arm-9.0-daily-2018112-a80c9bb-rock64.img.gz
LibreELEC-RK3328.arm-9.0-weekly-201816-a80c9bb-rock64.img.gz
LibreELEC-RK3328.arm-9.0-monthly-201804-a80c9bb-rock64.img.gz
```
