### PR TITLE
grub: use host:grub-mkimage to run grub - fix glibc host and target mismatched 

### DIFF
--- a/packages/tools/grub/package.mk
+++ b/packages/tools/grub/package.mk
@@ -8,10 +8,26 @@ PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://www.gnu.org/software/grub/index.html"
 PKG_URL="http://git.savannah.gnu.org/cgit/grub.git/snapshot/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain flex freetype:host gettext:host"
+PKG_DEPENDS_HOST="toolchain:host"
+PKG_DEPENDS_TARGET="toolchain flex freetype:host gettext:host grub:host"
 PKG_DEPENDS_UNPACK="gnulib"
 PKG_LONGDESC="GRUB is a Multiboot boot loader."
 PKG_TOOLCHAIN="configure"
+
+pre_configure_host() {
+  unset CFLAGS
+  unset CPPFLAGS
+  unset CXXFLAGS
+  unset LDFLAGS
+  unset CPP
+
+  cd ${PKG_BUILD}
+    # keep grub synced with gnulib
+    ./bootstrap --gnulib-srcdir=$(get_build_dir gnulib) --copy --no-git --no-bootstrap-sync --skip-po
+
+  mkdir -p .${HOST_NAME}
+    cd .${HOST_NAME}
+}
 
 pre_configure_target() {
   PKG_CONFIGURE_OPTS_TARGET="--target=i386-pc-linux \
@@ -27,6 +43,9 @@ pre_configure_target() {
   cd ${PKG_BUILD}
     # keep grub synced with gnulib
     ./bootstrap --gnulib-srcdir=$(get_build_dir gnulib) --copy --no-git --no-bootstrap-sync --skip-po
+
+  mkdir -p .${TARGET_NAME}
+    cd .${TARGET_NAME}
 }
 
 make_target() {
@@ -38,15 +57,13 @@ make_target() {
 }
 
 makeinstall_target() {
-  cd ${PKG_BUILD}/grub-core
-     ${PKG_BUILD}/grub-mkimage -d . -o bootia32.efi -O i386-efi -p /EFI/BOOT \
-                                boot chain configfile ext2 fat linux search \
-                                efi_gop efi_uga part_gpt gzio \
-                                gettext loadenv loadbios memrw
+  ${PKG_BUILD}/.${HOST_NAME}/grub-mkimage -d grub-core -o bootia32.efi -O i386-efi -p /EFI/BOOT \
+    boot chain configfile ext2 fat linux search efi_gop \
+    efi_uga part_gpt gzio gettext loadenv loadbios memrw
 
   mkdir -p ${INSTALL}/usr/share/grub
-     cp -P ${PKG_BUILD}/grub-core/bootia32.efi ${INSTALL}/usr/share/grub
+     cp -P bootia32.efi ${INSTALL}/usr/share/grub
 
   mkdir -p ${TOOLCHAIN}/share/grub
-     cp -P ${PKG_BUILD}/grub-core/bootia32.efi ${TOOLCHAIN}/share/grub
+     cp -P bootia32.efi ${TOOLCHAIN}/share/grub
 }


### PR DESCRIPTION
this package can only be build on an x86_64 host.

it uses the :target compiled grub-mkimage during the build.

whilst my testing to update to GLIBC_2.33 has raised the error, review /
remidiation could be looked at using :host grub-mkimage / cross-compile / ...

the problem being addressed here is:
- /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found
- (required by grub-mkimage)

refer: https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=8ed005daf0ab03e142500324a34087ce179ae78e

Notes about the root cause:
Until glibc 2.32, stat64 etc. were redirected to __xstat64 etc. by
inline functions or macros; glibc 2.33 changed them to true
functions. As a result, code compiled against glibc 2.32 or older
will get the old __xstat64 etc.  implementation that is still
present, whereas code compiled against glibc 2.33 will get the new
stat64 etc. implementation.