### PR TITLE
util-linux: update to util-linux-2.33.1 + lscpu

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -53,7 +53,8 @@ PKG_CONFIGURE_OPTS_TARGET="$UTILLINUX_CONFIG_DEFAULT \
                            --enable-losetup \
                            --enable-fsck \
                            --enable-fstrim \
-                           --enable-blkid"
+                           --enable-blkid \
+                           --enable-lscpu"
 
 if [ "$SWAP_SUPPORT" = "yes" ]; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-swapon"

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="util-linux"
-PKG_VERSION="2.32.1"
-PKG_SHA256="86e6707a379c7ff5489c218cfaf1e3464b0b95acf7817db0bc5f179e356a67b2"
+PKG_VERSION="2.33.1"
+PKG_SHA256="c14bd9f3b6e1792b90db87696e87ec643f9d63efa0a424f092a5a6b2f2dbef21"
 PKG_LICENSE="GPL"
 PKG_URL="http://www.kernel.org/pub/linux/utils/util-linux/v${PKG_VERSION%.*}/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST="gcc:host pkg-config:host"

--- a/packages/sysutils/util-linux/patches/util-linux-0100-enable-lscpu.patch
+++ b/packages/sysutils/util-linux/patches/util-linux-0100-enable-lscpu.patch
@@ -1,0 +1,17 @@
+diff --git a/configure.ac b/configure.ac
+index a05a294..558851d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1498,7 +1498,11 @@ UL_REQUIRES_BUILD([lsblk], [libsmartcols])
+ AM_CONDITIONAL([BUILD_LSBLK], [test "x$build_lsblk" = xyes])
+ 
+ 
+-UL_BUILD_INIT([lscpu], [check])
++AC_ARG_ENABLE([lscpu],
++  AS_HELP_STRING([--disable-lscpu], [do not build lscpu]),
++  [], [UL_DEFAULT_ENABLE([lscpu], [check])]
++)
++UL_BUILD_INIT([lscpu])
+ UL_REQUIRES_LINUX([lscpu])
+ UL_REQUIRES_BUILD([lscpu], [libsmartcols])
+ UL_REQUIRES_HAVE([lscpu], [cpu_set_t], [cpu_set_t type])


### PR DESCRIPTION
Installs `/usr/bin/lscpu`, 55KB on ARM.