### PR TITLE
convert libva related packages to use meson

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -8,18 +8,18 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"
 PKG_URL="https://github.com/intel/libva-utils/archive/$PKG_VERSION.tar.gz"
 PKG_LONGDESC="Libva-utils is a collection of tests for VA-API (VIdeo Acceleration API)"
-PKG_TOOLCHAIN="autotools"
+PKG_TOOLCHAIN="meson"
 
 if [ "$DISPLAYSERVER" = "x11" ]; then
   PKG_DEPENDS_TARGET="toolchain libva libdrm libX11"
-  DISPLAYSERVER_LIBVA="--enable-x11"
+  DISPLAYSERVER_LIBVA="-Dx11=true"
 else
   PKG_DEPENDS_TARGET="toolchain libva libdrm"
-  DISPLAYSERVER_LIBVA="--disable-x11"
+  DISPLAYSERVER_LIBVA="-Dx11=false"
 fi
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-silent-rules \
-                           --enable-drm \
-                           $DISPLAYSERVER_LIBVA \
-                           --disable-wayland \
-                           --disable-tests"
+PKG_MESON_OPTS_TARGET="-Ddrm=true \
+                       $DISPLAYSERVER_LIBVA \
+                       -Dwayland=false \
+                       -Dtests=false"
+

--- a/packages/multimedia/intel-vaapi-driver/package.mk
+++ b/packages/multimedia/intel-vaapi-driver/package.mk
@@ -11,15 +11,17 @@ PKG_SITE="https://01.org/linuxmedia"
 PKG_URL="https://github.com/intel/intel-vaapi-driver/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libva libdrm"
 PKG_LONGDESC="intel-vaapi-driver: VA-API user mode driver for Intel GEN Graphics family"
-PKG_TOOLCHAIN="autotools"
+PKG_TOOLCHAIN="meson"
 
 if [ "$DISPLAYSERVER" = "x11" ]; then
-  DISPLAYSERVER_LIBVA="--enable-x11 --disable-wayland"
+  DISPLAYSERVER_LIBVA="-Dwith_x11=yes -Dwith_wayland=no"
 elif [ "$DISPLAYSERVER" = "weston" ]; then
-  DISPLAYSERVER_LIBVA="--disable-x11 --enable-wayland"
+  DISPLAYSERVER_LIBVA="-Dwith_x11=no -Dwith_wayland=yes"
 else
-  DISPLAYSERVER_LIBVA="--disable-x11 --disable-wayland"
+  DISPLAYSERVER_LIBVA="-Dwith_x11=no -Dwith_wayland=no"
 fi
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-silent-rules \
-                           $DISPLAYSERVER_LIBVA"
+PKG_MESON_OPTS_TARGET="-Denable_hybrid_code=false \
+                       -Denable_tests=false \
+                       $DISPLAYSERVER_LIBVA"
+

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -10,20 +10,20 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"
 PKG_URL="https://github.com/intel/libva/archive/$PKG_VERSION.tar.gz"
 PKG_LONGDESC="Libva is an implementation for VA-API (VIdeo Acceleration API)."
-PKG_TOOLCHAIN="autotools"
+PKG_TOOLCHAIN="meson"
 
 if [ "$DISPLAYSERVER" = "x11" ]; then
   PKG_DEPENDS_TARGET="toolchain libX11 libXext libXfixes libdrm"
-  DISPLAYSERVER_LIBVA="--enable-x11 --disable-glx --disable-wayland"
+  DISPLAYSERVER_LIBVA="-Dwith_x11=yes -Dwith_glx=no -Dwith_wayland=no"
 elif [ "$DISPLAYSERVER" = "weston" ]; then
-  DISPLAYSERVER_LIBVA="--disable-x11 --disable-glx --enable-wayland"
+  DISPLAYSERVER_LIBVA="-Dwith_x11=no -Dwith_glx=no -Dwith_wayland=yes"
   PKG_DEPENDS_TARGET="toolchain libdrm wayland"
 else
   PKG_DEPENDS_TARGET="toolchain libdrm"
-  DISPLAYSERVER_LIBVA="--disable-x11 --disable-glx --disable-wayland"
+  DISPLAYSERVER_LIBVA="-Dwith_x11=no -Dwith_glx=no -Dwith_wayland=no"
 fi
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-silent-rules \
-                           --disable-docs \
-                           --enable-drm \
-                           $DISPLAYSERVER_LIBVA"
+PKG_MESON_OPTS_TARGET="-Ddisable_drm=false \
+                       -Denable_docs=false \
+                       -Denable_va_messaging=true \
+                       $DISPLAYSERVER_LIBVA"


### PR DESCRIPTION
self explanatory.

libva-utils loses a couple utilities but nothing we care about.