### PR TITLE
Python3: fix year 2038 regression on 32-bit

### DIFF
--- a/packages/lang/Python3/patches/Python3-0400-fix-bpo5537.patch
+++ b/packages/lang/Python3/patches/Python3-0400-fix-bpo5537.patch
@@ -1,0 +1,27 @@
+From 7c35472bc734876f940fdc71090ad3d526e95a82 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Fri, 14 Feb 2020 01:33:34 +0000
+Subject: [PATCH] Fix issue 5537 - regression on 32-bit
+
+https://bugs.python.org/issue5537
+https://forum.kodi.tv/showthread.php?tid=343068&pid=2923934#pid2923934
+---
+ Lib/http/cookiejar.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Lib/http/cookiejar.py b/Lib/http/cookiejar.py
+index d43a219..53bb391 100644
+--- a/Lib/http/cookiejar.py
++++ b/Lib/http/cookiejar.py
+@@ -98,7 +98,7 @@ def time2isoz(t=None):
+     if t is None:
+         dt = datetime.datetime.utcnow()
+     else:
+-        dt = datetime.datetime.utcfromtimestamp(t)
++        dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=t)
+     return "%04d-%02d-%02d %02d:%02d:%02dZ" % (
+         dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
See: https://bugs.python.org/issue5537#msg361962

Forum: https://forum.libreelec.tv/thread/21369-exception-when-trying-to-save-lwpcookiejar-in-addon-on-milhouse-nightly/

Creating as a draft in case there's further discussion/changes in the issue before being marked as "fixed" in Python3.

This is also broken in Python2, and since the fix appears trivial it could be pushed as a backport.