### PR TITLE
add RemainAfterExit=yes to our oneshot systemd services

### DIFF
--- a/packages/graphics/bcm2835-driver/system.d/unbind-console.service
+++ b/packages/graphics/bcm2835-driver/system.d/unbind-console.service
@@ -5,6 +5,7 @@ ConditionPathExists=/sys/class/vtconsole/vtcon1/bind
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/bin/sh -c 'echo 0 > /sys/class/vtconsole/vtcon1/bind'
 
 [Install]

--- a/packages/linux-firmware/brcmfmac_sdio-firmware/system.d/brcmfmac-firmware.service
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/system.d/brcmfmac-firmware.service
@@ -5,6 +5,7 @@ Before=kodi.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "/usr/bin/brcmfmac-firmware-setup"
 
 [Install]

--- a/packages/network/samba/system.d/samba-config.service
+++ b/packages/network/samba/system.d/samba-config.service
@@ -5,5 +5,6 @@ After=basic.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/lib/samba/samba-config
 StartLimitInterval=0

--- a/packages/security/openssl/system.d/openssl-config.service
+++ b/packages/security/openssl/system.d/openssl-config.service
@@ -5,6 +5,7 @@ After=systemd-tmpfiles-setup.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/openssl-config
 
 [Install]

--- a/packages/sysutils/systemd/system.d/hwdb.service
+++ b/packages/sysutils/systemd/system.d/hwdb.service
@@ -6,6 +6,7 @@ Before=systemd-udevd.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=-/usr/bin/udevadm hwdb --update
 
 [Install]

--- a/packages/sysutils/systemd/system.d/kernel-overlays.service
+++ b/packages/sysutils/systemd/system.d/kernel-overlays.service
@@ -5,6 +5,7 @@ Before=systemd-udevd.service systemd-udev-trigger.service systemd-modules-load.s
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/sbin/kernel-overlays-setup
 
 [Install]


### PR DESCRIPTION
This is required since systemd 245, without it oneshot services
may get started more than once.