### PR TITLE
busybox: add 'xpad' to SUSPEND_MODULES

### DIFF
--- a/packages/sysutils/busybox/config/suspend-modules.conf
+++ b/packages/sysutils/busybox/config/suspend-modules.conf
@@ -1,1 +1,1 @@
-SUSPEND_MODULES="jme asix anysee rtl8192se imon r8712u cx23885 cdc_acm ddbridge brcmfmac 8812au"
+SUSPEND_MODULES="jme asix anysee rtl8192se imon r8712u cx23885 cdc_acm ddbridge brcmfmac 8812au xpad"


### PR DESCRIPTION
In some systems, `xpad` times out during suspend:
```
[ 4470.773651] xpad 2-1.5:1.6: timed out waiting for output URB to complete, killing
[ 4475.892774] xpad 2-1.5:1.4: timed out waiting for output URB to complete, killing
[ 4481.011717] xpad 2-1.5:1.2: timed out waiting for output URB to complete, killing
[ 4486.130707] xpad 2-1.5:1.0: timed out waiting for output URB to complete, killing
[ 4486.288630] PM: suspend devices took 20.880 seconds
```
This causes suspend to take a long time to complete. Unloading/reloading
the module during suspend/wakeup successfully works around this issue.