### PR TITLE
apache-ant: update to apache-ant-1.10.7

### DIFF
--- a/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
+++ b/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="apache-ant"
-PKG_VERSION="1.10.6"
-PKG_SHA256="a4adf371696089e1730d4f55fd4d0c6f3784dea1eee402fcc981f2330f8d6fc1"
+PKG_VERSION="1.10.7"
+PKG_SHA256="c8d68b396d9e44b49668bafe0c82f8c89497915254b5395d73d6f6e41d7a0e25"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://ant.apache.org/"
 PKG_URL="https://archive.apache.org/dist/ant/source/${PKG_NAME}-${PKG_VERSION}-src.tar.xz"


### PR DESCRIPTION
Update to latest apache-ant, as Apache [no longer accept](https://support.sonatype.com/hc/en-us/articles/360041287334) http download requests, resulting in this failure:

```
[1;36mUNPACK[0m      jdk-x86_64-zulu
[1;36mUNPACK[0m      apache-ant
[1;33mBUILD[0m      apache-ant [1;37m(host)[0m
    [1;35mTOOLCHAIN[0m      manual
... Bootstrapping Ant Distribution
... Compiling Ant Classes
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
... Copying Required Files
... Building Ant Distribution
Buildfile: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build.xml

bootstrap:

check-optional-packages:

prepare:

build:
Created dir: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib
Compiling 297 source files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/classes
warning: unknown enum constant Status.STABLE
  reason: class file for org.apiguardian.api.API$Status not found
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.INTERNAL
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.INTERNAL
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.EXPERIMENTAL
warning: unknown enum constant Status.EXPERIMENTAL
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.MAINTAINED
warning: unknown enum constant Status.MAINTAINED
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.INTERNAL
warning: unknown enum constant Status.INTERNAL
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
25 warnings
Creating empty /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/classes/org/apache/tools/ant/taskdefs/optional/junitlauncher/package-info.class
Deleting directory /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/classes/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined
Compiling 11 source files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/classes
Creating empty /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/classes/org/apache/tools/ant/taskdefs/optional/junitlauncher/confined/package-info.class
Copying 6 files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/classes
Copying 2 files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/classes
Copying 4 files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/classes/org/apache/tools/ant/taskdefs/optional/junit/xsl

jars:
Copying 2 files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-launcher.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-bootstrap.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-apache-resolver.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-junit.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-junit4.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-junitlauncher.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-apache-regexp.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-apache-oro.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-apache-bcel.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-apache-log4j.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-commons-logging.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-apache-bsf.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-javamail.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-netrexx.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-commons-net.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-antlr.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-imageio.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-jmf.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-jai.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-swing.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-jsch.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-jdepend.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-apache-xalan2.jar
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-xz.jar

compile-tests:
Created dir: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/testcases
Compiling 326 source files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/testcases
warning: unknown enum constant Status.STABLE
  reason: class file for org.apiguardian.api.API$Status not found
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.INTERNAL
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
14 warnings
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/testcases/org/apache/tools/ant/taskdefs/test2-antlib.jar

test-jar:
Building jar: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/build/lib/ant-testutil.jar

-ant-dist-warn-jdk9+:
Java 9+ features won't be available in the distribution

dist-lite:
Created dir: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/bootstrap
Created dir: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/bootstrap/bin
Created dir: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/bootstrap/lib
Copying 25 files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/bootstrap/lib
Copying 13 files to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/bootstrap/bin

BUILD SUCCESSFUL
Total time: 19 seconds
... Cleaning Up Build Directories
... Done Bootstrapping Ant Distribution
Buildfile: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/fetch.xml

pick-dest:
     [echo] Downloading to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/lib/optional

probe-m2:

download-m2:
     [echo] Downloading to /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/lib/optional
      [get] Getting: https://archive.apache.org/dist/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar
      [get] To: /home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/lib/optional/maven-ant-tasks-2.1.3.jar
      [get] ....................................................
      [get] .............................

dont-validate-m2-checksum:

validate-m2-checksum:

checksum-mismatch:

checksum-match:

get-m2:

macros:

init:

antunit:
[artifact:dependencies] Downloading: org/apache/ant/ant-antunit/1.4/ant-antunit-1.4.pom from repository central at http://repo1.maven.org/maven2/
[artifact:dependencies] Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/apache/ant/ant-antunit/1.4/ant-antunit-1.4.pom
[artifact:dependencies] [WARNING] Unable to get resource 'org.apache.ant:ant-antunit:pom:1.4' from repository central (http://repo1.maven.org/maven2/): Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/apache/ant/ant-antunit/1.4/ant-antunit-1.4.pom
[artifact:dependencies] Downloading: org/apache/ant/ant-antunit/1.4/ant-antunit-1.4.jar from repository central at http://repo1.maven.org/maven2/
[artifact:dependencies] Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/apache/ant/ant-antunit/1.4/ant-antunit-1.4.jar
[artifact:dependencies] [WARNING] Unable to get resource 'org.apache.ant:ant-antunit:jar:1.4' from repository central (http://repo1.maven.org/maven2/): Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/apache/ant/ant-antunit/1.4/ant-antunit-1.4.jar
[artifact:dependencies] An error has occurred while processing the Maven artifact tasks.
[artifact:dependencies]  Diagnosis:
[artifact:dependencies] 
[artifact:dependencies] Unable to resolve artifact: Missing:
[artifact:dependencies] ----------
[artifact:dependencies] 1) org.apache.ant:ant-antunit:jar:1.4
[artifact:dependencies] 
[artifact:dependencies]   Try downloading the file manually from the project website.
[artifact:dependencies] 
[artifact:dependencies]   Then, install it using the command: 
[artifact:dependencies]       mvn install:install-file -DgroupId=org.apache.ant -DartifactId=ant-antunit -Dversion=1.4 -Dpackaging=jar -Dfile=/path/to/file
[artifact:dependencies] 
[artifact:dependencies]   Alternatively, if you host your own repository you can deploy the file there: 
[artifact:dependencies]       mvn deploy:deploy-file -DgroupId=org.apache.ant -DartifactId=ant-antunit -Dversion=1.4 -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]
[artifact:dependencies] 
[artifact:dependencies]   Path to dependency: 
[artifact:dependencies]   	1) org.apache.maven:super-pom:pom:2.0
[artifact:dependencies]   	2) org.apache.ant:ant-antunit:jar:1.4
[artifact:dependencies] 
[artifact:dependencies] ----------
[artifact:dependencies] 1 required artifact is missing.
[artifact:dependencies] 
[artifact:dependencies] for artifact: 
[artifact:dependencies]   org.apache.maven:super-pom:pom:2.0
[artifact:dependencies] 
[artifact:dependencies] from the specified remote repositories:
[artifact:dependencies]   central (http://repo1.maven.org/maven2/)
[artifact:dependencies] 
[artifact:dependencies] 

BUILD FAILED
/home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/fetch.xml:212: The following error occurred while executing this line:
/home/ubuntu/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-9.80-devel/build/apache-ant-1.10.6/fetch.xml:122: Unable to resolve artifact: Missing:
----------
1) org.apache.ant:ant-antunit:jar:1.4

  Try downloading the file manually from the project website.

  Then, install it using the command: 
      mvn install:install-file -DgroupId=org.apache.ant -DartifactId=ant-antunit -Dversion=1.4 -Dpackaging=jar -Dfile=/path/to/file

  Alternatively, if you host your own repository you can deploy the file there: 
      mvn deploy:deploy-file -DgroupId=org.apache.ant -DartifactId=ant-antunit -Dversion=1.4 -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]

  Path to dependency: 
  	1) org.apache.maven:super-pom:pom:2.0
  	2) org.apache.ant:ant-antunit:jar:1.4

----------
1 required artifact is missing.

for artifact: 
  org.apache.maven:super-pom:pom:2.0

from the specified remote repositories:
  central (http://repo1.maven.org/maven2/)



Total time: 3 seconds
[1;31mFAILURE: scripts/build apache-ant:host during make_host (package.mk)[0m
*********** FAILED COMMAND ***********
${PKG_CURRENT_CALL} "${@}"
**************************************
[1;31mFAILURE: scripts/build apache-ant:host has failed![0m
```

This may need to be backported.