### PR TITLE
[le92] binary addons: update to latest Leia versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gme"
-PKG_VERSION="2.0.0-Leia"
-PKG_SHA256="cc6da8989d54b32c4ed575b2c980cc6339264b019c74f462f7cfb7817d4ca95a"
-PKG_REV="4"
+PKG_VERSION="2.0.1-Leia"
+PKG_SHA256="b40ba2349f132997ae9c728ec6a23f0353875d080b86b1f95d383a5f30eeb681"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gme"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gsf"
-PKG_VERSION="2.0.0-Leia"
-PKG_SHA256="595b262068586a3317a65c34a67c9bd47d799a344cbb738d120ffb76754e219d"
-PKG_REV="4"
+PKG_VERSION="2.0.1-Leia"
+PKG_SHA256="097690480fcc2dc19b0576f46be70dff83ce264d10821d2f92315cdf04c8518a"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.vgmstream"
-PKG_VERSION="1.1.3-Leia"
-PKG_SHA256="ff2d7e506c9239068ff47db376f79bdf6506976d1690d670fc90885458987549"
-PKG_REV="4"
+PKG_VERSION="1.1.4-Leia"
+PKG_SHA256="6f1940d2a0607342cba8cffc0beb7c78caae5995c2d554a6079f4849997da7ba"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.vgmstream"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.wsr"
-PKG_VERSION="2.0.0-Leia"
-PKG_SHA256="6fe9b16657ed2d9ae868aafec009ac57250d464981ce9a10b1bdc124680f7a67"
-PKG_REV="4"
+PKG_VERSION="2.0.1-Leia"
+PKG_SHA256="e69a8e21441257204e9e93c0e142fd35fbab971f0df2f20bdfc4aba45bb8c346"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.wsr"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="2.3.22-Leia"
-PKG_SHA256="2c21abeead9dc172de297c47930f62050f382c449682cbdb6c70c7e19a2d561b"
-PKG_REV="2"
+PKG_VERSION="2.4.2-Leia"
+PKG_SHA256="e47263240ac9276546ead439ba14ee26c3f3b45f2882351a9081e5502e296329"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/peak3d/inputstream.adaptive"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="3.7.2-Leia"
-PKG_SHA256="0f2c64c8e4faa6a9bcaade7a4dbc27c787ec4e8350fdf286dbe1c8bdcfc074b9"
+PKG_VERSION="3.8.1-Leia"
+PKG_SHA256="4e1af2fbe40f297aa0fd72dad038783ec551aa7b6855822e856a041cd3916a1c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="5.10.8"
-PKG_SHA256="44125e9f2efe5ea27402e6eec1b16559bf49ecaecb246f4a728dc004da5c4a7b"
+PKG_VERSION="5.10.9-Leia"
+PKG_SHA256="f6642c115e05f8e505dfe04870cfa6dcbc3d66b9e54c96f7ea514a50d5943f33"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
inputstream.adaptive and pvr addon updates could be important.

haven't looked at changelogs, only build tested for RPi4