### PR TITLE
pastekodi cleanup and improvements

### DIFF
--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -85,10 +85,7 @@ fi
   journalctl -a -o short-precise | cat_data "journalctl -a"
 
   if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then
-    bootloader_version="$(vcgencmd bootloader_version)"
-    if ! echo "${bootloader_version}" | grep -q "Command not registered"; then
-      echo  "${bootloader_version}" | cat_data "Bootloader version"
-    fi
+    vcgencmd bootloader_version | cat_data "Bootloader version"
   fi
 
   cat_file "/flash/config.txt" # RPi

--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -82,7 +82,7 @@ fi
 
   cat_file "${LOG_FILE}"
 
-  journalctl -a | cat_data "journalctl -a"
+  journalctl -a -o short-precise | cat_data "journalctl -a"
 
   if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then
     bootloader_version="$(vcgencmd bootloader_version)"

--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -14,6 +14,18 @@ cat_file() {
   fi
 }
 
+ls_dir() {
+  if [ -d "${1}" ]; then
+    ls -lA "${1}" | cat_data "${1}"
+  fi
+}
+
+ls_dir_recursive() {
+  if [ -d "${1}" ]; then
+    ls -lAR "${1}" | cat_data "${1}"
+  fi
+}
+
 usage() {
   [ -n "${1}" ] && echo "Unknown argument: ${1}"
   cat <<EOF
@@ -92,6 +104,10 @@ fi
   cat_file "${KODI_ROOT}/.smb/smb.conf"
   cat_file "${KODI_ROOT}/.smb/user.conf"
   cat_file "/run/samba/smb.conf"
+
+  ls_dir /storage/.config
+  ls_dir_recursive /storage/.config/system.d
+  ls_dir /storage/.config/udev.rules.d
 
   pem_sys="$(sha256sum /etc/ssl/cacert.pem.system | cut -d' ' -f1)"
   pem_run="$(sha256sum /run/libreelec/cacert.pem | cut -d' ' -f1)"

--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -65,6 +65,7 @@ fi
   fi
   if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then
     echo "RPi Hardware Revision: $(vcgencmd otp_dump | grep 30: | cut -d: -f2)"
+    echo "RPi $(vcgencmd get_throttled)"
   fi
 
   cat_file "${LOG_FILE}"


### PR DESCRIPTION
@mglae  recently pointed out on the forum that pastekodi is a bit broken on LE9.2/RPi0-3 https://forum.libreelec.tv/thread/23566-pastekodi-unknown-command-and-no-log-on-first-attempt/?postID=151282#post151282 which reminded me I wanted to extend pastekodi a bit for quite some time :)

No huge changes, only a few minor things which are really helpful for debugging user issues though:

- On RPi include the get_throttled output - insufficient power supplies and cooling are still quite common and cause all sorts of weird issues. A quick glance at the log if throttled is 0x0 is great to tick that off the list
- Users often have old config file leftovers on their systems they've long forgotten about - listing the contents of .config, .config/system.d and .config/udev.rules.d should flag up the most important culprits
- Having the journal timestamps in higher precision than seconds makes it easier to analyze timing issues and cross-reference the timestamps with kodi log - quite a lot can happen within one second on nowadays computers :)

Tested on RPi4: http://ix.io/2Rpa and RPi3B: http://ix.io/2Rpb