### PR TITLE
libjpeg-turbo: build shared lib instead of static

### DIFF
--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -13,14 +13,14 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A high-speed version of libjpeg for x86 and x86-64 processors which uses SIMD."
 PKG_BUILD_FLAGS="+pic +pic:host"
 
-PKG_CMAKE_OPTS_HOST="-DENABLE_STATIC=ON \
-                     -DENABLE_SHARED=OFF \
-                     -DWITH_JPEG8=ON \
+PKG_CMAKE_OPTS_HOST="-DENABLE_STATIC=OFF \
+                     -DENABLE_SHARED=ON \
+                     -DWITH_JPEG8=OFF \
                      -DWITH_SIMD=OFF"
 
-PKG_CMAKE_OPTS_TARGET="-DENABLE_STATIC=ON \
-                       -DENABLE_SHARED=OFF \
-                       -DWITH_JPEG8=ON"
+PKG_CMAKE_OPTS_TARGET="-DENABLE_STATIC=OFF \
+                       -DENABLE_SHARED=ON \
+                       -DWITH_JPEG8=OFF"
 
 if target_has_feature "(neon|sse)"; then
   PKG_CMAKE_OPTS_TARGET+=" -DWITH_SIMD=ON"


### PR DESCRIPTION
libjpeg-turbo is used by several other packages. Building a shared library saves ~100kb for RPi2 build.

TexturePacker is the sole user of libjpeg-turbo:host. Made shared anyway to match target build.

Turning off `WITH_JPEG8` means don't bother emulating IJG's libjpeg version 8. I probably won't do the argument justice, but in short, IJG started experimenting with libjpeg and altered the jpeg format in version 7, 8 and 9. If you have a camera/phone that takes photos in jpegs, it's using the format from version 6 (the one recognized by ITU-T). Most users have no need for formats >=7, so don't support them. Additionally, from what I remember, libjpeg-turbo's emulation is solely to keep the program using it from crashing, not to actually support the formats. Libjpeg-turbo's views on the topic are here: https://libjpeg-turbo.org/About/Jpeg-9

I don't know why emulation was enabled originally. It dates from ~2011 and has no message with it.