### PR TITLE
Kodi: Remove "disable addon dialog at startup" for LibreELEC

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.31.le-addons-no-startupenable.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.31.le-addons-no-startupenable.patch
@@ -1,0 +1,27 @@
+Date: Tue, 25 May 2021 19:32:28 +0200
+Subject: [PATCH] Remove "disable addon dialog at startup" for LibreELEC.
+
+The feature is not only not needed for LE but as well does enable the DVB
+driver addons.
+
+See https://github.com/LibreELEC/LibreELEC.tv/issues/5397 and
+https://github.com/xbmc/xbmc/pull/19091
+---
+ xbmc/platform/linux/PlatformLinux.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/xbmc/platform/linux/PlatformLinux.h b/xbmc/platform/linux/PlatformLinux.h
+index c45d41143a..9a872a5f55 100644
+--- a/xbmc/platform/linux/PlatformLinux.h
++++ b/xbmc/platform/linux/PlatformLinux.h
+@@ -21,7 +21,6 @@ public:
+   ~CPlatformLinux() override = default;
+ 
+   bool Init() override;
+-  bool IsConfigureAddonsAtStartupEnabled() override { return true; };
+ 
+ private:
+   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;
+-- 
+2.31.1
+


### PR DESCRIPTION
The feature is not only not needed for LE but as well does enable the DVB driver addons.

Fix for #5397

Tested on Generic.
