### PR TITLE
kodi-binary-addons: update to latest versions [LibreELEC-9.2]

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.timidity"
-PKG_VERSION="2.0.4-Leia"
-PKG_SHA256="3ddd560b1c907f092f30e51dfc1f0b19e3cf77071fa557cb949d6fc3d9133497"
+PKG_VERSION="2.0.5-Leia"
+PKG_SHA256="b20a3a23056aaf76c216c755f36dff03e943d7c086d3e3fca4c920b93113e073"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="4.4.20-Leia"
-PKG_SHA256="fcf2df3566b196addf99d8166fa5a8b77635ac905214c36071d9e778cc42978e"
+PKG_VERSION="4.4.21-Leia"
+PKG_SHA256="6958b91ca616554e4c068bc303c66388e9a2c3a68b5979d8918b4e0d7b6bb95c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="3.3.18-Leia"
-PKG_SHA256="f7b6ea2e79e469fc265d008d3ba8ebb7e286e789a8b4bc809681a254ff225775"
+PKG_VERSION="3.3.19-Leia"
+PKG_SHA256="5f1b7fa00d7248fa840a0e7574bb7714867bff4ad81ceb8ed33cb3aa6d5ccbe9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.sledovanitv.cz"
-PKG_VERSION="1.5.1-Leia"
-PKG_SHA256="70c2fd8d8f1157f329f3b13f69f1eae556092b8e6f8556468ebf748a4ea6c31d"
+PKG_VERSION="1.7.0-Leia"
+PKG_SHA256="b46ad6132a830bf64feab8f298094cf07ddadfb56859a5908430b8c0c2db7b4f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="18.1.14-Leia"
-PKG_SHA256="e05ac58f5a2a112f13113bbaaf4e79c3e894d227e8879dc06a1c27ead25248b7"
+PKG_VERSION="18.1.15-Leia"
+PKG_SHA256="d1bc9628e87b2efd398f3732b34961b4b7016f6d30e3b1e7d97ab3577872e764"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.libarchive"
-PKG_VERSION="1.0.6-Leia"
-PKG_SHA256="a5b72a79c92e2bf217fd68e185e6814df914b4dc5ad3d10e7d6b706febd6294d"
+PKG_VERSION="1.0.7-Leia"
+PKG_SHA256="69ebeddbab2097f97cae46a2cabcea8e5f0d021ae44c9ba9366050ac17d3e4b4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.rar"
-PKG_VERSION="2.0.8-Leia"
-PKG_SHA256="986c26c3454279dafc36ceb5a9247290616c7357b94f7f5ceed04d530d004895"
+PKG_VERSION="2.3.0-Leia"
+PKG_SHA256="07ab4a4e5f2ad9e6c7e15badb3474d3f4d9d5e1405c4ff82815cc44452177e3b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.sftp"
-PKG_VERSION="1.0.5-Leia"
-PKG_SHA256="6a6d7fc777f574746bcc34b618700a4db3981aee470b68d60c3407eeeb0c16d9"
+PKG_VERSION="1.0.6-Leia"
+PKG_SHA256="dc3db18b6cef90cd518b741e5c9bc7b3f4412774ee60bf70b451a8d2fc88a091"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"


### PR DESCRIPTION
Replaces #4308 
