### PR TITLE
Update X11 packages (minors)

### DIFF
--- a/packages/x11/lib/libXt/package.mk
+++ b/packages/x11/lib/libXt/package.mk
@@ -3,13 +3,13 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXt"
-PKG_VERSION="1.2.0"
-PKG_SHA256="b31df531dabed9f4611fc8980bc51d7782967e2aff44c4105251a1acb5a77831"
+PKG_VERSION="1.2.1"
+PKG_SHA256="679cc08f1646dbd27f5e48ffe8dd49406102937109130caab02ca32c083a3d60"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11 libSM"
-PKG_LONGDESC="LibXt provides the X Toolkit Intrinsics, an abstract widget library upon which other toolkits are based."
+PKG_LONGDESC="libXt provides the X Toolkit Intrinsics library, an abstract widget library upon which other toolkits are based."
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/x11/util/util-macros/package.mk
+++ b/packages/x11/util/util-macros/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="util-macros"
-PKG_VERSION="1.19.2"
-PKG_SHA256="d7e43376ad220411499a79735020f9d145fdc159284867e99467e0d771f3e712"
+PKG_VERSION="1.19.3"
+PKG_SHA256="0f812e6e9d2786ba8f54b960ee563c0663ddbe2434bf24ff193f5feab1f31971"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/util/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
Update X11 packages

util-macros: update to 1.19.3
- update 1.19.2 (2018-03-05) to 1.19.3 (2021-01-24)
- changelog: https://gitlab.freedesktop.org/xorg/util/macros/-/commits/master/

libXt: update to 1.2.1
- update 1.2.0 (2019-06-21) to 1.2.1 (2021-01-24)
- changelog: https://github.com/freedesktop/xorg-libXt/commits/master