### PR TITLE
ninja: update to v1.10.2

### DIFF
--- a/packages/python/devel/ninja/package.mk
+++ b/packages/python/devel/ninja/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ninja"
-PKG_VERSION="1.10.0"
-PKG_SHA256="3810318b08489435f8efc19c05525e80a993af5a55baa0dfeae0465a9d45f99f"
+PKG_VERSION="1.10.2"
+PKG_SHA256="ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed"
 PKG_LICENSE="Apache"
-PKG_SITE="http://martine.github.io/ninja/"
+PKG_SITE="https://ninja-build.org/"
 PKG_URL="https://github.com/ninja-build/ninja/archive/v$PKG_VERSION.tar.gz"
 PKG_DEPENDS_HOST="Python3:host"
 PKG_LONGDESC="Small build system with a focus on speed"


### PR DESCRIPTION
Split ninja out of package update #4667 bundle, as 1.10.2 was released. Package update has had 1.10.1 in it for a while.

Release notes are at:
https://groups.google.com/g/ninja-build/c/oobwq_F0PpA/m/FeJC5LoRBgAJ

Differences between 1.10.1 (tested extensively on Generic) and 1.10.2 are https://github.com/ninja-build/ninja/compare/v1.10.1...v1.10.2 .