### PR TITLE
librespot: stop crashing when logging titles with wide characters

### DIFF
--- a/packages/addons/service/librespot/source/resources/lib/ls_spotify.py
+++ b/packages/addons/service/librespot/source/resources/lib/ls_spotify.py
@@ -74,7 +74,9 @@ class Spotify:
         listitem.setArt(dict(fanart=thumb, thumb=thumb))
         listitem.setInfo('music', dict(
             album=album, artist=artist, title=title))
-        log('{}#{}#{}#{}'.format(title, artist, album, thumb))
-
+        log('{}#{}#{}#{}'.format(title.encode('ascii', 'ignore'),
+                                 artist.encode('ascii', 'ignore'),
+                                 album.encode('ascii', 'ignore'),
+                                 thumb))
 
 SPOTIFY = Spotify()


### PR DESCRIPTION
The librespot service crashes when a song with a non-ASCII title/artist is played because the logging stream is ASCII-only. I'm no Python enthusiast, but I believe this should fix the issue. Feel free to remix/adapt if necessary.