### PR TITLE
 samba-config.service: fix destroying .cache structure 

### DIFF
--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -4,6 +4,9 @@
 # Copyright (C) 2009-2017 Stephan Raue (stephan@openelec.tv)
 
 SMB_CONF="/run/samba/smb.conf"
+SMB_TMP="$(mktemp -p /run/samba)"
+
+cp -f $SMB_CONF $SMB_TMP
 
 if [ ! -f /storage/.cache/services/samba.conf ]; then
   cp /usr/share/services/samba.conf /storage/.cache/services
@@ -17,21 +20,21 @@ SAMBA_MAXPROTOCOL=SMB3
 . /storage/.cache/services/samba.conf
 
 # fixup synonyms
-sed -i 's/browsable/browseable/g; s/writable/writeable/g' $SMB_CONF
+sed -i 's/browsable/browseable/g; s/writable/writeable/g' $SMB_TMP
 
 # handle external drives
 if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
   for dir in /media/* ; do
     if [ -d "$dir" ] ; then
       name=$(basename "$dir")
-      echo -e "[$name]\n  path = $dir\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_CONF
+      echo -e "[$name]\n  path = $dir\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_TMP
     fi
   done
 fi
 
 # Allow access to a "failed" (safe mode) Kodi installation
 if [ -d /storage/.kodi.FAILED ]; then
-  echo -e "[Kodi-Failed]\n  path = /storage/.kodi.FAILED\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_CONF
+  echo -e "[Kodi-Failed]\n  path = /storage/.kodi.FAILED\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_TMP
 fi
 
 ADD_CONFIG=
@@ -39,7 +42,7 @@ ADD_CONFIG=
 # If workgroup is not set, don't set it - who knows, user may know better.
 if [ -n "$SAMBA_WORKGROUP" ]; then
   # Remove any existing workgroup setting
-  sed -E '/^[[:space:]]*workgroup[[:space:]]*=/d' -i $SMB_CONF
+  sed -E '/^[[:space:]]*workgroup[[:space:]]*=/d' -i $SMB_TMP
   ADD_CONFIG="${ADD_CONFIG}  workgroup = ${SAMBA_WORKGROUP:-WORKGROUP}\n"
 fi
 
@@ -47,7 +50,7 @@ ADD_CONFIG="${ADD_CONFIG}  server min protocol = ${SAMBA_MINPROTOCOL/SMB1/NT1}\n
 ADD_CONFIG="${ADD_CONFIG}  server max protocol = ${SAMBA_MAXPROTOCOL/SMB1/NT1}\n"
 
 # Add extra config after [global], escaping spaces so that all are retained by sed
-sed -e "/\[global\]/ a ${ADD_CONFIG// /\\ }" -i $SMB_CONF
+sed -e "/\[global\]/ a ${ADD_CONFIG// /\\ }" -i $SMB_TMP
 
 # only letters & numbers permitted for username & password
   SAMBA_USERNAME=`echo $SAMBA_USERNAME | sed "s/[^a-zA-Z0-9]//g;"`
@@ -65,11 +68,13 @@ if [ "$SAMBA_SECURE" == "true" -a ! "$SAMBA_USERNAME" == "" -a ! "$SAMBA_PASSWOR
       -e 's|^.[ \t]*.username map.=.*||' \
       -e 's|^.[ \t]*.security.=.*|  security = user\n  username map = /run/samba/samba.map|' \
       -e 's|^.[ \t]*.map.to.guest.=.*|  map to guest = Never|' \
-      -i $SMB_CONF
+      -i $SMB_TMP
 else
   sed -e 's|^.[ \t]*.public.=.*|  public = yes |' \
       -e 's|^.[ \t]*.username map.=.*||' \
       -e 's|^.[ \t]*.security.=.*|  security = user|' \
       -e 's|^.[ \t]*.map.to.guest.=.*|  map to guest = Bad User|' \
-      -i $SMB_CONF
+      -i $SMB_TMP
 fi
+
+mv -f $SMB_TMP $SMB_CONF

--- a/packages/network/samba/system.d/samba-config.service
+++ b/packages/network/samba/system.d/samba-config.service
@@ -1,11 +1,9 @@
 [Unit]
 Description=Samba Configuration
 DefaultDependencies=false
+After=basic.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/lib/samba/samba-config
 StartLimitInterval=0
-
-[Install]
-WantedBy=sysinit.target

--- a/packages/sysutils/systemd/scripts/usercache-setup
+++ b/packages/sysutils/systemd/scripts/usercache-setup
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
+# Fix bug in older versions creating file /storage/.cache/services
+[ -f /storage/.cache/services ] && rm /storage/.cache/services && mkdir -p /storage/.cache/services
+
 # Copy cache files, but don't overwrite
 false | cp -iRp /usr/cache/* /storage/.cache/ &>/dev/null
 


### PR DESCRIPTION
samba-config.service runs before systemd-tmpfiles-setup.service:

![systemd-analyse](https://user-images.githubusercontent.com/8526926/45908956-904bd880-bdff-11e8-93c0-c792f7ed5a15.png)

On first boot the samba-config script creates a file /storage/.cache/services.  systemd-tmpfiles-setup.service is not able any more to create the same directory name. With the directory missing no LE service can be configured. More worse the avahi and cron services do not even start.

Journal: http://ix.io/1neo

The first commit delays the samba-config after basic.target to avoid the fault at new installations and extends usercache-setup to detect and fix a damaged system.

The second commit removes in place modification of smb.conf because I'm afraid of races.