### PR TITLE
pigz: update to 2.5

### DIFF
--- a/packages/compress/pigz/package.mk
+++ b/packages/compress/pigz/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pigz"
-PKG_VERSION="2.4"
-PKG_SHA256="e228e7d18b34c4ece8d596eb6eee97bde533c6beedbb728d07d3abe90b4b1b52"
+PKG_VERSION="2.5"
+PKG_SHA256="13b9945999c0b20052f320943302f3160e2639bcc362e5e4182b198ea0e88b0a"
 PKG_LICENSE="Other"
 PKG_SITE="https://zlib.net/pigz/"
 PKG_URL="https://github.com/madler/pigz/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 2.4 (2017-12-26) to 2.5 (2021-01-24)
log: https://github.com/madler/pigz/commits/master
changelog (from pigz.c):
- Add --alias/-A option to set .zip name for stdin input
- Add --comment/-C option to add comment in .gz or .zip
- Fix a bug that misidentified a multi-entry .zip
- Fix a bug that did not emit double syncs for -i -p 1
- Fix a bug in yarn that could try to access freed data
- Do not delete multi-entry .zip files when extracting
- Do not reject .zip entries with bit 11 set
- Avoid a possible threads lock-order inversion
- Ignore trailing junk after a gzip stream by default