### PR TITLE
alsa-lib: update to 1.2.3.2

### DIFF
--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-lib"
-PKG_VERSION="1.2.3.1"
-PKG_SHA256="1244585515fbebce7d0e53656c1fb614f99accb8413115ce3efb9a9309c4c892"
+PKG_VERSION="1.2.3.2"
+PKG_SHA256="e81fc5b7afcaee8c9fd7f64a1e3043e88d62e9ad2c4cff55f578df6b0a9abe15"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/lib/alsa-lib-$PKG_VERSION.tar.bz2"

--- a/packages/audio/alsa-lib/patches/alsa-lib-asound.conf_configdir.patch
+++ b/packages/audio/alsa-lib/patches/alsa-lib-asound.conf_configdir.patch
@@ -2,10 +2,10 @@ diff --git a/src/conf/alsa.conf b/src/conf/alsa.conf
 index bb00ff40..cba5b6f2 100644
 --- a/src/conf/alsa.conf
 +++ b/src/conf/alsa.conf
-@@ -10,7 +10,8 @@
- 		files [
+@@ -11,7 +11,8 @@
+ 			"/usr/etc/alsa/conf.d"
  			"/etc/alsa/conf.d"
- 			"/etc/asound.conf"
+ 			"/etc/asound.conf|||/usr/etc/asound.conf"
 -			"~/.asoundrc"
 +			"/run/asound.conf"
 +			"/storage/.config/asound.conf"


### PR DESCRIPTION
Untested PR.
made modification to asound-confdir patch so that it'd apply cleanly on alsa-lib 1.2.3.2