### PR TITLE
buildsystem: minors

### DIFF
--- a/config/options
+++ b/config/options
@@ -76,7 +76,7 @@ VERBOSE="${VERBOSE:-yes}"
 #  Try values between 1 and number of processor cores present.
 #  default: use all cores
 [ -z "${CONCURRENCY_MAKE_LEVEL}" ] && export CONCURRENCY_MAKE_LEVEL=$(nproc)
-[ -z "${CONCURRENCY_LOAD}" ] && export CONCURRENCY_LOAD=$(python3 -c "import os; print('%.2f' % (os.cpu_count() * 1.5))")
+[ -z "${CONCURRENCY_LOAD}" ] && export CONCURRENCY_LOAD=$(python3 -c "import os; print(f'{os.cpu_count() * 1.5:.2f}')")
 
 # cache size for ccache
 # Set the maximum size of the files stored in the cache. You can specify a

--- a/config/path
+++ b/config/path
@@ -64,7 +64,7 @@ XORG_PATH_DRIVERS=/usr/lib/xorg/modules/drivers
 # use ARM toolchain on 64/32 split builds
 if [ -z "$KERNEL_TOOLCHAIN" -a "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
   if [ "${MACHINE_HARDWARE_NAME}" = "x86_64" ]; then
-  KERNEL_TOOLCHAIN="aarch64-none-linux-gnu"
+    KERNEL_TOOLCHAIN="aarch64-none-linux-gnu"
   elif [ "${MACHINE_HARDWARE_NAME}" = "aarch64" ]; then
     KERNEL_TOOLCHAIN="aarch64-none-elf"
   else


### PR DESCRIPTION
Two minors for the buildsystem. The first in `config/path` is an indent fix. The second in `config/options` converts embedded python to use f-strings. This is a very (very) small performance improvement, but it may be noticeable on slow machines given how often options is sourced.

Use of f-strings makes the assumption the host's python3 is >=3.6. Python 3.5 went EOL September 2020, so I believe that is fair.