### PR TITLE
busybox: quit countdown timers on keyboard input

### DIFF
--- a/packages/sysutils/busybox/scripts/functions
+++ b/packages/sysutils/busybox/scripts/functions
@@ -144,7 +144,7 @@ ProgressTask_Countdown() {
 
   while [ ${countfrom} -gt 0 ]; do
     echo ${countfrom} | awk '{ printf "\b\b%2d", $1 }'
-    sleep 1
+    read -r -s -t1 && break
     countfrom=$((countfrom - 1))
   done
 


### PR DESCRIPTION
There are two wait timers in the fs-resize script. The first shows when you shouldn't be trying to resize a full-size partition and this remains at 15s so it can be noticed. The second simply kills time after the resize and this is reduced from 15s to 5s which is long enough to be noticed but short enough to be less annoying for developers frequently testing installs :)