### PR TITLE
lftp: explicitly disable libidn2 to prevent linking [LE9]

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/lftp/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/lftp/package.mk
@@ -12,6 +12,7 @@ PKG_LONGDESC="A sophisticated ftp/http client, and a file transfer program suppo
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-nls \
                            --without-gnutls \
+                           --without-libidn2 \
                            --with-openssl \
                            --with-readline=$SYSROOT_PREFIX/usr \
                            --with-zlib=$SYSROOT_PREFIX/usr"


### PR DESCRIPTION
~~Backport of #3363~~ No longer a backport, but the alternative to #3373 that keeps libidn2 out of the image for LE9.