### PR TITLE
Alliwinner: Add eMMC definition to device tree of Orange PI 3

### DIFF
--- a/projects/Allwinner/devices/H6/patches/linux/07-opi3.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/07-opi3.patch
@@ -302,7 +302,7 @@ new file mode 100644
 index 0000000000000..17d4969901086
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
-@@ -0,0 +1,219 @@
+@@ -0,0 +1,229 @@
 +// SPDX-License-Identifier: (GPL-2.0+ or MIT)
 +/*
 + * Copyright (C) 2019 Ondřej Jirman <megous@megous.com>
@@ -372,6 +372,16 @@ index 0000000000000..17d4969901086
 +	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
 +	bus-width = <4>;
 +	status = "okay";
++};
++
++&mmc2 {
++      pinctrl-names = "default";
++      pinctrl-0 = <&mmc2_pins>;
++      vmmc-supply = <&reg_cldo1>;
++      non-removable;
++      cap-mmc-hw-reset;
++      bus-width = <8>;
++      status = "okay";
 +};
 +
 +&ohci0 {

--- a/projects/Allwinner/devices/H6/patches/u-boot/002-orange-pi-3-support.patch
+++ b/projects/Allwinner/devices/H6/patches/u-boot/002-orange-pi-3-support.patch
@@ -15,7 +15,7 @@ new file mode 100644
 index 0000000000..8070adc39b
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h6-orangepi-3.dts
-@@ -0,0 +1,316 @@
+@@ -0,0 +1,326 @@
 +// SPDX-License-Identifier: (GPL-2.0+ or MIT)
 +/*
 + * Copyright (C) 2019 Ondřej Jirman <megous@megous.com>
@@ -181,6 +181,16 @@ index 0000000000..8070adc39b
 +	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
 +	bus-width = <4>;
 +	status = "okay";
++};
++
++&mmc2 {
++      pinctrl-names = "default";
++      pinctrl-0 = <&mmc2_pins>;
++      vmmc-supply = <&reg_cldo1>;
++      non-removable;
++      cap-mmc-hw-reset;
++      bus-width = <8>;
++      status = "okay";
 +};
 +
 +&ohci0 {


### PR DESCRIPTION
This change adds the "mmc2" definition for the device tree for Orange PI 3 on u-boot and linux. This definition enables the eMMC present on some Orange PI 3 models.