### PR TITLE
add hwdb.d installations from packages, make o2.cz BT remote config globally available

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -1,0 +1,3 @@
+# o2.cz bluetooth remote
+evdev:input:b0005v0217p0000e0110*
+ KEYBOARD_KEY_c0041=enter		# OK button

--- a/projects/Amlogic/filesystem/usr/lib/udev/hwdb.d/70-local-keyboard.hwdb
+++ b/projects/Amlogic/filesystem/usr/lib/udev/hwdb.d/70-local-keyboard.hwdb
@@ -1,2 +1,0 @@
-evdev:input:b0005v0217p0000e0110*
- KEYBOARD_KEY_c0041=enter

--- a/scripts/install
+++ b/scripts/install
@@ -90,6 +90,11 @@ if [ "${TARGET}" = "target" ] ; then
       cp ${PKG_TMP_DIR}/udev.d/*.rules ${INSTALL}/usr/lib/udev/rules.d
     fi
 
+    if [ -d ${PKG_TMP_DIR}/hwdb.d ]; then
+      mkdir -p ${INSTALL}/usr/lib/udev/hwdb.d
+      cp ${PKG_TMP_DIR}/hwdb.d/*.hwdb ${INSTALL}/usr/lib/udev/hwdb.d
+    fi
+
     if [ -d ${PKG_TMP_DIR}/sleep.d ]; then
       mkdir -p ${INSTALL}/usr/lib/systemd/system-sleep
       cp ${PKG_TMP_DIR}/sleep.d/* ${INSTALL}/usr/lib/systemd/system-sleep


### PR DESCRIPTION
This is a follow-up to #4019 

Instead of adding hwdb.d files to some selected projects add the configuration for all projects

Only build-tested, the hwdb file was properly added to /usr/lib/udev/hwdb.d but I don't have the specific remote - ping @chewitt can you please test this?