### PR TITLE
iMX6: modify Wandboard device tree to apply i2c bus recovery

### DIFF
--- a/projects/NXP/devices/iMX6/patches/linux/linux-002-imx6qdl-wandboard-dtsi-i2c-bus-recovery.patch
+++ b/projects/NXP/devices/iMX6/patches/linux/linux-002-imx6qdl-wandboard-dtsi-i2c-bus-recovery.patch
@@ -1,0 +1,56 @@
+Add scl/sda gpios defitions for i2c bus recovery.
+
+--- a/arch/arm/boot/dts/imx6qdl-wandboard.dtsi
++++ b/arch/arm/boot/dts/imx6qdl-wandboard.dtsi
+@@ -97,15 +97,21 @@
+ 
+ &i2c1 {
+ 	clock-frequency = <100000>;
+-	pinctrl-names = "default";
++	pinctrl-names = "default", "gpio";
+ 	pinctrl-0 = <&pinctrl_i2c1>;
++	pinctrl-1 = <&pinctrl_i2c1_gpio>;
++	scl-gpios = <&gpio3 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
++	sda-gpios = <&gpio3 28 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+ 	status = "okay";
+ };
+ 
+ &i2c2 {
+ 	clock-frequency = <100000>;
+-	pinctrl-names = "default";
++	pinctrl-names = "default", "gpio";
+ 	pinctrl-0 = <&pinctrl_i2c2>;
++	pinctrl-1 = <&pinctrl_i2c2_gpio>;
++	scl-gpios = <&gpio4 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;	
++	sda-gpios = <&gpio4 13 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+ 	status = "okay";
+ 
+ 	codec: sgtl5000@a {
+@@ -185,6 +191,13 @@
+ 			>;
+ 		};
+ 
++		pinctrl_i2c1_gpio: i2c1gpiogrp {
++			fsl,pins = <
++				MX6QDL_PAD_EIM_D21__GPIO3_IO21		0x4001b8b0
++				MX6QDL_PAD_EIM_D28__GPIO3_IO28		0x4001b8b0
++			>;
++		};
++
+ 		pinctrl_i2c2: i2c2grp {
+ 			fsl,pins = <
+ 				MX6QDL_PAD_KEY_COL3__I2C2_SCL		0x4001b8b1
+@@ -192,6 +205,13 @@
+ 			>;
+ 		};
+ 
++		pinctrl_i2c2_gpio: i2c2gpiogrp {
++			fsl,pins = <
++				MX6QDL_PAD_KEY_COL3__GPIO4_IO12		0x4001b8b0
++				MX6QDL_PAD_KEY_ROW3__GPIO4_IO13		0x4001b8b0
++			>;
++		};
++
+ 		pinctrl_mclk: mclkgrp {
+ 			fsl,pins = <
+ 				MX6QDL_PAD_GPIO_0__CCM_CLKO1		0x130b0


### PR DESCRIPTION
In Wandboard the i2c bus sometimes(often) stuck during transmission, this can happen when reading EDID from the TV and lead to incorrect resolution and no sound. Add scl/sda gpios definitions to the device tree for i2c bus recovery.