### PR TITLE
glib: update to 2.68.1

### DIFF
--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.67.2"
-PKG_SHA256="b41d42d6c572e1e420ffc38a077e0157e0b53b5a94c9647a3dc3701043c3b69b"
+PKG_VERSION="2.68.1"
+PKG_SHA256="241654b96bd36b88aaa12814efc4843b578e55d47440103727959ac346944333"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.gtk.org/"
 PKG_URL="http://ftp.gnome.org/pub/gnome/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
glib: update to 2.68.1

updated 2.67.2 (8 Jan 2021) to 2.68.1 (8 Apr 2021)
changelog:
- https://raw.githubusercontent.com/GNOME/glib/master/NEWS
- https://gitlab.gnome.org/GNOME/glib/-/releases#2.67.3
- https://gitlab.gnome.org/GNOME/glib/-/releases#2.67.4
- https://gitlab.gnome.org/GNOME/glib/-/releases#2.67.5
- https://gitlab.gnome.org/GNOME/glib/-/releases#2.67.6
- https://gitlab.gnome.org/GNOME/glib/-/releases#2.68.0
- https://gitlab.gnome.org/GNOME/glib/-/releases#2.68.1