### PR TITLE
kodi: backport PR16643 always allow black screen saver

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.99-PR16643-always-allow-black-screensaver.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.99-PR16643-always-allow-black-screensaver.patch
@@ -1,0 +1,61 @@
+From aebe2f53ee873739b89259d9f4493824cc608ffe Mon Sep 17 00:00:00 2001
+From: Kai Sommerfeld <kai.sommerfeld@gmx.com>
+Date: Tue, 17 Sep 2019 22:25:18 +0200
+Subject: [PATCH] [application] Fix CApplication::ActivateScreenSaver to always
+ allow 'Black' screen saver. Closes #16123.
+
+---
+ xbmc/Application.cpp | 26 ++++++++++++++++----------
+ 1 file changed, 16 insertions(+), 10 deletions(-)
+
+diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
+index dcb2e3cb95ea..eedf819da73c 100644
+--- a/xbmc/Application.cpp
++++ b/xbmc/Application.cpp
+@@ -3632,30 +3632,36 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
+   // disable screensaver lock from the login screen
+   m_iScreenSaveLock = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_LOGIN_SCREEN ? 1 : 0;
+ 
+-  // set to Dim in the case of a dialog on screen or playing video
+-  bool bUseDim = false;
++  m_screensaverIdInUse = settings->GetString(CSettings::SETTING_SCREENSAVER_MODE);
++
+   if (!forceType)
+   {
++    if (m_screensaverIdInUse == "screensaver.xbmc.builtin.dim" ||
++        m_screensaverIdInUse == "screensaver.xbmc.builtin.black" ||
++        m_screensaverIdInUse.empty())
++    {
++      return;
++    }
++
++    // Enforce Dim for special cases.
++    bool bUseDim = false;
+     if (CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true))
+       bUseDim = true;
+     else if (m_appPlayer.IsPlayingVideo() && settings->GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE))
+       bUseDim = true;
+     else if (CServiceBroker::GetPVRManager().GUIActions()->IsRunningChannelScan())
+       bUseDim = true;
+-  }
+ 
+-  if (bUseDim)
+-    m_screensaverIdInUse = "screensaver.xbmc.builtin.dim";
+-  else // Get Screensaver Mode
+-    m_screensaverIdInUse = settings->GetString(CSettings::SETTING_SCREENSAVER_MODE);
++    if (bUseDim)
++      m_screensaverIdInUse = "screensaver.xbmc.builtin.dim";
++  }
+ 
+   if (m_screensaverIdInUse == "screensaver.xbmc.builtin.dim" ||
+-      m_screensaverIdInUse == "screensaver.xbmc.builtin.black")
++      m_screensaverIdInUse == "screensaver.xbmc.builtin.black" ||
++      m_screensaverIdInUse.empty())
+   {
+     return;
+   }
+-  else if (m_screensaverIdInUse.empty())
+-    return;
+   else if (CServiceBroker::GetAddonMgr().GetAddon(m_screensaverIdInUse, m_pythonScreenSaver, ADDON_SCREENSAVER))
+   {
+     std::string libPath = m_pythonScreenSaver->LibPath();


### PR DESCRIPTION
This is important for OLED TV owner.

Kodi PR https://github.com/xbmc/xbmc/pull/16643

Build tested for Generic/RPi2/RPi4.
Run time tested for Generic and RPi4.