### PR TITLE
update packages/graphics 

### DIFF
--- a/packages/graphics/glmark2/package.mk
+++ b/packages/graphics/glmark2/package.mk
@@ -2,31 +2,18 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glmark2"
-PKG_VERSION="7632c2e2677ef01e44af758823c2fffcced22524"
-PKG_SHA256="c0fb0fb2f62d05f229466a4c1cbb902816595b0a5ed860de46f763533c515e6c"
+PKG_VERSION="784aca755a469b144acf3cae180b6e613b7b057a"
+PKG_SHA256="787dd7de05c795c7c42694e648b5c6418e4b395fc460ea349d1d35d493469356"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/glmark2/glmark2"
 PKG_URL="https://github.com/glmark2/glmark2/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="glmark2 is an OpenGL 2.0 and ES 2.0 benchmark"
-PKG_TOOLCHAIN="manual"
 
 if [ "$OPENGLES_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" $OPENGLES"
-  PKG_CONFIGURE_OPTS_TARGET="--with-flavors=drm-glesv2"
+  PKG_MESON_OPTS_TARGET="-Dflavors=drm-glesv2"
 elif [ "$OPENGL_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" $OPENGL"
-  PKG_CONFIGURE_OPTS_TARGET="--with-flavors=drm-gl"
+  PKG_MESON_OPTS_TARGET="-Dflavors=drm-gl"
 fi
-
-configure_target() {
-  ./waf configure $PKG_CONFIGURE_OPTS_TARGET --prefix=/usr
-}
-
-make_target() {
-  ./waf
-}
-
-makeinstall_target() {
-  ./waf install --destdir=$INSTALL
-}

--- a/packages/graphics/lcms2/package.mk
+++ b/packages/graphics/lcms2/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lcms2"
-PKG_VERSION="2.9"
-PKG_SHA256="8e23a09dc81af856db37941a4ea26acdf6a45b0281ec5b7ee94b5a4e9f7afbf7"
-PKG_LICENSE="MIT"
+PKG_VERSION="2.11"
+PKG_SHA256="dc49b9c8e4d7cdff376040571a722902b682a795bf92985a85b48854c270772e"
+PKG_LICENSE="MIT/GPLv3"
 PKG_SITE="http://www.littlecms.com"
-PKG_URL="https://github.com/mm2/Little-CMS/archive/lcms${PKG_VERSION}.tar.gz"
+PKG_URL="$SOURCEFORGE_SRC/lcms/lcms/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain tiff"
 PKG_LONGDESC="An small-footprint color management engine, with special focus on accuracy and performance."

--- a/packages/graphics/libde265/package.mk
+++ b/packages/graphics/libde265/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libde265"
-PKG_VERSION="50987014f7b041079ac1961352781904b691cf7b"
-PKG_SHA256="5cdefeb099141608331efe9a9bd33dad271e5810438b654e53e4d2359acdc12a"
+PKG_VERSION="1.0.8"
+PKG_SHA256="24c791dd334fa521762320ff54f0febfd3c09fc978880a8c5fbc40a88f21d905"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="http://www.libde265.org"
-PKG_URL="https://github.com/strukturag/libde265/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/strukturag/libde265/releases/download/v${PKG_VERSION}/${PKG_NAME}-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Open h.265 video codec implementation."
 PKG_BUILD_FLAGS="+pic"

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.102"
-PKG_SHA256="8bcbf9336c28e393d76c1f16d7e79e394a7fce8a2e929d52d3ad7ad8525ba05b"
+PKG_VERSION="2.4.103"
+PKG_SHA256="3fe0affdba6460166a7323290c18cf68e9b59edcb520722826cb244e9cb50222"
 PKG_LICENSE="GPL"
 PKG_SITE="http://dri.freedesktop.org"
 PKG_URL="http://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/libepoxy/package.mk
+++ b/packages/graphics/libepoxy/package.mk
@@ -8,8 +8,8 @@
 # in Xorg.log
 
 PKG_NAME="libepoxy"
-PKG_VERSION="1.5.4"
-PKG_SHA256="0bd2cc681dfeffdef739cb29913f8c3caa47a88a451fd2bc6e606c02997289d2"
+PKG_VERSION="1.5.5"
+PKG_SHA256="261663db21bcc1cc232b07ea683252ee6992982276536924271535875f5b0556"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/anholt/libepoxy"
 PKG_URL="https://github.com/anholt/libepoxy/releases/download/${PKG_VERSION}/libepoxy-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.6.2"
-PKG_SHA256="bb229e855621deb374f61bee95c4642f60c2a2496bded35df3d3c42cc6d8eefc"
+PKG_VERSION="1.10.0"
+PKG_SHA256="ad5af1276f341277dc537b0d19a4193e0833c247b2aacb936e0c5494141533ae"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="http://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v$PKG_VERSION/libheif-$PKG_VERSION.tar.gz"

--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libjpeg-turbo"
-PKG_VERSION="2.0.5"
-PKG_SHA256="b3090cd37b5a8b3e4dbd30a1311b3989a894e5d3c668f14cbc6739d77c9402b7"
+PKG_VERSION="2.0.6"
+PKG_SHA256="005aee2fcdca252cee42271f7f90574dda64ca6505d9f8b86ae61abc2b426371"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libjpeg-turbo.org/"
 PKG_URL="https://github.com/libjpeg-turbo/libjpeg-turbo/archive/$PKG_VERSION.tar.gz"

--- a/packages/graphics/libprojectM/package.mk
+++ b/packages/graphics/libprojectM/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libprojectM"
-PKG_VERSION="3.1.2"
-PKG_SHA256="d59f61806f4e0e89bb42c494514ee295b3a7c4893432a1d38607777040a90823"
+PKG_VERSION="3.1.7"
+PKG_SHA256="968551c5d6292179838bf5d3ab85f5bd785c6fec7c1de42c0cf5ec3dbf4b04f9"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/projectM-visualizer/projectm"
 PKG_URL="https://github.com/projectM-visualizer/projectm/archive/v$PKG_VERSION.tar.gz"

--- a/packages/graphics/libraw/package.mk
+++ b/packages/graphics/libraw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libraw"
-PKG_VERSION="0.19.5"
-PKG_SHA256="40a262d7cc71702711a0faec106118ee004f86c86cc228281d12d16da03e02f5"
+PKG_VERSION="0.20.2"
+PKG_SHA256="dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libraw.org/"
 PKG_URL="http://www.libraw.org/data/LibRaw-$PKG_VERSION.tar.gz"

--- a/packages/graphics/tiff/package.mk
+++ b/packages/graphics/tiff/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tiff"
-PKG_VERSION="4.1.0"
-PKG_SHA256="5d29f32517dadb6dbcd1255ea5bbc93a2b54b94fbf83653b4d65c7d6775b8634"
+PKG_VERSION="4.2.0"
+PKG_SHA256="eb0484e568ead8fa23b513e9b0041df7e327f4ee2d22db5a533929dfc19633cb"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.remotesensing.org/libtiff/"
 PKG_URL="http://download.osgeo.org/libtiff/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Graphics packages updated. Mostly minor.

Notable changes:
- libheif had a few version jumps.
- libde265 now using release number not a sha256
- glmark2 now compiled with meson

Notes/Todos: (these packages have not been updated in this PR)
- looks like **vsxu** has not been updated for a while? It has some updated releases, the GitHub is archived. Do we want to update this? 
- kmscube - skipping only a single commit
- cairo - are we bumping to 1.17.4? Also note maintainer update - https://gitlab.freedesktop.org/cairo/cairo/-/blob/156cd3eaaebfd8635517c2baf61fcf3627ff7ec2/NEWS
- glfw - working through the Xcursor dependancy with glfw-3.3.2
 

```
=== tested on ===
 01:00:25 up 1 day,  2:31,  load average: 1.27, 1.22, 1.25
Generic.x86_64-devel-20201222112050-a9a38e4
Linux LibreELEC 5.10.2 #1 SMP Mon Dec 21 14:09:09 UTC 2020 x86_64 GNU/Linux
Starting Kodi (19.0-BETA2 (18.9.821) Git:19.0b2-Matrix). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2020-12-15 by GCC 10.2.0 for Linux x86 64-bit version 5.10.0 (330240)
Running on LibreELEC (community): devel-20201222112050-a9a38e4 9.80, kernel: Linux x86 64-bit version 5.10.2
FFmpeg version/source: 4.3.1-Kodi
Host CPU: Intel(R) Core(TM) i5-6260U CPU @ 1.80GHz, 4 cores available
[    0.000000] DMI:  /NUC6i5SYB, BIOS SYSKLi35.86A.0073.2020.0909.1625 09/09/2020
```

