### PR TITLE
libretro-fsuae: Fix compilation with gcc10

### DIFF
--- a/packages/emulation/libretro-fsuae/package.mk
+++ b/packages/emulation/libretro-fsuae/package.mk
@@ -24,6 +24,8 @@ fi
 pre_configure_target() {
   cd $PKG_BUILD
   rm -rf .$TARGET_NAME
+  # check if this flag is still needed when this package is updated
+  export CFLAGS="$CFLAGS -fcommon"
   export ac_cv_func_realloc_0_nonnull=yes
 }
 


### PR DESCRIPTION
This PR fixes compilation of game.libretro.fsuae addon with gcc 10.