### PR TITLE
wireguard-tools: update to 1.0.20210223

### DIFF
--- a/packages/network/wireguard-tools/package.mk
+++ b/packages/network/wireguard-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-tools"
-PKG_VERSION="1.0.20200827"
-PKG_SHA256="ec08772216da73a2f6a925927ce794fe9686ba169bb774e451d34199db19795c"
+PKG_VERSION="1.0.20210223"
+PKG_SHA256="65b1c6a96137296603df2e7576e7e69d955c542b4af7f0389853e53f1b754f17"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-v${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update 1.0.20200827 to 1.0.20210223
log: https://git.zx2c4.com/wireguard-tools/log/
announce: https://www.mail-archive.com/wireguard@lists.zx2c4.com/msg06037.html

--

A new version, v1.0.20210223, of wireguard-tools has been tagged in the git
repository, containing various required userspace utilities, such as the
wg(8) and wg-quick(8) commands and documentation.

== Changes ==

  * wg-quick: android: do not free iterated pointer
  * wg-quick: openbsd: no use for userspace support
  * embeddable-wg-library: sync latest from netlink.h
  * wincompat: recent mingw has inet_ntop/inet_pton
  * wincompat: add resource and manifest and enable lto
  * wincompat: do not elevate by default
  * completion: add help and syncconf completions
  * sticky-sockets: do not use SO_REUSEADDR
  * man: LOG_LEVEL variables changed name
  * ipc: do not use fscanf with trailing \n
  * ipc: read trailing responses after set operation

This release contains commits from: Jason A. Donenfeld.