### PR TITLE
scripts/pkgbuilder.py: bookend combined log with searchable tags

### DIFF
--- a/config/multithread
+++ b/config/multithread
@@ -35,6 +35,7 @@ start_multithread_build() {
   else
     buildopts+=" --colors=${MTCOLORS:-auto}"
   fi
+  [ "${MTBOOKENDS}" = "no" ] && buildopts+=" --without-bookends" || buildopts+=" --with-bookends"
 
   buildopts+=" --stats-interval ${MTINTERVAL:-60}"
 


### PR DESCRIPTION
Small change to improve searching within a combined log.

Now, the start of an individual package log in the combined log will be prefixed with:
```
<<< intel-ucode:host seq 4 <<<
```
and postfixed with:
```
>>> intel-ucode:host seq 4 >>>
```

so if you want to find the start of `intel-ucode:host`, search for `>>> intel-ucode:host`.

If you need to find the end of seq 4 (because it's been referenced as the root failure of another package) then search for `seq 4 <<<`.