### PR TITLE
scripts/mkimage: show message when temp folder is full

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -39,11 +39,16 @@ cleanup() {
 }
 
 show_error() {
-  echo -e "image: error happen...\n"
-  cat "${SAVE_ERROR}"
+  echo "image: An error has occurred..."
   echo
+  if [ -s "${SAVE_ERROR}" ]; then
+    cat "${SAVE_ERROR}"
+  else
+    echo "Folder $LE_TMP might be out of free space..."
+  fi
+  echo 
   cleanup
-  exit 1
+  die
 }
 
 trap cleanup SIGINT


### PR DESCRIPTION
If temporary folder is full error message can't be saved and shown to the user which doesn't know what the problem actually is. In this case show some message.

old behaviour
```
image: extracting part1 from image...
image: error happen...
image: cleanup...
```
new behaviour
```
image: extracting part1 from image...
image: error happen...

  folder /tmp.inTRp2QM1b might be out of free space...

image: cleanup...
```