### PR TITLE
whois: update to 5.5.7

### DIFF
--- a/packages/addons/addon-depends/whois/package.mk
+++ b/packages/addons/addon-depends/whois/package.mk
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2011 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="whois"
-PKG_VERSION="5.2.13"
-PKG_SHA256="d7af1e89e7b3c63835e78bcea6c8aeb14640a3f1027f18b7b619a47100a6f2dc"
+PKG_VERSION="5.5.7"
+PKG_SHA256="ae389c1486cdeae99f5f02940f98f5d7ff1f08ac0f96810365159b27b0189b5e"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.linux.it/~md/software/"
 PKG_URL="https://github.com/rfc1036/whois/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
used simply for its toolchain.
proftpd/package.mk:    cp $(get_install_dir whois)/usr/bin/mkpasswd $ADDON_BUILD/$PKG_ADDON_ID/bin
