### PR TITLE
libX11: update to 1.6.12

### DIFF
--- a/packages/x11/lib/libX11/package.mk
+++ b/packages/x11/lib/libX11/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libX11"
-PKG_VERSION="1.6.9"
-PKG_SHA256="9cc7e8d000d6193fa5af580d50d689380b8287052270f5bb26a5fb6b58b2bed1"
+PKG_VERSION="1.6.12"
+PKG_SHA256="f108227469419ac04d196df0f3b80ce1f7f65059bb54c0de811f4d8e03fd6ec7"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.x.org/"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
Splitting libX11: update to 1.6.12 out of main package update #4667 bundle.

Version 1.7.0 is out but it does include a new API. Suggesting we update to 1.6.12 which has been tested extensively on Generic. With a plan to merge 1.7.0 subsequently.

https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/master/README.md