### PR TITLE
pcscd: update addon (101)

### DIFF
--- a/packages/addons/addon-depends/ccid/package.mk
+++ b/packages/addons/addon-depends/ccid/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccid"
-PKG_VERSION="1.4.33"
-PKG_SHA256="5256da939711deb42b74d05d2bd6bd0c73c4d564feb0c1a50212609eb680e424"
+PKG_VERSION="1.4.34"
+PKG_SHA256="e6f7645b59a9a2844eb4b1a7eff512960d7f04a4654af02f7fd2f8aded5db40a"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://ccid.apdu.fr"
 PKG_URL="https://ccid.apdu.fr/files/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/service/pcscd/changelog.txt
+++ b/packages/addons/service/pcscd/changelog.txt
@@ -1,2 +1,5 @@
+101
+- ccid: update to 1.4.34
+
 100
 - initial addon

--- a/packages/addons/service/pcscd/package.mk
+++ b/packages/addons/service/pcscd/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="pcscd"
 PKG_VERSION="1.0"
-PKG_REV="100"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
ccid: update to 1.4.34
- update 1.4.33 (2020-06-25) to 1.4.34 (2021-01-24)
- changelog: https://salsa.debian.org/rousseau/CCID/blob/master/README.md