### PR TITLE
vdr-plugin-xmltv2vdr: link against openssl

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="eacc91062095563d8adc93873b373ddb34b076a8c0a9e5a86f6220d1d5d892e9"
 PKG_LICENSE="GPL"
 PKG_SITE="http://projects.vdr-developer.org/projects/plg-xmltv2vdr"
 PKG_URL="https://github.com/vdr-projects/vdr-plugin-xmltv2vdr/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain vdr sqlite curl libzip libxml2 libxslt enca pcre"
+PKG_DEPENDS_TARGET="toolchain vdr sqlite openssl curl libzip libxml2 libxslt enca pcre"
 PKG_NEED_UNPACK="$(get_pkg_directory vdr)"
 PKG_LONGDESC="xmltv2vdr imports data in xmltv format"
 PKG_TOOLCHAIN="manual"
@@ -16,7 +16,7 @@ PKG_BUILD_FLAGS="+pic"
 
 pre_configure_target() {
   export CXXFLAGS="$CXXFLAGS -Wno-narrowing"
-  export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv -lpcre -lpcrecpp"
+  export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv -lpcre -lpcrecpp -lssl -lcrypto"
 }
 
 make_target() {


### PR DESCRIPTION
Package fails to build with undefined references to SSL_new, BN_free, TLS_server_method, and similar. openssl provides these functions in libssl and libcrypto, so add to depends and link them in.

Needs runtime testing still.