### PR TITLE
libssh: fix vfs.sftp and cleanup

### DIFF
--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -21,16 +21,12 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
 makeinstall_target() {
 # install static library only
   mkdir -p $SYSROOT_PREFIX/usr/lib
-    cp src/libssh.a $SYSROOT_PREFIX/usr/lib
+    cp $PKG_BUILD/.$TARGET_NAME/src/libssh.a $SYSROOT_PREFIX/usr/lib
 
   mkdir -p $SYSROOT_PREFIX/usr/lib/pkgconfig
-    cp libssh.pc $SYSROOT_PREFIX/usr/lib/pkgconfig
+    cp $PKG_BUILD/.$TARGET_NAME/libssh.pc $SYSROOT_PREFIX/usr/lib/pkgconfig
 
   mkdir -p $SYSROOT_PREFIX/usr/include/libssh
-    cp ../include/libssh/callbacks.h $SYSROOT_PREFIX/usr/include/libssh
-    cp ../include/libssh/legacy.h $SYSROOT_PREFIX/usr/include/libssh
-    cp ../include/libssh/libssh.h $SYSROOT_PREFIX/usr/include/libssh
-    cp ../include/libssh/server.h $SYSROOT_PREFIX/usr/include/libssh
-    cp ../include/libssh/sftp.h $SYSROOT_PREFIX/usr/include/libssh
-    cp ../include/libssh/ssh2.h $SYSROOT_PREFIX/usr/include/libssh
+    cp $PKG_BUILD/include/libssh/{callbacks.h,legacy.h,libssh.h,server.h,sftp.h,ssh2.h} \
+    $SYSROOT_PREFIX/usr/include/libssh
 }

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -28,5 +28,6 @@ makeinstall_target() {
 
   mkdir -p $SYSROOT_PREFIX/usr/include/libssh
     cp $PKG_BUILD/include/libssh/{callbacks.h,legacy.h,libssh.h,server.h,sftp.h,ssh2.h} \
+       $PKG_BUILD/.$TARGET_NAME/include/libssh/libssh_version.h \
     $SYSROOT_PREFIX/usr/include/libssh
 }


### PR DESCRIPTION
- cleanup libssh and using full paths instead of relative paths
- copy libssh_version.h that is required by vfs.sftp