### PR TITLE
kodi: use HTTPS and SHA256 for LibreELEC repo addons

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -193,7 +193,7 @@
   DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 
 # Addon Server Url
-  ADDON_SERVER_URL="http://addons.libreelec.tv"
+  ADDON_SERVER_URL="https://addons.libreelec.tv"
 
 # set the addon dirs
   ADDON_PATH="$ADDON_VERSION/${DEVICE:-$PROJECT}/$TARGET_ARCH"

--- a/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.libreelec.tv"
 		name="LibreELEC Add-ons"
-		version="9.0.0"
+		version="9.0.1"
 		provider-name="Team LibreELEC">
 	<extension point="xbmc.addon.repository"
 		name="LibreELEC Add-ons">
 		<info>@ADDON_URL@/addons.xml.gz</info>
-		<checksum>@ADDON_URL@/addons.xml.gz.md5</checksum>
+		<checksum verify="sha256">@ADDON_URL@/addons.xml.gz.sha256</checksum>
 		<datadir zip="true">@ADDON_URL@</datadir>
 	</extension>
 	<extension point="xbmc.addon.metadata">


### PR DESCRIPTION
K18 logs `WARNING: Repository LibreELEC Add-ons uses plain HTTP for add-on downloads - this is insecure and will make your Kodi installation vulnerable to attacks if enabled!` unless the addon repo supports either HTTPS or uses SHA256 verification instead of MD5. This change implements both. To avoid path issues in existing addon databases we also need to increment the repo addon version. Next time around we should avoid bumping the repo addon version until we move from beta to release (as with the build-system repo version).