### PR TITLE
egl fix for amlogic

### DIFF
--- a/packages/graphics/opengl-meson/package.mk
+++ b/packages/graphics/opengl-meson/package.mk
@@ -7,7 +7,8 @@ PKG_LICENSE="nonfree"
 PKG_SITE="http://openlinux.amlogic.com:8000/download/ARM/filesystem/"
 case $MESON_FAMILY in
   8)
-    PKG_VERSION="8-r5p1-01rel0-armhf"
+    PKG_VERSION="8-r5p1-02rel0-armhf"
+    PKG_SHA256="717739c9f65f6782e3185aad09d01f228873315f70f9a58c0526b9e63a6e386f"
     ;;
   6)
     PKG_VERSION="6-r5p1-01rel0-armhf"
@@ -15,7 +16,8 @@ case $MESON_FAMILY in
     ;;
   gxbb)
     if [ "$TARGET_ARCH" = "arm" ]; then
-      PKG_VERSION="8-r5p1-01rel0-armhf"
+      PKG_VERSION="8-r5p1-02rel0-armhf"
+      PKG_SHA256="717739c9f65f6782e3185aad09d01f228873315f70f9a58c0526b9e63a6e386f"
     else
       PKG_VERSION="gxbb-r5p1-01rel0"
     fi

--- a/packages/graphics/opengl-meson/package.mk
+++ b/packages/graphics/opengl-meson/package.mk
@@ -11,8 +11,8 @@ case $MESON_FAMILY in
     PKG_SHA256="717739c9f65f6782e3185aad09d01f228873315f70f9a58c0526b9e63a6e386f"
     ;;
   6)
-    PKG_VERSION="6-r5p1-01rel0-armhf"
-    PKG_SHA256="21a8376668c84bf1b9e64a917fcfa1cf74689035fed8e4630833c9cde28d40c1"
+    PKG_VERSION="6-r5p1-02rel0-armhf"
+    PKG_SHA256="de38a1fa23191bd5de5c85c66627d4537775ee4634b71baa8d0e241b8b9d4ba2"
     ;;
   gxbb)
     if [ "$TARGET_ARCH" = "arm" ]; then


### PR DESCRIPTION
Since https://github.com/xbmc/xbmc/pull/14772 Kodi doesn't supports the old AML 3.14 buildroot EGL headers anymore. So we need some kind of HACK/workaround/backport to fix it.

- this fixes S905 compiling of Kodi
updated headers from https://github.com/khadas/buildroot_buildroot/tree/buildroot/package/meson-mali/include and added to `EGL/eglext.h` 
```
#ifndef EGL_KHR_debug
#define EGL_KHR_debug 1
typedef void *EGLLabelKHR;
typedef void *EGLObjectKHR;
typedef void (EGLAPIENTRY  *EGLDEBUGPROCKHR)(EGLenum error,const char *command,EGLint messageType,EGLLabelKHR threadLabel,EGLLabelKHR objectLabel,const char* message);
#define EGL_OBJECT_THREAD_KHR             0x33B0
#define EGL_OBJECT_DISPLAY_KHR            0x33B1
#define EGL_OBJECT_CONTEXT_KHR            0x33B2
#define EGL_OBJECT_SURFACE_KHR            0x33B3
#define EGL_OBJECT_IMAGE_KHR              0x33B4
#define EGL_OBJECT_SYNC_KHR               0x33B5
#define EGL_OBJECT_STREAM_KHR             0x33B6
#define EGL_DEBUG_MSG_CRITICAL_KHR        0x33B9
#define EGL_DEBUG_MSG_ERROR_KHR           0x33BA
#define EGL_DEBUG_MSG_WARN_KHR            0x33BB
#define EGL_DEBUG_MSG_INFO_KHR            0x33BC
#define EGL_DEBUG_CALLBACK_KHR            0x33B8
typedef EGLint (EGLAPIENTRYP PFNEGLDEBUGMESSAGECONTROLKHRPROC) (EGLDEBUGPROCKHR callback, const EGLAttrib *attrib_list);
typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDEBUGKHRPROC) (EGLint attribute, EGLAttrib *value);
typedef EGLint (EGLAPIENTRYP PFNEGLLABELOBJECTKHRPROC) (EGLDisplay display, EGLenum objectType, EGLObjectKHR object, EGLLabelKHR label);
#ifdef EGL_EGLEXT_PROTOTYPES
EGLAPI EGLint EGLAPIENTRY eglDebugMessageControlKHR (EGLDEBUGPROCKHR callback, const EGLAttrib *attrib_list);
EGLAPI EGLBoolean EGLAPIENTRY eglQueryDebugKHR (EGLint attribute, EGLAttrib *value);
EGLAPI EGLint EGLAPIENTRY eglLabelObjectKHR (EGLDisplay display, EGLenum objectType, EGLObjectKHR object, EGLLabelKHR label);
#endif
#endif /* EGL_KHR_debug */
``` 


**todo:** fix for WC and WP1

**disclaimer:** !NO idea if this is a proper solution, at least Kodi for AML is building again, the EGL debug function itself is likely broken and needs fixing upstream.