### PR TITLE
nss: Fix building with glibc 2.32 and gcc 10

### DIFF
--- a/packages/security/nss/patches/nss-09-gcc-warning-workaround.patch
+++ b/packages/security/nss/patches/nss-09-gcc-warning-workaround.patch
@@ -1,0 +1,11 @@
+diff -r ab04fd73fd6d coreconf/nsinstall/nsinstall.c
+--- a/nss/coreconf/nsinstall/nsinstall.c	Mon Aug 24 22:52:43 2020 +0000
++++ b/nss/coreconf/nsinstall/nsinstall.c	Wed Aug 26 13:04:16 2020 +0200
+@@ -50,6 +50,7 @@
+ extern int fchmod(int fildes, mode_t mode);
+ #endif
+ 
++#define GETCWD_CANT_MALLOC 1
+ 
+ #ifdef GETCWD_CANT_MALLOC
+ /*


### PR DESCRIPTION
Due to unfortunate combination of glibc 2.32, gcc 10 and nss code and compiler flags, nss:host doesn't build anymore. nss has -Wall flag set which cause aggressive code checks. Those checks produce warning even though nss code is correct albeit it's using glibc specific behaviour. nss also sets -Werror flag which then breaks build.