### PR TITLE
init: more informative syslinux boot message

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -589,7 +589,8 @@ update_bootmenu() {
         progress "Updating /flash/syslinux.cfg [$crnt_default -> $SYSLINUX_DEFAULT]"
 
         mount -o remount,rw /flash
-        sed -i "s/^DEFAULT .*/DEFAULT $SYSLINUX_DEFAULT/" /flash/syslinux.cfg
+        sed -e "s/^SAY Wait for .* mode/SAY Wait for ${SYSLINUX_DEFAULT} mode/" -i /flash/syslinux.cfg
+        sed -e "s/^DEFAULT .*/DEFAULT $SYSLINUX_DEFAULT/" -i /flash/syslinux.cfg
         rm -f /flash/EFI/BOOT/syslinux.cfg
         mount -o remount,ro /flash
       fi
@@ -603,7 +604,7 @@ update_bootmenu() {
         progress "Updating /flash/EFI/BOOT/grub.cfg [$crnt_default -> \"$GRUB_DEFAULT\"]"
 
         mount -o remount,rw /flash
-        sed -i "s/^set default=.*/set default=\"$GRUB_DEFAULT\"/" /flash/EFI/BOOT/grub.cfg
+        sed -e "s/^set default=.*/set default=\"$GRUB_DEFAULT\"/" -i /flash/EFI/BOOT/grub.cfg
         rm -f /flash/grub.cfg
         mount -o remount,ro /flash
       fi

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -115,7 +115,14 @@ if [ "${BOOTLOADER}" = "syslinux" ]; then
   # create bootloader configuration
   echo "image: creating bootloader configuration..."
   cat << EOF > "${LE_TMP}/syslinux.cfg"
-SAY Wait for installer mode to start or <TAB> for options (installer, live, run)
+SAY Wait for installer mode to start automatically in 5 seconds...
+SAY
+SAY Options
+SAY =======
+SAY installer: permanently install ${DISTRO} to HDD/SSD
+SAY live: boot ${DISTRO} using RAM for temporary storage
+SAY run: boot ${DISTRO} using this USB memory device for storage
+SAY
 DEFAULT installer
 TIMEOUT 50
 PROMPT 1

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -115,7 +115,7 @@ if [ "${BOOTLOADER}" = "syslinux" ]; then
   # create bootloader configuration
   echo "image: creating bootloader configuration..."
   cat << EOF > "${LE_TMP}/syslinux.cfg"
-SAY Wait for installer to start or press <TAB> for more options (live, run)
+SAY Wait for installer mode to start or <TAB> for options (installer, live, run)
 DEFAULT installer
 TIMEOUT 50
 PROMPT 1


### PR DESCRIPTION
I recently watched a [YouTube video](https://www.youtube.com/watch?v=QCdh0VZvBGs&t=381) of someone installing LibreELEC to run only from the USB flash drive. He entered `run` at the boot prompt:
```
Wait for installer to start or press <TAB> for more options (live, run)
```
but in the comments for the video there are several people asking how to install to the HDD, with some even saying it isn't possible...


When you look at the boot message, the confusion is perhaps obvious - we don't mention that `installer` is even an option!

This PR addresses the ommission by changing the boot message to:
```
Wait for installer mode to start or <TAB> for options (installer, live, run)
```

I've tried to fit the updated message within 80 chars to avoid wrapping on most displays (Generic/non-UEFI boot mode).

I've also added an extra change so that the current "default" option is reflected in the boot message - for example if you enter `run`, the next time the system boots the boot message will be:
```
Wait for run mode to start or <TAB> for options (installer, live, run)
```
