### PR TITLE
iwd: update to 1.11

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="1.9"
-PKG_SHA256="1e6803885280da343805ad9997d604e1719c434266b83f1afffe210d55dfaea9"
+PKG_VERSION="1.11"
+PKG_SHA256="db854f569cfa94dc32120d8cf2e7d483a16679f238e1a4794837d0e455ea7aa9"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
upgrade from 1.9 (2020-09-04) to 1.11 (2021-01-07)
Commit logs:
https://git.kernel.org/pub/scm/network/wireless/iwd.git/log/
ver 1.11:
	Add support for ACD client for static configuration.
	Add support for intelligent scan of all frequencies.
ver 1.10:
	Add support for DHCP v6 configuration.
	Add support for DHCP server operation with AP mode.
	Add support for IP allocation during the 4-Way Handshake.
	Add support for P2P Group-owner handling.