### PR TITLE
checkdeps: cleanup

### DIFF
--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -85,21 +85,3 @@
 
   # debug tty path
     DEBUG_TTY="/dev/ttyS2"
-
-################################################################################
-# buildsystem extras for aarch64 native builds
-################################################################################
-# rkbin supplied as an x86-64 binary only
-if [ "$(uname -m)" = "aarch64" ]; then
-  declare -A EXTRA_DEP_MAP
-    EXTRA_DEP_MAP=(
-      [qemu-x86_64]=qemu-user-binfmt
-    )
-
-  echo -e "Copy from a working x86_64 system:\n\t/lib64/libc.so.6\n\t/lib/x86_64-linux-gnu/libc.so.6\n"
-  declare -A EXTRA_FILE_MAP
-    EXTRA_FILE_MAP=(
-      [/lib64/ld-linux-x86-64.so.2]="libc6:amd64"
-      [/lib/x86_64-linux-gnu/libc.so.6]="libc6:amd64"
-    )
-fi

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -85,3 +85,21 @@
 
   # debug tty path
     DEBUG_TTY="/dev/ttyS2"
+
+################################################################################
+# buildsystem extras for aarch64 native builds
+################################################################################
+# rkbin supplied as an x86-64 binary only
+if [ "$(uname -m)" = "aarch64" ]; then
+  declare -A EXTRA_DEP_MAP
+    EXTRA_DEP_MAP=(
+      [qemu-x86_64]=qemu-user-binfmt
+    )
+
+  echo -e "Copy from a working x86_64 system:\n\t/lib64/libc.so.6\n\t/lib/x86_64-linux-gnu/libc.so.6\n"
+  declare -A EXTRA_FILE_MAP
+    EXTRA_FILE_MAP=(
+      [/lib64/ld-linux-x86-64.so.2]="libc6:amd64"
+      [/lib/x86_64-linux-gnu/libc.so.6]="libc6:amd64"
+    )
+fi

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -4,35 +4,30 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
+set -e
+
+# set up arrays
+declare -A dep_map file_map perl_map need_map
+
 get_deps() {
-  need=()
-  need_pkg=()
+  # start from a blank slate
+  need_map=()
 
-  for i in "${!deps[@]}"; do
-    dep=${deps[${i}]}
-    dep_pkg=${deps_pkg[${i}]}
-    if ! command -v "${dep}" >/dev/null; then
-      need+=(${dep})
-      need_pkg+=("${dep_pkg}")
+  for key in "${!dep_map[@]}"; do
+    if ! command -v "${key}" >/dev/null; then
+      need_map["${key}"]="${dep_map[${key}]}"
     fi
   done
 
-  for i in "${!files[@]}"; do
-    file=${files[${i}]}
-    file_pkg=${files_pkg[${i}]}
-    if [ ! -f "${file}" ]; then
-      need+=(${file})
-      need_pkg+=("${file_pkg}")
+  for key in "${!file_map[@]}"; do
+    if [ ! -f "${key}" ]; then
+      need_map["${key}"]="${file_map[${key}]}"
     fi
   done
 
-  for i in "${!perl_mod[@]}"; do
-    mod=${perl_mod[${i}]}
-    pkg=${perl_pkg[${i}]}
-
-    if ! perl -M"${mod}" -e exit 2>/dev/null; then
-      need+=(perl::${mod})
-      need_pkg+=(${pkg})
+  for key in "${!perl_map[@]}"; do
+    if ! perl -M"${key}" -e exit 2>/dev/null; then
+      need_map["perl::${key}"]="${perl_map[${key}]}"
     fi
   done
 }
@@ -40,11 +35,12 @@ get_deps() {
 get_yes_no()
 {
   local ans
-  read -p "Would you like to install the needed tools? (y/n) " ans
+  read -p "Would you like to install the needed tools? (y/n)" ans
   [ "${ans,,}" = "y" ] && return 0
   [ "${ans,,}" = "yes" ] && return 0
   return 1
 }
+
 
 if  [ -f /etc/lsb-release ]; then
   DISTRO=$(grep DISTRIB_ID /etc/lsb-release | cut -d "=" -f 2)
@@ -56,115 +52,213 @@ fi
 
 DISTRO=${DISTRO,,}
 
-deps=(wget bash bc gcc sed patch lsdiff tar bzip2 gzip xz perl gawk gperf zip unzip diff lzop make file)
-deps_pkg=(wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file)
+# [program]=package
+dep_map=(
+  [bash]=bash
+  [bc]=bc
+  [bzip2]=bzip2
+  [diff]=diffutils
+  [gawk]=gawk
+  [gcc]=gcc
+  [gperf]=gperf
+  [gzip]=gzip
+  [file]=file
+  [lsdiff]=patchutils
+  [lzop]=lzop
+  [make]=make
+  [patch]=patch
+  [perl]=perl
+  [sed]=sed
+  [tar]=tar
+  [unzip]=unzip
+  [wget]=wget
+  [xz]=xz-utils
+  [zip]=zip
+)
 
-files=(/usr/include/stdio.h /usr/include/ncurses.h)
-files_pkg=(libc6-dev libncurses5-dev)
+# [file]=package
+file_map=(
+  [/usr/include/ncurses.h]=libncurses5-dev
+  [/usr/include/stdio.h]=libc6-dev
+)
 
-perl_mod=(JSON XML::Parser Thread::Queue Parse::Yapp::Driver)
+# [module]=package
+perl_map=(
+  [JSON]=libjson-perl
+  [Parse::Yapp::Driver]=libparse-yapp-perl
+  [Thread::Queue]=perl
+  [XML::Parser]=libxml-parser-perl
+)
 
 case "${DISTRO}" in
     fedora|centos|rhel)
-      deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python3 rpcgen)
-      deps_pkg+=(gcc-c++ xorg-x11-font-utils xorg-x11-font-utils xorg-x11-font-utils libxslt java-1.7.0-openjdk python3 rpcgen)
+      dep_map+=(
+        [g++]=gcc-c++
+        [mkfontscale]=xorg-x11-font-utils
+        [mkfontdir]=xorg-x11-font-utils
+        [bdftopcf]=xorg-x11-font-utils
+        [xsltproc]=libxslt
+        [java]=java-1.7.0-openjdk
+        [python3]=python3
+        [rpcgen]=rpcgen
+      )
       if [[ ! $(rpm -qa glibc-static) ]]; then
-        deps+=(glibc-static)
-        deps_pkg+=(glibc-static)
+        dep_map+=(
+          [glibc-static]=glibc-static
+        )
       fi
       if [[ ! $(rpm -qa libstdc++-static) ]]; then
-        deps+=(libstdc++-static)
-        deps_pkg+=(libstdc++-static)
+        dep_map+=(
+          [libstdc++-static]=libstdc++-static
+        )
       fi
-      files_pkg=(glibc-headers ncurses-devel)
-      perl_pkg=(perl-JSON perl-XML-Parser perl-Thread-Queue perl-Parse-Yapp)
+      file_map+=(
+        [/usr/include/ncurses.h]=ncurses-devel
+        [/usr/inculde/stdio.h]=glibc-headers
+      )
+      perl_map+=(
+        [JSON]=perl-JSON
+        [Parse::Yapp::Driver]=perl-Parse-Yapp
+        [Thread::Queue]=perl-Thread-Queue
+        [XML::Parser]=perl-XML-Parser
+      )
       ;;
     gentoo|sabayon)
-      deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python3 rpcgen)
-      deps_pkg+=("gcc[cxx]" mkfontscale mkfontdir bdftopcf libxslt virtual/jre python3 net-libs/rpcsvc-proto)
-      files_pkg=(glibc ncurses)
-      perl_pkg=(JSON XML-Parser perl-Thread-Queue perl-Parse-Yapp)
+      dep_map+=(
+        [g++]="gcc[cxx]"
+        [mkfontscale]=mkfontscale
+        [bdftopcf]=bdftopcf
+        [xsltproc]=libxslt
+        [java]=virtual/jre
+        [python3]=python
+        [rpcgen]=net-libs/rpcsvc-proto
+      )
+      file_map+=(
+        [/usr/inculde/stdio.h]=glibc
+        [/usr/include/ncurses.h]=ncurses
+      )
+      perl_map+=(
+        [JSON]=JSON
+        [Parse::Yapp::Driver]=perl-Parse-Yapp
+        [Thread::Queue]=perl-Thread-Queue
+        [XML::Parser]=XML-Parser
+      )
       ;;
     arch)
-      deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python3 rpcgen)
-      deps_pkg+=(g++ xorg-mkfontscale xorg-mkfontdir xorg-bdftopcf libxslt "java-runtime-common jdk8-openjdk" python3 rpcsvc-proto)
-      perl_pkg=(perl-json perl-xml-parser perl perl-parse-yapp)
+      dep_map+=(
+        [g++]=g++
+        [mkfontscale]=xorg-mkfontscale
+        [mkfontdir]=xorg-mkfontdir
+        [bdftopcf]=xorg-bdftopcf
+        [xsltproc]=libxslt
+        [java]="java-runtime-common jdk8-openjdk"
+        [python3]=python3
+        [rpcgen]=rpcsvc-proto
+      )
+      perl_map+=(
+        [JSON]=perl-json
+        [XML::Parser]=perl-xml-parser
+        [Thread::Queue]=perl
+        [Parse::Yapp::Driver]=perl-parse-yapp
+      )
       ;;
     opensuse)
-      deps+=( g++ mkfontscale mkfontdir bdftopcf xsltproc java python3)
-      deps_pkg+=(gcc-c++ mkfontscale mkfontdir bdftopcf libxslt-tools java-1_8_0-openjdk python3)
+      dep_map+=(
+        [g++]=gcc-c++
+        [mkfontscale]=mkfontscale
+        [mkfontdir]=mkfontdir
+        [bdftopcf]=bdftopcf
+        [xsltproc]=libxslt-tools
+        [java]=java-1_8_0-openjdk
+        [python3]=python3
+      )
       if [[ ! $(rpm -qa glibc-devel-static) ]]; then
-        deps+=(glibc-devel-static)
-        deps_pkg+=(glibc-devel-static)
+        dep_map+=(
+          [glibc-devel-static]=glibc-devel-static
+        )
       fi
-      perl_pkg=(perl-JSON perl-XML-Parser perl perl-Parse-Yapp)
+      perl_map+=(
+        [JSON]=perl-JSON
+        [XML::Parser]=perl-XML-Parser
+        [Thread::Queue]=perl
+        [Parse::Yapp::Driver]=perl-Parse-Yapp
+      )
       ;;
     *)
-      deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python3)
-      deps_pkg+=(g++ xfonts-utils xfonts-utils xfonts-utils xsltproc default-jre python3)
-      perl_pkg=(libjson-perl libxml-parser-perl perl libparse-yapp-perl)
+      dep_map+=(
+        [g++]=g++
+        [mkfontscale]=xfonts-utils
+        [mkfontdir]=xfonts-utils
+        [bdftopcf]=xfonts-utils
+        [xsltproc]=xsltproc
+        [java]=default-jre
+        [python3]=python3
+      )
       ;;
 esac
 
+# EXTRA_* won't work without sourcing config/options in this script
 # project specific dependencies
-if [ -n "${EXTRA_DEPS}" ] ; then
-  deps+=(${EXTRA_DEPS})
+if [ "${#EXTRA_DEP_MAP[@]}" -gt 0 ]; then
+  echo "${EXTRA_DEP_MAP[@]}"
+  for key in "${!EXTRA_DEP_MAP[@]}"; do
+    dep_map["${key}"]="${EXTRA_DEP_MAP[${key}]}"
+  done
 fi
-if [ -n "${EXTRA_DEPS_PKG}" ] ; then
-  deps_pkg+=(${EXTRA_DEPS_PKG})
+
+# project specific file needs
+if [ "${#EXTRA_FILE_MAP[@]}" -gt 0 ]; then
+  for key in "${!EXTRA_FILE_MAP[@]}"; do
+    file_map["${key}"]="${EXTRA_FILE_MAP[${key}]}"
+  done
+fi
+
+# project specific perl modules
+if [ "${#EXTRA_PERL_MAP[@]}" -gt 0 ]; then
+  for key in "${!EXTRA_PERL_MAP[@]}"; do
+    perl_map["${key}"]="${EXTRA_PERL_MAP[${key}]}"
+  done
 fi
 
 # distro specific dependencies
-if [ -n "${DISTRO_DEPS}" ] ; then
-  deps+=(${DISTRO_DEPS})
-fi
-if [ -n "${DISTRO_DEPS_PKG}" ] ; then
-  deps_pkg+=(${DISTRO_DEPS_PKG})
-fi
-
-# aarch64 dependencies
-if [ "$(uname -m)" = "aarch64" ]; then
-  if [ ! -f /lib64/ld-linux-x86-64.so.2 -a ! -f /lib/x86_64-linux-gnu/libc.so.6 ]; then
-    printf "Copy from a working x86_64 system:\n\t/lib64/libc.so.6\n\t/lib/x86_64-linux-gnu/libc.so.6\n"
-  fi
-  files+=(/lib64/ld-linux-x86-64.so.2 /lib/x86_64-linux-gnu/libc.so.6)
-  files_pkg+=(libc6:amd64 libc6:amd64)
-  deps+=(qemu-x86_64)
-  deps_pkg+=(qemu-user-binfmt)
+if [ "${#DISTRO_DEP_MAP[@]}" -gt 0 ]; then
+  for key in "${!DISTRO_DEP_MAP[@]}"; do
+    dep_map["${key}"]="${DISTRO_DEP_MAP[${key}]}"
+  done
 fi
 
 get_deps
 
-if [ "${#need[@]}" -gt 0 ]; then
-  echo "**** Your system lacks the following tools needed to build ${DISTRONAME} ****"
-  for i in "${!need[@]}"; do
-    echo "${need[${i}]} provided by ${need_pkg[${i}]}"
+if [ "${#need_map[@]}" -gt 0 ]; then
+  echo "**** This system lacks the following tools needed to build ${DISTRONAME} ****"
+  for key in "${!need_map[@]}"; do
+    echo "${key} provided by ${need_map[${key}]}"
   done
-  echo "**** You seem to use a ${DISTRO} system ****"
+  echo "**** The system appears to be a ${DISTRO} system ****"
 
   if command -v sudo >/dev/null; then
     case "${DISTRO}" in
       ubuntu|debian|linuxmint|\"elementary\")
-        get_yes_no && sudo apt-get install "${need_pkg[@]}"
+        get_yes_no && sudo apt-get install "${need_map[@]}"
         ;;
       fedora|centos|rhel)
         command -v dnf >/dev/null && YUM=dnf || YUM=yum
-        get_yes_no && sudo ${YUM} install "${need_pkg[@]}"
+        get_yes_no && sudo ${YUM} install "${need_map[@]}"
         ;;
       gentoo)
-        get_yes_no && sudo emerge --ask --deep "${need_pkg[@]}"
+        get_yes_no && sudo emerge --ask --deep "${need_map[@]}"
         ;;
       sabayon)
-        get_yes_no && sudo equo install --ask "${need_pkg[@]}"
+        get_yes_no && sudo equo install --ask "${need_map[@]}"
         ;;
       mageia)
-        get_yes_no && sudo urpmi "${need_pkg[@]}"
+        get_yes_no && sudo urpmi "${need_map[@]}"
         ;;
       arch)
-        get_yes_no && sudo pacman -Sy "${need_pkg[@]}"
+        get_yes_no && sudo pacman -Sy "${need_map[@]}"
         ;;
       opensuse)
-        get_yes_no && sudo zypper install -y --no-recommends "${need_pkg[@]}"
+        get_yes_no && sudo zypper install -y --no-recommends "${need_map[@]}"
         ;;
       *)
         echo "**** unsupported distro ${DISTRO} ****"
@@ -173,15 +267,17 @@ if [ "${#need[@]}" -gt 0 ]; then
     esac
   else
     echo "The command 'sudo' was not found. Please install necessary packages manually."
+    exit 1
   fi
 fi
 
+# check if installed packages satisifed deps
 get_deps
 
-if [ "${#need[@]}" -gt 0 ]; then
+if [ "${#need_map[@]}" -gt 0 ]; then
   echo "**** The following packages were not installed correctly ****"
-  for i in "${!need[@]}"; do
-    echo "${need[${i}]} provided by ${need_pkg[${i}]}"
+  for key in "${!need_map[@]}"; do
+    echo "${key} provided by ${need_map[${key}]}"
   done
   echo "********"
   exit 1

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -90,6 +90,19 @@ perl_map=(
   [XML::Parser]=libxml-parser-perl
 )
 
+### PROJECT SPECIFIC REQUIREMENTS ###
+# Extend build scripts to look for distro/project/device checkdep scripts before adding further checks here
+# Native aarch64 on debian(?) host Rockchip needs to support rkbin
+if [ "$(uname -m)" = "aarch64" -a "${PROJECT}" = "Rockchip" ]; then
+  dep_map[qemu-x86_64]=qemu-user-binfmt
+  if [ ! -f /lib64/ld-linux-x86-64.so.2 -o ! -f /lib/x86_64-linux-gnu/libc.so.6 ]; then
+    echo -e "Copy from a working x86_64 system:\n\t/lib64/ld-linux-x86-64.so.2\n\t/lib/x86_64-linux-gnu/libc.so.6"
+  fi
+  file_map[/lib64/ld-linux-x86-64.so.2]="libc6:amd64"
+  file_map[/lib/x86_64-linux-gnu/libc.so.6]="libc6:amd64"
+fi
+
+# remap or add [depend]=package needs based on host distro
 case "${DISTRO}" in
     fedora|centos|rhel)
       dep_map+=(
@@ -197,36 +210,7 @@ case "${DISTRO}" in
       ;;
 esac
 
-# EXTRA_* won't work without sourcing config/options in this script
-# project specific dependencies
-if [ "${#EXTRA_DEP_MAP[@]}" -gt 0 ]; then
-  echo "${EXTRA_DEP_MAP[@]}"
-  for key in "${!EXTRA_DEP_MAP[@]}"; do
-    dep_map["${key}"]="${EXTRA_DEP_MAP[${key}]}"
-  done
-fi
-
-# project specific file needs
-if [ "${#EXTRA_FILE_MAP[@]}" -gt 0 ]; then
-  for key in "${!EXTRA_FILE_MAP[@]}"; do
-    file_map["${key}"]="${EXTRA_FILE_MAP[${key}]}"
-  done
-fi
-
-# project specific perl modules
-if [ "${#EXTRA_PERL_MAP[@]}" -gt 0 ]; then
-  for key in "${!EXTRA_PERL_MAP[@]}"; do
-    perl_map["${key}"]="${EXTRA_PERL_MAP[${key}]}"
-  done
-fi
-
-# distro specific dependencies
-if [ "${#DISTRO_DEP_MAP[@]}" -gt 0 ]; then
-  for key in "${!DISTRO_DEP_MAP[@]}"; do
-    dep_map["${key}"]="${DISTRO_DEP_MAP[${key}]}"
-  done
-fi
-
+### DEPENDENCY CHECKING AND INSTALLATION ###
 get_deps
 
 if [ "${#need_map[@]}" -gt 0 ]; then

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -6,8 +6,9 @@
 
 set -e
 
-# set up arrays
+# set up variables
 declare -A dep_map file_map perl_map need_map
+DEBUG="false"
 
 get_deps() {
   # start from a blank slate
@@ -210,8 +211,30 @@ case "${DISTRO}" in
       ;;
 esac
 
+if [ "${DEBUG}" = "true" ]; then
+  echo "DEP MAP"
+  for key in "${!dep_map[@]}"; do
+    echo "${key}:${dep_map[${key}]}"
+  done
+  echo "FILE MAP"
+  for key in "${!file_map[@]}"; do
+    echo "${key}:${file_map[${key}]}"
+  done
+  echo "PERL MAP"
+  for key in "${!perl_map[@]}"; do
+    echo "${key}:${perl_map[${key}]}"
+  done
+fi
+
 ### DEPENDENCY CHECKING AND INSTALLATION ###
 get_deps
+
+if [ "${DEBUG}" = "true" ]; then
+  echo "NEED MAP"
+  for key in "${!need_map[@]}"; do
+    echo "${key}:${need_map[${key}]}"
+  done
+fi
 
 if [ "${#need_map[@]}" -gt 0 ]; then
   echo "**** This system lacks the following tools needed to build ${DISTRONAME} ****"


### PR DESCRIPTION
The primary change is shifting dependency checking from using two arrays that are paired to each other by index position to using a single associative array to match them in [key]=value pairs. I've added a debug switch to the top of the script that when enabled will echo every array's mapping.

The second change is that I was moving the qemu-user-binfmt stuff out to the Rockchip project as it was added  for aarch64 native building to support the rkbin program. The EXTRA_* dependency arrays for project and distribution have been broken since checkdeps stopped sourcing config/options. Since it's been broken since November 2019 without complaint, I opted to remove this feature. About 95% of the necessary bits to have this work are in the first commit. (There are probably some bugs in that, as I noticed it was broken when I went to test.)

Some other one-liners that were folded in too. They should be in the commit message if not obvious.

Draft because I'm not entirely happy with the present solution for the extra project/distribution dependencies being tacked into the script directly. checkdeps stopped sourcing config/options because config/options(or one of the files it sourced...) had a dependency check on gcc that aborted before checkdeps would offer to install it... 