### PR TITLE
ncurses: also include dumb terminfo in fallbacks

### DIFF
--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -32,7 +32,7 @@ PKG_CONFIGURE_OPTS_TARGET="--without-ada \
                            --without-dmalloc \
                            --disable-rpath \
                            --disable-database \
-                           --with-fallbacks=linux,screen,xterm,xterm-color \
+                           --with-fallbacks=linux,screen,xterm,xterm-color,dumb \
                            --with-termpath=/storage/.config/termcap \
                            --disable-big-core \
                            --enable-termcap \


### PR DESCRIPTION
This fixes "top -b" erroring out with "'dumb': unknown terminal type."