### PR TITLE
Add support for http2 in curl

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -16,7 +16,7 @@ PKG_SHA256="7802c54076500be500b171fde786258579d60547a3a35b8c5a23d8c88e8f9620"
 PKG_LICENSE="MIT"
 PKG_SITE="http://curl.haxx.se"
 PKG_URL="http://curl.haxx.se/download/$PKG_NAME-$PKG_VERSION.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain zlib openssl rtmpdump"
+PKG_DEPENDS_TARGET="toolchain zlib openssl rtmpdump nghttp2"
 PKG_LONGDESC="Client and library for (HTTP, HTTPS, FTP, ...) transfers."
 PKG_TOOLCHAIN="configure"
 
@@ -73,7 +73,9 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_lib_rtmp_RTMP_Init=yes \
                            --without-libmetalink \
                            --without-libssh2 \
                            --with-librtmp=$SYSROOT_PREFIX/usr \
-                           --without-libidn"
+                           --without-libidn \
+                           --without-libidn2 \
+                           --with-nghttp2"
 
 pre_configure_target() {
 # link against librt because of undefined reference to 'clock_gettime'

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="nghttp2"
+PKG_VERSION="1.36.0"
+PKG_SHA256="e9bb86157b88eda5a6844a232e039febbb52c1aa44b640acbbfabe729b8287fc"
+PKG_LICENSE="MIT"
+PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
+PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v$PKG_VERSION/nghttp2-$PKG_VERSION.tar.xz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="nghttp2 is an implementation of HTTP/2 and its header compression algorithm, HPACK."
+PKG_TOOLCHAIN="configure"
+
+PKG_CONFIGURE_OPTS_TARGET="--enable-lib-only"
+
+post_makeinstall_target() {
+  rm -r "${INSTALL}/usr/share"
+}
+


### PR DESCRIPTION
Adds http2 support for curl. Tested on RPi2 without an issue. test results below.

curl --version
curl 7.62.0 (armv7ve-libreelec-linux-gnueabi) libcurl/7.62.0 OpenSSL/1.0.2q zlib/1.2.11 nghttp2/1.36.0 librtmp/2.3
Release-Date: 2018-10-31
Protocols: file ftp ftps http https rtmp rtsp
Features: AsynchDNS IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP HTTP2 UnixSockets HTTPS-proxy

curl --http2 -I https://http2.akamai.com/
HTTP/2 200
server: Apache
etag: "9068c20f1c727825919f58f136cdfb91:1506554442"
last-modified: Wed, 27 Sep 2017 23:04:38 GMT
accept-ranges: bytes
content-length: 11710
push: true
rtt: 50
ghost_ip: 184.50.210.229
ghost_service_ip: 23.43.58.76
client_real_ip: X.X.X.X
client_ip: X.X.X.X
myproto: h2
protocol_negotiation: h2
cache-control: max-age=43200
expires: Sat, 23 Feb 2019 13:32:28 GMT
date: Sat, 23 Feb 2019 01:32:28 GMT
content-type: text/html;charset=UTF-8
accept-ch: DPR, Width, Viewport-Width, Downlink, Save-Data
access-control-max-age: 86400
access-control-allow-credentials: false
access-control-allow-headers: *
access-control-allow-methods: GET,HEAD,POST
access-control-allow-origin: *
strict-transport-security: max-age=31536000 ; includeSubDomains