### PR TITLE
Allwinner: Disable non-working Kodi settings

### DIFF
--- a/projects/Allwinner/kodi/appliance.xml
+++ b/projects/Allwinner/kodi/appliance.xml
@@ -4,6 +4,10 @@
   <section id="system">
     <category id="display">
       <group id="1">
+        <setting id="videoscreen.limitedrange">
+          <default>false</default>
+          <visible>false</visible>
+        </setting>
         <setting id="videoscreen.limitguisize">
           <visible>false</visible>
           <default>3</default>
@@ -14,6 +18,12 @@
       <group id="1">
         <setting id="audiooutput.audiodevice">
           <default>ALSA:hdmi:CARD=allwinnerhdmi,DEV=0</default>
+        </setting>
+      </group>
+      <group id="3">
+        <visible>false</visible>
+        <setting id="audiooutput.passthrough">
+          <default>false</default>
         </setting>
       </group>
     </category>


### PR DESCRIPTION
This PR disables two things:
limited range selection - this is automatically handled by HDMI driver
audio passthrough - driver and alsa lib are not fixed yet to support it