### PR TITLE
slang: update to 2.3.2

### DIFF
--- a/packages/devel/slang/package.mk
+++ b/packages/devel/slang/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="slang"
-PKG_VERSION="2.1.4"
-PKG_SHA256="14877efebbf0e57a3543f7ab3c72b491d3e398ea852616990f88463d64a3b4e3"
+PKG_VERSION="2.3.2"
+PKG_SHA256="fc9e3b0fc4f67c3c1f6d43c90c16a5c42d117b8e28457c5b46831b8b5d3ae31a"
 PKG_LICENSE="GPL"
-PKG_SITE="http://s-lang.org/"
-PKG_URL="ftp://space.mit.edu/pub/davis/slang/v2.1/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SITE="http://www.jedsoft.org/slang/"
+PKG_URL="https://www.jedsoft.org/releases/slang/$PKG_NAME-$PKG_VERSION.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A library designed to allow a developer to create robust multi-platform software."
 PKG_BUILD_FLAGS="-parallel"


### PR DESCRIPTION
This is a large update from slang 2.1.4 to 2.3.2.
A 10 year jump - https://www.jedsoft.org/releases/slang/

Newt still builds 😀
 
$ git grep slang
packages/devel/slang/package.mk:PKG_NAME="slang"
packages/devel/slang/package.mk:PKG_URL="ftp://space.mit.edu/pub/davis/slang/v2.1/$PKG_NAME-$PKG_VERSION.tar.gz"
packages/devel/slang/package.mk: # slang fails to build in subdirs
packages/devel/slang/package.mk: # slang fails to build in subdirs
packages/sysutils/util-linux/package.mk:                          --without-slang \
packages/tools/newt/package.mk:PKG_DEPENDS_TARGET="toolchain slang popt"