### PR TITLE
kodi: enable games and disable rewind by default

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings version="1">
 
+  <section id="games">
+    <category id="gamesgeneral">
+      <group id="1">
+        <setting id="gamesgeneral.enable">
+          <default>true</default>
+        </setting>
+        <setting id="gamesgeneral.enablerewind">
+          <default>false</default>
+        </setting>
+      </group>
+    </category>
+  </section>
+
   <section id="system">
     <category id="display">
       <group id="1">


### PR DESCRIPTION
We want to get more visibility for retroplayer so let's enable games by default.
The only reason kodi doesn't do this is because it doesn't have the sense of a
binary add-on repo. LibreELEC is special in that we have had this ability forever.

We also want to disable rewind by default because it makes low powered devices
suffer in performance. It also isn't exposed in a manner that makes it easy to use yet.