### PR TITLE
pixman: package configuration is for configure, use it

### DIFF
--- a/packages/x11/lib/pixman/package.mk
+++ b/packages/x11/lib/pixman/package.mk
@@ -11,6 +11,7 @@ PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/$PKG_NAME-$PKG_VERSI
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain util-macros"
 PKG_LONGDESC="Pixman is a generic library for manipulating pixel regions, contains low-level pixel manipulation routines."
+PKG_TOOLCHAIN="configure"
 
 if [ "$TARGET_ARCH" = arm ]; then
   if target_has_feature neon; then


### PR DESCRIPTION
Additional meson build method was introduced with pixman 0.38. This is auto-detected by our build system but only configure is configured in the package.

Select `configure` again.

This is not against meson but changing the build method should be a development decision and not orruc by accident.

