### PR TITLE
kodi: service addon wrapper call fix

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.09-use-a-wrapper-to-setup-service-addons.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.09-use-a-wrapper-to-setup-service-addons.patch
@@ -19,8 +19,8 @@ index 8343101b96..8130d99b83 100644
 +    case LE_ADDON_DISABLED:
 +      contextStr = "disable";
 +      break;
-+    case LE_ADDON_POST_INSTALL:
-+      contextStr = "post-install";
++    case LE_ADDON_POST_UPDATE:
++      contextStr = "post-update";
 +      break;
 +    case LE_ADDON_PRE_UNINSTALL:
 +      contextStr = "pre-uninstall";
@@ -40,12 +40,13 @@ index 8343101b96..8130d99b83 100644
  void OnPreInstall(const AddonPtr& addon)
  {
    //Fallback to the pre-install callback in the addon.
-@@ -426,6 +457,8 @@ void OnPostInstall(const AddonPtr& addon, bool update, bool modal)
+@@ -426,6 +457,9 @@ void OnPostInstall(const AddonPtr& addon, bool update, bool modal)
      }
      closedir(addonsDir);
    }
 +
-+  LEAddonHook(addon, LE_ADDON_POST_INSTALL);
++  if (update)
++    LEAddonHook(addon, LE_ADDON_POST_UPDATE);
    // OE
  
    addon->OnPostInstall(update, modal);
@@ -69,7 +70,7 @@ index b877839848..f7c0b717f6 100644
 +typedef enum {
 +  LE_ADDON_ENABLED,
 +  LE_ADDON_DISABLED,
-+  LE_ADDON_POST_INSTALL,
++  LE_ADDON_POST_UPDATE,
 +  LE_ADDON_PRE_UNINSTALL,
 +} LE_ADDON_CONTEXT;
 +

--- a/packages/mediacenter/kodi/scripts/service-addon-wrapper
+++ b/packages/mediacenter/kodi/scripts/service-addon-wrapper
@@ -29,8 +29,8 @@ if [ -f "${SERVICE_FILE}" ] ; then
       systemctl stop "${ADDON_ID}.service"
       systemctl disable "${ADDON_ID}.service"
       ;;
-    post-install)
-      # post-install is triggered on update as well,
+    post-update)
+      # post-update is triggered on update,
       # make sure to stop and re-install service
       systemctl stop "${ADDON_ID}.service"
       systemctl disable "${ADDON_ID}.service"
@@ -77,7 +77,7 @@ if [ -d "${OVERLAY_PATH}" ] ; then
   OVERLAY_CONF="/storage/.cache/kernel-overlays/50-${ADDON_ID}.conf"
 
   case "${CONTEXT}" in
-    enable | post-install )
+    enable | post-update )
       create_overlay_conf
       ;;
     disable | pre-uninstall )


### PR DESCRIPTION
Currently when addon is installed it's service is enabled and started.
But immediately service is stopped, disabled, enabled and started again.
This second part should be executed only on addon's update.

Discussion in PR #1835 https://github.com/LibreELEC/LibreELEC.tv/pull/1835#commitcomment-31787284