### PR TITLE
scripts/build: fix broken sym link after #3328

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -480,7 +480,7 @@ debug_strip() {
 }
 
 init_package_cache() {
-  local _ANCHOR="@?+?@" DIR
+  local _ANCHOR="@?+?@"
   local temp_global temp_local
 
   # If the package caches are unset, then populate them
@@ -488,22 +488,16 @@ init_package_cache() {
     temp_global="$(mktemp)"
     temp_local="$(mktemp)"
 
-    # cache project/device folder for a package
-    if [ -n $DEVICE ]; then
-      for DIR in $(find $ROOT/projects/$PROJECT/devices/$DEVICE/packages -type d 2>/dev/null); do
-        [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${temp_local}"
-      done
+    # cache project/device folder for packages
+    if [ -n "${DEVICE}" ]; then
+      find "${ROOT}/projects/${PROJECT}/devices/${DEVICE}/packages" -type f -name package.mk 2>/dev/null | sed "s#/package\.mk\$#${_ANCHOR}#" >> "${temp_local}"
     fi
 
-    # cache project folder for a package
-    for DIR in $(find $ROOT/projects/$PROJECT/packages -type d 2>/dev/null); do
-      [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${temp_local}"
-    done
+    # cache project folder for packages
+    find "${ROOT}/projects/${PROJECT}/packages" -type f -name package.mk 2>/dev/null | sed "s#/package\.mk\$#${_ANCHOR}#" >> "${temp_local}"
 
     # cache packages folder
-    for DIR in $(find $ROOT/$PACKAGES -type d 2>/dev/null); do
-      [ -r "$DIR/package.mk" ] && echo "${DIR}${_ANCHOR}" >> "${temp_global}"
-    done
+    find "${ROOT}/${PACKAGES}" -type f -name package.mk 2>/dev/null | sed "s#/package\.mk\$#${_ANCHOR}#" >> "${temp_global}"
 
     _CACHE_PACKAGE_LOCAL="${BUILD}/.cache_package_local"
     _CACHE_PACKAGE_GLOBAL="${BUILD}/.cache_package_global"
@@ -606,14 +600,14 @@ check_device() {
 
 check_arch() {
   local dashes="===========================" arch_err_msg linux_config_dir
-  if [ -d ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/linux ]; then
+  if [ -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/linux" ]; then
     linux_config_dir="${PROJECT_DIR}/${PROJECT}/devices/$DEVICE/linux"
   else
     linux_config_dir="${PROJECT_DIR}/${PROJECT}/linux"
   fi
 
-  if [ ! -e $linux_config_dir/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf ] &&
-     ! ls $linux_config_dir/*/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf &>/dev/null; then
+  if [ ! -e "$linux_config_dir/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf" ] &&
+       ! ls "$linux_config_dir/"*/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf &>/dev/null; then
     arch_err_msg="\n $dashes$dashes$dashes"
     arch_err_msg="${arch_err_msg}\n ERROR: Architecture not found, use a valid Architecture"
     arch_err_msg="${arch_err_msg}\n for your project or create a new config"

--- a/config/multithread
+++ b/config/multithread
@@ -26,11 +26,6 @@ json_worker() {
 
     [[ ${pkgpath} =~ ^${ROOT}/${PACKAGES}/ ]] && hierarchy="global" || hierarchy="local"
 
-    if [ -n "$PKG_ARCH" ]; then
-      listcontains "$PKG_ARCH" "!$TARGET_ARCH" && continue
-      listcontains "$PKG_ARCH" "$TARGET_ARCH" || listcontains "$PKG_ARCH" "any" || continue
-    fi
-
     cat <<EOF
   {
     "name": "${PKG_NAME}",

--- a/config/multithread
+++ b/config/multithread
@@ -61,7 +61,7 @@ package_worker() {
 
   . config/options "${pkgname}"
 
-  [ ! -f "${THREAD_CONTROL}/pid" ] && echo "${PARALLEL_PID}" >"${THREAD_CONTROL}/pid"
+  [ ! -f "${THREAD_CONTROL}/parallel.pid" ] && echo "${PARALLEL_PID}" >"${THREAD_CONTROL}/parallel.pid"
 
   ${SCRIPTS}/${task} ${pkgname} 2>&1 && result=0 || result=1
 
@@ -141,7 +141,7 @@ EOF
 export -f package_worker
 
 start_multithread_build() {
-  local singlethread buildopts
+  local singlethread buildopts result=0
 
   # init thread control folder
   rm -rf "${THREAD_CONTROL}"
@@ -174,12 +174,18 @@ start_multithread_build() {
 
   cat ${_CACHE_PACKAGE_GLOBAL} ${_CACHE_PACKAGE_LOCAL} | \
     ${TOOLCHAIN}/bin/parallel --plain --no-notice --max-args 30 --halt now,fail=1 json_worker | \
-    ${SCRIPTS}/genbuildplan.py --no-reorder --show-wants --build ${@} > "${THREAD_CONTROL}"/plan || return
+    ${SCRIPTS}/genbuildplan.py --no-reorder --show-wants --build ${@} > "${THREAD_CONTROL}"/plan || result=1
 
-  cat "${THREAD_CONTROL}"/plan | awk '{print $1 " " $2}' | \
-    MTBUILDSTART=$(date +%s) MTWITHLOCKS=yes ${TOOLCHAIN}/bin/parallel \
-      --plain --no-notice --max-procs ${THREADCOUNT} --joblog="${THREAD_CONTROL}/joblog" --plus ${buildopts} \
-      package_worker {%} {#} {##} {} || return
+  if [ ${result} -eq 0 ]; then
+    cat "${THREAD_CONTROL}"/plan | awk '{print $1 " " $2}' | \
+      MTBUILDSTART=$(date +%s) MTWITHLOCKS=yes ${TOOLCHAIN}/bin/parallel \
+        --plain --no-notice --max-procs ${THREADCOUNT} --joblog="${THREAD_CONTROL}/joblog" --plus ${buildopts} \
+        package_worker {%} {#} {##} {} || result=1
+
+    rm -f "${THREAD_CONTROL}/parallel.pid"
+  fi
 
   set +o pipefail
+
+  return ${result}
 }

--- a/packages/databases/mysql/package.mk
+++ b/packages/databases/mysql/package.mk
@@ -79,7 +79,7 @@ post_makeinstall_target() {
   sed -i "s|pkgincludedir=.*|pkgincludedir=\'$SYSROOT_PREFIX/usr/include/mysql\'|" scripts/mysql_config
   sed -i "s|pkglibdir=.*|pkglibdir=\'$SYSROOT_PREFIX/usr/lib/mysql\'|" scripts/mysql_config
   cp scripts/mysql_config $SYSROOT_PREFIX/usr/bin
-  ln -sf $SYSROOT_PREFIX/usr/bin/mysql_config $TOOLCHAIN/bin/mysql_config
+  cp scripts/mysql_config $TOOLCHAIN/bin/mysql_config
 
   rm -rf $INSTALL
 }

--- a/scripts/build
+++ b/scripts/build
@@ -439,6 +439,12 @@ done
 for i in $(find "${SYSROOT_PREFIX}/usr"/{lib,share} -type f -name "*.cmake" 2>/dev/null); do
   sed -e "s#${SYSROOT_PREFIX}/usr#${PKG_ORIG_SYSROOT_PREFIX}/usr#g" -i "${i}"
 done
+for i in $(find "${SYSROOT_PREFIX}" -type l 2>/dev/null); do
+  _tmp="$(readlink -m "${i}")"
+  if [[ ${_tmp} =~ ^${SYSROOT_PREFIX}/ ]]; then
+    ln -sf "${_tmp/${SYSROOT_PREFIX}\//${PKG_ORIG_SYSROOT_PREFIX}\/}" "${i}"
+  fi
+done
 
 # Transfer the new sysroot content to the shared sysroot
 mkdir -p "${PKG_ORIG_SYSROOT_PREFIX}"

--- a/scripts/build_mt
+++ b/scripts/build_mt
@@ -6,6 +6,8 @@
 . config/options ""
 . config/multithread
 
+${SCRIPTS}/checkdeps
+
 # Setup both toolchain cmake configs to avoid potentially racy behaviour later.
 # Use a fork for host to isolate any variable modifications.
 ( setup_toolchain host )

--- a/tools/dashboard
+++ b/tools/dashboard
@@ -10,11 +10,16 @@ if [ -n "${PROJECT}" -a "$1" != "auto" ]; then
 fi
 
 _find_latest_tcdir() {
+  local IFS=$'\n'
+
   if [ -n "${THREAD_CONTROL}" ]; then
     echo "${THREAD_CONTROL}"
   else
-    ls -1tdr "${PWD}"/build.*/.threads 2>/dev/null | tail -1
+    for dir in $(ls -1td "${PWD}"/build.*/.threads 2>/dev/null); do
+      [ -f "${dir}/parallel.pid" ] && echo "${dir}" && break
+    done
   fi
+  return 0
 }
 
 while [ : ]; do
@@ -24,7 +29,7 @@ while [ : ]; do
     tcdir="$(_find_latest_tcdir)"
 
     if [ -n "${tcdir}" ]; then
-      pid="$(cat "${tcdir}/pid" 2>/dev/null || true)"
+      pid="$(cat "${tcdir}/parallel.pid" 2>/dev/null || true)"
       [ -n "${pid}" ] && ps -p ${pid} &>/dev/null && break
     fi
 

--- a/tools/viewplan
+++ b/tools/viewplan
@@ -24,6 +24,6 @@ command -v ${PARALLEL_BIN} >/dev/null || PARALLEL_BIN=fake_parallel
 set -o pipefail
 
 cat ${_CACHE_PACKAGE_GLOBAL} ${_CACHE_PACKAGE_LOCAL} | \
-  ${PARALLEL_BIN} --plain --no-notice --max-args 30 json_worker --halt now,fail=1 | \
+  ${PARALLEL_BIN} --plain --no-notice --max-args 30 --halt now,fail=1 json_worker | \
   ${SCRIPTS}/genbuildplan.py --no-reorder --show-wants --build ${@:-image} --warn-invalid ${GENFLAGS} || \
     die "FAILURE: Unable to generate plan"


### PR DESCRIPTION
~I don't know if anyone still builds `mysql` but this change is probably required when using the isolated sysroot.~

Edit 1: This PR was initially prompted by code in `mysql` which will create a broken sym link. I subsequently discovered that `open-vm-tools` does something similar, but during `make`, so we have to fix that sym link during the transfer to the shared sysroot. The fix for `open-vm-tools` also fixes `mysql` so that change is now dropped.

Edit 2: So looking at `mysql` again, it's creating the broken sym link in `$TOOLCHAIN/usr/bin` so that still needs to be fixed, as the change to `scripts/build` can only fix sym links where the link is within the isolated sysroot. Easiest solution is to just copy the `mysql` file rather than create a sym link.