### PR TITLE
init: make copying SYSTEM to RAM opt-in

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -41,9 +41,6 @@ GRUB_DEFAULT=""
 NBD_DEVS="0"
 FLASH_FREE_MIN="5"
 
-INSTALLED_MEMORY=$(cat /proc/meminfo | grep 'MemTotal:' | awk '{print $2}')
-SYSTEM_TORAM_LIMIT=1024000
-
 LIVE="no"
 
 BREAK_TRIPPED="no"
@@ -919,11 +916,11 @@ check_update() {
 prepare_sysroot() {
   progress "Preparing system"
 
-  if [ "$SYSTEM_TORAM" = "no" -o "$INSTALLED_MEMORY" -lt "$SYSTEM_TORAM_LIMIT" ]; then
-    mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
-  else
+  if [ "$SYSTEM_TORAM" = "yes" ]; then
     cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
     mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+  else
+    mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
   fi
 
   mount --move /flash /sysroot/flash
@@ -1024,11 +1021,8 @@ for arg in $(cat /proc/cmdline); do
     nosplash)
       SPLASH=no
       ;;
-    noram)
-      SYSTEM_TORAM=no
-      ;;
-    ramlimit=*)
-      SYSTEM_TORAM_LIMIT="${arg#*=}"
+    toram)
+      SYSTEM_TORAM=yes
       ;;
     live)
       LIVE=yes


### PR DESCRIPTION
Copying SYSTEM to RAM eats up precious memory that'd be better used
for kernel filesystem cache and other things and can takes quite some
time on slower storage devices like SD cards.

Instead of having two options to define a minimum RAM size (below
which SYSTEM won't be copied) and the "noram" option (which disables
copying completely) reverse the logic and use a single "toram" option
which users can set on kernel command line if they want SYSTEM copied
to RAM.