### PR TITLE
Allwinner: linux: GPU and HDMI improvements

### DIFF
--- a/projects/Allwinner/patches/linux/0046-drm-lima-add-governor-data-with-pre-defined-thresholds.patch
+++ b/projects/Allwinner/patches/linux/0046-drm-lima-add-governor-data-with-pre-defined-thresholds.patch
@@ -1,0 +1,57 @@
+From: Christian Hewitt <christianshewitt@gmail.com>
+Subject: [PATCH v2] drm/lima: add governor data with pre-defined thresholds
+Date: Wed, 27 Jan 2021 19:40:47 +0000
+
+This patch adapts the panfrost pre-defined thresholds change [0] to the
+lima driver to improve real-world performance. The upthreshold value has
+been set to ramp GPU frequency to max freq faster (compared to panfrost)
+to compensate for the lower overall performance of utgard devices.
+
+[0] https://patchwork.kernel.org/project/dri-devel/patch/20210121170445.19761-1-lukasz.luba@arm.com/
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+Reviewed-by: Lukasz Luba <lukasz.luba@arm.com>
+Reviewed-by: Qiang Yu <yuq825@gmail.com>
+---
+ drivers/gpu/drm/lima/lima_devfreq.c | 10 +++++++++-
+ drivers/gpu/drm/lima/lima_devfreq.h |  2 ++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+--- a/drivers/gpu/drm/lima/lima_devfreq.c
++++ b/drivers/gpu/drm/lima/lima_devfreq.c
+@@ -177,8 +177,16 @@ int lima_devfreq_init(struct lima_device
+ 	lima_devfreq_profile.initial_freq = cur_freq;
+ 	dev_pm_opp_put(opp);
+ 
++	/*
++	 * Setup default thresholds for the simple_ondemand governor.
++	 * The values are chosen based on experiments.
++	 */
++	ldevfreq->gov_data.upthreshold = 30;
++	ldevfreq->gov_data.downdifferential = 5;
++
+ 	devfreq = devm_devfreq_add_device(dev, &lima_devfreq_profile,
+-					  DEVFREQ_GOV_SIMPLE_ONDEMAND, NULL);
++					  DEVFREQ_GOV_SIMPLE_ONDEMAND,
++					  &ldevfreq->gov_data);
+ 	if (IS_ERR(devfreq)) {
+ 		dev_err(dev, "Couldn't initialize GPU devfreq\n");
+ 		ret = PTR_ERR(devfreq);
+--- a/drivers/gpu/drm/lima/lima_devfreq.h
++++ b/drivers/gpu/drm/lima/lima_devfreq.h
+@@ -4,6 +4,7 @@
+ #ifndef __LIMA_DEVFREQ_H__
+ #define __LIMA_DEVFREQ_H__
+ 
++#include <linux/devfreq.h>
+ #include <linux/spinlock.h>
+ #include <linux/ktime.h>
+ 
+@@ -18,6 +19,7 @@ struct lima_devfreq {
+ 	struct opp_table *clkname_opp_table;
+ 	struct opp_table *regulators_opp_table;
+ 	struct thermal_cooling_device *cooling;
++	struct devfreq_simple_ondemand_data gov_data;
+ 	bool opp_of_table_added;
+ 
+ 	ktime_t busy_time;

--- a/projects/Allwinner/patches/linux/0047-drm-lima-Use-delayed-timer-as-default-in-devfreq-profile.patch
+++ b/projects/Allwinner/patches/linux/0047-drm-lima-Use-delayed-timer-as-default-in-devfreq-profile.patch
@@ -1,0 +1,24 @@
+From: Lukasz Luba <lukasz.luba@arm.com>
+Subject: [PATCH] drm/lima: Use delayed timer as default in devfreq profile
+Date: Wed, 27 Jan 2021 10:51:21 +0000
+
+Devfreq framework supports 2 modes for monitoring devices.
+Use delayed timer as default instead of deferrable timer
+in order to monitor the GPU status regardless of CPU idle.
+
+Signed-off-by: Lukasz Luba <lukasz.luba@arm.com>
+Reviewed-by: Qiang Yu <yuq825@gmail.com>
+---
+ drivers/gpu/drm/lima/lima_devfreq.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/gpu/drm/lima/lima_devfreq.c
++++ b/drivers/gpu/drm/lima/lima_devfreq.c
+@@ -86,6 +86,7 @@ static int lima_devfreq_get_dev_status(s
+ }
+ 
+ static struct devfreq_dev_profile lima_devfreq_profile = {
++	.timer = DEVFREQ_TIMER_DELAYED,
+ 	.polling_ms = 50, /* ~3 frames */
+ 	.target = lima_devfreq_target,
+ 	.get_dev_status = lima_devfreq_get_dev_status,

--- a/projects/Allwinner/patches/linux/0048-drm-panfrost-Add-governor-data-with-pre-defined-thre.patch
+++ b/projects/Allwinner/patches/linux/0048-drm-panfrost-Add-governor-data-with-pre-defined-thre.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lukasz Luba <lukasz.luba@arm.com>
+Date: Thu, 21 Jan 2021 17:04:45 +0000
+Subject: [PATCH] drm/panfrost: Add governor data with pre-defined thresholds
+
+The simple_ondemand devfreq governor uses two thresholds to decide about
+the frequency change: upthreshold, downdifferential. These two tunable
+change the behavior of the governor decision, e.g. how fast to increase
+the frequency or how rapidly limit the frequency. This patch adds needed
+governor data with thresholds values gathered experimentally in different
+workloads.
+
+Signed-off-by: Lukasz Luba <lukasz.luba@arm.com>
+Reviewed-by: Steven Price <steven.price@arm.com>
+Signed-off-by: Steven Price <steven.price@arm.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20210121170445.19761-1-lukasz.luba@arm.com
+---
+ drivers/gpu/drm/panfrost/panfrost_devfreq.c | 10 +++++++++-
+ drivers/gpu/drm/panfrost/panfrost_devfreq.h |  2 ++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+--- a/drivers/gpu/drm/panfrost/panfrost_devfreq.c
++++ b/drivers/gpu/drm/panfrost/panfrost_devfreq.c
+@@ -134,8 +134,16 @@ int panfrost_devfreq_init(struct panfros
+ 	panfrost_devfreq_profile.initial_freq = cur_freq;
+ 	dev_pm_opp_put(opp);
+ 
++	/*
++	 * Setup default thresholds for the simple_ondemand governor.
++	 * The values are chosen based on experiments.
++	 */
++	pfdevfreq->gov_data.upthreshold = 45;
++	pfdevfreq->gov_data.downdifferential = 5;
++
+ 	devfreq = devm_devfreq_add_device(dev, &panfrost_devfreq_profile,
+-					  DEVFREQ_GOV_SIMPLE_ONDEMAND, NULL);
++					  DEVFREQ_GOV_SIMPLE_ONDEMAND,
++					  &pfdevfreq->gov_data);
+ 	if (IS_ERR(devfreq)) {
+ 		DRM_DEV_ERROR(dev, "Couldn't initialize GPU devfreq\n");
+ 		ret = PTR_ERR(devfreq);
+--- a/drivers/gpu/drm/panfrost/panfrost_devfreq.h
++++ b/drivers/gpu/drm/panfrost/panfrost_devfreq.h
+@@ -4,6 +4,7 @@
+ #ifndef __PANFROST_DEVFREQ_H__
+ #define __PANFROST_DEVFREQ_H__
+ 
++#include <linux/devfreq.h>
+ #include <linux/spinlock.h>
+ #include <linux/ktime.h>
+ 
+@@ -17,6 +18,7 @@ struct panfrost_devfreq {
+ 	struct devfreq *devfreq;
+ 	struct opp_table *regulators_opp_table;
+ 	struct thermal_cooling_device *cooling;
++	struct devfreq_simple_ondemand_data gov_data;
+ 	bool opp_of_table_added;
+ 
+ 	ktime_t busy_time;

--- a/projects/Allwinner/patches/linux/0049-drm-panfrost-Use-delayed-timer-as-default-in-devfreq.patch
+++ b/projects/Allwinner/patches/linux/0049-drm-panfrost-Use-delayed-timer-as-default-in-devfreq.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lukasz Luba <lukasz.luba@arm.com>
+Date: Tue, 5 Jan 2021 16:41:11 +0000
+Subject: [PATCH] drm/panfrost: Use delayed timer as default in devfreq profile
+
+Devfreq framework supports 2 modes for monitoring devices.
+Use delayed timer as default instead of deferrable timer
+in order to monitor the GPU status regardless of CPU idle.
+
+Signed-off-by: Lukasz Luba <lukasz.luba@arm.com>
+Reviewed-by: Steven Price <steven.price@arm.com>
+Signed-off-by: Steven Price <steven.price@arm.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20210105164111.30122-1-lukasz.luba@arm.com
+---
+ drivers/gpu/drm/panfrost/panfrost_devfreq.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/gpu/drm/panfrost/panfrost_devfreq.c
++++ b/drivers/gpu/drm/panfrost/panfrost_devfreq.c
+@@ -81,6 +81,7 @@ static int panfrost_devfreq_get_dev_stat
+ }
+ 
+ static struct devfreq_dev_profile panfrost_devfreq_profile = {
++	.timer = DEVFREQ_TIMER_DELAYED,
+ 	.polling_ms = 50, /* ~3 frames */
+ 	.target = panfrost_devfreq_target,
+ 	.get_dev_status = panfrost_devfreq_get_dev_status,

--- a/projects/Allwinner/patches/linux/0050-clk-sunxi-ng-mp-fix-parent-rate-change-flag-check.patch
+++ b/projects/Allwinner/patches/linux/0050-clk-sunxi-ng-mp-fix-parent-rate-change-flag-check.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 3 Feb 2021 23:09:31 +0100
+Subject: [PATCH] clk: sunxi-ng: mp: fix parent rate change flag check
+
+CLK_SET_RATE_PARENT flag is checked on parent clock instead of current
+one. Fix that.
+
+Fixes: 3f790433c3cb ("clk: sunxi-ng: Adjust MP clock parent rate when allowed")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/clk/sunxi-ng/ccu_mp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/clk/sunxi-ng/ccu_mp.c
++++ b/drivers/clk/sunxi-ng/ccu_mp.c
+@@ -108,7 +108,7 @@ static unsigned long ccu_mp_round_rate(s
+ 	max_m = cmp->m.max ?: 1 << cmp->m.width;
+ 	max_p = cmp->p.max ?: 1 << ((1 << cmp->p.width) - 1);
+ 
+-	if (!(clk_hw_get_flags(hw) & CLK_SET_RATE_PARENT)) {
++	if (!(clk_hw_get_flags(&cmp->common.hw) & CLK_SET_RATE_PARENT)) {
+ 		ccu_mp_find_best(*parent_rate, rate, max_m, max_p, &m, &p);
+ 		rate = *parent_rate / p / m;
+ 	} else {

--- a/projects/Allwinner/patches/linux/0051-drm-sun4i-tcon-set-sync-polarity-for-tcon1-channel.patch
+++ b/projects/Allwinner/patches/linux/0051-drm-sun4i-tcon-set-sync-polarity-for-tcon1-channel.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 3 Feb 2021 23:16:42 +0100
+Subject: [PATCH] drm/sun4i: tcon: set sync polarity for tcon1 channel
+
+Channel 1 has polarity bits for vsync and hsync signals but driver never
+sets them. It turns out that with pre-HDMI2 controllers seemingly there
+is no issue if polarity is not set. However, with HDMI2 controllers
+(H6) there often comes to de-synchronization due to phase shift. This
+causes flickering screen. It's safe to assume that similar issues might
+happen also with pre-HDMI2 controllers.
+
+Solve issue with setting vsync and hsync polarity. Note that display
+stacks with tcon top have polarity bits actually in tcon0 polarity
+register.
+
+Fixes: 9026e0d122ac ("drm: Add Allwinner A10 Display Engine support")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/gpu/drm/sun4i/sun4i_tcon.c | 24 ++++++++++++++++++++++++
+ drivers/gpu/drm/sun4i/sun4i_tcon.h |  5 +++++
+ 2 files changed, 29 insertions(+)
+
+--- a/drivers/gpu/drm/sun4i/sun4i_tcon.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tcon.c
+@@ -689,6 +689,29 @@ static void sun4i_tcon1_mode_set(struct
+ 		     SUN4I_TCON1_BASIC5_V_SYNC(vsync) |
+ 		     SUN4I_TCON1_BASIC5_H_SYNC(hsync));
+ 
++	/* Setup the polarity of sync signals */
++	if (tcon->quirks->polarity_in_ch0) {
++		val = 0;
++
++		if (mode->flags & DRM_MODE_FLAG_PHSYNC)
++			val |= SUN4I_TCON0_IO_POL_HSYNC_POSITIVE;
++
++		if (mode->flags & DRM_MODE_FLAG_PVSYNC)
++			val |= SUN4I_TCON0_IO_POL_VSYNC_POSITIVE;
++
++		regmap_write(tcon->regs, SUN4I_TCON0_IO_POL_REG, val);
++	} else {
++		val = SUN4I_TCON1_IO_POL_UNKNOWN;
++
++		if (mode->flags & DRM_MODE_FLAG_PHSYNC)
++			val |= SUN4I_TCON1_IO_POL_HSYNC_POSITIVE;
++
++		if (mode->flags & DRM_MODE_FLAG_PVSYNC)
++			val |= SUN4I_TCON1_IO_POL_VSYNC_POSITIVE;
++
++		regmap_write(tcon->regs, SUN4I_TCON1_IO_POL_REG, val);
++	}
++
+ 	/* Map output pins to channel 1 */
+ 	regmap_update_bits(tcon->regs, SUN4I_TCON_GCTL_REG,
+ 			   SUN4I_TCON_GCTL_IOMAP_MASK,
+@@ -1517,6 +1540,7 @@ static const struct sun4i_tcon_quirks su
+ 
+ static const struct sun4i_tcon_quirks sun8i_r40_tv_quirks = {
+ 	.has_channel_1		= true,
++	.polarity_in_ch0	= true,
+ 	.set_mux		= sun8i_r40_tcon_tv_set_mux,
+ };
+ 
+--- a/drivers/gpu/drm/sun4i/sun4i_tcon.h
++++ b/drivers/gpu/drm/sun4i/sun4i_tcon.h
+@@ -153,6 +153,10 @@
+ #define SUN4I_TCON1_BASIC5_V_SYNC(height)		(((height) - 1) & 0x3ff)
+ 
+ #define SUN4I_TCON1_IO_POL_REG			0xf0
++#define SUN4I_TCON1_IO_POL_UNKNOWN			BIT(26)
++#define SUN4I_TCON1_IO_POL_HSYNC_POSITIVE		BIT(25)
++#define SUN4I_TCON1_IO_POL_VSYNC_POSITIVE		BIT(24)
++
+ #define SUN4I_TCON1_IO_TRI_REG			0xf4
+ 
+ #define SUN4I_TCON_ECC_FIFO_REG			0xf8
+@@ -235,6 +239,7 @@ struct sun4i_tcon_quirks {
+ 	bool	needs_de_be_mux; /* sun6i needs mux to select backend */
+ 	bool    needs_edp_reset; /* a80 edp reset needed for tcon0 access */
+ 	bool	supports_lvds;   /* Does the TCON support an LVDS output? */
++	bool	polarity_in_ch0; /* some tcon1 channels have polarity bits in tcon0 pol register */
+ 	u8	dclk_min_div;	/* minimum divider for TCON0 DCLK */
+ 
+ 	/* callback to handle tcon muxing options */

--- a/projects/Allwinner/patches/linux/0052-drm-sun4i-dw-hdmi-always-set-clock-rate.patch
+++ b/projects/Allwinner/patches/linux/0052-drm-sun4i-dw-hdmi-always-set-clock-rate.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 3 Feb 2021 23:25:13 +0100
+Subject: [PATCH] drm/sun4i: dw-hdmi: always set clock rate
+
+As expected, HDMI controller clock should always match pixel clock. In
+the past, changing HDMI controller rate would seemingly worsen
+situation. However, that was the result of other bugs which are now
+fixed.
+
+Fix that by removing set_rate quirk and always set clock rate.
+
+Fixes: 40bb9d3147b2 ("drm/sun4i: Add support for H6 DW HDMI controller")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/gpu/drm/sun4i/sun8i_dw_hdmi.c | 4 +---
+ drivers/gpu/drm/sun4i/sun8i_dw_hdmi.h | 1 -
+ 2 files changed, 1 insertion(+), 4 deletions(-)
+
+--- a/drivers/gpu/drm/sun4i/sun8i_dw_hdmi.c
++++ b/drivers/gpu/drm/sun4i/sun8i_dw_hdmi.c
+@@ -21,8 +21,7 @@ static void sun8i_dw_hdmi_encoder_mode_s
+ {
+ 	struct sun8i_dw_hdmi *hdmi = encoder_to_sun8i_dw_hdmi(encoder);
+ 
+-	if (hdmi->quirks->set_rate)
+-		clk_set_rate(hdmi->clk_tmds, mode->crtc_clock * 1000);
++	clk_set_rate(hdmi->clk_tmds, mode->crtc_clock * 1000);
+ }
+ 
+ static const struct drm_encoder_helper_funcs
+@@ -295,7 +294,6 @@ static int sun8i_dw_hdmi_remove(struct p
+ 
+ static const struct sun8i_dw_hdmi_quirks sun8i_a83t_quirks = {
+ 	.mode_valid = sun8i_dw_hdmi_mode_valid_a83t,
+-	.set_rate = true,
+ };
+ 
+ static const struct sun8i_dw_hdmi_quirks sun50i_h6_quirks = {
+--- a/drivers/gpu/drm/sun4i/sun8i_dw_hdmi.h
++++ b/drivers/gpu/drm/sun4i/sun8i_dw_hdmi.h
+@@ -179,7 +179,6 @@ struct sun8i_dw_hdmi_quirks {
+ 	enum drm_mode_status (*mode_valid)(struct dw_hdmi *hdmi, void *data,
+ 					   const struct drm_display_info *info,
+ 					   const struct drm_display_mode *mode);
+-	unsigned int set_rate : 1;
+ 	unsigned int use_drm_infoframe : 1;
+ };
+ 

--- a/projects/Allwinner/patches/linux/0053-drm-sun4i-Fix-H6-HDMI-PHY-configuration.patch
+++ b/projects/Allwinner/patches/linux/0053-drm-sun4i-Fix-H6-HDMI-PHY-configuration.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 3 Feb 2021 23:29:47 +0100
+Subject: [PATCH] drm/sun4i: Fix H6 HDMI PHY configuration
+
+cpce value for 594 MHz is set differently in BSP driver. Fix that.
+
+Fixes: c71c9b2fee17 ("drm/sun4i: Add support for Synopsys HDMI PHY")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
++++ b/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
+@@ -89,7 +89,7 @@ static const struct dw_hdmi_mpll_config
+ 		},
+ 	},  {
+ 		594000000, {
+-			{ 0x1a40, 0x0003 },
++			{ 0x1a7c, 0x0003 },
+ 			{ 0x3b4c, 0x0003 },
+ 			{ 0x5a64, 0x0003 },
+ 		},

--- a/projects/Allwinner/patches/linux/0054-drm-sun4i-dw-hdmi-Fix-max.-frequency-for-H6.patch
+++ b/projects/Allwinner/patches/linux/0054-drm-sun4i-dw-hdmi-Fix-max.-frequency-for-H6.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 3 Feb 2021 23:32:16 +0100
+Subject: [PATCH] drm/sun4i: dw-hdmi: Fix max. frequency for H6
+
+It turns out that reasoning for lowering max. supported frequency is
+wrong. Scrambling works just fine. Several now fixed bugs prevented
+proper functioning, even with rates lower than 340 MHz. Issues were just
+more pronounced with higher frequencies.
+
+Fix that by allowing max. supported frequency in HW and fix the comment.
+
+Fixes: cd9063757a22 ("drm/sun4i: DW HDMI: Lower max. supported rate for H6")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/gpu/drm/sun4i/sun8i_dw_hdmi.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+--- a/drivers/gpu/drm/sun4i/sun8i_dw_hdmi.c
++++ b/drivers/gpu/drm/sun4i/sun8i_dw_hdmi.c
+@@ -47,11 +47,9 @@ sun8i_dw_hdmi_mode_valid_h6(struct dw_hd
+ {
+ 	/*
+ 	 * Controller support maximum of 594 MHz, which correlates to
+-	 * 4K@60Hz 4:4:4 or RGB. However, for frequencies greater than
+-	 * 340 MHz scrambling has to be enabled. Because scrambling is
+-	 * not yet implemented, just limit to 340 MHz for now.
++	 * 4K@60Hz 4:4:4 or RGB.
+ 	 */
+-	if (mode->clock > 340000)
++	if (mode->clock > 594000)
+ 		return MODE_CLOCK_HIGH;
+ 
+ 	return MODE_OK;


### PR DESCRIPTION
This PR improves GUI responsiveness by adjusting lima/panfrost scheduler parameters and fixes plethora of different issues with H6 HDMI. 4K@60 and other HDMI2 modes also work now.

All patches are/will be upstreamed soon, so they'll go away in one or two kernel cycles.