### PR TITLE
brcmfmac_sdio-firmware-rpi: fix delay on non-wifi enabled devices

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/system.d/brcmfmac_sdio-firmware.service
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/system.d/brcmfmac_sdio-firmware.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Broadcom sdio firmware update for BCM43430A1
+ConditionFileNotEmpty=/proc/device-tree/soc/gpio@7e200000/bt_pins/brcm,pins
 Requires=dev-serial1.device
-After=dev-serial1.device
+After=dev-serial1.device network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
#3354 introduces a startup delay of over 90 seconds on devices without built-in WiFi/Bluetooth (ie. RPi0, RPi1, RPi2) as services such as Kodi will wait for `network.target` to be reached, which is itself blocked while waiting for `brcmfmac_sdio-firmware-rpi` service which cannot start until device `dev-serial1` becomes available, or times out.

The [upstream](https://github.com/RPi-Distro/pi-bluetooth/blob/051881526027f38f0f031d7185bcd2152425d8db/debian/pi-bluetooth.hciuart.service) service includes a condition check which doesn't really work as the service still blocks while waiting for the `dev-serial1` job to start, which never happens on RPi0/1/2 so the service eventually times out, but I'll include it anyway as it shouldn't do any harm. Likely not an issue on upstream due to different dependencies. However my understanding is that the condition should mean the service silently fails rather, but that doesn't seem to be happening, it still blocks on the device.

Scheduling this service after `network.target` avoids blocking `network.target` - eventually this service will fail after 90 seconds once the `dev-serial1` job times out, or Bluetooth will be configured concurrently with other network-dependent services (eg. Kodi).

```
Mar 07 04:56:20 rpi512 systemd[1]: dev-serial1.device: Job dev-serial1.device/start timed out.
Mar 07 04:56:20 rpi512 systemd[1]: Timed out waiting for device dev-serial1.device.
Mar 07 04:56:20 rpi512 systemd[1]: Dependency failed for Broadcom sdio firmware update for BCM43430A1.
Mar 07 04:56:20 rpi512 systemd[1]: brcmfmac_sdio-firmware.service: Job brcmfmac_sdio-firmware.service/start failed with result 'dependency'.
Mar 07 04:56:20 rpi512 systemd[1]: dev-serial1.device: Job dev-serial1.device/start failed with result 'timeout'.
Mar 07 04:56:20 rpi512 systemd[1]: Reached target Network.
Mar 07 04:56:20 rpi512 systemd[1]: Reached target Network is Online.
```