### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="1.21.1-Matrix"
-PKG_SHA256="69aa62596633da3bc884b0a056761260d21a772eed988f4e1c629bb07c6e178f"
+PKG_VERSION="1.21.2-Matrix"
+PKG_SHA256="b1a6131f5bdf849a4de8db84144e554e1a196d9132970c720febb90198edec01"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="7.6.1-Matrix"
-PKG_SHA256="0bffd09eba7cf758a818607562b4dec53f4a20acb7a8b43dd0a1499e92cb3057"
+PKG_VERSION="7.6.2-Matrix"
+PKG_SHA256="59347c41dfd0dfa45f3d85deed0430346ef2898eb7276d5793244b877519f385"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.waipu"
-PKG_VERSION="2.8.1-Matrix"
-PKG_SHA256="0bb81ab116ff95d0954e090d09aabf6d238cad46b466ba54b04872c1fe2e131a"
+PKG_VERSION="2.8.2-Matrix"
+PKG_SHA256="df4de5444cfceb93e914310979bb13eb94075ce0646c731218aab34dd8af1bbb"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
inputstream.ffmpegdirect
- Fixed: Allow timezone shift when live URLs have placeholders 

pvr.iptvsimple
- Fixed: Allow catchup correction (timezone shift) when live URLs have catchup placeholders
- Fixed: Always load EPG data if we prefer XMLTV logos or catchup is enabled

pvr.waipu:
- Fix replay and recordable state
- Update eid mapping for EPG tags