### PR TITLE
samba: update to 4.13.9

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.13.8"
-PKG_SHA256="3347c0c62cc5b1df1fc92d802282e809c354bfb4941a33c91a7fda3795efbf7f"
+PKG_VERSION="4.13.9"
+PKG_SHA256="b97a773ed3b4dae6d5ebd3e09337c897ae898b65f38abad550f852b594d4e07f"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Scheduled samba maintenance release (July and September are the next two scheduled maintenance releases of 4.13 - at which time there will be security releases till ~Mar-2022)

- https://wiki.samba.org/index.php/Release_Planning_for_Samba_4.13
- https://wiki.samba.org/index.php/Samba_Release_Planning

—-

update 4.13.8 (2021-04-29) to 4.13.9 (2021-05-11)
release notes: https://www.samba.org/samba/history/samba-4.13.9.html

This is the latest stable release of the Samba 4.13 release series.

Changes since 4.13.8
--------------------

o  Jeremy Allison <jra@samba.org>
   * BUG 14696: s3: smbd: SMB1 SMBsplwr doesn't send a reply packet on success.

o  Andrew Bartlett <abartlet@samba.org>
   * BUG 14689: Add documentation for dsdb_group_audit and dsdb_group_json_audit
     to "log level", synchronise "log level" in smb.conf with the code.

o  Ralph Boehme <slow@samba.org>
   * BUG 14672: Fix smbd panic when two clients open same file.
   * BUG 14675: Fix memory leak in the RPC server.
   * BUG 14679: s3: smbd: Fix deferred renames.

o  Samuel Cabrero <scabrero@samba.org>
   * BUG 14675: s3-iremotewinspool: Set the per-request memory context.

o  Volker Lendecke <vl@samba.org>
   * BUG 14675: rpc_server3: Fix a memleak for internal pipes.

o  Stefan Metzmacher <metze@samba.org>
   * BUG 11899: third_party: Update socket_wrapper to version 1.3.2.
   * BUG 14640: third_party: Update socket_wrapper to version 1.3.3.

o  Christof Schmitt <cs@samba.org>
   * BUG 14663: idmap_rfc2307 and idmap_nss return wrong mapping for uid/gid
     conflict.

o  Martin Schwenke <martin@meltin.net
   * BUG 14288: Fix the build on OmniOS.