### PR TITLE
strace: update to 5.11

### DIFF
--- a/packages/debug/strace/package.mk
+++ b/packages/debug/strace/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="strace"
-PKG_VERSION="5.10"
-PKG_SHA256="fe3982ea4cd9aeb3b4ba35f6279f0b577a37175d3282be24b9a5537b56b8f01c"
+PKG_VERSION="5.11"
+PKG_SHA256="ffe340b10c145a0f85734271e9cce56457d23f21a7ea5931ab32f8cf4e793879"
 PKG_LICENSE="BSD"
 PKG_SITE="https://strace.io/"
 PKG_URL="https://strace.io/files/${PKG_VERSION}/strace-${PKG_VERSION}.tar.xz"

--- a/packages/debug/strace/patches/strace-0001-autoreconf.patch
+++ b/packages/debug/strace/patches/strace-0001-autoreconf.patch
@@ -7,11 +7,11 @@ index 4e7bc2a89..3b762c94c 100644
  
  AC_PREREQ(2.57)
 -AC_INIT([strace],
--	st_esyscmd_s([./git-version-gen .tarball-version]),
+-	st_esyscmd_s([./build-aux/git-version-gen .tarball-version]),
 -	[strace-devel@lists.strace.io],
 -	[strace],
 -	[https://strace.io])
-+AC_INIT([strace],[5.10])
- m4_define([copyright_year], st_esyscmd_s([./copyright-year-gen .year]))
- m4_define([manpage_date], st_esyscmd_s([./file-date-gen strace.1.in]))
++AC_INIT([strace],[5.11])
+ m4_define([copyright_year], st_esyscmd_s([./build-aux/copyright-year-gen .year]))
+ m4_define([manpage_date], st_esyscmd_s([./build-aux/file-date-gen doc/strace.1.in]))
  AC_COPYRIGHT([Copyright (c) 1999-]copyright_year[ The strace developers.])


### PR DESCRIPTION
- update 5.10 (2020-12-14) to 5.11 (2021-02-17)
- release notes: https://github.com/strace/strace/releases/tag/v5.11
- news: https://github.com/strace/strace/blob/master/NEWS

**some important and interesting improvements**
  * Implemented decoding of V4L2_BUF_TYPE_META_CAPTURE,
    V4L2_BUF_TYPE_META_OUTPUT, and VIDIOC_QUERY_EXT_CTRL ioctl commands.
  * Updated lists of BPF_*, BTRFS_*, CLOSE_RANGE_*, ETH_*, IORING_*, KVM_*,
    PR_*, PTRACE_*, RTA_*, RTAX_*, RTM_*, RTNH_*, SCTP_*, SO_*, SYS_*, UFFD_*,
    and V4L2_* constants.
  * Updated lists of ioctl commands from Linux 5.11.
 
 ```
Generic # strace -V
strace -- version 5.11
Copyright (c) 1991-2021 The strace developers <>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Optional features enabled: no-m32-mpers no-mx32-mpers

odroid N2+ # strace -V
strace -- version 5.11
Copyright (c) 1991-2021 The strace developers <>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Optional features enabled: no-m32-mpers
```
