### PR TITLE
ffmpegx: update addon to 114 with x264 update to 2021-01-07

### DIFF
--- a/packages/addons/addon-depends/ffmpegx-depends/x264/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x264/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="x264"
-PKG_VERSION="d4099dd4c722f52c4f3c14575d7d39eb8fadb97f"
-PKG_SHA256="9b6688b81e13cf342fc9b6b7adf1759eebd300c243c0707566ffe7ea9f0ccc7e"
+PKG_VERSION="6bc7fe4f36ea95db77e6df6d76153dd5a2c770a0"
+PKG_SHA256="d89911373d1de50b5ed1fc8ace9744968e15b69490e1b197d2d4f1b1c456930b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.videolan.org/developers/x264.html"
-PKG_URL="http://repo.or.cz/x264.git/snapshot/$PKG_VERSION.tar.gz"
+PKG_URL="https://code.videolan.org/videolan/x264/-/archive/master/x264-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="x264 codec"
 

--- a/packages/addons/tools/ffmpeg-tools/changelog.txt
+++ b/packages/addons/tools/ffmpeg-tools/changelog.txt
@@ -1,3 +1,6 @@
+114
+- x264: update to 2021-01-07
+
 113
 - Update Ffmpeg to 4.3.1
 

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
x264: update to 2021-01-07
- update d4099dd (2019-03-06) to 6bc7fe4 (2020-01-07)
- change to PKG_URL
- changelog: https://code.videolan.org/videolan/x264/-/commits/master/

** used by ffmpegx