### PR TITLE
linux: ignore gcc-plugin.sh

### DIFF
--- a/packages/linux/patches/linux-0000-nop-gcc-plugin.patch
+++ b/packages/linux/patches/linux-0000-nop-gcc-plugin.patch
@@ -1,0 +1,23 @@
+From a7163ecab9b2a395e809e41255f3567d7a188a5d Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Fri, 14 Feb 2020 00:34:00 +0000
+Subject: [PATCH] gcc-plugin.sh: use CONFIG_PLUGIN_HOSTCC="" on all distros
+
+---
+ scripts/gcc-plugin.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/scripts/gcc-plugin.sh b/scripts/gcc-plugin.sh
+index d3caefe..6ba7f13 100755
+--- a/scripts/gcc-plugin.sh
++++ b/scripts/gcc-plugin.sh
+@@ -1,5 +1,6 @@
+ #!/bin/sh
+ # SPDX-License-Identifier: GPL-2.0
++exit 0
+ srctree=$(dirname "$0")
+ 
+ SHOW_ERROR=
+-- 
+2.20.1
+


### PR DESCRIPTION
Ping @jernejsk and @HiassofT 

As discussed on Slack with @jernejsk, when running `make oldconfig` the kernel executes `scripts/gcc-plugin.sh g++ g++ gcc`  which means it detects the host configuration and not the build host (ie. `host-g++ host-gcc`).

Some distros (eg. Arch, but not Ubuntu or Debian) include:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.1/plugin/include/bversion.h
```

The presence of this header results in `scripts/gcc-plugin.sh` enabling plugin support on Arch, but plugin support is not enabled on Ubuntu etc. since this header isn't installed by default.

We don't want different config options being enabled/disabled depending on the distribution, and as 
we don't need plugin support the easiest solution is to disable plugin support by having the script return nothing for everyone.

Other options would be to patch the script/kernel so that it uses the correct host compiler variants, or install the missing `bversion.h` header package (`gcc-5-plugin-dev`, [link](https://askubuntu.com/questions/870244/build-linux-4-9)) for those distros that don't install it by default. But permanently disabling plugin support should be an effective and simple fix (and will work even when running `make oldconfig` outside of the build environment, ie. when intentionally using the host compiler).

From Slack:

> jernej: are plugins something that we want?
> hiassoft: IRC the plugins are used for implementing security stuff like randomizing kernel memory layout, so probably yes
> hiassoft: OTOH reading through scripts/gcc-plugins/Kconfig we probably don't need these features in LE (and they default to off in Kconfig)
```
GCC plugins (GCC_PLUGINS) [N/y/?] (NEW) y
  Compute the cyclomatic complexity of a function (GCC_PLUGIN_CYC_COMPLEXITY) [N/y/?] (NEW) 
  Generate some entropy during boot and runtime (GCC_PLUGIN_LATENT_ENTROPY) [N/y/?] (NEW) 
  Force initialization of variables containing userspace addresses (GCC_PLUGIN_STRUCTLEAK) [N/y/?] (NEW) 
  Randomize layout of sensitive kernel structures (GCC_PLUGIN_RANDSTRUCT) [N/y/?] (NEW) 
```
> hiassoft: yea, none of the gcc plugin stuff has been used to build default Debian kernel either, seems to be advanced security/hardening/analysis stuff. no need for that in LE IMO
>hiassoft: @MilhouseVH @jernejsk I think either patching scripts/gcc-plugin.sh or Kconfig should be fine. That'll prevent config flipping if gcc plugin dev files are present on the host and if we ever want to enable gcc plugins in kernel config we'll need to revisit this topic anyways
