### PR TITLE
nss: update to 3.60.1

### DIFF
--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.60"
-PKG_SHA256="850deb3f4d49703618b64ca5c0ca92d2f195e0e41d7124f7b2149a6ca9eaae1f"
+PKG_VERSION="3.60.1"
+PKG_SHA256="696b2abca0f76848484d82fd614b0020966f1e97cd8902f1ec28bbeb301a22fb"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
-PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION/./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"
+PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"
 PKG_DEPENDS_HOST="nspr:host zlib:host"
 PKG_DEPENDS_TARGET="toolchain nss:host nspr zlib sqlite"
 PKG_LONGDESC="The Network Security Services (NSS) package is a set of libraries designed to support cross-platform development of security-enabled client and server applications"


### PR DESCRIPTION
update 3.60 (11-Dec-2020) to 3.60.1 (04-Jan-2021)
https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.60.1_release_notes