### PR TITLE
fixup slice cleanup, revert accidentally added testing change

### DIFF
--- a/projects/RPi/devices/RPi2/options
+++ b/projects/RPi/devices/RPi2/options
@@ -7,6 +7,3 @@
 
   # NOOBS supported model versions
     NOOBS_SUPPORTED_MODELS='"Pi 2","Pi 3"'
-
-  # TESTING, do not commit!
-    ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS} slice-drivers"


### PR DESCRIPTION
dtc:host dependency was already dropped in e3c0a79024a, git rebase worked fine but unfortunately I had a local testing change in my commit so rebase left the commit with only the testing change.