### PR TITLE
Audio package updates

### DIFF
--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.4.11"
-PKG_SHA256="260e92cc2f6af37113442bff2c75a3c36a09eba4078dc593203a0502f95d26bd"
+PKG_VERSION="0.4.16"
+PKG_SHA256="4fb4d9901390e2129f8609a2e369ad47c356145664dacbbaece562f2cf51e6d4"
 PKG_LICENSE="BSD"
 PKG_SITE="http://lib.openmpt.org/libopenmpt/"
 PKG_URL="http://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/audio/openal-soft/package.mk
+++ b/packages/audio/openal-soft/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openal-soft"
-PKG_VERSION="1.20.1"
-PKG_SHA256="b6ceb051325732c23f5c8b6d37dbd89534517e6439a87e970882b447c3025d6d"
+PKG_VERSION="1.21.0"
+PKG_SHA256="cd3650530866f3906058225f4bfbe0052be19e0a29dcc6df185a460f9948feec"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openal.org/"
-PKG_URL="http://kcat.strangesoft.net/openal-releases/$PKG_NAME-$PKG_VERSION.tar.bz2"
+PKG_URL="https://github.com/kcat/openal-soft/archive/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain openal-soft:host alsa-lib"
 PKG_LONGDESC="OpenAL the Open Audio Library"

--- a/packages/audio/sbc/package.mk
+++ b/packages/audio/sbc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sbc"
-PKG_VERSION="1.4"
-PKG_SHA256="050058cfc5a2709d324868ddbb82f9b796ba6c4f5e00cb6a715b3841ee13dfe9"
+PKG_VERSION="1.5"
+PKG_SHA256="51d4e385237e9d4780c7b20e660e30fb6a7a6d75ca069f1ed630fa6105232aba"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="http://www.kernel.org/pub/linux/bluetooth/sbc-$PKG_VERSION.tar.gz"


### PR DESCRIPTION
- sbc: update to 1.5 from 1.4
- - released 07-Dec-2020, 1.4 was Sep 2018
- openal-soft: update to 1.21.0 from 1.20.1
- - https://github.com/kcat/openal-soft/blob/master/ChangeLog
- libopenmpt: update to 0.4.16 from 0.4.11
- - further update to 0.5.4 will be submitted as a PR at a later date.
- - https://lib.openmpt.org/doc/changelog.html
- - https://lib.openmpt.org/libopenmpt/2020/11/29/releases-0.5.4-0.4.16-0.3.25/