### PR TITLE
glmark2: update to 2021.02

### DIFF
--- a/packages/graphics/glmark2/package.mk
+++ b/packages/graphics/glmark2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glmark2"
-PKG_VERSION="dab3e7d8ab185a59e7475845d189f9a2d7d67ad0"
-PKG_SHA256="01dc8adb82ae01e248e3d16f7510356bae87900e119089f7402e4915824fcd75"
+PKG_VERSION="2021.02"
+PKG_SHA256="bebadb78c13aea5e88ed892e5563101ccb745b75f1dc86a8fc7229f00d78cbf1"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/glmark2/glmark2"
 PKG_URL="https://github.com/glmark2/glmark2/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
### Official Release

update dab3e7d (2021-02-13) to 2021.02 (2021-02-15)
News: https://github.com/glmark2/glmark2/blob/master/NEWS


### glmark2 2021.02 (20210215)
Release notes:
- Meson build system support for DRM/X11/Wayland builds.
- Fix precision handling in various fragment shaders.
- Fix spurious failures when using --validate.
- Always draw to the correct, offscreen buffer when using --off-screen.
- Don't prefer framebuffer formats with more than 8 bytes per component.
- Add basic mouse and keyboard support on Wayland.