### PR TITLE
nss: update to 3.64 and nspr to 4.30

### DIFF
--- a/packages/security/nspr/package.mk
+++ b/packages/security/nspr/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nspr"
-PKG_VERSION="4.29"
+PKG_VERSION="4.30"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/svn/general/nspr.html"
 PKG_DEPENDS_HOST="ccache:host"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.60.1"
-PKG_SHA256="696b2abca0f76848484d82fd614b0020966f1e97cd8902f1ec28bbeb301a22fb"
+PKG_VERSION="3.64"
+PKG_SHA256="2ff04af68135b5777aed558fe8a895d6cf855cbbdef6738d87f1ac3c8cbb2785"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
nspr: update to 4.30 
nss: update to 3.64
- update 3.60.1 (04-Jan-2021) to 3.64 (15-Apr-2021)
- https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases