### PR TITLE
librespot: use utf-8 encoding in Python when parsing librespot

### DIFF
--- a/packages/addons/service/librespot/changelog.txt
+++ b/packages/addons/service/librespot/changelog.txt
@@ -1,3 +1,6 @@
+128
+- Python: fix Librespot output is utf-8
+
 127
 - Update to 0.1.6
 

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="librespot"
 PKG_VERSION="0.1.6"
 PKG_SHA256="7506b4448d3ae0eba063cd711baebdc23444c706c87d0551d5a4cbc623e70f30"
-PKG_REV="127"
+PKG_REV="128"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/librespot-org/librespot/"

--- a/packages/addons/service/librespot/source/resources/lib/ls_librespot.py
+++ b/packages/addons/service/librespot/source/resources/lib/ls_librespot.py
@@ -119,7 +119,8 @@ class Librespot(xbmc.Player):
                 env=ADDON_ENVT,
                 stderr=subprocess.STDOUT,
                 stdout=subprocess.PIPE,
-                text=True)
+                text=True,
+                encoding='utf-8')
             log('librespot started')
             with self.librespot.stdout:
                 for line in self.librespot.stdout:


### PR DESCRIPTION
Bug reported an fix tested in: https://forum.libreelec.tv/thread/23822-rpi4-le10-0-nightly-20210411-5a67b41-librespot-crashes-after-playing-some-songs/