### PR TITLE
Revert "kodi: service addon wrapper call fix"

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.09-use-a-wrapper-to-setup-service-addons.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.09-use-a-wrapper-to-setup-service-addons.patch
@@ -17,8 +17,8 @@
 +    case LE_ADDON_DISABLED:
 +      contextStr = "disable";
 +      break;
-+    case LE_ADDON_POST_UPDATE:
-+      contextStr = "post-update";
++    case LE_ADDON_POST_INSTALL:
++      contextStr = "post-install";
 +      break;
 +    case LE_ADDON_PRE_UNINSTALL:
 +      contextStr = "pre-uninstall";
@@ -38,13 +38,12 @@
  void OnPreInstall(const AddonPtr& addon)
  {
    //Fallback to the pre-install callback in the addon.
-@@ -409,6 +440,9 @@ void OnPostInstall(const AddonPtr& addon
+@@ -409,6 +440,8 @@ void OnPostInstall(const AddonPtr& addon
      }
      closedir(addonsDir);
    }
 +
-+  if (update)
-+    LEAddonHook(addon, LE_ADDON_POST_UPDATE);
++  LEAddonHook(addon, LE_ADDON_POST_INSTALL);
    // OE
  
    addon->OnPostInstall(update, modal);
@@ -66,7 +65,7 @@
 +typedef enum {
 +  LE_ADDON_ENABLED,
 +  LE_ADDON_DISABLED,
-+  LE_ADDON_POST_UPDATE,
++  LE_ADDON_POST_INSTALL,
 +  LE_ADDON_PRE_UNINSTALL,
 +} LE_ADDON_CONTEXT;
 +

--- a/packages/mediacenter/kodi/scripts/service-addon-wrapper
+++ b/packages/mediacenter/kodi/scripts/service-addon-wrapper
@@ -29,8 +29,8 @@ if [ -f "${SERVICE_FILE}" ] ; then
       systemctl stop "${ADDON_ID}.service"
       systemctl disable "${ADDON_ID}.service"
       ;;
-    post-update)
-      # post-update is triggered on update,
+    post-install)
+      # post-install is triggered on update as well,
       # make sure to stop and re-install service
       systemctl stop "${ADDON_ID}.service"
       systemctl disable "${ADDON_ID}.service"
@@ -77,7 +77,7 @@ if [ -d "${OVERLAY_PATH}" ] ; then
   OVERLAY_CONF="/storage/.cache/kernel-overlays/50-${ADDON_ID}.conf"
 
   case "${CONTEXT}" in
-    enable | post-update )
+    enable | post-install )
       create_overlay_conf
       ;;
     disable | pre-uninstall )


### PR DESCRIPTION
This reverts commit 3fc36563b1ae228e26979751439a6a069e078136.

This fixes service addons not being started after installation.

Tested on RPi4 with lcdd addon: systemd service was started on installation, before update service was stopped and started again after update