### PR TITLE
Allwinner: configure systemd-suspend.service to only use suspend-to-ram

### DIFF
--- a/projects/Allwinner/filesystem/usr/lib/systemd/sleep.conf.d/memonly.conf
+++ b/projects/Allwinner/filesystem/usr/lib/systemd/sleep.conf.d/memonly.conf
@@ -1,0 +1,2 @@
+[Sleep]
+SuspendState=mem


### PR DESCRIPTION
Avoid using "freeze" method, which is used by systemd in case default "mem" method fails.

"freeze" type suspend can't be woken from using IR remote and Crust firmware
on Allwinner boards.