### PR TITLE
alsa: update 1.1.8

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-plugins"
-PKG_VERSION="1.1.7"
-PKG_SHA256="a74b405ab6d9e346e6908a853d5e7631cc61038d9b265bc7f37fab16e827da47"
+PKG_VERSION="1.1.8"
+PKG_SHA256="7f77df171685ccec918268477623a39db4d9f32d5dc5e76874ef2467a2405994"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/plugins/$PKG_NAME-$PKG_VERSION.tar.bz2"

--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-lib"
-PKG_VERSION="1.1.7"
-PKG_SHA256="9d6000b882a3b2df56300521225d69717be6741b71269e488bb20a20783bdc09"
+PKG_VERSION="1.1.8"
+PKG_SHA256="3cdc3a93a6427a26d8efab4ada2152e64dd89140d981f6ffa003e85be707aedf"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/lib/alsa-lib-$PKG_VERSION.tar.bz2"

--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-utils"
-PKG_VERSION="1.1.7"
-PKG_SHA256="1db27fb54ab7fdeb54b00d68b8a174808ffea198cfbd67e3c959482194e1540a"
+PKG_VERSION="1.1.8"
+PKG_SHA256="fd9bf528922b3829a91913b89a1858c58a0b24271a7b5f529923aa9ea12fa4cf"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/utils/alsa-utils-$PKG_VERSION.tar.bz2"

--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -30,7 +30,7 @@ post_makeinstall_target() {
 # so we avoid resetting our soundconfig
   rm -rf $INSTALL/usr/lib/udev/rules.d/90-alsa-restore.rules
 
-  for i in aconnect alsamixer alsaucm amidi aplaymidi arecord arecordmidi aseqdump aseqnet iecset; do
+  for i in aconnect alsamixer amidi aplaymidi arecord arecordmidi aseqdump aseqnet iecset; do
     rm -rf $INSTALL/usr/bin/$i
   done
 


### PR DESCRIPTION
Update alsa-lib, alsa-plugins and alsa-utils to 1.1.8

With the fixes in alsa-lib alsaucm is now working and we can ship it as well.

alsaucm is a ~10k binary needed to configure audio routing on Intel Baytrail and various other boards.

Build and runtime tested on RPi2