### PR TITLE
init: set ondemand up_threshold for multi-cluster CPUs

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -933,6 +933,10 @@ echo '1 4 1 7' > /proc/sys/kernel/printk
 # set ondemand up_threshold
 if [ -e /sys/devices/system/cpu/cpufreq/ondemand/up_threshold ]; then
   echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
+else
+  for f in $(ls /sys/devices/system/cpu/cpufreq/policy*/ondemand/up_threshold 2>/dev/null) ; do
+    echo 50 > $f
+  done
 fi
 
 # run platform_init script if exists


### PR DESCRIPTION
For multi-cluster CPUs (e.g. Amlogic S912) there is a separate policy for each CPU cluster. Add a case in init script to cover setting up_threshold for all clusters.

```
LibreELEC:~ # find /sys/devices/system/cpu/cpufreq -name up_threshold
/sys/devices/system/cpu/cpufreq/policy4/ondemand/up_threshold
/sys/devices/system/cpu/cpufreq/policy0/ondemand/up_threshold
```