### PR TITLE
brcmfmac_sdio-firmware-rpi: update to 9c0ffe9

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="39f45e47c480f46b334770b88a738f12cc00010c"
-PKG_SHA256="8a830d67a3758f9453b10efc9592515289df9b8743ae1a05bc1fd046bde6969f"
+PKG_VERSION="9c0ffe9a7f0753b36ed88f7981905a989d940ea9"
+PKG_SHA256="cf806f6bdba0f803b90bc210f524a6ac37bac7ad19306c61474bb2dc59875e87"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"
 PKG_URL="https://github.com/LibreELEC/$PKG_NAME/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Sync with RPi-Distro repos, add Pi 400 firmwares