### PR TITLE
LibreELEC-settings: re-enable bytecode compilation

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -25,9 +25,11 @@ post_makeinstall_target() {
 
   ADDON_INSTALL_DIR=$INSTALL/usr/share/kodi/addons/service.libreelec.settings
 
-  #python_compile $ADDON_INSTALL_DIR/resources/lib/
+  python_compile $ADDON_INSTALL_DIR/resources/lib/
 
-  #python_compile $ADDON_INSTALL_DIR/oe.py
+  python_compile $ADDON_INSTALL_DIR/defaults.py
+
+  python_compile $ADDON_INSTALL_DIR/oe.py
 }
 
 post_install() {


### PR DESCRIPTION
Once https://github.com/LibreELEC/service.libreelec.settings/pull/143 merges with Python3 fixes, it can be added to this PR.