### PR TITLE
packages/sysutils: small bumps of already bumped packages to latest.

### DIFF
--- a/packages/sysutils/gptfdisk/package.mk
+++ b/packages/sysutils/gptfdisk/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gptfdisk"
-PKG_VERSION="1.0.5"
-PKG_SHA256="0e7d3987cd0488ecaf4b48761bc97f40b1dc089e5ff53c4b37abe30bc67dcb2f"
+PKG_VERSION="1.0.6"
+PKG_SHA256="ddc551d643a53f0bd4440345d3ae32c49b04a797e9c01036ea460b6bb4168ca8"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.rodsbooks.com/gdisk/"
 PKG_URL="https://downloads.sourceforge.net/project/$PKG_NAME/$PKG_NAME/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"

--- a/packages/sysutils/libevdev/package.mk
+++ b/packages/sysutils/libevdev/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libevdev"
-PKG_VERSION="1.10.0"
-PKG_SHA256="3522c26e2c148be0ad68ce26fbced408a4185dea90bfe8079dc82b8ace962d4a"
+PKG_VERSION="1.10.1"
+PKG_SHA256="0330fe8357ece915db9366c1b9a6648941aea6f724b73ad6e71401127aa08932"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libevdev/"
 PKG_URL="http://www.freedesktop.org/software/libevdev/$PKG_NAME-$PKG_VERSION.tar.xz"

--- a/packages/sysutils/open-vm-tools/package.mk
+++ b/packages/sysutils/open-vm-tools/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="open-vm-tools"
-PKG_VERSION="11.2.0"
-PKG_SHA256="280970a15dd8210b89e68df5fce64fa8bfb3ff7ca3737ce5ebf8634d8c1a2494"
+PKG_VERSION="11.2.5"
+PKG_SHA256="7c31bb8ef70a0e32b81cde6550cae390a53108e4abb28bb539b0ab5b9e4fc188"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/vmware/open-vm-tools"


### PR DESCRIPTION
- libevdev: update to 1.10.1
- open-vm-tools: update to 11.2.5
- gptfdisk: update to 1.0.6
