### PR TITLE
libglvnd: switch to meson toolchain

### DIFF
--- a/packages/graphics/libglvnd/package.mk
+++ b/packages/graphics/libglvnd/package.mk
@@ -9,10 +9,10 @@ PKG_SITE="https://github.com/NVIDIA/libglvnd"
 PKG_URL="https://github.com/NVIDIA/libglvnd/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libX11 libXext xorgproto"
 PKG_LONGDESC="libglvnd is a vendor-neutral dispatch layer for arbitrating OpenGL API calls between multiple vendors."
-PKG_TOOLCHAIN="autotools"
 
 if [ "${OPENGLES_SUPPORT}" = "no" ]; then
-  PKG_CONFIGURE_OPTS_TARGET+=" --disable-gles"
+  PKG_MESON_OPTS_TARGET="-Dgles1=false \
+                         -Dgles2=false"
 fi
 
 post_makeinstall_target() {


### PR DESCRIPTION
Switch to meson build & disable OpenGL ES1 & ES2 if it's not enabled.