### PR TITLE
addons: drop dependency to LE

### DIFF
--- a/config/addon/xbmc.broken.xml
+++ b/config/addon/xbmc.broken.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="3.0.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.python.module.xml
+++ b/config/addon/xbmc.python.module.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="3.0.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.python.script.xml
+++ b/config/addon/xbmc.python.script.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="3.0.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.service.library.xml
+++ b/config/addon/xbmc.service.library.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="3.0.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.service.pluginsource.xml
+++ b/config/addon/xbmc.service.pluginsource.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="3.0.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.service.xml
+++ b/config/addon/xbmc.service.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="3.0.0"/>
 @REQUIRES@
   </requires>

--- a/distributions/LibreELEC/version
+++ b/distributions/LibreELEC/version
@@ -5,4 +5,4 @@
   OS_VERSION="9.80"
 
 # ADDON_VERSION: Addon version
-  ADDON_VERSION="9.80.5"
+  ADDON_VERSION="9.80.6"

--- a/packages/addons/script/script.config.vdr/package.mk
+++ b/packages/addons/script/script.config.vdr/package.mk
@@ -21,7 +21,6 @@ PKG_ADDON_TYPE="dummy"
 
 make_target() {
   sed -e "s|@ADDON_VERSION@|$ADDON_VERSION|g" \
-      -e "s|@OS_VERSION@|$OS_VERSION|g" \
       -i addon.xml
 }
 

--- a/packages/addons/script/script.config.vdr/sources/addon.xml
+++ b/packages/addons/script/script.config.vdr/sources/addon.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="Team LibreELEC">
    <requires>
-     <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
      <import addon="xbmc.python" version="3.0.0"/>
   </requires>
   <extension library="default.py" point="xbmc.python.pluginsource">

--- a/packages/addons/service/touchscreen/addon.xml
+++ b/packages/addons/service/touchscreen/addon.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="3.0.0"/>
 @REQUIRES@
   </requires>

--- a/packages/addons/service/tvheadend42/addon.xml
+++ b/packages/addons/service/tvheadend42/addon.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="3.0.0"/>
 @REQUIRES@
   </requires>

--- a/packages/mediacenter/kodi/config/os.libreelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/os.libreelec.tv/addon.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<addon id="os.libreelec.tv" version="@OS_VERSION@" provider-name="LibreELEC.tv">
-  <requires>
-    <import addon="xbmc.addon" version="12.0"/>
-  </requires>
-</addon>

--- a/packages/mediacenter/kodi/config/os.openelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/os.openelec.tv/addon.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<addon id="os.openelec.tv" version="@OS_VERSION@" provider-name="OpenELEC.tv">
-  <requires>
-    <import addon="xbmc.addon" version="12.0"/>
-  </requires>
-</addon>

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -276,10 +276,6 @@ post_makeinstall_target() {
     ln -sf /usr/bin/pastekodi $INSTALL/usr/bin/pastecrash
 
   mkdir -p $INSTALL/usr/share/kodi/addons
-    cp -R $PKG_DIR/config/os.openelec.tv $INSTALL/usr/share/kodi/addons
-    sed -e "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.openelec.tv/addon.xml
-    cp -R $PKG_DIR/config/os.libreelec.tv $INSTALL/usr/share/kodi/addons
-    sed -e "s|@OS_VERSION@|$OS_VERSION|g" -i $INSTALL/usr/share/kodi/addons/os.libreelec.tv/addon.xml
     cp -R $PKG_DIR/config/repository.libreelec.tv $INSTALL/usr/share/kodi/addons
     sed -e "s|@ADDON_URL@|$ADDON_URL|g" -i $INSTALL/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
     sed -e "s|@ADDON_VERSION@|$ADDON_VERSION|g" -i $INSTALL/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
@@ -316,8 +312,6 @@ post_makeinstall_target() {
   xmlstarlet ed -L -d "/addons/addon[text()='service.xbmc.versioncheck']" $ADDON_MANIFEST
   xmlstarlet ed -L -d "/addons/addon[text()='skin.estouchy']" $ADDON_MANIFEST
   xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "repository.kodi.game" $ADDON_MANIFEST
-  xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "os.libreelec.tv" $ADDON_MANIFEST
-  xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "os.openelec.tv" $ADDON_MANIFEST
   xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "repository.libreelec.tv" $ADDON_MANIFEST
   if [ -n "$DISTRO_PKG_SETTINGS" ]; then
     xmlstarlet ed -L --subnode "/addons" -t elem -n "addon" -v "$DISTRO_PKG_SETTINGS_ID" $ADDON_MANIFEST


### PR DESCRIPTION
Getting rid of the add-on dependency to LE (and OE). 
Since LE9 it creates a annoying confirmation window for every add-on regardless if a dependency is needed or not.
![image](https://user-images.githubusercontent.com/1355173/81101481-80b6d000-8f0e-11ea-9db3-90afa39a512d.png)

- removed requirements for LE addons
- removed requirements for Kodi bin addons
- bump add-on repo version

Drawback: You could now install the addons somewhere else (Windows ...) and they won't work. 
