### PR TITLE
checkdeps: add qemu-user as req for native aarch64 Amlogic builds

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -93,8 +93,8 @@ perl_map=(
 
 ### PROJECT SPECIFIC REQUIREMENTS ###
 # Extend build scripts to look for distro/project/device checkdep scripts before adding further checks here
-# Native aarch64 on debian(?) host Rockchip needs to support rkbin
-if [ "$(uname -m)" = "aarch64" -a "${PROJECT}" = "Rockchip" ]; then
+# Native aarch64 on debian host needs to support rkbin (Rockchip) and aml_encrypt_* (Amlogic)
+if [ "$(uname -m)" = "aarch64" ] && [ "${PROJECT}" = "Rockchip" -o "${PROJECT}" = "Amlogic" ]; then
   dep_map[qemu-x86_64]=qemu-user-binfmt
   if [ ! -f /lib64/ld-linux-x86-64.so.2 -o ! -f /lib/x86_64-linux-gnu/libc.so.6 ]; then
     echo -e "Copy from a working x86_64 system:\n\t/lib64/ld-linux-x86-64.so.2\n\t/lib/x86_64-linux-gnu/libc.so.6"


### PR DESCRIPTION
Amlogic has image specific aml_encrypt_* binaries for creating(?) the firmware image package. Said binaries are for x86-64, so require qemu-binfmt-user on native builds.

@150balbes 