### PR TITLE
bluez: add patch "Fix removing all remote SEPs when loading from cache"

### DIFF
--- a/packages/network/bluez/patches/bluez-999.01-fix-removing-all-remote-SEPs-when-loading-from-cache.patch
+++ b/packages/network/bluez/patches/bluez-999.01-fix-removing-all-remote-SEPs-when-loading-from-cache.patch
@@ -1,0 +1,40 @@
+From 28ddec8d6b829e002fa268c07b71e4c564ba9e16 Mon Sep 17 00:00:00 2001
+From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Date: Thu, 11 Mar 2021 07:36:07 -0800
+Subject: [PATCH] avdtp: Fix removing all remote SEPs when loading from cache
+
+If avdtp_discover is called after cache has been loaded it end up
+removing all remote SEPs as they have not been discovered yet.
+
+Fixes: https://github.com/bluez/bluez/issues/102
+---
+ profiles/audio/avdtp.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/profiles/audio/avdtp.c b/profiles/audio/avdtp.c
+index 088ca58b3..1d5871c62 100644
+--- a/profiles/audio/avdtp.c
++++ b/profiles/audio/avdtp.c
+@@ -3381,10 +3381,18 @@ int avdtp_discover(struct avdtp *session, avdtp_discover_cb_t cb,
+ 	session->discover = g_new0(struct discover_callback, 1);
+ 
+ 	if (session->seps) {
+-		session->discover->cb = cb;
+-		session->discover->user_data = user_data;
+-		session->discover->id = g_idle_add(process_discover, session);
+-		return 0;
++		struct avdtp_remote_sep *sep = session->seps->data;
++
++		/* Check that SEP have been discovered as it may be loaded from
++		 * cache.
++		 */
++		if (sep->discovered) {
++			session->discover->cb = cb;
++			session->discover->user_data = user_data;
++			session->discover->id = g_idle_add(process_discover,
++								session);
++			return 0;
++		}
+ 	}
+ 
+ 	err = send_request(session, FALSE, NULL, AVDTP_DISCOVER, NULL, 0);


### PR DESCRIPTION
Some users reported issues with repairing after package bump 5.56 https://github.com/LibreELEC/LibreELEC.tv/commit/24c3d53f8ad0e1411920d707eca38807d5d6a2a5 but I can't proof it since my devices worked fine before & after adding the patch.

Tested with Generic & RK builds + Anker Soundcore & Echo Dot 3. + 8bitdo controllers

Fixes:
- https://github.com/bluez/bluez/issues/102
