### PR TITLE
xf86-video-nvidia/xf86-video-nvidia-legacy: use toolchain linker

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
@@ -24,7 +24,7 @@ make_target() {
   unset LDFLAGS
 
   cd kernel
-    make module CC=$CC SYSSRC=$(kernel_path) SYSOUT=$(kernel_path)
+    make module CC=${CC} LD=${LD} SYSSRC=$(kernel_path) SYSOUT=$(kernel_path)
     $STRIP --strip-debug nvidia.ko
   cd ..
 }

--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -27,7 +27,7 @@ make_target() {
   unset LDFLAGS
 
   cd kernel
-    make module CC=$CC SYSSRC=$(kernel_path) SYSOUT=$(kernel_path)
+    make module CC=${CC} LD=${LD} SYSSRC=$(kernel_path) SYSOUT=$(kernel_path)
     $STRIP --strip-debug nvidia.ko
   cd ..
 }


### PR DESCRIPTION
Using the (older) host linker may cause errors.

Backport of #3869