### PR TITLE
gettext: build runtime and tools

### DIFF
--- a/packages/devel/gettext/package.mk
+++ b/packages/devel/gettext/package.mk
@@ -11,16 +11,12 @@ PKG_URL="http://ftp.gnu.org/pub/gnu/gettext/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_LONGDESC="A program internationalization library and tools."
 
-configure_package() {
-  PKG_CONFIGURE_SCRIPT="${PKG_BUILD}/gettext-tools/configure"
-
-  PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared \
-                           --disable-rpath \
-                           --with-gnu-ld \
-                           --disable-java \
-                           --disable-curses \
-                           --with-included-libxml \
-                           --disable-native-java \
-                           --disable-csharp \
-                           --without-emacs"
-}
+PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared \
+                         --disable-rpath \
+                         --with-gnu-ld \
+                         --disable-java \
+                         --disable-curses \
+                         --with-included-libxml \
+                         --disable-native-java \
+                         --disable-csharp \
+                         --without-emacs"

--- a/packages/tools/grub/package.mk
+++ b/packages/tools/grub/package.mk
@@ -8,7 +8,7 @@ PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://www.gnu.org/software/grub/index.html"
 PKG_URL="http://git.savannah.gnu.org/cgit/grub.git/snapshot/$PKG_NAME-$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain flex freetype:host gnulib:host"
+PKG_DEPENDS_TARGET="toolchain flex freetype:host gnulib:host gettext:host"
 PKG_LONGDESC="GRUB is a Multiboot boot loader."
 PKG_TOOLCHAIN="configure"
 


### PR DESCRIPTION
This PR makes `gettext:host` install both runtime and tools in order to install `gettext` binary, fixes building of `grub` package when `gettext` is missing on host.

`grub` package fails with the following error if `gettext` is missing on host.
```
$ scripts/build grub
UNPACK      grub
BUILD      grub (target)
    TOOLCHAIN      configure
./bootstrap: 470: ./bootstrap: gettext: not found
./bootstrap: Error: 'gettext' not found

./bootstrap: Please install the prerequisite programs
```

This PR will add extra build time, quick `time` test on my build host:

Only tools (before PR):
```
real    2m35.375s
user    6m1.630s
sys     1m22.207s
```

Both runtime and tools (after PR):
```
real    3m30.435s
user    6m58.925s
sys     1m45.584s
```