### PR TITLE
game.libretro.mrboom: fix build issue and update to 5.2

### DIFF
--- a/packages/emulation/libretro-mrboom/package.mk
+++ b/packages/emulation/libretro-mrboom/package.mk
@@ -2,11 +2,12 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mrboom"
-PKG_VERSION="e074bafa1fe9480df1ba412752912a2c2c454958"
-PKG_SHA256="ac337b339cb1da9d013745c72b59b84ee64d94ada8f303be671e680d50061c15"
-PKG_LICENSE="GPLv3"
-PKG_SITE="https://github.com/libretro/mrboom-libretro"
-PKG_URL="https://github.com/libretro/mrboom-libretro/archive/${PKG_VERSION}.tar.gz"
+PKG_VERSION="5.2"
+PKG_SUBVER=".454d614"
+PKG_SHA256="50e4fe4bc74b23ac441499c756c4575dfe9faab9e787a3ab942a856ac63cf10d"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/Javanaise/mrboom-libretro"
+PKG_URL="https://github.com/Javanaise/mrboom-libretro/releases/download/${PKG_VERSION}/MrBoom-src-${PKG_VERSION}${PKG_SUBVER}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_LONGDESC="game.libretro.mrboom: mrboom for Kodi"
 

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mrboom"
-PKG_VERSION="5.0.0.118-Matrix"
-PKG_SHA256="2e7db249d046d3ec5843b5db0de5366185a647077aae84b4223edc4e8efee62d"
+PKG_VERSION="5.2.0.122-Matrix"
+PKG_SHA256="8b48ad277e213f8210cfeabb2930217db06fe8045c3cc86c9c197364b399b5bc"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
due to GET_HANDLER_SUPPORT limited to archive, libretro.mrboom has gitsubmodule,
which will not included in github's default release tar.gz, thus build failed.

add PKG_DEPENDS_UNPACK="libretro-common"

BTW, update version to 5.2