### PR TITLE
enable LTO only for selected packages

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1,8 +1,13 @@
 setup_toolchain() {
+  TARGET_AR_NM_RANLIB_PREFIX=""
+
   if [ "$LTO_SUPPORT" = "yes" ] && flag_enabled "lto" "no"; then
     TARGET_CFLAGS+=" $CFLAGS_OPTIM_LTO"
     TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_LTO"
     TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO"
+    # static libs with lto info require gcc-ar/gcc-nm/gcc-ranlib instead of
+    # default binutils versions
+    TARGET_AR_NM_RANLIB_PREFIX="gcc-"
   fi
 
   # gold flag
@@ -46,9 +51,9 @@ setup_toolchain() {
       export CPP="${TARGET_PREFIX}cpp"
       export LD="${TARGET_PREFIX}ld"
       export AS="${TARGET_PREFIX}as"
-      export AR="${TARGET_PREFIX}ar"
-      export NM="${TARGET_PREFIX}nm"
-      export RANLIB="${TARGET_PREFIX}ranlib"
+      export AR="${TARGET_PREFIX}${TARGET_AR_NM_RANLIB_PREFIX}ar"
+      export NM="${TARGET_PREFIX}${TARGET_AR_NM_RANLIB_PREFIX}nm"
+      export RANLIB="${TARGET_PREFIX}${TARGET_AR_NM_RANLIB_PREFIX}ranlib"
       export OBJCOPY="${TARGET_PREFIX}objcopy"
       export OBJDUMP="${TARGET_PREFIX}objdump"
       export STRIP="${TARGET_PREFIX}strip"

--- a/config/functions
+++ b/config/functions
@@ -2,9 +2,9 @@ setup_toolchain() {
   TARGET_AR_NM_RANLIB_PREFIX=""
 
   if [ "$LTO_SUPPORT" = "yes" ] && flag_enabled "lto" "no"; then
-    TARGET_CFLAGS+=" $CFLAGS_OPTIM_LTO"
-    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_LTO"
-    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO"
+    TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
+    TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
+    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO_COMMON $FLAGS_OPTIM_LTO_NO_PARALLEL"
     # static libs with lto info require gcc-ar/gcc-nm/gcc-ranlib instead of
     # default binutils versions
     TARGET_AR_NM_RANLIB_PREFIX="gcc-"

--- a/config/functions
+++ b/config/functions
@@ -1,13 +1,8 @@
 setup_toolchain() {
-  # lto flag
-  if flag_enabled "lto" "$LTO_SUPPORT" "only-disable"; then
+  if [ "$LTO_SUPPORT" = "yes" ] && flag_enabled "lto" "no"; then
     TARGET_CFLAGS+=" $CFLAGS_OPTIM_LTO"
     TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_LTO"
     TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO"
-  else
-    TARGET_CFLAGS+=" $CFLAGS_OPTIM_NOLTO"
-    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_NOLTO"
-    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_NOLTO"
   fi
 
   # gold flag

--- a/config/functions
+++ b/config/functions
@@ -1,13 +1,31 @@
 setup_toolchain() {
   TARGET_AR_NM_RANLIB_PREFIX=""
 
-  if [ "$LTO_SUPPORT" = "yes" ] && flag_enabled "lto" "no"; then
-    TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
-    TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
-    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO_COMMON $FLAGS_OPTIM_LTO_NO_PARALLEL"
-    # static libs with lto info require gcc-ar/gcc-nm/gcc-ranlib instead of
-    # default binutils versions
-    TARGET_AR_NM_RANLIB_PREFIX="gcc-"
+  if [ "$LTO_SUPPORT" = "yes" ]; then
+    if flag_enabled "lto-parallel" "no"; then
+      TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
+      TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
+      TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO_COMMON $FLAGS_OPTIM_LTO_PARALLEL"
+      # static libs with lto info require gcc-ar/gcc-nm/gcc-ranlib instead of
+      # default binutils versions
+      TARGET_AR_NM_RANLIB_PREFIX="gcc-"
+    elif flag_enabled "lto-fat" "no"; then
+      TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_FAT"
+      TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_FAT"
+      TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO_COMMON $FLAGS_OPTIM_LTO_NO_PARALLEL"
+      TARGET_AR_NM_RANLIB_PREFIX="gcc-"
+    elif flag_enabled "lto" "no"; then
+      TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
+      TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
+      TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO_COMMON $FLAGS_OPTIM_LTO_NO_PARALLEL"
+      TARGET_AR_NM_RANLIB_PREFIX="gcc-"
+    fi
+  fi
+
+  if flag_enabled "lto-off" "no"; then
+    TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_OFF"
+    TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_OFF"
+    TARGET_LDFLAGS+=" $FLAGS_OPTIM_LTO_OFF"
   fi
 
   # gold flag

--- a/config/optimize
+++ b/config/optimize
@@ -32,12 +32,12 @@ HOST_CFLAGS="$HOST_CFLAGS -Wno-format-security"
 HOST_CXXFLAGS="$HOST_CXXFLAGS -Wno-format-security" 
 
 # lto flags
-CFLAGS_OPTIM_LTO="-flto -ffat-lto-objects"
-CXXFLAGS_OPTIM_LTO="-flto -ffat-lto-objects"
-LDFLAGS_OPTIM_LTO="-fuse-linker-plugin -flto"
-CFLAGS_OPTIM_NOLTO="-fno-lto"
-CXXFLAGS_OPTIM_NOLTO="-fno-lto"
-LDFLAGS_OPTIM_NOLTO="-fno-lto"
+FLAGS_OPTIM_LTO_NO_PARALLEL="-flto"
+FLAGS_OPTIM_LTO_PARALLEL="-flto=${CONCURRENCY_MAKE_LEVEL}"
+FLAGS_OPTIM_LTO_NO_FAT="-fno-fat-lto-objects"
+FLAGS_OPTIM_LTO_FAT="-ffat-lto-objects"
+FLAGS_OPTIM_LTO_OFF="-fno-lto"
+LDFLAGS_OPTIM_LTO_COMMON="-fuse-linker-plugin"
 
 # gold flags
 LDFLAGS_OPTIM_GOLD="-fuse-ld=gold"

--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -28,7 +28,7 @@ PKG_DEPENDS_TARGET="toolchain bzip2 fdk-aac libvorbis openssl opus x264 x265 zli
 PKG_SECTION="multimedia"
 PKG_LONGDESC="FFmpegx is an complete FFmpeg build to support encoding and decoding"
 # ffmpeg builds better with these options
-PKG_BUILD_FLAGS="-gold -lto"
+PKG_BUILD_FLAGS="-gold"
 
 # Dependencies
 get_graphicdrivers

--- a/packages/addons/addon-depends/icu/package.mk
+++ b/packages/addons/addon-depends/icu/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain icu:host"
 PKG_SECTION="textproc"
 PKG_SHORTDESC="International Components for Unicode library"
 PKG_LONGDESC="International Components for Unicode library"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared"
 

--- a/packages/addons/addon-depends/lcdd-depends/libugpio/package.mk
+++ b/packages/addons/addon-depends/lcdd-depends/libugpio/package.mk
@@ -26,5 +26,6 @@ PKG_URL="https://github.com/mhei/$PKG_NAME/archive/v$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain linux"
 PKG_LONGDESC="A free software library to ease the use of linux kernel's sysfs gpio interface from C programs and/or other libraries"
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"

--- a/packages/addons/addon-depends/libdvbcsa/package.mk
+++ b/packages/addons/addon-depends/libdvbcsa/package.mk
@@ -30,7 +30,7 @@ PKG_SHORTDESC="libdvbcsa is a free implementation of the DVB Common Scrambling A
 PKG_LONGDESC="libdvbcsa is a free implementation of the DVB Common Scrambling Algorithm - DVB/CSA - with encryption and decryption capabilities"
 PKG_TOOLCHAIN="autotools"
 # libdvbcsa is a bit faster without LTO, and tests will fail with gcc-5.x
-PKG_BUILD_FLAGS="-lto +pic"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static --with-sysroot=$SYSROOT_PREFIX"
 

--- a/packages/addons/addon-depends/libiconv/package.mk
+++ b/packages/addons/addon-depends/libiconv/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="devel"
 PKG_SHORTDESC="Libiconv converts from one character encoding to another through Unicode conversion."
 PKG_LONGDESC="Libiconv converts from one character encoding to another through Unicode conversion."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--host=$TARGET_NAME \
             --build=$HOST_NAME \

--- a/packages/addons/addon-depends/network-tools-depends/iw/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/iw/package.mk
@@ -28,7 +28,6 @@ PKG_SECTION="tools"
 PKG_SHORTDESC="iw is a new nl80211 based CLI configuration utility for wireless devices"
 PKG_LONGDESC="iw is a new nl80211 based CLI configuration utility for wireless devices. It supports all new drivers that have been added to the kernel recently."
 # iw fails at runtime with lto enabled
-PKG_BUILD_FLAGS="-lto"
 
 pre_configure_target() {
   export LDFLAGS="$LDFLAGS -pthread"

--- a/packages/addons/addon-depends/rsyslog-depends/librelp/package.mk
+++ b/packages/addons/addon-depends/rsyslog-depends/librelp/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="rsyslog"
 PKG_SHORTDESC="librelp"
 PKG_LONGDESC="librelp"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-tls \
                            --enable-static --disable-shared \

--- a/packages/addons/addon-depends/system-tools-depends/depends/efivar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/efivar/package.mk
@@ -29,7 +29,6 @@ PKG_DEPENDS_TARGET="toolchain efivar:host"
 PKG_SECTION="tools"
 PKG_SHORTDESC="evivar: maniulate EFI Variables"
 PKG_LONGDESC="Tools and library to manipulate EFI variables."
-PKG_BUILD_FLAGS="-lto"
 
 make_host() {
   make -C src/ makeguids

--- a/packages/addons/addon-depends/system-tools-depends/efibootmgr/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/efibootmgr/package.mk
@@ -28,7 +28,6 @@ PKG_DEPENDS_TARGET="toolchain efivar pciutils zlib"
 PKG_SECTION="tools"
 PKG_SHORTDESC="EFI Boot Manager"
 PKG_LONGDESC="This is a Linux user-space application to modify the Intel Extensible Firmware Interface (EFI) Boot Manager configuration. This application can create and destroy boot entries, change the boot order, change the next running boot option, and more."
-PKG_BUILD_FLAGS="-lto"
 
 pre_make_target() {
   export EXTRA_CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include -I$SYSROOT_PREFIX/usr/include/efivar -fgnu89-inline"

--- a/packages/addons/browser/chromium/package.mk
+++ b/packages/addons/browser/chromium/package.mk
@@ -32,7 +32,6 @@ PKG_SECTION="browser"
 PKG_SHORTDESC="Chromium Browser: the open-source web browser from Google"
 PKG_LONGDESC="Chromium Browser ($PKG_VERSION): the open-source web browser from Google"
 PKG_TOOLCHAIN="manual"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Chromium"

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -30,7 +30,6 @@ PKG_SECTION="service"
 PKG_SHORTDESC="Librespot: play Spotify through LibreELEC using a Spotify app as a remote"
 PKG_LONGDESC="Librespot ($PKG_VERSION) plays Spotify through LibreELEC using the open source librespot library using a Spotify app as a remote."
 PKG_TOOLCHAIN="manual"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Librespot"

--- a/packages/addons/tools/mono/package.mk
+++ b/packages/addons/tools/mono/package.mk
@@ -30,7 +30,6 @@ PKG_SECTION="tools"
 PKG_SHORTDESC="Mono: a cross platform, open source .NET framework"
 PKG_LONGDESC="Mono ($PKG_VERSION) is a software platform designed to allow developers to easily create cross platform applications part of the .NET Foundation"
 PKG_TOOLCHAIN="autotools"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Mono"

--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -28,7 +28,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_LONGDESC="ALSA (Advanced Linux Sound Architecture) is the next generation Linux Sound API."
 PKG_TOOLCHAIN="autotools"
-PKG_BUILD_FLAGS="-lto +pic"
+PKG_BUILD_FLAGS="+pic"
 
 if build_with_debug; then
   PKG_ALSA_DEBUG=--with-debug

--- a/packages/audio/flac/package.mk
+++ b/packages/audio/flac/package.mk
@@ -29,7 +29,7 @@ PKG_SHORTDESC="flac: An Free Lossless Audio Codec"
 PKG_LONGDESC="Grossly oversimplified, FLAC is similar to MP3, but lossless, meaning that audio is compressed in FLAC without throwing away any information. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio."
 PKG_TOOLCHAIN="autotools"
 # flac-1.3.1 dont build with LTO support
-PKG_BUILD_FLAGS="-lto +pic"
+PKG_BUILD_FLAGS="+pic"
 
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \

--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_SHORTDESC="FluidSynth: A SoundFont Synthesizer."
 PKG_LONGDESC="FluidSynth renders midi music files as raw audio data, for playing or conversion. "
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=0 \
                        -Denable-readline=0 \

--- a/packages/audio/lame/package.mk
+++ b/packages/audio/lame/package.mk
@@ -27,7 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_SHORTDESC="lame: LAME Ain't an Mp3 Encoder"
 PKG_LONGDESC="LAME originally stood for LAME Ain't an Mp3 Encoder. The goal of the LAME project is to use the open source model to improve the psycho acoustics, noise shaping and speed of MP3. Another goal of the LAME project is to use these improvements for the basis of a patent free audio compression codec for the GNU project."
-PKG_BUILD_FLAGS="-parallel"
+PKG_BUILD_FLAGS="-parallel +pic"
 
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \

--- a/packages/audio/libmodplug/package.mk
+++ b/packages/audio/libmodplug/package.mk
@@ -27,5 +27,6 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_SHORTDESC="libmodplug: renders mod music files as raw audio data, for playing or conversion."
 PKG_LONGDESC="libmodplug renders mod music files as raw audio data, for playing or conversion. libmodplug is based on the fast and high quality mod playing code written and released to the public domain by Olivier Lapicque. mod, .s3m, .it, .xm, and a number of lesser-known formats are supported. Optional features include high-quality resampling, bass expansion, surround and reverb."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"

--- a/packages/audio/libogg/package.mk
+++ b/packages/audio/libogg/package.mk
@@ -27,6 +27,7 @@ PKG_URL="http://downloads.xiph.org/releases/ogg/libogg-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_LONGDESC="Libogg contains necessary functionality to create, decode, and work with Ogg bitstreams."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared"

--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain libogg libvorbis"
 PKG_SECTION="audio"
 PKG_SHORTDESC="libopenmpt: renders mod music files as raw audio data, for playing or conversion."
 PKG_LONGDESC="libopenmpt renders mod music files as raw audio data, for playing or conversion."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/audio/sidplay-libs/package.mk
+++ b/packages/audio/sidplay-libs/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="audio"
 PKG_SHORTDESC="sidplay-libs"
 PKG_LONGDESC="sidplay-libs"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
 

--- a/packages/audio/soxr/package.mk
+++ b/packages/audio/soxr/package.mk
@@ -28,7 +28,7 @@ PKG_SOURCE_DIR="$PKG_NAME-$PKG_VERSION-Source"
 PKG_DEPENDS_TARGET="toolchain cmake:host"
 PKG_SECTION="audio"
 PKG_LONGDESC="The SoX Resampler library performs one-dimensional sample-rate conversion. It may be used to resample PCM-encoded audio."
-PKG_BUILD_FLAGS="-lto +pic"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_EXAMPLES=OFF \
                        -DBUILD_SHARED_LIBS=OFF \

--- a/packages/databases/mysql/package.mk
+++ b/packages/databases/mysql/package.mk
@@ -28,7 +28,6 @@ PKG_DEPENDS_TARGET="toolchain zlib ncurses openssl boost mysql:host"
 PKG_SECTION="database"
 PKG_SHORTDESC="mysql: A database server"
 PKG_LONGDESC="MySQL is a SQL (Structured Query Language) database server. SQL is the most popular database language in the world. MySQL is a client server implementation that consists of a server daemon mysqld and many different client programs/libraries."
-build_with_debug && [ "$TARGET_ARCH" = "aarch64" ] && PKG_BUILD_FLAGS="-lto"
 
 post_unpack() {
   sed -i 's|GET_TARGET_PROPERTY(LIBMYSQL_OS_OUTPUT_NAME libmysql OUTPUT_NAME)|SET(LIBMYSQL_OS_OUTPUT_NAME "mysqlclient")|' $PKG_BUILD/scripts/CMakeLists.txt

--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -28,7 +28,6 @@ PKG_SECTION="debug"
 PKG_SHORTDESC="gdb: The GNU Debugger"
 PKG_LONGDESC="The purpose of a debugger such as GDB is to allow you to see what is going on ``inside'' another program while it executes--or what another program was doing at the moment it crashed."
 # gdb could fail on runtime if build with LTO support
-PKG_BUILD_FLAGS="-lto"
 
 CC_FOR_BUILD="$HOST_CC"
 CFLAGS_FOR_BUILD="$HOST_CFLAGS"

--- a/packages/debug/valgrind/package.mk
+++ b/packages/debug/valgrind/package.mk
@@ -27,7 +27,6 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="debug"
 PKG_SHORTDESC="A tool to help find memory-management problems in programs"
 PKG_LONGDESC="A tool to help find memory-management problems in programs"
-PKG_BUILD_FLAGS="-lto"
 
 if [ "$TARGET_ARCH" = "arm" ]; then
   PKG_CONFIGURE_OPTS_TARGET="--enable-only32bit"

--- a/packages/devel/dbus-glib/package.mk
+++ b/packages/devel/dbus-glib/package.mk
@@ -28,7 +28,7 @@ PKG_SECTION="devel"
 PKG_SHORTDESC="dbus-glib: A message bus system"
 PKG_LONGDESC="D-BUS is a message bus, used for sending messages between applications. Conceptually, it fits somewhere in between raw sockets and CORBA in terms of complexity."
 PKG_TOOLCHAIN="autotools"
-PKG_BUILD_FLAGS="+pic"
+PKG_BUILD_FLAGS="+pic +lto"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_have_abstract_sockets=yes \
                            ac_cv_func_posix_getpwnam_r=yes \

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -28,7 +28,7 @@ PKG_DEPENDS_INIT="glibc"
 PKG_SECTION="toolchain/devel"
 PKG_SHORTDESC="glibc: The GNU C library"
 PKG_LONGDESC="The Glibc package contains the main C library. This library provides the basic routines for allocating memory, searching directories, opening and closing files, reading and writing files, string handling, pattern matching, arithmetic, and so on."
-PKG_BUILD_FLAGS="-lto -gold"
+PKG_BUILD_FLAGS="-gold"
 
 PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            ac_cv_path_PERL=no \

--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -28,7 +28,7 @@ PKG_SECTION="devel"
 PKG_SHORTDESC="ncurses: The ncurses (new curses) library"
 PKG_LONGDESC="The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0, and more. It uses terminfo format, supports pads and color and multiple highlights and forms characters and function-key mapping, and has all the other SYSV-curses enhancements over BSD curses."
 # causes some segmentation fault's (dialog) when compiled with gcc's link time optimization.
-PKG_BUILD_FLAGS="-lto +pic"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--without-ada \
                            --without-cxx \

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -28,7 +28,6 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.bluemsx: BlueMSX for Kodi"
 PKG_LONGDESC="game.libretro.bluemsx: BlueMSX for Kodi"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="bluemsx_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"

--- a/packages/emulation/libretro-dosbox/package.mk
+++ b/packages/emulation/libretro-dosbox/package.mk
@@ -28,7 +28,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.dosbox: DOSBox for Kodi"
 PKG_LONGDESC="game.libretro.dosbox: DOSBox for Kodi"
-PKG_BUILD_FLAGS="-lto +pic"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_LIBNAME="dosbox_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"

--- a/packages/emulation/libretro-fbalpha/package.mk
+++ b/packages/emulation/libretro-fbalpha/package.mk
@@ -30,7 +30,6 @@ PKG_SHORTDESC="game.libretro.fba: fba for Kodi"
 PKG_LONGDESC="game.libretro.fba: fba for Kodi"
 PKG_TOOLCHAIN="manual"
 # linking takes too long with lto
-PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="fbalpha_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"

--- a/packages/emulation/libretro-genplus/package.mk
+++ b/packages/emulation/libretro-genplus/package.mk
@@ -29,7 +29,6 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.genplus: Genesis Plus GX for Kodi"
 PKG_LONGDESC="game.libretro.genplus: Genesis Plus GX for Kodi"
 PKG_TOOLCHAIN="manual"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="genesis_plus_gx_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"

--- a/packages/emulation/libretro-mame/package.mk
+++ b/packages/emulation/libretro-mame/package.mk
@@ -28,7 +28,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.mame: MAME for Kodi"
 PKG_LONGDESC="game.libretro.mame: MAME for Kodi"
-PKG_BUILD_FLAGS="-gold -lto"
+PKG_BUILD_FLAGS="-gold"
 
 PKG_LIBNAME="mame_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"

--- a/packages/emulation/libretro-mame2000/package.mk
+++ b/packages/emulation/libretro-mame2000/package.mk
@@ -28,7 +28,6 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="2000 version of MAME (0.37b5) for libretro"
 PKG_LONGDESC="2000 version of MAME (0.37b5) for libretro"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="mame2000_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"

--- a/packages/emulation/libretro-mame2010/package.mk
+++ b/packages/emulation/libretro-mame2010/package.mk
@@ -28,7 +28,6 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="Late 2010 version of MAME (0.139) for libretro"
 PKG_LONGDESC="Late 2010 version of MAME (0.139) for libretro"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="mame2010_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"

--- a/packages/emulation/libretro-mame2014/package.mk
+++ b/packages/emulation/libretro-mame2014/package.mk
@@ -28,7 +28,6 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION="emulation"
 PKG_SHORTDESC="Late 2014/Early 2015 version of MAME (0.159-ish) for libretro"
 PKG_LONGDESC="Late 2014/Early 2015 version of MAME (0.159-ish) for libretro"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="mame2014_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"

--- a/packages/emulation/libretro-ppsspp/package.mk
+++ b/packages/emulation/libretro-ppsspp/package.mk
@@ -28,7 +28,6 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="A PSP emulator for Android, Windows, Mac, Linux and Blackberry 10, written in C++."
 PKG_LONGDESC="A PSP emulator for Android, Windows, Mac, Linux and Blackberry 10, written in C++."
 PKG_TOOLCHAIN="make"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="ppsspp_libretro.so"
 PKG_LIBPATH="libretro/$PKG_LIBNAME"

--- a/packages/emulation/libretro-scummvm/package.mk
+++ b/packages/emulation/libretro-scummvm/package.mk
@@ -29,7 +29,6 @@ PKG_SECTION="emulation"
 PKG_SHORTDESC="game.libretro.scummvm: scummvm for Kodi"
 PKG_LONGDESC="game.libretro.scummvm: scummvm for Kodi"
 PKG_TOOLCHAIN="manual"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_LIBNAME="scummvm_libretro.so"
 PKG_LIBPATH="backends/platform/libretro/build/$PKG_LIBNAME"

--- a/packages/graphics/libraw/package.mk
+++ b/packages/graphics/libraw/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain libjpeg-turbo"
 PKG_SECTION="graphics"
 PKG_SHORTDESC="A library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)"
 PKG_LONGDESC="A library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/lang/Python2/package.mk
+++ b/packages/lang/Python2/package.mk
@@ -31,7 +31,7 @@ PKG_SHORTDESC="python2: The Python2 programming language"
 PKG_LONGDESC="Python2 is an interpreted object-oriented programming language, and is often compared with Tcl, Perl, Java or Scheme."
 
 PKG_TOOLCHAIN="autotools"
-PKG_BUILD_FLAGS="-parallel"
+PKG_BUILD_FLAGS="-parallel +lto-parallel"
 
 PKG_PY_DISABLED_MODULES="_tkinter nis gdbm bsddb ossaudiodev"
 

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -28,6 +28,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform p8-platform"
 PKG_SECTION=""
 PKG_SHORTDESC="peripheral.joystick: Joystick support in Kodi"
 PKG_LONGDESC="peripheral.joystick provides joystick support and button mapping"
+PKG_BUILD_FLAGS="+lto"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.peripheral"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -33,8 +33,6 @@ PKG_LONGDESC="Kodi Media Center (which was formerly named Xbox Media Center or X
 # Single threaded LTO is very slow so rely on Kodi for parallel LTO support
 if [ "$LTO_SUPPORT" = "yes" ] && ! build_with_debug; then
   PKG_KODI_USE_LTO="-DUSE_LTO=$CONCURRENCY_MAKE_LEVEL"
-else
-  PKG_BUILD_FLAGS="-lto"
 fi
 
 get_graphicdrivers

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -30,7 +30,7 @@ PKG_DEPENDS_TARGET="toolchain yasm:host zlib bzip2 openssl speex"
 PKG_SECTION="multimedia"
 PKG_SHORTDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
 PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
-PKG_BUILD_FLAGS="-gold -lto"
+PKG_BUILD_FLAGS="-gold"
 
 # Dependencies
 get_graphicdrivers

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="network"
 PKG_SHORTDESC="bluez: Bluetooth Tools and System Daemons for Linux."
 PKG_LONGDESC="Bluetooth Tools and System Daemons for Linux."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+lto"
 
 if build_with_debug; then
   BLUEZ_CONFIG="--enable-debug"

--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="network"
 PKG_SHORTDESC="openssh: An open re-implementation of the SSH package"
 PKG_LONGDESC="This is a Linux port of OpenBSD's excellent OpenSSH. OpenSSH is based on the last free version of Tatu Ylonen's SSH with all patent-encumbered algorithms removed, all known security bugs fixed, new features reintroduced, and many other clean-ups. SSH (Secure Shell) is a program to log into another computer over a network, to execute commands in a remote machine, and to move files from one machine to another. It provides strong authentication and secure communications over insecure channels. It is intended as a replacement for rlogin, rsh, rcp, and rdist."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+lto"
 
 PKG_CONFIGURE_OPTS_TARGET="--sysconfdir=/etc/ssh \
                            --libexecdir=/usr/lib/openssh \

--- a/packages/network/wpa_supplicant/package.mk
+++ b/packages/network/wpa_supplicant/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="network"
 PKG_SHORTDESC="wpa_supplicant: An IEEE 802.11i supplicant implementation"
 PKG_LONGDESC="The wpa_supplicant is a free software implementation of an IEEE 802.11i supplicant. In addition to being a full-featured WPA2 supplicant, it also has support for WPA and older wireless LAN security protocols."
 PKG_TOOLCHAIN="make"
+PKG_BUILD_FLAGS="+lto-parallel"
 
 PKG_MAKE_OPTS_TARGET="-C wpa_supplicant V=1 LIBDIR=/usr/lib BINDIR=/usr/bin"
 PKG_MAKEINSTALL_OPTS_TARGET="-C wpa_supplicant V=1 LIBDIR=/usr/lib BINDIR=/usr/bin"

--- a/packages/python/system/dbus-python/package.mk
+++ b/packages/python/system/dbus-python/package.mk
@@ -27,6 +27,7 @@ PKG_DEPENDS_TARGET="toolchain Python2 dbus dbus-glib"
 PKG_SECTION="python/system"
 PKG_SHORTDESC="dbus-python: A message bus system"
 PKG_LONGDESC="D-BUS is a message bus, used for sending messages between applications. Conceptually, it fits somewhere in between raw sockets and CORBA in terms of complexity. D-BUS supports broadcast messages, asynchronous messages (thus decreasing latency), authentication, and more. It is designed to be low-overhead; messages are sent using a binary protocol, not using XML. D-BUS also supports a method call mapping for its messages, but it is not required; this makes using the system quite simple."
+PKG_BUILD_FLAGS="+lto"
 
 pre_configure_target() {
   export PYTHON_CONFIG="$SYSROOT_PREFIX/usr/bin/python2-config"

--- a/packages/python/system/simplejson/package.mk
+++ b/packages/python/system/simplejson/package.mk
@@ -28,7 +28,6 @@ PKG_SECTION="python/system"
 PKG_SHORTDESC="simplejson: a simple, fast, complete, correct and extensible JSON <http://json.org> encoder and decoder for Python 2.5+."
 PKG_LONGDESC="simplejson is a simple, fast, complete, correct and extensible JSON <http://json.org> encoder and decoder for Python 2.5+. It is pure Python code with no dependencies, but includes an optional C extension for a serious speed boost."
 PKG_TOOLCHAIN="manual"
-PKG_BUILD_FLAGS="-lto"
 
 pre_make_target() {
   export PYTHONXCPREFIX="$SYSROOT_PREFIX/usr"

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -118,7 +118,10 @@ Set the variable `PKG_BUILD_FLAGS` in the `package.mk` to enable/disable the sin
 |----------|----------|----------------|-------------|
 | pic      | disabled | target/init    | [Position Independent Code](https://en.wikipedia.org/wiki/Position-independent_code) |
 | pic:host | disabled | host/bootstrap | see above |
-| lto      | depend on `LTO_SUPPORT` | target/init | can only disabled, use of "Link Time Optimisation" of the compiler |
+| lto      | disabled | target/init    | enable LTO (Link Time optimization) in the compiler and linker unless disabled via `LTO_SUPPORT`. Compiles non-fat LTO objects (only bytecode) and performs single-threaded optimization at link stage |
+| lto-parallel | disabled | target/init | same as `lto` but enable parallel optimization at link stage. Only enable this if the package build doesn't run multiple linkers in parallel otherwise this can result in lots of parallel processes! |
+| lto-fat  | disabled | target/init | same as `lto` but compile fat LTO objects (bytecode plus optimized assembly). This increases compile time but can be useful to create static libraries suitable both for LTO and non-LTO linking |
+| lto-off  | disabled | target/init | explicitly disable LTO in the compiler and linker |
 | gold     | depend on `GOLD_SUPPORT` | target/init | can only disabled, use of the GOLD-Linker |
 | parallel | enabled  | all | `make` or `ninja` builds with multiple threads/processes (or not) |
 

--- a/packages/security/libgcrypt/package.mk
+++ b/packages/security/libgcrypt/package.mk
@@ -30,7 +30,6 @@ PKG_LONGDESC="Libgcrypt is a general purpose cryptographic library based on the 
 PKG_TOOLCHAIN="autotools"
 # libgcrypt-1.7.x fails to build with LTO support
 # see for example https://bugs.gentoo.org/show_bug.cgi?id=581114
-PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            ac_cv_sys_symbol_underscore=no \

--- a/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
+++ b/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
@@ -28,6 +28,7 @@ PKG_SECTION="system"
 PKG_SHORTDESC="ntfs-3g_ntfsprogs: NTFS-3G Read/Write userspace driver"
 PKG_LONGDESC="The NTFS-3G_ntfsprogs driver is an open source, freely available NTFS driver for Linux with read and write support. It provides safe and fast handling of the Windows XP, Windows Server 2003, Windows 2000 and Windows Vista file systems."
 PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+lto"
 
 PKG_CONFIGURE_OPTS_TARGET="--exec-prefix=/usr/ \
                            --disable-dependency-tracking \

--- a/packages/tools/grub/package.mk
+++ b/packages/tools/grub/package.mk
@@ -28,7 +28,6 @@ PKG_SECTION="tools"
 PKG_SHORTDESC="GNU GRUB is a Multiboot boot loader."
 PKG_LONGDESC="GNU GRUB is a Multiboot boot loader that was derived from GRUB, the GRand Unified Bootloader, which was originally designed and implemented by Erich Stefan Boleyn"
 PKG_TOOLCHAIN="configure"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="--target=i386-pc-linux \
                            --disable-nls \

--- a/packages/wayland/wayland/package.mk
+++ b/packages/wayland/wayland/package.mk
@@ -28,7 +28,6 @@ PKG_DEPENDS_HOST="libffi:host expat:host libxml2:host"
 PKG_SECTION="wayland"
 PKG_SHORTDESC="a display server protocol"
 PKG_LONGDESC="a display server protocol"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-shared \
                          --disable-static \

--- a/packages/wayland/weston/package.mk
+++ b/packages/wayland/weston/package.mk
@@ -27,7 +27,6 @@ PKG_DEPENDS_TARGET="toolchain wayland-protocols libdrm libxkbcommon libinput cai
 PKG_SECTION="wayland"
 PKG_SHORTDESC="Reference implementation of a Wayland compositor"
 PKG_LONGDESC="Reference implementation of a Wayland compositor"
-PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="CFLAGS=-DMESA_EGL_NO_X11_HEADERS \
                            LIBS=-lturbojpeg \

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -30,7 +30,6 @@ PKG_SHORTDESC="xf86-video-intel: The Xorg driver for Intel video chips"
 PKG_LONGDESC="The Xorg driver for Intel i810, i815, 830M, 845G, 852GM, 855GM, 865G, 915G, 915GM and 965G video chips."
 PKG_TOOLCHAIN="autotools"
 # xf86-video-intel is broken enough. dont link with LTO
-PKG_BUILD_FLAGS="-lto"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-backlight \
                            --disable-backlight-helper \


### PR DESCRIPTION
Enabling LTO by default for all packages turned out to be rather tedious.

Despite the rather large hit in CPU and memory usage (about 30% longer compile time on a clean Generic build and a lot more on inremental rebuilds) only few packages seem to take advantage of it - size comparison of LTO and non-LTO builds showed that the majority of the binaries had the exact same size.

We kind of got used to the spurious build breakages after package bumps and occasional internal compiler errors, resulting in the typical "disable lto for that package" fix, but after analyzing the rather scary "code may be misoptimized" warnings from lto (see #2722) and finding more warnings (eg "size of ... differ from the size of original declaration [-Wlto-type-mismatch]" in util-linux and v4l-utils) I think it's time to approach that from a different angle:

Let's enable LTO only for the packages that actually benefit from LTO and build without errors or warnings when enabling.

With this approach we also have the opportunity to specifically tune LTO build parameters. Use fat lto objects only where it's needed (or doesn't hurt much) and enable parallel LTO linking where it's beneficial and safe (parallel make combined with parallel LTO can result in really a lot of processes, we wouldn't want that to happen).

I've build and runtime tested this PR so far only on RPi2 and focussed on enabling LTO for the packages where size reduction was noticable and LTO only had a slight impact on compile time.

v4l-utils and util-linux would profit from LTO (size-wise), but seeing the LTO warnings made that a no-go.

I also had a look at trying to tackle perf (built from linux package) and xmlstarlet but didn't get too far - either I ran into warnings, size didn't change or even went up. I might have a go at it later.

In it's current state this PR results in a slight size increase (about 1MB larger tar on RPi2, which is about half-way between the current master build and a master build with LTO_SUPPORT=no) and should result in significantly lower build time (haven't measured that yet).

Detailed size comparison between current master (githash 66a913dac5) and this pr (named "newlto" in the size comparison) is here: http://ix.io/1bL1