### PR TITLE
libgcrypt: updated to 1.8.7

### DIFF
--- a/packages/security/libgcrypt/package.mk
+++ b/packages/security/libgcrypt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgcrypt"
-PKG_VERSION="1.8.6"
-PKG_SHA256="0cba2700617b99fc33864a0c16b1fa7fdf9781d9ed3509f5d767178e5fd7b975"
+PKG_VERSION="1.8.7"
+PKG_SHA256="03b70f028299561b7034b8966d7dd77ef16ed139c43440925fe8782561974748"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.gnupg.org/"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libgcrypt/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
Very minor changes - https://dev.gnupg.org/T5113