### PR TITLE
systemd: add version-tag build option

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -89,7 +89,8 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dkmod-path=/usr/bin/kmod \
                        -Dmount-path=/usr/bin/mount \
                        -Dumount-path=/usr/bin/umount \
-                       -Ddebug-tty=$DEBUG_TTY"
+                       -Ddebug-tty=$DEBUG_TTY \
+                       -Dversion-tag=${PKG_VERSION}"
 
 pre_configure_target() {
   export CFLAGS="$CFLAGS -fno-schedule-insns -fno-schedule-insns2 -Wno-format-truncation"


### PR DESCRIPTION
Without this option systemd 241 and newer builds will run git describe
and report the LibreELEC git tree info as version, eg in journal

systemd 8.95.002-927-gb1cdc76 running in system mode.

With version-tag set the version is reported like before

systemd 242 running in system mode.