### PR TITLE
dotnet-runtime: update to 3.1.16

### DIFF
--- a/packages/addons/tools/dotnet-runtime/changelog.txt
+++ b/packages/addons/tools/dotnet-runtime/changelog.txt
@@ -1,3 +1,6 @@
+113
+- Update to ASP.NET Core Runtime 3.1.16
+
 112
 - Update to ASP.NET Core Runtime 3.1.10
 

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_VERSION="3.1.10"
-PKG_REV="112"
+PKG_VERSION="3.1.16"
+PKG_REV="113"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
-PKG_SITE="https://dotnet.github.io/"
+PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain icu"
 PKG_SECTION="tools"
 PKG_SHORTDESC=".NET Core Runtime"
@@ -21,16 +21,16 @@ PKG_MAINTAINER="Anton Voyl (awiouy)"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="ef11a880d59b19f1df355b3c9c8b35ea1aa37e72d179850051cad963cb72358f"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/936a9563-1dad-4c4b-b366-c7fcc3e28215/a1edcaf4c35bce760d07e3f1f3d0b9cf/aspnetcore-runtime-3.1.10-linux-arm64.tar.gz"
+    PKG_SHA256="b76c049484efd86466d2e1cd88994521633c399d090adb1c6804128603816abe"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/64353333-3080-45f7-a3d5-33e391e4596c/e9d5d53cb318628485e8d1fbd26ec30d/aspnetcore-runtime-3.1.16-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="29c6aa914739dce59e04d1fc7dceb33e97dfec6624ec3c297a8375f66aece092"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/a2223d1f-c138-4586-8cd1-274c5387e975/623ece755546aca8f4be268f525683c5/aspnetcore-runtime-3.1.10-linux-arm.tar.gz"
+    PKG_SHA256="a0163cd5c5ceae228bfffb40053f3509e155a110c23e81c38705757a870e24cc"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/bd734390-3b5f-402a-826f-e0eae538b8ba/5914dd937ede96cb9297e6e7a80f46f3/aspnetcore-runtime-3.1.16-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="b58376e76c68f03e142ac9a771b782cb7be926a16e920d83c711903b82608f3a"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/eca743d3-030f-4b1b-bd15-3573091f1c02/f3e464abc31deb7bc2747ed6cc1a8f5c/aspnetcore-runtime-3.1.10-linux-x64.tar.gz"
+    PKG_SHA256="b1a2f61d8a49e2a3ca5eb9daa103b83eb49ea1bcf14914560e601222e94a3022"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/c20a5ac5-5174-46b8-a875-b916a416050d/b2ddd212a183260569178d880899bd94/aspnetcore-runtime-3.1.16-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"


### PR DESCRIPTION
update 3.1.10 (2020-11-10) to 3.1.16 (2021-06-08)

release notes:
- 3.1.11 (security) - https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.11/3.1.11.md
- 3.1.12 (security) - https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.12/3.1.12.md
- 3.1.13 (security) - https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.13/3.1.13.md
- 3.1.14 - https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.14/3.1.14.md
- 3.1.15 (security) - https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.15/3.1.15.md
- 3.1.16 (security) - https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.16/3.1.16.md

```
# ps -ef | grep emby
 1448 root      0:03 dotnet /storage/.kodi/addons/service.emby4/libs/system/EmbyServer.dll -programdata /storage/.kodi/userdata/addon_data/service.emby4 -ffmpeg /storage/.kodi/addons/tools.ffmpeg-tools/bin/ffmpeg -ffprobe /storage/.kodi/addons/tools.ffmpeg-tools/bin/ffprobe

# dotnet --info
  It was not possible to find any installed .NET Core SDKs
  Did you mean to run .NET Core SDK commands? Install a .NET Core SDK from:
      https://aka.ms/dotnet-download

Host (useful for support):
  Version: 3.1.16
  Commit:  4c6b4aa257

.NET Core SDKs installed:
  No SDKs were found.

.NET Core runtimes installed:
  Microsoft.AspNetCore.App 3.1.16 [/storage/.kodi/addons/tools.dotnet-runtime/bin/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 3.1.16 [/storage/.kodi/addons/tools.dotnet-runtime/bin/shared/Microsoft.NETCore.App]

To install additional .NET Core runtimes or SDKs:
  https://aka.ms/dotnet-download
```