### PR TITLE
pulseaudio: update to 14.0

### DIFF
--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pulseaudio"
-PKG_VERSION="13.0"
-PKG_SHA256="961b23ca1acfd28f2bc87414c27bb40e12436efcf2158d29721b1e89f3f28057"
+PKG_VERSION="14.0"
+PKG_SHA256="a834775d9382b055504e5ee7625dc50768daac29329531deb6597bf05e06c261"
 PKG_LICENSE="GPL"
 PKG_SITE="http://pulseaudio.org/"
 PKG_URL="http://www.freedesktop.org/software/pulseaudio/releases/$PKG_NAME-$PKG_VERSION.tar.xz"

--- a/packages/audio/pulseaudio/patches/pulseaudio-100.02-check_uid.patch
+++ b/packages/audio/pulseaudio/patches/pulseaudio-100.02-check_uid.patch
@@ -1,11 +1,11 @@
 --- pulseaudio-4.0.orig/src/pulsecore/core-util.c	2014-01-12 23:31:26.281525000 -0800
 +++ pulseaudio-4.0/src/pulsecore/core-util.c	2014-01-12 23:32:32.977118803 -0800
-@@ -1524,10 +1524,6 @@
+@@ -1447,10 +1447,6 @@
      if (stat(p, &st) < 0)
          return -errno;
  
 -#ifdef HAVE_GETUID
--    if (st.st_uid != getuid())
+-    if (st.st_uid != getuid() && st.st_uid != 0)
 -        return -EACCES;
 -#endif
 


### PR DESCRIPTION
This has been tested in production for the last few weeks as 13.99.3

The release version is now out: v14.0

Release Notes are at: https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/14.0/

Some changes to take note of:

- Compile-time option to forget pre-14.0 stream routing(I have no enabled this)
- Automatic switching to HDMI is now disabled by default (been better on my system I think)
- qpaeq switched from Python 2 to Python 3
- reverted to pre 13.0 behavior  - pa_mainloop_prepare interprets the timeout argument as microseconds again

The git compare between 13.99.3 and 14.0 is minimal.
https://github.com/pulseaudio/pulseaudio/compare/v13.99.3...v14.0
Code changes between 13.99.3 and 14.0 are mostly cosmetic, +api version, + the microsecond change.