### PR TITLE
gperftools: fix for release files

### DIFF
--- a/packages/devel/gperftools/package.mk
+++ b/packages/devel/gperftools/package.mk
@@ -10,4 +10,4 @@ PKG_URL="https://github.com/gperftools/gperftools/releases/download/gperftools-$
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Google Performance Tools"
 
-PKG_CMAKE_OPTS_TARGET="-Dgperftools_build_minimal=ON -DGPERFTOOLS_BUILD_STATIC=OFF"
+PKG_CONFIGURE_OPTS_TARGET="--enable-minimal --disable-debugalloc --disable-static"


### PR DESCRIPTION
release files != git .... 
gperftools release files contain no cmake, just the source dump of the release files contain cmake
reverted back to configure because we want to use release files :)
@kszaq can you check if 9.2 works ? 