### PR TITLE
mkimage: replace deprecated "tty" with "systemd.debug_shell" for Generic

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -129,15 +129,15 @@ PROMPT 1
 
 LABEL installer
   KERNEL /${KERNEL_NAME}
-  APPEND boot=UUID=${UUID_SYSTEM} installer quiet tty vga=current
+  APPEND boot=UUID=${UUID_SYSTEM} installer quiet systemd.debug_shell vga=current
 
 LABEL live
   KERNEL /${KERNEL_NAME}
-  APPEND boot=UUID=${UUID_SYSTEM} live quiet tty vga=current
+  APPEND boot=UUID=${UUID_SYSTEM} live quiet vga=current
 
 LABEL run
   KERNEL /${KERNEL_NAME}
-  APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} tty portable quiet
+  APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} portable quiet
 EOF
 
   cat << EOF > "${LE_TMP}/grub.cfg"
@@ -145,15 +145,15 @@ set timeout="25"
 set default="Installer"
 menuentry "Installer" {
 	search --set -f /KERNEL
-	linux /KERNEL boot=UUID=${UUID_SYSTEM} installer quiet tty vga=current
+	linux /KERNEL boot=UUID=${UUID_SYSTEM} installer quiet systemd.debug_shell vga=current
 }
 menuentry "Live" {
 	search --set -f /KERNEL
-	linux /KERNEL boot=UUID=${UUID_SYSTEM} grub_live quiet tty vga=current
+	linux /KERNEL boot=UUID=${UUID_SYSTEM} grub_live quiet vga=current
 }
 menuentry "Run" {
 	search --set -f /KERNEL
-	linux /KERNEL boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} tty grub_portable quiet
+	linux /KERNEL boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} grub_portable quiet
 }
 EOF
 


### PR DESCRIPTION
`tty` parameter was removed with #3326/#3843.

Note: there is another behavior change with these PRs. Debug shell is not opened any more with `debugging` parameter or `/storage/.cache/debug.libreelec` set. Is this feature still needed?