### PR TITLE
xmlstarlet: update to 1.6.7

### DIFF
--- a/packages/textproc/xmlstarlet/package.mk
+++ b/packages/textproc/xmlstarlet/package.mk
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xmlstarlet"
-PKG_VERSION="1.6.1"
-PKG_SHA256="15d838c4f3375332fd95554619179b69e4ec91418a3a5296e7c631b7ed19e7ca"
+PKG_VERSION="1.6.7"
+PKG_SHA256="70b73cd9555d2cdfbdd1d87bd64f44e04e95a8ad11d4507b406bbdd9d5ca1c46"
 PKG_LICENSE="MIT"
-PKG_SITE="http://xmlstar.sourceforge.net"
-PKG_URL="http://netcologne.dl.sourceforge.net/project/xmlstar/${PKG_NAME}/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_SITE="https://pypi.org/project/xmlstarlet"
+PKG_URL="https://github.com/dimitern/xmlstarlet/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="libxml2:host libxslt:host"
 PKG_DEPENDS_TARGET="toolchain libxml2 libxslt"
 PKG_LONGDESC="XMLStarlet is a command-line XML utility which allows the modification and validation of XML documents."
+PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_HOST="  ac_cv_func_malloc_0_nonnull=yes \
                            ac_cv_func_realloc_0_nonnull=yes \
@@ -30,6 +32,16 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            --with-libxml-libs-prefix=${SYSROOT_PREFIX}/usr/lib \
                            --with-libxslt-include-prefix=${SYSROOT_PREFIX}/usr/include \
                            --with-libxslt-libs-prefix=${SYSROOT_PREFIX}/usr/lib"
+
+post_unpack() {
+  ( 
+    cd ${PKG_BUILD}
+    mkdir .temp
+    mv * .temp
+    mv .temp/xmlstarlet/* .
+    rm -rf .temp
+  )
+}
 
 post_makeinstall_host() {
   ln -sf xml ${TOOLCHAIN}/bin/xmlstarlet


### PR DESCRIPTION
update 1.6.1 to 1.6.7
- no code changes apart from exit() to return()
- new PKG_SITE and PKG_URL
- improvements could be done by moving back to configure, issues with configure in the xmlstarlet directory not configuring correctly using the build toolchain