### PR TITLE
linux (RPi): update to 5.10.5-a896a00

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="481ccbbbe505c9ac0a9f105a3be86b498a25baa9"
-PKG_SHA256="78010d22c9011bd2e4d9f53f0bfd1495b742d2b939b98207484b5f8db3e9c92f"
+PKG_VERSION="e542b67e7f5487d222aa39b3e9ee780a5dbbb9eb"
+PKG_SHA256="02e529b42b463bffa70b46bd3c06ef010a78e7dad00fff663d9c46a0f7325167"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -16,8 +16,8 @@ PKG_PATCH_DIRS="$LINUX"
 
 case "$LINUX" in
   raspberrypi)
-    PKG_VERSION="b32354539bd4e3cff29eda643b5d3a983a24c063" # 5.10.4
-    PKG_SHA256="ca4731ace105c456e0f7b6676b159ea3ddc38a9c7757ba8358a7e2b9714858c7"
+    PKG_VERSION="a896a00ebffd0b016627f65ff236b660e66e782b" # 5.10.5
+    PKG_SHA256="654cb832818ec70022c6c4d880a8ca4795603af850f285894899a23f302c4de3"
     PKG_URL="https://github.com/raspberrypi/linux/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="481ccbbbe505c9ac0a9f105a3be86b498a25baa9"
-PKG_SHA256="93cb950bdb79bbffc540e449ac3bda0fed70275114133a91256f72faaf0c7358"
+PKG_VERSION="e542b67e7f5487d222aa39b3e9ee780a5dbbb9eb"
+PKG_SHA256="0c8dcef7e86649332fbf1a1c8d432000c4d02ba74d3bd40a1c2d9d14b2e200bd"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="54a9796abbee59067bff9da6b90c1014178f2c21"
-PKG_SHA256="64f8a6c9efcf4d9e0a7e707cfe60cd32ed4ca516ce5f67af52c28c09f1012224"
+PKG_VERSION="2318f44baa57a6b2c877b7cd7cbdedca07bd4f28"
+PKG_SHA256="07b9d860903e0bfc2857561e4262362e84bd4497cad56aa890cd61882a3e8ae1"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"


### PR DESCRIPTION
SD card filesystem corruption on RPi0-3 is fixed, tested on RPi2B and RPi3B+

RPi4 HD audio improvements are also included, tested with DTS HD MA and Dolby Atmos samples