### PR TITLE
Rockchip: package updates

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -18,8 +18,8 @@ case $KODI_VENDOR in
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;
   rockchip)
-    PKG_VERSION="rockchip_18.0b3-Leia"
-    PKG_SHA256="e785669ffe70cee47bcbc83c3d75a17b73e77c8add4f1cca4a983552711f821e"
+    PKG_VERSION="rockchip_18.0b4-Leia"
+    PKG_SHA256="bcd1a35c87c5f22a84e98d3f01df6ddbba7b4f62a8c79c4dea54be83086b7e48"
     PKG_URL="https://github.com/kwiboo/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -18,8 +18,8 @@ case $KODI_VENDOR in
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;
   rockchip)
-    PKG_VERSION="rockchip_18.0b4-Leia"
-    PKG_SHA256="bcd1a35c87c5f22a84e98d3f01df6ddbba7b4f62a8c79c4dea54be83086b7e48"
+    PKG_VERSION="rockchip_18.0b5-Leia"
+    PKG_SHA256="bef89dabe4be2f155e0c912d0221845f570372c6d0b6d8be615381992dc76bc9"
     PKG_URL="https://github.com/kwiboo/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;

--- a/packages/multimedia/ffmpeg/patches/ffmpeg-99.1006-rkmppdec-continue-on-errinfo-frame.patch
+++ b/packages/multimedia/ffmpeg/patches/ffmpeg-99.1006-rkmppdec-continue-on-errinfo-frame.patch
@@ -1,25 +1,44 @@
-From 277118ae73eab2ddad116bf923b9553db3a871d0 Mon Sep 17 00:00:00 2001
+From 35e9805c3dfc636d1a3130411c5c210c091776ee Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 9 Sep 2018 12:37:29 +0200
 Subject: [PATCH] rkmppdec: continue on errinfo frame
 
 ---
- libavcodec/rkmppdec.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ libavcodec/rkmppdec.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/rkmppdec.c b/libavcodec/rkmppdec.c
-index c00f08c70b..7c246db0d1 100644
+index c00f08c70b..72be832141 100644
 --- a/libavcodec/rkmppdec.c
 +++ b/libavcodec/rkmppdec.c
-@@ -386,7 +386,7 @@ static int rkmpp_retrieve_frame(AVCodecContext *avctx, AVFrame *frame)
+@@ -49,6 +49,7 @@ typedef struct {
+ 
+     char first_packet;
+     char eos_reached;
++    int errors;
+ 
+     AVBufferRef *frames_ref;
+     AVBufferRef *device_ref;
+@@ -386,12 +387,13 @@ static int rkmpp_retrieve_frame(AVCodecContext *avctx, AVFrame *frame)
              goto fail;
          } else if (mpp_frame_get_errinfo(mppframe)) {
              av_log(avctx, AV_LOG_ERROR, "Received a errinfo frame.\n");
 -            ret = AVERROR_UNKNOWN;
-+            ret = AVERROR(EAGAIN);
++            ret = (decoder->errors++ > 100) ? AVERROR_UNKNOWN : AVERROR(EAGAIN);
              goto fail;
          }
  
--- 
-2.18.0
-
+         // here we should have a valid frame
+         av_log(avctx, AV_LOG_DEBUG, "Received a frame.\n");
++        decoder->errors = 0;
+ 
+         // setup general frame fields
+         frame->format           = AV_PIX_FMT_DRM_PRIME;
+@@ -544,6 +546,7 @@ static void rkmpp_flush(AVCodecContext *avctx)
+     ret = decoder->mpi->reset(decoder->ctx);
+     if (ret == MPP_OK) {
+         decoder->first_packet = 1;
++        decoder->errors = 0;
+     } else
+         av_log(avctx, AV_LOG_ERROR, "Failed to reset MPI (code = %d)\n", ret);
+ }

--- a/packages/multimedia/ffmpeg/patches/ffmpeg-99.1007-rkmppdec-enable-mpeg2.patch
+++ b/packages/multimedia/ffmpeg/patches/ffmpeg-99.1007-rkmppdec-enable-mpeg2.patch
@@ -1,4 +1,4 @@
-From 944f3bc90fb402b11f2419e5877a1f8395ba7e6a Mon Sep 17 00:00:00 2001
+From 7ddf0485e54d624d11aaa0234e7bf4b9b8393ae3 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Wed, 12 Sep 2018 22:29:22 +0200
 Subject: [PATCH] rkmppdec: enable mpeg2
@@ -47,10 +47,10 @@ index 4d4ef530e4..07e1216333 100644
  extern AVCodec ff_mpeg2_mediacodec_decoder;
  extern AVCodec ff_msa1_decoder;
 diff --git a/libavcodec/rkmppdec.c b/libavcodec/rkmppdec.c
-index 7c246db0d1..cf41f8895a 100644
+index 72be832141..48016bc681 100644
 --- a/libavcodec/rkmppdec.c
 +++ b/libavcodec/rkmppdec.c
-@@ -69,6 +69,7 @@ static MppCodingType rkmpp_get_codingtype(AVCodecContext *avctx)
+@@ -70,6 +70,7 @@ static MppCodingType rkmpp_get_codingtype(AVCodecContext *avctx)
      switch (avctx->codec_id) {
      case AV_CODEC_ID_H264:          return MPP_VIDEO_CodingAVC;
      case AV_CODEC_ID_HEVC:          return MPP_VIDEO_CodingHEVC;
@@ -58,7 +58,7 @@ index 7c246db0d1..cf41f8895a 100644
      case AV_CODEC_ID_VP8:           return MPP_VIDEO_CodingVP8;
      case AV_CODEC_ID_VP9:           return MPP_VIDEO_CodingVP9;
      default:                        return MPP_VIDEO_CodingUnused;
-@@ -403,6 +404,12 @@ static int rkmpp_retrieve_frame(AVCodecContext *avctx, AVFrame *frame)
+@@ -405,6 +406,12 @@ static int rkmpp_retrieve_frame(AVCodecContext *avctx, AVFrame *frame)
          frame->color_trc        = mpp_frame_get_color_trc(mppframe);
          frame->colorspace       = mpp_frame_get_colorspace(mppframe);
  
@@ -71,13 +71,10 @@ index 7c246db0d1..cf41f8895a 100644
          mode = mpp_frame_get_mode(mppframe);
          frame->interlaced_frame = ((mode & MPP_FRAME_FLAG_FIELD_ORDER_MASK) == MPP_FRAME_FLAG_DEINTERLACED);
          frame->top_field_first  = ((mode & MPP_FRAME_FLAG_FIELD_ORDER_MASK) == MPP_FRAME_FLAG_TOP_FIRST);
-@@ -582,5 +589,6 @@ static const AVCodecHWConfigInternal *rkmpp_hw_configs[] = {
+@@ -585,5 +592,6 @@ static const AVCodecHWConfigInternal *rkmpp_hw_configs[] = {
  
  RKMPP_DEC(h264,  AV_CODEC_ID_H264,          "h264_mp4toannexb")
  RKMPP_DEC(hevc,  AV_CODEC_ID_HEVC,          "hevc_mp4toannexb")
 +RKMPP_DEC(mpeg2, AV_CODEC_ID_MPEG2VIDEO,    NULL)
  RKMPP_DEC(vp8,   AV_CODEC_ID_VP8,           NULL)
  RKMPP_DEC(vp9,   AV_CODEC_ID_VP9,           NULL)
--- 
-2.18.0
-

--- a/packages/multimedia/rkmpp/package.mk
+++ b/packages/multimedia/rkmpp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rkmpp"
-PKG_VERSION="7a21a6a0454f604fdf752a1d45be6e2c954cc6de"
-PKG_SHA256="ea981633839673dcfdc0fa0e4666b61ed0626def4273cdf5336b6a6bf322fdb3"
+PKG_VERSION="b9dda0fb95674651673cbab0b846d29ab9b0e96c"
+PKG_SHA256="c78ce9cd4a77fade1122e10553b00eec42d622d97838bd08e644ec816bb43e5f"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/rockchip-linux/mpp"

--- a/packages/tools/u-boot/patches/rockchip/u-boot-0010-rk3288-tinker-enable-emmc.patch
+++ b/packages/tools/u-boot/patches/rockchip/u-boot-0010-rk3288-tinker-enable-emmc.patch
@@ -1,18 +1,18 @@
-From a973521ff1cbee88498db1b75ce935fca55642fb Mon Sep 17 00:00:00 2001
+From f6ac1287103cf1abae453ddaf3e78ef9c204542a Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Thu, 13 Sep 2018 22:23:48 +0200
 Subject: [PATCH] rk3288-tinker: enable emmc
 
 ---
- arch/arm/dts/rk3288-tinker.dtsi | 13 +++++++++++++
+ arch/arm/dts/rk3288-tinker.dtsi | 11 +++++++++++
  include/configs/tinker_rk3288.h | 13 ++++---------
- 2 files changed, 17 insertions(+), 9 deletions(-)
+ 2 files changed, 15 insertions(+), 9 deletions(-)
 
 diff --git a/arch/arm/dts/rk3288-tinker.dtsi b/arch/arm/dts/rk3288-tinker.dtsi
-index 81f8d5a6c3..93e5dd223b 100644
+index 81f8d5a6c3..91f6e78ad3 100644
 --- a/arch/arm/dts/rk3288-tinker.dtsi
 +++ b/arch/arm/dts/rk3288-tinker.dtsi
-@@ -129,6 +129,19 @@
+@@ -129,6 +129,17 @@
  	cpu0-supply = <&vdd_cpu>;
  };
  
@@ -20,8 +20,6 @@ index 81f8d5a6c3..93e5dd223b 100644
 +	bus-width = <8>;
 +	cap-mmc-highspeed;
 +	disable-wp;
-+	mmc-ddr-1_8v;
-+	mmc-hs200-1_8v;
 +	non-removable;
 +	num-slots = <1>;
 +	pinctrl-names = "default";

--- a/packages/tools/u-boot/patches/rockchip/u-boot-0011-Revert-rockchip-dts-rk3328-evb-Enable-gmac2io-for-rk.patch
+++ b/packages/tools/u-boot/patches/rockchip/u-boot-0011-Revert-rockchip-dts-rk3328-evb-Enable-gmac2io-for-rk.patch
@@ -1,4 +1,4 @@
-From a230a5d8c54457df420907c3c8790ec0fd7004c3 Mon Sep 17 00:00:00 2001
+From fc0ea138b00b1a0fb35b5b4e3e2d26c19e2f2d6a Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 16 Sep 2018 11:56:50 +0200
 Subject: [PATCH] Revert "rockchip: dts: rk3328-evb: Enable gmac2io for

--- a/projects/Rockchip/README.md
+++ b/projects/Rockchip/README.md
@@ -16,7 +16,6 @@ This project is for Rockchip SoC devices
 
 **RK3399**
 * [96rocks ROCK960](devices/RK3399)
-* [Hardkernel ODROID-N1](devices/RK3399)
 * [PINE64 RockPro64](devices/RK3399)
 * [Rockchip Sapphire Board](devices/RK3399)
 

--- a/projects/Rockchip/devices/MiQi/kodi/appliance.xml
+++ b/projects/Rockchip/devices/MiQi/kodi/appliance.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings version="1">
+  <section id="player">
+    <category id="videoplayer">
+      <group id="3">
+        <setting id="videoplayer.hdmioutputformat">
+          <default>0</default>
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/projects/Rockchip/devices/TinkerBoard/README.md
+++ b/projects/Rockchip/devices/TinkerBoard/README.md
@@ -1,37 +1,6 @@
 # ASUS Tinker Board
 
-This is an experimental project for the ASUS Tinker Board
-
-**Progress**
-
-* [x] LEDs
-* [ ] ~~CEC~~
-* [ ] Audio
-  * [x] HDMI Stereo L-PCM
-  * [x] HDMI Multi-channel L-PCM
-  * [x] HDA 3.5 mm jack
-  * [ ] HDMI NL-PCM (AC3/E-AC3/DTS)
-  * [ ] HDMI HBR (TrueHD/DTS-HD)
-* [ ] Video
-  * [x] Software decoding
-  * [ ] Hardware decoding
-    * [x] h264 / hevc / vp8
-    * [ ] mpeg4 / mpeg2
-* [ ] HDMI Video Format
-  * [x] RGB 4:4:4 Limited Range
-  * [ ] RGB 4:4:4 Full Range
-  * [ ] YCbCr 4:4:4
-  * [ ] YCbCr 4:2:0
-* [x] WiFi
-* [x] Bluetooth
-
-**Known Issues/Limitations**
-
-* Video output is RGB 4:4:4 8-bit limited range
-* Video aspect ratio / zoom is not working for all modes
-* Generic USB-Audio do not work due to a custom alsa config
-* 4K resolution is limited to 30hz due to failed compliance test
-* CEC is not connected to SoC
+This is a device for the ASUS Tinker Board / Tinker Board S
 
 **Serial Console**
 

--- a/projects/Rockchip/devices/TinkerBoard/kodi/appliance.xml
+++ b/projects/Rockchip/devices/TinkerBoard/kodi/appliance.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings version="1">
+  <section id="player">
+    <category id="videoplayer">
+      <group id="3">
+        <setting id="videoplayer.hdmioutputformat">
+          <default>0</default>
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/projects/Rockchip/patches/linux/rockchip-4.4/linux-0001-rockchip.patch
+++ b/projects/Rockchip/patches/linux/rockchip-4.4/linux-0001-rockchip.patch
@@ -587,7 +587,7 @@ index 8864582b1706..b5a388cc3cbe 100755
  	},
  };
 
-From 088790f59f74dc73cde328bb1751c75b1cdbd7a0 Mon Sep 17 00:00:00 2001
+From 922cc477bd191cbfddae005b27a2c89cb9c9623a Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 1 Jul 2018 23:17:47 +0200
 Subject: [PATCH] drm/rockchip: clip yuv
@@ -599,14 +599,14 @@ Subject: [PATCH] drm/rockchip: clip yuv
  3 files changed, 7 insertions(+)
 
 diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
-index 1418402c2668..50d7d4c983a1 100644
+index 1418402c2668..0916b4284f88 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
 +++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
 @@ -1731,6 +1731,7 @@ static void vop_plane_atomic_update(struct drm_plane *plane,
  	s = to_rockchip_crtc_state(crtc->state);
  
  	spin_lock(&vop->reg_lock);
-+	VOP_WIN_SET(vop, win, yuv_clip, 1);
++	VOP_WIN_SET(vop, win, yuv_clip, 0);
  	VOP_WIN_SET(vop, win, xmirror, xmirror);
  	VOP_WIN_SET(vop, win, ymirror, ymirror);
  	VOP_WIN_SET(vop, win, format, vop_plane_state->format);
@@ -614,7 +614,7 @@ index 1418402c2668..50d7d4c983a1 100644
  		VOP_CTRL_SET(vop, dsp_data_swap, 0);
  
  	VOP_CTRL_SET(vop, out_mode, s->output_mode);
-+	VOP_CTRL_SET(vop, yuv_clip, 1);
++	VOP_CTRL_SET(vop, yuv_clip, 0);
  
  	switch (s->bus_format) {
  	case MEDIA_BUS_FMT_RGB565_1X16:
@@ -667,7 +667,7 @@ index 9c96d5614e54..aeb1c7644bc9 100644
  	.ymirror = VOP_REG(RK3328_DSP_CTRL0, 0x1, 23),
  
 
-From 34af37e51e11b9a48d7ca4a77d4430697e4c775d Mon Sep 17 00:00:00 2001
+From 991811443d72d7915afdee23c30843669a347d7c Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 8 Jul 2018 12:38:00 +0200
 Subject: [PATCH] drm/atomic: use active_only flag for connector atomic
@@ -724,7 +724,7 @@ index f77d4aa1e58b..4da489b54dc5 100644
  
  		DRM_DEBUG_ATOMIC("flushing [CONNECTOR:%d:%s]\n",
 
-From 103d19f54aa345a9a80ed386f750482a9f905ec2 Mon Sep 17 00:00:00 2001
+From 8d514d5127fbb4d49247f893ac6b803cbdd3304d Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 22 Jul 2018 14:51:58 +0200
 Subject: [PATCH] drm: rockchip: dw-hdmi: only force YCbCr422 when max tmds is
@@ -750,7 +750,7 @@ index 7273561fe6b1..e2aad6e2149b 100644
  	}
  
 
-From 5e6283e0832bf7ef0c8b02cc0576276b1d08b03f Mon Sep 17 00:00:00 2001
+From 9d6de32c2e992b71e6634a284dc99ab1b3bd43e2 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 22 Jul 2018 15:09:16 +0200
 Subject: [PATCH] drm: bridge: dw-hdmi: signal full range for rgb output
@@ -779,7 +779,7 @@ index 393bd5b28f07..91c5b8fc8fa0 100644
  	 * The Designware IP uses a different byte format from standard
  	 * AVI info frames, though generally the bits are in the correct
 
-From d6543095fd910b2108e8f823aa4bdc5e90f39965 Mon Sep 17 00:00:00 2001
+From 35c0ac957d5fcec21d807e801efed57a37c41d9d Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 28 Jul 2018 10:41:40 +0200
 Subject: [PATCH] WIP: mm: dma-mapping: increase dma pool size
@@ -816,7 +816,7 @@ index 2b05653e8156..2ad8515cd4da 100644
  
  static int __init early_coherent_pool(char *p)
 
-From a6d53734dc1bf083a8b8d77eb03747cbf834e204 Mon Sep 17 00:00:00 2001
+From 24a070f21767a8d381b81ab5fc5f39c2b9729b24 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 4 Aug 2018 15:19:39 +0200
 Subject: [PATCH] drm: add picture_aspect_ratio to hdmi 1.4 4k modes
@@ -860,7 +860,7 @@ index f7d41950614e..69a1eb4ee382 100644
  
  /*** DDC fetch and block validation ***/
 
-From b6c4fe8035c6ceb21b2420532d95489bf4dbc25c Mon Sep 17 00:00:00 2001
+From daadd2b2e1bf5419694ebae5243e61e462885b03 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 4 Aug 2018 16:26:47 +0200
 Subject: [PATCH] drm: bridge: dw-hdmi: signal none colorimetry for rgb output
@@ -883,7 +883,7 @@ index 91c5b8fc8fa0..8261ba15f98e 100644
  		frame.ycc_quantization_range = HDMI_YCC_QUANTIZATION_RANGE_FULL;
  	} else {
 
-From 52fd44fe708ada3fb673c0b8b093e49beabfd62e Mon Sep 17 00:00:00 2001
+From 88c6dbd7a37b01d4029102c6fdad2b1fc24098e0 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 4 Aug 2018 16:27:08 +0200
 Subject: [PATCH] drm: bridge: dw-hdmi: signal it content and content type
@@ -906,7 +906,7 @@ index 8261ba15f98e..cdfa295fc323 100644
  	if (hdmi_bus_fmt_is_rgb(hdmi->hdmi_data.enc_out_bus_format)) {
  		frame.colorimetry = HDMI_COLORIMETRY_NONE;
 
-From 6e57feede98bc6134077215139211d51f0fb7b97 Mon Sep 17 00:00:00 2001
+From 5d069752d8885584beaac3905a21c34a0bfa5f22 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 4 Aug 2018 16:27:40 +0200
 Subject: [PATCH] drm: bridge: dw-hdmi: log infoframes
@@ -956,7 +956,7 @@ index cdfa295fc323..25546a4471fb 100644
  	hdmi_writeb(hdmi, frame.length, HDMI_FC_DRM_HB1);
  	hdmi_writeb(hdmi, frame.eotf, HDMI_FC_DRM_PB0);
 
-From dcdbd37723553a9ede3754a1e15c9a1e9d566cf1 Mon Sep 17 00:00:00 2001
+From 3f61791c437d217b760d9f64d38f69e7c2ac6987 Mon Sep 17 00:00:00 2001
 From: Nickey Yang <nickey.yang@rock-chips.com>
 Date: Mon, 17 Jul 2017 16:35:34 +0800
 Subject: [PATCH] MINIARM: set npll be used for hdmi only
@@ -1004,7 +1004,7 @@ index ca6c2ad3de96..415df387a5d6 100644
  			RK3288_CLKGATE_CON(3), 1, GFLAGS),
  	COMPOSITE(DCLK_VOP1, "dclk_vop1", mux_pll_src_cpll_gpll_npll_p, 0,
 
-From bd89275c319915fc48f830637d9594d5ae9d657d Mon Sep 17 00:00:00 2001
+From 23a9cfafd5b8c641c2e9d2fdd1c299f19947c548 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 4 Aug 2018 14:51:14 +0200
 Subject: [PATCH] clk: rockchip: rk3288: use npll table to to improve HDMI
@@ -1057,7 +1057,7 @@ index 415df387a5d6..f748a292b7f4 100644
  
  static struct clk_div_table div_hclk_cpu_t[] = {
 
-From e5b26e2385f2792fce564d4ab8901f170ac0ba41 Mon Sep 17 00:00:00 2001
+From ba1e5834eef028ca22c2089a2bff453c9bee38af Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
 Date: Wed, 30 May 2018 13:06:14 +0200
 Subject: [PATCH] ayufan: fan53555: support syr83x found in rockpro64
@@ -1088,7 +1088,7 @@ index 74e5ae2bc0d2..6b0854a3cae3 100644
  		di->vsel_step = 12500;
  		break;
 
-From 8d6f3424a0d486913f6ab2bebc3cd82e4017be10 Mon Sep 17 00:00:00 2001
+From 99674f3279042bd694019c26309e4f2a44b6fe81 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 9 Sep 2018 12:33:23 +0200
 Subject: [PATCH] WIP: video: rockchip: iep: fix compile issue
@@ -1119,7 +1119,7 @@ index 73e2ff159e86..d87b8d2c9904 100644
  #define IEP_IOMMU_COMPATIBLE_NAME "rockchip,iep_mmu"
  #define VIP_IOMMU_COMPATIBLE_NAME "rockchip,vip_mmu"
 
-From 1e888a00891c2ded5cd802d987884ad564b8f97f Mon Sep 17 00:00:00 2001
+From 7405c1596ae36388bc2d32dd8b72f0b1f22ffb41 Mon Sep 17 00:00:00 2001
 From: Randy Li <randy.li@rock-chips.com>
 Date: Thu, 20 Sep 2018 10:59:11 +0800
 Subject: [PATCH] Mali: midgard: fix the memory translation for aarch32
@@ -1321,3 +1321,53 @@ index 24bafe2bf32c..65bc5ad2a7c2 100644
  	if (err) {
  		kfree(buf);
  		return err;
+
+From 6de4ce0e92be7b66429efe88c406e30703639661 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 28 Oct 2018 21:43:01 +0100
+Subject: [PATCH] clk: rockchip: rk3288: add more npll clocks
+
+Fixes 2560x1440@60Hz, 1600x1200@60Hz, 1920x1200@60Hz, 1680x1050@60Hz and 1440x900@60Hz modes on my monitor
+---
+ drivers/clk/rockchip/clk-rk3288.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/clk/rockchip/clk-rk3288.c b/drivers/clk/rockchip/clk-rk3288.c
+index f748a292b7f4..d72c02afeb76 100644
+--- a/drivers/clk/rockchip/clk-rk3288.c
++++ b/drivers/clk/rockchip/clk-rk3288.c
+@@ -111,18 +111,34 @@ static struct rockchip_pll_rate_table rk3288_npll_rates[] = {
+ 	RK3066_PLL_RATE_NB(432000000, 3, 216, 4, 32),
+ 	RK3066_PLL_RATE_NB(426000000, 3, 213, 4, 32),
+ 	RK3066_PLL_RATE_NB(400000000, 1, 100, 6, 32),
++	RK3066_PLL_RATE(348500000, 8, 697, 6),
+ 	RK3066_PLL_RATE_NB(342000000, 3, 171, 4, 32),
+ 	RK3066_PLL_RATE_NB(297000000, 2, 198, 8, 16),
+ 	RK3066_PLL_RATE_NB(270000000, 1, 135, 12, 32),
+ 	RK3066_PLL_RATE_NB(260000000, 1, 130, 12, 32),
++	RK3066_PLL_RATE(241500000, 2, 161, 8),
++	RK3066_PLL_RATE(162000000, 1, 81, 12),
++	RK3066_PLL_RATE(154000000, 6, 539, 14),
+ 	RK3066_PLL_RATE_NB(148500000, 1, 99, 16, 32),
+ 	RK3066_PLL_RATE(148352000, 13, 1125, 14),
+ 	RK3066_PLL_RATE_NB(146250000, 6, 585, 16, 32),
++	RK3066_PLL_RATE(121750000, 6, 487, 16),
++	RK3066_PLL_RATE(119000000, 3, 238, 16),
+ 	RK3066_PLL_RATE_NB(108000000, 1, 54, 12, 32),
+ 	RK3066_PLL_RATE_NB(106500000, 4, 213, 12, 32),
++	RK3066_PLL_RATE(101000000, 3, 202, 16),
++	RK3066_PLL_RATE(88750000, 6, 355, 16),
+ 	RK3066_PLL_RATE_NB(85500000, 4, 171, 12, 32),
++	RK3066_PLL_RATE(83500000, 3, 167, 16),
++	RK3066_PLL_RATE(79500000, 1, 53, 16),
+ 	RK3066_PLL_RATE_NB(74250000, 4, 198, 16, 32),
+ 	RK3066_PLL_RATE(74176000, 26, 1125, 14),
++	RK3066_PLL_RATE(72000000, 1, 48, 16),
++	RK3066_PLL_RATE(71000000, 3, 142, 16),
++	RK3066_PLL_RATE(68250000, 2, 91, 16),
++	RK3066_PLL_RATE(65000000, 3, 130, 16),
++	RK3066_PLL_RATE(40000000, 3, 80, 16),
++	RK3066_PLL_RATE(33750000, 2, 45, 16),
+ 	{ /* sentinel */ },
+ };
+ 

--- a/projects/Rockchip/patches/linux/rockchip-4.4/linux-0005-dts.patch
+++ b/projects/Rockchip/patches/linux/rockchip-4.4/linux-0005-dts.patch
@@ -99,17 +99,17 @@ index 1b7602f25f34..9cca69f9f5ba 100644
  
  		upthreshold = <75>;
 
-From c1b9be22ba80dfeeccfe14d64642f3bd6dda8765 Mon Sep 17 00:00:00 2001
+From 4cea1d3405885efca9c1d7e80b6eeb52e40d990f Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 13 Aug 2017 10:24:19 +0200
 Subject: [PATCH] arm: dts: rk3288-miniarm: update dts
 
 ---
- arch/arm/boot/dts/rk3288-miniarm.dts | 63 +++++++++++++++++++++++++++++-------
- 1 file changed, 52 insertions(+), 11 deletions(-)
+ arch/arm/boot/dts/rk3288-miniarm.dts | 64 +++++++++++++++++++++++++++++-------
+ 1 file changed, 53 insertions(+), 11 deletions(-)
 
 diff --git a/arch/arm/boot/dts/rk3288-miniarm.dts b/arch/arm/boot/dts/rk3288-miniarm.dts
-index a5c5300797ab..e20662aae028 100644
+index a5c5300797ab..eac9b1501878 100644
 --- a/arch/arm/boot/dts/rk3288-miniarm.dts
 +++ b/arch/arm/boot/dts/rk3288-miniarm.dts
 @@ -42,11 +42,22 @@
@@ -165,7 +165,7 @@ index a5c5300797ab..e20662aae028 100644
  		simple-audio-card,mclk-fs = <512>;
  		simple-audio-card,cpu {
  			sound-dai = <&i2s>;
-@@ -204,20 +215,33 @@
+@@ -204,20 +215,34 @@
  	cpu0-supply = <&vdd_cpu>;
  };
  
@@ -186,6 +186,7 @@ index a5c5300797ab..e20662aae028 100644
  	phy-supply = <&vcc33_lan>;
  	phy-mode = "rgmii";
  	clock_in_out = "input";
++	snps,force_thresh_dma_mode;
  	snps,reset-gpio = <&gpio4 7 0>;
  	snps,reset-active-low;
 -	snps,reset-delays-us = <0 10000 1000000>;
@@ -201,7 +202,7 @@ index a5c5300797ab..e20662aae028 100644
  };
  
  &dsi0 {
-@@ -238,6 +262,11 @@
+@@ -238,6 +263,11 @@
  	#address-cells = <1>;
  	#size-cells = <0>;
  	#sound-dai-cells = <0>;
@@ -213,7 +214,7 @@ index a5c5300797ab..e20662aae028 100644
  	status = "okay";
  	/* Don't use vopl for HDMI */
  	ports {
-@@ -545,6 +574,15 @@
+@@ -545,6 +575,15 @@
  
  &i2s {
  	#sound-dai-cells = <0>;
@@ -229,7 +230,7 @@ index a5c5300797ab..e20662aae028 100644
  	status = "okay";
  };
  
-@@ -558,7 +596,7 @@
+@@ -558,7 +597,7 @@
  &sdio0 {
  	status = "okay";
  	clock-frequency = <50000000>;
@@ -238,7 +239,7 @@ index a5c5300797ab..e20662aae028 100644
  	bus-width = <4>;
  	cap-sd-highspeed;
  	cap-sdio-irq;
-@@ -579,7 +617,7 @@
+@@ -579,7 +618,7 @@
  
  &saradc {
  	vref-supply = <&vcc18_ldo1>;
@@ -247,7 +248,7 @@ index a5c5300797ab..e20662aae028 100644
  };
  
  &sdmmc {
-@@ -604,7 +642,6 @@
+@@ -604,7 +643,6 @@
  &tsadc {
  	rockchip,hw-tshut-mode = <1>; /* tshut mode 0:CRU 1:GPIO */
  	rockchip,hw-tshut-polarity = <1>; /* tshut polarity 0:LOW 1:HIGH */
@@ -255,7 +256,7 @@ index a5c5300797ab..e20662aae028 100644
  	status = "okay";
  };
  
-@@ -615,6 +652,8 @@
+@@ -615,6 +653,8 @@
  };
  
  &uart1 {
@@ -264,7 +265,7 @@ index a5c5300797ab..e20662aae028 100644
  	status = "okay";
  };
  
-@@ -627,6 +666,8 @@
+@@ -627,6 +667,8 @@
  };
  
  &uart4 {
@@ -273,7 +274,7 @@ index a5c5300797ab..e20662aae028 100644
  	status = "okay";
  };
  
-@@ -644,7 +685,7 @@
+@@ -644,7 +686,7 @@
  };
  
  &usb_otg {
@@ -283,7 +284,7 @@ index a5c5300797ab..e20662aae028 100644
  
  &vopb {
 
-From 89309e089d4cda5e1194cf9f19aea6699369cd3d Mon Sep 17 00:00:00 2001
+From 3da8fccb1f5b73ef313d320925e81bd1b5cacbfa Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Thu, 2 Nov 2017 23:17:46 +0100
 Subject: [PATCH] arm: dts: rk3288-miqi: update dts
@@ -437,7 +438,7 @@ index a2862c6a17f1..9655365db416 100644
  };
 -
 
-From a6b0b521feeddf71159db7197e5a60d53434abf7 Mon Sep 17 00:00:00 2001
+From 49c65a7f1c91517d56efdbe72a046b64b687664c Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Wed, 17 Jan 2018 22:17:45 +0100
 Subject: [PATCH] arm64: dts: rockchip: rk3328: update dtsi
@@ -645,7 +646,7 @@ index 0d2251c903b1..b7b6f9304706 100644
  	};
  
 
-From a380fed7df787269e4cb466ca346e6f4e73cee55 Mon Sep 17 00:00:00 2001
+From bffef35a0fe1b0cd133c32569b448575ae422be5 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Wed, 17 Jan 2018 22:17:45 +0100
 Subject: [PATCH] arm64: dts: rockchip: rk3328-rock64: update dts
@@ -1189,7 +1190,7 @@ index 4b2eef609601..ff90c5379671 100644
  };
  
 
-From b3eff85958958b3073b7585b6402c1f328b8ad71 Mon Sep 17 00:00:00 2001
+From ed7848e24407cd2a65e524c46ba8fbb92db2bdc5 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Wed, 17 Jan 2018 22:17:45 +0100
 Subject: [PATCH] arm64: dts: rockchip: add rk3328-box board
@@ -1854,7 +1855,7 @@ index 000000000000..eae652d55208
 +	status = "okay";
 +};
 
-From 7e5241cae976148b89c5d0d64e2949f6c75730aa Mon Sep 17 00:00:00 2001
+From 8d1e765adaeb6d597b7cda84c9922f2aa5d34239 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Wed, 17 Jan 2018 22:17:45 +0100
 Subject: [PATCH] arm64: dts: rockchip: add rk3328-rockbox board
@@ -2454,7 +2455,7 @@ index 000000000000..4ba9b1e78846
 +	status = "okay";
 +};
 
-From 0203874c5284aece3cc9461c5837dcacebb83ee1 Mon Sep 17 00:00:00 2001
+From aa7c314431dcd5fd3dd6dd8b06859c472e93cf5d Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Wed, 17 Jan 2018 22:17:45 +0100
 Subject: [PATCH] arm64: dts: rockchip: add rk3328-roc-cc board
@@ -3047,7 +3048,7 @@ index 000000000000..af2af859d56e
 +	status = "okay";
 +};
 
-From 843651111d6923677211176dc707149ab290f6c0 Mon Sep 17 00:00:00 2001
+From 1652fa888921eb14a53fd6b12b6860247d5a9d0c Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 3 Sep 2017 11:19:19 +0200
 Subject: [PATCH] arm64: dts: rockchip: rk3328-rock64: use two dai-link for i2s
@@ -3137,7 +3138,7 @@ index 53dd085d3ee2..bf7ce34084a9 100644
  	.probe = snd_soc_dummy_probe,
  	.remove = snd_soc_dummy_remove,
 
-From 9962ca93f611151d0fcdf6c16a6a0d1aa29841be Mon Sep 17 00:00:00 2001
+From 3184eaf3788de374e37ba0ee24ce641d6a20f780 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Fri, 26 Jan 2018 00:03:46 +0100
 Subject: [PATCH] arm64: dts: rockchip: rk3328-roc-cc: disable sd-card voltage
@@ -3188,7 +3189,7 @@ index af2af859d56e..e911cf265a64 100644
  };
  
 
-From d6db0954321db50c6da255ca5a4194f98adcbfc6 Mon Sep 17 00:00:00 2001
+From 200c456121d8644da9f4ffc3ac8acf2f8f8ecb5c Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 28 Jan 2018 15:17:34 +0100
 Subject: [PATCH] arm64: dts: rockchip: add rk3399-sapphire board
@@ -3375,7 +3376,7 @@ index 000000000000..8706dc7d91af
 +	};
 +};
 
-From a21f5bf348d0c46ca74aa2643bfa5c0e7359ff60 Mon Sep 17 00:00:00 2001
+From 1ac825316b3a44cd22bf7904f230e725a8163f2c Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 28 Jan 2018 15:17:53 +0100
 Subject: [PATCH] arm64: dts: rockchip: add rk3399-rock960 board
@@ -4395,7 +4396,7 @@ index 000000000000..865a1da96aee
 +	status = "okay";
 +};
 
-From 275c99b24db42bf8bb3538c8004d20f79538bd27 Mon Sep 17 00:00:00 2001
+From 493cb1d1e8ae9aeafe0a008039fb03fe7f441c8b Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 28 Jan 2018 15:38:32 +0100
 Subject: [PATCH] arm: dts: rk3288: add cec clock and pinctrl
@@ -4447,7 +4448,7 @@ index 9cca69f9f5ba..2141eb23faa7 100644
  				rockchip,pins = <7 19 RK_FUNC_2 &pcfg_pull_none>,
  						<7 20 RK_FUNC_2 &pcfg_pull_none>;
 
-From ee38cb48bce378cdc72254cb42f713c0e4a4b827 Mon Sep 17 00:00:00 2001
+From d7b647f6bb133b0ee27d759900516c1750c268fe Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 4 Mar 2018 09:08:35 +0100
 Subject: [PATCH] arm64: dts: rockchip: add rk3328-box-trn9 board
@@ -5139,22 +5140,22 @@ index 000000000000..51d471ba8cef
 +	status = "okay";
 +};
 
-From 1303049a6d57db4aa2fc4a046ed0dc39acd2cd63 Mon Sep 17 00:00:00 2001
+From 9c8d6637e4223718bdefacb33c32ffd1b386a343 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 4 Mar 2018 09:08:35 +0100
 Subject: [PATCH] arm64: dts: rockchip: add rk3328-box-z28 board
 
 ---
- arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts | 603 ++++++++++++++++++++++++
- 1 file changed, 603 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts | 598 ++++++++++++++++++++++++
+ 1 file changed, 598 insertions(+)
  create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts b/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
 new file mode 100644
-index 000000000000..596b4f4e16bd
+index 000000000000..00a3394cefcb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
-@@ -0,0 +1,603 @@
+@@ -0,0 +1,598 @@
 +/*
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
 + *
@@ -5274,15 +5275,10 @@ index 000000000000..596b4f4e16bd
 +	leds {
 +		compatible = "gpio-leds";
 +
-+		led1 {
-+			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
++		power {
++			gpios = <&rk805 0 GPIO_ACTIVE_HIGH>;
 +			linux,default-trigger = "default-on";
 +			default-state = "on";
-+		};
-+
-+		led2 {
-+			gpios = <&rk805 1 GPIO_ACTIVE_LOW>;
-+			linux,default-trigger = "mmc0";
 +		};
 +	};
 +
@@ -5759,7 +5755,7 @@ index 000000000000..596b4f4e16bd
 +	status = "okay";
 +};
 
-From 1a69340b92389476523e88641f3c82ebea385fe7 Mon Sep 17 00:00:00 2001
+From 63d34d434542f4551cc12578317f7d6337918d1d Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Tue, 10 Apr 2018 22:07:37 +0200
 Subject: [PATCH] arm64: dts: rockchip: rk3328-roc-cc: use 1066MHz ddr
@@ -6092,7 +6088,7 @@ index e911cf265a64..5df9b4976ba2 100644
  
  &display_subsystem {
 
-From c8fd351dcd859074ce24811e0796506b246dffba Mon Sep 17 00:00:00 2001
+From 76d468bccff1b742965b5a8d78beb028488ee6e3 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 21 Apr 2018 13:21:24 +0200
 Subject: [PATCH] arm64: dts: rockchip: rk3328-box-trn9: use 1066MHz ddr
@@ -6150,7 +6146,7 @@ index 51d471ba8cef..81ec7b66e199 100644
  
  &display_subsystem {
 
-From 41ca937148360197f4a77adb0cac058e4469f52a Mon Sep 17 00:00:00 2001
+From 6116b7515612fa5ce0ada65030f3cfc71eb70206 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 18 Aug 2018 20:53:04 +0200
 Subject: [PATCH] arm64: dts: rockchip: rk3399: update dtsi
@@ -6370,17 +6366,17 @@ index 815a8c131239..fbe3d0edc961 100644
  		clocks = <&cru PCLK_HDMI_CTRL>,
  			 <&cru SCLK_HDMI_SFR>,
 
-From d86ec6e344fc83fabab6894a28d529b92f44886a Mon Sep 17 00:00:00 2001
+From caa58eaa7cec6e36cdd4e3ec91757f01504b5f2e Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 19 Aug 2018 23:10:05 +0200
 Subject: [PATCH] arm64: dts: rk3399-rockpro64: update dts
 
 ---
- arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts | 420 +++++++++-------------
- 1 file changed, 175 insertions(+), 245 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts | 421 +++++++++-------------
+ 1 file changed, 175 insertions(+), 246 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
-index 02b8ba7dcc94..fafefcf3617e 100644
+index 02b8ba7dcc94..aa1aee547036 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
 @@ -8,23 +8,33 @@
@@ -6828,7 +6824,7 @@ index 02b8ba7dcc94..fafefcf3617e 100644
  	supports-sdio;
  	bus-width = <4>;
  	disable-wp;
-@@ -707,35 +731,51 @@
+@@ -707,35 +731,50 @@
  	pinctrl-names = "default";
  	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
  	sd-uhs-sdr104;
@@ -6838,7 +6834,7 @@ index 02b8ba7dcc94..fafefcf3617e 100644
  
  &sdhci {
  	bus-width = <8>;
- 	mmc-hs200-1_8v;
+-	mmc-hs200-1_8v;
  	mmc-hs400-1_8v;
 +	mmc-hs400-enhanced-strobe;
 +	supports-emmc;
@@ -6885,7 +6881,7 @@ index 02b8ba7dcc94..fafefcf3617e 100644
  &tcphy0 {
  	extcon = <&fusb0>;
  	status = "okay";
-@@ -826,114 +866,15 @@
+@@ -826,114 +865,15 @@
  	status = "okay";
  };
  
@@ -7004,7 +7000,7 @@ index 02b8ba7dcc94..fafefcf3617e 100644
  };
  
  &pinctrl {
-@@ -951,6 +892,13 @@
+@@ -951,6 +891,13 @@
  		};
  	};
  
@@ -7018,7 +7014,7 @@ index 02b8ba7dcc94..fafefcf3617e 100644
  	pcie {
  		pcie_pwr_en: pcie-pwr-en {
  			rockchip,pins =
-@@ -982,6 +930,7 @@
+@@ -982,6 +929,7 @@
  	sdio-pwrseq {
  		wifi_enable_h: wifi-enable-h {
  			rockchip,pins =
@@ -7026,7 +7022,7 @@ index 02b8ba7dcc94..fafefcf3617e 100644
  				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
-@@ -1085,35 +1034,6 @@
+@@ -1085,35 +1033,6 @@
  	status = "okay";
  };
  
@@ -7062,17 +7058,17 @@ index 02b8ba7dcc94..fafefcf3617e 100644
  &vdec_mmu {
  	status = "okay";
  };
-@@ -1135,3 +1055,13 @@
+@@ -1135,3 +1054,13 @@
  &vopb_mmu {
  	status = "okay";
  };
 +
 +&vopl {
-+	status = "okay";
++	status = "disabled";
 +	assigned-clocks = <&cru DCLK_VOP1_DIV>;
 +	assigned-clock-parents = <&cru PLL_CPLL>;
 +};
 +
 +&vopl_mmu {
-+	status = "okay";
++	status = "disabled";
 +};


### PR DESCRIPTION
This PR updates some rockchip patches, ~~bootloader blobs,~~ rkmpp to latest version and kodi to beta 4.

Changes:
- Fix for emmc boot issue on Tinker Board S
- Possible to select YCbCr 4:2:2 or 4:4:4 output in Kodi
- YUV framebuffers is no longer clipped to 16-235/240 by Video Output Processor
- rkmppdec should now stop after 100 consecutive error frames
- Display Port disabled on RockPro64 to workaround 4K issue
- Add some dmt resolution clocks on RK3288 (2560x1440@60Hz and more)
- Fix inverted led on box-z28

Currently only runtime tested on Rock64 and Tinker Board S