### PR TITLE
simplejson: update to 3.17.2

### DIFF
--- a/packages/python/system/simplejson/package.mk
+++ b/packages/python/system/simplejson/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="simplejson"
-PKG_VERSION="3.17.0"
-PKG_SHA256="2b4b2b738b3b99819a17feaf118265d0753d5536049ea570b3c43b51c4701e81"
+PKG_VERSION="3.17.2"
+PKG_SHA256="75ecc79f26d99222a084fbdd1ce5aad3ac3a8bd535cd9059528452da38b68841"
 PKG_LICENSE="OSS"
 PKG_SITE="http://pypi.org/project/simplejson"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Minor bump from 3.17.0 to 3.17.2 

I have reviewed the code changes - they are minor
- https://github.com/simplejson/simplejson/compare/v3.17.0...v3.17.2

Change list is:
Version 3.17.2 released 2020-07-16

* Added arm64 to build matrix and reintroduced   manylinux wheels
  https://github.com/simplejson/simplejson/pull/264
* No more bdist_wininst builds per PEP 527
  https://github.com/simplejson/simplejson/pull/260
* Minor grammatical issue fixed in README
  https://github.com/simplejson/simplejson/pull/261