### PR TITLE
kodi (RPi4): update workaround to hide pixel wrap issue

### DIFF
--- a/projects/RPi/devices/RPi4/patches/kodi/0001-hack-try-to-hide-pixel-wrap-issues.patch
+++ b/projects/RPi/devices/RPi4/patches/kodi/0001-hack-try-to-hide-pixel-wrap-issues.patch
@@ -1,34 +1,47 @@
-From 8dc2c71f7b568733b7e6629013f05f67639a1938 Mon Sep 17 00:00:00 2001
+From cbafa5c050c24d8d0517a4398837d0b670060dcb Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Wed, 8 Apr 2020 11:19:22 +0100
 Subject: [PATCH] pi4: hack: Try to hide pixel wrap issue
 
 ---
- .../HwDecRender/VideoLayerBridgeDRMPRIME.cpp          | 11 +++++++++--
- xbmc/windowing/gbm/drm/DRMAtomic.cpp                  | 10 ++++++++--
- 2 files changed, 17 insertions(+), 4 deletions(-)
+ .../HwDecRender/VideoLayerBridgeDRMPRIME.cpp   | 18 +++++++++++++++---
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp           | 10 ++++++++--
+ 2 files changed, 23 insertions(+), 5 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
-index c78636b68004..ee3bde3bfde5 100644
+index c78636b680..dcb1f1d5f2 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
-@@ -264,13 +264,20 @@ void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, cons
+@@ -11,6 +11,7 @@
+ #include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
+ #include "utils/log.h"
+ #include "windowing/gbm/drm/DRMAtomic.h"
++#include "settings/DisplaySettings.h"
+ 
+ #include <utility>
+ 
+@@ -264,13 +265,24 @@ void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, cons
    auto plane = m_DRM->GetVideoPlane();
    m_DRM->AddProperty(plane, "FB_ID", buffer->m_fb_id);
    m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->GetCrtcId());
 +
 +  uint32_t srcw = buffer->GetWidth() << 16;
 +  uint32_t dstw = static_cast<uint32_t>(destRect.Width());
++  uint32_t dstx = static_cast<int32_t>(destRect.x1);
 +  double scalex = (double)srcw / (double)dstw;
-+  dstw -= 2;
-+  srcw = (uint32_t)(srcw - 2.0 * scalex + 0.5);
-+
++  RESOLUTION_INFO &res = CDisplaySettings::GetInstance().GetCurrentResolutionInfo();
++  if (dstw > 2 && dstx + dstw > (uint32_t)res.iScreenWidth - 2)
++  {
++    dstw -= 2;
++    srcw = (uint32_t)(srcw - 2.0 * scalex + 0.5);
++  }
    m_DRM->AddProperty(plane, "SRC_X", 0);
    m_DRM->AddProperty(plane, "SRC_Y", 0);
 -  m_DRM->AddProperty(plane, "SRC_W", buffer->GetWidth() << 16);
 +  m_DRM->AddProperty(plane, "SRC_W", srcw);
    m_DRM->AddProperty(plane, "SRC_H", buffer->GetHeight() << 16);
-   m_DRM->AddProperty(plane, "CRTC_X", static_cast<int32_t>(destRect.x1) & ~1);
+-  m_DRM->AddProperty(plane, "CRTC_X", static_cast<int32_t>(destRect.x1) & ~1);
++  m_DRM->AddProperty(plane, "CRTC_X", (dstx + 1) & ~1);
    m_DRM->AddProperty(plane, "CRTC_Y", static_cast<int32_t>(destRect.y1) & ~1);
 -  m_DRM->AddProperty(plane, "CRTC_W", (static_cast<uint32_t>(destRect.Width()) + 1) & ~1);
 +  m_DRM->AddProperty(plane, "CRTC_W", (dstw + 1) & ~1);
@@ -36,7 +49,7 @@ index c78636b68004..ee3bde3bfde5 100644
  }
  
 diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-index 37166b8dcddc..803f22be831c 100644
+index 5d61a699d4..1e87ebddf2 100644
 --- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
 +++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
 @@ -92,13 +92,19 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
@@ -69,3 +82,6 @@ index 37166b8dcddc..803f22be831c 100644
        AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
      }
  
+-- 
+2.20.1
+


### PR DESCRIPTION
The updated version fixes the "atomic commit failed" issues
that were present in the previous workaround.