### PR TITLE
ffmpeg: optionally allow minimal ffmpeg binary in image

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -115,6 +115,15 @@ pre_configure_target() {
   rm -rf .${TARGET_NAME}
 }
 
+if [ "${FFMPEG_TESTING}" = "yes" ]; then
+  PKG_FFMPEG_TESTING="--enable-encoder=wrapped_avframe --enable-muxer=null"
+  if [ "${PROJECT}" = "RPi" ]; then
+    PKG_FFMPEG_TESTING+=" --enable-vout-drm --enable-outdev=vout_drm"
+  fi
+else
+  PKG_FFMPEG_TESTING="--disable-programs"
+fi
+
 configure_target() {
   ./configure --prefix="/usr" \
               --cpu="${TARGET_CPU}" \
@@ -146,7 +155,6 @@ configure_target() {
               --pkg-config="${TOOLCHAIN}/bin/pkg-config" \
               --enable-optimizations \
               --disable-extra-warnings \
-              --disable-programs \
               --enable-avdevice \
               --enable-avcodec \
               --enable-avformat \
@@ -218,7 +226,8 @@ configure_target() {
               --enable-asm \
               --disable-altivec \
               ${PKG_FFMPEG_FPU} \
-              --disable-symver
+              --disable-symver \
+              ${PKG_FFMPEG_TESTING}
 }
 
 post_makeinstall_target() {


### PR DESCRIPTION
When testing ffmpeg / hardware decoders it's very convenient
if one can do that with ffmpeg instead of only kodi. Using the
same ffmpeg patches and options as used by kodi also reduces the
risk of testing a different version than what's used by LE/kodi.

As the ffmpeg binary is way too minimal for normal use and only
intended for internal testing this feature is disabled by default
and has to be explicitly requested by building with FFMPEG_TESTING=yes

In addition to ffmpeg and ffprobe binaries this enables the null muxer
and wrapped_avframe encoder so one can test with "-f null".

On RPi it also enables vout_drm (which is only included in jc's
tree / RPi ffmpeg patches) so "-f vout_drm" can be used, too.