### PR TITLE
vdr-addon updates

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-vnsiserver/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-vnsiserver/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-vnsiserver"
-PKG_VERSION="49003f036609ee2a0b8d819979c063d8f8d348c8"
-PKG_SHA256="fc64c343685bf87e4cc14018bcf642cba9aa637adfe1ab21725a19945c620737"
+PKG_VERSION="908684b58a3ebd4a447bc4b0a82b0bd8059bf605"
+PKG_SHA256="6c39a2e9854632274cec2b11e4eaaea9edc4095856941672f40d0633ece506df"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/FernetMenta/vdr-plugin-vnsiserver"
-PKG_URL="https://github.com/FernetMenta/vdr-plugin-vnsiserver/archive/$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/mdre77/vdr-plugin-vnsiserver"
+PKG_URL="https://github.com/mdre77/vdr-plugin-vnsiserver/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain vdr"
 PKG_NEED_UNPACK="$(get_pkg_directory vdr)"
 PKG_LONGDESC="VDR plugin to handle Kodi clients."

--- a/packages/addons/addon-depends/vdr/package.mk
+++ b/packages/addons/addon-depends/vdr/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr"
-PKG_VERSION="2.4.4"
-PKG_SHA256="8a04d12af73d15daed2f9864a9ca0cfb25400da388c41e8476048c61b7ee2c5a"
+PKG_VERSION="2.4.6"
+PKG_SHA256="c8993babf2a878a0fba84558de1e35f042c3c66f7c1ec569eea00a3af1014e4b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvdr.de"
 PKG_URL="http://ftp.tvdr.de/vdr-$PKG_VERSION.tar.bz2"

--- a/packages/addons/service/vdr-addon/changelog.txt
+++ b/packages/addons/service/vdr-addon/changelog.txt
@@ -1,3 +1,7 @@
+113
+- update VDR to 2.4.6
+- update VNSI plugin to 908684b
+
 112
 - update VDR to 2.4.4
 - update dvbapi to 2019-07-27

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-addon"
-PKG_VERSION="2.4.4"
-PKG_REV="112"
+PKG_VERSION="2.4.6"
+PKG_REV="113"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
vdr: updated to 2.4.6
vdr-plugin-vnsiserver: changed source to github.com/mdre77/vdr-plugin-vnsiserver and updated  to 908684b
Runtime tested.