### PR TITLE
 multimedia-tools: update addon (113)

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmediainfo"
-PKG_VERSION="18.05"
-PKG_SHA256="76759613ca71d5659818e6ed121be9f31c552931b04939b0db4c58bc57cd5221" 
+PKG_VERSION="20.09"
+PKG_SHA256="d07ce857330a9f9eedc4e5748f8022af1e9540e88a732d4e45c818c8ec4dd196"
 PKG_LICENSE="GPL"
-PKG_SITE="http://mediaarea.net/en/MediaInfo/Download/Source"
-PKG_URL="http://mediaarea.net/download/source/libmediainfo/${PKG_VERSION}/libmediainfo_${PKG_VERSION}.tar.xz"
+PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
+PKG_URL="https://mediaarea.net/download/source/libmediainfo/${PKG_VERSION}/libmediainfo_${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libzen zlib"
 PKG_DEPENDS_CONFIG="libzen"
 PKG_LONGDESC="MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files"

--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libzen/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libzen/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libzen"
-PKG_VERSION="0.4.37"
-PKG_SHA256="38c0a68b715b55d6685d2759eecda040adf37bd066955d79a5d01f91977bd9a0"
+PKG_VERSION="0.4.38"
+PKG_SHA256="b8825b3190b3a31d8d362547cfa26a3c10e8c063df2d87e4a05758d6b756c8ab"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mediaarea.net/en/MediaInfo/"
 PKG_URL="http://mediaarea.net/download/source/libzen/${PKG_VERSION}/libzen_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mediainfo"
-PKG_VERSION="18.05"
-PKG_SHA256="d94093aaf910759f302fb6b5ac23540a217eb940cfbb21834de2381de975fa65"
+PKG_VERSION="20.09"
+PKG_SHA256="39327ef83caa38a96114d1b90654012b9ef727538fe82c37dd67aea2cf4f0f67"
 PKG_LICENSE="GPL"
-PKG_SITE="http://mediaarea.net/en/MediaInfo/Download/Source"
-PKG_URL="http://mediaarea.net/download/source/mediainfo/${PKG_VERSION}/mediainfo_${PKG_VERSION}.tar.xz"
+PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
+PKG_URL="https://mediaarea.net/download/source/mediainfo/${PKG_VERSION}/mediainfo_${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libmediainfo"
 PKG_DEPENDS_CONFIG="libzen libmediainfo"
 PKG_LONGDESC="A convenient unified display of the most relevant technical and tag data for video and audio files."

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpg123"
-PKG_VERSION="1.25.10"
-PKG_SHA256="6c1337aee2e4bf993299851c70b7db11faec785303cfca3a5c3eb5f329ba7023"
+PKG_VERSION="1.26.4"
+PKG_SHA256="081991540df7a666b29049ad870f293cfa28863b36488ab4d58ceaa7b5846454"
 PKG_LICENSE="LGPLv2"
 PKG_SITE="http://www.mpg123.org/"
 PKG_URL="http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-$PKG_VERSION.tar.bz2"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpv-drmprime"
-PKG_VERSION="0.30.0"
-PKG_SHA256="33a1bcb7e74ff17f070e754c15c52228cf44f2cefbfd8f34886ae81df214ca35"
+PKG_VERSION="0.33.0"
+PKG_SHA256="f1b9baf5dc2eeaf376597c28a6281facf6ed98ff3d567e3955c95bf2459520b4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mpv.io/"
 PKG_URL="https://github.com/mpv-player/mpv/archive/v$PKG_VERSION.tar.gz"
@@ -13,8 +13,6 @@ PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--prefix=/usr \
-                           --disable-libsmbclient \
-                           --disable-apple-remote \
                            --disable-libarchive \
                            --disable-lua \
                            --disable-javascript \
@@ -28,7 +26,6 @@ PKG_CONFIGURE_OPTS_TARGET="--prefix=/usr \
                            --disable-vulkan \
                            --disable-caca \
                            --enable-drm \
-                           --enable-drmprime \
                            --enable-gbm \
                            --enable-egl-drm"
 

--- a/packages/addons/tools/multimedia-tools/changelog.txt
+++ b/packages/addons/tools/multimedia-tools/changelog.txt
@@ -1,3 +1,10 @@
+113
+- libmediainfo: update to 20.09
+- libzen: update to 0.4.38
+- mediainfo: update to 20.09
+- mpg123: update to 1.26.4
+- mpv-drmprime: update to 0.33.0
+
 112
 - Update sqeezelite 2020-11-16
 

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="112"
+PKG_REV="113"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- libmediainfo: update to 20.09 from 18.05
https://mediaarea.net/MediaInfo/ChangeLog
- libzen: update to 0.4.38 from 0.4.37
https://github.com/MediaArea/ZenLib/blob/master/History.txt
- mediainfo: update to 20.09 from 18.05
https://mediaarea.net/MediaInfo/ChangeLog
- mpv-drmprime: update to 0.33.0 from 0.30.0
https://github.com/mpv-player/mpv/releases
- mpg123: update to 1.26.4 from 1.25.10
http://www.mpg123.org/cgi-bin/news.cgi