### PR TITLE
init: remove file before overwriting

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -313,6 +313,7 @@ update_file() {
   if [ -f "$UPDATE_DIR/$2" -a -f "$3" ]; then
     mount -o remount,rw /flash
 
+    rm -f "$3"
     StartProgress percent "Updating $1... " "$3" $(stat -t "$UPDATE_DIR/$2" | awk '{print $2}')
       # use dd here with conv=fsync so that all writes are non-buffered
       # ensuring accurate progress - take the sync hit during the


### PR DESCRIPTION
When updating kernel.img and SYSTEM, we momentarily read the size of the existing file which means the percentage progress very briefly reads 100% and then starts incrementing from 0% as the file is overwritten by the new content.

Resolve this by removing the existing file before starting the progress meter thread.