### PR TITLE
libva: updated to 2.10.0

### DIFF
--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva"
-PKG_VERSION="2.9.0"
-PKG_SHA256="f31549dd476e01504ba6ff62f69862eb78555a9809ebe737056543a189d619dc"
+PKG_VERSION="2.10.0"
+PKG_SHA256="f04d5c829da602690f9f098a6d92065507ec9d0c957c1a6df3dea4e2de1204c5"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
Update to current Libva - VA-API (Video Acceleration API)

I have been running the following builds on NUC6 / i5-6260U CPU / 5.9.12
- PKG_VERSION="88408602b748e00bfe81ee2796e4a2ff06741b82"
- PKG_VERSION="2.10.0.pre2"

version 2.10.0 - 04.Dec.2020
* add: Pass offset and size of pred_weight_table
* add: add vaCopy interface to copy surface and buffer
* add: add definition for different execution
* add: New parameters for transport controlled BRC were added
* add: add FreeBSD support
* add: add a bufer type to adjust context priority dynamically
* fix: correct the api version in meson.build
* fix: remove deprecated variable from va_trace.c
* fix: Use va_deprecated for the deprecate variable
* fix: Mark chroma_sample_position as deprecated
* doc: va_dec_av1: clarifies CDEF syntax element packing
* doc: [AV1] Update documented ranges for loop filter and quantization params.
* doc: Update va.h for multi-threaded usages
* trace: va/va_trace: ignore system gettid() on Linux
