### PR TITLE
buildsystem: introduce TARGET_KERNEL_PATCH_ARCH

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -763,8 +763,8 @@ check_arch() {
     linux_config_dir="${PROJECT_DIR}/${PROJECT}/linux"
   fi
 
-  if [ ! -e "$linux_config_dir/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf" ] &&
-       ! ls "$linux_config_dir/"*/linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf &>/dev/null; then
+  if [ ! -e "$linux_config_dir/linux.${TARGET_KERNEL_PATCH_ARCH:-$TARGET_ARCH}.conf" ] &&
+       ! ls "$linux_config_dir/"*/linux.${TARGET_KERNEL_PATCH_ARCH:-$TARGET_ARCH}.conf &>/dev/null; then
     arch_err_msg="\n $dashes$dashes$dashes"
     arch_err_msg="${arch_err_msg}\n ERROR: Architecture not found, use a valid Architecture"
     arch_err_msg="${arch_err_msg}\n for your project or create a new config"
@@ -1246,7 +1246,7 @@ kernel_config_path() {
   pkg_linux_version="$(get_pkg_version linux)"
   pkg_linux_dir="$(get_pkg_directory linux)"
 
-  config_name="linux.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf"
+  config_name="linux.${TARGET_KERNEL_PATCH_ARCH:-$TARGET_ARCH}.conf"
 
   for cfg in $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/$pkg_linux_version/$config_name \
              $PROJECT_DIR/$PROJECT/devices/$DEVICE/linux/$LINUX/$config_name \
@@ -1268,7 +1268,7 @@ kernel_config_path() {
 kernel_initramfs_confs() {
   local config_name cfg confs
 
-  config_name="initramfs.${TARGET_PATCH_ARCH:-$TARGET_ARCH}.conf"
+  config_name="initramfs.${TARGET_KERNEL_PATCH_ARCH:-$TARGET_ARCH}.conf"
   confs="$(get_pkg_directory initramfs)/config/initramfs.conf"
 
   for cfg in $PROJECT_DIR/$PROJECT/packages/initramfs/config/$config_name \

--- a/projects/ARM/devices/ARMv8/options
+++ b/projects/ARM/devices/ARMv8/options
@@ -12,7 +12,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Allwinner/devices/A64/options
+++ b/projects/Allwinner/devices/A64/options
@@ -13,7 +13,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Allwinner/devices/H5/options
+++ b/projects/Allwinner/devices/H5/options
@@ -13,7 +13,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Allwinner/devices/H6/options
+++ b/projects/Allwinner/devices/H6/options
@@ -13,7 +13,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Amlogic/devices/AMLGX/options
+++ b/projects/Amlogic/devices/AMLGX/options
@@ -12,7 +12,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/NXP/devices/iMX8/options
+++ b/projects/NXP/devices/iMX8/options
@@ -12,7 +12,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT=hard
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -12,7 +12,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT=hard
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Rockchip/devices/RK3328/options
+++ b/projects/Rockchip/devices/RK3328/options
@@ -12,7 +12,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -12,7 +12,7 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_PATCH_ARCH="aarch64"
+        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a72.cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -126,6 +126,8 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
 
     if [ "${TARGET_ARCH}" = "x86_64" ]; then
       PATCH_ARCH="x86"
+    elif  [ "${PKG_IS_KERNEL_PKG}" = "yes" ]; then
+      PATCH_ARCH="${TARGET_KERNEL_PATCH_ARCH:-${TARGET_ARCH}}"
     else
       PATCH_ARCH="${TARGET_PATCH_ARCH:-${TARGET_ARCH}}"
     fi


### PR DESCRIPTION
While testing https://github.com/LibreELEC/LibreELEC.tv/pull/5422, I wondered why this change doesn't work on RK3328. It turns out, it couldn't work, because the glibc patches weren't applied for this device.

Thats because AML/AW/iMX8/Qualcomm/RK projects are using split configs for aarch64 devices, i.e. aarch64 kernel with arm userspace and the unpack script checks for `TARGET_PATCH_ARCH` when trying to figure out the `PATCH_ARCH` for any package.
These glibc patches are using (the correct) arm patches subdirectory, but those split-config project/devices are specifing `TARGET_PATCH_ARCH=aarch64`, which actually defines the the kernel (-drivers, u-boot etc.) patch arch. 

This introduces the new `TARGET_KERNEL_PATCH_ARCH` and replaces `TARGET_PATCH_ARCH` in the options of those devices (it is currently only used `packages/linux-drivers/RTL8192DU` package). `scripts/unpack` will now look for `"${PKG_IS_KERNEL_PKG}" = "yes" `before setting the `PATCH_ARCH` according that new variable. I kept the `TARGET_PATCH_ARCH` for future use.

I'm not the one who knows buildsystem the best and I'm open if there is any smarter way to achieve the splitting `PATCH_ARCH` between kernel and userspace packages.
There might also be some implications which I'm not aware of at this point.

Build&runtime tested on RK3328.