### PR TITLE
Cleanup OOTB IR remote support and make it configurable

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -218,3 +218,10 @@
 
 # Settings package name - blank if not required
   DISTRO_PKG_SETTINGS="LibreELEC-settings"
+
+# IR remote protocols supported in default config
+  IR_REMOTE_PROTOCOLS="RC6 NEC"
+
+# IR remote keymaps supported in default config
+  IR_REMOTE_KEYMAPS="rc6_mce xbox_360 xbox_one"
+

--- a/packages/sysutils/v4l-utils/package.mk
+++ b/packages/sysutils/v4l-utils/package.mk
@@ -62,7 +62,7 @@ create_multi_keymap() {
 }
 
 post_makeinstall_target() {
-  local default_multi_maps f keymap
+  local f keymap
 
   rm -rf $INSTALL/etc/rc_keymaps
     ln -sf /storage/.config/rc_keymaps $INSTALL/etc/rc_keymaps
@@ -86,16 +86,13 @@ post_makeinstall_target() {
   )
 
   # create multi keymap to support several remotes OOTB
+  if [ -n "$IR_REMOTE_PROTOCOLS" -a -n "$IR_REMOTE_KEYMAPS" ]; then
+    create_multi_keymap libreelec_multi "$IR_REMOTE_PROTOCOLS" $IR_REMOTE_KEYMAPS
 
-  default_multi_maps="rc6_mce xbox_360 zotac_ad10 hp_mce xbox_one cubox_i"
+    # use multi-keymap instead of default one
+    sed -i '/^\*\s*rc-rc6-mce\s*rc6_mce/d' $INSTALL/etc/rc_maps.cfg
 
-  create_multi_keymap libreelec_multi "RC6 NEC" $default_multi_maps
-  create_multi_keymap libreelec_multi_amlogic "RC6 NEC" $default_multi_maps \
-    odroid wetek_hub wetek_play_2 minix_neo
-
-  # use multi-keymap instead of default one
-  sed -i '/^\*\s*rc-rc6-mce\s*rc6_mce/d' $INSTALL/etc/rc_maps.cfg
-  cat << EOF >> $INSTALL/etc/rc_maps.cfg
+    cat << EOF >> $INSTALL/etc/rc_maps.cfg
 #
 # Custom LibreELEC configuration starts here
 #
@@ -103,6 +100,8 @@ post_makeinstall_target() {
 # *		rc-rc6-mce	rc6_mce
 *		rc-rc6-mce	libreelec_multi
 # multi-table for amlogic devices
-meson-ir	*		libreelec_multi_amlogic
+meson-ir	*		libreelec_multi
 EOF
+
+  fi
 }

--- a/projects/Amlogic/devices/Odroid_C2/options
+++ b/projects/Amlogic/devices/Odroid_C2/options
@@ -24,3 +24,7 @@
 
   # Amlogic IR remote support (yes / no)
     AMREMOTE_SUPPORT="no"
+
+  # add OOTB support for Odroid IR remote
+    IR_REMOTE_KEYMAPS="$IR_REMOTE_KEYMAPS odroid"
+

--- a/projects/Amlogic/devices/WeTek_Hub/options
+++ b/projects/Amlogic/devices/WeTek_Hub/options
@@ -11,3 +11,6 @@
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
     FIRMWARE="$FIRMWARE brcmfmac_sdio-firmware-aml"
+
+  # add OOTB support for Wetek Hub IR remote
+    IR_REMOTE_KEYMAPS="$IR_REMOTE_KEYMAPS wetek_hub"

--- a/projects/Amlogic/devices/WeTek_Play_2/options
+++ b/projects/Amlogic/devices/WeTek_Play_2/options
@@ -11,3 +11,7 @@
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
     FIRMWARE="$FIRMWARE brcmfmac_sdio-firmware-aml"
+
+  # add OOTB support for Wetek Play 2 IR remote
+    IR_REMOTE_KEYMAPS="$IR_REMOTE_KEYMAPS wetek_play_2"
+


### PR DESCRIPTION
This has been on my TODO list for quite a long time:

I've cleaned up the list of IR remotes that are supported in LibreELEC out-of-the-box and removed broken tables (hp_mce and zotac_ad10 won't work as is with current kernel) and rarely used ones (like cubox-i) from the default config.

I still kept the (semi-)broken tables, we can clean them up later.

The default setup is now very simple: LE supports (Microsoft) MCE remotes, the Xbox one and Xbox 360 remotes out of the box on all devices.

Projects/devices can extend or override the list of OOTB remotes as they wish, for simplicity I suggest to just add the remote that comes with the device to the list of default remotes.

Then people can use an MCE (compatible) remote on any device if they prefer. Or they can use the remote that came eg with their Wetek Play 2 to control their Wetek Play 2 - but the Wetek Play 2 remote won't control their Odroid C2 sitting next to it.

I've included commits for Odroid C2, Wetek Hub and Wetek Play 2 to implement that, 

This only affects the default config in SYSTEM, people can still override this via a .config/rc_maps.cfg file as before