### PR TITLE
strace: dont build 32bit support for aarch64

### DIFF
--- a/packages/debug/strace/package.mk
+++ b/packages/debug/strace/package.mk
@@ -11,6 +11,6 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="strace is a diagnostic, debugging and instructional userspace utility"
 PKG_TOOLCHAIN="autotools"
 
-if [ "${TARGET_ARCH}" = x86_64 ]; then
+if [ "${TARGET_ARCH}" = x86_64 -o "${TARGET_ARCH}" = "aarch64" ]; then
   PKG_CONFIGURE_OPTS_TARGET="--enable-mpers=no"
 fi


### PR DESCRIPTION
32-bit binaries shouldn't be present in said build. Presently, it errors with:

checking for m32 personality compile support (using   -I.  )... no
checking whether to enable m32 personality support... no
configure: error: Cannot enable m32 personality support
