### PR TITLE
options: support per-buildsystem options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # mkpkg temp
 mkpkg-temp
 
+# options
+/.libreelec
+
 # private working directory
 /.work/
 

--- a/config/options
+++ b/config/options
@@ -86,7 +86,12 @@ VERBOSE="${VERBOSE:-yes}"
 # directory.
 CCACHE_CACHE_SIZE="10G"
 
-# read options from $HOME if available
+# read local persistent options from $ROOT if available
+if [ -f "${ROOT}/.libreelec/options" ]; then
+  . "${ROOT}/.libreelec/options"
+fi
+
+# read global persistent options from $HOME if available
 if [ -f "${HOME}/.libreelec/options" ]; then
   . "${HOME}/.libreelec/options"
 fi


### PR DESCRIPTION
I normally have several different build-system clones at different stages of "work in progress" so it's useful to support persistent options at $ROOT level in addition to $HOME.

e.g. I have `LIBREELEC_VERSION="9.2.0"` for RPi4 things, and `LIBREELEC_VERSION="9.8.0"` for Amlogic work. I hard-code the version so that scripts I use to automate the pull of update files to test devices have static paths on the build server.