### PR TITLE
arch.aarch64: don't attempt to use the LSE cpu feature

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -23,5 +23,7 @@
 
 # setup ARCH specific *FLAGS
   TARGET_CFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mabi=lp64 -Wno-psabi -mtune=$TARGET_CPU"
+# Disable runtime checking support of ARMv8.0's optional LSE feature. Breaks gdb and mesa compile.
+  TARGET_CFLAGS="${TARGET_CFLAGS} -mno-outline-atomics"
   TARGET_LDFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mtune=$TARGET_CPU"
   GCC_OPTS="--with-abi=lp64 --with-arch=$TARGET_VARIANT"


### PR DESCRIPTION
ARMv8.0-A cpus have an optional LSE feature. This is mandatory in ARMv8.1-A. By default, gcc will attempt to build support for runtime detection of the LSE feature on ARMv8.0-A. This causes build failures when attempting to create a 64-bit userland.

Packages that fail include gdb and mesa.

My understanding is this flag will be ignored on >=ARMv8.1 targets. I don't know that there are any such targets in LE at present, or if there are, if they're being built with a 64-bit userland.

Patch tested atop #4406 and an RPi3.

From GCC's docs: 

-moutline-atomics
-mno-outline-atomics

Enable or disable calls to out-of-line helpers to implement atomic operations. These helpers will, at runtime, determine if the LSE instructions from ARMv8.1-A can be used; if not, they will use the load/store-exclusive instructions that are present in the base ARMv8.0 ISA.

This option is only applicable when compiling for the base ARMv8.0 instruction set. If using a later revision, e.g. -march=armv8.1-a or -march=armv8-a+lse, the ARMv8.1-Atomics instructions will be used directly. The same applies when using -mcpu= when the selected cpu supports the ‘lse’ feature. This option is on by default.