### PR TITLE
oem: depends on PROJECT package conditionally

### DIFF
--- a/packages/oem/package.mk
+++ b/packages/oem/package.mk
@@ -6,6 +6,9 @@ PKG_VERSION=""
 PKG_LICENSE="various"
 PKG_SITE="http://www.libreelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain $PROJECT"
+PKG_DEPENDS_TARGET="toolchain"
+if [ -f $(get_pkg_directory $PROJECT)/package.mk ]; then
+  PKG_DEPENDS_TARGET+=" $PROJECT"
+fi
 PKG_SECTION="virtual"
 PKG_LONGDESC="OEM: Metapackage for various OEM packages"


### PR DESCRIPTION
If package for specific project doesn't exist still allow using OEM.