### PR TITLE
libX11: update to 1.7.0

### DIFF
--- a/packages/x11/lib/libX11/package.mk
+++ b/packages/x11/lib/libX11/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libX11"
-PKG_VERSION="1.6.12"
-PKG_SHA256="f108227469419ac04d196df0f3b80ce1f7f65059bb54c0de811f4d8e03fd6ec7"
+PKG_VERSION="1.7.0"
+PKG_SHA256="36c8f93b6595437c8cfbc9f08618bcb3041cbd303e140a0013f88e4c2977cb54"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.x.org/"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
LibX11 1.7.0 has been tested for the last 2 weeks with Generic:
- previous PR was - https://github.com/LibreELEC/LibreELEC.tv/pull/4709
- new api = https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/master/README.md
- XSetIOErrorExitHandler which provides a mechanism for applications
to recover from I/O error conditions instead of being forced to
exit.

```
=== tested on ===
 22:38:25 up  4:12,  load average: 1.14, 1.41, 1.80
Generic.x86_64-devel-20201219065725-c2b7869
Linux LibreELEC 5.10.1 #1 SMP Wed Dec 16 13:02:48 UTC 2020 x86_64 GNU/Linux
Starting Kodi (19.0-BETA2 (18.9.821) Git:19.0b2-Matrix). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2020-12-15 by GCC 10.2.0 for Linux x86 64-bit version 5.10.0 (330240)
Running on LibreELEC (community): devel-20201219065725-c2b7869 9.80, kernel: Linux x86 64-bit version 5.10.1
FFmpeg version/source: 4.3.1-Kodi
Host CPU: Intel(R) Core(TM) i5-6260U CPU @ 1.80GHz, 4 cores available
[    0.000000] DMI:  /NUC6i5SYB, BIOS SYSKLi35.86A.0073.2020.0909.1625 09/09/2020
```