### PR TITLE
audiodecoder.timidity: add libtimidity.so

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.timidity"
 PKG_VERSION="2.0.1-Leia"
 PKG_SHA256="a289c49ec58b34697efd499e081e3f6580c2958e7e6801e2617e7d3f2d648a1d"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.timidity"
@@ -17,3 +17,10 @@ PKG_LONGDESC="audiodecoder.timidity"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.audiodecoder"
+
+addon() {
+  install_binary_addon $PKG_ADDON_ID
+
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID
+    cp -P $PKG_BUILD/.$TARGET_NAME/lib/timidity/libtimidity.so $ADDON_BUILD/$PKG_ADDON_ID/
+}

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/patches/audiodecoder.timidity-001-dynamic_lib.patch
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/patches/audiodecoder.timidity-001-dynamic_lib.patch
@@ -1,0 +1,16 @@
+commit 4f51d0b2ad01b0dce8e93732e70d338e24509d88
+Author: mglae <mglmail@arcor.de>
+Date:   Tue Jul 30 18:14:28 2019 +0200
+
+    build libtimidity.so
+
+diff --git a/lib/timidity/CMakeLists.txt b/lib/timidity/CMakeLists.txt
+index fc5e446..2f930ed 100644
+--- a/lib/timidity/CMakeLists.txt
++++ b/lib/timidity/CMakeLists.txt
+@@ -55,4 +55,4 @@ endif()
+ 
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR} timidity libarc utils)
+ 
+-add_library(timidity STATIC ${SOURCES})
++add_library(timidity SHARED ${SOURCES})


### PR DESCRIPTION
Build and pack needed libtimidity.so.

See bug report on the [forum](https://forum.libreelec.tv/thread/17956-timidity-problem/?postID=123322#post123322).

Tested in my LE 9.0 Generic environment.