### PR TITLE
openssh: update to 8.6p1

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="8.5p1"
-PKG_SHA256="f52f3f41d429aa9918e38cf200af225ccdd8e66f052da572870c89737646ec25"
+PKG_VERSION="8.6p1"
+PKG_SHA256="c3e6e4da1621762c850d03b47eed1e48dff4cc9608ddeb547202a234df8ed7ae"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 8.5p1 (2021-03-03) to 8.6p1 (2021-04-19)
release notes: http://www.openssh.com/txt/release-8.6

This release contains mostly bug fixes.