### PR TITLE
cputemp: add amdgpu, prefer dedicated gpu

### DIFF
--- a/packages/mediacenter/kodi/scripts/cputemp
+++ b/packages/mediacenter/kodi/scripts/cputemp
@@ -19,14 +19,11 @@ if [ $(basename "$0") = "gputemp" -o "$1" = "gpu" ]; then
     for hwmon in /sys/class/hwmon/*; do
       if [ -f "${hwmon}/name" ]; then
         case $(cat ${hwmon}/name) in
-          nouveau|radeon)
+          nouveau|radeon|amdgpu)
             [[ -f "${hwmon}/temp1_input" ]] && TEMP="$(cat ${hwmon}/temp1_input)" && break
             [[ -f "${hwmon}/temp2_input" ]] && TEMP="$(cat ${hwmon}/temp2_input)" && break
             ;;
-          coretemp)
-            [[ -f "${hwmon}/temp1_input" ]] && TEMP="$(cat ${hwmon}/temp1_input)" && break
-            [[ -f "${hwmon}/temp2_input" ]] && TEMP="$(cat ${hwmon}/temp2_input)" && break
-            ;;
+          # intel gpu is supported by cpu coretemp below
         esac
       fi
     done


### PR DESCRIPTION
- Support amdgpu devices.
- Remove coretemp from GPU case statement. Avoids showing CPU temperature on systems with Intel CPU and dedicated (i.e. AMD) GPU. 