### PR TITLE
nano: updated to v4.3

### DIFF
--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nano"
-PKG_VERSION="4.2"
-PKG_SHA256="1143defce62e391b241252ffdb6e5c1ded56cfe26d46ee81b796abe0ccc45df9"
+PKG_VERSION="4.3"
+PKG_SHA256="00d3ad1a287a85b4bf83e5f06cedd0a9f880413682bebd52b4b1e2af8cfc0d81"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.nano-editor.org/"
 PKG_URL="http://ftpmirror.gnu.org/nano/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
```
2019.06.18 - GNU nano 4.3 "Musa Kart"
â€¢ The ability to read from and write to a FIFO has been regained.
â€¢ Startup time is reduced by fully parsing a syntax only when needed.
â€¢ Asking for help (^G) when using --operatingdir does not crash.
â€¢ The reading of a huge or slow file can be stopped with ^C.
â€¢ Cut, zap, and copy operations are undone separately when intermixed.
â€¢ M-D reports the correct number of lines (zero for an empty buffer).
```
https://www.nano-editor.org/dist/v4/NEWS