### PR TITLE
mesa: bump to 20.3.0 and change source url

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="20.2.3"
-PKG_SHA256="966ff3f876c89e8131ed8c39ec32a575638b0838020080c3ed6e9473224fb729"
+PKG_VERSION="20.3.0"
+PKG_SHA256="2999738e888731531cd62b27519fa37566cc0ea2cd7d4d97f46abaa3e949c630"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
-PKG_URL="https://github.com/mesa3d/mesa/archive/mesa-${PKG_VERSION}.tar.gz"
+PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain expat libdrm Mako:host"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API."
 PKG_TOOLCHAIN="meson"
@@ -17,19 +17,19 @@ get_graphicdrivers
 PKG_MESON_OPTS_TARGET="-Ddri-drivers=${DRI_DRIVERS// /,} \
                        -Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
-                       -Dgallium-xvmc=false \
+                       -Dgallium-xvmc=disabled \
                        -Dgallium-omx=disabled \
                        -Dgallium-nine=false \
                        -Dgallium-opencl=disabled \
                        -Dvulkan-drivers= \
-                       -Dshader-cache=true \
-                       -Dshared-glapi=true \
+                       -Dshader-cache=enabled \
+                       -Dshared-glapi=enabled \
                        -Dopengl=true \
-                       -Dgbm=true \
-                       -Degl=true \
-                       -Dvalgrind=false \
-                       -Dlibunwind=false \
-                       -Dlmsensors=false \
+                       -Dgbm=enabled \
+                       -Degl=enabled \
+                       -Dvalgrind=disabled \
+                       -Dlibunwind=disabled \
+                       -Dlmsensors=disabled \
                        -Dbuild-tests=false \
                        -Dselinux=false \
                        -Dosmesa=none"
@@ -37,44 +37,44 @@ PKG_MESON_OPTS_TARGET="-Ddri-drivers=${DRI_DRIVERS// /,} \
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr libglvnd"
   export X11_INCLUDES=
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms=x11,drm -Ddri3=true -Dglx=dri -Dglvnd=true"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms=x11 -Ddri3=enabled -Dglx=dri -Dglvnd=true"
 elif [ "${DISPLAYSERVER}" = "weston" ]; then
   PKG_DEPENDS_TARGET+=" wayland wayland-protocols"
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms=wayland,drm -Ddri3=false -Dglx=disabled -Dglvnd=false"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms=wayland -Ddri3=disabled -Dglx=disabled -Dglvnd=false"
 else
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms=drm -Ddri3=false -Dglx=disabled -Dglvnd=false"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms="" -Ddri3=disabled -Dglx=disabled -Dglvnd=false"
 fi
 
 if [ "${LLVM_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" elfutils llvm"
-  PKG_MESON_OPTS_TARGET+=" -Dllvm=true"
+  PKG_MESON_OPTS_TARGET+=" -Dllvm=enabled"
 else
-  PKG_MESON_OPTS_TARGET+=" -Dllvm=false"
+  PKG_MESON_OPTS_TARGET+=" -Dllvm=disabled"
 fi
 
 if [ "${VDPAU_SUPPORT}" = "yes" -a "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET+=" libvdpau"
-  PKG_MESON_OPTS_TARGET+=" -Dgallium-vdpau=true"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-vdpau=enabled"
 else
-  PKG_MESON_OPTS_TARGET+=" -Dgallium-vdpau=false"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-vdpau=disabled"
 fi
 
 if [ "${VAAPI_SUPPORT}" = "yes" ] && listcontains "${GRAPHIC_DRIVERS}" "(r600|radeonsi)"; then
   PKG_DEPENDS_TARGET+=" libva"
-  PKG_MESON_OPTS_TARGET+=" -Dgallium-va=true"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-va=enabled"
 else
-  PKG_MESON_OPTS_TARGET+=" -Dgallium-va=false"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-va=disabled"
 fi
 
 if listcontains "${GRAPHIC_DRIVERS}" "vmware"; then
-  PKG_MESON_OPTS_TARGET+=" -Dgallium-xa=true"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-xa=enabled"
 else
-  PKG_MESON_OPTS_TARGET+=" -Dgallium-xa=false"
+  PKG_MESON_OPTS_TARGET+=" -Dgallium-xa=disabled"
 fi
 
 if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
-  PKG_MESON_OPTS_TARGET+=" -Dgles1=false -Dgles2=true"
+  PKG_MESON_OPTS_TARGET+=" -Dgles1=disabled -Dgles2=enabled"
 else
-  PKG_MESON_OPTS_TARGET+=" -Dgles1=false -Dgles2=false"
+  PKG_MESON_OPTS_TARGET+=" -Dgles1=disabled -Dgles2=disabled"
 fi
 


### PR DESCRIPTION
This PR bumps mesa to 20.3.0 which is the first official release to support ARM Mali Bifrost GPUs with Panfrost. I've also switched the package source to the official FDO gitlab instance as this makes tracking mesa development snapshots easier (replace the version tag with a githash in package.mk). I've also cleaned up some of the build options where true/false are deprecated in favour of enabled/disabled and `drm` has been dropped (drm/surfaceless are enabled by default). I've only changed the true/false options that I have seen warnings on during build. There are probably more to change with different build options (something for future PRs).