### PR TITLE
glibc: choose minimum kernel based on packaged linux

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -44,7 +44,6 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --with-__thread \
                            --with-binutils=$BUILD/toolchain/bin \
                            --with-headers=$SYSROOT_PREFIX/usr/include \
-                           --enable-kernel=3.0.0 \
                            --without-cvs \
                            --without-gd \
                            --enable-obsolete-rpc \
@@ -53,6 +52,24 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --disable-nscd \
                            --enable-lock-elision \
                            --disable-timezone-tools"
+
+case $LINUX in
+  amlogic-3.10)
+    PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-kernel=3.10.0"
+    ;;
+  amlogic-3.14)
+    PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-kernel=3.14.0"
+    ;;
+  rockchip-4.4)
+    PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-kernel=4.4.0"
+    ;;
+  raspberrypi)
+    PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-kernel=4.14.0"
+    ;;
+  *)
+    PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-kernel=4.14.0"
+    ;;
+esac
 
 if build_with_debug; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-debug"


### PR DESCRIPTION
Updates glibc to the built linux to determine its minimum kernel to support. Alternatively, this line should be raised to 3.2 (glibc >=2.24 requires linux >=3.2 for arm).

Tested on a RPi3.