### PR TITLE
busybox: improvements to dtname/dtfile

### DIFF
--- a/packages/sysutils/busybox/scripts/dtfile
+++ b/packages/sysutils/busybox/scripts/dtfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
-COMPATIBLE=$(cat /proc/device-tree/compatible | tr -d '\000' | sed -n -e 's/.*\(allwinner\|amlogic\|rockchip\).*/\1/p')
+COMPATIBLE=$(cat /proc/device-tree/compatible 2>/dev/null | tr -d '\000' | sed -n -e 's/.*\(allwinner\|amlogic\|rockchip\).*/\1/p')
 
 if [ -n "$COMPATIBLE" ]; then
   if [ -e /flash/extlinux/extlinux.conf ]; then

--- a/packages/sysutils/busybox/scripts/dtname
+++ b/packages/sysutils/busybox/scripts/dtname
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-COMPATIBLE=$(cat /proc/device-tree/compatible | tr -d '\000' | sed -n -e 's/.*\(allwinner\|amlogic\|rockchip\).*/\1/p')
+COMPATIBLE=$(cat /proc/device-tree/compatible 2>/dev/null | tr -d '\000' | sed -n -e 's/.*\(allwinner\|amlogic\|rockchip\).*/\1/p')
 
 if [ -n "$COMPATIBLE" ]; then
   DTNAME=$(cat /proc/device-tree/compatible | cut -f1,2 -d',' | head -n 1)


### PR DESCRIPTION
Prevents errors on platforms where the device-tree values don't exist.