### PR TITLE
linux: disable lima/panfrost when using libmali

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -89,6 +89,12 @@ post_patch() {
     sed -i -e "s|^CONFIG_ISCSI_IBFT_FIND=.*$|# CONFIG_ISCSI_IBFT_FIND is not set|" $PKG_BUILD/.config
     sed -i -e "s|^CONFIG_ISCSI_IBFT=.*$|# CONFIG_ISCSI_IBFT is not set|" $PKG_BUILD/.config
   fi
+
+  # disable lima/panfrost if libmali is configured
+  if [ "$OPENGLES" = "libmali" ]; then
+    sed -e "s|^CONFIG_DRM_LIMA=.*$|# CONFIG_DRM_LIMA is not set|" -i $PKG_BUILD/.config
+    sed -e "s|^CONFIG_DRM_PANFROST=.*$|# CONFIG_DRM_PANFROST is not set|" -i $PKG_BUILD/.config
+  fi
 }
 
 make_host() {


### PR DESCRIPTION
Linux 5.2 now contains Lima and Panfrost and Panfrost has rudimentary detection for Bifrost GPUs (5.1 patches only detect Midgard). Amlogic current uses a single kernel defconfig for both images and we'd like that to continue, so to use the Mali Bifrost blob/driver we now need to ensure in-kernel Panfrost is disabled. As people are also/still experimenting with the Mali Utgard blob in Amlogic images we also apply the same logic to Lima.