### PR TITLE
Python3: update to 3.8.9 (security hotfix)

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.8.8"
-PKG_SHA256="7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc"
+PKG_VERSION="3.8.9"
+PKG_SHA256="5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.python.org/"
 PKG_URL="http://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update form 3.8.8 to 3.8.9
changelog: https://docs.python.org/release/3.8.9/whatsnew/changelog.html#python-3-8-9

release schedule: PEP 569 - https://www.python.org/dev/peps/pep-0569/
3.8.8: Friday, 2021-02-19
3.8.9: Friday, 2021-04-02 (security hotfix)
3.8.10: Monday, 2021-05-03 - Final regular bugfix release with binary installers: