### PR TITLE
[le11] build: LDFLAGS cleanup

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -31,5 +31,5 @@
   TARGET_CFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mabi=lp64 -Wno-psabi -mtune=$TARGET_CPU"
 # Disable runtime checking support of ARMv8.0's optional LSE feature. Breaks gdb and mesa compile.
   TARGET_CFLAGS="${TARGET_CFLAGS} -mno-outline-atomics"
-  TARGET_LDFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mtune=$TARGET_CPU"
+  TARGET_LDFLAGS=""
   TARGET_ARCH_GCC_OPTS="--with-abi=lp64 --with-arch=$TARGET_VARIANT"

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -71,6 +71,6 @@
 # setup ARCH specific *FLAGS
   TARGET_CFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64"
   [ -n "$TARGET_FPU" ] && TARGET_CFLAGS="$TARGET_CFLAGS $TARGET_FPU_FLAGS"
-  TARGET_LDFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU"
+  TARGET_LDFLAGS=""
   TARGET_ARCH_GCC_OPTS="--with-abi=aapcs-linux --with-arch=$TARGET_SUBARCH --with-float=$TARGET_FLOAT --with-fpu=$TARGET_FPU"
   TARGET_CXXFLAGS="-D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64"

--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -11,7 +11,7 @@
 
 # setup ARCH specific *FLAGS
   TARGET_CFLAGS="-march=${TARGET_CPU}"
-  TARGET_LDFLAGS="-march=${TARGET_CPU}"
+  TARGET_LDFLAGS=""
 
 # build with microarchitecture feature support defined by the TARGET_CPU value
 # see https://gitlab.com/x86-psABIs/x86-64-ABI/-/wikis/home for further details


### PR DESCRIPTION
This removes march & mtune from LDFLAGS. I don't know why they were added. Way back when, when using LTO, C(XX)FLAGS were added en masse to LDFLAGS, but that's not what this is doing. Generic's '-m64' is probably superfluous but I don't build generic / want to speak with authority on it.

The flags added, sort-common, and O1 in non-debug both relate to application start up performance, which should mostly translate to a faster boot time.

Wider testing appreciated.