### PR TITLE
libmali: update to 74c27b4

### DIFF
--- a/packages/graphics/libmali/package.mk
+++ b/packages/graphics/libmali/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmali"
-PKG_VERSION="3e06d6226c22d8d69cd5cb4935d040178b0737f6"
-PKG_SHA256="dfdcf2b9f55c3ba9a4e723834708edefb5d7bc7596c4cbde8448e1b0410796d7"
+PKG_VERSION="74c27b4b401e3266c71ab3718ef9878bd36dbd34"
+PKG_SHA256="3a4d9295a5539fcaa470a5f0cdeda794be604842ff2c2936f2aab33ccf50bc2d"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="https://github.com/LibreELEC/libmali"
@@ -12,7 +12,7 @@ PKG_LONGDESC="OpenGL ES user-space binary for the ARM Mali GPU family"
 
 PKG_DEPENDS_TARGET="libdrm"
 
-if [ "$MALI_FAMILY" = "t720" ]; then
+if [ "$MALI_FAMILY" = "t620" -o "$MALI_FAMILY" = "t720" -o "$MALI_FAMILY" = "g52" ]; then
   PKG_DEPENDS_TARGET+=" wayland"
 fi
 


### PR DESCRIPTION
This update adds libmali blobs for t620 (Exynos 5422), g52 (Amlogic S922) and updates EGL+GLES includes to latest version. 

https://github.com/LibreELEC/libmali/compare/3e06d6226c22d8d69cd5cb4935d040178b0737f6...74c27b4b401e3266c71ab3718ef9878bd36dbd34