### PR TITLE
cleanup and improve addon update scripts

### DIFF
--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -158,6 +158,7 @@ for ADDON in $(ls -1 "${ROOT}/packages/mediacenter/kodi-binary-addons"); do
 
   check_package_excluded "${ADDON}" "${EXCLUDED_PACKAGES}" && continue
 
+  ADDON_PATH="${ROOT}/packages/mediacenter/kodi-binary-addons/${ADDON}/"
   # Obtain git url - ignore if not a suitable repo
   GIT_DIR="${ADDON}.git"
   GIT_REPO="$(geturl "${ADDON}")" || continue
@@ -167,9 +168,11 @@ for ADDON in $(ls -1 "${ROOT}/packages/mediacenter/kodi-binary-addons"); do
   # update package.mk for stale github.com packages
   RESOLVED_HASH=$(resolve_hash_in_branch ${ADDON}.git HEAD) || continue
   echo "Resolving hash for ${ADDON}: HEAD => ${RESOLVED_HASH}"
-  if update_pkg "${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON" ${ADDON} ${RESOLVED_HASH}; then
+  if update_pkg "${ADDON_PATH}" "${ADDON}" "${RESOLVED_HASH}"; then
     # always bump PKG_REV when updating untagged addons
-    bump_pkg_rev "${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON" ${ADDON}
+    bump_pkg_rev "${ADDON_PATH}" "${ADDON}"
+  else
+    [ "${BUMP_PKG_REV}" = "yes" ] && bump_pkg_rev "${ADDON_PATH}" "${ADDON}"
   fi
 
   if [ "${KEEP_GIT_DIRS}" != "yes" ]; then

--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -4,17 +4,49 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-if [ -z "$1" ]; then
-  echo "Usage: $0 <branch-name>"
-  exit 0
+BUMP_PKG_REV=""
+KEEP_GIT_DIRS="yes"
+
+usage() {
+  echo "Usage: $0 [options] <branch-name>"
+  echo " -b, --bump-pkg-rev: bump PKG_REV if package was not updated"
+  echo " -d, --delete-git-dirs: delete cloned git dirs after update"
+  echo " -h, --help: display help and exit"
+  exit 1
+}
+
+while [ $# -ne 0 ]; do
+  case "$1" in
+  -b|--bump-pkg-rev)
+    BUMP_PKG_REV="yes"
+    shift
+    ;;
+  -d|--delete-git-dirs)
+    KEEP_GIT_DIRS=""
+    shift
+    ;;
+  -h|--help)
+    usage
+    exit 1
+    ;;
+  -*)
+    echo "illegal option $1"
+    usage
+    exit 1
+    ;;
+  *)
+    break
+    ;;
+  esac
+done
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
 fi
 
 # list of packages to exclude from update
 EXCLUDED_PACKAGES="vfs.nfs vfs.sacd"
-
-# the following environment variables can be set to "yes" to enable optional features:
-# KEEP_GIT_DIRS: don't delete cloned git directories after update check
-# BUMP_PKG_REV: bump PKG_REV if PKG_VERSION has changed
 
 MY_DIR="$(dirname "$0")"
 ROOT="$(cd "${MY_DIR}"/../.. && pwd)"

--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -58,20 +58,18 @@ rm -rf "${TMPDIR}"
 mkdir -p "${TMPDIR}"
 
 KODI_BRANCH="$1"
-KODI_DIR="kodi-${KODI_BRANCH}.git"
+KODI_DIR="kodi.git"
 
 . "${MY_DIR}/update_common_functions"
 
-if [ ! -d ${KODI_DIR} ] ; then
-  git_clone https://github.com/xbmc/xbmc ${KODI_BRANCH} ${KODI_DIR}
-fi
+git_clone https://github.com/xbmc/xbmc ${KODI_DIR} ${KODI_BRANCH}
 
-# kodi-platform
+# kodi-platform, points to repo+githash
 REPO=$(cat $KODI_DIR/cmake/addons/depends/common/kodi-platform/kodi-platform.txt | awk '{print $2}')
 GIT_HASH=$(cat $KODI_DIR/cmake/addons/depends/common/kodi-platform/kodi-platform.txt | awk '{print $3}')
 PKG_NAME="kodi-platform"
 
-git_clone $REPO master $PKG_NAME.git $GIT_HASH
+git_clone $REPO $PKG_NAME.git
 if [ -f "${ROOT}/packages/mediacenter/kodi-platform/package.mk" ] ; then
   # update package.mk
   RESOLVED_HASH=$(resolve_hash $PKG_NAME.git $GIT_HASH)
@@ -84,30 +82,60 @@ fi
 # addons
 for addontxt in $KODI_DIR/cmake/addons/bootstrap/repositories/*-addons.txt ; do
   ADDONS=$(cat $addontxt | awk '{print $1}')
-  ADDONREPO=$(cat $addontxt | awk '{print $2}')
-  GIT_HASH=$(cat $addontxt | awk '{print $3}')
-  git_clone $ADDONREPO ${KODI_BRANCH} $ADDONS.git $GIT_HASH
-  for addon in $ADDONS.git/*.*/ ; do
+  ADDONS_GIT_DIR="${ADDONS}.git"
+  ADDONS_GIT_REPO=$(cat $addontxt | awk '{print $2}')
+  ADDONS_GIT_BRANCH=$(cat $addontxt | awk '{print $3}')
+  git_clone $ADDONS_GIT_REPO $ADDONS_GIT_DIR ${ADDONS_GIT_BRANCH}
+
+  for addon in $ADDONS_GIT_DIR/*.*/ ; do
     ADDON=$(basename $addon)
 
     [[ ${ADDON} =~ ^game.* ]] && continue # ignore game.* addons - handled by update_retroplayer-addons
 
     check_package_excluded "${ADDON}" "${EXCLUDED_PACKAGES}" && continue
 
-    REPO=$(cat $addon/$ADDON.txt | awk '{print $2}')
-    GIT_HASH=$(cat $addon/$ADDON.txt | awk '{print $3}')
+    GIT_DIR="${ADDON}.git"
+    GIT_REPO=$(cat ${addon}/${ADDON}.txt | awk '{print $2}')
+    GIT_BRANCH=$(cat ${addon}/${ADDON}.txt | awk '{print $3}')
 
-    if ! grep -q all $addon/platforms.txt && ! grep -q linux $addon/platforms.txt && ! grep -q ! $addon/platforms.txt; then
+    if ! grep -q all ${addon}/platforms.txt && ! grep -q linux ${addon}/platforms.txt && ! grep -q ! ${addon}/platforms.txt; then
       continue
     fi
 
-    ADDON_PATH="${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON/"
+    ADDON_PATH="${ROOT}/packages/mediacenter/kodi-binary-addons/${ADDON}/"
     if [ -f "${ADDON_PATH}/package.mk" ] ; then
       # Verify the Kodi repo matches our package repo
       # If different, ignore the addon and process it later as an "unofficial" addon
-      validate_pkg_url "$ADDON" "$REPO" || continue
+      validate_pkg_url "${ADDON}" "${GIT_REPO}" || continue
 
-      update_to_latest_tag "${ADDON_PATH}" ${ADDON} ${REPO} ${KODI_BRANCH} ${GIT_HASH}
+      git_clone ${GIT_REPO} ${GIT_DIR} ${GIT_BRANCH}
+
+      NO_TAG=""
+      NEW_VERSION=$(resolve_tag_in_branch ${GIT_DIR} ${GIT_BRANCH})
+      if [ -z "${NEW_VERSION}" ]; then
+        NO_TAG="yes"
+        echo "========================================================================"
+        msg_warn "WARNING: no tag found for addon ${ADDON}, falling back to HEAD"
+        echo "========================================================================"
+        NEW_VERSION=$(resolve_hash_in_branch "${GIT_DIR}" "${GIT_BRANCH}")
+      fi
+
+      echo "Resolved version for ${ADDON}: ${GIT_BRANCH} => ${NEW_VERSION}"
+
+      if update_pkg "${ADDON_PATH}" ${ADDON} ${NEW_VERSION}; then
+        if [ -n "${NO_TAG}" ]; then
+          # always bump PKG_REV on updates as we have no info if version changed
+          bump_pkg_rev "${ADDON_PATH}" "${ADDON}"
+        else
+          reset_pkg_rev "${ADDON_PATH}" "${ADDON}"
+        fi
+      else
+        [ "${BUMP_PKG_REV}" = "yes" ] && bump_pkg_rev "${ADDON_PATH}" "${ADDON}"
+      fi
+
+      if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
+        rm -rf "${GIT_DIR}"
+      fi
     else
       echo "[mkpkg] Skipped $ADDON"
       SKIPPED_ADDONS="$SKIPPED_ADDONS $ADDON"
@@ -131,12 +159,13 @@ for ADDON in $(ls -1 "${ROOT}/packages/mediacenter/kodi-binary-addons"); do
   check_package_excluded "${ADDON}" "${EXCLUDED_PACKAGES}" && continue
 
   # Obtain git url - ignore if not a suitable repo
-  REPO="$(geturl "${ADDON}")" || continue
+  GIT_DIR="${ADDON}.git"
+  GIT_REPO="$(geturl "${ADDON}")" || continue
 
-  git_clone $REPO ${KODI_BRANCH} $ADDON.git HEAD
+  git_clone ${GIT_REPO} ${GIT_DIR}
 
   # update package.mk for stale github.com packages
-  RESOLVED_HASH=$(resolve_hash ${ADDON}.git HEAD) || continue
+  RESOLVED_HASH=$(resolve_hash_in_branch ${ADDON}.git HEAD) || continue
   echo "Resolving hash for ${ADDON}: HEAD => ${RESOLVED_HASH}"
   if update_pkg "${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON" ${ADDON} ${RESOLVED_HASH}; then
     # always bump PKG_REV when updating untagged addons
@@ -144,7 +173,7 @@ for ADDON in $(ls -1 "${ROOT}/packages/mediacenter/kodi-binary-addons"); do
   fi
 
   if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
-    rm -rf $ADDON.git
+    rm -rf ${GIT_DIR}
   fi
 done
 

--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -75,7 +75,7 @@ git_clone $REPO master $PKG_NAME.git $GIT_HASH
 if [ -f "${ROOT}/packages/mediacenter/kodi-platform/package.mk" ] ; then
   # update package.mk
   RESOLVED_HASH=$(resolve_hash $PKG_NAME.git $GIT_HASH)
-  update_pkg "${ROOT}/packages/mediacenter/kodi-platform" ${PKG_NAME} ${RESOLVED_HASH}
+  update_pkg "${ROOT}/packages/mediacenter/kodi-platform" ${PKG_NAME} ${RESOLVED_HASH} || true
 fi
 if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
   rm -rf $PKG_NAME.git
@@ -138,7 +138,10 @@ for ADDON in $(ls -1 "${ROOT}/packages/mediacenter/kodi-binary-addons"); do
   # update package.mk for stale github.com packages
   RESOLVED_HASH=$(resolve_hash ${ADDON}.git HEAD) || continue
   echo "Resolving hash for ${ADDON}: HEAD => ${RESOLVED_HASH}"
-  update_pkg "${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON" ${ADDON} ${RESOLVED_HASH}
+  if update_pkg "${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON" ${ADDON} ${RESOLVED_HASH}; then
+    # always bump PKG_REV when updating untagged addons
+    bump_pkg_rev "${ROOT}/packages/mediacenter/kodi-binary-addons/$ADDON" ${ADDON}
+  fi
 
   if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
     rm -rf $ADDON.git

--- a/tools/mkpkg/update_common_functions
+++ b/tools/mkpkg/update_common_functions
@@ -118,6 +118,15 @@ bump_pkg_rev() {
   msg_info "BUMPED ${pkg_name} PKG_REV from ${pkg_rev} to ${new_pkg_rev}"
 }
 
+reset_pkg_rev() {
+  local package_mk="$1/package.mk" pkg_name="$2"
+  local pkg_rev=$(get_pkg_var "${pkg_name}" PKG_REV)
+  local new_pkg_rev="1"
+
+  sed -e "s|PKG_REV=.*|PKG_REV=\"${new_pkg_rev}\"|" -i "${package_mk}"
+  msg_info "RESET ${pkg_name} PKG_REV from ${pkg_rev} to ${new_pkg_rev}"
+}
+
 update_pkg() {
   local pkg_path="$1" pkg_name="$2" pkg_version="$3"
 
@@ -131,9 +140,9 @@ update_pkg() {
     download_pkg_file "${pkg_name}"
     set_pkg_sha256 "${pkg_path}"
 
-    if [ "${BUMP_PKG_REV}" = "yes" ]; then
-      bump_pkg_rev "${pkg_path}" "${pkg_name}"
-    fi
+    return 0
+  else
+    return 1
   fi
 }
 
@@ -141,11 +150,13 @@ update_to_latest_tag() {
   local pkg_path="$1" pkg_name="$2" repo="$3" branch="$4" ref="$5"
   local gitdir=${pkg_name}.git
   local resolved_version
+  local no_tag=""
 
   git_clone "${repo}" "${branch}" "${gitdir}" "${ref}"
 
   resolved_version=$(resolve_tag "${gitdir}" "${ref}")
   if [ -z "${resolved_version}" ]; then
+    no_tag="yes"
     echo "========================================================================"
     msg_warn "WARNING: no tag found for package ${pkg_name}, falling back to HEAD"
     echo "========================================================================"
@@ -154,7 +165,16 @@ update_to_latest_tag() {
 
   echo "Resolved version for ${pkg_name}: ${ref} => ${resolved_version}"
 
-  update_pkg "${pkg_path}" "${pkg_name}" "${resolved_version}"
+  if update_pkg "${pkg_path}" "${pkg_name}" "${resolved_version}"; then
+    if [ -n "${no_tag}" ]; then
+      # always bump PKG_REV on updates as we have no info if version changed
+      bump_pkg_rev "${pkg_path}" "${pkg_name}"
+    else
+      reset_pkg_rev "${pkg_path}" "${pkg_name}"
+    fi
+  else
+    [ "${BUMP_PKG_REV}" = "yes" ] && bump_pkg_rev "${pkg_path}" "${pkg_name}"
+  fi
 
   if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
     rm -rf "${gitdir}"

--- a/tools/mkpkg/update_common_functions
+++ b/tools/mkpkg/update_common_functions
@@ -23,31 +23,18 @@ msg_info() {
 }
 
 git_clone() {
-  # git_clone https://repo.url branch ./target_dir [githash]
+  # git_clone https://repo.url target_dir [branch]
   echo "[mkpkg] Checking out $1 ..."
-  if [ ! -d "$3" ]; then
-    git clone "$1" "$3"
-    # Try to switch to specified branch if it exist, if not then use default branch
-    if [ -n "$2" ]; then
-      cd "$3"
-      git checkout $2 >/dev/null 2>/dev/null
-      cd ..
-    fi
+  if [ ! -d "$2" ]; then
+    git clone "$1" "$2"
   else
-    if [ -d "$3" ] ; then
-      cd "$3"
-      git checkout $2 >/dev/null 2>/dev/null
-      git pull
-      cd ..
-    fi
+    cd "$2"
+    git fetch
+    cd ..
   fi
-
-  if [ ! -z "$4" ] ; then
-    cd "$3"
-    git fetch >/dev/null 2>/dev/null
-    git branch -D $4 >/dev/null 2>/dev/null
-    git checkout $4 >/dev/null 2>/dev/null
-    git checkout -b ref-$4 >/dev/null 2>/dev/null
+  if [ -n "$3" ]; then
+    cd "$2"
+    git checkout -q origin/"$3";
     cd ..
   fi
 }
@@ -66,10 +53,17 @@ resolve_hash() {
   fi
 }
 
-resolve_tag() {
+resolve_hash_in_branch() {
   if [ -d "$1" ] ; then
     cd "$1"
-    git describe --abbrev=0 --tags $2 2>/dev/null
+    git rev-parse origin/$2 2>/dev/null
+  fi
+}
+
+resolve_tag_in_branch() {
+  if [ -d "$1" ] ; then
+    cd "$1"
+    git describe --abbrev=0 --tags origin/$2 2>/dev/null
   fi
 }
 
@@ -140,44 +134,11 @@ update_pkg() {
     download_pkg_file "${pkg_name}"
     set_pkg_sha256 "${pkg_path}"
 
+    msg_info "UPDATED ${pkg_name} from ${old_version} to ${pkg_version}"
+
     return 0
   else
     return 1
-  fi
-}
-
-update_to_latest_tag() {
-  local pkg_path="$1" pkg_name="$2" repo="$3" branch="$4" ref="$5"
-  local gitdir=${pkg_name}.git
-  local resolved_version
-  local no_tag=""
-
-  git_clone "${repo}" "${branch}" "${gitdir}" "${ref}"
-
-  resolved_version=$(resolve_tag "${gitdir}" "${ref}")
-  if [ -z "${resolved_version}" ]; then
-    no_tag="yes"
-    echo "========================================================================"
-    msg_warn "WARNING: no tag found for package ${pkg_name}, falling back to HEAD"
-    echo "========================================================================"
-    resolved_version=$(resolve_hash "${gitdir}" "${ref}")
-  fi
-
-  echo "Resolved version for ${pkg_name}: ${ref} => ${resolved_version}"
-
-  if update_pkg "${pkg_path}" "${pkg_name}" "${resolved_version}"; then
-    if [ -n "${no_tag}" ]; then
-      # always bump PKG_REV on updates as we have no info if version changed
-      bump_pkg_rev "${pkg_path}" "${pkg_name}"
-    else
-      reset_pkg_rev "${pkg_path}" "${pkg_name}"
-    fi
-  else
-    [ "${BUMP_PKG_REV}" = "yes" ] && bump_pkg_rev "${pkg_path}" "${pkg_name}"
-  fi
-
-  if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
-    rm -rf "${gitdir}"
   fi
 }
 

--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -78,128 +78,124 @@ mkdir -p "${TMPDIR}"
 
 . "${MY_DIR}/update_common_functions"
 
-# addons
-for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-addons.git ${KODI_BRANCH}" ; do
-  ADDONS=$(echo $addontxt | awk '{print $1}')
-  ADDONS_DIR="${ADDONS}.git"
-  ADDONS_REPO=$(echo $addontxt | awk '{print $2}')
-  ADDONS_BRANCH=$(echo $addontxt | awk '{print $3}')
-  git_clone ${ADDONS_REPO} ${ADDONS_DIR} ${ADDONS_BRANCH}
+ADDONS="game-binary-addons"
+ADDONS_DIR="${ADDONS}.git"
+ADDONS_REPO="https://github.com/kodi-game/repo-binary-addons.git"
+git_clone ${ADDONS_REPO} ${ADDONS_DIR} ${KODI_BRANCH}
 
-  for addon in ${ADDONS_DIR}/*.*/ ; do
-    GAME_ADDON=$(basename ${addon})
+for addon in ${ADDONS_DIR}/*.*/ ; do
+  GAME_ADDON=$(basename ${addon})
 
-    [[ "${GAME_ADDON}" =~ ^game. ]] || continue
+  [[ "${GAME_ADDON}" =~ ^game. ]] || continue
 
-    check_package_excluded "${GAME_ADDON}" "${EXCLUDED_PACKAGES}" && continue
+  check_package_excluded "${GAME_ADDON}" "${EXCLUDED_PACKAGES}" && continue
 
-    if ! grep -q all $addon/platforms.txt && ! grep -q linux $addon/platforms.txt && ! grep -q ! $addon/platforms.txt; then
-      continue
+  if ! grep -q all $addon/platforms.txt && ! grep -q linux $addon/platforms.txt && ! grep -q ! $addon/platforms.txt; then
+    continue
+  fi
+
+  GAME_GIT_DIR="${GAME_ADDON}.git"
+  GAME_GIT_REPO=$(cat $addon/${GAME_ADDON}.txt | awk '{print $2}')
+  GAME_GIT_BRANCH=$(cat $addon/${GAME_ADDON}.txt | awk '{print $3}')
+  GAME_PATH="${ROOT}/packages/mediacenter/kodi-binary-addons/${GAME_ADDON}"
+
+  if [ ! -d "$GAME_PATH" ] ; then
+    msg_warn "SKIPPING ${GAME_ADDON}, not present in LE"
+    continue
+  fi
+
+  if [[ "${GAME_ADDON}" =~ ^game.libretro. ]]; then
+    RETRO_NAME="${GAME_ADDON#game.libretro.}"
+    RETRO_ADDON="libretro-${RETRO_NAME}"
+    RETRO_PATH="${ROOT}/packages/emulation/${RETRO_ADDON}"
+  else
+    RETRO_NAME=""
+    RETRO_ADDON=""
+    RETRO_PATH=""
+  fi
+
+  BUMPED_ADDON=""
+  BUMPED_RETRO=""
+  NO_TAG=""
+  CHECK_RETRO=""
+
+  git_clone "${GAME_GIT_REPO}" "${GAME_GIT_DIR}"
+  GAME_NEW_VERSION=$(resolve_tag_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
+  if [ -z "${GAME_NEW_VERSION}" ]; then
+    NO_TAG="yes"
+    echo "========================================================================"
+    msg_warn "WARNING: no tag found for addon ${GAME_ADDON}, falling back to HEAD"
+    echo "========================================================================"
+    GAME_NEW_VERSION=$(resolve_hash_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
+  fi
+
+  if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
+    rm -rf "${GAME_GIT_DIR}"
+  fi
+
+  if update_pkg "${GAME_PATH}" "${GAME_ADDON}" "${GAME_NEW_VERSION}"; then
+    BUMPED_ADDON="yes"
+    [ -n "${RETRO_NAME}" ] && CHECK_RETRO="yes"
+  else
+    if [ -n "${FORCE_LIBRETRO_BUMP}" -a -n "${RETRO_NAME}" ]; then
+      download_pkg_file "${GAME_ADDON}"
+      CHECK_RETRO="yes"
+    fi
+  fi
+
+  if [ -n "${CHECK_RETRO}" ]; then
+    if [ ! -d "${RETRO_PATH}" ]; then
+      msg_error "ERROR: ${RETRO_PATH} doesn't exist"
+      cleanup_pkg_tmp
+      exit 1
     fi
 
-    GAME_GIT_DIR="${GAME_ADDON}.git"
-    GAME_GIT_REPO=$(cat $addon/${GAME_ADDON}.txt | awk '{print $2}')
-    GAME_GIT_BRANCH=$(cat $addon/${GAME_ADDON}.txt | awk '{print $3}')
-    GAME_PATH="${ROOT}/packages/mediacenter/kodi-binary-addons/${GAME_ADDON}"
+    RETRO_VERSION=$(get_pkg_var "${RETRO_ADDON}" PKG_VERSION)
+    extract_pkg_file
 
-    if [ ! -d "$GAME_PATH" ] ; then
-      msg_warn "SKIPPING ${GAME_ADDON}, not present in LE"
-      continue
+    RETRO_VERSION_FILE="${TMP_PKG_DIR}/depends/common/${RETRO_NAME}/${RETRO_NAME}.txt"
+
+    if [ ! -f "${RETRO_VERSION_FILE}" ]; then
+      msg_error "ERROR: ${RETRO_VERSION_FILE} does not exist"
+      cleanup_pkg_tmp
+      exit 1
     fi
 
-    if [[ "${GAME_ADDON}" =~ ^game.libretro. ]]; then
-      RETRO_NAME="${GAME_ADDON#game.libretro.}"
-      RETRO_ADDON="libretro-${RETRO_NAME}"
-      RETRO_PATH="${ROOT}/packages/emulation/${RETRO_ADDON}"
+    VERSION_INFO=$(grep "^${RETRO_NAME}" "${RETRO_VERSION_FILE}" | head -1)
+    if [[ "$VERSION_INFO" =~ .zip$ ]] ; then
+      # version referenced by githash
+      RETRO_NEW_VERSION=$(sed -e 's|^.*/archive/||' -e 's|\.zip$||' "${RETRO_VERSION_FILE}")
     else
-      RETRO_NAME=""
-      RETRO_ADDON=""
-      RETRO_PATH=""
+      msg_warn "unmanaged version in kodi package: ${VERSION_INFO}"
+      # unmanaged version, repo plus branch
+      RETRO_SITE=$(echo "${VERSION_INFO}" | awk '{print $2}')
+      RETRO_BRANCH=$(echo "${VERSION_INFO}" | awk '{print $3}')
+      RETRO_NEW_VERSION=$(git ls-remote "${RETRO_SITE}" "${RETRO_BRANCH}" | awk '{print $1}')
     fi
 
-    BUMPED_ADDON=""
-    BUMPED_RETRO=""
-    NO_TAG=""
-    CHECK_RETRO=""
-
-    git_clone "${GAME_GIT_REPO}" "${GAME_GIT_DIR}"
-    GAME_NEW_VERSION=$(resolve_tag_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
-    if [ -z "${GAME_NEW_VERSION}" ]; then
-      NO_TAG="yes"
-      echo "========================================================================"
-      msg_warn "WARNING: no tag found for addon ${GAME_ADDON}, falling back to HEAD"
-      echo "========================================================================"
-      GAME_NEW_VERSION=$(resolve_hash_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
+    if update_pkg "${RETRO_PATH}" "${RETRO_ADDON}" "${RETRO_NEW_VERSION}"; then
+      BUMPED_RETRO="yes"
     fi
+  fi
 
-    if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
-      rm -rf "${GAME_GIT_DIR}"
+  if [ -n "${NO_TAG}" ]; then
+    # always bump PKG_REV on updates as we have no info if version changed
+    if [ -n "${BUMPED_ADDON}" -o -n "${BUMPED_RETRO}" -o -n "${BUMP_PKG_REV}" ]; then
+      bump_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
     fi
-
-    if update_pkg "${GAME_PATH}" "${GAME_ADDON}" "${GAME_NEW_VERSION}"; then
-      BUMPED_ADDON="yes"
-      [ -n "${RETRO_NAME}" ] && CHECK_RETRO="yes"
+  else
+    if [ -n "${BUMPED_ADDON}" ]; then
+      # reset PKG_REV if version changed
+      reset_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
     else
-      if [ -n "${FORCE_LIBRETRO_BUMP}" -a -n "${RETRO_NAME}" ]; then
-        download_pkg_file "${GAME_ADDON}"
-        CHECK_RETRO="yes"
-      fi
-    fi
-
-    if [ -n "${CHECK_RETRO}" ]; then
-      if [ ! -d "${RETRO_PATH}" ]; then
-        msg_error "ERROR: ${RETRO_PATH} doesn't exist"
-        cleanup_pkg_tmp
-        exit 1
-      fi
-
-      RETRO_VERSION=$(get_pkg_var "${RETRO_ADDON}" PKG_VERSION)
-      extract_pkg_file
-
-      RETRO_VERSION_FILE="${TMP_PKG_DIR}/depends/common/${RETRO_NAME}/${RETRO_NAME}.txt"
-
-      if [ ! -f "${RETRO_VERSION_FILE}" ]; then
-        msg_error "ERROR: ${RETRO_VERSION_FILE} does not exist"
-        cleanup_pkg_tmp
-        exit 1
-      fi
-
-      VERSION_INFO=$(grep "^${RETRO_NAME}" "${RETRO_VERSION_FILE}" | head -1)
-      if [[ "$VERSION_INFO" =~ .zip$ ]] ; then
-        # version referenced by githash
-        RETRO_NEW_VERSION=$(sed -e 's|^.*/archive/||' -e 's|\.zip$||' "${RETRO_VERSION_FILE}")
-      else
-        msg_warn "unmanaged version in kodi package: ${VERSION_INFO}"
-        # unmanaged version, repo plus branch
-        RETRO_SITE=$(echo "${VERSION_INFO}" | awk '{print $2}')
-        RETRO_BRANCH=$(echo "${VERSION_INFO}" | awk '{print $3}')
-        RETRO_NEW_VERSION=$(git ls-remote "${RETRO_SITE}" "${RETRO_BRANCH}" | awk '{print $1}')
-      fi
-
-      if update_pkg "${RETRO_PATH}" "${RETRO_ADDON}" "${RETRO_NEW_VERSION}"; then
-        BUMPED_RETRO="yes"
-      fi
-    fi
-
-    if [ -n "${NO_TAG}" ]; then
-      # always bump PKG_REV on updates as we have no info if version changed
-      if [ -n "${BUMPED_ADDON}" -o -n "${BUMPED_RETRO}" -o -n "${BUMP_PKG_REV}" ]; then
+      # if addon version is unchanged but libretro changed bump PKG_REV
+      if [ -n "${BUMPED_RETRO}" -o -n "${BUMP_PKG_REV}" ]; then
         bump_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
       fi
-    else
-      if [ -n "${BUMPED_ADDON}" ]; then
-        # reset PKG_REV if version changed
-        reset_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
-      else
-        # if addon version is unchanged but libretro changed bump PKG_REV
-        if [ -n "${BUMPED_RETRO}" -o -n "${BUMP_PKG_REV}" ]; then
-          bump_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
-        fi
-      fi
     fi
+  fi
 
-    cleanup_pkg_tmp
-  done
+  cleanup_pkg_tmp
 done
 
 rm -rf "${TMPDIR}"

--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -81,11 +81,12 @@ mkdir -p "${TMPDIR}"
 # addons
 for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-addons.git ${KODI_BRANCH}" ; do
   ADDONS=$(echo $addontxt | awk '{print $1}')
-  ADDONREPO=$(echo $addontxt | awk '{print $2}')
-  GIT_HASH=$(echo $addontxt | awk '{print $3}')
-  git_clone $ADDONREPO retroplayer $ADDONS.git $GIT_HASH
+  ADDONS_DIR="${ADDONS}.git"
+  ADDONS_REPO=$(echo $addontxt | awk '{print $2}')
+  ADDONS_BRANCH=$(echo $addontxt | awk '{print $3}')
+  git_clone ${ADDONS_REPO} ${ADDONS_DIR} ${ADDONS_BRANCH}
 
-  for addon in $ADDONS.git/*.*/ ; do
+  for addon in ${ADDONS_DIR}/*.*/ ; do
     GAME_ADDON=$(basename ${addon})
 
     [[ "${GAME_ADDON}" =~ ^game. ]] || continue
@@ -121,34 +122,28 @@ for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-add
     NO_TAG=""
     CHECK_RETRO=""
 
-    git_clone "${GAME_GIT_REPO}" "${GAME_GIT_BRANCH}" "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}"
-    GAME_NEW_VERSION=$(resolve_tag "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
+    git_clone "${GAME_GIT_REPO}" "${GAME_GIT_DIR}"
+    GAME_NEW_VERSION=$(resolve_tag_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
     if [ -z "${GAME_NEW_VERSION}" ]; then
       NO_TAG="yes"
       echo "========================================================================"
       msg_warn "WARNING: no tag found for addon ${GAME_ADDON}, falling back to HEAD"
       echo "========================================================================"
-      GAME_NEW_VERSION=$(resolve_hash "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
+      GAME_NEW_VERSION=$(resolve_hash_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
     fi
 
     if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
       rm -rf "${GAME_GIT_DIR}"
     fi
 
-    GAME_VERSION=$(get_pkg_var "${GAME_ADDON}" PKG_VERSION)
-
-    if [ "${GAME_VERSION}" != "${GAME_NEW_VERSION}" ]; then
+    if update_pkg "${GAME_PATH}" "${GAME_ADDON}" "${GAME_NEW_VERSION}"; then
       BUMPED_ADDON="yes"
       [ -n "${RETRO_NAME}" ] && CHECK_RETRO="yes"
-      set_pkg_version "${GAME_PATH}" "${GAME_NEW_VERSION}"
-      download_pkg_file "${GAME_ADDON}"
-      set_pkg_sha256 "${GAME_PATH}"
-      msg_info "UPDATED ${GAME_ADDON} from ${GAME_VERSION} to ${GAME_NEW_VERSION}"
-    fi
-
-    if [ -n "${FORCE_LIBRETRO_BUMP}" -a -n "${RETRO_NAME}" -a -z "${CHECK_RETRO}" ]; then
-      download_pkg_file "${GAME_ADDON}"
-      CHECK_RETRO="yes"
+    else
+      if [ -n "${FORCE_LIBRETRO_BUMP}" -a -n "${RETRO_NAME}" ]; then
+        download_pkg_file "${GAME_ADDON}"
+        CHECK_RETRO="yes"
+      fi
     fi
 
     if [ -n "${CHECK_RETRO}" ]; then
@@ -172,21 +167,17 @@ for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-add
       VERSION_INFO=$(grep "^${RETRO_NAME}" "${RETRO_VERSION_FILE}" | head -1)
       if [[ "$VERSION_INFO" =~ .zip$ ]] ; then
         # version referenced by githash
-        RETRO_NEW_HASH=$(sed -e 's|^.*/archive/||' -e 's|\.zip$||' "${RETRO_VERSION_FILE}")
+        RETRO_NEW_VERSION=$(sed -e 's|^.*/archive/||' -e 's|\.zip$||' "${RETRO_VERSION_FILE}")
       else
         msg_warn "unmanaged version in kodi package: ${VERSION_INFO}"
         # unmanaged version, repo plus branch
         RETRO_SITE=$(echo "${VERSION_INFO}" | awk '{print $2}')
         RETRO_BRANCH=$(echo "${VERSION_INFO}" | awk '{print $3}')
-        RETRO_NEW_HASH=$(git ls-remote "${RETRO_SITE}" "${RETRO_BRANCH}" | awk '{print $1}')
+        RETRO_NEW_VERSION=$(git ls-remote "${RETRO_SITE}" "${RETRO_BRANCH}" | awk '{print $1}')
       fi
 
-      if [ "${RETRO_VERSION}" != "${RETRO_NEW_HASH}" ]; then
+      if update_pkg "${RETRO_PATH}" "${RETRO_ADDON}" "${RETRO_NEW_VERSION}"; then
         BUMPED_RETRO="yes"
-        set_pkg_version "${RETRO_PATH}" "${RETRO_NEW_HASH}"
-        download_pkg_file "${RETRO_ADDON}"
-        set_pkg_sha256 "${RETRO_PATH}"
-        msg_info "UPDATED ${RETRO_ADDON} from ${RETRO_VERSION} to ${RETRO_NEW_HASH}"
       fi
     fi
 

--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -116,12 +116,15 @@ for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-add
       RETRO_PATH=""
     fi
 
-    BUMPED=""
+    BUMPED_ADDON=""
+    BUMPED_RETRO=""
+    NO_TAG=""
     CHECK_RETRO=""
 
     git_clone "${GAME_GIT_REPO}" "${GAME_GIT_BRANCH}" "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}"
     GAME_NEW_VERSION=$(resolve_tag "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
     if [ -z "${GAME_NEW_VERSION}" ]; then
+      NO_TAG="yes"
       echo "========================================================================"
       msg_warn "WARNING: no tag found for addon ${GAME_ADDON}, falling back to HEAD"
       echo "========================================================================"
@@ -135,9 +138,7 @@ for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-add
     GAME_VERSION=$(get_pkg_var "${GAME_ADDON}" PKG_VERSION)
 
     if [ "${GAME_VERSION}" != "${GAME_NEW_VERSION}" ]; then
-      if [ "${BUMP_PKG_REV}" = "yes" ]; then
-        BUMPED="yes"
-      fi
+      BUMPED_ADDON="yes"
       [ -n "${RETRO_NAME}" ] && CHECK_RETRO="yes"
       set_pkg_version "${GAME_PATH}" "${GAME_NEW_VERSION}"
       download_pkg_file "${GAME_ADDON}"
@@ -181,7 +182,7 @@ for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-add
       fi
 
       if [ "${RETRO_VERSION}" != "${RETRO_NEW_HASH}" ]; then
-        BUMPED="yes"
+        BUMPED_RETRO="yes"
         set_pkg_version "${RETRO_PATH}" "${RETRO_NEW_HASH}"
         download_pkg_file "${RETRO_ADDON}"
         set_pkg_sha256 "${RETRO_PATH}"
@@ -189,10 +190,24 @@ for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-add
       fi
     fi
 
-    if [ -n "${BUMPED}" ]; then
-      bump_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
-      cleanup_pkg_tmp
+    if [ -n "${NO_TAG}" ]; then
+      # always bump PKG_REV on updates as we have no info if version changed
+      if [ -n "${BUMPED_ADDON}" -o -n "${BUMPED_RETRO}" -o -n "${BUMP_PKG_REV}" ]; then
+        bump_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
+      fi
+    else
+      if [ -n "${BUMPED_ADDON}" ]; then
+        # reset PKG_REV if version changed
+        reset_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
+      else
+        # if addon version is unchanged but libretro changed bump PKG_REV
+        if [ -n "${BUMPED_RETRO}" -o -n "${BUMP_PKG_REV}" ]; then
+          bump_pkg_rev "${GAME_PATH}" "${GAME_ADDON}"
+        fi
+      fi
     fi
+
+    cleanup_pkg_tmp
   done
 done
 

--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -3,16 +3,59 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
+BUMP_PKG_REV=""
 FORCE_LIBRETRO_BUMP=""
+KEEP_GIT_DIRS="yes"
 
-if [ "$1" == "-f" ]; then
-  FORCE_LIBRETRO_BUMP="yes"
-  shift
+usage() {
+  echo "Usage: $0 [options] [<branch>]"
+  echo " -b, --bump-pkg-rev: bump PKG_REV if package was not updated"
+  echo " -d, --delete-git-dirs: delete cloned git dirs after update"
+  echo " -f, --force-libretro-bump: check for new libretro package"
+  echo "     even if kodi game package version has not changed"
+  echo " -h, --help: display help"
+}
+
+while [ $# -ne 0 ]; do
+  case "$1" in
+  -b|--bump-pkg-rev)
+    BUMP_PKG_REV="yes"
+    shift
+    ;;
+  -d|--delete-git-dirs)
+    KEEP_GIT_DIRS=""
+    shift
+    ;;
+  -f|--force-libretro-bump)
+    FORCE_LIBRETRO_BUMP="yes"
+    shift
+    ;;
+  -h|--help)
+    usage
+    exit 1
+    ;;
+  -*)
+    echo "illegal option $1"
+    usage
+    exit 1
+    ;;
+  *)
+    break
+    ;;
+  esac
+done
+
+
+if [ $# -gt 1 ]; then
+  usage
+  exit 1
 fi
-
-# the following environment variables can be set to "yes" to enable optional features:
-# KEEP_GIT_DIRS: don't delete cloned git directories after update check
-# BUMP_PKG_REV: bump PKG_REV if PKG_VERSION has changed
+if [ $# -eq 0 ]; then
+  KODI_BRANCH="retroplayer"
+  echo "using default branch ${KODI_BRANCH}"
+else
+  KODI_BRANCH="$1"
+fi
 
 # list of packages to exclude from update
 EXCLUDED_PACKAGES="game.libretro.chailove
@@ -36,7 +79,7 @@ mkdir -p "${TMPDIR}"
 . "${MY_DIR}/update_common_functions"
 
 # addons
-for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-addons.git retroplayer" ; do
+for addontxt in "game-binary-addons https://github.com/kodi-game/repo-binary-addons.git ${KODI_BRANCH}" ; do
   ADDONS=$(echo $addontxt | awk '{print $1}')
   ADDONREPO=$(echo $addontxt | awk '{print $2}')
   GIT_HASH=$(echo $addontxt | awk '{print $3}')


### PR DESCRIPTION
In addition to some general code refactoring a couple of features were added:

Operation mode is now controlled via command line options ("-b" = bump PKG_REV, "-d" = delete git dirs) instead of environment variables.

The previous mode of deleting cloned addon git dirs is now inverted, they are now kept by default. This speeds up addon bumping a lot as the addons gits don't need to be re-downloaded on subsequent runs.

To keep the LE git dir clean it's best to run the scripts in some out-of-tree directory. eg
```
cd addon-bump-tmp
../libreelec-master/tools/mkpkg/update_binary-addons Leia
```

PKG_REV is now automatically reset to 1 on version bumps (if we have version tags) or bumped (if we don't have version tags).

In addition to that PKG_REV can be force-bumped for all addons that weren't updated by using the '-b' option - this ensures that all addons get a new version/rev so kodi will update them.

BTW: the last commit "update_retroplayer-addons: drop loop over single item" drops a for loop and shifts a large block 2 chars to the left, so it looks like a large change with it isn't really.