### PR TITLE
scripts/build: strip all executables in /usr

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -488,7 +488,7 @@ if [ "$TARGET" = "target" -o "$TARGET" = "init" ]; then
         if [ "$TARGET" = "init" ]; then
           $STRIP $(find $INSTALL -type f -name "*.so*" 2>/dev/null) 2>/dev/null || :
         fi
-        $STRIP $(find $INSTALL/bin $INSTALL/usr/bin $INSTALL/sbin $INSTALL/usr/sbin \
+        $STRIP $(find $INSTALL ! -name "*.so*" ! -name "*.ko" \
           -type f -executable 2>/dev/null) 2>/dev/null || :
     fi
   fi


### PR DESCRIPTION
Some packages install outside `/usr/*bin`, e.g. `/usr/lib/bluetooth` and executables remain unstripped. Try to strip everything executable except .ko and .so which are handled in separate cases.

All file size differences in an Amlogic-mainline build:

| | Before | After | Diff | Diff % |
| -- | -- | -- | -- | -- |
| /usr/lib/bluetooth/bluetoothd | 783956 | 572456 | -211500 | -26.98% |
| /usr/lib/bluetooth/obexd | 400816 | 305844 | -94972 | -23.69% |
| /usr/lib/dbus/dbus-daemon-launch-helper | 59216 | 39172 | -20044 | -33.85% |
| /usr/lib/libinput/libinput-debug-events | 105508 | 31584 | -73924 | -70.06% |
| /usr/lib/libinput/libinput-list-devices | 66836 | 18516 | -48320 | -72.30% |
| /usr/lib/libinput/libinput-measure | 48472 | 14280 | -34192 | -70.54% |
| /usr/lib/pulse/gsettings-helper | 13280 | 5816 | -7464 | -56.20% |
| /usr/lib/udev/hid2hci | 16668 | 9916 | -6752 | -40.51% |
| /usr/lib/udev/libinput-device-group | 17408 | 5780 | -11628 | -66.80% |
| /usr/lib/udev/libinput-model-quirks | 18264 | 5768 | -12496 | -68.42% |
| | 1530424 | 1009132 | -521292 | -34.06%