### PR TITLE
samba: update to 4.13.8

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.13.7"
-PKG_SHA256="4e7d700867071047be74d802e25f071255bb7f382c2d788ecb7526fa61c95baa"
+PKG_VERSION="4.13.8"
+PKG_SHA256="3347c0c62cc5b1df1fc92d802282e809c354bfb4941a33c91a7fda3795efbf7f"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 4.1.7 (2021-03-24) to 4.18.8 (2021-04-29)
release notes: https://www.samba.org/samba/history/samba-4.13.8.html

==

This is a security release in order to address the following defect:

o CVE-2021-20254: Negative idmap cache entries can cause incorrect group entries
  in the Samba file server process token.

=======
Details
=======

o  CVE-2021-20254:
   The Samba smbd file server must map Windows group identities (SIDs) into unix
   group ids (gids). The code that performs this had a flaw that could allow it
   to read data beyond the end of the array in the case where a negative cache
   entry had been added to the mapping cache. This could cause the calling code
   to return those values into the process token that stores the group
   membership for a user.

   Most commonly this flaw caused the calling code to crash, but an alert user
   (Peter Eriksson, IT Department, Linköping University) found this flaw by
   noticing an unprivileged user was able to delete a file within a network
   share that they should have been disallowed access to.

   Analysis of the code paths has not allowed us to discover a way for a
   remote user to be able to trigger this flaw reproducibly or on demand,
   but this CVE has been issued out of an abundance of caution.

Changes since 4.13.7
--------------------

o  Volker Lendecke <vl@samba.org>
   * BUG 14571: CVE-2021-20254: Fix buffer overrun in sids_to_unixids().