### PR TITLE
buildsystem: fix symbolic link fixups

### DIFF
--- a/packages/addons/addon-depends/lcdd-depends/serdisplib/package.mk
+++ b/packages/addons/addon-depends/lcdd-depends/serdisplib/package.mk
@@ -26,16 +26,14 @@ pre_configure_target() {
   export ac_cv_path_LIBUSB_CONFIG=$SYSROOT_PREFIX/usr/bin/libusb-config
 }
 
-post_make_target() {
+makeinstall_target() {
   # copy necessary libs and headers to build serdisplib support
   # into the driver glcd from lcdproc
   mkdir -p $SYSROOT_PREFIX/usr/include/serdisplib
   cp include/serdisplib/*.h $SYSROOT_PREFIX/usr/include/serdisplib
   mkdir -p $SYSROOT_PREFIX/usr/lib
   cp lib/libserdisp.so* $SYSROOT_PREFIX/usr/lib
-}
 
-makeinstall_target() {
   mkdir -p $INSTALL/usr/lib
   cp lib/libserdisp.so* $INSTALL/usr/lib
 }

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -19,7 +19,7 @@ else
   PKG_FLOAT="hardfp"
 fi
 
-make_target() {
+makeinstall_target() {
   # Install vendor header files
   mkdir -p ${SYSROOT_PREFIX}/usr/include
     if [ "${OPENGLES}" = "bcm2835-driver" ]; then
@@ -57,9 +57,7 @@ make_target() {
   mkdir -p ${SYSROOT_PREFIX}/opt/vc
     ln -sf ${SYSROOT_PREFIX}/usr/lib     ${SYSROOT_PREFIX}/opt/vc/lib
     ln -sf ${SYSROOT_PREFIX}/usr/include ${SYSROOT_PREFIX}/opt/vc/include
-}
 
-makeinstall_target() {
   # Install EGL, OpenGL ES and other vendor libs
   mkdir -p ${INSTALL}/usr/lib
     if [ "${OPENGLES}" = "bcm2835-driver" ]; then

--- a/scripts/build
+++ b/scripts/build
@@ -430,6 +430,7 @@ for i in $(find "${SYSROOT_PREFIX}/usr"/{lib,share} -type f -name "*.cmake" 2>/d
 done
 for i in $(find "${SYSROOT_PREFIX}" -type l 2>/dev/null); do
   _tmp="$(readlink -m "${i}")"
+  [[ ${_tmp} =~ ^/usr ]] && _tmp="${SYSROOT_PREFIX}${_tmp}"
   if [[ ${_tmp} =~ ^${SYSROOT_PREFIX}/ ]]; then
     ln -sfn "${_tmp/${SYSROOT_PREFIX}\//${PKG_ORIG_SYSROOT_PREFIX}\/}" "${i}"
   fi

--- a/scripts/build
+++ b/scripts/build
@@ -431,7 +431,7 @@ done
 for i in $(find "${SYSROOT_PREFIX}" -type l 2>/dev/null); do
   _tmp="$(readlink -m "${i}")"
   if [[ ${_tmp} =~ ^${SYSROOT_PREFIX}/ ]]; then
-    ln -sf "${_tmp/${SYSROOT_PREFIX}\//${PKG_ORIG_SYSROOT_PREFIX}\/}" "${i}"
+    ln -sfn "${_tmp/${SYSROOT_PREFIX}\//${PKG_ORIG_SYSROOT_PREFIX}\/}" "${i}"
   fi
 done
 


### PR DESCRIPTION
Inspired by #3639 

### Issue #&#8203;1:

Packages should only modify the contents of `${SYSROOT_PREFIX}` during installation (including `pre_` and `post_`) which is when the package will be reading/writing to the _isolated_ sysroot. At all other times the package will be accessing the _shared_ sysroot when it is recommended that such access is read-only (ie. no writing).

This PR fixes two packages that were breaking this rule.

### Issue #&#8203;2:

Since the `LINK_NAME` (`${i}`) in the isolated sysroot may already be a symbolic link (ie. `/opt/vc/lib` -> `/usr/lib`) we must always treat the `LINK_NAME` as a normal file and avoid dereferencing it, else we will create a new `TARGET` file within the dereferenced link (ie. `/usr/lib/lib`).

This PR fixes this issue.

### Issue #&#8203;3:

Some packages are creating symbolic links that point to the build host `/usr`. For Example:
```
$ find toolchain/armv7ve-libreelec-linux-gnueabi/sysroot -type l -not -lname /home\* -lname /\* -ls
 20722449      0 lrwxrwxrwx   1 neil     neil           30 Jun 22 02:24 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/usr/bin/iptables-xml -> /usr/sbin/xtables-legacy-multi
 31855272      0 lrwxrwxrwx   1 neil     neil           49 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/65-nonlatin.conf -> /usr/share/fontconfig/conf.avail/65-nonlatin.conf
 31855263      0 lrwxrwxrwx   1 neil     neil           49 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/40-nonlatin.conf -> /usr/share/fontconfig/conf.avail/40-nonlatin.conf
 31855275      0 lrwxrwxrwx   1 neil     neil           50 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/90-synthetic.conf -> /usr/share/fontconfig/conf.avail/90-synthetic.conf
 31855259      0 lrwxrwxrwx   1 neil     neil           55 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/10-hinting-slight.conf -> /usr/share/fontconfig/conf.avail/10-hinting-slight.conf
 31855270      0 lrwxrwxrwx   1 neil     neil           46 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/60-latin.conf -> /usr/share/fontconfig/conf.avail/60-latin.conf
 31855264      0 lrwxrwxrwx   1 neil     neil           48 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/45-generic.conf -> /usr/share/fontconfig/conf.avail/45-generic.conf
 31855262      0 lrwxrwxrwx   1 neil     neil           55 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/30-metric-aliases.conf -> /usr/share/fontconfig/conf.avail/30-metric-aliases.conf
 31855273      0 lrwxrwxrwx   1 neil     neil           48 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/69-unifont.conf -> /usr/share/fontconfig/conf.avail/69-unifont.conf
 31855267      0 lrwxrwxrwx   1 neil     neil           45 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/50-user.conf -> /usr/share/fontconfig/conf.avail/50-user.conf
 31855269      0 lrwxrwxrwx   1 neil     neil           48 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/60-generic.conf -> /usr/share/fontconfig/conf.avail/60-generic.conf
 31855271      0 lrwxrwxrwx   1 neil     neil           54 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/65-fonts-persian.conf -> /usr/share/fontconfig/conf.avail/65-fonts-persian.conf
 31855261      0 lrwxrwxrwx   1 neil     neil           58 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/20-unhint-small-vera.conf -> /usr/share/fontconfig/conf.avail/20-unhint-small-vera.conf
 31855260      0 lrwxrwxrwx   1 neil     neil           59 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/10-scale-bitmap-fonts.conf -> /usr/share/fontconfig/conf.avail/10-scale-bitmap-fonts.conf
 31855265      0 lrwxrwxrwx   1 neil     neil           46 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/45-latin.conf -> /usr/share/fontconfig/conf.avail/45-latin.conf
 31855274      0 lrwxrwxrwx   1 neil     neil           50 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/80-delicious.conf -> /usr/share/fontconfig/conf.avail/80-delicious.conf
 31855268      0 lrwxrwxrwx   1 neil     neil           46 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/51-local.conf -> /usr/share/fontconfig/conf.avail/51-local.conf
 31855266      0 lrwxrwxrwx   1 neil     neil           50 Jun 22 03:25 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/etc/fonts/conf.d/49-sansserif.conf -> /usr/share/fontconfig/conf.avail/49-sansserif.conf
 22421938      0 lrwxrwxrwx   1 neil     neil           16 Jun 22 05:45 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/sbin/mkfs.ntfs -> /usr/sbin/mkntfs
 22421940      0 lrwxrwxrwx   1 neil     neil           19 Jun 22 05:45 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/sbin/mount.lowntfs-3g -> /usr/bin/lowntfs-3g
 22421939      0 lrwxrwxrwx   1 neil     neil           16 Jun 22 05:45 toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/sbin/mount.ntfs-3g -> /usr/bin/ntfs-3g
```

This PR fixes this issue.