### PR TITLE
RPi4: Enable DWC2 driver for USB

### DIFF
--- a/projects/RPi/devices/RPi4/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.arm.conf
@@ -4790,7 +4790,7 @@ CONFIG_USB_UAS=y
 # CONFIG_USB_CDNS3 is not set
 # CONFIG_USB_MUSB_HDRC is not set
 # CONFIG_USB_DWC3 is not set
-# CONFIG_USB_DWC2 is not set
+CONFIG_USB_DWC2=y
 # CONFIG_USB_ISP1760 is not set
 
 #


### PR DESCRIPTION
With CONFIG_USB_DWC2=y and

	dtoverlay=dwc2,dr_mode=host

added to /flash/config.txt the two USB host ports on the Raspberry Pi Compute Module 4 IO Board actually work.

There doesn't seem to be a config.txt filter specific for the Compute module 4, so I didn't add the config.txt snippet to the image.