### PR TITLE
system-tools: fix 7z

### DIFF
--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,6 @@
+112
+- fixed 7z
+
 111
 - updated autossh to 1.4g
 - updated file to d1ff3af

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="111"
+PKG_REV="112"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -143,7 +143,7 @@ addon() {
     # p7zip
     cp -P $(get_build_dir p7zip)/bin/7z.so $ADDON_BUILD/$PKG_ADDON_ID/bin
     cp -PR $(get_build_dir p7zip)/bin/Codecs $ADDON_BUILD/$PKG_ADDON_ID/bin
-    cp -P $(get_build_dir p7zip)/bin/7z $ADDON_BUILD/$PKG_ADDON_ID/bin
+    cp -P $(get_build_dir p7zip)/bin/7z $ADDON_BUILD/$PKG_ADDON_ID/bin/7z-dummy
     cp -P $(get_build_dir p7zip)/bin/7za $ADDON_BUILD/$PKG_ADDON_ID/bin
 
     # patch

--- a/packages/addons/tools/system-tools/source/bin/7z
+++ b/packages/addons/tools/system-tools/source/bin/7z
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /storage/.kodi/addons/virtual.system-tools/bin/7z-dummy "$@"


### PR DESCRIPTION
```
cd /storage
7z a /tmp/test.7z /storage/.kodi/temp/kodi.log
```
wasn't working due missing 7z.so

```
LibreELEC:~ # 7z a /tmp/test.7z .kodi/temp/kodi.log
7-Zip [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
p7zip Version 16.02 (locale=C,Utf16=off,HugeFiles=on,64 bits,2 CPUs x64)
Can't load './7z.dll' (./7z.so: cannot open shared object file: No such file or directory)
ERROR:
7-Zip cannot find the code that works with archives.
```

some makefile/libtool issue prevents proper paths at the binary, this is a workaround that make it work