### PR TITLE
RTL8192DU: fix build for Kernel 3.14.29 / Project Amlogic_Legacy

### DIFF
--- a/packages/linux-drivers/RTL8192DU/patches/RTL8192DU-0004-revert-fix-for-old-kernels.patch
+++ b/packages/linux-drivers/RTL8192DU/patches/RTL8192DU-0004-revert-fix-for-old-kernels.patch
@@ -1,0 +1,29 @@
+From ad504e6bd4df0210904a10d57ddc48670bc41675 Mon Sep 17 00:00:00 2001
+From: 5schatten <supervisedthinking@gmail.com>
+Date: Thu, 21 Mar 2019 22:26:31 +0100
+Subject: [PATCH] Revert "rtl8192du: Fix builds for kernels older than 4.11.0"
+
+This reverts commit 01722435acb1d62c9453b86161d2d8b99d702648.
+---
+ os_dep/osdep_service.c | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/os_dep/osdep_service.c b/os_dep/osdep_service.c
+index 9efffc4..99a424f 100644
+--- a/os_dep/osdep_service.c
++++ b/os_dep/osdep_service.c
+@@ -34,14 +34,6 @@
+ 
+ #define RT_TAG	'1178'
+ 
+-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0))
+-static inline ssize_t call_read_iter(struct file *file, struct kiocb *kio,
+-				     struct iov_iter *iter)
+-{
+-	return file->f_op->read_iter(kio, iter);
+-}
+-#endif
+-
+ #ifdef DBG_MEMORY_LEAK
+ #include <asm/atomic.h>
+ atomic_t _malloc_cnt = ATOMIC_INIT(0);


### PR DESCRIPTION
Fixes the build for Amlogic_Legacy devices but is not tested with a real RTL8192DU chipset base device.