### PR TITLE
[le92] fix noobs image creation

### DIFF
--- a/config/noobs/os.json
+++ b/config/noobs/os.json
@@ -6,6 +6,6 @@
   "description": "@DESCRIPTION@",
   "username": "root",
   "password": "@ROOT_PASSWORD@",
-  "supported_models": [@NOOBS_SUPPORTED_MODELS@],
-  "supported_hex_revisions": "@NOOBS_HEX@"
+  "supported_hex_revisions": "@NOOBS_HEX@",
+  "supported_models": [@NOOBS_SUPPORTED_MODELS@]
 }

--- a/projects/RPi/devices/RPi4/options
+++ b/projects/RPi/devices/RPi4/options
@@ -2,8 +2,8 @@
 # Device defaults
 ################################################################################
 
-  # NOOBS supported hex versions (legacy)
-    NOOBS_HEX="1040,1041,2082"
+  # NOOBS supported hex versions (legacy) is not relevant for RPi4
+    unset NOOBS_HEX
 
   # NOOBS supported model versions
     NOOBS_SUPPORTED_MODELS='"Pi 4"'

--- a/scripts/image
+++ b/scripts/image
@@ -364,6 +364,14 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
     cp ${ROOT}/README* ${RELEASE_DIR}/${NOOBS_DISTRO}
     cp ${ROOT}/CHANGELOG ${RELEASE_DIR}/${NOOBS_DISTRO}/release_notes.txt
 
+    if [ -n "${NOOBS_HEX}" ]; then
+      sed -e "s%@NOOBS_HEX@%${NOOBS_HEX}%g" \
+          -i ${RELEASE_DIR}/${NOOBS_DISTRO}/os.json
+    else
+      sed -e "/@NOOBS_HEX@/d" \
+          -i ${RELEASE_DIR}/${NOOBS_DISTRO}/os.json
+    fi
+
     sed -e "s%@DISTRONAME@%${DISTRONAME}%g" \
         -e "s%@PROJECT@%${DEVICE:-${PROJECT}}%g" \
         -e "s%@LIBREELEC_VERSION@%${LIBREELEC_VERSION}%g" \
@@ -372,7 +380,6 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
         -e "s%@DESCRIPTION@%${DESCRIPTION}%g" \
         -e "s%@ROOT_PASSWORD@%${ROOT_PASSWORD}%g" \
         -e "s%@NOOBS_SUPPORTED_MODELS@%${NOOBS_SUPPORTED_MODELS}%g" \
-        -e "s%@NOOBS_HEX@%${NOOBS_HEX}%g" \
         -i ${RELEASE_DIR}/${NOOBS_DISTRO}/os.json
 
     sed -e "s%@DISTRONAME@%${DISTRONAME}%g" \

--- a/scripts/image
+++ b/scripts/image
@@ -383,12 +383,9 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
     # Create System dir
     mkdir -p ${RELEASE_DIR}/${NOOBS_DISTRO}/System
 
-    BOOTLOADER_DIR="$(get_pkg_directory "${BOOTLOADER}")"
-    if [ -d ${BOOTLOADER_DIR}/files/3rdparty/bootloader/ ]; then
-      cp -PR ${BOOTLOADER_DIR}/files/3rdparty/bootloader/* ${RELEASE_DIR}/${NOOBS_DISTRO}/System
-    fi
-
     # Copy Bootloader
+    cp -PR ${INSTALL}/usr/share/bootloader/config.txt ${RELEASE_DIR}/${NOOBS_DISTRO}/System/
+    cp -PR ${INSTALL}/usr/share/bootloader/distroconfig.txt ${RELEASE_DIR}/${NOOBS_DISTRO}/System/
     cp -PR ${INSTALL}/usr/share/bootloader/LICENCE* ${RELEASE_DIR}/${NOOBS_DISTRO}/System/
     cp -PR ${INSTALL}/usr/share/bootloader/bootcode.bin ${RELEASE_DIR}/${NOOBS_DISTRO}/System/
     cp -PR ${INSTALL}/usr/share/bootloader/fixup.dat ${RELEASE_DIR}/${NOOBS_DISTRO}/System/

--- a/scripts/image
+++ b/scripts/image
@@ -427,8 +427,8 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
     rm -rf ${RELEASE_DIR}/${NOOBS_DISTRO}/Storage.tar.xz
 
     # Create filesystem tarballs
-    tar cJf ${RELEASE_DIR}/${NOOBS_DISTRO}/System.tar.xz -C ${RELEASE_DIR}/${NOOBS_DISTRO}/System/ .
-    tar cJf ${RELEASE_DIR}/${NOOBS_DISTRO}/Storage.tar.xz -C ${RELEASE_DIR}/${NOOBS_DISTRO}/Storage/ .
+    ${TOOLCHAIN}/bin/fakeroot tar cJf ${RELEASE_DIR}/${NOOBS_DISTRO}/System.tar.xz -C ${RELEASE_DIR}/${NOOBS_DISTRO}/System/ .
+    ${TOOLCHAIN}/bin/fakeroot tar cJf ${RELEASE_DIR}/${NOOBS_DISTRO}/Storage.tar.xz -C ${RELEASE_DIR}/${NOOBS_DISTRO}/Storage/ .
 
     # Remove filesystem dirs
     rm -rf ${RELEASE_DIR}/${NOOBS_DISTRO}/System


### PR DESCRIPTION
Noobs image build didn't take device specific (distro)config.txt files into account which lead to default (RPi/RPi2) files being installed for RPi4 - and a non-working installation.

The System and especially Storage tarballs were created without fakeroot which lead to the storage partition not being owned by root but by with whatever user/goup the image was built, instead of root, which caused lots of services (including ssh and kodi) fail to start.

The RPi4 options copied the (legacy) noobs supported hex revisions from RPi2/3 which was not correct. This option is only relevant to ancient noobs versions which don't support RPi4 anyway, so we can just drop it from os.json.