### PR TITLE
binary addons: add pvr.waipu

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pvr.waipu"
+PKG_VERSION="0.2.0-Leia"
+PKG_SHA256="9884c0a7c5f040c44b16ac3de0dad2fdca506ecc382c86a32fdc7a41b258b6c9"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/flubshi/pvr.waipu"
+PKG_URL="https://github.com/flubshi/pvr.waipu/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform rapidjson"
+PKG_SECTION=""
+PKG_SHORTDESC="pvr.waipu"
+PKG_LONGDESC="pvr.waipu"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.pvrclient"


### PR DESCRIPTION
This PR adds binary addon pvr.waipu. Package file is borrowed from MilhouseVH testbuilds.

pvr.waipu is a pvr addon for the german tv provider waipu.tv. This pvr addon is an official kodi binary addon starting from Kodi Matrix: https://github.com/xbmc/repo-binary-addons/pull/116
The Leia branch of pvr.waipu is on the same level as the Matrix branch. Both branches are actively maintained and all 'basic features' are implemented.

Both versions are in daily use and stable. I think the plugin is ready to get shipped by LibreELEC.
