### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="2.6.14-Matrix"
-PKG_SHA256="f1756932e8cc602ce66c5db3bc1d44a442c01197c193561ca9248a405bd8bd86"
+PKG_VERSION="2.6.15-Matrix"
+PKG_SHA256="179b337c397ff484f25a936f8c50114a112d5107f6d3cf41b4e9fb92507525fd"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="1.7.1-Matrix"
-PKG_SHA256="4dc63c6c5bdad25881eeba800765d97c53b2583addf28e71bbcd67775452ecdb"
-PKG_REV="4"
+PKG_VERSION="1.7.2-Matrix"
+PKG_SHA256="405acfbcc510f96a48244168362213955357f95cd8b1b92fe1ce483213045bfb"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/peripheral.joystick"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="8.1.2-Matrix"
-PKG_SHA256="cea87ccdceee834c96d6b6887b78213ccf79890fec97436cbef17c57b9cdac15"
+PKG_VERSION="8.2.0-Matrix"
+PKG_SHA256="0109daa45d7b6450954b40d0b09dbef28818c551e9f0fea9943cfd06f0a7ec40"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
inputstream.adaptive 2.6.15
peripheral.joystick 1.7.2
pvr.mediaportal.tvserver 8.2.0

build-tested for RPi4