### PR TITLE
i2c-tools: fix dest PREFIX to /usr

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
@@ -27,7 +27,7 @@ make_target() {
 
 makeinstall_target() {
   make  DESTDIR=${INSTALL} \
-        prefix="/usr" \
+        PREFIX="/usr" \
         EXTRA="py-smbus" \
         PYTHON=${TOOLCHAIN}/bin/python3 \
         install

--- a/packages/addons/addon-depends/system-tools-depends/i2c-tools/patches/pyinstalldir.patch
+++ b/packages/addons/addon-depends/system-tools-depends/i2c-tools/patches/pyinstalldir.patch
@@ -6,7 +6,7 @@ diff -ur a/py-smbus/Module.mk b/py-smbus/Module.mk
  
  install-python:
 -	$(DISTUTILS) install
-+	$(DISTUTILS) install --prefix=$(DESTDIR)$(prefix)
++	$(DISTUTILS) install --prefix=$(DESTDIR)$(PREFIX)
  
  all: all-python
  


### PR DESCRIPTION
Both prefix and PREFIX are used in i2c-tools since version 4.1. Added PREFIX to makeinstall_target.

```
py-smbus/Module.mk:       $(DISTUTILS) install --prefix=$(DESTDIR)$(prefix)
Makefile:PREFIX   ?= /usr/local
```

test built both 
```
PROJECT=Generic ARCH=x86_64 scripts/create_addon system-tools
PROJECT=Allwinner ARCH=arm DEVICE=H6 UBOOT_SYSTEM=tanix-tx6 s/create_addon  system-tools
```