### PR TITLE
getedid: added the active HDMI/DP port to new kernel parameters

### DIFF
--- a/packages/sysutils/busybox/scripts/getedid
+++ b/packages/sysutils/busybox/scripts/getedid
@@ -183,7 +183,7 @@ intel_amd() {
   if [ "$kernel" -lt "415000" ]; then
     sed -i "/ APPEND/s/$/ initrd=\/edid.cpio drm_kms_helper.edid_firmware=$hdmi:edid\/edid.bin video=$hdmi:D/" "$file"
   else
-    sed -i "/ APPEND/s/$/ initrd=\/edid.cpio drm.edid_firmware=edid\/edid.bin/" "$file"
+    sed -i "/ APPEND/s/$/ initrd=\/edid.cpio drm.edid_firmware=edid\/edid.bin video=$hdmi:D/" "$file"
   fi
 
   #reboot


### PR DESCRIPTION
Added the active HDMI/DP port to kernel parameters. 

Without it, fixed EDID does not work on Intel Haswell and possibly others.