### PR TITLE
Return usleep to busybox init

### DIFF
--- a/packages/sysutils/busybox/config/busybox-init.conf
+++ b/packages/sysutils/busybox/config/busybox-init.conf
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.32.0.git
-# Fri Jun 26 21:30:52 2020
+# Sun Feb  2 19:50:06 2020
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -329,7 +329,7 @@ CONFIG_UNAME_OSNAME="GNU/Linux"
 # CONFIG_BB_ARCH is not set
 # CONFIG_UNIQ is not set
 # CONFIG_UNLINK is not set
-# CONFIG_USLEEP is not set
+CONFIG_USLEEP=y
 # CONFIG_UUDECODE is not set
 # CONFIG_BASE64 is not set
 # CONFIG_UUENCODE is not set

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -111,7 +111,7 @@ mount_common() {
     mount $MOUNT_OPTIONS $1 $2 >&$SILENT_OUT 2>&1
     [ "$?" -eq "0" ] && ERR_ENV=0 && break
 
-    sleep 1
+    usleep 1000000
   done
   [ "$ERR_ENV" -eq "0" ] && return 0
   error "mount_common" "Could not mount $1"
@@ -442,7 +442,7 @@ do_reboot() {
     /usr/bin/busybox umount /storage
   fi
 
-  sleep 2
+  usleep 2000000
   /usr/bin/busybox reboot
 }
 
@@ -496,7 +496,7 @@ check_disks() {
         if [ $i -eq 0 ]; then
           progress "Device not found, continuing..."
         else
-          sleep 1
+          usleep 500000
         fi
       elif [ $(( $FSCK_RET & 4 )) -eq 4 ]; then
         # errors left


### PR DESCRIPTION
usleep is used by init's functions to create quarter and half second progress reports. Not having it spams output with the equivalent of 'usleep not found' when running spinners or percent progress.