### PR TITLE
config/arch.arm: -mcpu=cortex-a9 conflicts with -march=armv7-a switch

### DIFF
--- a/config/arch.arm
+++ b/config/arch.arm
@@ -40,7 +40,6 @@
     cortex-a5|cortex-a8|cortex-a9)
       TARGET_SUBARCH=armv7-a
       TARGET_ABI=eabi
-      TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       TARGET_FEATURES+=" neon"
       ;;


### PR DESCRIPTION
glibc returns an error when compiling without this fix
```
cc1: error: switch -mcpu=cortex-a9 conflicts with -march=armv7-a switch [-Werror]
```