### PR TITLE
Make docker not slowing down boot proccess

### DIFF
--- a/packages/addons/service/docker/source/system.d/service.system.docker.service
+++ b/packages/addons/service/docker/source/system.d/service.system.docker.service
@@ -4,7 +4,7 @@ Documentation=https://docs.docker.com
 After=network.target
 
 [Service]
-Type=notify
+Type=idle
 Environment=PATH=/bin:/sbin:/usr/bin:/usr/sbin:/storage/.kodi/addons/service.system.docker/bin
 ExecStartPre=/storage/.kodi/addons/service.system.docker/bin/docker-config
 EnvironmentFile=-/storage/.kodi/userdata/addon_data/service.system.docker/config/docker.conf


### PR DESCRIPTION
If you have multiple docker containers, boot process is slowing down drastically. Lets docker starting lastly.