### PR TITLE
liberation-fonts-ttf: update to 2.1.2

### DIFF
--- a/packages/x11/font/liberation-fonts-ttf/package.mk
+++ b/packages/x11/font/liberation-fonts-ttf/package.mk
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="liberation-fonts-ttf"
-PKG_VERSION="2.00.1"
-PKG_SHA256="7890278a6cd17873c57d9cd785c2d230d9abdea837e96516019c5885dd271504"
+PKG_VERSION="2.1.2"
+PKG_SHA256="14694930f28391675008c67b18889d1a7dfea74b16adf50394f8057b57eaf8e0"
 PKG_LICENSE="OFL1_1"
-PKG_SITE="https://www.redhat.com/promo/fonts/"
-PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/liberationfonts/liberation-fonts"
+PKG_URL="https://github.com/liberationfonts/liberation-fonts/files/5722233/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain util-macros"
 PKG_LONGDESC="This packages included the high-quality and open-sourced TrueType vector fonts."
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
update 2.00.1 (Oct 04 2012) to 2.1.2 (Dec 21 2020)
changelog: https://raw.githubusercontent.com/liberationfonts/liberation-fonts/master/ChangeLog

updated the PKG_SITE

All 12 .ttf are still contained in tar file
