### PR TITLE
config/otpions: export PROJECT and ARCH defaults

### DIFF
--- a/config/options
+++ b/config/options
@@ -24,10 +24,10 @@ PROJECT_DIR="${ROOT}/projects"
 DISTRO="${DISTRO:-LibreELEC}"
 
 # determines PROJECT, if not forced by user
-PROJECT="${PROJECT:-Generic}"
+export PROJECT="${PROJECT:-Generic}"
 
 # determines TARGET_ARCH, if not forced by user
-ARCH="${ARCH:-x86_64}"
+export ARCH="${ARCH:-x86_64}"
 TARGET_ARCH="${ARCH}"
 
 # include helper functions


### PR DESCRIPTION
Although `PROJECT` and `ARCH` have sane defaults when not passed on the command line, these 2 variables are not being (re-)exported so some packages (eg. `libretro-mame2010`) fail since `make` doesn't know the arch it's building for.

So, the following fails:
```
scripts/create_addon game.libretro.mame2010
```
with the following error:
```
src/emu/validity.c: At global scope:
src/emu/validity.c:35:57: warning: narrowing conversion of '-3' from 'int' to 'long unsigned int' is ill-formed in C++11 [-Wnarrowing]
   35 | UINT8 your_ptr64_flag_is_wrong[(int)(5 - sizeof(void *))];
      |                                                         ^
src/emu/validity.c:35:32: error: size '-3' of array 'your_ptr64_flag_is_wrong' is negative
   35 | UINT8 your_ptr64_flag_is_wrong[(int)(5 - sizeof(void *))];
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/emu/emucore.h:34,
                 from src/emu/emu.h:53,
                 from src/emu/validity.c:12:
```

yet this works:
```
PROJECT=Generic ARCH=x86_64 scripts/create_addon game.libretro.mame2010
```

With this PR, they both now succeed.

The configuration for `libretro-mame2010` should also have a sane default configuration (that might have avoided this general issue - so maybe a good thing it didn't!) but that's something for another PR...

Thanks @hiassoft for identifying this issue!