### PR TITLE
systemd: enable utmp support

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -49,7 +49,7 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Ddefault-dnssec=no \
                        -Dimportd=false \
                        -Dremote=false \
-                       -Dutmp=false \
+                       -Dutmp=true \
                        -Dhibernate=false \
                        -Denvironment-d=false \
                        -Dbinfmt=false \


### PR DESCRIPTION
`systemd-v244` is no longer creating `/run/utmp`: https://github.com/systemd/systemd/pull/13483 when `utemp` is disabled, which is entirely correct.

Without `utmp`, the following error is logged when logging out of an ssh session as ssh is [unable to write](https://github.com/openssh/openssh-portable/blob/be02d7c/loginrec.c#L1435) to `/var/run/utmp`:
```
Dec 10 20:38:49 rpi22 sshd[855]: syslogin_perform_logout: logout() returned an error
```

According to https://linux.die.net/man/5/wtmp, `utmp` should always exist on Linux, so enable it:
```
Unlike various other systems, where utmp logging can be disabled by removing the file, utmp must always exist on Linux. If you want to disable who(1) then do not make utmp world readable. 
```

Thanks @lrusak 