### PR TITLE
rpi: add RPi3 device

### DIFF
--- a/packages/devel/arm-mem/package.mk
+++ b/packages/devel/arm-mem/package.mk
@@ -15,7 +15,7 @@ PKG_SHORTDESC="arm-mem: ARM-accelerated versions of selected functions from stri
 PKG_LONGDESC="arm-mem is a ARM-accelerated versions of selected functions from string.h"
 PKG_BUILD_FLAGS="+pic"
 
-if [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ] ; then
+if [ "$DEVICE" = "RPi2" -o "$DEVICE" = "RPi3" -o "$DEVICE" = "Slice3" ] ; then
   PKG_LIB_ARM_MEM="libarmmem-v7l.so"
 else
   PKG_LIB_ARM_MEM="libarmmem-v6l.so"

--- a/packages/emulation/libretro-reicast/package.mk
+++ b/packages/emulation/libretro-reicast/package.mk
@@ -19,7 +19,7 @@ PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="REICAST_LIB"
 
 make_target() {
-  if [ "$DEVICE" = "RPi2" ]; then
+  if [ "$DEVICE" = "RPi2" -o "$DEVICE" = "RPi3" ]; then
     make platform=${DEVICE,,}
   else
     case $TARGET_CPU in

--- a/projects/RPi/devices/RPi3/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi3/linux/linux.arm.conf
@@ -1,0 +1,1 @@
+../../RPi2/linux/linux.arm.conf

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -8,7 +8,6 @@
       arm)
         # Valid TARGET_CPU for Raspberry Pi based devices are:
         # arm1176jzf-s cortex-a7 cortex-a53
-
         if [ "$DEVICE" = "RPi" -o "$DEVICE" = "Slice" ]; then
           TARGET_CPU="arm1176jzf-s"
         elif [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ]; then
@@ -27,7 +26,6 @@
         # This specifies what floating point hardware (or hardware emulation) is
         # available on the target. Permissible names are:
         # vfp neon-vfpv4 neon-fp-armv8
-
         if [ "$DEVICE" = "RPi" -o "$DEVICE" = "Slice" ]; then
           TARGET_FPU="vfp"
         elif [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ]; then
@@ -36,11 +34,10 @@
           TARGET_FPU="neon-fp-armv8"
         fi
         TARGET_FEATURES="32bit"
-
         ;;
     esac
 
-  # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
+  # Bootloader to use (bcm2835-bootloader)
     BOOTLOADER="bcm2835-bootloader"
 
   # u-boot version to use (default)
@@ -96,7 +93,6 @@ fi
   # SquashFS compression method (gzip / lzo / xz / zstd)
     SQUASHFS_COMPRESSION="lzo"
 
-
 ################################################################################
 # setup project defaults
 ################################################################################
@@ -107,7 +103,7 @@ fi
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
-  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
+  # OpenGL-ES implementation to use (no / bcm2835-driver / mesa)
     OPENGLES="bcm2835-driver"
 
   # include uvesafb support (yes / no)
@@ -116,18 +112,18 @@ fi
   # Displayserver to use (x11 / no)
     DISPLAYSERVER="no"
 
-  # Windowmanager to use (ratpoison / fluxbox / none)
+  # Windowmanager to use (fluxbox / none)
     WINDOWMANAGER="none"
 
-  # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
+  # Xorg Graphic drivers to use (all / vc4 / none)
   # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
+  # e.g. GRAPHIC_DRIVERS="vc4"
     GRAPHIC_DRIVERS=""
 
   # Use a vendor specific KODI repo
     KODI_VENDOR="raspberrypi"
 
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
+  # KODI Player implementation to use (default / bcm2835-driver / mesa)
     KODIPLAYER_DRIVER="bcm2835-driver"
 
   # Modules to install in initramfs for early boot

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -13,6 +13,9 @@
           TARGET_CPU="arm1176jzf-s"
         elif [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ]; then
           TARGET_CPU="cortex-a7"
+        elif [ "$DEVICE" = "RPi3" ]; then
+          TARGET_CPU="cortex-a53"
+          TARGET_CPU_FLAGS="+crc"
         fi
 
         # TARGET_FLOAT:
@@ -29,6 +32,8 @@
           TARGET_FPU="vfp"
         elif [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ]; then
           TARGET_FPU="neon-vfpv4"
+        elif [ "$DEVICE" = "RPi3" ]; then
+          TARGET_FPU="neon-fp-armv8"
         fi
         TARGET_FEATURES="32bit"
 

--- a/tools/repo-tool
+++ b/tools/repo-tool
@@ -190,6 +190,9 @@ if [ "$1" = "-b" -o "$1" = "-ru" ]; then
     elif [ "$3" == "RPi2" ]; then
       project="RPi"
       device="RPi2"
+    elif [ "$3" == "RPi3" ]; then
+      project="RPi"
+      device="RPi3"
     fi
   fi
 fi


### PR DESCRIPTION
This series adds the RPi3 device to the RPi project as an AArch32 build. I've been using it since early June, so I thought I would share it. AArch32 is a superset of armv7-a with armv8-a's neon improvements. This should mostly just bring improved neon performance over the existing RPi2 images. I'm not recommending this beyond making it available to users who wish to build their own image at this time (i.e. no new pre-built image for users).

No attempt is made to do anything with NOOBS, or migrate the Slice3 over.

tools/repo-tool change is untested as I'm not sure what the script is used for.
libretro-reicast change is untested as I'm not using any emulators.