### PR TITLE
cairo: set options based on OPENGL/ES

### DIFF
--- a/packages/graphics/cairo/package.mk
+++ b/packages/graphics/cairo/package.mk
@@ -74,18 +74,27 @@ pre_configure_target() {
                                  --x-libraries="${SYSROOT_PREFIX}/usr/lib" \
                                  --enable-xlib \
                                  --enable-xlib-xrender \
-                                 --enable-gl \
-                                 --enable-glx \
-                                 --disable-glesv2 \
-                                 --disable-egl \
                                  --with-x"
-   else
+  else
     PKG_CONFIGURE_OPTS_TARGET+=" --disable-xlib \
                                  --disable-xlib-xrender \
-                                 --disable-gl \
+                                 --without-x"
+  fi
+
+  if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+    PKG_CONFIGURE_OPTS_TARGET+=" --enable-gl \
+                                 --enable-glx \
+                                 --disable-glesv2 \
+                                 --disable-egl"
+  elif [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+    PKG_CONFIGURE_OPTS_TARGET+=" --disable-gl \
                                  --disable-glx \
                                  --enable-glesv2 \
-                                 --enable-egl \
-                                 --without-x"
+                                 --enable-egl"
+  else
+    PKG_CONFIGURE_OPTS_TARGET+=" --disable-gl \
+                                 --disable-glx \
+                                 --disable-glesv2 \
+                                 --disable-egl"
   fi
 }


### PR DESCRIPTION
Dear maintainers,

here are two fixes I made to upstream while porting Lakka to LibreELEC master branch. There are more changes for Lakka, but those are Lakka specific (e.g. Lakka requires in some cases shared libs instead of static, different boot messages / menus, vulkan drivers, ...), so I am not sending those over.

`cairo`
Originally the package file chose between OpenGL and OpenGLES flags based on the presence of the DISPLAYSERVER. These flags should be most probably set based on the fact if OpenGL or OpenGLES (or neither of both) is used.

`get_git`
The script originally looked at every file AND folder in the sources folder, which is incorrect and causes unintentional deletion of archive files. After the fix the script checks only folders.

If it is preferred to have two separate pull requests, please close this request with such message.