### PR TITLE
buildsystem: unpacking / extracting cleanup

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -934,8 +934,7 @@ install_addon_files() {
 
 install_driver_addon_files() {
   if [ "$#" -eq 0 ] ; then
-    printf "$(print_color CLR_ERROR "no module search path defined")\n"
-    die
+    die "$(print_color CLR_ERROR "no module search path defined")"
   fi
 
   PKG_MODULE_DIR="$INSTALL/$(get_full_module_dir $PKG_ADDON_ID)/updates/$PKG_ADDON_ID"

--- a/scripts/build
+++ b/scripts/build
@@ -2,11 +2,12 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 . config/options $1
 
 if [ "$1" = "--all" ]; then
-  if [ ! -z "$2" ]; then
+  if [ -n "$2" ]; then
     for build_dir in $(ls -1d ${ROOT}/build.*); do
       load_build_config ${build_dir} && ./scripts/build $2
     done
@@ -15,13 +16,11 @@ if [ "$1" = "--all" ]; then
 fi
 
 if [ -z "$1" ]; then
-  echo "usage: $0 package_name[:<host|target|init|bootstrap>]"
-  exit 1
+  die "usage: $0 package_name[:<host|target|init|bootstrap>]"
 fi
 
 if [ ! -f $PKG_DIR/package.mk ]; then
-  printf "$(print_color CLR_ERROR "$1: no package.mk file found")\n"
-  exit 1
+  die "$(print_color CLR_ERROR "$1: no package.mk file found")"
 fi
 
 # set defaults
@@ -36,7 +35,7 @@ else
   PACKAGE_NAME=$1
   TARGET=
 fi
-[ -z "$TARGET" ] && TARGET="target"
+TARGET="${TARGET:-target}"
 
 if [ -n "$PKG_ARCH" ]; then
   listcontains "$PKG_ARCH" "!$TARGET_ARCH" && exit 0
@@ -53,15 +52,11 @@ $SCRIPTS/unpack $PACKAGE_NAME
 if [ -f $STAMP ] ; then
   . $STAMP
   PKG_DEEPHASH=$(calculate_stamp)
-  if [ ! "$PKG_DEEPHASH" = "$STAMP_PKG_DEEPHASH" ] ; then
+  if [ ! "$PKG_DEEPHASH" = "$STAMP_PKG_DEEPHASH" ]; then
     rm -f $STAMP
-  fi
-
-  if [ ! "$BUILD_WITH_DEBUG" = "$STAMP_BUILD_WITH_DEBUG" ]; then
+  elif [ ! "$BUILD_WITH_DEBUG" = "$STAMP_BUILD_WITH_DEBUG" ]; then
     rm -f $STAMP
-  fi
-
-  if [ "$1" = "u-boot" -a ! "$UBOOT_SYSTEM" = "$STAMP_UBOOT_SYSTEM" ]; then
+  elif [ "$1" = "u-boot" -a ! "$UBOOT_SYSTEM" = "$STAMP_UBOOT_SYSTEM" ]; then
     rm -f $STAMP
   fi
 fi
@@ -232,32 +227,26 @@ fi
 
 # configure other variables
 if [ "$TARGET" = "target" ]; then
-  INSTALL=$PKG_BUILD/.install_pkg
+  INSTALL="$PKG_BUILD/.install_pkg"
 elif [ "$TARGET" = "init" ]; then
-  INSTALL=$PKG_BUILD/.install_init
+  INSTALL="$PKG_BUILD/.install_init"
 fi
 
-# clean up
-if [ ! -z "$INSTALL" ] ; then
-  if [ -d "$INSTALL" ] ; then
-    rm -rf $INSTALL
-  fi
+# clear previous image files
+if [ -n "$INSTALL" -a -d "$INSTALL" ]; then
+  rm -rf "$INSTALL"
 fi
 
-# setup configure script
+# setup configure scripts
 if [ -z "$PKG_CONFIGURE_SCRIPT" ]; then
   PKG_CONFIGURE_SCRIPT="$PKG_BUILD/configure"
 else
   PKG_CONFIGURE_SCRIPT="$PKG_BUILD/$PKG_CONFIGURE_SCRIPT"
 fi
 
-if [ -z "$PKG_CMAKE_SCRIPT" ]; then
-  PKG_CMAKE_SCRIPT="$PKG_BUILD/CMakeLists.txt"
-fi
+PKG_CMAKE_SCRIPT="${PKG_CMAKE_SCRIPT:-$PKG_BUILD/CMakeLists.txt}"
 
-if [ -z "$PKG_MESON_SCRIPT" ]; then
-  PKG_MESON_SCRIPT="$PKG_BUILD/meson.build"
-fi
+PKG_MESON_SCRIPT="${PKG_MESON_SCRIPT:-$PKG_BUILD/meson.build}"
 
 # auto detect toolchain
 _auto_toolchain=""
@@ -268,17 +257,15 @@ if [ -z "$PKG_TOOLCHAIN" -o "$PKG_TOOLCHAIN" = "auto" ]; then
     PKG_TOOLCHAIN="cmake"
   elif [ -f "$PKG_CONFIGURE_SCRIPT" ]; then
     PKG_TOOLCHAIN="configure"
-  elif [ -f $PKG_BUILD/Makefile ]; then
+  elif [ -f "$PKG_BUILD/Makefile" ]; then
     PKG_TOOLCHAIN="make"
   else
-    echo "Not possible to detect toolchain automatically. Add PKG_TOOLCHAIN= to package.mk"
-    exit 1
+    die "Not possible to detect toolchain automatically. Add PKG_TOOLCHAIN= to package.mk"
   fi
   _auto_toolchain=" (auto-detect)"
 fi
 if ! listcontains "meson cmake cmake-make configure ninja make autotools manual" "$PKG_TOOLCHAIN"; then
-  printf "$(print_color bold-red "ERROR:") unknown toolchain $PKG_TOOLCHAIN"
-  exit 1
+  die "$(print_color bold-red "ERROR:") unknown toolchain $PKG_TOOLCHAIN"
 fi
 printf "%${BUILD_INDENT}c $(print_color CLR_TOOLCHAIN "TOOLCHAIN")    $PKG_TOOLCHAIN${_auto_toolchain}\n" ' '>&$SILENT_OUT
 
@@ -293,11 +280,11 @@ if [ "$(type -t pre_build_$TARGET)" = "function" ]; then
 fi
 
 # ensure $PKG_BUILD is there. (installer? PKG_URL="")
-if [ ! -d $PKG_BUILD ] ; then
-  mkdir -p $PKG_BUILD
+if [ ! -d "$PKG_BUILD" ] ; then
+  mkdir -p "$PKG_BUILD"
 fi
 
-cd $PKG_BUILD
+cd "$PKG_BUILD"
 
 if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" -o -f "$PKG_MESON_SCRIPT" ]; then
   case "$TARGET" in
@@ -306,9 +293,9 @@ if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" -o -f "$PKG_MESON_SCRI
     "init")      PKG_REAL_BUILD="$PKG_BUILD/.$TARGET_NAME-$TARGET" ;;
     "bootstrap") PKG_REAL_BUILD="$PKG_BUILD/.$HOST_NAME-$TARGET" ;;
   esac
-  mkdir -p $PKG_REAL_BUILD
-  cd $PKG_REAL_BUILD
-  
+  mkdir -p "$PKG_REAL_BUILD"
+  cd "$PKG_REAL_BUILD"
+
   MESON_CONF="$PKG_REAL_BUILD/meson.conf"
 fi
 
@@ -494,7 +481,7 @@ if [ "$(type -t post_makeinstall_$TARGET)" = "function" ]; then
 fi
 
 if [ "$TARGET" = "target" -o "$TARGET" = "init" ]; then
-  if [ -d $INSTALL ] ; then
+  if [ -d $INSTALL ]; then
     rm -rf $INSTALL/{usr/,}include
     rm -rf $INSTALL/{usr/,}lib/cmake
     rm -rf $INSTALL/{usr/,}lib/pkgconfig
@@ -520,26 +507,26 @@ if [ "$TARGET" = "target" -o "$TARGET" = "init" ]; then
     find $INSTALL -type d -exec rmdir -p {} \; 2>/dev/null || :
 
     if [ ! "${BUILD_WITH_DEBUG}" = "yes" ]; then
-      $STRIP `find $INSTALL \
+      $STRIP $(find $INSTALL \
         -type f -name "*.so*" \
         ! -name "ld-*.so" \
         ! -name "libc-*.so" \
         ! -name "libpthread-*.so" \
         ! -name "libthread_db-*so" \
-        2>/dev/null` 2>/dev/null || :
+        2>/dev/null) 2>/dev/null || :
         if [ "$TARGET" = "init" ]; then
-          $STRIP `find $INSTALL -type f -name "*.so*" 2>/dev/null` 2>/dev/null || :
+          $STRIP $(find $INSTALL -type f -name "*.so*" 2>/dev/null) 2>/dev/null || :
         fi
-        $STRIP `find $INSTALL/bin $INSTALL/usr/bin $INSTALL/sbin $INSTALL/usr/sbin \
-          -type f -executable 2>/dev/null` 2>/dev/null || :
+        $STRIP $(find $INSTALL/bin $INSTALL/usr/bin $INSTALL/sbin $INSTALL/usr/sbin \
+          -type f -executable 2>/dev/null) 2>/dev/null || :
     fi
   fi
 fi
 
 cd $ROOT
 
-for i in `find $SYSROOT_PREFIX/usr/lib/ -name "*.la" 2>/dev/null`; do \
-  $SED "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $i; \
+for i in $(find $SYSROOT_PREFIX/usr/lib/ -name "*.la" 2>/dev/null); do
+  sed -e "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $i
 done
 
 PKG_DEEPHASH=$(calculate_stamp)

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -93,9 +93,9 @@ function find_addons() {
 
     # abort when nothing found and not embedded
     if [ $? -ne 0 ]; then
-      printf  "$(print_color CLR_ERROR "ERROR: '$1' matches nothing...")\n" ' '>&$SILENT_OUT
-      printf  "for more informations type: ./scripts/create_addon --help\n" ' '>&$SILENT_OUT
-      exit 1
+      echo  "$(print_color CLR_ERROR "ERROR: '$1' matches nothing...")" >&$SILENT_OUT
+      echo  "for more informations type: ./scripts/create_addon --help" >&$SILENT_OUT
+      die
     fi
   fi
 
@@ -297,13 +297,13 @@ for addon in $(tr " " "\n" <<< $addons | sort -u); do
   fi
 
   # build package
-  printf "$(print_color CLR_BUILD "CREATE ADDON $addon") (${DEVICE:-$PROJECT}/$TARGET_ARCH)\n" ' '>&$SILENT_OUT
+  echo "$(print_color CLR_BUILD "CREATE ADDON $addon") (${DEVICE:-$PROJECT}/$TARGET_ARCH)" >&$SILENT_OUT
   _count+='x'
   ( build_addon $addon ) \
     2>&1 | tee $log_file
   if [ ${PIPESTATUS[0]} != 0 ]; then
     addons_failed+="$addon "
-    printf "$(print_color CLR_ERROR "ADDON FAILED $addon")\n" ' '>&$SILENT_OUT
+    echo "$(print_color CLR_ERROR "ADDON FAILED $addon")" >&$SILENT_OUT
     echo "failed: ${addon}" >> $summary_file
   else
     if [ "$remove_success_logs" = "true" ]; then
@@ -321,10 +321,9 @@ fi
 # print summary
 if [ "$_count" != 'x' ]; then
   if [ -z "$addons_failed" ]; then
-    printf "$(print_color CLR_INFO "ALL ADDONS BUILDS SUCCESSFUL")\n"
+    echo "$(print_color CLR_INFO "ALL ADDONS BUILDS SUCCESSFUL")"
     exit 0
   else
-    printf "$(print_color CLR_ERROR "FAILED ADDONS: $addons_failed")\n"
-    exit 1
+    die "$(print_color CLR_ERROR "FAILED ADDONS: $addons_failed")"
   fi
 fi

--- a/scripts/extract
+++ b/scripts/extract
@@ -2,16 +2,17 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 . config/options $1
 
 if [ -z "$2" ]; then
-  echo "usage: $0 package_name target_dir"
-  exit 1
+  die "usage: $0 package_name target_dir"
 fi
 
-[ -z "$PKG_URL" -o -z "$PKG_SOURCE_NAME" ] && exit 1
-[ ! -d "$SOURCES/$1" -o ! -d "$2" ] && exit 1
+[ -z "$PKG_URL" -o -z "$PKG_SOURCE_NAME" ] && die "$PKG_NAME: PKG_URL or PKG_SOURCE_NAME undefined"
+[ ! -d "$SOURCES/$1" ] && die "$PKG_NAME: $SOURCES/$1 not found"
+[ ! -d "$2" ] && die "$PKG_NAME: target $2 not found"
 
 if [[ ${PKG_URL} =~ ^file:// ]]; then
   FULL_SOURCE_PATH="$PKG_SOURCE_NAME"
@@ -22,11 +23,11 @@ fi
 if [ ! -f "$FULL_SOURCE_PATH" -a ! -d "$FULL_SOURCE_PATH" ]; then
   echo "error: File $PKG_SOURCE_NAME doesn't exist for package $1"
   echo "Have you called scripts/extract before scripts/get ?"
-  exit 1
+  die
 fi
 
 # The build system expects packages to be extracted to
-# $BUILD/$PKG_NAME-$PKG_VERSION.
+# $PKG_BUILD.
 # Try to strip the top level dir from the archive and extract to
 # the correct directory if possible so packages don't need to
 # set PKG_SOURCE_DIR and scripts/unpack doesn't need to rename
@@ -36,11 +37,11 @@ fi
 # so advanced renaming (eg stripping more than one directory level)
 # can be performed by scripts/unpack.
 if [ -z "$PKG_SOURCE_DIR" ]; then
-	TAR_OPTS="--strip-components=1"
-	DESTDIR="$2/$PKG_NAME-$PKG_VERSION"
+  TAR_OPTS="--strip-components=1"
+  DESTDIR="$2/$PKG_NAME-$PKG_VERSION"
 else
-	TAR_OPTS=""
-	DESTDIR="$2"
+  TAR_OPTS=""
+  DESTDIR="$2"
 fi
 
 case $PKG_SOURCE_NAME in

--- a/scripts/install
+++ b/scripts/install
@@ -8,13 +8,11 @@
 . config/options $1
 
 if [ -z "$1" ]; then
-  echo "usage: $0 package_name"
-  exit 1
+  die "usage: $0 package_name"
 fi
 
 if [ -z "$INSTALL" ] ; then
-  echo "error: '\$INSTALL' not set! this script is not intended to be run manually"
-  exit 1
+  die "error: '\$INSTALL' not set! this script is not intended to be run manually"
 fi
 
 # set defaults
@@ -38,8 +36,7 @@ if [ -n "$PKG_ARCH" ]; then
 fi
 
 if [ ! -f $PKG_DIR/package.mk ]; then
-  printf "$(print_color CLR_ERROR "${PACKAGE_NAME}: no package.mk file found")\n"
-  exit 1
+  die "$(print_color CLR_ERROR "${PACKAGE_NAME}: no package.mk file found")"
 fi
 
 $SCRIPTS/build $@

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -2,22 +2,21 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 . config/options $1
 
 if [ -z "$1" ]; then
-  echo "usage: $0 package_name"
-  exit 1
+  die "usage: $0 package_name"
 fi
 
 if [ ! -f $PKG_DIR/package.mk ]; then
-  printf "$(print_color CLR_ERROR "$1: no package.mk file found")\n"
-  exit 1
+  die "$(print_color CLR_ERROR "$1: no package.mk file found")"
 fi
 
 $SCRIPTS/get $1
 
-STAMP=$PKG_BUILD/.libreelec-unpack
+STAMP="$PKG_BUILD/.libreelec-unpack"
 
 mkdir -p $BUILD
 
@@ -67,21 +66,21 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     fi
   fi
 
-  if [ ! -d $BUILD/$PKG_NAME-$PKG_VERSION ]; then
+  if [ ! -d "$PKG_BUILD" ]; then
     if [ -n "$PKG_SOURCE_DIR" ]; then
-      mv $BUILD/$PKG_SOURCE_DIR $BUILD/$PKG_NAME-$PKG_VERSION
-    elif [ -d $BUILD/$PKG_NAME-$PKG_VERSION* ]; then
-      mv $BUILD/$PKG_NAME-$PKG_VERSION* $BUILD/$PKG_NAME-$PKG_VERSION
+      mv $BUILD/$PKG_SOURCE_DIR "$PKG_BUILD"
+    elif [ -d "$PKG_BUILD"* ]; then
+      mv "$PKG_BUILD"* "$PKG_BUILD"
     fi
   fi
 
   if [ -d "$PKG_DIR/sources" ]; then
-    [ ! -d "$BUILD/${PKG_NAME}-${PKG_VERSION}" ] && mkdir -p $BUILD/${PKG_NAME}-${PKG_VERSION}
-    cp -PRf $PKG_DIR/sources/* $BUILD/${PKG_NAME}-${PKG_VERSION}
+    [ ! -d "$PKG_BUILD" ] && mkdir -p "$PKG_BUILD"
+    cp -PRf "$PKG_DIR/sources/"* "$PKG_BUILD"
   fi
 
   if [ -z "$PKG_URL" ]; then
-    mkdir -p "${BUILD}/${PKG_NAME}-${PKG_VERSION}"
+    mkdir -p "${PKG_BUILD}"
   fi
 
   if [ "$(type -t post_unpack)" = "function" ]; then
@@ -153,9 +152,9 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
       if [ -f "$i" ]; then
         printf "%${BUILD_INDENT}c $(print_color CLR_APPLY_PATCH "APPLY PATCH") $(print_color CLR_PATCH_DESC "${PATCH_DESC}")   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
         if grep -qE '^GIT binary patch$|^rename from|^rename to' $i; then
-          cat $i | git apply --directory=`echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 --verbose --whitespace=nowarn --unsafe-paths >&$VERBOSE_OUT
+          cat $i | git apply --directory=$(echo "$PKG_BUILD" | cut -f1 -d\ ) -p1 --verbose --whitespace=nowarn --unsafe-paths >&$VERBOSE_OUT
         else
-          cat $i | patch -d `echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 >&$VERBOSE_OUT
+          cat $i | patch -d $(echo "$PKG_BUILD" | cut -f1 -d\ ) -p1 >&$VERBOSE_OUT
         fi
       fi
     done
@@ -166,7 +165,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
   fi
 
   if [ ! "$PKG_NAME" = "configtools" ] ; then
-    for config in `find $PKG_BUILD -name config.guess | sed 's/config.guess//'`; do
+    for config in $(find "$PKG_BUILD" -name config.guess | sed 's/config.guess//'); do
       printf "%${BUILD_INDENT}c $(print_color CLR_FIXCONFIG "FIXCONFIG")   $config\n" ' '
 
       [ -f "$config/config.guess" -a -f $TOOLCHAIN/configtools/config.guess ] && \
@@ -178,7 +177,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
 fi
 
 if [ "$PKG_SECTION" != "virtual" ]; then
-  mkdir -p $PKG_BUILD
+  mkdir -p "$PKG_BUILD"
 
   rm -f $STAMPS/$1/build_*
 


### PR DESCRIPTION
I was looking at adjusting PKG_BUILD and came across these cleanups. There shouldn't be anything exciting in here. This replaces a few places that should be using PKG_BUILD too. To ease looking it up, PKG_BUILD is defined in config/path: https://github.com/LibreELEC/LibreELEC.tv/blob/master/config/path#L132

Tested with an RPi build.