### PR TITLE
buildsystem: fix building meson:init

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -321,7 +321,7 @@ setup_toolchain() {
   export MAKEFLAGS
 
   case "$1:$2" in
-    target:meson)
+    target:meson|init:meson)
       export DESTIMAGE="target"
       export AWK="gawk"
       export CC="$TOOLCHAIN/bin/host-gcc"


### PR DESCRIPTION
This fixes building packages into init with the meson buildsystem.
The issue is that `setup_toolchain` exports `$CC` and not `$TARGET_CC`, which in turn leads us create a meson.conf file where the compiler is emptystring.
To make the code clear I decided against reusing `create_meson_conf_host` which actually might look exactly the same now, but I want to make sure it's obvious that the init configuration is generated.

Also I just fixed CC, CXX, AR, STRIP and I'm not sure if other variables need changes as well.
I might be able to judge it once I can actually run my WIP branch and verify the init packages work.