### PR TITLE
config/options: add ARM_MEM_SUPPORT option to control arm-mem inclusion

### DIFF
--- a/config/options
+++ b/config/options
@@ -30,6 +30,13 @@ export PROJECT="${PROJECT:-Generic}"
 export ARCH="${ARCH:-x86_64}"
 TARGET_ARCH="${ARCH}"
 
+# include arm-mem package on arm
+if [ "${TARGET_ARCH}" = "arm" ]; then
+  ARM_MEM_SUPPORT="yes"
+else
+  ARM_MEM_SUPPORT="no"
+fi
+
 # include helper functions
 . config/functions
 

--- a/packages/virtual/libc/package.mk
+++ b/packages/virtual/libc/package.mk
@@ -12,7 +12,7 @@ PKG_DEPENDS_INIT="toolchain glibc:init"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Meta package for installing various tools and libs needed for libc"
 
-if [ "${TARGET_ARCH}" = "arm" ]; then
+if [ "${ARM_MEM_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" arm-mem"
   PKG_DEPENDS_INIT+=" arm-mem:init"
 fi


### PR DESCRIPTION
Move the check if arm-mem should be included from virtual/libc
to config/options and set the ARM_MEM_SUPPORT variable accordingly.

This makes it possible to opt-out of using arm-mem which can
be helpful for performance testing and debugging (eg valgrind
doesn't play nicely with it).