### PR TITLE
kodi (RPi): backport fix to avoid division by zero in Log() message

### DIFF
--- a/projects/RPi/patches/kodi/kodi-001-mmalrenderer-protect-against-divide-by-zero.patch
+++ b/projects/RPi/patches/kodi/kodi-001-mmalrenderer-protect-against-divide-by-zero.patch
@@ -1,0 +1,25 @@
+From 1cee1f1156e0866111140d7823d034f73197f3a3 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Thu, 30 Aug 2018 20:37:35 +0100
+Subject: [PATCH] MMALRender: Protect against divide by zero
+
+---
+ xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+index a9860f587f..f4f430510d 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+@@ -58,7 +58,7 @@ public:
+   static uint32_t TranslateFormat(AVPixelFormat pixfmt);
+   virtual int Width() { return m_width; }
+   virtual int Height() { return m_height; }
+-  virtual int AlignedWidth() { return m_mmal_format == MMAL_ENCODING_YUVUV128 || m_mmal_format == MMAL_ENCODING_YUVUV64_16 ? 0 : m_geo.getStrideY() / m_geo.getBytesPerPixel(); }
++  virtual int AlignedWidth() { return m_mmal_format == MMAL_ENCODING_YUVUV128 || m_mmal_format == MMAL_ENCODING_YUVUV64_16 || m_geo.getBytesPerPixel() == 0 ? 0 : m_geo.getStrideY() / m_geo.getBytesPerPixel(); }
+   virtual int AlignedHeight() { return m_mmal_format == MMAL_ENCODING_YUVUV128 || m_mmal_format == MMAL_ENCODING_YUVUV64_16 ? 0 : m_geo.getHeightY(); }
+   virtual int BitsPerPixel() { return m_geo.getBitsPerPixel(); }
+   virtual uint32_t &Encoding() { return m_mmal_format; }
+-- 
+2.11.0
+


### PR DESCRIPTION
This fixes MMAL not working on RPi1.

Commit picked from newclock5 branch, patch can be dropped on next
kodi RPi update.