### PR TITLE
init: fsck: fix kmsg log writes

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -533,7 +533,9 @@ check_disks() {
         break
       fi
     done
-    sed -e '/^$/d' -e 's/^/fsck: /' </dev/fsck.latest >/dev/kmsg
+    while read line; do
+      [ -n "$line" ] && echo "fsck: ${line::160}" >/dev/kmsg
+    done </dev/fsck.latest
     rm -f /dev/fsck.latest
   fi
 }


### PR DESCRIPTION
/dev/kmsg does only allow writes up to 976 bytes. Allow larger fsck output by writing line by line.

Bug was reported on [forum](https://forum.libreelec.tv/thread/20713-sed-write-error-during-boot-on-latest-generic-beta/?pageNo=1).

Backport of #4026