### PR TITLE
[RPi] fix vendor header & lib includes / remove project specific include CFLAGS WIP

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -41,7 +41,6 @@ pre_configure_target() {
   LDFLAGS="$LDFLAGS -L$(get_build_dir gnutls)/.INSTALL_PKG/usr/lib"
 
   if [ "$KODIPLAYER_DRIVER" == "bcm2835-driver" ]; then
-    CFLAGS="-DRPI=1 -I$SYSROOT_PREFIX/usr/include/IL -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux $CFLAGS"
     PKG_FFMPEG_LIBS="-lbcm_host -ldl -lmmal -lmmal_core -lmmal_util -lvchiq_arm -lvcos -lvcsm"
   fi
 

--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -41,6 +41,7 @@ pre_configure_target() {
   LDFLAGS="$LDFLAGS -L$(get_build_dir gnutls)/.INSTALL_PKG/usr/lib"
 
   if [ "$KODIPLAYER_DRIVER" == "bcm2835-driver" ]; then
+    CFLAGS="$CFLAGS -DRPI=1 -I$SYSROOT_PREFIX/usr/include/IL"
     PKG_FFMPEG_LIBS="-lbcm_host -ldl -lmmal -lmmal_core -lmmal_util -lvchiq_arm -lvcos -lvcsm"
   fi
 

--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -44,10 +44,6 @@ fi
 
 pre_configure_target() {
   if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
-    export CXXFLAGS="$CXXFLAGS \
-      -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads/ \
-      -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux"
-
     # detecting RPi support fails without -lvchiq_arm
     export LDFLAGS="$LDFLAGS -lvchiq_arm"
   fi

--- a/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
@@ -27,12 +27,3 @@ if [ "$OPENGLES_SUPPORT" = yes ]; then
 # for OpenGL-ES support
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET $OPENGLES"
 fi
-
-pre_configure_target() {
-  if [ "$KODIPLAYER_DRIVER" = bcm2835-driver ]; then
-    BCM2835_INCLUDES="-I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads/ \
-                      -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux"
-    export CFLAGS="$CFLAGS $BCM2835_INCLUDES"
-    export CXXFLAGS="$CXXFLAGS $BCM2835_INCLUDES"
-  fi
-}

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -27,12 +27,3 @@ if [ "$OPENGLES_SUPPORT" = yes ]; then
 # for OpenGL-ES support
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET $OPENGLES"
 fi
-
-pre_configure_target() {
-  if [ "$KODIPLAYER_DRIVER" = bcm2835-driver ]; then
-    BCM2835_INCLUDES="-I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads/ \
-                      -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux"
-    export CFLAGS="$CFLAGS $BCM2835_INCLUDES"
-    export CXXFLAGS="$CXXFLAGS $BCM2835_INCLUDES"
-  fi
-}

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -81,7 +81,6 @@ pre_configure_target() {
   rm -rf .$TARGET_NAME
 
   if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
-    CFLAGS="-I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux $CFLAGS"
     PKG_FFMPEG_LIBS="-lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
     PKG_FFMPEG_RPI="--enable-rpi"
   else

--- a/projects/Allwinner/devices/H3/options
+++ b/projects/Allwinner/devices/H3/options
@@ -21,7 +21,7 @@
 
         # TARGET_FLOAT:
         # Specifies which floating-point ABI to use. Permissible values are:
-        # soft softfp hard
+        # soft hard
         TARGET_FLOAT="hard"
 
         # TARGET_FPU:

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -16,7 +16,7 @@
 
         # TARGET_FLOAT:
         # Specifies which floating-point ABI to use. Permissible values are:
-        # soft softfp hard
+        # soft hard
         TARGET_FLOAT="hard"
 
         # Valid TARGET_FPU for Raspberry Pi based devices:


### PR DESCRIPTION
The bcm2835-driver package contains several vendor headers & libs which were normally installed to `/opt/vc/include` & `/opt/vc/libs` but LE installs them to `/usr/...` so we need extra include flags to tell packages where they find these includes.

Also the pkgconfig files provided by the Raspberry project contain a `prefix=/opt/vc` var which leads to wrong include paths if pkg-config is used to compile packages.

So this PR changes the prefix to `prefix=/usr` & creates symlinks for `/opt/vc` to make sure hardcoded include paths were correct & pkg-config creates valid include paths.

- the PR also removes the CFLAGS in some projects
- reduces the TARGET_FPU options to hard or soft
- removes the softfp option for Allwinner H3 & RPi

Tests:
- RPi3 -> the usual stuff so video, tv & music works
- screensaver.shadertoy & visualization.shadertoy addons build, install & run fine