### PR TITLE
Amlogic/update.sh: fix issues with binary compatability using UUIDs

### DIFF
--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -52,20 +52,6 @@ makeinstall_target() {
     # Always install the update script
     find_file_path bootloader/update.sh && cp -av ${FOUND_PATH} $INSTALL/usr/share/bootloader
 
-    # Replace partition names in update.sh
-    if [ -f "$INSTALL/usr/share/bootloader/update.sh" ] ; then
-      sed -e "s/@BOOT_LABEL@/$DISTRO_BOOTLABEL/g" \
-          -e "s/@DISK_LABEL@/$DISTRO_DISKLABEL/g" \
-          -i $INSTALL/usr/share/bootloader/update.sh
-    fi
-
-    # Replace labels in boot.ini
-    if [ -f "$INSTALL/usr/share/bootloader/boot.ini" ] ; then
-      sed -e "s/@BOOT_LABEL@/$DISTRO_BOOTLABEL/g" \
-          -e "s/@DISK_LABEL@/$DISTRO_DISKLABEL/g" \
-          -i $INSTALL/usr/share/bootloader/boot.ini
-    fi
-
     # Always install the canupdate script
     if find_file_path bootloader/canupdate.sh; then
       cp -av ${FOUND_PATH} $INSTALL/usr/share/bootloader

--- a/projects/Amlogic/bootloader/mkimage
+++ b/projects/Amlogic/bootloader/mkimage
@@ -18,7 +18,11 @@ if [ -f "$RELEASE_DIR/3rdparty/bootloader/u-boot" ]; then
 fi
 
 if [ -f "$RELEASE_DIR/3rdparty/bootloader/boot.ini" ]; then
-  mcopy $RELEASE_DIR/3rdparty/bootloader/boot.ini ::
+  cp -p "$RELEASE_DIR/3rdparty/bootloader/boot.ini" "$LE_TMP/boot.ini"
+  sed -e "s/@BOOT_UUID@/$UUID_SYSTEM/" \
+      -e "s/@DISK_UUID@/$UUID_STORAGE/" \
+      -i "$LE_TMP/boot.ini"
+  mcopy "$LE_TMP/boot.ini" ::
 fi
 
 if [ -f "$RELEASE_DIR/3rdparty/bootloader/config.ini" ]; then

--- a/projects/Amlogic/bootloader/update.sh
+++ b/projects/Amlogic/bootloader/update.sh
@@ -6,8 +6,10 @@
 [ -z "$SYSTEM_ROOT" ] && SYSTEM_ROOT=""
 [ -z "$BOOT_ROOT" ] && BOOT_ROOT="/flash"
 [ -z "$UPDATE_DIR" ] && UPDATE_DIR="/storage/.update"
+
 UPDATE_DTB_IMG="$UPDATE_DIR/dtb.img"
-UPDATE_DTB=`ls -1 "$UPDATE_DIR"/*.dtb 2>/dev/null | head -n 1`
+UPDATE_DTB="$(ls -1 "$UPDATE_DIR"/*.dtb 2>/dev/null | head -n 1)"
+
 [ -z "$BOOT_PART" ] && BOOT_PART=$(df "$BOOT_ROOT" | tail -1 | awk {' print $1 '})
 if [ -z "$BOOT_DISK" ]; then
   case $BOOT_PART in

--- a/projects/Amlogic/devices/KVIM/bootloader/boot.ini
+++ b/projects/Amlogic/devices/KVIM/bootloader/boot.ini
@@ -8,7 +8,7 @@
 #------------------------------------------------------------------------------------------------------
 KHADAS-UBOOT-CONFIG
 
-setenv bootrootfs "BOOT_IMAGE=kernel.img boot=LABEL=@BOOT_LABEL@ disk=LABEL=@DISK_LABEL@"
+setenv bootrootfs "BOOT_IMAGE=kernel.img boot=UUID=@BOOT_UUID@ disk=UUID=@DISK_UUID@"
 setenv condev "ttyS0,115200"
 setenv hdmimode "1080p60hz"
 setenv hdmioutput   "1"

--- a/projects/Amlogic/devices/KVIM2/bootloader/boot.ini
+++ b/projects/Amlogic/devices/KVIM2/bootloader/boot.ini
@@ -8,7 +8,7 @@
 #------------------------------------------------------------------------------------------------------
 KHADAS-UBOOT-CONFIG
 
-setenv bootrootfs "BOOT_IMAGE=kernel.img boot=LABEL=@BOOT_LABEL@ disk=LABEL=@DISK_LABEL@"
+setenv bootrootfs "BOOT_IMAGE=kernel.img boot=UUID=@BOOT_UUID@ disk=UUID=@DISK_UUID@"
 setenv condev "ttyS0,115200"
 setenv hdmimode "1080p60hz"
 setenv hdmioutput   "1"

--- a/projects/Amlogic/devices/LePotato/bootloader/boot.ini
+++ b/projects/Amlogic/devices/LePotato/bootloader/boot.ini
@@ -8,7 +8,7 @@
 #------------------------------------------------------------------------------------------------------
 LIBRETECH-UBOOT-CONFIG
 
-setenv bootrootfs "BOOT_IMAGE=kernel.img boot=LABEL=@BOOT_LABEL@ disk=LABEL=@DISK_LABEL@"
+setenv bootrootfs "BOOT_IMAGE=kernel.img boot=UUID=@BOOT_UUID@ disk=UUID=@DISK_UUID@"
 setenv condev "ttyS0,115200"
 setenv hdmimode "1080p60hz"
 setenv hdmioutput   "1"

--- a/projects/Amlogic/devices/Odroid_C2/bootloader/boot.ini
+++ b/projects/Amlogic/devices/Odroid_C2/bootloader/boot.ini
@@ -8,7 +8,7 @@
 #------------------------------------------------------------------------------------------------------
 ODROIDC2-UBOOT-CONFIG
 
-setenv bootrootfs "BOOT_IMAGE=KERNEL boot=LABEL=@BOOT_LABEL@ disk=LABEL=@DISK_LABEL@"
+setenv bootrootfs "BOOT_IMAGE=KERNEL boot=UUID=@BOOT_UUID@ disk=UUID=@DISK_UUID@"
 setenv condev "ttyS0,115200"
 setenv hdmimode "1080p60hz"
 setenv hdmioutput   "1"

--- a/projects/Amlogic/packages/u-boot/package.mk
+++ b/projects/Amlogic/packages/u-boot/package.mk
@@ -73,18 +73,4 @@ makeinstall_target() {
         cp -av $PKG_BUILD/fip/u-boot.bin.sd.bin $INSTALL/usr/share/bootloader/u-boot
         ;;
     esac
-
-    # Replace partition names in update.sh
-    if [ -f "$INSTALL/usr/share/bootloader/update.sh" ] ; then
-      sed -e "s/@BOOT_LABEL@/$DISTRO_BOOTLABEL/g" \
-          -e "s/@DISK_LABEL@/$DISTRO_DISKLABEL/g" \
-          -i $INSTALL/usr/share/bootloader/update.sh
-    fi
-
-    # Replace labels in boot.ini
-    if [ -f "$INSTALL/usr/share/bootloader/boot.ini" ] ; then
-      sed -e "s/@BOOT_LABEL@/$DISTRO_BOOTLABEL/g" \
-          -e "s/@DISK_LABEL@/$DISTRO_DISKLABEL/g" \
-          -i $INSTALL/usr/share/bootloader/boot.ini
-    fi
 }


### PR DESCRIPTION
Cross-grading (aarch64 to arm, and vice versa) is [broken](https://forum.libreelec.tv/thread/13542-how-to-integrate-driver-for-geniatech-dvb-t2-stick-into-libreelec).

Use UUIDs to avoid overriding the users choice of partition label (which may have been made to avoid a LABEL clash) or adding missing partition labels, using binaries that can't be executed.

I've not changed [platform_init](https://github.com/LibreELEC/LibreELEC.tv/blob/76ed87318661962a72cb61f3dd55efbaba709d10/projects/Amlogic/initramfs/platform_init#L32), because I'm not sure if we need it, or who uses it.