### PR TITLE
[busybox] getedid fixes

### DIFF
--- a/packages/sysutils/busybox/scripts/getedid
+++ b/packages/sysutils/busybox/scripts/getedid
@@ -142,6 +142,9 @@ create_edid() {
   # create edid 
   mkdir -p /tmp/cpio/lib/firmware/edid
   cat "/sys/class/drm/$card/edid" > /tmp/cpio/lib/firmware/edid/edid.bin
+  mkdir -p /storage/.config/firmware/edid
+  cp /tmp/cpio/lib/firmware/edid/edid.bin /storage/.config/firmware/edid
+
 
   # create cpio archive
   cd /tmp/cpio/
@@ -182,12 +185,8 @@ intel_amd() {
   #check kernel version
   check_kernel
 
-  # add boot parameters to $file in relation to the used kernel
-  if [ "$kernel" -lt "415000" ]; then
-    sed -i "/ APPEND/s/$/ initrd=\/edid.cpio drm_kms_helper.edid_firmware=$hdmi:edid\/edid.bin video=$hdmi:D/" "$file"
-  else
-    sed -i "/ APPEND/s/$/ initrd=\/edid.cpio drm.edid_firmware=edid\/edid.bin video=$hdmi:D/" "$file"
-  fi
+  # add boot parameters to $file
+  sed -i "/ APPEND/s/$/ initrd=\/edid.cpio drm.edid_firmware=edid\/edid.bin video=$hdmi:D/" "$file"
 
   # reboot
   sys_reboot


### PR DESCRIPTION
As discussed here: https://forum.kodi.tv/showthread.php?tid=343069&pid=2919267#pid2919267

we might need a copy of the edid.bin locally 

So, here it is ;)

Dropped the kernel check and the different modification for  syslinux/extlinux for intel as well, as we don't need that anymore. Not sure if we still need to check if `syslinux` or `extlinux` is in use. If that's not needed anymore as well, we might also consider dropping that check too