### PR TITLE
libxslt, libssh2: build with -fPIC

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/depends/libssh2/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/libssh2/package.mk
@@ -9,6 +9,7 @@ PKG_SITE="https://www.libssh2.org"
 PKG_URL="https://www.libssh2.org/download/libssh2-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain openssl"
 PKG_LONGDESC="A library implementing the SSH2 protocol"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_EXAMPLES=OFF \
                        -DBUILD_TESTING=OFF"

--- a/packages/textproc/libxslt/package.mk
+++ b/packages/textproc/libxslt/package.mk
@@ -11,6 +11,7 @@ PKG_URL="ftp://xmlsoft.org/libxml2/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_HOST="libxml2:host"
 PKG_DEPENDS_TARGET="toolchain libxml2"
 PKG_LONGDESC="A XSLT C library."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_HOST="  ac_cv_header_ansidecl_h=no \
                            ac_cv_header_xlocale_h=no \


### PR DESCRIPTION
Compiling a shared library requires -fPIC. But this two libs are build without.