### PR TITLE
dav1d: updated to 0.3.0 / cleaned up

### DIFF
--- a/packages/multimedia/dav1d/package.mk
+++ b/packages/multimedia/dav1d/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dav1d"
-PKG_VERSION="0.2.1"
-PKG_SHA256="887f672f0afad9ff66735997e4d55d03b72a098238e291ecb17ae529adc7dd23"
+PKG_VERSION="0.3.0"
+PKG_SHA256="22946ddd8c5122d3490b250933328c3278da21b0659db9b7fa8f875e4735c2e6"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.jbkempf.com/blog/post/2018/Introducing-dav1d"
-PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/dav1d-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="dav1d is an AV1 decoder :)"
 


### PR DESCRIPTION
Release notes:

- https://code.videolan.org/videolan/dav1d/tags/0.2.2
- https://code.videolan.org/videolan/dav1d/tags/0.3.0

I testet it on my Generic i3-6100 & J3455 systems. The SSSE3 gave the Celeron a nice speed boost & lowered the average CPU usage from ~350% to under 300%