### PR TITLE
xf86-video-nvidia: update to xf86-video-nvidia-410.104

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="xf86-video-nvidia"
 # Remember to run "python packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py" and commit changes to
 # "packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules" whenever bumping version.
 # Host may require installation of python-lxml and python-requests packages.
-PKG_VERSION="410.93"
-PKG_SHA256="b1ce054f8307080a257538ab82873e8b8022183f68e08e20fbb07089f7ddbb08"
+PKG_VERSION="410.104"
+PKG_SHA256="0f4f61a742831d82a94457ff12c4583a6e17ace71e0e6ca794ee3ce0a0b9db32"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.nvidia.com/"


### PR DESCRIPTION
Announcement: [forum](https://devtalk.nvidia.com/default/topic/1047709), [alt](https://www.nvidia.com/Download/driverResults.aspx/142569/en-us)

418.43 as a "long-lived branch" release (#3327) is increasingly looking to have been a mistake by Nvidia. I'll re-introduce this 410.xx driver (which I believe is the real "long lived branch") into test builds until the situation is resolved.