### PR TITLE
i.MX8: add SPI-NOR eMMC driver and install2emmc script

### DIFF
--- a/projects/NXP/devices/iMX8/bootloader/update.sh
+++ b/projects/NXP/devices/iMX8/bootloader/update.sh
@@ -30,9 +30,20 @@ fi
   done
 
 # update bootloader files
-  if [ -f $SYSTEM_ROOT/usr/share/bootloader/flash.bin ]; then
-    echo "*** updating u-boot image on: $BOOT_DISK ..."
-    dd if=$SYSTEM_ROOT/usr/share/bootloader/flash.bin of="$BOOT_DISK" bs=1024 seek=33 conv=fsync &>/dev/null
+  UBOOT="${SYSTEM_ROOT}/usr/share/bootloader/flash.bin"
+  if [ -f "${UBOOT}" ]; then
+    DEVICE="$(basename ${BOOT_DISK})"
+    if grep -q "MMC" /sys/class/block/${DEVICE}/device/type; then
+      echo 0 > /sys/block/${DEVICE}boot0/force_ro
+      echo "*** updating u-boot image on: ${BOOT_DISK}boot0 ..."
+      dd if="${UBOOT}" of="${DEVICE}boot0" bs=1024 seek=33 conv=fsync > /dev/null 2>&1
+      echo 0 > /sys/block/${DEVICE}boot1/force_ro
+      echo "*** updating u-boot image on: ${BOOT_DISK}boot1 ..."
+      dd if="${UBOOT}" of="${DEVICE}boot1" bs=1024 seek=33 conv=fsync > /dev/null 2>&1
+    else
+      echo "*** updating u-boot image on: ${BOOT_DISK} ..."
+      dd if="${UBOOT}" of="$BOOT_DISK" bs=1024 seek=33 conv=fsync &>/dev/null
+    fi
   fi
 
 # mount $BOOT_ROOT r/o

--- a/projects/NXP/devices/iMX8/filesystem/usr/bin/install2emmc
+++ b/projects/NXP/devices/iMX8/filesystem/usr/bin/install2emmc
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+TMP=/tmp/mnt/
+
+SYSTEM_SIZE=512
+UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
+UUID_STORAGE="$(uuidgen)"
+BOOT=$(grep /flash /proc/mounts | awk '{print $1}' | sed 's/p[012]//g')
+DISK=""
+
+UBOOT="/usr/share/bootloader/flash.bin"
+
+if [ ! -f "${UBOOT}" ]; then
+  echo "U-Boot not found. Please update current installation with board specific update or image first."
+  exit 1
+fi
+
+for TYPE in /sys/class/block/mmcblk*/device/type; do
+  if grep -q "MMC" "${TYPE}"; then
+    DISK="/dev/$(echo "${TYPE}" | awk -F/ '{print $5}')"
+    break
+  fi
+done
+
+if [ -z "${DISK}" ]; then
+  echo "Can't find eMMC module!"
+  exit 1
+fi
+
+if [ "${BOOT}" = "${DISK}" ]; then
+  echo "Your device is booted from the eMMC module!"
+  exit 1
+fi
+
+echo ""
+echo -e "\033[36m==============================="
+echo "Installing LibreELEC to eMMC"
+echo -e "===============================\033[37m"
+echo ""
+echo "eMMC found at ${DISK}"
+echo ""
+
+if [ ! -b "${DISK}" ]; then
+  echo "Error: eMMC not found."
+  exit 1
+fi
+
+echo ""
+echo -n "WARNING: ALL DATA ON eMMC WILL BE ERASED! Continue (y/N)?  "
+read -n 1 ANSWER
+
+if [ ! "${ANSWER}" = "y" ]; then
+  echo ""
+  echo "Aborting..."
+  exit 0
+fi
+echo ""
+
+umount ${DISK}* > /dev/null 2>&1
+
+echo "Erasing eMMC ..."
+dd if=/dev/zero of="${DISK}" bs=1M count=1 conv=fsync > /dev/null 2>&1
+
+echo "Creating partitions"
+parted -s "${DISK}" mklabel msdos
+parted -s "${DISK}" -a optimal mkpart primary fat32 0% ${SYSTEM_SIZE}MiB
+parted -s "${DISK}" set 1 boot on
+parted -s "${DISK}" -a optimal mkpart primary ext4 ${SYSTEM_SIZE}MiB 100%
+sync
+
+echo "Creating filesystems"
+dd if=/dev/zero of="${DISK}p1" bs=1M count=1 conv=fsync > /dev/null 2>&1
+mkfs.vfat -n SYSTEM -i ${UUID_SYSTEM//-/} ${DISK}p1 > /dev/null 2>&1
+dd if=/dev/zero of="${DISK}p2" bs=1M count=1 conv=fsync > /dev/null 2>&1
+mkfs.ext4 -L STORAGE -U ${UUID_STORAGE} ${DISK}p2 > /dev/null 2>&1
+sync
+
+echo "Installing bootloader"
+echo 0 > /sys/block/mmcblk0boot0/force_ro
+echo 0 > /sys/block/mmcblk0boot1/force_ro
+dd if=/dev/zero of="${DISK}boot0" bs=1M count=4 conv=fsync > /dev/null 2>&1
+dd if=/dev/zero of="${DISK}boot1" bs=1M count=4 conv=fsync > /dev/null 2>&1
+dd if="${UBOOT}" of="${DISK}boot0" bs=1024 seek=33 conv=fsync > /dev/null 2>&1
+dd if="${UBOOT}" of="${DISK}boot1" bs=1024 seek=33 conv=fsync > /dev/null 2>&1
+
+echo "Copying system files"
+
+mkdir -p ${TMP}
+
+mount -t vfat ${DISK}p1 ${TMP}
+
+cp -R /flash/. ${TMP}/
+sync
+
+echo "Adjusting partition UUIDs"
+
+sed -i "s/boot=UUID=[0-9a-f\-]*/boot=UUID=${UUID_SYSTEM}/g" ${TMP}/extlinux/extlinux.conf
+sed -i "s/disk=UUID=[0-9a-f\-]*/disk=UUID=${UUID_STORAGE}/g" ${TMP}/extlinux/extlinux.conf
+
+umount ${TMP}
+
+echo "Done"

--- a/projects/NXP/devices/iMX8/linux/linux.aarch64.conf
+++ b/projects/NXP/devices/iMX8/linux/linux.aarch64.conf
@@ -1435,7 +1435,98 @@ CONFIG_GENERIC_ARCH_TOPOLOGY=y
 
 # CONFIG_CONNECTOR is not set
 # CONFIG_GNSS is not set
-# CONFIG_MTD is not set
+CONFIG_MTD=y
+# CONFIG_MTD_TESTS is not set
+
+#
+# Partition parsers
+#
+# CONFIG_MTD_AR7_PARTS is not set
+# CONFIG_MTD_CMDLINE_PARTS is not set
+CONFIG_MTD_OF_PARTS=y
+# CONFIG_MTD_AFS_PARTS is not set
+# CONFIG_MTD_REDBOOT_PARTS is not set
+# end of Partition parsers
+
+#
+# User Modules And Translation Layers
+#
+CONFIG_MTD_BLKDEVS=y
+CONFIG_MTD_BLOCK=y
+# CONFIG_FTL is not set
+# CONFIG_NFTL is not set
+# CONFIG_INFTL is not set
+# CONFIG_RFD_FTL is not set
+# CONFIG_SSFDC is not set
+# CONFIG_SM_FTL is not set
+# CONFIG_MTD_OOPS is not set
+# CONFIG_MTD_SWAP is not set
+# CONFIG_MTD_PARTITIONED_MASTER is not set
+
+#
+# RAM/ROM/Flash chip drivers
+#
+# CONFIG_MTD_CFI is not set
+# CONFIG_MTD_JEDECPROBE is not set
+CONFIG_MTD_MAP_BANK_WIDTH_1=y
+CONFIG_MTD_MAP_BANK_WIDTH_2=y
+CONFIG_MTD_MAP_BANK_WIDTH_4=y
+CONFIG_MTD_CFI_I1=y
+CONFIG_MTD_CFI_I2=y
+# CONFIG_MTD_RAM is not set
+# CONFIG_MTD_ROM is not set
+# CONFIG_MTD_ABSENT is not set
+# end of RAM/ROM/Flash chip drivers
+
+#
+# Mapping drivers for chip access
+#
+# CONFIG_MTD_COMPLEX_MAPPINGS is not set
+# CONFIG_MTD_INTEL_VR_NOR is not set
+# CONFIG_MTD_PLATRAM is not set
+# end of Mapping drivers for chip access
+
+#
+# Self-contained MTD device drivers
+#
+# CONFIG_MTD_PMC551 is not set
+# CONFIG_MTD_DATAFLASH is not set
+# CONFIG_MTD_MCHP23K256 is not set
+# CONFIG_MTD_SST25L is not set
+# CONFIG_MTD_SLRAM is not set
+# CONFIG_MTD_PHRAM is not set
+# CONFIG_MTD_MTDRAM is not set
+# CONFIG_MTD_BLOCK2MTD is not set
+
+#
+# Disk-On-Chip Device Drivers
+#
+# CONFIG_MTD_DOCG3 is not set
+# end of Self-contained MTD device drivers
+
+#
+# NAND
+#
+# CONFIG_MTD_ONENAND is not set
+# CONFIG_MTD_RAW_NAND is not set
+# CONFIG_MTD_SPI_NAND is not set
+
+#
+# ECC engine support
+#
+# end of ECC engine support
+# end of NAND
+
+#
+# LPDDR & LPDDR2 PCM memory drivers
+#
+# CONFIG_MTD_LPDDR is not set
+# end of LPDDR & LPDDR2 PCM memory drivers
+
+CONFIG_MTD_SPI_NOR=y
+CONFIG_MTD_SPI_NOR_USE_4K_SECTORS=y
+# CONFIG_MTD_UBI is not set
+# CONFIG_MTD_HYPERBUS is not set
 CONFIG_DTC=y
 CONFIG_OF=y
 # CONFIG_OF_UNITTEST is not set
@@ -4426,6 +4517,7 @@ CONFIG_LEDS_SYSCON=y
 CONFIG_LEDS_TRIGGERS=y
 # CONFIG_LEDS_TRIGGER_TIMER is not set
 # CONFIG_LEDS_TRIGGER_ONESHOT is not set
+# CONFIG_LEDS_TRIGGER_MTD is not set
 CONFIG_LEDS_TRIGGER_HEARTBEAT=y
 # CONFIG_LEDS_TRIGGER_BACKLIGHT is not set
 CONFIG_LEDS_TRIGGER_CPU=y
@@ -5590,6 +5682,7 @@ CONFIG_HFSPLUS_FS=m
 # CONFIG_BEFS_FS is not set
 # CONFIG_BFS_FS is not set
 # CONFIG_EFS_FS is not set
+# CONFIG_JFFS2_FS is not set
 # CONFIG_CRAMFS is not set
 CONFIG_SQUASHFS=y
 # CONFIG_SQUASHFS_FILE_CACHE is not set


### PR DESCRIPTION
This adds support for the SPI-NOR chip on the i.MX8MQ-evk board

ref: https://cateee.net/lkddb/web-lkddb/MTD_SPI_NOR.html

I've added support to the `update.sh` script to be able to update the bootloader if located on the eMMC.

I've also added the `install2emmc` script from Allwinner and made a few changes specific to i.MX8