### PR TITLE
RTL8822BU: add support for RTL88x2BU wifi devices

### DIFF
--- a/packages/linux-drivers/RTL8822BU/package.mk
+++ b/packages/linux-drivers/RTL8822BU/package.mk
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="RTL8822BU"
+PKG_VERSION="9c0fc247466901f90e04604844c8e581b837e771"
+PKG_SHA256="e8dae9554176d8efcfc39c629fd2ceaf7df52e51e6aebe1c2d770236068f197f"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/RinCat/RTL88x2BU-Linux-Driver"
+PKG_URL="https://github.com/RinCat/RTL88x2BU-Linux-Driver/archive/$PKG_VERSION.tar.gz"
+
+
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_LONGDESC="Realtek RTL8822BU Linux 4.x driver"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make V=1 \
+       ARCH=$TARGET_KERNEL_ARCH \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
+       CONFIG_POWER_SAVING=n
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+    cp *.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME
+}

--- a/packages/linux-drivers/RTL8822BU/patches/arm/arch.patch
+++ b/packages/linux-drivers/RTL8822BU/patches/arm/arch.patch
@@ -1,0 +1,13 @@
+--- a/Makefile	2018-10-07 08:40:26.000000000 -0500
++++ b/Makefile	2018-11-21 15:33:02.032610440 -0600
+@@ -95,8 +95,8 @@
+ ###################### MP HW TX MODE FOR VHT #######################
+ CONFIG_MP_VHT_HW_TX_MODE = n
+ ###################### Platform Related #######################
+-CONFIG_PLATFORM_I386_PC = y
+-CONFIG_PLATFORM_ARM_RPI = n
++CONFIG_PLATFORM_I386_PC = n
++CONFIG_PLATFORM_ARM_RPI = y
+ CONFIG_PLATFORM_ANDROID_X86 = n
+ CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
+ CONFIG_PLATFORM_JB_X86 = n

--- a/packages/linux-drivers/RTL8822BU/patches/arm/arm.patch
+++ b/packages/linux-drivers/RTL8822BU/patches/arm/arm.patch
@@ -1,0 +1,33 @@
+diff --git a/Makefile b/Makefile
+index 25c8450..c745a85 100755
+--- a/Makefile
++++ b/Makefile
+@@ -107,7 +107,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+ ###################### MP HW TX MODE FOR VHT #######################
+ CONFIG_MP_VHT_HW_TX_MODE = n
+ ###################### Platform Related #######################
+-CONFIG_PLATFORM_I386_PC = y
++CONFIG_PLATFORM_I386_PC = n
++ CONFIG_PLATFORM_ARM_RPI = y
+ CONFIG_PLATFORM_ANDROID_X86 = n
+ CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
+ CONFIG_PLATFORM_JB_X86 = n
+@@ -1225,6 +1226,18 @@ INSTALL_PREFIX :=
+ STAGINGMODDIR := /lib/modules/$(KVER)/kernel/drivers/staging
+ endif
+ 
++ifeq ($(CONFIG_PLATFORM_ARM_RPI), y)
++EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
++EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
++EXTRA_CFLAGS += -DPLATFORM_LINUX
++ARCH ?= arm
++CROSS_COMPILE ?=
++KVER ?= $(shell uname -r)
++KSRC := /lib/modules/$(KVER)/build
++MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
++INSTALL_PREFIX :=
++endif
++
+ ifeq ($(CONFIG_PLATFORM_NV_TK1), y)
+ EXTRA_CFLAGS += -DCONFIG_PLATFORM_NV_TK1
+ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN


### PR DESCRIPTION
This adds a driver for the RTL88x2BU chipset 

These USB wifi devices are produced by a number of manufacturers and whilst low cost, claim to provide 1200Mbps speeds.