### PR TITLE
Generic: disable dvb add-ons

### DIFF
--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -74,7 +74,7 @@
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm_sta"
 
   # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="yes"
+    DRIVER_ADDONS_SUPPORT="no"
 
   # driver addons to install:
   # for a list of additional drivers see packages/linux-driver-addons


### PR DESCRIPTION
Likewise if the path is too long where the LE git is located this error turns up, no proper fix yet so disable for now that jenkins is happy again

`/bin/sh: Argument list too long`

```
  LD [M]  /var/lib/jenkins/LE/build4/workspace/Generic/LibreELEC.tv/build.LibreELEC-Generic.x86_64-10.0-devel/build/crazycat-4a6d5e54cb90363e50f20a91af93aec84eef3205/v4l/dvb-vidtv-demod.o
make[4]: /bin/sh: Die Argumentliste ist zu lang
make[4]: *** [scripts/Makefile.build:414: /var/lib/jenkins/LE/build4/workspace/Generic/LibreELEC.tv/build.LibreELEC-Generic.x86_64-10.0-devel/build/crazycat-4a6d5e54cb90363e50f20a91af93aec84eef3205/v4l/modules.order] Fehler 127
```
