### PR TITLE
init: add sky42 enhancements/bug fixes

### DIFF
--- a/config/options
+++ b/config/options
@@ -61,6 +61,9 @@ PROJECT_DIR="$ROOT/projects"
    . $PROJECT_DIR/$PROJECT/devices/$DEVICE/options
  fi
 
+# projects can set KERNEL_NAME (kernel.img)
+[ -z "$KERNEL_NAME" ] && KERNEL_NAME="KERNEL"
+
 LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux $PROJECT_DIR/$PROJECT/patches/linux $ROOT/packages/linux"
 [ -n "$DEVICE" ] && LINUX_DEPENDS+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/linux"
 [ "$TARGET_ARCH" = "x86_64" ] && LINUX_DEPENDS+=" $ROOT/packages/linux-firmware/intel-ucode $ROOT/packages/linux-firmware/kernel-firmware"

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -93,7 +93,7 @@ pre_configure_target() {
   export BUILD_CC=$HOST_CC
   export OBJDUMP_FOR_HOST=objdump
 
-cat >config.cache <<EOF
+  cat >config.cache <<EOF
 libc_cv_forced_unwind=yes
 libc_cv_c_cleanup=yes
 libc_cv_ssp=no
@@ -101,13 +101,21 @@ libc_cv_ssp_strong=no
 libc_cv_slibdir=/usr/lib
 EOF
 
-echo "libdir=/usr/lib" >> configparms
-echo "slibdir=/usr/lib" >> configparms
-echo "sbindir=/usr/bin" >> configparms
-echo "rootsbindir=/usr/bin" >> configparms
-echo "build-programs=yes" >> configparms
+  cat >configparms <<EOF
+libdir=/usr/lib
+slibdir=/usr/lib
+sbindir=/usr/bin
+rootsbindir=/usr/bin
+build-programs=yes
+EOF
 
-GLIBC_INCLUDE_BIN="getent ldd locale"
+  # binaries to install into target
+  GLIBC_INCLUDE_BIN="getent ldd locale"
+
+  # Generic "installer" needs localedef to define drawing chars
+  if [ "$PROJECT" = "Generic" ]; then
+    GLIBC_INCLUDE_BIN+=" localedef"
+  fi
 }
 
 post_makeinstall_target() {
@@ -117,14 +125,7 @@ post_makeinstall_target() {
 # cleanup
 # remove any programs we don't want/need, keeping only those we want
   for f in $(find $INSTALL/usr/bin -type f); do
-    fb="$(basename "${f}")"
-    for ib in $GLIBC_INCLUDE_BIN; do
-      if [ "${ib}" == "${fb}" ]; then
-        fb=
-        break
-      fi
-    done
-    [ -n "${fb}" ] && rm -rf ${f}
+    listcontains "${GLIBC_INCLUDE_BIN}" "$(basename "${f}")" || rm -fr "${f}"
   done
 
   rm -rf $INSTALL/usr/lib/audit

--- a/packages/sysutils/busybox/scripts/getedid
+++ b/packages/sysutils/busybox/scripts/getedid
@@ -114,7 +114,7 @@ sys_reboot() {
 # check syslinux.cfg and/or extlinux.conf
 check_file() {
   # check boot system
-  if [ -d /sys/firmware/efi ]; then
+  if [ -d /sys/firmware/efi -a -f /flash/EFI/BOOT/syslinux.cfg ] ; then
     sys_boot="UEFI"
     sys_path="/flash/EFI/BOOT"
   else

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -1,23 +1,24 @@
 #!/bin/sh
 
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 #      Copyright (C) 2010-2011 Roman Weber (roman@openelec.tv)
 #      Copyright (C) 2012 Yann Cézard (eesprit@free.fr)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
   # create directories

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -1051,7 +1051,7 @@
 
     if [ ! -d "/sysroot/usr/lib/kernel-overlays/base/lib/modules/$(uname -r)/" -a -f "/sysroot/usr/lib/systemd/systemd" ]; then
       echo ""
-      echo "NEVER TOUCH boot= in extlinux.conf / cmdline.txt!"
+      echo "NEVER TOUCH boot= in syslinux.conf / cmdline.txt!"
       echo "If you don't know what you are doing,"
       echo "your installation is now broken."
       echo ""

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -46,8 +46,8 @@
 
   UPDATE_KERNEL="KERNEL"
   UPDATE_SYSTEM="SYSTEM"
-  IMAGE_KERNEL="@KERNEL_NAME@"
-  IMAGE_SYSTEM="SYSTEM"
+  IMAGE_KERNEL="/@KERNEL_NAME@"
+  IMAGE_SYSTEM="/SYSTEM"
 
   BOOT_STEP="start"
   MD5_FAILED="0"
@@ -477,7 +477,7 @@
     export BOOT_ROOT="/flash"
     export SYSTEM_ROOT="/sysroot"
 
-    mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+    mount_part "/flash$IMAGE_SYSTEM" "/sysroot" "ro,loop"
 
     if [ -f $SYSTEM_ROOT/usr/share/bootloader/update.sh ]; then
       StartProgress spinner "Updating Bootloader... "
@@ -972,7 +972,7 @@
     # Verify that the new upgrade is compatible with the current system - this should avoid creating
     # non-booting systems after (for example) an RPi tar is incorrectly applied to an RPi2 system.
     if [ ! -f "$UPDATE_ROOT/.nocompat" ]; then
-      if ! check_is_compatible "$UPDATE_FILENAME" "/flash/$IMAGE_SYSTEM" "$UPDATE_DIR/$UPDATE_SYSTEM"; then
+      if ! check_is_compatible "$UPDATE_FILENAME" "/flash$IMAGE_SYSTEM" "$UPDATE_DIR/$UPDATE_SYSTEM"; then
         do_cleanup
         StartProgress countdown "Normal startup in 60s... " 60 "NOW"
         return 0
@@ -985,12 +985,12 @@
 
     # Disregard kernel size if it's a a block device, which is the case on Amlogic/WeTek devices
     if [ ! -b $IMAGE_KERNEL ]; then
-      OLD_KERNEL=$(stat -t "/flash/$IMAGE_KERNEL" | awk '{print $2}')
+      OLD_KERNEL=$(stat -t "/flash$IMAGE_KERNEL" | awk '{print $2}')
     else
       OLD_KERNEL="0"
     fi
 
-    OLD_SYSTEM=$(stat -t "/flash/$IMAGE_SYSTEM" | awk '{print $2}')
+    OLD_SYSTEM=$(stat -t "/flash$IMAGE_SYSTEM" | awk '{print $2}')
     NEW_KERNEL=$(stat -t "$UPDATE_DIR/$UPDATE_KERNEL" | awk '{print $2}')
     NEW_SYSTEM=$(stat -t "$UPDATE_DIR/$UPDATE_SYSTEM" | awk '{print $2}')
 
@@ -1021,9 +1021,9 @@
     if [ -b $IMAGE_KERNEL ]; then
       update_partition "Kernel" "$UPDATE_KERNEL" "$IMAGE_KERNEL"
     else
-      update_file "Kernel" "$UPDATE_KERNEL" "/flash/$IMAGE_KERNEL"
+      update_file "Kernel" "$UPDATE_KERNEL" "/flash$IMAGE_KERNEL"
     fi
-    update_file "System" "$UPDATE_SYSTEM" "/flash/$IMAGE_SYSTEM"
+    update_file "System" "$UPDATE_SYSTEM" "/flash$IMAGE_SYSTEM"
     update_bootloader
     do_cleanup
     do_reboot
@@ -1033,10 +1033,10 @@
     progress "Preparing system"
 
     if [ "$SYSTEM_TORAM" = "no" -o "$INSTALLED_MEMORY" -lt "$SYSTEM_TORAM_LIMIT" ]; then
-      mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+      mount_part "/flash$IMAGE_SYSTEM" "/sysroot" "ro,loop"
     else
-      cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
-      mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+      cp /flash$IMAGE_SYSTEM /dev$IMAGE_SYSTEM
+      mount_part "/dev$IMAGE_SYSTEM" "/sysroot" "ro,loop"
     fi
 
     mount --move /flash /sysroot/flash

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -59,7 +59,7 @@
   NBD_DEVS="0"
   FLASH_FREE_MIN="5"
 
-  INSTALLED_MEMORY=`cat /proc/meminfo | grep 'MemTotal:' | awk '{print $2}'`
+  INSTALLED_MEMORY=$(cat /proc/meminfo | grep 'MemTotal:' | awk '{print $2}')
   SYSTEM_TORAM_LIMIT=1024000
 
   LIVE="no"
@@ -324,7 +324,7 @@
 
     mount_common "$NBD_DEV" "$2" "$3" "$4"
 
-    NBD_DEVS=$(( ${NBD_DEVS} + 1 ))
+    NBD_DEVS=$(( NBD_DEVS + 1 ))
   }
 
   mount_nfs() {
@@ -693,7 +693,7 @@
 
     if [ -n "$disk" ]; then
       if [ -n "$OVERLAY" ]; then
-        OVERLAY_DIR=`cat /sys/class/net/eth0/address | tr -d :`
+        OVERLAY_DIR=$(cat /sys/class/net/eth0/address | tr -d :)
 
         mount_part "$disk" "/storage" "rw,noatime"
         mkdir -p /storage/$OVERLAY_DIR
@@ -798,9 +798,9 @@
 
   check_update() {
     progress "Checking for updates"
-    UPDATE_TAR=`ls -1 "$UPDATE_DIR"/*.tar 2>/dev/null | head -n 1`
-    UPDATE_IMG_GZ=`ls -1 "$UPDATE_DIR"/*.img.gz 2>/dev/null | head -n 1`
-    UPDATE_IMG=`ls -1 "$UPDATE_DIR"/*.img 2>/dev/null | head -n 1`
+    UPDATE_TAR=$(ls -1 "$UPDATE_DIR"/*.tar 2>/dev/null | head -n 1)
+    UPDATE_IMG_GZ=$(ls -1 "$UPDATE_DIR"/*.img.gz 2>/dev/null | head -n 1)
+    UPDATE_IMG=$(ls -1 "$UPDATE_DIR"/*.img 2>/dev/null | head -n 1)
 
     if ! [ -f "$UPDATE_DIR/$UPDATE_KERNEL" -a -f "$UPDATE_DIR/$UPDATE_SYSTEM" ] &&
        ! [ -f "$UPDATE_TAR" -o -f "$UPDATE_IMG_GZ" -o -f "$UPDATE_IMG" ]; then
@@ -997,8 +997,8 @@
     # old KERNEL+SYSTEM+free space - new KERNEL+SYSTEM must be higher than 5MB
     # at least 5MB free after update
 
-    TMP_SIZE=$(($OLD_KERNEL+$OLD_SYSTEM+$FLASH_FREE-$NEW_KERNEL-$NEW_SYSTEM))
-    FLASH_FREE_MIN=$(($FLASH_FREE_MIN*1024*1024))
+    TMP_SIZE=$((OLD_KERNEL + OLD_SYSTEM + FLASH_FREE - NEW_KERNEL - NEW_SYSTEM))
+    FLASH_FREE_MIN=$((FLASH_FREE_MIN * 1024 * 1024))
 
     if [ $TMP_SIZE -ge $FLASH_FREE_MIN ]; then
       echo "Checking size: OK"
@@ -1118,7 +1118,7 @@
     INIT_UNIT="--unit=fs-resize.target"
   fi
 
-  BACKUP_FILE=`ls -1 /sysroot/storage/.restore/??????????????.tar 2>/dev/null | head -n 1`
+  BACKUP_FILE=$(ls -1 /sysroot/storage/.restore/??????????????.tar 2>/dev/null | head -n 1)
   if [ -f "$BACKUP_FILE" ] ; then
     INIT_UNIT="--unit=backup-restore.target"
   fi

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -719,7 +719,7 @@
 
           mount -o remount,rw /flash
           sed -i "s/^DEFAULT .*/DEFAULT $SYSLINUX_DEFAULT/" /flash/syslinux.cfg
-          [ -f /flash/EFI/BOOT/syslinux.cfg ] && cp /flash/syslinux.cfg /flash/EFI/BOOT/syslinux.cfg
+          rm -f /flash/EFI/BOOT/syslinux.cfg
           mount -o remount,ro /flash
         fi
       fi

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -738,15 +738,15 @@
       fi
     fi
 
-    if [ -n "$GRUB_DEFAULT" -a -f /flash/grub.cfg ]; then
-      if grep -q "^menuentry \"$GRUB_DEFAULT\"" /flash/grub.cfg; then
-        crnt_default="$(awk '/^set default/ {print substr($2,9,19)}' /flash/grub.cfg)"
+    if [ -n "$GRUB_DEFAULT" -a -f /flash/EFI/BOOT/grub.cfg ]; then
+      if grep -q "^menuentry \"$GRUB_DEFAULT\"" /flash/EFI/BOOT/grub.cfg; then
+        crnt_default="$(awk '/^set default/ {print substr($2,9,19)}' /flash/EFI/BOOT/grub.cfg)"
         if [ ! "$crnt_default" = "\"$GRUB_DEFAULT\"" ]; then
-          progress "Updating /flash/grub.cfg [$crnt_default -> \"$GRUB_DEFAULT\"]"
+          progress "Updating /flash/EFI/BOOT/grub.cfg [$crnt_default -> \"$GRUB_DEFAULT\"]"
 
           mount -o remount,rw /flash
-          sed -i "s/^set default=.*/set default=\"$GRUB_DEFAULT\"/" /flash/grub.cfg
-          [ -f /flash/EFI/BOOT/grub.cfg ] && cp /flash/grub.cfg /flash/EFI/BOOT/grub.cfg
+          sed -i "s/^set default=.*/set default=\"$GRUB_DEFAULT\"/" /flash/EFI/BOOT/grub.cfg
+          rm -f /flash/grub.cfg
           mount -o remount,ro /flash
         fi
       fi

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -45,7 +45,7 @@
 
   UPDATE_KERNEL="KERNEL"
   UPDATE_SYSTEM="SYSTEM"
-  IMAGE_KERNEL="KERNEL"
+  IMAGE_KERNEL="@KERNEL_NAME@"
   IMAGE_SYSTEM="SYSTEM"
 
   BOOT_STEP="start"
@@ -914,11 +914,7 @@
       # don't make temporary files but instead copy
       # directly from mountpoint to /flash
       UPDATE_DIR=$UPDATE_ROOT/.tmp/mnt
-      if [ ! -b $IMAGE_KERNEL -o -z "@KERNEL_NAME@" ]; then
-        UPDATE_KERNEL=$(basename $IMAGE_KERNEL)
-      else
-        UPDATE_KERNEL="@KERNEL_NAME@"
-      fi
+      UPDATE_KERNEL="@KERNEL_NAME@"
     else
       UPDATE_FILENAME="$UPDATE_DIR/$UPDATE_SYSTEM"
     fi

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -147,6 +147,9 @@
       noram)
         SYSTEM_TORAM=no
         ;;
+      ramlimit=*)
+        SYSTEM_TORAM_LIMIT="${arg#*=}"
+        ;;
       live)
         LIVE=yes
         SYSLINUX_DEFAULT="live"

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -922,10 +922,17 @@
 
     sync
 
-    if [ ! -f "$UPDATE_DIR/$UPDATE_KERNEL" -o ! -f "$UPDATE_DIR/$UPDATE_SYSTEM" ] ; then
-      echo "Missing ${UPDATE_KERNEL} or ${UPDATE_SYSTEM}!"
+    if [ ! -b "$IMAGE_KERNEL" -a ! -f "/flash$IMAGE_KERNEL" ] || [ ! -f "/flash$IMAGE_SYSTEM" ]; then
+      echo "Missing (target) ${IMAGE_KERNEL} or ${IMAGE_SYSTEM}!"
       do_cleanup
-      StartProgress countdown "Normal startup in 10s... " 10 "NOW"
+      StartProgress countdown "Normal startup in 30s... " 30 "NOW"
+      return 0
+    fi
+
+    if [ ! -f "$UPDATE_DIR/$UPDATE_KERNEL" -o ! -f "$UPDATE_DIR/$UPDATE_SYSTEM" ] ; then
+      echo "Missing (source) ${UPDATE_KERNEL} or ${UPDATE_SYSTEM}!"
+      do_cleanup
+      StartProgress countdown "Normal startup in 30s... " 30 "NOW"
       return 0
     fi
 

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -673,6 +673,10 @@
     wakeonlan
 
     mount_part "$boot" "/flash" "ro,noatime"
+
+    if [ -f /flash/post-flash.sh ] ; then
+      . /flash/post-flash.sh
+    fi
   }
 
   mount_storage() {
@@ -703,7 +707,12 @@
           disk="$target/$OVERLAY_DIR,$options"
         fi
       fi
-      mount_part "$disk" "/storage" "rw,noatime"
+
+      if [ -f /flash/mount-storage.sh ] ; then
+        . /flash/mount-storage.sh
+      else
+        mount_part "$disk" "/storage" "rw,noatime"
+      fi
     else
       # /storage should always be writable
       mount -t tmpfs none /storage

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -738,7 +738,7 @@
       fi
     fi
 
-    if [ -n "\"$GRUB_DEFAULT\"" -a -f /flash/grub.cfg ]; then
+    if [ -n "$GRUB_DEFAULT" -a -f /flash/grub.cfg ]; then
       if grep -q "^menuentry \"$GRUB_DEFAULT\"" /flash/grub.cfg; then
         crnt_default="$(awk '/^set default/ {print substr($2,9,19)}' /flash/grub.cfg)"
         if [ ! "$crnt_default" = "\"$GRUB_DEFAULT\"" ]; then

--- a/packages/tools/installer/config/installer.conf
+++ b/packages/tools/installer/config/installer.conf
@@ -25,8 +25,8 @@
 # Default starting offset for system partition, in sectors (1 sector = 512B), eg. 2048
   PARTSIZE_SYSTEM_OFFSET="@SYSTEM_PART_START@"
 
-# additional parameters to extlinux
-  EXTLINUX_PARAMETERS="@EXTLINUX_PARAMETERS@"
+# additional parameters to syslinux
+  SYSLINUX_PARAMETERS="@SYSLINUX_PARAMETERS@"
 
 # enable BIOS update function
   BIOS_UPDATE="no"

--- a/packages/tools/installer/package.mk
+++ b/packages/tools/installer/package.mk
@@ -39,7 +39,7 @@ post_install() {
     cp ${FOUND_PATH} $INSTALL/etc
     sed -e "s/@SYSTEM_SIZE@/$SYSTEM_SIZE/g" \
         -e "s/@SYSTEM_PART_START@/$SYSTEM_PART_START/g" \
-        -e "s/@EXTLINUX_PARAMETERS@/$EXTLINUX_PARAMETERS/g" \
+        -e "s/@SYSLINUX_PARAMETERS@/$SYSLINUX_PARAMETERS/g" \
         -i $INSTALL/etc/installer.conf
 
   enable_service installer.service

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -25,18 +25,18 @@
 # cat /proc/partitions | sed -n "s/\ *[0-9][0-9]*\ *[0-9][0-9]*\ *[0-9][0-9]*\ \([a-z]*\)$/\1/p"
 
 # list all partitionnumbers from /dev/sda:
-# parted -m /dev/sda print |grep -v ^/dev |grep -v ^BYT | cut -f1 -d ":"
+# parted -m /dev/sda print | grep -v ^/dev | grep -v ^BYT | cut -f1 -d ":"
 
 # list device data from /dev/sda:
-# parted -m /dev/sda print |grep /dev/sda
+# parted -m /dev/sda print | grep /dev/sda
 
 # list mounted partitions:
-# mount |grep ^/dev
+# mount | grep ^/dev
 
 # list modelnumber:
-# parted -m /dev/sda print |grep /dev/sda | cut -f7 -d ":" | sed "s/;//"
+# parted -m /dev/sda print | grep /dev/sda | cut -f7 -d ":" | sed "s/;//"
 # list size:
-# parted -m /dev/sda print |grep /dev/sda | cut -f2 -d ":"
+# parted -m /dev/sda print | grep /dev/sda | cut -f2 -d ":"
 
 # exclude mounted partitions
 # for i in `cat /proc/mounts | grep ^/dev/ | cut -f1 -d " " | sed "s/[0-9]//"`; do TEST="$TEST `echo "| grep -v $i"`"; done
@@ -56,6 +56,36 @@ dbglg() {
   echo "" >> $LOGFILE
 }
 
+log_system_status() {
+  echo "# cat /proc/mounts"
+  cat /proc/mounts
+  echo
+
+  echo "# df"
+  df
+  echo
+
+  echo "# df -h"
+  df -h
+  echo
+
+  echo "# parted -s -m -l"
+  parted -s -m -l
+  echo
+
+  echo "# blkid"
+  blkid
+  echo
+
+  echo "# UEFI (if directory exists)"
+  ls -la /sys/firmware/efi
+  echo
+
+  echo "# Disk sizes (bytes)"
+  grep . /sys/block/*/size
+  echo
+}
+
 get_device_unmount() {
   # get all unmounted devices
   # usage: get_devices_unmount
@@ -66,15 +96,15 @@ get_device_unmount() {
   DEVICES=$(parted -s -m -l 2>/dev/null | grep -E '^/dev/sd|^/dev/mmcblk|^/dev/nvme' | grep -E -v '.?rpmb|.?boot?' | cut -f1 -d ":")
 
   for i in $(cat /proc/mounts | grep -E '^/dev/sd' | cut -f1 -d " " | sed "s/[0-9].*$//"); do
-    DEVICES=$(echo $DEVICES |sed -e "s|$i||")
+    DEVICES=$(echo $DEVICES | sed -e "s|$i||")
   done
 
   for i in $(cat /proc/mounts | grep -E '^/dev/mmcblk' | cut -f1 -d " " | sed "s/p.*$//"); do
-    DEVICES=$(echo $DEVICES |sed -e "s|$i||")
+    DEVICES=$(echo $DEVICES | sed -e "s|$i||")
   done
 
   for i in $(cat /proc/mounts | grep -E '^/dev/nvme' | cut -f1 -d " " | sed "s/p.*$//"); do
-    DEVICES=$(echo $DEVICES |sed -e "s|$i||")
+    DEVICES=$(echo $DEVICES | sed -e "s|$i||")
   done
 }
 
@@ -84,7 +114,7 @@ get_partition() {
   # uses:     -
   # provides: PARTITIONS
 
-  PARTITIONS=$(parted -s -m $1 print |grep -v ^/dev |grep -v BYT | cut -f1 -d ":")
+  PARTITIONS=$(parted -s -m $1 print | grep -v ^/dev | grep -v BYT | cut -f1 -d ":")
 }
 
 create_device_list() {
@@ -221,6 +251,7 @@ do_install_quick() {
     UUID_SYSTEM="$(blkid --output udev ${INSTALL_DEVICE}${PART1} | grep ^ID_FS_UUID= | cut -d= -f2)"
     UUID_STORAGE="$(blkid --output udev ${INSTALL_DEVICE}${PART2} | grep ^ID_FS_UUID= | cut -d= -f2)"
 
+    echo "" >> $LOGFILE
     echo "UUID_SYSTEM : ${UUID_SYSTEM}" >> $LOGFILE
     echo "UUID_STORAGE: ${UUID_STORAGE}" >> $LOGFILE
 
@@ -329,6 +360,7 @@ prompt_gpt() {
   GPT="0"
   UEFI="0"
   # Get size in GB.
+  # 2^41 bytes is the DOS limit (2199023255552 bytes, 2.2TB). Use GUID Partition Table.>= 2200GB
   INSTALL_DEVICE_SIZE=$(($(cat /sys/block/${INSTALL_DEVICE#/dev/}/size)*512/1000/1000/1000))
   if [ "$INSTALL_DEVICE_SIZE" -ge 2200 ] 2>/dev/null; then
     GPT="1"
@@ -369,10 +401,11 @@ out during the installation. \
   MSG_CANCEL="Close"
 
   whiptail --backtitle "$BACKTITLE" --cancel-button "$MSG_CANCEL" \
-    --title "$MSG_TITLE" --menu "$MSG_MENU" 18 73 3 \
+    --title "$MSG_TITLE" --menu "$MSG_MENU" 18 73 4 \
       1 "Install @DISTRONAME@" \
       2 "View installation log" \
-      3 "Reboot" 2> $TMPDIR/mainmenu
+      3 "Save installation log" \
+      4 "Reboot" 2> $TMPDIR/mainmenu
 
   case $? in
     0)
@@ -380,7 +413,8 @@ out during the installation. \
       case $ITEM_MAINMENU in
         1) do_install_quick;;
         2) logfile_show;;
-        3) do_reboot;;
+        3) logfile_save;;
+        4) do_reboot;;
       esac
       ;;
     1)
@@ -394,6 +428,20 @@ out during the installation. \
 
 logfile_show() {
   whiptail --textbox "$LOGFILE" 20 73 --scrolltext --backtitle "$BACKTITLE"
+}
+
+logfile_save() {
+  mount -o remount,rw /flash
+
+  mkdir -p $(dirname $LOGBACKUP)
+  cp $LOGFILE $LOGBACKUP
+  sync
+
+  mount -o remount,ro /flash
+
+  MSG_TITLE="@DISTRONAME@ Log Saved"
+  MSG_DETAIL="Log location: ${LOGBACKUP}\n"
+  whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 7 52
 }
 
 do_reboot() {
@@ -416,6 +464,7 @@ BACKTITLE="@DISTRONAME@ Installer - $OS_VERSION"
 
 TMPDIR="/tmp/installer"
 LOGFILE="$TMPDIR/install.log"
+LOGBACKUP="/flash/logs/$(date +%Y%m%d%H%M%S).log"
 
 export COLORTERM="1"
 export NEWT_COLORS="$WHIPTAIL_COLORS"
@@ -427,6 +476,9 @@ mkdir -p $TMPDIR
 #create log file
 echo "@DISTRONAME@ Installer - $OS_VERSION started at:" > $LOGFILE
 date >> $LOGFILE
+
+dbglg "System status"
+log_system_status >> $LOGFILE 2>&1
 
 # generate the en_US.UTF-8 locale to enable line drawing
 mkdir -p $TMPDIR/locale

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -221,6 +221,12 @@ do_install_quick() {
         msg_progress_install "30" "Set uuid and disklabel $DISKLABEL_STORAGE on ${INSTALL_DEVICE}${PART2}"
         tune2fs -U random -L $DISKLABEL_STORAGE  ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
 
+        UUID_SYSTEM="$(blkid --output udev ${INSTALL_DEVICE}${PART1} | grep ^ID_FS_UUID= | cut -d= -f2)"
+        UUID_STORAGE="$(blkid --output udev ${INSTALL_DEVICE}${PART2} | grep ^ID_FS_UUID= | cut -d= -f2)"
+
+        echo "UUID_SYSTEM : ${UUID_SYSTEM}" >> $LOGFILE
+        echo "UUID_STORAGE: ${UUID_STORAGE}" >> $LOGFILE
+
         # mount system partition
         msg_progress_install "35" "Creating $TMPDIR/part1"
         mkdir -p $TMPDIR/part1 >> $LOGFILE 2>&1
@@ -249,7 +255,7 @@ PROMPT 0
 
 LABEL linux
  KERNEL /KERNEL
- APPEND boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE $SYSLINUX_PARAMETERS quiet
+ APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE $SYSLINUX_PARAMETERS quiet
 EOF
         cat << EOF > $TMPDIR/part1/EFI/BOOT/grub.cfg
 set timeout="0"
@@ -257,7 +263,7 @@ set default="LibreELEC"
 
 menuentry "LibreELEC" {
 	search --set -f /KERNEL
-	linux /KERNEL boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE quiet
+	linux /KERNEL boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet
 }
 EOF
         # uefi boot / hybrid mode

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -194,11 +194,7 @@ do_install_quick() {
         partsize_storage_end=-1024
 
         msg_progress_install "10" "Creating partition on $INSTALL_DEVICE"
-        if [ "$UEFI" = "1" ]; then
-          parted -s $INSTALL_DEVICE unit s mkpart primary fat32 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
-        else
-          parted -s $INSTALL_DEVICE unit s mkpart primary ext2  -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
-        fi
+        parted -s $INSTALL_DEVICE unit s mkpart primary fat32 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
 
         msg_progress_install "13" "Creating partition on $INSTALL_DEVICE"
         parted -s $INSTALL_DEVICE unit s mkpart primary ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
@@ -209,23 +205,15 @@ do_install_quick() {
           parted -s $INSTALL_DEVICE set 1 legacy_boot on >> $LOGFILE 2>&1
         fi
 
-        msg_progress_install "20" "Tell the kernel we have a new partitiontable on $INSTALL_DEVICE"
+        msg_progress_install "20" "Tell the kernel we have a new partition table on $INSTALL_DEVICE"
         partprobe $INSTALL_DEVICE >> $LOGFILE 2>&1
 
         # create filesystem
         msg_progress_install "23" "Creating filesystem on ${INSTALL_DEVICE}1"
-        if [ "$UEFI" = "1" ]; then
-          mkfs.vfat ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
-        else
-          mke2fs -t ext4 -m 0 ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
-        fi
+        mkfs.vfat ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
 
         msg_progress_install "25" "Set uuid and disklabel $DISKLABEL_SYSTEM on ${INSTALL_DEVICE}${PART1}"
-        if [ "$UEFI" = "1" ]; then
-          dosfslabel ${INSTALL_DEVICE}${PART1}  $DISKLABEL_SYSTEM >> $LOGFILE 2>&1
-        else
-          tune2fs -U random -L $DISKLABEL_SYSTEM  ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
-        fi
+        dosfslabel ${INSTALL_DEVICE}${PART1}  $DISKLABEL_SYSTEM >> $LOGFILE 2>&1
 
         msg_progress_install "28" "Creating filesystem on ${INSTALL_DEVICE}${PART2}"
         mke2fs -t ext4 -m 0 ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
@@ -238,20 +226,11 @@ do_install_quick() {
         mkdir -p $TMPDIR/part1 >> $LOGFILE 2>&1
 
         msg_progress_install "40" "Mounting ${INSTALL_DEVICE}${PART1} to $TMPDIR/part1"
-        if [ "$UEFI" = "1" ]; then
-          mount -t vfat ${INSTALL_DEVICE}${PART1} $TMPDIR/part1 >> $LOGFILE 2>&1
-        else
-          mount -t ext4 ${INSTALL_DEVICE}${PART1} $TMPDIR/part1 >> $LOGFILE 2>&1
-        fi
+        mount -t vfat ${INSTALL_DEVICE}${PART1} $TMPDIR/part1 >> $LOGFILE 2>&1
 
-        # installing extlinux
-        if [ "$UEFI" = "1" ]; then
-          msg_progress_install "50" "Installing syslinux to $TMPDIR/part1"
-          syslinux -i ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
-        else
-          msg_progress_install "50" "Installing extlinux to $TMPDIR/part1"
-          extlinux -i $TMPDIR/part1 >> $LOGFILE 2>&1
-        fi
+        # installing syslinux
+        msg_progress_install "50" "Installing syslinux to $TMPDIR/part1"
+        syslinux -i ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
 
         # install system files
         msg_progress_install "60" "Installing Kernel"
@@ -262,15 +241,15 @@ do_install_quick() {
         sync
 
         # configuring bootloader
-        mkdir -p $TMPDIR/part1/EFI/BOOT
         msg_progress_install "80" "Setup bootloader with boot label = $DISKLABEL_SYSTEM and disk label = $DISKLABEL_STORAGE"
-        cat << EOF > $TMPDIR/part1/extlinux.conf
+        mkdir -p $TMPDIR/part1/EFI/BOOT
+        cat << EOF > $TMPDIR/part1/syslinux.cfg
 DEFAULT linux
 PROMPT 0
 
 LABEL linux
  KERNEL /KERNEL
- APPEND boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE $EXTLINUX_PARAMETERS quiet
+ APPEND boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE $SYSLINUX_PARAMETERS quiet
 EOF
         cat << EOF > $TMPDIR/part1/EFI/BOOT/grub.cfg
 set timeout="0"
@@ -282,12 +261,9 @@ menuentry "LibreELEC" {
 }
 EOF
         # uefi boot / hybrid mode
-        if [ "$UEFI" = "1" ]; then
-          mv $TMPDIR/part1/extlinux.conf $TMPDIR/part1/syslinux.cfg
-          cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
-          cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
-          cp /usr/share/grub/bootia32.efi $TMPDIR/part1/EFI/BOOT
-        fi
+        cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
+        cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
+        cp /usr/share/grub/bootia32.efi $TMPDIR/part1/EFI/BOOT
         sync
 
         # umount system partition, remove mountpoint

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -262,6 +262,7 @@ do_install_quick() {
         sync
 
         # configuring bootloader
+        mkdir -p $TMPDIR/part1/EFI/BOOT
         msg_progress_install "80" "Setup bootloader with boot label = $DISKLABEL_SYSTEM and disk label = $DISKLABEL_STORAGE"
         echo "DEFAULT linux" > $TMPDIR/part1/extlinux.conf
         echo "PROMPT 0" >> $TMPDIR/part1/extlinux.conf
@@ -269,20 +270,18 @@ do_install_quick() {
         echo "LABEL linux" >> $TMPDIR/part1/extlinux.conf
         echo " KERNEL /KERNEL" >> $TMPDIR/part1/extlinux.conf
         echo " APPEND boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE $EXTLINUX_PARAMETERS quiet" >> $TMPDIR/part1/extlinux.conf
-        echo "set timeout=\"0\"" > $TMPDIR/part1/grub.cfg
-        echo "set default=\"LibreELEC\"" >> $TMPDIR/part1/grub.cfg
-        echo "" >> $TMPDIR/part1/grub.cfg
-        echo "menuentry \"LibreELEC\" {" >> $TMPDIR/part1/grub.cfg
-        echo "	search --set -f /KERNEL" >> $TMPDIR/part1/grub.cfg
-        echo "	linux /KERNEL boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE quiet" >> $TMPDIR/part1/grub.cfg
-        echo "}" >> $TMPDIR/part1/grub.cfg
+        echo "set timeout=\"0\"" > $TMPDIR/part1/EFI/BOOT/grub.cfg
+        echo "set default=\"LibreELEC\"" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
+        echo "" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
+        echo "menuentry \"LibreELEC\" {" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
+        echo "	search --set -f /KERNEL" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
+        echo "	linux /KERNEL boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE quiet" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
+        echo "}" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
         # uefi boot / hybrid mode
         if [ "$UEFI" = "1" ]; then
           mv $TMPDIR/part1/extlinux.conf $TMPDIR/part1/syslinux.cfg
-          mkdir -p $TMPDIR/part1/EFI/BOOT
           cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
           cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
-          cp $TMPDIR/part1/grub.cfg $TMPDIR/part1/EFI/BOOT
           cp /usr/share/grub/bootia32.efi $TMPDIR/part1/EFI/BOOT
         fi
         sync

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -103,6 +103,7 @@ create_device_list() {
 
   if [ "$DEVICES" = "" ]; then
     msg_no_device
+    return 1
   fi
 
   for i in $DEVICES; do
@@ -111,6 +112,7 @@ create_device_list() {
     DEVICE_NAME=$(echo $DEVICE_MODEL ${DEVICE_SIZE} | sed 's/ /_/g')
     DEVICE_LIST="$DEVICE_LIST $i $DEVICE_NAME"
   done
+  return 0
 }
 
 do_install_quick() {
@@ -119,137 +121,132 @@ do_install_quick() {
   MSG_MENU="\nUse the up/down arrows to select the device you wish to install to.\n\nPlease select a device:"
   MSG_CANCEL="Back"
 
-  create_device_list
+  create_device_list || return
 
   whiptail --backtitle "$BACKTITLE" --cancel-button "$MSG_CANCEL" \
-     $DIALOG_OPTIONS --title "$MSG_TITLE" --menu "$MSG_MENU" 20 50 5 \
-     $DEVICE_LIST 2> $TMPDIR/device_for_install
+    $DIALOG_OPTIONS --title "$MSG_TITLE" --menu "$MSG_MENU" 20 50 5 \
+    $DEVICE_LIST 2> $TMPDIR/device_for_install
+  [ $? -ne 0 ] && return
 
   # now we must do everything
-  case $? in
-    0)
-      INSTALL_DEVICE=$(cat "$TMPDIR/device_for_install")
-      INSTALL_DEVICE_FULL=$(echo $DEVICE_LIST | sed "s|.*$INSTALL_DEVICE \([^ ]*\).*|$INSTALL_DEVICE \1|")
+  INSTALL_DEVICE=$(cat "$TMPDIR/device_for_install")
+  INSTALL_DEVICE_FULL=$(echo $DEVICE_LIST | sed "s|.*$INSTALL_DEVICE \([^ ]*\).*|$INSTALL_DEVICE \1|")
 
-      case $INSTALL_DEVICE in
-        "/dev/mmcblk"*|"/dev/nvme"*)
-          PART1="p1"
-          PART2="p2"
-          ;;
-        *)
-          PART1="1"
-          PART2="2"
-          ;;
-      esac
+  case $INSTALL_DEVICE in
+    "/dev/mmcblk"*|"/dev/nvme"*)
+      PART1="p1"
+      PART2="p2"
+      ;;
+    *)
+      PART1="1"
+      PART2="2"
+      ;;
+  esac
 
-      prompt_gpt
-      prompt_backup_unpack
+  prompt_gpt
+  prompt_backup_unpack
 
-      # check for confirmation (twice!)
-      MSG_TITLE="Confirmation before installing"
-      MSG_DETAIL="\nIf you continue the contents of the target disk will be wiped out:\n\n$INSTALL_DEVICE_FULL\n\n"
-      DIALOG_OPTIONS="--defaultno"
-      whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" \
-       $DIALOG_OPTIONS --yesno "$MSG_DETAIL" 0 0
-      if [ $? -ne 0 ]; then
-        menu_main
-      fi
+  # check for confirmation (twice!)
+  MSG_TITLE="Confirmation before installing"
+  MSG_DETAIL="\nIf you continue the contents of the target disk will be wiped out:\n\n$INSTALL_DEVICE_FULL\n\n"
+  DIALOG_OPTIONS="--defaultno"
+  whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" \
+    $DIALOG_OPTIONS --yesno "$MSG_DETAIL" 0 0
+  [ $? -ne 0 ] && return
 
-      MSG_TITLE="Confirmation before installing"
-      MSG_DETAIL="\nThis is last chance to abort the installation!\n\nIf you continue the target disk will be wiped out:\n\n$INSTALL_DEVICE_FULL\n\n\n"
-      DIALOG_OPTIONS="--defaultno"
-      whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" \
-        $DIALOG_OPTIONS --yesno "$MSG_DETAIL" 0 0
-      if [ $? -ne 0 ]; then
-        menu_main
-      fi
+  MSG_TITLE="Confirmation before installing"
+  MSG_DETAIL="\nThis is last chance to abort the installation!\n\nIf you continue the target disk will be wiped out:\n\n$INSTALL_DEVICE_FULL\n\n\n"
+  DIALOG_OPTIONS="--defaultno"
+  whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" \
+    $DIALOG_OPTIONS --yesno "$MSG_DETAIL" 0 0
+  [ $? -ne 0 ] && return
 
-      # start the progress bar (whiptail --gauge)
-      {
-        # remove all partitions
-        msg_progress_install "1" "Get all partitions $INSTALL_DEVICE"
-        get_partition $INSTALL_DEVICE
+  # start the progress bar (whiptail --gauge)
+  {
+    # remove all partitions
+    msg_progress_install "1" "Get all partitions $INSTALL_DEVICE"
+    get_partition $INSTALL_DEVICE
 
-        msg_progress_install "5" "Wiping disk $INSTALL_DEVICE"
-        dd if=/dev/zero of=$INSTALL_DEVICE bs=4096 count=1024 2>>$LOGFILE
+    msg_progress_install "5" "Wiping disk $INSTALL_DEVICE"
+    dd if=/dev/zero of=$INSTALL_DEVICE bs=4096 count=1024 2>>$LOGFILE
 
-        # create 2 new partitions (first $PARTSIZE_SYSTEM, second rest)
-        msg_progress_install "7"  "Creating label on $INSTALL_DEVICE"
-        if [ "$GPT" = "1" ]; then
-          parted -s $INSTALL_DEVICE mklabel gpt >> $LOGFILE 2>&1
-        else
-          parted -s $INSTALL_DEVICE mklabel msdos >> $LOGFILE 2>&1
-        fi
+    # create 2 new partitions (first $PARTSIZE_SYSTEM, second rest)
+    msg_progress_install "7"  "Creating label on $INSTALL_DEVICE"
+    if [ "$GPT" = "1" ]; then
+      parted -s $INSTALL_DEVICE mklabel gpt >> $LOGFILE 2>&1
+    else
+      parted -s $INSTALL_DEVICE mklabel msdos >> $LOGFILE 2>&1
+    fi
 
-        msg_progress_install "9" "Writing Master Boot Record on $INSTALL_DEVICE"
-        if [ "$GPT" = "1" ]; then
-          cat /usr/share/syslinux/gptmbr.bin > $INSTALL_DEVICE
-        else
-          cat /usr/share/syslinux/mbr.bin > $INSTALL_DEVICE
-        fi
+    msg_progress_install "9" "Writing Master Boot Record on $INSTALL_DEVICE"
+    if [ "$GPT" = "1" ]; then
+      cat /usr/share/syslinux/gptmbr.bin > $INSTALL_DEVICE
+    else
+      cat /usr/share/syslinux/mbr.bin > $INSTALL_DEVICE
+    fi
 
-        partsize_system_start=$PARTSIZE_SYSTEM_OFFSET
-        partsize_system_end=$(((PARTSIZE_SYSTEM * 1024 * 1024 / 512) + partsize_system_start - 1))
-        partsize_storage_start=$((partsize_system_end + 1))
-        partsize_storage_end=-1024
+    partsize_system_start=$PARTSIZE_SYSTEM_OFFSET
+    partsize_system_end=$(((PARTSIZE_SYSTEM * 1024 * 1024 / 512) + partsize_system_start - 1))
+    partsize_storage_start=$((partsize_system_end + 1))
+    partsize_storage_end=-1024
 
-        msg_progress_install "10" "Creating partition on $INSTALL_DEVICE"
-        parted -s $INSTALL_DEVICE unit s mkpart primary fat32 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
+    msg_progress_install "10" "Creating partition on $INSTALL_DEVICE"
+    parted -s $INSTALL_DEVICE unit s mkpart primary fat32 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
 
-        msg_progress_install "13" "Creating partition on $INSTALL_DEVICE"
-        parted -s $INSTALL_DEVICE unit s mkpart primary ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
+    msg_progress_install "13" "Creating partition on $INSTALL_DEVICE"
+    parted -s $INSTALL_DEVICE unit s mkpart primary ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
 
-        msg_progress_install "16" "Setup bootflag on partition 1 of $INSTALL_DEVICE"
-        parted -s $INSTALL_DEVICE set 1 boot on >> $LOGFILE 2>&1
-        if [ "$GPT" = "1" ]; then
-          parted -s $INSTALL_DEVICE set 1 legacy_boot on >> $LOGFILE 2>&1
-        fi
+    msg_progress_install "16" "Setup bootflag on partition 1 of $INSTALL_DEVICE"
+    parted -s $INSTALL_DEVICE set 1 boot on >> $LOGFILE 2>&1
+    if [ "$GPT" = "1" ]; then
+      parted -s $INSTALL_DEVICE set 1 legacy_boot on >> $LOGFILE 2>&1
+    fi
 
-        msg_progress_install "20" "Tell the kernel we have a new partition table on $INSTALL_DEVICE"
-        partprobe $INSTALL_DEVICE >> $LOGFILE 2>&1
+    msg_progress_install "20" "Tell the kernel we have a new partition table on $INSTALL_DEVICE"
+    partprobe $INSTALL_DEVICE >> $LOGFILE 2>&1
 
-        # create filesystem
-        msg_progress_install "23" "Creating filesystem on ${INSTALL_DEVICE}1"
-        mkfs.vfat ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
+    # create filesystem
+    msg_progress_install "23" "Creating filesystem on ${INSTALL_DEVICE}1"
+    mkfs.vfat ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
 
-        msg_progress_install "25" "Set uuid and disklabel $DISKLABEL_SYSTEM on ${INSTALL_DEVICE}${PART1}"
-        dosfslabel ${INSTALL_DEVICE}${PART1}  $DISKLABEL_SYSTEM >> $LOGFILE 2>&1
+    msg_progress_install "25" "Set uuid and disklabel $DISKLABEL_SYSTEM on ${INSTALL_DEVICE}${PART1}"
+    dosfslabel ${INSTALL_DEVICE}${PART1}  $DISKLABEL_SYSTEM >> $LOGFILE 2>&1
 
-        msg_progress_install "28" "Creating filesystem on ${INSTALL_DEVICE}${PART2}"
-        mke2fs -t ext4 -m 0 ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
+    msg_progress_install "28" "Creating filesystem on ${INSTALL_DEVICE}${PART2}"
+    mke2fs -t ext4 -m 0 ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
 
-        msg_progress_install "30" "Set uuid and disklabel $DISKLABEL_STORAGE on ${INSTALL_DEVICE}${PART2}"
-        tune2fs -U random -L $DISKLABEL_STORAGE  ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
+    msg_progress_install "30" "Set uuid and disklabel $DISKLABEL_STORAGE on ${INSTALL_DEVICE}${PART2}"
+    tune2fs -U random -L $DISKLABEL_STORAGE  ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
 
-        UUID_SYSTEM="$(blkid --output udev ${INSTALL_DEVICE}${PART1} | grep ^ID_FS_UUID= | cut -d= -f2)"
-        UUID_STORAGE="$(blkid --output udev ${INSTALL_DEVICE}${PART2} | grep ^ID_FS_UUID= | cut -d= -f2)"
+    UUID_SYSTEM="$(blkid --output udev ${INSTALL_DEVICE}${PART1} | grep ^ID_FS_UUID= | cut -d= -f2)"
+    UUID_STORAGE="$(blkid --output udev ${INSTALL_DEVICE}${PART2} | grep ^ID_FS_UUID= | cut -d= -f2)"
 
-        echo "UUID_SYSTEM : ${UUID_SYSTEM}" >> $LOGFILE
-        echo "UUID_STORAGE: ${UUID_STORAGE}" >> $LOGFILE
+    echo "UUID_SYSTEM : ${UUID_SYSTEM}" >> $LOGFILE
+    echo "UUID_STORAGE: ${UUID_STORAGE}" >> $LOGFILE
 
-        # mount system partition
-        msg_progress_install "35" "Creating $TMPDIR/part1"
-        mkdir -p $TMPDIR/part1 >> $LOGFILE 2>&1
+    # mount system partition
+    msg_progress_install "35" "Creating $TMPDIR/part1"
+    mkdir -p $TMPDIR/part1 >> $LOGFILE 2>&1
 
-        msg_progress_install "40" "Mounting ${INSTALL_DEVICE}${PART1} to $TMPDIR/part1"
-        mount -t vfat ${INSTALL_DEVICE}${PART1} $TMPDIR/part1 >> $LOGFILE 2>&1
+    msg_progress_install "40" "Mounting ${INSTALL_DEVICE}${PART1} to $TMPDIR/part1"
+    mount -t vfat ${INSTALL_DEVICE}${PART1} $TMPDIR/part1 >> $LOGFILE 2>&1
 
-        # installing syslinux
-        msg_progress_install "50" "Installing syslinux to $TMPDIR/part1"
-        syslinux -i ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
+    # installing syslinux
+    msg_progress_install "50" "Installing syslinux to $TMPDIR/part1"
+    syslinux -i ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
 
-        # install system files
-        msg_progress_install "60" "Installing Kernel"
-        cp /flash/KERNEL $TMPDIR/part1 >> $LOGFILE 2>&1
+    # install system files
+    msg_progress_install "60" "Installing Kernel"
+    cp /flash/KERNEL $TMPDIR/part1 >> $LOGFILE 2>&1
 
-        msg_progress_install "65" "Installing System"
-        cp /flash/SYSTEM $TMPDIR/part1 >> $LOGFILE 2>&1
-        sync
+    msg_progress_install "65" "Installing System"
+    cp /flash/SYSTEM $TMPDIR/part1 >> $LOGFILE 2>&1
+    sync
 
-        # configuring bootloader
-        msg_progress_install "80" "Setup bootloader with boot label = $DISKLABEL_SYSTEM and disk label = $DISKLABEL_STORAGE"
-        mkdir -p $TMPDIR/part1/EFI/BOOT
-        cat << EOF > $TMPDIR/part1/syslinux.cfg
+    # configuring bootloader
+    msg_progress_install "80" "Setup bootloader with boot label = $DISKLABEL_SYSTEM and disk label = $DISKLABEL_STORAGE"
+    mkdir -p $TMPDIR/part1/EFI/BOOT
+    cat << EOF > $TMPDIR/part1/syslinux.cfg
 DEFAULT linux
 PROMPT 0
 
@@ -257,7 +254,8 @@ LABEL linux
  KERNEL /KERNEL
  APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE $SYSLINUX_PARAMETERS quiet
 EOF
-        cat << EOF > $TMPDIR/part1/EFI/BOOT/grub.cfg
+
+    cat << EOF > $TMPDIR/part1/EFI/BOOT/grub.cfg
 set timeout="0"
 set default="LibreELEC"
 
@@ -266,55 +264,46 @@ menuentry "LibreELEC" {
 	linux /KERNEL boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet
 }
 EOF
-        # uefi boot / hybrid mode
-        cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
-        cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
-        cp /usr/share/grub/bootia32.efi $TMPDIR/part1/EFI/BOOT
-        sync
 
-        # umount system partition, remove mountpoint
-        msg_progress_install "85" "Unmount $TMPDIR/part1"
-        umount $TMPDIR/part1 >> $LOGFILE 2>&1
+    # uefi boot / hybrid mode
+    cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
+    cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
+    cp /usr/share/grub/bootia32.efi $TMPDIR/part1/EFI/BOOT
+    sync
 
-        msg_progress_install "87" "Remove $TMPDIR/part1"
-        rmdir $TMPDIR/part1 >> $LOGFILE 2>&1
+    # umount system partition, remove mountpoint
+    msg_progress_install "85" "Unmount $TMPDIR/part1"
+    umount $TMPDIR/part1 >> $LOGFILE 2>&1
 
-        if [ "$BACKUP_UNPACK" = "1" ]; then
-          # mount storage partition
-          msg_progress_install "89" "Creating $TMPDIR/part2"
-          mkdir -p $TMPDIR/part2 >> $LOGFILE 2>&1
+    msg_progress_install "87" "Remove $TMPDIR/part1"
+    rmdir $TMPDIR/part1 >> $LOGFILE 2>&1
 
-          msg_progress_install "90" "Mounting ${INSTALL_DEVICE}${PART2} to $TMPDIR/part2"
-          mount -t ext4 ${INSTALL_DEVICE}${PART2} $TMPDIR/part2 >> $LOGFILE 2>&1
+    if [ "$BACKUP_UNPACK" = "1" ]; then
+      # mount storage partition
+      msg_progress_install "89" "Creating $TMPDIR/part2"
+      mkdir -p $TMPDIR/part2 >> $LOGFILE 2>&1
 
-          msg_progress_install "92" "Restoring backup"
-          [ -f /flash/backup.tar.bz2 ] && tar -xjf /flash/backup.tar.bz2 -C $TMPDIR/part2 >> $LOGFILE 2>&1
-          [ -f /flash/backup.zip ] && unzip -qq /flash/backup.zip -d $TMPDIR/part2 >> $LOGFILE 2>&1
-          sync
+      msg_progress_install "90" "Mounting ${INSTALL_DEVICE}${PART2} to $TMPDIR/part2"
+      mount -t ext4 ${INSTALL_DEVICE}${PART2} $TMPDIR/part2 >> $LOGFILE 2>&1
 
-          # umount system partition, remove mountpoint
-          msg_progress_install "97" "Unmount $TMPDIR/part2"
-          umount $TMPDIR/part2 >> $LOGFILE 2>&1
+      msg_progress_install "92" "Restoring backup"
+      [ -f /flash/backup.tar.bz2 ] && tar -xjf /flash/backup.tar.bz2 -C $TMPDIR/part2 >> $LOGFILE 2>&1
+      [ -f /flash/backup.zip ] && unzip -qq /flash/backup.zip -d $TMPDIR/part2 >> $LOGFILE 2>&1
+      sync
 
-          msg_progress_install "100" "Remove $TMPDIR/part2"
-          rmdir $TMPDIR/part2 >> $LOGFILE 2>&1
-        fi
-      } | whiptail --backtitle "$BACKTITLE" --gauge "Please wait while your system is being setup ..." 6 73 0
+      # umount system partition, remove mountpoint
+      msg_progress_install "97" "Unmount $TMPDIR/part2"
+      umount $TMPDIR/part2 >> $LOGFILE 2>&1
 
-      # install complete
-      MSG_TITLE="@DISTRONAME@ Install Complete"
-      MSG_DETAIL="You may now remove the install media and reboot.\n"
-      whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 7 52
+      msg_progress_install "100" "Remove $TMPDIR/part2"
+      rmdir $TMPDIR/part2 >> $LOGFILE 2>&1
+    fi
+  } | whiptail --backtitle "$BACKTITLE" --gauge "Please wait while your system is being setup ..." 6 73 0
 
-      menu_main
-      ;;
-    1)
-      menu_main
-      ;;
-    255)
-      do_poweroff
-      ;;
-  esac
+  # install complete
+  MSG_TITLE="@DISTRONAME@ Install Complete"
+  MSG_DETAIL="You may now remove the install media and reboot.\n"
+  whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_DETAIL" 7 52
 }
 
 msg_no_device() {
@@ -323,18 +312,6 @@ msg_no_device() {
   MSG_INFOBOX=" No devices were found. "
 
   whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_INFOBOX" 9 73
-
-  menu_main
-}
-
-msg_target_space() {
-  # show an error dialog for missing space
-  MSG_TITLE="TARGET SPACE"
-  MSG_INFOBOX="Not enough target space!\nInstallation aborted.\n"
-
-  whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox "$MSG_INFOBOX" 9 73
-
-  menu_main
 }
 
 msg_progress_install() {
@@ -346,15 +323,6 @@ msg_progress_install() {
   echo $1
   echo "$2 ..."
   echo XXX
-}
-
-msg_install_ready() {
-  # show a dialog that we have installed
-  MSG_TITLE="INFORMATION"
-
-  whiptail --backtitle "$BACKTITLE" --title "$MSG_TITLE" --msgbox " $1" 7 73
-
-  menu_main
 }
 
 prompt_gpt() {
@@ -403,16 +371,16 @@ out during the installation. \
   whiptail --backtitle "$BACKTITLE" --cancel-button "$MSG_CANCEL" \
     --title "$MSG_TITLE" --menu "$MSG_MENU" 18 73 3 \
       1 "Install @DISTRONAME@" \
-      2 "Installation log" \
+      2 "View installation log" \
       3 "Reboot" 2> $TMPDIR/mainmenu
 
   case $? in
     0)
       ITEM_MAINMENU=$(cat "$TMPDIR/mainmenu")
       case $ITEM_MAINMENU in
-        1) do_install_quick; break;;
-        2) logfile_show; break;;
-        3) do_reboot;
+        1) do_install_quick;;
+        2) logfile_show;;
+        3) do_reboot;;
       esac
       ;;
     1)
@@ -426,8 +394,6 @@ out during the installation. \
 
 logfile_show() {
   whiptail --textbox "$LOGFILE" 20 73 --scrolltext --backtitle "$BACKTITLE"
-  clear
-  menu_main
 }
 
 do_reboot() {

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -264,19 +264,23 @@ do_install_quick() {
         # configuring bootloader
         mkdir -p $TMPDIR/part1/EFI/BOOT
         msg_progress_install "80" "Setup bootloader with boot label = $DISKLABEL_SYSTEM and disk label = $DISKLABEL_STORAGE"
-        echo "DEFAULT linux" > $TMPDIR/part1/extlinux.conf
-        echo "PROMPT 0" >> $TMPDIR/part1/extlinux.conf
-        echo " " >> $TMPDIR/part1/extlinux.conf
-        echo "LABEL linux" >> $TMPDIR/part1/extlinux.conf
-        echo " KERNEL /KERNEL" >> $TMPDIR/part1/extlinux.conf
-        echo " APPEND boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE $EXTLINUX_PARAMETERS quiet" >> $TMPDIR/part1/extlinux.conf
-        echo "set timeout=\"0\"" > $TMPDIR/part1/EFI/BOOT/grub.cfg
-        echo "set default=\"LibreELEC\"" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
-        echo "" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
-        echo "menuentry \"LibreELEC\" {" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
-        echo "	search --set -f /KERNEL" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
-        echo "	linux /KERNEL boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE quiet" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
-        echo "}" >> $TMPDIR/part1/EFI/BOOT/grub.cfg
+        cat << EOF > $TMPDIR/part1/extlinux.conf
+DEFAULT linux
+PROMPT 0
+
+LABEL linux
+ KERNEL /KERNEL
+ APPEND boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE $EXTLINUX_PARAMETERS quiet
+EOF
+        cat << EOF > $TMPDIR/part1/EFI/BOOT/grub.cfg
+set timeout="0"
+set default="LibreELEC"
+
+menuentry "LibreELEC" {
+	search --set -f /KERNEL
+	linux /KERNEL boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE quiet
+}
+EOF
         # uefi boot / hybrid mode
         if [ "$UEFI" = "1" ]; then
           mv $TMPDIR/part1/extlinux.conf $TMPDIR/part1/syslinux.cfg

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -279,7 +279,6 @@ do_install_quick() {
         if [ "$UEFI" = "1" ]; then
           mv $TMPDIR/part1/extlinux.conf $TMPDIR/part1/syslinux.cfg
           mkdir -p $TMPDIR/part1/EFI/BOOT
-          cp $TMPDIR/part1/syslinux.cfg $TMPDIR/part1/EFI/BOOT
           cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
           cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
           cp $TMPDIR/part1/grub.cfg $TMPDIR/part1/EFI/BOOT

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -1,21 +1,22 @@
 #!/bin/sh
 
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 # some DOCs:

--- a/packages/tools/syslinux/package.mk
+++ b/packages/tools/syslinux/package.mk
@@ -66,7 +66,6 @@ make_host() {
 
 makeinstall_host() {
   mkdir -p $TOOLCHAIN/bin
-    cp bios/extlinux/extlinux $TOOLCHAIN/bin
     cp bios/linux/syslinux $TOOLCHAIN/bin
     cp bios/mtools/syslinux $TOOLCHAIN/bin/syslinux.mtools
 
@@ -79,11 +78,9 @@ makeinstall_host() {
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
-    cp bios/extlinux/extlinux $INSTALL/usr/bin
     cp bios/linux/syslinux $INSTALL/usr/bin
 
   $STRIP $INSTALL/usr/bin/syslinux
-  $STRIP $INSTALL/usr/bin/extlinux
 
   mkdir -p $INSTALL/usr/share/syslinux
     cp bios/mbr/mbr.bin $INSTALL/usr/share/syslinux

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -538,7 +538,7 @@ CONFIG_ATAGS=y
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
 # CONFIG_ARM_APPENDED_DTB is not set
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/kernel.img usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -619,7 +619,7 @@ CONFIG_ATAGS=y
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
 # CONFIG_ARM_APPENDED_DTB is not set
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/kernel.img usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/Rockchip/devices/MiQi/linux/rockchip-4.4/linux.arm.conf
+++ b/projects/Rockchip/devices/MiQi/linux/rockchip-4.4/linux.arm.conf
@@ -547,7 +547,7 @@ CONFIG_ATAGS=y
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
 # CONFIG_ARM_APPENDED_DTB is not set
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/zImage usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/Rockchip/devices/RK3328/linux/rockchip-4.4/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3328/linux/rockchip-4.4/linux.aarch64.conf
@@ -475,7 +475,7 @@ CONFIG_ARM64_MODULE_CMODEL_LARGE=y
 #
 # Boot options
 #
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/Image usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/Rockchip/devices/RK3399/linux/rockchip-4.4/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3399/linux/rockchip-4.4/linux.aarch64.conf
@@ -475,7 +475,7 @@ CONFIG_ARM64_MODULE_CMODEL_LARGE=y
 #
 # Boot options
 #
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/Image usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/Rockchip/devices/TinkerBoard/linux/rockchip-4.4/linux.arm.conf
+++ b/projects/Rockchip/devices/TinkerBoard/linux/rockchip-4.4/linux.arm.conf
@@ -547,7 +547,7 @@ CONFIG_ATAGS=y
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
 # CONFIG_ARM_APPENDED_DTB is not set
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/zImage usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/scripts/image
+++ b/scripts/image
@@ -326,11 +326,6 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
 
   # create image files if requested
   if [[ ( "$1" = "amlpkg" || "$1" = "noobs" || "$1" = "mkimage" ) && -n "$BOOTLOADER" ]]; then
-    # projects can set KERNEL_NAME (kernel.img)
-    if [ -z "$KERNEL_NAME" ] ; then
-      KERNEL_NAME="KERNEL"
-    fi
-
     # INSTALL_SRC_DIR can be board specific
     if [ -n "$DEVICE" -a -d "$PROJECT_DIR/$PROJECT/devices/$DEVICE/install" ]; then
       INSTALL_SRC_DIR="$PROJECT_DIR/$PROJECT/devices/$DEVICE/install"

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -1,21 +1,22 @@
 #!/bin/bash
 
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 ################################################################################

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -189,7 +189,6 @@ EOF
     mcopy $TOOLCHAIN/share/syslinux/bootx64.efi ::/EFI/BOOT
     mcopy $TOOLCHAIN/share/syslinux/ldlinux.e64 ::/EFI/BOOT
     mcopy $TOOLCHAIN/share/grub/bootia32.efi ::/EFI/BOOT
-    mcopy "$LE_TMP"/syslinux.cfg ::/EFI/BOOT
     mcopy "$LE_TMP"/grub.cfg ::/EFI/BOOT
 elif [ "$BOOTLOADER" = "bcm2835-bootloader" ]; then
   # create bootloader configuration
@@ -312,7 +311,6 @@ fi # bootloader
     sed -i "/DEFAULT/ s/installer/run/" "$LE_TMP"/syslinux.cfg
     sed -i "/set default=/s/\"Installer\"/\"Run\"/" "$LE_TMP"/grub.cfg
     # FIXME: an unalias should work here, but it does not; call mcopy directly
-    $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/syslinux.cfg ::/EFI/BOOT
     $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/syslinux.cfg ::
     $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/grub.cfg ::/EFI/BOOT
     $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/grub.cfg ::

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -174,8 +174,8 @@ EOF
 
     mcopy "$LE_TMP/syslinux.cfg" ::
 
-  # install extlinux
-    echo "image: installing extlinux to part1..."
+  # install syslinux
+    echo "image: installing syslinux to part1..."
     syslinux.mtools --offset "$OFFSET" -i "$DISK"
 
   # copy files

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -173,7 +173,6 @@ menuentry "Run" {
 EOF
 
     mcopy "$LE_TMP/syslinux.cfg" ::
-    mcopy "$LE_TMP/grub.cfg" ::
 
   # install extlinux
     echo "image: installing extlinux to part1..."
@@ -314,7 +313,6 @@ fi # bootloader
     # FIXME: an unalias should work here, but it does not; call mcopy directly
     $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/syslinux.cfg ::
     $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/grub.cfg ::/EFI/BOOT
-    $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/grub.cfg ::
     sync
     # merge modified part1 back to tmp disk image
     echo "image: merging part1 back to open virtual appliance..."


### PR DESCRIPTION
As discussed on the forum:

1) Upgrade from img.gz fails when using a custom kernel filename ([thread](https://forum.libreelec.tv/thread/12400-update-with-new-le-img-gz-failes-when-boot-image-kern-82))
2) /flash/EFI/BOOT/syslinux.cfg is redundant ([thread](https://forum.libreelec.tv/thread/12411-just-one-syslinux-cfg-to-edit-for-bios-uefi))
3) Boot hooks (for encryption, other things) and configurable system to ram limit ([thread](https://forum.libreelec.tv/thread/12413-2-init-boot-hooks-and-kernel-argument-to-configure-system-toram-limit-patch-incl))

Thanks sky42.