### PR TITLE
fix system-tools build

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/diffutils/patches/diffutils-001-no-man-or-doc.patch
+++ b/packages/addons/addon-depends/system-tools-depends/diffutils/patches/diffutils-001-no-man-or-doc.patch
@@ -5,7 +5,7 @@
  
  EXTRA_DIST = bootstrap exgettext ChangeLog-2008 cfg.mk dist-check.mk
 -SUBDIRS = lib src tests doc man po gnulib-tests
-+SUBDIRS = lib src tests doc po gnulib-tests
++SUBDIRS = lib src tests po gnulib-tests
  
  ACLOCAL_AMFLAGS = -I m4
  AM_CFLAGS = $(WARN_CFLAGS) $(WERROR_CFLAGS)

--- a/packages/addons/addon-depends/system-tools-depends/screen/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/screen/package.mk
@@ -9,7 +9,7 @@ PKG_SITE="http://www.gnu.org/software/screen/"
 PKG_URL="http://ftpmirror.gnu.org/screen/$PKG_NAME-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="Screen is a window manager that multiplexes a physical terminal between several processes"
-PKG_BUILD_FLAGS="-sysroot"
+PKG_BUILD_FLAGS="-sysroot -parallel"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_utempter_h=no \
                            --enable-colors256 \


### PR DESCRIPTION
diffutils jenkins build is failing in install doc phase, I couldn't reproduce that locally but as we don't need the docs anyways just drop them from recursive build/install. This should fix builds on jenkins, too.

I could reproduce the screen build issue, the "comm.h" not found error seems to be caused by a parallel build race. Building non-parallel fixed the issue here.