### PR TITLE
RFC: initial coding standards

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -6,6 +6,7 @@
 * Avoid backticks. Use `$()` instead
 * String comparison: use `=` not `==`
 * Numeric comparison: use `-eq` not `=` etc.
+* Use `[ test 1 -o test2 ]/[ test1 -a test2 ]` rather than `[[ test1 ]] || [[ test2 ]]`/`[[ test1 ]] && [[ test2 ]]` etc. See [test constructs](https://www.tldp.org/LDP/abs/html/testconstructs.html)
 * Shell variables do not use braces ie. use `$FOO` unless braces are required (string substitution etc.)
 * Use double-quotes (") around variables (or sequences that include variables) when possible to avoid issues with special characters, eg. `cd "$PKG_DIR/scripts"`. See [quoting variables](https://www.tldp.org/LDP/abs/html/quotingvar.html)
 * Use `. config/blah` to source a file, don't use `source config/blah`

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -5,6 +5,7 @@
 * All LibreELEC build system scripts are bash scripts (`/bin/bash`)
 * Avoid backticks. Use `$()` instead
 * Shell variables do not use braces ie. `${FOO}` unless required (string substitution etc.)
+* Use double-quotes (") around variables (or sequences that include variables) when possible to avoid issues with special characters, eg. `cd "$PKG_DIR/scripts"`. See [quoting variables](https://www.tldp.org/LDP/abs/html/quotingvar.html)
 * Use `. config/blah` to source a file, don't use `source config/blah`
 * To be efficient, avoid forking child processes (`sed`, `cut`, etc.) when a shell built-in can be used instead
 * Avoid long lines (> 90 columns) unless it aids maintainability/processing (eg. `LINUX_DEPENDS`, `PKG_DEPENDS_TARGET` etc.)

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -7,7 +7,7 @@
 * String comparison: use `=` not `==`
 * Numeric comparison: use `-eq` not `=` etc.
 * Use `[ test 1 -o test2 ]/[ test1 -a test2 ]` rather than `[[ test1 ]] || [[ test2 ]]`/`[[ test1 ]] && [[ test2 ]]` etc. See [test constructs](https://www.tldp.org/LDP/abs/html/testconstructs.html)
-* Shell variables do not use braces ie. use `$FOO` unless braces are required (string substitution etc.)
+* Shell variables should use braces ie. use `${FOO}` not `$FOO`
 * Use double-quotes (") around variables (or sequences that include variables) when possible to avoid issues with special characters, eg. `cd "$PKG_DIR/scripts"`. See [quoting variables](https://www.tldp.org/LDP/abs/html/quotingvar.html)
 * Use `. config/blah` to source a file, don't use `source config/blah`
 * To be efficient, avoid forking child processes (`sed`, `cut`, etc.) when a shell built-in can be used instead

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,0 +1,27 @@
+## Project Coding Standards
+
+### Build system scripts and config:
+
+* All LibreELEC build system scripts are bash scripts (`/bin/bash`)
+* Avoid backticks. Use `$()` instead
+* Shell variables do not use braces ie. `${FOO}` unless required (string substitution etc.)
+* Use `. config/blah` to source a file, don't use `source config/blah`
+* To be efficient, avoid forking child processes (`sed`, `cut`, etc.) when a shell built-in can be used instead
+* Avoid long lines (> 90 columns) unless it aids maintainability/processing (eg. `LINUX_DEPENDS`, `PKG_DEPENDS_TARGET` etc.)
+* Indent using 2 spaces within comments:
+```
+# include helper functions
+  . config/functions
+
+# include versioning
+  . config/version
+```
+
+### Within `package.mk`:
+
+* Prefix package specific variables with `PKG_` as they are automatically unset before `package.mk` is sourced
+* When creating a directory, related lines are indented:
+```
+  cd $INSTALL/blah
+    cp -P foo $INSTALL/blah
+```

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -19,6 +19,7 @@
 
 ### Within `package.mk`:
 
+* When using git revisions, the full 40-char revision is to be used
 * Prefix package specific variables with `PKG_` as they are automatically unset before `package.mk` is sourced
 * When creating a directory, related lines are indented:
 ```

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -31,3 +31,5 @@
   cd $INSTALL/blah
     cp -P foo $INSTALL/blah
 ```
+* The use of `foo && bar` is allowed, but care should be taken so that package functions do not unintentionally exit with a non-zero exit code in which case `foo && bar || true` may be required, or alternatively use the multi-line `if foo then; bar fi` pattern in place of `foo && bar`
+

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -4,7 +4,9 @@
 
 * All LibreELEC build system scripts are bash scripts (`/bin/bash`)
 * Avoid backticks. Use `$()` instead
-* Shell variables do not use braces ie. `${FOO}` unless required (string substitution etc.)
+* String comparison: use `=` not `==`
+* Numeric comparison: use `-eq` not `=` etc.
+* Shell variables do not use braces ie. use `$FOO` unless braces are required (string substitution etc.)
 * Use double-quotes (") around variables (or sequences that include variables) when possible to avoid issues with special characters, eg. `cd "$PKG_DIR/scripts"`. See [quoting variables](https://www.tldp.org/LDP/abs/html/quotingvar.html)
 * Use `. config/blah` to source a file, don't use `source config/blah`
 * To be efficient, avoid forking child processes (`sed`, `cut`, etc.) when a shell built-in can be used instead

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -19,6 +19,7 @@
 
 ### Within `package.mk`:
 
+* See [packages/readme.md](packages/readme.md) for more detailed package structure information
 * When using git revisions, the full 40-char revision is to be used
 * Prefix package specific variables with `PKG_` as they are automatically unset before `package.mk` is sourced
 * When creating a directory, related lines are indented:

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -6,7 +6,7 @@
 * Avoid backticks. Use `$()` instead
 * String comparison: use `=` not `==`
 * Numeric comparison: use `-eq` not `=` etc.
-* Use `[ test 1 -o test2 ]/[ test1 -a test2 ]` rather than `[[ test1 ]] || [[ test2 ]]`/`[[ test1 ]] && [[ test2 ]]` etc. See [test constructs](https://www.tldp.org/LDP/abs/html/testconstructs.html)
+* For tests, `[ expr1 -o expr2 ]/[ expr1 -a expr2 ]` is preferred to the extended form `[[ expr1 ]] || [[ expr2 ]]`/`[[ expr1 ]] && [[ expr2 ]]` etc., unless short-cicruit evaluation is required as this is not supported by `-a` or `-o`. Use of the extended test syntax can result in a small optimisation due to short-circuit evaluation, which may be an important consideration. See [test constructs](https://www.tldp.org/LDP/abs/html/testconstructs.html)
 * Shell variables should use braces ie. use `${FOO}` not `$FOO`
 * Use double-quotes (") around variables (or sequences that include variables) when possible to avoid issues with special characters, eg. `cd "$PKG_DIR/scripts"`. See [quoting variables](https://www.tldp.org/LDP/abs/html/quotingvar.html)
 * Use `. config/blah` to source a file, don't use `source config/blah`

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -8,7 +8,7 @@
 * Numeric comparison: use `-eq` not `=` etc.
 * For tests, `[ expr1 -o expr2 ]/[ expr1 -a expr2 ]` is preferred to the extended form `[[ expr1 ]] || [[ expr2 ]]`/`[[ expr1 ]] && [[ expr2 ]]` etc., unless short-cicruit evaluation is required as this is not supported by `-a` or `-o`. Use of the extended test syntax can result in a small optimisation due to short-circuit evaluation, which may be an important consideration. See [test constructs](https://www.tldp.org/LDP/abs/html/testconstructs.html)
 * Shell variables should use braces ie. use `${FOO}` not `$FOO`
-* Use double-quotes (") around variables (or sequences that include variables) when possible to avoid issues with special characters, eg. `cd "$PKG_DIR/scripts"`. See [quoting variables](https://www.tldp.org/LDP/abs/html/quotingvar.html)
+* Use double-quotes (") around variables (or sequences that include variables) when possible to avoid issues with special characters, eg. `cd "$PKG_DIR/scripts"`, although paths should no longer include spaces after #3351. See [quoting variables](https://www.tldp.org/LDP/abs/html/quotingvar.html)
 * Use `. config/blah` to source a file, don't use `source config/blah`
 * To be efficient, avoid forking child processes (`sed`, `cut`, etc.) when a shell built-in can be used instead
 * Avoid long lines (> 90 columns) unless it aids maintainability/processing (eg. `LINUX_DEPENDS`, `PKG_DEPENDS_TARGET` etc.)


### PR DESCRIPTION
#### This is for discussion!

I've created the initial coding "standards" list based on my personal interpretation of how the code is currently written, and should be written. It is an incomplete list. It may also be wrong.

Any existing standard in the list is open for change (for instance, we could decide to use `source` instead of `.`, or always use braces etc.).

We can change existing code only once we agree what the coding standard for the project is, or should be. It's surprising that we have survived this long without such a document.

Please discuss and suggest changes - if we can agree on changes (maybe use thumbsup/thumbsdown reactions to a suggestion?) then I will update the list.

Eventually we can merge this and new code should then conform to the "standard", and existing code can be updated (either en-mass or as it is changed - to be decided...).