### PR TITLE
unrar: Fix compilation

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
@@ -23,6 +23,7 @@ make_target() {
      CXXFLAGS="$TARGET_CXXFLAGS" \
      RANLIB="$RANLIB" \
      AR="$AR" \
+     STRIP="$STRIP" \
      -C unrar \
      -f makefile
 


### PR DESCRIPTION
strip program is used from host, which may not know target architecture.