### PR TITLE
Don't define -DMINIMAL=ON for tini

### DIFF
--- a/packages/addons/addon-depends/tini/package.mk
+++ b/packages/addons/addon-depends/tini/package.mk
@@ -11,8 +11,6 @@ PKG_URL="https://github.com/krallin/tini/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Tini is a simplest init system."
 
-PKG_CMAKE_OPTS_TARGET="-DMINIMAL=ON"
-
 PKG_MAKE_OPTS_TARGET="tini-static"
 
 pre_configure_target(){


### PR DESCRIPTION
Fixes #4541

Could that be backported to 9.2?