### PR TITLE
add ENABLED_DTOVERLAYS config variable

### DIFF
--- a/config/show_config
+++ b/config/show_config
@@ -48,6 +48,10 @@ show_config() {
     config_message+="\n - Include firmware:\t\t\t $config_firmware"
   done
 
+  for config_enabled_dtoverlay in $ENABLED_DTOVERLAYS; do
+    config_message+="\n - Enable DT overlay:\t\t\t $config_enabled_dtoverlay"
+  done
+
   # Misc. Filesystems
 
   config_message+="\n\n Misc. Filesystems:"

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -64,3 +64,8 @@
 
   # additional packages to install:
     ADDITIONAL_PACKAGES="dt-overlays"
+
+  # u-boot device-tree overlays to enable:
+  # Whitespace separated list without path and extension,
+  # e.g. ENABLED_DTOVERLAYS="sun8i-h2-plus-bpi-m2-zero-ethernet"
+    ENABLED_DTOVERLAYS=""

--- a/scripts/image
+++ b/scripts/image
@@ -54,6 +54,7 @@ function do_mkimage() {
     SYSTEM_SIZE="${SYSTEM_SIZE}" \
     SYSTEM_PART_START="${SYSTEM_PART_START}" \
     OVA_SIZE="${OVA_SIZE}" \
+    ENABLED_DTOVERLAYS="${ENABLED_DTOVERLAYS}" \
     ${SCRIPTS}/mkimage
 }
 

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -225,12 +225,17 @@ elif [ "${BOOTLOADER}" = "u-boot" -a -n "${UBOOT_SYSTEM}" ]; then
 
     mkdir -p "${LE_TMP}/extlinux"
 
-    cat << EOF > "${LE_TMP}/extlinux/extlinux.conf"
+    EXTLINUX_CONF="${LE_TMP}/extlinux/extlinux.conf"
+    cat << EOF > "${EXTLINUX_CONF}"
 LABEL ${DISTRO}
   LINUX /${KERNEL_NAME}
   FDT /${DTB}
   APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} quiet ${EXTRA_CMDLINE}
 EOF
+    if [ -n "${ENABLED_DTOVERLAYS}" ]; then
+      dtoverlays=($ENABLED_DTOVERLAYS)
+      echo "  FDTOVERLAYS" $(printf "/overlays/%s.dtbo" ${dtoverlays[@]}) >> ${EXTLINUX_CONF}
+    fi
 
     mcopy -s "${LE_TMP}/extlinux" ::
   fi


### PR DESCRIPTION
This is a whitespace separated list of u-boot device-tree overlays that
should be added to FDTOVERLAYS in extlinux.conf

Signed-off-by: Michael Klein <michael@fossekall.de>