### PR TITLE
Fix U-Boot compilation when board config is missing

### DIFF
--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -35,7 +35,10 @@ esac
 
 post_patch() {
   if [ -n "$UBOOT_SYSTEM" ] && find_file_path bootloader/config; then
-    cat $FOUND_PATH >> "$PKG_BUILD/configs/$($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM config)"
+    PKG_CONFIG_FILE="$PKG_BUILD/configs/$($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM config)"
+    if [ -f "$PKG_CONFIG_FILE" ]; then
+      cat $FOUND_PATH >> "$PKG_CONFIG_FILE"
+    fi
   fi
 }
 

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -12,13 +12,14 @@ devices = {
     'A64' : {
       'pine64' : { 'dtb' : 'sun50i-a64-pine64.dtb', 'config' : 'pine64_plus_defconfig' },
       'pine64_plus' : { 'dtb' : 'sun50i-a64-pine64-plus.dtb', 'config' : 'pine64_plus_defconfig' },
-      'pine64_lts' : { 'dtb' : 'sun50i-a64-sopine-baseboard.dtb', 'config' : 'sopine_baseboard_defconfig' },
+      'pine64_lts' : { 'dtb' : 'sun50i-a64-pine64-lts.dtb', 'config' : 'pine64-lts_defconfig' },
       'orangepi_win' : { 'dtb' : 'sun50i-a64-orangepi-win.dtb', 'config' : 'orangepi_win_defconfig' },
     },
     'H3' : {
-      'bananapi_m2p' : { 'dtb' : 'sun8i-h3-bananapi-m2-plus.dtb', 'config' : 'Sinovoip_BPI_M2_Plus_defconfig' },
+      'bananapi_m2p' : { 'dtb' : 'sun8i-h3-bananapi-m2-plus.dtb', 'config' : 'bananapi_m2_plus_h3_defconfig' },
       'beelink_x2' : { 'dtb' : 'sun8i-h3-beelink-x2.dtb', 'config' : 'beelink_x2_defconfig' },
       'libretech_h3' : { 'dtb' : 'sun8i-h3-libretech-all-h3-cc.dtb', 'config' : 'libretech_all_h3_cc_h3_defconfig' },
+      'nanopi_m1' : { 'dtb' : 'sun8i-h3-nanopi-m1.dtb', 'config' : 'nanopi_m1_defconfig' },
       'orangepi_2' : { 'dtb' : 'sun8i-h3-orangepi-2.dtb', 'config' : 'orangepi_2_defconfig' },
       'orangepi_pc': { 'dtb': 'sun8i-h3-orangepi-pc.dtb', 'config': 'orangepi_pc_defconfig' },
       'orangepi_pc_plus': { 'dtb': 'sun8i-h3-orangepi-pc-plus.dtb', 'config': 'orangepi_pc_plus_defconfig' },


### PR DESCRIPTION
If board config is not present, appending project U-Boot settings will cause compilation problem and log would fill whole empty space on disk. Fix it by explicitly checking if config file really exist. If not, compilation will fail later, when makefile won't be able to find defconfig.

This PR also fixes U-Boot board config names for Allwinner project and adds new board, NanoPi M1.