### PR TITLE
Fix game.libretro.scummvm build for 9.2

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -15,3 +15,7 @@ PKG_LONGDESC="game.libretro.scummvm: scummvm for Kodi"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.gameclient"
+
+pre_configure_target() {
+  export LDFLAGS=`echo $LDFLAGS | sed -e "s|-Wl,--as-needed||"`
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.scummvm"
 PKG_VERSION="2.1.0.7-Leia"
 PKG_SHA256="8d0d01bb97d0b530b2f002eb53874f4d515bd464c4dcf00dcf10060e561d54cd"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.scummvm"


### PR DESCRIPTION
Backport of the scummvm build fix from the master branch, see https://github.com/LibreELEC/LibreELEC.tv/pull/4129