### PR TITLE
buildsystem: fix go-based packages

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -911,6 +911,47 @@ target_has_feature() {
   listcontains "$TARGET_FEATURES" "$1"
 }
 
+# configure variables for go
+go_configure() {
+  unset GOARCH GOARM
+  case ${TARGET_ARCH} in
+    x86_64)
+      export GOARCH=amd64
+      ;;
+    arm)
+      export GOARCH=arm
+
+      case ${TARGET_CPU} in
+        arm1176jzf-s)
+          export GOARM=6
+          ;;
+        *)
+          export GOARM=7
+          ;;
+      esac
+      ;;
+    aarch64)
+      export GOARCH=arm64
+      ;;
+  esac
+
+  export GOOS=linux
+  export GOROOT=${TOOLCHAIN}/lib/golang
+  export PATH=${PATH}:${GOROOT}/bin
+
+  go_configure_path
+
+  export CGO_ENABLED=1
+  export CGO_NO_EMULATION=1
+  export CGO_CFLAGS=$CFLAGS
+}
+
+go_configure_path() {
+  export GOLANG=${TOOLCHAIN}/lib/golang/bin/go
+  export GOPATH=${PKG_BUILD}/.gopath
+  export GOFLAGS="-modcacherw"
+}
+
 # find path for matching file or directory, searching standard directory hierarchy, using optional default
 # if a path is located it will be set in FOUND_PATH and exit code will be 0.
 find_path() {

--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -16,46 +16,20 @@ PKG_TOOLCHAIN="manual"
 PKG_GIT_COMMIT="a4bc1d432a2c33aa2eed37f338dceabb93641310"
 
 pre_make_target() {
-  case ${TARGET_ARCH} in
-    x86_64)
-      export GOARCH=amd64
-      ;;
-    arm)
-      export GOARCH=arm
 
-      case ${TARGET_CPU} in
-        arm1176jzf-s)
-          export GOARM=6
-          ;;
-        *)
-          export GOARM=7
-          ;;
-      esac
-      ;;
-    aarch64)
-      export GOARCH=arm64
-      ;;
-  esac
+  go_configure
 
-  export GOOS=linux
-  export CGO_ENABLED=1
-  export CGO_NO_EMULATION=1
-  export CGO_CFLAGS=${CFLAGS}
   export CONTAINERD_VERSION=${PKG_VERSION}
   export CONTAINERD_REVISION=${PKG_GIT_COMMIT}
   export CONTAINERD_PKG=github.com/containerd/containerd
   export LDFLAGS="-w -extldflags -static -X ${CONTAINERD_PKG}/version.Version=${CONTAINERD_VERSION} -X ${CONTAINERD_PKG}/version.Revision=${CONTAINERD_REVISION} -X ${CONTAINERD_PKG}/version.Package=${CONTAINERD_PKG} -extld $CC"
-  export GOLANG=${TOOLCHAIN}/lib/golang/bin/go
-  export GOPATH=${PKG_BUILD}/.gopath
-  export GOROOT=${TOOLCHAIN}/lib/golang
-  export PATH=${PATH}:${GOROOT}/bin
 
-  mkdir -p ${PKG_BUILD}/.gopath
+  mkdir -p ${GOPATH}
   if [ -d ${PKG_BUILD}/vendor ]; then
-    mv ${PKG_BUILD}/vendor ${PKG_BUILD}/.gopath/src
+    mv ${PKG_BUILD}/vendor ${GOPATH}/src
   fi
 
-  ln -fs ${PKG_BUILD} ${PKG_BUILD}/.gopath/src/github.com/containerd/containerd
+  ln -fs ${PKG_BUILD} ${GOPATH}/src/github.com/containerd/containerd
 }
 
 make_target() {

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.12.9"
-PKG_SHA256="c31433aa0bb01856c812d40a91336e25cbce2e50800eb9fe88a7adf0305f1a5b"
+PKG_VERSION="1.14.2"
+PKG_SHA256="97b24d8992a8623eaf717cfc18a190b33f789cadd8cafdfd3c1b3616fd511d16"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/libnetwork/package.mk
+++ b/packages/addons/addon-depends/libnetwork/package.mk
@@ -13,43 +13,17 @@ PKG_LONGDESC="A native Go implementation for connecting containers."
 PKG_TOOLCHAIN="manual"
 
 pre_make_target() {
-  case $TARGET_ARCH in
-    x86_64)
-      export GOARCH=amd64
-      ;;
-    arm)
-      export GOARCH=arm
+  go_configure
 
-      case $TARGET_CPU in
-        arm1176jzf-s)
-          export GOARM=6
-          ;;
-        *)
-          export GOARM=7
-          ;;
-      esac
-      ;;
-    aarch64)
-      export GOARCH=arm64
-      ;;
-  esac
-
-  export GOOS=linux
   export CGO_ENABLED=0
-  export CGO_NO_EMULATION=1
-  export CGO_CFLAGS=$CFLAGS
   export LDFLAGS="-extld $CC"
-  export GOLANG=$TOOLCHAIN/lib/golang/bin/go
-  export GOPATH=$PKG_BUILD/.gopath
-  export GOROOT=$TOOLCHAIN/lib/golang
-  export PATH=$PATH:$GOROOT/bin
 
-  mkdir -p $PKG_BUILD/.gopath
+  mkdir -p ${GOPATH}
   if [ -d $PKG_BUILD/vendor ]; then
-    mv $PKG_BUILD/vendor $PKG_BUILD/.gopath/src
+    mv $PKG_BUILD/vendor ${GOPATH}/src
   fi
 
-  ln -fs $PKG_BUILD $PKG_BUILD/.gopath/src/github.com/docker/libnetwork
+  ln -fs $PKG_BUILD ${GOPATH}/src/github.com/docker/libnetwork
 }
 
 make_target() {

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -16,43 +16,16 @@ PKG_TOOLCHAIN="manual"
 PKG_GIT_COMMIT="425e105d5a03fabd737a126ad93d62a9eeede87f"
 
 pre_make_target() {
-  case $TARGET_ARCH in
-    x86_64)
-      export GOARCH=amd64
-      ;;
-    arm)
-      export GOARCH=arm
+  go_configure
 
-      case $TARGET_CPU in
-        arm1176jzf-s)
-          export GOARM=6
-          ;;
-        *)
-          export GOARM=7
-          ;;
-      esac
-      ;;
-    aarch64)
-      export GOARCH=arm64
-      ;;
-  esac
-
-  export GOOS=linux
-  export CGO_ENABLED=1
-  export CGO_NO_EMULATION=1
-  export CGO_CFLAGS=$CFLAGS
   export LDFLAGS="-w -extldflags -static -X main.gitCommit=${PKG_GIT_COMMIT} -X main.version=$(cat ./VERSION) -extld $CC"
-  export GOLANG=$TOOLCHAIN/lib/golang/bin/go
-  export GOPATH=$PKG_BUILD/.gopath
-  export GOROOT=$TOOLCHAIN/lib/golang
-  export PATH=$PATH:$GOROOT/bin
 
-  mkdir -p $PKG_BUILD/.gopath
+  mkdir -p ${GOPATH}
   if [ -d $PKG_BUILD/vendor ]; then
-    mv $PKG_BUILD/vendor $PKG_BUILD/.gopath/src
+    mv $PKG_BUILD/vendor ${GOPATH}/src
   fi
 
-  ln -fs $PKG_BUILD $PKG_BUILD/.gopath/src/github.com/opencontainers/runc
+  ln -fs $PKG_BUILD ${GOPATH}/src/github.com/opencontainers/runc
 }
 
 make_target() {

--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,6 @@
+110
+- Update to 1.5.0
+
 109
 - Update to 1.4.2
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.4.2"
-PKG_SHA256="061af43c1bbfcdf949499cdc50a325fff7cd67fb48f9d270adb52b4decbab899"
-PKG_REV="109"
+PKG_VERSION="1.5.0"
+PKG_SHA256="4b4e3c9bbe9dd796919d300118b6817edfe3db9513b067a58591524b3c5a248d"
+PKG_REV="110"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"
@@ -12,7 +12,7 @@ PKG_URL="https://github.com/syncthing/syncthing/releases/download/v${PKG_VERSION
 PKG_DEPENDS_TARGET="toolchain go:host"
 PKG_SECTION="service/system"
 PKG_SHORTDESC="Syncthing: open source continuous file synchronization"
-PKG_LONGDESC="Syncthing ($PKG_VERSION) replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet."
+PKG_LONGDESC="Syncthing (${PKG_VERSION}) replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet."
 PKG_TOOLCHAIN="manual"
 
 PKG_IS_ADDON="yes"
@@ -27,10 +27,11 @@ configure_target() {
 }
 
 make_target() {
-  ${GOLANG} build -v -o bin/syncthing -a -ldflags "${LDFLAGS}" ./cmd/syncthing
+  ${GOLANG} build -a -ldflags "${LDFLAGS}" -o bin/syncthing -v ./cmd/syncthing
 }
 
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-  cp -P ${PKG_BUILD}/bin/syncthing ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P ${PKG_BUILD}/bin/syncthing \
+        ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 }

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -21,35 +21,9 @@ PKG_ADDON_TYPE="xbmc.service"
 PKG_MAINTAINER="Anton Voyl (awiouy)"
 
 configure_target() {
-  export CGO_CFLAGS=${CFLAGS}
-  export CGO_ENABLED=1
-  export CGO_NO_EMULATION=1
-  export GOLANG=${TOOLCHAIN}/lib/golang/bin/go
-  export GOOS=linux
-  export GOROOT=${TOOLCHAIN}/lib/golang
+  go_configure
   export LDFLAGS="-w -linkmode external -extldflags -Wl,--unresolved-symbols=ignore-in-shared-libs -extld ${CC} \
                   -X github.com/syncthing/syncthing/lib/build.Version=v${PKG_VERSION}"
-  export PATH=${PATH}:${GOROOT}/bin
-
-  case $TARGET_ARCH in
-    x86_64)
-      export GOARCH=amd64
-      ;;
-    aarch64)
-      export GOARCH=arm64
-      ;;
-    arm)
-      export GOARCH=arm
-      case $TARGET_CPU in
-        arm1176jzf-s)
-          export GOARM=6
-          ;;
-        *)
-          export GOARM=7
-          ;;
-      esac
-      ;;
-  esac
 }
 
 make_target() {


### PR DESCRIPTION
A couple of issues are now plaguing Jenkins:

1. `syncthing` is running `go generate -v` with a default `GOPATH` that results in `go` modules being installed into `$HOME/go`. Obviously this is messy and wrong, and there is no guarantee this is "thread safe" should multiple `go`-based packages concurrently install modules at the same time into the same `$HOME/go` directory.

2. `syncthing` installs `go` modules with bonkers [read-only file permissions](https://github.com/golang/go/issues/27455) that can't subsequently be deleted when cleaning the package or when deleting the entire build directory - this is breaking Jenkins. When cleaning packages we need to ensure we have read/write access prior to removal. The actual error is:
```
rm: cannot remove '/home/ubuntu/projects/xLibreELEC.tv/build.LibreELEC-RPi2.arm-9.80-devel/build/syncthing-1.2.0/.gopath/pkg/mod/github.com/sasha-s/go-deadlock@v0.2.0/LICENSE': Permission denied
rm: cannot remove '/home/ubuntu/projects/xLibreELEC.tv/build.LibreELEC-RPi2.arm-9.80-devel/build/syncthing-1.2.0/.gopath/pkg/mod/github.com/sasha-s/go-deadlock@v0.2.0/deadlock.go': Permission denied
rm: cannot remove '/home/ubuntu/projects/xLibreELEC.tv/build.LibreELEC-RPi2.arm-9.80-devel/build/syncthing-1.2.0/.gopath/pkg/mod/github.com/sasha-s/go-deadlock@v0.2.0/stacktraces.go': Permission denied
rm: cannot remove '/home/ubuntu/projects/xLibreELEC.tv/build.LibreELEC-RPi2.arm-9.80-devel/build/syncthing-1.2.0/.gopath/pkg/mod/github.com/sasha-s/go-deadlock@v0.2.0/Readme.md': Permission denied
rm: cannot remove '/home/ubuntu/projects/xLibreELEC.tv/build.LibreELEC-RPi2.arm-9.80-devel/build/syncthing-1.2.0/.gopath/pkg/mod/github.com/sasha-s/go-deadlock@v0.2.0/.travis.yml': Permission denied
rm: cannot remove '/home/ubuntu/projects/xLibreELEC.tv/build.LibreELEC-RPi2.arm-9.80-devel/build/syncthing-1.2.0/.gopath/pkg/mod/github.com/sasha-s/go-deadlock@v0.2.0/deadlock_test.go': Permission denied
...
```

Although we can now successfully clean individual packages, users will still experience an error when attempting to delete a build directory that contains a partially or fully built `syncthing` build directory. I don't have a clean solution for this - even running `chmod` in the package isn't guaranteed to be successful.

Jenkins will likely need to be aware of this issue and deal with it specifically when cleaning up.

----

To reduce the amount of duplicated `go` configuration, I've added helper functions.

I've successfully built `docker` and `syncthing` (along with associated add-on dependencies: `containerd`, `runc`, `libnetwork`) without issue for RPi, RPi2 and Generic.

I have **NOT** run-time tested the resulting add-ons.