### PR TITLE
rpi-eeprom: update to rpi-eeprom-<next>

### DIFF
--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="2105f604756e0f3be16c8bfb1a987def56f2e8c1"
-PKG_SHA256="fa9e4043570fb5e034145221d4fe6d50e2caa7b5f39b086a020afa9c48b0b4ae"
+PKG_VERSION="92ed6c634ab16245f042ab13ac8f55080b6253d6"
+PKG_SHA256="fb0f42e4f039761c66eb1a72addbf8bc347f422364651eb2522aadd7315ddbb2"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="92ed6c634ab16245f042ab13ac8f55080b6253d6"
-PKG_SHA256="fb0f42e4f039761c66eb1a72addbf8bc347f422364651eb2522aadd7315ddbb2"
+PKG_VERSION="a70a647233a1103dc12ec006b46e8451f4b93401"
+PKG_SHA256="ce5410222b07dd493b66a87f12babd97bc2ecaea2593ca710b03d65947580cfa"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="17086f2637a46b9ed47633c9b6d0c27f7d2043aa"
-PKG_SHA256="2602be582f1b408240557472dd61f55e5dddcb9ab3b473d055f5049fef7c1c0b"
+PKG_VERSION="f5f8e72f048d64bfa92408d074e27e37184583ca"
+PKG_SHA256="e4ed95f567370217be4879776e2dee980b8967775fa997f5f0fc8fbf8d57df4c"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -16,7 +16,7 @@ makeinstall_target() {
   DESTDIR=${INSTALL}/$(get_kernel_overlay_dir)/lib/firmware/raspberrypi/bootloader
 
   mkdir -p ${DESTDIR}
-    _dirs="critical"
+    _dirs="critical stable"
     [ "$LIBREELEC_VERSION" = "devel" ] && _dirs+=" beta"
 
     for _maindir in ${_dirs}; do

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="cbb061e0c3ccff823d866733970addc206821415"
-PKG_SHA256="b5fc4061ffc795b59854c5118e88fbe7329dd1551c8a054968f57128ed479e9b"
+PKG_VERSION="ad18a5b468f787ed37ab62e0a699dabeaa580e27"
+PKG_SHA256="2f77ef84d34f77208e4caf90aa65bbbaa6234ee58ffe9c23a819d44c25a631b4"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="421c965cddf8fb5910a78422627684f0d72edd06"
-PKG_SHA256="34af656d7474240268c8f42648bb9fb544536094bd37b992d17ac84cea2977b3"
+PKG_VERSION="a9ca308223c1d0426b9ab320696b95954078c3b4"
+PKG_SHA256="072dbbd4b53c2c0b5764ff628f63cc8d679a99cfe84d8f50acea06922084515e"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="30905b49096df59e50694fab05bcca55b66be5ef"
-PKG_SHA256="8f9f77424ff5d8ff97250ac9ed9fea9de3f6cf7b57c7d8e86a5f935648c3abec"
+PKG_VERSION="17086f2637a46b9ed47633c9b6d0c27f7d2043aa"
+PKG_SHA256="2602be582f1b408240557472dd61f55e5dddcb9ab3b473d055f5049fef7c1c0b"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="a9ca308223c1d0426b9ab320696b95954078c3b4"
-PKG_SHA256="072dbbd4b53c2c0b5764ff628f63cc8d679a99cfe84d8f50acea06922084515e"
+PKG_VERSION="c2e0986a14258bc0b836579569ea2a72b97b575a"
+PKG_SHA256="204ca510c640f535a108ca221ce9e8691a671a4015ec933c1afcace2bd7a19dd"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="c2e0986a14258bc0b836579569ea2a72b97b575a"
-PKG_SHA256="204ca510c640f535a108ca221ce9e8691a671a4015ec933c1afcace2bd7a19dd"
+PKG_VERSION="e0e53a2df44faac0d210e0a9ecb9ddd8f7cff74d"
+PKG_SHA256="514a3a2ff9c60892321d23bc99741cb3e4806a5c7e434a71b929069284f533c9"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="d1e04d2042851b7ffceeecc35260ccc2fb27f678"
-PKG_SHA256="164729df9d85f9ca1997ca3daeb6ce6f6c10d470b8ccd6494022e407b822a3ec"
+PKG_VERSION="2105f604756e0f3be16c8bfb1a987def56f2e8c1"
+PKG_SHA256="fa9e4043570fb5e034145221d4fe6d50e2caa7b5f39b086a020afa9c48b0b4ae"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="f5f8e72f048d64bfa92408d074e27e37184583ca"
-PKG_SHA256="e4ed95f567370217be4879776e2dee980b8967775fa997f5f0fc8fbf8d57df4c"
+PKG_VERSION="421c965cddf8fb5910a78422627684f0d72edd06"
+PKG_SHA256="34af656d7474240268c8f42648bb9fb544536094bd37b992d17ac84cea2977b3"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="0ddc858039266df1f978a96a6feabfbf65953224"
-PKG_SHA256="6b4f2f6e0e5e2e71bdd7edaf345bcf21ca28b4638e5160202469d11e248b2551"
+PKG_VERSION="d1e04d2042851b7ffceeecc35260ccc2fb27f678"
+PKG_SHA256="164729df9d85f9ca1997ca3daeb6ce6f6c10d470b8ccd6494022e407b822a3ec"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="e0e53a2df44faac0d210e0a9ecb9ddd8f7cff74d"
-PKG_SHA256="514a3a2ff9c60892321d23bc99741cb3e4806a5c7e434a71b929069284f533c9"
+PKG_VERSION="0ddc858039266df1f978a96a6feabfbf65953224"
+PKG_SHA256="6b4f2f6e0e5e2e71bdd7edaf345bcf21ca28b4638e5160202469d11e248b2551"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="a70a647233a1103dc12ec006b46e8451f4b93401"
-PKG_SHA256="ce5410222b07dd493b66a87f12babd97bc2ecaea2593ca710b03d65947580cfa"
+PKG_VERSION="cbb061e0c3ccff823d866733970addc206821415"
+PKG_SHA256="b5fc4061ffc795b59854c5118e88fbe7329dd1551c8a054968f57128ed479e9b"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"


### PR DESCRIPTION
#### rpi-eeprom-17086f2:

While `critical/pieeprom-2019-09-10.bin` remains the default, this update adds `stable/pieeprom-2020-01-17.bin` firmware as an option which brings:
```
    * Add a stable firmware directory based on the latest beta release.
      Stable should be interpreted as feature-freeze releases. In this
      case the core network boot is stable enough for most scenarios
      and this de-risks adding new more experimental features in the
      beta folder.
```

This could be backported to `libreelec-9.2` and included with any future Kodi 18.7 release.

----
#### rpi-eeprom-f5f8e72

New 2020-03-04 beta SPI firmware.
```
## 2020-03-11 Add 2020-03-04 beta firmware recovery
    * Support static IP address configuration. The following fields may be
      set manually using dotted decimal address. If set, then DHCP if skipped.
       * CLIENT_IP
       * SUBNET
       * GATEWAY
       * TFTP_IP
    * If a fatal bootloader occurs then a HDMI diagnostics screen is displayed
      at VGA/DVI resolution on both monitors for two minutes. This may be
      disabled by setting DISABLE_HDMI=1 in the EEPROM configuration OR
      setting display_splash=1 in config.txt.
    * Allow the PXE menu option to match a custom string specified by
      PXE_OPTION43. The default is still "Raspberry Pi Boot"
    * DHCP_OPTION97 - The default GUID has now changed to 
      RPI4+BOARD_ID+ETH_MAC_LSB+SERIAL in order to make it easier to
      automatically identify Raspberry Pi computers. The old behaviour
      is enabled by setting DHCP_OPTION97=0 which simply repeats the serial
      number 4 times.
    * SELF_UPDATE. If SELF_UPDATE is set to 1 in the EEPROM configration AND
      config.txt contains bootloader_update=1 then the bootloader will looking
      for pieeprom.upd and vl805.bin and apply these firmware files if 
      they are different to current image before doing a watchdog reset.
      This should make it easier to update the bootloader for network
      booted setups because an sd-card is not required for recovery.bin.
      As usual, TFTP should only be used on private networks because the
      protocol is not secure against spoofing.
    * recovery.bin. The beta recovery.bin will now display a green screen
      via HDMI if successful or red if a failure occurs.
```
----
#### rpi-eeprom-421c965
```
## 2020-03-16 Add 2020-03-16 beta firmware
    * Fix DHCP Option97 GUID generation. The MAC LSB portion was previously
      always zero.
```
----
#### rpi-eeprom-a9ca308
```
## 2020-03-19 Add 2020-03-19 beta firmware
    * Minor mods for manufacture test.
```
----
#### rpi-eeprom-c2e0986
```
## 2020-04-07 Promote 2020-03-19 beta firmware to stable.
    * No major bugs reported. Promote this to stable as a step
      towards getting HDMI diagnostics into the default firmware
      via a critical update.
```
----
#### rpi-eeprom-e0e53a2
```
## 2020-04-09 Add 2020-04-09 beta firmware.
    * Experimental tweaks for PLL analog setup to reduced jitter and
      improve PCIe reliability on slower silicon.
```
----
#### rpi-eeprom-0ddc858
```
## 2020-04-12 Update beta+stable recovery.bin
    * If the VL805 image was updated but the bootloader was not then
      recovery.bin would incorrectly switch to infinite flashing activity
      LED pattern used in the rescue image to prevent infinite reboots.
      Fix recovery.bin to reboot in this case. The current 'critical'
      release does not have this problem.
    * Fix uart_2ndstage logging in beta/stable recovery image.
    * Change recovery.bin to reboot instead of displaying an error patern
      if there are no EEPROM images. The Raspberry Pi Image makes it very
      difficult to create a broken rescue image but a stray recovery.bin
      could stop Raspbian from booting.
    * Fix detection of VL805 EEPROM in recovery.bin

    N.B. These recovery.bin file used for critical updates and the rescue
    image does not suffer from these bugs.
```
----
#### rpi-eeprom-d1e04d2
```
## 2020-04-16 Revert PLL analog changes
    * This seems to cause problems on some firmware releases if enable_tvout
      is set due to different behaviour in PLL management.
```
----
#### rpi-eeprom-2105f60
```
pieeprom-2020-16-04.bin -> pieeprom-2020-04-16.bin
```
----
#### rpi-eeprom-92ed6c6 (date should be 2020-04-23)
```
## 2020-04-16 Promote to stable
    * The PLL analog changes in the beta release never made it to stable.
      Skip straight 2020-04-16 to synchronize releases.
```
----
#### rpi-eeprom-a70a647
```
## Promote 2020-04-16 EEPROM release critical
    * Make this the default release for all users. This supports network
      boot, configurable boot order and HDMI diagnostics screen.
```
----
#### rpi-eeprom-cbb061e
```
## 2020-05-11 Garbage collect old binaries
    * Now that 2020-04-16 is has been released as the default production
      release move the old binaries to an old (deprecated) directory.
      These can be removed for the APT package to reduce disk space.
```
----
#### rpi-eeprom-ad18a5b
```
## 2020-05-15 Add pieeprom-2020-05-15 beta with USB boot
    * USB mass storage boot will NOT work without the updated firmware
      start.elf binaries. These will probably be released via rpi-update
      in a few days time.
      This release simply helps to validate if there are regressions in
      the current SD and Network boot modes.

      * SELF_UPDATE and bootloader_update are now enabled by default.
```