### PR TITLE
config/functions: respect CONCURRENCY_MAKE_LEVEL for ninja

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -231,6 +231,7 @@ setup_toolchain() {
     NINJA_OPTS="$NINJA_OPTS -j1"
     export MAKEFLAGS="-j1"
   else
+    NINJA_OPTS="$NINJA_OPTS -j$CONCURRENCY_MAKE_LEVEL"
     export MAKEFLAGS="-j$CONCURRENCY_MAKE_LEVEL"
   fi
 

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -40,7 +40,7 @@ PKG_CMAKE_OPTS_HOST="$PKG_CMAKE_OPTS_COMMON \
                      -DCMAKE_INSTALL_RPATH=$TOOLCHAIN/lib"
 
 make_host() {
-  ninja llvm-config llvm-tblgen
+  ninja $NINJA_OPTS llvm-config llvm-tblgen
 }
 
 makeinstall_host() {


### PR DESCRIPTION
I know everyone would like to build system as fast as possible. But when you don't have much cpu cores and you need to share them between different things it is good if build system respects CONCURRENCY_MAKE_LEVEL parameter. Currently llvm builds on all cores which this PR fixes.