### PR TITLE
busybox: update to 1.32.1

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="busybox"
-PKG_VERSION="1.32.0"
-PKG_SHA256="c35d87f1d04b2b153d33c275c2632e40d388a88f19a9e71727e0bbbff51fe689"
+PKG_VERSION="1.32.1"
+PKG_SHA256="9d57c4bd33974140fd4111260468af22856f12f5b5ef7c70c8d9b75c712a0dee"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.busybox.net"
 PKG_URL="https://busybox.net/downloads/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
update 1.32.0 (26 June 2020) to 1.32.1-stable (1 January 2021)
changelog: https://www.busybox.net

whilst busybox 1.33.0 has been released it is in the unstable track. 1.32.1 is the released stable. The only change from 1.32.0 is as a bug fix release 1.32.0:
- Bug fix release. 1.32.1 fixes a case where in ash, "wait" never finishes.
- https://git.busybox.net/busybox/log/?h=1_32_stable
