### PR TITLE
fakeroot: update to 1.25.3

### DIFF
--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -3,12 +3,18 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fakeroot"
-PKG_VERSION="1.24"
-PKG_SHA256="2e045b3160370b8ab4d44d1f8d267e5d1d555f1bb522d650e7167b09477266ed"
+PKG_VERSION="1.25.3"
+PKG_SHA256="8e903683357f7f5bcc31b879fd743391ad47691d4be33d24a76be3b6c21e956c"
 PKG_LICENSE="GPL3"
-PKG_SITE="http://freshmeat.sourceforge.net/projects/fakeroot"
+PKG_SITE="https://tracker.debian.org/pkg/fakeroot"
 PKG_URL="http://ftp.debian.org/debian/pool/main/f/fakeroot/${PKG_NAME}_${PKG_VERSION}.orig.tar.gz"
-PKG_DEPENDS_HOST="ccache:host libcap:host"
+PKG_DEPENDS_HOST="ccache:host libcap:host autoconf:host libtool:host"
 PKG_LONGDESC="fakeroot provides a fake root environment by means of LD_PRELOAD and SYSV IPC (or TCP) trickery."
+PKG_TOOLCHAIN="configure"
 
 PKG_CONFIGURE_OPTS_HOST="--with-gnu-ld"
+
+pre_configure_host() {
+  cd $PKG_BUILD
+  ./bootstrap
+}

--- a/packages/devel/fakeroot/patches/fakeroot-001-disable-docs-tests.patch
+++ b/packages/devel/fakeroot/patches/fakeroot-001-disable-docs-tests.patch
@@ -1,0 +1,23 @@
+--- fakeroot-1.25.3/configure.ac	2020-10-08 17:13:18.000000000 +0000
++++ fakeroot-1.25.3/configure.ac	2021-01-10 03:57:50.295218481 +0000
+@@ -597,9 +597,7 @@
+ AC_CONFIG_FILES([
+    Makefile
+    scripts/Makefile
+-   doc/Makefile
+-   doc/de/Makefile doc/es/Makefile doc/fr/Makefile doc/nl/Makefile doc/pt/Makefile doc/sv/Makefile
+-   test/Makefile test/defs])
++   ])
+ AC_OUTPUT
+ 
+ dnl Local variables:
+--- fakeroot-1.25.3/Makefile.am	2020-10-08 17:13:18.000000000 +0000
++++ fakeroot-1.25.3/Makefile.am	2021-01-10 04:02:06.703081728 +0000
+@@ -1,6 +1,6 @@
+ AUTOMAKE_OPTIONS=foreign
+ ACLOCAL_AMFLAGS = -I build-aux
+-SUBDIRS=doc scripts test
++SUBDIRS=scripts
+ 
+ noinst_LTLIBRARIES = libcommunicate.la libmacosx.la
+ libcommunicate_la_SOURCES = communicate.c


### PR DESCRIPTION
update 1.24 (2019-09-07) to 1.25.3 (2020-10-08)
changelog: https://salsa.debian.org/clint/fakeroot/-/blob/master/debian/changelog
update PKG_SITE and do not build docs/tests