### PR TITLE
libzip: update to libzip-1.6.1

### DIFF
--- a/packages/addons/addon-depends/libzip/package.mk
+++ b/packages/addons/addon-depends/libzip/package.mk
@@ -3,18 +3,25 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libzip"
-PKG_VERSION="0.11.2"
-PKG_SHA256="7cfbbc2c540e154b933b6e9ec781e2671086bd8114eb744ae1a1ade34d2bb6bb"
+PKG_VERSION="1.6.1"
+PKG_SHA256="705dac7a671b3f440181481e607b0908129a9cf1ddfcba75d66436c0e7d33641"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.nih.at/libzip/"
-PKG_URL="http://www.nih.at/libzip/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain zlib"
+PKG_SITE="https://libzip.org/"
+PKG_URL="https://libzip.org/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain zlib bzip2"
 PKG_LONGDESC="A C library for reading, creating, and modifying zip archives."
-PKG_TOOLCHAIN="configure"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
+PKG_CMAKE_OPTS_TARGET="-DENABLE_COMMONCRYPTO=OFF \
+                       -DENABLE_GNUTLS=OFF \
+                       -DENABLE_MBEDTLS=OFF \
+                       -DENABLE_OPENSSL=OFF \
+                       -DENABLE_WINDOWS_CRYPTO=OFF \
+                       -DBUILD_TOOLS=OFF \
+                       -DBUILD_REGRESS=OFF \
+                       -DBUILD_EXAMPLES=OFF \
+                       -DBUILD_DOC=OFF \
+                       -DBUILD_SHARED_LIBS=OFF"
 
 post_makeinstall_target() {
-  rm -rf $INSTALL/usr/bin
   rm -rf $INSTALL/usr/lib
 }

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
@@ -16,7 +16,7 @@ PKG_BUILD_FLAGS="+pic"
 
 pre_configure_target() {
   export CXXFLAGS="$CXXFLAGS -Wno-narrowing"
-  export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv -lpcre -lpcrecpp -lssl -lcrypto"
+  export LIBS="-L$SYSROOT_PREFIX/usr/lib/iconv -lpcre -lpcrecpp -lssl -lcrypto -lbz2"
 }
 
 make_target() {


### PR DESCRIPTION
Sync with kodi https://github.com/xbmc/xbmc/pull/17706 - we haven't updated `libzip` in a long while.

Only consumer appears to be `vdr-plugin-xmltv2vdr`, which I have build tested on `x86_64` but not able to run-time test.