### PR TITLE
Set CONFIG_USB_DWC2 for RPi4 USB OTG

### DIFF
--- a/projects/RPi/devices/RPi4/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.arm.conf
@@ -4192,7 +4192,7 @@ CONFIG_USB_UAS=y
 # CONFIG_USBIP_CORE is not set
 # CONFIG_USB_MUSB_HDRC is not set
 # CONFIG_USB_DWC3 is not set
-# CONFIG_USB_DWC2 is not set
+CONFIG_USB_DWC2=y
 # CONFIG_USB_ISP1760 is not set
 
 #


### PR DESCRIPTION
backport issue #4722 in libreelec-9.2