### PR TITLE
[le92] bcm2835-driver: fix /opt/vc symlink creation

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -55,8 +55,8 @@ make_target() {
 
   # Create symlinks to /opt/vc to satisfy hardcoded include & lib paths
   mkdir -p ${SYSROOT_PREFIX}/opt/vc
-    ln -sf ${SYSROOT_PREFIX}/usr/lib     ${SYSROOT_PREFIX}/opt/vc/lib
-    ln -sf ${SYSROOT_PREFIX}/usr/include ${SYSROOT_PREFIX}/opt/vc/include
+    ln -sfn ${SYSROOT_PREFIX}/usr/lib     ${SYSROOT_PREFIX}/opt/vc/lib
+    ln -sfn ${SYSROOT_PREFIX}/usr/include ${SYSROOT_PREFIX}/opt/vc/include
 }
 
 makeinstall_target() {


### PR DESCRIPTION
On unclean builds where, the /opt/vc/ symlinks to /usr/include
and /usr/lib were already present in the sysroot, ln -sf follows
the /opt/vc symlinks and creates the symlinks in /usr/include and
/usr/lib, respectively.

Use ln -sfn instead so ln doesn't dereference existing symlinks.

backport of #3639 