### PR TITLE
buildsystem: small unpack improvements

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -53,11 +53,6 @@ if [ -f ${STAMP} ]; then
   rm -f ${STAMP}
 fi
 
-if [ -n "${PKG_DEPENDS_UNPACK}" ]; then
-  for p in ${PKG_DEPENDS_UNPACK}; do
-    ${SCRIPTS}/unpack "${p}" "${PARENT_PKG}"
-  done
-fi
 ${SCRIPTS}/unpack "${PKG_NAME}" "${PARENT_PKG}"
 
 # build dependencies, only when PKG_DEPENDS_? is filled

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -21,6 +21,12 @@ pkg_lock_status "ACTIVE" "${PKG_NAME}" "unpack"
 
 ${SCRIPTS}/get "${PKG_NAME}"
 
+if [ -n "${PKG_DEPENDS_UNPACK}" ]; then
+  for p in ${PKG_DEPENDS_UNPACK}; do
+    ${SCRIPTS}/unpack "${p}" "${PARENT_PKG}"
+  done
+fi
+
 STAMP="${PKG_BUILD}/.libreelec-unpack"
 
 mkdir -p ${BUILD}

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -17,10 +17,6 @@ PARENT_PKG="${2:-${PKG_NAME}}"
 
 pkg_lock "${PKG_NAME}" "unpack" "${PARENT_PKG}"
 
-pkg_lock_status "ACTIVE" "${PKG_NAME}" "unpack"
-
-${SCRIPTS}/get "${PKG_NAME}"
-
 if [ -n "${PKG_DEPENDS_UNPACK}" ]; then
   for p in ${PKG_DEPENDS_UNPACK}; do
     ${SCRIPTS}/unpack "${p}" "${PARENT_PKG}"
@@ -54,6 +50,10 @@ if [ -f "${STAMP}" ]; then
   pkg_lock_status "UNLOCK" "${PKG_NAME}" "unpack" "already unpacked"
   exit 0
 fi
+
+pkg_lock_status "ACTIVE" "${PKG_NAME}" "unpack"
+
+${SCRIPTS}/get "${PKG_NAME}"
 
 if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ]; then
   build_msg "CLR_UNPACK" "UNPACK" "${PKG_NAME}" "indent"


### PR DESCRIPTION
Small improvement when unpacking packages with a `PKG_DEPENDS_UNPACK` property.

Currently, when running `scripts/unpack TexturePacker` which has `PKG_DEPENDS_UNPACK="kodi"`, only the `TexturePacker` package is unpacked. Ideally, we would want to unpack `kodi` first, then unpack `TexturePacker`. 

With this change, the package being unpacked will now recursively unpack all packages in `PKG_DEPENDS_UNPACK`, which is better.

I've also moved the `ACTIVE` announcement to occur _after_ cleaning and stamp checking, so that the unpack process doesn't become "active" if the package is already unpacked.

The download call (`scripts/get`) also doesn't need to happen if the package is already unpacked, so again move that until after we clean/check stamps.