### PR TITLE
config/graphic: allow using the new intel gallium iris driver

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -23,7 +23,7 @@ get_graphicdrivers() {
   V4L2_SUPPORT="no"
 
   if [ "${GRAPHIC_DRIVERS}" = "all" ]; then
-    GRAPHIC_DRIVERS="i915 i965 r200 r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
+    GRAPHIC_DRIVERS="iris i915 i965 r200 r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
@@ -49,6 +49,13 @@ get_graphicdrivers() {
 
   if listcontains "${GRAPHIC_DRIVERS}" "i965"; then
     DRI_DRIVERS+=" i965"
+    XORG_DRIVERS+=" intel"
+    COMPOSITE_SUPPORT="yes"
+    VAAPI_SUPPORT="yes"
+  fi
+
+  if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
+    GALLIUM_DRIVERS+=" iris"
     XORG_DRIVERS+=" intel"
     COMPOSITE_SUPPORT="yes"
     VAAPI_SUPPORT="yes"

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -135,7 +135,7 @@
 # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
 # Space separated list is supported,
 # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
-  GRAPHIC_DRIVERS="r300 r600 radeonsi i915 i965 nvidia nvidia-legacy vmware virtio"
+  GRAPHIC_DRIVERS="r300 r600 radeonsi iris i915 i965 nvidia nvidia-legacy vmware virtio"
 
 # build and install remote support (yes / no)
   REMOTE_SUPPORT="yes"

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -27,7 +27,7 @@ PKG_MESON_OPTS_TARGET="-Dlibkms=false \
                        -Dinstall-test-programs=false \
                        -Dudev=false"
 
-listcontains "${GRAPHIC_DRIVERS}" "(i915|i965)" &&
+listcontains "${GRAPHIC_DRIVERS}" "(iris|i915|i965)" &&
   PKG_MESON_OPTS_TARGET+=" -Dintel=true" || PKG_MESON_OPTS_TARGET+=" -Dintel=false"
 
 listcontains "${GRAPHIC_DRIVERS}" "(r200|r300|r600|radeonsi)" &&

--- a/packages/virtual/mediacenter/package.mk
+++ b/packages/virtual/mediacenter/package.mk
@@ -39,7 +39,7 @@ if [ "$MEDIACENTER" = "kodi" ]; then
   fi
 
   get_graphicdrivers
-  if listcontains "$GRAPHIC_DRIVERS" "(i915|i965)"; then
+  if listcontains "$GRAPHIC_DRIVERS" "(iris|i915|i965)"; then
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET intel-vaapi-driver"
   fi
 


### PR DESCRIPTION
This driver will become the default in mesa 20, let's enable it now to do some pre-testing.

To test you need to use the env variable `MESA_LOADER_DRIVER_OVERRIDE=iris`. This won't be needed with mesa 20.