### PR TITLE
ffmpeg: drop --disable-rpi option on non-RPi projects

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -83,8 +83,6 @@ pre_configure_target() {
   if [ "$PROJECT" = "RPi" ]; then
     PKG_FFMPEG_LIBS="-lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
     PKG_FFMPEG_RPI="--enable-rpi"
-  else
-    PKG_FFMPEG_RPI="--disable-rpi"
   fi
 }
 


### PR DESCRIPTION
The ffmpeg patches which add enable/disable-rpi options are now
RPi device specific, so using --disable-rpi breaks builds on non-RPi
projects.