### PR TITLE
u-boot: add support for installing firmware into the u-boot root directory

### DIFF
--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -12,16 +12,13 @@ PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems."
 PKG_IS_KERNEL_PKG="yes"
 PKG_STAMP="$UBOOT_SYSTEM"
 
-[ -n "$ATF_PLATFORM" ] && PKG_DEPENDS_TARGET+=" atf"
+if [ -n "$UBOOT_FIRMWARE" ]; then
+  PKG_DEPENDS_TARGET+=" $UBOOT_FIRMWARE"
+  PKG_DEPENDS_UNPACK+=" $UBOOT_FIRMWARE"
+fi
 
 PKG_NEED_UNPACK="$PROJECT_DIR/$PROJECT/bootloader"
 [ -n "$DEVICE" ] && PKG_NEED_UNPACK+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader"
-
-case "$PROJECT" in
-  Amlogic)
-    PKG_DEPENDS_TARGET+=" amlogic-boot-fip"
-    ;;
-esac
 
 case "$PROJECT" in
   Rockchip)
@@ -29,8 +26,6 @@ case "$PROJECT" in
     PKG_SHA256="3f9f2bbd0c28be6d7d6eb909823fee5728da023aca0ce37aef3c8f67d1179ec1"
     PKG_URL="https://github.com/rockchip-linux/u-boot/archive/$PKG_VERSION.tar.gz"
     PKG_PATCH_DIRS="rockchip"
-    PKG_DEPENDS_TARGET+=" rkbin"
-    PKG_NEED_UNPACK+=" $(get_pkg_directory rkbin)"
     ;;
   *)
     PKG_VERSION="2019.04"
@@ -54,7 +49,7 @@ make_target() {
     echo "see './scripts/uboot_helper' for more information"
   else
     [ "${BUILD_WITH_DEBUG}" = "yes" ] && PKG_DEBUG=1 || PKG_DEBUG=0
-    [ -n "$ATF_PLATFORM" ] &&  cp -av $(get_build_dir atf)/bl31.bin .
+    [ -n "$UBOOT_FIRMWARE" ] && find_file_path bootloader/firmware && . ${FOUND_PATH}
     DEBUG=${PKG_DEBUG} CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm make mrproper
     DEBUG=${PKG_DEBUG} CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm make $($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM config)
     DEBUG=${PKG_DEBUG} CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm _python_sysroot="$TOOLCHAIN" _python_prefix=/ _python_exec_prefix=/ make HOSTCC="$HOST_CC" HOSTLDFLAGS="-L$TOOLCHAIN/lib" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"

--- a/projects/Allwinner/bootloader/firmware
+++ b/projects/Allwinner/bootloader/firmware
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+[ -n "$ATF_PLATFORM" ] && cp -av $(get_build_dir atf)/bl31.bin .

--- a/projects/Allwinner/devices/A64/options
+++ b/projects/Allwinner/devices/A64/options
@@ -25,6 +25,9 @@
   # Kernel target
     KERNEL_TARGET="Image"
 
+  # U-Boot firmware package(s) to use
+    UBOOT_FIRMWARE="atf"
+
   # ATF platform
     ATF_PLATFORM="sun50i_a64"
 

--- a/projects/Allwinner/devices/H6/options
+++ b/projects/Allwinner/devices/H6/options
@@ -25,6 +25,9 @@
   # Kernel target
     KERNEL_TARGET="Image"
 
+  # U-Boot firmware package(s) to use
+    UBOOT_FIRMWARE="atf"
+
   # ATF platform
     ATF_PLATFORM="sun50i_h6"
 

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -5,6 +5,9 @@
   # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
     BOOTLOADER="u-boot"
 
+  # U-Boot firmware package(s) to use
+    UBOOT_FIRMWARE="amlogic-boot-fip"
+
   # Linux Kernel to use
     LINUX="default"
 

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -5,6 +5,9 @@
   # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
     BOOTLOADER="u-boot"
 
+  # U-Boot firmware package(s) to use
+    UBOOT_FIRMWARE="rkbin"
+
   # Kernel to use. values can be:
   # default:  default mainline kernel
     LINUX="${LINUX:-rockchip-4.4}"


### PR DESCRIPTION
i.MX8 requires that firmware be copied into the u-boot root directory prior to building.

This PR allows us to do the following:
1) Specify if a package needs to be unpacked prior to building
2) Have a `firmware` script that copies the require files before building

I've done it this way to keep it platform agnostic. If a project/device doesn't need any firmware then leaving it blank/undefined will cause no harm. If someone has a better idea please advise.

The requirement for i.MX8 is laid out here https://github.com/u-boot/u-boot/blob/master/board/freescale/imx8mq_evk/README#L18-L24