### PR TITLE
scripts/get: make hash output easier to copy

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -37,7 +37,7 @@ while [ $NBWGET -gt 0 ]; do
 
       [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2
 
-      printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "WARNING") Incorrect checksum calculated on downloaded file: got ${CALC_SHA256}, wanted ${PKG_SHA256}\n\n" ' '>&$SILENT_OUT
+      printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "WARNING") Incorrect checksum calculated on downloaded file: got ${CALC_SHA256} wanted ${PKG_SHA256}\n\n" ' '>&$SILENT_OUT
     fi
   done
   NBWGET=$((NBWGET - 1))


### PR DESCRIPTION
really just an minor change to make copying of the hash easier

click at the gifs for big (fantasy hash values !)

before the change you also copy the `,` at double click at the hash
![1](https://user-images.githubusercontent.com/1355173/45487810-af8f9980-b75f-11e8-9cc3-1e4471c74f56.gif)

fixed
![2](https://user-images.githubusercontent.com/1355173/45487813-b28a8a00-b75f-11e8-86d8-44bfd9f4c165.gif)
