### PR TITLE
nss: drop supression of warnings

### DIFF
--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -80,7 +80,7 @@ make_target() {
      NSS_TESTS="dummy" \
      NSINSTALL=$TOOLCHAIN/bin/nsinstall \
      CPU_ARCH_TAG=$TARGET_ARCH \
-     CC=$CC XCFLAGS="-Wno-error=stringop-truncation -Wno-error=format-overflow" \
+     CC=$CC \
      LDFLAGS="$LDFLAGS -L$SYSROOT_PREFIX/usr/lib" \
      V=1
 }


### PR DESCRIPTION
- warnings added with gcc8 and not needed, after last update of nss

build test on RPi2