### PR TITLE
create_addon now also writes a summary when log writing is used.

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -238,6 +238,7 @@ addons_drop=""
 show_only="false"
 write_logs="no"
 log_path="$BUILD/logs"
+summary_file="/dev/null"
 export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 # read addons from parameter list
@@ -264,6 +265,8 @@ case "$write_logs" in
 esac
 if [ -n "$log_path" ]; then
   mkdir -p "$log_path"
+  summary_file="$log_path/addon-summary.log"  
+  rm -f $summary_file
 fi
 
 # check environment and create toolchain
@@ -301,10 +304,12 @@ for addon in $(tr " " "\n" <<< $addons | sort -u); do
   if [ ${PIPESTATUS[0]} != 0 ]; then
     addons_failed+="$addon "
     printf "$(print_color CLR_ERROR "ADDON FAILED $addon")\n" ' '>&$SILENT_OUT
+    echo "failed: ${addon}" >> $summary_file
   else
     if [ "$remove_success_logs" = "true" ]; then
       rm -f $log_file
     fi
+    echo "success: ${addon}" >> $summary_file
   fi
 done
 


### PR DESCRIPTION
on special wish of @cvh

`addon-summary.log`
```
success: audioencoder.flac
failed: audioencoder.lame
success: audioencoder.vorbis
success: audioencoder.wav
```