### PR TITLE
libva-utils: fix non x11 build after e46c85e

### DIFF
--- a/packages/debug/libva-utils/patches/libva-utils-001-fix-build-withouth-x11.patch
+++ b/packages/debug/libva-utils/patches/libva-utils-001-fix-build-withouth-x11.patch
@@ -1,27 +1,29 @@
-From 5efef48d74d772cb5318345aa61d94d27e0c42d1 Mon Sep 17 00:00:00 2001
-From: Lukas Rusak <lorusak@gmail.com>
-Date: Fri, 22 Feb 2019 18:43:25 -0800
-Subject: [PATCH] only build sfcsample when x11 is enabled
+From 0d033c074b63ab0ef0798128b94b364ce33da93a Mon Sep 17 00:00:00 2001
+From: Ed Baker <edward.baker@intel.com>
+Date: Wed, 8 Jan 2020 13:43:38 -0700
+Subject: [PATCH] Ifdef va_x11 in VP sample for usrptr
 
-Signed-off-by: Lukas Rusak <lorusak@gmail.com>
+When updating libva-utils from 2.4.0 to 2.6.0 in Chrome OS I bumped into
+the following error:
+portage/media-video/libva-utils-2.6.0-r1/work/libva-utils-2.6.0/videoprocess/vppscaling_n_out_usrptr.cpp:41:10: fatal error:
+      'va/va_x11.h' file not found
+
+Signed-off-by: Edward Baker <edward.baker@intel.com>
 ---
- Makefile.am | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ videoprocess/vppscaling_n_out_usrptr.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
 
-diff --git a/Makefile.am b/Makefile.am
-index d28175a..12da79e 100644
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -24,10 +24,10 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
+diff --git a/videoprocess/vppscaling_n_out_usrptr.cpp b/videoprocess/vppscaling_n_out_usrptr.cpp
+index 4a3a222..a853442 100644
+--- a/videoprocess/vppscaling_n_out_usrptr.cpp
++++ b/videoprocess/vppscaling_n_out_usrptr.cpp
+@@ -38,7 +38,9 @@
+ #include <va/va.h>
+ #include <va/va_vpp.h>
+ #include "va_display.h"
++#if 0
+ #include <va/va_x11.h>
++#endif
  
- AUTOMAKE_OPTIONS = foreign
+ #define MAX_LEN   1024
  
--SUBDIRS = common decode encode vainfo videoprocess vendor/intel vendor/intel/sfcsample
-+SUBDIRS = common decode encode vainfo videoprocess vendor/intel
- 
- if USE_X11
--SUBDIRS += putsurface
-+SUBDIRS += putsurface vendor/intel/sfcsample
- else
- if USE_WAYLAND
- SUBDIRS += putsurface


### PR DESCRIPTION
This is just a simple hack to remove the videoprocess subdir (which requires x11). We don't need the utilities that it provides.
