### PR TITLE
libretro-picodrive: fix build error

### DIFF
--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -44,7 +44,7 @@ post_configure_target() {
 }
 
 make_target() {
-  make -f Makefile.libretro
+  R= make -f Makefile.libretro
 }
 
 makeinstall_target() {


### PR DESCRIPTION
The environment variable "R" leaks into the Makefile,
if it is set the build will fail. eg

export R=12345
scripts/build libretro-picodrive
...
make: *** No rule to make target '12345pico/pico.o', needed by 'picodrive_libretro.so'.  Stop.

Unset the variable before calling make to fix this issue