### PR TITLE
pulseaudio: silence some warnings

### DIFF
--- a/packages/audio/pulseaudio/system.d/pulseaudio.service
+++ b/packages/audio/pulseaudio/system.d/pulseaudio.service
@@ -5,7 +5,7 @@ After=syslog.target local-fs.target
 [Service]
 Type=dbus
 BusName=org.pulseaudio.Server
-ExecStart=/usr/bin/pulseaudio --system
+ExecStart=/usr/bin/pulseaudio --system --disallow-exit --exit-idle-time=-1 --disable-shm
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
This change gets rid of the `Running in system mode, ...` flannel.

@lrusak, @5schatten - any concerns?

Before:
```
NUC:~ # journalctl -a  _SYSTEMD_UNIT=pulseaudio.service
-- Logs begin at Fri 2018-08-03 21:20:15 BST, end at Fri 2018-08-03 21:49:46 BST. --
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] main.c: Running in system mode, but --disallow-exit not set.
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] main.c: Running in system mode, but --disallow-module-loading not set.
Aug 03 21:20:16 NUC pulseaudio[289]: N: [pulseaudio] main.c: Running in system mode, forcibly disabling SHM mode.
Aug 03 21:20:16 NUC pulseaudio[289]: N: [pulseaudio] main.c: Running in system mode, forcibly disabling exit idle time.
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] main.c: Home directory of user 'root' is not '/var/run/pulse', ignoring.
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] caps.c: Normally all extra capabilities would be dropped now, but that's impossible because PulseAudio was built without capabilities support.
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] main.c: OK, so you are running PA in system mode. Please make sure that you actually do want to do that.
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] main.c: Please read http://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/ for an explanation why system mode is usually a bad idea.
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] authkey.c: Failed to open cookie file '/var/run/pulse/.config/pulse/cookie': No such file or directory
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] authkey.c: Failed to load authentication key '/var/run/pulse/.config/pulse/cookie': No such file or directory
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] authkey.c: Failed to open cookie file '/var/run/pulse/.pulse-cookie': No such file or directory
Aug 03 21:20:16 NUC pulseaudio[289]: W: [pulseaudio] authkey.c: Failed to load authentication key '/var/run/pulse/.pulse-cookie': No such file or directory
Aug 03 21:20:16 NUC pulseaudio[289]: E: [pulseaudio] bluez5-util.c: GetManagedObjects() failed: org.freedesktop.DBus.Error.ServiceUnknown: The name org.bluez was not provided by any .service files
```
After:
```
NUC:~ # journalctl -a  _SYSTEMD_UNIT=pulseaudio.service
-- Logs begin at Fri 2018-08-03 22:14:28 BST, end at Fri 2018-08-03 22:15:05 BST. --
Aug 03 22:14:29 NUC pulseaudio[283]: W: [pulseaudio] main.c: Home directory of user 'root' is not '/var/run/pulse', ignoring.
Aug 03 22:14:29 NUC pulseaudio[283]: W: [pulseaudio] caps.c: Normally all extra capabilities would be dropped now, but that's impossible because PulseAudio was built without capabilities support.
Aug 03 22:14:29 NUC pulseaudio[283]: W: [pulseaudio] main.c: OK, so you are running PA in system mode. Please make sure that you actually do want to do that.
Aug 03 22:14:29 NUC pulseaudio[283]: W: [pulseaudio] main.c: Please read http://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/ for an explanation why system mode is usually a bad idea.
Aug 03 22:14:29 NUC pulseaudio[283]: W: [pulseaudio] authkey.c: Failed to open cookie file '/var/run/pulse/.config/pulse/cookie': No such file or directory
Aug 03 22:14:29 NUC pulseaudio[283]: W: [pulseaudio] authkey.c: Failed to load authentication key '/var/run/pulse/.config/pulse/cookie': No such file or directory
Aug 03 22:14:29 NUC pulseaudio[283]: W: [pulseaudio] authkey.c: Failed to open cookie file '/var/run/pulse/.pulse-cookie': No such file or directory
Aug 03 22:14:29 NUC pulseaudio[283]: W: [pulseaudio] authkey.c: Failed to load authentication key '/var/run/pulse/.pulse-cookie': No such file or directory
Aug 03 22:14:29 NUC pulseaudio[283]: E: [pulseaudio] bluez5-util.c: GetManagedObjects() failed: org.freedesktop.DBus.Error.ServiceUnknown: The name org.bluez was not provided by any .service files
```