### PR TITLE
Add Dark Mode Toggle in Chrome Add-On

### DIFF
--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,3 +1,6 @@
+103
+- add flag for dark mode
+
 102
 - support for latest Chrome
 

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
-PKG_REV="102"
+PKG_REV="103"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/addons/browser/chrome/source/bin/chrome-start
+++ b/packages/addons/browser/chrome/source/bin/chrome-start
@@ -77,6 +77,12 @@ if [ ! -z $ALSA_DEVICE ]; then
   chrome_OPTS="$chrome_OPTS --alsa-output-device=$ALSA_DEVICE"
 fi
 
+# dark mode
+if [ "$DARK_MODE" == "true" ]
+then
+  chrome_OPTS="$chrome_OPTS --force-dark-mode"
+fi
+
 # HACK!!! to get sound at Chrome stop pulseaudio
 systemctl stop pulseaudio
 

--- a/packages/addons/browser/chrome/source/default.py
+++ b/packages/addons/browser/chrome/source/default.py
@@ -35,6 +35,7 @@ def startchrome(args):
     new_env['VAAPI_MODE'] = __addon__.getSetting('VAAPI_MODE')
     new_env['WINDOW_MODE'] = __addon__.getSetting('WINDOW_MODE')
     new_env['RASTER_MODE'] = __addon__.getSetting('RASTER_MODE')
+    new_env['DARK_MODE'] = __addon__.getSetting('DARK_MODE')
 
     new_env['ALSA_DEVICE'] = ''
     if __addon__.getSetting('USE_CUST_AUDIODEVICE') == 'true':

--- a/packages/addons/browser/chrome/source/resources/language/English/strings.po
+++ b/packages/addons/browser/chrome/source/resources/language/English/strings.po
@@ -44,3 +44,7 @@ msgstr ""
 msgctxt "#30009"
 msgid "Hide Cursor"
 msgstr ""
+
+msgctxt "#30010"
+msgid "Dark Mode"
+msgstr ""

--- a/packages/addons/browser/chrome/source/resources/settings.xml
+++ b/packages/addons/browser/chrome/source/resources/settings.xml
@@ -11,5 +11,6 @@
         <setting id="USE_CUST_AUDIODEVICE" type="bool" label="30007" default="false" />
         <setting id="CUST_AUDIODEVICE_STR" type="text" label="30008" visible="eq(-1,true)" subsetting="true" default="" />
         <setting id="HIDE_CURSOR" type="bool" label="30009" default="false" />
+        <setting id="DARK_MODE" type="bool" label="30010" default="false" />
     </category>
 </settings>

--- a/packages/addons/browser/chrome/source/settings-default.xml
+++ b/packages/addons/browser/chrome/source/settings-default.xml
@@ -7,4 +7,5 @@
     <setting id="USE_CUST_AUDIODEVICE" default="true">false</setting>
     <setting id="VAAPI_MODE" default="true">intel</setting>
     <setting id="WINDOW_MODE" default="true">maximized</setting>
+    <setting id="DARK_MODE" default="true">false</setting>   
 </settings>


### PR DESCRIPTION
Add a Dark Mode Toggle in Settings. 

Appends Chrome `--force-dark-mode` flag to enable Dark Mode for the browser. 

Defaults to Dark Mode off.