### PR TITLE
evenlircd: fix SKY-Q remote

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -79,7 +79,7 @@ SUBSYSTEMS=="input", ATTRS{name}=="iMON Panel, Knob and Mouse(15c2:ffdc)", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="default.evmap" 
 
-SUBSYSTEMS=="input", ATTRS{name}=="P218ruwido Sky Remote Keyboard", \
+SUBSYSTEMS=="input", ATTRS{name}=="*ruwido Sky Remote Keyboard", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="skyqremote.evmap"
 


### PR DESCRIPTION
Accidentally paired the wrong SKY remote to my system and observed strange behavior. 
The keymap (from PR https://github.com/LibreELEC/LibreELEC.tv/pull/4546) wasn't picked up so I investigated. It looks like the remote name changes randomly if you pair it.
Thats the names I got from two of my remotes. Fixed it with an wildcard. Should support other Sky remotes too.

```
P235ruwido Sky Remote
U069ruwido Sky Remote
U189ruwido Sky Remote
U235ruwido Sky Remote
U251ruwido Sky Remote
```