### PR TITLE
meson: update to 0.57.0

### DIFF
--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="0.56.0"
-PKG_SHA256="291dd38ff1cd55fcfca8fc985181dd39be0d3e5826e5f0013bf867be40117213"
+PKG_VERSION="0.57.0"
+PKG_SHA256="7ccb75fe1a4d404bcab86e72678abc7f75793401aa9054f881a4eb3cb990f5d9"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update from 0.56.0 (30 Oct 2020) to 0.56.2 (15 Feb 2021)
changelogs:
- https://github.com/mesonbuild/meson/milestone/55?closed=1
- https://github.com/mesonbuild/meson/milestone/56?closed=1
- https://github.com/mesonbuild/meson/milestone/54?closed=1

release notes:
- https://mesonbuild.com/Release-notes-for-0-57-0.html