### PR TITLE
Make kodi-config return a zero exit status

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -40,4 +40,6 @@ else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf
 fi
 
-[ -f /storage/.config/kodi.conf ] && cat /storage/.config/kodi.conf >>/run/libreelec/kodi.conf
+if [ -f /storage/.config/kodi.conf ] ; then
+  cat /storage/.config/kodi.conf >>/run/libreelec/kodi.conf
+fi


### PR DESCRIPTION
If /storage/.config/kodi.conf doesn't exist (which it doesn't by default), then the failing "test -f" at the end of this script causes it to return a non-zero exit status, which it turn causes systemd to record it as failed when it runs it as a pre-start for the main kodi service  (and show it as such in "systemctl status kodi"), which is ugly. Instead force the exit status back to 0.