### PR TITLE
docker: fix python addon (rev 132)

### DIFF
--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,6 @@
+132
+- Fix python addon
+
 131
 - Update to docker 19.03.14
 

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="docker"
 PKG_VERSION="19.03.14"
 PKG_SHA256="0b8838b0da1f1368fc1a0809a2ed11840bd7d58df1f090e668de209faddcef7c"
-PKG_REV="131"
+PKG_REV="132"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION


Summary:
- Do not import oe
- Retry connection on error
- Add periodically kodi termination check via timeout
- Remove unneeded thread

With recent LibreELEC-Settings bump python module oe was moved resulting in

```
ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                  - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                 Error Type: <class 'ModuleNotFoundError'>
                 Error Contents: No module named 'oe'
                 Traceback (most recent call last):
                   File "/storage/.kodi/addons/service.system.docker/default.py", line 15, in <module>
                     import oe
                 ModuleNotFoundError: No module named 'oe'
                 -->End of Python script error report<--
```
The only used function oe.execute() is replaced by subprocess.run() and the module import is removed.

Connection to the docker socket is retried on any error.

Kodi abort request is checked periodically and addon terminated. Setting and using an own socket timeout avoids fail of functionality when inheriting unwanted socket.setdefaulttimeout() set by another addon.

Tested on Generic.

