### PR TITLE
Reintroduce trigger for debug shell again

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -301,4 +301,5 @@ post_install() {
   enable_service network-base.service
   enable_service systemd-timesyncd.service
   enable_service systemd-timesyncd-setup.service
+  enable_service debug-shell-trigger.service
 }

--- a/packages/sysutils/systemd/system.d/debug-shell-trigger.service
+++ b/packages/sysutils/systemd/system.d/debug-shell-trigger.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=LibreELEC trigger for early root shell FOR DEBUGGING ONLY
+DefaultDependencies=no
+IgnoreOnIsolate=yes
+ConditionKernelCommandLine=|tty
+ConditionKernelCommandLine=|debugging
+ConditionPathExists=|/storage/.cache/debug.libreelec
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl start debug-shell.service
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -129,7 +129,7 @@ PROMPT 1
 
 LABEL installer
   KERNEL /${KERNEL_NAME}
-  APPEND boot=UUID=${UUID_SYSTEM} installer quiet systemd.debug_shell vga=current
+  APPEND boot=UUID=${UUID_SYSTEM} installer quiet tty vga=current
 
 LABEL live
   KERNEL /${KERNEL_NAME}


### PR DESCRIPTION
Alternative or addition (without the second commit) to #4494, based on the discussion there.

Kernel parameter `systemd.debug_shell` is only working if system is booting into default.target or the deviant target is forced with `systemd.unit=...`

Reintroduce `tty` option launching the default debug shell in any case. In addition the debug shell is active when using `debugging` or on existing file "/storage/.cache/debug.libreelec".

The advanced user still can use `systemd.debug_shell` if wanted.

Successful tested with "installer", "run" and installed system after incremental Generic build with my LE 9.2 tree.
