### PR TITLE
crazycat_aml: fix crash

### DIFF
--- a/packages/linux-driver-addons/dvb/crazycat_aml/patches/driver.dvb.crazycat_aml-03-config_mycompat_h.patch
+++ b/packages/linux-driver-addons/dvb/crazycat_aml/patches/driver.dvb.crazycat_aml-03-config_mycompat_h.patch
@@ -1,7 +1,6 @@
 --- /dev/null
 +++ b/v4l/config-mycompat.h
-@@ -0,0 +1,4 @@
-+#undef NEED_SMP_MB_AFTER_ATOMIC
+@@ -0,0 +1,3 @@
 +#undef NEED_PFN_TO_PHYS
 +#undef NEED_WRITEL_RELAXED
 +#undef NEED_PM_RUNTIME_GET


### PR DESCRIPTION
fixes `dvb_usb_v2: Unknown symbol smp_mb__after_atomic (err 0)` while using for example `Technotrend CT-4400`