### PR TITLE
mesa: disable assert() for release build

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -85,3 +85,6 @@ else
   PKG_MESON_OPTS_TARGET+=" -Dgles1=false -Dgles2=false"
 fi
 
+if [ "${BUILD_WITH_DEBUG}" != "yes" ]; then
+  PKG_MESON_OPTS_TARGET+=" -Db_ndebug=true"
+fi


### PR DESCRIPTION
From docs/meson.html:
>`-Db_ndebug`
>This option controls assertions in meson projects. When set to `false` (the default) assertions are enabled, when set to true they are disabled. This is unrelated to the `buildtype`; setting the latter to `release` will not turn off assertions.

Work around the crash when AMD VDPAU is selected with `KODI_GL_INTERFACE=GLX`:

```
Thread 1 (Thread 0x7f9f879c2d40 (LWP 1352)):
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f9f85616524 in __GI_abort () at abort.c:79
#2  0x00007f9f8561640f in __assert_fail_base (fmt=0x7f9f8576be00 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x7f9f809399c0 "stObj->level_override || last_level(stObj) == view->u.tex.last_level", file=0x7f9f80939378 "../src/mesa/state_tracker/st_sampler_view.c", line=546, function=0x7f9f80955420 "st_get_texture_sampler_view_from_stobj") at assert.c:92
#3  0x00007f9f856237e2 in __GI___assert_fail (assertion=0x7f9f809399c0 "stObj->level_override || last_level(stObj) == view->u.tex.last_level", file=0x7f9f80939378 "../src/mesa/state_tracker/st_sampler_view.c", line=546, function=0x7f9f80955420 "st_get_texture_sampler_view_from_stobj") at assert.c:101
#4  0x00007f9f80426096 in ?? () from /usr/lib/dri/radeonsi_dri.so
#5  0x00007f9f803374d7 in ?? () from /usr/lib/dri/radeonsi_dri.so
#6  0x00007f9f8034d5a8 in ?? () from /usr/lib/dri/radeonsi_dri.so
#7  0x00007f9f802be496 in ?? () from /usr/lib/dri/radeonsi_dri.so
#8  0x00007f9f8035059a in ?? () from /usr/lib/dri/radeonsi_dri.so
#9  0x00007f9f802b7060 in ?? () from /usr/lib/dri/radeonsi_dri.so
#10 0x00007f9f802d7cb0 in ?? () from /usr/lib/dri/radeonsi_dri.so
#11 0x000000000121d395 in CLinuxRendererGL::RenderRGB(int, int) ()
#12 0x00000000012462a0 in CRendererVDPAU::RenderHook(int) ()
#13 0x00000000012455fe in CLinuxRendererGL::Render(unsigned int, int) ()
#14 0x0000000001245ad1 in CLinuxRendererGL::RenderUpdate(int, int, bool, unsigned int, unsigned int) ()
#15 0x000000000124227e in CRenderManager::Render(bool, unsigned int, unsigned int, bool) ()
#16 0x0000000000d44256 in CApplicationPlayer::Render(bool, unsigned int, bool) ()
#17 0x0000000000f0ba6e in CGUIVideoControl::Render() ()
#18 0x0000000000f07d98 in CGUIControl::DoRender() ()
#19 0x0000000000eff86e in CGUIControlGroup::Render() ()
#20 0x0000000000f07d98 in CGUIControl::DoRender() ()
#21 0x0000000000f110ea in CGUIWindow::DoRender() ()
#22 0x0000000000ed3f07 in CGUIWindowManager::RenderPass() const ()
#23 0x0000000000eed708 in CGUIWindowManager::Render() ()
#24 0x0000000000d5b5b0 in CApplication::Render() ()
#25 0x0000000000d2c195 in CXBApplicationEx::Run(CAppParamParser const&) ()
#26 0x0000000000fc3ae6 in XBMC_Run ()
#27 0x000000000093a967 in main ()
```
