### PR TITLE
kodi: set MALLOC_MMAP_THRESHOLD_=8192 for aarch64 kernels (backport)

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -34,7 +34,7 @@ KODI_ARGS=""
 
 echo "KODI_ARGS=\"$KODI_ARGS\"" > /run/libreelec/kodi.conf
 
-if [ "$(uname -m)" = "x86_64" -o "$(uname -m)" = "aarch64" ]; then
+if [ "$(uname -m)" = "x86_64" ]; then
   echo "MALLOC_MMAP_THRESHOLD_=524288" >> /run/libreelec/kodi.conf
 else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf


### PR DESCRIPTION
Backport of https://github.com/LibreELEC/LibreELEC.tv/pull/3382