### PR TITLE
mesa: change to use meson and update

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -186,6 +186,7 @@ cpp = '$CXX'
 ar = '$AR'
 strip = '$STRIP'
 pkgconfig = '$PKG_CONFIG'
+llvm-config = '$SYSROOT_PREFIX/usr/bin/llvm-config-host'
 
 [host_machine]
 system = 'linux'

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -17,13 +17,13 @@
 ################################################################################
 
 PKG_NAME="mesa"
-PKG_VERSION="18.0.2"
-PKG_SHA256="98fa159768482dc568b9f8bf0f36c7acb823fa47428ffd650b40784f16b9e7b3"
+PKG_VERSION="18.1.1"
+PKG_SHA256="d3312a2ede5aac14a47476b208b8e3a401367838330197c4588ab8ad420d7781"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="ftp://freedesktop.org/pub/mesa/$PKG_NAME-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="toolchain expat libdrm"
+PKG_DEPENDS_TARGET="toolchain expat libdrm Mako:host"
 PKG_SECTION="graphics"
 PKG_SHORTDESC="mesa: 3-D graphics library with OpenGL API"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API which is very similar to that of OpenGL*. To the extent that Mesa utilizes the OpenGL command syntax or state machine, it is being used with authorization from Silicon Graphics, Inc. However, the author makes no claim that Mesa is in any way a compatible replacement for OpenGL or associated with Silicon Graphics, Inc. Those who want a licensed implementation of OpenGL should contact a licensed vendor. While Mesa is not a licensed OpenGL implementation, it is currently being tested with the OpenGL conformance tests. For the current conformance status see the CONFORM file included in the Mesa distribution."

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -29,6 +29,7 @@ PKG_SECTION="graphics"
 PKG_SHORTDESC="mesa: 3-D graphics library with OpenGL API"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API which is very similar to that of OpenGL*. To the extent that Mesa utilizes the OpenGL command syntax or state machine, it is being used with authorization from Silicon Graphics, Inc. However, the author makes no claim that Mesa is in any way a compatible replacement for OpenGL or associated with Silicon Graphics, Inc. Those who want a licensed implementation of OpenGL should contact a licensed vendor. While Mesa is not a licensed OpenGL implementation, it is currently being tested with the OpenGL conformance tests. For the current conformance status see the CONFORM file included in the Mesa distribution."
 PKG_TOOLCHAIN="meson"
+PKG_BUILD_FLAGS="+lto"
 
 get_graphicdrivers
 

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -1,20 +1,20 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2018 Team LibreELEC
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="mesa"

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -1,5 +1,6 @@
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2018 Team LibreELEC
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
 #  OpenELEC is free software: you can redistribute it and/or modify
@@ -27,102 +28,79 @@ PKG_DEPENDS_TARGET="toolchain expat libdrm Mako:host"
 PKG_SECTION="graphics"
 PKG_SHORTDESC="mesa: 3-D graphics library with OpenGL API"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API which is very similar to that of OpenGL*. To the extent that Mesa utilizes the OpenGL command syntax or state machine, it is being used with authorization from Silicon Graphics, Inc. However, the author makes no claim that Mesa is in any way a compatible replacement for OpenGL or associated with Silicon Graphics, Inc. Those who want a licensed implementation of OpenGL should contact a licensed vendor. While Mesa is not a licensed OpenGL implementation, it is currently being tested with the OpenGL conformance tests. For the current conformance status see the CONFORM file included in the Mesa distribution."
-PKG_TOOLCHAIN="autotools"
+PKG_TOOLCHAIN="meson"
+
+get_graphicdrivers
+
+PKG_MESON_OPTS_TARGET="-Ddri-drivers=$DRI_DRIVERS \
+                       -Ddri-drivers-path=$XORG_PATH_DRI \
+                       -Ddri-search-path=$XORG_PATH_DRI \
+                       -Dgallium-drivers=$GALLIUM_DRIVERS \
+                       -Dgallium-extra-hud=false \
+                       -Dgallium-xvmc=false \
+                       -Dgallium-omx=disabled \
+                       -Dgallium-nine=false \
+                       -Dgallium-opencl=disabled \
+                       -Dvulkan-drivers= \
+                       -Dshader-cache=true \
+                       -Dshared-glapi=true \
+                       -Dopengl=true \
+                       -Dgbm=true \
+                       -Degl=true \
+                       -Dglvnd=false \
+                       -Dasm=true \
+                       -Dvalgrind=false \
+                       -Dlibunwind=false \
+                       -Dlmsensors=false \
+                       -Dbuild-tests=false \
+                       -Dtexture-float=true \
+                       -Dselinux=false \
+                       -Dosmesa=none"
 
 if [ "$DISPLAYSERVER" = "x11" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET glproto dri2proto presentproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 dri3proto libxshmfence"
-  export DRI_DRIVER_INSTALL_DIR=$XORG_PATH_DRI
-  export DRI_DRIVER_SEARCH_DIR=$XORG_PATH_DRI
   export X11_INCLUDES=
-  MESA_DRI="--enable-dri --enable-dri3"
-  MESA_GLX="--enable-glx --enable-driglx-direct --enable-glx-tls"
-  MESA_PLATFORMS="--with-platforms=x11,drm"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms=x11,drm -Ddri3=true -Dglx=dri"
 elif [ "$DISPLAYSERVER" = "weston" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET wayland wayland-protocols"
-  MESA_DRI="--enable-dri --disable-dri3"
-  # The glx in glx-tls is a misnomer - there's nothing glx in it.
-  MESA_GLX="--disable-glx --disable-driglx-direct --enable-glx-tls"
-  MESA_PLATFORMS="--with-platforms=drm,wayland"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms=wayland,drm -Ddri3=false -Dglx=disabled"
 else
-  MESA_DRI="--enable-dri --disable-dri3"
-  # The glx in glx-tls is a misnomer - there's nothing glx in it.
-  MESA_GLX="--disable-glx --disable-driglx-direct --enable-glx-tls"
-  MESA_PLATFORMS="--with-platforms=drm"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms=drm -Ddri3=false -Dglx=disabled"
 fi
-
-# configure GPU drivers and dependencies:
-  get_graphicdrivers
 
 if [ "$LLVM_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET elfutils llvm"
   export LLVM_CONFIG="$SYSROOT_PREFIX/usr/bin/llvm-config-host"
-  MESA_GALLIUM_LLVM="--enable-llvm --enable-llvm-shared-libs"
+  PKG_MESON_OPTS_TARGET+=" -Dllvm=true"
 else
-  MESA_GALLIUM_LLVM="--disable-llvm"
+  PKG_MESON_OPTS_TARGET+=" -Dllvm=false"
 fi
 
 if [ "$VDPAU_SUPPORT" = "yes" -a "$DISPLAYSERVER" = "x11" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libvdpau"
-  MESA_VDPAU="--enable-vdpau"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-vdpau=true"
 else
-  MESA_VDPAU="--disable-vdpau"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-vdpau=false"
 fi
 
 if [ "$VAAPI_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libva"
-  MESA_VAAPI="--enable-va"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-va=true"
 else
-  MESA_VAAPI="--disable-va"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-va=false"
 fi
 
-XA_CONFIG="--disable-xa"
-for drv in $GRAPHIC_DRIVERS; do
-  [ "$drv" = "vmware" ] && XA_CONFIG="--enable-xa"
-done
+if listcontains "$GRAPHIC_DRIVERS" "vmware"; then
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-xa=true"
+else
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-xa=false"
+fi
 
 if [ "$OPENGLES_SUPPORT" = "yes" ]; then
-  MESA_GLES="--disable-gles1 --enable-gles2"
+  PKG_MESON_OPTS_TARGET+=" -Dgles1=false -Dgles2=true"
 else
-  MESA_GLES="--disable-gles1 --disable-gles2"
+  PKG_MESON_OPTS_TARGET+=" -Dgles1=false -Dgles2=false"
 fi
-
-PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
-                           CXX_FOR_BUILD=$HOST_CXX \
-                           CFLAGS_FOR_BUILD= \
-                           CXXFLAGS_FOR_BUILD= \
-                           LDFLAGS_FOR_BUILD= \
-                           --disable-debug \
-                           --disable-mangling \
-                           --enable-texture-float \
-                           --enable-asm \
-                           --disable-selinux \
-                           $MESA_PLATFORMS \
-                           --disable-libunwind \
-                           --enable-opengl \
-                           $MESA_GLES \
-                           $MESA_DRI \
-                           $MESA_GLX \
-                           --disable-osmesa \
-                           --disable-gallium-osmesa \
-                           --enable-egl \
-                           $XA_CONFIG \
-                           --enable-gbm \
-                           --disable-nine \
-                           --disable-xvmc \
-                           $MESA_VDPAU \
-                           --disable-omx-bellagio \
-                           $MESA_VAAPI \
-                           --disable-opencl \
-                           --enable-opencl-icd \
-                           --disable-gallium-tests \
-                           --enable-shared-glapi \
-                           $MESA_GALLIUM_LLVM \
-                           --disable-silent-rules \
-                           --with-osmesa-lib-name=OSMesa \
-                           --with-gallium-drivers=$GALLIUM_DRIVERS \
-                           --with-dri-drivers=$DRI_DRIVERS \
-                           --with-vulkan-drivers=no \
-                           --with-sysroot=$SYSROOT_PREFIX"
 
 # Temporary workaround:
 # Listed libraries are static, while mesa expects shared ones. This breaks the

--- a/packages/graphics/mesa/patches/mesa-0001-only-build-vl-winsys-dri-with-x11.patch
+++ b/packages/graphics/mesa/patches/mesa-0001-only-build-vl-winsys-dri-with-x11.patch
@@ -1,0 +1,19 @@
+commit aebae9835f39d7925dfc71819bb31e8445e12a8f
+Author: Lukas Rusak <lorusak@gmail.com>
+Date:   Thu May 31 23:44:03 2018 -0700
+
+    meson: only build vl_winsys_dri.c when x11 platform is used
+
+diff --git a/src/gallium/auxiliary/meson.build b/src/gallium/auxiliary/meson.build
+index 584cbe4509..857001e12c 100644
+--- a/src/gallium/auxiliary/meson.build
++++ b/src/gallium/auxiliary/meson.build
+@@ -453,7 +453,7 @@ files_libgalliumvl = files(
+ )
+ 
+ files_libgalliumvlwinsys = files('vl/vl_winsys.h')
+-if with_dri2
++if with_dri2 and with_platform_x11
+   files_libgalliumvlwinsys += files('vl/vl_winsys_dri.c')
+   if with_dri3
+     files_libgalliumvlwinsys += files('vl/vl_winsys_dri3.c')

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -1,19 +1,20 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="llvm"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -50,7 +50,8 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_BUILD_LLVM_DYLIB=ON \
                        -DLLVM_LINK_LLVM_DYLIB=ON \
                        -DLLVM_OPTIMIZED_TABLEGEN=ON \
-                       -DLLVM_APPEND_VC_REV=OFF"
+                       -DLLVM_APPEND_VC_REV=OFF \
+                       -DLLVM_ENABLE_RTTI=ON"
 
 PKG_CMAKE_OPTS_HOST="$PKG_CMAKE_OPTS_COMMON \
                      -DCMAKE_INSTALL_RPATH=$TOOLCHAIN/lib"

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2018 Team LibreELEC
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="Mako"
+PKG_VERSION="1.0.7"
+PKG_SHA256="4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://pypi.org/project/Mako"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_HOST="Python2:host setuptools:host MarkupSafe:host"
+PKG_SECTION="python"
+PKG_SHORTDESC="Mako: A super-fast templating language that borrows the best ideas from the existing templating languages."
+PKG_LONGDESC="Mako is a super-fast templating language that borrows the best ideas from the existing templating languages."
+PKG_TOOLCHAIN="manual"
+
+makeinstall_host() {
+  python setup.py install --prefix=$TOOLCHAIN
+}

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -1,20 +1,20 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2018 Team LibreELEC
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
 #      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="Mako"

--- a/packages/python/devel/MarkupSafe/package.mk
+++ b/packages/python/devel/MarkupSafe/package.mk
@@ -1,20 +1,20 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2018 Team LibreELEC
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
 #      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="MarkupSafe"

--- a/packages/python/devel/MarkupSafe/package.mk
+++ b/packages/python/devel/MarkupSafe/package.mk
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2018 Team LibreELEC
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="MarkupSafe"
+PKG_VERSION="1.0"
+PKG_SHA256="a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://pypi.org/project/MarkupSafe/"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_HOST="Python2:host setuptools:host"
+PKG_SECTION="python"
+PKG_SHORTDESC="MarkupSafe: Implements a XML/HTML/XHTML Markup safe string for Python"
+PKG_LONGDESC="MarkupSafe implements a XML/HTML/XHTML Markup safe string for Python"
+PKG_TOOLCHAIN="manual"
+
+makeinstall_host() {
+  python setup.py install --prefix=$TOOLCHAIN
+}


### PR DESCRIPTION
This should be tested on all mesa platforms before merging. I only build tested for a couple platforms that I test with.

@evelikov would you mind having a look over?

I was forced to update to 18.1.0 because I couldn't enable EGL with only gallium drivers present in 18.0.x