### PR TITLE
syncthing: update to 1.15.1

### DIFF
--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,7 @@
+115
+- Update to 1.15.1
+- fix script - STNODEFAULTFOLDER=1
+
 114
 - Update to 1.14.0
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.14.0"
-PKG_SHA256="55a6fb08a9dbc1a31a6b429a16abb3a76d8c24b491a86a52170ddaadea33f683"
-PKG_REV="114"
+PKG_VERSION="1.15.1"
+PKG_SHA256="b867c5056ad073bcb690853558bf9ef6c2356b2038527973cfee501bf9076911"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/service/syncthing/source/bin/syncthing-service
+++ b/packages/addons/service/syncthing/source/bin/syncthing-service
@@ -6,7 +6,7 @@
 . /etc/profile
 oe_setup_addon service.system.syncthing
 
-STNODEFAULTFOLDER="y" syncthing -home=$ADDON_HOME           \
+STNODEFAULTFOLDER="1" syncthing -home=$ADDON_HOME           \
                                 -gui-address="$gui_address" \
                                 -logflags=0                 \
                                 -no-browser                 \


### PR DESCRIPTION
- update 1.14.0 (2021-03-03) to 1.15.1 (2021-04-06)
- release notes: https://github.com/syncthing/syncthing/releases/tag/v1.15.1
- also fix reported issue https://forum.libreelec.tv/thread/972-syncthing/?postID=153781#post153781
  - reference to 1 is located in https://docs.syncthing.net/dev/debugging.html?highlight=stnodefaultfolder