### PR TITLE
qca-firmware: remove reference from Amlogic firmware

### DIFF
--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -55,7 +55,7 @@
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="dvb-firmware brcmfmac_sdio-firmware kernel-firmware qca-firmware"
+    FIRMWARE="dvb-firmware brcmfmac_sdio-firmware kernel-firmware"
 
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"


### PR DESCRIPTION
Cleanup reference from https://github.com/LibreELEC/LibreELEC.tv/pull/4626

**fixes**
```
Traceback (most recent call last):
  File "scripts/genbuildplan.py", line 367, in <module>
    REQUIRED_PKGS = processPackages(args, ALL_PACKAGES)
  File "scripts/genbuildplan.py", line 296, in processPackages
    raise Exception(msg)
Exception: Invalid package reference: dependency qca-firmware in package linux-firmware::PKG_DEPENDS_TARGET is not valid
Parallel build failure - see log for details. Time of failure: Tue Jan 12 13:23:47 UTC 2021
Makefile:12: recipe for target 'image' failed
make: *** [image] Error 1
```