### PR TITLE
busybox: add getedid script for RPi

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -123,6 +123,7 @@ makeinstall_host() {
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
     [ ${TARGET_ARCH} = x86_64 ] && cp ${PKG_DIR}/scripts/getedid ${INSTALL}/usr/bin
+    cp ${PKG_DIR}/scripts/create-edid-cpio ${INSTALL}/usr/bin/
     cp ${PKG_DIR}/scripts/createlog ${INSTALL}/usr/bin/
     cp ${PKG_DIR}/scripts/dthelper ${INSTALL}/usr/bin
       ln -sf dthelper ${INSTALL}/usr/bin/dtfile

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -128,6 +128,9 @@ makeinstall_target() {
       cp ${PKG_DIR}/scripts/dump-active-edids-drm ${INSTALL}/usr/bin/dump-active-edids
     fi
     cp ${PKG_DIR}/scripts/create-edid-cpio ${INSTALL}/usr/bin/
+    if [ "${PROJECT}" = "RPi" ]; then
+      cp ${PKG_DIR}/scripts/update-bootloader-edid-rpi ${INSTALL}/usr/bin/update-bootloader-edid
+    fi
     cp ${PKG_DIR}/scripts/createlog ${INSTALL}/usr/bin/
     cp ${PKG_DIR}/scripts/dthelper ${INSTALL}/usr/bin
       ln -sf dthelper ${INSTALL}/usr/bin/dtfile

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -122,7 +122,11 @@ makeinstall_host() {
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
-    [ ${TARGET_ARCH} = x86_64 ] && cp ${PKG_DIR}/scripts/getedid ${INSTALL}/usr/bin
+    if [ ${TARGET_ARCH} = x86_64 ]; then
+      cp ${PKG_DIR}/scripts/getedid ${INSTALL}/usr/bin
+    else
+      cp ${PKG_DIR}/scripts/dump-active-edids-drm ${INSTALL}/usr/bin/dump-active-edids
+    fi
     cp ${PKG_DIR}/scripts/create-edid-cpio ${INSTALL}/usr/bin/
     cp ${PKG_DIR}/scripts/createlog ${INSTALL}/usr/bin/
     cp ${PKG_DIR}/scripts/dthelper ${INSTALL}/usr/bin

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -130,6 +130,7 @@ makeinstall_target() {
     cp ${PKG_DIR}/scripts/create-edid-cpio ${INSTALL}/usr/bin/
     if [ "${PROJECT}" = "RPi" ]; then
       cp ${PKG_DIR}/scripts/update-bootloader-edid-rpi ${INSTALL}/usr/bin/update-bootloader-edid
+      cp ${PKG_DIR}/scripts/getedid-drm ${INSTALL}/usr/bin/getedid
     fi
     cp ${PKG_DIR}/scripts/createlog ${INSTALL}/usr/bin/
     cp ${PKG_DIR}/scripts/dthelper ${INSTALL}/usr/bin

--- a/packages/sysutils/busybox/scripts/create-edid-cpio
+++ b/packages/sysutils/busybox/scripts/create-edid-cpio
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+EDID_DIR="/storage/.config/firmware/edid"
+EDID_CPIO="/flash/edid.cpio"
+TMPDIR="/tmp/edid-cpio"
+
+if [ "$1" = "-q" ]; then
+  VERBOSE=0
+else
+  VERBOSE=1
+fi
+
+if [ ! -d "${EDID_DIR}" ]; then
+  echo "error: ${EDID_DIR} does not exist"
+  exit 1
+fi
+
+set -e
+
+rm -rf "${TMPDIR}"
+mkdir -p "${TMPDIR}/usr/lib/firmware"
+cp -r "${EDID_DIR}" "${TMPDIR}/usr/lib/firmware"
+cd "${TMPDIR}"
+mount -o remount,rw /flash
+find usr -print | cpio -ov -H newc > "${EDID_CPIO}"
+sync
+mount -o remount,ro /flash
+cd /storage
+rm -rf "${TMPDIR}"
+
+if [ "${VERBOSE}" = "1" ]; then
+  echo "successfully created ${EDID_CPIO}"
+fi

--- a/packages/sysutils/busybox/scripts/dump-active-edids-drm
+++ b/packages/sysutils/busybox/scripts/dump-active-edids-drm
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+EDID_DIR="/storage/.config/firmware/edid"
+CONNECTORS=""
+
+if [ "$1" = "-q" ]; then
+  VERBOSE=0
+else
+  VERBOSE=1
+fi
+
+info() {
+  [ "${VERBOSE}" = "1" ] && echo "$@"
+}
+
+mkdir -p "${EDID_DIR}"
+
+for c in /sys/class/drm/card?-* ; do
+  [ ! -d "$c" ] && continue
+  [ ! -e "$c/status" ] && continue
+
+  if [ $(cat $c/status 2>/dev/null) = "connected" ]; then
+    CONNECTOR=$(basename $c | cut -c 7-)
+    EDID_NAME="edid-${CONNECTOR}.bin"
+    cat $c/edid > "${EDID_DIR}/${EDID_NAME}" 2>/dev/null
+    if [ $? -eq 0 ]; then
+      [ -n "${CONNECTORS}" ] && CONNECTORS="${CONNECTORS} "
+      CONNECTORS="${CONNECTORS}${CONNECTOR}"
+    fi
+  fi
+done
+
+if [ -z "${CONNECTORS}" ]; then
+  info "error: no active connectors found"
+  exit 1
+else
+  info "found active connector(s) ${CONNECTORS}"
+  [ "${VERBOSE}" = "0" ] && echo "${CONNECTORS}"
+fi

--- a/packages/sysutils/busybox/scripts/getedid-drm
+++ b/packages/sysutils/busybox/scripts/getedid-drm
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+usage() {
+  echo "$0 create|delete|help"
+}
+
+delete_edid() {
+  update-bootloader-edid delete
+  if [ $? -eq 0 ]; then
+    echo "successfully removed edid override"
+  else
+    echo "error removing bootloader edid-override options"
+    exit 1
+  fi
+}
+
+create_edid() {
+  CONNECTORS=$(dump-active-edids -q)
+  if [ $? -ne 0 -o -z "${CONNECTORS}" ]; then
+    echo "error: cannot detemine active connectors"
+    exit 1
+  fi
+  create-edid-cpio -q
+  if [ $? -ne 0 ]; then
+    echo "error creating edid.cpio"
+    exit 1
+  fi
+  update-bootloader-edid set ${CONNECTORS}
+  if [ $? -eq 0 ]; then
+    echo "successfully installed edid override for ${CONNECTORS}"
+  else
+    echo "error setting bootloader edid-override options"
+    exit 1
+  fi
+}
+
+case $1 in
+  create)
+    shift
+    create_edid "$@"
+    ;;
+  delete)
+    delete_edid
+    ;;
+  help)
+    usage
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/packages/sysutils/busybox/scripts/update-bootloader-edid-rpi
+++ b/packages/sysutils/busybox/scripts/update-bootloader-edid-rpi
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+EDID_DIR="/storage/.config/firmware/edid"
+EDID_CPIO="/flash/edid.cpio"
+CONFIG_TXT="/flash/config.txt"
+CMDLINE_TXT="/flash/cmdline.txt"
+
+usage() {
+  echo "$0 set CONNECTOR... | delete | help"
+}
+
+check_args() {
+  if [ $# -eq 0 ]; then
+    echo "error: no connector(s) specified!"
+    exit 1
+  fi
+  if [ ! -f "${EDID_CPIO}" ]; then
+    echo "error: ${EDID_CPIO} not present"
+    exit 1
+  fi
+  for conn in "$@"; do
+    if [ ! -f "${EDID_DIR}/edid-${conn}.bin" ]; then
+      echo "error: ${EDID_DIR}/edid-${conn}.bin not present"
+      exit 1
+    fi
+  done
+}
+
+cleanup_config_txt() {
+  sed -i "/^initramfs edid\.cpio/d" ${CONFIG_TXT}
+}
+
+get_cleaned_cmdline_txt() {
+  sed \
+    -e 's| drm\.edid_firmware=[^ ]*||g' \
+    -e 's| video=[^ ]*||g' \
+    ${CMDLINE_TXT}
+}
+
+add_initramfs() {
+  # make sure config.txt ends with a newline
+  if [ "$(tail -c 1 ${CONFIG_TXT} | tr -c -d '\n' | tr '\n' 'X')" != "X" ]; then
+    echo "" >> ${CONFIG_TXT}
+  fi
+  echo "initramfs edid.cpio" >> ${CONFIG_TXT}
+}
+
+add_cmdline() {
+  CMDLINE=$(get_cleaned_cmdline_txt)
+  FIRMWARE="" 
+  VIDEO=""
+  for conn in "$@"; do
+    VIDEO="${VIDEO} video=${conn}:D"
+    [ -n "${FIRMWARE}" ] && FIRMWARE="${FIRMWARE},"
+    FIRMWARE="${FIRMWARE}${conn}:edid/edid-${conn}.bin"
+  done
+  echo "${CMDLINE} drm.edid_firmware=${FIRMWARE}${VIDEO}" > ${CMDLINE_TXT}
+}
+
+set_edids() {
+  check_args "$@"
+  mount -o remount,rw /flash
+  cleanup_config_txt
+  add_initramfs
+  add_cmdline "$@"
+  mount -o remount,ro /flash
+}
+
+delete_edids() {
+  mount -o remount,rw /flash
+  cleanup_config_txt
+  CMDLINE=$(get_cleaned_cmdline_txt)
+  echo "${CMDLINE}" > ${CMDLINE_TXT}
+  mount -o remount,ro /flash
+}
+
+case $1 in
+  set)
+    shift
+    set_edids "$@"
+    ;;
+  delete)
+    delete_edids
+    ;;
+  help)
+    usage
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This script simply creates /flash/edid.cpio with the contents from
.config/firmware/edid

Compared to the x86 specific getedid script this works on all platforms
as it doesn't contain any platform specific code. Eventually getedid
should be refactored make use of this helper script, too.