### PR TITLE
aarch64: add TARGET_CPU option cortex-a73.cortex-a53

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -10,7 +10,7 @@
 
 # determine architecture's family
   case $TARGET_CPU in
-    generic|cortex-a35|cortex-a53|cortex-a57|cortex-a72|exynos-m1|qdf24xx|thunderx|xgene1|cortex-a57.cortex-a53|cortex-a72.cortex-a53)
+    generic|cortex-a35|cortex-a53|cortex-a57|cortex-a72|exynos-m1|qdf24xx|thunderx|xgene1|cortex-a57.cortex-a53|cortex-a72.cortex-a53|cortex-a73.cortex-a53)
       TARGET_SUBARCH=aarch64
       TARGET_VARIANT=armv8-a
       TARGET_ABI=eabi


### PR DESCRIPTION
These are the cpus used in Odroid N2/N2+ and Khadas VIM3
A311D/S922X-B/S922X - cortex-a73.cortex-a53

these are not used by default and only if overridden in **options** file