### PR TITLE
RPi4: add tools for updating SPI bootloader

### DIFF
--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -67,6 +67,7 @@ make_target() {
   make -C libiberty
   make -C bfd
   make -C opcodes
+  make -C binutils strings
 }
 
 makeinstall_target() {
@@ -74,4 +75,7 @@ makeinstall_target() {
     cp libiberty/libiberty.a $SYSROOT_PREFIX/usr/lib
   make DESTDIR="$SYSROOT_PREFIX" -C bfd install
   make DESTDIR="$SYSROOT_PREFIX" -C opcodes install
+
+  mkdir -p ${INSTALL}/usr/bin
+    cp binutils/strings ${INSTALL}/usr/bin
 }

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -78,11 +78,13 @@ makeinstall_target() {
     ln -s dtoverlay                            ${INSTALL}/usr/bin/dtparam
     cp -PRv ${PKG_FLOAT}/opt/vc/bin/vcdbg      ${INSTALL}/usr/bin
     cp -PRv ${PKG_FLOAT}/opt/vc/bin/vcgencmd   ${INSTALL}/usr/bin
+    cp -PRv ${PKG_FLOAT}/opt/vc/bin/vcmailbox  ${INSTALL}/usr/bin
     cp -PRv ${PKG_FLOAT}/opt/vc/bin/tvservice  ${INSTALL}/usr/bin
     cp -PRv ${PKG_FLOAT}/opt/vc/bin/edidparser ${INSTALL}/usr/bin
 
   # Create symlinks to /opt/vc to satisfy hardcoded lib paths
   mkdir -p ${INSTALL}/opt/vc
+    ln -sf /usr/bin ${INSTALL}/opt/vc/bin
     ln -sf /usr/lib ${INSTALL}/opt/vc/lib
 }
 

--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="f59dcc824fd8fe5b79c0a709a0c70676cc9ab3b1"
-PKG_SHA256="0dcfa78f80386c0bcbf550ef0cb0e28a99e6aca1208ccb0664a5fccaff20d01e"
+PKG_VERSION="edbb35f3abcd375aaffc1220cf01925218b6d19b"
+PKG_SHA256="fc9f4814b28025dc1ebc5b9671c92f0c09f403b687c557deac99cf7242a27c32"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -139,6 +139,10 @@ makeinstall_target() {
     sed -e "s/@DISTRONAME@/$DISTRONAME/g" \
         -i $INSTALL/usr/lib/libreelec/fs-resize
 
+    if listcontains "${FIRMWARE}" "rpi-eeprom"; then
+      cp $PKG_DIR/scripts/rpi-flash-firmware $INSTALL/usr/lib/libreelec
+    fi
+
   mkdir -p $INSTALL/etc
     cp $PKG_DIR/config/profile $INSTALL/etc
     cp $PKG_DIR/config/inputrc $INSTALL/etc
@@ -183,6 +187,7 @@ post_install() {
   enable_service var.mount
   enable_service var-log-debug.service
   enable_service fs-resize.service
+  listcontains "${FIRMWARE}" "rpi-eeprom" && enable_service rpi-flash-firmware.service
 
   # cron support
   if [ "$CRON_SUPPORT" = "yes" ] ; then

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -1117,17 +1117,16 @@ if [ "$STORAGE_NETBOOT" = "yes" ]; then
   echo "" > /sysroot/dev/.storage_netboot
 fi
 
+BACKUP_FILE=$(ls -1 /sysroot/storage/.restore/??????????????.tar 2>/dev/null | head -n 1)
+
 if [ -f /sysroot/storage/.please_resize_me ]; then
   INIT_UNIT="--unit=fs-resize.target"
-fi
-
-BACKUP_FILE=$(ls -1 /sysroot/storage/.restore/??????????????.tar 2>/dev/null | head -n 1)
-if [ -f "$BACKUP_FILE" ]; then
-  INIT_UNIT="--unit=backup-restore.target"
-fi
-
-if [ -f /sysroot/storage/.cache/reset_oe -o -f /sysroot/storage/.cache/reset_xbmc ]; then
+elif [ -f /sysroot/storage/.cache/reset_oe -o -f /sysroot/storage/.cache/reset_xbmc ]; then
   INIT_UNIT="--unit=factory-reset.target"
+elif [ -f "$BACKUP_FILE" ]; then
+  INIT_UNIT="--unit=backup-restore.target"
+elif [ -f /sysroot/storage/.rpi_flash_firmware ]; then
+  INIT_UNIT="--unit=rpi-flash-firmware.target"
 fi
 
 # switch to new sysroot and start real init

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -548,6 +548,17 @@ mount_flash() {
   fi
 }
 
+cleanup_flash() {
+  progress "Cleaning up flash (if required)"
+
+  if [ -f /flash/pieeprom.upd ]; then
+    mount -o remount,rw /flash
+    rm -f /flash/pieeprom.bin /flash/pieeprom.upd
+    rm -f /flash/recovery.bin /flash/recovery.[0-9][0-9][0-9] /flash/RECOVERY.[0-9][0-9][0-9]
+    mount -o remount,ro /flash
+  fi
+}
+
 mount_storage() {
   progress "Mounting storage"
 
@@ -1072,6 +1083,7 @@ for BOOT_STEP in \
     set_consolefont \
     check_disks \
     mount_flash \
+    cleanup_flash \
     update_bootmenu \
     load_splash \
     mount_storage \

--- a/packages/sysutils/busybox/scripts/rpi-flash-firmware
+++ b/packages/sysutils/busybox/scripts/rpi-flash-firmware
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+FLAG_FILE="/storage/.rpi_flash_firmware"
+
+. /usr/lib/libreelec/functions
+
+hidecursor
+
+if ! mount -o remount,rw /flash 2>/dev/null; then
+  # Remove flag file and bail out
+  rm -f "${FLAG_FILE}"
+  sync
+
+  echo "ERROR: Unable to mount /flash as a read/write file system."
+  echo
+  echo "Aborting Flash update process - please proceed with a manual update."
+  echo
+
+  StartProgress countdown "Rebooting in 15s... " 15 "NOW"
+fi
+
+if [ -f "${FLAG_FILE}" ]; then
+  . ${FLAG_FILE}
+
+  # Prepare flashing environment
+  if [ "${MODE}" = "init" ]; then
+    # Install new SPI bootloader files to /flash (if required)
+    if [ "${BOOTLOADER}" = "yes" ]; then
+      USE_FLASHROM=0 /usr/bin/rpi-eeprom-update -a
+    fi
+
+    # Bump process to next step
+    sed -e 's/^MODE=.*/MODE="update"/' -i "${FLAG_FILE}"
+    sync
+  else
+    rm -f "${FLAG_FILE}"
+    sync
+
+    if [ "${MODE}" = "update" ]; then
+      # Cleanup SPI bootloader files and show current version
+      if [ "${BOOTLOADER}" = "yes" ]; then
+        rm -f /flash/pieeprom.bin /flash/pieeprom.upd
+        rm -f /flash/recovery.bin /flash/recovery.[0-9][0-9][0-9] /flash/RECOVERY.[0-9][0-9][0-9]
+        # Display current bootloader status
+        USE_FLASHROM=0 /usr/bin/rpi-eeprom-update
+      fi
+
+      # Apply VIA USB3 update
+#      if [ "${USB3}" = "yes" ]; then
+#        /usr/bin/vl805
+#      fi
+
+      sync
+      echo ""
+      StartProgress countdown "Rebooting in 15s... " 15 "NOW"
+    fi
+  fi
+
+  sync
+  mount -o remount,ro /flash
+fi
+
+reboot -f &>/dev/null

--- a/packages/sysutils/busybox/scripts/rpi-flash-firmware
+++ b/packages/sysutils/busybox/scripts/rpi-flash-firmware
@@ -29,7 +29,7 @@ if [ -f "${FLAG_FILE}" ]; then
   if [ "${MODE}" = "init" ]; then
     # Install new SPI bootloader files to /flash (if required)
     if [ "${BOOTLOADER}" = "yes" ]; then
-      USE_FLASHROM=0 /usr/bin/rpi-eeprom-update -a
+      USE_FLASHROM=0 /usr/bin/.rpi-eeprom-update.real -a
     fi
 
     # Bump process to next step
@@ -40,12 +40,9 @@ if [ -f "${FLAG_FILE}" ]; then
     sync
 
     if [ "${MODE}" = "update" ]; then
-      # Cleanup SPI bootloader files and show current version
+      # Display current bootloader status
       if [ "${BOOTLOADER}" = "yes" ]; then
-        rm -f /flash/pieeprom.bin /flash/pieeprom.upd
-        rm -f /flash/recovery.bin /flash/recovery.[0-9][0-9][0-9] /flash/RECOVERY.[0-9][0-9][0-9]
-        # Display current bootloader status
-        USE_FLASHROM=0 /usr/bin/rpi-eeprom-update
+        USE_FLASHROM=0 /usr/bin/.rpi-eeprom-update.real
       fi
 
       # Apply VIA USB3 update

--- a/packages/sysutils/busybox/system.d/rpi-flash-firmware.service
+++ b/packages/sysutils/busybox/system.d/rpi-flash-firmware.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=RPi Flash Firmware
+Requires=tmp.mount var.mount sys-kernel-config.mount kernel-overlays.service
+After=tmp.mount var.mount sys-kernel-config.mount kernel-overlays.service
+DefaultDependencies=no
+
+[Service]
+Type=idle
+ExecStart=/usr/lib/libreelec/rpi-flash-firmware
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit

--- a/packages/sysutils/busybox/system.d/rpi-flash-firmware.target
+++ b/packages/sysutils/busybox/system.d/rpi-flash-firmware.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=RPi Flash Firmware target
+Requires=rpi-flash-firmware.service
+After=rpi-flash-firmware.service
+AllowIsolate=yes

--- a/packages/tools/flashrom/package.mk
+++ b/packages/tools/flashrom/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019 Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="flashrom"
+PKG_VERSION="1.1"
+PKG_SHA256="aeada9c70c22421217c669356180c0deddd0b60876e63d2224e3260b90c14e19"
+PKG_LICENSE="GPL"
+PKG_SITE="https://www.flashrom.org/Flashrom"
+PKG_URL="https://download.flashrom.org/releases/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"
+PKG_DEPENDS_TARGET="toolchain libusb-compat"
+PKG_LONGDESC="flashrom is a utility for identifying, reading, writing, verifying and erasing flash chips. It is designed to flash BIOS/EFI/coreboot/firmware/optionROM images on mainboards, network/graphics/storage controller cards, and various other programmer devices."
+
+PKG_MAKE_OPTS_TARGET="PREFIX=/usr \
+                      CONFIG_ENABLE_LIBPCI_PROGRAMMERS=no \
+                      CONFIG_FT2232_SPI=no \
+                      CONFIG_USBBLASTER_SPI=no \
+                      CONFIG_JLINK_SPI=no"
+PKG_MAKEINSTALL_OPTS_TARGET="${PKG_MAKE_OPTS_TARGET}"
+
+post_makeinstall_target() {
+  rm -fr ${INSTALL}/usr/share/man
+}

--- a/packages/tools/rpi-eeprom/config/rpi-eeprom-update
+++ b/packages/tools/rpi-eeprom/config/rpi-eeprom-update
@@ -1,0 +1,5 @@
+# Use direct path to firmware as update script doesn't dereference sym links.
+FIRMWARE_ROOT="/usr/lib/kernel-overlays/base/lib/firmware/raspberrypi/bootloader"
+FIRMWARE_BACKUP_DIR="/storage/.config/rpifw-backup"
+BOOTFS=/flash
+USE_FLASHROM=${USE_FLASHROM:-1}

--- a/packages/tools/rpi-eeprom/config/rpi-eeprom-update
+++ b/packages/tools/rpi-eeprom/config/rpi-eeprom-update
@@ -2,4 +2,3 @@
 FIRMWARE_ROOT="/usr/lib/kernel-overlays/base/lib/firmware/raspberrypi/bootloader"
 FIRMWARE_BACKUP_DIR="/storage/.config/rpifw-backup"
 BOOTFS=/flash
-USE_FLASHROM=${USE_FLASHROM:-1}

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="rpi-eeprom"
+PKG_VERSION="ffec4bd48ff2ab753da10bd42b2fd7b904d8dca5"
+PKG_SHA256="94eba989f3776c6d2f06cf021fffb1cb4c2f550fa325e5a08cab2fdd4a4e00bd"
+PKG_ARCH="arm"
+PKG_LICENSE="BSD-3/custom"
+PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
+PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="flashrom"
+PKG_LONGDESC="rpi-eeprom: firmware, config and scripts to update RPi4 SPI bootloader"
+PKG_TOOLCHAIN="manual"
+
+makeinstall_target() {
+  DESTDIR=${INSTALL}/$(get_kernel_overlay_dir)/lib/firmware/raspberrypi/bootloader
+
+  mkdir -p ${DESTDIR}
+    mkdir -p ${DESTDIR}/${_dir}
+      cp -PRv ${PKG_BUILD}/firmware/recovery.bin ${DESTDIR}
+
+    _dirs="critical"
+    [ "$LIBREELEC_VERSION" = "devel" ] && _dirs+=" beta"
+    for _dir in ${_dirs}; do
+      if [ -n "$(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* 2>/dev/null)" ]; then
+        mkdir -p ${DESTDIR}/${_dir}
+          cp -PRv $(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* | tail -1) ${DESTDIR}/${_dir}
+      fi
+    done
+
+  mkdir -p ${INSTALL}/usr/bin
+    cp -PRv ${PKG_BUILD}/rpi-eeprom-{config,update} ${INSTALL}/usr/bin
+
+  mkdir -p ${INSTALL}/etc/default
+    cp -PRv ${PKG_DIR}/config/* ${INSTALL}/etc/default
+}

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -29,7 +29,9 @@ makeinstall_target() {
     done
 
   mkdir -p ${INSTALL}/usr/bin
-    cp -PRv ${PKG_BUILD}/rpi-eeprom-{config,update} ${INSTALL}/usr/bin
+    cp -PRv ${PKG_DIR}/source/rpi-eeprom-update ${INSTALL}/usr/bin
+    cp -PRv ${PKG_BUILD}/rpi-eeprom-update ${INSTALL}/usr/bin/.rpi-eeprom-update.real
+    cp -PRv ${PKG_BUILD}/rpi-eeprom-config ${INSTALL}/usr/bin
 
   mkdir -p ${INSTALL}/etc/default
     cp -PRv ${PKG_DIR}/config/* ${INSTALL}/etc/default

--- a/packages/tools/rpi-eeprom/source/rpi-eeprom-update
+++ b/packages/tools/rpi-eeprom/source/rpi-eeprom-update
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# If read-only then mount writeable, and restore read-only on exit
+# This means we don't restore read-only if /flash is already writeable
+if [ -n "$(grep " /flash " /proc/mounts | grep "[[:space:]]ro[[:space:],]")" ]; then
+  trap "mount -o remount,ro /flash" EXIT
+  mount -o remount,rw /flash
+fi
+
+sh /usr/bin/.rpi-eeprom-update.real $@

--- a/projects/RPi/devices/RPi4/options
+++ b/projects/RPi/devices/RPi4/options
@@ -8,6 +8,9 @@
   # NOOBS supported model versions
     NOOBS_SUPPORTED_MODELS='"Pi 4"'
 
+  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
+    FIRMWARE="${FIRMWARE} rpi-eeprom"
+
     OPENGLES="mesa"
     GRAPHIC_DRIVERS="vc4"
     KODIPLAYER_DRIVER="mesa"


### PR DESCRIPTION
First stab at this, not yet ready to merge.

It uses the RPi supplied shell and Python scripts to update the bootloader, once these are hosted on an upstream repository (along with the SPI firmware) we can hopefully install from there (I'll adapt this PR as/when it becomes clear where the scripts and firmware will be hosted).

I'm currently patching changes to the scripts as required by LibreELEC, but it would be nice to avoid these changes in future.

I'm only planning on including one version of the SPI firmware (the latest) in the image - I'm not sure there's much point including older firmware versions.

As yet there is no GUI plumbing - this is command line only, using `rpi-eeprom-update`, with backups of existing SPI firmware being written to `/storage/.config/rpifw-backup`.