### PR TITLE
libjpeg-turbo: bump version/switch to cmake; fix host cmake

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -323,6 +323,7 @@ setup_toolchain() {
         mkdir -p $TOOLCHAIN/etc
         echo "SET(CMAKE_SYSTEM_NAME Linux)" >> $CMAKE_CONF
         echo "SET(CMAKE_SYSTEM_VERSION 1)"  >> $CMAKE_CONF
+        echo "SET(CMAKE_SYSTEM_PROCESSOR ${MACHINE_HARDWARE_PLATFORM})" >> $CMAKE_CONF
         echo "SET(CMAKE_C_COMPILER   $CC)"  >> $CMAKE_CONF
         echo "SET(CMAKE_CXX_COMPILER $CXX)" >> $CMAKE_CONF
         echo "SET(CMAKE_CPP_COMPILER $CXX)" >> $CMAKE_CONF

--- a/config/optimize
+++ b/config/optimize
@@ -60,8 +60,8 @@ if [ -z "$HOST_LIBDIR" ]; then
   HOST_LIBDIR="$TOOLCHAIN/lib"
 
   # ubuntu/debian specific "multiarch support"
-  MACHINE_HARDWARE_NAME="$(uname -m)"
-  MACHINE_HARDWARE_PLATFORM="$(uname -i)"
+  export MACHINE_HARDWARE_NAME="$(uname -m)"
+  export MACHINE_HARDWARE_PLATFORM="$(uname -i)"
   FAMILY_TRIPLET=${HOST_NAME/${MACHINE_HARDWARE_NAME}/${MACHINE_HARDWARE_PLATFORM}}
   if [ -d /lib/$FAMILY_TRIPLET ]; then
     HOST_LIBDIR="$HOST_LIBDIR /lib/$FAMILY_TRIPLET"

--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -4,10 +4,10 @@
 
 PKG_NAME="libjpeg-turbo"
 PKG_VERSION="2.0.1"
-PKG_SHA256="e5f86cec31df1d39596e0cca619ab1b01f99025a27dafdfc97a30f3a12f866ff"
+PKG_SHA256="a30db8bcc8a0fab56998ea134233a8cdcb7ac81170e7d87f8bc900f02dda39d4"
 PKG_LICENSE="GPL"
-PKG_SITE="http://libjpeg-turbo.virtualgl.org/"
-PKG_URL="$SOURCEFORGE_SRC/libjpeg-turbo/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SITE="https://libjpeg-turbo.org/"
+PKG_URL="https://github.com/libjpeg-turbo/libjpeg-turbo/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_HOST="toolchain"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A high-speed version of libjpeg for x86 and x86-64 processors which uses SIMD."

--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -3,26 +3,29 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libjpeg-turbo"
-PKG_VERSION="1.5.3"
-PKG_SHA256="b24890e2bb46e12e72a79f7e965f409f4e16466d00e1dd15d93d73ee6b592523"
+PKG_VERSION="2.0.1"
+PKG_SHA256="e5f86cec31df1d39596e0cca619ab1b01f99025a27dafdfc97a30f3a12f866ff"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libjpeg-turbo.virtualgl.org/"
 PKG_URL="$SOURCEFORGE_SRC/libjpeg-turbo/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_HOST="toolchain"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A high-speed version of libjpeg for x86 and x86-64 processors which uses SIMD."
-PKG_TOOLCHAIN="configure"
 PKG_BUILD_FLAGS="+pic +pic:host"
 
-PKG_CONFIGURE_OPTS_HOST="--enable-static \
-                         --disable-shared \
-                         --with-jpeg8 \
-                         --without-simd"
+PKG_CMAKE_OPTS_HOST="-DENABLE_STATIC=ON \
+                     -DENABLE_SHARED=OFF \
+                     -DWITH_JPEG8=ON \
+                     -DWITH_SIMD=OFF"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --with-jpeg8"
+PKG_CMAKE_OPTS_TARGET="-DENABLE_STATIC=ON \
+                       -DENABLE_SHARED=OFF \
+                       -DWITH_JPEG8=ON"
 
-if ! target_has_feature "(neon|sse)"; then
-  PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --without-simd"
+if target_has_feature "(neon|sse)"; then
+  PKG_CMAKE_OPTS_TARGET+=" -DWITH_SIMD=ON"
+else
+  PKG_CMAKE_OPTS_TARGET+=" -DWITH_SIMD=OFF"
 fi
 
 if [ $TARGET_ARCH = "x86_64" ]; then


### PR DESCRIPTION
Strictly speaking `nasm` is only required when SSE support is required, but building it always for x86_64 may be the least troublesome option.