### PR TITLE
scripts/create_addon: fix typo of official

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -36,7 +36,7 @@ DESCRIPTION
               - the name of the addon
               - a group name of addons
                   * all - all addons found under packages and project/*/packages
-                  * offical - all addons found under packages/addons
+                  * official - all addons found under packages/addons
                   * binary - all addons found under packages/mediacenter/kodi-binary-addons
               - a regex term (grep styled), the term is automatic sorounded with string begin and end (^[term]$)
 
@@ -62,7 +62,7 @@ function find_addons() {
   local _filter="."
   case $1 in
     binary)      _paths="$ROOT/packages/mediacenter/kodi-binary-addons";;
-    offical)     _paths="$ROOT/packages/addons";;
+    official)    _paths="$ROOT/packages/addons";;
     all)         _paths="$ROOT/packages $ROOT/projects/*/packages";;
     *)           _paths="$ROOT/packages $ROOT/projects/*/packages";
                  _filter="^$1$";;


### PR DESCRIPTION
`scripts/create_addon official` was not working