### PR TITLE
userconfig-setup: avoid // in test

### DIFF
--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -5,7 +5,7 @@
 
 # Remove those sample files that we manage
 for sample in $(find /storage/.config -name '*.sample' 2>/dev/null); do
-  [ -f /usr/config/${sample:16} ] && rm -f ${sample}
+  [ -f /usr/config/${sample:17} ] && rm -f ${sample}
 done
 
 # Copy config files, but don't overwrite - this should replace our sample files


### PR DESCRIPTION
Cosmetic, really. Not worth backporting.

BEFORE:
```
[ -f /usr/config//rc_maps.cfg.sample ] && rm -f /storage/.config/rc_maps.cfg.sample
[ -f /usr/config//rpi-cirrus-config.sh.sample ] && rm -f /storage/.config/rpi-cirrus-config.sh.sample
[ -f /usr/config//samba.conf.sample ] && rm -f /storage/.config/samba.conf.sample
[ -f /usr/config//sleep.conf.d/sleep.conf.sample ] && rm -f /storage/.config/sleep.conf.d/sleep.conf.sample
[ -f /usr/config//system.d/nfs.mount.sample ] && rm -f /storage/.config/system.d/nfs.mount.sample
[ -f /usr/config//system.d/cifs.mount.sample ] && rm -f /storage/.config/system.d/cifs.mount.sample
[ -f /usr/config//system.d/openvpn.service.sample ] && rm -f /storage/.config/system.d/openvpn.service.sample
```

AFTER:
```
[ -f /usr/config/rc_maps.cfg.sample ] && rm -f /storage/.config/rc_maps.cfg.sample
[ -f /usr/config/rpi-cirrus-config.sh.sample ] && rm -f /storage/.config/rpi-cirrus-config.sh.sample
[ -f /usr/config/samba.conf.sample ] && rm -f /storage/.config/samba.conf.sample
[ -f /usr/config/sleep.conf.d/sleep.conf.sample ] && rm -f /storage/.config/sleep.conf.d/sleep.conf.sample
[ -f /usr/config/system.d/nfs.mount.sample ] && rm -f /storage/.config/system.d/nfs.mount.sample
[ -f /usr/config/system.d/cifs.mount.sample ] && rm -f /storage/.config/system.d/cifs.mount.sample
[ -f /usr/config/system.d/openvpn.service.sample ] && rm -f /storage/.config/system.d/openvpn.service.sample
```