### PR TITLE
mesa: update to 21.0.3

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="21.0.2"
-PKG_SHA256="46c1dc5bb54a372dee43ec3c067229c299187d5bdadf1402756bbf66a6df5b88"
+PKG_VERSION="21.0.3"
+PKG_SHA256="565c6f4bd2d5747b919454fc1d439963024fc78ca56fd05158c3b2cde2f6912b"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update 21.0.2 to 21.0.3
announce: https://lists.freedesktop.org/archives/mesa-dev/2021-April/225130.html

AMD revert patch is not included in the release 