### PR TITLE
linux (RPi): update to 5.10.17

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="ba6259246c702b04ea56ff1034325e476d460ae8"
-PKG_SHA256="4b7a887674e56f9811abf457a677ec045f3e88fabd048ee31bb32bc68255d152"
+PKG_VERSION="787227279ea72eb4bbf9ab077bd17336fe2158d8"
+PKG_SHA256="50e3e3d99eb1f060e3c0e2a997c53de21efc3a831da2a8e146e3af303a7d3bc6"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="787227279ea72eb4bbf9ab077bd17336fe2158d8"
-PKG_SHA256="50e3e3d99eb1f060e3c0e2a997c53de21efc3a831da2a8e146e3af303a7d3bc6"
+PKG_VERSION="5985247fb75681985547641d66196c77499f26b9"
+PKG_SHA256="bf2807be5ca1589a662a3a4f832f21c27cd0bf803a1b11fa57c1aae1b554396a"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="14e997de54579db1db04d6504be8f700e34461da" # 5.10.16
-    PKG_SHA256="a5cde2becf720ad505bbe361168514fed25f2883a989d62e473adbc23733029b"
+    PKG_VERSION="12fdeddcde1ce67177ae0e13931ff24944015625" # 5.10.17
+    PKG_SHA256="e4dcdb2ee22ffeae85c4f3916d60a5065f7068f852b76a530f5604628d4e60ba"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="787227279ea72eb4bbf9ab077bd17336fe2158d8"
-PKG_SHA256="fc20d51432df4ac3eb1bd7d4b0e42820830512f7471bd48a58b5969a6f80f0b3"
+PKG_VERSION="5985247fb75681985547641d66196c77499f26b9"
+PKG_SHA256="539e7768d9d7fd553dc3e294b8e0f53b9d843a81587ff99b52c2aceb67c37d6f"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="ba6259246c702b04ea56ff1034325e476d460ae8"
-PKG_SHA256="44fc5b364518cf41bdffc02bf159a8685641e2eaac2d220244ae39c19bbde120"
+PKG_VERSION="787227279ea72eb4bbf9ab077bd17336fe2158d8"
+PKG_SHA256="fc20d51432df4ac3eb1bd7d4b0e42820830512f7471bd48a58b5969a6f80f0b3"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="3129546271da09dde04da5c9715db909b8e1e417"
-PKG_SHA256="8ae34dd286d777484e670284883c91831ca8bdd15cc90a069009fdf1016de40b"
+PKG_VERSION="1b937edc4b9523f4d7f902b3e77ac787bcede597"
+PKG_SHA256="3596e56a30a6b53b211db54e6287f6dc90c10edf74cb7783d29492631d09c607"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"


### PR DESCRIPTION
Nothing spectacular in the kernel update, but the firmware update contains a fix for non-working DMA channel 6 https://github.com/raspberrypi/firmware/issues/1541 (which could probably affect all devices that get that channel assigned, not only the audio card mentioned in the issue)