### PR TITLE
PulseAudio: enable zeroconf-discover module

### DIFF
--- a/packages/audio/pulseaudio/config/system.pa
+++ b/packages/audio/pulseaudio/config/system.pa
@@ -65,5 +65,9 @@ load-module module-position-event-sounds
   load-module module-zeroconf-publish
 .endif
 
+.ifexists module-zeroconf-discover.so
+  load-module module-zeroconf-discover
+.endif
+
 load-module module-native-protocol-tcp auth-anonymous=1
 load-module module-switch-on-connect


### PR DESCRIPTION
zeroconf-discover module lets PulseAudio to discover PulseAudio servers
on local networks and lets LibreElec to stream sound over network with
nearly zero configuration

Exemplary setup where it is necessary: 2 × Raspberry Pis, one is driving speakers via external sound card, the other is driving a projector. Distance between rPis is several meters, so wireless sound transfer is extremely desirable.