### PR TITLE
Update build system for new meson and fix up glib package

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -482,12 +482,14 @@ cpu_family = '$TARGET_ARCH'
 cpu = '$TARGET_SUBARCH'
 endian = 'little'
 
-[properties]
-root = '$TOOLCHAIN'
+[built-in options]
 $(python3 -c "import os; print('c_args = {}'.format([x for x in os.getenv('CFLAGS').split()]))")
 $(python3 -c "import os; print('c_link_args = {}'.format([x for x in os.getenv('LDFLAGS').split()]))")
 $(python3 -c "import os; print('cpp_args = {}'.format([x for x in os.getenv('CXXFLAGS').split()]))")
 $(python3 -c "import os; print('cpp_link_args = {}'.format([x for x in os.getenv('LDFLAGS').split()]))")
+
+[properties]
+root = '$TOOLCHAIN'
 ${!properties}
 EOF
 }
@@ -512,12 +514,14 @@ cpu_family = '$TARGET_ARCH'
 cpu = '$TARGET_SUBARCH'
 endian = 'little'
 
-[properties]
-root = '$SYSROOT_PREFIX/usr'
+[built-in options]
 $(python3 -c "import os; print('c_args = {}'.format([x for x in os.getenv('TARGET_CFLAGS').split()]))")
 $(python3 -c "import os; print('c_link_args = {}'.format([x for x in os.getenv('TARGET_LDFLAGS').split()]))")
 $(python3 -c "import os; print('cpp_args = {}'.format([x for x in os.getenv('TARGET_CXXFLAGS').split()]))")
 $(python3 -c "import os; print('cpp_link_args = {}'.format([x for x in os.getenv('TARGET_LDFLAGS').split()]))")
+
+[properties]
+root = '$SYSROOT_PREFIX/usr'
 ${!properties}
 EOF
 }

--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -33,11 +33,9 @@ PKG_MESON_OPTS_TARGET="-Ddefault_library=shared \
                        -Dforce_posix_threads=true \
                        -Dtests=false"
 
-PKG_MESON_PROPERTIES_TARGET="
-have_c99_vsnprintf=false
-have_c99_snprintf=false
-growing_stack=false
-va_val_copy=false"
+if [ "${MACHINE_HARDWARE_NAME}" = "aarch64" -a "${TARGET_ARCH}" = "arm" ]; then
+  PKG_MESON_PROPERTIES_TARGET="needs_exe_wrapper = true"
+fi
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="0.56.0"
-PKG_SHA256="291dd38ff1cd55fcfca8fc985181dd39be0d3e5826e5f0013bf867be40117213"
+PKG_VERSION="0.57.1"
+PKG_SHA256="72e1c782ba9bda204f4a1ed57f98d027d7b6eb9414c723eebbd6ec7f1955c8a6"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
I'm opening this PR to discuss a fix for glib failing to build on a docker container on an aarch64 device for other ARM based devices.
This combination fails after the last meson bump, due to several issues converging.
1. The current implementations of `create_meson_conf_host` and `create_meson_conf_target` are outdated, and use deprecated labels.
2. The `PKG_MESON_PROPERTIES_TARGET` variable in glib package has no effect, ~~as in older meson these options were never even picked up, and in meson 0.56.0 you get a warning about them being unsupported.
`WARNING: Unknown options: "growing_stack, have_c99_snprintf, have_c99_vsnprintf, root, va_val_copy"`~~
3. This commit: https://github.com/mesonbuild/meson/commit/cc201a539674babf46f726859587afb5ed6a6867 introduced in meson 0.56.0 causes the build system to run tests which cannot be executed on the platform. Specifically the ones set to false by `PKG_MESON_PROPERTIES_TARGET` which are ignored by the build process. It's possible that I'm missing a package on the container, but I can't figure out which one.
4. A small, but confusing issue, in meson 0.56.0, the incorrect target uarch was written into the meson-log file, making things even more confusing. Bumping it to the latest version solves that problem.