### PR TITLE
graphics: update libva/libva-utils to 2.3.0

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -2,14 +2,12 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva-utils"
-PKG_VERSION="2.2.0"
-PKG_SHA256="1c45452090456f2b972d51960b1294215615b0dd925aa36b90eceac77777f3e3"
+PKG_VERSION="2.3.0"
+PKG_SHA256="f338497b867bbc9bf008e4892eaebda08955785dc7eb2005855bba5f1a20b037"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"
 PKG_URL="https://github.com/intel/libva-utils/archive/$PKG_VERSION.tar.gz"
-PKG_SECTION="debug"
-PKG_SHORTDESC="Libva-utils is a collection of tests for VA-API (VIdeo Acceleration API)"
 PKG_LONGDESC="Libva-utils is a collection of tests for VA-API (VIdeo Acceleration API)"
 PKG_TOOLCHAIN="autotools"
 

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -3,15 +3,13 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva"
-PKG_VERSION="2.2.0"
-PKG_SHA256="327181061056b49f8f9b5c5ee08fdd9832df06f4282451b218d1d0bde26a99b7"
+PKG_VERSION="2.3.0"
+PKG_SHA256="8d95e65c4d84d0f82097581e163d3770694c600cbb040ebd827f2d375e004f4b"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"
 PKG_URL="https://github.com/intel/libva/archive/$PKG_VERSION.tar.gz"
-PKG_SECTION="multimedia"
-PKG_SHORTDESC="Libva is an implementation for VA-API (VIdeo Acceleration API)."
-PKG_LONGDESC="Libva is an open source software library and API specification to provide access to hardware accelerated video decoding/encoding and video processing."
+PKG_LONGDESC="Libva is an implementation for VA-API (VIdeo Acceleration API)."
 PKG_TOOLCHAIN="autotools"
 
 if [ "$DISPLAYSERVER" = "x11" ]; then


### PR DESCRIPTION
As suggested by fritsch, we should bump libva/libva-utils to 2.3.0

It adds tone mapping support via libva

First time bumping a package.mk, so please bear with me ;)

The SHA seems to be correct and the packages build fine. That's what I've tested so far