### PR TITLE
buildsystem: allow onexit trap to be selectively ignored

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -28,7 +28,7 @@ onexitcleanup() {
     fi
   fi
 }
-trap "onexitcleanup $0 $@" EXIT
+[ "${NOONEXIT}" != "yes" ] && trap "onexitcleanup $0 $@" EXIT
 
 # return 0 if $2 in space-separated list $1, otherwise return 1
 listcontains() {

--- a/tools/dashboard
+++ b/tools/dashboard
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
+export NOONEXIT=yes
+
 cd "$(readlink -f "$(dirname "$0")")/.."
 
 export _CACHE_PACKAGE_LOCAL=none _CACHE_PACKAGE_GLOBAL=none _DEBUG_DEPENDS_LIST=none DEFAULT_PYTHON_VERSION=none

--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -5,6 +5,8 @@
 
 set -e
 
+export NOONEXIT=yes
+
 [ -z "${DEBUG_LOG}" ] && DEBUG_LOG=/tmp/distro-tool.log
 
 LIBREELEC_DIR=$HOME/LibreELEC.tv


### PR DESCRIPTION
Stop logging a failed bash command when interrupting `PROJECT=RPi DEVICE=RPi2 ARCH=arm tools/dashboard`. Anywhere else we don't want/need to log the bash command, add `export NOONEXIT=yes` or use `NOONEXIT=yes . config/options ""`