### PR TITLE
pngquant: update to 2.13.1

### DIFF
--- a/packages/addons/addon-depends/pngquant/package.mk
+++ b/packages/addons/addon-depends/pngquant/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pngquant"
-PKG_VERSION="2.12.0"
-PKG_SHA256="0e540c64bb58c05f2a05b4eaf1d3d165f0d3278500f15abfeac47f93f8fa8fa8"
+PKG_VERSION="2.13.1"
+PKG_SHA256="4b911a11aa0c35d364b608c917d13002126185c8c314ba4aa706b62fd6a95a7a"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://pngquant.org"
-PKG_URL="http://pngquant.org/pngquant-${PKG_VERSION}-src.tar.gz"
+PKG_URL="https://pngquant.org/pngquant-${PKG_VERSION}-src.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host libpng:host zlib:host"
 PKG_LONGDESC="A lossy PNG compressor."
 


### PR DESCRIPTION
update 2.12.0 (2018-06-04) to 2.13.1 (2020-11-23)

the library has had a big bump, 
number of releases between 2.12.0 and 2.13.1 - being 2.12.1,2,3,4,5,6 and 2.13.0

changelogs:
- https://raw.githubusercontent.com/kornelski/pngquant/master/CHANGELOG
- https://github.com/kornelski/pngquant/compare/2.12.0...2.13.1
- https://github.com/ImageOptim/libimagequant/compare/feae85c61f58c1453f5c73ba3a32458b81750f42...5ea4f8a3c3186fa83e1e7c08c9238e071eedb95f

Used by tvheadend42 as pngquant:host