### PR TITLE
LibreELEC-settings: only python_compile /resources/lib/*

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -28,7 +28,7 @@ post_makeinstall_target() {
       -i $INSTALL/usr/lib/libreelec/backup-restore
 
   ADDON_INSTALL_DIR=${INSTALL}/usr/share/kodi/addons/service.libreelec.settings
-  python_compile ${ADDON_INSTALL_DIR}
+  python_compile ${ADDON_INSTALL_DIR}/resources/lib/
 }
 
 post_install() {


### PR DESCRIPTION
After recent changes `addon.xml` references `default.py` and `services.py` but we `python_compile` all files which changes them to *.pyc and breaks the add-on. Avoid this by only pre-compiling the /resources subfolder.

@thoradia do we also need to pre-compile `syspath.py` ?? (or could that live under /resources as well).
