### PR TITLE
brcmfmac_sdio-firmware-rpi: fix race between service and /dev/serial1

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/system.d/brcmfmac_sdio-firmware.service
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/system.d/brcmfmac_sdio-firmware.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Broadcom sdio firmware update for BCM43430A1
-ConditionPathExists=/dev/serial1
-After=network.target
+Requires=dev-serial1.device
+After=dev-serial1.device
 
 [Service]
 Type=simple


### PR DESCRIPTION
I noticed that Bluetooth isn't always being enabled on a RPi3+ (and probably RPi3 too) - LibreELEC will sometimes try to configure the BT hardware before `/dev/serial1` is available:

Not working:
```
LibreELEC (official): 9.0.1 (RPi2.arm)
rpi22:~ # systemctl status brcmfmac_sdio-firmware.service
? brcmfmac_sdio-firmware.service - Broadcom sdio firmware update for BCM43430A1
   Loaded: loaded (/usr/lib/systemd/system/brcmfmac_sdio-firmware.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
Condition: start condition failed at Fri 2018-06-22 12:11:51 BST; 8 months 11 days ago
           +- ConditionPathExists=/dev/serial1 was not met
```

Reboot the RPi3+, and BT is now working:
```
LibreELEC (official): 9.0.1 (RPi2.arm)
rpi22:~ # systemctl status brcmfmac_sdio-firmware.service
? brcmfmac_sdio-firmware.service - Broadcom sdio firmware update for BCM43430A1
   Loaded: loaded (/usr/lib/systemd/system/brcmfmac_sdio-firmware.service; disabled; vendor preset: disabled)
   Active: active (exited) since Fri 2018-06-22 12:11:51 BST; 8 months 11 days ago
  Process: 655 ExecStart=/usr/bin/rpi-btuart (code=exited, status=0/SUCCESS)
 Main PID: 655 (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/brcmfmac_sdio-firmware.service
           +-857 /usr/bin/hciattach /dev/serial1 bcm43xx 3000000 flow - b8:27:eb:0e:ae:c5

Jun 22 12:11:51 rpi22 systemd[1]: Started Broadcom sdio firmware update for BCM43430A1.
Jun 22 12:11:58 rpi22 rpi-btuart[655]: bcm43xx_init
Jun 22 12:11:58 rpi22 rpi-btuart[655]: Flash firmware /etc/firmware/brcm/BCM4345C0.hcd
Jun 22 12:11:58 rpi22 rpi-btuart[655]: Set BDADDR UART: b8:27:eb:0e:ae:c5
Jun 22 12:11:58 rpi22 rpi-btuart[655]: Set Controller UART speed to 3000000 bit/s
Jun 22 12:11:58 rpi22 rpi-btuart[655]: Device setup complete
```

The fix is based on the [upstream](https://github.com/RPi-Distro/pi-bluetooth/blob/051881526027f38f0f031d7185bcd2152425d8db/debian/pi-bluetooth.hciuart.service) service, and it seems to be 100% reliable so far.

This probably needs a backport, unless anyone thinks there might be a problem?