### PR TITLE
scripts/mkimage: drop chowning image to SUDO_USER

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -319,18 +319,12 @@ if [ "${PROJECT}" = "Generic" ]; then
   echo "image: cleaning up..."
   # remove tmp ${DISK}, vmdk and ovf
   rm "${DISK_BASENAME}.tmp" "${DISK_BASENAME}.vmdk" "${DISK_BASENAME}.ovf"
-  # set owner
-  [ -n "${SUDO_USER}" ] && chown "${SUDO_USER}:" "${DISK_BASENAME}.ova"
 fi
 
 # gzip
 echo "image: compressing..."
 pigz --best --force "${DISK}"
 
-# set owner
-if [ -n "${SUDO_USER}" ]; then
-  chown "${SUDO_USER}:" "${DISK}.gz"
-fi
 # create sha256 checksum of image
 ( cd "${TARGET_IMG}"
   sha256sum $(basename "${DISK}").gz > $(basename "${DISK}").gz.sha256


### PR DESCRIPTION
This is a leftover from ancient times when mkimage had to be run via sudo.