### PR TITLE
vdr-plugin-xmltv2vdr: add buildfix patch

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/patches/vdr-plugin-xmltv2vdr-02_gcc721_fixes.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/patches/vdr-plugin-xmltv2vdr-02_gcc721_fixes.patch
@@ -1,0 +1,74 @@
+taken from https://github.com/VDR4Arch/vdr4arch/blob/vdr-stable/plugins/vdr-xmltv2vdr/xmltv2vdr_gcc721_fixes.diff
+fixes 
+
+event.cpp: In member function 'void cXMLTVEvent::GetSQL(const char*, int, const char*, char**, char**)':
+event.cpp:531:5: error: 'string' was not declared in this scope
+     string si=sql_insert;
+     ^~~~~~
+
+diff --git a/dist/epgdata2xmltv/epgdata2xmltv.cpp b/dist/epgdata2xmltv/epgdata2xmltv.cpp
+index de6fb26..ec465fb 100644
+--- a/dist/epgdata2xmltv/epgdata2xmltv.cpp
++++ b/dist/epgdata2xmltv/epgdata2xmltv.cpp
+@@ -561,7 +561,7 @@ int cepgdata2xmltv::Process(int argc, char *argv[])
+                 enca_analyser_free(analyser);
+             }
+ 
+-            string s = xmlmem;
++            std::string s = xmlmem;
+             int reps=pcrecpp::RE("&(?![a-zA-Z]{1,8};)").GlobalReplace("%amp;",&s);
+             if (reps) {
+                 xmlmem = (char *)realloc(xmlmem, s.size()+1);
+diff --git a/event.cpp b/event.cpp
+index ae33002..1df43ec 100644
+--- a/event.cpp
++++ b/event.cpp
+@@ -528,7 +528,7 @@ void cXMLTVEvent::GetSQL(const char *Source, int SrcIdx, const char *ChannelID,
+         return;
+     }
+ 
+-    string si=sql_insert;
++    std::string si=sql_insert;
+     int ireps;
+     ireps=pcrecpp::RE("'").GlobalReplace("''",&si);
+     ireps+=pcrecpp::RE("\\^").GlobalReplace("'",&si);
+@@ -540,7 +540,7 @@ void cXMLTVEvent::GetSQL(const char *Source, int SrcIdx, const char *ChannelID,
+     }
+     *Insert=sql_insert;
+ 
+-    string su=sql_update;
++    std::string su=sql_update;
+     int ureps;
+     ureps=pcrecpp::RE("'").GlobalReplace("''",&su);
+     ureps+=pcrecpp::RE("\\^").GlobalReplace("'",&su);
+diff --git a/import.cpp b/import.cpp
+index 0d6f7bf..e417c59 100644
+--- a/import.cpp
++++ b/import.cpp
+@@ -1401,7 +1401,7 @@ bool cImport::UpdateXMLTVEvent(cEPGSource *Source, sqlite3 *Db, cXMLTVEvent *xEv
+             return false;
+         }
+ 
+-        string ed=shortdesc;
++        std::string ed=shortdesc;
+ 
+         int reps;
+         reps=pcrecpp::RE("'").GlobalReplace("''",&ed);
+@@ -1511,7 +1511,7 @@ bool cImport::UpdateXMLTVEvent(cEPGSource *Source, sqlite3 *Db, const cEvent *Ev
+             return false;
+         }
+ 
+-        string ed=eitdescription;
++        std::string ed=eitdescription;
+ 
+         int reps;
+         reps=pcrecpp::RE("'").GlobalReplace("''",&ed);
+@@ -1649,7 +1649,7 @@ cXMLTVEvent *cImport::SearchXMLTVEvent(sqlite3 **Db,const char *ChannelID, const
+             return NULL;
+         }
+ 
+-        string st=sqltitle;
++        std::string st=sqltitle;
+ 
+         int reps;
+         reps=pcrecpp::RE("'").GlobalReplace("''",&st);


### PR DESCRIPTION
fixes
```
event.cpp:531:5: error: 'string' was not declared in this scope
     string si=sql_insert;
     ^~~~~~
event.cpp:531:5: note: suggested alternatives:
In file included from /builddir/toolchain/armv7ve-libreelec-linux-gnueabi/include/c++/8.2.0/string:39,
                 from /builddir/toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/usr/include/pcrecpp.h:333,
                 from event.cpp:12:
/builddir/toolchain/armv7ve-libreelec-linux-gnueabi/include/c++/8.2.0/bits/stringfwd.h:74:33: note:   'std::string'
   typedef basic_string<char>    string;
                                 ^~~~~~
/builddir/toolchain/armv7ve-libreelec-linux-gnueabi/include/c++/8.2.0/bits/stringfwd.h:74:33: note:   'std::string'
event.cpp:533:48: error: 'si' was not declared in this scope
     ireps=pcrecpp::RE("'").GlobalReplace("''",&si);
                                                ^~
event.cpp:533:48: note: suggested alternative: 'sin'
     ireps=pcrecpp::RE("'").GlobalReplace("''",&si);
                                                ^~
                                                sin
event.cpp:543:11: error: expected ';' before 'su'
     string su=sql_update;
           ^~~
           ;
event.cpp:545:48: error: 'su' was not declared in this scope
     ureps=pcrecpp::RE("'").GlobalReplace("''",&su);
                                                ^~
event.cpp:545:48: note: suggested alternative: 'sr'
     ureps=pcrecpp::RE("'").GlobalReplace("''",&su);
                                                ^~
                                                sr
make: *** [Makefile:70: event.o] Error 1
make: *** Waiting for unfinished jobs....
import.cpp: In member function 'bool cImport::UpdateXMLTVEvent(cEPGSource*, sqlite3*, cXMLTVEvent*)':
import.cpp:1404:9: error: 'string' was not declared in this scope
         string ed=shortdesc;
         ^~~~~~
```