### PR TITLE
samba: disable automatic icu pickup

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -115,6 +115,13 @@ configure_target() {
   PYTHON=${TOOLCHAIN}/bin/python3 ./configure $PKG_CONFIGURE_OPTS
 }
 
+# disable icu, there is no buildswitch to disable
+pre_make_target() {
+  sed -e '/#define HAVE_ICU_I18N 1/d' \
+      -e '/#define HAVE_LIBICUI.* 1/d' \
+      -i bin/default/include/config.h
+}
+
 make_target() {
   ./buildtools/bin/waf build ${PKG_WAF_VERBOSE} --targets=$PKG_SAMBA_TARGET -j$CONCURRENCY_MAKE_LEVEL
 }


### PR DESCRIPTION
Disclaimer, this is just a HACK because I found no proper way. Better ideas are welcome :)

If you build icu before samba, icu gets used at samba buildtime and fails (all archs).
That function was introduced at Samba 4.12 https://github.com/samba-team/samba/commit/107020793c7ea44e5e776a1401bbf4f8ccb9bd85
Likely the same happens if you have icu-dev at the host system.

```
[ 911/2444] Compiling libcli/security/dom_sid.c
/LE/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/lib/gcc/x86_64-libreelec-linux-gnu/10.1.0/../../../../x86_64-libreelec-linux-gnu/bin/ld: lib/util/charset/iconv.c.1.o: in function `sys_uconv':
iconv.c:(.text+0x9ba): undefined reference to `u_strFromUTF8_61'
/LE/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/lib/gcc/x86_64-libreelec-linux-gnu/10.1.0/../../../../x86_64-libreelec-linux-gnu/bin/ld: iconv.c:(.text+0xa0f): undefined reference to `utrans_transUChars_61'
/LE/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/lib/gcc/x86_64-libreelec-linux-gnu/10.1.0/../../../../x86_64-libreelec-linux-gnu/bin/ld: iconv.c:(.text+0xa52): undefined reference to `u_strToUTF8_61'
/LE/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/lib/gcc/x86_64-libreelec-linux-gnu/10.1.0/../../../../x86_64-libreelec-linux-gnu/bin/ld: lib/util/charset/iconv.c.1.o: in function `smb_iconv_t_destructor':
iconv.c:(.text+0xea5): undefined reference to `utrans_close_61'
/LE/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/lib/gcc/x86_64-libreelec-linux-gnu/10.1.0/../../../../x86_64-libreelec-linux-gnu/bin/ld: lib/util/charset/iconv.c.1.o: in function `smb_iconv_open_ex':
iconv.c:(.text+0x1251): undefined reference to `utrans_openU_61'
collect2: error: ld returned 1 exit status

Waf: Leaving directory `/LE/build.LibreELEC-Generic.x86_64-9.80-devel/build/samba-4.12.3/bin/default'
Build failed
 -> task in 'samba-util' failed with exit status 1 (run with -v to display more information)
FAILURE: scripts/build samba during make_target (package.mk)
```
