### PR TITLE
kernel-firmware: pick BT firmware for USB/QCA9377 cards

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
@@ -1,6 +1,7 @@
 ath10k/*
 ctefx.bin
 lbtf_usb.bin
+qca/*00000302.bin
 rt2561.bin
 rt2561s.bin
 rt2661.bin

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="3b3dd5abf07ab3819a7f28e75a61d921ecc640fd"
-PKG_SHA256="2fe9537dcf732b0ae3cb467ceeff8f7ee1d24a3e497f744e771b958981d42eaa"
+PKG_VERSION="64dba0fedb22eae32f76dcd4534b3f416db178de"
+PKG_SHA256="94538804809daa1ddb04ee6bc6753690c8739ab144ce1a4e4e2bc02e45bf59b3"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
See https://forum.libreelec.tv/thread/21794-help-for-bluetooth-support/?postID=137978#post137978 for the original user report. This should pick the firmware.