### PR TITLE
iptables: fix helper script

### DIFF
--- a/packages/network/iptables/scripts/iptables_helper
+++ b/packages/network/iptables/scripts/iptables_helper
@@ -1,4 +1,4 @@
-#!/bin/sh -
+#!/bin/sh
 
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
@@ -14,18 +14,22 @@ SYSTEMCTL="/usr/bin/systemctl"
 CONNMANCTL="/usr/bin/connmanctl"
 
 check_docker() {
-    $SYSTEMCTL is-active --quiet $DOCKER && $SYSTEMCTL restart $DOCKER
+  $SYSTEMCTL is-active --quiet $DOCKER && $SYSTEMCTL restart $DOCKER
+}
+
+get_technology_config() {
+  $CONNMANCTL technologies | awk -v pattern="^/.*/technology/$1$" -e 'BEGIN {S=0}; /^\/.*/ {S=0}; $0 ~ pattern {S=1}; S==1 {print $0}'
 }
 
 check_tether() {
-    if [ -n "`$CONNMANCTL technologies | grep -e -A5 technology/wifi -e 'Tethering = True'`" ]; then
-        TECHNOLOGY="wifi"
-    elif [ -n "`$CONNMANCTL technologies | grep -e -A5 technology/ethernet -e 'Tethering = True'`" ]; then
-        TECHNOLOGY="ethernet"
+  for technology in wifi ethernet; do
+    if get_technology_config $technology | grep -q 'Tethering = True'; then
+      $CONNMANCTL tether $technology off
+      sleep 1
+      $CONNMANCTL tether $technology on
+      break
     fi
-    $CONNMANCTL tether $TECHNOLOGY off
-    sleep 1
-    $CONNMANCTL tether $TECHNOLOGY on
+  done
 }
 
 flush() {


### PR DESCRIPTION
I'm pretty sure `check_tether()` has never worked correctly.

The commands:
```
$CONNMANCTL technologies | grep -e -A5 technology/wifi -e 'Tethering = True'`"
$CONNMANCTL technologies | grep -e -A5 technology/ethernet -e 'Tethering = True'`"
```
result in the following errors being logged:
```
Apr 15 04:13:04 NUC systemd[1]: Starting IPTABLES Packet Filtering...
Apr 15 04:13:04 NUC iptables_helper[669]: grep: technology/wifi: No such file or directory
Apr 15 04:13:04 NUC iptables_helper[767]: grep: technology/ethernet: No such file or directory
Apr 15 04:13:04 NUC iptables_helper[768]: Error 'tether': Invalid argument
Apr 15 04:13:05 NUC iptables_helper[836]: Error 'tether': Invalid argument
Apr 15 04:13:05 NUC systemd[1]: Finished IPTABLES Packet Filtering.
```
as `grep -e -A5 technology/wifi -e 'Tethering = True'` is attempting to open the file `technology/wifi` due to `-A5` being interpreted as the pattern for `-e`, causing `technology/wifi` to be interpreted as the file to be searched.

Furthermore, once the `grep` statement is corrected by moving the `-A5` argument before `-e`, the `grep` statement doesn't actually work as intended.

It appears the script is attempting to identify the `Tethering` status of a specific technology (`wifi` and `ethernet`), and has been written under the assumption that multiple `-e` patterns *must all* be matched to return any result. However, this is not true, at least not with Busybox `grep`, which will in fact match either of the patterns, meaning that a result would be returned for either technology whether or not it has `Tethering` capability. For example:
```
NUC:~ # connmanctl technologies | grep -A5 -e technology/wifi -e 'Tethering = True'
/net/connman/technology/wifi
  Name = WiFi
  Type = wifi
  Powered = True
  Connected = False
  Tethering = False
NUC:~ # connmanctl technologies | grep -A5 -e technology/ethernet -e 'Tethering = True'
/net/connman/technology/ethernet
  Name = Wired
  Type = ethernet
  Powered = True
  Connected = True
  Tethering = False
```

The `grep` command also assumes the Tether status will be present in the first 5 lines after the technology, which may be true today, but not necessarily true with a future version of connman which might add another capability bumping `Tethering` down a line.

To resolve all the issues, I've added a small `awk` program that now reliably extracts the capabilities of the requested technology which can then be parsed reliably.

I suspect this should be backported.

Also: anyone know what `#!/bin/sh -` is meant to be? I'm assuming it's a typo.