### PR TITLE
openssl: cert.pem sym link for parts of openssl that don't use cacert…

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -115,6 +115,7 @@ post_makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
     cp $PKG_DIR/scripts/openssl-config $INSTALL/usr/bin
     ln -sf /run/libreelec/cacert.pem $INSTALL/etc/ssl/cacert.pem
+    ln -sf /run/libreelec/cacert.pem $INSTALL/etc/ssl/cert.pem
 
   # backwards comatibility
   mkdir -p $INSTALL/etc/pki/tls


### PR DESCRIPTION
….pem

Fix regression: https://github.com/LibreELEC/LibreELEC.tv/pull/2825#issuecomment-405167195