### PR TITLE
Allwinner: Fixup the bluetooth address on Orange Pi 3

### DIFF
--- a/projects/Allwinner/devices/H6/patches/linux/07-opi3.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/07-opi3.patch
@@ -610,3 +610,62 @@ index eb379cd402ac..d3e30a67587c 100644
  &uart0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&uart0_ph_pins>;
+
+
+From: Andre Heider <a.heider@gmail.com>
+Date: Tue, 19 Nov 2019 09:35:10 +0100
+Subject: [PATCH 2/2] WIP: Bluetooth: Accept
+ HCI_QUIRK_INVALID_BDADDR|HCI_QUIRK_USE_BDADDR_PROPERTY
+
+Don't bail out if the former is set (in case of bcm: default controller
+address), but an address was supplied because of the latter.
+---
+ net/bluetooth/hci_core.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/net/bluetooth/hci_core.c b/net/bluetooth/hci_core.c
+index 04bc79359a17..7bc384be89f8 100644
+--- a/net/bluetooth/hci_core.c
++++ b/net/bluetooth/hci_core.c
+@@ -1470,7 +1470,8 @@ static int hci_dev_do_open(struct hci_dev *hdev)
+ 		 * start up as unconfigured.
+ 		 */
+ 		if (test_bit(HCI_QUIRK_EXTERNAL_CONFIG, &hdev->quirks) ||
+-		    test_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks))
++		    (test_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks) &&
++		     !test_bit(HCI_QUIRK_USE_BDADDR_PROPERTY, &hdev->quirks)))
+ 			hci_dev_set_flag(hdev, HCI_UNCONFIGURED);
+ 
+ 		/* For an unconfigured controller it is required to
+-- 
+2.24.0
+
+
+From: Andre Heider <a.heider@gmail.com>
+Date: Sun, 17 Nov 2019 20:31:17 +0100
+Subject: [PATCH 1/2] bluetooth: bcm: Use HCI_QUIRK_USE_BDADDR_PROPERTY
+
+Some devices ship with the controller default address, like the
+Orange Pi 3 (BCM4345C5).
+
+Allow the bootloader to set a valid address through the device tree.
+
+Signed-off-by: Andre Heider <a.heider@gmail.com>
+---
+ drivers/bluetooth/btbcm.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
+index 2d2e6d862068..9d16162d01ea 100644
+--- a/drivers/bluetooth/btbcm.c
++++ b/drivers/bluetooth/btbcm.c
+@@ -439,6 +439,7 @@ int btbcm_finalize(struct hci_dev *hdev)
+ 	btbcm_check_bdaddr(hdev);
+ 
+ 	set_bit(HCI_QUIRK_STRICT_DUPLICATE_FILTER, &hdev->quirks);
++	set_bit(HCI_QUIRK_USE_BDADDR_PROPERTY, &hdev->quirks);
+ 
+ 	return 0;
+ }
+-- 
+2.24.0

--- a/projects/Allwinner/devices/H6/patches/u-boot/008-sunxi-board-fixup-the-BT-address-for-Orange-Pi-3.patch
+++ b/projects/Allwinner/devices/H6/patches/u-boot/008-sunxi-board-fixup-the-BT-address-for-Orange-Pi-3.patch
@@ -1,0 +1,60 @@
+From c7e886b9f2a39fe2ce98a16c6e7359171bac8c65 Mon Sep 17 00:00:00 2001
+From: Andre Heider <a.heider@gmail.com>
+Date: Sun, 17 Nov 2019 20:24:43 +0100
+Subject: [PATCH] sunxi: board: fixup the BT address for Orange Pi 3
+
+The BCM4345C5 of the Orange Pi 3 ships with the controller default
+address. Fix it up so it can function properly.
+
+The used address is "ethaddr" with the LSB flipped.
+
+Signed-off-by: Andre Heider <a.heider@gmail.com>
+---
+ board/sunxi/board.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index e3b2d13892..a0e08dc9b8 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -864,6 +864,28 @@ int misc_init_r(void)
+ 	return 0;
+ }
+ 
++static void fixup_bdaddr(void *blob)
++{
++#if defined(CONFIG_MACH_SUN50I_H6)
++	uchar mac[ETH_ALEN], bdaddr[ETH_ALEN];
++	int i;
++
++	if (!of_machine_is_compatible("xunlong,orangepi-3"))
++		return;
++
++	if (!eth_env_get_enetaddr("ethaddr", mac))
++		return;
++
++	for (i = 0; i < sizeof(mac); ++i)
++		bdaddr[i] = mac[ETH_ALEN - i - 1];
++
++	bdaddr[0] ^= 0x01;
++
++	do_fixup_by_compat(blob, "brcm,bcm4345c5",
++			   "local-bd-address", bdaddr, ETH_ALEN, 1);
++#endif
++}
++
+ int ft_board_setup(void *blob, bd_t *bd)
+ {
+ 	int __maybe_unused r;
+@@ -874,6 +896,8 @@ int ft_board_setup(void *blob, bd_t *bd)
+ 	 */
+ 	setup_environment(blob);
+ 
++	fixup_bdaddr(blob);
++
+ #ifdef CONFIG_VIDEO_DT_SIMPLEFB
+ 	r = sunxi_simplefb_setup(blob);
+ 	if (r)
+-- 
+2.24.0
+


### PR DESCRIPTION
The driver refuses to use the shipped controller default address.