### PR TITLE
llvm: fix cross compilation issues

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -416,7 +416,7 @@ cpp = '$CXX'
 ar = '$AR'
 strip = '$STRIP'
 pkgconfig = '$PKG_CONFIG'
-llvm-config = '$SYSROOT_PREFIX/usr/bin/llvm-config-host'
+llvm-config = '$TOOLCHAIN/bin/llvm-config-host'
 libgcrypt-config = '$SYSROOT_PREFIX/usr/bin/libgcrypt-config'
 
 [host_machine]
@@ -446,7 +446,7 @@ cpp = '$TARGET_CXX'
 ar = '$TARGET_AR'
 strip = '$TARGET_STRIP'
 pkgconfig = '$PKG_CONFIG'
-llvm-config = '$SYSROOT_PREFIX/usr/bin/llvm-config-host'
+llvm-config = '$TOOLCHAIN/bin/llvm-config-host'
 libgcrypt-config = '$SYSROOT_PREFIX/usr/bin/libgcrypt-config'
 
 [host_machine]

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -53,7 +53,6 @@ fi
 
 if [ "${LLVM_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" elfutils llvm"
-  export LLVM_CONFIG="${SYSROOT_PREFIX}/usr/bin/llvm-config-host"
   PKG_MESON_OPTS_TARGET+=" -Dllvm=true"
 else
   PKG_MESON_OPTS_TARGET+=" -Dllvm=false"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -13,7 +13,8 @@ PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain llvm:host zlib"
 PKG_LONGDESC="Low-Level Virtual Machine (LLVM) is a compiler infrastructure."
 
-PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
+PKG_CMAKE_OPTS_COMMON="-DCMAKE_BUILD_TYPE=MinSizeRel \
+                       -DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_BUILD_TOOLS=OFF \
                        -DLLVM_BUILD_UTILS=OFF \
                        -DLLVM_BUILD_EXAMPLES=OFF \
@@ -21,10 +22,13 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_BUILD_TESTS=OFF \
                        -DLLVM_INCLUDE_TESTS=OFF \
                        -DLLVM_INCLUDE_GO_TESTS=OFF \
+                       -DLLVM_BUILD_BENCHMARKS=OFF \
                        -DLLVM_BUILD_DOCS=OFF \
                        -DLLVM_INCLUDE_DOCS=OFF \
                        -DLLVM_ENABLE_DOXYGEN=OFF \
                        -DLLVM_ENABLE_SPHINX=OFF \
+                       -DLLVM_ENABLE_OCAMLDOC=OFF \
+                       -DLLVM_ENABLE_BINDINGS=OFF \
                        -DLLVM_TARGETS_TO_BUILD="AMDGPU" \
                        -DLLVM_ENABLE_TERMINFO=OFF \
                        -DLLVM_ENABLE_ASSERTIONS=OFF \
@@ -35,14 +39,16 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_OPTIMIZED_TABLEGEN=ON \
                        -DLLVM_APPEND_VC_REV=OFF \
                        -DLLVM_ENABLE_RTTI=ON \
-                       -DLLVM_ENABLE_UNWIND_TABLES=OFF"
+                       -DLLVM_ENABLE_UNWIND_TABLES=OFF \
+                       -DLLVM_ENABLE_Z3_SOLVER=OFF"
 
-PKG_CMAKE_OPTS_HOST="$PKG_CMAKE_OPTS_COMMON \
-                     -DCMAKE_INSTALL_RPATH=$TOOLCHAIN/lib"
+pre_configure_host() {
+  CXXFLAGS+=" -DLLVM_CONFIG_EXEC_PREFIX=\\\"$SYSROOT_PREFIX/usr\\\""
+  PKG_CMAKE_OPTS_HOST="$PKG_CMAKE_OPTS_COMMON"
+}
 
 pre_configure_target() {
   PKG_CMAKE_OPTS_TARGET="$PKG_CMAKE_OPTS_COMMON \
-                         -DCMAKE_BUILD_TYPE=MinSizeRel \
                          -DCMAKE_C_FLAGS="$CFLAGS" \
                          -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
                          -DLLVM_TARGET_ARCH="$TARGET_ARCH" \
@@ -54,7 +60,8 @@ make_host() {
 }
 
 makeinstall_host() {
-  cp -a bin/llvm-config $SYSROOT_PREFIX/usr/bin/llvm-config-host
+  cp -a lib/libLLVM-*.so $TOOLCHAIN/lib
+  cp -a bin/llvm-config $TOOLCHAIN/bin/llvm-config-host
   cp -a bin/llvm-tblgen $TOOLCHAIN/bin
 }
 

--- a/packages/lang/llvm/patches/llvm-config.patch
+++ b/packages/lang/llvm/patches/llvm-config.patch
@@ -1,0 +1,13 @@
+--- a/tools/llvm-config/llvm-config.cpp	2019-12-15 20:54:21.898634608 +0100
++++ b/tools/llvm-config/llvm-config.cpp	2019-12-15 20:56:12.280223943 +0100
+@@ -285,6 +285,10 @@
+   CurrentExecPrefix =
+       sys::path::parent_path(sys::path::parent_path(CurrentPath)).str();
+ 
++#ifdef LLVM_CONFIG_EXEC_PREFIX
++  CurrentExecPrefix = LLVM_CONFIG_EXEC_PREFIX;
++#endif
++
+   // Check to see if we are inside a development tree by comparing to possible
+   // locations (prefix style or CMake style).
+   if (sys::fs::equivalent(CurrentExecPrefix, LLVM_OBJ_ROOT)) {

--- a/packages/lang/llvm/patches/no-z3.patch
+++ b/packages/lang/llvm/patches/no-z3.patch
@@ -1,0 +1,47 @@
+Description:
+ Disable z3 to avoid pulling ocaml into main.
+ For some reason the cmake option LLVM_ENABLE_Z3_SOLVER was not taken into account
+Author: Gianfranco Costamagna <locutusofborg@debian.org>
+
+Last-Update: 2019-11-26
+
+Index: llvm-toolchain-9-9.0.0/CMakeLists.txt
+===================================================================
+--- llvm-toolchain-9-9.0.0.orig/CMakeLists.txt
++++ llvm-toolchain-9-9.0.0/CMakeLists.txt
+@@ -340,24 +340,22 @@
+ 
+ set(LLVM_Z3_INSTALL_DIR "" CACHE STRING "Install directory of the Z3 solver.")
+ 
+-find_package(Z3 4.7.1)
+-
+-if (LLVM_Z3_INSTALL_DIR)
+-  if (NOT Z3_FOUND)
+-    message(FATAL_ERROR "Z3 >= 4.7.1 has not been found in LLVM_Z3_INSTALL_DIR: ${LLVM_Z3_INSTALL_DIR}.")
+-  endif()
+-endif()
+-
+-set(LLVM_ENABLE_Z3_SOLVER_DEFAULT "${Z3_FOUND}")
+-
+ option(LLVM_ENABLE_Z3_SOLVER
+   "Enable Support for the Z3 constraint solver in LLVM."
+-  ${LLVM_ENABLE_Z3_SOLVER_DEFAULT}
++  OFF
+ )
+ 
+ if (LLVM_ENABLE_Z3_SOLVER)
+-  if (NOT Z3_FOUND)
+-    message(FATAL_ERROR "LLVM_ENABLE_Z3_SOLVER cannot be enabled when Z3 is not available.")
++  find_package(Z3 4.7.1)
++
++  if (LLVM_Z3_INSTALL_DIR)
++    if (NOT Z3_FOUND)
++      message(FATAL_ERROR "Z3 >= 4.7.1 has not been found in LLVM_Z3_INSTALL_DIR: ${LLVM_Z3_INSTALL_DIR}.")
++    endif()
++  else()
++    if (NOT Z3_FOUND)
++      message(FATAL_ERROR "LLVM_ENABLE_Z3_SOLVER cannot be enabled when Z3 is not available.")
++    endif()
+   endif()
+ 
+   set(LLVM_WITH_Z3 1)


### PR DESCRIPTION
llvm-config is a compiled host binary used to get infos about the
target installation (sic). It currently lives in the target sysroot,
which may not be usable because now we're mixing build host and
target libraries:

toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/bin/llvm-config-host:
  relocation error: /lib/x86_64-linux-gnu/libpthread.so.0: symbol
                    __libc_vfork version GLIBC_PRIVATE not defined in file
                    libc.so.6 with link time reference

Move it to $TOOLCHAIN/bin where host binaries belong. But llvm-config
doesn't support spitting out a library path from a different prefix than
its own (which explains the placement in sysroot). Patch that in to
prevail sanity.

Then disable the z3 solver so the target doesn't use build host libraries.
But that's broken too, use debian's patch to fix it up.

While at it, use the build type "MinSizeRel" for the host as well.