### PR TITLE
DVB add-on fixes

### DIFF
--- a/packages/linux-driver-addons/dvb/crazycat/package.mk
+++ b/packages/linux-driver-addons/dvb/crazycat/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="crazycat"
-PKG_VERSION="4a6d5e54cb90363e50f20a91af93aec84eef3205"
-PKG_SHA256="b55eb13d2f9a92d8b75a84f4f77d841ae12bbb6c97bd672ffd9eb2e2800d0523"
+PKG_VERSION="10.0-cc"
+PKG_SHA256="66c298f178cac3bd5c2182cd42122c603bd9ae6e3abadc2ccc8be75112bd196e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/crazycat69/media_build"
 PKG_URL="https://github.com/LibreELEC/media_build/archive/${PKG_VERSION}.tar.gz"

--- a/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
+++ b/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media_tree"
-PKG_VERSION="2021-02-10-ce79aecf6084"
-PKG_SHA256="4383675ff2394128a42d108ee47b44536396ab598fcff14926af256f1786f552"
+PKG_VERSION="2021-04-08-4f4e6644cd87"
+PKG_SHA256="894530c842092646631a1595c7dff04e7a0ec55f4c7f246b8f89aa56f41d486e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.linuxtv.org/media_tree.git"
 PKG_URL="http://linuxtv.org/downloads/drivers/linux-media-${PKG_VERSION}.tar.bz2"

--- a/packages/linux-driver-addons/dvb/dvb-latest/package.mk
+++ b/packages/linux-driver-addons/dvb/dvb-latest/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dvb-latest"
-PKG_VERSION="9e52fd5c00a5e3bdb34561bc325f8ff864fdf1a7"
-PKG_SHA256="0beeb160677012a94c1a0cf826edba9c501d9c2e2c3fceb4282d1ce1871debea"
+PKG_VERSION="10.0-latest"
+PKG_SHA256="50ed45ec6eeac0c8d537f8de3e7e82ef1f37b2f91552cdd99fbda05e5646f351"
 PKG_LICENSE="GPL"
 PKG_SITE="http://git.linuxtv.org/media_build.git"
 PKG_URL="https://github.com/LibreELEC/media_build/archive/${PKG_VERSION}.tar.gz"

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -74,7 +74,7 @@
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm_sta"
 
   # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
+    DRIVER_ADDONS_SUPPORT="yes"
 
   # driver addons to install:
   # for a list of additional drivers see packages/linux-driver-addons


### PR DESCRIPTION
- update dvb-latest to kernel 5.13ish
- workaround `/bin/sh: Argument list too long` problem due too long filepaths, instead of using the git hash we use now a tag that is much shorter, avoids adding other strange workarounds like disabling modules to reduce amount of files etc

should hopefully fix jenkins