### PR TITLE
xf86-video-nvidia: update to xf86-video-nvidia-410.73

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="xf86-video-nvidia"
 # Remember to run "python packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py" and commit changes to
 # "packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules" whenever bumping version.
 # Host may require installation of python-lxml and python-requests packages.
-PKG_VERSION="410.66"
-PKG_SHA256="c4e297ed93341841c7ccb32569c179baecbb6ea253215cbc3668a51d729227cd"
+PKG_VERSION="410.73"
+PKG_SHA256="7d6b6c9931f8b89404149a5fdf7a580edae0cd567cc2d4ffe3823b1af02a705d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.nvidia.com/"


### PR DESCRIPTION
Announcement: [410.73](https://devtalk.nvidia.com/default/topic/1043354)

No new PCI IDs this time - the "new" cards supported with this driver were already supported by 410.66.