### PR TITLE
eventlircd: adding new rule for iMON Panel, Knob and Mouse(15c2:ffdc)

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -73,6 +73,11 @@ SUBSYSTEMS=="input", ATTRS{name}=="Xiaomi Remote", \
 SUBSYSTEMS=="input", ATTRS{name}=="小米蓝牙遥控器", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="xiaomibtremoteAM.evmap"
+  
+ # iMON Ultrabay Front Panel
+SUBSYSTEMS=="input", ATTRS{name}=="iMON Panel, Knob and Mouse(15c2:ffdc)", \
+  ENV{eventlircd_enable}="true", \
+  ENV{eventlircd_evmap}="default.evmap" 
 
 #-------------------------------------------------------------------------------
 # Ask eventlircd to handle USB HID devices that show up as event devices and are


### PR DESCRIPTION
- enables eventlircd for Imon UltraBay (front panel buttons)
- this will fix the issue with some front panel buttons not being
detected by Kodi (if keycode value is higher than 255)
- no keycode remapping is necessary everything works just fine with default.evmap