### PR TITLE
busybox: add fsl to dthelper compatibles

### DIFF
--- a/packages/sysutils/busybox/scripts/dthelper
+++ b/packages/sysutils/busybox/scripts/dthelper
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-COMPATIBLE=$(cat /proc/device-tree/compatible 2>/dev/null | tr -d '\000' | sed -n -e 's/.*\(allwinner\|amlogic\|nxp\|qcom\|raspberrypi\|rockchip\|samsung\).*/\1/p')
+COMPATIBLE=$(cat /proc/device-tree/compatible 2>/dev/null | tr -d '\000' | sed -n -e 's/.*\(allwinner\|amlogic\|fsl\|nxp\|qcom\|raspberrypi\|rockchip\|samsung\).*/\1/p')
 
 do_dtfile(){
   if [ -e /flash/extlinux/extlinux.conf ]; then


### PR DESCRIPTION
iMX6 devices use the `fsl` compatible