### PR TITLE
buildsystem: ignore custom host Python installations

### DIFF
--- a/config/path
+++ b/config/path
@@ -97,6 +97,6 @@ unset LD_LIBRARY_PATH
 # multilib? nah
 unset CONFIG_SITE
 
-# meh suse
-unset PYTHONSTARTUP
-unset PYTHONPATH
+# Ignore custom python installs...
+unset PYTHONHOME PYTHONPATH PYTHONSTARTUP
+export PYTHONNOUSERSITE=yes #disable PEP 370


### PR DESCRIPTION
Fixes issue mentioned in #4326: we don't want Python adding the user site-packages directory to `sys.path` as the user site-packages may conflict/interfere with our `$TOOLCHAIN` packages, so disable this behaviour by setting `PYTHONNOUSERSITE` (value doesn't matter, just so long as it's set).

Belt & braces: also unset `PYTHONHOME` because bad things are likely to happen if that is ever set in a users profile, or whatever.