### PR TITLE
kernel-firmware: add rtw88/rtw8821c_fw.bin to image

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/x86_64.dat
@@ -8,6 +8,7 @@ rt2561s.bin
 rt2661.bin
 rt2860.bin
 rt3290.bin
+rtw88/rtw8821c_fw.bin
 ar3k/*.dfu
 intel/dsp_fw_{bxtn,cnl,glk,kbl,release}.bin
 intel/fw_sst_*.bin*


### PR DESCRIPTION
Fix firmware download for card: 
- `Direct firmware load for rtw88/rtw8821c_fw.bin failed`

Ref: https://forum.libreelec.tv/thread/23871-wifi-not-installed-on-mini-pc-using-libreelec/?postID=154604#post154604

wait confirmation from user that this fixes the issue.