### PR TITLE
Avoid managing ZeroTier network interfaces

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -78,7 +78,7 @@ post_makeinstall_target() {
         -e "s|^# TetheringTechnologies.*|TetheringTechnologies = wifi|g" \
         -e "s|^# AllowHostnameUpdates.*|AllowHostnameUpdates = false|g" \
         -e "s|^# PersistentTetheringMode.*|PersistentTetheringMode = true|g" \
-        -e "s|^# NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb|NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb,docker,veth|g"
+        -e "s|^# NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb|NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb,docker,veth,zt|g"
 
   mkdir -p $INSTALL/usr/config
     cp $PKG_DIR/config/hosts.conf $INSTALL/usr/config


### PR DESCRIPTION
[ZeroTier](https://zerotier.com/) is a VPN/SD-WAN that provides wide access to a virtual wide peer to peer ethernet network.
The daemon manages new interface networks under the `zt` prefix, and handle all the ip configuration under those interrfaces.

After [battling](https://github.com/zerotier/ZeroTierOne/issues/868) for a whole week figuring why the IPv6 addresses didn't show up on that interface under LibreElec, I found the issue was related to the configuration on `connman` regarding which interfaces it should manage.

This commit proposes a new network interface prefix to be included on the block list by default for new LibreElec installations, in order to avoid more people facing issues while trying to hook up their devices on the ZeroTier network.