### PR TITLE
[getedid] remove kernel check

### DIFF
--- a/packages/sysutils/busybox/scripts/getedid
+++ b/packages/sysutils/busybox/scripts/getedid
@@ -132,12 +132,6 @@ check_content() {
 }
 
 
-check_kernel() {
-  # determine which kernel is in use and store it in a compareable format. This will probably be deprecated for LE10
-  kernel="$(uname -r | sed 's/[^0-9\.].*//g' | awk -F. '{ printf "%d%02d%03d\n",int($1),int($2),int($3) }')"
-}
-
-
 create_edid() {
   # create edid 
   mkdir -p /tmp/cpio/lib/firmware/edid
@@ -182,9 +176,6 @@ intel_amd() {
   # make a backup of $file
   cp "$file" "$file".old
   
-  #check kernel version
-  check_kernel
-
   # add boot parameters to $file
   sed -i "/ APPEND/s/$/ initrd=\/edid.cpio drm.edid_firmware=edid\/edid.bin video=$hdmi:D/" "$file"
 


### PR DESCRIPTION
there's currently no need to check for the kernel in use anymore as the variable `$kernel` also is nowhere in use anymore. Hence we could clean that. 

