### PR TITLE
heimdal: Disable OTP [backport]

### DIFF
--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -44,6 +44,7 @@ PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared \
                          --without-libedit \
                          --without-hesiod \
                          --without-x \
+                         --disable-otp \
                          --with-db-type-preference= \
                          --disable-heimdal-documentation"
 


### PR DESCRIPTION
Building OTP is broken on ArchLinux and it seems it is not needed
anyway.

Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>

Also see https://github.com/heimdal/heimdal/issues/396