### PR TITLE
openssl: tamper CRYPTO_set_locking_callback() for kodi

### DIFF
--- a/packages/security/openssl/patches/openssl-0002-lock_callback.patch
+++ b/packages/security/openssl/patches/openssl-0002-lock_callback.patch
@@ -1,0 +1,12 @@
+--- a/crypto/cryptlib.c	2018-11-20 14:44:49.000000000 +0100
++++ b/crypto/cryptlib.c	2019-01-12 14:04:56.000000000 +0100
+@@ -405,6 +405,9 @@ int (*CRYPTO_get_add_lock_callback(void)
+ void CRYPTO_set_locking_callback(void (*func) (int mode, int type,
+                                                const char *file, int line))
+ {
++    /* work around error kodi plugins overwriting kodi */
++    if (func && locking_callback)
++        return;
+     /*
+      * Calling this here ensures initialisation before any threads are
+      * started.


### PR DESCRIPTION
Enabling vfs.sftp result in kodi crashing at exit in openssl's libcrypto: http://ix.io/1ylh

Kodi is using deprecated CRYPTO_set_id_callback(). vfs.sftp call CRYPTO_THREADID_set_callback() later in start up getting precedence over the kodi callback function. After vfs.sftp memory was freed at
exit the callback crash.

As a note: python is using CRYPTO_THREADID_set_callback() too, but this does not result in a traceable error. On the other hand the change let another issue disappear: Generic is not crashing any more at exit when debug logging is enabled (ping @MilhouseVH).

The kodi patch activate CRYPTO_set_id_callback() use for openssl 1.0.x. This APi prevent later components from overtaking. This is now fixed with kodi \#15301 (see below).

There is a similar behavior for CRYPTO_set_locking_callback() although without visible effect. The openssl patch is hardening the call.

A real solution will be updating openssl to 1.1.x dropping all the callbacks.
