### PR TITLE
config/functions: add cross-compile property support

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -332,7 +332,7 @@ setup_toolchain() {
 }
 
 create_meson_conf() {
-  local endian root
+  local endian root properties
   case "$1" in
     target|init)    endian="little"
                     root="$SYSROOT_PREFIX/usr"
@@ -341,6 +341,8 @@ create_meson_conf() {
                     root="$TOOLCHAIN"
                     ;;
   esac
+
+  properties="PKG_MESON_PROPERTIES_${1^^}"
 
   cat > $2 <<EOF
 [binaries]
@@ -361,6 +363,7 @@ endian = '$endian'
 root = '$root'
 $(python -c "import os; print('c_args = {}'.format([x for x in os.getenv('CFLAGS').split()]))")
 $(python -c "import os; print('c_link_args = {}'.format([x for x in os.getenv('LDFLAGS').split()]))")
+${!properties}
 EOF
 }
 


### PR DESCRIPTION
Allow usage of cross-compile properties eg.

```
PKG_MESON_PROPERTIES_TARGET="
have_c99_vsnprintf=true
have_c99_snprintf=true
growing_stack=false
va_val_copy=false"
```