### PR TITLE
mesa: only build va tracker if using a gallium driver that uses it

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -82,7 +82,7 @@ else
   PKG_MESON_OPTS_TARGET+=" -Dgallium-vdpau=false"
 fi
 
-if [ "$VAAPI_SUPPORT" = "yes" ]; then
+if [ "$VAAPI_SUPPORT" = "yes" ] && listcontains "$GRAPHIC_DRIVERS" "(r600|radeonsi)"; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libva"
   PKG_MESON_OPTS_TARGET+=" -Dgallium-va=true"
 else


### PR DESCRIPTION
see: https://cgit.freedesktop.org/mesa/mesa/tree/meson.build#n553

when doing an intel only build you will come across this issue.