### PR TITLE
snapclient and snapserver: update to 0.23.0

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/snapcast/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/snapcast/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapcast"
-PKG_VERSION="0.22.0"
-PKG_SHA256="b5156f346c32557bc1347c81fd5071fd4a32be61adc582e63323c11b105c9ff6"
+PKG_VERSION="0.23.0"
+PKG_SHA256="70efdeea60021f493f77ba1f3d00784911463cad11c6df214ecb19d74899b611"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/badaix/snapcast"
 PKG_URL="https://github.com/badaix/snapcast/archive/v$PKG_VERSION.tar.gz"

--- a/packages/addons/addon-depends/snapcast-depends/snapcast/patches/snapcast-01_makefiles.patch
+++ b/packages/addons/addon-depends/snapcast-depends/snapcast/patches/snapcast-01_makefiles.patch
@@ -5,10 +5,10 @@
  else
  
 -CXX       = g++
- CXXFLAGS += -pthread -DHAS_VORBIS -DHAS_ALSA -DHAS_AVAHI -DHAS_DAEMON
--LDFLAGS  += -lrt -lasound -lvorbis -lavahi-client -lavahi-common -latomic
-+LDFLAGS  += -lrt -lasound -lvorbis -lavahi-client -lavahi-common -logg
- OBJ      += ../common/daemon.o player/alsa_player.o browseZeroConf/browse_avahi.o
+ CXXFLAGS += -pthread -DHAS_VORBIS -DHAS_ALSA -DHAS_PULSE -DHAS_AVAHI -DHAS_DAEMON
+-LDFLAGS  += -lrt -lasound -lpulse -lvorbis -lavahi-client -lavahi-common -latomic
++LDFLAGS  += -lrt -lasound -lpulse -lvorbis -lavahi-client -lavahi-common -logg
+ OBJ      += ../common/daemon.o player/alsa_player.o player/pulse_player.o browseZeroConf/browse_avahi.o
 diff -Naur snapcast-0.14.0/server/Makefile snapcast-0.14.0.makefiles/server/Makefile
 --- snapcast-0.14.0/server/Makefile	2018-04-27 19:43:25.000000000 +0200
 +++ snapcast-0.14.0.makefiles/server/Makefile	2018-05-21 13:14:56.881206277 +0200

--- a/packages/addons/service/snapclient/changelog.txt
+++ b/packages/addons/service/snapclient/changelog.txt
@@ -1,3 +1,6 @@
+104
+- Update to 0.23.0
+
 103
 - Update to 0.22.0
 

--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapclient"
-PKG_VERSION="0.22.0"
-PKG_REV="103"
+PKG_VERSION="0.23.0"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain alsa-plugins snapcast"

--- a/packages/addons/service/snapserver/changelog.txt
+++ b/packages/addons/service/snapserver/changelog.txt
@@ -1,3 +1,6 @@
+104
+- Update to 0.23.0
+
 103
 - Update to 0.22.0
 

--- a/packages/addons/service/snapserver/package.mk
+++ b/packages/addons/service/snapserver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapserver"
-PKG_VERSION="0.22.0"
-PKG_REV="103"
+PKG_VERSION="0.23.0"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain shairport-sync snapcast"


### PR DESCRIPTION
snapcast: update to 0.23.0 …
update 0.22.0 to 0.23.0
changelog: https://github.com/badaix/snapcast/blob/master/changelog.md

Features
- Client: Add PulseAudio player backend (Issue #722)
- Client: Configurable buffer time for alsa and pulse players
- Server: If docroot is not configured, a default page is served (Issue #711)
- Server: airplay source supports "password" parameter (Issue #754)