### PR TITLE
Update SSL 1.1 patches

### DIFF
--- a/packages/multimedia/rtmpdump/patches/002_build-with-openssl11.patch
+++ b/packages/multimedia/rtmpdump/patches/002_build-with-openssl11.patch
@@ -1,9 +1,6 @@
-Source: https://github.com/xbmc/inputstream.rtmp/tree/master/depends/common/librtmp
-Date: 21. Oct 2018
-
 --- a/librtmp/dh.h
 +++ b/librtmp/dh.h
-@@ -253,20 +253,44 @@
+@@ -253,20 +253,42 @@
    if (!dh)
      goto failed;
  
@@ -17,8 +14,6 @@ Date: 21. Oct 2018
 +  MP_new(g);
 +  if (!g)
 +    goto failed;
-+
-+  DH_set0_pqg(dh, NULL, g, NULL);
 +#endif
  
 +#if !defined(USE_OPENSSL) || !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -37,7 +32,7 @@ Date: 21. Oct 2018
    MP_set_w(dh->g, 2);	/* base 2 */
 +#else
 +  MP_set_w(g, 2);   /* base 2 */
-+  DH_set0_pqg(dh, NULL, g, NULL);
++  DH_set0_pqg(dh, p, NULL, g);
 +#endif
  
 +#if !defined(USE_OPENSSL) || !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -48,7 +43,7 @@ Date: 21. Oct 2018
    return dh;
  
  failed:
-@@ -293,12 +317,24 @@
+@@ -293,12 +315,24 @@
        MP_gethex(q1, Q1024, res);
        assert(res);
  
@@ -73,7 +68,7 @@ Date: 21. Oct 2018
  	}
  
        MP_free(q1);
-@@ -314,15 +350,29 @@
+@@ -314,15 +348,29 @@
  DHGetPublicKey(MDH *dh, uint8_t *pubkey, size_t nPubkeyLen)
  {
    int len;
@@ -103,7 +98,7 @@ Date: 21. Oct 2018
    return 1;
  }
  
-@@ -364,7 +414,13 @@
+@@ -364,7 +412,13 @@
    MP_gethex(q1, Q1024, len);
    assert(len);
  
@@ -161,7 +156,7 @@ Date: 21. Oct 2018
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +#define HMAC_setup(ctx, key, len)	HMAC_CTX_init(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#else
-+#define HMAC_setup(ctx, key, len)       HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
++#define HMAC_setup(ctx, key, len)	ctx = HMAC_CTX_new(); HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#endif
 +#define HMAC_crunch(ctx, buf, len)	HMAC_Update(ctx, buf, len)
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -228,7 +223,7 @@ Date: 21. Oct 2018
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +#define HMAC_setup(ctx, key, len)	HMAC_CTX_init(ctx); HMAC_Init_ex(ctx, (unsigned char *)key, len, EVP_sha256(), 0)
 +#else
-+#define HMAC_setup(ctx, key, len) HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, (unsigned char *)key, len, EVP_sha256(), 0)
++#define HMAC_setup(ctx, key, len)	ctx = HMAC_CTX_new(); HMAC_CTX_reset(ctx); HMAC_Init_ex(ctx, key, len, EVP_sha256(), 0)
 +#endif
 +#define HMAC_crunch(ctx, buf, len)	HMAC_Update(ctx, (unsigned char *)buf, len)
 +#define HMAC_finish(ctx, dig, dlen)	HMAC_Final(ctx, (unsigned char *)dig, &dlen);


### PR DESCRIPTION
This patch update fixes issues with rtmpe streams and swf hash auto-calculation causing core dumps and Kodi crashes.

For more info, refer to https://github.com/xbmc/inputstream.rtmp/pull/46