### PR TITLE
tvheadend42: update

### DIFF
--- a/packages/addons/service/tvheadend42/source/bin/tv_grab_file
+++ b/packages/addons/service/tvheadend42/source/bin/tv_grab_file
@@ -37,7 +37,7 @@ then
       exec "$XMLTV_LOCATION_SCRIPT"
     fi
   elif [ "$XMLTV_TYPE" = "WEB" ]; then
-    wget -qO - "$XMLTV_LOCATION_WEB"
+    wget -qO - "${XMLTV_LOCATION_WEB//&amp\;/\&}"
     exit 0
   fi
 fi


### PR DESCRIPTION
- fixes xmltv urls like `http://xmltv.tv/script.php?username=123&password=1234&type=m3u_plus`
if you enter `&` at Kodi it get rewritten to `&amp;` - that change inline replaces it

ping @edit4ever @TheUlpio maybe you have some opinion about 

- other updates are following (just pushed the xmltv change to get some feedback at the moment)