### PR TITLE
bluez: Auto configure unconfigured interfaces

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -63,10 +63,15 @@ post_makeinstall_target() {
 
   # bluez looks in /etc/firmware/
     ln -sf /usr/lib/firmware $INSTALL/etc/firmware
+
+  # following programs are needed to set MAC address on some devices
+    cp -P tools/btmgmt $INSTALL/usr/bin
+    cp $PKG_DIR/scripts/setbtmac $INSTALL/usr/bin/
 }
 
 post_install() {
   enable_service bluetooth-defaults.service
   enable_service bluetooth.service
   enable_service obex.service
+  enable_service bluetooth-mac.service
 }

--- a/packages/network/bluez/scripts/setbtmac
+++ b/packages/network/bluez/scripts/setbtmac
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+AWK_PROG='
+/^hci[0-9]*:/ { interface = substr($1, 0, length($1) - 1) }
+/^[[:space:]]*missing options: public-address[[:space:]]?$/ { print interface }
+'
+
+for INTERFACE in $(btmgmt config | awk -e "${AWK_PROG}"); do
+  MAC_FILE="/storage/.config/btmac-$INTERFACE.txt"
+  MAC_ADDR=""
+
+  # load and validate mac address, if exists
+  if [ -f "$MAC_FILE" ]; then
+    MAC_ADDR=$(grep -E "^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$" $MAC_FILE)
+  fi
+
+  # if mac is not valid or file doesn't exist, generate a random one and save it
+  if [ -z "$MAC_ADDR" ]; then
+    MAC_ADDR=$(od -An -N6 -t xC /dev/urandom | cut -c2- | sed -e 's/ /:/g')
+    echo "$MAC_ADDR" > "$MAC_FILE"
+  fi
+
+  btmgmt --index ${INTERFACE:3} public-addr $MAC_ADDR
+done

--- a/packages/network/bluez/system.d/bluetooth-mac.service
+++ b/packages/network/bluez/system.d/bluetooth-mac.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Bluetooth MAC configuration
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/setbtmac
+StandardInput=tty
+TTYPath=/dev/tty1
+
+[Install]
+WantedBy=bluetooth.target


### PR DESCRIPTION
Some bluetooth modules might not come with pre-programmed MAC address. Add a script to configure them and start it by systemd service.

While this is originally made for OrangePi 3 board, it applies to any kind of HW.

Thanks to @MilhouseVH for help with output parsing.