### PR TITLE
busybox: fix createlog udev rule wildcard

### DIFF
--- a/packages/sysutils/busybox/scripts/createlog
+++ b/packages/sysutils/busybox/scripts/createlog
@@ -90,7 +90,7 @@ mkdir -p $BASEDIR/$LOGDIR
       /storage/.config/modules-load.d/*.conf \
       /storage/.config/sleep.d/*.power \
       /storage/.config/sysctl.d/*.conf \
-      /storage/.config/udev.rules.d/.rules \
+      /storage/.config/udev.rules.d/*.rules \
   ; do
     if [ -f "$i" ] ; then
       getlog_cmd cat $i


### PR DESCRIPTION
Seems like this was broken for 6+ years :)
