### PR TITLE
iptables: update to iptables-1.8.2

### DIFF
--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iptables"
-PKG_VERSION="1.6.1"
-PKG_SHA256="0fc2d7bd5d7be11311726466789d4c65fb4c8e096c9182b56ce97440864f0cf5"
+PKG_VERSION="1.8.2"
+PKG_SHA256="a3778b50ed1a3256f9ca975de82c2204e508001fc2471238c8c97f3d1c4c12af"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.netfilter.org/"
 PKG_URL="http://www.netfilter.org/projects/iptables/files/$PKG_NAME-$PKG_VERSION.tar.bz2"

--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -3,8 +3,13 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iptables"
-PKG_VERSION="1.8.2"
-PKG_SHA256="a3778b50ed1a3256f9ca975de82c2204e508001fc2471238c8c97f3d1c4c12af"
+if [[ ! $LINUX =~ ^amlogic-3 ]]; then
+  PKG_VERSION="1.8.2"
+  PKG_SHA256="a3778b50ed1a3256f9ca975de82c2204e508001fc2471238c8c97f3d1c4c12af"
+else
+  PKG_VERSION="1.6.1"
+  PKG_SHA256="0fc2d7bd5d7be11311726466789d4c65fb4c8e096c9182b56ce97440864f0cf5"
+fi
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.netfilter.org/"
 PKG_URL="http://www.netfilter.org/projects/iptables/files/$PKG_NAME-$PKG_VERSION.tar.bz2"

--- a/packages/network/libnftnl/package.mk
+++ b/packages/network/libnftnl/package.mk
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnftnl"
-PKG_VERSION="1.0.7"
-PKG_SHA256="9bb66ecbc64b8508249402f0093829f44177770ad99f6042b86b3a467d963982"
+PKG_VERSION="1.1.2"
+PKG_SHA256="a5c7b7a6c13c9c5898b13fcb1126fefce2015d5a96d7c354b19aaa40b6aece5d"
 PKG_LICENSE="GPL"
 PKG_SITE="http://netfilter.org/projects/libnftnl"
 PKG_URL="http://netfilter.org/projects/libnftnl/files/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
`iptables` 1.8.1 now requires `libnftnl` >= 1.1.1:

```
checking for libnftnl >= 1.1.1... no
*** Error: no suitable libnftnl found. ***
    Please install the 'libnftnl' package
    Or consider --disable-nftables to skip
    iptables-compat over nftables support.
````