### PR TITLE
Reduce subprocesses in buildsystem

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -707,11 +707,11 @@ save_build_config() {
 check_path() {
   local dashes="===========================" path_err_msg
   if [ "${PWD##/usr}" != "${PWD}" ]; then
-    path_err_msg="\n $dashes$dashes$dashes"
-    path_err_msg="${path_err_msg}\n ERROR: Detected building inside /usr"
-    path_err_msg="${path_err_msg}\n $dashes$dashes$dashes"
-    path_err_msg="${path_err_msg}\n This is not supported with our buildsystem."
-    path_err_msg="${path_err_msg}\n Please use another dir (for example your \$HOME) to build ${DISTRONAME}"
+    path_err_msg="\n ${dashes}${dashes}${dashes}"
+    path_err_msg+="\n ERROR: Detected building inside /usr"
+    path_err_msg+="\n ${dashes}${dashes}${dashes}"
+    path_err_msg+="\n This is not supported by the buildsystem."
+    path_err_msg+="\n Please use another directory (for example your \$HOME) to build ${DISTRONAME}"
 
     die "${path_err_msg}"
   fi
@@ -720,13 +720,13 @@ check_path() {
 check_distro() {
   local dashes="===========================" distro_err_msg
   if [ -z "${DISTRO}" -o ! -d "${DISTRO_DIR}/${DISTRO}" ]; then
-    distro_err_msg="\n $dashes$dashes$dashes"
-    distro_err_msg="${distro_err_msg}\n ERROR: Distro not found, use a valid distro or create a new config"
-    distro_err_msg="${distro_err_msg}\n $dashes$dashes$dashes"
-    distro_err_msg="${distro_err_msg}\n\n Valid distros:"
+    distro_err_msg="\n ${dashes}${dashes}${dashes}"
+    distro_err_msg+="\n ERROR: Distro not found, use a valid distro or create a new config"
+    distro_err_msg+="\n ${dashes}${dashes}${dashes}"
+    distro_err_msg+="\n\n Valid distros:"
 
     for distros in ${DISTRO_DIR}/*; do
-      distro_err_msg="${distro_err_msg}\n - ${distros##*/}"
+      distro_err_msg+="\n - ${distros##*/}"
     done
     die "${distro_err_msg}"
   fi
@@ -735,13 +735,13 @@ check_distro() {
 check_project() {
   local dashes="===========================" project_err_msg
   if [ -z "${PROJECT}" -o ! -d "${PROJECT_DIR}/${PROJECT}" ]; then
-    project_err_msg="\n $dashes$dashes$dashes"
-    project_err_msg="${project_err_msg}\n ERROR: Project not found, use a valid project or create a new config"
-    project_err_msg="${project_err_msg}\n $dashes$dashes$dashes"
-    project_err_msg="${project_err_msg}\n\n Valid projects:"
+    project_err_msg="\n ${dashes}${dashes}${dashes}"
+    project_err_msg+="\n ERROR: Project not found. Use a valid project or create a new config"
+    project_err_msg+="\n ${dashes}${dashes}${dashes}"
+    project_err_msg+="\n\n Valid projects:"
 
     for projects in ${PROJECT_DIR}/*; do
-      project_err_msg="${project_err_msg}\n - ${projects##*/}"
+      project_err_msg+="\n - ${projects##*/}"
     done
     die "${project_err_msg}"
   fi
@@ -751,13 +751,13 @@ check_device() {
   local dashes="===========================" device_err_msg
   if [ \( -z "${DEVICE}" -a -d "${PROJECT_DIR}/${PROJECT}/devices" \) -o \
        \( -n "${DEVICE}" -a ! -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}" \) ]; then
-    device_err_msg="\n $dashes$dashes$dashes"
-    device_err_msg="${device_err_msg}\n ERROR: You need to specify a valid device for the $PROJECT project"
-    device_err_msg="${device_err_msg}\n $dashes$dashes$dashes"
-    device_err_msg="${device_err_msg}\n\n Valid devices for project: ${PROJECT}"
+    device_err_msg="\n ${dashes}${dashes}${dashes}"
+    device_err_msg+="\n ERROR: Specify a valid device for the ${PROJECT} project"
+    device_err_msg+="\n ${dashes}${dashes}${dashes}"
+    device_err_msg+="\n\n Valid devices for project: ${PROJECT}"
 
     for device in ${PROJECT_DIR}/${PROJECT}/devices/*; do
-      device_err_msg="${device_err_msg}\n - ${device##*/}"
+      device_err_msg+="\n - ${device##*/}"
     done
     die "${device_err_msg}"
   fi
@@ -771,17 +771,17 @@ check_arch() {
     linux_config_dir="${PROJECT_DIR}/${PROJECT}/linux"
   fi
 
-  if [ ! -e "$linux_config_dir/linux.${TARGET_KERNEL_PATCH_ARCH:-$TARGET_ARCH}.conf" ] &&
-       ! ls "$linux_config_dir/"*/linux.${TARGET_KERNEL_PATCH_ARCH:-$TARGET_ARCH}.conf &>/dev/null; then
-    arch_err_msg="\n $dashes$dashes$dashes"
-    arch_err_msg="${arch_err_msg}\n ERROR: Architecture not found, use a valid Architecture"
-    arch_err_msg="${arch_err_msg}\n for your project or create a new config"
-    arch_err_msg="${arch_err_msg}\n $dashes$dashes$dashes"
-    arch_err_msg="${arch_err_msg}\n\n Valid Architectures for your project: ${PROJECT}"
+  if [ ! -e "${linux_config_dir}/linux.${TARGET_KERNEL_PATCH_ARCH:-$TARGET_ARCH}.conf" ] &&
+       ! ls "${linux_config_dir}/"*/linux.${TARGET_KERNEL_PATCH_ARCH:-$TARGET_ARCH}.conf &>/dev/null; then
+    arch_err_msg="\n ${dashes}${dashes}${dashes}"
+    arch_err_msg+="\n ERROR: Architecture not found. Use a valid Architecture"
+    arch_err_msg+="\n for your project or create a new config"
+    arch_err_msg+="\n ${dashes}${dashes}${dashes}"
+    arch_err_msg+="\n\n Valid Architectures for project: ${PROJECT}"
 
-    for arch in $linux_config_dir/*.conf $linux_config_dir/*/linux.$TARGET_ARCH.conf; do
+    for arch in ${linux_config_dir}/*.conf ${linux_config_dir}/*/linux.${TARGET_ARCH}.conf; do
       [[ ${arch} =~ .*\*.* ]] && continue #ignore unexpanded wildcard
-      arch_err_msg="${arch_err_msg}\n - $(basename $arch | cut -f2 -d".")"
+      arch_err_msg+="\n - $(basename ${arch} | cut -f2 -d".")"
     done
     die "${arch_err_msg}"
   fi

--- a/config/functions
+++ b/config/functions
@@ -669,7 +669,7 @@ init_package_cache() {
     export _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL
 
     # overwrite existing cache files only when they are invalid, or not yet created
-    mkdir -p "$(dirname "${_CACHE_PACKAGE_GLOBAL}")"
+    mkdir -p "${_CACHE_PACKAGE_GLOBAL%/*}"
     if [ -f "${_CACHE_PACKAGE_LOCAL}" ] && cmp -s "${temp_local}" "${_CACHE_PACKAGE_LOCAL}"; then
       rm "${temp_local}"
     else
@@ -781,7 +781,7 @@ check_arch() {
 
     for arch in ${linux_config_dir}/*.conf ${linux_config_dir}/*/linux.${TARGET_ARCH}.conf; do
       [[ ${arch} =~ .*\*.* ]] && continue #ignore unexpanded wildcard
-      arch_err_msg+="\n - $(basename ${arch} | cut -f2 -d".")"
+      arch_err_msg+="\n - $(echo ${arch##*/} | cut -f2 -d".")"
     done
     die "${arch_err_msg}"
   fi
@@ -1128,7 +1128,7 @@ source_package() {
   unset_functions
 
   if [ -n "${1}" ]; then
-    [ -f "${1}" ] && PKG_DIR="$(dirname "${1}")" || PKG_DIR="$(get_pkg_directory "${1}")"
+    [ -f "${1}" ] && PKG_DIR="${1%/*}" || PKG_DIR="$(get_pkg_directory "${1}")"
 
     [ -n "$PKG_DIR" -a -r $PKG_DIR/package.mk ] || die "FAILURE: unable to source package - ${1}/package.mk does not exist"
 
@@ -1423,7 +1423,7 @@ done
 
   for f in $PKG_DIR/source/resources/screenshot-*.{jpg,png}; do
     if [ -f "$f" ]; then
-      screenshots+="<screenshot>resources/$(basename $f)</screenshot>\n"
+      screenshots+="<screenshot>resources/${f##*/}</screenshot>\n"
     fi
   done
 

--- a/scripts/build
+++ b/scripts/build
@@ -258,59 +258,59 @@ else
     # meson builds
     "meson:target")
       create_meson_conf_target ${TARGET} ${MESON_CONF}
-      echo "Executing (target): meson ${TARGET_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_TARGET} $(dirname ${PKG_MESON_SCRIPT})" | tr -s " "
-      CC="${HOST_CC}" CXX="${HOST_CXX}" meson ${TARGET_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_TARGET} $(dirname ${PKG_MESON_SCRIPT})
+      echo "Executing (target): meson ${TARGET_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_TARGET} ${PKG_MESON_SCRIPT%/*}" | tr -s " "
+      CC="${HOST_CC}" CXX="${HOST_CXX}" meson ${TARGET_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_TARGET} ${PKG_MESON_SCRIPT%/*}
       ;;
     "meson:host")
       create_meson_conf_host ${TARGET} ${MESON_CONF}
-      echo "Executing (host): meson ${HOST_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_HOST} $(dirname ${PKG_MESON_SCRIPT})" | tr -s " "
-      meson ${HOST_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_HOST} $(dirname ${PKG_MESON_SCRIPT})
+      echo "Executing (host): meson ${HOST_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_HOST} ${PKG_MESON_SCRIPT%/*}" | tr -s " "
+      meson ${HOST_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_HOST} ${PKG_MESON_SCRIPT%/*}
       ;;
     "meson:init")
       create_meson_conf_target ${TARGET} ${MESON_CONF}
-      echo "Executing (init): meson ${INIT_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_INIT} $(dirname ${PKG_MESON_SCRIPT})" | tr -s " "
-      meson ${INIT_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_INIT} $(dirname ${PKG_MESON_SCRIPT})
+      echo "Executing (init): meson ${INIT_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_INIT} ${PKG_MESON_SCRIPT%/*}" | tr -s " "
+      meson ${INIT_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_INIT} ${PKG_MESON_SCRIPT%/*}
       ;;
     "meson:bootstrap")
       create_meson_conf_host ${TARGET} ${MESON_CONF}
-      echo "Executing (bootstrap): meson ${BOOTSTRAP_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_BOOTSTRAP} $(dirname ${PKG_MESON_SCRIPT})" | tr -s " "
-      meson ${BOOTSTRAP_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_BOOTSTRAP} $(dirname ${PKG_MESON_SCRIPT})
+      echo "Executing (bootstrap): meson ${BOOTSTRAP_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_BOOTSTRAP} ${PKG_MESON_SCRIPT%/*}" | tr -s " "
+      meson ${BOOTSTRAP_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_BOOTSTRAP} ${PKG_MESON_SCRIPT%/*}
       ;;
 
     # cmake builds with ninja
     "cmake:target")
-      echo "Executing (target): cmake ${CMAKE_GENERATOR_NINJA} ${TARGET_CMAKE_OPTS} ${PKG_CMAKE_OPTS_TARGET} $(dirname ${PKG_CMAKE_SCRIPT})" | tr -s " "
-      cmake ${CMAKE_GENERATOR_NINJA} ${TARGET_CMAKE_OPTS} ${PKG_CMAKE_OPTS_TARGET} $(dirname ${PKG_CMAKE_SCRIPT})
+      echo "Executing (target): cmake ${CMAKE_GENERATOR_NINJA} ${TARGET_CMAKE_OPTS} ${PKG_CMAKE_OPTS_TARGET} ${PKG_CMAKE_SCRIPT%/*}" | tr -s " "
+      cmake ${CMAKE_GENERATOR_NINJA} ${TARGET_CMAKE_OPTS} ${PKG_CMAKE_OPTS_TARGET} ${PKG_CMAKE_SCRIPT%/*}
       ;;
     "cmake:host")
-      echo "Executing (host): cmake ${CMAKE_GENERATOR_NINJA} ${HOST_CMAKE_OPTS} ${PKG_CMAKE_OPTS_HOST} $(dirname ${PKG_CMAKE_SCRIPT})" | tr -s " "
-      cmake ${CMAKE_GENERATOR_NINJA} ${HOST_CMAKE_OPTS} ${PKG_CMAKE_OPTS_HOST} $(dirname ${PKG_CMAKE_SCRIPT})
+      echo "Executing (host): cmake ${CMAKE_GENERATOR_NINJA} ${HOST_CMAKE_OPTS} ${PKG_CMAKE_OPTS_HOST} ${PKG_CMAKE_SCRIPT%/*}" | tr -s " "
+      cmake ${CMAKE_GENERATOR_NINJA} ${HOST_CMAKE_OPTS} ${PKG_CMAKE_OPTS_HOST} ${PKG_CMAKE_SCRIPT%/*}
       ;;
     "cmake:init")
-      echo "Executing (init): cmake ${CMAKE_GENERATOR_NINJA} ${INIT_CMAKE_OPTS} ${PKG_CMAKE_OPTS_INIT} $(dirname ${PKG_CMAKE_SCRIPT})" | tr -s " "
-      cmake ${CMAKE_GENERATOR_NINJA} ${INIT_CMAKE_OPTS} ${PKG_CMAKE_OPTS_INIT} $(dirname ${PKG_CMAKE_SCRIPT})
+      echo "Executing (init): cmake ${CMAKE_GENERATOR_NINJA} ${INIT_CMAKE_OPTS} ${PKG_CMAKE_OPTS_INIT} ${PKG_CMAKE_SCRIPT%/*}" | tr -s " "
+      cmake ${CMAKE_GENERATOR_NINJA} ${INIT_CMAKE_OPTS} ${PKG_CMAKE_OPTS_INIT} ${PKG_CMAKE_SCRIPT%/*}
       ;;
     "cmake:bootstrap")
-      echo "Executing (bootstrap): cmake ${CMAKE_GENERATOR_NINJA} ${BOOTSTRAP_CMAKE_OPTS} ${PKG_CMAKE_OPTS_BOOTSTRAP} $(dirname ${PKG_CMAKE_SCRIPT})" | tr -s " "
-      cmake ${CMAKE_GENERATOR_NINJA} ${BOOTSTRAP_CMAKE_OPTS} ${PKG_CMAKE_OPTS_BOOTSTRAP} $(dirname ${PKG_CMAKE_SCRIPT})
+      echo "Executing (bootstrap): cmake ${CMAKE_GENERATOR_NINJA} ${BOOTSTRAP_CMAKE_OPTS} ${PKG_CMAKE_OPTS_BOOTSTRAP} ${PKG_CMAKE_SCRIPT%/*}" | tr -s " "
+      cmake ${CMAKE_GENERATOR_NINJA} ${BOOTSTRAP_CMAKE_OPTS} ${PKG_CMAKE_OPTS_BOOTSTRAP} ${PKG_CMAKE_SCRIPT%/*}
       ;;
 
     # cmake builds with make
     "cmake-make:target")
-      echo "Executing (target): cmake ${TARGET_CMAKE_OPTS} ${PKG_CMAKE_OPTS_TARGET} $(dirname ${PKG_CMAKE_SCRIPT})" | tr -s " "
-      cmake ${TARGET_CMAKE_OPTS} ${PKG_CMAKE_OPTS_TARGET} $(dirname ${PKG_CMAKE_SCRIPT})
+      echo "Executing (target): cmake ${TARGET_CMAKE_OPTS} ${PKG_CMAKE_OPTS_TARGET} ${PKG_CMAKE_SCRIPT%/*}" | tr -s " "
+      cmake ${TARGET_CMAKE_OPTS} ${PKG_CMAKE_OPTS_TARGET} ${PKG_CMAKE_SCRIPT%/*}
       ;;
     "cmake-make:host")
-      echo "Executing (host): cmake ${HOST_CMAKE_OPTS} ${PKG_CMAKE_OPTS_HOST} $(dirname ${PKG_CMAKE_SCRIPT})" | tr -s " "
-      cmake ${HOST_CMAKE_OPTS} ${PKG_CMAKE_OPTS_HOST} $(dirname ${PKG_CMAKE_SCRIPT})
+      echo "Executing (host): cmake ${HOST_CMAKE_OPTS} ${PKG_CMAKE_OPTS_HOST} ${PKG_CMAKE_SCRIPT%/*}" | tr -s " "
+      cmake ${HOST_CMAKE_OPTS} ${PKG_CMAKE_OPTS_HOST} ${PKG_CMAKE_SCRIPT%/*}
       ;;
     "cmake-make:init")
-      echo "Executing (init): cmake ${INIT_CMAKE_OPTS} ${PKG_CMAKE_OPTS_INIT} $(dirname ${PKG_CMAKE_SCRIPT})" | tr -s " "
-      cmake ${INIT_CMAKE_OPTS} ${PKG_CMAKE_OPTS_INIT} $(dirname ${PKG_CMAKE_SCRIPT})
+      echo "Executing (init): cmake ${INIT_CMAKE_OPTS} ${PKG_CMAKE_OPTS_INIT} ${PKG_CMAKE_SCRIPT%/*}" | tr -s " "
+      cmake ${INIT_CMAKE_OPTS} ${PKG_CMAKE_OPTS_INIT} ${PKG_CMAKE_SCRIPT%/*}
       ;;
     "cmake-make:bootstrap")
-      echo "Executing (bootstrap): cmake ${BOOTSTRAP_CMAKE_OPTS} ${PKG_CMAKE_OPTS_BOOTSTRAP} $(dirname ${PKG_CMAKE_SCRIPT})" | tr -s " "
-      cmake ${BOOTSTRAP_CMAKE_OPTS} ${PKG_CMAKE_OPTS_BOOTSTRAP} $(dirname ${PKG_CMAKE_SCRIPT})
+      echo "Executing (bootstrap): cmake ${BOOTSTRAP_CMAKE_OPTS} ${PKG_CMAKE_OPTS_BOOTSTRAP} ${PKG_CMAKE_SCRIPT%/*}" | tr -s " "
+      cmake ${BOOTSTRAP_CMAKE_OPTS} ${PKG_CMAKE_OPTS_BOOTSTRAP} ${PKG_CMAKE_SCRIPT%/*}
       ;;
 
     # configure builds

--- a/scripts/image
+++ b/scripts/image
@@ -187,7 +187,7 @@ if [ -d "${PROJECT_DIR}/${PROJECT}/filesystem" ]; then
   # Install project specific systemd services
   for service in ${PROJECT_DIR}/${PROJECT}/filesystem/usr/lib/systemd/system/*.service; do
     if [ -f "${service}" ]; then
-      enable_service $(basename ${service})
+      enable_service ${service##*/}
     fi
   done
 fi
@@ -198,7 +198,7 @@ if [ -n "${DEVICE}" -a -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesyste
   # Install device specific systemd services
   for service in ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem/usr/lib/systemd/system/*.service; do
     if [ -f "${service}" ]; then
-      enable_service $(basename ${service})
+      enable_service ${service##*/}
     fi
   done
 fi

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -54,7 +54,7 @@ show_error() {
 trap cleanup SIGINT
 
 # create an image
-echo -e "\nimage: creating file $(basename ${DISK})..."
+echo -e "\nimage: creating file ${DISK##*/}..."
 dd if=/dev/zero of="${DISK}" bs=1M count="${DISK_SIZE}" conv=fsync >"${SAVE_ERROR}" 2>&1 || show_error
 
 # write a disklabel
@@ -200,7 +200,7 @@ EOF
 
   for dtb in "${RELEASE_DIR}/3rdparty/bootloader/"*.dtb ; do
     if [ -f "${dtb}" ]; then
-      mcopy "${dtb}" ::/$(basename "${dtb}")
+      mcopy "${dtb}" ::/"${dtb##*/}"
     fi
   done
 
@@ -327,7 +327,7 @@ pigz --best --force "${DISK}"
 
 # create sha256 checksum of image
 ( cd "${TARGET_IMG}"
-  sha256sum $(basename "${DISK}").gz > $(basename "${DISK}").gz.sha256
+  sha256sum "${DISK##*/}.gz" > "${DISK##*/}.gz.sha256"
 )
 
 # cleanup

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -158,7 +158,7 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
              ${PROJECT_DIR}/${PROJECT}/patches/${PKG_NAME}/${PKG_VERSION}/*.patch \
              ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/patches/${PKG_NAME}/*.patch; do
 
-      thisdir="$(dirname "${i}")"
+      thisdir="${i%/*}"
 
       if [ "${thisdir}" = "${PKG_DIR}/patches" ]; then
         PATCH_DESC="(common)"
@@ -178,11 +178,11 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
         PATCH_DESC="(device)"
       else
         if [[ "${thisdir}" =~ ^${PKG_DIR}/.* ]]; then
-          PATCH_DESC="(common - $(basename "${thisdir}"))"
+          PATCH_DESC="(common - ${thisdir##*/})"
         elif [[ "${thisdir}" =~ ^${PROJECT_DIR}/.*/devices/.* ]]; then
-          PATCH_DESC="(device - $(basename "${thisdir}"))"
+          PATCH_DESC="(device - ${thisdir##*/})"
         elif [[ "${thisdir}" =~ ^${PROJECT_DIR}/.* ]]; then
-          PATCH_DESC="(project - $(basename "${thisdir}"))"
+          PATCH_DESC="(project - ${thisdir##*/})"
         else
           PATCH_DESC="(absolute - ${i})"
         fi

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -191,9 +191,9 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
       if [ -f "${i}" ]; then
         build_msg "CLR_APPLY_PATCH" "APPLY PATCH $(print_color "CLR_PATCH_DESC" "${PATCH_DESC}")" "${i#${ROOT}/}"
         if grep -qE '^GIT binary patch$|^rename from|^rename to' ${i}; then
-          cat ${i} | git apply --directory=$(echo "${PKG_BUILD}" | cut -f1 -d\ ) -p1 --verbose --whitespace=nowarn --unsafe-paths >&${VERBOSE_OUT}
+          git apply --directory="${PKG_BUILD}" -p1 --verbose --whitespace=nowarn --unsafe-paths < ${i} >&${VERBOSE_OUT}
         else
-          cat ${i} | patch -d $(echo "${PKG_BUILD}" | cut -f1 -d\ ) -p1 >&${VERBOSE_OUT}
+          patch -d "${PKG_BUILD}" -p1 < ${i} >&${VERBOSE_OUT}
         fi
       fi
     done
@@ -201,7 +201,7 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
     pkg_call_exists_opt post_patch && pkg_call
   fi
 
-  if [ ! "${PKG_NAME}" = "configtools" ] ; then
+  if [ "${PKG_NAME}" != "configtools" ] ; then
     for config in $(find "${PKG_BUILD}" -name config.guess | sed 's/config.guess//'); do
       build_msg "CLR_FIXCONFIG" "FIXCONFIG" "${config}"
 


### PR DESCRIPTION
This series is about reducing the number of subprocesses invoked in the buildsystem. Mostly reducing `basename` and `dirname` usage through bash builtins. Also replacing some `cat $file | patch ...` with `patch ... < $file`.

I've been using since Christmas or so.