### PR TITLE
tools/docker: install python3

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -8,7 +8,7 @@
 **Build container**
 
 * `cd ~/LibreELEC`
-* `docker build --pull -t libreelec tools/docker/xenial`
+* `docker build --pull -t libreelec tools/docker/bionic`
 
 **Build image inside container**
 

--- a/tools/docker/bionic/Dockerfile
+++ b/tools/docker/bionic/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop python \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop python python3 \
     g++ xfonts-utils xfonts-utils xfonts-utils xsltproc default-jre-headless \
     libc6-dev libncurses5-dev \
     u-boot-tools \

--- a/tools/docker/stretch/Dockerfile
+++ b/tools/docker/stretch/Dockerfile
@@ -19,7 +19,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop python \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop python python3 \
     g++ xfonts-utils xfonts-utils xfonts-utils xsltproc default-jre-headless \
     libc6-dev libncurses5-dev \
     u-boot-tools \

--- a/tools/docker/xenial/Dockerfile
+++ b/tools/docker/xenial/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop python \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop python python3 \
     g++ xfonts-utils xfonts-utils xfonts-utils xsltproc default-jre-headless \
     libc6-dev libncurses5-dev \
     u-boot-tools \


### PR DESCRIPTION
This PR adds `python3` to docker build containers to fix build of `glibc` 2.29+.
Also changes the example in README to use `bionic` container instead of `xenial`

From [glibc 2.29 changelog](https://sourceware.org/ml/libc-announce/2019/msg00000.html):
* Python 3.4 or later is required to build the GNU C Library.