### PR TITLE
Allwinner: Fix HDMI audio

### DIFF
--- a/projects/Allwinner/devices/A64/patches/linux/01_a64_hdmi_audio.patch
+++ b/projects/Allwinner/devices/A64/patches/linux/01_a64_hdmi_audio.patch
@@ -30,7 +30,7 @@ index 0f69f35939755..0b44018361cbf 100644
 +			compatible = "simple-audio-card";
 +			simple-audio-card,format = "i2s";
 +			simple-audio-card,name = "allwinner-hdmi";
-+			simple-audio-card,mclk-fs = <256>;
++			simple-audio-card,mclk-fs = <128>;
 +
 +			simple-audio-card,codec {
 +				sound-dai = <&hdmi>;

--- a/projects/Allwinner/devices/H3/patches/linux/16-H3-add-HDMI-sound-nodes.patch
+++ b/projects/Allwinner/devices/H3/patches/linux/16-H3-add-HDMI-sound-nodes.patch
@@ -10,7 +10,7 @@ index 8aa2befc..d3d70eac 100644
 +		compatible = "simple-audio-card";
 +		simple-audio-card,format = "i2s";
 +		simple-audio-card,name = "allwinner-hdmi";
-+		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,mclk-fs = <128>;
 +
 +		simple-audio-card,codec {
 +			sound-dai = <&hdmi>;

--- a/projects/Allwinner/devices/H6/patches/linux/05-sound-hack.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/05-sound-hack.patch
@@ -20,7 +20,7 @@ index 62a0eae77639..f1c53aec6523 100644
 +		compatible = "simple-audio-card";
 +		simple-audio-card,format = "i2s";
 +		simple-audio-card,name = "allwinner-hdmi";
-+		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,mclk-fs = <128>;
 +
 +		simple-audio-card,codec {
 +			sound-dai = <&hdmi>;

--- a/projects/Allwinner/patches/linux/0004-sun4i-i2s-improvements.patch
+++ b/projects/Allwinner/patches/linux/0004-sun4i-i2s-improvements.patch
@@ -723,3 +723,30 @@ index d0a8d5810c0a..9a715a6bdbf9 100644
 -- 
 2.23.0
 
+From 2da43795f6191505b2dd6e30938c3af4c90bf745 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Thu, 7 Nov 2019 07:36:11 +0100
+Subject: [PATCH] sound: soc: sun4i-i2s: Fix rate calculation
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ sound/soc/sunxi/sun4i-i2s.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/sound/soc/sunxi/sun4i-i2s.c b/sound/soc/sunxi/sun4i-i2s.c
+index d0a8d5810c0a..6c4241cb6509 100644
+--- a/sound/soc/sunxi/sun4i-i2s.c
++++ b/sound/soc/sunxi/sun4i-i2s.c
+@@ -334,6 +334,9 @@ static int sun4i_i2s_set_clk_rate(struct snd_soc_dai *dai,
+ 		return -EINVAL;
+ 	}
+ 
++	if (i2s->slot_width)
++		slot_width = i2s->slot_width;
++
+ 	bclk_parent_rate = i2s->variant->get_bclk_parent_rate(i2s);
+ 	bclk_div = sun4i_i2s_get_bclk_div(i2s, bclk_parent_rate,
+ 					  rate, slots, slot_width);
+-- 
+2.24.0
+


### PR DESCRIPTION
It was reported that high bitrate audio doesn't work anymore after I2S driver rework.

Thanks to @codekipper for fixing this.