### PR TITLE
systemd: fix kernel-overlays.service ordering

### DIFF
--- a/packages/sysutils/systemd/system.d/modprobe@.service.d/dependencies.conf
+++ b/packages/sysutils/systemd/system.d/modprobe@.service.d/dependencies.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=kernel-overlays.service


### PR DESCRIPTION
kernel-overlays.service needs to be ordered before the modprobe@
instances, which were introduced in systemd 245, otherwise
modprobe@drm.service can run before /lib/firmware exists and
edid-override will fail.

Fix that by adding modprobe@.service template drop-in to order it
after kernel-overlays.service