### PR TITLE
kodi: export PYTHONPATH from kodi addons

### DIFF
--- a/packages/mediacenter/kodi/profile.d/00-addons.conf
+++ b/packages/mediacenter/kodi/profile.d/00-addons.conf
@@ -2,6 +2,9 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
+# reset variables for recursion case
+unset PYTHONPATH
+
 # addons profile.d/*.profile
 for config in /storage/.kodi/addons/*/profile.d/*.profile; do
   if [ -f "$config" ] ; then

--- a/packages/mediacenter/kodi/profile.d/99-kodi.conf
+++ b/packages/mediacenter/kodi/profile.d/99-kodi.conf
@@ -12,3 +12,9 @@ for addon in /storage/.kodi/addons/*/lib /usr/lib/kodi/addons/*/lib; do
   [ -d "$addon" ] && LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$addon"
 done
 export LD_LIBRARY_PATH
+
+# PYTHONPATH
+for addon in /storage/.kodi/addons/*/lib /storage/.kodi/addons/*/libs /usr/lib/kodi/addons/*/lib; do
+  [ -d "${addon}" ] && PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${addon}"
+done
+export PYTHONPATH

--- a/packages/mediacenter/kodi/scripts/kodi.sh
+++ b/packages/mediacenter/kodi/scripts/kodi.sh
@@ -14,6 +14,8 @@
 
 . /etc/profile
 
+unset PYTHONPATH
+
 trap cleanup TERM
 
 KODI_ROOT=$HOME/.kodi


### PR DESCRIPTION
Allow system wide use of Python libraries installed as Kodi addons by exporting environment variable PYTHONPATH.

Avoid adding `sys.path.append('/storage/.kodi/userdata/<addon name>/lib')` to get the library imported.

To eliminate any possible side effect to our main application PYTHONPATH is unset for Kodi.

Functionality is working on Generic. Volunteers testing i.e. their GPIO fan control scripts on RPIs are highly welcome.