### PR TITLE
LibreELEC-settings: update to LibreELEC-settings-12ba57a

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="881a2d114412f4e6d80c39c0b17ae172a26316eb"
-PKG_SHA256="3ae041ea93fa5ae3129fae0cc4b3e9e3fd4270c2f46709d65b87fe2c0dad5dc0"
+PKG_VERSION="12ba57a61d0cf0384760cf0e1d9e21310ef75de1"
+PKG_SHA256="6a122edf32a4c7630e18c60e3190ac36b9d1d7018ba43524a20dca7f91a01cd4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
```
Andre Heider (5):
      Sync help text of the bluetooth toggle with the actual feature
      Improve BT wtf codeflow
      Only disconnect connected BT devices
      Use the BT standby feature for DPMS as well
      Add idle timeout feature for BT standby devices

Christian Hewitt (1):
      Merge pull request #144 from MilhouseVH/le10_wiz-no-vis

MilhouseVH (4):
      service.py: not every window may have a visible attribute
      oeWindows.py: add visible attribute to wizard window
      Merge pull request #145 from dhewg/pull/bt
      Merge pull request #146 from chewitt/updates

chewitt (1):
      improve update section titles
```