### PR TITLE
e2fsprogs: update to 1.45.6

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -94,14 +94,12 @@ makeinstall_init() {
     ln -sf e2fsck $INSTALL/usr/sbin/fsck.ext2
     ln -sf e2fsck $INSTALL/usr/sbin/fsck.ext3
     ln -sf e2fsck $INSTALL/usr/sbin/fsck.ext4
-    ln -sf e2fsck $INSTALL/usr/sbin/fsck.ext4dev
 
   if [ $INITRAMFS_PARTED_SUPPORT = "yes" ]; then
     cp misc/mke2fs $INSTALL/usr/sbin
     ln -sf mke2fs $INSTALL/usr/sbin/mkfs.ext2
     ln -sf mke2fs $INSTALL/usr/sbin/mkfs.ext3
     ln -sf mke2fs $INSTALL/usr/sbin/mkfs.ext4
-    ln -sf mke2fs $INSTALL/usr/sbin/mkfs.ext4dev
   fi
 }
 

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="e2fsprogs"
-PKG_VERSION="1.45.5"
-PKG_SHA256="f9faccc0d90f73556e797dc7cc5979b582bd50d3f8609c0f2ad48c736d44aede"
+PKG_VERSION="1.45.6"
+PKG_SHA256="ffa7ae6954395abdc50d0f8605d8be84736465afc53b8938ef473fcf7ff44256"
 PKG_LICENSE="GPL"
 PKG_SITE="http://e2fsprogs.sourceforge.net/"
 PKG_URL="https://www.kernel.org/pub/linux/kernel/people/tytso/$PKG_NAME/v$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
Tested via hard reset on rpi3.

I dropped the symlinks for ext4dev because it stopped being a thing after 2.6.28 released (~2008), and I'm not sure LE could even mount such a filesystem (it's not listed in /proc/filesystems). 