### PR TITLE
mkimage: really enable debug shell for installer

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -129,7 +129,7 @@ PROMPT 1
 
 LABEL installer
   KERNEL /${KERNEL_NAME}
-  APPEND boot=UUID=${UUID_SYSTEM} installer quiet systemd.debug_shell vga=current
+  APPEND boot=UUID=${UUID_SYSTEM} installer quiet systemd.debug_shell systemd.unit=installer.target vga=current
 
 LABEL live
   KERNEL /${KERNEL_NAME}


### PR DESCRIPTION
Fix for [bug report](https://forum.libreelec.tv/thread/22357-libreelec-9-2-3-console-does-not-open-using-control-alt-f3/) in the forum.

systemd-debug-generator must be configured if not booting into systemd's `default.target`. In our case `installer.target` has to be set.

Backport of #4494