### PR TITLE
tiff: fix automagic codec support resulting in undefined symbols

### DIFF
--- a/packages/graphics/tiff/package.mk
+++ b/packages/graphics/tiff/package.mk
@@ -16,6 +16,10 @@ PKG_TOOLCHAIN="configure"
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \
                            --disable-mdi \
+                           --disable-jbig \
+                           --disable-lzma \
+                           --disable-zstd \
+                           --disable-webp \
                            --enable-cxx \
                            --with-jpeg-lib-dir=$SYSROOT_PREFIX/usr/lib \
                            --with-jpeg-include-dir=$SYSROOT_PREFIX/usr/include \


### PR DESCRIPTION
Now that we include `--enable-xz` in `Python3:target`, when building `tiff` and `Pillow` we are automagically enabling `lzma` support (which comes from `xz`), but we aren't statically linking the `lzma` library when building `tiff`, so we end up with the following run-time error:

```
NUC:~ # python
Python 3.7.5 (default, Nov 30 2019, 00:35:30)
[GCC 9.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from PIL import Image
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.7/site-packages/PIL/Image.py", line 90, in <module>
ImportError: /usr/lib/python3.7/site-packages/PIL/_imaging.so: undefined symbol: lzma_code
>>>
```

One solution is to add the missing dependency, and tell `tiff` where to find the codec library using the `--with-lzma-{lib,include}-dir` directives (as we do already for `jpeg`).

However, at this time there's no need to bloat the `tiff` library with unused codecs (`lzma` support isn't available in `Python2` so shouldn't be required by `Python3`), and this PR fixes the issue by explicitly disabling all unwanted codecs so that they are not automagically enabled in future (and then fail at run-time, due to undefined symbols etc.).