### PR TITLE
Allwinner: H5: u-boot: Fix OrangePi PC2 config

### DIFF
--- a/projects/Allwinner/devices/H5/patches/u-boot/0001-OrangePi-PC2-Update-defaults.patch
+++ b/projects/Allwinner/devices/H5/patches/u-boot/0001-OrangePi-PC2-Update-defaults.patch
@@ -11,13 +11,11 @@ diff --git a/configs/orangepi_pc2_defconfig b/configs/orangepi_pc2_defconfig
 index 3d65b87d33..1ffeeed6cd 100644
 --- a/configs/orangepi_pc2_defconfig
 +++ b/configs/orangepi_pc2_defconfig
-@@ -3,13 +3,15 @@ CONFIG_NR_DRAM_BANKS=1
- CONFIG_SPL=y
+@@ -3,12 +3,14 @@ CONFIG_SPL=y
  CONFIG_MACH_SUN50I_H5=y
  CONFIG_DRAM_CLK=672
--CONFIG_DRAM_ZQ=3881977
+ CONFIG_DRAM_ZQ=3881977
 -# CONFIG_DRAM_ODT_EN is not set
-+CONFIG_DRAM_ZQ=4145117
  CONFIG_MACPWR="PD6"
  CONFIG_SPL_SPI_SUNXI=y
 +CONFIG_SPL_I2C_SUPPORT=y


### PR DESCRIPTION
After double checking BSP values, original ZQ value is correct, so drop this change. Other changes are correct though and in process of upstreaming.