### PR TITLE
flag_enabled(): declare is local by default - remove it

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -148,29 +148,20 @@ safe_remove() {
 ### BUILDSYSTEM HELPERS ###
 # check if a flag is enabled
 # $1: flag-name, $2: default (yes/no), $3: ingenious check (none,only-disable,only-enable)
-# set variable PKG_[FLAG]_[HOST/TARGET]_ENABLED=(yes/no)
 # return 0 if flag is enabled, otherwise 1
 flag_enabled() {
-  # make flag name upper case and replace hyphen with underscore, to use as variable name
-  local flag_name=${1^^}
-  [[ $flag_name =~ : ]] || flag_name+="_TARGET"
-  flag_name="PKG_${flag_name//[:-]/_}_ENABLED"
-
   # check flag
   if [ -n "${PKG_BUILD_FLAGS}" ] && listcontains "${PKG_BUILD_FLAGS}" "[+]?$1"; then
     if [ "${3:none}" = "only-disable" ]; then
       die "ERROR: $1 cannot enable via PKG_BUILD_FLAGS (found in $PKG_NAME)"
     fi
-    declare ${flag_name}="yes"
     return 0
   elif [ "$2" = "yes" ] && ! listcontains "${PKG_BUILD_FLAGS}" "-$1"; then
-    declare ${flag_name}="yes"
     return 0
   else
     if [ "${3:none}" = "only-enable" ]; then
       die "ERROR: $1 cannot disable via PKG_BUILD_FLAGS (found in $PKG_NAME)"
     fi
-    declare ${flag_name}="no"
     return 1
   fi
 }


### PR DESCRIPTION
Reviewing the `flag_enabled()` code that sets the flag variable (ie. `PKG_SPEED_TARGET_ENABLED` etc.) I noticed the declared variables were not actually visible outside of the `flag_enabled()` function.

From `help declare`:
```
    When used in a function, `declare' makes NAMEs local, as with the `local'
    command.  The `-g' option suppresses this behavior.
```

Adding the `-g` option would allow the variables to become visible to the caller, meaning this code would work as intended.

However, as the variables are not currently used and I suspect will almost certainly never be used, I'd like to remove support for the declared variables as it complicates the function unnecessarily, could potentially result in a hard-to-debug variable name collision, and is just additional overhead.