### PR TITLE
kodi: add option to use RPi vendor repo

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -37,6 +37,9 @@
 # Default Skin (Estuary)
   SKIN_DEFAULT="Estuary"
 
+# Select whether to use default (upstream xbmc/xbmc) repo, or specific vendor repo
+  KODI_VENDOR="default"
+
 # install extra subtitle Fonts for KODI (yes / no)
   KODI_EXTRA_FONTS="yes"
 

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,17 +3,30 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="f08d8686e96edcfbe065d4e5094ab6221da057b9"
-PKG_SHA256="eec4e71d836894c39cd722eb3a1b73e2ee678aeadb64abcea2d85227d871bb86"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
-PKG_URL="https://github.com/xbmc/xbmc/archive/$PKG_VERSION.tar.gz"
-PKG_SOURCE_DIR="xbmc-$PKG_VERSION*"
 PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python2 zlib systemd pciutils lzo pcre swig:host libass curl fontconfig fribidi tinyxml libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid giflib libdvdnav libhdhomerun libfmt lirc libfstrcmp flatbuffers:host flatbuffers"
 PKG_SECTION="mediacenter"
 PKG_SHORTDESC="kodi: Kodi Mediacenter"
 PKG_LONGDESC="Kodi Media Center (which was formerly named Xbox Media Center or XBMC) is a free and open source cross-platform media player and home entertainment system software with a 10-foot user interface designed for the living-room TV. Its graphical user interface allows the user to easily manage video, photos, podcasts, and music from a computer, optical disk, local network, and the internet using a remote control."
+
+PKG_PATCH_DIRS="$KODI_VENDOR"
+
+case $KODI_VENDOR in
+  raspberrypi)
+    PKG_VERSION="tag" #Leia BetaX
+    PKG_SHA256="sha-for-tag"
+    PKG_URL="https://github.com/popcornmix/xbmc/archive/$PKG_VERSION.tar.gz"
+    PKG_SOURCE_DIR="xbmc-$PKG_VERSION*"
+    ;;
+  *)
+    PKG_VERSION="f08d8686e96edcfbe065d4e5094ab6221da057b9" #Leia Beta 1
+    PKG_SHA256="eec4e71d836894c39cd722eb3a1b73e2ee678aeadb64abcea2d85227d871bb86"
+    PKG_URL="https://github.com/xbmc/xbmc/archive/$PKG_VERSION.tar.gz"
+    PKG_SOURCE_DIR="xbmc-$PKG_VERSION*"
+    ;;
+esac
 
 # Single threaded LTO is very slow so rely on Kodi for parallel LTO support
 if [ "$LTO_SUPPORT" = "yes" ] && ! build_with_debug; then

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -119,6 +119,9 @@ fi
   # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
     GRAPHIC_DRIVERS=""
 
+  # Use a vendor specific KODI repo
+  # KODI_VENDOR="raspberrypi"
+
   # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
     KODIPLAYER_DRIVER="bcm2835-driver"
 


### PR DESCRIPTION
Now we only build RPi patches in branches, never master.

Anyone wanting to build with RPi patches in master can add the `raspberrypi` tag/sha and switch to using the `raspberrypi` repo.

Switch to `raspberrypi` after we branch for `libreelec-9.0`.