### PR TITLE
kodi: hide and disable "Sync playback to display" on GBM

### DIFF
--- a/packages/mediacenter/kodi/config/appliance-gbm.xml
+++ b/packages/mediacenter/kodi/config/appliance-gbm.xml
@@ -2,6 +2,12 @@
 <settings version="1">
   <section id="player">
     <category id="videoplayer">
+      <group id="2">
+        <setting id="videoplayer.usedisplayasclock">
+          <visible>false</visible>
+          <default>false</default>
+        </setting>
+      </group>
       <group id="3">
         <setting id="videoplayer.useprimedecoder">
           <default>true</default>


### PR DESCRIPTION
This is not supported on GBM. Before the multi-windowing kodi
change it was disabled via gbm.xml, and we forgot to include it
in appliance-gbm.xml