### PR TITLE
wireguard: bump packages and use wait-time-sync

### DIFF
--- a/packages/network/wireguard-linux-compat/package.mk
+++ b/packages/network/wireguard-linux-compat/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-linux-compat"
-PKG_VERSION="v1.0.20200401"
-PKG_SHA256="e80e6c6386217585640974106cf6f9a0a8a8fb91a4f75e943c0a39a204a3045f"
+PKG_VERSION="v1.0.20200611"
+PKG_SHA256="0a15a6b9798d4df660093eca3e9cc8a9058b3a50130111182348a238e82911be"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-$PKG_VERSION.tar.xz"

--- a/packages/network/wireguard-tools/config/system.d/wireguard.service.sample
+++ b/packages/network/wireguard-tools/config/system.d/wireguard.service.sample
@@ -1,7 +1,7 @@
 [Unit]
 Description=WireGuard VPN Service
-After=network-online.target nss-lookup.target connman-vpn.service
-Wants=network-online.target nss-lookup.target connman-vpn.service
+After=network-online.target nss-lookup.target connman-vpn.service time-sync.target
+Wants=network-online.target nss-lookup.target connman-vpn.service time-sync.target
 
 [Service]
 Type=oneshot

--- a/packages/network/wireguard-tools/package.mk
+++ b/packages/network/wireguard-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-tools"
-PKG_VERSION="v1.0.20200319"
-PKG_SHA256="bba0d33f29412ad80dfd4426b088a6485bb0991f8071c45439895b7140271336"
+PKG_VERSION="v1.0.20200513"
+PKG_SHA256="4effe7e9c79b70d6ff17a78bdf4e16fb02d4e6711f85beeaea80db5b11435fdb"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
Add a dependency on `wait-time-sync.service` to the sample wireguard service and bump the wireguard-linux-compat and tools packages to current versions.