### PR TITLE
libretro-pcsx-rearmed: updated to git 976907a / fix build

### DIFF
--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-pcsx-rearmed"
-PKG_VERSION="54686ee7ccbba7220aaf69892ad3d77515478776"
-PKG_SHA256="aeb8941cb9a262d4e9f94d6491c2cfaa823df759f40b30dd624c27a36f369fa1"
+PKG_VERSION="976907a40062e6e9bb6a05530259132fe1c2a90e"
+PKG_SHA256="ab77c325831b4f275a8e94366f583267405b916769f7636096d1a1a68c3ec315"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="https://github.com/libretro/pcsx_rearmed/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-pcsx-rearmed/patches/libretro-pcsx-rearmed-995.01-disable-thread-rendering-for-arm.patch
+++ b/packages/emulation/libretro-pcsx-rearmed/patches/libretro-pcsx-rearmed-995.01-disable-thread-rendering-for-arm.patch
@@ -1,0 +1,35 @@
+From d79df6249723586473108c92ab5ecf2ac3d9341d Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Wed, 10 Feb 2021 13:53:55 +0100
+Subject: [PATCH] Makefile.libretro: disable THREAD_RENDERING for
+ ARCH=arm/aarch64
+
+---
+ Makefile.libretro | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.libretro b/Makefile.libretro
+index 60feab41..ffb2c7f3 100644
+--- a/Makefile.libretro
++++ b/Makefile.libretro
+@@ -48,7 +48,6 @@ EXTRA_LDFLAGS =
+ ifeq ($(platform), unix)
+ 	TARGET := $(TARGET_NAME)_libretro.so
+ 	fpic := -fPIC
+-	THREAD_RENDERING = 1
+ ifneq ($(findstring SunOS,$(shell uname -s)),)
+ 	CC = gcc
+ endif
+@@ -59,6 +58,12 @@ ifneq ($(findstring __thumb__,$(shell $(CC) -E -dD $(CFLAGS) include/arm_feature
+ endif
+ endif
+ 
++ifeq ($(ARCH), $(filter $(ARCH), arm aarch64))
++	THREAD_RENDERING = 0
++else
++	THREAD_RENDERING = 1
++endif
++
+ # ODROIDN2
+ else ifneq (,$(findstring CortexA73_G12B,$(platform)))
+ 	TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
disable threaded rendering for ARCH=arm/aarch64

Basically supersedes https://github.com/LibreELEC/LibreELEC.tv/pull/5047

Tested on Generic, RK3399 & VIM3 so should be fine for every SBC with NEON support which was broken by https://github.com/libretro/pcsx_rearmed/pull/462