### PR TITLE
dbus, systemd: fix duplicate tmpfiles and missing groups

### DIFF
--- a/packages/sysutils/dbus/tmpfiles.d/z_02_dbus.conf
+++ b/packages/sysutils/dbus/tmpfiles.d/z_02_dbus.conf
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
-
-d    /var/lib/dbus            0755 root root - -
-d    /run/dbus                0755 root root - -
-
-L    /var/lib/dbus/machine-id - - - - /etc/machine-id

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -277,7 +277,9 @@ post_install() {
   add_group disk 6
   add_group floppy 19
   add_group kmem 9
+  add_group kvm 10
   add_group lp 7
+  add_group render 12
   add_group tape 33
   add_group tty 5
   add_group video 39


### PR DESCRIPTION
We have these issues:
```
Mar 06 12:38:53 LibreELEC systemd-tmpfiles[239]: [/usr/lib/tmpfiles.d/static-nodes-permissions.conf:17] Unknown group 'kvm'.
Mar 06 12:38:53 LibreELEC systemd-tmpfiles[254]: [/usr/lib/tmpfiles.d/z_02_dbus.conf:4] Duplicate line for path "/var/lib/dbus", ignoring.
Apr 21 17:00:21 rpi22 systemd-tmpfiles[723]: [/usr/lib/tmpfiles.d/static-nodes-permissions.conf:17] Unknown group 'kvm'.
Apr 21 17:00:21 rpi22 systemd-tmpfiles[723]: [/usr/lib/tmpfiles.d/z_02_dbus.conf:4] Duplicate line for path "/var/lib/dbus", ignoring.
```

* Adding the `kvm` and `render` groups fixes 50% of the problem.

* The `dbus` package installs the following:
```
rpi22:~ # cat /usr/lib/tmpfiles.d/dbus.conf
# Fields: type; path; mode; uid; gid; age; argument (symlink target)

# Make ${localstatedir}/lib/dbus (required for systemd < 237)
# Adjust mode and ownership if it already exists.
d /var/lib/dbus 0755 - - -

# Make ${localstatedir}/lib/dbus/machine-id a symlink to /etc/machine-id
# if it does not already exist
L /var/lib/dbus/machine-id - - - - /etc/machine-id

# Create ${runstatedir}/dbus/containers owned by the system bus user.
# org.freedesktop.DBus.Containers1 uses this to create sockets.
d /run/dbus/containers 0755 dbus - - -
```
which makes our custom `z_02_dbus.conf` redundant:
```
# SPDX-License-Identifier: GPL-2.0-or-later
# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)

d    /var/lib/dbus            0755 root root - -
d    /run/dbus                0755 root root - -

L    /var/lib/dbus/machine-id - - - - /etc/machine-id
```