### PR TITLE
kodi: temp fix stream details are being lost once playback ends [backport]

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-995.01-revert-always-update-stream-detail.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.01-revert-always-update-stream-detail.patch
@@ -1,0 +1,24 @@
+commit 545ca6a2e8b3af40fba3e9786c7b7b677eb712d3
+Author: afl1 <afl2001@gmail.com>
+Date:   Tue May 14 23:37:59 2019 +0200
+
+    Revert "fixed: We should always update stream details from player (fixes #15584)"
+    
+    This reverts commit be1ed70fb4b926cbdaf60367172ac7902690f00f.
+
+diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
+index 1c4f5dfcd0..4b1550d1b9 100644
+--- a/xbmc/Application.cpp
++++ b/xbmc/Application.cpp
+@@ -3049,8 +3049,9 @@ void CApplication::OnPlayBackStarted(const CFileItem &file)
+ {
+   CLog::LogF(LOGDEBUG,"CApplication::OnPlayBackStarted");
+ 
+-  // Always update file item stream details
+-  m_appPlayer.SetUpdateStreamDetails();
++  // check if VideoPlayer should set file item stream details from its current streams
++  if (file.GetProperty("get_stream_details_from_player").asBoolean())
++    m_appPlayer.SetUpdateStreamDetails();
+ 
+   if (m_stackHelper.IsPlayingISOStack() || m_stackHelper.IsPlayingRegularStack())
+     m_itemCurrentFile.reset(new CFileItem(*m_stackHelper.GetRegisteredStack(file)));


### PR DESCRIPTION
Backport of #3623 