### PR TITLE
safe_remove: remove also broken symbolic links

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -136,7 +136,7 @@ safe_remove() {
 
   [ -z "${path}" ] && return 0
 
-  if [ -f "${path}" -o -d "${path}" ]; then
+  if [ -e "${path}" -o -L "${path}" ]; then
     rm -r "${path}"
   elif [ -n "${PKG_NAME}" ]; then
     print_color CLR_WARNING "safe_remove: path does not exist: [${PKG_NAME}]: ${path}\n"


### PR DESCRIPTION
if the target ($1) is a symbolic link to a removed file/folder, the
check will fail and the (broken) symbolic link will be not removed.