### PR TITLE
installer: use FAT16 for Generic system partition / dosfstools: reduce fsck.fat log spam

### DIFF
--- a/packages/sysutils/dosfstools/patches/dosfstools-01-silence_backup_boot_sector_diff.patch
+++ b/packages/sysutils/dosfstools/patches/dosfstools-01-silence_backup_boot_sector_diff.patch
@@ -1,0 +1,23 @@
+
+Do not print backup boot sector diff in non interactive mode to avoid log spam.
+
+--- a/src/boot.c	2017-01-23 02:16:58.000000000 +0100
++++ a/src/boot.c	2020-02-05 18:32:16.000000000 +0100
+@@ -174,6 +174,9 @@ static void check_backup_boot(DOS_FS * f
+ 	char buf[20];
+ 
+ 	printf("There are differences between boot sector and its backup.\n");
++	if (!interactive)
++	    printf("This is mostly harmless.\n");
++	else {
+ 	printf("This is mostly harmless. Differences: (offset:original/backup)\n  ");
+ 	pos = 2;
+ 	for (p = (uint8_t *) b, q = (uint8_t *) & b2, i = 0; i < sizeof(b2);
+@@ -188,6 +191,7 @@ static void check_backup_boot(DOS_FS * f
+ 		first = 0;
+ 	    }
+ 	}
++	}
+ 	printf("\n");
+ 
+ 	if (interactive)

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -206,7 +206,7 @@ do_install_quick() {
     partsize_storage_end=-1024
 
     msg_progress_install "10" "Creating partition on $INSTALL_DEVICE"
-    parted -s $INSTALL_DEVICE unit s mkpart primary fat32 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
+    parted -s $INSTALL_DEVICE unit s mkpart primary fat16 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
 
     msg_progress_install "13" "Creating partition on $INSTALL_DEVICE"
     parted -s $INSTALL_DEVICE unit s mkpart primary ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
@@ -222,7 +222,7 @@ do_install_quick() {
 
     # create filesystem
     msg_progress_install "23" "Creating filesystem on ${INSTALL_DEVICE}1"
-    mkfs.vfat ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
+    mkfs.vfat -F 16 ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
 
     msg_progress_install "25" "Set uuid and disklabel $DISKLABEL_SYSTEM on ${INSTALL_DEVICE}${PART1}"
     dosfslabel ${INSTALL_DEVICE}${PART1}  $DISKLABEL_SYSTEM >> $LOGFILE 2>&1

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -206,10 +206,18 @@ do_install_quick() {
     partsize_storage_end=-1024
 
     msg_progress_install "10" "Creating partition on $INSTALL_DEVICE"
-    parted -s $INSTALL_DEVICE unit s mkpart primary fat16 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
+    if [ "$GPT" = "1" ]; then
+      parted -s $INSTALL_DEVICE unit s mkpart $DISKLABEL_SYSTEM fat16 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
+    else
+      parted -s $INSTALL_DEVICE unit s mkpart primary fat16 -- $partsize_system_start $partsize_system_end >> $LOGFILE 2>&1
+    fi
 
     msg_progress_install "13" "Creating partition on $INSTALL_DEVICE"
-    parted -s $INSTALL_DEVICE unit s mkpart primary ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
+    if [ "$GPT" = "1" ]; then
+      parted -s $INSTALL_DEVICE unit s mkpart $DISKLABEL_STORAGE ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
+    else
+      parted -s $INSTALL_DEVICE unit s mkpart primary ext4 -- $partsize_storage_start $partsize_storage_end >> $LOGFILE 2>&1
+    fi
 
     msg_progress_install "16" "Setup bootflag on partition 1 of $INSTALL_DEVICE"
     parted -s $INSTALL_DEVICE set 1 boot on >> $LOGFILE 2>&1


### PR DESCRIPTION
Since dosfstools bump to 4.1 (#3858) mkfs.fat used in installer automatically format the system partition FAT32 instead of FAT16.

One difference in the file system layout is the introduced FAT32 backup boot sector. On Generic build the Syslinux legacy installation is writing the boot sector and omitting the backup boot sector. Therefore fsck.fat complains about differences in boot and backup sector on every boot generating a long diff, i.e.:

```
[    3.451803] fsck: CP437: Invalid argument
[    3.451916] fsck: fsck.fat 4.1 (2017-01-24)
[    3.452089] fsck: There are differences between boot sector and its backup.
[    3.452270] fsck: This is mostly harmless. Differences: (offset:original/backup)
[    3.452476] fsck: 3:53/6d, 4:59/6b, 5:53/66, 6:4c/73, 7:49/2e, 8:4e/66, 9:55/61, 10:58/74
[    3.452680] fsck: , 90:fa/0e, 91:fc/1f, 92:31/be, 93:c9/77, 94:8e/7c, 95:d1/ac, 96:bc/22
[    3.452887] fsck: , 97:76/c0, 98:7b/74, 99:52/0b, 100:06/56, 101:57/b4, 102:1e/0e, 103:56/bb
[    3.453082] fsck: , 104:8e/07, 105:c1/00, 106:b1/cd, 107:26/10, 108:bf/5e, 109:78/eb
--- 57 lines deleted ---
[    3.464837] fsck: , 478:20/00, 479:65/00, 480:72/00, 481:72/00, 482:6f/00, 483:72/00
[    3.465033] fsck: , 484:0d/00, 485:0a/00, 504:fe/00, 505:02/00, 506:b2/00, 507:3e/00
[    3.465139] fsck: , 508:18/00, 509:37/00
[    3.465261] fsck: Not automatically fixing this.
[    3.465404] fsck: /dev/sda1: 12 files, 63314/130812 clusters
```

To avoid this annoying output format the system partition FAT16 again on new installations. For existing installations reduce log spam by adding a fsck.fat patch to suppress the diff output in automatic mode .

Third commit is more cosmetic setting the GPT partition labels to the defined names instead of using "primary".

Note: The image generation with scripts/mkimage using mformat of mtools is not affected by the implicit file system change.