### PR TITLE
config/functions: eliminate unecessary dashboard flock()

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1245,20 +1245,19 @@ pkg_lock() {
 
   local pkg="$1" task="$2" parent_pkg="$3"
   local this_job="${MTJOBID}"
-  local lock_job lock_seq lock_task lock_pkg
+  local lock_job lock_seq lock_task lock_pkg locked=no
   local fail_seq
 
   exec 98>"${THREAD_CONTROL}/locks/${pkg}.${task}"
-  if ! flock --nonblock --exclusive 98; then
-    while [ : ]; do
-      read -r lock_job lock_seq lock_task lock_pkg <<<$(cat "${THREAD_CONTROL}/locks/${pkg}.${task}.owner" 2>/dev/null)
-      [ -n "${lock_job}" ] && break || sleep 1
-    done
+  while [ : ]; do
+    read -r lock_job lock_seq lock_task lock_pkg <<<$(cat "${THREAD_CONTROL}/locks/${pkg}.${task}.owner" 2>/dev/null)
+    [ -n "${lock_job}" ] && break
+    flock --wait 1 --exclusive 98 && locked=yes && break
+  done
 
-    if [ "${lock_job}/${lock_seq}" != "${this_job}/${PARALLEL_SEQ}" ]; then
-      pkg_lock_status "STALLED" "${parent_pkg}" "${task}" "$(printf "waiting on [%02d] %s %s" ${lock_job} "${lock_task}" "${lock_pkg}")"
-      flock --exclusive 98
-    fi
+  if [ "${locked}" = "no" -a "${lock_job}/${lock_seq}" != "${this_job}/${PARALLEL_SEQ}" ]; then
+    pkg_lock_status "STALLED" "${parent_pkg}" "${task}" "$(printf "waiting on [%02d] %s %s" ${lock_job} "${lock_task}" "${lock_pkg}")"
+    flock --exclusive 98
   fi
 
   # As we now have the lock, if .failed still exists then a previous process must have failed
@@ -1305,6 +1304,7 @@ pkg_lock_status() {
     echo "${PARALLEL_SEQ}" > "${THREAD_CONTROL}/locks/${pkg}.${task}.failed"
     echo "${this_job} ${PARALLEL_SEQ} ${task} ${pkg}" >"${THREAD_CONTROL}/locks/${pkg}.${task}.owner"
   elif [ "${status}" = "UNLOCK" ]; then
+    rm "${THREAD_CONTROL}/locks/${pkg}.${task}.owner"
     rm "${THREAD_CONTROL}/locks/${pkg}.${task}.failed"
   fi
 
@@ -1361,19 +1361,18 @@ acquire_exclusive_lock() {
 
   local pkg="$1" task="$2" lockfile="${3:-global}"
   local this_job="${MTJOBID}"
-  local lock_job lock_seq lock_task lock_pkg
+  local lock_job lock_seq lock_task lock_pkg locked=no
 
   exec 96>"${THREAD_CONTROL}/locks/.mutex.${lockfile}"
-  if ! flock --nonblock --exclusive 96; then
-    while [ : ]; do
-      read -r lock_job lock_seq lock_task lock_pkg <<<$(cat "${THREAD_CONTROL}/locks/.mutex.${lockfile}.owner" 2>/dev/null)
-      [ -n "${lock_job}" ] && break || sleep 1
-    done
+  while [ : ]; do
+    read -r lock_job lock_seq lock_task lock_pkg <<<$(cat "${THREAD_CONTROL}/locks/.mutex.${lockfile}.owner" 2>/dev/null)
+    [ -n "${lock_job}" ] && break
+    flock --wait 1 --exclusive 96 && locked=yes && break
+  done
 
-    if [ "${lock_job}/${lock_seq}" != "${this_job}/${PARALLEL_SEQ}" ]; then
-      pkg_lock_status "MUTEX/W" "${pkg}" "${task}" "$(printf "mutex: %s; waiting on [%02d] %s %s" "${lockfile}" ${lock_job} "${lock_task}" "${lock_pkg}")"
-      flock --exclusive 96
-    fi
+  if [ "${locked}" = "no" -a "${lock_job}/${lock_seq}" != "${this_job}/${PARALLEL_SEQ}" ]; then
+    pkg_lock_status "MUTEX/W" "${pkg}" "${task}" "$(printf "mutex: %s; waiting on [%02d] %s %s" "${lockfile}" ${lock_job} "${lock_task}" "${lock_pkg}")"
+    flock --exclusive 96
   fi
 
   pkg_lock_status "MUTEX" "${pkg}" "${task}" "mutex: ${lockfile}"
@@ -1384,10 +1383,11 @@ acquire_exclusive_lock() {
 release_exclusive_lock() {
   [ "${MTWITHLOCKS}" != "yes" ] && return 0
 
-  local pkg="$1" task="$2"
+  local pkg="$1" task="$2" lockfile="${3:-global}"
 
   pkg_lock_status "ACTIVE" "${pkg}" "${task}"
 
+  rm "${THREAD_CONTROL}/locks/.mutex.${lockfile}.owner"
   flock --unlock 96 2>/dev/null
 }
 

--- a/config/functions
+++ b/config/functions
@@ -1295,9 +1295,11 @@ pkg_lock_status() {
     [ -n "${msg}" ] && line+=" (${msg})"
 
     echo "${line}" >>"${THREAD_CONTROL}/history"
-  ) 94>"${THREAD_CONTROL}/locks/.history"
 
-  [ "${DASHBOARD}" != "no" ] && update_dashboard "${status}" "${pkg}" "${task}" "${msg}"
+    if [ "${DASHBOARD}" != "no" ]; then
+      update_dashboard "${status}" "${pkg}" "${task}" "${msg}"
+    fi
+  ) 94>"${THREAD_CONTROL}/locks/.history"
 
   if [ "${status}" = "LOCKED" ]; then
     echo "${PARALLEL_SEQ}" > "${THREAD_CONTROL}/locks/${pkg}.${task}.failed"
@@ -1314,47 +1316,43 @@ update_dashboard() {
   local line sedline preamble num elapsed projdevarch
   local boldred boldgreen boldyellow endcolor
 
-  (
-    flock --exclusive 97
+  [ -n "${MTJOBID}" ] && sedline=$((MTJOBID + 2)) || sedline=1
 
-    [ -n "${MTJOBID}" ] && sedline=$((MTJOBID + 2)) || sedline=1
+  num=$(cat "${THREAD_CONTROL}/status" | wc -l)
+  while [ ${num} -lt ${sedline} ]; do echo "" >>"${THREAD_CONTROL}/status"; num=$((num + 1)); done
 
-    num=$(cat "${THREAD_CONTROL}/status" | wc -l)
-    while [ ${num} -lt ${sedline} ]; do echo "" >>"${THREAD_CONTROL}/status"; num=$((num + 1)); done
+  num=$(($(cat "${THREAD_CONTROL}/progress.prev") + 1))
+  projdevarch="${PROJECT}/"
+  [ -n "${DEVICE}" ] && projdevarch+="${DEVICE}/"
+  projdevarch+="${TARGET_ARCH}"
+  TZ=UTC0 printf -v elapsed "%(%H:%M:%S)T" $(($(date +%s) - MTBUILDSTART))
+  printf -v preamble "%s Dashboard (%s) - %d of %d jobs completed, %s elapsed" "${DISTRONAME}" "${projdevarch}" ${num} ${MTMAXJOBS} "${elapsed}"
+  printf -v preamble "%b%-105s %s" "\e[2J\e[0;0H" "${preamble//\//\\/}" "$(date "+%Y-%m-%d %H:%M:%S")"
 
-    num=$(($(cat "${THREAD_CONTROL}/progress.prev") + 1))
-    projdevarch="${PROJECT}/"
-    [ -n "${DEVICE}" ] && projdevarch+="${DEVICE}/"
-    projdevarch+="${TARGET_ARCH}"
-    TZ=UTC0 printf -v elapsed "%(%H:%M:%S)T" $(($(date +%s) - MTBUILDSTART))
-    printf -v preamble "%s Dashboard (%s) - %d of %d jobs completed, %s elapsed" "${DISTRONAME}" "${projdevarch}" ${num} ${MTMAXJOBS} "${elapsed}"
-    printf -v preamble "%b%-105s %s" "\e[2J\e[0;0H" "${preamble//\//\\/}" "$(date "+%Y-%m-%d %H:%M:%S")"
+  # Only update the header when caller is not a worker thread
+  if [ -z "${MTJOBID}" ]; then
+    sed -e "1s/.*/${preamble}/" -i "${THREAD_CONTROL}/status"
+  else
+    if [ "${DISABLE_COLORS}" != "yes" ]; then
+      boldred="\e[1;31m"
+      boldgreen="\e[1;32m"
+      boldyellow="\e[1;33m"
+      white="\e[0;37m"
+      endcolor="\e[0m"
 
-    # Only update the header when caller is not a worker thread
-    if [ -z "${MTJOBID}" ]; then
-      sed -e "1s/.*/${preamble}/" -i "${THREAD_CONTROL}/status"
-    else
-      if [ "${DISABLE_COLORS}" != "yes" ]; then
-        boldred="\e[1;31m"
-        boldgreen="\e[1;32m"
-        boldyellow="\e[1;33m"
-        white="\e[0;37m"
-        endcolor="\e[0m"
-
-        case "${status}" in
-          IDLE)    color="${white}";;
-          STALLED) color="${boldyellow}";;
-          MUTEX/W) color="${boldyellow}";;
-          FAILED ) color="${boldred}";;
-          *)       color="${boldgreen}";;
-        esac
-      fi
-
-      printf -v line "[%02d\/%0*d] %b%-7s%b %-7s %-35s" ${MTJOBID} ${#MTMAXJOBS} ${PARALLEL_SEQ:-0} "${color}" "${status//\//\\/}" "${endcolor}" "${task}" "${pkg}"
-      [ -n "${msg}" ] && line+=" ${msg//\//\\/}"
-      sed -e "1s/.*/${preamble}/;${sedline}s/.*/${line}/" -i "${THREAD_CONTROL}/status"
+      case "${status}" in
+        IDLE)    color="${white}";;
+        STALLED) color="${boldyellow}";;
+        MUTEX/W) color="${boldyellow}";;
+        FAILED ) color="${boldred}";;
+        *)       color="${boldgreen}";;
+      esac
     fi
-  ) 97>"${THREAD_CONTROL}/locks/.status"
+
+    printf -v line "[%02d\/%0*d] %b%-7s%b %-7s %-35s" ${MTJOBID} ${#MTMAXJOBS} ${PARALLEL_SEQ:-0} "${color}" "${status//\//\\/}" "${endcolor}" "${task}" "${pkg}"
+    [ -n "${msg}" ] && line+=" ${msg//\//\\/}"
+    sed -e "1s/.*/${preamble}/;${sedline}s/.*/${line}/" -i "${THREAD_CONTROL}/status"
+  fi
 }
 
 # Thread concurrency helpers to avoid concurrency issues with some code,

--- a/config/functions
+++ b/config/functions
@@ -1312,11 +1312,13 @@ pkg_lock_status() {
 }
 
 update_dashboard() {
+  [ "${MTWITHLOCKS}" != "yes" ] && return 0
+
   local status="$1" pkg="$2" task="$3" msg="$4"
   local line sedline preamble num elapsed projdevarch
   local boldred boldgreen boldyellow endcolor
 
-  [ -n "${MTJOBID}" ] && sedline=$((MTJOBID + 2)) || sedline=1
+  sedline=$((MTJOBID + 2))
 
   num=$(cat "${THREAD_CONTROL}/status" | wc -l)
   while [ ${num} -lt ${sedline} ]; do echo "" >>"${THREAD_CONTROL}/status"; num=$((num + 1)); done
@@ -1329,30 +1331,26 @@ update_dashboard() {
   printf -v preamble "%s Dashboard (%s) - %d of %d jobs completed, %s elapsed" "${DISTRONAME}" "${projdevarch}" ${num} ${MTMAXJOBS} "${elapsed}"
   printf -v preamble "%b%-105s %s" "\e[2J\e[0;0H" "${preamble//\//\\/}" "$(date "+%Y-%m-%d %H:%M:%S")"
 
-  # Only update the header when caller is not a worker thread
-  if [ -z "${MTJOBID}" ]; then
-    sed -e "1s/.*/${preamble}/" -i "${THREAD_CONTROL}/status"
-  else
-    if [ "${DISABLE_COLORS}" != "yes" ]; then
-      boldred="\e[1;31m"
-      boldgreen="\e[1;32m"
-      boldyellow="\e[1;33m"
-      white="\e[0;37m"
-      endcolor="\e[0m"
+  if [ "${DISABLE_COLORS}" != "yes" ]; then
+    boldred="\e[1;31m"
+    boldgreen="\e[1;32m"
+    boldyellow="\e[1;33m"
+    white="\e[0;37m"
+    endcolor="\e[0m"
 
-      case "${status}" in
-        IDLE)    color="${white}";;
-        STALLED) color="${boldyellow}";;
-        MUTEX/W) color="${boldyellow}";;
-        FAILED ) color="${boldred}";;
-        *)       color="${boldgreen}";;
-      esac
-    fi
-
-    printf -v line "[%02d\/%0*d] %b%-7s%b %-7s %-35s" ${MTJOBID} ${#MTMAXJOBS} ${PARALLEL_SEQ:-0} "${color}" "${status//\//\\/}" "${endcolor}" "${task}" "${pkg}"
-    [ -n "${msg}" ] && line+=" ${msg//\//\\/}"
-    sed -e "1s/.*/${preamble}/;${sedline}s/.*/${line}/" -i "${THREAD_CONTROL}/status"
+    case "${status}" in
+      IDLE)    color="${white}";;
+      STALLED) color="${boldyellow}";;
+      MUTEX/W) color="${boldyellow}";;
+      FAILED ) color="${boldred}";;
+      *)       color="${boldgreen}";;
+    esac
   fi
+
+  printf -v line "[%02d\/%0*d] %b%-7s%b %-7s %-35s" ${MTJOBID} ${#MTMAXJOBS} ${PARALLEL_SEQ:-0} "${color}" "${status//\//\\/}" "${endcolor}" "${task}" "${pkg}"
+  [ -n "${msg}" ] && line+=" ${msg//\//\\/}"
+
+  sed -e "1s/.*/${preamble}/;${sedline}s/.*/${line}/" -i "${THREAD_CONTROL}/status"
 }
 
 # Thread concurrency helpers to avoid concurrency issues with some code,


### PR DESCRIPTION
We only update the dashboard after updating the history, and since we already have an exclusive lock on the history there's no need to take a lock on the status (dashboard) file too, so we can dispense with the `flock()` on `.status` entirely.

(Hiding the whitespace changes makes the relevant changes much easier to see!)