### PR TITLE
intel-ucode: update to intel-ucode-20201110

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20200508"
-PKG_SHA256="f5ed22de61be346fe28918eed196d052432e2af13a3d6eb5823d528ee9bbef81"
+PKG_VERSION="20201110"
+PKG_SHA256="c9e42ad0032d8cd611c7bc2fb94a16429ac485c7971809737b055550a49f58b8"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"


### PR DESCRIPTION
Resolution for SRBDS. 
Was previously rolled back in 20200616. 
Fixes Skylake CPUs. 

Also security updates for:
Security updates for INTEL-SA-00381.
Security updates for INTEL-SA-00389.

Release notes at https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases

Tested on NUC6

[    0.000000] microcode: microcode updated early to revision 0xe2, date = 2020-07-14
[    0.000000] Linux version 5.9.7 (rudi@10ad6d490609) (x86_64-libreelec-linux-gnu-gcc-10.2.0 (GCC) 10.2.0, GNU ld (GNU Binutils) 2.34) #1 SMP Wed Nov 11 10:04:38 UTC 2020
[    0.222354] SRBDS: Mitigation: Microcode
[    0.226459] smpboot: CPU0: Intel(R) Core(TM) i5-6260U CPU @ 1.80GHz (family: 0x6, model: 0x4e, stepping: 0x3)
[    1.589680] microcode: sig=0x406e3, pf=0x40, revision=0xe2
[    1.589838] microcode: Microcode Update Driver: v2.2.