### PR TITLE
[le92] rpi-eeprom: update to 8e9aca3

### DIFF
--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="2a8c2e77c34d16554956e5ca56697eba9611d2ad"
-PKG_SHA256="3982aa10f45f3dcd80d6072db0ddf27d76d4fbf2e9cdb08304ba32a953d55c8b"
+PKG_VERSION="8e9aca34aeead5fb87aa334cc29edc927bbeae7a"
+PKG_SHA256="f3d3af536adf4bc105ed5b86e4090b008f298daccacc7536cb3c91a2f8a22352"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"


### PR DESCRIPTION
partial backport of #4485 

New stable bootloader eeprom version 2020-07-16, new stable USB eeprom version 000138a1