### PR TITLE
rpi-eeprom: update to latest rpi-eeprom

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="a799a10652567cfd327fd588cf0e180d9962cf61"
-PKG_SHA256="d72329051ac748cb6764597b36b2a6ed965f9b95c11a224b1a92ddf27db721be"
+PKG_VERSION="6dbbbed01f8173b346319b5bd501134920678403"
+PKG_SHA256="9c1de9d5dbf0bbf8296651a350bbe8091af1e2426f415253167b53ea2bccf200"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -568,10 +568,13 @@ mount_flash() {
 cleanup_flash() {
   progress "Cleaning up flash (if required)"
 
-  if [ -f /flash/pieeprom.upd ]; then
+  if [ -f /flash/pieeprom.bin -o -f /flash/pieeprom.upd -o -f /flash/vl805.bin ]; then
     mount -o remount,rw /flash
-    rm -f /flash/pieeprom.bin /flash/pieeprom.upd
+
+    rm -f /flash/pieeprom.bin /flash/pieeprom.upd /flash/pieeprom.sig
+    rm -f /flash/vl805.bin /flash/vl805.sig
     rm -f /flash/recovery.bin /flash/recovery.[0-9][0-9][0-9] /flash/RECOVERY.[0-9][0-9][0-9]
+
     mount -o remount,ro /flash
   fi
 }

--- a/packages/sysutils/busybox/scripts/rpi-flash-firmware
+++ b/packages/sysutils/busybox/scripts/rpi-flash-firmware
@@ -9,51 +9,30 @@ FLAG_FILE="/storage/.rpi_flash_firmware"
 
 hidecursor
 
-if ! mount -o remount,rw /flash 2>/dev/null; then
-  # Remove flag file and bail out
-  rm -f "${FLAG_FILE}"
-  sync
-
-  echo "ERROR: Unable to mount /flash as a read/write file system."
-  echo
-  echo "Aborting Flash update process - please proceed with a manual update."
-  echo
-
-  StartProgress countdown "Rebooting in 15s... " 15 "NOW"
-fi
-
 if [ -f "${FLAG_FILE}" ]; then
   . ${FLAG_FILE}
+  rm -f "${FLAG_FILE}"
 
-  # Prepare flashing environment
-  if [ "${MODE}" = "init" ]; then
-    # Install new SPI bootloader files to /flash (if required)
-    if [ "${BOOTLOADER}" = "yes" ]; then
-      USE_FLASHROM=0 /usr/bin/.rpi-eeprom-update.real -a
-    fi
+  if ! mount -o remount,rw /flash 2>/dev/null; then
+    echo "ERROR: Unable to mount /flash as a read/write file system."
+    echo
+    echo "Aborting Flash update process - please proceed with a manual update."
+    echo
 
-    # Bump process to next step
-    sed -e 's/^MODE=.*/MODE="update"/' -i "${FLAG_FILE}"
-    sync
-  else
-    rm -f "${FLAG_FILE}"
-    sync
+    StartProgress countdown "Rebooting in 15s... " 15 "NOW"
+    reboot -f &>/dev/null
+  fi
 
-    if [ "${MODE}" = "update" ]; then
-      # Display current bootloader status
-      if [ "${BOOTLOADER}" = "yes" ]; then
-        USE_FLASHROM=0 /usr/bin/.rpi-eeprom-update.real
-      fi
+  # Install new bootloader and/or USB3 firmware files to /flash
+  # Firmware flashing will occur during the next boot, after
+  # which the system will again reboot.
+  # Old firmware files will be automatically removed by init.
+  CMD_ARGS=""
+  [ "${BOOTLOADER}" = "yes" ] && CMD_ARGS="${CMD_ARGS} -A bootloader"
+  [ "${VL805}" = "yes" ] && CMD_ARGS="${CMD_ARGS} -A vl805"
 
-      # Apply VIA USB3 update
-#      if [ "${USB3}" = "yes" ]; then
-#        /usr/bin/vl805
-#      fi
-
-      sync
-      echo ""
-      StartProgress countdown "Rebooting in 15s... " 15 "NOW"
-    fi
+  if [ -n "${CMD_ARGS}" ]; then
+    USE_FLASHROM=0 /usr/bin/.rpi-eeprom-update.real ${CMD_ARGS}
   fi
 
   sync

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="ffec4bd48ff2ab753da10bd42b2fd7b904d8dca5"
-PKG_SHA256="94eba989f3776c6d2f06cf021fffb1cb4c2f550fa325e5a08cab2fdd4a4e00bd"
+PKG_VERSION="b360b29ab64bb1cbf223d21aa6086d6541675471"
+PKG_SHA256="58196f74d9b9b62f22f966441a7822962ff28c6633578e4863ab356a9d6a8ba7"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
@@ -16,15 +16,13 @@ makeinstall_target() {
   DESTDIR=${INSTALL}/$(get_kernel_overlay_dir)/lib/firmware/raspberrypi/bootloader
 
   mkdir -p ${DESTDIR}
-    mkdir -p ${DESTDIR}/${_dir}
-      cp -PRv ${PKG_BUILD}/firmware/recovery.bin ${DESTDIR}
-
     _dirs="critical"
     [ "$LIBREELEC_VERSION" = "devel" ] && _dirs+=" beta"
     for _dir in ${_dirs}; do
       if [ -n "$(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* 2>/dev/null)" ]; then
         mkdir -p ${DESTDIR}/${_dir}
           cp -PRv $(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* | tail -1) ${DESTDIR}/${_dir}
+          cp -PRv ${PKG_BUILD}/firmware/${_dir}/recovery.bin ${DESTDIR}/${_dir}
       fi
     done
 

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -19,17 +19,26 @@ makeinstall_target() {
     _dirs="critical"
     [ "$LIBREELEC_VERSION" = "devel" ] && _dirs+=" beta"
     for _dir in ${_dirs}; do
-      if [ -n "$(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* 2>/dev/null)" ]; then
-        mkdir -p ${DESTDIR}/${_dir}
-          cp -PRv $(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* | tail -1) ${DESTDIR}/${_dir}
-          cp -PRv ${PKG_BUILD}/firmware/${_dir}/recovery.bin ${DESTDIR}/${_dir}
-      fi
+      mkdir -p ${DESTDIR}/${_dir}
+        cp -PRv ${PKG_BUILD}/firmware/${_dir}/recovery.bin ${DESTDIR}/${_dir}
+
+        # Bootloader SPI
+        PKG_FW_FILE="$(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* 2>/dev/null | tail -1)"
+        [ -n "${PKG_FW_FILE}" ] && cp -PRv "${PKG_FW_FILE}" ${DESTDIR}/${_dir}
+
+        # VIA USB3
+        if [ -f ${PKG_BUILD}/firmware/${_dir}/vl805.latest ]; then
+          PKG_FW_FILE="$(tail -1 ${PKG_BUILD}/firmware/${_dir}/vl805.latest)"
+          cp -PRv ${PKG_BUILD}/firmware/${_dir}/vl805-${PKG_FW_FILE}.bin ${DESTDIR}/${_dir}
+          cp -PRv ${PKG_BUILD}/firmware/${_dir}/vl805.latest ${DESTDIR}/${_dir}
+        fi
     done
 
   mkdir -p ${INSTALL}/usr/bin
     cp -PRv ${PKG_DIR}/source/rpi-eeprom-update ${INSTALL}/usr/bin
     cp -PRv ${PKG_BUILD}/rpi-eeprom-update ${INSTALL}/usr/bin/.rpi-eeprom-update.real
     cp -PRv ${PKG_BUILD}/rpi-eeprom-config ${INSTALL}/usr/bin
+    cp -PRv ${PKG_BUILD}/vl805 ${INSTALL}/usr/bin
 
   mkdir -p ${INSTALL}/etc/default
     cp -PRv ${PKG_DIR}/config/* ${INSTALL}/etc/default

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="9202943804f01fe8015cdaab692be8092d11719d"
-PKG_SHA256="9833abdfd47f1dd5c8bd4f993e9f103259d3aa35c065a04e25f1bde035ebdaca"
+PKG_VERSION="99e88912af108d46e4edd5f168634b84883c1d86"
+PKG_SHA256="13057de869bbfef78138c67c4315a43370e6409cf1798d0828de01a879b91c4d"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="b360b29ab64bb1cbf223d21aa6086d6541675471"
-PKG_SHA256="58196f74d9b9b62f22f966441a7822962ff28c6633578e4863ab356a9d6a8ba7"
+PKG_VERSION="9202943804f01fe8015cdaab692be8092d11719d"
+PKG_SHA256="9833abdfd47f1dd5c8bd4f993e9f103259d3aa35c065a04e25f1bde035ebdaca"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
@@ -38,7 +38,7 @@ makeinstall_target() {
     cp -PRv ${PKG_DIR}/source/rpi-eeprom-update ${INSTALL}/usr/bin
     cp -PRv ${PKG_BUILD}/rpi-eeprom-update ${INSTALL}/usr/bin/.rpi-eeprom-update.real
     cp -PRv ${PKG_BUILD}/rpi-eeprom-config ${INSTALL}/usr/bin
-    cp -PRv ${PKG_BUILD}/vl805 ${INSTALL}/usr/bin
+    cp -PRv ${PKG_BUILD}/firmware/vl805 ${INSTALL}/usr/bin
 
   mkdir -p ${INSTALL}/etc/default
     cp -PRv ${PKG_DIR}/config/* ${INSTALL}/etc/default


### PR DESCRIPTION
64-bit OS support (https://github.com/raspberrypi/rpi-eeprom/pull/6)
New beta firmware (https://github.com/raspberrypi/rpi-eeprom/pull/7)
help2man fixes (https://github.com/raspberrypi/rpi-eeprom/pull/8)
Cosmetics (https://github.com/raspberrypi/rpi-eeprom/pull/10)
Rpi eeprom config magic (https://github.com/raspberrypi/rpi-eeprom/pull/12)
Pieeprom 2019 09 10 (https://github.com/raspberrypi/rpi-eeprom/pull/15)
2019-09-23 - Beta test for network boot (https://github.com/raspberrypi/rpi-eeprom/pull/19)
Set unused data to zero if size of config is reduced (https://github.com/raspberrypi/rpi-eeprom/pull/20)
2019-09-25 - Beta test update for network boot (https://github.com/raspberrypi/rpi-eeprom/pull/22)
Rpi eeprom config 2 k (https://github.com/raspberrypi/rpi-eeprom/pull/29)
2019-10-08 - TFTP prefix strings, block size, various netboot fixes (https://github.com/raspberrypi/rpi-eeprom/pull/30)
Recovery beta (https://github.com/raspberrypi/rpi-eeprom/pull/31)
Remove pieeprom-2019-05-10.bin release (https://github.com/raspberrypi/rpi-eeprom/pull/32)
Vli update (https://github.com/raspberrypi/rpi-eeprom/pull/34)
1.4-1 release (https://github.com/raspberrypi/rpi-eeprom/pull/35)
Restore machine output exit code as string (https://github.com/raspberrypi/rpi-eeprom/pull/36)
rpi-eeprom-update: Don't remove update files if run with no arguments (https://github.com/raspberrypi/rpi-eeprom/pull/37)
critical update: Update VLI to 000137ab revision (https://github.com/raspberrypi/rpi-eeprom/pull/38)
rpi-eeprom-update: Verify DPKG checksums if available (https://github.com/raspberrypi/rpi-eeprom/pull/39)
Tweak update status for BOOTLOADER, VL805 (https://github.com/raspberrypi/rpi-eeprom/pull/42)
Add Python3 support (https://github.com/raspberrypi/rpi-eeprom/pull/45)
use lspci if available instead of vl805. Avoid calling vl805 twice. (https://github.com/raspberrypi/rpi-eeprom/pull/50)

NEEDS: https://github.com/LibreELEC/service.libreelec.settings/pull/141