### PR TITLE
pulseaudio: update to 14.2

### DIFF
--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pulseaudio"
-PKG_VERSION="14.0"
-PKG_SHA256="a834775d9382b055504e5ee7625dc50768daac29329531deb6597bf05e06c261"
+PKG_VERSION="14.2"
+PKG_SHA256="75d3f7742c1ae449049a4c88900e454b8b350ecaa8c544f3488a2562a9ff66f1"
 PKG_LICENSE="GPL"
 PKG_SITE="http://pulseaudio.org/"
 PKG_URL="http://www.freedesktop.org/software/pulseaudio/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- update 14.0 to 14.2
- release: https://lists.freedesktop.org/archives/pulseaudio-discuss/2021-January/031986.html
- release: https://lists.freedesktop.org/archives/pulseaudio-discuss/2021-January/031990.html
- news: https://raw.githubusercontent.com/pulseaudio/pulseaudio/stable-14.x/NEWS

**PulseAudio 14.1**
_A bug fix release._
 * Support upto 8 mixer channels on ALSA devices
 * Handle ALSA jacks with the same name but different index values
 * Switch to plugged-in headset when mic availability is unknown
 * Fix a potential segfault in the Bluetooth oFono HFP backend
 * Fix a problem with module-ladspa-sink when avoid-resampling=true
 * Fix database names containing canonical host for meson builds

**PulseAudio 14.2**
_A bug fix release._
 * Fix port switching when unplugging headphones