### PR TITLE
samba: update to samba-4.9.17

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.9.15"
-PKG_SHA256="377102b80b97941bf0d131b828cae8415190e5bdd2928c2e2c954e29f1904496"
+PKG_VERSION="4.9.17"
+PKG_SHA256="42467af2efab4793c7988561644a84de4000e96a87ce8239362c6d10abace295"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
https://www.samba.org/samba/history/samba-4.9.16.html
https://www.samba.org/samba/history/samba-4.9.17.html

Couple of (AD DC related) security fixes in 4.9.17.