### PR TITLE
build: only use gnu-style hash table in binaries

### DIFF
--- a/config/optimize
+++ b/config/optimize
@@ -1,4 +1,5 @@
 GCC_OPTIM="-Os"
+# Linker hash-style is set to gnu via gcc default
 LD_OPTIM="-Wl,--as-needed"
 
 if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -41,6 +41,7 @@ GCC_COMMON_CONFIGURE_OPTS="--target=$TARGET_NAME \
                            --enable-lto \
                            --enable-gold \
                            --enable-ld=default \
+                           --with-linker-hash-style=gnu \
                            --disable-multilib \
                            --disable-nls \
                            --enable-checking=release \


### PR DESCRIPTION
Builds are currently creating both styles of hash table in the ELF
header. Only one style of table is necessary, and the GNU one is
more performant for lookups. Eliminating the SysV style hash table
trims ~450kb.

Note that if MIPS is ever added as a supported architecture, it
does not support hash-style=gnu at this time.

Compiled & tested for RPi3.

Signed-off-by: Ian Leonard <antonlacon@gmail.com>