### PR TITLE
buildsystem: restore set -e behaviour after #3136

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -805,22 +805,18 @@ find_dir_path() {
   find_path -d "$1" "$2"
 }
 
-# p1: name of potential function to execute if it exists
-# return 0 if function executed, 1 if not, die if error
+# p1: name of function to test for
+# return 0 if function exists, 1 if not
+pkg_call_exists() {
+  [ "$(type -t ${1})" = "function" ] && return 0 || return 1
+}
+
+# p1: name of function to execute unconditionally
+# testing the exit code value of this function is likely to break set -e fail-on-error behaviour
 pkg_call() {
   [ -n "${PKG_NAME}" ] || die "$(print_color CLR_ERROR "FAILURE: Cannot call ${1} package function when package is not known!")"
 
-  if [ "$(type -t ${1})" = "function" ]; then
-    ${1} || die "$(print_color CLR_ERROR "FAILURE: ${1} for package ${PKG_NAME} did not succeed!")"
-  else
-    return 1
-  fi
-}
-
-# p1: name of potential function to execute if it exists
-# return 0 if function executed or not, or die if error
-pkg_call_optional() {
-  pkg_call ${1} || return 0
+  ${1}
 }
 
 unset_functions() {
@@ -922,7 +918,11 @@ source_package() {
   # Late variable binding - allow the package to now evaluate any variables
   # that we may have initialised after sourcing the package, typically
   # PKG_BUILD etc.
-  [ -n "${PKG_NAME}" ] && pkg_call_optional configure_package || true
+  if [ -n "${PKG_NAME}" ]; then
+    if pkg_call_exists configure_package; then
+      pkg_call configure_package
+    fi
+  fi
 }
 
 

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -206,7 +206,7 @@ make_target() {
   ( cd $ROOT
     rm -rf $BUILD/initramfs
     $SCRIPTS/install initramfs
-  ) || die "FAILURE: Building initramfs"
+  )
 
   if [ "$BOOTLOADER" = "u-boot" -a -n "$KERNEL_UBOOT_EXTRA_TARGET" ]; then
     for extra_target in "$KERNEL_UBOOT_EXTRA_TARGET"; do

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -85,7 +85,9 @@ configure_package() {
 
   PKG_SAMBA_TARGET="smbclient,client/smbclient,smbtree,testparm"
 
-  [ "$SAMBA_SERVER" = "yes" ] && PKG_SAMBA_TARGET+=",smbd/smbd,nmbd,smbpasswd"
+  if [ "$SAMBA_SERVER" = "yes" ]; then
+    PKG_SAMBA_TARGET+=",smbd/smbd,nmbd,smbpasswd"
+  fi
 }
 
 pre_configure_target() {

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -48,7 +48,7 @@ pre_configure_target() {
 }
 
 pre_configure_init() {
-  pkg_call pre_configure_target || die "pre_configure_target not found"
+  pkg_call pre_configure_target
 
   PKG_CONFIGURE_OPTS_INIT="$PKG_CONFIGURE_OPTS_TARGET"
 }

--- a/scripts/build
+++ b/scripts/build
@@ -205,7 +205,7 @@ if [ "$PKG_TOOLCHAIN" = "autotools" ]; then
 fi
 
 # include build template and build
-pkg_call_optional pre_build_$TARGET
+pkg_call_exists pre_build_$TARGET && pkg_call pre_build_$TARGET
 
 # ensure $PKG_BUILD is there. (installer? PKG_URL="")
 if [ ! -d "$PKG_BUILD" ] ; then
@@ -228,9 +228,11 @@ if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" -o -f "$PKG_MESON_SCRI
 fi
 
 # configure
-pkg_call_optional pre_configure_$TARGET
+pkg_call_exists pre_configure_$TARGET && pkg_call pre_configure_$TARGET
 
-if ! pkg_call configure_$TARGET; then
+if pkg_call_exists configure_$TARGET; then
+  pkg_call configure_$TARGET
+else
   case "$PKG_TOOLCHAIN:$TARGET" in
     # meson builds
     "meson:target")
@@ -310,12 +312,14 @@ if ! pkg_call configure_$TARGET; then
   esac
 fi
 
-pkg_call_optional post_configure_$TARGET
+pkg_call_exists post_configure_$TARGET && pkg_call post_configure_$TARGET
 
 # make
-pkg_call_optional pre_make_$TARGET
+pkg_call_exists pre_make_$TARGET && pkg_call pre_make_$TARGET
 
-if ! pkg_call make_$TARGET; then
+if pkg_call_exists make_$TARGET; then
+  pkg_call make_$TARGET
+else
   case "$PKG_TOOLCHAIN:$TARGET" in
     # ninja based builds
     "meson:target"|"cmake:target"|"ninja:target")
@@ -355,12 +359,14 @@ if ! pkg_call make_$TARGET; then
   esac
 fi
 
-pkg_call_optional post_make_$TARGET
+pkg_call_exists post_make_$TARGET && pkg_call post_make_$TARGET
 
 # make install
-pkg_call_optional pre_makeinstall_$TARGET
+pkg_call_exists pre_makeinstall_$TARGET && pkg_call pre_makeinstall_$TARGET
 
-if ! pkg_call makeinstall_$TARGET; then
+if pkg_call_exists makeinstall_$TARGET; then
+  pkg_call makeinstall_$TARGET
+else
   case "$PKG_TOOLCHAIN:$TARGET" in
     # ninja based builds
     "meson:target"|"cmake:target")
@@ -394,7 +400,7 @@ if ! pkg_call makeinstall_$TARGET; then
   esac
 fi
 
-pkg_call_optional post_makeinstall_$TARGET
+pkg_call_exists post_makeinstall_$TARGET && pkg_call post_makeinstall_$TARGET
 
 if [ "$TARGET" = "target" -o "$TARGET" = "init" ]; then
   if [ -d $INSTALL ]; then

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -208,7 +208,9 @@ build_addon() {
   rm -rf $ADDON_BUILD
 
   # install addon parts
-  if ! pkg_call addon; then
+  if pkg_call_exists addon; then
+    pkg_call addon
+  else
     install_binary_addon $PKG_ADDON_ID
   fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -123,7 +123,7 @@ fi
 
 # install
 if [ "$TARGET" = target ] ; then
-  pkg_call_optional pre_install
+  pkg_call_exists pre_install && pkg_call pre_install
 fi
 
 if [ "$TARGET" = "target" -a -d $PKG_BUILD/.install_pkg ]; then
@@ -133,7 +133,7 @@ elif [ "$TARGET" = "init" -a -d $PKG_BUILD/.install_init ]; then
 fi
 
 if [ "$TARGET" = target ] ; then
-  pkg_call_optional post_install
+  pkg_call_exists post_install && pkg_call post_install
 fi
 
 touch $STAMP

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -44,9 +44,11 @@ fi
 if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
   build_msg "CLR_UNPACK" "UNPACK" "${1}" "indent"
 
-  pkg_call_optional pre_unpack
+  pkg_call_exists pre_unpack && pkg_call pre_unpack
 
-  if ! pkg_call unpack; then
+  if pkg_call_exists unpack; then
+    pkg_call unpack
+  else
     if [ -n "$PKG_URL" ]; then
       $SCRIPTS/extract $1 $BUILD
     fi
@@ -69,10 +71,10 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
     mkdir -p "${PKG_BUILD}"
   fi
 
-  pkg_call_optional post_unpack
+  pkg_call_exists post_unpack && pkg_call post_unpack
 
   if [ "${PKG_SKIP_PATCHES}" != "yes" ]; then
-    pkg_call_optional pre_patch
+    pkg_call_exists pre_patch && pkg_call pre_patch
 
     if [ "$TARGET_ARCH" = "x86_64" ]; then
       PATCH_ARCH="x86"
@@ -141,7 +143,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
       fi
     done
 
-    pkg_call_optional post_patch
+    pkg_call_exists post_patch && pkg_call post_patch
   fi
 
   if [ ! "$PKG_NAME" = "configtools" ] ; then


### PR DESCRIPTION
This restores the `set -e` (exit on failure) behaviour that is broken by #3136. This should also make #3248 unnecessary.

The core issue with the change in #3136 is that it is testing the exit code of the called function - any attempt to test the exit code will disable `set -e` behaviour. The `set -e` behaviour kicks in whenever a command or function is executed *unconditionally*.

This also means we can't have a helpful ` ${1} for package ${PKG_NAME} did not succeed!` failure message. :(

Apologies for not catching this sooner.