### PR TITLE
iMX6: kodi: add patch to quirk the plane usage

### DIFF
--- a/projects/NXP/devices/iMX6/patches/kodi/kodi-100.90-imx-quirk-plane-usage.patch
+++ b/projects/NXP/devices/iMX6/patches/kodi/kodi-100.90-imx-quirk-plane-usage.patch
@@ -1,0 +1,24 @@
+From 91f6e594dcd0f657b17d3ffa2e64972b5fb3339d Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Fri, 19 Jul 2019 09:35:02 -0700
+Subject: [PATCH] windowing/gbm: quirk imx-drm to only allow selecting an
+ overlay plane for video
+
+---
+ xbmc/windowing/gbm/DRMUtils.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/xbmc/windowing/gbm/DRMUtils.cpp b/xbmc/windowing/gbm/DRMUtils.cpp
+index bbbc447498cf..bb8baf42dab9 100644
+--- a/xbmc/windowing/gbm/DRMUtils.cpp
++++ b/xbmc/windowing/gbm/DRMUtils.cpp
+@@ -370,6 +370,9 @@ drmModePlanePtr CDRMUtils::FindPlane(drmModePlaneResPtr resources, int crtc_inde
+           {
+             case KODI_VIDEO_PLANE:
+             {
++              if (m_module == "imx-drm" && props->prop_values[j] != DRM_PLANE_TYPE_OVERLAY)
++                break;
++
+               if (SupportsFormat(plane, DRM_FORMAT_NV12))
+               {
+                 CLog::Log(LOGDEBUG, "CDRMUtils::%s - found video plane %u", __FUNCTION__, plane->plane_id);


### PR DESCRIPTION
This patch is needed to allow kodi to run properly on some iMX6 platforms. I've added it as a patch for now as I would like to find a better solution for upstream Kodi.