### PR TITLE
use e2fsprogs/dosfstools from toolchain for image creation

### DIFF
--- a/packages/sysutils/dosfstools/package.mk
+++ b/packages/sysutils/dosfstools/package.mk
@@ -41,4 +41,7 @@ makeinstall_host() {
   mkdir -p $TOOLCHAIN/sbin
     cp mkfs.fat $TOOLCHAIN/sbin
     ln -sf mkfs.fat $TOOLCHAIN/sbin/mkfs.vfat
+    cp fsck.fat $TOOLCHAIN/sbin
+    ln -sf fsck.fat $TOOLCHAIN/sbin/fsck.vfat
+    cp fatlabel $TOOLCHAIN/sbin
 }

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -20,7 +20,24 @@ fi
 
 PKG_CONFIGURE_OPTS_HOST="--prefix=$TOOLCHAIN/ \
                          --bindir=$TOOLCHAIN/bin \
-                         --sbindir=$TOOLCHAIN/sbin"
+                         --sbindir=$TOOLCHAIN/sbin \
+                         --enable-verbose-makecmds \
+                         --disable-symlink-install \
+                         --disable-symlink-build \
+                         --disable-subset \
+                         --disable-debugfs \
+                         --disable-imager \
+                         --disable-resizer \
+                         --disable-defrag \
+                         --disable-fsck \
+                         --disable-e2initrd-helper \
+                         --enable-tls \
+                         --disable-uuid \
+                         --disable-uuidd \
+                         --disable-nls \
+                         --disable-rpath \
+                         --disable-fuse2fs \
+                         --with-gnu-ld"
 
 pre_configure() {
   PKG_CONFIGURE_OPTS_INIT="BUILD_CC=$HOST_CC \
@@ -83,12 +100,11 @@ makeinstall_init() {
   fi
 }
 
-make_host() {
-  make -C lib/et
-  make -C lib/ext2fs
-}
-
 makeinstall_host() {
   make -C lib/et LIBMODE=644 install
   make -C lib/ext2fs LIBMODE=644 install
+  mkdir -p $TOOLCHAIN/sbin
+  cp e2fsck/e2fsck $TOOLCHAIN/sbin
+  cp misc/mke2fs $TOOLCHAIN/sbin
+  cp misc/tune2fs $TOOLCHAIN/sbin
 }

--- a/scripts/image
+++ b/scripts/image
@@ -23,7 +23,6 @@ setup_toolchain target
 function do_mkimage() {
   # Variables used in mkimage script must be passed
   env \
-    PATH="${PATH}:/sbin" \
     ROOT="${ROOT}" \
     SCRIPTS="${SCRIPTS}" \
     TOOLCHAIN="${TOOLCHAIN}" \

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -286,7 +286,7 @@ SYSTEM_PART_COUNT=$(( ${SYSTEM_PART_END} - ${SYSTEM_PART_START} + 1 ))
 sync
 dd if="${DISK}" of="${LE_TMP}/part1.fat" bs=512 skip="${SYSTEM_PART_START}" count="${SYSTEM_PART_COUNT}" conv=fsync >"${SAVE_ERROR}" 2>&1 || show_error
 echo "image: checking filesystem on part1..."
-fsck -n "${LE_TMP}/part1.fat" >"${SAVE_ERROR}" 2>&1 || show_error
+fsck.fat -n "${LE_TMP}/part1.fat" >"${SAVE_ERROR}" 2>&1 || show_error
 
 # create virtual image
 if [ "${PROJECT}" = "Generic" ]; then


### PR DESCRIPTION
We already build fsck.fat in dosfstools:host but didn't install it to toolchain. Add that (plus fatlabel which may be helpful, too) and use it in mkimage

Edit: by building e2fsck, mke2fs and tune2fs and installing to toolchain we can drop the dependency on build host tools completely and also remove /sbin from the PATH for mkimage