### PR TITLE
vim: work around broken make dependencies

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -40,6 +40,10 @@ make_target() {
   :
 }
 
+pre_makeinstall_target() {
+  mkdir -p $INSTALL/usr/bin
+}
+
 post_makeinstall_target() {
   (
   cd $INSTALL/storage/.kodi/addons/virtual.system-tools/data/vim


### PR DESCRIPTION
Work around missing install directory error:

cp vimtutor build.LibreELEC-RPi.arm-9.80-devel/install_pkg/vim-8.2.0023/usr/bin/vimtutor
cp: cannot create regular file
'build.LibreELEC-RPi.arm-9.80-devel/install_pkg/vim-8.2.0023/usr/bin/vimtutor': No such file or directory
make[1]: *** [Makefile:2468: installtutorbin] Error 1