### PR TITLE
Allwinner: Fix errors in U-Boot patches

### DIFF
--- a/projects/Allwinner/devices/H6/patches/u-boot/002-orange-pi-3-support.patch
+++ b/projects/Allwinner/devices/H6/patches/u-boot/002-orange-pi-3-support.patch
@@ -348,7 +348,7 @@ new file mode 100644
 index 0000000000..9a9cd28142
 --- /dev/null
 +++ b/configs/orangepi_3_defconfig
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,14 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_SPL=y

--- a/projects/Allwinner/patches/u-boot/001-sun8i-h3-Add-support-for-the-Beelink-x2-STB.patch
+++ b/projects/Allwinner/patches/u-boot/001-sun8i-h3-Add-support-for-the-Beelink-x2-STB.patch
@@ -258,7 +258,7 @@ new file mode 100644
 index 0000000000..6508e470a0
 --- /dev/null
 +++ b/configs/beelink_x2_defconfig
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,18 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_SPL=y
@@ -269,6 +269,7 @@ index 0000000000..6508e470a0
 +CONFIG_MMC_SUNXI_SLOT_EXTRA=2
 +CONFIG_NR_DRAM_BANKS=1
 +# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL_TEXT_BASE=0x60
 +# CONFIG_CMD_FLASH is not set
 +# CONFIG_SPL_DOS_PARTITION is not set
 +# CONFIG_SPL_EFI_PARTITION is not set


### PR DESCRIPTION
This fixes OrangePi 3 and Beelink X2 image creation after https://github.com/LibreELEC/LibreELEC.tv/pull/3756