### PR TITLE
dvb-latest: update to 2018-12-07

### DIFF
--- a/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
+++ b/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media_tree"
-PKG_VERSION="2018-11-23-708d75fe1c7c"
-PKG_SHA256="57ed46bdc5905b093c578c69252564be80343ceeefab92c0b081f99b9463a3b8"
+PKG_VERSION="2018-12-07-e159b6074c82"
+PKG_SHA256="8df4e76878239881cf69bddab2f1c69be698c25682d114b706d75123972c95b7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.linuxtv.org/media_tree.git"
 PKG_URL="http://linuxtv.org/downloads/drivers/linux-media-${PKG_VERSION}.tar.bz2"

--- a/packages/linux-driver-addons/dvb/dvb-latest/package.mk
+++ b/packages/linux-driver-addons/dvb/dvb-latest/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dvb-latest"
-PKG_VERSION="a8aef9cea0a4a2f3ea86c0b37bd6a1378018c0c1"
-PKG_SHA256="a26566b1f8ad52f2a1b3c60f0ee8862702e51e2a7bc9e5385999137db0da3fe3"
+PKG_VERSION="bd2896dbe1969af199b9f0569d1c60b0ab2859ff"
+PKG_SHA256="00923e79db7b34fec4015cafc1390db388165b86e78564f340759f6da245824e"
 PKG_LICENSE="GPL"
 PKG_SITE="http://git.linuxtv.org/media_build.git"
 PKG_URL="https://git.linuxtv.org/media_build.git/snapshot/${PKG_VERSION}.tar.gz"
@@ -29,10 +29,6 @@ make_target() {
 
   # make config all
   kernel_make VER=$KERNEL_VER SRCDIR=$(kernel_path) allyesconfig
-
-  if [ "$PROJECT" = Rockchip ]; then
-    sed -e 's/CONFIG_VIDEO_ADV7604=m/# CONFIG_VIDEO_ADV7604 is not set/g' -i v4l/.config
-  fi
 
   kernel_make VER=$KERNEL_VER SRCDIR=$(kernel_path)
 }


### PR DESCRIPTION
- updates media_tree a bit further
- RK workaround is now fixed upstream