### PR TITLE
syncthing: update to 1.14.0 (addon 114)

### DIFF
--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,6 @@
+114
+- Update to 1.14.0
+
 113
 - Update to 1.13.1
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.13.1"
-PKG_SHA256="bc5c431f28fb5bd219dcbeb68534e0da2b118a5ea6ed27edd17317aa84e08e5d"
-PKG_REV="113"
+PKG_VERSION="1.14.0"
+PKG_SHA256="55a6fb08a9dbc1a31a6b429a16abb3a76d8c24b491a86a52170ddaadea33f683"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"


### PR DESCRIPTION
update 1.13.1 (2021-02-04) to 1.14.0 (2021-03-03)
release notes: https://github.com/syncthing/syncthing/releases/tag/v1.14.0