### PR TITLE
kodi: hack around broken non-X11 keyboard layouts until LE10

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 KODI_ROOT=$HOME/.kodi
 
@@ -37,4 +38,57 @@ if [ "$(uname -m)" = "x86_64" -o "$(uname -m)" = "aarch64" ]; then
   echo "MALLOC_MMAP_THRESHOLD_=524288" >> /run/libreelec/kodi.conf
 else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf
+
+  if [ -f /storage/.kodi/userdata/addon_data/service.libreelec.settings/oe_settings.xml ]; then
+    KBLAYOUT="$(xmlstarlet sel -t -v libreelec/settings/system/KeyboardLayout1 /storage/.kodi/userdata/addon_data/service.libreelec.settings/oe_settings.xml)"
+    if [ -n "${KBLAYOUT}" ]; then
+      # http://dev.alpinelinux.org/archive/bkeymaps/
+      # https://elinux.org/RPi_Keyboard_Layout#Basic_Layouts
+      val="${KBLAYOUT%%-*}"
+      case "${val}" in
+        azerty)
+          val="fr";;
+        bg_*)
+          val="bg";;
+        cf)
+          val="ca";; # French Canadian
+        croat)
+          val="hr";;
+        de_CH)
+          val="ch";;
+        fr_CH)
+          val="ch";;
+        hu*)
+          val="hu";;
+        it2)
+          val="it";;
+        jp106)
+          val="jp";;
+        mk0)
+          val="mk";; #Macedonian
+        nl2)
+          val="nl";;
+        pl[1-4])
+          val="pl";;
+        ro_*)
+          val="ro";;
+        ru_*)
+          val="ru";;
+        sg)
+          val="us";; #Singapore
+        slovene)
+          val="si";;
+        sr)
+          val="rs";; #Serbian
+        sv)
+          val="se";; #Swedish
+        tr*)
+          val="tr";; #Turkish
+        uk)
+          val="gb";;
+      esac
+      [ -f /usr/share/X11/xkb/symbols/$val ] || val="us"
+      echo "XKB_DEFAULT_LAYOUT=\"${val}\"" >> /run/libreelec/kodi.conf
+    fi
+  fi
 fi


### PR DESCRIPTION
This follows on from this comment/discussion: https://github.com/LibreELEC/LibreELEC.tv/pull/2536#issuecomment-397497347

It's now unlikely we'll fix this issue "properly" in time for LE9 as it requires more work in libinput and Kodi, which would mean users of ARM systems and non-US keyboards being left with "broken" keyboard layouts.

To avoid this, here is a very quick & (very) dirty fix that should allow non-US keyboard layouts to work on non-X11 systems, without introducing too much pain. The plan would be to remove this hack in LE10 and fix keyboard layouts and libinput properly.

![s1](https://i.imgur.com/9Ma7Wiq.jpg)

A restart of Kodi will be required for the layout change to take effect - for bonus points I could adapt the wording of the first keyboard layout help message - on X86_64 systems, two keyboards can be configured - in the LE Settings Addon, adding something along the lines of `... On ARM based systems a restart will be required for the new keyboard layout to take effect.`.

As the keyboard layout codes provided by [bkeymaps](http://dev.alpinelinux.org/archive/bkeymaps/) do not map cleanly to libinput, some adjustment is necessary before setting `XKB_DEFAULT_LAYOUT`, hence the mappings.

Anything that cannot be mapped successfully will default to `us` (eg. `ANSI-dvorak` etc.).

Minimal testing performed with a UK keyboard, but it seems to be working as expected (`shift-3` now produces `£` not `#`). I also selected `de` as a layout, and my `Z` and `Y` keys were swapped, which I think is correct.

I'll include this in my nightly builds to gather more feedback.