### PR TITLE
busybox: temporary fix for nfs based boot

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -38,6 +38,10 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --enable-lock-elision \
                            --disable-timezone-tools"
 
+# busybox:init needs it
+# testcase: boot with /storage as nfs-share (set cmdline.txt -> "ip=dhcp boot=UUID=2407-5145 disk=NFS=[nfs-share] quiet")
+PKG_CONFIGURE_OPTS_TARGET+=" --enable-obsolete-rpc"
+
 if build_with_debug; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-debug"
 else


### PR DESCRIPTION
partial revert of #2763 
`busybox:init` has problems with the drop of `obsolete-rpc`. The result was, no nfs mounts was possible from the initramfs.
Actual, i hadn't any idea, why it happens and howto fix it.
So rollback, for now.

ping @MilhouseVH 

PS: `busybox:target` is working fine, with nfs...