### PR TITLE
Update packages/graphics current

### DIFF
--- a/packages/graphics/cairo/package.mk
+++ b/packages/graphics/cairo/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cairo"
-PKG_VERSION="1.16.0"
-PKG_SHA256="5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331"
+PKG_VERSION="1.17.4"
+PKG_SHA256="74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://cairographics.org/"
-PKG_URL="http://cairographics.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="http://cairographics.org/snapshots/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain zlib freetype fontconfig glib libpng pixman"
 PKG_LONGDESC="Cairo is a vector graphics library with cross-device output support."
 PKG_TOOLCHAIN="configure"

--- a/packages/graphics/kmscube/package.mk
+++ b/packages/graphics/kmscube/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kmscube"
-PKG_VERSION="26326be53e30da9c101075fda081d38ea9ec758d"
-PKG_SHA256="ce96a78edd37387058a81070950c993853f427959cfafc15cfc5f78e9f2e9b07"
+PKG_VERSION="e6386d1b99366ea7559438c0d3abd2ae2d6d61ac"
+PKG_SHA256="0f162bbcef951d5e3fc5e8974f5944c420657edc72bf51e0074f46f30d942722"
 PKG_LICENSE="GPL"
 PKG_SITE="https://gitlab.freedesktop.org/mesa/kmscube"
 PKG_URL="https://gitlab.freedesktop.org/mesa/kmscube/-/archive/master/kmscube-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libepoxy/package.mk
+++ b/packages/graphics/libepoxy/package.mk
@@ -9,10 +9,10 @@
 
 PKG_NAME="libepoxy"
 PKG_VERSION="1.5.5"
-PKG_SHA256="261663db21bcc1cc232b07ea683252ee6992982276536924271535875f5b0556"
+PKG_SHA256="5d80a43a6524a1ebdd0c9c5d5105295546a0794681853c636a0c70f8f9c658ce"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/anholt/libepoxy"
-PKG_URL="https://github.com/anholt/libepoxy/releases/download/${PKG_VERSION}/libepoxy-${PKG_VERSION}.tar.xz"
+PKG_URL="https://github.com/anholt/libepoxy/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Epoxy is a library for handling OpenGL function pointer management for you."
 


### PR DESCRIPTION
libepoxy: update to 1.5.5
- https://github.com/anholt/libepoxy/releases/tag/1.5.5
- No change URI only and SHA256

kmscube: update to HEAD
- drm: grab correct handle for plane != 0
- Multiplanar formats can have different BOs for each plane, so call the
- correct GBM function to get the handle for a specific plane

cairo: update to 1.17.4
- bumping to 1.17.4.
- Also note maintainer update - https://gitlab.freedesktop.org/cairo/cairo/-/blob/156cd3eaaebfd8635517c2baf61fcf3627ff7ec2/NEWS