### PR TITLE
gitignore: ignore tools/mkpkg/.git files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ mkpkg-temp
 # crap
 .DS_Store
 .directory
+
+# ignore git repos from update scripts
+tools/mkpkg/*.git


### PR DESCRIPTION
ignores the tools/mkpkg/*.git folders from update scripts (addons for example)

not 100% sure this syntax is correct, but works for me