### PR TITLE
lz4: fix compilation

### DIFF
--- a/packages/compress/lz4/package.mk
+++ b/packages/compress/lz4/package.mk
@@ -10,9 +10,10 @@ PKG_URL="https://github.com/lz4/lz4/archive/v$PKG_VERSION.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="lz4 data compressor/decompressor"
+PKG_TOOLCHAIN="cmake"
 
 configure_package() {
-  PKG_CMAKE_SCRIPT="$PKG_BUILD/contrib/cmake_unofficial/CMakeLists.txt"
+  PKG_CMAKE_SCRIPT="$PKG_BUILD/build/cmake/CMakeLists.txt"
 
   PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=0 -DCMAKE_POSITION_INDEPENDENT_CODE=0"
 }


### PR DESCRIPTION
The cmake files were moved upstream [0] and the build now fails because it
silently falls back to the GNU Makefile:
install: cannot change permissions of '/usr/local/bin/': Operation not permitted

Point to the new location and set PKG_TOOLCHAIN explicitely to "cmake", which
would have caugth this issue:
CMake Error: The source directory "/tmp/libreelec/build.LibreELEC-H6.arm-9.80-devel/build/lz4-1.9.3/contrib/cmake_unofficial" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
FAILURE: ./scripts/build lz4:host during configure_host (default)

[0] https://github.com/lz4/lz4/commit/31d477db07c999afd639c3a37105894ecbf710fc