### PR TITLE
dthelper: only flag memsize for pi and 512mb boards

### DIFF
--- a/packages/sysutils/busybox/scripts/dthelper
+++ b/packages/sysutils/busybox/scripts/dthelper
@@ -51,8 +51,7 @@ do_dtflag(){
     if [ "${MEMSIZE}" -lt "524288" ]; then
       MEMSIZE="-512"
     else
-      MEMSIZE=$(( $MEMSIZE / ( 1024 * 1024 ) + 1 ))
-      MEMSIZE="-${MEMSIZE}g"
+      MEMSIZE=""
     fi
   fi
   echo "${DTFLAG}${MEMSIZE}"


### PR DESCRIPTION
It's good to know ram size for Pi boards (and works well) but for other SoC types the board name 99% correlates to a known config so we don't really need to capture it and Allwinner/Amlogic/Rockchip stats get easier to read. I've left 512MB devices as an exception since we don't formally support <1GB non-pi devices and it's good to expose them.