### PR TITLE
json-c and ir-bpf-decoders: version cleanup

### DIFF
--- a/packages/addons/addon-depends/ttyd-depends/json-c/package.mk
+++ b/packages/addons/addon-depends/ttyd-depends/json-c/package.mk
@@ -4,10 +4,10 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="json-c"
-PKG_VERSION="9021cdcdd01fc9dbcbe1f06391848c2ac915212f"
-PKG_SHA256="a102249b3f7f11c526d1af6e428f351398620ec3d679458b9ad3cdcfb14ceaaf"
+PKG_VERSION="0.15"
+PKG_SHA256="74985882e39467b34722e584ab836ed2abd47061888f318125fd4b167002afd5"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/json-c/json-c"
-PKG_URL="https://github.com/json-c/json-c/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/json-c/json-c/archive/json-c-${PKG_VERSION%-*}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Implements a reference counting object model that allows you to easily construct JSON objects in C."

--- a/packages/sysutils/ir-bpf-decoders/package.mk
+++ b/packages/sysutils/ir-bpf-decoders/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ir-bpf-decoders"
-PKG_VERSION="v4l-utils-1.20.0"
+PKG_VERSION="1.20.0"
 PKG_SHA256="aaf2b3d0cf3086317a4ee9c2a80af2520b59b303a71238742ee8bc20c4f2bbb6"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://linuxtv.org/"
-PKG_URL="https://github.com/LibreELEC/ir-bpf-decoders/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/LibreELEC/ir-bpf-decoders/archive/v4l-utils-$PKG_VERSION.tar.gz"
 PKG_LONGDESC="ir-bpf-decoders: precompiled binaries of IR BPF decoders from v4l-utils utils/keytable/bpf_protocols"
 PKG_TOOLCHAIN="manual"
 


### PR DESCRIPTION
2 @CvH commits
- json-c is the same version. It is a document change only.
https://github.com/json-c/json-c/releases/tag/json-c-0.15-20200726
- ir-bpf-decoders is just variable updates