### PR TITLE
Addons: update xbmc.translatePath (deprecated) to xbmcvfs.translatePath

### DIFF
--- a/packages/addons/driver/hdhomerun/source/resources/actions.py
+++ b/packages/addons/driver/hdhomerun/source/resources/actions.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 import os
 import sys
 import xbmcaddon
+import xbmcvfs
 
 __settings__      = xbmcaddon.Addon(id = 'driver.dvb.hdhomerun')
 __cwd__           = __settings__.getAddonInfo('path')
-__resources_lib__ = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib'))
-__settings_xml__  = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'settings.xml'))
+__resources_lib__ = xbmcvfs.translatePath(os.path.join(__cwd__, 'resources', 'lib'))
+__settings_xml__  = xbmcvfs.translatePath(os.path.join(__cwd__, 'resources', 'settings.xml'))
 
 if len(sys.argv) == 2 and sys.argv[1] == 'refresh_tuners':
   sys.path.append(__resources_lib__)

--- a/packages/addons/driver/imon-mce/source/default.py
+++ b/packages/addons/driver/imon-mce/source/default.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 import os
 import sys
 import xbmcaddon
+import xbmcvfs
 
 __scriptname__ = "IMON MCE Remote driver"
 __author__ = "LibreELEC"
 __url__ = "https://libreelec.tv"
 __settings__   = xbmcaddon.Addon(id='driver.remote.imon-mce')
 __cwd__        = __settings__.getAddonInfo('path')
-__path__       = xbmc.translatePath( os.path.join( __cwd__, 'bin', "imon-mce.service") )
+__path__       = xbmcvfs.translatePath( os.path.join( __cwd__, 'bin', "imon-mce.service") )
 
 os.system(__path__)

--- a/packages/addons/driver/sundtek-mediatv/source/resources/actions.py
+++ b/packages/addons/driver/sundtek-mediatv/source/resources/actions.py
@@ -1,19 +1,21 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 import os
 import sys
 import subprocess
 import xbmcaddon
+import xbmcvfs
 
 __settings__      = xbmcaddon.Addon(id = 'driver.dvb.sundtek-mediatv')
 __cwd__           = __settings__.getAddonInfo('path')
-__resources_lib__ = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib'))
-__settings_xml__  = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'settings.xml'))
+__resources_lib__ = xbmcvfs.translatePath(os.path.join(__cwd__, 'resources', 'lib'))
+__settings_xml__  = xbmcvfs.translatePath(os.path.join(__cwd__, 'resources', 'settings.xml'))
 
-__mediaclient__   = xbmc.translatePath(os.path.join(__cwd__, 'bin', 'mediaclient'))
+__mediaclient__   = xbmcvfs.translatePath(os.path.join(__cwd__, 'bin', 'mediaclient'))
 __mediaclient_e__ = __mediaclient__ + ' -e'
-__update_sh__     = xbmc.translatePath(os.path.join(__cwd__, 'bin', 'sundtek-update-driver.sh'))
+__update_sh__     = xbmcvfs.translatePath(os.path.join(__cwd__, 'bin', 'sundtek-update-driver.sh'))
 
 if len(sys.argv) == 2:
   if sys.argv[1] == 'refresh_tuners':

--- a/packages/addons/service/librespot/source/resources/lib/ls_addon.py
+++ b/packages/addons/service/librespot/source/resources/lib/ls_addon.py
@@ -1,6 +1,7 @@
 import os
 import socket
 import xbmc
+import xbmcvfs
 import xbmcaddon
 import xbmcgui
 
@@ -18,7 +19,7 @@ DEFAULTS = dict(
 )
 
 ADDON = xbmcaddon.Addon()
-ADDON_HOME = xbmc.translatePath(ADDON.getAddonInfo('profile'))
+ADDON_HOME = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
 ADDON_ICON = ADDON.getAddonInfo('icon')
 ADDON_NAME = ADDON.getAddonInfo('name')
 ADDON_PATH = ADDON.getAddonInfo('path')

--- a/packages/addons/service/net-snmp/source/default.py
+++ b/packages/addons/service/net-snmp/source/default.py
@@ -17,12 +17,12 @@ class MyMonitor(xbmc.Monitor):
             
 # addon
 __addon__ = xbmcaddon.Addon(id='service.net-snmp')
-__addonpath__ = xbmc.translatePath(__addon__.getAddonInfo('path'))
-__addonhome__ = xbmc.translatePath(__addon__.getAddonInfo('profile'))
-if not xbmcvfs.exists(xbmc.translatePath(__addonhome__ + 'share/snmp/')):
-    xbmcvfs.mkdirs(xbmc.translatePath(__addonhome__ + 'share/snmp/'))
-config = xbmc.translatePath(__addonhome__ + 'share/snmp/snmpd.conf')
-persistent = xbmc.translatePath(__addonhome__ + 'snmpd.conf')
+__addonpath__ = xbmcvfs.translatePath(__addon__.getAddonInfo('path'))
+__addonhome__ = xbmcvfs.translatePath(__addon__.getAddonInfo('profile'))
+if not xbmcvfs.exists(xbmcvfs.translatePath(__addonhome__ + 'share/snmp/')):
+    xbmcvfs.mkdirs(xbmcvfs.translatePath(__addonhome__ + 'share/snmp/'))
+config = xbmcvfs.translatePath(__addonhome__ + 'share/snmp/snmpd.conf')
+persistent = xbmcvfs.translatePath(__addonhome__ + 'snmpd.conf')
 
 
 def writeconfig():


### PR DESCRIPTION
Update addon code to conform to the the migration away from xbmc.translatePath to xbmcvfs.translatePath.

- net-snmp: update xbmc.translatePath (deprecated) to xbmcvfs.translatePath
- sundtek-mediatv: update xbmc.translatePath (deprecated) to xbmcvfs.translatePath
- hdhomerun: update xbmc.translatePath (deprecated) to xbmcvfs.translatePath
- imon-mce: update xbmc.translatePath (deprecated) to xbmcvfs.translatePath
- librespot: update xbmc.translatePath (deprecated) to xbmcvfs.translatePath