### PR TITLE
Intel Media Driver 2020Q4 Release - 20.4.5

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="20.3.3"
-PKG_SHA256="a9ac5be82822652414fe1d7260c9fa80aa14c07c137de5c4d73f23989a13ff77"
+PKG_VERSION="20.4.1"
+PKG_SHA256="d54d547f9f9e74196dead6a338923039ea10c859f1f693f33f10be1562b81d6d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/intel-vaapi-driver/patches/0001-intel-vaapi-driver-2.4.1-Handle-odd-resolution.patch
+++ b/packages/multimedia/intel-vaapi-driver/patches/0001-intel-vaapi-driver-2.4.1-Handle-odd-resolution.patch
@@ -1,0 +1,288 @@
+From d87db2111a33b157d1913415f15d201cc5182850 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 12 Aug 2020 14:24:55 +0800
+Subject: [PATCH] Handle odd resolution
+
+This fixes https://github.com/intel/intel-vaapi-driver/issues/516
+
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ src/gen8_post_processing.c | 24 +++++++++----------
+ src/gen9_post_processing.c | 24 +++++++++----------
+ src/i965_drv_video.c       | 48 +++++++++++++++++++-------------------
+ 3 files changed, 48 insertions(+), 48 deletions(-)
+
+diff --git a/src/gen8_post_processing.c b/src/gen8_post_processing.c
+index abddcd078..2163300ac 100644
+--- a/src/gen8_post_processing.c
++++ b/src/gen8_post_processing.c
+@@ -1909,17 +1909,17 @@ gen8_pp_context_get_surface_conf(VADriverContextP ctx,
+             fourcc == VA_FOURCC_BGRA) {
+             /* nothing to do here */
+         } else if (fourcc == VA_FOURCC_P010 || fourcc == VA_FOURCC_NV12) {
+-            width[1] = width[0] / 2;
+-            height[1] = height[0] / 2;
++            width[1] = ALIGN(width[0], 2) / 2;
++            height[1] = ALIGN(height[0], 2) / 2;
+             pitch[1] = obj_surface->cb_cr_pitch;
+             bo_offset[1] = obj_surface->width * obj_surface->y_cb_offset;
+         } else {
+-            width[1] = width[0] / 2;
+-            height[1] = height[0] / 2;
++            width[1] = ALIGN(width[0], 2) / 2;
++            height[1] = ALIGN(height[0], 2) / 2;
+             pitch[1] = obj_surface->cb_cr_pitch;
+             bo_offset[1] = obj_surface->width * obj_surface->y_cb_offset;
+-            width[2] = width[0] / 2;
+-            height[2] = height[0] / 2;
++            width[2] = ALIGN(width[0], 2) / 2;
++            height[2] = ALIGN(height[0], 2) / 2;
+             pitch[2] = obj_surface->cb_cr_pitch;
+             bo_offset[2] = obj_surface->width * obj_surface->y_cr_offset;
+         }
+@@ -1940,8 +1940,8 @@ gen8_pp_context_get_surface_conf(VADriverContextP ctx,
+             fourcc == VA_FOURCC_BGRA) {
+             /* nothing to do here */
+         } else if (fourcc == VA_FOURCC_P010 || fourcc == VA_FOURCC_NV12) {
+-            width[1] = width[0] / 2;
+-            height[1] = height[0] / 2;
++            width[1] = ALIGN(width[0], 2) / 2;
++            height[1] = ALIGN(height[0], 2) / 2;
+             pitch[1] = obj_image->image.pitches[1];
+             bo_offset[1] = obj_image->image.offsets[1];
+         } else {
+@@ -1950,12 +1950,12 @@ gen8_pp_context_get_surface_conf(VADriverContextP ctx,
+             if (fourcc == VA_FOURCC_YV12 || fourcc == VA_FOURCC_IMC1)
+                 u = 2, v = 1;
+ 
+-            width[1] = width[0] / 2;
+-            height[1] = height[0] / 2;
++            width[1] = ALIGN(width[0], 2) / 2;
++            height[1] = ALIGN(height[0], 2) / 2;
+             pitch[1] = obj_image->image.pitches[u];
+             bo_offset[1] = obj_image->image.offsets[u];
+-            width[2] = width[0] / 2;
+-            height[2] = height[0] / 2;
++            width[2] = ALIGN(width[0], 2) / 2;
++            height[2] = ALIGN(height[0], 2) / 2;
+             pitch[2] = obj_image->image.pitches[v];
+             bo_offset[2] = obj_image->image.offsets[v];
+         }
+diff --git a/src/gen9_post_processing.c b/src/gen9_post_processing.c
+index eede36f7f..da36f2abc 100644
+--- a/src/gen9_post_processing.c
++++ b/src/gen9_post_processing.c
+@@ -731,19 +731,19 @@ gen9_pp_context_get_surface_conf(VADriverContextP ctx,
+             fourcc == VA_FOURCC_BGRA) {
+             /* nothing to do here */
+         } else if (fourcc == VA_FOURCC_P010 || fourcc == VA_FOURCC_NV12) {
+-            width[1] = width[0] / 2;
+-            height[1] = height[0] / 2;
++            width[1] = ALIGN(width[0], 2) / 2;
++            height[1] = ALIGN(height[0], 2) / 2;
+             pitch[1] = obj_surface->cb_cr_pitch;
+             bo_offset[1] = obj_surface->width * obj_surface->y_cb_offset;
+         } else if (fourcc == VA_FOURCC_YUY2 || fourcc == VA_FOURCC_UYVY) {
+             /* nothing to do here */
+         } else {
+-            width[1] = width[0] / 2;
+-            height[1] = height[0] / 2;
++            width[1] = ALIGN(width[0], 2) / 2;
++            height[1] = ALIGN(height[0], 2) / 2;
+             pitch[1] = obj_surface->cb_cr_pitch;
+             bo_offset[1] = obj_surface->width * obj_surface->y_cb_offset;
+-            width[2] = width[0] / 2;
+-            height[2] = height[0] / 2;
++            width[2] = ALIGN(width[0], 2) / 2;
++            height[2] = ALIGN(height[0], 2) / 2;
+             pitch[2] = obj_surface->cb_cr_pitch;
+             bo_offset[2] = obj_surface->width * obj_surface->y_cr_offset;
+         }
+@@ -764,8 +764,8 @@ gen9_pp_context_get_surface_conf(VADriverContextP ctx,
+             fourcc == VA_FOURCC_BGRA) {
+             /* nothing to do here */
+         } else if (fourcc == VA_FOURCC_P010 || fourcc == VA_FOURCC_NV12) {
+-            width[1] = width[0] / 2;
+-            height[1] = height[0] / 2;
++            width[1] = ALIGN(width[0], 2) / 2;
++            height[1] = ALIGN(height[0], 2) / 2;
+             pitch[1] = obj_image->image.pitches[1];
+             bo_offset[1] = obj_image->image.offsets[1];
+         } else if (fourcc == VA_FOURCC_YUY2 || fourcc == VA_FOURCC_UYVY) {
+@@ -776,12 +776,12 @@ gen9_pp_context_get_surface_conf(VADriverContextP ctx,
+             if (fourcc == VA_FOURCC_YV12 || fourcc == VA_FOURCC_IMC1)
+                 u = 2, v = 1;
+ 
+-            width[1] = width[0] / 2;
+-            height[1] = height[0] / 2;
++            width[1] = ALIGN(width[0], 2) / 2;
++            height[1] = ALIGN(height[0], 2) / 2;
+             pitch[1] = obj_image->image.pitches[u];
+             bo_offset[1] = obj_image->image.offsets[u];
+-            width[2] = width[0] / 2;
+-            height[2] = height[0] / 2;
++            width[2] = ALIGN(width[0], 2) / 2;
++            height[2] = ALIGN(height[0], 2) / 2;
+             pitch[2] = obj_image->image.pitches[v];
+             bo_offset[2] = obj_image->image.offsets[v];
+         }
+diff --git a/src/i965_drv_video.c b/src/i965_drv_video.c
+index ff163887e..80278bb70 100644
+--- a/src/i965_drv_video.c
++++ b/src/i965_drv_video.c
+@@ -1725,8 +1725,8 @@ i965_suface_external_memory(VADriverContextP ctx,
+         obj_surface->subsampling = SUBSAMPLE_YUV420;
+         obj_surface->y_cb_offset = obj_surface->height;
+         obj_surface->y_cr_offset = obj_surface->height;
+-        obj_surface->cb_cr_width = obj_surface->orig_width / 2;
+-        obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++        obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
++        obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+         obj_surface->cb_cr_pitch = memory_attibute->pitches[1];
+         if (tiling)
+             ASSERT_RET(IS_ALIGNED(obj_surface->cb_cr_pitch, 128), VA_STATUS_ERROR_INVALID_PARAMETER);
+@@ -1743,8 +1743,8 @@ i965_suface_external_memory(VADriverContextP ctx,
+         obj_surface->subsampling = SUBSAMPLE_YUV420;
+         obj_surface->y_cr_offset = obj_surface->height;
+         obj_surface->y_cb_offset = memory_attibute->offsets[2] / obj_surface->width;
+-        obj_surface->cb_cr_width = obj_surface->orig_width / 2;
+-        obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++        obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
++        obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+         obj_surface->cb_cr_pitch = memory_attibute->pitches[1];
+ 
+         if (tiling)
+@@ -1764,8 +1764,8 @@ i965_suface_external_memory(VADriverContextP ctx,
+         obj_surface->subsampling = SUBSAMPLE_YUV420;
+         obj_surface->y_cb_offset = obj_surface->height;
+         obj_surface->y_cr_offset = memory_attibute->offsets[2] / obj_surface->width;
+-        obj_surface->cb_cr_width = obj_surface->orig_width / 2;
+-        obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++        obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
++        obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+         obj_surface->cb_cr_pitch = memory_attibute->pitches[1];
+         if (tiling)
+             ASSERT_RET(IS_ALIGNED(obj_surface->cb_cr_pitch, 128), VA_STATUS_ERROR_INVALID_PARAMETER);
+@@ -1837,7 +1837,7 @@ i965_suface_external_memory(VADriverContextP ctx,
+         obj_surface->subsampling = SUBSAMPLE_YUV422H;
+         obj_surface->y_cb_offset = obj_surface->height;
+         obj_surface->y_cr_offset = memory_attibute->offsets[2] / obj_surface->width;
+-        obj_surface->cb_cr_width = obj_surface->orig_width / 2;
++        obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
+         obj_surface->cb_cr_height = obj_surface->orig_height;
+         obj_surface->cb_cr_pitch = memory_attibute->pitches[1];
+         if (tiling)
+@@ -1854,7 +1854,7 @@ i965_suface_external_memory(VADriverContextP ctx,
+         obj_surface->subsampling = SUBSAMPLE_YUV422H;
+         obj_surface->y_cr_offset = memory_attibute->offsets[1] / obj_surface->width;
+         obj_surface->y_cb_offset = memory_attibute->offsets[2] / obj_surface->width;
+-        obj_surface->cb_cr_width = obj_surface->orig_width / 2;
++        obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
+         obj_surface->cb_cr_height = obj_surface->orig_height;
+         obj_surface->cb_cr_pitch = memory_attibute->pitches[1];
+         ASSERT_RET(IS_ALIGNED(obj_surface->cb_cr_pitch, i965->codec_info->min_linear_wpitch), VA_STATUS_ERROR_INVALID_PARAMETER);
+@@ -1869,7 +1869,7 @@ i965_suface_external_memory(VADriverContextP ctx,
+         obj_surface->y_cb_offset = obj_surface->height;
+         obj_surface->y_cr_offset = memory_attibute->offsets[2] / obj_surface->width;
+         obj_surface->cb_cr_width = obj_surface->orig_width;
+-        obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++        obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+         obj_surface->cb_cr_pitch = memory_attibute->pitches[1];
+         if (tiling)
+             ASSERT_RET(IS_ALIGNED(obj_surface->cb_cr_pitch, 128), VA_STATUS_ERROR_INVALID_PARAMETER);
+@@ -4526,8 +4526,8 @@ i965_check_alloc_surface_bo(VADriverContextP ctx,
+         case VA_FOURCC_P010:
+             assert(subsampling == SUBSAMPLE_YUV420);
+             obj_surface->cb_cr_pitch = obj_surface->width;
+-            obj_surface->cb_cr_width = obj_surface->orig_width / 2;
+-            obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++            obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
++            obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+             obj_surface->y_cb_offset = obj_surface->height;
+             obj_surface->y_cr_offset = obj_surface->height;
+             region_width = obj_surface->width;
+@@ -4538,8 +4538,8 @@ i965_check_alloc_surface_bo(VADriverContextP ctx,
+         case VA_FOURCC_IMC1:
+             assert(subsampling == SUBSAMPLE_YUV420);
+             obj_surface->cb_cr_pitch = obj_surface->width;
+-            obj_surface->cb_cr_width = obj_surface->orig_width / 2;
+-            obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++            obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
++            obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+             obj_surface->y_cr_offset = obj_surface->height;
+             obj_surface->y_cb_offset = obj_surface->y_cr_offset + ALIGN(obj_surface->cb_cr_height, 32);
+             region_width = obj_surface->width;
+@@ -4550,8 +4550,8 @@ i965_check_alloc_surface_bo(VADriverContextP ctx,
+         case VA_FOURCC_IMC3:
+             assert(subsampling == SUBSAMPLE_YUV420);
+             obj_surface->cb_cr_pitch = obj_surface->width;
+-            obj_surface->cb_cr_width = obj_surface->orig_width / 2;
+-            obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++            obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
++            obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+             obj_surface->y_cb_offset = obj_surface->height;
+             obj_surface->y_cr_offset = obj_surface->y_cb_offset + ALIGN(obj_surface->cb_cr_height, 32);
+             region_width = obj_surface->width;
+@@ -4562,7 +4562,7 @@ i965_check_alloc_surface_bo(VADriverContextP ctx,
+         case VA_FOURCC_422H:
+             assert(subsampling == SUBSAMPLE_YUV422H);
+             obj_surface->cb_cr_pitch = obj_surface->width;
+-            obj_surface->cb_cr_width = obj_surface->orig_width / 2;
++            obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
+             obj_surface->cb_cr_height = obj_surface->orig_height;
+             obj_surface->y_cb_offset = obj_surface->height;
+             obj_surface->y_cr_offset = obj_surface->y_cb_offset + ALIGN(obj_surface->cb_cr_height, 32);
+@@ -4575,7 +4575,7 @@ i965_check_alloc_surface_bo(VADriverContextP ctx,
+             assert(subsampling == SUBSAMPLE_YUV422V);
+             obj_surface->cb_cr_pitch = obj_surface->width;
+             obj_surface->cb_cr_width = obj_surface->orig_width;
+-            obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++            obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+             obj_surface->y_cb_offset = obj_surface->height;
+             obj_surface->y_cr_offset = obj_surface->y_cb_offset + ALIGN(obj_surface->cb_cr_height, 32);
+             region_width = obj_surface->width;
+@@ -4663,17 +4663,17 @@ i965_check_alloc_surface_bo(VADriverContextP ctx,
+         case VA_FOURCC_P010:
+             obj_surface->y_cb_offset = obj_surface->height;
+             obj_surface->y_cr_offset = obj_surface->height;
+-            obj_surface->cb_cr_width = obj_surface->orig_width / 2;
++            obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
+             obj_surface->width = ALIGN(obj_surface->cb_cr_width * 2, i965->codec_info->min_linear_wpitch) *
+                                  bpp_1stplane;
+-            obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++            obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+             obj_surface->cb_cr_pitch = obj_surface->width;
+             region_width = obj_surface->width;
+             region_height = obj_surface->height + obj_surface->height / 2;
+             break;
+ 
+         case VA_FOURCC_YV16:
+-            obj_surface->cb_cr_width = obj_surface->orig_width / 2;
++            obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
+             obj_surface->width = ALIGN(obj_surface->cb_cr_width, i965->codec_info->min_linear_wpitch) * 2;
+             obj_surface->cb_cr_height = obj_surface->orig_height;
+             obj_surface->y_cr_offset = obj_surface->height;
+@@ -4694,9 +4694,9 @@ i965_check_alloc_surface_bo(VADriverContextP ctx,
+                 obj_surface->y_cr_offset = obj_surface->height + obj_surface->height / 4;
+             }
+ 
+-            obj_surface->cb_cr_width = obj_surface->orig_width / 2;
++            obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
+             obj_surface->width = ALIGN(obj_surface->cb_cr_width, i965->codec_info->min_linear_wpitch) * 2;
+-            obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++            obj_surface->cb_cr_height = ALIGN(obj_surface->orig_height, 2) / 2;
+             obj_surface->cb_cr_pitch = obj_surface->width / 2;
+             region_width = obj_surface->width;
+             region_height = obj_surface->height + obj_surface->height / 2;
+@@ -4705,9 +4705,9 @@ i965_check_alloc_surface_bo(VADriverContextP ctx,
+         case VA_FOURCC_I010:
+             obj_surface->y_cb_offset = obj_surface->height;
+             obj_surface->y_cr_offset = obj_surface->height + obj_surface->height / 4;
+-            obj_surface->cb_cr_width = obj_surface->orig_width / 2;
++            obj_surface->cb_cr_width = ALIGN(obj_surface->orig_width, 2) / 2;
+             obj_surface->width = ALIGN(obj_surface->cb_cr_width * 2, i965->codec_info->min_linear_wpitch) * 2;
+-            obj_surface->cb_cr_height = obj_surface->orig_height / 2;
++            obj_surface->cb_cr_height =ALIGN(obj_surface->orig_height, 2) / 2;
+             obj_surface->cb_cr_pitch = obj_surface->width / 2;
+             region_width = obj_surface->width;
+             region_height = obj_surface->height + obj_surface->height / 2;

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="20.4.3"
-PKG_SHA256="0f2b0fe189793365124a653885646965389bff4c6690c8e17789eb4dcf75c9d0"
+PKG_VERSION="20.4.5"
+PKG_SHA256="3d856a963127ddd6690fc6dac521d7674947675d5f20452f1e6f45c0fc83f9e6"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
### Intel driver refresh
**This brings all Intel video components up to current.**

Release notes:
- https://github.com/intel/media-driver/releases/tag/intel-media-20.4.5

Dependencies
- GmmLib: intel-gmmlib-20.4.1
- Libva: 2.10.0 (already in master)

Also including small upstream patch for intel-vaapi-driver https://github.com/intel/intel-vaapi-driver/commit/d87db2111a33b157d1913415f15d201cc5182850 since 2.4.1 was released. See compare @ https://github.com/intel/intel-vaapi-driver/compare/2.4.1...master


