### PR TITLE
busybox: add console-helper script

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -125,7 +125,12 @@ makeinstall_target() {
     cp $PKG_DIR/scripts/apt-get $INSTALL/usr/bin/
     cp $PKG_DIR/scripts/sudo $INSTALL/usr/bin/
     cp $PKG_DIR/scripts/pastebinit $INSTALL/usr/bin/
-    ln -sf pastebinit $INSTALL/usr/bin/paste
+      ln -sf pastebinit $INSTALL/usr/bin/paste
+    cp $PKG_DIR/scripts/console-helper $INSTALL/usr/bin/
+      ln -sf console-helper $INSTALL/usr/bin/codecinfo
+      ln -sf console-helper $INSTALL/usr/bin/playerdebug
+      ln -sf console-helper $INSTALL/usr/bin/screenshot
+      ln -sf console-helper $INSTALL/usr/bin/wanip
 
   mkdir -p $INSTALL/usr/lib/libreelec
     cp $PKG_DIR/scripts/functions $INSTALL/usr/lib/libreelec

--- a/packages/sysutils/busybox/scripts/console-helper
+++ b/packages/sysutils/busybox/scripts/console-helper
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+COMMAND=$(basename "$0")
+
+case $COMMAND in
+  codecinfo)
+    kodi-send --host="127.0.0.1" --action="codecinfo"
+    ;;
+  playerdebug)
+    kodi-send --host="127.0.0.1" --action="playerdebug"
+    ;;
+  screenshot)
+    kodi-send --host="127.0.0.1" --action="TakeScreenshot"
+    ;;
+  wanip)
+    curl -s icanhazip.com
+    ;;
+esac


### PR DESCRIPTION
Inspired by how busybox applets are deployed in the filesystem, this adds a `console-helper` script and symlinks for some frequently used console commands (wanip is provided as another example so it's not all kodi-send commands).