### PR TITLE
RPi: show guisize limit options in kodi

### DIFF
--- a/projects/RPi/devices/RPi/kodi/appliance.xml
+++ b/projects/RPi/devices/RPi/kodi/appliance.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<settings version="1">
+  <section id="system">
+    <category id="display">
+      <group id="1">
+        <setting id="videoscreen.limitguisize">
+          <default>3</default>
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/projects/RPi/kodi/appliance.xml
+++ b/projects/RPi/kodi/appliance.xml
@@ -9,6 +9,14 @@
         </setting>
       </group>
     </category>
+    <category id="display">
+      <group id="1">
+        <setting id="videoscreen.limitguisize">
+          <visible>true</visible>
+          <default>3</default>
+        </setting>
+      </group>
+    </category>
   </section>
 
 </settings>


### PR DESCRIPTION
The appliance.xml settings to show the guisize limit option in kodi settings got lost when moving to upstream kodi/gbm, add them back.