### PR TITLE
settings: bump LibreELEC-settings to pick-up changes

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -18,8 +18,8 @@
 ################################################################################
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="a562ed0"
-PKG_SHA256="98f2d5aa3ef3d422a359fc0a10e2c50efc14d3eaf351312b3aceea449a0ff151"
+PKG_VERSION="659afa8"
+PKG_SHA256="f01e6e2f0b9db3ca0addd6f00b93b192596fd1640ba8cd88197a4c3c1a4719fb"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
This bumps the settings add-on to include support for opting out of stats collection after #2708 and drops the CPU (64/32 bit) detection flag which is obsolete since we dropped Generic i386 images in OE 5.0. The idea of sending useful flags back has been adapted to detect GPU type (Generic) or board revision (RPi) which will be used to support upcoming project decisions to continue or discontinue support for some older hardware in LE 10.0. Collecting those stats is essential as it allows the team to make support decisions based on hard facts not personal hunches/opinions.