### PR TITLE
linux (RPi): revert to 5.10.27-7fb9d00

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="1a46874494146f470d7a61b0b6f4f15a07dd8b35"
-PKG_SHA256="84f8387b060478c3edf4d3b1e107c7b041eba6ef4075ede1a9f6d1ca4cae8c99"
+PKG_VERSION="1df55790fb191704c0ce630d4d0713a8beb43a7d"
+PKG_SHA256="9be26aae349616aa2cfa82c11f3188efb848e36d6ebe401f5d8682e376483d56"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="96110e96f1a82e236afb9a248258f1ef917766e9" # 5.10.33
-    PKG_SHA256="8815eff6547cfc4a895a5b01444d8a936c81306aaf3578360a5210798aa7405d"
+    PKG_VERSION="7fb9d006d3ff3baf2e205e0c85c4e4fd0a64fcd0" # 5.10.27
+    PKG_SHA256="e70ecd479ea323d00ed441f1888256687dec96b0f4098585b1646f2d5d930eff"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="1a46874494146f470d7a61b0b6f4f15a07dd8b35"
-PKG_SHA256="e3ba450885e1f0d5eb899ce3e7272342e613ee52ac9d1ff6217531f3e1c17a72"
+PKG_VERSION="1df55790fb191704c0ce630d4d0713a8beb43a7d"
+PKG_SHA256="b6163311508800ac82bae28260ea774ee35d92f86987a09cf0fc7880c61e9040"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"


### PR DESCRIPTION
This reverts the RPi kernel and firmware bumps of #5348 as the recent changes caused a regression - see https://github.com/LibreELEC/LibreELEC.tv/pull/5348#issuecomment-830673202

Kernel and firmware are now back to the versions used in LE10 beta2 and runtime test on RPi4 was fine