### PR TITLE
Kodi: use toolchain nm for generating wrapper.def

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1,24 +1,17 @@
 setup_toolchain() {
-  TARGET_AR_NM_RANLIB_PREFIX=""
-
   if [ "$LTO_SUPPORT" = "yes" ]; then
     if flag_enabled "lto-parallel" "no"; then
       TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
       TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
       TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO_COMMON $FLAGS_OPTIM_LTO_PARALLEL"
-      # static libs with lto info require gcc-ar/gcc-nm/gcc-ranlib instead of
-      # default binutils versions
-      TARGET_AR_NM_RANLIB_PREFIX="gcc-"
     elif flag_enabled "lto-fat" "no"; then
       TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_FAT"
       TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_FAT"
       TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO_COMMON $FLAGS_OPTIM_LTO_NO_PARALLEL"
-      TARGET_AR_NM_RANLIB_PREFIX="gcc-"
     elif flag_enabled "lto" "no"; then
       TARGET_CFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
       TARGET_CXXFLAGS+=" $FLAGS_OPTIM_LTO_NO_PARALLEL $FLAGS_OPTIM_LTO_NO_FAT"
       TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_LTO_COMMON $FLAGS_OPTIM_LTO_NO_PARALLEL"
-      TARGET_AR_NM_RANLIB_PREFIX="gcc-"
     fi
   fi
 
@@ -69,9 +62,9 @@ setup_toolchain() {
       export CPP="${TARGET_PREFIX}cpp"
       export LD="${TARGET_PREFIX}ld"
       export AS="${TARGET_PREFIX}as"
-      export AR="${TARGET_PREFIX}${TARGET_AR_NM_RANLIB_PREFIX}ar"
-      export NM="${TARGET_PREFIX}${TARGET_AR_NM_RANLIB_PREFIX}nm"
-      export RANLIB="${TARGET_PREFIX}${TARGET_AR_NM_RANLIB_PREFIX}ranlib"
+      export AR="${TARGET_PREFIX}ar"
+      export NM="${TARGET_PREFIX}nm"
+      export RANLIB="${TARGET_PREFIX}ranlib"
       export OBJCOPY="${TARGET_PREFIX}objcopy"
       export OBJDUMP="${TARGET_PREFIX}objdump"
       export STRIP="${TARGET_PREFIX}strip"

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -117,6 +117,10 @@ EOF
 
   # To avoid cache trashing
   touch -c -t $DATE $CROSS_CXX
+
+  # install lto plugin for binutils
+  mkdir -p $TOOLCHAIN/lib/bfd-plugins
+    ln -sf ../gcc/$TARGET_NAME/$GCC_VERSION/liblto_plugin.so $TOOLCHAIN/lib/bfd-plugins
 }
 
 configure_target() {

--- a/packages/mediacenter/kodi/patches/kodi-995.01-pr14354_wrapper_toolchain_nm.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.01-pr14354_wrapper_toolchain_nm.patch
@@ -1,0 +1,17 @@
+wrapper.def:
+  - make nm binary configurable (-DCMAKE_NM=..)
+  - fail if an empty file is generated
+
+diff --git a/xbmc/cores/DllLoader/exports/CMakeLists.txt b/xbmc/cores/DllLoader/exports/CMakeLists.txt
+index 580a779fdc..efcd872cad 100644
+--- a/xbmc/cores/DllLoader/exports/CMakeLists.txt
++++ b/xbmc/cores/DllLoader/exports/CMakeLists.txt
+@@ -16,7 +16,7 @@ elseif(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL w
+   add_options(C ALL_BUILDS "-fPIC")
+   add_library(wrapper OBJECT wrapper.c)
+ 
+-  add_custom_target(wrapper.def ALL nm ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/wrapper.dir/wrapper.c.o | grep __wrap | awk '{ printf(\"%s \", \$\$3) }' | sed \"s/___wrap_/__wrap_/g\" | sed \"s/__wrap_/-Wl,-wrap,/g\" > wrapper.def)
++  add_custom_target(wrapper.def ALL ${CMAKE_NM} ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/wrapper.dir/wrapper.c.o | grep __wrap | awk '{ printf(\"%s \", \$\$3) }' | sed \"s/___wrap_/__wrap_/g\" | sed \"s/__wrap_/-Wl,-wrap,/g\" > wrapper.def && test -s wrapper.def)
+ 
+   if(CORE_SYSTEM_NAME STREQUAL android)
+     add_custom_command(TARGET wrapper.def COMMAND echo \"-L${DEPENDS_PATH}/lib/dummy-lib${APP_NAME_LC} -l${APP_NAME_LC}\" >> wrapper.def)


### PR DESCRIPTION
When building LibreELEC on a Ubuntu 16.04 build host, playing DVDs from VIDEO_TS folders with Kodi ​fails. This is caused by an empty wrapper.def file generated during and libdvdnav-x86_64-linux.so not linked correctly. 

When executing the wrapper.def custom target nm fails with
```
[17/1519] cd /home/m/tools/libreelec/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-f08d8686e96edcfbe065d4e5094ab6221da057b9/.x86_64-libreelec-linux-gnu/build/cores/dll-loader/exports && nm /home/m/tools/libreelec/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-f08d8686e96edcfbe065d4e5094ab6221da057b9/.x86_64-libreelec-linux-gnu/build/cores/dll-loader/exports/CMakeFiles/wrapper.dir/wrapper.c.o | grep __wrap | awk '{ printf ( "%s ", $3 ) }' | sed "s/___wrap_/__wrap_/g" | sed "s/__wrap_/-Wl,-wrap,/g" > wrapper.def
nm: /home/m/tools/libreelec/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-f08d8686e96edcfbe065d4e5094ab6221da057b9/.x86_64-libreelec-linux-gnu/build/cores/dll-loader/exports/CMakeFiles/wrapper.dir/wrapper.c.o: plugin needed to handle lto object
```
, an empty wrapper.def is created, but the build continues because the nm error code is ignored in the pipe.

Replacing build hosts /usr/bin/nm with the lto capable nm from the LibreELEC tool chain solves the problem.

gcc's package.mk now installs the linker lto plugin for binutils ar/nm/ranlib so there is no need any more to prefer the gcc-ar/gcc-nm/gcc-ranlib in config/functions.

The Kodi patch can be dropped  when it is  merged upstream.
