### PR TITLE
setup_toolchain: add OpenGL_GL_PREFERENCE to target config

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -341,6 +341,11 @@ setup_toolchain() {
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)"  >> $CMAKE_CONF
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)"  >> $CMAKE_CONF
         echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"  >> $CMAKE_CONF
+        if [ "${DISPLAYSERVER}" = "x11" ]; then
+          if [ "${OPENGL}" = "mesa" ] || listcontains "${GRAPHIC_DRIVERS}" "nvidia"; then
+            echo "SET(OpenGL_GL_PREFERENCE GLVND)" >> $CMAKE_CONF
+          fi
+        fi
       fi
       export HOST_CC="$TOOLCHAIN/bin/host-gcc"
       export HOST_CXX="$TOOLCHAIN/bin/host-g++"


### PR DESCRIPTION
This PR sets OpenGL_GL_PREFERENCE to GLVND if either mesa or nvidia is used for the X11 displayserver.

https://cmake.org/cmake/help/v3.15/module/FindOpenGL.html#linux-specific

https://cmake.org/cmake/help/v3.15/policy/CMP0072.html#policy:CMP0072