### PR TITLE
[le92] kodi binary addons: update to latest Leia versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="3.9.8-Leia"
-PKG_SHA256="0812e359a943f4ffb763b47fc0440768a8aa09f12172ef8dff4440b0a48f9c96"
+PKG_VERSION="3.10.0-Leia"
+PKG_SHA256="906d023b4713be558445902ff703ae65e03733d47dd7d0e1b16d02c05679c7ed"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="18.1.21-Leia"
-PKG_SHA256="19de7bc58bcf37bbcff5ad2cb2f095cb15a4217f9abec5c9ff30d0489dab89d2"
+PKG_VERSION="18.1.23-Leia"
+PKG_SHA256="9c3dc2ed9f8c39bcc4f5798439b85f2bdae1a427ffeb1b9d18aa5e2caca29f4e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
only 2 pvr addons - pvr.zattoo bump should fix issue reported on forum https://forum.libreelec.tv/thread/23473-pvr-zattoo-not-working-fix-18-1-23-available-but-needs-compile-for-libreelec/

build-tested for RPi4