### PR TITLE
intel-ucode: update to 20210608

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20201118"
-PKG_SHA256="e42a264b7b86e80d013d6d00062467352c1f37e0aaea10fe5b51e4d8687921ab"
+PKG_VERSION="20210608"
+PKG_SHA256="fd85b6b769efd029dec6a2c07106fd18fb4dcb548b7bc4cde09295a8344ef6d7"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"


### PR DESCRIPTION
update 20201118 to 20210608
skipped 20210216 as it was only relevant to Server chips.

release notes:
- https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20210608
- https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20210216

Testing:
- Skylake SKL i5-6260U (6th Gen)
  - was:
  - [    0.000000] microcode: microcode updated early to revision 0xe2, date = 2020-07-14
  - [    1.550067] microcode: sig=0x406e3, pf=0x40, revision=0xe2
  - is:
  - [    0.000000] microcode: microcode updated early to revision 0xea, date = 2021-01-25
  - [    1.609035] microcode: sig=0x406e3, pf=0x40, revision=0xea
- Tigerlake TGL i7-1165G7 (11th Gen)
  - was:
  - [    2.223390] microcode: sig=0x806c1, pf=0x80, revision=0x72
  - is:
  - [    0.000000] microcode: microcode updated early to revision 0x88, date = 2021-03-31
  - [    2.209681] microcode: sig=0x806c1, pf=0x80, revision=0x88
