### PR TITLE
systemd: add backport patch to fix device enumeration

### DIFF
--- a/packages/sysutils/systemd/patches/systemd-0100-backport-pr-17267.patch
+++ b/packages/sysutils/systemd/patches/systemd-0100-backport-pr-17267.patch
@@ -1,0 +1,188 @@
+From 11e9fec2590d9726c57498d5c2ed9ea2860ad443 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Tue, 13 Oct 2020 22:39:02 +0900
+Subject: [PATCH 1/3] hashmap: introduce {hashmap,set}_put_strdup_full()
+
+They can take hash_ops.
+---
+ src/basic/hashmap.c | 12 ++++++------
+ src/basic/hashmap.h |  5 +++--
+ src/basic/set.h     | 10 ++++++----
+ 3 files changed, 15 insertions(+), 12 deletions(-)
+
+diff --git a/src/basic/hashmap.c b/src/basic/hashmap.c
+index 77cebd9f158..61946cea326 100644
+--- a/src/basic/hashmap.c
++++ b/src/basic/hashmap.c
+@@ -1794,10 +1794,10 @@ int set_consume(Set *s, void *value) {
+         return r;
+ }
+ 
+-int _hashmap_put_strdup(Hashmap **h, const char *k, const char *v  HASHMAP_DEBUG_PARAMS) {
++int _hashmap_put_strdup_full(Hashmap **h, const struct hash_ops *hash_ops, const char *k, const char *v  HASHMAP_DEBUG_PARAMS) {
+         int r;
+ 
+-        r = _hashmap_ensure_allocated(h, &string_hash_ops_free_free  HASHMAP_DEBUG_PASS_ARGS);
++        r = _hashmap_ensure_allocated(h, hash_ops  HASHMAP_DEBUG_PASS_ARGS);
+         if (r < 0)
+                 return r;
+ 
+@@ -1828,14 +1828,14 @@ int _hashmap_put_strdup(Hashmap **h, const char *k, const char *v  HASHMAP_DEBUG
+         return r;
+ }
+ 
+-int _set_put_strdup(Set **s, const char *p  HASHMAP_DEBUG_PARAMS) {
++int _set_put_strdup_full(Set **s, const struct hash_ops *hash_ops, const char *p  HASHMAP_DEBUG_PARAMS) {
+         char *c;
+         int r;
+ 
+         assert(s);
+         assert(p);
+ 
+-        r = _set_ensure_allocated(s, &string_hash_ops_free  HASHMAP_DEBUG_PASS_ARGS);
++        r = _set_ensure_allocated(s, hash_ops  HASHMAP_DEBUG_PASS_ARGS);
+         if (r < 0)
+                 return r;
+ 
+@@ -1849,14 +1849,14 @@ int _set_put_strdup(Set **s, const char *p  HASHMAP_DEBUG_PARAMS) {
+         return set_consume(*s, c);
+ }
+ 
+-int _set_put_strdupv(Set **s, char **l  HASHMAP_DEBUG_PARAMS) {
++int _set_put_strdupv_full(Set **s, const struct hash_ops *hash_ops, char **l  HASHMAP_DEBUG_PARAMS) {
+         int n = 0, r;
+         char **i;
+ 
+         assert(s);
+ 
+         STRV_FOREACH(i, l) {
+-                r = _set_put_strdup(s, *i  HASHMAP_DEBUG_PASS_ARGS);
++                r = _set_put_strdup_full(s, hash_ops, *i  HASHMAP_DEBUG_PASS_ARGS);
+                 if (r < 0)
+                         return r;
+ 
+diff --git a/src/basic/hashmap.h b/src/basic/hashmap.h
+index 890f90a9d11..6933c0b1e62 100644
+--- a/src/basic/hashmap.h
++++ b/src/basic/hashmap.h
+@@ -153,8 +153,9 @@ static inline int ordered_hashmap_put(OrderedHashmap *h, const void *key, void *
+         return hashmap_put(PLAIN_HASHMAP(h), key, value);
+ }
+ 
+-int _hashmap_put_strdup(Hashmap **h, const char *k, const char *v  HASHMAP_DEBUG_PARAMS);
+-#define hashmap_put_strdup(h, k, v) _hashmap_put_strdup(h, k, v  HASHMAP_DEBUG_SRC_ARGS)
++int _hashmap_put_strdup_full(Hashmap **h, const struct hash_ops *hash_ops, const char *k, const char *v  HASHMAP_DEBUG_PARAMS);
++#define hashmap_put_strdup_full(h, hash_ops, k, v) _hashmap_put_strdup_full(h, hash_ops, k, v  HASHMAP_DEBUG_SRC_ARGS)
++#define hashmap_put_strdup(h, k, v) hashmap_put_strdup_full(h, &string_hash_ops_free_free, k, v)
+ 
+ int hashmap_update(Hashmap *h, const void *key, void *value);
+ static inline int ordered_hashmap_update(OrderedHashmap *h, const void *key, void *value) {
+diff --git a/src/basic/set.h b/src/basic/set.h
+index 7170eea84c1..7749c18c457 100644
+--- a/src/basic/set.h
++++ b/src/basic/set.h
+@@ -128,10 +128,12 @@ int _set_ensure_consume(Set **s, const struct hash_ops *hash_ops, void *key  HAS
+ 
+ int set_consume(Set *s, void *value);
+ 
+-int _set_put_strdup(Set **s, const char *p  HASHMAP_DEBUG_PARAMS);
+-#define set_put_strdup(s, p) _set_put_strdup(s, p  HASHMAP_DEBUG_SRC_ARGS)
+-int _set_put_strdupv(Set **s, char **l  HASHMAP_DEBUG_PARAMS);
+-#define set_put_strdupv(s, l) _set_put_strdupv(s, l  HASHMAP_DEBUG_SRC_ARGS)
++int _set_put_strdup_full(Set **s, const struct hash_ops *hash_ops, const char *p  HASHMAP_DEBUG_PARAMS);
++#define set_put_strdup_full(s, hash_ops, p) _set_put_strdup_full(s, hash_ops, p  HASHMAP_DEBUG_SRC_ARGS)
++#define set_put_strdup(s, p) set_put_strdup_full(s, &string_hash_ops_free, p)
++int _set_put_strdupv_full(Set **s, const struct hash_ops *hash_ops, char **l  HASHMAP_DEBUG_PARAMS);
++#define set_put_strdupv_full(s, hash_ops, l) _set_put_strdupv_full(s, hash_ops, l  HASHMAP_DEBUG_SRC_ARGS)
++#define set_put_strdupv(s, l) set_put_strdupv_full(s, &string_hash_ops_free, l)
+ 
+ int set_put_strsplit(Set *s, const char *v, const char *separators, ExtractFlags flags);
+ 
+
+From 5e71868ced159355a25dc935b24c8e9b1d946bd7 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Tue, 13 Oct 2020 22:40:19 +0900
+Subject: [PATCH 2/3] util: introduce two trivial hash_ops
+
+Will be used in a later commit.
+---
+ src/basic/hash-funcs.c | 13 +++++++++++++
+ src/basic/hash-funcs.h |  2 ++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/src/basic/hash-funcs.c b/src/basic/hash-funcs.c
+index cf279e5cbef..83016c0fd61 100644
+--- a/src/basic/hash-funcs.c
++++ b/src/basic/hash-funcs.c
+@@ -71,6 +71,19 @@ const struct hash_ops trivial_hash_ops = {
+         .compare = trivial_compare_func,
+ };
+ 
++const struct hash_ops trivial_hash_ops_free = {
++        .hash = trivial_hash_func,
++        .compare = trivial_compare_func,
++        .free_key = free,
++};
++
++const struct hash_ops trivial_hash_ops_free_free = {
++        .hash = trivial_hash_func,
++        .compare = trivial_compare_func,
++        .free_key = free,
++        .free_value = free,
++};
++
+ void uint64_hash_func(const uint64_t *p, struct siphash *state) {
+         siphash24_compress(p, sizeof(uint64_t), state);
+ }
+diff --git a/src/basic/hash-funcs.h b/src/basic/hash-funcs.h
+index 005d1b21d21..fb602009416 100644
+--- a/src/basic/hash-funcs.h
++++ b/src/basic/hash-funcs.h
+@@ -88,6 +88,8 @@ extern const struct hash_ops path_hash_ops_free;
+ void trivial_hash_func(const void *p, struct siphash *state);
+ int trivial_compare_func(const void *a, const void *b) _const_;
+ extern const struct hash_ops trivial_hash_ops;
++extern const struct hash_ops trivial_hash_ops_free;
++extern const struct hash_ops trivial_hash_ops_free_free;
+ 
+ /* 32bit values we can always just embed in the pointer itself, but in order to support 32bit archs we need store 64bit
+  * values indirectly, since they don't fit in a pointer. */
+
+From a0887abbd8bd9f1a9a975af08e6b4a43960bb3e2 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Tue, 13 Oct 2020 22:41:34 +0900
+Subject: [PATCH 3/3] sd-device: use trivial_hash_ops_free_free for managing
+ match sysattrs or properties
+
+This fixes an issue caused by eb1c1dc029c91750e6255c3fd844b4f4bf238fab.
+
+Before the commit, multiple values can be specified for the same
+sysattr or property.
+
+Fixes #17259.
+---
+ src/libsystemd/sd-device/device-enumerator.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libsystemd/sd-device/device-enumerator.c b/src/libsystemd/sd-device/device-enumerator.c
+index f3bac17ca3a..2d1ce798887 100644
+--- a/src/libsystemd/sd-device/device-enumerator.c
++++ b/src/libsystemd/sd-device/device-enumerator.c
+@@ -118,7 +118,7 @@ _public_ int sd_device_enumerator_add_match_sysattr(sd_device_enumerator *enumer
+         else
+                 hashmap = &enumerator->nomatch_sysattr;
+ 
+-        r = hashmap_put_strdup(hashmap, sysattr, value);
++        r = hashmap_put_strdup_full(hashmap, &trivial_hash_ops_free_free, sysattr, value);
+         if (r <= 0)
+                 return r;
+ 
+@@ -133,7 +133,7 @@ _public_ int sd_device_enumerator_add_match_property(sd_device_enumerator *enume
+         assert_return(enumerator, -EINVAL);
+         assert_return(property, -EINVAL);
+ 
+-        r = hashmap_put_strdup(&enumerator->match_property, property, value);
++        r = hashmap_put_strdup_full(&enumerator->match_property, &trivial_hash_ops_free_free, property, value);
+         if (r <= 0)
+                 return r;
+ 


### PR DESCRIPTION
Revert the problematic systemd commit (plus a dependent one) that
causes partitions to be missing in kodi's "Files" list.

See https://github.com/systemd/systemd/issues/17259