### PR TITLE
config/arch.x86_64: add SSE3 TARGET_CFLAGS/TARGET_FEATURES

### DIFF
--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -1,17 +1,17 @@
 # determines TARGET_CPU, if not forced by user
   if [ -z "$TARGET_CPU" ]; then
-    TARGET_CPU=core2
+    TARGET_CPU="core2"
   fi
 
 # determine architecture's family
-  TARGET_SUBARCH=x86_64
+  TARGET_SUBARCH="x86_64"
 
   TARGET_GCC_ARCH="${TARGET_SUBARCH/-/}"
-  TARGET_KERNEL_ARCH=x86
+  TARGET_KERNEL_ARCH="x86"
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=$TARGET_CPU -m64 -mmmx -msse -msse2 -mfpmath=sse"
+  TARGET_CFLAGS="-march=$TARGET_CPU -m64 -mmmx -msse -msse2 -msse3 -mfpmath=sse"
   TARGET_LDFLAGS="-march=$TARGET_CPU -m64"
 
 # build with SIMD support ( yes / no )
-  TARGET_FEATURES+=" mmx sse sse2"
+  TARGET_FEATURES+=" mmx sse sse2 sse3"


### PR DESCRIPTION
This flag is supported by all Intel CPUs sold since 2004 / AMD CPUs since 20005

- SSE3 is supported since ‘prescott’: Improved version of Intel Pentium 4 CPU with MMX, SSE, SSE2 and SSE3 instruction set support.

https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
https://wiki.gentoo.org/wiki/GCC_optimization#-msse.2C_-msse2.2C_-msse3.2C_-mmmx.2C_-m3dnow

[SSSE3](https://github.com/SupervisedThinking/LibreELEC-RR/commit/eca3d1c58655562cddf1eafbe9eefb0943724c97) could be also considered but opts-out all AMD CPU before [Bulldozer](https://en.wikipedia.org/wiki/Bulldozer_(microarchitecture)) but the [Nvidia Ion platform](https://en.wikipedia.org/wiki/Nvidia_Ion#Existing_products) also supports SSSE3 if it uses the [Atom 230](https://en.wikichip.org/wiki/intel/atom/230#Features) or later which means if the Ion is ~ the minimum we support then we should make use of all of it's features. We could also just replace `x86_64` by [bonnell](https://en.wikipedia.org/wiki/Bonnell_(microarchitecture)) which means:
>Intel Bonnell CPU with 64-bit extensions, MOVBE, MMX, SSE, SSE2, SSE3 and SSSE3 instruction set support.


FYI & a possibility for LE11 & gcc11+ -> maybe we could move to `silvermont` or `x86-64-v2` which supports e.g. SSE4
https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level/
https://www.phoronix.com/scan.php?page=news_item&px=GCC-11-x86-64-Feature-Levels