### PR TITLE
linux: support creating gz/bz2 uImage for arm64

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -248,7 +248,7 @@ make_target() {
   if [ -n "$KERNEL_UIMAGE_TARGET" ] ; then
     # determine compression used for kernel image
     KERNEL_UIMAGE_COMP=${KERNEL_UIMAGE_TARGET:7}
-    KERNEL_UIMAGE_COMP=${KERNEL_UIMAGE_COMP:-none}
+    KERNEL_UIMAGE_COMP=$(echo ${KERNEL_UIMAGE_COMP:-none} | sed 's/gz/gzip/; s/bz2/bzip2/')
 
     # calculate new load address to make kernel Image unpack to memory area after compressed image
     if [ "$KERNEL_UIMAGE_COMP" != "none" ] ; then


### PR DESCRIPTION
When building kernel image, suffixes are 'gz' and 'bz2'.
mkimage requires them to be 'gzip' and 'bzip2'.