### PR TITLE
Allwinner: atf: Don't enable all regulators

### DIFF
--- a/projects/Allwinner/patches/atf/0001-sunxi-Don-t-enable-referenced-regulators.patch
+++ b/projects/Allwinner/patches/atf/0001-sunxi-Don-t-enable-referenced-regulators.patch
@@ -1,0 +1,26 @@
+From 89a2da7c8bae95cf9225015489736e2fc434f4d9 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Sat, 2 Jan 2021 16:35:31 +0100
+Subject: [PATCH] sunxi: Don't enable referenced regulators
+
+This break certain devices which need appropriate power on sequence.
+---
+ drivers/allwinner/axp/common.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/allwinner/axp/common.c b/drivers/allwinner/axp/common.c
+index e98b16fdb2ec..45c6507e0e23 100644
+--- a/drivers/allwinner/axp/common.c
++++ b/drivers/allwinner/axp/common.c
+@@ -98,8 +98,6 @@ static int setup_regulator(const void *fdt, int node,
+ 
+ static bool should_enable_regulator(const void *fdt, int node)
+ {
+-	if (fdt_getprop(fdt, node, "phandle", NULL) != NULL)
+-		return true;
+ 	if (fdt_getprop(fdt, node, "regulator-always-on", NULL) != NULL)
+ 		return true;
+ 	return false;
+-- 
+2.30.0
+


### PR DESCRIPTION
Some boards, like OrangePi 3, needs special power on sequence for some regulators. Leave that to kernel.

Note: This is workaround. Possible solution was already discussed and fix will likely be included in one of the next ATF versions.