### PR TITLE
[LE 10] add LIBC_WIDEVINE_PATCHLEVEL environment variable to kodi config

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -43,6 +43,11 @@ else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf
 fi
 
+# required for inputstreamhelper to detect TLS 64-bytes support
+if [ -n "$(uname -m | grep arm)" ] || [ "$(uname -m)" == "aarch64" ]; then
+  echo "LIBC_WIDEVINE_PATCHLEVEL=1" >> /run/libreelec/kodi.conf
+fi
+
 if [ -f /storage/.config/kodi.conf ] ; then
   cat /storage/.config/kodi.conf >>/run/libreelec/kodi.conf
 fi


### PR DESCRIPTION
This is necessary for script.module.inputstreamhelper addon to detect that the glibc package already contains the [TLS 64-byte alignment](https://github.com/LibreELEC/LibreELEC.tv/commit/5ce550c35407a8b20af0fce094b163695be64e9e#diff-246ec78884f9e3f4631cd12faacde7f0bfcbf7c16824b02791f573c3bb095ce6) patch.

References:
https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/450
https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/457