### PR TITLE
[Wayland] updated all Wayland packages, dependencies & patches

### DIFF
--- a/packages/debug/libva-utils/patches/libva-utils-001-fix-build-withouth-x11.patch
+++ b/packages/debug/libva-utils/patches/libva-utils-001-fix-build-withouth-x11.patch
@@ -1,0 +1,27 @@
+From 5efef48d74d772cb5318345aa61d94d27e0c42d1 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Fri, 22 Feb 2019 18:43:25 -0800
+Subject: [PATCH] only build sfcsample when x11 is enabled
+
+Signed-off-by: Lukas Rusak <lorusak@gmail.com>
+---
+ Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index d28175a..12da79e 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -24,10 +24,10 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
+ 
+ AUTOMAKE_OPTIONS = foreign
+ 
+-SUBDIRS = common decode encode vainfo videoprocess vendor/intel vendor/intel/sfcsample
++SUBDIRS = common decode encode vainfo videoprocess vendor/intel
+ 
+ if USE_X11
+-SUBDIRS += putsurface
++SUBDIRS += putsurface vendor/intel/sfcsample
+ else
+ if USE_WAYLAND
+ SUBDIRS += putsurface

--- a/packages/graphics/cairo/package.mk
+++ b/packages/graphics/cairo/package.mk
@@ -1,87 +1,91 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cairo"
-PKG_VERSION="1.14.10"
-PKG_SHA256="7e87878658f2c9951a14fc64114d4958c0e65ac47530b8ac3078b2ce41b66a09"
+PKG_VERSION="1.16.0"
+PKG_SHA256="5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://cairographics.org/"
-PKG_URL="http://cairographics.org/releases/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="http://cairographics.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain zlib freetype fontconfig glib libpng pixman"
 PKG_LONGDESC="Cairo is a vector graphics library with cross-device output support."
-PKG_TOOLCHAIN="configure" # ToDo
+PKG_TOOLCHAIN="configure"
 
-if [ "$OPENGL" != "no" ]; then
-  PKG_DEPENDS_TARGET+=" $OPENGL"
-fi
+configure_package() {
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    PKG_DEPENDS_TARGET+=" libXrender libX11 mesa"
+  fi
 
-if [ "$OPENGLES" != "no" ]; then
-  PKG_DEPENDS_TARGET+=" $OPENGLES"
-fi
+  if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+    PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  elif [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+    PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+  fi
+}
 
-if [ "$DISPLAYSERVER" = "x11" ]; then
-  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libXrender libX11 mesa"
-  PKG_CAIRO_CONFIG="--x-includes="$SYSROOT_PREFIX/usr/include" \
-                    --x-libraries="$SYSROOT_PREFIX/usr/lib" \
-                    --enable-xlib \
-                    --enable-xlib-xrender \
-                    --enable-gl \
-                    --enable-glx \
-                    --disable-glesv2 \
-                    --disable-egl \
-                    --with-x"
-else
-  PKG_CAIRO_CONFIG="--disable-xlib \
-                    --disable-xlib-xrender \
-                    --disable-gl \
-                    --disable-glx \
-                    --enable-glesv2 \
-                    --enable-egl \
-                    --without-x"
-fi
+pre_configure_target() {
+  PKG_CONFIGURE_OPTS_TARGET="--disable-silent-rules \
+                             --enable-shared \
+                             --disable-static \
+                             --disable-gtk-doc \
+                             --enable-largefile \
+                             --enable-atomic \
+                             --disable-gcov \
+                             --disable-valgrind \
+                             --disable-xcb \
+                             --disable-xlib-xcb \
+                             --disable-xcb-shm \
+                             --disable-qt \
+                             --disable-quartz \
+                             --disable-quartz-font \
+                             --disable-quartz-image \
+                             --disable-win32 \
+                             --disable-win32-font \
+                             --disable-os2 \
+                             --disable-beos \
+                             --disable-cogl \
+                             --disable-drm \
+                             --disable-gallium \
+                             --enable-png \
+                             --disable-directfb \
+                             --disable-vg \
+                             --disable-wgl \
+                             --disable-script \
+                             --enable-ft \
+                             --enable-fc \
+                             --enable-ps \
+                             --enable-pdf \
+                             --enable-svg \
+                             --disable-test-surfaces \
+                             --disable-tee \
+                             --disable-xml \
+                             --enable-pthread \
+                             --enable-gobject=yes \
+                             --disable-full-testing \
+                             --disable-trace \
+                             --enable-interpreter \
+                             --disable-symbol-lookup \
+                             --enable-some-floating-point \
+                             --with-gnu-ld"
 
-PKG_CONFIGURE_OPTS_TARGET="$PKG_CAIRO_CONFIG \
-                           --disable-silent-rules \
-                           --enable-shared \
-                           --disable-static \
-                           --disable-gtk-doc \
-                           --enable-largefile \
-                           --enable-atomic \
-                           --disable-gcov \
-                           --disable-valgrind \
-                           --disable-xcb \
-                           --disable-xlib-xcb \
-                           --disable-xcb-shm \
-                           --disable-qt \
-                           --disable-quartz \
-                           --disable-quartz-font \
-                           --disable-quartz-image \
-                           --disable-win32 \
-                           --disable-win32-font \
-                           --disable-skia \
-                           --disable-os2 \
-                           --disable-beos \
-                           --disable-cogl \
-                           --disable-drm \
-                           --disable-gallium \
-                           --enable-png \
-                           --disable-directfb \
-                           --disable-vg \
-                           --disable-wgl \
-                           --disable-script \
-                           --enable-ft \
-                           --enable-fc \
-                           --enable-ps \
-                           --enable-pdf \
-                           --enable-svg \
-                           --disable-test-surfaces \
-                           --disable-tee \
-                           --disable-xml \
-                           --enable-pthread \
-                           --enable-gobject=yes \
-                           --disable-full-testing \
-                           --disable-trace \
-                           --enable-interpreter \
-                           --disable-symbol-lookup \
-                           --enable-some-floating-point \
-                           --with-gnu-ld"
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    PKG_CONFIGURE_OPTS_TARGET+=" --x-includes="${SYSROOT_PREFIX}/usr/include" \
+                                 --x-libraries="${SYSROOT_PREFIX}/usr/lib" \
+                                 --enable-xlib \
+                                 --enable-xlib-xrender \
+                                 --enable-gl \
+                                 --enable-glx \
+                                 --disable-glesv2 \
+                                 --disable-egl \
+                                 --with-x"
+   else
+    PKG_CONFIGURE_OPTS_TARGET+=" --disable-xlib \
+                                 --disable-xlib-xrender \
+                                 --disable-gl \
+                                 --disable-glx \
+                                 --enable-glesv2 \
+                                 --enable-egl \
+                                 --without-x"
+  fi
+}

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -52,7 +52,9 @@ configure_package() {
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET wayland waylandpp"
     CFLAGS="$CFLAGS -DMESA_EGL_NO_X11_HEADERS"
     CXXFLAGS="$CXXFLAGS -DMESA_EGL_NO_X11_HEADERS"
-    KODI_XORG="-DCORE_PLATFORM_NAME=wayland -DWAYLAND_RENDER_SYSTEM=gles"
+    KODI_XORG="-DCORE_PLATFORM_NAME=wayland \
+               -DWAYLAND_RENDER_SYSTEM=gles \
+               -DWAYLANDPP_PROTOCOLS_DIR=${SYSROOT_PREFIX}/usr/share/waylandpp/protocols"
   fi
 
   if [ ! "$OPENGL" = "no" ]; then

--- a/packages/mediacenter/kodi/patches/kodi-100.14-use-alsa-and-pulse-together.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.14-use-alsa-and-pulse-together.patch
@@ -1,17 +1,18 @@
-From 0bb21ebfe5f26545ccc9f105560c6c0fcbce77b3 Mon Sep 17 00:00:00 2001
-From: MilhouseVH <milhouseVH.github@nmacleod.com>
-Date: Wed, 26 Sep 2018 02:47:03 +0100
+From 2e7de29a69b37ad0a7d8632c5aafcdd02a4f550d Mon Sep 17 00:00:00 2001
+From: 5schatten <supervisedthinking@gmail.com>
+Date: Tue, 7 May 2019 01:30:10 +0200
 Subject: [PATCH] allow using alsa and pulse together
 
 ---
- xbmc/windowing/X11/WinSystemX11GLContext.cpp | 35 ++--------------------------
+ xbmc/windowing/X11/WinSystemX11GLContext.cpp | 35 ++------------------
  xbmc/windowing/amlogic/WinSystemAmlogic.cpp  |  2 ++
- xbmc/windowing/gbm/WinSystemGbm.cpp          | 34 ++-------------------------
- xbmc/windowing/rpi/WinSystemRpi.cpp          | 17 ++++----------
- 4 files changed, 10 insertions(+), 78 deletions(-)
+ xbmc/windowing/gbm/WinSystemGbm.cpp          | 34 ++-----------------
+ xbmc/windowing/rpi/WinSystemRpi.cpp          | 17 +++-------
+ xbmc/windowing/wayland/WinSystemWayland.cpp  | 35 ++------------------
+ 5 files changed, 13 insertions(+), 110 deletions(-)
 
 diff --git a/xbmc/windowing/X11/WinSystemX11GLContext.cpp b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
-index 1980916..2524716 100644
+index 5b0b155736b9..a3a3251a5d10 100644
 --- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
 +++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
 @@ -40,39 +40,8 @@ std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
@@ -57,7 +58,7 @@ index 1980916..2524716 100644
  }
  
 diff --git a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
-index 9df83a6..5d41c1f 100644
+index 0637f83fc0fd..b1b41b05039e 100644
 --- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
 +++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
 @@ -20,6 +20,7 @@
@@ -68,7 +69,7 @@ index 9df83a6..5d41c1f 100644
  #include "windowing/GraphicContext.h"
  #include "windowing/Resolution.h"
  #include "platform/linux/powermanagement/LinuxPowerSyscall.h"
-@@ -66,6 +67,7 @@ CWinSystemAmlogic::CWinSystemAmlogic() :
+@@ -67,6 +68,7 @@ CWinSystemAmlogic::CWinSystemAmlogic() :
    // Register sink
    AE::CAESinkFactory::ClearSinks();
    CAESinkALSA::Register();
@@ -77,10 +78,10 @@ index 9df83a6..5d41c1f 100644
    m_lirc.reset(OPTIONALS::LircRegister());
    m_libinput->Start();
 diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
-index 12f2da6..c2bdd0e 100644
+index 4a3291a55045..9ad1f2daf1af 100644
 --- a/xbmc/windowing/gbm/WinSystemGbm.cpp
 +++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
-@@ -31,38 +31,8 @@ CWinSystemGbm::CWinSystemGbm() :
+@@ -33,38 +33,8 @@ CWinSystemGbm::CWinSystemGbm() :
    m_GBM(new CGBMUtils),
    m_libinput(new CLibInputHandler)
  {
@@ -122,10 +123,10 @@ index 12f2da6..c2bdd0e 100644
    CLinuxPowerSyscall::Register();
    m_lirc.reset(OPTIONALS::LircRegister());
 diff --git a/xbmc/windowing/rpi/WinSystemRpi.cpp b/xbmc/windowing/rpi/WinSystemRpi.cpp
-index a403464..6a68d9f 100644
+index bdeb68c8c006..f5bc22c3cbdb 100644
 --- a/xbmc/windowing/rpi/WinSystemRpi.cpp
 +++ b/xbmc/windowing/rpi/WinSystemRpi.cpp
-@@ -21,7 +21,9 @@
+@@ -22,7 +22,9 @@
  #include "guilib/DispResource.h"
  #include "utils/log.h"
  #include "cores/AudioEngine/AESinkFactory.h"
@@ -135,7 +136,7 @@ index a403464..6a68d9f 100644
  #include "platform/linux/powermanagement/LinuxPowerSyscall.h"
  
  #include <EGL/egl.h>
-@@ -44,19 +46,8 @@ CWinSystemRpi::CWinSystemRpi() :
+@@ -45,19 +47,8 @@ CWinSystemRpi::CWinSystemRpi() :
    AE::CAESinkFactory::ClearSinks();
  
    CAESinkPi::Register();
@@ -157,6 +158,49 @@ index a403464..6a68d9f 100644
    CLinuxPowerSyscall::Register();
    m_lirc.reset(OPTIONALS::LircRegister());
    m_libinput->Start();
--- 
-2.14.1
-
+diff --git a/xbmc/windowing/wayland/WinSystemWayland.cpp b/xbmc/windowing/wayland/WinSystemWayland.cpp
+index 9d0031239c6e..2b76e773f329 100644
+--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
++++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
+@@ -137,38 +137,9 @@ struct MsgBufferScale
+ CWinSystemWayland::CWinSystemWayland()
+ : CWinSystemBase{}, m_protocol{"WinSystemWaylandInternal"}
+ {
+-  std::string envSink;
+-  if (getenv("KODI_AE_SINK"))
+-    envSink = getenv("KODI_AE_SINK");
+-  if (StringUtils::EqualsNoCase(envSink, "ALSA"))
+-  {
+-    OPTIONALS::ALSARegister();
+-  }
+-  else if (StringUtils::EqualsNoCase(envSink, "PULSE"))
+-  {
+-    OPTIONALS::PulseAudioRegister();
+-  }
+-  else if (StringUtils::EqualsNoCase(envSink, "OSS"))
+-  {
+-    OPTIONALS::OSSRegister();
+-  }
+-  else if (StringUtils::EqualsNoCase(envSink, "SNDIO"))
+-  {
+-    OPTIONALS::SndioRegister();
+-  }
+-  else
+-  {
+-    if (!OPTIONALS::PulseAudioRegister())
+-    {
+-      if (!OPTIONALS::ALSARegister())
+-      {
+-        if (!OPTIONALS::SndioRegister())
+-        {
+-          OPTIONALS::OSSRegister();
+-        }
+-      }
+-    }
+-  }
++  OPTIONALS::ALSARegister();
++  OPTIONALS::PulseAudioRegister();
++
+   m_winEvents.reset(new CWinEventsWayland());
+   CLinuxPowerSyscall::Register();
+   m_lirc.reset(OPTIONALS::LircRegister());

--- a/packages/multimedia/intel-vaapi-driver/patches/intel-vaapi-driver-999.01-check-the-interface-from-libva-first.patch
+++ b/packages/multimedia/intel-vaapi-driver/patches/intel-vaapi-driver-999.01-check-the-interface-from-libva-first.patch
@@ -1,0 +1,81 @@
+From fa7fd06b25e98a6af3b221eb7c653887f53ece3d Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Fri, 7 Dec 2018 13:31:43 +0800
+Subject: [PATCH] Check the interface from libva first
+
+And bump libva dependency to 1.4.0
+
+This fixes https://github.com/intel/intel-vaapi-driver/issues/419
+
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ configure.ac              |  2 +-
+ src/i965_output_wayland.c | 27 ++++++++++++++++-----------
+ 2 files changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6cde1a3a..a0b462fb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -10,7 +10,7 @@ m4_append([intel_vaapi_driver_version], intel_vaapi_driver_pre_version, [.pre])
+ ])
+ 
+ # libva minimum version requirement
+-m4_define([va_api_version], [1.1.0])
++m4_define([va_api_version], [1.4.0])
+ 
+ # libdrm minimum version requirement
+ m4_define([libdrm_version], [2.4.52])
+diff --git a/src/i965_output_wayland.c b/src/i965_output_wayland.c
+index 122db953..a637552e 100644
+--- a/src/i965_output_wayland.c
++++ b/src/i965_output_wayland.c
+@@ -397,6 +397,7 @@ i965_output_wayland_init(VADriverContextP ctx)
+     struct i965_driver_data * const i965 = i965_driver_data(ctx);
+     struct dso_handle *dso_handle;
+     struct wl_vtable *wl_vtable;
++    struct VADriverVTableWayland * const vtable = ctx->vtable_wayland;
+ 
+     static const struct dso_symbol libegl_symbols[] = {
+         {
+@@ -465,25 +466,29 @@ i965_output_wayland_init(VADriverContextP ctx)
+     if (!i965->wl_output)
+         goto error;
+ 
+-    i965->wl_output->libegl_handle = dso_open(LIBEGL_NAME);
+-    if (!i965->wl_output->libegl_handle) {
+-        i965->wl_output->libegl_handle = dso_open(LIBEGL_NAME_FALLBACK);
+-        if (!i965->wl_output->libegl_handle)
++    wl_vtable = &i965->wl_output->vtable;
++
++    if (vtable->wl_interface)
++        wl_vtable->drm_interface = vtable->wl_interface;
++    else {
++        i965->wl_output->libegl_handle = dso_open(LIBEGL_NAME);
++        if (!i965->wl_output->libegl_handle) {
++            i965->wl_output->libegl_handle = dso_open(LIBEGL_NAME_FALLBACK);
++            if (!i965->wl_output->libegl_handle)
++                goto error;
++        }
++
++        dso_handle = i965->wl_output->libegl_handle;
++        if (!dso_get_symbols(dso_handle, wl_vtable, sizeof(*wl_vtable),
++                             libegl_symbols))
+             goto error;
+     }
+ 
+-    dso_handle = i965->wl_output->libegl_handle;
+-    wl_vtable  = &i965->wl_output->vtable;
+-    if (!dso_get_symbols(dso_handle, wl_vtable, sizeof(*wl_vtable),
+-                         libegl_symbols))
+-        goto error;
+-
+     i965->wl_output->libwl_client_handle = dso_open(LIBWAYLAND_CLIENT_NAME);
+     if (!i965->wl_output->libwl_client_handle)
+         goto error;
+ 
+     dso_handle = i965->wl_output->libwl_client_handle;
+-    wl_vtable  = &i965->wl_output->vtable;
+     if (!dso_get_symbols(dso_handle, wl_vtable, sizeof(*wl_vtable),
+                          libwl_client_symbols))
+         goto error;

--- a/packages/textproc/pugixml/package.mk
+++ b/packages/textproc/pugixml/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pugixml"
+PKG_VERSION="1.9"
+PKG_SHA256="7ac060048bf00da4b3902cf411f0ba9f048cdc5580eed1f5a27ff51be4a38243"
+PKG_LICENSE="MIT"
+PKG_SITE="https://pugixml.org/"
+PKG_URL="https://github.com/zeux/pugixml/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Light-weight, simple and fast XML parser for C++ with XPath support."

--- a/packages/textproc/pugixml/patches/pugixml-100.01-always-install-the-pkg-config-file.patch
+++ b/packages/textproc/pugixml/patches/pugixml-100.01-always-install-the-pkg-config-file.patch
@@ -1,0 +1,71 @@
+From 314dc6a95baaca90294a8ea957d9810e3bee0f62 Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz93@gmail.com>
+Date: Mon, 9 Apr 2018 01:46:30 -0400
+Subject: [PATCH] cmake: always install the pkg-config file
+
+There's really never a reason to *not* want this installed. If an option
+is needed to specify installing in a versioned subdirectory, this option
+should be explicitly described rather than hidden in something else.
+
+As an added bonus, this makes the CMake install code slightly *less*
+complicated.
+---
+ CMakeLists.txt        | 10 ++++------
+ scripts/pugixml.pc.in |  6 +++---
+ 2 files changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 90fa6793..d7bc1b20 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,7 +4,7 @@ project(pugixml)
+ 
+ option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
+ option(BUILD_TESTS "Build tests" OFF)
+-option(BUILD_PKGCONFIG "Build in PKGCONFIG mode" OFF)
++option(USE_VERSIONED_LIBDIR "Use a private subdirectory to install the headers and libs" OFF)
+ 
+ set(BUILD_DEFINES "" CACHE STRING "Build defines")
+ 
+@@ -55,7 +55,7 @@ endif()
+ set_target_properties(pugixml PROPERTIES VERSION 1.9 SOVERSION 1)
+ get_target_property(PUGIXML_VERSION_STRING pugixml VERSION)
+ 
+-if(BUILD_PKGCONFIG)
++if(USE_VERSIONED_LIBDIR)
+ 	# Install library into its own directory under LIBDIR
+ 	set(INSTALL_SUFFIX /pugixml-${PUGIXML_VERSION_STRING})
+ endif()
+@@ -71,10 +71,8 @@ install(TARGETS pugixml EXPORT pugixml-config
+ install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX})
+ install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
+ 
+-if(BUILD_PKGCONFIG)
+-	configure_file(scripts/pugixml.pc.in ${PROJECT_BINARY_DIR}/pugixml.pc @ONLY)
+-	install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+-endif()
++configure_file(scripts/pugixml.pc.in ${PROJECT_BINARY_DIR}/pugixml.pc @ONLY)
++install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+ 
+ if(BUILD_TESTS)
+ 	file(GLOB TEST_SOURCES tests/*.cpp)
+diff --git a/scripts/pugixml.pc.in b/scripts/pugixml.pc.in
+index 3c97c28d..804c4d38 100644
+--- a/scripts/pugixml.pc.in
++++ b/scripts/pugixml.pc.in
+@@ -1,11 +1,11 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-includedir=${prefix}/include/pugixml-@PUGIXML_VERSION_STRING@
+-libdir=${exec_prefix}/lib/pugixml-@PUGIXML_VERSION_STRING@
++includedir=${prefix}/include@INSTALL_SUFFIX@
++libdir=${exec_prefix}/lib@INSTALL_SUFFIX@
+ 
+ Name: pugixml
+ Description: Light-weight, simple and fast XML parser for C++ with XPath support.
+ URL: http://pugixml.org/
+ Version: @PUGIXML_VERSION_STRING@
+ Cflags: -I${includedir}
+-Libs: -L${libdir} -lpugixml
+\ No newline at end of file
++Libs: -L${libdir} -lpugixml

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -2,14 +2,13 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.10.4"
-PKG_SHA256="2330a82f3e4b617a4f9ff0f2bf9cc217b3c4e69d767e61ca59ca07add61f68ac"
+PKG_VERSION="1.13.2"
+PKG_SHA256="1d9fa0698348dea46f75321d98788f8ac7181c069b70c4d10736910a12bb6a6d"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libinput/"
-PKG_URL="http://www.freedesktop.org/software/libinput/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="http://www.freedesktop.org/software/libinput/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain systemd libevdev mtdev"
 PKG_LONGDESC="libinput is a library to handle input devices in Wayland compositors and to provide a generic X.Org input driver."
-PKG_TOOLCHAIN="meson"
 
 PKG_MESON_OPTS_TARGET="-Dlibwacom=false \
                        -Ddebug-gui=false \

--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.12"
-PKG_SHA256="3b19e8a9e1e19474756a7069db23b90ca9b8ebb438448c6063b4a7fc89b7c8b2"
+PKG_VERSION="1.17"
+PKG_SHA256="df1319cf9705643aea9fd16f9056f4e5b2471bd10c0cc3713d4a4cdc23d6812f"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -11,5 +11,5 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Specifications of extended Wayland protocols"
 
 post_makeinstall_target() {
-  rm -rf $INSTALL
+  rm -rf ${INSTALL}
 }

--- a/packages/wayland/wayland/package.mk
+++ b/packages/wayland/wayland/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland"
-PKG_VERSION="1.14.0"
-PKG_SHA256="ed80cabc0961a759a42092e2c39aabfc1ec9a13c86c98bbe2b812f008da27ab8"
+PKG_VERSION="1.17.0"
+PKG_SHA256="72aa11b8ac6e22f4777302c9251e8fec7655dc22f9d94ee676c6b276f95f91a4"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -17,7 +17,7 @@ PKG_CONFIGURE_OPTS_HOST="--enable-shared \
                          --disable-documentation \
                          --with-gnu-ld"
 
-PKG_CONFIGURE_OPTS_TARGET="--with-sysroot=$SYSROOT_PREFIX \
+PKG_CONFIGURE_OPTS_TARGET="--with-sysroot=${SYSROOT_PREFIX} \
                            --with-host-scanner \
                            --enable-shared \
                            --disable-static \
@@ -26,8 +26,8 @@ PKG_CONFIGURE_OPTS_TARGET="--with-sysroot=$SYSROOT_PREFIX \
                            --with-gnu-ld"
 
 post_makeinstall_target() {
-  rm -rf $INSTALL/usr/bin
-  rm -rf $INSTALL/usr/share
+  rm -rf ${INSTALL}/usr/bin
+  rm -rf ${INSTALL}/usr/share
 
-  cp $TOOLCHAIN/lib/pkgconfig/wayland-scanner.pc $SYSROOT_PREFIX/usr/lib/pkgconfig/
+  cp ${TOOLCHAIN}/lib/pkgconfig/wayland-scanner.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig/
 }

--- a/packages/wayland/waylandpp/package.mk
+++ b/packages/wayland/waylandpp/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="waylandpp"
-PKG_VERSION="0.1.6"
-PKG_SHA256="33d3ec385704c5545fb50d2283aabf4ef26aaaf3e416b292e650fea67c430d23"
+PKG_VERSION="0.2.5"
+PKG_SHA256="5a4361f73d2bee65bfe54b954ce085c9bfc7bc4429ac2bdc97c10e3b84660907"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/NilsBrause/waylandpp"
-PKG_URL="https://github.com/NilsBrause/waylandpp/archive/$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain waylandpp:host"
+PKG_URL="https://github.com/NilsBrause/waylandpp/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain pugixml:host waylandpp:host"
 PKG_LONGDESC="Wayland C++ bindings"
 
 PKG_CMAKE_OPTS_HOST="-DBUILD_SCANNER=ON \
@@ -16,4 +16,4 @@ PKG_CMAKE_OPTS_HOST="-DBUILD_SCANNER=ON \
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SCANNER=OFF \
                        -DBUILD_LIBRARIES=ON \
                        -DCMAKE_CROSSCOMPILING=ON \
-                       -DWAYLAND_SCANNERPP=$TOOLCHAIN/bin/wayland-scanner++"
+                       -DWAYLAND_SCANNERPP=${TOOLCHAIN}/bin/wayland-scanner++"

--- a/packages/wayland/weston/package.mk
+++ b/packages/wayland/weston/package.mk
@@ -2,43 +2,46 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="weston"
-PKG_VERSION="3.0.0"
-PKG_SHA256="cde1d55e8dd70c3cbb3d1ec72f60e60000041579caa1d6a262bd9c35e93723a5"
+PKG_VERSION="6.0.0"
+PKG_SHA256="546323a90607b3bd7f48809ea9d76e64cd09718102f2deca6d95aa59a882e612"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain wayland-protocols libdrm libxkbcommon libinput cairo libjpeg-turbo dbus"
 PKG_LONGDESC="Reference implementation of a Wayland compositor"
 
-PKG_CONFIGURE_OPTS_TARGET="CFLAGS=-DMESA_EGL_NO_X11_HEADERS \
-                           LIBS=-lturbojpeg \
-                           --with-cairo-glesv2 \
-                           --disable-xwayland \
-                           --disable-x11-compositor \
-                           --disable-xwayland-test \
-                           --disable-libunwind \
-                           --disable-colord \
-                           --disable-ivi-shell \
-                           --disable-fbdev-compositor \
-                           --disable-rdp-compositor \
-                           --disable-screen-sharing \
-                           --disable-vaapi-recorder \
-                           --disable-headless-compositor \
-                           --enable-systemd-login \
-                           --disable-weston-launch \
-                           --disable-fullscreen-shell \
-                           --disable-demo-clients-install \
-                           --enable-systemd-notify"
+PKG_MESON_OPTS_TARGET="-Dbackend-drm-screencast-vaapi=false \
+                       -Dbackend-headless=false \
+                       -Dbackend-rdp=false \
+                       -Dscreenshare=false \
+                       -Dbackend-x11=false \
+                       -Dbackend-fbdev=false \
+                       -Dweston-launch=false \
+                       -Dxwayland=false \
+                       -Dremoting=false \
+                       -Dshell-fullscreen=false \
+                       -Dshell-ivi=false \
+                       -Dcolor-management-lcms=false \
+                       -Dcolor-management-colord=false \
+                       -Dimage-webp=false \
+                       -Dsimple-dmabuf-drm=intel \
+                       -Ddemo-clients=false \
+                       -Dsimple-clients=egl \
+                       -Dresize-pool=false \
+                       -Dwcap-decode=false \
+                       -Dtest-junit-xml=false"
 
 post_makeinstall_target() {
-  mkdir -p $INSTALL/usr/lib/weston
-    cp $PKG_DIR/scripts/weston-config $INSTALL/usr/lib/weston
+  mkdir -p ${INSTALL}/usr/lib/weston
+    cp ${PKG_DIR}/scripts/weston-config ${INSTALL}/usr/lib/weston
 
-  mkdir -p $INSTALL/usr/share/weston
-    cp $PKG_DIR/config/weston.ini $INSTALL/usr/share/weston
+  mkdir -p ${INSTALL}/usr/share/weston
+    cp ${PKG_DIR}/config/weston.ini ${INSTALL}/usr/share/weston
 
-  rm -r $INSTALL/usr/share/wayland-sessions
-  rm -r $INSTALL/usr/lib/weston-simple-im
+  safe_remove ${INSTALL}/usr/share/wayland-sessions
+  safe_remove ${INSTALL}/usr/bin/weston-calibrator 
+  safe_remove ${INSTALL}/usr/bin/weston-simple-*
+  safe_remove ${INSTALL}/usr/bin/weston-touch-calibrator
 }
 
 post_install() {


### PR DESCRIPTION
- This PR should allow to build `Kodi 18.2` without `X11` and use instead `Wayland/Weston` & `OpenGL ES`
- it updates all packages to the latest versions, added dependencies as `pugixml` & added or updated patches for them
- Generic build tested on an Intel system with these project changes:

```
  # OpenGL(X) implementation to use (no / mesa)
    OPENGL="no"

  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
    OPENGLES="mesa"

  # include uvesafb support (yes / no)
    UVESAFB_SUPPORT="yes"

  # Displayserver to use (x11 / no)
    DISPLAYSERVER="weston"

  # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
  # Space separated list is supported,
  # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
    GRAPHIC_DRIVERS="r300 r600 radeonsi i915 i965 vmware virtio"
```