### PR TITLE
arithmetic Libraries: update to current

### DIFF
--- a/packages/devel/gmp/package.mk
+++ b/packages/devel/gmp/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmp"
-PKG_VERSION="6.2.0"
-PKG_SHA256="258e6cd51b3fbdfc185c716d55f82c08aff57df0c6fbd143cf6ed561267a1526"
+PKG_VERSION="6.2.1"
+PKG_SHA256="fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2"
 PKG_LICENSE="LGPLv3+"
 PKG_SITE="http://gmplib.org/"
 PKG_URL="https://gmplib.org/download/gmp/$PKG_NAME-$PKG_VERSION.tar.xz"

--- a/packages/devel/mpc/package.mk
+++ b/packages/devel/mpc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpc"
-PKG_VERSION="1.1.0"
-PKG_SHA256="6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e"
+PKG_VERSION="1.2.1"
+PKG_SHA256="17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.multiprecision.org"
 PKG_URL="http://ftpmirror.gnu.org/mpc/$PKG_NAME-$PKG_VERSION.tar.gz"

--- a/packages/devel/mpfr/package.mk
+++ b/packages/devel/mpfr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpfr"
-PKG_VERSION="4.0.2"
-PKG_SHA256="1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a"
+PKG_VERSION="4.1.0"
+PKG_SHA256="0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.mpfr.org/"
 PKG_URL="http://ftpmirror.gnu.org/mpfr/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
mpc from 1.1.0 to 1.2.1
- http://www.multiprecision.org/mpc/
- http://www.multiprecision.org/mpc/olds.html

mpfr from 4.0.2 to 4.1.0
- https://www.mpfr.org/mpfr-current/#changes


gmp from 6.2.0 to 6.2.1
- https://gmplib.org/gmp6.2
- bug fixes 