### PR TITLE
linux (default, RPi): fix perf build with glibc 2.30

### DIFF
--- a/packages/linux/patches/default/linux-001-backport-tools-build-check-if-gettid-is-available.patch
+++ b/packages/linux/patches/default/linux-001-backport-tools-build-check-if-gettid-is-available.patch
@@ -1,0 +1,170 @@
+From 4541a8bb13a86e504416a13360c8dc64d2fd612a Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Thu, 13 Jun 2019 12:04:19 -0300
+Subject: [PATCH] tools build: Check if gettid() is available before providing
+ helper
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Laura reported that the perf build failed in fedora when we got a glibc
+that provides gettid(), which I reproduced using fedora rawhide with the
+glibc-devel-2.29.9000-26.fc31.x86_64 package.
+
+Add a feature check to avoid providing a gettid() helper in such
+systems.
+
+On a fedora rawhide system with this patch applied we now get:
+
+  [root@7a5f55352234 perf]# grep gettid /tmp/build/perf/FEATURE-DUMP
+  feature-gettid=1
+  [root@7a5f55352234 perf]# cat /tmp/build/perf/feature/test-gettid.make.output
+  [root@7a5f55352234 perf]# ldd /tmp/build/perf/feature/test-gettid.bin
+          linux-vdso.so.1 (0x00007ffc6b1f6000)
+          libc.so.6 => /lib64/libc.so.6 (0x00007f04e0a74000)
+          /lib64/ld-linux-x86-64.so.2 (0x00007f04e0c47000)
+  [root@7a5f55352234 perf]# nm /tmp/build/perf/feature/test-gettid.bin | grep -w gettid
+                   U gettid@@GLIBC_2.30
+  [root@7a5f55352234 perf]#
+
+While on a fedora:29 system:
+
+  [acme@quaco perf]$ grep gettid /tmp/build/perf/FEATURE-DUMP
+  feature-gettid=0
+  [acme@quaco perf]$ cat /tmp/build/perf/feature/test-gettid.make.output
+  test-gettid.c: In function ‘main’:
+  test-gettid.c:8:9: error: implicit declaration of function ‘gettid’; did you mean ‘getgid’? [-Werror=implicit-function-declaration]
+    return gettid();
+           ^~~~~~
+           getgid
+  cc1: all warnings being treated as errors
+  [acme@quaco perf]$
+
+Reported-by: Laura Abbott <labbott@redhat.com>
+Tested-by: Laura Abbott <labbott@redhat.com>
+Acked-by: Jiri Olsa <jolsa@kernel.org>
+Cc: Adrian Hunter <adrian.hunter@intel.com>
+Cc: Florian Weimer <fweimer@redhat.com>
+Cc: Namhyung Kim <namhyung@kernel.org>
+Cc: Stephane Eranian <eranian@google.com>
+Link: https://lkml.kernel.org/n/tip-yfy3ch53agmklwu9o7rlgf9c@git.kernel.org
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/build/Makefile.feature      |  1 +
+ tools/build/feature/Makefile      |  4 ++++
+ tools/build/feature/test-all.c    |  5 +++++
+ tools/build/feature/test-gettid.c | 11 +++++++++++
+ tools/perf/Makefile.config        |  4 ++++
+ tools/perf/jvmti/jvmti_agent.c    |  2 ++
+ 6 files changed, 27 insertions(+)
+ create mode 100644 tools/build/feature/test-gettid.c
+
+diff --git a/tools/build/Makefile.feature b/tools/build/Makefile.feature
+index 3b24231c58a2b..50377cc2f5f99 100644
+--- a/tools/build/Makefile.feature
++++ b/tools/build/Makefile.feature
+@@ -36,6 +36,7 @@ FEATURE_TESTS_BASIC :=                  \
+         fortify-source                  \
+         sync-compare-and-swap           \
+         get_current_dir_name            \
++        gettid				\
+         glibc                           \
+         gtk2                            \
+         gtk2-infobar                    \
+diff --git a/tools/build/feature/Makefile b/tools/build/feature/Makefile
+index 4b8244ee65ce6..523ee42db0c8d 100644
+--- a/tools/build/feature/Makefile
++++ b/tools/build/feature/Makefile
+@@ -54,6 +54,7 @@ FILES=                                          \
+          test-get_cpuid.bin                     \
+          test-sdt.bin                           \
+          test-cxx.bin                           \
++         test-gettid.bin			\
+          test-jvmti.bin				\
+          test-jvmti-cmlr.bin			\
+          test-sched_getcpu.bin			\
+@@ -267,6 +268,9 @@ $(OUTPUT)test-sdt.bin:
+ $(OUTPUT)test-cxx.bin:
+ 	$(BUILDXX) -std=gnu++11
+ 
++$(OUTPUT)test-gettid.bin:
++	$(BUILD)
++
+ $(OUTPUT)test-jvmti.bin:
+ 	$(BUILD)
+ 
+diff --git a/tools/build/feature/test-all.c b/tools/build/feature/test-all.c
+index a59c537050934..3b3d5d72124a5 100644
+--- a/tools/build/feature/test-all.c
++++ b/tools/build/feature/test-all.c
+@@ -38,6 +38,10 @@
+ # include "test-get_current_dir_name.c"
+ #undef main
+ 
++#define main main_test_gettid
++# include "test-gettid.c"
++#undef main
++
+ #define main main_test_glibc
+ # include "test-glibc.c"
+ #undef main
+@@ -195,6 +199,7 @@ int main(int argc, char *argv[])
+ 	main_test_libelf();
+ 	main_test_libelf_mmap();
+ 	main_test_get_current_dir_name();
++	main_test_gettid();
+ 	main_test_glibc();
+ 	main_test_dwarf();
+ 	main_test_dwarf_getlocations();
+diff --git a/tools/build/feature/test-gettid.c b/tools/build/feature/test-gettid.c
+new file mode 100644
+index 0000000000000..ef24e42d3f1b8
+--- /dev/null
++++ b/tools/build/feature/test-gettid.c
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: GPL-2.0
++// Copyright (C) 2019, Red Hat Inc, Arnaldo Carvalho de Melo <acme@redhat.com>
++#define _GNU_SOURCE
++#include <unistd.h>
++
++int main(void)
++{
++	return gettid();
++}
++
++#undef _GNU_SOURCE
+diff --git a/tools/perf/Makefile.config b/tools/perf/Makefile.config
+index 51dd00f65709d..5f16a20cae86a 100644
+--- a/tools/perf/Makefile.config
++++ b/tools/perf/Makefile.config
+@@ -332,6 +332,10 @@ ifeq ($(feature-get_current_dir_name), 1)
+   CFLAGS += -DHAVE_GET_CURRENT_DIR_NAME
+ endif
+ 
++ifeq ($(feature-gettid), 1)
++  CFLAGS += -DHAVE_GETTID
++endif
++
+ ifdef NO_LIBELF
+   NO_DWARF := 1
+   NO_DEMANGLE := 1
+diff --git a/tools/perf/jvmti/jvmti_agent.c b/tools/perf/jvmti/jvmti_agent.c
+index f7eb63cbbc655..88108598d6e94 100644
+--- a/tools/perf/jvmti/jvmti_agent.c
++++ b/tools/perf/jvmti/jvmti_agent.c
+@@ -45,10 +45,12 @@
+ static char jit_path[PATH_MAX];
+ static void *marker_addr;
+ 
++#ifndef HAVE_GETTID
+ static inline pid_t gettid(void)
+ {
+ 	return (pid_t)syscall(__NR_gettid);
+ }
++#endif
+ 
+ static int get_e_machine(struct jitheader *hdr)
+ {
+-- 
+2.20.1
+

--- a/packages/linux/patches/raspberrypi/linux-001-backport-tools-build-check-if-gettid-is-available.patch
+++ b/packages/linux/patches/raspberrypi/linux-001-backport-tools-build-check-if-gettid-is-available.patch
@@ -1,0 +1,170 @@
+From 4541a8bb13a86e504416a13360c8dc64d2fd612a Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Thu, 13 Jun 2019 12:04:19 -0300
+Subject: [PATCH] tools build: Check if gettid() is available before providing
+ helper
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Laura reported that the perf build failed in fedora when we got a glibc
+that provides gettid(), which I reproduced using fedora rawhide with the
+glibc-devel-2.29.9000-26.fc31.x86_64 package.
+
+Add a feature check to avoid providing a gettid() helper in such
+systems.
+
+On a fedora rawhide system with this patch applied we now get:
+
+  [root@7a5f55352234 perf]# grep gettid /tmp/build/perf/FEATURE-DUMP
+  feature-gettid=1
+  [root@7a5f55352234 perf]# cat /tmp/build/perf/feature/test-gettid.make.output
+  [root@7a5f55352234 perf]# ldd /tmp/build/perf/feature/test-gettid.bin
+          linux-vdso.so.1 (0x00007ffc6b1f6000)
+          libc.so.6 => /lib64/libc.so.6 (0x00007f04e0a74000)
+          /lib64/ld-linux-x86-64.so.2 (0x00007f04e0c47000)
+  [root@7a5f55352234 perf]# nm /tmp/build/perf/feature/test-gettid.bin | grep -w gettid
+                   U gettid@@GLIBC_2.30
+  [root@7a5f55352234 perf]#
+
+While on a fedora:29 system:
+
+  [acme@quaco perf]$ grep gettid /tmp/build/perf/FEATURE-DUMP
+  feature-gettid=0
+  [acme@quaco perf]$ cat /tmp/build/perf/feature/test-gettid.make.output
+  test-gettid.c: In function ‘main’:
+  test-gettid.c:8:9: error: implicit declaration of function ‘gettid’; did you mean ‘getgid’? [-Werror=implicit-function-declaration]
+    return gettid();
+           ^~~~~~
+           getgid
+  cc1: all warnings being treated as errors
+  [acme@quaco perf]$
+
+Reported-by: Laura Abbott <labbott@redhat.com>
+Tested-by: Laura Abbott <labbott@redhat.com>
+Acked-by: Jiri Olsa <jolsa@kernel.org>
+Cc: Adrian Hunter <adrian.hunter@intel.com>
+Cc: Florian Weimer <fweimer@redhat.com>
+Cc: Namhyung Kim <namhyung@kernel.org>
+Cc: Stephane Eranian <eranian@google.com>
+Link: https://lkml.kernel.org/n/tip-yfy3ch53agmklwu9o7rlgf9c@git.kernel.org
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/build/Makefile.feature      |  1 +
+ tools/build/feature/Makefile      |  4 ++++
+ tools/build/feature/test-all.c    |  5 +++++
+ tools/build/feature/test-gettid.c | 11 +++++++++++
+ tools/perf/Makefile.config        |  4 ++++
+ tools/perf/jvmti/jvmti_agent.c    |  2 ++
+ 6 files changed, 27 insertions(+)
+ create mode 100644 tools/build/feature/test-gettid.c
+
+diff --git a/tools/build/Makefile.feature b/tools/build/Makefile.feature
+index 3b24231c58a2b..50377cc2f5f99 100644
+--- a/tools/build/Makefile.feature
++++ b/tools/build/Makefile.feature
+@@ -36,6 +36,7 @@ FEATURE_TESTS_BASIC :=                  \
+         fortify-source                  \
+         sync-compare-and-swap           \
+         get_current_dir_name            \
++        gettid				\
+         glibc                           \
+         gtk2                            \
+         gtk2-infobar                    \
+diff --git a/tools/build/feature/Makefile b/tools/build/feature/Makefile
+index 4b8244ee65ce6..523ee42db0c8d 100644
+--- a/tools/build/feature/Makefile
++++ b/tools/build/feature/Makefile
+@@ -54,6 +54,7 @@ FILES=                                          \
+          test-get_cpuid.bin                     \
+          test-sdt.bin                           \
+          test-cxx.bin                           \
++         test-gettid.bin			\
+          test-jvmti.bin				\
+          test-jvmti-cmlr.bin			\
+          test-sched_getcpu.bin			\
+@@ -267,6 +268,9 @@ $(OUTPUT)test-sdt.bin:
+ $(OUTPUT)test-cxx.bin:
+ 	$(BUILDXX) -std=gnu++11
+ 
++$(OUTPUT)test-gettid.bin:
++	$(BUILD)
++
+ $(OUTPUT)test-jvmti.bin:
+ 	$(BUILD)
+ 
+diff --git a/tools/build/feature/test-all.c b/tools/build/feature/test-all.c
+index a59c537050934..3b3d5d72124a5 100644
+--- a/tools/build/feature/test-all.c
++++ b/tools/build/feature/test-all.c
+@@ -38,6 +38,10 @@
+ # include "test-get_current_dir_name.c"
+ #undef main
+ 
++#define main main_test_gettid
++# include "test-gettid.c"
++#undef main
++
+ #define main main_test_glibc
+ # include "test-glibc.c"
+ #undef main
+@@ -195,6 +199,7 @@ int main(int argc, char *argv[])
+ 	main_test_libelf();
+ 	main_test_libelf_mmap();
+ 	main_test_get_current_dir_name();
++	main_test_gettid();
+ 	main_test_glibc();
+ 	main_test_dwarf();
+ 	main_test_dwarf_getlocations();
+diff --git a/tools/build/feature/test-gettid.c b/tools/build/feature/test-gettid.c
+new file mode 100644
+index 0000000000000..ef24e42d3f1b8
+--- /dev/null
++++ b/tools/build/feature/test-gettid.c
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: GPL-2.0
++// Copyright (C) 2019, Red Hat Inc, Arnaldo Carvalho de Melo <acme@redhat.com>
++#define _GNU_SOURCE
++#include <unistd.h>
++
++int main(void)
++{
++	return gettid();
++}
++
++#undef _GNU_SOURCE
+diff --git a/tools/perf/Makefile.config b/tools/perf/Makefile.config
+index 51dd00f65709d..5f16a20cae86a 100644
+--- a/tools/perf/Makefile.config
++++ b/tools/perf/Makefile.config
+@@ -332,6 +332,10 @@ ifeq ($(feature-get_current_dir_name), 1)
+   CFLAGS += -DHAVE_GET_CURRENT_DIR_NAME
+ endif
+ 
++ifeq ($(feature-gettid), 1)
++  CFLAGS += -DHAVE_GETTID
++endif
++
+ ifdef NO_LIBELF
+   NO_DWARF := 1
+   NO_DEMANGLE := 1
+diff --git a/tools/perf/jvmti/jvmti_agent.c b/tools/perf/jvmti/jvmti_agent.c
+index f7eb63cbbc655..88108598d6e94 100644
+--- a/tools/perf/jvmti/jvmti_agent.c
++++ b/tools/perf/jvmti/jvmti_agent.c
+@@ -45,10 +45,12 @@
+ static char jit_path[PATH_MAX];
+ static void *marker_addr;
+ 
++#ifndef HAVE_GETTID
+ static inline pid_t gettid(void)
+ {
+ 	return (pid_t)syscall(__NR_gettid);
+ }
++#endif
+ 
+ static int get_e_machine(struct jitheader *hdr)
+ {
+-- 
+2.20.1
+


### PR DESCRIPTION
perf build fails because glibc 2.30 includes a gettid() function:

```
jvmti/jvmti_agent.c:48:21: error: static declaration of 'gettid' follows non-static declaration
   48 | static inline pid_t gettid(void)
      |                     ^~~~~~
In file included from /home/hias/rpi/libreelec-master/build.LibreELEC-RPi4.arm-9.80-devel/toolchain/armv8a-libreelec-linux-gnueabi/sysroot/usr/include/unistd.h:1170,
                 from jvmti/jvmti_agent.c:33:
/home/hias/rpi/libreelec-master/build.LibreELEC-RPi4.arm-9.80-devel/toolchain/armv8a-libreelec-linux-gnueabi/sysroot/usr/include/bits/unistd_ext.h:34:16: note: previous declaration of 'gettid' was here
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~
```

This has already been fixed in the 5.3 kernel tree. Add a backport
commit until the fix dribbles down into stable 5.2 or we swtich to 5.3.