### PR TITLE
glibc: update to glibc-2.30

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/lttng-ust/patches/lttng-ust-0001-namespace-gettid-wrapper.patch
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/lttng-ust/patches/lttng-ust-0001-namespace-gettid-wrapper.patch
@@ -1,0 +1,87 @@
+From 3e2aaf78e6f8d57c7dbc42e39764862ba8c64bd7 Mon Sep 17 00:00:00 2001
+From: Michael Jeanson <mjeanson@efficios.com>
+Date: Mon, 3 Jun 2019 15:25:32 -0400
+Subject: [PATCH] Fix: namespace our gettid wrapper
+
+Since glibc 2.30, a gettid wrapper was added that conflicts with our
+static declaration. Namespace our wrapper so there is no conflict,
+we'll add support for the glibc provided wrapper in a further commit.
+
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ include/lttng/ust-tid.h           | 12 +++++++-----
+ include/usterr-signal-safe.h      |  2 +-
+ liblttng-ust/lttng-context-vtid.c |  4 ++--
+ 3 files changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/include/lttng/ust-tid.h b/include/lttng/ust-tid.h
+index e669d7e7..e637718a 100644
+--- a/include/lttng/ust-tid.h
++++ b/include/lttng/ust-tid.h
+@@ -31,23 +31,25 @@
+ #include <syscall.h>
+ #endif
+ 
+-#if defined(_syscall0)
+-_syscall0(pid_t, gettid)
+-#elif defined(__NR_gettid)
++#if defined(__NR_gettid)
++
+ #include <unistd.h>
+-static inline pid_t gettid(void)
++static inline pid_t lttng_gettid(void)
+ {
+ 	return syscall(__NR_gettid);
+ }
++
+ #else
++
+ #include <sys/types.h>
+ #include <unistd.h>
+ 
+ /* Fall-back on getpid for tid if not available. */
+-static inline pid_t gettid(void)
++static inline pid_t lttng_gettid(void)
+ {
+ 	return getpid();
+ }
++
+ #endif
+ 
+ #endif /* _LTTNG_UST_TID_H */
+diff --git a/include/usterr-signal-safe.h b/include/usterr-signal-safe.h
+index 1df5ada0..d987c1f0 100644
+--- a/include/usterr-signal-safe.h
++++ b/include/usterr-signal-safe.h
+@@ -95,7 +95,7 @@ do {									\
+ 	do {					\
+ 		sigsafe_print_err(UST_STR_COMPONENT "[%ld/%ld]: " fmt " (in %s() at " __FILE__ ":" UST_XSTR(__LINE__) ")\n", \
+ 		(long) getpid(),		\
+-		(long) gettid(),		\
++		(long) lttng_gettid(),		\
+ 		## args, __func__);		\
+ 	} while(0)
+ 
+diff --git a/liblttng-ust/lttng-context-vtid.c b/liblttng-ust/lttng-context-vtid.c
+index f28e470a..2f721fa0 100644
+--- a/liblttng-ust/lttng-context-vtid.c
++++ b/liblttng-ust/lttng-context-vtid.c
+@@ -62,7 +62,7 @@ void vtid_record(struct lttng_ctx_field *field,
+ 		 struct lttng_channel *chan)
+ {
+ 	if (caa_unlikely(!URCU_TLS(cached_vtid)))
+-		URCU_TLS(cached_vtid) = gettid();
++		URCU_TLS(cached_vtid) = lttng_gettid();
+ 	lib_ring_buffer_align_ctx(ctx, lttng_alignof(URCU_TLS(cached_vtid)));
+ 	chan->ops->event_write(ctx, &URCU_TLS(cached_vtid),
+ 		sizeof(URCU_TLS(cached_vtid)));
+@@ -73,7 +73,7 @@ void vtid_get_value(struct lttng_ctx_field *field,
+ 		struct lttng_ctx_value *value)
+ {
+ 	if (caa_unlikely(!URCU_TLS(cached_vtid)))
+-		URCU_TLS(cached_vtid) = gettid();
++		URCU_TLS(cached_vtid) = lttng_gettid();
+ 	value->u.s64 = URCU_TLS(cached_vtid);
+ }
+ 

--- a/packages/addons/addon-depends/system-tools-depends/lm_sensors/patches/lm_sensors-02-PR192.patch
+++ b/packages/addons/addon-depends/system-tools-depends/lm_sensors/patches/lm_sensors-02-PR192.patch
@@ -1,0 +1,48 @@
+From ee1aba92d670701b2aa3d798f1c3c84061eca554 Mon Sep 17 00:00:00 2001
+From: Lucas Magasweran <lucas.magasweran@ieee.org>
+Date: Wed, 7 Aug 2019 14:43:23 +0200
+Subject: [PATCH] makefile: use target arch when determining what programs to
+ compile
+
+`uname -m` lists the host machine architecture. To support cross-compilation
+the Makefile should detect the compiler's target architecture. This approach
+uses the `gcc`/`clang` compatible `-dumpmachine` option and parses the first
+word in the tuple representing the target architecture.
+
+Renaming `MACHINE` to `ARCH` to match cross-compiler conventions for
+specifying the target architecture (e.g.
+`make ARCH=arm CC=arm-linux-gnueabi-gcc`)
+
+Just like for PPC the `isadump` and `isaset` tools should not be compiled
+on ARM. This has the side affect of "fixing" the ARM build with glibc-2.30,
+which removed `sys/io.h` I/O port functions.
+
+Fixes #190
+
+Signed-off-by: Lucas Magasweran <lucas.magasweran@ieee.org>
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 2f5859f0..47ffe788 100644
+--- a/Makefile
++++ b/Makefile
+@@ -77,7 +77,7 @@ LIBINCLUDEDIR := $(INCLUDEDIR)/sensors
+ # manual pages will be installed.
+ MANDIR := $(PREFIX)/man
+ 
+-MACHINE := $(shell uname -m)
++ARCH := $(firstword $(subst -, ,$(shell $(CC) -dumpmachine)))
+ 
+ # Extra non-default programs to build; e.g., sensord
+ #PROG_EXTRA := sensord
+@@ -109,7 +109,7 @@ BUILD_STATIC_LIB := 1
+ SRCDIRS := lib prog/detect prog/pwm \
+            prog/sensors ${PROG_EXTRA:%=prog/%} etc
+ # Only build isadump and isaset on x86 machines.
+-ifneq (,$(findstring $(MACHINE), i386 i486 i586 i686 x86_64))
++ifneq (,$(findstring $(ARCH), i386 i486 i586 i686 x86_64))
+ SRCDIRS += prog/dump
+ endif
+ SRCDIRS += lib/test

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glibc"
-PKG_VERSION="2.29"
-PKG_SHA256="f3eeb8d57e25ca9fc13c2af3dae97754f9f643bc69229546828e3a240e2af04b"
+PKG_VERSION="2.30"
+PKG_SHA256="e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/libc/"
 PKG_URL="http://ftp.gnu.org/pub/gnu/glibc/$PKG_NAME-$PKG_VERSION.tar.xz"

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -108,18 +108,18 @@ post_makeinstall_target() {
 # cleanup
 # remove any programs we don't want/need, keeping only those we want
   for f in $(find $INSTALL/usr/bin -type f); do
-    listcontains "${GLIBC_INCLUDE_BIN}" "$(basename "${f}")" || rm -fr "${f}"
+    listcontains "${GLIBC_INCLUDE_BIN}" "$(basename "${f}")" || safe_remove "${f}"
   done
 
-  rm -rf $INSTALL/usr/lib/audit
-  rm -rf $INSTALL/usr/lib/glibc
-  rm -rf $INSTALL/usr/lib/libc_pic
-  rm -rf $INSTALL/usr/lib/*.o
-  rm -rf $INSTALL/usr/lib/*.map
-  rm -rf $INSTALL/var
+  safe_remove $INSTALL/usr/lib/audit
+  safe_remove $INSTALL/usr/lib/glibc
+  safe_remove $INSTALL/usr/lib/libc_pic
+  safe_remove $INSTALL/usr/lib/*.o
+  safe_remove $INSTALL/usr/lib/*.map
+  safe_remove $INSTALL/var
 
 # remove locales and charmaps
-  rm -rf $INSTALL/usr/share/i18n/charmaps
+  safe_remove $INSTALL/usr/share/i18n/charmaps
 
 # add UTF-8 charmap for Generic (charmap is needed for installer)
   if [ "$PROJECT" = "Generic" ]; then
@@ -129,7 +129,7 @@ post_makeinstall_target() {
   fi
 
   if [ ! "$GLIBC_LOCALES" = yes ]; then
-    rm -rf $INSTALL/usr/share/i18n/locales
+    safe_remove $INSTALL/usr/share/i18n/locales
 
     mkdir -p $INSTALL/usr/share/i18n/locales
       cp -PR $PKG_BUILD/localedata/locales/POSIX $INSTALL/usr/share/i18n/locales

--- a/packages/x11/lib/libpciaccess/package.mk
+++ b/packages/x11/lib/libpciaccess/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libpciaccess"
-PKG_VERSION="0.14"
-PKG_SHA256="3df543e12afd41fea8eac817e48cbfde5aed8817b81670a4e9e493bb2f5bf2a4"
+PKG_VERSION="0.16"
+PKG_SHA256="214c9d0d884fdd7375ec8da8dcb91a8d3169f263294c9a90c575bf1938b9f489"
 PKG_LICENSE="OSS"
 PKG_SITE="http://freedesktop.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
Start using `safe_remove`.

Need to bump `libpciaccess` due to removal of [`sys/io.h`](https://sourceware.org/glibc/wiki/Release/2.30#A.3Csys.2BAC8-io.h.3E_removed_on_32-bit_Arm)

Add patch for `lttng-ust` (used by `dotnet-runtime`)

Issues:
* ~`lm_sensors` doesn't currently build (https://github.com/lm-sensors/lm-sensors/issues/190)~ fixed by https://github.com/lm-sensors/lm-sensors/pull/192