### PR TITLE
avahi: set root user as default for published sftp

### DIFF
--- a/packages/network/avahi/package.mk
+++ b/packages/network/avahi/package.mk
@@ -64,6 +64,8 @@ post_makeinstall_target() {
   sed -e "s,^.*publish-workstation=.*$,publish-workstation=no,g" -i $INSTALL/etc/avahi/avahi-daemon.conf
 # browse domains?
   sed -e "s,^.*browse-domains=.*$,# browse-domains=,g" -i $INSTALL/etc/avahi/avahi-daemon.conf
+# set root user as default
+  sed -e "s,<port>22</port>,<port>22</port>\n    <txt-record>path=/storage</txt-record>\n    <txt-record>u=root</txt-record>,g" -i $INSTALL/etc/avahi/services/sftp-ssh.service
 
   rm -rf $INSTALL/etc/avahi/avahi-dnsconfd.action
   rm -rf $INSTALL/etc/avahi/services/ssh.service


### PR DESCRIPTION
If root user not set on the avahi(on ssh server), most of the file explorers using default user(on ssh client) for sftp connections. If you have ssh connection without password setted on your libreelec, file explorers refuse to connect because they are trying to connect with their user.

With this change we can connect libreelec with avahi's published link without a problem.