### PR TITLE
dav1d: updated to 0.2.1 / added meson opts to disable tools & tests

### DIFF
--- a/packages/multimedia/dav1d/package.mk
+++ b/packages/multimedia/dav1d/package.mk
@@ -2,14 +2,17 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dav1d"
-PKG_VERSION="0e3c21979b5e2e6e7e49968b1377e38220c58774"
-PKG_SHA256="3662184809fa29af39c920877cedec3724dc5c3cf71d94bec424f2a7ee4825cf"
+PKG_VERSION="0.2.1"
+PKG_SHA256="887f672f0afad9ff66735997e4d55d03b72a098238e291ecb17ae529adc7dd23"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.jbkempf.com/blog/post/2018/Introducing-dav1d"
-PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/dav1d-${PKG_VERSION}.tar.bz2"
+PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="dav1d is an AV1 decoder :)"
 
-if [ "$TARGET_ARCH" = "x86_64" ]; then
+if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" nasm:host"
 fi
+
+PKG_MESON_OPTS_TARGET="-Dbuild_tools=false \
+                       -Dbuild_tests=false"

--- a/packages/multimedia/ffmpeg/patches/ffmpeg-99.1008-dav1d-enable-av1.patch
+++ b/packages/multimedia/ffmpeg/patches/ffmpeg-99.1008-dav1d-enable-av1.patch
@@ -47,7 +47,7 @@ diff -Nur a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
 diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 --- a/libavcodec/libdav1d.c	1969-12-31 19:00:00.000000000 -0500
 +++ b/libavcodec/libdav1d.c	2018-11-23 12:33:35.820468086 -0500
-@@ -0,0 +1,276 @@
+@@ -0,0 +1,346 @@
 +/*
 + * Copyright (c) 2018 Ronald S. Bultje <rsbultje gmail com>
 + * Copyright (c) 2018 James Almer <jamrial gmail com>
@@ -72,7 +72,8 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +#include <dav1d/dav1d.h>
 +
 +#include "libavutil/avassert.h"
-+#include "libavutil/fifo.h"
++#include "libavutil/mastering_display_metadata.h"
++#include "libavutil/imgutils.h"
 +#include "libavutil/opt.h"
 +
 +#include "avcodec.h"
@@ -82,11 +83,82 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +typedef struct Libdav1dContext {
 +    AVClass *class;
 +    Dav1dContext *c;
++    AVBufferPool *pool;
++    int pool_size;
 +
-+    AVFifoBuffer *cache;
 +    Dav1dData data;
 +    int tile_threads;
++    int apply_grain;
 +} Libdav1dContext;
++
++static const enum AVPixelFormat pix_fmt[][3] = {
++    [DAV1D_PIXEL_LAYOUT_I400] = { AV_PIX_FMT_GRAY8,   AV_PIX_FMT_GRAY10,    AV_PIX_FMT_GRAY12 },
++    [DAV1D_PIXEL_LAYOUT_I420] = { AV_PIX_FMT_YUV420P, AV_PIX_FMT_YUV420P10, AV_PIX_FMT_YUV420P12 },
++    [DAV1D_PIXEL_LAYOUT_I422] = { AV_PIX_FMT_YUV422P, AV_PIX_FMT_YUV422P10, AV_PIX_FMT_YUV422P12 },
++    [DAV1D_PIXEL_LAYOUT_I444] = { AV_PIX_FMT_YUV444P, AV_PIX_FMT_YUV444P10, AV_PIX_FMT_YUV444P12 },
++};
++
++static void libdav1d_log_callback(void *opaque, const char *fmt, va_list vl)
++{
++    AVCodecContext *c = opaque;
++
++    av_vlog(c, AV_LOG_ERROR, fmt, vl);
++}
++
++static int libdav1d_picture_allocator(Dav1dPicture *p, void *cookie)
++{
++    Libdav1dContext *dav1d = cookie;
++    enum AVPixelFormat format = pix_fmt[p->p.layout][p->seq_hdr->hbd];
++    int ret, linesize[4], h = FFALIGN(p->p.h, 128);
++    uint8_t *aligned_ptr, *data[4];
++    AVBufferRef *buf;
++
++    ret = av_image_fill_arrays(data, linesize, NULL, format, FFALIGN(p->p.w, 128),
++                               h, DAV1D_PICTURE_ALIGNMENT);
++    if (ret < 0)
++        return ret;
++
++    if (ret != dav1d->pool_size) {
++        av_buffer_pool_uninit(&dav1d->pool);
++        // Use twice the amount of required padding bytes for aligned_ptr below.
++        dav1d->pool = av_buffer_pool_init(ret + DAV1D_PICTURE_ALIGNMENT * 2, NULL);
++        if (!dav1d->pool) {
++            dav1d->pool_size = 0;
++            return AVERROR(ENOMEM);
++        }
++        dav1d->pool_size = ret;
++    }
++    buf = av_buffer_pool_get(dav1d->pool);
++    if (!buf)
++        return AVERROR(ENOMEM);
++
++    // libdav1d requires DAV1D_PICTURE_ALIGNMENT aligned buffers, which av_malloc()
++    // doesn't guarantee for example when AVX is disabled at configure time.
++    // Use the extra DAV1D_PICTURE_ALIGNMENT padding bytes in the buffer to align it
++    // if required.
++    aligned_ptr = (uint8_t *)FFALIGN((uintptr_t)buf->data, DAV1D_PICTURE_ALIGNMENT);
++    ret = av_image_fill_pointers(data, format, h, aligned_ptr, linesize);
++    if (ret < 0) {
++        av_buffer_unref(&buf);
++        return ret;
++    }
++
++    p->data[0] = data[0];
++    p->data[1] = data[1];
++    p->data[2] = data[2];
++    p->stride[0] = linesize[0];
++    p->stride[1] = linesize[1];
++    p->allocator_data = buf;
++
++    return 0;
++}
++
++static void libdav1d_picture_release(Dav1dPicture *p, void *cookie)
++{
++    AVBufferRef *buf = p->allocator_data;
++
++    av_buffer_unref(&buf);
++}
 +
 +static av_cold int libdav1d_init(AVCodecContext *c)
 +{
@@ -97,12 +169,14 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +    av_log(c, AV_LOG_INFO, "libdav1d %s\n", dav1d_version());
 +
 +    dav1d_default_settings(&s);
++    s.logger.cookie = c;
++    s.logger.callback = libdav1d_log_callback;
++    s.allocator.cookie = dav1d;
++    s.allocator.alloc_picture_callback = libdav1d_picture_allocator;
++    s.allocator.release_picture_callback = libdav1d_picture_release;
 +    s.n_tile_threads = dav1d->tile_threads;
-+    s.n_frame_threads = FFMIN(c->thread_count ? c->thread_count : av_cpu_count(), 256);
-+
-+    dav1d->cache = av_fifo_alloc(8 * sizeof(AVPacket));
-+    if (!dav1d->cache)
-+        return AVERROR(ENOMEM);
++    s.apply_grain = dav1d->apply_grain;
++    s.n_frame_threads = FFMIN(c->thread_count ? c->thread_count : av_cpu_count(), DAV1D_MAX_FRAME_THREADS);
 +
 +    res = dav1d_open(&dav1d->c, &s);
 +    if (res < 0)
@@ -115,21 +189,8 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +{
 +    Libdav1dContext *dav1d = c->priv_data;
 +
-+    av_fifo_reset(dav1d->cache);
 +    dav1d_data_unref(&dav1d->data);
 +    dav1d_flush(dav1d->c);
-+}
-+
-+static int libdav1d_fifo_write(void *src, void *dst, int dst_size) {
-+    AVPacket *pkt_dst = dst, *pkt_src = src;
-+
-+    av_assert2(dst_size >= sizeof(AVPacket));
-+
-+    pkt_src->buf = NULL;
-+    av_packet_free_side_data(pkt_src);
-+    *pkt_dst = *pkt_src;
-+
-+    return sizeof(AVPacket);
 +}
 +
 +static void libdav1d_data_free(const uint8_t *data, void *opaque) {
@@ -138,108 +199,81 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +    av_buffer_unref(&buf);
 +}
 +
-+static void libdav1d_frame_free(void *opaque, uint8_t *data) {
-+    Dav1dPicture p = { 0 };
-+
-+    p.ref = opaque;
-+    p.data[0] = (void *) 0x1; // this has to be non-NULL
-+    dav1d_picture_unref(&p);
-+}
-+
-+static const enum AVPixelFormat pix_fmt[][2] = {
-+    [DAV1D_PIXEL_LAYOUT_I400] = { AV_PIX_FMT_GRAY8,   AV_PIX_FMT_GRAY10 },
-+    [DAV1D_PIXEL_LAYOUT_I420] = { AV_PIX_FMT_YUV420P, AV_PIX_FMT_YUV420P10 },
-+    [DAV1D_PIXEL_LAYOUT_I422] = { AV_PIX_FMT_YUV422P, AV_PIX_FMT_YUV422P10 },
-+    [DAV1D_PIXEL_LAYOUT_I444] = { AV_PIX_FMT_YUV444P, AV_PIX_FMT_YUV444P10 },
-+};
-+
-+// TODO: Update once 12bit support is added.
-+static const int profile[] = {
-+    [DAV1D_PIXEL_LAYOUT_I400] = FF_PROFILE_AV1_MAIN,
-+    [DAV1D_PIXEL_LAYOUT_I420] = FF_PROFILE_AV1_MAIN,
-+    [DAV1D_PIXEL_LAYOUT_I422] = FF_PROFILE_AV1_PROFESSIONAL,
-+    [DAV1D_PIXEL_LAYOUT_I444] = FF_PROFILE_AV1_HIGH,
-+};
-+
 +static int libdav1d_receive_frame(AVCodecContext *c, AVFrame *frame)
 +{
 +    Libdav1dContext *dav1d = c->priv_data;
 +    Dav1dData *data = &dav1d->data;
-+    AVPacket pkt = { 0 };
-+    Dav1dPicture p = { 0 };
++    Dav1dPicture pic = { 0 }, *p = &pic;
 +    int res;
 +
 +    if (!data->sz) {
++        AVPacket pkt = { 0 };
++
 +        res = ff_decode_get_packet(c, &pkt);
 +        if (res < 0 && res != AVERROR_EOF)
 +            return res;
 +
 +        if (pkt.size) {
-+            if (!av_fifo_space(dav1d->cache)) {
-+                res = av_fifo_grow(dav1d->cache, 8 * sizeof(pkt));
-+                if (res < 0) {
-+                    av_packet_unref(&pkt);
-+                    return res;
-+                }
-+            }
-+
 +            res = dav1d_data_wrap(data, pkt.data, pkt.size, libdav1d_data_free, pkt.buf);
 +            if (res < 0) {
 +                av_packet_unref(&pkt);
 +                return res;
 +            }
 +
-+            av_fifo_generic_write(dav1d->cache, &pkt, sizeof(pkt), libdav1d_fifo_write);
++            data->m.timestamp = pkt.pts;
++            data->m.offset = pkt.pos;
++            data->m.duration = pkt.duration;
++
++            pkt.buf = NULL;
++            av_packet_unref(&pkt);
 +        }
 +    }
 +
 +    res = dav1d_send_data(dav1d->c, data);
 +    if (res < 0) {
-+        if (res == -EINVAL)
++        if (res == AVERROR(EINVAL))
 +            res = AVERROR_INVALIDDATA;
-+        if (res != -EAGAIN)
++        if (res != AVERROR(EAGAIN))
 +            return res;
 +    }
 +
-+    res = dav1d_get_picture(dav1d->c, &p);
++    res = dav1d_get_picture(dav1d->c, p);
 +    if (res < 0) {
-+        if (res == -EINVAL)
++        if (res == AVERROR(EINVAL))
 +            res = AVERROR_INVALIDDATA;
-+        else if (res == -EAGAIN && c->internal->draining)
++        else if (res == AVERROR(EAGAIN) && c->internal->draining)
 +            res = AVERROR_EOF;
 +
 +        return res;
 +    }
 +
-+    av_assert0(p.data[0] != NULL);
++    av_assert0(p->data[0] != NULL);
 +
-+    av_fifo_generic_read(dav1d->cache, &pkt, sizeof(pkt), NULL);
-+
-+    frame->buf[0] = av_buffer_create(NULL, 0, libdav1d_frame_free,
-+                                     p.ref, AV_BUFFER_FLAG_READONLY);
++    // This requires the custom allocator above
++    frame->buf[0] = av_buffer_ref(p->allocator_data);
 +    if (!frame->buf[0]) {
-+        dav1d_picture_unref(&p);
++        dav1d_picture_unref(p);
 +        return AVERROR(ENOMEM);
 +    }
 +
-+    frame->data[0] = p.data[0];
-+    frame->data[1] = p.data[1];
-+    frame->data[2] = p.data[2];
-+    frame->linesize[0] = p.stride[0];
-+    frame->linesize[1] = p.stride[1];
-+    frame->linesize[2] = p.stride[1];
++    frame->data[0] = p->data[0];
++    frame->data[1] = p->data[1];
++    frame->data[2] = p->data[2];
++    frame->linesize[0] = p->stride[0];
++    frame->linesize[1] = p->stride[1];
++    frame->linesize[2] = p->stride[1];
 +
-+    c->profile = profile[p.p.layout];
-+    frame->format = c->pix_fmt = pix_fmt[p.p.layout][p.p.bpc == 10];
-+    frame->width = p.p.w;
-+    frame->height = p.p.h;
-+    if (c->width != p.p.w || c->height != p.p.h) {
-+        res = ff_set_dimensions(c, p.p.w, p.p.h);
++    c->profile = p->seq_hdr->profile;
++    frame->format = c->pix_fmt = pix_fmt[p->p.layout][p->seq_hdr->hbd];
++    frame->width = p->p.w;
++    frame->height = p->p.h;
++    if (c->width != p->p.w || c->height != p->p.h) {
++        res = ff_set_dimensions(c, p->p.w, p->p.h);
 +        if (res < 0)
-+            return res;
++            goto fail;
 +    }
 +
-+    switch (p.p.chr) {
++    switch (p->seq_hdr->chr) {
 +    case DAV1D_CHR_VERTICAL:
 +        frame->chroma_location = c->chroma_sample_location = AVCHROMA_LOC_LEFT;
 +        break;
@@ -247,25 +281,25 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +        frame->chroma_location = c->chroma_sample_location = AVCHROMA_LOC_TOPLEFT;
 +        break;
 +    }
-+    frame->colorspace = c->colorspace = (enum AVColorSpace) p.p.mtrx;
-+    frame->color_primaries = c->color_primaries = (enum AVColorPrimaries) p.p.pri;
-+    frame->color_trc = c->color_trc = (enum AVColorTransferCharacteristic) p.p.trc;
-+    frame->color_range = c->color_range = p.p.fullrange ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
++    frame->colorspace = c->colorspace = (enum AVColorSpace) p->seq_hdr->mtrx;
++    frame->color_primaries = c->color_primaries = (enum AVColorPrimaries) p->seq_hdr->pri;
++    frame->color_trc = c->color_trc = (enum AVColorTransferCharacteristic) p->seq_hdr->trc;
++    frame->color_range = c->color_range = p->seq_hdr->color_range ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
 +
 +    // match timestamps and packet size
-+    frame->pts = frame->best_effort_timestamp = pkt.pts;
++    frame->pts = frame->best_effort_timestamp = p->m.timestamp;
 +#if FF_API_PKT_PTS
 +FF_DISABLE_DEPRECATION_WARNINGS
-+    frame->pkt_pts = pkt.pts;
++    frame->pkt_pts = p->m.timestamp;
 +FF_ENABLE_DEPRECATION_WARNINGS
 +#endif
-+    frame->pkt_dts = pkt.dts;
-+    frame->pkt_pos = pkt.pos;
-+    frame->pkt_size = pkt.size;
-+    frame->pkt_duration = pkt.duration;
-+    frame->key_frame = p.p.type == DAV1D_FRAME_TYPE_KEY;
++    frame->pkt_dts = p->m.timestamp;
++    frame->pkt_pos = p->m.offset;
++    frame->pkt_size = p->m.size;
++    frame->pkt_duration = p->m.duration;
++    frame->key_frame = p->frame_hdr->frame_type == DAV1D_FRAME_TYPE_KEY;
 +
-+    switch (p.p.type) {
++    switch (p->frame_hdr->frame_type) {
 +    case DAV1D_FRAME_TYPE_KEY:
 +    case DAV1D_FRAME_TYPE_INTRA:
 +        frame->pict_type = AV_PICTURE_TYPE_I;
@@ -277,17 +311,53 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +        frame->pict_type = AV_PICTURE_TYPE_SP;
 +        break;
 +    default:
-+        return AVERROR_INVALIDDATA;
++        res = AVERROR_INVALIDDATA;
++        goto fail;
 +    }
 +
-+    return 0;
++    if (p->mastering_display) {
++        AVMasteringDisplayMetadata *mastering = av_mastering_display_metadata_create_side_data(frame);
++        if (!mastering) {
++            res = AVERROR(ENOMEM);
++            goto fail;
++        }
++
++        for (int i = 0; i < 3; i++) {
++            mastering->display_primaries[i][0] = av_make_q(p->mastering_display->primaries[i][0], 1 << 16);
++            mastering->display_primaries[i][1] = av_make_q(p->mastering_display->primaries[i][1], 1 << 16);
++        }
++        mastering->white_point[0] = av_make_q(p->mastering_display->white_point[0], 1 << 16);
++        mastering->white_point[1] = av_make_q(p->mastering_display->white_point[1], 1 << 16);
++
++        mastering->max_luminance = av_make_q(p->mastering_display->max_luminance, 1 << 8);
++        mastering->min_luminance = av_make_q(p->mastering_display->min_luminance, 1 << 14);
++
++        mastering->has_primaries = 1;
++        mastering->has_luminance = 1;
++    }
++    if (p->content_light) {
++        AVContentLightMetadata *light = av_content_light_metadata_create_side_data(frame);
++        if (!light) {
++            res = AVERROR(ENOMEM);
++            goto fail;
++        }
++        light->MaxCLL = p->content_light->max_content_light_level;
++        light->MaxFALL = p->content_light->max_frame_average_light_level;
++    }
++
++    res = 0;
++fail:
++    dav1d_picture_unref(p);
++    if (res < 0)
++        av_frame_unref(frame);
++    return res;
 +}
 +
 +static av_cold int libdav1d_close(AVCodecContext *c)
 +{
 +    Libdav1dContext *dav1d = c->priv_data;
 +
-+    av_fifo_freep(&dav1d->cache);
++    av_buffer_pool_uninit(&dav1d->pool);
 +    dav1d_data_unref(&dav1d->data);
 +    dav1d_close(&dav1d->c);
 +
@@ -297,7 +367,8 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +#define OFFSET(x) offsetof(Libdav1dContext, x)
 +#define VD AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_DECODING_PARAM
 +static const AVOption libdav1d_options[] = {
-+    { "tilethreads",  "Tile threads",  OFFSET(tile_threads),  AV_OPT_TYPE_INT, { .i64 = 1 }, 1,  64, VD, NULL },
++    { "tilethreads", "Tile threads", OFFSET(tile_threads), AV_OPT_TYPE_INT, { .i64 = 1 }, 1, DAV1D_MAX_TILE_THREADS, VD },
++    { "filmgrain", "Apply Film Grain", OFFSET(apply_grain), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VD },
 +    { NULL }
 +};
 +
@@ -319,8 +390,7 @@ diff -Nur a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
 +    .flush          = libdav1d_flush,
 +    .receive_frame  = libdav1d_receive_frame,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,
-+    .caps_internal  = FF_CODEC_CAP_INIT_THREADSAFE | FF_CODEC_CAP_INIT_CLEANUP |
-+                      FF_CODEC_CAP_SETS_PKT_DTS,
++    .caps_internal  = FF_CODEC_CAP_INIT_THREADSAFE | FF_CODEC_CAP_SETS_PKT_DTS,
 +    .priv_class     = &libdav1d_class,
 +    .wrapper_name   = "libdav1d",
 +};

--- a/packages/multimedia/ffmpeg/patches/ffmpeg-99.1009-dav1d-fix-multithreaded-av1-sw-decoding.patch
+++ b/packages/multimedia/ffmpeg/patches/ffmpeg-99.1009-dav1d-fix-multithreaded-av1-sw-decoding.patch
@@ -1,0 +1,60 @@
+From 0ae5ba3567a896af2b272e3a52ca574b7f41ec5a Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Wed, 10 Apr 2019 13:40:07 -0700
+Subject: [PATCH 0/1] *** SUBJECT HERE ***
+
+*** BLURB HERE ***
+
+Lukas Rusak (1):
+  libavcodec/libdav1d: add libdav1d_get_format method in order to call
+    ff_get_format
+
+ libavcodec/libdav1d.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+-- 
+2.20.1
+
+From 0ae5ba3567a896af2b272e3a52ca574b7f41ec5a Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Wed, 10 Apr 2019 13:39:21 -0700
+Subject: [PATCH 1/1] libavcodec/libdav1d: add libdav1d_get_format method in
+ order to call ff_get_format
+
+---
+ libavcodec/libdav1d.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
+index 30c6eccfef..fa71834543 100644
+--- a/libavcodec/libdav1d.c
++++ b/libavcodec/libdav1d.c
+@@ -48,6 +48,16 @@ static const enum AVPixelFormat pix_fmt[][3] = {
+     [DAV1D_PIXEL_LAYOUT_I444] = { AV_PIX_FMT_YUV444P, AV_PIX_FMT_YUV444P10, AV_PIX_FMT_YUV444P12 },
+ };
+ 
++static enum AVPixelFormat libdav1d_get_format(AVCodecContext *avctx, const Dav1dPicture *p)
++{
++   enum AVPixelFormat pix_fmts[2], *fmt = pix_fmts;
++
++   *fmt++ = pix_fmt[p->p.layout][p->seq_hdr->hbd];
++   *fmt = AV_PIX_FMT_NONE;
++
++   return ff_get_format(avctx, pix_fmts);
++}
++
+ static void libdav1d_log_callback(void *opaque, const char *fmt, va_list vl)
+ {
+     AVCodecContext *c = opaque;
+@@ -214,7 +224,7 @@ static int libdav1d_receive_frame(AVCodecContext *c, AVFrame *frame)
+     frame->linesize[2] = p->stride[1];
+ 
+     c->profile = p->seq_hdr->profile;
+-    frame->format = c->pix_fmt = pix_fmt[p->p.layout][p->seq_hdr->hbd];
++    frame->format = c->pix_fmt = libdav1d_get_format(c, p);
+     frame->width = p->p.w;
+     frame->height = p->p.h;
+     if (c->width != p->p.w || c->height != p->p.h) {
+-- 
+2.20.1
+


### PR DESCRIPTION
Tested with:
- https://www.elecard.com/videos
- http://download.opencontent.netflix.com/?prefix=AV1/Chimera/

My [J3455-ITX](https://asrock.com/mb/Intel/J3455-ITX/) was able to handle this [1080p / 8bit video](http://download.opencontent.netflix.com.s3.amazonaws.com/AV1/Chimera/Chimera-AV1-8bit-1920x1080-6736kbps.mp4) file at 24Hz which equals roughly performance wise an Intel® Core™2 Quad Processor Q6600 so I guess older cpus with SSSE3 support should be able to handle this video specs as well.

Additional updates:
- ffmpeg: updated AV1 support patch for dav1d 0.2.1 -> backported upstream [libdav1d.c](https://github.com/FFmpeg/FFmpeg/blob/9e62e1a1104bb0d64e604051ffc25004ad748eaf/libavcodec/libdav1d.c)
- ffmpeg: fixed multithreaded sw decoding for AV1 thx to @lrusak 

Release notes:
- https://code.videolan.org/videolan/dav1d/tags/0.2.1
```
dav1d 0.2.1 'Antelope', the fast and small AV1 decoder

This is the second release of dav1d, the fast and small AV1 decoder,
codename 'Antelope'.

It still supports all AV1 features and all bitdepths, from 8 to 12bits,
and decodes more samples than before.

While still being the fastest decoder on AVX-2 CPUs, dav1d is now also
faster on ARM, ARM64 and SSSE3 CPUs in normal loads.
0.2.x is around 2x/2.5x faster on SSSE3 and achieves 1080p at 80fps
on an iPhone XS

0.2.1 is a small bugfix release above 0.2.0 to fix build issues, and
increase a bit the speed of SSSE3
```

