### PR TITLE
Addon - Snapclient - Add snapserver hostname/IP setting

### DIFF
--- a/packages/addons/service/snapclient/source/bin/snapclient.start
+++ b/packages/addons/service/snapclient/source/bin/snapclient.start
@@ -26,12 +26,14 @@ case "$LIBREELEC_ARCH" in
     ;;
 esac
 
+[ -n "$sc_ss" ] && sc_SS="--h $sc_ss"
 [ -n "$sc_h" ] && sc_H="--hostID $sc_h"
 [ -n "$sc_s" ] && sc_S="--soundcard $sc_s"
 
 HOME="$ADDON_HOME" \
 nice -n "$sc_n" \
 snapclient \
+  $sc_SS \
   $sc_H \
   --latency "$sc_l" \
   --port "$sc_p" \

--- a/packages/addons/service/snapclient/source/resources/language/English/strings.po
+++ b/packages/addons/service/snapclient/source/resources/language/English/strings.po
@@ -21,6 +21,10 @@ msgctxt "#30003"
 msgid "Host ID"
 msgstr ""
 
+msgctxt "#30016"
+msgid "Snapserver hostname/IP"
+msgstr ""
+
 msgctxt "#30004"
 msgid "Port"
 msgstr ""

--- a/packages/addons/service/snapclient/source/resources/settings.xml
+++ b/packages/addons/service/snapclient/source/resources/settings.xml
@@ -4,6 +4,7 @@
     <setting label="30001" type="action" action="RunAddon(service.snapclient)"/>
     <setting label="30002" type="text"   id="sc_s" default=""/>
     <setting label="30003" type="text"   id="sc_h" default=""/>
+    <setting label="30016" type="text"   id="sc_ss" default=""/>
     <setting label="30004" type="number" id="sc_p" default="1704"/>
     <setting label="30005" type="slider" id="sc_n" default="-3" range="-20,1,19" option="int"/>
     <setting label="30006" type="number" id="sc_l" default="0"/>

--- a/packages/addons/service/snapclient/source/settings-default.xml
+++ b/packages/addons/service/snapclient/source/settings-default.xml
@@ -7,4 +7,5 @@
     <setting id="sc_p" default="true">1704</setting>
     <setting id="sc_r" default="true">0</setting>
     <setting id="sc_s" default="true"></setting>
+    <setting id="sc_ss" default="true"></setting>
 </settings>


### PR DESCRIPTION
There is currently no way to tell a snapclient the hostname or IP of the snapserver it should connect to. Usually this isn't a problem; sometimes it is.

There is a "Host ID" setting, for setting the _ID_ of host running the snapclient. This is [apparently confusing some people](https://forum.libreelec.tv/thread/11817-snapcast/?postID=126566#post126566), who are looking for a way to set the _hostname_ or _IP_ of the host running the snapserver.

