### PR TITLE
openssl: update to 1.1.1k

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="1.1.1j"
-PKG_SHA256="aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf"
+PKG_VERSION="1.1.1k"
+PKG_SHA256="892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.openssl.org"
 PKG_URL="https://www.openssl.org/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Security fix for 2 CVEs: https://www.openssl.org/news/changelog.html#openssl-111