### PR TITLE
Fix cross compilation of libX11

### DIFF
--- a/packages/x11/lib/libX11/package.mk
+++ b/packages/x11/lib/libX11/package.mk
@@ -31,11 +31,8 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-loadable-i18n \
                            --without-launchd \
                            --without-lint"
 
-pre_make_target() {
+make_target() {
   echo '' > $PKG_BUILD/src/util/Makefile.am
   $HOST_CC $PKG_BUILD/src/util/makekeys.c -o $PKG_BUILD/.$TARGET_NAME/src/util/makekeys
-}
-
-make_target() {
   make V=1 CC=$CC AR=$AR LD=$LD CFLAGS="$TARGET_CFLAGS"
 }

--- a/packages/x11/lib/libX11/package.mk
+++ b/packages/x11/lib/libX11/package.mk
@@ -31,8 +31,11 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-loadable-i18n \
                            --without-launchd \
                            --without-lint"
 
-make_target() {
+pre_make_target() {
   echo '' > $PKG_BUILD/src/util/Makefile.am
   $HOST_CC $PKG_BUILD/src/util/makekeys.c -o $PKG_BUILD/.$TARGET_NAME/src/util/makekeys
+}
+
+make_target() {
   make V=1 CC=$CC AR=$AR LD=$LD CFLAGS="$TARGET_CFLAGS"
 }

--- a/packages/x11/lib/libX11/package.mk
+++ b/packages/x11/lib/libX11/package.mk
@@ -35,7 +35,3 @@ pre_make_target() {
   echo '' > $PKG_BUILD/src/util/Makefile.am
   $HOST_CC $HOST_CFLAGS -I$PKG_BUILD/include $PKG_BUILD/src/util/makekeys.c -o $PKG_BUILD/.$TARGET_NAME/src/util/makekeys
 }
-
-make_target() {
-  make V=1 CC=$CC LD=$LD CFLAGS="$TARGET_CFLAGS"
-}

--- a/packages/x11/lib/libX11/package.mk
+++ b/packages/x11/lib/libX11/package.mk
@@ -30,3 +30,9 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-loadable-i18n \
                            --disable-ipv6 \
                            --without-launchd \
                            --without-lint"
+
+make_target() {
+  echo '' > $PKG_BUILD/src/util/Makefile.am
+  $HOST_CC $PKG_BUILD/src/util/makekeys.c -o $PKG_BUILD/.$TARGET_NAME/src/util/makekeys
+  make V=1 CC=$CC AR=$AR LD=$LD CFLAGS="$TARGET_CFLAGS"
+}

--- a/packages/x11/lib/libX11/package.mk
+++ b/packages/x11/lib/libX11/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="4d3890db2ba225ba8c55ca63c6409c1ebb078a2806de59fb16342768ae63435d"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.x.org/"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/$PKG_NAME-$PKG_VERSION.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain util-macros xtrans libXau libxcb"
+PKG_DEPENDS_TARGET="toolchain util-macros xtrans libXau libxcb xorgproto:host"
 PKG_LONGDESC="LibX11 is the main X11 library containing all the client-side code to access the X11 windowing system."
 PKG_TOOLCHAIN="autotools"
 
@@ -31,8 +31,11 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-loadable-i18n \
                            --without-launchd \
                            --without-lint"
 
-make_target() {
+pre_make_target() {
   echo '' > $PKG_BUILD/src/util/Makefile.am
-  $HOST_CC $PKG_BUILD/src/util/makekeys.c -o $PKG_BUILD/.$TARGET_NAME/src/util/makekeys
-  make V=1 CC=$CC AR=$AR LD=$LD CFLAGS="$TARGET_CFLAGS"
+  $HOST_CC $HOST_CFLAGS -I$PKG_BUILD/include $PKG_BUILD/src/util/makekeys.c -o $PKG_BUILD/.$TARGET_NAME/src/util/makekeys
+}
+
+make_target() {
+  make V=1 CC=$CC LD=$LD CFLAGS="$TARGET_CFLAGS"
 }


### PR DESCRIPTION
I need to cross compile this package for one of my projects.

`makekeys` has to be built for the host architecture, not the target architecture.

See more detailed explanations here about why this change make sense 
https://github.com/hanshuebner/buildroot/blob/master/package/x11r7/xlib_libX11/xlib_libX11.mk#L24-L29

This change will also help in building LibreELEC from another architecture than x86_64.