### PR TITLE
[le10] use a larger console font on HiDPI displays

### DIFF
--- a/packages/sysutils/busybox/config/busybox-init.conf
+++ b/packages/sysutils/busybox/config/busybox-init.conf
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.31.0
-# Wed Jun 12 00:51:44 2019
+# Tue Aug 13 17:29:50 2019
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -365,10 +365,14 @@ CONFIG_CLEAR=y
 # CONFIG_FGCONSOLE is not set
 # CONFIG_KBD_MODE is not set
 # CONFIG_LOADFONT is not set
-# CONFIG_SETFONT is not set
+CONFIG_SETFONT=y
 # CONFIG_FEATURE_SETFONT_TEXTUAL_MAP is not set
-CONFIG_DEFAULT_SETFONT_DIR=""
-# CONFIG_FEATURE_LOADFONT_PSF2 is not set
+CONFIG_DEFAULT_SETFONT_DIR="/usr/share"
+
+#
+# Common options for loadfont and setfont
+#
+CONFIG_FEATURE_LOADFONT_PSF2=y
 # CONFIG_FEATURE_LOADFONT_RAW is not set
 # CONFIG_LOADKMAP is not set
 # CONFIG_OPENVT is not set

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -367,6 +367,18 @@ load_modules() {
   done
 }
 
+set_consolefont() {
+  local vres
+
+  progress "Set console font"
+  if [ -e /dev/fb0 ]; then
+    vres="$(fbset 2>/dev/null | awk '/geometry/ { print $3 }')"
+    if [ $vres -gt 1080 ]; then
+      setfont -C /dev/tty0 ter-v32b.psf
+    fi
+  fi
+}
+
 load_splash() {
   local set_default_res=no
   local vres
@@ -1052,6 +1064,7 @@ debug_msg "Unique identifier for this client: ${MACHINE_UID:-NOT AVAILABLE}"
 # main boot sequence
 for BOOT_STEP in \
     load_modules \
+    set_consolefont \
     check_disks \
     mount_flash \
     update_bootmenu \

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -48,6 +48,8 @@ LIVE="no"
 
 BREAK_TRIPPED="no"
 
+BIGFONT="1080"
+
 # Get a serial number if present (eg. RPi) otherwise use MAC address from eth0
 MACHINE_UID="$(cat /proc/cpuinfo | awk '/^Serial/{s=$3; gsub ("^0*","",s); print s}')"
 [ -z "$MACHINE_UID" ] && MACHINE_UID="$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d :)"
@@ -373,7 +375,7 @@ set_consolefont() {
   progress "Set console font"
   if [ -e /dev/fb0 ]; then
     vres="$(fbset 2>/dev/null | awk '/geometry/ { print $3 }')"
-    if [ $vres -gt 1080 ]; then
+    if [ $vres -gt "$BIGFONT" ]; then
       setfont -C /dev/tty0 ter-v32b.psf
     fi
   fi
@@ -1040,6 +1042,9 @@ for arg in $(cat /proc/cmdline); do
       ;;
     break=*)
       BREAK="${arg#*=}"
+      ;;
+    bigfont=*)
+      BIGFONT="${arg#*=}"
       ;;
   esac
 done

--- a/packages/sysutils/terminus-font/package.mk
+++ b/packages/sysutils/terminus-font/package.mk
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019 Matthias Reichl <hias@horus.com>
+
+PKG_NAME="terminus-font"
+PKG_VERSION="4.48"
+PKG_SHA256="34799c8dd5cec7db8016b4a615820dfb43b395575afbb24fc17ee19c869c94af"
+PKG_LICENSE="OFL1_1"
+PKG_SITE="https://terminus-font.sourceforge.net/"
+PKG_URL="https://downloads.sourceforge.net/project/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_INIT="toolchain Python3:host"
+PKG_LONGDESC="This package contains the Terminus Font"
+PKG_TOOLCHAIN="manual"
+
+pre_configure_init() {
+  cd $PKG_BUILD
+  rm -rf .${TARGET_NAME}-${TARGET}
+}
+
+configure_init() {
+  ./configure INT=${TOOLCHAIN}/bin/python3
+}
+
+make_init() {
+  make ter-v32b.psf
+}
+
+makeinstall_init() {
+  mkdir -p ${INSTALL}/usr/share/consolefonts
+    cp ter-v32b.psf ${INSTALL}/usr/share/consolefonts
+}

--- a/packages/virtual/initramfs/package.mk
+++ b/packages/virtual/initramfs/package.mk
@@ -7,7 +7,7 @@ PKG_VERSION=""
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain libc:init busybox:init plymouth-lite:init util-linux:init e2fsprogs:init dosfstools:init fakeroot:host"
+PKG_DEPENDS_TARGET="toolchain libc:init busybox:init plymouth-lite:init util-linux:init e2fsprogs:init dosfstools:init fakeroot:host terminus-font:init"
 PKG_SECTION="virtual"
 PKG_LONGDESC="debug is a Metapackage for installing initramfs"
 


### PR DESCRIPTION
Console output (eg during an update or if a filesystem error occurred) is almost unreadable on 4k screens.

Use the terminus 16x32 font instead of the default built-in 8x16 font on display with more than 1080 lines. This is done very eary during init, after load_modules, so that errors from check_disks and subsequent init steps can be properly seen.

Runtime tested with RPi4 connected to 4k TV