### PR TITLE
update_binary-addons: fix unofficial addon bumping

### DIFF
--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -165,9 +165,15 @@ for ADDON in $(ls -1 "${ROOT}/packages/mediacenter/kodi-binary-addons"); do
 
   git_clone ${GIT_REPO} ${GIT_DIR}
 
-  # update package.mk for stale github.com packages
-  RESOLVED_HASH=$(resolve_hash_in_branch ${ADDON}.git HEAD) || continue
-  echo "Resolving hash for ${ADDON}: HEAD => ${RESOLVED_HASH}"
+  if RESOLVED_HASH=$(resolve_hash_in_branch ${ADDON}.git ${KODI_BRANCH}); then
+    echo "Resolved hash for ${ADDON}: ${KODI_BRANCH} => ${RESOLVED_HASH}"
+  elif RESOLVED_HASH=$(resolve_hash_in_branch ${ADDON}.git HEAD); then
+    echo "Resolved hash for ${ADDON}: HEAD => ${RESOLVED_HASH}"
+  else
+    msg_warn "WARNING: Could not resolve hash for ${ADDON}"
+    continue
+  fi
+
   if update_pkg "${ADDON_PATH}" "${ADDON}" "${RESOLVED_HASH}"; then
     # always bump PKG_REV when updating untagged addons
     bump_pkg_rev "${ADDON_PATH}" "${ADDON}"

--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -8,7 +8,7 @@ BUMP_PKG_REV=""
 KEEP_GIT_DIRS="yes"
 
 usage() {
-  echo "Usage: $0 [options] <branch-name>"
+  echo "Usage: $0 [options] <kodi-branch> [<unofficial-addon-branch>]"
   echo " -b, --bump-pkg-rev: bump PKG_REV if package was not updated"
   echo " -d, --delete-git-dirs: delete cloned git dirs after update"
   echo " -h, --help: display help and exit"
@@ -40,7 +40,7 @@ while [ $# -ne 0 ]; do
   esac
 done
 
-if [ $# -ne 1 ]; then
+if [ $# -eq 0 -o $# -gt 2 ]; then
   usage
   exit 1
 fi
@@ -59,6 +59,12 @@ mkdir -p "${TMPDIR}"
 
 KODI_BRANCH="$1"
 KODI_DIR="kodi.git"
+
+if [ $# -eq 1 ]; then
+  UNOFFICIAL_ADDON_BRANCH="${KODI_BRANCH}"
+else
+  UNOFFICIAL_ADDON_BRANCH="$2"
+fi
 
 . "${MY_DIR}/update_common_functions"
 
@@ -165,8 +171,8 @@ for ADDON in $(ls -1 "${ROOT}/packages/mediacenter/kodi-binary-addons"); do
 
   git_clone ${GIT_REPO} ${GIT_DIR}
 
-  if RESOLVED_HASH=$(resolve_hash_in_branch ${ADDON}.git ${KODI_BRANCH}); then
-    echo "Resolved hash for ${ADDON}: ${KODI_BRANCH} => ${RESOLVED_HASH}"
+  if RESOLVED_HASH=$(resolve_hash_in_branch ${ADDON}.git ${UNOFFICIAL_ADDON_BRANCH}); then
+    echo "Resolved hash for ${ADDON}: ${UNOFFICIAL_ADDON_BRANCH} => ${RESOLVED_HASH}"
   elif RESOLVED_HASH=$(resolve_hash_in_branch ${ADDON}.git HEAD); then
     echo "Resolved hash for ${ADDON}: HEAD => ${RESOLVED_HASH}"
   else


### PR DESCRIPTION
Extend the unofficial addon update logic to check if a kodi specific branch (Leia, Matrix, ...) is available and if yes bump to the HEAD of the branch. If no such branch exists bump to the HEAD of the default branch (origin/HEAD) as before.

As kodi Matrix is still developed in the master branch, but addons already created Matrix branches add the possibility to optionally specify the addon branch to use. eg:
```
./update_binary-addons master Matrix
```

This fixes visualization.pictureit bumps which incorrectly picked up the master branch instead of Leia/Matrix branches.