### PR TITLE
[le92] connman: fix compile with older headers

### DIFF
--- a/packages/network/connman/patches/connman-08-fix_for_building_with_old_headers.patch
+++ b/packages/network/connman/patches/connman-08-fix_for_building_with_old_headers.patch
@@ -1,0 +1,27 @@
+diff --git a/src/shared/mnlg.c b/src/shared/mnlg.c
+index 6b02059d..b2f71941 100644
+--- a/src/shared/mnlg.c
++++ b/src/shared/mnlg.c
+@@ -28,6 +28,22 @@
+ #define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
+ #endif
+ 
++#ifndef NETLINK_CAP_ACK
++#define NETLINK_CAP_ACK 10
++#endif /* NETLINK_CAP_ACK */
++/* support for extack if compilation headers are too old */
++#ifndef NETLINK_EXT_ACK
++#define NETLINK_EXT_ACK 11
++enum nlmsgerr_attrs {
++	NLMSGERR_ATTR_UNUSED,
++	NLMSGERR_ATTR_MSG,
++	NLMSGERR_ATTR_OFFS,
++	NLMSGERR_ATTR_COOKIE,
++
++	__NLMSGERR_ATTR_MAX,
++	NLMSGERR_ATTR_MAX = __NLMSGERR_ATTR_MAX - 1
++};
++#endif
+ 
+ struct mnlg_socket {
+ 	struct mnl_socket *nl;


### PR DESCRIPTION
This should fix compiling of connman for Rockchip devices on the libreelec-9.2 branch.

Problem:
The Rockchip build fails because some defines were missing from the older Rockchip headers.

Solution:
Add the needed defines if they are missing, the same as is done with wpa_supplicant.
