### PR TITLE
Wayland packages updates

### DIFF
--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.13.2"
-PKG_SHA256="1d9fa0698348dea46f75321d98788f8ac7181c069b70c4d10736910a12bb6a6d"
+PKG_VERSION="1.16.4"
+PKG_SHA256="65923a06d5a8970e4a999c4668797b9b689614b62b1d44432ab1c87b65e39e29"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="http://www.freedesktop.org/software/libinput/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbcommon"
-PKG_VERSION="0.8.4"
-PKG_SHA256="60ddcff932b7fd352752d51a5c4f04f3d0403230a584df9a2e0d5ed87c486c8b"
+PKG_VERSION="1.0.3"
+PKG_SHA256="a2202f851e072b84e64a395212cbd976ee18a8ee602008b0bad02a13247dbc52"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xkbcommon.org"
 PKG_URL="http://xkbcommon.org/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/mtdev/package.mk
+++ b/packages/wayland/mtdev/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="mtdev"
-PKG_VERSION="1.1.5"
-PKG_SHA256="6677d5708a7948840de734d8b4675d5980d4561171c5a8e89e54adf7a13eba7f"
+PKG_VERSION="1.1.6"
+PKG_SHA256="15d7b28da8ac71d8bc8c9287c2045fd174267bc740bec10cfda332dc1204e0e0"
 PKG_LICENSE="MIT"
 PKG_SITE="http://bitmath.org"
 PKG_URL="http://bitmath.org/code/mtdev/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.17"
-PKG_SHA256="df1319cf9705643aea9fd16f9056f4e5b2471bd10c0cc3713d4a4cdc23d6812f"
+PKG_VERSION="1.20"
+PKG_SHA256="9782b7a1a863d82d7c92478497d13c758f52e7da4f197aa16443f73de77e4de7"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/wayland/package.mk
+++ b/packages/wayland/wayland/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland"
-PKG_VERSION="1.17.0"
-PKG_SHA256="72aa11b8ac6e22f4777302c9251e8fec7655dc22f9d94ee676c6b276f95f91a4"
+PKG_VERSION="1.18.0"
+PKG_SHA256="4675a79f091020817a98fd0484e7208c8762242266967f55a67776936c2e294d"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/waylandpp/package.mk
+++ b/packages/wayland/waylandpp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="waylandpp"
-PKG_VERSION="0.2.5"
-PKG_SHA256="5a4361f73d2bee65bfe54b954ce085c9bfc7bc4429ac2bdc97c10e3b84660907"
+PKG_VERSION="0.2.8"
+PKG_SHA256="e7f486165d3568c3558b5c7099133aea4a285b82820eeafad329fc10271c654d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/NilsBrause/waylandpp"
 PKG_URL="https://github.com/NilsBrause/waylandpp/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/weston/package.mk
+++ b/packages/wayland/weston/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="weston"
-PKG_VERSION="6.0.0"
-PKG_SHA256="546323a90607b3bd7f48809ea9d76e64cd09718102f2deca6d95aa59a882e612"
+PKG_VERSION="9.0.0"
+PKG_SHA256="5cf5d6ce192e0eb15c1fc861a436bf21b5bb3b91dbdabbdebe83e1f83aa098fe"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Moved wayland updates out of https://github.com/LibreELEC/LibreELEC.tv/pull/4667 
and updated
- libinput: update to 1.16.4
- libxkbcommon: update to 1.0.3