### PR TITLE
binutils: explicitly depend on target zlib

### DIFF
--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -9,7 +9,7 @@ PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/binutils/"
 PKG_URL="http://ftp.gnu.org/gnu/binutils/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST="ccache:host bison:host flex:host linux:host"
-PKG_DEPENDS_TARGET="toolchain binutils:host"
+PKG_DEPENDS_TARGET="toolchain zlib binutils:host"
 PKG_LONGDESC="A GNU collection of binary utilities."
 
 PKG_CONFIGURE_OPTS_HOST="--target=$TARGET_NAME \
@@ -31,6 +31,7 @@ PKG_CONFIGURE_OPTS_HOST="--target=$TARGET_NAME \
 PKG_CONFIGURE_OPTS_TARGET="--target=$TARGET_NAME \
                          --with-sysroot=$SYSROOT_PREFIX \
                          --with-lib-path=$SYSROOT_PREFIX/lib:$SYSROOT_PREFIX/usr/lib \
+                         --with-system-zlib \
                          --without-ppl \
                          --without-cloog \
                          --enable-static \


### PR DESCRIPTION
By default binutils 2.33 will automatically build and use it's
bundled zlib version - which isn't obvious from package.mk as
we don't explicitly build the zlib folder.

binutils 2.32 uses the zlib include from it's bundled version but
won't build it and try to link with libz.a from sysroot - which
will either fail (if zlib wasn't built before) or result in a
possible version mix (which isn't nice as well).

Explicitly using the target zlib - like most linux distributions
do - solves these issues and makes the build consistent.