### PR TITLE
mpg123: drop dependency on SDL2

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="6c1337aee2e4bf993299851c70b7db11faec785303cfca3a5c3eb5f329ba7023"
 PKG_LICENSE="LGPLv2"
 PKG_SITE="http://www.mpg123.org/"
 PKG_URL="http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-$PKG_VERSION.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain alsa-lib SDL2"
+PKG_DEPENDS_TARGET="toolchain alsa-lib"
 PKG_LONGDESC="A console based real time MPEG Audio Player for Layer 1, 2 and 3."
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared \


### PR DESCRIPTION
mpg123 only checks for SDL, not SDL2, so we only built mpg123 with
alsa, oss and pulse support (which is enough) and we ca drop the SDL2
dependency.
