### PR TITLE
Rockchip: use default kernel name

### DIFF
--- a/projects/Rockchip/devices/MiQi/linux/rockchip-4.4/linux.arm.conf
+++ b/projects/Rockchip/devices/MiQi/linux/rockchip-4.4/linux.arm.conf
@@ -547,7 +547,7 @@ CONFIG_ATAGS=y
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
 # CONFIG_ARM_APPENDED_DTB is not set
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/zImage usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/Rockchip/devices/MiQi/options
+++ b/projects/Rockchip/devices/MiQi/options
@@ -26,8 +26,5 @@
     MALI_FAMILY="t760"
     MALI_REVISION="r1p0"
 
-  # kernel image name
-    KERNEL_NAME="zImage"
-
   # kernel serial console
     EXTRA_CMDLINE="console=uart8250,mmio32,0xff690000 console=tty0"

--- a/projects/Rockchip/devices/RK3328/linux/rockchip-4.4/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3328/linux/rockchip-4.4/linux.aarch64.conf
@@ -475,7 +475,7 @@ CONFIG_ARM64_MODULE_CMODEL_LARGE=y
 #
 # Boot options
 #
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/Image usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/Rockchip/devices/RK3328/options
+++ b/projects/Rockchip/devices/RK3328/options
@@ -36,8 +36,5 @@
   # Mali GPU family
     MALI_FAMILY="450"
 
-  # kernel image name
-    KERNEL_NAME="Image"
-
   # kernel serial console
     EXTRA_CMDLINE="console=uart8250,mmio32,0xff130000 console=tty0"

--- a/projects/Rockchip/devices/RK3399/linux/rockchip-4.4/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3399/linux/rockchip-4.4/linux.aarch64.conf
@@ -475,7 +475,7 @@ CONFIG_ARM64_MODULE_CMODEL_LARGE=y
 #
 # Boot options
 #
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/Image usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -34,8 +34,5 @@
   # Mali GPU family
     MALI_FAMILY="t860"
 
-  # kernel image name
-    KERNEL_NAME="Image"
-
   # kernel serial console
     EXTRA_CMDLINE="console=uart8250,mmio32,0xff1a0000 console=tty0"

--- a/projects/Rockchip/devices/TinkerBoard/linux/rockchip-4.4/linux.arm.conf
+++ b/projects/Rockchip/devices/TinkerBoard/linux/rockchip-4.4/linux.arm.conf
@@ -547,7 +547,7 @@ CONFIG_ATAGS=y
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
 # CONFIG_ARM_APPENDED_DTB is not set
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init BOOT_IMAGE=/zImage usbcore.autosuspend=-1"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/projects/Rockchip/devices/TinkerBoard/options
+++ b/projects/Rockchip/devices/TinkerBoard/options
@@ -25,8 +25,5 @@
   # Mali GPU family
     MALI_FAMILY="t760"
 
-  # kernel image name
-    KERNEL_NAME="zImage"
-
   # kernel serial console
     EXTRA_CMDLINE="console=uart8250,mmio32,0xff690000 console=tty0"


### PR DESCRIPTION
I'm not sure why this was done this way, but let's fix it now :+1: 