### PR TITLE
addons: bump sapphire driver to v7.1

### DIFF
--- a/packages/addons/driver/sapphire/package.mk
+++ b/packages/addons/driver/sapphire/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sapphire"
-PKG_VERSION="6.9"
-PKG_SHA256="191661e8186712fe4a08a7555dbca36676338c630536a48373048afbbb3ad2ff"
-PKG_REV="104"
+PKG_VERSION="7.1"
+PKG_SHA256="24c662c45c581f8fe395d1cdcd6e1dca3db9e0eb590433f39de6037b2d4c5764"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
Supersedes #3185 which has wrong sha256, no add-on version bump, and bad commit description.

Not tested (as no hardware) but it builds .. same as all previous versions we shipped :)