### PR TITLE
ncurses: include dumb terminfo again

### DIFF
--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -32,7 +32,7 @@ PKG_CONFIGURE_OPTS_TARGET="--without-ada \
                            --without-dmalloc \
                            --disable-rpath \
                            --disable-database \
-                           --with-fallbacks=linux,screen,xterm,xterm-color,st-256color \
+                           --with-fallbacks=linux,screen,xterm,xterm-color,dumb,st-256color \
                            --with-termpath=/storage/.config/termcap \
                            --disable-big-core \
                            --enable-termcap \


### PR DESCRIPTION
"dumb" terminfo added with #4186 was remove by accident in #4799. Include it again.