### PR TITLE
dav1d: updated to 0.8.0

### DIFF
--- a/packages/multimedia/dav1d/package.mk
+++ b/packages/multimedia/dav1d/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dav1d"
-PKG_VERSION="0.7.1"
-PKG_SHA256="9eac4f50089f54a9f562827bda4a21187d68c01d8b20055eef1d7efca9f84cf8"
+PKG_VERSION="0.8.0"
+PKG_SHA256="b62eb846fd8af15b402c8f6615a74405fe4448cf16663efd0358d4124db0829f"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.jbkempf.com/blog/post/2018/Introducing-dav1d"
 PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/dav1d-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
The dav1d team have been making some good improvements, and 1080p AV1 files can now reliably be played on most of the LE platforms that you would expect to be capable of 1080p software decoding.