### PR TITLE
Allwinner: H6: Fix emmc in U-Boot for Tanix TX6

### DIFF
--- a/projects/Allwinner/devices/H6/patches/u-boot/0008-arm64-dts-allwinner-h6-tanix-tx6-enable-emmc.patch
+++ b/projects/Allwinner/devices/H6/patches/u-boot/0008-arm64-dts-allwinner-h6-tanix-tx6-enable-emmc.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Wed, 15 Jan 2020 18:39:17 +0100
+Subject: [PATCH] arm64: dts: allwinner: h6: tanix-tx6: enable emmc
+
+Tanix TX6 has 32 GiB eMMC. Add a node for it.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ .../dts/allwinner/sun50i-h6-tanix-tx6.dts     | 20 +++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+--- a/arch/arm/dts/sun50i-h6-tanix-tx6.dts
++++ b/arch/arm/dts/sun50i-h6-tanix-tx6.dts
+@@ -32,6 +32,13 @@
+ 		};
+ 	};
+ 
++	reg_vcc1v8: vcc1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc1v8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++	};
++
+ 	reg_vcc3v3: vcc3v3 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc3v3";
+@@ -91,6 +98,15 @@
+ 	status = "okay";
+ };
+ 
++&mmc2 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc1v8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	bus-width = <8>;
++	status = "okay";
++};
++
+ &ohci0 {
+ 	status = "okay";
+ };
+@@ -99,6 +115,10 @@
+ 	status = "okay";
+ };
+ 
++&pio {
++	vcc-pc-supply = <&reg_vcc1v8>;
++};
++
+ &r_ir {
+ 	linux,rc-map-name = "rc-tanix-tx5max";
+ 	status = "okay";


### PR DESCRIPTION
This PR adds DT node for emmc in U-Boot, which is needed to properly load mmc driver in U-Boot. Without it, it's impossible to boot LE from emmc.