### PR TITLE
Pillow: update to 8.1.0

### DIFF
--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="8.0.1"
-PKG_SHA256="004c1fce0d3427fdba9cb67b445aa7f9926ec5c1ba58760942e8c0374239fec0"
+PKG_VERSION="8.1.0"
+PKG_SHA256="b670476feb912d1f07b8f42815ebef13a039cccfd549b2dac84d2a1599f68af8"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update from 8.0.1 (2020-10-22) to 8.1.0 (2020-01-02)
Release notes at:
https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst