### PR TITLE
kernel-firmware: update to 20210208

### DIFF
--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="20201218"
-PKG_SHA256="d60a418260bc083df8c7d3359aa207b48181ec8354b6c8545cac28ff19ce8950"
+PKG_VERSION="20210208"
+PKG_SHA256="45ae017429f60e701ece1e8cd0271e2cd3fc4400e7505856833b08f8a84a1bd9"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 20201218 to 20210208
log: https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/

```
Age	Commit message (Expand)	Author	Files	Lines
22 hours	Merge branch 'DG1-guc-huc-ADLS-dmc' of
  git://anongit.freedesktop.org/drm/drm-...HEAD20210208mastermain
22 hours	Merge branch 'qcom-rb5' of
  https://github.com/lumag/linux-firmware into main
22 hours	Mellanox: Add new mlxsw_spectrum firmware xx.2008.2304
22 hours	linux-firmware: add firmware for MT7921
22 hours	rtw88: RTL8821C: Update firmware to v24.8
22 hours	linux-firmware: Update firmware file for Intel Bluetooth AX210
22 hours	linux-firmware: Update firmware file for Intel Bluetooth AX200
22 hours	linux-firmware: Update firmware file for Intel Bluetooth AX201
11 days	i915: Add DMC v2.01 for ADL-S
11 days	i915: Add HuC v7.7.1 for DG1
11 days	i915: Add GuC v49.0.1 for DG1
2021-01-23	qcom: Add venus firmware files for VPU-1.0
2021-01-23	qcom: Add SM8250 Compute DSP firmware
2021-01-23	qcom: Add SM8250 Audio DSP firmware
2021-01-23	qcom: add firmware files for Adreno a650
2021-01-19	brcm: Link RPi4's WiFi firmware with DMI machine name.
2021-01-09	brcm: Add NVRAM for Vamrs 96boards Rock960
2021-01-09	brcm: Update Raspberry Pi 3B+/4B NVRAM for downstream changes
2021-01-08	cypress: Fix link direction
2021-01-07	cypress: Link the new cypress firmware to the old brcm files
2021-01-07	brcm: remove old brcm firmwares that have newer cypress variants
2020-12-30	rtl_bt: Update RTL8822C BT(UART I/F) FW to 0x059A_25CB
2020-12-30	rtl_bt: Update RTL8822C BT(USB I/F) FW to 0x099a_7253
2020-12-30	rtl_bt: Add firmware and config files for RTL8852A BT USB chip
2020-12-30	rtl_bt: Update RTL8821C BT(USB I/F) FW to 0x829a_7644
```