### PR TITLE
game.libretro.dosbox: add DOSbox-Pure to Kodi Game packages

### DIFF
--- a/packages/emulation/libretro-dosbox-pure/package.mk
+++ b/packages/emulation/libretro-dosbox-pure/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-dosbox-pure"
+PKG_VERSION="0.10"
+PKG_SHA256="1bcc9cfb02afd1ceaf85e2030c696a3a641d3a2ef0f6988604f4a4959e38df20"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/schellingb/dosbox-pure"
+PKG_URL="https://github.com/schellingb/dosbox-pure/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_LONGDESC="game.libretro.dosbox-pure: DOSBox-Pure for Kodi"
+PKG_BUILD_FLAGS="+pic"
+
+PKG_LIBNAME="dosbox_pure_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="DOSBOX-PURE_LIB"
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox-pure/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox-pure/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.dosbox-pure"
+PKG_VERSION="0.10.0.1-Matrix"
+PKG_SHA256="e01e7e894a0ffb80b7361843af7636917b674db2c45f32756401ef244a9e6fcf"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.libretro.dosbox-pure"
+PKG_URL="https://github.com/kodi-game/game.libretro.dosbox-pure/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-dosbox-pure"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.dosbox-pure: DOSBox-Pure for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
FYI:
https://github.com/schellingb/dosbox-pure
https://www.libretro.com/index.php/dosbox-pure-out-now-for-public-testing/
https://arstechnica.com/gadgets/2021/01/dosbox-pure-for-retroarch-aims-to-simplify-classic-ms-dos-gaming/

Build tested on Generic -> WIP / needs some testing