### PR TITLE
openssl: generate cacert.pem from system and user CA

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -109,13 +109,22 @@ post_makeinstall_target() {
 
   # cert from https://curl.haxx.se/docs/caextract.html
   mkdir -p $INSTALL/etc/ssl
-    cp $PKG_DIR/cert/cacert.pem $INSTALL/etc/ssl/cert.pem
+    cp $PKG_DIR/cert/cacert.pem $INSTALL/etc/ssl/cacert.pem.system
+
+  # give user the chance to include their own CA
+  mkdir -p $INSTALL/usr/bin
+    cp $PKG_DIR/scripts/openssl-config $INSTALL/usr/bin
+    ln -sf /run/libreelec/cacert.pem $INSTALL/etc/ssl/cacert.pem
 
   # backwards comatibility
   mkdir -p $INSTALL/etc/pki/tls
-    ln -sf /etc/ssl/cert.pem $INSTALL/etc/pki/tls/cacert.pem
+    ln -sf /run/libreelec/cacert.pem $INSTALL/etc/pki/tls/cacert.pem
   mkdir -p $INSTALL/etc/pki/tls/certs
-    ln -sf /etc/ssl/cert.pem $INSTALL/etc/pki/tls/certs/ca-bundle.crt
+    ln -sf /run/libreelec/cacert.pem $INSTALL/etc/pki/tls/certs/ca-bundle.crt
   mkdir -p $INSTALL/usr/lib/ssl
-    ln -sf /etc/ssl/cert.pem $INSTALL/usr/lib/ssl/cert.pem
+    ln -sf /run/libreelec/cacert.pem $INSTALL/usr/lib/ssl/cert.pem
+}
+
+post_install() {
+  enable_service openssl-config.service
 }

--- a/packages/security/openssl/scripts/openssl-config
+++ b/packages/security/openssl/scripts/openssl-config
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+cp /etc/ssl/cacert.pem.system /run/libreelec/cacert.pem
+
+[ -f /storage/.config/cacert.pem ] && cat /storage/.config/cacert.pem >>/run/libreelec/cacert.pem
+
+exit 0

--- a/packages/security/openssl/system.d/openssl-config.service
+++ b/packages/security/openssl/system.d/openssl-config.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OpenSSL configuration service
+DefaultDependencies=no
+After=systemd-tmpfiles-setup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/openssl-config
+
+[Install]
+WantedBy=sysinit.target

--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -84,7 +84,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_lib_rtmp_RTMP_Init=yes \
                            --with-ssl \
                            --without-polarssl \
                            --without-nss \
-                           --with-ca-bundle=/etc/ssl/cert.pem \
+                           --with-ca-bundle=/run/libreelec/cacert.pem \
                            --without-ca-path \
                            --without-libpsl \
                            --without-libmetalink \


### PR DESCRIPTION
This should allow users to append their own self-signed CA.

https://forum.libreelec.tv/thread/12789-adding-own-certs-to-connect-via-webdavs-sftp-again