### PR TITLE
project/generic: use mtune=generic

### DIFF
--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -10,7 +10,7 @@
   TARGET_KERNEL_ARCH=x86
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=$TARGET_CPU -m64"
+  TARGET_CFLAGS="-march=$TARGET_CPU -m64 -mmmx -msse -msse2 -mfpmath=sse"
   TARGET_LDFLAGS="-march=$TARGET_CPU -m64"
 
 # build with SIMD support ( yes / no )

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -49,7 +49,7 @@
 ################################################################################
 
   # Project CFLAGS
-    PROJECT_CFLAGS="-mmmx -msse -msse2 -mfpmath=sse"
+    PROJECT_CFLAGS=""
 
   # SquashFS compression method (gzip / lzo / xz / zstd)
     SQUASHFS_COMPRESSION="gzip"

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -49,7 +49,7 @@
 ################################################################################
 
   # Project CFLAGS
-    PROJECT_CFLAGS=""
+    PROJECT_CFLAGS="-mtune=generic"
 
   # SquashFS compression method (gzip / lzo / xz / zstd)
     SQUASHFS_COMPRESSION="gzip"


### PR DESCRIPTION
@MilhouseVH @5schatten 

This should be a "free" performance improvement for Generic. march=x86_64 compiles for what every x86-64 processor should have. mtune=generic adds instructions to suit 'most common' x86-64 processors at the time of the GCC major release.

I compiled enough of a Generic project to confirm the flags were in place, but don't have available hardware for benchmarking.