### PR TITLE
add Intel's new media-driver

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="gmmlib"
+PKG_VERSION="50707fb182bc8fc8f9711d2c0da96f6ded1b8ef4"
+PKG_SHA256="73c8895e3d5c54c8a44682c69db5c1a40da5500dacc07c89cb520d2b21626b05"
+PKG_ARCH="x86_64"
+PKG_LICENSE="MIT"
+PKG_SITE="https://01.org/linuxmedia"
+PKG_URL="https://github.com/intel/gmmlib/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="gmmlib: The Intel(R) Graphics Memory Management Library provides device specific and buffer management for the Intel(R) Graphics Compute Runtime for OpenCL(TM) and the Intel(R) Media Driver for VAAPI."
+
+PKG_CMAKE_OPTS_TARGET="-DRUN_TEST_SUITE=OFF"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="media-driver"
+PKG_VERSION="82c0e6f7f6fd920218031a1d202b4ae06e3cf148"
+PKG_SHA256="6f689d174a7a9597bc1d4b368530f822f29c2a26200c44bead6d885754b0e4b8"
+PKG_ARCH="x86_64"
+PKG_LICENSE="MIT"
+PKG_SITE="https://01.org/linuxmedia"
+PKG_URL="https://github.com/intel/media-driver/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libva libdrm gmmlib"
+PKG_LONGDESC="media-driver: The Intel(R) Media Driver for VAAPI is a new VA-API (Video Acceleration API) user mode driver supporting hardware accelerated decoding, encoding, and video post processing for GEN based graphics hardware."
+
+PKG_CMAKE_OPTS_TARGET="-DENABLE_NONFREE_KERNELS=OFF -DBUILD_KERNELS=OFF"

--- a/packages/multimedia/media-driver/patches/media-driver-0001-remove-x11-dependency.patch
+++ b/packages/multimedia/media-driver/patches/media-driver-0001-remove-x11-dependency.patch
@@ -1,0 +1,14 @@
+diff -Naur a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp
+--- a/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp	2019-04-12 00:30:46.000000000 -0700
++++ b/media_driver/linux/common/codec/ddi/media_libva_decoder.cpp	2019-04-12 22:55:05.146368984 -0700
+@@ -41,10 +41,6 @@
+ #include "media_interfaces.h"
+ #include "media_ddi_decode_const.h"
+ 
+-#ifndef ANDROID
+-#include <X11/Xutil.h>
+-#endif
+-
+ #include <linux/fb.h>
+ 
+ typedef MediaDdiFactory<DdiMediaDecode, DDI_DECODE_CONFIG_ATTR> DdiDecodeFactory;


### PR DESCRIPTION
This adds a package for intels new media-driver which will eventually replace intel-vaapi-driver for newer intel platforms

>The Intel(R) Media Driver for VAAPI is a new VA-API (Video Acceleration API) user mode driver supporting hardware accelerated decoding, encoding, and video post processing for GEN based graphics hardware.

I did not include this by default as it is quite large and requires manual user interaction to use it anyways.
For example:
```
LIBVA_DRIVER_NAME="iHD" /usr/lib/kodi/kodi.bin
```