### PR TITLE
config/functions: ln -sf is not always thread safe

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1192,7 +1192,7 @@ add_user() {
 
   mkdir -p ${INSTALL}/usr/cache
   touch ${INSTALL}/usr/cache/shadow
-  ln -sf /storage/.cache/shadow ${INSTALL}/etc/shadow
+  ln -sf /storage/.cache/shadow ${INSTALL}/etc/shadow 2>/dev/null || true
 
   PASSWORD="$2"
   if [ "$PASSWORD" = "x" ]; then


### PR DESCRIPTION
When building concurrently, if two or more processes execute `add_user()` concurrently there is a chance that `ln -sf` will fail with the following error:

```
ln: failed to create symbolic link '${INSTALL}/etc/shadow': File exists
```

This is because `ln -sf` (force create symbolic link) prior to [`coreutils-8.27`](https://github.com/coreutils/coreutils/commit/376967889ed7ed561e46ff6d88a66779db62737a) is NOT atomic.

This is a simple test script - run it concurrently in two different processes to reproduce the error when using `coreutils` prior to 8.27:
```
#!/bin/bash

INSTALL=/tmp/ln-sf-test

add_user() {
  mkdir -p ${INSTALL}/etc
  ln -sf /storage/.cache/shadow ${INSTALL}/etc/shadow
}

while [ : ]; do
  add_user || break
done

echo FAIL
```

Ubuntu 17.10 provides `coreutils-8.26`, and the test script will fail.

Ubuntu 19.04 provides `coreutils-8.30`, and the test script does not fail.

Given that an error due to this race condition is only likely to occur because the link already exists, it should be safe to ignore the error in this instance.
