### PR TITLE
unpack: prevent circular unpacking between two packages

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -20,9 +20,16 @@ pkg_lock "${PKG_NAME}" "unpack" "${PARENT_PKG}"
 ${SCRIPTS}/get "${PKG_NAME}"
 
 if [ -n "${PKG_DEPENDS_UNPACK}" ]; then
+  export _unpack_recursive_cnt=$((_unpack_recursive_cnt+1)) 
+  if [ ${_unpack_recursive_cnt} -gt 2 ]; then
+    die "unpack recursive limit hit: ${PKG_DEPENDS_UNPACK}, ${PARENT_PKG}"
+  fi
+
   for p in ${PKG_DEPENDS_UNPACK}; do
     ${SCRIPTS}/unpack "${p}" "${PARENT_PKG}"
   done
+  
+  unset _unpack_recursive_cnt
 fi
 
 STAMP="${PKG_BUILD}/.libreelec-unpack"


### PR DESCRIPTION
In case two packages has dependency on each other unpacking fails because unpack script goes to loop and eats all the computer resources. With this change unpack fails on third pass.

```
unpack recursive limit hit [package1, package2]
*********** FAILED COMMAND ***********
${SCRIPTS}/unpack "${p}" "${PARENT_PKG}"
**************************************
*********** FAILED COMMAND ***********
${SCRIPTS}/unpack "${p}" "${PARENT_PKG}"
**************************************
*********** FAILED COMMAND ***********
${SCRIPTS}/unpack "${PKG_NAME}" "${PARENT_PKG}"
**************************************
```