### PR TITLE
init: add fix for RPi4 serial numbers

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -48,7 +48,7 @@ BREAK_TRIPPED="no"
 BIGFONT="1080"
 
 # Get a serial number if present (eg. RPi) otherwise use MAC address from eth0
-MACHINE_UID="$(cat /proc/cpuinfo | awk '/^Serial/{s=$3; gsub ("^0*","",s); print s}')"
+MACHINE_UID="$(awk '/^Serial/{s='0000000' $3; print substr(s, length(s) - 7)}' /proc/cpuinfo)"
 [ -z "$MACHINE_UID" ] && MACHINE_UID="$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d :)"
 
 # common functions

--- a/packages/tools/rpi-eeprom/config/rpi-eeprom-update
+++ b/packages/tools/rpi-eeprom/config/rpi-eeprom-update
@@ -1,4 +1,4 @@
 # Use direct path to firmware as update script doesn't dereference sym links.
 FIRMWARE_ROOT="/usr/lib/kernel-overlays/base/lib/firmware/raspberrypi/bootloader"
 FIRMWARE_BACKUP_DIR="/storage/.config/rpifw-backup"
-BOOTFS=/flash
+BOOTFS=${BOOTFS:-/flash}


### PR DESCRIPTION
RPi4 serial number: `1000000022bba2d2`
RPi3 serial number: `0000000023a4046f`

The top 32 bits are 0x10000000 for Pi4 and 0 for older Pi's.
This was purely added so people wouldn't be able to buy codec licences with a Pi4 serial number.

When network booting, the serial number used when communicating with the TFTP server is the bottom 32 bits, ie. `23a4046f`

Also include a fix for `rpi-eeprom-update` that allows installing firmware to a file system other than `/flash`.