### PR TITLE
multimedia-tools: drop mesa-demos and mpv

### DIFF
--- a/packages/addons/tools/multimedia-tools/changelog.txt
+++ b/packages/addons/tools/multimedia-tools/changelog.txt
@@ -1,3 +1,6 @@
+111
+- drop mesa-demos and mpv
+
 110
 - Add mpv
 

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="110"
+PKG_REV="111"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of multimedia tools and programs"
-PKG_LONGDESC="This bundle currently includes alsamixer, mediainfo, mesa-demos, mpg123, mpv, opencaster, squeezelite, tsdecrypt and tstools."
+PKG_LONGDESC="This bundle currently includes alsamixer, mediainfo, mpg123, opencaster, squeezelite, tsdecrypt and tstools."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Multimedia Tools"
@@ -22,15 +22,10 @@ PKG_DEPENDS_TARGET="toolchain \
                     alsa-utils \
                     mediainfo \
                     mpg123 \
-                    mpv-drmprime \
                     opencaster \
                     squeezelite \
                     tsdecrypt \
                     tstools"
-
-if [ "$TARGET_ARCH" = "x86_64" ]; then
-  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET mesa-demos"
-fi
 
 addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin/
@@ -40,16 +35,8 @@ addon() {
     # mediainfo
     cp -P $(get_build_dir mediainfo)/Project/GNU/CLI/mediainfo $ADDON_BUILD/$PKG_ADDON_ID/bin
 
-    # mesa-demos
-    cp -P $(get_build_dir mesa-demos)/.$TARGET_NAME/src/xdemos/glxdemo $ADDON_BUILD/$PKG_ADDON_ID/bin 2>/dev/null || :
-    cp -P $(get_build_dir mesa-demos)/.$TARGET_NAME/src/xdemos/glxgears $ADDON_BUILD/$PKG_ADDON_ID/bin 2>/dev/null || :
-    cp -P $(get_build_dir mesa-demos)/.$TARGET_NAME/src/xdemos/glxinfo $ADDON_BUILD/$PKG_ADDON_ID/bin 2>/dev/null || :
-
     # mpg123
     cp -P $(get_build_dir mpg123)/.install_pkg/usr/bin/* $ADDON_BUILD/$PKG_ADDON_ID/bin/
-
-    # mpv
-    cp -P $(get_build_dir mpv-drmprime)/.install_pkg/usr/bin/* $ADDON_BUILD/$PKG_ADDON_ID/bin/
 
     # opencaster
     cp -P $(get_build_dir opencaster)/.install_pkg/* $ADDON_BUILD/$PKG_ADDON_ID/bin/


### PR DESCRIPTION
both these programs are only useful for testing outside of kodi
so they shouldn't be in the multimedia-tools package

This also fixes RPi and RPi2 builds of multimedia-tools where mpv-drmprime build fails.

mesa-demos and mpv should be handled like other additional test packages (eg kmscube), for example being pulled in via ADDITIONAL_PACKAGES. Or, as an alternative, grouped into some "devtest" or similar addon.