### PR TITLE
sbc: fix linker issue if not x86_64

### DIFF
--- a/packages/audio/sbc/patches/sbc_primitives-Fix-build-on-non-x86.patch
+++ b/packages/audio/sbc/patches/sbc_primitives-Fix-build-on-non-x86.patch
@@ -1,0 +1,39 @@
+From: Marius Bakke <marius@xxxxxxx>
+
+Don't call __builtin_cpu_init unless targeting i386 or x86_64.
+Otherwise we get an error at link time:
+
+  CC       sbc/sbc_primitives.lo
+sbc/sbc_primitives.c: In function ‘sbc_init_primitives_x86’:
+sbc/sbc_primitives.c:596:2: warning: implicit declaration of function ‘__builtin_cpu_init’; did you mean ‘__builtin_irint’? [-Wimplicit-function-declaration]
+[...]
+  CCLD     src/sbcdec
+ld: sbc/.libs/libsbc-private.a(sbc_primitives.o): in function `sbc_init_primitives':
+sbc_primitives.c:(.text+0x3a30): undefined reference to `__builtin_cpu_init'
+---
+ sbc/sbc_primitives.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sbc/sbc_primitives.c b/sbc/sbc_primitives.c
+index 97a75be..09c214a 100644
+--- a/sbc/sbc_primitives.c
++++ b/sbc/sbc_primitives.c
+@@ -593,6 +593,7 @@ static int sbc_calc_scalefactors_j(
+ 
+ static void sbc_init_primitives_x86(struct sbc_encoder_state *state)
+ {
++#if defined(__x86_64__) || defined(__i386__)
+ 	__builtin_cpu_init();
+ 
+ #ifdef SBC_BUILD_WITH_MMX_SUPPORT
+@@ -604,6 +605,7 @@ static void sbc_init_primitives_x86(struct sbc_encoder_state *state)
+ 	if (__builtin_cpu_supports("sse4.2"))
+ 		sbc_init_primitives_sse(state);
+ #endif
++#endif
+ }
+ 
+ /*
+-- 
+2.29.2
+


### PR DESCRIPTION
Ref:
sbc_primitives: Fix build on non-x86
https://www.spinics.net/lists/linux-bluetooth/msg89603.html