### PR TITLE
swig: update to 4.0.2

### DIFF
--- a/packages/devel/swig/package.mk
+++ b/packages/devel/swig/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="swig"
-PKG_VERSION="4.0.1"
-PKG_SHA256="7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
+PKG_VERSION="4.0.2"
+PKG_SHA256="d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.swig.org"
 PKG_URL="$SOURCEFORGE_SRC/swig/$PKG_NAME-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
### ~ 12 month update.

Version: 4.0.2 (8 Jun 2020) 
Version 4.0.1 (21 Aug 2019)

Mostly fixes
http://www.swig.org/Release/CHANGES.current
