### PR TITLE
v4l-utils: update to 1.18.1

### DIFF
--- a/packages/sysutils/v4l-utils/package.mk
+++ b/packages/sysutils/v4l-utils/package.mk
@@ -5,8 +5,8 @@
 # with 1.0.0 repeat delay is broken. test on upgrade
 
 PKG_NAME="v4l-utils"
-PKG_VERSION="1.18.0"
-PKG_SHA256="6cb60d822eeed20486a03cc23e0fc65956fbc1e85e0c1a7477f68bbd9802880d"
+PKG_VERSION="1.18.1"
+PKG_SHA256="25fc42253722401f8742f04dc50a444dfa9b75378e7d09b55035bcbb44c5f342"
 PKG_LICENSE="GPL"
 PKG_SITE="http://linuxtv.org/"
 PKG_URL="http://linuxtv.org/downloads/v4l-utils/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
Changelog is really boring/minimal, just a build fix for gcc 10

```
v4l-utils-1.18.1
----------------

David Seifert (1):
      Fix GCC 10 / -fno-common
```