### PR TITLE
allow packages to install *.o files into the image

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -132,17 +132,17 @@ build_msg() {
 # prints a warning if the file slated for removal doesn't exist
 # this allows us to continue instead of bailing out with just "rm"
 safe_remove() {
-  local path="$1"
+  local path
 
-  [ -z "${path}" ] && return 0
-
-  if [ -e "${path}" -o -L "${path}" ]; then
-    rm -r "${path}"
-  elif [ -n "${PKG_NAME}" ]; then
-    print_color CLR_WARNING "safe_remove: path does not exist: [${PKG_NAME}]: ${path}\n"
-  else
-    print_color CLR_WARNING "safe_remove: path does not exist: ${path}\n"
-  fi
+  for path in "$@" ; do
+    if [ -e "${path}" -o -L "${path}" ]; then
+      rm -r "${path}"
+    elif [ -n "${PKG_NAME}" ]; then
+      print_color CLR_WARNING "safe_remove: path does not exist: [${PKG_NAME}]: ${path}\n"
+    else
+      print_color CLR_WARNING "safe_remove: path does not exist: ${path}\n"
+    fi
+  done
 }
 
 ### BUILDSYSTEM HELPERS ###

--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -130,6 +130,8 @@ post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin/python*-config
   rm -rf $INSTALL/usr/bin/smtpd.py $INSTALL/usr/bin/smtpd.py.*
 
+  find $INSTALL -name '*.o' -delete
+
   python_compile $PKG_INSTALL_PATH_LIB
 
   # strip

--- a/scripts/build
+++ b/scripts/build
@@ -468,7 +468,6 @@ if [ "${TARGET}" = "target" -o "${TARGET}" = "init" ]; then
     rm -rf ${INSTALL}/{usr/local/,usr/,}var
     find ${INSTALL} \( -name "*.orig" \
                   -o -name "*.rej" \
-                  -o -name "*.o" \
                   -o -name "*.in" \
                   -o -name ".git*" \) \
         -exec rm -f {} \; 2>/dev/null || :


### PR DESCRIPTION
*.o files were silently removed in scripts/build (for no obvious reason) which prevents shipping *.o files in the LE image. Drop that so we can include IR BPF decoders in the image.

This drop revealed a bug in safe_remove, it's called with wildcards in several places but it only removed the first file so several *.o files from glibc ended up in /usr/lib.

Python3 installs a python.o file eg in /usr/lib/python3.7/config-3.7-x86_64-linux-gnu/python.o, delete this is post_makeinstall_target.

With these changes both RPi4 and Generic images built fine and didn't include any unwanted *.o files.