### PR TITLE
gnutls: update to 3.6.13

### DIFF
--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.6.12"
-PKG_SHA256="bfacf16e342949ffd977a9232556092c47164bd26e166736cf3459a870506c4b"
+PKG_VERSION="3.6.13"
+PKG_SHA256="32041df447d9f4644570cf573c9f60358e865637d69b7e59d1159b7240b52f38"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
Security fix: https://lists.gnupg.org/pipermail/gnutls-help/2020-March/004642.html