### PR TITLE
config/options: use a smarter ARCH fallback

### DIFF
--- a/config/options
+++ b/config/options
@@ -7,6 +7,11 @@ fi
 # set default language for buildsystem
   export LC_ALL=C
 
+# set default independent variables
+ROOT="${PWD}"
+DISTRO_DIR="$ROOT/distributions"
+PROJECT_DIR="$ROOT/projects"
+
 # determines DISTRO, if not forced by user
 # default is LibreELEC
 if [ -z "$DISTRO" ]; then
@@ -30,10 +35,6 @@ if [ -z "$ARCH" ]; then
 else
   TARGET_ARCH="$ARCH"
 fi
-
-ROOT="${PWD}"
-DISTRO_DIR="$ROOT/distributions"
-PROJECT_DIR="$ROOT/projects"
 
 # include helper functions
 . config/functions

--- a/config/options
+++ b/config/options
@@ -31,7 +31,20 @@ fi
 # determines TARGET_ARCH, if not forced by user (x86_64 / arm)
 # default is x86_64
 if [ -z "$ARCH" ]; then
-  TARGET_ARCH="x86_64"
+  if [ -n "$DEVICE" ]; then
+    linux_config_dir="$PROJECT_DIR/$PROJECT/devices/$DEVICE/linux"
+  else
+    linux_config_dir="$PROJECT_DIR/$PROJECT/linux"
+  fi
+
+  arch_list=()
+  for arch in $linux_config_dir/*.conf $linux_config_dir/*/linux.*.conf; do
+    [[ ${arch} =~ .*\*.* ]] && continue
+    arch_list+=($(basename $arch | cut -f2 -d "."))
+  done
+  if [ ${#arch_list[@]} -eq 1 ]; then
+    TARGET_ARCH=${arch_list[0]}
+  fi
 else
   TARGET_ARCH="$ARCH"
 fi


### PR DESCRIPTION
When ARCH isn't set, this runs through check_config()'s logic to see if a single ARCH gets reported as an acceptable ARCH and, if so, uses that instead of throwing an error.

This and check_config() share a flaw, in that it assumes that the kernel arch matches the userland arch, so something like Amlogic will report aarch64 as the acceptable arch, but won't mention arm. The current check_config works around setting it to ARM by looking to see if using ARM also sets a TARGET_PATCH_ARCH, which it does.

My first thought for a solution would be to set a PROJECT_ARCHES in project directory options, and a DEVICE_ARCHES in the device dir options if they're required. This would have check_config check if ARCH was in DEVICE_ARCHES if present, PROJECT_ARCHES if not, and if it fails to find a match, output one or the other as the acceptable ARCHes in the error message.

The default arch mechanic introduced here would check ${DEVICE_ARCHES:-$PROJECT_ARCHES} to see if they hold a single value in the array, and use that when ARCH isn't set.

Results for the different projects when you skip setting an arch under the current commits:

Amlogic = aarch64
Generic = x86_64
Rockchip 3328 = aarch64
Rockchip 3399 = aarch64
Rockchip MiQi = arm
Rockchip TinkerBoard = arm
RPi RPi = arm
RPi RPi2 = arm
RPi Slice = arm
RPi Slice3 = arm
WeTek_Core = arm
WeTek_Play = arm

Amlogic & Rockchip are the ones with a mix of aarch64 + arm.

Or this is unwanted... I'm mostly just annoyed that an error message that tells me there was one acceptable answer didn't just use it when I forgot to set it altogether. This goes about fixing that.