### PR TITLE
eventlircd: don't grab power buttons

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -61,21 +61,8 @@ SUBSYSTEMS=="rc", \
   ENV{eventlircd_evmap}="default.evmap"
 
 #-------------------------------------------------------------------------------
-# Ask eventlircd to handle power button and input event devices.
+# Ask eventlircd to handle input event devices.
 #-------------------------------------------------------------------------------
-SUBSYSTEMS=="acpi", ATTRS{hid}=="LNXPWRBN", \
-  ENV{eventlircd_enable}="true", \
-  ENV{eventlircd_evmap}="default.evmap"
-
-# WeTek Play (power button)
-SUBSYSTEMS=="input", ATTRS{name}=="key_input", \
-  ENV{eventlircd_enable}="true", \
-  ENV{eventlircd_evmap}="default.evmap"
-
-# WeTek Core (power button)
-SUBSYSTEMS=="input", ATTRS{name}=="gpio_keypad", \
-  ENV{eventlircd_enable}="true", \
-  ENV{eventlircd_evmap}="default.evmap"
 
 # Xiaomi Mi Box USA remote
 SUBSYSTEMS=="input", ATTRS{name}=="Xiaomi Remote", \


### PR DESCRIPTION
By routing the x86, Wetek Play and Wetek Core power buttons through eventlircd it's impossible to configure systemd-logind to use them as eventlircd is grabbing the input.

OTOH routing the power button through eventlircd is not needed as Kodi will happily use the power button's input event device.

I've successfully tested this on Generic/x86_64 but can't test on WP or WC. Would be great if someone could verify if this works - ping @codesnake 

I also tested with the gpio-shutdown overlay on RPi, which creates a power button input device that's not run through eventlircd, and Kodi picked it up nicely as well so I'm rather confident the change should work on WP/WC.

Note: In my tests I also had the Kodi bump PR #2654 with the switch to libinput applied, could be that this PR depends on it