### PR TITLE
buildsystem: fix scripts/unpack after #3570

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -116,9 +116,9 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ]; then
     PATCH_DIRS_PRJ=""
     if [ -n "${PKG_PATCH_DIRS}" ]; then
       for patch_dir in ${PKG_PATCH_DIRS}; do
-        [ -d ${PKG_DIR}/patches/${patch_dir} ] && PATCH_DIRS_PKG+="${PATCH_DIRS_PKG} ${PKG_DIR}/patches/${patch_dir}/*.patch"
-        [ -d ${PROJECT_DIR}/${PROJECT}/patches/${PKG_NAME}/${patch_dir} ] && PATCH_DIRS_PRJ="${PATCH_DIRS_PRJ} ${PROJECT_DIR}/${PROJECT}/patches/${PKG_NAME}/${patch_dir}/*.patch"
-        [ -d ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/patches/${PKG_NAME}/${patch_dir} ] && PATCH_DIRS_PRJ="${PATCH_DIRS_PRJ} ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/patches/${PKG_NAME}/${patch_dir}/*.patch"
+        [ -d ${PKG_DIR}/patches/${patch_dir} ] && PATCH_DIRS_PKG+=" ${PKG_DIR}/patches/${patch_dir}/*.patch"
+        [ -d ${PROJECT_DIR}/${PROJECT}/patches/${PKG_NAME}/${patch_dir} ] && PATCH_DIRS_PRJ+=" ${PROJECT_DIR}/${PROJECT}/patches/${PKG_NAME}/${patch_dir}/*.patch"
+        [ -d ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/patches/${PKG_NAME}/${patch_dir} ] && PATCH_DIRS_PRJ+=" ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/patches/${PKG_NAME}/${patch_dir}/*.patch"
       done
     fi
 


### PR DESCRIPTION
The original change was half arsed. Now it's not.