### PR TITLE
CrazyCat TBS 5520SE fix

### DIFF
--- a/packages/linux-driver-addons/dvb/depends/media_tree_cc/patches/media_tree_cc-04-fix-tbs5520se.patch
+++ b/packages/linux-driver-addons/dvb/depends/media_tree_cc/patches/media_tree_cc-04-fix-tbs5520se.patch
@@ -1,0 +1,22 @@
+https://bitbucket.org/CrazyCat/linux_media/commits/ebd9c45524383e09d993563f4bd3cc765796b38a/raw
+https://forum.libreelec.tv/thread/14405-dual-tbs-5520se-libreelec-9-0-0-intel-generic/?postID=110926#post110926
+fixes TBS5520se scanning of frequencies
+
+From: CrazyCat
+Date: Mon, 12 Nov 2018 19:49:55 +0200
+Subject: [PATCH] si2183: Fixed minimal frequency for DVB-C.
+
+diff --git a/drivers/media/dvb-frontends/si2183.c b/drivers/media/dvb-frontends/si2183.c
+index f1cc0da..333abd0 100644
+--- a/drivers/media/dvb-frontends/si2183.c
++++ b/drivers/media/dvb-frontends/si2183.c
+@@ -1335,7 +1335,7 @@ static int si2183_set_property(struct dvb_frontend *fe,
+ 			break;
+ 		case SYS_DVBC_ANNEX_A:
+ 		case SYS_DVBC_ANNEX_B:
+-			fe->ops.info.frequency_min_hz = 470 * MHz;
++			fe->ops.info.frequency_min_hz = 47 * MHz;
+ 			fe->ops.info.frequency_max_hz = 862 * MHz;
+ 			fe->ops.info.frequency_stepsize_hz = 62500;
+ 			break;
+

--- a/packages/linux-driver-addons/dvb/depends/media_tree_cc_aml/patches/media_tree_cc_aml-04-fix-tbs5520se.patch
+++ b/packages/linux-driver-addons/dvb/depends/media_tree_cc_aml/patches/media_tree_cc_aml-04-fix-tbs5520se.patch
@@ -1,0 +1,22 @@
+https://bitbucket.org/CrazyCat/linux_media/commits/ebd9c45524383e09d993563f4bd3cc765796b38a/raw
+https://forum.libreelec.tv/thread/14405-dual-tbs-5520se-libreelec-9-0-0-intel-generic/?postID=110926#post110926
+fixes TBS5520se scanning of frequencies
+
+From: CrazyCat
+Date: Mon, 12 Nov 2018 19:49:55 +0200
+Subject: [PATCH] si2183: Fixed minimal frequency for DVB-C.
+
+diff --git a/drivers/media/dvb-frontends/si2183.c b/drivers/media/dvb-frontends/si2183.c
+index f1cc0da..333abd0 100644
+--- a/drivers/media/dvb-frontends/si2183.c
++++ b/drivers/media/dvb-frontends/si2183.c
+@@ -1335,7 +1335,7 @@ static int si2183_set_property(struct dvb_frontend *fe,
+ 			break;
+ 		case SYS_DVBC_ANNEX_A:
+ 		case SYS_DVBC_ANNEX_B:
+-			fe->ops.info.frequency_min_hz = 470 * MHz;
++			fe->ops.info.frequency_min_hz = 47 * MHz;
+ 			fe->ops.info.frequency_max_hz = 862 * MHz;
+ 			fe->ops.info.frequency_stepsize_hz = 62500;
+ 			break;
+


### PR DESCRIPTION
```
usb 1-1.3: DVB: adapter 0 frontend 1 frequency 386000000 out of range (470000000..862000000)
So basically I can scan UHF channels but not the VHF (out of range)
```

tx to crazycat

@awiouy 