### PR TITLE
alsa-lib: remove duplicate user creation (already in systemd)

### DIFF
--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -34,7 +34,3 @@ post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/config
     cp -PR ${PKG_DIR}/config/modprobe.d ${INSTALL}/usr/config
 }
-
-post_install() {
-  add_group audio 63
-}


### PR DESCRIPTION
I'm not sure if this was on purpose or not. It's also pretty harmless as we check if a user was added already, but there is no circumstances where we include alsa-lib without systemd so let's just remove this.

duplicate of:
https://github.com/LibreELEC/LibreELEC.tv/blob/965d74e6e166f6bcb29ca3e76c3ae6b40ce0d0d6/packages/sysutils/systemd/package.mk#L264