### PR TITLE
Rockchip: fix kernel crash when kodi 18.0rc1 starts

### DIFF
--- a/packages/multimedia/rkmpp/package.mk
+++ b/packages/multimedia/rkmpp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rkmpp"
-PKG_VERSION="b9dda0fb95674651673cbab0b846d29ab9b0e96c"
-PKG_SHA256="c78ce9cd4a77fade1122e10553b00eec42d622d97838bd08e644ec816bb43e5f"
+PKG_VERSION="1babbc9cc277692d02fc4727daef2e91f91ce8b0"
+PKG_SHA256="6cbc3c5656c5b2ab61f6466899012e0725c2b573f19765c68a197a19f95c4d54"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/rockchip-linux/mpp"

--- a/projects/Rockchip/patches/linux/rockchip-4.4/linux-0001-rockchip.patch
+++ b/projects/Rockchip/patches/linux/rockchip-4.4/linux-0001-rockchip.patch
@@ -1371,3 +1371,27 @@ index f748a292b7f4..d72c02afeb76 100644
  	{ /* sentinel */ },
  };
  
+
+From 06d1099d7f4cece7af7793ff68fabc08eb55935d Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Wed, 14 Nov 2018 06:08:01 +0100
+Subject: [PATCH] drm: workaround for crash when trying to open render node
+
+---
+ drivers/gpu/drm/drm_ioctl.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_ioctl.c b/drivers/gpu/drm/drm_ioctl.c
+index 34757168ffaa..0914c886277f 100644
+--- a/drivers/gpu/drm/drm_ioctl.c
++++ b/drivers/gpu/drm/drm_ioctl.c
+@@ -57,6 +57,9 @@ static int drm_getunique(struct drm_device *dev, void *data,
+ 	struct drm_unique *u = data;
+ 	struct drm_master *master = file_priv->master;
+ 
++	if (!master)
++		return -EINVAL;
++
+ 	if (u->unique_len >= master->unique_len) {
+ 		if (copy_to_user(u->unique, master->unique, master->unique_len))
+ 			return -EFAULT;

--- a/projects/Rockchip/patches/linux/rockchip-4.4/linux-0006-rtl8211f.patch
+++ b/projects/Rockchip/patches/linux/rockchip-4.4/linux-0006-rtl8211f.patch
@@ -868,4 +868,3 @@ index f307d220b49a..15d342eefd6d 100644
  
  #define RTL821x_INSR				0x13
  
-


### PR DESCRIPTION
This PR fixes a rockchip-4.4 kernel crash when Kodi 18.0rc1 is started and tries to open a drm render node. Also includes a rkmpp version bump with some [fixes](https://github.com/rockchip-linux/mpp/compare/b9dda0fb95674651673cbab0b846d29ab9b0e96c...1babbc9cc277692d02fc4727daef2e91f91ce8b0).

Tested on Rock64 and RockPro64