### PR TITLE
texturecache.py: update to texturecache.py-2.5.2 [backport]

### DIFF
--- a/packages/tools/texturecache.py/package.mk
+++ b/packages/tools/texturecache.py/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="texturecache.py"
-PKG_VERSION="2.5.1"
-PKG_SHA256="bb8a7adca58d04a282af5c1ec5cb4c2dc012dda87510cc665ec4ba4ac7bc0cb3"
+PKG_VERSION="2.5.2"
+PKG_SHA256="821f1668979edc8686f082f41419b39d63769d9dadc0bb99c24ce28648fca972"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/MilhouseVH/texturecache.py"
 PKG_URL="https://github.com/MilhouseVH/$PKG_NAME/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Backport of #3950
