### PR TITLE
libretro-mame: update to libretro-mame-c816514

### DIFF
--- a/packages/emulation/libretro-mame/package.mk
+++ b/packages/emulation/libretro-mame/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame"
-PKG_VERSION="3f5b1456"
-PKG_SHA256="6814be8a249bef7bd847ba51ef5f10c94ca3b8d996b772d5ef4ee7304bd31b3f"
+PKG_VERSION="c816514"
+PKG_SHA256="2aff1615e7f298210e4bc3342b3472ed0cab275b91bc0f3ba7c062ce2958be6a"
 PKG_ARCH="x86_64 arm"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mame"


### PR DESCRIPTION
Resolves issue with incorrect PKG_SHA256.