### PR TITLE
NXP/iMX6: drop matrix-q board

### DIFF
--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -133,10 +133,6 @@ devices = \
         'dtb': 'imx6q-cubox-i.dtb',
         'config': 'mx6cuboxi_defconfig'
       },
-      'matrix-q': {
-        'dtb': 'imx6q-tbs2910.dtb',
-        'config': 'tbs2910_defconfig'
-      },
       'udoo-dl': {
         'dtb': 'imx6dl-udoo.dtb',
         'config': 'udoo_defconfig'


### PR DESCRIPTION
`matrix-q` doesn't build as it seems to generate `u-boot.imx` not `u-boot.img`.

```
  COPY    u-boot.bin
  CFGS    u-boot.cfgout
  MKIMAGE u-boot.imx
===================== WARNING ======================
This board does not use CONFIG_DM_PCI Please update
the board to use CONFIG_DM_PCI before the v2019.07 release.
Failure to update by the deadline may result in board removal.
See doc/driver-model/MIGRATION.txt for more info.
====================================================
===================== WARNING ======================
This board does not use CONFIG_DM_VIDEO Please update
the board to use CONFIG_DM_VIDEO before the v2019.07 release.
Failure to update by the deadline may result in board removal.
See doc/driver-model/MIGRATION.txt for more info.
====================================================
===================== WARNING ======================
CONFIG_OF_EMBED is enabled. This option should only
be used for debugging purposes. Please use
CONFIG_OF_SEPARATE for boards in mainline.
See doc/README.fdt-control for more info.
====================================================
  CFGCHK  u-boot.cfg
make[1]: Leaving directory '/home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-iMX6.arm-9.80-devel/u-boot-2019.07'
cp: cannot stat 'u-boot.img': No such file or directory
Makefile:12: recipe for target 'image' failed
make: *** [image] Error 1
```

@lrusak from Slack:
> @milhouse I think the matrix-q is the only one that is broken when looking at the u-boot source code. If that's the case we can just remove it. The others should work
