### PR TITLE
openssl: update to 1.0.2p

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="1.0.2o"
-PKG_SHA256="ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d"
+PKG_VERSION="1.0.2p"
+PKG_SHA256="50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.openssl.org"


### PR DESCRIPTION
build for Generic, RPi2
run test on RPi2