### PR TITLE
kodi: building with ninja makes xbmc/1600 more likely - don't use ninja

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -8,6 +8,7 @@ PKG_SITE="http://www.kodi.tv"
 PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python2 zlib systemd lzo pcre swig:host libass curl fontconfig fribidi tinyxml libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid giflib libdvdnav libhdhomerun libfmt lirc libfstrcmp flatbuffers:host flatbuffers"
 PKG_LONGDESC="A free and open source cross-platform media player."
 PKG_BUILD_FLAGS="+speed"
+PKG_TOOLCHAIN="cmake-make"
 
 PKG_PATCH_DIRS="$KODI_VENDOR"
 


### PR DESCRIPTION
Kodi occasionally fails to build due to https://github.com/xbmc/xbmc/issues/16000.

It appears that `ninja` is more likely to cause this failure than `cmake-make` - I've tested 1,000 `cmake-make` Kodi builds with 0 (zero) failures, and 250 `ninja` builds with 4 failures (all due to issue xbmc/16000).

Team Kodi has seen this same failure when using `cmake` and their own Jenkins, so this PR may not eliminate the issue entirely (which could be a `kodi` and/or `cmake` issue, made worse by `ninja`) but should hopefully make it less of an issue for LibreELEC until it is fixed (if it is ever fixed).