### PR TITLE
dav1d: update to 0.7.1

### DIFF
--- a/packages/multimedia/dav1d/package.mk
+++ b/packages/multimedia/dav1d/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dav1d"
-PKG_VERSION="0.7.0"
-PKG_SHA256="8057149f5f08c5ca47e1344fba9046ff84ac85ca409d7adbec8268c707ec5c19"
+PKG_VERSION="0.7.1"
+PKG_SHA256="9eac4f50089f54a9f562827bda4a21187d68c01d8b20055eef1d7efca9f84cf8"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.jbkempf.com/blog/post/2018/Introducing-dav1d"
 PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/dav1d-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
```
This release increases the speed of decoding on ARM32 by up to 28%,
adds some SSE2 optimizations, some AVX2 for MC scaled
and fixes a couple of minor issues.
```

builds for generic and armv8