### PR TITLE
proftpd, net-snmp, openvpn: updates to recent version

### DIFF
--- a/packages/addons/service/net-snmp/changelog.txt
+++ b/packages/addons/service/net-snmp/changelog.txt
@@ -1,3 +1,6 @@
+106
+- update to 5.8
+
 105
 - Improve configuration screen
 - Make snmpv3 work again (missing include)

--- a/packages/addons/service/net-snmp/package.mk
+++ b/packages/addons/service/net-snmp/package.mk
@@ -2,13 +2,13 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="net-snmp"
-PKG_VERSION="5.7.3"
-PKG_SHA256="12ef89613c7707dc96d13335f153c1921efc9d61d3708ef09f3fc4a7014fb4f0"
-PKG_REV="105"
+PKG_VERSION="5.8"
+PKG_SHA256="b2fc3500840ebe532734c4786b0da4ef0a5f67e51ef4c86b3345d697e4976adf"
+PKG_REV="106"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.net-snmp.org"
-PKG_URL="http://sourceforge.net/projects/net-snmp/files/$PKG_NAME/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="https://sourceforge.net/projects/net-snmp/files/$PKG_NAME/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libnl openssl"
 PKG_SECTION="service"
 PKG_SHORTDESC="Simple Network Management Protocol utilities."

--- a/packages/addons/service/proftpd/changelog.txt
+++ b/packages/addons/service/proftpd/changelog.txt
@@ -1,2 +1,5 @@
+101
+- update to proftpd 1.3.6
+
 100
 - initial LibreELEC release

--- a/packages/addons/service/proftpd/package.mk
+++ b/packages/addons/service/proftpd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="proftpd"
-PKG_VERSION="1.3.5b"
-PKG_SHA256="afc1789f2478acf88dfdc7d70da90a4fa2786d628218e9574273295d044b4fc8"
+PKG_VERSION="1.3.6"
+PKG_SHA256="91ef74b143495d5ff97c4d4770c6804072a8c8eb1ad1ecc8cc541b40e152ecaf"
 PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.4.1"
-PKG_SHA256="fde9e22c6df7a335d2d58c6a4d5967be76df173c766a5c51ece57fd044c76ee5"
+PKG_VERSION="2.4.6"
+PKG_SHA256="4f6434fa541cc9e363434ea71a16a62cf2615fb2f16af5b38f43ab5939998c26"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="http://openvpn.net"
-PKG_URL="http://swupdate.openvpn.org/community/releases/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_SITE="https://openvpn.net"
+PKG_URL="https://swupdate.openvpn.org/community/releases/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain lzo openssl"
 PKG_SECTION="network"
 PKG_SHORTDESC="openvpn: a full featured SSL VPN software solution that integrates OpenVPN server capabilities."


### PR DESCRIPTION
proftpd to 1.3.6
net-snmp to 5.8
openvpn to 2.4.6

all build tested Generic & RPi2
proftpd and net-snmp functional tested on Generic