### PR TITLE
buildsystem: validate UBOOT_SYSTEM at start of build

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -326,6 +326,7 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
 
     if [ -n "${DEVICE_BOARDS}" ]; then
       for UBOOT_SYSTEM in ${DEVICE_BOARDS}; do
+        echo "Installing u-boot for board ${UBOOT_SYSTEM}..."
 
         # Re-install u-boot package
         rm ${STAMPS_INSTALL}/u-boot/install_target

--- a/scripts/image
+++ b/scripts/image
@@ -10,6 +10,15 @@ unset _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL _DEBUG_DEPENDS_LIST _DEBUG_PACK
 . config/multithread
 . config/show_config
 
+# Validate UBOOT_SYSTEM if it is specified
+if [ "${BOOTLOADER}" = "u-boot" -a -n "${DEVICE}" ]; then
+  if [ -z "${UBOOT_SYSTEM}" ]; then
+    ${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} >/dev/null
+  elif [ "${UBOOT_VERSION}" != "vendor" ]; then
+    ${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb >/dev/null
+  fi
+fi
+
 show_config
 save_build_config
 
@@ -310,9 +319,12 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
     UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
     UUID_STORAGE="$(uuidgen)"
 
-    DEVICE_BOARDS=$(${SCRIPTS}/uboot_helper "${PROJECT}" "${DEVICE}")
+    DEVICE_BOARDS=
+    if [ "${BOOTLOADER}" = "u-boot" -a -z "${UBOOT_SYSTEM}" -a -n "${DEVICE}" ]; then
+      DEVICE_BOARDS=$(${SCRIPTS}/uboot_helper "${PROJECT}" "${DEVICE}")
+    fi
 
-    if [ "${BOOTLOADER}" = "u-boot" -a -z "${UBOOT_SYSTEM}" -a -n "${DEVICE}" -a -n "${DEVICE_BOARDS}" ]; then
+    if [ -n "${DEVICE_BOARDS}" ]; then
       for UBOOT_SYSTEM in ${DEVICE_BOARDS}; do
 
         # Re-install u-boot package

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -240,13 +240,13 @@ def usage(PROJECT=None, SOC=None, FILE=sys.stdout):
 
   print('Projects:', file=FILE)
   print('', file=FILE)
-  for project in devices:
+  for project in sorted(devices):
     if PROJECT is None or PROJECT == project:
       print('  %s:' % project, file=FILE)
-      for soc in devices[project]:
+      for soc in sorted(devices[project]):
         if SOC is None or SOC == soc:
           print('    %s:' % soc, file=FILE)
-          for board in devices[project][soc]:
+          for board in sorted(devices[project][soc]):
             print('      %s' % board, file=FILE)
           print('', file=FILE)
       print('', file=FILE)

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
+
+from __future__ import print_function
 import sys
 
 # When adding new devices to the list please keep them in alphabetical order
@@ -223,60 +227,76 @@ devices = \
   },
 }
 
-def usage():
-  print(' '.join(['Usage:', sys.argv[0], '<project>', '<soc>', '<board-name>', 'dtb|config']))
-  print(' '.join(['      ', sys.argv[0], '<project>', '<soc>']))
-  print(' '.join(['      ', sys.argv[0], '<project>']) + '\n')
-  print('Projects:' + '\n')
+def usage(PROJECT=None, SOC=None, FILE=sys.stdout):
+  print('Usage: %s <project> <soc> <board-name> dtb|config' % sys.argv[0], file=FILE)
+  print('       %s <project> <soc>' % sys.argv[0], file=FILE)
+  print('       %s <project>' % sys.argv[0], file=FILE)
+  print('', file=FILE)
+
+  if PROJECT and PROJECT not in devices:
+    PROJECT = SOC = None
+  if PROJECT and SOC and SOC not in devices[PROJECT]:
+    SOC = None
+
+  print('Projects:', file=FILE)
+  print('', file=FILE)
   for project in devices:
-    print('  ' + project + ':')
-    for soc in devices[project]:
-      print('    ' + soc + ':')
-      for board in devices[project][soc]:
-        print('      ' + board)
-      print('')
-    print('')
+    if PROJECT is None or PROJECT == project:
+      print('  %s:' % project, file=FILE)
+      for soc in devices[project]:
+        if SOC is None or SOC == soc:
+          print('    %s:' % soc, file=FILE)
+          for board in devices[project][soc]:
+            print('      %s' % board, file=FILE)
+          print('', file=FILE)
+      print('', file=FILE)
+
+def exit_error(msg, PROJECT=None, SOC=None):
+  print(msg, file=sys.stderr)
+  print('', file=sys.stderr)
+  usage(PROJECT=PROJECT, SOC=SOC, FILE=sys.stderr)
+  sys.exit(1)
+
+# Basic argument validation
+if len(sys.argv) == 2 and sys.argv[1] in ['help', 'usage']:
+  usage()
+  sys.exit(0)
+
+if len(sys.argv) > 1 and sys.argv[1] not in devices:
+  exit_error('Invalid project: %s' % sys.argv[1])
+
+if len(sys.argv) > 2 and sys.argv[2] not in devices[sys.argv[1]]:
+  exit_error('Invalid soc: %s' % sys.argv[2], PROJECT=sys.argv[1])
+
+if len(sys.argv) > 3 and sys.argv[3] not in devices[sys.argv[1]][sys.argv[2]]:
+  exit_error('Invalid board-name: %s' % sys.argv[3], PROJECT=sys.argv[1], SOC=sys.argv[2])
+
+if len(sys.argv) == 4:
+  exit_error('Invalid option: must specify dtb or config', PROJECT=sys.argv[1], SOC=sys.argv[2])
+elif len(sys.argv) > 4 and sys.argv[4] not in ['dtb', 'config']:
+  exit_error('Invalid option: %s' % sys.argv[4], PROJECT=sys.argv[1], SOC=sys.argv[2])
+
+if len(sys.argv) > 5:
+  exit_error('Invalid number of arguments: %s' % ' '.join(sys.argv[1:]), PROJECT=sys.argv[1], SOC=sys.argv[2])
 
 # Get dtb or u-boot config for a given project, soc, and board
-# ./scripts/uboot_helper project device board_name dtb
+# ./scripts/uboot_helper project device board-name dtb|config
 if len(sys.argv) == 5:
-  if sys.argv[1] in devices:
-    if sys.argv[2] in devices[sys.argv[1]]:
-      if sys.argv[3] in devices[sys.argv[1]][sys.argv[2]]:
-        if sys.argv[4] in ['dtb', 'config']:
-          print(devices[sys.argv[1]][sys.argv[2]][sys.argv[3]][sys.argv[4]])
-          sys.exit(0)
+  print(devices[sys.argv[1]][sys.argv[2]][sys.argv[3]][sys.argv[4]])
 
 # List boards supported by a given project and soc
 # ./scripts/uboot_helper project device
 elif len(sys.argv) == 3:
-  if sys.argv[1] in devices:
-    if sys.argv[2] in devices[sys.argv[1]]:
-      boards = []
-      for board in sorted(devices[sys.argv[1]][sys.argv[2]]):
-          boards.append(board)
-      print(' '.join(boards))
-  sys.exit(0)
+  print(' '.join([board for board in sorted(devices[sys.argv[1]][sys.argv[2]])]))
 
 # List socs supported by a given project
 # ./scripts/uboot_helper project
 elif len(sys.argv) == 2:
-  if sys.argv[1] in ['help', 'usage']:
-    usage()
-  elif sys.argv[1] in devices:
-    socs = []
-    for soc in sorted(devices[sys.argv[1]]):
-      socs.append(soc)
-    print(' '.join(socs))
-  sys.exit(0)
+  print(' '.join([soc for soc in sorted(devices[sys.argv[1]])]))
 
 # List projects
 # ./scripts/uboot_helper
 elif len(sys.argv) == 1:
-  projects = []
-  for project in sorted(devices):
-    projects.append(project)
-  print(' '.join(projects))
-  sys.exit(0)
+  print(' '.join([project for project in sorted(devices)]))
 
-usage()
+sys.exit(0)


### PR DESCRIPTION
Update `scripts/uboot_helper`:

1) Exit with error (1) when invalid arguments are specified
2) Reorganise to simplify/improve validation
3) Redirect errors (including `usage`) to stderr
4) Make `print()` statements more Pythonic
5) Improve `usage` usability by listing information only for the matching project and/or SOC (rather than listing everything)

Previously, calling `scripts/boot_helper` with invalid Project/Device would output no result (ie. no boards would be listed). Now, it will exit with an error (either invalid project or invalid soc), so it's important to not speculatively call `scripts/uboot_helper` with an invalid project/device in order to determine if any boards require processing (`scripts/image` has been updated to address this).

`scripts/image` will now abort if an invalid `UBOOT_SYSTEM` is specified, or an invalid project/device is specified for a u-boot build.