### PR TITLE
wavpack: update to 5.4.0

### DIFF
--- a/packages/audio/wavpack/package.mk
+++ b/packages/audio/wavpack/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wavpack"
-PKG_VERSION="5.3.0"
-PKG_SHA256="b444379a0bee0330f137cb3e9a100e6a12a63a6d01987ba66b3729f85e282307"
+PKG_VERSION="5.4.0"
+PKG_SHA256="4bde6a6b2a86614a6bd2579e60dcc974e2c8f93608d2281110a717c1b3c28b79"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.wavpack.com"
 PKG_URL="http://www.wavpack.com/wavpack-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update 5.3.0 to 5.4.0
news: https://raw.githubusercontent.com/dbry/WavPack/master/NEWS
release notes: https://github.com/dbry/WavPack/releases/tag/5.4.0