### PR TITLE
config/functions: endianness in meson cross is always little

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -357,11 +357,9 @@ setup_toolchain() {
 create_meson_conf() {
   local endian root properties
   case "$1" in
-    target|init)    endian="little"
-                    root="$SYSROOT_PREFIX/usr"
+    target|init)    root="$SYSROOT_PREFIX/usr"
                     ;;
-    host|bootstrap) endian="big"
-                    root="$TOOLCHAIN"
+    host|bootstrap) root="$TOOLCHAIN"
                     ;;
   esac
 
@@ -380,7 +378,7 @@ llvm-config = '$SYSROOT_PREFIX/usr/bin/llvm-config-host'
 system = 'linux'
 cpu_family = '$TARGET_ARCH'
 cpu = '$TARGET_SUBARCH'
-endian = '$endian'
+endian = 'little'
 
 [properties]
 root = '$root'


### PR DESCRIPTION
`x86_64` and ARM are both `little` endian architectures. Until such time as we need to support a big-endian architecture (unlikely) this can be hard-coded as `little`.