### PR TITLE
heimdal: add patches for automake 1.16+

### DIFF
--- a/packages/devel/heimdal/patches/c4cff6859d183a40fb35a76e2bc1ce084b3a6d67.patch
+++ b/packages/devel/heimdal/patches/c4cff6859d183a40fb35a76e2bc1ce084b3a6d67.patch
@@ -1,0 +1,22 @@
+From c4cff6859d183a40fb35a76e2bc1ce084b3a6d67 Mon Sep 17 00:00:00 2001
+From: Luke Howard <lukeh@padl.com>
+Date: Mon, 24 Dec 2018 02:21:32 +0000
+Subject: [PATCH] hx509: fix dependency, hxtool requires ASN.1 headers
+
+---
+ lib/hx509/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/hx509/Makefile.am b/lib/hx509/Makefile.am
+index c7ef53182d..b21d85202c 100644
+--- a/lib/hx509/Makefile.am
++++ b/lib/hx509/Makefile.am
+@@ -164,7 +164,7 @@ hxtool-commands.c hxtool-commands.h: hxtool-commands.in $(SLC)
+ dist_hxtool_SOURCES = hxtool.c
+ nodist_hxtool_SOURCES = hxtool-commands.c hxtool-commands.h
+ 
+-$(hxtool_OBJECTS): hxtool-commands.h hx509_err.h
++$(hxtool_OBJECTS): hxtool-commands.h $(nodist_include_HEADERS)
+ 
+ hxtool_LDADD = \
+ 	libhx509.la \

--- a/packages/devel/heimdal/patches/cc6a3f337bac0411d0bb1c924fd857603a258d2f.patch
+++ b/packages/devel/heimdal/patches/cc6a3f337bac0411d0bb1c924fd857603a258d2f.patch
@@ -1,0 +1,22 @@
+From cc6a3f337bac0411d0bb1c924fd857603a258d2f Mon Sep 17 00:00:00 2001
+From: Nicolas Williams <nico@twosigma.com>
+Date: Tue, 17 Mar 2020 19:46:37 -0500
+Subject: [PATCH] hcrypto: Fix Makefile build race
+
+---
+ lib/hcrypto/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/hcrypto/Makefile.am b/lib/hcrypto/Makefile.am
+index 195117d174..3c6ee3ca84 100644
+--- a/lib/hcrypto/Makefile.am
++++ b/lib/hcrypto/Makefile.am
+@@ -298,7 +298,7 @@ ltmsources = \
+ 	libtommath/bn_mp_to_unsigned_bin_n.c
+ 
+ 
+-$(libhcrypto_la_OBJECTS): hcrypto-link
++$(libhcrypto_la_OBJECTS) $(test_rand_OBJECTS): hcrypto-link
+ 
+ libhcrypto_la_CPPFLAGS = -DBUILD_HCRYPTO_LIB $(AM_CPPFLAGS)
+ 


### PR DESCRIPTION
Add the patches to allow heimdal to be build by automake 1.16+
Note we are not using automake 1.16 yet.