### PR TITLE
pulseaudio: module-rescue-stream is deprecated - remove it 

### DIFF
--- a/packages/audio/pulseaudio/config/system.pa
+++ b/packages/audio/pulseaudio/config/system.pa
@@ -34,10 +34,6 @@ load-module module-device-restore
 ### that look up the default sink/source get the right value
 load-module module-default-device-restore
 
-### Automatically move streams to the default sink if the sink they are
-### connected to dies, similar for sources
-load-module module-rescue-streams
-
 ### Make sure we always have a sink around, even if it is a null sink.
 load-module module-always-sink
 


### PR DESCRIPTION
...from system.pa config to get rid of journalctl warning:


>Mar 04 18:26:04 phoenix pulseaudio[482]: E: [pulseaudio] module-rescue-streams.c: module-rescue-stream is obsolete and should no longer be loaded. Please remove it from your configuration.

https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/14.0/#module-rescue-streamsisdeprecatedfunctionalitymovedtothecore