### PR TITLE
samba: update to samba-4.9.15

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.9.13"
-PKG_SHA256="ab18331e37766b13dbb07d1f115bda3d794917baf502d0ca2b2b8fff014b88f2"
+PKG_VERSION="4.9.15"
+PKG_SHA256="377102b80b97941bf0d131b828cae8415190e5bdd2928c2e2c954e29f1904496"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
https://www.samba.org/samba/history/samba-4.9.14.html
https://www.samba.org/samba/history/samba-4.9.15.html

4.9.15 is a security release:

*  CVE-2019-10218:
   Malicious servers can cause Samba client code to return filenames containing path separators to calling code.

*  CVE-2019-14833:
   When the password contains multi-byte (non-ASCII) characters, the check password script does not receive the full password string.

*  CVE-2019-14847:
   Users with the "get changes" extended access right can crash the AD DC LDAP server by requesting an attribute using the range= syntax.