### PR TITLE
samba: update to samba-4.9.5

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.9.4"
-PKG_SHA256="6d98a8d8bcccbe788e4bbb406362e6676311aca711a3f3cc9b3a404bb9ff0b4f"
+PKG_VERSION="4.9.5"
+PKG_SHA256="078956d2d98e22011265afd4b7221efe4861067dcba4a031583b01f34d423700"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Changelog: https://www.samba.org/samba/history/samba-4.9.5.html

No security fixes.