### PR TITLE
Linux: fix DVBSky S960 bug

### DIFF
--- a/packages/linux/patches/default/linux-999.03-dvbskys960-fix.patch
+++ b/packages/linux/patches/default/linux-999.03-dvbskys960-fix.patch
@@ -1,0 +1,39 @@
+From: jahutchi
+Date: Fri, 11 Jan 2019 13:35:00 +0000
+Subject: [PATCH] media: m88ds3103: serialize reset messages in m88ds3103_set_frontend
+
+Ref:
+https://bugzilla.kernel.org/show_bug.cgi?id=199323
+https://forum.libreelec.tv/thread/12452-problems-with-dvbsky-technotrend-usb-dvb-s2-tuners-since-le8/
+
+DVBSky S960/S960C are partly broken since linux kernel commit (4.10rc1)
+https://github.com/torvalds/linux/commit/9d659ae14b545c4296e812c70493bfdc999b5c1c
+
+diff --git a/drivers/media/dvb-frontends/m88ds3103.c b/drivers/media/dvb-frontends/m88ds3103.c
+index dffd2d4bf1..e495a26e6e 100644
+--- a/drivers/media/dvb-frontends/m88ds3103.c
++++ b/drivers/media/dvb-frontends/m88ds3103.c
+@@ -309,6 +309,7 @@ static int m88ds3103_set_frontend(struct dvb_frontend *fe)
+ 	u16 u16tmp;
+ 	u32 tuner_frequency_khz, target_mclk;
+ 	s32 s32tmp;
++	static const struct reg_sequence reset_buf[] = {{0x07, 0x80}, {0x07, 0x00}};
+ 
+ 	dev_dbg(&client->dev,
+ 		"delivery_system=%d modulation=%d frequency=%u symbol_rate=%d inversion=%d pilot=%d rolloff=%d\n",
+@@ -321,11 +322,7 @@ static int m88ds3103_set_frontend(struct dvb_frontend *fe)
+ 	}
+ 
+ 	/* reset */
+-	ret = regmap_write(dev->regmap, 0x07, 0x80);
+-	if (ret)
+-		goto err;
+-
+-	ret = regmap_write(dev->regmap, 0x07, 0x00);
++	ret = regmap_multi_reg_write(dev->regmap, reset_buf, 2);
+ 	if (ret)
+ 		goto err;
+ 
+-- 
+2.7.4
+

--- a/packages/linux/patches/raspberrypi/linux-999.03-dvbskys960-fix.patch
+++ b/packages/linux/patches/raspberrypi/linux-999.03-dvbskys960-fix.patch
@@ -1,0 +1,39 @@
+From: jahutchi
+Date: Fri, 11 Jan 2019 13:35:00 +0000
+Subject: [PATCH] media: m88ds3103: serialize reset messages in m88ds3103_set_frontend
+
+Ref:
+https://bugzilla.kernel.org/show_bug.cgi?id=199323
+https://forum.libreelec.tv/thread/12452-problems-with-dvbsky-technotrend-usb-dvb-s2-tuners-since-le8/
+
+DVBSky S960/S960C are partly broken since linux kernel commit (4.10rc1)
+https://github.com/torvalds/linux/commit/9d659ae14b545c4296e812c70493bfdc999b5c1c
+
+diff --git a/drivers/media/dvb-frontends/m88ds3103.c b/drivers/media/dvb-frontends/m88ds3103.c
+index dffd2d4bf1..e495a26e6e 100644
+--- a/drivers/media/dvb-frontends/m88ds3103.c
++++ b/drivers/media/dvb-frontends/m88ds3103.c
+@@ -309,6 +309,7 @@ static int m88ds3103_set_frontend(struct dvb_frontend *fe)
+ 	u16 u16tmp;
+ 	u32 tuner_frequency_khz, target_mclk;
+ 	s32 s32tmp;
++	static const struct reg_sequence reset_buf[] = {{0x07, 0x80}, {0x07, 0x00}};
+ 
+ 	dev_dbg(&client->dev,
+ 		"delivery_system=%d modulation=%d frequency=%u symbol_rate=%d inversion=%d pilot=%d rolloff=%d\n",
+@@ -321,11 +322,7 @@ static int m88ds3103_set_frontend(struct dvb_frontend *fe)
+ 	}
+ 
+ 	/* reset */
+-	ret = regmap_write(dev->regmap, 0x07, 0x80);
+-	if (ret)
+-		goto err;
+-
+-	ret = regmap_write(dev->regmap, 0x07, 0x00);
++	ret = regmap_multi_reg_write(dev->regmap, reset_buf, 2);
+ 	if (ret)
+ 		goto err;
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
That bug made the S960 (VERY popular device) basically useless for proper usage since Kernel 4.10. 
Tx to https://forum.libreelec.tv/thread/12452-problems-with-dvbsky-technotrend-usb-dvb-s2-tuners-since-le8/?postID=107702#post107702 who fixed it.

Patch goes upstream "soon" so we could expect an backport to the LTS kernel at some date.