### PR TITLE
prep for 9.2.7 widevine release

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="741464546af6b34c5532b83dccb6a03ba0b941a5"
-PKG_SHA256="e43cc2ad4123638ad0a543151e9594bbb137c9c18d6893bf7046d9da96b729e2"
+PKG_VERSION="67f0b7ffbdee07283c751190bf6bda979ac28b9f"
+PKG_SHA256="c0313131cd794d27fceb297270c0cd23e91e64308f968aa69e5736f97e83686f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/$PKG_VERSION.tar.gz"

--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -43,6 +43,10 @@ else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf
 fi
 
+if [ -f /usr/lib/libtcmalloc_minimal.so ] ; then
+  echo "LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so" >> /run/libreelec/kodi.conf
+fi
+
 if [ -f /storage/.config/kodi.conf ] ; then
   cat /storage/.config/kodi.conf >>/run/libreelec/kodi.conf
 fi


### PR DESCRIPTION
This adds the LD_PRELOAD content to kodi.conf and also bumps the settings add-on to pick-up one minor fix and the dtflags stats change (both are backports of things we've run in master for some time).