### PR TITLE
add game.libretro.atari800

### DIFF
--- a/packages/emulation/libretro-atari800/package.mk
+++ b/packages/emulation/libretro-atari800/package.mk
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-atari800"
+PKG_VERSION="ac0bc2e690fda9e0b7c85600bc6b9d2e27e3b41f"
+PKG_SHA256="d2197ad9e19b5969844603f35e30a8fbaaba87688a6906fa53b84950ecb17593"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/libretro/libretro-atari800"
+PKG_URL="https://github.com/libretro/libretro-atari800/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_LONGDESC="Atari 8-bit computer and 5200 console emulator"
+PKG_TOOLCHAIN="make"
+
+PKG_MAKE_OPTS_TARGET="platform=unix"
+
+PKG_LIBNAME="atari800_libretro.so"
+PKG_LIBPATH="$PKG_LIBNAME"
+PKG_LIBVAR="ATARI800_LIB"
+
+makeinstall_target() {
+  mkdir -p $SYSROOT_PREFIX/usr/lib/cmake/$PKG_NAME
+  cp $PKG_LIBPATH $SYSROOT_PREFIX/usr/lib/$PKG_LIBNAME
+  echo "set($PKG_LIBVAR $SYSROOT_PREFIX/usr/lib/$PKG_LIBNAME)" > $SYSROOT_PREFIX/usr/lib/cmake/$PKG_NAME/$PKG_NAME-config.cmake
+}

--- a/packages/emulation/libretro-atari800/package.mk
+++ b/packages/emulation/libretro-atari800/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-atari800"
-PKG_VERSION="ac0bc2e690fda9e0b7c85600bc6b9d2e27e3b41f"
-PKG_SHA256="d2197ad9e19b5969844603f35e30a8fbaaba87688a6906fa53b84950ecb17593"
+PKG_VERSION="70182481ec0ce2d027ed6fb3f7296d9662c7d58e"
+PKG_SHA256="12edac9c3a4cacdd1139f21d2cafee1d66152d53d1114ee2bf613dcb8b827bbe"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-atari800"
 PKG_URL="https://github.com/libretro/libretro-atari800/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.atari800"
+PKG_VERSION="3.1.0.4-Matrix"
+PKG_SHA256="15d3dfa8a59c8ea3e1be564c31f09d6dd6394f660d61219f43d8b8adac0a046a"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.libretro.atari800"
+PKG_URL="https://github.com/kodi-game/game.libretro.atari800/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-atari800"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.atari800: atari800 for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
Runtime tested on RPi4.

Note: be careful for now with the update_retroplayer-addons script, libretro-atari800 is currently ahead of the version referenced by the kodi addon.

The libretro-atari800 bump is required as the currently referenced version doesn't build (libretro-atari800 got a git submodule a few months ago, so the archive was missing code, and this was finally reverted just 3 days ago).