### PR TITLE
tools/pkginfo: simple tool to dump a package.mk

### DIFF
--- a/tools/pkginfo
+++ b/tools/pkginfo
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+STRIP=no
+if [ "$1" = "--strip" -o "$1" = "-s" ]; then
+  shift
+  STRIP=yes
+fi
+
+. config/options "$1"
+
+shift
+
+echo "PROJECT=${PROJECT}, DEVICE=${DEVICE}, ARCH=${ARCH}"
+
+for v in PKG_NAME PKG_VERSION PKG_SITE PKG_URL PKG_DIR \
+         PKG_NEED_UNPACK PKG_DEPENDS_UNPACK \
+         PKG_DEPENDS_BOOTSTRAP PKG_DEPENDS_INIT PKG_DEPENDS_HOST PKG_DEPENDS_TARGET \
+         PKG_IS_ADDON PKG_IS_KERNEL_PKG $@; do
+  if [ "${STRIP}" = "yes" ]; then
+    echo "${v}=\"${!v}\"" | sed "s#${ROOT}/##g"
+  else
+    echo "${v}=\"${!v}\""
+  fi
+done


### PR DESCRIPTION
Tool to dump fully evaluated package variables for a specific package. Additional parameters will be interpreted as variable names to be evaluated.

For example:
```
$ tools/pkginfo linux PKG_BUILD_PERF
PROJECT=Generic, DEVICE=, ARCH=x86_64
PKG_NAME="linux"
PKG_VERSION="5.0.7"
PKG_SITE="http://www.kernel.org"
PKG_URL="https://www.kernel.org/pub/linux/kernel/v5.x/linux-5.0.7.tar.xz"
PKG_DIR="/home/neil/projects/pullrequest_repos/LibreELEC.tv/packages/linux"
PKG_NEED_UNPACK="/home/neil/projects/pullrequest_repos/LibreELEC.tv/projects/Generic/linux /home/neil/projects/pullrequest_repos/LibreELEC.tv/projects/Generic/patches/linux /home/neil/projects/pullrequest_repos/LibreELEC.tv/projects/Generic/packages/linux /home/neil/projects/pullrequest_repos/LibreELEC.tv/packages/linux /home/neil/projects/pullrequest_repos/LibreELEC.tv/packages/linux-firmware/intel-ucode /home/neil/projects/pullrequest_repos/LibreELEC.tv/packages/linux-firmware/kernel-firmware"
PKG_DEPENDS_UNPACK=""
PKG_DEPENDS_BOOTSTRAP=""
PKG_DEPENDS_INIT="toolchain"
PKG_DEPENDS_HOST="ccache:host openssl:host"
PKG_DEPENDS_TARGET="toolchain cpio:host kmod:host xz:host wireless-regdb keyutils  binutils elfutils libunwind zlib openssl intel-ucode:host kernel-firmware elfutils:host pciutils"
PKG_IS_ADDON="no"
PKG_IS_KERNEL_PKG="yes"
PKG_BUILD_PERF="yes"
```