### PR TITLE
add old linux configs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ mkpkg-temp
 
 # ignore git repos from update scripts
 tools/mkpkg/*.git
+
+# ignore old linux configs
+projects/**/*.old


### PR DESCRIPTION
This allows git to ignore the .old files created when using `./tools/adjust_kernel_config` (they are actually created by `kbuild`.

before:
```
$ git status
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        projects/Generic/linux/linux.x86_64.conf.old
        projects/NXP/devices/iMX8/linux/linux.aarch64.conf.old
```