### PR TITLE
Allwinner: H6: Add RC keymap for Beelink GS1

### DIFF
--- a/projects/Allwinner/devices/H6/patches/linux/10-beelink-gs1.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/10-beelink-gs1.patch
@@ -37,3 +37,171 @@ index 0dc33c90dd60..ef595e6a0cd6 100644
 +};
 -- 
 2.20.1
+From b1cff682042c5aa6f5fc9204018fe7466503e2cf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Cl=C3=A9ment=20P=C3=A9ron?= <peron.clem@gmail.com>
+Date: Mon, 21 Oct 2019 23:09:10 +0200
+Subject: [PATCH 1/2] media: rc: add keymap for Beelink GS1 remote control
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Beelink GS1 Andoid TV Box ships with a simple NEC remote.
+
+Signed-off-by: Clément Péron <peron.clem@gmail.com>
+---
+ drivers/media/rc/keymaps/Makefile             |  1 +
+ drivers/media/rc/keymaps/rc-beelink-gs1.c     | 84 +++++++++++++++++++
+ include/media/rc-map.h                        |  1 +
+ 4 files changed, 87 insertions(+)
+ create mode 100644 drivers/media/rc/keymaps/rc-beelink-gs1.c
+
+diff --git a/drivers/media/rc/keymaps/Makefile b/drivers/media/rc/keymaps/Makefile
+index 4ab4af062abf..63261ef6380a 100644
+--- a/drivers/media/rc/keymaps/Makefile
++++ b/drivers/media/rc/keymaps/Makefile
+@@ -17,6 +17,7 @@ obj-$(CONFIG_RC_MAP) += rc-adstech-dvb-t-pci.o \
+ 			rc-avermedia-rm-ks.o \
+ 			rc-avertv-303.o \
+ 			rc-azurewave-ad-tu700.o \
++			rc-beelink-gs1.o \
+ 			rc-behold.o \
+ 			rc-behold-columbus.o \
+ 			rc-budget-ci-old.o \
+diff --git a/drivers/media/rc/keymaps/rc-beelink-gs1.c b/drivers/media/rc/keymaps/rc-beelink-gs1.c
+new file mode 100644
+index 000000000000..cedbd5d20bc7
+--- /dev/null
++++ b/drivers/media/rc/keymaps/rc-beelink-gs1.c
+@@ -0,0 +1,84 @@
++// SPDX-License-Identifier: GPL-2.0+
++// Copyright (c) 2019 Clément Péron
++
++#include <media/rc-map.h>
++#include <linux/module.h>
++
++/*
++ * Keymap for the Beelink GS1 remote control
++ */
++
++static struct rc_map_table beelink_gs1_table[] = {
++	/*
++	 * TV Keys (Power, Learn and Volume)
++	 * { 0x40400d, KEY_TV },
++	 * { 0x80f1, KEY_TV },
++	 * { 0x80f3, KEY_TV },
++	 * { 0x80f4, KEY_TV },
++	 */
++
++	{ 0x8051, KEY_POWER },
++	{ 0x804d, KEY_MUTE },
++	{ 0x8040, KEY_CONFIG },
++
++	{ 0x8026, KEY_UP },
++	{ 0x8028, KEY_DOWN },
++	{ 0x8025, KEY_LEFT },
++	{ 0x8027, KEY_RIGHT },
++	{ 0x800d, KEY_OK },
++
++	{ 0x8053, KEY_HOME },
++	{ 0x80bc, KEY_MEDIA },
++	{ 0x801b, KEY_BACK },
++	{ 0x8049, KEY_MENU },
++
++	{ 0x804e, KEY_VOLUMEUP },
++	{ 0x8056, KEY_VOLUMEDOWN },
++
++	{ 0x8054, KEY_SUBTITLE }, /* Web */
++	{ 0x8052, KEY_EPG }, /* Media */
++
++	{ 0x8041, KEY_CHANNELUP },
++	{ 0x8042, KEY_CHANNELDOWN },
++
++	{ 0x8031, KEY_1 },
++	{ 0x8032, KEY_2 },
++	{ 0x8033, KEY_3 },
++
++	{ 0x8034, KEY_4 },
++	{ 0x8035, KEY_5 },
++	{ 0x8036, KEY_6 },
++
++	{ 0x8037, KEY_7 },
++	{ 0x8038, KEY_8 },
++	{ 0x8039, KEY_9 },
++
++	{ 0x8044, KEY_DELETE },
++	{ 0x8030, KEY_0 },
++	{ 0x8058, KEY_MODE }, /* # Input Method */
++};
++
++static struct rc_map_list beelink_gs1_map = {
++	.map = {
++		.scan     = beelink_gs1_table,
++		.size     = ARRAY_SIZE(beelink_gs1_table),
++		.rc_proto = RC_PROTO_NEC,
++		.name     = RC_MAP_BEELINK_GS1,
++	}
++};
++
++static int __init init_rc_map_beelink_gs1(void)
++{
++	return rc_map_register(&beelink_gs1_map);
++}
++
++static void __exit exit_rc_map_beelink_gs1(void)
++{
++	rc_map_unregister(&beelink_gs1_map);
++}
++
++module_init(init_rc_map_beelink_gs1)
++module_exit(exit_rc_map_beelink_gs1)
++
++MODULE_LICENSE("GPL");
++MODULE_AUTHOR("Clément Péron <peron.clem@gmail.com>");
+diff --git a/include/media/rc-map.h b/include/media/rc-map.h
+index 0a8669daeaaa..f99575a0d29c 100644
+--- a/include/media/rc-map.h
++++ b/include/media/rc-map.h
+@@ -168,6 +168,7 @@ struct rc_map *rc_map_get(const char *name);
+ #define RC_MAP_AVERMEDIA_RM_KS           "rc-avermedia-rm-ks"
+ #define RC_MAP_AVERTV_303                "rc-avertv-303"
+ #define RC_MAP_AZUREWAVE_AD_TU700        "rc-azurewave-ad-tu700"
++#define RC_MAP_BEELINK_GS1               "rc-beelink-gs1"
+ #define RC_MAP_BEHOLD_COLUMBUS           "rc-behold-columbus"
+ #define RC_MAP_BEHOLD                    "rc-behold"
+ #define RC_MAP_BUDGET_CI_OLD             "rc-budget-ci-old"
+-- 
+2.20.1
+
+From 4dd806bd04e98e3800b3c4ab3f9d0d42155451b6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Cl=C3=A9ment=20P=C3=A9ron?= <peron.clem@gmail.com>
+Date: Fri, 25 Oct 2019 15:04:20 +0200
+Subject: [PATCH 2/2] arm64: dts: allwinner: beelink-gs1: Add rc-beelink-gs1
+ keymap
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Beelink GS1 ships with a NEC remote control.
+
+Add the rc keymap to the device-tree.
+
+Signed-off-by: Clément Péron <peron.clem@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts
+index 1d05d570142f..ce4b0679839d 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts
+@@ -252,6 +252,7 @@
+ };
+ 
+ &r_ir {
++	linux,rc-map-name = "rc-beelink-gs1";
+ 	status = "okay";
+ };
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
Hi,

This add the support for the remote controller ships with Beelink GS1.

The TV section is leave unmapped.
Web is replaced by Subtitle
Mouse is replaced by EPG (Guide)

I'm open to different bindings, if it's more consistent with other remote controllers.