### PR TITLE
avahi: do not delete ssh.service

### DIFF
--- a/packages/network/avahi/package.mk
+++ b/packages/network/avahi/package.mk
@@ -71,8 +71,8 @@ post_makeinstall_target() {
   sed -e "s,<port>22</port>,<port>22</port>\n    <txt-record>path=/storage</txt-record>\n    <txt-record>u=root</txt-record>,g" -i ${INSTALL}/etc/avahi/services/sftp-ssh.service
 
   rm -rf ${INSTALL}/etc/avahi/avahi-dnsconfd.action
-  rm -rf ${INSTALL}/etc/avahi/services/ssh.service
   if [ ! ${SFTP_SERVER} = "yes" ]; then
+    rm -rf ${INSTALL}/etc/avahi/services/ssh.service
     rm -rf ${INSTALL}/etc/avahi/services/sftp-ssh.service
   fi
   rm -rf ${INSTALL}/usr/lib/systemd


### PR DESCRIPTION
Currently there is only `/etc/avahi/services/sftp-ssh.service` which announces `_sftp-ssh._tcp`.
There should also be `/etc/avahi/services/ssh.service` which should announce `_ssh._tcp`.

Discussion:
https://github.com/LibreELEC/LibreELEC.tv/issues/4841

Replaces https://github.com/LibreELEC/LibreELEC.tv/pull/4843