### PR TITLE
rpi-tools: update addon (109)

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/gpiozero/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/gpiozero/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gpiozero"
-PKG_VERSION="1.5.0"
-PKG_SHA256="5075c93f61e1ca4f7813544a9e7ef238e77482b47a5602b8e40c71f177930585"
+PKG_VERSION="1.5.1"
+PKG_SHA256="ae1a8dc4e6e793ffd8f900968f3290d218052c46347fa0c0503c65fabe422e4d"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/RPi-Distro/python-gpiozero"

--- a/packages/addons/tools/rpi-tools/changelog.txt
+++ b/packages/addons/tools/rpi-tools/changelog.txt
@@ -1,3 +1,6 @@
+109
+- Update gpiozero to 1.5.1
+
 108
 - Remove legacy camera tools
 

--- a/packages/addons/tools/rpi-tools/package.mk
+++ b/packages/addons/tools/rpi-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rpi-tools"
 PKG_VERSION="1.0"
-PKG_REV="108"
+PKG_REV="109"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
gpiozero: update to 1.5.1
- update 1.5.0 (13 Feb 2019) to 1.5.1 (25 Jun 2019)
- **changelog**:
- https://raw.githubusercontent.com/gpiozero/gpiozero/master/debian/changelog