### PR TITLE
pycryptodome: update to 3.10.1

### DIFF
--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.9.9"
-PKG_SHA256="abb476e10b4266472d709697a9ec96eb4bdcaaa8708badcfec64daadbacbcef0"
+PKG_VERSION="3.10.1"
+PKG_SHA256="11f07d59a0e35a477ce8d73b90047fa11b7e3af4ebbac23745858d0f37e4f7c2"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pycryptodome"
 PKG_URL="https://github.com/Legrandin/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 3.9.9 (2020-11-02) to 3.10.1 (2021-02-09)
changelog: https://raw.githubusercontent.com/Legrandin/pycryptodome/master/Changelog.rst