### PR TITLE
e2fsprogs: disable automagic udev/systemd/crond detection

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -20,6 +20,9 @@ fi
 
 PKG_CONFIGURE_OPTS_HOST="--prefix=$TOOLCHAIN/ \
                          --bindir=$TOOLCHAIN/bin \
+                         --with-udev-rules-dir=no \
+                         --with-crond-dir=no \
+                         --with-systemd-unit-dir=no \
                          --sbindir=$TOOLCHAIN/sbin \
                          --enable-verbose-makecmds \
                          --disable-symlink-install \
@@ -41,6 +44,9 @@ PKG_CONFIGURE_OPTS_HOST="--prefix=$TOOLCHAIN/ \
 
 pre_configure() {
   PKG_CONFIGURE_OPTS_INIT="BUILD_CC=$HOST_CC \
+                           --with-udev-rules-dir=no \
+                           --with-crond-dir=no \
+                           --with-systemd-unit-dir=no \
                            --enable-verbose-makecmds \
                            --enable-symlink-install \
                            --enable-symlink-build \

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -35,7 +35,6 @@ PKG_CONFIGURE_OPTS_HOST="--prefix=$TOOLCHAIN/ \
                          --disable-fsck \
                          --disable-e2initrd-helper \
                          --enable-tls \
-                         --disable-uuid \
                          --disable-uuidd \
                          --disable-nls \
                          --disable-rpath \


### PR DESCRIPTION
`udev`, `systemd` and `crond` are being enabled automagically, installing `e2scrub` rules, services and cron scripts when detected. We don't need `e2scrub`, so explicitly disable all 3 dependencies to ensure predictable build behaviour.