### PR TITLE
Compress packages updated

### DIFF
--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libarchive"
-PKG_VERSION="3.4.2"
-PKG_SHA256="b60d58d12632ecf1e8fad7316dc82c6b9738a35625746b47ecdcaf4aed176176"
+PKG_VERSION="3.5.0"
+PKG_SHA256="245bff9d17e78986bf9716eb887e3bc731d7fd8e5d04efebb8bb1e1c39a3a354"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libarchive.org"
-PKG_URL="https://www.libarchive.org/downloads/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="https://www.libarchive.org/downloads/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SHORTDESC="A multi-format archive and compression library."

--- a/packages/compress/lz4/package.mk
+++ b/packages/compress/lz4/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lz4"
-PKG_VERSION="1.9.2"
-PKG_SHA256="658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc"
+PKG_VERSION="1.9.3"
+PKG_SHA256="030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/lz4/lz4"
 PKG_URL="https://github.com/lz4/lz4/archive/v$PKG_VERSION.tar.gz"

--- a/packages/compress/xz/package.mk
+++ b/packages/compress/xz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xz"
-PKG_VERSION="5.2.4"
-PKG_SHA256="3313fd2a95f43d88e44264e6b015e7d03053e681860b0d5d3f9baca79c57b7bf"
+PKG_VERSION="5.2.5"
+PKG_SHA256="5117f930900b341493827d63aa910ff5e011e0b994197c3b71c08a20228a42df"
 PKG_LICENSE="GPL"
 PKG_SITE="http://tukaani.org/xz/"
 PKG_URL="http://tukaani.org/xz/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
Update the following compres packages to current:

libarchive/package.mk 3.5.0
lz4/package.mk 1.9.3
minizip/package.mk 2.10.4
xz/package.mk 5.2.5

**Note: fixed minizip - it hadn't been compiling. miniunz_exec and minizip_exec were not valid targets, even when BUILD_TEST was corrected to MZ_BUILD_TEST
