### PR TITLE
create_addon: jenkins specific quirks

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -97,6 +97,17 @@ pack_addon() {
         cp $f $ADDON_INSTALL_DIR/resources
       fi
     done
+
+    # Jenkins add-on build
+    if [ "$ADDON_JENKINS" = "yes" ]; then
+      ADDON_JENKINS_DIR="$TARGET_IMG/jenkins/$ADDON_VERSION/${DEVICE:-$PROJECT}/$TARGET_ARCH"
+      mkdir -p "$ADDON_JENKINS_DIR"
+      cd $ADDON_INSTALL_DIR
+      $TOOLCHAIN/bin/7za a -l -mx0 -bsp0 -bso0 -tzip $ADDON_JENKINS_DIR/$PKG_ADDON_ID-$ADDONVER.zip $PKG_ADDON_ID-$ADDONVER.zip resources/
+      ADDON_SHA256="$(sha256sum $ADDON_JENKINS_DIR/$PKG_ADDON_ID-$ADDONVER.zip | cut -d" " -f1)"
+      echo ${ADDON_SHA256} > $ADDON_JENKINS_DIR/$PKG_ADDON_ID-$ADDONVER.zip.sha256
+      echo "*** creating $PKG_ADDON_ID.zip for Jenkins complete ***"
+    fi
   fi
 }
 


### PR DESCRIPTION
@islipfd19 @chewitt works for LE addons + binary addons from my tests, not sure if something is missing or do not work if used under real conditions

usage `PROJECT=Generic ARCH=x86_64 ADDON_JENKINS=yes scripts/create_addon abc`