### PR TITLE
u-boot: support host mkimage

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -61,6 +61,10 @@ if [ "$TARGET_ARCH" = "x86_64" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET intel-ucode:host kernel-firmware elfutils:host pciutils"
 fi
 
+if [[ "$KERNEL_TARGET" = uImage* ]]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET u-boot-tools:host"
+fi
+
 if [ "$BUILD_ANDROID_BOOTIMG" = "yes" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET mkbootimg:host"
 fi

--- a/packages/tools/u-boot-tools/package.mk
+++ b/packages/tools/u-boot-tools/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="u-boot-tools"
+PKG_LICENSE="GPL"
+PKG_SITE="https://www.denx.de/wiki/U-Boot"
+PKG_DEPENDS_TARGET="toolchain swig:host"
+PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems."
+PKG_VERSION="2019.01"
+PKG_SHA256="50bd7e5a466ab828914d080d5f6a432345b500e8fba1ad3b7b61e95e60d51c22"
+PKG_URL="http://ftp.denx.de/pub/u-boot/u-boot-$PKG_VERSION.tar.bz2"
+
+make_host() {
+  make qemu-x86_64_defconfig
+  make tools-only
+}
+
+make_target() {
+  : # host-only package
+}
+
+makeinstall_host() {
+  mkdir -p $TOOLCHAIN/bin
+    cp tools/mkimage $TOOLCHAIN/bin
+}


### PR DESCRIPTION
If a host doesn't have `mkimage`, building `uImage` would fail. This PR adds support to build host `mkimage`.

Another way of solving this would be to add `uboot_tools` to `scripts/checkdeps`.

Third way to go is to add `u-boot-tools` host-only package, similar to `u-boot-tools-aml`.