### PR TITLE
update: Tvh, Emby and ffmpeg-tools

### DIFF
--- a/packages/addons/addon-depends/emby-depends/imagemagick/package.mk
+++ b/packages/addons/addon-depends/emby-depends/imagemagick/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="imagemagick"
-PKG_VERSION="7.0.7-1"
-PKG_SHA256="5a45e29509dbb23793a9c8db5c47ef1114c1ee82c9ca60053eaf06b3fc243e2c"
+PKG_VERSION="7.0.7-32"
+PKG_SHA256="f1785adf8bbf378b47e789c74c2fd9ebdd5ec1c4de12e53306f8f6eb5b55d656"
 PKG_ARCH="any"
 PKG_LICENSE="http://www.imagemagick.org/script/license.php"
 PKG_SITE="http://www.imagemagick.org/"
@@ -26,7 +26,6 @@ PKG_URL="https://github.com/ImageMagick/ImageMagick/archive/$PKG_VERSION.tar.gz"
 PKG_SOURCE_DIR="ImageMagick-$PKG_VERSION"
 PKG_DEPENDS_TARGET="toolchain libX11"
 PKG_SECTION="graphics"
-PKG_SHORTDESC="ImageMagick"
 PKG_LONGDESC="Software suite to create, edit, compose, or convert bitmap images"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \

--- a/packages/addons/addon-depends/ffmpegx-depends/fdk-aac/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/fdk-aac/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="fdk-aac"
-PKG_VERSION="0.1.5"
-PKG_SHA256="ff53d1d01cacc29c071e23192dfefa93bdbeaf775fc5d296259b4859d0306b79"
+PKG_VERSION="0.1.6"
+PKG_SHA256="adbcd793e406e1b88b3c1c41382d49f8c27371485b823c0fdab69c9124fd2ce3"
 PKG_ARCH="any"
 PKG_LICENSE="other"
 PKG_SITE="https://sourceforge.net/projects/opencore-amr/"

--- a/packages/addons/addon-depends/ffmpegx-depends/x264/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x264/package.mk
@@ -17,15 +17,14 @@
 ################################################################################
 
 PKG_NAME="x264"
-PKG_VERSION="snapshot-20180220-2245"
-PKG_SHA256="80090285b40983776793168a3828dfd8125caca06cb6949511d64946d6166882"
+PKG_VERSION="snapshot-20180517-2245"
+PKG_SHA256="55c6558ca6458f92939a53f669a4e51b104c2275f22984393e36fb670528bcbf"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.videolan.org/developers/x264.html"
 PKG_URL="https://download.videolan.org/x264/snapshots/$PKG_NAME-$PKG_VERSION.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="multimedia"
-PKG_SHORTDESC="x264"
 PKG_LONGDESC="x264"
 
 pre_configure_target() {

--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="ffmpegx"
-PKG_VERSION="3.4.2"
-PKG_SHA256="d079c68dc19a0223239a152ffc2b67ef1e9d3144e4d2c2563380dc59dccf33e5"
+PKG_VERSION="4.0"
+PKG_SHA256="95296f881f7e367731a35a71e3df5ebe9360cd4c859f06793bf8dcf917ee8e5a"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
@@ -93,9 +93,11 @@ pre_configure_target() {
     --enable-hwaccel=h263_vaapi \
     --enable-hwaccel=h264_vaapi \
     --enable-hwaccel=hevc_vaapi \
+    --enable-hwaccel=mjpeg_vaapi \
     --enable-hwaccel=mpeg2_vaapi \
     --enable-hwaccel=mpeg4_vaapi \
     --enable-hwaccel=vc1_vaapi \
+    --enable-hwaccel=vp8_vaapi \
     --enable-hwaccel=vp9_vaapi \
     --enable-hwaccel=wmv3_vaapi"
   fi
@@ -110,6 +112,8 @@ pre_configure_target() {
     --enable-encoder=x264 \
     --enable-libx265 \
     --enable-encoder=x265 \
+    --enable-libaom \
+    --enable-encoder=libaom_av1 \
     \
     `#Audio encoders` \
     --enable-encoder=ac3 \
@@ -142,7 +146,6 @@ configure_target() {
     --enable-ffmpeg \
     --disable-ffplay \
     --enable-ffprobe \
-    --disable-ffserver \
     \
     `#Static and Shared` \
     --enable-static \

--- a/packages/addons/addon-depends/tvh-dtv-scan-tables/package.mk
+++ b/packages/addons/addon-depends/tvh-dtv-scan-tables/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="tvh-dtv-scan-tables"
-PKG_VERSION="a3ebfcd"
-PKG_SHA256="0cfb977f9346b3a19f8494816379214a9e197301254f6fd46d9072f3895f5f68"
+PKG_VERSION="4258e52"
+PKG_SHA256="48de5baa843ecd5a2231e9b007fc6b3fd86739ddd075158b31fcdefdcd3ce2dd"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/tvheadend"

--- a/packages/addons/service/emby/changelog.txt
+++ b/packages/addons/service/emby/changelog.txt
@@ -1,3 +1,7 @@
+119
+- Update to 3.4.1.6
+- Add script (emby-update) to update Emby
+
 118
 - Update to 3.3.0.0
 - Moved ffmpegx to ffmpeg-tools add-on

--- a/packages/addons/service/emby/package.mk
+++ b/packages/addons/service/emby/package.mk
@@ -17,9 +17,9 @@
 ################################################################################
 
 PKG_NAME="emby"
-PKG_VERSION="3.3.0.0"
-PKG_SHA256="15ca0835d939dbd2ac730bafa1377276c3a63854fd6a2ace8ff02dd439cdd692"
-PKG_REV="118"
+PKG_VERSION="3.4.1.6"
+PKG_SHA256="8eb129f538cefec612239932fd85ddc6bd5221cd97613e142f41f2126412ea04"
+PKG_REV="119"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://emby.media"

--- a/packages/addons/service/emby/source/bin/emby-update
+++ b/packages/addons/service/emby/source/bin/emby-update
@@ -1,0 +1,67 @@
+#!/bin/sh
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+. /etc/profile
+oe_setup_addon service.emby
+
+# set version to use
+if [ -z "$1" ]; then
+# if no input
+  echo -e "\nUsage:"
+  echo -e "${0##*/} 3.4.1.0"
+  echo -e "${0##*/} latest"
+  echo -e "\n====== last releases ======"
+  curl --silent "https://api.github.com/repos/MediaBrowser/Emby/releases" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | head -n 20
+  echo -e "==========================="
+  exit 0
+
+# if input = latest
+elif [ "$1" = "latest" ]; then
+  EMBY_VERSION=$(curl --silent "https://api.github.com/repos/MediaBrowser/Emby/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  echo "latest is $EMBY_VERSION"
+  read -p "continue (y/n)? " EMBY_CONT
+  if [ $EMBY_CONT = "Y" ] || [ $EMBY_CONT = "y" ]; then
+    echo ""
+  else
+    exit 0
+  fi
+
+# if input = 1.2.3.4
+else
+  EMBY_VERSION="$1"
+fi
+
+echo "1. stopping Emby service" && sleep 1
+  systemctl stop service.emby
+
+echo "2. download Emby version $EMBY_VERSION" && sleep 1
+  rm -f /storage/.kodi/temp/Emby.Mono.zip
+  curl --progress-bar --fail -L -o /storage/.kodi/temp/Emby.Mono.zip https://github.com/MediaBrowser/Emby/releases/download/$EMBY_VERSION/Emby.Mono.zip || exit 1
+
+echo "3. removing old install" && sleep 1
+  rm -rf $ADDON_DIR/Emby/system/*
+
+echo "4. extracting Emby" && sleep 1
+  unzip -q /storage/.kodi/temp/Emby.Mono.zip -d $ADDON_DIR/Emby/system
+
+echo "5. restarting Emby service" && sleep 1
+  systemctl start service.emby
+
+echo "... done"
+exit 0

--- a/packages/addons/service/tvheadend42/changelog.txt
+++ b/packages/addons/service/tvheadend42/changelog.txt
@@ -1,3 +1,6 @@
+115
+- update to 4.2.6-7
+
 114
 - update to 4.2.5-31
 - addded manual Scan-Table update

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -17,10 +17,10 @@
 ################################################################################
 
 PKG_NAME="tvheadend42"
-PKG_VERSION="fc63a8a"
-PKG_SHA256="38c25e191733a0e0944ec3e32de2aab6a1cff9ddfc597fc328a73579f7c8bf41"
-PKG_VERSION_NUMBER="4.2.5-31"
-PKG_REV="114"
+PKG_VERSION="5613551"
+PKG_SHA256="eff2d5aa08d7c91595d2ec4d4dda2f1bedc07ee8672d1ffb5ed994e284714f23"
+PKG_VERSION_NUMBER="4.2.6-7"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"

--- a/packages/addons/tools/ffmpeg-tools/changelog.txt
+++ b/packages/addons/tools/ffmpeg-tools/changelog.txt
@@ -1,2 +1,6 @@
+101
+- Update to FFmpeg 4.0
+- Added AV1 codec
+
 100
 - Initial release

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="100"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/audio/speex/package.mk
+++ b/packages/audio/speex/package.mk
@@ -1,30 +1,29 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="speex"
-PKG_VERSION="1.2rc2"
-PKG_SHA256="caa27c7247ff15c8521c2ae0ea21987c9e9710a8f2d3448e8b79da9806bce891"
+PKG_VERSION="1.2.0"
+PKG_SHA256="eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
-PKG_SITE="http://downloads.us.xiph.org/releases/speex"
-#PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.gz"
-PKG_URL="$PKG_SITE/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SITE="https://speex.org"
+PKG_URL="http://downloads.us.xiph.org/releases/speex/speex-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
-PKG_SHORTDESC="Speex / OPUS audio codec"
-PKG_LONGDESC="Speex / OPUS audio codec"
+PKG_LONGDESC="An Open Source Software patent-free audio compression format designed for speech."

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -1,0 +1,32 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="aom"
+PKG_VERSION="a586982"
+PKG_SHA256="078c0cc780fa9fcd3d67456722339a8eaa5591a484e1daae9fc2c3c34810ec46"
+PKG_ARCH="any"
+PKG_LICENSE="BSD"
+PKG_SITE="https://www.webmproject.org"
+PKG_URL="http://repo.or.cz/aom.git/snapshot/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="multimedia"
+PKG_LONGDESC="AV1 Codec Library"
+
+PKG_CMAKE_OPTS_TARGET="-DENABLE_CCACHE=1 \
+                       -DENABLE_DOCS=0 \
+                       -DENABLE_TOOLS=0"

--- a/packages/multimedia/libhdhomerun/package.mk
+++ b/packages/multimedia/libhdhomerun/package.mk
@@ -18,8 +18,8 @@
 ################################################################################
 
 PKG_NAME="libhdhomerun"
-PKG_VERSION="20171221"
-PKG_SHA256="08e22db43621b96260086a834e7c586cb92aa4b3ec30adf0adf3c7588d527ff8"
+PKG_VERSION="20180327"
+PKG_SHA256="d91fd3782f9a0834242f7110c44067647843602f8e95052045250b7c229ccbd5"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.silicondust.com"
@@ -27,8 +27,7 @@ PKG_URL="http://download.silicondust.com/hdhomerun/${PKG_NAME}_${PKG_VERSION}.tg
 PKG_SOURCE_DIR="$PKG_NAME"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="driver"
-PKG_SHORTDESC="The library provides functionality to setup the HDHomeRun, change channels, setup PID filtering, get signal quality and so on."
-PKG_LONGDESC="The library provides functionality to setup the HDHomeRun, change channels, setup PID filtering, get signal quality and so on."
+PKG_LONGDESC="The library provides functionality to setup the HDHomeRun."
 
 PKG_MAKE_OPTS_TARGET="CROSS_COMPILE=$TARGET_PREFIX"
 


### PR DESCRIPTION
This updates 3 add-ons, as they have dependencies at each other I bump them all together in one pr.
- adds AOM -> AV1 codec @lrusak might have a look if this is okay`ish for the moment (also the location of the package)
- adds Emby script for easy manual upgrade from SSH @awiouy -> this is could kill an emby install if emby changes something significantly at their code so this is NOT save for an gui button !
- updated packages