### PR TITLE
brcmfmac_sdio-firmware: update to 47c4aae

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware"
-PKG_VERSION="6d49ff1bc15a1c55f711292ed22a7687fa2c9e14"
-PKG_SHA256="f3698b81fec401dc9b20c32896aab884e8dded1b1e7a5e595060fe3cbce7a5d3"
+PKG_VERSION="47c4aae498c935746b1e4a1fad87b0d9649ad947"
+PKG_SHA256="fee6192b6e5c1b46465faff4499189d12ce3568e40ed3909de821e4e3a9573cf"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/brcmfmac_sdio-firmware"
 PKG_URL="https://github.com/LibreELEC/brcmfmac_sdio-firmware/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Depends on https://github.com/LibreELEC/brcmfmac_sdio-firmware/pull/17