### PR TITLE
libretro-stella: fix PKG_LIBNAME

### DIFF
--- a/packages/emulation/libretro-stella/package.mk
+++ b/packages/emulation/libretro-stella/package.mk
@@ -10,7 +10,7 @@ PKG_URL="https://github.com/libretro/stella-libretro/archive/$PKG_VERSION.tar.gz
 PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_LONGDESC="game.libretro.stella: Stella for Kodi"
 
-PKG_LIBNAME="stella_libretro.so"
+PKG_LIBNAME="stella2014_libretro.so"
 PKG_LIBPATH="$PKG_LIBNAME"
 PKG_LIBVAR="STELLA_LIB"
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/LibreELEC/LibreELEC.tv/commit/480fc09d5aa70697900b84594678fbf2e08af72c which is already in `libreelec-9.2`.