### PR TITLE
eventlircd: prevent race with libinput / kodi

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -224,4 +224,7 @@ ATTRS{name}=="Amazon Fire TV Remote", \
 
 LABEL="end-bluetooth"
 
+# tell libinput to ignore devices handled by eventlircd
+ENV{eventlircd_enable}=="true", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+
 LABEL="end"


### PR DESCRIPTION
Currently both eventlircd and kodi try to grab input devices
which leads to a nasty race. If kodi wins the race eventlircd
can't do the keycode to lirc translation and users are left
with non-working buttons like OK.

Setting the LIBINPUT_IGNORE_DEVICE udev property for input
devices handled by eventlircd prevents the race as libinput
will then ignore these devices and kodi won't try to grab them.

Note: several users have been using `systemctl mask eventlircd` and setup custom IR keytables (changing eg KEY_OK to KEY_ENTER) to get longpress support in kodi.

This hack (which was never officiially supported) won't work any longer, instead of masking the eventlircd service people now have to override the eventlircd udev rule file, eg via
`: > /storage/.config/udev.rules.d/98-eventlircd.rules`

ping @lrusak 
