### PR TITLE
Allwinner: H2-plus: enable ethernet on Banana Pi M2 Zero

### DIFF
--- a/projects/Allwinner/devices/H2-plus/patches/linux/94-bananapim2-zero-ethernet.patch
+++ b/projects/Allwinner/devices/H2-plus/patches/linux/94-bananapim2-zero-ethernet.patch
@@ -1,0 +1,22 @@
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+index 4c6704e4c57e..ad3e16ea2d96 100644
+--- a/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+@@ -20,6 +20,7 @@ / {
+ 	aliases {
+ 		serial0 = &uart0;
+ 		serial1 = &uart1;
++		ethernet0 = &emac;
+ 	};
+ 
+ 	chosen {
+@@ -151,3 +152,9 @@ &usbphy {
+ 	 */
+ 	status = "okay";
+ };
++
++&emac {
++	status = "okay";
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++};


### PR DESCRIPTION
This adds device tree information for the on-board 10/100 Mbps
interface. See [linux-sunxi.org] and [banana-pi.org] for how to
connect an RJ45 jack to the board.

[linux-sunxi.org]: https://linux-sunxi.org/Sinovoip_Banana_Pi_M2_Zero#Ethernet
[banana-pi.org]: http://wiki.banana-pi.org/Banana_Pi_BPI-M2_ZERO#how_to_use_zero_10.2F100_Ethernet