### PR TITLE
remove need of symlinks for the repository

### DIFF
--- a/config/options
+++ b/config/options
@@ -86,6 +86,10 @@ VERBOSE="${VERBOSE:-yes}"
 # directory.
 CCACHE_CACHE_SIZE="10G"
 
+# set addon paths
+ADDON_PATH="$ADDON_VERSION/$ADDON_PROJECT/$TARGET_ARCH"
+ADDON_URL="$ADDON_SERVER_URL/$ADDON_PATH"
+
 # read local persistent options from $ROOT if available
 if [ -f "${ROOT}/.libreelec/options" ]; then
   . "${ROOT}/.libreelec/options"

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -195,9 +195,8 @@
 # Addon Server Url
   ADDON_SERVER_URL="https://addons.libreelec.tv"
 
-# set the addon dirs
-  ADDON_PATH="$ADDON_VERSION/${DEVICE:-$PROJECT}/$TARGET_ARCH"
-  ADDON_URL="$ADDON_SERVER_URL/$ADDON_PATH"
+# set the default addon project
+  ADDON_PROJECT="${DEVICE:-$PROJECT}"
 
 # Default size of system partition, in MB, eg. 512
   SYSTEM_SIZE=512

--- a/projects/Allwinner/devices/A20/options
+++ b/projects/Allwinner/devices/A20/options
@@ -45,7 +45,3 @@
 
   # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
     KODIPLAYER_DRIVER="$OPENGLES"
-
-  # set the addon dirs
-    ADDON_PATH="$ADDON_VERSION/H3/$TARGET_ARCH"
-    ADDON_URL="$ADDON_SERVER_URL/$ADDON_PATH"

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -62,3 +62,5 @@
   # debug tty path
     DEBUG_TTY="/dev/console"
 
+  # set the addon project
+    ADDON_PROJECT="H3"

--- a/projects/Amlogic/devices/AMLGX/options
+++ b/projects/Amlogic/devices/AMLGX/options
@@ -32,7 +32,3 @@
 
   # Mali GPU family
     MALI_FAMILY="450 t820"
-
-  # set the addon dirs
-    ADDON_PATH="$ADDON_VERSION/AMLG12/$TARGET_ARCH"
-    ADDON_URL="$ADDON_SERVER_URL/$ADDON_PATH"

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -89,3 +89,6 @@
 
   # debug tty path
     DEBUG_TTY="/dev/ttyAML0"
+
+  # set the addon project
+    ADDON_PROJECT="AMLG12"

--- a/projects/RPi/devices/Slice/options
+++ b/projects/RPi/devices/Slice/options
@@ -13,3 +13,6 @@
 
   # Additional drivers
     ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS} slice-drivers"
+
+  # set the addon project
+    ADDON_PROJECT="RPi"

--- a/projects/RPi/devices/Slice3/options
+++ b/projects/RPi/devices/Slice3/options
@@ -13,3 +13,6 @@
 
   # Additional drivers
     ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS} slice-drivers"
+
+  # set the addon project
+    ADDON_PROJECT="RPi2"

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -85,3 +85,6 @@
 
   # debug tty path
     DEBUG_TTY="/dev/ttyS2"
+
+  # set the addon project
+    ADDON_PROJECT="H3"


### PR DESCRIPTION
Currently we symlinking/alias addon repos for several devices.

To avoid messing around with server/jenkins configs at every repo bump and the possibility to mess it up, just hard code it into the image what should be used.

With Repo 9.80.3 there is only a single addon build for RK and AW (AW H3). 
This is only a temporary solution till we have some kind of arm32 addon build that could be used by every arm device, a H3 build is what comes quite close to it.

AML could use it too but currently hold back till it has the same kernel version in use.
RPi4 basically the same, RPi 2-3 needs an more relaxed compiler options that should be included into a arm32 "project".

This is an intermediate step to find possible problems.