### PR TITLE
tini: fix typos

### DIFF
--- a/packages/addons/addon-depends/tini/package.mk
+++ b/packages/addons/addon-depends/tini/package.mk
@@ -11,9 +11,9 @@ PKG_URL="https://github.com/krallin/tini/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Tini is a simplest init system."
 
-PKG_CMAKE_TARGET_OPTS="-DMINIMAL=ON"
+PKG_CMAKE_OPTS_TARGET="-DMINIMAL=ON"
 
-PKG_MAKE_TARGET_OPTS="tini-static"
+PKG_MAKE_OPTS_TARGET="tini-static"
 
 pre_configure_target(){
   sed -i "s|@tini_VERSION_GIT@| - git.${PKG_VERSION}|" $PKG_BUILD/src/tiniConfig.h.in


### PR DESCRIPTION
I'm not 100% sure, but the existing variable names look like they are typos - @lrusak can you confirm as you committed this originally (86be339d0df5b438ca6eb2f6ecae296aa28a22c9).