### PR TITLE
brcmfmac_sdio-firmware: Banana Pi M2 Zero fix

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware/scripts/brcmfmac-firmware-setup
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/scripts/brcmfmac-firmware-setup
@@ -5,7 +5,10 @@
 
 DTNAME=$(/usr/bin/dtname)
 
-if [ "$DTNAME" = "khadas,vim" -o "$DTNAME" = "xunlong,orangepi-win" -o "$DTNAME" = "sinovoip,bpi-m2-ultra" ]; then
+if [ "$DTNAME" = "khadas,vim" -o \
+  "$DTNAME" = "xunlong,orangepi-win" -o \
+  "$DTNAME" = "sinovoip,bpi-m2-ultra" -o \
+  "$DTNAME" = "sinovoip,bpi-m2-zero" ]; then
   ln -sf /usr/lib/kernel-overlays/base/lib/firmware/brcm/BCM43430A1.vim /usr/lib/firmware/brcm/BCM43430A1.hcd
 else
   ln -sf /usr/lib/kernel-overlays/base/lib/firmware/brcm/BCM43430A1.def /usr/lib/firmware/brcm/BCM43430A1.hcd


### PR DESCRIPTION
Use BCM43430A1.vim for Banana Pi M2 Zero