### PR TITLE
rpi: rpi4: add canupdate.sh to only install on compatible hardware

### DIFF
--- a/projects/RPi/devices/RPi4/bootloader/canupdate.sh
+++ b/projects/RPi/devices/RPi4/bootloader/canupdate.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+CURRENT_IMG=$1
+UPGRADE_IMG=$2
+
+RPI_REVISION=$(hexdump -ve '1/1 "%.2x"' </proc/device-tree/system/linux,revision)
+RPI_CPU=${RPI_REVISION:4:1}
+
+if echo $CURRENT_IMG | grep -qE "^RPi[0-9]?+\..*"; then
+  if  [ $RPI_CPU = "3" ]; then
+    exit 0
+  else
+    echo "ERROR: canupdate.sh: cpu unsupported by $UPGRADE_IMG image - not a BCM2838?"
+    exit 1
+  fi
+else
+  echo "ERROR: canupdate.sh: current platform not a Raspberry Pi?"
+  exit 1
+fi


### PR DESCRIPTION
Applies on top of PR3597.

The code logic is tested on an RPi3 (with suitable changes) for ~2 months on my builds. Needs testing to confirm I didn't make a mistake in adapting.