### PR TITLE
network-tools add-on buildfix

### DIFF
--- a/packages/network/libnl/package.mk
+++ b/packages/network/libnl/package.mk
@@ -1,31 +1,33 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2016-present Team LibreELEC
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="libnl"
-PKG_VERSION="3.2.27"
-PKG_SHA256="4bbbf92b3c78a90f423cf96260bf419a28b75db8cced47051217a56795f58ec6"
+PKG_VERSION="3.4.0"
+PKG_SHA256="b7287637ae71c6db6f89e1422c995f0407ff2fe50cecd61a312b6a9b0921f5bf"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"
-PKG_SITE="http://people.suug.ch/~tgr/libnl/"
-PKG_URL="https://github.com/thom311/$PKG_NAME/releases/download/${PKG_NAME}${PKG_VERSION//./_}/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/thom311/libnl"
+PKG_URL="https://github.com/thom311/libnl/releases/download/libnl${PKG_VERSION//./_}/libnl-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="network"
-PKG_SHORTDESC="libnl: libnl - netlink library"
-PKG_LONGDESC="libnl is a library for applications dealing with netlink socket. It provides an easy to use interface for raw netlink message but also netlink family specific APIs."
+PKG_LONGDESC="A library for applications dealing with netlink socket."
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --disable-cli"
+PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+                           --disable-shared \
+                           --disable-cli"


### PR DESCRIPTION
fixes network-tools add-on

libnl: update to 3.4.0

fixes
```
  BUILD    iw (target)
      TOOLCHAIN    make (auto-detect)
Executing (target): make 
 CC   iw.o
...
 CC   iw
/builddir/toolchain/armv7a-libreelec-linux-gnueabi/sysroot/usr/lib/libnl-3.a(utils.o):utils.c:function nl_prob2int: error: undefined reference to 'rint'
```