### PR TITLE
Allwinner: add u-boot patch for setting fixed MAC address

### DIFF
--- a/projects/Allwinner/patches/u-boot/0001-sunxi-call-fdt_fixup_ethernet-again-to-set-macaddr-f.patch
+++ b/projects/Allwinner/patches/u-boot/0001-sunxi-call-fdt_fixup_ethernet-again-to-set-macaddr-f.patch
@@ -1,0 +1,42 @@
+From 55d3cc28b37000d1a3d7224c0ba4a808274e0b33 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Fri, 27 Oct 2017 17:25:00 +0800
+Subject: [PATCH 20/20] sunxi: call fdt_fixup_ethernet again to set macaddr for
+ more aliases
+
+Sometimes some ethernet aliases do not exist in U-Boot FDT but they
+exist in the FDT used to boot the system. In this situation
+setup_environment is called again in ft_board_setup to generate macaddr
+environment variable for them. However now the call to
+fdt_fixup_ethernet is moved before the call of ft_board_setup.
+
+Call fdt_fixup_ethernet again to add MAC addresses for the extra
+ethernet aliases.
+
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+---
+ board/sunxi/board.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index 192cf8ca45..0fe70f47cb 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -751,10 +751,12 @@ int ft_board_setup(void *blob, bd_t *bd)
+ 	int __maybe_unused r;
+ 
+ 	/*
+-	 * Call setup_environment again in case the boot fdt has
+-	 * ethernet aliases the u-boot copy does not have.
++	 * Call setup_environment and fdt_fixup_ethernet again
++	 * in case the boot fdt has ethernet aliases the u-boot
++	 * copy does not have.
+ 	 */
+ 	setup_environment(blob);
++	fdt_fixup_ethernet(blob);
+ 
+ #ifdef CONFIG_VIDEO_DT_SIMPLEFB
+ 	r = sunxi_simplefb_setup(blob);
+-- 
+2.13.6
+


### PR DESCRIPTION
```
Sometimes some ethernet aliases do not exist in U-Boot FDT but they
exist in the FDT used to boot the system. In this situation
setup_environment is called again in ft_board_setup to generate macaddr
environment variable for them. However now the call to
fdt_fixup_ethernet is moved before the call of ft_board_setup.
```

from U-Boot ML