### PR TITLE
linux-firmware: pick mrvl/sd8897_uapsta.bin for Generic

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
@@ -1,6 +1,7 @@
 ath10k/*
 ctefx.bin
 lbtf_usb.bin
+mrvl/sd8897_uapsta.bin
 qca/*00000302.bin
 rt2561.bin
 rt2561s.bin


### PR DESCRIPTION
This picks the firmware needed for WiFi support on Dell (Wyse) 3040 devices into the Generic image, as per forum posts:

https://forum.libreelec.tv/thread/21537-dell-wyse-3040-wifi-not-working/