### PR TITLE
Friendlier for RPi aarch64

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -275,12 +275,18 @@ makeinstall_target() {
 
     # install platform dtbs, but remove upstream kernel dtbs (i.e. without downstream
     # drivers and decent USB support) as these are not required by LibreELEC
-    cp -p arch/${TARGET_KERNEL_ARCH}/boot/dts/*.dtb ${INSTALL}/usr/share/bootloader
+    for dtb in arch/${TARGET_KERNEL_ARCH}/boot/dts/*.dtb arch/${TARGET_KERNEL_ARCH}/boot/dts/*/*.dtb; do
+      if [ -f ${dtb} ]; then
+        cp -v ${dtb} ${INSTALL}/usr/share/bootloader
+      fi
+    done
     rm -f ${INSTALL}/usr/share/bootloader/bcm283*.dtb
+    # duplicated in overlays below
+    safe_remove ${INSTALL}/usr/share/bootloader/overlay_map.dtb
 
     # install overlay dtbs
-    for dtb in arch/${TARGET_KERNEL_ARCH}/boot/dts/overlays/*.dtb \
-               arch/${TARGET_KERNEL_ARCH}/boot/dts/overlays/*.dtbo; do
+    for dtb in arch/arm/boot/dts/overlays/*.dtb \
+               arch/arm/boot/dts/overlays/*.dtbo; do
       cp ${dtb} ${INSTALL}/usr/share/bootloader/overlays 2>/dev/null || :
     done
     cp -p arch/${TARGET_KERNEL_ARCH}/boot/dts/overlays/README ${INSTALL}/usr/share/bootloader/overlays

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="bcm2835-bootloader"
 PKG_VERSION="ba6259246c702b04ea56ff1034325e476d460ae8"
 PKG_SHA256="44fc5b364518cf41bdffc02bf159a8685641e2eaac2d220244ae39c19bbde120"
-PKG_ARCH="arm"
+PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
These are the changes outside of project/device to have an RPi3.aarch64 image work. They're unobtrusive, so I hope to merge them despite LE not distributing such an image.

Change to the linux package.mk handling of .dts files lets it cope with the different locations of device tree files between arm and arm64 kernels. The same method is being used by u-boot devices. The safe_remove is because overlay_map.dtb is duplicated. The file should be in the `overlays/` directory (which it is), according to the RPi docs: https://www.raspberrypi.org/documentation/configuration/device-tree.md

Hardcoding to arm's overlay devicetrees because that's where they live in RPi's kernel tree. This is admittedly a guess at the "right thing", as there isn't an `overlays/` dir in `arch/arm64/boot/dts/broadcom/`. My image has been using vc4-kms-v3d from this without complaint.

Change to bcm2835-bootloader is just to add the arch keyword, as every firmware bump requires a manual rebase just to readd it.

Files within `/usr/share/bootloader` are the same before/after for RPi2.arm.

I've been running this since June/July on RPi3.aarch64.