### PR TITLE
RPi: add udev rule to increase alsa buffer size to 1.2MB

### DIFF
--- a/projects/RPi/filesystem/usr/lib/udev/rules.d/80-alsa-preallocsize.rules
+++ b/projects/RPi/filesystem/usr/lib/udev/rules.d/80-alsa-preallocsize.rules
@@ -1,0 +1,3 @@
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="pcmC*", ATTRS{id}=="vc4hdmi*", \
+  ENV{.snd_card}="$id", \
+  RUN+="/bin/sh -c 'echo 1280 > /proc/asound/$env{.snd_card}/pcm0p/sub0/prealloc'"


### PR DESCRIPTION
The default of 512k is too small at 192kHz/8ch, kodi can only get a
86ms buffer instead of the 200ms buffer it usually wants. That results
in occasional buffer underruns when playing media from local storage
which is uncached in kodi's default settings.

Increase the alsa buffer size to 1.2MB so kodi can get the audio buffer
size it likes to have.