### PR TITLE
Allwinner: Pick upstreamed patches

### DIFF
--- a/projects/Allwinner/devices/H6/patches/linux/07-opi3.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/07-opi3.patch
@@ -73,9 +73,9 @@ index 17d4969901086..6d6b1f66796d9 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
 @@ -15,6 +15,7 @@
- 
  	aliases {
  		serial0 = &uart0;
+ 		serial1 = &uart1;
 +		ethernet0 = &emac;
  	};
  
@@ -138,89 +138,6 @@ index 17d4969901086..6d6b1f66796d9 100644
  	vmmc-supply = <&reg_cldo1>;
  	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
 
-From 5fd2d3bd956cc875d07433454f18dcbc14e120d5 Mon Sep 17 00:00:00 2001
-From: Ondrej Jirman <megous@megous.com>
-Date: Tue, 26 Mar 2019 15:14:14 +0100
-Subject: [PATCH 24/34] bluetooth: bcm: Add support for loading firmware for
- BCM4345C5
-
-WIP
-
-Signed-off-by: Ondrej Jirman <megous@megous.com>
----
- drivers/bluetooth/btbcm.c   | 3 +++
- drivers/bluetooth/hci_bcm.c | 1 +
- 2 files changed, 4 insertions(+)
-
-diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
-index d5d6e6e5da3bf..a58bf860bcbfc 100644
---- a/drivers/bluetooth/btbcm.c
-+++ b/drivers/bluetooth/btbcm.c
-@@ -37,6 +37,7 @@
- #define BDADDR_BCM4324B3 (&(bdaddr_t) {{0x00, 0x00, 0x00, 0xb3, 0x24, 0x43}})
- #define BDADDR_BCM4330B1 (&(bdaddr_t) {{0x00, 0x00, 0x00, 0xb1, 0x30, 0x43}})
- #define BDADDR_BCM43341B (&(bdaddr_t) {{0xac, 0x1f, 0x00, 0x1b, 0x34, 0x43}})
-+#define BDADDR_BCM4345C5 (&(bdaddr_t) {{0xac, 0x1f, 0x00, 0xc5, 0x45, 0x43}})
- 
- int btbcm_check_bdaddr(struct hci_dev *hdev)
- {
-@@ -82,6 +83,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
- 	    !bacmp(&bda->bdaddr, BDADDR_BCM4324B3) ||
- 	    !bacmp(&bda->bdaddr, BDADDR_BCM4330B1) ||
-+	    !bacmp(&bda->bdaddr, BDADDR_BCM4345C5) ||
- 	    !bacmp(&bda->bdaddr, BDADDR_BCM43430A0) ||
- 	    !bacmp(&bda->bdaddr, BDADDR_BCM43341B)) {
- 		bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
- 			    &bda->bdaddr);
-@@ -339,6 +341,7 @@ static const struct bcm_subver_table bcm_uart_subver_table[] = {
- 	{ 0x2122, "BCM4343A0"	},	/* 001.001.034 */
- 	{ 0x2209, "BCM43430A1"  },	/* 001.002.009 */
- 	{ 0x6119, "BCM4345C0"	},	/* 003.001.025 */
-+	{ 0x6606, "BCM4345C5"	},	/* 003.006.006 */
- 	{ 0x230f, "BCM4356A2"	},	/* 001.003.015 */
- 	{ 0x220e, "BCM20702A1"  },	/* 001.002.014 */
- 	{ 0x4217, "BCM4329B1"   },	/* 002.002.023 */
-diff --git a/drivers/bluetooth/hci_bcm.c b/drivers/bluetooth/hci_bcm.c
-index ddbe518c3e5b8..d5d5ddc3cf1b8 100644
---- a/drivers/bluetooth/hci_bcm.c
-+++ b/drivers/bluetooth/hci_bcm.c
-@@ -1419,6 +1419,7 @@ static void bcm_serdev_remove(struct serdev_device *serdev)
- #ifdef CONFIG_OF
- static const struct of_device_id bcm_bluetooth_of_match[] = {
- 	{ .compatible = "brcm,bcm20702a1" },
-+	{ .compatible = "brcm,bcm4345c5" },
- 	{ .compatible = "brcm,bcm4330-bt" },
- 	{ .compatible = "brcm,bcm43438-bt" },
- 	{ },
-
-From d5626d424fbdc9dde5f8a2e525e88de33fc898cc Mon Sep 17 00:00:00 2001
-From: Ondrej Jirman <megous@megous.com>
-Date: Fri, 12 Apr 2019 13:24:26 +0200
-Subject: [PATCH 25/34] bluetooth: hci_bcm: Give more time to come out of reset
-
-Some devices need more time to come out of reset (eg. BCM4345).
-Increase the post-reset delay. I don't have datasheet, so rather
-be safe than to get intermittent failures during probe.
-
-Signed-off-by: Ondrej Jirman <megous@megous.com>
----
- drivers/bluetooth/hci_bcm.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/drivers/bluetooth/hci_bcm.c b/drivers/bluetooth/hci_bcm.c
-index d5d5ddc3cf1b8..9eacaf8f72ec3 100644
---- a/drivers/bluetooth/hci_bcm.c
-+++ b/drivers/bluetooth/hci_bcm.c
-@@ -263,7 +263,7 @@ static int bcm_gpio_set_power(struct bcm_device *dev, bool powered)
- 	}
- 
- 	/* wait for device to power on and come out of reset */
--	usleep_range(10000, 20000);
-+	usleep_range(50000, 60000);
- 
- 	dev->res_enabled = powered;
- 
-
 From 5141fbafc9bf5f1a7cbb6923bc719f595ce54dae Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 25 Dec 2017 12:10:06 +0800
@@ -280,106 +197,6 @@ index c5c0608e67403..38784589558ca 100644
  		ehci3: usb@5311000 {
  			compatible = "allwinner,sun50i-h6-ehci", "generic-ehci";
  			reg = <0x05311000 0x100>;
-
-FFrom 19ed1005f6d1d2955c9e3e88c3fe037b46284ca8 Mon Sep 17 00:00:00 2001
-From: Ondrej Jirman <megous@megous.com>
-Date: Tue, 26 Mar 2019 15:13:34 +0100
-Subject: [PATCH 32/34] arm64: dts: allwinner: h6: Add pin configs for uart1
-
-Orange Pi 3 uses UART1 for bluetooth. Add pinconfigs so that
-we can use them.
-
-Signed-off-by: Ondrej Jirman <megous@megous.com>
----
- arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi | 10 ++++++++++
- 1 file changed, 10 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
-index 5c5b1240c7790..dc785da9ce0a2 100644
---- a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
-@@ -322,6 +322,16 @@
- 				pins = "PH0", "PH1";
- 				function = "uart0";
- 			};
-+
-+			uart1_pins: uart1-pins {
-+				pins = "PG6", "PG7";
-+				function = "uart1";
-+			};
-+
-+			uart1_rts_cts_pins: uart1-rts-cts-pins {
-+				pins = "PG8", "PG9";
-+				function = "uart1";
-+			};
- 		};
- 
- 		gic: interrupt-controller@3021000 {
-
-From 785248f1b1d89bbd8a25435f873bfa91c27fa123 Mon Sep 17 00:00:00 2001
-From: Ondrej Jirman <megous@megous.com>
-Date: Wed, 27 Mar 2019 13:48:59 +0100
-Subject: [PATCH 33/34] arm64: dts: allwinner: orange-pi-3: Enable UART1 /
- Bluetooth
-
-The board contains AP6256 WiFi/BT module that has its bluetooth
-part connected to SoC's UART1 port. Enable this port, and add
-node for the bluetooth device.
-
-Bluetooth part is named bcm4345c5.
-
-You'll need a BCM4345C5.hcd firmware file that can be found in
-the Xulongs's repository for H6:
-
-https://github.com/orangepi-xunlong/OrangePiH6_external/tree/master/ap6256
-
-Mainline brcmbt driver expects the firmware at the following path
-relative to the firmware directory:
-
-  brcm/BCM4345C5.hcd
-
-Signed-off-by: Ondrej Jirman <megous@megous.com>
----
- .../dts/allwinner/sun50i-h6-orangepi-3.dts    | 19 +++++++++++++++++++
- 1 file changed, 19 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
-index f795362f5b77e..d9e8610b5f83f 100644
---- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
-@@ -15,6 +15,7 @@
- 
- 	aliases {
- 		serial0 = &uart0;
-+		serial1 = &uart1;
- 		ethernet0 = &emac;
- 	};
- 
-@@ -324,6 +325,24 @@
- 	status = "okay";
- };
- 
-+/* There's the BT part of the AP6256 connected to that UART */
-+&uart1 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
-+	uart-has-rtscts;
-+	status = "okay";
-+
-+	bluetooth {
-+		compatible = "brcm,bcm4345c5";
-+		clocks = <&rtc 1>;
-+		clock-names = "lpo";
-+		device-wakeup-gpios = <&r_pio 1 2 GPIO_ACTIVE_HIGH>; /* PM2 */
-+		host-wakeup-gpios = <&r_pio 1 1 GPIO_ACTIVE_HIGH>; /* PM1 */
-+		shutdown-gpios = <&r_pio 1 4 GPIO_ACTIVE_HIGH>; /* PM4 */
-+		max-speed = <1500000>;
-+	};
-+};
-+
- &usb2otg {
- 	/*
- 	 * This board doesn't have a controllable VBUS even though it
 
 From c74e4ba1e28d5808cda02b34eee59dc1a5f15a6d Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megous@megous.com>

--- a/projects/Allwinner/patches/linux/0001-backport-from-5.4.patch
+++ b/projects/Allwinner/patches/linux/0001-backport-from-5.4.patch
@@ -5706,3 +5706,97 @@ index e6fb9683f213..25099202c52c 100644
 -- 
 2.23.0
 
+From 52c8c7a766ecc49ff2e4c1db30b0a24a019e31d4 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Fri, 23 Aug 2019 12:31:36 +0200
+Subject: [PATCH] bluetooth: bcm: Add support for loading firmware for
+ BCM4345C5
+
+Detect BCM4345C5 and load a corresponding firmware file.
+
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/btbcm.c   | 3 +++
+ drivers/bluetooth/hci_bcm.c | 1 +
+ 2 files changed, 4 insertions(+)
+
+diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
+index 124ef0a3e1dd..2d2e6d862068 100644
+--- a/drivers/bluetooth/btbcm.c
++++ b/drivers/bluetooth/btbcm.c
+@@ -23,6 +23,7 @@
+ #define BDADDR_BCM43430A0 (&(bdaddr_t) {{0xac, 0x1f, 0x12, 0xa0, 0x43, 0x43}})
+ #define BDADDR_BCM4324B3 (&(bdaddr_t) {{0x00, 0x00, 0x00, 0xb3, 0x24, 0x43}})
+ #define BDADDR_BCM4330B1 (&(bdaddr_t) {{0x00, 0x00, 0x00, 0xb1, 0x30, 0x43}})
++#define BDADDR_BCM4345C5 (&(bdaddr_t) {{0xac, 0x1f, 0x00, 0xc5, 0x45, 0x43}})
+ #define BDADDR_BCM43341B (&(bdaddr_t) {{0xac, 0x1f, 0x00, 0x1b, 0x34, 0x43}})
+ 
+ int btbcm_check_bdaddr(struct hci_dev *hdev)
+@@ -73,6 +74,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
+ 	    !bacmp(&bda->bdaddr, BDADDR_BCM2076B1) ||
+ 	    !bacmp(&bda->bdaddr, BDADDR_BCM4324B3) ||
+ 	    !bacmp(&bda->bdaddr, BDADDR_BCM4330B1) ||
++	    !bacmp(&bda->bdaddr, BDADDR_BCM4345C5) ||
+ 	    !bacmp(&bda->bdaddr, BDADDR_BCM43430A0) ||
+ 	    !bacmp(&bda->bdaddr, BDADDR_BCM43341B)) {
+ 		bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
+@@ -332,6 +334,7 @@ static const struct bcm_subver_table bcm_uart_subver_table[] = {
+ 	{ 0x2122, "BCM4343A0"	},	/* 001.001.034 */
+ 	{ 0x2209, "BCM43430A1"  },	/* 001.002.009 */
+ 	{ 0x6119, "BCM4345C0"	},	/* 003.001.025 */
++	{ 0x6606, "BCM4345C5"	},	/* 003.006.006 */
+ 	{ 0x230f, "BCM4356A2"	},	/* 001.003.015 */
+ 	{ 0x220e, "BCM20702A1"  },	/* 001.002.014 */
+ 	{ 0x4217, "BCM4329B1"   },	/* 002.002.023 */
+diff --git a/drivers/bluetooth/hci_bcm.c b/drivers/bluetooth/hci_bcm.c
+index 4d9de20bab7b..95c312ae94cf 100644
+--- a/drivers/bluetooth/hci_bcm.c
++++ b/drivers/bluetooth/hci_bcm.c
+@@ -1419,6 +1419,7 @@ static void bcm_serdev_remove(struct serdev_device *serdev)
+ #ifdef CONFIG_OF
+ static const struct of_device_id bcm_bluetooth_of_match[] = {
+ 	{ .compatible = "brcm,bcm20702a1" },
++	{ .compatible = "brcm,bcm4345c5" },
+ 	{ .compatible = "brcm,bcm4330-bt" },
+ 	{ .compatible = "brcm,bcm43438-bt" },
+ 	{ },
+-- 
+2.23.0
+
+From 16946de5905fff243c1e4415c4565803945e8c47 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Fri, 23 Aug 2019 12:31:37 +0200
+Subject: [PATCH] bluetooth: hci_bcm: Give more time to come out of reset
+
+Some supported devices need more time to come out of reset (eg.
+BCM4345C5 in AP6256).
+
+I don't have/found a datasheet, so the value was arrive at
+experimentally with the Oprange Pi 3 board. Without increased delay,
+I got intermittent failures during probe. This is a Bluetooth 5.0
+device, so maybe that's why it takes longer to initialize than the
+others.
+
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/hci_bcm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/bluetooth/hci_bcm.c b/drivers/bluetooth/hci_bcm.c
+index 95c312ae94cf..7646636f2d18 100644
+--- a/drivers/bluetooth/hci_bcm.c
++++ b/drivers/bluetooth/hci_bcm.c
+@@ -260,7 +260,7 @@ static int bcm_gpio_set_power(struct bcm_device *dev, bool powered)
+ 	}
+ 
+ 	/* wait for device to power on and come out of reset */
+-	usleep_range(10000, 20000);
++	usleep_range(100000, 120000);
+ 
+ 	dev->res_enabled = powered;
+ 
+-- 
+2.23.0
+

--- a/projects/Allwinner/patches/linux/0002-backport-from-5.5.patch
+++ b/projects/Allwinner/patches/linux/0002-backport-from-5.5.patch
@@ -266,3 +266,215 @@ index d89353a3cdec..e254c06c8621 100644
 -- 
 2.23.0
 
+From 1606cf29f8e743fe254485bb350f0d9d3c33affd Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Fri, 4 Oct 2019 00:14:15 +0200
+Subject: [PATCH] arm64: dts: allwinner: a64: orangepi-win: Enable audio codec
+
+This patch enables internal audio codec on OrangePi Win board by
+enabling all relevant nodes and adding appropriate routing. Board has
+on-board microphone (MIC1) and 3.5 mm jack with stereo audio and
+microphone (MIC2).
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ .../dts/allwinner/sun50i-a64-orangepi-win.dts | 29 +++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-orangepi-win.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-orangepi-win.dts
+index 04446e4716c4..f54a415f2e3b 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-orangepi-win.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-orangepi-win.dts
+@@ -114,6 +114,19 @@
+ 	};
+ };
+ 
++&codec {
++	status = "okay";
++};
++
++&codec_analog {
++	cpvdd-supply = <&reg_eldo1>;
++	status = "okay";
++};
++
++&dai {
++	status = "okay";
++};
++
+ &de {
+ 	status = "okay";
+ };
+@@ -333,6 +346,22 @@
+ 	vcc-hdmi-supply = <&reg_dldo1>;
+ };
+ 
++&sound {
++	status = "okay";
++	simple-audio-card,widgets = "Headphone", "Headphone Jack",
++				    "Microphone", "Microphone Jack",
++				    "Microphone", "Onboard Microphone";
++	simple-audio-card,routing =
++			"Left DAC", "AIF1 Slot 0 Left",
++			"Right DAC", "AIF1 Slot 0 Right",
++			"AIF1 Slot 0 Left ADC", "Left ADC",
++			"AIF1 Slot 0 Right ADC", "Right ADC",
++			"Headphone Jack", "HP",
++			"MIC2", "Microphone Jack",
++			"Onboard Microphone", "MBIAS",
++			"MIC1", "Onboard Microphone";
++};
++
+ &spi0 {
+ 	status = "okay";
+ 
+-- 
+2.23.0
+
+From cd380e0d00b2b21506f9319a626b6205e9d64aae Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Mon, 7 Oct 2019 22:31:51 +0200
+Subject: [PATCH] arm64: dts: allwinner: h6: Add pin configs for uart1
+
+Orange Pi 3 uses UART1 for bluetooth. Add pinconfigs so that we can use
+them.
+
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+Signed-off-by: Maxime Ripard <mripard@kernel.org>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
+index 4020a1aafa3e..0754f01fd731 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
+@@ -299,6 +299,16 @@
+ 				pins = "PH0", "PH1";
+ 				function = "uart0";
+ 			};
++
++			uart1_pins: uart1-pins {
++				pins = "PG6", "PG7";
++				function = "uart1";
++			};
++
++			uart1_rts_cts_pins: uart1-rts-cts-pins {
++				pins = "PG8", "PG9";
++				function = "uart1";
++			};
+ 		};
+ 
+ 		gic: interrupt-controller@3021000 {
+-- 
+2.23.0
+
+From 351170463471d2037aa034625d05f185e6d85f80 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Mon, 7 Oct 2019 22:31:52 +0200
+Subject: [PATCH] arm64: dts: allwinner: orange-pi-3: Enable UART1 / Bluetooth
+
+The board contains AP6256 WiFi/BT module that has its bluetooth part
+connected to SoC's UART1 port. Enable this port, and add node for the
+bluetooth device.
+
+Bluetooth part is named bcm4345c5.
+
+You'll need a BCM4345C5.hcd firmware file that can be found in the
+Xulongs's repository for H6:
+
+https://github.com/orangepi-xunlong/OrangePiH6_external/tree/master/ap6256
+
+The driver expects the firmware at the following path relative to the
+firmware directory:
+
+  brcm/BCM4345C5.hcd
+
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+Signed-off-by: Maxime Ripard <mripard@kernel.org>
+---
+ .../dts/allwinner/sun50i-h6-orangepi-3.dts    | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
+index eb379cd402ac..2557cc6c8d50 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
+@@ -15,6 +15,7 @@
+ 
+ 	aliases {
+ 		serial0 = &uart0;
++		serial1 = &uart1;
+ 	};
+ 
+ 	chosen {
+@@ -269,6 +270,24 @@
+ 	status = "okay";
+ };
+ 
++/* There's the BT part of the AP6256 connected to that UART */
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	uart-has-rtscts;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm4345c5";
++		clocks = <&rtc 1>;
++		clock-names = "lpo";
++		device-wakeup-gpios = <&r_pio 1 2 GPIO_ACTIVE_HIGH>; /* PM2 */
++		host-wakeup-gpios = <&r_pio 1 1 GPIO_ACTIVE_HIGH>; /* PM1 */
++		shutdown-gpios = <&r_pio 1 4 GPIO_ACTIVE_HIGH>; /* PM4 */
++		max-speed = <1500000>;
++	};
++};
++
+ &usb2otg {
+ 	/*
+ 	 * This board doesn't have a controllable VBUS even though it
+-- 
+2.23.0
+
+From fadfee3f9d8f114435a8a3e9f83a227600d89de7 Mon Sep 17 00:00:00 2001
+From: Daniel Kurtz <djkurtz@chromium.org>
+Date: Tue, 8 Oct 2019 18:21:45 +0800
+Subject: [PATCH] drm/bridge: dw-hdmi: Restore audio when setting a mode
+
+When setting a new display mode, dw_hdmi_setup() calls
+dw_hdmi_enable_video_path(), which disables all hdmi clocks, including
+the audio clock.
+
+We should only (re-)enable the audio clock if audio was already enabled
+when setting the new mode.
+
+Without this patch, on RK3288, there will be HDMI audio on some monitors
+if i2s was played to headphone when the monitor was plugged.
+ACER H277HU and ASUS PB278 are two of the monitors showing this issue.
+
+Signed-off-by: Cheng-Yi Chiang <cychiang@chromium.org>
+Signed-off-by: Daniel Kurtz <djkurtz@chromium.org>
+Signed-off-by: Yakir Yang <ykk@rock-chips.com>
+Reviewed-by: Neil Armstrong <narmstrong@baylibre.com>
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20191008102145.55134-1-cychiang@chromium.org
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index fdc29869d75a..dbe38a54870b 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -2090,7 +2090,7 @@ static int dw_hdmi_setup(struct dw_hdmi *hdmi, struct drm_display_mode *mode)
+ 
+ 		/* HDMI Initialization Step E - Configure audio */
+ 		hdmi_clk_regenerator_update_pixel_clock(hdmi);
+-		hdmi_enable_audio_clk(hdmi, true);
++		hdmi_enable_audio_clk(hdmi, hdmi->audio_enable);
+ 	}
+ 
+ 	/* not for DVI mode */
+-- 
+2.23.0
+


### PR DESCRIPTION
Apart from grouping merged patches, this PR also includes upstreamed patch for OrangePi Win analog audio and one DW-HDMI patch which fixes HDMI audio issue with certain monitors.