### PR TITLE
add support for setting wireless regulatory domain

### DIFF
--- a/packages/addons/tools/network-tools/changelog.txt
+++ b/packages/addons/tools/network-tools/changelog.txt
@@ -1,3 +1,6 @@
+104
+- drop iw
+
 103
 - added rar2fs
 - updated iperf to 3.6

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of network tools and programs"
-PKG_LONGDESC="This bundle currently includes bwm-ng, iftop, iperf, irssi, iw, lftp, ncftp, ngrep, nmap, rar2fs, rsync, sshfs, tcpdump, udpxy and wireless_tools."
+PKG_LONGDESC="This bundle currently includes bwm-ng, iftop, iperf, irssi, lftp, ncftp, ngrep, nmap, rar2fs, rsync, sshfs, tcpdump, udpxy and wireless_tools."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Network Tools"
@@ -22,7 +22,6 @@ PKG_DEPENDS_TARGET="toolchain \
                     iftop \
                     iperf \
                     irssi \
-                    iw \
                     lftp \
                     ncftp \
                     ngrep \
@@ -48,9 +47,6 @@ addon() {
 
     # irssi
     cp -P $(get_build_dir irssi)/.$TARGET_NAME/src/fe-text/irssi $ADDON_BUILD/$PKG_ADDON_ID/bin
-
-    # iw
-    cp -P $(get_build_dir iw)/iw $ADDON_BUILD/$PKG_ADDON_ID/bin
 
     # lftp
     cp -P $(get_build_dir lftp)/.$TARGET_NAME/src/lftp $ADDON_BUILD/$PKG_ADDON_ID/bin

--- a/packages/network/iw/package.mk
+++ b/packages/network/iw/package.mk
@@ -14,3 +14,8 @@ PKG_LONGDESC="A new nl80211 based CLI configuration utility for wireless devices
 pre_configure_target() {
   export LDFLAGS="$LDFLAGS -pthread"
 }
+
+post_makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/iw
+    cp $PKG_DIR/scripts/setregdomain $INSTALL/usr/lib/iw
+}

--- a/packages/network/iw/package.mk
+++ b/packages/network/iw/package.mk
@@ -14,7 +14,3 @@ PKG_LONGDESC="A new nl80211 based CLI configuration utility for wireless devices
 pre_configure_target() {
   export LDFLAGS="$LDFLAGS -pthread"
 }
-
-makeinstall_target() {
-  : # meh
-}

--- a/packages/network/iw/scripts/setregdomain
+++ b/packages/network/iw/scripts/setregdomain
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+REGDOMAIN=
+REGDOMAIN_CONF="/storage/.cache/regdomain.conf"
+[ -r "$REGDOMAIN_CONF" ] && . "$REGDOMAIN_CONF"
+[ -z "$REGDOMAIN" ] && exit 0
+
+exec /usr/sbin/iw reg set "$REGDOMAIN"

--- a/packages/network/iw/udev.d/60-iw-regdomain.rules
+++ b/packages/network/iw/udev.d/60-iw-regdomain.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="ieee80211", ACTION=="add", RUN+="/usr/lib/iw/setregdomain"

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="network"
 PKG_VERSION=""
 PKG_LICENSE="various"
-PKG_SITE="http://www.openelec.tv"
+PKG_SITE="https://libreelec.tv"
 PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain connman netbase ethtool openssh iw"
 PKG_SECTION="virtual"

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -6,7 +6,7 @@ PKG_VERSION=""
 PKG_LICENSE="various"
 PKG_SITE="http://www.openelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain connman netbase ethtool openssh"
+PKG_DEPENDS_TARGET="toolchain connman netbase ethtool openssh iw"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Metapackage for various packages to install network support"
 


### PR DESCRIPTION
Include iw in image builds (this adds a 200k binary) and add support for configuring the regulatory domain (country) like on other linux distributions.

The regulatory domain is read from .cache/regdomain.conf (which should probably be managed by the LE settings addon), that file should set REGDOMAIN to a valid ISO country code. eg
```
LibreELEC:~ # cat .cache/regdomain.conf 
REGDOMAIN="AT"
```