### PR TITLE
libretro-pcsx-rearmed: target ARCH is x86_64 not x86-64

### DIFF
--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -36,7 +36,7 @@ make_target() {
     arm)
       make -f Makefile.libretro USE_DYNAREC=1 GIT_VERSION=$PKG_VERSION
       ;;
-    x86-64)
+    x86_64)
       make -f Makefile.libretro GIT_VERSION=$PKG_VERSION
       ;;
   esac


### PR DESCRIPTION
make_target() uses $TARGET_ARCH which should be x86_64 for generic builds