### PR TITLE
buildsystem: proxy calls to package functions

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -38,7 +38,7 @@ listcontains() {
 }
 
 # remove item(s) from list.
-# looping makes it greedy (eg. removefromlist "abc def ghi" "(abc|def)" will work).
+# looping makes it greedy (eg. listremoveitem "abc def ghi" "(abc|def)" removes both "abc" and "def").
 listremoveitem() {
   local data="${1}" odata tmp_array
   if [ -n "$1" -a -n "$2" ]; then

--- a/config/functions
+++ b/config/functions
@@ -10,6 +10,24 @@ die() {
   exit "${2:-1}"
 }
 
+# p1: name of potential function to execute if it exists
+# return 0 if function executed, 1 if not, die if error
+pkg_call() {
+  [ -n "${PKG_NAME}" ] || die "$(print_color CLR_ERROR "FAILURE: Cannot call ${1} package function when package is not known!")"
+
+  if [ "$(type -t ${1})" = "function" ]; then
+    ${1} || die "$(print_color CLR_ERROR "FAILURE: ${1} for package ${PKG_NAME} did not succeed!")"
+  else
+    return 1
+  fi
+}
+
+# p1: name of potential function to execute if it exists
+# return 0 if function executed or not, or die if error
+pkg_call_optional() {
+  pkg_call ${1} || return 0
+}
+
 # return 0 if $2 in space-separated list $1, otherwise return 1
 listcontains() {
   if [ -n "$1" -a -n "$2" ]; then

--- a/config/path
+++ b/config/path
@@ -164,9 +164,7 @@ BUILD_INDENT_SIZE=4
 
 # If sourcing a package, configure any package variables dependent on variables we have set
 if [ -n "$PKG_DIR" -a -r $PKG_DIR/package.mk ]; then
-  if [ "$(type -t configure_package)" = "function" ]; then
-    configure_package
-  fi
+  pkg_call_optional configure_package
 fi
 
 # multilib? nah

--- a/scripts/build
+++ b/scripts/build
@@ -192,9 +192,7 @@ BOOTSTRAP_MESON_OPTS="$HOST_MESON_OPTS"
 . $PKG_DIR/package.mk
 
 # finalise package configuration
-if [ "$(type -t configure_package)" = "function" ]; then
-  configure_package
-fi
+pkg_call_optional configure_package
 
 # build dependencies, only when PKG_DEPENDS_? is filled
 unset _pkg_depends
@@ -274,9 +272,7 @@ if [ "$PKG_TOOLCHAIN" = "autotools" ]; then
 fi
 
 # include build template and build
-if [ "$(type -t pre_build_$TARGET)" = "function" ]; then
-  pre_build_$TARGET
-fi
+pkg_call_optional pre_build_$TARGET
 
 # ensure $PKG_BUILD is there. (installer? PKG_URL="")
 if [ ! -d "$PKG_BUILD" ] ; then
@@ -299,12 +295,9 @@ if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" -o -f "$PKG_MESON_SCRI
 fi
 
 # configure
-if [ "$(type -t pre_configure_$TARGET)" = "function" ]; then
-  pre_configure_$TARGET
-fi
-if [ "$(type -t configure_$TARGET)" = "function" ]; then
-  configure_$TARGET
-else
+pkg_call_optional pre_configure_$TARGET
+
+if ! pkg_call configure_$TARGET; then
   case "$PKG_TOOLCHAIN:$TARGET" in
     # meson builds
     "meson:target")
@@ -383,17 +376,13 @@ else
       ;;
   esac
 fi
-if [ "$(type -t post_configure_$TARGET)" = "function" ]; then
-  post_configure_$TARGET
-fi
+
+pkg_call_optional post_configure_$TARGET
 
 # make
-if [ "$(type -t pre_make_$TARGET)" = "function" ]; then
-  pre_make_$TARGET
-fi
-if [ "$(type -t make_$TARGET)" = "function" ]; then
-  make_$TARGET
-else
+pkg_call_optional pre_make_$TARGET
+
+if ! pkg_call make_$TARGET; then
   case "$PKG_TOOLCHAIN:$TARGET" in
     # ninja based builds
     "meson:target"|"cmake:target"|"ninja:target")
@@ -432,17 +421,13 @@ else
       ;;
   esac
 fi
-if [ "$(type -t post_make_$TARGET)" = "function" ]; then
-  post_make_$TARGET
-fi
+
+pkg_call_optional post_make_$TARGET
 
 # make install
-if [ "$(type -t pre_makeinstall_$TARGET)" = "function" ]; then
-  pre_makeinstall_$TARGET
-fi
-if [ "$(type -t makeinstall_$TARGET)" = "function" ]; then
-  makeinstall_$TARGET
-else
+pkg_call_optional pre_makeinstall_$TARGET
+
+if ! pkg_call makeinstall_$TARGET; then
   case "$PKG_TOOLCHAIN:$TARGET" in
     # ninja based builds
     "meson:target"|"cmake:target")
@@ -475,9 +460,8 @@ else
       ;;
   esac
 fi
-if [ "$(type -t post_makeinstall_$TARGET)" = "function" ]; then
-  post_makeinstall_$TARGET
-fi
+
+pkg_call_optional post_makeinstall_$TARGET
 
 if [ "$TARGET" = "target" -o "$TARGET" = "init" ]; then
   if [ -d $INSTALL ]; then

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -208,9 +208,7 @@ build_addon() {
   rm -rf $ADDON_BUILD
 
   # install addon parts
-  if [ "$(type -t addon)" = "function" ]; then
-    addon
-  else
+  if ! pkg_call addon; then
     install_binary_addon $PKG_ADDON_ID
   fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -130,9 +130,7 @@ unset -f post_install
 
 # install
 if [ "$TARGET" = target ] ; then
-  if [ "$(type -t pre_install)" = "function" ]; then
-    pre_install
-  fi
+  pkg_call_optional pre_install
 fi
 
 if [ "$TARGET" = "target" -a -d $PKG_BUILD/.install_pkg ]; then
@@ -144,9 +142,7 @@ elif [ "$TARGET" = "init" -a -d $PKG_BUILD/.install_init ]; then
 fi
 
 if [ "$TARGET" = target ] ; then
-  if [ "$(type -t post_install)" = "function" ]; then
-    post_install
-  fi
+  pkg_call_optional post_install
 fi
 
 touch $STAMP

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -53,13 +53,9 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
 
   . $PKG_DIR/package.mk
 
-  if [ "$(type -t pre_unpack)" = "function" ]; then
-    pre_unpack
-  fi
+  pkg_call_optional pre_unpack
 
-  if [ "$(type -t unpack)" = "function" ]; then
-    unpack
-  else
+  if ! pkg_call unpack; then
     if [ -n "$PKG_URL" ]; then
       $SCRIPTS/extract $1 $BUILD
     fi
@@ -82,14 +78,10 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     mkdir -p "${PKG_BUILD}"
   fi
 
-  if [ "$(type -t post_unpack)" = "function" ]; then
-    post_unpack
-  fi
+  pkg_call_optional post_unpack
 
   if [ "${PKG_SKIP_PATCHES}" != "yes" ]; then
-    if [ "$(type -t pre_patch)" = "function" ]; then
-      pre_patch
-    fi
+    pkg_call_optional pre_patch
 
     if [ "$TARGET_ARCH" = "x86_64" ]; then
       PATCH_ARCH="x86"
@@ -158,9 +150,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
       fi
     done
 
-    if [ "$(type -t post_patch)" = "function" ]; then
-      post_patch
-    fi
+    pkg_call_optional post_patch
   fi
 
   if [ ! "$PKG_NAME" = "configtools" ] ; then


### PR DESCRIPTION
This adds a helper function that is used to call into package functions if they exist, handle errors when the call fails, and return a suitable exit code to indicate when the function does not exist.

If the package function does not exist, the proxy does nothing and returns with exit code 1, which would normally be an error so when the exit code isn't relevant to the caller then `|| true` must be used to prevent the calling script from bailing out due to `set -e`.

This change eliminates repeated code, and makes the calls to package functions more robust - if the call to the package function fails we will now output a (hopefully) helpful error message, rather than failing silently which normally leads to a lot of head scratching/confusion.

I've called the proxy function `pkg_function`, but I'm open to suggestion on better names - `pkg_exec` is another possibility, or maybe `pkg_proxy`...