### PR TITLE
retroplayer: fix update script, update to latest version

### DIFF
--- a/packages/emulation/libretro-2048/package.mk
+++ b/packages/emulation/libretro-2048/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-2048"
-PKG_VERSION="82843002384e8d9b495f80acdee8bdf0e2bde74c"
-PKG_SHA256="1676cdf0479b31b0827ce9eac54630493b7dc76b007716f24b4fb5bde12ec858"
+PKG_VERSION="80d462acf92ceb030774c69a0539b73189d3e4f4"
+PKG_SHA256="6871cde6fa3d58c0e014006b0b99be5ca1ba076301ee3ee54c0481c5dabe34ca"
 PKG_LICENSE="Public domain"
 PKG_SITE="https://github.com/libretro/libretro-2048"
 PKG_URL="https://github.com/libretro/libretro-2048/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-4do/package.mk
+++ b/packages/emulation/libretro-4do/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-4do"
-PKG_VERSION="9d76c93c140d227211411b351ad03b8252d21a3a"
-PKG_SHA256="607feb97f269e1741b295b761c407393febd422161c9eb2219545e16ff90204f"
+PKG_VERSION="e1fec6e5c51ed6a579e4597e51e3facdb62df743"
+PKG_SHA256="7d2269e6c045ba37a9a5bf514dcd74a35746cd7a350593a3e16d76350e71fc86"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://github.com/libretro/4do-libretro"
 PKG_URL="https://github.com/libretro/4do-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-beetle-lynx/package.mk
+++ b/packages/emulation/libretro-beetle-lynx/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-lynx"
-PKG_VERSION="6816829"
+PKG_VERSION="6816829ae785e2d468256d346fcd90b5baaa7327"
 PKG_SHA256="15a66e65ba7306de06c598d4f82ab3e1b1afaad6baa0b298db6729aea6e0d2c4"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-lynx-libretro"

--- a/packages/emulation/libretro-beetle-ngp/package.mk
+++ b/packages/emulation/libretro-beetle-ngp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-ngp"
-PKG_VERSION="69293c940ca27008ab2a1e37cc3077c677b36d1e"
-PKG_SHA256="6934596bac9be082ff32f0fc4be32da3d50079d98c2f0839f8bbe3edb4b8801a"
+PKG_VERSION="576eafc87306c4ffcec07d92ec44edca1a8a7cc0"
+PKG_SHA256="35cfd153e4ec008d3c46910702fad34073164dc24b4efc0c540477f3af786144"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-ngp-libretro"
 PKG_URL="https://github.com/libretro/beetle-ngp-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-beetle-pce-fast/package.mk
+++ b/packages/emulation/libretro-beetle-pce-fast/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-pce-fast"
-PKG_VERSION="f61ab365200b3e3eed56bf3fc27fdc879c5d5269"
-PKG_SHA256="94cca490864984e64074cdd9aa4b1f0b92e7ce24dcb29b5e398035d5905c3861"
+PKG_VERSION="7f6f0618b96014badaba0545fd68b98656cdceb3"
+PKG_SHA256="cccecf92082de0c7c2ea66b7b043b383098d7443db3b2a58c7186d0752e020bc"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-pce-fast-libretro"
 PKG_URL="https://github.com/libretro/beetle-pce-fast-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-beetle-psx/package.mk
+++ b/packages/emulation/libretro-beetle-psx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-psx"
-PKG_VERSION="70449aadae758516d5d16e1b3b893ab0b49190ab"
-PKG_SHA256="4cb52d2b10ad177ac3e63e187e95793a62a5993e210361008a2630e8af783ad7"
+PKG_VERSION="a38aa45f61e0da3f1e105b41be2e44be02430971"
+PKG_SHA256="8325e530cc4350b7101ca8dc0958c787f22484eedafe612cd074f425ed54f834"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-psx-libretro"
 PKG_URL="https://github.com/libretro/beetle-psx-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-beetle-supergrafx/package.mk
+++ b/packages/emulation/libretro-beetle-supergrafx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-supergrafx"
-PKG_VERSION="0d4d964"
-PKG_SHA256="25ca680d554fd0e1f1bc84e7910102aac46af01ae9e1eda855e5b68ea3bbb49a"
+PKG_VERSION="a8f924e9ef062b40248560d2eb9c797f2729dbb7"
+PKG_SHA256="505e374b1a3f972161f27d4fbcc97c55859f9fbcb461bc05f6e6936de10a298c"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-supergrafx-libretro"
 PKG_URL="https://github.com/libretro/beetle-supergrafx-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-beetle-vb/package.mk
+++ b/packages/emulation/libretro-beetle-vb/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-vb"
-PKG_VERSION="cc11960675aaef4bb9c8e50b8ada6c81d9044d96"
-PKG_SHA256="61d20d873c660f06de59f910f98ac71c55fb38d7c436efa1b57ce3fd5e68f061"
+PKG_VERSION="93f5b60cf82025a88c88b1cb9b4546a060f0265a"
+PKG_SHA256="fe257a95e4e04fce285fe6607952e6460b77e8636afb1439e6f3bc6b326c07f0"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-vb-libretro"
 PKG_URL="https://github.com/libretro/beetle-vb-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-beetle-wswan/package.mk
+++ b/packages/emulation/libretro-beetle-wswan/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-wswan"
-PKG_VERSION="b4dc85b0ada2b27af3d4420439b0e4528363ef67"
-PKG_SHA256="abe970835dfdea0212acffa48c991e4912b66ba762f1ad3838f5a509d68b137b"
+PKG_VERSION="207404bac2a3193b72ce1946ea07ffd13733d973"
+PKG_SHA256="9749701fd85bb376a6497f6a651c9548f489247a3130a9f3ae6bfc5e9058b352"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-wswan-libretro"
 PKG_URL="https://github.com/libretro/beetle-wswan-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bluemsx"
-PKG_VERSION="8ff0884d2b80d67b55ee46e3b5429ce5d5ee6538"
-PKG_SHA256="2e079887c05e6a0efb3078dd7c3cae96a4446dfa11f809354c393e66cb27c904"
+PKG_VERSION="4be0a245fb8593f1b83a86af80d7191ef71f0f4a"
+PKG_SHA256="993158a68fa7757a2d1503c68cbe5c9cfc09e98035b31bffb22585cb427a0e4b"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/blueMSX-libretro"
 PKG_URL="https://github.com/libretro/blueMSX-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-desmume/package.mk
+++ b/packages/emulation/libretro-desmume/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-desmume"
-PKG_VERSION="f546d2dd15c8c8c44907e4332339c36d9f8319d5"
-PKG_SHA256="6ed1a6115debf52a1507a8fc25ba41746f2a6d5a81b927067bb711064f7ef7a8"
+PKG_VERSION="3032b69714c07ea076759aef09d353d64741fdbe"
+PKG_SHA256="9a3f4b2bff3b4f17d0f42220c27b490260fabf2091587414285df7b8867bbeb4"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/desmume"
 PKG_URL="https://github.com/libretro/desmume/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-dinothawr/package.mk
+++ b/packages/emulation/libretro-dinothawr/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-dinothawr"
-PKG_VERSION="92431d1"
-PKG_SHA256="93f31617fbed6274efc312c056d64018cc3d42a0302ea583950ec41cb788c05c"
+PKG_VERSION="7794da5cc170b969c214b869f1d8cd3393e0a3cb"
+PKG_SHA256="40e0a967ce0b2419b5a3180ee9c8229fd3184aafd0332cca0034b6c87c7daf94"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/Dinothawr"
 PKG_URL="https://github.com/libretro/Dinothawr/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-dolphin/package.mk
+++ b/packages/emulation/libretro-dolphin/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-dolphin"
-PKG_VERSION="9ef58b5"
-PKG_SHA256="b9a040233219bdb2bfb2b67f4bc6ea63faf0b9b85bf22893408710a62df4c2da"
+PKG_VERSION="a5bce7d67abeaa9142d466a578ca5049197073e9"
+PKG_SHA256="3fdad8ee0d4d8280935d1bb4af619ace0e3f38ad8779e6f9ec19e2d7d11d9e7d"
 PKG_ARCH="none"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/dolphin"

--- a/packages/emulation/libretro-dosbox/package.mk
+++ b/packages/emulation/libretro-dosbox/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-dosbox"
-PKG_VERSION="2d6bfbfe9ae82be17afbadf41f24950c2f9e2db9"
-PKG_SHA256="48b0e329bfe7e11822d220a5a622da1af3fd06dfbb5f88b4c5ba141fda8b4d2a"
+PKG_VERSION="8f2d7318b6e66e397448a5905b30bc4f92de7133"
+PKG_SHA256="ee1bd0d04f9aa0e11eb827b8badbceec5bd9f0727765688436bd1d67fdb65816"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/dosbox-libretro"
 PKG_URL="https://github.com/libretro/dosbox-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-fbalpha/package.mk
+++ b/packages/emulation/libretro-fbalpha/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-fbalpha"
-PKG_VERSION="9ceab7f6293864591e63a2669396dc200e3246bb"
-PKG_SHA256="26eb3e4c3f5c7238fd9632c055d2941be50348fc16998c774126aba2e81508d2"
+PKG_VERSION="20daa807957d7fce64371620271b502811318163"
+PKG_SHA256="73bb074e85327848a05d2a6e64b2b7c6786c3db35e84eb8999d72bf663ef4f7d"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/fbalpha"
 PKG_URL="https://github.com/libretro/fbalpha/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-fceumm/package.mk
+++ b/packages/emulation/libretro-fceumm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-fceumm"
-PKG_VERSION="afd4cdf58bc3affcedcfd9537b27f838b1915833"
-PKG_SHA256="6704173348d0402f46d14ee435823aefcc863892bbd0f5fbdf0654f58b5c6326"
+PKG_VERSION="eb17f882dfcb945c5439c2d60b8e8aba580fce45"
+PKG_SHA256="8a3c3e7f52c2d463e708b15051f7b2255b336491a94169c0e82e81b6bafc3c4f"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-fceumm"
 PKG_URL="https://github.com/libretro/libretro-fceumm/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-fmsx/package.mk
+++ b/packages/emulation/libretro-fmsx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-fmsx"
-PKG_VERSION="778773f04ef0d7c0f7f3c423fb4065981e811a36"
-PKG_SHA256="43c6d793d4035a3cb6d2b7a30b11ec4879b5ae0b4fe195b027480b0f6af0b535"
+PKG_VERSION="a61ef7bfc97442b1116069e070edd09f0c6587f2"
+PKG_SHA256="3eb1e9990967a85281b29f35d2532f540f34293e0538e94d848fc04fcac5b0f4"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/fmsx-libretro"
 PKG_URL="https://github.com/libretro/fmsx-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-fuse/package.mk
+++ b/packages/emulation/libretro-fuse/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-fuse"
-PKG_VERSION="69a44421bd82b7ed4b389b1f997e6d5153ea855c"
-PKG_SHA256="bd505c92bc4753204b00a41f2f7f506577abd9b0be45b33a5048dd0266b191d5"
+PKG_VERSION="ab0c67ec6588b553b5399335892615c8410907e2"
+PKG_SHA256="256e6a5bb4da5c25161281dc84092eb5ae6b18fa5d6ba16d3de3fae940aad8df"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/fuse-libretro"
 PKG_URL="https://github.com/libretro/fuse-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-gambatte/package.mk
+++ b/packages/emulation/libretro-gambatte/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-gambatte"
-PKG_VERSION="7722012"
-PKG_SHA256="c964bd5b9e3c7db4d605f8332f5a8285e6bf1953294ab1ab439cbce534fc13c9"
+PKG_VERSION="5ee8b1e9da0835be8e526e9e4ff73346eef20fd1"
+PKG_SHA256="9de56ac0c523ae8ad0db5b0a3759ec03046d54bafd3dfe3a661c47b6e5a31f0e"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/gambatte-libretro"
 PKG_URL="https://github.com/libretro/gambatte-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-genplus/package.mk
+++ b/packages/emulation/libretro-genplus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-genplus"
-PKG_VERSION="7856b7208981fa4dc33623f89c4f330a95019c26"
-PKG_SHA256="bb7253623488e57b6e852135c7fedce693fd997a6cb8abb2309c20886ee6aed8"
+PKG_VERSION="7d0c04c4b9522b47b828dc2a26397d7d5a4efed4"
+PKG_SHA256="409e3800386603b0ae3004b7d12ca4114d0305ef612d34701fe8f32b03c8d86e"
 PKG_LICENSE="Modified BSD / LGPLv2.1"
 PKG_SITE="https://github.com/libretro/Genesis-Plus-GX"
 PKG_URL="https://github.com/libretro/Genesis-Plus-GX/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-gw/package.mk
+++ b/packages/emulation/libretro-gw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-gw"
-PKG_VERSION="b6bcc81340ba442972e3f19179bf61115105c739"
-PKG_SHA256="03ec51e251bed58ea13981c8346c5fafb32944871e7d7c8815310534bed0ca2b"
+PKG_VERSION="dea8b93021d43f81d332646cb92c88b467745f15"
+PKG_SHA256="76d5d11f5ecf423e79bb33f2e6d94c0f1373cddd3c4cccda83bb4bc8f1101e9c"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/gw-libretro"
 PKG_URL="https://github.com/libretro/gw-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-handy/package.mk
+++ b/packages/emulation/libretro-handy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-handy"
-PKG_VERSION="debca1e"
-PKG_SHA256="9512e18f8073355a1a1d1da9aee3be5f048da935dde8dfc0513b99a768bcb245"
+PKG_VERSION="08cc63376cd8886aea6e6cd38297ba7c9ea0344c"
+PKG_SHA256="e2e70fcf4d983549fa2a33791cd570958087f4dbf3664374dcc38a82d29139ce"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-handy"
 PKG_URL="https://github.com/libretro/libretro-handy/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-mame/package.mk
+++ b/packages/emulation/libretro-mame/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame"
-PKG_VERSION="c816514"
-PKG_SHA256="2aff1615e7f298210e4bc3342b3472ed0cab275b91bc0f3ba7c062ce2958be6a"
+PKG_VERSION="9f9e6b6c9bde4d50c72e9a5c80496a1fec6b8aa9"
+PKG_SHA256="4b0280d5413cd0b681338c086b14734badff4b68124a2b0065ca5cb5265b0590"
 PKG_ARCH="x86_64 arm"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mame"

--- a/packages/emulation/libretro-meteor/package.mk
+++ b/packages/emulation/libretro-meteor/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-meteor"
-PKG_VERSION="f8ab66c"
+PKG_VERSION="f8ab66ce5f68991bf9f926bf1dd5b662abd9d74b"
 PKG_SHA256="3d2c4934ccb688782353f017313ca5bfea75441cc4c6751cda2751688d255c13"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/meteor-libretro"

--- a/packages/emulation/libretro-mgba/package.mk
+++ b/packages/emulation/libretro-mgba/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mgba"
-PKG_VERSION="d98de4a"
-PKG_SHA256="cca97b095137a3ad43915776d535960b6cbcbbf5e0da54d371a638c747f5aae8"
+PKG_VERSION="0a79981bfa2d84f933fe66ad28b34a8913d3b8f2"
+PKG_SHA256="f6171ee6b5459de8eca30231c6fcacdfd94e7375508e347042714a668aa8970d"
 PKG_LICENSE="MPL 2.0"
 PKG_SITE="https://github.com/libretro/mgba"
 PKG_URL="https://github.com/libretro/mgba/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-mrboom/package.mk
+++ b/packages/emulation/libretro-mrboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mrboom"
-PKG_VERSION="4645af8"
-PKG_SHA256="b14ff4890902849049075d3cadb03221c5dd32d670b081e8a3386e3fb0b89527"
+PKG_VERSION="aafe738638f4323dfa1269816ccb97bd4ce3ed58"
+PKG_SHA256="5a905d32ec6c60f444acaef13b2284a86314ac44a698da574bf6f552b7dbcb9f"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/mrboom-libretro"
 PKG_URL="https://github.com/libretro/mrboom-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-mupen64plus/package.mk
+++ b/packages/emulation/libretro-mupen64plus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mupen64plus"
-PKG_VERSION="d2abd0c"
-PKG_SHA256="99aa710207e19d30bdfc5bf3b891bf77e77c27095e75e953af0c89bf28e4f575"
+PKG_VERSION="e7ea1ae1f7a6e9913a46946e322d1a2f6d8c4ae0"
+PKG_SHA256="f1d86cc8ac9e3b951bd757a0c2196f3e42473a6a81ac8952374cf92743069d25"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mupen64plus-libretro"
 PKG_URL="https://github.com/libretro/mupen64plus-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-nestopia/package.mk
+++ b/packages/emulation/libretro-nestopia/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-nestopia"
-PKG_VERSION="faf19f8e64baa09059201d40f09621f820453fca"
-PKG_SHA256="b22a362ddd3ae25151e53ed3ae0dc429cd402ba99ac43f08d061b5def0c807ce"
+PKG_VERSION="28aa27ccd6a44cf8e1e406b58356a8d0bb646834"
+PKG_SHA256="ea0d16236355f67c9b16aca47415ca19f713adfa87371d82e7e96e09ce83ecbe"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/nestopia"
 PKG_URL="https://github.com/libretro/nestopia/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-nx/package.mk
+++ b/packages/emulation/libretro-nx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-nx"
-PKG_VERSION="4321bbc"
-PKG_SHA256="4b485533aa9ea8f5aa9e85f251c272b63f8f6051febf8fb7304cfc9915dddce3"
+PKG_VERSION="51cf8a11def57f7288f5768a9b7ffcff5a88b25f"
+PKG_SHA256="6313f59b9134b4d5985dfceb0ddb6b2d59c7a06a67cb4283ba88d834503511f0"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/nxengine-libretro"
 PKG_URL="https://github.com/libretro/nxengine-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-o2em/package.mk
+++ b/packages/emulation/libretro-o2em/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-o2em"
-PKG_VERSION="8af1aec"
-PKG_SHA256="870f11d9e8a49431315d759f43bb9935a35507562b7492cad38206c1eebea1f1"
+PKG_VERSION="8df6bdddbfc551a47b3f0fed7bb5dfd50d2ce55d"
+PKG_SHA256="de9fc757ac32166bc49c54b684a6294b584e482e282aeedf1ab1b626b9204503"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-o2em"
 PKG_URL="https://github.com/libretro/libretro-o2em/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-picodrive"
-PKG_VERSION="1a49e06"
-PKG_SHA256="3a62c8a43cd66d253a2a9de406b818da9e3d3d363b78d5c29708d1cb99d07348"
+PKG_VERSION="c64747fd2b28fa2c48058678f035a3379838a182"
+PKG_SHA256="f1442132ea417122fc5cc3e9a634201fc486b5adb810a05111f37a29cccc9905"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/picodrive"
 PKG_URL="https://github.com/libretro/picodrive/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-ppsspp/package.mk
+++ b/packages/emulation/libretro-ppsspp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-ppsspp"
-PKG_VERSION="bd678d4f4be7a3aad3d5dc9f0698be97e1baf755"
-PKG_SHA256="fd7af56fc7a7136d635a296e4c7151da4df4259d565b2f4ccf59e57475da8352"
+PKG_VERSION="8883156e457cf072e12814a1403056fdf8ced0bf"
+PKG_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/hrydgard/ppsspp"

--- a/packages/emulation/libretro-prboom/package.mk
+++ b/packages/emulation/libretro-prboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-prboom"
-PKG_VERSION="3ff6c1c30ed4f23e2eba4f13a5a4851d401badbe"
-PKG_SHA256="2f7b7e19dc7b178facd08874632cf148ce6976f43e9cc1788453fbc9df941037"
+PKG_VERSION="b516a666f7a63f421a89de1a819aa738697574d8"
+PKG_SHA256="4fc8ee7f7e9d39f3777aff258e22b10fed229532c8341612bc9fb13d06355222"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-prboom"
 PKG_URL="https://github.com/libretro/libretro-prboom/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-prosystem/package.mk
+++ b/packages/emulation/libretro-prosystem/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-prosystem"
-PKG_VERSION="463dfff97f2e7d707ee5ae238cb2e8e70beb585a"
-PKG_SHA256="65a5331e3ff0e820e6b22ad8bb32b40fec7fed1d54d30b3bdc0b4da759eb7a45"
+PKG_VERSION="247d5f2dccd748495c5310081e6a9c4ff33a377f"
+PKG_SHA256="6eb3e5bd342a0a0b34668e988e9a110e4c6250584823fa04bab4f4cd6486a442"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/prosystem-libretro"
 PKG_URL="https://github.com/libretro/prosystem-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-quicknes/package.mk
+++ b/packages/emulation/libretro-quicknes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-quicknes"
-PKG_VERSION="6d50e29"
-PKG_SHA256="fcc9e87fc0f1192dcadf71c316e383f2400c0d29af0ed2b275aafffc14364cb3"
+PKG_VERSION="264639f12f490db85537a38a06a5df76222cf35a"
+PKG_SHA256="09202bb7a86a238d593f39b7d452bc08b96e9acf209cb31de3240649b2144687"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/QuickNES_Core"
 PKG_URL="https://github.com/libretro/QuickNES_Core/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-reicast/package.mk
+++ b/packages/emulation/libretro-reicast/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-reicast"
-PKG_VERSION="a2d26a57ffe882fb2e35d05842dff9162f654723"
-PKG_SHA256="afb791b674f720110e07ada7cb7af90c5e08d5601a33ac4f4d527fc47db531be"
+PKG_VERSION="c78cc08daa4debd28c4488ec27da0a96548efb12"
+PKG_SHA256="78597f5c5be358dacf646bbe9ffc82c31fa3f908a5e8079f06789cf3335d85f3"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/reicast-emulator"
 PKG_URL="https://github.com/libretro/reicast-emulator/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-scummvm/package.mk
+++ b/packages/emulation/libretro-scummvm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-scummvm"
-PKG_VERSION="0daf2f441c73b0ec0b1562c3483390ade790795c"
-PKG_SHA256="5420a7ad148cc83f898e597f44bb4924ff019cc40add43851782ab5c8c4524cc"
+PKG_VERSION="20d71cd7189ae7fdd453a3041f3103bffabea13e"
+PKG_SHA256="571710ba831604096e1e0c76f764cf8e037adefd72a9b94d302bd51c6e94010d"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/scummvm"
 PKG_URL="https://github.com/libretro/scummvm/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-snes9x/package.mk
+++ b/packages/emulation/libretro-snes9x/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-snes9x"
-PKG_VERSION="249b5cf9765c435177414ff6ca23ea2b6cb4c893"
-PKG_SHA256="fd63a9f119f2b00340fbc610646e7b587b3362022771c54df47da0120211b915"
+PKG_VERSION="d7ebfaa83b042bb703dbe9673c3f63c211cba294"
+PKG_SHA256="da1b1ae608c4e39c91780c13fd19e675cf5f0e0d3492eb1a20d393c9bf108514"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/snes9x"
 PKG_URL="https://github.com/libretro/snes9x/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-snes9x2002/package.mk
+++ b/packages/emulation/libretro-snes9x2002/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-snes9x2002"
-PKG_VERSION="c98e1c3"
+PKG_VERSION="c98e1c3a8414d35aa94ea588d1ca693986a76ca8"
 PKG_SHA256="4b1bfac658941dd955a0fbea6e7fc719f7166ed96747cf3962f63f65ecd9b10f"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"

--- a/packages/emulation/libretro-snes9x2010/package.mk
+++ b/packages/emulation/libretro-snes9x2010/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-snes9x2010"
-PKG_VERSION="21e176e"
-PKG_SHA256="2a478c476edb079bab50cde3f8fbd14c827fc2a4cace89045f50a4bce6b828a8"
+PKG_VERSION="d857a313e3631636d256b27185567e874581d86d"
+PKG_SHA256="b03785e76292562b30098c954c42281bbbcdacd6e8cb8306b84b9ac7d036c0ac"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/snes9x2010"
 PKG_URL="https://github.com/libretro/snes9x2010/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-stella/package.mk
+++ b/packages/emulation/libretro-stella/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-stella"
-PKG_VERSION="b0d525b"
-PKG_SHA256="72f6d611bc51de9da1bd86fb922019d29eb0f30f53386f27e1a404a26736ba1f"
+PKG_VERSION="3ed815409799f0e6ea92a1866a936ef95a741e39"
+PKG_SHA256="e37374d092ed5e01d38fd442ed5d0788ff863c0f4adbd4b4a49bea3c60348145"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/stella-libretro"
 PKG_URL="https://github.com/libretro/stella-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-tgbdual/package.mk
+++ b/packages/emulation/libretro-tgbdual/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-tgbdual"
-PKG_VERSION="fe5c3ff"
-PKG_SHA256="54b0a1e75d715f7f4aa3edb825561b37c975039f312317018e0fe52d726d617e"
+PKG_VERSION="6606b0e039d0ed84323c40786fa168a95b37a711"
+PKG_SHA256="7a010cf3849d950933c119fe22b04e3b3e4469ae3745af836b2281aae8f437cc"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/tgbdual-libretro"
 PKG_URL="https://github.com/libretro/tgbdual-libretro/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-tyrquake/package.mk
+++ b/packages/emulation/libretro-tyrquake/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-tyrquake"
-PKG_VERSION="7d18c405b3713577865d2bbb1a654b1ad0c3cd62"
-PKG_SHA256="cb19180f50b767866d5f1d77de15797dda999400d5175c70cd6c104cea497339"
+PKG_VERSION="83291a112e09c6a613a1bfd85fd44a47949f2d5f"
+PKG_SHA256="0f5586daa142794e43dfa4918b04829188b259c6ac5e75f2f36648d804241424"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/tyrquake"
 PKG_URL="https://github.com/libretro/tyrquake/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-vba-next/package.mk
+++ b/packages/emulation/libretro-vba-next/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vba-next"
-PKG_VERSION="3726a6f85c120aae42c206739d80bebab26405d0"
-PKG_SHA256="8f1cea22028ee765e6880b41892395bcb4bd341b962e0eb1d7faae6022cdfd6f"
+PKG_VERSION="4dd1d210ba5ac98caecdb094ae23ada356915d7f"
+PKG_SHA256="778f2bd1544d702b0dbe77f153342d14262e5a9298bbaa1ba129f95c3e0faab9"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vba-next"
 PKG_URL="https://github.com/libretro/vba-next/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-vbam/package.mk
+++ b/packages/emulation/libretro-vbam/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vbam"
-PKG_VERSION="8041717"
+PKG_VERSION="8041717e1c9993085754b646d3c62ef9422ad652"
 PKG_SHA256="0dc90879651118310d3334400d11de77c4682191df6a73aed5abfec57df0f2c4"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vbam-libretro"

--- a/packages/emulation/libretro-vecx/package.mk
+++ b/packages/emulation/libretro-vecx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vecx"
-PKG_VERSION="7c16fe2eaff5c0538df2ce63467ff7111b49d56b"
-PKG_SHA256="dc0fc726e7b05653b9d1a4a3b5dce667dcdb4358ab7a266fab7cb0cdd3c189b9"
+PKG_VERSION="fb70263e9db9a1f283acecd7d54b1233c4953094"
+PKG_SHA256="7f976bc0ee645ff713533b84b6cf381735dc64e472bb2f4bca1d7172bc5c5f74"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-vecx"
 PKG_URL="https://github.com/libretro/libretro-vecx/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-yabause/package.mk
+++ b/packages/emulation/libretro-yabause/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-yabause"
-PKG_VERSION="fae968218a93d10ca9b811ed47df942f8bec697d"
-PKG_SHA256="b48318d2192d06edc6d4e22c3fa508a625716b31216a34aec74c7d5edc205511"
+PKG_VERSION="aa15301b1d1b49d035d0672a1ccaa5631211b29b"
+PKG_SHA256="268e356c6c3f30a88f8cd3394a48d863d3166cbc060fe7e7eb02be4a93a38f7c"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/yabause"
 PKG_URL="https://github.com/libretro/yabause/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.2048"
-PKG_VERSION="ad9f584"
-PKG_SHA256="e306c4ae68d1118e57bc3973d4d02bd5a5b59f0ab2f8448553b43a44d2c2df47"
-PKG_REV="107"
+PKG_VERSION="8eb35832ec38f3b7680ce89dda31f470b1891920"
+PKG_SHA256="42426a1239381b8cd3b87f7a253587983b1c530ca16af7f4e71292aeeae57984"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.2048"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.4do/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.4do/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.4do"
-PKG_VERSION="4398cc388f945ab3a1a5b1f2cf0655af867d5e7a"
-PKG_SHA256="b47b7600c0ba0ba81a20aae784036f246e77ccb3838e025274218f3f31e201a8"
-PKG_REV="108"
+PKG_VERSION="4747ab9b827cdd271567aadf254b232a88fce62a"
+PKG_SHA256="46686977db2beb8843f59e5b5669c5126bf263110f6e32d7d335b29508fe4002"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.4do"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-bsnes"
-PKG_VERSION="1c7021f"
-PKG_SHA256="d4b69983146ff64e42a5c75f6774611a42d35a81b4f4ccba29c701f19c283439"
-PKG_REV="106"
+PKG_VERSION="fa75af44abb5e13af7402f81fe6ea8c3be4b32da"
+PKG_SHA256="54ee6313fb53f0672e2a0ebc682e82c73c877ca42f538dc273a293d696ccdcfc"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-bsnes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-gba"
-PKG_VERSION="cd5311bcb543232c88ddcd81bb6fe41df9562c15"
-PKG_SHA256="a1bd58cad60fc8252dea5ca37604fadf3ea4966ca7a2c19afcf8d1d8246d9b74"
-PKG_REV="107"
+PKG_VERSION="975806aa8b6ee9bbf25a3d3b2de56aaf096b8efe"
+PKG_SHA256="49f8d436acb797a4aba31c00a30d5dabaa376d40183d961858d4ed5068744df5"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-gba"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-lynx"
-PKG_VERSION="fa7da46"
-PKG_SHA256="4ff4a8f8abd375b4af8188f86ea9a4256e289b9643f77e2631392af585f9db0c"
-PKG_REV="106"
+PKG_VERSION="98f24c72ee30434e4daf4e348435517e908a1d49"
+PKG_SHA256="14031cd060eeceec49f3c4c73a81f82afe29f7bcf899bf8a0cf9a5e6a6e96b35"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-lynx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-ngp"
-PKG_VERSION="5818ba5"
-PKG_SHA256="8c5a8948f2c7162f20eda896d6de73844144357ade36fe9c79c4b85641fe9617"
-PKG_REV="107"
+PKG_VERSION="645876212408999700e346073f1404627231dc7c"
+PKG_SHA256="16d0e104566385e5a8d68e971e26b723c38f0f41ca61639756f798455702fac1"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-ngp"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-pce-fast"
-PKG_VERSION="7e0e1b9"
-PKG_SHA256="a8593456d6283a6a293d64afb413f4d47ca1703fc61391c42d1f03e4af588c41"
-PKG_REV="107"
+PKG_VERSION="843a4cd90b97020c78ff118c42a600556cbd3c10"
+PKG_SHA256="16d1192ef05caf7443afa4ec4758c34c55f57700d7d0b2c9c1d02e72c401da0f"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-pce-fast"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-pcfx"
-PKG_VERSION="a78422d"
-PKG_SHA256="b03a7a36da512cb2b6fd89951b1be05f6ec241f893b7ee73ab153f3698e4fcde"
-PKG_REV="107"
+PKG_VERSION="148362a965f5821f6c67683c4d05b46d6377178e"
+PKG_SHA256="5094dc0c4fcf6ee8f93cb6f05171eb714c1b9390f273e9cc2a31eb30ece9b9cc"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-pcfx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-psx"
-PKG_VERSION="ee4270fde54c2207094426ac902eb3352c9b0d6f"
-PKG_SHA256="a74ac441751f027a5460b74dc4bcc8ec093fda4f39cf6bbd03ba529c2c3edb50"
-PKG_REV="107"
+PKG_VERSION="76e4f7302a4709af2122c021a5daebd2f2090f6c"
+PKG_SHA256="88f75ab022477e321fa5c4ea7d6ded9b5ce1b8d2391b97ec0addd4776f11d5a2"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-psx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-saturn"
-PKG_VERSION="62a1d61"
-PKG_SHA256="0c8bf56b97024d6f17b0f70f0097dbab53657baa0e38391d415c1fa8bb1f1d63"
-PKG_REV="107"
+PKG_VERSION="d08474202ab76353edb3e0b6d237db583dc6160a"
+PKG_SHA256="c24168e6390b2d91f73302ab90930572016db04640029e20fca1e12fa2b31420"
+PKG_REV="108"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-supergrafx"
-PKG_VERSION="f8f219e"
-PKG_SHA256="4a2004289947b685f6571dd319b55ec46e098327757b9d62c47bdc5b37a95c0d"
-PKG_REV="106"
+PKG_VERSION="35cb141c4e24d571aea3dd6565b5b366ed8c2b07"
+PKG_SHA256="074a908e6e618b78fa0105db057693161eb711150c8f0442b0195943edaf7a89"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-supergrafx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-vb"
-PKG_VERSION="307b9c2"
-PKG_SHA256="cf4e002fcea1b662018171fde277db3318f8567ccf337d763411ad75bddd42d1"
-PKG_REV="107"
+PKG_VERSION="71d579c19e4eb0909b4bbc1951ef3f37575e2e8d"
+PKG_SHA256="fe516650b603ed987e0a95a457e3ed8b872adfafbee263d6685f67d34cd05717"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-vb"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-wswan"
-PKG_VERSION="c786733"
-PKG_SHA256="a19b457270096bc272a6e10a1db3691521fa8f5758457b70de0c440ea775d10f"
-PKG_REV="107"
+PKG_VERSION="de61bf87dfb5ae972f23d4ac28b403affe468e61"
+PKG_SHA256="51aa16db63a16cde65a7597a1aa947c0a66c0d1f441ea42f93880325fe92079e"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-wswan"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bluemsx"
-PKG_VERSION="ab8c0ea"
-PKG_SHA256="0bf9e58c38e8d4399964a1d43e039aaef45cd6db13bb1d95f1d6a1d2f419219b"
-PKG_REV="107"
+PKG_VERSION="3bb299434f74bb67fc8bbabb200b9dad355fc6f7"
+PKG_SHA256="875c334ed7e16dc9965423119d5034fd5ae37fb818c357fc9a568eb1e2e515f0"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bluemsx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bnes"
-PKG_VERSION="32fc7c1"
-PKG_SHA256="e99e8147a76ffbe2b060c3b06185ec201dec024713d4bbce3635ec215508de74"
-PKG_REV="106"
+PKG_VERSION="2d54b6bad7e4b57db69d3ba3a0a47c13c2503fd6"
+PKG_SHA256="b186c70bd4460063cfc8d5870b3bdfb6cf0b9132b96f01e8c87e4b0536a9b501"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bnes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-accuracy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-accuracy/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes-mercury-accuracy"
-PKG_VERSION="8c75ec3"
-PKG_SHA256="61f570ccea8a30f8a853384729c3fe3038f49a3f55e06b873e9a11d48ace78ca"
-PKG_REV="107"
+PKG_VERSION="fef35217c5c145ce34a75db8e908e6a16330f1e7"
+PKG_SHA256="b0d2ee9f4f066ec25b37a801564e32852c3148d1f5c80c6039e0fc11ffece0af"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-accuracy"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-balanced/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-balanced/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes-mercury-balanced"
-PKG_VERSION="eda2575"
-PKG_SHA256="64ec6a816c44beb8da30641d90d4775be60df73209a7b5023071c69f33d8ba80"
-PKG_REV="107"
+PKG_VERSION="101b4d4c0719c66a96e278d4921a9c685e051914"
+PKG_SHA256="2711227e5229885697017cd4d8480b54f108b83d390d39709d5a7ec4d8b91355"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-balanced"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes-mercury-performance"
-PKG_VERSION="5b19c24"
-PKG_SHA256="aa569a6f32631f9c7f2fd09c2fe9bde0ddb81e47e9557c6f62b9621eda99f28b"
-PKG_REV="107"
+PKG_VERSION="c8fdaf105aadf761d7bbc9cd1bf8dde38d3e1720"
+PKG_SHA256="b15bbce6ab93263c0a04b5bb39941b7b71ef0fdc8189b291d15b37392d9bd628"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-performance"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.cap32"
-PKG_VERSION="e820c0f873242d4cd6f9327d461ff6150adfd832"
-PKG_SHA256="5fbf139f951137db69021b6966d60cd129fdcea2443852cabbd123937298b7af"
-PKG_REV="107"
+PKG_VERSION="3046a34b441da0590f0689614aafc0789bf8e507"
+PKG_SHA256="b185963b0564acbc71ce8c9b22cfe8f9ddc9c2ab205bbb4629915208d8a0fe53"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.cap32"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.desmume/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.desmume/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.desmume"
-PKG_VERSION="8aedfec"
-PKG_SHA256="684daac7d15c7ab96ab52a62ba9c55c316a8737ced7314c76ac317529d5dd428"
-PKG_REV="106"
+PKG_VERSION="3c06f90739c32da61107b58e89bab9ad6399a729"
+PKG_SHA256="82fc4e9e342627121f6a7da7f56ec1c4c52d33b9fbb54faaee19b76a873c0f38"
+PKG_REV="107"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dinothawr"
-PKG_VERSION="8fe1780"
-PKG_SHA256="f5b520ffbf7afa07c28c2348147425cd4232b1f71cb510810cc23e07c95d4fa4"
-PKG_REV="106"
+PKG_VERSION="395da917bbf0d784d2a6ed090a89dd36d729f4e9"
+PKG_SHA256="d623894f4272ad1cff6cc7cccf41cd96a5a4fe0b3d66d70dc6cd928b4c54aae5"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.dinothawr"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dolphin/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dolphin/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dolphin"
-PKG_VERSION="f73b307"
+PKG_VERSION="f73b3073e3368bf6a75a2a286d79a66538d12679"
 PKG_SHA256="039cfecbfe67c24e87708008f811538b7d4502aa2171379570ee2632a33effe6"
-PKG_REV="105"
+PKG_REV="106"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dosbox"
-PKG_VERSION="5f5a58556de46e225757b2596e130228f2688fe8"
-PKG_SHA256="2c338d108dd8c54cbaa084d0a40e147bb0687e47ea520cc2540cd5fc091bb538"
-PKG_REV="108"
+PKG_VERSION="d0ec051c49dc00f47e5abef455579b1441a773a2"
+PKG_SHA256="efd51a35ed5c5c5276dfa2a21057bebbafe52adcb694916c5589c1cfa580e7ab"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.dosbox"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fbalpha/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fbalpha/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fbalpha"
-PKG_VERSION="24a3c7f"
-PKG_SHA256="0992248694e382e3a9366c44059182ef5e17e8fa90233e699e448077085e0d1a"
-PKG_REV="107"
+PKG_VERSION="80a1f9f0f1b95722ea5fc00db7b4b9bb73adb204"
+PKG_SHA256="bad45747199bac068295eef637aaa3946eb0465a85b21d51657a9ee84a646757"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fbalpha"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fceumm"
-PKG_VERSION="2f58851"
-PKG_SHA256="b15ab71d212fdb6431ae0c2bd8374616ecae8b3b52cf70bcf1ccd26c0659d988"
-PKG_REV="107"
+PKG_VERSION="085a5b65b2eaee28ffc6589a5dd5665f37cf8e19"
+PKG_SHA256="c7b281a6f10f1bd7f441d7b71a3a9bb8883ea82a6d9271958205d9973639b2c3"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fceumm"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fmsx"
-PKG_VERSION="9c1d33b"
-PKG_SHA256="9955c5f19d420d352d76e6acd810bdcb6e2b43087cbaf8bf97ca8035ccf54ee5"
-PKG_REV="107"
+PKG_VERSION="2c9de17d14e7d4031f782c634362f9662c51678d"
+PKG_SHA256="1dcec7d2b75c6e01e56a65162d079c61f99fda092888577bd9facbc40d2dc3e4"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fmsx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fuse"
-PKG_VERSION="393794d"
-PKG_SHA256="05be01cfef296a8b2b7859ed7fd04f781770930005bbc23eea50c17f446ba7fc"
-PKG_REV="107"
+PKG_VERSION="636724b0bfb2ffb349296f549e668a9029079f8f"
+PKG_SHA256="1de7dee5ce896c68a0382d6582a40202211c2e8844b3ede82133d805a4e2355b"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fuse"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.gambatte"
-PKG_VERSION="029ba12"
-PKG_SHA256="0ffff2d60cb64c4689a11098309269bf29fd5acd070e050c06fa1a77726023ff"
-PKG_REV="107"
+PKG_VERSION="00b8f4bc3707043db9872aa69dec920bf58538d3"
+PKG_SHA256="08b303d038ed844996062c6188e8dda137d822ec2e5187e55b1acbbee361f1da"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.gambatte"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.genplus"
-PKG_VERSION="67c9c43f3e6327b61efdeba0b51701750dd70cc5"
-PKG_SHA256="38794b49c049bd35ef5138cb74c9e74862580a7aff16ab530dde930fbe09ae78"
-PKG_REV="107"
+PKG_VERSION="4274b145e294dec0be6c70922cb87b745a1211c1"
+PKG_SHA256="a85cb04e2512fa6b22faf8a30c3d66672c5f7be8399074d0ebadb587ed4fb889"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.genplus"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.gw"
-PKG_VERSION="06a3500"
-PKG_SHA256="c2826c5968462ccbc1631dffd134daae71cfea4875cb8ff2042d64bc2aa71374"
-PKG_REV="106"
+PKG_VERSION="48ee862c24dd32182ed680d22bdc6120e29a073f"
+PKG_SHA256="e632100edd192b6054cb303a23b0221ad63c523cd1e90fac382b73c8a2d42ee8"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.gw"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.handy"
-PKG_VERSION="b1eb04b"
-PKG_SHA256="c1ea0c1f27d982bb47af32be41b7463e98502aa11291f29218da5dbb580c7b9a"
-PKG_REV="106"
+PKG_VERSION="619d4ded8eef961fe64e189438973a6a7fc44d35"
+PKG_SHA256="3c758c15a4f6008965b676588b0aeeae4a009cb8400f4d457cfdf7ffea71fa20"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.handy"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.hatari"
-PKG_VERSION="1d2ddba95f07e6c25f11d33f7f1417dc43a9ff81"
-PKG_SHA256="9555d16b8220510729db8b77c52933322d77b3bed5e17ebb8cfa99a4164c01dd"
-PKG_REV="107"
+PKG_VERSION="46bf0448ef1e61eb45bc7bdd3aca264f0c00737d"
+PKG_SHA256="177958c5838938be08a3747ae8116825ee71fa949f32993df0f37b2c9bd72d5c"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.hatari"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mame"
-PKG_VERSION="c6f51cb"
-PKG_SHA256="516cafcd8c3d07bc5482f42d1da57fa8aa26dc94c795594a52f79d6fe2b9d9c1"
-PKG_REV="105"
+PKG_VERSION="88d35d5d1bb6018b7bfab8c6097f9277f85bdca5"
+PKG_SHA256="8a674153af1f8f867c5e9407e350d39cc148ca90b41bc08a9b72a58f4a471fd9"
+PKG_REV="106"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.meteor/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.meteor/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.meteor"
-PKG_VERSION="b50abb1"
-PKG_SHA256="b75fc715b2211c5620c2cd3a682ecca3a1eca8fe512a068e21ee910079a58399"
-PKG_REV="105"
+PKG_VERSION="dbffa98b064d709c06d7709ee7b71f46e53639ab"
+PKG_SHA256="aca2769e051cfd59621a5b6c21a8055eb666ff185c8a10d20f4fdac0b0cd57ae"
+PKG_REV="106"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.meteor"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mgba"
-PKG_VERSION="22d20f3"
-PKG_SHA256="e83cd7b3fd1706f136a025e18a0b15192e738e994f5eec20b953996f1c9f6845"
-PKG_REV="106"
+PKG_VERSION="0dba5c5646963c2f7d5cda04964b723eeee4a0c0"
+PKG_SHA256="8f1248b16dc7ccbd610e885d9649b84d341045555648aea887e24ab019989ec4"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mgba"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mrboom"
-PKG_VERSION="56e28ff"
-PKG_SHA256="ce8d6462232f15bb0638f060ae24febe81ad0f85f9aa77737b1b6bd312c5c275"
-PKG_REV="106"
+PKG_VERSION="18fed851e032989bc2b61d0a99af636bec96d21f"
+PKG_SHA256="233af85baa5d34004de77cc7bf6a427beeee0678e8ac79beffe508edbdb8cf38"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mrboom"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mupen64plus"
-PKG_VERSION="011865ad2ad79bfa10844f435230d24855076f4a"
-PKG_SHA256="f749bcfd7fadd0fad5e88331c79cca0bdb1f8108acce6292963bed345437a3a1"
-PKG_REV="107"
+PKG_VERSION="cde9e49acf0adfc6783b5bcf76ca75e5e5ca139e"
+PKG_SHA256="0b047e6fe8ce97c5c34853dcee69f43e02799350cdf24e1daa482d08088c835d"
+PKG_REV="108"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.nestopia"
-PKG_VERSION="fce68cc"
-PKG_SHA256="41d612482e8f01e5cad624b22fa7ab0aa0afa1279590aa7c4f4bea26b7ded414"
-PKG_REV="107"
+PKG_VERSION="c9d16ce10ef5b81ddea2cffd3430c8b3128c9f3e"
+PKG_SHA256="087bdf46ea16b6814911601ccf21285d1ed97c14b51b010855a4731adf2b136e"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.nestopia"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.nx"
-PKG_VERSION="a484d9a"
-PKG_SHA256="3bd6cb26a947dbf52d27a502edf32062b849a767eb9a13a22a50311d3283201c"
-PKG_REV="106"
+PKG_VERSION="a4470d73d828f394e47bba909f2e11d4ca12f4a7"
+PKG_SHA256="af5eddcaae5aea0b10c616ebb6f4baa76211b95121e44f9bf8a915c15b7cb1ad"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.nx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.o2em"
-PKG_VERSION="985d342"
-PKG_SHA256="8878505cc6b682cbd9fb608a60217e5ef158b5bced623a50678a9a04f0138b52"
-PKG_REV="106"
+PKG_VERSION="b6abe559630579cf400f0623fdc90c0c1829be79"
+PKG_SHA256="fbac67666131740a8a71d85ebd8ac683e059661855762c88f88c3fc8da06c583"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.o2em"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.pcsx-rearmed"
-PKG_VERSION="75208998eb366f70624d427d14353662b07990a2"
-PKG_SHA256="5d99e36d62f1016ebff01a6877a48aa8b01a9c0b88f5c5dd67c0dd710d5ff352"
-PKG_REV="108"
+PKG_VERSION="c0aee9b5622cc6e629f9ae966c283d17b40587b1"
+PKG_SHA256="9a624c7c7f8acd8578fc77af754a492b0cdd0e79ff1ee0d54ebed20fd5cc5649"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.pcsx-rearmed"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.picodrive"
-PKG_VERSION="48db908"
-PKG_SHA256="edb5d0db5eaddb693a271db99dbe1732083188849b278aabc6ef29d6f1a660c2"
-PKG_REV="106"
+PKG_VERSION="89a9b818c948073deaa3ce30521aded8e7248360"
+PKG_SHA256="76e1342967d08cc8dcf3bb0d08b1742581fb7d5ad18141912c18102f09eb651a"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.picodrive"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.ppsspp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.ppsspp/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.ppsspp"
-PKG_VERSION="d24a963"
+PKG_VERSION="d24a9638f02a67d5b16097dbbb15013f8b645440"
 PKG_SHA256="2634b9c6f47bd32afcc2beb3f53b03b3ca3fb8d1391b502396ff24862aafca27"
-PKG_REV="106"
+PKG_REV="107"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.prboom"
-PKG_VERSION="d2df449bd237c59f8f95bc4ebee88d7780483fb8"
-PKG_SHA256="e68f7fb6618cdda7da6a27f3924fb94c21b998290374efef8cedd6c58d2fdd52"
-PKG_REV="107"
+PKG_VERSION="4556522b05d6cc0d9e2695d468ab32e0a697233e"
+PKG_SHA256="dcf0d9a7c06be9dd46e0c931fe80b50bc7cdcdd98a7bdc0331cbe663049d25f8"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.prboom"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.prosystem"
-PKG_VERSION="13c20e8"
-PKG_SHA256="956004c1f2998bec94f91e04e77e3af6627d0dd3285e27aefeeb5527ac69fcbb"
-PKG_REV="108"
+PKG_VERSION="647410dc7d95a994b7947e49a3f41934989f3107"
+PKG_SHA256="0a0c229c40981f125a9286070b4eb7793c7dd147118b6a4ab2bab5572c3c676f"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.prosystem"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.quicknes"
-PKG_VERSION="e13ec66"
-PKG_SHA256="f37cb48087bc6e0e24dfb883caea04b1f34fb98a55a1cbcdab263540b5b90a75"
-PKG_REV="106"
+PKG_VERSION="dffadbc5fc3663c5c480047ffdb234dc12dc1499"
+PKG_SHA256="671648b1cb15b8348e83635a71bbde3c503eb7321df45a0632c3d41e9fceb550"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.quicknes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.reicast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.reicast/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.reicast"
-PKG_VERSION="c7a799553f39e5602ae1f6a4f64934bcde6f72be"
-PKG_SHA256="41a5748442f1c46faff9d85850062073322cb216ec9165fd7113f4618d84c05a"
-PKG_REV="108"
+PKG_VERSION="b9def2125ff37a142f720b8ab8520427686d96a4"
+PKG_SHA256="7b65a25cc19f47a75bb77fc7598e2b13a378055baee72afc93ecbb6a04ae7b81"
+PKG_REV="109"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.scummvm"
-PKG_VERSION="f4be287"
-PKG_SHA256="5c960d9814df97201056c61f61af096a0a2bb646c16e0c254a5048f961e2f54b"
-PKG_REV="107"
+PKG_VERSION="9f0e8b7051fe85ccc12de90c8b13ed4c797fd710"
+PKG_SHA256="7bb38fb75575202d4a9e85b437cca386086103547349ea06d7459a7ac8f58f40"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.scummvm"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.snes9x"
-PKG_VERSION="afc910ac7e2ad26c76a374468f7581f5a72769aa"
-PKG_SHA256="9f04cdb0e10ab9be2316d79be6759f6c416d4a07e1cb52965015aaa31ff057b4"
-PKG_REV="107"
+PKG_VERSION="8ba4a5de7272ef784d1aafc37615559fa2a8cf7a"
+PKG_SHA256="8d10676a5b156513e218af635b7421aa37816f811a132b445eb518d37c105b4b"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.snes9x"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2002/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2002/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.snes9x2002"
-PKG_VERSION="9bc3e70"
-PKG_SHA256="5a8207c26a8edd9e53d98e16058d0c56ae3875e4fd9d7c43b375ef099f937391"
-PKG_REV="105"
+PKG_VERSION="f5746ec0b0cf71a0fd93231b3ffb4d0f91d5a049"
+PKG_SHA256="590406bd4cc111393c63d2cc0635c0ecd2313c98f397391a96cd1c099729609e"
+PKG_REV="106"
 # neon optimizations make it only useful for arm
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2010/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2010/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.snes9x2010"
-PKG_VERSION="534efff"
-PKG_SHA256="748704f251e28f45489718a6fc68b7c76d9766c56e1ee9ae3c15d98796a2797c"
-PKG_REV="106"
+PKG_VERSION="0f905a65dc0cfd5d54f287756dd99718fd3aa1e1"
+PKG_SHA256="e30404150bc03553102a1bd732bf5f95302a50d3f74d4aa399c3ea23ea094005"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.snes9x2010"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.stella"
-PKG_VERSION="0817513"
-PKG_SHA256="c8517a82a4a824952ed74014c6a4faafc2cc6ec6f1876073129c806e2bb23319"
-PKG_REV="106"
+PKG_VERSION="16daa7b28b1ef0498c1f7db71cd307935951f9a9"
+PKG_SHA256="7c0d9546f3e55e0690459b5d47640c3cf618efe7cd064ca1e37a7846757c2982"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.stella"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.tgbdual"
-PKG_VERSION="4c5bccf"
-PKG_SHA256="713574e66d0e90dcc7f8ae59dd8ae7297ce1816b3c2191ae0a8ed4e16d3e5fa6"
-PKG_REV="106"
+PKG_VERSION="89616f6ca2bc9eb2b257f2acd24c40dcda9da595"
+PKG_SHA256="b24c0d41f3fde94ba936cbf56a74adb38c7e613fb1154b79a9456a29535afa74"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.tgbdual"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.tyrquake"
-PKG_VERSION="8fe7f682472c98532036965812b5d0e0b77b6b55"
-PKG_SHA256="9f358c75553984be63657ce7bdad25689947b71dd2db5a4990540920412f0d5f"
-PKG_REV="107"
+PKG_VERSION="3119e4f5c4fed210a9e91adb2a5aefbd57cd0c64"
+PKG_SHA256="f5dc51e67e0b3a89c1056cd424583d1b04531255b5ae75e796da6399217e9b10"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.tyrquake"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vba-next/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vba-next/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vba-next"
-PKG_VERSION="432b0da"
-PKG_SHA256="fac1ab35da8a57bae6e929758d8e55c1de8f09607bce7d41fe7df0fcdd6a5334"
-PKG_REV="107"
+PKG_VERSION="748c69cd7475a4ca10d9de23e333aeeafc544da5"
+PKG_SHA256="814cc3b795a5908db9b95b4202cb8d8183da6a77b8d345404b8b95def8073263"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vba-next"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vbam"
-PKG_VERSION="38e6675"
-PKG_SHA256="e48f52312c10afe959d4c454427de9a3d2488c8356c480a0e8a41666f7dcfc16"
-PKG_REV="106"
+PKG_VERSION="27448415083d9fb4095262999486d508a41e6aea"
+PKG_SHA256="8e646d9615414e78d2b161c6603df86aea358ab6307b066b2faff0716e3256bc"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vbam"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vecx"
-PKG_VERSION="0655f94"
-PKG_SHA256="32c65d25d30eb05ba7bc684b342b8edfedf489fe36dfd2cafb0282eae9fc65bc"
-PKG_REV="107"
+PKG_VERSION="a6844c2c120f6012ed1f653634a87c0162da9534"
+PKG_SHA256="4a6706652a4ab05d815293162448b09b6eab895b2df963b527447f9d71ae9f4d"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vecx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.virtualjaguar"
-PKG_VERSION="b3e709c"
-PKG_SHA256="4ff30d8e5dc402df50d469a2473064fd7993d55a8773ace9afd5f3e03a83cb0d"
-PKG_REV="107"
+PKG_VERSION="543924c7dd0a64164e27a92f97a5eb2bd9e1d145"
+PKG_SHA256="81e3e568e38d3ca2d82aa439360711144d075f53a66c095e6cd15714c1c7deaf"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.virtualjaguar"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.yabause"
-PKG_VERSION="fd5aed6"
-PKG_SHA256="e156196b0978c624df08d71bbfc0297e29a2f06f03b2e55cc890e6c96a0778a6"
-PKG_REV="107"
+PKG_VERSION="24209107c3e76ff3a79ebfded1032c44135c4d77"
+PKG_SHA256="c7718973b4f160fa78e2518e8108f9d455ffd3b82a2700007d855b42af7bd7d5"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.yabause"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro"
-PKG_VERSION="15db97a0c1e2921396298f05481f66df5c2d9bb5"
-PKG_SHA256="5bb52c2a4651e002b2f68d8328e750b28e41d2a749e97e2560b89238506e54df"
-PKG_REV="109"
+PKG_VERSION="af15fa7327017edd12c96af5c76ab7ddb5bd02f5"
+PKG_SHA256="5057f5a3f624457e45b1675005c1f71f29bbcc1f72acb03d5b85736f9ea98d7b"
+PKG_REV="110"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro"

--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -28,13 +28,6 @@ git_clone() {
   fi
 }
 
-resolve_hash() {
-  if [ -d "$1" ] ; then
-    cd "$1"
-    git rev-parse --short $2 2>/dev/null
-  fi
-}
-
 get_pkg_var() {
   local pkg_name="$1" pkg_var="$2"
   cd ${ROOT}
@@ -60,7 +53,7 @@ update_pkg() {
 }
 
 # addons
-for addontxt in "binary-addons https://github.com/lrusak/repo-binary-addons.git retroplayer" ; do
+for addontxt in "binary-addons https://github.com/kodi-game/repo-binary-addons.git retroplayer" ; do
   ADDONS=$(echo $addontxt | awk '{print $1}')
   ADDONREPO=$(echo $addontxt | awk '{print $2}')
   GIT_HASH=$(echo $addontxt | awk '{print $3}')
@@ -70,12 +63,11 @@ for addontxt in "binary-addons https://github.com/lrusak/repo-binary-addons.git 
     for addon in $ADDONS.git/*.*/ ; do
       if [ -n "$(echo $addon | grep game.)" -o -n "$(echo $addon | grep peripheral.)" ]; then
         ADDON=$(basename $addon)
-        REPO=$(cat $addon/$ADDON.txt | awk '{print $2}')
-        GIT_HASH=$(cat $addon/$ADDON.txt | awk '{print $3}')
+        GIT_BRANCH=$(cat $addon/$ADDON.txt | awk '{print $3}')
         EMULATOR="libretro-${ADDON##*.}"
         BUMP_REV=""
         OLD_HASH=""
-        RESOLVED_HASH=""
+        GIT_HASH=""
 
         if ! grep -q all $addon/platforms.txt && ! grep -q linux $addon/platforms.txt && ! grep -q ! $addon/platforms.txt; then
           continue
@@ -88,16 +80,17 @@ for addontxt in "binary-addons https://github.com/lrusak/repo-binary-addons.git 
         if [ -f ${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON/package.mk ]; then
 
           OLD_HASH=$(get_pkg_var "${ADDON}" PKG_VERSION)
-          git_clone $REPO master $ADDON.git $GIT_HASH
+          PKG_SITE=$(get_pkg_var "${ADDON}" PKG_SITE)
+          GIT_HASH=$(git ls-remote $PKG_SITE $GIT_BRANCH | awk '{print $1}')
 
-          RESOLVED_HASH=$(resolve_hash $ADDON.git $GIT_HASH)
-          if [ "$OLD_HASH" != "$RESOLVED_HASH" ]; then
-            update_pkg ${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON/package.mk ${ADDON} ${RESOLVED_HASH}
+          if [ "$OLD_HASH" != "$GIT_HASH" -a -n "$GIT_HASH" ]; then
+            update_pkg ${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON/package.mk ${ADDON} ${GIT_HASH}
 
             BUMP_REV=true
 
+            echo "UPDATING: $ADDON"
             echo "OLD_HASH: $OLD_HASH"
-            echo "NEW_HASH: $RESOLVED_HASH"
+            echo "NEW_HASH: $GIT_HASH"
             echo ""
 
           fi
@@ -111,15 +104,16 @@ for addontxt in "binary-addons https://github.com/lrusak/repo-binary-addons.git 
 
           OLD_HASH=$(get_pkg_var "${EMULATOR}" PKG_VERSION)
           PKG_SITE=$(get_pkg_var "${EMULATOR}" PKG_SITE)
-          git_clone $PKG_SITE master $EMULATOR.git
+          GIT_HASH=$(git ls-remote $PKG_SITE master | awk '{print $1}')
 
-          RESOLVED_HASH=$(resolve_hash $EMULATOR.git master)
-          if [ "$OLD_HASH" != "$RESOLVED_HASH" ]; then
-            update_pkg ${ROOT}/packages/emulation/$EMULATOR/package.mk ${EMULATOR} ${RESOLVED_HASH}
+          if [ "$OLD_HASH" != "$GIT_HASH" -a -n "$GIT_HASH" ]; then
+            update_pkg ${ROOT}/packages/emulation/$EMULATOR/package.mk ${EMULATOR} ${GIT_HASH}
+
             BUMP_REV=true
 
+            echo "UPDATING: $EMULATOR"
             echo "OLD_HASH: $OLD_HASH"
-            echo "NEW_HASH: $RESOLVED_HASH"
+            echo "NEW_HASH: $GIT_HASH"
             echo ""
 
           fi


### PR DESCRIPTION
* fixed tools/mkpkg/update_retroplayer-addons so that it generates full githashes
* ran fixed tools/mkpkg/update_retroplayer-addons to update all retroplayer addons

only game.libretro was build-tested (RPi2 build was fine)