### PR TITLE
binutils: fix parallel build with libctf requiring bfd

### DIFF
--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -60,6 +60,7 @@ make_host() {
 
 makeinstall_host() {
   cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
+  make -C bfd install # fix parallel build with libctf requiring bfd
   make install
 }
 


### PR DESCRIPTION
Moving from my NUC6 to a NUC11 as a build host / Kodi test binutils fails to compile (and I believe it is a parallel issue)

This is the error log 
- http://paste.ubuntu.com/p/VYSv72W6CF/ 
- lines 3668-3676
- `/usr/bin/ld: cannot find -lbfd`

If I execute `PROJECT=Generic ARCH=x86_64 make image` a second time it finishes the build.

the patch attached fixes the dependancy. Not sure if it is the right way, but happy to take a direction to resolve.

the details of the build host below (old was Skylake 4 CPU, new Tiger Lake 8 CPU)
```
$ rm -rf build.LibreELEC-Generic.x86_64-9.80-devel/
$ PROJECT=Generic ARCH=x86_64 make image
...

Total Build Time: 01:09:06.950 (wall clock)
Accum Build Time: 09:12:55.500 (8 slots)

Breakdown by status (all slots):

  Status   Usage         ( Pct )  Count  State
  ACTIVE   05:20:44.757  (58.0%)  889    busy 
  FAILED     :  :00.000  (00.0%)  0           
  GETPKG     :  :00.000  (00.0%)  0      busy 
  IDLE     03:50:10.400  (41.6%)  324         
  LOCKED     :01:10.595  (00.2%)  1004        
  MUTEX      :  :06.394  (00.0%)  6      busy 
  MUTEX/W    :  :03.620  (00.0%)  3      stall
  STALLED    :  :01.190  (00.0%)  3      stall
  UNLOCK     :  :38.544  (00.1%)  1004        
  -------------------------------------
  TOTAL    09:12:55.500  ( 100%)  3233 

Peak concurrency: 8 out of 8 slots

6 job slots were held in a "stall" state for 00:00:04.810

Slot usage (time in a "busy" state):     | Concurrency breakdown ("busy"):
                                         |
#Rank  Slot  Usage        ( Pct )        | # of Slots  Usage        ( Pct )
 #01    05     :53:26.422 (09.7%)        |     01      01:08:52.302 (12.5%)
 #02    08     :44:45.779 (08.1%)        |     02        :52:53.150 (09.6%)
 #03    03     :41:58.827 (07.6%)        |     03        :46:34.562 (08.4%)
 #04    02     :39:43.100 (07.2%)        |     04        :42:25.003 (07.7%)
 #05    01     :37:34.417 (06.8%)        |     05        :32:54.782 (06.0%)
 #06    07     :35:02.215 (06.3%)        |     06        :27:01.186 (04.9%)
 #07    04     :34:32.697 (06.2%)        |     07        :26:18.962 (04.8%)
 #08    06     :33:47.695 (06.1%)        |     08        :23:51.204 (04.3%)
-----------------------------------------+---------------------------------
 TOTALS      05:20:51.151 (58.0%)                      05:20:51.151 (58.0%)

DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0037.2021.0106.1527 01/06/2021

Intel(R) Xe Graphics (TGL GT2)

Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   39 bits physical, 48 bits virtual
CPU(s):                          8
On-line CPU(s) list:             0-7
Thread(s) per core:              2
Core(s) per socket:              4
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           140
Model name:                      11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
Stepping:                        1
CPU MHz:                         1201.228
CPU max MHz:                     4700.0000
CPU min MHz:                     400.0000
BogoMIPS:                        5608.00
Virtualization:                  VT-x
L1d cache:                       192 KiB
L1i cache:                       128 KiB
L2 cache:                        5 MiB
L3 cache:                        12 MiB
NUMA node0 CPU(s):               0-7
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RSB filling
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l2 invpcid_single cdp_l2 ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves split_lock_detect dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp hwp_pkg_req avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid movdiri movdir64b fsrm avx512_vp2intersect md_clear flush_l1d arch_capabilities
```

