### PR TITLE
chrome: fix latest version

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/chrome-libxkbcommon/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libxkbcommon/package.mk
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+. $(get_pkg_directory libxkbcommon)/package.mk
+
+PKG_NAME="chrome-libxkbcommon"
+PKG_LONGDESC="libxkbcommon for chrome"
+PKG_URL=""
+PKG_DEPENDS_UNPACK+=" libxkbcommon"
+PKG_BUILD_FLAGS="-sysroot"
+
+PKG_MESON_OPTS_TARGET="$PKG_MESON_OPTS_TARGET \
+                           -Denable-static=false \
+                           -Denable-shared=true"
+
+unpack() {
+  mkdir -p $PKG_BUILD
+  tar --strip-components=1 -xf $SOURCES/${PKG_NAME:7}/${PKG_NAME:7}-$PKG_VERSION.tar.xz -C $PKG_BUILD
+}

--- a/packages/addons/addon-depends/chrome-depends/cups/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/cups/package.mk
@@ -15,6 +15,7 @@ PKG_BUILD_FLAGS="+pic -sysroot"
 PKG_CONFIGURE_OPTS_TARGET="--libdir=/usr/lib \
                            --disable-gssapi \
                            --disable-avahi \
+                           --disable-dnssd \
                            --disable-systemd \
                            --disable-launchd \
                            --disable-unit-tests"

--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,3 +1,6 @@
+104
+- support for latest Chrome
+
 103
 - fix getting default audio device
 

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -3,13 +3,13 @@
 
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"
 PKG_DEPENDS_TARGET="toolchain at-spi2-atk atk cairo chrome-libXcomposite \
                     chrome-libXdamage chrome-libXfixes chrome-libXi chrome-libXrender \
-                    chrome-libXtst chrome-libxcb cups gdk-pixbuf gtk3 harfbuzz \
+                    chrome-libXtst chrome-libxcb chrome-libxkbcommon cups gdk-pixbuf gtk3 harfbuzz \
                     libXcursor libxss nss pango scrnsaverproto unclutter"
 PKG_SECTION="browser"
 PKG_SHORTDESC="Google Chrome Browser"
@@ -82,6 +82,9 @@ addon() {
 
   # libXi
   cp -PL $(get_install_dir chrome-libXi)/usr/lib/libXi.so.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
+
+  # libxkbcommon
+  cp -PL $(get_install_dir chrome-libxkbcommon)/usr/lib/libxkbcommon.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
 
   # libXrender
   cp -PL $(get_install_dir chrome-libXrender)/usr/lib/libXrender.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib


### PR DESCRIPTION
- added a buildfix for cups, if avahi and nss-mdns is build cups is confused
- libxkbcommon.so.0 is now required by chrome

[browser.chrome-9.80.8.104.zip](https://github.com/LibreELEC/LibreELEC.tv/files/5580472/browser.chrome-9.80.8.104.zip)
