### PR TITLE
 xorg-intel-gpu-tools: add package

### DIFF
--- a/packages/debug/xorg-intel-gpu-tools/package.mk
+++ b/packages/debug/xorg-intel-gpu-tools/package.mk
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="xorg-intel-gpu-tools"
+PKG_VERSION="504367d33b787de2ba8e007a5b620cfd6f0b3074"
+PKG_SHA256="3e118ce6ab58b506de88ab158e9e630b3db9ab75b14cd0c4a8019548d2d0c320"
+PKG_LICENSE="GPL"
+PKG_DEPENDS_TARGET="toolchain cairo procps-ng"
+PKG_SITE="https://github.com/freedesktop/xorg-intel-gpu-tools"
+PKG_URL="https://github.com/freedesktop/xorg-intel-gpu-tools/archive/$PKG_VERSION.tar.gz"
+PKG_LONGDESC="Test suite and tools for DRM/KMS drivers"
+PKG_TOOLCHAIN="meson"
+
+PKG_MESON_OPTS_TARGET="-Dbuild_overlay=false \
+                       -Dbuild_man=false \
+                       -Dwith_valgrind=false \
+                       -Dbuild_audio=false \
+                       -Dbuild_chamelium=false \
+                       -Dbuild_docs=false \
+                       -Dbuild_tests=true
+                       -Dwith_libdrm=auto \
+                       -Dwith_libunwind=false \
+                       -Dbuild_runner=false"

--- a/packages/graphics/cairo/package.mk
+++ b/packages/graphics/cairo/package.mk
@@ -30,22 +30,13 @@ if [ "$DISPLAYSERVER" = "x11" ]; then
                     --disable-glesv2 \
                     --disable-egl \
                     --with-x"
-
-elif [ "$DISPLAYSERVER" = "weston" ]; then
+else
   PKG_CAIRO_CONFIG="--disable-xlib \
                     --disable-xlib-xrender \
                     --disable-gl \
                     --disable-glx \
                     --enable-glesv2 \
                     --enable-egl \
-                    --without-x"
-else
-  PKG_CAIRO_CONFIG="--disable-xlib \
-                    --disable-xlib-xrender \
-                    --disable-gl \
-                    --disable-glx \
-                    --disable-glesv2 \
-                    --disable-egl \
                     --without-x"
 fi
 

--- a/packages/tools/procps-ng/package.mk
+++ b/packages/tools/procps-ng/package.mk
@@ -9,6 +9,7 @@ PKG_SITE="https://gitlab.com/procps-ng/procps"
 PKG_URL="$SOURCEFORGE_SRC/$PKG_NAME/Production/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="Command line and full screen utilities for browsing procfs."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            ac_cv_func_realloc_0_nonnull=yes \
@@ -16,7 +17,13 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            --disable-modern-top \
                            --enable-static"
 
+PKG_MAKE_OPTS_TARGET="top/top proc/libprocps.la proc/libprocps.pc"
+
+PKG_MAKEINSTALL_OPTS_TARGET="install-libLTLIBRARIES install-pkgconfigDATA"
+
 makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
     cp -P $PKG_BUILD/.$TARGET_NAME/top/top $INSTALL/usr/bin
+
+  make DESTDIR=$SYSROOT_PREFIX -j1 $PKG_MAKEINSTALL_OPTS_TARGET
 }


### PR DESCRIPTION
This add a new package [xorg-intel-gpu-tools](https://github.com/freedesktop/xorg-intel-gpu-tools).

> IGT GPU Tools is a collection of tools for development and testing of the DRM drivers. There are many macro-level test suites that get used against the drivers, including xtest, rendercheck, piglit, and oglconform, but failures from those can be difficult to track down to kernel changes, and many require complicated build procedures or specific testing environments to get useful results. Therefore, IGT GPU Tools includes low-level tools and tests specifically for development and testing of the DRM Drivers.


I ended up using for some intel stuff I'm working on so I figured I would PR it if anyone else wanted to use it. I didn't actually include it in the build as it is quite big so someone wanting to use it will have to add it to their own build.

The changes to cairo just allows building with glesv2 and egl when x11 isn't enabled.
The changes to procps-ng allows builing and installing libprocps.a and pkgconfig into the sysroot.