### PR TITLE
brcmfmac_sdio-firmware: add AP6255 NVRAM for Orange Pi Lite2

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware"
-PKG_VERSION="79932201f7827ec06ec708a44bf583a772ae7522"
-PKG_SHA256="b31665e3b0dfd595234241ef233e47f2e12312ce019c9b5c2e02919d0b2ddbc0"
+PKG_VERSION="34aaf208f983cefc1d3188d43510c4dc4a35238b"
+PKG_SHA256="b2e096f4ef037236401ada0e0955c783b509c2186acfc0ed8c07a53aa7bcb138"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/brcmfmac_sdio-firmware"
 PKG_URL="https://github.com/LibreELEC/brcmfmac_sdio-firmware/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
update to 34aaf208f983cefc1d3188d43510c4dc4a35238b
fix for WiFi+BT issues in #3961  