### PR TITLE
Kodi binary addons update

### DIFF
--- a/packages/graphics/lcms2/package.mk
+++ b/packages/graphics/lcms2/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="lcms2"
+PKG_VERSION="2.9"
+PKG_SHA256="8e23a09dc81af856db37941a4ea26acdf6a45b0281ec5b7ee94b5a4e9f7afbf7"
+PKG_LICENSE="MIT"
+PKG_SITE="http://www.littlecms.com"
+PKG_URL="https://github.com/mm2/Little-CMS/archive/lcms${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tiff"
+PKG_LONGDESC="An small-footprint color management engine, with special focus on accuracy and performance."

--- a/packages/graphics/libraw/package.mk
+++ b/packages/graphics/libraw/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="40a262d7cc71702711a0faec106118ee004f86c86cc228281d12d16da03e02f5"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libraw.org/"
 PKG_URL="http://www.libraw.org/data/LibRaw-$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain libjpeg-turbo"
+PKG_DEPENDS_TARGET="toolchain libjpeg-turbo lcms2"
 PKG_LONGDESC="A library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)"
 PKG_BUILD_FLAGS="+pic"
 
@@ -16,5 +16,5 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-openmp \
                            --enable-jpeg \
                            --disable-jasper \
-                           --disable-lcms \
+                           --enable-lcms \
                            --disable-examples"

--- a/packages/graphics/libraw/package.mk
+++ b/packages/graphics/libraw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libraw"
-PKG_VERSION="0.19.2"
-PKG_SHA256="400d47969292291d297873a06fb0535ccce70728117463927ddd9452aa849644"
+PKG_VERSION="0.19.5"
+PKG_SHA256="40a262d7cc71702711a0faec106118ee004f86c86cc228281d12d16da03e02f5"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libraw.org/"
 PKG_URL="http://www.libraw.org/data/LibRaw-$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.mpo"
-PKG_VERSION="1.1.0-Leia"
-PKG_SHA256="1aa166cfad9feb1521a7cc4432900a1f9f0b0afc686c25358ab65f1d32c60621"
+PKG_VERSION="1.1.2-Leia"
+PKG_SHA256="e0eaad1ff7ffbca13bf4d38be2c7c1acf8127c6c55f3d06940166f4775e6c2ab"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.raw"
-PKG_VERSION="2.0.1-Leia"
-PKG_SHA256="bbc8c6f5c3e9d418616a7f614973bc425eb8748cd8643623065bb2071e54c78b"
-PKG_REV="2"
+PKG_VERSION="2.1.2-Leia"
+PKG_SHA256="8f1b38e7a1412cc36e2c2648af5f8b92ad4dc08e3723930ae8324c4224aa6b90"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.raw"

--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="3.5.4-Leia"
-PKG_SHA256="2d0fae3721715a17e1c1454dd7029eb8d18e7f761ed65e00f8c488c7c08433e8"
-PKG_REV="4"
+PKG_VERSION="3.5.6-Leia"
+PKG_SHA256="7bfedb27b2aec4015b2594df18b76fe42e97ec10f4b5cb9c6987b1a7a264c844"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.argustv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="3.6.1-Leia"
-PKG_SHA256="0d35d1bd968e67a504c16b222bbfb3b79e6f64c5bd430d567c8caf9940d1ebba"
-PKG_REV="4"
+PKG_VERSION="3.6.3-Leia"
+PKG_SHA256="2ab870941c0cc29786332df12d94d2e4a87e137709d1618a52ca3b64c9e04596"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.demo"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.filmon"
-PKG_VERSION="2.4.4-Leia"
-PKG_SHA256="763500fb4a7210569f05dba8307d400e532dd0e72b24f1a1d2cd516695145190"
-PKG_REV="4"
+PKG_VERSION="2.4.6-Leia"
+PKG_SHA256="90988e4833c0f84ab08e08be3cd08b84e4ba2baf2ebc1545c62e5dbd6708d749"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.filmon"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="5.10.15-Leia"
-PKG_SHA256="36d9142e0e19b904e1c4a6d8cd67063d291e63971f80a98a6f24b7f4554bb2e3"
+PKG_VERSION="5.10.16-Leia"
+PKG_SHA256="fef27e73009f095a22e4843e48455a343a4fe095ae9692b9fa96ffac7fb0844c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.pctv"
-PKG_VERSION="2.4.5-Leia"
-PKG_SHA256="a9f1c5596786cf4cfa279d0b4477839ef7f5bb7267c65152dbcf7ae0bda56679"
-PKG_REV="4"
+PKG_VERSION="2.4.7-Leia"
+PKG_SHA256="10124e5444c6cfb0c77bad1d1122f6ba5fc233248d6b33066ba799f4dedceeee"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.pctv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.sledovanitv.cz"
-PKG_VERSION="1.7.0-Leia"
-PKG_SHA256="b46ad6132a830bf64feab8f298094cf07ddadfb56859a5908430b8c0c2db7b4f"
+PKG_VERSION="1.8.0-Leia"
+PKG_SHA256="872fb25dace7bddcb2726d30ce308e9f290a7fcbccbca544b436e5728cacdce4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="2.4.5-Leia"
-PKG_SHA256="4cb81f29cba23172d042e50bbab00cd64cd5670ad7350fd9d25301f63178e5f7"
+PKG_VERSION="2.4.6-Leia"
+PKG_SHA256="7fb150ba3b8b41cf164425b56ae5dda3a5fb2f64cdea7229900113965d492fee"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="18.1.17-Leia"
-PKG_SHA256="3bf466e4d477b57b313689bbcdbef8b1e017d3e6687cd87edc3a7da25daf6a51"
+PKG_VERSION="18.1.19-Leia"
+PKG_SHA256="36dedc8bc6b95aa6036d0e5aa94d90f7d965f57325cc858ad6bcc401f371d3ed"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- imagedecoder.raw requires now lcms2 build along with libraw 0.19.5
- all binary addons updated
