### PR TITLE
image: add /etc/environment

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.30-addons-refresh-etc-environment.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.30-addons-refresh-etc-environment.patch
@@ -1,0 +1,36 @@
+From 8c8803dc15ea7820f0f980bc12fcea2c7b8c4487 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Tue, 17 Dec 2019 15:51:23 +0000
+Subject: [PATCH] refresh /etc/environment on install and uninstall
+
+---
+ xbmc/addons/Addon.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/xbmc/addons/Addon.cpp b/xbmc/addons/Addon.cpp
+index 8a4bd0b..1046ab4 100644
+--- a/xbmc/addons/Addon.cpp
++++ b/xbmc/addons/Addon.cpp
+@@ -443,6 +443,9 @@ void OnPostInstall(const AddonPtr& addon, bool update, bool modal)
+   // OE
+ 
+   addon->OnPostInstall(update, modal);
++ 
++  if (addon->Type() == ADDON_SERVICE || addon->Type() == ADDON_SCRIPT)
++    system("/usr/bin/environment-setup");
+ }
+ 
+ void OnPreUnInstall(const AddonPtr& addon)
+@@ -455,6 +458,9 @@ void OnPreUnInstall(const AddonPtr& addon)
+ void OnPostUnInstall(const AddonPtr& addon)
+ {
+   addon->OnPostUnInstall();
++
++  if (addon->Type() == ADDON_SERVICE || addon->Type() == ADDON_SCRIPT)
++    system("/usr/bin/environment-setup");
+ }
+ 
+ } /* namespace ADDON */
+-- 
+2.20.1
+

--- a/packages/network/openssh/patches/openssh-source-etc-environment.patch
+++ b/packages/network/openssh/patches/openssh-source-etc-environment.patch
@@ -1,0 +1,32 @@
+From c05ee9208db5e25d550ec6dd4b5ff54a199959fd Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Mon, 16 Dec 2019 20:34:22 +0000
+Subject: [PATCH] openssh: source /etc/environment
+
+---
+ session.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/session.c b/session.c
+index ac06b08..0a1c59a 100644
+--- a/session.c
++++ b/session.c
+@@ -1080,7 +1080,6 @@ do_setup_env(struct ssh *ssh, Session *s, const char *shell)
+ 			child_set_env(&env, &envsize, "KRB5CCNAME", cp);
+ 	}
+ 
+-#ifdef _AIX
+ 	{
+ 		char *cp;
+ 
+@@ -1089,7 +1088,6 @@ do_setup_env(struct ssh *ssh, Session *s, const char *shell)
+ 		read_environment_file(&env, &envsize, "/etc/environment",
+ 		    options.permit_user_env_whitelist);
+ 	}
+-#endif
+ #ifdef KRB5
+ 	if (s->authctxt->krb5_ccname)
+ 		child_set_env(&env, &envsize, "KRB5CCNAME",
+-- 
+2.7.4
+

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -205,6 +205,7 @@ post_makeinstall_target() {
   cp $PKG_DIR/scripts/systemd-machine-id-setup $INSTALL/usr/bin
   cp $PKG_DIR/scripts/userconfig-setup $INSTALL/usr/bin
   cp $PKG_DIR/scripts/usercache-setup $INSTALL/usr/bin
+  cp $PKG_DIR/scripts/environment-setup $INSTALL/usr/bin
 
   # use systemd to set cpufreq governor and tunables
   find_file_path scripts/cpufreq && cp -PRv $FOUND_PATH $INSTALL/usr/bin
@@ -217,6 +218,7 @@ post_makeinstall_target() {
   # /etc/resolv.conf and /etc/hosts must be writable
   ln -sf /run/libreelec/resolv.conf $INSTALL/etc/resolv.conf
   ln -sf /run/libreelec/hosts $INSTALL/etc/hosts
+  ln -sf /run/libreelec/environment $INSTALL/etc/environment
 
   # provide 'halt', 'shutdown', 'reboot' & co.
   ln -sf /usr/bin/systemctl $INSTALL/usr/sbin/halt
@@ -276,6 +278,7 @@ post_install() {
   enable_service debugconfig.service
   enable_service userconfig.service
   enable_service usercache.service
+  enable_service envconfig.service
   enable_service kernel-overlays.service
   enable_service hwdb.service
   enable_service cpufreq.service

--- a/packages/sysutils/systemd/scripts/environment-setup
+++ b/packages/sysutils/systemd/scripts/environment-setup
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+# read config files
+for config in /etc/profile.d/*; do
+  if [ -f "$config" ] ; then
+    . $config
+  fi
+done
+
+# generate system-wide environment file
+cat <<EOF >/run/libreelec/environment
+PATH=${PATH}
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+EOF

--- a/packages/sysutils/systemd/system.d/envconfig.service
+++ b/packages/sysutils/systemd/system.d/envconfig.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Generate system-wide /etc/environment file
+DefaultDependencies=no
+After=systemd-tmpfiles-setup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/environment-setup
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
Executables (scripts, binaries) installed via add-ons are not accessible to `sshd` unless the full add-on path is specified because profiles are not sourced unless the user actually logs in to an interactive session.

This is a particular issue with `rsync`:
```
hias@lenny:~$ mkdir /tmp/videos
hias@lenny:~$ rsync -avn root@xbmc:~/videos/ /tmp/videos/
sh: rsync: not found
rsync: connection unexpectedly closed (0 bytes received so far) [Receiver]
rsync error: error in rsync protocol data stream (code 12) at io.c(235) [Receiver=3.1.3]
hias@lenny:~$ rsync -avn --rsync-path=/storage/.kodi/addons/virtual.network-tools/bin/rsync root@xbmc:~/videos/ /tmp/videos/
receiving incremental file list
```
In the case of `rsync`, the current workaround is to specify the full path of the remote LibreELEC `rsync` binary to the `rsync` client (with `--rsync-path=/storage/.kodi/addons/virtual.network-tools/bin/rsync`) but this is far from ideal.

Installing `rsync` into the image would also work, but this is wasteful and doesn't solve the problem for other add-on installed executables, and we can't install them all in to the image...

This PR provides a general solution by adding the system-wide `/etc/environment` file which is sourced by `sshd` when a session is connected allowing add-on executables to be successfully located on the `PATH`.

I've added `/bin` and `/sbin` to the base PATH set by `98-busybox.conf` as although `/bin` is a symbolic link to `/usr/bin`, `sshd` doesn't seem to follow symbolic links. eg:
```
rpi4:~ # which date
/usr/bin/date
rpi4:~ # exit
Connection to rpi4 closed.
```
##### with `/bin` in `/etc/environment`
```
neil@nm-linux:~/projects$ ssh root@rpi4 -C date
Mon Dec 16 22:39:10 GMT 2019
```
##### without `/bin` in `/etc/environment`
```
neil@nm-linux:~/projects$ ssh root@rpi4 -C date
sh: date: not found
```
