### PR TITLE
allow including valgrind in non-debug builds

### DIFF
--- a/packages/virtual/debug/package.mk
+++ b/packages/virtual/debug/package.mk
@@ -21,7 +21,7 @@ if [ "${VAAPI_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" libva-utils"
 fi
 
-if build_with_debug && [ "${VALGRIND}" = "yes" ]; then
+if [ "${VALGRIND}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" valgrind"
 fi
 

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -60,10 +60,6 @@
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 
-  # build debug with valgrind (yes / no)
-  # Increases image size significantly
-    VALGRIND="no"
-
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -101,10 +101,6 @@
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 
-  # build debug with valgrind (yes / no)
-  # Not available for armv6. Increases image size significantly
-    VALGRIND="no"
-
   # kernel image name
     KERNEL_NAME="kernel.img"
 

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -62,10 +62,6 @@
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"
 
-  # build debug with valgrind (yes / no)
-  # Increases image size significantly
-    VALGRIND="no"
-
   # additional packages to install:
   # Space separated list is supported,
   # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"


### PR DESCRIPTION
valgrind can be useful to check if memory allocation is OK in release
builds and to check for issues that don't occur in debug builds.

As valgrind needs to be explicitly enabled removing the debug-only
restriction has no impact on normal builds.

Also drop unneeded VALGRIND="no" settings in project options files.