### PR TITLE
libva-utils: update to 2.10.0

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva-utils"
-PKG_VERSION="2.9.1"
-PKG_SHA256="7cd7111349cdc227c64d5ab68de4a03eacbea26441c7781ccd548491994f0320"
+PKG_VERSION="2.10.0"
+PKG_SHA256="cbb7f9f6eae21d772e31b67bc8c311be6e35fe9c65e63acc57f9b16d72bf8dc0"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"
 PKG_URL="https://github.com/intel/libva-utils/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
https://github.com/intel/libva-utils/releases
- add Mediacopy Sample code
- Enable new caps for rate control TCBRC
- Add --repeat command line option to vp8enc.
- fix one null pointer dereference risk