### PR TITLE
bcm_sta: fix kernel_read() parameters

### DIFF
--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-0012-kernel-4.14.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-0012-kernel-4.14.patch
@@ -1,0 +1,29 @@
+From d1dfd471bfc5bb4e9513e8a26ecb11de934dc27e Mon Sep 17 00:00:00 2001
+From: Marcelo Henrique Cerri <marcelo.cerri@canonical.com>
+Date: Fri, 15 Dec 2017 17:09:04 +0000
+Subject: [PATCH 25/26] add support for Linux 4.14
+
+Signed-off-by: Marcelo Henrique Cerri <marcelo.cerri@canonical.com>
+---
+ src/shared/linux_osl.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/shared/linux_osl.c b/src/shared/linux_osl.c
+index 6157d1832767..318874541d89 100644
+--- a/x86-64/src/shared/linux_osl.c
++++ b/x86-64/src/shared/linux_osl.c
+@@ -1076,7 +1076,11 @@ osl_os_get_image_block(char *buf, int len, void *image)
+ 	if (!image)
+ 		return 0;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
++	rdlen = kernel_read(fp, buf, len, &fp->f_pos);
++#else
+ 	rdlen = kernel_read(fp, fp->f_pos, buf, len);
++#endif
+ 	if (rdlen > 0)
+ 		fp->f_pos += rdlen;
+ 
+-- 
+2.14.1
+


### PR DESCRIPTION
While looking at a build log I stumbled upon:
```
/home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/shared/linux_osl.c: In function 'osl_os_get_image_block':
/home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/shared/linux_osl.c:1083:28: warning: passing argument 2 of 'kernel_read' makes pointer from integer without a cast [-Wint-conversion]
 1083 |  rdlen = kernel_read(fp, fp->f_pos, buf, len);
      |                          ~~^~~~~~~
      |                            |
      |                            loff_t {aka long long int}
In file included from ./include/linux/huge_mm.h:8,
                 from ./include/linux/mm.h:687,
                 from /home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/include/linuxver.h:65,
                 from /home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/shared/linux_osl.c:25:
./include/linux/fs.h:2853:43: note: expected 'void *' but argument is of type 'loff_t' {aka 'long long int'}
 2853 | extern ssize_t kernel_read(struct file *, void *, size_t, loff_t *);
      |                                           ^~~~~~
/home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/shared/linux_osl.c:1083:37: warning: passing argument 3 of 'kernel_read' makes integer from pointer without a cast [-Wint-conversion]
 1083 |  rdlen = kernel_read(fp, fp->f_pos, buf, len);
      |                                     ^~~
      |                                     |
      |                                     char *
In file included from ./include/linux/huge_mm.h:8,
                 from ./include/linux/mm.h:687,
                 from /home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/include/linuxver.h:65,
                 from /home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/shared/linux_osl.c:25:
./include/linux/fs.h:2853:51: note: expected 'size_t' {aka 'long unsigned int'} but argument is of type 'char *'
 2853 | extern ssize_t kernel_read(struct file *, void *, size_t, loff_t *);
      |                                                   ^~~~~~
/home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/shared/linux_osl.c:1083:42: warning: passing argument 4 of 'kernel_read' makes pointer from integer without a cast [-Wint-conversion]
 1083 |  rdlen = kernel_read(fp, fp->f_pos, buf, len);
      |                                          ^~~
      |                                          |
      |                                          int
In file included from ./include/linux/huge_mm.h:8,
                 from ./include/linux/mm.h:687,
                 from /home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/include/linuxver.h:65,
                 from /home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/build/bcm_sta-6.30.223.271/x86-64/src/shared/linux_osl.c:25:
./include/linux/fs.h:2853:59: note: expected 'loff_t *' {aka 'long long int *'} but argument is of type 'int'
 2853 | extern ssize_t kernel_read(struct file *, void *, size_t, loff_t *);
      |                                                           ^~~~~~~~
```

Fixes are available in https://github.com/UnitedRPMs/broadcom-wl-dkms/commits/master or bcmwl_6.30.223.271+bdcom-0ubuntu7.diff.gz of https://launchpad.net/ubuntu/+source/bcmwl/

PR is building fine but I do not own any HW to test.