### PR TITLE
rpi: switch to zstd squashfs images

### DIFF
--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -52,7 +52,7 @@
     PROJECT_CFLAGS=""
 
   # SquashFS compression method (gzip / lzo / xz / zstd)
-    SQUASHFS_COMPRESSION="gzip"
+    SQUASHFS_COMPRESSION="zstd"
 
 
 ################################################################################

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -68,7 +68,7 @@
     PROJECT_CFLAGS=""
 
   # SquashFS compression method (gzip / lzo / xz / zstd)
-    SQUASHFS_COMPRESSION="lzo"
+    SQUASHFS_COMPRESSION="zstd"
 
 ################################################################################
 # setup project defaults

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -19,8 +19,8 @@
   # Project CFLAGS
     PROJECT_CFLAGS=""
 
-  # SquashFS compression method (gzip / lzo / xz)
-    SQUASHFS_COMPRESSION="lzo"
+  # SquashFS compression method (gzip / lzo / xz / zstd)
+    SQUASHFS_COMPRESSION="zstd"
 
 ################################################################################
 # setup project defaults

--- a/scripts/image
+++ b/scripts/image
@@ -226,7 +226,7 @@ if [ -z "$SQUASHFS_COMPRESSION_OPTION" ]; then
   elif [ "$SQUASHFS_COMPRESSION" = "lzo" ]; then
     SQUASHFS_COMPRESSION_OPTION="-Xcompression-level 9 -b 524288"
   elif [ "$SQUASHFS_COMPRESSION" = "zstd" ]; then
-    SQUASHFS_COMPRESSION_OPTION="-Xcompression-level 22 -b 262144"
+    SQUASHFS_COMPRESSION_OPTION="-Xcompression-level 22 -b 1048576"
   fi
 fi
 


### PR DESCRIPTION
For LE10.

Switch generic too? I'm not sure a user will notice but it should save bandwidth/storage on LE's end.

Benchmarks available here: https://github.com/LibreELEC/LibreELEC.tv/pull/3209