### PR TITLE
iMX6: repackage cubox/udoo/wandboard images to use FDTDIR

### DIFF
--- a/projects/NXP/devices/iMX6/bootloader/canupdate.sh
+++ b/projects/NXP/devices/iMX6/bootloader/canupdate.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+[ "$1" = "iMX6.arm" ] && exit 0 || exit 1

--- a/projects/NXP/devices/iMX6/bootloader/mkimage
+++ b/projects/NXP/devices/iMX6/bootloader/mkimage
@@ -2,11 +2,25 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 if [ -f "$RELEASE_DIR/3rdparty/bootloader/u-boot.img" ]; then
-  echo "Writing u-boot.img to $(basename $DISK)"
+  echo "image: writing u-boot.img to $(basename $DISK)"
   dd if="$RELEASE_DIR/3rdparty/bootloader/u-boot.img" of="$DISK" bs=1K seek=69 conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
 fi
 
 if [ -f "$RELEASE_DIR/3rdparty/bootloader/SPL" ]; then
-  echo "Writing SPL to $(basename $DISK)"
+  echo "image: writing SPL to $(basename $DISK)"
   dd if="$RELEASE_DIR/3rdparty/bootloader/SPL" of="$DISK" bs=1K seek=1 conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
 fi
+
+echo "image: copying device trees"
+mcopy -s -o "${RELEASE_DIR}/3rdparty/bootloader"/imx6d*${UBOOT_SYSTEM}*.dtb ::
+mcopy -s -o "${RELEASE_DIR}/3rdparty/bootloader"/imx6q*${UBOOT_SYSTEM}*.dtb ::
+
+echo "image: copying exlinux.conf"
+mkdir -p "${LE_TMP}/extlinux"
+cat << EOF > "${LE_TMP}/extlinux/extlinux.conf"
+LABEL ${DISTRO}
+  LINUX /${KERNEL_NAME}
+  FDTDIR /
+  APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} quiet ${EXTRA_CMDLINE}
+EOF
+mcopy -s -o "${LE_TMP}/extlinux" ::

--- a/projects/NXP/devices/iMX6/bootloader/update.sh
+++ b/projects/NXP/devices/iMX6/bootloader/update.sh
@@ -20,23 +20,21 @@ fi
 # mount $BOOT_ROOT r/w
   mount -o remount,rw $BOOT_ROOT
 
-# update Device Tree Blobs
-  for all_dtb in /flash/*.dtb; do
-    dtb=$(basename $all_dtb)
-    if [ -f $SYSTEM_ROOT/usr/share/bootloader/$dtb ]; then
-      echo "*** updating Device Tree Blob: $dtb ..."
-      cp -p $SYSTEM_ROOT/usr/share/bootloader/$dtb $BOOT_ROOT
-    fi
+# update extlinux device trees
+  for dtbfile in $BOOT_ROOT/*.dtb; do
+    dtb=$(basename $dtbfile)
+    echo "Updating $dtb"
+    cp -p $SYSTEM_ROOT/usr/share/bootloader/$dtb $BOOT_ROOT/ 2>/dev/null || true
   done
 
 # update bootloader files
   if [ -f $SYSTEM_ROOT/usr/share/bootloader/u-boot.img ]; then
-    echo "*** updating u-boot image on: $BOOT_DISK ..."
+    echo "Updating u-boot image on $BOOT_DISK"
     dd if=$SYSTEM_ROOT/usr/share/bootloader/u-boot.img of="$BOOT_DISK" bs=1K seek=69 conv=fsync &>/dev/null
   fi
 
   if [ -f $SYSTEM_ROOT/usr/share/bootloader/SPL ]; then
-    echo "*** updating u-boot SPL Blob on: $BOOT_DISK ..."
+    echo "Updating u-boot SPL on $BOOT_DISK"
     dd if=$SYSTEM_ROOT/usr/share/bootloader/SPL of="$BOOT_DISK" bs=1k seek=1 conv=fsync &>/dev/null
   fi
 

--- a/projects/NXP/devices/iMX6/filesystem/usr/share/bootloader/canupdate.sh
+++ b/projects/NXP/devices/iMX6/filesystem/usr/share/bootloader/canupdate.sh
@@ -1,1 +1,0 @@
-[ "$1" = "imx6.arm" ] && exit 0 || exit 1

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -196,28 +196,16 @@ devices = \
   },
   'NXP': {
     'iMX6': {
-      'cubox-dl': {
-        'dtb': 'imx6dl-cubox-i.dtb',
+      'cubox': {
+        'dtb': '',
         'config': 'mx6cuboxi_defconfig'
       },
-      'cubox-q': {
-        'dtb': 'imx6q-cubox-i.dtb',
-        'config': 'mx6cuboxi_defconfig'
-      },
-      'udoo-dl': {
-        'dtb': 'imx6dl-udoo.dtb',
+      'udoo': {
+        'dtb': '',
         'config': 'udoo_defconfig'
       },
-      'udoo-q': {
-        'dtb': 'imx6q-udoo.dtb',
-        'config': 'udoo_defconfig'
-      },
-      'wandboard-dl': {
-        'dtb': 'imx6dl-wandboard.dtb',
-        'config': 'wandboard_defconfig'
-      },
-      'wandboard-q': {
-        'dtb': 'imx6q-wandboard.dtb',
+      'wandboard': {
+        'dtb': '',
         'config': 'wandboard_defconfig'
       },
     },


### PR DESCRIPTION
This combines https://github.com/by-gnome/LibreELEC.tv/commit/de7b1d38ec57a71854afe4eb948e5ea32848578d and #4917 testing with FDTDIR to halve the number of iMX6 images from six to three. I've also added `canupdate.sh` to block upgrades from legacy images; total user numbers are small and support will be easier if we force a clean install. If testing subsequently proves upgrading LE 8.0/8.2 > LE 10.0 can be done reliably we can always merge another PR. Until then, it's been years since iMX6 had an active maintainer so let's keep it simple.

@by-gnome @etrax79 please test the images here https://chewitt.libreelec.tv/testing/9.80/ as I don't have iMX6 h/w