### PR TITLE
gnutls: update to 3.7.0

### DIFF
--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.6.15"
-PKG_SHA256="0ea8c3283de8d8335d7ae338ef27c53a916f15f382753b174c18b45ffd481558"
+PKG_VERSION="3.7.0"
+PKG_SHA256="49e2a22691d252c9f24a9829b293a8f359095bc5a818351f05f1c0a5188a1df8"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
-PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libidn2 nettle zlib"
 PKG_LONGDESC="A library which provides a secure layer over a reliable transport layer."
 


### PR DESCRIPTION
Update from 3.6.15 (2020-09-04) to 3.7.0 (2020-12-02)

Release Notes:
https://lists.gnupg.org/pipermail/gnutls-help/2020-December/004670.html