### PR TITLE
chrome: update to 87 and using fixed versions / minor downloader fixes

### DIFF
--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,6 +1,6 @@
 104
 - fix getting default audio device
-- support for latest Chrome
+- updated to 87.0.4280
 
 103
 - add flag for dark mode

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -3,6 +3,8 @@
 
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
+# curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
+PKG_VERSION_NUMBER="87.0.4280.66"
 PKG_REV="104"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
@@ -33,6 +35,7 @@ addon() {
 
   # config
   cp -P $PKG_DIR/config/* $ADDON_BUILD/$PKG_ADDON_ID/config
+  echo "CHROME_VERSION=${PKG_VERSION_NUMBER}" >$ADDON_BUILD/$PKG_ADDON_ID/config/chrome.version
 
   # atk
   cp -PL $(get_build_dir atk)/.$TARGET_NAME/atk/libatk-1.0.so.0 $ADDON_BUILD/$PKG_ADDON_ID/lib

--- a/packages/addons/browser/chrome/source/bin/chrome-downloader
+++ b/packages/addons/browser/chrome/source/bin/chrome-downloader
@@ -6,9 +6,14 @@
 . /etc/profile
 oe_setup_addon browser.chrome
 
-ICON=$ADDON_DIR/resources/icon.png
-CONTROL_FILE=/tmp/curl.done
-DATA_FILE=/tmp/curl.data
+ICON="$ADDON_DIR/resources/icon.png"
+CONTROL_FILE="/tmp/curl.done"
+DATA_FILE="/tmp/curl.data"
+CHROME_VERSION_FILE="$ADDON_DIR/config/chrome.version"
+
+. "$CHROME_VERSION_FILE"
+
+CHROME_FILE="google-chrome-stable_${CHROME_VERSION}-1_amd64.deb"
 
 # check for enough free disk space
 if [ $(df . | awk 'END {print $4}') -lt 400000 ]; then
@@ -38,7 +43,7 @@ echo "Downloading Chrome"
 # download chrome
 rm -f ${CONTROL_FILE} ${DATA_FILE}
 (
-  curl -# -O -C - https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>${DATA_FILE}
+  curl -# -O -C - https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_FILE} 2>${DATA_FILE}
   touch ${CONTROL_FILE}
 ) | \
   while [ : ]; do
@@ -53,7 +58,7 @@ rm -f ${CONTROL_FILE} ${DATA_FILE}
 ## extract chrome
 # extrat chrome.deb
 kodi-send --action="Notification(Extracting Chrome,starting,1000,${ICON})" >/dev/null
-ar -x google-chrome-stable_current_amd64.deb
+ar -x ${CHROME_FILE}
 
 # extract data.tar.xz to chrome-bin directory
 mkdir $ADDON_DIR/chrome-bin

--- a/packages/addons/browser/chrome/source/bin/chrome-downloader
+++ b/packages/addons/browser/chrome/source/bin/chrome-downloader
@@ -43,7 +43,7 @@ rm -f ${CONTROL_FILE} ${DATA_FILE}
 ) | \
   while [ : ]; do
     [ -f ${DATA_FILE} ] && prog="$(tr '\r' '\n' < ${DATA_FILE} | tail -n 1 | sed -r 's/^[# ]+/#/;s/^[^0-9]*//g')" || prog=
-    kodi-send --action="Notification(Downloading Chrome,"${prog:-0.0%}",3000,${ICON})" >/dev/null
+    kodi-send --action="Notification(Downloading Chrome,\"${prog:-0.0%}\",3000,${ICON})" >/dev/null
     [ -f ${CONTROL_FILE} ] && break
     sleep 4
   done
@@ -60,6 +60,7 @@ mkdir $ADDON_DIR/chrome-bin
 tar xf data.tar.xz --strip-components=4 -C $ADDON_DIR/chrome-bin ./opt/google/chrome
 
 # cleanup
+cd $ADDON_DIR
 rm -rf $ADDON_DIR/tmp_download
 touch $ADDON_DIR/extract.ok
 kodi-send --action="Notification(Extracting Chrome,finished,1000,${ICON})" >/dev/null


### PR DESCRIPTION
Partial backport of #4702 including a work around for the missing post_install_addon() function.

No package bump either due merged with latest fix

The first commit is to sanitize the curl output. When i.e. German locale is configured "35,7%" is printed instead of "35.7%". The comma must not be used without protection.


LE9.2 testbuild: [browser.chrome-9.2.0.104.zip](https://github.com/LibreELEC/LibreELEC.tv/files/5632414/browser.chrome-9.2.0.104.zip)
