### PR TITLE
rpi: support the OK button on the o2.cz BT remote

### DIFF
--- a/projects/RPi/filesystem/usr/lib/udev/hwdb.d/70-local-keyboard.hwdb
+++ b/projects/RPi/filesystem/usr/lib/udev/hwdb.d/70-local-keyboard.hwdb
@@ -1,0 +1,2 @@
+evdev:input:b0005v0217p0000e0110*
+ KEYBOARD_KEY_c0041=enter


### PR DESCRIPTION
The same change wasn't accepted into 9.2.0 because it hadn't been submitted to master.. so here is your great wish. I'd still prefer to fix it differently.. but bikeshed away.