### PR TITLE
fix game.libretro.pcsx-rearmed and visualization.matrix addon builds

### DIFF
--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -25,6 +25,9 @@ make_target() {
    else
     export HAVE_NEON=0
   fi
+
+  # check if this flag is still needed when this package is updated
+  export CFLAGS="$CFLAGS -fcommon"
   
   case $TARGET_ARCH in
     aarch64)

--- a/packages/mediacenter/kodi-binary-addons/visualization.matrix/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.matrix/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.matrix"
-PKG_VERSION="v0.4.2"
-PKG_SHA256="2fb66404c43d6279a403d9ef9a2bc18d0944bae2033bc1cd7b1f78b5892d5c0c"
-PKG_REV="1"
+PKG_VERSION="f7bef981e20b0fd967e128c7726213330819b2c8"
+PKG_SHA256="955ee74e0e0fc9e98c79274d715115e84c04cb3e22172b625816bbdaf936e4f5"
+PKG_REV="2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.matrix"
 PKG_URL="https://github.com/xbmc/visualization.matrix/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
libretro-pcsx-rearmed needs -fcommon with gcc 10 and visualization.matrix needs the fixes from the not yet released snapshot we had in LE before the last bump