### PR TITLE
u-boot: only append suffix when creating multiple u-boot variants

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -71,7 +71,7 @@ else
     IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
   fi
 
-  if [ -n "$UBOOT_SYSTEM" ]; then
+  if [ -n "$UBOOT_SYSTEM" ] && [ "$UBOOT_SYSTEM" != "${DEVICE:-$PROJECT}" ]; then
     IMAGE_NAME="$IMAGE_NAME-$UBOOT_SYSTEM"
   fi
 fi


### PR DESCRIPTION
This change simplifies SBC image filenames by only appending the board-type suffix when the image file is one of multiple u-boot variants, e.g. `LibreELEC-RK3399.arm-8.90.006-rockpro64.img.gz` will remain the same. If the device has its own u-boot variant and entry in `scripts/uboot-helper` the name is shortened, e.g. `LibreELEC-TinkerBoard.arm-8.90.006-rk3288.img.gz` becomes shortened to `LibreELEC-TinkerBoard.arm-8.90.006.img.gz`. To work the scripts/uboot-helper entries just need to match the buildsystem `$DEVICE` name.