### PR TITLE
v4l-utils: simplify 70-infrared.rules and fix kernel 4.20 issues

### DIFF
--- a/packages/sysutils/v4l-utils/udev.d/70-infrared.rules
+++ b/packages/sysutils/v4l-utils/udev.d/70-infrared.rules
@@ -1,25 +1,19 @@
+
 # Automatically load the proper keymaps after the Remote Controller device
 # creation.
 #
 # User-defined rules can be stored in /storage/.config/rc_maps.cfg. If that
 # file doesn't exist the default rules from /etc/rc_maps.cfg are used.
 
-ACTION=="add", SUBSYSTEMS=="rc", GOTO="begin"
+ACTION=="add", KERNEL=="event*", SUBSYSTEM=="input", SUBSYSTEMS=="rc", ENV{.rc_sysdev}="$id", GOTO="begin"
 GOTO="end"
 
 LABEL="begin"
 
-SUBSYSTEM=="rc", ENV{rc_sysdev}="$name"
+ENV{.rc_maps_cfg}="/etc/rc_maps.cfg"
+TEST=="/storage/.config/rc_maps.cfg", ENV{.rc_maps_cfg}="/storage/.config/rc_maps.cfg"
 
-SUBSYSTEM=="input", IMPORT{parent}="rc_sysdev"
-
-KERNEL=="event[0-9]*", ENV{rc_sysdev}=="?*", IMPORT{program}="/usr/bin/sh -c '\
-  if [ -r /storage/.config/rc_maps.cfg ] ; then \
-    echo rc_maps_cfg=/storage/.config/rc_maps.cfg ; \
-  else \
-    echo rc_maps_cfg=/etc/rc_maps.cfg ; \
-  fi'"
-
-ENV{rc_maps_cfg}=="?*", RUN+="/usr/bin/ir-keytable -a $env{rc_maps_cfg} -s $env{rc_sysdev}"
+RUN+="/usr/bin/ir-keytable -a $env{.rc_maps_cfg} -s $env{.rc_sysdev}"
 
 LABEL="end"
+


### PR DESCRIPTION
Using $id to get the rcX device name from the SUBSYSTEMS match,
as used by the upstrem v4l-utils udev rule, is easier and more
stable than using IMPORT{parent}, which needs to transmit info across
two levels (rcX->inputY->eventZ) and breaks with kernel 4.20.

Instead of running a shell script to check for the existance of
/storage/.config/rc_maps.cfg we can use the builtin udev TEST
function.

Also it's better to use ENV variables prefixed with a dot as
they are used only locally in the udev rule file and don't need
to be persisted in the udev database or exported to external tools.