### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.heif"
-PKG_VERSION="1.3.0-Matrix"
-PKG_SHA256="bb75fa34382443f6320bd7ab0a623834c1bd98743464de05029eb31fb5ac6494"
-PKG_REV="4"
+PKG_VERSION="1.4.0-Matrix"
+PKG_SHA256="0ab56bb77777dd348117586474a3fc3c398b27de971e104bddb963b54751c59e"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="2.6.13-Matrix"
-PKG_SHA256="83ffa1f5047782e049b54b94e7e9615638147f751980533bf4616140901129c9"
+PKG_VERSION="2.6.14-Matrix"
+PKG_SHA256="f1756932e8cc602ce66c5db3bc1d44a442c01197c193561ca9248a405bd8bd86"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
imagedecoder.heif - 1.4.0-Matrix
inputstream.adaptive - 2.6.14-Matrix