### PR TITLE
Allwinner: Add support for H3/H5 TVE

### DIFF
--- a/packages/tools/dt-overlays/package.mk
+++ b/packages/tools/dt-overlays/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dt-overlays"
-PKG_VERSION="e57a9b1eadd420a4e5d50c0669184828ff12abc5"
-PKG_SHA256="b63ee4f54723349ce405c9bd3545b5bb0814e4d1959a6a1db0bb2517318b1cc5"
+PKG_VERSION="4352d87db6e85d285673359e80cce87d5e025c64"
+PKG_SHA256="754a0c37a41f8e5d9d179eb1df40b84eb48c0a505a37e39fed5f1ceb35e8e120"
 PKG_LICENSE="GPLv2+ or MIT"
 PKG_SITE="https://github.com/LibreELEC/dt-overlays"
 PKG_URL="https://github.com/LibreELEC/dt-overlays/archive/${PKG_VERSION}.tar.gz"

--- a/projects/Allwinner/patches/linux/0055-wip-h3-h5-cvbs.patch
+++ b/projects/Allwinner/patches/linux/0055-wip-h3-h5-cvbs.patch
@@ -1,0 +1,307 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 20 Jan 2021 22:15:36 +0100
+Subject: [PATCH] wip h3/h5 cvbs
+
+---
+ arch/arm/boot/dts/sunxi-h3-h5.dtsi         | 111 ++++++++++++++++++++-
+ drivers/clk/sunxi-ng/ccu-sun8i-h3.c        |  14 ++-
+ drivers/gpu/drm/sun4i/Makefile             |   2 +-
+ drivers/gpu/drm/sun4i/sun8i_mixer.c        |  42 +++++++-
+ drivers/gpu/drm/sun4i/sun8i_mixer.h        |   5 +-
+ 6 files changed, 169 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index 22d533d18992..f18959b2e8df 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -101,7 +101,7 @@ osc32k: osc32k_clk {
+
+ 	de: display-engine {
+ 		compatible = "allwinner,sun8i-h3-display-engine";
+-		allwinner,pipelines = <&mixer0>;
++		allwinner,pipelines = <&mixer0>, <&mixer1>;
+ 		status = "disabled";
+ 	};
+
+@@ -138,11 +138,50 @@ ports {
+ 				#size-cells = <0>;
+
+ 				mixer0_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 					reg = <1>;
+
+-					mixer0_out_tcon0: endpoint {
++					mixer0_out_tcon0: endpoint@0 {
++						reg = <0>;
+ 						remote-endpoint = <&tcon0_in_mixer0>;
+ 					};
++
++					mixer0_out_tcon1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tcon1_in_mixer0>;
++					};
++				};
++			};
++		};
++
++		mixer1: mixer@1200000 {
++			compatible = "allwinner,sun8i-h3-de2-mixer-1";
++			reg = <0x01200000 0x100000>;
++			clocks = <&display_clocks CLK_BUS_MIXER1>,
++				 <&display_clocks CLK_MIXER1>;
++			clock-names = "bus",
++				      "mod";
++			resets = <&display_clocks RST_WB>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				mixer1_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <1>;
++
++					mixer1_out_tcon0: endpoint@0 {
++						reg = <0>;
++						remote-endpoint = <&tcon0_in_mixer1>;
++					};
++
++					mixer1_out_tcon1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tcon1_in_mixer1>;
++					};
+ 				};
+ 			};
+ 		};
+@@ -171,11 +210,19 @@ ports {
+ 				#size-cells = <0>;
+
+ 				tcon0_in: port@0 {
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 					reg = <0>;
+
+-					tcon0_in_mixer0: endpoint {
++					tcon0_in_mixer0: endpoint@0 {
++						reg = <0>;
+ 						remote-endpoint = <&mixer0_out_tcon0>;
+ 					};
++
++					tcon0_in_mixer1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&mixer1_out_tcon0>;
++					};
+ 				};
+
+ 				tcon0_out: port@1 {
+@@ -191,6 +238,49 @@ tcon0_out_hdmi: endpoint@1 {
+ 			};
+ 		};
+
++		tcon1: lcd-controller@1c0d000 {
++			compatible = "allwinner,sun8i-h3-tcon-tv",
++				     "allwinner,sun8i-a83t-tcon-tv";
++			reg = <0x01c0d000 0x1000>;
++			interrupts = <GIC_SPI 87 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_TCON1>, <&ccu CLK_TVE>;
++			clock-names = "ahb", "tcon-ch1";
++			resets = <&ccu RST_BUS_TCON1>;
++			reset-names = "lcd";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				tcon1_in: port@0 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <0>;
++
++					tcon1_in_mixer0: endpoint@0 {
++						reg = <0>;
++						remote-endpoint = <&mixer0_out_tcon1>;
++					};
++
++					tcon1_in_mixer1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&mixer1_out_tcon1>;
++					};
++				};
++
++				tcon1_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <1>;
++
++					tcon1_out_tve: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tve_in_tcon1>;
++					};
++				};
++			};
++		};
++
+ 		mmc0: mmc@1c0f000 {
+ 			/* compatible and clocks are in per SoC .dtsi file */
+ 			reg = <0x01c0f000 0x1000>;
+@@ -792,6 +882,21 @@ csi: camera@1cb0000 {
+ 			status = "disabled";
+ 		};
+
++		tve: tv-encoder@1e00000 {
++			compatible = "allwinner,sun8i-h3-tv-encoder",
++				     "allwinner,sun4i-a10-tv-encoder";
++			reg = <0x01e00000 0x1000>;
++			clocks = <&ccu CLK_BUS_TVE>;
++			resets = <&ccu RST_BUS_TVE>;
++			status = "disabled";
++
++			port {
++				tve_in_tcon1: endpoint {
++					remote-endpoint = <&tcon1_out_tve>;
++				};
++			};
++		};
++
+ 		hdmi: hdmi@1ee0000 {
+ 			compatible = "allwinner,sun8i-h3-dw-hdmi",
+ 				     "allwinner,sun8i-a83t-dw-hdmi";
+diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+index 7e629a4493af..334b7edea3b7 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
++++ b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+@@ -456,8 +456,18 @@ static SUNXI_CCU_M_WITH_MUX_GATE(tcon_clk, "tcon", tcon_parents,
+ 				 CLK_SET_RATE_PARENT);
+
+ static const char * const tve_parents[] = { "pll-de", "pll-periph1" };
+-static SUNXI_CCU_M_WITH_MUX_GATE(tve_clk, "tve", tve_parents,
+-				 0x120, 0, 4, 24, 3, BIT(31), 0);
++struct ccu_div tve_clk = {
++	.enable	= BIT(31),
++	.div	= _SUNXI_CCU_DIV(0, 4),
++	.mux	= _SUNXI_CCU_MUX(24, 3),
++	.fixed_post_div = 16,
++	.common	= {
++		.reg		= 0x120,
++		.features	= CCU_FEATURE_FIXED_POSTDIV,
++		.hw.init	= CLK_HW_INIT_PARENTS("tve", tve_parents,
++						      &ccu_div_ops, 0),
++	},
++};
+
+ static const char * const deinterlace_parents[] = { "pll-periph0", "pll-periph1" };
+ static SUNXI_CCU_M_WITH_MUX_GATE(deinterlace_clk, "deinterlace", deinterlace_parents,
+diff --git a/drivers/gpu/drm/sun4i/Makefile b/drivers/gpu/drm/sun4i/Makefile
+index 0d04f2447b01..7b151994e904 100644
+--- a/drivers/gpu/drm/sun4i/Makefile
++++ b/drivers/gpu/drm/sun4i/Makefile
+@@ -16,7 +16,7 @@ sun8i-drm-hdmi-y		+= sun8i_hdmi_phy_clk.o
+
+ sun8i-mixer-y			+= sun8i_mixer.o sun8i_ui_layer.o \
+ 				   sun8i_vi_layer.o sun8i_ui_scaler.o \
+-				   sun8i_vi_scaler.o sun8i_csc.o
++				   sun8i_vi_scaler.o sun8i_csc.o sun4i_tv.o
+
+ sun4i-tcon-y			+= sun4i_crtc.o
+ sun4i-tcon-y			+= sun4i_dotclock.o
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.c b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+index 5b42cf25cc86..35ca78a30087 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_mixer.c
++++ b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+@@ -32,6 +32,12 @@ struct de2_fmt_info {
+ 	u32	de2_fmt;
+ };
+
++static const u32 sun8i_rgb2yuv_coef[12] = {
++	0x00000107, 0x00000204, 0x00000064, 0x00004200,
++	0x00001f68, 0x00001ed6, 0x000001c2, 0x00020200,
++	0x000001c2, 0x00001e87, 0x00001fb7, 0x00020200,
++};
++
+ static const struct de2_fmt_info de2_formats[] = {
+ 	{
+ 		.drm_fmt = DRM_FORMAT_ARGB8888,
+@@ -298,9 +304,28 @@ static struct drm_plane **sun8i_layers_init(struct drm_device *drm,
+ 	return planes;
+ }
+
++static void sun8i_mixer_apply_color_correction(struct sunxi_engine *engine)
++{
++	DRM_DEBUG_DRIVER("Applying RGB to YUV color correction\n");
++
++	regmap_bulk_write(engine->regs, SUN8I_MIXER_DCSC_COEF_REG(0),
++			  sun8i_rgb2yuv_coef, 12);
++	regmap_write(engine->regs, SUN8I_MIXER_DCSC_EN, 1);
++}
++
++static void sun8i_mixer_disable_color_correction(struct sunxi_engine *engine)
++{
++	DRM_DEBUG_DRIVER("Disabling color correction\n");
++
++	/* Disable color correction */
++	regmap_write(engine->regs, SUN8I_MIXER_DCSC_EN, 0);
++}
++
+ static const struct sunxi_engine_ops sun8i_engine_ops = {
+-	.commit		= sun8i_mixer_commit,
+-	.layers_init	= sun8i_layers_init,
++	.commit				= sun8i_mixer_commit,
++	.layers_init			= sun8i_layers_init,
++	.apply_color_correction		= sun8i_mixer_apply_color_correction,
++	.disable_color_correction	= sun8i_mixer_disable_color_correction,
+ };
+
+ static const struct regmap_config sun8i_mixer_regmap_config = {
+@@ -560,6 +585,15 @@ static const struct sun8i_mixer_cfg sun8i_h3_mixer0_cfg = {
+ 	.vi_num		= 1,
+ };
+
++static const struct sun8i_mixer_cfg sun8i_h3_mixer1_cfg = {
++	.ccsc		= 1,
++	.mod_rate	= 432000000,
++	.scaler_mask	= 0x3,
++	.scanline_yuv	= 2048,
++	.ui_num		= 1,
++	.vi_num		= 1,
++};
++
+ static const struct sun8i_mixer_cfg sun8i_r40_mixer0_cfg = {
+ 	.ccsc		= 0,
+ 	.mod_rate	= 297000000,
+@@ -628,6 +662,10 @@ static const struct of_device_id sun8i_mixer_of_table[] = {
+ 		.compatible = "allwinner,sun8i-h3-de2-mixer-0",
+ 		.data = &sun8i_h3_mixer0_cfg,
+ 	},
++	{
++		.compatible = "allwinner,sun8i-h3-de2-mixer-1",
++		.data = &sun8i_h3_mixer1_cfg,
++	},
+ 	{
+ 		.compatible = "allwinner,sun8i-r40-de2-mixer-0",
+ 		.data = &sun8i_r40_mixer0_cfg,
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.h b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+index 7576b523fdbb..6593085cecf3 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_mixer.h
++++ b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+@@ -120,6 +120,10 @@
+ /* format 20 is packed YVU444 10-bit */
+ /* format 21 is packed YUV444 10-bit */
+
++/* The DCSC sub-engine is used to do color space conversation */
++#define SUN8I_MIXER_DCSC_EN			0xb0000
++#define SUN8I_MIXER_DCSC_COEF_REG(x)		(0xb0010 + 0x4 * (x))
++
+ /*
+  * Sub-engines listed bellow are unused for now. The EN registers are here only
+  * to be used to disable these sub-engines.
+@@ -130,7 +134,6 @@
+ #define SUN8I_MIXER_PEAK_EN			0xa6000
+ #define SUN8I_MIXER_ASE_EN			0xa8000
+ #define SUN8I_MIXER_FCC_EN			0xaa000
+-#define SUN8I_MIXER_DCSC_EN			0xb0000
+
+ #define SUN50I_MIXER_FCE_EN			0x70000
+ #define SUN50I_MIXER_PEAK_EN			0x70800


### PR DESCRIPTION
This adds support for TVE (CVBS) on H3 and H5. It must be activated with DT overlays.