### PR TITLE
 wait-time-sync: new package to reliable detect ntp synchronized system time

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="f34f1dc52b2dc60563c2deb6db86d78f6a97bceb29aa0511436844b2fc618040"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd/archive/v$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain libcap kmod util-linux entropy libidn2"
+PKG_DEPENDS_TARGET="toolchain libcap kmod util-linux entropy libidn2 wait-time-sync"
 PKG_LONGDESC="A system and session manager for Linux, compatible with SysV and LSB init scripts."
 
 PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
@@ -194,6 +194,10 @@ post_makeinstall_target() {
 
   # remove networkd
   safe_remove $INSTALL/usr/lib/systemd/network
+
+  # remove systemd-time-wait-sync (not detecting slew time updates, using package wait-time-sync)
+  safe_remove $INSTALL/usr/lib/systemd/system/systemd-time-wait-sync.service
+  safe_remove $INSTALL/usr/lib/systemd/systemd-time-wait-sync
 
   # tune journald.conf
   sed -e "s,^.*Compress=.*$,Compress=no,g" -i $INSTALL/etc/systemd/journald.conf

--- a/packages/sysutils/wait-time-sync/package.mk
+++ b/packages/sysutils/wait-time-sync/package.mk
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="wait-time-sync"
+PKG_VERSION="1.0"
+PKG_LICENSE="GPL"
+PKG_SITE=""
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="A simple tool and systemd service to wait until NTP time is synced"
+
+
+post_install() {
+  enable_service wait-time-sync.service
+}

--- a/packages/sysutils/wait-time-sync/sources/Makefile
+++ b/packages/sysutils/wait-time-sync/sources/Makefile
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+.PHONY: all
+all: wait-time-sync
+
+PREFIX = /usr
+
+.PHONY: install
+install: wait-time-sync
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install $< $(DESTDIR)$(PREFIX)/bin

--- a/packages/sysutils/wait-time-sync/sources/wait-time-sync.c
+++ b/packages/sysutils/wait-time-sync/sources/wait-time-sync.c
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv) */
+
+#include <sys/timex.h>
+#include <unistd.h>
+#include <errno.h>
+
+int main()
+{
+  int rc;
+
+  for (;;)
+  {
+    struct timex tx = {};
+
+    rc = adjtimex(&tx);
+    if (rc != TIME_ERROR)
+      break;
+    usleep(1000000U/3);
+  }
+
+  return rc == -1 ? errno : 0;
+}

--- a/packages/sysutils/wait-time-sync/system.d/wait-time-sync.service
+++ b/packages/sysutils/wait-time-sync/system.d/wait-time-sync.service
@@ -1,0 +1,28 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file was part of systemd.
+#  Modified by Team LibreELEC (https://libreelec.tv)
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Wait For Kernel Time Synchronized
+
+ConditionVirtualization=!container
+
+DefaultDependencies=no
+Before=time-sync.target shutdown.target
+Wants=time-sync.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/wait-time-sync
+TimeoutStartSec=infinity
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
There was some [discussion in the forum](https://forum.libreelec.tv/thread/21906-wireguard-changes-the-default-route-although-not-configured/?postID=140348#post140348) that wireguard requires time-sync.target on systems without RTC.

Unfortunately the default systemd-time-wait-sync binary fails to detect system time slew adjusts and randomly hangs on devices with RTC (i.e. X86_64). The behavior is documented in the source, see [time-wait-sync.c](https://github.com/systemd/systemd/blob/v245/src/time-wait-sync/time-wait-sync.c#L117-L139).

Use the simple wait-time-sync tool instead.

(Only) tested on my Generic installation.