### PR TITLE
systemd: fix swap partition handling when multiple present

### DIFF
--- a/packages/sysutils/util-linux/scripts/mount-swap
+++ b/packages/sysutils/util-linux/scripts/mount-swap
@@ -34,7 +34,7 @@ case $1 in
   mount)
     [ -z "$SWAP" -a -f "$SWAPFILE" ] && SWAP=$SWAPFILE
     for i in $SWAP; do
-      swapon -p 10000 $SWAP
+      swapon -p 10000 $i
     done
     ;;
   unmount)


### PR DESCRIPTION
When multiple swap partition are present, `$SWAP` contains multiple lines.  A for loop already existed to handle this, but the original variable was still used in the command in the body of the loop.