### PR TITLE
samba: update to current stable 4.13.2

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.12.7"
-PKG_SHA256="30556a0dd2f9ab3b251eb9db6132ffd4379c159f574366fc2f2eabbc018c6fd2"
+PKG_VERSION="4.13.2"
+PKG_SHA256="276464396a05d88b775bda01ac2eb1e5a636ccf7010b0fd28efc3d85583af2b4"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/$PKG_NAME-$PKG_VERSION.tar.gz"

--- a/packages/network/samba/patches/samba-950-no-man.patch
+++ b/packages/network/samba/patches/samba-950-no-man.patch
@@ -34,36 +34,6 @@ index a077026..2a897d0 100644
  Build.BuildContext.SAMBA_BINARY = SAMBA_BINARY
  
  
-diff --git a/docs-xml/wscript_build b/docs-xml/wscript_build
-index 86600ae..ba3c7e0 100644
---- a/docs-xml/wscript_build
-+++ b/docs-xml/wscript_build
-@@ -150,25 +150,3 @@ bld.SAMBA_GENERATOR(parameter_all,
-                     target=parameter_all,
-                     rule=smbdotconf_generate_parameter_list,
-                     dep_vars=bld.dynconfig_varnames())
--
--def SMBDOTCONF_MANPAGE(bld, target):
--    ''' assemble and build smb.conf.5 manual page'''
--    bld.SAMBAMANPAGES(target, parameter_all)
--
--if ('XSLTPROC_MANPAGES' in bld.env and bld.env['XSLTPROC_MANPAGES']):
--
--    SMBDOTCONF_MANPAGE(bld, 'manpages/smb.conf.5')
--    bld.SAMBAMANPAGES(manpages)
--
--    if bld.CONFIG_SET('WITH_PAM_MODULES') and bld.CONFIG_SET('HAVE_PAM_START'):
--        bld.SAMBAMANPAGES(pam_winbind_manpages)
--
--    if bld.CONFIG_SET('HAVE_KRB5_LOCATE_PLUGIN_H'):
--        bld.SAMBAMANPAGES(krb5_locator_manpages)
--
--    if bld.CONFIG_SET('HAVE_KRB5_LOCALAUTH_PLUGIN_H'):
--        bld.SAMBAMANPAGES(krb5_localauth_manpages)
--
--    for manpage in vfs_module_manpages:
--        if bld.SAMBA3_IS_ENABLED_MODULE(manpage):
--            bld.SAMBAMANPAGES('manpages/%s.8' % manpage)
 -- 
 2.7.4
 

--- a/packages/network/samba/patches/samba-951-no-man-4.13.patch
+++ b/packages/network/samba/patches/samba-951-no-man-4.13.patch
@@ -1,0 +1,32 @@
+diff --git a/docs-xml/wscript_build b/docs-xml/wscript_build
+--- a/docs-xml/wscript_build	2020-12-05 09:01:19.652459634 +0000
++++ b/docs-xml/wscript_build	2020-12-05 09:10:10.639446971 +0000
+@@ -153,28 +153,3 @@
+                     target=parameter_all,
+                     rule=smbdotconf_generate_parameter_list,
+                     dep_vars=bld.dynconfig_varnames())
+-
+-def SMBDOTCONF_MANPAGE(bld, target):
+-    ''' assemble and build smb.conf.5 manual page'''
+-    bld.SAMBAMANPAGES(target, parameter_all)
+-
+-if ('XSLTPROC_MANPAGES' in bld.env and bld.env['XSLTPROC_MANPAGES']):
+-
+-    SMBDOTCONF_MANPAGE(bld, 'manpages/smb.conf.5')
+-    bld.SAMBAMANPAGES(manpages)
+-
+-    if bld.CONFIG_SET('WITH_PAM_MODULES') and bld.CONFIG_SET('HAVE_PAM_START'):
+-        bld.SAMBAMANPAGES(pam_winbind_manpages)
+-
+-    if bld.CONFIG_SET('HAVE_KRB5_LOCATE_PLUGIN_H'):
+-        bld.SAMBAMANPAGES(krb5_locator_manpages)
+-
+-    if bld.CONFIG_SET('HAVE_KRB5_LOCALAUTH_PLUGIN_H'):
+-        bld.SAMBAMANPAGES(krb5_localauth_manpages)
+-
+-    if conf.env.build_winexe == True:
+-        bld.SAMBAMANPAGES(winexe_manpages)
+-
+-    for manpage in vfs_module_manpages:
+-        if bld.SAMBA3_IS_ENABLED_MODULE(manpage):
+-            bld.SAMBAMANPAGES('manpages/%s.8' % manpage)


### PR DESCRIPTION
Update to current stable samba. Minor changes to patch files. 
This stable release of samba 4.13 will become maintenance in~ March 2021, and Security in ~ Sep 2021. So candidate to LE10 release. 

https://wiki.samba.org/index.php/Samba_Release_Planning