### PR TITLE
iwd: disable using ConfigurationDirectory

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -32,6 +32,7 @@ post_makeinstall_target() {
       -e 's|^\(ReadWritePaths=.*\)$|#\1|g' \
       -e 's|^\(ProtectControlGroups=.*\)$|#\1|g' \
       -e 's|^\(ProtectKernelModules=.*\)$|#\1|g' \
+      -e 's|^\(ConfigurationDirectory=.*\)$|#\1|g' \
       -i $INSTALL/usr/lib/systemd/system/iwd.service
 }
 


### PR DESCRIPTION
systemd tries to create `/etc/iwd` but fails because of the r/o filesystem. iwd doesn't install anything to this directory so let's just disable it for now.