### PR TITLE
packages: use single = not == for string comparison

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -14,7 +14,7 @@ PKG_BUILD_FLAGS="-gold"
 # Dependencies
 get_graphicdrivers
 
-if [ "$KODIPLAYER_DRIVER" == "bcm2835-driver" ]; then
+if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET bcm2835-driver"
 fi
 
@@ -40,7 +40,7 @@ pre_configure_target() {
   CFLAGS="$CFLAGS -I$(get_build_dir gnutls)/.INSTALL_PKG/usr/include"
   LDFLAGS="$LDFLAGS -L$(get_build_dir gnutls)/.INSTALL_PKG/usr/lib"
 
-  if [ "$KODIPLAYER_DRIVER" == "bcm2835-driver" ]; then
+  if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
     CFLAGS="$CFLAGS -DRPI=1 -I$SYSROOT_PREFIX/usr/include/IL"
     PKG_FFMPEG_LIBS="-lbcm_host -ldl -lmmal -lmmal_core -lmmal_util -lvchiq_arm -lvcos -lvcsm"
   fi
@@ -48,7 +48,7 @@ pre_configure_target() {
 # HW encoders
 
   # RPi 0-3
-  if [ "$KODIPLAYER_DRIVER" == "bcm2835-driver" ]; then
+  if [ "$KODIPLAYER_DRIVER" = "bcm2835-driver" ]; then
     PKG_FFMPEG_HW_ENCODERS_RPi="\
     `#Video encoders` \
     --enable-omx-rpi \

--- a/packages/emulation/libretro-mame/package.mk
+++ b/packages/emulation/libretro-mame/package.mk
@@ -21,9 +21,9 @@ make_target() {
   PTR64="0"
   NOASM="0"
 
-  if [ "$ARCH" == "arm" ]; then
+  if [ "$ARCH" = "arm" ]; then
     NOASM="1"
-  elif [ "$ARCH" == "x86_64" ]; then
+  elif [ "$ARCH" = "x86_64" ]; then
     PTR64="1"
   fi
 

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -28,7 +28,7 @@ pre_configure_host() {
 }
 
 make_host() {
-  if [ "$ARCH" == "arm" ]; then
+  if [ "$ARCH" = "arm" ]; then
     make -C cpu/cyclone CONFIG_FILE=../cyclone_config.h
   fi
 }

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -211,7 +211,7 @@ make_target() {
 
   # arm64 target does not support creating uImage.
   # Build Image first, then wrap it using u-boot's mkimage.
-  if [[ "$TARGET_KERNEL_ARCH" == "arm64" && "$KERNEL_TARGET" == uImage* ]]; then
+  if [[ "$TARGET_KERNEL_ARCH" = "arm64" && "$KERNEL_TARGET" = uImage* ]]; then
     if [ -z "$KERNEL_UIMAGE_LOADADDR" -o -z "$KERNEL_UIMAGE_ENTRYADDR" ]; then
       die "ERROR: KERNEL_UIMAGE_LOADADDR and KERNEL_UIMAGE_ENTRYADDR have to be set to build uImage - aborting"
     fi

--- a/scripts/genbuildplan.py
+++ b/scripts/genbuildplan.py
@@ -185,8 +185,8 @@ def dep_resolve(node, resolved, unresolved, noreorder):
     for edge in node.edges:
         if edge not in resolved:
             if edge in unresolved:
-                    raise Exception('Circular reference detected: %s -> %s\nRemove %s from %s package.mk::PKG_DEPENDS_%s' % \
-                                    (node.fqname, edge.commonName(), edge.commonName(), node.name, node.target.upper()))
+                raise Exception('Circular reference detected: %s -> %s\nRemove %s from %s package.mk::PKG_DEPENDS_%s' % \
+                                (node.fqname, edge.commonName(), edge.commonName(), node.name, node.target.upper()))
             dep_resolve(edge, resolved, unresolved, noreorder)
 
     if node not in resolved:


### PR DESCRIPTION
Small cosmetic cleanup to fix a few instances of `==` that have slipped in when the project standard is `=` (see #3055).

I've not bothered to fix 

https://github.com/LibreELEC/LibreELEC.tv/blob/6b93ae6ae0e0d5411256bdce14beea0393ce9eaf/projects/Amlogic_Legacy/packages/device-trees-amlogic/package.mk#L41-L46

as this file is due for the chop soon (#3458)