### PR TITLE
buildsystem: fix custom colors

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -69,10 +69,14 @@ print_color() {
   # "standard" color determined by an indirect name (CLR_ERROR etc.)
   #
   # If ${!clr_name} doesn't exist then assume it's a standard color.
+  # If ${!clr_name} does exist then check it's not a custom color mapping.
+  # Custom color mappings can be configured in options files.
   #
   clr_actual="${!clr_name}"
 
-  if [ -z "${clr_actual}" ]; then
+  if [ -n "${clr_actual}" ]; then
+    clr_actual="${!clr_actual}"
+  else
     case "${clr_name}" in
       CLR_ERROR)        clr_actual="${boldred}";;
       CLR_WARNING)      clr_actual="${boldred}";;


### PR DESCRIPTION
After #3109 custom color names are printed, not used.

I.e. with `CLR_TARGET="yellow"`
```
BUILD      vdr-plugin-dvbapi yellow(target)
```

