### PR TITLE
libheif: update to 1.12.0

### DIFF
--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.10.0"
-PKG_SHA256="ad5af1276f341277dc537b0d19a4193e0833c247b2aacb936e0c5494141533ae"
+PKG_VERSION="1.12.0"
+PKG_SHA256="e1ac2abb354fdc8ccdca71363ebad7503ad731c84022cf460837f0839e171718"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="http://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update 1.10.0 to 1.12.0
Changelog: https://github.com/strukturag/libheif/releases

-  check for MIAF conformance and add as compatible brand
-  signaling of premultiplied alpha
-  parse AV1 obu_sequence_header for av1C box
-  write pixi box in AVIFs
-  save alpha as monochrome in AVIF if possible
-  many build fixes (thanks to the numerous external contributors)
-  fix writing ispe box in HEIFs
-  nclx output profile encoding parameters
-  change the way nclx profiles is written so that macOS can read them
-  API for listing file brands and checking file type
-  fix heif_image_handle_get_depth_image_representation_info()