### PR TITLE
rpi: add canupdate.sh to allow installing compatible images

### DIFF
--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -22,6 +22,7 @@ makeinstall_target() {
 
     find_file_path config/dt-blob.bin && cp -PRv $FOUND_PATH $INSTALL/usr/share/bootloader
 
+    cp -PRv $PKG_DIR/scripts/canupdate.sh $INSTALL/usr/share/bootloader
     cp -PRv $PKG_DIR/scripts/update.sh $INSTALL/usr/share/bootloader
 
     find_file_path config/distroconfig.txt $PKG_DIR/files/3rdparty/bootloader/distroconfig.txt && cp -PRv ${FOUND_PATH} $INSTALL/usr/share/bootloader

--- a/packages/tools/bcm2835-bootloader/scripts/canupdate.sh
+++ b/packages/tools/bcm2835-bootloader/scripts/canupdate.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+# Verify update image compatibility with Raspberry Pi hardware
+
+UPGRADE_IMG=$2
+
+substring_test() {
+# check string $1 for substring $2
+  $(echo "$1" | grep -qE "$2")
+  return $?
+}
+
+RPI_MODEL=$(cat /proc/device-tree/model)
+
+if [ "${RPI_MODEL:0:12}" != "Raspberry Pi" ]; then
+  echo "ERROR: canupdate.sh aborted - not a Raspberry Pi device?"
+  exit 1
+fi
+
+# Test for Compute Module else standard Pi
+if [ ${RPI_MODEL:13:1} = "C" ]; then
+  # Set "Raspberry Pi Compute Module 3 (...)" to "Compute Module 3"
+  # Test if CM3 else CM1
+  if [ ${RPI_MODEL:28:1} -a ${RPI_MODEL:28:1} = "3" ]; then
+    RPI_MODEL="Compute Module 3"
+  else
+    RPI_MODEL="Compute Module 1"
+  fi
+else
+  # Reduce "Raspberry Pi 3 Model B (...)" to "Raspberry Pi 3"
+  RPI_MODEL=${RPI_MODEL:0:14}
+fi
+
+if substring_test $UPGRADE_IMG "^RPi.\.*" && [ ${RPI_MODEL:0:1} = "R" ]; then
+  # Reduce "Raspberry Pi 3" to "3"
+  case ${RPI_MODEL:(-1)} in
+    # RPi 3
+    3)
+      COMPATIBLE_IMG="RPi3.arm RPi2.arm RPi.arm"
+      substring_test "$COMPATIBLE_IMG" $UPGRADE_IMG && exit 0 || exit 1
+      ;;
+    # RPi 2
+    2)
+      COMPATIBLE_IMG="RPi2.arm RPi.arm"
+      substring_test "$COMPATIBLE_IMG" $UPGRADE_IMG && exit 0 || exit 1
+      ;;
+    # RPi 1
+    M)
+      [ $UPGRADE_IMG = "RPi.arm" ] && exit 0 || exit 1
+      ;;
+    *)
+      echo "ERROR: canupdate.sh aborted - device model not recognized to pass compatibility check"
+      exit 1
+      ;;
+  esac
+# Slice image for Compute Module
+elif substring_test $UPGRADE_IMG "^Slice.\.*" && [ ${RPI_MODEL:0:1} = "C" ]; then
+  case ${RPI_MODEL:(-1)} in
+    3)
+      COMPATIBLE_IMG="Slice3.arm Slice.arm"
+      substring_test "$COMPATIBLE_IMG" $UPGRADE_IMG && exit 0 || exit 1
+      ;;
+    1)
+      [ $UPGRADE_IMG = "Slice.arm" ] && exit 0 || exit 1
+      ;;
+    *)
+      echo "ERROR: canupdate.sh aborted - device model not recognized to pass compatibility check"
+      exit 1
+      ;;
+  esac
+else
+  echo "ERROR: canupdate.sh aborted - wrong update image for device?"
+  exit 1
+fi


### PR DESCRIPTION
Draft/RFC:

This script manages the compatibility check for RPI/Slice hardware images. It has the assumption that compute modules are only used for Slice images (unsure if true). It also allows updating an RPi3 with an RPi image, which should work, but probably won't be the best user experience so should maybe reject it anyway.

The basis of the script's model detection is on pulling apart `/proc/device-tree/model`. This is used instead of the Revision field out of `/proc/cpuinfo` because arm64 does not (and will not) provide that field.  I believe the alternative way to reach that is through `/proc/device-tree/system/linux,revision`, but that involves the use of hexdump and is harder to parse, imo.

The model version appears to come from the device-tree files:

https://github.com/raspberrypi/linux/blob/rpi-4.19.y/arch/arm/boot/dts/bcm2835-rpi-b-rev2.dts
https://github.com/raspberrypi/linux/blob/rpi-4.19.y/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
https://github.com/raspberrypi/linux/blob/rpi-4.19.y/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
https://github.com/raspberrypi/linux/blob/rpi-4.19.y/arch/arm/boot/dts/bcm2708-rpi-cm.dts
https://github.com/raspberrypi/linux/blob/rpi-4.19.y/arch/arm/boot/dts/bcm2710-rpi-cm3.dts

but those are added with something else, as the model off my RPi3 is: `Raspberry Pi 3 Model B Rev 1.2`

This also has most of the foundation for a migration check of slice to rpi. That would look like: https://gist.github.com/antonlacon/92e5839ddd3ac7ad670a84e4a38154fa

Tested with RPi3 -> RPi2 -> RPi3 images on an RPi3 device.