### PR TITLE
Upgraded pvr.zattoo to 18.1.15.1

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="18.1.14-Leia"
-PKG_SHA256="e05ac58f5a2a112f13113bbaaf4e79c3e894d227e8879dc06a1c27ead25248b7"
+PKG_VERSION="18.1.15-Leia"
+PKG_SHA256="d1bc9628e87b2efd398f3732b34961b4b7016f6d30e3b1e7d97ab3577872e764"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Upgraded pvr.zattoo to _18.1.15.1_.

Previous version was failing since a couple of days.
Zattoo has changed their login. This is the [commit from rbuehlma](https://github.com/rbuehlma/pvr.zattoo/commit/73b3111b5d9159ecd45e089f4002cdca9fc97e1b) which should fix this.

Tested this on a Raspberry Pie 3 which has latest release installed:
http://releases.libreelec.tv/LibreELEC-RPi2.arm-9.2.1.img.gz

Remaining issues:

1. this should probably be done on the other branches as well...

2. libgpg-error failed to build for me. I have gawk 5.0.1 on my build host.
I had to apply this [fix](https://dev.gnupg.org/rE7865041c77f4f7005282f10f9b6666b19072fbdf).
Not sure if this should be included in the PR?

3. Replay and EPG is gone for me. I still have to find out what is wrong there. 
Here are some kodi logs which might be related:

```
2019-04-11 20:40:22.078 T:1790935936   ERROR: AddOnLog: Zattoo PVR Client: Open URL failed. Try to re-init session.
2019-04-11 20:40:22.084 T:1561322368   ERROR: CCurlFile::FillBuffer - Failed: SSL peer certificate or SSH remote key was not OK(60)
2019-04-11 20:40:22.084 T:1561322368   ERROR: CCurlFile::Open failed with code 0 for https://zattoo.buehlmann.net/epg/api/Epg/CH/485dabc0465a6ee1b952f945d3d1dc2c/d17/1554854400/1555286400:
```