### PR TITLE
nano: updated to nano-4.0

### DIFF
--- a/packages/tools/nano/config/nanorc
+++ b/packages/tools/nano/config/nanorc
@@ -1,0 +1,1 @@
+include /usr/share/nano/*.nanorc

--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nano"
-PKG_VERSION="3.2"
-PKG_SHA256="d12773af3589994b2e4982c5792b07c6240da5b86c5aef2103ab13b401fe6349"
+PKG_VERSION="4.0"
+PKG_SHA256="1e2fcfea35784624a7d86785768b772d58bb3995d1aec9176a27a113b1e9bac3"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.nano-editor.org/"
-PKG_URL="http://ftpmirror.gnu.org/nano/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="http://ftpmirror.gnu.org/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="Nano is an enhanced clone of the Pico text editor."
 
@@ -16,5 +17,23 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-utf8 \
                            --disable-wrapping"
 
 post_makeinstall_target() {
-  rm -rf $INSTALL/usr/share/nano
+  rm -rf ${INSTALL}/usr/share/nano
+
+  mkdir -p ${INSTALL}/etc
+  cp -a ${PKG_DIR}/config/* ${INSTALL}/etc/
+
+  mkdir -p ${INSTALL}/usr/share/nano 
+  for FILE_TYPES in \
+    css \
+    html \
+    java \
+    javascript \
+    json \
+    php \
+    python \
+    sh \
+    xml
+  do
+    cp -a ${PKG_BUILD}/syntax/${FILE_TYPES}.nanorc ${INSTALL}/usr/share/nano/
+  done
 }

--- a/packages/tools/nano/patches/nano-999.01-initialize-a-variable-before-referencing-it.patch
+++ b/packages/tools/nano/patches/nano-999.01-initialize-a-variable-before-referencing-it.patch
@@ -1,0 +1,39 @@
+From 7ad232d71470cd8c4dc63aeb02f11c9e8df9ecdb Mon Sep 17 00:00:00 2001
+From: Devin Hussey <address@hidden>
+Date: Thu, 28 Mar 2019 17:28:47 -0400
+Subject: [PATCH] files: initialize a variable before referencing it
+
+The lack of initialization caused a nasty bug on some targets (such as
+ARMv7) which would make it so that ^S would just say "Cancelled".
+
+While x86 (both 64 and 32 bits) seems to initialize 'response' to zero or
+a positive number, ARM does not, and there is usually a negative value in
+its place, which triggers the 'if (response < 0)' check and, as a result,
+the code says "Cancelled".
+
+This fixes https://savannah.gnu.org/bugs/?56023.
+Reported-by: Devin Hussey <address@hidden>
+
+Bug existed since version 4.0, commit 0f9d60a3.
+
+Signed-off-by: Devin Hussey <address@hidden>
+---
+ src/files.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/files.c b/src/files.c
+index 84e3f684..fd54c168 100644
+--- a/src/files.c
++++ b/src/files.c
+@@ -2101,7 +2101,7 @@ int do_writeout(bool exiting, bool withprompt)
+ 
+ 	while (TRUE) {
+ 		const char *msg;
+-		int response, choice;
++		int response = 0, choice = 0;
+ 		functionptrtype func;
+ #ifndef NANO_TINY
+ 		const char *formatstr, *backupstr;
+-- 
+2.20.1
+


### PR DESCRIPTION
- update to [Nano 4.0](https://www.phoronix.com/scan.php?page=news_item&px=GNU-Nano-4.0-Released)
- added patch to init vars before referencing them -> for ARM builds
- added some nanorc files to enable syntax highlighting for common file types -> adds about 8,8kB to the uncompressed size

Example:
https://i.imgur.com/XBJQ0j9.jpg