### PR TITLE
scripts/extract: cleanup and add support for zstd tarballs

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1170,10 +1170,10 @@ source_package() {
           ${PKG_NAME}-${PKG_VERSION}.*)
             PKG_SOURCE_NAME=$PKG_SOURCE_NAME
             ;;
-          *.tar | *.tbz | *.tgz | *.txz | *.7z | *.zip)
+          *.tar | *.tbz | *.tgz | *.txz | *.tzst | *.7z | *.zip)
             PKG_SOURCE_NAME=${PKG_NAME}-${PKG_VERSION}.${PKG_SOURCE_NAME##*\.}
             ;;
-          *.tar.bz2 | *.tar.gz | *.tar.xz)
+          *.tar.bz2 | *.tar.gz | *.tar.xz | *.tar.zst )
             PKG_SOURCE_NAME=${PKG_NAME}-${PKG_VERSION}.tar.${PKG_SOURCE_NAME##*\.}
             ;;
           *.diff | *.patch | *.diff.bz2 | *.patch.bz2 | patch-*.bz2 | *.diff.gz | *.patch.gz | patch-*.gz)

--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.4.9"
-PKG_SHA256="29ac74e19ea28659017361976240c4b5c5c24db3b89338731a6feb97c038d293"
+PKG_VERSION="1.5.0"
+PKG_SHA256="9aa8dfc1ca17f358b28988ca1f6e00ffe1c6f3198853f8d2022799e6f0669180"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"
-PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.zst"
 PKG_DEPENDS_HOST="ccache:host meson:host ninja:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A fast real-time compression algorithm."

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -75,6 +75,7 @@ dep_map=(
   [wget]=wget
   [xz]=xz-utils
   [zip]=zip
+  [zstd]=zstd
 )
 
 # [file]=package

--- a/scripts/extract
+++ b/scripts/extract
@@ -51,6 +51,10 @@ case ${PKG_SOURCE_NAME} in
     mkdir -p "${DESTDIR}"
     tar xf ${FULL_SOURCE_PATH} ${TAR_OPTS} -C "${DESTDIR}"
     ;;
+  *.tar.zst | *.tzst)
+    mkdir -p "${DESTDIR}"
+    zstdcat ${FULL_SOURCE_PATH} | tar xf - ${TAR_OPTS} -C "${DESTDIR}"
+    ;;
   *.7z)
     mkdir -p ${2}/${1}
     7z x -o${2}/${1} ${FULL_SOURCE_PATH}

--- a/scripts/extract
+++ b/scripts/extract
@@ -14,7 +14,7 @@ fi
 [ ! -d "${SOURCES}/${1}" ] && die "${PKG_NAME}: ${SOURCES}/${1} not found"
 [ ! -d "${2}" ] && die "${PKG_NAME}: target ${2} not found"
 
-if [[ ${PKG_URL} =~ ^file:// ]]; then
+if [[ "${PKG_URL}" =~ ^file:// ]]; then
   FULL_SOURCE_PATH="${PKG_SOURCE_NAME}"
 else
   FULL_SOURCE_PATH="${SOURCES}/${1}/${PKG_SOURCE_NAME}"
@@ -22,12 +22,12 @@ fi
 
 if [ ! -f "${FULL_SOURCE_PATH}" -a ! -d "${FULL_SOURCE_PATH}" ]; then
   echo "error: File ${PKG_SOURCE_NAME} doesn't exist for package ${1}"
-  echo "Have you called scripts/extract before scripts/get ?"
+  echo "Have you called scripts/extract before scripts/get?"
   die
 fi
 
 # The build system expects packages to be extracted to
-# ${PKG_BUILD.}
+# ${PKG_BUILD}.
 # Try to strip the top level dir from the archive and extract to
 # the correct directory if possible so packages don't need to
 # set PKG_SOURCE_DIR and scripts/unpack doesn't need to rename
@@ -40,41 +40,40 @@ fi
 # can be disabled by PKG_TAR_STRIP_COMPONENTS="no" in package.mk
 TAR_OPTS=""
 if [ -z "${PKG_SOURCE_DIR}" ]; then
-  [ -z ${PKG_TAR_STRIP_COMPONENTS} ] && TAR_OPTS="--strip-components=1" || :
+  [ -z "${PKG_TAR_STRIP_COMPONENTS}" ] && TAR_OPTS="--strip-components=1" || :
   DESTDIR="${2}/${PKG_NAME}-${PKG_VERSION}"
 else
   DESTDIR="${2}"
 fi
 
-case ${PKG_SOURCE_NAME} in
+case "${PKG_SOURCE_NAME}" in
   *.tar | *.tar.bz2 | *.tbz | *.tar.gz | *.tgz | *.tar.xz | *.txz)
     mkdir -p "${DESTDIR}"
-    tar xf ${FULL_SOURCE_PATH} ${TAR_OPTS} -C "${DESTDIR}"
+    tar xf "${FULL_SOURCE_PATH}" "${TAR_OPTS}" -C "${DESTDIR}"
     ;;
   *.tar.zst | *.tzst)
     mkdir -p "${DESTDIR}"
-    zstdcat ${FULL_SOURCE_PATH} | tar xf - ${TAR_OPTS} -C "${DESTDIR}"
+    zstdcat "${FULL_SOURCE_PATH}" | tar xf - "${TAR_OPTS}" -C "${DESTDIR}"
     ;;
   *.7z)
-    mkdir -p ${2}/${1}
-    7z x -o${2}/${1} ${FULL_SOURCE_PATH}
+    mkdir -p "${2}/${1}"
+    7z x -o"${2}/${1}" "${FULL_SOURCE_PATH}"
     ;;
   *.zip)
-    unzip -q ${FULL_SOURCE_PATH} -d ${2}
+    unzip -q "${FULL_SOURCE_PATH}" -d "${2}"
     ;;
   *.diff | *.patch)
-    cat ${FULL_SOURCE_PATH} | patch -d ${2} -p1
+    patch -d "${2}" -p1 < "${FULL_SOURCE_PATH}"
     ;;
   *.diff.bz2 | *.patch.bz2 | patch-*.bz2)
-    bzcat ${FULL_SOURCE_PATH} | patch -d ${2} -p1
+    bzcat "${FULL_SOURCE_PATH}" | patch -d "${2}" -p1
     ;;
   *.diff.gz | *.patch.gz | patch-*.gz)
-    zcat ${FULL_SOURCE_PATH} | patch -d ${2} -p1
+    zcat "${FULL_SOURCE_PATH}" | patch -d "${2}" -p1
     ;;
   *)
     FULL_DEST_PATH="${2}/${PKG_NAME}-${PKG_VERSION}"
-    mkdir ${FULL_DEST_PATH}
-    tar cf - -C ${FULL_SOURCE_PATH} ${PKG_TAR_COPY_OPTS} . | \
-      tar xf - -C ${FULL_DEST_PATH}
+    mkdir "${FULL_DEST_PATH}"
+    tar cf - -C "${FULL_SOURCE_PATH}" "${PKG_TAR_COPY_OPTS}" . | tar xf - -C "${FULL_DEST_PATH}"
     ;;
 esac

--- a/tools/docker/bionic/Dockerfile
+++ b/tools/docker/bionic/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
     libjson-perl libxml-parser-perl libparse-yapp-perl \

--- a/tools/docker/buster/Dockerfile
+++ b/tools/docker/buster/Dockerfile
@@ -19,7 +19,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
     libjson-perl libxml-parser-perl libparse-yapp-perl \

--- a/tools/docker/focal/Dockerfile
+++ b/tools/docker/focal/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
     libjson-perl libxml-parser-perl libparse-yapp-perl \

--- a/tools/docker/groovy/Dockerfile
+++ b/tools/docker/groovy/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
     libjson-perl libxml-parser-perl libparse-yapp-perl \

--- a/tools/docker/hirsute/Dockerfile
+++ b/tools/docker/hirsute/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
     libjson-perl libxml-parser-perl libparse-yapp-perl \

--- a/tools/docker/sid/Dockerfile
+++ b/tools/docker/sid/Dockerfile
@@ -19,7 +19,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
     libjson-perl libxml-parser-perl libparse-yapp-perl \

--- a/tools/docker/stretch/Dockerfile
+++ b/tools/docker/stretch/Dockerfile
@@ -19,7 +19,7 @@ RUN adduser --disabled-password --gecos '' docker \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN apt-get update && apt-get install -y \
-    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils perl gawk gperf zip unzip diffutils lzop make file \
+    wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
     libjson-perl libxml-parser-perl libparse-yapp-perl \


### PR DESCRIPTION
This adds support for packages packed in .tar.zst's. The zstdcat | tar approach is used to be compatible with older versions of tar (<1.32, iirc). Thus far, I've only found zstd itself packed in such a tarball.

Also cleans up scripts/extract some.