### PR TITLE
kodi (Rockchip): update to kodi-rockchip_18.3-Leia-v2

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -18,8 +18,8 @@ case $KODI_VENDOR in
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;
   rockchip)
-    PKG_VERSION="rockchip_18.3-Leia"
-    PKG_SHA256="a9eb3f44b0c7ab409604a2de0c3469f88b20c5d4a69209c006ca4a61673db318"
+    PKG_VERSION="rockchip_18.3-Leia-v2"
+    PKG_SHA256="dfce13129aa8381a4e06cd6c0f597c6212f4230184723edf802d06ea20d5509b"
     PKG_URL="https://github.com/kwiboo/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;


### PR DESCRIPTION
This PR updates the kodi rockchip tag with minor changes to the Rockchip HDR commit, sync more code with upstream HDR PR and adds support for setting full HDR metadata in the DRM infoframe.

Changes: https://github.com/Kwiboo/xbmc/compare/rockchip_18.3-Leia...rockchip_18.3-Leia-v2
Fixup commit: https://github.com/Kwiboo/xbmc/commit/6beb573e3de1a6db747687468cca7fdd6866e3a9