### PR TITLE
libdrm: Revert set FB_MODIFIERS flag when modifiers are supplied

### DIFF
--- a/packages/graphics/libdrm/patches/revert-xf86drmMode-set-FB_MODIFIERS-flag-when-modifiers-are-supplied.patch
+++ b/packages/graphics/libdrm/patches/revert-xf86drmMode-set-FB_MODIFIERS-flag-when-modifiers-are-supplied.patch
@@ -1,0 +1,35 @@
+From 40f73d0b0b3936ccadc693edc25aad70c1225766 Mon Sep 17 00:00:00 2001
+From: Bas Nieuwenhuizen <bas@basnieuwenhuizen.nl>
+Date: Wed, 21 Apr 2021 21:31:06 +0200
+Subject: [PATCH] Revert "xf86drmMode: set FB_MODIFIERS flag when modifiers are
+ supplied"
+
+This reverts commit b362850689d1b0048b7f4641cc236128b5a43773.
+
+This breaks when the kernel driver does not support modifiers and the
+application properly zeroes the modifiers.
+
+Acked-by: Simon Ser <contact@emersion.fr>
+---
+ xf86drmMode.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/xf86drmMode.c b/xf86drmMode.c
+index dc177241..c3920b91 100644
+--- a/xf86drmMode.c
++++ b/xf86drmMode.c
+@@ -289,10 +289,8 @@ drm_public int drmModeAddFB2WithModifiers(int fd, uint32_t width,
+ 	memcpy(f.handles, bo_handles, 4 * sizeof(bo_handles[0]));
+ 	memcpy(f.pitches, pitches, 4 * sizeof(pitches[0]));
+ 	memcpy(f.offsets, offsets, 4 * sizeof(offsets[0]));
+-	if (modifier) {
+-		f.flags |= DRM_MODE_FB_MODIFIERS;
++	if (modifier)
+ 		memcpy(f.modifier, modifier, 4 * sizeof(modifier[0]));
+-	}
+ 
+ 	if ((ret = DRM_IOCTL(fd, DRM_IOCTL_MODE_ADDFB2, &f)))
+ 		return ret;
+-- 
+GitLab
+


### PR DESCRIPTION
Bug introduced in #5301 
- https://github.com/LibreELEC/LibreELEC.tv/pull/5301#issuecomment-827952096

Fix is included in libdrm master (and likely 2.4.106)
- https://gitlab.freedesktop.org/mesa/drm/-/commit/40f73d0b0b3936ccadc693edc25aad70c1225766