### PR TITLE
kodi: waitonnetwork service shouldn't be considered failed if it timed out

### DIFF
--- a/packages/mediacenter/kodi/system.d/kodi-waitonnetwork.service
+++ b/packages/mediacenter/kodi/system.d/kodi-waitonnetwork.service
@@ -14,6 +14,7 @@ EnvironmentFile=/storage/.cache/libreelec/network_wait
 ExecStart=/usr/bin/wait-time-sync --timeout ${WAIT_NETWORK_TIME}
 StandardOutput=tty
 RemainAfterExit=yes
+SuccessExitStatus=1
 
 [Install]
 WantedBy=network-online.target


### PR DESCRIPTION
if the kodi-waitonnetwork service timed out we shouldn't consider it failed.