### PR TITLE
rpi-eeprom: update with vl805 support [backport]

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="a799a10652567cfd327fd588cf0e180d9962cf61"
-PKG_SHA256="d72329051ac748cb6764597b36b2a6ed965f9b95c11a224b1a92ddf27db721be"
+PKG_VERSION="6dbbbed01f8173b346319b5bd501134920678403"
+PKG_SHA256="9c1de9d5dbf0bbf8296651a350bbe8091af1e2426f415253167b53ea2bccf200"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -574,10 +574,13 @@ mount_flash() {
 cleanup_flash() {
   progress "Cleaning up flash (if required)"
 
-  if [ -f /flash/pieeprom.upd ]; then
+  if [ -f /flash/pieeprom.bin -o -f /flash/pieeprom.upd -o -f /flash/vl805.bin ]; then
     mount -o remount,rw /flash
-    rm -f /flash/pieeprom.bin /flash/pieeprom.upd
+
+    rm -f /flash/pieeprom.bin /flash/pieeprom.upd /flash/pieeprom.sig
+    rm -f /flash/vl805.bin /flash/vl805.sig
     rm -f /flash/recovery.bin /flash/recovery.[0-9][0-9][0-9] /flash/RECOVERY.[0-9][0-9][0-9]
+
     mount -o remount,ro /flash
   fi
 }

--- a/packages/sysutils/busybox/scripts/rpi-flash-firmware
+++ b/packages/sysutils/busybox/scripts/rpi-flash-firmware
@@ -9,51 +9,30 @@ FLAG_FILE="/storage/.rpi_flash_firmware"
 
 hidecursor
 
-if ! mount -o remount,rw /flash 2>/dev/null; then
-  # Remove flag file and bail out
-  rm -f "${FLAG_FILE}"
-  sync
-
-  echo "ERROR: Unable to mount /flash as a read/write file system."
-  echo
-  echo "Aborting Flash update process - please proceed with a manual update."
-  echo
-
-  StartProgress countdown "Rebooting in 15s... " 15 "NOW"
-fi
-
 if [ -f "${FLAG_FILE}" ]; then
   . ${FLAG_FILE}
+  rm -f "${FLAG_FILE}"
 
-  # Prepare flashing environment
-  if [ "${MODE}" = "init" ]; then
-    # Install new SPI bootloader files to /flash (if required)
-    if [ "${BOOTLOADER}" = "yes" ]; then
-      USE_FLASHROM=0 /usr/bin/.rpi-eeprom-update.real -a
-    fi
+  if ! mount -o remount,rw /flash 2>/dev/null; then
+    echo "ERROR: Unable to mount /flash as a read/write file system."
+    echo
+    echo "Aborting Flash update process - please proceed with a manual update."
+    echo
 
-    # Bump process to next step
-    sed -e 's/^MODE=.*/MODE="update"/' -i "${FLAG_FILE}"
-    sync
-  else
-    rm -f "${FLAG_FILE}"
-    sync
+    StartProgress countdown "Rebooting in 15s... " 15 "NOW"
+    reboot -f &>/dev/null
+  fi
 
-    if [ "${MODE}" = "update" ]; then
-      # Display current bootloader status
-      if [ "${BOOTLOADER}" = "yes" ]; then
-        USE_FLASHROM=0 /usr/bin/.rpi-eeprom-update.real
-      fi
+  # Install new bootloader and/or USB3 firmware files to /flash
+  # Firmware flashing will occur during the next boot, after
+  # which the system will again reboot.
+  # Old firmware files will be automatically removed by init.
+  CMD_ARGS=""
+  [ "${BOOTLOADER}" = "yes" ] && CMD_ARGS="${CMD_ARGS} -A bootloader"
+  [ "${VL805}" = "yes" ] && CMD_ARGS="${CMD_ARGS} -A vl805"
 
-      # Apply VIA USB3 update
-#      if [ "${USB3}" = "yes" ]; then
-#        /usr/bin/vl805
-#      fi
-
-      sync
-      echo ""
-      StartProgress countdown "Rebooting in 15s... " 15 "NOW"
-    fi
+  if [ -n "${CMD_ARGS}" ]; then
+    USE_FLASHROM=0 /usr/bin/.rpi-eeprom-update.real ${CMD_ARGS}
   fi
 
   sync

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="741bf84e3262b9303470cd02689d297aef4a8c95"
-PKG_SHA256="8d84824068ef6ed10d22d69d84199f1ac38a1dbe4fb1c5ae63ca153e38ec1339"
+PKG_VERSION="b360b29ab64bb1cbf223d21aa6086d6541675471"
+PKG_SHA256="58196f74d9b9b62f22f966441a7822962ff28c6633578e4863ab356a9d6a8ba7"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -19,17 +19,26 @@ makeinstall_target() {
     _dirs="critical"
     [ "$LIBREELEC_VERSION" = "devel" ] && _dirs+=" beta"
     for _dir in ${_dirs}; do
-      if [ -n "$(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* 2>/dev/null)" ]; then
-        mkdir -p ${DESTDIR}/${_dir}
-          cp -PRv $(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* | tail -1) ${DESTDIR}/${_dir}
-          cp -PRv ${PKG_BUILD}/firmware/${_dir}/recovery.bin ${DESTDIR}/${_dir}
-      fi
+      mkdir -p ${DESTDIR}/${_dir}
+        cp -PRv ${PKG_BUILD}/firmware/${_dir}/recovery.bin ${DESTDIR}/${_dir}
+
+        # Bootloader SPI
+        PKG_FW_FILE="$(ls -1 ${PKG_BUILD}/firmware/${_dir}/pieeprom-* 2>/dev/null | tail -1)"
+        [ -n "${PKG_FW_FILE}" ] && cp -PRv "${PKG_FW_FILE}" ${DESTDIR}/${_dir}
+
+        # VIA USB3
+        if [ -f ${PKG_BUILD}/firmware/${_dir}/vl805.latest ]; then
+          PKG_FW_FILE="$(tail -1 ${PKG_BUILD}/firmware/${_dir}/vl805.latest)"
+          cp -PRv ${PKG_BUILD}/firmware/${_dir}/vl805-${PKG_FW_FILE}.bin ${DESTDIR}/${_dir}
+          cp -PRv ${PKG_BUILD}/firmware/${_dir}/vl805.latest ${DESTDIR}/${_dir}
+        fi
     done
 
   mkdir -p ${INSTALL}/usr/bin
     cp -PRv ${PKG_DIR}/source/rpi-eeprom-update ${INSTALL}/usr/bin
     cp -PRv ${PKG_BUILD}/rpi-eeprom-update ${INSTALL}/usr/bin/.rpi-eeprom-update.real
     cp -PRv ${PKG_BUILD}/rpi-eeprom-config ${INSTALL}/usr/bin
+    cp -PRv ${PKG_BUILD}/vl805 ${INSTALL}/usr/bin
 
   mkdir -p ${INSTALL}/etc/default
     cp -PRv ${PKG_DIR}/config/* ${INSTALL}/etc/default

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="9202943804f01fe8015cdaab692be8092d11719d"
-PKG_SHA256="9833abdfd47f1dd5c8bd4f993e9f103259d3aa35c065a04e25f1bde035ebdaca"
+PKG_VERSION="99e88912af108d46e4edd5f168634b84883c1d86"
+PKG_SHA256="13057de869bbfef78138c67c4315a43370e6409cf1798d0828de01a879b91c4d"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="b360b29ab64bb1cbf223d21aa6086d6541675471"
-PKG_SHA256="58196f74d9b9b62f22f966441a7822962ff28c6633578e4863ab356a9d6a8ba7"
+PKG_VERSION="9202943804f01fe8015cdaab692be8092d11719d"
+PKG_SHA256="9833abdfd47f1dd5c8bd4f993e9f103259d3aa35c065a04e25f1bde035ebdaca"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
@@ -38,7 +38,7 @@ makeinstall_target() {
     cp -PRv ${PKG_DIR}/source/rpi-eeprom-update ${INSTALL}/usr/bin
     cp -PRv ${PKG_BUILD}/rpi-eeprom-update ${INSTALL}/usr/bin/.rpi-eeprom-update.real
     cp -PRv ${PKG_BUILD}/rpi-eeprom-config ${INSTALL}/usr/bin
-    cp -PRv ${PKG_BUILD}/vl805 ${INSTALL}/usr/bin
+    cp -PRv ${PKG_BUILD}/firmware/vl805 ${INSTALL}/usr/bin
 
   mkdir -p ${INSTALL}/etc/default
     cp -PRv ${PKG_DIR}/config/* ${INSTALL}/etc/default


### PR DESCRIPTION
Backport of #3807, this adds support for updating USB3 firmware, with corresponding firmware.

~Needs to be updated once https://github.com/LibreELEC/service.libreelec.settings/pull/141 is merged.~