### PR TITLE
glibc: include C.UTF-8 locale in image

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -123,12 +123,14 @@ post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/lib/*.map
   safe_remove ${INSTALL}/var
 
-# add UTF-8 charmap for Generic (charmap is needed for installer)
-  if [ "${PROJECT}" = "Generic" ]; then
-    mkdir -p ${INSTALL}/usr/share/i18n/charmaps
-    cp -PR ${PKG_BUILD}/localedata/charmaps/UTF-8 ${INSTALL}/usr/share/i18n/charmaps
-    pigz --best --force ${INSTALL}/usr/share/i18n/charmaps/UTF-8
-  fi
+# add UTF-8 charmap
+  mkdir -p ${INSTALL}/usr/share/i18n/charmaps
+    cp -PR ${INSTALL}/.noinstall/charmaps/UTF-8.gz ${INSTALL}/usr/share/i18n/charmaps
+
+# compile locale definition C.UTF-8
+  mkdir -p ${INSTALL}/usr/share/locpath
+    I18NPATH=${INSTALL}/.noinstall \
+      localedef -c -i POSIX -f UTF-8 ${INSTALL}/usr/share/locpath/C.UTF-8 || test $? -le 1
 
   if [ ! "${GLIBC_LOCALES}" = yes ]; then
     safe_remove ${INSTALL}/usr/share/i18n/locales

--- a/packages/devel/glibc/profile.d/10-locale.conf
+++ b/packages/devel/glibc/profile.d/10-locale.conf
@@ -1,0 +1,5 @@
+# if env is set by locale addon then leave it set from there
+if [ -z "${LOCPATH}" ]; then
+  export LANG="C.UTF-8"
+  export LOCPATH="/usr/share/locpath"
+fi


### PR DESCRIPTION
Normally locale addon must be installed but users don't know that. Simplify this with adding default C.UTF-8 locale in image. Users can still install addon to use some other locale.

fixes Python3 error
UnicodeEncodeError: 'ascii' codec can't encode characters in position 40-41: ordinal not in range(128)

like
https://github.com/croneter/PlexKodiConnect/issues/1447
https://forum.libreelec.tv/thread/23116-pvr-recorder-unsuppored-locale/?postID=147453

from Kodi Python
  before
    sys.getdefaultencoding(): utf-8
    sys.getfilesystemencoding(): ascii
  after
    sys.getdefaultencoding(): utf-8
    sys.getfilesystemencoding(): utf-8