### PR TITLE
dvb-firmware: update to 1.4.2

### DIFF
--- a/packages/linux-firmware/dvb-firmware/package.mk
+++ b/packages/linux-firmware/dvb-firmware/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dvb-firmware"
-PKG_VERSION="1.4.1"
-PKG_SHA256="621a322904baeb112aa086e91d34cc71f7f2f14d4cd2dd6d3501f70926a8c43f"
+PKG_VERSION="1.4.2"
+PKG_SHA256="f23b14cf75b45a381c5894b8057c66812a30506a9731f9ff64e9142a8f834cda"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/dvb-firmware"
 PKG_URL="https://github.com/LibreELEC/dvb-firmware/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Fixes reported issue: https://github.com/LibreELEC/dvb-firmware/pull/17
- PCTV 461e v2 DVB-S adapter