### PR TITLE
bluez: bump version to 5.50

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="bluez"
-PKG_VERSION="5.48"
-PKG_SHA256="a89ba9f21eabdc28a6eec046c14f901ee2d9809d303f8df25e9e2d4d7c4c2dc8"
+PKG_VERSION="5.50"
+PKG_SHA256="c44b776660bf78e664e388b979da152976296e444dece833f3ddbd5be5a3b1b4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"


### PR DESCRIPTION
Tested in mainline branches I've been using recently with no obvious ill effects, but it would be good to pick into @MilhouseVH releases for a few days to prove on a larger audience before merging.