### PR TITLE
go: update to 1.14.14 and revert accidentally update linux: update to 5.10.12

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.14.13"
-PKG_SHA256="2c2b36bcda9cee460f1089a60b43e0d4c2b25385caf1645c227e14231d1c3115"
+PKG_VERSION="1.14.14"
+PKG_SHA256="84085a23f7b78becc7da6000f9359930bd48bc0b1e1d205b10590b58baed1366"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.14.14"
-PKG_SHA256="84085a23f7b78becc7da6000f9359930bd48bc0b1e1d205b10590b58baed1366"
+PKG_VERSION="1.14.13"
+PKG_SHA256="2c2b36bcda9cee460f1089a60b43e0d4c2b25385caf1645c227e14231d1c3115"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="5.10.12"
-    PKG_SHA256="1d454f2817ab4f34cf313ea680ab75e20f79c6431b3bd3ea3bcd39353030c4aa"
+    PKG_VERSION="5.10.11"
+    PKG_SHA256="02ef2b56b00fc5145701c603a5235e1265772e40d488a936b27ba65fe78e710f"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v5.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;


### PR DESCRIPTION
### Revert "go: update to 1.14.14" 
this incorrectly included a kernel bump in #5077. (Linux: update to 5.10.12) 
This reverts commit 80f9c7e.

### go: update to 1.14.14
update 1.14.13 (2020/12/03) to 1.14.14 (2021/01/19)

includes security fixes to the go command and the crypto/elliptic
package. See the Go 1.14.14 milestone on our issue tracker for details.

log:
https://github.com/golang/go/issues?q=milestone%3AGo1.14.14+label%3ACherryPickApproved

diff: golang/go@go1.14.13...go1.14.14