### PR TITLE
binary addons: updated to latest Leia, bump PKG_REV on current ones

### DIFF
--- a/packages/emulation/libretro-2048/package.mk
+++ b/packages/emulation/libretro-2048/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-2048"
-PKG_VERSION="bc05dc6e504e78fd4eaf7bf91f5b3f84a93c2962"
-PKG_SHA256="39d283fdf59ffc22e66a06918b8e2afa27cd2912317fb0754431516b0e34277e"
+PKG_VERSION="b8d222ace1bf1962423111e395e01d4674776270"
+PKG_SHA256="7591faae469c571c1ec36bffddabccd0efc7304e31936c8d56b487a6a4947fd1"
 PKG_LICENSE="Public domain"
 PKG_SITE="https://github.com/libretro/libretro-2048"
 PKG_URL="https://github.com/libretro/libretro-2048/archive/$PKG_VERSION.tar.gz"

--- a/packages/emulation/libretro-vecx/package.mk
+++ b/packages/emulation/libretro-vecx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vecx"
-PKG_VERSION="42366f88249a7fb52b823f53cdc4730f6778afc5"
-PKG_SHA256="879d2844cacfa8579349aa908fde2bd4c0c10b2016c8c1f6dc507d185d18f7f3"
+PKG_VERSION="6780accf94a06d78b462b07ace2354cb19c1f173"
+PKG_SHA256="5078b09ab0c2dc5e8491bf9f4769580ebe40b66bf2bce1cd37feffc2390d4874"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-vecx"
 PKG_URL="https://github.com/libretro/libretro-vecx/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.2sf"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="1e56b402cc851a2bce3ecda7c0679581467ce00b35fa8a780cad73f4e7da42e7"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.2sf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.asap"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="f270b46a123440c0c894bab93184c798cebeec814a71b2dde0ad4a64f222d4b3"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.asap"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.dumb"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="278e65b805c01b32d7d916da7b312e737a38ae5da7402aeaeec4207c98ae42d7"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.dumb"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.fluidsynth"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="8c3d62f3e5821db8bfb9c893f132e024fa74aaa93e365384741c831079f7d13d"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.fluidsynth"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.gme"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="cc6da8989d54b32c4ed575b2c980cc6339264b019c74f462f7cfb7817d4ca95a"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gme"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.gsf"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="595b262068586a3317a65c34a67c9bd47d799a344cbb738d120ffb76754e219d"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.modplug/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.modplug/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.modplug"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="eb7d07a0ec618a3184389b7af93119c261b57beb3691f9a728c2d16b5ff03f43"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.modplug"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.ncsf"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="25330d7425b69b0c684ec92b5351d445ceac05fc17cb38af6b25f2bc17a1ffb9"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.ncsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.nosefart"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="264eb3f7f9eadb9a216a324fc3acde5b92c08f40b803e2029890152872543ad1"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.nosefart"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.openmpt"
 PKG_VERSION="2.0.1-Leia"
 PKG_SHA256="40779e34403fecb17fa1c58bbca3392b15cba91722a41665b0f9dcbae5bd853d"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.openmpt"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.organya"
 PKG_VERSION="1.1.3-Leia"
 PKG_SHA256="48736fceee378261c6c51a6a7dbcada1d924dca398c3c2d9bbcb15a09bc663bc"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.organya"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.qsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.qsf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.qsf"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="3da3f35ce47e91c1cb24d5a62012e7e6d99ef52a5a5cc39e4b65e9bcf56a5d7e"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.qsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.sidplay"
 PKG_VERSION="1.1.3-Leia"
 PKG_SHA256="d1388fa0d5358ced760b9d87c35f35088e29a9ab7723068155259715495247fd"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.sidplay"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.snesapu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.snesapu/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.snesapu"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="440175129e609d78e039c95cfa18e4e0f8b45dc67b9d89ca859a3cef362d5aee"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.snesapu"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ssf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ssf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.ssf"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="01f3fbfc987f66c43508ee2aafe50294557d9baa78cd858e152a9f3d2ccfb014"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.ssf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.stsound/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.stsound/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.stsound"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="ebc003053ae09f8f6393aead3eff754c062f64d751760f31b30a5abee629263a"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.stsound"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.timidity"
 PKG_VERSION="2.0.1-Leia"
 PKG_SHA256="a289c49ec58b34697efd499e081e3f6580c2958e7e6801e2617e7d3f2d648a1d"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.timidity"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.upse"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="a9879b970e53156dad2b937e9c366fb77aa7e85bf8d2702175469f68ad4569cb"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.upse"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.usf"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="d134f76ecf07e4f3394df861760d5bf0d8f83ec5a1bac1832c3e44e77566fc36"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.usf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.vgmstream"
 PKG_VERSION="1.1.3-Leia"
 PKG_SHA256="ff2d7e506c9239068ff47db376f79bdf6506976d1690d670fc90885458987549"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.vgmstream"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.wsr"
 PKG_VERSION="2.0.0-Leia"
 PKG_SHA256="6fe9b16657ed2d9ae868aafec009ac57250d464981ce9a10b1bdc124680f7a67"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.wsr"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audioencoder.flac"
 PKG_VERSION="v2.0.1"
 PKG_SHA256="782f49f7905da48fda1357c41c62a5bbcce23e1f410bd30b69fb0ef0924e0048"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.flac"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audioencoder.lame"
 PKG_VERSION="v2.0.1"
 PKG_SHA256="d554c86cd05e2895b5d9619373ae0b62d4c8e978197a58cf7a1036e6ab726b88"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.lame"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audioencoder.vorbis"
 PKG_VERSION="v2.0.1"
 PKG_SHA256="cb6ab5aa121e36b9a9d7ccbd92d5aca4684cbd4a4839135df08b65b6925e1d6b"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.vorbis"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.wav/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.wav/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audioencoder.wav"
 PKG_VERSION="v2.0.1"
 PKG_SHA256="465990fa763dded3459cb44d47aecdaab4ecf67825d4698485a8e2ce880c3f11"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.wav"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.2048"
-PKG_VERSION="1.0.0.105-Leia"
-PKG_SHA256="4437d07ff40cffc8f59481498be47b984cfbc10f4772d385aeaa2fd83fb9bdb2"
-PKG_REV="114"
+PKG_VERSION="1.0.0.106-Leia"
+PKG_SHA256="b74004b4ec2ac834ba60e1b82a205d99879232e900c83ee20849736b03a5f9c7"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.2048"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.4do/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.4do/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.4do"
 PKG_VERSION="1.3.2.4-Leia"
 PKG_SHA256="25e801ebd007c146e28ed60b2289875e7ba2ad0cf7ec05955530d4b2ce7a3baf"
-PKG_REV="115"
+PKG_REV="116"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.4do"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-bsnes"
 PKG_VERSION="0.9.26.3-Leia"
 PKG_SHA256="5d549b6cb9a7e9d21354c93bd37cd244f4d713ddf58f46103e8af7a8a2e01301"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-bsnes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-gba"
 PKG_VERSION="0.9.36.2-Leia"
 PKG_SHA256="a6132503ee86257b4c5f120b1dca3ae274be5d00f9fe9243a66796e5541551f4"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-gba"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-lynx"
 PKG_VERSION="0.9.47.4-Leia"
 PKG_SHA256="e2d9573ec98f28fc6d8faf0d2ce0aceb35d3033b9254a877c4743f8e85db5467"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-lynx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-ngp"
 PKG_VERSION="0.9.36.3-Leia"
 PKG_SHA256="4ad4f464434c7ee87172d4a6ba7c0a58dd5105db69c43912cf4536c8d7d25819"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-ngp"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-pce-fast"
 PKG_VERSION="0.9.38.2-Leia"
 PKG_SHA256="05efc96d504915798cba1ec3eaa489606b9cbd832909b7480218cb3b6925d8e3"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-pce-fast"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-pcfx"
 PKG_VERSION="0.9.36.1-Leia"
 PKG_SHA256="9d1b0ced5b159ee2da56e1ac0fc8b1d3968849be139c31afadf8b5c3f9a87cdd"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-pcfx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-psx"
 PKG_VERSION="0.9.44.7-Leia"
 PKG_SHA256="d711cfa6603b8621d282f9c4993445b657889a225e6e85087459bf7658a98d62"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-psx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-saturn"
 PKG_VERSION="1.21.2.4-Leia"
 PKG_SHA256="dfdc90bcf07974097d696cb1c57e3723fce7e35db0516fb0a1e42f90c1126952"
-PKG_REV="114"
+PKG_REV="115"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-supergrafx"
 PKG_VERSION="0.9.41.2-Leia"
 PKG_SHA256="f2971416993ee88f28b661908cca5387a6c2265e44c1eb4f5d8a5693823c2875"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-supergrafx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-vb"
 PKG_VERSION="0.9.36.3-Leia"
 PKG_SHA256="48136ff0251dad6a52ca985f3f2da7ee251f3a58058af0e5006a652dffde1ba7"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-vb"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.beetle-wswan"
 PKG_VERSION="0.9.35.3-Leia"
 PKG_SHA256="e69d1bc924ce9d5dcbd78b098dc5df3360ec26aacae69f886bc643a50f949da1"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-wswan"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.bluemsx"
 PKG_VERSION="0.0.1.5-Leia"
 PKG_SHA256="2c05d3474058785031b1b1ae019a37a7425f54a592524f67a5f6f4542a32258c"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bluemsx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.bnes"
 PKG_VERSION="0.83.0.3-Leia"
 PKG_SHA256="7b3aec8954628d1b610d4dce368b94eb60d521246710d5cd026b87bf916d6690"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bnes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-accuracy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-accuracy/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.bsnes-mercury-accuracy"
 PKG_VERSION="0.94.0.2-Leia"
 PKG_SHA256="f4acff531d4956cc4697f1d4f91b65d94d2cdd69bd95ef805bad7a95565a3278"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-accuracy"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-balanced/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-balanced/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.bsnes-mercury-balanced"
 PKG_VERSION="0.94.0.2-Leia"
 PKG_SHA256="02fe702f1728d2edcba7c0f77b86025b15b816d24f974c9fe83cc8d9d001b2c5"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-balanced"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.bsnes-mercury-performance"
 PKG_VERSION="0.94.0.2-Leia"
 PKG_SHA256="15cd1f02436cec4f788c544174dfacb97e42b9492a1ae671281704092bb87106"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-performance"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.cap32"
 PKG_VERSION="4.2.0.3-Leia"
 PKG_SHA256="70e2e0a9b3f58dac593402538a0fdbc3ae591e7c113c501d3cf850c7a99bebc3"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.cap32"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.desmume/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.desmume/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.desmume"
 PKG_VERSION="0.0.1.2-Leia"
 PKG_SHA256="0e4a482699e0fdcfde9e45f33bba686d3e8372c28ad351df701fd67a35147307"
-PKG_REV="111"
+PKG_REV="112"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.dinothawr"
 PKG_VERSION="1.0.0.3-Leia"
 PKG_SHA256="905766f67de6053c5c7af019ed0834e376a40ff7dcd98829e0f40f3b5f98e54d"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.dinothawr"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.dosbox"
 PKG_VERSION="0.74.0.3-Leia"
 PKG_SHA256="1ef23816465def68e2e40ad7be1a8bb10afac1a40c70f18ff1dfbb08babdd628"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.dosbox"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fbalpha/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fbalpha/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.fbalpha"
 PKG_VERSION="0.2.97.11-Leia"
 PKG_SHA256="f14887027a2258189c84f6a5e4fdaf7887b0773c4f01f90389d4b6ba82299763"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fbalpha"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.fceumm"
 PKG_VERSION="0.0.1.9-Leia"
 PKG_SHA256="e8b5057a2b1552c13402fd456aedd814d01664a2ab13e7360ef73711a0453acd"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fceumm"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.fmsx"
 PKG_VERSION="4.9.0.3-Leia"
 PKG_SHA256="ad6f76f5ed43688c177244cfd6ea43d0d50c947be9f6e3683b202dab55d4a3b6"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fmsx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fsuae/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fsuae/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.fsuae"
 PKG_VERSION="f615a46bd611db79465ef8de379f3174ca925fc0"
 PKG_SHA256="15f6f9c805d65383d4809e48c934a25a9d6d2021e8ae3e2c887d877ab953b237"
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fsuae"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.fuse"
 PKG_VERSION="1.1.1.3-Leia"
 PKG_SHA256="9ca1a5bc6cd8fdd6c72133b4ab2e8c933cac40f2ab8af287ed13cb68af031ff2"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fuse"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.gambatte"
 PKG_VERSION="0.5.0.5-Leia"
 PKG_SHA256="66e63d9c1f4a4223295a6225d858ed1991f353a607efd1b64486dc6f1741dedb"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.gambatte"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.genplus"
 PKG_VERSION="1.7.4.4-Leia"
 PKG_SHA256="382e1c87e24f9343c666374e9c8101dbf6d7827a0dfe5c3095cabee52f549f66"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.genplus"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.gw"
 PKG_VERSION="1.6.3.2-Leia"
 PKG_SHA256="5e16f9a7cb099d2a541d5b89cd93035d2ee252c05292c4d27c4c05a93519a032"
-PKG_REV="112"
+PKG_REV="113"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.gw"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.handy"
 PKG_VERSION="0.97.0.1-Leia"
 PKG_SHA256="c9751ca3ef957c7b65208d9aa5b80efcfa9c46d0567b1c11f29b54b29c8934b8"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.handy"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.hatari"
 PKG_VERSION="1.8.0.3-Leia"
 PKG_SHA256="6854de92b4242ec7d548fe4fc9fb7e5ba948b762e868021bae644e26ed76d590"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.hatari"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mame"
 PKG_VERSION="0.204.0.2-Leia"
 PKG_SHA256="57f92a3e4c737262bfec22e8d46243a117e80822fdd9f863b84f7cb058f5a003"
-PKG_REV="109"
+PKG_REV="110"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2000/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2000/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mame2000"
 PKG_VERSION="0.37.0.4-Leia"
 PKG_SHA256="1eda18b34ff573cb1edf5c47b546ebea3f0656405235a98761ea97bda1aa53be"
-PKG_REV="106"
+PKG_REV="107"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2000"
 PKG_URL="https://github.com/kodi-game/game.libretro.mame2000/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mame2003"
 PKG_VERSION="0.78.0.11-Leia"
 PKG_SHA256="a53551d1472a07ffa23321454e3fa2a76ae0368ca1574b0bd63bc4138b687b52"
-PKG_REV="106"
+PKG_REV="107"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2003"
 PKG_URL="https://github.com/kodi-game/game.libretro.mame2003/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mame2003_plus"
 PKG_VERSION="0.0.1.19-Leia"
 PKG_SHA256="7bf3fdf1f9cc575ca09514a8e19dc52e873d057eda636f023bb13afd04e8a71e"
-PKG_REV="102"
+PKG_REV="103"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2003_plus"
 PKG_URL="https://github.com/kodi-game/game.libretro.mame2003_plus/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2010/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2010/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mame2010"
 PKG_VERSION="0.139.0.1-Leia"
 PKG_SHA256="46d252423aae4049b98d13dd4488eae75863797f601db1f54b06960d636e7521"
-PKG_REV="104"
+PKG_REV="105"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2010"
 PKG_URL="https://github.com/kodi-game/game.libretro.mame2010/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2014/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2014/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mame2014"
 PKG_VERSION="0.159.0.1-Leia"
 PKG_SHA256="9a2f65b0aa9177ece7494d9fac805280149a11a6e61b6830fd0f7c0405d02ae6"
-PKG_REV="104"
+PKG_REV="105"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2014"
 PKG_URL="https://github.com/kodi-game/game.libretro.mame2014/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2016/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2016/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mame2016"
 PKG_VERSION="0.174.0.1-Leia"
 PKG_SHA256="307847974ad63b9d339f56aa089249b8ebefcfb0ee76aa0942f56fdad024875d"
-PKG_REV="101"
+PKG_REV="102"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2016"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.melonds/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.melonds/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.melonds"
 PKG_VERSION="0.6.0.2-Leia"
 PKG_SHA256="c337fd53512bc1a56af60c98fa4c34cc9b6764cb6e8fce35e4294634e32f2672"
-PKG_REV="107"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.melonds"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mesen/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mesen/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mesen"
 PKG_VERSION="0.9.7.5-Leia"
 PKG_SHA256="208a05273b5392d9ce604edfc322509351b8cb3c9e56b6381c77b9c4ea794688"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mesen"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.meteor/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.meteor/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.meteor"
 PKG_VERSION="1.4.0.1-Leia"
 PKG_SHA256="3e1b973787e6f3345d9596794c04ee442a704f445c332bd4c42beeb24e601d85"
-PKG_REV="111"
+PKG_REV="112"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.meteor"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mgba"
 PKG_VERSION="0.7.0.5-Leia"
 PKG_SHA256="a01161c7cb24ca2a72183b4a5d56c4c157caff715f609678ae3f31d51dfd02ef"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mgba"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mrboom"
 PKG_VERSION="4.7.0.107-Leia"
 PKG_SHA256="eb92cbec42654bf93a8cd5ecb1923e719280da92785831d33d9f5086622ae501"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mrboom"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.mupen64plus"
 PKG_VERSION="2.5.0.6-Leia"
 PKG_SHA256="bad6dd3e677ac1fa897bbad2508e3e3c1b90f0ac390fadac6cd967863557e8ad"
-PKG_REV="114"
+PKG_REV="115"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.nestopia"
 PKG_VERSION="1.50.0.3-Leia"
 PKG_SHA256="dd8bbf8bec38f018fd21ea19f010094e3696303d8c0d9f5654e86adf09d4a62b"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.nestopia"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.nx"
 PKG_VERSION="1.0.0.4-Leia"
 PKG_SHA256="d39c10d3acd2409afd085ce9fc03bf3163d5d2e66310ae16ee554040341b85a2"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.nx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.o2em"
 PKG_VERSION="1.18.0.3-Leia"
 PKG_SHA256="38f2ee71b87c0c8e5ad81b13cce69f1a306dd434a375547b5e3e0fb72ed16e96"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.o2em"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.pcsx-rearmed"
 PKG_VERSION="22.0.0.4-Leia"
 PKG_SHA256="c215dc5f1b9d498a649d2c037c52594d35051bb4d43b0ec433dcd9de67f25d69"
-PKG_REV="116"
+PKG_REV="117"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.pcsx-rearmed"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.picodrive"
 PKG_VERSION="1.92.0.4-Leia"
 PKG_SHA256="e93f0e49929d99eeba221a658331289c94cfab8ed9201c72dcb7dd134c9bc499"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.picodrive"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pokemini/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pokemini/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.pokemini"
 PKG_VERSION="0.60.0.5-Leia"
 PKG_SHA256="1051e3eaf05f9ed0e78b038059368576524dd9e3590decdb41b43fab74726c57"
-PKG_REV="108"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.pokemini"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.prboom"
 PKG_VERSION="2.5.0.5-Leia"
 PKG_SHA256="05210cfefe6ddfecc9beedda0171c348f8090ea13e9069456f7853189ce55298"
-PKG_REV="115"
+PKG_REV="116"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.prboom"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.prosystem"
 PKG_VERSION="1.3.0.3-Leia"
 PKG_SHA256="e06c0a4abb41a1a566930edbf757539737ee0141a983cc78c71a00a3fa2cbf91"
-PKG_REV="115"
+PKG_REV="116"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.prosystem"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.quicknes"
 PKG_VERSION="1.0.0.5-Leia"
 PKG_SHA256="1bd8d950eb797772fbd2ec5652f3007089ab73f8c1a91a0c4bd7443f6c758c3a"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.quicknes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.reicast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.reicast/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.reicast"
 PKG_VERSION="0.1.0.11-Leia"
 PKG_SHA256="ddc4d7a025643642ac0d4f33d4d1d1693e6491df2d34d733b7a47319640060c3"
-PKG_REV="115"
+PKG_REV="116"
 # no openGL suport in retroplayer yet
 PKG_ARCH="none"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.sameboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.sameboy/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.sameboy"
 PKG_VERSION="0.11.2.6-Leia"
 PKG_SHA256="a08a5b0e7eeed6c4f5c6348733dd2df80ad75773dcc9cfdc088cfeb8529fa79b"
-PKG_REV="107"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.sameboy"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.scummvm"
 PKG_VERSION="2.0.0.4-Leia"
 PKG_SHA256="af667d068dfd728eb1a9e58900b8743240b5480a02e1077d626db867cf5171ac"
-PKG_REV="115"
+PKG_REV="116"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.scummvm"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.snes9x"
 PKG_VERSION="1.58.0.6-Leia"
 PKG_SHA256="43f6e99897c5f79410409283408542f8111e2f524380e57ba03020deae66193e"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.snes9x"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2002/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2002/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.snes9x2002"
 PKG_VERSION="7.2.0.5-Leia"
 PKG_SHA256="ff4d1922c84ae7f4fc6119910fb296d80265e1f9073160ee8aeb21d4a0b466a7"
-PKG_REV="112"
+PKG_REV="113"
 # neon optimizations make it only useful for arm
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2010/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2010/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.snes9x2010"
 PKG_VERSION="1.52.4.4-Leia"
 PKG_SHA256="83bd6ecc47816761b47df9d15e4cf8409cfa6186bd587bbde370a60e9397a988"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.snes9x2010"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.stella"
 PKG_VERSION="3.9.3.4-Leia"
 PKG_SHA256="777e8232c7f032d69a16e0f5604810cbe9f60526fe8c83e98b5f73a6a60b7811"
-PKG_REV="112"
+PKG_REV="113"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.stella"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.tgbdual"
 PKG_VERSION="0.8.3.3-Leia"
 PKG_SHA256="f5c8e0c85b7518316cad44ec9552cc1e86394494b239b6106bb91580d3dc7ad1"
-PKG_REV="112"
+PKG_REV="113"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.tgbdual"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.tyrquake"
 PKG_VERSION="0.62.0.3-Leia"
 PKG_SHA256="ed9c3219a1800adc580ae2b4c0549971d3a4e92943c1b74d63a1e13c812c5a88"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.tyrquake"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.uae/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.uae/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.uae"
 PKG_VERSION="2.6.1.1-Leia"
 PKG_SHA256="c0db1d17d45e5484dd47f78cdd3cd9c28c6b4425357297b625be616d8a7b8d06"
-PKG_REV="107"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.uae"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.uae4arm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.uae4arm/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.uae4arm"
 PKG_VERSION="ae25a2655717032add0ad95793929b039d4a87e5"
 PKG_SHA256="5c6b1cc5a5200a47d090e8dee884ee24726c191887d412c738a1a165139dc297"
-PKG_REV="102"
+PKG_REV="103"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.uae4arm"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vba-next/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vba-next/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.vba-next"
 PKG_VERSION="1.0.2.1-Leia"
 PKG_SHA256="9e153b16107cd460655104293fbc2273b279be24a77bf2f5de184e1dc91d4890"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vba-next"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.vbam"
 PKG_VERSION="2.1.0.4-Leia"
 PKG_SHA256="203b485861dad5fce935ee51b092d1b27a3423e3cba91983a7c816634129fa2f"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vbam"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vecx"
-PKG_VERSION="1.2.0.3-Leia"
-PKG_SHA256="002cc478876c38ac916d5bf78d1e3bdb2ea0b85aeb9926046696673dca959fde"
-PKG_REV="114"
+PKG_VERSION="1.2.0.4-Leia"
+PKG_SHA256="f743ab6900974c58a2d0f50f627ee892b46209ab85f739fa23731d3f438b2ac5"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vecx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.vice"
 PKG_VERSION="3.0.0.3-Leia"
 PKG_SHA256="66dd2c9b80bc5981ddb1abb68f7b69caea9ba91e4817dfa2bda76052b24a4a41"
-PKG_REV="108"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vice"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.virtualjaguar"
 PKG_VERSION="2.1.0.3-Leia"
 PKG_SHA256="a329ce852471f01b070088c3cbaf377ccd5e08bb50e1236375491f0900be9c6c"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.virtualjaguar"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.yabause"
 PKG_VERSION="0.9.14.1-Leia"
 PKG_SHA256="ebd3edcc9605892d0db2313ee90f3533dcb0a6742cb586fb68c9149b18488f28"
-PKG_REV="115"
+PKG_REV="116"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.yabause"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro"
 PKG_VERSION="1.1.0-Leia"
 PKG_SHA256="a0585aef603fcb764bed922bdfb73e3b0992f79930f36d06be6c3b9c13b25212"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.mpo"
 PKG_VERSION="1.0.1-Leia"
 PKG_SHA256="33e580c7878dbf4e29e40aaf844ad2b138cc42a3156c3ec9621b33f6a764a4f3"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.mpo"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.raw"
 PKG_VERSION="2.0.1-Leia"
 PKG_SHA256="bbc8c6f5c3e9d418616a7f614973bc425eb8748cd8643623065bb2071e54c78b"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.raw"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="inputstream.adaptive"
 PKG_VERSION="2.3.22-Leia"
 PKG_SHA256="2c21abeead9dc172de297c47930f62050f382c449682cbdb6c70c7e19a2d561b"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/peak3d/inputstream.adaptive"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.rtmp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.rtmp/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="inputstream.rtmp"
 PKG_VERSION="2.0.5-Leia"
 PKG_SHA256="6f3372753201af5b335ed3ec759db68573c9cf0deab8ee6daa14338b6ec8572f"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/inputstream.rtmp"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="peripheral.joystick"
 PKG_VERSION="v1.4.7"
 PKG_SHA256="f87ad879f8982800e06e12359886d8c032fb9e83b77a2b21220aae9e5e3b6221"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/peripheral.joystick"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="peripheral.xarcade"
 PKG_VERSION="v1.0.0"
 PKG_SHA256="d484fa1caf795d78df33f5176813f7a422d0a4ec810d04153f21eb8fa8b224b3"
-PKG_REV="104"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/peripheral.xarcade"

--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.argustv"
 PKG_VERSION="3.5.4-Leia"
 PKG_SHA256="2d0fae3721715a17e1c1454dd7029eb8d18e7f761ed65e00f8c488c7c08433e8"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.argustv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.demo"
 PKG_VERSION="3.6.1-Leia"
 PKG_SHA256="0d35d1bd968e67a504c16b222bbfb3b79e6f64c5bd430d567c8caf9940d1ebba"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.demo"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.dvblink"
 PKG_VERSION="4.7.2-Leia"
 PKG_SHA256="ad7586abfe7b3f9dd67b3a2225c442fc8d2a442e48bd7df75b11652286392c2f"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.dvblink"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.dvbviewer"
 PKG_VERSION="3.7.11-Leia"
 PKG_SHA256="8a3d167e652574caf30ba0ce9c22d278715e0237774b817e37826f1b2d647bff"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.dvbviewer"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.filmon"
 PKG_VERSION="2.4.4-Leia"
 PKG_SHA256="763500fb4a7210569f05dba8307d400e532dd0e72b24f1a1d2cd516695145190"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.filmon"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.hdhomerun"
 PKG_VERSION="3.5.0-Leia"
 PKG_SHA256="815ba3dfbe6e1318226d41879057f0b8a4f0ac960d12ebc5d69f0a1ac28cfa09"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hdhomerun"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.hts"
 PKG_VERSION="4.4.18-Leia"
 PKG_SHA256="1a5ee260f0e9ca597376ca6d9014c922116a3739e1bbf53ce7de7a715b2aecfe"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hts"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.iptvsimple"
 PKG_VERSION="3.5.8-Leia"
 PKG_SHA256="84e985b5b31044352eaf54914c266a1775f6b7c32a6ce6a46001ddb7d1f9d7fa"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.iptvsimple"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.mediaportal.tvserver"
 PKG_VERSION="3.5.18-Leia"
 PKG_SHA256="9c05578566f7448dc3a7677587c804596aa314afd493cb9c62cc65ea883645aa"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.mediaportal.tvserver"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.mythtv"
 PKG_VERSION="5.10.7-Leia"
 PKG_SHA256="4813f3453d213bb4636ddeca9a3f44249e3dcbd07bb1f7a82576b4dd6edabfb1"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/janbar/pvr.mythtv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.nextpvr"
 PKG_VERSION="3.3.15-Leia"
 PKG_SHA256="3ee070de148d9473d5ad9a3b27cd5f22a81a9da24193c82bf793e1bb590ba054"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.nextpvr"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.njoy"
 PKG_VERSION="3.4.2-Leia"
 PKG_SHA256="8c42a3c3754d7a07de9682504c4883a584eb21a92b9af70f0129ffc2707c1554"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.njoy"

--- a/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.octonet"
 PKG_VERSION="0.7.0-Leia"
 PKG_SHA256="ad78297e5934915bbcaafafbd2bfcccc187984a53ce88a2732831a82f0114140"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/DigitalDevices/pvr.octonet"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.pctv"
 PKG_VERSION="2.4.5-Leia"
 PKG_SHA256="a9f1c5596786cf4cfa279d0b4477839ef7f5bb7267c65152dbcf7ae0bda56679"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.pctv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.sledovanitv.cz"
 PKG_VERSION="1.5.0-Leia"
 PKG_SHA256="6089a7b800e0338160363415a13dff8ea3d0c5c956897b2ae8ccfad7800ea176"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/palinek/pvr.sledovanitv.cz"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.stalker"
 PKG_VERSION="3.4.9-Leia"
 PKG_SHA256="248c9b85199d4f442e17dce814e1094ccdd743b7f1260e5a08e7a25a25c1a56a"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.stalker"

--- a/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.teleboy"
 PKG_VERSION="18.0.24-Leia"
 PKG_SHA256="bf6cca85cd3d043348db2bf4d22526f710f36baada2a20736fdfc6b4a6cc2a07"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rbuehlma/pvr.teleboy"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.vbox"
 PKG_VERSION="4.4.8-Leia"
 PKG_SHA256="7063ee14c222ed797ce6dddca3908d2558ee94b3a2a29fed68bde4ff8f55cd19"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vbox"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.vdr.vnsi"
 PKG_VERSION="3.6.3-Leia"
 PKG_SHA256="6afaf1f3f1e0670edb9dc01581a0d6c3f57502c791e19283eb63807e8936a768"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vdr.vnsi"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="3.25.0-Leia"
-PKG_SHA256="030d1ed942e0baa651538ce0a07f55a05559a1fc6564d0a90f3fcd48cbc2f75d"
+PKG_VERSION="3.26.0-Leia"
+PKG_SHA256="b5c371c529cc15532debcdd44169ab4c35dd4a7720a3a3b80f91c1907e4cd7a6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.wmc"
 PKG_VERSION="2.4.4-Leia"
 PKG_SHA256="2d2dc55bf0888a28966c51b5a0d703ec226a6efafe01fcc2e62c772afa0730dc"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.wmc"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="18.1.3-Leia"
-PKG_SHA256="1474dd13c8f4f437e198284b70db2dc46fb9e2de646b6799ffd36827639df67a"
+PKG_VERSION="18.1.4-Leia"
+PKG_SHA256="3f3b9fae7d380e4497a7d62c991d458bb897521e60576c76f41b7bf976fa1859"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.asteroids"
 PKG_VERSION="2.3.0-Leia"
 PKG_SHA256="8e4849d336bac04bb26c1d6694f5608a76940351cb5e39fa338a47a5855fc771"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.asteroids"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.asterwave"
 PKG_VERSION="3.0.3-Leia"
 PKG_SHA256="ff018b5bdd353747a4e962c72ec622a74232e05eae1742a116259273f1db0552"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.asterwave"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.biogenesis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.biogenesis/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.biogenesis"
 PKG_VERSION="2.2.2-Leia"
 PKG_SHA256="1d1edff918d2a94ba0efd329a45294be47e73eef65f700d62b311eb750d0fef7"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.biogenesis"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.greynetic"
 PKG_VERSION="2.2.1-Leia"
 PKG_SHA256="d95bc93d022b12fbfcbaedf1128292b40dd16276b65a3ffecb90707055e1d55f"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.greynetic"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.matrixtrails"
 PKG_VERSION="v2.2.1-Leia"
 PKG_SHA256="2d2c795853c5a72184bb6720247d79c48b1d9fbc97e9c2913003a707d612e3ac"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.matrixtrails"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.pingpong/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.pingpong/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.pingpong"
 PKG_VERSION="2.1.1-Leia"
 PKG_SHA256="d4e09509bf036b7d5c381cd4ecac926a59396fb481347a4056d843ae68d3a20d"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.pingpong"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.pyro"
 PKG_VERSION="3.0.0-Leia"
 PKG_SHA256="55f867b703e5cf409f8e0a8a2c34373f896feb990004b5901b4efaee905d42e5"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.pyro"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.shadertoy"
 PKG_VERSION="81b2758c8037ccc4e85f13b3a48e0622e9316c94"
 PKG_SHA256="6d07eb8155a73786860b1d7e90b1c8b82bdd6e0cde970ce00a4d5ca5189b0e30"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/popcornmix/screensaver.shadertoy"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.stars"
 PKG_VERSION="2.1.2-Leia"
 PKG_SHA256="8873de9be41365af9dc639e3624d887f7b18d8e1f43e9a69af0c3154f9b59020"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.stars"

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="vfs.libarchive"
 PKG_VERSION="1.0.5-Leia"
 PKG_SHA256="4e851761bcd2d49da8e20a2cd40fd969a103288e561fe14052ac5b7397e497f7"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/vfs.libarchive"

--- a/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="vfs.rar"
 PKG_VERSION="2.0.7-Leia"
 PKG_SHA256="b42db08aae80a10cfe3534b72241737c3fac39fc1d4bbb8473163b9a30d12251"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/vfs.rar"

--- a/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="vfs.sftp"
 PKG_VERSION="1.0.1-Leia"
 PKG_SHA256="fc1fe2efd080ae96f5eb5a0fee0a53c0986c825cbffc26f6cb6a95a196af9bab"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/xbmc/vfs.sftp"

--- a/packages/mediacenter/kodi-binary-addons/visualization.pictureit/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.pictureit/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.pictureit"
 PKG_VERSION="f08d0aa6d5f80cfa95a24adca48be15e333ca8e0"
 PKG_SHA256="f29112d232907b46a738e6971f03c75ec6a61b70be70de203db82b2252ae4f8d"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"

--- a/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.projectm"
 PKG_VERSION="v2.2.0"
 PKG_SHA256="d0d10786cb3f7e7f9210ad6073ee5d0cd735a7e3cf5a55a00c40af33ec486da4"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.projectm"

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.shadertoy"
 PKG_VERSION="1.1.10-Leia"
 PKG_SHA256="342b89a6d9ec1175023d085f540358b5ddc427bb73e172f155d61e77e87ee56e"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.shadertoy"

--- a/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.spectrum"
 PKG_VERSION="v2.0.4-Leia"
 PKG_SHA256="0c08c318fc3781560e2a112d17c347cd69aba3e5388472009eef774555760aeb"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.spectrum"

--- a/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.waveform"
 PKG_VERSION="2.0.1-Leia"
 PKG_SHA256="ee5fd55287cbdf112da941f0c13ebe575d7af082f7ef764ab399cd047ca384ab"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.waveform"


### PR DESCRIPTION
the PKG_REV bump on non-updated addons ensures rebuilt addons will
be rolled out to RPi4 users.

generated with new update sripts from #3692 using "-b" option