### PR TITLE
Remove redundant ARCH specific *FLAGS for x86-64

### DIFF
--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -10,8 +10,8 @@
   TARGET_KERNEL_ARCH=x86
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=$TARGET_CPU -m64 -mmmx -msse -msse2 -mfpmath=sse"
-  TARGET_LDFLAGS="-march=$TARGET_CPU -m64"
+  TARGET_CFLAGS="-march=$TARGET_CPU"
+  TARGET_LDFLAGS="-march=$TARGET_CPU"
 
 # build with SIMD support ( yes / no )
   TARGET_FEATURES+=" mmx sse sse2"


### PR DESCRIPTION
-m64 -mmmx -msse -msse2 -mfpmath=sse are not needed for x86-64 targets and are already enabled by default. Probably leftovers from 32-bit OpenELEC days. 
Build and runtime tested on Gemini Lake.

https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html