### PR TITLE
openssh: drop support for ssh-dss keys

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -51,8 +51,6 @@ post_makeinstall_target() {
       -e "s|^#StrictModes.*|StrictModes no|g" \
       -i $INSTALL/etc/ssh/sshd_config
 
-  echo "PubkeyAcceptedKeyTypes +ssh-dss" >> $INSTALL/etc/ssh/sshd_config
-
   debug_strip $INSTALL/usr
 }
 


### PR DESCRIPTION
OpenSSH 7.0 was released in August 2015 and removed default-config support for DSA keys which are 1024 bit and considered insecure. I presume we re-added support in https://github.com/LibreELEC/LibreELEC.tv/commit/6390ccb28a162d7882fb2c89b963048879db7b89 to address users reporting their keys not working, but [3.5 years later] it would be better to accept defaults and prefer RSA/ed25519 keys. You can always use /storage/.cache/ssh/sshd_config to keep using DSA keys if needed. No backport to 9.0 as this is a breaking change.