### PR TITLE
lcdd: fix cross-compile breakage

### DIFF
--- a/packages/addons/service/lcdd/package.mk
+++ b/packages/addons/service/lcdd/package.mk
@@ -21,7 +21,7 @@ PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="LCDproc"
 PKG_ADDON_TYPE="xbmc.service"
 
-PKG_CONFIGURE_OPTS_TARGET="--with-ft-prefix=/usr \
+PKG_CONFIGURE_OPTS_TARGET="--with-ft-prefix=$SYSROOT_PREFIX/usr \
                            --enable-libusb \
                            --enable-libftdi \
                            --disable-libX11 \

--- a/packages/addons/service/lcdd/package.mk
+++ b/packages/addons/service/lcdd/package.mk
@@ -31,7 +31,6 @@ PKG_CONFIGURE_OPTS_TARGET="--with-ft-prefix=$SYSROOT_PREFIX/usr \
 
 pre_configure_target() {
   CFLAGS="$CFLAGS -O3"
-  CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/freetype2"
 }
 
 addon() {

--- a/packages/print/freetype/package.mk
+++ b/packages/print/freetype/package.mk
@@ -27,5 +27,7 @@ pre_configure_target() {
 }
 
 post_makeinstall_target() {
+  sed -e "s#prefix=/usr#prefix=${SYSROOT_PREFIX}/usr#" -i "${SYSROOT_PREFIX}/usr/lib/pkgconfig/freetype2.pc"
+
   cp -P "${PKG_BUILD}/.${TARGET_NAME}/freetype-config" "${SYSROOT_PREFIX}/usr/bin"
 }


### PR DESCRIPTION
`lcdd` currently fails to build if the build host has `libfreetype6-dev` installed as `-I/usr/include/freetype2` is then added during the `lcdd` build due to the incorrect prefix in `freetype2.pc` (from the `freertype` package).