### PR TITLE
Force AP Port to use just ap's with port 443

### DIFF
--- a/packages/addons/service/librespot/source/bin/librespot.start
+++ b/packages/addons/service/librespot/source/bin/librespot.start
@@ -74,6 +74,7 @@ init_alsa() {
 oe_setup_addon service.librespot
 
 LIBRESPOT="librespot --cache \"$ADDON_HOME/cache\" \
+                     --ap-port 443 \
                      --disable-audio-cache \
                      --name \"Librespot@$HOSTNAME\" \
                      --onevent librespot.onevent"


### PR DESCRIPTION
Since APs using 4070 in ap_list response  is not working, at least to me,  I suggest to use other port rather than 4070... may we could create a fallback in case it get no response from an AP