### PR TITLE
LibreELEC-settings: update to caee341

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="9e62eaae3083cb30e1efc45a9c21ed1918283275"
-PKG_SHA256="f0d6e03c78d12577fb2c51cf2c344fdd4cfca2ded17e96b5c17f3bdd561d7cd6"
+PKG_VERSION="caee341cb6ab69a8e864640c304fd980c9e5139f"
+PKG_SHA256="a2a126481f7ea50ea0584014e9b265cf895977af1c4191628ed7835b92460323"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
partly fixes BT at the settings addon