### PR TITLE
glibc: raise minimum kernel supported to 4.4.0

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -27,7 +27,7 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --with-__thread \
                            --with-binutils=$BUILD/toolchain/bin \
                            --with-headers=$SYSROOT_PREFIX/usr/include \
-                           --enable-kernel=3.0.0 \
+                           --enable-kernel=4.4.0 \
                            --without-cvs \
                            --without-gd \
                            --disable-build-nscd \


### PR DESCRIPTION
This is a micro-op for glibc's generic (non-SIMD) string and memory functions, removing support for kernels before 4.4. It's a revisit, and lower maintenance burden version, of #2756. 