### PR TITLE
Allwinner: Add installation script

### DIFF
--- a/projects/Allwinner/filesystem/usr/bin/install2emmc
+++ b/projects/Allwinner/filesystem/usr/bin/install2emmc
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+TMP=/tmp/mnt/
+
+SYSTEM_SIZE=512
+UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
+UUID_STORAGE="$(uuidgen)"
+BOOT=$(grep /flash /proc/mounts | awk '{print $1}' | sed 's/p[012]//g')
+DISK=""
+
+if [ ! -f /usr/share/bootloader/u-boot-sunxi-with-spl.bin ]; then
+  echo "U-Boot not found. Please update current installation with board specific update or image first."
+  exit 1
+fi
+
+for TYPE in /sys/class/block/mmcblk*/device/type; do
+  if grep -q "MMC" "${TYPE}"; then
+    DISK="/dev/$(echo "${TYPE}" | awk -F/ '{print $5}')"
+    break
+  fi
+done
+
+if [ -z "${DISK}" ]; then
+  echo "Can't find eMMC module!"
+  exit 1
+fi
+
+if [ "${BOOT}" = "${DISK}" ]; then
+  echo "Your device is booted from the eMMC module!"
+  exit 1
+fi
+
+echo ""
+echo -e "\033[36m==============================="
+echo "Installing LibreELEC to eMMC"
+echo -e "===============================\033[37m"
+echo ""
+echo "eMMC found at ${DISK}"
+echo ""
+
+if [ ! -b "${DISK}" ]; then
+    echo "Error: eMMC not found."
+    exit 1
+fi
+
+echo ""
+echo -n "WARNING: ALL DATA ON eMMC WILL BE ERASED! Continue (y/N)?  "
+read -n 1 ANSWER
+
+if [ ! "${ANSWER}" = "y" ]; then
+  echo ""
+  echo "Aborting..."
+  exit 0
+fi
+echo ""
+
+umount ${DISK}* > /dev/null 2>&1
+
+echo "Erasing eMMC ..."
+dd if=/dev/zero of="${DISK}" bs=1M count=1 conv=fsync > /dev/null 2>&1
+
+echo "Creating partitions"
+parted -s "${DISK}" mklabel msdos
+parted -s "${DISK}" -a optimal mkpart primary fat32 0% ${SYSTEM_SIZE}MiB
+parted -s "${DISK}" set 1 boot on
+parted -s "${DISK}" -a optimal mkpart primary ext4 ${SYSTEM_SIZE}MiB 100%
+sync
+
+echo "Creating filesystems"
+dd if=/dev/zero of="${DISK}p1" bs=1M count=1 conv=fsync > /dev/null 2>&1
+mkfs.vfat -n SYSTEM -i ${UUID_SYSTEM//-/} ${DISK}p1 > /dev/null 2>&1
+dd if=/dev/zero of="${DISK}p2" bs=1M count=1 conv=fsync > /dev/null 2>&1
+mkfs.ext4 -L STORAGE -U ${UUID_STORAGE} ${DISK}p2 > /dev/null 2>&1
+sync
+
+echo "Installing bootloader"
+dd if=/usr/share/bootloader/u-boot-sunxi-with-spl.bin of="${DISK}" bs=1k seek=8 conv=fsync > /dev/null 2>&1
+
+echo "Copying system files"
+
+mkdir -p ${TMP}
+
+mount -t vfat ${DISK}p1 ${TMP}
+
+cp -R /flash/. ${TMP}/
+sync
+
+echo "Adjusting partition UUIDs"
+
+sed -i "s/boot=UUID=[0-9a-f\-]*/boot=UUID=${UUID_SYSTEM}/g" ${TMP}/extlinux/extlinux.conf
+sed -i "s/disk=UUID=[0-9a-f\-]*/disk=UUID=${UUID_STORAGE}/g" ${TMP}/extlinux/extlinux.conf
+
+umount ${TMP}
+
+echo "Done"


### PR DESCRIPTION
This PR adds installation script for Allwinner images. Script recreates clean image on eMMC using files from current installation. Storage partition is already extended to full size, so additional resize step after booting from eMMC is not necessary.

If user wants to transfer Kodi configuration, backup/restore functionality must be used.