### PR TITLE
bcm2835-bootloader: config.txt cosmetics

### DIFF
--- a/packages/tools/bcm2835-bootloader/files/config.txt
+++ b/packages/tools/bcm2835-bootloader/files/config.txt
@@ -22,3 +22,6 @@ hdmi_ignore_cec_init=1
 ################################################################################
 [all]
 include distroconfig.txt
+
+# uncomment to enable infrared remote recevier connected to GPIO 18
+#dtoverlay=gpio-ir,gpio_pin=18


### PR DESCRIPTION
Add commended-out example dtoverlay line and info how to enable
GPIO IR receiver.