### PR TITLE
MarkupSafe: bump to 1.1.1

### DIFF
--- a/packages/python/devel/MarkupSafe/package.mk
+++ b/packages/python/devel/MarkupSafe/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="MarkupSafe"
-PKG_VERSION="1.0"
-PKG_SHA256="a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+PKG_VERSION="1.1.1"
+PKG_SHA256="29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/MarkupSafe/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
This fix the following warning 

```
<<< MarkupSafe:host seq 55 <<<
BUILD      MarkupSafe (host)
    TOOLCHAIN      manual
Traceback (most recent call last):
  File "setup.py", line 6, in <module>
    from setuptools import setup, Extension, Feature
ImportError: cannot import name 'Feature' from 'setuptools' (/home/clement/.local/lib/python3.7/site-packages/setuptools/__init__.py)
FAILURE: scripts/build MarkupSafe:host during makeinstall_host (package.mk)
*********** FAILED COMMAND ***********
$@
**************************************
FAILURE: scripts/build MarkupSafe:host has failed!

The following log for this failure is available:
  /home/clement/LibreELEC.tv/build.LibreELEC-H6.arm-9.80-devel/.threads/logs/55.log

>>> MarkupSafe:host seq 55 >>>
```