### PR TITLE
scripts/pkgbuilder.py: assign each subprocess a process group

### DIFF
--- a/config/multithread
+++ b/config/multithread
@@ -30,6 +30,7 @@ start_multithread_build() {
   # When building addons, don't halt on error - keep building all packages/addons
   [ "${MTADDONBUILD}" = "yes" ] && buildopts+=" --continue-on-error" || buildopts+=" --halt-on-error"
 
+  [ "${MTPROGRESS}" = "yes" ] && buildopts+=" --progress"
   [ "${MTVERBOSE}" = "yes" ] && buildopts+=" --verbose"
   [ "${MTDEBUG}" = "yes" ] && buildopts+=" --debug"
   if [ "${DISABLE_COLORS}" = "yes" ]; then

--- a/scripts/pkgbuilder.py
+++ b/scripts/pkgbuilder.py
@@ -376,7 +376,6 @@ class Builder:
             else:
                 self.threadcount = int(maxthreadcount)
 
-        self.threadcount = 1 if self.threadcount < 1 else self.threadcount
         self.threadcount = min(self.jobtotal, self.threadcount)
         self.threadcount = max(1, self.threadcount)
 


### PR DESCRIPTION
When pkgbuilder.py is terminated with SIGINT (ie. ctrl-c), or exits
immediately due to a failed job, it is sometimes possible for child
subprocesses (ie. build tasks) to remain alive and continue running
in the background.

To fix this, assign each subprocess a new process group identifier,
and capture the pid of each child subprocess so that on shutdown we
can kill the entire child process group (ie. kill the child subprocess,
and all subprocesses the child subprocess may have created) for any
builder processes that are still running.