### PR TITLE
config/functions: ensure enable_service tells us why it failed

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1298,11 +1298,12 @@ add_group() {
 # Usage: enable_service <unit> [target]
 enable_service() {
   local unit="$1"
-  local unit_dir="/usr/lib/systemd/system"
+  local unit_dir="usr/lib/systemd/system"
   local target="$2"
   local target_dir=$INSTALL
 
-  [ -f "$target_dir/$unit_dir/$unit" ] || die
+  [ -f "$target_dir/$unit_dir/$unit" ] || die "ERROR: cannot enable non-existent service $target_dir/$unit_dir/$unit"
+
   if [ -z "$target" ] ; then
     for target in `grep '^WantedBy' $target_dir/$unit_dir/$unit | cut -f2 -d=` ; do
       if [ -n "$target" ]; then


### PR DESCRIPTION
Also, remove leading `/` from unit_dir to avoid a double `//` when creating the full path.