### PR TITLE
addons: rebuild network-tools (lftp) and game.libretro.scummvm

### DIFF
--- a/packages/addons/tools/network-tools/changelog.txt
+++ b/packages/addons/tools/network-tools/changelog.txt
@@ -1,3 +1,6 @@
+104
+- rebuild for lftp because of missing library libidn2
+
 103
 - added rar2fs
 - updated iperf to 3.6

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.scummvm"
 PKG_VERSION="2.0.0.4-Leia"
 PKG_SHA256="af667d068dfd728eb1a9e58900b8743240b5480a02e1077d626db867cf5171ac"
-PKG_REV="115"
+PKG_REV="116"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.scummvm"


### PR DESCRIPTION
Fixes
https://forum.libreelec.tv/core/ticketsystem/ticket/64-lftp-not-working-in-libreelec-9-0-1/
https://forum.libreelec.tv/core/ticketsystem/ticket/67-scummvm-linker-error/

Would be probably nice to have them ready with next stable LibreELEC version.