### PR TITLE
config: don't use mcpu switch for arm and aarch64

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -14,7 +14,6 @@
       TARGET_SUBARCH=aarch64
       TARGET_VARIANT=armv8-a
       TARGET_ABI=eabi
-      TARGET_EXTRA_FLAGS="-mcpu=${TARGET_CPU}${TARGET_CPU_FLAGS}"
       TARGET_FEATURES+=" neon"
       ;;
   esac
@@ -23,6 +22,6 @@
   TARGET_KERNEL_ARCH=arm64
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mabi=lp64 -Wno-psabi -mtune=$TARGET_CPU $TARGET_EXTRA_FLAGS"
+  TARGET_CFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mabi=lp64 -Wno-psabi -mtune=$TARGET_CPU"
   TARGET_LDFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mtune=$TARGET_CPU"
   GCC_OPTS="--with-abi=lp64 --with-arch=$TARGET_VARIANT"

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -27,27 +27,23 @@
     arm1176jzf-s)
       TARGET_SUBARCH=armv6zk
       TARGET_ABI=eabi
-      TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       ;;
     cortex-a7|cortex-a15|cortex-a17|cortex-a15.cortex-a7|cortex-a17.cortex-a7)
       TARGET_SUBARCH=armv7ve
       TARGET_ABI=eabi
-      TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       TARGET_FEATURES+=" neon"
       ;;
     cortex-a5|cortex-a8|cortex-a9)
       TARGET_SUBARCH=armv7-a
       TARGET_ABI=eabi
-      TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       TARGET_FEATURES+=" neon"
       ;;
     cortex-a53|cortex-a72.cortex-a53)
       TARGET_SUBARCH=armv8-a
       TARGET_ABI=eabi
-      TARGET_EXTRA_FLAGS="-mcpu=${TARGET_CPU}"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       TARGET_FEATURES+=" neon"
       ;;
@@ -58,7 +54,7 @@
   TARGET_KERNEL_ARCH=${TARGET_KERNEL_ARCH:-arm}
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated $TARGET_EXTRA_FLAGS"
+  TARGET_CFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated"
   [ -n "$TARGET_FPU" ] && TARGET_CFLAGS="$TARGET_CFLAGS $TARGET_FPU_FLAGS"
   TARGET_LDFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU"
   GCC_OPTS="--with-abi=aapcs-linux --with-arch=$TARGET_SUBARCH --with-float=$TARGET_FLOAT --with-fpu=$TARGET_FPU"


### PR DESCRIPTION
When compiling glibc for cortex-a9, the following errors appears:
`cc1: error: switch -mcpu=cortex-a9 conflicts with -march=armv7-a switch [-Werror]`

Using `mcpu` with `march` and `mtune` is not recommended and compiler emits warnings/errors when mismatched.