### PR TITLE
wlan-firmwate: Update package

### DIFF
--- a/packages/linux-firmware/wlan-firmware/package.mk
+++ b/packages/linux-firmware/wlan-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="wlan-firmware"
-PKG_VERSION="2142727"
-PKG_SHA256="d03e3108ef18ec10774b601d06d8445aebbd3c39f8ea3ab2b20a26c62af3500f"
+PKG_VERSION="adb069a3c95913f4a55e540ed7bb2be33a582479"
+PKG_SHA256="1cd010f0e9eaba38376c15b08520ea1825fcb84c73bb1b4ce8ce248d6530eccc"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/wlan-firmware"
 PKG_URL="https://github.com/LibreELEC/wlan-firmware/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Update package in order to support old ZyDAS WIFI dongles.