### PR TITLE
libbluray: bump to 1.0.2

### DIFF
--- a/packages/multimedia/libbluray/package.mk
+++ b/packages/multimedia/libbluray/package.mk
@@ -1,26 +1,27 @@
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
 #      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 PKG_NAME="libbluray"
-PKG_VERSION="1.0.1"
-PKG_SHA256="0f9f9a1db2f48cafc70ed2596ff3594b597e2027408f5f2be6191c245d67853a"
+PKG_VERSION="1.0.2"
+PKG_SHA256="6d9e7c4e416f664c330d9fa5a05ad79a3fb39b95adfc3fd6910cbed503b7aeff"
 PKG_ARCH="any"
-PKG_LICENSE="GPL"
+PKG_LICENSE="LGPL"
 PKG_SITE="https://www.videolan.org/developers/libbluray.html"
 PKG_URL="https://ftp.videolan.org/pub/videolan/libbluray/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain fontconfig freetype libxml2"

--- a/packages/multimedia/libbluray/patches/libbluray-01-bump_to_Nevcairiel_vL20170904.patch
+++ b/packages/multimedia/libbluray/patches/libbluray-01-bump_to_Nevcairiel_vL20170904.patch
@@ -1,200 +1,230 @@
 diff --git a/Makefile.am b/Makefile.am
-index 33813b07..d7b909c4 100644
+index 04365fd..ff15527 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -210,6 +210,15 @@ noinst_HEADERS = \
- 	jni/win32/jni_md.h \
- 	jni/darwin/jni_md.h
+@@ -1,10 +1,15 @@
+ include $(top_srcdir)/doxygen-include.am
  
-+
-+bdnavdir=$(pkgincludedir)/bdnav
-+bdnav_HEADERS = \
-+	src/libbluray/bdnav/clpi_data.h
-+
-+utildir=$(pkgincludedir)/../util
-+util_HEADERS = \
-+	src/util/attributes.h
-+
- pkginclude_HEADERS = \
- 	src/file/filesystem.h \
- 	src/libbluray/bluray.h \
-@@ -217,6 +226,10 @@ pkginclude_HEADERS = \
- 	src/libbluray/keys.h \
- 	src/libbluray/player_settings.h \
- 	src/libbluray/bdnav/clpi_data.h \
-+	src/libbluray/bdnav/clpi_parse.h \
-+	src/libbluray/bdnav/mpls_parse.h \
-+	src/libbluray/bdnav/mpls_data.h \
-+	src/libbluray/bdnav/uo_mask_table.h \
- 	src/libbluray/bdnav/meta_data.h \
+ ACLOCAL_AMFLAGS = -I m4
++DISTCHECK_CONFIGURE_FLAGS = --enable-bdjava --enable-udf
+ 
+ MOSTLYCLEANFILES = $(DX_CLEANFILES)
+ 
++if ENABLE_UDF
+ POSIX_C_SOURCE=200809L
++else
++POSIX_C_SOURCE=200112L
++endif
+ 
+ EXTRA_DIST = \
+ 	bootstrap \
+@@ -35,7 +40,7 @@ libbluray_la_CPPFLAGS = \
+ 	$(AM_CPPFLAGS) \
+ 	-I$(top_builddir)/src/libbluray \
+ 	$(BDJAVA_CFLAGS) \
+-	-I${top_srcdir}/contrib/libudfread/src/ \
++	$(UDF_CFLAGS) \
+ 	$(LIBXML2_CFLAGS) \
+ 	$(FT2_CFLAGS) \
+ 	$(FONTCONFIG_CFLAGS)
+@@ -166,6 +171,7 @@ libbluray_la_SOURCES += \
+ 	src/libbluray/bdj/native/util.c
+ 
+ # libudfread
++if ENABLE_UDF
+ libbluray_la_SOURCES += \
+ 	src/libbluray/disc/udf_fs.h \
+ 	src/libbluray/disc/udf_fs.c\
+@@ -177,6 +183,7 @@ libbluray_la_SOURCES += \
+ 	contrib/libudfread/src/ecma167.c \
+ 	contrib/libudfread/src/udfread.h \
+ 	contrib/libudfread/src/udfread.c
++endif
+ 
+ if HAVE_DARWIN
+ libbluray_la_SOURCES+= \
+@@ -223,7 +230,7 @@ pkginclude_HEADERS = \
  	src/libbluray/decoders/overlay.h \
  	src/util/log_control.h
-diff --git a/config.h b/config.h
-new file mode 100644
-index 00000000..bd39268a
---- /dev/null
-+++ b/config.h
-@@ -0,0 +1,157 @@
-+/* config.h.  Generated from config.h.in by configure.  */
-+/* config.h.in.  Generated from configure.ac by autoheader.  */
+ 
+-
++if USING_BDJAVA
+ if USING_BDJAVA_BUILD_JAR
+ jardir=$(datadir)/java/
+ jar_DATA=$(top_builddir)/.libs/libbluray-$(BDJ_TYPE)-$(VERSION).jar
+@@ -245,6 +252,7 @@ clean-local:
+ 	    -Dversion='$(BDJ_TYPE)-$(VERSION)' \
+ 	    clean
+ endif
++endif
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = src/libbluray.pc
+@@ -257,7 +265,6 @@ pkgconfig_DATA = src/libbluray.pc
+ if USING_EXAMPLES
+ 
+ noinst_PROGRAMS = \
+-	bdj_test \
+ 	bdjo_dump \
+ 	bdsplice \
+ 	clpi_dump \
+@@ -269,6 +276,11 @@ noinst_PROGRAMS = \
+ 	mpls_dump \
+ 	sound_dump
+ 
++if USING_BDJAVA
++noinst_PROGRAMS += \
++	bdj_test
++endif
 +
-+/* Define to 1 if libudfread is to be used for disc image access */
-+/* #undef ENABLE_UDF */
+ bin_PROGRAMS = \
+ 	bd_info
+ 
+diff --git a/configure.ac b/configure.ac
+index 5fd3c8d..15f53ca 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -81,6 +81,16 @@ AC_ARG_ENABLE([examples],
+   [use_examples=$enableval],
+   [use_examples=yes])
+ 
++AC_ARG_ENABLE([bdjava],
++  [AS_HELP_STRING([--disable-bdjava], [disable BD-Java support @<:@default=enabled@:>@])],
++  [use_bdjava=$enableval],
++  [use_bdjava=yes])
 +
-+/* Define to 1 if using libbluray J2ME stack */
-+/* #undef HAVE_BDJ_J2ME */
++AC_ARG_ENABLE([udf],
++  [AS_HELP_STRING([--disable-udf], [disable UDF support @<:@default=enabled@:>@])],
++  [enable_udf=$enableval],
++  [enable_udf=yes])
 +
-+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
-+   */
-+/* #undef HAVE_DIRENT_H */
+ AC_ARG_ENABLE([bdjava-jar],
+   [AS_HELP_STRING([--disable-bdjava-jar],
+   [disable building of BD-Java JAR file @<:@default=enabled@:>@])],
+@@ -196,23 +206,24 @@ dnl use examples
+ AM_CONDITIONAL([USING_EXAMPLES], [ test $use_examples = "yes" ])
+ 
+ dnl use bdjava
+-case $host_cpu in
+-     x86_64) java_arch=amd64 ;;
+-     i?86)   java_arch=i386 ;;
+-     arm*)   java_arch=arm ;;
+-     *)      java_arch=$host_cpu ;;
+-esac
+-case $host_os in
+-     linux*)   java_os=linux ;;
+-     win*)     java_os=win32 ;;
+-     mingw*)   java_os=win32 ;;
+-     freebsd*) java_os=freebsd ;;
+-     solaris*) java_os=solaris ;;
+-     darwin*)  java_os=darwin ;;
+-     *)        java_os=$host_os ;;
+-esac
+-
+-AS_IF([test "x${JDK_HOME}" != "x"], [
++if [[ $use_bdjava = "yes" ]]; then
++  case $host_cpu in
++       x86_64) java_arch=amd64 ;;
++       i?86)   java_arch=i386 ;;
++       arm*)   java_arch=arm ;;
++       *)      java_arch=$host_cpu ;;
++  esac
++  case $host_os in
++       linux*)   java_os=linux ;;
++       win*)     java_os=win32 ;;
++       mingw*)   java_os=win32 ;;
++       freebsd*) java_os=freebsd ;;
++       solaris*) java_os=solaris ;;
++       darwin*)  java_os=darwin ;;
++       *)        java_os=$host_os ;;
++  esac
 +
-+/* Define to 1 if you have the <dlfcn.h> header file. */
-+/* #undef HAVE_DLFCN_H */
++  AS_IF([test "x${JDK_HOME}" != "x"], [
+     BDJAVA_CFLAGS="-I${JDK_HOME}/include -I${JDK_HOME}/include/$java_os"
+ 
+     temp_CPPFLAGS="$CPPFLAGS"
+@@ -223,13 +234,16 @@ AS_IF([test "x${JDK_HOME}" != "x"], [
+     BDJAVA_CFLAGS='-I${abs_top_srcdir}/jni -I${abs_top_srcdir}/jni/'"${java_os}"
+ ])
+ 
+-AC_CHECK_PROG(HAVE_ANT, [ant], yes, no)
+-if test "x$use_bdjava_jar" = "xyes" && test "x$HAVE_ANT" = "xno"; then
+-    AC_MSG_ERROR([BD-J requires ANT, but ant was not found. Please install it.])
+-fi
++  AC_CHECK_PROG(HAVE_ANT, [ant], yes, no)
++  if test "x$use_bdjava_jar" = "xyes" && test "x$HAVE_ANT" = "xno"; then
++      AC_MSG_ERROR([BD-J requires ANT, but ant was not found. Please install it.])
++  fi
+ 
+-AC_DEFINE_UNQUOTED([JAVA_ARCH], ["$java_arch"], ["Defines the architecture of the java vm."])
+-AC_DEFINE_UNQUOTED([JDK_HOME], ["$JDK_HOME"], [""])
++  AC_DEFINE([USING_BDJAVA], [1], ["Define to 1 if using BD-Java"])
++  AC_DEFINE_UNQUOTED([JAVA_ARCH], ["$java_arch"], ["Defines the architecture of the java vm."])
++  AC_DEFINE_UNQUOTED([JDK_HOME], ["$JDK_HOME"], [""])
++fi
++AM_CONDITIONAL([USING_BDJAVA], [ test $use_bdjava = "yes" ])
+ AM_CONDITIONAL([USING_BDJAVA_BUILD_JAR], [ test $use_bdjava_jar = "yes" ])
+ 
+ dnl BD-J type
+@@ -243,13 +257,22 @@ dnl bootclasspath
+ AC_SUBST(BDJ_BOOTCLASSPATH)
+ 
+ dnl udf support (using git submodule)
+-if test ! -f "${srcdir}/contrib/libudfread/src/udfread.h"; then
+-    AC_MSG_ERROR("libudfread source tree not found")
+-fi
+-AC_CHECK_HEADERS([unistd.h fcntl.h])
+-AS_IF([test "${SYS}" != "mingw32"], [
+-    AC_CHECK_FUNC([pread],, [AC_DEFINE([NEED_PREAD_IMPL], [1], [Define to 1 to use inefficient pread() replacement])])
+-])
++AS_IF([test "x$enable_udf" = "xyes"], [
++    if test ! -f "${srcdir}/contrib/libudfread/src/udfread.h"; then
++        AC_MSG_ERROR("libudfread source tree not found")
++    fi
++    AC_CHECK_HEADERS([unistd.h fcntl.h])
++    AS_IF([test "${SYS}" != "mingw32"], [
++      AC_CHECK_FUNC([pread],, [AC_MSG_ERROR("Function pread not found. Try with --disable-udf.")])
++    ])
 +
-+/* Define to 1 if you have the <errno.h> header file. */
-+#define HAVE_ERRNO_H 1
++    AC_DEFINE([ENABLE_UDF], [1], [Define to 1 if libudfread is to be used for disc image access])
++    UDF_CFLAGS='-I${srcdir}/contrib/libudfread/src/'
++    AC_SUBST(UDF_CFLAGS)
++    ],
++  [enable_udf=no])
 +
-+/* Define to 1 if you have the <fcntl.h> header file. */
-+/* #undef HAVE_FCNTL_H */
-+
-+/* Define this if you have fontconfig library */
-+/* #undef HAVE_FONTCONFIG */
-+
-+/* Define this if you have FreeType2 library */
-+/* #undef HAVE_FT2 */
-+
-+/* Define to 1 if you have the <inttypes.h> header file. */
-+#define HAVE_INTTYPES_H 1
-+
-+/* Define to 1 if you have the <jni.h> header file. */
-+/* #undef HAVE_JNI_H */
-+
-+/* Define to 1 if you have the <libgen.h> header file. */
-+#define HAVE_LIBGEN_H 1
-+
-+/* Define to 1 if libxml2 is to be used for metadata parsing */
-+/* #undef HAVE_LIBXML2 */
-+
-+/* Define to 1 if you have the <linux/cdrom.h> header file. */
-+/* #undef HAVE_LINUX_CDROM_H */
-+
-+/* Define to 1 if you have the <malloc.h> header file. */
-+#define HAVE_MALLOC_H 1
-+
-+/* Define to 1 if you have the <memory.h> header file. */
-+#define HAVE_MEMORY_H 1
-+
-+/* Define to 1 if you have the <mntent.h> header file. */
-+/* #undef HAVE_MNTENT_H */
-+
-+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
-+/* #undef HAVE_NDIR_H */
-+
-+/* Define to 1 if you have the <pthread.h> header file. */
-+/* #undef HAVE_PTHREAD_H */
-+
-+/* Define to 1 if you have the <stdarg.h> header file. */
-+#define HAVE_STDARG_H 1
-+
-+/* Define to 1 if you have the <stdint.h> header file. */
-+#define HAVE_STDINT_H 1
-+
-+/* Define to 1 if you have the <stdlib.h> header file. */
-+#define HAVE_STDLIB_H 1
-+
-+/* Define to 1 if you have the <strings.h> header file. */
-+/* #undef HAVE_STRINGS_H */
-+
-+/* Define to 1 if you have the <string.h> header file. */
-+#define HAVE_STRING_H 1
-+
-+/* Define to 1 if `d_type' is a member of `struct dirent'. */
-+/* #undef HAVE_STRUCT_DIRENT_D_TYPE */
-+
-+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
-+   */
-+/* #undef HAVE_SYS_DIR_H */
-+
-+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
-+   */
-+/* #undef HAVE_SYS_NDIR_H */
-+
-+/* Define to 1 if you have the <sys/stat.h> header file. */
-+#define HAVE_SYS_STAT_H 1
-+
-+/* Define to 1 if you have the <sys/time.h> header file. */
-+#define HAVE_SYS_TIME_H 1
-+
-+/* Define to 1 if you have the <sys/types.h> header file. */
-+#define HAVE_SYS_TYPES_H 1
-+
-+/* Define to 1 if you have the <time.h> header file. */
-+#define HAVE_TIME_H 1
-+
-+/* Define to 1 if you have the <unistd.h> header file. */
-+/* #undef HAVE_UNISTD_H */
-+
-+/* "Defines the architecture of the java vm." */
-+/* #undef JAVA_ARCH */
-+
-+/* "" */
-+/* #undef JDK_HOME */
-+
-+/* Define to the sub-directory where libtool stores uninstalled libraries. */
-+#define LT_OBJDIR ".libs/"
-+
-+/* Name of package */
-+#define PACKAGE "libbluray"
-+
-+/* Define to the address where bug reports for this package should be sent. */
-+#define PACKAGE_BUGREPORT "http://www.videolan.org/developers/libbluray.html"
-+
-+/* Define to the full name of this package. */
-+#define PACKAGE_NAME "libbluray"
-+
-+/* Define to the full name and version of this package. */
-+#define PACKAGE_STRING "libbluray 1.0.0"
-+
-+/* Define to the one symbol short name of this package. */
-+#define PACKAGE_TARNAME "libbluray"
-+
-+/* Define to the home page for this package. */
-+#define PACKAGE_URL ""
-+
-+/* Define to the version of this package. */
-+#define PACKAGE_VERSION "1.0.0"
-+
-+/* Define as the return type of signal handlers (`int' or `void'). */
-+#define RETSIGTYPE void
-+
-+/* Define to 1 if you have the ANSI C header files. */
-+#define STDC_HEADERS 1
-+
-+/* "Define to 1 if using BD-Java" */
-+/* #undef USING_BDJAVA */
-+
-+/* Version number of package */
-+#define VERSION "1.0.0"
-+
-+/* Enable large inode numbers on Mac OS X 10.5.  */
-+#ifndef _DARWIN_USE_64_BIT_INODE
-+# define _DARWIN_USE_64_BIT_INODE 1
-+#endif
-+
-+/* Number of bits in a file offset, on hosts where this is settable. */
-+#define _FILE_OFFSET_BITS 64
-+
-+/* Define for large files, on AIX-style hosts. */
-+/* #undef _LARGE_FILES */
-+
-+/* Define to '0x0501' for IE 5.01. */
-+#define _WIN32_IE 0x0501
-+
-+/* Define to '0x0502' for Windows XP SP2 APIs. */
-+#define _WIN32_WINNT 0x0502
++AM_CONDITIONAL([ENABLE_UDF], [test $enable_udf = "yes" ])
+ 
+ dnl generate documentation
+ DX_INIT_DOXYGEN(libbluray, doc/doxygen-config, [doc/doxygen])
+@@ -279,19 +302,25 @@ dnl ---------------------------------------------
+ 
+ echo "  Summary:"
+ echo "  --------"
++echo "  BD-J support:                  $use_bdjava"
++if [[ $use_bdjava = "yes" ]]; then
+ echo "  BD-J type:                     $BDJ_TYPE"
+ echo "  build JAR:                     $use_bdjava_jar"
+ if test x"$BDJ_BOOTCLASSPATH" != x""; then
+ echo "  BD-J bootclasspath:            $BDJ_BOOTCLASSPATH"
+ fi
++fi
+ echo "  Font support (freetype2):      $with_freetype"
+ if [[ $with_freetype = "yes" ]]; then
++if [[ $use_bdjava = "yes" ]]; then
+ if test "${SYS}" != "mingw32"; then
+ echo "  Use system fonts (fontconfig): $with_fontconfig"
+ else
+ echo "  Use system fonts:              yes"
+ fi
+ fi
++fi
+ echo "  Metadata support (libxml2):    $with_libxml2"
++echo "  UDF filesystem support:        $enable_udf"
+ echo "  Build examples:                $use_examples"
+ 
 diff --git a/includes/inttypes.h b/includes/inttypes.h
 new file mode 100644
-index 00000000..ead903f7
+index 0000000..ead903f
 --- /dev/null
 +++ b/includes/inttypes.h
 @@ -0,0 +1,305 @@
@@ -505,7 +535,7 @@ index 00000000..ead903f7
 +#endif // _MSC_INTTYPES_H_ ]
 diff --git a/libbluray.def b/libbluray.def
 new file mode 100644
-index 00000000..d4c93cb9
+index 0000000..d4c93cb
 --- /dev/null
 +++ b/libbluray.def
 @@ -0,0 +1,63 @@
@@ -574,10 +604,10 @@ index 00000000..d4c93cb9
 +                bd_get_debug_mask
 diff --git a/libbluray.vcxproj b/libbluray.vcxproj
 new file mode 100644
-index 00000000..393cd1a0
+index 0000000..6de7ad2
 --- /dev/null
 +++ b/libbluray.vcxproj
-@@ -0,0 +1,236 @@
+@@ -0,0 +1,241 @@
 +﻿<?xml version="1.0" encoding="utf-8"?>
 +<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 +  <ItemGroup Label="ProjectConfigurations">
@@ -613,6 +643,7 @@ index 00000000..393cd1a0
 +    <ClInclude Include="src\file\filesystem.h" />
 +    <ClInclude Include="src\file\mount.h" />
 +    <ClInclude Include="src\libbluray\bdnav\bdid_parse.h" />
++    <ClInclude Include="src\libbluray\bdnav\bdmv_parse.h" />
 +    <ClInclude Include="src\libbluray\bdnav\bdparse.h" />
 +    <ClInclude Include="src\libbluray\bdnav\clpi_data.h" />
 +    <ClInclude Include="src\libbluray\bdnav\clpi_parse.h" />
@@ -623,6 +654,7 @@ index 00000000..393cd1a0
 +    <ClInclude Include="src\libbluray\bdnav\mpls_parse.h" />
 +    <ClInclude Include="src\libbluray\bdnav\navigation.h" />
 +    <ClInclude Include="src\libbluray\bdnav\sound_parse.h" />
++    <ClInclude Include="src\libbluray\bdnav\uo_mask.h" />
 +    <ClInclude Include="src\libbluray\bdnav\uo_mask_table.h" />
 +    <ClInclude Include="src\libbluray\bluray-version.h" />
 +    <ClInclude Include="src\libbluray\bluray.h" />
@@ -646,6 +678,7 @@ index 00000000..393cd1a0
 +    <ClInclude Include="src\libbluray\disc\dec.h" />
 +    <ClInclude Include="src\libbluray\disc\disc.h" />
 +    <ClInclude Include="src\libbluray\disc\enc_info.h" />
++    <ClInclude Include="src\libbluray\disc\properties.h" />
 +    <ClInclude Include="src\libbluray\hdmv\hdmv_insn.h" />
 +    <ClInclude Include="src\libbluray\hdmv\hdmv_vm.h" />
 +    <ClInclude Include="src\libbluray\hdmv\mobj_parse.h" />
@@ -672,6 +705,7 @@ index 00000000..393cd1a0
 +    <ClCompile Include="src\file\file_win32.c" />
 +    <ClCompile Include="src\file\mount.c" />
 +    <ClCompile Include="src\libbluray\bdnav\bdid_parse.c" />
++    <ClCompile Include="src\libbluray\bdnav\bdmv_parse.c" />
 +    <ClCompile Include="src\libbluray\bdnav\clpi_parse.c" />
 +    <ClCompile Include="src\libbluray\bdnav\extdata_parse.c" />
 +    <ClCompile Include="src\libbluray\bdnav\index_parse.c" />
@@ -679,6 +713,7 @@ index 00000000..393cd1a0
 +    <ClCompile Include="src\libbluray\bdnav\mpls_parse.c" />
 +    <ClCompile Include="src\libbluray\bdnav\navigation.c" />
 +    <ClCompile Include="src\libbluray\bdnav\sound_parse.c" />
++    <ClCompile Include="src\libbluray\bdnav\uo_mask.c" />
 +    <ClCompile Include="src\libbluray\bluray.c" />
 +    <ClCompile Include="src\libbluray\decoders\graphics_controller.c" />
 +    <ClCompile Include="src\libbluray\decoders\graphics_processor.c" />
@@ -694,6 +729,7 @@ index 00000000..393cd1a0
 +    <ClCompile Include="src\libbluray\disc\bdplus.c" />
 +    <ClCompile Include="src\libbluray\disc\dec.c" />
 +    <ClCompile Include="src\libbluray\disc\disc.c" />
++    <ClCompile Include="src\libbluray\disc\properties.c" />
 +    <ClCompile Include="src\libbluray\hdmv\hdmv_vm.c" />
 +    <ClCompile Include="src\libbluray\hdmv\mobj_parse.c" />
 +    <ClCompile Include="src\libbluray\hdmv\mobj_print.c" />
@@ -716,17 +752,16 @@ index 00000000..393cd1a0
 +    <RootNamespace>libbluray</RootNamespace>
 +  </PropertyGroup>
 +  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-+  <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '11.0'">
-+    <PlatformToolset>v110_xp</PlatformToolset>
-+  </PropertyGroup>
 +  <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '12.0'">
-+    <PlatformToolset>v120_xp</PlatformToolset>
++    <PlatformToolset>v120</PlatformToolset>
 +  </PropertyGroup>
 +  <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '14.0'">
-+    <PlatformToolset>v140_xp</PlatformToolset>
++    <PlatformToolset>v140</PlatformToolset>
++    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
 +  </PropertyGroup>
 +  <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '15.0'">
-+    <PlatformToolset>v141_xp</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
++    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
 +  </PropertyGroup>
 +  <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='DebugRelease'" Label="Configuration">
 +    <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -817,10 +852,10 @@ index 00000000..393cd1a0
 \ No newline at end of file
 diff --git a/libbluray.vcxproj.filters b/libbluray.vcxproj.filters
 new file mode 100644
-index 00000000..4352ef05
+index 0000000..02a4161
 --- /dev/null
 +++ b/libbluray.vcxproj.filters
-@@ -0,0 +1,359 @@
+@@ -0,0 +1,377 @@
 +﻿<?xml version="1.0" encoding="utf-8"?>
 +<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 +  <ItemGroup>
@@ -1045,6 +1080,15 @@ index 00000000..4352ef05
 +    <ClInclude Include="src\util\event_queue.h">
 +      <Filter>Header Files\util</Filter>
 +    </ClInclude>
++    <ClInclude Include="src\libbluray\bdnav\bdmv_parse.h">
++      <Filter>Header Files\libbluray\bdnav</Filter>
++    </ClInclude>
++    <ClInclude Include="src\libbluray\bdnav\uo_mask.h">
++      <Filter>Header Files\libbluray\bdnav</Filter>
++    </ClInclude>
++    <ClInclude Include="src\libbluray\disc\properties.h">
++      <Filter>Header Files\libbluray\disc</Filter>
++    </ClInclude>
 +  </ItemGroup>
 +  <ItemGroup>
 +    <ClCompile Include="src\util\logging.c">
@@ -1173,6 +1217,15 @@ index 00000000..4352ef05
 +    <ClCompile Include="src\util\event_queue.c">
 +      <Filter>Source Files\util</Filter>
 +    </ClCompile>
++    <ClCompile Include="src\libbluray\bdnav\bdmv_parse.c">
++      <Filter>Source Files\libbluray\bdnav</Filter>
++    </ClCompile>
++    <ClCompile Include="src\libbluray\bdnav\uo_mask.c">
++      <Filter>Source Files\libbluray\bdnav</Filter>
++    </ClCompile>
++    <ClCompile Include="src\libbluray\disc\properties.c">
++      <Filter>Source Files\libbluray\disc</Filter>
++    </ClCompile>
 +  </ItemGroup>
 +  <ItemGroup>
 +    <None Include="libbluray.def">
@@ -1182,7 +1235,7 @@ index 00000000..4352ef05
 +</Project>
 \ No newline at end of file
 diff --git a/src/file/dir_win32.c b/src/file/dir_win32.c
-index 5cbc3c86..40308966 100644
+index 5cbc3c8..4030896 100644
 --- a/src/file/dir_win32.c
 +++ b/src/file/dir_win32.c
 @@ -76,7 +76,7 @@ static dir_data_t *_open_impl(const char *dirname)
@@ -1204,7 +1257,7 @@ index 5cbc3c86..40308966 100644
      if (!result) {
          return NULL;
 diff --git a/src/file/dirs_win32.c b/src/file/dirs_win32.c
-index e165feac..3d07251a 100644
+index e165fea..3d07251 100644
 --- a/src/file/dirs_win32.c
 +++ b/src/file/dirs_win32.c
 @@ -36,7 +36,7 @@
@@ -1235,7 +1288,7 @@ index e165feac..3d07251a 100644
      if (!dir) {
          // first call
 diff --git a/src/file/dl_win32.c b/src/file/dl_win32.c
-index 6155ad6a..3a09fa1c 100644
+index 6155ad6..c7e3eee 100644
 --- a/src/file/dl_win32.c
 +++ b/src/file/dl_win32.c
 @@ -57,7 +57,7 @@ void *dl_dlopen(const char *path, const char *version)
@@ -1247,17 +1300,6 @@ index 6155ad6a..3a09fa1c 100644
      char *name;
      void *result;
      int iresult;
-@@ -81,8 +81,8 @@ void *dl_dlopen(const char *path, const char *version)
-     if (GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
-                        "SetDefaultDllDirectories") != NULL)
- #endif
--        flags = LOAD_LIBRARY_SEARCH_APPLICATION_DIR |
--                LOAD_LIBRARY_SEARCH_SYSTEM32;
-+        flags = 0xA00; /*LOAD_LIBRARY_SEARCH_APPLICATION_DIR |
-+                LOAD_LIBRARY_SEARCH_SYSTEM32;*/
- 
-     result = LoadLibraryExW(wname, NULL, flags);
- 
 @@ -125,7 +125,7 @@ const char *dl_get_path(void)
      if (!initialized) {
          initialized = 1;
@@ -1268,7 +1310,7 @@ index 6155ad6a..3a09fa1c 100644
          wchar_t wpath[MAX_PATH];
  
 diff --git a/src/file/file_win32.c b/src/file/file_win32.c
-index 11aaf820..f5518636 100644
+index 11aaf82..f551863 100644
 --- a/src/file/file_win32.c
 +++ b/src/file/file_win32.c
 @@ -107,9 +107,9 @@ static BD_FILE_H *_file_open(const char* filename, const char *mode)
@@ -1293,33 +1335,35 @@ index 11aaf820..f5518636 100644
      file = calloc(1, sizeof(BD_FILE_H));
      if (!file) {
          BD_DEBUG(DBG_FILE | DBG_CRIT, "Error opening file %s (out of memory)\n", filename);
-diff --git a/src/libbluray/bdnav/clpi_parse.c b/src/libbluray/bdnav/clpi_parse.c
-index 839e10c3..5fa490dc 100644
---- a/src/libbluray/bdnav/clpi_parse.c
-+++ b/src/libbluray/bdnav/clpi_parse.c
-@@ -39,6 +39,7 @@
- #define CLPI_SIG1  ('H' << 24 | 'D' << 16 | 'M' << 8 | 'V')
- #define CLPI_SIG2A ('0' << 24 | '2' << 16 | '0' << 8 | '0')
- #define CLPI_SIG2B ('0' << 24 | '1' << 16 | '0' << 8 | '0')
-+#define CLPI_SIG2C ('0' << 24 | '2' << 16 | '4' << 8 | '0')
+diff --git a/src/libbluray/bdnav/bdmv_parse.c b/src/libbluray/bdnav/bdmv_parse.c
+index e298ca3..2c310aa 100644
+--- a/src/libbluray/bdnav/bdmv_parse.c
++++ b/src/libbluray/bdnav/bdmv_parse.c
+@@ -59,6 +59,7 @@ int bdmv_parse_header(BITSTREAM *bs, uint32_t type, uint32_t *version)
+     switch (ver) {
+         case BDMV_VERSION_0100:
+         case BDMV_VERSION_0200:
++        case BDMV_VERSION_0240:
+         case BDMV_VERSION_0300:
+             break;
+         default:
+diff --git a/src/libbluray/bdnav/bdmv_parse.h b/src/libbluray/bdnav/bdmv_parse.h
+index 8f953a3..9dbbed5 100644
+--- a/src/libbluray/bdnav/bdmv_parse.h
++++ b/src/libbluray/bdnav/bdmv_parse.h
+@@ -27,6 +27,7 @@
  
- static void
- _human_readable_sig(char *sig, uint32_t s1, uint32_t s2)
-@@ -134,7 +135,8 @@ _parse_header(BITSTREAM *bits, CLPI_CL *cl)
-     cl->type_indicator2 = bs_read(bits, 32);
-     if (cl->type_indicator != CLPI_SIG1 || 
-         (cl->type_indicator2 != CLPI_SIG2A &&
--         cl->type_indicator2 != CLPI_SIG2B)) {
-+         cl->type_indicator2 != CLPI_SIG2B &&
-+         cl->type_indicator2 != CLPI_SIG2C)) {
+ #define BDMV_VERSION_0100 ('0' << 24 | '1' << 16 | '0' << 8 | '0')
+ #define BDMV_VERSION_0200 ('0' << 24 | '2' << 16 | '0' << 8 | '0')
++#define BDMV_VERSION_0240 ('0' << 24 | '2' << 16 | '4' << 8 | '0')
+ #define BDMV_VERSION_0300 ('0' << 24 | '3' << 16 | '0' << 8 | '0')
  
-         char sig[9];
-         char expect[9];
+ BD_PRIVATE int bdmv_parse_header(BITSTREAM *bs, uint32_t type, uint32_t *version);
 diff --git a/src/libbluray/bdnav/index_parse.c b/src/libbluray/bdnav/index_parse.c
-index 6a0f5a01..56b3d949 100644
+index 0deb617..300a1bf 100644
 --- a/src/libbluray/bdnav/index_parse.c
 +++ b/src/libbluray/bdnav/index_parse.c
-@@ -104,12 +104,11 @@ static int _parse_index(BITSTREAM *bs, INDX_ROOT *index)
+@@ -105,12 +105,11 @@ static int _parse_index(BITSTREAM *bs, INDX_ROOT *index)
  
      index->num_titles = bs_read(bs, 16);
      if (!index->num_titles) {
@@ -1335,7 +1379,7 @@ index 6a0f5a01..56b3d949 100644
          return 0;
      }
 diff --git a/src/libbluray/bdnav/mpls_data.h b/src/libbluray/bdnav/mpls_data.h
-index f148d513..b6a8cdd0 100644
+index 2ceac92..d23d40e 100644
 --- a/src/libbluray/bdnav/mpls_data.h
 +++ b/src/libbluray/bdnav/mpls_data.h
 @@ -47,6 +47,7 @@ typedef struct
@@ -1355,18 +1399,10 @@ index f148d513..b6a8cdd0 100644
  
  typedef struct
 diff --git a/src/libbluray/bdnav/mpls_parse.c b/src/libbluray/bdnav/mpls_parse.c
-index 82b61854..92ea99a7 100644
+index 358b634..569c015 100644
 --- a/src/libbluray/bdnav/mpls_parse.c
 +++ b/src/libbluray/bdnav/mpls_parse.c
-@@ -40,6 +40,7 @@
- #define MPLS_SIG1  ('M' << 24 | 'P' << 16 | 'L' << 8 | 'S')
- #define MPLS_SIG2A ('0' << 24 | '2' << 16 | '0' << 8 | '0')
- #define MPLS_SIG2B ('0' << 24 | '1' << 16 | '0' << 8 | '0')
-+#define MPLS_SIG2C ('0' << 24 | '2' << 16 | '4' << 8 | '0')
- 
- static void
- _human_readable_sig(char *sig, uint32_t s1, uint32_t s2)
-@@ -92,9 +93,10 @@ _parse_appinfo(BITSTREAM *bits, MPLS_AI *ai)
+@@ -77,9 +77,10 @@ _parse_appinfo(BITSTREAM *bits, MPLS_AI *ai)
      ai->random_access_flag = bs_read(bits, 1);
      ai->audio_mix_flag = bs_read(bits, 1);
      ai->lossless_bypass_flag = bs_read(bits, 1);
@@ -1378,17 +1414,7 @@ index 82b61854..92ea99a7 100644
      bs_seek_byte(bits, pos + len);
  #endif
      return 1;
-@@ -112,7 +114,8 @@ _parse_header(BITSTREAM *bits, MPLS_PL *pl)
-     pl->type_indicator2 = bs_read(bits, 32);
-     if (pl->type_indicator != MPLS_SIG1 || 
-         (pl->type_indicator2 != MPLS_SIG2A && 
--         pl->type_indicator2 != MPLS_SIG2B)) {
-+         pl->type_indicator2 != MPLS_SIG2B &&
-+         pl->type_indicator2 != MPLS_SIG2C)) {
- 
-         char sig[9];
-         char expect[9];
-@@ -218,6 +221,7 @@ _parse_stream(BITSTREAM *bits, MPLS_STREAM *s)
+@@ -194,6 +195,7 @@ _parse_stream(BITSTREAM *bits, MPLS_STREAM *s)
              break;
      };
      s->lang[3] = '\0';
@@ -1396,10 +1422,11 @@ index 82b61854..92ea99a7 100644
  
      if (bs_seek_byte(bits, pos + len) < 0) {
          return 0;
-@@ -911,6 +915,99 @@ _parse_subpath_extension(BITSTREAM *bits, MPLS_PL *pl)
+@@ -958,6 +960,99 @@ _parse_subpath_extension(BITSTREAM *bits, MPLS_PL *pl)
+     return 0;
  }
  
- static int
++static int
 +_parse_stn_ss_extension(BITSTREAM *bits, MPLS_PL *pl)
 +{
 +    int ii, s;
@@ -1492,11 +1519,10 @@ index 82b61854..92ea99a7 100644
 +    return 0;
 +}
 +
-+static int
+ static int
  _parse_mpls_extension(BITSTREAM *bits, int id1, int id2, void *handle)
  {
-     MPLS_PL *pl = (MPLS_PL*)handle;
-@@ -924,7 +1021,7 @@ _parse_mpls_extension(BITSTREAM *bits, int id1, int id2, void *handle)
+@@ -972,7 +1067,7 @@ _parse_mpls_extension(BITSTREAM *bits, int id1, int id2, void *handle)
  
      if (id1 == 2) {
          if (id2 == 1) {
@@ -1506,10 +1532,313 @@ index 82b61854..92ea99a7 100644
          if (id2 == 2) {
              // SubPath entries extension
 diff --git a/src/libbluray/bluray.c b/src/libbluray/bluray.c
-index ce4854d8..94565278 100644
+index 883b35c..8220787 100644
 --- a/src/libbluray/bluray.c
 +++ b/src/libbluray/bluray.c
-@@ -1651,6 +1651,25 @@ int64_t bd_seek_time(BLURAY *bd, uint64_t tick)
+@@ -51,8 +51,10 @@
+ #include "disc/disc.h"
+ #include "disc/enc_info.h"
+ #include "file/file.h"
++#ifdef USING_BDJAVA
+ #include "bdj/bdj.h"
+ #include "bdj/bdjo_parse.h"
++#endif
+ 
+ #include <stdio.h> // SEEK_
+ #include <stdlib.h>
+@@ -150,9 +152,11 @@ struct bluray {
+     uint8_t         hdmv_suspended;
+ 
+     /* BD-J */
++#ifdef USING_BDJAVA
+     BDJAVA         *bdjava;
+     BDJ_STORAGE     bdjstorage;
+     uint8_t         bdj_wait_start;  /* BD-J has selected playlist (prefetch) but not yet started playback */
++#endif
+ 
+     /* HDMV graphics */
+     GRAPHICS_CONTROLLER *graphics_controller;
+@@ -166,10 +170,12 @@ struct bluray {
+     uint64_t gc_wakeup_pos;   /* stream position of gc_wakeup_time */
+ 
+     /* ARGB overlay output */
++#ifdef USING_BDJAVA
+     void                *argb_overlay_proc_handle;
+     bd_argb_overlay_proc_f argb_overlay_proc;
+     BD_ARGB_BUFFER      *argb_buffer;
+     BD_MUTEX             argb_buffer_mutex;
++#endif
+ };
+ 
+ /* Stream Packet Number = byte offset / 192. Avoid 64-bit division. */
+@@ -532,6 +538,16 @@ static void _update_uo_mask(BLURAY *bd)
+     bd->uo_mask = new_mask;
+ }
+ 
++#ifdef USING_BDJAVA
++void bd_set_bdj_uo_mask(BLURAY *bd, unsigned mask)
++{
++    bd->title_uo_mask.title_search = !!(mask & BDJ_TITLE_SEARCH_MASK);
++    bd->title_uo_mask.menu_call    = !!(mask & BDJ_MENU_CALL_MASK);
++
++    _update_uo_mask(bd);
++}
++#endif
++
+ static void _update_hdmv_uo_mask(BLURAY *bd)
+ {
+     uint32_t mask = hdmv_vm_get_uo_mask(bd->hdmv_vm);
+@@ -899,6 +915,7 @@ static int _run_gc(BLURAY *bd, gc_ctrl_e msg, uint32_t param)
+ 
+ static void _check_bdj(BLURAY *bd)
+ {
++#ifdef USING_BDJAVA
+     if (!bd->disc_info.bdj_handled) {
+         if (!bd->disc || bd->disc_info.bdj_detected) {
+ 
+@@ -911,6 +928,7 @@ static void _check_bdj(BLURAY *bd)
+             }
+         }
+     }
++#endif /* USING_BDJAVA */
+ }
+ 
+ static void _fill_disc_info(BLURAY *bd, BD_ENC_INFO *enc_info)
+@@ -940,7 +958,7 @@ static void _fill_disc_info(BLURAY *bd, BD_ENC_INFO *enc_info)
+     bd->disc_info.num_unsupported_titles = 0;
+ 
+     bd->disc_info.bdj_detected    = 0;
+-    bd->disc_info.bdj_supported   = 1;
++    bd->disc_info.bdj_supported   = 0;
+ 
+     bd->disc_info.num_titles  = 0;
+     bd->disc_info.titles      = NULL;
+@@ -1104,22 +1122,17 @@ const BLURAY_DISC_INFO *bd_get_disc_info(BLURAY *bd)
+ }
+ 
+ /*
+- * bdj callbacks
++ * bdj
+  */
+ 
+-void bd_set_bdj_uo_mask(BLURAY *bd, unsigned mask)
+-{
+-    bd->title_uo_mask.title_search = !!(mask & BDJ_TITLE_SEARCH_MASK);
+-    bd->title_uo_mask.menu_call    = !!(mask & BDJ_MENU_CALL_MASK);
+-
+-    _update_uo_mask(bd);
+-}
+-
++#ifdef USING_BDJAVA
+ const uint8_t *bd_get_aacs_data(BLURAY *bd, int type)
+ {
+     return disc_get_data(bd->disc, type);
+ }
++#endif
+ 
++#ifdef USING_BDJAVA
+ uint64_t bd_get_uo_mask(BLURAY *bd)
+ {
+     /* internal function. Used by BD-J. */
+@@ -1134,25 +1147,16 @@ uint64_t bd_get_uo_mask(BLURAY *bd)
+ 
+     return mask.u64;
+ }
++#endif
+ 
++#ifdef USING_BDJAVA
+ void bd_set_bdj_kit(BLURAY *bd, int mask)
+ {
+     _queue_event(bd, BD_EVENT_KEY_INTEREST_TABLE, mask);
+ }
++#endif
+ 
+-int bd_bdj_sound_effect(BLURAY *bd, int id)
+-{
+-    if (bd->sound_effects && id >= bd->sound_effects->num_sounds) {
+-        return -1;
+-    }
+-    if (id < 0 || id > 0xff) {
+-        return -1;
+-    }
+-
+-    _queue_event(bd, BD_EVENT_SOUND_EFFECT, id);
+-    return 0;
+-}
+-
++#ifdef USING_BDJAVA
+ void bd_select_rate(BLURAY *bd, float rate, int reason)
+ {
+     if (reason == BDJ_PLAYBACK_STOP) {
+@@ -1171,26 +1175,9 @@ void bd_select_rate(BLURAY *bd, float rate, int reason)
+         _queue_event(bd, BD_EVENT_STILL, 0);
+     }
+ }
++#endif
+ 
+-int bd_bdj_seek(BLURAY *bd, int playitem, int playmark, int64_t time)
+-{
+-    bd_mutex_lock(&bd->mutex);
+-
+-    if (playitem > 0) {
+-        bd_seek_playitem(bd, playitem);
+-    }
+-    if (playmark >= 0) {
+-        bd_seek_mark(bd, playmark);
+-    }
+-    if (time >= 0) {
+-        bd_seek_time(bd, time);
+-    }
+-
+-    bd_mutex_unlock(&bd->mutex);
+-
+-    return 1;
+-}
+-
++#ifdef USING_BDJAVA
+ int bd_set_virtual_package(BLURAY *bd, const char *vp_path, int psr_init_backup)
+ {
+     bd_mutex_lock(&bd->mutex);
+@@ -1216,12 +1203,16 @@ int bd_set_virtual_package(BLURAY *bd, const char *vp_path, int psr_init_backup)
+ 
+     return 0;
+ }
++#endif
+ 
++#ifdef USING_BDJAVA
+ BD_DISC *bd_get_disc(BLURAY *bd)
+ {
+     return bd ? bd->disc : NULL;
+ }
++#endif
+ 
++#ifdef USING_BDJAVA
+ uint32_t bd_reg_read(BLURAY *bd, int psr, int reg)
+ {
+     if (psr) {
+@@ -1230,7 +1221,9 @@ uint32_t bd_reg_read(BLURAY *bd, int psr, int reg)
+         return bd_gpr_read(bd->regs, reg);
+     }
+ }
++#endif
+ 
++#ifdef USING_BDJAVA
+ int bd_reg_write(BLURAY *bd, int psr, int reg, uint32_t value, uint32_t psr_value_mask)
+ {
+     if (psr) {
+@@ -1247,7 +1240,9 @@ int bd_reg_write(BLURAY *bd, int psr, int reg, uint32_t value, uint32_t psr_valu
+         return bd_gpr_write(bd->regs, reg, value);
+     }
+ }
++#endif
+ 
++#ifdef USING_BDJAVA
+ BD_ARGB_BUFFER *bd_lock_osd_buffer(BLURAY *bd)
+ {
+     bd_mutex_lock(&bd->argb_buffer_mutex);
+@@ -1333,13 +1328,11 @@ void bd_bdj_osd_cb(BLURAY *bd, const unsigned *img, int w, int h,
+         bd->argb_buffer->dirty[BD_OVERLAY_IG].y1 = 0;
+     }
+ }
+-
+-/*
+- * BD-J
+- */
++#endif
+ 
+ static int _start_bdj(BLURAY *bd, unsigned title)
+ {
++#ifdef USING_BDJAVA
+     if (bd->bdjava == NULL) {
+         const char *root = disc_root(bd->disc);
+         bd->bdjava = bdj_open(root, bd, bd->disc_info.bdj_disc_id, &bd->bdjstorage);
+@@ -1349,8 +1342,14 @@ static int _start_bdj(BLURAY *bd, unsigned title)
+     }
+ 
+     return !bdj_process_event(bd->bdjava, BDJ_EVENT_START, title);
++#else
++    (void)bd;
++    BD_DEBUG(DBG_BLURAY | DBG_CRIT, "Title %d: BD-J not compiled in\n", title);
++    return 0;
++#endif
+ }
+ 
++#ifdef USING_BDJAVA
+ static int _bdj_event(BLURAY *bd, unsigned ev, unsigned param)
+ {
+     if (bd->bdjava != NULL) {
+@@ -1358,7 +1357,11 @@ static int _bdj_event(BLURAY *bd, unsigned ev, unsigned param)
+     }
+     return -1;
+ }
++#else
++#define _bdj_event(bd, ev, param) do{}while(0)
++#endif
+ 
++#ifdef USING_BDJAVA
+ static void _stop_bdj(BLURAY *bd)
+ {
+     if (bd->bdjava != NULL) {
+@@ -1367,7 +1370,11 @@ static void _stop_bdj(BLURAY *bd)
+         _queue_event(bd, BD_EVENT_KEY_INTEREST_TABLE, 0);
+     }
+ }
++#else
++#define _stop_bdj(bd) do{}while(0)
++#endif
+ 
++#ifdef USING_BDJAVA
+ static void _close_bdj(BLURAY *bd)
+ {
+     if (bd->bdjava != NULL) {
+@@ -1375,6 +1382,20 @@ static void _close_bdj(BLURAY *bd)
+         bd->bdjava = NULL;
+     }
+ }
++#else
++#define _close_bdj(bd) do{}while(0)
++#endif
++
++#ifdef USING_BDJAVA
++static void _storage_free(BLURAY *bd)
++{
++    X_FREE(bd->bdjstorage.cache_root);
++    X_FREE(bd->bdjstorage.persistent_root);
++    X_FREE(bd->bdjstorage.classpath);
++}
++#else
++#define _storage_free(bd) do{}while(0)
++#endif
+ 
+ /*
+  * open / close
+@@ -1401,6 +1422,7 @@ BLURAY *bd_init(void)
+     }
+ 
+     bd_mutex_init(&bd->mutex);
++#ifdef USING_BDJAVA
+     bd_mutex_init(&bd->argb_buffer_mutex);
+ 
+     env = getenv("LIBBLURAY_PERSISTENT_STORAGE");
+@@ -1408,6 +1430,7 @@ BLURAY *bd_init(void)
+         int v = (!strcmp(env, "yes")) ? 1 : (!strcmp(env, "no")) ? 0 : atoi(env);
+         bd->bdjstorage.no_persistent_storage = !v;
+     }
++#endif
+ 
+     BD_DEBUG(DBG_BLURAY, "BLURAY initialized!\n");
+ 
+@@ -1522,7 +1545,9 @@ void bd_close(BLURAY *bd)
+     disc_close(&bd->disc);
+ 
+     bd_mutex_destroy(&bd->mutex);
++#ifdef USING_BDJAVA
+     bd_mutex_destroy(&bd->argb_buffer_mutex);
++#endif
+ 
+     BD_DEBUG(DBG_BLURAY, "BLURAY destroyed!\n");
+ 
+@@ -1654,6 +1679,25 @@ int64_t bd_seek_time(BLURAY *bd, uint64_t tick)
      return bd->s_pos;
  }
  
@@ -1535,7 +1864,74 @@ index ce4854d8..94565278 100644
  uint64_t bd_tell_time(BLURAY *bd)
  {
      uint32_t clip_pkt = 0, out_pkt = 0, out_time = 0;
-@@ -2648,6 +2667,7 @@ static BLURAY_TITLE_INFO* _fill_title_info(NAV_TITLE* title, uint32_t title_idx,
+@@ -2394,7 +2438,26 @@ int bd_select_playlist(BLURAY *bd, uint32_t playlist)
+     return result;
+ }
+ 
+-/* BD-J callback */
++#ifdef USING_BDJAVA
++int bd_bdj_seek(BLURAY *bd, int playitem, int playmark, int64_t time)
++{
++    bd_mutex_lock(&bd->mutex);
++
++    if (playitem > 0) {
++        bd_seek_playitem(bd, playitem);
++    }
++    if (playmark >= 0) {
++        bd_seek_mark(bd, playmark);
++    }
++    if (time >= 0) {
++        bd_seek_time(bd, time);
++    }
++
++    bd_mutex_unlock(&bd->mutex);
++
++    return 1;
++}
++
+ static int _play_playlist_at(BLURAY *bd, int playlist, int playitem, int playmark, int64_t time)
+ {
+     if (playlist < 0) {
+@@ -2406,14 +2469,15 @@ static int _play_playlist_at(BLURAY *bd, int playlist, int playitem, int playmar
+         return 0;
+     }
+ 
++#ifdef USING_BDJAVA
+     bd->bdj_wait_start = 1;  /* playback is triggered by bd_select_rate() */
++#endif
+ 
+     bd_bdj_seek(bd, playitem, playmark, time);
+ 
+     return 1;
+ }
+ 
+-/* BD-J callback */
+ int bd_play_playlist_at(BLURAY *bd, int playlist, int playitem, int playmark, int64_t time)
+ {
+     int result;
+@@ -2426,6 +2490,21 @@ int bd_play_playlist_at(BLURAY *bd, int playlist, int playitem, int playmark, in
+     return result;
+ }
+ 
++int bd_bdj_sound_effect(BLURAY *bd, int id)
++{
++    if (bd->sound_effects && id >= bd->sound_effects->num_sounds) {
++        return -1;
++    }
++    if (id < 0 || id > 0xff) {
++        return -1;
++    }
++
++    _queue_event(bd, BD_EVENT_SOUND_EFFECT, id);
++    return 0;
++}
++
++#endif /* USING_BDJAVA */
++
+ // Select a title for playback
+ // The title index is an index into the list
+ // established by bd_get_titles()
+@@ -2651,6 +2730,7 @@ static BLURAY_TITLE_INFO* _fill_title_info(NAV_TITLE* title, uint32_t title_idx,
              NAV_CLIP *nc = &title->clip_list.clip[ii];
  
              memcpy(ci->clip_id, pi->clip->clip_id, sizeof(ci->clip_id));
@@ -1543,7 +1939,7 @@ index ce4854d8..94565278 100644
              ci->pkt_count = nc->end_pkt - nc->start_pkt;
              ci->start_time = (uint64_t)nc->title_time * 2;
              ci->in_time = (uint64_t)pi->in_time * 2;
-@@ -2672,6 +2692,8 @@ static BLURAY_TITLE_INFO* _fill_title_info(NAV_TITLE* title, uint32_t title_idx,
+@@ -2675,6 +2755,8 @@ static BLURAY_TITLE_INFO* _fill_title_info(NAV_TITLE* title, uint32_t title_idx,
          }
      }
  
@@ -1552,10 +1948,147 @@ index ce4854d8..94565278 100644
      return title_info;
  
   error:
-@@ -3825,3 +3847,28 @@ void bd_free_bdjo(struct bdjo_data *obj)
- {
-     bdjo_free(&obj);
+@@ -2802,7 +2884,7 @@ int bd_set_player_setting(BLURAY *bd, uint32_t idx, uint32_t value)
+         bd_mutex_unlock(&bd->mutex);
+         return result;
+     }
+-
++#ifdef USING_BDJAVA
+     if (idx == BLURAY_PLAYER_SETTING_PERSISTENT_STORAGE) {
+         if (bd->title_type != title_undef) {
+             BD_DEBUG(DBG_BLURAY | DBG_CRIT, "Can't disable persistent storage during playback\n");
+@@ -2811,6 +2893,7 @@ int bd_set_player_setting(BLURAY *bd, uint32_t idx, uint32_t value)
+         bd->bdjstorage.no_persistent_storage = !value;
+         return 1;
+     }
++#endif
+ 
+     for (i = 0; i < sizeof(map) / sizeof(map[0]); i++) {
+         if (idx == map[i].idx) {
+@@ -2835,6 +2918,7 @@ int bd_set_player_setting_str(BLURAY *bd, uint32_t idx, const char *s)
+         case BLURAY_PLAYER_SETTING_COUNTRY_CODE:
+             return bd_set_player_setting(bd, idx, str_to_uint32(s, 2));
+ 
++#ifdef USING_BDJAVA
+         case BLURAY_PLAYER_CACHE_ROOT:
+             bd_mutex_lock(&bd->mutex);
+             X_FREE(bd->bdjstorage.cache_root);
+@@ -2850,6 +2934,7 @@ int bd_set_player_setting_str(BLURAY *bd, uint32_t idx, const char *s)
+             bd_mutex_unlock(&bd->mutex);
+             BD_DEBUG(DBG_BDJ, "Persistent root dir set to %s\n", bd->bdjstorage.persistent_root);
+             return 1;
++#endif /* USING_BDJAVA */
+ 
+         default:
+             return 0;
+@@ -3265,7 +3350,7 @@ static int _play_title(BLURAY *bd, unsigned title)
+     return 0;
  }
+ 
+-/* BD-J callback */
++#ifdef USING_BDJAVA
+ int bd_play_title_internal(BLURAY *bd, unsigned title)
+ {
+     /* used by BD-J. Like bd_play_title() but bypasses UO mask checks. */
+@@ -3275,6 +3360,7 @@ int bd_play_title_internal(BLURAY *bd, unsigned title)
+     bd_mutex_unlock(&bd->mutex);
+     return ret;
+ }
++#endif
+ 
+ int bd_play(BLURAY *bd)
+ {
+@@ -3505,6 +3591,7 @@ static int _read_ext(BLURAY *bd, unsigned char *buf, int len, BD_EVENT *event)
+         return 0;
+     }
+ 
++#ifdef USING_BDJAVA
+     if (bd->title_type == title_bdj) {
+         if (bd->end_of_playlist == 1) {
+             _bdj_event(bd, BDJ_EVENT_END_OF_PLAYLIST, bd_psr_read(bd->regs, PSR_PLAYLIST));
+@@ -3523,6 +3610,7 @@ static int _read_ext(BLURAY *bd, unsigned char *buf, int len, BD_EVENT *event)
+             return 0;
+         }
+     }
++#endif
+ 
+     int bytes = _bd_read(bd, buf, len);
+ 
+@@ -3584,9 +3672,11 @@ static int _set_rate(BLURAY *bd, uint32_t rate)
+         return -1;
+     }
+ 
++#ifdef USING_BDJAVA
+     if (bd->title_type == title_bdj) {
+         return _bdj_event(bd, BDJ_EVENT_RATE, rate);
+     }
++#endif
+ 
+     return 0;
+ }
+@@ -3613,8 +3703,10 @@ int bd_mouse_select(BLURAY *bd, int64_t pts, uint16_t x, uint16_t y)
+ 
+     if (bd->title_type == title_hdmv) {
+         result = _run_gc(bd, GC_CTRL_MOUSE_MOVE, param);
++#ifdef USING_BDJAVA
+     } else if (bd->title_type == title_bdj) {
+         result = _bdj_event(bd, BDJ_EVENT_MOUSE, param);
++#endif
+     }
+ 
+     bd_mutex_unlock(&bd->mutex);
+@@ -3636,8 +3728,10 @@ int bd_user_input(BLURAY *bd, int64_t pts, uint32_t key)
+ 
+     if (bd->title_type == title_hdmv) {
+         result = _run_gc(bd, GC_CTRL_VK_KEY, key);
++#ifdef USING_BDJAVA
+     } else if (bd->title_type == title_bdj) {
+         result = _bdj_event(bd, BDJ_EVENT_VK_KEY, key);
++#endif
+     }
+ 
+     bd_mutex_unlock(&bd->mutex);
+@@ -3664,6 +3758,7 @@ void bd_register_overlay_proc(BLURAY *bd, void *handle, bd_overlay_proc_f func)
+ 
+ void bd_register_argb_overlay_proc(BLURAY *bd, void *handle, bd_argb_overlay_proc_f func, BD_ARGB_BUFFER *buf)
+ {
++#ifdef USING_BDJAVA
+     if (!bd) {
+         return;
+     }
+@@ -3675,6 +3770,12 @@ void bd_register_argb_overlay_proc(BLURAY *bd, void *handle, bd_argb_overlay_pro
+     bd->argb_buffer              = buf;
+ 
+     bd_mutex_unlock(&bd->argb_buffer_mutex);
++#else
++    (void)bd;
++    (void)handle;
++    (void)func;
++    (void)buf;
++#endif
+ }
+ 
+ int bd_get_sound_effect(BLURAY *bd, unsigned sound_id, BLURAY_SOUND_EFFECT *effect)
+@@ -3825,10 +3926,44 @@ void bd_free_mobj(struct mobj_objects *obj)
+ 
+ struct bdjo_data *bd_read_bdjo(const char *bdjo_file)
+ {
++#ifdef USING_BDJAVA
+     return bdjo_parse(bdjo_file);
++#else
++    (void)bdjo_file;
++    return NULL;
++#endif
+ }
+ 
+ void bd_free_bdjo(struct bdjo_data *obj)
+ {
++#ifdef USING_BDJAVA
+     bdjo_free(&obj);
++#else
++    (void)obj;
++#endif
++}
 +
 +int bd_get_clip_infos(BLURAY *bd, unsigned clip, uint64_t *clip_start_time, uint64_t *stream_start_time, uint64_t *pos, uint64_t *duration)
 +{
@@ -1580,9 +2113,9 @@ index ce4854d8..94565278 100644
 +    return bd->title->pl;
 +  }
 +  return NULL;
-+}
+ }
 diff --git a/src/libbluray/bluray.h b/src/libbluray/bluray.h
-index b7b52e55..744a6926 100644
+index 70e6a84..0cd6047 100644
 --- a/src/libbluray/bluray.h
 +++ b/src/libbluray/bluray.h
 @@ -32,6 +32,7 @@ extern "C" {
@@ -1593,7 +2126,16 @@ index b7b52e55..744a6926 100644
  
  #define TITLES_ALL              0    /**< all titles. */
  #define TITLES_FILTER_DUP_TITLE 0x01 /**< remove duplicate titles. */
-@@ -222,6 +223,7 @@ typedef struct bd_stream_info {
+@@ -90,7 +91,7 @@ typedef struct {
+ 
+     /* BD-J info  (valid only if disc uses BD-J) */
+     uint8_t  bdj_detected;     /* 1 if disc uses BD-J */
+-    uint8_t  bdj_supported;    /* (deprecated) */
++    uint8_t  bdj_supported;    /* 1 if BD-J support was compiled in */
+     uint8_t  libjvm_detected;  /* 1 if usable Java VM was found */
+     uint8_t  bdj_handled;      /* 1 if usable Java VM + libbluray.jar was found */
+ 
+@@ -224,6 +225,7 @@ typedef struct bd_stream_info {
  } BLURAY_STREAM_INFO;
  
  typedef struct bd_clip {
@@ -1601,7 +2143,7 @@ index b7b52e55..744a6926 100644
      uint32_t           pkt_count;
      uint8_t            still_mode;
      uint16_t           still_time;  /* seconds */
-@@ -272,6 +274,8 @@ typedef struct bd_title_info {
+@@ -274,6 +276,8 @@ typedef struct bd_title_info {
      BLURAY_CLIP_INFO     *clips;
      BLURAY_TITLE_CHAPTER *chapters;
      BLURAY_TITLE_MARK    *marks;
@@ -1610,10 +2152,12 @@ index b7b52e55..744a6926 100644
  } BLURAY_TITLE_INFO;
  
  /*
-@@ -480,6 +484,16 @@ uint32_t bd_get_current_title(BLURAY *bd);
+@@ -480,6 +484,16 @@ int bd_select_playlist(BLURAY *bd, uint32_t playlist);
+  */
+ uint32_t bd_get_current_title(BLURAY *bd);
  
- /**
-  *
++/**
++ *
 + * Find the byte position to specific time in 90Khz ticks
 + *
 + * @param bd    BLURAY ojbect
@@ -1622,12 +2166,10 @@ index b7b52e55..744a6926 100644
 + */
 +int64_t bd_find_seek_point(BLURAY *bd, uint64_t tick);
 +
-+/**
-+ *
-  *  Read from currently selected title file, decrypt if possible
+ /**
   *
-  * @param bd  BLURAY object
-@@ -1033,7 +1047,6 @@ int bd_mouse_select(BLURAY *bd, int64_t pts, uint16_t x, uint16_t y);
+  *  Read from currently selected title file, decrypt if possible
+@@ -1039,7 +1053,6 @@ int bd_mouse_select(BLURAY *bd, int64_t pts, uint16_t x, uint16_t y);
  
  /* access to internal information */
  
@@ -1635,7 +2177,7 @@ index b7b52e55..744a6926 100644
  /**
   *
   *  Get copy of clip information for requested playitem.
-@@ -1086,6 +1099,28 @@ void bd_stop_bdj(BLURAY *bd); // shutdown BD-J and clean up resources
+@@ -1092,6 +1105,28 @@ void bd_stop_bdj(BLURAY *bd); // shutdown BD-J and clean up resources
   */
  int bd_read_file(BLURAY *, const char *path, void **data, int64_t *size);
  
@@ -1665,10 +2207,20 @@ index b7b52e55..744a6926 100644
  #ifdef __cplusplus
  }
 diff --git a/src/libbluray/disc/disc.c b/src/libbluray/disc/disc.c
-index be6a279d..8ed14e64 100644
+index be6a279..e96539a 100644
 --- a/src/libbluray/disc/disc.c
 +++ b/src/libbluray/disc/disc.c
-@@ -75,7 +75,7 @@ static BD_FILE_H *_bdrom_open_path(void *p, const char *rel_path)
+@@ -38,7 +38,9 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
++#ifdef ENABLE_UDF
+ #include "udf_fs.h"
++#endif
+ 
+ struct bd_disc {
+     BD_MUTEX  ovl_mutex;     /* protect access to overlay root */
+@@ -75,7 +77,7 @@ static BD_FILE_H *_bdrom_open_path(void *p, const char *rel_path)
          return NULL;
      }
  
@@ -1677,3 +2229,19 @@ index be6a279d..8ed14e64 100644
      X_FREE(abs_path);
  
      return fp;
+@@ -316,6 +318,7 @@ BD_DISC *disc_open(const char *device_path,
+     _set_paths(p, device_path);
+ 
+     /* check if disc root directory can be opened. If not, treat it as device/image file. */
++#ifdef ENABLE_UDF
+     BD_DIR_H *dp_img = device_path ? dir_open(device_path) : NULL;
+     if (!dp_img) {
+         void *udf = udf_image_open(device_path, p_fs ? p_fs->fs_handle : NULL, p_fs ? p_fs->read_blocks : NULL);
+@@ -336,6 +339,7 @@ BD_DISC *disc_open(const char *device_path,
+         dir_close(dp_img);
+         BD_DEBUG(DBG_FILE, "%s does not seem to be image file or device node\n", device_path);
+     }
++#endif
+ 
+     struct dec_dev dev = { p->fs_handle, p->pf_file_open_bdrom, p, (file_openFp)disc_open_path, p->disc_root, device_path };
+     p->dec = dec_init(&dev, enc_info, keyfile_path, regs, psr_read, psr_write);

--- a/packages/multimedia/libbluray/patches/libbluray-02-install-extra-MVC-headers.patch
+++ b/packages/multimedia/libbluray/patches/libbluray-02-install-extra-MVC-headers.patch
@@ -1,0 +1,42 @@
+From 316310d889d0bcffa299ef6a7fb5726847f2dd3a Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Wed, 20 Jun 2018 15:01:32 +0100
+Subject: [PATCH] add missing 3D MVC headers
+
+---
+ Makefile.am | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index ff15527..00db9af 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -219,6 +219,14 @@ noinst_HEADERS = \
+ 	jni/win32/jni_md.h \
+ 	jni/darwin/jni_md.h
+ 
++bdnavdir=$(pkgincludedir)/bdnav
++bdnav_HEADERS = \
++        src/libbluray/bdnav/clpi_data.h
++
++utildir=$(pkgincludedir)/util
++util_HEADERS = \
++        src/util/attributes.h
++
+ pkginclude_HEADERS = \
+ 	src/file/filesystem.h \
+ 	src/libbluray/bluray.h \
+@@ -226,6 +234,10 @@ pkginclude_HEADERS = \
+ 	src/libbluray/keys.h \
+ 	src/libbluray/player_settings.h \
+ 	src/libbluray/bdnav/clpi_data.h \
++	src/libbluray/bdnav/clpi_parse.h \
++	src/libbluray/bdnav/mpls_parse.h \
++	src/libbluray/bdnav/mpls_data.h \
++	src/libbluray/bdnav/uo_mask_table.h \
+ 	src/libbluray/bdnav/meta_data.h \
+ 	src/libbluray/decoders/overlay.h \
+ 	src/util/log_control.h
+-- 
+2.14.1
+


### PR DESCRIPTION
Similar to #2417 (which I suggest this replaces), this PR fixes the licence, bumps the version and rebases the `L20170904` 3D MVC patch from http://git.1f0.de/gitweb?p=libbluray.git;a=summary;js=1

From the forum, confirmation that UHD support is now working with this PR:
https://forum.kodi.tv/showthread.php?tid=298462&pid=2744919#pid2744919
https://forum.kodi.tv/showthread.php?tid=298462&pid=2745004#pid2745004

However resuming UHD playback may be a problem, which is under investigation.

This needs further testing on RPi with 3D playback - my own testing didn't reveal any issues.