### PR TITLE
qemu: disable gcrypt

### DIFF
--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -9,22 +9,21 @@ PKG_LICENSE="GPL"
 PKG_SITE="http://wiki.qemu.org"
 PKG_URL="https://download.qemu.org/qemu-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST="toolchain glib:host pixman:host Python2:host zlib:host"
-PKG_SECTION="tools"
-PKG_SHORTDESC="QEMU is a generic and open source machine emulator and virtualizer."
 PKG_LONGDESC="QEMU is a generic and open source machine emulator and virtualizer."
 
-HOST_CONFIGURE_OPTS="--prefix=$TOOLCHAIN \
-  --bindir=$TOOLCHAIN/bin \
-  --sbindir=$TOOLCHAIN/sbin \
-  --sysconfdir=$TOOLCHAIN/etc \
-  --libexecdir=$TOOLCHAIN/lib \
-  --localstatedir=$TOOLCHAIN/var \
+HOST_CONFIGURE_OPTS="--bindir=$TOOLCHAIN/bin \
   --extra-cflags=-I$TOOLCHAIN/include \
   --extra-ldflags=-L$TOOLCHAIN/lib \
+  --libexecdir=$TOOLCHAIN/lib \
+  --localstatedir=$TOOLCHAIN/var \
+  --prefix=$TOOLCHAIN \
+  --sbindir=$TOOLCHAIN/sbin \
   --static \
-  --disable-vnc \
-  --disable-werror \
+  --sysconfdir=$TOOLCHAIN/etc \
   --disable-blobs \
+  --disable-docs \
+  --disable-gcrypt \
   --disable-system \
   --disable-user \
-  --disable-docs"
+  --disable-vnc \
+  --disable-werror"


### PR DESCRIPTION
- fixes 
```
  LINK    tests/qemu-iotests/socket_scm_helper
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: cannot find -lgcrypt
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: cannot find -lgpg-error
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: cannot find -lgpg-error
collect2: error: ld returned 1 exit status
make[1]: *** [/LE/build.../qemu-2.12.0/rules.mak:121: tests/qemu-iotests/socket_scm_helper] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/LE/build.../qemu-2.12.0/.x86_64-pc-linux-gnu'
```

fix is from https://forum.libreelec.tv/thread/13205-build-failure-for-8-90-004-generic-x64-broken-toolchain/?postID=99135#post99135
`Although libgcrypt is a package that is installed into the LE image, it's not part of the toolchain and qemu was erroneously enabling libgcrypt support because it detected it as being present on the host system doing the build.`

- added small cleanup to the package