### PR TITLE
libdrm: also install modeprint and proptest tests

### DIFF
--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -50,4 +50,6 @@ listcontains "${GRAPHIC_DRIVERS}" "etnaviv" &&
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
     cp -a ${PKG_BUILD}/.${TARGET_NAME}/tests/modetest/modetest ${INSTALL}/usr/bin/
+    cp -a ${PKG_BUILD}/.${TARGET_NAME}/tests/modeprint/modeprint ${INSTALL}/usr/bin/
+    cp -a ${PKG_BUILD}/.${TARGET_NAME}/tests/proptest/proptest ${INSTALL}/usr/bin/
 }


### PR DESCRIPTION
These test programs are already built but haven't been included in image yet.

They are quite handy when testing drm stuff and only add about 40k (uncompressed) to the image