### PR TITLE
chrome: fix default audio device detection

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -12,7 +12,8 @@ PKG_DEPENDS_TARGET="toolchain atk dbus glib libXtst"
 PKG_LONGDESC="Protocol definitions and daemon for D-Bus at-spi."
 
 PKG_MESON_OPTS_TARGET="-Denable_docs=false \
-                       -Denable-introspection=no"
+                       -Denable-introspection=no \
+                       -Ddbus_daemon=/usr/bin/dbus-daemon"
 
 pre_configure_target() {
   TARGET_LDFLAGS="$LDFLAGS -lXext"

--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,3 +1,6 @@
+103
+- fix getting default audio device
+
 102
 - add dark mode at options
 - support for latest Chrome

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
-PKG_REV="102"
+PKG_REV="103"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/addons/browser/chrome/source/default.py
+++ b/packages/addons/browser/chrome/source/default.py
@@ -9,9 +9,7 @@ import xbmcaddon
 import subprocess
 import json
 
-sys.path.append('/usr/share/kodi/addons/@DISTRO_PKG_SETTINGS_ID@')
-
-import oe
+import xbmc
 
 __addon__ = xbmcaddon.Addon();
 __path__  = os.path.join(__addon__.getAddonInfo('path'), 'bin') + '/'
@@ -49,7 +47,7 @@ def startchrome(args):
                     __addon__.getSetting('HOMEPAGE')
     subprocess.call(__path__ + 'chrome-start ' + chrome_params, shell=True, env=new_env)
   except Exception as e:
-    oe.dbg_log('chrome', e)
+    xbmc.log('## Chrome Error:' + repr(e), xbmc.LOGERROR)
 
 def isRuning(pname):
   tmp = os.popen("ps -Af").read()
@@ -101,3 +99,4 @@ else:
       time.sleep(1)
     resumeXbmc()
 
+del __addon__

--- a/packages/addons/browser/chrome/source/default.py
+++ b/packages/addons/browser/chrome/source/default.py
@@ -7,7 +7,7 @@ import sys
 import time
 import xbmcaddon
 import subprocess
-from xml.dom.minidom import parse
+import json
 
 sys.path.append('/usr/share/kodi/addons/@DISTRO_PKG_SETTINGS_ID@')
 
@@ -59,21 +59,22 @@ def isRuning(pname):
   return False
 
 def getAudioDevice():
-  try:
-    dom = parse("/storage/.kodi/userdata/guisettings.xml")
-    audiooutput=dom.getElementsByTagName('audiooutput')
-    for node in audiooutput:
-      dev = node.getElementsByTagName('audiodevice')[0].childNodes[0].nodeValue
-    if dev.startswith("ALSA:"):
-      dev = dev.split("ALSA:")[1]
-      if dev == "@":
-        return None
-      if dev.startswith("@:"):
-        dev = dev.split("@:")[1]
-    else:
-      # not ALSA
+  dev = json.loads(xbmc.executeJSONRPC(json.dumps({
+                      "jsonrpc": "2.0",
+                      "method": "Settings.GetSettingValue",
+                      "params": {
+                                  "setting": "audiooutput.audiodevice",
+                                },
+                      "id": 1,
+                   })))['result']['value']
+  if dev.startswith("ALSA:"):
+    dev = dev.split("ALSA:")[1]
+    if dev == "@":
       return None
-  except:
+    if dev.startswith("@:"):
+      dev = dev.split("@:")[1]
+  else:
+    # not ALSA
     return None
   if dev.startswith("CARD="):
     dev = "plughw:" + dev


### PR DESCRIPTION
Since guisettings.xml settings format was changed to version 2 the default audio device wss not detected any more.

Use Kodi json RPC to read the string.

at-spi2-core: building of the package failed when dbus-daemon binary was not installed on the build host (i.e. LE docker image). Set the target path.

In third commit the usage of oe.py is removed and a log warning fixed.

Runtime tested and checked that different device names are passed to chrome commend line.