### PR TITLE
config/arm: use eabihf for hard float

### DIFF
--- a/config/arch.arm
+++ b/config/arch.arm
@@ -49,6 +49,10 @@
       ;;
   esac
 
+  if [ "${TARGET_FLOAT}" = "hard" ]; then
+    TARGET_ABI+="hf"
+  fi
+
   TARGET_VARIANT="${TARGET_SUBARCH}${TARGET_CPU_FLAGS}"
   TARGET_GCC_ARCH=${TARGET_SUBARCH/-}
   TARGET_KERNEL_ARCH=${TARGET_KERNEL_ARCH:-arm}

--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -18,11 +18,11 @@ pre_configure_target() {
   case ${TARGET_ARCH} in
     aarch64)
       GPGERROR_TUPLE=aarch64-unknown-linux-gnu
-      GPGERROR_TARGET=linux-gnueabi
+      GPGERROR_TARGET=linux-gnu${TARGET_ABI}
       ;;
     arm)
       GPGERROR_TUPLE=arm-unknown-linux-gnueabi
-      GPGERROR_TARGET=linux-gnueabi
+      GPGERROR_TARGET=linux-gnu${TARGET_ABI}
       ;;
     x86_64)
       GPGERROR_TUPLE=x86_64-unknown-linux-gnu


### PR DESCRIPTION
Following a discussion on https://github.com/zlib-ng/zlib-ng/issues/478 it became apparent that the TARGET_ABI used for arm doesn't reflect the presence of hard float.

I have successfully created images for RPi, RPi2 and Allwinner/A64 with this PR (RPi and RPi2 images also booted OK). Add-ons are yet to be build tested.

Creating as a draft for discussion, and in case any additions are required.