### PR TITLE
apache-ant: make sure ${TOOLCHAIN}/bin exists

### DIFF
--- a/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
+++ b/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
@@ -17,5 +17,6 @@ makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/apache-ant/lib
     cp bin/ant ${TOOLCHAIN}/apache-ant/bin
     cp lib/*.jar ${TOOLCHAIN}/apache-ant/lib
+  mkdir -p ${TOOLCHAIN}/bin
     ln -sf ${TOOLCHAIN}/apache-ant/bin/ant ${TOOLCHAIN}/bin/ant
 }


### PR DESCRIPTION
this was accidentally removed in 387c11e253