### PR TITLE
RPi4: update to firmware 2b76cfc

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="cb2b95d73e9f0b1ebf05e03bb1959603d982feeb"
-PKG_SHA256="814b1e012513f08b9e4a4a72fd37d2a3d2ba4b8fd5aeb0bb093e87b0085b5c21"
+PKG_VERSION="2b76cfc6f57d4943144b9ceb5b57d3d455d6a8fd"
+PKG_SHA256="0b2fcab341441845acf93c0577c491b83b135307cb81dbf8a3e681db1123ab5a"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -7,8 +7,8 @@ PKG_NAME="bcm2835-bootloader"
 # use latest master firmware on RPi4 and latest pre-common
 # firmware on RPi0-3
 if [ "$DEVICE" = "RPi4" ]; then
-  PKG_VERSION="cb2b95d73e9f0b1ebf05e03bb1959603d982feeb"
-  PKG_SHA256="e223022bf48ba55aecbcb0013f98cb50ef449daffcfb96cf9af48c5b61e85869"
+  PKG_VERSION="2b76cfc6f57d4943144b9ceb5b57d3d455d6a8fd"
+  PKG_SHA256="8e3197667d80bd4e6faccf1e77dbb546c884467298edc7ce46db241ca6c137fc"
 else
   PKG_VERSION="9e3c23ce779e8cf44c33d6a25bba249319207f68"
   PKG_SHA256="7ab85b6d7082be87556bc02353b97f97bb1d4af304e4004a3d7ad2a17bb8a696"


### PR DESCRIPTION
partial backport of #4430 

This should fix channel swaps when playing multi-channel audio on RPi4

As I don't have a multi-channel AVR/setup it would be great if someone could runtime test this PR and check if the issue is resolved before merging.