### PR TITLE
New version of linux causes build to fail with older patch. This one …

### DIFF
--- a/projects/RPi/devices/Slice/patches/linux/linux-999.99-slice-mmc-aliases.patch
+++ b/projects/RPi/devices/Slice/patches/linux/linux-999.99-slice-mmc-aliases.patch
@@ -1,20 +1,13 @@
---- a/arch/arm/boot/dts/bcm2708-rpi.dtsi	2017-11-18 04:56:28.149405247 +0000
-+++ b/arch/arm/boot/dts/bcm2708-rpi.dtsi	2017-11-18 05:35:40.265159491 +0000
-@@ -21,7 +21,7 @@
- 		gpio = &gpio;
- 		uart0 = &uart0;
+--- a/arch/arm/boot/dts/bcm270x-rpi.dtsi	2020-04-29 05:31:07.000000000 -0400
++++ b/arch/arm/boot/dts/bcm270x-rpi.dtsi	2020-05-08 09:07:16.487587235 -0400
+@@ -16,8 +16,8 @@
+ 		uart1 = &uart1;
  		sdhost = &sdhost;
--		mmc0 = &sdhost;
-+		mmc1 = &sdhost;
- 		i2s = &i2s;
- 		spi0 = &spi0;
- 		i2c0 = &i2c0;
-@@ -29,7 +29,7 @@
- 		spi1 = &spi1;
- 		spi2 = &spi2;
  		mmc = &mmc;
 -		mmc1 = &mmc;
+-		mmc0 = &sdhost;
++		mmc1 = &sdhost;
 +		mmc0 = &mmc;
+ 		i2s = &i2s;
+ 		i2c0 = &i2c0;
  		i2c1 = &i2c1;
- 		i2c2 = &i2c2;
- 		usb = &usb;

--- a/projects/RPi/devices/Slice3/patches/linux/linux-999.99-slice-mmc-aliases.patch
+++ b/projects/RPi/devices/Slice3/patches/linux/linux-999.99-slice-mmc-aliases.patch
@@ -1,20 +1,13 @@
---- a/arch/arm/boot/dts/bcm2708-rpi.dtsi	2017-11-18 04:56:28.149405247 +0000
-+++ b/arch/arm/boot/dts/bcm2708-rpi.dtsi	2017-11-18 05:35:40.265159491 +0000
-@@ -21,7 +21,7 @@
- 		gpio = &gpio;
- 		uart0 = &uart0;
+--- a/arch/arm/boot/dts/bcm270x-rpi.dtsi	2020-04-29 05:31:07.000000000 -0400
++++ b/arch/arm/boot/dts/bcm270x-rpi.dtsi	2020-05-08 09:07:16.487587235 -0400
+@@ -16,8 +16,8 @@
+ 		uart1 = &uart1;
  		sdhost = &sdhost;
--		mmc0 = &sdhost;
-+		mmc1 = &sdhost;
- 		i2s = &i2s;
- 		spi0 = &spi0;
- 		i2c0 = &i2c0;
-@@ -29,7 +29,7 @@
- 		spi1 = &spi1;
- 		spi2 = &spi2;
  		mmc = &mmc;
 -		mmc1 = &mmc;
+-		mmc0 = &sdhost;
++		mmc1 = &sdhost;
 +		mmc0 = &mmc;
+ 		i2s = &i2s;
+ 		i2c0 = &i2c0;
  		i2c1 = &i2c1;
- 		i2c2 = &i2c2;
- 		usb = &usb;


### PR DESCRIPTION
…fixes that.

Both Slice and Slice3 were built locally without issues. Unable to test since hardware is not available.