### PR TITLE
samba: update to samba-4.9.18

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.9.17"
-PKG_SHA256="42467af2efab4793c7988561644a84de4000e96a87ce8239362c6d10abace295"
+PKG_VERSION="4.9.18"
+PKG_SHA256="c6d23982b7233ce8bc0c87b8b03585d782ddf3bd7c634c1ffa853d7d397d87f7"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
https://www.samba.org/samba/history/samba-4.9.18.html

Various security fixes.