### PR TITLE
p7zip: needs helping hand with cross-compiling

### DIFF
--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -141,10 +141,10 @@ addon() {
     cp -P $(get_build_dir nmon)/nmon $ADDON_BUILD/$PKG_ADDON_ID/bin/
 
     # p7zip
-    cp -P $(get_build_dir p7zip)/bin/7z.so $ADDON_BUILD/$PKG_ADDON_ID/bin
-    cp -PR $(get_build_dir p7zip)/bin/Codecs $ADDON_BUILD/$PKG_ADDON_ID/bin
-    cp -P $(get_build_dir p7zip)/bin/7z $ADDON_BUILD/$PKG_ADDON_ID/bin
-    cp -P $(get_build_dir p7zip)/bin/7za $ADDON_BUILD/$PKG_ADDON_ID/bin
+    cp -P $(get_build_dir p7zip)/.$TARGET_NAME/bin/7z.so $ADDON_BUILD/$PKG_ADDON_ID/bin
+    cp -PR $(get_build_dir p7zip)/.$TARGET_NAME/bin/Codecs $ADDON_BUILD/$PKG_ADDON_ID/bin
+    cp -P $(get_build_dir p7zip)/.$TARGET_NAME/bin/7z $ADDON_BUILD/$PKG_ADDON_ID/bin
+    cp -P $(get_build_dir p7zip)/.$TARGET_NAME/bin/7za $ADDON_BUILD/$PKG_ADDON_ID/bin
 
     # patch
     cp -P $(get_build_dir patch)/.$TARGET_NAME/src/patch $ADDON_BUILD/$PKG_ADDON_ID/bin

--- a/packages/compress/p7zip/package.mk
+++ b/packages/compress/p7zip/package.mk
@@ -12,15 +12,27 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="p7zip is a port of 7za.exe for POSIX systems like Unix."
 PKG_TOOLCHAIN="manual"
 
-make_host() {
-  make CXX=$CXX CC=$CC 7za
+pre_build_host() {
+  rm -fr $PKG_BUILD/.$HOST_NAME
+  mkdir -p $PKG_BUILD/.$HOST_NAME
+  cp -RP $PKG_BUILD/* $PKG_BUILD/.$HOST_NAME
 }
 
-make_target() {
-  make CXX=$CXX CC=$CC 7z 7za
+make_host() {
+  make CXX=$CXX CC=$CC -C $PKG_BUILD/.$HOST_NAME 7za
 }
 
 makeinstall_host() {
   mkdir -p $TOOLCHAIN/bin
-    cp bin/7za $TOOLCHAIN/bin
+    cp $PKG_BUILD/.$HOST_NAME/bin/7za $TOOLCHAIN/bin
+}
+
+pre_build_target() {
+  rm -fr $PKG_BUILD/.$TARGET_NAME
+  mkdir -p $PKG_BUILD/.$TARGET_NAME
+  cp -RP $PKG_BUILD/* $PKG_BUILD/.$TARGET_NAME
+}
+
+make_target() {
+  make CXX=$CXX CC=$CC -C $PKG_BUILD/.$TARGET_NAME 7z 7za
 }

--- a/packages/compress/p7zip/patches/p7zip-0100-CVE-2016-9296.patch
+++ b/packages/compress/p7zip/patches/p7zip-0100-CVE-2016-9296.patch
@@ -1,0 +1,12 @@
+--- ./CPP/7zip/Archive/7z/7zIn.cpp.orig	2016-11-21 01:42:29.460901230 +0000
++++ ./CPP/7zip/Archive/7z/7zIn.cpp	2016-11-21 01:42:57.481197725 +0000
+@@ -1097,7 +1097,8 @@ HRESULT CInArchive::ReadAndDecodePackedS
+       if (CrcCalc(data, unpackSize) != folders.FolderCRCs.Vals[i])
+         ThrowIncorrect();
+   }
+-  HeadersSize += folders.PackPositions[folders.NumPackStreams];
++  if (folders.PackPositions)
++      HeadersSize += folders.PackPositions[folders.NumPackStreams];
+   return S_OK;
+ }
+ 

--- a/packages/compress/p7zip/patches/p7zip-0200-CVE-2017-17969.patch
+++ b/packages/compress/p7zip/patches/p7zip-0200-CVE-2017-17969.patch
@@ -1,0 +1,26 @@
+From 79bca880ce7bcf07216c45f93afea545e0344418 Mon Sep 17 00:00:00 2001
+From: aone <aone@keka.io>
+Date: Mon, 5 Feb 2018 13:01:09 +0100
+Subject: [PATCH] Security fix CVE-2017-17969
+
+---
+ CPP/7zip/Compress/ShrinkDecoder.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/CPP/7zip/Compress/ShrinkDecoder.cpp b/CPP/7zip/Compress/ShrinkDecoder.cpp
+index 80b7e67..5bb0559 100644
+--- a/CPP/7zip/Compress/ShrinkDecoder.cpp
++++ b/CPP/7zip/Compress/ShrinkDecoder.cpp
+@@ -121,7 +121,12 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+     {
+       _stack[i++] = _suffixes[cur];
+       cur = _parents[cur];
++	  if (cur >= kNumItems || i >= kNumItems)
++	  	break;
+     }
++	
++	if (cur >= kNumItems || i >= kNumItems)
++		break;
+     
+     _stack[i++] = (Byte)cur;
+     lastChar2 = (Byte)cur;

--- a/packages/compress/p7zip/patches/p7zip-0300-CVE-2018-5996.patch
+++ b/packages/compress/p7zip/patches/p7zip-0300-CVE-2018-5996.patch
@@ -1,0 +1,221 @@
+From: Robert Luberda <robert@debian.org>
+Date: Sun, 28 Jan 2018 23:47:40 +0100
+Subject: CVE-2018-5996
+
+Hopefully fix Memory Corruptions via RAR PPMd (CVE-2018-5996) by
+applying a few changes from 7Zip 18.00-beta.
+
+Bug-Debian: https://bugs.debian.org/#888314
+---
+ CPP/7zip/Compress/Rar1Decoder.cpp | 13 +++++++++----
+ CPP/7zip/Compress/Rar1Decoder.h   |  1 +
+ CPP/7zip/Compress/Rar2Decoder.cpp | 10 +++++++++-
+ CPP/7zip/Compress/Rar2Decoder.h   |  1 +
+ CPP/7zip/Compress/Rar3Decoder.cpp | 23 ++++++++++++++++++++---
+ CPP/7zip/Compress/Rar3Decoder.h   |  2 ++
+ 6 files changed, 42 insertions(+), 8 deletions(-)
+
+diff --git a/CPP/7zip/Compress/Rar1Decoder.cpp b/CPP/7zip/Compress/Rar1Decoder.cpp
+index 1aaedcc..68030c7 100644
+--- a/CPP/7zip/Compress/Rar1Decoder.cpp
++++ b/CPP/7zip/Compress/Rar1Decoder.cpp
+@@ -29,7 +29,7 @@ public:
+ };
+ */
+ 
+-CDecoder::CDecoder(): m_IsSolid(false) { }
++CDecoder::CDecoder(): m_IsSolid(false), _errorMode(false) { }
+ 
+ void CDecoder::InitStructures()
+ {
+@@ -406,9 +406,14 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+   InitData();
+   if (!m_IsSolid)
+   {
++    _errorMode = false;
+     InitStructures();
+     InitHuff();
+   }
++
++  if (_errorMode)
++    return S_FALSE;
++
+   if (m_UnpackSize > 0)
+   {
+     GetFlagsBuf();
+@@ -477,9 +482,9 @@ STDMETHODIMP CDecoder::Code(ISequentialInStream *inStream, ISequentialOutStream
+     const UInt64 *inSize, const UInt64 *outSize, ICompressProgressInfo *progress)
+ {
+   try { return CodeReal(inStream, outStream, inSize, outSize, progress); }
+-  catch(const CInBufferException &e) { return e.ErrorCode; }
+-  catch(const CLzOutWindowException &e) { return e.ErrorCode; }
+-  catch(...) { return S_FALSE; }
++  catch(const CInBufferException &e) { _errorMode = true; return e.ErrorCode; }
++  catch(const CLzOutWindowException &e) { _errorMode = true; return e.ErrorCode; }
++  catch(...) { _errorMode = true; return S_FALSE; }
+ }
+ 
+ STDMETHODIMP CDecoder::SetDecoderProperties2(const Byte *data, UInt32 size)
+diff --git a/CPP/7zip/Compress/Rar1Decoder.h b/CPP/7zip/Compress/Rar1Decoder.h
+index 630f089..01b606b 100644
+--- a/CPP/7zip/Compress/Rar1Decoder.h
++++ b/CPP/7zip/Compress/Rar1Decoder.h
+@@ -39,6 +39,7 @@ public:
+ 
+   Int64 m_UnpackSize;
+   bool m_IsSolid;
++  bool _errorMode;
+ 
+   UInt32 ReadBits(int numBits);
+   HRESULT CopyBlock(UInt32 distance, UInt32 len);
+diff --git a/CPP/7zip/Compress/Rar2Decoder.cpp b/CPP/7zip/Compress/Rar2Decoder.cpp
+index b3f2b4b..0580c8d 100644
+--- a/CPP/7zip/Compress/Rar2Decoder.cpp
++++ b/CPP/7zip/Compress/Rar2Decoder.cpp
+@@ -80,7 +80,8 @@ static const UInt32 kHistorySize = 1 << 20;
+ static const UInt32 kWindowReservSize = (1 << 22) + 256;
+ 
+ CDecoder::CDecoder():
+-  m_IsSolid(false)
++  m_IsSolid(false),
++  m_TablesOK(false)
+ {
+ }
+ 
+@@ -100,6 +101,8 @@ UInt32 CDecoder::ReadBits(unsigned numBits) { return m_InBitStream.ReadBits(numB
+ 
+ bool CDecoder::ReadTables(void)
+ {
++  m_TablesOK = false;
++
+   Byte levelLevels[kLevelTableSize];
+   Byte newLevels[kMaxTableSize];
+   m_AudioMode = (ReadBits(1) == 1);
+@@ -170,6 +173,8 @@ bool CDecoder::ReadTables(void)
+   }
+   
+   memcpy(m_LastLevels, newLevels, kMaxTableSize);
++  m_TablesOK = true;
++
+   return true;
+ }
+ 
+@@ -344,6 +349,9 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+       return S_FALSE;
+   }
+ 
++  if (!m_TablesOK)
++    return S_FALSE;
++
+   UInt64 startPos = m_OutWindowStream.GetProcessedSize();
+   while (pos < unPackSize)
+   {
+diff --git a/CPP/7zip/Compress/Rar2Decoder.h b/CPP/7zip/Compress/Rar2Decoder.h
+index 3a0535c..0e9005f 100644
+--- a/CPP/7zip/Compress/Rar2Decoder.h
++++ b/CPP/7zip/Compress/Rar2Decoder.h
+@@ -139,6 +139,7 @@ class CDecoder :
+ 
+   UInt64 m_PackSize;
+   bool m_IsSolid;
++  bool m_TablesOK;
+ 
+   void InitStructures();
+   UInt32 ReadBits(unsigned numBits);
+diff --git a/CPP/7zip/Compress/Rar3Decoder.cpp b/CPP/7zip/Compress/Rar3Decoder.cpp
+index 3bf2513..6cb8a6a 100644
+--- a/CPP/7zip/Compress/Rar3Decoder.cpp
++++ b/CPP/7zip/Compress/Rar3Decoder.cpp
+@@ -92,7 +92,8 @@ CDecoder::CDecoder():
+   _writtenFileSize(0),
+   _vmData(0),
+   _vmCode(0),
+-  m_IsSolid(false)
++  m_IsSolid(false),
++  _errorMode(false)
+ {
+   Ppmd7_Construct(&_ppmd);
+ }
+@@ -545,6 +546,9 @@ HRESULT CDecoder::ReadTables(bool &keepDecompressing)
+     return InitPPM();
+   }
+ 
++  TablesRead = false;
++  TablesOK = false;
++
+   _lzMode = true;
+   PrevAlignBits = 0;
+   PrevAlignCount = 0;
+@@ -606,6 +610,9 @@ HRESULT CDecoder::ReadTables(bool &keepDecompressing)
+       }
+     }
+   }
++  if (InputEofError())
++    return S_FALSE;
++
+   TablesRead = true;
+ 
+   // original code has check here:
+@@ -623,6 +630,9 @@ HRESULT CDecoder::ReadTables(bool &keepDecompressing)
+   RIF(m_LenDecoder.Build(&newLevels[kMainTableSize + kDistTableSize + kAlignTableSize]));
+ 
+   memcpy(m_LastLevels, newLevels, kTablesSizesSum);
++
++  TablesOK = true;
++
+   return S_OK;
+ }
+ 
+@@ -824,7 +834,12 @@ HRESULT CDecoder::CodeReal(ICompressProgressInfo *progress)
+     PpmEscChar = 2;
+     PpmError = true;
+     InitFilters();
++    _errorMode = false;
+   }
++
++  if (_errorMode)
++    return S_FALSE;
++
+   if (!m_IsSolid || !TablesRead)
+   {
+     bool keepDecompressing;
+@@ -838,6 +853,8 @@ HRESULT CDecoder::CodeReal(ICompressProgressInfo *progress)
+     bool keepDecompressing;
+     if (_lzMode)
+     {
++      if (!TablesOK)
++        return S_FALSE;
+       RINOK(DecodeLZ(keepDecompressing))
+     }
+     else
+@@ -901,8 +918,8 @@ STDMETHODIMP CDecoder::Code(ISequentialInStream *inStream, ISequentialOutStream
+     _unpackSize = outSize ? *outSize : (UInt64)(Int64)-1;
+     return CodeReal(progress);
+   }
+-  catch(const CInBufferException &e)  { return e.ErrorCode; }
+-  catch(...) { return S_FALSE; }
++  catch(const CInBufferException &e)  { _errorMode = true; return e.ErrorCode; }
++  catch(...) { _errorMode = true; return S_FALSE; }
+   // CNewException is possible here. But probably CNewException is caused
+   // by error in data stream.
+ }
+diff --git a/CPP/7zip/Compress/Rar3Decoder.h b/CPP/7zip/Compress/Rar3Decoder.h
+index c130cec..2f72d7d 100644
+--- a/CPP/7zip/Compress/Rar3Decoder.h
++++ b/CPP/7zip/Compress/Rar3Decoder.h
+@@ -192,6 +192,7 @@ class CDecoder:
+   UInt32 _lastFilter;
+ 
+   bool m_IsSolid;
++  bool _errorMode;
+ 
+   bool _lzMode;
+   bool _unsupportedFilter;
+@@ -200,6 +201,7 @@ class CDecoder:
+   UInt32 PrevAlignCount;
+ 
+   bool TablesRead;
++  bool TablesOK;
+ 
+   CPpmd7 _ppmd;
+   int PpmEscChar;

--- a/packages/compress/p7zip/patches/p7zip-0400-CVE-2018-10115.patch
+++ b/packages/compress/p7zip/patches/p7zip-0400-CVE-2018-10115.patch
@@ -1,0 +1,311 @@
+From: Robert Luberda <robert@debian.org>
+Date: Tue, 29 May 2018 23:59:09 +0200
+Subject: Fix CVE-2018-10115
+
+Apply "patch" taken from https://landave.io/files/patch_7zip_CVE-2018-10115.txt
+
+
+Bugs-Debian: https://bugs.debian.org/897674
+---
+ CPP/7zip/Compress/Rar1Decoder.cpp | 16 +++++++++++-----
+ CPP/7zip/Compress/Rar1Decoder.h   |  3 ++-
+ CPP/7zip/Compress/Rar2Decoder.cpp | 17 +++++++++++++----
+ CPP/7zip/Compress/Rar2Decoder.h   |  3 ++-
+ CPP/7zip/Compress/Rar3Decoder.cpp | 19 +++++++++++++++----
+ CPP/7zip/Compress/Rar3Decoder.h   |  3 ++-
+ CPP/7zip/Compress/Rar5Decoder.cpp |  8 ++++++++
+ CPP/7zip/Compress/Rar5Decoder.h   |  1 +
+ 8 files changed, 54 insertions(+), 16 deletions(-)
+
+diff --git a/CPP/7zip/Compress/Rar1Decoder.cpp b/CPP/7zip/Compress/Rar1Decoder.cpp
+index 68030c7..8c890c8 100644
+--- a/CPP/7zip/Compress/Rar1Decoder.cpp
++++ b/CPP/7zip/Compress/Rar1Decoder.cpp
+@@ -29,7 +29,7 @@ public:
+ };
+ */
+ 
+-CDecoder::CDecoder(): m_IsSolid(false), _errorMode(false) { }
++CDecoder::CDecoder(): _isSolid(false), _solidAllowed(false), _errorMode(false) { }
+ 
+ void CDecoder::InitStructures()
+ {
+@@ -345,7 +345,7 @@ void CDecoder::GetFlagsBuf()
+ 
+ void CDecoder::InitData()
+ {
+-  if (!m_IsSolid)
++  if (!_isSolid)
+   {
+     AvrPlcB = AvrLn1 = AvrLn2 = AvrLn3 = NumHuf = Buf60 = 0;
+     AvrPlc = 0x3500;
+@@ -391,6 +391,11 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+   if (inSize == NULL || outSize == NULL)
+     return E_INVALIDARG;
+ 
++  if (_isSolid && !_solidAllowed)
++    return S_FALSE;
++
++  _solidAllowed = false;
++
+   if (!m_OutWindowStream.Create(kHistorySize))
+     return E_OUTOFMEMORY;
+   if (!m_InBitStream.Create(1 << 20))
+@@ -398,13 +403,13 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+ 
+   m_UnpackSize = (Int64)*outSize;
+   m_OutWindowStream.SetStream(outStream);
+-  m_OutWindowStream.Init(m_IsSolid);
++  m_OutWindowStream.Init(_isSolid);
+   m_InBitStream.SetStream(inStream);
+   m_InBitStream.Init();
+ 
+   // CCoderReleaser coderReleaser(this);
+   InitData();
+-  if (!m_IsSolid)
++  if (!_isSolid)
+   {
+     _errorMode = false;
+     InitStructures();
+@@ -475,6 +480,7 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+   }
+   if (m_UnpackSize < 0)
+     return S_FALSE;
++  _solidAllowed = true;
+   return m_OutWindowStream.Flush();
+ }
+ 
+@@ -491,7 +497,7 @@ STDMETHODIMP CDecoder::SetDecoderProperties2(const Byte *data, UInt32 size)
+ {
+   if (size < 1)
+     return E_INVALIDARG;
+-  m_IsSolid = ((data[0] & 1) != 0);
++  _isSolid = ((data[0] & 1) != 0);
+   return S_OK;
+ }
+ 
+diff --git a/CPP/7zip/Compress/Rar1Decoder.h b/CPP/7zip/Compress/Rar1Decoder.h
+index 01b606b..8abb3a3 100644
+--- a/CPP/7zip/Compress/Rar1Decoder.h
++++ b/CPP/7zip/Compress/Rar1Decoder.h
+@@ -38,7 +38,8 @@ public:
+   UInt32 LastLength;
+ 
+   Int64 m_UnpackSize;
+-  bool m_IsSolid;
++  bool _isSolid;
++  bool _solidAllowed;
+   bool _errorMode;
+ 
+   UInt32 ReadBits(int numBits);
+diff --git a/CPP/7zip/Compress/Rar2Decoder.cpp b/CPP/7zip/Compress/Rar2Decoder.cpp
+index 0580c8d..be8d842 100644
+--- a/CPP/7zip/Compress/Rar2Decoder.cpp
++++ b/CPP/7zip/Compress/Rar2Decoder.cpp
+@@ -80,7 +80,8 @@ static const UInt32 kHistorySize = 1 << 20;
+ static const UInt32 kWindowReservSize = (1 << 22) + 256;
+ 
+ CDecoder::CDecoder():
+-  m_IsSolid(false),
++  _isSolid(false),
++  _solidAllowed(false),
+   m_TablesOK(false)
+ {
+ }
+@@ -320,6 +321,10 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+   if (inSize == NULL || outSize == NULL)
+     return E_INVALIDARG;
+ 
++  if (_isSolid && !_solidAllowed)
++    return S_FALSE;
++  _solidAllowed = false;
++
+   if (!m_OutWindowStream.Create(kHistorySize))
+     return E_OUTOFMEMORY;
+   if (!m_InBitStream.Create(1 << 20))
+@@ -330,12 +335,12 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+   UInt64 pos = 0, unPackSize = *outSize;
+   
+   m_OutWindowStream.SetStream(outStream);
+-  m_OutWindowStream.Init(m_IsSolid);
++  m_OutWindowStream.Init(_isSolid);
+   m_InBitStream.SetStream(inStream);
+   m_InBitStream.Init();
+ 
+   // CCoderReleaser coderReleaser(this);
+-  if (!m_IsSolid)
++  if (!_isSolid)
+   {
+     InitStructures();
+     if (unPackSize == 0)
+@@ -343,6 +348,7 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+       if (m_InBitStream.GetProcessedSize() + 2 <= m_PackSize) // test it: probably incorrect;
+         if (!ReadTables())
+           return S_FALSE;
++      _solidAllowed = true;
+       return S_OK;
+     }
+     if (!ReadTables())
+@@ -386,6 +392,9 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+ 
+   if (!ReadLastTables())
+     return S_FALSE;
++
++  _solidAllowed = true;
++
+   return m_OutWindowStream.Flush();
+ }
+ 
+@@ -402,7 +411,7 @@ STDMETHODIMP CDecoder::SetDecoderProperties2(const Byte *data, UInt32 size)
+ {
+   if (size < 1)
+     return E_INVALIDARG;
+-  m_IsSolid = ((data[0] & 1) != 0);
++  _isSolid = ((data[0] & 1) != 0);
+   return S_OK;
+ }
+ 
+diff --git a/CPP/7zip/Compress/Rar2Decoder.h b/CPP/7zip/Compress/Rar2Decoder.h
+index 0e9005f..370bce2 100644
+--- a/CPP/7zip/Compress/Rar2Decoder.h
++++ b/CPP/7zip/Compress/Rar2Decoder.h
+@@ -138,7 +138,8 @@ class CDecoder :
+   Byte m_LastLevels[kMaxTableSize];
+ 
+   UInt64 m_PackSize;
+-  bool m_IsSolid;
++  bool _isSolid;
++  bool _solidAllowed;
+   bool m_TablesOK;
+ 
+   void InitStructures();
+diff --git a/CPP/7zip/Compress/Rar3Decoder.cpp b/CPP/7zip/Compress/Rar3Decoder.cpp
+index 6cb8a6a..7b85833 100644
+--- a/CPP/7zip/Compress/Rar3Decoder.cpp
++++ b/CPP/7zip/Compress/Rar3Decoder.cpp
+@@ -92,7 +92,8 @@ CDecoder::CDecoder():
+   _writtenFileSize(0),
+   _vmData(0),
+   _vmCode(0),
+-  m_IsSolid(false),
++  _isSolid(false),
++  _solidAllowed(false),
+   _errorMode(false)
+ {
+   Ppmd7_Construct(&_ppmd);
+@@ -821,7 +822,7 @@ HRESULT CDecoder::CodeReal(ICompressProgressInfo *progress)
+ {
+   _writtenFileSize = 0;
+   _unsupportedFilter = false;
+-  if (!m_IsSolid)
++  if (!_isSolid)
+   {
+     _lzSize = 0;
+     _winPos = 0;
+@@ -840,12 +841,15 @@ HRESULT CDecoder::CodeReal(ICompressProgressInfo *progress)
+   if (_errorMode)
+     return S_FALSE;
+ 
+-  if (!m_IsSolid || !TablesRead)
++  if (!_isSolid || !TablesRead)
+   {
+     bool keepDecompressing;
+     RINOK(ReadTables(keepDecompressing));
+     if (!keepDecompressing)
++    {
++      _solidAllowed = true;
+       return S_OK;
++    }
+   }
+ 
+   for (;;)
+@@ -870,6 +874,9 @@ HRESULT CDecoder::CodeReal(ICompressProgressInfo *progress)
+     if (!keepDecompressing)
+       break;
+   }
++
++  _solidAllowed = true;
++
+   RINOK(WriteBuf());
+   UInt64 packSize = m_InBitStream.BitDecoder.GetProcessedSize();
+   RINOK(progress->SetRatioInfo(&packSize, &_writtenFileSize));
+@@ -890,6 +897,10 @@ STDMETHODIMP CDecoder::Code(ISequentialInStream *inStream, ISequentialOutStream
+     if (!inSize)
+       return E_INVALIDARG;
+ 
++    if (_isSolid && !_solidAllowed)
++      return S_FALSE;
++    _solidAllowed = false;
++
+     if (!_vmData)
+     {
+       _vmData = (Byte *)::MidAlloc(kVmDataSizeMax + kVmCodeSizeMax);
+@@ -928,7 +939,7 @@ STDMETHODIMP CDecoder::SetDecoderProperties2(const Byte *data, UInt32 size)
+ {
+   if (size < 1)
+     return E_INVALIDARG;
+-  m_IsSolid = ((data[0] & 1) != 0);
++  _isSolid = ((data[0] & 1) != 0);
+   return S_OK;
+ }
+ 
+diff --git a/CPP/7zip/Compress/Rar3Decoder.h b/CPP/7zip/Compress/Rar3Decoder.h
+index 2f72d7d..32c8943 100644
+--- a/CPP/7zip/Compress/Rar3Decoder.h
++++ b/CPP/7zip/Compress/Rar3Decoder.h
+@@ -191,7 +191,8 @@ class CDecoder:
+   CRecordVector<CTempFilter *>  _tempFilters;
+   UInt32 _lastFilter;
+ 
+-  bool m_IsSolid;
++  bool _isSolid;
++  bool _solidAllowed;
+   bool _errorMode;
+ 
+   bool _lzMode;
+diff --git a/CPP/7zip/Compress/Rar5Decoder.cpp b/CPP/7zip/Compress/Rar5Decoder.cpp
+index dc8830f..a826d5a 100644
+--- a/CPP/7zip/Compress/Rar5Decoder.cpp
++++ b/CPP/7zip/Compress/Rar5Decoder.cpp
+@@ -72,6 +72,7 @@ CDecoder::CDecoder():
+     _writtenFileSize(0),
+     _dictSizeLog(0),
+     _isSolid(false),
++    _solidAllowed(false),
+     _wasInit(false),
+     _inputBuf(NULL)
+ {
+@@ -801,7 +802,10 @@ HRESULT CDecoder::CodeReal()
+   */
+ 
+   if (res == S_OK)
++  {
++    _solidAllowed = true;
+     res = res2;
++  }
+      
+   if (res == S_OK && _unpackSize_Defined && _writtenFileSize != _unpackSize)
+     return S_FALSE;
+@@ -821,6 +825,10 @@ STDMETHODIMP CDecoder::Code(ISequentialInStream *inStream, ISequentialOutStream
+ {
+   try
+   {
++    if (_isSolid && !_solidAllowed)
++      return S_FALSE;
++    _solidAllowed = false;
++
+     if (_dictSizeLog >= sizeof(size_t) * 8)
+       return E_NOTIMPL;
+ 
+diff --git a/CPP/7zip/Compress/Rar5Decoder.h b/CPP/7zip/Compress/Rar5Decoder.h
+index b0a4dd1..3db5018 100644
+--- a/CPP/7zip/Compress/Rar5Decoder.h
++++ b/CPP/7zip/Compress/Rar5Decoder.h
+@@ -271,6 +271,7 @@ class CDecoder:
+   Byte _dictSizeLog;
+   bool _tableWasFilled;
+   bool _isSolid;
++  bool _solidAllowed;
+   bool _wasInit;
+ 
+   UInt32 _reps[kNumReps];


### PR DESCRIPTION
p7zip has a very basic build system, which has no support for building into a multi-arch directory.

Consequently it drops the host binaries into `$PKG_BUILD/bin`, and the target binaries are also dropped into the same `$PKG_BUILD/bin`. However if the host `7za` binary is already present when building the target (as it normally would) then `7za` is not created for the target and `system-tools` installs the host binary to the add-on.

This change is hack, based on what we [used to do for dosfstools-v3](https://github.com/LibreELEC/LibreELEC.tv/pull/3858#issuecomment-533950792), but allows `p7zip` to build host and target into arch-specific directories..

I've also added a number of security fixes that other distros have been carrying for some time (copied [from Arch](https://git.archlinux.org/svntogit/packages.git/tree/trunk?h=packages/p7zip&id=bdbf4b9e919d95c91c0b01e44bfdf1635630c347)).

Thanks @dhewg for bringing this up (although you may need to update #4042 - and related PRs - to take account of these changes, sorry!)