### PR TITLE
glu: update to glu-9.0.1

### DIFF
--- a/packages/graphics/glu/package.mk
+++ b/packages/graphics/glu/package.mk
@@ -1,17 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glu"
-PKG_VERSION="9.0.0"
-PKG_SHA256="3d19cca9b26ec4048dd22e3d294acd43e080a3205a29ff47765bd514571ea8f9"
+PKG_VERSION="9.0.1"
+PKG_SHA256="f98dff2045e0c557da88553bf4cf9958f49cd5bd40d33d2f8b5e13c8f904d126"
 PKG_LICENSE="OSS"
 PKG_SITE="http://cgit.freedesktop.org/mesa/glu/"
-PKG_URL="http://cgit.freedesktop.org/mesa/glu/snapshot/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="http://cgit.freedesktop.org/mesa/glu/snapshot/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain mesa"
 PKG_LONGDESC="libglu is the The OpenGL utility library"
 PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-silent-rules \
-            --disable-debug \
-            --disable-osmesa \
-            --with-gnu-ld"
+                           --disable-debug \
+                           --disable-osmesa \
+                           --with-gnu-ld"


### PR DESCRIPTION
Bump package to fix build failure due to undefined `NULL`.