### PR TITLE
aixlog: update sha256

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/aixlog/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/aixlog/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="aixlog"
 PKG_VERSION="1.5.0"
-PKG_SHA256="1d9d344448493c1e74e0baa5e76fc175b9e4497012d6d17591ca49c2e511fbe8"
+PKG_SHA256="c32b2b2e7ed2632fab53aba01f731fce1e7b150fe7d08bccdafc250e5cb836a8"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/badaix/aixlog"
 PKG_URL="https://github.com/badaix/aixlog/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
SHA256 has been updated since it was first downloaded.

```
<<< aixlog:target seq 392 <<<
^[[1;36mGET^[[0m      aixlog (archive)
--2021-03-10 17:17:46--  https://github.com/badaix/aixlog/archive/v1.5.0.tar.gz
Resolving github.com (github.com)... 140.82.112.4
Connecting to github.com (github.com)|140.82.112.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/badaix/aixlog/tar.gz/v1.5.0 [following]
--2021-03-10 17:17:46--  https://codeload.github.com/badaix/aixlog/tar.gz/v1.5.0
Resolving codeload.github.com (codeload.github.com)... 140.82.114.10
Connecting to codeload.github.com (codeload.github.com)|140.82.114.10|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/x-gzip]
Saving to: '/home/jenkins/LE/build2/sources/aixlog/aixlog-1.5.0.tar.gz'


          /home/jen     [<=>                 ]       0  --.-KB/s
/home/jenkins/LE/bu     [ <=>                ]  13.75K  --.-KB/s    in 0.02s

2021-03-10 17:17:47 (678 KB/s) - '/home/jenkins/LE/build2/sources/aixlog/aixlog-1.5.0.tar.gz' saved [14080]

    ^[[1;31mWARNING^[[0m      Incorrect checksum calculated on downloaded file: got c32b2b2e7ed2632fab53aba01f731fce1e7b150fe7d08bccdafc250e5cb836a8 wanted 1d9d344448493c1e74e0baa5e76fc175b9e4497012d6d17591ca49c2e511fbe8
```