### PR TITLE
samba: update to samba-4.9.8

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.9.7"
-PKG_SHA256="44e5bc58dcae6d86ca8d5f269fa927f20ff91bce97cde86fe4e83addcb89c001"
+PKG_VERSION="4.9.8"
+PKG_SHA256="82ebb7c3f1847c39341dd97ff8b73f40fa83f5f794daeceb80f3c349ace3cf56"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Addictive Directory vuln: https://www.samba.org/samba/history/samba-4.9.8.html