### PR TITLE
libprojectM: update to libprojectM-3.1.1-rc4

### DIFF
--- a/packages/graphics/libprojectM/package.mk
+++ b/packages/graphics/libprojectM/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libprojectM"
-PKG_VERSION="8b52061e17ace56737de191b81adf3c3df34504e"
-PKG_SHA256="1bc4a2b9a0310b5215ff29b4bd12c807c776174ea28c11acf37b76587e88c7b8"
+PKG_VERSION="3.1.1-rc4"
+PKG_SHA256="a0a3cf3a24e372ddfaab43c509c679ed8f5f0e962093228d2982c58e59eb2034"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/projectM-visualizer/projectm"
 PKG_URL="https://github.com/projectM-visualizer/projectm/archive/$PKG_VERSION.tar.gz"
@@ -14,7 +14,10 @@ PKG_TOOLCHAIN="configure"
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
-                           --enable-static"
+                           --enable-static \
+                           --disable-qt \
+                           --disable-pulseaudio \
+                           --disable-jack"
 
 # workaround due broken release files, remove at next bump
 pre_configure_target() {


### PR DESCRIPTION
`visualization.projectm` doesn't build with the current `libprojectM` - the upstream add-on is using 3.1.1-rc4 for both Leia and Matrix.

https://github.com/xbmc/visualization.projectm/blob/Leia/depends/common/projectm/projectm.txt

I'll include this commit on #3908 
