### PR TITLE
treewide: retire $SED

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -911,19 +911,19 @@ done
     fi
   done
 
-  $SED -e "s|@PKG_ADDON_ID@|$PKG_ADDON_ID|g" \
-       -e "s|@ADDON_NAME@|$addon_name|g" \
-       -e "s|@ADDON_VERSION@|$addon_version|g" \
-       -e "s|@REQUIRES@|$requires|g" \
-       -e "s|@PKG_SHORTDESC@|$PKG_SHORTDESC|g" \
-       -e "s|@OS_VERSION@|$OS_VERSION|g" \
-       -e "s|@PKG_LONGDESC@|$PKG_LONGDESC|g" \
-       -e "s|@PKG_DISCLAIMER@|$PKG_DISCLAIMER|g" \
-       -e "s|@PROVIDER_NAME@|$provider_name|g" \
-       -e "s|@PKG_ADDON_PROVIDES@|$PKG_ADDON_PROVIDES|g" \
-       -e "s|@PKG_ADDON_SCREENSHOT@|$screenshots|g" \
-       -e "s|@PKG_ADDON_BROKEN@|$PKG_ADDON_BROKEN|g" \
-       -i "$addon_xml"
+  sed -e "s|@PKG_ADDON_ID@|$PKG_ADDON_ID|g" \
+      -e "s|@ADDON_NAME@|$addon_name|g" \
+      -e "s|@ADDON_VERSION@|$addon_version|g" \
+      -e "s|@REQUIRES@|$requires|g" \
+      -e "s|@PKG_SHORTDESC@|$PKG_SHORTDESC|g" \
+      -e "s|@OS_VERSION@|$OS_VERSION|g" \
+      -e "s|@PKG_LONGDESC@|$PKG_LONGDESC|g" \
+      -e "s|@PKG_DISCLAIMER@|$PKG_DISCLAIMER|g" \
+      -e "s|@PROVIDER_NAME@|$provider_name|g" \
+      -e "s|@PKG_ADDON_PROVIDES@|$PKG_ADDON_PROVIDES|g" \
+      -e "s|@PKG_ADDON_SCREENSHOT@|$screenshots|g" \
+      -e "s|@PKG_ADDON_BROKEN@|$PKG_ADDON_BROKEN|g" \
+      -i "$addon_xml"
 }
 
 install_addon_files() {

--- a/config/path
+++ b/config/path
@@ -58,7 +58,6 @@ INSTALL_INIT=$BUILD/image/initramfs/root-image
 
 MAKE="$TOOLCHAIN/bin/make"
 MAKEINSTALL="$TOOLCHAIN/bin/make -j1 DESTDIR=$SYSROOT_PREFIX install"
-SED="sed -i"
 
 unset LD_LIBRARY_PATH
 

--- a/packages/addons/addon-depends/cxxtools/package.mk
+++ b/packages/addons/addon-depends/cxxtools/package.mk
@@ -20,7 +20,7 @@ post_makeinstall_host() {
 }
 
 post_makeinstall_target() {
-  $SED "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/bin/cxxtools-config
+  sed -e "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/bin/cxxtools-config
 
   rm -rf $INSTALL/usr/bin
 }

--- a/packages/addons/addon-depends/tntnet/package.mk
+++ b/packages/addons/addon-depends/tntnet/package.mk
@@ -29,7 +29,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-unittest \
                            --with-stressjob=no"
 
 post_makeinstall_target() {
-  $SED "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/bin/tntnet-config
+  sed -e "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/bin/tntnet-config
 
   rm -rf $INSTALL/usr/bin
   rm -rf $INSTALL/usr/share

--- a/packages/addons/repository/repository.kodinerds/package.mk
+++ b/packages/addons/repository/repository.kodinerds/package.mk
@@ -19,9 +19,9 @@ PKG_ADDON_NAME="Kodinerds Repository"
 PKG_ADDON_TYPE="xbmc.addon.repository"
 
 make_target() {
-  $SED -e "s|@PKG_VERSION@|$PKG_VERSION|g" \
-       -e "s|@PKG_REV@|$PKG_REV|g" \
-       -i addon.xml
+  sed -e "s|@PKG_VERSION@|$PKG_VERSION|g" \
+      -e "s|@PKG_REV@|$PKG_REV|g" \
+      -i addon.xml
 }
 
 addon() {

--- a/packages/addons/repository/repository.linuxserver.docker/package.mk
+++ b/packages/addons/repository/repository.linuxserver.docker/package.mk
@@ -20,9 +20,9 @@ PKG_ADDON_NAME="LinuxServer.io Repository"
 PKG_ADDON_TYPE="xbmc.addon.repository"
 
 make_target() {
-  $SED -e "s|@PKG_VERSION@|$PKG_VERSION|g" \
-       -e "s|@PKG_REV@|$PKG_REV|g" \
-       -i addon.xml
+  sed -e "s|@PKG_VERSION@|$PKG_VERSION|g" \
+      -e "s|@PKG_REV@|$PKG_REV|g" \
+      -i addon.xml
 }
 
 addon() {

--- a/packages/addons/script/script.config.vdr/package.mk
+++ b/packages/addons/script/script.config.vdr/package.mk
@@ -19,9 +19,9 @@ PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="dummy"
 
 make_target() {
-  $SED -e "s|@ADDON_VERSION@|$ADDON_VERSION.$PKG_REV|g" \
-       -e "s|@OS_VERSION@|$OS_VERSION|g" \
-       -i addon.xml
+  sed -e "s|@ADDON_VERSION@|$ADDON_VERSION.$PKG_REV|g" \
+      -e "s|@OS_VERSION@|$OS_VERSION|g" \
+      -i addon.xml
 }
 
 addon() {

--- a/packages/addons/service/fd628/package.mk
+++ b/packages/addons/service/fd628/package.mk
@@ -20,8 +20,8 @@ PKG_ADDON_PROJECTS="S905 S912"
 PKG_ADDON_TYPE="xbmc.service"
 
 make_target() {
-  $SED -e "s|@PKG_VERSION@|$PKG_VERSION|g" \
-       -i addon.xml
+  sed -e "s|@PKG_VERSION@|$PKG_VERSION|g" \
+      -i addon.xml
 }
 
 addon() {

--- a/packages/addons/service/touchscreen/package.mk
+++ b/packages/addons/service/touchscreen/package.mk
@@ -27,8 +27,8 @@ addon() {
   cp $PKG_DIR/addon.xml $ADDON_BUILD/$PKG_ADDON_ID
 
   # set only version (revision will be added by buildsystem)
-  $SED -e "s|@ADDON_VERSION@|$ADDON_VERSION|g" \
-       -i $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
+  sed -e "s|@ADDON_VERSION@|$ADDON_VERSION|g" \
+      -i $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
 
   cp $(get_build_dir tslib)/.install_pkg/usr/bin/* $ADDON_BUILD/$PKG_ADDON_ID/bin
   cp $(get_build_dir evtest)/.$TARGET_NAME/evtest  $ADDON_BUILD/$PKG_ADDON_ID/bin

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -107,8 +107,8 @@ addon() {
   cp $PKG_DIR/addon.xml $ADDON_BUILD/$PKG_ADDON_ID
 
   # set only version (revision will be added by buildsystem)
-  $SED -e "s|@ADDON_VERSION@|$ADDON_VERSION|g" \
-       -i $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
+  sed -e "s|@ADDON_VERSION@|$ADDON_VERSION|g" \
+      -i $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
 
   cp -P $PKG_BUILD/build.linux/tvheadend $ADDON_BUILD/$PKG_ADDON_ID/bin
   cp -P $PKG_BUILD/capmt_ca.so $ADDON_BUILD/$PKG_ADDON_ID/bin

--- a/packages/audio/taglib/package.mk
+++ b/packages/audio/taglib/package.mk
@@ -17,9 +17,9 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin
   # pkgconf hack
-  $SED "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/bin/taglib-config
-  $SED "s:\([':\" ]\)-I/usr:\\1-I$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/lib/pkgconfig/taglib.pc
-  $SED "s:\([':\" ]\)-L/usr:\\1-L$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/lib/pkgconfig/taglib.pc
-  $SED "s:\([':\" ]\)-I/usr:\\1-I$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/lib/pkgconfig/taglib_c.pc
-  $SED "s:\([':\" ]\)-L/usr:\\1-L$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/lib/pkgconfig/taglib_c.pc
+  sed -e "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/bin/taglib-config
+  sed -e "s:\([':\" ]\)-I/usr:\\1-I$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/lib/pkgconfig/taglib.pc
+  sed -e "s:\([':\" ]\)-L/usr:\\1-L$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/lib/pkgconfig/taglib.pc
+  sed -e "s:\([':\" ]\)-I/usr:\\1-I$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/lib/pkgconfig/taglib_c.pc
+  sed -e "s:\([':\" ]\)-L/usr:\\1-L$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/lib/pkgconfig/taglib_c.pc
 }

--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -60,6 +60,6 @@ PKG_CONFIGURE_OPTS_TARGET="--without-ada \
 post_makeinstall_target() {
   cp misc/ncurses-config $TOOLCHAIN/bin
   chmod +x $TOOLCHAIN/bin/ncurses-config
-  $SED "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $TOOLCHAIN/bin/ncurses-config
+  sed -e "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $TOOLCHAIN/bin/ncurses-config
   rm -rf $INSTALL/usr/bin
 }

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -266,9 +266,9 @@ post_makeinstall_target() {
     cp $PKG_DIR/scripts/kodi.sh $INSTALL/usr/lib/kodi
 
     # Configure safe mode triggers - default 5 restarts within 900 seconds/15 minutes
-    $SED -e "s|@KODI_MAX_RESTARTS@|${KODI_MAX_RESTARTS:-5}|g" \
-         -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
-         -i $INSTALL/usr/lib/kodi/kodi.sh
+    sed -e "s|@KODI_MAX_RESTARTS@|${KODI_MAX_RESTARTS:-5}|g" \
+        -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
+        -i $INSTALL/usr/lib/kodi/kodi.sh
 
   mkdir -p $INSTALL/usr/sbin
     cp $PKG_DIR/scripts/service-addon-wrapper $INSTALL/usr/sbin
@@ -281,11 +281,11 @@ post_makeinstall_target() {
 
   mkdir -p $INSTALL/usr/share/kodi/addons
     cp -R $PKG_DIR/config/os.openelec.tv $INSTALL/usr/share/kodi/addons
-    $SED "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.openelec.tv/addon.xml
+    sed -e "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.openelec.tv/addon.xml
     cp -R $PKG_DIR/config/os.libreelec.tv $INSTALL/usr/share/kodi/addons
-    $SED "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.libreelec.tv/addon.xml
+    sed -e "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.libreelec.tv/addon.xml
     cp -R $PKG_DIR/config/repository.libreelec.tv $INSTALL/usr/share/kodi/addons
-    $SED "s|@ADDON_URL@|$ADDON_URL|g" -i $INSTALL/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
+    sed -e "s|@ADDON_URL@|$ADDON_URL|g" -i $INSTALL/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
     cp -R $PKG_DIR/config/repository.kodi.game $INSTALL/usr/share/kodi/addons
 
   mkdir -p $INSTALL/usr/share/kodi/config

--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -92,7 +92,7 @@ else
 fi
 
 post_makeinstall_target() {
-  $SED "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/bin/sdl2-config
+  sed -e "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/bin/sdl2-config
 
   rm -rf $INSTALL/usr/bin
 }

--- a/packages/print/freetype/package.mk
+++ b/packages/print/freetype/package.mk
@@ -25,7 +25,7 @@ pre_configure_target() {
 }
 
 post_makeinstall_target() {
-  $SED "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/bin/freetype-config
+  sed -e "s:\(['=\" ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/bin/freetype-config
   ln -v -sf $SYSROOT_PREFIX/usr/include/freetype2 $SYSROOT_PREFIX/usr/include/freetype
 
   rm -rf $INSTALL/usr/bin

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -26,7 +26,7 @@ PKG_CONFIGURE_OPTS_HOST="$PKG_CONFIGURE_OPTS_ALL --with-zlib=$TOOLCHAIN"
 PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_ALL --with-zlib=$SYSROOT_PREFIX/usr --with-sysroot=$SYSROOT_PREFIX"
 
 post_makeinstall_target() {
-  $SED "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/bin/xml2-config
+  sed -e "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/bin/xml2-config
 
   rm -rf $INSTALL/usr/bin
   rm -rf $INSTALL/usr/lib/xml2Conf.sh

--- a/packages/textproc/libxslt/package.mk
+++ b/packages/textproc/libxslt/package.mk
@@ -29,7 +29,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_ansidecl_h=no \
                            --without-crypto"
 
 post_makeinstall_target() {
-  $SED "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $SYSROOT_PREFIX/usr/bin/xslt-config
+  sed -e "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $SYSROOT_PREFIX/usr/bin/xslt-config
 
   rm -rf $INSTALL/usr/bin/xsltproc
   rm -rf $INSTALL/usr/lib/xsltConf.sh


### PR DESCRIPTION
`$SED` is generally ignored, or used incorrectly. Retire it.

Relies on PR3078.