### PR TITLE
nettle: update to 3.7.2

### DIFF
--- a/packages/security/nettle/package.mk
+++ b/packages/security/nettle/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nettle"
-PKG_VERSION="3.7"
-PKG_SHA256="f001f64eb444bf13dd91bceccbc20acbc60c4311d6e2b20878452eb9a9cec75a"
+PKG_VERSION="3.7.2"
+PKG_SHA256="8d2a604ef1cde4cd5fb77e422531ea25ad064679ff0adf956e78b3352e0ef162"
 PKG_LICENSE="GPL2"
 PKG_SITE="http://www.lysator.liu.se/~nisse/nettle"
 PKG_URL="http://ftpmirror.gnu.org/gnu/nettle/nettle-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 3.7 (2021-01-04) to 3.7.2 (2021-03-21)
changelog: https://git.lysator.liu.se/nettle/nettle/-/blob/master/ChangeLog
news: https://git.lysator.liu.se/nettle/nettle/-/blob/master/NEWS

 NEWS for the Nettle 3.7.2 release

	This is a bugfix release, fixing a bug in ECDSA signature
	verification that could lead to a denial of service attack
	(via an assertion failure) or possibly incorrect results. It
	also fixes a few related problems where scalars are required
	to be canonically reduced modulo the ECC group order, but in
	fact may be slightly larger.

	Upgrading to the new version is strongly recommended.

	Even when no assert is triggered in ecdsa_verify, ECC point
	multiplication may get invalid intermediate values as input,
	and produce incorrect results. It's trivial to construct
	alleged signatures that result in invalid intermediate values.
	It appears difficult to construct an alleged signature that
	makes the function misbehave in such a way that an invalid
	signature is accepted as valid, but such attacks can't be
	ruled out without further analysis.

	Thanks to Guido Vranken for setting up the fuzzer tests that
	uncovered this problem.

	The new version is intended to be fully source and binary
	compatible with Nettle-3.6. The shared library names are
	libnettle.so.8.3 and libhogweed.so.6.3, with sonames
	libnettle.so.8 and libhogweed.so.6.

	Bug fixes:

	* Fixed bug in ecdsa_verify, and added a corresponding test
          case.

	* Similar fixes to ecc_gostdsa_verify and gostdsa_vko.

	* Similar fixes to eddsa signatures. The problem is less severe
          for these curves, because (i) the potentially out or range
          value is derived from output of a hash function, making it
          harder for the attacker to to hit the narrow range of
          problematic values, and (ii) the ecc operations are
          inherently more robust, and my current understanding is that
          unless the corresponding assert is hit, the verify
          operation should complete with a correct result.

	* Fix to ecdsa_sign, which with a very low probability could
          return out of range signature values, which would be
          rejected immediately by a verifier.

NEWS for the Nettle 3.7.1 release

	This is primarily a bug fix release, fixing a couple of
	problems found in Nettle-3.7.

	The new version is intended to be fully source and binary
	compatible with Nettle-3.6. The shared library names are
	libnettle.so.8.2 and libhogweed.so.6.2, with sonames
	libnettle.so.8 and libhogweed.so.6.

	Bug fixes:

	* Fix bug in chacha counter update logic. The problem affected
	  ppc64 and ppc64el, with the new altivec assembly code
	  enabled. Reported by Andreas Metzler, after breakage in
	  GnuTLS tests on ppc64.

	* Support for big-endian ARM platforms has been restored.
	  Fixes contributed by Michael Weiser.

	* Fix build problem on OpenBSD/powerpc64, reported by Jasper
	  Lievisse Adriaanse.

	* Fix corner case bug in ECDSA verify, it would produce
	  incorrect result in the unlikely case of an all-zero
	  message hash. Reported by Guido Vranken.

	New features:

	* Support for pbkdf2_hmac_sha384 and pbkdf2_hmac_sha512,
	  contributed by Nicolas Mora.

	Miscellaneous:

	* Poorly performing ARM Neon code for doing single-block
	  Salsa20 and Chacha has been deleted. The code to do two or
	  three blocks in parallel, introduced in Nettle-3.7, is
	  unchanged.
