### PR TITLE
Improve fs-resize, fix delay and simplify

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -36,31 +36,23 @@ if [ -e /storage/.please_resize_me ] ; then
 
   # just in case
   if [ ! -z "$DISK" -a ! -z "$PART" ] ; then
-    # get storage partition start
-    PART_START=$(parted -s -m $DISK unit b print 2>/dev/null | grep -v ^/dev | grep -v BYT | grep ^2: |  cut -f2 -d ":")
+    umount $PART
 
-    # failed to get partition start offset ?
-    if [ ! -z "$PART_START" ] ; then
-      umount $PART
+    echo "PARTITION RESIZING IN PROGRESS"
+    echo ""
+    echo "Please do not reboot or turn off your @DISTRONAME@ device!"
+    echo ""
 
-      echo "PARTITION RESIZING IN PROGRESS"
-      echo ""
-      echo "Please do not reboot or turn off your @DISTRONAME@ device!"
-      echo ""
-
-      # identify the partition scheme, and if gpt fix minor issues such as gpt header not at end of disk
-      SCHEME=$(blkid -s PTTYPE -o value $DISK)
-      if [ "$SCHEME" = "gpt" ]; then
-        StartProgress spinner "Checking layout...   " "sgdisk -e $DISK &>/dev/null"
-      fi
-
-      StartProgress spinner "Deleting /storage... " "parted -s -m $DISK rm 2 &>/dev/null"
-      StartProgress spinner "Creating /storage... " "parted -s -m $DISK unit b mkpart primary $PART_START 100% &>/dev/null"
-      StartProgress spinner "Checking /storage... " "e2fsck -f -p $PART &>/dev/null"
-      StartProgress spinner "Resizing /storage... " "resize2fs $PART &>/dev/null"
-
-      StartProgress countdown "Rebooting in 15s... " 15 "NOW"
+    # identify the partition scheme, and if gpt fix minor issues such as gpt header not at end of disk
+    SCHEME=$(blkid -s PTTYPE -o value $DISK)
+    if [ "$SCHEME" = "gpt" ]; then
+      StartProgress spinner "Checking layout...      " "sgdisk -e $DISK &>/dev/null"
     fi
+
+    StartProgress spinner "Resizing partition...   " "parted -s -m $DISK resizepart 2 100% &>/dev/null"
+    StartProgress spinner "Checking file system... " "e2fsck -f -p $PART &>/dev/null"
+    StartProgress spinner "Resizing file system... " "resize2fs $PART &>/dev/null"
+    StartProgress countdown "Rebooting in 15s...     " 15 "NOW"
   fi
 fi
 reboot -f &>/dev/null

--- a/packages/sysutils/gptfdisk/package.mk
+++ b/packages/sysutils/gptfdisk/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gptfdisk"
-PKG_VERSION="1.0.1"
-PKG_SHA256="864c8aee2efdda50346804d7e6230407d5f42a8ae754df70404dd8b2fdfaeac7"
+PKG_VERSION="1.0.4"
+PKG_SHA256="b663391a6876f19a3cd901d862423a16e2b5ceaa2f4a3b9bb681e64b9c7ba78d"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.rodsbooks.com/gdisk/"
 PKG_URL="https://downloads.sourceforge.net/project/$PKG_NAME/$PKG_NAME/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="util-linux"
-PKG_VERSION="2.31"
-PKG_SHA256="f9be7cdcf4fc5c5064a226599acdda6bdf3d86c640152ba01ea642d91108dc8a"
+PKG_VERSION="2.32.1"
+PKG_SHA256="86e6707a379c7ff5489c218cfaf1e3464b0b95acf7817db0bc5f179e356a67b2"
 PKG_LICENSE="GPL"
-PKG_URL="http://www.kernel.org/pub/linux/utils/util-linux/v${PKG_VERSION%-*}/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="http://www.kernel.org/pub/linux/utils/util-linux/v${PKG_VERSION%.*}/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_INIT="toolchain"


### PR DESCRIPTION
fs-resize running at early boot time may need minutes to complete because the kernel RNG is not initialized. 

When parted and sgdisk call uuid_generate(), util-linux libuuid implementation use a blocking getrandom() syscall. It waits until the kernel crng has collected enough entropy. Having a SSD, no network, no user input and no HW RNG this can take a long time. The behavior explains the delay seen in #2957. 

This is fixed in util-linux 2.32:
```
commit a9cf659e0508c1f56813a7d74c64f67bbc962538
Author: Carlo Caione <carlo@endlessm.com>
Date:   Mon Mar 19 10:31:07 2018 +0000

    lib/randutils: Do not block on getrandom()
    
    In Endless we have hit a problem when using 'sfdisk' on the really first
    boot to automatically expand the rootfs partition. On this platform
    'sfdisk' is blocking on getrandom() because not enough random bytes are
    available. This is an ARM platform without a hwrng.
    
    We fix this passing GRND_NONBLOCK to getrandom(). 'sfdisk' will use the
    best entropy it has available and fallback only as necessary.
    
    Signed-off-by: Carlo Caione <carlo@endlessm.com>
``` 

Using parted's 3.2 'resizepart' command removes the partition recreation hack.
