### PR TITLE
update_binary-addons: drop kodi-platform bump

### DIFF
--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -70,21 +70,6 @@ fi
 
 git_clone https://github.com/xbmc/xbmc ${KODI_DIR} ${KODI_BRANCH}
 
-# kodi-platform, points to repo+githash
-REPO=$(cat $KODI_DIR/cmake/addons/depends/common/kodi-platform/kodi-platform.txt | awk '{print $2}')
-GIT_HASH=$(cat $KODI_DIR/cmake/addons/depends/common/kodi-platform/kodi-platform.txt | awk '{print $3}')
-PKG_NAME="kodi-platform"
-
-git_clone $REPO $PKG_NAME.git
-if [ -f "${ROOT}/packages/mediacenter/kodi-platform/package.mk" ] ; then
-  # update package.mk
-  RESOLVED_HASH=$(resolve_hash $PKG_NAME.git $GIT_HASH)
-  update_pkg "${ROOT}/packages/mediacenter/kodi-platform" ${PKG_NAME} ${RESOLVED_HASH} || true
-fi
-if [ "${KEEP_GIT_DIRS}" != "yes" ]; then
-  rm -rf $PKG_NAME.git
-fi
-
 # addons
 for addontxt in $KODI_DIR/cmake/addons/bootstrap/repositories/*-addons.txt ; do
   ADDONS=$(cat $addontxt | awk '{print $1}')


### PR DESCRIPTION
kodi-platform version is no longer managed in kodi's git tree and
needs to be updated manually, like p8-platform