### PR TITLE
docker: updated to 18.09.5

### DIFF
--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.2.2"
-PKG_SHA256="91d480816986d74ff4fa7dd0412c787615fa705975b18fa4079c333b137c653f"
+PKG_VERSION="1.2.6"
+PKG_SHA256="f2d578b743fb9faa5b3477b7cf4b33d00501087043a53b27754f14bbe741f891"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.tools/"
 PKG_URL="https://github.com/containerd/containerd/archive/v$PKG_VERSION.tar.gz"
@@ -13,14 +13,14 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 pre_make_target() {
-  case $TARGET_ARCH in
+  case ${TARGET_ARCH} in
     x86_64)
       export GOARCH=amd64
       ;;
     arm)
       export GOARCH=arm
 
-      case $TARGET_CPU in
+      case ${TARGET_CPU} in
         arm1176jzf-s)
           export GOARM=6
           ;;
@@ -37,26 +37,26 @@ pre_make_target() {
   export GOOS=linux
   export CGO_ENABLED=1
   export CGO_NO_EMULATION=1
-  export CGO_CFLAGS=$CFLAGS
+  export CGO_CFLAGS=${CFLAGS}
   export CONTAINERD_VERSION=v${PKG_VERSION}
   export CONTAINERD_REVISION=${PKG_VERSION}
   export CONTAINERD_PKG=github.com/containerd/containerd
   export LDFLAGS="-w -extldflags -static -X ${CONTAINERD_PKG}/version.Version=${CONTAINERD_VERSION} -X ${CONTAINERD_PKG}/version.Revision=${CONTAINERD_REVISION} -X ${CONTAINERD_PKG}/version.Package=${CONTAINERD_PKG} -extld $CC"
-  export GOLANG=$TOOLCHAIN/lib/golang/bin/go
-  export GOPATH=$PKG_BUILD/.gopath
-  export GOROOT=$TOOLCHAIN/lib/golang
-  export PATH=$PATH:$GOROOT/bin
+  export GOLANG=${TOOLCHAIN}/lib/golang/bin/go
+  export GOPATH=${PKG_BUILD}/.gopath
+  export GOROOT=${TOOLCHAIN}/lib/golang
+  export PATH=${PATH}:${GOROOT}/bin
 
-  mkdir -p $PKG_BUILD/.gopath
-  if [ -d $PKG_BUILD/vendor ]; then
-    mv $PKG_BUILD/vendor $PKG_BUILD/.gopath/src
+  mkdir -p ${PKG_BUILD}/.gopath
+  if [ -d ${PKG_BUILD}/vendor ]; then
+    mv ${PKG_BUILD}/vendor ${PKG_BUILD}/.gopath/src
   fi
 
-  ln -fs $PKG_BUILD $PKG_BUILD/.gopath/src/github.com/containerd/containerd
+  ln -fs ${PKG_BUILD} ${PKG_BUILD}/.gopath/src/github.com/containerd/containerd
 }
 
 make_target() {
   mkdir -p bin
-  $GOLANG build -v -o bin/containerd      -a -tags "static_build no_btrfs" -ldflags "$LDFLAGS" ./cmd/containerd
-  $GOLANG build -v -o bin/containerd-shim -a -tags "static_build no_btrfs" -ldflags "$LDFLAGS" ./cmd/containerd-shim
+  ${GOLANG} build -v -o bin/containerd      -a -tags "static_build no_btrfs" -ldflags "${LDFLAGS}" ./cmd/containerd
+  ${GOLANG} build -v -o bin/containerd-shim -a -tags "static_build no_btrfs" -ldflags "${LDFLAGS}" ./cmd/containerd-shim
 }

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.11.2"
-PKG_SHA256="7854866866c57394217ae5facc41944dff2a7386a064b2bcc4149f7c68e3c79a"
+PKG_VERSION="1.12.3"
+PKG_SHA256="b710a65982e9001ef99a167cf6e8636e46ec36a10e487e7c1c7384cdcd6fcd7c"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"
@@ -21,7 +21,7 @@ PKG_TOOLCHAIN="manual"
 
 configure_host() {
   export GOOS=linux
-  export GOROOT_FINAL=$TOOLCHAIN/lib/golang
+  export GOROOT_FINAL=${TOOLCHAIN}/lib/golang
   if [ -x /usr/lib/go/bin/go ]; then
     export GOROOT_BOOTSTRAP=/usr/lib/go
   else
@@ -31,16 +31,16 @@ configure_host() {
 }
 
 make_host() {
-  cd $PKG_BUILD/src
+  cd ${PKG_BUILD}/src
   bash make.bash --no-banner
 }
 
 pre_makeinstall_host() {
   # need to cleanup old golang version when updating to a new version
-  rm -rf $TOOLCHAIN/lib/golang
+  rm -rf ${TOOLCHAIN}/lib/golang
 }
 
 makeinstall_host() {
-  mkdir -p $TOOLCHAIN/lib/golang
-  cp -av $PKG_BUILD/* $TOOLCHAIN/lib/golang/
+  mkdir -p ${TOOLCHAIN}/lib/golang
+  cp -av ${PKG_BUILD}/* ${TOOLCHAIN}/lib/golang/
 }

--- a/packages/addons/addon-depends/go/patches/go-0001-add-ca-cert-location.patch
+++ b/packages/addons/addon-depends/go/patches/go-0001-add-ca-cert-location.patch
@@ -1,11 +1,10 @@
-diff -Naur go-1.9.2.orig/src/crypto/x509/root_unix.go go-1.9.2/src/crypto/x509/root_unix.go
---- go-1.9.2.orig/src/crypto/x509/root_unix.go	2017-11-03 14:58:53.655965257 +0100
-+++ go-1.9.2/src/crypto/x509/root_unix.go	2017-11-03 14:59:16.923786983 +0100
-@@ -19,6 +19,7 @@
- 	"/usr/local/share/certs",       // FreeBSD
+--- a/src/crypto/x509/root_unix.go
++++ b/src/crypto/x509/root_unix.go
+@@ -20,6 +20,7 @@
  	"/etc/pki/tls/certs",           // Fedora/RHEL
  	"/etc/openssl/certs",           // NetBSD
-+	"/etc/ssl",                     // LibreELEC
+ 	"/var/ssl/certs",               // AIX
++    "/etc/ssl",                     // LibreELEC
  }
  
  const (

--- a/packages/addons/addon-depends/libnetwork/package.mk
+++ b/packages/addons/addon-depends/libnetwork/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnetwork"
-PKG_VERSION="2cfbf9b1f98162a55829a21cc603c76072a75382"
-PKG_SHA256="12986c29a112f989886ceec675f5b11ccd001dcdb1c17a49835970c56aa406d0"
+PKG_VERSION="4725f2163fb214a6312f3beae5991f838ec36326"
+PKG_SHA256="049bddc1e584f30c29e0fed8716b3c7023d4bb31789d7c3aa48d17b979f1522b"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/docker/libnetwork"
 PKG_URL="https://github.com/docker/libnetwork/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="96ec2177ae841256168fcf76954f7177af9446eb"
-PKG_SHA256="96040a78008abad13b412863813011f4cbe55407e513acad1d8509f4ab9b39cd"
+PKG_VERSION="v1.0.0-rc7"
+PKG_SHA256="e8388b812d93a8a131a2a2fdd851847295c8e341721002940dadd2999fb81b51"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,12 @@
+125
+- Update to docker 18.09.5
+
+124
+- Update to docker 18.09.4
+
+123
+- Update to docker 18.09.3
+
 122
 - Update to docker 18.09.1
 

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_VERSION="18.09.1"
-PKG_SHA256="9eadb1eae1954b0322aadf6505f5397d1b1eccf6395ab511cadf8e6975cfc576"
-PKG_REV="122"
+PKG_VERSION="18.09.5"
+PKG_SHA256="57f2a5d3374d86a8eb680c91df4351f5cb648351b9b32520c6fd2d66e7e97fd5"
+PKG_REV="125"
 PKG_ARCH="any"
 PKG_ADDON_PROJECTS="any !WeTek_Core !WeTek_Play"
 PKG_LICENSE="ASL"
@@ -29,14 +29,14 @@ configure_target() {
                            exclude_graphdriver_btrfs \
                            journald"
 
-  case $TARGET_ARCH in
+  case ${TARGET_ARCH} in
     x86_64)
       export GOARCH=amd64
       ;;
     arm)
       export GOARCH=arm
 
-      case $TARGET_CPU in
+      case ${TARGET_CPU} in
         arm1176jzf-s)
           export GOARM=6
           ;;
@@ -53,54 +53,54 @@ configure_target() {
   export GOOS=linux
   export CGO_ENABLED=1
   export CGO_NO_EMULATION=1
-  export CGO_CFLAGS=$CFLAGS
+  export CGO_CFLAGS=${CFLAGS}
   export LDFLAGS="-w -linkmode external -extldflags -Wl,--unresolved-symbols=ignore-in-shared-libs -extld $CC"
-  export GOLANG=$TOOLCHAIN/lib/golang/bin/go
-  export GOPATH=$PKG_BUILD/.gopath_cli:$PKG_BUILD/.gopath
-  export GOROOT=$TOOLCHAIN/lib/golang
-  export PATH=$PATH:$GOROOT/bin
+  export GOLANG=${TOOLCHAIN}/lib/golang/bin/go
+  export GOPATH=${PKG_BUILD}/.gopath_cli:${PKG_BUILD}/.gopath
+  export GOROOT=${TOOLCHAIN}/lib/golang
+  export PATH=${PATH}:${GOROOT}/bin
 
-  mkdir -p $PKG_BUILD/.gopath
-  mkdir -p $PKG_BUILD/.gopath_cli
+  mkdir -p ${PKG_BUILD}/.gopath
+  mkdir -p ${PKG_BUILD}/.gopath_cli
 
-  PKG_ENGINE_PATH=$PKG_BUILD/components/engine
-  PKG_CLI_PATH=$PKG_BUILD/components/cli
+  PKG_ENGINE_PATH=${PKG_BUILD}/components/engine
+  PKG_CLI_PATH=${PKG_BUILD}/components/cli
 
-  if [ -d $PKG_ENGINE_PATH/vendor ]; then
-    mv $PKG_ENGINE_PATH/vendor $PKG_BUILD/.gopath/src
+  if [ -d ${PKG_ENGINE_PATH}/vendor ]; then
+    mv ${PKG_ENGINE_PATH}/vendor ${PKG_BUILD}/.gopath/src
   fi
 
-  if [ -d $PKG_CLI_PATH/vendor ]; then
-    mv $PKG_CLI_PATH/vendor $PKG_BUILD/.gopath_cli/src
+  if [ -d ${PKG_CLI_PATH}/vendor ]; then
+    mv ${PKG_CLI_PATH}/vendor ${PKG_BUILD}/.gopath_cli/src
   fi
 
   # Fix missing/incompatible .go files
-  cp -rf $PKG_BUILD/.gopath/src/github.com/moby/buildkit/frontend/* $PKG_BUILD/.gopath_cli/src/github.com/moby/buildkit/frontend
-  cp -rf $PKG_BUILD/.gopath/src/github.com/moby/buildkit/frontend/gateway/* $PKG_BUILD/.gopath_cli/src/github.com/moby/buildkit/frontend/gateway
-  cp -rf $PKG_BUILD/.gopath/src/github.com/moby/buildkit/solver/* $PKG_BUILD/.gopath_cli/src/github.com/moby/buildkit/solver
-  cp -rf $PKG_BUILD/.gopath/src/github.com/moby/buildkit/util/progress/* $PKG_BUILD/.gopath_cli/src/github.com/moby/buildkit/util/progress
-  cp -rf $PKG_BUILD/.gopath/src/github.com/docker/swarmkit/manager/* $PKG_BUILD/.gopath_cli/src/github.com/docker/swarmkit/manager
-  cp -rf $PKG_BUILD/.gopath/src/github.com/coreos/etcd/raft/* $PKG_BUILD/.gopath_cli/src/github.com/coreos/etcd/raft
-  cp -rf $PKG_BUILD/.gopath/src/golang.org/x/* $PKG_BUILD/.gopath_cli/src/golang.org/x
-  cp -rf $PKG_BUILD/.gopath/src/github.com/opencontainers/runtime-spec/specs-go/* $PKG_BUILD/.gopath_cli/src/github.com/opencontainers/runtime-spec/specs-go
+  cp -rf ${PKG_BUILD}/.gopath/src/github.com/moby/buildkit/frontend/*               ${PKG_BUILD}/.gopath_cli/src/github.com/moby/buildkit/frontend
+  cp -rf ${PKG_BUILD}/.gopath/src/github.com/moby/buildkit/frontend/gateway/*       ${PKG_BUILD}/.gopath_cli/src/github.com/moby/buildkit/frontend/gateway
+  cp -rf ${PKG_BUILD}/.gopath/src/github.com/moby/buildkit/solver/*                 ${PKG_BUILD}/.gopath_cli/src/github.com/moby/buildkit/solver
+  cp -rf ${PKG_BUILD}/.gopath/src/github.com/moby/buildkit/util/progress/*          ${PKG_BUILD}/.gopath_cli/src/github.com/moby/buildkit/util/progress
+  cp -rf ${PKG_BUILD}/.gopath/src/github.com/docker/swarmkit/manager/*              ${PKG_BUILD}/.gopath_cli/src/github.com/docker/swarmkit/manager
+  cp -rf ${PKG_BUILD}/.gopath/src/github.com/coreos/etcd/raft/*                     ${PKG_BUILD}/.gopath_cli/src/github.com/coreos/etcd/raft
+  cp -rf ${PKG_BUILD}/.gopath/src/golang.org/x/*                                    ${PKG_BUILD}/.gopath_cli/src/golang.org/x
+  cp -rf ${PKG_BUILD}/.gopath/src/github.com/opencontainers/runtime-spec/specs-go/* ${PKG_BUILD}/.gopath_cli/src/github.com/opencontainers/runtime-spec/specs-go
 
-  rm -rf $PKG_BUILD/.gopath_cli/src/github.com/containerd/containerd
-  mkdir -p $PKG_BUILD/.gopath_cli/src/github.com/containerd/containerd
-  cp -rf $PKG_BUILD/.gopath/src/github.com/containerd/containerd/* $PKG_BUILD/.gopath_cli/src/github.com/containerd/containerd
+  rm -rf   ${PKG_BUILD}/.gopath_cli/src/github.com/containerd/containerd
+  mkdir -p ${PKG_BUILD}/.gopath_cli/src/github.com/containerd/containerd
+  cp -rf   ${PKG_BUILD}/.gopath/src/github.com/containerd/containerd/* ${PKG_BUILD}/.gopath_cli/src/github.com/containerd/containerd
 
-  rm -rf $PKG_BUILD/.gopath_cli/src/github.com/containerd/continuity
-  mkdir -p $PKG_BUILD/.gopath_cli/src/github.com/containerd/continuity
-  cp -rf $PKG_BUILD/.gopath/src/github.com/containerd/continuity/* $PKG_BUILD/.gopath_cli/src/github.com/containerd/continuity
+  rm -rf   ${PKG_BUILD}/.gopath_cli/src/github.com/containerd/continuity
+  mkdir -p ${PKG_BUILD}/.gopath_cli/src/github.com/containerd/continuity
+  cp -rf   ${PKG_BUILD}/.gopath/src/github.com/containerd/continuity/* ${PKG_BUILD}/.gopath_cli/src/github.com/containerd/continuity
 
-  mkdir -p $PKG_BUILD/.gopath_cli/src/github.com/docker/docker/builder
-  cp -rf $PKG_ENGINE_PATH/builder/* $PKG_BUILD/.gopath_cli/src/github.com/docker/docker/builder
+  mkdir -p ${PKG_BUILD}/.gopath_cli/src/github.com/docker/docker/builder
+  cp -rf   ${PKG_ENGINE_PATH}/builder/* ${PKG_BUILD}/.gopath_cli/src/github.com/docker/docker/builder
 
-  if [ ! -L $PKG_BUILD/.gopath/src/github.com/docker/docker ];then
-    ln -fs $PKG_ENGINE_PATH $PKG_BUILD/.gopath/src/github.com/docker/docker
+  if [ ! -L ${PKG_BUILD}/.gopath/src/github.com/docker/docker ];then
+    ln -fs  ${PKG_ENGINE_PATH} ${PKG_BUILD}/.gopath/src/github.com/docker/docker
   fi
 
-  if [ ! -L $PKG_BUILD/.gopath_cli/src/github.com/docker/cli ];then
-    ln -fs $PKG_CLI_PATH $PKG_BUILD/.gopath_cli/src/github.com/docker/cli
+  if [ ! -L ${PKG_BUILD}/.gopath_cli/src/github.com/docker/cli ];then
+    ln -fs ${PKG_CLI_PATH} ${PKG_BUILD}/.gopath_cli/src/github.com/docker/cli
   fi
 
   # used for docker version
@@ -108,9 +108,9 @@ configure_target() {
   export VERSION=${PKG_VERSION}
   export BUILDTIME="$(date --utc)"
 
-  cd $PKG_ENGINE_PATH
+  cd ${PKG_ENGINE_PATH}
   bash hack/make/.go-autogen
-  cd $PKG_BUILD
+  cd ${PKG_BUILD}
 }
 
 make_target() {
@@ -118,8 +118,8 @@ make_target() {
   PKG_CLI_FLAGS="-X 'github.com/docker/cli/cli.Version=${VERSION}'"
   PKG_CLI_FLAGS="${PKG_CLI_FLAGS} -X 'github.com/docker/cli/cli.GitCommit=${GITCOMMIT}'"
   PKG_CLI_FLAGS="${PKG_CLI_FLAGS} -X 'github.com/docker/cli/cli.BuildTime=${BUILDTIME}'"
-  $GOLANG build -v -o bin/docker -a -tags "$DOCKER_BUILDTAGS" -ldflags "$LDFLAGS ${PKG_CLI_FLAGS}" ./components/cli/cmd/docker
-  $GOLANG build -v -o bin/dockerd -a -tags "$DOCKER_BUILDTAGS" -ldflags "$LDFLAGS" ./components/engine/cmd/dockerd
+  ${GOLANG} build -v -o bin/docker -a -tags "${DOCKER_BUILDTAGS}" -ldflags "${LDFLAGS} ${PKG_CLI_FLAGS}" ./components/cli/cmd/docker
+  ${GOLANG} build -v -o bin/dockerd -a -tags "${DOCKER_BUILDTAGS}" -ldflags "${LDFLAGS}" ./components/engine/cmd/dockerd
 }
 
 makeinstall_target() {
@@ -127,20 +127,20 @@ makeinstall_target() {
 }
 
 addon() {
-  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin
-    cp -P $PKG_BUILD/bin/docker $ADDON_BUILD/$PKG_ADDON_ID/bin
-    cp -P $PKG_BUILD/bin/dockerd $ADDON_BUILD/$PKG_ADDON_ID/bin
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P ${PKG_BUILD}/bin/docker ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P ${PKG_BUILD}/bin/dockerd ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # containerd
-    cp -P $(get_build_dir containerd)/bin/containerd $ADDON_BUILD/$PKG_ADDON_ID/bin/containerd
-    cp -P $(get_build_dir containerd)/bin/containerd-shim $ADDON_BUILD/$PKG_ADDON_ID/bin/containerd-shim
+    cp -P $(get_build_dir containerd)/bin/containerd ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/containerd
+    cp -P $(get_build_dir containerd)/bin/containerd-shim ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/containerd-shim
 
     # libnetwork
-    cp -P $(get_build_dir libnetwork)/bin/docker-proxy $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-proxy
+    cp -P $(get_build_dir libnetwork)/bin/docker-proxy ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/docker-proxy
 
     # runc
-    cp -P $(get_build_dir runc)/bin/runc $ADDON_BUILD/$PKG_ADDON_ID/bin/runc
+    cp -P $(get_build_dir runc)/bin/runc ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/runc
 
     # tini
-    cp -P $(get_build_dir tini)/.$TARGET_NAME/tini-static $ADDON_BUILD/$PKG_ADDON_ID/bin/docker-init
+    cp -P $(get_build_dir tini)/.${TARGET_NAME}/tini-static ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/docker-init
 }


### PR DESCRIPTION
Compiled & tested on Generic builds with my [PCSX2 Docker image](https://cloud.docker.com/repository/docker/5schatten/arch-pcsx2/general).

18.09.3 changelog: https://docs.docker.com/engine/release-notes/#18093
- Adresses https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736

18.09.4 changelog: https://docs.docker.com/engine/release-notes/#18094

18.09.5 changelog: https://docs.docker.com/engine/release-notes/#18095