### PR TITLE
RPi, Generic: fix erratic IR timeout behaviour on Topseed mceusb receiver 1784:0011

### DIFF
--- a/packages/linux/patches/default/linux-999-improve-ir-timeout-handling.patch
+++ b/packages/linux/patches/default/linux-999-improve-ir-timeout-handling.patch
@@ -1,7 +1,7 @@
 From 057ccfd1d18842bd2fa39c4b996a9a952c5a821d Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:35:11 +0200
-Subject: [PATCH 1/9] media: rc: set timeout to smallest value required by
+Subject: [PATCH 01/10] media: rc: set timeout to smallest value required by
  enabled protocols
 
 backport of https://patchwork.linuxtv.org/patch/48516/
@@ -31,7 +31,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  12 files changed, 46 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/media/rc/ir-jvc-decoder.c b/drivers/media/rc/ir-jvc-decoder.c
-index e2bd68c42edfa..fc931fe39bb75 100644
+index e2bd68c42edf..fc931fe39bb7 100644
 --- a/drivers/media/rc/ir-jvc-decoder.c
 +++ b/drivers/media/rc/ir-jvc-decoder.c
 @@ -212,6 +212,7 @@ static struct ir_raw_handler jvc_handler = {
@@ -43,7 +43,7 @@ index e2bd68c42edfa..fc931fe39bb75 100644
  
  static int __init ir_jvc_decode_init(void)
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 7c572a6436563..7afeab04dbbfd 100644
+index 7c572a643656..7afeab04dbbf 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -474,6 +474,7 @@ static struct ir_raw_handler mce_kbd_handler = {
@@ -55,7 +55,7 @@ index 7c572a6436563..7afeab04dbbfd 100644
  
  static int __init ir_mce_kbd_decode_init(void)
 diff --git a/drivers/media/rc/ir-nec-decoder.c b/drivers/media/rc/ir-nec-decoder.c
-index a95d09acc22a5..3e12059add84d 100644
+index a95d09acc22a..3e12059add84 100644
 --- a/drivers/media/rc/ir-nec-decoder.c
 +++ b/drivers/media/rc/ir-nec-decoder.c
 @@ -264,6 +264,7 @@ static struct ir_raw_handler nec_handler = {
@@ -67,7 +67,7 @@ index a95d09acc22a5..3e12059add84d 100644
  
  static int __init ir_nec_decode_init(void)
 diff --git a/drivers/media/rc/ir-rc5-decoder.c b/drivers/media/rc/ir-rc5-decoder.c
-index 1292f534de434..1eaca0528b691 100644
+index 1292f534de43..1eaca0528b69 100644
 --- a/drivers/media/rc/ir-rc5-decoder.c
 +++ b/drivers/media/rc/ir-rc5-decoder.c
 @@ -282,6 +282,7 @@ static struct ir_raw_handler rc5_handler = {
@@ -79,7 +79,7 @@ index 1292f534de434..1eaca0528b691 100644
  
  static int __init ir_rc5_decode_init(void)
 diff --git a/drivers/media/rc/ir-rc6-decoder.c b/drivers/media/rc/ir-rc6-decoder.c
-index 5d0d2fe3b7a7f..8c4c733a5f27b 100644
+index 5d0d2fe3b7a7..8c4c733a5f27 100644
 --- a/drivers/media/rc/ir-rc6-decoder.c
 +++ b/drivers/media/rc/ir-rc6-decoder.c
 @@ -408,6 +408,7 @@ static struct ir_raw_handler rc6_handler = {
@@ -91,7 +91,7 @@ index 5d0d2fe3b7a7f..8c4c733a5f27b 100644
  
  static int __init ir_rc6_decode_init(void)
 diff --git a/drivers/media/rc/ir-sanyo-decoder.c b/drivers/media/rc/ir-sanyo-decoder.c
-index 758c60956850f..935880d4889ec 100644
+index 758c60956850..935880d4889e 100644
 --- a/drivers/media/rc/ir-sanyo-decoder.c
 +++ b/drivers/media/rc/ir-sanyo-decoder.c
 @@ -218,6 +218,7 @@ static struct ir_raw_handler sanyo_handler = {
@@ -103,7 +103,7 @@ index 758c60956850f..935880d4889ec 100644
  
  static int __init ir_sanyo_decode_init(void)
 diff --git a/drivers/media/rc/ir-sharp-decoder.c b/drivers/media/rc/ir-sharp-decoder.c
-index 129b558acc921..96d818bd0cc98 100644
+index 129b558acc92..96d818bd0cc9 100644
 --- a/drivers/media/rc/ir-sharp-decoder.c
 +++ b/drivers/media/rc/ir-sharp-decoder.c
 @@ -226,6 +226,7 @@ static struct ir_raw_handler sharp_handler = {
@@ -115,7 +115,7 @@ index 129b558acc921..96d818bd0cc98 100644
  
  static int __init ir_sharp_decode_init(void)
 diff --git a/drivers/media/rc/ir-sony-decoder.c b/drivers/media/rc/ir-sony-decoder.c
-index a47ced763031d..d57d15b431f6d 100644
+index a47ced763031..d57d15b431f6 100644
 --- a/drivers/media/rc/ir-sony-decoder.c
 +++ b/drivers/media/rc/ir-sony-decoder.c
 @@ -221,6 +221,7 @@ static struct ir_raw_handler sony_handler = {
@@ -127,7 +127,7 @@ index a47ced763031d..d57d15b431f6d 100644
  
  static int __init ir_sony_decode_init(void)
 diff --git a/drivers/media/rc/ir-xmp-decoder.c b/drivers/media/rc/ir-xmp-decoder.c
-index 6f464be1c8d7a..1ac3a4cee69e3 100644
+index 6f464be1c8d7..1ac3a4cee69e 100644
 --- a/drivers/media/rc/ir-xmp-decoder.c
 +++ b/drivers/media/rc/ir-xmp-decoder.c
 @@ -198,6 +198,7 @@ static int ir_xmp_decode(struct rc_dev *dev, struct ir_raw_event ev)
@@ -139,7 +139,7 @@ index 6f464be1c8d7a..1ac3a4cee69e3 100644
  
  static int __init ir_xmp_decode_init(void)
 diff --git a/drivers/media/rc/rc-core-priv.h b/drivers/media/rc/rc-core-priv.h
-index 7da9c96cb0588..5fd3b5aed9ece 100644
+index 7da9c96cb058..5fd3b5aed9ec 100644
 --- a/drivers/media/rc/rc-core-priv.h
 +++ b/drivers/media/rc/rc-core-priv.h
 @@ -29,6 +29,7 @@ struct ir_raw_handler {
@@ -151,7 +151,7 @@ index 7da9c96cb0588..5fd3b5aed9ece 100644
  	/* These two should only be used by the lirc decoder */
  	int (*raw_register)(struct rc_dev *dev);
 diff --git a/drivers/media/rc/rc-ir-raw.c b/drivers/media/rc/rc-ir-raw.c
-index 503bc425a187c..7f0197bf5d32d 100644
+index 503bc425a187..7f0197bf5d32 100644
 --- a/drivers/media/rc/rc-ir-raw.c
 +++ b/drivers/media/rc/rc-ir-raw.c
 @@ -215,7 +215,36 @@ ir_raw_get_allowed_protocols(void)
@@ -193,7 +193,7 @@ index 503bc425a187c..7f0197bf5d32d 100644
  }
  
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index 72f381522cb26..e7e20bcfe2729 100644
+index 72f381522cb2..e7e20bcfe272 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -1161,6 +1161,9 @@ static ssize_t store_protocols(struct device *device,
@@ -243,7 +243,7 @@ index 72f381522cb26..e7e20bcfe2729 100644
 From 00f54931b0ff7202020567544605b7e3c4f1dee8 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:45:36 +0200
-Subject: [PATCH 2/9] media: rc: per-protocol repeat period and minimum keyup
+Subject: [PATCH 02/10] media: rc: per-protocol repeat period and minimum keyup
  timer
 
 backport of https://patchwork.linuxtv.org/patch/48520/
@@ -265,7 +265,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  3 files changed, 30 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/media/cec/cec-core.c b/drivers/media/cec/cec-core.c
-index 648136e552d5b..4cf35e4af7bd6 100644
+index 648136e552d5..4cf35e4af7bd 100644
 --- a/drivers/media/cec/cec-core.c
 +++ b/drivers/media/cec/cec-core.c
 @@ -280,7 +280,7 @@ struct cec_adapter *cec_allocate_adapter(const struct cec_adap_ops *ops,
@@ -278,7 +278,7 @@ index 648136e552d5b..4cf35e4af7bd6 100644
  #endif
  	return adap;
 diff --git a/drivers/media/rc/ir-lirc-codec.c b/drivers/media/rc/ir-lirc-codec.c
-index 4c8f456238bca..ef7e43038092f 100644
+index 4c8f456238bc..ef7e43038092 100644
 --- a/drivers/media/rc/ir-lirc-codec.c
 +++ b/drivers/media/rc/ir-lirc-codec.c
 @@ -314,7 +314,7 @@ static long ir_lirc_ioctl(struct file *filep, unsigned int cmd,
@@ -291,7 +291,7 @@ index 4c8f456238bca..ef7e43038092f 100644
  
  		lirc->send_timeout_reports = !!val;
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index e7e20bcfe2729..36f99a0919c30 100644
+index e7e20bcfe272..36f99a0919c3 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -35,48 +35,48 @@ static const struct {
@@ -409,7 +409,7 @@ index e7e20bcfe2729..36f99a0919c30 100644
 From 6f3d979fa02a3847799d838a03ad9c5ad009a778 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:39 +0100
-Subject: [PATCH 3/9] media: rc: mce_kbd decoder: low timeout values cause
+Subject: [PATCH 03/10] media: rc: mce_kbd decoder: low timeout values cause
  double keydowns
 
 backport of https://patchwork.linuxtv.org/patch/48522/
@@ -429,7 +429,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 7afeab04dbbfd..a243d2d1ca935 100644
+index 7afeab04dbbf..a243d2d1ca93 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -319,11 +319,13 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
@@ -458,7 +458,7 @@ index 7afeab04dbbfd..a243d2d1ca935 100644
 From f4d8df33339167784bb6a17e3ee2d20f9efe1b21 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:40 +0100
-Subject: [PATCH 4/9] media: rc: mce_kbd protocol encodes two scancodes
+Subject: [PATCH 04/10] media: rc: mce_kbd protocol encodes two scancodes
 
 backport of https://patchwork.linuxtv.org/patch/48518/
 
@@ -473,7 +473,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  2 files changed, 13 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index a243d2d1ca935..2ea48a54f2b3e 100644
+index a243d2d1ca93..2ea48a54f2b3 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -147,13 +147,14 @@ static enum mce_kbd_mode mce_kbd_mode(struct mce_kbd_dec *data)
@@ -522,7 +522,7 @@ index a243d2d1ca935..2ea48a54f2b3e 100644
  			if (scancode) {
  				delay = nsecs_to_jiffies(dev->timeout) +
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index 36f99a0919c30..34cef7aa207c9 100644
+index 36f99a0919c3..34cef7aa207c 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -60,7 +60,7 @@ static const struct {
@@ -541,7 +541,7 @@ index 36f99a0919c30..34cef7aa207c9 100644
 From 8b0ffc3eccf8737aa93c6b7bf9bc9d1e10d634bd Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:41 +0100
-Subject: [PATCH 5/9] media: rc: mce_kbd decoder: fix stuck keys
+Subject: [PATCH 05/10] media: rc: mce_kbd decoder: fix stuck keys
 
 backport of https://patchwork.linuxtv.org/patch/48519/
 
@@ -557,7 +557,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 2ea48a54f2b3e..164302ec4fef0 100644
+index 2ea48a54f2b3..164302ec4fef 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -130,6 +130,8 @@ static void mce_kbd_rx_timeout(unsigned long data)
@@ -576,7 +576,7 @@ index 2ea48a54f2b3e..164302ec4fef0 100644
 From b77de094b54449079890b8cc4fbc2f98573253b2 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:42 +0100
-Subject: [PATCH 6/9] media: rc: mceusb: allow the timeout to be configurable
+Subject: [PATCH 06/10] media: rc: mceusb: allow the timeout to be configurable
 
 backport of https://patchwork.linuxtv.org/patch/48521/
 
@@ -589,7 +589,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 22 insertions(+)
 
 diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
-index bf7aaff3aa375..160754a7a3822 100644
+index bf7aaff3aa37..160754a7a382 100644
 --- a/drivers/media/rc/mceusb.c
 +++ b/drivers/media/rc/mceusb.c
 @@ -937,6 +937,25 @@ static int mceusb_set_tx_carrier(struct rc_dev *dev, u32 carrier)
@@ -636,7 +636,7 @@ index bf7aaff3aa375..160754a7a3822 100644
 From dccebb7231209acb8da7f9f1e8fd1e7c12c3e70f Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:26:21 +0200
-Subject: [PATCH 7/9] media: rc: mce_kbd decoder: remove superfluous call to
+Subject: [PATCH 07/10] media: rc: mce_kbd decoder: remove superfluous call to
  input_sync
 
 backport of https://patchwork.linuxtv.org/patch/48681/
@@ -651,7 +651,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 164302ec4fef0..f057b57074c97 100644
+index 164302ec4fef..f057b57074c9 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -355,7 +355,6 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
@@ -669,7 +669,7 @@ index 164302ec4fef0..f057b57074c97 100644
 From 731b38824c8145bbc7d55a9c2af4e449ff5988fb Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:38:49 +0200
-Subject: [PATCH 8/9] media: rc: mce_kbd decoder: fix race condition
+Subject: [PATCH 08/10] media: rc: mce_kbd decoder: fix race condition
 
 backport of https://patchwork.linuxtv.org/patch/48680/
 
@@ -692,7 +692,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  2 files changed, 17 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index f057b57074c97..67c37db76737f 100644
+index f057b57074c9..67c37db76737 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -120,18 +120,24 @@ static void mce_kbd_rx_timeout(unsigned long data)
@@ -752,7 +752,7 @@ index f057b57074c97..67c37db76737f 100644
  	input_set_drvdata(idev, mce_kbd);
  
 diff --git a/drivers/media/rc/rc-core-priv.h b/drivers/media/rc/rc-core-priv.h
-index 5fd3b5aed9ece..77928ae431041 100644
+index 5fd3b5aed9ec..77928ae43104 100644
 --- a/drivers/media/rc/rc-core-priv.h
 +++ b/drivers/media/rc/rc-core-priv.h
 @@ -97,6 +97,7 @@ struct ir_raw_event_ctrl {
@@ -770,7 +770,7 @@ index 5fd3b5aed9ece..77928ae431041 100644
 From 4e363f78b2aae387980ac411e0f901caee5da9e1 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Wed, 18 Apr 2018 13:50:52 +0200
-Subject: [PATCH 9/9] media: rc: mceusb: IR of length 0 means IR timeout, not
+Subject: [PATCH 09/10] media: rc: mceusb: IR of length 0 means IR timeout, not
  reset
 
 backport of https://patchwork.linuxtv.org/patch/48782/
@@ -785,7 +785,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
-index 160754a7a3822..dc7ebed00b3ac 100644
+index 160754a7a382..dc7ebed00b3a 100644
 --- a/drivers/media/rc/mceusb.c
 +++ b/drivers/media/rc/mceusb.c
 @@ -1056,8 +1056,14 @@ static void mceusb_process_ir_data(struct mceusb_dev *ir, int buf_len)
@@ -805,6 +805,88 @@ index 160754a7a3822..dc7ebed00b3ac 100644
  			break;
  		}
  
+-- 
+2.11.0
+
+
+From f74716d6fc4a38f56a374a00cb96be61f2d6fc2d Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Thu, 10 May 2018 10:42:24 +0200
+Subject: [PATCH 10/10] media: mceusb: MCE_CMD_SETIRTIMEOUT cause strange
+ behaviour on device
+
+backport of https://patchwork.linuxtv.org/patch/49409/
+
+If the IR timeout is set on vid 1784 pid 0011, the device starts
+behaving strangely.
+
+Reported-by: Matthias Reichl <hias@horus.com>
+Signed-off-by: Sean Young <sean@mess.org>
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/mceusb.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
+index dc7ebed00b3a..2e1241f09c9d 100644
+--- a/drivers/media/rc/mceusb.c
++++ b/drivers/media/rc/mceusb.c
+@@ -181,6 +181,7 @@ enum mceusb_model_type {
+ 	MCE_GEN2 = 0,		/* Most boards */
+ 	MCE_GEN1,
+ 	MCE_GEN3,
++	MCE_GEN3_BROKEN_IRTIMEOUT,
+ 	MCE_GEN2_TX_INV,
+ 	POLARIS_EVK,
+ 	CX_HYBRID_TV,
+@@ -196,6 +197,7 @@ struct mceusb_model {
+ 	u32 mce_gen3:1;
+ 	u32 tx_mask_normal:1;
+ 	u32 no_tx:1;
++	u32 broken_irtimeout:1;
+ 
+ 	int ir_intfnum;
+ 
+@@ -223,6 +225,11 @@ static const struct mceusb_model mceusb_model[] = {
+ 		.mce_gen3 = 1,
+ 		.tx_mask_normal = 1,
+ 	},
++	[MCE_GEN3_BROKEN_IRTIMEOUT] = {
++		.mce_gen3 = 1,
++		.tx_mask_normal = 1,
++		.broken_irtimeout = 1
++	},
+ 	[POLARIS_EVK] = {
+ 		/*
+ 		 * In fact, the EVK is shipped without
+@@ -320,7 +327,7 @@ static struct usb_device_id mceusb_dev_table[] = {
+ 	  .driver_info = MCE_GEN2_TX_INV },
+ 	/* Topseed eHome Infrared Transceiver */
+ 	{ USB_DEVICE(VENDOR_TOPSEED, 0x0011),
+-	  .driver_info = MCE_GEN3 },
++	  .driver_info = MCE_GEN3_BROKEN_IRTIMEOUT },
+ 	/* Ricavision internal Infrared Transceiver */
+ 	{ USB_DEVICE(VENDOR_RICAVISION, 0x0010) },
+ 	/* Itron ione Libra Q-11 */
+@@ -1295,8 +1302,16 @@ static struct rc_dev *mceusb_init_rc_dev(struct mceusb_dev *ir)
+ 	rc->allowed_protocols = RC_PROTO_BIT_ALL_IR_DECODER;
+ 	rc->min_timeout = US_TO_NS(MCE_TIME_UNIT);
+ 	rc->timeout = MS_TO_NS(100);
+-	rc->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
+-	rc->s_timeout = mceusb_set_timeout;
++	if (!mceusb_model[ir->model].broken_irtimeout) {
++		rc->s_timeout = mceusb_set_timeout;
++		rc->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
++	} else {
++		/*
++		 * If we can't set the timeout using CMD_SETIRTIMEOUT, we can
++		 * rely on software timeouts for timeouts < 100ms.
++		 */
++		rc->max_timeout = rc->timeout;
++	}
+ 	if (!ir->flags.no_tx) {
+ 		rc->s_tx_mask = mceusb_set_tx_mask;
+ 		rc->s_tx_carrier = mceusb_set_tx_carrier;
 -- 
 2.11.0
 

--- a/packages/linux/patches/default/linux-999-improve-ir-timeout-handling.patch
+++ b/packages/linux/patches/default/linux-999-improve-ir-timeout-handling.patch
@@ -1,7 +1,7 @@
 From 057ccfd1d18842bd2fa39c4b996a9a952c5a821d Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:35:11 +0200
-Subject: [PATCH 01/10] media: rc: set timeout to smallest value required by
+Subject: [PATCH 01/11] media: rc: set timeout to smallest value required by
  enabled protocols
 
 backport of https://patchwork.linuxtv.org/patch/48516/
@@ -243,7 +243,7 @@ index 72f381522cb2..e7e20bcfe272 100644
 From 00f54931b0ff7202020567544605b7e3c4f1dee8 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:45:36 +0200
-Subject: [PATCH 02/10] media: rc: per-protocol repeat period and minimum keyup
+Subject: [PATCH 02/11] media: rc: per-protocol repeat period and minimum keyup
  timer
 
 backport of https://patchwork.linuxtv.org/patch/48520/
@@ -409,7 +409,7 @@ index e7e20bcfe272..36f99a0919c3 100644
 From 6f3d979fa02a3847799d838a03ad9c5ad009a778 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:39 +0100
-Subject: [PATCH 03/10] media: rc: mce_kbd decoder: low timeout values cause
+Subject: [PATCH 03/11] media: rc: mce_kbd decoder: low timeout values cause
  double keydowns
 
 backport of https://patchwork.linuxtv.org/patch/48522/
@@ -458,7 +458,7 @@ index 7afeab04dbbf..a243d2d1ca93 100644
 From f4d8df33339167784bb6a17e3ee2d20f9efe1b21 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:40 +0100
-Subject: [PATCH 04/10] media: rc: mce_kbd protocol encodes two scancodes
+Subject: [PATCH 04/11] media: rc: mce_kbd protocol encodes two scancodes
 
 backport of https://patchwork.linuxtv.org/patch/48518/
 
@@ -541,7 +541,7 @@ index 36f99a0919c3..34cef7aa207c 100644
 From 8b0ffc3eccf8737aa93c6b7bf9bc9d1e10d634bd Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:41 +0100
-Subject: [PATCH 05/10] media: rc: mce_kbd decoder: fix stuck keys
+Subject: [PATCH 05/11] media: rc: mce_kbd decoder: fix stuck keys
 
 backport of https://patchwork.linuxtv.org/patch/48519/
 
@@ -576,7 +576,7 @@ index 2ea48a54f2b3..164302ec4fef 100644
 From b77de094b54449079890b8cc4fbc2f98573253b2 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:42 +0100
-Subject: [PATCH 06/10] media: rc: mceusb: allow the timeout to be configurable
+Subject: [PATCH 06/11] media: rc: mceusb: allow the timeout to be configurable
 
 backport of https://patchwork.linuxtv.org/patch/48521/
 
@@ -636,7 +636,7 @@ index bf7aaff3aa37..160754a7a382 100644
 From dccebb7231209acb8da7f9f1e8fd1e7c12c3e70f Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:26:21 +0200
-Subject: [PATCH 07/10] media: rc: mce_kbd decoder: remove superfluous call to
+Subject: [PATCH 07/11] media: rc: mce_kbd decoder: remove superfluous call to
  input_sync
 
 backport of https://patchwork.linuxtv.org/patch/48681/
@@ -669,7 +669,7 @@ index 164302ec4fef..f057b57074c9 100644
 From 731b38824c8145bbc7d55a9c2af4e449ff5988fb Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:38:49 +0200
-Subject: [PATCH 08/10] media: rc: mce_kbd decoder: fix race condition
+Subject: [PATCH 08/11] media: rc: mce_kbd decoder: fix race condition
 
 backport of https://patchwork.linuxtv.org/patch/48680/
 
@@ -770,7 +770,7 @@ index 5fd3b5aed9ec..77928ae43104 100644
 From 4e363f78b2aae387980ac411e0f901caee5da9e1 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Wed, 18 Apr 2018 13:50:52 +0200
-Subject: [PATCH 09/10] media: rc: mceusb: IR of length 0 means IR timeout, not
+Subject: [PATCH 09/11] media: rc: mceusb: IR of length 0 means IR timeout, not
  reset
 
 backport of https://patchwork.linuxtv.org/patch/48782/
@@ -812,7 +812,7 @@ index 160754a7a382..dc7ebed00b3a 100644
 From f74716d6fc4a38f56a374a00cb96be61f2d6fc2d Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Thu, 10 May 2018 10:42:24 +0200
-Subject: [PATCH 10/10] media: mceusb: MCE_CMD_SETIRTIMEOUT cause strange
+Subject: [PATCH 10/11] media: mceusb: MCE_CMD_SETIRTIMEOUT cause strange
  behaviour on device
 
 backport of https://patchwork.linuxtv.org/patch/49409/
@@ -887,6 +887,45 @@ index dc7ebed00b3a..2e1241f09c9d 100644
  	if (!ir->flags.no_tx) {
  		rc->s_tx_mask = mceusb_set_tx_mask;
  		rc->s_tx_carrier = mceusb_set_tx_carrier;
+-- 
+2.11.0
+
+
+From 0899b373cb0604ed80a80b501dd48cf6a3cbff25 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Fri, 11 May 2018 12:20:44 +0200
+Subject: [PATCH 11/11] media: mceusb: filter out bogus timing irdata of
+ duration 0
+
+Backport of https://patchwork.linuxtv.org/patch/49430/
+
+A mceusb device has been observed producing invalid irdata. Proactively
+guard against this.
+
+Suggested-by: Matthias Reichl <hias@horus.com>
+Signed-off-by: Sean Young <sean@mess.org>
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/mceusb.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
+index 2e1241f09c9d..7864a30c4f9e 100644
+--- a/drivers/media/rc/mceusb.c
++++ b/drivers/media/rc/mceusb.c
+@@ -1038,6 +1038,12 @@ static void mceusb_process_ir_data(struct mceusb_dev *ir, int buf_len)
+ 			rawir.duration = (ir->buf_in[i] & MCE_PULSE_MASK)
+ 					 * US_TO_NS(MCE_TIME_UNIT);
+ 
++			if (unlikely(!rawir.duration)) {
++				dev_warn(ir->dev, "nonsensical irdata %02x with duration 0",
++					 ir->buf_in[i]);
++				break;
++			}
++
+ 			dev_dbg(ir->dev, "Storing %s with duration %u",
+ 				rawir.pulse ? "pulse" : "space",
+ 				rawir.duration);
 -- 
 2.11.0
 

--- a/packages/linux/patches/raspberrypi/linux-999-improve-ir-timeout-handling.patch
+++ b/packages/linux/patches/raspberrypi/linux-999-improve-ir-timeout-handling.patch
@@ -1,7 +1,7 @@
 From 057ccfd1d18842bd2fa39c4b996a9a952c5a821d Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:35:11 +0200
-Subject: [PATCH 1/9] media: rc: set timeout to smallest value required by
+Subject: [PATCH 01/10] media: rc: set timeout to smallest value required by
  enabled protocols
 
 backport of https://patchwork.linuxtv.org/patch/48516/
@@ -31,7 +31,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  12 files changed, 46 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/media/rc/ir-jvc-decoder.c b/drivers/media/rc/ir-jvc-decoder.c
-index e2bd68c42edfa..fc931fe39bb75 100644
+index e2bd68c42edf..fc931fe39bb7 100644
 --- a/drivers/media/rc/ir-jvc-decoder.c
 +++ b/drivers/media/rc/ir-jvc-decoder.c
 @@ -212,6 +212,7 @@ static struct ir_raw_handler jvc_handler = {
@@ -43,7 +43,7 @@ index e2bd68c42edfa..fc931fe39bb75 100644
  
  static int __init ir_jvc_decode_init(void)
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 7c572a6436563..7afeab04dbbfd 100644
+index 7c572a643656..7afeab04dbbf 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -474,6 +474,7 @@ static struct ir_raw_handler mce_kbd_handler = {
@@ -55,7 +55,7 @@ index 7c572a6436563..7afeab04dbbfd 100644
  
  static int __init ir_mce_kbd_decode_init(void)
 diff --git a/drivers/media/rc/ir-nec-decoder.c b/drivers/media/rc/ir-nec-decoder.c
-index a95d09acc22a5..3e12059add84d 100644
+index a95d09acc22a..3e12059add84 100644
 --- a/drivers/media/rc/ir-nec-decoder.c
 +++ b/drivers/media/rc/ir-nec-decoder.c
 @@ -264,6 +264,7 @@ static struct ir_raw_handler nec_handler = {
@@ -67,7 +67,7 @@ index a95d09acc22a5..3e12059add84d 100644
  
  static int __init ir_nec_decode_init(void)
 diff --git a/drivers/media/rc/ir-rc5-decoder.c b/drivers/media/rc/ir-rc5-decoder.c
-index 1292f534de434..1eaca0528b691 100644
+index 1292f534de43..1eaca0528b69 100644
 --- a/drivers/media/rc/ir-rc5-decoder.c
 +++ b/drivers/media/rc/ir-rc5-decoder.c
 @@ -282,6 +282,7 @@ static struct ir_raw_handler rc5_handler = {
@@ -79,7 +79,7 @@ index 1292f534de434..1eaca0528b691 100644
  
  static int __init ir_rc5_decode_init(void)
 diff --git a/drivers/media/rc/ir-rc6-decoder.c b/drivers/media/rc/ir-rc6-decoder.c
-index 5d0d2fe3b7a7f..8c4c733a5f27b 100644
+index 5d0d2fe3b7a7..8c4c733a5f27 100644
 --- a/drivers/media/rc/ir-rc6-decoder.c
 +++ b/drivers/media/rc/ir-rc6-decoder.c
 @@ -408,6 +408,7 @@ static struct ir_raw_handler rc6_handler = {
@@ -91,7 +91,7 @@ index 5d0d2fe3b7a7f..8c4c733a5f27b 100644
  
  static int __init ir_rc6_decode_init(void)
 diff --git a/drivers/media/rc/ir-sanyo-decoder.c b/drivers/media/rc/ir-sanyo-decoder.c
-index 758c60956850f..935880d4889ec 100644
+index 758c60956850..935880d4889e 100644
 --- a/drivers/media/rc/ir-sanyo-decoder.c
 +++ b/drivers/media/rc/ir-sanyo-decoder.c
 @@ -218,6 +218,7 @@ static struct ir_raw_handler sanyo_handler = {
@@ -103,7 +103,7 @@ index 758c60956850f..935880d4889ec 100644
  
  static int __init ir_sanyo_decode_init(void)
 diff --git a/drivers/media/rc/ir-sharp-decoder.c b/drivers/media/rc/ir-sharp-decoder.c
-index 129b558acc921..96d818bd0cc98 100644
+index 129b558acc92..96d818bd0cc9 100644
 --- a/drivers/media/rc/ir-sharp-decoder.c
 +++ b/drivers/media/rc/ir-sharp-decoder.c
 @@ -226,6 +226,7 @@ static struct ir_raw_handler sharp_handler = {
@@ -115,7 +115,7 @@ index 129b558acc921..96d818bd0cc98 100644
  
  static int __init ir_sharp_decode_init(void)
 diff --git a/drivers/media/rc/ir-sony-decoder.c b/drivers/media/rc/ir-sony-decoder.c
-index a47ced763031d..d57d15b431f6d 100644
+index a47ced763031..d57d15b431f6 100644
 --- a/drivers/media/rc/ir-sony-decoder.c
 +++ b/drivers/media/rc/ir-sony-decoder.c
 @@ -221,6 +221,7 @@ static struct ir_raw_handler sony_handler = {
@@ -127,7 +127,7 @@ index a47ced763031d..d57d15b431f6d 100644
  
  static int __init ir_sony_decode_init(void)
 diff --git a/drivers/media/rc/ir-xmp-decoder.c b/drivers/media/rc/ir-xmp-decoder.c
-index 6f464be1c8d7a..1ac3a4cee69e3 100644
+index 6f464be1c8d7..1ac3a4cee69e 100644
 --- a/drivers/media/rc/ir-xmp-decoder.c
 +++ b/drivers/media/rc/ir-xmp-decoder.c
 @@ -198,6 +198,7 @@ static int ir_xmp_decode(struct rc_dev *dev, struct ir_raw_event ev)
@@ -139,7 +139,7 @@ index 6f464be1c8d7a..1ac3a4cee69e3 100644
  
  static int __init ir_xmp_decode_init(void)
 diff --git a/drivers/media/rc/rc-core-priv.h b/drivers/media/rc/rc-core-priv.h
-index 7da9c96cb0588..5fd3b5aed9ece 100644
+index 7da9c96cb058..5fd3b5aed9ec 100644
 --- a/drivers/media/rc/rc-core-priv.h
 +++ b/drivers/media/rc/rc-core-priv.h
 @@ -29,6 +29,7 @@ struct ir_raw_handler {
@@ -151,7 +151,7 @@ index 7da9c96cb0588..5fd3b5aed9ece 100644
  	/* These two should only be used by the lirc decoder */
  	int (*raw_register)(struct rc_dev *dev);
 diff --git a/drivers/media/rc/rc-ir-raw.c b/drivers/media/rc/rc-ir-raw.c
-index 503bc425a187c..7f0197bf5d32d 100644
+index 503bc425a187..7f0197bf5d32 100644
 --- a/drivers/media/rc/rc-ir-raw.c
 +++ b/drivers/media/rc/rc-ir-raw.c
 @@ -215,7 +215,36 @@ ir_raw_get_allowed_protocols(void)
@@ -193,7 +193,7 @@ index 503bc425a187c..7f0197bf5d32d 100644
  }
  
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index 72f381522cb26..e7e20bcfe2729 100644
+index 72f381522cb2..e7e20bcfe272 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -1161,6 +1161,9 @@ static ssize_t store_protocols(struct device *device,
@@ -243,7 +243,7 @@ index 72f381522cb26..e7e20bcfe2729 100644
 From 00f54931b0ff7202020567544605b7e3c4f1dee8 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:45:36 +0200
-Subject: [PATCH 2/9] media: rc: per-protocol repeat period and minimum keyup
+Subject: [PATCH 02/10] media: rc: per-protocol repeat period and minimum keyup
  timer
 
 backport of https://patchwork.linuxtv.org/patch/48520/
@@ -265,7 +265,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  3 files changed, 30 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/media/cec/cec-core.c b/drivers/media/cec/cec-core.c
-index 648136e552d5b..4cf35e4af7bd6 100644
+index 648136e552d5..4cf35e4af7bd 100644
 --- a/drivers/media/cec/cec-core.c
 +++ b/drivers/media/cec/cec-core.c
 @@ -280,7 +280,7 @@ struct cec_adapter *cec_allocate_adapter(const struct cec_adap_ops *ops,
@@ -278,7 +278,7 @@ index 648136e552d5b..4cf35e4af7bd6 100644
  #endif
  	return adap;
 diff --git a/drivers/media/rc/ir-lirc-codec.c b/drivers/media/rc/ir-lirc-codec.c
-index 4c8f456238bca..ef7e43038092f 100644
+index 4c8f456238bc..ef7e43038092 100644
 --- a/drivers/media/rc/ir-lirc-codec.c
 +++ b/drivers/media/rc/ir-lirc-codec.c
 @@ -314,7 +314,7 @@ static long ir_lirc_ioctl(struct file *filep, unsigned int cmd,
@@ -291,7 +291,7 @@ index 4c8f456238bca..ef7e43038092f 100644
  
  		lirc->send_timeout_reports = !!val;
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index e7e20bcfe2729..36f99a0919c30 100644
+index e7e20bcfe272..36f99a0919c3 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -35,48 +35,48 @@ static const struct {
@@ -409,7 +409,7 @@ index e7e20bcfe2729..36f99a0919c30 100644
 From 6f3d979fa02a3847799d838a03ad9c5ad009a778 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:39 +0100
-Subject: [PATCH 3/9] media: rc: mce_kbd decoder: low timeout values cause
+Subject: [PATCH 03/10] media: rc: mce_kbd decoder: low timeout values cause
  double keydowns
 
 backport of https://patchwork.linuxtv.org/patch/48522/
@@ -429,7 +429,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 7afeab04dbbfd..a243d2d1ca935 100644
+index 7afeab04dbbf..a243d2d1ca93 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -319,11 +319,13 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
@@ -458,7 +458,7 @@ index 7afeab04dbbfd..a243d2d1ca935 100644
 From f4d8df33339167784bb6a17e3ee2d20f9efe1b21 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:40 +0100
-Subject: [PATCH 4/9] media: rc: mce_kbd protocol encodes two scancodes
+Subject: [PATCH 04/10] media: rc: mce_kbd protocol encodes two scancodes
 
 backport of https://patchwork.linuxtv.org/patch/48518/
 
@@ -473,7 +473,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  2 files changed, 13 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index a243d2d1ca935..2ea48a54f2b3e 100644
+index a243d2d1ca93..2ea48a54f2b3 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -147,13 +147,14 @@ static enum mce_kbd_mode mce_kbd_mode(struct mce_kbd_dec *data)
@@ -522,7 +522,7 @@ index a243d2d1ca935..2ea48a54f2b3e 100644
  			if (scancode) {
  				delay = nsecs_to_jiffies(dev->timeout) +
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index 36f99a0919c30..34cef7aa207c9 100644
+index 36f99a0919c3..34cef7aa207c 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -60,7 +60,7 @@ static const struct {
@@ -541,7 +541,7 @@ index 36f99a0919c30..34cef7aa207c9 100644
 From 8b0ffc3eccf8737aa93c6b7bf9bc9d1e10d634bd Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:41 +0100
-Subject: [PATCH 5/9] media: rc: mce_kbd decoder: fix stuck keys
+Subject: [PATCH 05/10] media: rc: mce_kbd decoder: fix stuck keys
 
 backport of https://patchwork.linuxtv.org/patch/48519/
 
@@ -557,7 +557,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 2ea48a54f2b3e..164302ec4fef0 100644
+index 2ea48a54f2b3..164302ec4fef 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -130,6 +130,8 @@ static void mce_kbd_rx_timeout(unsigned long data)
@@ -576,7 +576,7 @@ index 2ea48a54f2b3e..164302ec4fef0 100644
 From b77de094b54449079890b8cc4fbc2f98573253b2 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:42 +0100
-Subject: [PATCH 6/9] media: rc: mceusb: allow the timeout to be configurable
+Subject: [PATCH 06/10] media: rc: mceusb: allow the timeout to be configurable
 
 backport of https://patchwork.linuxtv.org/patch/48521/
 
@@ -589,7 +589,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 22 insertions(+)
 
 diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
-index bf7aaff3aa375..160754a7a3822 100644
+index bf7aaff3aa37..160754a7a382 100644
 --- a/drivers/media/rc/mceusb.c
 +++ b/drivers/media/rc/mceusb.c
 @@ -937,6 +937,25 @@ static int mceusb_set_tx_carrier(struct rc_dev *dev, u32 carrier)
@@ -636,7 +636,7 @@ index bf7aaff3aa375..160754a7a3822 100644
 From dccebb7231209acb8da7f9f1e8fd1e7c12c3e70f Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:26:21 +0200
-Subject: [PATCH 7/9] media: rc: mce_kbd decoder: remove superfluous call to
+Subject: [PATCH 07/10] media: rc: mce_kbd decoder: remove superfluous call to
  input_sync
 
 backport of https://patchwork.linuxtv.org/patch/48681/
@@ -651,7 +651,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 164302ec4fef0..f057b57074c97 100644
+index 164302ec4fef..f057b57074c9 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -355,7 +355,6 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
@@ -669,7 +669,7 @@ index 164302ec4fef0..f057b57074c97 100644
 From 731b38824c8145bbc7d55a9c2af4e449ff5988fb Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:38:49 +0200
-Subject: [PATCH 8/9] media: rc: mce_kbd decoder: fix race condition
+Subject: [PATCH 08/10] media: rc: mce_kbd decoder: fix race condition
 
 backport of https://patchwork.linuxtv.org/patch/48680/
 
@@ -692,7 +692,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  2 files changed, 17 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index f057b57074c97..67c37db76737f 100644
+index f057b57074c9..67c37db76737 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -120,18 +120,24 @@ static void mce_kbd_rx_timeout(unsigned long data)
@@ -752,7 +752,7 @@ index f057b57074c97..67c37db76737f 100644
  	input_set_drvdata(idev, mce_kbd);
  
 diff --git a/drivers/media/rc/rc-core-priv.h b/drivers/media/rc/rc-core-priv.h
-index 5fd3b5aed9ece..77928ae431041 100644
+index 5fd3b5aed9ec..77928ae43104 100644
 --- a/drivers/media/rc/rc-core-priv.h
 +++ b/drivers/media/rc/rc-core-priv.h
 @@ -97,6 +97,7 @@ struct ir_raw_event_ctrl {
@@ -770,7 +770,7 @@ index 5fd3b5aed9ece..77928ae431041 100644
 From 4e363f78b2aae387980ac411e0f901caee5da9e1 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Wed, 18 Apr 2018 13:50:52 +0200
-Subject: [PATCH 9/9] media: rc: mceusb: IR of length 0 means IR timeout, not
+Subject: [PATCH 09/10] media: rc: mceusb: IR of length 0 means IR timeout, not
  reset
 
 backport of https://patchwork.linuxtv.org/patch/48782/
@@ -785,7 +785,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
-index 160754a7a3822..dc7ebed00b3ac 100644
+index 160754a7a382..dc7ebed00b3a 100644
 --- a/drivers/media/rc/mceusb.c
 +++ b/drivers/media/rc/mceusb.c
 @@ -1056,8 +1056,14 @@ static void mceusb_process_ir_data(struct mceusb_dev *ir, int buf_len)
@@ -805,6 +805,88 @@ index 160754a7a3822..dc7ebed00b3ac 100644
  			break;
  		}
  
+-- 
+2.11.0
+
+
+From f74716d6fc4a38f56a374a00cb96be61f2d6fc2d Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Thu, 10 May 2018 10:42:24 +0200
+Subject: [PATCH 10/10] media: mceusb: MCE_CMD_SETIRTIMEOUT cause strange
+ behaviour on device
+
+backport of https://patchwork.linuxtv.org/patch/49409/
+
+If the IR timeout is set on vid 1784 pid 0011, the device starts
+behaving strangely.
+
+Reported-by: Matthias Reichl <hias@horus.com>
+Signed-off-by: Sean Young <sean@mess.org>
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/mceusb.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
+index dc7ebed00b3a..2e1241f09c9d 100644
+--- a/drivers/media/rc/mceusb.c
++++ b/drivers/media/rc/mceusb.c
+@@ -181,6 +181,7 @@ enum mceusb_model_type {
+ 	MCE_GEN2 = 0,		/* Most boards */
+ 	MCE_GEN1,
+ 	MCE_GEN3,
++	MCE_GEN3_BROKEN_IRTIMEOUT,
+ 	MCE_GEN2_TX_INV,
+ 	POLARIS_EVK,
+ 	CX_HYBRID_TV,
+@@ -196,6 +197,7 @@ struct mceusb_model {
+ 	u32 mce_gen3:1;
+ 	u32 tx_mask_normal:1;
+ 	u32 no_tx:1;
++	u32 broken_irtimeout:1;
+ 
+ 	int ir_intfnum;
+ 
+@@ -223,6 +225,11 @@ static const struct mceusb_model mceusb_model[] = {
+ 		.mce_gen3 = 1,
+ 		.tx_mask_normal = 1,
+ 	},
++	[MCE_GEN3_BROKEN_IRTIMEOUT] = {
++		.mce_gen3 = 1,
++		.tx_mask_normal = 1,
++		.broken_irtimeout = 1
++	},
+ 	[POLARIS_EVK] = {
+ 		/*
+ 		 * In fact, the EVK is shipped without
+@@ -320,7 +327,7 @@ static struct usb_device_id mceusb_dev_table[] = {
+ 	  .driver_info = MCE_GEN2_TX_INV },
+ 	/* Topseed eHome Infrared Transceiver */
+ 	{ USB_DEVICE(VENDOR_TOPSEED, 0x0011),
+-	  .driver_info = MCE_GEN3 },
++	  .driver_info = MCE_GEN3_BROKEN_IRTIMEOUT },
+ 	/* Ricavision internal Infrared Transceiver */
+ 	{ USB_DEVICE(VENDOR_RICAVISION, 0x0010) },
+ 	/* Itron ione Libra Q-11 */
+@@ -1295,8 +1302,16 @@ static struct rc_dev *mceusb_init_rc_dev(struct mceusb_dev *ir)
+ 	rc->allowed_protocols = RC_PROTO_BIT_ALL_IR_DECODER;
+ 	rc->min_timeout = US_TO_NS(MCE_TIME_UNIT);
+ 	rc->timeout = MS_TO_NS(100);
+-	rc->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
+-	rc->s_timeout = mceusb_set_timeout;
++	if (!mceusb_model[ir->model].broken_irtimeout) {
++		rc->s_timeout = mceusb_set_timeout;
++		rc->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
++	} else {
++		/*
++		 * If we can't set the timeout using CMD_SETIRTIMEOUT, we can
++		 * rely on software timeouts for timeouts < 100ms.
++		 */
++		rc->max_timeout = rc->timeout;
++	}
+ 	if (!ir->flags.no_tx) {
+ 		rc->s_tx_mask = mceusb_set_tx_mask;
+ 		rc->s_tx_carrier = mceusb_set_tx_carrier;
 -- 
 2.11.0
 

--- a/packages/linux/patches/raspberrypi/linux-999-improve-ir-timeout-handling.patch
+++ b/packages/linux/patches/raspberrypi/linux-999-improve-ir-timeout-handling.patch
@@ -1,7 +1,7 @@
 From 057ccfd1d18842bd2fa39c4b996a9a952c5a821d Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:35:11 +0200
-Subject: [PATCH 01/10] media: rc: set timeout to smallest value required by
+Subject: [PATCH 01/11] media: rc: set timeout to smallest value required by
  enabled protocols
 
 backport of https://patchwork.linuxtv.org/patch/48516/
@@ -243,7 +243,7 @@ index 72f381522cb2..e7e20bcfe272 100644
 From 00f54931b0ff7202020567544605b7e3c4f1dee8 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:45:36 +0200
-Subject: [PATCH 02/10] media: rc: per-protocol repeat period and minimum keyup
+Subject: [PATCH 02/11] media: rc: per-protocol repeat period and minimum keyup
  timer
 
 backport of https://patchwork.linuxtv.org/patch/48520/
@@ -409,7 +409,7 @@ index e7e20bcfe272..36f99a0919c3 100644
 From 6f3d979fa02a3847799d838a03ad9c5ad009a778 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:39 +0100
-Subject: [PATCH 03/10] media: rc: mce_kbd decoder: low timeout values cause
+Subject: [PATCH 03/11] media: rc: mce_kbd decoder: low timeout values cause
  double keydowns
 
 backport of https://patchwork.linuxtv.org/patch/48522/
@@ -458,7 +458,7 @@ index 7afeab04dbbf..a243d2d1ca93 100644
 From f4d8df33339167784bb6a17e3ee2d20f9efe1b21 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:40 +0100
-Subject: [PATCH 04/10] media: rc: mce_kbd protocol encodes two scancodes
+Subject: [PATCH 04/11] media: rc: mce_kbd protocol encodes two scancodes
 
 backport of https://patchwork.linuxtv.org/patch/48518/
 
@@ -541,7 +541,7 @@ index 36f99a0919c3..34cef7aa207c 100644
 From 8b0ffc3eccf8737aa93c6b7bf9bc9d1e10d634bd Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:41 +0100
-Subject: [PATCH 05/10] media: rc: mce_kbd decoder: fix stuck keys
+Subject: [PATCH 05/11] media: rc: mce_kbd decoder: fix stuck keys
 
 backport of https://patchwork.linuxtv.org/patch/48519/
 
@@ -576,7 +576,7 @@ index 2ea48a54f2b3..164302ec4fef 100644
 From b77de094b54449079890b8cc4fbc2f98573253b2 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:42 +0100
-Subject: [PATCH 06/10] media: rc: mceusb: allow the timeout to be configurable
+Subject: [PATCH 06/11] media: rc: mceusb: allow the timeout to be configurable
 
 backport of https://patchwork.linuxtv.org/patch/48521/
 
@@ -636,7 +636,7 @@ index bf7aaff3aa37..160754a7a382 100644
 From dccebb7231209acb8da7f9f1e8fd1e7c12c3e70f Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:26:21 +0200
-Subject: [PATCH 07/10] media: rc: mce_kbd decoder: remove superfluous call to
+Subject: [PATCH 07/11] media: rc: mce_kbd decoder: remove superfluous call to
  input_sync
 
 backport of https://patchwork.linuxtv.org/patch/48681/
@@ -669,7 +669,7 @@ index 164302ec4fef..f057b57074c9 100644
 From 731b38824c8145bbc7d55a9c2af4e449ff5988fb Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:38:49 +0200
-Subject: [PATCH 08/10] media: rc: mce_kbd decoder: fix race condition
+Subject: [PATCH 08/11] media: rc: mce_kbd decoder: fix race condition
 
 backport of https://patchwork.linuxtv.org/patch/48680/
 
@@ -770,7 +770,7 @@ index 5fd3b5aed9ec..77928ae43104 100644
 From 4e363f78b2aae387980ac411e0f901caee5da9e1 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Wed, 18 Apr 2018 13:50:52 +0200
-Subject: [PATCH 09/10] media: rc: mceusb: IR of length 0 means IR timeout, not
+Subject: [PATCH 09/11] media: rc: mceusb: IR of length 0 means IR timeout, not
  reset
 
 backport of https://patchwork.linuxtv.org/patch/48782/
@@ -812,7 +812,7 @@ index 160754a7a382..dc7ebed00b3a 100644
 From f74716d6fc4a38f56a374a00cb96be61f2d6fc2d Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Thu, 10 May 2018 10:42:24 +0200
-Subject: [PATCH 10/10] media: mceusb: MCE_CMD_SETIRTIMEOUT cause strange
+Subject: [PATCH 10/11] media: mceusb: MCE_CMD_SETIRTIMEOUT cause strange
  behaviour on device
 
 backport of https://patchwork.linuxtv.org/patch/49409/
@@ -887,6 +887,45 @@ index dc7ebed00b3a..2e1241f09c9d 100644
  	if (!ir->flags.no_tx) {
  		rc->s_tx_mask = mceusb_set_tx_mask;
  		rc->s_tx_carrier = mceusb_set_tx_carrier;
+-- 
+2.11.0
+
+
+From 0899b373cb0604ed80a80b501dd48cf6a3cbff25 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Fri, 11 May 2018 12:20:44 +0200
+Subject: [PATCH 11/11] media: mceusb: filter out bogus timing irdata of
+ duration 0
+
+Backport of https://patchwork.linuxtv.org/patch/49430/
+
+A mceusb device has been observed producing invalid irdata. Proactively
+guard against this.
+
+Suggested-by: Matthias Reichl <hias@horus.com>
+Signed-off-by: Sean Young <sean@mess.org>
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/mceusb.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
+index 2e1241f09c9d..7864a30c4f9e 100644
+--- a/drivers/media/rc/mceusb.c
++++ b/drivers/media/rc/mceusb.c
+@@ -1038,6 +1038,12 @@ static void mceusb_process_ir_data(struct mceusb_dev *ir, int buf_len)
+ 			rawir.duration = (ir->buf_in[i] & MCE_PULSE_MASK)
+ 					 * US_TO_NS(MCE_TIME_UNIT);
+ 
++			if (unlikely(!rawir.duration)) {
++				dev_warn(ir->dev, "nonsensical irdata %02x with duration 0",
++					 ir->buf_in[i]);
++				break;
++			}
++
+ 			dev_dbg(ir->dev, "Storing %s with duration %u",
+ 				rawir.pulse ? "pulse" : "space",
+ 				rawir.duration);
 -- 
 2.11.0
 


### PR DESCRIPTION
This should fix the issues with the Topseed mceusb receiver 1784:0011 reported
here https://forum.kodi.tv/showthread.php?tid=298461&pid=2727866#pid2727866
and here https://forum.kodi.tv/showthread.php?tid=298461&pid=2732458#pid2732458

@MilhouseVH could you please add this to your builds?