### PR TITLE
gcc: update to 10.3.0 / updated license short identifier

### DIFF
--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc"
-PKG_VERSION="10.2.0"
-PKG_SHA256="b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
-PKG_LICENSE="GPL"
+PKG_VERSION="10.3.0"
+PKG_SHA256="64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344"
+PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://gcc.gnu.org/"
 PKG_URL="http://ftpmirror.gnu.org/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_BOOTSTRAP="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc:host zstd:host"


### PR DESCRIPTION
Build & run tested on Generic (APL/SKL), Rockchip (RK3399) & Amlogic (AMLG12B)

>GCC 10.3 is a bug-fix release from the GCC 10 branch
containing important fixes for regressions and serious bugs in
GCC 10.2 with more than 178 bugs fixed since the previous release.

- https://www.phoronix.com/scan.php?page=news_item&px=GCC-10.3-Released
