### PR TITLE
kmod: update to 27

### DIFF
--- a/packages/sysutils/kmod/package.mk
+++ b/packages/sysutils/kmod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="kmod"
-PKG_VERSION="24"
-PKG_SHA256="610b8d1df172acc39a4fdf1eaa47a57b04873c82f32152e7a62e29b6ff9cb397"
+PKG_VERSION="27"
+PKG_SHA256="c1d3fbf16ca24b95f334c1de1b46f17bbe5a10b0e81e72668bdc922ebffbbc0c"
 PKG_LICENSE="GPL"
 PKG_SITE="http://git.profusion.mobi/cgit.cgi/kmod.git/"
 PKG_URL="https://www.kernel.org/pub/linux/utils/kernel/kmod/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
### 3 year update

24-Feb-2017 - 24
19-Feb-2020 - 27

mainstream distros using #27.

https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/tree/NEWS
https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/log/
