### PR TITLE
libnfs: update to libnfs-4.0.0 [backport]

### DIFF
--- a/packages/network/libnfs/package.mk
+++ b/packages/network/libnfs/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnfs"
-PKG_VERSION="38b62bcf873c778ebde79707bb0409b6a09ee608"
-PKG_SHA256="12e8e2e142ca4c41e1f1a22ce6e88b205bacdedfa29daaff91a5d54cf834ea61"
-PKG_LICENSE="GPL"
+PKG_VERSION="4.0.0"
+PKG_SHA256="6ee77e9fe220e2d3e3b1f53cfea04fb319828cc7dbb97dd9df09e46e901d797d"
+PKG_LICENSE="LGPL2.1+"
 PKG_SITE="https://github.com/sahlberg/libnfs"
-PKG_URL="https://github.com/sahlberg/libnfs/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/sahlberg/libnfs/archive/libnfs-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A client library for accessing NFS shares over a network."
 PKG_TOOLCHAIN="autotools"


### PR DESCRIPTION
Backport of #3304.

I include latest `libnfs` so let this be tested a day or two before merging, close if issues.

The delta is minor:

https://github.com/sahlberg/libnfs/compare/38b62bcf873c778ebde79707bb0409b6a09ee608...libnfs-4.0.0