### PR TITLE
improve github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,8 +8,7 @@ assignees: ''
 ---
 
 ### Describe the bug
-<!--- A clear description of what the bug is.
-Add a kodi.log (https://libreelec.wiki/how_to/provide_logfile) that we can search for errors. -->
+<!--- A clear description of what the bug is. -->
 
 ### To Reproduce
 Steps to reproduce the behavior:
@@ -20,6 +19,9 @@ Steps to reproduce the behavior:
 ### Informations
  - LE Version: [e.g. 9.2.1]
  - Hardware Platform: [e.g. RPi3]
+
+### Log file
+<!-- Add log files (https://libreelec.wiki/how_to/provide_logfile) that we can search for errors. -->
 
 ### Additional context
 <!--- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
When people create issues they really should fill out the form and include log files.

Disable the "Open blank issue" link via config.yml and move "Log file" to a separate section so it's clearer that we want these.
