### PR TITLE
scripts/mkimage: only configure extlinux for valid uboot_helper dtb

### DIFF
--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -5,9 +5,6 @@
   # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
     BOOTLOADER="u-boot"
 
-  # u-boot version to use (default)
-    UBOOT_VERSION="default"
-
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)
     KERNEL_MAKE_EXTRACMD="dtbs"
 

--- a/projects/Amlogic/bootloader/mkimage
+++ b/projects/Amlogic/bootloader/mkimage
@@ -3,8 +3,6 @@
 
 . config/options ""
 
-DTB="$(${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb)"
-
 mkimage_uboot(){
   echo "image: writing u-boot to $(basename $DISK)"
   dd if="$INSTALL/usr/share/bootloader/u-boot.bin.sd.bin" of="$DISK" conv=fsync,notrunc bs=1 count=444 >"$SAVE_ERROR" 2>&1 || show_error

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -18,9 +18,6 @@
   # Bootloader to use (syslinux / u-boot)
     BOOTLOADER="syslinux"
 
-  # u-boot version to use (default)
-    UBOOT_VERSION="default"
-
   # Kernel target
     KERNEL_TARGET="bzImage"
 

--- a/projects/NXP/options
+++ b/projects/NXP/options
@@ -5,9 +5,6 @@
   # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
     BOOTLOADER="u-boot"
 
-  # u-boot version to use (default)
-    UBOOT_VERSION="default"
-
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)
     KERNEL_MAKE_EXTRACMD="dtbs"
 

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -40,9 +40,6 @@
   # Bootloader to use (bcm2835-bootloader)
     BOOTLOADER="bcm2835-bootloader"
 
-  # u-boot version to use (default)
-    UBOOT_VERSION="default"
-
   # Kernel target
     KERNEL_TARGET="zImage"
 

--- a/scripts/image
+++ b/scripts/image
@@ -14,7 +14,7 @@ unset _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL _DEBUG_DEPENDS_LIST _DEBUG_PACK
 if [ "${BOOTLOADER}" = "u-boot" -a -n "${DEVICE}" ]; then
   if [ -z "${UBOOT_SYSTEM}" ]; then
     ${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} >/dev/null
-  elif [ "${UBOOT_VERSION}" != "vendor" ]; then
+  else
     ${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb >/dev/null
   fi
 fi
@@ -50,7 +50,6 @@ function do_mkimage() {
     DISTRO_BOOTLABEL="${DISTRO_BOOTLABEL}" \
     DISTRO_DISKLABEL="${DISTRO_DISKLABEL}" \
     UBOOT_SYSTEM="${UBOOT_SYSTEM}" \
-    UBOOT_VERSION="${UBOOT_VERSION}" \
     EXTRA_CMDLINE="${EXTRA_CMDLINE}" \
     SYSTEM_SIZE="${SYSTEM_SIZE}" \
     SYSTEM_PART_START="${SYSTEM_PART_START}" \

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -216,8 +216,8 @@ elif [ "${BOOTLOADER}" = "u-boot" -a -n "${UBOOT_SYSTEM}" ]; then
   # create bootloader configuration
   echo "image: creating bootloader configuration..."
 
-  if [ "${UBOOT_SYSTEM}" != "box" ]; then
-    DTB="$(${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb)"
+  DTB="$(${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb)"
+  if [ -n "${DTB}" ]; then
 
     if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ]; then
       mcopy "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ::

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -133,7 +133,7 @@ devices = \
   'Amlogic': {
     'AMLGX': {
       'box': {
-        'dtb': 'meson-gxl-s905x-p212.dtb',
+        'dtb': '',
         'config': 'p212_defconfig'
       },
       'lepotato': {
@@ -151,7 +151,7 @@ devices = \
     },
     'AMLG12': {
       'box': {
-        'dtb': 'meson-g12a-x96max.dtb',
+        'dtb': '',
         'config': 'p212_defconfig'
       },
       'odroid-n2': {


### PR DESCRIPTION
This PR changes `scripts/mkimage` to install `extlinux.conf` for `UBOOT_SYSTEM=box`, fixes an issue reported in [forum for Rockchip RK3328 box image](https://forum.libreelec.tv/thread/21142-why-no-dtb-for-generic-rockchip-box-with-mainline-kernel/) where dtb and `extlinux.conf` is not added to the image. `UBOOT_VERSION` leftovers is also removed.

For Amlogic `box` variants the uboot_helper dtb is changed to an empty value, the resulting `box` images is still generated without `extlinux.conf`.

~The Amlogic `mkimage` script is changed to not re-generate a custom `extlinux.conf`, this change still needs to be runtime tested on devices.~