### PR TITLE
lirc: add patch to fix zotac driver

### DIFF
--- a/packages/sysutils/lirc/patches/lirc-0001-fix-zotac-poll.patch
+++ b/packages/sysutils/lirc/patches/lirc-0001-fix-zotac-poll.patch
@@ -1,0 +1,29 @@
+From 79e2494e4880d0446bf837c8bbca0b01baac4ed4 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Wed, 8 Apr 2020 11:27:11 +0200
+Subject: [PATCH] plugins/zotac: fix poll timeout
+
+poll requires a negative timeout value for infinite waits.
+See https://sourceforge.net/p/lirc/tickets/327/
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ plugins/zotac.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/zotac.c b/plugins/zotac.c
+index ac528c67..4a66acf5 100644
+--- a/plugins/zotac.c
++++ b/plugins/zotac.c
+@@ -352,7 +352,7 @@ static void* zotac_repeat(void* arg)
+ 		if (pressed)
+ 			sel = curl_poll(&pfd, 1, delay_ms);
+ 		else
+-			sel = curl_poll(&pfd, 1, 0);
++			sel = curl_poll(&pfd, 1, -1);
+ 		switch (sel) {
+ 		case 1:
+ 			// Data ready in device's file
+-- 
+2.20.1
+


### PR DESCRIPTION
See https://sourceforge.net/p/lirc/tickets/327/

Fix is reported to work fine https://forum.libreelec.tv/thread/21597-remote-woes-after-updating-to-9-2-1/?postID=137644#post137644