### PR TITLE
slice-drivers: update to 8a2bdcd

### DIFF
--- a/packages/linux-drivers/slice-drivers/package.mk
+++ b/packages/linux-drivers/slice-drivers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="slice-drivers"
-PKG_VERSION="d02f3e7"
-PKG_SHA256="31c32eba1549c8cf6204c5cfdd25ec0480bcc95c0253f06258596189c84926ca"
+PKG_VERSION="8a2bdcd5dc182de899f19b0935d8beeb7f5fdbcb"
+PKG_SHA256="ffb3b9ef5a0e6101d661407447257abf136f1ae206a17bd18d9b204e0b29f050"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/slice-drivers"


### PR DESCRIPTION
This fixes build issues on kernel 4.17 and newer