### PR TITLE
kodi: update SHA for corrected rockchip_18.0b5-Leia tag

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -19,7 +19,7 @@ case $KODI_VENDOR in
     ;;
   rockchip)
     PKG_VERSION="rockchip_18.0b5-Leia"
-    PKG_SHA256="bef89dabe4be2f155e0c912d0221845f570372c6d0b6d8be615381992dc76bc9"
+    PKG_SHA256="9b43e77fe4e191016cd51c57f02a6d7c10c1806189dc8be6d95aac7d716a267d"
     PKG_URL="https://github.com/kwiboo/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;


### PR DESCRIPTION
This PR fixes SHA of force updated `rockchip_18.0b5-Leia` tag, old tag included `master` commits merged after `18.0b5-Leia` was taged