### PR TITLE
snapclient: Fixed incompatible types when listing sound cards and added --host support

### DIFF
--- a/packages/addons/service/snapclient/changelog.txt
+++ b/packages/addons/service/snapclient/changelog.txt
@@ -1,3 +1,7 @@
+106
+- Fixed issue when listing sound cards
+- Added the option to specify the snapcast server host address
+
 105
 - aixlog: update to 1.5.0
 - snapcast: update to 0.24.0

--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="snapclient"
 PKG_VERSION="0.24.0"
-PKG_REV="105"
+PKG_REV="106"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain alsa-plugins snapcast"

--- a/packages/addons/service/snapclient/source/addon.py
+++ b/packages/addons/service/snapclient/source/addon.py
@@ -9,9 +9,10 @@ import xbmcgui
 SNAPCLIENT = os.path.join(
     xbmcaddon.Addon().getAddonInfo('path'), 'bin', 'snapclient')
 
+line = ''
 card = ''
 cards = []
-lines = subprocess.check_output([SNAPCLIENT, '--list']).splitlines()
+lines = subprocess.run([SNAPCLIENT, '--list'], capture_output=True, text=True).stdout.splitlines()
 
 for line in lines:
     if line != '':
@@ -19,6 +20,10 @@ for line in lines:
     else:
         cards.append(card)
         card = ''
+
+# If last line was not empty, make sure to add the last card
+if line != '' and card != '':
+    cards.append(card)
 
 dialog = xbmcgui.Dialog()
 dialog.select(xbmcaddon.Addon().getLocalizedString(30015), cards)

--- a/packages/addons/service/snapclient/source/bin/snapclient.start
+++ b/packages/addons/service/snapclient/source/bin/snapclient.start
@@ -28,12 +28,14 @@ esac
 
 [ -n "$sc_h" ] && sc_H="--hostID $sc_h"
 [ -n "$sc_s" ] && sc_S="--soundcard $sc_s"
+[ -n "$sc_addr" ] && HOST="--host $sc_addr"
 
 HOME="$ADDON_HOME" \
 nice -n "$sc_n" \
 snapclient \
   $sc_H \
   --latency "$sc_l" \
+  $HOST \
   --port "$sc_p" \
   $sc_S \
   > /dev/null

--- a/packages/addons/service/snapclient/source/resources/language/English/strings.po
+++ b/packages/addons/service/snapclient/source/resources/language/English/strings.po
@@ -68,3 +68,7 @@ msgstr ""
 msgctxt "#30015"
 msgid "Available sound cards"
 msgstr ""
+
+msgctxt "#30016"
+msgid "Server"
+msgstr ""

--- a/packages/addons/service/snapclient/source/resources/settings.xml
+++ b/packages/addons/service/snapclient/source/resources/settings.xml
@@ -3,8 +3,9 @@
   <category  label="30000">
     <setting label="30001" type="action" action="RunAddon(service.snapclient)"/>
     <setting label="30002" type="text"   id="sc_s" default=""/>
-    <setting label="30003" type="text"   id="sc_h" default=""/>
+    <setting label="30016" type="text"   id="sc_addr" default=""/>
     <setting label="30004" type="number" id="sc_p" default="1704"/>
+    <setting label="30003" type="text"   id="sc_h" default=""/>
     <setting label="30005" type="slider" id="sc_n" default="-3" range="-20,1,19" option="int"/>
     <setting label="30006" type="number" id="sc_l" default="0"/>
   </category>

--- a/packages/addons/service/snapclient/source/settings-default.xml
+++ b/packages/addons/service/snapclient/source/settings-default.xml
@@ -4,6 +4,7 @@
     <setting id="sc_k" default="true">false</setting>
     <setting id="sc_l" default="true">0</setting>
     <setting id="sc_n" default="true">-3</setting>
+    <setting id="sc_addr" default="true"></setting>
     <setting id="sc_p" default="true">1704</setting>
     <setting id="sc_r" default="true">0</setting>
     <setting id="sc_s" default="true"></setting>


### PR DESCRIPTION
The listing of sound cards failed due to the previous method used returned bytes instead of str.