### PR TITLE
intel-ucode: update to intel-ucode-20201118

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20201110"
-PKG_SHA256="c9e42ad0032d8cd611c7bc2fb94a16429ac485c7971809737b055550a49f58b8"
+PKG_VERSION="20201118"
+PKG_SHA256="e42a264b7b86e80d013d6d00062467352c1f37e0aaea10fe5b51e4d8687921ab"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"


### PR DESCRIPTION
20201110 firmware has been running fine on my 5.9.x kernels 
My CPU
[    0.000000] microcode: microcode updated early to revision 0xe2, date = 2020-07-14
[    0.224611] smpboot: CPU0: Intel(R) Core(TM) i5-6260U CPU @ 1.80GHz (family: 0x6, model: 0x4e, stepping: 0x3)

20201118 removes the following
- Removed TGL/06-8c-01/80 due to functional issues with some OEM platforms. 
Which are the following CPUs
- Core Gen11 Mobile

20201112 adds the following
- Security updates for INTEL-SA-00381.
- Security updates for INTEL-SA-00389.
For 
- Pentium Silver N/J5xxx, 
- Celeron N/J4xxx