### PR TITLE
linux: amend uimage load address for proper decompression

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -270,6 +270,8 @@ make_target() {
             -e $PKG_KERNEL_UIMAGE_ENTRYADDR \
             -d arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_TARGET \
                arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_UIMAGE_TARGET
+
+    KERNEL_TARGET="${KERNEL_UIMAGE_TARGET}"
   fi
 }
 

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -255,16 +255,19 @@ make_target() {
       COMPRESSED_SIZE=$(stat -t "arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_TARGET" | awk '{print $2}')
       # align to 1 MiB
       COMPRESSED_SIZE=$(( (($COMPRESSED_SIZE - 1 >> 20) + 1) << 20 ))
-      KERNEL_UIMAGE_LOADADDR=$(printf '%X' "$(( $KERNEL_UIMAGE_LOADADDR + $COMPRESSED_SIZE ))")
-      KERNEL_UIMAGE_ENTRYADDR=$(printf '%X' "$(( $KERNEL_UIMAGE_ENTRYADDR + $COMPRESSED_SIZE ))")
+      PKG_KERNEL_UIMAGE_LOADADDR=$(printf '%X' "$(( $KERNEL_UIMAGE_LOADADDR + $COMPRESSED_SIZE ))")
+      PKG_KERNEL_UIMAGE_ENTRYADDR=$(printf '%X' "$(( $KERNEL_UIMAGE_ENTRYADDR + $COMPRESSED_SIZE ))")
+    else
+      PKG_KERNEL_UIMAGE_LOADADDR=${KERNEL_UIMAGE_LOADADDR}
+      PKG_KERNEL_UIMAGE_ENTRYADDR=${KERNEL_UIMAGE_ENTRYADDR}
     fi
 
     mkimage -A $TARGET_KERNEL_ARCH \
             -O linux \
             -T kernel \
             -C $KERNEL_UIMAGE_COMP \
-            -a $KERNEL_UIMAGE_LOADADDR \
-            -e $KERNEL_UIMAGE_ENTRYADDR \
+            -a $PKG_KERNEL_UIMAGE_LOADADDR \
+            -e $PKG_KERNEL_UIMAGE_ENTRYADDR \
             -d arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_TARGET \
                arch/$TARGET_KERNEL_ARCH/boot/$KERNEL_UIMAGE_TARGET
   fi

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -212,6 +212,9 @@ make_target() {
   # arm64 target does not support creating uImage.
   # Build Image first, then wrap it using u-boot's mkimage.
   if [[ "$TARGET_KERNEL_ARCH" == "arm64" && "$KERNEL_TARGET" == uImage* ]]; then
+    if [ -z "$KERNEL_UIMAGE_LOADADDR" -o -z "$KERNEL_UIMAGE_ENTRYADDR" ]; then
+      die "ERROR: KERNEL_UIMAGE_LOADADDR and KERNEL_UIMAGE_ENTRYADDR have to be set to build uImage - aborting"
+    fi
     KERNEL_UIMAGE_TARGET="$KERNEL_TARGET"
     KERNEL_TARGET="${KERNEL_TARGET/uImage/Image}"
   fi


### PR DESCRIPTION
When kernel image is compressed, it is first loaded to RAM at load address specified in command line, then unpacks to loadaddr provided by uImage.

For decompressed image not to overwrite compressed data, uncompressed image load address needs to be shifted by compressed image size + 64 kiB alignment.