### PR TITLE
buildsystem: use no-lto, when lto is disabled

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -4,6 +4,10 @@ setup_toolchain() {
     TARGET_CFLAGS+=" $CFLAGS_OPTIM_LTO"
     TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_LTO"
     TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO"
+  else
+    TARGET_CFLAGS+=" -fno-lto"
+    TARGET_CXXFLAGS+=" -fno-lto"
+    TARGET_LDFLAGS+=" -fno-lto"
   fi
 
   # gold flag

--- a/config/functions
+++ b/config/functions
@@ -5,9 +5,9 @@ setup_toolchain() {
     TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_LTO"
     TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO"
   else
-    TARGET_CFLAGS+=" -fno-lto"
-    TARGET_CXXFLAGS+=" -fno-lto"
-    TARGET_LDFLAGS+=" -fno-lto"
+    TARGET_CFLAGS+=" $CFLAGS_OPTIM_NOLTO"
+    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_NOLTO"
+    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_NOLTO"
   fi
 
   # gold flag

--- a/config/optimize
+++ b/config/optimize
@@ -35,6 +35,9 @@ HOST_CXXFLAGS="$HOST_CXXFLAGS -Wno-format-security"
 CFLAGS_OPTIM_LTO="-flto -ffat-lto-objects"
 CXXFLAGS_OPTIM_LTO="-flto -ffat-lto-objects"
 LDFLAGS_OPTIM_LTO="-fuse-linker-plugin -flto"
+CFLAGS_OPTIM_NOLTO="-fno-lto"
+CXXFLAGS_OPTIM_NOLTO="-fno-lto"
+LDFLAGS_OPTIM_NOLTO="-fno-lto"
 
 # gold flags
 LDFLAGS_OPTIM_GOLD="-fuse-ld=gold"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -28,8 +28,13 @@ PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python2 
 PKG_SECTION="mediacenter"
 PKG_SHORTDESC="kodi: Kodi Mediacenter"
 PKG_LONGDESC="Kodi Media Center (which was formerly named Xbox Media Center or XBMC) is a free and open source cross-platform media player and home entertainment system software with a 10-foot user interface designed for the living-room TV. Its graphical user interface allows the user to easily manage video, photos, podcasts, and music from a computer, optical disk, local network, and the internet using a remote control."
-# Single threaded LTO is very slow so rely on Kodi for LTO support
-PKG_BUILD_FLAGS="-lto"
+
+# Single threaded LTO is very slow so rely on Kodi for parallel LTO support
+if [ "$LTO_SUPPORT" = "yes" ] && ! build_with_debug; then
+  PKG_KODI_USE_LTO="-DUSE_LTO=$CONCURRENCY_MAKE_LEVEL"
+else
+  PKG_BUILD_FLAGS="-lto"
+fi
 
 get_graphicdrivers
 
@@ -203,9 +208,6 @@ fi
 KODI_LIBDVD="$KODI_DVDCSS \
              -DLIBDVDNAV_URL=$SOURCES/libdvdnav/libdvdnav-$(get_pkg_version libdvdnav).tar.gz \
              -DLIBDVDREAD_URL=$SOURCES/libdvdread/libdvdread-$(get_pkg_version libdvdread).tar.gz"
-
-# Build Kodi using parallel LTO
-[ "$LTO_SUPPORT" = "yes" ] && ! build_with_debug && PKG_KODI_USE_LTO="-DUSE_LTO=$CONCURRENCY_MAKE_LEVEL"
 
 PKG_CMAKE_OPTS_TARGET="-DNATIVEPREFIX=$TOOLCHAIN \
                        -DWITH_TEXTUREPACKER=$TOOLCHAIN/bin/TexturePacker \


### PR DESCRIPTION
else gcc/binultis can reenable it, automatically

Build tested with Generic, RPi2 and LePotato