### PR TITLE
inputstream.adaptive: bump revision

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="inputstream.adaptive"
 PKG_VERSION="2.6.6-Matrix"
 PKG_SHA256="0fe366b9e5db692b98d58dfa76fa111a4ce510c6466c3b6bad50d138bed62428"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/peak3d/inputstream.adaptive"


### PR DESCRIPTION
The following PR broke the compiled version of inputstream.adaptive:
https://github.com/LibreELEC/LibreELEC.tv/pull/4775

See:
https://forum.libreelec.tv/thread/23273-missing-libnss3-so-in-nightly-20210106-1d5a0dc/

