### PR TITLE
libtool: don't install source files on target

### DIFF
--- a/packages/devel/libtool/package.mk
+++ b/packages/devel/libtool/package.mk
@@ -14,3 +14,8 @@ PKG_LONGDESC="A generic library support script."
 PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared"
+
+post_makeinstall_target() {
+  rm -rf $INSTALL/usr/bin
+  rm -rf $INSTALL/usr/share
+}


### PR DESCRIPTION
`libtool`, `libtoolize` and source files in `/usr/share` are not required in target image. Removing them saves 1.6MB from (uncompressed) system image. `pulseaudio` compiles fine with this patch.

Note: after applying this patch you need to `rm -f build*/toolchain/bin/libtool*`. Thanks to @MilhouseVH for the tip. 