### PR TITLE
samba: enable nmblookup, for kodi

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -83,7 +83,7 @@ configure_package() {
                       --without-ldb-lmdb \
                       --nopyc --nopyo"
 
-  PKG_SAMBA_TARGET="smbclient,client/smbclient,smbtree,testparm"
+  PKG_SAMBA_TARGET="smbclient,client/smbclient,smbtree,nmblookup,testparm"
 
   if [ "$SAMBA_SERVER" = "yes" ]; then
     PKG_SAMBA_TARGET+=",smbd/smbd,nmbd,smbpasswd"
@@ -143,6 +143,7 @@ post_makeinstall_target() {
   mkdir -p $INSTALL/usr/bin
     cp -PR bin/default/source3/client/smbclient $INSTALL/usr/bin
     cp -PR bin/default/source3/utils/smbtree $INSTALL/usr/bin
+    cp -PR bin/default/source3/utils/nmblookup $INSTALL/usr/bin
     cp -PR bin/default/source3/utils/testparm $INSTALL/usr/bin
 
   if [ "$SAMBA_SERVER" = "yes" ]; then


### PR DESCRIPTION
I noticed when starting a YouTube video with Kodi 18.4 (and also 19), the following error being logged:
```
Oct 15 03:32:58 NUC kodi.sh[1098]: sh: nmblookup: not found
```

[nmblookup](https://www.samba.org/samba/docs/current/man-html/nmblookup.1.html) is being used [by kodi](https://github.com/xbmc/xbmc/blob/05488ed68e4dc4c3cf9e1c4b2907e87bd8f0a26b/xbmc/network/DNSNameCache.cpp#L52) to resolve Samba hostnames, which might be useful and may even explain some issues...

It's a 104KB binary on RPi2/4.