### PR TITLE
lftp: explicitly disable libidn2 to prevent linking

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/lftp/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/lftp/package.mk
@@ -12,6 +12,7 @@ PKG_LONGDESC="A sophisticated ftp/http client, and a file transfer program suppo
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-nls \
                            --without-gnutls \
+                           --without-libidn2 \
                            --with-openssl \
                            --with-readline=$SYSROOT_PREFIX/usr \
                            --with-zlib=$SYSROOT_PREFIX/usr"


### PR DESCRIPTION
Resolves missing libidn2.so.4 error reported on LE's subreddit.