### PR TITLE
RPi4: update to July 2 firmware 66fc5ea

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="2b76cfc6f57d4943144b9ceb5b57d3d455d6a8fd"
-PKG_SHA256="0b2fcab341441845acf93c0577c491b83b135307cb81dbf8a3e681db1123ab5a"
+PKG_VERSION="66fc5eaac3d0af1d5a7ffa616086cbfaefd72e98"
+PKG_SHA256="373872b00d566fbc8873125336b3a09696e85602d2e49a48c0b5c5cabb15d989"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -7,8 +7,8 @@ PKG_NAME="bcm2835-bootloader"
 # use latest master firmware on RPi4 and latest pre-common
 # firmware on RPi0-3
 if [ "$DEVICE" = "RPi4" ]; then
-  PKG_VERSION="2b76cfc6f57d4943144b9ceb5b57d3d455d6a8fd"
-  PKG_SHA256="8e3197667d80bd4e6faccf1e77dbb546c884467298edc7ce46db241ca6c137fc"
+  PKG_VERSION="66fc5eaac3d0af1d5a7ffa616086cbfaefd72e98"
+  PKG_SHA256="fe7fe713409120768c37dbbe02a7a06c0e808b0e60dad09ea054d7006947b76d"
 else
   PKG_VERSION="9e3c23ce779e8cf44c33d6a25bba249319207f68"
   PKG_SHA256="7ab85b6d7082be87556bc02353b97f97bb1d4af304e4004a3d7ad2a17bb8a696"


### PR DESCRIPTION
Partial backport of #4430 

The USB GPT fix may be beneficial to people using USB boot.

See https://github.com/raspberrypi/firmware/commit/66fc5eaac3d0af1d5a7ffa616086cbfaefd72e98 for changelog

I've been testing this firmware on my main LE9.2/RPi4 setup the last week and haven't noticed any issues yet