### PR TITLE
projects/WeTek_Core: Load amlvideodri module at startup

### DIFF
--- a/projects/WeTek_Core/filesystem/usr/lib/modules-load.d/amlvideodri.conf
+++ b/projects/WeTek_Core/filesystem/usr/lib/modules-load.d/amlvideodri.conf
@@ -1,0 +1,1 @@
+amlvideodri


### PR DESCRIPTION
Load amlvideodri module on WeTek Core at startup, otherwise HW video decoding won't work.