### PR TITLE
init: stop checking for OPENELEC_ARCH

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -263,7 +263,7 @@ mount_sysroot() {
 get_project_arch() {
   if [ -f ${1}/etc/os-release ]; then
     . ${1}/etc/os-release
-    echo "${OPENELEC_ARCH:-${LIBREELEC_ARCH}}"
+    echo "${LIBREELEC_ARCH}"
   fi
 }
 


### PR DESCRIPTION
This stops LE's update checker from accepting OE images as system updates. The checker may be disabled if someone wants to do this. LE stopped generating OPENELEC_ARCH in its images in May 2019 (#3026).