### PR TITLE
scripts/clean: print build message with color

### DIFF
--- a/scripts/clean
+++ b/scripts/clean
@@ -28,7 +28,7 @@ clean_package() {
       # force clean if no stamp found (previous unpack failed)
       . "${i}/.libreelec-package"
       if [ "${INFO_PKG_NAME}" = "${1}" ]; then
-        build_msg "" "" "* Removing ${i} ..."
+        build_msg "CLR_WARNING" "*" "$(print_color "CLR_WARNING_DIM" "Removing ${i} ...")"
         rm -rf "${i}"
       fi
     fi


### PR DESCRIPTION
This PR changes to use the same color on the newly added `Removing ...` messages as is used the `Removing ...` messages a few lines above.