### PR TITLE
Pythons: bump internal Python3 version, add reminders

### DIFF
--- a/packages/lang/Python2/package.mk
+++ b/packages/lang/Python2/package.mk
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Python2"
+# When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
 PKG_VERSION="2.7.15"
 PKG_SHA256="22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574"
 PKG_ARCH="any"

--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -2,6 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Python3"
+# When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
 PKG_VERSION="3.7.0"
 PKG_SHA256="0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549"
 PKG_ARCH="any"
@@ -15,7 +16,7 @@ PKG_SECTION="lang"
 PKG_SHORTDESC="python3: The Python3 programming language"
 PKG_LONGDESC="Python3 is an interpreted object-oriented programming language, and is often compared with Tcl, Perl, Java or Scheme."
 
-PKG_PYTHON_VERSION=python3.6
+PKG_PYTHON_VERSION=python3.7
 
 PKG_TOOLCHAIN="autotools"
 


### PR DESCRIPTION
Thanks [@vpeter](https://github.com/LibreELEC/LibreELEC.tv/commit/1821a2078db4e950ca63cc2d2c2c3765cc81cecc#commitcomment-30460104).

The reminder for Python2 is unlikely to be required, but doesn't do any harm.

The only consequence of this snafu is that reindent.py is installed incorrectly in $TOOLCHAIN/lib - no big deal, as nothing uses it.