### PR TITLE
curl: update to curl-7.65.0

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -11,8 +11,8 @@
 #   there: http://forum.xbmc.org/showthread.php?tid=177557
 
 PKG_NAME="curl"
-PKG_VERSION="7.64.1"
-PKG_SHA256="9252332a7f871ce37bfa7f78bdd0a0e3924d8187cc27cb57c76c9474a7168fb3"
+PKG_VERSION="7.65.0"
+PKG_SHA256="7766d263929404f693905b5e5222aa0f2bdf8c66ab4b8758f0c0820a42b966cd"
 PKG_LICENSE="MIT"
 PKG_SITE="http://curl.haxx.se"
 PKG_URL="http://curl.haxx.se/download/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
[Changelog](https://curl.haxx.se/changes.html#7_65_0)

Security fixes:
* [Integer overflows in curl_url_set()](https://curl.haxx.se/docs/CVE-2019-5435.html)
* [TFTP receive buffer overflow](https://curl.haxx.se/docs/CVE-2019-5436.html)