### PR TITLE
libprojectM: add --enable-preset-subdirs

### DIFF
--- a/packages/graphics/libprojectM/package.mk
+++ b/packages/graphics/libprojectM/package.mk
@@ -17,7 +17,8 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
                            --enable-static \
                            --disable-qt \
                            --disable-pulseaudio \
-                           --disable-jack"
+                           --disable-jack \
+                           --enable-preset-subdirs"
 
 # workaround due broken release files, remove at next bump
 pre_configure_target() {

--- a/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.projectm"
 PKG_VERSION="2.3.5-Leia"
 PKG_SHA256="69085611ee6af255a95c759e43e64b54ff350f2be87699c255d7db54cd4bfea2"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.projectm"
@@ -24,5 +24,4 @@ fi
 
 pre_configure_target() {
   export LDFLAGS=`echo $LDFLAGS | sed -e "s|-Wl,--as-needed||"`
-  sed -i "s|\${PROJECTM_PREFIX}|$SYSROOT_PREFIX\/usr|" -i $PKG_BUILD/FindProjectM.cmake
 }


### PR DESCRIPTION
Enable preset subdirs for libprojectM to make preset selection and visualization change in visualization.projectm work again.

Beside revision bump in visualization.projectm remove the "sed" line without effect.

Successful tested on my LE 9.2 Generic installation.

Backport of #4277