### PR TITLE
openssh: update to 8.5p1

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="8.4p1"
-PKG_SHA256="5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24"
+PKG_VERSION="8.5p1"
+PKG_SHA256="f52f3f41d429aa9918e38cf200af225ccdd8e66f052da572870c89737646ec25"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/openssh/patches/openssh-silence-missing-identity-error.patch
+++ b/packages/network/openssh/patches/openssh-silence-missing-identity-error.patch
@@ -2,12 +2,13 @@ diff --git a/sshconnect2.c b/sshconnect2.c
 index d6af0b9..22c0aa6 100644
 --- a/sshconnect2.c
 +++ b/sshconnect2.c
-@@ -1320,8 +1320,7 @@ load_identity_file(char *filename, int userprovided)
+@@ -1524,9 +1524,7 @@
  	struct stat st;
  
  	if (stat(id->filename, &st) == -1) {
--		(id->userprovided ? logit : debug3)("no such identity: %s: %s",
--		    id->filename, strerror(errno));
+-		do_log2(id->userprovided ?
+-		    SYSLOG_LEVEL_INFO : SYSLOG_LEVEL_DEBUG3,
+-		    "no such identity: %s: %s", id->filename, strerror(errno));
 +		debug3("no such identity: %s", id->filename);
  		return NULL;
  	}


### PR DESCRIPTION
update 8.4p1 (2020-09-27) to 8.5p1 (2021-03-03)
release notes: http://www.openssh.com/txt/release-8.5

update patches - reverting openssh-portable patch:
- https://github.com/openssh/openssh-portable/commit/acadbb3402b70f72f14d9a6930ad41be97c2f9dc

```
=== tested on ===
Generic.x86_64-devel-20210304120039-2afdd84
Linux LibreELEC 5.10.20 #1 SMP Thu Mar 4 12:01:01 UTC 2021 x86_64 GNU/Linux
Starting Kodi (19.0 (19.0.0) Git:19.0-Matrix). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2021-02-28 by GCC 10.2.0 for Linux x86 64-bit version 5.10.19 (330259)
Running on LibreELEC (heitbaum): devel-20210304120039-2afdd84 10.0, kernel: Linux x86 64-bit version 5.10.20
FFmpeg version/source: 4.3.1-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0037.2021.0106.1527 01/06/2021
CRenderSystemGL::InitRenderSystem - Version: 4.6 (Core Profile) Mesa 21.1.0-devel, Major: 4, Minor: 6
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = 4.6 (Core Profile) Mesa 21.1.0-devel

LibreELEC:~ # ssh -V
OpenSSH_8.5p1, OpenSSL 1.1.1j  16 Feb 2021
LibreELEC:~ #
```