### PR TITLE
iptables: fix README for saving rules

### DIFF
--- a/packages/network/iptables/config/README
+++ b/packages/network/iptables/config/README
@@ -5,8 +5,8 @@ To create your own set of Netfilters you can save your rules in:
 
 To modify tables, edit with nano then save with:
 
-iptables-save /storage/.config/iptables/rules.v4
-ip6tables-save /storage/.config/iptables/rules.v6
+iptables-save >/storage/.config/iptables/rules.v4
+ip6tables-save >/storage/.config/iptables/rules.v6
 
 To disable iptables use the following command:
 


### PR DESCRIPTION
iptables-save and ip6tables-save dumps rules to stdout and not in file directly.