### PR TITLE
LibreELEC-settings: update to LibreELEC-settings-37e206b

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="6a8fb79472c9657d9176d47b6e10e3a267c2ac89"
-PKG_SHA256="c982aedd369e17e6c5a5b8d06a7661e650afdb3adcaf33570a880ceaf53202e7"
+PKG_VERSION="37e206b712a46213522a567a408382f5f082502a"
+PKG_SHA256="d2d219f76ff41e3e933bac946978fd8971ef65df117459c3fd911dabb95115ad"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Fixes stale list of versions when clicking on "Available versions" button.