### PR TITLE
qemu: update to 5.2.0

### DIFF
--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -2,29 +2,51 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qemu"
-PKG_VERSION="4.0.0"
-PKG_SHA256="13a93dfe75b86734326f8d5b475fde82ec692d5b5a338b4262aeeb6b0fa4e469"
+PKG_VERSION="5.2.0"
+PKG_SHA256="cb18d889b628fbe637672b0326789d9b0e3b8027e0445b936537c78549df17bc"
 PKG_LICENSE="GPL"
-PKG_SITE="http://wiki.qemu.org"
+PKG_SITE="https://www.qemu.org"
 PKG_URL="https://download.qemu.org/qemu-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host glib:host pixman:host Python3:host zlib:host"
 PKG_LONGDESC="QEMU is a generic and open source machine emulator and virtualizer."
+PKG_TOOLCHAIN="configure"
 
 pre_configure_host() {
-  HOST_CONFIGURE_OPTS="--bindir=$TOOLCHAIN/bin \
-                       --extra-cflags=-I$TOOLCHAIN/include \
-                       --extra-ldflags=-L$TOOLCHAIN/lib \
-                       --libexecdir=$TOOLCHAIN/lib \
-                       --localstatedir=$TOOLCHAIN/var \
-                       --prefix=$TOOLCHAIN \
-                       --sbindir=$TOOLCHAIN/sbin \
-                       --static \
-                       --sysconfdir=$TOOLCHAIN/etc \
-                       --disable-blobs \
-                       --disable-docs \
-                       --disable-gcrypt \
-                       --disable-system \
-                       --disable-user \
-                       --disable-vnc \
-                       --disable-werror"
+  HOST_CONFIGURE_OPTS="\
+    --bindir=$TOOLCHAIN/bin \
+    --extra-cflags=-I$TOOLCHAIN/include \
+    --extra-ldflags=-L$TOOLCHAIN/lib \
+    --libexecdir=$TOOLCHAIN/lib \
+    --localstatedir=$TOOLCHAIN/var \
+    --prefix=$TOOLCHAIN \
+    --sbindir=$TOOLCHAIN/sbin \
+    --static \
+    --sysconfdir=$TOOLCHAIN/etc \
+    --enable-tools \
+    --disable-attr \
+    --disable-auth-pam \
+    --disable-blobs \
+    --disable-capstone \
+    --disable-curl \
+    --disable-debug-info \
+    --disable-debug-mutex \
+    --disable-debug-tcg \
+    --disable-docs \
+    --disable-gcrypt \
+    --disable-git-update \
+    --disable-gnutls \
+    --disable-libxml2 \
+    --disable-system \
+    --disable-tcmalloc \
+    --disable-user \
+    --disable-vnc \
+    --disable-werror \
+    --disable-xkbcommon \
+    --disable-zstd"
 }
+
+makeinstall_host() {
+  mkdir -p $TOOLCHAIN/bin
+    cp $PKG_BUILD/.$HOST_NAME/qemu-img $TOOLCHAIN/bin
+}
+                       


### PR DESCRIPTION
still builds the kitchen sink, I cut it down to the least possible without doing patches
- installs now just the required stuff to the toolchain