### PR TITLE
linux: fix Module.symvers generation

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -216,7 +216,10 @@ make_target() {
     done
   fi
 
-  kernel_make $KERNEL_TARGET $KERNEL_MAKE_EXTRACMD
+  # the modules target is required to get a proper Module.symvers
+  # file with symbols from built-in and external modules.
+  # Without that it'll contain only the symbols from the kernel
+  kernel_make $KERNEL_TARGET $KERNEL_MAKE_EXTRACMD modules
 
   if [ "$BUILD_ANDROID_BOOTIMG" = "yes" ]; then
     DTB_BLOBS=($(ls arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic/*.dtb 2>/dev/null || true))


### PR DESCRIPTION
Building the kernel separately, after the modules have been built, has
the side-effect that modpost (called from scripts/link-vmlinux.sh in
the kernel tree) generates a Module.symvers files containing only the
in-kernel symbols.

  ${MAKE} -f "${srctree}/scripts/Makefile.modpost" vmlinux.o
 
This causes undefined symbol warnings when building external
modules/drivers and these drivers reference symbols from modules.
eg when building RTL8812AU for RPi2:
WARNING: "cfg80211_put_bss" [.../RTL8812AU-ff2f1dd/8812au.ko] undefined!
...

When building the kernel in the usual way (by just running "make")
this problem does not occur because the default kernel build target
includes "modules", which is built after the kernel. So Modules.symvers
generated from link-kernel.sh will later be replaced by the symvers
from modpost.

The easiest way to fix this is to add "modules" to the kernel image
build target. The actual modules build is a no-op (as they've been built
just before), but modpost will be triggered after the kernel build
and we get a correct Module.symvers file - and external modules/drivers
build without warnings.