### PR TITLE
connman: ignore kernel-configured netdev and improve resolv.conf handling

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -72,7 +72,7 @@ post_makeinstall_target() {
     cp -P $PKG_DIR/scripts/connman-setup $INSTALL/usr/lib/connman
 
   mkdir -p $INSTALL/etc
-    ln -sf /run/connman/resolv.conf $INSTALL/etc/resolv.conf
+    ln -sf /run/resolv.conf $INSTALL/etc/resolv.conf
 
     # /etc/hosts must be writeable
     ln -sf /run/connman/hosts $INSTALL/etc/hosts

--- a/packages/network/connman/scripts/connman-setup
+++ b/packages/network/connman/scripts/connman-setup
@@ -11,9 +11,9 @@
 
 # set variable for connman main.conf location
   if [ -f /storage/.config/connman_main.conf ]; then
-    export CONNMAN_MAIN="--config=/storage/.config/connman_main.conf"
+    CONNMAN_MAIN="--config=/storage/.config/connman_main.conf"
   else
-    export CONNMAN_MAIN="--config=/etc/connman/main.conf"
+    CONNMAN_MAIN="--config=/etc/connman/main.conf"
   fi
 
 # find network device used for given NFS mount
@@ -40,3 +40,5 @@ elif [ -n "$NFS_DEV" -a -e /proc/net/pnp ]; then
 else
   ln -sf /run/connman/resolv.conf /run/resolv.conf
 fi
+
+export CONNMAN_MAIN

--- a/packages/network/connman/scripts/connman-setup
+++ b/packages/network/connman/scripts/connman-setup
@@ -15,3 +15,28 @@
   else
     export CONNMAN_MAIN="--config=/etc/connman/main.conf"
   fi
+
+# find network device used for given NFS mount
+get_nfs_device() {
+  nfs_ip=$(grep -E "^[^ ]+ $1 " /proc/mounts | head -1 | cut -d ':' -f 1)
+  [ -z "$nfs_ip" ] && return
+  NFS_DEV=$(ip route get to "$nfs_ip" | grep -o -E "\\<dev \\w+" | head -1 | sed -e "s/^dev //")
+}
+
+# in case of netboot tell connman to ignore the network device
+# used for NFS mount as it's already configured by the kernel
+NFS_DEV=""
+[ -f /dev/.flash_netboot ] && get_nfs_device /flash
+[ -z "$NFS_DEV" -a -f /dev/.storage_netboot ] && get_nfs_device /storage
+[ -n "$NFS_DEV" ] && CONNMAN_MAIN="$CONNMAN_MAIN -I $NFS_DEV"
+
+# setup resolv.conf.
+# Allow static user configuration and use kernel provided resolver
+# info in case of netboot.
+if [ -f /storage/.config/resolv.conf ]; then
+  ln -sf /storage/.config/resolv.conf /run/resolv.conf
+elif [ -n "$NFS_DEV" -a -e /proc/net/pnp ]; then
+  ln -sf /proc/net/pnp /run/resolv.conf
+else
+  ln -sf /run/connman/resolv.conf /run/resolv.conf
+fi


### PR DESCRIPTION
When netbooting the device used for /flash and/or /storage NFS mounts
is already managed by the kernel and has to be ignored by connman.

Connman only autodetects that case for standard netboot with nfsroot=
on kernel command line but doesn't know about boot= or disk= netboot
in LibreELEC so we have to set up the ignore manually.

When using kernel network (auto-)configuration the kernel provides
/proc/net/pnp with nameserver and in case of dhcp autoconfiguration
also with domain info, in standard resolv.conf format.

Though connman parses /proc/net/pnp if present it only uses the
nameserver info in it when creating resolv.conf but not the domain
info. To fix that use /proc/net/pnp directly as resolv.conf in case
of netboot.

To handle corner cases not covered by connman or kernel resolv.conf
setup allow users to provide their own resolv.conf file in
/storage/.config/