### PR TITLE
mpv-drmprime: new package

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="mpv-drmprime"
+PKG_VERSION="0.29.1"
+PKG_SHA256="f9f9d461d1990f9728660b4ccb0e8cb5dce29ccaa6af567bec481b79291ca623"
+PKG_LICENSE="GPL"
+PKG_SITE="https://mpv.io/"
+PKG_URL="https://github.com/mpv-player/mpv/archive/v$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain waf:host alsa ffmpeg libass libdrm"
+PKG_LONGDESC="A media player based on MPlayer and mplayer2. It supports a wide variety of video file formats, audio and video codecs, and subtitle types."
+PKG_TOOLCHAIN="manual"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-libsmbclient \
+                           --disable-apple-remote \
+                           --prefix=/usr \
+                           --enable-drm \
+                           --enable-drmprime \
+                           --enable-gbm \
+                           --enable-egl-drm"
+
+if [ "$OPENGLES_SUPPORT" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" $OPENGLES"
+fi
+
+if [ "$OPENGL_SUPPORT" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" $OPENGL"
+fi
+
+if [ "$VAAPI_SUPPORT" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" libva"
+  PKG_CONFIGURE_OPTS_TARGET+=" --enable-vaapi --enable-vaapi-drm"
+else
+  PKG_CONFIGURE_OPTS_TARGET+=" --disable-vaapi"
+fi
+
+if [ "$PULSEAUDIO_SUPPORT" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" pulseaudio"
+  PKG_CONFIGURE_OPTS_TARGET+=" --enable-pulse"
+else
+  PKG_CONFIGURE_OPTS_TARGET+=" --disable-pulse"
+fi
+
+if [ "$KODI_BLURAY_SUPPORT" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" libbluray"
+  PKG_CONFIGURE_OPTS_TARGET+=" --enable-libbluray"
+else
+  PKG_CONFIGURE_OPTS_TARGET+=" --disable-libbluray"
+fi
+
+configure_target() {
+  waf configure $PKG_CONFIGURE_OPTS_TARGET
+}
+
+make_target() {
+  waf build
+}
+
+makeinstall_target() {
+  waf install --destdir=$INSTALL
+  rm -r $INSTALL/usr/share
+}

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/patches/mpv-drmprime-PR6461.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/patches/mpv-drmprime-PR6461.patch
@@ -1,0 +1,73 @@
+From 9c39a05e87e89534bc0ebf0b1a1bfb918cfb127d Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Thu, 24 Jan 2019 22:11:10 +0100
+Subject: [PATCH] vo_gpu: hwdec_drmprime_drm: add hwdec ctx
+
+This allows to use drm hwaccels that require a hwdevice.
+
+Tested with v4l2request hwaccel and cedrus driver on an allwinner device
+running mpv with --vo=gpu --gpu-context=drm --hwdec=drm.
+---
+ video/out/opengl/hwdec_drmprime_drm.c | 14 ++++++++++++++
+ wscript                               |  2 +-
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/video/out/opengl/hwdec_drmprime_drm.c b/video/out/opengl/hwdec_drmprime_drm.c
+index fd3d383c55..13fbe7528f 100644
+--- a/video/out/opengl/hwdec_drmprime_drm.c
++++ b/video/out/opengl/hwdec_drmprime_drm.c
+@@ -23,6 +23,7 @@
+ #include <math.h>
+ #include <stdbool.h>
+ 
++#include <libavutil/hwcontext.h>
+ #include <libavutil/hwcontext_drm.h>
+ 
+ #include "common.h"
+@@ -44,6 +45,7 @@ struct drm_frame {
+ 
+ struct priv {
+     struct mp_log *log;
++    struct mp_hwdec_ctx hwctx;
+ 
+     struct mp_image_params params;
+ 
+@@ -231,6 +233,9 @@ static void uninit(struct ra_hwdec *hw)
+     disable_video_plane(hw);
+     set_current_frame(hw, NULL);
+ 
++    hwdec_devices_remove(hw->devs, &p->hwctx);
++    av_buffer_unref(&p->hwctx.av_device_ref);
++
+     if (p->ctx) {
+         drm_atomic_destroy_context(p->ctx);
+         p->ctx = NULL;
+@@ -284,6 +289,15 @@ static int init(struct ra_hwdec *hw)
+     }
+ 
+     disable_video_plane(hw);
++
++    p->hwctx = (struct mp_hwdec_ctx) {
++        .driver_name = hw->driver->name,
++    };
++    if (!av_hwdevice_ctx_create(&p->hwctx.av_device_ref, AV_HWDEVICE_TYPE_DRM,
++                                drmGetDeviceNameFromFd2(p->ctx->fd), NULL, 0)) {
++        hwdec_devices_add(hw->devs, &p->hwctx);
++    }
++
+     return 0;
+ 
+ err:
+diff --git a/wscript b/wscript
+index d3d49090c8..c437d5adc1 100644
+--- a/wscript
++++ b/wscript
+@@ -554,7 +554,7 @@ video_output_features = [
+         'name': '--drm',
+         'desc': 'DRM',
+         'deps': 'vt.h',
+-        'func': check_pkg_config('libdrm'),
++        'func': check_pkg_config('libdrm', '>= 2.4.74'),
+     }, {
+         'name': '--drmprime',
+         'desc': 'DRM Prime ffmpeg support',

--- a/packages/addons/tools/multimedia-tools/changelog.txt
+++ b/packages/addons/tools/multimedia-tools/changelog.txt
@@ -1,3 +1,6 @@
+110
+- Add mpv
+
 109
 - Update squeezelite to b2ed99e and support all possible media formats
 

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="109"
+PKG_REV="110"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of multimedia tools and programs"
-PKG_LONGDESC="This bundle currently includes alsamixer, mediainfo, mesa-demos, mpg123, opencaster, squeezelite, tsdecrypt and tstools."
+PKG_LONGDESC="This bundle currently includes alsamixer, mediainfo, mesa-demos, mpg123, mpv, opencaster, squeezelite, tsdecrypt and tstools."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Multimedia Tools"
@@ -22,6 +22,7 @@ PKG_DEPENDS_TARGET="toolchain \
                     alsa-utils \
                     mediainfo \
                     mpg123 \
+                    mpv-drmprime \
                     opencaster \
                     squeezelite \
                     tsdecrypt \
@@ -46,6 +47,9 @@ addon() {
 
     # mpg123
     cp -P $(get_build_dir mpg123)/.install_pkg/usr/bin/* $ADDON_BUILD/$PKG_ADDON_ID/bin/
+
+    # mpv
+    cp -P $(get_build_dir mpv-drmprime)/.install_pkg/usr/bin/* $ADDON_BUILD/$PKG_ADDON_ID/bin/
 
     # opencaster
     cp -P $(get_build_dir opencaster)/.install_pkg/* $ADDON_BUILD/$PKG_ADDON_ID/bin/

--- a/packages/python/devel/waf/package.mk
+++ b/packages/python/devel/waf/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="waf"
+PKG_VERSION="2.0.15"
+PKG_SHA256="34b8156ea375089e1bed5a31acfaff4024f6f3e96f3bee98f801f0c281ad3d2c"
+PKG_LICENSE="MIT"
+PKG_SITE="https://waf.io"
+PKG_URL="https://waf.io/$PKG_NAME-$PKG_VERSION"
+PKG_LONGDESC="The Waf build system"
+PKG_TOOLCHAIN="manual"
+
+unpack() {
+  mkdir -p $PKG_BUILD
+    cp $SOURCES/$PKG_NAME/$PKG_SOURCE_NAME $PKG_BUILD/waf
+    chmod a+x $PKG_BUILD/waf
+}
+
+makeinstall_host() {
+  cp -pf waf $TOOLCHAIN/bin/
+}


### PR DESCRIPTION
This PR adds a `mpv` package that is useful for debugging and testing ffmpeg drmprime decoding on mainline and rockchip projects.

Run `mpv --vo=gpu --gpu-context=drm --hwdec=drm/rkmpp/help <path>` when kodi has been stopped to start playback.

Tested on Allwinner (4.20) and Rockchip (4.4/4.20) projects.

Work-in-progress due to awaiting feedback on mpv patch/pull-request.