### PR TITLE
samba: make services depend on network-online.target

### DIFF
--- a/packages/network/samba/system.d.opt/nmbd.service
+++ b/packages/network/samba/system.d.opt/nmbd.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Samba NMB Daemon
-After=network.target samba-config.service
+Wants=network-online.target samba-config.service
+After=network-online.target samba-config.service
 ConditionPathExists=!/storage/.cache/services/samba.disabled
 ConditionPathExists=/run/samba/smb.conf
-Wants=samba-config.service
 
 [Service]
 Type=forking

--- a/packages/network/samba/system.d.opt/smbd.service
+++ b/packages/network/samba/system.d.opt/smbd.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Samba SMB Daemon
-After=network.target samba-config.service
+Wants=network-online.target nmbd.service
+After=network-online.target nmbd.service
 ConditionPathExists=!/storage/.cache/services/samba.disabled
 ConditionPathExists=/run/samba/smb.conf
-Wants=samba-config.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Also cleanup interdependencies, ensuring:
```
   samba-config.service
   |
   +-- nmbd.service
       |
       +-- smbd.service
```