### PR TITLE
vdr-addon updates

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-vnsiserver/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-vnsiserver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-vnsiserver"
-PKG_VERSION="908684b58a3ebd4a447bc4b0a82b0bd8059bf605"
-PKG_SHA256="6c39a2e9854632274cec2b11e4eaaea9edc4095856941672f40d0633ece506df"
+PKG_VERSION="47a90dd9298753083a9a6482bb9990ea9a88aa7a"
+PKG_SHA256="cd8087306dc5d77b150ca9f77bba91460507dc9a2336b9f61ce13aeefecf23e3"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/mdre77/vdr-plugin-vnsiserver"
 PKG_URL="https://github.com/mdre77/vdr-plugin-vnsiserver/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/vdr-addon/changelog.txt
+++ b/packages/addons/service/vdr-addon/changelog.txt
@@ -1,3 +1,6 @@
+114
+- update VNSI plugin to 47a90dd
+
 113
 - update VDR to 2.4.6
 - update VNSI plugin to 908684b

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="vdr-addon"
 PKG_VERSION="2.4.6"
-PKG_REV="113"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
Updated vdr-plugin-vnsiserver.

I also removed PKG_ADDON_REQUIRES="pvr.vdr.vnsi:0.0.0 script.config.vdr:0.0.0" from package.mk. Not sure why we should require them for vdr-addon installation.