### PR TITLE
October Package Updates 2: Electric Boogaloo

### DIFF
--- a/packages/addons/tools/network-tools/changelog.txt
+++ b/packages/addons/tools/network-tools/changelog.txt
@@ -1,3 +1,6 @@
+105
+- update rsync to 3.2.3
+
 104
 - drop iw
 

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="104"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libfmt"
-PKG_VERSION="7.0.1"
-PKG_SHA256="ac335a4ca6beaebec4ddb2bc35b9ae960b576f3b64a410ff2c379780f0cd4948"
+PKG_VERSION="7.0.3"
+PKG_SHA256="b4b51bc16288e2281cddc59c28f0b4f84fed58d016fb038273a09f05f8473297"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/fmtlib/fmt"
 PKG_URL="https://github.com/fmtlib/fmt/archive/$PKG_VERSION.tar.gz"

--- a/packages/devel/spdlog/package.mk
+++ b/packages/devel/spdlog/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spdlog"
-PKG_VERSION="1.7.0"
-PKG_SHA256="f0114a4d3c88be9e696762f37a7c379619443ce9d668546c61b21d41affe5b62"
+PKG_VERSION="1.8.1"
+PKG_SHA256="5197b3147cfcfaa67dd564db7b878e4a4b3d9f3443801722b3915cdeced656cb"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/gabime/spdlog"
 PKG_URL="https://github.com/gabime/spdlog/archive/v$PKG_VERSION.tar.gz"

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="20.2.0"
-PKG_SHA256="3ccb2167ba538535c03a2432d007af12682f75522117a93db5a8b7c634b5294a"
+PKG_VERSION="20.2.1"
+PKG_SHA256="c7d97c519fe54e6b981d2af5b3919a8b6a196b7453350561610dbb5cbc9063e9"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://github.com/mesa3d/mesa/archive/mesa-${PKG_VERSION}.tar.gz"

--- a/packages/network/rsync/package.mk
+++ b/packages/network/rsync/package.mk
@@ -2,19 +2,26 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rsync"
-PKG_VERSION="3.1.3"
-PKG_SHA256="55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0"
+PKG_VERSION="3.2.3"
+PKG_SHA256="becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e"
 PKG_LICENSE="GPLv3"
 PKG_SITE="http://www.samba.org/ftp/rsync/rsync.html"
 PKG_URL="https://download.samba.org/pub/rsync/src/$PKG_NAME-$PKG_VERSION.tar.gz"
-PKG_DEPENDS_HOST="autotools:host"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_HOST="autotools:host zlib:host zstd:host"
+PKG_DEPENDS_TARGET="toolchain zlib"
 PKG_LONGDESC="A very fast method for bringing remote files into sync."
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_HOST="--with-included-popt \
-                         --with-included-zlib"
+                         --without-included-zlib \
+                         --disable-lz4 \
+                         --enable-zstd \
+                         --disable-xxhash"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-acl-support \
                            --disable-xattr-support \
-                           --with-included-popt"
+                           --with-included-popt \
+                           --without-include-zlib \
+                           --disable-lz4 \
+                           --disable-zstd \
+                           --disable-xxhash"

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.12.5"
-PKG_SHA256="54b41cc6378acae20dd155ba55d78ff171875c2eaa3f05f87b485d3d6891b815"
+PKG_VERSION="4.12.7"
+PKG_SHA256="30556a0dd2f9ab3b251eb9db6132ffd4379c159f574366fc2f2eabbc018c6fd2"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Run tested on RPi3. 

rsync:host tested in build. rsync:target (and hence network-tools) was not. Some configuration changes to make use of zstd (available on host) and external zlib on host & target since it's available and shrinks package slightly iirc. Makes it incompatible with very old versions of rsync (like 6+ years old).

samba-4.12.8 is available but made changes to heimdal which affects a patch here. Could be trivial; I didn't look.