### PR TITLE
linux: bail when config options are missing

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -7,6 +7,9 @@
 # HARDENING (security relevant linker and compiler flags) support
   HARDENING_SUPPORT="no"
 
+# Abort kernel build when unknown options are present
+  KERNEL_PARANOID_CONFIG="yes"
+
 # Name of the Distro to build (full name, without special characters)
   DISTRONAME="LibreELEC"
 

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -8,7 +8,7 @@
   HARDENING_SUPPORT="no"
 
 # Abort kernel build when unknown options are present
-  KERNEL_PARANOID_CONFIG="yes"
+  KERNEL_PARANOID_CONFIG="${KERNEL_PARANOID_CONFIG:-yes}"
 
 # Name of the Distro to build (full name, without special characters)
   DISTRONAME="LibreELEC"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -158,13 +158,28 @@ pre_make_target() {
 
   PKG_NEWOPTIONS="$(kernel_make listnewconfig | grep -E '^CONFIG_' || true)"
   if [ -n "${PKG_NEWOPTIONS}" ]; then
-    echo "INCOMPLETE KERNEL CONFIG! THE FOLLOWING ARE NEW OPTIONS:"
-    echo "***********************************"
-    echo "${PKG_NEWOPTIONS}"
-    echo "***********************************"
-    echo "Run 'make oldconfig' and update ${PKG_KERNEL_CFG_FILE}"
-    echo "so that unknown options are not resolved at build time!"
-    [ "${KERNEL_PARANOID_CONFIG}" = "yes" ] && die
+    cat >&2 <<EOF
+KERNEL CONFIG: ${PKG_KERNEL_CFG_FILE}
+
+INCOMPLETE KERNEL CONFIG! THE FOLLOWING ARE NEW OPTIONS:
+********************************************************
+${PKG_NEWOPTIONS}
+********************************************************
+
+Run 'make oldconfig' and update your kernel config so
+that unknown options are not resolved at build time!
+
+EOF
+    if [ "${KERNEL_PARANOID_CONFIG}" = "yes" ]; then
+      cat >&2 <<EOF
+To convert this to a non-fatal message, add the following
+to your \$HOME/.libreelec/options or command line:
+
+KERNEL_PARANOID_CONFIG=no
+
+EOF
+      die
+    fi
   fi
   kernel_make oldconfig
 }


### PR DESCRIPTION
When a kernel config is missing options (and prompting thus for answers during the build) we should bail out rather than have the kernel use unknown values.

When `KERNEL_PARANOID_CONFIG` is enabled (the default), the `linux:target` build will end in failure with the following message should any new options be detected:
```
./splash/splash-768.png
./splash/splash-1080.png
11815 blocks
INCOMPLETE KERNEL CONFIG! THE FOLLOWING ARE NEW OPTIONS:
***********************************
CONFIG_MEDIA_CEC_RC=n
***********************************
Run 'make oldconfig' and update /home/neil/projects/LibreELEC.tv/projects/Generic/linux/linux.x86_64.conf
so that unknown options are not resolved at build time!
```

Setting `KERNEL_CONFIG_PARANOID=no` (command line, options file) will output the above as a warning but the build will continue (use at your own risk).