### PR TITLE
kodi: use system cacert.pem

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -302,6 +302,9 @@ post_makeinstall_target() {
     cp -R $PKG_DIR/config/repository.kodi.game $INSTALL/usr/share/kodi/addons
 
   mkdir -p $INSTALL/usr/share/kodi/config
+
+  ln -sf /run/libreelec/cacert.pem $INSTALL/usr/share/kodi/system/certs/cacert.pem
+
   mkdir -p $INSTALL/usr/share/kodi/system/settings
 
   $PKG_DIR/scripts/xml_merge.py $PKG_DIR/config/guisettings.xml \

--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -91,4 +91,9 @@ fi
   cat_file "${KODI_ROOT}/.smb/smb.conf"
   cat_file "${KODI_ROOT}/.smb/user.conf"
   cat_file "/run/samba/smb.conf"
+  if cmp -s /etc/ssl/cacert.pem.system /run/libreelec/cacert.pem; then
+    cat_data "/run/libreelec/cacert.pem is default" </dev/null
+  else
+    cat_file /run/libreelec/cacert.pem "/run/libreelec/cacert.pem (modified)"
+  fi
 ) | ${OUTPUT} 2>/dev/null


### PR DESCRIPTION
Make kodi use user configurable /run/libreelec/cacert.pem instead of own copy in /usr/share/kodi/system/certs/cacert.pem.

Add cacert.pem logging to pastekodi in case of configuration errors.

System cacert.pem is usually the same as the kodi one (i.e. #3290).

A bug report can be found in the [forum](https://forum.libreelec.tv/thread/20806-http-s-proxy-how-to-add-my-ca-to-kodi/).