### PR TITLE
[game.libretro.vecx] fix build issue when opengl is disabled

### DIFF
--- a/packages/emulation/libretro-vecx/package.mk
+++ b/packages/emulation/libretro-vecx/package.mk
@@ -15,7 +15,11 @@ PKG_LIBPATH="${PKG_LIBNAME}"
 PKG_LIBVAR="VECX_LIB"
 
 make_target() {
-  make
+  if [ "$OPENGL_SUPPORT" = no ]; then
+    HAS_GLES=1 make
+  else
+    make
+  fi
 }
 
 makeinstall_target() {


### PR DESCRIPTION
`PROJECT=Allwinner DEVICE=H3 ARCH=arm  scripts/create_addon game.libretro.vecx` command failed, ld unable to find GL, because Allwinner isn't config to support  OpenGL.


