### PR TITLE
nghttp2: update to 1.43.0

### DIFF
--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.42.0"
-PKG_SHA256="c5a7f09020f31247d0d1609078a75efadeccb7e5b86fc2e4389189b1b431fe63"
+PKG_VERSION="1.43.0"
+PKG_SHA256="f7d54fa6f8aed29f695ca44612136fa2359013547394d5dffeffca9e01a26b0f"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Update 1.42.0 to 1.43.0
Changelog: https://github.com/nghttp2/nghttp2/releases/tag/v1.43.0
Announcement: https://nghttp2.org/blog/2021/02/02/nghttp2-v1-43-0/