### PR TITLE
[emulation] add game.libretro.opera as game.libretro.4do replacement

### DIFF
--- a/packages/emulation/libretro-opera/package.mk
+++ b/packages/emulation/libretro-opera/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-opera"
+PKG_VERSION="539dc447b536ba52eb3485f11d9bf1c06e30cf75"
+PKG_SHA256="5552025528d8e9100b2f6729ab511f7708f36a687d2d07c379a0087ae7b81021"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/libretro/opera-libretro"
+PKG_URL="https://github.com/libretro/opera-libretro/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_LONGDESC="game.libretro.opera: Port of 4DO/libfreedo for Kodi."
+PKG_TOOLCHAIN="make"
+PKG_BUILD_FLAGS="+lto"
+
+PKG_LIBNAME="opera_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="OPERA_LIB"
+
+PKG_MAKE_OPTS_TARGET="GIT_VERSION=${PKG_VERSION:0:7}"
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/emulation/libretro-opera/patches/libretro-opera-995.01-crosscompile.patch
+++ b/packages/emulation/libretro-opera/patches/libretro-opera-995.01-crosscompile.patch
@@ -1,0 +1,148 @@
+From a845c2c44e2bed070b1f6db5b0fda5a7a84485e6 Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Thu, 18 Feb 2021 13:21:30 +0100
+Subject: [PATCH] Makefile: only define cc, cxx, ar, ld if not predefined
+
+---
+ Makefile | 52 ++++++++++++++++++++++++++--------------------------
+ 1 file changed, 26 insertions(+), 26 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index f588a3c..27c5461 100644
+--- a/Makefile
++++ b/Makefile
+@@ -49,8 +49,8 @@ unixpath = $(subst \,/,$1)
+ unixcygpath = /$(subst :,,$(call unixpath,$1))
+ 
+ ifneq (,$(findstring unix,$(platform)))
+-    AR = ${CC_PREFIX}ar
+-    CC = ${CC_PREFIX}gcc
++    AR ?= ${CC_PREFIX}ar
++    CC ?= ${CC_PREFIX}gcc
+ 
+     TARGET := $(TARGET_NAME)_libretro.so
+     fpic := -fPIC
+@@ -138,8 +138,8 @@ else ifeq ($(platform), classic_armv7_a7)
+ 
+ # ARM
+ else ifneq (,$(findstring armv,$(platform)))
+-    AR = ${CC_PREFIX}ar
+-    CC = ${CC_PREFIX}gcc
++    AR ?= ${CC_PREFIX}ar
++    CC ?= ${CC_PREFIX}gcc
+ 
+     TARGET := $(TARGET_NAME)_libretro.so
+     fpic := -fPIC
+@@ -180,9 +180,9 @@ ifeq ($(IOSSDK),)
+    IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
+ endif
+ ifeq ($(platform),ios-arm64)
+-   CC = cc -arch arm64 -isysroot $(IOSSDK)
++   CC ?= cc -arch arm64 -isysroot $(IOSSDK)
+ else
+-   CC = cc -arch armv7 -isysroot $(IOSSDK)
++   CC ?= cc -arch armv7 -isysroot $(IOSSDK)
+ endif
+ ifeq ($(platform),$(filter $(platform),ios9 ios-arm64))
+    SHARED += -miphoneos-version-min=8.0
+@@ -213,18 +213,18 @@ else ifeq ($(platform), qnx)
+    TARGET := $(TARGET_NAME)_libretro_$(platform).so
+    fpic := -fPIC
+    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
+-   CC = qcc -Vgcc_ntoarmv7le
++   CC ?= qcc -Vgcc_ntoarmv7le
+ else ifeq ($(platform), ps3)
+    TARGET := $(TARGET_NAME)_libretro_$(platform).a
+-   CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
+-   AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
++   CC ?= $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
++   AR ?= $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
+    STATIC_LINKING = 1
+    FLAGS += -DMSB_FIRST -D__CELLOS_LV2__
+    OLD_GCC = 1
+ else ifeq ($(platform), sncps3)
+    TARGET := $(TARGET_NAME)_libretro_ps3.a
+-   CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
+-   AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
++   CC ?= $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
++   AR ?= $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
+    STATIC_LINKING = 1
+    FLAGS += -DMSB_FIRST
+    NO_GCC = 1
+@@ -232,25 +232,25 @@ else ifeq ($(platform), sncps3)
+ # PSP1
+ else ifeq ($(platform), psp1)
+    TARGET := $(TARGET_NAME)_libretro_$(platform).a
+-   CC = psp-gcc$(EXE_EXT)
+-   AR = psp-ar$(EXE_EXT)
++   CC ?= psp-gcc$(EXE_EXT)
++   AR ?= psp-ar$(EXE_EXT)
+    STATIC_LINKING = 1
+    FLAGS += -G0
+ 
+ # Vita
+ else ifeq ($(platform), vita)
+    TARGET := $(TARGET_NAME)_libretro_$(platform).a
+-   CC = arm-vita-eabi-gcc$(EXE_EXT)
+-   AR = arm-vita-eabi-ar$(EXE_EXT)
++   CC ?= arm-vita-eabi-gcc$(EXE_EXT)
++   AR ?= arm-vita-eabi-ar$(EXE_EXT)
+    STATIC_LINKING = 1
+    FLAGS += -DVITA
+ 
+ # CTR (3DS)
+ else ifeq ($(platform), ctr)
+    TARGET := $(TARGET_NAME)_libretro_$(platform).a
+-   CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
+-   CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
+-   AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
++   CC ?= $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
++   CXX ?=$(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
++   AR ?= $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
+    FLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard
+    FLAGS += -Wall -mword-relocations
+    FLAGS += -fomit-frame-pointer -ffast-math
+@@ -308,8 +308,8 @@ else ifeq ($(platform), emscripten)
+ # Windows MSVC 2003 Xbox 1
+ else ifeq ($(platform), xbox1_msvc2003)
+ TARGET := $(TARGET_NAME)_libretro_xdk1.lib
+-CC = CL.exe
+-LD = lib.exe
++CC ?= CL.exe
++LD ?= lib.exe
+ 
+ export INCLUDE := $(XDK)/xbox/include
+ export LIB := $(XDK)/xbox/lib
+@@ -322,8 +322,8 @@ HAS_GCC := 0
+ else ifeq ($(platform), xbox360_msvc2010)
+ TARGET := $(TARGET_NAME)_libretro_xdk360.lib
+ MSVCBINDIRPREFIX = $(XEDK)/bin/win32
+-CC = "$(MSVCBINDIRPREFIX)/cl.exe"
+-LD = "$(MSVCBINDIRPREFIX)/lib.exe"
++CC ?= "$(MSVCBINDIRPREFIX)/cl.exe"
++LD ?= "$(MSVCBINDIRPREFIX)/lib.exe"
+ 
+ export INCLUDE := $(XEDK)/include/xbox
+ export LIB := $(XEDK)/lib/xbox
+@@ -456,9 +456,9 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
+ 
+ 	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
+ 
+-	CC  = cl.exe
+-	CXX = cl.exe
+-	LD = link.exe
++	CC  ?= cl.exe
++	CXX ?= cl.exe
++	LD ?= link.exe
+ 
+ 	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
+ 	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
+@@ -612,7 +612,7 @@ ifeq ($(STATIC_LINKING),1)
+ 	LD ?= lib.exe
+ 	STATIC_LINKING=0
+ else
+-	LD = link.exe
++	LD ?= link.exe
+ endif
+ else
+ 	LD = $(CC)

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.opera/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.opera/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.opera"
+PKG_VERSION="1.0.0.16-Matrix"
+PKG_SHA256="cc62de7326e52c0ffa7bf1afb13081360d57084d31ab03d5fb8041d90fff1f9c"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.libretro.opera"
+PKG_URL="https://github.com/kodi-game/game.libretro.opera/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-opera"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.opera: Port of 4DO/libfreedo for Kodi."
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
As follow up to https://github.com/LibreELEC/LibreELEC.tv/pull/5151#issue-574801219 and as a replacement for `game.libretro.4do` the 3DO emulator `game.libretro.opera` will be added.