### PR TITLE
system-tools: Vim update and move redundant runtime dir

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -29,6 +29,8 @@ PKG_CONFIGURE_OPTS_TARGET="vim_cv_getcwd_broken=no \
                            --with-tlib=ncurses \
                            --without-x"
 
+PKG_MAKEINSTALL_OPTS_TARGET=VIMRTDIR=
+
 pre_configure_target() {
   cd ..
   rm -rf .$TARGET_NAME
@@ -40,8 +42,8 @@ make_target() {
 
 post_makeinstall_target() {
   (
-  cd $INSTALL/storage/.kodi/addons/virtual.system-tools/data/vim/vim*
+  cd $INSTALL/storage/.kodi/addons/virtual.system-tools/data/vim
   rm -r doc tutor gvimrc_example.vim
-  mv vimrc_example.vim ../vimrc
+  mv vimrc_example.vim vimrc
   )
 }

--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vim"
-PKG_VERSION="8.1.2384"
-PKG_SHA256="f17462971e577063552cd4dbbebeb84e77a9fb47cd40c6234969e7672aebcd59"
+PKG_VERSION="8.2.0023"
+PKG_SHA256="100c1226286e24421084b9301d945d0310c7b3c9d45a6da4741dc23c0be60050"
 PKG_LICENSE="VIM"
 PKG_SITE="http://www.vim.org/"
 PKG_URL="https://github.com/vim/vim/archive/v$PKG_VERSION.tar.gz"

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,7 @@
+112
+- added vim runtime files
+- updated vim
+
 111
 - updated autossh to 1.4g
 - updated file to d1ff3af

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="111"
+PKG_REV="112"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
I'm sorry to push it again, but soon after #4033 was merged, the next Vim 8.x release is out.
So please let's bump it again.

It doesn't happen very often, the previous 8.1 release was out at May 2018.


Right now system-tools addon has following redundant Vim directory structure, where `vim81` is a runtime dir:
```
# ls -l .kodi/addons/virtual.system-tools/data/vim
total 4
drwxr-xr-x 1 root root  476 Dec 24 01:58 vim81/
-rw-r--r-- 1 root root 1384 Dec 24 01:58 vimrc
```
It's needless for this addon.

So this PR also moves Vim runtime to the `vim` directory itself.