### PR TITLE
zstd: update to 1.3.8

### DIFF
--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.3.7"
-PKG_SHA256="5dd1e90eb16c25425880c8a91327f63de22891ffed082fcc17e5ae84fce0d5fb"
+PKG_VERSION="1.3.8"
+PKG_SHA256="293fa004dfacfbe90b42660c474920ff27093e3fb6c99f7b76e6083b21d6d48e"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"
-PKG_URL="https://github.com/facebook/zstd/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_SOURCE_DIR=$PKG_NAME-$PKG_VERSION
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A fast real-time compression algorithm."


### PR DESCRIPTION
Of note is compression ratio improvements. Takes another ~370kb off an RPi image for me.

Updated URL to point to releases so the checksum matches what the zstd maintainers say the checksum should be.