### PR TITLE
LibreELEC-settings: make it easier to disable, or use alternative

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -935,7 +935,7 @@ pkg_call_exists() {
 pkg_call() {
   [ -n "${PKG_NAME}" ] || die "$(print_color CLR_ERROR "FAILURE: Cannot call ${1} package function when package is not known!")"
 
-  ${1}
+  "${@}"
 }
 
 unset_functions() {
@@ -955,7 +955,7 @@ unset_functions() {
 
   unset -f pre_install post_install
 
-  unset -f addon
+  unset -f addon post_install_addon
 }
 
 # p1: name of package to be sourced
@@ -1283,6 +1283,10 @@ install_addon_files() {
   install_addon_images "$1"
   create_addon_xml "$1"
   python_fix_abi "$1"
+
+  if pkg_call_exists post_install_addon; then
+    INSTALL="$1" pkg_call post_install_addon
+  fi
 }
 
 install_driver_addon_files() {

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -215,6 +215,7 @@
 
 # Settings package name - blank if not required
   DISTRO_PKG_SETTINGS="LibreELEC-settings"
+  DISTRO_PKG_SETTINGS_ID="service.libreelec.settings"
 
 # IR remote keymaps supported in default config
   IR_REMOTE_KEYMAPS="rc6_mce xbox_360 xbox_one"

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -98,5 +98,8 @@ addon() {
 
   # unclutter
   cp -P $(get_build_dir unclutter)/.install_pkg/usr/bin/unclutter $ADDON_BUILD/$PKG_ADDON_ID/bin
+}
 
+post_install_addon() {
+  sed -e "s/@DISTRO_PKG_SETTINGS_ID@/${DISTRO_PKG_SETTINGS_ID}/g" -i "${INSTALL}/default.py"
 }

--- a/packages/addons/browser/chrome/source/default.py
+++ b/packages/addons/browser/chrome/source/default.py
@@ -9,7 +9,7 @@ import xbmcaddon
 import subprocess
 from xml.dom.minidom import parse
 
-sys.path.append('/usr/share/kodi/addons/service.libreelec.settings')
+sys.path.append('/usr/share/kodi/addons/@DISTRO_PKG_SETTINGS_ID@')
 
 import oe
 

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -146,3 +146,7 @@ addon() {
     # tini
     cp -P $(get_build_dir tini)/.${TARGET_NAME}/tini-static ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/docker-init
 }
+
+post_install_addon() {
+  sed -e "s/@DISTRO_PKG_SETTINGS_ID@/${DISTRO_PKG_SETTINGS_ID}/g" -i "${INSTALL}/default.py"
+}

--- a/packages/addons/service/docker/source/default.py
+++ b/packages/addons/service/docker/source/default.py
@@ -10,7 +10,7 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 
-sys.path.append('/usr/share/kodi/addons/service.libreelec.settings')
+sys.path.append('/usr/share/kodi/addons/@DISTRO_PKG_SETTINGS_ID@')
 import oe
 
 __author__      = 'lrusak'

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -332,7 +332,9 @@ post_makeinstall_target() {
   xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "os.libreelec.tv" $ADDON_MANIFEST
   xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "os.openelec.tv" $ADDON_MANIFEST
   xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "repository.libreelec.tv" $ADDON_MANIFEST
-  xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "service.libreelec.settings" $ADDON_MANIFEST
+  if [ -n "$DISTRO_PKG_SETTINGS" ]; then
+    xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "$DISTRO_PKG_SETTINGS_ID" $ADDON_MANIFEST
+  fi
 
   if [ "$DRIVER_ADDONS_SUPPORT" = "yes" ]; then
     xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "script.program.driverselect" $ADDON_MANIFEST

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -154,6 +154,7 @@ Full list of overwrittable functions.
 | make_\[stage]<br>pre_make_\[stage]<br>post_make_\[stage] | yes | Build of the package |
 | makeinstall_\[stage]<br>pre_makeinstall_\[stage]<br>post_makeinstall_\[stage] | yes | Installation of the files in the correct pathes<br>host: TOOLCHAIN<br>target: SYSROOT and IMAGE<br>bootstrap and init: temporary destination
 | addon                   | -      | Copy all files together for addon creation. This is requiered for addons |
+| post_install_addon      | -      | Post processing of installed addon files in `${INSTALL}` directory |
 
 ## Late Binding variable assignment
 

--- a/tools/pkgcheck
+++ b/tools/pkgcheck
@@ -101,7 +101,7 @@ check_func_name() {
            pre_configure \
            ${TARGET_FUNCS} \
            pre_install post_install \
-           addon \
+           addon post_install_addon \
            ; do
     [[ ${line} =~ ^${f} ]] && return 0
   done


### PR DESCRIPTION
~Adds a helper to extract the addon id of the specified package (why OpenELEC chose to call the settings package `LibreELEC-settings` rather than use the addon id baffles me to this day).~

Only add the addon id of the configured package to the Kodi manifest if the add-on is enabled, otherwise Kodi will crash on startup.