### PR TITLE
Fix build of xorg-intel-gpu-tools

### DIFF
--- a/packages/debug/xorg-intel-gpu-tools/package.mk
+++ b/packages/debug/xorg-intel-gpu-tools/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xorg-intel-gpu-tools"
-PKG_VERSION="1.25"
-PKG_SHA256="2257a73d6a5d431dfbea4dec0dae07397b1e3269416049ced978550853616a2b"
+PKG_VERSION="1.26"
+PKG_SHA256="36d4193b9f22fbb4834ec97be3bb6322ec901e20f7be018f0a50d3eb03ec9bb7"
 PKG_LICENSE="GPL"
 PKG_DEPENDS_TARGET="toolchain cairo procps-ng"
-PKG_SITE="https://github.com/freedesktop/xorg-intel-gpu-tools"
-PKG_URL="https://github.com/freedesktop/xorg-intel-gpu-tools/archive/igt-gpu-tools-${PKG_VERSION}.tar.gz"
+PKG_SITE="https://gitlab.freedesktop.org/drm/igt-gpu-tools"
+PKG_URL="https://www.x.org/releases/individual/app/igt-gpu-tools-${PKG_VERSION}.tar.xz"
 PKG_LONGDESC="Test suite and tools for DRM/KMS drivers"
 PKG_TOOLCHAIN="meson"
 

--- a/packages/tools/procps-ng/package.mk
+++ b/packages/tools/procps-ng/package.mk
@@ -20,7 +20,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
 
 PKG_MAKE_OPTS_TARGET="free top/top proc/libprocps.la proc/libprocps.pc"
 
-PKG_MAKEINSTALL_OPTS_TARGET="install-libLTLIBRARIES install-pkgconfigDATA"
+PKG_MAKEINSTALL_OPTS_TARGET="install-libLTLIBRARIES install-pkgconfigDATA install-proc_libprocps_la_includeHEADERS"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin


### PR DESCRIPTION
Fix build of xorg-intel-gpu-tools:
- error occurring:

```
../lib/igt_aux.c:54:10: fatal error: proc/readproc.h: No such file or directory
   54 | #include <proc/readproc.h>
      |          ^~~~~~~~~~~~~~~~~
```

- procps-ng: install missing headers required for dependant packages
  - additionally tested build of **busybox** which is dependant on procps-ng 
- xorg-intel-gpu-tools: update to 1.26
  - update 1.25 (2020-03-20) to 1.26 (2021-04-23)
  - news: https://cgit.freedesktop.org/xorg/app/intel-gpu-tools/tree/NEWS
  - Update the URLs