### PR TITLE
add support for SKY-Q remote

### DIFF
--- a/packages/sysutils/eventlircd/evmap/skyqremote.evmap
+++ b/packages/sysutils/eventlircd/evmap/skyqremote.evmap
@@ -1,0 +1,25 @@
+# SKY Q bluetooth remote
+# Bus=0005 Vendor=119b Product=212b Version=0001
+# Name="P218ruwido Sky Remote Keyboard"
+
+KEY_ESC        = KEY_EXIT
+KEY_HOME       = KEY_MEDIA
+KEY_F5         = KEY_MENU
+KEY_F10        = KEY_REWIND
+KEY_F11        = KEY_PLAY
+KEY_F12        = KEY_FASTFORWARD
+KEY_F1         = KEY_POWER
+KEY_F3         = KEY_STOP
+KEY_KPASTERISK = KEY_MUTE
+KEY_F9         = KEY_INFO
+KEY_PAGEUP     = KEY_CHANNELUP
+KEY_PAGEDOWN   = KEY_CHANNELDOWN
+KEY_F15        = KEY_TUNER
+KEY_F2         = KEY_EPG
+KEY_KPPLUS     = KEY_VOLUMEUP
+KEY_KPMINUS    = KEY_VOLUMEDOWN
+KEY_F4         = KEY_RED
+KEY_DELETE     = KEY_GREEN
+KEY_INSERT     = KEY_YELLOW
+KEY_END        = KEY_BLUE
+KEY_F7         = KEY_RECORD

--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -142,10 +142,6 @@ ENV{ID_VENDOR_ID}=="05a4", ENV{ID_MODEL_ID}=="9881", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="03_$env{ID_VENDOR_ID}_$env{ID_MODEL_ID}.evmap"
 
-# ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="8241", \
-#   ENV{eventlircd_enable}="true", \
-#   ENV{eventlircd_evmap}="03_$env{ID_VENDOR_ID}_$env{ID_MODEL_ID}.evmap"
-
 ENV{ID_VENDOR_ID}=="0709", ENV{ID_MODEL_ID}=="9137", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="03_$env{ID_VENDOR_ID}_$env{ID_MODEL_ID}.evmap"
@@ -174,7 +170,6 @@ ENV{ID_VENDOR_ID}=="1d57", ENV{ID_MODEL_ID}=="ac01", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="03_$env{ID_VENDOR_ID}_$env{ID_MODEL_ID}.evmap"
 
-#ENV{ID_VENDOR_ID}=="9022", ENV{ID_MODEL_ID}=="d660", \
 ATTRS{idVendor}=="9022", ATTRS{idProduct}=="d660", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="tevii_s660.evmap"
@@ -192,12 +187,12 @@ ENV{ID_VENDOR_ID}=="0471", ENV{ID_MODEL_ID}=="20cc", \
   ENV{eventlircd_evmap}="spinelplus.evmap"
 
 ENV{ID_VENDOR_ID}=="2252", ENV{ID_MODEL_ID}=="1037", \
-ENV{eventlircd_enable}="true", \
-ENV{eventlircd_evmap}="osmc_rf.evmap"
+  ENV{eventlircd_enable}="true", \
+  ENV{eventlircd_evmap}="osmc_rf.evmap"
 
 ENV{ID_VENDOR_ID}=="2017", ENV{ID_MODEL_ID}=="1688", \
-ENV{eventlircd_enable}="true", \
-ENV{eventlircd_evmap}="osmc_rf2.evmap"
+  ENV{eventlircd_enable}="true", \
+  ENV{eventlircd_evmap}="osmc_rf2.evmap"
 
 # Enable wake-on-usb for the USB remotes.
   RUN+="wakeup_enable"

--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -79,6 +79,10 @@ SUBSYSTEMS=="input", ATTRS{name}=="iMON Panel, Knob and Mouse(15c2:ffdc)", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="default.evmap" 
 
+SUBSYSTEMS=="input", ATTRS{name}=="P218ruwido Sky Remote Keyboard", \
+  ENV{eventlircd_enable}="true", \
+  ENV{eventlircd_evmap}="skyqremote.evmap"
+
 #-------------------------------------------------------------------------------
 # Ask eventlircd to handle USB HID devices that show up as event devices and are
 # known to be remote controls. For simplicity, the event map file names have the


### PR DESCRIPTION
Add support for SKY-Q remote (just this model).
![image](https://user-images.githubusercontent.com/1355173/92329329-12724d80-f067-11ea-84af-1c7c8cc29e8c.png)

Besides the usual button configuration I added some buttons that don't have a proper usage at Kodi.
1 - Stop
2 - tv
3 - videos
4 - music
5 - pictures
6 - directly to livetv
7 - directly to epg

Due the strange default handling of the power button you should add that to the keymaps otherwise you likely shutdown your htpc a lot. The kodi default is rather insane for modern remotes :(
`/storage/.kodi/userdata/keymaps/remote.xml`
```
<keymap>
  <global>
    <remote>
      <power>ActivateWindow(ShutdownMenu)</power>
    </remote>
  </global>
</keymap>
```

**Pairing:**
press 7+9 till the red led goes off
wait 2-3sec
press 1+3 till the red led starts blinking
pair at LE