### PR TITLE
Fixed incompatible types when listing sound cards

### DIFF
--- a/packages/addons/service/snapclient/source/addon.py
+++ b/packages/addons/service/snapclient/source/addon.py
@@ -11,7 +11,7 @@ SNAPCLIENT = os.path.join(
 
 card = ''
 cards = []
-lines = subprocess.check_output([SNAPCLIENT, '--list']).splitlines()
+lines = subprocess.getoutput(SNAPCLIENT + ' --list').splitlines()
 
 for line in lines:
     if line != '':


### PR DESCRIPTION
The listing of sound card failed due to the previous method returned bytes instead of str.