### PR TITLE
libprojectM: add --enable-preset-subdirs

### DIFF
--- a/packages/graphics/libprojectM/package.mk
+++ b/packages/graphics/libprojectM/package.mk
@@ -17,7 +17,8 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
                            --enable-static \
                            --disable-qt \
                            --disable-pulseaudio \
-                           --disable-jack"
+                           --disable-jack \
+                           --enable-preset-subdirs"
 
 # workaround due broken release files, remove at next bump
 pre_configure_target() {

--- a/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.projectm"
 PKG_VERSION="3.0.1-Matrix"
 PKG_SHA256="c5dc37779303524ecaa90fdab27f916d51f2e4ca64fa387174a1f9cce0512377"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.projectm"
@@ -24,5 +24,4 @@ fi
 
 pre_configure_target() {
   export LDFLAGS=`echo $LDFLAGS | sed -e "s|-Wl,--as-needed||"`
-  sed -i "s|\${PROJECTM_PREFIX}|$SYSROOT_PREFIX\/usr|" -i $PKG_BUILD/FindProjectM.cmake
 }


### PR DESCRIPTION
Enable preset subdirs for libprojectM to make preset selection and visualization change in visualization.projectm work again.

Beside revision bump in visualization.projectm remove the "sed" line without effect.

Successful tested on my LE 9.2 Generic installation.