### PR TITLE
libmali: add depends on kernel driver

### DIFF
--- a/packages/graphics/libmali/package.mk
+++ b/packages/graphics/libmali/package.mk
@@ -17,6 +17,12 @@ if listcontains "$MALI_FAMILY" "(t620|t720)"; then
   PKG_DEPENDS_TARGET+=" wayland"
 fi
 
+if [ "$LINUX" != "rockchip-4.4" ]; then
+  listcontains "$MALI_FAMILY" "4[0-9]+" && PKG_DEPENDS_TARGET+=" mali-utgard"
+  listcontains "$MALI_FAMILY" "t[0-9]+" && PKG_DEPENDS_TARGET+=" mali-midgard"
+  listcontains "$MALI_FAMILY" "g[0-9]+" && PKG_DEPENDS_TARGET+=" mali-bifrost"
+fi
+
 PKG_CMAKE_OPTS_TARGET="-DMALI_VARIANT=${MALI_FAMILY// /;}"
 
 if [ "$TARGET_ARCH" = "aarch64" ]; then

--- a/projects/Allwinner/devices/A64/options
+++ b/projects/Allwinner/devices/A64/options
@@ -28,8 +28,5 @@
   # ATF platform
     ATF_PLATFORM="sun50i_a64"
 
-  # additional drivers to install:
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS mali-utgard"
-
   # Mali GPU family
     MALI_FAMILY="400"

--- a/projects/Allwinner/devices/H3/options
+++ b/projects/Allwinner/devices/H3/options
@@ -37,8 +37,5 @@
   # Kernel target
     KERNEL_TARGET="zImage"
 
-  # additional drivers to install:
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS mali-utgard"
-
   # Mali GPU family
     MALI_FAMILY="400"

--- a/projects/Allwinner/devices/H6/options
+++ b/projects/Allwinner/devices/H6/options
@@ -28,8 +28,5 @@
   # ATF platform
     ATF_PLATFORM="sun50i_h6"
 
-  # additional drivers to install:
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS mali-midgard"
-
   # Mali GPU family
     MALI_FAMILY="t720"


### PR DESCRIPTION
This PR changes `libmali` to depend on kernel drivers for `mali-utgard/midgard/bifrost`. Removes the need to define `ADDITIONAL_DRIVERS` in project/device `options`-file. `rockchip-4.4` is excluded since it has mali driver bundled in kernel tree.

There is currently not a `mali-bifrost` package in master branch, it will be added once Amlogic mainline is merged into master branch.

Only Allwinner is affected by this change at the moment, mainline Amlogic and Rockchip will also benefit from this change once they land in master.