### PR TITLE
parallel: update to parallel-20190722

### DIFF
--- a/packages/devel/parallel/package.mk
+++ b/packages/devel/parallel/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="parallel"
-PKG_VERSION="20190122"
-PKG_SHA256="ae735f201a8ceeff2ace48ff779bda9d19846e629bcc02ea7c8768a42394190c"
+PKG_VERSION="20190722"
+PKG_SHA256="0ed0863184dbb396b4c030848e754b1ea76329c06ae9e43314bc0915eb6cbca7"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://www.gnu.org/software/parallel/"
 PKG_URL="http://ftpmirror.gnu.org/parallel/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
20190722 includes startup performance optimisations. I've been using a snapshot of this release since [Jun 25](https://git.savannah.gnu.org/cgit/parallel.git/commit/?id=7aa0394278b6abb439ba6e333f7a80120efa8762) without any issue.

https://lists.gnu.org/archive/html/bug-parallel/2019-07/msg00003.html