### PR TITLE
buildsystem: fix debug broken by #3171

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -522,6 +522,10 @@ init_package_cache() {
       mv "${temp_global}" "${_CACHE_PACKAGE_GLOBAL}"
     fi
   fi
+
+  if [ -z "${_DEBUG_DEPENDS_LIST+x}" ]; then
+    set_debug_depends
+  fi
 }
 
 load_build_config() {

--- a/config/options
+++ b/config/options
@@ -88,8 +88,6 @@ if [ "${OEM}" = "yes" -o "${OEM}" = "no" ]; then
   OEM_SUPPORT="${OEM}"
 fi
 
-[ -z "${_DEBUG_DEPENDS_LIST+x}" ] && set_debug_depends
-
 check_config
 
 . config/graphic


### PR DESCRIPTION
After #3171 we init the package cache too late for `set_debug_depends`, which then fails.

I'll push a backport for libreelec-9.0 after further testing.