### PR TITLE
ffmpeg tools update

### DIFF
--- a/packages/addons/addon-depends/ffmpegx-depends/libvpx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/libvpx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libvpx"
-PKG_VERSION="1.8.1"
-PKG_SHA256="df19b8f24758e90640e1ab228ab4a4676ec3df19d23e4593375e6f3847dee03e"
+PKG_VERSION="1.8.2"
+PKG_SHA256="8735d9fcd1a781ae6917f28f239a8aa358ce4864ba113ea18af4bb2dc8b474ac"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="https://github.com/webmproject/libvpx/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="x265"
-PKG_VERSION="3.2"
-PKG_SHA256="364d79bcd56116a9e070fdeb1d9d2aaef1a786b4970163fb56ff0991a183133b"
+PKG_VERSION="3.4"
+PKG_SHA256="c2047f23a6b729e5c70280d23223cb61b57bfe4ad4e8f1471eeee2a61d148672"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.videolan.org/developers/x265.html"
-PKG_URL="http://download.videolan.org/pub/videolan/x265/${PKG_NAME}_${PKG_VERSION}.tar.gz"
+PKG_URL="https://bitbucket.org/multicoreware/x265/downloads/x265_${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="x265 is a H.265/HEVC video encoder application library"
 PKG_TOOLCHAIN="make"

--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ffmpegx"
-PKG_VERSION="4.2.1"
-PKG_SHA256="cec7c87e9b60d174509e263ac4011b522385fd0775292e1670ecc1180c9bb6d4"
+PKG_VERSION="4.3"
+PKG_SHA256="1d0ad06484f44bcb97eba5e93c40bcb893890f9f64aeb43e46cd9bb4cbd6795d"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="https://ffmpeg.org/releases/ffmpeg-$PKG_VERSION.tar.xz"

--- a/packages/addons/tools/ffmpeg-tools/changelog.txt
+++ b/packages/addons/tools/ffmpeg-tools/changelog.txt
@@ -1,3 +1,9 @@
+111
+- Update AV1 to 2020-06-20
+- Update FFmpeg to 4.3
+- Update VPX to 1.8.2
+- Update x265 to 3.4
+
 110
 - Update AV1 to 2019-11-15
 - Update FFmpeg to 4.2.1

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="110"
+PKG_REV="111"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="990da97d18a80dcdb0cb291ffb91e284e2e25320"
-PKG_SHA256="830cc4b00a5fb747144218f1a6bf48c4ddff49670d95acda61313502520c236b"
+PKG_VERSION="8c113ea88bc5afc1d5d7001c8dedbde7af2c82dc"
+PKG_SHA256="cac9000fb82296d3c1e590c373fc8d4067620c003c707027410711081f8b7e26"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="http://repo.or.cz/aom.git/snapshot/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
changes are not yet runtime tested

I have not updated Tvh or Emby that depend on that addon at buildtime, its a bit meh but I think okay at the current state.