### PR TITLE
jsoncpp: only build static library

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.argustv"
 PKG_VERSION="7.1.0-Matrix"
 PKG_SHA256="d91f195c4a91af893231d03a887a340900c4e515597ea059ee6b9e6444717fc9"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.argustv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.filmon"
 PKG_VERSION="6.1.0-Matrix"
 PKG_SHA256="7c2998bdde04acee5c147cb9f82939cfb13af57e5ecf46a4343dcfee15eb02e2"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.filmon"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.hdhomerun"
 PKG_VERSION="7.1.0-Matrix"
 PKG_SHA256="a31587e00d58efb72aadba3ad1bd67c08332feef0d558e0eeb6fda7c81bf93e8"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hdhomerun"

--- a/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.octonet"
 PKG_VERSION="4.1.0-2-Matrix"
 PKG_SHA256="091ba0288a8c12d42f6352b453fb39bcace3174c8763f6cbe3dc8fef40a33f2b"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/DigitalDevices/pvr.octonet"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.pctv"
 PKG_VERSION="6.1.0-Matrix"
 PKG_SHA256="94b8be4988cb6d8c61f6bdf237ddabb04d77fe4900f61411f5abf918eb5a078c"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.pctv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.sledovanitv.cz"
 PKG_VERSION="4.4.0-Matrix"
 PKG_SHA256="7ab303125172c315babbb70f4cb5a3b41c98ac1e318cadd93edf1264d4e4df0b"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/palinek/pvr.sledovanitv.cz"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.stalker"
 PKG_VERSION="7.1.0-Matrix"
 PKG_SHA256="bce055008d0ae7212924f41753970e3176a218f6a45bd76b202463a43be3d192"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.stalker"

--- a/packages/textproc/jsoncpp/package.mk
+++ b/packages/textproc/jsoncpp/package.mk
@@ -13,4 +13,8 @@ PKG_LONGDESC="A C++ library for interacting with JSON."
 PKG_TOOLCHAIN="cmake"
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CMAKE_OPTS_TARGET="-DJSONCPP_WITH_TESTS=OFF -DJSONCPP_WITH_EXAMPLE=OFF"
+PKG_CMAKE_OPTS_TARGET="-DJSONCPP_WITH_TESTS=OFF \
+                       -DJSONCPP_WITH_EXAMPLE=OFF \
+                       -DBUILD_SHARED_LIBS=OFF \
+                       -DBUILD_STATIC_LIBS=ON \
+                       -DBUILD_OBJECT_LIBS=OFF"


### PR DESCRIPTION
Version 1.9.4 changed default build options so that the shared library is built by default which breaks addons linking against it.

Explicitly set the build options so that only the static library is built, as before the bump.