### PR TITLE
Allwinner: Fix and improvement

### DIFF
--- a/projects/Allwinner/devices/H5/patches/linux/18-enable-deinterlace.patch
+++ b/projects/Allwinner/devices/H5/patches/linux/18-enable-deinterlace.patch
@@ -1,0 +1,24 @@
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+index 10489e508695..578a63dedf46 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+@@ -121,6 +121,19 @@ crypto: crypto@1c15000 {
+ 			resets = <&ccu RST_BUS_CE>;
+ 		};
+ 
++		deinterlace: deinterlace@1e00000 {
++			compatible = "allwinner,sun8i-h3-deinterlace";
++			reg = <0x01e00000 0x20000>;
++			clocks = <&ccu CLK_BUS_DEINTERLACE>,
++				 <&ccu CLK_DEINTERLACE>,
++				 <&ccu CLK_DRAM_DEINTERLACE>;
++			clock-names = "bus", "mod", "ram";
++			resets = <&ccu RST_BUS_DEINTERLACE>;
++			interrupts = <GIC_SPI 93 IRQ_TYPE_LEVEL_HIGH>;
++			interconnects = <&mbus 9>;
++			interconnect-names = "dma-mem";
++		};
++
+ 		mali: gpu@1e80000 {
+ 			compatible = "allwinner,sun50i-h5-mali", "arm,mali-450";
+ 			reg = <0x01e80000 0x30000>;

--- a/projects/Allwinner/patches/linux/0002-media-cedrus-Fix-H264-decoding.patch
+++ b/projects/Allwinner/patches/linux/0002-media-cedrus-Fix-H264-decoding.patch
@@ -1,0 +1,38 @@
+From 45e6e50e3420425d1db8022aa2773dd697c6f054 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 23 Dec 2020 11:23:40 +0100
+Subject: [PATCH 2/2] media: cedrus: Fix H264 decoding
+
+During H264 API overhaul subtle bug was introduced Cedrus driver.
+Progressive references have both, top and bottom reference flags set.
+Cedrus reference list expects only bottom reference flag and only when
+interlaced frames are decoded. However, due to a bug in Cedrus check,
+exclusivity is not tested and that flag is set also for progressive
+references. That causes "jumpy" background with many videos.
+
+Fix that by checking that only bottom reference flag is set in control
+and nothing else.
+
+Tested-by: Andre Heider <a.heider@gmail.com>
+Fixes: cfc8c3ed533e ("media: cedrus: h264: Properly configure reference field")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/staging/media/sunxi/cedrus/cedrus_h264.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+index 781c84a9b1b7..de7442d4834d 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+@@ -203,7 +203,7 @@ static void _cedrus_write_ref_list(struct cedrus_ctx *ctx,
+ 		position = cedrus_buf->codec.h264.position;
+ 
+ 		sram_array[i] |= position << 1;
+-		if (ref_list[i].fields & V4L2_H264_BOTTOM_FIELD_REF)
++		if (ref_list[i].fields == V4L2_H264_BOTTOM_FIELD_REF)
+ 			sram_array[i] |= BIT(0);
+ 	}
+ 
+-- 
+2.29.2
+


### PR DESCRIPTION
This PR fixes H264 decoding introduced in https://github.com/LibreELEC/LibreELEC.tv/pull/4606 and adds a patch which enables deinterlace core on H5.