### PR TITLE
buildsystem: die if a kernel config is not available

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1001,8 +1001,10 @@ kernel_config_path() {
              $pkg_linux_dir/config/$config_name \
              ; do
     [[ $cfg =~ /devices//linux/ ]] && continue
-    [ -f "$cfg" ] && echo "$cfg" && break
+    [ -f "$cfg" ] && echo "$cfg" && return
   done
+
+  die "ERROR: Unable to locate kernel config for ${LINUX} - looking for ${config_name}"
 }
 
 kernel_make() {

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -48,10 +48,12 @@ makeinstall_target() {
     done < "${fwlist}"
   done
 
+  PKG_KERNEL_CFG_FILE=$(kernel_config_path) || die
+
   # The following files are RPi specific and installed by brcmfmac_sdio-firmware-rpi instead.
   # They are also not required at all if the kernel is not suitably configured.
   if listcontains "${FIRMWARE}" "brcmfmac_sdio-firmware-rpi" || \
-     ! grep -q "^CONFIG_BRCMFMAC_SDIO=y" $(kernel_config_path); then
+     ! grep -q "^CONFIG_BRCMFMAC_SDIO=y" ${PKG_KERNEL_CFG_FILE}; then
     rm -fr $FW_TARGET_DIR/brcm/brcmfmac43430*-sdio.*
     rm -fr $FW_TARGET_DIR/brcm/brcmfmac43455*-sdio.*
   fi

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -36,7 +36,7 @@ case "$LINUX" in
     ;;
 esac
 
-PKG_KERNEL_CFG_FILE=$(kernel_config_path)
+PKG_KERNEL_CFG_FILE=$(kernel_config_path) || die
 
 if [ -n "$KERNEL_TOOLCHAIN" ]; then
   PKG_DEPENDS_HOST="$PKG_DEPENDS_HOST gcc-arm-$KERNEL_TOOLCHAIN:host"


### PR DESCRIPTION
If a kernel config is not available, sourcing the `linux` package will hang because we `grep` for content without providing a filename.