### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="8.2.1-Matrix"
-PKG_SHA256="ebe2b1f96b49c08c5960a6f75da6cb3cfc0cc30d6fafe43b77d2f2249915b752"
-PKG_REV="3"
+PKG_VERSION="8.2.2-Matrix"
+PKG_SHA256="67d292877da7a017d2915ec4921a0ac7beb378411c08087f8885dd32a42eefdf"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.nextpvr"


### PR DESCRIPTION
pvr.nextpvr: update to 8.2.2
- Add missing break
- Keyword timers where falling through and acting as advanced searches