### PR TITLE
dav1d: update to 0.8.2

### DIFF
--- a/packages/multimedia/dav1d/package.mk
+++ b/packages/multimedia/dav1d/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dav1d"
-PKG_VERSION="0.8.1"
-PKG_SHA256="842da2945afcf54e651d17112bf2823a238e6c935a6c8dff3a8e96a2eb740269"
+PKG_VERSION="0.8.2"
+PKG_SHA256="78ec7a1714d98a8f4ecbc4255e83e6c4c944cdd881871ea234ce40153fd3df04"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.jbkempf.com/blog/post/2018/Introducing-dav1d"
 PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/dav1d-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
update 0.8.1 to 0.8.2
release notes: https://code.videolan.org/videolan/dav1d/-/releases

### dav1d 0.8.2 'Eurasian hobby' the fast and lean AV1 decoder
This is a middle-size update of the dav1d decoder, from the 0.8.x branch.

This release adds most of the remaining NEON optimizations for ARM,
especially for 10/12bit bitdepth, in both ARM32 and ARM64.

This release also split the post-filters into their own threads.

This release speeds up quite a bit the desktop version, notably in the
coefficient decoding and the MSAC parts. It also introduces the first
10bit optimizations for x86.

Finally, this release improves the speed in numerous parts of the
decoder, improves the player shipped and brings other fixes.