### PR TITLE
use a systemd generator for selecting the default target

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -144,6 +144,9 @@ makeinstall_target() {
       cp $PKG_DIR/scripts/rpi-flash-firmware $INSTALL/usr/lib/libreelec
     fi
 
+  mkdir -p $INSTALL/usr/lib/systemd/system-generators/
+    cp $PKG_DIR/scripts/libreelec-target-generator $INSTALL/usr/lib/systemd/system-generators/
+
   mkdir -p $INSTALL/etc
     cp $PKG_DIR/config/profile $INSTALL/etc
     cp $PKG_DIR/config/inputrc $INSTALL/etc

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -1005,11 +1005,7 @@ for arg in $(cat /proc/cmdline); do
     wol_wait=*)
       wol_wait="${arg#*=}"
       ;;
-    textmode)
-      INIT_UNIT="--unit=textmode.target"
-      ;;
     installer)
-      INIT_UNIT="--unit=installer.target"
       SYSLINUX_DEFAULT="installer"
       ;;
     debugging)
@@ -1134,19 +1130,7 @@ if [ "$STORAGE_NETBOOT" = "yes" ]; then
   echo "" > /sysroot/dev/.storage_netboot
 fi
 
-BACKUP_FILE=$(ls -1 /sysroot/storage/.restore/*.tar 2>/dev/null | head -n 1)
-
-if [ -f /sysroot/storage/.please_resize_me ]; then
-  INIT_UNIT="--unit=fs-resize.target"
-elif [ -f /sysroot/storage/.cache/reset_oe -o -f /sysroot/storage/.cache/reset_xbmc ]; then
-  INIT_UNIT="--unit=factory-reset.target"
-elif [ -f "$BACKUP_FILE" ]; then
-  INIT_UNIT="--unit=backup-restore.target"
-elif [ -f /sysroot/storage/.rpi_flash_firmware ]; then
-  INIT_UNIT="--unit=rpi-flash-firmware.target"
-fi
-
 # switch to new sysroot and start real init
-exec /usr/bin/busybox switch_root /sysroot /usr/lib/systemd/systemd $INIT_ARGS $INIT_UNIT
+exec /usr/bin/busybox switch_root /sysroot /usr/lib/systemd/systemd $INIT_ARGS
 
 error "switch_root" "Error in initramfs. Could not switch to new root"

--- a/packages/sysutils/busybox/scripts/libreelec-target-generator
+++ b/packages/sysutils/busybox/scripts/libreelec-target-generator
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Matthias Reichl <hias@horus.com>
+
+EARLY_DIR="$2"
+
+log() {
+  echo "libreelec-target-generator: $@" > /dev/kmsg
+}
+
+if [ -z "$EARLY_DIR" ]; then
+  log "error: generator directory missing"
+  exit 1
+fi
+
+TARGET=""
+
+for arg in $(cat /proc/cmdline); do
+  case "$arg" in
+    textmode)
+      TARGET="textmode.target"
+      ;;
+    installer)
+      TARGET="installer.target"
+      ;;
+  esac
+done
+
+BACKUP_FILE=$(ls -1 /storage/.restore/*.tar 2>/dev/null | head -n 1)
+
+if [ -f /storage/.please_resize_me ]; then
+  TARGET="fs-resize.target"
+elif [ -f /storage/.cache/reset_oe -o -f /storage/.cache/reset_xbmc ]; then
+  TARGET="factory-reset.target"
+elif [ -f "$BACKUP_FILE" ]; then
+  TARGET="backup-restore.target"
+elif [ -f /storage/.rpi_flash_firmware ]; then
+  TARGET="rpi-flash-firmware.target"
+fi
+
+if [ -n "$TARGET" ]; then
+  ln -sT "/usr/lib/systemd/system/$TARGET" "$EARLY_DIR/default.target" 2>/dev/kmsg || log "error creating symlink to $TARGET: $?"
+fi


### PR DESCRIPTION
Setting the target unit via the `--unit` systemd option has the huge disadvantage that it doesn't play nicely with software that expects the default unit to be set via the standard mechanisms (`systemctl set-default` or via `systemd.unit` kernel command line option).

The `systemd-debug-generator` is such an example, currently the debug shell only works when booting into kodi.target but not in installer, textmode, backup-restore or all other targets where a debug shell might be highly wanted.

The solution is rather easy though, instead of using the `--unit` option we can use a systemd generator to dynamically symlink the default target if needed.

Runtime tested on RPi4 with textmode, factory reset and fs-resize targets and with x86_64 installer.