### PR TITLE
kernel-overlays: move volatile runtime data to /run

### DIFF
--- a/packages/sysutils/systemd/scripts/kernel-overlays-setup
+++ b/packages/sysutils/systemd/scripts/kernel-overlays-setup
@@ -6,8 +6,9 @@
 SYSTEM_OVERLAYS_DIR=/usr/lib/kernel-overlays
 OVERLAY_CONFIG_DIR=/storage/.cache/kernel-overlays
 KVER=$(uname -r)
-MODULES_DIR="/var/lib/modules/${KVER}"
-FIRMWARE_DIR="/var/lib/firmware"
+RUNTIME_DIR="/run/kernel-overlays"
+MODULES_DIR="${RUNTIME_DIR}/modules/${KVER}"
+FIRMWARE_DIR="${RUNTIME_DIR}/firmware"
 USER_FIRMWARE_DIR="/storage/.config/firmware"
 
 mkdir -p "${MODULES_DIR}"

--- a/packages/sysutils/systemd/system.d/kernel-overlays.service
+++ b/packages/sysutils/systemd/system.d/kernel-overlays.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Create kernel modules tree from overlays
 DefaultDependencies=no
-After=var.mount
 Before=systemd-udevd.service systemd-udev-trigger.service systemd-modules-load.service systemd-remount-fs.service swap.service machine-id.service kmod-static-nodes.service
 
 [Service]

--- a/scripts/image
+++ b/scripts/image
@@ -217,10 +217,10 @@ for MOD in $(find ${INSTALL}/usr/lib/kernel-overlays/ -type f -name *.ko); do
 done
 
 # Symlink overlayed modules to /usr/lib/modules
-ln -sT /var/lib/modules ${INSTALL}/usr/lib/modules
+ln -sT /run/kernel-overlays/modules ${INSTALL}/usr/lib/modules
 
 # Symlink overlayed firmware to /usr/lib/firmware
-ln -sT /var/lib/firmware ${INSTALL}/usr/lib/firmware
+ln -sT /run/kernel-overlays/firmware ${INSTALL}/usr/lib/firmware
 
 # Make target dir
 mkdir -p ${TARGET_IMG}


### PR DESCRIPTION
Create the module and firmware symlink trees in /run/kernel-overlays
instead of /var/lib as recommended by FHS 3.0. This also allows us
to drop the After=var.mount ordering in the systemd service.