### PR TITLE
steamcontroller: initial package (broken)

### DIFF
--- a/packages/addons/driver/steamcontroller/package.mk
+++ b/packages/addons/driver/steamcontroller/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="steamcontroller"
+PKG_VERSION="1.0"
+PKG_REV="100"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE=""
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Add-on removed"
+PKG_LONGDESC="Add-on removed"
+PKG_TOOLCHAIN="manual"
+
+PKG_ADDON_BROKEN="Drivers are already included."
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_NAME="Steam Controller Driver"
+PKG_ADDON_TYPE="xbmc.broken"
+
+addon() {
+  :
+}

--- a/packages/addons/driver/steamcontroller/package.mk
+++ b/packages/addons/driver/steamcontroller/package.mk
@@ -14,7 +14,7 @@ PKG_SHORTDESC="Add-on removed"
 PKG_LONGDESC="Add-on removed"
 PKG_TOOLCHAIN="manual"
 
-PKG_ADDON_BROKEN="Drivers are already included."
+PKG_ADDON_BROKEN="Drivers are now natively supported by the kernel."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Steam Controller Driver"


### PR DESCRIPTION
adding a stub addon was missed at https://github.com/LibreELEC/LibreELEC.tv/pull/3674