### PR TITLE
 gcc-linaro: update to latest version

### DIFF
--- a/packages/lang/gcc-linaro-aarch64-elf/package.mk
+++ b/packages/lang/gcc-linaro-aarch64-elf/package.mk
@@ -17,14 +17,14 @@
 ################################################################################
 
 PKG_NAME="gcc-linaro-aarch64-elf"
-PKG_VERSION="4.9-2016.02"
-PKG_SHA256="67b8d6d3c764a5b2e21bf4a9cc990f6d6db691df5fcc814e34051c521346ec10"
+PKG_VERSION="4.9.4-2017.01"
+PKG_SHA256="00c79aaf7ff9b1c22f7b0443a730056b3936561a4206af187ef61a4e3cab1716"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""
-PKG_URL="https://releases.linaro.org/components/toolchain/binaries/${PKG_VERSION}/aarch64-elf/gcc-linaro-${PKG_VERSION}-x86_64_aarch64-elf.tar.xz"
+PKG_URL="https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/aarch64-elf/gcc-linaro-${PKG_VERSION}-x86_64_aarch64-elf.tar.xz"
 PKG_SOURCE_DIR="gcc-linaro-${PKG_VERSION}-x86_64_aarch64-elf"
-PKG_DEPENDS_HOST="toolchain"
+PKG_DEPENDS_HOST="ccache:host"
 PKG_SECTION="lang"
 PKG_LONGDESC="Linaro Aarch64 GNU Linux Binary Toolchain"
 PKG_TOOLCHAIN="manual"

--- a/packages/lang/gcc-linaro-aarch64-linux-gnu/package.mk
+++ b/packages/lang/gcc-linaro-aarch64-linux-gnu/package.mk
@@ -17,16 +17,16 @@
 ################################################################################
 
 PKG_NAME="gcc-linaro-aarch64-linux-gnu"
-PKG_VERSION="7.2.1-2017.11"
-PKG_SHA256="20181f828e1075f1a493947ff91e82dd578ce9f8638fbdfc39e24b62857d8f8d"
+PKG_VERSION="7.3.1-2018.05"
+PKG_SHA256="73eed74e593e2267504efbcf3678918bb22409ab7afa3dc7c135d2c6790c2345"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""
-PKG_URL="https://releases.linaro.org/components/toolchain/binaries/7.2-2017.11/aarch64-linux-gnu/gcc-linaro-${PKG_VERSION}-x86_64_aarch64-linux-gnu.tar.xz"
+PKG_URL="https://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/aarch64-linux-gnu/gcc-linaro-${PKG_VERSION}-x86_64_aarch64-linux-gnu.tar.xz"
 PKG_SOURCE_DIR="gcc-linaro-${PKG_VERSION}-x86_64_aarch64-linux-gnu"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_SECTION="lang"
-PKG_SHORTDESC="Linaro Aarch64 GNU Linux Binary Toolchain"
+PKG_LONGDESC="Linaro Aarch64 GNU Linux Binary Toolchain"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_host() {

--- a/packages/lang/gcc-linaro-arm-eabi/package.mk
+++ b/packages/lang/gcc-linaro-arm-eabi/package.mk
@@ -17,16 +17,16 @@
 ################################################################################
 
 PKG_NAME="gcc-linaro-arm-eabi"
-PKG_VERSION="4.9-2016.02"
-PKG_SHA256="b46f97e1eea542e98ed7e4278a4ea98c750e679b816d5a8c66286cd4fdc42448"
+PKG_VERSION="4.9.4-2017.01"
+PKG_SHA256="5fa170a74db172dca098c70ae58f4c08d2fca0232ce135530b2ef4996326b4bd"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""
-PKG_URL="https://releases.linaro.org/components/toolchain/binaries/${PKG_VERSION}/arm-eabi/gcc-linaro-${PKG_VERSION}-x86_64_arm-eabi.tar.xz"
+PKG_URL="https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-eabi/gcc-linaro-${PKG_VERSION}-x86_64_arm-eabi.tar.xz"
 PKG_SOURCE_DIR="gcc-linaro-${PKG_VERSION}-x86_64_arm-eabi"
-PKG_DEPENDS_HOST="toolchain"
+PKG_DEPENDS_HOST="ccache:host"
 PKG_SECTION="lang"
-PKG_LONGDESC="Linaro Aarch64 GNU Linux Binary Toolchain"
+PKG_LONGDESC="Linaro ARM GNU Linux Binary Toolchain"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_host() {

--- a/packages/lang/gcc-linaro-arm-linux-gnueabihf/package.mk
+++ b/packages/lang/gcc-linaro-arm-linux-gnueabihf/package.mk
@@ -17,16 +17,16 @@
 ################################################################################
 
 PKG_NAME="gcc-linaro-arm-linux-gnueabihf"
-PKG_VERSION="7.2.1-2017.11"
-PKG_SHA256="cee0087b1f1205b73996651b99acd3a926d136e71047048f1758ffcec69b1ca2"
+PKG_VERSION="7.3.1-2018.05"
+PKG_SHA256="7248bf105d0d468887a9b8a7120bb281ac8ad0223d9cb3d00dc7c2d498485d91"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""
-PKG_URL="https://releases.linaro.org/components/toolchain/binaries/7.2-2017.11/arm-linux-gnueabihf/gcc-linaro-7.2.1-2017.11-x86_64_arm-linux-gnueabihf.tar.xz"
-PKG_SOURCE_DIR="gcc-linaro-$PKG_VERSION-x86_64_arm-linux-gnueabihf"
+PKG_URL="https://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/arm-linux-gnueabihf/gcc-linaro-${PKG_VERSION}-x86_64_arm-linux-gnueabihf.tar.xz"
+PKG_SOURCE_DIR="gcc-linaro-${PKG_VERSION}-x86_64_arm-linux-gnueabihf"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_SECTION="lang"
-PKG_LONGDESC="Linaro ARMv8 GNU Linux Binary Toolchain"
+PKG_LONGDESC="Linaro ARM GNU Linux Binary Toolchain"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_host() {


### PR DESCRIPTION
This PR updates gcc-linaro toolchains to latest `4.9.4-2017.01` and `7.3.1-2018.05`.

I have tested this on Rock64 (`gcc-linaro-aarch64-linux-gnu`) and Tinker Board S (`gcc-linaro-arm-linux-gnueabihf`) without any issues.
This needs testing on Amlogic before going in.