### PR TITLE
scripts/image_st: use a 1MB blocksize by default

### DIFF
--- a/scripts/image_st
+++ b/scripts/image_st
@@ -275,7 +275,7 @@ if [ -z "$SQUASHFS_COMPRESSION_OPTION" ]; then
   elif [ "$SQUASHFS_COMPRESSION" = "lzo" ]; then
     SQUASHFS_COMPRESSION_OPTION="-Xcompression-level 9 -b 524288"
   elif [ "$SQUASHFS_COMPRESSION" = "zstd" ]; then
-    SQUASHFS_COMPRESSION_OPTION="-Xcompression-level 22 -b 262144"
+    SQUASHFS_COMPRESSION_OPTION="-Xcompression-level 22 -b 1048576"
   fi
 fi
 


### PR DESCRIPTION
Applies https://github.com/LibreELEC/LibreELEC.tv/pull/3212 for single-threaded builds.