### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="2.6.6-Matrix"
-PKG_SHA256="0fe366b9e5db692b98d58dfa76fa111a4ce510c6466c3b6bad50d138bed62428"
-PKG_REV="2"
+PKG_VERSION="2.6.7-Matrix"
+PKG_SHA256="353207f5f98bf81ce8d79cec903c28da8c0227d7c7a632692c910d81e59c2dbe"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/inputstream.adaptive"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="7.4.0-Matrix"
-PKG_SHA256="02d448e7f2cdba43f73c5d72e6b4ee03ae14a52561b0145c0b47ce22743b89d0"
+PKG_VERSION="7.4.2-Matrix"
+PKG_SHA256="d583ae9904879ccc3e0c00dbda51eb3d36c67587d427a37963dd3750e013e90d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.waipu"
-PKG_VERSION="2.5.1-Matrix"
-PKG_SHA256="088667e131893a3a632b6b6c9e94161a4130dbc8d6e9f1a53d5e4646fa670cb7"
+PKG_VERSION="2.6.0-Matrix"
+PKG_SHA256="017080ebfc38519924743c0ec49a41f8b23e66db51af4d67cd21c114d0fc8f1b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="19.6.1-Matrix"
-PKG_SHA256="9d14c13601f551e94bd8fe2bb6ea68fab14a63e7844ffd82eb76ed5f5e83796b"
+PKG_VERSION="19.7.1-Matrix"
+PKG_SHA256="badea5f5feba692ffa2341a3b6bfb7958ea323c293e3ad9c22072dbd044ff5c4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Build-tested for RPi4.

pvr.zattoo bump should fix issue reported on forum https://forum.libreelec.tv/thread/23473-pvr-zattoo-not-working-fix-18-1-23-available-but-needs-compile-for-libreelec/?postID=150461#post150461