### PR TITLE
kodi: update to 19.0a1-Matrix, drop kodi vendor tree support

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -81,9 +81,6 @@
 # Default Skin (Estuary)
   SKIN_DEFAULT="Estuary"
 
-# Select whether to use default (upstream xbmc/xbmc) repo, or specific vendor repo
-  KODI_VENDOR="default"
-
 # install extra subtitle Fonts for KODI (yes / no)
   KODI_EXTRA_FONTS="yes"
 

--- a/distributions/LibreELEC/show_config
+++ b/distributions/LibreELEC/show_config
@@ -18,7 +18,6 @@ show_distro_config() {
   config_message+="\n\n Kodi Software configuration:"
   config_message+="\n $dashes$dashes"
 
-  config_message+="\n - Kodi Vendor:\t\t\t\t $KODI_VENDOR"
   config_message+="\n - Kodi Blu-ray support:\t\t $KODI_BLURAY_SUPPORT"
   if [ "$KODI_BLURAY_SUPPORT" = "yes" ] ; then
     config_message+="\n   - Blu-ray BD+ support:\t\t $BLURAY_BDPLUS_SUPPORT"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -19,8 +19,8 @@ case $KODI_VENDOR in
     PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
     ;;
   *)
-    PKG_VERSION="db74480506b32d0e8df429882d5bab8b9172db69"
-    PKG_SHA256="c06563bef2ca53c80d62a9302938482ebdc29b4ee453253516e65df925039cc8"
+    PKG_VERSION="19.0a1-Matrix"
+    PKG_SHA256="3c66715448e18f95bc5e8a3075f95e643f3b2c0bae3957f2abb5b567b7e7eceb"
     PKG_URL="https://github.com/xbmc/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$PKG_VERSION.tar.gz"
     ;;

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,28 +3,14 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
+PKG_VERSION="19.0a1-Matrix"
+PKG_SHA256="3c66715448e18f95bc5e8a3075f95e643f3b2c0bae3957f2abb5b567b7e7eceb"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
+PKG_URL="https://github.com/xbmc/xbmc/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre swig:host libass curl fontconfig fribidi tinyxml libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid giflib libdvdnav libhdhomerun libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog"
 PKG_LONGDESC="A free and open source cross-platform media player."
 PKG_BUILD_FLAGS="+speed"
-
-PKG_PATCH_DIRS="$KODI_VENDOR"
-
-case $KODI_VENDOR in
-  raspberrypi)
-    PKG_VERSION="newclock5_20200419"
-    PKG_SHA256="f50ea08a4f7f4dc2083c8470115063eaeb67c9b8682ecc6bfaf42dafcb69fd5c"
-    PKG_URL="https://github.com/popcornmix/xbmc/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_NAME="kodi-$KODI_VENDOR-$PKG_VERSION.tar.gz"
-    ;;
-  *)
-    PKG_VERSION="19.0a1-Matrix"
-    PKG_SHA256="3c66715448e18f95bc5e8a3075f95e643f3b2c0bae3957f2abb5b567b7e7eceb"
-    PKG_URL="https://github.com/xbmc/xbmc/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_NAME="kodi-$PKG_VERSION.tar.gz"
-    ;;
-esac
 
 configure_package() {
   # Single threaded LTO is very slow so rely on Kodi for parallel LTO support

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -52,9 +52,6 @@
   # Windowmanager to use (fluxbox / none)
     WINDOWMANAGER="none"
 
-  # Use a vendor specific KODI repo
-    KODI_VENDOR="amlogic"
-
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -87,9 +87,6 @@
   # e.g. GRAPHIC_DRIVERS="vc4"
     GRAPHIC_DRIVERS="vc4"
 
-  # Use a vendor specific KODI repo
-    KODI_VENDOR="default"
-
   # KODI Player implementation to use (default / bcm2835-driver / mesa)
     KODIPLAYER_DRIVER="mesa"
 

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -54,9 +54,6 @@
   # Windowmanager to use (fluxbox / none)
     WINDOWMANAGER="none"
 
-  # Use a vendor specific KODI repo
-    KODI_VENDOR="samsung"
-
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"


### PR DESCRIPTION
Runtime tested on RPi4 and RPi2 build on RPi3B+

As RPi has been switched to upstream kodi tree and no other project uses kodi vendor trees we can drop support for vendor trees.