### PR TITLE
gnutls: update to 3.7.1

### DIFF
--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.7.0"
-PKG_SHA256="49e2a22691d252c9f24a9829b293a8f359095bc5a818351f05f1c0a5188a1df8"
+PKG_VERSION="3.7.1"
+PKG_SHA256="3777d7963eca5e06eb315686163b7b3f5045e2baac5e54e038ace9835e5cac6f"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Built and running on RPi3. I don't know with certainty what ffmpeg uses it for to say it's tested too, but streaming addons are working.