### PR TITLE
linux (RPi): add patch to fix zoom in video player

### DIFF
--- a/packages/linux/patches/raspberrypi/linux-010-vc4-plane-Dont-reject-fractional-source-coords.patch
+++ b/packages/linux/patches/raspberrypi/linux-010-vc4-plane-Dont-reject-fractional-source-coords.patch
@@ -1,0 +1,23 @@
+From 023078a22c3a6baf6339c946aa7be3c8f1b90a14 Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Sat, 23 Jan 2021 18:00:48 +0000
+Subject: [PATCH] vc4_place: Don't reject fractional source coords
+
+---
+ drivers/gpu/drm/vc4/vc4_plane.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/vc4/vc4_plane.c b/drivers/gpu/drm/vc4/vc4_plane.c
+index b5586c92bfe54..1947798f3eaf3 100644
+--- a/drivers/gpu/drm/vc4/vc4_plane.c
++++ b/drivers/gpu/drm/vc4/vc4_plane.c
+@@ -358,7 +358,8 @@ static int vc4_plane_setup_clipping_and_scaling(struct drm_plane_state *state)
+ 	    (state->src.x2 & subpixel_src_mask) ||
+ 	    (state->src.y1 & subpixel_src_mask) ||
+ 	    (state->src.y2 & subpixel_src_mask)) {
+-		return -EINVAL;
++		DRM_DEBUG_KMS("Invalid subpixel scaling %x %x %x %x (%x)\n", state->src.x1, state->src.x2, state->src.y1, state->src.y2, subpixel_src_mask);
++		//return -EINVAL;
+ 	}
+ 
+ 	vc4_state->src_x = state->src.x1 >> 16;


### PR DESCRIPTION
This also fixes playback issues of 720p videos if no 720p modes
are whitelisted or refresh switch is disabled after the pixel-wrap
workaround commit 01e90a2882.

Fixes: #5048 