### PR TITLE
kodi binary addons: add vfs.sacd and missing visualization addons

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/vfs.sacd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.sacd/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="vfs.sacd"
+PKG_VERSION="1.2.0-Matrix"
+PKG_SHA256="a633a848f7e4e3c72f378edca5bda71ee6fe6e73416ad16db8480a8096f48f31"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/vfs.sacd"
+PKG_URL="https://github.com/xbmc/vfs.sacd/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_SECTION=""
+PKG_SHORTDESC="vfs.sacd"
+PKG_LONGDESC="vfs.sacd"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.vfs"

--- a/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="visualization.fishbmc"
+PKG_VERSION="6.0.1-Matrix"
+PKG_SHA256="ce38c70ee0727d3a8f4037fae40a509bd148128cdb6fe6756cef39e59ef80bd8"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/visualization.fishbmc"
+PKG_URL="https://github.com/xbmc/visualization.fishbmc/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform glm"
+PKG_SECTION=""
+PKG_SHORTDESC="visualization.fishbmc"
+PKG_LONGDESC="visualization.fishbmc"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.player.musicviz"

--- a/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="visualization.goom"
+PKG_VERSION="3.1.1-Matrix"
+PKG_SHA256="8f39066c9de09cc5439f475e4bd115af8ac9742b6362002a45fda9317117aa73"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/visualization.goom"
+PKG_URL="https://github.com/xbmc/visualization.goom/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform glm"
+PKG_SECTION=""
+PKG_SHORTDESC="visualization.goom"
+PKG_LONGDESC="visualization.goom"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.player.musicviz"

--- a/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="visualization.starburst"
+PKG_VERSION="2.1.1-Matrix"
+PKG_SHA256="5f77920509941bfe82f29521a5a8ec437f7aefdc34a4c42fa3c3ba0b92bc8b5a"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/visualization.starburst"
+PKG_URL="https://github.com/xbmc/visualization.starburst/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform glm"
+PKG_SECTION=""
+PKG_SHORTDESC="visualization.starburst"
+PKG_LONGDESC="visualization.starburst"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.player.musicviz"

--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -46,7 +46,7 @@ if [ $# -eq 0 -o $# -gt 2 ]; then
 fi
 
 # list of packages to exclude from update
-EXCLUDED_PACKAGES="vfs.nfs vfs.sacd"
+EXCLUDED_PACKAGES=""
 
 MY_DIR="$(dirname "$0")"
 ROOT="$(cd "${MY_DIR}"/../.. && pwd)"


### PR DESCRIPTION
vfs.sacd is included in the kodi binary addon repo but was missing in LE.

Build-tested for RPi4