### PR TITLE
go: update to 1.14.15

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.14.14"
-PKG_SHA256="84085a23f7b78becc7da6000f9359930bd48bc0b1e1d205b10590b58baed1366"
+PKG_VERSION="1.14.15"
+PKG_SHA256="8167eeb636eeef6010dc004e5ab4a0af77ea3e1c9fe8b3c2fef38c3ddb72bc7d"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 1.14.14 (2021/01/19) to 1.14.15 (2021-02-04)

See the Go 1.14.15 milestone on our issue tracker for details.

log: https://github.com/golang/go/issues?q=milestone%3AGo1.14.15+label%3ACherryPickApproved

diff: https://github.com/golang/go/compare/go1.14.14...go1.14.15