### PR TITLE
NXP: make images indepent from cpu-cores

### DIFF
--- a/projects/NXP/devices/iMX6/bootloader/mkimage
+++ b/projects/NXP/devices/iMX6/bootloader/mkimage
@@ -10,3 +10,30 @@ if [ -f "$RELEASE_DIR/3rdparty/bootloader/SPL" ]; then
   echo "Writing SPL to $(basename $DISK)"
   dd if="$RELEASE_DIR/3rdparty/bootloader/SPL" of="$DISK" bs=1K seek=1 conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
 fi
+  echo "image: copying device trees..."
+  declare -i dtbfiles
+  dtbfiles=0
+  for file in ${DTB[@]}; do
+    if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${file}" ]; then
+       echo "image: ${file} added"
+       dtbfiles=${dtbfiles}+1
+       mcopy -s -o "${RELEASE_DIR}/3rdparty/bootloader"/${file} ::
+    fi
+  done
+
+  echo "image: creating extlinux.conf file..."
+    if [ "${dtbfiles}" -gt 1 ]; then
+       echo "image: setting up u-boot using 'FDTDIR /' with ${dtbfiles} files "
+    else
+       echo "image: setting up u-boot using 'FDTDIR /' with single file '${DTB}'"
+    fi
+
+  mkdir -p "${LE_TMP}/extlinux"
+  cat << EOF > "${LE_TMP}/extlinux/extlinux.conf"
+LABEL ${DISTRO}
+  LINUX /${KERNEL_NAME}
+  FDTDIR /
+  APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} quiet ${EXTRA_CMDLINE}
+EOF
+  mcopy -s -o "${LE_TMP}/extlinux" ::
+

--- a/projects/NXP/devices/iMX6/bootloader/update.sh
+++ b/projects/NXP/devices/iMX6/bootloader/update.sh
@@ -3,16 +3,17 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
+
 [ -z "$SYSTEM_ROOT" ] && SYSTEM_ROOT=""
 [ -z "$BOOT_ROOT" ] && BOOT_ROOT="/flash"
 [ -z "$BOOT_PART" ] && BOOT_PART=$(df "$BOOT_ROOT" | tail -1 | awk {' print $1 '})
 if [ -z "$BOOT_DISK" ]; then
   case $BOOT_PART in
     /dev/sd[a-z][0-9]*)
-      BOOT_DISK=$(echo $BOOT_PART | sed -e "s,[0-9]*,,g")
+      BOOT_DISK=$(echo "$BOOT_PART" | sed -e "s,[0-9]*,,g")
       ;;
     /dev/mmcblk*)
-      BOOT_DISK=$(echo $BOOT_PART | sed -e "s,p[0-9]*,,g")
+      BOOT_DISK=$(echo "$BOOT_PART" | sed -e "s,p[0-9]*,,g")
       ;;
   esac
 fi
@@ -20,24 +21,51 @@ fi
 # mount $BOOT_ROOT r/w
   mount -o remount,rw $BOOT_ROOT
 
-# update Device Tree Blobs
-  for all_dtb in /flash/*.dtb; do
-    dtb=$(basename $all_dtb)
-    if [ -f $SYSTEM_ROOT/usr/share/bootloader/$dtb ]; then
-      echo "*** updating Device Tree Blob: $dtb ..."
-      cp -p $SYSTEM_ROOT/usr/share/bootloader/$dtb $BOOT_ROOT
-    fi
-  done
-
-# update bootloader files
-  if [ -f $SYSTEM_ROOT/usr/share/bootloader/u-boot.img ]; then
-    echo "*** updating u-boot image on: $BOOT_DISK ..."
-    dd if=$SYSTEM_ROOT/usr/share/bootloader/u-boot.img of="$BOOT_DISK" bs=1K seek=69 conv=fsync &>/dev/null
+# update EXTLINUX.CONF to FDTDIR
+  echo "*** checking extlinux.conf on: $BOOT_DISK ..."
+  if ! grep -q "FDTDIR /" $BOOT_ROOT/extlinux/extlinux.conf; then
+     # update EXTLINUX.CONF to FDTDIR
+     echo "*** updating extlinux.conf to use FDTDIR on: $BOOT_DISK ..."
+     sed -i 's#FDT .*$#FDTDIR /#' $BOOT_ROOT/extlinux/extlinux.conf &>/dev/null
+     for dtbfile in /"$BOOT_ROOT"/*.dtb ; do
+        if [ -f "$dtbfile" ]; then
+           dtb=$(basename "$dtbfile")
+           [ "${dtb%imx6dl*}" != "$dtb" ] && dtb="${dtb%imx6dl*}imx6q${dtb#*imx6dl}"
+           if ! [ -f /"$BOOT_ROOT"/"$dtb" ]; then
+              if [ -f "$SYSTEM_ROOT"/usr/share/bootloader/"$dtb" ]; then
+                 echo "*** adding new Device Tree Blob: $dtb ..."
+                 cp -p "$SYSTEM_ROOT"/usr/share/bootloader/"$dtb" "$BOOT_ROOT"/ &>/dev/null                 
+              fi
+           fi
+           [ "${dtb%imx6q*}" != "$dtb" ] && dtb="${dtb%imx6q*}imx6dl${dtb#*imx6q}"
+           if ! [ -f /"$BOOT_ROOT"/"$dtb" ]; then
+              if [ -f "$SYSTEM_ROOT"/usr/share/bootloader/"$dtb" ]; then
+                 echo "*** adding new Device Tree Blob: $dtb ..."
+                 cp -p "$SYSTEM_ROOT"/usr/share/bootloader/"$dtb" "$BOOT_ROOT"/ &>/dev/null                 
+              fi
+           fi
+        fi
+     done
   fi
 
-  if [ -f $SYSTEM_ROOT/usr/share/bootloader/SPL ]; then
+# update Device Tree Blobs
+    for all_dtb in $BOOT_ROOT/*.dtb ; do
+      dtb=$(basename "$all_dtb")
+      if [ -f "$SYSTEM_ROOT"/usr/share/bootloader/"$dtb" ]; then
+        echo "*** updating Device Tree Blob: $dtb ..."
+        cp -p "$SYSTEM_ROOT"/usr/share/bootloader/"$dtb" "$BOOT_ROOT"/ &>/dev/null
+      fi
+    done
+
+# update bootloader files
+  if [ -f "$SYSTEM_ROOT"/usr/share/bootloader/u-boot.img ]; then
+    echo "*** updating u-boot image on: $BOOT_DISK ..."
+    dd if="$SYSTEM_ROOT"/usr/share/bootloader/u-boot.img of="$BOOT_DISK" bs=1K seek=69 conv=fsync &>/dev/null
+  fi
+
+  if [ -f "$SYSTEM_ROOT"/usr/share/bootloader/SPL ]; then
     echo "*** updating u-boot SPL Blob on: $BOOT_DISK ..."
-    dd if=$SYSTEM_ROOT/usr/share/bootloader/SPL of="$BOOT_DISK" bs=1k seek=1 conv=fsync &>/dev/null
+    dd if="$SYSTEM_ROOT"/usr/share/bootloader/SPL of="$BOOT_DISK" bs=1k seek=1 conv=fsync &>/dev/null
   fi
 
 # mount $BOOT_ROOT r/o

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -214,17 +214,27 @@ elif [ "${BOOTLOADER}" = "u-boot" -a -n "${UBOOT_SYSTEM}" ]; then
 
   DTB="$(${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb)"
   if [ -n "${DTB}" ]; then
-
-    if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ]; then
-      mcopy "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ::
+    mkdir -p "${LE_TMP}/dtbs"
+    while IFS= read -r -d '' file; do
+      echo "image: adding device tree file $(basename "$file")"
+      mcopy -n "$file" "${LE_TMP}/dtbs/$(basename "$file")"
+    done < <(find "${RELEASE_DIR}/3rdparty/bootloader/" -maxdepth 1 -name "${DTB}" -print0)
+    dtbfiles=$(find "${RELEASE_DIR}/3rdparty/bootloader/" -maxdepth 1 -name "${DTB}" -printf '.' | wc -c)
+    if [ "${dtbfiles}" -gt 1 ]; then
+       FDTSTRING="FDTDIR /dtbs"
+       echo "image: u-boot using ${dtbfiles} device tree files in folder /dtbs"
+    else
+       FDTSTRING="FDT /dtbs/${DTB}"
+       echo "image: u-boot using single device tree file /dtbs/${DTB}"
     fi
+    mcopy -s "${LE_TMP}/dtbs" ::
 
     mkdir -p "${LE_TMP}/extlinux"
 
     cat << EOF > "${LE_TMP}/extlinux/extlinux.conf"
 LABEL ${DISTRO}
   LINUX /${KERNEL_NAME}
-  FDT /${DTB}
+  ${FDTSTRING}
   APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} quiet ${EXTRA_CMDLINE}
 EOF
 

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -214,27 +214,17 @@ elif [ "${BOOTLOADER}" = "u-boot" -a -n "${UBOOT_SYSTEM}" ]; then
 
   DTB="$(${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb)"
   if [ -n "${DTB}" ]; then
-    mkdir -p "${LE_TMP}/dtbs"
-    while IFS= read -r -d '' file; do
-      echo "image: adding device tree file $(basename "$file")"
-      mcopy -n "$file" "${LE_TMP}/dtbs/$(basename "$file")"
-    done < <(find "${RELEASE_DIR}/3rdparty/bootloader/" -maxdepth 1 -name "${DTB}" -print0)
-    dtbfiles=$(find "${RELEASE_DIR}/3rdparty/bootloader/" -maxdepth 1 -name "${DTB}" -printf '.' | wc -c)
-    if [ "${dtbfiles}" -gt 1 ]; then
-       FDTSTRING="FDTDIR /dtbs"
-       echo "image: u-boot using ${dtbfiles} device tree files in folder /dtbs"
-    else
-       FDTSTRING="FDT /dtbs/${DTB}"
-       echo "image: u-boot using single device tree file /dtbs/${DTB}"
+
+    if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ]; then
+      mcopy "${RELEASE_DIR}/3rdparty/bootloader/${DTB}" ::
     fi
-    mcopy -s "${LE_TMP}/dtbs" ::
 
     mkdir -p "${LE_TMP}/extlinux"
 
     cat << EOF > "${LE_TMP}/extlinux/extlinux.conf"
 LABEL ${DISTRO}
   LINUX /${KERNEL_NAME}
-  ${FDTSTRING}
+  FDT /${DTB}
   APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} quiet ${EXTRA_CMDLINE}
 EOF
 

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -215,11 +215,16 @@ elif [ "${BOOTLOADER}" = "u-boot" -a -n "${UBOOT_SYSTEM}" ]; then
   DTB="$(${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb)"
   if [ -n "${DTB}" ]; then
     mkdir -p "${LE_TMP}/dtbs"
-    while IFS= read -r -d '' file; do
-      echo "image: adding device tree file $(basename "$file")"
-      mcopy -n "$file" "${LE_TMP}/dtbs/$(basename "$file")"
-    done < <(find "${RELEASE_DIR}/3rdparty/bootloader/" -maxdepth 1 -name "${DTB}" -print0)
-    dtbfiles=$(find "${RELEASE_DIR}/3rdparty/bootloader/" -maxdepth 1 -name "${DTB}" -printf '.' | wc -c)
+    OLDIFS="$IFS"    
+    IFS=';'
+    for file in ${DTB[@]}; do
+      if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${file}" ]; then
+        echo "image: adding device tree file ${file}"
+        mcopy "${RELEASE_DIR}/3rdparty/bootloader/${file}" "${LE_TMP}/dtbs/${file}"
+      fi
+    done
+    IFS="${OLDIFS}"
+    dtbfiles=$(find "${LE_TMP}/dtbs/" -maxdepth 1 -name "*.dtb" -printf '.' | wc -c)
     if [ "${dtbfiles}" -gt 1 ]; then
        FDTSTRING="FDTDIR /dtbs"
        echo "image: u-boot using ${dtbfiles} device tree files in folder /dtbs"

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -215,16 +215,11 @@ elif [ "${BOOTLOADER}" = "u-boot" -a -n "${UBOOT_SYSTEM}" ]; then
   DTB="$(${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} dtb)"
   if [ -n "${DTB}" ]; then
     mkdir -p "${LE_TMP}/dtbs"
-    OLDIFS="$IFS"    
-    IFS=';'
-    for file in ${DTB[@]}; do
-      if [ -f "${RELEASE_DIR}/3rdparty/bootloader/${file}" ]; then
-        echo "image: adding device tree file ${file}"
-        mcopy "${RELEASE_DIR}/3rdparty/bootloader/${file}" "${LE_TMP}/dtbs/${file}"
-      fi
-    done
-    IFS="${OLDIFS}"
-    dtbfiles=$(find "${LE_TMP}/dtbs/" -maxdepth 1 -name "*.dtb" -printf '.' | wc -c)
+    while IFS= read -r -d '' file; do
+      echo "image: adding device tree file $(basename "$file")"
+      mcopy -n "$file" "${LE_TMP}/dtbs/$(basename "$file")"
+    done < <(find "${RELEASE_DIR}/3rdparty/bootloader/" -maxdepth 1 -name "${DTB}" -print0)
+    dtbfiles=$(find "${RELEASE_DIR}/3rdparty/bootloader/" -maxdepth 1 -name "${DTB}" -printf '.' | wc -c)
     if [ "${dtbfiles}" -gt 1 ]; then
        FDTSTRING="FDTDIR /dtbs"
        echo "image: u-boot using ${dtbfiles} device tree files in folder /dtbs"

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -194,16 +194,20 @@ devices = \
   },
   'NXP': {
     'iMX6': {
+      'generic': {
+        'dtb': '*.dtb',
+        'config': 'mx6cuboxi_defconfig'
+      },
       'cubox': {
-        'dtb': 'imx6dl-cubox-i.dtb;imx6dl-cubox-i-emmc-som-v15.dtb;imx6dl-cubox-i-som-v15.dtb;imx6q-cubox-i.dtb;imx6q-cubox-i-emmc-som-v15.dtb;imx6q-cubox-i-som-v15.dtb',
+        'dtb': '*cubox*.dtb',
         'config': 'mx6cuboxi_defconfig'
       },
       'udoo': {
-        'dtb': 'imx6dl-udoo.dtb imx6q-udoo.dtb',
+        'dtb': '*udoo*.dtb',
         'config': 'udoo_defconfig'
       },
       'wandboard': {
-        'dtb': 'imx6dl-wandboard.dtb imx6dl-wandboard-revb1.dtb imx6dl-wandboard-revd1.dtb imx6dl-wandboard.dtb imx6dl-wandboard-revb1.dtb imx6dl-wandboard-revd1.dtb',
+        'dtb': '*wandboard*.dtb',
         'config': 'wandboard_defconfig'
       },
     },

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -194,20 +194,16 @@ devices = \
   },
   'NXP': {
     'iMX6': {
-      'generic': {
-        'dtb': '*.dtb',
-        'config': 'mx6cuboxi_defconfig'
-      },
       'cubox': {
-        'dtb': '*cubox*.dtb',
+        'dtb': 'imx6dl-cubox-i.dtb;imx6dl-cubox-i-emmc-som-v15.dtb;imx6dl-cubox-i-som-v15.dtb;imx6q-cubox-i.dtb;imx6q-cubox-i-emmc-som-v15.dtb;imx6q-cubox-i-som-v15.dtb',
         'config': 'mx6cuboxi_defconfig'
       },
       'udoo': {
-        'dtb': '*udoo*.dtb',
+        'dtb': 'imx6dl-udoo.dtb imx6q-udoo.dtb',
         'config': 'udoo_defconfig'
       },
       'wandboard': {
-        'dtb': '*wandboard*.dtb',
+        'dtb': 'imx6dl-wandboard.dtb imx6dl-wandboard-revb1.dtb imx6dl-wandboard-revd1.dtb imx6dl-wandboard.dtb imx6dl-wandboard-revb1.dtb imx6dl-wandboard-revd1.dtb',
         'config': 'wandboard_defconfig'
       },
     },

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -194,28 +194,20 @@ devices = \
   },
   'NXP': {
     'iMX6': {
-      'cubox-dl': {
-        'dtb': 'imx6dl-cubox-i.dtb',
+      'generic': {
+        'dtb': '*.dtb',
         'config': 'mx6cuboxi_defconfig'
       },
-      'cubox-q': {
-        'dtb': 'imx6q-cubox-i.dtb',
+      'cubox': {
+        'dtb': '*cubox*.dtb',
         'config': 'mx6cuboxi_defconfig'
       },
-      'udoo-dl': {
-        'dtb': 'imx6dl-udoo.dtb',
+      'udoo': {
+        'dtb': '*udoo*.dtb',
         'config': 'udoo_defconfig'
       },
-      'udoo-q': {
-        'dtb': 'imx6q-udoo.dtb',
-        'config': 'udoo_defconfig'
-      },
-      'wandboard-dl': {
-        'dtb': 'imx6dl-wandboard.dtb',
-        'config': 'wandboard_defconfig'
-      },
-      'wandboard-q': {
-        'dtb': 'imx6q-wandboard.dtb',
+      'wandboard': {
+        'dtb': '*wandboard*.dtb',
         'config': 'wandboard_defconfig'
       },
     },

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -194,28 +194,16 @@ devices = \
   },
   'NXP': {
     'iMX6': {
-      'cubox-dl': {
-        'dtb': 'imx6dl-cubox-i.dtb',
+     'cubox': {
+        'dtb': 'imx6dl-cubox-i.dtb imx6q-cubox-i.dtb',
         'config': 'mx6cuboxi_defconfig'
       },
-      'cubox-q': {
-        'dtb': 'imx6q-cubox-i.dtb',
-        'config': 'mx6cuboxi_defconfig'
-      },
-      'udoo-dl': {
-        'dtb': 'imx6dl-udoo.dtb',
+      'udoo': {
+        'dtb': 'imx6dl-udoo.dtb imx6q-udoo.dtb',
         'config': 'udoo_defconfig'
       },
-      'udoo-q': {
-        'dtb': 'imx6q-udoo.dtb',
-        'config': 'udoo_defconfig'
-      },
-      'wandboard-dl': {
-        'dtb': 'imx6dl-wandboard.dtb',
-        'config': 'wandboard_defconfig'
-      },
-      'wandboard-q': {
-        'dtb': 'imx6q-wandboard.dtb',
+      'wandboard': {
+        'dtb': 'imx6dl-wandboard.dtb imx6q-wandboard.dtb',
         'config': 'wandboard_defconfig'
       },
     },

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -194,20 +194,28 @@ devices = \
   },
   'NXP': {
     'iMX6': {
-      'generic': {
-        'dtb': '*.dtb',
+      'cubox-dl': {
+        'dtb': 'imx6dl-cubox-i.dtb',
         'config': 'mx6cuboxi_defconfig'
       },
-      'cubox': {
-        'dtb': '*cubox*.dtb',
+      'cubox-q': {
+        'dtb': 'imx6q-cubox-i.dtb',
         'config': 'mx6cuboxi_defconfig'
       },
-      'udoo': {
-        'dtb': '*udoo*.dtb',
+      'udoo-dl': {
+        'dtb': 'imx6dl-udoo.dtb',
         'config': 'udoo_defconfig'
       },
-      'wandboard': {
-        'dtb': '*wandboard*.dtb',
+      'udoo-q': {
+        'dtb': 'imx6q-udoo.dtb',
+        'config': 'udoo_defconfig'
+      },
+      'wandboard-dl': {
+        'dtb': 'imx6dl-wandboard.dtb',
+        'config': 'wandboard_defconfig'
+      },
+      'wandboard-q': {
+        'dtb': 'imx6q-wandboard.dtb',
         'config': 'wandboard_defconfig'
       },
     },


### PR DESCRIPTION
This PR switches NXP/iMX6 project to create images independent from the number of cpu-cores (single, dual, quad)
scripts/mkimage has been reworked to switch between using single device tree file ("FDT /dtbs/example.dtb") and multiple files ("FDTDIR /dtbs")
scripts/uboot_helper has been reworked to strip options down to "cubox", "udoo" and "wandboard"