### PR TITLE
linux-drivers: update RTL drivers with kernel 5.3 support.

### DIFF
--- a/packages/linux-drivers/RTL8192EU/package.mk
+++ b/packages/linux-drivers/RTL8192EU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8192EU"
-PKG_VERSION="d6aa91a72870185f71d5956cddb6f333537fbfa9"
-PKG_SHA256="3ad503a704f644652353a8ab7e1b2861506b8aefa79a8b903af7af4d8be360d1"
+PKG_VERSION="e7361e951c15d998f8c63b45478ef320d447f769"
+PKG_SHA256="33da47764fc053d8e2122a5d980277035e97ddcf2723707f4555f6d37a62a37d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/Mange/rtl8192eu-linux-driver"
 PKG_URL="https://github.com/Mange/rtl8192eu-linux-driver/archive/$PKG_VERSION.tar.gz"

--- a/packages/linux-drivers/RTL8812AU/package.mk
+++ b/packages/linux-drivers/RTL8812AU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8812AU"
-PKG_VERSION="bd00d87dd33440f70354e6a1905a09cd62e876bd"
-PKG_SHA256="78c740de2d64920b5a053c02cd24ca62ea959969c2193498a77baf21dd77e5dd"
+PKG_VERSION="4aaf486f7f758a1b5132552420773780efdf946e"
+PKG_SHA256="fa8f55a1998f860c4629c6e5ccc79e01164fbcfd59fb511fd22027962dc2d36a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/MilhouseVH/RTL8812AU"
 PKG_URL="https://github.com/MilhouseVH/RTL8812AU/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
- RTL8192EU: update to RTL8192EU-e7361e9 kernel 5.3 support.
- RTL8812AU: update to RTL8812AU-4aaf486 kernel 5.3 support
~~- RTL8812AU: Repository changed to use a newer version v5.1.5 vs v5.2.20.2.~~

~~RTL8812AU repository contains a newer version, and looks mantained and updated, is used at https://aur.archlinux.org/packages/rtl8812au-dkms-git/ looks a decent upstream for me.~~
