### PR TITLE
libmicrohttpd: enable https for kodi webserver

### DIFF
--- a/packages/web/libmicrohttpd/package.mk
+++ b/packages/web/libmicrohttpd/package.mk
@@ -8,14 +8,13 @@ PKG_SHA256="0ae825f8e0d7f41201fd44a0df1cf454c1cb0bc50fe9d59c26552260264c2ff8"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="http://www.gnu.org/software/libmicrohttpd/"
 PKG_URL="http://ftpmirror.gnu.org/libmicrohttpd/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain gnutls"
 PKG_LONGDESC="A small C library that is supposed to make it easy to run an HTTP server as part of another application."
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
                            --enable-static \
                            --disable-curl \
-                           --disable-https \
-                           --with-libgcrypt-prefix=${SYSROOT_PREFIX}/usr"
+                           --enable-https"
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin


### PR DESCRIPTION
Allow kodi web server to use https. With this change "Settings->Services->Control->Enable SSL" is visiible and can be used.

Kodi size is only increased by ~20k

Reported in issue #5136