### PR TITLE
openvpn: update to 2.4.10

### DIFF
--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.4.8"
-PKG_SHA256="fb8ca66bb7807fff595fbdf2a0afd085c02a6aa47715c9aa3171002f9f1a3f91"
+PKG_VERSION="2.4.10"
+PKG_SHA256="cf285395a679f0b68c0acde2cb2480e8ead6ca07ff14c1bc52ae65a1243aa377"
 PKG_LICENSE="GPL"
 PKG_SITE="https://openvpn.net"
 PKG_URL="https://swupdate.openvpn.org/community/releases/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
Feel free to close if there is a plan to update to 2.5 instead of continuing to track 2.4.x.
