### PR TITLE
RTL8189FS: WiFi+BT driver for Orange Pi 2 & Orange Pi Plus2E

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -68,7 +68,7 @@
 # for a list of additional drivers see packages/linux-drivers
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU"
+  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU RTL8189FS"
 
 # build and install bluetooth support (yes / no)
   BLUETOOTH_SUPPORT="yes"

--- a/packages/linux-drivers/RTL8189FS/package.mk
+++ b/packages/linux-drivers/RTL8189FS/package.mk
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="RTL8189FS"
+PKG_VERSION="54bd680"
+PKG_SHA256="f3f8bcc1e75f095350f12c36f7b8af88eebf3913d4bc921083489f1758cb5068"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/jwrdegoede/rtl8189ES_linux/"
+PKG_URL="https://github.com/jwrdegoede/rtl8189ES_linux/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_LONGDESC="Realtek RTL8189FS Linux driver"
+PKG_SECTION="driver.wifi"
+PKG_LONGDESC="Realtek RTL8189FS Linux driver"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make V=1 \
+       ARCH=$TARGET_KERNEL_ARCH \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
+       CONFIG_POWER_SAVING=n
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+    cp *.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME
+}


### PR DESCRIPTION
The module is tested on Orange Pi Plus 2E (branch master).
According to Orange Pi's specs in OPi 2 is used same wifi module.