### PR TITLE
scripts/pkgbuilder.py: avoid returning negative timeout which is fatal

### DIFF
--- a/scripts/pkgbuilder.py
+++ b/scripts/pkgbuilder.py
@@ -450,7 +450,7 @@ class Builder:
                   self.generator.activeJobCount(), ",".join(self.generator.activeJobNames())), \
                   file=self.loadstatsfile, flush=True)
 
-        return (self.nextstats - time.time())
+        return (self.nextstats - now)
 
     # Output progress info, and links to any relevant logs
     def displayJobStatus(self, job):


### PR DESCRIPTION
Would be nice to get this in sooner than later, although I've only hit this once (just now). Rather obvious now that I look at the code... :blush: