### PR TITLE
expat: update cmake build options

### DIFF
--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -12,6 +12,13 @@ PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Expat is an XML parser library written in C."
 
-PKG_CMAKE_OPTS_TARGET="-DBUILD_doc=OFF -DBUILD_tools=OFF -DBUILD_examples=OFF -DBUILD_tests=OFF -DBUILD_shared=ON"
-PKG_CMAKE_OPTS_HOST="-DBUILD_doc=OFF -DBUILD_tools=OFF -DBUILD_examples=OFF -DBUILD_tests=OFF -DBUILD_shared=ON"
-
+PKG_CMAKE_OPTS_TARGET="-DEXPAT_BUILD_DOCS=OFF \
+                       -DEXPAT_BUILD_TOOLS=OFF \
+                       -DEXPAT_BUILD_EXAMPLES=OFF \
+                       -DEXPAT_BUILD_TESTS=OFF \
+                       -DEXPAT_SHARED_LIBS=ON"
+PKG_CMAKE_OPTS_HOST="-DEXPAT_BUILD_DOCS=OFF \
+                     -DEXPAT_BUILD_TOOLS=OFF \
+                     -DEXPAT_BUILD_EXAMPLES=OFF \
+                     -DEXPAT_BUILD_TESTS=OFF \
+                     -DEXPAT_SHARED_LIBS=ON"


### PR DESCRIPTION
This PR updates expat build options after the update to 2.2.9, build complains about:

```
-- Configuration
--   Prefix ..................... /usr
--   Build type ................. MinSizeRel
--   Shared libraries ........... ON
--   Character type ............. char (UTF-8)
--
--   Build documentation ........ OFF
--   Build examples ............. ON
--   Build fuzzers .............. OFF
--   Build tests ................ ON
--   Build tools (xmlwf) ........ ON
--   Install files .............. ON


CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_doc
    BUILD_examples
    BUILD_shared
    BUILD_tests
    BUILD_tools
```

With these changes expat now builds with:

```
-- Configuration
--   Prefix ..................... /usr
--   Build type ................. MinSizeRel
--   Shared libraries ........... ON
--   Character type ............. char (UTF-8)
--
--   Build documentation ........ OFF
--   Build examples ............. OFF
--   Build fuzzers .............. OFF
--   Build tests ................ OFF
--   Build tools (xmlwf) ........ OFF
--   Install files .............. ON
```