### PR TITLE
kodi: fix 24fp refresh rate switching

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.99-PR16055.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99-PR16055.patch
@@ -1,0 +1,29 @@
+From 36e78e1bd8d0f43ccace8e8ce03a4b73ab63a4c9 Mon Sep 17 00:00:00 2001
+From: peak3d <pfau@peak3d.de>
+Date: Fri, 3 May 2019 11:32:13 +0200
+Subject: [PATCH] Remove 3:2 pullback from current check
+
+---
+ xbmc/windowing/Resolution.cpp | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/xbmc/windowing/Resolution.cpp b/xbmc/windowing/Resolution.cpp
+index 1921dd260e1c..19a2dde602e9 100644
+--- a/xbmc/windowing/Resolution.cpp
++++ b/xbmc/windowing/Resolution.cpp
+@@ -163,13 +163,12 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
+     }
+   }
+ 
+-  CLog::Log(LOGDEBUG, "No double refresh rate whitelisted resolution matched, trying current resolution");
++  CLog::Log(LOGDEBUG, "No 3:2 pullback refresh rate whitelisted resolution matched, trying current resolution");
+ 
+   if (width <= curr.iScreenWidth
+     && height <= curr.iScreenHeight
+     && (MathUtils::FloatEquals(curr.fRefreshRate, fps, 0.01f)
+-      || MathUtils::FloatEquals(curr.fRefreshRate, fps * 2, 0.01f)
+-      || MathUtils::FloatEquals(curr.fRefreshRate, fps * 2.5f, 0.01f)))
++      || MathUtils::FloatEquals(curr.fRefreshRate, fps * 2, 0.01f)))
+   {
+     CLog::Log(LOGDEBUG, "Matched current Resolution %s (%d)", curr.strMode.c_str(), resolution);
+     return;


### PR DESCRIPTION
As recommended by @fritsch on Team Kodi slack:

![s1](https://i.imgur.com/h4GDO6G.png)

(:+1: from @lrusak)