### PR TITLE
kernel-overlays-setup: fix ls error in journal if .config/firmware do…

### DIFF
--- a/packages/sysutils/systemd/scripts/kernel-overlays-setup
+++ b/packages/sysutils/systemd/scripts/kernel-overlays-setup
@@ -74,7 +74,7 @@ if [ -d "${OVERLAY_CONFIG_DIR}" ] ; then
   fi
 fi
 
-if [ -d "${USER_FIRMWARE_DIR}" -a -n "$(ls ${USER_FIRMWARE_DIR})" ] ; then
+if [ -d "${USER_FIRMWARE_DIR}" ] && [ -n "$(ls ${USER_FIRMWARE_DIR})" ] ; then
   if cp -rfs "${USER_FIRMWARE_DIR}"/* "${FIRMWARE_DIR}" ; then
     log "added firmware from ${USER_FIRMWARE_DIR}"
   else


### PR DESCRIPTION
…esn't exist

Sorry, I missed that when testing the .config/firmware changes