### PR TITLE
kodi: smb chunksize 1 -> 32k for smooth bluray iso playback

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.99.smb-chunksize-32k.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99.smb-chunksize-32k.patch
@@ -1,0 +1,27 @@
+diff --git a/xbmc/filesystem/SMBFile.cpp b/xbmc/filesystem/SMBFile.cpp
+index e5301b0..8d68fe2 100644
+--- a/xbmc/filesystem/SMBFile.cpp
++++ b/xbmc/filesystem/SMBFile.cpp
+@@ -499,8 +499,7 @@ int CSMBFile::Truncate(int64_t size)
+ 
+ ssize_t CSMBFile::Read(void *lpBuf, size_t uiBufSize)
+ {
+-  if (uiBufSize > SSIZE_MAX)
+-    uiBufSize = SSIZE_MAX;
++  uiBufSize = 32768;
+ 
+   if (m_fd == -1)
+     return -1;
+diff --git a/xbmc/filesystem/SMBFile.h b/xbmc/filesystem/SMBFile.h
+index 5fb5323..24828df 100644
+--- a/xbmc/filesystem/SMBFile.h
++++ b/xbmc/filesystem/SMBFile.h
+@@ -89,7 +89,7 @@ public:
+   virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
+   virtual bool Delete(const CURL& url);
+   virtual bool Rename(const CURL& url, const CURL& urlnew);
+-  virtual int GetChunkSize() { return 1; }
++  virtual int GetChunkSize() { return 32*1024; }
+   virtual int IoControl(EIoControl request, void* param);
+ 
+ protected:


### PR DESCRIPTION
At request of @wrxtasy i created builds with these 2 patches and now the PR.

The 1st part i did catch from @MilhouseVH in a discussion in slack and changed the number down to 32k, because @samnazarko explained that tests from the beginning of the year showed more then 32k does not change much. wrxtasy said with this patch it worked better.
The 2nd part solved the problem for the bluray playback problem from the forum. I am not sure who created this patch in the first place.

The forum link https://forum.libreelec.tv/thread/13267-le-8-2-5-unable-to-play-blu-ray-iso-over-gigabit-smb-share-smoothly-on-chromebox/