### PR TITLE
shared-mime-info: update to 2.1

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/shared-mime-info/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/shared-mime-info/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="shared-mime-info"
-PKG_VERSION="1.15"
-PKG_SHA256="f482b027437c99e53b81037a9843fccd549243fd52145d016e9c7174a4f5db90"
+PKG_VERSION="2.1"
+PKG_SHA256="37df6475da31a8b5fc63a54ba0770a3eefa0a708b778cb6366dccee96393cb60"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://freedesktop.org/wiki/Software/shared-mime-info/"
-PKG_URL="https://gitlab.freedesktop.org/xdg/shared-mime-info/uploads/b27eb88e4155d8fccb8bb3cd12025d5b/shared-mime-info-1.15.tar.xz"
+PKG_URL="https://gitlab.freedesktop.org/xdg/${PKG_NAME}/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain glib libxml2 gettext itstool:host"
 PKG_LONGDESC="The shared-mime-info package contains the core database of common types."
 PKG_BUILD_FLAGS="-parallel -sysroot"

--- a/packages/addons/addon-depends/chrome-depends/shared-mime-info/patches/no-man-no-html.patch
+++ b/packages/addons/addon-depends/chrome-depends/shared-mime-info/patches/no-man-no-html.patch
@@ -1,0 +1,37 @@
+diff -Nur shared-mime-info-2.1.orig/data/meson.build shared-mime-info-2.1/data/meson.build
+--- shared-mime-info-2.1.orig/data/meson.build	2021-01-01 06:12:16.000000000 +1100
++++ shared-mime-info-2.1/data/meson.build	2021-01-14 00:25:58.299790452 +1100
+@@ -1,6 +1,4 @@
+ 
+-install_man('update-mime-database.1')
+-
+ freedesktop_org_xml = custom_target('freedesktop.org.xml',
+     input : files(
+         'freedesktop.org.xml.in',
+@@ -21,15 +19,3 @@
+   [ 'its/shared-mime-info.loc', 'its/shared-mime-info.its', ],
+   install_dir : get_option('datadir') / 'gettext/its'
+ )
+-
+-custom_target('shared-mime-info-spec-html',
+-    input : 'shared-mime-info-spec.xml',
+-    output: 'shared-mime-info-spec-html',
+-    command: [
+-        xmlto,
+-        '-o', '@OUTPUT@',
+-        'html-nochunks',
+-        '@INPUT@',
+-    ],
+-    build_by_default: true,
+-)
+diff -Nur shared-mime-info-2.1.orig/meson.build shared-mime-info-2.1/meson.build
+--- shared-mime-info-2.1.orig/meson.build	2021-01-01 06:12:16.000000000 +1100
++++ shared-mime-info-2.1/meson.build	2021-01-14 00:24:18.552142696 +1100
+@@ -22,7 +22,6 @@
+ 
+ itstool = find_program('itstool')
+ xmllint = find_program('xmllint')
+-xmlto   = find_program('xmlto')
+ 
+ ###############################################################################
+ # Find xdgmime


### PR DESCRIPTION
update 1.9 to 1.15 and subsequently 2.1 - replacing https://github.com/LibreELEC/LibreELEC.tv/pull/4884
changelog: https://gitlab.freedesktop.org/xdg/shared-mime-info/-/blob/master/NEWS