### PR TITLE
scripts/image: build an image for each UBOOT_SYSTEM

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -32,6 +32,7 @@ function do_mkimage() {
     DEVICE="$DEVICE" \
     DISTRO="$DISTRO" \
     TARGET_IMG="$TARGET_IMG" \
+    BUILD_NAME="$IMAGE_NAME" \
     IMAGE_NAME="$IMAGE_NAME" \
     INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
     BOOTLOADER="$BOOTLOADER" \

--- a/scripts/image
+++ b/scripts/image
@@ -33,7 +33,7 @@ function do_mkimage() {
     DISTRO="$DISTRO" \
     TARGET_IMG="$TARGET_IMG" \
     BUILD_NAME="$IMAGE_NAME" \
-    IMAGE_NAME="$IMAGE_NAME" \
+    IMAGE_NAME="${1:-$IMAGE_NAME}" \
     INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
     BOOTLOADER="$BOOTLOADER" \
     KERNEL_NAME="$KERNEL_NAME" \
@@ -316,7 +316,26 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
     UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
     UUID_STORAGE="$(uuidgen)"
 
-    do_mkimage
+    DEVICE_BOARDS=$($SCRIPTS/uboot_helper "$PROJECT" "$DEVICE")
+
+    if [ "$BOOTLOADER" = "u-boot" -a -z "$UBOOT_SYSTEM" -a -n "$DEVICE" -a -n "$DEVICE_BOARDS" ]; then
+      for UBOOT_SYSTEM in $DEVICE_BOARDS; do
+
+        # Re-install u-boot package
+        rm $STAMPS_INSTALL/u-boot/install_target
+        UBOOT_SYSTEM="$UBOOT_SYSTEM" $SCRIPTS/install u-boot
+
+        # Re-run bootloader/release
+        if find_file_path bootloader/release $BOOTLOADER_DIR/release; then
+          echo "Running $FOUND_PATH"
+          . $FOUND_PATH
+        fi
+
+        do_mkimage "$IMAGE_NAME-$UBOOT_SYSTEM"
+      done
+    else
+      do_mkimage
+    fi
   fi
 
   # Cleanup release dir

--- a/scripts/image
+++ b/scripts/image
@@ -20,6 +20,36 @@ ${SCRIPTS}/checkdeps
 ( setup_toolchain host )
 setup_toolchain target
 
+function do_mkimage() {
+  # Variables used in mkimage script must be passed
+  env \
+    PATH="$PATH:/sbin" \
+    ROOT="$ROOT" \
+    SCRIPTS="$SCRIPTS" \
+    TOOLCHAIN="$TOOLCHAIN" \
+    PROJECT_DIR="$PROJECT_DIR" \
+    PROJECT="$PROJECT" \
+    DEVICE="$DEVICE" \
+    DISTRO="$DISTRO" \
+    TARGET_IMG="$TARGET_IMG" \
+    IMAGE_NAME="$IMAGE_NAME" \
+    INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
+    BOOTLOADER="$BOOTLOADER" \
+    KERNEL_NAME="$KERNEL_NAME" \
+    TARGET_KERNEL_ARCH="$TARGET_KERNEL_ARCH" \
+    RELEASE_DIR="$RELEASE_DIR" \
+    UUID_STORAGE="$(uuidgen)" \
+    DISTRO_BOOTLABEL="$DISTRO_BOOTLABEL" \
+    DISTRO_DISKLABEL="$DISTRO_DISKLABEL" \
+    UBOOT_SYSTEM="$UBOOT_SYSTEM" \
+    UBOOT_VERSION="$UBOOT_VERSION" \
+    EXTRA_CMDLINE="$EXTRA_CMDLINE" \
+    SYSTEM_SIZE="$SYSTEM_SIZE" \
+    SYSTEM_PART_START="$SYSTEM_PART_START" \
+    OVA_SIZE="$OVA_SIZE" \
+    $SCRIPTS/mkimage
+}
+
 if [ -n "$CUSTOM_GIT_HASH" ]; then
   GIT_HASH="$CUSTOM_GIT_HASH"
 else
@@ -281,33 +311,7 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
       INSTALL_SRC_DIR="$PROJECT_DIR/$PROJECT/install"
     fi
 
-    # Variables used in image script must be passed
-    env \
-      PATH="$PATH:/sbin" \
-      ROOT="$ROOT" \
-      SCRIPTS="$SCRIPTS" \
-      TOOLCHAIN="$TOOLCHAIN" \
-      PROJECT_DIR="$PROJECT_DIR" \
-      PROJECT="$PROJECT" \
-      DEVICE="$DEVICE" \
-      DISTRO="$DISTRO" \
-      TARGET_IMG="$TARGET_IMG" \
-      IMAGE_NAME="$IMAGE_NAME" \
-      INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
-      BOOTLOADER="$BOOTLOADER" \
-      KERNEL_NAME="$KERNEL_NAME" \
-      TARGET_KERNEL_ARCH="$TARGET_KERNEL_ARCH" \
-      RELEASE_DIR=$RELEASE_DIR \
-      UUID_STORAGE="$(uuidgen)" \
-      DISTRO_BOOTLABEL="$DISTRO_BOOTLABEL" \
-      DISTRO_DISKLABEL="$DISTRO_DISKLABEL" \
-      UBOOT_SYSTEM="$UBOOT_SYSTEM" \
-      UBOOT_VERSION="$UBOOT_VERSION" \
-      EXTRA_CMDLINE="$EXTRA_CMDLINE" \
-      SYSTEM_SIZE="$SYSTEM_SIZE" \
-      SYSTEM_PART_START="$SYSTEM_PART_START" \
-      OVA_SIZE="$OVA_SIZE" \
-      $SCRIPTS/mkimage
+    do_mkimage
   fi
 
   # Cleanup release dir

--- a/scripts/image
+++ b/scripts/image
@@ -38,7 +38,8 @@ function do_mkimage() {
     KERNEL_NAME="$KERNEL_NAME" \
     TARGET_KERNEL_ARCH="$TARGET_KERNEL_ARCH" \
     RELEASE_DIR="$RELEASE_DIR" \
-    UUID_STORAGE="$(uuidgen)" \
+    UUID_SYSTEM="$UUID_SYSTEM" \
+    UUID_STORAGE="$UUID_STORAGE" \
     DISTRO_BOOTLABEL="$DISTRO_BOOTLABEL" \
     DISTRO_DISKLABEL="$DISTRO_DISKLABEL" \
     UBOOT_SYSTEM="$UBOOT_SYSTEM" \
@@ -310,6 +311,9 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
     else
       INSTALL_SRC_DIR="$PROJECT_DIR/$PROJECT/install"
     fi
+
+    UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
+    UUID_STORAGE="$(uuidgen)"
 
     do_mkimage
   fi

--- a/scripts/image_st
+++ b/scripts/image_st
@@ -23,6 +23,36 @@ $SCRIPTS/build kmod:host
 $SCRIPTS/build mtools:host
 $SCRIPTS/build populatefs:host
 
+function do_mkimage() {
+  # Variables used in mkimage script must be passed
+  env \
+    PATH="$PATH:/sbin" \
+    ROOT="$ROOT" \
+    SCRIPTS="$SCRIPTS" \
+    TOOLCHAIN="$TOOLCHAIN" \
+    PROJECT_DIR="$PROJECT_DIR" \
+    PROJECT="$PROJECT" \
+    DEVICE="$DEVICE" \
+    DISTRO="$DISTRO" \
+    TARGET_IMG="$TARGET_IMG" \
+    IMAGE_NAME="$IMAGE_NAME" \
+    INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
+    BOOTLOADER="$BOOTLOADER" \
+    KERNEL_NAME="$KERNEL_NAME" \
+    TARGET_KERNEL_ARCH="$TARGET_KERNEL_ARCH" \
+    RELEASE_DIR="$RELEASE_DIR" \
+    UUID_STORAGE="$(uuidgen)" \
+    DISTRO_BOOTLABEL="$DISTRO_BOOTLABEL" \
+    DISTRO_DISKLABEL="$DISTRO_DISKLABEL" \
+    UBOOT_SYSTEM="$UBOOT_SYSTEM" \
+    UBOOT_VERSION="$UBOOT_VERSION" \
+    EXTRA_CMDLINE="$EXTRA_CMDLINE" \
+    SYSTEM_SIZE="$SYSTEM_SIZE" \
+    SYSTEM_PART_START="$SYSTEM_PART_START" \
+    OVA_SIZE="$OVA_SIZE" \
+    $SCRIPTS/mkimage
+}
+
 if [ -n "$CUSTOM_GIT_HASH" ]; then
   GIT_HASH="$CUSTOM_GIT_HASH"
 else
@@ -331,33 +361,7 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
       INSTALL_SRC_DIR="$PROJECT_DIR/$PROJECT/install"
     fi
 
-    # variables used in image script must be passed
-    env \
-      PATH="$PATH:/sbin" \
-      ROOT="$ROOT" \
-      SCRIPTS="$SCRIPTS" \
-      TOOLCHAIN="$TOOLCHAIN" \
-      PROJECT_DIR="$PROJECT_DIR" \
-      PROJECT="$PROJECT" \
-      DEVICE="$DEVICE" \
-      DISTRO="$DISTRO" \
-      TARGET_IMG="$TARGET_IMG" \
-      IMAGE_NAME="$IMAGE_NAME" \
-      INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
-      BOOTLOADER="$BOOTLOADER" \
-      KERNEL_NAME="$KERNEL_NAME" \
-      TARGET_KERNEL_ARCH="$TARGET_KERNEL_ARCH" \
-      RELEASE_DIR=$RELEASE_DIR \
-      UUID_STORAGE="$(uuidgen)" \
-      DISTRO_BOOTLABEL="$DISTRO_BOOTLABEL" \
-      DISTRO_DISKLABEL="$DISTRO_DISKLABEL" \
-      UBOOT_SYSTEM="$UBOOT_SYSTEM" \
-      UBOOT_VERSION="$UBOOT_VERSION" \
-      EXTRA_CMDLINE="$EXTRA_CMDLINE" \
-      SYSTEM_SIZE="$SYSTEM_SIZE" \
-      SYSTEM_PART_START="$SYSTEM_PART_START" \
-      OVA_SIZE="$OVA_SIZE" \
-      $SCRIPTS/mkimage
+    do_mkimage
   fi
 
   # cleanup release dir

--- a/scripts/image_st
+++ b/scripts/image_st
@@ -36,7 +36,7 @@ function do_mkimage() {
     DISTRO="$DISTRO" \
     TARGET_IMG="$TARGET_IMG" \
     BUILD_NAME="$IMAGE_NAME" \
-    IMAGE_NAME="$IMAGE_NAME" \
+    IMAGE_NAME="${1:-$IMAGE_NAME}" \
     INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
     BOOTLOADER="$BOOTLOADER" \
     KERNEL_NAME="$KERNEL_NAME" \
@@ -366,7 +366,26 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
     UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
     UUID_STORAGE="$(uuidgen)"
 
-    do_mkimage
+    DEVICE_BOARDS=$($SCRIPTS/uboot_helper "$PROJECT" "$DEVICE")
+
+    if [ "$BOOTLOADER" = "u-boot" -a -z "$UBOOT_SYSTEM" -a -n "$DEVICE" -a -n "$DEVICE_BOARDS" ]; then
+      for UBOOT_SYSTEM in $DEVICE_BOARDS; do
+
+        # re-install u-boot package
+        rm $STAMPS_INSTALL/u-boot/install_target
+        UBOOT_SYSTEM="$UBOOT_SYSTEM" $SCRIPTS/install u-boot
+
+        # re-run bootloader/release
+        if find_file_path bootloader/release $BOOTLOADER_DIR/release; then
+          echo "Running $FOUND_PATH"
+          . $FOUND_PATH
+        fi
+
+        do_mkimage "$IMAGE_NAME-$UBOOT_SYSTEM"
+      done
+    else
+      do_mkimage
+    fi
   fi
 
   # cleanup release dir

--- a/scripts/image_st
+++ b/scripts/image_st
@@ -41,7 +41,8 @@ function do_mkimage() {
     KERNEL_NAME="$KERNEL_NAME" \
     TARGET_KERNEL_ARCH="$TARGET_KERNEL_ARCH" \
     RELEASE_DIR="$RELEASE_DIR" \
-    UUID_STORAGE="$(uuidgen)" \
+    UUID_SYSTEM="$UUID_SYSTEM" \
+    UUID_STORAGE="$UUID_STORAGE" \
     DISTRO_BOOTLABEL="$DISTRO_BOOTLABEL" \
     DISTRO_DISKLABEL="$DISTRO_DISKLABEL" \
     UBOOT_SYSTEM="$UBOOT_SYSTEM" \
@@ -360,6 +361,9 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
     else
       INSTALL_SRC_DIR="$PROJECT_DIR/$PROJECT/install"
     fi
+
+    UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
+    UUID_STORAGE="$(uuidgen)"
 
     do_mkimage
   fi

--- a/scripts/image_st
+++ b/scripts/image_st
@@ -35,6 +35,7 @@ function do_mkimage() {
     DEVICE="$DEVICE" \
     DISTRO="$DISTRO" \
     TARGET_IMG="$TARGET_IMG" \
+    BUILD_NAME="$IMAGE_NAME" \
     IMAGE_NAME="$IMAGE_NAME" \
     INSTALL_SRC_DIR="$INSTALL_SRC_DIR" \
     BOOTLOADER="$BOOTLOADER" \

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -158,8 +158,8 @@ EOF
 
   # copy files
   echo "image: copying files to part1..."
-  mcopy "${TARGET_IMG}/${IMAGE_NAME}.kernel" "::/${KERNEL_NAME}"
-  mcopy "${TARGET_IMG}/${IMAGE_NAME}.system" ::/SYSTEM
+  mcopy "${TARGET_IMG}/${BUILD_NAME}.kernel" "::/${KERNEL_NAME}"
+  mcopy "${TARGET_IMG}/${BUILD_NAME}.system" ::/SYSTEM
   mcopy "${RELEASE_DIR}/target/KERNEL.md5" "::/${KERNEL_NAME}.md5"
   mcopy "${RELEASE_DIR}/target/SYSTEM.md5" ::/SYSTEM.md5
 
@@ -180,8 +180,8 @@ EOF
 
   # copy files
   echo "image: copying files to part1..."
-  mcopy "${TARGET_IMG}/${IMAGE_NAME}.kernel" "::/${KERNEL_NAME}"
-  mcopy "${TARGET_IMG}/${IMAGE_NAME}.system" ::/SYSTEM
+  mcopy "${TARGET_IMG}/${BUILD_NAME}.kernel" "::/${KERNEL_NAME}"
+  mcopy "${TARGET_IMG}/${BUILD_NAME}.system" ::/SYSTEM
   mcopy "${RELEASE_DIR}/target/KERNEL.md5" "::/${KERNEL_NAME}.md5"
   mcopy "${RELEASE_DIR}/target/SYSTEM.md5" ::/SYSTEM.md5
 
@@ -237,8 +237,8 @@ EOF
   fi
 
   echo "image: copying files to part1..."
-  mcopy "${TARGET_IMG}/${IMAGE_NAME}.kernel" "::/${KERNEL_NAME}"
-  mcopy "${TARGET_IMG}/${IMAGE_NAME}.system" ::/SYSTEM
+  mcopy "${TARGET_IMG}/${BUILD_NAME}.kernel" "::/${KERNEL_NAME}"
+  mcopy "${TARGET_IMG}/${BUILD_NAME}.system" ::/SYSTEM
   mcopy "${RELEASE_DIR}/target/KERNEL.md5" "::/${KERNEL_NAME}.md5"
   mcopy "${RELEASE_DIR}/target/SYSTEM.md5" ::/SYSTEM.md5
 

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -53,12 +53,6 @@ show_error() {
 
 trap cleanup SIGINT
 
-# generate volume id for fat partition
-UUID_1=$(date '+%d%m')
-UUID_2=$(date '+%M%S')
-FAT_SERIAL_NUMBER="${UUID_1}${UUID_2}"
-UUID_SYSTEM="${UUID_1}-${UUID_2}"
-
 # create an image
 echo -e "\nimage: creating file $(basename ${DISK})..."
 dd if=/dev/zero of="${DISK}" bs=1M count="${DISK_SIZE}" conv=fsync >"${SAVE_ERROR}" 2>&1 || show_error
@@ -113,7 +107,7 @@ alias mcopy="mcopy -i ${DISK}@@${OFFSET}"
 alias mmd="mmd -i ${DISK}@@${OFFSET}"
 
 if [ "${BOOTLOADER}" = "syslinux" -o "${BOOTLOADER}" = "bcm2835-bootloader" -o "${BOOTLOADER}" = "u-boot" ]; then
-  mformat -v "${DISTRO_BOOTLABEL}" -N "${FAT_SERIAL_NUMBER}" ::
+  mformat -v "${DISTRO_BOOTLABEL}" -N "${UUID_SYSTEM//-/}" ::
 fi
 sync
 

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -3,12 +3,11 @@
 import sys
 
 devices = {
-  'project' : {
-    'device' : {
-      'board_name' : { 'dtb' : 'board_name.dtb', 'config' : 'board_name_defconfig' },
-    },
-  },
-
+#  'project' : {
+#    'device' : {
+#      'board_name' : { 'dtb' : 'board_name.dtb', 'config' : 'board_name_defconfig' },
+#    },
+#  },
   'Allwinner' : {
     'A64' : {
       'pine64' : { 'dtb' : 'sun50i-a64-pine64.dtb', 'config' : 'pine64_plus_defconfig' },
@@ -30,7 +29,6 @@ devices = {
       'pine_h64' : { 'dtb' : 'sun50i-h6-pine-h64.dtb', 'config' : 'pine_h64_defconfig' },
     },
   },
-
   'Rockchip' : {
     'MiQi' : { 'rk3288' : { 'dtb' : 'rk3288-miqi.dtb', 'config' : 'miqi-rk3288_config' }, },
     'RK3328' : {
@@ -85,17 +83,19 @@ elif len(sys.argv) == 3:
       for board in devices[sys.argv[1]][sys.argv[2]]:
           boards.append(board)
       print(' '.join(boards))
-      sys.exit(0)
+  sys.exit(0)
 
 # List socs supported by a given project
 # ./scripts/uboot_helper project
 elif len(sys.argv) == 2:
-  if sys.argv[1] in devices:
+  if sys.argv[1] in ['help', 'usage']:
+    usage()
+  elif sys.argv[1] in devices:
     socs = []
     for soc in devices[sys.argv[1]]:
       socs.append(soc)
     print(' '.join(socs))
-    sys.exit(0)
+  sys.exit(0)
 
 # List projects
 # ./scripts/uboot_helper


### PR DESCRIPTION
This PR makes it possible to build multiple images based on the same `.kernel` and `.system` files.

**When is multiple images built?**

Building of multiple images is only activated when `BOOTLOADER` is `u-boot`, `UBOOT_SYSTEM` is empty, `DEVICE` is set and boards is defined in `scripts/uboot_helper`.

**How is images built?**

The `u-boot` package is built with empty `UBOOT_SYSTEM` and only `update.sh`, `canupdate.sh` and dtbs is installed into `.system` file at `/usr/share/bootloader`.
The device universal update `<IMAGE_NAME>.tar` file is created

For each uboot system returned by `scripts/uboot_helper <PROJECT> <DEVICE>`:
- `u-boot` package is re-built and re-installed with `UBOOT_SYSTEM` set
- `bootloader/release` is invoked to copy the `u-boot` files to `3rdparty/bootloader`
- `scripts/mkimage` is invoked and will generate a `<IMAGE_NAME>-<UBOOT_SYSTEM>.img.gz` image

**How does images differ?**

The images produced will differ slightly from an image built with  `UBOOT_SYSTEM` set:
-  `u-boot` files installed by `bootloader/install` is not added to the final image
- using these images to upgrade a device will not upgrade `u-boot`

**Example**

Running `PROJECT=Rockchip ARCH=arm DEVICE=RK3328 make image` will produce:
```
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-box.img.gz
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-box.img.gz.sha256
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-box-trn9.img.gz
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-box-trn9.img.gz.sha256
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-box-z28.img.gz
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-box-z28.img.gz.sha256
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320.kernel
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-roc-cc.img.gz
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-roc-cc.img.gz.sha256
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-rock64.img.gz
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-rock64.img.gz.sha256
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-rockbox.img.gz
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320-rockbox.img.gz.sha256
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320.system
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320.tar
LibreELEC-RK3328.arm-9.1-devel-20190429010728-13da320.tar.sha256
```