### PR TITLE
librespot: update to 0.1.0

### DIFF
--- a/packages/addons/addon-depends/librespot-depends/rustup.rs/package.mk
+++ b/packages/addons/addon-depends/librespot-depends/rustup.rs/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rustup.rs"
-PKG_VERSION="1.18.3"
-PKG_SHA256="9a2ae2c85bbbfc838b25d86d049bc677532950d78765725beabb8a61df1c2710"
+PKG_VERSION="1.20.2"
+PKG_SHA256="28207ee4c2d66840ca903df152b23b916326a5d3eeb643a1de0f24a16afa4209"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://github.com/rust-lang-nursery/rustup.rs/archive/$PKG_VERSION.tar.gz"

--- a/packages/addons/service/librespot/changelog.txt
+++ b/packages/addons/service/librespot/changelog.txt
@@ -1,3 +1,6 @@
+118
+- Update to 0.1.0
+
 117
 - Update to 51a634d (2019-07-23)
 - Set bit rate to 320 kpbs

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -3,15 +3,14 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="librespot"
-PKG_VERSION="51a634dc33233ca85a92db3e723d19550b548593"
-PKG_SHA256="581727e560c81cafbfeaf611b51f0a6987a48d348795785b3b6c0a304656a731"
-PKG_VERSION_DATE="2019-07-23"
-PKG_REV="117"
+PKG_VERSION="0.1.0"
+PKG_SHA256="4e03c69d1893ed14414d5a76ecdb5ea139ddfcce47fd57cc4e77b696001badb7"
+PKG_REV="118"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/librespot-org/librespot/"
-PKG_URL="https://github.com/librespot-org/librespot/archive/$PKG_VERSION.zip"
-PKG_DEPENDS_TARGET="toolchain avahi pulseaudio rust"
+PKG_URL="https://github.com/librespot-org/librespot/archive/v$PKG_VERSION.zip"
+PKG_DEPENDS_TARGET="toolchain pulseaudio rust"
 PKG_SECTION="service"
 PKG_SHORTDESC="Librespot: play Spotify through Kodi using a Spotify app as a remote"
 PKG_LONGDESC="Librespot ($PKG_VERSION_DATE) lets you play Spotify through Kodi using a Spotify app as a remote."
@@ -22,21 +21,16 @@ PKG_ADDON_NAME="Librespot"
 PKG_ADDON_TYPE="xbmc.service"
 PKG_MAINTAINER="Anton Voyl (awiouy)"
 
-configure_target() {
-  . "$TOOLCHAIN/.cargo/env"
-  export PKG_CONFIG_ALLOW_CROSS=0
-}
-
 make_target() {
   cd src
+  . "$(get_build_dir rust)/cargo/env"
   $CARGO_BUILD --no-default-features --features "pulseaudio-backend with-dns-sd"
-  cd "$PKG_BUILD/.$TARGET_NAME"/*/release
-  $STRIP librespot
+  "$STRIP" $PKG_BUILD/.$TARGET_NAME/*/release/librespot
 }
 
 addon() {
   mkdir -p "$ADDON_BUILD/$PKG_ADDON_ID/bin"
-    cp "$PKG_BUILD/.$TARGET_NAME"/*/release/librespot  \
+    cp $PKG_BUILD/.$TARGET_NAME/*/release/librespot \
        "$ADDON_BUILD/$PKG_ADDON_ID/bin"
 
   mkdir -p "$ADDON_BUILD/$PKG_ADDON_ID/lib"


### PR DESCRIPTION
This builds for and runs on RPi4, supports podcasts and does not anymore require avahi.
I will test build for other architectures and port to master in the coming days.