### PR TITLE
libretro-genplus: bus error fix for non RPi arm based systems

### DIFF
--- a/packages/emulation/libretro-genplus/package.mk
+++ b/packages/emulation/libretro-genplus/package.mk
@@ -20,7 +20,11 @@ PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="GENPLUS_LIB"
 
 make_target() {
-  make -f Makefile.libretro
+  if [ "$ARCH" = "arm" ]; then
+    CFLAGS="$CFLAGS -DALIGN_LONG"
+  fi
+
+  make -f Makefile.libretro GIT_VERSION=$PKG_VERSION
 }
 
 makeinstall_target() {


### PR DESCRIPTION
Fixes a bus error, the makefile already sets this flag for RPi based systems but not for other arm platforms like the AML S905 chips.

See https://github.com/ekeeke/Genesis-Plus-GX/issues/158 for further details.