### PR TITLE
Allwinner: R40: Enable deinterlace driver

### DIFF
--- a/projects/Allwinner/devices/R40/patches/linux/0018-r40-enable-deinterlace.patch
+++ b/projects/Allwinner/devices/R40/patches/linux/0018-r40-enable-deinterlace.patch
@@ -1,0 +1,30 @@
+diff --git a/arch/arm/boot/dts/sun8i-r40.dtsi b/arch/arm/boot/dts/sun8i-r40.dtsi
+index 7907569e7b5c..d5ad3b9efd12 100644
+--- a/arch/arm/boot/dts/sun8i-r40.dtsi
++++ b/arch/arm/boot/dts/sun8i-r40.dtsi
+@@ -190,6 +190,25 @@ mixer1_out_tcon_top: endpoint {
+ 			};
+ 		};
+ 
++		deinterlace: deinterlace@1400000 {
++			compatible = "allwinner,sun8i-r40-deinterlace",
++				     "allwinner,sun8i-h3-deinterlace";
++			reg = <0x01400000 0x20000>;
++			clocks = <&ccu CLK_BUS_DEINTERLACE>,
++				 <&ccu CLK_DEINTERLACE>,
++				 /*
++				  * NOTE: Contrary to what datasheet claims,
++				  * DRAM deinterlace gate doesn't exist and
++				  * it's shared with CSI1.
++				  */
++				 <&ccu CLK_DRAM_CSI1>;
++			clock-names = "bus", "mod", "ram";
++			resets = <&ccu RST_BUS_DEINTERLACE>;
++			interrupts = <GIC_SPI 93 IRQ_TYPE_LEVEL_HIGH>;
++			interconnects = <&mbus 9>;
++			interconnect-names = "dma-mem";
++		};
++
+ 		syscon: system-control@1c00000 {
+ 			compatible = "allwinner,sun8i-r40-system-control",
+ 				     "allwinner,sun4i-a10-system-control";


### PR DESCRIPTION
This PR enables deinterlace driver for R40.