### PR TITLE
Add support for OSMC RF rev 2.5

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -1,3 +1,8 @@
 # o2.cz bluetooth remote
 evdev:input:b0005v0217p0000e0110*
  KEYBOARD_KEY_c0041=enter		# OK button
+
+# osmcrf25 remote
+evdev:input:b0003v2017p1689*
+ KEYBOARD_KEY_7002e=f10 # volume up
+ KEYBOARD_KEY_7002d=f9 # volume down


### PR DESCRIPTION
This remote revision adds support for long press (as eventlircd is not used); as well as a low battery indicator when the CR-2032 drops below 2.2V