### PR TITLE
buildsystem: optimize for size when building with debug

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -222,14 +222,17 @@ setup_toolchain() {
   fi
 
   # compiler optimization, descending priority: speed, size, default
-  if flag_enabled "speed" "no"; then
+  if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
+    TARGET_CFLAGS+=" $CFLAGS_OPTIM_SIZE"
+    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_SIZE"
+  elif flag_enabled "speed" "no"; then
     TARGET_CFLAGS+=" $CFLAGS_OPTIM_SPEED"
     TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_SPEED"
   elif flag_enabled "size" "no"; then
     TARGET_CFLAGS+=" $CFLAGS_OPTIM_SIZE"
     TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_SIZE"
   else
-    TARGET_CFLAGS+=" $CXXFLAGS_OPTIM_DEFAULT"
+    TARGET_CFLAGS+=" $CFLAGS_OPTIM_DEFAULT"
     TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_DEFAULT"
   fi
 

--- a/config/functions
+++ b/config/functions
@@ -223,8 +223,9 @@ setup_toolchain() {
 
   # compiler optimization, descending priority: speed, size, default
   if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
-    TARGET_CFLAGS+=" $CFLAGS_OPTIM_SIZE"
-    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_SIZE"
+    TARGET_CFLAGS+=" $CFLAGS_OPTIM_DEBUG"
+    TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_DEBUG"
+    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_DEBUG"
   elif flag_enabled "speed" "no"; then
     TARGET_CFLAGS+=" $CFLAGS_OPTIM_SPEED"
     TARGET_CXXFLAGS+=" $CXXFLAGS_OPTIM_SPEED"

--- a/config/optimize
+++ b/config/optimize
@@ -33,14 +33,18 @@ LDFLAGS_OPTIM_LTO_COMMON="-fuse-linker-plugin"
 LDFLAGS_OPTIM_GOLD="-fuse-ld=gold"
 
 # default compiler optimization
-CFLAGS_OPTIM_DEFAULT="-O2"
+CFLAGS_OPTIM_DEFAULT="-O2 -fomit-frame-pointer"
 CXXFLAGS_OPTIM_DEFAULT="$CFLAGS_OPTIM_DEFAULT"
 # speed flag
-CFLAGS_OPTIM_SPEED="-O3"
+CFLAGS_OPTIM_SPEED="-O3 -fomit-frame-pointer"
 CXXFLAGS_OPTIM_SPEED="$CFLAGS_OPTIM_SPEED"
 # size flag
-CFLAGS_OPTIM_SIZE="-Os"
+CFLAGS_OPTIM_SIZE="-Os -fomit-frame-pointer"
 CXXFLAGS_OPTIM_SIZE="$CFLAGS_OPTIM_SIZE"
+# debug settings
+CFLAGS_OPTIM_DEBUG="-ggdb -Os"
+CXXFLAGS_OPTIM_DEBUG="$CFLAGS_OPTIM_DEBUG"
+LDFLAGS_OPTIM_DEBUG="-ggdb"
 
 # position-independent code
 CFLAGS_OPTIM_PIC="-fPIC -DPIC"

--- a/config/optimize
+++ b/config/optimize
@@ -1,16 +1,6 @@
 # Linker hash-style is set to gnu via gcc default
 LD_OPTIM="-Wl,--as-needed"
 
-if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
-  TARGET_CFLAGS="$TARGET_CFLAGS -ggdb"
-  TARGET_CXXFLAGS="$TARGET_CXXFLAGS -ggdb"
-  TARGET_LDFLAGS="$TARGET_LDFLAGS -ggdb"
-else
-  TARGET_CFLAGS="$TARGET_CFLAGS -fomit-frame-pointer"
-  TARGET_CXXFLAGS="$TARGET_CXXFLAGS -fomit-frame-pointer"
-  TARGET_LDFLAGS="$TARGET_LDFLAGS"
-fi
-
 NINJA_OPTS=""
 
 TARGET_CPPFLAGS=""

--- a/config/options
+++ b/config/options
@@ -112,3 +112,13 @@ fi
 
 # set package metadata
 source_package "${1}"
+
+if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
+  TARGET_CFLAGS="$TARGET_CFLAGS -ggdb"
+  TARGET_CXXFLAGS="$TARGET_CXXFLAGS -ggdb"
+  TARGET_LDFLAGS="$TARGET_LDFLAGS -ggdb"
+else
+  TARGET_CFLAGS="$TARGET_CFLAGS -fomit-frame-pointer"
+  TARGET_CXXFLAGS="$TARGET_CXXFLAGS -fomit-frame-pointer"
+  TARGET_LDFLAGS="$TARGET_LDFLAGS"
+fi

--- a/config/options
+++ b/config/options
@@ -112,13 +112,3 @@ fi
 
 # set package metadata
 source_package "${1}"
-
-if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
-  TARGET_CFLAGS="$TARGET_CFLAGS -ggdb"
-  TARGET_CXXFLAGS="$TARGET_CXXFLAGS -ggdb"
-  TARGET_LDFLAGS="$TARGET_LDFLAGS -ggdb"
-else
-  TARGET_CFLAGS="$TARGET_CFLAGS -fomit-frame-pointer"
-  TARGET_CXXFLAGS="$TARGET_CXXFLAGS -fomit-frame-pointer"
-  TARGET_LDFLAGS="$TARGET_LDFLAGS"
-fi

--- a/config/path
+++ b/config/path
@@ -80,8 +80,6 @@ if [[ -z "$PATH" || ( "$PATH" != "$TOOLCHAIN/bin:$TOOLCHAIN/sbin" && "$PATH" = "
   export PATH="$TOOLCHAIN/bin:$TOOLCHAIN/sbin${PATH:+":$PATH"}"
 fi
 
-VERSION_SUFFIX=$TARGET_ARCH
-
 # redirect formatted output
 export BUILD_INDENT_SIZE=4
 SILENT_OUT=3


### PR DESCRIPTION
After #3524, we now build `kodi` with `-O3` (speed) rather than `-Os` (size). Consequently, when building with `DEBUG=yes` or `DEBUG=kodi` the size of the resulting `kod.bin` is massive (1.1GB up from 545MB on RPi2, 1.6GB up from 712MB for Generic).

This change ensures we only use `-Os` when building a package with debug. Not all packages are similarly bloated like `kodi` (when using `-O2` or `-Og` most packages show a small increase in size), but I don't think there's any benefit in optimising for anything but size whenever debug is enabled.