### PR TITLE
shared-mime-info: update to 1.15 and itstool:host dependency 

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/itstool/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/itstool/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="itstool"
+PKG_VERSION="2.0.6"
+PKG_SHA256="6233cc22726a9a5a83664bf67d1af79549a298c23185d926c3677afa917b92a9"
+PKG_LICENSE="GPLv3"
+PKG_SITE="http://itstool.org"
+PKG_URL="http://files.itstool.org/itstool/itstool-$PKG_VERSION.tar.bz2"
+PKG_DEPENDS_HOST="toolchain libxml2:host"
+PKG_LONGDESC="ITS Tool allows you to translate your XML documents with PO files."

--- a/packages/addons/addon-depends/chrome-depends/shared-mime-info/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/shared-mime-info/package.mk
@@ -2,14 +2,13 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="shared-mime-info"
-PKG_VERSION="1.9"
-PKG_SHA256="5c0133ec4e228e41bdf52f726d271a2d821499c2ab97afd3aa3d6cf43efcdc83"
+PKG_VERSION="1.15"
+PKG_SHA256="f482b027437c99e53b81037a9843fccd549243fd52145d016e9c7174a4f5db90"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://freedesktop.org/wiki/Software/shared-mime-info/"
-PKG_URL="http://freedesktop.org/~hadess/shared-mime-info-$PKG_VERSION.tar.xz"
-PKG_DEPENDS_TARGET="toolchain glib libxml2"
+PKG_URL="https://gitlab.freedesktop.org/xdg/shared-mime-info/uploads/b27eb88e4155d8fccb8bb3cd12025d5b/shared-mime-info-1.15.tar.xz"
+PKG_DEPENDS_TARGET="toolchain glib libxml2 gettext itstool:host"
 PKG_LONGDESC="The shared-mime-info package contains the core database of common types."
 PKG_BUILD_FLAGS="-parallel -sysroot"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-nls \
-                           --disable-update-mimedb"
+PKG_MESON_OPTS_TARGET="-Dupdate-mimedb=false"


### PR DESCRIPTION
### Change-log
https://github.com/freedesktop/xdg-shared-mime-info/blob/master/NEWS

previous version
- shared-mime-info 1.9 (2017-09-18)

new version 
- shared-mime-info 1.15 (2019-10-30)


**Building 2.1 not yet successful (and brand new)**

https://github.com/freedesktop/xdg-shared-mime-info/releases

### itstool
Only used for :host