### PR TITLE
Python3: update to 3.8.11 and HSTS

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,11 +3,11 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.8.9"
-PKG_SHA256="5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572"
+PKG_VERSION="3.8.10"
+PKG_SHA256="6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.python.org/"
-PKG_URL="http://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.python.org/"
+PKG_URL="https://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="zlib:host bzip2:host libffi:host util-linux:host xz:host"
 PKG_DEPENDS_TARGET="toolchain Python3:host sqlite expat zlib bzip2 xz openssl libffi readline ncurses util-linux"
 PKG_LONGDESC="Python3 is an interpreted object-oriented programming language."

--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.8.10"
-PKG_SHA256="6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9"
+PKG_VERSION="3.8.11"
+PKG_SHA256="fb1a1114ebfe9e97199603c6083e20b236a0e007a2c51f29283ffb50c1420fb2"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.python.org/"
 PKG_URL="https://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
**This is the final regular bugfix release of Python 3.8**
Run tested on x86_64 TGL and AMLG12

update 3.8.9 (2021-04-02) to 3.8.10 (2021-05-03)
changelog: https://docs.python.org/release/3.8.10/whatsnew/changelog.html

This is the final regular bugfix release of Python 3.8. Security
releases will follow until October 2024. Release schedule can be found
at https://www.python.org/dev/peps/pep-0569/

Update URLs to https inline with HSTS policy of python.org.