### PR TITLE
squeezelite: link instead dlopen again and update

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
@@ -2,13 +2,18 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squeezelite"
-PKG_VERSION="b2ed99e"
-PKG_SHA256="9773543d6565481c519fb73d42d59a25a2940bfbb39b48ce81054cd9dd24e2a9"
+PKG_VERSION="ecb6e3696a42113994640e5345d0b5ca2e77d28b"
+PKG_SHA256="b0fbded72fbf400613b5cb071bc0efdaddaeba6b4ba32b1de9b24098c505b40b"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ralph-irving/squeezelite"
 PKG_URL="https://github.com/ralph-irving/squeezelite/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain faad2 ffmpeg flac libmad libvorbis mpg123 soxr libogg"
 PKG_LONGDESC="A client for the Logitech Media Server."
+
+pre_make_target() {
+  export OPTS="-DDSD -DFFMPEG -DRESAMPLE -DVISEXPORT -DLINKALL"
+  export LIBS="-lvorbis -logg"
+}
 
 makeinstall_target() {
   :

--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/patches/squeezelite-01-makefile.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/patches/squeezelite-01-makefile.patch
@@ -1,0 +1,11 @@
+--- a/Makefile	2018-05-07 14:06:07.000000000 +0200
++++ b/Makefile	2018-10-25 19:08:15.000000000 +0200
+@@ -103,7 +103,7 @@
+ all: $(EXECUTABLE)
+ 
+ $(EXECUTABLE): $(OBJECTS)
+-	$(CC) $(OBJECTS) $(LDFLAGS) $(LDADD) -o $@
++	$(CC) $(OBJECTS) $(LDFLAGS) $(LDADD) $(LIBS) -o $@
+ 
+ $(OBJECTS): $(DEPS)
+ 

--- a/packages/addons/tools/multimedia-tools/changelog.txt
+++ b/packages/addons/tools/multimedia-tools/changelog.txt
@@ -1,3 +1,6 @@
+109
+- Update squeezelite to b2ed99e and support all possible media formats
+
 108
 - Update alsamixer to 1.1.6
 - Update mediainfo to 18.05

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="108"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
Linking (#2289) got lost on update.

There is a bug report on [forum](https://forum.libreelec.tv/thread/5887-multimedia-tools-squeezelite-missing-libraries-solved/?postID=101027#post101027).

Needs testing, I'm not using Logitech Media Server.