### PR TITLE
RPi btuart: Sync with upstream 0.1.11

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/scripts/rpi-btuart
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/scripts/rpi-btuart
@@ -1,14 +1,22 @@
 #!/bin/sh
 
 HCIATTACH=/usr/bin/hciattach
-SERIAL=$(awk '/^Serial/{ print $3 }' /proc/cpuinfo)
-B1=${SERIAL:10:2}
-B2=${SERIAL:12:2}
-B3=${SERIAL:14:2}
-BDADDR=$(printf b8:27:eb:%02x:%02x:%02x $((0x$B1 ^ 0xaa)) $((0x$B2 ^ 0xaa)) $((0x$B3 ^ 0xaa)))
+if grep -q "Pi 4" /proc/device-tree/model; then
+  BDADDR=
+else
+  SERIAL=$(cat /proc/device-tree/serial-number | cut -c9-)
+  B1=${SERIAL:2:2}
+  B2=${SERIAL:4:2}
+  B3=${SERIAL:6:2}
+  BDADDR=$(printf b8:27:eb:%02x:%02x:%02x $((0x$B1 ^ 0xaa)) $((0x$B2 ^ 0xaa)) $((0x$B3 ^ 0xaa)))
+fi
 
-if [ "$(cat /proc/device-tree/aliases/uart0)" = "$(cat /proc/device-tree/aliases/serial1)" ] ; then
-  if [ "$(wc -c /proc/device-tree/soc/gpio@7e200000/uart0_pins/brcm\,pins | cut -f 1 -d ' ')" = "16" ] ; then
+uart0="$(cat /proc/device-tree/aliases/uart0)"
+serial1="$(cat /proc/device-tree/aliases/serial1)"
+
+if [ "$uart0" = "$serial1" ] ; then
+  uart0_pins="$(wc -c /proc/device-tree/soc/gpio@7e200000/uart0_pins/brcm\,pins | cut -f 1 -d ' ')"
+  if [ "$uart0_pins" = "16" ] ; then
     $HCIATTACH /dev/serial1 bcm43xx 3000000 flow - $BDADDR
   else
     $HCIATTACH /dev/serial1 bcm43xx 921600 noflow - $BDADDR


### PR DESCRIPTION
https://github.com/RPi-Distro/pi-bluetooth/commit/d596d06cce9b7cdee857d54b55004a427b6a6dfc

* Don't override the BT address on Pi 4

From @popcornmix:
> I think Pi4 has separate BT mac address in OTP. Earlier Pi's just used bits from serial number. Probably no huge effect, but it's more correct to include that patch.