### PR TITLE
scripts/get_archive, tools-distro-tool: fix wget redirection issue when wget running in background

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -21,7 +21,7 @@ export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$PKG_SOURCE_NAME"
 [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-WGET_CMD="wget --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c $WGET_OPT -O $PACKAGE"
+WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c $WGET_OPT -O $PACKAGE"
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
 unset LD_LIBRARY_PATH

--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -349,7 +349,7 @@ class MyUtility(object):
     while attempts < retries:
       if stopped.is_set(): break
       attempts += 1
-      (result, output) = MyUtility.runcommand(msgs, "wget --timeout=30 --tries=3 --passive-ftp --no-check-certificate -O %s %s" % (filename_data, url), logfile=filename_log)
+      (result, output) = MyUtility.runcommand(msgs, "wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -O %s %s" % (filename_data, url), logfile=filename_log)
       if result == 0:
         return True
 


### PR DESCRIPTION
Issue discussed [here](https://savannah.gnu.org/bugs/?51181), although doesn't actually resolve it as latest 1.19.5 still has the same issue, in which case I'm not sure if this is a regression/bug in `wget` or new/expected behaviour.

To reproduce:

1. Create `/tmp/test.sh`
```
#!/bin/bash

wget --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c -O /tmp/aom.tar.gz "http://repo.or.cz/aom.git/snapshot/1b0e7dc4ac4b50f245dacc1e2362e50b7b2d1860.tar.gz"
```
2.  Run `/tmp/test.sh` as a "background" process
```
bash /tmp/test.sh &
```

Result: instead of the output from `wget` being sent to the console, it is sent instead to `wget-log` in the current directory. And if `wget-log` exists, then `wget-log.1` is created, then `wget-log.2` etc. etc.

Adding `--output-file=-` overrides the buggy/new behaviour whenever `wget` is being run in the background.

Edit to add OS details: 

Ubuntu 16.04 with `wget` 1.17.1: `wget` output always appears in the console regardless of whether `wget` is a foreground or background process.

Ubuntu 17.10 with `wget` 1.19.1 (and presumably later): `wget` output appears in the console when `wget` is a foreground process, but is redirected to `wget-log` when a background process.
