### PR TITLE
samba: update to samba-4.9.11

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.9.10"
-PKG_SHA256="f81ab92924b2f3c368ab64a381c1bb2befc7ddc90043dbb10b02d85cca27df61"
+PKG_VERSION="4.9.11"
+PKG_SHA256="bb736624d16f7369e395de2f15fec153b554f76f95864015b4ce1f2ae53e817b"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
https://www.samba.org/samba/history/samba-4.9.11.html

Not worth backporting to 9.2.