### PR TITLE
RTL8812AU: Change source code to aircrack-ng

### DIFF
--- a/packages/linux-drivers/RTL8812AU/package.mk
+++ b/packages/linux-drivers/RTL8812AU/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8812AU"
-PKG_VERSION="8af27f5bebe1c890879fb2cc50e672a7f55c6505"
-PKG_SHA256="6badcf35d7f42e0f906000d7cf59b0afcdc7d97f41de16e54158cf53e1518c58"
+PKG_VERSION="e9fbf5c051453941bbc029810b893a6c010714e6"
+PKG_SHA256="a79f06b1b2d9fd880cddebe7723b7e46abf9a8ba1c40c1eee6498c623913cadb"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/MilhouseVH/RTL8812AU"
-PKG_URL="https://github.com/MilhouseVH/RTL8812AU/archive/$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/aircrack-ng/rtl8812au"
+PKG_URL="https://github.com/aircrack-ng/rtl8812au/archive/$PKG_VERSION.tar.gz"
 PKG_LONGDESC="Realtek RTL8812AU Linux 3.x driver"
 PKG_IS_KERNEL_PKG="yes"
 


### PR DESCRIPTION
Change the source code from @MilhouseVH repository to  [aircrack-ng](https://github.com/aircrack-ng/rtl8812au).

Repository looks maintained and updated.

aircrack-ng is used as upstream by other projects like [armbian](https://github.com/armbian/build/blob/master/lib/compilation-prepare.sh#L317).
