### PR TITLE
settings: update to 080f0dc

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="659afa8"
-PKG_SHA256="f01e6e2f0b9db3ca0addd6f00b93b192596fd1640ba8cd88197a4c3c1a4719fb"
+PKG_VERSION="080f0dce1cb3b539a0bf53061cfbe2d5f2131108"
+PKG_SHA256="3b7b9eaec95a62852dcb0f7e1f76a4d1f24d22909b9c6949e06c03f0bdc3682f"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -26,11 +26,6 @@ fi
 post_makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libreelec
     cp $PKG_DIR/scripts/* $INSTALL/usr/lib/libreelec
-
-#  # bluetooth is optional
-#    if [ ! "$BLUETOOTH_SUPPORT" = yes ]; then
-#      rm -f resources/lib/modules/bluetooth.py
-#    fi
 
   ADDON_INSTALL_DIR=$INSTALL/usr/share/kodi/addons/service.libreelec.settings
 


### PR DESCRIPTION
This bumps settings after https://github.com/LibreELEC/service.libreelec.settings/pull/102 and cleans up some cruft that's been commented out for aeons.