### PR TITLE
scripts/image: fix noobs tarball

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -535,7 +535,7 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
     rm -rf $TARGET_IMG/${IMAGE_NAME}-$1.tar
 
     # create release tarball
-    tar cf $TARGET_IMG/${IMAGE_NAME}-$1.tar -C $TARGET ${IMAGE_NAME}-$1
+    tar cf $TARGET_IMG/${IMAGE_NAME}-$1.tar -C $TARGET_IMG ${IMAGE_NAME}-$1
 
     # create sha256 checksum of tarball
     ( cd $TARGET_IMG


### PR DESCRIPTION
Found this small typo when I realized that the noobs tarballs are failing to create:
```
Creating "noobs" release tarball...
tar: Cowardly refusing to create an empty archive
Try 'tar --help' or 'tar --usage' for more information.
Makefile:15: recipe for target 'noobs' failed
make: *** [noobs] Error 2
```