### PR TITLE
libretro-picodrive: drop git rev-parse call from Makefile

### DIFF
--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -39,6 +39,10 @@ pre_configure_target() {
   rm -rf .$TARGET_NAME
 }
 
+post_configure_target() {
+  sed -e "s|^GIT_VERSION :=.*$|GIT_VERSION := \" ${PKG_VERSION:0:7}\"|" -i Makefile.libretro
+}
+
 make_target() {
   make -f Makefile.libretro
 }


### PR DESCRIPTION
git rev-parse runs into the LE tree and sets GIT_VERSION to the
current LE githash - which is nonsense.

Just set GIT_VERSION to the (shortened) PKG_VERSION in the Makefile
to avoid this issue.
