### PR TITLE
Rockchip: fix ROCKPro64 audio jack sound output

### DIFF
--- a/projects/Rockchip/patches/linux/rockchip-4.4/linux-1001-add-vpu-fix-reg-es8316-rk3399-rockpro64-dts.patch
+++ b/projects/Rockchip/patches/linux/rockchip-4.4/linux-1001-add-vpu-fix-reg-es8316-rk3399-rockpro64-dts.patch
@@ -1,0 +1,35 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts	2018-11-27 21:33:23.431899971 +0200
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts	2018-11-27 21:32:31.370204542 +0200
+@@ -1046,6 +1046,19 @@
+ 	extcon = <&fusb0>;
+ };
+ 
++
++&vpu {
++        status = "okay";
++        /* 0 means ion, 1 means drm */
++        //allocator = <0>;
++};
++
++&rkvdec {
++        status = "okay";
++        /* 0 means ion, 1 means drm */
++        //allocator = <0>;
++};
++
+ &display_subsystem {
+ 	/delete-property/ devfreq;
+ 	status = "okay";
+@@ -1161,10 +1174,10 @@
+ 	i2c-scl-rising-time-ns = <168>;
+ 	i2c-scl-falling-time-ns = <4>;
+ 
+-	es8316: es8316@10 {
++	es8316: es8316@11 {
+ 		#sound-dai-cells = <0>;
+ 		compatible = "everest,es8316";
+-		reg = <0x10>;
++		reg = <0x11>;
+ 		clocks = <&cru SCLK_I2S_8CH_OUT>;
+ 		clock-names = "mclk";
+ 		pinctrl-names = "default";


### PR DESCRIPTION
Without this fix the analog audio output stays silent.

- https://forum.pine64.org/showthread.php?tid=6409&pid=42765#pid42765

- https://bitbucket.org/sndwvs/slackware_arm_build_kit/src/3bfce84ee6bec63e1988fb58237ef3663e64e9c7/patch/kernel/rk3399-legacy/add-vpu-fix-reg-es8316-rk3399-rockpro64-dts.patch

PS: @Kwiboo @CvH can you test this too?