### PR TITLE
kodi: add scpi_sensors to cputemp script

### DIFF
--- a/packages/mediacenter/kodi/scripts/cputemp
+++ b/packages/mediacenter/kodi/scripts/cputemp
@@ -1,21 +1,22 @@
 #!/bin/sh
 
 ################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
+#      This file is part of LibreELEC - https://libreelec.tv
+#      Copyright (C) 2018-present Team LibreELEC
 #      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 #
-#  OpenELEC is free software: you can redistribute it and/or modify
+#  LibreELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  OpenELEC is distributed in the hope that it will be useful,
+#  LibreELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 # inspired by
@@ -55,7 +56,7 @@ if [ "$1" = "cpu" -o "$TEMP" = "0" ]; then
   for hwmon in /sys/class/hwmon/*; do
     if [ -f "${hwmon}/name" ]; then
       case $(cat ${hwmon}/name) in
-        coretemp|k10temp)
+        coretemp|k10temp|scpi_sensors)
           [[ -f "${hwmon}/temp1_input" ]] && TEMP="$(cat ${hwmon}/temp1_input)" && break
           [[ -f "${hwmon}/temp2_input" ]] && TEMP="$(cat ${hwmon}/temp2_input)" && break
           ;;
@@ -67,7 +68,7 @@ if [ "$1" = "cpu" -o "$TEMP" = "0" ]; then
     TEMP="$(cat /sys/class/hwmon/hwmon0/device/temp1_input)"
   fi
 
-  # used on RaspberryPi and amlogic
+  # used on RaspberryPi and 3.14 kernel amlogic
   if [ "$TEMP" = "0" -a -f /sys/class/thermal/thermal_zone0/temp ]; then
     TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
   fi


### PR DESCRIPTION
adds support for the `scpi_sensors` location used in some newer (mainline) kernels