### PR TITLE
faad2: update to 2.10.0 and PKG_SITE and PKG_URL

### DIFF
--- a/packages/addons/addon-depends/faad2/package.mk
+++ b/packages/addons/addon-depends/faad2/package.mk
@@ -3,13 +3,14 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="faad2"
-PKG_VERSION="2.8.8"
-PKG_SHA256="985c3fadb9789d2815e50f4ff714511c79c2710ac27a4aaaf5c0c2662141426d"
+PKG_VERSION="2.10.0"
+PKG_SHA256="0c6d9636c96f95c7d736f097d418829ced8ec6dbd899cc6cc82b728480a84bfb"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.audiocoding.com"
-PKG_URL="https://downloads.sourceforge.net/sourceforge/faac/faad2-$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/knik0/faad2/"
+PKG_URL="https://github.com/knik0/faad2/archive/${PKG_VERSION//./_}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="An MPEG-4 AAC decoder."
+PKG_TOOLCHAIN="configure"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \
@@ -17,6 +18,9 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --with-gnu-ld \
                            --without-mpeg4ip \
                            --without-xmms"
+pre_configure_target() {
+  ./bootstrap
+}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin


### PR DESCRIPTION
Update from 2.8.8 to 2.10.0

mostly fixes (security): https://github.com/knik0/faad2/blob/master/ChangeLog

2.8.8 - 18 Dec 2017
2.10.0 -: 20 Oct 2020

https://github.com/knik0/faad2/releases
