### PR TITLE
kodi: add patch to fix gbm default resolution handling

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-995.20-gbm-default-to-original-crtc-mode.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.20-gbm-default-to-original-crtc-mode.patch
@@ -1,0 +1,70 @@
+From bdd6c0e14d52f1ec8dac34c1dee9a636fd5cd1e8 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Wed, 17 Feb 2021 22:14:15 +0100
+Subject: [PATCH] windowing/gbm/drm: default to original crtc mode
+
+This brings RES_DESKTOP handling of gbm in line with other windowing
+systems.
+
+If the framebuffer has been set up with a valid mode before kodi
+startup then use that as the default / DESKTOP mode, otherwise fall
+back to the previous behaviour of setting DESKTOP to the preferred
+mode reported by drm.
+
+This avoids unnecessary mode switches at kodi startup (which usually
+lead to screen blanking for a short time) and allows users to easily
+override broken video/edid/... setups by manually configuring a mode
+in linux which then kodi uses too. That is especially important when
+running kodi for the first time, if it switches to a different mode
+that might not be working with the user's monitor the result is a
+black screen with no easy possibility to fix the settings.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ xbmc/windowing/gbm/drm/DRMCrtc.h    |  1 +
+ xbmc/windowing/gbm/drm/DRMUtils.cpp | 10 ++++++++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/xbmc/windowing/gbm/drm/DRMCrtc.h b/xbmc/windowing/gbm/drm/DRMCrtc.h
+index 15d7f8faf6..a1aadc2fad 100644
+--- a/xbmc/windowing/gbm/drm/DRMCrtc.h
++++ b/xbmc/windowing/gbm/drm/DRMCrtc.h
+@@ -30,6 +30,7 @@ public:
+   uint32_t GetX() const { return m_crtc->x; }
+   uint32_t GetY() const { return m_crtc->y; }
+   drmModeModeInfoPtr GetMode() const { return &m_crtc->mode; }
++  bool GetModeValid() const { return m_crtc->mode_valid != 0; }
+ 
+ private:
+   struct DrmModeCrtcDeleter
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.cpp b/xbmc/windowing/gbm/drm/DRMUtils.cpp
+index 5593ce086b..85fc266fd2 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
++++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
+@@ -144,6 +144,9 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
+ 
+ bool CDRMUtils::FindPreferredMode()
+ {
++  if (m_mode)
++    return true;
++
+   for (int i = 0, area = 0; i < m_connector->GetModesCount(); i++)
+   {
+     drmModeModeInfo* current_mode = m_connector->GetModeForIndex(i);
+@@ -534,6 +537,13 @@ bool CDRMUtils::FindCrtc()
+       if (m_crtcs[i]->GetCrtcId() == m_encoder->GetCrtcId())
+       {
+         m_orig_crtc = m_crtcs[i].get();
++        if (m_orig_crtc->GetModeValid())
++        {
++          m_mode = m_orig_crtc->GetMode();
++          CLog::Log(LOGDEBUG, "CDRMUtils::{} - original crtc mode: {}x{}{} @ {} Hz", __FUNCTION__,
++                    m_mode->hdisplay, m_mode->vdisplay,
++                    m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "", m_mode->vrefresh);
++        }
+         return true;
+       }
+     }
+-- 
+2.20.1
+


### PR DESCRIPTION
This brings kodi's RES_DESKTOP handling in line with other
windowing systems, kodi's default is now the mode configured
prior to kodi startup.

Kodi PR is here: https://github.com/xbmc/xbmc/pull/19244

Tested on RPi4: custom video mode set on kernel command line, kodi folder removed, kodi used the configured custom video mode (instead of the DRM "preferred" mode) and set screenmode to DESKTOP in guisettings.xml.