### PR TITLE
libretro-pcsx-rearmed: fix PCSX ReARMed build

### DIFF
--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -21,19 +21,20 @@ make_target() {
   
   if target_has_feature neon; then
     export HAVE_NEON=1
+    export BUILTIN_GPU=neon
    else
     export HAVE_NEON=0
   fi
   
   case $TARGET_ARCH in
     aarch64)
-      make -f Makefile.libretro platform=aarch64 GIT_VERSION=$PKG_VERSION
+      make -f Makefile.libretro DYNAREC=lightrec platform=aarch64 GIT_VERSION=$PKG_VERSION
       ;;
     arm)
-      make -f Makefile.libretro USE_DYNAREC=1 GIT_VERSION=$PKG_VERSION
+      make -f Makefile.libretro DYNAREC=ari64 GIT_VERSION=$PKG_VERSION
       ;;
     x86_64)
-      make -f Makefile.libretro GIT_VERSION=$PKG_VERSION
+      make -f Makefile.libretro DYNAREC=lightrec GIT_VERSION=$PKG_VERSION
       ;;
   esac
 }

--- a/packages/emulation/libretro-pcsx-rearmed/patches/libretro-pcsx-rearmed-0001-aarch64-support.patch
+++ b/packages/emulation/libretro-pcsx-rearmed/patches/libretro-pcsx-rearmed-0001-aarch64-support.patch
@@ -1,17 +1,17 @@
 diff -Naur a/Makefile.libretro b/Makefile.libretro
---- a/Makefile.libretro	2016-05-05 20:28:57.000000000 -0700
-+++ b/Makefile.libretro	2016-05-10 10:10:33.447118136 -0700
-@@ -246,6 +246,14 @@
+--- a/Makefile.libretro	2020-03-17 06:53:23.000000000 +0100
++++ b/Makefile.libretro	2020-06-22 16:00:10.616134362 +0200
+@@ -380,6 +380,14 @@
  	ARCH = arm
- 	USE_DYNAREC = 1
+ 	DYNAREC = ari64
  
 +# aarch64
 +else ifneq (,$(findstring aarch64,$(platform)))
-+        TARGET := $(TARGET_NAME)_libretro.so
-+        SHARED := -shared -Wl,--no-undefined
-+        fpic := -fPIC
-+        DRC_CACHE_BASE = 0
-+        ARCH = aarch64
++	TARGET := $(TARGET_NAME)_libretro.so
++	SHARED := -shared -Wl,--no-undefined
++	fpic := -fPIC
++	DRC_CACHE_BASE = 0
++	ARCH = aarch64
 +
  # Windows
  else


### PR DESCRIPTION
The _game.libretro.pcsx-rearmed_ addon is currently broken and is crashing Kodi in both _master_ and _libreelec-9.2_ branches. The build needs to be updated to reflect the changes in the upstream Makefile.libretro:
https://github.com/libretro/pcsx_rearmed/commit/3d96277d011b4d683d682740eed61b1113a613b1

Fixes https://github.com/LibreELEC/LibreELEC.tv/issues/4431

Needs backport to LE 9.2

This is a second try to clean up the original PR #4469.