### PR TITLE
[le92] add MPEG4 HW decoding for rkmpp to FFmpeg

### DIFF
--- a/packages/multimedia/ffmpeg/patches/rkmpp/ffmpeg-99.1011-rkmppdec-enable-mpeg4.patch
+++ b/packages/multimedia/ffmpeg/patches/rkmpp/ffmpeg-99.1011-rkmppdec-enable-mpeg4.patch
@@ -1,0 +1,61 @@
+commit c24bca2f81e02008f0603dd32d246dc2041ff432
+Author: Alex Bee <knaerzche@gmail.com>
+Date:   Sat Feb 1 15:27:34 2020 +0100
+
+    [PATCH] rkmppdec: enable mpeg4
+
+diff --git a/configure b/configure
+index c1136b6a6d..e171ee8c44 100755
+--- a/configure
++++ b/configure
+@@ -2967,6 +2967,7 @@ mpeg4_cuvid_decoder_deps="cuvid"
+ mpeg4_mediacodec_decoder_deps="mediacodec"
+ mpeg4_mmal_decoder_deps="mmal"
+ mpeg4_omx_encoder_deps="omx"
++mpeg4_rkmpp_decoder_deps="rkmpp"
+ mpeg4_v4l2m2m_decoder_deps="v4l2_m2m mpeg4_v4l2_m2m"
+ mpeg4_v4l2m2m_encoder_deps="v4l2_m2m mpeg4_v4l2_m2m"
+ msmpeg4_crystalhd_decoder_select="crystalhd"
+diff --git a/libavcodec/Makefile b/libavcodec/Makefile
+index 4f8d5523af..a402cbce3a 100644
+--- a/libavcodec/Makefile
++++ b/libavcodec/Makefile
+@@ -460,6 +460,7 @@ OBJS-$(CONFIG_MPEG4_DECODER)           += xvididct.o
+ OBJS-$(CONFIG_MPEG4_CUVID_DECODER)     += cuviddec.o
+ OBJS-$(CONFIG_MPEG4_MEDIACODEC_DECODER) += mediacodecdec.o
+ OBJS-$(CONFIG_MPEG4_OMX_ENCODER)       += omx.o
++OBJS-$(CONFIG_MPEG4_RKMPP_DECODER)     += rkmppdec.o
+ OBJS-$(CONFIG_MPEG4_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
+ OBJS-$(CONFIG_MPEG4_V4L2M2M_ENCODER)   += v4l2_m2m_enc.o
+ OBJS-$(CONFIG_MPL2_DECODER)            += mpl2dec.o ass.o
+diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
+index 0b8ff86106..a840e04bd1 100644
+--- a/libavcodec/allcodecs.c
++++ b/libavcodec/allcodecs.c
+@@ -187,6 +187,7 @@ extern AVCodec ff_mpeg4_decoder;
+ extern AVCodec ff_mpeg4_crystalhd_decoder;
+ extern AVCodec ff_mpeg4_v4l2m2m_decoder;
+ extern AVCodec ff_mpeg4_mmal_decoder;
++extern AVCodec ff_mpeg4_rkmpp_decoder;
+ extern AVCodec ff_mpegvideo_decoder;
+ extern AVCodec ff_mpeg1_v4l2m2m_decoder;
+ extern AVCodec ff_mpeg2_mmal_decoder;
+diff --git a/libavcodec/rkmppdec.c b/libavcodec/rkmppdec.c
+index faae23c064..877a36733a 100644
+--- a/libavcodec/rkmppdec.c
++++ b/libavcodec/rkmppdec.c
+@@ -72,6 +72,7 @@ static MppCodingType rkmpp_get_codingtype(AVCodecContext *avctx)
+     case AV_CODEC_ID_H264:          return MPP_VIDEO_CodingAVC;
+     case AV_CODEC_ID_HEVC:          return MPP_VIDEO_CodingHEVC;
+     case AV_CODEC_ID_MPEG2VIDEO:    return MPP_VIDEO_CodingMPEG2;
++    case AV_CODEC_ID_MPEG4:         return MPP_VIDEO_CodingMPEG4;
+     case AV_CODEC_ID_VP8:           return MPP_VIDEO_CodingVP8;
+     case AV_CODEC_ID_VP9:           return MPP_VIDEO_CodingVP9;
+     default:                        return MPP_VIDEO_CodingUnused;
+@@ -657,5 +658,6 @@ static const AVCodecHWConfigInternal *rkmpp_hw_configs[] = {
+ RKMPP_DEC(h264,  AV_CODEC_ID_H264,          "h264_mp4toannexb")
+ RKMPP_DEC(hevc,  AV_CODEC_ID_HEVC,          "hevc_mp4toannexb")
+ RKMPP_DEC(mpeg2, AV_CODEC_ID_MPEG2VIDEO,    NULL)
++RKMPP_DEC(mpeg4, AV_CODEC_ID_MPEG4,         NULL)
+ RKMPP_DEC(vp8,   AV_CODEC_ID_VP8,           NULL)
+ RKMPP_DEC(vp9,   AV_CODEC_ID_VP9,           NULL)


### PR DESCRIPTION
This PR adds a patch to FFmpeg which allows MPEG4 hardware decoding on Rockchip based devices.