### PR TITLE
dash: add package, configure as default CONFIG_SHELL [RFC]

### DIFF
--- a/config/path
+++ b/config/path
@@ -37,6 +37,8 @@ SYSROOT_PREFIX=$TOOLCHAIN/$TARGET_NAME/sysroot
 LIB_PREFIX=$SYSROOT_PREFIX/usr
 TARGET_PREFIX=$TOOLCHAIN/bin/$TARGET_NAME-
 
+[ -z "$CONFIG_SHELL" -a -x $TOOLCHAIN/bin/dash ] && export CONFIG_SHELL=$TOOLCHAIN/bin/dash
+
 # use linaro toolchain on 64/32 split builds
 if [ -z "$TARGET_KERNEL_RELATIVE_PREFIX" ]; then
   if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then

--- a/config/show_config
+++ b/config/show_config
@@ -104,6 +104,7 @@ show_config() {
 
   config_message="$config_message\n - OEM Support:\t\t\t\t $OEM_SUPPORT"
   config_message="$config_message\n - Default ROOT Password:\t\t $ROOT_PASSWORD"
+  config_message="$config_message\n - CONFIG_SHELL:\t\t\t $CONFIG_SHELL"
   config_message="$config_message\n - Bootloader:\t\t\t\t $BOOTLOADER"
   if [ "$BOOTLOADER" = "u-boot" ]; then
     config_message="$config_message\n   - U-Boot configuration:\t\t $UBOOT_CONFIG"

--- a/packages/lang/dash/package.mk
+++ b/packages/lang/dash/package.mk
@@ -1,7 +1,6 @@
 ################################################################################
 #      This file is part of LibreELEC - https://libreelec.tv
 #      Copyright (C) 2018-present Team LibreELEC
-#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
 #  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,13 +16,19 @@
 #  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-PKG_NAME="toolchain"
-PKG_VERSION=""
+PKG_NAME="dash"
+PKG_VERSION="0.5.10.2"
+PKG_SHA256="c34e1259c4179a6551dc3ceb41c668cf3be0135c5ec430deb2edfc17fff44da9"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="https://libreelec.tv"
-PKG_URL=""
-PKG_DEPENDS_TARGET="configtools:host make:host xz:host sed:host pkg-config:host autoconf:host automake:host dash:host intltool:host libtool:host autoconf-archive:host gcc:host bison:host flex:host cmake:host xmlstarlet:host yasm:host p7zip:host ninja:host meson:host"
-PKG_SECTION="virtual"
-PKG_SHORTDESC="toolchain: LibreELEC.tv' toolchain"
-PKG_LONGDESC="a crosscompiling toolchain to compile all packages"
+PKG_SITE="http://gondor.apana.org.au/~herbert/dash/"
+PKG_URL="https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_HOST=""
+PKG_SECTION="lang"
+PKG_SHORTDESC="dash: Debian Almquist shell"
+PKG_LONGDESC="DASH is a POSIX-compliant implementation of /bin/sh that aims to be as small as possible. It does this without sacrificing speed where possible. In fact, it is significantly faster than bash (the GNU Bourne-Again SHell) for most tasks."
+PKG_TOOLCHAIN="configure"
+
+pre_configure_host() {
+  $PKG_BUILD/autogen.sh
+}


### PR DESCRIPTION
This has been discussed on Slack, so I did some investigating (prompted by @cvh) to see what the actual benefit is using `dash`, this PR is mainly to document those results assuming this isn't accepted/merged.

----

This PR adds the `dash` package to the toolchain, and uses it during `configure` by adding `CONFIG_SHELL=$TOOLCHAIN/bin/dash` (unless another shell is already set).

I ran some test builds on an 8-core 4GHz Intel machine, Ubuntu 16.04.

The default system shell for Ubuntu is `/bin/dash` 0.58.2, but the default user shell is `/bin/bash`, so by default `configure` will use `/bin/bash` not `/bin/dash`.

@cvh determined there is a performance improvement in `dash` 0.5.10.2 compared with 0.5.8-2, so I've included timings for the stock `/bin/dash` and `/bin/bash`.

Build times with/without `$TOOLCHAIN/bin/dash` configured as `CONFIG_SHELL`:

#### Generic:

| secs | hms | config |
| ---- | ----- | ------ |
| 7848 | 02:10:48 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 7644 | 02:07:24 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 7848 | 02:10:48 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 7503 | 02:05:03 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 7690 | 02:08:10 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 7706 | 02:08:26 | AVERAGE |

| secs | hms | config |
| ---- | ----- | ------ |
| 8351 | 02:19:11 | `CONFIG_SHELL=` |
| 8174 | 02:16:14 | `CONFIG_SHELL=` |
| 8247 | 02:17:27 | `CONFIG_SHELL=` |
| 8304 | 02:18:24 | `CONFIG_SHELL=` |
| 8354 | 02:19:14 | `CONFIG_SHELL=` |
| 8286 | 02:18:06 | AVERAGE |

#### RPi2:

| secs | hms | config |
| ---- | ----- | ------ |
| 5098 | 01:24:58 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 5086 | 01:24:46 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 5131 | 01:25:31 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 5163 | 01:26:03 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 5296 | 01:28:16 | `CONFIG_SHELL=$TOOLCHAIN/bin/dash` |
| 5154 | 01:25:54 | AVERAGE  |

| secs | hms | config |
| ---- | ----- | ------ |
| 5338 | 01:28:58 | `CONFIG_SHELL=` |
| 5393 | 01:29:53 | `CONFIG_SHELL=` |
| 5576 | 01:32:56 | `CONFIG_SHELL=` |
| 5416 | 01:30:16 | `CONFIG_SHELL=` |
| 5327 | 01:28:47 | `CONFIG_SHELL=` |
| 5410 | 01:30:10 | AVERAGE    |

With `CONFIG_SHELL=/bin/bash` (RPi2):

| secs | hms | config |
| ---- | ----- | ------ |
| 5466 | 01:31:06 | `CONFIG_SHELL=/bin/bash` |
| 5654 | 01:34:14 | `CONFIG_SHELL=/bin/bash` |
| 5662 | 01:34:22 | `CONFIG_SHELL=/bin/bash` |
| 5763 | 01:36:03 | `CONFIG_SHELL=/bin/bash` |
| 5342 | 01:29:02 | `CONFIG_SHELL=/bin/bash` |
| 5577 | 01:32:57 | AVERAGE  |

With `CONFIG_SHELL=/bin/dash` (RPi2):

| secs | hms | config |
| ---- | ----- | ------ |
| 5138 | 01:25:38 | `CONFIG_SHELL=/bin/dash` |
| 5189 | 01:26:29 | `CONFIG_SHELL=/bin/dash` |
| 5157 | 01:25:57 | `CONFIG_SHELL=/bin/dash` |
| 5140 | 01:25:40 | `CONFIG_SHELL=/bin/dash` |
| 5198 | 01:26:38 | `CONFIG_SHELL=/bin/dash` |
| 5164 | 01:26:04 | AVERAGE  |

Relative improvement compared with default `CONFIG_SHELL=` (negative is slower):

| secs | hms | config |
| ---- | ----- | ------ |
| 580 | 00:09:40 | x86, `$TOOLCHAIN/bin/dash`, v0.5.10.2 |
| 256 | 00:04:16 | pi2, `$TOOLCHAIN/bin/dash`, v0.5.10.2 |
|-167 |-00:02:47 | pi2, `/bin/bash`, v4.3-14 |
| 246 | 00:04:06 | pi2, `/bin/dash`, v0.5.8-2 |

#### Conclusion

From the above we can see that `/bin/bash` is slower than `/bin/dash`

`dash` version 0.5.8-2 is a little slower than 0.5.10.2.

I'm not sure what shell Ubuntu is using when `CONFIG_SHELL` is not configured - it doesn't appear to be `/bin/dash` or `/bin/bash`. Maybe it's a combination of both.


The improvement in build times when using `dash` is not particularly significant, but still quite good for what is a trivial change (`dash` itself takes a few seconds to build). On a slower machine the difference may be more pronounced.

In addition, this change gives us predictability in terms of which shell is used during `configure` rather than use the host system default which could be `sh`, `dash`, `bash` or whatever. This may be more relevant on non-Ubuntu systems that don't sym link `/bin/sh` to `/bin/dash`.
