### PR TITLE
libdvd: update to Matrix-Beta-2

### DIFF
--- a/packages/multimedia/libdvdcss/package.mk
+++ b/packages/multimedia/libdvdcss/package.mk
@@ -3,8 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdvdcss"
-PKG_VERSION="1.4.2-Leia-Beta-5"
-PKG_SHA256="38816f8373e243bc5950449b4f3b18938c4e1c59348e3411e23f31db4072e40d"
+# From https://github.com/howie-f/libdvdcss/releases/tag/1.4.3-Matrix-Beta-2
+PKG_VERSION="bc00dd5770eea1b71209c279f7af43a66a5327fd"
+PKG_SHA256="976f373888dd782f74b97264799005a6817b43db3805e9d844b94980027a4fbe"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/libdvdcss"
 PKG_URL="https://github.com/xbmc/libdvdcss/archive/$PKG_VERSION.tar.gz"

--- a/packages/multimedia/libdvdnav/package.mk
+++ b/packages/multimedia/libdvdnav/package.mk
@@ -3,8 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdvdnav"
-PKG_VERSION="9277007ce2263b908e9ce3091cc31b3dd87c351c"
-PKG_SHA256="e50db40a823ddc795d1fe5f18db2517fb3e05fe0c4a88abf1578d95d7a1cce63"
+# From https://github.com/howie-f/libdvdnav/releases/tag/6.1.0-Matrix-Beta-2
+PKG_VERSION="724039332ab2d1dab342a279afd74bd436b4a78f" # 2020-12-12
+PKG_SHA256="48469044e38740706d91b738e6233b584a65dfb72b3e7a6c76903c07332046c2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/libdvdnav"
 PKG_URL="https://github.com/xbmc/libdvdnav/archive/$PKG_VERSION.tar.gz"

--- a/packages/multimedia/libdvdread/package.mk
+++ b/packages/multimedia/libdvdread/package.mk
@@ -3,8 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdvdread"
-PKG_VERSION="bd6b329f0137ab6a9f779a28dd96f04713735e17"
-PKG_SHA256="2d9d6d185dd25a983d6dfc2a00207cafdc396a969c227d5edd84b6215b2fba89"
+# From https://github.com/howie-f/libdvdread/releases/tag/6.1.1-Matrix-Beta-2
+PKG_VERSION="ec3b447bb9f2ef4bb64b8e9ebd71ea377a1f4783" # 2020-12-12
+PKG_SHA256="7bc6206a771b5cd4977dcf009793b8f6f4b9ac16e5368c5175f7584e304e53bf"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/libdvdread"
 PKG_URL="https://github.com/xbmc/libdvdread/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Update the libdvd code from Howie-f fork

- https://github.com/howie-f/libdvdcss/releases/tag/1.4.3-Matrix-Beta-2
- https://github.com/howie-f/libdvdnav/releases/tag/6.1.0-Matrix-Beta-2
- https://github.com/howie-f/libdvdread/releases/tag/6.1.1-Matrix-Beta-2

** will need to update once fork is added back upstream