### PR TITLE
RTL8821CU: add package

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -68,7 +68,7 @@
 # for a list of additional drivers see packages/linux-drivers
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU"
+  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU RTL8821CU"
 
 # build and install bluetooth support (yes / no)
   BLUETOOTH_SUPPORT="yes"

--- a/packages/linux-drivers/RTL8821CU/package.mk
+++ b/packages/linux-drivers/RTL8821CU/package.mk
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2020-present Alexander Amelkin (alexander@amelkin.msk.ru)
+
+PKG_NAME="RTL8821CU"
+PKG_VERSION="2bebdb9a35c1d9b6e6a928e371fa39d5fcec8a62"
+PKG_SHA256="e6d2fde8d3d4a857e9f6089378034716ce7b8406f790d789edfc46e469512dae"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/brektrou/rtl8821CU"
+PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
+PKG_LONGDESC="Realtek RTL8821CU Linux 5.x driver"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make V=1 \
+       ARCH=$TARGET_KERNEL_ARCH \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
+       CONFIG_POWER_SAVING=n 2>&1 | tee /tmp/make.log
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+    cp *.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME
+}

--- a/packages/linux-drivers/RTL8821CU/patches/0001-Disable-the-floating-poing-features.patch
+++ b/packages/linux-drivers/RTL8821CU/patches/0001-Disable-the-floating-poing-features.patch
@@ -1,0 +1,31 @@
+From a4386054dbb96267cd5eeb23490cefb26f80dbc7 Mon Sep 17 00:00:00 2001
+From: Alexander Amelkin <alexander@amelkin.msk.ru>
+Date: Sun, 17 May 2020 00:34:03 +0300
+Subject: [PATCH] Disable the floating poing features
+
+With CONFIG_MP_VHT_HW_TX_MODE enabled the build wants
+to use -mfloat-abi=hard which conflicts with the LibreELEC
+-msoft-float. This patch disables the MP_VHT_HW_TX_MODE
+to get rid of the floating point ABI dependency.
+
+Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 6a065bf..d7aad0b 100755
+--- a/Makefile
++++ b/Makefile
+@@ -99,7 +99,7 @@ CONFIG_AP_WOWLAN = n
+ ######### Notify SDIO Host Keep Power During Syspend ##########
+ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+ ###################### MP HW TX MODE FOR VHT #######################
+-CONFIG_MP_VHT_HW_TX_MODE = y
++CONFIG_MP_VHT_HW_TX_MODE = n
+ ###################### Platform Related #######################
+ CONFIG_PLATFORM_I386_PC = y
+ CONFIG_PLATFORM_ARM_RPI = n
+-- 
+2.17.1
+


### PR DESCRIPTION
This adds support for RTL8821CU USB WiFi dongles.

If you know how to filter out the standard `-msoft-float` option so that it doesn't clash with the package's `-mfloat-abi=hard`, I would appreciate that. I couldn't find a way, so I just disabled the feature that wants floating point with a patch. Everyting seems to work fine without that feature.

This PR has been verified by me against LibreELEC 9.2.2