### PR TITLE
RPi4: set KODI_VENDOR to default

### DIFF
--- a/projects/RPi/devices/RPi4/options
+++ b/projects/RPi/devices/RPi4/options
@@ -14,4 +14,4 @@
     OPENGLES="mesa"
     GRAPHIC_DRIVERS="vc4"
     KODIPLAYER_DRIVER="mesa"
-    unset KODI_VENDOR
+    KODI_VENDOR="default"


### PR DESCRIPTION
This change was missed when adding RPi4 support to LE master.

While unsetting KODI_VENDOR works fine ATM it's not correct and
should be fixed.