### PR TITLE
openssl: do not include from host

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -60,7 +60,7 @@ pre_configure_host() {
 
 configure_host() {
   cd $PKG_BUILD/.$HOST_NAME
-  ./Configure --prefix=/ $PKG_CONFIGURE_OPTS_SHARED linux-x86_64 $CFLAGS $LDFLAGS
+  ./Configure --prefix=$TOOLCHAIN $PKG_CONFIGURE_OPTS_SHARED linux-x86_64 $CFLAGS $LDFLAGS
 }
 
 makeinstall_host() {


### PR DESCRIPTION
If host has `libssl-dev` installed openssl includes wrong files.

Problem should exist for a long time already and only came up recently because Ubuntu 18.04 (other distros likely too) includes openssl 1.1.x and we are still at 1.0.x (1.1 and 1.0 are incompatible to each other).

This needs an complete rebuild.

fix was found by @ksooo , tx !