### PR TITLE
buildsystem: log pkg_call that failed

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -10,6 +10,26 @@ die() {
   exit "${2:-1}"
 }
 
+onexitcleanup() {
+  [ $? -eq 0 ] && return
+
+  local _BASH_COMMAND="${BASH_COMMAND}"
+ 
+  if [ -n "${PKG_CURRENT_CALL}" ]; then
+    print_color CLR_ERROR "FAILURE: $* during ${PKG_CURRENT_CALL} (${PKG_CURRENT_CALL_TYPE})"
+    echo
+  fi
+
+  if [ -n "${_BASH_COMMAND}" ]; then
+    if [[ ! ${_BASH_COMMAND} =~ ^exit\  ]] && [[ ! ${_BASH_COMMAND} =~ ^return\  ]]; then
+      echo "*********** FAILED COMMAND ***********"
+      echo "${_BASH_COMMAND}"
+      echo "**************************************"
+    fi
+  fi
+}
+trap "onexitcleanup $0 $@" EXIT
+
 # return 0 if $2 in space-separated list $1, otherwise return 1
 listcontains() {
   if [ -n "$1" -a -n "$2" ]; then
@@ -952,15 +972,40 @@ find_dir_path() {
 # p1: name of function to test for
 # return 0 if function exists, 1 if not
 pkg_call_exists() {
-  [ "$(type -t ${1})" = "function" ] && return 0 || return 1
+  PKG_CURRENT_CALL="${1}"
+  if [ "$(type -t ${1})" = "function" ]; then
+    PKG_CURRENT_CALL_TYPE="package.mk"
+    return 0
+  else
+    PKG_CURRENT_CALL_TYPE="default"
+    return 1
+  fi
 }
 
-# p1: name of function to execute unconditionally
+# Optional variant of pkg_call_exists()
+# Clear PKG_CURRENT_CALL when function is not implemented.
+pkg_call_exists_opt() {
+  if pkg_call_exists $1; then
+    return 0
+  else
+    pkg_call_finish
+    return 1
+  fi
+}
+
+# Function to be called is set by pkg_call_exists/pkg_call_exists_opt
+# Args: whatever the called function expects
 # testing the exit code value of this function is likely to break set -e fail-on-error behaviour
 pkg_call() {
-  [ -n "${PKG_NAME}" ] || die "$(print_color CLR_ERROR "FAILURE: Cannot call ${1} package function when package is not known!")"
+  [ -n "${PKG_CURRENT_CALL}" ] || die "$(print_color CLR_ERROR "PKG_CURRENT_CALL is not set!")"
+  [ -n "${PKG_NAME}" ] || die "$(print_color CLR_ERROR "FAILURE: Cannot call ${PKG_CURRENT_CALL} package function when package is not known!")"
 
-  "${@}"
+  ${PKG_CURRENT_CALL} "${@}"
+  pkg_call_finish
+}
+
+pkg_call_finish() {
+  PKG_CURRENT_CALL=""
 }
 
 unset_functions() {
@@ -1081,8 +1126,8 @@ source_package() {
   # that we may have initialised after sourcing the package, typically
   # PKG_BUILD etc.
   if [ -n "${PKG_NAME}" ]; then
-    if pkg_call_exists configure_package; then
-      pkg_call configure_package
+    if pkg_call_exists_opt configure_package; then
+      pkg_call
     fi
   fi
 }
@@ -1321,8 +1366,8 @@ install_addon_files() {
   create_addon_xml "$1"
   python_fix_abi "$1"
 
-  if pkg_call_exists post_install_addon; then
-    INSTALL="$1" pkg_call post_install_addon
+  if pkg_call_exists_opt post_install_addon; then
+    INSTALL="$1" pkg_call
   fi
 }
 

--- a/scripts/build
+++ b/scripts/build
@@ -210,7 +210,7 @@ fi
 pkg_lock_status "ACTIVE" "${PKG_NAME}:${TARGET}" "build"
 
 # include build template and build
-pkg_call_exists pre_build_${TARGET} && pkg_call pre_build_${TARGET}
+pkg_call_exists_opt pre_build_${TARGET} && pkg_call
 
 # ensure ${PKG_BUILD} is there. (installer? PKG_URL="")
 mkdir -p "${PKG_BUILD}"
@@ -245,11 +245,11 @@ if [ -n "${PKG_DEPENDS_CONFIG}" -a -n "${PKG_INSTALL}" ]; then
   export PKG_CONFIG_PATH
 fi
 
-pkg_call_exists pre_configure && pkg_call pre_configure
-pkg_call_exists pre_configure_${TARGET} && pkg_call pre_configure_${TARGET}
+pkg_call_exists_opt pre_configure && pkg_call
+pkg_call_exists_opt pre_configure_${TARGET} && pkg_call
 
 if pkg_call_exists configure_${TARGET}; then
-  pkg_call configure_${TARGET}
+  pkg_call
 else
   case "${PKG_TOOLCHAIN}:${TARGET}" in
     # meson builds
@@ -330,13 +330,13 @@ else
   esac
 fi
 
-pkg_call_exists post_configure_${TARGET} && pkg_call post_configure_${TARGET}
+pkg_call_exists_opt post_configure_${TARGET} && pkg_call
 
 # make
-pkg_call_exists pre_make_${TARGET} && pkg_call pre_make_${TARGET}
+pkg_call_exists_opt pre_make_${TARGET} && pkg_call
 
 if pkg_call_exists make_${TARGET}; then
-  pkg_call make_${TARGET}
+  pkg_call
 else
   case "${PKG_TOOLCHAIN}:${TARGET}" in
     # ninja based builds
@@ -377,7 +377,7 @@ else
   esac
 fi
 
-pkg_call_exists post_make_${TARGET} && pkg_call post_make_${TARGET}
+pkg_call_exists_opt post_make_${TARGET} && pkg_call
 
 # Hack around directly writing/modifying the content of a shared sysroot
 # by temporarily installing new files to a package specific sysroot
@@ -392,10 +392,10 @@ for d in /usr/lib /usr/include /usr/bin /usr/lib/pkgconfig; do
 done
 
 # make install
-pkg_call_exists pre_makeinstall_${TARGET} && pkg_call pre_makeinstall_${TARGET}
+pkg_call_exists_opt pre_makeinstall_${TARGET} && pkg_call
 
 if pkg_call_exists makeinstall_${TARGET}; then
-  pkg_call makeinstall_${TARGET}
+  pkg_call
 else
   flag_enabled "sysroot" "yes" && INSTALL_TO_SYSROOT="yes" || INSTALL_TO_SYSROOT="no"
 
@@ -434,7 +434,7 @@ else
   esac
 fi
 
-pkg_call_exists post_makeinstall_${TARGET} && pkg_call post_makeinstall_${TARGET}
+pkg_call_exists_opt post_makeinstall_${TARGET} && pkg_call
 
 # Fixup temporary sysroot references to the shared sysroot
 for i in $(find "${SYSROOT_PREFIX}/usr/lib" -type f -name "*.la" 2>/dev/null); do

--- a/scripts/install
+++ b/scripts/install
@@ -140,7 +140,7 @@ fi
 
 # install
 if [ "${TARGET}" = "target" ] ; then
-  pkg_call_exists pre_install && pkg_call pre_install
+  pkg_call_exists_opt pre_install && pkg_call
 fi
 
 if [ -n "${PKG_INSTALL}" -a -d "${PKG_INSTALL}" ]; then
@@ -168,7 +168,7 @@ if [ -n "${PKG_INSTALL}" -a -d "${PKG_INSTALL}" ]; then
 fi
 
 if [ "${TARGET}" = "target" ] ; then
-  pkg_call_exists post_install && pkg_call post_install
+  pkg_call_exists_opt post_install && pkg_call
 fi
 
 release_update_lock

--- a/scripts/install_addon
+++ b/scripts/install_addon
@@ -13,9 +13,10 @@ rm -rf "${ADDON_BUILD}"
 
 # install addon parts
 if pkg_call_exists addon; then
-  pkg_call addon
+  pkg_call
 else
   install_binary_addon "${PKG_ADDON_ID}"
+  pkg_call_finish
 fi
 
 # Make sure we have a value for STRIP

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -55,7 +55,8 @@ fi
 
 pkg_lock_status "ACTIVE" "${PKG_NAME}" "unpack"
 
-if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists unpack; then
+if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists_opt unpack; then
+  pkg_call_finish
   build_msg "CLR_UNPACK" "UNPACK" "${PKG_NAME}" "indent"
 
   # unpack into a unique location as unpacking into a single ${BUILD} directory is not thread-safe
@@ -68,14 +69,15 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
   PKG_BUILD_ORIG="${PKG_BUILD}"
   PKG_BUILD="${PKG_UNPACK_DIR}/${PKG_NAME}-${PKG_VERSION}"
 
-  pkg_call_exists pre_unpack && pkg_call pre_unpack
+  pkg_call_exists_opt pre_unpack && pkg_call
 
   if pkg_call_exists unpack; then
-    pkg_call unpack
+    pkg_call
   else
     if [ -n "${PKG_URL}" ]; then
       ${SCRIPTS}/extract "${PKG_NAME}" "${PKG_UNPACK_DIR}"
     fi
+    pkg_call_finish
   fi
 
   if [ -z "${PKG_SOURCE_DIR}" -a -d "${PKG_UNPACK_DIR}/${PKG_NAME}-${PKG_VERSION}"* ]; then
@@ -110,10 +112,10 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
   # cleanup
   rm -rf "${PKG_UNPACK_DIR}"
 
-  pkg_call_exists post_unpack && pkg_call post_unpack
+  pkg_call_exists_opt post_unpack && pkg_call
 
   if [ "${PKG_SKIP_PATCHES}" != "yes" ]; then
-    pkg_call_exists pre_patch && pkg_call pre_patch
+    pkg_call_exists_opt pre_patch && pkg_call
 
     if [ "${TARGET_ARCH}" = "x86_64" ]; then
       PATCH_ARCH="x86"
@@ -187,7 +189,7 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
       fi
     done
 
-    pkg_call_exists post_patch && pkg_call post_patch
+    pkg_call_exists_opt post_patch && pkg_call
   fi
 
   if [ ! "${PKG_NAME}" = "configtools" ] ; then
@@ -201,6 +203,7 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
     done
   fi
 fi
+pkg_call_finish
 
 if [ "${PKG_SECTION}" != "virtual" ]; then
   mkdir -p "${PKG_BUILD}"


### PR DESCRIPTION
This allows additional build failure information to be logged that should help more quickly narrow down the point of failure.

Example:
![s1](https://i.imgur.com/MtbQ2Ty.png)