### PR TITLE
qtbase: update to 5.15.2

### DIFF
--- a/packages/addons/addon-depends/qtbase/package.mk
+++ b/packages/addons/addon-depends/qtbase/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qtbase"
-PKG_VERSION="5.14.0"
-PKG_SHA256="4ef921c0f208a1624439801da8b3f4344a3793b660ce1095f2b7f5c4246b9463"
+PKG_VERSION="5.15.2"
+PKG_SHA256="909fad2591ee367993a75d7e2ea50ad4db332f05e1c38dd7a5a274e156a4e0f8"
 PKG_LICENSE="GPL"
 PKG_SITE="http://qt-project.org"
 PKG_URL="http://download.qt.io/archive/qt/${PKG_VERSION%.*}/${PKG_VERSION}/submodules/${PKG_NAME}-everywhere-src-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Update 5.14.0 to 5.15.2
Update to latest qt5
Updates skipped are 5.14.1, 5.14.2, 5.15.0, 5.15.1
Change logs are at:
- https://github.com/qt/qtbase/tree/5.15/dist

The Qt version 5.15 series is binary compatible with the 5.14.x series.
Applications compiled for 5.14 will continue to run with 5.15.