### PR TITLE
u-boot: fix build for sunxi

### DIFF
--- a/projects/Allwinner/bootloader/firmware
+++ b/projects/Allwinner/bootloader/firmware
@@ -6,4 +6,5 @@
 CRUST_CONFIG=$($ROOT/$SCRIPTS/uboot_helper $PROJECT $DEVICE $UBOOT_SYSTEM crust_config)
 [ -n "$CRUST_CONFIG" ] && cp -av $(get_install_dir crust)/usr/share/bootloader/scp.bin .
 
-exit 0
+# Suppress errors from uboot_helper so u-boot properly builds with and without crust
+true


### PR DESCRIPTION
This script is sourced in u-boot's package.mk, 'exit 0' just makes
building a no-op.

Suppress errors from uboot_helper instead.