### PR TITLE
connman: update to 1.39

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="40947be3848b0a864a366f8d67ce347265ea98c4" # 1.38 + HEAD 12/12/20
-PKG_SHA256="d59e93caf297f0ad8d2034fcf956747ba879266e2ad9b7e42abcce86867083e6"
+PKG_VERSION="1.39"
+PKG_SHA256="0366881f73cdb0acb14619b58cf7a452fe5bf05a70f9db84519933b3afb9744c"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-${PKG_VERSION}.tar.gz"

--- a/packages/network/connman/patches/connman-06-timeserver_fix_warning.patch
+++ b/packages/network/connman/patches/connman-06-timeserver_fix_warning.patch
@@ -1,0 +1,11 @@
+--- a/src/timeserver.c	2021-02-05 19:46:42.000000000 +0100
++++ b/src/timeserver.c	2021-02-06 15:08:10.777408574 +0100
+@@ -66,7 +66,7 @@ static void ntp_callback(bool success, v
+ 		return;
+ 	}
+ 
+-	if (!gettimeofday(&tv, NULL)) {
++	if (gettimeofday(&tv, NULL)) {
+ 		connman_warn("Failed to get current time");
+ 	}
+ 


### PR DESCRIPTION
Changes (from https://git.kernel.org/pub/scm/network/connman/connman.git/log/):
- src: Test return value of inet_pton consistently
- vpn: Do not do mixed declerations and code
- vpn: Export vpn_ipconfig_foreach as linker symbol
- vpnc: Do not lose credentials with VPN agent timeouts
- openvpn: Update documemtation for --proto
- wifi: Fix wireless interface not being added to tether bridge sometimes
- wifi: Base BSS expiration age on long scanning interval
- services: Escape passphrase string
- timeserver: Split new service and configuration update
- wifi: Always disconnect connection completely
- clock: Add TimeSynced signal emitted when the system time has been synced
- timeserver: Reset time sync on system timeserver update
- service: Restart online check when default service changes
- gdhcp: Avoid reading invalid data in dhcp_get_option
- gdhcp: Avoid leaking stack data via unitiialized variable
- dnsproxy: Add length checks to prevent buffer overflow

Important for us: "services: Escape passphrase string" and "wifi: Fix wireless interface not being added to tether".

Minimal tested by booting Generic.