### PR TITLE
Allwinner: Crust fix and additional board configurations

### DIFF
--- a/projects/Allwinner/devices/H6/patches/linux/22-opi3-crust-eth-workaround.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/22-opi3-crust-eth-workaround.patch
@@ -1,0 +1,29 @@
+From 8515bba5b33addcf87c4da5ab67cd7ffc052a87d Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Tue, 8 Dec 2020 19:48:39 -0600
+Subject: [PATCH] hack to fix sun8i_dwmac
+
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
+index d1a47145fe4e0..54f8ee992f560 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
+@@ -1299,12 +1299,14 @@ static const struct of_device_id sun8i_dwmac_match[] = {
+ };
+ MODULE_DEVICE_TABLE(of, sun8i_dwmac_match);
+ 
++static SIMPLE_DEV_PM_OPS(sun8i_dwmac_pm_ops, stmmac_suspend, stmmac_resume);
++
+ static struct platform_driver sun8i_dwmac_driver = {
+ 	.probe  = sun8i_dwmac_probe,
+ 	.remove = stmmac_pltfr_remove,
+ 	.driver = {
+ 		.name           = "dwmac-sun8i",
+-		.pm		= &stmmac_pltfr_pm_ops,
++		.pm		= &sun8i_dwmac_pm_ops,
+ 		.of_match_table = sun8i_dwmac_match,
+ 	},
+ };

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -109,15 +109,17 @@ devices = \
       'orangepi-3': {
         'dtb': 'sun50i-h6-orangepi-3.dtb',
         'config': 'orangepi_3_defconfig',
-        'crust_config': 'orangepi_3_defconfig',
+        'crust_config': 'orangepi_3_defconfig'
       },
       'orangepi-lite2': {
         'dtb': 'sun50i-h6-orangepi-lite2.dtb',
-        'config': 'orangepi_lite2_defconfig'
+        'config': 'orangepi_lite2_defconfig',
+        'crust_config': 'orangepi_3_defconfig'
       },
       'orangepi-one-plus': {
         'dtb': 'sun50i-h6-orangepi-one-plus.dtb',
-        'config': 'orangepi_one_plus_defconfig'
+        'config': 'orangepi_one_plus_defconfig',
+        'crust_config': 'orangepi_3_defconfig'
       },
       'pine-h64': {
         'dtb': 'sun50i-h6-pine-h64.dtb',
@@ -126,7 +128,8 @@ devices = \
       },
       'pine-h64-model-b': {
         'dtb': 'sun50i-h6-pine-h64-model-b.dtb',
-        'config': 'pine_h64_defconfig'
+        'config': 'pine_h64_defconfig',
+        'crust_config': 'pine_h64_defconfig'
       },
       'tanix-tx6' : {
         'dtb' : 'sun50i-h6-tanix-tx6.dtb',


### PR DESCRIPTION
This PR fixes ethernet when resumed from sleep on OrangePi3 and it introduces crust support for additional boards.