### PR TITLE
create_addon: change jenkins sha256 files

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -90,8 +90,9 @@ pack_addon() {
       mkdir -p "$ADDON_JENKINS_DIR"
       cd $ADDON_INSTALL_DIR
       $TOOLCHAIN/bin/7za a -l -mx0 -bsp0 -bso0 -tzip $ADDON_JENKINS_DIR/$ADDON_JENKINS_ADDON_NAME.zip $PKG_ADDON_ID-$ADDONVER.zip resources/
-      ADDON_SHA256="$(sha256sum $ADDON_JENKINS_DIR/$ADDON_JENKINS_ADDON_NAME.zip | cut -d" " -f1)"
-      echo ${ADDON_SHA256} > $ADDON_JENKINS_DIR/$ADDON_JENKINS_ADDON_NAME.zip.sha256
+      ( cd $ADDON_JENKINS_DIR
+        sha256sum $ADDON_JENKINS_ADDON_NAME.zip > $ADDON_JENKINS_ADDON_NAME.zip.sha256
+      )
       echo "*** creating $ADDON_JENKINS_ADDON_NAME.zip for Jenkins complete ***"
     fi
   fi


### PR DESCRIPTION
from 
```
$ cat 9.0-Generic-x86_64-driver.dvb.hdhomerun-9.0.101.zip.sha256
617e636517c149e67ddaee4bdef0883f17aa7de36eb96d65b653f08d26ebfe6d
```

to 
```
$ cat 9.0-Generic-x86_64-driver.dvb.hdhomerun-9.0.101.zip.sha256
617e636517c149e67ddaee4bdef0883f17aa7de36eb96d65b653f08d26ebfe6d  9.0-Generic-x86_64-driver.dvb.hdhomerun-9.0.101.zip
```
creates proper sha256 file instead just the hash