### PR TITLE
fix "code may be misoptimized" warnings

### DIFF
--- a/packages/audio/libcdio/package.mk
+++ b/packages/audio/libcdio/package.mk
@@ -27,7 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_SHORTDESC="libcdio: A CD-ROM reading and control library"
 PKG_LONGDESC="This library is to encapsulate CD-ROM reading and control. Applications wishing to be oblivious of the OS- and device-dependant properties of a CD-ROM can use this library. Some support for disk image types like BIN/CUE and NRG is available, so applications that use this library also have the ability to read disc images as though they were CD's."
-PKG_BUILD_FLAGS="+pic"
+PKG_BUILD_FLAGS="+pic -lto"
 
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-cxx \

--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain libtool alsa-lib libsndfile soxr dbus systemd open
 PKG_SECTION="audio"
 PKG_SHORTDESC="pulseaudio: Yet another sound server for Unix"
 PKG_LONGDESC="PulseAudio is a sound server for Linux and other Unix-like operating systems. It is intended to be an improved drop-in replacement for the Enlightened Sound Daemon (esound or esd). In addition to the features esound provides, PulseAudio has an extensible plugin architecture, support for more than one sink per source, better low-latency behavior, the ability to be embedded into other software, a completely asynchronous C API, a simple command line interface for reconfiguring the daemon while running, flexible and implicit sample type conversion and resampling, and a "Zero-Copy" architecture."
+PKG_BUILD_FLAGS="-lto"
 
 if [ "$BLUETOOTH_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET sbc"

--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain zlib openssl"
 PKG_SECTION="database"
 PKG_SHORTDESC="mariadb-connector: library to conntect to mariadb/mysql database server"
 PKG_LONGDESC="mariadb-connector: library to conntect to mariadb/mysql database server"
+PKG_BUILD_FLAGS="-lto"
 
 PKG_CMAKE_OPTS_TARGET="-DWITH_EXTERNAL_ZLIB=ON
                        -DAUTH_CLEARTEXT=STATIC

--- a/packages/devel/libtool/package.mk
+++ b/packages/devel/libtool/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="devel"
 PKG_SHORTDESC="libtool: Generic library support script"
 PKG_LONGDESC="This is GNU Libtool, a generic library support script. Libtool hides the complexity of using shared libraries behind a consistent, portable interface."
+PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared"
 

--- a/packages/devel/libtool/package.mk
+++ b/packages/devel/libtool/package.mk
@@ -28,6 +28,10 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="devel"
 PKG_SHORTDESC="libtool: Generic library support script"
 PKG_LONGDESC="This is GNU Libtool, a generic library support script. Libtool hides the complexity of using shared libraries behind a consistent, portable interface."
-PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared"
+
+post_patch() {
+  cd $PKG_BUILD
+  $TOOLCHAIN/bin/autoreconf --verbose --force -I $SYSROOT_PREFIX/usr/share/aclocal
+}

--- a/packages/devel/readline/package.mk
+++ b/packages/devel/readline/package.mk
@@ -27,7 +27,7 @@ PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_SECTION="devel"
 PKG_SHORTDESC="readline: The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in."
 PKG_LONGDESC="The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in."
-PKG_BUILD_FLAGS="+pic"
+PKG_BUILD_FLAGS="+pic -lto"
 
 PKG_CONFIGURE_OPTS_TARGET="bash_cv_wcwidth_broken=no \
                            --disable-shared \

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="graphics"
 PKG_SHORTDESC="mesa: 3-D graphics library with OpenGL API"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API which is very similar to that of OpenGL*. To the extent that Mesa utilizes the OpenGL command syntax or state machine, it is being used with authorization from Silicon Graphics, Inc. However, the author makes no claim that Mesa is in any way a compatible replacement for OpenGL or associated with Silicon Graphics, Inc. Those who want a licensed implementation of OpenGL should contact a licensed vendor. While Mesa is not a licensed OpenGL implementation, it is currently being tested with the OpenGL conformance tests. For the current conformance status see the CONFORM file included in the Mesa distribution."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="-lto"
 
 if [ "$DISPLAYSERVER" = "x11" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET glproto dri2proto presentproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 dri3proto libxshmfence"

--- a/packages/multimedia/libvdpau/package.mk
+++ b/packages/multimedia/libvdpau/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain libX11 dri2proto libXext"
 PKG_SECTION="multimedia"
 PKG_SHORTDESC="libvdpau: a Video Decode and Presentation API for UNIX."
 PKG_LONGDESC="VDPAU is the Video Decode and Presentation API for UNIX. It provides an interface to video decode acceleration and presentation hardware present in modern GPUs."
+PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-dri2 \
                            --disable-documentation \

--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="python"
 PKG_SHORTDESC="pil: Imaging handling/processing for Python"
 PKG_LONGDESC="The Python Imaging Library (PIL) adds image processing capabilities to your Python interpreter. This library supports many file formats, and provides powerful image processing and graphics capabilities."
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-lto"
 
 pre_make_target() {
   export PYTHONXCPREFIX="$SYSROOT_PREFIX/usr"

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -28,7 +28,7 @@ PKG_DEPENDS_INIT="toolchain"
 PKG_SECTION="tools"
 PKG_SHORTDESC="e2fsprogs: Utilities for use with the ext2 filesystem"
 PKG_LONGDESC="The filesystem utilities for the EXT2 filesystem, including e2fsck, mke2fs, dumpe2fs, fsck, and others."
-PKG_BUILD_FLAGS="-parallel"
+PKG_BUILD_FLAGS="-parallel -lto"
 
 if [ "$HFSTOOLS" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET diskdev_cmds"
@@ -63,7 +63,6 @@ PKG_CONFIGURE_OPTS_TARGET="BUILD_CC=$HOST_CC \
                            --with-gnu-ld"
 
 PKG_CONFIGURE_OPTS_INIT="$PKG_CONFIGURE_OPTS_TARGET"
-
 
 post_makeinstall_target() {
   make -C lib/et LIBMODE=644 DESTDIR=$SYSROOT_PREFIX install

--- a/packages/wayland/mtdev/package.mk
+++ b/packages/wayland/mtdev/package.mk
@@ -27,6 +27,6 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="wayland"
 PKG_SHORTDESC="The mtdev is a stand-alone library which transforms all variants of kernel MT events to the slotted type B protocol."
 PKG_LONGDESC="The mtdev is a stand-alone library which transforms all variants of kernel MT events to the slotted type B protocol. The events put into mtdev may be from any MT device, specifically type A without contact tracking, type A with contact tracking, or type B with contact tracking. See the kernel documentation for further details."
-PKG_BUILD_FLAGS="+pic"
+PKG_BUILD_FLAGS="+pic -lto"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -29,6 +29,7 @@ PKG_SECTION="x11/xserver"
 PKG_SHORTDESC="xorg-server: The Xorg X server"
 PKG_LONGDESC="Xorg is a full featured X server that was originally designed for UNIX and UNIX-like operating systems running on Intel x86 hardware."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="-lto"
 
 get_graphicdrivers
 


### PR DESCRIPTION
lto causes scary "code may be misoptimized" warnings on a bunch of packages, like this:

```
/home/hias/rpi/libreelec-master/build.LibreELEC-RPi2.arm-9.0-devel/toolchain/bin/armv7ve-libreelec-linux-gnueabi-gcc -march=armv7ve -mtune=cortex-a7 -Wl,--as-needed -fuse-linker-plugin -flto -fuse-ld=gold  -rdynamic -o e2fsck unix.o e2fsck.o super.o pass1.o pass1b.o pass2.o pass3.o pass4.o pass5.o journal.o badblocks.o util.o dirinfo.o dx_dirinfo.o ehandler.o problem.o message.o quota.o recovery.o region.o revoke.o ea_refcount.o rehash.o logfile.o sigcatcher.o  readahead.o extents.o  ../lib/libsupport.a ../lib/libext2fs.a ../lib/libcom_err.a  -lpthread ../lib/libblkid.a  ../lib/libuuid.a  ../lib/libuuid.a   ../lib/libe2p.a -ldl
/home/hias/rpi/libreelec-master/build.LibreELEC-RPi2.arm-9.0-devel/e2fsprogs-1.43.9/lib/ext2fs/ext2fsP.h:178:13: warning: type of 'ext2fs_warn_bitmap32' does not match original declaration [-Wlto-type-mismatch]
 extern void ext2fs_warn_bitmap32(ext2fs_generic_bitmap bitmap,const char *func);
             ^
/home/hias/rpi/libreelec-master/build.LibreELEC-RPi2.arm-9.0-devel/e2fsprogs-1.43.9/lib/ext2fs/gen_bitmap64.c:745:6: note: 'ext2fs_warn_bitmap32' was previously declared here
 void ext2fs_warn_bitmap32(ext2fs_generic_bitmap bitmap, const char *func)
      ^
/home/hias/rpi/libreelec-master/build.LibreELEC-RPi2.arm-9.0-devel/e2fsprogs-1.43.9/lib/ext2fs/gen_bitmap64.c:745:6: note: code may be misoptimized unless -fno-strict-aliasing is used
```

Despite what the warning message says -fno-strict-aliasing doesn't remove these warnings, but disabling lto does.

Fixing the RPi2 build by disabling lto on the affected packages increased the tar size by 61440 bytes which looks like a very good tradeoff compared to the potential risk of falsely optimized code.

build without this PR:
```
-rw-r--r-- 1 hias hias 141864960 May 25 17:42 LibreELEC-RPi2.arm-9.0-devel-20180525141411-c896380.tar
```
build with this PR:
```
-rw-r--r-- 1 hias hias 141926400 May 25 22:29 LibreELEC-RPi2.arm-9.0-devel-20180525203057-c896380.tar
```

I've also included a commit to fix rebuilding of libtool, currently autoreconf fails on unclean builds because libtoolize is present in the toolchain (without this commit a clean build would be needed for this PR; as libtool package also needs lto disabled).

I'm running a clean Generic build overnight with this PR to check if some other packages may need building without lto as well