### PR TITLE
system: accept compressed configuration backups

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/scripts/backup-restore
+++ b/packages/mediacenter/LibreELEC-settings/scripts/backup-restore
@@ -8,7 +8,11 @@
 
 hidecursor
 
-BACKUP_FILE=$(find /storage/.restore/ -name "*.tar" -print -quit 2>/dev/null)
+BACKUP_EXTENSION_LIST=".tar .tar.gz .tar.bz2 .tar.xz"
+for EXTENSION in $BACKUP_EXTENSION_LIST; do
+  BACKUP_FILE=$(find /storage/.restore/ -name "*${EXTENSION}" -print -quit 2>/dev/null)
+  [ -n "${BACKUP_FILE}" ] && break
+done
 
 
 if [ -f "${BACKUP_FILE}" ]; then

--- a/packages/sysutils/busybox/scripts/libreelec-target-generator
+++ b/packages/sysutils/busybox/scripts/libreelec-target-generator
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2020-present Matthias Reichl <hias@horus.com>
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 EARLY_DIR="$2"
 
@@ -27,7 +28,11 @@ for arg in $(cat /proc/cmdline); do
   esac
 done
 
-BACKUP_FILE=$(ls -1 /storage/.restore/*.tar 2>/dev/null | head -n 1)
+BACKUP_EXTENSION_LIST=".tar .tar.gz .tar.bz2 .tar.xz"
+for extension in $BACKUP_EXTENSION_LIST; do
+  BACKUP_FILE=$(ls -1 /storage/.restore/*${EXTENSION} 2>/dev/null | head -n 1)
+  [ -n "${BACKUP_FILE}" ] && break
+done
 
 if [ -f /storage/.please_resize_me ]; then
   TARGET="fs-resize.target"


### PR DESCRIPTION
This allows restoring the system with a compressed tarball. gzip, bz2, and xz are the compressed formats busybox's tar understands, so those are wired up. Busybox's shell doesn't understand brace expansion, so using word splitting to cycle through the file extensions.