### PR TITLE
Rockchip: use correct rk3328 bootloader bl31 filename

### DIFF
--- a/projects/Rockchip/bootloader/install
+++ b/projects/Rockchip/bootloader/install
@@ -21,7 +21,7 @@ case "$PKG_SOC" in
   rk3328)
     PKG_DATAFILE="$PKG_RKBIN/rk33/rk3328_ddr_786MHz_v1.13.bin"
     PKG_LOADER="$PKG_RKBIN/rk33/rk3328_miniloader_v2.49.bin"
-    PKG_BL31="$PKG_RKBIN/rk33/rk3328_bl31_v1.40.bin"
+    PKG_BL31="$PKG_RKBIN/rk33/rk3328_bl31_v1.40.elf"
     PKG_LOAD_ADDR="0x200000"
     ;;
   rk3399)


### PR DESCRIPTION
This PR makes RK3328 images boot again after #3239