### PR TITLE
p8-platform: switch to correct repo, update to p8-platform-cee64e9

### DIFF
--- a/packages/mediacenter/p8-platform/package.mk
+++ b/packages/mediacenter/p8-platform/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="p8-platform"
-PKG_VERSION="1eb12b1b1efa6747c1e190964854e9e267e3a1e2"
-PKG_SHA256="94dba139066a332d048486f817736e4cf4962393c9f892d2c7dd40d9d69ca788"
+PKG_VERSION="cee64e9dc0b69e8d286dc170a78effaabfa09c44"
+PKG_SHA256="8d2c3c2e2951a3f202aadd774ce52e2096468a6470ef4c926dbb13bb564ea378"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
-PKG_URL="https://github.com/Pulse-Eight/platform/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/xbmc/platform/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Platform support library used by libCEC and binary add-ons for Kodi"
 

--- a/packages/mediacenter/p8-platform/patches/p8-platform-02-cmake_install_prefix_toolchain.patch
+++ b/packages/mediacenter/p8-platform/patches/p8-platform-02-cmake_install_prefix_toolchain.patch
@@ -1,12 +1,12 @@
 diff --git a/p8-platform-config.cmake.in b/p8-platform-config.cmake.in
-index f59418d..df7ed21 100644
+index 47f30f1..df7ed21 100644
 --- a/p8-platform-config.cmake.in
 +++ b/p8-platform-config.cmake.in
 @@ -10,7 +10,7 @@
  #
  # propagate these properties from one build system to the other
  set (p8-platform_VERSION "@p8-platform_VERSION_MAJOR@.@p8-platform_VERSION_MINOR@")
--find_path (p8-platform_INCLUDE_DIRS p8-platform/os.h)
+-set (p8-platform_INCLUDE_DIRS @p8-platform_INCLUDE_DIRS@ @CMAKE_INSTALL_PREFIX@/include)
 +set (p8-platform_INCLUDE_DIRS @p8-platform_INCLUDE_DIRS@ @CMAKE_INSTALL_PREFIX_TOOLCHAIN@/include/p8-platform)
  set (p8-platform_LIBRARY_DIRS "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
  set (p8-platform_LINKER_FLAGS "@p8-platform_LINKER_FLAGS@")
@@ -15,7 +15,7 @@ index f59418d..df7ed21 100644
  if(WIN32)
    set (p8-platform_LIBRARY "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/p8-platform.lib")
  else(WIN32)
--  find_library (p8-platform_LIBRARY p8-platform)
+-  set (p8-platform_LIBRARY "-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lp8-platform")
 +  set (p8-platform_LIBRARY "-L@CMAKE_INSTALL_PREFIX_TOOLCHAIN@/@CMAKE_INSTALL_LIBDIR@ -lp8-platform")
  endif(WIN32)
  set (p8-platform_LIBRARIES ${p8-platform_LIBRARY} "@p8-platform_LIBRARIES@")


### PR DESCRIPTION
Aligns us with https://github.com/xbmc/xbmc/blob/master/cmake/addons/depends/common/p8-platform/p8-platform.txt rather than the upstream Pulse-Eight fork.

Bumps to latest commit in anticipation of https://github.com/xbmc/xbmc/pull/16417

Leaving as a draft to allow further testing.