### PR TITLE
bump ADDON_VERSION to 9.1.901

### DIFF
--- a/distributions/LibreELEC/version
+++ b/distributions/LibreELEC/version
@@ -5,4 +5,4 @@
   OS_VERSION="9.1"
 
 # ADDON_VERSION: Addon version
-  ADDON_VERSION="9.1.900"
+  ADDON_VERSION="9.1.901"


### PR DESCRIPTION
This makes sure the RPi4 LE addons get rebuilt by Jenkins and distributed to users