### PR TITLE
Allwinner: Add support for Belink X2 and Tanix TX6 remotes

### DIFF
--- a/projects/Allwinner/devices/H3/patches/linux/02-ARM-dts-sun8i-h3-Add-rc-map-for-Beelink-X2.patch
+++ b/projects/Allwinner/devices/H3/patches/linux/02-ARM-dts-sun8i-h3-Add-rc-map-for-Beelink-X2.patch
@@ -1,0 +1,27 @@
+From 806099cadd96ebbf908e5cd29fe55eb6868cb28e Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Sat, 9 Nov 2019 19:13:36 +0100
+Subject: [PATCH] ARM: dts: sun8i: h3: Add rc map for Beelink X2
+
+Beelink X2 box comes with a remote. Add a mapping for it.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ arch/arm/boot/dts/sun8i-h3-beelink-x2.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-h3-beelink-x2.dts b/arch/arm/boot/dts/sun8i-h3-beelink-x2.dts
+index ac9e26b1d906..45a24441ff18 100644
+--- a/arch/arm/boot/dts/sun8i-h3-beelink-x2.dts
++++ b/arch/arm/boot/dts/sun8i-h3-beelink-x2.dts
+@@ -143,6 +143,7 @@ hdmi_out_con: endpoint {
+ };
+ 
+ &ir {
++	linux,rc-map-name = "rc-tanix-tx3mini";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&r_ir_rx_pin>;
+ 	status = "okay";
+-- 
+2.24.0
+

--- a/projects/Allwinner/devices/H6/patches/linux/13-Tanix-TX6.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/13-Tanix-TX6.patch
@@ -121,3 +121,31 @@ index 67b732e34091..e436fc78ac71 100644
 -- 
 2.23.0
 
+From d73a0d0c3465fa34008cf8fba6ef9da7fb46a0ef Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 23 Oct 2019 19:58:34 +0200
+Subject: [PATCH] arm64: dts: allwinner: h6: tanix-tx6: Add IR remote mapping
+
+Tanix TX6 box comes with a remote. Add a mapping for it.
+
+Suggested-by: Michael Lange <linuxstuff@milaw.biz>
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
+index bccfe1e65b6a..898eee82888c 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
+@@ -85,6 +85,7 @@ &ohci3 {
+ };
+ 
+ &r_ir {
++	linux,rc-map-name = "rc-tanix-tx5max";
+ 	status = "okay";
+ };
+ 
+-- 
+2.24.0
+

--- a/projects/Allwinner/patches/linux/0001-backport-from-5.4.patch
+++ b/projects/Allwinner/patches/linux/0001-backport-from-5.4.patch
@@ -6642,3 +6642,248 @@ index b2c9f5816c4a..13236c191796 100644
 -- 
 2.23.0
 
+From e30399e1bd6e215ec20981612646ec73a4385c33 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Thu, 15 Aug 2019 11:59:13 -0300
+Subject: [PATCH] media: rc: add keymap for Tanix TX3 mini remote
+
+The Tanix TX3 mini Android STB ships with a simple NEC remote.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+Signed-off-by: Sean Young <sean@mess.org>
+Signed-off-by: Mauro Carvalho Chehab <mchehab+samsung@kernel.org>
+---
+ drivers/media/rc/keymaps/Makefile           |  1 +
+ drivers/media/rc/keymaps/rc-tanix-tx3mini.c | 77 +++++++++++++++++++++
+ include/media/rc-map.h                      |  1 +
+ 3 files changed, 79 insertions(+)
+ create mode 100644 drivers/media/rc/keymaps/rc-tanix-tx3mini.c
+
+diff --git a/drivers/media/rc/keymaps/Makefile b/drivers/media/rc/keymaps/Makefile
+index 39192b0abf91..31720d842f88 100644
+--- a/drivers/media/rc/keymaps/Makefile
++++ b/drivers/media/rc/keymaps/Makefile
+@@ -95,6 +95,7 @@ obj-$(CONFIG_RC_MAP) += rc-adstech-dvb-t-pci.o \
+ 			rc-snapstream-firefly.o \
+ 			rc-streamzap.o \
+ 			rc-tango.o \
++			rc-tanix-tx3mini.o \
+ 			rc-tbs-nec.o \
+ 			rc-technisat-ts35.o \
+ 			rc-technisat-usb2.o \
+diff --git a/drivers/media/rc/keymaps/rc-tanix-tx3mini.c b/drivers/media/rc/keymaps/rc-tanix-tx3mini.c
+new file mode 100644
+index 000000000000..d486cd69afb2
+--- /dev/null
++++ b/drivers/media/rc/keymaps/rc-tanix-tx3mini.c
+@@ -0,0 +1,77 @@
++// SPDX-License-Identifier: GPL-2.0+
++// Copyright (c) 2018 Christian Hewitt
++
++#include <media/rc-map.h>
++#include <linux/module.h>
++
++/*
++ * Keymap for the Tanix TX3 mini STB remote control
++ */
++
++static struct rc_map_table tanix_tx3mini[] = {
++	{ 0x8051, KEY_POWER },
++	{ 0x804d, KEY_MUTE },
++
++	{ 0x8009, KEY_RED },
++	{ 0x8011, KEY_GREEN },
++	{ 0x8054, KEY_YELLOW },
++	{ 0x804f, KEY_BLUE },
++
++	{ 0x8056, KEY_VOLUMEDOWN },
++	{ 0x80bd, KEY_PREVIOUS },
++	{ 0x80bb, KEY_NEXT },
++	{ 0x804e, KEY_VOLUMEUP },
++
++	{ 0x8053, KEY_HOME },
++	{ 0x801b, KEY_BACK },
++
++	{ 0x8026, KEY_UP },
++	{ 0x8028, KEY_DOWN },
++	{ 0x8025, KEY_LEFT },
++	{ 0x8027, KEY_RIGHT },
++	{ 0x800d, KEY_OK },
++
++	{ 0x8049, KEY_MENU },
++	{ 0x8052, KEY_EPG }, // mouse
++
++	{ 0x8031, KEY_1 },
++	{ 0x8032, KEY_2 },
++	{ 0x8033, KEY_3 },
++
++	{ 0x8034, KEY_4 },
++	{ 0x8035, KEY_5 },
++	{ 0x8036, KEY_6 },
++
++	{ 0x8037, KEY_7 },
++	{ 0x8038, KEY_8 },
++	{ 0x8039, KEY_9 },
++
++	{ 0x8058, KEY_SUBTITLE }, // 1/a
++	{ 0x8030, KEY_0 },
++	{ 0x8044, KEY_DELETE },
++};
++
++static struct rc_map_list tanix_tx3mini_map = {
++	.map = {
++		.scan     = tanix_tx3mini,
++		.size     = ARRAY_SIZE(tanix_tx3mini),
++		.rc_proto = RC_PROTO_NEC,
++		.name     = RC_MAP_TANIX_TX3MINI,
++	}
++};
++
++static int __init init_rc_map_tanix_tx3mini(void)
++{
++	return rc_map_register(&tanix_tx3mini_map);
++}
++
++static void __exit exit_rc_map_tanix_tx3mini(void)
++{
++	rc_map_unregister(&tanix_tx3mini_map);
++}
++
++module_init(init_rc_map_tanix_tx3mini)
++module_exit(exit_rc_map_tanix_tx3mini)
++
++MODULE_LICENSE("GPL");
++MODULE_AUTHOR("Christian Hewitt <christianshewitt@gmail.com>");
+diff --git a/include/media/rc-map.h b/include/media/rc-map.h
+index 9754017518a0..b8929d0c5d6b 100644
+--- a/include/media/rc-map.h
++++ b/include/media/rc-map.h
+@@ -249,6 +249,7 @@ struct rc_map *rc_map_get(const char *name);
+ #define RC_MAP_SNAPSTREAM_FIREFLY        "rc-snapstream-firefly"
+ #define RC_MAP_STREAMZAP                 "rc-streamzap"
+ #define RC_MAP_TANGO                     "rc-tango"
++#define RC_MAP_TANIX_TX3MINI             "rc-tanix-tx3mini"
+ #define RC_MAP_TBS_NEC                   "rc-tbs-nec"
+ #define RC_MAP_TECHNISAT_TS35            "rc-technisat-ts35"
+ #define RC_MAP_TECHNISAT_USB2            "rc-technisat-usb2"
+-- 
+2.24.0
+
+From 7bb53f361c59b68e521a05fce579ccfa8021c3a0 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Thu, 15 Aug 2019 11:59:14 -0300
+Subject: [PATCH] media: rc: add keymap for Tanix TX5 max remote
+
+The Tanix TX5 max Android STB ships with a simple NEC remote.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+Signed-off-by: Sean Young <sean@mess.org>
+Signed-off-by: Mauro Carvalho Chehab <mchehab+samsung@kernel.org>
+---
+ drivers/media/rc/keymaps/Makefile          |  1 +
+ drivers/media/rc/keymaps/rc-tanix-tx5max.c | 68 ++++++++++++++++++++++
+ include/media/rc-map.h                     |  1 +
+ 3 files changed, 70 insertions(+)
+ create mode 100644 drivers/media/rc/keymaps/rc-tanix-tx5max.c
+
+diff --git a/drivers/media/rc/keymaps/Makefile b/drivers/media/rc/keymaps/Makefile
+index 31720d842f88..85423cc84149 100644
+--- a/drivers/media/rc/keymaps/Makefile
++++ b/drivers/media/rc/keymaps/Makefile
+@@ -96,6 +96,7 @@ obj-$(CONFIG_RC_MAP) += rc-adstech-dvb-t-pci.o \
+ 			rc-streamzap.o \
+ 			rc-tango.o \
+ 			rc-tanix-tx3mini.o \
++			rc-tanix-tx5max.o \
+ 			rc-tbs-nec.o \
+ 			rc-technisat-ts35.o \
+ 			rc-technisat-usb2.o \
+diff --git a/drivers/media/rc/keymaps/rc-tanix-tx5max.c b/drivers/media/rc/keymaps/rc-tanix-tx5max.c
+new file mode 100644
+index 000000000000..59aaabed80dd
+--- /dev/null
++++ b/drivers/media/rc/keymaps/rc-tanix-tx5max.c
+@@ -0,0 +1,68 @@
++// SPDX-License-Identifier: GPL-2.0+
++// Copyright (c) 2018 Christian Hewitt
++
++#include <media/rc-map.h>
++#include <linux/module.h>
++
++/*
++ * Keymap for the Tanix TX5 max STB remote control
++ */
++
++static struct rc_map_table tanix_tx5max[] = {
++	{ 0x40404d, KEY_POWER },
++	{ 0x404043, KEY_MUTE },
++
++	{ 0x404017, KEY_VOLUMEDOWN },
++	{ 0x404018, KEY_VOLUMEUP },
++
++	{ 0x40400b, KEY_UP },
++	{ 0x404010, KEY_LEFT },
++	{ 0x404011, KEY_RIGHT },
++	{ 0x40400e, KEY_DOWN },
++	{ 0x40400d, KEY_OK },
++
++	{ 0x40401a, KEY_HOME },
++	{ 0x404045, KEY_MENU },
++	{ 0x404042, KEY_BACK },
++
++	{ 0x404001, KEY_1 },
++	{ 0x404002, KEY_2 },
++	{ 0x404003, KEY_3 },
++
++	{ 0x404004, KEY_4 },
++	{ 0x404005, KEY_5 },
++	{ 0x404006, KEY_6 },
++
++	{ 0x404007, KEY_7 },
++	{ 0x404008, KEY_8 },
++	{ 0x404009, KEY_9 },
++
++	{ 0x404047, KEY_SUBTITLE }, // mouse
++	{ 0x404000, KEY_0 },
++	{ 0x40400c, KEY_DELETE },
++};
++
++static struct rc_map_list tanix_tx5max_map = {
++	.map = {
++		.scan     = tanix_tx5max,
++		.size     = ARRAY_SIZE(tanix_tx5max),
++		.rc_proto = RC_PROTO_NECX,
++		.name     = RC_MAP_TANIX_TX5MAX,
++	}
++};
++
++static int __init init_rc_map_tanix_tx5max(void)
++{
++	return rc_map_register(&tanix_tx5max_map);
++}
++
++static void __exit exit_rc_map_tanix_tx5max(void)
++{
++	rc_map_unregister(&tanix_tx5max_map);
++}
++
++module_init(init_rc_map_tanix_tx5max)
++module_exit(exit_rc_map_tanix_tx5max)
++
++MODULE_LICENSE("GPL");
++MODULE_AUTHOR("Christian Hewitt <christianshewitt@gmail.com>");
+diff --git a/include/media/rc-map.h b/include/media/rc-map.h
+index b8929d0c5d6b..a2ebe4868567 100644
+--- a/include/media/rc-map.h
++++ b/include/media/rc-map.h
+@@ -250,6 +250,7 @@ struct rc_map *rc_map_get(const char *name);
+ #define RC_MAP_STREAMZAP                 "rc-streamzap"
+ #define RC_MAP_TANGO                     "rc-tango"
+ #define RC_MAP_TANIX_TX3MINI             "rc-tanix-tx3mini"
++#define RC_MAP_TANIX_TX5MAX              "rc-tanix-tx5max"
+ #define RC_MAP_TBS_NEC                   "rc-tbs-nec"
+ #define RC_MAP_TECHNISAT_TS35            "rc-technisat-ts35"
+ #define RC_MAP_TECHNISAT_USB2            "rc-technisat-usb2"
+-- 
+2.24.0
+


### PR DESCRIPTION
This PR adds support for these two remotes.