### PR TITLE
distro: bump ADDON_VERSION to 9.1.900

### DIFF
--- a/distributions/LibreELEC/version
+++ b/distributions/LibreELEC/version
@@ -5,4 +5,4 @@
   OS_VERSION="9.1"
 
 # ADDON_VERSION: Addon version
-  ADDON_VERSION="9.1"
+  ADDON_VERSION="9.1.900"


### PR DESCRIPTION
final 9.2 release would have 9.2.0 addon version
x.x.900 is a workaround because we bumped to 9.1 already that was basically a mistake
for future bumps we can use x.x.0, x.x.1, x.x.2, ... x.x.9999,  - 3 digits saves us from trouble and allows maximal flexibility