### PR TITLE
zstd: update to 1.4.0 / dropped CMake pthread workaround

### DIFF
--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,17 +2,15 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.3.8"
-PKG_SHA256="293fa004dfacfbe90b42660c474920ff27093e3fb6c99f7b76e6083b21d6d48e"
+PKG_VERSION="1.4.0"
+PKG_SHA256="7f323f0e0c18488748f3d9b2d4353f00e904ea2ccd0372ea04d7f77aa1156557"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"
 PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_SOURCE_DIR=$PKG_NAME-$PKG_VERSION
 PKG_DEPENDS_HOST="gcc:host ninja:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A fast real-time compression algorithm."
 
 configure_package() {
   PKG_CMAKE_SCRIPT="$PKG_BUILD/build/cmake/CMakeLists.txt"
-  PKG_CMAKE_OPTS_HOST="-DTHREADS_PTHREAD_ARG=0"
 }


### PR DESCRIPTION
Release notes
- https://www.phoronix.com/scan.php?page=news_item&px=Zstd-1.4-Released

The CMake issue should be fixed by this commit 
- https://gitlab.kitware.com/cmake/cmake/commit/d4e551a90b6bf6ea4e18fa408f40f39df6ad6fb4