### PR TITLE
RPi.GPIO: Fix compilation with gcc10

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/RPi.GPIO/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/RPi.GPIO/package.mk
@@ -15,6 +15,7 @@ PKG_TOOLCHAIN="manual"
 pre_configure_target() {
   export PYTHONXCPREFIX="$SYSROOT_PREFIX/usr"
   export LDSHARED="$CC -shared"
+  export CFLAGS="$CFLAGS -fcommon"
   export CPPFLAGS="$TARGET_CPPFLAGS -I${SYSROOT_PREFIX}/usr/include/$PKG_PYTHON_VERSION"
 }
 


### PR DESCRIPTION
This is due -fno-common being default starting with GCC 10. Because code was clearly written with "-fcommon" assumption, I just added it to CFLAGS.