### PR TITLE
wireless-regdb: update to wireless-regdb-2020.04.29

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2019.06.03"
-PKG_SHA256="cd917ed86b63ce8d93947979f1f18948f03a4ac0ad89ec25227b36ac00dc54bf"
+PKG_VERSION="2020.04.29"
+PKG_SHA256="89fd031aed5977c219a71501e144375a10e7c90d1005d5d086ea7972886a2c7a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://wireless.kernel.org/en/developers/Regulatory"
 PKG_URL="https://www.kernel.org/pub/software/network/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
```
wireless-regdb: update regulatory database based on preceding changes
wireless-regdb: update rules for US on 2.4/5G
GB: Extend to cover DMG channels 5 & 6
wireless-regdb: Update regulatory rules for Singapore (SG)
wireless-regdb: Update regulatory rules for Indonesia (ID)
regdb: fix compatibility with python2
wireless-regdb: Update regulatory rules for Russia (RU)
wireless-regdb: Harmonize ranges of CEPT countries (stand of July 2019)
wireless-regdb: Fix ranges of EU countries as they are harmonized since 2014
wireless-regdb: Extend 5470-5725 MHz range to 5730 MHz for Taiwan (TW)
wireless-regdb: Fix overlapping ranges for Switzerland and Liechtenstein
```