### PR TITLE
uboot_helper: convert to use argparse

### DIFF
--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -342,8 +342,6 @@ devices = \
   },
 }
 
-choices = ['dtb', 'config', 'crust_config']
-
 class OptionsAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
@@ -383,8 +381,12 @@ class OptionsAction(argparse.Action):
             soc = getattr(namespace, 'soc')
             board = getattr(namespace, 'board')
 
-            if values not in choices:
-                message = "invalid choice: {0!r} (choose from {1})".format(values, ', '.join([repr(value) for value in choices]))
+            if values is None:
+                print(' '.join(value for value in sorted(devices[project][soc][board].keys())))
+                parser.exit()
+
+            if values not in devices[project][soc][board].keys():
+                parser.exit()
 
         if message is not None:
             raise argparse.ArgumentError(self, message)
@@ -399,7 +401,7 @@ parser.add_argument('soc', nargs='?', action=OptionsAction)
 
 parser.add_argument('board', nargs='?', action=OptionsAction)
 
-parser.add_argument('value', nargs='?', metavar='|'.join(choices), action=OptionsAction)
+parser.add_argument('value', nargs='?', action=OptionsAction)
 
 options = parser.parse_args()
 

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
-import sys
+import argparse
 
 # When adding new devices to the list please keep them in alphabetical order
 # board-name should contain 'dashes' (-) not 'underscores' (_) and shouldn't contain capitals
@@ -342,77 +342,67 @@ devices = \
   },
 }
 
-def usage(PROJECT=None, SOC=None, FILE=sys.stdout):
-  print('Usage: %s <project> <soc> <board-name> dtb|config|crust_config' % sys.argv[0], file=FILE)
-  print('       %s <project> <soc>' % sys.argv[0], file=FILE)
-  print('       %s <project>' % sys.argv[0], file=FILE)
-  print('', file=FILE)
+choices = ['dtb', 'config', 'crust_config']
 
-  if PROJECT and PROJECT not in devices:
-    PROJECT = SOC = None
-  if PROJECT and SOC and SOC not in devices[PROJECT]:
-    SOC = None
+class OptionsAction(argparse.Action):
 
-  print('Projects:', file=FILE)
-  print('', file=FILE)
-  for project in sorted(devices):
-    if PROJECT is None or PROJECT == project:
-      print('  %s:' % project, file=FILE)
-      for soc in sorted(devices[project]):
-        if SOC is None or SOC == soc:
-          print('    %s:' % soc, file=FILE)
-          for board in sorted(devices[project][soc]):
-            print('      %s' % board, file=FILE)
-          print('', file=FILE)
-      print('', file=FILE)
+    def __call__(self, parser, namespace, values, option_string=None):
+        message = None
 
-def exit_error(msg, PROJECT=None, SOC=None):
-  print(msg, file=sys.stderr)
-  print('', file=sys.stderr)
-  usage(PROJECT=PROJECT, SOC=SOC, FILE=sys.stderr)
-  sys.exit(1)
+        if self.dest == 'project':
+            if values is None:
+                print(' '.join(project for project in sorted(devices)))
+                parser.exit()
 
-# Basic argument validation
-if len(sys.argv) == 2 and sys.argv[1] in ['help', 'usage']:
-  usage()
-  sys.exit(0)
+            if values not in devices.keys():
+                message = "invalid choice: {0!r} (choose from {1})".format(values, ', '.join([repr(project) for project in devices]))
 
-if len(sys.argv) > 1 and sys.argv[1] not in devices:
-  exit_error('Invalid project: %s' % sys.argv[1])
+        if self.dest == 'soc':
+            project = getattr(namespace, 'project')
 
-if len(sys.argv) > 2 and sys.argv[2] not in devices[sys.argv[1]]:
-  exit_error('Invalid soc: %s' % sys.argv[2], PROJECT=sys.argv[1])
+            if values is None:
+                print(' '.join(soc for soc in sorted(devices[project])))
+                parser.exit()
 
-if len(sys.argv) > 3 and sys.argv[3] not in devices[sys.argv[1]][sys.argv[2]]:
-  exit_error('Invalid board-name: %s' % sys.argv[3], PROJECT=sys.argv[1], SOC=sys.argv[2])
+            if values not in devices[project].keys():
+                message = "invalid choice: {0!r} (choose from {1})".format(values, ', '.join([repr(soc) for soc in devices[project]]))
 
-if len(sys.argv) == 4:
-  exit_error('Invalid option: must specify dtb, config or crust_config', PROJECT=sys.argv[1], SOC=sys.argv[2])
-elif len(sys.argv) > 4 and sys.argv[4] not in ['dtb', 'config', 'crust_config']:
-  exit_error('Invalid option: %s' % sys.argv[4], PROJECT=sys.argv[1], SOC=sys.argv[2])
+        if self.dest == 'board':
+            project = getattr(namespace, 'project')
+            soc = getattr(namespace, 'soc')
 
-if len(sys.argv) > 5:
-  exit_error('Invalid number of arguments: %s' % ' '.join(sys.argv[1:]), PROJECT=sys.argv[1], SOC=sys.argv[2])
+            if values is None:
+                print(' '.join(board for board in sorted(devices[project][soc])))
+                parser.exit()
 
-# Get dtb, u-boot or crust config for a given project, soc, and board
-# ./scripts/uboot_helper project device board-name dtb|config|crust_config
-if len(sys.argv) == 5:
-  if sys.argv[4] in devices[sys.argv[1]][sys.argv[2]][sys.argv[3]]:
-    print(devices[sys.argv[1]][sys.argv[2]][sys.argv[3]][sys.argv[4]])
+            if values not in devices[project][soc].keys():
+                message = "invalid choice: {0!r} (choose from {1})".format(values, ', '.join([repr(board) for board in devices[project][soc]]))
 
-# List boards supported by a given project and soc
-# ./scripts/uboot_helper project device
-elif len(sys.argv) == 3:
-  print(' '.join([board for board in sorted(devices[sys.argv[1]][sys.argv[2]])]))
+        if self.dest == 'value':
+            project = getattr(namespace, 'project')
+            soc = getattr(namespace, 'soc')
+            board = getattr(namespace, 'board')
 
-# List socs supported by a given project
-# ./scripts/uboot_helper project
-elif len(sys.argv) == 2:
-  print(' '.join([soc for soc in sorted(devices[sys.argv[1]])]))
+            if values not in choices:
+                message = "invalid choice: {0!r} (choose from {1})".format(values, ', '.join([repr(value) for value in choices]))
 
-# List projects
-# ./scripts/uboot_helper
-elif len(sys.argv) == 1:
-  print(' '.join([project for project in sorted(devices)]))
+        if message is not None:
+            raise argparse.ArgumentError(self, message)
 
-sys.exit(0)
+        setattr(namespace, self.dest, values)
+
+parser = argparse.ArgumentParser(description='Script to help with u-boot configuration')
+
+parser.add_argument('project', nargs='?', action=OptionsAction)
+
+parser.add_argument('soc', nargs='?', action=OptionsAction)
+
+parser.add_argument('board', nargs='?', action=OptionsAction)
+
+parser.add_argument('value', nargs='?', metavar='|'.join(choices), action=OptionsAction)
+
+options = parser.parse_args()
+
+print(devices[options.project][options.soc][options.board][options.value])
+
+parser.exit()


### PR DESCRIPTION
I originally wanted to use argparse when I wrote this script but didn't have the ability to do it then.

These change makes it much easier to read.

The functionality should be the exact same as before. The help has changed though.

```
$ ./scripts/uboot_helper --help                                                                                                                                                                                
usage: uboot_helper [-h] [project] [soc] [board] [dtb|config|crust_config]

Script to help with u-boot configuration

positional arguments:
  project
  soc
  board
  dtb|config|crust_config

optional arguments:
  -h, --help            show this help message and exit
```

@jernejsk @Kwiboo please test if you have a chance