### PR TITLE
tools: refresh-patches: fix PATCH_ARCH

### DIFF
--- a/tools/refresh-patches
+++ b/tools/refresh-patches
@@ -67,6 +67,8 @@ pkg_call_exists_opt pre_patch && pkg_call
 
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PATCH_ARCH="x86"
+elif  [ "${PKG_IS_KERNEL_PKG}" = "yes" ]; then
+  PATCH_ARCH="${TARGET_KERNEL_PATCH_ARCH:-${TARGET_ARCH}}"
 else
   PATCH_ARCH="${TARGET_PATCH_ARCH:-${TARGET_ARCH}}"
 fi


### PR DESCRIPTION
A leftover from https://github.com/LibreELEC/LibreELEC.tv/pull/5431
I missed to check tools - there should be no further cases now:

```
~/LibreELEC.tv$ grep -r TARGET_PATCH_ARCH
tools/refresh-patches:  PATCH_ARCH="${TARGET_PATCH_ARCH:-${TARGET_ARCH}}"
scripts/unpack:      PATCH_ARCH="${TARGET_PATCH_ARCH:-${TARGET_ARCH}}"
```