### PR TITLE
Really show valid architectures on error.

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -765,11 +765,12 @@ check_arch() {
 
   if [ ! -e "$linux_config_dir/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf" ] &&
        ! ls "$linux_config_dir/"*/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf &>/dev/null; then
+       archs=$(ls $linux_config_dir/linux.*.conf $linux_config_dir/*/linux.*.conf 2>/dev/null | sed -e 's,.*/,,' -e 's/^linux\.\(.*\)\.conf/\1/')
     arch_err_msg="\n $dashes$dashes$dashes"
     arch_err_msg="${arch_err_msg}\n ERROR: Architecture not found, use a valid Architecture"
     arch_err_msg="${arch_err_msg}\n for your project or create a new config"
     arch_err_msg="${arch_err_msg}\n $dashes$dashes$dashes"
-    arch_err_msg="${arch_err_msg}\n\n Valid Architectures for your project: ${PROJECT}"
+    arch_err_msg="${arch_err_msg}\n\n Valid Architectures for your project: ${archs}"
 
     for arch in $linux_config_dir/*.conf $linux_config_dir/*/linux.$TARGET_ARCH.conf; do
       [[ ${arch} =~ .*\*.* ]] && continue #ignore unexpanded wildcard


### PR DESCRIPTION
When ARCH is not specified, the list of valid values was wrongly
showing the PROJECT value instead:

```
 LibreELEC.tv ((9.95.3))$ PROJECT=Rockchip DEVICE=RK3399 make image
 ./scripts/image mkimage

  =================================================================================
  ERROR: Architecture not found, use a valid Architecture
  for your project or create a new config
  =================================================================================

  Valid Architectures for your project: Rockchip
```

This makes it show more correctly:

```
  Valid Architectures for your project: aarch64
```