### PR TITLE
mkimage: support tty in run mode

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -135,7 +135,7 @@ LABEL live
 
 LABEL run
   KERNEL /$KERNEL_NAME
-  APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE portable quiet
+  APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE tty portable quiet
 EOF
 
     cat << EOF > "$LE_TMP"/grub.cfg
@@ -151,7 +151,7 @@ menuentry "Live" {
 }
 menuentry "Run" {
 	search --set -f /KERNEL
-	linux /KERNEL boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE grub_portable quiet
+	linux /KERNEL boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE tty grub_portable quiet
 }
 EOF
 


### PR DESCRIPTION
This enables the local console (CTRL+ALT+F3) in run mode. For some unknown to the mists of time reason it's enabled for all the other modes, but not run.