### PR TITLE
multimedia-tools: update addon to 115

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmediainfo"
-PKG_VERSION="20.09"
-PKG_SHA256="d07ce857330a9f9eedc4e5748f8022af1e9540e88a732d4e45c818c8ec4dd196"
+PKG_VERSION="21.03"
+PKG_SHA256="56b7e9abf80cba48032165cd7a46fd8d43dd63e3af35765f66c3f134caaca4ca"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/libmediainfo/${PKG_VERSION}/libmediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libzen/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libzen/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libzen"
-PKG_VERSION="0.4.38"
-PKG_SHA256="b8825b3190b3a31d8d362547cfa26a3c10e8c063df2d87e4a05758d6b756c8ab"
+PKG_VERSION="0.4.39"
+PKG_SHA256="cded5d7774294e7d5b42768ceb285243709b6e99eec6e980a3cf7f0890dbb622"
 PKG_LICENSE="GPL"
-PKG_SITE="http://mediaarea.net/en/MediaInfo/"
-PKG_URL="http://mediaarea.net/download/source/libzen/${PKG_VERSION}/libzen_${PKG_VERSION}.tar.xz"
+PKG_SITE="https://mediaarea.net/en/MediaInfo/"
+PKG_URL="https://mediaarea.net/download/source/libzen/${PKG_VERSION}/libzen_${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files"
 PKG_TOOLCHAIN="manual"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mediainfo"
-PKG_VERSION="20.09"
-PKG_SHA256="39327ef83caa38a96114d1b90654012b9ef727538fe82c37dd67aea2cf4f0f67"
+PKG_VERSION="21.03"
+PKG_SHA256="de50ca0b2c607b8999d3c9e542d27c97030a59f31859b612335315be6850021e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/mediainfo/${PKG_VERSION}/mediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpg123"
-PKG_VERSION="1.26.4"
-PKG_SHA256="081991540df7a666b29049ad870f293cfa28863b36488ab4d58ceaa7b5846454"
+PKG_VERSION="1.27.2"
+PKG_SHA256="52f6ceb962c05db0c043bb27acf5a721381f5f356ac4610e5221f50293891b04"
 PKG_LICENSE="LGPLv2"
 PKG_SITE="http://www.mpg123.org/"
 PKG_URL="http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpv-drmprime"
-PKG_VERSION="0.33.0"
-PKG_SHA256="f1b9baf5dc2eeaf376597c28a6281facf6ed98ff3d567e3955c95bf2459520b4"
+PKG_VERSION="0.33.1"
+PKG_SHA256="100a116b9f23bdcda3a596e9f26be3a69f166a4f1d00910d1789b6571c46f3a9"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mpv.io/"
 PKG_URL="https://github.com/mpv-player/mpv/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squeezelite"
-PKG_VERSION="78fef68d39704753cb7101231a8d3bc29f2aa2c9" # 2021-01-03 # 1.9.8.1315
-PKG_SHA256="e4dce15d6f8968150d9535cb4e95017b4097d2282a1da1c87b3c7651dbca40c3"
+PKG_VERSION="556de5689d27b4440adbfeb3c3012da02dbf438e" # 2021-05-14 # 1.9.9.1386
+PKG_SHA256="8de5348b0ee23f4a24371dad589c887d083194e24a0e526585417edcd34a4d86"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ralph-irving/squeezelite"
 PKG_URL="https://github.com/ralph-irving/squeezelite/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/multimedia-tools/changelog.txt
+++ b/packages/addons/tools/multimedia-tools/changelog.txt
@@ -1,3 +1,11 @@
+115
+- libmediainfo: update to 21.03
+- libzen: update to 0.4.39
+- mediainfo: update to 21.03
+- mpg123: update to 1.27.2
+- mpv-drmprime: update to 0.33.1
+- squeezelite: update to 2021-05-13 (1.9.9.1386)
+
 114
 - squeezelite: update to 2021-01-03 (1.9.8.1315)
 

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="114"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- libmediainfo: update to 21.03
- libzen: update to 0.4.39
- mediainfo: update to 21.03
- mpg123: update to 1.27.2
- mpv-drmprime: update to 0.33.1
- squeezelite: update to 2021-05-13 (1.9.9.1386)