### PR TITLE
docker: updated to 18.09.1

### DIFF
--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="c4446665cb9c30056f4998ed953e6d4ff22c7c39" # v1.2.0
-PKG_SHA256="0bd3370f769c25f077445b77266a0afba6fe60b9caa443153e604d8727f2a891"
+PKG_VERSION="1.2.2"
+PKG_SHA256="91d480816986d74ff4fa7dd0412c787615fa705975b18fa4079c333b137c653f"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.tools/"
-PKG_URL="https://github.com/containerd/containerd/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/containerd/containerd/archive/v$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain go:host"
 PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
@@ -38,9 +38,8 @@ pre_make_target() {
   export CGO_ENABLED=1
   export CGO_NO_EMULATION=1
   export CGO_CFLAGS=$CFLAGS
-  # Update CONTAINERD_VERSION if you update the PKG_VERSION
-  export CONTAINERD_VERSION=v1.2.0
-  export CONTAINERD_REVISION=$PKG_VERSION
+  export CONTAINERD_VERSION=v${PKG_VERSION}
+  export CONTAINERD_REVISION=${PKG_VERSION}
   export CONTAINERD_PKG=github.com/containerd/containerd
   export LDFLAGS="-w -extldflags -static -X ${CONTAINERD_PKG}/version.Version=${CONTAINERD_VERSION} -X ${CONTAINERD_PKG}/version.Revision=${CONTAINERD_REVISION} -X ${CONTAINERD_PKG}/version.Package=${CONTAINERD_PKG} -extld $CC"
   export GOLANG=$TOOLCHAIN/lib/golang/bin/go

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.10.5"
-PKG_SHA256="afe38b3c6a91e7e6c2bae0cf7427d1080ed3b7d8c044504400db56c3b72bb082"
+PKG_VERSION="1.11.2"
+PKG_SHA256="7854866866c57394217ae5facc41944dff2a7386a064b2bcc4149f7c68e3c79a"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/libnetwork/package.mk
+++ b/packages/addons/addon-depends/libnetwork/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnetwork"
-PKG_VERSION="3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b"
-PKG_SHA256="572ce85f2c51a21c1cd55056cf8cb9ef1d447c2de9c82485233be9f851284299"
+PKG_VERSION="2cfbf9b1f98162a55829a21cc603c76072a75382"
+PKG_SHA256="12986c29a112f989886ceec675f5b11ccd001dcdb1c17a49835970c56aa406d0"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/docker/libnetwork"
 PKG_URL="https://github.com/docker/libnetwork/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="69663f0bd4b60df09991c08812a60108003fa340"
-PKG_SHA256="994a3a0447fcbf7e37614b02aa5604d2d6b9fdb41e6870d8d3ff1138ed6e61ef"
+PKG_VERSION="96ec2177ae841256168fcf76954f7177af9446eb"
+PKG_SHA256="96040a78008abad13b412863813011f4cbe55407e513acad1d8509f4ab9b39cd"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,15 @@
+122
+- Update to docker 18.09.1
+
+121
+- Update to docker 18.09.1-rc1
+
+120
+- Update to docker 18.09.1-beta1
+
+119
+- Update to docker 18.09.0
+
 118
 - Update to docker 18.06.1-ce
 

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,14 +3,14 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_VERSION="18.06.1"
-PKG_SHA256="153cb489033686260dfe7a42acbdd1753d56f7a9c2d7ad90633f0c8cce563b23"
-PKG_REV="119"
+PKG_VERSION="18.09.1"
+PKG_SHA256="9eadb1eae1954b0322aadf6505f5397d1b1eccf6395ab511cadf8e6975cfc576"
+PKG_REV="122"
 PKG_ARCH="any"
 PKG_ADDON_PROJECTS="any !WeTek_Core !WeTek_Play"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"
-PKG_URL="https://github.com/docker/docker-ce/archive/v${PKG_VERSION}-ce.tar.gz"
+PKG_URL="https://github.com/docker/docker-ce/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain sqlite go:host containerd runc libnetwork tini systemd"
 PKG_SECTION="service/system"
 PKG_SHORTDESC="Docker is an open-source engine that automates the deployment of any application as a lightweight, portable, self-sufficient container that will run virtually anywhere."
@@ -74,7 +74,23 @@ configure_target() {
     mv $PKG_CLI_PATH/vendor $PKG_BUILD/.gopath_cli/src
   fi
 
-  cp -rf $PKG_BUILD/.gopath/src/* $PKG_BUILD/.gopath_cli/src
+  # Fix missing/incompatible .go files
+  cp -rf $PKG_BUILD/.gopath/src/github.com/moby/buildkit/frontend/* $PKG_BUILD/.gopath_cli/src/github.com/moby/buildkit/frontend
+  cp -rf $PKG_BUILD/.gopath/src/github.com/moby/buildkit/frontend/gateway/* $PKG_BUILD/.gopath_cli/src/github.com/moby/buildkit/frontend/gateway
+  cp -rf $PKG_BUILD/.gopath/src/github.com/moby/buildkit/solver/* $PKG_BUILD/.gopath_cli/src/github.com/moby/buildkit/solver
+  cp -rf $PKG_BUILD/.gopath/src/github.com/moby/buildkit/util/progress/* $PKG_BUILD/.gopath_cli/src/github.com/moby/buildkit/util/progress
+  cp -rf $PKG_BUILD/.gopath/src/github.com/docker/swarmkit/manager/* $PKG_BUILD/.gopath_cli/src/github.com/docker/swarmkit/manager
+  cp -rf $PKG_BUILD/.gopath/src/github.com/coreos/etcd/raft/* $PKG_BUILD/.gopath_cli/src/github.com/coreos/etcd/raft
+  cp -rf $PKG_BUILD/.gopath/src/golang.org/x/* $PKG_BUILD/.gopath_cli/src/golang.org/x
+  cp -rf $PKG_BUILD/.gopath/src/github.com/opencontainers/runtime-spec/specs-go/* $PKG_BUILD/.gopath_cli/src/github.com/opencontainers/runtime-spec/specs-go
+
+  rm -rf $PKG_BUILD/.gopath_cli/src/github.com/containerd/containerd
+  mkdir -p $PKG_BUILD/.gopath_cli/src/github.com/containerd/containerd
+  cp -rf $PKG_BUILD/.gopath/src/github.com/containerd/containerd/* $PKG_BUILD/.gopath_cli/src/github.com/containerd/containerd
+
+  rm -rf $PKG_BUILD/.gopath_cli/src/github.com/containerd/continuity
+  mkdir -p $PKG_BUILD/.gopath_cli/src/github.com/containerd/continuity
+  cp -rf $PKG_BUILD/.gopath/src/github.com/containerd/continuity/* $PKG_BUILD/.gopath_cli/src/github.com/containerd/continuity
 
   mkdir -p $PKG_BUILD/.gopath_cli/src/github.com/docker/docker/builder
   cp -rf $PKG_ENGINE_PATH/builder/* $PKG_BUILD/.gopath_cli/src/github.com/docker/docker/builder
@@ -88,8 +104,8 @@ configure_target() {
   fi
 
   # used for docker version
-  export GITCOMMIT=${PKG_VERSION}-ce
-  export VERSION=${PKG_VERSION}-ce
+  export GITCOMMIT=${PKG_VERSION}
+  export VERSION=${PKG_VERSION}
   export BUILDTIME="$(date --utc)"
 
   cd $PKG_ENGINE_PATH
@@ -116,14 +132,14 @@ addon() {
     cp -P $PKG_BUILD/bin/dockerd $ADDON_BUILD/$PKG_ADDON_ID/bin
 
     # containerd
-    cp -P $(get_build_dir containerd)/bin/containerd $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-containerd
-    cp -P $(get_build_dir containerd)/bin/containerd-shim $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-containerd-shim
+    cp -P $(get_build_dir containerd)/bin/containerd $ADDON_BUILD/$PKG_ADDON_ID/bin/containerd
+    cp -P $(get_build_dir containerd)/bin/containerd-shim $ADDON_BUILD/$PKG_ADDON_ID/bin/containerd-shim
 
     # libnetwork
     cp -P $(get_build_dir libnetwork)/bin/docker-proxy $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-proxy
 
     # runc
-    cp -P $(get_build_dir runc)/bin/runc $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-runc
+    cp -P $(get_build_dir runc)/bin/runc $ADDON_BUILD/$PKG_ADDON_ID/bin/runc
 
     # tini
     cp -P $(get_build_dir tini)/.$TARGET_NAME/tini-static $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-init


### PR DESCRIPTION
Updated Docker & it's dependencies to the latest stable release [18.09.1](https://github.com/docker/docker-ce/releases/tag/v18.09.1)

Compiled & tested on Generic systems to run PCSX2.