### PR TITLE
 arm-mem: update to arm-mem-0100445, enable for all arm builds

### DIFF
--- a/packages/devel/arm-mem/package.mk
+++ b/packages/devel/arm-mem/package.mk
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="arm-mem"
-PKG_VERSION="a3277ce"
-PKG_SHA256="f571bbc43e3670c8f52447eb885f0c561ed039bcfb692678681899d7df13b165"
+PKG_VERSION="010044568a9691bb375e86a96f7e26495f5c5d6e"
+PKG_SHA256="7a73fc64e0c56b2257f3a4d6d0facee078da74a8a98761823ebf266d57381fd5"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/bavison/arm-mem"

--- a/packages/devel/arm-mem/package.mk
+++ b/packages/devel/arm-mem/package.mk
@@ -14,7 +14,7 @@ PKG_DEPENDS_INIT="toolchain arm-mem"
 PKG_LONGDESC="arm-mem is a ARM-accelerated versions of selected functions from string.h"
 PKG_BUILD_FLAGS="+pic"
 
-if [ "$DEVICE" = "RPi2" -o "$DEVICE" = "Slice3" ] ; then
+if target_has_feature neon; then
   PKG_LIB_ARM_MEM="libarmmem-v7l.so"
 else
   PKG_LIB_ARM_MEM="libarmmem-v6l.so"

--- a/packages/virtual/libc/package.mk
+++ b/packages/virtual/libc/package.mk
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libc"
 PKG_VERSION=""
@@ -11,7 +12,7 @@ PKG_DEPENDS_INIT="toolchain glibc:init"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Meta package for installing various tools and libs needed for libc"
 
-if [ "$BOOTLOADER" = "bcm2835-bootloader" ]; then
+if [ "${TARGET_ARCH}" = "arm" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET arm-mem"
   PKG_DEPENDS_INIT="$PKG_DEPENDS_INIT arm-mem:init"
 fi


### PR DESCRIPTION
This has been in my RPi/RPi2 test builds since 15 March 2019 without complaint.

I can drop the second commit which enables `arm-mem` for all `arm`-based projects if this is not wanted - I have not build/run-time tested this with any other projects.