### PR TITLE
WIP: glvnd/mesa: fix build when opengl enabled but X11 disabled

### DIFF
--- a/packages/graphics/libglvnd/package.mk
+++ b/packages/graphics/libglvnd/package.mk
@@ -7,12 +7,18 @@ PKG_SHA256="6f41ace909302e6a063fd9dc04760b391a25a670ba5f4b6edf9e30f21410b673"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/NVIDIA/libglvnd"
 PKG_URL="https://github.com/NVIDIA/libglvnd/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain libX11 libXext xorgproto"
+PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="libglvnd is a vendor-neutral dispatch layer for arbitrating OpenGL API calls between multiple vendors."
 PKG_TOOLCHAIN="autotools"
 
 if [ "${OPENGLES_SUPPORT}" = "no" ]; then
-  PKG_CONFIGURE_OPTS_TARGET+=" --disable-gles"
+  PKG_CONFIGURE_OPTS_TARGET+=" --disable-gles1 --disable-gles2"
+fi
+
+if [ "${DISPLAYSERVER}" != "x11" ]; then
+  PKG_CONFIGURE_OPTS_TARGET+=" --disable-x11"
+else
+  PKG_DEPENDS_TARGET+=" libX11 libXext xorgproto"
 fi
 
 post_makeinstall_target() {

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -34,15 +34,22 @@ PKG_MESON_OPTS_TARGET="-Ddri-drivers=${DRI_DRIVERS// /,} \
                        -Dselinux=false \
                        -Dosmesa=none"
 
+if [ ${OPENGL_SUPPORT} = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" libglvnd"
+  PKG_MESON_OPTS_TARGET+=" -Dglvnd=true"
+else
+  PKG_MESON_OPTS_TARGET+=" -Dglvnd=false"
+fi
+
 if [ "${DISPLAYSERVER}" = "x11" ]; then
-  PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr libglvnd"
+  PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr"
   export X11_INCLUDES=
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms=x11 -Ddri3=enabled -Dglx=dri -Dglvnd=true"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms=x11 -Ddri3=enabled -Dglx=dri"
 elif [ "${DISPLAYSERVER}" = "weston" ]; then
   PKG_DEPENDS_TARGET+=" wayland wayland-protocols"
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms=wayland -Ddri3=disabled -Dglx=disabled -Dglvnd=false"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms=wayland -Ddri3=disabled -Dglx=disabled"
 else
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms="" -Ddri3=disabled -Dglx=disabled -Dglvnd=false"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms="" -Ddri3=disabled -Dglx=disabled"
 fi
 
 if [ "${LLVM_SUPPORT}" = "yes" ]; then


### PR DESCRIPTION
mesa doesn't provide libGL, thus when OpenGL is enabled, any pkg link to libGL will failed to build.

use glvnd to provide libGL, and build it when OpenGL is supported.

BTW: when X11 is disabled, glvnd should not link to X11, and fix disable gles options.