### PR TITLE
Allwinner: linux: fix OrangePi Plus ethernet

### DIFF
--- a/projects/Allwinner/patches/linux/0061-ARM-dts-sun8i-h3-orangepi-plus-Fix-ethernet-phy-mode.patch
+++ b/projects/Allwinner/patches/linux/0061-ARM-dts-sun8i-h3-orangepi-plus-Fix-ethernet-phy-mode.patch
@@ -1,0 +1,41 @@
+From b19d3479f25e8a0ff24df0b46c82e50ef0f900dd Mon Sep 17 00:00:00 2001
+From: Salvatore Bonaccorso <carnil@debian.org>
+Date: Mon, 24 May 2021 14:21:11 +0200
+Subject: [PATCH] ARM: dts: sun8i: h3: orangepi-plus: Fix ethernet phy-mode
+
+Commit bbc4d71d6354 ("net: phy: realtek: fix rtl8211e rx/tx delay
+config") sets the RX/TX delay according to the phy-mode property in the
+device tree. For the Orange Pi Plus board this is "rgmii", which is the
+wrong setting.
+
+Following the example of a900cac3750b ("ARM: dts: sun7i: a20: bananapro:
+Fix ethernet phy-mode") the phy-mode is changed to "rgmii-id" which gets
+the Ethernet working again on this board.
+
+Fixes: bbc4d71d6354 ("net: phy: realtek: fix rtl8211e rx/tx delay config")
+Reported-by: "B.R. Oake" <broake@mailfence.com>
+Reported-by: Vagrant Cascadian <vagrant@reproducible-builds.org>
+Link: https://bugs.debian.org/988574
+Signed-off-by: Salvatore Bonaccorso <carnil@debian.org>
+Signed-off-by: Maxime Ripard <maxime@cerno.tech>
+Link: https://lore.kernel.org/r/20210524122111.416885-1-carnil@debian.org
+---
+ arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts
+index 97f497854e05..d05fa679dcd3 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts
+@@ -85,7 +85,7 @@ &emac {
+ 	pinctrl-0 = <&emac_rgmii_pins>;
+ 	phy-supply = <&reg_gmac_3v3>;
+ 	phy-handle = <&ext_rgmii_phy>;
+-	phy-mode = "rgmii";
++	phy-mode = "rgmii-id";
+ 
+ 	status = "okay";
+ };
+-- 
+2.31.1
+


### PR DESCRIPTION
This fixes #5415 