### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="2.6.16-Matrix"
-PKG_SHA256="49b9971973a8df16faa2a7a46d81156484a27c98930eae56dad12d466910db13"
+PKG_VERSION="2.6.17-Matrix"
+PKG_SHA256="e8cae619332e269736e95f336279e4d76e36d52714060472d6a07028bdf05a81"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive - 2.6.16-Matrix