### PR TITLE
HACK: fix audio for WP1

### DIFF
--- a/projects/WeTek_Core/patches/kodi/kodi-100.26-hack-fix-audio.patch
+++ b/projects/WeTek_Core/patches/kodi/kodi-100.26-hack-fix-audio.patch
@@ -1,0 +1,13 @@
+fixes broken audio at WP1 and WC
+Fill audio packets completely when resampling to prevent 'audio data unaligned' kernel warnings
+
+--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
++++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+@@ -143,6 +143,7 @@
+     m_inputFormat.m_channelLayout.Reset();
+     m_inputFormat.m_channelLayout += AE_CH_FC;
+   }
++  m_fillPackets = true;
+   m_resampleQuality = quality;
+ }
+ 

--- a/projects/WeTek_Play/patches/kodi/kodi-100.26-hack-fix-audio.patch
+++ b/projects/WeTek_Play/patches/kodi/kodi-100.26-hack-fix-audio.patch
@@ -1,0 +1,13 @@
+fixes broken audio at WP1 and WC
+Fill audio packets completely when resampling to prevent 'audio data unaligned' kernel warnings
+
+--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
++++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+@@ -143,6 +143,7 @@
+     m_inputFormat.m_channelLayout.Reset();
+     m_inputFormat.m_channelLayout += AE_CH_FC;
+   }
++  m_fillPackets = true;
+   m_resampleQuality = quality;
+ }
+ 


### PR DESCRIPTION
We have a lot reports that WP1 audio is broken, this HACK makes it work again. 
This is no proper fix but there is currently nothing else available to have working audio at WP1.
It is an adapted version of https://github.com/LibreELEC/xbmc/commit/dd2255d77e5c3a819a92543de9f3ce276a522947
from https://www.kodinerds.net/index.php/Thread/62885-LE-9-auf-Wetek-Play-Ton-seltsam/?postID=483736#post483736

I have no WP1 so I can't test it at all (I ship an testimage to the forum).