### PR TITLE
scripts/image: drop OPENELEC_ARCH

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -250,7 +250,7 @@ get_project_arch() {
 
   if [ -f /sysroot/etc/os-release ]; then
     . /sysroot/etc/os-release
-    echo "${LIBREELEC_ARCH:-${OPENELEC_ARCH}}"
+    echo "${OPENELEC_ARCH:-${LIBREELEC_ARCH}}"
   fi
 
   umount /sysroot

--- a/scripts/image
+++ b/scripts/image
@@ -154,7 +154,6 @@ echo -e "PRETTY_NAME=\"$DISTRONAME ($LIBREELEC_BUILD): $LIBREELEC_VERSION\"" >> 
 echo -e "HOME_URL=\"https://libreelec.tv\"" >> $INSTALL/etc/os-release
 echo -e "BUG_REPORT_URL=\"$ORIGIN_URL\"" >> $INSTALL/etc/os-release
 echo -e "BUILD_ID=\"$GIT_HASH\"" >> $INSTALL/etc/os-release
-echo -e "OPENELEC_ARCH=\"$LIBREELEC_ARCH\"" >> $INSTALL/etc/os-release
 echo -e "LIBREELEC_ARCH=\"$LIBREELEC_ARCH\"" >> $INSTALL/etc/os-release
 echo -e "LIBREELEC_BUILD=\"$LIBREELEC_BUILD\"" >> $INSTALL/etc/os-release
 echo -e "LIBREELEC_PROJECT=\"$PROJECT\"" >> $INSTALL/etc/os-release

--- a/scripts/image_st
+++ b/scripts/image_st
@@ -150,7 +150,6 @@ echo -e "PRETTY_NAME=\"$DISTRONAME ($LIBREELEC_BUILD): $LIBREELEC_VERSION\"" >> 
 echo -e "HOME_URL=\"https://libreelec.tv\"" >> $INSTALL/etc/os-release
 echo -e "BUG_REPORT_URL=\"$ORIGIN_URL\"" >> $INSTALL/etc/os-release
 echo -e "BUILD_ID=\"$GIT_HASH\"" >> $INSTALL/etc/os-release
-echo -e "OPENELEC_ARCH=\"$LIBREELEC_ARCH\"" >> $INSTALL/etc/os-release
 echo -e "LIBREELEC_ARCH=\"$LIBREELEC_ARCH\"" >> $INSTALL/etc/os-release
 echo -e "LIBREELEC_BUILD=\"$LIBREELEC_BUILD\"" >> $INSTALL/etc/os-release
 echo -e "LIBREELEC_PROJECT=\"$PROJECT\"" >> $INSTALL/etc/os-release


### PR DESCRIPTION
For merger post-9.0(?)

This drops OPENELEC_ARCH from /etc/os-release, which may break out of date addons. As Kodi 19 is expected to break plenty of addons too, take the opportunity to drop this variable.

I reversed get_project_arch() in the busybox init because I don't like the idea of the variable falling back as default to what will be a known null value.