### PR TITLE
libretro-pcsx-rearmed: set PKG_ARCH to any since PCSX_reARMed performs

### DIFF
--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="libretro-pcsx-rearmed"
 PKG_VERSION="0370856deb325e759179c6835897e2553cef31c2"
 PKG_SHA256="e4971b2624100a4389e81ac51f2b43ab2784993e6803b47f8cdf7b96c86d8d8e"
-PKG_ARCH="arm"
+PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="https://github.com/libretro/pcsx_rearmed/archive/$PKG_VERSION.tar.gz"
@@ -31,13 +31,13 @@ make_target() {
   
   case $TARGET_ARCH in
     aarch64)
-      make -f Makefile.libretro platform=aarch64
+      make -f Makefile.libretro platform=aarch64 GIT_VERSION=$PKG_VERSION
       ;;
     arm)
-      make -f Makefile.libretro USE_DYNAREC=1
+      make -f Makefile.libretro USE_DYNAREC=1 GIT_VERSION=$PKG_VERSION
       ;;
     x86-64)
-      make -f Makefile.libretro
+      make -f Makefile.libretro GIT_VERSION=$PKG_VERSION
       ;;
   esac
 }

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -5,8 +5,7 @@ PKG_NAME="game.libretro.pcsx-rearmed"
 PKG_VERSION="75208998eb366f70624d427d14353662b07990a2"
 PKG_SHA256="5d99e36d62f1016ebff01a6877a48aa8b01a9c0b88f5c5dd67c0dd710d5ff352"
 PKG_REV="108"
-# neon optimizations make it only useful for arm
-PKG_ARCH="arm"
+PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.pcsx-rearmed"
 PKG_URL="https://github.com/kodi-game/game.libretro.pcsx-rearmed/archive/$PKG_VERSION.tar.gz"
@@ -16,8 +15,3 @@ PKG_LONGDESC="game.libretro.pcsx-rearmed: PCSX Rearmed for Kodi"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.gameclient"
-
-if ! target_has_feature neon; then
-  echo "${DEVICE:-${PROJECT}} doesn't support neon"
-  exit 0
-fi


### PR DESCRIPTION
on lowend generic systems better than beetle-psx / added correct GIT version

If you have a well performing generic system beetle-psx is the PSX emulator of choice but if you struggle to run games at full speed PCSX_reARMed could be a better choice and at least an option. It has less features but is less demanding too.