### PR TITLE
Update RTL wifi drivers to 5.10

### DIFF
--- a/packages/linux-drivers/RTL8192CU/package.mk
+++ b/packages/linux-drivers/RTL8192CU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8192CU"
-PKG_VERSION="0f37bd7f97573f835e4dedb4b2628c1ceedd71ad"
-PKG_SHA256="0291b11b11b0949769270ba28b279194c3f77a407922cb1221d06c13cbbb5a13"
+PKG_VERSION="7a15cb42e568b0f9c3c872bd6a06cdcab9f0ffd0"
+PKG_SHA256="93cd979956ab3f60618707cd11395549ecff17135fa969e25f031a1f06453a7d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/pvaret/rtl8192cu-fixes"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"

--- a/packages/linux-drivers/RTL8192DU/package.mk
+++ b/packages/linux-drivers/RTL8192DU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8192DU"
-PKG_VERSION="d6185ff4a242ebf553e9e9980da21591660e8f8c"
-PKG_SHA256="fef5ab863b3f4f3d6e7e4af891aca6bcb5a080fc9a0a4bd88abef82e8966c35d"
+PKG_VERSION="331ec03d89d0c0ebe771c4011846f029f6af33d3"
+PKG_SHA256="74e173b96d366ad50a0634fe98a8e55dc865276cd07de8fd635eaa4d5f71dae4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/lwfinger/rtl8192du"
 PKG_URL="https://github.com/lwfinger/rtl8192du/archive/$PKG_VERSION.tar.gz"

--- a/packages/linux-drivers/RTL8192EU/package.mk
+++ b/packages/linux-drivers/RTL8192EU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8192EU"
-PKG_VERSION="1628c748ced6c18441440fb40bbc86d1a4aa1627"
-PKG_SHA256="700ef69727fb675d0cb23cac29b3f00a07b4800c15f9f1228133a8bdb0343aff"
+PKG_VERSION="2ff6fb4f871819e12dd86f2177283d5c6734933c"
+PKG_SHA256="87ba3622d655277f29cc568fe74d9daef40ccfbf6b9ef2a40776252888d21e82"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/Mange/rtl8192eu-linux-driver"
 PKG_URL="https://github.com/Mange/rtl8192eu-linux-driver/archive/$PKG_VERSION.tar.gz"

--- a/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-0001-fix_kernel_5_10.patch
+++ b/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-0001-fix_kernel_5_10.patch
@@ -1,0 +1,281 @@
+From ee9619ba0c8840db6d59d11989c31e24a8f0d806 Mon Sep 17 00:00:00 2001
+From: Carlos <CGarces@users.noreply.github.com>
+Date: Sun, 8 Nov 2020 12:25:43 +0000
+Subject: [PATCH] Fix kernel 5.10-rc1
+
+---
+ core/rtw_btcoex.c       |  7 ++++++-
+ core/rtw_wlan_util.c    | 10 ++++++----
+ os_dep/linux/os_intfs.c | 19 +++++++++++++-----
+ os_dep/osdep_service.c  | 43 +++++++++++++++++++++++++++--------------
+ 4 files changed, 54 insertions(+), 25 deletions(-)
+
+diff --git a/core/rtw_btcoex.c b/core/rtw_btcoex.c
+index d5b89bdc..f5e0f567 100644
+--- a/core/rtw_btcoex.c
++++ b/core/rtw_btcoex.c
+@@ -1443,7 +1443,9 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
+ {
+ 	u8 error;
+ 	struct msghdr	udpmsg;
++#ifdef set_fs
+ 	mm_segment_t	oldfs;
++#endif
+ 	struct iovec	iov;
+ 	struct bt_coex_info *pcoex_info = &padapter->coex_info;
+ 
+@@ -1473,15 +1475,18 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
+ 	udpmsg.msg_control	= NULL;
+ 	udpmsg.msg_controllen = 0;
+ 	udpmsg.msg_flags	= MSG_DONTWAIT | MSG_NOSIGNAL;
++#ifdef set_fs
+ 	oldfs = get_fs();
+ 	set_fs(KERNEL_DS);
+-
++#endif
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+ 	error = sock_sendmsg(pcoex_info->udpsock, &udpmsg);
+ #else
+ 	error = sock_sendmsg(pcoex_info->udpsock, &udpmsg, msg_size);
+ #endif
++#ifdef set_fs
+ 	set_fs(oldfs);
++#endif
+ 	if (error < 0) {
+ 		RTW_INFO("Error when sendimg msg, error:%d\n", error);
+ 		return _FAIL;
+diff --git a/core/rtw_wlan_util.c b/core/rtw_wlan_util.c
+index b4cecd11..e465e9b5 100644
+--- a/core/rtw_wlan_util.c
++++ b/core/rtw_wlan_util.c
+@@ -4744,7 +4744,9 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
+ 
+ 	int i = 0;
+ 	struct file *fp;
++#ifdef set_fs
+ 	mm_segment_t fs;
++#endif
+ 	loff_t pos = 0;
+ 	u8 *source = NULL;
+ 	long len = 0;
+@@ -4780,10 +4782,10 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
+ 		RTW_INFO("Error, cipher array using default value.\n");
+ 		return 0;
+ 	}
+-
++#ifdef set_fs
+ 	fs = get_fs();
+ 	set_fs(KERNEL_DS);
+-
++#endif
+ 	source = rtw_zmalloc(2048);
+ 
+ 	if (source != NULL) {
+@@ -4791,10 +4793,10 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
+ 		rtw_parse_cipher_list(nlo_info, source);
+ 		rtw_mfree(source, 2048);
+ 	}
+-
++#ifdef set_fs
+ 	set_fs(fs);
+ 	filp_close(fp, NULL);
+-
++#endif
+ 	RTW_INFO("-%s-\n", __func__);
+ 	return 0;
+ }
+diff --git a/os_dep/linux/os_intfs.c b/os_dep/linux/os_intfs.c
+index 1085d6cd..a37e488b 100644
+--- a/os_dep/linux/os_intfs.c
++++ b/os_dep/linux/os_intfs.c
+@@ -4029,7 +4029,9 @@ static int route_dump(u32 *gw_addr , int *gw_index)
+ 	struct msghdr msg;
+ 	struct iovec iov;
+ 	struct sockaddr_nl nladdr;
++#ifdef set_fs
+ 	mm_segment_t oldfs;
++#endif
+ 	char *pg;
+ 	int size = 0;
+ 
+@@ -4067,16 +4069,18 @@ static int route_dump(u32 *gw_addr , int *gw_index)
+ 	msg.msg_control = NULL;
+ 	msg.msg_controllen = 0;
+ 	msg.msg_flags = MSG_DONTWAIT;
+-
++#ifdef set_fs
+ 	oldfs = get_fs();
+ 	set_fs(KERNEL_DS);
++#endif
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+ 	err = sock_sendmsg(sock, &msg);
+ #else
+ 	err = sock_sendmsg(sock, &msg, sizeof(req));
+ #endif
++#ifdef set_fs
+ 	set_fs(oldfs);
+-
++#endif
+ 	if (err < 0)
+ 		goto out_sock;
+ 
+@@ -4099,16 +4103,18 @@ static int route_dump(u32 *gw_addr , int *gw_index)
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+ 		iov_iter_init(&msg.msg_iter, READ, &iov, 1, PAGE_SIZE);
+ #endif
+-
++#ifdef set_fs
+ 		oldfs = get_fs();
+ 		set_fs(KERNEL_DS);
++#endif
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
+ 		err = sock_recvmsg(sock, &msg, MSG_DONTWAIT);
+ #else
+ 		err = sock_recvmsg(sock, &msg, PAGE_SIZE, MSG_DONTWAIT);
+ #endif
++#ifdef set_fs
+ 		set_fs(oldfs);
+-
++#endif
+ 		if (err < 0)
+ 			goto out_sock_pg;
+ 
+@@ -4178,15 +4184,18 @@ static int route_dump(u32 *gw_addr , int *gw_index)
+ 		msg.msg_controllen = 0;
+ 		msg.msg_flags = MSG_DONTWAIT;
+ 
++#ifdef set_fs
+ 		oldfs = get_fs();
+ 		set_fs(KERNEL_DS);
++#endif
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+ 		err = sock_sendmsg(sock, &msg);
+ #else
+ 		err = sock_sendmsg(sock, &msg, sizeof(req));
+ #endif
++#ifdef set_fs
+ 		set_fs(oldfs);
+-
++#endif
+ 		if (err > 0)
+ 			goto restart;
+ 	}
+diff --git a/os_dep/osdep_service.c b/os_dep/osdep_service.c
+index 7c6d1208..0769b49d 100644
+--- a/os_dep/osdep_service.c
++++ b/os_dep/osdep_service.c
+@@ -2164,11 +2164,21 @@ static int writeFile(struct file *fp, char *buf, int len)
+ {
+ 	int wlen = 0, sum = 0;
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
++	if (!(fp->f_mode & FMODE_CAN_WRITE))
++#else
+ 	if (!fp->f_op || !fp->f_op->write)
++#endif
+ 		return -EPERM;
+ 
+ 	while (sum < len) {
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
++		wlen = kernel_write(fp, buf + sum, len - sum, &fp->f_pos);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
++		wlen = __vfs_write(fp, buf + sum, len - sum, &fp->f_pos);
++#else
+ 		wlen = fp->f_op->write(fp, buf + sum, len - sum, &fp->f_pos);
++#endif
+ 		if (wlen > 0)
+ 			sum += wlen;
+ 		else if (0 != wlen)
+@@ -2191,19 +2201,19 @@ static int isFileReadable(const char *path, u32 *sz)
+ {
+ 	struct file *fp;
+ 	int ret = 0;
++#ifdef set_fs
+ 	mm_segment_t oldfs;
++#endif
+ 	char buf;
+ 
+ 	fp = filp_open(path, O_RDONLY, 0);
+ 	if (IS_ERR(fp))
+ 		ret = PTR_ERR(fp);
+ 	else {
++#ifdef set_fs
+ 		oldfs = get_fs();
+-		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+ 		set_fs(KERNEL_DS);
+-		#else
+-		set_fs(get_ds());
+-		#endif
++#endif
+ 
+ 		if (1 != readFile(fp, &buf, 1))
+ 			ret = PTR_ERR(fp);
+@@ -2215,8 +2225,9 @@ static int isFileReadable(const char *path, u32 *sz)
+ 			*sz = i_size_read(fp->f_dentry->d_inode);
+ 			#endif
+ 		}
+-
++#ifdef set_fs
+ 		set_fs(oldfs);
++#endif
+ 		filp_close(fp, NULL);
+ 	}
+ 	return ret;
+@@ -2232,22 +2243,23 @@ static int isFileReadable(const char *path, u32 *sz)
+ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
+ {
+ 	int ret = -1;
++#ifdef set_fs
+ 	mm_segment_t oldfs;
++#endif
+ 	struct file *fp;
+ 
+ 	if (path && buf) {
+ 		ret = openFile(&fp, path, O_RDONLY, 0);
+ 		if (0 == ret) {
+ 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
+-
++#ifdef set_fs
+ 			oldfs = get_fs();
+-			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+ 			set_fs(KERNEL_DS);
+-			#else
+-			set_fs(get_ds());
+-			#endif
+ 			ret = readFile(fp, buf, sz);
+ 			set_fs(oldfs);
++#else
++			ret = readFile(fp, buf, sz);
++#endif
+ 			closeFile(fp);
+ 
+ 			RTW_INFO("%s readFile, ret:%d\n", __FUNCTION__, ret);
+@@ -2271,22 +2283,23 @@ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
+ static int storeToFile(const char *path, u8 *buf, u32 sz)
+ {
+ 	int ret = 0;
++#ifdef set_fs
+ 	mm_segment_t oldfs;
++#endif
+ 	struct file *fp;
+ 
+ 	if (path && buf) {
+ 		ret = openFile(&fp, path, O_CREAT | O_WRONLY, 0666);
+ 		if (0 == ret) {
+ 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
+-
++#ifdef set_fs
+ 			oldfs = get_fs();
+-			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+ 			set_fs(KERNEL_DS);
+-			#else
+-			set_fs(get_ds());
+-			#endif
+ 			ret = writeFile(fp, buf, sz);
+ 			set_fs(oldfs);
++#else
++			ret = writeFile(fp, buf, sz);
++#endif
+ 			closeFile(fp);
+ 
+ 			RTW_INFO("%s writeFile, ret:%d\n", __FUNCTION__, ret);


### PR DESCRIPTION
Only needed for generic, arm architecture not are affected (yet).

Generic build tested with linux kernel 5.10-rc4
PKG_VERSION="418baf2c28f3473039f2f7377760bd8f6897ae18"  # 5.10-rc4

I'll keep this as draft while patches are accepted on upstream.
