### PR TITLE
visualization.pictureit: update to 3.0.1

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/visualization.pictureit/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.pictureit/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.pictureit"
-PKG_VERSION="d246c1493d5c4e21236449bf7d15d62fcb7a8bf8"
-PKG_SHA256="041d086c473d7dfb44f8f9d90924185491a16e813a5995d3af65710198646c3e"
-PKG_REV="5"
+PKG_VERSION="3.0.1-Leia"
+PKG_SHA256="fb10cd200e2f682cf0e5e715a4bb61da88b51eb2402724cf1d5ca5f7d4f17edf"
+PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"


### PR DESCRIPTION
We have already this version, just to clean it up for the next bump/rebuild of the addons.
Main problem was that there was no release was tagged upstream, this is fixed now.