### PR TITLE
comskip: fix build

### DIFF
--- a/packages/addons/addon-depends/comskip/package.mk
+++ b/packages/addons/addon-depends/comskip/package.mk
@@ -12,6 +12,8 @@ PKG_LONGDESC="Comskip detects commercial breaks from a video stream. It can be u
 PKG_TOOLCHAIN="autotools"
 
 pre_configure_target() {
+  LDFLAGS="$LDFLAGS -ldl"
+
   export argtable2_CFLAGS="-I$(get_build_dir argtable2)/src"
   export argtable2_LIBS="-L$(get_build_dir argtable2)/src/.libs -largtable2"
 


### PR DESCRIPTION
fixes 
```
libavcodec/omx.c:185: error: undefined reference to 'dlclose'
libavcodec/omx.c:93: error: undefined reference to 'dlsym'
libavcodec/omx.c:101: error: undefined reference to 'dlopen'
libavcodec/omx.c:106: error: undefined reference to 'dlsym'
libavcodec/omx.c:109: error: undefined reference to 'dlclose'
libavcodec/omx.c:114: error: undefined reference to 'dlopen'
libavcodec/omx.c:130: error: undefined reference to 'dlclose'
libavcodec/omx.c:133: error: undefined reference to 'dlclose'
```