### PR TITLE
libgpg-error: update to 1.41

### DIFF
--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpg-error"
-PKG_VERSION="1.39"
-PKG_SHA256="4a836edcae592094ef1c5a4834908f44986ab2b82e0824a0344b49df8cdb298f"
+PKG_VERSION="1.41"
+PKG_SHA256="64b078b45ac3c3003d7e352a5e05318880a5778c42331ce1ef33d1a0d9922742"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.gnupg.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libgpg-error/$PKG_NAME-$PKG_VERSION.tar.bz2"


### PR DESCRIPTION
Upgrade from 1.39 to 1.41

https://files.gnupg.net/file/data/hhjxih2bil66zncwdjf4/PHID-FILE-jo3zbsuftkwqa2omsp22/NEWS

Noteworthy changes in version 1.41 (2020-12-21) [C31/A31/R1]
-----------------------------------------------

Release-info: https://dev.gnupg.org/T5192

 * Fixes another glitch in the "ignore" meta command.
 * Fixes two typos in the German translation.
 


Noteworthy changes in version 1.40 (2020-12-21) [C31/A31/R0]
-----------------------------------------------

Release-info: https://dev.gnupg.org/T5191

 * New function gpgrt_access.
 * Make "ignore" meta command work correctly in the option parser.
 * On Windows gpgrt_getcwd and the internal getusername now handle
   Unicode values.  [#5098]
 * Update the build system.
 * Interface changes relative to the 1.39 release:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 gpgrt_access                     NEW.