### PR TITLE
samba: update to samba-4.12.0

### DIFF
--- a/packages/network/samba/config/samba4-cache.txt
+++ b/packages/network/samba/config/samba4-cache.txt
@@ -39,4 +39,8 @@ Checking value of SIGRTMAX: "64"
 Checking value of SIGRTMIN: "32"
 Checking errno of iconv for illegal multibyte sequence: "0"
 Checking for a 64-bit host to support lmdb: NO
+Checking value of GNUTLS_CIPHER_AES_128_CFB8: OK
+Checking value of GNUTLS_MAC_AES_CMAC_128: OK
+Checking whether fcntl supports flags to send direct I/O availability signals: OK
+Checking whether fcntl supports setting/geting hints: OK
 

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.11.6"
-PKG_SHA256="91438f4d7b71f673421435fa7f26b03b613f214139636ce50af35bc2ff09ef38"
+PKG_VERSION="4.12.0"
+PKG_SHA256="6ec0b70a567d3c3f4dd3cf2a90b515dcef03a3804b00abb5896eba382d9665fe"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -62,7 +62,7 @@ deps_pkg=(wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gaw
 files=(/usr/include/stdio.h /usr/include/ncurses.h)
 files_pkg=(libc6-dev libncurses5-dev)
 
-perl_mod=(JSON XML::Parser Thread::Queue)
+perl_mod=(JSON XML::Parser Thread::Queue Parse::Yapp::Driver)
 
 case "${DISTRO}" in
     fedora|centos|rhel)
@@ -77,18 +77,18 @@ case "${DISTRO}" in
         deps_pkg+=(libstdc++-static)
       fi
       files_pkg=(glibc-headers ncurses-devel)
-      perl_pkg=(perl-JSON perl-XML-Parser perl-Thread-Queue)
+      perl_pkg=(perl-JSON perl-XML-Parser perl-Thread-Queue perl-Parse-Yapp)
       ;;
     gentoo|sabayon)
       deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python3 rpcgen)
       deps_pkg+=("gcc[cxx]" mkfontscale mkfontdir bdftopcf libxslt virtual/jre python3 net-libs/rpcsvc-proto)
       files_pkg=(glibc ncurses)
-      perl_pkg=(JSON XML-Parser perl-Thread-Queue)
+      perl_pkg=(JSON XML-Parser perl-Thread-Queue perl-Parse-Yapp)
       ;;
     arch)
       deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python3 rpcgen)
       deps_pkg+=(g++ xorg-mkfontscale xorg-mkfontdir xorg-bdftopcf libxslt "java-runtime-common jdk8-openjdk" python3 rpcsvc-proto)
-      perl_pkg=(perl-json perl-xml-parser perl)
+      perl_pkg=(perl-json perl-xml-parser perl perl-parse-yapp)
       ;;
     opensuse)
       deps+=( g++ mkfontscale mkfontdir bdftopcf xsltproc java python3)
@@ -97,12 +97,12 @@ case "${DISTRO}" in
         deps+=(glibc-devel-static)
         deps_pkg+=(glibc-devel-static)
       fi
-      perl_pkg=(perl-JSON perl-XML-Parser perl)
+      perl_pkg=(perl-JSON perl-XML-Parser perl perl-Parse-Yapp)
       ;;
     *)
       deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python3)
       deps_pkg+=(g++ xfonts-utils xfonts-utils xfonts-utils xsltproc default-jre python3)
-      perl_pkg=(libjson-perl libxml-parser-perl perl)
+      perl_pkg=(libjson-perl libxml-parser-perl perl libparse-yapp-perl)
       ;;
 esac
 


### PR DESCRIPTION
https://www.samba.org/samba/history/samba-4.12.0.html

The Parse::Yapp::Driver module is no longer bundled with 4.12.0, so we need to add this as a new build dependency ([bug#14284](https://bugzilla.samba.org/show_bug.cgi?id=14284))