### PR TITLE
Fix Rock Pi 4 nightly builds

### DIFF
--- a/projects/Rockchip/devices/RK3399/README.md
+++ b/projects/Rockchip/devices/RK3399/README.md
@@ -6,6 +6,8 @@ This is a SoC device for RK3399
 
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=khadas-edge make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock960 make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-4 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-4a make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-4b make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-4c make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rockpro64 make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=sapphire make image`

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -298,8 +298,16 @@ devices = \
         'dtb': 'rk3399-rock960.dtb',
         'config': 'evb-rk3399_config'
       },
-      'rock-pi-4': {
-        'dtb': 'rk3399-rock-pi-4.dtb',
+      'rock-pi-4a': {
+        'dtb': 'rk3399-rock-pi-4a.dtb',
+        'config': 'evb-rk3399_config'
+      },
+      'rock-pi-4b': {
+        'dtb': 'rk3399-rock-pi-4b.dtb',
+        'config': 'evb-rk3399_config'
+      },
+      'rock-pi-4c': {
+        'dtb': 'rk3399-rock-pi-4c.dtb',
         'config': 'evb-rk3399_config'
       },
       'rockpro64': {


### PR DESCRIPTION
Fixes #4725 

It'd be nice to actually break the build in the event that DTBs are missing (I presume somewhere in `packages/Rockhip/bootloader/release`), but I'm not sure how that would affect the development workflow for the other Rockchip targets -- I see that there's a glob copy of all DTBs to DSTDIR but I'm assuming only one of those is actually necessary when building using the `make image` lines from the READMEs...