### PR TITLE
linux: update to linux-4.14.48

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -18,8 +18,8 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="784fe6c"
-PKG_SHA256="5830e68ca44768c8d96a25c7ebae558b39340c1cbb6626386c5605dbc125d08b"
+PKG_VERSION="7884178"
+PKG_SHA256="8d95f8c6d9c6f03a849b74a3eeddffbbfb18051e7260f7622b0a71dadf210ec4"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -1,24 +1,25 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="b530731"
-PKG_SHA256="c219f1d232fb80fbf23e7f2ed97d9c495855355a36dda373a8985c699ee1dd4b"
+PKG_VERSION="dd61ee1"
+PKG_SHA256="e8d083b04e405aef5601b485a927d06398642e50c2492a98d10e1f6bcf20d75f"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -56,13 +56,13 @@ case "$LINUX" in
     PKG_SOURCE_DIR="kernel-$PKG_VERSION"
     ;;
   raspberrypi)
-    PKG_VERSION="e3e047e02089bf95d28e1c8e2477e22752bed52e" # 4.14.44
-    PKG_SHA256="3e7c4a7b9aebcdbbcfece2e129500d7621f64aefbdf1210b266dc9d2ddcb7857"
+    PKG_VERSION="58eb131ce78d1976dad26c21bd75a7da290cd6aa" # 4.14.48
+    PKG_SHA256="0eda040a9ef97274d96069008785d65ca343c66f91e759ff261a93ee9af1ed7a"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     ;;
   *)
-    PKG_VERSION="4.14.44"
-    PKG_SHA256="2eb356e6af25f6ca65affe7704be8c4e0cdf224505e7441ac9d5b6e8d96ec8e4"
+    PKG_VERSION="4.14.48"
+    PKG_SHA256="80a0608f611fe7a5c54556402cdc2880a21301e1c4e1b19d4c1db82ad2bf22b9"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -56,13 +56,13 @@ case "$LINUX" in
     PKG_SOURCE_DIR="kernel-$PKG_VERSION"
     ;;
   raspberrypi)
-    PKG_VERSION="629e3cfe03cccce80bbb99c6f175a87c3d3bd005" # 4.14.43
-    PKG_SHA256="9d39421632034418b2a837d0e7c140c90799de20a2ae2279349066ffe8b50d0a"
+    PKG_VERSION="e3e047e02089bf95d28e1c8e2477e22752bed52e" # 4.14.44
+    PKG_SHA256="3e7c4a7b9aebcdbbcfece2e129500d7621f64aefbdf1210b266dc9d2ddcb7857"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     ;;
   *)
-    PKG_VERSION="4.14.43"
-    PKG_SHA256="133fc0f8f9ea04006c255a052704e8eb95a021fc799dd27f98fcfcace59e714a"
+    PKG_VERSION="4.14.44"
+    PKG_SHA256="2eb356e6af25f6ca65affe7704be8c4e0cdf224505e7441ac9d5b6e8d96ec8e4"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v4.x/$PKG_NAME-$PKG_VERSION.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2017.03.07"
-PKG_SHA256="371eafa3b26ece916ef83aca02c4bed2e54099eb5b8c6d22d3a4358dce6535b9"
+PKG_VERSION="2018.05.31"
+PKG_SHA256="e1dfbc3b97771373077f430c3c05082fae883145b37db5b2cfd12c56676fbe7b"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://wireless.kernel.org/en/developers/Regulatory"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -18,8 +18,8 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="784fe6c"
-PKG_SHA256="df0603357e1c3e4fe31ad63de22cf91a0d7cca13fe9b9b68cff0909825cba6a8"
+PKG_VERSION="7884178"
+PKG_SHA256="8f6c8d404736e92c80bab0bc2a7612f92a8486ca2701a9c2797e2640b9abe9be"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"


### PR DESCRIPTION
Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.44
Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.45 (skipped)
Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.46 (skipped)
Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.47 (skipped)
Changelog: https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.48
