### PR TITLE
systemd: use upstream method to enable and configure debug shell

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -156,8 +156,19 @@ post_makeinstall_target() {
   safe_remove $INSTALL/usr/bin/systemd-nspawn
   safe_remove $INSTALL/usr/lib/systemd/system/systemd-nspawn@.service
 
-  # remove genetators/catalog
-  safe_remove $INSTALL/usr/lib/systemd/system-generators
+  # remove unneeded generators
+  for gen in $INSTALL/usr/lib/systemd/system-generators/*; do
+    case "$gen" in
+      */systemd-debug-generator)
+        # keep it
+        ;;
+      *)
+        safe_remove "$gen"
+        ;;
+    esac
+  done
+
+  # remove catalog
   safe_remove $INSTALL/usr/lib/systemd/catalog
 
   # remove partition
@@ -257,5 +268,4 @@ post_install() {
   enable_service usercache.service
   enable_service kernel-overlays.service
   enable_service hwdb.service
-  enable_service debug-shell.service
 }


### PR DESCRIPTION
With systemd-debug-generator installed we can use the standard
"systemd.debug_shell" kernel command line parameter to enable the debug
shell. Since systemd 243 the tty can also be changed by appending
"=ttyXYZ" to that parameter.

Use this method instead of enabling the debug shell on all systems
by default.