### PR TITLE
bootloader: canupdate.sh: clarify substitution

### DIFF
--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -72,7 +72,7 @@ makeinstall_target() {
     # Always install the canupdate script
     if find_file_path bootloader/canupdate.sh; then
       cp -av ${FOUND_PATH} ${INSTALL}/usr/share/bootloader
-      sed -e "s/@PROJECT@/${DEVICE:-${PROJECT}}/g" \
+      sed -e "s/@DEVICE@/${DEVICE:-${PROJECT}}/g" \
           -i ${INSTALL}/usr/share/bootloader/canupdate.sh
     fi
 }

--- a/projects/Rockchip/bootloader/canupdate.sh
+++ b/projects/Rockchip/bootloader/canupdate.sh
@@ -11,7 +11,7 @@ case $(uname -r) in
 esac
 
 # Allow upgrades between arm and aarch64
-if [ "$1" = "@PROJECT@.arm" -o "$1" = "@PROJECT@.aarch64" ]; then
+if [ "$1" = "@DEVICE@.arm" -o "$1" = "@DEVICE@.aarch64" ]; then
   exit 0
 else
   exit 1


### PR DESCRIPTION
When looking at `@PROJECT@.arm ` in  bootloader/canupdate.sh, one would think, that this will be substitued to `${PROJECT}.arm` in the first place.
This in not the case, since `${PROJECT} `will only be taken for that substitution, if no `${DEVICE}` exists - so this will result in `RK3399.arm` instead of `Rockchip.arm` (for example)
This PRs clarifies that and replaces `@PROJECT@` with `@DEVICE@ ` - the outcame will be the same.

The only project that uses this currently is Rockchip.