### PR TITLE
add dbussy python package

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="bb2452866afe7465ce8566eac3dcff8e6ce6f7ce7e0b9e53fd83125ece0c7be2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain Python3 connman pygobject dbus-python"
+PKG_DEPENDS_TARGET="toolchain Python3 connman pygobject dbus-python dbussy"
 PKG_LONGDESC="LibreELEC-settings: is a settings dialog for LibreELEC"
 
 PKG_MAKE_OPTS_TARGET="DISTRONAME=$DISTRONAME ROOT_PASSWORD=$ROOT_PASSWORD"

--- a/packages/python/system/dbussy/package.mk
+++ b/packages/python/system/dbussy/package.mk
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="dbussy"
+PKG_VERSION="1.3"
+PKG_SHA256="30a96caddcbbe7ef9e4f506c01c2d19f529cdaae6d3dac759c103b20e49641fe"
+PKG_LICENSE="LGPLv2.1+"
+PKG_SITE="https://gitlab.com/ldo/dbussy"
+PKG_URL="https://github.com/ldo/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain Python3 dbus"
+PKG_LONGDESC="DBussy is a wrapper around libdbus, written in pure Python"
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+  python3 setup.py build
+}
+
+makeinstall_target() {
+  python3 setup.py install --root=$INSTALL --prefix=/usr
+}
+
+post_makeinstall_target() {
+  python_remove_source
+}


### PR DESCRIPTION
dbussy https://github.com/ldo/dbussy seems to be a very nice alternative to the other python dbus bindings. It's implemented purely in python 3 and only requires libdbus to be installed on the system.

I did a few quick test with the examples from https://github.com/ldo/dbussy_examples , `list_bus_names` and `introspect_all system net.connman` worked fine.

ping @edit4ever please have a look at this