### PR TITLE
linux: set DTC_FLAGS as environment variable instead of make argument

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -190,7 +190,7 @@ make_target() {
     KERNEL_TARGET="${KERNEL_TARGET/uImage/Image}"
   fi
 
-  kernel_make DTC_FLAGS=-@ ${KERNEL_TARGET} ${KERNEL_MAKE_EXTRACMD} modules
+  DTC_FLAGS=-@ kernel_make ${KERNEL_TARGET} ${KERNEL_MAKE_EXTRACMD} modules
 
   if [ "${PKG_BUILD_PERF}" = "yes" ]; then
     ( cd tools/perf


### PR DESCRIPTION
Setting DTC_FLAGS as a make argument overrides the additional dtc flags
which are added in kernel's scripts/Makefile.lib.

This results in lots of noisy warnings when building RPi DT and overlays
and could be potentially problematic if kbuild adds important dtc flags.

Pass in DTC_FLAGS as an environment variable so that kbuild can
adjust DTC_FLAGS as needed.

@jernejsk I did an AW A64 kernel build and fdtdump showed that symbols were present in dtbs but doing a runtime test probably wouldn't hurt