### PR TITLE
game.libretro.scummvm: fix linker issue

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -15,3 +15,7 @@ PKG_LONGDESC="game.libretro.scummvm: scummvm for Kodi"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.gameclient"
+
+pre_configure_target() {
+  export LDFLAGS=`echo $LDFLAGS | sed -e "s|-Wl,--as-needed||"`
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.scummvm"
 PKG_VERSION="2.0.0.6-Leia"
 PKG_SHA256="f71f7ba56ca4c7717afdd0626b0ce1d9da3ae199a32eceb22837f8658c7d4698"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.scummvm"


### PR DESCRIPTION
Using "-Wl,--as-needed" with ld causes undefined symbols.

This should fix the issue that was reported here:
https://forum.libreelec.tv/core/ticketsystem/ticket/67-scummvm-linker-error/

There was an earlier pull request that was supposed to fix it, but it didn't, see #3479

I am actually not able to test this fix myself, and as far as I understand comments from @vpeter4 it is only reproducible on the automatic build system. So if someone could trigger a build from this branch and make the resulting binary available, I could check if this change actually fixes it.

Also I guess that I would also have to increase PKG_REV, is that right?