### PR TITLE
mesonbuild: udate to 0.52

### DIFF
--- a/packages/compress/xz/package.mk
+++ b/packages/compress/xz/package.mk
@@ -11,7 +11,7 @@ PKG_URL="http://tukaani.org/xz/$PKG_NAME-$PKG_VERSION.tar.bz2"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_DEPENDS_TARGET="gcc:host"
 PKG_LONGDESC="A free general-purpose data compression software with high compression ratio."
-PKG_BUILD_FLAGS="+pic"
+PKG_BUILD_FLAGS="+pic +pic:host"
 
 # never build shared or k0p happens when building
 # on fedora due to host selinux/liblzma

--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.python.org/"
 PKG_URL="http://www.python.org/ftp/python/$PKG_VERSION/${PKG_NAME::-1}-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_HOST="zlib:host bzip2:host libffi:host util-linux:host"
+PKG_DEPENDS_HOST="zlib:host bzip2:host libffi:host util-linux:host xz:host"
 PKG_DEPENDS_TARGET="toolchain sqlite expat zlib bzip2 openssl Python3:host readline ncurses"
 PKG_LONGDESC="Python3 is an interpreted object-oriented programming language."
 
@@ -28,7 +28,7 @@ PKG_CONFIGURE_OPTS_HOST="ac_cv_prog_HAS_HG=/bin/false
                          --disable-readline
                          --disable-bzip2
                          --enable-zlib
-                         --disable-xz
+                         --enable-xz
                          --disable-tk
                          --disable-curses
                          --disable-pydoc

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="0.51.2"
-PKG_SHA256="23688f0fc90be623d98e80e1defeea92bbb7103bf9336a5f5b9865d36e892d76"
+PKG_VERSION="0.52.0"
+PKG_SHA256="d60f75f0dedcc4fd249dbc7519d6f3ce6df490033d276ef1cf27453ef4938d32"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
build tested (incl. addons) for: Generic, RPi2