### PR TITLE
Generic: allow lower IR timeouts on ITE CIR devices

### DIFF
--- a/packages/linux/patches/default/linux-999-improve-ir-timeout-handling-of-ite-cir.patch
+++ b/packages/linux/patches/default/linux-999-improve-ir-timeout-handling-of-ite-cir.patch
@@ -1,0 +1,66 @@
+From 039b4125aef0d84c831aeb6e9fdca41b47852f50 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sun, 13 May 2018 12:31:42 +0200
+Subject: [PATCH] media: rc: ite-cir: lower timeout and extend allowed timeout
+ range
+
+The minimum possible timeout of ite-cir is 8 samples, which is
+typically about 70us. The driver however changes the FIFO trigger
+level from the hardware's default of 1 byte to 17 bytes, so the minimum
+usable timeout value is 17 * 8 samples, which is typically about 1.2ms.
+
+Tests showed that using timeouts down to 1.2ms actually work fine.
+
+The current default timeout of 200ms is much longer than necessary and
+the maximum timeout of 1s seems to have been chosen a bit arbitrarily.
+
+So change the minimum timeout to the driver's limit of 17 * 8 samples
+and bring timeout and maximum timeout in line with the settings
+of many other receivers.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ite-cir.c | 8 +++++---
+ drivers/media/rc/ite-cir.h | 7 -------
+ 2 files changed, 5 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/media/rc/ite-cir.c b/drivers/media/rc/ite-cir.c
+index 65e104c7ddfc..de77d22c30a7 100644
+--- a/drivers/media/rc/ite-cir.c
++++ b/drivers/media/rc/ite-cir.c
+@@ -1561,9 +1561,11 @@ static int ite_probe(struct pnp_dev *pdev, const struct pnp_device_id
+ 	rdev->close = ite_close;
+ 	rdev->s_idle = ite_s_idle;
+ 	rdev->s_rx_carrier_range = ite_set_rx_carrier_range;
+-	rdev->min_timeout = ITE_MIN_IDLE_TIMEOUT;
+-	rdev->max_timeout = ITE_MAX_IDLE_TIMEOUT;
+-	rdev->timeout = ITE_IDLE_TIMEOUT;
++	/* FIFO threshold is 17 bytes, so 17 * 8 samples minimum */
++	rdev->min_timeout = 17 * 8 * ITE_BAUDRATE_DIVISOR *
++			    itdev->params.sample_period;
++	rdev->timeout = IR_DEFAULT_TIMEOUT;
++	rdev->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
+ 	rdev->rx_resolution = ITE_BAUDRATE_DIVISOR *
+ 				itdev->params.sample_period;
+ 	rdev->tx_resolution = ITE_BAUDRATE_DIVISOR *
+diff --git a/drivers/media/rc/ite-cir.h b/drivers/media/rc/ite-cir.h
+index 0e8ebc880d1f..9cb24ac01350 100644
+--- a/drivers/media/rc/ite-cir.h
++++ b/drivers/media/rc/ite-cir.h
+@@ -154,13 +154,6 @@ struct ite_dev {
+ /* default carrier freq for when demodulator is off (Hz) */
+ #define ITE_DEFAULT_CARRIER_FREQ	38000
+ 
+-/* default idling timeout in ns (0.2 seconds) */
+-#define ITE_IDLE_TIMEOUT		200000000UL
+-
+-/* limit timeout values */
+-#define ITE_MIN_IDLE_TIMEOUT		100000000UL
+-#define ITE_MAX_IDLE_TIMEOUT		1000000000UL
+-
+ /* convert bits to us */
+ #define ITE_BITS_TO_NS(bits, sample_period) \
+ ((u32) ((bits) * ITE_BAUDRATE_DIVISOR * sample_period))
+-- 
+2.11.0
+


### PR DESCRIPTION
Tests on my PC (with ITE8713 receiver) worked fine, if testing on other PCs is fine, too I'll send the patch upstream