### PR TITLE
tigervnc: addon update to 1.10.1 (105)

### DIFF
--- a/packages/addons/service/tigervnc/changelog.txt
+++ b/packages/addons/service/tigervnc/changelog.txt
@@ -1,3 +1,6 @@
+105
+- Update to 1.10.1
+
 103
 - Update to 1.9.0
 

--- a/packages/addons/service/tigervnc/package.mk
+++ b/packages/addons/service/tigervnc/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tigervnc"
-PKG_VERSION="1.9.0"
-PKG_SHA256="f15ced8500ec56356c3bf271f52e58ed83729118361c7103eab64a618441f740"
-PKG_REV="104"
+PKG_VERSION="1.10.1"
+PKG_SHA256="19fcc80d7d35dd58115262e53cac87d8903180261d94c2a6b0c19224f50b58c4"
+PKG_REV="105"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"
 PKG_SITE="http://www.tigervnc.org"


### PR DESCRIPTION
### Release notes 1.10.1
https://github.com/TigerVNC/tigervnc/releases/tag/v1.10.1

### Release notes 1.11.0
https://github.com/TigerVNC/tigervnc/releases/tag/v1.11.0

Note: it is not possible to update to 1.11.0 without reverting mandatory PAM patches.
Make PAM mandatory -
https://github.com/TigerVNC/tigervnc/commit/d80817f101d1b3f1a9b1c5ec268f28fffa2d75f9#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a
Start sessions via PAM -
https://github.com/TigerVNC/tigervnc/commit/1af1cfdf8709dd1a5574efa19fb4f0e68a98021e#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a