### PR TITLE
curl: update to 7.78.0 and HSTS

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="curl"
-PKG_VERSION="7.74.0"
-PKG_SHA256="999d5f2c403cf6e25d58319fdd596611e455dd195208746bc6e6d197a77e878b"
+PKG_VERSION="7.78.0"
+PKG_SHA256="be42766d5664a739c3974ee3dfbbcbe978a4ccb1fe628bb1d9b59ac79e445fb5"
 PKG_LICENSE="MIT"
-PKG_SITE="http://curl.haxx.se"
-PKG_URL="http://curl.haxx.se/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://curl.haxx.se"
+PKG_URL="https://curl.haxx.se/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain zlib openssl rtmpdump libidn2 nghttp2"
 PKG_LONGDESC="Client and library for (HTTP, HTTPS, FTP, ...) transfers."
 PKG_TOOLCHAIN="configure"
@@ -65,7 +65,6 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_lib_rtmp_RTMP_Init=yes \
                            --with-ca-bundle=/run/libreelec/cacert.pem \
                            --without-ca-path \
                            --without-libpsl \
-                           --without-libmetalink \
                            --without-libssh2 \
                            --with-librtmp \
                            --with-libidn2 \


### PR DESCRIPTION
curl: update to 7.78.0 and HSTS
  
update 7.74.0 (2020-12-09) to 7.78.0 (2021-07-21)
changelog:
- https://curl.se/changes.html#7_78_0
- https://curl.se/changes.html#7_77_0
- https://curl.se/changes.html#7_76_1
- https://curl.se/changes.html#7_76_0
- https://curl.se/changes.html#7_75_0

metalink removed: https://github.com/curl/curl/pull/7176