### PR TITLE
udevil: don't change permissions of mounted filesystems

### DIFF
--- a/packages/sysutils/udevil/config/udevil.conf
+++ b/packages/sysutils/udevil/config/udevil.conf
@@ -259,11 +259,11 @@ allowed_options_exfat     = nosuid, noexec, nodev, noatime, ro, rw, uid=$UID, gi
 # mount_point_mode_FSTYPE, if present, is used to override mount_point_mode
 # when mounting a specific fstype (eg ext2, nfs).
 # NOT SETTING A MODE CAN HAVE SECURITY IMPLICATIONS FOR SOME FSTYPES
-mount_point_mode = 0755
+# mount_point_mode = 0755
 # don't set a mode for some types:
-mount_point_mode_sshfs =
-mount_point_mode_curlftpfs =
-mount_point_mode_ftpfs =
+# mount_point_mode_sshfs =
+# mount_point_mode_curlftpfs =
+# mount_point_mode_ftpfs =
 
 
 # Use the settings below to change the default locations of programs used by


### PR DESCRIPTION
Setting mount_point_mode results in permanent changes of filesystem
permissions, trashing permissions users may have manually set up.

Udisks2 doesn't do that either so drop that option.

This fixes the issue reported here: https://forum.libreelec.tv/thread/13891-external-drives-with-linux-filesystem-get-unwanted-rights-if-once-connected-to-l/