### PR TITLE
linux: added capacity dmips mhz attributes to g12b dtsi

### DIFF
--- a/packages/linux/patches/amlogic/amlogic-0187-added-capacity-dmips-mhz-attributes-to-g12b-dtsi.patch
+++ b/packages/linux/patches/amlogic/amlogic-0187-added-capacity-dmips-mhz-attributes-to-g12b-dtsi.patch
@@ -1,0 +1,51 @@
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+@@ -48,6 +48,7 @@
+ 			compatible = "arm,cortex-a53";
+ 			reg = <0x0 0x0>;
+ 			enable-method = "psci";
++      capacity-dmips-mhz = <592>;
+ 			next-level-cache = <&l2>;
+ 		};
+ 
+@@ -56,6 +57,7 @@
+ 			compatible = "arm,cortex-a53";
+ 			reg = <0x0 0x1>;
+ 			enable-method = "psci";
++      capacity-dmips-mhz = <592>;
+ 			next-level-cache = <&l2>;
+ 		};
+ 
+@@ -64,6 +66,7 @@
+ 			compatible = "arm,cortex-a73";
+ 			reg = <0x0 0x100>;
+ 			enable-method = "psci";
++      capacity-dmips-mhz = <1024>;
+ 			next-level-cache = <&l2>;
+ 		};
+ 
+@@ -72,6 +75,7 @@
+ 			compatible = "arm,cortex-a73";
+ 			reg = <0x0 0x101>;
+ 			enable-method = "psci";
++      capacity-dmips-mhz = <1024>;
+ 			next-level-cache = <&l2>;
+ 		};
+ 
+@@ -80,6 +84,7 @@
+ 			compatible = "arm,cortex-a73";
+ 			reg = <0x0 0x102>;
+ 			enable-method = "psci";
++      capacity-dmips-mhz = <1024>;
+ 			next-level-cache = <&l2>;
+ 		};
+ 
+@@ -88,6 +93,7 @@
+ 			compatible = "arm,cortex-a73";
+ 			reg = <0x0 0x103>;
+ 			enable-method = "psci";
++      capacity-dmips-mhz = <1024>;
+ 			next-level-cache = <&l2>;
+ 		};
+ 
+


### PR DESCRIPTION
The current g12b dtsi file lacks any [cpu-capacity](https://www.kernel.org/doc/Documentation/devicetree/bindings/arm/cpu-capacity.txt) attributes like the [rk3399](https://github.com/torvalds/linux/commit/97df3aa76b4a384e29668f374a8b1034a31aa215) or [hi3660](https://lore.kernel.org/patchwork/patch/862742/) SoCs own.

This PR is based on the PR for the hi3660 SoC which is quite equal (A73+A53) to the G12B SoCs but differs in clock speed. But when you do the math you'll end up which the same capacities `A73=1024` & `A53=592` which were normalised depending on the clock speed later. The score of `508` is based on `592×(1896÷2208)`

These values have a huge impact if it comes to demanding single thread programs like a lot of emulators which only rely on one fast core. For example the libretro flycast core now avoids the slow A53 cores and the scheduler uses the fast A73 cores.

**Flycast**
![image](https://user-images.githubusercontent.com/36100210/64899182-7ba8c600-d68a-11e9-80eb-81808ff234ab.png)

**Mame2016**
![image](https://user-images.githubusercontent.com/36100210/64899885-e0195480-d68d-11e9-81a7-9aa7b1e5c2f9.png)


Before applying the patch:
```
vim3:~ # cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq
1896000
1896000
2208000
2208000
2208000
2208000
vim3:~ # cat /sys/devices/system/cpu/cpu*/cpu_capacity
1024
1024
1024
1024
1024
1024
```

After applying the patch:
```
vim3:~ # cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq
100000
100000
2208000
2208000
2208000
2208000
vim3:~ # cat /sys/devices/system/cpu/cpu*/cpu_capacity
508
508
1024
1024
1024
1024
```