### PR TITLE
Allwinner: Support for DT overlays

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -190,7 +190,7 @@ make_target() {
     KERNEL_TARGET="${KERNEL_TARGET/uImage/Image}"
   fi
 
-  kernel_make ${KERNEL_TARGET} ${KERNEL_MAKE_EXTRACMD} modules
+  kernel_make DTC_FLAGS=-@ ${KERNEL_TARGET} ${KERNEL_MAKE_EXTRACMD} modules
 
   if [ "${PKG_BUILD_PERF}" = "yes" ]; then
     ( cd tools/perf

--- a/packages/tools/dt-overlays/package.mk
+++ b/packages/tools/dt-overlays/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="dt-overlays"
+PKG_VERSION="e57a9b1eadd420a4e5d50c0669184828ff12abc5"
+PKG_SHA256="b63ee4f54723349ce405c9bd3545b5bb0814e4d1959a6a1db0bb2517318b1cc5"
+PKG_LICENSE="GPLv2+ or MIT"
+PKG_SITE="https://github.com/LibreELEC/dt-overlays"
+PKG_URL="https://github.com/LibreELEC/dt-overlays/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="dtc:host"
+PKG_LONGDESC="The Device Tree Overlays"
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/share/bootloader/overlays
+    cp -p overlays/*/*.dtbo $INSTALL/usr/share/bootloader/overlays
+}

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -32,6 +32,7 @@ case "${PROJECT}" in
     PKG_VERSION="2021.01"
     PKG_SHA256="b407e1510a74e863b8b5cb42a24625344f0e0c2fc7582d8c866bd899367d0454"
     PKG_URL="http://ftp.denx.de/pub/u-boot/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+    PKG_PATCH_DIRS="default"
     ;;
 esac
 

--- a/packages/tools/u-boot/patches/default/0001-pxe-add-support-for-FDT-overlays.patch
+++ b/packages/tools/u-boot/patches/default/0001-pxe-add-support-for-FDT-overlays.patch
@@ -1,0 +1,197 @@
+From ac4728b374f39debc266fe42c513ea8f61e3d369 Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Thu, 24 Dec 2020 09:03:15 +0100
+Subject: [PATCH] pxe: add support for FDT overlays
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This adds support for specicyinf FDT overlays in an extlinux/pxelinux
+configuration file.
+
+Without this, there is no simple way to apply overlays when the kernel
+and ftd is loaded by the pxe command.
+
+This change adds the 'fdtoverlays' keyword for a label, supporting multiple
+overlay files to be applied on top of the fdt specific in the 'fdt' or
+'devicetree' keyword.
+
+Cc: Jernej Škrabec <jernej.skrabec@siol.net>
+Cc: Jonas Karlman <jonas@kwiboo.se>
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ cmd/pxe_utils.c | 103 ++++++++++++++++++++++++++++++++++++++++++++++++
+ cmd/pxe_utils.h |   1 +
+ 2 files changed, 104 insertions(+)
+
+diff --git a/cmd/pxe_utils.c b/cmd/pxe_utils.c
+index 8716e782f6aa..25367190a700 100644
+--- a/cmd/pxe_utils.c
++++ b/cmd/pxe_utils.c
+@@ -13,6 +13,8 @@
+ #include <mapmem.h>
+ #include <lcd.h>
+ #include <net.h>
++#include <fdt_support.h>
++#include <linux/libfdt.h>
+ #include <linux/string.h>
+ #include <linux/ctype.h>
+ #include <errno.h>
+@@ -284,6 +286,9 @@ static void label_destroy(struct pxe_label *label)
+ 	if (label->fdtdir)
+ 		free(label->fdtdir);
+ 
++	if (label->fdtoverlays)
++		free(label->fdtoverlays);
++
+ 	free(label);
+ }
+ 
+@@ -331,6 +336,92 @@ static int label_localboot(struct pxe_label *label)
+ 	return run_command_list(localcmd, strlen(localcmd), 0);
+ }
+ 
++/*
++ * Loads fdt overlays specified in 'fdtoverlays'.
++ */
++#ifdef CONFIG_OF_LIBFDT_OVERLAY
++static void label_boot_fdtoverlay(struct cmd_tbl *cmdtp, struct pxe_label *label)
++{
++	char *fdtoverlay = label->fdtoverlays;
++	struct fdt_header *working_fdt;
++	char *fdtoverlay_addr_env;
++	ulong fdtoverlay_addr;
++	ulong fdt_addr;
++	int err;
++
++	/* Get the main fdt and map it */
++	fdt_addr = simple_strtoul(env_get("fdt_addr_r"), NULL, 16);
++	working_fdt = map_sysmem(fdt_addr, 0);
++	err = fdt_check_header(working_fdt);
++	if (err)
++		return;
++
++	/* Get the specific overlay loading address */
++	fdtoverlay_addr_env = env_get("fdtoverlay_addr_r");
++	if (!fdtoverlay_addr_env) {
++		printf("Invalid fdtoverlay_addr_r for loading overlays\n");
++		return;
++	}
++
++	fdtoverlay_addr = simple_strtoul(fdtoverlay_addr_env, NULL, 16);
++
++	/* Cycle over the overlay files and apply them in order */
++	do {
++		struct fdt_header *blob;
++		char *overlayfile;
++		char *end;
++		int len;
++
++		/* Drop leading spaces */
++		while (*fdtoverlay == ' ')
++			++fdtoverlay;
++
++		/* Copy a single filename if multiple provided */
++		end = strstr(fdtoverlay, " ");
++		if (end) {
++			len = (int)(end - fdtoverlay);
++			overlayfile = malloc(len + 1);
++			strncpy(overlayfile, fdtoverlay, len);
++			overlayfile[len] = '\0';
++		} else
++			overlayfile = fdtoverlay;
++
++		if (!strlen(overlayfile))
++			goto skip_overlay;
++
++		/* Load overlay file */
++		err = get_relfile_envaddr(cmdtp, overlayfile,
++					  "fdtoverlay_addr_r");
++		if (err < 0) {
++			printf("Failed loading overlay %s\n", overlayfile);
++			goto skip_overlay;
++		}
++
++		/* Resize main fdt */
++		fdt_shrink_to_minimum(working_fdt, 8192);
++
++		blob = map_sysmem(fdtoverlay_addr, 0);
++		err = fdt_check_header(blob);
++		if (err) {
++			printf("Invalid overlay %s, skipping\n",
++			       overlayfile);
++			goto skip_overlay;
++		}
++
++		err = fdt_overlay_apply_verbose(working_fdt, blob);
++		if (err) {
++			printf("Failed to apply overlay %s, skipping\n",
++			       overlayfile);
++			goto skip_overlay;
++		}
++
++skip_overlay:
++		if (end)
++			free(overlayfile);
++	} while ((fdtoverlay = strstr(fdtoverlay, " ")));
++}
++#endif
++
+ /*
+  * Boot according to the contents of a pxe_label.
+  *
+@@ -525,6 +616,11 @@ static int label_boot(struct cmd_tbl *cmdtp, struct pxe_label *label)
+ 				       label->name);
+ 				goto cleanup;
+ 			}
++
++#ifdef CONFIG_OF_LIBFDT_OVERLAY
++			if (label->fdtoverlays)
++				label_boot_fdtoverlay(cmdtp, label);
++#endif
+ 		} else {
+ 			bootm_argv[3] = NULL;
+ 		}
+@@ -582,6 +678,7 @@ enum token_type {
+ 	T_INCLUDE,
+ 	T_FDT,
+ 	T_FDTDIR,
++	T_FDTOVERLAYS,
+ 	T_ONTIMEOUT,
+ 	T_IPAPPEND,
+ 	T_BACKGROUND,
+@@ -616,6 +713,7 @@ static const struct token keywords[] = {
+ 	{"fdt", T_FDT},
+ 	{"devicetreedir", T_FDTDIR},
+ 	{"fdtdir", T_FDTDIR},
++	{"fdtoverlays", T_FDTOVERLAYS},
+ 	{"ontimeout", T_ONTIMEOUT,},
+ 	{"ipappend", T_IPAPPEND,},
+ 	{"background", T_BACKGROUND,},
+@@ -1048,6 +1146,11 @@ static int parse_label(char **c, struct pxe_menu *cfg)
+ 				err = parse_sliteral(c, &label->fdtdir);
+ 			break;
+ 
++		case T_FDTOVERLAYS:
++			if (!label->fdtoverlays)
++				err = parse_sliteral(c, &label->fdtoverlays);
++			break;
++
+ 		case T_LOCALBOOT:
+ 			label->localboot = 1;
+ 			err = parse_integer(c, &label->localboot_val);
+diff --git a/cmd/pxe_utils.h b/cmd/pxe_utils.h
+index 77d25888758f..6af952373430 100644
+--- a/cmd/pxe_utils.h
++++ b/cmd/pxe_utils.h
+@@ -43,6 +43,7 @@ struct pxe_label {
+ 	char *initrd;
+ 	char *fdt;
+ 	char *fdtdir;
++	char *fdtoverlays;
+ 	int ipappend;
+ 	int attempted;
+ 	int localboot;
+-- 
+2.29.2
+

--- a/packages/tools/u-boot/patches/default/0002-sunxi-Add-fdtoverlay_addr_r-env-variable.patch
+++ b/packages/tools/u-boot/patches/default/0002-sunxi-Add-fdtoverlay_addr_r-env-variable.patch
@@ -1,0 +1,84 @@
+From 48f5c27ae2edfb36d7f6a628d3763b4c4b85c9c7 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 30 Dec 2020 21:01:20 +0100
+Subject: [PATCH] sunxi: Add fdtoverlay_addr_r env variable
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ include/configs/sunxi-common.h | 40 +++++++++++++++++++---------------
+ 1 file changed, 22 insertions(+), 18 deletions(-)
+
+diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
+index a6a4879523a3..34917be3325f 100644
+--- a/include/configs/sunxi-common.h
++++ b/include/configs/sunxi-common.h
+@@ -287,12 +287,13 @@ extern int soft_i2c_gpio_scl;
+  * Scripts, PXE and DTBs should go afterwards, leaving the rest for the initrd.
+  * Align the initrd to a 2MB page.
+  */
+-#define BOOTM_SIZE	__stringify(0xa000000)
+-#define KERNEL_ADDR_R	__stringify(SDRAM_OFFSET(0080000))
+-#define FDT_ADDR_R	__stringify(SDRAM_OFFSET(FA00000))
+-#define SCRIPT_ADDR_R	__stringify(SDRAM_OFFSET(FC00000))
+-#define PXEFILE_ADDR_R	__stringify(SDRAM_OFFSET(FD00000))
+-#define RAMDISK_ADDR_R	__stringify(SDRAM_OFFSET(FE00000))
++#define BOOTM_SIZE        __stringify(0xa000000)
++#define KERNEL_ADDR_R     __stringify(SDRAM_OFFSET(0080000))
++#define FDT_ADDR_R        __stringify(SDRAM_OFFSET(FA00000))
++#define FDTOVERLAY_ADDR_R __stringify(SDRAM_OFFSET(FB00000))
++#define SCRIPT_ADDR_R     __stringify(SDRAM_OFFSET(FC00000))
++#define PXEFILE_ADDR_R    __stringify(SDRAM_OFFSET(FD00000))
++#define RAMDISK_ADDR_R    __stringify(SDRAM_OFFSET(FE00000))
+ 
+ #else
+ /*
+@@ -301,24 +302,26 @@ extern int soft_i2c_gpio_scl;
+  * 1M script, 1M pxe and the ramdisk at the end.
+  */
+ #ifndef CONFIG_MACH_SUN8I_V3S
+-#define BOOTM_SIZE     __stringify(0xa000000)
+-#define KERNEL_ADDR_R  __stringify(SDRAM_OFFSET(2000000))
+-#define FDT_ADDR_R     __stringify(SDRAM_OFFSET(3000000))
+-#define SCRIPT_ADDR_R  __stringify(SDRAM_OFFSET(3100000))
+-#define PXEFILE_ADDR_R __stringify(SDRAM_OFFSET(3200000))
+-#define RAMDISK_ADDR_R __stringify(SDRAM_OFFSET(3300000))
++#define BOOTM_SIZE        __stringify(0xa000000)
++#define KERNEL_ADDR_R     __stringify(SDRAM_OFFSET(2000000))
++#define FDT_ADDR_R        __stringify(SDRAM_OFFSET(3000000))
++#define FDTOVERLAY_ADDR_R __stringify(SDRAM_OFFSET(3100000))
++#define SCRIPT_ADDR_R     __stringify(SDRAM_OFFSET(3200000))
++#define PXEFILE_ADDR_R    __stringify(SDRAM_OFFSET(3300000))
++#define RAMDISK_ADDR_R    __stringify(SDRAM_OFFSET(3400000))
+ #else
+ /*
+  * 64M RAM minus 2MB heap + 16MB for u-boot, stack, fb, etc.
+  * 16M uncompressed kernel, 8M compressed kernel, 1M fdt,
+  * 1M script, 1M pxe and the ramdisk at the end.
+  */
+-#define BOOTM_SIZE     __stringify(0x2e00000)
+-#define KERNEL_ADDR_R  __stringify(SDRAM_OFFSET(1000000))
+-#define FDT_ADDR_R     __stringify(SDRAM_OFFSET(1800000))
+-#define SCRIPT_ADDR_R  __stringify(SDRAM_OFFSET(1900000))
+-#define PXEFILE_ADDR_R __stringify(SDRAM_OFFSET(1A00000))
+-#define RAMDISK_ADDR_R __stringify(SDRAM_OFFSET(1B00000))
++#define BOOTM_SIZE        __stringify(0x2e00000)
++#define KERNEL_ADDR_R     __stringify(SDRAM_OFFSET(1000000))
++#define FDT_ADDR_R        __stringify(SDRAM_OFFSET(1800000))
++#define FDTOVERLAY_ADDR_R __stringify(SDRAM_OFFSET(1900000))
++#define SCRIPT_ADDR_R     __stringify(SDRAM_OFFSET(1A00000))
++#define PXEFILE_ADDR_R    __stringify(SDRAM_OFFSET(1B00000))
++#define RAMDISK_ADDR_R    __stringify(SDRAM_OFFSET(1C00000))
+ #endif
+ #endif
+ 
+@@ -326,6 +329,7 @@ extern int soft_i2c_gpio_scl;
+ 	"bootm_size=" BOOTM_SIZE "\0" \
+ 	"kernel_addr_r=" KERNEL_ADDR_R "\0" \
+ 	"fdt_addr_r=" FDT_ADDR_R "\0" \
++	"fdtoverlay_addr_r=" FDTOVERLAY_ADDR_R "\0" \
+ 	"scriptaddr=" SCRIPT_ADDR_R "\0" \
+ 	"pxefile_addr_r=" PXEFILE_ADDR_R "\0" \
+ 	"ramdisk_addr_r=" RAMDISK_ADDR_R "\0"
+-- 
+2.30.0
+

--- a/projects/Allwinner/bootloader/release
+++ b/projects/Allwinner/bootloader/release
@@ -4,9 +4,11 @@
 SRCDIR="$BUILD/image/system/usr/share/bootloader"
 DSTDIR="$RELEASE_DIR/3rdparty/bootloader"
 
-mkdir -p "$DSTDIR"
+mkdir -p "$DSTDIR/overlays"
   if [ -n "$UBOOT_SYSTEM" ]; then
     cp -a "$SRCDIR/u-boot-sunxi-with-spl.bin" "$DSTDIR"
   fi
 
   cp -a "$SRCDIR"/sun*-${DEVICE,,}-*.dtb "$DSTDIR"
+
+  cp -a "$SRCDIR"/overlays/sun*-${DEVICE,,}-*.dtbo "$DSTDIR"/overlays

--- a/projects/Allwinner/bootloader/update.sh
+++ b/projects/Allwinner/bootloader/update.sh
@@ -27,6 +27,13 @@ fi
     fi
   done
 
+# update Device Tree Overlays
+  if [ -d $SYSTEM_ROOT/usr/share/bootloader/overlays ]; then
+    echo "*** updating Device Tree Overlays ..."
+    mkdir -p /flash/overlays
+    cp -p $SYSTEM_ROOT/usr/share/bootloader/overlays/* /flash/overlays
+  fi
+
 # update bootloader files
   if [ -f $SYSTEM_ROOT/usr/share/bootloader/u-boot-sunxi-with-spl.bin ]; then
     echo "*** updating U-Boot on: $BOOT_DISK ..."

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -61,3 +61,6 @@
 
   # debug tty path
     DEBUG_TTY="/dev/console"
+
+  # additional packages to install:
+    ADDITIONAL_PACKAGES="dt-overlays"

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -219,6 +219,10 @@ elif [ "${BOOTLOADER}" = "u-boot" -a -n "${UBOOT_SYSTEM}" ]; then
       mcopy "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ::
     fi
 
+    if [ -d "${RELEASE_DIR}/3rdparty/bootloader/overlays" ]; then
+      mcopy -s "${RELEASE_DIR}/3rdparty/bootloader/overlays" ::
+    fi
+
     mkdir -p "${LE_TMP}/extlinux"
 
     cat << EOF > "${LE_TMP}/extlinux/extlinux.conf"


### PR DESCRIPTION
This PR is initial work to support DT overlays also for other than RPi ARM SoCs. Several users already asked for that functionality directly or indirectly (how to modify dtb file?).

Note that this mostly just brings up infrastructure with one simple Allwinner H6 overlay. Please tell me if you concur with approach taken here and what would you change.

Before this is merged I would expect that dt-overlay repo is moved to LE github and maintained there.