### PR TITLE
ffmpeg: add compatibility script

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -287,6 +287,7 @@ post_makeinstall_target() {
     cp $PKG_DIR/scripts/service-addon-wrapper $INSTALL/usr/sbin
 
   mkdir -p $INSTALL/usr/bin
+    cp $PKG_DIR/scripts/ffmpeg $INSTALL/usr/bin
     cp $PKG_DIR/scripts/kodi-remote $INSTALL/usr/bin
     cp $PKG_DIR/scripts/setwakeup.sh $INSTALL/usr/bin
     cp $PKG_DIR/scripts/pastekodi $INSTALL/usr/bin

--- a/packages/mediacenter/kodi/scripts/ffmpeg
+++ b/packages/mediacenter/kodi/scripts/ffmpeg
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+b="/storage/.kodi/addons/tools.ffmpeg-tools/bin/ffmpeg"
+if [ -x "$b" ]; then
+  exec $b "$@"
+else
+  echo "FFmpeg is not installed, please install the FFmpeg-Tools Add-on from the LibreELEC repository."
+fi


### PR DESCRIPTION
- allows to use `/usr/bin/ffmpeg` without installing the ffmpeg binary to the image and behave like a "normal" distribution (piping at tvh etc works too)
- tutorials, playlists and predefined paths at scripts that are not supporting LE are working now
```
LibreELEC:~/videos # which ffmpeg
/usr/bin/ffmpeg
```

usage examples
```
LibreELEC:~/videos # /usr/bin/ffmpeg -i color.mp4 abc.avi
LibreELEC:~/videos # ffmpeg -i color.mp4 abc.avi
LibreELEC:~/videos # /storage/.kodi/addons/tools.ffmpeg-tools/bin/ffmpeg -i color.mp4 abc.avi
```

if no add-on is installed
```
LibreELEC:~/videos # /usr/bin/ffmpeg -i color.mp4 abc.avi
FFmpeg is not installed, please install the ffmpeg-tools Add-on from the LibreELEC repository
```