### PR TITLE
glmark2: revert to commit before meson change

### DIFF
--- a/packages/graphics/glmark2/package.mk
+++ b/packages/graphics/glmark2/package.mk
@@ -2,18 +2,31 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glmark2"
-PKG_VERSION="784aca755a469b144acf3cae180b6e613b7b057a"
-PKG_SHA256="787dd7de05c795c7c42694e648b5c6418e4b395fc460ea349d1d35d493469356"
+PKG_VERSION="12977017a538abaa18d57e844f3bf3b95ed633f9"
+PKG_SHA256="b84d0a2c0600ad0d0423aa35b546c0997b59717163ee11d27451ed67dbaf4474"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/glmark2/glmark2"
 PKG_URL="https://github.com/glmark2/glmark2/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="glmark2 is an OpenGL 2.0 and ES 2.0 benchmark"
+PKG_TOOLCHAIN="manual"
 
 if [ "$OPENGLES_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" $OPENGLES"
-  PKG_MESON_OPTS_TARGET="-Dflavors=drm-glesv2"
+  PKG_CONFIGURE_OPTS_TARGET="--with-flavors=drm-glesv2"
 elif [ "$OPENGL_SUPPORT" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" $OPENGL"
-  PKG_MESON_OPTS_TARGET="-Dflavors=drm-gl"
+  PKG_CONFIGURE_OPTS_TARGET="--with-flavors=drm-gl"
 fi
+
+configure_target() {
+  ./waf configure $PKG_CONFIGURE_OPTS_TARGET --prefix=/usr
+}
+
+make_target() {
+  ./waf
+}
+
+makeinstall_target() {
+  ./waf install --destdir=$INSTALL
+}


### PR DESCRIPTION
The recent bump fails on ARM/GBM, see https://github.com/glmark2/glmark2/issues/138 so this reverts to the immediate commit before the change to meson build-system (the breaking change) which still uses waf and compiles fine.