### PR TITLE
iptables: fix build with 3.10.y, remove hack

### DIFF
--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -3,13 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iptables"
-if [[ ! $LINUX =~ ^amlogic-3 ]]; then
-  PKG_VERSION="1.8.2"
-  PKG_SHA256="a3778b50ed1a3256f9ca975de82c2204e508001fc2471238c8c97f3d1c4c12af"
-else
-  PKG_VERSION="1.6.1"
-  PKG_SHA256="0fc2d7bd5d7be11311726466789d4c65fb4c8e096c9182b56ce97440864f0cf5"
-fi
+PKG_VERSION="1.8.2"
+PKG_SHA256="a3778b50ed1a3256f9ca975de82c2204e508001fc2471238c8c97f3d1c4c12af"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.netfilter.org/"
 PKG_URL="http://www.netfilter.org/projects/iptables/files/$PKG_NAME-$PKG_VERSION.tar.bz2"

--- a/packages/network/iptables/patches/iptables-0001-fix-build-with-pre-4.2-kernels.patch
+++ b/packages/network/iptables/patches/iptables-0001-fix-build-with-pre-4.2-kernels.patch
@@ -1,0 +1,52 @@
+From fe9a5c043082a553ed1789cb478f2c48763e7f30 Mon Sep 17 00:00:00 2001
+From: Baruch Siach <baruch@tkos.co.il>
+Date: Fri, 16 Nov 2018 09:30:33 +0200
+Subject: [PATCH] include: fix build with kernel headers before 4.2
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Commit 672accf1530 (include: update kernel netfilter header files)
+updated linux/netfilter.h and brought with it the update from kernel
+commit a263653ed798 (netfilter: don't pull include/linux/netfilter.h
+from netns headers). This triggers conflict of headers that is fixed in
+kernel commit 279c6c7fa64f (api: fix compatibility of linux/in.h with
+netinet/in.h) included in kernel version 4.2. For earlier kernel headers
+we need a workaround that prevents the headers conflict.
+
+Fixes the following build failure:
+
+In file included from .../sysroot/usr/include/netinet/ip.h:25:0,
+                 from ../include/libiptc/ipt_kernel_headers.h:8,
+                 from ../include/libiptc/libiptc.h:6,
+                 from libip4tc.c:29:
+.../sysroot/usr/include/linux/in.h:26:3: error: redeclaration of enumerator ‘IPPROTO_IP’
+   IPPROTO_IP = 0,  /* Dummy protocol for TCP  */
+   ^
+.../sysroot/usr/include/netinet/in.h:33:5: note: previous definition of ‘IPPROTO_IP’ was here
+     IPPROTO_IP = 0,    /* Dummy protocol for TCP.  */
+     ^~~~~~~~~~
+
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Signed-off-by: Florian Westphal <fw@strlen.de>
+---
+ include/linux/netfilter.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/linux/netfilter.h b/include/linux/netfilter.h
+index c3f087a..bacf8cd 100644
+--- a/include/linux/netfilter.h
++++ b/include/linux/netfilter.h
+@@ -3,7 +3,9 @@
+ 
+ #include <linux/types.h>
+ 
++#ifndef _NETINET_IN_H
+ #include <linux/in.h>
++#endif
+ #include <linux/in6.h>
+ #include <limits.h>
+ 
+-- 
+2.14.1
+


### PR DESCRIPTION
This upstream commit fixes the build issue with 3,10.y kernels, and can be removed with iptables-1.8.3.