### PR TITLE
supporting sabayon host distro, quite straightforward, as a flavour of gentoo

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -80,7 +80,7 @@ case "$DISTRO" in
       files_pkg=(glibc-headers ncurses-devel)
       perl_pkg=(perl-JSON perl-XML-parser)
       ;;
-    gentoo)
+    gentoo|sabayon)
       deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python)
       deps_pkg+=("gcc[cxx]" mkfontscale mkfontdir bdftopcf libxslt virtual/jre python)
       files_pkg=(glibc ncurses)
@@ -142,6 +142,9 @@ if [ "${#need[@]}" -gt 0 ]; then
       ;;
     gentoo)
       get_yes_no && sudo emerge --ask --deep "${need_pkg[@]}"
+      ;;
+    sabayon)
+      get_yes_no && sudo equo install --ask "${need_pkg[@]}"
       ;;
     mageia)
       get_yes_no && sudo urpmi "${need_pkg[@]}"


### PR DESCRIPTION
Tested on a branch not containing #2970 and there heimdal is configured properly, so it seems that the host libncurses package is properly detected. Thanks @MilhouseVH for pointing to this approach in the other PR.