### PR TITLE
cleanup: curl, edid-decode

### DIFF
--- a/packages/debug/edid-decode/package.mk
+++ b/packages/debug/edid-decode/package.mk
@@ -11,8 +11,8 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Decode EDID data in human-readable format"
 
 make_target() {
-  echo "$CC $CFLAGS -Wall $LDFLAGS -lm -o edid-decode edid-decode.c"
-  $CC $CFLAGS -Wall $LDFLAGS -lm -o edid-decode edid-decode.c
+  echo "$CC $CFLAGS -Wall $LDFLAGS -o edid-decode edid-decode.c -lm"
+  $CC $CFLAGS -Wall $LDFLAGS -o edid-decode edid-decode.c -lm
 }
 
 makeinstall_target() {

--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -16,7 +16,7 @@ PKG_SHA256="f6c22074877f235aebc7c53057dbc7ee82358f8ae58bfb767e955c18c859a77a"
 PKG_LICENSE="MIT"
 PKG_SITE="http://curl.haxx.se"
 PKG_URL="http://curl.haxx.se/download/$PKG_NAME-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="toolchain zlib gnutls rtmpdump nghttp2"
+PKG_DEPENDS_TARGET="toolchain zlib gnutls rtmpdump libidn2 nghttp2"
 PKG_LONGDESC="Client and library for (HTTP, HTTPS, FTP, ...) transfers."
 PKG_TOOLCHAIN="configure"
 
@@ -65,22 +65,16 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_lib_rtmp_RTMP_Init=yes \
                            --with-random=/dev/urandom \
                            --with-gnutls \
                            --without-ssl \
-                           --without-polarssl \
+                           --without-mbedtls \
                            --without-nss \
                            --with-ca-bundle=/run/libreelec/cacert.pem \
                            --without-ca-path \
                            --without-libpsl \
                            --without-libmetalink \
                            --without-libssh2 \
-                           --with-librtmp=$SYSROOT_PREFIX/usr \
-                           --without-libidn \
-                           --without-libidn2 \
+                           --with-librtmp \
+                           --with-libidn2 \
                            --with-nghttp2"
-
-pre_configure_target() {
-# link against librt because of undefined reference to 'clock_gettime'
-  export LIBS="-lrt -lm -lrtmp"
-}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/share/zsh


### PR DESCRIPTION
edid-decode: fix building when not using the gold linker

curl: 
Update for some changes in configure options

pre_configure_target() was not necessary on an RPi3 build. configure states it doesn't need an   external lib for clock_gettime.

Use libidn2 because it's present

Library paths not used/present because they're only supposed to be necessary if pkg-config isn't working correctly (building fine without here)