### PR TITLE
system-tools: move redundant Vim runtime dir

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -29,6 +29,8 @@ PKG_CONFIGURE_OPTS_TARGET="vim_cv_getcwd_broken=no \
                            --with-tlib=ncurses \
                            --without-x"
 
+PKG_MAKEINSTALL_OPTS_TARGET=VIMRTDIR=
+
 pre_configure_target() {
   cd ..
   rm -rf .$TARGET_NAME
@@ -40,8 +42,8 @@ make_target() {
 
 post_makeinstall_target() {
   (
-  cd $INSTALL/storage/.kodi/addons/virtual.system-tools/data/vim/vim*
+  cd $INSTALL/storage/.kodi/addons/virtual.system-tools/data/vim
   rm -r doc tutor gvimrc_example.vim
-  mv vimrc_example.vim ../vimrc
+  mv vimrc_example.vim vimrc
   )
 }


### PR DESCRIPTION
Right now `system-tools` addon has following redundant Vim directory structure, where `vim82` is a runtime dir:
```
# ls -l .kodi/addons/virtual.system-tools/data/vim
total 4
drwxr-xr-x 1 root root  476 Dec 24 01:58 vim82/
-rw-r--r-- 1 root root 1384 Dec 24 01:58 vimrc
```
It's needless for this addon.

So this PR moves Vim runtime to the `vim` directory itself.