### PR TITLE
chrome: update to 89.0.4389.114 and fix gtk3 compile issues and addon (105)

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.39.1"
-PKG_SHA256="44d2b042e47d25571581efff673af0a8cd79531babbad2b043784879e15e4228"
+PKG_VERSION="2.40.0"
+PKG_SHA256="4196a7d30a0051e52a67b8ce4283fe79ae5e4e14a725719934565adf1d333429"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.gnome.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/chrome-libxshmfence/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libxshmfence/package.mk
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+. $(get_pkg_directory libxshmfence)/package.mk
+
+PKG_NAME="chrome-libxshmfence"
+PKG_LONGDESC="libxshmfence for chrome"
+PKG_URL=""
+PKG_DEPENDS_UNPACK+=" libxshmfence"
+PKG_BUILD_FLAGS="-sysroot"
+
+PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} \
+                           --disable-static \
+                           --enable-shared"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.bz2 -C ${PKG_BUILD}
+}

--- a/packages/addons/addon-depends/chrome-depends/gdk-pixbuf/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gdk-pixbuf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gdk-pixbuf"
-PKG_VERSION="2.42.2"
-PKG_SHA256="83c66a1cfd591d7680c144d2922c5955d38b4db336d7cd3ee109f7bcf9afef15"
+PKG_VERSION="2.42.4"
+PKG_SHA256="fe9c5dd88f486194ea2bc09b8814c1ed895bb6c530f37cbbf259757c4e482e4d"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/${PKG_VERSION:0:4}/gdk-pixbuf-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gtk3"
-PKG_VERSION="3.24.23"
-PKG_SHA256="5d864d248357a2251545b3387b35942de5f66e4c66013f0962eb5cb6f8dae2b1"
+PKG_VERSION="3.24.28"
+PKG_SHA256="b04e09763367f1ce932cd2ee3a359d4de150e1c38e7bef7d29aa72557a6b47c6"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gtk+/${PKG_VERSION:0:4}/gtk+-${PKG_VERSION}.tar.xz"
@@ -18,10 +18,11 @@ PKG_MESON_OPTS_TARGET="-Dbroadway_backend=false \
                        -Dcloudproviders=false \
                        -Dcolord=no \
                        -Ddemos=false \
+                       -Dexamples=false \
                        -Dgtk_doc=false \
                        -Dintrospection=false \
                        -Dman=false \
-                       -Dprint_backends=auto \
+                       -Dprint_backends=file,lpr \
                        -Dquartz_backend=false \
                        -Dtests=false \
                        -Dwayland_backend=false \

--- a/packages/addons/addon-depends/chrome-depends/gtk3/patches/disable-to-pixdata-build.patch
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/patches/disable-to-pixdata-build.patch
@@ -1,0 +1,26 @@
+--- a/gtk/gen-gtk-gresources-xml.py	2021-02-24 19:13:19.000000000 +0000
++++ b/gtk/gen-gtk-gresources-xml.py	2021-04-03 23:52:35.000000000 +0000
+@@ -23,11 +23,6 @@
+     <file>theme/Adwaita/gtk-contained-dark.css</file>
+ '''
+ 
+-for f in get_files('theme/Adwaita/assets', '.png'):
+-  xml += '    <file preprocess=\'to-pixdata\'>theme/Adwaita/assets/{0}</file>\n'.format(f)
+-
+-xml += '\n'
+-
+ for f in get_files('theme/Adwaita/assets', '.svg'):
+   xml += '    <file>theme/Adwaita/assets/{0}</file>\n'.format(f)
+ 
+@@ -38,11 +33,6 @@
+     <file>theme/HighContrast/gtk-contained-inverse.css</file>
+ '''
+ 
+-for f in get_files('theme/HighContrast/assets', '.png'):
+-  xml += '    <file preprocess=\'to-pixdata\'>theme/HighContrast/assets/{0}</file>\n'.format(f)
+-
+-xml += '\n'
+-
+ for f in get_files('theme/HighContrast/assets', '.svg'):
+   xml += '    <file>theme/HighContrast/assets/{0}</file>\n'.format(f)
+ 

--- a/packages/addons/addon-depends/chrome-depends/pango/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/pango/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pango"
-PKG_VERSION="1.48.0"
-PKG_SHA256="391f26f3341c2d7053e0fb26a956bd42360dadd825efe7088b1e9340a65e74e6"
+PKG_VERSION="1.48.4"
+PKG_SHA256="418913fb062071a075846244989d4a67aa5c80bf0eae8ee4555a092fd566a37a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.pango.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/pango/${PKG_VERSION:0:4}/pango-${PKG_VERSION}.tar.xz"

--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,3 +1,11 @@
+105
+- at-spi2-core: update to 2.40.0
+- chrome: update to 89.0.4389.114
+- gdk-pixbuf: update to 2.42.4
+- gtk3: disable use of to-pixdata during build
+- gtk3: update to 3.24.28
+- pango: update to 1.48.4
+
 104
 - updated to 87.0.4280
 

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -4,8 +4,8 @@
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
 # curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
-PKG_VERSION_NUMBER="87.0.4280.66"
-PKG_REV="104"
+PKG_VERSION_NUMBER="89.0.4389.114"
+PKG_REV="105"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -11,8 +11,9 @@ PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"
 PKG_DEPENDS_TARGET="toolchain at-spi2-atk atk cairo chrome-libXcomposite \
                     chrome-libXdamage chrome-libXfixes chrome-libXi chrome-libXrender \
-                    chrome-libXtst chrome-libxcb chrome-libxkbcommon cups gdk-pixbuf gtk3 harfbuzz-icu \
-                    libXcursor libxss nss pango scrnsaverproto unclutter"
+                    chrome-libXtst chrome-libxcb chrome-libxkbcommon chrome-libxshmfence cups \
+                    gdk-pixbuf gtk3 harfbuzz-icu libXcursor libxss nss pango \
+                    scrnsaverproto unclutter"
 PKG_SECTION="browser"
 PKG_SHORTDESC="Google Chrome Browser"
 PKG_LONGDESC="Google Chrome Browser"
@@ -56,6 +57,7 @@ addon() {
          $(get_install_dir chrome-libXi)/usr/lib/libXi.so.6 \
          $(get_install_dir chrome-libxkbcommon)/usr/lib/libxkbcommon.so.0 \
          $(get_install_dir chrome-libXrender)/usr/lib/libXrender.so.1 \
+         $(get_install_dir chrome-libxshmfence)/usr/lib/libxshmfence.so.1 \
          $(get_install_dir libxss)/usr/lib/libXss.so.1 \
          $(get_install_dir chrome-libXtst)/usr/lib/libXtst.so.6 \
          $(get_install_dir pango)/usr/lib/{libpangocairo-1.0.so.0,libpango-1.0.so.0,libpangoft2-1.0.so.0} \


### PR DESCRIPTION
### Included changes:
Note: these are only chrome dependancies - so no impact to other LE10 core or addons
- gdk-pixbuf: update to 2.42.4
- gtk3: disable use of to-pixdata during build
- gtk3: update to 3.24.28
- pango: update to 1.48.4
- at-spi2-core: update to 2.40.0
- chrome: update to 89.0.4389.114 and fix gtk3 compile issues and addon (105)
- New dependency for chrome 89 versus 87 - chrome-libxshmfence

### Notes:
- harfbuzz bump is not included as it is also used by libass
- Build tested against master [HEAD]
- Run tested on TGL