### PR TITLE
aom: disable NEON when not supported

### DIFF
--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -15,3 +15,7 @@ PKG_CMAKE_OPTS_TARGET="-DENABLE_CCACHE=1 \
                        -DENABLE_EXAMPLES=0 \
                        -DENABLE_TESTS=0 \
                        -DENABLE_TOOLS=0"
+
+if ! target_has_feature neon; then
+  PKG_CMAKE_OPTS_TARGET+=" -DENABLE_NEON=0 -DENABLE_NEON_ASM=0"
+fi


### PR DESCRIPTION
AV1 builds with NEON. Which isn't a good idea when NEON isn't supported (ie. RPi).