### PR TITLE
qtbase: disable zstd support

### DIFF
--- a/packages/addons/addon-depends/qtbase/package.mk
+++ b/packages/addons/addon-depends/qtbase/package.mk
@@ -31,6 +31,7 @@ PKG_CONFIGURE_OPTS_TARGET="-prefix /usr
                            -no-icu
                            -qt-pcre
                            -system-zlib
+                           -no-zstd
                            -openssl-linked
                            -no-libproxy
                            -no-cups


### PR DESCRIPTION
This prevents qtbase picking up libzstd if it had been built before and creating broken hyperion binaries (dynamically linking to non-existent libzstd.so.1)

Fixes the issue reported on forum: https://forum.libreelec.tv/thread/23388-hyperion-x11-error-while-loading-shared-libraries-libzstd-so-1-cannot-open-share/