### PR TITLE
minidlna: fix build for gettext 0.20 or newer

### DIFF
--- a/packages/addons/service/minidlna/patches/minidlna-03-allow-gettext-0.20.patch
+++ b/packages/addons/service/minidlna/patches/minidlna-03-allow-gettext-0.20.patch
@@ -1,0 +1,14 @@
+Subject: [PATCH] configure.ac: allow gettext >=0.18
+
+diff --git a/configure.ac b/configure.ac
+index cb596b9..2eaf0a4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -29,6 +29,7 @@ m4_ifdef([AC_USE_SYSTEM_EXTENSIONS], [AC_USE_SYSTEM_EXTENSIONS])
+ AM_ICONV
+ AM_GNU_GETTEXT([external])
+ AM_GNU_GETTEXT_VERSION(0.18)
++AM_GNU_GETTEXT_REQUIRE_VERSION(0.18)
+ 
+ # Checks for programs.
+ AC_PROG_AWK


### PR DESCRIPTION
fixes
`*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.18 but the autoconf macros are from gettext version 0.20`

* upstream https://sourceforge.net/p/minidlna/patches/186/
* works also with latest minidlna
