### PR TITLE
qca9377-firmware-aml: update to 5e4b712, now with BT firmware

### DIFF
--- a/packages/linux-firmware/amlogic/qca9377-firmware-aml/package.mk
+++ b/packages/linux-firmware/amlogic/qca9377-firmware-aml/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qca9377-firmware-aml"
-PKG_VERSION="1.0.0-3"
-PKG_SHA256="9a9f214943e77e89ce8fc8c0dc5b41bc253478a9d92383a76590993df861f36d"
+PKG_VERSION="5e4b71211ecbb79e7693d2ee07361847f5a0cb40"
+PKG_SHA256="366bd14df08b4c31a653ce3e0d586854ba1e510dcab0487454e0d30bdc6ca56f"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3c"
-PKG_SITE="http://linode.boundarydevices.com/repos/apt/ubuntu-relx/pool/main/q/qca-firmware/"
-PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_SITE="https://github.com/boundarydevices/qca-firmware"
+PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="qca9377 Linux firmware"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
The service qca9377-firmware-aml.service was complaining about missing BT firmware on a Xoro HST 260 S905X and Xoro HST 260 DVB-T2/C S905D and i use my Harmony with BT on all my devices.

Patch tested on both devices.

before:
systemctl status qca9377-firmware-aml.service
? qca9377-firmware-aml.service - QCA Bluetooth firmware service
   Loaded: loaded (/usr/lib/systemd/system/qca9377-firmware-aml.service; static; vendor preset: disabled)
   Active: failed (Result: exit-code) since Thu 2015-01-01 01:00:26 CET; 4 years 0 months ago
  Process: 2970 ExecStart=/usr/bin/hciattach -n -s 115200 /dev/ttyS1 qca 2000000 (code=exited, status=1/FAILURE)
 Main PID: 2970 (code=exited, status=1/FAILURE)

Jan 01 01:00:19 kodi07 systemd[1]: Started QCA Bluetooth firmware service.
Jan 01 01:00:19 kodi07 hciattach[2970]: qca_soc_init: Rome Version (0x03020023)
Jan 01 01:00:23 kodi07 hciattach[2970]: read_vs_hci_event: Not an HCI-VS-Event! buf[0]: 255/lib/firmware/qca/tfbtnv11.bin File Open Fail
Jan 01 01:00:26 kodi07 systemd[1]: qca9377-firmware-aml.service: Main process exited, code=exited, status=1/FAILURE
Jan 01 01:00:26 kodi07 systemd[1]: qca9377-firmware-aml.service: Failed with result 'exit-code'.


and after:
systemctl status qca9377-firmware-aml.service
● qca9377-firmware-aml.service - QCA Bluetooth firmware service
   Loaded: loaded (/usr/lib/systemd/system/qca9377-firmware-aml.service; static; vendor preset: disabled)
   Active: active (running) since Thu 2015-01-01 01:00:20 CET; 4 years 0 months ago
 Main PID: 3076 (hciattach)
   Memory: 444.0K
   CGroup: /system.slice/qca9377-firmware-aml.service
           └─3076 /usr/bin/hciattach -n -s 115200 /dev/ttyS1 qca 2000000

Jan 01 01:00:20 kodi07 systemd[1]: Started QCA Bluetooth firmware service.
Jan 01 01:00:20 kodi07 hciattach[3076]: qca_soc_init: Rome Version (0x03020023)
Jan 01 01:00:23 kodi07 hciattach[3076]: read_vs_hci_event: Not an HCI-VS-Event! buf[0]: 255Failed to open /etc/bluetooth/firmware.conf
Jan 01 01:00:23 kodi07 hciattach[3076]: Ignoring invalid deep sleep config value
Jan 01 01:00:23 kodi07 hciattach[3076]: Failed to open /etc/bluetooth/firmware.conf
