### PR TITLE
sapphire: fix build

### DIFF
--- a/packages/addons/driver/sapphire/package.mk
+++ b/packages/addons/driver/sapphire/package.mk
@@ -46,10 +46,10 @@ pre_make_target() {
 }
 
 make_target() {
-  make V=1 \
-       KVER=$(kernel_version) \
-       KDIR=$(kernel_path) \
-       INPUT_H=$INPUT_H
+  kernel_make -C $(kernel_path) M=$(pwd) modules
+
+  make INPUT_H=$INPUT_H \
+       sapphire_keymap.sh
 }
 
 post_make_target() {


### PR DESCRIPTION
The kernel module needs to be built with kernel_make

Build-tested for RPi2 (kernel 4.14) and Generic (kernel 4.18-rc2)