### PR TITLE
retire DEVTOOLS

### DIFF
--- a/config/options
+++ b/config/options
@@ -99,11 +99,6 @@ fi
     . $HOME/.libreelec/options
   fi
 
-# install devtools on development builds
-  if [ -z "$DEVTOOLS" -a "$LIBREELEC_VERSION" = "devel" ]; then
-    DEVTOOLS=yes
-  fi
-
 # overwrite OEM_SUPPORT via commandline
 if [ "$OEM" = yes -o "$OEM" = no ]; then
   OEM_SUPPORT=$OEM

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -75,7 +75,7 @@ if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
   HEADERS_ARCH=$TARGET_ARCH
 fi
 
-if [ "$DEVTOOLS" = "yes" -a "$PKG_BUILD_PERF" != "no" ] && grep -q ^CONFIG_PERF_EVENTS= $PKG_KERNEL_CFG_FILE ; then
+if [ "$PKG_BUILD_PERF" != "no" ] && grep -q ^CONFIG_PERF_EVENTS= $PKG_KERNEL_CFG_FILE ; then
   PKG_BUILD_PERF="yes"
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET binutils elfutils libunwind zlib openssl"
 fi

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -35,11 +35,7 @@ else
   BLUEZ_CONFIG="--disable-debug"
 fi
 
-if [ "$DEVTOOLS" = "yes" ]; then
-  BLUEZ_CONFIG="$BLUEZ_CONFIG --enable-monitor --enable-test"
-else
-  BLUEZ_CONFIG="$BLUEZ_CONFIG --disable-monitor --disable-test"
-fi
+BLUEZ_CONFIG="$BLUEZ_CONFIG --enable-monitor --enable-test"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-dependency-tracking \
                            --disable-silent-rules \

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -97,10 +97,9 @@ PKG_CONFIGURE_OPTS="--prefix=/usr \
                     --with-syslog  \
                     --nopyc --nopyo"
 
-PKG_SAMBA_TARGET="smbclient"
+PKG_SAMBA_TARGET="smbclient,client/smbclient,smbtree,testparm"
 
 [ "$SAMBA_SERVER" = "yes" ] && PKG_SAMBA_TARGET+=",smbd/smbd,nmbd,smbpasswd"
-[ "$DEVTOOLS" = "yes" ] && PKG_SAMBA_TARGET+=",client/smbclient,smbtree,testparm"
 
 pre_configure_target() {
 # samba uses its own build directory
@@ -150,12 +149,10 @@ post_makeinstall_target() {
       cp $INSTALL/etc/samba/smb.conf $INSTALL/usr/config/samba.conf.sample
   fi
 
-  if [ "$DEVTOOLS" = "yes" ]; then
-    mkdir -p $INSTALL/usr/bin
-      cp -PR bin/default/source3/client/smbclient $INSTALL/usr/bin
-      cp -PR bin/default/source3/utils/smbtree $INSTALL/usr/bin
-      cp -PR bin/default/source3/utils/testparm $INSTALL/usr/bin
-  fi
+  mkdir -p $INSTALL/usr/bin
+    cp -PR bin/default/source3/client/smbclient $INSTALL/usr/bin
+    cp -PR bin/default/source3/utils/smbtree $INSTALL/usr/bin
+    cp -PR bin/default/source3/utils/testparm $INSTALL/usr/bin
 
   if [ "$SAMBA_SERVER" = "yes" ]; then
     mkdir -p $INSTALL/usr/bin

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -87,10 +87,6 @@ configure_target() {
     # set install dir
     sed -i -e "s|^CONFIG_PREFIX=.*$|CONFIG_PREFIX=\"$INSTALL/usr\"|" .config
 
-    if [ ! "$DEVTOOLS" = yes ]; then
-      sed -i -e "s|^CONFIG_DEVMEM=.*$|# CONFIG_DEVMEM is not set|" .config
-    fi
-
     if [ ! "$CRON_SUPPORT" = "yes" ] ; then
       sed -i -e "s|^CONFIG_CROND=.*$|# CONFIG_CROND is not set|" .config
       sed -i -e "s|^CONFIG_FEATURE_CROND_D=.*$|# CONFIG_FEATURE_CROND_D is not set|" .config

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -156,8 +156,9 @@ post_makeinstall_target() {
   fi
 
   mkdir -p $INSTALL/etc/X11
-    find_file_path config/xorg.conf &&
+    if find_file_path config/xorg.conf ; then
       cp $FOUND_PATH $INSTALL/etc/X11
+    fi
 
   if [ ! "$DEVTOOLS" = yes ]; then
     rm -rf $INSTALL/usr/bin/cvt

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -159,11 +159,6 @@ post_makeinstall_target() {
     if find_file_path config/xorg.conf ; then
       cp $FOUND_PATH $INSTALL/etc/X11
     fi
-
-  if [ ! "$DEVTOOLS" = yes ]; then
-    rm -rf $INSTALL/usr/bin/cvt
-    rm -rf $INSTALL/usr/bin/gtf
-  fi
 }
 
 post_install() {


### PR DESCRIPTION
The idea behind DEVTOOLS was that builds which had LIBREELEC_VERSION set to "devel" include an additional set of programs that are only relevant to development which don't need to be included in release versions to save space.

In reality the space saving is rather small (less than 2MB on a ~140MB RPi build) and the additional programs are actually rather useful ones like smbclient and btmon which are helpful on release builds as well - so users can test for issues or we can instruct them to do certain tests.

Another problem with this approach is that we developers will be testing different things than what's released. We might not notice during development that some script or addon depends on functionality that's not available in release builds - which is really bad as we'd probably not find out about until a LE release hits users.

LIBREELEC_VERSION should only affect the version info in the image, the rest of the image (set of programs, build options etc) should be identical.

So, let's retire DEVTOOLS and always include the rather useful programs in LE.