### PR TITLE
alsa-lib: add modprobe.d file to work around NUC audio issues

### DIFF
--- a/packages/audio/alsa-lib/modprobe.d/intel-audio.conf
+++ b/packages/audio/alsa-lib/modprobe.d/intel-audio.conf
@@ -1,0 +1,2 @@
+# work around no audio issue on Intel NUCs
+blacklist snd_soc_skl


### PR DESCRIPTION
Blacklist snd_soc_skl so that hda_intel gets used. This fixes audio
not working on NUCs which have a DSP on board.

Users needed snd_soc_skl can override this via an (empty)
/storage/.config/modprobe.d/intel-audio.conf file

Note: build-tested only (and verified that the intel-audio.conf file was included in image) but not runtime tested - I don't have any NUCs.

Also this is for LE9.2 only, for master we can (and probably should) use a different approach, see eg here https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=82d9d54a6c0ee8b12211fa4e59fd940a2da4e063