### PR TITLE
connman/wireguard updates

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="9c781b75657bb72a9d65ba7cc73aa5111ae13eb2" # pre 1.38
-PKG_SHA256="384ac276b593e919614f8615da8641dac4268c8e6ebc1166b78b3d260d5ca242"
+PKG_VERSION="1ee420ace2b8edb0d4025f469aaa3d00d220dc98" # 1.38
+PKG_SHA256="2688c7d1f4b947f4b616157bad9d50234d86d5151a1e1a9e8d51acad2b1481c6"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-$PKG_VERSION.tar.gz"

--- a/packages/network/wireguard-linux-compat/package.mk
+++ b/packages/network/wireguard-linux-compat/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-linux-compat"
-PKG_VERSION="v0.0.20200121"
-PKG_SHA256="509a26a28ac1e96cf15d9a457a4143c43d4455eee877fdef20ebf11cbfd012b6"
+PKG_VERSION="v0.0.20200215"
+PKG_SHA256="0ae4d63e93e94a8953209c547416d84470816d152cdb8df4f36f3169cf3f43a6"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-$PKG_VERSION.tar.xz"

--- a/packages/network/wireguard-linux-compat/patches/wireguard-linux-compat-01-skip-compat_h-version-checks.patch
+++ b/packages/network/wireguard-linux-compat/patches/wireguard-linux-compat-01-skip-compat_h-version-checks.patch
@@ -1,0 +1,13 @@
+diff --git a/src/compat/compat.h b/src/compat/compat.h
+index 1aa0e7b..751ace7 100644
+--- a/src/compat/compat.h
++++ b/src/compat/compat.h
+@@ -43,7 +43,7 @@
+ #error "WireGuard requires Linux >= 3.10"
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)
+ #error "WireGuard has been merged into Linux >= 5.6 and therefore this compatibility module is no longer required."
+ #endif
+ 

--- a/packages/network/wireguard-tools/package.mk
+++ b/packages/network/wireguard-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-tools"
-PKG_VERSION="v1.0.20200121"
-PKG_SHA256="e7aa8985dfeb495eff4b90b1817ea6c44f59ed124bac9fc85f6ba78173beef29"
+PKG_VERSION="v1.0.20200206"
+PKG_SHA256="2528b9f99dbbb7a9498b9e1657996c865a04fa2f7c5fb6fe484f3725b7723d9c"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
This bumps connman to v1.38 and the WireGuard tools/module packages to their respective latest release tags (the packages are no longer in version sync with each other).

NB: The WireGuard module needs a patch to workaround Linux 5.6 checks the developers added to drive people to the in-kernel module. Once we've bumped projects in master to Linux 5.6 we can enable the in-kernel module everywhere and drop the compat package. In case we forget to do it we'll be reminded with build failures once we reach Linux 5.7, which is why I chose to bump the value instead of simply patching it out.