### PR TITLE
Python3: update to 3.8.8

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.8.7"
-PKG_SHA256="ddcc1df16bb5b87aa42ec5d20a5b902f2d088caa269b28e01590f97a798ec50a"
+PKG_VERSION="3.8.8"
+PKG_SHA256="7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.python.org/"
 PKG_URL="http://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
**release schedule:** https://www.python.org/dev/peps/pep-0569/

This is the second last of the scheduled Python 3.8.y series.

The ninth and final 3.8 bugfix update will be released in May 2021. After that, it is expected that security updates (source only) will be released until 5 years after the release of 3.8 final, so until approximately October 2024. 

update 3.8.7 (2020-12-21) to 3.8.8 (2021-02-19)
release: https://www.python.org/downloads/release/python-388/
diff: https://github.com/python/cpython/compare/v3.8.7...v3.8.8

### 3.8.8 introduces two security fixes (also present in 3.8.8 RC1) and is recommended to all users:
- bpo-42938: Avoid static buffers when computing the repr of ctypes.c_double and ctypes.c_longdouble values. This issue was assigned CVE-2021-3177.
- bpo-42967: Fix web cache poisoning vulnerability by defaulting the query args separator to &, and allowing the user to choose a custom separator. This issue was assigned CVE-2021-23336.