### PR TITLE
ntfs-3g_ntfsprogs: fix mount problem caused by Windows 10 Creators Update

### DIFF
--- a/packages/sysutils/ntfs-3g_ntfsprogs/patches/ntfs-3g_ntfsprogs-001-fix-mounting-after-Win10-Creators-Update.patch
+++ b/packages/sysutils/ntfs-3g_ntfsprogs/patches/ntfs-3g_ntfsprogs-001-fix-mounting-after-Win10-Creators-Update.patch
@@ -1,0 +1,28 @@
+From 801c894b3723ed6345982e0105b342ec119f81ee Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Sat, 16 Jun 2018 15:38:06 +0100
+Subject: [PATCH] Fix for NTFS partitions mounted with Windows 10 Creators
+ Update
+
+See: https://bugzilla.redhat.com/show_bug.cgi?id=1527231
+---
+ libntfs-3g/volume.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libntfs-3g/volume.c b/libntfs-3g/volume.c
+index 68b8ee1..d36c7d5 100644
+--- a/libntfs-3g/volume.c
++++ b/libntfs-3g/volume.c
+@@ -959,7 +959,8 @@ ntfs_volume *ntfs_device_mount(struct ntfs_device *dev, ntfs_mount_flags flags)
+ 		vol->mftmirr_size = l;
+ 	}
+ 	ntfs_log_debug("Comparing $MFTMirr to $MFT...\n");
+-	for (i = 0; i < vol->mftmirr_size; ++i) {
++		/* Windows 10 does not update the full $MFTMirr any more */
++	for (i = 0; (i < vol->mftmirr_size) && (i < FILE_first_user); ++i) {
+ 		MFT_RECORD *mrec, *mrec2;
+ 		const char *ESTR[12] = { "$MFT", "$MFTMirr", "$LogFile",
+ 			"$Volume", "$AttrDef", "root directory", "$Bitmap",
+-- 
+2.14.1
+


### PR DESCRIPTION
See forum: https://forum.libreelec.tv/thread/10888-external-hard-drives-no-longer-mount/?postID=94104#post94104