### PR TITLE
mesa-demos: drop i386 support

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/mesa-demos/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mesa-demos/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="mesa-demos"
 PKG_VERSION="8.4.0"
 PKG_SHA256="01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d"
-PKG_ARCH="i386 x86_64"
+PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="ftp://ftp.freedesktop.org/pub/mesa/demos/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
remove PKG_ARCH=i386

Cleanup.of i386 (following on from https://github.com/LibreELEC/LibreELEC.tv/commit/bebaafb33145dd4260cb95f57308e09196629a3c)