### PR TITLE
brcmfmac_sdio-firmware-rpi: update to brcmfmac_sdio-firmware-rpi-8c1e2bff

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="dd61ee1"
-PKG_SHA256="e8d083b04e405aef5601b485a927d06398642e50c2492a98d10e1f6bcf20d75f"
+PKG_VERSION="8c1e2bff1da9850f68efcfff3da5d939ec27a2ee"
+PKG_SHA256="155ebd5f08b819e0ce4e1950fcc972b2086cee3c16d36aba348beba1910c1fd2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"


### PR DESCRIPTION
https://github.com/LibreELEC/brcmfmac_sdio-firmware-rpi/pull/9