### PR TITLE
[le92] busybox: init: mount squashfs early

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -261,14 +261,10 @@ mount_sysroot() {
 
 # mount the specified SYSTEM file and output arch from /etc/os-release
 get_project_arch() {
-  mount_part "$1" "/update" "ro,loop" || return
-
-  if [ -f /update/etc/os-release ]; then
-    . /update/etc/os-release
+  if [ -f ${1}/etc/os-release ]; then
+    . ${1}/etc/os-release
     echo "${LIBREELEC_ARCH:-${OPENELEC_ARCH}}"
   fi
-
-  umount /update
 }
 
 # If the project/arch of current matches the upgrade, then it is considered compatible.
@@ -278,16 +274,12 @@ get_project_arch() {
 is_compatible() {
   local result=1
 
-  if [ "${2}" = "${3}" ]; then
+  if [ "${1}" = "${2}" ]; then
     result=0
   else
-    mount_part "$1" "/update" "ro,loop"
-
     if [ -f /update/usr/share/bootloader/canupdate.sh ]; then
-      sh /update/usr/share/bootloader/canupdate.sh "${2}" "${3}" && result=0
+      sh /update/usr/share/bootloader/canupdate.sh "${1}" "${2}" && result=0
     fi
-
-    umount /update
   fi
 
   return ${result}
@@ -296,17 +288,15 @@ is_compatible() {
 # determine if the new SYSTEM file is compatible with the current SYSTEM file
 check_is_compatible() {
   local update_filename="${1}"
-  local old_system="${2}"
-  local new_system="${3}"
   local old_project_arch new_project_arch
 
-  old_project_arch="$(get_project_arch "${old_system}")" || return
-  new_project_arch="$(get_project_arch "${new_system}")" || return
+  old_project_arch="$(get_project_arch "/sysroot")" || return
+  new_project_arch="$(get_project_arch "/update")" || return
 
   # If old or new project/arch isn't available then could be very old (pre-/etc/os-release) build - have to trust it
   if [ -n "${old_project_arch}" -a -n "${new_project_arch}" ]; then
     # If the old project/arch is not compatible with the new project/arch then abort...
-    if ! is_compatible "${new_system}" "${old_project_arch}" "${new_project_arch}"; then
+    if ! is_compatible "${old_project_arch}" "${new_project_arch}"; then
       echo ""
       echo "ERROR: $(basename "${update_filename}") is not compatible with ${old_project_arch} hardware - update cancelled."
       echo ""
@@ -359,8 +349,6 @@ update_bootloader() {
   export BOOT_ROOT="/flash"
   export SYSTEM_ROOT="/update"
 
-  mount_part "/flash/$IMAGE_SYSTEM" "$SYSTEM_ROOT" "ro,loop"
-
   if [ -f $SYSTEM_ROOT/usr/share/bootloader/update.sh ]; then
     StartProgress spinner "Updating Boot Files... "
       result="$(sh $SYSTEM_ROOT/usr/share/bootloader/update.sh 2>&1)"
@@ -368,8 +356,6 @@ update_bootloader() {
       StopProgress "done"
     [ -n "${result}" ] && echo "${result}"
   fi
-
-  umount $SYSTEM_ROOT
 }
 
 load_modules() {
@@ -875,10 +861,12 @@ check_update() {
     fi
   fi
 
+  mount_part "$UPDATE_DIR/$UPDATE_SYSTEM" "/update" "ro,loop"
+
   # Verify that the new upgrade is compatible with the current system - this should avoid creating
   # non-booting systems after (for example) an RPi tar is incorrectly applied to an RPi2 system.
   if [ ! -f "$UPDATE_ROOT/.nocompat" ]; then
-    if ! check_is_compatible "$UPDATE_FILENAME" "/flash/$IMAGE_SYSTEM" "$UPDATE_DIR/$UPDATE_SYSTEM"; then
+    if ! check_is_compatible "$UPDATE_FILENAME"; then
       do_cleanup
       StartProgress countdown "Normal startup in 60s... " 60 "NOW"
       return 0
@@ -932,6 +920,7 @@ check_update() {
   umount /sysroot
   update_file "System" "$UPDATE_SYSTEM" "/flash/$IMAGE_SYSTEM"
   update_bootloader
+  umount /update
   do_cleanup
   do_reboot
 }
@@ -1093,10 +1082,10 @@ for BOOT_STEP in \
     set_consolefont \
     check_disks \
     mount_flash \
-    mount_sysroot \
     cleanup_flash \
     update_bootmenu \
     load_splash \
+    mount_sysroot \
     mount_storage \
     check_update \
     prepare_sysroot; do

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -15,6 +15,9 @@
 /usr/bin/busybox mkdir -p /sysroot
 /usr/bin/busybox mkdir -p /storage
 
+# temp mountpoint for updates
+/usr/bin/busybox mkdir -p /update
+
 # mount all needed special filesystems
 /usr/bin/busybox mount -t devtmpfs devtmpfs /dev
 /usr/bin/busybox mount -t proc proc /proc
@@ -243,16 +246,29 @@ mount_part() {
   $MOUNT_CMD "$MOUNT_TARGET" "$2" "$3" "$4"
 }
 
+mount_sysroot() {
+  if [ "$SYSTEM_TORAM" = "yes" ]; then
+    cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
+    mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+  else
+    mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+  fi
+
+  if [ -f /flash/post-sysroot.sh ]; then
+    . /flash/post-sysroot.sh
+  fi
+}
+
 # mount the specified SYSTEM file and output arch from /etc/os-release
 get_project_arch() {
-  mount_part "$1" "/sysroot" "ro,loop" || return
+  mount_part "$1" "/update" "ro,loop" || return
 
-  if [ -f /sysroot/etc/os-release ]; then
-    . /sysroot/etc/os-release
+  if [ -f /update/etc/os-release ]; then
+    . /update/etc/os-release
     echo "${LIBREELEC_ARCH:-${OPENELEC_ARCH}}"
   fi
 
-  umount /sysroot
+  umount /update
 }
 
 # If the project/arch of current matches the upgrade, then it is considered compatible.
@@ -265,13 +281,13 @@ is_compatible() {
   if [ "${2}" = "${3}" ]; then
     result=0
   else
-    mount_part "$1" "/sysroot" "ro,loop"
+    mount_part "$1" "/update" "ro,loop"
 
-    if [ -f /sysroot/usr/share/bootloader/canupdate.sh ]; then
-      sh /sysroot/usr/share/bootloader/canupdate.sh "${2}" "${3}" && result=0
+    if [ -f /update/usr/share/bootloader/canupdate.sh ]; then
+      sh /update/usr/share/bootloader/canupdate.sh "${2}" "${3}" && result=0
     fi
 
-    umount /sysroot
+    umount /update
   fi
 
   return ${result}
@@ -341,9 +357,9 @@ update_bootloader() {
   local result
 
   export BOOT_ROOT="/flash"
-  export SYSTEM_ROOT="/sysroot"
+  export SYSTEM_ROOT="/update"
 
-  mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+  mount_part "/flash/$IMAGE_SYSTEM" "$SYSTEM_ROOT" "ro,loop"
 
   if [ -f $SYSTEM_ROOT/usr/share/bootloader/update.sh ]; then
     StartProgress spinner "Updating Boot Files... "
@@ -353,7 +369,7 @@ update_bootloader() {
     [ -n "${result}" ] && echo "${result}"
   fi
 
-  umount /sysroot
+  umount $SYSTEM_ROOT
 }
 
 load_modules() {
@@ -913,6 +929,7 @@ check_update() {
   else
     update_file "Kernel" "$UPDATE_KERNEL" "/flash/$IMAGE_KERNEL"
   fi
+  umount /sysroot
   update_file "System" "$UPDATE_SYSTEM" "/flash/$IMAGE_SYSTEM"
   update_bootloader
   do_cleanup
@@ -921,13 +938,6 @@ check_update() {
 
 prepare_sysroot() {
   progress "Preparing system"
-
-  if [ "$SYSTEM_TORAM" = "yes" ]; then
-    cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
-    mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
-  else
-    mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
-  fi
 
   mount --move /flash /sysroot/flash
   mount --move /storage /sysroot/storage
@@ -1083,6 +1093,7 @@ for BOOT_STEP in \
     set_consolefont \
     check_disks \
     mount_flash \
+    mount_sysroot \
     cleanup_flash \
     update_bootmenu \
     load_splash \

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -267,9 +267,9 @@ get_project_arch() {
   fi
 }
 
-# If the project/arch of current matches the upgrade, then it is considered compatible.
-# Otherwise, mount the upgrade SYSTEM partition and, if canupdate.sh is available,
-# call the script to determine if the current upgrade file can be applied on to the
+# If the project/arch of current matches the update, then it is considered compatible.
+# Otherwise, mount the update SYSTEM partition and, if canupdate.sh is available,
+# call the script to determine if the current update file can be applied on to the
 # current system - 0 means it is compatible, non-zero that it is not compatible.
 is_compatible() {
   local result=1
@@ -642,7 +642,7 @@ check_out_of_space() {
   if [ "$(df /storage | awk '/[0-9]%/{print $4}')" -eq "0" ]; then
     echo ""
     echo "The $1 is corrupt, or there is not enough"
-    echo "free space on /storage to complete the upgrade!"
+    echo "free space on /storage to complete the update!"
     echo ""
     echo "Please free up space on your /storage partition"
     echo "by deleting unecessary files, then try again."
@@ -710,7 +710,7 @@ check_update() {
   mkdir -p $UPDATE_DIR/.tmp &>/dev/null
   sync
 
-  echo "UPGRADE IN PROGRESS"
+  echo "UPDATE IN PROGRESS"
   echo ""
   echo "Please do not reboot or turn off your @DISTRONAME@ device!"
   echo ""
@@ -863,7 +863,7 @@ check_update() {
 
   mount_part "$UPDATE_DIR/$UPDATE_SYSTEM" "/update" "ro,loop"
 
-  # Verify that the new upgrade is compatible with the current system - this should avoid creating
+  # Verify that the new update is compatible with the current system - this should avoid creating
   # non-booting systems after (for example) an RPi tar is incorrectly applied to an RPi2 system.
   if [ ! -f "$UPDATE_ROOT/.nocompat" ]; then
     if ! check_is_compatible "$UPDATE_FILENAME"; then


### PR DESCRIPTION
To have a full set of binaries in the init process as early as possible it now mounts the squashfs direct after mounting /flash.
There is also a hook /flash/post-sysroot.sh for custom scripting. I will use this e.g. for lvm2 and cryptsetup in the init process, because they are very big and i dont like them in initramfs.

Backport of https://github.com/LibreELEC/LibreELEC.tv/pull/3825