### PR TITLE
kernel-firmware/intel-ucode: update to 20190514

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,18 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20180807a"
-PKG_SHA256="46ab18699ec42eb6cc01ee1846ec4d7ca979766dee2156f92d69e2f6df548137"
+PKG_VERSION="20190514"
+PKG_SHA256="553858de4315d267d1f259d1146db028eec5112a797379a7a83f5c8a22e626b3"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"
-PKG_URL="https://downloadmirror.intel.com/28087/eng/microcode-${PKG_VERSION}.tgz"
-PKG_DEPENDS_HOST="toolchain"
-PKG_DEPENDS_TARGET="toolchain intel-ucode:host"
+PKG_URL="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/microcode-${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="intel-ucode: Intel CPU microcodes"
 PKG_TOOLCHAIN="manual"
-
-unpack() {
-  mkdir -p $PKG_BUILD
-  tar xf $SOURCES/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tgz -C $PKG_BUILD
-}

--- a/packages/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -5,10 +5,14 @@ htc_9271.fw
 ath3k-1.fw
 ar5523.bin
 carl9170-1.fw
-mt7601u.bin
 rt2870.bin
 rt73.bin
 vntwusb.fw
+
+#mediatek
+mt7601u.bin
+mt7662*.bin
+mediatek/mt7662u*.bin
 
 ath6k/AR6004/hw1.?/bdata.bin
 ath9k_htc/*

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -16,11 +16,15 @@ PKG_TOOLCHAIN="manual"
 makeinstall_target() {
   FW_TARGET_DIR=$INSTALL/$(get_full_firmware_dir)
 
-  if find_file_path firmwares/kernel-firmware.dat; then
+  if find_file_path config/kernel-firmware.dat; then
     FW_LISTS="${FOUND_PATH}"
   else
     FW_LISTS="${PKG_DIR}/firmwares/any.dat ${PKG_DIR}/firmwares/${TARGET_ARCH}.dat"
   fi
+
+  FW_LISTS+=" ${PROJECT_DIR}/${PROJECT}/config/kernel-firmware-any.dat ${PROJECT_DIR}/${PROJECT}/config/kernel-firmware-${TARGET_ARCH}.dat"
+
+  FW_LISTS+=" ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/config/kernel-firmware-any.dat ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/config/kernel-firmware-${TARGET_ARCH}.dat"
 
   for fwlist in ${FW_LISTS}; do
     [ -f "${fwlist}" ] || continue

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="92e17d0dd2437140fab044ae62baf69b35d7d1fa"
-PKG_SHA256="614aeecebe641a20fbc2825b6cd749d5c5528cba40a75503a5fd93321681e312"
+PKG_VERSION="20190514"
+PKG_SHA256="13dede60a1ba7b967f0eef72f40720a2ea0678dee54ea3fc44800f58ec38aafc"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
* Latest Intel ucode with ZombieLoad fixes, switch to github repo
* Amlogic vdec firmwares
* Add support for installing project and/or device firmwares
* Add Mediatek mt7662[u] firmwares ([ref](https://forum.kodi.tv/showthread.php?tid=343068&pid=2854648#pid2854648))