### PR TITLE
kodi (RPi): add missing alsa+pulseaudio patch

### DIFF
--- a/packages/mediacenter/kodi/patches/raspberrypi/kodi-100.14-use-alsa-and-pulse-together.patch
+++ b/packages/mediacenter/kodi/patches/raspberrypi/kodi-100.14-use-alsa-and-pulse-together.patch
@@ -1,0 +1,1 @@
+../default/kodi-100.14-use-alsa-and-pulse-together.patch


### PR DESCRIPTION
Commit f1ef2f099c5a9312f17508beb1a408d58f791071 missed to
add the "use-alsa-and-pulse-together" for kodi vendor raspberrypi.
Add it back so pulseaudio shows up in Kodi on RPi again.

See also https://forum.libreelec.tv/thread/13245-kodi-18-0-update-for-slice/?postID=123042#post123042