### PR TITLE
kodi.sh: upgrade crash log information

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi.sh
+++ b/packages/mediacenter/kodi/scripts/kodi.sh
@@ -46,7 +46,11 @@ single_stacktrace()
   find "$1" -name 'core.*kodi.bin.*' | while read core; do
     echo "=====>  Core file: "$core"" >> $FILE
     echo "        =========================================" >> $FILE
-    gdb /usr/lib/kodi/kodi.bin --core="$core" --batch -ex "thread apply all bt" 2>/dev/null >> $FILE
+    if [ -f /storage/.config/debug.enhanced ]; then
+      gdb /usr/lib/kodi/kodi.bin --core="$core" --batch -ex "thread apply all bt full" -ex "info registers" -ex "set print asm-demangle on" -ex "disassemble" 2>/dev/null >> $FILE
+    else
+      gdb /usr/lib/kodi/kodi.bin --core="$core" --batch -ex "thread apply all bt" 2>/dev/null >> $FILE
+    fi
     rm -f "$core"
   done
 }


### PR DESCRIPTION
Write more information into kodi crash log.

Use full back trace. Add CPU register dump and disassembly of current function.

Backport of #3306