### PR TITLE
kodi: use project specific cputemp scripts for all projects

### DIFF
--- a/packages/mediacenter/kodi/config/advancedsettings.xml
+++ b/packages/mediacenter/kodi/config/advancedsettings.xml
@@ -1,4 +1,7 @@
 <advancedsettings>
+  <cputempcommand>/usr/bin/cputemp</cputempcommand>
+  <gputempcommand>/usr/bin/gputemp</gputempcommand>
+
   <showexitbutton>false</showexitbutton>
   <remotedelay>1</remotedelay>
   <samba>

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -274,8 +274,6 @@ post_makeinstall_target() {
     cp $PKG_DIR/scripts/service-addon-wrapper $INSTALL/usr/sbin
 
   mkdir -p $INSTALL/usr/bin
-    cp $PKG_DIR/scripts/cputemp $INSTALL/usr/bin
-      ln -sf cputemp $INSTALL/usr/bin/gputemp
     cp $PKG_DIR/scripts/kodi-remote $INSTALL/usr/bin
     cp $PKG_DIR/scripts/setwakeup.sh $INSTALL/usr/bin
 

--- a/projects/Amlogic/filesystem/usr/bin/cputemp
+++ b/projects/Amlogic/filesystem/usr/bin/cputemp
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
+echo "$(( $TEMP / 1000 )) C"

--- a/projects/Amlogic/filesystem/usr/bin/gputemp
+++ b/projects/Amlogic/filesystem/usr/bin/gputemp
@@ -1,0 +1,1 @@
+/usr/bin/cputemp

--- a/projects/Amlogic/kodi/advancedsettings.xml
+++ b/projects/Amlogic/kodi/advancedsettings.xml
@@ -1,4 +1,0 @@
-<advancedsettings>
-  <cputempcommand>cputemp</cputempcommand>
-  <gputempcommand>gputemp</gputempcommand>
-</advancedsettings>

--- a/projects/Generic/filesystem/usr/bin/cputemp
+++ b/projects/Generic/filesystem/usr/bin/cputemp
@@ -4,9 +4,6 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-# inspired by
-# https://github.com/xtranophilist/gnome-shell-extension-cpu-temperature/blob/master/extension.js
-
 TEMP=0
 
 if [ $(basename "$0") = "gputemp" -o "$1" = "gpu" ]; then
@@ -29,7 +26,6 @@ if [ $(basename "$0") = "gputemp" -o "$1" = "gpu" ]; then
     done
 
     TEMP="$(( $TEMP / 1000 ))"
-
   fi
 fi
 
@@ -48,11 +44,6 @@ if [ "$1" = "cpu" -o "$TEMP" = "0" ]; then
 
   if [ "$TEMP" = "0" -a -f /sys/class/hwmon/hwmon0/device/temp1_input ]; then
     TEMP="$(cat /sys/class/hwmon/hwmon0/device/temp1_input)"
-  fi
-
-  # used on RaspberryPi and 3.14 kernel amlogic
-  if [ "$TEMP" = "0" -a -f /sys/class/thermal/thermal_zone0/temp ]; then
-    TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
   fi
 
   TEMP="$(( $TEMP / 1000 ))"

--- a/projects/Generic/filesystem/usr/bin/gputemp
+++ b/projects/Generic/filesystem/usr/bin/gputemp
@@ -1,0 +1,1 @@
+/usr/bin/cputemp

--- a/projects/Generic/kodi/advancedsettings.xml
+++ b/projects/Generic/kodi/advancedsettings.xml
@@ -1,6 +1,4 @@
 <advancedsettings>
-  <cputempcommand>cputemp</cputempcommand>
-  <gputempcommand>gputemp</gputempcommand>
   <video>
     <latency>
       <delay>0</delay>

--- a/projects/RPi/filesystem/usr/bin/cputemp
+++ b/projects/RPi/filesystem/usr/bin/cputemp
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
+echo "$(( $TEMP / 1000 )) C"

--- a/projects/RPi/filesystem/usr/bin/gputemp
+++ b/projects/RPi/filesystem/usr/bin/gputemp
@@ -1,0 +1,1 @@
+/usr/bin/cputemp

--- a/projects/Rockchip/filesystem/usr/bin/cputemp
+++ b/projects/Rockchip/filesystem/usr/bin/cputemp
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
+echo "$(( $TEMP / 1000 )) C"

--- a/projects/Rockchip/filesystem/usr/bin/gputemp
+++ b/projects/Rockchip/filesystem/usr/bin/gputemp
@@ -1,0 +1,1 @@
+/usr/bin/cputemp

--- a/projects/WeTek_Core/filesystem/usr/bin/cputemp
+++ b/projects/WeTek_Core/filesystem/usr/bin/cputemp
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
+echo "$(( $TEMP / 1000 )) C"

--- a/projects/WeTek_Core/filesystem/usr/bin/gputemp
+++ b/projects/WeTek_Core/filesystem/usr/bin/gputemp
@@ -1,0 +1,1 @@
+/usr/bin/cputemp

--- a/projects/WeTek_Core/kodi/advancedsettings.xml
+++ b/projects/WeTek_Core/kodi/advancedsettings.xml
@@ -1,4 +1,0 @@
-<advancedsettings>
-  <cputempcommand>cputemp</cputempcommand>
-  <gputempcommand>gputemp</gputempcommand>
-</advancedsettings>

--- a/projects/WeTek_Play/filesystem/usr/bin/cputemp
+++ b/projects/WeTek_Play/filesystem/usr/bin/cputemp
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
+echo "$(( $TEMP / 1000 )) C"

--- a/projects/WeTek_Play/filesystem/usr/bin/gputemp
+++ b/projects/WeTek_Play/filesystem/usr/bin/gputemp
@@ -1,0 +1,1 @@
+/usr/bin/cputemp

--- a/projects/WeTek_Play/kodi/advancedsettings.xml
+++ b/projects/WeTek_Play/kodi/advancedsettings.xml
@@ -1,4 +1,0 @@
-<advancedsettings>
-  <cputempcommand>cputemp</cputempcommand>
-  <gputempcommand>gputemp</gputempcommand>
-</advancedsettings>


### PR DESCRIPTION
1) All projects other than RPi and Rockchip use the `cputemp`/`gputemp` setting in Kodi `advancedsettings.xml`. This means that RPi (and potentially Rockchip) are at the mercy of Kodi to get it right (which doesn't always happen: see #3073)

    With this PR, all projects now use the `cputemp` and `gputemp` scripts.

2) The current `cputemp` script includes logic for all platforms, even old kernels. This is unnecessary when most platforms and kernels use only a single path for the CPU temp.

    With this PR, all projects now use only the path(s) necessary to return the CPU temp for the current kernel.

This means that Amlogic (and possibly others) will need to amend this script when using the mainline kernel. Allwinner - which apparently has a gpu temp sensor - may need to differentiate between `cputemp` and `gputemp` based on the script name (see Generic version for details).

Please can the various project maintainers check that I have used the correct /sysfs path for the CPU temperature sensor (based on current LE master kernels). Thanks.

- [x] RPi
- [x] Generic
- [x] Rockchip (same as RPi)
- [ ] Amlogic (3.10/3.14)
- [ ] WeTek_Core
- [ ] WeTek_Play