### PR TITLE
tools/docker: add libparse-yapp-perl and more

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,17 +1,27 @@
 # Build container
 
-**Clone repo**
+**Build docker image**
 
-* `cd ~/`
-* `git clone https://github.com/LibreELEC/LibreELEC.tv.git LibreELEC`
+Use the following command to create a docker image and tag it with `libreelec`.
 
-**Build container**
+```
+docker build --pull -t libreelec tools/docker/focal
+```
 
-* `cd ~/LibreELEC`
-* `docker build --pull -t libreelec tools/docker/bionic`
+See https://docs.docker.com/engine/reference/commandline/build/ for details on `docker build` usage.
 
-**Build image inside container**
+**Build LibreELEC image inside a container**
 
-* `docker run -v ~/:/home/docker -h libreelec -it libreelec`
-* `cd ~/LibreELEC`
-* `make image`
+Use the following command to build LibreELEC images inside a new container based on the docker image tagged with `libreelec`.
+
+```
+docker run --rm -v `pwd`:/build -w /build -it libreelec make image
+```
+
+Use `--env`, `-e` or `--env-file` to pass environment variables used by the LibreELEC buildsystem.
+
+```
+docker run --rm -v `pwd`:/build -w /build -it -e PROJECT=RPi -e DEVICE=RPi4 -e ARCH=arm libreelec make image
+```
+
+See https://docs.docker.com/engine/reference/commandline/run/ for details on `docker run` usage.

--- a/tools/docker/bionic/Dockerfile
+++ b/tools/docker/bionic/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
-    libjson-perl libxml-parser-perl \
+    libjson-perl libxml-parser-perl libparse-yapp-perl \
     golang-go \
     git openssh-client \
     --no-install-recommends \

--- a/tools/docker/buster/Dockerfile
+++ b/tools/docker/buster/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:buster
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y locales sudo \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+ && locale-gen en_US.UTF-8 \
+ && update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+RUN adduser --disabled-password --gecos '' docker \
+ && adduser docker sudo \
+ && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN apt-get update && apt-get install -y \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    g++ xfonts-utils xsltproc default-jre-headless python3 \
+    libc6-dev libncurses5-dev \
+    libjson-perl libxml-parser-perl libparse-yapp-perl \
+    golang-go \
+    git openssh-client \
+    --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
+
+USER docker

--- a/tools/docker/eoan/Dockerfile
+++ b/tools/docker/eoan/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
-    libjson-perl libxml-parser-perl \
+    libjson-perl libxml-parser-perl libparse-yapp-perl \
     golang-go \
     git openssh-client \
     --no-install-recommends \

--- a/tools/docker/focal/Dockerfile
+++ b/tools/docker/focal/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y locales sudo \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8 \
+ && update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+RUN adduser --disabled-password --gecos '' docker \
+ && adduser docker sudo \
+ && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN apt-get update && apt-get install -y \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    g++ xfonts-utils xsltproc default-jre-headless python3 \
+    libc6-dev libncurses5-dev \
+    libjson-perl libxml-parser-perl libparse-yapp-perl \
+    golang-go \
+    git openssh-client \
+    --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
+
+USER docker

--- a/tools/docker/stretch/Dockerfile
+++ b/tools/docker/stretch/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
-    libjson-perl libxml-parser-perl \
+    libjson-perl libxml-parser-perl libparse-yapp-perl \
     golang-go \
     git openssh-client \
     --no-install-recommends \

--- a/tools/docker/xenial/Dockerfile
+++ b/tools/docker/xenial/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
-    libjson-perl libxml-parser-perl \
+    libjson-perl libxml-parser-perl libparse-yapp-perl \
     golang-go \
     git openssh-client \
     --no-install-recommends \


### PR DESCRIPTION
This PR adds `libparse-yapp-perl` to the `Dockerfile`'s in `tools/docker` that was added to `scripts/checkdeps` in #4240, also adds a `buster` and `focal` container and changes to recommend `focal` in readme.