### PR TITLE
config/functions: add C++ compiler and linker flags to meson.conf

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -386,6 +386,8 @@ endian = '$endian'
 root = '$root'
 $(python -c "import os; print('c_args = {}'.format([x for x in os.getenv('CFLAGS').split()]))")
 $(python -c "import os; print('c_link_args = {}'.format([x for x in os.getenv('LDFLAGS').split()]))")
+$(python -c "import os; print('cpp_args = {}'.format([x for x in os.getenv('CXXFLAGS').split()]))")
+$(python -c "import os; print('cpp_link_args = {}'.format([x for x in os.getenv('LDFLAGS').split()]))")
 ${!properties}
 EOF
 }


### PR DESCRIPTION
Due to missing cpp_args and cpp_link_args in meson.conf ninja builds
of projects with C++ code were performed without CPU optimization
flags (-march, -mcpu, -mtune etc). Add these args so C++ code is
built with proper flags.