### PR TITLE
connman/wireguard package bumps

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="1ee420ace2b8edb0d4025f469aaa3d00d220dc98" # 1.38
-PKG_SHA256="2688c7d1f4b947f4b616157bad9d50234d86d5151a1e1a9e8d51acad2b1481c6"
+PKG_VERSION="82699007fa89e26206771047d8cbb7c160fd2990" # 1.38 + HEAD 31/7/20
+PKG_SHA256="72710b2a0edd57b9ae61285bc2192bbff7317c721ff8a110360f299c35ba9175"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-$PKG_VERSION.tar.gz"

--- a/packages/network/wireguard-linux-compat/package.mk
+++ b/packages/network/wireguard-linux-compat/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-linux-compat"
-PKG_VERSION="v1.0.20200611"
-PKG_SHA256="0a15a6b9798d4df660093eca3e9cc8a9058b3a50130111182348a238e82911be"
+PKG_VERSION="v1.0.20200908"
+PKG_SHA256="83dd096f793641a513f8c1f0ea9999b442873e3c7c590b313d155cbe99d0eab9"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-$PKG_VERSION.tar.xz"

--- a/packages/network/wireguard-tools/config/wireguard/wireguard.config.sample
+++ b/packages/network/wireguard-tools/config/wireguard/wireguard.config.sample
@@ -2,7 +2,6 @@
 Type = WireGuard
 Name = WireGuard VPN Tunnel
 Host = 3.2.5.6
-Domain = my.home.network
 WireGuard.Address = 10.2.0.2/24
 WireGuard.ListenPort = 51820
 WireGuard.PrivateKey = qKIj010hDdWSjQQyVCnEgthLXusBgm3I6HWrJUaJymc=

--- a/packages/network/wireguard-tools/package.mk
+++ b/packages/network/wireguard-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-tools"
-PKG_VERSION="v1.0.20200513"
-PKG_SHA256="4effe7e9c79b70d6ff17a78bdf4e16fb02d4e6711f85beeaea80db5b11435fdb"
+PKG_VERSION="v1.0.20200827"
+PKG_SHA256="ec08772216da73a2f6a925927ce794fe9686ba169bb774e451d34199db19795c"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
This bumps WireGuard packages to latest and ConnMan to current head which adds a couple of minor but useful WireGuard related tweaks: a) The confusing 'domain' config item is now optional (and we drop this from the sample template - there is no impact on users with it configured), b) If using a hostname for the WireGuard 'host' config item instead of an IP address, the DNS is re-resolved at frequent intervals and if an IP change is detected (due to DDNS update) the active WireGuard interface is updated to use the new IP value - it does not prevent downtime, but should minimise it. ConnMan seems to have an annual release cadence in recent years so we need to become acustomed to using a githash.

Not tested on master (and no plan to, I have nothing using master at the moment) but tested on 9.2 without issues.