### PR TITLE
u-boot: restore bootloader/firmware script

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -30,10 +30,9 @@ case "$LINUX" in
 esac
 
 PKG_KERNEL_CFG_FILE=$(kernel_config_path) || die
-if [ -n "$UBOOT_SYSTEM" ]; then
-  if [ -n "$($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM crust_config)" ]; then
-    PKG_PATCH_DIRS="$PKG_PATCH_DIRS crust"
-  fi
+
+if listcontains "${UBOOT_FIRMWARE}" "crust"; then
+  PKG_PATCH_DIRS+=" crust"
 fi
 
 if [ -n "$KERNEL_TOOLCHAIN" ]; then

--- a/packages/tools/crust/package.mk
+++ b/packages/tools/crust/package.mk
@@ -11,6 +11,7 @@ PKG_URL="https://github.com/crust-firmware/crust/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="gcc-or1k-linux:host"
 PKG_LONGDESC="Crust: Libre SCP firmware for Allwinner sunxi SoCs"
 PKG_TOOLCHAIN="manual"
+PKG_STAMP="$UBOOT_SYSTEM"
 
 pre_configure_target() {
   export CROSS_COMPILE="$TOOLCHAIN/lib/gcc-or1k-linux/bin/or1k-linux-"

--- a/packages/tools/crust/package.mk
+++ b/packages/tools/crust/package.mk
@@ -18,12 +18,16 @@ pre_configure_target() {
 }
 
 make_target() {
-  CRUST_CONFIG=$($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM crust_config)
+  if [ -z "$UBOOT_SYSTEM" ]; then
+    echo "crust is only built when building an image"
+    exit 0
+  fi
 
+  CRUST_CONFIG=$($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM crust_config)
   if [ -z "$CRUST_CONFIG" ]; then
-    echo "crust_config must be set to build an image"
+    echo "crust_config must be set to build crust firmware"
     echo "see './scripts/uboot_helper' for more information"
-    exit 1
+    exit 0
   fi
 
   make distclean

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -18,10 +18,6 @@ if [ -n "$UBOOT_FIRMWARE" ]; then
   PKG_DEPENDS_UNPACK+=" $UBOOT_FIRMWARE"
 fi
 
-CRUST_CONFIG=""
-[ -n "$UBOOT_SYSTEM" ] && CRUST_CONFIG=$($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM crust_config)
-[ -n "$CRUST_CONFIG" ] && PKG_DEPENDS_TARGET+=" crust"
-
 PKG_NEED_UNPACK="$PROJECT_DIR/$PROJECT/bootloader"
 [ -n "$DEVICE" ] && PKG_NEED_UNPACK+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader"
 
@@ -54,9 +50,8 @@ make_target() {
     echo "see './scripts/uboot_helper' for more information"
   else
     [ "${BUILD_WITH_DEBUG}" = "yes" ] && PKG_DEBUG=1 || PKG_DEBUG=0
-    [ -n "$ATF_PLATFORM" ] && cp -av $(get_install_dir atf)/usr/share/bootloader/bl31.bin .
-    [ -n "$CRUST_CONFIG" ] && cp -av $(get_install_dir crust)/usr/share/bootloader/scp.bin .
     DEBUG=${PKG_DEBUG} CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm make mrproper
+    [ -n "$UBOOT_FIRMWARE" ] && find_file_path bootloader/firmware && . ${FOUND_PATH}
     DEBUG=${PKG_DEBUG} CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm make $($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM config)
     DEBUG=${PKG_DEBUG} CROSS_COMPILE="$TARGET_KERNEL_PREFIX" LDFLAGS="" ARCH=arm _python_sysroot="$TOOLCHAIN" _python_prefix=/ _python_exec_prefix=/ make $UBOOT_TARGET HOSTCC="$HOST_CC" HOSTLDFLAGS="-L$TOOLCHAIN/lib" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"
   fi

--- a/projects/Allwinner/bootloader/firmware
+++ b/projects/Allwinner/bootloader/firmware
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+[ -n "$ATF_PLATFORM" ] && cp -av $(get_install_dir atf)/usr/share/bootloader/bl31.bin .
+
+CRUST_CONFIG=$($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM crust_config)
+[ -n "$CRUST_CONFIG" ] && cp -av $(get_install_dir crust)/usr/share/bootloader/scp.bin .
+
+exit 0

--- a/projects/Allwinner/devices/A64/options
+++ b/projects/Allwinner/devices/A64/options
@@ -26,7 +26,7 @@
     KERNEL_TARGET="Image"
 
   # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="atf"
+    UBOOT_FIRMWARE="atf crust"
 
   # ATF platform
     ATF_PLATFORM="sun50i_a64"

--- a/projects/Allwinner/devices/H3/options
+++ b/projects/Allwinner/devices/H3/options
@@ -37,6 +37,9 @@
   # Kernel target
     KERNEL_TARGET="zImage"
 
+  # U-Boot firmware package(s) to use
+    UBOOT_FIRMWARE="crust"
+
   # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
     OPENGLES="mesa"
 

--- a/projects/Allwinner/devices/H5/options
+++ b/projects/Allwinner/devices/H5/options
@@ -26,7 +26,7 @@
     KERNEL_TARGET="Image"
 
   # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="atf"
+    UBOOT_FIRMWARE="atf crust"
 
   # ATF platform
     ATF_PLATFORM="sun50i_a64"

--- a/projects/Allwinner/devices/H6/options
+++ b/projects/Allwinner/devices/H6/options
@@ -26,7 +26,7 @@
     KERNEL_TARGET="Image"
 
   # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="atf"
+    UBOOT_FIRMWARE="atf crust"
 
   # ATF platform
     ATF_PLATFORM="sun50i_h6"

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -348,7 +348,7 @@ devices = \
 }
 
 def usage(PROJECT=None, SOC=None, FILE=sys.stdout):
-  print('Usage: %s <project> <soc> <board-name> dtb|config' % sys.argv[0], file=FILE)
+  print('Usage: %s <project> <soc> <board-name> dtb|config|crust_config' % sys.argv[0], file=FILE)
   print('       %s <project> <soc>' % sys.argv[0], file=FILE)
   print('       %s <project>' % sys.argv[0], file=FILE)
   print('', file=FILE)
@@ -392,15 +392,15 @@ if len(sys.argv) > 3 and sys.argv[3] not in devices[sys.argv[1]][sys.argv[2]]:
   exit_error('Invalid board-name: %s' % sys.argv[3], PROJECT=sys.argv[1], SOC=sys.argv[2])
 
 if len(sys.argv) == 4:
-  exit_error('Invalid option: must specify dtb or config', PROJECT=sys.argv[1], SOC=sys.argv[2])
+  exit_error('Invalid option: must specify dtb, config or crust_config', PROJECT=sys.argv[1], SOC=sys.argv[2])
 elif len(sys.argv) > 4 and sys.argv[4] not in ['dtb', 'config', 'crust_config']:
   exit_error('Invalid option: %s' % sys.argv[4], PROJECT=sys.argv[1], SOC=sys.argv[2])
 
 if len(sys.argv) > 5:
   exit_error('Invalid number of arguments: %s' % ' '.join(sys.argv[1:]), PROJECT=sys.argv[1], SOC=sys.argv[2])
 
-# Get dtb or u-boot config for a given project, soc, and board
-# ./scripts/uboot_helper project device board-name dtb|config
+# Get dtb, u-boot or crust config for a given project, soc, and board
+# ./scripts/uboot_helper project device board-name dtb|config|crust_config
 if len(sys.argv) == 5:
   if sys.argv[4] in devices[sys.argv[1]][sys.argv[2]][sys.argv[3]]:
     print(devices[sys.argv[1]][sys.argv[2]][sys.argv[3]][sys.argv[4]])


### PR DESCRIPTION
This PR restores the `bootloader/firmware` script that was removed in #4762 and ensure `crust` is rebuilt for each unique release image. The `bootloader/firmware` script is needed to complete #4591.
Source of `bootloader/firmware` is also moved until after `make mrproper` to avoid issue with u-boot clean removing i.e. `bl31.elf` on rockchip platform.

It also decouple `crust` from the `u-boot` package and is no longer executing `scripts/uboot_helper` when `u-boot` `package.mk` is sourced.
~~The `linux` package is still executing `scripts/uboot_helper` when `linux` `package.mk` is sourced and is probably something that should be looked at in a separate PR.~~
`linux` package was changed to use `crust` patch dir when `UBOOT_FIRMWARE` contains `crust`.

Note: I have not tried a full Allwinner image re-build and have not done any runtime testing.

cc @dhewg @jernejsk 