### PR TITLE
bluez: update to bluez-5.56 / set JustWorksRepairing=always

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -56,7 +56,8 @@ post_makeinstall_target() {
     cp src/main.conf ${INSTALL}/etc/bluetooth
     sed -i ${INSTALL}/etc/bluetooth/main.conf \
         -e "s|^#\[Policy\]|\[Policy\]|g" \
-        -e "s|^#AutoEnable.*|AutoEnable=true|g"
+        -e "s|^#AutoEnable.*|AutoEnable=true|g" \
+        -e "s|^#JustWorksRepairing.*|JustWorksRepairing=always|g"
 
   mkdir -p ${INSTALL}/usr/share/services
     cp -P ${PKG_DIR}/default.d/*.conf ${INSTALL}/usr/share/services

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bluez"
-PKG_VERSION="5.55"
-PKG_SHA256="8863717113c4897e2ad3271fc808ea245319e6fd95eed2e934fae8e0894e9b88"
+PKG_VERSION="5.56"
+PKG_SHA256="59c4dba9fc8aae2a6a5f8f12f19bc1b0c2dc27355c7ca3123eed3fe6bd7d0b9d"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Builds fine for Generic, RK3399 & AMLG12B. Tested with 8bitdo controllers @chewitt tested it too with some devices. The new config option needs further testing!

Release notes:
http://www.bluez.org/release-of-bluez-5-56/

@HiassofT
added `JustWorksRepairing=always` to config
```
# Specify the policy to the JUST-WORKS repairing initiated by peer
# Possible values: "never", "confirm", "always"
# Defaults to "never"
#JustWorksRepairing = never
```

***
BlueZ 5.54 adds new policy support for Just-Works repairing. The Bluetooth Just-Works pairing is for when hitting a button on the smartphone/computer and Bluetooth device to initiate pairing without entering of keys. The policy support is around Just-Works repairing for after the fact when there is an incoming JW pairing by the paired device. This policy support offers via the configuration file for BlueZ of never / confirm / always. Never is the default mode for BlueZ 5.54's Just-Work repairing ability.
***
https://www.phoronix.com/scan.php?page=news_item&px=BlueZ-5.54-Released
https://patchwork.kernel.org/project/bluetooth/patch/20200214114350.Bluez.v3.1.I333a90ad3c75882c6f008c94a28ca7d3e8f6c76e@changeid/