### PR TITLE
fixes $VERBOSE usage

### DIFF
--- a/config/options
+++ b/config/options
@@ -82,7 +82,7 @@ fi
   [ -z "${LOCAL_CXX}" ] && export LOCAL_CXX="$(which g++)"
 
 # verbose compilation mode (yes/no)
-  VERBOSE="yes"
+  VERBOSE="${VERBOSE:-yes}"
 
 # Concurrency make level (-j option)
 #  Try value 1 (default) to 4 on single CPU computer, or more on

--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -21,7 +21,7 @@ export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$PKG_SOURCE_NAME"
 [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c --progress=bar:force --show-progress -O $PACKAGE"
+WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c $WGET_OPT --progress=bar:force --show-progress -O $PACKAGE"
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
 unset LD_LIBRARY_PATH


### PR DESCRIPTION
fixes https://github.com/LibreELEC/LibreELEC.tv/pull/2979#issuecomment-423802948 (accidentally dropped the verbose variable) and added the possibility to use VERBOSE=yes/no from the commandline
`PROJECT=RPi DEVICE=RPi2 ARCH=arm VERBOSE=no scripts/abc def`


![image](https://user-images.githubusercontent.com/1355173/45926996-55938e80-bf2c-11e8-8236-6bd3cc1fe1ad.png)
