### PR TITLE
librespot: update addon (126)

### DIFF
--- a/packages/addons/addon-depends/librespot-depends/rust/package.mk
+++ b/packages/addons/addon-depends/librespot-depends/rust/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.49.0"
+PKG_VERSION="1.50.0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_DEPENDS_TARGET="toolchain rustup.rs"

--- a/packages/addons/service/librespot/changelog.txt
+++ b/packages/addons/service/librespot/changelog.txt
@@ -1,3 +1,6 @@
+126
+- rust: update to 1.50.0
+
 125
 - Update to 0.1.3
 - Revert to dns-sd instead of mdns

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="librespot"
 PKG_VERSION="0.1.3"
 PKG_SHA256="2d28a63c6dda08ecbc1245c7cfe34c9b3b29e8c5304f4aa8b65aedb899056b25"
-PKG_REV="125"
+PKG_REV="126"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/librespot-org/librespot/"


### PR DESCRIPTION
rust: update to 1.50.0

- update 1.49.0 (2020-12-31) to 1.50.0 (2021-02-11)
- announcement: https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html

```
=== tested on ===
 18:00:52 up 11 min,  load average: 0.27, 0.31, 0.20
AMLGX.aarch64-devel-20210212111004-6d60364
Linux odroid 5.11.0-rc7 #1 SMP PREEMPT Fri Feb 12 11:10:21 UTC 2021 aarch64 GNU/Linux
Starting Kodi (19.0-RC1 (18.9.910) Git:04303bf0c08adb47d9519cf7339acdd6edb1ec87). Platform: Linux ARM 64-bit
Using Release Kodi x64
Kodi compiled 2021-02-12 by GCC 10.2.0 for Linux ARM 64-bit version 5.11.0 (330496)
Running on Amlogic Meson G12B (S922X) Hardkernel ODROID-N2Plus with LibreELEC (heitbaum): devel-20210212111004-6d60364 9.80, kernel: Linux ARM 64-bit version 5.11.0-rc7
FFmpeg version/source: 4.3.1-Kodi
Host CPU: ARMv8 Processor rev 2 (v8l), 6 cores available
ARM Features: Neon enabled
EGL_VENDOR = Mesa Project
GL_VERSION = OpenGL ES 3.0 Mesa 21.1.0-devel


NAME="LibreELEC"
VERSION="devel-20210212111004-6d60364"
ID="libreelec"
VERSION_ID="9.80"
PRETTY_NAME="LibreELEC (heitbaum): devel-20210212111004-6d60364"
HOME_URL="https://libreelec.tv"
BUG_REPORT_URL="https://github.com/heitbaum/LibreELEC.tv"
BUILD_ID="6d603649add6fbf185543afc89fcae225ef11cd1"
LIBREELEC_ARCH="AMLGX.aarch64"
LIBREELEC_BUILD="heitbaum"
LIBREELEC_PROJECT="Amlogic"
LIBREELEC_DEVICE="AMLGX"
BUILDER_NAME="heitbaum"
```


```
2021-02-13 17:49:38.659 T:739      INFO <general>: Librespot: monitor started
2021-02-13 17:49:38.662 T:739      INFO <general>: Librespot: ['librespot', '--backend', 'pulseaudio', '--bitrate', '320', '--cache', 'cache', '--device', 'librespot', '--device-type', 'TV', '--disable-audio-cache', '--name', 'Librespot@odroid', '--notify-kodi', '--autoplay']
2021-02-13 17:49:38.780 T:739      INFO <general>: Librespot: loaded module-null-sink sink_name=librespot
2021-02-13 17:49:38.840 T:739      INFO <general>: Librespot: loaded module-rtp-send destination_ip=127.0.0.1 port=24642 source=librespot.monitor
2021-02-13 17:49:38.939 T:739      INFO <general>: Librespot: suspended sink 1
2021-02-13 17:49:38.939 T:863      INFO <general>: Librespot: librespot thread started
2021-02-13 17:49:38.972 T:863      INFO <general>: Librespot: librespot started
2021-02-13 17:49:38.996 T:863      INFO <general>: Librespot: [2021-02-13T06:49:38Z INFO  librespot] librespot aeb567f5eb (2021-02-13). Built on 2021-02-13. Build ID: ffQ7BUJ3
2021-02-13 17:49:39.016 T:863      INFO <general>: Librespot: *** WARNING *** The program 'librespot' uses the Apple Bonjour compatibility layer of Avahi.
2021-02-13 17:49:39.016 T:863      INFO <general>: Librespot: *** WARNING *** Please fix your application to use the native API of Avahi!
2021-02-13 17:49:39.016 T:863      INFO <general>: Librespot: *** WARNING *** For more information see <http://0pointer.de/blog/projects/avahi-compat.html>
2021-02-13 17:52:11.335 T:863      INFO <general>: Librespot: [2021-02-13T06:52:11Z INFO  librespot_core::session] Connecting to AP "gae2-accesspoint-e-53n7.ap.spotify.com:4070"
2021-02-13 17:52:12.076 T:863      INFO <general>: Librespot: thread 'main' panicked at 'Authentication failed with reason: PremiumAccountRequired', core/src/connection/mod.rs:121:21
2021-02-13 17:52:12.184 T:863      INFO <general>: Librespot: suspended sink 1
```