### PR TITLE
mesa: update to 20.2.3

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="20.2.2"
-PKG_SHA256="de67bb162d8a5cacd8c32f499d9459009630681d9a557f72dc14a82a7a5e547b"
+PKG_VERSION="20.2.3"
+PKG_SHA256="966ff3f876c89e8131ed8c39ec32a575638b0838020080c3ed6e9473224fb729"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://github.com/mesa3d/mesa/archive/mesa-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update to Mesa.

Tested on Generic / Intel NUC6i5SYB / Intel(R) Core(TM) i5-6260U

Minor bug fixes - https://docs.mesa3d.org/relnotes/20.2.3.html

# grep -i mesa kodi.log 
2020-11-29 20:40:45.507 T:1144     INFO <general>: CRenderSystemGL::InitRenderSystem - Version: 4.6 (Core Profile) Mesa 20.2.3, Major: 4, Minor: 6
2020-11-29 20:40:45.507 T:1144     INFO <general>: GL_RENDERER = Mesa Intel(R) Iris(R) Graphics 540 (SKL GT3)
2020-11-29 20:40:45.507 T:1144     INFO <general>: GL_VERSION = 4.6 (Core Profile) Mesa 20.2.3
2020-11-29 20:40:45.508 T:1144     INFO <general>: GL_EXTENSIONS = 