### PR TITLE
kodi-config: create userdata when it doesn't exist

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -8,6 +8,9 @@ KODI_ROOT=$HOME/.kodi
 
 BOOT_STATE="$(cat $HOME/.config/boot.status 2>/dev/null)"
 
+# May not exist if testing a clean /storage/.kodi without rebooting
+mkdir -p $KODI_ROOT/userdata
+
 # hack: make addon-bins executable
 # done in kodi on addon install. but just in case..
 chmod +x $KODI_ROOT/addons/*/bin/* 2>/dev/null

--- a/packages/mediacenter/kodi/tmpfiles.d/kodi-userdirs.conf
+++ b/packages/mediacenter/kodi/tmpfiles.d/kodi-userdirs.conf
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
-d    /storage/.kodi/userdata     0755 root root - -
 d    /storage/music              0755 root root - -
 d    /storage/pictures           0755 root root - -
 d    /storage/tvshows            0755 root root - -


### PR DESCRIPTION
`/storage/.kodi/userdata` is created by [tmpfiles.d](https://github.com/LibreELEC/LibreELEC.tv/blob/85150686feda583445ee7ad35e687eb935865cda/packages/mediacenter/kodi/tmpfiles.d/kodi-userdirs.conf#L4) when booting.

However, when testing a "clean" kodi installation using:
```
cd /storage
systemctl stop kodi
mv .kodi .kodi.bak
systemctl start kodi
```
then the following errors will be logged:
```
Nov 16 02:58:05 NUC systemd[1]: Starting Kodi Media Center...
Nov 16 02:58:05 NUC kodi-config[1789]: cp: can't create '/storage/.kodi/userdata': Path does not exist
Nov 16 02:58:05 NUC kodi-config[1789]: cp: can't create '/storage/.kodi/userdata': Path does not exist
Nov 16 02:58:05 NUC systemd[1]: Started Kodi Media Center.
```
and `sources.xml` and `guisettings.xml` will not be installed.

This PR fixes this issue. Should be safe to backport.