### PR TITLE
busybox: don't fix GPT tables when partition scheme is MBR

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -48,8 +48,11 @@ if [ -e /storage/.please_resize_me ] ; then
       echo "Please do not reboot or turn off your @DISTRONAME@ device!"
       echo ""
 
-      # fix any minor issues, such as gpt header not at end of disk
-      StartProgress spinner "Checking layout...   " "sgdisk -e $DISK &>/dev/null"
+      # identify the partition scheme, and if gpt fix minor issues such as gpt header not at end of disk
+      SCHEME=$(blkid -s PTTYPE -o value $DISK)
+      if [ "$SCHEME" = "gpt" ]; then
+        StartProgress spinner "Checking layout...   " "sgdisk -e $DISK &>/dev/null"
+      fi
 
       StartProgress spinner "Deleting /storage... " "parted -s -m $DISK rm 2 &>/dev/null"
       StartProgress spinner "Creating /storage... " "parted -s -m $DISK unit b mkpart primary $PART_START 100% &>/dev/null"


### PR DESCRIPTION
In Amlogic mainline images (and probably others) the `fs-resize` script attempts to fix GPT headers with sgdisk even though the SD card uses an MBR scheme. This creates a ~2 min delay until sgdisk fails/time-out and the script continues. The error can be see if you uncomment the command output redirect to /dev/null:

![gpt](https://user-images.githubusercontent.com/251794/45203607-c16bcb00-b28d-11e8-82b2-828b7f58a129.jpg)

I'm not sure why long delay isn't seen with other MBR images (older kernel codebase etc.) but this change detects the partition scheme (MBR or GPT) and skips sgdisk fixup unless a GPT scheme is being used. Initial boot and resize now takes ~20 seconds again.