### PR TITLE
samba: set fruit:model = Xserve for macOS finder

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -21,6 +21,7 @@
   enable core files = no
   passdb backend = smbpasswd
   smb encrypt = disabled
+  fruit:model = Xserve
 
   # samba share options
   map to guest = Bad User


### PR DESCRIPTION
Samba broadcasts `model = MacSamba` via bonjour but at some point the macOS Finder stopped showing a generic monitor icon (see the `msad` device) and instead displays a question mark (see the `N2` device). This PR sets `model = Xserve` (see the `X96` device) which is the least-worst of the Finder icons available that work. Options like `model = macmini` that would be more HTPC-like also display a question-mark so I'm not sure if this is a general macOS bug (in 10.13 which I use, so 10.14 is not tested) or a deliberate action from Apple. Either way the Xserve icon (also used by Synology and most NAS devices) looks better than a large `?` mark.

![image](https://user-images.githubusercontent.com/251794/55930791-01d06480-5c34-11e9-9f3b-78f44ee99fd5.png)