### PR TITLE
procps-ng: update to 3.3.17

### DIFF
--- a/packages/tools/procps-ng/package.mk
+++ b/packages/tools/procps-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="procps-ng"
-PKG_VERSION="3.3.16"
-PKG_SHA256="720caf307ab5dfe6d1cf4fc3e6ce786d749c69baa088627dbe1b01828f2528b1"
+PKG_VERSION="3.3.17"
+PKG_SHA256="8374d281f91e5fc9bb9ea8dc991b25331e3a2b0299b46f22c633f7fb6bcb0764"
 PKG_LICENSE="GPL"
 PKG_SITE="https://gitlab.com/procps-ng/procps"
 PKG_URL="https://gitlab.com/procps-ng/procps/-/archive/v${PKG_VERSION}/procps-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
update 3.3.16 (2019-12-08) to 3.3.17 (2021-02-09)
news: https://gitlab.com/procps-ng/procps/-/blob/master/NEWS
tags: https://gitlab.com/procps-ng/procps/-/tags