### PR TITLE
iwlwifi-firmware: update to 7ffb8b6

### DIFF
--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwlwifi-firmware"
-PKG_VERSION="422508ec618285ef41a6a4baae731cb84b2a53be"
-PKG_SHA256="67f6097c62feb82bd51bd94b8b5607a37bf5cb34ae079649d35e505c2db2b107"
+PKG_VERSION="7ffb8b6cfb7b6dca10029d39d021e72c72763f27"
+PKG_SHA256="6085b206c16257e8c8834ed5ce6524bb38bc9b8dafda0dcc32502e8b1b50b1a4"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/iwlwifi-firmware"
 PKG_URL="https://github.com/LibreELEC/iwlwifi-firmware/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update firmware for 5.10.16 from
- https://github.com/LibreELEC/iwlwifi-firmware/pull/28

https://www.intel.com/content/www/us/en/support/articles/000005511/wireless.html

updated:
- iwlwifi-3168-29.ucode
- iwlwifi-7265D-29.ucode
- iwlwifi-8000C-36.ucode
- iwlwifi-8265-36.ucode
- iwlwifi-9000-pu-b0-jf-b0-46.ucode
- iwlwifi-9260-th-b0-jf-b0-46.ucode

Add firmware for AX210
- iwlwifi-ty-a0-gf-a0-59.ucode

added: (ver 59)
- iwlwifi-Qu-b0-hr-b0-59.ucode (AX201)
- iwlwifi-Qu-b0-jf-b0-59.ucode (AX201)
- iwlwifi-Qu-c0-hr-b0-59.ucode (AX201)
- iwlwifi-Qu-c0-jf-b0-59.ucode (AX201)
- iwlwifi-QuZ-a0-hr-b0-59.ucode (AX201)
- iwlwifi-QuZ-a0-jf-b0-59.ucode (AX201)
- iwlwifi-cc-a0-59.ucode (AX200)

deleted: (ver 53) - replaced by (ver 59) - above
- iwlwifi-Qu-b0-hr-b0-53.ucode (AX201)
- iwlwifi-Qu-b0-jf-b0-53.ucode (AX201)
- iwlwifi-Qu-c0-hr-b0-53.ucode (AX201)
- iwlwifi-Qu-c0-jf-b0-53.ucode (AX201)
- iwlwifi-QuZ-a0-hr-b0-53.ucode (AX201)
- iwlwifi-QuZ-a0-jf-b0-53.ucode (AX201)
- iwlwifi-cc-a0-53.ucode (AX200)