### PR TITLE
glibc: include C.UTF-8 locale in image

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -102,11 +102,6 @@ post_makeinstall_target() {
     cp -a ${INSTALL}/usr/share/i18n/locales ${INSTALL}/.noinstall
     mv ${INSTALL}/usr/share/i18n/charmaps ${INSTALL}/.noinstall
 
-  # Generic "installer" needs localedef to define drawing chars
-  if [ "${PROJECT}" != "Generic" ]; then
-    rm ${INSTALL}/usr/bin/localedef
-  fi
-
 # we are linking against ld.so, so symlink
   ln -sf $(basename ${INSTALL}/usr/lib/ld-*.so) ${INSTALL}/usr/lib/ld.so
 
@@ -123,12 +118,9 @@ post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/lib/*.map
   safe_remove ${INSTALL}/var
 
-# add UTF-8 charmap for Generic (charmap is needed for installer)
-  if [ "${PROJECT}" = "Generic" ]; then
-    mkdir -p ${INSTALL}/usr/share/i18n/charmaps
-    cp -PR ${PKG_BUILD}/localedata/charmaps/UTF-8 ${INSTALL}/usr/share/i18n/charmaps
-    pigz --best --force ${INSTALL}/usr/share/i18n/charmaps/UTF-8
-  fi
+# add UTF-8 charmap
+  mkdir -p ${INSTALL}/usr/share/i18n/charmaps
+    cp -PR ${INSTALL}/.noinstall/charmaps/UTF-8.gz ${INSTALL}/usr/share/i18n/charmaps
 
   if [ ! "${GLIBC_LOCALES}" = yes ]; then
     safe_remove ${INSTALL}/usr/share/i18n/locales

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -197,6 +197,7 @@ post_install() {
   enable_service shell.service
   enable_service show-version.service
   enable_service var.mount
+  enable_service locale.service
   listcontains "${FIRMWARE}" "rpi-eeprom" && enable_service rpi-flash-firmware.service
 
   # cron support

--- a/packages/sysutils/busybox/profile.d/10-locale.conf
+++ b/packages/sysutils/busybox/profile.d/10-locale.conf
@@ -1,0 +1,5 @@
+# don't overwrite value set by Locale Kodi addon
+if [ -z "${LOCPATH}" ]; then
+  export LANG="C.UTF-8"
+  export LOCPATH="/storage/.cache/locpath"
+fi

--- a/packages/sysutils/busybox/system.d/locale.service
+++ b/packages/sysutils/busybox/system.d/locale.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Compile locale definition files
+ConditionPathExists=!/storage/.cache/locpath
+ConditionPathExists=!/storage/.kodi/addons/service.locale/locpath
+Before=kodi.service
+
+[Service]
+Type=oneshot
+Environment=HOME=/storage
+Environment=I18NPATH=/usr/share/i18n
+ExecStartPre=/bin/mkdir /storage/.cache/locpath
+ExecStart=/usr/bin/localedef --quiet -i POSIX -f UTF-8 /storage/.cache/locpath/C.UTF-8
+SuccessExitStatus=0 1
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Normally Locale addon must be installed but users don't know that. Simplify this with adding default C.UTF-8 locale in image. Users can still install Locale addon to use some other locale.

fixes Python3 error
`UnicodeEncodeError: 'ascii' codec can't encode characters in position 40-41: ordinal not in range(128)`

like
https://github.com/croneter/PlexKodiConnect/issues/1447
https://forum.libreelec.tv/thread/23116-pvr-recorder-unsuppored-locale/?postID=147453

from Kodi Python
  before
```
    sys.getdefaultencoding(): utf-8
    sys.getfilesystemencoding(): ascii
```
  after
```
    sys.getdefaultencoding(): utf-8
    sys.getfilesystemencoding(): utf-8
```

from SSH console
  before
```
    # locale
    LANG=
    LC_CTYPE="POSIX"
    LC_NUMERIC="POSIX"
    LC_TIME="POSIX"
    LC_COLLATE="POSIX"
    LC_MONETARY="POSIX"
    LC_MESSAGES="POSIX"
    LC_PAPER="POSIX"
    LC_NAME="POSIX"
    LC_ADDRESS="POSIX"
    LC_TELEPHONE="POSIX"
    LC_MEASUREMENT="POSIX"
    LC_IDENTIFICATION="POSIX"
    LC_ALL=
```

  after
```
    # locale
    LANG=C.UTF-8
    LC_CTYPE="C.UTF-8"
    LC_NUMERIC="C.UTF-8"
    LC_TIME="C.UTF-8"
    LC_COLLATE="C.UTF-8"
    LC_MONETARY="C.UTF-8"
    LC_MESSAGES="C.UTF-8"
    LC_PAPER="C.UTF-8"
    LC_NAME="C.UTF-8"
    LC_ADDRESS="C.UTF-8"
    LC_TELEPHONE="C.UTF-8"
    LC_MEASUREMENT="C.UTF-8"
    LC_IDENTIFICATION="C.UTF-8"
    LC_ALL=
```