### PR TITLE
dosfstools/e2fsprogs: bump and fix [backport]

### DIFF
--- a/packages/sysutils/busybox/config/busybox-target.conf
+++ b/packages/sysutils/busybox/config/busybox-target.conf
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.31.0
-# Wed Jun 12 00:53:01 2019
+# Mon Sep 23 04:46:37 2019
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -645,7 +645,7 @@ CONFIG_IONICE=y
 # CONFIG_FEATURE_MINIX2 is not set
 # CONFIG_MKFS_REISER is not set
 # CONFIG_MKDOSFS is not set
-CONFIG_MKFS_VFAT=y
+# CONFIG_MKFS_VFAT is not set
 CONFIG_MKSWAP=y
 CONFIG_FEATURE_MKSWAP_UUID=y
 CONFIG_MORE=y

--- a/packages/sysutils/dosfstools/package.mk
+++ b/packages/sysutils/dosfstools/package.mk
@@ -21,16 +21,6 @@ make_init() {
   : # reuse make_target()
 }
 
-pre_build_host() {
-  mkdir -p $PKG_BUILD/.$HOST_NAME
-  cp -RP $PKG_BUILD/* $PKG_BUILD/.$HOST_NAME
-}
-
-make_host() {
-  cd $PKG_BUILD/.$HOST_NAME
-  make PREFIX=/usr
-}
-
 makeinstall_init() {
   mkdir -p $INSTALL/usr/sbin
     cp ../.install_pkg/usr/sbin/fsck.fat $INSTALL/usr/sbin

--- a/packages/sysutils/dosfstools/package.mk
+++ b/packages/sysutils/dosfstools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dosfstools"
-PKG_VERSION="3.0.28"
-PKG_SHA256="ee95913044ecf2719b63ea11212917649709a6e53209a72d622135aaa8517ee2"
+PKG_VERSION="4.1"
+PKG_SHA256="e6b2aca70ccc3fe3687365009dd94a2e18e82b688ed4e260e04b7412471cc173"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/dosfstools/dosfstools"
 PKG_URL="https://github.com/dosfstools/dosfstools/releases/download/v$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.xz"
@@ -13,6 +13,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_INIT="toolchain dosfstools"
 PKG_LONGDESC="dosfstools contains utilities for making and checking MS-DOS FAT filesystems."
 
+PKG_CONFIGURE_OPTS_TARGET="--enable-compat-symlinks"
 PKG_MAKE_OPTS_TARGET="PREFIX=/usr"
 PKG_MAKEINSTALL_OPTS_TARGET="PREFIX=/usr"
 
@@ -32,16 +33,16 @@ make_host() {
 
 makeinstall_init() {
   mkdir -p $INSTALL/usr/sbin
-    cp fsck.fat $INSTALL/usr/sbin
+    cp ../.install_pkg/usr/sbin/fsck.fat $INSTALL/usr/sbin
     ln -sf fsck.fat $INSTALL/usr/sbin/fsck.msdos
     ln -sf fsck.fat $INSTALL/usr/sbin/fsck.vfat
 }
 
 makeinstall_host() {
   mkdir -p $TOOLCHAIN/sbin
-    cp mkfs.fat $TOOLCHAIN/sbin
+    cp src/mkfs.fat $TOOLCHAIN/sbin
     ln -sf mkfs.fat $TOOLCHAIN/sbin/mkfs.vfat
-    cp fsck.fat $TOOLCHAIN/sbin
+    cp src/fsck.fat $TOOLCHAIN/sbin
     ln -sf fsck.fat $TOOLCHAIN/sbin/fsck.vfat
-    cp fatlabel $TOOLCHAIN/sbin
+    cp src/fatlabel $TOOLCHAIN/sbin
 }

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="e2fsprogs"
-PKG_VERSION="1.45.2"
-PKG_SHA256="4952c9ae91e36d762e13cc5b9e8f7eeb5453e4aee4cd9b7402e73f2d4e65e009"
+PKG_VERSION="1.45.3"
+PKG_SHA256="90d10066b815e27b0b4875f0d5e396c663e0bf55aa3ca10868978d10c6ffe595"
 PKG_LICENSE="GPL"
 PKG_SITE="http://e2fsprogs.sourceforge.net/"
 PKG_URL="https://www.kernel.org/pub/linux/kernel/people/tytso/$PKG_NAME/v$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.xz"

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -20,6 +20,9 @@ fi
 
 PKG_CONFIGURE_OPTS_HOST="--prefix=$TOOLCHAIN/ \
                          --bindir=$TOOLCHAIN/bin \
+                         --with-udev-rules-dir=no \
+                         --with-crond-dir=no \
+                         --with-systemd-unit-dir=no \
                          --sbindir=$TOOLCHAIN/sbin \
                          --enable-verbose-makecmds \
                          --disable-symlink-install \
@@ -41,6 +44,9 @@ PKG_CONFIGURE_OPTS_HOST="--prefix=$TOOLCHAIN/ \
 
 pre_configure() {
   PKG_CONFIGURE_OPTS_INIT="BUILD_CC=$HOST_CC \
+                           --with-udev-rules-dir=no \
+                           --with-crond-dir=no \
+                           --with-systemd-unit-dir=no \
                            --enable-verbose-makecmds \
                            --enable-symlink-install \
                            --enable-symlink-build \

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -35,7 +35,6 @@ PKG_CONFIGURE_OPTS_HOST="--prefix=$TOOLCHAIN/ \
                          --disable-fsck \
                          --disable-e2initrd-helper \
                          --enable-tls \
-                         --disable-uuid \
                          --disable-uuidd \
                          --disable-nls \
                          --disable-rpath \


### PR DESCRIPTION
Backport of #3858 and #4120 

* bumps `dosfstools` and `e2fsprogs` to the latest version used by `master`
* removes the hacky workaround when building `dos2fstools` v4
* remove the automagic randomness of `e2fsprogs` when detecting `udev`/`systemd`/`crond`
* always uses the full-fat `mkfs.vfat` from `dosfstools` (as we sometimes could end up using the more limited `busybox` version, depending on build order)