### PR TITLE
kodi: Hack around 'not available' notification with built-in dependen…

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.99.avoid-bogus-dependency-not-available-notification.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99.avoid-bogus-dependency-not-available-notification.patch
@@ -1,0 +1,32 @@
+diff --git a/xbmc/addons/AddonManager.cpp b/xbmc/addons/AddonManager.cpp
+index ef662d3..fe97b1f 100644
+--- a/xbmc/addons/AddonManager.cpp
++++ b/xbmc/addons/AddonManager.cpp
+@@ -14,6 +14,7 @@
+ #include "events/EventLog.h"
+ #include "events/NotificationEvent.h"
+ #include "filesystem/File.h"
++#include "filesystem/Directory.h"
+ #include "filesystem/SpecialProtocol.h"
+ #include "utils/log.h"
+ #include "utils/StringUtils.h"
+@@ -1259,7 +1260,8 @@ bool CAddonMgr::IsCompatible(const IAddon& addon)
+       // Intentionally only check the xbmc.* and kodi.* magic dependencies. Everything else will
+       // not be missing anyway, unless addon was installed in an unsupported way.
+       if (StringUtils::StartsWith(dependency.id, "xbmc.") ||
+-          StringUtils::StartsWith(dependency.id, "kodi."))
++          StringUtils::StartsWith(dependency.id, "kodi.") ||
++          CDirectory::Exists("/usr/share/kodi/addons/" + dependency.id))
+       {
+         AddonPtr addon;
+         bool haveAddon = GetAddon(dependency.id, addon);
+@@ -1287,7 +1289,8 @@ std::vector<DependencyInfo> CAddonMgr::GetDepsRecursive(const std::string& id)
+     auto current_dep = *toProcess.begin();
+     toProcess.erase(toProcess.begin());
+     if (StringUtils::StartsWith(current_dep.id, "xbmc.") ||
+-        StringUtils::StartsWith(current_dep.id, "kodi."))
++        StringUtils::StartsWith(current_dep.id, "kodi.") ||
++        CDirectory::Exists("/usr/share/kodi/addons/" + current_dep.id))
+       continue;
+ 
+     auto added_it = std::find_if(added.begin(), added.end(), [&](const DependencyInfo& d){ return d.id == current_dep.id;});


### PR DESCRIPTION
…cies

This is a temporary fix for https://trac.kodi.tv/ticket/18062 in the absence of an upstream solution. Otherwise we'll be inundated with false support issues due to "not available" addons that are already installed.

Before:

![s1](https://i.imgur.com/GpPTnD1.png)

After:

![s2](https://i.imgur.com/4IOOgYK.png)