### PR TITLE
xcb-proto: update to 1.14.1

### DIFF
--- a/packages/x11/proto/xcb-proto/package.mk
+++ b/packages/x11/proto/xcb-proto/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xcb-proto"
-PKG_VERSION="1.14"
-PKG_SHA256="186a3ceb26f9b4a015f5a44dcc814c93033a5fc39684f36f1ecc79834416a605"
+PKG_VERSION="1.14.1"
+PKG_SHA256="f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xcb.freedesktop.org/dist/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/proto/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros Python3:host"
 PKG_LONGDESC="X C-language Bindings protocol headers."
 


### PR DESCRIPTION
update 1.14 to 1.14.1
announce: https://www.mail-archive.com/xorg-announce@lists.x.org/msg01270.html