### PR TITLE
scripts/image: add BUILDER_NAME, BUILDER_VERSION support

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -138,6 +138,8 @@ echo -e "BUILD_ID=\"$GIT_HASH\"" >> $INSTALL/etc/os-release
 echo -e "OPENELEC_ARCH=\"$LIBREELEC_ARCH\"" >> $INSTALL/etc/os-release
 echo -e "LIBREELEC_ARCH=\"$LIBREELEC_ARCH\"" >> $INSTALL/etc/os-release
 echo -e "LIBREELEC_BUILD=\"$LIBREELEC_BUILD\"" >> $INSTALL/etc/os-release
+[ -n "$BUILDER_NAME" ] && echo -e "BUILDER_NAME=\"$BUILDER_NAME\"" >> $INSTALL/etc/os-release
+[ -n "$BUILDER_VERSION" ] && echo -e "BUILDER_VERSION=\"$BUILDER_VERSION\"" >> $INSTALL/etc/os-release
 
 # create /etc/issue
 echo "$GREETING0" >  $INSTALL/etc/issue


### PR DESCRIPTION
Part of https://github.com/LibreELEC/service.libreelec.settings/pull/100 depends on this.

Updated: 
If `BUILDER_NAME` is present in `/etc/os-release`, eg. `BUILDER_NAME="Milhouse"`, this value will be included in the url when performing the update check, allowing stats to be aggregated by author.

If `BUILDER_VERSION` is present in `/etc/os-release`, eg. `BUILDER_VERSION=#0601`, this value will be included in the url instead of the normal `devel-20180601153228-g89fe123` version that would otherwise be used. This allows stats for the builder to be grouped by a version identifier they are more familiar with (or prefer to use). When using a custom `BUILDER_VERSION` it's important to include a unique `BUILDER_NAME` in order to differentiate build statistics with the same version identifier but from different builders.

I'll add the service.libreelec.settings add-on bump to this PR before merging.