### PR TITLE
fontconfig: use a custom dir instead of Kodi's font dir for user fonts

### DIFF
--- a/packages/x11/other/fontconfig/conf.d/05-user-fonts.conf
+++ b/packages/x11/other/fontconfig/conf.d/05-user-fonts.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
-  <dir>/storage/.kodi/media/Fonts</dir>
+  <dir>/storage/.cache/fonts</dir>
 </fontconfig>


### PR DESCRIPTION
Untested. Mostly opened as a reminder to follow up on https://github.com/xbmc/xbmc/issues/19728

Ultimate conclusion is to have a space for users to store custom fonts that is not also Kodi's space for custom fonts. I don't know how this interacts with current users storing fonts in Kodi's space (will they need to move fonts?).