### PR TITLE
kodi: more easily support user configuration

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 KODI_ROOT=$HOME/.kodi
 
@@ -38,3 +39,5 @@ if [ "$(uname -m)" = "x86_64" -o "$(uname -m)" = "aarch64" ]; then
 else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf
 fi
+
+[ -f /storage/.config/kodi.conf ] && cat /storage/.config/kodi.conf >>/run/libreelec/kodi.conf


### PR DESCRIPTION
This allows the user to more easily configure the Kodi service without having to add entries to /storage/.config/autostart.sh which append environment variables to /run/libreelec/debug/kodi.conf etc.

This also ensures that the users settings are loaded after the standard system kodi config.

Every now and again it's sometimes necessary for users to force a specific version of GL/GLX, or some other behaviour, and this change should simplify the steps needed to achieve that.

Obviously this could result in users configuring an environment variable that results in breakage or sub-optimal performance of the Kodi service in the future, but that's something they can do today, just with more faffing about.