### PR TITLE
kodi: cleanup Lircmap.xml patch

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-995.10-devinputmappings.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.10-devinputmappings.patch
@@ -1,16 +1,8 @@
 diff --git a/system/Lircmap.xml b/system/Lircmap.xml
-index ec7c6e0..a8a7a8a 100644
+index ec7c6e0e6a..05dc05521e 100644
 --- a/system/Lircmap.xml
 +++ b/system/Lircmap.xml
-@@ -497,6 +497,7 @@
- 		<teletext>KEY_TEXT</teletext>
- 		<clear>KEY_DELETE</clear>
- 	</remote>
-+
- 	<remote device="mediacenter">
- 		<pause>pause</pause>
- 		<stop>stop</stop>
-@@ -548,51 +549,94 @@
+@@ -548,50 +548,85 @@
  		<up>KEY_UP</up>
  		<down>KEY_DOWN</down>
  		<select>KEY_OK</select>
@@ -34,18 +26,13 @@ index ec7c6e0..a8a7a8a 100644
  		<stop>KEY_STOP</stop>
 +		<stop>KEY_STOPCD</stop>
  		<forward>KEY_FASTFORWARD</forward>
-+		<forward>KEY_FFORWARD</forward>
 +		<forward>KEY_FORWARD</forward>
  		<reverse>KEY_REWIND</reverse>
  		<volumeplus>KEY_VOLUMEUP</volumeplus>
-+		<volumeplus>KEY_VOLUP</volumeplus>
  		<volumeminus>KEY_VOLUMEDOWN</volumeminus>
-+		<volumeminus>KEY_VOLDOWN</volumeminus>
  		<pageplus>KEY_CHANNELUP</pageplus>
-+		<pageplus>KEY_CHUP</pageplus>
 +		<pageplus>KEY_PAGEUP</pageplus>
  		<pageminus>KEY_CHANNELDOWN</pageminus>
-+		<pageminus>KEY_CHDOWN</pageminus>
 +		<pageminus>KEY_PAGEDOWN</pageminus>
  		<skipplus>KEY_NEXT</skipplus>
 +		<skipplus>KEY_NEXTSONG</skipplus>
@@ -56,7 +43,6 @@ index ec7c6e0..a8a7a8a 100644
 +		<title>KEY_TV2</title>
 +		<title>KEY_CONTEXT_MENU</title>
  		<subtitle>KEY_SUBTITLE</subtitle>
-+		<subtitle>KEY_TITLE</subtitle>
  		<language>KEY_LANGUAGE</language>
  		<info>KEY_INFO</info>
 +		<info>KEY_PROPS</info>
@@ -99,10 +85,7 @@ index ec7c6e0..a8a7a8a 100644
  		<nine>KEY_NUMERIC_9</nine>
 +		<zero>KEY_0</zero>
  		<zero>KEY_NUMERIC_0</zero>
-+		<star>KEY_STAR</star>
 +		<star>KEY_KPASTERISK</star>
  		<star>KEY_NUMERIC_STAR</star>
-+		<hash>KEY_POUND</hash>
  		<hash>KEY_NUMERIC_POUND</hash>
  		<red>KEY_RED</red>
- 		<green>KEY_GREEN</green>


### PR DESCRIPTION
Drop KEY_TITLE mapping, this is already mapped in kodi Lircmap.xml.

Drop mappings with invalid keycodes KEY_FFORWARD KEY_VOLUP KEY_VOLDOWN
KEY_CHUP KEY_CHDOWN KEY_STAR KEY_POUND, they don't exist in
linux/input-event-codes.h

This fixes the bug reported here: https://forum.libreelec.tv/thread/14500-9-0-0-key-title-mapped-twice-in-lircmap-xml/