### PR TITLE
[vdr-addon] Fix deprecated VDR_CHARSET_OVERRIDE

### DIFF
--- a/packages/addons/service/vdr-addon/changelog.txt
+++ b/packages/addons/service/vdr-addon/changelog.txt
@@ -1,3 +1,6 @@
+110
+- fix deprecated VDR_CHARSET_OVERRIDE
+
 109
 - fix script.config.vdr scan:
   . reststfulapi: use header from current wirbelscan

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="vdr-addon"
 PKG_VERSION="2.4"
-PKG_REV="109"
+PKG_REV="110"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/service/vdr-addon/source/bin/vdr.start
+++ b/packages/addons/service/vdr-addon/source/bin/vdr.start
@@ -64,7 +64,7 @@ fi
 
 if [ "$ENABLE_CHARSET_OVERRIDE" == "true" ] ; then
   if [ ! -z "$CHARSET_OVERRIDE_STR" ] ; then
-    VDR_CHARSET_OVERRIDE="$CHARSET_OVERRIDE_STR"
+    VDR_ARG="$VDR_ARG --chartab=$CHARSET_OVERRIDE_STR"
   fi
 fi
 
@@ -181,4 +181,4 @@ if [ "$ENABLE_VDR_DEBUG" == "true" ] ; then
   sleep 1
 fi
 
-eval LANG=en_US.UTF-8 VDR_CHARSET_OVERRIDE="$VDR_CHARSET_OVERRIDE" exec vdr.bin $VDR_ARG
+eval LANG=en_US.UTF-8 exec vdr.bin $VDR_ARG


### PR DESCRIPTION
This fix costed me more time than I care to admit.

Unfortunately VDR's git history is a bit lacking, to say the least. Official git repo seems to be dead and, to add injury to insult, I decided to update all my boxes at once.

The rest is history and resulted in a lot of wasted time. Moving on.

The option `--chartab` was introduced in v2.1.10, with the following note:

> - The new command line option --chartab can be used to set the default character table to use for strings in the DVB data stream that don't begin with a proper character table indicator (suggested by Christopher Reimer). The old mechanism of using the environment variable VDR_CHARSET_OVERRIDE still works, but is now deprecated and may be removed in a future version. The value given in the --chartab option takes precedence over that in VDR_CHARSET_OVERRIDE.

`VDR_CHARSET_OVERRIDE` was deprecated in v2.3.9, with the following note:
> - The default for DEPRECATED_VDR_CHARSET_OVERRIDE has been set to 0, which means VDR no longer reacts on the environment variable VDR_CHARSET_OVERRIDE. You can add 'DEPRECATED_VDR_CHARSET_OVERRIDE=1' when compiling in order to restore this functionality. However, it is recommended to use the command line option --chartab instead.

Note to self: stop being a moron, update one box at a time and RTFM, in this case the `HISTORY` file.

Run-time tested. I'll PR a backport after this goes into master.