### PR TITLE
freetype: update to freetype-2.10.1

### DIFF
--- a/packages/print/freetype/package.mk
+++ b/packages/print/freetype/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="freetype"
-PKG_VERSION="2.10.0"
-PKG_SHA256="fccc62928c65192fff6c98847233b28eb7ce05f12d2fea3f6cc90e8b4e5fbe06"
+PKG_VERSION="2.10.1"
+PKG_SHA256="16dbfa488a21fe827dc27eaf708f42f7aa3bb997d745d31a19781628c36ba26f"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freetype.org"
-PKG_URL="http://download.savannah.gnu.org/releases/freetype/$PKG_NAME-$PKG_VERSION.tar.bz2"
+PKG_URL="http://download.savannah.gnu.org/releases/freetype/freetype-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain zlib libpng"
 PKG_LONGDESC="The FreeType engine is a free and portable TrueType font rendering engine."


### PR DESCRIPTION
Stay in sync with Kodi: https://github.com/xbmc/xbmc/pull/16575

Changes: https://sourceforge.net/projects/freetype/files/freetype2/2.10.1/

Switch to xz as bz2 is not available.

Not yet build tested.