### PR TITLE
kmscube: bump to HEAD and revise package

### DIFF
--- a/packages/graphics/kmscube/package.mk
+++ b/packages/graphics/kmscube/package.mk
@@ -2,14 +2,13 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kmscube"
-PKG_VERSION="98f31bf"
-PKG_SHA256="78b52b9e606f0d3444e10ea2ed7c0c03a87f1ad2ef99e35036551395faade041"
+PKG_VERSION="26326be53e30da9c101075fda081d38ea9ec758d"
+PKG_SHA256="ce96a78edd37387058a81070950c993853f427959cfafc15cfc5f78e9f2e9b07"
 PKG_LICENSE="GPL"
-PKG_SITE="https://cgit.freedesktop.org/mesa/kmscube"
-PKG_URL="https://cgit.freedesktop.org/mesa/kmscube/snapshot/$PKG_VERSION.tar.xz"
+PKG_SITE="https://gitlab.freedesktop.org/mesa/kmscube"
+PKG_URL="https://gitlab.freedesktop.org/mesa/kmscube/-/archive/master/kmscube-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Example KMS/GBM/EGL application"
-PKG_TOOLCHAIN="autotools"
 
 if [ "$OPENGLES_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" $OPENGLES"


### PR DESCRIPTION
FDO moved their upstream repos to gitlab so switch URLs to use them and bump to current HEAD. The buildsystem also changed to meson but setting "auto" works fine.