### PR TITLE
jre.zulu: update addon to JDK11 (101)

### DIFF
--- a/packages/addons/addon-depends/jre-depends/jdk-aarch64-zulu/package.mk
+++ b/packages/addons/addon-depends/jre-depends/jdk-aarch64-zulu/package.mk
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Peter Vicman (peter.vicman@gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jdk-aarch64-zulu"
-PKG_VERSION="8.38.0.162-1.8.0_212"
-PKG_SHA256="2afa6b9a86fea6f9275856506b5cc1efd8420f674c5e2dc3e1b04e140d6ad852"
+PKG_VERSION="11.45.27-11.0.10"
+PKG_SHA256="e5d211df9576040919eb22884189b59f50cd319877c8855e37714eff1b327d2b"
 PKG_LICENSE="GPLv2"
+if [ ! "${HOSTTYPE}" = "${TARGET_ARCH}" ]; then
+  PKG_DEPENDS_UNPACK="jdk-${HOSTTYPE}-zulu"
+fi
 PKG_SITE="https://www.azul.com/products/zulu-embedded/"
 PKG_URL="http://cdn.azul.com/zulu-embedded/bin/zulu${PKG_VERSION%%-*}-ca-jdk${PKG_VERSION##*-}-linux_aarch64.tar.gz"
 PKG_LONGDESC="Zulu, the open Java(TM) platform from Azul Systems."
@@ -12,4 +16,8 @@ PKG_TOOLCHAIN="manual"
 
 post_unpack() {
   rm -f ${PKG_BUILD}/src.zip
+
+  # Create a runtime image with all Java SE modules
+  cd $(get_build_dir jdk-${HOSTTYPE}-zulu) # this is the buildhost.ARCH
+    bin/jlink --module-path ${PKG_BUILD}/jmods --output ${PKG_BUILD}/jre11 --add-modules java.se
 }

--- a/packages/addons/addon-depends/jre-depends/jdk-arm-zulu/package.mk
+++ b/packages/addons/addon-depends/jre-depends/jdk-arm-zulu/package.mk
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Peter Vicman (peter.vicman@gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jdk-arm-zulu"
-PKG_VERSION="8.38.0.163-1.8.0_212"
-PKG_SHA256="bc45f41eab6e55c4e740e980001831c5e35db85745ec61a2b110e816e1074715"
+PKG_VERSION="11.45.27-11.0.10"
+PKG_SHA256="1f19d69f14057f8da549a166e897ee99fa8a47a647f8326205378246fe8b7a52"
 PKG_LICENSE="GPLv2"
+if [ ! "${HOSTTYPE}" = "${TARGET_ARCH}" ]; then
+  PKG_DEPENDS_UNPACK="jdk-${HOSTTYPE}-zulu"
+fi
 PKG_SITE="https://www.azul.com/products/zulu-embedded/"
 PKG_URL="https://cdn.azul.com/zulu-embedded/bin/zulu${PKG_VERSION%%-*}-ca-jdk${PKG_VERSION##*-}-linux_aarch32hf.tar.gz"
 PKG_LONGDESC="Zulu, the open Java(TM) platform from Azul Systems."
@@ -13,7 +17,10 @@ PKG_TOOLCHAIN="manual"
 post_unpack() {
   rm -f ${PKG_BUILD}/src.zip
 
+  # Create a runtime image with all Java SE modules
+  cd $(get_build_dir jdk-${HOSTTYPE}-zulu) # this is the buildhost.ARCH
+    bin/jlink --module-path ${PKG_BUILD}/jmods --output ${PKG_BUILD}/jre11 --add-modules java.se
+
   # libbluray needs arm/server
-  mv ${PKG_BUILD}/jre/lib/aarch32    ${PKG_BUILD}/jre/lib/arm
-  mv ${PKG_BUILD}/jre/lib/arm/client ${PKG_BUILD}/jre/lib/arm/server
+  mv ${PKG_BUILD}/jre/lib/client ${PKG_BUILD}/jre/lib/server
 }

--- a/packages/addons/addon-depends/jre-depends/jdk-x86_64-zulu/package.mk
+++ b/packages/addons/addon-depends/jre-depends/jdk-x86_64-zulu/package.mk
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Peter Vicman (peter.vicman@gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jdk-x86_64-zulu"
-PKG_VERSION="8.38.0.13-8.0.212"
-PKG_SHA256="568e7578f1b20b1e62a8ed2c374bad4eb0e75d221323ccfa6ba8d7bc56cf33cf"
+PKG_VERSION="11.45.27-11.0.10"
+PKG_SHA256="0bd85593bae021314378f3b146cfe36a6c9b0afd964d897c34201034ace3e785"
 PKG_LICENSE="GPLv2"
+if [ ! "${HOSTTYPE}" = "${TARGET_ARCH}" ]; then
+  PKG_DEPENDS_UNPACK="jdk-${HOSTTYPE}-zulu"
+fi
 PKG_SITE="https://www.azul.com/products/zulu-enterprise/"
 PKG_URL="https://cdn.azul.com/zulu/bin/zulu${PKG_VERSION%%-*}-ca-jdk${PKG_VERSION##*-}-linux_x64.tar.gz"
 PKG_LONGDESC="Zulu, the open Java(TM) platform from Azul Systems."
@@ -12,4 +16,8 @@ PKG_TOOLCHAIN="manual"
 
 post_unpack() {
   rm -f ${PKG_BUILD}/src.zip
+
+  # Create a runtime image with all Java SE modules
+  cd ${PKG_BUILD}
+    bin/jlink --output jre11 --add-modules java.se
 }

--- a/packages/addons/tools/jre.zulu/changelog.txt
+++ b/packages/addons/tools/jre.zulu/changelog.txt
@@ -1,2 +1,7 @@
+101
+- jdk-aarch64-zulu: update to 11.45.27-11.0.10
+- jdk-arm-zulu: update to 11.45.27-11.0.10
+- jdk-x86_64-zulu: update to 11.45.27-11.0.10
+
 100
 - Initial release

--- a/packages/addons/tools/jre.zulu/package.mk
+++ b/packages/addons/tools/jre.zulu/package.mk
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Peter Vicman (peter.vicman@gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jre.zulu"
 PKG_VERSION="1.0"
-PKG_REV="100"
+PKG_REV="101"
 PKG_LICENSE="GPL2"
 PKG_DEPENDS_TARGET="jre-libbluray libXext chrome-libXtst chrome-libXi chrome-libXrender jre-libXinerama"
 PKG_DEPENDS_UNPACK="jdk-${TARGET_ARCH}-zulu"
@@ -25,8 +26,9 @@ _pkg_copy_lib() {
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
 
-  cp -a $(get_build_dir jdk-${TARGET_ARCH}-zulu)/jre \
-        $(get_install_dir jre-libbluray)/usr/share/java/*.jar \
+  cp -a $(get_build_dir jdk-${TARGET_ARCH}-zulu)/jre11 \
+    ${ADDON_BUILD}/${PKG_ADDON_ID}/jre
+  cp -a $(get_install_dir jre-libbluray)/usr/share/java/*.jar \
         ${PKG_DIR}/profile.d \
     ${ADDON_BUILD}/${PKG_ADDON_ID}
 


### PR DESCRIPTION
Move to the current LTS supported Java.

- jdk-aarch64-zulu: update to 11.45.27-11.0.10
- jdk-arm-zulu: update to 11.45.27-11.0.10
- jdk-x86_64-zulu: update to 11.45.27-11.0.10

all of the JREs have been updated (note: some work was required to use jlink to create the JREs)

update 8.38.0.162-1.8.0_212 to 11.45.27-11.0.10 (2021-01-19)

ref that openjdk 11 is supported by libbluray 1.1.0
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=893227#101

changelog (libbluray support):
- https://code.videolan.org/videolan/libbluray/-/blob/master/ChangeLog
- 2019-02-12: Version 1.1.0
  - Add initial support for OpenJDK 11.

release notes:
- https://docs.azul.com/zulu/zulurelnotes/ZuluReleaseNotes/Title.htm

update the package to enable building jre (cross-target):
- https://www.oracle.com/java/technologies/javase/jdk-11-relnote.html
    Installing the JDK in previous releases optionally
    installed a JRE. In JDK 11, this is no longer an option. In this
    release, the JRE or Server JRE is no longer offered. Only the JDK is
    offered. Users can use jlink to create smaller custom runtimes.

