### PR TITLE
bcm_sta: fix building on Linux 5.9

### DIFF
--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-0400-kernel-5.9-fix.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-0400-kernel-5.9-fix.patch
@@ -1,0 +1,12 @@
+--- a/x86-64/src/wl/sys/wl_linux.c	2020-10-12 21:19:15.256305165 +0000
++++ b/x86-64/src/wl/sys/wl_linux.c	2020-10-12 21:20:38.687530895 +0000
+@@ -1643,7 +1643,7 @@
+ 		goto done2;
+ 	}
+ 
+-	if (segment_eq(get_fs(), KERNEL_DS))
++	if (get_fs().seg == KERNEL_DS.seg)
+ 		buf = ioc.buf;
+ 
+ 	else if (ioc.buf) {
+


### PR DESCRIPTION
This is required for Generic after #4594 