### PR TITLE
scripts/image: use maximum lzo and zstd compression level for images

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -231,9 +231,16 @@ rm -rf $TARGET_IMG/$IMAGE_NAME.kernel
 cp -PR $BUILD/linux-$(kernel_version)/arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_TARGET $TARGET_IMG/$IMAGE_NAME.kernel
 chmod 0644 $TARGET_IMG/$IMAGE_NAME.kernel
 
+# use strongest available compression level for images
+if [ "$SQUASHFS_COMPRESSION"  = "lzo" -o "${SQUASHFS_COMPRESSION:-gzip}" = "gzip" ]; then
+  SQUASHFS_COMPRESSION_OPTION="-Xcompression-level 9"
+elif [ "$SQUASHFS_COMPRESSION" = "zstd" ]; then
+  SQUASHFS_COMPRESSION_OPTION="-Xcompression-level 22"
+fi
+
 # create squashfs file, default to gzip if no compression configured
 echo "rm -rf \"$TARGET_IMG/$IMAGE_NAME.system\"" >> $FAKEROOT_SCRIPT
-echo "$TOOLCHAIN/bin/mksquashfs \"$BUILD/image/system\" \"$TARGET_IMG/$IMAGE_NAME.system\" -noappend -comp ${SQUASHFS_COMPRESSION:-gzip}" >> $FAKEROOT_SCRIPT
+echo "$TOOLCHAIN/bin/mksquashfs \"$BUILD/image/system\" \"$TARGET_IMG/$IMAGE_NAME.system\" -noappend -comp ${SQUASHFS_COMPRESSION:-gzip} ${SQUASHFS_COMPRESSION_OPTION}" >> $FAKEROOT_SCRIPT
 
 # run fakeroot
 $TOOLCHAIN/bin/fakeroot -- $FAKEROOT_SCRIPT


### PR DESCRIPTION
The compression methods used by mksquashfs take compression levels, which are trade offs between time spent compression and size of the compressed file. This makes use of them for lzo and zstd. For lzo, it's a ~40kb size savings, and for zstd it's about 500kb size savings.

I also tested gzip, where the size reduction was 4kb, and xz where size reduction was 8kb. If those reductions should be included, let me know. gzip is a simple -o squashfs_compression == gzip to the lzo test, while xz requires exporting a variable.