### PR TITLE
xf86-video-intel: update to xf86-video-intel-3d39506, add libdrm depe…

### DIFF
--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -18,14 +18,14 @@
 ################################################################################
 
 PKG_NAME="xf86-video-intel"
-PKG_VERSION="26f5406"
-PKG_SHA256="8393ec70f45e9a243de7e6d085b1fa02aa3933c8ac9c72ccd83ce2d890052a5d"
+PKG_VERSION="3d39506"
+PKG_SHA256="cfc7287fcb38028a68ffd7677032db0882c02112ad24038ee936de854761e8b3"
 PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="http://intellinuxgraphics.org/"
 PKG_URL="https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/$PKG_VERSION.tar.xz"
 PKG_SOURCE_DIR="$PKG_VERSION"
-PKG_DEPENDS_TARGET="toolchain libXcomposite libXxf86vm libXdamage util-macros systemd xorg-server"
+PKG_DEPENDS_TARGET="toolchain libXcomposite libXxf86vm libXdamage libdrm util-macros systemd xorg-server"
 PKG_SECTION="x11/driver"
 PKG_SHORTDESC="xf86-video-intel: The Xorg driver for Intel video chips"
 PKG_LONGDESC="The Xorg driver for Intel i810, i815, 830M, 845G, 852GM, 855GM, 865G, 915G, 915GM and 965G video chips."


### PR DESCRIPTION
…ndency

libdrm change: https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/commit/?id=3d395062ce73f85e8340218df01c2ebf4bc25023