### PR TITLE
kodi: don't enable webserver by default

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -49,14 +49,6 @@
       </group>
     </category>
 
-    <category id="control">
-      <group id="1">
-        <setting id="services.webserver">
-          <default>true</default>
-        </setting>
-      </group>
-    </category>
-
     <category id="smb">
       <group id="2">
         <setting id="smb.maxprotocol">


### PR DESCRIPTION
Kodi defaults to require authentication when the webserver is
enabled and as no password is set this results in an annoying
error box on fresh installations.

![screenshot005](https://user-images.githubusercontent.com/3920953/92724373-c7a84c80-f36a-11ea-8299-f0b24d453618.png)

As neither disabling authentication or pre-setting a well known
password are great options just stop enabling the webserver via
appliance.xml. Users can enable it and choose authentication options
if they like via settings.