### PR TITLE
scripts/mkimage: force gzip to overwrite target/*.img.gz

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -325,7 +325,7 @@ fi
 
 # gzip
 echo "image: compressing..."
-gzip "${DISK}"
+gzip -f "${DISK}"
 
 # set owner
 if [ -n "${SUDO_USER}" ]; then


### PR DESCRIPTION
If doing unclean rebuild of a device that uses UBOOT_SYSTEM with a static version number, mkimage fails as the output image file already exists in the target/* folder. Adding -f allows gzip to overwrite the existing file allowing the UBOOT_SYSTEM loop to continue. The issue is not seen with Jenkins as we're always building clean, or devel images as the filenames change with each build run.