### PR TITLE
iMX8: add cputemp and gputemp scripts

### DIFF
--- a/projects/NXP/devices/iMX8/filesystem/usr/bin/cputemp
+++ b/projects/NXP/devices/iMX8/filesystem/usr/bin/cputemp
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
+echo "$(( $TEMP / 1000 )) C"

--- a/projects/NXP/devices/iMX8/filesystem/usr/bin/gputemp
+++ b/projects/NXP/devices/iMX8/filesystem/usr/bin/gputemp
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+TEMP="$(cat /sys/class/thermal/thermal_zone1/temp)"
+echo "$(( $TEMP / 1000 )) C"


### PR DESCRIPTION
Pretty simple, just add the normal cputemp/gputemp scripts.

Note that kodi doesn't actually show gpu temp for arm platforms. I'll PR a fix upstream for that.

ref: https://github.com/xbmc/xbmc/blob/master/xbmc/windows/GUIWindowSystemInfo.cpp#L144-L146