### PR TITLE
Allwinner: Fix DT overlay copy

### DIFF
--- a/projects/Allwinner/bootloader/release
+++ b/projects/Allwinner/bootloader/release
@@ -11,4 +11,4 @@ mkdir -p "$DSTDIR/overlays"
 
   cp -a "$SRCDIR"/sun*-${DEVICE,,}-*.dtb "$DSTDIR"
 
-  cp -a "$SRCDIR"/overlays/sun*-${DEVICE,,}-*.dtbo "$DSTDIR"/overlays
+  cp -a "$SRCDIR"/overlays/sun*-${DEVICE,,}-*.dtbo "$DSTDIR"/overlays > /dev/null 2>&1 || true


### PR DESCRIPTION
Currently, if no DT overlay exists for specific device, image building fails. Fix that by ignoring copy error.