### PR TITLE
kodi-waitonnetwork.service: use wait-time-sync

### DIFF
--- a/packages/mediacenter/kodi/system.d/kodi-waitonnetwork.service
+++ b/packages/mediacenter/kodi/system.d/kodi-waitonnetwork.service
@@ -11,7 +11,7 @@ ConditionPathExists=/storage/.kodi/userdata/addon_data/service.libreelec.setting
 [Service]
 Type=oneshot
 EnvironmentFile=/storage/.cache/libreelec/network_wait
-ExecStart=/usr/sbin/connmand-wait-online --timeout=${WAIT_NETWORK_TIME}
+ExecStart=/usr/bin/wait-time-sync --timeout ${WAIT_NETWORK_TIME}
 StandardOutput=tty
 RemainAfterExit=yes
 


### PR DESCRIPTION
Fixup for #4802

Change to wait-time-sync was lost eventually on squash or rebase.