### PR TITLE
enet: update to 1.3.17+vita

### DIFF
--- a/packages/addons/addon-depends/enet/package.mk
+++ b/packages/addons/addon-depends/enet/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="enet"
-PKG_VERSION="e33ca1dc47635882bfcadd192dbc54ea8584cbc5"
-PKG_SHA256="0ba5547de2c4c7fc79d367179a9bc92a7ac27e9258dd50fb277cd8761afaf9b0"
-PKG_LICENSE=""
+PKG_VERSION="d9e561938fd9360cdbbd67d78b105ccbe4af0a65" # 10 Jan 2021 # 1.3.17+vita
+PKG_SHA256="ff52ea54edb71662d5933b165c073f079c90ed9adcf98bcb7b2e74d4ddf3dc6b"
+PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/cgutman/enet/"
 PKG_URL="https://github.com/cgutman/enet/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"


### PR DESCRIPTION
update e33ca1d (1.3.13+vita) (2 Oct 2016) to 1.3.17+vita (10 Jan 2021)
changelog: https://raw.githubusercontent.com/cgutman/enet/moonlight/ChangeLog

**this is only used by libretro.dolphin**