### PR TITLE
Include /dev/nvme* for automounting m.2 devices

### DIFF
--- a/packages/sysutils/udevil/udev.d/95-udevil-mount.rules
+++ b/packages/sysutils/udevil/udev.d/95-udevil-mount.rules
@@ -2,15 +2,15 @@
 IMPORT{cmdline}="installer"
 ENV{installer}=="1", GOTO="exit"
 
-# check for blockdevices, /dev/sd*, /dev/sr* and /dev/mmc*
-SUBSYSTEM!="block", KERNEL!="sd*|sr*|mmc*", GOTO="exit"
+# check for blockdevices, /dev/sd*, /dev/sr*, /dev/mmc*, and /dev/nvme*
+SUBSYSTEM!="block", KERNEL!="sd*|sr*|mmc*|nvme*", GOTO="exit"
 
 # check for special partitions we dont want mount
 IMPORT{builtin}="blkid"
 ENV{ID_FS_LABEL}=="EFI|BOOT|Recovery|RECOVERY|SETTINGS|boot|root0|share0", GOTO="exit"
 
-# /dev/sd* and /dev/mmc* ith partitions/disk and filesystems only and /dev/sr* disks only
-KERNEL=="sd*|mmc*", ENV{DEVTYPE}=="partition|disk", ENV{ID_FS_USAGE}=="filesystem", GOTO="harddisk"
+# /dev/sd*, /dev/mmc*, and /dev/nvme* ith partitions/disk and filesystems only and /dev/sr* disks only
+KERNEL=="sd*|mmc*|nvme*", ENV{DEVTYPE}=="partition|disk", ENV{ID_FS_USAGE}=="filesystem", GOTO="harddisk"
 KERNEL=="sr*", ENV{DEVTYPE}=="disk", GOTO="optical"
 GOTO="exit"
 

--- a/packages/sysutils/udevil/udev.d/95-udevil-mount.rules
+++ b/packages/sysutils/udevil/udev.d/95-udevil-mount.rules
@@ -9,7 +9,7 @@ SUBSYSTEM!="block", KERNEL!="sd*|sr*|mmc*|nvme*", GOTO="exit"
 IMPORT{builtin}="blkid"
 ENV{ID_FS_LABEL}=="EFI|BOOT|Recovery|RECOVERY|SETTINGS|boot|root0|share0", GOTO="exit"
 
-# /dev/sd*, /dev/mmc*, and /dev/nvme* ith partitions/disk and filesystems only and /dev/sr* disks only
+# /dev/sd*, /dev/mmc*, and /dev/nvme* with partitions/disk and filesystems only, and /dev/sr* disks only
 KERNEL=="sd*|mmc*|nvme*", ENV{DEVTYPE}=="partition|disk", ENV{ID_FS_USAGE}=="filesystem", GOTO="harddisk"
 KERNEL=="sr*", ENV{DEVTYPE}=="disk", GOTO="optical"
 GOTO="exit"


### PR DESCRIPTION
This patch includes /dev/nvme* block devices (for example, m.2 SSDs) in udevil's udev.d rules so they are auto-mounted along with SCSI disks, MMC, discs, etc.