### PR TITLE
linux (RPi): update to 4.14.69 + CMA fix

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -41,8 +41,8 @@ case "$LINUX" in
     PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="27e84c625ebbdfccf78220f2f90995a050c7b64a" # 4.14.69
-    PKG_SHA256="fd75cc94436ed88133d1e3567473fd0e9a3412497d6b335de6ec953968e22fcc"
+    PKG_VERSION="91c64870bb6f940011e723f4a7d499f7d40a2923" # 4.14.69 + CMA fix
+    PKG_SHA256="8c441ac00a6895f742e7d33a72506637438e949a85bc480008723cb6e2cd56b8"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     ;;


### PR DESCRIPTION
This fixes CMA allocations failures since RPi kernel commit https://github.com/raspberrypi/linux/commit/00f0e834c44c492555e43fdaf9c112ed269db01f which lead to Kodi locking up.

See https://github.com/raspberrypi/linux/issues/2680
