### PR TITLE
Add cryptsetup and libdevmapper packages

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -9,7 +9,7 @@ PKG_LICENSE="GPL"
 PKG_SITE="http://www.busybox.net"
 PKG_URL="https://busybox.net/downloads/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_HOST="toolchain:host"
-PKG_DEPENDS_TARGET="toolchain busybox:host hdparm dosfstools e2fsprogs zip unzip usbutils parted procps-ng gptfdisk libtirpc"
+PKG_DEPENDS_TARGET="toolchain busybox:host hdparm dosfstools e2fsprogs zip unzip usbutils parted procps-ng gptfdisk libtirpc cryptsetup"
 PKG_DEPENDS_INIT="toolchain libtirpc"
 PKG_LONGDESC="BusyBox combines tiny versions of many common UNIX utilities into a single small executable."
 # busybox fails to build with GOLD support enabled with binutils-2.25

--- a/packages/sysutils/cryptsetup/package.mk
+++ b/packages/sysutils/cryptsetup/package.mk
@@ -1,0 +1,18 @@
+PKG_NAME=cryptsetup
+PKG_MAJOR=2.3
+PKG_VERSION=$PKG_MAJOR.4
+PKG_LICENSE=GPL
+PKG_URL=https://www.kernel.org/pub/linux/utils/cryptsetup/v$PKG_MAJOR/$PKG_NAME-$PKG_VERSION.tar.xz
+PKG_SHA256="9d16eebb96b53b514778e813019b8dd15fea9fec5aafde9fae5febf59df83773"
+PKG_LONGDESC="cryptsetup utility for managing LUKS containers"
+PKG_DEPENDS_HOST="toolchain ccache:host"
+PKG_DEPENDS_TARGET="toolchain popt libdevmapper util-linux json-c openssl"
+
+PKG_CONFIGURE_OPTS_TARGET="
+        --disable-cryptsetup-reencrypt \
+        --disable-integritysetup \
+        --disable-selinux \
+        --disable-rpath \
+        --disable-veritysetup \
+        --disable-udev \
+        --enable-blkid"

--- a/packages/sysutils/libdevmapper/package.mk
+++ b/packages/sysutils/libdevmapper/package.mk
@@ -1,0 +1,20 @@
+PKG_NAME="libdevmapper"
+PKG_VERSION="2.03.10"
+PKG_LICENSE="GPLv2 LGPL2.1"
+PKG_SITE="https://sourceware.org/lvm2"
+PKG_URL="http://mirrors.kernel.org/sourceware/lvm2/releases/LVM2.$PKG_VERSION.tgz"
+PKG_SHA256="5ad1645a480440892e35f31616682acba0dc204ed049635d2df3e5a5929d0ed0"
+PKG_LONGDESC="libdevmapper library from lvm2 package"
+PKG_DEPENDS_TARGET="toolchain systemd readline util-linux"
+
+PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
+                           ac_cv_func_realloc_0_nonnull=yes \
+                           --disable-o_direct \
+                           --disable-nsl \
+                           --disable-selinux \
+                           --disable-symvers"
+
+post_makeinstall_target() {
+  rm -rf $INSTALL/etc
+  rm -rf $INSTALL/usr/bin
+}

--- a/packages/sysutils/libdevmapper/patches/004-device-include-goto-label-as-well.patch
+++ b/packages/sysutils/libdevmapper/patches/004-device-include-goto-label-as-well.patch
@@ -1,0 +1,26 @@
+From a887fe76be459d32a638d0abde96cc715632c8d5 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Fri, 20 May 2016 06:31:15 +0200
+Subject: [PATCH] device: include goto lable as well
+To: lvm-devel@redhat.com
+
+commit b5314c2a6ae5fe4f802e82a4f31cf2fad398ded9
+device:  Retry open without O_NOATIME if it fails.
+
+makes use of goto lable 'opened:' but that might not be defined, e.g.
+on standard C libraries without O_DIRECT_SUPPORT.
+---
+ lib/device/dev-io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/lib/device/dev-io.c
++++ b/lib/device/dev-io.c
+@@ -564,7 +564,7 @@ int dev_open_flags(struct device *dev, int flags, int direct, int quiet)
+ 		return 0;
+ 	}
+ 
+-#ifdef O_DIRECT_SUPPORT
++#if defined(O_DIRECT_SUPPORT) || defined(O_NOATIME)
+       opened:
+ 	if (direct)
+ 		dev->flags |= DEV_O_DIRECT_TESTED;


### PR DESCRIPTION
This patch adds the cryptsetup binary, allowing users to create and mount encrypted devices.

Cryptsetup depends on libdevmapper, which is part of the lvm2 (not currently included in LE). The library is only 366k but the lvm2 binaries are 4M so instead of including them I've created a libdevmapper package that installs just the library. I'm open to suggestions if there's a better way of doing this.

In total, this adds about 870k (uncompressed) to the system:

```
./usr/lib:
lrwxrwxrwx    1 1000     1000          23 Jan  1 12:00 libcryptsetup.so -> libcryptsetup.so.12.6.0
lrwxrwxrwx    1 1000     1000          23 Jan  1 12:00 libcryptsetup.so.12 -> libcryptsetup.so.12.6.0
-rwxr-xr-x    1 1000     1000      378.5K Jan  1 12:00 libcryptsetup.so.12.6.0
lrwxrwxrwx    1 1000     1000          20 Jan  1 12:00 libdevmapper.so -> libdevmapper.so.1.02
-r-xr-xr-x    1 1000     1000      366.8K Jan  1 12:00 libdevmapper.so.1.02

./usr/lib/tmpfiles.d:
-rw-r--r--    1 1000     1000          35 Jan  1 12:00 cryptsetup.conf

./usr/sbin:
-rwxr-xr-x    1 1000     1000       93.4K Jan  1 12:00 cryptsetup
```