### PR TITLE
buildsystem: check wrong toolchain configuration

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -207,6 +207,25 @@ setup_pkg_config_host() {
   unset PKG_CONFIG_ALLOW_SYSTEM_LIBS
 }
 
+check_toolchain_config() {
+  local target=${1^^}
+  local toolchain=${2^^}
+  local var
+  if [ "${toolchain}" == "AUTOTOOLS" ]; then
+    toolchain="CONFIGURE"
+  fi
+  for var in "${!PKG_@}"; do
+    if [[ "${var}" =~ INSTALL_OPTS_ || "${var}" =~ _MAKE_OPTS ]]; then
+      continue
+    fi
+    if [[ "${var}" =~ _OPTS_${target}$ \
+            && ! "${var}" =~ _${toolchain}_OPTS_${target}$
+          || "${var}" =~ _OPTS$ && ! "${var}" =~ _${toolchain}_OPTS$ ]]; then
+      die "ERROR: using $2 toolchain but ${var} is configured."
+    fi
+  done
+}
+
 setup_toolchain() {
   local have_gold="no"
   if [ "$LTO_SUPPORT" = "yes" ]; then

--- a/scripts/build
+++ b/scripts/build
@@ -114,6 +114,9 @@ if ! listcontains "meson cmake cmake-make configure ninja make autotools manual"
 fi
 build_msg "CLR_TOOLCHAIN" "TOOLCHAIN" "${PKG_TOOLCHAIN}${_auto_toolchain}"
 
+# check wrong toolchain configuration
+check_toolchain_config ${TARGET} ${PKG_TOOLCHAIN}
+
 # setup toolchain
 setup_toolchain ${TARGET} ${PKG_TOOLCHAIN}
 


### PR DESCRIPTION
Check if different toolchain is configured when building package.

Suggested by @CvH in https://github.com/LibreELEC/LibreELEC.tv/pull/4876#issuecomment-755607408

Clean Generic build without addons did succeed without detecting any further packages.
