### PR TITLE
[le92] kodi binary addons: add vfs.sacd and missing visualization addons

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/vfs.sacd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.sacd/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="vfs.sacd"
+PKG_VERSION="1.0.4-Leia"
+PKG_SHA256="b21143d8ab59e95a2f46471e648c2a2ac67b75c8df7d6af452a5435e866046e9"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/vfs.sacd"
+PKG_URL="https://github.com/xbmc/vfs.sacd/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_SECTION=""
+PKG_SHORTDESC="vfs.sacd"
+PKG_LONGDESC="vfs.sacd"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.vfs"

--- a/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="visualization.fishbmc"
+PKG_VERSION="5.1.2-Leia"
+PKG_SHA256="8142fe4a32c0c113945c5fc9745e54639ca73308371d292e3422730bfad1d064"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/visualization.fishbmc"
+PKG_URL="https://github.com/xbmc/visualization.fishbmc/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform glm"
+PKG_SECTION=""
+PKG_SHORTDESC="visualization.fishbmc"
+PKG_LONGDESC="visualization.fishbmc"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.player.musicviz"

--- a/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="visualization.goom"
+PKG_VERSION="2.2.1-Leia"
+PKG_SHA256="a02dfd844cfd5ff24f735e614a2a4727771112ce15642957a2511061f724392a"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/visualization.goom"
+PKG_URL="https://github.com/xbmc/visualization.goom/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform glm"
+PKG_SECTION=""
+PKG_SHORTDESC="visualization.goom"
+PKG_LONGDESC="visualization.goom"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.player.musicviz"

--- a/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="visualization.starburst"
+PKG_VERSION="2.0.2-Leia"
+PKG_SHA256="8e2ee8b39fe1c0daa24b11a9c4a175a85fdbdf7dc1bc48a1ab4876edeb6f676f"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/xbmc/visualization.starburst"
+PKG_URL="https://github.com/xbmc/visualization.starburst/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform glm"
+PKG_SECTION=""
+PKG_SHORTDESC="visualization.starburst"
+PKG_LONGDESC="visualization.starburst"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.player.musicviz"

--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -46,7 +46,7 @@ if [ $# -eq 0 -o $# -gt 2 ]; then
 fi
 
 # list of packages to exclude from update
-EXCLUDED_PACKAGES="vfs.nfs vfs.sacd"
+EXCLUDED_PACKAGES=""
 
 MY_DIR="$(dirname "$0")"
 ROOT="$(cd "${MY_DIR}"/../.. && pwd)"


### PR DESCRIPTION
backport of #4337