### PR TITLE
Update rust resolving TARGET=HOST build issues 

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
@@ -14,6 +14,7 @@ PKG_TOOLCHAIN="manual"
 make_target() {
   . "$(get_build_dir rust)/cargo/env"
   cargo build \
+    ${CARGO_Z_TARGET_APPLIES_TO_HOST} \
     --release \
     --locked \
     --all-features

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -25,6 +25,7 @@ PKG_MAINTAINER="Anton Voyl (awiouy)"
 make_target() {
   . $(get_build_dir rust)/cargo/env
   cargo build \
+    ${CARGO_Z_TARGET_APPLIES_TO_HOST} \
     --release \
     --no-default-features \
     --features "alsa-backend pulseaudio-backend with-dns-sd with-vorbis"

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,6 @@
+124
+- Include bottom (btm) in Generic
+
 123
 - Update stress-ng to 0.12.11
 - Update unrar to 6.0.7

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="123"
+PKG_REV="124"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -19,6 +19,7 @@ PKG_ADDON_TYPE="xbmc.python.script"
 
 PKG_DEPENDS_TARGET="toolchain \
                     autossh \
+                    bottom \
                     diffutils \
                     dstat \
                     dtach \
@@ -51,8 +52,6 @@ PKG_DEPENDS_TARGET="toolchain \
 
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" efibootmgr st"
-else
-  PKG_DEPENDS_TARGET+=" bottom"
 fi
 
 addon() {


### PR DESCRIPTION
PR that fixes the rust TARGET=HOST build issues

- librespot: fix build where TARGET=HOST with rust 1.54
-  system-tools: update to (124)
- bottom: fix build where TARGET=HOST with rust 1.54
- rust: use nightly until 1.54 is released

this was tested with **nightly-x86_64-unknown-linux-gnu installed - rustc 1.55.0-nightly (ce1d5611a 2021-06-18)**

no planned to be pulled into master until 1.54 is released - 29th July 2021

- https://github.com/rust-lang/rust/pull/85926 (cargo update)
- https://github.com/rust-lang/cargo/pull/9322 (patch to cargo)
- https://github.com/rust-lang/cargo/issues/9453 (Tracking issue)
- https://github.com/rust-lang/rust/milestone/82?closed=1 (1.54 milestone)
- https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#target-applies-to-host
- https://github.com/rust-lang/cargo/pull/9753 (Stabilize)
