### PR TITLE
init: don't mount nfs shares with soft option by default

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -203,7 +203,7 @@ mount_nfs() {
 
   [ "$NFS_OPTIONS" = "$1" ] && NFS_OPTIONS=
 
-  mount_common "$NFS_EXPORT" "$2" "$3,nolock,soft,timeo=3,retrans=2,rsize=32768,wsize=32768,$NFS_OPTIONS" "nfs"
+  mount_common "$NFS_EXPORT" "$2" "$3,nolock,rsize=32768,wsize=32768,$NFS_OPTIONS" "nfs"
 }
 
 mount_ubifs() {


### PR DESCRIPTION
Using the soft timeout option for NFS mounts is a really bad idea
and the nfs(5) manpage explicitly warns about it's issues:

    NB: A so-called "soft" timeout  can  cause  silent  data
    corruption  in  certain cases. As such, use the soft op‐
    tion only when client responsiveness is  more  important
    than  data  integrity.  Using NFS over TCP or increasing
    the value of the retrans option may mitigate some of the
    risks of using the soft option.

So don't enable it by default, anyone who feels keen to take the
risk can specify it manually on kernel command line.