### PR TITLE
gdb: fix expat search on some hosts

### DIFF
--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -22,6 +22,7 @@ PKG_CONFIGURE_OPTS_TARGET="bash_cv_have_mbstate_t=set \
                            --with-intel-pt=no \
                            --with-babeltrace=no \
                            --with-expat=yes \
+                           --with-libexpat-prefix=${SYSROOT_PREFIX}/usr \
                            --disable-source-highlight \
                            --disable-nls \
                            --disable-sim \


### PR DESCRIPTION
~~If /usr/lib/libexpat.so exists on host, it's picked instead of that from LE build system. From what I can tell, this issue was present before. However, in older configure logs only warning is issued but now error is returned.~~

Give search path for expat explicitly. This solves issue on some hosts where expat is present in system. Previously expat was set on auto and gdb configure only printed a warning. But now that it's set to "yes" configure script fails if expat isn't found.