### PR TITLE
init: strip leading / from BOOT_IMAGE & DISK_IMAGE, normalising for all projects

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -92,9 +92,11 @@
     case $arg in
       BOOT_IMAGE=*)
         IMAGE_KERNEL="${arg#*=}"
+        [ "${IMAGE_KERNEL:0:1}" = "/" ] && IMAGE_KERNEL="${IMAGE_KERNEL:1}"
         ;;
       SYSTEM_IMAGE=*)
         IMAGE_SYSTEM="${arg#*=}"
+        [ "${IMAGE_SYSTEM:0:1}" = "/" ] && IMAGE_SYSTEM="${IMAGE_SYSTEM:1}"
         ;;
       boot=*)
         boot="${arg#*=}"
@@ -922,7 +924,7 @@
 
     sync
 
-    if [ ! -b "$IMAGE_KERNEL" -a ! -f "/flash/$IMAGE_KERNEL" ] || [ ! -f "/flash/$IMAGE_SYSTEM" ]; then
+    if [ ! -b "/$IMAGE_KERNEL" -a ! -f "/flash/$IMAGE_KERNEL" ] || [ ! -f "/flash/$IMAGE_SYSTEM" ]; then
       echo "Missing (target) ${IMAGE_KERNEL} or ${IMAGE_SYSTEM}!"
       do_cleanup
       StartProgress countdown "Normal startup in 30s... " 30 "NOW"
@@ -991,7 +993,7 @@
     FLASH_FREE=$(( $FLASH_FREE * 1024 ))
 
     # Disregard kernel size if it's a a block device, which is the case on Amlogic/WeTek devices
-    if [ ! -b $IMAGE_KERNEL ]; then
+    if [ ! -b "/$IMAGE_KERNEL" ]; then
       OLD_KERNEL=$(stat -t "/flash/$IMAGE_KERNEL" | awk '{print $2}')
     else
       OLD_KERNEL="0"
@@ -1025,8 +1027,8 @@
     fi
 
     # all ok, update
-    if [ -b $IMAGE_KERNEL ]; then
-      update_partition "Kernel" "$UPDATE_KERNEL" "$IMAGE_KERNEL"
+    if [ -b "/$IMAGE_KERNEL" ]; then
+      update_partition "Kernel" "$UPDATE_KERNEL" "/$IMAGE_KERNEL"
     else
       update_file "Kernel" "$UPDATE_KERNEL" "/flash/$IMAGE_KERNEL"
     fi


### PR DESCRIPTION
Better fix for #2767 

Some systems, eg. Amlogic, use BOOT_IMAGE=kernel.img, while others (eg. Generic,
Rockchip, RPi) will use (or have used) BOOT_IMAGE=/KERNEL or BOOT_IMAGE=/kernel.img. We could change this in new installations but we still have to support legacy installations that are upgrading, so we'll always have a mixture of with-slash and without-slash regardless of what we do with BOOT_IMAGE from here onwards.

With this change we no longer care whether the leading / is specified - both forms should now work reliably.

Since the original change (https://github.com/LibreELEC/LibreELEC.tv/pull/2689/commits/01a87ad78870f81c41c876959e803e970cb014a1) broke Amlogic, upgrades, can an Amlogic builder confirm this PR now restores normal upgrade functionality before we merge this.