### PR TITLE
e2fsprogs: update to 1.45.7

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="e2fsprogs"
-PKG_VERSION="1.45.6"
-PKG_SHA256="ffa7ae6954395abdc50d0f8605d8be84736465afc53b8938ef473fcf7ff44256"
+PKG_VERSION="1.45.7"
+PKG_SHA256="62d49c86d9d4becf305093edd65464484dc9ea41c6ff9ae4f536e4a341b171a2"
 PKG_LICENSE="GPL"
 PKG_SITE="http://e2fsprogs.sourceforge.net/"
 PKG_URL="https://www.kernel.org/pub/linux/kernel/people/tytso/${PKG_NAME}/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -14,10 +14,6 @@ PKG_DEPENDS_INIT="toolchain"
 PKG_LONGDESC="The filesystem utilities for the EXT2 filesystem, including e2fsck, mke2fs, dumpe2fs, fsck, and others."
 PKG_BUILD_FLAGS="-parallel"
 
-if [ "${HFSTOOLS}" = "yes" ]; then
-  PKG_DEPENDS_TARGET+=" diskdev_cmds"
-fi
-
 PKG_CONFIGURE_OPTS_HOST="--prefix=${TOOLCHAIN}/ \
                          --bindir=${TOOLCHAIN}/bin \
                          --with-udev-rules-dir=no \

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -20,6 +20,9 @@ PKG_LONGDESC="Root package used to build and create complete image"
 # Automounter support
 [ "${UDEVIL}" = "yes" ] && PKG_DEPENDS_TARGET+=" udevil"
 
+# HFS filesystem tools
+[ "${HFSTOOLS}" = "yes" ] && PKG_DEPENDS_TARGET+=" diskdev_cmds"
+
 # NTFS 3G support
 [ "${NTFS3G}" = "yes" ] && PKG_DEPENDS_TARGET+=" ntfs-3g_ntfsprogs"
 


### PR DESCRIPTION
Updates e2fsprogs to 1.45.7, which is a bugfix release: http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.45.7

1.46.x releases have already started. I don't intend on updating to that at this time.

This also moves diskdev_cmds (HFSTOOLS) out of a depend for e2fsprogs and as one for virtual/image.

Built and run tested on RPi3.