### PR TITLE
uboot_helper: added support for Pine H64 Model B

### DIFF
--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -138,6 +138,10 @@ devices = \
         'dtb': 'sun50i-h6-pine-h64.dtb',
         'config': 'pine_h64_defconfig'
       },
+      'pine-h64b': {
+        'dtb': 'sun50i-h6-pine-h64-model-b.dtb',
+        'config': 'pine_h64_defconfig'
+      },
       'tanix-tx6' : {
         'dtb' : 'sun50i-h6-tanix-tx6.dtb',
         'config' : 'eachlink_h6_mini_defconfig'

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -138,7 +138,7 @@ devices = \
         'dtb': 'sun50i-h6-pine-h64.dtb',
         'config': 'pine_h64_defconfig'
       },
-      'pine-h64b': {
+      'pine-h64-model-b': {
         'dtb': 'sun50i-h6-pine-h64-model-b.dtb',
         'config': 'pine_h64_defconfig'
       },


### PR DESCRIPTION
The dtb for the Pine H64 Model B is created during the build, but the target image isn't created for DEVICE=H6 and can't be selected with UBOOT_SYSTEM=

The ethernet configuration in the image created for the original Pine H64 board doesn't work on the model B board.