### PR TITLE
kodi: fix pastekodi efi check

### DIFF
--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -36,7 +36,7 @@ fi
   echo "${LOG_TYPE} log output for: $(lsb_release)"
 
   if [ "${SYSTEM_ARCH}" = "x86_64" ]; then
-    if [ -f "/sys/firmware/efi" ]; then
+    if [ -d "/sys/firmware/efi" ]; then
       echo "Firmware Boot Mode: EFI"
     else
       echo "Firmware Boot Mode: BIOS"


### PR DESCRIPTION
No brainer. :)

Old `LibreELEC-settings` code:
```
                 if os.path.exists('/sys/firmware/efi'):
```
New `pastekodi` code:
```
    if [ -f "/sys/firmware/efi" ]; then
```
Bah, `/sys/firmware/efi` is a directory, so we always reported `BIOS` when booting with `UEFI`.