### PR TITLE
Python2: don't install 2to3, clashes with Python3 equivalent

### DIFF
--- a/packages/lang/Python2/patches/Python2-2.7.11-017-dont-install-2to3.patch
+++ b/packages/lang/Python2/patches/Python2-2.7.11-017-dont-install-2to3.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 69b76e7..7a50cc3 100644
+--- a/setup.py
++++ b/setup.py
+@@ -2315,7 +2315,6 @@ def main():
+ 
+           # Scripts to install
+           scripts = ['Tools/scripts/pydoc', 'Tools/scripts/idle',
+-                     'Tools/scripts/2to3',
+                      'Lib/smtpd.py']
+         )
+ 

--- a/scripts/build
+++ b/scripts/build
@@ -448,7 +448,7 @@ done
 
 # Transfer the new sysroot content to the shared sysroot
 mkdir -p "${PKG_ORIG_SYSROOT_PREFIX}"
-cp -PR "${SYSROOT_PREFIX}"/* "${PKG_ORIG_SYSROOT_PREFIX}"
+cp -PRf "${SYSROOT_PREFIX}"/* "${PKG_ORIG_SYSROOT_PREFIX}"
 rm -rf "${SYSROOT_PREFIX}"
 
 export SYSROOT_PREFIX="${PKG_ORIG_SYSROOT_PREFIX}"

--- a/scripts/install_addon
+++ b/scripts/install_addon
@@ -26,7 +26,7 @@ if [ -f $ADDON_INSTALL_DIR/$PKG_ADDON_ID-$ADDONVER.zip ]; then
   if [ "$ADDON_OVERWRITE" = "yes" ]; then
     rm $ADDON_INSTALL_DIR/$PKG_ADDON_ID-$ADDONVER.zip
   else
-    build_msg "CLR_WARNING" "*** WARNING: ${PKG_ADDON_ID}-${ADDONVER}.zip already exists. Not overwrittng it. ***"
+    build_msg "CLR_WARNING" "*** WARNING: ${PKG_ADDON_ID}-${ADDONVER}.zip already exists. Not overwriting it. ***"
     exit 0
   fi
 fi


### PR DESCRIPTION
Noticed this `Python3` failure on Jenkins:
```
(cd /var/lib/jenkins/LE/build2/workspace/Addons/Category/service/snapserver/build.LibreELEC-RK3328.arm-9.1-devel/toolchain/bin; ln -s 2to3-3.7 2to3)
/usr/bin/install -c -m 644 /var/lib/jenkins/LE/build2/workspace/Addons/Category/service/snapserver/build.LibreELEC-RK3328.arm-9.1-devel/Python3-3.7.1/Include/fileutils.h /var/lib/jenkins/LE/build2/workspace/Addons/Category/service/snapserver/build.LibreELEC-RK3328.arm-9.1-devel/toolchain/include/python3.7
/usr/bin/install -c -m 644 /var/lib/jenkins/LE/build2/workspace/Addons/Category/service/snapserver/build.LibreELEC-RK3328.arm-9.1-devel/Python3-3.7.1/Include/floatobject.h /var/lib/jenkins/LE/build2/workspace/Addons/Category/service/snapserver/build.LibreELEC-RK3328.arm-9.1-devel/toolchain/include/python3.7
ln: failed to create symbolic link '2to3': File exists
make: *** [Makefile:1225: bininstall] Error 1
```

`Python2` is also installing `2to3` in toolchain/bin:
```
copying build/scripts-2.7/2to3 -> /var/lib/jenkins/LE/build2/workspace/Addons/Category/service/snapserver/build.LibreELEC-RK3328.arm-9.1-devel/toolchain/bin
```

so if `Python2` finishes before `Python3`, then `Python3` will fail as above.

Obviously we need to prevent `Python2` installing `toolchain/bin/2to3`. I can't find a clean solution so have patched it out for now (only temporary until we bin `Python2` completely).