### PR TITLE
configtools: update to 2020-12-22

### DIFF
--- a/packages/devel/configtools/package.mk
+++ b/packages/devel/configtools/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="configtools"
-PKG_VERSION="5256817ace8493502ec88501a19e4051c2e220b0"
+PKG_VERSION="5256817ace8493502ec88501a19e4051c2e220b0" # 2020-01-01
 PKG_SHA256="3856ff9a2a9382a3396549c047c28e0f05b7e4822239ffe91ce2e59b0a0284db"
 PKG_LICENSE="GPL"
 PKG_SITE="http://git.savannah.gnu.org/cgit/config.git"

--- a/packages/devel/configtools/package.mk
+++ b/packages/devel/configtools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="configtools"
-PKG_VERSION="5256817ace8493502ec88501a19e4051c2e220b0" # 2020-01-01
-PKG_SHA256="3856ff9a2a9382a3396549c047c28e0f05b7e4822239ffe91ce2e59b0a0284db"
+PKG_VERSION="c8ddc8472f8efcadafc1ef53ca1d863415fddd5f" # 2020-12-22
+PKG_SHA256="6389d62e4e55554c764c2c0deb5b42767f34d7f274728c28355fedbaa337165b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://git.savannah.gnu.org/cgit/config.git"
 PKG_URL="http://git.savannah.gnu.org/cgit/config.git/snapshot/config-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Update configtools from 2020-01-01 to 2020-12-22
(2 commits - first updating the from version in the file before the update)

no changes that refer to LibreELEC hardware projects 