### PR TITLE
kodi (RPi4): add patch to set colorspace connector property

### DIFF
--- a/projects/RPi/devices/RPi4/patches/kodi/0002-set-colorspace-connector-property.patch
+++ b/projects/RPi/devices/RPi4/patches/kodi/0002-set-colorspace-connector-property.patch
@@ -1,0 +1,90 @@
+From a6834e2b37fa968c2cb7f57c6198d7ecb03f8583 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 29 Apr 2019 18:48:45 -0700
+Subject: [PATCH] CVideoLayerBridgeDRMPRIME add colourspace connector property
+
+---
+ .../Buffers/VideoBufferDRMPRIME.cpp           | 12 ++++++++++
+ .../VideoPlayer/Buffers/VideoBufferDRMPRIME.h |  1 +
+ .../HwDecRender/VideoLayerBridgeDRMPRIME.cpp  | 22 ++++++++++++++++++-
+ 3 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+index b85097d37b..037f66db72 100644
+--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+@@ -19,6 +19,18 @@ extern "C"
+ namespace DRMPRIME
+ {
+ 
++std::string GetColorimetry(const VideoPicture& picture)
++{
++  switch (picture.color_space)
++  {
++    case AVCOL_SPC_BT2020_CL:
++    case AVCOL_SPC_BT2020_NCL:
++      return "BT2020_RGB";
++  }
++
++  return "Default";
++}
++
+ std::string GetColorEncoding(const VideoPicture& picture)
+ {
+   switch (picture.color_space)
+diff --git a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+index e77f75b58b..4de9732308 100644
+--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
++++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+@@ -34,6 +34,7 @@ enum hdmi_eotf
+   HDMI_EOTF_BT_2100_HLG,
+ };
+ 
++std::string GetColorimetry(const VideoPicture& picture);
+ std::string GetColorEncoding(const VideoPicture& picture);
+ std::string GetColorRange(const VideoPicture& picture);
+ uint8_t GetEOTF(const VideoPicture& picture);
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+index 4f07ffc0b8..c78636b680 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+@@ -35,8 +35,18 @@ void CVideoLayerBridgeDRMPRIME::Disable()
+   m_DRM->AddProperty(plane, "FB_ID", 0);
+   m_DRM->AddProperty(plane, "CRTC_ID", 0);
+ 
+-  // disable HDR metadata
+   auto connector = m_DRM->GetConnector();
++
++  bool result;
++  uint64_t value;
++  std::tie(result, value) = connector->GetPropertyValue("Colorspace", "Default");
++  if (result)
++  {
++    CLog::Log(LOGDEBUG, "CVideoLayerBridgeDRMPRIME::{} - setting connector colorspace to Default", __FUNCTION__);
++    m_DRM->AddProperty(connector, "Colorspace", value);
++  }
++
++  // disable HDR metadata
+   if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
+   {
+     m_DRM->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
+@@ -173,6 +183,16 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
+     m_DRM->AddProperty(plane, "COLOR_RANGE", value);
+ 
+   auto connector = m_DRM->GetConnector();
++
++  std::tie(result, value) =  connector->GetPropertyValue("Colorspace", GetColorimetry(picture));
++  if (result)
++  {
++    CLog::Log(LOGDEBUG, "CVideoLayerBridgeDRMPRIME::{} - setting connector colorspace to {}", __FUNCTION__,
++              GetColorimetry(picture));
++    m_DRM->AddProperty(connector, "Colorspace", value);
++    m_DRM->SetActive(true);
++  }
++
+   if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
+   {
+     m_hdr_metadata.metadata_type = HDMI_STATIC_METADATA_TYPE1;
+-- 
+2.20.1
+


### PR DESCRIPTION
This enables signalling of BT.2020 colorspace via HDMI.

#5319 is needed for this, HDR video playback looks OK now (only 10bit output is missing ATM)