### PR TITLE
systemd: update to 247.7

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="systemd"
-PKG_VERSION="247.3"
-PKG_SHA256="2869986e219a8dfc96cc0dffac66e0c13bb70a89e16b85a3948876c146cfa3e0"
+PKG_VERSION="247.7"
+PKG_SHA256="e491b4da203f9d16df17001af82555a075172b8cb6853f9d64c3c06d47781aec"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd-stable/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 247.3 (2021-02-03) to 247.7 (2021-05-16)

diffs: https://github.com/systemd/systemd-stable/compare/v247.3...v247.4
diffs: https://github.com/systemd/systemd-stable/compare/v247.4...v247.5
diffs: https://github.com/systemd/systemd-stable/compare/v247.5...v247.6
diffs: https://github.com/systemd/systemd-stable/compare/v247.6...v247.7

prs: https://github.com/systemd/systemd-stable/pulls?q=is%3Apr+is%3Aclosed

logs: https://github.com/systemd/systemd-stable/commits/v247.7

I have been running 247.4 for 2 weeks. there isn’t anything specific I saw that is needed for LE10, but PR’ing if others note something worthy of committing now.