### PR TITLE
kodi (Generic): update to kodi 19 snapshot with Python3

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -25,8 +25,8 @@ case $KODI_VENDOR in
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;
   *)
-    PKG_VERSION="e31d257e4b6a9c5a622bb280d4abc4e44dc9eca5" # kodi19-pre-python3
-    PKG_SHA256="d8647c883661685bbcae6fd9f3312298636f4cacfb1b2ee53d4d349028579ffa"
+    PKG_VERSION="05488ed68e4dc4c3cf9e1c4b2907e87bd8f0a26b" # kodi-19-with-Python3
+    PKG_SHA256="830756b753b01dc313f640206cb08293f21ac82e6069b5973d298a526700d0c7"
     PKG_URL="https://github.com/xbmc/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$PKG_VERSION.tar.gz"
     ;;


### PR DESCRIPTION
#3906 accidentally merged (now reverted).

This PR is mainly for testing at this time, to aid Python3 progress.