### PR TITLE
Update tools - mtools and hdparm

### DIFF
--- a/packages/tools/hdparm/package.mk
+++ b/packages/tools/hdparm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hdparm"
-PKG_VERSION="9.58"
-PKG_SHA256="9ae78e883f3ce071d32ee0f1b9a2845a634fc4dd94a434e653fdbef551c5e10f"
+PKG_VERSION="9.60"
+PKG_SHA256="8397739c73e44d5ab96c4aef28fa9c0147276d53a1b5657ce04c4565cf6635cc"
 PKG_LICENSE="BSD"
 PKG_SITE="http://sourceforge.net/projects/hdparm/"
 PKG_URL="$SOURCEFORGE_SRC/$PKG_NAME/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"

--- a/packages/tools/mtools/package.mk
+++ b/packages/tools/mtools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mtools"
-PKG_VERSION="4.0.24"
-PKG_SHA256="24f4a2da9219f98498eb1b340cd96db7ef9b684c067d1bdeb6e85efdd13b2fb9"
+PKG_VERSION="4.0.26"
+PKG_SHA256="539f1c8b476a16e198d8bcb10a5799e22e69de49d854f7dbd85b64c2a45dea1a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/mtools/"
 PKG_URL="http://ftpmirror.gnu.org/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
Mtools upgrade from Mar 22, 2020 to Nov 28, 2020

    1 v4_0_26
    2 	- Fix compilation on Macintosh
    3 	- Ignore image file locking errors if we are performing a
    4           read-only access anyways
    5 	- Minor man-page fixes
    6 v4_0_25
    7 	- Preserve non-updated contents of info sector, just in case
    8           it contains program code
    9 	- When parsing config file, always use "C" locale for
   10           case-insensitive comparisons
   11 v4_0_24
   12 	- Spelling fixes in documentation
   13 	- Permit calling "make install" with >= -j2
   14 	- Added AC_SYS_LARGEFILE, needed for compiling on certain ARM procs

minor fixes.

hdparm 
- 9.58 is 2018-10-26
- 9.60 is 2020-11-21

minor fixes - https://fossies.org/linux/hdparm/Changelog