### PR TITLE
bluez: default enable bluetooth services

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -56,9 +56,13 @@ post_makeinstall_target() {
     sed -i $INSTALL/etc/bluetooth/main.conf \
         -e "s|^#\[Policy\]|\[Policy\]|g" \
         -e "s|^#AutoEnable.*|AutoEnable=true|g"
+
+  mkdir -p $INSTALL/usr/share/services
+    cp -P $PKG_DIR/default.d/*.conf $INSTALL/usr/share/services
 }
 
 post_install() {
+  enable_service bluetooth-defaults.service
   enable_service bluetooth.service
   enable_service obex.service
 }

--- a/packages/network/bluez/system.d/bluetooth-defaults.service
+++ b/packages/network/bluez/system.d/bluetooth-defaults.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Bluetooth defaults
+After=local-fs.target
+
+ConditionPathExists=!/storage/.cache/services/bluez.conf
+ConditionPathExists=!/storage/.cache/services/bluez.disabled
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'cp /usr/share/services/bluez.conf /storage/.cache/services/'
+RemainAfterExit=yes

--- a/packages/network/bluez/system.d/bluetooth.service
+++ b/packages/network/bluez/system.d/bluetooth.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Bluetooth service
-Requires=bluetooth.target
+After=syslog.target bluetooth-defaults.service
+Requires=bluetooth-defaults.service
 
 ConditionPathExists=/storage/.cache/services/bluez.conf
 


### PR DESCRIPTION
I've had this in my Amlogic image for some time. It defaults the BT service to enabled so that users do not have to search/find and enable it manually before trying to pair devices. If there is no BT hardware present the Bluetooth connections page shows "no hardware" instead of "service disabled" so IMHO there is no real-world impact.