### PR TITLE
cmake: updated to v3.15.1 / clean up

### DIFF
--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,22 +3,22 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.14.5"
-PKG_SHA256="505ae49ebe3c63c595fa5f814975d8b72848447ee13b6613b0f8b96ebda18c06"
+PKG_VERSION="3.15.1"
+PKG_SHA256="18dec548d8f8b04d53c60f9cedcebaa6762f8425339d1e2c889c383d3ccdd7f7"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.cmake.org/"
-PKG_URL="http://www.cmake.org/files/v${PKG_VERSION%.*}/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="http://www.cmake.org/files/v${PKG_VERSION%.*}/cmake-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="ccache:host openssl:host"
 PKG_LONGDESC="A cross-platform, open-source make system."
 PKG_TOOLCHAIN="configure"
 
 configure_host() {
-  ../configure --prefix=$TOOLCHAIN \
+  ../configure --prefix=${TOOLCHAIN} \
                --no-qt-gui --no-system-libs \
                -- \
                -DCMAKE_C_FLAGS="-O2 -Wall -pipe -Wno-format-security" \
                -DCMAKE_CXX_FLAGS="-O2 -Wall -pipe -Wno-format-security" \
-               -DCMAKE_EXE_LINKER_FLAGS="$HOST_LDFLAGS" \
+               -DCMAKE_EXE_LINKER_FLAGS="${HOST_LDFLAGS}" \
                -DCMAKE_USE_OPENSSL=ON \
                -DBUILD_CursesDialog=0
 }


### PR DESCRIPTION
A clean Generic & RPi image builds fine.
https://cmake.org/cmake/help/v3.15/release/3.15.html#cmake-3-15-release-notes