### PR TITLE
libmali: add support for multiple so-files

### DIFF
--- a/packages/graphics/libmali/package.mk
+++ b/packages/graphics/libmali/package.mk
@@ -2,26 +2,36 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmali"
-PKG_VERSION="ad56ed30985471c0950a654cc9db1e86310650d5"
-PKG_SHA256="72438ea73cf6c2e8e770545872386b66ccad200c568261e5304845547099c9ed"
+PKG_VERSION="4cbf211cfd9b07854aab4978e50b1151052c6d4c"
+PKG_SHA256="d3c5dd43ee0830feada4a86d32b9c794cddab29a863dfd1dddb3954f380086c5"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="https://github.com/LibreELEC/libmali"
 PKG_URL="https://github.com/LibreELEC/libmali/archive/$PKG_VERSION.tar.gz"
 PKG_LONGDESC="OpenGL ES user-space binary for the ARM Mali GPU family"
+PKG_STAMP="$MALI_FAMILY"
 
 PKG_DEPENDS_TARGET="libdrm"
 
-if [ "$MALI_FAMILY" = "t620" -o "$MALI_FAMILY" = "t720" -o "$MALI_FAMILY" = "g52" ]; then
+if listcontains "$MALI_FAMILY" "(t620|t720)"; then
   PKG_DEPENDS_TARGET+=" wayland"
 fi
 
-PKG_CMAKE_OPTS_TARGET="-DMALI_VARIANT=$MALI_FAMILY"
-
-if [ -n "$MALI_REVISION" ]; then
-  PKG_CMAKE_OPTS_TARGET+=" -DMALI_REVISION=$MALI_REVISION"
-fi
+PKG_CMAKE_OPTS_TARGET="-DMALI_VARIANT=${MALI_FAMILY// /;}"
 
 if [ "$TARGET_ARCH" = "aarch64" ]; then
   PKG_CMAKE_OPTS_TARGET+=" -DMALI_ARCH=aarch64-linux-gnu"
 fi
+
+post_makeinstall_target() {
+  mkdir -p $INSTALL/usr/bin
+    cp -v $PKG_DIR/scripts/libmali-setup $INSTALL/usr/bin
+
+  if [ $(ls -1q $INSTALL/usr/lib/libmali-*.so | wc -l) -gt 1 ]; then
+    ln -sfv /var/lib/libmali/libmali.so $INSTALL/usr/lib/libmali.so
+  fi
+}
+
+post_install() {
+  enable_service libmali-setup.service
+}

--- a/packages/graphics/libmali/scripts/libmali-setup
+++ b/packages/graphics/libmali/scripts/libmali-setup
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+GPUINFO=/sys/kernel/debug/mali/version
+[ ! -f "$GPUINFO" ] && GPUINFO=$(find /sys/devices/platform -name gpuinfo)
+
+echo "GPUINFO: $GPUINFO"
+[ ! -f "$GPUINFO" ] && exit
+
+GPU=$(cat $GPUINFO)
+echo "GPU: $GPU"
+
+case $GPU in
+  Mali-400*) LIB="libmali-utgard-400-*.so" ;;
+  Mali-450*) LIB="libmali-utgard-450-*.so" ;;
+  Mali-T60x*) LIB="libmali-midgard-t60x-*.so" ;;
+  Mali-T62x*) LIB="libmali-midgard-t620-*.so" ;;
+  Mali-T72x*) LIB="libmali-midgard-t720-*.so" ;;
+  Mali-T76x*r0p0*) LIB="libmali-midgard-t76x-*-r0p0-*.so" ;;
+  Mali-T76x*r1p0*) LIB="libmali-midgard-t76x-*-r1p0-*.so" ;;
+  Mali-T82x*) LIB="libmali-midgard-t82x-*.so" ;;
+  Mali-T83x*) LIB="libmali-midgard-t83x-*.so" ;;
+  Mali-T86x*) LIB="libmali-midgard-t86x-*.so" ;;
+  Mali-T88x*) LIB="libmali-midgard-t88x-*.so" ;;
+  Mali-G31*) LIB="libmali-bifrost-g31-*.so" ;;
+  Mali-G51*) LIB="libmali-bifrost-g51-*.so" ;;
+  Mali-G52*) LIB="libmali-bifrost-g52-*.so" ;;
+  Mali-G71*) LIB="libmali-bifrost-g71-*.so" ;;
+  Mali-G72*) LIB="libmali-bifrost-g72-*.so" ;;
+  Mali-G76*) LIB="libmali-bifrost-g76-*.so" ;;
+esac
+
+echo "LIB: $LIB"
+[ -z "$LIB" ] && exit
+
+LIBMALI=$(find /usr/lib -name $LIB)
+
+echo "LIBMALI: $LIBMALI"
+[ ! -f "$LIBMALI" ] && exit
+
+mkdir -p /var/lib/libmali
+ln -sf $LIBMALI /var/lib/libmali/libmali.so

--- a/packages/graphics/libmali/system.d/libmali-setup.service
+++ b/packages/graphics/libmali/system.d/libmali-setup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Setup symlink for ARM Mali library
+Before=graphical.target
+After=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/libmali-setup
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR updates libmali to latest to add support for multiple so-files in an image.

`/usr/lib/libmali.so` will be linked to `/var/lib/libmali/libmali.so` when there is multiple .so-files installed.
`libmali-setup` script/service will create the `/var/lib/libmali/libmali.so` symlink based on gpu reported by kernel driver.

Example of `libmali-setup` output:
```
LibreELEC:~ # libmali-setup
GPUINFO: /sys/devices/platform/ffa30000.gpu/gpuinfo
GPU: Mali-T76x 4 cores r0p0 0x0750
LIB: libmali-midgard-t76x-*-r0p0-*.so
LIBMALI: /usr/lib/libmali-midgard-t76x-r14p0-r0p0-gbm.so
```