### PR TITLE
soxr: don't create libavutil dependency on ARM

### DIFF
--- a/packages/audio/soxr/package.mk
+++ b/packages/audio/soxr/package.mk
@@ -32,4 +32,13 @@ PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_EXAMPLES=OFF \
                        -DBUILD_SHARED_LIBS=OFF \
-                       -DBUILD_TESTS=OFF"
+                       -DBUILD_TESTS=OFF \
+                       -DWITH_AVFFT=OFF"
+
+if [ "$TARGET_ARCH" = "arm" ]; then
+  if target_has_feature neon; then
+    PKG_CMAKE_OPTS_TARGET+=" -DWITH_CR32=OFF"
+  else
+    PKG_CMAKE_OPTS_TARGET+=" -DWITH_CR32S=OFF"
+  fi
+fi


### PR DESCRIPTION
This prevents soxr getting a dependency on libavutil/libavcodec
and fixes pulseaudio build failures on ARM.