### PR TITLE
Mako: update to 1.1.4

### DIFF
--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Mako"
-PKG_VERSION="1.1.3"
-PKG_SHA256="8195c8c1400ceb53496064314c6736719c6f25e7479cd24c77be3d9361cddc27"
+PKG_VERSION="1.1.4"
+PKG_SHA256="17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/Mako"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 1.1.3 to 1.1.4
changelog: https://docs.makotemplates.org/en/latest/changelog.html#id1