### PR TITLE
buildsystem: use pigz when compressing images

### DIFF
--- a/packages/compress/pigz/package.mk
+++ b/packages/compress/pigz/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pigz"
+PKG_VERSION="2.4"
+PKG_SHA256="e228e7d18b34c4ece8d596eb6eee97bde533c6beedbb728d07d3abe90b4b1b52"
+PKG_LICENSE="Other"
+PKG_SITE="https://zlib.net/pigz/"
+PKG_URL="https://github.com/madler/pigz/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="make:host zlib:host"
+PKG_LONGDESC="a parallel implementation of the gzip file compressor"
+PKG_TOOLCHAIN="manual"
+
+make_host() {
+  make CPPFLAGS="${CPPFLAGS} -I${TOOLCHAIN}/include" \
+       LDFLAGS="${LDFLAGS}" \
+       CXX="${CXX}" \
+       CC="${CC}" \
+       pigz
+}
+
+makeinstall_host() {
+  mkdir -p $TOOLCHAIN/bin
+    cp pigz ${TOOLCHAIN}/bin
+}

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="f3eeb8d57e25ca9fc13c2af3dae97754f9f643bc69229546828e3a240e2af04b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/libc/"
 PKG_URL="http://ftp.gnu.org/pub/gnu/glibc/$PKG_NAME-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap"
+PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap pigz:host"
 PKG_DEPENDS_INIT="glibc"
 PKG_LONGDESC="The Glibc package contains the main C library."
 PKG_BUILD_FLAGS="-gold"
@@ -125,7 +125,7 @@ post_makeinstall_target() {
   if [ "$PROJECT" = "Generic" ]; then
     mkdir -p $INSTALL/usr/share/i18n/charmaps
     cp -PR $PKG_BUILD/localedata/charmaps/UTF-8 $INSTALL/usr/share/i18n/charmaps
-    gzip $INSTALL/usr/share/i18n/charmaps/UTF-8
+    pigz --best --force $INSTALL/usr/share/i18n/charmaps/UTF-8
   fi
 
   if [ ! "$GLIBC_LOCALES" = yes ]; then

--- a/packages/virtual/toolchain/package.mk
+++ b/packages/virtual/toolchain/package.mk
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="toolchain"
 PKG_VERSION=""
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="configtools:host make:host xz:host sed:host pkg-config:host autoconf:host automake:host intltool:host libtool:host autoconf-archive:host gcc:host bison:host flex:host cmake:host xmlstarlet:host p7zip:host ninja:host meson:host"
+PKG_DEPENDS_TARGET="configtools:host make:host xz:host sed:host pkg-config:host autoconf:host automake:host intltool:host libtool:host autoconf-archive:host gcc:host bison:host flex:host cmake:host xmlstarlet:host p7zip:host pigz:host ninja:host meson:host"
 PKG_SECTION="virtual"
 PKG_LONGDESC="LibreELEC.tv' toolchain to compile all packages"

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -325,7 +325,7 @@ fi
 
 # gzip
 echo "image: compressing..."
-gzip -f "${DISK}"
+pigz --best --force "${DISK}"
 
 # set owner
 if [ -n "${SUDO_USER}" ]; then


### PR DESCRIPTION
#### Generic 250MB `.img` on 8-core build host:

gzip:
```
real    0m11.084s
user    0m10.731s
sys     0m0.352s
```
pigz:
```
real    0m1.891s
user    0m14.122s
sys     0m0.440s
```

The time to build `pigz` is an extra overhead but this is a small/simple C package (2-3 seconds to build) which should more than offset the time saved when creating the compressed image. U-boot-based projects will see the most benefit from this change.