### PR TITLE
init: drop support for loading modules in initramfs

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -23,9 +23,6 @@
 /usr/bin/busybox mount -t proc proc /proc
 /usr/bin/busybox mount -t sysfs sysfs /sys
 
-# set needed variables
-MODULE_DIR=/usr/lib/modules
-
 UPDATE_ROOT=/storage/.update
 UPDATE_DIR="$UPDATE_ROOT"
 
@@ -356,16 +353,6 @@ update_bootloader() {
       StopProgress "done"
     [ -n "${result}" ] && echo "${result}"
   fi
-}
-
-load_modules() {
-  progress "Loading kernel modules"
-
-  [ ! -f "/etc/modules" ] && return
-  for module in $(cat /etc/modules); do
-    progress "Loading kernel module $module"
-    insmod "$MODULE_DIR/$module.ko" || progress "... Failed to load kernel module $module, skipping"
-  done
 }
 
 set_consolefont() {
@@ -1092,7 +1079,6 @@ debug_msg "Unique identifier for this client: ${MACHINE_UID:-NOT AVAILABLE}"
 
 # main boot sequence
 for BOOT_STEP in \
-    load_modules \
     set_consolefont \
     check_disks \
     mount_flash \


### PR DESCRIPTION
Support for modules in initramfs was removed more than half a year
ago but I forgot to remove the now useless load_modules function in
init.