### PR TITLE
update_retroplayer-addons: check for orphaned addon packages

### DIFF
--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -193,5 +193,13 @@ for addon in ${ADDONS_DIR}/*.*/ ; do
   cleanup_pkg_tmp
 done
 
+msg_info "Checking for orphaned addon packages in LE"
+for addon in ${ROOT}/packages/mediacenter/kodi-binary-addons/game.libretro.* ; do
+  GAME_ADDON=$(basename ${addon})
+  if [ ! -d "${ADDONS_DIR}/${GAME_ADDON}" ] ; then
+    msg_warn "ORHPANED ${GAME_ADDON}, not present in kodi game repo"
+  fi
+done
+
 rm -rf "${TMPDIR}"
 


### PR DESCRIPTION
Report which game addon packages are only present in LE but not in
the kodi game binary addon repo.

These packages are not automatically bumped by the script and should
either be removed from LE or added to the kodi game binary repo.

With current master this gives the following output:
```
Checking for orphaned addon packages in LE
ORHPANED game.libretro.4do, not present in kodi game repo
ORHPANED game.libretro.dosbox-pure, not present in kodi game repo
ORHPANED game.libretro.fbalpha, not present in kodi game repo
ORHPANED game.libretro.mame, not present in kodi game repo
ORHPANED game.libretro.mame2014, not present in kodi game repo
ORHPANED game.libretro.mupen64plus, not present in kodi game repo
ORHPANED game.libretro.reicast, not present in kodi game repo
ORHPANED game.libretro.vram-test, not present in kodi game repo
```