### PR TITLE
fakeroot: host build fix with glibc 2.33

### DIFF
--- a/packages/devel/fakeroot/patches/fakeroot-002-build-fix.patch
+++ b/packages/devel/fakeroot/patches/fakeroot-002-build-fix.patch
@@ -1,0 +1,413 @@
+From 03bc0ee07fb6e293d081ffd8af1654788b434f6a Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Thu, 11 Feb 2021 20:59:25 -0800
+Subject: [PATCH 1/6] libfakeroot.c: define _STAT_VER if not already defined
+
+Based on patch from Jan Pazdziora:
+https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/SMQ3RYXEYTVZH6PLQMKNB3NM4XLPMNZO/
+
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+---
+ libfakeroot.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/libfakeroot.c b/libfakeroot.c
+index 3e80e38..14cdbc4 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -90,6 +90,16 @@
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b)
+ #endif
+ 
++#ifndef _STAT_VER
++ #if defined (__aarch64__)
++  #define _STAT_VER 0
++ #elif defined (__x86_64__)
++  #define _STAT_VER 1
++ #else
++  #define _STAT_VER 3
++ #endif
++#endif
++
+ /*
+    These INT_* (which stands for internal) macros should always be used when
+    the fakeroot library owns the storage of the stat variable.
+-- 
+GitLab
+
+
+From feda578ca3608b7fc9a28a3a91293611c0ef47b7 Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Thu, 11 Feb 2021 21:00:04 -0800
+Subject: [PATCH 2/6] libfakeroot.c: add wrappers for new glibc 2.33+ symbols
+
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+---
+ libfakeroot.c | 48 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/libfakeroot.c b/libfakeroot.c
+index 14cdbc4..d75c51f 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -1352,6 +1352,54 @@ int renameat(int olddir_fd, const char *oldpath,
+ #endif /* HAVE_FSTATAT */
+ 
+ 
++#if defined(__GLIBC__) && __GLIBC_PREREQ(2,33)
++/* Glibc 2.33 exports symbols for these functions in the shared lib */
++  int lstat(const char *file_name, struct stat *statbuf) {
++     return WRAP_LSTAT LSTAT_ARG(_STAT_VER, file_name, statbuf);
++  }
++  int stat(const char *file_name, struct stat *st) {
++     return WRAP_STAT STAT_ARG(_STAT_VER, file_name, st);
++  }
++  int fstat(int fd, struct stat *st) {
++     return WRAP_FSTAT FSTAT_ARG(_STAT_VER, fd, st);
++  }
++
++  #ifdef HAVE_FSTATAT
++    int fstatat(int dir_fd, const char *path, struct stat *st, int flags) {
++       return WRAP_FSTATAT FSTATAT_ARG(_STAT_VER, dir_fd, path, st, flags);
++    }
++  #endif
++
++  #ifdef STAT64_SUPPORT
++    int lstat64(const char *file_name, struct stat64 *st) {
++       return WRAP_LSTAT64 LSTAT64_ARG(_STAT_VER, file_name, st);
++    }
++    int stat64(const char *file_name, struct stat64 *st) {
++       return WRAP_STAT64 STAT64_ARG(_STAT_VER, file_name, st);
++    }
++    int fstat64(int fd, struct stat64 *st) {
++       return WRAP_FSTAT64 FSTAT64_ARG(_STAT_VER, fd, st);
++    }
++
++    #ifdef HAVE_FSTATAT
++      int fstatat64(int dir_fd, const char *path, struct stat64 *st, int flags) {
++	 return WRAP_FSTATAT64 FSTATAT64_ARG(_STAT_VER, dir_fd, path, st, flags);
++      }
++    #endif
++  #endif
++
++  int mknod(const char *pathname, mode_t mode, dev_t dev) {
++     return WRAP_MKNOD MKNOD_ARG(_STAT_VER, pathname, mode, &dev);
++  }
++
++  #if defined(HAVE_FSTATAT) && defined(HAVE_MKNODAT)
++    int mknodat(int dir_fd, const char *pathname, mode_t mode, dev_t dev) {
++       return WRAP_MKNODAT MKNODAT_ARG(_STAT_VER, dir_fd, pathname, mode, &dev);
++    }
++  #endif
++#endif /* GLIBC_PREREQ */
++
++
+ #ifdef FAKEROOT_FAKENET
+ pid_t fork(void)
+ {
+-- 
+GitLab
+
+
+From d074aaa34d6928989308a3870738d6b1c28f2bae Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Thu, 11 Feb 2021 21:00:20 -0800
+Subject: [PATCH 3/6] libfakeroot.c: fix compile error with DEBUG enabled
+
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+---
+ libfakeroot.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libfakeroot.c b/libfakeroot.c
+index d75c51f..31480f8 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -2525,7 +2525,7 @@ int statx (int dirfd, const char *path, int flags, unsigned int mask, struct sta
+ 
+ #ifdef LIBFAKEROOT_DEBUGGING
+   if (fakeroot_debug) {
+-    fprintf(stderr, "statx fd %d\n", fd);
++    fprintf(stderr, "statx fd %d\n", dirfd);
+   }
+ #endif /* LIBFAKEROOT_DEBUGGING */
+   r=INT_NEXT_FSTATAT(dirfd, path, &st, flags);
+-- 
+GitLab
+
+
+From c3eebec293e35b997bb46c22fb5a4e114afb5e7f Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Sat, 13 Feb 2021 19:32:08 -0800
+Subject: [PATCH 4/6] configure.ac: fix __xmknod{,at} pointer argument
+
+Switch default to assume * and not the absence of *.
+
+On glibc 2.33+, there is no definition for these functions in header
+files, so the compile test doesn't work. But, we can default to using
+the pointer (as is the case with newer glibc), and use the header file
+on older platforms to fail the test and use no pointer.
+
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+---
+ configure.ac | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 73415d2..d85566f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -183,13 +183,13 @@ AC_MSG_CHECKING([for type of arg of __xmknod])
+   ]], [[
+        int __xmknod  ( int ver,
+                        const char *pathname ,
+-                       mode_t  mode ,  dev_t dev);
++                       mode_t  mode ,  dev_t *dev);
+   ]])],[
+-   AC_DEFINE(XMKNOD_FRTH_ARG,)
+-   AC_MSG_RESULT([no extra *])
+-  ],[
+    AC_DEFINE(XMKNOD_FRTH_ARG,[*])
+    AC_MSG_RESULT([needs *])
++  ],[
++   AC_DEFINE(XMKNOD_FRTH_ARG,)
++   AC_MSG_RESULT([no extra *])
+ 
+   ])
+ 
+@@ -210,13 +210,13 @@ AC_MSG_CHECKING([for type of arg of __xmknodat])
+        int __xmknodat  ( int ver,
+                          int dirfd,
+                          const char *pathname ,
+-                         mode_t  mode ,  dev_t dev);
++                         mode_t  mode ,  dev_t *dev);
+   ]])],[
+-   AC_DEFINE(XMKNODAT_FIFTH_ARG,)
+-   AC_MSG_RESULT([no extra *])
+-  ],[
+    AC_DEFINE(XMKNODAT_FIFTH_ARG,[*])
+    AC_MSG_RESULT([needs *])
++  ],[
++   AC_DEFINE(XMKNODAT_FIFTH_ARG,)
++   AC_MSG_RESULT([no extra *])
+ 
+   ])
+ 
+-- 
+GitLab
+
+
+From 01671986b4ee8eb76dc7f63dfe034a7faf4a4c28 Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Sat, 13 Feb 2021 19:35:31 -0800
+Subject: [PATCH 5/6] libfakeroot.c: fix fts_read and fts_children
+
+Apply Debian patch from [0], since glibc is usually built without LFS.
+__USE_LARGEFILE64 and FTSENT64 should be used anyway for proper support
+of this, if needed. See [1] for more details.
+
+[0]: https://sources.debian.org/patches/fakeroot/1.25.3-1.1/eglibc-fts-without-LFS/
+[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=676428
+
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+---
+ libfakeroot.c | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/libfakeroot.c b/libfakeroot.c
+index 31480f8..169f4da 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -2066,11 +2066,7 @@ FTSENT *fts_read(FTS *ftsp) {
+             || r->fts_info == FTS_NS || r->fts_info == FTS_NSOK))
+     r->fts_statp = NULL;  /* Otherwise fts_statp may be a random pointer */
+   if(r && r->fts_statp) {  /* Should we bother checking fts_info here? */
+-# if defined(STAT64_SUPPORT) && !defined(__APPLE__)
+-    SEND_GET_STAT64(r->fts_statp, _STAT_VER);
+-# else
+     SEND_GET_STAT(r->fts_statp, _STAT_VER);
+-# endif
+   }
+ 
+   return r;
+@@ -2089,11 +2085,7 @@ FTSENT *fts_children(FTS *ftsp, int options) {
+   first=next_fts_children(ftsp, options);
+   for(r = first; r; r = r->fts_link) {
+     if(r && r->fts_statp) {  /* Should we bother checking fts_info here? */
+-# if defined(STAT64_SUPPORT) && !defined(__APPLE__)
+-      SEND_GET_STAT64(r->fts_statp, _STAT_VER);
+-# else
+       SEND_GET_STAT(r->fts_statp, _STAT_VER);
+-# endif
+     }
+   }
+ 
+-- 
+GitLab
+
+
+From f5e0a89ab6f0024f3d3bec5fd9cf631676b44f6c Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Sat, 13 Feb 2021 20:05:17 -0800
+Subject: [PATCH 6/6] OS X portability
+
+OS X portability work from OpenWrt.
+
+Cc: Felix Fietkau <nbd@nbd.name>
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+---
+ configure.ac   |  1 +
+ libfakeroot.c  | 36 ++++++++++++++++++++++++++++++++++--
+ wrapawk_macosx | 10 +++++++---
+ wrapfunc.inp   |  4 ++--
+ 4 files changed, 44 insertions(+), 7 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index d85566f..35f9ecf 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -146,6 +146,7 @@ for first in size_t int; do
+ #include <sys/types.h>
+ #endif
+ #include <unistd.h>
++#include <stdio.h>
+ #ifdef HAVE_GRP_H
+ #include <grp.h>
+ #endif
+diff --git a/libfakeroot.c b/libfakeroot.c
+index 169f4da..7593dd6 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -122,8 +122,16 @@
+ #define INT_SEND_STAT(a,b) SEND_STAT(a,b,_STAT_VER)
+ #define INT_SEND_GET_XATTR(a,b) SEND_GET_XATTR(a,b,_STAT_VER)
+ #define INT_SEND_GET_STAT(a,b) SEND_GET_STAT(a,b)
++
++/* 10.10 uses id_t in getpriority/setpriority calls, so pretend
++   id_t is used everywhere, just happens to be int on some OSes */
++#ifndef _ID_T
++#define _ID_T
++typedef int id_t;
++#endif
+ #endif
+ 
++#include <sys/types.h>
+ #include <stdlib.h>
+ #include <sys/ipc.h>
+ #include <sys/msg.h>
+@@ -135,7 +143,6 @@
+ #include <unistd.h>
+ #include <dirent.h>
+ #include <errno.h>
+-#include <sys/types.h>
+ #ifdef HAVE_SYS_ACL_H
+ #include <sys/acl.h>
+ #endif /* HAVE_SYS_ACL_H */
+@@ -198,6 +205,15 @@ extern int unsetenv (const char *name);
+ #undef __lxstat64
+ #undef _FILE_OFFSET_BITS
+ 
++
++#ifndef AT_EMPTY_PATH
++#define AT_EMPTY_PATH 0
++#endif
++
++#ifndef AT_NO_AUTOMOUNT
++#define AT_NO_AUTOMOUNT 0
++#endif
++
+ /*
+ // next_wrap_st:
+ // this structure is used in next_wrap, which is defined in
+@@ -1969,7 +1985,7 @@ ssize_t fremovexattr(int fd, const char *name)
+ }
+ #endif /* HAVE_FREMOVEXATTR */
+ 
+-int setpriority(int which, int who, int prio){
++int setpriority(int which, id_t who, int prio){
+   if (fakeroot_disabled)
+     return next_setpriority(which, who, prio);
+   next_setpriority(which, who, prio);
+@@ -2570,3 +2586,19 @@ int sysinfo(int command, char *buf, long count)
+     }
+ }
+ #endif
++
++#ifdef HAVE_OPENAT
++int openat(int dir_fd, const char *pathname, int flags, ...)
++{
++	mode_t mode;
++
++    if (flags & O_CREAT) {
++        va_list args;
++        va_start(args, flags);
++        mode = va_arg(args, int);
++        va_end(args);
++    }
++
++    return next_openat(dir_fd, pathname, flags, mode);
++}
++#endif
+diff --git a/wrapawk_macosx b/wrapawk_macosx
+index 088a7f4..f783219 100644
+--- a/wrapawk_macosx
++++ b/wrapawk_macosx
+@@ -46,26 +46,30 @@ BEGIN{
+   argtype=$3;
+   argname=$4;
+   MACRO=$5;
++  argtype_def=$6
++  if(!argtype_def) {
++    argtype_def = argtype
++  }
+   if(MACRO){
+     print "extern " ret " MY_DEF(" name ")" argtype " __attribute__((visibility(\"hidden\")));" > headerfile;
+     print "INTERPOSE(MY_DEF(" name "_RAW)," name "_RAW);"   > structfile;
+     print "#undef " name                      > deffile
+     print "#define " name " MY_DEF(" name "_RAW)" > deffile
+ 
+-    print "extern " ret, name, argtype ";"              > tmpffile;
++    print "extern " ret, name, argtype_def ";"          > tmpffile;
+     print "static __inline__ " ret " NEXT_" MACRO "_NOARG " argtype " __attribute__((always_inline));" > tmpffile;
+     print "static __inline__ " ret " NEXT_" MACRO "_NOARG " argtype " {" > tmpffile;
+     print "  return " name, argname ";"                 > tmpffile;
+     print "}"                                           > tmpffile;
+     print ""                                            > tmpffile;
+   } else {
+-    print "extern " ret " my_" name, argtype " __attribute__((visibility(\"hidden\")));" > headerfile;
++    print "extern " ret " my_" name, argtype_def " __attribute__((visibility(\"hidden\")));" > headerfile;
+     print "#undef " name                                > structfile;
+     print "INTERPOSE(my_" name "," name ");"            > structfile;
+     print "#define " name " my_" name                   > structfile
+     print "#define " name " my_" name                   > deffile
+ 
+-    print "extern " ret, name, argtype ";"              > tmpffile;
++    print "extern " ret, name, argtype_def ";"          > tmpffile;
+     if(argname){
+         print "static __inline__ " ret " next_" name, argtype " __attribute__((always_inline));" > tmpffile;
+         print "static __inline__ " ret " next_" name, argtype " {" > tmpffile;
+diff --git a/wrapfunc.inp b/wrapfunc.inp
+index f7ad186..556af34 100644
+--- a/wrapfunc.inp
++++ b/wrapfunc.inp
+@@ -146,7 +146,7 @@ setfsgid;gid_t;(gid_t fsgid);(fsgid)
+ initgroups;int;(const char *user, INITGROUPS_SECOND_ARG group);(user, group)
+ getgroups;int;(int size, gid_t list[]);(size, list)
+ setgroups;int;(SETGROUPS_SIZE_TYPE size, const gid_t *list);(size, list)
+-setpriority;int;(int which, int who, int prio);(which, who, prio)
++setpriority;int;(int which, id_t who, int prio);(which, who, prio)
+ #ifdef HAVE_CAPSET
+ capset;int;(cap_user_header_t hdrp, const cap_user_data_t datap);(hdrp, datap)
+ #endif /* HAVE_CAPSET */
+@@ -198,7 +198,7 @@ fchownat;int;(int dir_fd, const char *path, uid_t owner, gid_t group, int flags)
+ mkdirat;int;(int dir_fd, const char *pathname, mode_t mode);(dir_fd, pathname, mode)
+ #endif /* HAVE_MKDIRAT */
+ #ifdef HAVE_OPENAT
+-openat;int;(int dir_fd, const char *pathname, int flags);(dir_fd, pathname, flags)
++openat;int;(int dir_fd, const char *pathname, int flags, mode_t mode);(dir_fd, pathname, flags, mode);;(int dir_fd, const char *pathname, int flags, ...)
+ #endif /* HAVE_OPENAT */
+ #ifdef HAVE_RENAMEAT
+ renameat;int;(int olddir_fd, const char *oldpath, int newdir_fd, const char *newpath);(olddir_fd, oldpath, newdir_fd, newpath)
+-- 
+GitLab
+


### PR DESCRIPTION
This is upstream fix for host build issues introduced with glibc 2.33. Issue can be observed on Arch and upcoming Fedora.

Since this package is used only during build process, it should be safe to include in LE10.

More info:
https://bugs.archlinux.org/task/69572
https://bugzilla.redhat.com/show_bug.cgi?id=1901049
https://bugzilla.redhat.com/show_bug.cgi?id=1889862

Fix:
https://salsa.debian.org/clint/fakeroot/-/merge_requests/10