### PR TITLE
Allwinner: Update kernel configs

### DIFF
--- a/projects/Allwinner/linux/linux.aarch64.conf
+++ b/projects/Allwinner/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.2.1 Kernel Configuration
+# Linux/arm64 5.3.0 Kernel Configuration
 #
 
 #
@@ -9,6 +9,7 @@
 CONFIG_CC_IS_GCC=y
 CONFIG_GCC_VERSION=80300
 CONFIG_CLANG_VERSION=0
+CONFIG_CC_CAN_LINK=y
 CONFIG_CC_HAS_ASM_GOTO=y
 CONFIG_CC_HAS_WARN_MAYBE_UNINITIALIZED=y
 CONFIG_IRQ_WORK=y

--- a/projects/Allwinner/linux/linux.arm.conf
+++ b/projects/Allwinner/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.2.1 Kernel Configuration
+# Linux/arm 5.3.0 Kernel Configuration
 #
 
 #
@@ -9,6 +9,7 @@
 CONFIG_CC_IS_GCC=y
 CONFIG_GCC_VERSION=80300
 CONFIG_CLANG_VERSION=0
+CONFIG_CC_CAN_LINK=y
 CONFIG_CC_HAS_ASM_GOTO=y
 CONFIG_CC_HAS_WARN_MAYBE_UNINITIALIZED=y
 CONFIG_IRQ_WORK=y


### PR DESCRIPTION
Some kernel config options were left out during update to Linux 5.3. Add them now.