### PR TITLE
Allwinner: Add HDMI ALSA conf file

### DIFF
--- a/projects/Allwinner/devices/H3/patches/linux/16-H3-add-HDMI-sound-nodes.patch
+++ b/projects/Allwinner/devices/H3/patches/linux/16-H3-add-HDMI-sound-nodes.patch
@@ -9,7 +9,7 @@ index 8aa2befc..d3d70eac 100644
 +	sound_hdmi: sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,format = "i2s";
-+		simple-audio-card,name = "allwinner,hdmi";
++		simple-audio-card,name = "allwinner-hdmi";
 +		simple-audio-card,mclk-fs = <256>;
 +		status = "disabled";
 +

--- a/projects/Allwinner/filesystem/usr/share/alsa/cards/allwinner-hdmi.conf
+++ b/projects/Allwinner/filesystem/usr/share/alsa/cards/allwinner-hdmi.conf
@@ -1,0 +1,34 @@
+#
+# Configuration for HDMI
+#
+
+<confdir:pcm/hdmi.conf>
+
+allwinner-hdmi.pcm.hdmi.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+		device 0
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				interface MIXER
+				name "IEC958 Playback Default"
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+	hint.device 0
+}


### PR DESCRIPTION
This commit allows Kodi to recognize HDMI as digital audio interface. This brings support for passthrough.