### PR TITLE
default to using iwd

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -161,7 +161,7 @@
   DEBUG_GROUP_YES="kodi+"
 
 # wireless daemon to use (wpa_supplicant/iwd)
-  WIRELESS_DAEMON="wpa_supplicant"
+  WIRELESS_DAEMON="iwd"
 
 # build and install iSCSI support - iscsistart (yes / no)
   ISCSI_SUPPORT="yes"


### PR DESCRIPTION
I initially added support for IWD 4 years ago. It's time to switch in LE 11. The required kernel options should be propagated to all the platforms now as well.

I've been using it in my personal builds since adding it and it has been wonderful

I would recommend anyone wanting to try it in their own builds use
```
echo WIRELESS_DAEMON=\"iwd\" >> ~/.libreelec/options
```