### PR TITLE
vdr-addon 109 / script.config.vdr 103

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-restfulapi/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-restfulapi/package.mk
@@ -9,9 +9,13 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/yavdr/vdr-plugin-restfulapi"
 PKG_URL="https://github.com/yavdr/${PKG_NAME}/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain vdr cxxtools vdr-plugin-wirbelscan"
-PKG_NEED_UNPACK="$(get_pkg_directory vdr)"
+PKG_NEED_UNPACK="$(get_pkg_directory vdr) $(get_pkg_directory vdr-plugin-wirbelscan)"
 PKG_LONGDESC="Allows to access many internals of the VDR via a restful API."
 PKG_TOOLCHAIN="manual"
+
+pre_build_target() {
+  cp $(get_build_dir vdr-plugin-wirbelscan)/wirbelscan_services.h $PKG_BUILD/wirbelscan/
+}
 
 make_target() {
   VDR_DIR=$(get_build_dir vdr)

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-restfulapi/patches/vdr-plugin-restfulapi-02-webapp-path.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-restfulapi/patches/vdr-plugin-restfulapi-02-webapp-path.patch
@@ -9,3 +9,14 @@
    SetHeaders((string)"true");
    webapp_filetypes_filename = "webapp_file_types.conf";
  }
+--- a/tools.h
++++ b/tools.h
+@@ -40,7 +40,7 @@
+ #define RESTFULAPI_EXTENSIONS
+ 
+ #ifndef DOCUMENT_ROOT
+-#define DOCUMENT_ROOT "/var/lib/vdr/plugins/restfulapi/"
++#define DOCUMENT_ROOT "/storage/.kodi/addons/service.multimedia.vdr-addon/res/plugins/restfulapi/"
+ #endif
+ 
+ class Settings

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-vnsiserver/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-vnsiserver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-vnsiserver"
-PKG_VERSION="8c898d9"
-PKG_SHA256="3f01213b24a12bbbae97575aac2cf166d740c3f4f7f9a40e31cfe67f5964b192"
+PKG_VERSION="49003f036609ee2a0b8d819979c063d8f8d348c8"
+PKG_SHA256="fc64c343685bf87e4cc14018bcf642cba9aa637adfe1ab21725a19945c620737"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/FernetMenta/vdr-plugin-vnsiserver"
 PKG_URL="https://github.com/FernetMenta/vdr-plugin-vnsiserver/archive/$PKG_VERSION.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/patches/vdr-plugin-wirbelscan-001-fix_segv.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/patches/vdr-plugin-wirbelscan-001-fix_segv.patch
@@ -1,0 +1,12 @@
+--- a/statemachine.c
++++ b/statemachine.c
+@@ -309,7 +309,8 @@ void cStateMachine::Action(void) {
+                  else
+                     newState = eAddChannels;
+               if (time(0) != tm) {
+-                 MenuScanning->SetProgress(lProgress);
++                 if (MenuScanning)
++                    MenuScanning->SetProgress(lProgress);
+                  tm = time(0);
+                  }
+               }

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/patches/vdr-plugin-wirbelscan-002-channel_count.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/patches/vdr-plugin-wirbelscan-002-channel_count.patch
@@ -1,0 +1,22 @@
+--- a/wirbelscan.c
++++ b/wirbelscan.c
+@@ -13,6 +13,8 @@
+ #include "countries.h"
+ #include "satellites.h"
+ 
++extern TChannels NewChannels;
++
+ static const char *VERSION        = "2017.06.04";
+ static const char *DESCRIPTION    = "DVB channel scan for VDR";
+ static const char *MAINMENUENTRY  = NULL; /* main menu -> use wirbelscancontrol plugin */
+@@ -201,8 +203,8 @@ bool cPluginWirbelscan::Service(const ch
+         strcpy(s->transponder, lTransponder.length()? lTransponder.c_str():"none");
+         s->progress = s->status == StatusScanning?lProgress:0;
+         s->strength = s->status == StatusScanning?lStrength:0;
+-        s->numChannels = 0;              // Channels.Count(); // not possible any longer.
+-        s->newChannels = channelcount;   // ((Channels.Count() - channelcount) > 0) && channelcount?Channels.Count() - channelcount:0;
++        s->numChannels = cChannels::MaxNumber();
++        s->newChannels = (NewChannels.Count() > cChannels::MaxNumber()) ? NewChannels.Count() - cChannels::MaxNumber():0;
+         s->nextTransponders = nextTransponders;
+         return true;
+         }

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/patches/vdr-plugin-wirbelscan-003-detect.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/patches/vdr-plugin-wirbelscan-003-detect.patch
@@ -1,0 +1,27 @@
+--- a/common.c
++++ b/common.c
+@@ -46,20 +46,10 @@ void cMySetup::InitSystems(void) {
+   for(int i = 0; i < cDevice::NumDevices(); i++) {
+      cDevice* device = cDevice::GetDevice(i);
+      if (device == NULL) continue;
+-     std::string t = *device->DeviceType();
+-     if (t == "DVB-C" ) systems[SCAN_CABLE         ] = 1;
+-     if (t == "DVB-T" ) systems[SCAN_TERRESTRIAL   ] = 1;
+-     if (t == "DSS"   ) systems[SCAN_SATELLITE     ] = 1;
+-     if (t == "DVB-S" ) systems[SCAN_SATELLITE     ] = 1;
+-     if (t == "DVB-S2") systems[SCAN_SATELLITE     ] = 1;
+-     if (t == "ATSC"  ) systems[SCAN_TERRCABLE_ATSC] = 1;
+-     if (t == "DVB-T2") systems[SCAN_TERRESTRIAL   ] = 1;
+-     if (t == "TURBO" ) systems[SCAN_SATELLITE     ] = 1;
+-     if (t == "SAT>IP") {
+-        if (device->ProvidesSource(cSource::FromString("S"))) systems[SCAN_SATELLITE     ] = 1;
+-        if (device->ProvidesSource(cSource::FromString("T"))) systems[SCAN_TERRESTRIAL   ] = 1;
+-        if (device->ProvidesSource(cSource::FromString("C"))) systems[SCAN_CABLE         ] = 1;
+-        }
++     if (device->ProvidesSource(cSource::stSat))   systems[SCAN_SATELLITE] = 1;
++     if (device->ProvidesSource(cSource::stTerr))  systems[SCAN_TERRESTRIAL] = 1;
++     if (device->ProvidesSource(cSource::stCable)) systems[SCAN_CABLE] = 1;
++     if (device->ProvidesSource(cSource::stAtsc))  systems[SCAN_TERRCABLE_ATSC] = 1;
+      }
+ 
+   if (DVB_Type >= SCAN_NO_DEVICE || ! systems[DVB_Type]) {

--- a/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-01-svdrp-modt-recflag.patch
+++ b/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-01-svdrp-modt-recflag.patch
@@ -4,8 +4,8 @@ ftp://ftp.tvdr.de/vdr/Developer/Patches/vdr-2.4/
 # and UPDT. The tfRecording flag must only be handled by the VDR that actually hosts
 # and processes the timer.
 #
---- svdrp.c	2018/03/19 12:16:33	5.0
-+++ svdrp.c	2018/04/19 09:45:08
+--- a/svdrp.c	2018/03/19 12:16:33	5.0
++++ b/svdrp.c	2018/04/19 09:45:08
 @@ -2036,6 +2036,7 @@
          LOCK_TIMERS_WRITE;
          Timers->SetExplicitModify();

--- a/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-02-invalid-locking-sequence.patch
+++ b/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-02-invalid-locking-sequence.patch
@@ -1,0 +1,48 @@
+# This patch fixes a possible invalid locking sequence in case a remote timer handling error message
+# is displayed on the OSD and the skin tries to lock the Recordings or DeletedRecordings
+# list in its Flush() function (for instance by calling cVideoDiskUsage::HasChanged()).
+# To do this, the call to Skins.Message() in menu.c's HandleRemoteModifications() has
+# been changed to Skins.QueueMessage(), and cSkins::ProcessQueuedMessages() is now called
+# unconditionally in the main loop, and checks whether the current cSkinDisplay object
+# (if any) implements SetMessage().
+#
+--- 1/menu.c	2018/04/14 10:24:41	5.0
++++ 1/menu.c	2018/04/28 12:09:45
+@@ -1075,7 +1075,7 @@
+ {
+   cString ErrorMessage;
+   if (!HandleRemoteTimerModifications(NewTimer, OldTimer, &ErrorMessage)) {
+-     Skins.Message(mtError, ErrorMessage);
++     Skins.QueueMessage(mtError, ErrorMessage);
+      return false;
+      }
+   return true;
+--- 1/skins.c	2013/08/18 12:07:22	5.0
++++ 1/skins.c	2018/04/28 12:13:01
+@@ -352,6 +352,14 @@
+      dsyslog("cSkins::ProcessQueuedMessages() called from background thread - ignored!");
+      return;
+      }
++  // Check whether there is a cSkinDisplay object (if any) that implements SetMessage():
++  if (cSkinDisplay *sd = cSkinDisplay::Current()) {
++     if (!(dynamic_cast<cSkinDisplayChannel *>(sd) ||
++           dynamic_cast<cSkinDisplayMenu *>(sd) ||
++           dynamic_cast<cSkinDisplayReplay *>(sd) ||
++           dynamic_cast<cSkinDisplayMessage *>(sd)))
++        return;
++     }
+   cSkinQueuedMessage *msg = NULL;
+   // Get the first waiting message:
+   queueMessageMutex.Lock();
+--- 1/vdr.c	2018/04/10 13:24:43	5.0
++++ 1/vdr.c	2018/04/28 11:27:48
+@@ -1176,8 +1176,7 @@
+         if (!Menu && !cOsd::IsOpen())
+            Menu = CamControl();
+         // Queued messages:
+-        if (!Skins.IsOpen())
+-           Skins.ProcessQueuedMessages();
++        Skins.ProcessQueuedMessages();
+         // User Input:
+         cOsdObject *Interact = Menu ? Menu : cControl::Control();
+         eKeys key = Interface->GetKey(!Interact || !Interact->NeedsFastResponse());

--- a/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-03-locking-channel-display.patch
+++ b/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-03-locking-channel-display.patch
@@ -1,0 +1,89 @@
+# Fixed locking the Channels list in cDisplayChannel, where the lock was still held
+# when Flush() was called.
+#
+--- 1/menu.c	2018/04/28 12:09:45	5.1
++++ 1/menu.c	2018/05/06 09:30:11
+@@ -4626,14 +4626,17 @@
+   cOsdProvider::OsdSizeChanged(osdState); // just to get the current state
+   positioner = NULL;
+   channel = NULL;
+-  LOCK_CHANNELS_READ;
+-  channel = Channels->GetByNumber(Number);
+-  lastPresent = lastFollowing = NULL;
+-  if (channel) {
+-     DisplayChannel();
+-     DisplayInfo();
++  {
++    LOCK_CHANNELS_READ;
++    channel = Channels->GetByNumber(Number);
++    lastPresent = lastFollowing = NULL;
++    if (channel) {
++       DisplayChannel();
++       DisplayInfo();
++       }
++  }
++  if (channel)
+      displayChannel->Flush();
+-     }
+   lastTime.Set();
+ }
+ 
+@@ -4868,31 +4871,33 @@
+             }
+     };
+   if (positioner || !timeout || lastTime.Elapsed() < (uint64_t)(Setup.ChannelInfoTime * 1000)) {
+-     LOCK_CHANNELS_READ;
+-     if (Key == kNone && !number && group < 0 && !NewChannel && channel && channel->Number() != cDevice::CurrentChannel()) {
+-        // makes sure a channel switch through the SVDRP CHAN command is displayed
+-        channel = Channels->GetByNumber(cDevice::CurrentChannel());
+-        Refresh();
+-        lastTime.Set();
+-        }
+-     DisplayInfo();
+-     if (NewChannel) {
+-        SetTrackDescriptions(NewChannel->Number()); // to make them immediately visible in the channel display
+-        Channels->SwitchTo(NewChannel->Number());
+-        SetTrackDescriptions(NewChannel->Number()); // switching the channel has cleared them
+-        channel = NewChannel;
+-        }
+-     const cPositioner *Positioner = cDevice::ActualDevice()->Positioner();
+-     bool PositionerMoving = Positioner && Positioner->IsMoving();
+-     SetNeedsFastResponse(PositionerMoving);
+-     if (!PositionerMoving) {
+-        if (positioner)
+-           lastTime.Set(); // to keep the channel display up a few seconds after the target position has been reached
+-        Positioner = NULL;
+-        }
+-     if (Positioner || positioner) // making sure we call SetPositioner(NULL) if there is a switch from "with" to "without" positioner
+-        displayChannel->SetPositioner(Positioner);
+-     positioner = Positioner;
++     {
++       LOCK_CHANNELS_READ;
++       if (Key == kNone && !number && group < 0 && !NewChannel && channel && channel->Number() != cDevice::CurrentChannel()) {
++          // makes sure a channel switch through the SVDRP CHAN command is displayed
++          channel = Channels->GetByNumber(cDevice::CurrentChannel());
++          Refresh();
++          lastTime.Set();
++          }
++       DisplayInfo();
++       if (NewChannel) {
++          SetTrackDescriptions(NewChannel->Number()); // to make them immediately visible in the channel display
++          Channels->SwitchTo(NewChannel->Number());
++          SetTrackDescriptions(NewChannel->Number()); // switching the channel has cleared them
++          channel = NewChannel;
++          }
++       const cPositioner *Positioner = cDevice::ActualDevice()->Positioner();
++       bool PositionerMoving = Positioner && Positioner->IsMoving();
++       SetNeedsFastResponse(PositionerMoving);
++       if (!PositionerMoving) {
++          if (positioner)
++             lastTime.Set(); // to keep the channel display up a few seconds after the target position has been reached
++          Positioner = NULL;
++          }
++       if (Positioner || positioner) // making sure we call SetPositioner(NULL) if there is a switch from "with" to "without" positioner
++          displayChannel->SetPositioner(Positioner);
++       positioner = Positioner;
++     }
+      displayChannel->Flush();
+      return osContinue;
+      }

--- a/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-04-locking-channel-display-2.patch
+++ b/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-04-locking-channel-display-2.patch
@@ -1,0 +1,18 @@
+# Fixed locking the Channels list in cDisplayChannel, where the lock was still held
+# when Flush() was called (cont'd).
+#
+--- 1/menu.c	2018/05/06 09:30:11	5.2
++++ 1/menu.c	2018/05/27 09:51:56	5.3
+@@ -4654,8 +4654,10 @@
+   displayChannel = Skins.Current()->DisplayChannel(withInfo);
+   positioner = NULL;
+   channel = NULL;
+-  LOCK_CHANNELS_READ;
+-  channel = Channels->GetByNumber(cDevice::CurrentChannel());
++  {
++    LOCK_CHANNELS_READ;
++    channel = Channels->GetByNumber(cDevice::CurrentChannel());
++  }
+   ProcessKey(FirstKey);
+ }
+ 

--- a/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-05-shutdown.patch
+++ b/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-05-shutdown.patch
@@ -1,0 +1,33 @@
+# Fixed shutdown after user inactivity in case a plugin is keeping the OSD open.
+#
+--- a/vdr.c	2018/04/28 11:27:48	5.1
++++ b/vdr.c	2018/07/16 08:52:40	5.2
+@@ -1514,9 +1514,7 @@
+               ShutdownHandler.countdown.Cancel();
+            }
+ 
+-        if ((Now - LastInteract) > ACTIVITYTIMEOUT && !cRecordControls::Active() && !RecordingsHandler.Active() && (Now - cRemote::LastActivity()) > ACTIVITYTIMEOUT) {
+-           // Handle housekeeping tasks
+-
++        if (!cRecordControls::Active() && !RecordingsHandler.Active() && (Now - cRemote::LastActivity()) > ACTIVITYTIMEOUT) {
+            // Shutdown:
+            // Check whether VDR will be ready for shutdown in SHUTDOWNWAIT seconds:
+            time_t Soon = Now + SHUTDOWNWAIT;
+@@ -1535,7 +1533,8 @@
+               // Do this again a bit later:
+               ShutdownHandler.SetRetry(SHUTDOWNRETRY);
+               }
+-
++           // Handle housekeeping tasks
++           if ((Now - LastInteract) > ACTIVITYTIMEOUT) {
+            // Disk housekeeping:
+            RemoveDeletedRecordings();
+            ListGarbageCollector.Purge();
+@@ -1543,6 +1542,7 @@
+            // Plugins housekeeping:
+            PluginManager.Housekeeping();
+            }
++           }
+ 
+         ReportEpgBugFixStats();
+ 

--- a/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-06-channel-switch.patch
+++ b/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-06-channel-switch.patch
@@ -1,0 +1,31 @@
+# Fixed switching through encrypted channels with the Up/Down keys
+#
+--- a/device.c	2018/03/24 09:49:14	5.0
++++ b/device.c	2018/07/16 09:29:57
+@@ -787,6 +787,7 @@
+   if (LiveView) {
+      isyslog("switching to channel %d %s (%s)", Channel->Number(), *Channel->GetChannelID().ToString(), Channel->Name());
+      cControl::Shutdown(); // prevents old channel from being shown too long if GetDevice() takes longer
++                           // and, if decrypted, this removes the now superflous PIDs from the CAM, too
+      }
+   for (int i = 3; i--;) {
+       switch (SetChannel(Channel, LiveView)) {
+@@ -809,6 +810,7 @@
+   Direction = sgn(Direction);
+   if (Direction) {
+      cControl::Shutdown(); // prevents old channel from being shown too long if GetDevice() takes longer
++                           // and, if decrypted, this removes the now superflous PIDs from the CAM, too
+      int n = CurrentChannel() + Direction;
+      int first = n;
+      LOCK_CHANNELS_READ;
+--- a/menu.c	2018/05/27 09:51:56	5.3
++++ b/menu.c	2018/07/16 09:29:57
+@@ -4704,6 +4704,8 @@
+ const cChannel *cDisplayChannel::NextAvailableChannel(const cChannel *Channel, int Direction)
+ {
+   if (Direction) {
++     cControl::Shutdown(); // prevents old channel from being shown too long if GetDevice() takes longer
++                           // and, if decrypted, this removes the now superflous PIDs from the CAM, too
+      LOCK_CHANNELS_READ;
+      while (Channel) {
+            Channel = Direction > 0 ? Channels->Next(Channel) : Channels->Prev(Channel);

--- a/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-07-disabling-mtd.patch
+++ b/packages/addons/addon-depends/vdr/patches/vdr-10-upstream-fix-07-disabling-mtd.patch
@@ -1,0 +1,13 @@
+# Now deactivating MTD support if a non MCD capable CAM is inserted after removing
+# a previously used CAM that is MCD capable.
+#
+--- a/ci.c	2018/03/19 16:37:03	5.0
++++ b/ci.c	2018/09/23 10:17:20
+@@ -1213,6 +1213,7 @@
+         }
+      else {
+         dsyslog("CAM %d: doesn't reply to QUERY - only a single channel can be decrypted", CamSlot()->SlotNumber());
++        CamSlot()->MtdActivate(false);
+         state = 4; // normal operation
+         }
+      }

--- a/packages/addons/script/script.config.vdr/changelog.txt
+++ b/packages/addons/script/script.config.vdr/changelog.txt
@@ -1,3 +1,7 @@
+103
+- scan: "HD Channels" option does not exist any more
+- fix for Leia skinning engine changes
+
 102
 - fix maintainer name
 

--- a/packages/addons/script/script.config.vdr/package.mk
+++ b/packages/addons/script/script.config.vdr/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="script.config.vdr"
-PKG_VERSION="61c2dde"
-PKG_SHA256="40e204ceae6e1e0c30810b891e0fb240ceec2988bab9c41d265f94db6b3c121f"
-PKG_REV="102"
+PKG_VERSION="0345a2a3b98de48cbbaf77768ca6c9289f531e2b"
+PKG_SHA256="793676258c399427047a7d6628984358c67b1180b98df44b48647d20e8f9395b"
+PKG_REV="103"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="https://libreelec.tv"
@@ -19,7 +19,7 @@ PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="dummy"
 
 make_target() {
-  sed -e "s|@ADDON_VERSION@|$ADDON_VERSION.$PKG_REV|g" \
+  sed -e "s|@ADDON_VERSION@|$ADDON_VERSION|g" \
       -e "s|@OS_VERSION@|$OS_VERSION|g" \
       -i addon.xml
 }

--- a/packages/addons/script/script.config.vdr/sources/addon.xml
+++ b/packages/addons/script/script.config.vdr/sources/addon.xml
@@ -7,25 +7,25 @@
      <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
      <import addon="xbmc.python" version="2.1.0"/>
   </requires>
-  <extension point="xbmc.python.pluginsource" library="default.py">
+  <extension library="default.py" point="xbmc.python.pluginsource">
     <provides>executable</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
-    <summary lang="de">VDR-Sendersuchlauf und DiSEqC-Konfiguration</summary>
-    <summary lang="en">VDR channel scan and Diseqc Configuration</summary>
+    <summary lang="de_DE">VDR-Sendersuchlauf und DiSEqC-Konfiguration</summary>
+    <summary lang="en_GB">VDR channel scan and Diseqc Configuration</summary>
     <summary lang="en_US">VDR channel scan and DiSEqC Configuration</summary>
-    <summary lang="lt">VDR kanalų paieška ir Diseqc konfigūravimas</summary>
-    <summary lang="nl">VDR kanaal scan en Diseqc configuratie</summary>
-    <summary lang="pl">Skanowanie kanałów i konfiguracja Diseqc</summary>
+    <summary lang="lt_LT">VDR kanalų paieška ir Diseqc konfigūravimas</summary>
+    <summary lang="nl_NL">VDR kanaal scan en Diseqc configuratie</summary>
+    <summary lang="pl_PL">Skanowanie kanałów i konfiguracja Diseqc</summary>
     <summary lang="pt_BR">Escanear canais VDR e Configuração Diseqc</summary>
-    <description lang="de">VDR-Sendersuchlauf und DiSEqC-Konfiguration</description>
-    <description lang="en">VDR channel scan and Diseqc Configuration</description>
+    <description lang="de_DE">VDR-Sendersuchlauf und DiSEqC-Konfiguration</description>
+    <description lang="en_GB">VDR channel scan and Diseqc Configuration</description>
     <description lang="en_US">VDR channel scan and DiSEqC Configuration</description>
-    <description lang="lt">VDR kanalų paieška ir Diseqc konfigūravimas</description>
-    <description lang="nl">VDR kanaal scan en Diseqc configuratie</description>
-    <description lang="pl">Skanowanie kanałów i konfiguracja Diseqc</description>
+    <description lang="lt_LT">VDR kanalų paieška ir Diseqc konfigūravimas</description>
+    <description lang="nl_NL">VDR kanaal scan en Diseqc configuratie</description>
+    <description lang="pl_PL">Skanowanie kanałów i konfiguracja Diseqc</description>
     <description lang="pt_BR">Escanear canais VDR e Configuração Diseqc</description>
-    <language></language>
+    <language />
     <platform>all</platform>
     <news>
 @PKG_ADDON_NEWS@

--- a/packages/addons/service/vdr-addon/changelog.txt
+++ b/packages/addons/service/vdr-addon/changelog.txt
@@ -1,3 +1,10 @@
+109
+- Fix script.config.vdr scan:
+  . reststfulapi: use header from current wirbelscan
+  . wirbelscan: fix segv, interface channel counts and device detection
+- update VNSI to 1.8.0
+- update VDR 2.4.0 upstream patches
+
 108
 - update VDR to 2.4.0
 - update EPG-Fixer plugin to 354f28b
@@ -5,7 +12,6 @@
 - update IPTV plugin to 5ae793f
 - update Sat>IP plugin to 299296b
 - update VNSI to 1.6.0
-
 
 107
 - add robotv plugin

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="vdr-addon"
 PKG_VERSION="2.4"
-PKG_REV="108"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -15,7 +15,7 @@ PKG_DEPENDS_TARGET="toolchain vdr vdr-plugin-ddci2 vdr-plugin-dummydevice vdr-pl
                     vdr-plugin-streamdev vdr-plugin-vnsiserver vdr-plugin-wirbelscan vdr-plugin-wirbelscancontrol vdr-plugin-xmltv2vdr"
 PKG_SECTION="service.multimedia"
 PKG_SHORTDESC="VDR: a TV streaming server for Linux"
-PKG_LONGDESC="VDR (2.3.x) is a TV streaming server for Linux supporting DVB-S/S2, DVB-C, DVB-T/T2, IPTV and SAT>IP"
+PKG_LONGDESC="VDR (2.4.x) is a TV streaming server for Linux supporting DVB-S/S2, DVB-C, DVB-T/T2, IPTV and SAT>IP"
 PKG_TOOLCHAIN="manual"
 
 PKG_IS_ADDON="yes"

--- a/packages/addons/service/vdr-addon/source/system.d/service.multimedia.vdr-addon.service
+++ b/packages/addons/service/vdr-addon/source/system.d/service.multimedia.vdr-addon.service
@@ -4,7 +4,7 @@ After=graphical.target
 
 [Service]
 ExecStart=/bin/sh -c "exec sh /storage/.kodi/addons/service.multimedia.vdr-addon/bin/vdr.start"
-TimeoutStopSec=4
+TimeoutStopSec=5
 Restart=always
 RestartSec=2
 StartLimitInterval=0


### PR DESCRIPTION
- update VNSI to 1.8.0
- add VDR 2.4.0 upstream patches from ftp://ftp.tvdr.de/vdr/Developer/Patches/vdr-2.4
- Fix script.config.vdr scan: 
  - reststfulapi: use header from current wirbelscan
  - wirbelscan: fix segv, interface channel counts and device detection
  - When LibreELEC/script.config.vdr#7 is merged, addon script.config.vdr can be updated.