### PR TITLE
rsync: fix target build

### DIFF
--- a/packages/network/rsync/package.mk
+++ b/packages/network/rsync/package.mk
@@ -19,9 +19,12 @@ PKG_CONFIGURE_OPTS_HOST="--with-included-popt \
                          --disable-xxhash"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-acl-support \
-                           --disable-xattr-support \
-                           --with-included-popt \
-                           --without-include-zlib \
+                           --disable-asm \
                            --disable-lz4 \
+                           --disable-md2man \
+                           --disable-simd \
+                           --disable-xattr-support \
+                           --disable-xxhash \
                            --disable-zstd \
-                           --disable-xxhash"
+                           --with-included-popt \
+                           --without-included-zlib"


### PR DESCRIPTION
broken for target since https://github.com/LibreELEC/LibreELEC.tv/pull/4604
@antonlacon, looks working

added 
```
                           --disable-asm \
                           --disable-md2man \
                           --disable-simd \
```
and sorted options