### PR TITLE
Fedora buildhost fixes

### DIFF
--- a/packages/devel/heimdal/patches/0001-upstream-check-libtinfo-for-tgetent.patch
+++ b/packages/devel/heimdal/patches/0001-upstream-check-libtinfo-for-tgetent.patch
@@ -1,0 +1,52 @@
+From 872222db35384f343a8a566a56a28c4eb73d38ed Mon Sep 17 00:00:00 2001
+From: Damir Franusic <df@release14.org>
+Date: Sun, 9 Dec 2018 19:50:47 +0100
+Subject: [PATCH] AC_FIND_FUNC_NO_LIBS should check libtinfo for tgetent
+
+---
+ configure.ac             | 2 +-
+ lib/libedit/config.h.in  | 3 +++
+ lib/libedit/configure.ac | 3 ++-
+ 3 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index f1e8d7b15e..f98a3c555e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -456,7 +456,7 @@ AC_FIND_FUNC_NO_LIBS(openpty, util,[
+ #endif
+ ],[0,0,0,0,0])
+ 
+-AC_FIND_FUNC_NO_LIBS(tgetent, termcap ncurses curses,[
++AC_FIND_FUNC_NO_LIBS(tgetent, termcap ncurses curses tinfo,[
+ #ifdef HAVE_TERMCAP_H
+ #include <termcap.h>
+ #endif
+diff --git a/lib/libedit/config.h.in b/lib/libedit/config.h.in
+index ba283cc39f..059e5abc6a 100644
+--- a/lib/libedit/config.h.in
++++ b/lib/libedit/config.h.in
+@@ -42,6 +42,9 @@
+ /* Define to 1 if you have the `ncurses' library (-lncurses). */
+ #undef HAVE_LIBNCURSES
+ 
++/* Define to 1 if you have the `tinfo' library (-ltinfo). */
++#undef HAVE_LIBTINFO
++
+ /* Define to 1 if you have the <limits.h> header file. */
+ #undef HAVE_LIMITS_H
+ 
+diff --git a/lib/libedit/configure.ac b/lib/libedit/configure.ac
+index 90c8ca57d7..89a9376b06 100644
+--- a/lib/libedit/configure.ac
++++ b/lib/libedit/configure.ac
+@@ -36,7 +36,8 @@ EL_MANTYPE
+ 
+ AC_CHECK_LIB(curses, tgetent,,
+    [AC_CHECK_LIB(ncurses, tgetent,,
+-      [AC_MSG_ERROR([libcurses or libncurses are required!])] )] )
++      [AC_CHECK_LIB(tinfo, tgetent,,
++         [AC_MSG_ERROR([libcurses or libncurses are required!])] )] )] )
+ 
+ 
+ # Checks for header files.

--- a/packages/devel/heimdal/patches/0002-upstream-fix-configure-err-msg.patch
+++ b/packages/devel/heimdal/patches/0002-upstream-fix-configure-err-msg.patch
@@ -1,0 +1,24 @@
+From 5e7bc8d8811fa401fa14adb9787504c0b460c7df Mon Sep 17 00:00:00 2001
+From: Earl Chew <earl_chew@yahoo.com>
+Date: Wed, 20 May 2020 09:46:28 -0700
+Subject: [PATCH] [libedit/configure.ac] Refactor tgetent message to reflect
+ libraries searched
+
+Signed-off-by: Earl Chew <earl_chew@yahoo.com>
+---
+ lib/libedit/configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/libedit/configure.ac b/lib/libedit/configure.ac
+index 89a9376b06..b94bafc6b9 100644
+--- a/lib/libedit/configure.ac
++++ b/lib/libedit/configure.ac
+@@ -37,7 +37,7 @@ EL_MANTYPE
+ AC_CHECK_LIB(curses, tgetent,,
+    [AC_CHECK_LIB(ncurses, tgetent,,
+       [AC_CHECK_LIB(tinfo, tgetent,,
+-         [AC_MSG_ERROR([libcurses or libncurses are required!])] )] )] )
++         [AC_MSG_ERROR([libcurses, libncurses, or tinfo are required!])] )] )] )
+ 
+ 
+ # Checks for header files.

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -112,7 +112,7 @@ case "${DISTRO}" in
         [mkfontdir]=xorg-x11-font-utils
         [bdftopcf]=xorg-x11-font-utils
         [xsltproc]=libxslt
-        [java]=java-1.7.0-openjdk
+        [java]=java-1.8.0-openjdk
         [python3]=python3
         [rpcgen]=rpcgen
       )
@@ -128,13 +128,16 @@ case "${DISTRO}" in
       fi
       file_map+=(
         [/usr/include/ncurses.h]=ncurses-devel
-        [/usr/inculde/stdio.h]=glibc-headers
+        [/usr/include/stdio.h]=glibc-headers
       )
       perl_map+=(
         [JSON]=perl-JSON
         [Parse::Yapp::Driver]=perl-Parse-Yapp
         [Thread::Queue]=perl-Thread-Queue
         [XML::Parser]=perl-XML-Parser
+        [FindBin]=perl-FindBin
+        [File::Compare]=perl-File-Compare
+        [File::Copy]=perl-File-Copy
       )
       ;;
     gentoo|sabayon)


### PR DESCRIPTION
These are some fixes for building with Fedora 33 Server as the host.

1 typo fix, newer java package and 3 new perl modules to check for in `scripts/checkdeps`.

A pair of upstreamed heimdal patches to resolve an issue where the build complains about not being able to find libncurses.

Fedora did, however, fail to build Kodi with a One Definition Rule C++ violation. I don't know if this is a new issue or not. I don't plan to investigate this further. Log: http://ix.io/2Obx

Series has been tested on a Ubuntu host and resulting image worked as expected.