### PR TITLE
scripts/build: CMake: use Release build type if speed flag set

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -133,7 +133,11 @@ if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
   CMAKE_BUILD_TYPE="Debug"
   MESON_BUILD_TYPE="debug"
 else
-  CMAKE_BUILD_TYPE="MinSizeRel"
+  if flag_enabled "speed" "no"; then
+    CMAKE_BUILD_TYPE="Release"
+  else
+    CMAKE_BUILD_TYPE="MinSizeRel"
+  fi
   MESON_BUILD_TYPE="plain"
 fi
 


### PR DESCRIPTION
If package is built using CMake, setting `speed` flag does not affect resulting binary. With `speed` flag set, CMake should use `Release` and not `MinSizeRel`.

The only affected package is Kodi, uncompressed size increases significantly, i.e. almost 8MiB (>60%) in my builds.

Probably something for LE11 and due to size increase the `speed` flag may need to be dropped for Kodi.