### PR TITLE
linux (default): add patch to fix ite-cir issues

### DIFF
--- a/packages/linux/patches/default/linux-002-fix-ite-cir-timeout.patch
+++ b/packages/linux/patches/default/linux-002-fix-ite-cir-timeout.patch
@@ -1,0 +1,34 @@
+From a42febb1ed2fe7f21833afaa495a7c7e04ba8f80 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sat, 9 Jan 2021 11:59:18 +0100
+Subject: [PATCH] media: rc: ite-cir: fix min_timeout calculation
+
+Commit 528222d853f92 ("media: rc: harmonize infrared durations to
+microseconds") missed to switch the min_timeout calculation from ns
+to us. This resulted in a minimum timeout of 1.2 seconds instead of 1.2ms,
+leading to large delays and long key repeats.
+
+Fix this by applying proper ns->us conversion.
+
+Fixes: 528222d853f92 ("media: rc: harmonize infrared durations to microseconds")
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ drivers/media/rc/ite-cir.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/rc/ite-cir.c b/drivers/media/rc/ite-cir.c
+index a905113fef6e..0c6229592e13 100644
+--- a/drivers/media/rc/ite-cir.c
++++ b/drivers/media/rc/ite-cir.c
+@@ -1551,7 +1551,7 @@ static int ite_probe(struct pnp_dev *pdev, const struct pnp_device_id
+ 	rdev->s_rx_carrier_range = ite_set_rx_carrier_range;
+ 	/* FIFO threshold is 17 bytes, so 17 * 8 samples minimum */
+ 	rdev->min_timeout = 17 * 8 * ITE_BAUDRATE_DIVISOR *
+-			    itdev->params.sample_period;
++			    itdev->params.sample_period / 1000;
+ 	rdev->timeout = IR_DEFAULT_TIMEOUT;
+ 	rdev->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
+ 	rdev->rx_resolution = ITE_BAUDRATE_DIVISOR *
+-- 
+2.20.1
+


### PR DESCRIPTION
min_timeout was calculated wrong, leading to long key repeats

This fixes the issue on NUC reported here: https://forum.libreelec.tv/thread/23211-intel-nightly-build-problem-with-mce-remote/?postID=148823#post148823

Upstream patchwork link: https://patchwork.linuxtv.org/project/linux-media/patch/20210109201055.12051-1-hias@horus.com/