### PR TITLE
libfmt: update to 7.1.3

### DIFF
--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libfmt"
-PKG_VERSION="7.0.3"
-PKG_SHA256="b4b51bc16288e2281cddc59c28f0b4f84fed58d016fb038273a09f05f8473297"
+PKG_VERSION="7.1.3"
+PKG_SHA256="5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/fmtlib/fmt"
 PKG_URL="https://github.com/fmtlib/fmt/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Update of libfmt from 7.0.3 to 7.1.3

7.0.3 @vitaut vitaut released this on 7 Aug 2020
7.1.3 @vitaut vitaut released this on 26 Nov 2020

https://github.com/fmtlib/fmt/releases

a big update in https://github.com/fmtlib/fmt/releases/tag/7.1.0 remaining 7.1.x are just fixes