### PR TITLE
pastekodi: add option to allow output to stdout

### DIFF
--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -14,6 +14,27 @@ cat_file() {
   fi
 }
 
+usage() {
+  [ -n "${1}" ] && echo "Unknown argument: ${1}"
+  cat <<EOF
+Usage: $0 [-c] [-h]
+
+  -c   send output to stdout not via /usr/bin/pastebinit
+  -h   this help message
+EOF
+  exit 1
+}
+
+OUTPUT="/usr/bin/pastebinit"
+
+while getopts ":hc" opt; do
+  case ${opt} in
+    c) OUTPUT="cat";;
+    ?) usage "${OPTARG}";;
+    h) usage;;
+  esac
+done
+
 source /etc/os-release
 SYSTEM_ARCH="${LIBREELEC_ARCH#*.}"
 
@@ -70,4 +91,4 @@ fi
   cat_file "${KODI_ROOT}/.smb/smb.conf"
   cat_file "${KODI_ROOT}/.smb/user.conf"
   cat_file "/run/samba/smb.conf"
-) | /usr/bin/pastebinit 2>/dev/null
+) | ${OUTPUT} 2>/dev/null


### PR DESCRIPTION
`pastekodi -c` (and `pastecrash -c`) will now output to stdout, which is useful if `http://ix.io` is not available.