### PR TITLE
heimdal: remove unrequired setting

### DIFF
--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2017 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="heimdal"
 PKG_VERSION="7.5.0"
@@ -24,7 +25,6 @@ PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared \
                          --without-hesiod \
                          --without-x \
                          --disable-otp \
-                         --with-db-type-preference= \
                          --disable-heimdal-documentation"
 
 makeinstall_host() {


### PR DESCRIPTION
@jernejsk in light of [this question](https://github.com/heimdal/heimdal/issues/396#issuecomment-447479814) (which is in relation to #2218), can you test if `heimdal` with this PR continues to build correctly on Arch? I've tested on Ubuntu 17.10 without issue.