### PR TITLE
binutils: fix build without texinfo

### DIFF
--- a/packages/devel/binutils/patches/nodocs.patch
+++ b/packages/devel/binutils/patches/nodocs.patch
@@ -1,0 +1,12 @@
+diff -ur a/binutils/Makefile.in b/binutils/Makefile.in
+--- a/binutils/Makefile.in	2020-02-01 12:50:05.000000000 +0100
++++ b/binutils/Makefile.in	2020-02-20 00:45:18.792253182 +0100
+@@ -560,7 +560,7 @@
+ zlibinc = @zlibinc@
+ AUTOMAKE_OPTIONS = dejagnu no-dist foreign subdir-objects
+ ACLOCAL_AMFLAGS = -I .. -I ../config -I ../bfd
+-SUBDIRS = doc po
++SUBDIRS =
+ tooldir = $(exec_prefix)/$(target_alias)
+ 
+ # Automake 1.10+ disables lex and yacc output file regeneration if


### PR DESCRIPTION
binutils-2.34/missing: 81: makeinfo: not found
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <http://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <http://www.gnu.org/software/make/>
make[3]: *** [Makefile:474: binutils.info] Error 127