### PR TITLE
btrfs-progs: update addon to (103) with disable-zstd

### DIFF
--- a/packages/addons/tools/btrfs-progs/changelog.txt
+++ b/packages/addons/tools/btrfs-progs/changelog.txt
@@ -1,3 +1,6 @@
+103
+- rebuild with --disable-zstd
+
 102
 - Update to 4.15.1
 

--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -4,12 +4,12 @@
 PKG_NAME="btrfs-progs"
 PKG_VERSION="4.15.1"
 PKG_SHA256="9cb985b3466e2e0ca712ef8570d7eb2f94b56592221baf0fc76622f413852445"
-PKG_REV="102"
+PKG_REV="103"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 PKG_URL="https://github.com/kdave/btrfs-progs/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain util-linux zlib lzo zstd"
+PKG_DEPENDS_TARGET="toolchain util-linux zlib lzo"
 PKG_SECTION="tools"
 PKG_SHORTDESC="tools for the btrfs filesystem"
 PKG_LONGDESC="tools for the btrfs filesystem"
@@ -22,8 +22,9 @@ PKG_ADDON_NAME="BTRFS Tools"
 PKG_ADDON_TYPE="xbmc.python.script"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-backtrace \
+                           --disable-convert \
                            --disable-documentation \
-                           --disable-convert"
+                           --disable-zstd"
 
 pre_configure_target() {
   ./autogen.sh


### PR DESCRIPTION
The bump #4895 included the zstd depend which was introduced in btrfs-progs v4.13.1 (Sep 2017).
LibreELEC does not include libzstd in the core build so the tools were failing due to the missing library. 
This patch reverts to a btrfs-prongs without zstd thus fixing the introduced bug.

ref: 
- https://btrfs.wiki.kernel.org/index.php/Changelog
- https://btrfs.wiki.kernel.org/index.php/Changelog#btrfs-progs_v4.13_.28Sep_2017.29