### PR TITLE
kodi: set MALLOC_MMAP_THRESHOLD_=8192 for aarch64 kernels

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -34,7 +34,7 @@ KODI_ARGS=""
 
 echo "KODI_ARGS=\"$KODI_ARGS\"" > /run/libreelec/kodi.conf
 
-if [ "$(uname -m)" = "x86_64" -o "$(uname -m)" = "aarch64" ]; then
+if [ "$(uname -m)" = "x86_64" ]; then
   echo "MALLOC_MMAP_THRESHOLD_=524288" >> /run/libreelec/kodi.conf
 else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf


### PR DESCRIPTION
Currently there are no targets that use aarch64 userspace - they run aarch64 kernel and arm userspace. Make them use MALLOC_MMAP_THRESHOLD_=8192 which greatly helps to lower memory fragmentation.

Tests for arm userspace (albeit with arm kernel) were done by @MilhouseVH and 512k is not a good choice: https://forum.kodi.tv/showthread.php?tid=298461&pid=2696616#pid2696616
I suspect that this would also be the case even if kernel is aarch64. My initial, completely non-scientific tests show lower Kodi memory usage after starting (83M vs 55M) and after playing a few videos (ca. 200M vs 85M).