### PR TITLE
Allwinner: Fix few Beelink GS1 issues

### DIFF
--- a/packages/tools/crust/package.mk
+++ b/packages/tools/crust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="crust"
-PKG_VERSION="219383cd48924179bdd6c5e125c0dd9ab0d78c16"
-PKG_SHA256="f16e362e20c4c59da4f4a6e692f5d1c3b442a7e398ae9f45932791711f6aa1f6"
+PKG_VERSION="58267556f1b3792b8e742328d693d23ee5ef72b7"
+PKG_SHA256="0da013866710ca85d90aca2f63d66d04a2878224e7fca83047768056e35d9242"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="https://github.com/crust-firmware/crust"

--- a/projects/Allwinner/patches/linux/0056-arm64-dts-allwinner-h6-beelink-gs1-Remove-ext.-32-kH.patch
+++ b/projects/Allwinner/patches/linux/0056-arm64-dts-allwinner-h6-beelink-gs1-Remove-ext.-32-kH.patch
@@ -1,0 +1,41 @@
+From 7d6a50657affa4cfdf4aae108147f1434a177019 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Tue, 30 Mar 2021 20:32:04 +0200
+Subject: [PATCH] arm64: dts: allwinner: h6: beelink-gs1: Remove ext. 32 kHz
+ osc reference
+
+Although every Beelink GS1 seems to have external 32768 Hz oscillator,
+it works only on one from four tested. There are more reports of RTC
+issues elsewhere, like Armbian forum.
+
+One Beelink GS1 owner read RTC osc status register on Android which
+shipped with the box. Reported value indicated problems with external
+oscillator.
+
+In order to fix RTC and related issues (HDMI-CEC and suspend/resume with
+Crust) on all boards, switch to internal oscillator.
+
+Fixes: 32507b868119 ("arm64: dts: allwinner: h6: Move ext. oscillator to board DTs")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts
+index 669d39fc716a..6249e9e02928 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-beelink-gs1.dts
+@@ -289,10 +289,6 @@ sw {
+ 	};
+ };
+ 
+-&rtc {
+-	clocks = <&ext_osc32k>;
+-};
+-
+ &spdif {
+ 	status = "okay";
+ };
+-- 
+2.31.0
+

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -111,7 +111,8 @@ devices = \
     'H6': {
       'beelink-gs1' : {
         'dtb' : 'sun50i-h6-beelink-gs1.dtb',
-        'config' : 'beelink_gs1_defconfig'
+        'config' : 'beelink_gs1_defconfig',
+        'crust_config' : 'beelink_gs1_defconfig'
       },
       'orangepi-3': {
         'dtb': 'sun50i-h6-orangepi-3.dtb',


### PR DESCRIPTION
Beelink GS1 has non-working RTC due to problems with external 32768 Hz oscillator. This also impacts HDMI-CEC and Crust firmware, used for suspend/resume functionality. Fix that by switching to internal, less precise oscillator. Linux patch was submitted upstream.