### PR TITLE
restore: adjust mtime when restore finishes if clock not set at start

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/scripts/backup-restore
+++ b/packages/mediacenter/LibreELEC-settings/scripts/backup-restore
@@ -20,7 +20,8 @@ if [ -f "${BACKUP_FILE}" ]; then
   echo -e "Please do not reboot or turn off your @DISTRONAME@ device!\n"
 
   StartProgress spinner "Checking backup file... "
-    tar tf "${BACKUP_FILE}" &>/dev/null
+    CLOCK_YEAR=$(date +%Y)
+    RESTORE_FILE_LIST=$(tar tf "${BACKUP_FILE}" 2&>/dev/null)
 
   if [ $? -eq 0 ]; then
     StopProgress "OK"
@@ -33,6 +34,13 @@ if [ -f "${BACKUP_FILE}" ]; then
              /storage/.config &>/dev/null
       tar xf "${BACKUP_FILE}" -C / &>/dev/null
       rm -f "${BACKUP_FILE}" &>/dev/null
+
+      # XXX: system clock wasn't set before restore started; set new mtime
+      if [ "${CLOCK_YEAR}" -eq "1970" ]; then
+        for FILE in ${RESTORE_FILE_LIST}; do
+          touch "/${FILE}"
+        done
+      fi
       sync
       StopProgress "done!"
 


### PR DESCRIPTION
A system restore could start before the system clock has been set by NTP in the case of a faulty or missing RTC. This change checks if the system year matches the epoch year, and, if true, adjusts mtime at the end of the restore process. This provides the duration of the restore to complete for the system clock to be set.

This should be an improvement for the situation described here: https://forum.libreelec.tv/thread/23744-le-9-95-1-backups-are-restored-with-mtime-jan-1-1970-for-some-files-with-testcas/