### PR TITLE
libarchive: update to 3.5.1

### DIFF
--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libarchive"
-PKG_VERSION="3.5.0"
-PKG_SHA256="245bff9d17e78986bf9716eb887e3bc731d7fd8e5d04efebb8bb1e1c39a3a354"
+PKG_VERSION="3.5.1"
+PKG_SHA256="0e17d3a8d0b206018693b27f08029b598f6ef03600c2b5d10c94ce58692e299b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libarchive.org"
 PKG_URL="https://www.libarchive.org/downloads/$PKG_NAME-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
Minor bump from 3.5.0 to 3.5.1

https://github.com/libarchive/libarchive/releases/tag/3.5.1

bugfixes