### PR TITLE
Update packages/x11 to latest 

### DIFF
--- a/packages/x11/app/xkbcomp/package.mk
+++ b/packages/x11/app/xkbcomp/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xkbcomp"
-PKG_VERSION="1.4.3"
-PKG_SHA256="06242c169fc11caf601cac46d781d467748c6a330e15b36dce46520b8ac8d435"
+PKG_VERSION="1.4.4"
+PKG_SHA256="59cce603a607a17722a0a1cf99010f4894e7812beb5d695abbc08474d59af27e"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/app/$PKG_NAME-$PKG_VERSION.tar.bz2"

--- a/packages/x11/driver/xf86-input-libinput/package.mk
+++ b/packages/x11/driver/xf86-input-libinput/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xf86-input-libinput"
-PKG_VERSION="0.29.0"
-PKG_SHA256="c28b56a21754b972db31798e6a4cf4dc9d69208d08f8fe41701a94def5e94bee"
+PKG_VERSION="0.30.0"
+PKG_SHA256="f9c7f9fd41ae14061e0e9c3bd45fa170e5e21027a2bc5810034e1e748db996c0"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/driver/$PKG_NAME-$PKG_VERSION.tar.bz2"

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xf86-video-intel"
-PKG_VERSION="9236c58252511d3e985cbd4c022a202c36314e3c"
-PKG_SHA256="11baa341fd6cbd308d88f8d7d7d0e82e1bc367a3ffbab6f77acaa72c9398387a"
+PKG_VERSION="a511f22cdec56504913b457a2e60dafee8e2b570"
+PKG_SHA256="ea41bbab7d2720a4bcd3b083800b8226f217c6af3e8bace4310063a7c5b56c25"
 PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="http://intellinuxgraphics.org/"

--- a/packages/x11/lib/pixman/package.mk
+++ b/packages/x11/lib/pixman/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pixman"
-PKG_VERSION="0.38.4"
-PKG_SHA256="84abb7fa2541af24d9c3b34bf75d6ac60cc94ac4410061bbb295b66a29221550"
+PKG_VERSION="0.40.0"
+PKG_SHA256="da8ed9fe2d1c5ef8ce5d1207992db959226bd4e37e3f88acf908fd9a71e2704e"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.x.org/"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/$PKG_NAME-$PKG_VERSION.tar.bz2"
+PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain util-macros"
 PKG_LONGDESC="Pixman is a generic library for manipulating pixel regions, contains low-level pixel manipulation routines."

--- a/packages/x11/other/fluxbox/package.mk
+++ b/packages/x11/other/fluxbox/package.mk
@@ -4,10 +4,10 @@
 PKG_NAME="fluxbox"
 # dont bump or go back to ratpoison then f*** all 3rdparty stuff.
 PKG_VERSION="1.3.7"
-PKG_SHA256="c99e2baa06fff1e96342b20415059d12ff1fa2917ade0173c75b2fa570295b9f"
+PKG_SHA256="fc8c75fe94c54ed5a5dd3fd4a752109f8949d6df67a48e5b11a261403c382ec0"
 PKG_LICENSE="OSS"
 PKG_SITE="http://fluxbox.org/"
-PKG_URL="http://sourceforge.net/projects/fluxbox/files/fluxbox/${PKG_VERSION}/$PKG_NAME-${PKG_VERSION}.tar.gz"
+PKG_URL="http://sourceforge.net/projects/fluxbox/files/fluxbox/${PKG_VERSION}/$PKG_NAME-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libX11 libXrandr libXext libXrender"
 PKG_LONGDESC="Fluxbox is a windowmanager for X that was based on the Blackbox 0.61.1 code."
 PKG_TOOLCHAIN="autotools"


### PR DESCRIPTION
- fontconfig is a jump to devel. But have been running 2.13.92 for the last month.
- the next version 2.13.93 will be using meson build. (PRs in the devel releases 21.13.91,2.13.92 are mostly fixes) https://www.freedesktop.org/wiki/Software/fontconfig/Devel/
- fluxbox is only a change from .gz to .xz

all others are next increment packages