### PR TITLE
busybox: kernel-overlays-setup: log depmod to /dev/kmsg

### DIFF
--- a/packages/sysutils/busybox/scripts/kernel-overlays-setup
+++ b/packages/sysutils/busybox/scripts/kernel-overlays-setup
@@ -70,7 +70,7 @@ if [ -d "${OVERLAY_CONFIG_DIR}" ] ; then
 
   if [ "yes" = "$GOT_MODULE_OVERLAY" ] ; then
     log "running depmod"
-    /usr/sbin/depmod -a
+    /usr/sbin/depmod -a >/dev/kmsg 2>&1
   fi
 fi
 


### PR DESCRIPTION
In forum thread https://forum.libreelec.tv/thread/23927-version-9-95-2-de-librelec/ some users are annoyed by the depmod error message due to the stale nvidia.ko symbolic link.

Log depmod messages to /dev/kmsg too. On real errors they will be visible in dmesg/journal.

It is possible that kmsg rate limit is triggered with larger output but I see no support impact here. 