### PR TITLE
fix .config/firmware handling

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -298,9 +298,6 @@ post_install() {
   mkdir -p $INSTALL/$(get_full_firmware_dir)/
     ln -sf /storage/.config/firmware/ $INSTALL/$(get_full_firmware_dir)/updates
 
-  # bluez looks in /etc/firmware/
-    ln -sf /$(get_full_firmware_dir)/ $INSTALL/etc/firmware
-
   # regdb and signature is now loaded as firmware by 4.15+
     if grep -q ^CONFIG_CFG80211_REQUIRE_SIGNED_REGDB= $PKG_BUILD/.config; then
       cp $(get_build_dir wireless-regdb)/regulatory.db{,.p7s} $INSTALL/$(get_full_firmware_dir)

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -296,7 +296,6 @@ makeinstall_init() {
 
 post_install() {
   mkdir -p $INSTALL/$(get_full_firmware_dir)/
-    ln -sf /storage/.config/firmware/ $INSTALL/$(get_full_firmware_dir)/updates
 
   # regdb and signature is now loaded as firmware by 4.15+
     if grep -q ^CONFIG_CFG80211_REQUIRE_SIGNED_REGDB= $PKG_BUILD/.config; then

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -59,6 +59,9 @@ post_makeinstall_target() {
 
   mkdir -p $INSTALL/usr/share/services
     cp -P $PKG_DIR/default.d/*.conf $INSTALL/usr/share/services
+
+  # bluez looks in /etc/firmware/
+    ln -sf /usr/lib/firmware $INSTALL/etc/firmware
 }
 
 post_install() {

--- a/packages/sysutils/systemd/scripts/kernel-overlays-setup
+++ b/packages/sysutils/systemd/scripts/kernel-overlays-setup
@@ -8,6 +8,7 @@ OVERLAY_CONFIG_DIR=/storage/.cache/kernel-overlays
 KVER=$(uname -r)
 MODULES_DIR="/var/lib/modules/${KVER}"
 FIRMWARE_DIR="/var/lib/firmware"
+USER_FIRMWARE_DIR="/storage/.config/firmware"
 
 mkdir -p "${MODULES_DIR}"
 mkdir -p "${FIRMWARE_DIR}"
@@ -70,6 +71,14 @@ if [ -d "${OVERLAY_CONFIG_DIR}" ] ; then
   if [ "yes" = "$GOT_MODULE_OVERLAY" ] ; then
     log "running depmod"
     /usr/sbin/depmod -a
+  fi
+fi
+
+if [ -d "${USER_FIRMWARE_DIR}" -a -n "$(ls ${USER_FIRMWARE_DIR})" ] ; then
+  if cp -rfs "${USER_FIRMWARE_DIR}"/* "${FIRMWARE_DIR}" ; then
+    log "added firmware from ${USER_FIRMWARE_DIR}"
+  else
+    log "failed to add firmware from ${USER_FIRMWARE_DIR}"
   fi
 fi
 


### PR DESCRIPTION
Creating an updates symlink to /storage/.config/firmware in the kernel firmware directory makes it impossible to add firmware overlays with an updates folder.

Furthermore bluez/hciattach only looks for firmware files directly in the /lib/firmware directory and ignores the /lib/firmware/updates directory. So adding BT firmware via .config/firmware didn't work.

Solve this by adding files from /storage/.config/firmware as the last step in kernel overlays setup so firmware files from there will show up directly under /lib/firmware and override other firmware files installed by the system and kernel overlays.

Also fix the /etc/firmware symlink for bluez, it pointed to the kernel firmware so hciattach would never pick up firmwares installed by kernel overlays or .config/firmware