### PR TITLE
[LE 9.2] add LIBC_WIDEVINE_PATCHLEVEL to kodi config and fix aarch64 patchload from arm

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -35,6 +35,11 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --enable-lock-elision \
                            --disable-timezone-tools"
 
+# workaround to use arm patches for aarch64
+if [ "${TARGET_PATCH_ARCH}" = "aarch64" ]; then
+  PKG_PATCH_DIRS="arm"
+fi
+
 # busybox:init needs it
 # testcase: boot with /storage as nfs-share (set cmdline.txt -> "ip=dhcp boot=UUID=2407-5145 disk=NFS=[nfs-share] quiet")
 PKG_CONFIGURE_OPTS_TARGET+=" --enable-obsolete-rpc"

--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -43,6 +43,11 @@ else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf
 fi
 
+# required for inputstreamhelper to detect TLS 64-bytes support
+if [ -n "$(uname -m | grep arm)" ] || [ "$(uname -m)" == "aarch64" ]; then
+  echo "LIBC_WIDEVINE_PATCHLEVEL=1" >> /run/libreelec/kodi.conf
+fi
+
 if [ -f /storage/.config/kodi.conf ] ; then
   cat /storage/.config/kodi.conf >>/run/libreelec/kodi.conf
 fi


### PR DESCRIPTION
This is necessary for script.module.inputstreamhelper addon to detect that the glibc package already contains the [TLS 64-byte alignment](https://github.com/LibreELEC/LibreELEC.tv/commit/16921614dcb206d53e78b654c60a1e06e8e72f25#diff-246ec78884f9e3f4631cd12faacde7f0bfcbf7c16824b02791f573c3bb095ce6) patch.

References:
https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/450
https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/457