### PR TITLE
kodi: move environment variables in systemd unit to environment file

### DIFF
--- a/packages/mediacenter/kodi/config/kodi.conf
+++ b/packages/mediacenter/kodi/config/kodi.conf
@@ -1,0 +1,4 @@
+KODI_AE_SINK=ALSA+PULSE
+HOME=/storage
+KODI_TEMP=/storage/.kodi/temp
+KODI_HOME=/usr/share/kodi/

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -258,6 +258,20 @@ post_makeinstall_target() {
         -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
         -i $INSTALL/usr/lib/kodi/kodi.sh
 
+    cp $PKG_DIR/config/kodi.conf $INSTALL/usr/lib/kodi/kodi.conf
+
+    # set default display environment
+    if [ "$DISPLAYSERVER" = "x11" ]; then
+      echo "DISPLAY=:0.0" >> $INSTALL/usr/lib/kodi/kodi.conf
+    elif [ "$DISPLAYSERVER" = "weston" ]; then 
+      echo "WAYLAND_DISPLAY=wayland-0" >> $INSTALL/usr/lib/kodi/kodi.conf
+    fi
+
+    # nvidia: Enable USLEEP to reduce CPU load while rendering
+    if listcontains "${GRAPHIC_DRIVERS}" "nvidia" || listcontains "${GRAPHIC_DRIVERS}" "nvidia-legacy"; then
+      echo "__GL_YIELD=USLEEP" >> $INSTALL/usr/lib/kodi/kodi.conf
+    fi
+
   mkdir -p $INSTALL/usr/sbin
     cp $PKG_DIR/scripts/service-addon-wrapper $INSTALL/usr/sbin
 

--- a/packages/mediacenter/kodi/system.d/kodi.service
+++ b/packages/mediacenter/kodi/system.d/kodi.service
@@ -5,14 +5,7 @@ Requires=graphical.target
 Wants=network-online.target
 
 [Service]
-Environment=KODI_AE_SINK=ALSA+PULSE
-Environment=__GL_YIELD=USLEEP
-Environment=DISPLAY=:0.0
-Environment=WAYLAND_DISPLAY=wayland-0
-Environment=SDL_MOUSE_RELATIVE=0
-Environment=HOME=/storage
-Environment=KODI_TEMP=/storage/.kodi/temp
-Environment=KODI_HOME=/usr/share/kodi/
+EnvironmentFile=/usr/lib/kodi/kodi.conf
 EnvironmentFile=-/run/libreelec/kodi.conf
 EnvironmentFile=-/run/libreelec/debug/kodi.conf
 ExecStartPre=-/usr/lib/kodi/kodi-config


### PR DESCRIPTION
Only set DISPLAY or WAYLAND_DISPLAY if actually running under
x11/wayland. This fixes latest kodi gbm refusing to start because
it thinks a window manager is active.

Also set the Nvidia-specific __GL_YIELD only when Nvidia drivers
are actually used and drop SDL_MOUSE_RELATIVE - kodi stopped using
SDL a long time ago.

Runtime tested on RPi4. Generic build test also looks good (correct /usr/lib/kodi/kodi.conf file created), but it would be nice if someone could runtime test this on Generic