### PR TITLE
zstd, libgcrypt, libpng: package updates

### DIFF
--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.3.4"
-PKG_SHA256="92e41b6e8dd26bbd46248e8aa1d86f1551bc221a796277ae9362954f26d605a9"
+PKG_VERSION="1.3.5"
+PKG_SHA256="d6e1559e4cdb7c4226767d4ddc990bff5f9aab77085ff0d0490c828b025e2eea"
 PKG_ARCH="any"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"

--- a/packages/graphics/libpng/package.mk
+++ b/packages/graphics/libpng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="libpng"
-PKG_VERSION="1.6.29"
-PKG_SHA256="4245b684e8fe829ebb76186327bb37ce5a639938b219882b53d64bd3cfc5f239"
+PKG_VERSION="1.6.35"
+PKG_SHA256="23912ec8c9584917ed9b09c5023465d71709dce089be503c7867fec68a93bcd7"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.libpng.org/"

--- a/packages/security/libgcrypt/package.mk
+++ b/packages/security/libgcrypt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="libgcrypt"
-PKG_VERSION="1.8.1"
-PKG_SHA256="7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3"
+PKG_VERSION="1.8.3"
+PKG_SHA256="66ec90be036747602f2b48f98312361a9180c97c68a690a5f376fa0f67d0af7c"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.gnupg.org/"


### PR DESCRIPTION
This updates zstd to 1.3.5, libgcrypt to 1.8.3, and libpng to 1.6.35. All are built test for raspi3. zstd and libpng have been tested in deployment. Libgcrypt, looking at what depends on it, I don't have appropriate media to test it beyond building.