### PR TITLE
Inadyn: Update to 2.4

### DIFF
--- a/packages/addons/service/inadyn/changelog.txt
+++ b/packages/addons/service/inadyn/changelog.txt
@@ -1,3 +1,6 @@
+104
+- Update to 2.4
+
 103
 - Update to 2.2
 

--- a/packages/addons/service/inadyn/package.mk
+++ b/packages/addons/service/inadyn/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inadyn"
-PKG_VERSION="2.2"
-PKG_SHA256="d6c69f0571161d9623fd4dcd2fa8515639b82e7f433058f524269c1e77d49b1a"
-PKG_REV="103"
+PKG_VERSION="2.4"
+PKG_SHA256="b19e83a0002b996796c3b103178a9cd397d8f2c2c2cb9851f74db89b9391ae90"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="http://troglobit.com/inadyn.html"

--- a/packages/addons/service/inadyn/source/resources/settings.xml
+++ b/packages/addons/service/inadyn/source/resources/settings.xml
@@ -1,7 +1,39 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
    <category label="30000">
-      <setting id="inadyn_S" label="30001" type="select" default="inadyn.conf" values="inadyn.conf|default@changeip.com|default@ddnss.de|default@dhis.org|default@dnsexit.com|default@dnsomatic.com|default@domains.google.com|default@dtdns.com|default@duckdns.org|default@duiadns.net|default@dyndns.org|default@dynsip.org|default@dynv6.com|default@easydns.com|default@freedns.afraid.org|default@gira.de|default@ipv4.dynv6.com|default@loopia.com|default@no-ip.com|default@ovh.com|default@sitelutions.com|default@spdyn.de|default@strato.com|default@tunnelbroker.net|default@tzo.com|default@zerigo.com|default@zoneedit.com|dyndns@3322.org|dyndns@he.net|ipv4@nsupdate.info" />
+      <!-- grep \"default@ inadyn-2.4/plugins/* | awk '{print $4}' | sed 's/"//g;s/,/|/g' | sort -->
+      <setting id="inadyn_S" label="30001" type="select" default="inadyn.conf" values="inadyn.conf|
+default@changeip.com|
+default@cloudxns.net|
+default@ddnss.de|
+default@dhis.org|
+default@dnsexit.com|
+default@dnsomatic.com|
+default@dnspod.cn|
+default@domains.google.com|
+default@dtdns.com|
+default@duckdns.org|
+default@duiadns.net|
+default@dyndns.org|
+default@dynsip.org|
+default@dynu.com|
+default@dynv6.com|
+default@easydns.com|
+default@freedns.afraid.org|
+default@freemyip.com|
+default@gira.de|
+default@ipv4.dynv6.com|
+default@loopia.com|
+default@no-ip.com|
+default@ovh.com|
+default@sitelutions.com|
+default@spdyn.de|
+default@strato.com|
+default@tunnelbroker.net|
+default@tzo.com|
+default@zerigo.com|
+default@zoneedit.com
+" />
       <setting id="inadyn_u" label="30002" type="text" visible="!eq(-1,inadyn.conf)" />
       <setting id="inadyn_p" label="30003" type="text" visible="!eq(-2,inadyn.conf)" option="hidden" />
       <setting id="inadyn_a" label="30004" type="text" visible="!eq(-3,inadyn.conf)" />


### PR DESCRIPTION
- Update to 2.4
- Add custom option for defining DDNS services which
  are not natively supported by inadyn

Signed-off-by: Miikka Tuppurainen <miikka75@gmail.com>