### PR TITLE
buildsystem: printf conversion to function

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -37,6 +37,8 @@ listremoveitem() {
 
 print_color() {
   local clr_name="$1" clr_text="$2" clr_actual
+  local black red green yellow blue magenta cyan white endcolor
+  local boldblack boldred boldgreen boldyellow boldblue boldmagenta boldcyan boldwhite
 
   [ -z "${clr_name}" ] && return 0
 
@@ -45,45 +47,60 @@ print_color() {
     return 0
   fi
 
+  black="\e[0;30m"
+  boldblack="\e[1;30m"
+  red="\e[0;31m"
+  boldred="\e[1;31m"
+  green="\e[0;32m"
+  boldgreen="\e[1;32m"
+  yellow="\e[0;33m"
+  boldyellow="\e[1;33m"
+  blue="\e[0;34m"
+  boldblue="\e[1;34m"
+  magenta="\e[0;35m"
+  boldmagenta="\e[1;35m"
+  cyan="\e[0;36m"
+  boldcyan="\e[1;36m"
+  white="\e[0;37m"
+  boldwhite="\e[1;37m"
+  endcolor="\e[0m"
+
+  # $clr_name can be a color variable (boldgreen etc.) or a
+  # "standard" color determined by an indirect name (CLR_ERROR etc.)
+  #
+  # If ${!clr_name} doesn't exist then assume it's a standard color.
+  #
   clr_actual="${!clr_name}"
 
-  # If $clr_name isn't another colour variable (boldgreen etc.), then
-  # assume it's an actual colour escape sequence.
-  #
-  # Otherwise if $clr_name isn't defined, or doesn't exist, then use
-  # standard colours.
-  #
-  if [[ -n "${clr_actual}" ]] && [[ -z "${!clr_actual}" ]]; then
-    clr_actual="${clr_name}"
-  elif [[ -z "${clr_actual}" ]] || [[ -z "${!clr_actual}" ]]; then
+  if [ -z "${clr_actual}" ]; then
     case "${clr_name}" in
-      CLR_ERROR)        clr_actual="boldred";;
-      CLR_WARNING)      clr_actual="boldred";;
-      CLR_WARNING_DIM)  clr_actual="red";;
+      CLR_ERROR)        clr_actual="${boldred}";;
+      CLR_WARNING)      clr_actual="${boldred}";;
+      CLR_WARNING_DIM)  clr_actual="${red}";;
 
-      CLR_APPLY_PATCH)  clr_actual="boldgreen";;
-      CLR_AUTORECONF)   clr_actual="boldmagenta";;
-      CLR_BUILD)        clr_actual="boldyellow";;
-      CLR_TOOLCHAIN)    clr_actual="boldmagenta";;
-      CLR_CLEAN)        clr_actual="boldred";;
-      CLR_FIXCONFIG)    clr_actual="boldyellow";;
-      CLR_GET)          clr_actual="boldcyan";;
-      CLR_INFO)         clr_actual="boldgreen";;
-      CLR_INSTALL)      clr_actual="boldgreen";;
-      CLR_PATCH_DESC)   clr_actual="boldwhite";;
-      CLR_TARGET)       clr_actual="boldwhite";;
-      CLR_UNPACK)       clr_actual="boldcyan";;
+      CLR_APPLY_PATCH)  clr_actual="${boldgreen}";;
+      CLR_AUTORECONF)   clr_actual="${boldmagenta}";;
+      CLR_BUILD)        clr_actual="${boldyellow}";;
+      CLR_TOOLCHAIN)    clr_actual="${boldmagenta}";;
+      CLR_CLEAN)        clr_actual="${boldred}";;
+      CLR_FIXCONFIG)    clr_actual="${boldyellow}";;
+      CLR_GET)          clr_actual="${boldcyan}";;
+      CLR_INFO)         clr_actual="${boldgreen}";;
+      CLR_INSTALL)      clr_actual="${boldgreen}";;
+      CLR_PATCH_DESC)   clr_actual="${boldwhite}";;
+      CLR_TARGET)       clr_actual="${boldwhite}";;
+      CLR_UNPACK)       clr_actual="${boldcyan}";;
 
-      CLR_ENDCOLOR)     clr_actual="endcolor";;
+      CLR_ENDCOLOR)     clr_actual="${endcolor}";;
 
-      *)                clr_actual="endcolor";;
+      *)                clr_actual="${endcolor}";;
     esac
   fi
 
   if [ $# -eq 2 ]; then
-    echo -en "${!clr_actual}${clr_text}${endcolor}"
+    echo -en "${clr_actual}${clr_text}${endcolor}"
   else
-    echo -en "${!clr_actual}"
+    echo -en "${clr_actual}"
   fi
 }
 

--- a/config/functions
+++ b/config/functions
@@ -107,10 +107,14 @@ print_color() {
 # print build progress messages
 # param1: message color, p2: label, p3: text, p4: indent (optional)
 build_msg() {
+  local spaces
+
+  [ -n "${BUILD_INDENT}" ] && spaces="$(printf "%${BUILD_INDENT}c" " ")" || spaces=""
+
   if [ -n "${3}" ]; then
-    printf "%${BUILD_INDENT}c$(print_color "${1}" "${2}")      ${3}\n" ' '>&${SILENT_OUT}
+    echo -e "${spaces}$(print_color "${1}" "${2}")      ${3}" >&${SILENT_OUT}
   else
-    printf "%${BUILD_INDENT}c$(print_color "${1}" "${2}")\n" ' '>&${SILENT_OUT}
+    echo -e "${spaces}$(print_color "${1}" "${2}")" >&${SILENT_OUT}
   fi
 
   # pad left space to create "indent" effect

--- a/config/functions
+++ b/config/functions
@@ -85,6 +85,23 @@ print_color() {
   fi
 }
 
+# print build progress messages
+# param1: message color, p2: label, p3: text, p4: indent (optional)
+build_msg() {
+  if [ -n "${3}" ]; then
+    printf "%${BUILD_INDENT}c$(print_color "${1}" "${2}")      ${3}\n" ' '>&${SILENT_OUT}
+  else
+    printf "%${BUILD_INDENT}c$(print_color "${1}" "${2}")\n" ' '>&${SILENT_OUT}
+  fi
+
+  # pad left space to create "indent" effect
+  if [ "${4}" = "indent" ]; then
+    export BUILD_INDENT=$((${BUILD_INDENT:-0}+${BUILD_INDENT_SIZE}))
+  elif [ -n "${4}" ]; then
+    die "ERROR: ${0} unexpected parameter: ${4}"
+  fi
+}
+
 
 ### BUILDSYSTEM HELPERS ###
 # check if a flag is enabled

--- a/config/functions
+++ b/config/functions
@@ -38,6 +38,8 @@ listremoveitem() {
 print_color() {
   local clr_name="$1" clr_text="$2" clr_actual
 
+  [ -z "${clr_name}" ] && return 0
+
   if [ "$DISABLE_COLORS" = "yes" ]; then
     [ $# -eq 2 ] && echo -en "${clr_text}"
     return 0

--- a/config/path
+++ b/config/path
@@ -162,27 +162,6 @@ else
 fi
 BUILD_INDENT_SIZE=4
 
-# define colors
-if [ "$DISABLE_COLORS" != "yes" ]; then
-  black="\e[0;30m"
-  boldblack="\e[1;30m"
-  red="\e[0;31m"
-  boldred="\e[1;31m"
-  green="\e[0;32m"
-  boldgreen="\e[1;32m"
-  yellow="\e[0;33m"
-  boldyellow="\e[1;33m"
-  blue="\e[0;34m"
-  boldblue="\e[1;34m"
-  magenta="\e[0;35m"
-  boldmagenta="\e[1;35m"
-  cyan="\e[0;36m"
-  boldcyan="\e[1;36m"
-  white="\e[0;37m"
-  boldwhite="\e[1;37m"
-  endcolor="\e[0m"
-fi
-
 # If sourcing a package, configure any package variables dependent on variables we have set
 if [ -n "$PKG_DIR" -a -r $PKG_DIR/package.mk ]; then
   if [ "$(type -t configure_package)" = "function" ]; then

--- a/scripts/autoreconf
+++ b/scripts/autoreconf
@@ -2,22 +2,21 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-. config/options $1
+. config/options "${1}"
 
-if [ ! -f "$PKG_BUILD/configure.in" \
-    -a ! -f "$PKG_BUILD/configure.ac" ] ; then
-  echo "configure.in or configure.ac not found"
-  exit 1
+if [ ! -f "${PKG_BUILD}/configure.in" \
+    -a ! -f "${PKG_BUILD}/configure.ac" ]; then
+  die "configure.in or configure.ac not found"
 fi
 
-if [ ! -f $PKG_BUILD/.autoreconf-done ] ; then
-  touch $PKG_BUILD/NEWS $PKG_BUILD/AUTHORS $PKG_BUILD/ChangeLog
-  mkdir -p $PKG_BUILD/m4
+if [ ! -f "${PKG_BUILD}/.autoreconf-done" ]; then
+  touch "${PKG_BUILD}/NEWS" "${PKG_BUILD}/AUTHORS" "${PKG_BUILD}/ChangeLog"
+  mkdir -p "${PKG_BUILD}/m4"
 
-  printf "%${BUILD_INDENT}c $(print_color CLR_AUTORECONF "AUTORECONF")   $1\n" ' '>&$SILENT_OUT
-  export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
+  build_msg "CLR_AUTORECONF" "AUTORECONF" "${1}" "indent"
 
-  do_autoreconf $PKG_BUILD
-  touch $PKG_BUILD/.autoreconf-done
+  do_autoreconf "${PKG_BUILD}"
+  touch "${PKG_BUILD}/.autoreconf-done"
 fi

--- a/scripts/build
+++ b/scripts/build
@@ -209,11 +209,10 @@ for p in $_pkg_depends; do
 done
 
 if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
-  printf "%${BUILD_INDENT}c $(print_color CLR_BUILD "BUILD")    $PACKAGE_NAME $(print_color CLR_TARGET "($TARGET)") [DEBUG]\n" ' '>&$SILENT_OUT
+  build_msg "CLR_BUILD" "BUILD" "${PACKAGE_NAME} $(print_color "CLR_TARGET" "(${TARGET})") [DEBUG]" "indent"
 else
-  printf "%${BUILD_INDENT}c $(print_color CLR_BUILD "BUILD")    $PACKAGE_NAME $(print_color CLR_TARGET "($TARGET)")\n" ' '>&$SILENT_OUT
+  build_msg "CLR_BUILD" "BUILD" "${PACKAGE_NAME} $(print_color "CLR_TARGET" "(${TARGET})")" "indent"
 fi
-export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
 # virtual packages dont must be build, they only contains dependencies, so dont go further here
 if [ "$PKG_SECTION" = "virtual" ]; then
@@ -267,7 +266,7 @@ fi
 if ! listcontains "meson cmake cmake-make configure ninja make autotools manual" "$PKG_TOOLCHAIN"; then
   die "$(print_color bold-red "ERROR:") unknown toolchain $PKG_TOOLCHAIN"
 fi
-printf "%${BUILD_INDENT}c $(print_color CLR_TOOLCHAIN "TOOLCHAIN")    $PKG_TOOLCHAIN${_auto_toolchain}\n" ' '>&$SILENT_OUT
+build_msg "CLR_TOOLCHAIN" "TOOLCHAIN" "${PKG_TOOLCHAIN}${_auto_toolchain}"
 
 # make autoreconf
 if [ "$PKG_TOOLCHAIN" = "autotools" ]; then

--- a/scripts/build
+++ b/scripts/build
@@ -264,7 +264,7 @@ if [ -z "$PKG_TOOLCHAIN" -o "$PKG_TOOLCHAIN" = "auto" ]; then
   _auto_toolchain=" (auto-detect)"
 fi
 if ! listcontains "meson cmake cmake-make configure ninja make autotools manual" "$PKG_TOOLCHAIN"; then
-  die "$(print_color bold-red "ERROR:") unknown toolchain $PKG_TOOLCHAIN"
+  die "$(print_color "CLR_ERROR" "ERROR:") unknown toolchain $PKG_TOOLCHAIN"
 fi
 build_msg "CLR_TOOLCHAIN" "TOOLCHAIN" "${PKG_TOOLCHAIN}${_auto_toolchain}"
 

--- a/scripts/clean
+++ b/scripts/clean
@@ -2,44 +2,40 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-. config/options $1
+. config/options "${1}"
 
 clean_package() {
-  printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "CLEAN")    $1\n" ' '>&$SILENT_OUT
-  export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
+  build_msg "CLR_CLEAN" "CLEAN" "${1}" "indent"
 
-  if [ "$CLEAN_SOURCES" = true ]; then
-    rm -rf $SOURCES/$1
+  if [ "${CLEAN_SOURCES}" = true ]; then
+    rm -rf "${SOURCES}/${1}"
     return
   fi
 
   # Use a wilcard here to remove all versions of the package
-  for i in $BUILD/$1-*; do
-    if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
-      . "$i/.libreelec-unpack"
-      if [ "$STAMP_PKG_NAME" = "$1" ]; then
-        printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "*") $(print_color CLR_WARNING_DIM "Removing $i ...")\n" ' '>&$SILENT_OUT
-        rm -rf $i
+  for i in "${BUILD}/${1}-"*; do
+    if [ -d "${i}" -a -f "${i}/.libreelec-unpack" ]; then
+      . "${i}/.libreelec-unpack"
+      if [ "${STAMP_PKG_NAME}" = "${1}" ]; then
+        build_msg "CLR_WARNING" "*" "$(print_color "CLR_WARNING_DIM" "Removing ${i} ...")"
+        rm -rf "${i}"
       fi
     else
       # force clean if no stamp found (previous unpack failed)
-      printf "%${BUILD_INDENT}c * Removing $i ...\n" ' '>&$SILENT_OUT
-      rm -rf $i
+      build_msg "" "" "* Removing ${i} ..."
+      rm -rf "${i}"
     fi
   done
-  rm -f $STAMPS/$1/build_*
+  rm -f "${STAMPS}/${1}/build_"*
 }
 
-if [ "$1" = "--all" ]; then
-  if [ ! -z "$2" ]; then
-    for build_dir in $(ls -1d ${ROOT}/build.*); do
-      load_build_config "${build_dir}" && ./scripts/clean $2
-    done
-  fi
-else
-  if [ ! -z "$1" ]; then
-    clean_package $1
-  fi
+if [ "${1}" = "--all" -a -n "${2}" ]; then
+  for build_dir in $(ls -1d "${ROOT}/build."*); do
+    load_build_config "${build_dir}" && "${SCRIPTS}/clean" "${2}"
+  done
+elif [ -n "${1}" ]; then
+  clean_package "${1}"
 fi
 

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -113,12 +113,12 @@ pack_addon() {
       if [ "$ADDON_OVERWRITE" = "yes" ]; then
         rm $ADDON_INSTALL_DIR/$PKG_ADDON_ID-$ADDONVER.zip
       else
-        printf  "%${BUILD_INDENT}c $(print_color CLR_WARNING "*** WARNING: $PKG_ADDON_ID-$ADDONVER.zip already exists. not overwriting it ***")\n" ' '>&$SILENT_OUT
+        build_msg "CLR_WARNING" "*** WARNING: ${PKG_ADDON_ID}-${ADDONVER}.zip already exists. Not overwrittng it. ***"
         return 0
       fi
     fi
     cd $ADDON_BUILD
-    printf  "%${BUILD_INDENT}c $(print_color CLR_INFO "*** compressing Addon $PKG_ADDON_ID ... ***")\n" ' '>&$SILENT_OUT
+    build_msg "CLR_INFO" "*** compressing addon ${PKG_ADDON_ID} ... ***"
     $TOOLCHAIN/bin/7za a -l -mx9 -bsp0 -bso0 -tzip $PKG_ADDON_ID-$ADDONVER.zip $PKG_ADDON_ID
     cd - &>/dev/null
 
@@ -158,20 +158,20 @@ pack_addon() {
       ( cd $ADDON_JENKINS_DIR
         sha256sum $ADDON_JENKINS_ADDON_NAME.zip > $ADDON_JENKINS_ADDON_NAME.zip.sha256
       )
-      printf  "%${BUILD_INDENT}c $(print_color CLR_INFO "*** creating $ADDON_JENKINS_ADDON_NAME.zip for Jenkins complete ***")\n" ' '>&$SILENT_OUT
+      build_msg "CLR_INFO" "*** creating ${ADDON_JENKINS_ADDON_NAME}.zip for Jenkins complete ***"
     else
-      printf  "%${BUILD_INDENT}c $(print_color CLR_INFO "*** creating $PKG_ADDON_ID complete ***")\n" ' '>&$SILENT_OUT
+      build_msg "CLR_INFO" "*** creating  ${PKG_ADDON_ID} complete ***"
     fi
   fi
 }
 
 not_supported_arch() {
-  printf  "%${BUILD_INDENT}c $(print_color CLR_WARNING "*** SKIP: $PKG_ADDON_ID: '${DEVICE:-$PROJECT}' not supported ***")\n" ' '>&$SILENT_OUT
+  build_msg "CLR_WARNING" "*** SKIP: ${PKG_ADDON_ID} '${TARGET_ARCH}' not supported ***"
   exit 0
 }
 
 not_supported_device() {
-  printf  "%${BUILD_INDENT}c $(print_color CLR_WARNING "*** SKIP: $PKG_ADDON_ID: '$TARGET_ARCH' not supported ***")\n" ' '>&$SILENT_OUT
+  build_msg "CLR_WARNING" "*** SKIP: ${PKG_ADDON_ID}: '${DEVICE:-${PROJECT}}' not supported ***"
   exit 0
 }
 
@@ -265,7 +265,7 @@ case "$write_logs" in
 esac
 if [ -n "$log_path" ]; then
   mkdir -p "$log_path"
-  summary_file="$log_path/addon-summary.log"  
+  summary_file="$log_path/addon-summary.log"
   rm -f $summary_file
 fi
 

--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -16,8 +16,7 @@ lock_source_dir "${1}"
 _get_file_already_downloaded && exit 0
 
 # At this point, we need to download something...
-printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      ${1} (archive)\n" ' '>&$SILENT_OUT
-export BUILD_INDENT=$((${BUILD_INDENT:-1}+${BUILD_INDENT_SIZE}))
+build_msg "CLR_GET" "GET" "${1} (archive)" "indent"
 
 PACKAGE_MIRROR="${DISTRO_MIRROR}/${PKG_NAME}/${PKG_SOURCE_NAME}"
 [ "${VERBOSE}" != "yes" ] && WGET_OPT=-q
@@ -37,7 +36,7 @@ while [ ${NBWGET} -gt 0 ]; do
 
       [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2
 
-      printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "WARNING") Incorrect checksum calculated on downloaded file: got ${CALC_SHA256} wanted ${PKG_SHA256}\n\n" ' '>&$SILENT_OUT
+      build_msg "CLR_WARNING" "WARNING" "Incorrect checksum calculated on downloaded file: got ${CALC_SHA256} wanted ${PKG_SHA256}"
     fi
   done
   NBWGET=$((NBWGET - 1))
@@ -46,7 +45,7 @@ done
 if [ ${NBWGET} -eq 0 ]; then
   die "\nCant't get ${1} sources : ${PKG_URL}\nTry later!"
 else
-  printf "%${BUILD_INDENT}c $(print_color CLR_INFO "INFO") Calculated checksum: ${CALC_SHA256}\n\n" ' '>&$SILENT_OUT
+  build_msg "CLR_INFO" "INFO" "Calculated checksum: ${CALC_SHA256}"
   echo "${PKG_URL}" > "${STAMP_URL}"
   echo "${CALC_SHA256}" > "${STAMP_SHA}"
 fi

--- a/scripts/get_file
+++ b/scripts/get_file
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      ${1} (file)\n" ' '>&$SILENT_OUT
-export BUILD_INDENT=$((${BUILD_INDENT:-1}+${BUILD_INDENT_SIZE}))
+build_msg "CLR_GET" "GET" "${1} (file)" "indent"

--- a/scripts/get_git
+++ b/scripts/get_git
@@ -42,8 +42,7 @@ lock_source_dir "${1}"
 _get_repo_already_downloaded && exit 0
 
 # At this point, we need to download something...
-printf "%${BUILD_INDENT}c $(print_color CLR_GET "GET")      ${1} (git)\n" ' '>&$SILENT_OUT
-export BUILD_INDENT=$((${BUILD_INDENT:-1}+${BUILD_INDENT_SIZE}))
+build_msg "CLR_GET" "GET" "${1} (git)" "indent"
 
 rm -f "${STAMP_URL}" "${STAMP_SHA}"
 
@@ -91,46 +90,44 @@ for d in "${SOURCES}/${1}/${1}-"* ; do
           _get_repo_clean
           git checkout -b "${PKG_GIT_CLONE_BRANCH}" "origin/${PKG_GIT_CLONE_BRANCH}"
         else
-          printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") (${d})\n" ' '>&$SILENT_OUT
+          build_msg "CLR_CLEAN" "DELETE" "(${d})"
           cd "${opwd}"
           rm -rf "${d}"
         fi
         if [ "${GIT_FOUND}" = "yes" ]; then
-          printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT PULL")   ${1}\n" ' '>&$SILENT_OUT
+          build_msg "CLR_GET" "GIT PULL" "${1}"
           git pull
           cd "${opwd}"
         fi
       else
-        printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") (${d})\n" ' '>&$SILENT_OUT
+        build_msg "CLR_CLEAN" "DELETE" "(${d})"
         cd "${opwd}"
         rm -rf "${d}"
       fi
     fi
   else
-    printf "%${BUILD_INDENT}c $(print_color CLR_CLEAN "DELETE") (${d})\n" ' '>&$SILENT_OUT
+    build_msg "CLR_CLEAN" "DELETE" "(${d})"
     rm -rf "${d}"
   fi
 done
 cd "${opwd}"
 
 if [ "${GIT_FOUND}" = "no" ]; then
-  printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT CLONE")   ${1}\n" ' '>&$SILENT_OUT
+  build_msg "CLR_GET" "GIT CLONE" "${1}"
   git clone ${GIT_CLONE_PARAMS} "${PKG_URL}" "${PACKAGE}"
-else
-  if [ ! "${GIT_DIR}" = "${PACKAGE}" ]; then
-    mv "${GIT_DIR}" "${PACKAGE}"
-  fi
+elif [ ! "${GIT_DIR}" = "${PACKAGE}" ]; then
+  mv "${GIT_DIR}" "${PACKAGE}"
 fi
 
 ( cd "${PACKAGE}"
   [ $(git log --oneline --pretty=tformat:"%H" | grep "^${PKG_VERSION}" | wc -l) -eq 1 ] || die "There is no commit '${PKG_VERSION}' on branch '$(git branch | grep ^\* | cut -d ' ' -f2)' of package '${1}'! Aborting!"
   git reset --hard "${PKG_VERSION}"
-  printf "%${BUILD_INDENT}c $(print_color CLR_GET "GIT SUBMODULE")   ${1}\n" ' '>&$SILENT_OUT
+  build_msg "CLR_GET" "GIT SUBMODULE" "${1}"
   git submodule update --init --recursive ${GIT_SUBMODULE_PARAMS}
 )
 
 GIT_SHA="$(git ls-remote "${PACKAGE}" | grep -m1 HEAD | awk '{print $1;}')"
 
-if [ -n "${PKG_GIT_SHA}" ]; then
-   [ "${PKG_GIT_SHA}" = "${GIT_SHA}" ] || printf "%${BUILD_INDENT}c $(print_color CLR_WARNING "WARNING") Incorrect git hash in respository: got ${GIT_SHA}, wanted ${PKG_GIT_SHA}\n\n" ' '>&$SILENT_OUT
+if [ -n "${PKG_GIT_SHA}" -a "${PKG_GIT_SHA}" != "${GIT_SHA}" ]; then
+  build_msg "CLR_WARNING" "WARNING" "Incorrect git hash in repository: got ${GIT_SHA}, wanted ${PKG_GIT_SHA}"
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -41,8 +41,7 @@ fi
 
 $SCRIPTS/build $@
 
-printf "%${BUILD_INDENT}c $(print_color CLR_INSTALL "INSTALL")    $PACKAGE_NAME $(print_color CLR_TARGET "($TARGET)")\n" ' '>&$SILENT_OUT
-export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
+build_msg "CLR_INSTALL" "INSTALL" "${PACKAGE_NAME} $(print_color CLR_TARGET "(${TARGET})")" "indent"
 
 if [ "$TARGET" = target ] ; then
   for p in $PKG_DEPENDS_TARGET; do

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -42,8 +42,7 @@ fi
 [ -f "$STAMP" ] && exit 0
 
 if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
-  printf "%${BUILD_INDENT}c $(print_color CLR_UNPACK "UNPACK")   $1\n" ' '>&$SILENT_OUT
-  export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
+  build_msg "CLR_UNPACK" "UNPACK" "${1}" "indent"
 
   # unset functions
   unset -f pre_unpack
@@ -150,7 +149,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
       fi
 
       if [ -f "$i" ]; then
-        printf "%${BUILD_INDENT}c $(print_color CLR_APPLY_PATCH "APPLY PATCH") $(print_color CLR_PATCH_DESC "${PATCH_DESC}")   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
+        build_msg "CLR_APPLY_PATCH" "APPLY PATCH $(print_color "CLR_PATCH_DESC" "${PATCH_DESC}")" "${i#${ROOT}/}"
         if grep -qE '^GIT binary patch$|^rename from|^rename to' $i; then
           cat $i | git apply --directory=$(echo "$PKG_BUILD" | cut -f1 -d\ ) -p1 --verbose --whitespace=nowarn --unsafe-paths >&$VERBOSE_OUT
         else
@@ -166,7 +165,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
 
   if [ ! "$PKG_NAME" = "configtools" ] ; then
     for config in $(find "$PKG_BUILD" -name config.guess | sed 's/config.guess//'); do
-      printf "%${BUILD_INDENT}c $(print_color CLR_FIXCONFIG "FIXCONFIG")   $config\n" ' '
+      build_msg "CLR_FIXCONFIG" "FIXCONFIG" "${config}"
 
       [ -f "$config/config.guess" -a -f $TOOLCHAIN/configtools/config.guess ] && \
         cp -f $TOOLCHAIN/configtools/config.guess $config


### PR DESCRIPTION
WIP demonstration of adding a printf helper function to config/functions to output build messages. Currently two functions, but easily combined to one (simply insert build_msg_indent's content into the if test where it's called). Since not every status message causes indent to shift further, this is controlled through the 4th parameter being "indent" or not (and erroring out on other content in $4)

get_archive conversion provided as sample. Tested by fetching a variety of packages.