### PR TITLE
arm-mem: update to 2019-04-30

### DIFF
--- a/packages/devel/arm-mem/package.mk
+++ b/packages/devel/arm-mem/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="arm-mem"
-PKG_VERSION="010044568a9691bb375e86a96f7e26495f5c5d6e"
-PKG_SHA256="7a73fc64e0c56b2257f3a4d6d0facee078da74a8a98761823ebf266d57381fd5"
+PKG_VERSION="b48ea154fd74410022d8189003cd69fad8f3d02c" # Apr 30, 2019
+PKG_SHA256="93240defef3abba7d42a7420e55ae4f8b90cc99ef16044fdfb8b5820a17e766d"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/bavison/arm-mem"


### PR DESCRIPTION
update from 0100445 (15 Mar 2019) to b48ea15 (30 Apr 2019)

changelog: https://github.com/bavison/arm-mem/commits/master

Included in this release are: 
- ARMv7: Ensure memcmp return value is always -1, 0 or +1
While other values are permitted by ISO, there are some fears that since
these are the values returned by glibc, we may expose latent bugs by
doing anything different.

this is the same version as is being used in https://github.com/RPi-Distro/arm-mem/tree/debian