### PR TITLE
H3: use opengl

### DIFF
--- a/projects/Allwinner/devices/H3/filesystem/etc/X11/xorg.conf.d/02-lima.conf
+++ b/projects/Allwinner/devices/H3/filesystem/etc/X11/xorg.conf.d/02-lima.conf
@@ -1,0 +1,6 @@
+Section "OutputClass"
+    Identifier "Lima"
+    MatchDriver "sun4i-drm"
+    Driver "modesetting"
+    Option "PrimaryGPU" "true"
+EndSection

--- a/projects/Allwinner/devices/H3/options
+++ b/projects/Allwinner/devices/H3/options
@@ -43,11 +43,19 @@
   # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
     OPENGLES="mesa"
 
+    OPENGL="mesa"
+
+    GRAPHIC_DRIVERS+=" swrast"
+
+    DISPLAYSERVER="x11"
+
+    WINDOWMANAGER="fluxbox"
+
   # Mali GPU family
     MALI_FAMILY="400"
 
   # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
-    KODIPLAYER_DRIVER="$OPENGLES"
+    KODIPLAYER_DRIVER="default"
 
   # set the addon project
     ADDON_PROJECT="ARMv7"


### PR DESCRIPTION
this PR enables openGL (lima) on H3, which fix not able to run game emulator issue.

inspired from Lakka, I check Lakka settings, GL is used, thus I guess need openGL to run games.

in this PR, X11 is also enabled, due to it looks like a requirement to enable openGL. and enble windowsmanager same reason.

and due to lima lack of some extensions, thus Xorg requires swrast to provide right GLX vinfo to kodi, without that, kodi will crash.

the ability to run game emulator is a function provided by LibreELEC, thus it needs to be fixed.

what have tested:
kodi displays normal.
game 2048 main screen is shown, and normal. lima pp interrupt is running.

due to not check video playback, make it a draft PR.

this PR depends on
https://github.com/LibreELEC/LibreELEC.tv/pull/5045
https://github.com/LibreELEC/LibreELEC.tv/pull/5046


