### PR TITLE
valgrind: add patch to enable armv8

### DIFF
--- a/packages/debug/valgrind/patches/valgrind-0001-enable-armv8.patch
+++ b/packages/debug/valgrind/patches/valgrind-0001-enable-armv8.patch
@@ -1,0 +1,12 @@
+diff -Naur a/configure b/configure
+--- a/configure	2017-06-15 06:41:35.000000000 -0700
++++ b/configure	2018-06-26 14:51:02.264580174 -0700
+@@ -5627,7 +5627,7 @@
+         ARCH_MAX="s390x"
+         ;;
+ 
+-     armv7*)
++     armv7*|armv8*)
+ 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: ok (${host_cpu})" >&5
+ $as_echo "ok (${host_cpu})" >&6; }
+ 	ARCH_MAX="arm"


### PR DESCRIPTION
otherwise when building a 64/32 split build you see
```
checking host system type... armv8a-libreelec-linux-gnueabi
checking for a supported CPU... no (armv8a)
configure: error: Unsupported host architecture. Sorry
```