### PR TITLE
inadyn: addon update to 2.7 and gettext fix 

### DIFF
--- a/licenses/ISC.txt
+++ b/licenses/ISC.txt
@@ -1,0 +1,15 @@
+ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD
+TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS.
+IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/packages/addons/addon-depends/inadyn/libconfuse/package.mk
+++ b/packages/addons/addon-depends/inadyn/libconfuse/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libconfuse"
-PKG_VERSION="3.2.2"
-PKG_SHA256="2cf7e032980aff8f488efba61510dc3fb95e9a4b9183f985dea457a5651b0e2c"
-PKG_LICENSE="https://github.com/martinh/libconfuse/blob/master/LICENSE"
-PKG_SITE="https://github.com/martinh/libconfuse"
-PKG_URL="https://github.com/martinh/libconfuse/archive/v$PKG_VERSION.tar.gz"
+PKG_VERSION="3.3"
+PKG_SHA256="cb90c06f2dbec971792af576d5b9a382fb3c4ca2b1deea55ea262b403f4e641e"
+PKG_LICENSE="ISC"
+PKG_SITE="https://github.com/libconfuse/libconfuse"
+PKG_URL="https://github.com/libconfuse/libconfuse/archive/v$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Small configuration file parser library for C"
 PKG_TOOLCHAIN="autotools"

--- a/packages/addons/addon-depends/inadyn/libconfuse/patches/gettext-0.20-libconfuse.patch
+++ b/packages/addons/addon-depends/inadyn/libconfuse/patches/gettext-0.20-libconfuse.patch
@@ -1,0 +1,11 @@
+--- libconfuse-3.3/configure.ac	2020-06-25 05:21:59.000000000 +0000
++++ libconfuse-3.3/configure.ac	2020-12-29 02:04:36.074750823 +0000
+@@ -29,7 +29,8 @@
+ # Unfortunately CentOS7, RHEL7 ships 0.18.2.1, so for best compat.
+ # level at this point in time we set 0.18.2.
+ AM_GNU_GETTEXT([external])
+ AM_GNU_GETTEXT_VERSION([0.18.2])
++AM_GNU_GETTEXT_REQUIRE_VERSION([0.18.2])
+ 
+ # Checks for header files.
+ AC_HEADER_STDC

--- a/packages/addons/service/inadyn/changelog.txt
+++ b/packages/addons/service/inadyn/changelog.txt
@@ -1,3 +1,6 @@
+106
+- Update to 2.7
+
 105
 - Update to 2.5
 - Fix settings

--- a/packages/addons/service/inadyn/package.mk
+++ b/packages/addons/service/inadyn/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inadyn"
-PKG_VERSION="2.5"
-PKG_SHA256="28fddd94cb7dda08aef0e5e97bbfd2af83f5dc7ac899a477b5936e82a76d3709"
-PKG_REV="105"
+PKG_VERSION="2.7"
+PKG_SHA256="b27ad8ac6718d167495ed8d2ce91fd90cf896916ab2eb28a6bf5ed1a54fe74e4"
+PKG_REV="106"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="http://troglobit.com/inadyn.html"


### PR DESCRIPTION
Update to current inadyn
- 18 month bump, but limited changes
- https://github.com/troglobit/inadyn/blob/master/ChangeLog.md

update libconfuse (dependency of inadyn)
- 2 year bump - minimal changes
- Includes get text 0.20 patch
- https://github.com/libconfuse/libconfuse/blob/master/ChangeLog.md

