### PR TITLE
update.sh (Amlogic): fix source path for copy dtb files

### DIFF
--- a/projects/Amlogic/bootloader/update.sh
+++ b/projects/Amlogic/bootloader/update.sh
@@ -89,7 +89,7 @@ done
 
 if [ -d $BOOT_ROOT/device_trees ]; then
   rm $BOOT_ROOT/device_trees/*.dtb
-  cp -p $SYSTEM_ROOT/usr/share/bootloader/*.dtb $BOOT_ROOT/device_trees/
+  cp -p $SYSTEM_ROOT/usr/share/bootloader/device_trees/*.dtb $BOOT_ROOT/device_trees/
 fi
 
 if [ -f $SYSTEM_ROOT/usr/share/bootloader/boot.ini ]; then


### PR DESCRIPTION
The copy of dtb had the wrong source path.

Tested on a Xoro 260 HST DVB-T2/C with S905D