### PR TITLE
fix updating on android bootloader devices

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -46,8 +46,8 @@
 
   UPDATE_KERNEL="KERNEL"
   UPDATE_SYSTEM="SYSTEM"
-  IMAGE_KERNEL="/@KERNEL_NAME@"
-  IMAGE_SYSTEM="/SYSTEM"
+  IMAGE_KERNEL="@KERNEL_NAME@"
+  IMAGE_SYSTEM="SYSTEM"
 
   BOOT_STEP="start"
   MD5_FAILED="0"
@@ -477,7 +477,7 @@
     export BOOT_ROOT="/flash"
     export SYSTEM_ROOT="/sysroot"
 
-    mount_part "/flash$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+    mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
 
     if [ -f $SYSTEM_ROOT/usr/share/bootloader/update.sh ]; then
       StartProgress spinner "Updating Bootloader... "
@@ -922,7 +922,7 @@
 
     sync
 
-    if [ ! -b "$IMAGE_KERNEL" -a ! -f "/flash$IMAGE_KERNEL" ] || [ ! -f "/flash$IMAGE_SYSTEM" ]; then
+    if [ ! -b "$IMAGE_KERNEL" -a ! -f "/flash/$IMAGE_KERNEL" ] || [ ! -f "/flash/$IMAGE_SYSTEM" ]; then
       echo "Missing (target) ${IMAGE_KERNEL} or ${IMAGE_SYSTEM}!"
       do_cleanup
       StartProgress countdown "Normal startup in 30s... " 30 "NOW"
@@ -979,7 +979,7 @@
     # Verify that the new upgrade is compatible with the current system - this should avoid creating
     # non-booting systems after (for example) an RPi tar is incorrectly applied to an RPi2 system.
     if [ ! -f "$UPDATE_ROOT/.nocompat" ]; then
-      if ! check_is_compatible "$UPDATE_FILENAME" "/flash$IMAGE_SYSTEM" "$UPDATE_DIR/$UPDATE_SYSTEM"; then
+      if ! check_is_compatible "$UPDATE_FILENAME" "/flash/$IMAGE_SYSTEM" "$UPDATE_DIR/$UPDATE_SYSTEM"; then
         do_cleanup
         StartProgress countdown "Normal startup in 60s... " 60 "NOW"
         return 0
@@ -992,12 +992,12 @@
 
     # Disregard kernel size if it's a a block device, which is the case on Amlogic/WeTek devices
     if [ ! -b $IMAGE_KERNEL ]; then
-      OLD_KERNEL=$(stat -t "/flash$IMAGE_KERNEL" | awk '{print $2}')
+      OLD_KERNEL=$(stat -t "/flash/$IMAGE_KERNEL" | awk '{print $2}')
     else
       OLD_KERNEL="0"
     fi
 
-    OLD_SYSTEM=$(stat -t "/flash$IMAGE_SYSTEM" | awk '{print $2}')
+    OLD_SYSTEM=$(stat -t "/flash/$IMAGE_SYSTEM" | awk '{print $2}')
     NEW_KERNEL=$(stat -t "$UPDATE_DIR/$UPDATE_KERNEL" | awk '{print $2}')
     NEW_SYSTEM=$(stat -t "$UPDATE_DIR/$UPDATE_SYSTEM" | awk '{print $2}')
 
@@ -1028,9 +1028,9 @@
     if [ -b $IMAGE_KERNEL ]; then
       update_partition "Kernel" "$UPDATE_KERNEL" "$IMAGE_KERNEL"
     else
-      update_file "Kernel" "$UPDATE_KERNEL" "/flash$IMAGE_KERNEL"
+      update_file "Kernel" "$UPDATE_KERNEL" "/flash/$IMAGE_KERNEL"
     fi
-    update_file "System" "$UPDATE_SYSTEM" "/flash$IMAGE_SYSTEM"
+    update_file "System" "$UPDATE_SYSTEM" "/flash/$IMAGE_SYSTEM"
     update_bootloader
     do_cleanup
     do_reboot
@@ -1040,10 +1040,10 @@
     progress "Preparing system"
 
     if [ "$SYSTEM_TORAM" = "no" -o "$INSTALLED_MEMORY" -lt "$SYSTEM_TORAM_LIMIT" ]; then
-      mount_part "/flash$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+      mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
     else
-      cp /flash$IMAGE_SYSTEM /dev$IMAGE_SYSTEM
-      mount_part "/dev$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+      cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
+      mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
     fi
 
     mount --move /flash /sysroot/flash


### PR DESCRIPTION
This fixes updating on amlogic (Wetek) android bootloader devices.

the android bootloader hardcodes BOOT_IMAGE=kernel.img so we cannot add a leading `/` to it.

This change was really ugly anyways :smile: 