### PR TITLE
iMX8 add u-boot patches

### DIFF
--- a/projects/NXP/devices/iMX8/patches/u-boot/0001-v2-tools-imx8mimage-Restore-the-original-__ALIGN_MASK-macro.patch
+++ b/projects/NXP/devices/iMX8/patches/u-boot/0001-v2-tools-imx8mimage-Restore-the-original-__ALIGN_MASK-macro.patch
@@ -1,0 +1,40 @@
+diff --git a/tools/imx8mimage.c b/tools/imx8mimage.c
+index bc4ee793cb97..9985b95a98ab 100644
+--- a/tools/imx8mimage.c
++++ b/tools/imx8mimage.c
+@@ -32,6 +32,8 @@ static uint32_t rom_version = ROM_V1;
+ 
+ #define HDMI_FW_SIZE		0x17000 /* Use Last 0x1000 for IVT and CSF */
+ #define ALIGN_SIZE		0x1000
++#define ALIGN_IMX(x, a)			__ALIGN_MASK_IMX((x), (__typeof__(x))(a) - 1, a)
++#define __ALIGN_MASK_IMX(x, mask, mask2)	(((x) + (mask)) / (mask2) * (mask2))
+ 
+ static uint32_t get_cfg_value(char *token, char *name,  int linenr)
+ {
+@@ -342,7 +344,7 @@ static int generate_ivt_for_fit(int fd, int fit_offset, uint32_t ep,
+ 
+ 	fit_size = fdt_totalsize(&image_header);
+ 
+-	fit_size = ALIGN(fit_size, ALIGN_SIZE);
++	fit_size = ALIGN_IMX(fit_size, ALIGN_SIZE);
+ 
+ 	ret = lseek(fd, fit_offset + fit_size, SEEK_SET);
+ 	if (ret < 0) {
+@@ -446,7 +448,7 @@ void build_image(int ofd)
+ 		 * Aligned to 104KB = 92KB FW image + 0x8000
+ 		 * (IVT and alignment) + 0x4000 (second IVT + CSF)
+ 		 */
+-		file_off += ALIGN(sbuf.st_size,
++		file_off += ALIGN_IMX(sbuf.st_size,
+ 				  HDMI_FW_SIZE + 0x2000 + 0x1000);
+ 	}
+ 
+@@ -479,7 +481,7 @@ void build_image(int ofd)
+ 	imx_header[IMAGE_IVT_ID].boot_data.start =
+ 		imx_header[IMAGE_IVT_ID].fhdr.self - ivt_offset;
+ 	imx_header[IMAGE_IVT_ID].boot_data.size =
+-		ALIGN(sbuf.st_size + sizeof(imx_header_v3_t) + ivt_offset,
++		ALIGN_IMX(sbuf.st_size + sizeof(imx_header_v3_t) + ivt_offset,
+ 		      sector_size);
+ 
+ 	image_off = header_image_off + sizeof(imx_header_v3_t);

--- a/projects/NXP/devices/iMX8/patches/u-boot/0002-ARM-dts-imx8mq-evk-Remove-u-boot-off-on-delay-us-property.patch
+++ b/projects/NXP/devices/iMX8/patches/u-boot/0002-ARM-dts-imx8mq-evk-Remove-u-boot-off-on-delay-us-property.patch
@@ -1,0 +1,14 @@
+diff --git a/arch/arm/dts/imx8mq-evk-u-boot.dtsi b/arch/arm/dts/imx8mq-evk-u-boot.dtsi
+index 44af66372712..2cfc12b7e0a4 100644
+--- a/arch/arm/dts/imx8mq-evk-u-boot.dtsi
++++ b/arch/arm/dts/imx8mq-evk-u-boot.dtsi
+@@ -1,9 +1,5 @@
+ // SPDX-License-Identifier: (GPL-2.0 OR MIT)
+ 
+-&reg_usdhc2_vmmc {
+-	u-boot,off-on-delay-us = <20000>;
+-};
+-
+ &usdhc1 {
+ 	mmc-hs400-1_8v;
+ };

--- a/projects/NXP/devices/iMX8/patches/u-boot/0003-imx8mq_evk-add-distro-boot-cmd-support.patch
+++ b/projects/NXP/devices/iMX8/patches/u-boot/0003-imx8mq_evk-add-distro-boot-cmd-support.patch
@@ -1,0 +1,121 @@
+From 4b5359b936e44421f9c5841feb39f6db8ae140f6 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 26 Oct 2020 16:33:12 -0700
+Subject: [PATCH 1/4] imx8mq_evk add distro boot cmd support
+
+---
+ configs/imx8mq_evk_defconfig |  1 +
+ include/configs/imx8mq_evk.h | 86 ++++++------------------------------
+ 2 files changed, 15 insertions(+), 72 deletions(-)
+
+diff --git a/configs/imx8mq_evk_defconfig b/configs/imx8mq_evk_defconfig
+index de91a76d41..bbcdb2d252 100644
+--- a/configs/imx8mq_evk_defconfig
++++ b/configs/imx8mq_evk_defconfig
+@@ -60,3 +60,4 @@ CONFIG_DM_REGULATOR_GPIO=y
+ CONFIG_DM_RESET=y
+ CONFIG_MXC_UART=y
+ CONFIG_DM_THERMAL=y
++CONFIG_DISTRO_DEFAULTS=y
+diff --git a/include/configs/imx8mq_evk.h b/include/configs/imx8mq_evk.h
+index 3f9a3bc100..62f670bb2a 100644
+--- a/include/configs/imx8mq_evk.h
++++ b/include/configs/imx8mq_evk.h
+@@ -74,80 +74,22 @@
+ #define IMX_FEC_BASE			0x30BE0000
+ #endif
+ 
+-#define CONFIG_MFG_ENV_SETTINGS \
+-	"mfgtool_args=setenv bootargs console=${console},${baudrate} " \
+-		"rdinit=/linuxrc " \
+-		"g_mass_storage.stall=0 g_mass_storage.removable=1 " \
+-		"g_mass_storage.idVendor=0x066F g_mass_storage.idProduct=0x37FF "\
+-		"g_mass_storage.iSerialNumber=\"\" "\
+-		"clk_ignore_unused "\
+-		"\0" \
+-	"initrd_addr=0x43800000\0" \
+-	"bootcmd_mfg=run mfgtool_args;booti ${loadaddr} ${initrd_addr} ${fdt_addr};\0" \
+-/* Initial environment variables */
++#define BOOT_TARGET_DEVICES(func) \
++        func(MMC, mmc, 1) \
++        func(MMC, mmc, 0) \
++        func(PXE, pxe, na) \
++        func(DHCP, dhcp, na)
++
++#include <config_distro_bootcmd.h>
++
+ #define CONFIG_EXTRA_ENV_SETTINGS		\
+-	CONFIG_MFG_ENV_SETTINGS \
+-	"script=boot.scr\0" \
+-	"image=Image\0" \
+ 	"console=ttymxc0,115200\0" \
+-	"fdt_addr=0x43000000\0"			\
+-	"boot_fdt=try\0" \
+-	"fdt_file=imx8mq-evk.dtb\0" \
+-	"initrd_addr=0x43800000\0"		\
+-	"bootm_size=0x10000000\0" \
+-	"mmcdev="__stringify(CONFIG_SYS_MMC_ENV_DEV)"\0" \
+-	"mmcpart=" __stringify(CONFIG_SYS_MMC_IMG_LOAD_PART) "\0" \
+-	"mmcroot=" CONFIG_MMCROOT " rootwait rw\0" \
+-	"mmcautodetect=yes\0" \
+-	"mmcargs=setenv bootargs console=${console} root=${mmcroot}\0 " \
+-	"loadbootscript=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${script};\0" \
+-	"bootscript=echo Running bootscript from mmc ...; " \
+-		"source\0" \
+-	"loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}\0" \
+-	"loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr} ${fdt_file}\0" \
+-	"mmcboot=echo Booting from mmc ...; " \
+-		"run mmcargs; " \
+-		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
+-			"if run loadfdt; then " \
+-				"booti ${loadaddr} - ${fdt_addr}; " \
+-			"else " \
+-				"echo WARN: Cannot load the DT; " \
+-			"fi; " \
+-		"else " \
+-			"echo wait for boot; " \
+-		"fi;\0" \
+-	"netargs=setenv bootargs console=${console} " \
+-		"root=/dev/nfs " \
+-		"ip=dhcp nfsroot=${serverip}:${nfsroot},v3,tcp\0" \
+-	"netboot=echo Booting from net ...; " \
+-		"run netargs;  " \
+-		"if test ${ip_dyn} = yes; then " \
+-			"setenv get_cmd dhcp; " \
+-		"else " \
+-			"setenv get_cmd tftp; " \
+-		"fi; " \
+-		"${get_cmd} ${loadaddr} ${image}; " \
+-		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
+-			"if ${get_cmd} ${fdt_addr} ${fdt_file}; then " \
+-				"booti ${loadaddr} - ${fdt_addr}; " \
+-			"else " \
+-				"echo WARN: Cannot load the DT; " \
+-			"fi; " \
+-		"else " \
+-			"booti; " \
+-		"fi;\0"
+-
+-#define CONFIG_BOOTCOMMAND \
+-	   "mmc dev ${mmcdev}; if mmc rescan; then " \
+-		   "if run loadbootscript; then " \
+-			   "run bootscript; " \
+-		   "else " \
+-			   "if run loadimage; then " \
+-				   "run mmcboot; " \
+-			   "else run netboot; " \
+-			   "fi; " \
+-		   "fi; " \
+-	   "else booti ${loadaddr} - ${fdt_addr}; fi"
++	"loadaddr=0x40480000\0" \
++	"kernel_addr_r=0x40480000\0" \
++	"fdt_addr_r=0x43000000\0"			\
++	"scriptaddr=0x50480000\0" \
++	"pxefile_addr_r=0x50580000\0" \
++	BOOTENV
+ 
+ /* Link Definitions */
+ #define CONFIG_LOADADDR			0x40480000
+-- 
+2.29.2
+


### PR DESCRIPTION
This adds some u-boot patches:

1) Fix booting from sdcard, this seems to have broke a little while back
https://patchwork.ozlabs.org/project/uboot/patch/20210222161643.315161-1-festevam@gmail.com/
https://patchwork.ozlabs.org/project/uboot/patch/20210222174047.464227-1-festevam@gmail.com/

2) Enable distro defaults to allow booting from an extlinux.conf file

With these patches I'm successfully able to boot LibreELEC on the iMX8mq-evk board