### PR TITLE
scripts/extract: add option 'PKG_TAR_STRIP_COMPONENTS'

### DIFF
--- a/packages/readme.md
+++ b/packages/readme.md
@@ -28,6 +28,7 @@ To control the build behaviour of your package, use variables in the top-down or
 | Variable    | Default | Required |Description |
 |-------------|---------|----------|------------|
 | PKG_SOURCE_DIR | -    | no  | Force the folder name that application sources are unpacked to. Used when sources do not automatically unpack to a folder with the `PKG_NAME-PKG_VERSION` naming convention. |
+| PKG_TAR_STRIP_COMPONENTS | -   | no  | When this option is set the top level directory is not get stripped off while extracting an archive. |
 | PKG_SOURCE_NAME | -   | no  | Force the filename of the application sources. Used when the filename is not the basename of `PKG_URL` |
 | PKG_PATCH_DIRS | -    | no  | Patches in `./patches` are automatically applied after package unpack. Use this option to include patches from an additional folder, e.g. `./patches/$PKG_PATCH_DIRS` |
 | PKG_NEED_UNPACK | -   | no  | Space separated list of files or folders to include in package stamp calculation. If the stamp is invalidated through changes to package files or dependent files/folders the package is cleaned and rebuilt. e.g. `PKG_NEED_UNPACK="$(get_pkg_directory linux)"` will trigger clean/rebuild of a Linux kernel driver package when a change to the `linux` kernel package is detected. |

--- a/scripts/extract
+++ b/scripts/extract
@@ -36,11 +36,13 @@ fi
 # If PKG_SOURCE_DIR is set don't apply any directory mangling
 # so advanced renaming (eg stripping more than one directory level)
 # can be performed by scripts/unpack.
+# If the archive does not contain a top level folder the strip components
+# can be disabled by PKG_TAR_STRIP_COMPONENTS="no" in package.mk
+TAR_OPTS=""
 if [ -z "${PKG_SOURCE_DIR}" ]; then
-  TAR_OPTS="--strip-components=1"
+  [ -z ${PKG_TAR_STRIP_COMPONENTS} ] && TAR_OPTS="--strip-components=1" || :
   DESTDIR="${2}/${PKG_NAME}-${PKG_VERSION}"
 else
-  TAR_OPTS=""
   DESTDIR="${2}"
 fi
 


### PR DESCRIPTION
Some archive do not include a top level directory.
By this new var the user is able to disable `strip-components` from `TAR_OPTS`.