### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="7.1.0-Matrix"
-PKG_SHA256="d91f195c4a91af893231d03a887a340900c4e515597ea059ee6b9e6444717fc9"
-PKG_REV="4"
+PKG_VERSION="7.1.1-Matrix"
+PKG_SHA256="2162e7e0998e984fe2ce87ba6f87ee6ed66fd1256172801b556892e3c7b09223"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.argustv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvblink"
-PKG_VERSION="9.1.0-Matrix"
-PKG_SHA256="4b216871a16c7d9d9ab29f2788dfd0abdc828d1a2cb8203e84aee60ded75c9f6"
-PKG_REV="3"
+PKG_VERSION="9.1.2-Matrix"
+PKG_SHA256="e4491b7f4ee7f565f5b13ca4ea52640c2be076271d22de1fb4e35e69dc8c2bbf"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.dvblink"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvbviewer"
-PKG_VERSION="7.2.0-Matrix"
-PKG_SHA256="aa81c0a59c00aa13bc1ea3adc078e2910fde42bc86ad3a78ecefc6e4c3d5de59"
-PKG_REV="3"
+PKG_VERSION="7.3.1-Matrix"
+PKG_SHA256="962066b3ea287438266f994dab00db81987debe15f57d9f8c9306897f71cd9a5"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.dvbviewer"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.filmon"
-PKG_VERSION="6.1.0-Matrix"
-PKG_SHA256="7c2998bdde04acee5c147cb9f82939cfb13af57e5ecf46a4343dcfee15eb02e2"
-PKG_REV="4"
+PKG_VERSION="6.1.1-Matrix"
+PKG_SHA256="e910a111c835f1f1b187ced1f8ccfdce189e37308519c733ae43b54ed3946c00"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.filmon"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hdhomerun"
-PKG_VERSION="7.1.0-Matrix"
-PKG_SHA256="a31587e00d58efb72aadba3ad1bd67c08332feef0d558e0eeb6fda7c81bf93e8"
-PKG_REV="4"
+PKG_VERSION="7.1.1-Matrix"
+PKG_SHA256="90a44fb73b471813c9ca99b802b5a119287c9d7fde705ae215d9f59bb8da9830"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hdhomerun"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="7.6.5-Matrix"
-PKG_SHA256="2b46ab509e26fb4a60759e78f9f13808f5bb2c67a03a62c58ebcadb31c26e6e1"
+PKG_VERSION="7.6.6-Matrix"
+PKG_SHA256="03014900663b0ba323b651169b2da1ff4e909622618ee09100ce3b63cc93e79c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="8.2.0-Matrix"
-PKG_SHA256="0109daa45d7b6450954b40d0b09dbef28818c551e9f0fea9943cfd06f0a7ec40"
+PKG_VERSION="8.2.1-Matrix"
+PKG_SHA256="2051aea6d4c94c963699f4e7bd84e0083d8355dc465df0673f6b67d1f4d6198b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="8.2.3-Matrix"
-PKG_SHA256="f5f36c2da5c74af3af5be5f50ce1dccd3b3026ddfbf68cbb2962cc721874668d"
+PKG_VERSION="8.2.5-Matrix"
+PKG_SHA256="5e8fb80f96daa658f1049a66be6d11aa055eca3f92e40f72f4c469767ca4504b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.njoy"
-PKG_VERSION="7.1.0-Matrix"
-PKG_SHA256="26134e815efd38fa09507a6119e6463c4785a78a417e253558d23a94a9989613"
-PKG_REV="3"
+PKG_VERSION="7.1.1-Matrix"
+PKG_SHA256="6a7edf45bfe0e9bad0fe460accf9a9c0bbb93a907c2becf5e48dcc79a803cc8b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.njoy"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.pctv"
-PKG_VERSION="6.1.0-Matrix"
-PKG_SHA256="94b8be4988cb6d8c61f6bdf237ddabb04d77fe4900f61411f5abf918eb5a078c"
-PKG_REV="4"
+PKG_VERSION="6.1.1-Matrix"
+PKG_SHA256="2692fc0387762f62e8fc9e57f21d613e4c2e52553d3eb30ee042f91cc61155ac"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.pctv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="7.1.0-Matrix"
-PKG_SHA256="bce055008d0ae7212924f41753970e3176a218f6a45bd76b202463a43be3d192"
-PKG_REV="4"
+PKG_VERSION="7.1.1-Matrix"
+PKG_SHA256="4450dcdacfb471d8d10e3a487bace8c57f1cab4629f1be1c57adae2165fcc5b8"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.stalker"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vbox"
-PKG_VERSION="8.1.0-Matrix"
-PKG_SHA256="b30548dfbf892f7bedbf191b5a9d93fa978fb794f897268876a1e607518e15af"
-PKG_REV="3"
+PKG_VERSION="8.1.2-Matrix"
+PKG_SHA256="b53943101401b97e6a3f63f7e4d3bffc78d892329b8fd9ef5cfb0833277456ea"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vbox"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="8.2.2-Matrix"
-PKG_SHA256="aebb00f433b93256760960149e41647d65c84fdf6a78d7467df304f26c8bc4b2"
-PKG_REV="3"
+PKG_VERSION="8.2.3-Matrix"
+PKG_SHA256="702410caf142c76434ed716900221f1292b3713501e3744330df6c2feb890614"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vdr.vnsi"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="7.4.3-Matrix"
-PKG_SHA256="0845aeb136395cad979d9d4c687a8a2bd0b30e361ac9569368d564ec88316a5e"
+PKG_VERSION="7.4.4-Matrix"
+PKG_SHA256="0f81cc26b99b7fecd364de6679b0c44701c46ad15fcda0a766b10bfe3d670ead"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="6.1.1-Matrix"
-PKG_SHA256="b58b4d6d2358faf5887133ea1794a2d3f8b35f77411aacafa569d45f7bc4bb3a"
-PKG_REV="3"
+PKG_VERSION="6.1.2-Matrix"
+PKG_SHA256="4e534ca49390b0fcb62c23f1076235e1664358ee67bd3f8ed04660d16094053a"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.wmc"


### PR DESCRIPTION
- pvr.argustv from 7.1.0-Matrix to 7.1.1-Matrix
- pvr.dvblink from 9.1.0-Matrix to 9.1.2-Matrix
- pvr.dvbviewer from 7.2.0-Matrix to 7.3.1-Matrix
- pvr.filmon from 6.1.0-Matrix to 6.1.1-Matrix
- pvr.hdhomerun from 7.1.0-Matrix to 7.1.1-Matrix
- pvr.iptvsimple from 7.6.5-Matrix to 7.6.6-Matrix
- pvr.mediaportal.tvserver from 8.2.0-Matrix to 8.2.1-Matrix
- pvr.nextpvr from 8.2.3-Matrix to 8.2.5-Matrix
- pvr.njoy from 7.1.0-Matrix to 7.1.1-Matrix
- pvr.pctv from 6.1.0-Matrix to 6.1.1-Matrix
- pvr.stalker from 7.1.0-Matrix to 7.1.1-Matrix
- pvr.vbox from 8.1.0-Matrix to 8.1.2-Matrix
- pvr.vdr.vnsi from 8.2.2-Matrix to 8.2.3-Matrix
- pvr.vuplus from 7.4.3-Matrix to 7.4.4-Matrix
- pvr.wmc from 6.1.1-Matrix to 6.1.2-Matrix
