### PR TITLE
Nghttp2

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi.sh
+++ b/packages/mediacenter/kodi/scripts/kodi.sh
@@ -46,7 +46,11 @@ single_stacktrace()
   find "$1" -name 'core.*kodi.bin.*' | while read core; do
     echo "=====>  Core file: "$core"" >> $FILE
     echo "        =========================================" >> $FILE
-    gdb /usr/lib/kodi/kodi.bin --core="$core" --batch -ex "thread apply all bt" 2>/dev/null >> $FILE
+    if [ -f /storage/.config/debug.enhanced ]; then
+      gdb /usr/lib/kodi/kodi.bin --core="$core" --batch -ex "thread apply all bt full" -ex "info registers" -ex "set print asm-demangle on" -ex "disassemble" 2>/dev/null >> $FILE
+    else
+      gdb /usr/lib/kodi/kodi.bin --core="$core" --batch -ex "thread apply all bt" 2>/dev/null >> $FILE
+    fi
     rm -f "$core"
   done
 }

--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -16,7 +16,7 @@ PKG_SHA256="7802c54076500be500b171fde786258579d60547a3a35b8c5a23d8c88e8f9620"
 PKG_LICENSE="MIT"
 PKG_SITE="http://curl.haxx.se"
 PKG_URL="http://curl.haxx.se/download/$PKG_NAME-$PKG_VERSION.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain zlib openssl rtmpdump"
+PKG_DEPENDS_TARGET="toolchain zlib openssl rtmpdump nghttp2"
 PKG_LONGDESC="Client and library for (HTTP, HTTPS, FTP, ...) transfers."
 PKG_TOOLCHAIN="configure"
 
@@ -73,7 +73,8 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_lib_rtmp_RTMP_Init=yes \
                            --without-libmetalink \
                            --without-libssh2 \
                            --with-librtmp=$SYSROOT_PREFIX/usr \
-                           --without-libidn"
+                           --without-libidn \
+                           --with-nghttp2"
 
 pre_configure_target() {
 # link against librt because of undefined reference to 'clock_gettime'

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="nghttp2"
+PKG_VERSION="1.36.0"
+PKG_SHA256="e9bb86157b88eda5a6844a232e039febbb52c1aa44b640acbbfabe729b8287fc"
+PKG_LICENSE="MIT"
+PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
+PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v$PKG_VERSION/nghttp2-$PKG_VERSION.tar.xz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="nghttp2 is an implementation of HTTP/2 and its header compression algorithm, HPACK."
+PKG_TOOLCHAIN="configure"
+
+PKG_CONFIGURE_OPTS_TARGET="--enable-lib-only"


### PR DESCRIPTION
Tested on RPi2 and works as expected using the libreelec-9.0 branch. Expected to work on master as well.