### PR TITLE
meson: update to 0.47.2

### DIFF
--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="0.46.0"
-PKG_SHA256="b7df91b01a358a8facdbfa33596a47cda38a760435ab55e1985c0bff06a9cbf0"
+PKG_VERSION="0.47.2"
+PKG_SHA256="92d8afd921751261e36151643464efd3394162f69efbe8cd53e0a66b1cf395eb"
 PKG_ARCH="any"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"


### PR DESCRIPTION
After updating Python to 3.7.0 we need to update Meson too.

https://docs.python.org/3.8/library/exceptions.html#StopIteration
https://github.com/mesonbuild/meson/issues/3821