### PR TITLE
xf86-video-nvidia: update to xf86-video-nvidia-410.93

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="xf86-video-nvidia"
 # Remember to run "python packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py" and commit changes to
 # "packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules" whenever bumping version.
 # Host may require installation of python-lxml and python-requests packages.
-PKG_VERSION="410.78"
-PKG_SHA256="5d5efb15d689cf3dd6652ba9379c7e5c339dfc3de9ac6734090a9421167dbcb3"
+PKG_VERSION="410.93"
+PKG_SHA256="b1ce054f8307080a257538ab82873e8b8022183f68e08e20fbb07089f7ddbb08"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.nvidia.com/"


### PR DESCRIPTION
Announcement: [forum](https://devtalk.nvidia.com/default/topic/1045858), [alt](https://www.nvidia.com/Download/driverResults.aspx/141700/en-us)

Fixes kernel 4.20 issues.