### PR TITLE
Intel Media Driver 2021Q1 Release - 21.1.3

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva-utils"
-PKG_VERSION="2.10.0"
-PKG_SHA256="cbb7f9f6eae21d772e31b67bc8c311be6e35fe9c65e63acc57f9b16d72bf8dc0"
+PKG_VERSION="2.11.1"
+PKG_SHA256="0c1eb7f717e391d00da74c53a9fe5caf3d6c510dcd35bac7f71a0e59ad1b8d26"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"
 PKG_URL="https://github.com/intel/libva-utils/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="20.4.1"
-PKG_SHA256="d54d547f9f9e74196dead6a338923039ea10c859f1f693f33f10be1562b81d6d"
+PKG_VERSION="21.1.2"
+PKG_SHA256="ecd3b39ae7fd8414e0a45b4b23877c5c13eec692b0a21e0126f336e9c02eea5d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva"
-PKG_VERSION="2.10.0"
-PKG_SHA256="f04d5c829da602690f9f098a6d92065507ec9d0c957c1a6df3dea4e2de1204c5"
+PKG_VERSION="2.11.0"
+PKG_SHA256="ee2bd79bad5e2404143f089360685f5da63a32dd551b54ccd61d2d49c041178a"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="20.4.5"
-PKG_SHA256="3d856a963127ddd6690fc6dac521d7674947675d5f20452f1e6f45c0fc83f9e6"
+PKG_VERSION="21.1.3"
+PKG_SHA256="219ce6b08a84bdce311160dc694d866249fd4e390391c2ac7be55f13a2fb928c"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xf86-video-intel"
-PKG_VERSION="a511f22cdec56504913b457a2e60dafee8e2b570"
-PKG_SHA256="ea41bbab7d2720a4bcd3b083800b8226f217c6af3e8bace4310063a7c5b56c25"
+PKG_VERSION="31486f40f8e8f8923ca0799aea84b58799754564"
+PKG_SHA256="e47eb678c681d80df138e897ee27c79f9b42e3517d55b1f0684e9a70361c8218"
 PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="http://intellinuxgraphics.org/"


### PR DESCRIPTION
Intel driver refresh

This brings all Intel video components up to current.

Dependencies
- libva: update to 2.11.0
- gmmlib: update to 21.1.2
- libva-utils: update to 2.11.1
- media-driver: update to 21.1.3
 
Also included is:
- xf86-video-intel: update to latest 2021-01-15
  - which I have run with SKL/TGL since Jan 2021
### Now officially released:
- https://github.com/intel/media-driver/releases/tag/intel-media-21.1.3

### Official quarterly release including some enhancements and key fixes.

Supported Platforms
- BDW/SKL/APL(BXT)/KBL/CFL/WHL/CML/ICL/EHL/JSL/TGL/RKL/DG1/SG1/ADL-S/ADL-P

What's New
- TGL/RKL/DG1/SG1/ADL-S/ADL-P New Features
- List of new features comparing to previous release as below. You could refer to Readme for more information.
  - Optimized AV1 Decode software latency
  - Enhanced AV1 Decode robustness for error clip
  - Put render/VEBOX heap in local memory if needed on DGFX

Key Fixes
- Decoding
  - Fixed AV1 Decode corruption issue
- HEVC VME Encoding
  - Fixed HEVC Encoder resolution threshold issue
  - Fixed HEVC Encoder active polling latency issue
- VP9 VDEnc Encoding
  - Corrected for VAConfigAttribEncPackedHeaders capability
  - Enabled encoding MxN tile configurations on a single VDBox
- Video Processing
  - Fixed NV12 interlaced scaling alignment issue

Known issues
- Refer to known-issues-and-limitations.

