### PR TITLE
iptables: iptables_helper support for ethernet tethering

### DIFF
--- a/packages/network/iptables/scripts/iptables_helper
+++ b/packages/network/iptables/scripts/iptables_helper
@@ -18,11 +18,14 @@ check_docker() {
 }
 
 check_tether() {
-    if [ -n "`$CONNMANCTL technologies|grep 'Tethering = True'`" ]; then
-	$CONNMANCTL tether wifi off
-	sleep 1
-	$CONNMANCTL tether wifi on
+    if [ -n "`$CONNMANCTL technologies | grep -e -A5 technology/wifi -e 'Tethering = True'`" ]; then
+        TECHNOLOGY="wifi"
+    elif [ -n "`$CONNMANCTL technologies | grep -e -A5 technology/ethernet -e 'Tethering = True'`" ]; then
+        TECHNOLOGY="ethernet"
     fi
+    $CONNMANCTL tether $TECHNOLOGY off
+    sleep 1
+    $CONNMANCTL tether $TECHNOLOGY on
 }
 
 flush() {


### PR DESCRIPTION
This prepares for a pending feature change to add Ethernet tethering support to LE settings.