### PR TITLE
workaround for broken border and menu detection

### DIFF
--- a/packages/addons/service/hyperion/source/system.d/service.hyperion.service
+++ b/packages/addons/service/hyperion/source/system.d/service.hyperion.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Hyperion service
-After=graphical.target
+After=kodi.target
 
 [Service]
 Type=forking
+ExecStartPre=/bin/sleep 5
 ExecStart=/bin/sh -c "exec sh /storage/.kodi/addons/service.hyperion/bin/hyperiond.start"
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/hyperiond.pid

--- a/packages/addons/service/hyperion/source/system.d/service.hyperion.service
+++ b/packages/addons/service/hyperion/source/system.d/service.hyperion.service
@@ -4,7 +4,7 @@ After=kodi.target
 
 [Service]
 Type=forking
-ExecStartPre=/bin/sleep 5
+ExecStartPre=/bin/sleep 10
 ExecStart=/bin/sh -c "exec sh /storage/.kodi/addons/service.hyperion/bin/hyperiond.start"
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/hyperiond.pid


### PR DESCRIPTION
## This is a workaround for the following problem:

If the hyperion service is started before the Kodi UI is fully up, both menu detection and border detection is broken:
- if menu detection is on (`"grabMenu" : false` is set for `"xbmcVideoChecker"`), then the LEDs don't turn on once a video is started
- even with `"grabMenu" : true`, the black border detection does not work i.e. LEDs at top and bottom of screen stay off when a video with black borders is played.

This problem also occurs with a vanilla hyperion installation.

## Workaround:

Both issues described above are gone with the proposed changes, which ensure that the hyperion service starts a bit later when the kodi UI is up.

## System info:
 - Raspberry pi 4B 2GB 
 - libreelec 9.2.0
 - hyperion addon v 9.2.0.112
 - WS2812 LEDs with adalight