### PR TITLE
update_retroplayer-addons: match lastest tag with kodi branch in name

### DIFF
--- a/tools/mkpkg/update_common_functions
+++ b/tools/mkpkg/update_common_functions
@@ -61,8 +61,16 @@ resolve_hash_in_branch() {
 }
 
 resolve_tag_in_branch() {
+  local tag
   if [ -d "$1" ] ; then
     cd "$1"
+    if [ $# -eq 3 ] ; then
+      tag=$(git describe --abbrev=0 --tags --match "$3" origin/$2 2>/dev/null)
+      if [ -n "$tag" ] ; then
+        echo "$tag"
+        return
+      fi
+    fi
     git describe --abbrev=0 --tags origin/$2 2>/dev/null
   fi
 }

--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -115,7 +115,7 @@ for addon in ${ADDONS_DIR}/*.*/ ; do
   CHECK_RETRO=""
 
   git_clone "${GAME_GIT_REPO}" "${GAME_GIT_DIR}"
-  GAME_NEW_VERSION=$(resolve_tag_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}")
+  GAME_NEW_VERSION=$(resolve_tag_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}" "*-${KODI_BRANCH}")
   if [ -z "${GAME_NEW_VERSION}" ]; then
     NO_TAG="yes"
     echo "========================================================================"


### PR DESCRIPTION
If no tag with the kodi branch name can be found, fall back to the
latest tag in the branch.

This fixes ambiguity if both a -Leia and a -Matrix tag point to the
same githash.