### PR TITLE
Busybox minors

### DIFF
--- a/packages/sysutils/busybox/config/busybox-host.conf
+++ b/packages/sysutils/busybox/config/busybox-host.conf
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
-# Busybox version: 1.32.0.git
-# Sun Feb  2 19:48:47 2020
+# Busybox version: 1.32.1
+# Thu Feb  4 21:32:49 2021
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -788,6 +788,7 @@ CONFIG_FEATURE_LESS_MAXLINES=0
 # CONFIG_FEATURE_MAKEDEVS_TABLE is not set
 # CONFIG_MAN is not set
 # CONFIG_MICROCOM is not set
+# CONFIG_MIM is not set
 # CONFIG_MT is not set
 # CONFIG_NANDWRITE is not set
 # CONFIG_NANDDUMP is not set
@@ -1074,6 +1075,7 @@ CONFIG_SH_IS_NONE=y
 # CONFIG_BASH_IS_ASH is not set
 # CONFIG_BASH_IS_HUSH is not set
 CONFIG_BASH_IS_NONE=y
+# CONFIG_SHELL_ASH is not set
 # CONFIG_ASH is not set
 # CONFIG_ASH_OPTIMIZE_FOR_SIZE is not set
 # CONFIG_ASH_INTERNAL_GLOB is not set
@@ -1094,6 +1096,7 @@ CONFIG_BASH_IS_NONE=y
 # CONFIG_ASH_CMDCMD is not set
 # CONFIG_CTTYHACK is not set
 # CONFIG_HUSH is not set
+# CONFIG_SHELL_HUSH is not set
 # CONFIG_HUSH_BASH_COMPAT is not set
 # CONFIG_HUSH_BRACE_EXPANSION is not set
 # CONFIG_HUSH_LINENO_VAR is not set
@@ -1129,7 +1132,6 @@ CONFIG_BASH_IS_NONE=y
 # CONFIG_HUSH_UMASK is not set
 # CONFIG_HUSH_GETOPTS is not set
 # CONFIG_HUSH_MEMLEAK is not set
-# CONFIG_SHELL_HUSH is not set
 
 #
 # Options common to all shells

--- a/packages/sysutils/busybox/config/busybox-init.conf
+++ b/packages/sysutils/busybox/config/busybox-init.conf
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.32.1
-# Thu Feb  4 21:25:28 2021
+# Fri Feb  5 01:01:29 2021
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -669,7 +669,7 @@ CONFIG_MOUNTPOINT=y
 # CONFIG_NOLOGIN is not set
 # CONFIG_NOLOGIN_DEPENDENCIES is not set
 # CONFIG_NSENTER is not set
-CONFIG_PIVOT_ROOT=y
+# CONFIG_PIVOT_ROOT is not set
 # CONFIG_RDATE is not set
 # CONFIG_RDEV is not set
 # CONFIG_READPROFILE is not set

--- a/packages/sysutils/busybox/config/busybox-init.conf
+++ b/packages/sysutils/busybox/config/busybox-init.conf
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
-# Busybox version: 1.32.0.git
-# Sun Feb  2 19:50:06 2020
+# Busybox version: 1.32.1
+# Thu Feb  4 21:25:28 2021
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -812,6 +812,7 @@ CONFIG_FEATURE_LESS_MAXLINES=9999999
 # CONFIG_FEATURE_MAKEDEVS_TABLE is not set
 # CONFIG_MAN is not set
 # CONFIG_MICROCOM is not set
+# CONFIG_MIM is not set
 # CONFIG_MT is not set
 CONFIG_NANDWRITE=y
 # CONFIG_NANDDUMP is not set
@@ -1098,6 +1099,7 @@ CONFIG_SH_IS_ASH=y
 # CONFIG_BASH_IS_ASH is not set
 # CONFIG_BASH_IS_HUSH is not set
 CONFIG_BASH_IS_NONE=y
+CONFIG_SHELL_ASH=y
 CONFIG_ASH=y
 # CONFIG_ASH_OPTIMIZE_FOR_SIZE is not set
 CONFIG_ASH_INTERNAL_GLOB=y
@@ -1118,6 +1120,7 @@ CONFIG_ASH_GETOPTS=y
 # CONFIG_ASH_CMDCMD is not set
 CONFIG_CTTYHACK=y
 # CONFIG_HUSH is not set
+# CONFIG_SHELL_HUSH is not set
 # CONFIG_HUSH_BASH_COMPAT is not set
 # CONFIG_HUSH_BRACE_EXPANSION is not set
 # CONFIG_HUSH_LINENO_VAR is not set
@@ -1153,7 +1156,6 @@ CONFIG_CTTYHACK=y
 # CONFIG_HUSH_UMASK is not set
 # CONFIG_HUSH_GETOPTS is not set
 # CONFIG_HUSH_MEMLEAK is not set
-# CONFIG_SHELL_HUSH is not set
 
 #
 # Options common to all shells

--- a/packages/sysutils/busybox/config/busybox-target.conf
+++ b/packages/sysutils/busybox/config/busybox-target.conf
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
-# Busybox version: 1.32.0.git
-# Fri Nov 13 18:57:19 2020
+# Busybox version: 1.32.1
+# Thu Feb  4 21:33:53 2021
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -808,6 +808,7 @@ CONFIG_FEATURE_LESS_ENV=y
 # CONFIG_FEATURE_MAKEDEVS_TABLE is not set
 # CONFIG_MAN is not set
 # CONFIG_MICROCOM is not set
+# CONFIG_MIM is not set
 # CONFIG_MT is not set
 CONFIG_NANDWRITE=y
 # CONFIG_NANDDUMP is not set
@@ -1094,6 +1095,7 @@ CONFIG_SH_IS_ASH=y
 CONFIG_BASH_IS_ASH=y
 # CONFIG_BASH_IS_HUSH is not set
 # CONFIG_BASH_IS_NONE is not set
+CONFIG_SHELL_ASH=y
 CONFIG_ASH=y
 # CONFIG_ASH_OPTIMIZE_FOR_SIZE is not set
 # CONFIG_ASH_INTERNAL_GLOB is not set
@@ -1114,6 +1116,7 @@ CONFIG_ASH_GETOPTS=y
 CONFIG_ASH_CMDCMD=y
 # CONFIG_CTTYHACK is not set
 # CONFIG_HUSH is not set
+# CONFIG_SHELL_HUSH is not set
 # CONFIG_HUSH_BASH_COMPAT is not set
 # CONFIG_HUSH_BRACE_EXPANSION is not set
 # CONFIG_HUSH_LINENO_VAR is not set
@@ -1149,7 +1152,6 @@ CONFIG_ASH_CMDCMD=y
 # CONFIG_HUSH_UMASK is not set
 # CONFIG_HUSH_GETOPTS is not set
 # CONFIG_HUSH_MEMLEAK is not set
-# CONFIG_SHELL_HUSH is not set
 
 #
 # Options common to all shells


### PR DESCRIPTION
These are the minors split off of #5096.

Refresh of the busybox configs.

Dropping of pivot_root from busybox:init. Documentation for this says it's intended for linux 2.4 systems using initrd. init is using switch_root, which is intended for linux >=2.6 using initramfs.