### PR TITLE
Buildsystem: mkimage / get cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ distclean:
 	rm -rf ./.ccache ./$(BUILD_DIRS)
 
 src-pkg:
-	tar cvjf sources.tar.bz2 sources .stamps
+	tar cvJf sources.tar.xz sources .stamps

--- a/scripts/get
+++ b/scripts/get
@@ -14,15 +14,11 @@ fi
 
 # Avoid concurrent processing of the same package
 lock_source_dir() {
-  local _isblocked=N
   exec 99<"${SOURCES}/${1}"
-  while ! flock --nonblock --exclusive 99; do
-    if [ ${_isblocked} = N ]; then
-      echo "Project/Device ${DEVICE:-${PROJECT}} waiting, to avoid concurrent processing of ${1}..."
-      _isblocked=Y
-    fi
-    sleep 1
-  done
+  if ! flock --nonblock --exclusive 99; then
+    echo "Project/Device ${DEVICE:-${PROJECT}} waiting, to avoid concurrent processing of ${1}..."
+    flock --exclusive 99
+  fi
 }
 
 if [ -n "${PKG_URL}" -a -n "${PKG_SOURCE_NAME}" ]; then

--- a/scripts/get
+++ b/scripts/get
@@ -3,32 +3,35 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
-. config/options $1
+. config/options "${1}"
 
-if [ -z "$1" ]; then
-  for i in `find packages/ -type f -name package.mk`; do
-    GET_PKG=`grep ^PKG_NAME= $i | sed -e "s,\",,g" -e "s,PKG_NAME=,,"`
-    $SCRIPTS/get $GET_PKG
+if [ -z "${1}" ]; then
+  for i in $(find "${PACKAGES}/" -type f -name "package.mk"); do
+    GET_PKG=$(grep "^PKG_NAME=" "${i}" | sed -e "s,\",,g" -e "s,PKG_NAME=,,")
+    "${SCRIPTS}"/get "${GET_PKG}"
   done
 fi
 
 # Avoid concurrent processing of the same package
-function lock_source_dir() {
+lock_source_dir() {
   local _isblocked=N
-  exec 99<$SOURCES/$1
+  exec 99<"${SOURCES}/${1}"
   while ! flock --nonblock --exclusive 99; do
-    [ ${_isblocked} = N ] && { echo "Project/Device ${DEVICE:-${PROJECT}} waiting, to avoid concurrent processing of ${1}..."; _isblocked=Y; }
+    if [ ${_isblocked} = N ]; then
+      echo "Project/Device ${DEVICE:-${PROJECT}} waiting, to avoid concurrent processing of ${1}..."
+      _isblocked=Y
+    fi
     sleep 1
   done
 }
 
-if [ -n "$PKG_URL" -a -n "$PKG_SOURCE_NAME" ]; then
-  mkdir -p $SOURCES/$1
+if [ -n "${PKG_URL}" -a -n "${PKG_SOURCE_NAME}" ]; then
+  mkdir -p "${SOURCES}/${1}"
 
-  PACKAGE="$SOURCES/$1/$PKG_SOURCE_NAME"
+  PACKAGE="${SOURCES}/${1}/${PKG_SOURCE_NAME}"
 
-  STAMP_URL="$PACKAGE.url"
-  STAMP_SHA="$PACKAGE.sha256"
+  STAMP_URL="${PACKAGE}.url"
+  STAMP_SHA="${PACKAGE}.sha256"
 
   # determine get handler based on protocol and/or filename
   case "${PKG_URL}" in
@@ -41,16 +44,14 @@ if [ -n "$PKG_URL" -a -n "$PKG_SOURCE_NAME" ]; then
   esac
 
   if ! listcontains "${GET_HANDLER_SUPPORT}" "${get_handler}"; then
-    echo "ERROR: get handler \"${get_handler}\" is not supported, unable to get package $1 - aborting!"
-    exit 1
+    die "ERROR: get handler \"${get_handler}\" is not supported, unable to get package ${1} - aborting!"
   else
     get_handler="${SCRIPTS}/get_${get_handler}"
-    if [ ! -f ${get_handler} ]; then
-      echo "ERROR: get handler \"${get_handler}\" does not exist, unable to get package $1 - aborting!"
-      exit 1
-    else
-      source ${get_handler}
+    if [ ! -f "${get_handler}" ]; then
+      die "ERROR: get handler \"${get_handler}\" does not exist, unable to get package ${1} - aborting!"
     fi
+
+    . "${get_handler}"
   fi
 fi
 

--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -2,38 +2,38 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 _get_file_already_downloaded() {
-  [ ! -f $PACKAGE -o ! -f $STAMP_URL -o ! -f $STAMP_SHA ] && return 1
-  [ -n "${PKG_SHA256}" -a "$(cat $STAMP_SHA 2>/dev/null)" != "${PKG_SHA256}" ] && return 1
+  [ ! -f "${PACKAGE}" -o ! -f "${STAMP_URL}" -o ! -f "${STAMP_SHA}" ] && return 1
+  [ -n "${PKG_SHA256}" -a "$(cat ${STAMP_SHA} 2>/dev/null)" != "${PKG_SHA256}" ] && return 1
   return 0
 }
 
 # Latest file already present, exit now...
 _get_file_already_downloaded && exit 0
 
-lock_source_dir $1
+lock_source_dir "${1}"
 
 # Check again in case of concurrent access - if nothing needs to be downloaded, exit now...
 _get_file_already_downloaded && exit 0
 
 # At this point, we need to download something...
-printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      $1 (archive)\n" ' '>&$SILENT_OUT
-export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
+printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      ${1} (archive)\n" ' '>&$SILENT_OUT
+export BUILD_INDENT=$((${BUILD_INDENT:-1}+${BUILD_INDENT_SIZE}))
 
-PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$PKG_SOURCE_NAME"
-[ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c $WGET_OPT --progress=bar:force --show-progress -O $PACKAGE"
+PACKAGE_MIRROR="${DISTRO_MIRROR}/${PKG_NAME}/${PKG_SOURCE_NAME}"
+[ "${VERBOSE}" != "yes" ] && WGET_OPT=-q
+WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c ${WGET_OPT} --progress=bar:force --show-progress -O ${PACKAGE}"
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
 unset LD_LIBRARY_PATH
 
-rm -f $STAMP_URL $STAMP_SHA
+rm -f "${STAMP_URL}" "${STAMP_SHA}"
 
 NBWGET=10
-while [ $NBWGET -gt 0 ]; do
-  for url in "$PKG_URL" "$PACKAGE_MIRROR"; do
-    rm -f $PACKAGE
-    if $WGET_CMD "$url"; then
-      CALC_SHA256="$(sha256sum $PACKAGE | cut -d" " -f1)"
+while [ ${NBWGET} -gt 0 ]; do
+  for url in "${PKG_URL}" "${PACKAGE_MIRROR}"; do
+    rm -f "${PACKAGE}"
+    if ${WGET_CMD} "${url}"; then
+      CALC_SHA256=$(sha256sum "${PACKAGE}" | cut -d" " -f1)
 
       [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2
 
@@ -43,11 +43,10 @@ while [ $NBWGET -gt 0 ]; do
   NBWGET=$((NBWGET - 1))
 done
 
-if [ $NBWGET -eq 0 ]; then
-  echo -e "\nCant't get $1 sources : $PKG_URL\n Try later !!"
-  exit 1
+if [ ${NBWGET} -eq 0 ]; then
+  die "\nCant't get ${1} sources : ${PKG_URL}\nTry later!"
 else
   printf "%${BUILD_INDENT}c $(print_color CLR_INFO "INFO") Calculated checksum: ${CALC_SHA256}\n\n" ' '>&$SILENT_OUT
-  echo "${PKG_URL}" > $STAMP_URL
-  echo "${CALC_SHA256}" > $STAMP_SHA
+  echo "${PKG_URL}" > "${STAMP_URL}"
+  echo "${CALC_SHA256}" > "${STAMP_SHA}"
 fi

--- a/scripts/get_file
+++ b/scripts/get_file
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      $1 (file)\n" ' '>&$SILENT_OUT
-export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
+printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      ${1} (file)\n" ' '>&$SILENT_OUT
+export BUILD_INDENT=$((${BUILD_INDENT:-1}+${BUILD_INDENT_SIZE}))

--- a/scripts/get_git
+++ b/scripts/get_git
@@ -12,14 +12,14 @@
 # PKG_GIT_SUBMODULE_DEPTH (optional) history of submodules to clone, must be a number
 
 _get_repo_already_downloaded() {
-  if [ -d $PACKAGE ]; then
+  if [ -d "${PACKAGE}" ]; then
     (
-      cd $PACKAGE
+      cd "${PACKAGE}"
       _get_repo_clean
-      [ -n "$(git ls-remote . | grep -m1 HEAD | awk "/^${PKG_VERSION}/ {print \$1;}")" ] || exit 1
-      [ "$PKG_URL" = "$(git remote get-url origin)" ] || exit 1
-      [ -z "$PKG_GIT_CLONE_BRANCH" ] && exit 0
-      [ "$PKG_GIT_CLONE_BRANCH" = "$(git branch | grep ^\* | cut -d ' ' -f2)" ] || exit 1
+      [ -n "$(git ls-remote . | grep -m1 HEAD | awk "/^${PKG_VERSION}/ {print \$1;}")" ] || die "ERROR: ${PACKAGE}: failed to determine git HEAD"
+      [ "${PKG_URL}" = "$(git remote get-url origin)" ] || die "ERROR: ${PACKAGE}: failed to obtain URL of origin"
+      [ -z "${PKG_GIT_CLONE_BRANCH}" ] && exit 0
+      [ "${PKG_GIT_CLONE_BRANCH}" = "$(git branch | grep ^\* | cut -d ' ' -f2)" ] || die "ERROR: ${PACKAGE}: failed to determine current git branch"
       exit 0
     )
     return
@@ -36,104 +36,101 @@ _get_repo_clean() {
 # Latest file already present, exit now...
 _get_repo_already_downloaded && exit 0
 
-lock_source_dir $1
+lock_source_dir "${1}"
 
 # Check again in case of concurrent access - if nothing needs to be downloaded, exit now...
 _get_repo_already_downloaded && exit 0
 
 # At this point, we need to download something...
-printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      $1 (git)\n" ' '>&$SILENT_OUT
-export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
+printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      ${1} (git)\n" ' '>&$SILENT_OUT
+export BUILD_INDENT=$((${BUILD_INDENT:-1}+${BUILD_INDENT_SIZE}))
 
-rm -f $STAMP_URL $STAMP_SHA
+rm -f "${STAMP_URL}" "${STAMP_SHA}"
 
 GIT_CLONE_PARAMS=""
 GIT_SUBMODULE_PARAMS=""
 
-[ -n "$PKG_GIT_CLONE_BRANCH" ] && GIT_CLONE_PARAMS="$GIT_CLONE_PARAMS --branch $PKG_GIT_CLONE_BRANCH"
-[ "$PKG_GIT_CLONE_SINGLE" = "yes" ] && GIT_CLONE_PARAMS="$GIT_CLONE_PARAMS --single-branch"
+[ -n "${PKG_GIT_CLONE_BRANCH}" ] && GIT_CLONE_PARAMS="${GIT_CLONE_PARAMS} --branch ${PKG_GIT_CLONE_BRANCH}"
+[ "${PKG_GIT_CLONE_SINGLE}" = "yes" ] && GIT_CLONE_PARAMS="${GIT_CLONE_PARAMS} --single-branch"
 
-if [ -n "$PKG_GIT_CLONE_DEPTH" ]; then
-  if [[ $PKG_GIT_CLONE_DEPTH =~ ^[0-9]+$ ]]; then
-    GIT_CLONE_PARAMS="$GIT_CLONE_PARAMS --depth $PKG_GIT_CLONE_DEPTH"
+if [ -n "${PKG_GIT_CLONE_DEPTH}" ]; then
+  if [[ "${PKG_GIT_CLONE_DEPTH}" =~ ^[0-9]+$ ]]; then
+    GIT_CLONE_PARAMS="$GIT_CLONE_PARAMS --depth ${PKG_GIT_CLONE_DEPTH}"
   else
-    echo "Fatal: PKG_GIT_CLONE_DEPTH is not a number! ($PKG_GIT_CLONE_DEPTH)"
-    exit 1
+    die "ERROR: PKG_GIT_CLONE_DEPTH is not a number! (${PKG_GIT_CLONE_DEPTH})"
   fi
 fi
 
-if [ -n "$PKG_GIT_SUBMODULE_DEPTH" ]; then
-  if [[ $PKG_GIT_SUBMODULE_DEPTH =~ ^[0-9]+$ ]]; then
-    GIT_SUBMODULE_PARAMS="$GIT_SUBMODULE_PARAMS --depth $PKG_GIT_SUBMODULE_DEPTH"
+if [ -n "${PKG_GIT_SUBMODULE_DEPTH}" ]; then
+  if [[ "${PKG_GIT_SUBMODULE_DEPTH}" =~ ^[0-9]+$ ]]; then
+    GIT_SUBMODULE_PARAMS="${GIT_SUBMODULE_PARAMS} --depth ${PKG_GIT_SUBMODULE_DEPTH}"
   else
-    echo "Fatal: PKG_GIT_SUBMODULE_DEPTH is not a number! ($PKG_GIT_SUBMODULE_DEPTH)"
-    exit 1
+    die "ERROR: PKG_GIT_SUBMODULE_DEPTH is not a number! (${PKG_GIT_SUBMODULE_DEPTH})"
   fi
 fi
 
 GIT_FOUND="no"
 opwd=$(pwd)
-for d in $SOURCES/$1/$1-* ; do
-  if [ -d "$d/.git" ]; then
+for d in "${SOURCES}/${1}/${1}-"* ; do
+  if [ -d "${d}/.git" ]; then
     if [ "${GIT_FOUND}" = "no" ]; then
-      cd $d
-      if [ "$PKG_URL" = "$(git remote get-url origin)" ]; then
-        if [ -n "$PKG_GIT_CLONE_BRANCH" -a $(git branch | grep "^\* ${PKG_GIT_CLONE_BRANCH}$" | wc -l) -eq 1 -o -z "$PKG_GIT_CLONE_BRANCH" ]; then
+      cd "${d}"
+      if [ "${PKG_URL}" = "$(git remote get-url origin)" ]; then
+        if [[ -z "${PKG_GIT_CLONE_BRANCH}"]] || [[ $(git branch | grep "^\* ${PKG_GIT_CLONE_BRANCH}$" | wc -l) -eq 1 ]]; then
           GIT_FOUND="yes"
-          GIT_DIR="$d"
+          GIT_DIR="${d}"
           _get_repo_clean
-        elif [ -n "$PKG_GIT_CLONE_BRANCH" -a $(git branch | grep "^  ${PKG_GIT_CLONE_BRANCH}$" | wc -l) -eq 1 ]; then
+        elif [ $(git branch | grep "^  ${PKG_GIT_CLONE_BRANCH}$" | wc -l) -eq 1 ]; then
           GIT_FOUND="yes"
-          GIT_DIR="$d"
+          GIT_DIR="${d}"
           _get_repo_clean
-          git checkout $PKG_GIT_CLONE_BRANCH
-        elif [ -n "$PKG_GIT_CLONE_BRANCH" -a $(git branch -a | grep "^  remotes/origin/${PKG_GIT_CLONE_BRANCH}$" | wc -l) -eq 1 ]; then
+          git checkout "${PKG_GIT_CLONE_BRANCH}"
+        elif [ $(git branch -a | grep "^  remotes/origin/${PKG_GIT_CLONE_BRANCH}$" | wc -l) -eq 1 ]; then
           GIT_FOUND="yes"
-          GIT_DIR="$d"
+          GIT_DIR="${d}"
           _get_repo_clean
-          git checkout -b $PKG_GIT_CLONE_BRANCH origin/$PKG_GIT_CLONE_BRANCH
+          git checkout -b "${PKG_GIT_CLONE_BRANCH}" "origin/${PKG_GIT_CLONE_BRANCH}"
         else
-          printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") ($d)\n" ' '>&$SILENT_OUT
+          printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") (${d})\n" ' '>&$SILENT_OUT
           cd "${opwd}"
-          rm -rf "$d"
+          rm -rf "${d}"
         fi
         if [ "$GIT_FOUND" = "yes" ]; then
-          printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT PULL")   $1\n" ' '>&$SILENT_OUT
+          printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT PULL")   ${1}\n" ' '>&$SILENT_OUT
           git pull
           cd "${opwd}"
         fi
       else
-        printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") ($d)\n" ' '>&$SILENT_OUT
+        printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") (${d})\n" ' '>&$SILENT_OUT
         cd "${opwd}"
-        rm -rf "$d"
+        rm -rf "${d}"
       fi
-    else
-      printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") ($d)\n" ' '>&$SILENT_OUT
-      rm -rf "$d"
     fi
+  else
+    printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") (${d})\n" ' '>&$SILENT_OUT
+    rm -rf "${d}"
   fi
 done
 cd "${opwd}"
 
 if [ "${GIT_FOUND}" = "no" ]; then
-  printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT CLONE")   $1\n" ' '>&$SILENT_OUT
-  git clone $GIT_CLONE_PARAMS $PKG_URL $PACKAGE
+  printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT CLONE")   ${1}\n" ' '>&$SILENT_OUT
+  git clone "${GIT_CLONE_PARAMS}" "${PKG_URL}" "${PACKAGE}"
 else
   if [ ! "${GIT_DIR}" = "${PACKAGE}" ]; then
     mv "${GIT_DIR}" "${PACKAGE}"
   fi
 fi
 
-(
-  cd $PACKAGE
-  [ $(git log --oneline --pretty=tformat:"%H" | grep "^$PKG_VERSION" | wc -l) -eq 1 ] || { echo "There is no commit '$PKG_VERSION' on branch '$(git branch | grep ^\* | cut -d ' ' -f2)' of package '$1'! Aborting!" ; exit 1 ; }
-  git reset --hard $PKG_VERSION
-  printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT SUBMODULE")   $1\n" ' '>&$SILENT_OUT
-  git submodule update --init --recursive $GIT_SUBMODULE_PARAMS
+( cd "${PACKAGE}"
+  [ $(git log --oneline --pretty=tformat:"%H" | grep "^${PKG_VERSION}" | wc -l) -eq 1 ] || die "There is no commit '${PKG_VERSION}' on branch '$(git branch | grep ^\* | cut -d ' ' -f2)' of package '${1}'! Aborting!"
+  git reset --hard "${PKG_VERSION}"
+  printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT SUBMODULE")   ${1}\n" ' '>&$SILENT_OUT
+  git submodule update --init --recursive "${GIT_SUBMODULE_PARAMS}"
 )
 
-GIT_SHA=$(git ls-remote $PACKAGE | grep -m1 HEAD | awk '{print $1;}')
+GIT_SHA=$(git ls-remote "${PACKAGE}" | grep -m1 HEAD | awk '{print $1;}')
 
-if [ -n "$PKG_GIT_SHA" ]; then
-   [ "$PKG_GIT_SHA" = "$GIT_SHA" ] || printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "WARNING") Incorrect git hash in respository: got ${GIT_SHA}, wanted ${PKG_GIT_SHA}\n\n" ' '>&$SILENT_OUT
+if [ -n "${PKG_GIT_SHA}" ]; then
+   [ "${PKG_GIT_SHA}" = "${GIT_SHA}" ] || printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "WARNING") Incorrect git hash in respository: got ${GIT_SHA}, wanted ${PKG_GIT_SHA}\n\n" ' '>&$SILENT_OUT
 fi

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -11,14 +11,14 @@
 
 # set variables
 LE_TMP=$(mktemp -d)
-SAVE_ERROR="$LE_TMP/save_error"
+SAVE_ERROR="${LE_TMP}/save_error"
 
-if [ -z "$SYSTEM_SIZE" -o -z "$SYSTEM_PART_START" ]; then
+if [ -z "${SYSTEM_SIZE}" -o -z "${SYSTEM_PART_START}" ]; then
   echo "mkimage: SYSTEM_SIZE and SYSTEM_PART_START must be configured!"
   exit 1
 fi
 
-if [ "$BOOTLOADER" = "syslinux" ]; then
+if [ "${BOOTLOADER}" = "syslinux" ]; then
   DISK_LABEL=gpt
 else
   DISK_LABEL=msdos
@@ -26,27 +26,24 @@ fi
 
 STORAGE_SIZE=32 # STORAGE_SIZE must be >= 32 !
 
-DISK_START_PADDING=$(( ($SYSTEM_PART_START + 2048 - 1) / 2048 ))
+DISK_START_PADDING=$(( (${SYSTEM_PART_START} + 2048 - 1) / 2048 ))
 DISK_GPT_PADDING=1
-DISK_SIZE=$(( $DISK_START_PADDING + $SYSTEM_SIZE + $STORAGE_SIZE + $DISK_GPT_PADDING ))
-DISK_BASENAME="$TARGET_IMG/$IMAGE_NAME"
+DISK_SIZE=$(( ${DISK_START_PADDING} + ${SYSTEM_SIZE} + ${STORAGE_SIZE} + ${DISK_GPT_PADDING} ))
+DISK_BASENAME="${TARGET_IMG}/${IMAGE_NAME}"
 DISK="${DISK_BASENAME}.img"
 
 # functions
 cleanup() {
-  echo "image: cleanup..."
-  rm -rf "$LE_TMP"
-  echo
-  exit
+  echo -e "image: cleanup...\n"
+  rm -rf "${LE_TMP}"
 }
 
 show_error() {
-  echo "image: error happen..."
-  echo
-  cat "$SAVE_ERROR"
+  echo -e "image: error happen...\n"
+  cat "${SAVE_ERROR}"
   echo
   cleanup
-  exit
+  exit 1
 }
 
 trap cleanup SIGINT
@@ -58,280 +55,281 @@ FAT_SERIAL_NUMBER="${UUID_1}${UUID_2}"
 UUID_SYSTEM="${UUID_1}-${UUID_2}"
 
 # create an image
-echo
-echo "image: creating file $(basename $DISK)..."
-dd if=/dev/zero of="$DISK" bs=1M count="$DISK_SIZE" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
+echo -e "\nimage: creating file $(basename ${DISK})..."
+dd if=/dev/zero of="${DISK}" bs=1M count="${DISK_SIZE}" conv=fsync >"${SAVE_ERROR}" 2>&1 || show_error
 
 # write a disklabel
-echo "image: creating $DISK_LABEL partition table..."
-parted -s "$DISK" mklabel $DISK_LABEL
+echo "image: creating ${DISK_LABEL} partition table..."
+parted -s "${DISK}" mklabel ${DISK_LABEL}
 sync
 
 # create part1
 echo "image: creating part1..."
-SYSTEM_PART_END=$(( $SYSTEM_PART_START + ($SYSTEM_SIZE * 1024 * 1024 / 512) - 1 ))
-if [ "$DISK_LABEL" = "gpt" ]; then
-  parted -s "$DISK" -a min unit s mkpart system fat32 $SYSTEM_PART_START $SYSTEM_PART_END
-  parted -s "$DISK" set 1 legacy_boot on
+SYSTEM_PART_END=$(( ${SYSTEM_PART_START} + (${SYSTEM_SIZE} * 1024 * 1024 / 512) - 1 ))
+if [ "${DISK_LABEL}" = "gpt" ]; then
+  parted -s "${DISK}" -a min unit s mkpart system fat32 ${SYSTEM_PART_START} ${SYSTEM_PART_END}
+  parted -s "${DISK}" set 1 legacy_boot on
 else
-  parted -s "$DISK" -a min unit s mkpart primary fat32 $SYSTEM_PART_START $SYSTEM_PART_END
-  parted -s "$DISK" set 1 boot on
+  parted -s "${DISK}" -a min unit s mkpart primary fat32 ${SYSTEM_PART_START} ${SYSTEM_PART_END}
+  parted -s "${DISK}" set 1 boot on
 fi
 sync
 
 # create part2
 echo "image: creating part2..."
-STORAGE_PART_START=$(( $SYSTEM_PART_END + 1 ))
-STORAGE_PART_END=$(( $STORAGE_PART_START + ($STORAGE_SIZE * 1024 * 1024 / 512) - 1 ))
-if [ "$DISK_LABEL" = "gpt" ]; then
-  parted -s "$DISK" -a min unit s mkpart storage ext4 $STORAGE_PART_START $STORAGE_PART_END
+STORAGE_PART_START=$(( ${SYSTEM_PART_END} + 1 ))
+STORAGE_PART_END=$(( ${STORAGE_PART_START} + (${STORAGE_SIZE} * 1024 * 1024 / 512) - 1 ))
+if [ "${DISK_LABEL}" = "gpt" ]; then
+  parted -s "${DISK}" -a min unit s mkpart storage ext4 ${STORAGE_PART_START} ${STORAGE_PART_END}
 else
-  parted -s "$DISK" -a min unit s mkpart primary ext4 $STORAGE_PART_START $STORAGE_PART_END
+  parted -s "${DISK}" -a min unit s mkpart primary ext4 ${STORAGE_PART_START} ${STORAGE_PART_END}
 fi
 sync
 
-if [ "$BOOTLOADER" = "syslinux" ]; then
+if [ "${BOOTLOADER}" = "syslinux" ]; then
   # write mbr
   echo "image: writing mbr..."
-  MBR="$TOOLCHAIN/share/syslinux/gptmbr.bin"
-  if [ -n "$MBR" ]; then
-    dd bs=440 count=1 conv=fsync,notrunc if="$MBR" of="$DISK" >"$SAVE_ERROR" 2>&1 || show_error
+  MBR="${TOOLCHAIN}/share/syslinux/gptmbr.bin"
+  if [ -n "${MBR}" ]; then
+    dd bs=440 count=1 conv=fsync,notrunc if="${MBR}" of="${DISK}" >"${SAVE_ERROR}" 2>&1 || show_error
   fi
 fi
 
 # create filesystem on part1
 echo "image: creating filesystem on part1..."
-OFFSET=$(( $SYSTEM_PART_START * 512 ))
+OFFSET=$(( ${SYSTEM_PART_START} * 512 ))
 HEADS=4
 TRACKS=32
-SECTORS=$(( $SYSTEM_SIZE * 1024 * 1024 / 512 / $HEADS / $TRACKS ))
+SECTORS=$(( ${SYSTEM_SIZE} * 1024 * 1024 / 512 / ${HEADS} / ${TRACKS} ))
 
 shopt -s expand_aliases  # enables alias expansion in script
-alias mformat="mformat -i $DISK@@$OFFSET -h $HEADS -t $TRACKS -s $SECTORS"
-alias mcopy="mcopy -i $DISK@@$OFFSET"
-alias mmd="mmd -i $DISK@@$OFFSET"
+alias mformat="mformat -i ${DISK}@@${OFFSET} -h ${HEADS} -t ${TRACKS} -s ${SECTORS}"
+alias mcopy="mcopy -i ${DISK}@@${OFFSET}"
+alias mmd="mmd -i ${DISK}@@${OFFSET}"
 
-if [ "$BOOTLOADER" = "syslinux" -o "$BOOTLOADER" = "bcm2835-bootloader" -o "$BOOTLOADER" = "u-boot" ]; then
-  mformat -v "$DISTRO_BOOTLABEL" -N "$FAT_SERIAL_NUMBER" ::
+if [ "${BOOTLOADER}" = "syslinux" -o "${BOOTLOADER}" = "bcm2835-bootloader" -o "${BOOTLOADER}" = "u-boot" ]; then
+  mformat -v "${DISTRO_BOOTLABEL}" -N "${FAT_SERIAL_NUMBER}" ::
 fi
 sync
 
-if [ "$BOOTLOADER" = "syslinux" ]; then
+if [ "${BOOTLOADER}" = "syslinux" ]; then
   # create bootloader configuration
   echo "image: creating bootloader configuration..."
-  cat << EOF > "$LE_TMP"/syslinux.cfg
+  cat << EOF > "${LE_TMP}/syslinux.cfg"
 SAY Wait for installer to start or press <TAB> for more options (live, run)
 DEFAULT installer
 TIMEOUT 50
 PROMPT 1
 
 LABEL installer
-  KERNEL /$KERNEL_NAME
-  APPEND boot=UUID=$UUID_SYSTEM installer quiet tty vga=current
+  KERNEL /${KERNEL_NAME}
+  APPEND boot=UUID=${UUID_SYSTEM} installer quiet tty vga=current
 
 LABEL live
-  KERNEL /$KERNEL_NAME
-  APPEND boot=UUID=$UUID_SYSTEM live quiet tty vga=current
+  KERNEL /${KERNEL_NAME}
+  APPEND boot=UUID=${UUID_SYSTEM} live quiet tty vga=current
 
 LABEL run
-  KERNEL /$KERNEL_NAME
-  APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE tty portable quiet
+  KERNEL /${KERNEL_NAME}
+  APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} tty portable quiet
 EOF
 
-  cat << EOF > "$LE_TMP"/grub.cfg
+  cat << EOF > "${LE_TMP}/grub.cfg"
 set timeout="25"
 set default="Installer"
 menuentry "Installer" {
 	search --set -f /KERNEL
-	linux /KERNEL boot=UUID=$UUID_SYSTEM installer quiet tty vga=current
+	linux /KERNEL boot=UUID=${UUID_SYSTEM} installer quiet tty vga=current
 }
 menuentry "Live" {
 	search --set -f /KERNEL
-	linux /KERNEL boot=UUID=$UUID_SYSTEM grub_live quiet tty vga=current
+	linux /KERNEL boot=UUID=${UUID_SYSTEM} grub_live quiet tty vga=current
 }
 menuentry "Run" {
 	search --set -f /KERNEL
-	linux /KERNEL boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE tty grub_portable quiet
+	linux /KERNEL boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} tty grub_portable quiet
 }
 EOF
 
-  mcopy "$LE_TMP/syslinux.cfg" ::
+  mcopy "${LE_TMP}/syslinux.cfg" ::
 
   # install syslinux
   echo "image: installing syslinux to part1..."
-  syslinux.mtools --offset "$OFFSET" -i "$DISK"
+  syslinux.mtools --offset "${OFFSET}" -i "${DISK}"
 
   # copy files
   echo "image: copying files to part1..."
-  mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
-  mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-  mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-  mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
+  mcopy "${TARGET_IMG}/${IMAGE_NAME}.kernel" "::/${KERNEL_NAME}"
+  mcopy "${TARGET_IMG}/${IMAGE_NAME}.system" ::/SYSTEM
+  mcopy "${RELEASE_DIR}/target/KERNEL.md5" "::/${KERNEL_NAME}.md5"
+  mcopy "${RELEASE_DIR}/target/SYSTEM.md5" ::/SYSTEM.md5
 
   mmd EFI EFI/BOOT
-  mcopy $TOOLCHAIN/share/syslinux/bootx64.efi ::/EFI/BOOT
-  mcopy $TOOLCHAIN/share/syslinux/ldlinux.e64 ::/EFI/BOOT
-  mcopy $TOOLCHAIN/share/grub/bootia32.efi ::/EFI/BOOT
-  mcopy "$LE_TMP"/grub.cfg ::/EFI/BOOT
+  mcopy "${TOOLCHAIN}/share/syslinux/bootx64.efi" ::/EFI/BOOT
+  mcopy "${TOOLCHAIN}/share/syslinux/ldlinux.e64" ::/EFI/BOOT
+  mcopy "${TOOLCHAIN}/share/grub/bootia32.efi" ::/EFI/BOOT
+  mcopy "${LE_TMP}/grub.cfg" ::/EFI/BOOT
 
-elif [ "$BOOTLOADER" = "bcm2835-bootloader" ]; then
+elif [ "${BOOTLOADER}" = "bcm2835-bootloader" ]; then
   # create bootloader configuration
   echo "image: creating bootloader configuration..."
-  cat << EOF > "$LE_TMP"/cmdline.txt
-boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet $EXTRA_CMDLINE
+  cat << EOF > "${LE_TMP}/cmdline.txt"
+boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} quiet ${EXTRA_CMDLINE}
 EOF
 
-  mcopy "$LE_TMP/cmdline.txt" ::
+  mcopy "${LE_TMP}/cmdline.txt" ::
 
   # copy files
   echo "image: copying files to part1..."
-  mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
-  mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-  mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-  mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
+  mcopy "${TARGET_IMG}/${IMAGE_NAME}.kernel" "::/${KERNEL_NAME}"
+  mcopy "${TARGET_IMG}/${IMAGE_NAME}.system" ::/SYSTEM
+  mcopy "${RELEASE_DIR}/target/KERNEL.md5" "::/${KERNEL_NAME}.md5"
+  mcopy "${RELEASE_DIR}/target/SYSTEM.md5" ::/SYSTEM.md5
 
-  mcopy $RELEASE_DIR/3rdparty/bootloader/bootcode.bin ::
-  mcopy $RELEASE_DIR/3rdparty/bootloader/fixup.dat ::
-  mcopy $RELEASE_DIR/3rdparty/bootloader/start.elf ::
-  mcopy $RELEASE_DIR/3rdparty/bootloader/config.txt ::
-  mcopy $RELEASE_DIR/3rdparty/bootloader/distroconfig.txt ::
+  mcopy "${RELEASE_DIR}/3rdparty/bootloader/bootcode.bin" ::
+  mcopy "${RELEASE_DIR}/3rdparty/bootloader/fixup.dat" ::
+  mcopy "${RELEASE_DIR}/3rdparty/bootloader/start.elf" ::
+  mcopy "${RELEASE_DIR}/3rdparty/bootloader/config.txt" ::
+  mcopy "${RELEASE_DIR}/3rdparty/bootloader/distroconfig.txt" ::
 
-  if [ -f $RELEASE_DIR/3rdparty/bootloader/dt-blob.bin ]; then
-    mcopy $RELEASE_DIR/3rdparty/bootloader/dt-blob.bin ::
+  if [ -f "${RELEASE_DIR}/3rdparty/bootloader/dt-blob.bin" ]; then
+    mcopy "${RELEASE_DIR}/3rdparty/bootloader/dt-blob.bin" ::
   fi
 
-  for dtb in $RELEASE_DIR/3rdparty/bootloader/*.dtb ; do
-    if [ -f $dtb ] ; then
-      mcopy "$dtb" ::/$(basename "$dtb")
+  for dtb in "${RELEASE_DIR}/3rdparty/bootloader/"*.dtb ; do
+    if [ -f "${dtb}" ]; then
+      mcopy "${dtb}" ::/$(basename "${dtb}")
     fi
   done
 
-  if [ -d $RELEASE_DIR/3rdparty/bootloader/overlays ]; then
-    mcopy -s $RELEASE_DIR/3rdparty/bootloader/overlays ::
+  if [ -d "${RELEASE_DIR}/3rdparty/bootloader/overlays" ]; then
+    mcopy -s "${RELEASE_DIR}/3rdparty/bootloader/overlays" ::
   fi
 
-elif [ "$BOOTLOADER" = "u-boot" -a \( -n "$UBOOT_SYSTEM" -o "$UBOOT_VERSION" = "vendor" \) ]; then
+elif [ "${BOOTLOADER}" = "u-boot" -a \( -n "${UBOOT_SYSTEM}" -o "${UBOOT_VERSION}" = "vendor" \) ]; then
   # create bootloader configuration
   echo "image: creating bootloader configuration..."
 
-  if [ "$UBOOT_VERSION" != "vendor" ]; then
-    DTB="$($SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM dtb)"
+  if [ "${UBOOT_VERSION}" != "vendor" ]; then
+    DTB="$(${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb)"
 
-    if [ -f "$RELEASE_DIR/3rdparty/bootloader/$DTB" ]; then
-      mcopy $RELEASE_DIR/3rdparty/bootloader/$DTB ::
+    if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ]; then
+      mcopy "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ::
     fi
 
-    mkdir -p "$LE_TMP"/extlinux
+    mkdir -p "${LE_TMP}/extlinux"
 
-    cat << EOF > "$LE_TMP"/extlinux/extlinux.conf
-LABEL $DISTRO
-  LINUX /$KERNEL_NAME
-  FDT /$DTB
-  APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet $EXTRA_CMDLINE
+    cat << EOF > "${LE_TMP}/extlinux/extlinux.conf"
+LABEL ${DISTRO}
+  LINUX /${KERNEL_NAME}
+  FDT /${DTB}
+  APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} quiet ${EXTRA_CMDLINE}
 EOF
 
-    mcopy -s "$LE_TMP"/extlinux ::
+    mcopy -s "${LE_TMP}/extlinux" ::
   fi
 
-  if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage ]; then
-    . $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage
-  elif [ -f $PROJECT_DIR/$PROJECT/bootloader/mkimage ]; then
-    . $PROJECT_DIR/$PROJECT/bootloader/mkimage
+  if [ -f "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/bootloader/mkimage" ]; then
+    . "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/bootloader/mkimage"
+  elif [ -f "${PROJECT_DIR}/${PROJECT}/bootloader/mkimage" ]; then
+    . "${PROJECT_DIR}/${PROJECT}/bootloader/mkimage"
   else
     echo "image: skipping u-boot. no mkimage script found"
   fi
 
   echo "image: copying files to part1..."
-  mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
-  mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-  mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-  mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
+  mcopy "${TARGET_IMG}/${IMAGE_NAME}.kernel" "::/${KERNEL_NAME}"
+  mcopy "${TARGET_IMG}/${IMAGE_NAME}.system" ::/SYSTEM
+  mcopy "${RELEASE_DIR}/target/KERNEL.md5" "::/${KERNEL_NAME}.md5"
+  mcopy "${RELEASE_DIR}/target/SYSTEM.md5" ::/SYSTEM.md5
 
-elif [ "$BOOTLOADER" = "u-boot" ]; then
+elif [ "${BOOTLOADER}" = "u-boot" ]; then
   echo "to make an image using u-boot UBOOT_SYSTEM must be set"
   cleanup
+  exit
 fi # bootloader
 
 # extract part2 from image to format and copy files
 echo "image: extracting part2 from image..."
-STORAGE_PART_COUNT=$(( $STORAGE_PART_END - $STORAGE_PART_START + 1 ))
+STORAGE_PART_COUNT=$(( ${STORAGE_PART_END} - ${STORAGE_PART_START} + 1 ))
 sync
-dd if="$DISK" of="$LE_TMP/part2.ext4" bs=512 skip="$STORAGE_PART_START" count="$STORAGE_PART_COUNT" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
+dd if="${DISK}" of="${LE_TMP}/part2.ext4" bs=512 skip="${STORAGE_PART_START}" count="${STORAGE_PART_COUNT}" conv=fsync >"${SAVE_ERROR}" 2>&1 || show_error
 
 # create filesystem on part2
 echo "image: creating filesystem on part2..."
-mke2fs -F -q -t ext4 -m 0 "$LE_TMP/part2.ext4"
-tune2fs -L "$DISTRO_DISKLABEL" -U $UUID_STORAGE "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
-e2fsck -n "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+mke2fs -F -q -t ext4 -m 0 "${LE_TMP}/part2.ext4"
+tune2fs -L "${DISTRO_DISKLABEL}" -U ${UUID_STORAGE} "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
+e2fsck -n "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 sync
 
 # add resize mark
-mkdir "$LE_TMP/part2.fs"
-touch "$LE_TMP/part2.fs/.please_resize_me"
+mkdir "${LE_TMP}/part2.fs"
+touch "${LE_TMP}/part2.fs/.please_resize_me"
 echo "image: populating filesystem on part2..."
-populatefs -U -d "$LE_TMP/part2.fs" "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+populatefs -U -d "${LE_TMP}/part2.fs" "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 sync
-e2fsck -n "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+e2fsck -n "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 
 # merge part2 back to disk image
 echo "image: merging part2 back to image..."
-dd if="$LE_TMP/part2.ext4" of="$DISK" bs=512 seek="$STORAGE_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
+dd if="${LE_TMP}/part2.ext4" of="${DISK}" bs=512 seek="${STORAGE_PART_START}" conv=fsync,notrunc >"${SAVE_ERROR}" 2>&1 || show_error
 
 # extract part1 from image to run fsck
 echo "image: extracting part1 from image..."
-SYSTEM_PART_COUNT=$(( $SYSTEM_PART_END - $SYSTEM_PART_START + 1 ))
+SYSTEM_PART_COUNT=$(( ${SYSTEM_PART_END} - ${SYSTEM_PART_START} + 1 ))
 sync
-dd if="$DISK" of="$LE_TMP/part1.fat" bs=512 skip="$SYSTEM_PART_START" count="$SYSTEM_PART_COUNT" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
+dd if="${DISK}" of="${LE_TMP}/part1.fat" bs=512 skip="${SYSTEM_PART_START}" count="${SYSTEM_PART_COUNT}" conv=fsync >"${SAVE_ERROR}" 2>&1 || show_error
 echo "image: checking filesystem on part1..."
-fsck -n $LE_TMP/part1.fat >"$SAVE_ERROR" 2>&1 || show_error
+fsck -n "${LE_TMP}/part1.fat" >"${SAVE_ERROR}" 2>&1 || show_error
 
 # create virtual image
-if [ "$PROJECT" = "Generic" ]; then
+if [ "${PROJECT}" = "Generic" ]; then
   echo "image: creating open virtual appliance..."
   # duplicate $DISK so anything we do to it directly doesn't effect original
-  dd if="$DISK" of="${DISK_BASENAME}.tmp" bs=1M >"$SAVE_ERROR" 2>&1 || show_error
+  dd if="${DISK}" of="${DISK_BASENAME}.tmp" bs=1M >"${SAVE_ERROR}" 2>&1 || show_error
   # change syslinux default to 'run'
   echo "image: modifying fs on part1 for open virtual appliance..."
-  sed -i "/DEFAULT/ s/installer/run/" "$LE_TMP"/syslinux.cfg
-  sed -i "/set default=/s/\"Installer\"/\"Run\"/" "$LE_TMP"/grub.cfg
+  sed -e "/DEFAULT/ s/installer/run/" -i "${LE_TMP}/syslinux.cfg"
+  sed -e "/set default=/s/\"Installer\"/\"Run\"/" -i "${LE_TMP}/grub.cfg"
   # FIXME: an unalias should work here, but it does not; call mcopy directly
-  $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/syslinux.cfg ::
-  $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/grub.cfg ::/EFI/BOOT
+  "${TOOLCHAIN}"/bin/mcopy -i "${LE_TMP}/part1.fat" -o "${LE_TMP}/syslinux.cfg" ::
+  "${TOOLCHAIN}"/bin/mcopy -i "${LE_TMP}/part1.fat" -o "${LE_TMP}/grub.cfg" ::/EFI/BOOT
   sync
   # merge modified part1 back to tmp disk image
   echo "image: merging part1 back to open virtual appliance..."
-  dd if="$LE_TMP/part1.fat" of="${DISK_BASENAME}.tmp" bs=512 seek="$SYSTEM_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
+  dd if="${LE_TMP}/part1.fat" of="${DISK_BASENAME}.tmp" bs=512 seek="${SYSTEM_PART_START}" conv=fsync,notrunc >"${SAVE_ERROR}" 2>&1 || show_error
   # create vmdk from tmp $DISK
   qemu-img convert -O vmdk -o subformat=streamOptimized "${DISK_BASENAME}.tmp" "${DISK_BASENAME}.vmdk"
   # generate ovf from template
-  sed -e "s,@DISTRO@,$DISTRO,g" -e "s,@DISK@,${IMAGE_NAME},g" \
-      -e "s,@DISK_SIZE@,$(($DISK_SIZE*1024*1024)),g" \
-      $PROJECT_DIR/$PROJECT/config/ovf.template > ${DISK_BASENAME}.ovf
+  sed -e "s,@DISTRO@,${DISTRO},g" -e "s,@DISK@,${IMAGE_NAME},g" \
+      -e "s,@DISK_SIZE@,$((${DISK_SIZE}*1024*1024)),g" \
+      "${PROJECT_DIR}/${PROJECT}/config/ovf.template" > "${DISK_BASENAME}.ovf"
   # combine ovf and vmdk into official ova
-  tar -C $TARGET_IMG -cf ${DISK_BASENAME}.ova ${IMAGE_NAME}.ovf ${IMAGE_NAME}.vmdk
+  tar -C "${TARGET_IMG}" -cf "${DISK_BASENAME}.ova" "${IMAGE_NAME}.ovf" "${IMAGE_NAME}.vmdk"
   # create sha256 checksum of ova image
-  ( cd $TARGET_IMG
-    sha256sum ${IMAGE_NAME}.ova > ${IMAGE_NAME}.ova.sha256
+  ( cd "${TARGET_IMG}"
+    sha256sum "${IMAGE_NAME}.ova" > "${IMAGE_NAME}.ova.sha256"
   )
   echo "image: cleaning up..."
   # remove tmp $DISK, vmdk and ovf
-  rm ${DISK_BASENAME}.tmp ${DISK_BASENAME}.vmdk ${DISK_BASENAME}.ovf
+  rm "${DISK_BASENAME}.tmp" "${DISK_BASENAME}.vmdk" "${DISK_BASENAME}.ovf"
   # set owner
-  [ -n "$SUDO_USER" ] && chown $SUDO_USER: ${DISK_BASENAME}.ova
+  [ -n "${SUDO_USER}" ] && chown "${SUDO_USER}:" "${DISK_BASENAME}.ova"
 fi
 
 # gzip
 echo "image: compressing..."
-gzip $DISK
+gzip "${DISK}"
 
 # set owner
-if [ -n "$SUDO_USER" ] ; then
-  chown $SUDO_USER: $DISK.gz
+if [ -n "${SUDO_USER}" ]; then
+  chown "${SUDO_USER}:" "${DISK}.gz"
 fi
 # create sha256 checksum of image
-( cd $TARGET_IMG
-  sha256sum $(basename $DISK).gz > $(basename $DISK).gz.sha256
+( cd "${TARGET_IMG}"
+  sha256sum $(basename "${DISK}").gz > $(basename "${DISK}").gz.sha256
 )
 
 # cleanup
 cleanup
+exit

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -10,116 +10,116 @@
 ################################################################################
 
 # set variables
-  LE_TMP=$(mktemp -d)
-  SAVE_ERROR="$LE_TMP/save_error"
+LE_TMP=$(mktemp -d)
+SAVE_ERROR="$LE_TMP/save_error"
 
-  if [ -z "$SYSTEM_SIZE" -o -z "$SYSTEM_PART_START" ]; then
-    echo "mkimage: SYSTEM_SIZE and SYSTEM_PART_START must be configured!"
-    exit 1
-  fi
+if [ -z "$SYSTEM_SIZE" -o -z "$SYSTEM_PART_START" ]; then
+  echo "mkimage: SYSTEM_SIZE and SYSTEM_PART_START must be configured!"
+  exit 1
+fi
 
-  if [ "$BOOTLOADER" = "syslinux" ]; then
-    DISK_LABEL=gpt
-  else
-    DISK_LABEL=msdos
-  fi
+if [ "$BOOTLOADER" = "syslinux" ]; then
+  DISK_LABEL=gpt
+else
+  DISK_LABEL=msdos
+fi
 
-  STORAGE_SIZE=32 # STORAGE_SIZE must be >= 32 !
+STORAGE_SIZE=32 # STORAGE_SIZE must be >= 32 !
 
-  DISK_START_PADDING=$(( ($SYSTEM_PART_START + 2048 - 1) / 2048 ))
-  DISK_GPT_PADDING=1
-  DISK_SIZE=$(( $DISK_START_PADDING + $SYSTEM_SIZE + $STORAGE_SIZE + $DISK_GPT_PADDING ))
-  DISK_BASENAME="$TARGET_IMG/$IMAGE_NAME"
-  DISK="${DISK_BASENAME}.img"
+DISK_START_PADDING=$(( ($SYSTEM_PART_START + 2048 - 1) / 2048 ))
+DISK_GPT_PADDING=1
+DISK_SIZE=$(( $DISK_START_PADDING + $SYSTEM_SIZE + $STORAGE_SIZE + $DISK_GPT_PADDING ))
+DISK_BASENAME="$TARGET_IMG/$IMAGE_NAME"
+DISK="${DISK_BASENAME}.img"
 
 # functions
-  cleanup() {
-    echo "image: cleanup..."
-    rm -rf "$LE_TMP"
-    echo
-    exit
-  }
+cleanup() {
+  echo "image: cleanup..."
+  rm -rf "$LE_TMP"
+  echo
+  exit
+}
 
-  show_error() {
-    echo "image: error happen..."
-    echo
-    cat "$SAVE_ERROR"
-    echo
-    cleanup
-    exit
-  }
+show_error() {
+  echo "image: error happen..."
+  echo
+  cat "$SAVE_ERROR"
+  echo
+  cleanup
+  exit
+}
 
 trap cleanup SIGINT
 
 # generate volume id for fat partition
-  UUID_1=$(date '+%d%m')
-  UUID_2=$(date '+%M%S')
-  FAT_SERIAL_NUMBER="${UUID_1}${UUID_2}"
-  UUID_SYSTEM="${UUID_1}-${UUID_2}"
+UUID_1=$(date '+%d%m')
+UUID_2=$(date '+%M%S')
+FAT_SERIAL_NUMBER="${UUID_1}${UUID_2}"
+UUID_SYSTEM="${UUID_1}-${UUID_2}"
 
 # create an image
-  echo
-  echo "image: creating file $(basename $DISK)..."
-  dd if=/dev/zero of="$DISK" bs=1M count="$DISK_SIZE" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
+echo
+echo "image: creating file $(basename $DISK)..."
+dd if=/dev/zero of="$DISK" bs=1M count="$DISK_SIZE" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
 
 # write a disklabel
-  echo "image: creating $DISK_LABEL partition table..."
-  parted -s "$DISK" mklabel $DISK_LABEL
-  sync
+echo "image: creating $DISK_LABEL partition table..."
+parted -s "$DISK" mklabel $DISK_LABEL
+sync
 
 # create part1
-  echo "image: creating part1..."
-  SYSTEM_PART_END=$(( $SYSTEM_PART_START + ($SYSTEM_SIZE * 1024 * 1024 / 512) - 1 ))
-  if [ "$DISK_LABEL" = "gpt" ]; then
-    parted -s "$DISK" -a min unit s mkpart system fat32 $SYSTEM_PART_START $SYSTEM_PART_END
-    parted -s "$DISK" set 1 legacy_boot on
-  else
-    parted -s "$DISK" -a min unit s mkpart primary fat32 $SYSTEM_PART_START $SYSTEM_PART_END
-    parted -s "$DISK" set 1 boot on
-  fi
-  sync
+echo "image: creating part1..."
+SYSTEM_PART_END=$(( $SYSTEM_PART_START + ($SYSTEM_SIZE * 1024 * 1024 / 512) - 1 ))
+if [ "$DISK_LABEL" = "gpt" ]; then
+  parted -s "$DISK" -a min unit s mkpart system fat32 $SYSTEM_PART_START $SYSTEM_PART_END
+  parted -s "$DISK" set 1 legacy_boot on
+else
+  parted -s "$DISK" -a min unit s mkpart primary fat32 $SYSTEM_PART_START $SYSTEM_PART_END
+  parted -s "$DISK" set 1 boot on
+fi
+sync
 
 # create part2
-  echo "image: creating part2..."
-  STORAGE_PART_START=$(( $SYSTEM_PART_END + 1 ))
-  STORAGE_PART_END=$(( $STORAGE_PART_START + ($STORAGE_SIZE * 1024 * 1024 / 512) - 1 ))
-  if [ "$DISK_LABEL" = "gpt" ]; then
-    parted -s "$DISK" -a min unit s mkpart storage ext4 $STORAGE_PART_START $STORAGE_PART_END
-  else
-    parted -s "$DISK" -a min unit s mkpart primary ext4 $STORAGE_PART_START $STORAGE_PART_END
-  fi
-  sync
+echo "image: creating part2..."
+STORAGE_PART_START=$(( $SYSTEM_PART_END + 1 ))
+STORAGE_PART_END=$(( $STORAGE_PART_START + ($STORAGE_SIZE * 1024 * 1024 / 512) - 1 ))
+if [ "$DISK_LABEL" = "gpt" ]; then
+  parted -s "$DISK" -a min unit s mkpart storage ext4 $STORAGE_PART_START $STORAGE_PART_END
+else
+  parted -s "$DISK" -a min unit s mkpart primary ext4 $STORAGE_PART_START $STORAGE_PART_END
+fi
+sync
 
 if [ "$BOOTLOADER" = "syslinux" ]; then
   # write mbr
-    echo "image: writing mbr..."
-    MBR="$TOOLCHAIN/share/syslinux/gptmbr.bin"
-    if [ -n "$MBR" ]; then
-      dd bs=440 count=1 conv=fsync,notrunc if="$MBR" of="$DISK" >"$SAVE_ERROR" 2>&1 || show_error
-    fi
+  echo "image: writing mbr..."
+  MBR="$TOOLCHAIN/share/syslinux/gptmbr.bin"
+  if [ -n "$MBR" ]; then
+    dd bs=440 count=1 conv=fsync,notrunc if="$MBR" of="$DISK" >"$SAVE_ERROR" 2>&1 || show_error
+  fi
 fi
 
 # create filesystem on part1
-  echo "image: creating filesystem on part1..."
-  OFFSET=$(( $SYSTEM_PART_START * 512 ))
-  HEADS=4
-  TRACKS=32
-  SECTORS=$(( $SYSTEM_SIZE * 1024 * 1024 / 512 / $HEADS / $TRACKS ))
+echo "image: creating filesystem on part1..."
+OFFSET=$(( $SYSTEM_PART_START * 512 ))
+HEADS=4
+TRACKS=32
+SECTORS=$(( $SYSTEM_SIZE * 1024 * 1024 / 512 / $HEADS / $TRACKS ))
 
-  shopt -s expand_aliases  # enables alias expansion in script
-  alias mformat="mformat -i $DISK@@$OFFSET -h $HEADS -t $TRACKS -s $SECTORS"
-  alias mcopy="mcopy -i $DISK@@$OFFSET"
-  alias mmd="mmd -i $DISK@@$OFFSET"
+shopt -s expand_aliases  # enables alias expansion in script
+alias mformat="mformat -i $DISK@@$OFFSET -h $HEADS -t $TRACKS -s $SECTORS"
+alias mcopy="mcopy -i $DISK@@$OFFSET"
+alias mmd="mmd -i $DISK@@$OFFSET"
 
-  if [ "$BOOTLOADER" = "syslinux" -o "$BOOTLOADER" = "bcm2835-bootloader" -o "$BOOTLOADER" = "u-boot" ]; then
-    mformat -v "$DISTRO_BOOTLABEL" -N "$FAT_SERIAL_NUMBER" ::
-  fi
-  sync
+if [ "$BOOTLOADER" = "syslinux" -o "$BOOTLOADER" = "bcm2835-bootloader" -o "$BOOTLOADER" = "u-boot" ]; then
+  mformat -v "$DISTRO_BOOTLABEL" -N "$FAT_SERIAL_NUMBER" ::
+fi
+sync
 
 if [ "$BOOTLOADER" = "syslinux" ]; then
   # create bootloader configuration
-    echo "image: creating bootloader configuration..."
-    cat << EOF > "$LE_TMP"/syslinux.cfg
+  echo "image: creating bootloader configuration..."
+  cat << EOF > "$LE_TMP"/syslinux.cfg
 SAY Wait for installer to start or press <TAB> for more options (live, run)
 DEFAULT installer
 TIMEOUT 50
@@ -138,7 +138,7 @@ LABEL run
   APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE tty portable quiet
 EOF
 
-    cat << EOF > "$LE_TMP"/grub.cfg
+  cat << EOF > "$LE_TMP"/grub.cfg
 set timeout="25"
 set default="Installer"
 menuentry "Installer" {
@@ -155,96 +155,97 @@ menuentry "Run" {
 }
 EOF
 
-    mcopy "$LE_TMP/syslinux.cfg" ::
+  mcopy "$LE_TMP/syslinux.cfg" ::
 
   # install syslinux
-    echo "image: installing syslinux to part1..."
-    syslinux.mtools --offset "$OFFSET" -i "$DISK"
+  echo "image: installing syslinux to part1..."
+  syslinux.mtools --offset "$OFFSET" -i "$DISK"
 
   # copy files
-    echo "image: copying files to part1..."
-    mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
-    mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-    mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-    mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
+  echo "image: copying files to part1..."
+  mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
+  mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
+  mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
+  mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
 
-    mmd EFI EFI/BOOT
-    mcopy $TOOLCHAIN/share/syslinux/bootx64.efi ::/EFI/BOOT
-    mcopy $TOOLCHAIN/share/syslinux/ldlinux.e64 ::/EFI/BOOT
-    mcopy $TOOLCHAIN/share/grub/bootia32.efi ::/EFI/BOOT
-    mcopy "$LE_TMP"/grub.cfg ::/EFI/BOOT
+  mmd EFI EFI/BOOT
+  mcopy $TOOLCHAIN/share/syslinux/bootx64.efi ::/EFI/BOOT
+  mcopy $TOOLCHAIN/share/syslinux/ldlinux.e64 ::/EFI/BOOT
+  mcopy $TOOLCHAIN/share/grub/bootia32.efi ::/EFI/BOOT
+  mcopy "$LE_TMP"/grub.cfg ::/EFI/BOOT
+
 elif [ "$BOOTLOADER" = "bcm2835-bootloader" ]; then
   # create bootloader configuration
-    echo "image: creating bootloader configuration..."
-    cat << EOF > "$LE_TMP"/cmdline.txt
+  echo "image: creating bootloader configuration..."
+  cat << EOF > "$LE_TMP"/cmdline.txt
 boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet $EXTRA_CMDLINE
 EOF
 
-    mcopy "$LE_TMP/cmdline.txt" ::
+  mcopy "$LE_TMP/cmdline.txt" ::
 
   # copy files
-    echo "image: copying files to part1..."
-    mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
-    mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-    mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-    mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
+  echo "image: copying files to part1..."
+  mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
+  mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
+  mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
+  mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
 
-    mcopy $RELEASE_DIR/3rdparty/bootloader/bootcode.bin ::
-    mcopy $RELEASE_DIR/3rdparty/bootloader/fixup.dat ::
-    mcopy $RELEASE_DIR/3rdparty/bootloader/start.elf ::
-    mcopy $RELEASE_DIR/3rdparty/bootloader/config.txt ::
-    mcopy $RELEASE_DIR/3rdparty/bootloader/distroconfig.txt ::
+  mcopy $RELEASE_DIR/3rdparty/bootloader/bootcode.bin ::
+  mcopy $RELEASE_DIR/3rdparty/bootloader/fixup.dat ::
+  mcopy $RELEASE_DIR/3rdparty/bootloader/start.elf ::
+  mcopy $RELEASE_DIR/3rdparty/bootloader/config.txt ::
+  mcopy $RELEASE_DIR/3rdparty/bootloader/distroconfig.txt ::
 
-    if [ -f $RELEASE_DIR/3rdparty/bootloader/dt-blob.bin ]; then
-      mcopy $RELEASE_DIR/3rdparty/bootloader/dt-blob.bin ::
+  if [ -f $RELEASE_DIR/3rdparty/bootloader/dt-blob.bin ]; then
+    mcopy $RELEASE_DIR/3rdparty/bootloader/dt-blob.bin ::
+  fi
+
+  for dtb in $RELEASE_DIR/3rdparty/bootloader/*.dtb ; do
+    if [ -f $dtb ] ; then
+      mcopy "$dtb" ::/$(basename "$dtb")
     fi
+  done
 
-    for dtb in $RELEASE_DIR/3rdparty/bootloader/*.dtb ; do
-      if [ -f $dtb ] ; then
-        mcopy "$dtb" ::/$(basename "$dtb")
-      fi
-    done
-
-    if [ -d $RELEASE_DIR/3rdparty/bootloader/overlays ]; then
-      mcopy -s $RELEASE_DIR/3rdparty/bootloader/overlays ::
-    fi
+  if [ -d $RELEASE_DIR/3rdparty/bootloader/overlays ]; then
+    mcopy -s $RELEASE_DIR/3rdparty/bootloader/overlays ::
+  fi
 
 elif [ "$BOOTLOADER" = "u-boot" -a \( -n "$UBOOT_SYSTEM" -o "$UBOOT_VERSION" = "vendor" \) ]; then
   # create bootloader configuration
-    echo "image: creating bootloader configuration..."
+  echo "image: creating bootloader configuration..."
 
-    if [ "$UBOOT_VERSION" != "vendor" ]; then
-      DTB="$($SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM dtb)"
+  if [ "$UBOOT_VERSION" != "vendor" ]; then
+    DTB="$($SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM dtb)"
 
-      if [ -f "$RELEASE_DIR/3rdparty/bootloader/$DTB" ]; then
-        mcopy $RELEASE_DIR/3rdparty/bootloader/$DTB ::
-      fi
+    if [ -f "$RELEASE_DIR/3rdparty/bootloader/$DTB" ]; then
+      mcopy $RELEASE_DIR/3rdparty/bootloader/$DTB ::
+    fi
 
-      mkdir -p "$LE_TMP"/extlinux
+    mkdir -p "$LE_TMP"/extlinux
 
-      cat << EOF > "$LE_TMP"/extlinux/extlinux.conf
+    cat << EOF > "$LE_TMP"/extlinux/extlinux.conf
 LABEL $DISTRO
   LINUX /$KERNEL_NAME
   FDT /$DTB
   APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet $EXTRA_CMDLINE
 EOF
 
-      mcopy -s "$LE_TMP"/extlinux ::
-    fi
+    mcopy -s "$LE_TMP"/extlinux ::
+  fi
 
-    if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage ]; then
-      . $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage
-    elif [ -f $PROJECT_DIR/$PROJECT/bootloader/mkimage ]; then
-      . $PROJECT_DIR/$PROJECT/bootloader/mkimage
-    else
-      echo "image: skipping u-boot. no mkimage script found"
-    fi
+  if [ -f $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage ]; then
+    . $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader/mkimage
+  elif [ -f $PROJECT_DIR/$PROJECT/bootloader/mkimage ]; then
+    . $PROJECT_DIR/$PROJECT/bootloader/mkimage
+  else
+    echo "image: skipping u-boot. no mkimage script found"
+  fi
 
-    echo "image: copying files to part1..."
-    mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
-    mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
-    mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
-    mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
+  echo "image: copying files to part1..."
+  mcopy $TARGET_IMG/$IMAGE_NAME.kernel "::/$KERNEL_NAME"
+  mcopy $TARGET_IMG/$IMAGE_NAME.system ::/SYSTEM
+  mcopy $RELEASE_DIR/target/KERNEL.md5 "::/$KERNEL_NAME.md5"
+  mcopy $RELEASE_DIR/target/SYSTEM.md5 ::/SYSTEM.md5
 
 elif [ "$BOOTLOADER" = "u-boot" ]; then
   echo "to make an image using u-boot UBOOT_SYSTEM must be set"
@@ -252,85 +253,85 @@ elif [ "$BOOTLOADER" = "u-boot" ]; then
 fi # bootloader
 
 # extract part2 from image to format and copy files
-  echo "image: extracting part2 from image..."
-  STORAGE_PART_COUNT=$(( $STORAGE_PART_END - $STORAGE_PART_START + 1 ))
-  sync
-  dd if="$DISK" of="$LE_TMP/part2.ext4" bs=512 skip="$STORAGE_PART_START" count="$STORAGE_PART_COUNT" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
+echo "image: extracting part2 from image..."
+STORAGE_PART_COUNT=$(( $STORAGE_PART_END - $STORAGE_PART_START + 1 ))
+sync
+dd if="$DISK" of="$LE_TMP/part2.ext4" bs=512 skip="$STORAGE_PART_START" count="$STORAGE_PART_COUNT" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
 
 # create filesystem on part2
-  echo "image: creating filesystem on part2..."
-  mke2fs -F -q -t ext4 -m 0 "$LE_TMP/part2.ext4"
-  tune2fs -L "$DISTRO_DISKLABEL" -U $UUID_STORAGE "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
-  e2fsck -n "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
-  sync
+echo "image: creating filesystem on part2..."
+mke2fs -F -q -t ext4 -m 0 "$LE_TMP/part2.ext4"
+tune2fs -L "$DISTRO_DISKLABEL" -U $UUID_STORAGE "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+e2fsck -n "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+sync
 
 # add resize mark
-  mkdir "$LE_TMP/part2.fs"
-  touch "$LE_TMP/part2.fs/.please_resize_me"
-  echo "image: populating filesystem on part2..."
-  populatefs -U -d "$LE_TMP/part2.fs" "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
-  sync
-  e2fsck -n "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+mkdir "$LE_TMP/part2.fs"
+touch "$LE_TMP/part2.fs/.please_resize_me"
+echo "image: populating filesystem on part2..."
+populatefs -U -d "$LE_TMP/part2.fs" "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
+sync
+e2fsck -n "$LE_TMP/part2.ext4" >"$SAVE_ERROR" 2>&1 || show_error
 
 # merge part2 back to disk image
-  echo "image: merging part2 back to image..."
-  dd if="$LE_TMP/part2.ext4" of="$DISK" bs=512 seek="$STORAGE_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
+echo "image: merging part2 back to image..."
+dd if="$LE_TMP/part2.ext4" of="$DISK" bs=512 seek="$STORAGE_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
 
 # extract part1 from image to run fsck
-  echo "image: extracting part1 from image..."
-  SYSTEM_PART_COUNT=$(( $SYSTEM_PART_END - $SYSTEM_PART_START + 1 ))
-  sync
-  dd if="$DISK" of="$LE_TMP/part1.fat" bs=512 skip="$SYSTEM_PART_START" count="$SYSTEM_PART_COUNT" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
-  echo "image: checking filesystem on part1..."
-  fsck -n $LE_TMP/part1.fat >"$SAVE_ERROR" 2>&1 || show_error
+echo "image: extracting part1 from image..."
+SYSTEM_PART_COUNT=$(( $SYSTEM_PART_END - $SYSTEM_PART_START + 1 ))
+sync
+dd if="$DISK" of="$LE_TMP/part1.fat" bs=512 skip="$SYSTEM_PART_START" count="$SYSTEM_PART_COUNT" conv=fsync >"$SAVE_ERROR" 2>&1 || show_error
+echo "image: checking filesystem on part1..."
+fsck -n $LE_TMP/part1.fat >"$SAVE_ERROR" 2>&1 || show_error
 
 # create virtual image
-  if [ "$PROJECT" = "Generic" ]; then
-    echo "image: creating open virtual appliance..."
-    # duplicate $DISK so anything we do to it directly doesn't effect original
-    dd if="$DISK" of="${DISK_BASENAME}.tmp" bs=1M >"$SAVE_ERROR" 2>&1 || show_error
-    # change syslinux default to 'run'
-    echo "image: modifying fs on part1 for open virtual appliance..."
-    sed -i "/DEFAULT/ s/installer/run/" "$LE_TMP"/syslinux.cfg
-    sed -i "/set default=/s/\"Installer\"/\"Run\"/" "$LE_TMP"/grub.cfg
-    # FIXME: an unalias should work here, but it does not; call mcopy directly
-    $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/syslinux.cfg ::
-    $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/grub.cfg ::/EFI/BOOT
-    sync
-    # merge modified part1 back to tmp disk image
-    echo "image: merging part1 back to open virtual appliance..."
-    dd if="$LE_TMP/part1.fat" of="${DISK_BASENAME}.tmp" bs=512 seek="$SYSTEM_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
-    # create vmdk from tmp $DISK
-    qemu-img convert -O vmdk -o subformat=streamOptimized "${DISK_BASENAME}.tmp" "${DISK_BASENAME}.vmdk"
-    # generate ovf from template
-    sed -e "s,@DISTRO@,$DISTRO,g" -e "s,@DISK@,${IMAGE_NAME},g" \
-        -e "s,@DISK_SIZE@,$(($DISK_SIZE*1024*1024)),g" \
-        $PROJECT_DIR/$PROJECT/config/ovf.template > ${DISK_BASENAME}.ovf
-    # combine ovf and vmdk into official ova
-    tar -C $TARGET_IMG -cf ${DISK_BASENAME}.ova ${IMAGE_NAME}.ovf ${IMAGE_NAME}.vmdk
-    # create sha256 checksum of ova image
-    ( cd $TARGET_IMG
-      sha256sum ${IMAGE_NAME}.ova > ${IMAGE_NAME}.ova.sha256
-    )
-    echo "image: cleaning up..."
-    # remove tmp $DISK, vmdk and ovf
-    rm ${DISK_BASENAME}.tmp ${DISK_BASENAME}.vmdk ${DISK_BASENAME}.ovf
-    # set owner
-    [ -n "$SUDO_USER" ] && chown $SUDO_USER: ${DISK_BASENAME}.ova
-  fi
+if [ "$PROJECT" = "Generic" ]; then
+  echo "image: creating open virtual appliance..."
+  # duplicate $DISK so anything we do to it directly doesn't effect original
+  dd if="$DISK" of="${DISK_BASENAME}.tmp" bs=1M >"$SAVE_ERROR" 2>&1 || show_error
+  # change syslinux default to 'run'
+  echo "image: modifying fs on part1 for open virtual appliance..."
+  sed -i "/DEFAULT/ s/installer/run/" "$LE_TMP"/syslinux.cfg
+  sed -i "/set default=/s/\"Installer\"/\"Run\"/" "$LE_TMP"/grub.cfg
+  # FIXME: an unalias should work here, but it does not; call mcopy directly
+  $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/syslinux.cfg ::
+  $TOOLCHAIN/bin/mcopy -i $LE_TMP/part1.fat -o "$LE_TMP"/grub.cfg ::/EFI/BOOT
+  sync
+  # merge modified part1 back to tmp disk image
+  echo "image: merging part1 back to open virtual appliance..."
+  dd if="$LE_TMP/part1.fat" of="${DISK_BASENAME}.tmp" bs=512 seek="$SYSTEM_PART_START" conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
+  # create vmdk from tmp $DISK
+  qemu-img convert -O vmdk -o subformat=streamOptimized "${DISK_BASENAME}.tmp" "${DISK_BASENAME}.vmdk"
+  # generate ovf from template
+  sed -e "s,@DISTRO@,$DISTRO,g" -e "s,@DISK@,${IMAGE_NAME},g" \
+      -e "s,@DISK_SIZE@,$(($DISK_SIZE*1024*1024)),g" \
+      $PROJECT_DIR/$PROJECT/config/ovf.template > ${DISK_BASENAME}.ovf
+  # combine ovf and vmdk into official ova
+  tar -C $TARGET_IMG -cf ${DISK_BASENAME}.ova ${IMAGE_NAME}.ovf ${IMAGE_NAME}.vmdk
+  # create sha256 checksum of ova image
+  ( cd $TARGET_IMG
+    sha256sum ${IMAGE_NAME}.ova > ${IMAGE_NAME}.ova.sha256
+  )
+  echo "image: cleaning up..."
+  # remove tmp $DISK, vmdk and ovf
+  rm ${DISK_BASENAME}.tmp ${DISK_BASENAME}.vmdk ${DISK_BASENAME}.ovf
+  # set owner
+  [ -n "$SUDO_USER" ] && chown $SUDO_USER: ${DISK_BASENAME}.ova
+fi
 
 # gzip
-  echo "image: compressing..."
-  gzip $DISK
+echo "image: compressing..."
+gzip $DISK
 
 # set owner
-  if [ -n "$SUDO_USER" ] ; then
-    chown $SUDO_USER: $DISK.gz
-  fi
-  # create sha256 checksum of image
-  ( cd $TARGET_IMG
-    sha256sum $(basename $DISK).gz > $(basename $DISK).gz.sha256
-  )
+if [ -n "$SUDO_USER" ] ; then
+  chown $SUDO_USER: $DISK.gz
+fi
+# create sha256 checksum of image
+( cd $TARGET_IMG
+  sha256sum $(basename $DISK).gz > $(basename $DISK).gz.sha256
+)
 
 # cleanup
-  cleanup
+cleanup


### PR DESCRIPTION
These are general cleanups for `mkimage` and the `get*` scripts. They cover:
Line indent
Backticks to $()
Quoting and braces/brackets/{}s for variables
Using build variables for path settings
Convert to die()

Testing by fetching/building an RPi2 `make image`. More testing probably needed as I don't think that it uses all the code paths here. For the Makefile change, the change is correct, but I'm not sure `make src-pkg` works, as I have no `.stamps` directory after building an image so it fails. Thus, I'm not sure how it is used currently.