### PR TITLE
[Allwinner,Generic,Rockchip] linux: Update to 5.10.30

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="5.10.26"
-    PKG_SHA256="fc532833f1ac167f363f1b9de85db39d2d635ab516f66dc381bdd70804601482"
+    PKG_VERSION="5.10.30"
+    PKG_SHA256="d40269b5ac5c8424ec808f4484c7f80947f8f2d549b1ef1a5149aec5b6a20640"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v5.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.21 Kernel Configuration
+# Linux/arm64 5.10.29 Kernel Configuration
 #
 
 #
@@ -6031,6 +6031,7 @@ CONFIG_DEBUG_INFO=y
 # CONFIG_DEBUG_INFO_COMPRESSED is not set
 # CONFIG_DEBUG_INFO_SPLIT is not set
 # CONFIG_DEBUG_INFO_DWARF4 is not set
+# CONFIG_DEBUG_INFO_BTF is not set
 # CONFIG_GDB_SCRIPTS is not set
 CONFIG_ENABLE_MUST_CHECK=y
 CONFIG_FRAME_WARN=2048


### PR DESCRIPTION
https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.27
https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.28
https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.29
https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.30

5.10.27,- 219 patches
5.10.28 - 126 patches
5.10.29 - 41 patches
5.10.30 - 188 patches

log - https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-5.10.y

- Generic (TGL) - build and run tested 5.10.27,5.10.28,5.10.29, 5.10.30 - heitbaum