### PR TITLE
update RPi.GPIO to 0.7.0

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/RPi.GPIO/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/RPi.GPIO/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RPi.GPIO"
-PKG_VERSION="0.6.3"
-PKG_SHA256="a5fc0eb5e401963b6c0a03650da6b42c4005f02d962b81241d96c98d0a578516"
+PKG_VERSION="0.7.0"
+PKG_SHA256="7424bc6c205466764f30f666c18187a0824077daf20b295c42f08aea2cb87d3f"
 PKG_ARCH="arm"
 PKG_LICENSE="MIT"
 PKG_SITE="http://sourceforge.net/p/raspberry-gpio-python/"

--- a/packages/addons/tools/rpi-tools/changelog.txt
+++ b/packages/addons/tools/rpi-tools/changelog.txt
@@ -1,3 +1,6 @@
+107
+- Update RPi.GPIO to 0.7.0
+
 106
 - Update gpiozero to 1.5.0 (doesn't require setuptools)
 - Add colorzero 1.1 required by gpiozero

--- a/packages/addons/tools/rpi-tools/package.mk
+++ b/packages/addons/tools/rpi-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rpi-tools"
 PKG_VERSION="1.0"
-PKG_REV="106"
+PKG_REV="107"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
This should fix issues with RPi4.

See https://forum.libreelec.tv/thread/20436-rpi-gpio-input-pin-pull-up-down-not-working-on-pi-4b/

Only build-tested so far, waiting for confirmation from user