### PR TITLE
init: unmount /update after a failed update

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -671,6 +671,10 @@ check_out_of_space() {
 do_cleanup() {
   StartProgress spinner "Cleaning up... "
 
+  if mountpoint -q /update; then
+    umount /update
+  fi
+
   if [ -d $UPDATE_ROOT/.tmp/mnt ]; then
     if mountpoint -q $UPDATE_ROOT/.tmp/mnt ; then
       # busybox umount deletes loop device automatically
@@ -932,7 +936,6 @@ check_update() {
   umount /sysroot
   update_file "System" "$UPDATE_SYSTEM" "/flash/$IMAGE_SYSTEM"
   update_bootloader
-  umount /update
   do_cleanup
   do_reboot
 }


### PR DESCRIPTION
If updating an RPi4 with RPi2.img.gz, the following occurs:
```
UPDATE IN PROGRESS

Please do not reboot or turn off your LibreELEC device!

Found new compressed image file
Decompressing image file... OK
Mounting system partition...
Checking kernel.img.md5... OK
Checking SYSTEM.md5... OK

ERROR: LibreELEC-RPi2.arm-9.1.502.img.gz is not compatible with RPi4.arm hardware - update cancelled.

Current system: RPi4.arm
Update  system: RPi2.arm

Create /storage/.update/.nocompat to disable compatibility checks and risk a non-booting system.

Cleaning up... |umount: can't unmount /storage/.update/.tmp/mnt: Device or resource busy                                                                                                                    done
Normal startup in 60s... 53
```

The system will boot, but leaves the new image mounted at `/storage/.update/.tmp/mnt`.

Rebooting the system will be successful, but as `/storage/.update/.tmp/mnt` continues to exist, the next time the user attempts an update a "failed update" will be detected and `/storage/.update` will be cleaned.