### PR TITLE
nss & nspr: update to nss-3.47.1 / nspr-4.23

### DIFF
--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.44"
-PKG_SHA256="298d86e18e96660d3c98476274b5857b48c135d809a10d6528d8661bdf834a49"
+PKG_VERSION="3.47.1"
+PKG_SHA256="07d4276168f59bb3038c7826dabb5fbfbab8336ddf65e4e6e43bce89ada78c64"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
-PKG_URL="http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_44_RTM/src/nss-3.44-with-nspr-4.21.tar.gz"
+PKG_URL="http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_47_1_RTM/src/nss-3.47.1-with-nspr-4.23.tar.gz"
 PKG_DEPENDS_HOST="nspr:host zlib:host"
 PKG_DEPENDS_TARGET="toolchain nss:host nspr zlib sqlite"
 PKG_LONGDESC="The Network Security Services (NSS) package is a set of libraries designed to support cross-platform development of security-enabled client and server applications"

--- a/packages/security/nss/patches/nss-08-tests-broken-since-3.47.patch
+++ b/packages/security/nss/patches/nss-08-tests-broken-since-3.47.patch
@@ -1,0 +1,25 @@
+From 674faa792fc6c1bd391915fb9aacef2fcfd6426f Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Mon, 25 Nov 2019 04:59:08 +0000
+Subject: [PATCH] tests are broken when cross-compiling
+
+---
+ nss/lib/ckfw/builtins/manifest.mn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nss/lib/ckfw/builtins/manifest.mn b/nss/lib/ckfw/builtins/manifest.mn
+index 5e6740f..00bcdc0 100644
+--- a/nss/lib/ckfw/builtins/manifest.mn
++++ b/nss/lib/ckfw/builtins/manifest.mn
+@@ -5,7 +5,7 @@
+ 
+ CORE_DEPTH = ../../..
+ 
+-DIRS = testlib
++#DIRS = testlib
+ 
+ MODULE = nss
+ MAPFILE = $(OBJDIR)/nssckbi.def
+-- 
+2.7.4
+


### PR DESCRIPTION
The tests added by https://github.com/nss-dev/nss/commit/47e35ec46e958b19c7176800708e1f7903a902e7 do not build when cross-compiling.