### PR TITLE
brcmfmac_sdio-firmware-rpi: update to c13705a

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="9c0ffe9a7f0753b36ed88f7981905a989d940ea9"
-PKG_SHA256="cf806f6bdba0f803b90bc210f524a6ac37bac7ad19306c61474bb2dc59875e87"
+PKG_VERSION="c13705adcee0b35824db70b5f035c86a7088dfce"
+PKG_SHA256="7c453641e332d70a310dae8ee450b6ce024ed0a2204da1b3f3a3624191be60d8"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"
 PKG_URL="https://github.com/LibreELEC/$PKG_NAME/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Sync with current RPi OS:

Add BCM43436 firmware
Fix 80MHz channels on BCM43456
Fix higher 5GHz channel and BLE issues on CYW43455