### PR TITLE
Amlogic: fix backport kernel patches for 5.1.9

### DIFF
--- a/projects/Amlogic/patches/linux/a-meson-integ.patch
+++ b/projects/Amlogic/patches/linux/a-meson-integ.patch
@@ -8666,45 +8666,6 @@ index 35df73e42cbc5..b9d9dde9fbaf4 100644
  	}
  
 
-From e595b9b55d362f9699dc404dd926258dd7c18faa Mon Sep 17 00:00:00 2001
-From: Jerome Brunet <jbrunet@baylibre.com>
-Date: Mon, 29 Apr 2019 15:29:39 +0200
-Subject: [PATCH 061/249] UPSTREAM: ASoC: hdmi-codec: unlock the device on
- startup errors
-
-If the hdmi codec startup fails, it should clear the current_substream
-pointer to free the device. This is properly done for the audio_startup()
-callback but for snd_pcm_hw_constraint_eld().
-
-Make sure the pointer cleared if an error is reported.
-
-Signed-off-by: Jerome Brunet <jbrunet@baylibre.com>
-Signed-off-by: Mark Brown <broonie@kernel.org>
-(cherry picked from commit 30180e8436046344b12813dc954b2e01dfdcd22d)
-Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
----
- sound/soc/codecs/hdmi-codec.c | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
-
-diff --git a/sound/soc/codecs/hdmi-codec.c b/sound/soc/codecs/hdmi-codec.c
-index b9d9dde9fbaf4..720de0a53c799 100644
---- a/sound/soc/codecs/hdmi-codec.c
-+++ b/sound/soc/codecs/hdmi-codec.c
-@@ -439,8 +439,12 @@ static int hdmi_codec_startup(struct snd_pcm_substream *substream,
- 		if (!ret) {
- 			ret = snd_pcm_hw_constraint_eld(substream->runtime,
- 							hcp->eld);
--			if (ret)
-+			if (ret) {
-+				mutex_lock(&hcp->current_stream_lock);
-+				hcp->current_stream = NULL;
-+				mutex_unlock(&hcp->current_stream_lock);
- 				return ret;
-+			}
- 		}
- 		/* Select chmap supported */
- 		hdmi_codec_eld_chmap(hcp);
-
 From a6118030ab40baa635a596af19136dd0039ebd8f Mon Sep 17 00:00:00 2001
 From: Jerome Brunet <jbrunet@baylibre.com>
 Date: Mon, 29 Apr 2019 15:29:40 +0200


### PR DESCRIPTION
The commit "ASoC: hdmi-codec: unlock the device on startup errors"
landed in 5.1.6 and can be dropped in LE.

This fixes kernel patches not applying in current LE master

Note: only scripts/unpack tested so far yet, build is still running