### PR TITLE
buildsystem: change when config/arch.$ARCH is sourced

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -3,6 +3,13 @@
     TARGET_CPU=cortex-a53
   fi
 
+  # 64bit userland and neon required by armv8
+  if [ -z "${TARGET_FEATURES}" ]; then
+    TARGET_FEATURES="64bit neon"
+  else
+    TARGET_FEATURES+=" 64bit neon"
+  fi
+
 # TARGET_CPU:
 # generic cortex-a35 cortex-a53 cortex-a57 cortex-a72
 # exynos-m1 qdf24xx thunderx xgene1 cortex-a57.cortex-a53
@@ -14,7 +21,6 @@
       TARGET_SUBARCH=aarch64
       TARGET_VARIANT=armv8-a
       TARGET_ABI=eabi
-      TARGET_FEATURES+=" neon"
       ;;
   esac
 

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -3,6 +3,13 @@
     TARGET_CPU=cortex-a8
   fi
 
+  # 32bit userland
+  if [ -z "${TARGET_FEATURES}" ]; then
+    TARGET_FEATURES="32bit"
+  else
+    TARGET_FEATURES+=" 32bit"
+  fi
+
 # TARGET_CPU:
 # arm2 arm250 arm3 arm6 arm60 arm600 arm610 arm620 arm7 arm7m arm7d
 # arm7dm arm7di arm7dmi arm70 arm700 arm700i arm710 arm710c

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -64,6 +64,10 @@
   TARGET_GCC_ARCH=${TARGET_SUBARCH/-}
   TARGET_KERNEL_ARCH=${TARGET_KERNEL_ARCH:-arm}
 
+  if [ "${TARGET_KERNEL_ARCH}" = "arm64" ]; then
+    TARGET_KERNEL_PATCH_ARCH="aarch64"
+  fi
+
 # setup ARCH specific *FLAGS
   TARGET_CFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated"
   [ -n "$TARGET_FPU" ] && TARGET_CFLAGS="$TARGET_CFLAGS $TARGET_FPU_FLAGS"

--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -3,6 +3,13 @@
     TARGET_CPU=core2
   fi
 
+  # 64bit userland
+  if [ -z "${TARGET_FEATURES}" ]; then
+    TARGET_FEATURES="64bit"
+  else
+    TARGET_FEATURES+=" 64bit"
+  fi
+
 # determine architecture's family
   TARGET_SUBARCH=x86_64
 

--- a/config/options
+++ b/config/options
@@ -43,19 +43,24 @@ fi
 # read DISTRO version information
 . "${DISTRO_DIR}/${DISTRO}/version" || die "\nERROR: No distro version present\n"
 
-# read DISTRO options if available
+# read DISTRO options
 if [ -f "${DISTRO_DIR}/${DISTRO}/options" ]; then
   . "${DISTRO_DIR}/${DISTRO}/options"
 fi
 
-# read PROJECT options if available
+# read PROJECT options
 if [ -f "${PROJECT_DIR}/${PROJECT}/options" ]; then
   . "${PROJECT_DIR}/${PROJECT}/options"
 fi
 
-# read DEVICE options if available
+# read DEVICE options
 if [ -f "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/options" ]; then
   . "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/options"
+fi
+
+# read architecture defaults
+if [ -f "config/arch.${TARGET_ARCH}" ]; then
+  . "config/arch.${TARGET_ARCH}"
 fi
 
 # projects can set KERNEL_NAME (kernel.img)

--- a/config/path
+++ b/config/path
@@ -13,11 +13,6 @@ set -e
   TARGET_IMG=${TARGET_DIR:-$ROOT/target}
   ADDONS=addons
 
-# include ARCH specific options
-  if [ -f config/arch.$TARGET_ARCH ]; then
-    . config/arch.$TARGET_ARCH
-  fi
-
 [ -z "${HOST_NAME}" ] && export HOST_NAME="$($LOCAL_CC -dumpmachine)"
 TARGET_NAME=$TARGET_GCC_ARCH-libreelec-linux-gnu${TARGET_ABI}
 

--- a/config/show_config
+++ b/config/show_config
@@ -16,7 +16,9 @@ show_config() {
 
   config_message+="\n - CPU (ARCH):\t\t\t\t $TARGET_CPU ($TARGET_ARCH)"
   config_message+="\n - FLOAT:\t\t\t\t $TARGET_FLOAT"
-  config_message+="\n - FPU:\t\t\t\t\t $TARGET_FPU"
+  if [ -n "${TARGET_FPU}" ]; then
+    config_message+="\n - FPU:\t\t\t\t\t ${TARGET_FPU}"
+  fi
   config_message+="\n - CPU features:\t\t\t $TARGET_FEATURES"
   config_message+="\n - LTO (Link Time Optimization) support: $LTO_SUPPORT"
   config_message+="\n - GOLD (Google Linker) Support:\t $GOLD_SUPPORT"

--- a/config/show_config
+++ b/config/show_config
@@ -14,7 +14,9 @@ show_config() {
   config_message+="\n\n Buildsystem configuration:"
   config_message+="\n $dashes$dashes"
 
-  config_message+="\n - CPU (ARCH):\t\t\t\t $TARGET_CPU ($TARGET_ARCH)"
+  config_message+="\n - CPU:\t\t\t\t\t $TARGET_CPU"
+  config_message+="\n - Kernel Architecture:\t\t\t $TARGET_KERNEL_ARCH"
+  config_message+="\n - Userland Architecture:\t\t $TARGET_ARCH"
   config_message+="\n - FLOAT:\t\t\t\t $TARGET_FLOAT"
   if [ -n "${TARGET_FPU}" ]; then
     config_message+="\n - FPU:\t\t\t\t\t ${TARGET_FPU}"

--- a/projects/ARM/devices/ARMv8/options
+++ b/projects/ARM/devices/ARMv8/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/ARM/devices/ARMv8/options
+++ b/projects/ARM/devices/ARMv8/options
@@ -8,7 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
-        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -17,7 +16,6 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Allwinner/devices/A64/options
+++ b/projects/Allwinner/devices/A64/options
@@ -8,8 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+crypto"
-        TARGET_FEATURES="64bit"
-        TARGET_KERNEL_ARCH="arm64"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -18,7 +16,6 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Allwinner/devices/A64/options
+++ b/projects/Allwinner/devices/A64/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Allwinner/devices/H5/options
+++ b/projects/Allwinner/devices/H5/options
@@ -8,8 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+crypto"
-        TARGET_FEATURES="64bit"
-        TARGET_KERNEL_ARCH="arm64"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -18,7 +16,6 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Allwinner/devices/H5/options
+++ b/projects/Allwinner/devices/H5/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Allwinner/devices/H6/options
+++ b/projects/Allwinner/devices/H6/options
@@ -8,8 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+crypto"
-        TARGET_FEATURES="64bit"
-        TARGET_KERNEL_ARCH="arm64"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -18,7 +16,6 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Allwinner/devices/H6/options
+++ b/projects/Allwinner/devices/H6/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Amlogic/devices/AMLGX/options
+++ b/projects/Amlogic/devices/AMLGX/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Amlogic/devices/AMLGX/options
+++ b/projects/Amlogic/devices/AMLGX/options
@@ -8,7 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+fp+simd"
-        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -17,7 +16,6 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -11,7 +11,6 @@
         # (Intel CPUs)  atom core2 nocona
         #
         TARGET_CPU="x86-64"
-        TARGET_FEATURES="64bit"
         ;;
     esac
 

--- a/projects/NXP/devices/iMX6/options
+++ b/projects/NXP/devices/iMX6/options
@@ -9,7 +9,6 @@
         TARGET_CPU="cortex-a9"
         TARGET_FLOAT="hard"
         TARGET_FPU="neon-vfpv3"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/NXP/devices/iMX8/options
+++ b/projects/NXP/devices/iMX8/options
@@ -8,7 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+fp+simd"
-        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -17,7 +16,6 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/NXP/devices/iMX8/options
+++ b/projects/NXP/devices/iMX8/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT=hard
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -8,7 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+fp+simd"
-        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -17,7 +16,6 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT=hard
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -33,7 +33,6 @@
         elif [ "$DEVICE" = "RPi4" ]; then
           TARGET_FPU="neon-fp-armv8"
         fi
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Rockchip/devices/RK3288/options
+++ b/projects/Rockchip/devices/RK3288/options
@@ -9,7 +9,6 @@
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a17"
         TARGET_FPU="neon-vfpv4"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Rockchip/devices/RK3328/options
+++ b/projects/Rockchip/devices/RK3328/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Rockchip/devices/RK3328/options
+++ b/projects/Rockchip/devices/RK3328/options
@@ -8,7 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc+crypto"
-        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -17,7 +16,6 @@
         TARGET_CPU="cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 

--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -11,7 +11,6 @@
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
         TARGET_FLOAT="hard"
         TARGET_CPU="cortex-a72.cortex-a53"
         TARGET_CPU_FLAGS="+crc"

--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -8,7 +8,6 @@
       aarch64)
         TARGET_CPU="cortex-a72.cortex-a53"
         TARGET_CPU_FLAGS="+crc+crypto"
-        TARGET_FEATURES="64bit"
         ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
@@ -17,7 +16,6 @@
         TARGET_CPU="cortex-a72.cortex-a53"
         TARGET_CPU_FLAGS="+crc"
         TARGET_FPU="crypto-neon-fp-armv8"
-        TARGET_FEATURES="32bit"
         ;;
     esac
 


### PR DESCRIPTION
This moves the sourcing of `config/arch.$ARCH` from `config/path` into `config/options`. It remains between distro/project/device options and `config/path` being sourced, but comes in before the buildsystem does a self-check.

This also allows moving TARGET_FEATURES and TARGET_KERNEL_ARCH out to the arch.$ARCH files, so do so.

Built / run tested on RPi3.aarch64.