### PR TITLE
Allwinner: linux: enable BT on Tanix TX6 and add wifi node for rtl8822cs (rtw88)

### DIFF
--- a/projects/Allwinner/devices/H6/patches/linux/0020-arm64-dts-allwinner-h6-tanix-tx6-add-bt-enable-rtw88.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/0020-arm64-dts-allwinner-h6-tanix-tx6-add-bt-enable-rtw88.patch
@@ -1,0 +1,113 @@
+From ba918badf612c19b4e31a57b2ff4baa06e99d7d5 Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Sun, 23 May 2021 06:37:45 +0000
+Subject: [PATCH] Allwinner: linux: enable BT on Tanix TX6 and add wifi node for rtl8822cs (rtw88)
+
+Add and enable dts nodes for both rtw88 (rtl8822cs sdio) and uart rtl8822cs bluetooth.
+
+# udevadm info /sys/bus/sdio/devices/mmc1\:0001\:1/
+P: /devices/platform/soc/4021000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:1
+L: 0
+E:
+DEVPATH=/devices/platform/soc/4021000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:1
+E: OF_NAME=sdio-wifi
+E: OF_FULLNAME=/soc/mmc@4021000/sdio-wifi@1
+E: OF_COMPATIBLE_N=0
+E: SDIO_CLASS=07
+E: SDIO_ID=024C:C822
+E: SDIO_REVISION=0.0
+E: MODALIAS=sdio:c07v024CdC822
+E: SUBSYSTEM=sdio
+
+# dmesg | grep hci0
+Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c subver=8822
+Bluetooth: hci0: RTL: rom_version status=0 version=3
+Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_fw.bin
+Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_config.bin
+
+---
+ .../dts/allwinner/sun50i-h6-tanix-tx6.dts     | 32 +++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
+index 5233ad1488..06e7820fd9 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
+@@ -47,12 +47,29 @@ reg_vcc3v3: vcc3v3 {
+ 		regulator-max-microvolt = <3300000>;
+ 	};
+ 
++	reg_vcc_wifi_io: vcc-wifi-io {
++		/* Always on 1.8V/300mA regulator for WiFi and BT IO */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-wifi-io";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++		vin-supply = <&reg_vcc3v3>;
++	};
++
+ 	reg_vdd_cpu_gpu: vdd-cpu-gpu {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vdd-cpu-gpu";
+ 		regulator-min-microvolt = <1135000>;
+ 		regulator-max-microvolt = <1135000>;
+ 	};
++
++	wifi_pwrseq: wifi-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rtc 1>;
++		clock-names = "ext_clock";
++		reset-gpios = <&r_pio 1 3 GPIO_ACTIVE_LOW>; /* PM3 */
++	};
+ };
+ 
+ &ac200_pwm_clk {
+@@ -122,6 +139,22 @@ &mmc0 {
+ 	status = "okay";
+ };
+ 
++&mmc1 {
++    vmmc-supply = <&reg_vcc3v3>;
++    vqmmc-supply = <&reg_vcc_wifi_io>;
++    mmc-pwrseq = <&wifi_pwrseq>;
++    bus-width = <4>;
++    non-removable;
++    status = "okay";
++
++    rtl8822cs: sdio-wifi@1 {
++        reg = <1>;
++        interrupt-parent = <&r_pio>;
++        interrupts = <1 0 IRQ_TYPE_LEVEL_LOW>; /* PM0 */
++        interrupt-names = "host-wake";
++    };
++};
++
+ &mmc2 {
+ 	vmmc-supply = <&reg_vcc3v3>;
+ 	vqmmc-supply = <&reg_vcc1v8>;
+@@ -158,6 +191,21 @@ &uart0 {
+ 	status = "okay";
+ };
+ 
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	uart-has-rtscts;
++	status = "okay";
++
++	bluetooth {
++		//use 8822cs compatible to load hci_h5 and btrtl driver
++		compatible = "realtek,rtl8822cs-bt";
++		device-wake-gpios = <&r_pio 1 2 GPIO_ACTIVE_HIGH>; /* PM2 */
++		host-wake-gpios = <&r_pio 1 1 GPIO_ACTIVE_HIGH>; /* PM1 */
++		enable-gpios = <&r_pio 1 4 GPIO_ACTIVE_HIGH>; /* PM4 */
++	};
++};
++
+ &usb2otg {
+ 	dr_mode = "host";
+ 	status = "okay";
+-- 
+2.29.2
+


### PR DESCRIPTION
### DTS
- Add the regulator - reg_vcc_wifi_io
- Add the wifi_pwrseq
- Add the mmc1 node for the SDIO card (rtl8822cs)
- Add the uart1 node for Bluetooth (rtl8822cs-bt)

### Testing
- &mmc1
  - wifi SDIO is yet to be added to the mainline rtw88 driver
- &uart1
  - Bluetooth is registered - rtl8822cs-bt

```
[    6.470501] Bluetooth: Core ver 2.22
[    6.470711] Bluetooth: HCI device and connection manager initialized
[    6.470789] Bluetooth: HCI socket layer initialized
[    6.470819] Bluetooth: L2CAP socket layer initialized
[    6.470918] Bluetooth: SCO socket layer initialized
[    6.514784] Bluetooth: HCI UART driver ver 2.3
[    6.514811] Bluetooth: HCI UART protocol H4 registered
[    6.514815] Bluetooth: HCI UART protocol BCSP registered
[    6.514977] Bluetooth: HCI UART protocol LL registered
[    6.514981] Bluetooth: HCI UART protocol ATH3K registered
[    6.515526] Bluetooth: HCI UART protocol Three-wire (H5) registered
[    6.515760] Bluetooth: HCI UART protocol Intel registered
[    6.515878] Bluetooth: HCI UART protocol Broadcom registered
[    6.515906] Bluetooth: HCI UART protocol QCA registered
[    6.515909] Bluetooth: HCI UART protocol AG6XX registered
[    6.515934] Bluetooth: HCI UART protocol Marvell registered
[    7.181919] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
[    7.197488] Bluetooth: hci0: RTL: rom_version status=0 version=3
[    7.197495] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_fw.bin
[    7.215933] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_config.bin
[    7.243344] Bluetooth: hci0: RTL: cfg_sz 33, total sz 36621
[    7.422253] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
[    7.422270] Bluetooth: BNEP filters: protocol multicast
[    7.422293] Bluetooth: BNEP socket layer initialized
[    7.774416] Bluetooth: hci0: RTL: fw version 0x059a76a3
[    7.851205] Bluetooth: RFCOMM TTY layer initialized
[    7.851242] Bluetooth: RFCOMM socket layer initialized
[    7.851278] Bluetooth: RFCOMM ver 1.11
```