### PR TITLE
[le9.0] add patch to fix Zotac IR remotes

### DIFF
--- a/packages/linux-driver-addons/dvb/depends/media_tree/patches/media_tree-03-linux-902-extend-rc6-toggle-support-for-zotac.patch
+++ b/packages/linux-driver-addons/dvb/depends/media_tree/patches/media_tree-03-linux-902-extend-rc6-toggle-support-for-zotac.patch
@@ -1,0 +1,41 @@
+From ae1ccaa3587c0bd3d6d01841fa2e668cdf738f1e Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sun, 3 Feb 2019 14:24:00 +0100
+Subject: [PATCH] media: rc: ir-rc6-decoder: enable toggle bit for Zotac
+ remotes
+
+The Zotac RC2604323/01G and RC2604329/02BG remotes use the 32-bit
+rc6 protocol and toggle bit 15 (0x8000) on repeated button presses,
+like MCE remotes.
+
+Add the customer code 0x80340000 to the 32-bit rc6 toggle
+handling code to get proper scancodes and toggle reports.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ir-rc6-decoder.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/rc/ir-rc6-decoder.c b/drivers/media/rc/ir-rc6-decoder.c
+index d96aed1343e4..5cc302fa4daa 100644
+--- a/drivers/media/rc/ir-rc6-decoder.c
++++ b/drivers/media/rc/ir-rc6-decoder.c
+@@ -40,6 +40,7 @@
+ #define RC6_6A_MCE_TOGGLE_MASK	0x8000	/* for the body bits */
+ #define RC6_6A_LCC_MASK		0xffff0000 /* RC6-6A-32 long customer code mask */
+ #define RC6_6A_MCE_CC		0x800f0000 /* MCE customer code */
++#define RC6_6A_ZOTAC_CC		0x80340000 /* Zotac customer code */
+ #define RC6_6A_KATHREIN_CC	0x80460000 /* Kathrein RCU-676 customer code */
+ #ifndef CHAR_BIT
+ #define CHAR_BIT 8	/* Normally in <limits.h> */
+@@ -246,6 +247,7 @@ static int ir_rc6_decode(struct rc_dev *dev, struct ir_raw_event ev)
+ 				switch (scancode & RC6_6A_LCC_MASK) {
+ 				case RC6_6A_MCE_CC:
+ 				case RC6_6A_KATHREIN_CC:
++				case RC6_6A_ZOTAC_CC:
+ 					protocol = RC_PROTO_RC6_MCE;
+ 					toggle = !!(scancode & RC6_6A_MCE_TOGGLE_MASK);
+ 					scancode &= ~RC6_6A_MCE_TOGGLE_MASK;
+-- 
+2.20.1
+

--- a/packages/linux-driver-addons/dvb/depends/media_tree_cc/patches/media_tree_cc-03-linux-902-extend-rc6-toggle-support-for-zotac.patch
+++ b/packages/linux-driver-addons/dvb/depends/media_tree_cc/patches/media_tree_cc-03-linux-902-extend-rc6-toggle-support-for-zotac.patch
@@ -1,0 +1,41 @@
+From ae1ccaa3587c0bd3d6d01841fa2e668cdf738f1e Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sun, 3 Feb 2019 14:24:00 +0100
+Subject: [PATCH] media: rc: ir-rc6-decoder: enable toggle bit for Zotac
+ remotes
+
+The Zotac RC2604323/01G and RC2604329/02BG remotes use the 32-bit
+rc6 protocol and toggle bit 15 (0x8000) on repeated button presses,
+like MCE remotes.
+
+Add the customer code 0x80340000 to the 32-bit rc6 toggle
+handling code to get proper scancodes and toggle reports.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ir-rc6-decoder.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/rc/ir-rc6-decoder.c b/drivers/media/rc/ir-rc6-decoder.c
+index d96aed1343e4..5cc302fa4daa 100644
+--- a/drivers/media/rc/ir-rc6-decoder.c
++++ b/drivers/media/rc/ir-rc6-decoder.c
+@@ -40,6 +40,7 @@
+ #define RC6_6A_MCE_TOGGLE_MASK	0x8000	/* for the body bits */
+ #define RC6_6A_LCC_MASK		0xffff0000 /* RC6-6A-32 long customer code mask */
+ #define RC6_6A_MCE_CC		0x800f0000 /* MCE customer code */
++#define RC6_6A_ZOTAC_CC		0x80340000 /* Zotac customer code */
+ #define RC6_6A_KATHREIN_CC	0x80460000 /* Kathrein RCU-676 customer code */
+ #ifndef CHAR_BIT
+ #define CHAR_BIT 8	/* Normally in <limits.h> */
+@@ -246,6 +247,7 @@ static int ir_rc6_decode(struct rc_dev *dev, struct ir_raw_event ev)
+ 				switch (scancode & RC6_6A_LCC_MASK) {
+ 				case RC6_6A_MCE_CC:
+ 				case RC6_6A_KATHREIN_CC:
++				case RC6_6A_ZOTAC_CC:
+ 					protocol = RC_PROTO_RC6_MCE;
+ 					toggle = !!(scancode & RC6_6A_MCE_TOGGLE_MASK);
+ 					scancode &= ~RC6_6A_MCE_TOGGLE_MASK;
+-- 
+2.20.1
+

--- a/packages/linux-driver-addons/dvb/depends/media_tree_cc_aml/patches/media_tree_cc_aml-03-linux-902-extend-rc6-toggle-support-for-zotac.patch
+++ b/packages/linux-driver-addons/dvb/depends/media_tree_cc_aml/patches/media_tree_cc_aml-03-linux-902-extend-rc6-toggle-support-for-zotac.patch
@@ -1,0 +1,41 @@
+From ae1ccaa3587c0bd3d6d01841fa2e668cdf738f1e Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sun, 3 Feb 2019 14:24:00 +0100
+Subject: [PATCH] media: rc: ir-rc6-decoder: enable toggle bit for Zotac
+ remotes
+
+The Zotac RC2604323/01G and RC2604329/02BG remotes use the 32-bit
+rc6 protocol and toggle bit 15 (0x8000) on repeated button presses,
+like MCE remotes.
+
+Add the customer code 0x80340000 to the 32-bit rc6 toggle
+handling code to get proper scancodes and toggle reports.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ir-rc6-decoder.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/rc/ir-rc6-decoder.c b/drivers/media/rc/ir-rc6-decoder.c
+index d96aed1343e4..5cc302fa4daa 100644
+--- a/drivers/media/rc/ir-rc6-decoder.c
++++ b/drivers/media/rc/ir-rc6-decoder.c
+@@ -40,6 +40,7 @@
+ #define RC6_6A_MCE_TOGGLE_MASK	0x8000	/* for the body bits */
+ #define RC6_6A_LCC_MASK		0xffff0000 /* RC6-6A-32 long customer code mask */
+ #define RC6_6A_MCE_CC		0x800f0000 /* MCE customer code */
++#define RC6_6A_ZOTAC_CC		0x80340000 /* Zotac customer code */
+ #define RC6_6A_KATHREIN_CC	0x80460000 /* Kathrein RCU-676 customer code */
+ #ifndef CHAR_BIT
+ #define CHAR_BIT 8	/* Normally in <limits.h> */
+@@ -246,6 +247,7 @@ static int ir_rc6_decode(struct rc_dev *dev, struct ir_raw_event ev)
+ 				switch (scancode & RC6_6A_LCC_MASK) {
+ 				case RC6_6A_MCE_CC:
+ 				case RC6_6A_KATHREIN_CC:
++				case RC6_6A_ZOTAC_CC:
+ 					protocol = RC_PROTO_RC6_MCE;
+ 					toggle = !!(scancode & RC6_6A_MCE_TOGGLE_MASK);
+ 					scancode &= ~RC6_6A_MCE_TOGGLE_MASK;
+-- 
+2.20.1
+

--- a/packages/linux/patches/default/linux-902-extend-rc6-toggle-support-for-zotac.patch
+++ b/packages/linux/patches/default/linux-902-extend-rc6-toggle-support-for-zotac.patch
@@ -1,0 +1,41 @@
+From ae1ccaa3587c0bd3d6d01841fa2e668cdf738f1e Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sun, 3 Feb 2019 14:24:00 +0100
+Subject: [PATCH] media: rc: ir-rc6-decoder: enable toggle bit for Zotac
+ remotes
+
+The Zotac RC2604323/01G and RC2604329/02BG remotes use the 32-bit
+rc6 protocol and toggle bit 15 (0x8000) on repeated button presses,
+like MCE remotes.
+
+Add the customer code 0x80340000 to the 32-bit rc6 toggle
+handling code to get proper scancodes and toggle reports.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ir-rc6-decoder.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/rc/ir-rc6-decoder.c b/drivers/media/rc/ir-rc6-decoder.c
+index d96aed1343e4..5cc302fa4daa 100644
+--- a/drivers/media/rc/ir-rc6-decoder.c
++++ b/drivers/media/rc/ir-rc6-decoder.c
+@@ -40,6 +40,7 @@
+ #define RC6_6A_MCE_TOGGLE_MASK	0x8000	/* for the body bits */
+ #define RC6_6A_LCC_MASK		0xffff0000 /* RC6-6A-32 long customer code mask */
+ #define RC6_6A_MCE_CC		0x800f0000 /* MCE customer code */
++#define RC6_6A_ZOTAC_CC		0x80340000 /* Zotac customer code */
+ #define RC6_6A_KATHREIN_CC	0x80460000 /* Kathrein RCU-676 customer code */
+ #ifndef CHAR_BIT
+ #define CHAR_BIT 8	/* Normally in <limits.h> */
+@@ -246,6 +247,7 @@ static int ir_rc6_decode(struct rc_dev *dev, struct ir_raw_event ev)
+ 				switch (scancode & RC6_6A_LCC_MASK) {
+ 				case RC6_6A_MCE_CC:
+ 				case RC6_6A_KATHREIN_CC:
++				case RC6_6A_ZOTAC_CC:
+ 					protocol = RC_PROTO_RC6_MCE;
+ 					toggle = !!(scancode & RC6_6A_MCE_TOGGLE_MASK);
+ 					scancode &= ~RC6_6A_MCE_TOGGLE_MASK;
+-- 
+2.20.1
+

--- a/packages/linux/patches/raspberrypi/linux-902-extend-rc6-toggle-support-for-zotac.patch
+++ b/packages/linux/patches/raspberrypi/linux-902-extend-rc6-toggle-support-for-zotac.patch
@@ -1,0 +1,41 @@
+From ae1ccaa3587c0bd3d6d01841fa2e668cdf738f1e Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sun, 3 Feb 2019 14:24:00 +0100
+Subject: [PATCH] media: rc: ir-rc6-decoder: enable toggle bit for Zotac
+ remotes
+
+The Zotac RC2604323/01G and RC2604329/02BG remotes use the 32-bit
+rc6 protocol and toggle bit 15 (0x8000) on repeated button presses,
+like MCE remotes.
+
+Add the customer code 0x80340000 to the 32-bit rc6 toggle
+handling code to get proper scancodes and toggle reports.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ir-rc6-decoder.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/rc/ir-rc6-decoder.c b/drivers/media/rc/ir-rc6-decoder.c
+index d96aed1343e4..5cc302fa4daa 100644
+--- a/drivers/media/rc/ir-rc6-decoder.c
++++ b/drivers/media/rc/ir-rc6-decoder.c
+@@ -40,6 +40,7 @@
+ #define RC6_6A_MCE_TOGGLE_MASK	0x8000	/* for the body bits */
+ #define RC6_6A_LCC_MASK		0xffff0000 /* RC6-6A-32 long customer code mask */
+ #define RC6_6A_MCE_CC		0x800f0000 /* MCE customer code */
++#define RC6_6A_ZOTAC_CC		0x80340000 /* Zotac customer code */
+ #define RC6_6A_KATHREIN_CC	0x80460000 /* Kathrein RCU-676 customer code */
+ #ifndef CHAR_BIT
+ #define CHAR_BIT 8	/* Normally in <limits.h> */
+@@ -246,6 +247,7 @@ static int ir_rc6_decode(struct rc_dev *dev, struct ir_raw_event ev)
+ 				switch (scancode & RC6_6A_LCC_MASK) {
+ 				case RC6_6A_MCE_CC:
+ 				case RC6_6A_KATHREIN_CC:
++				case RC6_6A_ZOTAC_CC:
+ 					protocol = RC_PROTO_RC6_MCE;
+ 					toggle = !!(scancode & RC6_6A_MCE_TOGGLE_MASK);
+ 					scancode &= ~RC6_6A_MCE_TOGGLE_MASK;
+-- 
+2.20.1
+


### PR DESCRIPTION
backport of #3289 - this time to the correct le9 branch