### PR TITLE
chrome: fix default audio device detection / update for latest version

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -12,7 +12,8 @@ PKG_DEPENDS_TARGET="toolchain atk dbus glib libXtst"
 PKG_LONGDESC="Protocol definitions and daemon for D-Bus at-spi."
 
 PKG_MESON_OPTS_TARGET="-Denable_docs=false \
-                       -Denable-introspection=no"
+                       -Denable-introspection=no \
+                       -Ddbus_daemon=/usr/bin/dbus-daemon"
 
 pre_configure_target() {
   LDFLAGS="$LDFLAGS -lXext"

--- a/packages/addons/addon-depends/chrome-depends/chrome-libxkbcommon/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libxkbcommon/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+. $(get_pkg_directory libxkbcommon)/package.mk
+
+PKG_NAME="chrome-libxkbcommon"
+PKG_LONGDESC="libxkbcommon for chrome"
+PKG_URL=""
+PKG_DEPENDS_UNPACK+=" libxkbcommon"
+# linking failed with meson
+PKG_TOOLCHAIN="autotools"
+
+PKG_CONFIGURE_OPTS_TARGET="--enable-docs \
+                           --disable-wayland \
+                           --disable-static \
+                           --enable-shared"
+
+unpack() {
+  mkdir -p $PKG_BUILD
+  tar --strip-components=1 -xf $SOURCES/${PKG_NAME:7}/${PKG_NAME:7}-$PKG_VERSION.tar.xz -C $PKG_BUILD
+}
+
+makeinstall_target() {
+  :
+}

--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,3 +1,7 @@
+104
+- fix getting default audio device
+- support for latest Chrome
+
 103
 - add flag for dark mode
 

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -9,8 +9,8 @@ PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"
 PKG_DEPENDS_TARGET="toolchain at-spi2-atk atk cairo chrome-libXcomposite \
                     chrome-libXdamage chrome-libXfixes chrome-libXi chrome-libXrender \
-                    chrome-libXtst chrome-libxcb cups gdk-pixbuf gtk3 harfbuzz \
-                    libXcursor libxss nss pango scrnsaverproto unclutter"
+                    chrome-libXtst chrome-libxcb chrome-libxkbcommon cups gdk-pixbuf gtk3 \
+                    harfbuzz libXcursor libxss nss pango scrnsaverproto unclutter"
 PKG_SECTION="browser"
 PKG_SHORTDESC="Google Chrome Browser"
 PKG_LONGDESC="Google Chrome Browser"
@@ -82,6 +82,9 @@ addon() {
 
   # libXi  
   cp -PL $(get_build_dir chrome-libXi)/.$TARGET_NAME/src/.libs/libXi.so.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
+
+  # libxkbcommon
+  cp -PL $(get_build_dir chrome-libxkbcommon)/.$TARGET_NAME/.libs/libxkbcommon.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
 
   # libXrender
   cp -PL $(get_build_dir chrome-libXrender)/.$TARGET_NAME/src/.libs/libXrender.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib

--- a/packages/addons/browser/chrome/source/default.py
+++ b/packages/addons/browser/chrome/source/default.py
@@ -7,7 +7,7 @@ import sys
 import time
 import xbmcaddon
 import subprocess
-from xml.dom.minidom import parse
+import json
 
 sys.path.append('/usr/share/kodi/addons/service.libreelec.settings')
 
@@ -59,21 +59,22 @@ def isRuning(pname):
   return False
 
 def getAudioDevice():
-  try:
-    dom = parse("/storage/.kodi/userdata/guisettings.xml")
-    audiooutput=dom.getElementsByTagName('audiooutput')
-    for node in audiooutput:
-      dev = node.getElementsByTagName('audiodevice')[0].childNodes[0].nodeValue
-    if dev.startswith("ALSA:"):
-      dev = dev.split("ALSA:")[1]
-      if dev == "@":
-        return None
-      if dev.startswith("@:"):
-        dev = dev.split("@:")[1]
-    else:
-      # not ALSA
+  dev = json.loads(xbmc.executeJSONRPC(json.dumps({
+                      "jsonrpc": "2.0",
+                      "method": "Settings.GetSettingValue",
+                      "params": {
+                                  "setting": "audiooutput.audiodevice",
+                                },
+                      "id": 1,
+                   })))['result']['value']
+  if dev.startswith("ALSA:"):
+    dev = dev.split("ALSA:")[1]
+    if dev == "@":
       return None
-  except:
+    if dev.startswith("@:"):
+      dev = dev.split("@:")[1]
+  else:
+    # not ALSA
     return None
   if dev.startswith("CARD="):
     dev = "plughw:" + dev


### PR DESCRIPTION
Since guisettings.xml settings format was changed to version 2 the default audio device wss not detected any more.

Use Kodi json RPC to read the string.

at-spi2-core: building of the package failed when dbus-daemon binary was not installed on the build host (i.e. LE docker image). Set the target path.

Runtime tested and checked that different device names are passed to chrome commend line.

Partial backport of #4665 and #4686