### PR TITLE
lcdd: fix addon build reference to serdisplib 2.02

### DIFF
--- a/packages/addons/service/lcdd/package.mk
+++ b/packages/addons/service/lcdd/package.mk
@@ -44,7 +44,7 @@ addon() {
   cp -PR $PKG_INSTALL/usr/lib       $ADDON_BUILD/$PKG_ADDON_ID/lib/
   cp -PR $PKG_INSTALL/usr/sbin      $ADDON_BUILD/$PKG_ADDON_ID/bin/
 
-  cp -L $(get_install_dir serdisplib)/usr/lib/libserdisp.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib/
+  cp -L $(get_install_dir serdisplib)/usr/lib/libserdisp.so.2 $ADDON_BUILD/$PKG_ADDON_ID/lib/
 
   sed -e "s|^DriverPath=.*$|DriverPath=/storage/.kodi/addons/service.lcdd/lib/lcdproc/|" \
       -e "s|^#Foreground=.*$|Foreground=no|" \


### PR DESCRIPTION
Fixes build issue.
```
[63/64] [DONE] build   serdisplib:target
<<< lcdd:target seq 64 <<<
cp: cannot stat '/home/christian/Documents/Git/LE-CvH/build.LibreELEC-Generic.x86_64-9.80-devel/install_pkg/serdisplib-2.02/usr/lib/libserdisp.so.1': No such file or directory
FAILURE: scripts/install_addon lcdd:target during addon (package.mk)
*********** FAILED COMMAND ***********
cp -L $(get_install_dir serdisplib)/usr/lib/libserdisp.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib/

christian@ubuntu:~/Documents/Git/LE-CvH$ ls build.LibreELEC-Generic.x86_64-9.80-devel/install_pkg/serdisplib-2.02/usr/lib/
libserdisp.so  libserdisp.so.2  libserdisp.so.2.02
```