### PR TITLE
busybox: add dtname/dtfile helper scripts

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -124,6 +124,8 @@ makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
     [ $TARGET_ARCH = x86_64 ] && cp $PKG_DIR/scripts/getedid $INSTALL/usr/bin
     cp $PKG_DIR/scripts/createlog $INSTALL/usr/bin/
+    cp $PKG_DIR/scripts/dtfile $INSTALL/usr/bin
+    cp $PKG_DIR/scripts/dtname $INSTALL/usr/bin
     cp $PKG_DIR/scripts/lsb_release $INSTALL/usr/bin/
     cp $PKG_DIR/scripts/apt-get $INSTALL/usr/bin/
     cp $PKG_DIR/scripts/sudo $INSTALL/usr/bin/

--- a/packages/sysutils/busybox/scripts/dtfile
+++ b/packages/sysutils/busybox/scripts/dtfile
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+COMPATIBLE=$(cat /proc/device-tree/compatible | tr -d '\000' | sed -n -e 's/.*\(allwinner\|amlogic\|rockchip\).*/\1/p')
+
+if [ -n "$COMPATIBLE" ]; then
+  if [ -e /flash/extlinux/extlinux.conf ]; then
+    DTFILE=$(grep FDT extlinux.conf | sed 's, *FDT /dtb/,,g')
+  elif [ -e /flash/boot.ini ]; then
+    DTFILE=$(grep -m 1 dtb_name boot.ini | cut -d \" -f2 | sed 's,/dtb/,,g')
+  elif [ -e /flash/uEnv.ini ]; then
+    DTFILE=$(grep dtb_name /flash/uEnv.ini | sed 's,dtb_name=/dtb/,,g')
+  else
+    DTFILE=""
+  fi
+fi
+
+echo "$DTFILE"

--- a/packages/sysutils/busybox/scripts/dtname
+++ b/packages/sysutils/busybox/scripts/dtname
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+COMPATIBLE=$(cat /proc/device-tree/compatible | tr -d '\000' | sed -n -e 's/.*\(allwinner\|amlogic\|rockchip\).*/\1/p')
+
+if [ -n "$COMPATIBLE" ]; then
+  DTNAME=$(cat /proc/device-tree/compatible | cut -f1,2 -d',' | head -n 1)
+  echo "$DTNAME"
+else
+  echo "unknown"
+fi


### PR DESCRIPTION
The `dtname` helper script reads the mainline kernel `compatible` strings from Allwinner, Amlogic and Rockchip devices. It's primary use is for project stats reporting so we have some pretty strings like `khadas,vim` and `pine,rockpro64` instead of the current `unknown` but it can also be used from userspace to assist decisions on which firmware, driver, config, keymap to load/use. As ever more devices move to mainline kernels there's a clear benefit from sending device-trees upstream so that more device-specific compatible strings exist; so over time more userspace things can be auto-configured for a better out-of-box user experience. NB: The first `compatible` in the device-tree results in a short string with no spaces that is simple to reuse whereas the `model` string contains a much longer string with spaces. Model is fine for showing a pretty name in the GUI but sucks for userspace scripting.

The `dtfile` helper script similarly returns the device-tree filename by looking for the active config file in /flash and parsing the value out. This too has some userspace configuration uses.