### PR TITLE
kodi: set @ADDON_VERSION@ in repo addon.xml

### DIFF
--- a/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/repository.libreelec.tv/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.libreelec.tv"
 		name="LibreELEC Add-ons"
-		version="9.0.1"
+		version="@ADDON_VERSION@"
 		provider-name="Team LibreELEC">
 	<extension point="xbmc.addon.repository"
 		name="LibreELEC Add-ons">

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -296,6 +296,7 @@ post_makeinstall_target() {
     sed -e "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.libreelec.tv/addon.xml
     cp -R $PKG_DIR/config/repository.libreelec.tv $INSTALL/usr/share/kodi/addons
     sed -e "s|@ADDON_URL@|$ADDON_URL|g" -i $INSTALL/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
+    sed -e "s|@ADDON_VERSION@|$ADDON_VERSION|g" -i $INSTALL/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
     cp -R $PKG_DIR/config/repository.kodi.game $INSTALL/usr/share/kodi/addons
 
   mkdir -p $INSTALL/usr/share/kodi/config


### PR DESCRIPTION
This sets the cosmetic version for the embedded LE repo add-on to $ADDON_VERSION from distro version config - instead of requiring a manual bump that we inevitably forget.