### PR TITLE
samba: stop mangling username and password

### DIFF
--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2017 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 SMB_CONF="/run/samba/smb.conf"
 SMB_TMP="$(mktemp -p /run/samba)"
@@ -52,17 +53,13 @@ ADD_CONFIG="${ADD_CONFIG}  server max protocol = ${SAMBA_MAXPROTOCOL/SMB1/NT1}\n
 # Add extra config after [global], escaping spaces so that all are retained by sed
 sed -e "/\[global\]/ a ${ADD_CONFIG// /\\ }" -i $SMB_TMP
 
-# only letters & numbers permitted for username & password
-  SAMBA_USERNAME=`echo $SAMBA_USERNAME | sed "s/[^a-zA-Z0-9]//g;"`
-  SAMBA_PASSWORD=`echo $SAMBA_PASSWORD | sed "s/[^a-zA-Z0-9]//g;"`
-
 if [ "$SAMBA_SECURE" == "true" -a ! "$SAMBA_USERNAME" == "" -a ! "$SAMBA_PASSWORD" == "" ] ; then
   # username map: first line makes sure plain root does not work all the time
   # processing continues, so if user chooses root as username, second line overrides the first
   # this is done always in case user uses passwords in userconf.
   # many thanks to viljoviitanen for this
-  echo -e "$SAMBA_PASSWORD\n$SAMBA_PASSWORD" | smbpasswd -s -a root >/dev/null 2>&1
-  echo -e "nobody = root\nroot = $SAMBA_USERNAME" > /run/samba/samba.map
+  printf "%s\n%s" "$SAMBA_PASSWORD" "$SAMBA_PASSWORD" | smbpasswd -s -a root >/dev/null 2>&1
+  printf "nobody = root\nroot = %s" "$SAMBA_USERNAME" > /run/samba/samba.map
 
   sed -e 's|^.[ \t]*.public.=.*|  public = no |' \
       -e 's|^.[ \t]*.username map.=.*||' \


### PR DESCRIPTION
Issue reported on the [forum](https://forum.kodi.tv/showthread.php?tid=343069&pid=2919489#pid2919489)

When setting the Samba username and password we're stripping out all non-alphanumeric characters which means we are potentially setting a username and password that is different to the username and/or password entered by the user. Worse still, we don't inform the user that this happened, so the configured and set (via `smbpasswd`) username/passwords don't match, and confusion reigns.

I'm not aware of any limitations relating to Samba usernames or passwords, so it's not at all obvious why we are doing this as the [original commit](https://github.com/OpenELEC/OpenELEC.tv/commit/9a0d1404d7f2df6cff074cf433c728fa2bb4b479) does not make this clear (but does suggest in the associated [PR308](https://github.com/OpenELEC/OpenELEC.tv/pull/308) that it could be changed in future).

Some reasons why we might be doing this:
* some old or broken Samba clients may only allow certain values - but if that's the case, it's not a server problem
* different operating systems may have various username/password limitations, but OS interop is not our concern
* the method used to set the username appears to be trivially exploitable

This PR removes the username and password name mangling, and sets the username and password in a way that is hopefully less likely to be exploited.

After the addition of this PR, any users that have configured a username or password with previously excluded characters may find their old mangled username/password is no longer working - with this PR they'll need to connect using the configured username and password. Radical!

The way we set the password still isn't ideal - should `smbpasswd` fail then we have no way of notifying the user that the password has not been accepted. We should somehow pre-validate the password in the Settings add-on, perhaps by adding/removing a dummy samba account - but that's a fix for another PR...