### PR TITLE
Allwinner: Fix USB3 support

### DIFF
--- a/projects/Allwinner/devices/H6/patches/linux/09-pineh64-enable-usb3.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/09-pineh64-enable-usb3.patch
@@ -1,0 +1,41 @@
+From b5554a30a6486e6e769130718d285902e6705bf8 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Mon, 25 Dec 2017 12:10:59 +0800
+Subject: [PATCH] arm64: allwinner: dts: h6: enable USB3 port on Pine H64
+
+Pine H64 board have a USB3 port, which is connected to the USB3 pins of
+the H6 SoC, and the 5V power supply is controlled via GPIO (shared with
+the power USB ports).
+
+Enable this port.
+
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+Reviewed-by: Chen-Yu Tsai <wens@csie.org>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64.dts | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64.dts
+index f01fdf622756f..f2d04cfeec900 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64.dts
+@@ -71,6 +71,10 @@
+ 	status = "okay";
+ };
+ 
++&dwc3 {
++	status = "okay";
++};
++
+ &emac {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&ext_rgmii_pins>;
+@@ -279,3 +283,8 @@
+ 	usb3_vbus-supply = <&reg_usb_vbus>;
+ 	status = "okay";
+ };
++
++&usb3phy {
++	phy-supply = <&reg_usb_vbus>;
++	status = "okay";
++};

--- a/projects/Allwinner/patches/linux/0002-backport-from-5.3.patch
+++ b/projects/Allwinner/patches/linux/0002-backport-from-5.3.patch
@@ -2525,3 +2525,71 @@ index 4802902e128f..9e464d40cbff 100644
 -- 
 2.21.0
 
+From dc1b5d9aed1794b5a1c6b0da46e372cc09974cbc Mon Sep 17 00:00:00 2001
+From: Enric Balletbo i Serra <enric.balletbo@collabora.com>
+Date: Thu, 13 Jun 2019 17:01:07 +0200
+Subject: [PATCH] usb: dwc3: Fix core validation in probe, move after clocks
+ are enabled
+
+The required clocks needs to be enabled before the first register
+access. After commit fe8abf332b8f ("usb: dwc3: support clocks and resets
+for DWC3 core"), this happens when the dwc3_core_is_valid function is
+called, but the mentioned commit adds that call in the wrong place,
+before the clocks are enabled. So, move that call after the
+clk_bulk_enable() to ensure the clocks are enabled and the reset
+deasserted.
+
+I detected this while, as experiment, I tried to move the clocks and resets
+from the glue layer to the DWC3 core on a Samsung Chromebook Plus.
+
+That was not detected before because, in most cases, the glue layer
+initializes SoC-specific things and then populates the child "snps,dwc3"
+with those clocks already enabled.
+
+Fixes: b873e2d0ea1ef ("usb: dwc3: Do core validation early on probe")
+Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>
+Signed-off-by: Felipe Balbi <felipe.balbi@linux.intel.com>
+---
+ drivers/usb/dwc3/core.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/usb/dwc3/core.c b/drivers/usb/dwc3/core.c
+index 4aff1d8dbc4f..6e9e172010fc 100644
+--- a/drivers/usb/dwc3/core.c
++++ b/drivers/usb/dwc3/core.c
+@@ -1423,11 +1423,6 @@ static int dwc3_probe(struct platform_device *pdev)
+ 	dwc->regs	= regs;
+ 	dwc->regs_size	= resource_size(&dwc_res);
+ 
+-	if (!dwc3_core_is_valid(dwc)) {
+-		dev_err(dwc->dev, "this is not a DesignWare USB3 DRD Core\n");
+-		return -ENODEV;
+-	}
+-
+ 	dwc3_get_properties(dwc);
+ 
+ 	dwc->reset = devm_reset_control_get_optional_shared(dev, NULL);
+@@ -1460,6 +1455,12 @@ static int dwc3_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		goto unprepare_clks;
+ 
++	if (!dwc3_core_is_valid(dwc)) {
++		dev_err(dwc->dev, "this is not a DesignWare USB3 DRD Core\n");
++		ret = -ENODEV;
++		goto disable_clks;
++	}
++
+ 	platform_set_drvdata(pdev, dwc);
+ 	dwc3_cache_hwparams(dwc);
+ 
+@@ -1525,6 +1526,7 @@ static int dwc3_probe(struct platform_device *pdev)
+ 	pm_runtime_put_sync(&pdev->dev);
+ 	pm_runtime_disable(&pdev->dev);
+ 
++disable_clks:
+ 	clk_bulk_disable(dwc->num_clks, dwc->clks);
+ unprepare_clks:
+ 	clk_bulk_unprepare(dwc->num_clks, dwc->clks);
+-- 
+2.22.0
+


### PR DESCRIPTION
USB3 doesn't work for H6 with kernel 5.2 currently. This PR adds a kernel patch which fixes that. Another patch enables USB3 support on PineH64 board.