### PR TITLE
factory-reset: cleanup

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -26,6 +26,8 @@ post_makeinstall_target() {
     cp ${PKG_DIR}/scripts/* ${INSTALL}/usr/lib/libreelec
     sed -e "s/@DISTRONAME@/${DISTRONAME}/g" \
       -i ${INSTALL}/usr/lib/libreelec/backup-restore
+    sed -e "s/@DISTRONAME@/${DISTRONAME}/g" \
+      -i ${INSTALL}/usr/lib/libreelec/factory-reset
 
   ADDON_INSTALL_DIR=${INSTALL}/usr/share/kodi/addons/service.libreelec.settings
   python_compile ${ADDON_INSTALL_DIR}/resources/lib/

--- a/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
+++ b/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
@@ -2,17 +2,15 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 . /usr/lib/libreelec/functions
 
-# Get NAME, which is DISTRONAME, ie. LibreELEC
-. /etc/os-release
-
 hidecursor
 
-label=
-target=
-uuid=
+label=""
+target=""
+uuid=""
 
 get_target() {
   for arg in $(cat /proc/cmdline); do
@@ -22,11 +20,11 @@ get_target() {
         case $disk in
           LABEL=*)
             label="${disk#*=}"
-            target="$(blkid -L $label)"
+            target="$(blkid -L ${label})"
             ;;
           UUID=*)
             uuid="${disk#*=}"
-            target="$(blkid -U $uuid)"
+            target="$(blkid -U ${uuid})"
             ;;
           /*)
             target="$disk"
@@ -38,43 +36,45 @@ get_target() {
 }
 
 show_reset_msg() {
-  echo "RESET IN PROGRESS"
-  echo ""
-  echo "Please do not reboot or turn off your ${NAME} device!"
-  echo ""
+  echo -e "RESET IN PROGRESS\n"
+  echo -e "Please do not reboot or turn off your @DISTRONAME@ device!\n"
 }
 
-if [ -f /storage/.cache/reset_oe ] ; then
+if [ -f /storage/.cache/reset_oe ]; then
   # hard reset
   rm -f /storage/.cache/reset_oe
   get_target
-  if [ ! -z $target ] ; then
+  if [ -n "${target}" ]; then
     show_reset_msg
 
     StartProgress spinner "Performing hard reset... "
-      umount /storage
-      mke2fs -t ext4 -m 0 $target &>/dev/null
-      if [ ! -z $label ] ; then
-        tune2fs -U random -L $label $target &>/dev/null
+    if [ -b "${target}" -a $(blkid -o value -s TYPE "${target}") = "ext4" ]; then
+      umount /storage/
+      mke2fs -t ext4 -m 0 "${target}" &>/dev/null
+      if [ -n "${label}" ]; then
+        tune2fs -U random -L "${label}" "${target}" &>/dev/null
       fi
-      if [ ! -z $uuid ] ; then
-        tune2fs -U $uuid $target &>/dev/null
+      if [ -n "${uuid}" ]; then
+        tune2fs -U "${uuid}" "${target}" &>/dev/null
       fi
-      StopProgress "done!"
+    else
+      find /storage/ -mindepth 1 -delete
+    fi
+    StopProgress "done!"
 
     echo
     StartProgress countdown "Rebooting in 5s... " 5 "NOW"
   fi
-elif [ -f /storage/.cache/reset_xbmc ] ; then
+elif [ -f /storage/.cache/reset_xbmc ]; then
   # soft reset
   rm -f /storage/.cache/reset_xbmc
   get_target
-  if [ ! -z $target ] ; then
+  if [ -n "${target}" ]; then
     show_reset_msg
 
     StartProgress spinner "Performing soft reset... "
-      rm -rf /storage/.??* &>/dev/null
-      StopProgress "done!"
+      find /storage/.cache/ /storage/.config/ /storage/.kodi/ -mindepth 1 -delete
+    StopProgress "done!"
 
     echo
     StartProgress countdown "Rebooting in 5s... " 5 "NOW"

--- a/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
+++ b/packages/mediacenter/LibreELEC-settings/scripts/factory-reset
@@ -40,9 +40,9 @@ show_reset_msg() {
   echo -e "Please do not reboot or turn off your @DISTRONAME@ device!\n"
 }
 
-if [ -f /storage/.cache/reset_oe ]; then
+if [ -f /storage/.cache/reset_hard ]; then
   # hard reset
-  rm -f /storage/.cache/reset_oe
+  rm -f /storage/.cache/reset_hard
   get_target
   if [ -n "${target}" ]; then
     show_reset_msg
@@ -65,9 +65,9 @@ if [ -f /storage/.cache/reset_oe ]; then
     echo
     StartProgress countdown "Rebooting in 5s... " 5 "NOW"
   fi
-elif [ -f /storage/.cache/reset_xbmc ]; then
+elif [ -f /storage/.cache/reset_soft ]; then
   # soft reset
-  rm -f /storage/.cache/reset_xbmc
+  rm -f /storage/.cache/reset_soft
   get_target
   if [ -n "${target}" ]; then
     show_reset_msg

--- a/packages/sysutils/busybox/scripts/libreelec-target-generator
+++ b/packages/sysutils/busybox/scripts/libreelec-target-generator
@@ -36,7 +36,7 @@ done
 
 if [ -f /storage/.please_resize_me ]; then
   TARGET="fs-resize.target"
-elif [ -f /storage/.cache/reset_oe -o -f /storage/.cache/reset_xbmc ]; then
+elif [ -f /storage/.cache/reset_hard -o -f /storage/.cache/reset_soft ]; then
   TARGET="factory-reset.target"
 elif [ -f "$BACKUP_FILE" ]; then
   TARGET="backup-restore.target"


### PR DESCRIPTION
This is a cleanup of the system reset script. Two functional changes:

The hard reset is now filesystem agnostic, meaning it will use rm to clear /storage, instead of recreating the filesystem.

The soft reset now specifically deletes .cache, .config and .kodi only. These are the same directories preserved by LE backups