### PR TITLE
at-spi2-core: update to 2.39.1

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.38.0"
-PKG_SHA256="84e36c3fe66862133f5fe229772b76aa2526e10de5014a3778f2fa46ce550da5"
+PKG_VERSION="2.39.1"
+PKG_SHA256="44d2b042e47d25571581efff673af0a8cd79531babbad2b043784879e15e4228"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.gnome.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-$PKG_VERSION.tar.xz"


### PR DESCRIPTION
update 2.38.0 to 2.39.1
changelog:
- https://gitlab.gnome.org/GNOME/at-spi2-core/-/blob/master/NEWS

note: NEWS:2.37.92 refers to 2.38.0 release