### PR TITLE
openssl: update to 1.1.1j

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="1.1.1i"
-PKG_SHA256="e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242"
+PKG_VERSION="1.1.1j"
+PKG_SHA256="aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.openssl.org"
 PKG_URL="https://www.openssl.org/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 1.1.1i (2020-12-08) to 1.1.1j (2021-02-16)
changelog: https://www.openssl.org/news/changelog.html#openssl-111

tested on Generic
```
LibreELEC:~ # ssh -V
OpenSSH_8.4p1, OpenSSL 1.1.1j  16 Feb 2021
```