### PR TITLE
chrome: update to 87 and using fixed versions

### DIFF
--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,5 +1,5 @@
 104
-- support for latest Chrome
+- updated to 87.0.4280
 
 103
 - fix getting default audio device

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -28,82 +28,38 @@ make_target() {
 }
 
 addon() {
-  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin \
-           $ADDON_BUILD/$PKG_ADDON_ID/config \
-           $ADDON_BUILD/$PKG_ADDON_ID/gdk-pixbuf-modules \
-           $ADDON_BUILD/$PKG_ADDON_ID/lib
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/{bin,config,gdk-pixbuf-modules,lib}
 
   # config
   cp -P $PKG_DIR/config/* $ADDON_BUILD/$PKG_ADDON_ID/config
 
-  # atk
-  cp -PL $(get_install_dir atk)/usr/lib/libatk-1.0.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # cairo
-  cp -PL $(get_install_dir cairo)/usr/lib/libcairo-gobject.so.2 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PL $(get_install_dir cairo)/usr/lib/libcairo.so.2 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # gdk-pixbuf
-  cp -PL $(get_install_dir gdk-pixbuf)/usr/lib/libgdk_pixbuf-2.0.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
   # gdk-pixbuf modules
   cp -PL $(get_install_dir gdk-pixbuf)/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/* $ADDON_BUILD/$PKG_ADDON_ID/gdk-pixbuf-modules
 
-  # gtk3 gdk3
-  cp -PL $(get_install_dir gtk3)/usr/lib/libgtk-3.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PL $(get_install_dir gtk3)/usr/lib/libgdk-3.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # harfbuzz
-  cp -PL $(get_install_dir harfbuzz)/usr/lib/libharfbuzz.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PL $(get_install_dir harfbuzz)/usr/lib/libharfbuzz-icu.so* $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libatk-bridge
-  cp -PL $(get_install_dir at-spi2-atk)/usr/lib/libatk-bridge-2.0.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libatspi
-  cp -PL $(get_install_dir at-spi2-core)/usr/lib/libatspi.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libcups
-  cp -PL $(get_install_dir cups)/usr/lib/libcups.so.2 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libxcb
-  cp -PL $(get_install_dir chrome-libxcb)/usr/lib/libxcb.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PL $(get_install_dir chrome-libxcb)/usr/lib/libxcb-dri3.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libXcomposite
-  cp -PL $(get_install_dir chrome-libXcomposite)/usr/lib/libXcomposite.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libXcursor
-  cp -PL $(get_install_dir libXcursor)/usr/lib/libXcursor.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libXdamage
-  cp -PL $(get_install_dir chrome-libXdamage)/usr/lib/libXdamage.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libXfixes
-  cp -PL $(get_install_dir chrome-libXfixes)/usr/lib/libXfixes.so.3 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libXi
-  cp -PL $(get_install_dir chrome-libXi)/usr/lib/libXi.so.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libxkbcommon
-  cp -PL $(get_install_dir chrome-libxkbcommon)/usr/lib/libxkbcommon.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libXrender
-  cp -PL $(get_install_dir chrome-libXrender)/usr/lib/libXrender.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libxss
-  cp -PL $(get_install_dir libxss)/usr/lib/libXss.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # libXtst
-  cp -PL $(get_install_dir chrome-libXtst)/usr/lib/libXtst.so.6 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
-  # pango
-  cp -PL $(get_install_dir pango)/usr/lib/libpangocairo-1.0.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PL $(get_install_dir pango)/usr/lib/libpango-1.0.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -PL $(get_install_dir pango)/usr/lib/libpangoft2-1.0.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib
-
   # unclutter
   cp -P $(get_install_dir unclutter)/usr/bin/unclutter $ADDON_BUILD/$PKG_ADDON_ID/bin
+
+  # libs
+  cp -PL $(get_install_dir atk)/usr/lib/libatk-1.0.so.0 \
+         $(get_install_dir cairo)/usr/lib/{libcairo-gobject.so.2,libcairo.so.2} \
+         $(get_install_dir gdk-pixbuf)/usr/lib/libgdk_pixbuf-2.0.so.0 \
+         $(get_install_dir gtk3)/usr/lib/{libgtk-3.so.0,libgdk-3.so.0} \
+         $(get_install_dir harfbuzz)/usr/lib/{libharfbuzz.so.0,libharfbuzz-icu.so*} \
+         $(get_install_dir at-spi2-atk)/usr/lib/libatk-bridge-2.0.so.0 \
+         $(get_install_dir at-spi2-core)/usr/lib/libatspi.so.0 \
+         $(get_install_dir cups)/usr/lib/libcups.so.2 \
+         $(get_install_dir chrome-libxcb)/usr/lib/{libxcb.so.1,libxcb-dri3.so.0} \
+         $(get_install_dir chrome-libXcomposite)/usr/lib/libXcomposite.so.1 \
+         $(get_install_dir libXcursor)/usr/lib/libXcursor.so.1 \
+         $(get_install_dir chrome-libXdamage)/usr/lib/libXdamage.so.1 \
+         $(get_install_dir chrome-libXfixes)/usr/lib/libXfixes.so.3 \
+         $(get_install_dir chrome-libXi)/usr/lib/libXi.so.6 \
+         $(get_install_dir chrome-libxkbcommon)/usr/lib/libxkbcommon.so.0 \
+         $(get_install_dir chrome-libXrender)/usr/lib/libXrender.so.1 \
+         $(get_install_dir libxss)/usr/lib/libXss.so.1 \
+         $(get_install_dir chrome-libXtst)/usr/lib/libXtst.so.6 \
+         $(get_install_dir pango)/usr/lib/{libpangocairo-1.0.so.0,libpango-1.0.so.0,libpangoft2-1.0.so.0} \
+         $ADDON_BUILD/$PKG_ADDON_ID/lib
 }
 
 post_install_addon() {

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -3,6 +3,8 @@
 
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
+# curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
+PKG_VERSION_NUMBER="87.0.4280.66"
 PKG_REV="104"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
@@ -106,4 +108,5 @@ addon() {
 
 post_install_addon() {
   sed -e "s/@DISTRO_PKG_SETTINGS_ID@/${DISTRO_PKG_SETTINGS_ID}/g" -i "${INSTALL}/default.py"
+  sed -e "s/@CHROME_VERSION@/${PKG_VERSION_NUMBER}/g" -i "${INSTALL}/bin/chrome-downloader"
 }

--- a/packages/addons/browser/chrome/source/bin/chrome-downloader
+++ b/packages/addons/browser/chrome/source/bin/chrome-downloader
@@ -6,9 +6,10 @@
 . /etc/profile
 oe_setup_addon browser.chrome
 
-ICON=$ADDON_DIR/resources/icon.png
-CONTROL_FILE=/tmp/curl.done
-DATA_FILE=/tmp/curl.data
+ICON="$ADDON_DIR/resources/icon.png"
+CONTROL_FILE="/tmp/curl.done"
+DATA_FILE="/tmp/curl.data"
+CHROME_FILE="google-chrome-stable_@CHROME_VERSION@-1_amd64.deb"
 
 # check for enough free disk space
 if [ $(df . | awk 'END {print $4}') -lt 400000 ]; then
@@ -38,7 +39,7 @@ echo "Downloading Chrome"
 # download chrome
 rm -f ${CONTROL_FILE} ${DATA_FILE}
 (
-  curl -# -O -C - https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>${DATA_FILE}
+  curl -# -O -C - https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_FILE} 2>${DATA_FILE}
   touch ${CONTROL_FILE}
 ) | \
   while [ : ]; do
@@ -53,7 +54,7 @@ rm -f ${CONTROL_FILE} ${DATA_FILE}
 ## extract chrome
 # extrat chrome.deb
 kodi-send --action="Notification(Extracting Chrome,starting,1000,${ICON})" >/dev/null
-ar -x google-chrome-stable_current_amd64.deb
+ar -x ${CHROME_FILE}
 
 # extract data.tar.xz to chrome-bin directory
 mkdir $ADDON_DIR/chrome-bin

--- a/packages/addons/browser/chrome/source/bin/chrome-downloader
+++ b/packages/addons/browser/chrome/source/bin/chrome-downloader
@@ -44,7 +44,7 @@ rm -f ${CONTROL_FILE} ${DATA_FILE}
 ) | \
   while [ : ]; do
     [ -f ${DATA_FILE} ] && prog="$(tr '\r' '\n' < ${DATA_FILE} | tail -n 1 | sed -r 's/^[# ]+/#/;s/^[^0-9]*//g')" || prog=
-    kodi-send --action="Notification(Downloading Chrome,"${prog:-0.0%}",3000,${ICON})" >/dev/null
+    kodi-send --action="Notification(Downloading Chrome,\"${prog:-0.0%}\",3000,${ICON})" >/dev/null
     [ -f ${CONTROL_FILE} ] && break
     sleep 4
   done
@@ -61,6 +61,7 @@ mkdir $ADDON_DIR/chrome-bin
 tar xf data.tar.xz --strip-components=4 -C $ADDON_DIR/chrome-bin ./opt/google/chrome
 
 # cleanup
+cd $ADDON_DIR
 rm -rf $ADDON_DIR/tmp_download
 touch $ADDON_DIR/extract.ok
 kodi-send --action="Notification(Extracting Chrome,finished,1000,${ICON})" >/dev/null


### PR DESCRIPTION
- using fixed versions instead of "latest"
- cleanup of the chrome package
- no package bump due merged with latest fix
should stop breaking the package, old addon version installs old chrome version so likely more stable in general

LE10 test file
[browser.chrome-9.80.8.104.zip](https://github.com/LibreELEC/LibreELEC.tv/files/5616593/browser.chrome-9.80.8.104.zip)
