### PR TITLE
linux, kodi: remove PKG_SOURCE_DIR, add PKG_SOURCE_NAME

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,7 +22,7 @@ case "$LINUX" in
     PKG_VERSION="95ba9d626c0fce672caa296f5911ab9190881642"
     PKG_SHA256="df34b086993fd3552efae92d84d28990a61a1ca79a8703a4b64241ab80e3b6db"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_DIR="linux-amlogic-$PKG_VERSION"
+    PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host u-boot-tools-aml:host"
     PKG_BUILD_PERF="no"
     ;;
@@ -30,7 +30,7 @@ case "$LINUX" in
     PKG_VERSION="29941550f05282411c00c437b4c18bb5c6319d63"
     PKG_SHA256="c97da3b9cd3d34432e69aeaa740076afee977b9ed7c0d0a8475f3f019288dd36"
     PKG_URL="https://github.com/LibreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_DIR="linux-amlogic-$PKG_VERSION"
+    PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host"
     PKG_BUILD_PERF="no"
     ;;
@@ -38,12 +38,13 @@ case "$LINUX" in
     PKG_VERSION="bca2464422eb8dd734f9218265dae256a82299be"
     PKG_SHA256="baaea04ca4a1b34e0bfce36bfcf74d65b06ae371e29fa2ef96d26327e55b690d"
     PKG_URL="https://github.com/rockchip-linux/kernel/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_DIR="kernel-$PKG_VERSION"
+    PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     ;;
   raspberrypi)
     PKG_VERSION="1f89ad77bf9b204c18fb6fdd167b4ee92d064f95" # 4.14.62
     PKG_SHA256="153deef35bf1895fb0825395c0f9fb61832dcf0131987fce99449beb17afa173"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
+    PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     ;;
   *)
     PKG_VERSION="4.18.3"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -18,13 +18,13 @@ case $KODI_VENDOR in
     PKG_VERSION="newclock5_18.0b1v2-Leia"
     PKG_SHA256="7434263c55aa528f3e3d8f455cffe3148e3707a1c1068f80bd08829094e16576"
     PKG_URL="https://github.com/popcornmix/xbmc/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_DIR="xbmc-$PKG_VERSION*"
+    PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;
   *)
     PKG_VERSION="18.0b1v2-Leia"
     PKG_SHA256="3808aa97723b710a0774261116e3387f091bc3d8150b9ba49ef36cb30b3d7ba2"
     PKG_URL="https://github.com/xbmc/xbmc/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_DIR="xbmc-$PKG_VERSION*"
+    PKG_SOURCE_NAME="kodi-$PKG_VERSION.tar.gz"
     ;;
 esac
 


### PR DESCRIPTION
PKG_SOURCE_DIR is no longer required since commit 1c5d050bc026ae387abf4c367c071601979f4842

Add PKG_SOURCE_NAME so that the kernel and kodi source files stored
in sources include the kernel/kodi variant in their file name (eg linux-amlogic-3.10, linux-raspberrypi, ...).

Currently a lot of files are named linux-GITHASH.tar.gz / kodi-GITHASH.tar.gz.
When PKG_SOURCE_NAME is set this will change to eg
linux-raspberrypi-GITHASH.tar.gz, linux-amlogic-3.10-GITHASH.tar.gz
etc and it's easer for humans to detect older versions and clean
up the sources dir.