### PR TITLE
[le92] kodi-binary-addons: update to latest Leia versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.flac"
-PKG_VERSION="2.0.4-Leia"
-PKG_SHA256="7ec525ec7c4ecfb6e832333869f77df03f71fd59209e8d6e22b3da8a72074db2"
+PKG_VERSION="2.0.5-Leia"
+PKG_SHA256="e6b8ad024c171eb463339a1f136f3ee9465267ef7fd3b80a5f0007b0180f36e5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="3.8.6-Leia"
-PKG_SHA256="d1661f4d88b750cb84fd6a1a3bb4f22b27e00f986f1d17703c04ca92311d5593"
+PKG_VERSION="3.8.8-Leia"
+PKG_SHA256="25eff252ad748e0cf166cd01b0f08e8fb3977c98a1b04cad9ef6509ea30c5fa9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="5.10.13-Leia"
-PKG_SHA256="f2bc43d366b64737cf5b1dce83e5a3737670bf423c5a65562daece6cc86d84ae"
+PKG_VERSION="5.10.14-Leia"
+PKG_SHA256="889dc2e5e5283d0fdd4447a853d91456e543d70d78f46627a1f801d7141ba9a2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.teleboy"
-PKG_VERSION="18.0.25-Leia"
-PKG_SHA256="7d55dc063e33fe63bdf7b5ec1caf00cc0cd433cff139ecbbc668d72cd59b14f1"
+PKG_VERSION="18.1.8-Leia"
+PKG_SHA256="57f2f77e825f267d1d0acfddb54aacd76b738c6f25b2e94cfb1442d3d1c3aeab"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="18.1.5-Leia"
-PKG_SHA256="0d6f8f89674dbabfe121f320fe198bef1c333817219bf4294c8fac36947d6b0b"
+PKG_VERSION="18.1.10-Leia"
+PKG_SHA256="a3cbaa98192660e4269a4dac99fdd57b31b59367601af17c5e465b35e2f30e84"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.stars"
-PKG_VERSION="2.1.2-Leia"
-PKG_SHA256="8873de9be41365af9dc639e3624d887f7b18d8e1f43e9a69af0c3154f9b59020"
-PKG_REV="2"
+PKG_VERSION="2.1.3-Leia"
+PKG_SHA256="dca39e68d803cca3c1d9524df17feb3e12fc7eeae4166c6311a97dc68c29f523"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.stars"

--- a/packages/mediacenter/kodi-binary-addons/visualization.pictureit/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.pictureit/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.pictureit"
-PKG_VERSION="f08d0aa6d5f80cfa95a24adca48be15e333ca8e0"
-PKG_SHA256="f29112d232907b46a738e6971f03c75ec6a61b70be70de203db82b2252ae4f8d"
-PKG_REV="3"
+PKG_VERSION="4060888ba482e99e9c08753a385ecf164a9ac821"
+PKG_SHA256="dbd9d355b62042887bcaed69cb58033a71447e0ae3143ca2e319fd5cac7bd292"
+PKG_REV="4"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"

--- a/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.projectm"
-PKG_VERSION="2.3.2-Leia"
-PKG_SHA256="e30163b4eb12518deb1b56c488b0a81f7eeb3467d291dad6e28234843fc9dc40"
+PKG_VERSION="2.3.4-Leia"
+PKG_SHA256="d6a11b53b55df6cf1dd2adea8c9b559d6b0bb1270eef9a8be8396599a205be3b"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
pvr.teleboy bump should fix the issue reported here https://forum.libreelec.tv/thread/21010-pvr-teleboy-stream-addresses-has-changed-use-new-version/

RPi4 build of audioencoder.flac, pvr.iptvsimple, pvr.mythtv, pvr.teleboy and pvr.zattoo was fine. I kicked off a Generic build of all changed addons (including the x86_64/GL only addons screensaver.stars, visualization.pictureit and visualization.projectm) but that'll take a while to finish