### PR TITLE
linux (RPi): update to linux-4.14.62

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="83146e2"
-PKG_SHA256="e95194fd507e229d7fb9ae98f42346c0001e7f6871d21c20f1a15aa173bcafd0"
+PKG_VERSION="9c78bf4"
+PKG_SHA256="fdc42cdcc24244a7c2cb26440ade78249b98aec6044ff70a9e6d69a9e95bf840"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="d3c3d03"
-PKG_SHA256="f4625d5dbdf7412fcc6f419e019b5fa72a151465c9dc36ec7b81387dc6b9808b"
+PKG_VERSION="bffe7ee"
+PKG_SHA256="9ae9056cd86e2c8cda467cc10eab0da1e15c1bf050b0ca5bff9c7a6355108ebd"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="bffe7ee"
-PKG_SHA256="9ae9056cd86e2c8cda467cc10eab0da1e15c1bf050b0ca5bff9c7a6355108ebd"
+PKG_VERSION="83146e2"
+PKG_SHA256="e95194fd507e229d7fb9ae98f42346c0001e7f6871d21c20f1a15aa173bcafd0"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/linux-drivers/RTL8812AU/package.mk
+++ b/packages/linux-drivers/RTL8812AU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8812AU"
-PKG_VERSION="af07b27"
-PKG_SHA256="a2c3c9554ec0a586e879684ba87b08bdbde5cd30231b4794f3a10ef822e461fc"
+PKG_VERSION="ff2f1dd"
+PKG_SHA256="79419ab37482b7098d9aa995c9be8e3f2f9bccfae20d0b0ccfefe0da9a03d144"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/paspro/rtl8812au"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -41,8 +41,8 @@ case "$LINUX" in
     PKG_SOURCE_DIR="kernel-$PKG_VERSION"
     ;;
   raspberrypi)
-    PKG_VERSION="ad1d85ad2a7dea6a17e6d3cc32adf6ce0ea844c0" # 4.14.59
-    PKG_SHA256="67bf83e782fe47de7a49061ffcc70b1ea16eb519772f6ad575c39c40c4fcbe1b"
+    PKG_VERSION="52d350fb107dbd9fa30d44685ed52d2c52b09d96" # 4.14.61
+    PKG_SHA256="b339528dc4b0156ebc0613262a415169ddaf6143e5a9971414f1224a075dbc15"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     ;;
   *)

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -41,8 +41,8 @@ case "$LINUX" in
     PKG_SOURCE_DIR="kernel-$PKG_VERSION"
     ;;
   raspberrypi)
-    PKG_VERSION="a06f9e522301dfacc1f382d72e6a9792d8350328" # 4.14.58
-    PKG_SHA256="83b1186f4f9012ee36b386798f31020109117e68b9b021172164bfec1f81559f"
+    PKG_VERSION="ad1d85ad2a7dea6a17e6d3cc32adf6ce0ea844c0" # 4.14.59
+    PKG_SHA256="67bf83e782fe47de7a49061ffcc70b1ea16eb519772f6ad575c39c40c4fcbe1b"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     ;;
   *)

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -41,8 +41,8 @@ case "$LINUX" in
     PKG_SOURCE_DIR="kernel-$PKG_VERSION"
     ;;
   raspberrypi)
-    PKG_VERSION="52d350fb107dbd9fa30d44685ed52d2c52b09d96" # 4.14.61
-    PKG_SHA256="b339528dc4b0156ebc0613262a415169ddaf6143e5a9971414f1224a075dbc15"
+    PKG_VERSION="1f89ad77bf9b204c18fb6fdd167b4ee92d064f95" # 4.14.62
+    PKG_SHA256="153deef35bf1895fb0825395c0f9fb61832dcf0131987fce99449beb17afa173"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     ;;
   *)

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -41,8 +41,8 @@ case "$LINUX" in
     PKG_SOURCE_DIR="kernel-$PKG_VERSION"
     ;;
   raspberrypi)
-    PKG_VERSION="db81c14ce9fbd705c2d3936edecbc6036ace6c05" # 4.14.54
-    PKG_SHA256="ae553b2deb6854646e56369cab57d3018bca2056b2ca2752c5e051093968635e"
+    PKG_VERSION="8fcf78e13c6661580af6639b3d5322ab81361dd2" # 4.14.56
+    PKG_SHA256="f507908a9445ff1205607736f1e657f9e03eb4043d6cc908ba698a8c92a93a57"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     ;;
   *)

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -41,8 +41,8 @@ case "$LINUX" in
     PKG_SOURCE_DIR="kernel-$PKG_VERSION"
     ;;
   raspberrypi)
-    PKG_VERSION="8fcf78e13c6661580af6639b3d5322ab81361dd2" # 4.14.56
-    PKG_SHA256="f507908a9445ff1205607736f1e657f9e03eb4043d6cc908ba698a8c92a93a57"
+    PKG_VERSION="a06f9e522301dfacc1f382d72e6a9792d8350328" # 4.14.58
+    PKG_SHA256="83b1186f4f9012ee36b386798f31020109117e68b9b021172164bfec1f81559f"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     ;;
   *)

--- a/packages/linux/patches/raspberrypi/linux-999-improve-ir-timeout-handling.patch
+++ b/packages/linux/patches/raspberrypi/linux-999-improve-ir-timeout-handling.patch
@@ -1,7 +1,7 @@
-From 057ccfd1d18842bd2fa39c4b996a9a952c5a821d Mon Sep 17 00:00:00 2001
+From 8ff44dfe7971a9ed7308945c0d609a54be5051a2 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:35:11 +0200
-Subject: [PATCH 01/11] media: rc: set timeout to smallest value required by
+Subject: [PATCH 01/10] media: rc: set timeout to smallest value required by
  enabled protocols
 
 backport of https://patchwork.linuxtv.org/patch/48516/
@@ -31,7 +31,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  12 files changed, 46 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/media/rc/ir-jvc-decoder.c b/drivers/media/rc/ir-jvc-decoder.c
-index e2bd68c42edf..fc931fe39bb7 100644
+index e2bd68c..fc931fe 100644
 --- a/drivers/media/rc/ir-jvc-decoder.c
 +++ b/drivers/media/rc/ir-jvc-decoder.c
 @@ -212,6 +212,7 @@ static struct ir_raw_handler jvc_handler = {
@@ -43,10 +43,10 @@ index e2bd68c42edf..fc931fe39bb7 100644
  
  static int __init ir_jvc_decode_init(void)
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 7c572a643656..7afeab04dbbf 100644
+index 2a1728e..04c0c28 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
-@@ -474,6 +474,7 @@ static struct ir_raw_handler mce_kbd_handler = {
+@@ -476,6 +476,7 @@ static struct ir_raw_handler mce_kbd_handler = {
  	.encode		= ir_mce_kbd_encode,
  	.raw_register	= ir_mce_kbd_register,
  	.raw_unregister	= ir_mce_kbd_unregister,
@@ -55,7 +55,7 @@ index 7c572a643656..7afeab04dbbf 100644
  
  static int __init ir_mce_kbd_decode_init(void)
 diff --git a/drivers/media/rc/ir-nec-decoder.c b/drivers/media/rc/ir-nec-decoder.c
-index a95d09acc22a..3e12059add84 100644
+index a95d09a..3e12059 100644
 --- a/drivers/media/rc/ir-nec-decoder.c
 +++ b/drivers/media/rc/ir-nec-decoder.c
 @@ -264,6 +264,7 @@ static struct ir_raw_handler nec_handler = {
@@ -67,7 +67,7 @@ index a95d09acc22a..3e12059add84 100644
  
  static int __init ir_nec_decode_init(void)
 diff --git a/drivers/media/rc/ir-rc5-decoder.c b/drivers/media/rc/ir-rc5-decoder.c
-index 1292f534de43..1eaca0528b69 100644
+index 1292f53..1eaca05 100644
 --- a/drivers/media/rc/ir-rc5-decoder.c
 +++ b/drivers/media/rc/ir-rc5-decoder.c
 @@ -282,6 +282,7 @@ static struct ir_raw_handler rc5_handler = {
@@ -79,7 +79,7 @@ index 1292f534de43..1eaca0528b69 100644
  
  static int __init ir_rc5_decode_init(void)
 diff --git a/drivers/media/rc/ir-rc6-decoder.c b/drivers/media/rc/ir-rc6-decoder.c
-index 5d0d2fe3b7a7..8c4c733a5f27 100644
+index 5d0d2fe..8c4c733 100644
 --- a/drivers/media/rc/ir-rc6-decoder.c
 +++ b/drivers/media/rc/ir-rc6-decoder.c
 @@ -408,6 +408,7 @@ static struct ir_raw_handler rc6_handler = {
@@ -91,7 +91,7 @@ index 5d0d2fe3b7a7..8c4c733a5f27 100644
  
  static int __init ir_rc6_decode_init(void)
 diff --git a/drivers/media/rc/ir-sanyo-decoder.c b/drivers/media/rc/ir-sanyo-decoder.c
-index 758c60956850..935880d4889e 100644
+index 758c609..935880d 100644
 --- a/drivers/media/rc/ir-sanyo-decoder.c
 +++ b/drivers/media/rc/ir-sanyo-decoder.c
 @@ -218,6 +218,7 @@ static struct ir_raw_handler sanyo_handler = {
@@ -103,7 +103,7 @@ index 758c60956850..935880d4889e 100644
  
  static int __init ir_sanyo_decode_init(void)
 diff --git a/drivers/media/rc/ir-sharp-decoder.c b/drivers/media/rc/ir-sharp-decoder.c
-index 129b558acc92..96d818bd0cc9 100644
+index 129b558..96d818b 100644
 --- a/drivers/media/rc/ir-sharp-decoder.c
 +++ b/drivers/media/rc/ir-sharp-decoder.c
 @@ -226,6 +226,7 @@ static struct ir_raw_handler sharp_handler = {
@@ -115,7 +115,7 @@ index 129b558acc92..96d818bd0cc9 100644
  
  static int __init ir_sharp_decode_init(void)
 diff --git a/drivers/media/rc/ir-sony-decoder.c b/drivers/media/rc/ir-sony-decoder.c
-index a47ced763031..d57d15b431f6 100644
+index a47ced7..d57d15b 100644
 --- a/drivers/media/rc/ir-sony-decoder.c
 +++ b/drivers/media/rc/ir-sony-decoder.c
 @@ -221,6 +221,7 @@ static struct ir_raw_handler sony_handler = {
@@ -127,7 +127,7 @@ index a47ced763031..d57d15b431f6 100644
  
  static int __init ir_sony_decode_init(void)
 diff --git a/drivers/media/rc/ir-xmp-decoder.c b/drivers/media/rc/ir-xmp-decoder.c
-index 6f464be1c8d7..1ac3a4cee69e 100644
+index 6f464be..1ac3a4c 100644
 --- a/drivers/media/rc/ir-xmp-decoder.c
 +++ b/drivers/media/rc/ir-xmp-decoder.c
 @@ -198,6 +198,7 @@ static int ir_xmp_decode(struct rc_dev *dev, struct ir_raw_event ev)
@@ -139,7 +139,7 @@ index 6f464be1c8d7..1ac3a4cee69e 100644
  
  static int __init ir_xmp_decode_init(void)
 diff --git a/drivers/media/rc/rc-core-priv.h b/drivers/media/rc/rc-core-priv.h
-index 7da9c96cb058..5fd3b5aed9ec 100644
+index 7da9c96..5fd3b5a 100644
 --- a/drivers/media/rc/rc-core-priv.h
 +++ b/drivers/media/rc/rc-core-priv.h
 @@ -29,6 +29,7 @@ struct ir_raw_handler {
@@ -151,7 +151,7 @@ index 7da9c96cb058..5fd3b5aed9ec 100644
  	/* These two should only be used by the lirc decoder */
  	int (*raw_register)(struct rc_dev *dev);
 diff --git a/drivers/media/rc/rc-ir-raw.c b/drivers/media/rc/rc-ir-raw.c
-index 503bc425a187..7f0197bf5d32 100644
+index 503bc42..7f0197b 100644
 --- a/drivers/media/rc/rc-ir-raw.c
 +++ b/drivers/media/rc/rc-ir-raw.c
 @@ -215,7 +215,36 @@ ir_raw_get_allowed_protocols(void)
@@ -193,7 +193,7 @@ index 503bc425a187..7f0197bf5d32 100644
  }
  
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index 72f381522cb2..e7e20bcfe272 100644
+index 72f3815..e7e20bc 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -1161,6 +1161,9 @@ static ssize_t store_protocols(struct device *device,
@@ -237,13 +237,13 @@ index 72f381522cb2..e7e20bcfe272 100644
  	set_bit(EV_REP, dev->input_dev->evbit);
  	set_bit(EV_MSC, dev->input_dev->evbit);
 -- 
-2.11.0
+2.14.1
 
 
-From 00f54931b0ff7202020567544605b7e3c4f1dee8 Mon Sep 17 00:00:00 2001
+From c750791828e2842dfc63b2d4fa1a4c6ce2054147 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Tue, 27 Mar 2018 19:45:36 +0200
-Subject: [PATCH 02/11] media: rc: per-protocol repeat period and minimum keyup
+Subject: [PATCH 02/10] media: rc: per-protocol repeat period and minimum keyup
  timer
 
 backport of https://patchwork.linuxtv.org/patch/48520/
@@ -265,7 +265,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  3 files changed, 30 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/media/cec/cec-core.c b/drivers/media/cec/cec-core.c
-index 648136e552d5..4cf35e4af7bd 100644
+index 648136e..4cf35e4 100644
 --- a/drivers/media/cec/cec-core.c
 +++ b/drivers/media/cec/cec-core.c
 @@ -280,7 +280,7 @@ struct cec_adapter *cec_allocate_adapter(const struct cec_adap_ops *ops,
@@ -278,7 +278,7 @@ index 648136e552d5..4cf35e4af7bd 100644
  #endif
  	return adap;
 diff --git a/drivers/media/rc/ir-lirc-codec.c b/drivers/media/rc/ir-lirc-codec.c
-index 4c8f456238bc..ef7e43038092 100644
+index 4c8f456..ef7e430 100644
 --- a/drivers/media/rc/ir-lirc-codec.c
 +++ b/drivers/media/rc/ir-lirc-codec.c
 @@ -314,7 +314,7 @@ static long ir_lirc_ioctl(struct file *filep, unsigned int cmd,
@@ -291,7 +291,7 @@ index 4c8f456238bc..ef7e43038092 100644
  
  		lirc->send_timeout_reports = !!val;
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index e7e20bcfe272..36f99a0919c3 100644
+index e7e20bc..36f99a0 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -35,48 +35,48 @@ static const struct {
@@ -403,13 +403,13 @@ index e7e20bcfe272..36f99a0919c3 100644
  			    (unsigned long)dev);
  
 -- 
-2.11.0
+2.14.1
 
 
-From 6f3d979fa02a3847799d838a03ad9c5ad009a778 Mon Sep 17 00:00:00 2001
+From b175295d3cc86f88c2bbd04938f690cae475db53 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:39 +0100
-Subject: [PATCH 03/11] media: rc: mce_kbd decoder: low timeout values cause
+Subject: [PATCH 03/10] media: rc: mce_kbd decoder: low timeout values cause
  double keydowns
 
 backport of https://patchwork.linuxtv.org/patch/48522/
@@ -429,10 +429,10 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 7afeab04dbbf..a243d2d1ca93 100644
+index 04c0c28..c157682 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
-@@ -319,11 +319,13 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
+@@ -321,11 +321,13 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
  		case MCIR2_KEYBOARD_NBITS:
  			scancode = data->body & 0xffff;
  			IR_dprintk(1, "keyboard data 0x%08x\n", data->body);
@@ -452,13 +452,13 @@ index 7afeab04dbbf..a243d2d1ca93 100644
  			ir_mce_kbd_process_keyboard_data(data->idev, scancode);
  			break;
 -- 
-2.11.0
+2.14.1
 
 
-From f4d8df33339167784bb6a17e3ee2d20f9efe1b21 Mon Sep 17 00:00:00 2001
+From 184b30f98772d4a1fd41572f5764bdef4d345bf7 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:40 +0100
-Subject: [PATCH 04/11] media: rc: mce_kbd protocol encodes two scancodes
+Subject: [PATCH 04/10] media: rc: mce_kbd protocol encodes two scancodes
 
 backport of https://patchwork.linuxtv.org/patch/48518/
 
@@ -473,10 +473,10 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  2 files changed, 13 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index a243d2d1ca93..2ea48a54f2b3 100644
+index c157682..164302e 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
-@@ -147,13 +147,14 @@ static enum mce_kbd_mode mce_kbd_mode(struct mce_kbd_dec *data)
+@@ -149,13 +149,14 @@ static enum mce_kbd_mode mce_kbd_mode(struct mce_kbd_dec *data)
  static void ir_mce_kbd_process_keyboard_data(struct input_dev *idev,
  					     u32 scancode)
  {
@@ -495,7 +495,7 @@ index a243d2d1ca93..2ea48a54f2b3 100644
  
  	for (i = 0; i < 7; i++) {
  		maskcode = kbd_keycodes[MCIR2_MASK_KEYS_START + i];
-@@ -164,10 +165,12 @@ static void ir_mce_kbd_process_keyboard_data(struct input_dev *idev,
+@@ -166,10 +167,12 @@ static void ir_mce_kbd_process_keyboard_data(struct input_dev *idev,
  		input_report_key(idev, maskcode, keystate);
  	}
  
@@ -512,7 +512,7 @@ index a243d2d1ca93..2ea48a54f2b3 100644
  		for (i = 0; i < MCIR2_MASK_KEYS_START; i++)
  			input_report_key(idev, kbd_keycodes[i], 0);
  	}
-@@ -317,7 +320,7 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
+@@ -319,7 +322,7 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
  
  		switch (data->wanted_bits) {
  		case MCIR2_KEYBOARD_NBITS:
@@ -522,7 +522,7 @@ index a243d2d1ca93..2ea48a54f2b3 100644
  			if (scancode) {
  				delay = nsecs_to_jiffies(dev->timeout) +
 diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
-index 36f99a0919c3..34cef7aa207c 100644
+index 36f99a0..34cef7a 100644
 --- a/drivers/media/rc/rc-main.c
 +++ b/drivers/media/rc/rc-main.c
 @@ -60,7 +60,7 @@ static const struct {
@@ -535,48 +535,13 @@ index 36f99a0919c3..34cef7aa207c 100644
  		.scancode_bits = 0x1fffff, .repeat_period = 100 },
  	[RC_PROTO_RC6_0] = { .name = "rc-6-0",
 -- 
-2.11.0
+2.14.1
 
 
-From 8b0ffc3eccf8737aa93c6b7bf9bc9d1e10d634bd Mon Sep 17 00:00:00 2001
-From: Sean Young <sean@mess.org>
-Date: Sun, 8 Apr 2018 22:19:41 +0100
-Subject: [PATCH 05/11] media: rc: mce_kbd decoder: fix stuck keys
-
-backport of https://patchwork.linuxtv.org/patch/48519/
-
-The MCE Remote sends a 0 scancode when keys are released. If this is not
-received or decoded, then keys can get "stuck"; the keyup event is not
-sent since the input_sync() is missing from the timeout handler.
-
-Cc: stable@vger.kernel.org
-Signed-off-by: Sean Young <sean@mess.org>
-Signed-off-by: Matthias Reichl <hias@horus.com>
----
- drivers/media/rc/ir-mce_kbd-decoder.c | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 2ea48a54f2b3..164302ec4fef 100644
---- a/drivers/media/rc/ir-mce_kbd-decoder.c
-+++ b/drivers/media/rc/ir-mce_kbd-decoder.c
-@@ -130,6 +130,8 @@ static void mce_kbd_rx_timeout(unsigned long data)
- 
- 	for (i = 0; i < MCIR2_MASK_KEYS_START; i++)
- 		input_report_key(mce_kbd->idev, kbd_keycodes[i], 0);
-+
-+	input_sync(mce_kbd->idev);
- }
- 
- static enum mce_kbd_mode mce_kbd_mode(struct mce_kbd_dec *data)
--- 
-2.11.0
-
-
-From b77de094b54449079890b8cc4fbc2f98573253b2 Mon Sep 17 00:00:00 2001
+From 455d3ec9f3b931f0b78bffdbff2a420891d1c609 Mon Sep 17 00:00:00 2001
 From: Sean Young <sean@mess.org>
 Date: Sun, 8 Apr 2018 22:19:42 +0100
-Subject: [PATCH 06/11] media: rc: mceusb: allow the timeout to be configurable
+Subject: [PATCH 05/10] media: rc: mceusb: allow the timeout to be configurable
 
 backport of https://patchwork.linuxtv.org/patch/48521/
 
@@ -589,7 +554,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 22 insertions(+)
 
 diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
-index bf7aaff3aa37..160754a7a382 100644
+index bf7aaff..160754a 100644
 --- a/drivers/media/rc/mceusb.c
 +++ b/drivers/media/rc/mceusb.c
 @@ -937,6 +937,25 @@ static int mceusb_set_tx_carrier(struct rc_dev *dev, u32 carrier)
@@ -630,13 +595,13 @@ index bf7aaff3aa37..160754a7a382 100644
  		rc->s_tx_mask = mceusb_set_tx_mask;
  		rc->s_tx_carrier = mceusb_set_tx_carrier;
 -- 
-2.11.0
+2.14.1
 
 
-From dccebb7231209acb8da7f9f1e8fd1e7c12c3e70f Mon Sep 17 00:00:00 2001
+From a95d47e2c9ae3d8c826ca14fe6973138bf57d0aa Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:26:21 +0200
-Subject: [PATCH 07/11] media: rc: mce_kbd decoder: remove superfluous call to
+Subject: [PATCH 06/10] media: rc: mce_kbd decoder: remove superfluous call to
  input_sync
 
 backport of https://patchwork.linuxtv.org/patch/48681/
@@ -651,7 +616,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index 164302ec4fef..f057b57074c9 100644
+index 164302e..f057b57 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -355,7 +355,6 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
@@ -663,13 +628,13 @@ index 164302ec4fef..f057b57074c9 100644
  }
  
 -- 
-2.11.0
+2.14.1
 
 
-From 731b38824c8145bbc7d55a9c2af4e449ff5988fb Mon Sep 17 00:00:00 2001
+From fd0375f3b8a3eee6fbc9ea6c570132e5a2feb239 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Sun, 15 Apr 2018 17:38:49 +0200
-Subject: [PATCH 08/11] media: rc: mce_kbd decoder: fix race condition
+Subject: [PATCH 07/10] media: rc: mce_kbd decoder: fix race condition
 
 backport of https://patchwork.linuxtv.org/patch/48680/
 
@@ -692,7 +657,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  2 files changed, 17 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
-index f057b57074c9..67c37db76737 100644
+index f057b57..67c37db 100644
 --- a/drivers/media/rc/ir-mce_kbd-decoder.c
 +++ b/drivers/media/rc/ir-mce_kbd-decoder.c
 @@ -120,18 +120,24 @@ static void mce_kbd_rx_timeout(unsigned long data)
@@ -752,7 +717,7 @@ index f057b57074c9..67c37db76737 100644
  	input_set_drvdata(idev, mce_kbd);
  
 diff --git a/drivers/media/rc/rc-core-priv.h b/drivers/media/rc/rc-core-priv.h
-index 5fd3b5aed9ec..77928ae43104 100644
+index 5fd3b5a..77928ae 100644
 --- a/drivers/media/rc/rc-core-priv.h
 +++ b/drivers/media/rc/rc-core-priv.h
 @@ -97,6 +97,7 @@ struct ir_raw_event_ctrl {
@@ -764,13 +729,13 @@ index 5fd3b5aed9ec..77928ae43104 100644
  		char phys[64];
  		int state;
 -- 
-2.11.0
+2.14.1
 
 
-From 4e363f78b2aae387980ac411e0f901caee5da9e1 Mon Sep 17 00:00:00 2001
+From 47633baec95db9c03d61ce59f47e67ee485f394c Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Wed, 18 Apr 2018 13:50:52 +0200
-Subject: [PATCH 09/11] media: rc: mceusb: IR of length 0 means IR timeout, not
+Subject: [PATCH 08/10] media: rc: mceusb: IR of length 0 means IR timeout, not
  reset
 
 backport of https://patchwork.linuxtv.org/patch/48782/
@@ -785,7 +750,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
-index 160754a7a382..dc7ebed00b3a 100644
+index 160754a..dc7ebed 100644
 --- a/drivers/media/rc/mceusb.c
 +++ b/drivers/media/rc/mceusb.c
 @@ -1056,8 +1056,14 @@ static void mceusb_process_ir_data(struct mceusb_dev *ir, int buf_len)
@@ -806,13 +771,13 @@ index 160754a7a382..dc7ebed00b3a 100644
  		}
  
 -- 
-2.11.0
+2.14.1
 
 
-From f74716d6fc4a38f56a374a00cb96be61f2d6fc2d Mon Sep 17 00:00:00 2001
+From ebb32fcc2aa4ebfce182fce11c4a203c4a6a908e Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Thu, 10 May 2018 10:42:24 +0200
-Subject: [PATCH 10/11] media: mceusb: MCE_CMD_SETIRTIMEOUT cause strange
+Subject: [PATCH 09/10] media: mceusb: MCE_CMD_SETIRTIMEOUT cause strange
  behaviour on device
 
 backport of https://patchwork.linuxtv.org/patch/49409/
@@ -828,7 +793,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 18 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
-index dc7ebed00b3a..2e1241f09c9d 100644
+index dc7ebed..2e1241f 100644
 --- a/drivers/media/rc/mceusb.c
 +++ b/drivers/media/rc/mceusb.c
 @@ -181,6 +181,7 @@ enum mceusb_model_type {
@@ -888,13 +853,13 @@ index dc7ebed00b3a..2e1241f09c9d 100644
  		rc->s_tx_mask = mceusb_set_tx_mask;
  		rc->s_tx_carrier = mceusb_set_tx_carrier;
 -- 
-2.11.0
+2.14.1
 
 
-From 0899b373cb0604ed80a80b501dd48cf6a3cbff25 Mon Sep 17 00:00:00 2001
+From f3db736f8a5b4278b7b2907d5c5c5fc2b76605a6 Mon Sep 17 00:00:00 2001
 From: Matthias Reichl <hias@horus.com>
 Date: Fri, 11 May 2018 12:20:44 +0200
-Subject: [PATCH 11/11] media: mceusb: filter out bogus timing irdata of
+Subject: [PATCH 10/10] media: mceusb: filter out bogus timing irdata of
  duration 0
 
 Backport of https://patchwork.linuxtv.org/patch/49430/
@@ -910,7 +875,7 @@ Signed-off-by: Matthias Reichl <hias@horus.com>
  1 file changed, 6 insertions(+)
 
 diff --git a/drivers/media/rc/mceusb.c b/drivers/media/rc/mceusb.c
-index 2e1241f09c9d..7864a30c4f9e 100644
+index 2e1241f..7864a30 100644
 --- a/drivers/media/rc/mceusb.c
 +++ b/drivers/media/rc/mceusb.c
 @@ -1038,6 +1038,12 @@ static void mceusb_process_ir_data(struct mceusb_dev *ir, int buf_len)
@@ -927,5 +892,5 @@ index 2e1241f09c9d..7864a30c4f9e 100644
  				rawir.pulse ? "pulse" : "space",
  				rawir.duration);
 -- 
-2.11.0
+2.14.1
 

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="bffe7ee"
-PKG_SHA256="1731a67cc435f0510ea82a8813a301c4b08244578493e3dcb05e1380fc52993f"
+PKG_VERSION="83146e2"
+PKG_SHA256="5df850bf2f54107e88cddabff2d3d209400bdc43de37eac2211bb804ffa3dedc"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="83146e2"
-PKG_SHA256="5df850bf2f54107e88cddabff2d3d209400bdc43de37eac2211bb804ffa3dedc"
+PKG_VERSION="9c78bf4"
+PKG_SHA256="b6ea09f5bf45a36861ebeae83ad74f384603c4d0be20862e8b639f568956ee7d"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="d3c3d03"
-PKG_SHA256="da488f8993cefbc503983e55aef4032ea4779654faafd1d3b09119a8ec834c13"
+PKG_VERSION="bffe7ee"
+PKG_SHA256="1731a67cc435f0510ea82a8813a301c4b08244578493e3dcb05e1380fc52993f"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.14.37 Kernel Configuration
+# Linux/arm 4.14.62 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_ARM_HAS_SG_CHAIN=y
@@ -2176,6 +2176,7 @@ CONFIG_HWMON=y
 # CONFIG_SENSORS_PCF8591 is not set
 # CONFIG_PMBUS is not set
 # CONFIG_SENSORS_PWM_FAN is not set
+CONFIG_SENSORS_RPI_POE_FAN=m
 # CONFIG_SENSORS_SHT15 is not set
 # CONFIG_SENSORS_SHT21 is not set
 # CONFIG_SENSORS_SHT3x is not set

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.14.37 Kernel Configuration
+# Linux/arm 4.14.62 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_ARM_HAS_SG_CHAIN=y
@@ -2273,6 +2273,7 @@ CONFIG_HWMON=y
 # CONFIG_SENSORS_PCF8591 is not set
 # CONFIG_PMBUS is not set
 # CONFIG_SENSORS_PWM_FAN is not set
+CONFIG_SENSORS_RPI_POE_FAN=m
 # CONFIG_SENSORS_SHT15 is not set
 # CONFIG_SENSORS_SHT21 is not set
 # CONFIG_SENSORS_SHT3x is not set


### PR DESCRIPTION
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.55
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.56
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.57
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.58
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.59
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.60
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.61
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.62

Includes POE HAT fan suppport.