### PR TITLE
Dragonboard: temp disable driver-addons to prevent Jenkins failures

### DIFF
--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -89,7 +89,7 @@
     FIRMWARE="misc-firmware wlan-firmware dvb-firmware firmware-dragonboard"
 
   # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="yes"
+    DRIVER_ADDONS_SUPPORT="no"
 
   # driver addons to install:
   # for a list of additional drivers see packages/linux-driver-addons


### PR DESCRIPTION
This disables driver add-ons for the Dragonboard to workaround Jenkins build failures. I'm not sure what the root cause is, but current stats show Dragonboard has zero users (which is not unexpected) so the change does not impact anyone in the real world.