### PR TITLE
pulseaudio: don't enable network audio support for everyone by default

### DIFF
--- a/packages/audio/pulseaudio/config/system.pa
+++ b/packages/audio/pulseaudio/config/system.pa
@@ -65,5 +65,4 @@ load-module module-position-event-sounds
   load-module module-zeroconf-publish
 .endif
 
-load-module module-native-protocol-tcp auth-anonymous=1
 load-module module-switch-on-connect


### PR DESCRIPTION
From @fritsch:
```
Are you guys sure you want this: https://github.com/LibreELEC/LibreELEC.tv/blame/85150686feda583445ee7ad35e687eb935865cda/packages/audio/pulseaudio/config/system.pa#L68
having PA open via tcp to everyone
so that every network sink can output via pulse's default device, e.g. BT headset?
...
If it's not a use-case that LE should provide
remove it
makes no sense to announce LE as tcp streaming target
without authentication
```

This module is needed for [network audio](https://wiki.libreelec.tv/pulseaudio#network_audio_receiving), but probably shouldn't be enabled by default - anyone that needs network audio support can load this module themselves in autostart.sh, or via a systemd service.

I'll include this PR in nightly builds - let's see what (if anything) breaks.