### PR TITLE
update packages/multimedia and their dependancies

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/harfbuzz-icu/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/harfbuzz-icu/package.mk
@@ -2,16 +2,15 @@
 # Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
-PKG_NAME="harfbuzz"
-PKG_VERSION="2.7.4"
-PKG_SHA256="6ad11d653347bd25d8317589df4e431a2de372c0cf9be3543368e07ec23bb8e7"
-PKG_LICENSE="GPL"
-PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
-PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/$PKG_VERSION/harfbuzz-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="toolchain cairo freetype glib icu"
-PKG_LONGDESC="HarfBuzz is an OpenType text shaping engine."
-PKG_TOOLCHAIN="meson"
+. $(get_pkg_directory harfbuzz)/package.mk
+
+PKG_NAME="harfbuzz-icu"
+PKG_URL=""
+PKG_DEPENDS_TARGET+=" icu"
+PKG_LONGDESC="HarfBuzz with icu"
 PKG_DEPENDS_CONFIG="icu"
+PKG_DEPENDS_UNPACK+=" harfbuzz"
+PKG_BUILD_FLAGS="-sysroot"
 
 PKG_MESON_OPTS_TARGET="-Dcairo=enabled \
                        -Ddocs=disabled \
@@ -21,3 +20,8 @@ PKG_MESON_OPTS_TARGET="-Dcairo=enabled \
                        -Dgobject=disabled \
                        -Dgraphite=disabled \
                        -Dicu=enabled"
+
+unpack() {
+  mkdir -p $PKG_BUILD
+  tar --strip-components=1 -xf $SOURCES/${PKG_NAME:0:8}/${PKG_NAME:0:8}-$PKG_VERSION.tar.xz -C $PKG_BUILD
+}

--- a/packages/addons/addon-depends/chrome-depends/harfbuzz/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/harfbuzz/package.mk
@@ -3,20 +3,21 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="1.8.1"
-PKG_SHA256="fbed6392ddb085e45e6090a9f389f72926d0e355f4b0a2ef51d35cf21686df45"
+PKG_VERSION="2.7.4"
+PKG_SHA256="6ad11d653347bd25d8317589df4e431a2de372c0cf9be3543368e07ec23bb8e7"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
-PKG_URL="https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-$PKG_VERSION.tar.bz2"
+PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/$PKG_VERSION/harfbuzz-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain cairo freetype glib icu"
 PKG_LONGDESC="HarfBuzz is an OpenType text shaping engine."
-PKG_TOOLCHAIN="configure"
+PKG_TOOLCHAIN="meson"
+PKG_DEPENDS_CONFIG="icu"
 
-PKG_CONFIGURE_OPTS_TARGET="--with-icu \
-                           --disable-gtk-doc \
-                           --disable-gtk-doc-html \
-                           --disable-gtk-doc-pdf"
-
-pre_configure_target() {
-  export LDFLAGS="$LDFLAGS -ldl"
-}
+PKG_MESON_OPTS_TARGET="-Dcairo=enabled \
+                       -Ddocs=disabled \
+                       -Dfontconfig=enabled \
+                       -Dfreetype=enabled \
+                       -Dglib=enabled \
+                       -Dgobject=disabled \
+                       -Dgraphite=disabled \
+                       -Dicu=enabled"

--- a/packages/addons/addon-depends/icu/package.mk
+++ b/packages/addons/addon-depends/icu/package.mk
@@ -2,14 +2,15 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="icu"
-PKG_VERSION="68.1"
-PKG_SHA256="5b3cfb519c20511c1c0429b093ec16960f6a6a0d7968a9065fda393f9eba48fc"
+PKG_VERSION="68.2"
+PKG_SHA256="f790b0202facbbf19c5581a7a5f21b2b4b6ed70ba3e4bef8d5560868e5e82476"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.icu-project.org"
 PKG_URL="https://github.com/unicode-org/icu/archive/release-${PKG_VERSION//./-}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain icu:host"
 PKG_LONGDESC="International Components for Unicode library."
+PKG_TOOLCHAIN="configure"
 
 PKG_BUILD_FLAGS="-sysroot"
 
@@ -17,7 +18,7 @@ configure_package() {
   PKG_CONFIGURE_SCRIPT="${PKG_BUILD}/icu4c/source/configure"
   PKG_CONFIGURE_OPTS_TARGET="--disable-layout \
                              --disable-layoutex \
-                             --disable-renaming \
+                             --enable-renaming \
                              --disable-samples \
                              --disable-tests \
                              --disable-tools \

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -11,7 +11,7 @@ PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"
 PKG_DEPENDS_TARGET="toolchain at-spi2-atk atk cairo chrome-libXcomposite \
                     chrome-libXdamage chrome-libXfixes chrome-libXi chrome-libXrender \
-                    chrome-libXtst chrome-libxcb chrome-libxkbcommon cups gdk-pixbuf gtk3 harfbuzz \
+                    chrome-libXtst chrome-libxcb chrome-libxkbcommon cups gdk-pixbuf gtk3 harfbuzz-icu \
                     libXcursor libxss nss pango scrnsaverproto unclutter"
 PKG_SECTION="browser"
 PKG_SHORTDESC="Google Chrome Browser"
@@ -44,7 +44,7 @@ addon() {
          $(get_install_dir cairo)/usr/lib/{libcairo-gobject.so.2,libcairo.so.2} \
          $(get_install_dir gdk-pixbuf)/usr/lib/libgdk_pixbuf-2.0.so.0 \
          $(get_install_dir gtk3)/usr/lib/{libgtk-3.so.0,libgdk-3.so.0} \
-         $(get_install_dir harfbuzz)/usr/lib/{libharfbuzz.so.0,libharfbuzz-icu.so*} \
+         $(get_install_dir harfbuzz-icu)/usr/lib/{libharfbuzz.so.0,libharfbuzz-icu.so*} \
          $(get_install_dir at-spi2-atk)/usr/lib/libatk-bridge-2.0.so.0 \
          $(get_install_dir at-spi2-core)/usr/lib/libatspi.so.0 \
          $(get_install_dir cups)/usr/lib/libcups.so.2 \

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="harfbuzz"
+PKG_VERSION="2.7.4"
+PKG_SHA256="6ad11d653347bd25d8317589df4e431a2de372c0cf9be3543368e07ec23bb8e7"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
+PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/$PKG_VERSION/harfbuzz-$PKG_VERSION.tar.xz"
+PKG_DEPENDS_TARGET="toolchain cairo freetype glib"
+PKG_LONGDESC="HarfBuzz is an OpenType text shaping engine."
+PKG_TOOLCHAIN="meson"
+
+PKG_MESON_OPTS_TARGET="-Dcairo=enabled \
+                       -Ddocs=disabled \
+                       -Dfontconfig=enabled \
+                       -Dfreetype=enabled \
+                       -Dglib=enabled \
+                       -Dgobject=disabled \
+                       -Dgraphite=disabled \
+                       -Dicu=disabled"

--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.0.10"
-PKG_SHA256="b4656c13a1f0d0023ae2f4a9cf08ec92fffb464e0f24238337784159b8b91d57"
+PKG_VERSION="2.0.14"
+PKG_SHA256="d8215b571a581be1332d2106f8036fcb03d12a70bae01e20f424976d275432bc"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
 PKG_URL="https://www.libsdl.org/release/$PKG_NAME-$PKG_VERSION.tar.gz"
@@ -56,6 +56,7 @@ PKG_CMAKE_OPTS_TARGET="-DSDL_STATIC=ON \
                        -DSDL_DLOPEN=ON \
                        -DCLOCK_GETTIME=OFF \
                        -DRPATH=OFF \
+		       -DVIDEO_KMSDRM=OFF \
                        -DRENDER_D3D=OFF"
 
 if [ "$DISPLAYSERVER" = "x11" ]; then

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="8c113ea88bc5afc1d5d7001c8dedbde7af2c82dc"
-PKG_SHA256="cac9000fb82296d3c1e590c373fc8d4067620c003c707027410711081f8b7e26"
+PKG_VERSION="7ddc21b28468b9e8d0f189bb46a2467de4e09e12"
+PKG_SHA256="995349787105db62daba924f22f7a90c4825575fe24d2b87c4b183d8ac99f5b3"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="http://repo.or.cz/aom.git/snapshot/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/libass/package.mk
+++ b/packages/multimedia/libass/package.mk
@@ -3,17 +3,16 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libass"
-PKG_VERSION="0.14.0"
-PKG_SHA256="881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
+PKG_VERSION="0.15.0"
+PKG_SHA256="9f09230c9a0aa68ef7aa6a9e2ab709ca957020f842e52c5b2e52b801a7d9e833"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/libass/libass"
 PKG_URL="https://github.com/libass/libass/releases/download/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="toolchain freetype fontconfig fribidi"
+PKG_DEPENDS_TARGET="toolchain freetype fontconfig fribidi harfbuzz"
 PKG_LONGDESC="A portable subtitle renderer for the ASS/SSA (Advanced Substation Alpha/Substation Alpha) subtitle format."
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-test \
                            --enable-fontconfig \
-                           --disable-harfbuzz \
                            --disable-silent-rules \
                            --with-gnu-ld"
 

--- a/packages/multimedia/libhdhomerun/package.mk
+++ b/packages/multimedia/libhdhomerun/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libhdhomerun"
-PKG_VERSION="b0e5d5f5c8e2bf37dea34beb014e08ebb598ebf6" #20190625
-PKG_SHA256="ac39e03090c148678e1a8d4f928a728caccd2d29a0555287e7e5ece28c876959"
+PKG_VERSION="64aa1606b58e9654385333031c5d7bf02989bf49" #20200303
+PKG_SHA256="bd2601ccbf78a15310f28e2b4384477fb124490688dd4177f8bb9e689d0b2fd8"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.silicondust.com"
 PKG_URL="https://github.com/Silicondust/libhdhomerun/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/libudfread/package.mk
+++ b/packages/multimedia/libudfread/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libudfread"
-PKG_VERSION="1.1.0"
-PKG_SHA256="5ad9f95c53e8f29853c1fefa0a20a301be4045e2c7ae49d1164bc74d94155627"
+PKG_VERSION="1.1.1"
+PKG_SHA256="5d237ff81caa46856dc75b8ddd1f17c0e262eea08ef59a466cc850585f1680dc"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="https://code.videolan.org/videolan/libudfread"
 PKG_URL="https://code.videolan.org/videolan/$PKG_NAME/-/archive/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"

--- a/packages/multimedia/rtmpdump/package.mk
+++ b/packages/multimedia/rtmpdump/package.mk
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rtmpdump"
-PKG_VERSION="fa8646daeb19dfd12c181f7d19de708d623704c0"
-PKG_SHA256="dba4d4d2e1c7de6884b01d98194b83cab6784669089fa3c919152087a3a38fd2"
+PKG_VERSION="c5f04a58fc2aeea6296ca7c44ee4734c18401aa3"
+PKG_SHA256="fd8c21263d93fbde8bee8aa6c5f6a657789674bb0f9e74f050651504d5f43b46"
 PKG_LICENSE="GPL"
 PKG_SITE="http://rtmpdump.mplayerhq.hu/"
 PKG_URL="http://repo.or.cz/rtmpdump.git/snapshot/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Limited testing on Generic so far.

- libass 0.15 now has a mandatory dependancy on harfbuzz
- harfbuzz 2.7.2 if using -Dicu=enable is fixed

all other package updates were quite minor
