### PR TITLE
sqlite: cleanup package.mk

### DIFF
--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.3.4"
+PKG_VERSION="3.34.0"
 PKG_SHA256="bf6db7fae37d51754737747aaaf413b4d6b3b5fbacd52bdb2d0d6e5b2edd9aee"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
-PKG_URL="https://www.sqlite.org/2020/${PKG_NAME}-autoconf-${PKG_VERSION//./}0000.tar.gz"
+PKG_URL="https://www.sqlite.org/2020/${PKG_NAME}-autoconf-${PKG_VERSION//./}000.tar.gz"
 PKG_DEPENDS_HOST="ccache:host autoconf:host automake:host"
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="An Embeddable SQL Database Engine."


### PR DESCRIPTION
This is a documentation only change. No versions or file name changes, just correcting the format of the PKG_vERSION field