### PR TITLE
vdr-plugin-xmltv2vdr: fix epgdata2xmltv static linking issue

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/patches/vdr-plugin-xmltv2vdr-03-fix-epgdata2xmltv-linking.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/patches/vdr-plugin-xmltv2vdr-03-fix-epgdata2xmltv-linking.patch
@@ -1,0 +1,12 @@
+diff -ru vdr-plugin-xmltv2vdr.orig/dist/epgdata2xmltv/Makefile vdr-plugin-xmltv2vdr/dist/epgdata2xmltv/Makefile
+--- vdr-plugin-xmltv2vdr.orig/dist/epgdata2xmltv/Makefile	2017-03-20 18:08:49.000000000 +0100
++++ vdr-plugin-xmltv2vdr/dist/epgdata2xmltv/Makefile	2020-06-17 12:34:35.472188515 +0200
+@@ -19,7 +19,7 @@
+ DEFINES += -D__STDC_CONSTANT_MACROS -D__USE_XOPEN_EXTENDED
+ 
+ INCLUDES += $(shell $(PKG-CONFIG) --cflags $(PKG-INCLUDES))
+-LIBS     += $(shell $(PKG-CONFIG) --libs $(PKG-LIBS)) 
++LIBS     += $(shell $(PKG-CONFIG) --libs --static $(PKG-LIBS)) 
+ 
+ INCLUDES += -I..
+ 


### PR DESCRIPTION
this fixes vdr-addon build failure

build-tested for RPi4