### PR TITLE
config/graphic+mesa: simplify dedupe by using space-delimited lists

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -1,10 +1,10 @@
-if [ "$OPENGL" = no ]; then
+if [ "${OPENGL}" = no ]; then
   OPENGL_SUPPORT="no"
 else
   OPENGL_SUPPORT="yes"
 fi
 
-if [ "$OPENGLES" = no ]; then
+if [ "${OPENGLES}" = no ]; then
   OPENGLES_SUPPORT="no"
 else
   OPENGLES_SUPPORT="yes"
@@ -22,111 +22,109 @@ get_graphicdrivers() {
   VAAPI_SUPPORT="no"
   V4L2_SUPPORT="no"
 
-  if [ "$GRAPHIC_DRIVERS" = "all" ]; then
+  if [ "${GRAPHIC_DRIVERS}" = "all" ]; then
     GRAPHIC_DRIVERS="i915 i965 r200 r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "etnaviv"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,etnaviv,imx"
+  if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} etnaviv imx"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "freedreno"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,freedreno"
+  if listcontains "${GRAPHIC_DRIVERS}" "freedreno"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} freedreno"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "i915"; then
-    DRI_DRIVERS="$DRI_DRIVERS,i915"
-    XORG_DRIVERS="$XORG_DRIVERS intel"
+  if listcontains "${GRAPHIC_DRIVERS}" "i915"; then
+    DRI_DRIVERS="${DRI_DRIVERS} i915"
+    XORG_DRIVERS="${XORG_DRIVERS} intel"
     COMPOSITE_SUPPORT="yes"
     VAAPI_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "i965"; then
-    DRI_DRIVERS="$DRI_DRIVERS,i965"
-    XORG_DRIVERS="$XORG_DRIVERS intel"
+  if listcontains "${GRAPHIC_DRIVERS}" "i965"; then
+    DRI_DRIVERS="${DRI_DRIVERS} i965"
+    XORG_DRIVERS="${XORG_DRIVERS} intel"
     COMPOSITE_SUPPORT="yes"
     VAAPI_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "lima"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,kmsro,lima"
+  if listcontains "${GRAPHIC_DRIVERS}" "lima"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} kmsro lima"
     V4L2_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "nvidia"; then
-    XORG_DRIVERS="$XORG_DRIVERS nvidia"
+  if listcontains "${GRAPHIC_DRIVERS}" "nvidia"; then
+    XORG_DRIVERS="${XORG_DRIVERS} nvidia"
     VDPAU_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "nvidia-legacy"; then
-    XORG_DRIVERS="$XORG_DRIVERS nvidia-legacy"
+  if listcontains "${GRAPHIC_DRIVERS}" "nvidia-legacy"; then
+    XORG_DRIVERS="${XORG_DRIVERS} nvidia-legacy"
     VDPAU_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "panfrost"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,kmsro,panfrost"
+  if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} kmsro panfrost"
     V4L2_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "r200"; then
-    DRI_DRIVERS="$DRI_DRIVERS,r200"
-    XORG_DRIVERS="$XORG_DRIVERS ati"
+  if listcontains "${GRAPHIC_DRIVERS}" "r200"; then
+    DRI_DRIVERS="${DRI_DRIVERS} r200"
+    XORG_DRIVERS="${XORG_DRIVERS} ati"
     COMPOSITE_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "r300"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,r300"
-    XORG_DRIVERS="$XORG_DRIVERS ati"
+  if listcontains "${GRAPHIC_DRIVERS}" "r300"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} r300"
+    XORG_DRIVERS="${XORG_DRIVERS} ati"
     LLVM_SUPPORT="yes"
     COMPOSITE_SUPPORT="yes"
     VDPAU_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "r600"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,r600"
-    XORG_DRIVERS="$XORG_DRIVERS ati"
-    LLVM_SUPPORT="yes"
-    COMPOSITE_SUPPORT="yes"
-    VDPAU_SUPPORT="yes"
-    VAAPI_SUPPORT="yes"
-  fi
-
-  if listcontains "$GRAPHIC_DRIVERS" "radeonsi"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,radeonsi"
-    XORG_DRIVERS="$XORG_DRIVERS ati amdgpu"
+  if listcontains "${GRAPHIC_DRIVERS}" "r600"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} r600"
+    XORG_DRIVERS="${XORG_DRIVERS} ati"
     LLVM_SUPPORT="yes"
     COMPOSITE_SUPPORT="yes"
     VDPAU_SUPPORT="yes"
     VAAPI_SUPPORT="yes"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "vc4"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,vc4"
+  if listcontains "${GRAPHIC_DRIVERS}" "radeonsi"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} radeonsi"
+    XORG_DRIVERS="${XORG_DRIVERS} ati amdgpu"
+    LLVM_SUPPORT="yes"
+    COMPOSITE_SUPPORT="yes"
+    VDPAU_SUPPORT="yes"
+    VAAPI_SUPPORT="yes"
+  fi
+
+  if listcontains "${GRAPHIC_DRIVERS}" "vc4"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} vc4"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "virtio"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,virgl"
+  if listcontains "${GRAPHIC_DRIVERS}" "virtio"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} virgl"
   fi
 
-  if listcontains "$GRAPHIC_DRIVERS" "vmware"; then
-    GALLIUM_DRIVERS="$GALLIUM_DRIVERS,svga"
-    XORG_DRIVERS="$XORG_DRIVERS vmware"
+  if listcontains "${GRAPHIC_DRIVERS}" "vmware"; then
+    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} svga"
+    XORG_DRIVERS="${XORG_DRIVERS} vmware"
     COMPOSITE_SUPPORT="yes"
   fi
-
-  # remove leading comma if present
-  [[ $GALLIUM_DRIVERS =~ ^, ]] && GALLIUM_DRIVERS="${GALLIUM_DRIVERS:1}"
-  [[ $DRI_DRIVERS =~ ^, ]] && DRI_DRIVERS="${DRI_DRIVERS:1}"
 
   # remove duplicate entries
-  XORG_DRIVERS="$(echo $XORG_DRIVERS | xargs -n1 | sort -u | xargs)"
+  GALLIUM_DRIVERS="$(echo ${GALLIUM_DRIVERS} | xargs -n1 | sort -u | xargs)"
+  XORG_DRIVERS="$(echo ${XORG_DRIVERS} | xargs -n1 | sort -u | xargs)"
+  DRI_DRIVERS="$(echo ${DRI_DRIVERS} | xargs -n1 | sort -u | xargs)"
 }

--- a/config/graphic
+++ b/config/graphic
@@ -27,70 +27,70 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} etnaviv imx"
+    GALLIUM_DRIVERS+=" etnaviv imx"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "freedreno"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} freedreno"
+    GALLIUM_DRIVERS+=" freedreno"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "i915"; then
-    DRI_DRIVERS="${DRI_DRIVERS} i915"
-    XORG_DRIVERS="${XORG_DRIVERS} intel"
+    DRI_DRIVERS+=" i915"
+    XORG_DRIVERS+=" intel"
     COMPOSITE_SUPPORT="yes"
     VAAPI_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "i965"; then
-    DRI_DRIVERS="${DRI_DRIVERS} i965"
-    XORG_DRIVERS="${XORG_DRIVERS} intel"
+    DRI_DRIVERS+=" i965"
+    XORG_DRIVERS+=" intel"
     COMPOSITE_SUPPORT="yes"
     VAAPI_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "lima"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} kmsro lima"
+    GALLIUM_DRIVERS+=" kmsro lima"
     V4L2_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "nvidia"; then
-    XORG_DRIVERS="${XORG_DRIVERS} nvidia"
+    XORG_DRIVERS+=" nvidia"
     VDPAU_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "nvidia-legacy"; then
-    XORG_DRIVERS="${XORG_DRIVERS} nvidia-legacy"
+    XORG_DRIVERS+=" nvidia-legacy"
     VDPAU_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} kmsro panfrost"
+    GALLIUM_DRIVERS+=" kmsro panfrost"
     V4L2_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "r200"; then
-    DRI_DRIVERS="${DRI_DRIVERS} r200"
-    XORG_DRIVERS="${XORG_DRIVERS} ati"
+    DRI_DRIVERS+=" r200"
+    XORG_DRIVERS+=" ati"
     COMPOSITE_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "r300"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} r300"
-    XORG_DRIVERS="${XORG_DRIVERS} ati"
+    GALLIUM_DRIVERS+=" r300"
+    XORG_DRIVERS+=" ati"
     LLVM_SUPPORT="yes"
     COMPOSITE_SUPPORT="yes"
     VDPAU_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "r600"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} r600"
-    XORG_DRIVERS="${XORG_DRIVERS} ati"
+    GALLIUM_DRIVERS+=" r600"
+    XORG_DRIVERS+=" ati"
     LLVM_SUPPORT="yes"
     COMPOSITE_SUPPORT="yes"
     VDPAU_SUPPORT="yes"
@@ -98,8 +98,8 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "radeonsi"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} radeonsi"
-    XORG_DRIVERS="${XORG_DRIVERS} ati amdgpu"
+    GALLIUM_DRIVERS+=" radeonsi"
+    XORG_DRIVERS+=" ati amdgpu"
     LLVM_SUPPORT="yes"
     COMPOSITE_SUPPORT="yes"
     VDPAU_SUPPORT="yes"
@@ -107,19 +107,19 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "vc4"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} vc4"
+    GALLIUM_DRIVERS+=" vc4"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "virtio"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} virgl"
+    GALLIUM_DRIVERS+=" virgl"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "vmware"; then
-    GALLIUM_DRIVERS="${GALLIUM_DRIVERS} svga"
-    XORG_DRIVERS="${XORG_DRIVERS} vmware"
+    GALLIUM_DRIVERS+=" svga"
+    XORG_DRIVERS+=" vmware"
     COMPOSITE_SUPPORT="yes"
   fi
 

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -15,8 +15,8 @@ PKG_BUILD_FLAGS="+lto"
 
 get_graphicdrivers
 
-PKG_MESON_OPTS_TARGET="-Ddri-drivers=$DRI_DRIVERS \
-                       -Dgallium-drivers=$GALLIUM_DRIVERS \
+PKG_MESON_OPTS_TARGET="-Ddri-drivers=${DRI_DRIVERS// /,} \
+                       -Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
                        -Dgallium-xvmc=false \
                        -Dgallium-omx=disabled \


### PR DESCRIPTION
Space delimited lists are generally easier to work with in shell code, and we only need to convert them to comma-delimited lists where they are ultimately "consumed".