### PR TITLE
RPi: support the OK button on the o2.cz BT remote

### DIFF
--- a/projects/RPi/filesystem/usr/lib/udev/hwdb.d/70-local-keyboard.hwdb
+++ b/projects/RPi/filesystem/usr/lib/udev/hwdb.d/70-local-keyboard.hwdb
@@ -1,0 +1,2 @@
+evdev:input:b0005v0217p0000e0110*
+ KEYBOARD_KEY_c0041=enter


### PR DESCRIPTION
This file is present in master branch under `projects\Amlogic` but I'm using the same remote with an RPi4 under LE 9.2. If anyone can point me to the correct upstream location for this change to be sent so we can remove such things in the future - I will happily send a PR.