### PR TITLE
rockchip: kodi: update appliance.xml

### DIFF
--- a/projects/Rockchip/kodi/appliance.xml
+++ b/projects/Rockchip/kodi/appliance.xml
@@ -3,13 +3,7 @@
   <section id="system">
     <category id="display">
       <group id="1">
-        <setting id="videoscreen.whitelist">
-          <default>0384002160060.00000pstd,0384002160059.94006pstd,0384002160050.00000pstd,0384002160030.00000pstd,0384002160029.97003pstd,0384002160025.00000pstd,0384002160024.00000pstd,0384002160023.97602pstd,0192001080060.00000pstd,0192001080059.94006pstd,0192001080050.00000pstd,0192001080030.00000pstd,0192001080029.97003pstd,0192001080024.00000pstd,0192001080023.97602pstd,0128000720060.00000pstd,0128000720059.94006pstd,0128000720050.00000pstd</default>
-        </setting>
         <setting id="videoscreen.blankdisplays">
-          <visible>false</visible>
-        </setting>
-        <setting id="videoscreen.fakefullscreen">
           <visible>false</visible>
         </setting>
         <setting id="videoscreen.limitguisize">
@@ -17,7 +11,12 @@
           <visible>true</visible>
         </setting>
       </group>
-      <group id="3">
+      <group id="2">
+        <setting id="videoscreen.whitelist">
+          <default>0384002160060.00000pstd,0384002160059.94006pstd,0384002160050.00000pstd,0384002160030.00000pstd,0384002160029.97003pstd,0384002160025.00000pstd,0384002160024.00000pstd,0384002160023.97602pstd,0192001080060.00000pstd,0192001080059.94006pstd,0192001080050.00000pstd,0192001080030.00000pstd,0192001080029.97003pstd,0192001080024.00000pstd,0192001080023.97602pstd,0128000720060.00000pstd,0128000720059.94006pstd,0128000720050.00000pstd</default>
+        </setting>
+     </group>
+      <group id="4">
         <setting id="videoscreen.noofbuffers">
           <default>2</default>
           <visible>false</visible>
@@ -28,13 +27,6 @@
       <group id="1">
         <setting id="audiooutput.audiodevice">
           <default>ALSA:hdmi:CARD=HDMI,DEV=0</default>
-        </setting>
-      </group>
-    </category>
-    <category id="logging">
-      <group id="1">
-        <setting id="debug.extralogging">
-          <default>false</default>
         </setting>
       </group>
     </category>


### PR DESCRIPTION
https://github.com/xbmc/xbmc/pull/16216 moved  settings for `videoscreen.whitelist` to /system/display/group 2 and `videoscreen.noofbuffers` to /system/display/group 4.
This currently prevents appliance.xml to be applied as whole for rockchip (I noticed it, because `videoscreen.limitguisize` wasn't set correctly) - not sure this is a bug/feature on kodi side.

While at that: also drop `videoscreen.fakefullscreen` and `debug.extralogging` settings, since the values matching the defaults.