### PR TITLE
pulseaudio: enable speex support 

### DIFF
--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="961b23ca1acfd28f2bc87414c27bb40e12436efcf2158d29721b1e89f3f28057"
 PKG_LICENSE="GPL"
 PKG_SITE="http://pulseaudio.org/"
 PKG_URL="http://www.freedesktop.org/software/pulseaudio/releases/$PKG_NAME-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="toolchain alsa-lib dbus libcap libsndfile libtool openssl soxr systemd glib:host"
+PKG_DEPENDS_TARGET="toolchain alsa-lib dbus libcap libsndfile libtool openssl soxr speexdsp systemd glib:host"
 PKG_LONGDESC="PulseAudio is a sound system for POSIX OSes, meaning that it is a proxy for your sound applications."
 PKG_TOOLCHAIN="meson"
 
@@ -58,7 +58,7 @@ PKG_MESON_OPTS_TARGET="-Dgcov=false \
                        -Dorc=disabled \
                        -Dsamplerate=disabled \
                        -Dsoxr=enabled \
-                       -Dspeex=disabled \
+                       -Dspeex=enabled \
                        -Dsystemd=enabled \
                        -Dudev=enabled \
                        -Dx11=disabled \

--- a/packages/audio/speexdsp/package.mk
+++ b/packages/audio/speexdsp/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="speexdsp"
+PKG_VERSION="1.2.0"
+PKG_SHA256="682042fc6f9bee6294ec453f470dadc26c6ff29b9c9e9ad2ffc1f4312fd64771"
+PKG_LICENSE="BSD"
+PKG_SITE="https://speex.org"
+PKG_URL="http://downloads.us.xiph.org/releases/speex/speexdsp-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Speex audio processing library"


### PR DESCRIPTION
This fixes the following warning:

```
You do not have speex support enabled. It is strongly recommended
that you enable speex support if your platform supports it as it is
the primary method used for audio resampling and is thus a critical
part of PulseAudio on that platform.
```

Note that this commit was done on top of the meson changes in #3928 thus the meson warning in the commit message. Ideally this can merge after the meson changes and I can update this to use meson instead.