### PR TITLE
system-tools: fix addon compile issues and update stress-ng

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
@@ -17,18 +17,26 @@ pre_make_target() {
 }
 
 make_target() {
+  make  CC="${CC}" \
+        AR="${AR}" \
+        CFLAGS="${TARGET_CFLAGS}" \
+        CPPFLAGS="${TARGET_CPPFLAGS} -I${SYSROOT_PREFIX}/usr/include/${PKG_PYTHON_VERSION}" \
+        PYTHON=${TOOLCHAIN}/bin/python3 \
+        all
+
   make  EXTRA="py-smbus" \
         CC="${CC}" \
         AR="${AR}" \
         CFLAGS="${TARGET_CFLAGS}" \
         CPPFLAGS="${TARGET_CPPFLAGS} -I${SYSROOT_PREFIX}/usr/include/${PKG_PYTHON_VERSION}" \
-        PYTHON=${TOOLCHAIN}/bin/python3
+        PYTHON=${TOOLCHAIN}/bin/python3 \
+        all-python
 }
 
 makeinstall_target() {
-  make  DESTDIR=${INSTALL} \
+  make  EXTRA="py-smbus" \
+        DESTDIR=${INSTALL} \
         PREFIX="/usr" \
-        EXTRA="py-smbus" \
         PYTHON=${TOOLCHAIN}/bin/python3 \
         install
 }

--- a/packages/addons/addon-depends/system-tools-depends/strace/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/strace/package.mk
@@ -11,3 +11,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="strace is a diagnostic, debugging and instructional userspace utility"
 PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="-sysroot"
+
+if [ "${TARGET_ARCH}" = x86_64 ]; then
+  PKG_CONFIGURE_OPTS_TARGET="--enable-mpers=no"
+fi

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.12.01"
-PKG_SHA256="d354bbbb1500cfe043c761014dc9c3f62779747fafea8a19af94402327f6d3fc"
+PKG_VERSION="0.12.02"
+PKG_SHA256="f847be115f60d3ad7d37c806fd1bfb1412aa3c631fca581d6dc233322f50d6a5"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://kernel.ubuntu.com/~cking/stress-ng/"
 PKG_URL="https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-${PKG_VERSION}.tar.xz"

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,5 +1,8 @@
 120
 - htop: update to 3.0.5
+- i2c-tools: fix runtime libraries
+- strace: fix compile on Generic due to mpers
+- stress-ng: update to 0.12.02
 
 119
 - dstat: update to 2020-06-19

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -104,6 +104,9 @@ addon() {
     # i2c-tools
     cp -P $(get_install_dir i2c-tools)/usr/sbin/{i2cdetect,i2cdump,i2cget,i2cset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir i2c-tools)/usr/lib/${PKG_PYTHON_VERSION}/site-packages/smbus.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0.1.1
 
     # inotify-tools
     cp -P $(get_install_dir inotify-tools)/usr/bin/{inotifywait,inotifywatch} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin


### PR DESCRIPTION
- i2c-tools: fix compile of libraries
- strace: fix compile on Generic due to mpers
- stress-ng: update to 0.12.02

Compile of i2c-tools was failing on a clean create_addon compile (on a build or a second go it would compile) isolated the issue down to the python compile of smbus.so must be done separately to pickup the shared library.

Took the opportunity to bump stress-ng 

compile of strace on Generic was also failing with m32/mx32 errors. Notes and reference to the addition of mpers setting - https://sourceforge.net/p/strace/mailman/message/36236388/ 

