### PR TITLE
mesa-demos: doesn't install anything, fix that

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/mesa-demos/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mesa-demos/package.mk
@@ -15,5 +15,8 @@ PKG_TOOLCHAIN="autotools"
 PKG_CONFIGURE_OPTS_TARGET="--without-glut"
 
 makeinstall_target() {
-  : # nop
+  mkdir -p $INSTALL/usr/bin
+    cp -P src/xdemos/glxdemo $INSTALL/usr/bin
+    cp -P src/xdemos/glxgears $INSTALL/usr/bin
+    cp -P src/xdemos/glxinfo $INSTALL/usr/bin
 }


### PR DESCRIPTION
#3749 removed `mesa-demos` as an add-on dependency, but when building `mesa-demos` via `ADDITIONAL_PACKAGES` nothing is being installed as we were still nopping out the install.