### PR TITLE
dtc: Build dtc also for host

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -13,9 +13,11 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="The Device Tree Compiler"
 
 PKG_MAKE_OPTS_TARGET="dtc fdtput fdtget libfdt"
-PKG_MAKE_OPTS_HOST="libfdt"
+PKG_MAKE_OPTS_HOST="dtc libfdt"
 
 makeinstall_host() {
+  mkdir -p ${TOOLCHAIN}/bin
+    cp -P ${PKG_BUILD}/dtc ${TOOLCHAIN}/bin
   mkdir -p ${TOOLCHAIN}/lib
     cp -P ${PKG_BUILD}/libfdt/libfdt.so ${TOOLCHAIN}/lib
 }


### PR DESCRIPTION
This should fix build issue for Allwinner images when dtc is not installed on system.