### PR TITLE
config/options: introduce TARGET_SYSTEM

### DIFF
--- a/config/noobs/os.json
+++ b/config/noobs/os.json
@@ -1,5 +1,5 @@
 {
-  "name": "@DISTRONAME@_@PROJECT@",
+  "name": "@DISTRONAME@_@TARGET_SYSTEM@",
   "version": "@LIBREELEC_VERSION@",
   "release_date": "@RELEASE_DATE@",
   "kernel": "@KERNEL_VERSION@",

--- a/config/options
+++ b/config/options
@@ -30,6 +30,9 @@ export PROJECT="${PROJECT:-Generic}"
 export ARCH="${ARCH:-x86_64}"
 TARGET_ARCH="${ARCH}"
 
+# determines TARGET_SYSTEM
+TARGET_SYSTEM="${DEVICE:-${PROJECT}}"
+
 # include arm-mem package on arm
 if [ "${TARGET_ARCH}" = "arm" ]; then
   ARM_MEM_SUPPORT="yes"

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -72,7 +72,7 @@ makeinstall_target() {
     # Always install the canupdate script
     if find_file_path bootloader/canupdate.sh; then
       cp -av ${FOUND_PATH} ${INSTALL}/usr/share/bootloader
-      sed -e "s/@PROJECT@/${DEVICE:-${PROJECT}}/g" \
+      sed -e "s/@TARGET_SYSTEM@/${TARGET_SYSTEM}/g" \
           -i ${INSTALL}/usr/share/bootloader/canupdate.sh
     fi
 }

--- a/projects/Rockchip/bootloader/canupdate.sh
+++ b/projects/Rockchip/bootloader/canupdate.sh
@@ -11,7 +11,7 @@ case $(uname -r) in
 esac
 
 # Allow upgrades between arm and aarch64
-if [ "$1" = "@PROJECT@.arm" -o "$1" = "@PROJECT@.aarch64" ]; then
+if [ "$1" = "@TARGET_SYSTEM@.arm" -o "$1" = "@TARGET_SYSTEM@.aarch64" ]; then
   exit 0
 else
   exit 1

--- a/scripts/get
+++ b/scripts/get
@@ -16,7 +16,7 @@ fi
 lock_source_dir() {
   exec 99<"${SOURCES}/${1}"
   if ! flock --nonblock --exclusive 99; then
-    echo "Project/Device ${DEVICE:-${PROJECT}} waiting, to avoid concurrent processing of ${1}..."
+    echo "Project/Device ${TARGET_SYSTEM} waiting, to avoid concurrent processing of ${1}..."
     flock --exclusive 99
   fi
 }

--- a/scripts/image
+++ b/scripts/image
@@ -93,7 +93,7 @@ if [ -n "${CUSTOM_VERSION}" ]; then
   LIBREELEC_VERSION="${CUSTOM_VERSION}"
 fi
 
-LIBREELEC_ARCH="${DEVICE:-${PROJECT}}.${TARGET_ARCH}"
+LIBREELEC_ARCH="${TARGET_SYSTEM}.${TARGET_ARCH}"
 TARGET_VERSION="${LIBREELEC_ARCH}-${LIBREELEC_VERSION}"
 
 if [ -n "${CUSTOM_IMAGE_NAME}" ]; then
@@ -105,7 +105,7 @@ else
     IMAGE_NAME="${DISTRONAME}-${TARGET_VERSION}"
   fi
 
-  if [ -n "${UBOOT_SYSTEM}" ] && [ "${UBOOT_SYSTEM}" != "${DEVICE:-${PROJECT}}" ]; then
+  if [ -n "${UBOOT_SYSTEM}" ] && [ "${UBOOT_SYSTEM}" != "${TARGET_SYSTEM}" ]; then
     IMAGE_NAME="${IMAGE_NAME}-${UBOOT_SYSTEM}"
   fi
 fi
@@ -353,7 +353,7 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
     RELEASE_DIR="${TARGET_IMG}/${IMAGE_NAME}-${1}"
 
     # eg. LibreELEC_RPi, LibreELEC_RPi2 etc.
-    NOOBS_DISTRO="${DISTRONAME}_${DEVICE:-${PROJECT}}"
+    NOOBS_DISTRO="${DISTRONAME}_${TARGET_SYSTEM}"
 
     # Create release dir
     mkdir -p ${RELEASE_DIR}/${NOOBS_DISTRO}
@@ -383,7 +383,7 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
     fi
 
     sed -e "s%@DISTRONAME@%${DISTRONAME}%g" \
-        -e "s%@PROJECT@%${DEVICE:-${PROJECT}}%g" \
+        -e "s%@TARGET_SYSTEM@%${TARGET_SYSTEM}%g" \
         -e "s%@LIBREELEC_VERSION@%${LIBREELEC_VERSION}%g" \
         -e "s%@RELEASE_DATE@%$(date +%F)%g" \
         -e "s%@KERNEL_VERSION@%$(kernel_version)%g" \
@@ -393,7 +393,7 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
         -i ${RELEASE_DIR}/${NOOBS_DISTRO}/os.json
 
     sed -e "s%@DISTRONAME@%${DISTRONAME}%g" \
-        -e "s%@PROJECT@%${DEVICE:-${PROJECT}}%g" \
+        -e "s%@TARGET_SYSTEM@%${TARGET_SYSTEM}%g" \
         -e "s%@SYSTEM_SIZE@%${SYSTEM_SIZE}%g" \
         -i ${RELEASE_DIR}/${NOOBS_DISTRO}/partitions.json
 

--- a/scripts/install_addon
+++ b/scripts/install_addon
@@ -29,7 +29,7 @@ install_addon_files "${ADDON_DIRECTORY}"
 debug_strip "${ADDON_DIRECTORY}"
 
 # pack_addon()
-ADDON_INSTALL_DIR="${TARGET_IMG}/${ADDONS}/${ADDON_VERSION}/${DEVICE:-${PROJECT}}/${TARGET_ARCH}/${PKG_ADDON_ID}"
+ADDON_INSTALL_DIR="${TARGET_IMG}/${ADDONS}/${ADDON_VERSION}/${TARGET_SYSTEM}/${TARGET_ARCH}/${PKG_ADDON_ID}"
 ADDONVER="$(xmlstarlet sel -t -v "/addon/@version" ${ADDON_BUILD}/${PKG_ADDON_ID}/addon.xml)"
 
 if [ -f ${ADDON_INSTALL_DIR}/${PKG_ADDON_ID}-${ADDONVER}.zip ]; then
@@ -76,7 +76,7 @@ done
 # Jenkins add-on build
 if [ "${ADDON_JENKINS}" = "yes" ]; then
   ADDON_JENKINS_DIR="${TARGET_IMG}/jenkins"
-  ADDON_JENKINS_ADDON_NAME="${ADDON_VERSION}-${DEVICE:-${PROJECT}}-${TARGET_ARCH}-${PKG_ADDON_ID}-${ADDONVER}"
+  ADDON_JENKINS_ADDON_NAME="${ADDON_VERSION}-${TARGET_SYSTEM}-${TARGET_ARCH}-${PKG_ADDON_ID}-${ADDONVER}"
   mkdir -p "${ADDON_JENKINS_DIR}"
   cd ${ADDON_INSTALL_DIR}
   ${TOOLCHAIN}/bin/7za a -l -mx0 -bsp0 -bso0 -tzip ${ADDON_JENKINS_DIR}/${ADDON_JENKINS_ADDON_NAME}.zip ${PKG_ADDON_ID}-${ADDONVER}.zip resources/


### PR DESCRIPTION
This introduces a new buildsystem variable `${TARGET_SYSTEM}` which replaces the `${DEVICE:-${PROJECT}}` expression which is used in several locations across the buildsystem, since it leads to missunderstandings, especially if its used to replace the `@PROJECT@` placeholder (which gets replaced here with `@TARGET_SYSTEM@` as well)
I've build- and runtime tested this with aarch64 and arm builds for RK3328 (also tested with inter-arch updates) and build tested for Generic (which has no `${DEVICE}`)

This should be good to go in LE10, but I'm labeling as LE11, since it is not really necessary. 

@antonlacon thanks for the hint about binary addons when switching the arch with an update in https://github.com/LibreELEC/LibreELEC.tv/pull/5173: they will get automatically disabled if kodi fails to load them - I guess this is OK, since aarch64 builds are relevant only to self-builders anyway.