### PR TITLE
 linux: arm: vdso: add vdso_clock_gettime64 syscall for non virtual timers

### DIFF
--- a/packages/linux/patches/default/linux.999.03-arm-vdso-add-vdso_clock_gettime64-phys-timer-syscall.patch
+++ b/packages/linux/patches/default/linux.999.03-arm-vdso-add-vdso_clock_gettime64-phys-timer-syscall.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm/kernel/vdso.c b/arch/arm/kernel/vdso.c
+index e0330a25e1..28cfe7bad1 100644
+--- a/arch/arm/kernel/vdso.c
++++ b/arch/arm/kernel/vdso.c
+@@ -184,6 +184,7 @@ static void __init patch_vdso(void *ehdr)
+ 	if (!cntvct_ok) {
+ 		vdso_nullpatch_one(&einfo, "__vdso_gettimeofday");
+ 		vdso_nullpatch_one(&einfo, "__vdso_clock_gettime");
++		vdso_nullpatch_one(&einfo, "__vdso_clock_gettime64");
+ 	}
+ }
+ 


### PR DESCRIPTION
`glibc-2.31` and kernel 5.6.y+ (and possibly 5.5.y, but not 5.4.y) has erratic date/time due to (most likely) broken or incomplete 32-bit/64-bit y2038 time conversions when using `__vdso_clock_gettime64`.

Disable `__vdso_clock_gettime64` until a fix is available.