### PR TITLE
mpd: update to 0.22.9 and addon (111)

### DIFF
--- a/packages/addons/service/mpd/changelog.txt
+++ b/packages/addons/service/mpd/changelog.txt
@@ -1,3 +1,7 @@
+111
+- include wavpack support
+- Update to version 0.22.9
+
 110
 - Update to version 0.22.6
 

--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -3,15 +3,16 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpd"
-PKG_VERSION="0.22.6"
-PKG_SHA256="2be149a4895c3cb613477f8cf1193593e3d8a1d38a75ffa7d32da8c8316a4d5e"
-PKG_REV="110"
+PKG_VERSION="0.22.9"
+PKG_SHA256="f937403297c2240bd4a569f4b937ee7ab17398a5284ba9df4d6d4c3a0512bc64"
+PKG_REV="111"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"
 PKG_URL="http://www.musicpd.org/download/mpd/$(get_pkg_version_maj_min)/mpd-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain alsa-lib avahi boost curl faad2 ffmpeg flac glib lame libcdio libiconv libid3tag \
-                    libmad libmpdclient libsamplerate libvorbis libnfs libogg mpd-mpc opus pulseaudio samba yajl libgcrypt"
+PKG_DEPENDS_TARGET="toolchain alsa-lib avahi boost curl faad2 ffmpeg flac glib lame libcdio libgcrypt \
+                    libiconv libid3tag libmad libmpdclient libsamplerate libvorbis libnfs libogg \
+                    mpd-mpc opus pulseaudio samba wavpack yajl"
 PKG_SECTION="service.multimedia"
 PKG_SHORTDESC="Music Player Daemon (MPD): a free and open Music Player Server"
 PKG_LONGDESC="Music Player Daemon (${PKG_VERSION}) is a flexible and powerful server-side application for playing music"
@@ -89,7 +90,7 @@ PKG_MESON_OPTS_TARGET=" \
   -Dvorbis=enabled \
   -Dvorbisenc=enabled \
   -Dwave_encoder=true \
-  -Dwavpack=disabled \
+  -Dwavpack=enabled \
   -Dwebdav=enabled \
   -Dwildmidi=disabled \
   -Dyajl=enabled \

--- a/packages/audio/wavpack/package.mk
+++ b/packages/audio/wavpack/package.mk
@@ -11,8 +11,8 @@ PKG_DEPENDS_TARGET="toolchain libiconv"
 PKG_LONGDESC="Audio compression format providing lossless, high-quality lossy and hybrid compression mode."
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_TESTING=OFF \
+                       -DCMAKE_INSTALL_INCLUDEDIR=include/wavpack \
                        -DWAVPACK_BUILD_PROGRAMS=OFF \
                        -DWAVPACK_BUILD_DOCS=OFF \
                        -DWAVPACK_ENABLE_ASM=OFF \
                        -DWAVPACK_INSTALL_DOCS=OFF"
-


### PR DESCRIPTION
include wavpack as a dependency

- update mpd 0.22.6 to 0.22.9
- wavpack fix includedir 

Ref: https://forum.libreelec.tv/thread/24193-raspberry-pi-4-libreelec-music-player-daemon-wavpack-dsd-fail/?postID=157364#post157364