### PR TITLE
kodi: add pastekodi script [backport]

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="a8481d9b223441d47c518161616bbeefc412a6fc"
-PKG_SHA256="5ed50f5317bcdee15cc113563b2d078175eb494a673412273cda463d6e95ad62"
+PKG_VERSION="d9765c9db18dc45a2bcc2b8d37dde41f38bb8f4b"
+PKG_SHA256="2c3714147298c5133250956496e4ae1987d6b84b37bca535454c13685706429b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -296,6 +296,8 @@ post_makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
     cp $PKG_DIR/scripts/kodi-remote $INSTALL/usr/bin
     cp $PKG_DIR/scripts/setwakeup.sh $INSTALL/usr/bin
+    cp $PKG_DIR/scripts/pastekodi $INSTALL/usr/bin
+    ln -sf /usr/bin/pastekodi $INSTALL/usr/bin/pastecrash
 
   mkdir -p $INSTALL/usr/share/kodi/addons
     cp -R $PKG_DIR/config/os.openelec.tv $INSTALL/usr/share/kodi/addons

--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+cat_data() {
+  echo "========== ${1} =========="
+  cat
+}
+
+cat_file() {
+  if [ -f "${1}" ]; then
+    cat "${1}" | cat_data "${2:-${1}}"
+  fi
+}
+
+source /etc/os-release
+SYSTEM_ARCH="${LIBREELEC_ARCH#*.}"
+
+# If running in SAFE mode, send FAILED logs
+if [ "$(cat "/storage/.config/boot.status" 2>/dev/null)" = "SAFE" ]; then
+  KODI_ROOT="/storage/.kodi.FAILED/temp"
+else
+  KODI_ROOT="/storage/.kodi/temp"
+fi
+
+if [ "$(basename $0)" = "pastekodi" ]; then
+  LOG_TYPE="System"
+  LOG_FILE="${KODI_ROOT}/kodi.log"
+else
+  LOG_TYPE="Crash"
+  LOG_FILE="${KODI_ROOT}/kodi_crash.log"
+fi
+
+(
+  echo "${LOG_TYPE} log output for: $(lsb_release)"
+
+  if [ "${SYSTEM_ARCH}" = "x86_64" ]; then
+    if [ -f "/sys/firmware/efi" ]; then
+      echo "Firmware Boot Mode: EFI"
+    else
+      echo "Firmware Boot Mode: BIOS"
+    fi
+  fi
+  if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then
+    echo "RPi Hardware Revision: $(vcgencmd otp_dump | grep 30: | cut -d: -f2)"
+  fi
+
+  cat_file "${LOG_FILE}"
+
+  journalctl -a | cat_data "journalctl -a"
+
+  if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then
+    bootloader_version="$(vcgencmd bootloader_version)"
+    if ! echo "${bootloader_version}" | grep -q "Command not registered"; then
+      echo  "${bootloader_version}" | cat_data "Bootloader version"
+    fi
+  fi
+
+  cat_file "/flash/config.txt" # RPi
+  cat_file "/flash/distroconfig.txt" # RPi
+  cat_file "/flash/cmdline.txt" # RPi
+
+  cat_file "/flash/syslinux.cfg" # x86 BIOS
+  cat_file "/flash/EFI/BOOT/syslinux.cfg" # x86 EFI
+  cat_file "/flash/extlinux.conf" # x86 legacy
+
+  cat_file "/flash/extlinux/extlinux.conf" # u-boot
+
+  cat_file "${KODI_ROOT}/.smb/smb.conf"
+  cat_file "${KODI_ROOT}/.smb/user.conf"
+  cat_file "/run/samba/smb.conf"
+) | /usr/bin/pastebinit 2>/dev/null


### PR DESCRIPTION
Backport of #3817 

We need to backport the `pastekodi` script in case we bump the LibreELEC Settings add-on in `libreelec-9.2` in future.