### PR TITLE
[le92] tz: update to 2019c

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2019a"
-PKG_SHA256="b8d449925e7883cbeb656fd660737cc5dcc7689f961b0b44c65d6644baf1a21a"
+PKG_VERSION="2019c"
+PKG_SHA256="38b1f7c7a050daa14fb07f6b72cdde1fc895fece40758d4d55736847041ad9e2"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
sync tz with master. This should fix the Brazil timezone issue reported here https://forum.libreelec.tv/thread/21161-wrong-time-on-some-brazilian-timezones-9-2-0/

Brazil DST cancellation was added in 2019b tz release https://github.com/eggert/tz/commit/8d1bcf9425ead6fd3447a658b20a8bb8a385228d