### PR TITLE
samba: update to samba-4.9.6

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.9.5"
-PKG_SHA256="078956d2d98e22011265afd4b7221efe4861067dcba4a031583b01f34d423700"
+PKG_VERSION="4.9.6"
+PKG_SHA256="c9205a651a83d69e200fec9dd65e9fa360f0c75ab3275b3dcb74e5cbaec60807"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
This is a security release in order to address the following defects:

o  CVE-2019-3870 (World writable files in Samba AD DC private/ dir)
o  CVE-2019-3880 (Save registry file outside share as unprivileged user)


Details
----

o  CVE-2019-3870:
   During the provision of a new Active Directory DC, some files in the private/
   directory are created world-writable.

o  CVE-2019-3880:
   Authenticated users with write permission can trigger a symlink traversal to
   write or detect files outside the Samba share.

For more details and workarounds, please refer to the security advisories.


Changes since 4.9.5:
--------------------

o  Andrew Bartlett <abartlet@samba.org>
   * BUG 13834: CVE-2019-3870: pysmbd: Ensure a zero umask is set for
     smbd.mkdir().

o  Jeremy Allison <jra@samba.org>
   * BUG 13851: CVE-2018-14629: rpc: winreg: Remove implementations of
     SaveKey/RestoreKey.

