### PR TITLE
dtc: because of adding building for host a make clean is needed

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -15,11 +15,19 @@ PKG_LONGDESC="The Device Tree Compiler"
 PKG_MAKE_OPTS_TARGET="dtc fdtput fdtget libfdt"
 PKG_MAKE_OPTS_HOST="dtc libfdt"
 
+pre_make_host() {
+  make clean
+}
+
 makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/bin
     cp -P ${PKG_BUILD}/dtc ${TOOLCHAIN}/bin
   mkdir -p ${TOOLCHAIN}/lib
     cp -P ${PKG_BUILD}/libfdt/libfdt.so ${TOOLCHAIN}/lib
+}
+
+pre_make_target() {
+  make clean
 }
 
 makeinstall_target() {


### PR DESCRIPTION
linking fails as the libraries need to be cleaned out before switching from target to host and vice versa.
issue got introduced by https://github.com/LibreELEC/LibreELEC.tv/commit/d3a1c8f230e4a24e46c90aaf6d20a491b2506d7e