### PR TITLE
tcpdump: properly reorder build step

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
@@ -19,7 +19,7 @@ pre_configure_target() {
   LDFLAGS+=" -ltirpc"
 }
 
-pre_build_target() {
+post_configure_target() {
   # discard native system includes
   sed -i "s%-I/usr/include%%g" Makefile
 }


### PR DESCRIPTION
For some reason, sed tried to fix Makefile before it existed. Even stranger, that even worked in some cases.