### PR TITLE
linux: add patch to fix IR timeout handling

### DIFF
--- a/packages/linux/patches/default/linux-001-fix-ir-timeout.patch
+++ b/packages/linux/patches/default/linux-001-fix-ir-timeout.patch
@@ -1,0 +1,74 @@
+From 1f363deec843ed4e75aa11e466f91e9224376c04 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 5 Jan 2021 09:57:29 +0100
+Subject: [PATCH] media: rc: fix timeout handling after switch to microsecond
+ durations
+
+Commit 528222d853f92 ("media: rc: harmonize infrared durations to
+microseconds") missed to switch some timeout calculations from
+nanoseconds to microseconds. This resulted in spurious key_up+key_down
+events at the last scancode if the rc device uses a long timeout
+(eg 100ms on nuvoton-cir) as the device timeout wasn't properly
+accounted for in the keyup timeout calculation.
+
+Fix this by applying the proper conversion functions.
+
+Fixes: 528222d853f92 ("media: rc: harmonize infrared durations to microseconds")
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ir-mce_kbd-decoder.c | 2 +-
+ drivers/media/rc/rc-main.c            | 4 ++--
+ drivers/media/rc/serial_ir.c          | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
+index be8f2756a444..1524dc0fc566 100644
+--- a/drivers/media/rc/ir-mce_kbd-decoder.c
++++ b/drivers/media/rc/ir-mce_kbd-decoder.c
+@@ -320,7 +320,7 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
+ 				data->body);
+ 			spin_lock(&data->keylock);
+ 			if (scancode) {
+-				delay = nsecs_to_jiffies(dev->timeout) +
++				delay = usecs_to_jiffies(dev->timeout) +
+ 					msecs_to_jiffies(100);
+ 				mod_timer(&data->rx_timeout, jiffies + delay);
+ 			} else {
+diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
+index 29d4d01896ff..1fd62c1dac76 100644
+--- a/drivers/media/rc/rc-main.c
++++ b/drivers/media/rc/rc-main.c
+@@ -737,7 +737,7 @@ static unsigned int repeat_period(int protocol)
+ void rc_repeat(struct rc_dev *dev)
+ {
+ 	unsigned long flags;
+-	unsigned int timeout = nsecs_to_jiffies(dev->timeout) +
++	unsigned int timeout = usecs_to_jiffies(dev->timeout) +
+ 		msecs_to_jiffies(repeat_period(dev->last_protocol));
+ 	struct lirc_scancode sc = {
+ 		.scancode = dev->last_scancode, .rc_proto = dev->last_protocol,
+@@ -855,7 +855,7 @@ void rc_keydown(struct rc_dev *dev, enum rc_proto protocol, u64 scancode,
+ 	ir_do_keydown(dev, protocol, scancode, keycode, toggle);
+ 
+ 	if (dev->keypressed) {
+-		dev->keyup_jiffies = jiffies + nsecs_to_jiffies(dev->timeout) +
++		dev->keyup_jiffies = jiffies + usecs_to_jiffies(dev->timeout) +
+ 			msecs_to_jiffies(repeat_period(protocol));
+ 		mod_timer(&dev->timer_keyup, dev->keyup_jiffies);
+ 	}
+diff --git a/drivers/media/rc/serial_ir.c b/drivers/media/rc/serial_ir.c
+index 8cc28c92d05d..96ae0294ac10 100644
+--- a/drivers/media/rc/serial_ir.c
++++ b/drivers/media/rc/serial_ir.c
+@@ -385,7 +385,7 @@ static irqreturn_t serial_ir_irq_handler(int i, void *blah)
+ 	} while (!(sinp(UART_IIR) & UART_IIR_NO_INT)); /* still pending ? */
+ 
+ 	mod_timer(&serial_ir.timeout_timer,
+-		  jiffies + nsecs_to_jiffies(serial_ir.rcdev->timeout));
++		  jiffies + usecs_to_jiffies(serial_ir.rcdev->timeout));
+ 
+ 	ir_raw_event_handle(serial_ir.rcdev);
+ 
+-- 
+2.20.1
+

--- a/packages/linux/patches/raspberrypi/linux-001-fix-ir-timeout.patch
+++ b/packages/linux/patches/raspberrypi/linux-001-fix-ir-timeout.patch
@@ -1,0 +1,74 @@
+From 1f363deec843ed4e75aa11e466f91e9224376c04 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 5 Jan 2021 09:57:29 +0100
+Subject: [PATCH] media: rc: fix timeout handling after switch to microsecond
+ durations
+
+Commit 528222d853f92 ("media: rc: harmonize infrared durations to
+microseconds") missed to switch some timeout calculations from
+nanoseconds to microseconds. This resulted in spurious key_up+key_down
+events at the last scancode if the rc device uses a long timeout
+(eg 100ms on nuvoton-cir) as the device timeout wasn't properly
+accounted for in the keyup timeout calculation.
+
+Fix this by applying the proper conversion functions.
+
+Fixes: 528222d853f92 ("media: rc: harmonize infrared durations to microseconds")
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ir-mce_kbd-decoder.c | 2 +-
+ drivers/media/rc/rc-main.c            | 4 ++--
+ drivers/media/rc/serial_ir.c          | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/rc/ir-mce_kbd-decoder.c b/drivers/media/rc/ir-mce_kbd-decoder.c
+index be8f2756a444..1524dc0fc566 100644
+--- a/drivers/media/rc/ir-mce_kbd-decoder.c
++++ b/drivers/media/rc/ir-mce_kbd-decoder.c
+@@ -320,7 +320,7 @@ static int ir_mce_kbd_decode(struct rc_dev *dev, struct ir_raw_event ev)
+ 				data->body);
+ 			spin_lock(&data->keylock);
+ 			if (scancode) {
+-				delay = nsecs_to_jiffies(dev->timeout) +
++				delay = usecs_to_jiffies(dev->timeout) +
+ 					msecs_to_jiffies(100);
+ 				mod_timer(&data->rx_timeout, jiffies + delay);
+ 			} else {
+diff --git a/drivers/media/rc/rc-main.c b/drivers/media/rc/rc-main.c
+index 29d4d01896ff..1fd62c1dac76 100644
+--- a/drivers/media/rc/rc-main.c
++++ b/drivers/media/rc/rc-main.c
+@@ -737,7 +737,7 @@ static unsigned int repeat_period(int protocol)
+ void rc_repeat(struct rc_dev *dev)
+ {
+ 	unsigned long flags;
+-	unsigned int timeout = nsecs_to_jiffies(dev->timeout) +
++	unsigned int timeout = usecs_to_jiffies(dev->timeout) +
+ 		msecs_to_jiffies(repeat_period(dev->last_protocol));
+ 	struct lirc_scancode sc = {
+ 		.scancode = dev->last_scancode, .rc_proto = dev->last_protocol,
+@@ -855,7 +855,7 @@ void rc_keydown(struct rc_dev *dev, enum rc_proto protocol, u64 scancode,
+ 	ir_do_keydown(dev, protocol, scancode, keycode, toggle);
+ 
+ 	if (dev->keypressed) {
+-		dev->keyup_jiffies = jiffies + nsecs_to_jiffies(dev->timeout) +
++		dev->keyup_jiffies = jiffies + usecs_to_jiffies(dev->timeout) +
+ 			msecs_to_jiffies(repeat_period(protocol));
+ 		mod_timer(&dev->timer_keyup, dev->keyup_jiffies);
+ 	}
+diff --git a/drivers/media/rc/serial_ir.c b/drivers/media/rc/serial_ir.c
+index 8cc28c92d05d..96ae0294ac10 100644
+--- a/drivers/media/rc/serial_ir.c
++++ b/drivers/media/rc/serial_ir.c
+@@ -385,7 +385,7 @@ static irqreturn_t serial_ir_irq_handler(int i, void *blah)
+ 	} while (!(sinp(UART_IIR) & UART_IIR_NO_INT)); /* still pending ? */
+ 
+ 	mod_timer(&serial_ir.timeout_timer,
+-		  jiffies + nsecs_to_jiffies(serial_ir.rcdev->timeout));
++		  jiffies + usecs_to_jiffies(serial_ir.rcdev->timeout));
+ 
+ 	ir_raw_event_handle(serial_ir.rcdev);
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
This fixes the "double button press" issue with nuvoton-cir
as reported on the forum.

See https://forum.libreelec.tv/thread/23211-intel-nightly-build-problem-with-mce-remote/

upstream patch status: https://patchwork.linuxtv.org/project/linux-media/patch/20210105093023.5212-1-hias@horus.com/