### PR TITLE
libevdev: update to 1.11.0

### DIFF
--- a/packages/sysutils/libevdev/package.mk
+++ b/packages/sysutils/libevdev/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libevdev"
-PKG_VERSION="1.10.1"
-PKG_SHA256="0330fe8357ece915db9366c1b9a6648941aea6f724b73ad6e71401127aa08932"
-PKG_LICENSE="GPL"
+PKG_VERSION="1.11.0"
+PKG_SHA256="63f4ea1489858a109080e0b40bd43e4e0903a1e12ea888d581db8c495747c2d0"
+PKG_LICENSE="MIT"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libevdev/"
 PKG_URL="http://www.freedesktop.org/software/libevdev/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain"


### PR DESCRIPTION
### this is only a license change.
**view history here: https://gitlab.freedesktop.org/libevdev/libevdev/-/commits/master/** 

update 1.10.1 to 1.11.0
commit: https://gitlab.freedesktop.org/libevdev/libevdev/-/commit/60d4f1b2aea14a65a4c2cfed7631fade405b7adf
