### PR TITLE
ffmpegx: update to 4.3.2 and ffmpeg-tools (115)

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ffmpegx"
-PKG_VERSION="4.3.1"
-PKG_SHA256="ad009240d46e307b4e03a213a0f49c11b650e445b1f8be0dda2a9212b34d2ffb"
+PKG_VERSION="4.3.2"
+PKG_SHA256="46e4e64f1dd0233cbc0934b9f1c0da676008cad34725113fb7f802cfa84ccddb"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="https://ffmpeg.org/releases/ffmpeg-${PKG_VERSION}.tar.xz"

--- a/packages/addons/tools/ffmpeg-tools/changelog.txt
+++ b/packages/addons/tools/ffmpeg-tools/changelog.txt
@@ -1,3 +1,7 @@
+115
+- aom (AV1): update to 3.0.0
+- ffmpegx: update to 4.3.2
+
 114
 - x264: update to 2021-01-07
 

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="7ddc21b28468b9e8d0f189bb46a2467de4e09e12"
-PKG_SHA256="995349787105db62daba924f22f7a90c4825575fe24d2b87c4b183d8ac99f5b3"
+PKG_VERSION="307ce06ed82d93885ee8ed53e152c9268ac0d98d" # 3.0.0
+PKG_SHA256="ec67e6a931effda7c938db016d2f1660716fe4df98b59ea07d8a30dc22cd6446"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="http://repo.or.cz/aom.git/snapshot/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- aom (AV1): update to 3.0.0
  - move aom from git hash to version numbering
  - but since 2020-05-07 official releases have been made available starting with v2.0.0 "Applejack".
- ffmpegx: update to 4.3.2
- ffmpeg-tools: update addon to 115

