### PR TITLE
systemd: fix systemd-machine-id-setup for v247 special case

### DIFF
--- a/packages/sysutils/systemd/scripts/systemd-machine-id-setup
+++ b/packages/sysutils/systemd/scripts/systemd-machine-id-setup
@@ -12,6 +12,9 @@ MACHINEID="$(cat /storage/.cache/systemd-machine-id 2>/dev/null)"
 [[ "${MACHINEID//[a-f0-9]/}" != "" ]] && MACHINEID=
 [ -z "${MACHINEID}" ] && MACHINEID=$(/usr/bin/dbus-uuidgen)
 
+# For first boot detection systemd may have overmounted the file
+umount /storage/.cache/systemd-machine-id >/dev/null 2>&1
+
 # persist uuid
 mkdir -p /storage/.cache
   echo "$MACHINEID" > /storage/.cache/systemd-machine-id

--- a/packages/sysutils/systemd/system.d/machine-id.service
+++ b/packages/sysutils/systemd/system.d/machine-id.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Setup machine-id
 DefaultDependencies=no
-Before=systemd-journald.service systemd-tmpfiles-setup-dev.service
+Conflicts=shutdown.target
+Before=systemd-journald.service systemd-tmpfiles-setup-dev.service shutdown.target
+After=local-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Since systemd v247 the [first boot machine-id handling](https://www.freedesktop.org/software/systemd/man/machine-id.html#First%20Boot%20Semantics) has changed slightly: the file is overmounted. 

That is no issue for the normal installation on an empty disk without `/storage/.cache` but if `/storage/.cache/systemd-machine-id` can be created the file is overmounted by a read only temporary id and a new machine ID is created on any boot:

```
May 26 16:56:51 LibreELEC systemd[1]: Initializing machine ID from random generator.
[..]
May 26 16:56:51 LibreELEC systemd[1]: Starting Setup machine-id...
[..]
May 26 16:56:51 LibreELEC systemd[1]: machine-id.service: Main process exited, code=exited, status=1/FAILURE
May 26 16:56:51 LibreELEC systemd[1]: machine-id.service: Failed with result 'exit-code'.
May 26 16:56:51 LibreELEC systemd[1]: Failed to start Setup machine-id.
```

Unmount the file to make it writable again.

In addition standard options for `DefaultDependencies=no` services are added.
