### PR TITLE
Remove u-boot-tools package dependency for WC & WP

### DIFF
--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -136,7 +136,6 @@
 
   # extra build dependeices
     EXTRA_DEPS="mkimage"
-    EXTRA_DEPS_PKG="u-boot-tools"
 
   # kernel image name
     KERNEL_NAME="kernel.img"

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -133,7 +133,6 @@
 
   # extra build dependeices
     EXTRA_DEPS="mkimage"
-    EXTRA_DEPS_PKG="u-boot-tools"
 
   # kernel image name
     KERNEL_NAME="kernel.img"


### PR DESCRIPTION
This removes the u-boot-tools package dependency for WeTek_Core and WeTek_Play. Changes were suggested by @codesnake. Images were built locally but unable to sanity test them due to lack of hardware.