### PR TITLE
RPi: revert to firmware 8e688a4

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="b9f83b14a8f8ea11e4cc509da037d05836efa00f"
-PKG_SHA256="31731c0e4b05f9ccb95f4c9c052d594a3b542929aaf202490c4cfdb44efcc25b"
+PKG_VERSION="8e688a44332268ee4f1e3d70d67b81e0567cbe71"
+PKG_SHA256="cccc552006cc4dfe698650a9a6d70c542f4e3ffcd02ac6403e14bf6394281179"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="b9f83b14a8f8ea11e4cc509da037d05836efa00f"
-PKG_SHA256="915c02c12269608830bbad34c0cf5e9294a4e98c6497913971c74759eda64fcb"
+PKG_VERSION="8e688a44332268ee4f1e3d70d67b81e0567cbe71"
+PKG_SHA256="5d3b83a5658f0acc29b15b5f2a15950c5b216530642a2e101bd8c5f52b276bcd"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"


### PR DESCRIPTION
Later firmware versions have a nasty bug that can lead to HDMI
lock-ups when the RPi is fully throttled (eg due to over-temperature).

Note: The bug is fixed in latest RPi firmware version but this contains the
rather experimental DVFS changes that we shouldn't use in LE9.2 stable yet.