### PR TITLE
alsa-lib: use hda_intel driver on Intel boards with a DSP

### DIFF
--- a/packages/audio/alsa-lib/modprobe.d/intel-audio.conf
+++ b/packages/audio/alsa-lib/modprobe.d/intel-audio.conf
@@ -1,0 +1,2 @@
+# use legacy hda-intel driver even if a DSP is present
+options snd_intel_dspcfg dsp_driver=1


### PR DESCRIPTION
Users who want to use the Intel SST drivers included in LibreELEC
can override that via an (empty)
/storage/.config/modprobe.d/intel-audio.conf file