### PR TITLE
kodi.sh: return zero on succesful exit

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi.sh
+++ b/packages/mediacenter/kodi/scripts/kodi.sh
@@ -157,4 +157,7 @@ if [ $(( ($RET >= 131 && $RET <= 136) || $RET == 139 )) = "1" ] ; then
   detect_crash_loop && activate_safe_mode
 fi
 
+# Filter Kodi powerdown/restartapp/reboot codes to satisfy systemd
+[ "$RET" -ge 64 -a "$RET" -le 66 ] && RET=0
+
 exit $RET


### PR DESCRIPTION
When stopping kodi the kodi.service always enters failed state even on successful exit.

Filter the [powerdown/restartapp/reboot exit codes](https://github.com/xbmc/xbmc/blob/195491e14f4dfafed2dc1b11a851dcf5b66ff9b3/xbmc/XBApplicationEx.h#L30-L32) to reduce log spam.