### PR TITLE
toolchain: enable correct handling of cmake-make in check_toolchain_config

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -214,6 +214,9 @@ check_toolchain_config() {
   if [ "${toolchain}" == "AUTOTOOLS" ]; then
     toolchain="CONFIGURE"
   fi
+  if [ "${toolchain}" == "CMAKE-MAKE" ]; then
+    toolchain="CMAKE"
+  fi
   for var in "${!PKG_@}"; do
     if [[ "${var}" =~ INSTALL_OPTS_ || "${var}" =~ _MAKE_OPTS ]]; then
       continue


### PR DESCRIPTION
Update check_toolchain_config to use CMAKE variables when using CMAKE-MAKE, the same logic as AUTOTOOLS and CONFIGURE