### PR TITLE
ttyd: fix addon build reference to libwebsockets 4.1.6

### DIFF
--- a/packages/addons/service/ttyd/package.mk
+++ b/packages/addons/service/ttyd/package.mk
@@ -24,6 +24,6 @@ addon() {
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/lib
   cp -p $(get_install_dir json-c)/usr/lib/libjson-c.so.5 $ADDON_BUILD/$PKG_ADDON_ID/lib
-  cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets.so.16 $ADDON_BUILD/$PKG_ADDON_ID/lib
+  cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets.so.17 $ADDON_BUILD/$PKG_ADDON_ID/lib
   cp -p $(get_install_dir libuv)/usr/lib/libuv.so.1 $ADDON_BUILD/$PKG_ADDON_ID/lib
 }


### PR DESCRIPTION
Fix build issues
```
[48/49] [DONE] build   libwebsockets:target
<<< ttyd:target seq 49 <<<
cp: cannot stat '/home/christian/Documents/Git/LE-CvH/build.LibreELEC-Generic.x86_64-9.80-devel/install_pkg/libwebsockets-4.1.6/usr/lib/libwebsockets.so.16': No such file or directory
FAILURE: scripts/install_addon ttyd:target during addon (package.mk)
*********** FAILED COMMAND ***********
cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets.so.16 $ADDON_BUILD/$PKG_ADDON_ID/lib

christian@ubuntu:~/Documents/Git/LE-CvH$ ls build.LibreELEC-Generic.x86_64-9.80-devel/install_pkg/libwebsockets-4.1.6/usr/lib/
cmake  libwebsockets.a  libwebsockets-evlib_uv.so  libwebsockets.so  libwebsockets.so.17  pkgconfig
```