### PR TITLE
config/graphic: add lima/panfrost options and sort

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -26,6 +26,20 @@ get_graphicdrivers() {
     GRAPHIC_DRIVERS="i915 i965 r200 r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
   fi
 
+  if listcontains "$GRAPHIC_DRIVERS" "etnaviv"; then
+    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,etnaviv,imx"
+    V4L2_SUPPORT="yes"
+    VAAPI_SUPPORT="no"
+    VDPAU_SUPPORT="no"
+  fi
+
+  if listcontains "$GRAPHIC_DRIVERS" "freedreno"; then
+    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,freedreno"
+    V4L2_SUPPORT="yes"
+    VAAPI_SUPPORT="no"
+    VDPAU_SUPPORT="no"
+  fi
+
   if listcontains "$GRAPHIC_DRIVERS" "i915"; then
     DRI_DRIVERS="$DRI_DRIVERS,i915"
     XORG_DRIVERS="$XORG_DRIVERS intel"
@@ -92,16 +106,6 @@ get_graphicdrivers() {
     VAAPI_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "vmware"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,svga"
-    XORG_DRIVERS="$XORG_DRIVERS vmware"
-    COMPOSITE_SUPPORT="yes"
-  fi
-
-  if listcontains "$GRAPHIC_DRIVERS" "virtio"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,virgl"
-  fi
-
   if listcontains "$GRAPHIC_DRIVERS" "vc4"; then
     GALLIUM_DRIVERS="$GALLIUM_DRIVERS,vc4"
     V4L2_SUPPORT="yes"
@@ -109,18 +113,14 @@ get_graphicdrivers() {
     VDPAU_SUPPORT="no"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "freedreno"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,freedreno"
-    V4L2_SUPPORT="yes"
-    VAAPI_SUPPORT="no"
-    VDPAU_SUPPORT="no"
+  if listcontains "$GRAPHIC_DRIVERS" "virtio"; then
+    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,virgl"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "etnaviv"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,etnaviv,imx"
-    V4L2_SUPPORT="yes"
-    VAAPI_SUPPORT="no"
-    VDPAU_SUPPORT="no"
+  if listcontains "$GRAPHIC_DRIVERS" "vmware"; then
+    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,svga"
+    XORG_DRIVERS="$XORG_DRIVERS vmware"
+    COMPOSITE_SUPPORT="yes"
   fi
 
   # remove leading comma if present

--- a/config/graphic
+++ b/config/graphic
@@ -40,6 +40,11 @@ get_graphicdrivers() {
     VAAPI_SUPPORT="yes"
   fi
 
+  if listcontains "$GRAPHIC_DRIVERS" "lima"; then
+    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,kmsro,lima"
+    V4L2_SUPPORT="yes"
+  fi
+
   if listcontains "$GRAPHIC_DRIVERS" "nvidia"; then
     XORG_DRIVERS="$XORG_DRIVERS nvidia"
     VDPAU_SUPPORT="yes"
@@ -48,6 +53,11 @@ get_graphicdrivers() {
   if listcontains "$GRAPHIC_DRIVERS" "nvidia-legacy"; then
     XORG_DRIVERS="$XORG_DRIVERS nvidia-legacy"
     VDPAU_SUPPORT="yes"
+  fi
+
+  if listcontains "$GRAPHIC_DRIVERS" "panfrost"; then
+    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,kmsro,panfrost"
+    V4L2_SUPPORT="yes"
   fi
 
   if listcontains "$GRAPHIC_DRIVERS" "r200"; then


### PR DESCRIPTION
This adds a combined if messy-named `limapanfrost` option for use with upstream mesa now that both are merged to mesa 19.1 and usable (with caveats). I thought about calling this `amlogic` but while use is currently limited to Amlogic 'GX' test images this would lead to duplication or renaming once other SoC platform take the plunge and go blob free. I toyed with the idea of also adding some separate `lima` and `panfrost` options, but building mesa with support for both does no harm so a single option will suffice. Suggestions for a prettier option name will be entertained :)