### PR TITLE
samba: update to samba-4.12.2

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.12.1"
-PKG_SHA256="017cb68b66ada6a46abba31ebcedd6faa17c9805c453605e59a4d2504c726d75"
+PKG_VERSION="4.12.2"
+PKG_SHA256="6490f2a858be200c0169a47391fb27287e80f45f2beef7afa6c16bd88526a150"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Security release.

*  CVE-2020-10700:
   A client combining the 'ASQ' and 'Paged Results' LDAP controls can cause a
   use-after-free in Samba's AD DC LDAP server.
*  CVE-2020-10704:
   A deeply nested filter in an un-authenticated LDAP search can exhaust the
   LDAP server's stack memory causing a SIGSEGV.