### PR TITLE
Package Updates November 2019

### DIFF
--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.4.3"
-PKG_SHA256="e88ec8d420ff228610b77fba4fbf22b9f8b9d3f223a40ef59c9c075fcdad5767"
+PKG_VERSION="1.4.4"
+PKG_SHA256="59ef70ebb757ffe74a7b3fe9c305e2ba3350021a918d168a046c6300aeea9315"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"
 PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="autoconf-3290000"
-PKG_SHA256="8e7c1e2950b5b04c5944a981cb31fffbf9d2ddda939d536838ebc854481afd5b"
+PKG_VERSION="autoconf-3300100"
+PKG_SHA256="8c5a50db089bd2a1b08dbc5b00d2027602ca7ff238ba7658fabca454d4298e60"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2019/$PKG_NAME-$PKG_VERSION.tar.gz"
@@ -29,9 +29,9 @@ pre_configure_target() {
 # This option adds additional logic to the ANALYZE command and to the query planner
 # that can help SQLite to chose a better query plan under certain situations. The
 # ANALYZE command is enhanced to collect histogram data from each index and store
-# that data in the sqlite_stat3 table. The query planner will then use the histogram
+# that data in the sqlite_stat4 table. The query planner will then use the histogram
 # data to help it make better index choices.
-  CFLAGS="$CFLAGS -DSQLITE_ENABLE_STAT3"
+  CFLAGS="$CFLAGS -DSQLITE_ENABLE_STAT4"
 
 # When this C-preprocessor macro is defined, SQLite includes some additional APIs
 # that provide convenient access to meta-data about tables and queries. The APIs that

--- a/packages/devel/parallel/package.mk
+++ b/packages/devel/parallel/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="parallel"
-PKG_VERSION="20190722"
-PKG_SHA256="0ed0863184dbb396b4c030848e754b1ea76329c06ae9e43314bc0915eb6cbca7"
+PKG_VERSION="20191022"
+PKG_SHA256="641beea4fb9afccb1969ac0fb43ebc458f375ceb6f7e24970a9aced463e909a9"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://www.gnu.org/software/parallel/"
 PKG_URL="http://ftpmirror.gnu.org/parallel/$PKG_NAME-$PKG_VERSION.tar.bz2"

--- a/packages/multimedia/dav1d/package.mk
+++ b/packages/multimedia/dav1d/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dav1d"
-PKG_VERSION="0.5.0"
-PKG_SHA256="b29c159bf7c56e8b6ae81bb24704599819fa89399ec3d6db3dbc052d7bc5baf8"
+PKG_VERSION="0.5.1"
+PKG_SHA256="0214d201a338e8418f805b68f9ad277e33d79c18594dee6eaf6dcd74db2674a9"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.jbkempf.com/blog/post/2018/Introducing-dav1d"
 PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/dav1d-${PKG_VERSION}.tar.bz2"

--- a/packages/textproc/libidn2/package.mk
+++ b/packages/textproc/libidn2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libidn2"
-PKG_VERSION="2.2.0"
-PKG_SHA256="fc734732b506d878753ec6606982bf7b936e868c25c30ddb0d83f7d7056381fe"
+PKG_VERSION="2.3.0"
+PKG_SHA256="e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5"
 PKG_LICENSE="LGPL3"
 PKG_SITE="https://www.gnu.org/software/libidn/"
 PKG_URL="http://ftpmirror.gnu.org/gnu/libidn/libidn2-$PKG_VERSION.tar.gz"

--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="curl"
-PKG_VERSION="7.66.0"
-PKG_SHA256="dbb48088193016d079b97c5c3efde8efa56ada2ebf336e8a97d04eb8e2ed98c1"
+PKG_VERSION="7.67.0"
+PKG_SHA256="f5d2e7320379338c3952dcc7566a140abb49edb575f9f99272455785c40e536c"
 PKG_LICENSE="MIT"
 PKG_SITE="http://curl.haxx.se"
 PKG_URL="http://curl.haxx.se/download/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
Nothing too notable here. Zstd image creation should be slightly faster. Dav1d should be faster on older x86 and armv7. The rest of the bumps looked like mostly bugfixes from the changelogs.

Built / tested for RPi.