### PR TITLE
LE9.2 bump gnutls/nettle/ffmpeg

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ffmpegx"
-PKG_VERSION="4.2.1"
-PKG_SHA256="cec7c87e9b60d174509e263ac4011b522385fd0775292e1670ecc1180c9bb6d4"
+PKG_VERSION="4.2.4"
+PKG_SHA256="0d5da81feba073ee78e0f18e0966bcaf91464ae75e18e9a0135186249e3d2a0b"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="https://ffmpeg.org/releases/ffmpeg-$PKG_VERSION.tar.xz"

--- a/packages/addons/service/tvheadend42/changelog.txt
+++ b/packages/addons/service/tvheadend42/changelog.txt
@@ -1,3 +1,6 @@
+123
+- update gnutls to 3.6.14
+
 122
 - update gnutls to 3.6.13
 

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -5,7 +5,7 @@ PKG_NAME="tvheadend42"
 PKG_VERSION="5bdcfd8ac97b3337e1c7911ae24127df76fa693a"
 PKG_SHA256="b562a26248cdc02dc94cc62038deea172668fa4c079b2ea4e1b4220f3b1d34f5"
 PKG_VERSION_NUMBER="4.2.8-36"
-PKG_REV="122"
+PKG_REV="123"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"
@@ -112,8 +112,8 @@ addon() {
   # copy gnutls lib that is needed for ffmpeg
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/lib
   cp -PL $(get_build_dir gnutls)/.INSTALL_PKG/usr/lib/libgnutls.so.30 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PL $(get_build_dir nettle)/.install_pkg/usr/lib/libnettle.so.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PL $(get_build_dir nettle)/.install_pkg/usr/lib/libhogweed.so.4 $ADDON_BUILD/$PKG_ADDON_ID/lib
+  cp -PL $(get_build_dir nettle)/.install_pkg/usr/lib/libnettle.so.8 $ADDON_BUILD/$PKG_ADDON_ID/lib
+  cp -PL $(get_build_dir nettle)/.install_pkg/usr/lib/libhogweed.so.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
   cp -PL $(get_build_dir gmp)/.install_pkg/usr/lib/libgmp.so.10 $ADDON_BUILD/$PKG_ADDON_ID/lib
 
   # set only version (revision will be added by buildsystem)

--- a/packages/addons/tools/ffmpeg-tools/changelog.txt
+++ b/packages/addons/tools/ffmpeg-tools/changelog.txt
@@ -1,3 +1,7 @@
+111
+- Update FFmpeg to 4.2.4
+- Update gnutls to 3.6.14
+
 110
 - Update gnutls to 3.6.13
 

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="110"
+PKG_REV="111"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -25,6 +25,6 @@ addon() {
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/lib
     cp -PL $(get_build_dir gmp)/.install_pkg/usr/lib/libgmp.so.10 \
            $(get_build_dir gnutls)/.INSTALL_PKG/usr/lib/libgnutls.so.30 \
-           $(get_build_dir nettle)/.install_pkg/usr/lib/{libhogweed.so.4,libnettle.so.6} \
+           $(get_build_dir nettle)/.install_pkg/usr/lib/{libhogweed.so.6,libnettle.so.8} \
            $ADDON_BUILD/$PKG_ADDON_ID/lib
 }

--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.6.13"
-PKG_SHA256="32041df447d9f4644570cf573c9f60358e865637d69b7e59d1159b7240b52f38"
+PKG_VERSION="3.6.14"
+PKG_SHA256="5630751adec7025b8ef955af4d141d00d252a985769f51b4059e5affa3d39d63"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-$PKG_VERSION.tar.xz"

--- a/packages/security/nettle/package.mk
+++ b/packages/security/nettle/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nettle"
-PKG_VERSION="3.4.1"
-PKG_SHA256="f941cf1535cd5d1819be5ccae5babef01f6db611f9b5a777bae9c7604b8a92ad"
+PKG_VERSION="3.6"
+PKG_SHA256="d24c0d0f2abffbc8f4f34dcf114b0f131ec3774895f3555922fe2f40f3d5e3f1"
 PKG_LICENSE="GPL2"
 PKG_SITE="http://www.lysator.liu.se/~nisse/nettle"
 PKG_URL="http://ftpmirror.gnu.org/gnu/nettle/nettle-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
gnutls to 3.6.14
nettle to 3.6
ffmpegx to 4.2.4
ffmpeg-tools + tvheadend42 addon bumps to pull above in.

Only compile tested.