### PR TITLE
zstd: update to 1.4.9 / add upstreamed build fix patch

### DIFF
--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.4.8"
-PKG_SHA256="32478297ca1500211008d596276f5367c54198495cf677e9439f4791a4c69f24"
+PKG_VERSION="1.4.9"
+PKG_SHA256="29ac74e19ea28659017361976240c4b5c5c24db3b89338731a6feb97c038d293"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"
 PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/compress/zstd/patches/zstd-999.01-build-fix.patch
+++ b/packages/compress/zstd/patches/zstd-999.01-build-fix.patch
@@ -1,0 +1,22 @@
+From edf2b1176df9302f6023d129e6379ffbe781885c Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Fri, 19 Mar 2021 19:52:45 +0100
+Subject: [PATCH] meson: fix build by adding missing files
+
+fixes https://github.com/facebook/zstd/issues/2519
+---
+ build/meson/lib/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/build/meson/lib/meson.build b/build/meson/lib/meson.build
+index 17806c8dc..004888753 100644
+--- a/build/meson/lib/meson.build
++++ b/build/meson/lib/meson.build
+@@ -22,6 +22,7 @@ libzstd_sources = [join_paths(zstd_rootdir, 'lib/common/entropy_common.c'),
+   join_paths(zstd_rootdir, 'lib/common/threading.c'),
+   join_paths(zstd_rootdir, 'lib/common/pool.c'),
+   join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
++  join_paths(zstd_rootdir, 'lib/common/zstd_trace.c'),
+   join_paths(zstd_rootdir, 'lib/common/error_private.c'),
+   join_paths(zstd_rootdir, 'lib/common/xxhash.c'),
+   join_paths(zstd_rootdir, 'lib/compress/hist.c'),


### PR DESCRIPTION
Tested on Generic, RK, AML, RPi.

Release notes:
https://www.phoronix.com/scan.php?page=news_item&px=Zstd-1.4.9-Released

Patch:
https://github.com/facebook/zstd/pull/2548