### PR TITLE
init: clean up splash image selection

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -403,21 +403,17 @@ load_splash() {
       if [ -z "$SPLASHIMAGE" ]; then
         vres="$(fbset 2>/dev/null | awk '/geometry/ { print $3 }')"
 
-        if [ -f /flash/oemsplash.png -o -f /flash/oemsplash-1080.png ]; then
-          if [ -n "$vres" -a -f /flash/oemsplash-$vres.png ]; then
-            SPLASHIMAGE="/flash/oemsplash-$vres.png"
-          elif [ -f /flash/oemsplash-1080.png ]; then
-            SPLASHIMAGE="/flash/oemsplash-1080.png"
-          else
-            SPLASHIMAGE="/flash/oemsplash.png"
+        for s in /flash/oemsplash-${vres}.png \
+                 /flash/oemsplash-1080.png \
+                 /flash/oemsplash.png \
+                 /splash/splash-${vres}.png \
+                 /splash/splash-1080.png \
+                 ; do
+          if [ -f "${s}" ]; then
+            SPLASHIMAGE="${s}"
+            break
           fi
-        else
-          if [ -n "$vres" -a -f /splash/splash-$vres.png ]; then
-            SPLASHIMAGE="/splash/splash-$vres.png"
-          else
-            SPLASHIMAGE="/splash/splash-1080.png"
-          fi
-        fi
+        done
       fi
 
       if [ -n "$SPLASHIMAGE" -a -f "$SPLASHIMAGE" ]; then


### PR DESCRIPTION
The current splash image selection logic is unnecessarily complicated, particularly with regard to OEM images. This PR simplifies it.