### PR TITLE
RPi: disable crazycat and dvb-latest drivers

### DIFF
--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -115,7 +115,7 @@
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS rpi-cirrus-config bcm2835-driver"
 
   # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="yes"
+    DRIVER_ADDONS_SUPPORT="no"
 
   # driver addons to install:
   # for a list of additional drivers see packages/linux-driver-addons


### PR DESCRIPTION
They need to be updated after the recent kernel bump.
