### PR TITLE
device-tree-amlogic: add LePotato dts files to EXTRA_TREE

### DIFF
--- a/projects/Amlogic/packages/device-trees-amlogic/package.mk
+++ b/projects/Amlogic/packages/device-trees-amlogic/package.mk
@@ -30,7 +30,11 @@ make_target() {
   pushd $BUILD/linux-$(kernel_version) > /dev/null
 
   # Device trees already present in kernel tree we want to include
-  EXTRA_TREES=(gxbb_p201 gxl_p212_1g gxl_p212_2g gxm_q200_2g gxm_q201_1g gxm_q201_2g gxl_p281_1g gxbb_p200_1G_wetek_hub gxbb_p200_2G_wetek_play_2)
+  EXTRA_TREES=( \
+                gxbb_p201 gxbb_p200_1G_wetek_hub gxbb_p200_2G_wetek_play_2 \
+                gxl_p212_1g gxl_p212_2g gxl_p281_1g gxl_p212_1g_lepotato gxl_p212_2g_lepotato \
+                gxm_q200_2g gxm_q201_1g gxm_q201_2g \
+	      )
 
   # Add trees to the list
   for f in ${EXTRA_TREES[@]}; do


### PR DESCRIPTION
solves the problem to build `linux:target` for LePotato

clean build for LePotato was ok.