### PR TITLE
buildsystem: better support for project and device config files

### DIFF
--- a/config/options
+++ b/config/options
@@ -64,8 +64,8 @@ PROJECT_DIR="$ROOT/projects"
 # projects can set KERNEL_NAME (kernel.img)
 [ -z "$KERNEL_NAME" ] && KERNEL_NAME="KERNEL"
 
-LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux $PROJECT_DIR/$PROJECT/patches/linux $ROOT/packages/linux"
-[ -n "$DEVICE" ] && LINUX_DEPENDS+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/linux"
+LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux $PROJECT_DIR/$PROJECT/patches/linux $PROJECT_DIR/$PROJECT/packages/linux $ROOT/packages/linux"
+[ -n "$DEVICE" ] && LINUX_DEPENDS+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/linux $PROJECT_DIR/$PROJECT/devices/$DEVICE/packages/linux"
 [ "$TARGET_ARCH" = "x86_64" ] && LINUX_DEPENDS+=" $ROOT/packages/linux-firmware/intel-ucode $ROOT/packages/linux-firmware/kernel-firmware"
 
 # Need to point to your actual cc

--- a/scripts/install
+++ b/scripts/install
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2010-2011 Roman Weber (roman@openelec.tv)
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 . config/options $1
 
@@ -60,60 +61,68 @@ fi
 mkdir -p $INSTALL
 
 if [ "$TARGET" = target ] ; then
-  if [ -d $PKG_DIR/profile.d ]; then
-    mkdir -p $INSTALL/etc/profile.d
-    cp $PKG_DIR/profile.d/*.conf $INSTALL/etc/profile.d/
-  fi
+  for PKG_TMP_DIR in $PKG_DIR \
+                      $PROJECT_DIR/$PROJECT/packages/$PKG_NAME \
+                      $PROJECT_DIR/$PROJECT/devices/$DEVICE/packages/$PKG_NAME \
+                      ; do
 
-  if [ -d $PKG_DIR/tmpfiles.d ]; then
-    mkdir -p $INSTALL/usr/lib/tmpfiles.d
-    cp $PKG_DIR/tmpfiles.d/*.conf $INSTALL/usr/lib/tmpfiles.d
-  fi
+    [ -d $PKG_TMP_DIR ] || continue
 
-  if [ -d $PKG_DIR/system.d ]; then
-    mkdir -p $INSTALL/usr/lib/systemd/system
-    cp $PKG_DIR/system.d/*.* $INSTALL/usr/lib/systemd/system
-  fi
+    if [ -d $PKG_TMP_DIR/profile.d ]; then
+      mkdir -p $INSTALL/etc/profile.d
+      cp $PKG_TMP_DIR/profile.d/*.conf $INSTALL/etc/profile.d
+    fi
 
-  if [ -d $PKG_DIR/udev.d ]; then
-    mkdir -p $INSTALL/usr/lib/udev/rules.d
-    cp $PKG_DIR/udev.d/*.rules $INSTALL/usr/lib/udev/rules.d
-  fi
+    if [ -d $PKG_TMP_DIR/tmpfiles.d ]; then
+      mkdir -p $INSTALL/usr/lib/tmpfiles.d
+      cp $PKG_TMP_DIR/tmpfiles.d/*.conf $INSTALL/usr/lib/tmpfiles.d
+    fi
 
-  if [ -d $PKG_DIR/sleep.d ]; then
-    mkdir -p $INSTALL/usr/lib/systemd/system-sleep/
-    cp $PKG_DIR/sleep.d/* $INSTALL/usr/lib/systemd/system-sleep/
-  fi
+    if [ -d $PKG_TMP_DIR/system.d ]; then
+      mkdir -p $INSTALL/usr/lib/systemd/system
+      cp $PKG_TMP_DIR/system.d/*.* $INSTALL/usr/lib/systemd/system
+    fi
 
-  if [ -d $PKG_DIR/sleep.d.serial ]; then
-    mkdir -p $INSTALL/usr/lib/systemd/system-sleep.serial
-    cp $PKG_DIR/sleep.d.serial/* $INSTALL/usr/lib/systemd/system-sleep.serial
-  fi
+    if [ -d $PKG_TMP_DIR/udev.d ]; then
+      mkdir -p $INSTALL/usr/lib/udev/rules.d
+      cp $PKG_TMP_DIR/udev.d/*.rules $INSTALL/usr/lib/udev/rules.d
+    fi
 
-  if [ -d $PKG_DIR/sysctl.d ]; then
-    mkdir -p $INSTALL/usr/lib/sysctl.d/
-    cp $PKG_DIR/sysctl.d/*.conf $INSTALL/usr/lib/sysctl.d/
-  fi
+    if [ -d $PKG_TMP_DIR/sleep.d ]; then
+      mkdir -p $INSTALL/usr/lib/systemd/system-sleep
+      cp $PKG_TMP_DIR/sleep.d/* $INSTALL/usr/lib/systemd/system-sleep
+    fi
 
-  if [ -d $PKG_DIR/modules-load.d ]; then
-    mkdir -p $INSTALL/usr/lib/modules-load.d/
-    cp $PKG_DIR/modules-load.d/*.conf $INSTALL/usr/lib/modules-load.d/
-  fi
+    if [ -d $PKG_TMP_DIR/sleep.d.serial ]; then
+      mkdir -p $INSTALL/usr/lib/systemd/system-sleep.serial
+      cp $PKG_TMP_DIR/sleep.d.serial/* $INSTALL/usr/lib/systemd/system-sleep.serial
+    fi
 
-  if [ -d $PKG_DIR/sysconf.d ]; then
-    mkdir -p $INSTALL/etc/sysconf.d
-    cp $PKG_DIR/sysconf.d/*.conf $INSTALL/etc/sysconf.d
-  fi
+    if [ -d $PKG_TMP_DIR/sysctl.d ]; then
+      mkdir -p $INSTALL/usr/lib/sysctl.d
+      cp $PKG_TMP_DIR/sysctl.d/*.conf $INSTALL/usr/lib/sysctl.d
+    fi
 
-  if [ -d $PKG_DIR/debug.d ]; then
-    mkdir -p $INSTALL/usr/share/debugconf
-    cp $PKG_DIR/debug.d/*.conf $INSTALL/usr/share/debugconf
-  fi
+    if [ -d $PKG_TMP_DIR/modules-load.d ]; then
+      mkdir -p $INSTALL/usr/lib/modules-load.d
+      cp $PKG_TMP_DIR/modules-load.d/*.conf $INSTALL/usr/lib/modules-load.d
+    fi
 
-  if [ -d $PKG_DIR/modprobe.d ]; then
-    mkdir -p $INSTALL/usr/lib/modprobe.d
-    cp $PKG_DIR/modprobe.d/*.conf $INSTALL/usr/lib/modprobe.d
-  fi
+    if [ -d $PKG_TMP_DIR/sysconf.d ]; then
+      mkdir -p $INSTALL/etc/sysconf.d
+      cp $PKG_TMP_DIR/sysconf.d/*.conf $INSTALL/etc/sysconf.d
+    fi
+
+    if [ -d $PKG_TMP_DIR/debug.d ]; then
+      mkdir -p $INSTALL/usr/share/debugconf
+      cp $PKG_TMP_DIR/debug.d/*.conf $INSTALL/usr/share/debugconf
+    fi
+
+    if [ -d $PKG_TMP_DIR/modprobe.d ]; then
+      mkdir -p $INSTALL/usr/lib/modprobe.d
+      cp $PKG_TMP_DIR/modprobe.d/*.conf $INSTALL/usr/lib/modprobe.d
+    fi
+  done
 fi
 
 # unset functions


### PR DESCRIPTION
We automatically install config files from the global package but completely ignore project and device specific equivalents.

These files also need to be considered when determining the LINUX_DEPENDS - any change to a conf file should rebuild linux.

Inspired by #2963.

I've quickly build tested this on RPi/RPi2/Generic and don't see any difference in the before/after images.