### PR TITLE
init: only touch /dev/.kernel_ipconfig when network is configured manually

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -1055,9 +1055,6 @@ for arg in $(cat /proc/cmdline); do
     bigfont=*)
       BIGFONT="${arg#*=}"
       ;;
-    ip=*)
-      KERNEL_IPCONFIG="yes"
-      ;;
   esac
 done
 
@@ -1125,7 +1122,12 @@ if [ "$FLASH_NETBOOT" = "yes" ]; then
   echo "" > /sysroot/dev/.flash_netboot
 fi
 
-if [ "$KERNEL_IPCONFIG" = "yes" ]; then
+# Tell userspace if network was configured manually via kernel-level IP
+# autoconfiguration, so systemd can avoid starting daemons that reconfigure the
+# interface (don't do this if DHCP was used: the interface will still need to be
+# managed in userspace, because the kernel doesn't contain a DHCP client daemon
+# to keep the lease active)
+if grep -qx '#PROTO: MANUAL' /proc/net/pnp 2>/dev/null; then
   echo "" > /sysroot/dev/.kernel_ipconfig
 fi
 


### PR DESCRIPTION
Using kernel-level IP autoconfiguration, network interfaces can be configured either manually (e.g. `ip=10.0.0.10:...`) or via DHCP (`ip=dhcp`). The IP autoconfiguration functionality in the kernel is [only intended to be used to configure the network sufficiently to mount the root filesystem via NFS](https://www.kernel.org/doc/html/latest/admin-guide/nfs/nfsroot.html); in particular, the kernel doesn't attempt to keep any DHCP lease active, so in this case the interface still needs to be managed in userspace after the system finishes booting. The technique of touching `/dev/.kernel_ipconfig` to inhibit systemd from starting network management daemons therefore shouldn't be used if DHCP-based IP autoconfiguration is used; instead, ConnMan should be allowed to take over management of the interface.

Tested on a RPi3 using an `RPi2` build.