### PR TITLE
config/options: ban spaces in paths

### DIFF
--- a/config/options
+++ b/config/options
@@ -4,6 +4,12 @@ if [[ "${EUID}" -eq 0 ]]; then
   exit 1
 fi
 
+# Spaces in paths are verboten
+if [[ ${PWD} =~ [[:space:]] ]]; then
+  echo "Building in a folder that includes spaces is NOT supported. Use a folder without spaces." 1>&2
+  exit 1
+fi
+
 # set default language for buildsystem
 export LC_ALL=C
 


### PR DESCRIPTION
We've been trying to support spaces in paths for quite a while, and it's not really working.

It's rarely - if ever - been a problem, as I can't really recall anyone ever complaining about the lack of spaces support so I'm not entirely sure why we have gone down this rabbit hole trying to fix what wasn't really an issue (but I will take responsibility for that, as it's something I've brought it up in reviews in the past).

This change takes the completely opposite approach, and now aborts the build if a space is detected in the path - it's brutally simple, and solves all the issues.

Over time we can even roll back some of the changes that attempted to add space-support as these changes often made the code more complicated, and/or ugly.

I'll be adding an entry to #3055 to say that it shouldn't be necessary to quote paths once we are sure they won't include spaces.