### PR TITLE
exfat: cleanup no longer in use fuse EXFAT option

### DIFF
--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -99,9 +99,6 @@
   # build and install diskmounter support (udevil)
     UDEVIL="no"
 
-  # build and install exFAT fuse support (yes / no)
-    EXFAT="no"
-
   # build and install NTFS-3G fuse support (yes / no)
     NTFS3G="no"
 


### PR DESCRIPTION
Only a cleanup of unused option.