### PR TITLE
Stop build when kernel_make fails

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -967,7 +967,7 @@ kernel_make() {
     HOSTLDFLAGS="$HOST_LDFLAGS" \
     HOSTCXXFLAGS="$HOST_CXXFLAGS" \
     DEPMOD="$TOOLCHAIN/bin/depmod" \
-    "$@"
+    "$@" || die "$(print_color CLR_ERROR "ERROR: kernel_make for ${PKG_NAME} did not succeed!")"
 }
 
 # get kernel module dir

--- a/projects/Rockchip/bootloader/install
+++ b/projects/Rockchip/bootloader/install
@@ -39,12 +39,12 @@ esac
 if [ -n "$PKG_DATAFILE" -a -n "$PKG_LOADER" ]; then
   tools/mkimage -n $PKG_SOC -T rksd -d "$PKG_DATAFILE" idbloader.img
   cat "$PKG_LOADER" >> idbloader.img
-  cp -av idbloader.img $INSTALL/usr/share/bootloader
+  cp -av idbloader.img $INSTALL/usr/share/bootloader || die "$(print_color CLR_ERROR "ERROR: idbloader.img could not be copied")"
 fi
 
 if [ -n "$PKG_LOAD_ADDR" ]; then
   $PKG_RKBIN/tools/loaderimage --pack --uboot u-boot-dtb.bin uboot.img $PKG_LOAD_ADDR
-  cp -av uboot.img $INSTALL/usr/share/bootloader
+  cp -av uboot.img $INSTALL/usr/share/bootloader || die "$(print_color CLR_ERROR "ERROR: uboot.img could not be copied")"
 fi
 
 if [ -n "$PKG_BL31" ]; then
@@ -63,5 +63,5 @@ SEC=0
 PATH=trust.img
 EOF
   $PKG_RKBIN/tools/trust_merger --verbose trust.ini
-  cp -av trust.img $INSTALL/usr/share/bootloader
+  cp -av trust.img $INSTALL/usr/share/bootloader || die "$(print_color CLR_ERROR "ERROR: trust.img could not be copied")"
 fi


### PR DESCRIPTION
This PR makes `linux` package stop the build if there is a compilation error or when `u-boot` package fails to copy bootloader files.

Due to some change in the buildsystem packages no longer fails on the first failed command and instead only fail when the last command fails inside package configure/make/install functions.

In the `linux` package there is multiple calls to `kernel_make` in the `make_target` function that may fail when there is a broken patch (code or dts changes that fails to build), workaround this and stop build when `kernel_make` fails.

This also includes a similar workaround for the Rockchip bootloader install script, it will now fail when generating `idbloader.img`, `uboot.img` or `trust.img` fails.

ping @MilhouseVH