### PR TITLE
libxkbcommon: fix missing dependency libxml2

### DIFF
--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="a2202f851e072b84e64a395212cbd976ee18a8ee602008b0bad02a13247dbc52"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xkbcommon.org"
 PKG_URL="http://xkbcommon.org/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain xkeyboard-config"
+PKG_DEPENDS_TARGET="toolchain xkeyboard-config libxml2"
 PKG_LONGDESC="xkbcommon is a library to handle keyboard descriptions."
 
 PKG_MESON_OPTS_TARGET="-Denable-docs=false"


### PR DESCRIPTION
Currently, the build fails while building on a machine with 32 threads. (Ryzen 9 5950X)
Adding this dependency fixes the problem.