### PR TITLE
Include version references in packages with githash only (that weren’t updated)

### DIFF
--- a/packages/addons/addon-depends/dvb-tools-depends/dvbsnoop/package.mk
+++ b/packages/addons/addon-depends/dvb-tools-depends/dvbsnoop/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dvbsnoop"
-PKG_VERSION="badf61fcdab1177c1162747be06d035a2b671e9b"
+PKG_VERSION="badf61fcdab1177c1162747be06d035a2b671e9b" # 2018-01-12
 PKG_SHA256="7f0f5d9ca15c5caae3ca249d95a5fc30cececd16f63e00a1404e0d2368ce56fa"
 PKG_LICENSE="GPL"
 PKG_SITE="http://dvbsnoop.sourceforge.net/"

--- a/packages/addons/addon-depends/libnetwork/package.mk
+++ b/packages/addons/addon-depends/libnetwork/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnetwork"
-PKG_VERSION="a543cbc4871f904b0efe205708eb45d72e65fd8b"
+PKG_VERSION="a543cbc4871f904b0efe205708eb45d72e65fd8b" # 2020-11-25
 PKG_SHA256="3e3b0048aa468de0fe33ad2c08bf3891ac1a72fca434f92620312da51f344488"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/docker/libnetwork"

--- a/packages/addons/addon-depends/system-tools-depends/mtpfs/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mtpfs/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mtpfs"
-PKG_VERSION="fd3864dd6f0e8183fa2598d4cf890401d3a1e09a"
+PKG_VERSION="fd3864dd6f0e8183fa2598d4cf890401d3a1e09a" # 2016-12-16
 PKG_SHA256="f004136a82452d13362581277eb2496033aa13a6c3f35d0501327248f3120456"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.adebenham.com/mtpfs/"

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="7ddc21b28468b9e8d0f189bb46a2467de4e09e12"
+PKG_VERSION="7ddc21b28468b9e8d0f189bb46a2467de4e09e12" # 2020-12-17
 PKG_SHA256="995349787105db62daba924f22f7a90c4825575fe24d2b87c4b183d8ac99f5b3"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"

--- a/packages/multimedia/rtmpdump/package.mk
+++ b/packages/multimedia/rtmpdump/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rtmpdump"
-PKG_VERSION="c5f04a58fc2aeea6296ca7c44ee4734c18401aa3"
+PKG_VERSION="c5f04a58fc2aeea6296ca7c44ee4734c18401aa3" # 2019-03-31
 PKG_SHA256="fd8c21263d93fbde8bee8aa6c5f6a657789674bb0f9e74f050651504d5f43b46"
 PKG_LICENSE="GPL"
 PKG_SITE="http://rtmpdump.mplayerhq.hu/"

--- a/packages/network/libshairplay/package.mk
+++ b/packages/network/libshairplay/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libshairplay"
-PKG_VERSION="096b61ad14c90169f438e690d096e3fcf87e504e"
+PKG_VERSION="096b61ad14c90169f438e690d096e3fcf87e504e" # 2018-08-24
 PKG_SHA256="7e2b013ffe75ea2f13fb12b1aa38b8e2e8b1899ac292d57f05d7b352a3a181cf"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/juhovh/shairplay"


### PR DESCRIPTION
- Add date comment for githash’ed PKG_VERSION matching other githash only packages.
- improves identifying the hash in timeline
