### PR TITLE
linux: allow specifying a mkbootimg script when using android bootloa…

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -219,24 +219,9 @@ make_target() {
   kernel_make $KERNEL_TARGET $KERNEL_MAKE_EXTRACMD
 
   if [ "$BUILD_ANDROID_BOOTIMG" = "yes" ]; then
-    DTB_BLOBS=($(ls arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/*.dtb 2>/dev/null || true))
-    DTB_BLOBS_COUNT="${#DTB_BLOBS[@]}"
-    DTB_BLOB_OUTPUT="arch/$TARGET_KERNEL_ARCH/boot/dtb.img"
-    ANDROID_BOOTIMG_SECOND="--second $DTB_BLOB_OUTPUT"
-
-    if [ "$DTB_BLOBS_COUNT" -gt 1 ]; then
-      $TOOLCHAIN/bin/dtbTool -o arch/$TARGET_KERNEL_ARCH/boot/dtb.img -p scripts/dtc/ arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/
-    elif [ "$DTB_BLOBS_COUNT" -eq 1 ]; then
-      cp -PR $DTB_BLOBS $DTB_BLOB_OUTPUT
-    else
-      ANDROID_BOOTIMG_SECOND=""
-    fi
-
-    LDFLAGS="" mkbootimg --kernel arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_TARGET --ramdisk $BUILD/image/initramfs.cpio \
-      $ANDROID_BOOTIMG_SECOND $ANDROID_BOOTIMG_OPTIONS --output arch/$TARGET_KERNEL_ARCH/boot/boot.img
+    find_file_path bootloader/mkbootimg && source ${FOUND_PATH}
 
     mv -f arch/$TARGET_KERNEL_ARCH/boot/boot.img arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_TARGET
-
   fi
 }
 

--- a/projects/Amlogic/bootloader/mkbootimg
+++ b/projects/Amlogic/bootloader/mkbootimg
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+DTB_BLOBS=($(ls arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/*.dtb 2>/dev/null || true))
+DTB_BLOBS_COUNT="${#DTB_BLOBS[@]}"
+DTB_BLOB_OUTPUT="arch/$TARGET_KERNEL_ARCH/boot/dtb.img"
+ANDROID_BOOTIMG_SECOND="--second $DTB_BLOB_OUTPUT"
+
+if [ "$DTB_BLOBS_COUNT" -gt 1 ]; then
+  $TOOLCHAIN/bin/dtbTool -o arch/$TARGET_KERNEL_ARCH/boot/dtb.img -p scripts/dtc/ arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/
+elif [ "$DTB_BLOBS_COUNT" -eq 1 ]; then
+  cp -PR $DTB_BLOBS $DTB_BLOB_OUTPUT
+else
+  ANDROID_BOOTIMG_SECOND=""
+fi
+
+LDFLAGS="" mkbootimg --kernel arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_TARGET --ramdisk $BUILD/image/initramfs.cpio \
+  $ANDROID_BOOTIMG_SECOND $ANDROID_BOOTIMG_OPTIONS --output arch/$TARGET_KERNEL_ARCH/boot/boot.img

--- a/projects/WeTek_Core/bootloader/mkbootimg
+++ b/projects/WeTek_Core/bootloader/mkbootimg
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+DTB_BLOBS=($(ls arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/*.dtb 2>/dev/null || true))
+DTB_BLOBS_COUNT="${#DTB_BLOBS[@]}"
+DTB_BLOB_OUTPUT="arch/$TARGET_KERNEL_ARCH/boot/dtb.img"
+ANDROID_BOOTIMG_SECOND="--second $DTB_BLOB_OUTPUT"
+
+if [ "$DTB_BLOBS_COUNT" -gt 1 ]; then
+  $TOOLCHAIN/bin/dtbTool -o arch/$TARGET_KERNEL_ARCH/boot/dtb.img -p scripts/dtc/ arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/
+elif [ "$DTB_BLOBS_COUNT" -eq 1 ]; then
+  cp -PR $DTB_BLOBS $DTB_BLOB_OUTPUT
+else
+  ANDROID_BOOTIMG_SECOND=""
+fi
+
+LDFLAGS="" mkbootimg --kernel arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_TARGET --ramdisk $BUILD/image/initramfs.cpio \
+  $ANDROID_BOOTIMG_SECOND $ANDROID_BOOTIMG_OPTIONS --output arch/$TARGET_KERNEL_ARCH/boot/boot.img


### PR DESCRIPTION
…ders

This moves some of the boiler plate to the platform. One main reason that I want to do this is because the dragonboard uses a different mkbootimg binary with different parameters and it's not nice ifdeffing the linux package to make it even more confusing. This duplicates some code but should be unified when the mainline amlogic project is ready.