### PR TITLE
Allwinner: Add frame inversion to correct audio channels

### DIFF
--- a/projects/Allwinner/devices/A64/patches/linux/04-Add-frame-inversion-to-correct-multi-channel-audio.patch
+++ b/projects/Allwinner/devices/A64/patches/linux/04-Add-frame-inversion-to-correct-multi-channel-audio.patch
@@ -1,0 +1,24 @@
+From 08d35c5d5ce6de3453f17e6eff7375afa74173d2 Mon Sep 17 00:00:00 2001
+From: Marcus Cooper <codekipper@gmail.com>
+Date: Thu, 2 Jan 2020 19:09:25 +0100
+Subject: [PATCH] Add frame inversion to correct multi-channel audio
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi
+index 988e261a0ab3..4e20a0872c0c 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi
+@@ -1101,6 +1101,7 @@
+ 			simple-audio-card,format = "i2s";
+ 			simple-audio-card,name = "allwinner-hdmi";
+ 			simple-audio-card,mclk-fs = <128>;
++			simple-audio-card,frame-inversion;
+ 
+ 			simple-audio-card,codec {
+ 				sound-dai = <&hdmi>;
+-- 
+2.24.1
+

--- a/projects/Allwinner/devices/H3/patches/linux/17-Add-frame-inversion-to-correct-multi-channel-audio.patch
+++ b/projects/Allwinner/devices/H3/patches/linux/17-Add-frame-inversion-to-correct-multi-channel-audio.patch
@@ -1,0 +1,24 @@
+From 51dcda7a261bcadca0a8f5e6fe6241ec266438d0 Mon Sep 17 00:00:00 2001
+From: Marcus Cooper <codekipper@gmail.com>
+Date: Thu, 2 Jan 2020 19:03:35 +0100
+Subject: [PATCH] Add frame inversion to correct multi-channel audio
+
+---
+ arch/arm/boot/dts/sunxi-h3-h5.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index 8644435e66d3..7375a9479e84 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -82,6 +82,7 @@
+ 		simple-audio-card,format = "i2s";
+ 		simple-audio-card,name = "allwinner-hdmi";
+ 		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,frame-inversion;
+ 
+ 		simple-audio-card,codec {
+ 			sound-dai = <&hdmi>;
+-- 
+2.24.1
+

--- a/projects/Allwinner/devices/H6/patches/linux/16-Add-frame-inversion-to-correct-multi-channel-audio.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/16-Add-frame-inversion-to-correct-multi-channel-audio.patch
@@ -1,0 +1,24 @@
+From 3e9d104275c44ab1711a3564ce67cabe850afe75 Mon Sep 17 00:00:00 2001
+From: Marcus Cooper <codekipper@gmail.com>
+Date: Thu, 2 Jan 2020 19:07:29 +0100
+Subject: [PATCH] Add frame inversion to correct multi-channel audio
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
+index 132ef9c2d348..43ed134b49f7 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
+@@ -103,6 +103,7 @@
+ 		simple-audio-card,format = "i2s";
+ 		simple-audio-card,name = "allwinner-hdmi";
+ 		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,frame-inversion;
+ 
+ 		simple-audio-card,codec {
+ 			sound-dai = <&hdmi>;
+-- 
+2.24.1
+


### PR DESCRIPTION
For some reason the mainline i2s driver inverts the frame clock
which in turn maps the audio channels incorrectly when not using
audio passthrough on multi-channel audio.

Adding frame-inversion to the device tree properties fixes the
issue but should be seen as a temporary fix whilst we investigate
the correct default setup of the i2s block.

Signed-off-by: Marcus Cooper <codekipper@gmail.com>