### PR TITLE
alsa: update lib/utils/plugins to 1.1.7

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-plugins"
-PKG_VERSION="1.1.6"
-PKG_SHA256="6f1d31ebe3b1fa1cc8dade60b7bed1cb2583ac998167002d350dc0a5e3e40c13"
+PKG_VERSION="1.1.7"
+PKG_SHA256="a74b405ab6d9e346e6908a853d5e7631cc61038d9b265bc7f37fab16e827da47"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/plugins/$PKG_NAME-$PKG_VERSION.tar.bz2"

--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-lib"
-PKG_VERSION="1.1.6"
-PKG_SHA256="5f2cd274b272cae0d0d111e8a9e363f08783329157e8dd68b3de0c096de6d724"
+PKG_VERSION="1.1.7"
+PKG_SHA256="9d6000b882a3b2df56300521225d69717be6741b71269e488bb20a20783bdc09"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/lib/alsa-lib-$PKG_VERSION.tar.bz2"

--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-utils"
-PKG_VERSION="1.1.6"
-PKG_SHA256="155caecc40b2220f686f34ba3655a53e3bdbc0586adb1056733949feaaf7d36e"
+PKG_VERSION="1.1.7"
+PKG_SHA256="1db27fb54ab7fdeb54b00d68b8a174808ffea198cfbd67e3c959482194e1540a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/utils/alsa-utils-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
`alsa-plugins` is only used by the `snapclient` addon - does the addon need any update to the PKG_REV?