### PR TITLE
add missing libretro addons

### DIFF
--- a/packages/emulation/libretro-mame2003_plus/package.mk
+++ b/packages/emulation/libretro-mame2003_plus/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-mame2003_plus"
+PKG_VERSION="6bee56fe5e6557cfaf019f0ba1fad6d961cdfde2"
+PKG_SHA256="723e14c33a7ec8f72c1628b57bd0d775ebb7e76813788869a22fe2de77c57a99"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"
+PKG_URL="https://github.com/libretro/mame2003-plus-libretro/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Updated 2018 version of MAME (0.78) with added game support plus many fixes and improvements"
+
+PKG_LIBNAME="mame2003_plus_libretro.so"
+PKG_LIBPATH="$PKG_LIBNAME"
+PKG_LIBVAR="MAME2003_PLUS_LIB"
+
+configure_target() {
+  export LD="$CC"
+}
+
+makeinstall_target() {
+  mkdir -p $SYSROOT_PREFIX/usr/lib/cmake/$PKG_NAME
+  cp $PKG_LIBPATH $SYSROOT_PREFIX/usr/lib/$PKG_LIBNAME
+  echo "set($PKG_LIBVAR $SYSROOT_PREFIX/usr/lib/$PKG_LIBNAME)" > $SYSROOT_PREFIX/usr/lib/cmake/$PKG_NAME/$PKG_NAME-config.cmake
+}

--- a/packages/emulation/libretro-mame2016/package.mk
+++ b/packages/emulation/libretro-mame2016/package.mk
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-mame2016"
+PKG_VERSION="e06d731644217f46bf5a7613222632d41a327f93"
+PKG_SHA256="60a8aaab5158868419f24cc0671f8bcba0a578aae46cae7b9482e2c332784553"
+PKG_ARCH="x86_64"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/libretro/mame2016-libretro"
+PKG_URL="https://github.com/libretro/mame2016-libretro/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Late 2016 version of MAME (0.174) for libretro. Compatible with MAME 0.174 romsets"
+PKG_TOOLCHAIN="make"
+PKG_BUILD_FLAGS="-gold"
+
+PKG_LIBNAME="mame2016_libretro.so"
+PKG_LIBPATH="$PKG_LIBNAME"
+PKG_LIBVAR="MAME2016_LIB"
+
+make_target() {
+  PTR64="1"
+  NOASM="0"
+
+  make REGENIE=1 VERBOSE=1 NOWERROR=1 PYTHON_EXECUTABLE=python2 CONFIG=libretro \
+       LIBRETRO_OS="unix" ARCH="" PROJECT="" LIBRETRO_CPU="$ARCH" DISTRO="debian-stable" \
+       CC="$CC" CXX="$CXX" LD="$LD" CROSS_BUILD="" PTR64="$PTR64" TARGET="mame" \
+       SUBTARGET="arcade" PLATFORM="$ARCH" RETRO=1 OSD="retro"
+}
+
+post_make_target() {
+  mv $PKG_BUILD/mamearcade2016_libretro.so $PKG_BUILD/mame2016_libretro.so
+}
+
+makeinstall_target() {
+  mkdir -p $SYSROOT_PREFIX/usr/lib/cmake/$PKG_NAME
+  cp $PKG_LIBPATH $SYSROOT_PREFIX/usr/lib/$PKG_LIBNAME
+  echo "set($PKG_LIBVAR $SYSROOT_PREFIX/usr/lib/$PKG_LIBNAME)" > $SYSROOT_PREFIX/usr/lib/cmake/$PKG_NAME/$PKG_NAME-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.mame2003_plus"
+PKG_VERSION="08646838fbb34eef69e1f16ad6d54afba461c677"
+PKG_SHA256="ccc7973b57fc045c4ef039c8f3477c48f4cbe98e7be0be9e4d0fb23de5e657d0"
+PKG_REV="100"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.libretro.mame2003_plus"
+PKG_URL="https://github.com/kodi-game/game.libretro.mame2003_plus/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-mame2003_plus"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.mame2003_plus: MAME 2003 Plus emulator for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2016/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2016/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.mame2016"
+PKG_VERSION="2581a76552da518cb82f8940e3dd1c37d07e640d"
+PKG_SHA256="80379af128de18adc4c3043fb17ae7511bcb90ebef42429484744e97bf25b771"
+PKG_REV="100"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.libretro.mame2016"
+PKG_URL="https://github.com/kodi-game/game.libretro.mame2016/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-mame2016"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.mame2016: MAME2016 emulator for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"

--- a/packages/mediacenter/kodi-binary-addons/game.netplay/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.netplay/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.netplay"
+PKG_VERSION="e11f6a81f57420eee10d99a9773611591a2a0fae"
+PKG_SHA256="bb6011de992f02d72fc8db7b6d6b032c6ebff71085d97a5b13a87daa5ca2d775"
+PKG_REV="100"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.netplay"
+PKG_URL="https://github.com/kodi-game/game.netplay/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform p8-platform"
+PKG_SECTION=""
+PKG_LONGDESC="game.netplay adds Netplay support for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
- this is just buildtested (at generic) because I have nothing to runtime test it
- mame2016 is building, game.libretro.mame2016 fails - ideas welcome how to fix it

```
buildbot:~/LE$ PROJECT=Generic ARCH=x86_64 scripts/create_addon game.libretro.mame2016
CREATE ADDON game.libretro.mame2016 (Generic/x86_64)
     BUILD      game.libretro.mame2016 (target)
         TOOLCHAIN      cmake (auto-detect)
Executing (target): cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=/builddir/toolchain/etc/cmake-x86_64-libreelec-linux-gnu.conf -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=MinSizeRel /builddir/game.libretro.mame2016-2581a76552da518cb82f8940e3dd1c37d07e640d
-- MAME2016_VERSION=0.174.0.1
-- Configuring done
-- Generating done
-- Build files have been written to: /builddir/game.libretro.mame2016-2581a76552da518cb82f8940e3dd1c37d07e640d/.x86_64-libreelec-linux-gnu
Executing (target): ninja 
ninja: no work to do.
[0/1] Install the project...
-- Install configuration: "MinSizeRel"
CMake Error at cmake_install.cmake:49 (file):
  file INSTALL cannot find
  "/builddir/game.libretro.mame2016-2581a76552da518cb82f8940e3dd1c37d07e640d/MAME2016_LIB-NOTFOUND".


FAILED: CMakeFiles/install.util 
cd /builddir/game.libretro.mame2016-2581a76552da518cb82f8940e3dd1c37d07e640d/.x86_64-libreelec-linux-gnu && /builddir/toolchain/bin/cmake -P cmake_install.cmake
ninja: build stopped: subcommand failed.
```