### PR TITLE
apache-ant: create TOOLCHAIN/bin before copying file

### DIFF
--- a/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
+++ b/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Peter Vicman (peter.vicman@gmail.com)
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="apache-ant"
 PKG_VERSION="1.10.6"
@@ -18,8 +19,11 @@ make_host() {
   ./bootstrap.sh
   ./bootstrap/bin/ant -f fetch.xml -Ddest=optional
   ./build.sh -Ddist.dir=${PKG_BUILD}/binary dist
-
-  cp binary/bin/ant ${TOOLCHAIN}/bin
-  cp -r binary/lib ${TOOLCHAIN}
   )
+}
+
+makeinstall_host() {
+  mkdir -p ${TOOLCHAIN}/bin
+    cp binary/bin/ant ${TOOLCHAIN}/bin
+    cp -r binary/lib ${TOOLCHAIN}
 }


### PR DESCRIPTION
If this package builds before the `${TOOLCHAIN}/bin` directory has been created then subsequent packages (ie. `make:host`) will fail as they are unable to create the `${TOOLCHAIN}/bin` directory (because it already exists, and is a file not a directory).