### PR TITLE
getedid: Fixed typo in order to make "getedid delete" work again

### DIFF
--- a/packages/sysutils/busybox/scripts/getedid
+++ b/packages/sysutils/busybox/scripts/getedid
@@ -42,7 +42,7 @@ check_gpu() {
 
 # run this first if the user already has a custom EDID but want to create a new one (TV or AVR change)
 del_edid() {
-  if [ "$gpu" = "intel" ]; then
+  if [ "$gpu" = "intel/amd" ]; then
     check_file
     if [ -f "$file".old ];  then
       mount_rw


### PR DESCRIPTION
"getedid delete" did not work because of the use of the wrong $gpu variable output "intel" which should read "intel/amd"