### PR TITLE
Rockchip: RK3399pro: add initial support for “Radxa ROCK Pi N10”

### DIFF
--- a/projects/Rockchip/README.md
+++ b/projects/Rockchip/README.md
@@ -23,6 +23,7 @@ This project is for Rockchip SoC devices
 * [Orange Pi RK3399](devices/RK3399)
 * [PINE64 RockPro64](devices/RK3399)
 * [Radxa ROCK Pi 4](devices/RK3399)
+* [Radxa ROCK Pi N10](devices/RK3399)
 * [ROC-RK3399-PC](devices/RK3399)
 * [Rockchip Sapphire Board](devices/RK3399)
 

--- a/projects/Rockchip/bootloader/release
+++ b/projects/Rockchip/bootloader/release
@@ -17,4 +17,4 @@ mkdir -p "${DSTDIR}"
     fi
   fi
 
-  cp -a "${SRCDIR}"/${DEVICE,,}-*.dtb "${DSTDIR}"
+  cp -a "${SRCDIR}"/${DEVICE,,}*.dtb "${DSTDIR}"

--- a/projects/Rockchip/devices/RK3399/README.md
+++ b/projects/Rockchip/devices/RK3399/README.md
@@ -11,6 +11,7 @@ This is a SoC device for RK3399
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=orangepi make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock960 make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-4 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-n10 make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rockpro64 make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=roc-pc make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=sapphire make image`

--- a/projects/Rockchip/patches/linux/default/linux-0030-regulator-from-list.patch
+++ b/projects/Rockchip/patches/linux/default/linux-0030-regulator-from-list.patch
@@ -1,0 +1,656 @@
+From 914df8faa7d6fdff7afa1fbde888a2bed8d72fa7 Mon Sep 17 00:00:00 2001
+From: Joseph Chen <chenjh@rock-chips.com>
+Date: Wed, 21 Apr 2021 18:03:38 -0300
+Subject: [PATCH] regulator: fan53555: Add TCS4525 DCDC support
+
+TCS4525 main features:
+
+- 2.7V to 5.5V Input Voltage Range;
+- 3MHz Constant Switching Frequency;
+- 5A Available Load Current;
+- Programmable Output Voltage: 0.6V to 1.4V in 6.25mV Steps;
+- PFM/PWM Operation for Optimum Increased Efficiency;
+
+Signed-off-by: Joseph Chen <chenjh@rock-chips.com>
+[Ezequiel: Forward port]
+Signed-off-by: Ezequiel Garcia <ezequiel@collabora.com>
+Link: https://lore.kernel.org/r/20210421210338.43819-3-ezequiel@collabora.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/regulator/fan53555.c | 136 +++++++++++++++++++++++++++++++----
+ 1 file changed, 122 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/regulator/fan53555.c b/drivers/regulator/fan53555.c
+index aa426183b6a118..f3918f03aaf3df 100644
+--- a/drivers/regulator/fan53555.c
++++ b/drivers/regulator/fan53555.c
+@@ -24,6 +24,12 @@
+ /* Voltage setting */
+ #define FAN53555_VSEL0		0x00
+ #define FAN53555_VSEL1		0x01
++
++#define TCS4525_VSEL0		0x11
++#define TCS4525_VSEL1		0x10
++#define TCS4525_TIME		0x13
++#define TCS4525_COMMAND		0x14
++
+ /* Control register */
+ #define FAN53555_CONTROL	0x02
+ /* IC Type */
+@@ -49,11 +55,20 @@
+ 
+ #define FAN53555_NVOLTAGES	64	/* Numbers of voltages */
+ #define FAN53526_NVOLTAGES	128
++#define TCS4525_NVOLTAGES	127	/* Numbers of voltages */
++
++#define TCS_VSEL_NSEL_MASK	0x7f
++#define TCS_VSEL0_MODE		(1 << 7)
++#define TCS_VSEL1_MODE		(1 << 6)
++
++#define TCS_SLEW_SHIFT		3
++#define TCS_SLEW_MASK		(0x3 < 3)
+ 
+ enum fan53555_vendor {
+ 	FAN53526_VENDOR_FAIRCHILD = 0,
+ 	FAN53555_VENDOR_FAIRCHILD,
+ 	FAN53555_VENDOR_SILERGY,
++	FAN53555_VENDOR_TCS,
+ };
+ 
+ enum {
+@@ -106,6 +121,11 @@ struct fan53555_device_info {
+ 	unsigned int mode_mask;
+ 	/* Sleep voltage cache */
+ 	unsigned int sleep_vol_cache;
++	/* Slew rate */
++	unsigned int slew_reg;
++	unsigned int slew_mask;
++	unsigned int slew_shift;
++	unsigned int slew_rate;
+ };
+ 
+ static int fan53555_set_suspend_voltage(struct regulator_dev *rdev, int uV)
+@@ -189,13 +209,37 @@ static const int slew_rates[] = {
+ 	  500,
+ };
+ 
++static const int tcs_slew_rates[] = {
++	18700,
++	 9300,
++	 4600,
++	 2300,
++};
++
+ static int fan53555_set_ramp(struct regulator_dev *rdev, int ramp)
+ {
+ 	struct fan53555_device_info *di = rdev_get_drvdata(rdev);
+ 	int regval = -1, i;
++	const int *slew_rate_t;
++	int slew_rate_n;
+ 
+-	for (i = 0; i < ARRAY_SIZE(slew_rates); i++) {
+-		if (ramp <= slew_rates[i])
++	switch (di->vendor) {
++	case FAN53526_VENDOR_FAIRCHILD:
++	case FAN53555_VENDOR_FAIRCHILD:
++	case FAN53555_VENDOR_SILERGY:
++		slew_rate_t = slew_rates;
++		slew_rate_n = ARRAY_SIZE(slew_rates);
++		break;
++	case FAN53555_VENDOR_TCS:
++		slew_rate_t = tcs_slew_rates;
++		slew_rate_n = ARRAY_SIZE(tcs_slew_rates);
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	for (i = 0; i < slew_rate_n; i++) {
++		if (ramp <= slew_rate_t[i])
+ 			regval = i;
+ 		else
+ 			break;
+@@ -206,8 +250,8 @@ static int fan53555_set_ramp(struct regulator_dev *rdev, int ramp)
+ 		return -EINVAL;
+ 	}
+ 
+-	return regmap_update_bits(rdev->regmap, FAN53555_CONTROL,
+-				  CTL_SLEW_MASK, regval << CTL_SLEW_SHIFT);
++	return regmap_update_bits(rdev->regmap, di->slew_reg,
++				  di->slew_mask, regval << di->slew_shift);
+ }
+ 
+ static const struct regulator_ops fan53555_regulator_ops = {
+@@ -292,7 +336,9 @@ static int fan53555_voltages_setup_fairchild(struct fan53555_device_info *di)
+ 			"Chip ID %d not supported!\n", di->chip_id);
+ 		return -EINVAL;
+ 	}
+-
++	di->slew_reg = FAN53555_CONTROL;
++	di->slew_mask = CTL_SLEW_MASK;
++	di->slew_shift = CTL_SLEW_SHIFT;
+ 	di->vsel_count = FAN53555_NVOLTAGES;
+ 
+ 	return 0;
+@@ -312,12 +358,29 @@ static int fan53555_voltages_setup_silergy(struct fan53555_device_info *di)
+ 			"Chip ID %d not supported!\n", di->chip_id);
+ 		return -EINVAL;
+ 	}
+-
++	di->slew_reg = FAN53555_CONTROL;
++	di->slew_reg = FAN53555_CONTROL;
++	di->slew_mask = CTL_SLEW_MASK;
++	di->slew_shift = CTL_SLEW_SHIFT;
+ 	di->vsel_count = FAN53555_NVOLTAGES;
+ 
+ 	return 0;
+ }
+ 
++static int fan53555_voltages_setup_tcs(struct fan53555_device_info *di)
++{
++	di->slew_reg = TCS4525_TIME;
++	di->slew_mask = TCS_SLEW_MASK;
++	di->slew_shift = TCS_SLEW_MASK;
++
++	/* Init voltage range and step */
++	di->vsel_min = 600000;
++	di->vsel_step = 6250;
++	di->vsel_count = TCS4525_NVOLTAGES;
++
++	return 0;
++}
++
+ /* For 00,01,03,05 options:
+  * VOUT = 0.60V + NSELx * 10mV, from 0.60 to 1.23V.
+  * For 04 option:
+@@ -329,17 +392,41 @@ static int fan53555_device_setup(struct fan53555_device_info *di,
+ 	int ret = 0;
+ 
+ 	/* Setup voltage control register */
+-	switch (pdata->sleep_vsel_id) {
+-	case FAN53555_VSEL_ID_0:
+-		di->sleep_reg = FAN53555_VSEL0;
+-		di->vol_reg = FAN53555_VSEL1;
++	switch (di->vendor) {
++	case FAN53526_VENDOR_FAIRCHILD:
++	case FAN53555_VENDOR_FAIRCHILD:
++	case FAN53555_VENDOR_SILERGY:
++		switch (pdata->sleep_vsel_id) {
++		case FAN53555_VSEL_ID_0:
++			di->sleep_reg = FAN53555_VSEL0;
++			di->vol_reg = FAN53555_VSEL1;
++			break;
++		case FAN53555_VSEL_ID_1:
++			di->sleep_reg = FAN53555_VSEL1;
++			di->vol_reg = FAN53555_VSEL0;
++			break;
++		default:
++			dev_err(di->dev, "Invalid VSEL ID!\n");
++			return -EINVAL;
++		}
+ 		break;
+-	case FAN53555_VSEL_ID_1:
+-		di->sleep_reg = FAN53555_VSEL1;
+-		di->vol_reg = FAN53555_VSEL0;
++	case FAN53555_VENDOR_TCS:
++		switch (pdata->sleep_vsel_id) {
++		case FAN53555_VSEL_ID_0:
++			di->sleep_reg = TCS4525_VSEL0;
++			di->vol_reg = TCS4525_VSEL1;
++			break;
++		case FAN53555_VSEL_ID_1:
++			di->sleep_reg = TCS4525_VSEL1;
++			di->vol_reg = TCS4525_VSEL0;
++			break;
++		default:
++			dev_err(di->dev, "Invalid VSEL ID!\n");
++			return -EINVAL;
++		}
+ 		break;
+ 	default:
+-		dev_err(di->dev, "Invalid VSEL ID!\n");
++		dev_err(di->dev, "vendor %d not supported!\n", di->vendor);
+ 		return -EINVAL;
+ 	}
+ 
+@@ -362,6 +449,18 @@ static int fan53555_device_setup(struct fan53555_device_info *di,
+ 		di->mode_reg = di->vol_reg;
+ 		di->mode_mask = VSEL_MODE;
+ 		break;
++	case FAN53555_VENDOR_TCS:
++		di->mode_reg = TCS4525_COMMAND;
++
++		switch (pdata->sleep_vsel_id) {
++		case FAN53555_VSEL_ID_0:
++			di->mode_mask = TCS_VSEL1_MODE;
++			break;
++		case FAN53555_VSEL_ID_1:
++			di->mode_mask = TCS_VSEL0_MODE;
++			break;
++		}
++		break;
+ 	default:
+ 		dev_err(di->dev, "vendor %d not supported!\n", di->vendor);
+ 		return -EINVAL;
+@@ -378,6 +477,9 @@ static int fan53555_device_setup(struct fan53555_device_info *di,
+ 	case FAN53555_VENDOR_SILERGY:
+ 		ret = fan53555_voltages_setup_silergy(di);
+ 		break;
++	case FAN53555_VENDOR_TCS:
++		ret = fan53555_voltages_setup_tcs(di);
++		break;
+ 	default:
+ 		dev_err(di->dev, "vendor %d not supported!\n", di->vendor);
+ 		return -EINVAL;
+@@ -449,6 +551,9 @@ static const struct of_device_id __maybe_unused fan53555_dt_ids[] = {
+ 	}, {
+ 		.compatible = "silergy,syr828",
+ 		.data = (void *)FAN53555_VENDOR_SILERGY,
++	}, {
++		.compatible = "tcs,tcs4525",
++		.data = (void *)FAN53555_VENDOR_TCS
+ 	},
+ 	{ }
+ };
+@@ -554,6 +659,9 @@ static const struct i2c_device_id fan53555_id[] = {
+ 	}, {
+ 		.name = "syr828",
+ 		.driver_data = FAN53555_VENDOR_SILERGY
++	}, {
++		.name = "tcs4525",
++		.driver_data = FAN53555_VENDOR_TCS
+ 	},
+ 	{ },
+ };
+--
+2.29.1
+
+
+From:   Peter Geis <pgwipeout@gmail.com>
+Subject: [PATCH 0/3] regulator: fan53555: tcs4525 fix and cleanup
+Date:   Tue, 11 May 2021 17:13:32 -0400
+
+The tcs4525 voltage calculation is incorrect, which leads to a deadlock
+on the rk3566-quartz64 board when loading cpufreq.
+Fix the voltage calculation to correct the deadlock.
+While we are at it, add a safety check and clean up the function names
+to be more accurate.
+
+Peter Geis (3):
+  regulator: fan53555: fix TCS4525 voltage calulation
+  regulator: fan53555: only bind tcs4525 to correct chip id
+  regulator: fan53555: fix tcs4525 function names
+
+ drivers/regulator/fan53555.c | 44 ++++++++++++++++++++++--------------
+ 1 file changed, 27 insertions(+), 17 deletions(-)
+
+-- 
+2.25.1
+
+
+From:   Peter Geis <pgwipeout@gmail.com>
+Subject: [PATCH 1/3] regulator: fan53555: fix TCS4525 voltage calulation
+Date:   Tue, 11 May 2021 17:13:33 -0400
+
+The TCS4525 has 128 voltage steps. With the calculation set to 127 the
+most significant bit is disregarded which leads to a miscalculation of
+the voltage by about 200mv.
+
+Fix the calculation to end deadlock on the rk3566-quartz64 which uses
+this as the cpu regulator.
+
+Fixes: 914df8faa7d6 ("regulator: fan53555: Add TCS4525 DCDC support")
+Signed-off-by: Peter Geis <pgwipeout@gmail.com>
+---
+ drivers/regulator/fan53555.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/regulator/fan53555.c b/drivers/regulator/fan53555.c
+index f3918f03aaf3..26f06f685b1b 100644
+--- a/drivers/regulator/fan53555.c
++++ b/drivers/regulator/fan53555.c
+@@ -55,7 +55,6 @@
+ 
+ #define FAN53555_NVOLTAGES	64	/* Numbers of voltages */
+ #define FAN53526_NVOLTAGES	128
+-#define TCS4525_NVOLTAGES	127	/* Numbers of voltages */
+ 
+ #define TCS_VSEL_NSEL_MASK	0x7f
+ #define TCS_VSEL0_MODE		(1 << 7)
+@@ -376,7 +375,7 @@ static int fan53555_voltages_setup_tcs(struct fan53555_device_info *di)
+ 	/* Init voltage range and step */
+ 	di->vsel_min = 600000;
+ 	di->vsel_step = 6250;
+-	di->vsel_count = TCS4525_NVOLTAGES;
++	di->vsel_count = FAN53526_NVOLTAGES;
+ 
+ 	return 0;
+ }
+-- 
+2.25.1
+
+
+From:   Peter Geis <pgwipeout@gmail.com>
+Subject: [PATCH 2/3] regulator: fan53555: only bind tcs4525 to correct chip id
+Date:   Tue, 11 May 2021 17:13:34 -0400
+
+The tcs4525 regulator has a chip id of <12>.
+Only allow the driver to bind to the correct chip id for safety, in
+accordance with the other supported devices.
+
+Signed-off-by: Peter Geis <pgwipeout@gmail.com>
+---
+ drivers/regulator/fan53555.c | 25 ++++++++++++++++++-------
+ 1 file changed, 18 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/regulator/fan53555.c b/drivers/regulator/fan53555.c
+index 26f06f685b1b..16f28f9df6a1 100644
+--- a/drivers/regulator/fan53555.c
++++ b/drivers/regulator/fan53555.c
+@@ -89,6 +89,10 @@ enum {
+ 	FAN53555_CHIP_ID_08 = 8,
+ };
+ 
++enum {
++	TCS4525_CHIP_ID_12 = 12,
++};
++
+ /* IC mask revision */
+ enum {
+ 	FAN53555_CHIP_REV_00 = 0x3,
+@@ -368,14 +372,21 @@ static int fan53555_voltages_setup_silergy(struct fan53555_device_info *di)
+ 
+ static int fan53555_voltages_setup_tcs(struct fan53555_device_info *di)
+ {
+-	di->slew_reg = TCS4525_TIME;
+-	di->slew_mask = TCS_SLEW_MASK;
+-	di->slew_shift = TCS_SLEW_MASK;
++	switch (di->chip_id) {
++	case TCS4525_CHIP_ID_12:
++		di->slew_reg = TCS4525_TIME;
++		di->slew_mask = TCS_SLEW_MASK;
++		di->slew_shift = TCS_SLEW_MASK;
+ 
+-	/* Init voltage range and step */
+-	di->vsel_min = 600000;
+-	di->vsel_step = 6250;
+-	di->vsel_count = FAN53526_NVOLTAGES;
++		/* Init voltage range and step */
++		di->vsel_min = 600000;
++		di->vsel_step = 6250;
++		di->vsel_count = FAN53526_NVOLTAGES;
++		break;
++	default:
++		dev_err(di->dev, "Chip ID %d not supported!\n", di->chip_id);
++		return -EINVAL;
++	}
+ 
+ 	return 0;
+ }
+-- 
+2.25.1
+
+
+From:   Peter Geis <pgwipeout@gmail.com>
+Subject: [PATCH 3/3] regulator: fan53555: fix tcs4525 function names
+Date:   Tue, 11 May 2021 17:13:35 -0400
+
+The tcs4525 is based off the fan53526.
+Rename the tcs4525 functions to align with this.
+
+Signed-off-by: Peter Geis <pgwipeout@gmail.com>
+---
+ drivers/regulator/fan53555.c | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/regulator/fan53555.c b/drivers/regulator/fan53555.c
+index 16f28f9df6a1..2695be617373 100644
+--- a/drivers/regulator/fan53555.c
++++ b/drivers/regulator/fan53555.c
+@@ -67,7 +67,7 @@ enum fan53555_vendor {
+ 	FAN53526_VENDOR_FAIRCHILD = 0,
+ 	FAN53555_VENDOR_FAIRCHILD,
+ 	FAN53555_VENDOR_SILERGY,
+-	FAN53555_VENDOR_TCS,
++	FAN53526_VENDOR_TCS,
+ };
+ 
+ enum {
+@@ -233,7 +233,7 @@ static int fan53555_set_ramp(struct regulator_dev *rdev, int ramp)
+ 		slew_rate_t = slew_rates;
+ 		slew_rate_n = ARRAY_SIZE(slew_rates);
+ 		break;
+-	case FAN53555_VENDOR_TCS:
++	case FAN53526_VENDOR_TCS:
+ 		slew_rate_t = tcs_slew_rates;
+ 		slew_rate_n = ARRAY_SIZE(tcs_slew_rates);
+ 		break;
+@@ -370,7 +370,7 @@ static int fan53555_voltages_setup_silergy(struct fan53555_device_info *di)
+ 	return 0;
+ }
+ 
+-static int fan53555_voltages_setup_tcs(struct fan53555_device_info *di)
++static int fan53526_voltages_setup_tcs(struct fan53555_device_info *di)
+ {
+ 	switch (di->chip_id) {
+ 	case TCS4525_CHIP_ID_12:
+@@ -420,7 +420,7 @@ static int fan53555_device_setup(struct fan53555_device_info *di,
+ 			return -EINVAL;
+ 		}
+ 		break;
+-	case FAN53555_VENDOR_TCS:
++	case FAN53526_VENDOR_TCS:
+ 		switch (pdata->sleep_vsel_id) {
+ 		case FAN53555_VSEL_ID_0:
+ 			di->sleep_reg = TCS4525_VSEL0;
+@@ -459,7 +459,7 @@ static int fan53555_device_setup(struct fan53555_device_info *di,
+ 		di->mode_reg = di->vol_reg;
+ 		di->mode_mask = VSEL_MODE;
+ 		break;
+-	case FAN53555_VENDOR_TCS:
++	case FAN53526_VENDOR_TCS:
+ 		di->mode_reg = TCS4525_COMMAND;
+ 
+ 		switch (pdata->sleep_vsel_id) {
+@@ -487,8 +487,8 @@ static int fan53555_device_setup(struct fan53555_device_info *di,
+ 	case FAN53555_VENDOR_SILERGY:
+ 		ret = fan53555_voltages_setup_silergy(di);
+ 		break;
+-	case FAN53555_VENDOR_TCS:
+-		ret = fan53555_voltages_setup_tcs(di);
++	case FAN53526_VENDOR_TCS:
++		ret = fan53526_voltages_setup_tcs(di);
+ 		break;
+ 	default:
+ 		dev_err(di->dev, "vendor %d not supported!\n", di->vendor);
+@@ -563,7 +563,7 @@ static const struct of_device_id __maybe_unused fan53555_dt_ids[] = {
+ 		.data = (void *)FAN53555_VENDOR_SILERGY,
+ 	}, {
+ 		.compatible = "tcs,tcs4525",
+-		.data = (void *)FAN53555_VENDOR_TCS
++		.data = (void *)FAN53526_VENDOR_TCS
+ 	},
+ 	{ }
+ };
+@@ -671,7 +671,7 @@ static const struct i2c_device_id fan53555_id[] = {
+ 		.driver_data = FAN53555_VENDOR_SILERGY
+ 	}, {
+ 		.name = "tcs4525",
+-		.driver_data = FAN53555_VENDOR_TCS
++		.driver_data = FAN53526_VENDOR_TCS
+ 	},
+ 	{ },
+ };
+-- 
+2.25.1
+
+
+Date:   Wed, 26 May 2021 16:23:46 +0000
+From:   Rudi Heitbaum <rudi@heitbaum.com>
+Subject: [PATCH v2] regulator: fan53555: add tcs4526
+
+
+For rk3399pro boards the tcs4526 regulator supports the vdd_gpu
+regulator. The tcs4526 regulator has a chip id of <0>.
+Add the compatibile tcs,tcs4526  
+
+without this patch, the dmesg output is:
+  fan53555-regulator 0-0010: Chip ID 0 not supported!
+  fan53555-regulator 0-0010: Failed to setup device!
+  fan53555-regulator: probe of 0-0010 failed with error -22
+with this patch, the dmesg output is:
+  vdd_gpu: supplied by vcc5v0_sys
+
+The regulators are described as:
+- Dedicated power management IC TCS4525
+- Lithium battery protection chip TCS4526
+
+This has been tested with a Radxa Rock Pi N10.
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ drivers/regulator/fan53555.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/regulator/fan53555.c b/drivers/regulator/fan53555.c
+index 2695be617373..ddab9359ea20 100644
+--- a/drivers/regulator/fan53555.c
++++ b/drivers/regulator/fan53555.c
+@@ -93,6 +93,10 @@ enum {
+ 	TCS4525_CHIP_ID_12 = 12,
+ };
+ 
++enum {
++	TCS4526_CHIP_ID_00 = 0,
++};
++
+ /* IC mask revision */
+ enum {
+ 	FAN53555_CHIP_REV_00 = 0x3,
+@@ -374,6 +375,7 @@ static int fan53555_voltages_setup_silergy(struct fan53555_device_info *di)
+ {
+ 	switch (di->chip_id) {
+ 	case TCS4525_CHIP_ID_12:
++	case TCS4526_CHIP_ID_00:
+ 		di->slew_reg = TCS4525_TIME;
+ 		di->slew_mask = TCS_SLEW_MASK;
+ 		di->slew_shift = TCS_SLEW_MASK;
+@@ -564,6 +566,9 @@ static const struct of_device_id __maybe_unused fan53555_dt_ids[] = {
+ 	}, {
+ 		.compatible = "tcs,tcs4525",
+ 		.data = (void *)FAN53526_VENDOR_TCS
++	}, {
++		.compatible = "tcs,tcs4526",
++		.data = (void *)FAN53526_VENDOR_TCS
+ 	},
+ 	{ }
+ };
+@@ -672,6 +677,9 @@ static const struct i2c_device_id fan53555_id[] = {
+ 	}, {
+ 		.name = "tcs4525",
+ 		.driver_data = FAN53526_VENDOR_TCS
++	}, {
++		.name = "tcs4526",
++		.driver_data = FAN53526_VENDOR_TCS
+ 	},
+ 	{ },
+ };
+-- 
+2.29.2
+
+
+From:   Axel Lin <axel.lin@ingics.com>
+Subject: [PATCH 1/2] regulator: fan53555: Fix slew_shift setting for tcs4525
+Date:   Mon, 17 May 2021 09:03:17 +0800
+
+Fix trivial copy-paste mistake.
+
+Signed-off-by: Axel Lin <axel.lin@ingics.com>
+---
+ drivers/regulator/fan53555.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/regulator/fan53555.c b/drivers/regulator/fan53555.c
+index 2695be617373..d582ef3a3aeb 100644
+--- a/drivers/regulator/fan53555.c
++++ b/drivers/regulator/fan53555.c
+@@ -376,7 +376,7 @@ static int fan53526_voltages_setup_tcs(struct fan53555_device_info *di)
+ 	case TCS4525_CHIP_ID_12:
+ 		di->slew_reg = TCS4525_TIME;
+ 		di->slew_mask = TCS_SLEW_MASK;
+-		di->slew_shift = TCS_SLEW_MASK;
++		di->slew_shift = TCS_SLEW_SHIFT;
+ 
+ 		/* Init voltage range and step */
+ 		di->vsel_min = 600000;
+-- 
+2.25.1
+
+
+From:   Axel Lin <axel.lin@ingics.com>
+Subject: [PATCH 2/2] regulator: fan53555: Cleanup unused define and redundant assignment
+Date:   Mon, 17 May 2021 09:03:18 +0800
+
+TCS_VSEL_NSEL_MASK is not used so remove it.
+Also remove redundant assignment for di->slew_reg.
+
+Signed-off-by: Axel Lin <axel.lin@ingics.com>
+---
+ drivers/regulator/fan53555.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/regulator/fan53555.c b/drivers/regulator/fan53555.c
+index d582ef3a3aeb..f3f49cf3731b 100644
+--- a/drivers/regulator/fan53555.c
++++ b/drivers/regulator/fan53555.c
+@@ -56,7 +56,6 @@
+ #define FAN53555_NVOLTAGES	64	/* Numbers of voltages */
+ #define FAN53526_NVOLTAGES	128
+ 
+-#define TCS_VSEL_NSEL_MASK	0x7f
+ #define TCS_VSEL0_MODE		(1 << 7)
+ #define TCS_VSEL1_MODE		(1 << 6)
+ 
+@@ -362,7 +361,6 @@ static int fan53555_voltages_setup_silergy(struct fan53555_device_info *di)
+ 		return -EINVAL;
+ 	}
+ 	di->slew_reg = FAN53555_CONTROL;
+-	di->slew_reg = FAN53555_CONTROL;
+ 	di->slew_mask = CTL_SLEW_MASK;
+ 	di->slew_shift = CTL_SLEW_SHIFT;
+ 	di->vsel_count = FAN53555_NVOLTAGES;
+-- 
+2.25.1
+
+
+From:   Axel Lin <axel.lin@ingics.com>
+Subject: [PATCH 1/2] regulator: fan53555: Fix missing slew_reg/mask/shift settings for FAN53526
+Date:   Tue, 25 May 2021 20:40:16 +0800
+
+The di->slew_reg/di->slew_mask/di->slew_shift was not set in current code,
+fix it.
+
+Fixes: f2a9eb975ab2 ("regulator: fan53555: Add support for FAN53526")
+Signed-off-by: Axel Lin <axel.lin@ingics.com>
+---
+ drivers/regulator/fan53555.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/regulator/fan53555.c b/drivers/regulator/fan53555.c
+index f3f49cf3731b..9770a4df83d4 100644
+--- a/drivers/regulator/fan53555.c
++++ b/drivers/regulator/fan53555.c
+@@ -296,6 +296,9 @@ static int fan53526_voltages_setup_fairchild(struct fan53555_device_info *di)
+ 		return -EINVAL;
+ 	}
+ 
++	di->slew_reg = FAN53555_CONTROL;
++	di->slew_mask = CTL_SLEW_MASK;
++	di->slew_shift = CTL_SLEW_SHIFT;
+ 	di->vsel_count = FAN53526_NVOLTAGES;
+ 
+ 	return 0;
+-- 
+2.25.1
+
+

--- a/projects/Rockchip/patches/linux/default/linux-0040-rockchip-dts.patch
+++ b/projects/Rockchip/patches/linux/default/linux-0040-rockchip-dts.patch
@@ -1,0 +1,116 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399pro-vmarc-som.dtsi	2021-05-08 09:11:59.000000000 +0000
++++ b/arch/arm64/boot/dts/rockchip/rk3399pro-vmarc-som.dtsi	2021-05-08 09:11:59.000000000 +0000
+@@ -57,6 +57,22 @@
+ 	pinctrl-0 = <&hdmi_cec>;
+ };
+ 
++&hdmi_sound {
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu>;
++	assigned-clocks = <&cru ACLK_GPU>;
++	assigned-clock-rates = <200000000>;
++	status = "okay";
++	/delete-property/ operating-points-v2;
++};
++
++&vopl {
++	status = "disabled";
++};
++
+ &i2c0 {
+ 	clock-frequency = <400000>;
+ 	i2c-scl-falling-time-ns = <30>;
+@@ -289,6 +288,50 @@
+ 			};
+ 		};
+ 	};
++
++	vdd_cpu_b: tcs4525@1c {
++		compatible = "tcs,tcs4525";
++		reg = <0x1c>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "fan53555-reg";
++		pinctrl-0 = <&vsel1_gpio>;
++		vsel-gpios = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
++		regulator-name = "vdd_cpu_b";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1500000>;
++		regulator-ramp-delay = <2300>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-initial-state = <3>;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_gpu: tcs4526@10 {
++		compatible = "tcs,tcs4526";
++		reg = <0x10>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "fan53555-reg";
++		pinctrl-0 = <&vsel2_gpio>;
++		vsel-gpios = <&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
++		regulator-name = "vdd_gpu";
++		regulator-min-microvolt = <735000>;
++		regulator-max-microvolt = <1400000>;
++		regulator-ramp-delay = <1000>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-initial-state = <3>;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
+ };
++
++&i2s2 {
++	status = "okay";
++};
+ 
+ &i2c1 {
+@@ -381,6 +380,29 @@
+ 		pmic_int_l: pmic-int-l {
+ 			rockchip,pins = <1 RK_PC2 0 &pcfg_pull_up>;
+ 		};
++		vsel1_gpio: vsel1-gpio {
++			rockchip,pins =
++				<1 RK_PC1 0 &pcfg_pull_down>;
++		};
++		vsel2_gpio: vsel2-gpio {
++			rockchip,pins =
++				<1 RK_PB6 0 &pcfg_pull_down>;
++		};
++
++		soc_slppin_gpio: soc-slppin-gpio {
++			rockchip,pins =
++				<1 RK_PA5 0 &pcfg_output_low>;
++		};
++
++		soc_slppin_slp: soc-slppin-slp {
++			rockchip,pins =
++				<1 RK_PA5 1 &pcfg_pull_down>;
++		};
++
++		soc_slppin_rst: soc-slppin-rst {
++			rockchip,pins =
++				<1 RK_PA5 2 &pcfg_pull_none>;
++		};
+ 	};
+ 
+ 	sdio-pwrseq {
+--- a/arch/arm64/boot/dts/rockchip/rk3399pro-rock-pi-n10.dts	2021-04-07 13:00:14.000000000 +0000
++++ b/arch/arm64/boot/dts/rockchip/rk3399pro-rock-pi-n10.dts	2021-04-07 13:00:14.000000000 +0000
+@@ -20,3 +20,7 @@
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+ };
++
++&uart2 {
++    status = "okay";
++};

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -292,6 +292,10 @@ devices = \
         'dtb': 'rk3399-rock-pi-4a.dtb',
         'config': 'evb-rk3399_defconfig'
       },
+      'rock-pi-n10': {
+        'dtb': 'rk3399pro-rock-pi-n10.dtb',
+        'config': 'evb-rk3399_defconfig'
+      },
       'rockpro64': {
         'dtb': 'rk3399-rockpro64.dtb',
         'config': 'evb-rk3399_defconfig'


### PR DESCRIPTION
### DTS
- add the additional dts sections to 
- gpu
- tcs4525 and tcs4526 regulators
- disable the VOP_LIT (Video Output Processor - Little)
- enable i2s2
- enable hdmi_sound
- add gpio/rst/slp
- enable uart2 for serial console

### Patches
- rockchip - regulator: fan53555: Add TCS4525 DCDC support
- Peter Geis
  - regulator: fan53555: fix TCS4525 voltage calulation
  - regulator: fan53555: only bind tcs4525 to correct chip id
  - regulator: fan53555: fix tcs4525 function names
 - @heitbaum - add TCS4526 as used by rk3399pro - vdd_gpu: tcs4526

### Others
- update the uboot_helper to include the additional rock-pi-n10 section
- update release to copy pro files in addition of RK3399
- update README

### Testing
- run tested with LE10b3
- run tested with LE10b3 + 5.10.40 - http://ix.io/3nRY
- run tested with LE10b3 + 5.12.7
