### PR TITLE
update_retroplayer-addons: stop defaulting to retroplayer branch

### DIFF
--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -8,7 +8,7 @@ FORCE_LIBRETRO_BUMP=""
 KEEP_GIT_DIRS="yes"
 
 usage() {
-  echo "Usage: $0 [options] [<branch>]"
+  echo "Usage: $0 [options] <kodi-branch>"
   echo " -b, --bump-pkg-rev: bump PKG_REV if package was not updated"
   echo " -d, --delete-git-dirs: delete cloned git dirs after update"
   echo " -f, --force-libretro-bump: check for new libretro package"
@@ -46,16 +46,11 @@ while [ $# -ne 0 ]; do
 done
 
 
-if [ $# -gt 1 ]; then
+if [ $# -ne 1 ]; then
   usage
   exit 1
 fi
-if [ $# -eq 0 ]; then
-  KODI_BRANCH="retroplayer"
-  echo "using default branch ${KODI_BRANCH}"
-else
-  KODI_BRANCH="$1"
-fi
+KODI_BRANCH="$1"
 
 # list of packages to exclude from update
 EXCLUDED_PACKAGES="game.libretro.chailove


### PR DESCRIPTION
The kodi-game binary addon repo now contains Leia and Matrix,
like the kodi binary addon repo, so make the branch name a
mandatory option.