### PR TITLE
mesa: updated to 21.0.2

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="21.0.1"
-PKG_SHA256="379fc984459394f2ab2d84049efdc3a659869dc1328ce72ef0598506611712bb"
+PKG_VERSION="21.0.2"
+PKG_SHA256="46c1dc5bb54a372dee43ec3c067229c299187d5bdadf1402756bbf66a6df5b88"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
### **Release notes:**

- https://www.phoronix.com/scan.php?page=news_item&px=Mesa-21.0.2-Released
- https://lists.freedesktop.org/archives/mesa-dev/2021-April/225039.html

> This un-breaks AMD vaapi.
https://www.phoronix.com/forums/forum/phoronix/latest-phoronix-articles/1249483-mesa-21-0-2-released-with-lavapipe-fixes-improved-amd-l3-cache-calculation?p=1249484#post1249484