### PR TITLE
Pillow: update to 8.1.2

### DIFF
--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="8.1.0"
-PKG_SHA256="b670476feb912d1f07b8f42815ebef13a039cccfd549b2dac84d2a1599f68af8"
+PKG_VERSION="8.1.2"
+PKG_SHA256="4b99c0a07e8bc4048b4f37ee515d02cc2f895453afe534e4b00bfe2f2a2dbe39"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update 8.1.0 (2021-01-02) to 8.1.2 (2021-03-06)
Release notes at: https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst

- Use more specific regex chars to prevent ReDoS. CVE-2021-25292 [hugovk]
- Fix OOB Read in TiffDecode.c, and check the tile validity before reading. CVE-2021-25291 [wiredfool]
- Fix negative size read in TiffDecode.c. CVE-2021-25290 [wiredfool]
- Fix OOB read in SgiRleDecode.c. CVE-2021-25293 [wiredfool]
- Incorrect error code checking in TiffDecode.c. CVE-2021-25289 [wiredfool]
- PyModule_AddObject fix for Python 3.10 #5194 [radarhere]

- Fix Memory DOS in BLP (CVE-2021-27921), ICNS (CVE-2021-27922) and ICO (CVE-2021-27923) Image Plugins [wiredfool]