### PR TITLE
netbase: fix site url; update to netbase-6.1

### DIFF
--- a/packages/network/netbase/package.mk
+++ b/packages/network/netbase/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="netbase"
-PKG_VERSION="6.0"
-PKG_SHA256="692baeb7b76eba5580c7edbc97ce1784a06b5aa4b367c5ed0b39e0ce7a97d594"
+PKG_VERSION="6.1"
+PKG_SHA256="084d743bd84d4d9380bac4c71c51e57406dce44f5a69289bb823c903e9b035d8"
 PKG_LICENSE="GPL"
-PKG_SITE="https://anonscm.debian.org/cgit/users/md/netbase.git/"
+PKG_SITE="https://salsa.debian.org/md/netbase"
 PKG_URL="http://ftp.debian.org/debian/pool/main/n/netbase/netbase_$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="The netbase package provides data for network services and protocols from the iana db."


### PR DESCRIPTION
Debian have retired their old "site" url.

Debian are no longer distributing the 6.0 tar file, but I've uploaded the copy of 6.0 I already had.

```
netbase (6.1) unstable; urgency=medium

  * services: added isakmp (500/udp) which was removed by mistake in
    6.0 instead of the UDP service. (Closes: #946138)
  * services: removed some historical or not actually used ports:
    isakmp (500/tcp), socks (1080/udp), ingreslock (1524/udp),
    kermit (1649/udp), groupwise (1677/udp), l2f (1701/tcp), msnp (1863),
    unix-status (1957/tcp), log-server (1958/tcp), remoteping (1959/tcp),
    cisco-sccp (2000/udp), search (2010/tcp), pipe-server (2010/tcp),
    gsigatekeeper (2119/udp), gris (2135/udp), cvspserver (2401/udp),
    dict (2628/udp), f5-globalsite (2792/udp), gsiftp (2811/udp),
    gpsd (2947/udp), gds-db (3050/udp), mysql (3306/udp).
```
https://salsa.debian.org/md/netbase/-/commit/0fc1e4ce39328f7388badace0aaf7b7294d5ed61
