### PR TITLE
Fix host platform for CMake

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -305,7 +305,7 @@ setup_toolchain() {
         mkdir -p $TOOLCHAIN/etc
         echo "SET(CMAKE_SYSTEM_NAME Linux)" >> $CMAKE_CONF
         echo "SET(CMAKE_SYSTEM_VERSION 1)"  >> $CMAKE_CONF
-        echo "SET(CMAKE_SYSTEM_PROCESSOR ${MACHINE_HARDWARE_PLATFORM})" >> $CMAKE_CONF
+        echo "SET(CMAKE_SYSTEM_PROCESSOR ${MACHINE_HARDWARE_NAME})" >> $CMAKE_CONF
         echo "SET(CMAKE_C_COMPILER   $CC)"  >> $CMAKE_CONF
         echo "SET(CMAKE_CXX_COMPILER $CXX)" >> $CMAKE_CONF
         echo "SET(CMAKE_CPP_COMPILER $CXX)" >> $CMAKE_CONF


### PR DESCRIPTION
Use _uname -m_ instead of _uname -i_ for CMAKE_SYSTEM_PROCESSOR.

Both actually returns x86_64 on most 64-bit systems however on other machines I get:
```
host ~ # uname -i
GenuineIntel
host ~ # uname -m
i686
```

Another Debian system shows:
```
root@ns:~# uname -i
unknown
root@ns:~# uname -m
i686
```

I know building on 32-bit hosts is no longer supported but this actually fixes _libjpeg-turbo_ build on 32-bit systems.
