### PR TITLE
scripts/get: wget uses bar indicators

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -21,7 +21,7 @@ export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$PKG_SOURCE_NAME"
 [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c $WGET_OPT -O $PACKAGE"
+WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c --progress=bar:force --show-progress -O $PACKAGE"
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
 unset LD_LIBRARY_PATH


### PR DESCRIPTION
new behaviour:
![image](https://user-images.githubusercontent.com/1355173/45639442-49cd4580-bab0-11e8-9067-87851cbb9375.png)

old behaviour:
![image](https://user-images.githubusercontent.com/1355173/45639747-15a65480-bab1-11e8-9275-320f97d6e725.png)

