### PR TITLE
kodi (Generic/RPi/RockChip): update to kodi-18.2-Leia

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="2.3.15"
-PKG_SHA256="edfaf6bfd18d2dcf2d5075ee8c30df9693754483caed5d274faa764c6c121805"
+PKG_VERSION="2.3.17"
+PKG_SHA256="39746955c301c67ad3613254979f792a0eb29c0c109e35c1b54ac928c3fb8f3c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="4.4.16-Leia"
-PKG_SHA256="d25aaaf9a98813070f5065dd8e2deceaf024cd615862c2d861e74b1e39b46587"
+PKG_VERSION="4.4.17-Leia"
+PKG_SHA256="9036f32396d17c06b820cc4c04381c6270abad9486c14c6fde429480de4674b1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="5.10.6-Leia"
-PKG_SHA256="a740a8194dda8a66a2cd79e99decd84fa46e97804da1528c078f0f8853e712ca"
+PKG_VERSION="5.10.7-Leia"
+PKG_SHA256="4813f3453d213bb4636ddeca9a3f44249e3dcbd07bb1f7a82576b4dd6edabfb1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="3.3.13-Leia"
-PKG_SHA256="7408aecd65d2c9bb9ac96142aa307d97274b7ce7e46cfe494287f086b48560f4"
+PKG_VERSION="3.3.15-Leia"
+PKG_SHA256="3ee070de148d9473d5ad9a3b27cd5f22a81a9da24193c82bf793e1bb590ba054"
 PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="3.19.0-Leia"
-PKG_SHA256="f642c80855cf5434b8dffbda757ad5eeb12cf554f665b429fc79ef832baf5ecd"
+PKG_VERSION="3.22.0-Leia"
+PKG_SHA256="71acd4b2c99a351a2ae5fbb3547fa4248bb98779475ec0369421cb90ce41076b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="18.0.66-Leia"
-PKG_SHA256="f80d2816f406892cc9e691126ead4884e6513bcbad4b2d862135040caa157a6c"
+PKG_VERSION="18.1.0-Leia"
+PKG_SHA256="acea12b9a22e85316e7926cab0feb563623d19e0994feb798eb474434de49a63"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.asteroids"
-PKG_VERSION="2.2.1-Leia"
-PKG_SHA256="3d7e70f247b03bedc8dc4292ca3a7bbff0c3003700111db793062e04b33e5c83"
+PKG_VERSION="2.3.0-Leia"
+PKG_SHA256="8e4849d336bac04bb26c1d6694f5608a76940351cb5e39fa338a47a5855fc771"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.asterwave"
-PKG_VERSION="3.0.1-Leia"
-PKG_SHA256="b05a8ef46ae17db52f2fb0ef2bf07e5b6f13f004a739e1d6d33836b1de469ff2"
+PKG_VERSION="3.0.3-Leia"
+PKG_SHA256="ff018b5bdd353747a4e962c72ec622a74232e05eae1742a116259273f1db0552"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.biogenesis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.biogenesis/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.biogenesis"
-PKG_VERSION="2.2.0-Leia"
-PKG_SHA256="fc23c2b1c824491b7d80958ab87f62215d769d3280042df96bcded4734323b53"
+PKG_VERSION="2.2.2-Leia"
+PKG_SHA256="1d1edff918d2a94ba0efd329a45294be47e73eef65f700d62b311eb750d0fef7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.greynetic"
-PKG_VERSION="2.1.0-Leia"
-PKG_SHA256="7754fe5d19c31ebade0ccdef7771314a6f355d6b6c61096122d55c61002707d6"
+PKG_VERSION="2.2.1-Leia"
+PKG_SHA256="d95bc93d022b12fbfcbaedf1128292b40dd16276b65a3ffecb90707055e1d55f"
 PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.matrixtrails"
-PKG_VERSION="v2.2.0-Leia"
-PKG_SHA256="cbc66bf1a9078fe9e426f99e16b005fc261f6b5e1c2e64c19b0055bfc8feac33"
+PKG_VERSION="v2.2.1-Leia"
+PKG_SHA256="2d2c795853c5a72184bb6720247d79c48b1d9fbc97e9c2913003a707d612e3ac"
 PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.pyro"
-PKG_VERSION="2.0.0-Leia"
-PKG_SHA256="248cd710de086d9dd77edb33ae565c0a5a9772ffe2484470df091006d2af9496"
+PKG_VERSION="3.0.0-Leia"
+PKG_SHA256="55f867b703e5cf409f8e0a8a2c34373f896feb990004b5901b4efaee905d42e5"
 PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.stars"
-PKG_VERSION="2.1.1-Leia"
-PKG_SHA256="a0b644d6f7ba3ad51765c176f7f6e52a6bccd0958bfbec3051d8a81591de2c43"
+PKG_VERSION="2.1.2-Leia"
+PKG_SHA256="8873de9be41365af9dc639e3624d887f7b18d8e1f43e9a69af0c3154f9b59020"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.rar"
-PKG_VERSION="2.0.6-Leia"
-PKG_SHA256="34d435d50a132b4b71a85092865ab22db9679bc73fa920e2047db75f39fe5a64"
+PKG_VERSION="2.0.7-Leia"
+PKG_SHA256="b42db08aae80a10cfe3534b72241737c3fac39fc1d4bbb8473163b9a30d12251"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.shadertoy"
-PKG_VERSION="1.1.9-Leia"
-PKG_SHA256="25b3b1b343350b9eee870d24c7d1ea4634f5499d8548e87fa7589e7119a3ed4d"
+PKG_VERSION="1.1.10-Leia"
+PKG_SHA256="342b89a6d9ec1175023d085f540358b5ddc427bb73e172f155d61e77e87ee56e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.spectrum"
-PKG_VERSION="v2.0.3"
-PKG_SHA256="10fa799599a6b99ad8fc80b882266b817bf5a72fb55508d931114f7f29be282f"
+PKG_VERSION="v2.0.4-Leia"
+PKG_SHA256="0c08c318fc3781560e2a112d17c347cd69aba3e5388472009eef774555760aeb"
 PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -12,20 +12,20 @@ PKG_PATCH_DIRS="$KODI_VENDOR"
 
 case $KODI_VENDOR in
   raspberrypi)
-    PKG_VERSION="newclock5_18.1-Leia"
-    PKG_SHA256="22a46122a8e6f5a6507baae8e6be6beaf5a4203358478c94da525187b0681b99"
+    PKG_VERSION="newclock5_18.2-Leia"
+    PKG_SHA256="ff3f1770dd7a3223fb1f9441c0abf028bb4c3d406c5d9ba6fe202872b7237ee5"
     PKG_URL="https://github.com/popcornmix/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;
   rockchip)
-    PKG_VERSION="rockchip_18.1-Leia"
-    PKG_SHA256="974a3b273462e99eb405ab0c8aafff5890772cfb0088c2d852aea30917528199"
+    PKG_VERSION="rockchip_18.2-Leia"
+    PKG_SHA256="437b3608bb4ddb4703cc2ee86acb0a4065846244b84fe555d9f4c7b74a49b263"
     PKG_URL="https://github.com/kwiboo/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;
   *)
-    PKG_VERSION="18.1-Leia"
-    PKG_SHA256="bc1ef0e271d0b6ce2e1be7546ad4f7d330930d7631cc19a9bbc5f75ddc586166"
+    PKG_VERSION="18.2-Leia"
+    PKG_SHA256="07b8cffc396473523a51354dc95dfffb54a6a456b82cda7ad67dc2c052d99f64"
     PKG_URL="https://github.com/xbmc/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$PKG_VERSION.tar.gz"
     ;;

--- a/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
@@ -1,6 +1,6 @@
-From ab5679fefbf2190008ba6c815e91f5c24820614e Mon Sep 17 00:00:00 2001
+From 5ef37fded5c9c84134f338fd489983177ec555f5 Mon Sep 17 00:00:00 2001
 From: MilhouseVH <milhouseVH.github@nmacleod.com>
-Date: Mon, 27 Aug 2018 17:48:05 +0100
+Date: Tue, 19 Mar 2019 18:06:56 +0000
 Subject: [PATCH] handle SIGTERM
 
 0. CApplication::Stop cant be trusted. (deadlocks crashes and boo)
@@ -15,18 +15,17 @@ so, when shutdown/reboot is requested:
 6. addons / pvrmanager / cec / everything else.. are free to deadlock / crash now, we dont care
 7. KILL
 ---
- xbmc/Application.cpp         | 21 ++++++++++++++++-----
- xbmc/Application.h           |  1 +
- xbmc/XBApplicationEx.cpp     |  1 +
- xbmc/XBApplicationEx.h       |  1 +
- xbmc/platform/posix/main.cpp |  2 +-
- 5 files changed, 20 insertions(+), 6 deletions(-)
+ xbmc/Application.cpp     | 23 +++++++++++++++++------
+ xbmc/Application.h       |  1 +
+ xbmc/XBApplicationEx.cpp |  1 +
+ xbmc/XBApplicationEx.h   |  1 +
+ 4 files changed, 20 insertions(+), 6 deletions(-)
 
 diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
-index f39a94e..80bcecb 100644
+index 3bd24ef..b151026 100644
 --- a/xbmc/Application.cpp
 +++ b/xbmc/Application.cpp
-@@ -2286,12 +2286,12 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
+@@ -2029,12 +2029,12 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
    switch (msg)
    {
    case TMSG_POWERDOWN:
@@ -41,7 +40,7 @@ index f39a94e..80bcecb 100644
      break;
  
    case TMSG_SHUTDOWN:
-@@ -2312,12 +2312,13 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
+@@ -2055,12 +2055,13 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
  
    case TMSG_RESTART:
    case TMSG_RESET:
@@ -56,7 +55,7 @@ index f39a94e..80bcecb 100644
      Stop(EXITCODE_RESTARTAPP);
  #endif
      break;
-@@ -2764,6 +2765,17 @@ bool CApplication::Cleanup()
+@@ -2522,6 +2523,17 @@ bool CApplication::Cleanup()
    }
  }
  
@@ -74,7 +73,7 @@ index f39a94e..80bcecb 100644
  void CApplication::Stop(int exitCode)
  {
    CLog::Log(LOGNOTICE, "Stopping player");
-@@ -2790,7 +2802,7 @@ void CApplication::Stop(int exitCode)
+@@ -2548,7 +2560,7 @@ void CApplication::Stop(int exitCode)
      m_frameMoveGuard.unlock();
  
      CVariant vExitCode(CVariant::VariantTypeObject);
@@ -83,7 +82,7 @@ index f39a94e..80bcecb 100644
      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "xbmc", "OnQuit", vExitCode);
  
      // Abort any active screensaver
-@@ -2822,7 +2834,6 @@ void CApplication::Stop(int exitCode)
+@@ -2580,7 +2592,6 @@ void CApplication::Stop(int exitCode)
      // Needs cleaning up
      CApplicationMessenger::GetInstance().Stop();
      m_AppFocused = false;
@@ -91,11 +90,20 @@ index f39a94e..80bcecb 100644
      CLog::Log(LOGNOTICE, "Stopping all");
  
      // cancel any jobs from the jobmanager
+@@ -4111,7 +4122,7 @@ void CApplication::ProcessSlow()
+   if (CPlatformPosix::TestShutdownFlag())
+   {
+     CLog::Log(LOGNOTICE, "Quitting due to POSIX signal");
+-    CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
++    CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTARTAPP);
+   }
+ #endif
+ 
 diff --git a/xbmc/Application.h b/xbmc/Application.h
-index 1faf9dd..379d3ca 100644
+index 30cf6e7..1866fab 100644
 --- a/xbmc/Application.h
 +++ b/xbmc/Application.h
-@@ -154,6 +154,7 @@ public:
+@@ -156,6 +156,7 @@ public:
    bool StartServer(enum ESERVERS eServer, bool bStart, bool bWait = false);
  
    bool IsCurrentThread() const;
@@ -104,7 +112,7 @@ index 1faf9dd..379d3ca 100644
    void UnloadSkin(bool forReload = false);
    bool LoadCustomWindows();
 diff --git a/xbmc/XBApplicationEx.cpp b/xbmc/XBApplicationEx.cpp
-index 9255271..da788b2 100644
+index fb0bd6c..4f82951 100644
 --- a/xbmc/XBApplicationEx.cpp
 +++ b/xbmc/XBApplicationEx.cpp
 @@ -24,6 +24,7 @@ CXBApplicationEx::CXBApplicationEx()
@@ -126,19 +134,6 @@ index e7534b8..8f45f04 100644
 +  bool m_ExitCodeSet;
    bool m_AppFocused;
    bool m_renderGUI;
- 
-diff --git a/xbmc/platform/posix/main.cpp b/xbmc/platform/posix/main.cpp
-index 55840fd..2828c7f 100644
---- a/xbmc/platform/posix/main.cpp
-+++ b/xbmc/platform/posix/main.cpp
-@@ -47,7 +47,7 @@ protected:
-   void Process() override
-   {
-     CMessagePrinter::DisplayMessage("Exiting application");
--    KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
-+    KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTARTAPP);
-   }
- };
  
 -- 
 2.14.1

--- a/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
@@ -73,7 +73,7 @@ index f39a94e..80bcecb 100644
 +
  void CApplication::Stop(int exitCode)
  {
-   CLog::Log(LOGNOTICE, "stop player");
+   CLog::Log(LOGNOTICE, "Stopping player");
 @@ -2790,7 +2802,7 @@ void CApplication::Stop(int exitCode)
      m_frameMoveGuard.unlock();
  
@@ -88,7 +88,7 @@ index f39a94e..80bcecb 100644
      CApplicationMessenger::GetInstance().Stop();
      m_AppFocused = false;
 -    m_ExitCode = exitCode;
-     CLog::Log(LOGNOTICE, "stop all");
+     CLog::Log(LOGNOTICE, "Stopping all");
  
      // cancel any jobs from the jobmanager
 diff --git a/xbmc/Application.h b/xbmc/Application.h

--- a/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
@@ -1,4 +1,4 @@
-From 5ef37fded5c9c84134f338fd489983177ec555f5 Mon Sep 17 00:00:00 2001
+From 332f8f5c552f695d4e893512a642f9f9bbed6d9e Mon Sep 17 00:00:00 2001
 From: MilhouseVH <milhouseVH.github@nmacleod.com>
 Date: Tue, 19 Mar 2019 18:06:56 +0000
 Subject: [PATCH] handle SIGTERM
@@ -15,14 +15,15 @@ so, when shutdown/reboot is requested:
 6. addons / pvrmanager / cec / everything else.. are free to deadlock / crash now, we dont care
 7. KILL
 ---
- xbmc/Application.cpp     | 23 +++++++++++++++++------
- xbmc/Application.h       |  1 +
- xbmc/XBApplicationEx.cpp |  1 +
- xbmc/XBApplicationEx.h   |  1 +
- 4 files changed, 20 insertions(+), 6 deletions(-)
+ xbmc/Application.cpp                          | 23 ++++++++++++++-----
+ xbmc/Application.h                            |  1 +
+ xbmc/XBApplicationEx.cpp                      |  1 +
+ xbmc/XBApplicationEx.h                        |  1 +
+ .../powermanagement/LogindUPowerSyscall.cpp   |  2 --
+ 5 files changed, 20 insertions(+), 8 deletions(-)
 
 diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
-index 3bd24ef..b151026 100644
+index bfa6083209..a7fbe8afd5 100644
 --- a/xbmc/Application.cpp
 +++ b/xbmc/Application.cpp
 @@ -2029,12 +2029,12 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
@@ -91,7 +92,7 @@ index 3bd24ef..b151026 100644
  
      // cancel any jobs from the jobmanager
 @@ -4111,7 +4122,7 @@ void CApplication::ProcessSlow()
-   if (CPlatformPosix::TestShutdownFlag())
+   if (CPlatformPosix::TestQuitFlag())
    {
      CLog::Log(LOGNOTICE, "Quitting due to POSIX signal");
 -    CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
@@ -100,7 +101,7 @@ index 3bd24ef..b151026 100644
  #endif
  
 diff --git a/xbmc/Application.h b/xbmc/Application.h
-index 30cf6e7..1866fab 100644
+index 57b006b60c..5b66d7f09f 100644
 --- a/xbmc/Application.h
 +++ b/xbmc/Application.h
 @@ -156,6 +156,7 @@ public:
@@ -112,7 +113,7 @@ index 30cf6e7..1866fab 100644
    void UnloadSkin(bool forReload = false);
    bool LoadCustomWindows();
 diff --git a/xbmc/XBApplicationEx.cpp b/xbmc/XBApplicationEx.cpp
-index fb0bd6c..4f82951 100644
+index fb0bd6c70d..4f829512f1 100644
 --- a/xbmc/XBApplicationEx.cpp
 +++ b/xbmc/XBApplicationEx.cpp
 @@ -24,6 +24,7 @@ CXBApplicationEx::CXBApplicationEx()
@@ -124,7 +125,7 @@ index fb0bd6c..4f82951 100644
  }
  
 diff --git a/xbmc/XBApplicationEx.h b/xbmc/XBApplicationEx.h
-index e7534b8..8f45f04 100644
+index e7534b8c05..8f45f04ec8 100644
 --- a/xbmc/XBApplicationEx.h
 +++ b/xbmc/XBApplicationEx.h
 @@ -29,6 +29,7 @@ public:
@@ -135,6 +136,19 @@ index e7534b8..8f45f04 100644
    bool m_AppFocused;
    bool m_renderGUI;
  
+diff --git a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
+index 9e65e939fc..fec636a417 100644
+--- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
++++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
+@@ -76,8 +76,6 @@ CLogindUPowerSyscall::~CLogindUPowerSyscall()
+ 
+ bool CLogindUPowerSyscall::Powerdown()
+ {
+-  // delay shutdown so that the app can close properly
+-  InhibitDelayLockShutdown();
+   return LogindSetPowerState("PowerOff");
+ }
+ 
 -- 
-2.14.1
+2.19.1
 

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -4,8 +4,8 @@
 
 PKG_NAME="ffmpeg"
 # Current branch is: release/4.0-kodi
-PKG_VERSION="4.0.3-Leia-RC5"
-PKG_SHA256="9a971662e44353c120f2ccf87655571998956e699a2dd800ec708b8b928a53c8"
+PKG_VERSION="4.0.3-Leia-18.2"
+PKG_SHA256="68535cc2a000946b62ce4be6edf7dda7900bd524f22bcb826800b94f4a873314"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="https://github.com/xbmc/FFmpeg/archive/${PKG_VERSION}.tar.gz"

--- a/packages/textproc/nlohmann-json/package.mk
+++ b/packages/textproc/nlohmann-json/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nlohmann-json"
-PKG_VERSION="3.5.0"
-PKG_SHA256="e0b1fc6cc6ca05706cce99118a87aca5248bd9db3113e703023d23f044995c1d"
+PKG_VERSION="3.6.1"
+PKG_SHA256="80c45b090e40bf3d7a7f2a6e9f36206d3ff710acfa8d8cc1f8c763bb3075e22e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://nlohmann.github.io/json/"
 PKG_URL="https://github.com/nlohmann/json/archive/v$PKG_VERSION.tar.gz"


### PR DESCRIPTION
~Backport of #3424~

No longer a backport - we'll keep master on 18.2-rc1 for now.