### PR TITLE
buildsystem: be more cautious when overwriting package cache files

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -478,33 +478,46 @@ debug_strip() {
 
 init_package_cache() {
   local _ANCHOR="@?+?@" DIR
+  local temp_global temp_local
 
   # If the package caches are unset, then populate them
   if [ -z "${_CACHE_PACKAGE_LOCAL}" -o -z "${_CACHE_PACKAGE_GLOBAL}" ]; then
-    _CACHE_PACKAGE_LOCAL="${BUILD}/.cache_package_local"
-    _CACHE_PACKAGE_GLOBAL="${BUILD}/.cache_package_global"
-    mkdir -p "${BUILD}"
-    : > "${_CACHE_PACKAGE_LOCAL}"
-    : > "${_CACHE_PACKAGE_GLOBAL}"
+    temp_global="$(mktemp)"
+    temp_local="$(mktemp)"
 
     # cache project/device folder for a package
     if [ -n $DEVICE ]; then
       for DIR in $(find $ROOT/projects/$PROJECT/devices/$DEVICE/packages -type d 2>/dev/null); do
-        [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${_CACHE_PACKAGE_LOCAL}"
+        [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${temp_local}"
       done
     fi
 
     # cache project folder for a package
     for DIR in $(find $ROOT/projects/$PROJECT/packages -type d 2>/dev/null); do
-      [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${_CACHE_PACKAGE_LOCAL}"
+      [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${temp_local}"
     done
 
     # cache packages folder
     for DIR in $(find $ROOT/$PACKAGES -type d 2>/dev/null); do
-      [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${_CACHE_PACKAGE_GLOBAL}"
+      [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${temp_global}"
     done
 
+    _CACHE_PACKAGE_LOCAL="${BUILD}/.cache_package_local"
+    _CACHE_PACKAGE_GLOBAL="${BUILD}/.cache_package_global"
     export _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL
+
+    # overwrite existing cache files only when they are invalid, or not yet created
+    mkdir -p "$(dirname "${_CACHE_PACKAGE_GLOBAL}")"
+    if [ -f "${_CACHE_PACKAGE_LOCAL}" ] && cmp -s "${temp_local}" "${_CACHE_PACKAGE_LOCAL}"; then
+      rm "${temp_local}"
+    else
+      mv "${temp_local}" "${_CACHE_PACKAGE_LOCAL}"
+    fi
+    if [ -f "${_CACHE_PACKAGE_GLOBAL}" ] && cmp -s "${temp_global}" "${_CACHE_PACKAGE_GLOBAL}"; then
+      rm "${temp_global}"
+    else
+      mv "${temp_global}" "${_CACHE_PACKAGE_GLOBAL}"
+    fi
   fi
 }
 


### PR DESCRIPTION
Sourcing `config/options` is not safe during a build. This hasn't always been the case, and I would argue (hence this PR) that it should generally be safe to source `config/options` at pretty much any time.

The problem now exists because the pacakge cache files are always generated by each new process that sources `config/options`. If a build process is ongoing then another process may result in corrupted cache files if the build process queries the cache files at the precise moment they are being regenerated by the second process. A corrupted cache file will result in errors such as `initramfs/package.mk does not exist`.

This change introduces a little more caution and we will now only update the cache files if they have changed (which would mean a new package has been introduced, or an existing package removed). This is _highly_ unlikely to happen during a build, and if it were to happen then the build should be restarted (in which case failing would have been a good thing).