### PR TITLE
glibc: ensure it uses our $TOOLCHAIN/bin/python3

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/libc/"
 PKG_URL="http://ftp.gnu.org/pub/gnu/glibc/$PKG_NAME-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap pigz:host"
+PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap pigz:host Python3:host"
 PKG_DEPENDS_INIT="glibc"
 PKG_LONGDESC="The Glibc package contains the main C library."
 PKG_BUILD_FLAGS="-gold"
@@ -44,6 +44,10 @@ if build_with_debug; then
 else
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --disable-debug"
 fi
+
+post_unpack() {
+  find "${PKG_BUILD}" -type f -name '*.py' -exec sed -e '1s,^#![[:space:]]*/usr/bin/python.*,#!/usr/bin/env python3,' -i {} \;
+}
 
 pre_build_target() {
   cd $PKG_BUILD


### PR DESCRIPTION
Some users when building `glibc:target` have seen the following errors:

```
make[2]: Entering directory '/letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/locale'
.././scripts/mkinstalldirs /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale
.././scripts/mkinstalldirs /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale
mkdir -p -- /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale
mkdir -p -- /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale
python3 -B gen-translit.py < C-translit.h.in > /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/C-translit.h.tmp
echo '' > /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/stamp.oST
mv -f /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/stamp.oST /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/stamp.oS
Could not find platform independent libraries <prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Fatal Python error: initfsencoding: unable to load the file system codec
ModuleNotFoundError: No module named 'encodings'

Current thread 0x00007f50a89a0700 (most recent call first):
Aborted
make[2]: *** [Makefile:85: /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/C-translit.h] Error 134
make[2]: Leaving directory '/letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/locale'
make[1]: *** [Makefile:259: locale/subdir_lib] Error 2
make[1]: Leaving directory '/letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30'
make: *** [Makefile:9: all] Error 2
```

and

```
make  subdir=locale -C locale ..=../ subdir_lib
make[2]: Entering directory '/letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/locale'
.././scripts/mkinstalldirs /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale
.././scripts/mkinstalldirs /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale
mkdir -p -- /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale
mkdir -p -- /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale
python3 -B gen-translit.py < C-translit.h.in > /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/C-translit.h.tmp
echo '' > /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/stamp.oST
mv -f /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/stamp.oST /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/stamp.oS
Fatal Python error: initfsencoding: unable to load the file system codec
LookupError: no codec search functions registered: can't find encoding

Current thread 0x00007f3e4ee77700 (most recent call first):
Aborted
make[2]: *** [Makefile:85: /letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/.x86_64-libreelec-linux-gnu/locale/C-translit.h] Error 134
make[2]: Leaving directory '/letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30/locale'
make[1]: *** [Makefile:259: locale/subdir_lib] Error 2
make[1]: Leaving directory '/letv/10/master/build.LibreELEC-Generic.x86_64-9.80-devel/build/glibc-2.30'
make: *** [Makefile:9: all] Error 2
```

`glibc` includes several Python scripts that hard code either `#!/usr/bin/python3` or `#!/usr/bin/python` in which case `glibc` is not using our $TOOLCHAIN Python3, and as there's no dependency there's no reason for it to do so.

The suspicion is that if our Python3:host binary has already been built, it's possible the system may become a little confused when executing `/usr/bin/python[3]` but finding libraries and modules for a different python3 version in $TOOLCHAIN (maybe, this is the best guess so far).

To avoid that, we should add the `Python3:host` dependency when building `glibc:target`, and ensure that `glibc` only uses our $TOOLCHAIN/bin/python3.

Creating as draft, for further testing.