### PR TITLE
imagedecoder.heif addon

### DIFF
--- a/packages/graphics/libde265/package.mk
+++ b/packages/graphics/libde265/package.mk
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libde265"
+PKG_VERSION="50987014f7b041079ac1961352781904b691cf7b"
+PKG_SHA256="5cdefeb099141608331efe9a9bd33dad271e5810438b654e53e4d2359acdc12a"
+PKG_LICENSE="LGPLv3"
+PKG_SITE="http://www.libde265.org"
+PKG_URL="https://github.com/strukturag/libde265/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Open h.265 video codec implementation."
+PKG_BUILD_FLAGS="+pic"
+PKG_TOOLCHAIN="configure"
+
+PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+                           --disable-shared \
+                           --disable-encoder \
+                           --disable-sherlock265"
+
+pre_configure_target() {
+  cd ..
+  ./autogen.sh
+}

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libheif"
+PKG_VERSION="1.5.1"
+PKG_SHA256="b134d0219dd2639cc13b8a8bcb8f264834593dd0417da1973fbe96e810918a8b"
+PKG_LICENSE="LGPLv3"
+PKG_SITE="http://www.libde265.org"
+PKG_URL="https://github.com/strukturag/libheif/releases/download/v$PKG_VERSION/libheif-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libde265 libjpeg-turbo libpng"
+PKG_LONGDESC="A HEIF file format decoder and encoder."
+PKG_BUILD_FLAGS="+pic"
+PKG_TOOLCHAIN="configure"
+
+PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+                           --disable-shared \
+                           --disable-go \
+                           --disable-examples \
+                           --disable-tests"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="imagedecoder.heif"
+PKG_VERSION="1.0.3-Leia"
+PKG_SHA256="f5da3b7af5874807c8ccafbde1a9584c9c1ea9cacb2ff504642220ff03306fa3"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/imagedecoder.heif"
+PKG_URL="https://github.com/xbmc/imagedecoder.heif/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libheif"
+PKG_SECTION=""
+PKG_SHORTDESC="imagedecoder.heif"
+PKG_LONGDESC="imagedecoder.heif"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.imagedecoder"


### PR DESCRIPTION
libde265 and libheif using configure because I found no way to disable some stuff via cmake, looks like proper packaging is not intended :(
- libde265 is current git HEAD because last release would otherwise requires patches
- addon is build static otherwise it would require shipping libde265 and libheif libs


test pic (extract zip)
[testppic.zip](https://github.com/LibreELEC/LibreELEC.tv/files/3627569/testppic.zip)
