### PR TITLE
rust: rework

### DIFF
--- a/packages/addons/addon-depends/librespot-depends/rust/package.mk
+++ b/packages/addons/addon-depends/librespot-depends/rust/package.mk
@@ -17,26 +17,21 @@
 ################################################################################
 
 PKG_NAME="rust"
-PKG_VERSION="1.23.0"
+PKG_VERSION="1.26.0"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
-PKG_URL=""
-PKG_DEPENDS="toolchain"
+PKG_DEPENDS_TARGET="toolchain rustup.rs"
 PKG_SECTION="devel"
 PKG_LONGDESC="Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety."
 PKG_TOOLCHAIN="manual"
-
-unpack() {
-  :
-}
 
 make_target() {
   export CARGO_HOME="$TOOLCHAIN/.cargo"
   export RUSTUP_HOME="$CARGO_HOME"
   export PATH="$CARGO_HOME/bin:$PATH"
   rm -rf "$CARGO_HOME"
-  curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y
+  $(get_build_dir rustup.rs)/rustup-init.sh --no-modify-path -y
   rustup default "$PKG_VERSION"
   case "$TARGET_ARCH" in
     aarch64)

--- a/packages/addons/addon-depends/librespot-depends/rustup.rs/package.mk
+++ b/packages/addons/addon-depends/librespot-depends/rustup.rs/package.mk
@@ -1,0 +1,29 @@
+################################################################################
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="rustup.rs"
+PKG_VERSION="1.3.0"
+PKG_SHA256="c0ca06b70104fed8f1de5a6f5ecfd8478e8bc03f15add8d7896b86b3b15e81e3"
+PKG_ARCH="any"
+PKG_LICENSE="MIT"
+PKG_SITE="https://www.rust-lang.org"
+PKG_URL="https://github.com/rust-lang-nursery/rustup.rs/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="devel"
+PKG_LONGDESC="The Rust toolchain installer."
+PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
This fixes librespot, which was broken due to changes at Spotify.
This also introduces versioned rustup.