### PR TITLE
gcc: update to gcc-8.3.0

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.7.1"
-PKG_SHA256="fa7e2b8e8c9402f192ad56dc4f814089d1c4466c97d780f5e5acc02c04243d6d"
+PKG_VERSION="3.7.2"
+PKG_SHA256="d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.python.org/"
 PKG_URL="http://www.python.org/ftp/python/$PKG_VERSION/${PKG_NAME::-1}-$PKG_VERSION.tar.xz"

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc"
-PKG_VERSION="8.2.0"
-PKG_SHA256="196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080"
+PKG_VERSION="8.3.0"
+PKG_SHA256="64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2c"
 PKG_LICENSE="GPL"
 PKG_SITE="http://gcc.gnu.org/"
 PKG_URL="http://ftpmirror.gnu.org/gcc/$PKG_NAME-$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.xz"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="7.0.0"
-PKG_SHA256="8bc1f844e6cbde1b652c19c1edebc1864456fd9c78b8c1bea038e51b363fe222"
+PKG_VERSION="7.0.1"
+PKG_SHA256="a38dfc4db47102ec79dcc2aa61e93722c5f6f06f0a961073bd84b78fb949419b"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="http://llvm.org/"

--- a/packages/multimedia/libhdhomerun/patches/libhdhomerun-pr19-fix-gcc-8.3.0-build.patch
+++ b/packages/multimedia/libhdhomerun/patches/libhdhomerun-pr19-fix-gcc-8.3.0-build.patch
@@ -1,0 +1,24 @@
+From a83ec0c045d3fadb78a879d0ac8ae999b89786df Mon Sep 17 00:00:00 2001
+From: fuzzard <bmurphy@bcmcs.net>
+Date: Sun, 24 Feb 2019 07:47:31 +1000
+Subject: [PATCH] alignas c++ fix
+
+alignas is a keyword in c++. Dont define.
+Change is in windows header already, and GCC 8.3.0 is erroring on this now.
+---
+ hdhomerun_os_posix.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hdhomerun_os_posix.h b/hdhomerun_os_posix.h
+index baab8e5..d3dc5cb 100644
+--- a/hdhomerun_os_posix.h
++++ b/hdhomerun_os_posix.h
+@@ -53,7 +53,7 @@ typedef struct {
+ 
+ #define LIBHDHOMERUN_API
+ 
+-#if !defined(alignas)
++#if !defined(alignas) && !defined(__cplusplus)
+ #define alignas(n) __attribute__((aligned(n)))
+ #endif
+ 


### PR DESCRIPTION
This is a draft PR for discussion/consideration.

I'm not entirely convinced this is a useful change, as we don't have any issues with gcc-8.2.0, but I have built RPi1/RPi2/Generic (`image` + all addons) successfully with this PR, which may be useful for bleeding-edge self builders.

gcc-9.1.0 is expected April-ish, however extra testing time with LibreELEC 10 and gcc-8.3.0 between now and then might still be useful in case of any gcc-9.1.0 regressions.

If not, this PR can be closed and cherry-picked for gcc-9.x.0.