### PR TITLE
linux: drop ati_remote.conf modprobe file

### DIFF
--- a/packages/linux/modprobe.d/ati_remote.conf
+++ b/packages/linux/modprobe.d/ati_remote.conf
@@ -1,3 +1,0 @@
-# /etc/modprobe.d/ati_remote.conf: setup modload options for module ati_remote.
-
-options ati_remote mouse=no


### PR DESCRIPTION
Disabling mouse support in the driver not only makes the mouse
feature of the remote non-functional but also results in a kernel
crash when a pressing a mouse button on the remote.

See https://forum.libreelec.tv/thread/17562-le-9-0-2-freeze-when-ati-remote-is-used/