### PR TITLE
config/multithread: dump build stats

### DIFF
--- a/config/multithread
+++ b/config/multithread
@@ -156,6 +156,8 @@ start_multithread_build() {
         --plain --no-notice --max-procs ${THREADCOUNT} --joblog="${THREAD_CONTROL}/joblog" --plus ${buildopts} \
         package_worker {%} {#} {##} {} || result=1
 
+    [ -f "${THREAD_CONTROL}"/history ] && echo && cat "${THREAD_CONTROL}"/history | ${ROOT}/tools/mtstats.py
+
     rm -f "${THREAD_CONTROL}/parallel.pid"
   fi
 

--- a/scripts/image
+++ b/scripts/image
@@ -136,6 +136,7 @@ done
 # Build image contents
 MTADDONBUILD=no start_multithread_build image || die "Parallel build failure - see log for details. Time of failure: $(date)"
 
+echo
 echo "Successful build, creating image..." >&2
 
 # Create legacy sym links


### PR DESCRIPTION
In order to further optimise the build system we should always output the build stats at the end of each build. This may also permit before/after comparisons when tuning the build system in future.

This is an example of the build stats for an 8-core system (FX-8350, with SSD) building all 688 addon steps (for Generic):

```
Total Build Time: 04:03:35.220 (wall clock)
Accum Build Time: 32:28:41.489 (8 slots)

Breakdown by status (all slots):

  Status   Usage         ( Pct )  Count  State
  ACTIVE   14:50:18.927  (45.7%)  1648   busy
  FAILED     :  :00.000  (00.0%)  0
  GETPKG     :  :01.297  (00.0%)  1      busy
  IDLE       :09:27.274  (00.5%)  688
  LOCKED     :12:27.079  (00.6%)  3781
  MUTEX      :  :07.644  (00.0%)  6      busy
  MUTEX/W    :  :00.000  (00.0%)  0      stall
  STALLED  17:04:24.917  (52.6%)  299    stall
  UNLOCK     :11:54.350  (00.6%)  3781
  -------------------------------------
  TOTAL    32:28:41.489  ( 100%)  10204

Peak concurrency: 8 out of 8 slots

299 job slots were held in a "stall" state for 17:04:24.917

Slot usage (time in a "busy" state):     | Concurrency breakdown ("busy"):
                                         |
#Rank  Slot  Usage        ( Pct )        | # of Slots  Usage        ( Pct )
 #01    01   02:28:01.789 (07.6%)        |     01      04:03:33.864 (12.5%)
 #02    02   02:22:11.956 (07.3%)        |     02      03:26:57.545 (10.6%)
 #03    06   02:10:03.905 (06.7%)        |     03      02:44:52.699 (08.5%)
 #04    03   02:05:36.174 (06.4%)        |     04      02:24:18.687 (07.4%)
 #05    08   01:57:00.636 (06.0%)        |     05      01:29:43.860 (04.6%)
 #06    04   01:38:28.971 (05.1%)        |     06        :26:42.610 (01.4%)
 #07    07   01:23:24.370 (04.3%)        |     07        :11:35.560 (00.6%)
 #08    05     :45:40.068 (02.3%)        |     08        :02:43.044 (00.1%)
-----------------------------------------+---------------------------------
 TOTALS      14:50:27.869 (45.7%)                      14:50:27.869 (45.7%)
```