### PR TITLE
cputemp: give RPi SoC sensor priority

### DIFF
--- a/packages/mediacenter/kodi/scripts/cputemp
+++ b/packages/mediacenter/kodi/scripts/cputemp
@@ -46,13 +46,14 @@ if [ "$1" = "cpu" -o "$TEMP" = "0" ]; then
     fi
   done
 
-  if [ "$TEMP" = "0" -a -f /sys/class/hwmon/hwmon0/device/temp1_input ]; then
-    TEMP="$(cat /sys/class/hwmon/hwmon0/device/temp1_input)"
-  fi
-
   # used on RaspberryPi and 3.14 kernel amlogic
   if [ "$TEMP" = "0" -a -f /sys/class/thermal/thermal_zone0/temp ]; then
     TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
+  fi
+
+  # other temp sensor, possibly GPIO based (and not a SOC sensor)
+  if [ "$TEMP" = "0" -a -f /sys/class/hwmon/hwmon0/device/temp1_input ]; then
+    TEMP="$(cat /sys/class/hwmon/hwmon0/device/temp1_input)"
   fi
 
   TEMP="$(( $TEMP / 1000 ))"


### PR DESCRIPTION
See: https://forum.libreelec.tv/thread/12662-libreelec-9-0-reborn-remix-emulationstation-retroarch-dolphinqt-moonlight-chrome/?postID=102667#post102667

When an RPi is configured with `dtoverlay w1-gpio gpiopin=4` (and the relevant temperature sensing hardware is connected to the GPIO pins so that a non-zero temperature is registered) then an extra temperature input becomes available which is misinterpreted as the SoC temperature.