### PR TITLE
texturecache.py: update to texturecache.py-2.4.9 [backport]

### DIFF
--- a/packages/tools/texturecache.py/package.mk
+++ b/packages/tools/texturecache.py/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="texturecache.py"
-PKG_VERSION="2.4.8"
-PKG_SHA256="e4279ee57e0afd3875c9cdbdc732598b0ca12722e0652271887700b0138e3c26"
+PKG_VERSION="2.4.9"
+PKG_SHA256="33e9f5faf07298a7da4136ac8f2a9310d486b267b3931b271070518b36ff9865"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/MilhouseVH/texturecache.py"
 PKG_URL="https://github.com/MilhouseVH/$PKG_NAME/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Backport of #3345 