### PR TITLE
autoreconf: support custom PKG_CONFIGURE_SCRIPT

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/asio/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/asio/package.mk
@@ -15,6 +15,6 @@ PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--without-boost --without-openssl"
 
-post_unpack() {
-  mv ${PKG_BUILD}/asio/* ${PKG_BUILD}
+configure_package() {
+  PKG_CONFIGURE_SCRIPT="${PKG_BUILD}/asio/configure"
 }

--- a/packages/sysutils/open-vm-tools/package.mk
+++ b/packages/sysutils/open-vm-tools/package.mk
@@ -28,13 +28,11 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-docs \
                            --with-udev-rules-dir=/usr/lib/udev/rules.d/ \
                            --with-sysroot=${SYSROOT_PREFIX}"
 
+configure_package() {
+  PKG_CONFIGURE_SCRIPT="${PKG_BUILD}/open-vm-tools/configure"
+}
+
 post_unpack() {
-  mv ${PKG_BUILD}/${PKG_NAME}/* ${PKG_BUILD}/
-
-  sed -e 's|.*common-agent/etc/config/Makefile.*||' -i ${PKG_BUILD}/configure.ac
-
-  mkdir -p ${PKG_BUILD}/common-agent/etc/config
-
   # Hack to allow package to be bumped without linking against old libraries
   rm -f ${SYSROOT_PREFIX}/usr/lib/libvmtools*
 }

--- a/scripts/autoreconf
+++ b/scripts/autoreconf
@@ -6,27 +6,29 @@
 
 . config/options "${1}"
 
-if [ ! -f "${PKG_BUILD}/configure.in" \
-    -a ! -f "${PKG_BUILD}/configure.ac" ]; then
+RECONF_DIR="${3}"
+
+if [ ! -f "${RECONF_DIR}/configure.in" \
+    -a ! -f "${RECONF_DIR}/configure.ac" ]; then
   die "configure.in or configure.ac not found"
 fi
 
-if [ ! -f "${PKG_BUILD}/.autoreconf-done" ]; then
+if [ ! -f "${RECONF_DIR}/.autoreconf-done" ]; then
   PARENT_PKG="${2}"
 
   # lock package during autoreconf otherwise it is racy, eg. glib:host/glib:target building concurrently
   pkg_lock "${PKG_NAME}" "reconf" "${PARENT_PKG}"
 
-  if [ ! -f "${PKG_BUILD}/.autoreconf-done" ]; then
+  if [ ! -f "${RECONF_DIR}/.autoreconf-done" ]; then
     pkg_lock_status "ACTIVE" "${PKG_NAME}" "reconf"
 
-    touch "${PKG_BUILD}/NEWS" "${PKG_BUILD}/AUTHORS" "${PKG_BUILD}/ChangeLog"
-    mkdir -p "${PKG_BUILD}/m4"
+    touch "${RECONF_DIR}/NEWS" "${RECONF_DIR}/AUTHORS" "${RECONF_DIR}/ChangeLog"
+    mkdir -p "${RECONF_DIR}/m4"
 
     build_msg "CLR_AUTORECONF" "AUTORECONF" "${PKG_NAME}" "indent"
 
-    do_autoreconf "${PKG_BUILD}"
-    touch "${PKG_BUILD}/.autoreconf-done"
+    do_autoreconf "${RECONF_DIR}"
+    touch "${RECONF_DIR}/.autoreconf-done"
 
     pkg_lock_status "UNLOCK" "${PKG_NAME}" "reconf" "configured"
   else

--- a/scripts/build
+++ b/scripts/build
@@ -207,7 +207,7 @@ BOOTSTRAP_MESON_OPTS="${HOST_MESON_OPTS}"
 
 # make autoreconf
 if [ "${PKG_TOOLCHAIN}" = "autotools" ]; then
-  ${SCRIPTS}/autoreconf "${PKG_NAME}" "${PARENT_PKG}"
+  ${SCRIPTS}/autoreconf "${PKG_NAME}" "${PARENT_PKG}" $(dirname "${PKG_CONFIGURE_SCRIPT}")
 fi
 
 pkg_lock_status "ACTIVE" "${PKG_NAME}:${TARGET}" "build"


### PR DESCRIPTION
PKG_BUILD path was hard coded in autoreconf script. Use path of PKG_CONFIGURE_SCRIPT that is by default set to "${PKG_BUILD}/configure".

See discussion of #4972