### PR TITLE
libssh: update to libssh-0.8.5

### DIFF
--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libssh"
-PKG_VERSION="0.8.4"
-PKG_SHA256="6bb07713021a8586ba2120b2c36c468dc9ac8096d043f9b1726639aa4275b81b"
+PKG_VERSION="0.8.5"
+PKG_SHA256="07d2c431240fc88f6b06bcb36ae267f9afeedce2e32f6c42f8844b205ab5a335"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libssh.org/"
 PKG_URL="https://www.libssh.org/files/${PKG_VERSION%.*}/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
https://www.libssh.org/2018/10/29/libssh-0-8-5-and-libssh-0-7-7/

Fixes a memory leak with OpenSSL: https://bugs.libssh.org/T116