### PR TITLE
libX11: remove makekeys dependency on X headers

### DIFF
--- a/packages/x11/lib/libX11/patches/libX11-building-makekeys-build-tool-when-cross-compiling.patch
+++ b/packages/x11/lib/libX11/patches/libX11-building-makekeys-build-tool-when-cross-compiling.patch
@@ -1,0 +1,32 @@
+--- a/src/util/makekeys.c	2015-09-03 06:27:24.000000000 +0200
++++ b/src/util/makekeys.c	2019-07-05 21:11:41.379083615 +0200
+@@ -28,17 +28,24 @@ from The Open Group.
+ 
+ /* Constructs hash tables for XStringToKeysym and XKeysymToString. */
+ 
+-#include <X11/X.h>
+-#include <X11/Xos.h>
+-#include <X11/Xresource.h>
+-#include <X11/keysymdef.h>
++#ifdef HAVE_CONFIG_H
++#include <config.h>
++#endif
++
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
++#include <stdint.h>
++#include <inttypes.h>
+ 
+-#include "../Xresinternal.h"
++typedef uint32_t Signature;
+ 
+ #define KTNUM 4000
+ 
++#define XK_VoidSymbol                  0xffffff  /* Void symbol */
++
++typedef unsigned long KeySym;
++
+ static struct info {
+     char	*name;
+     KeySym	val;


### PR DESCRIPTION
Needed for building on arm (and using with jre/bd-j menus).