### PR TITLE
network-tools and system-tools updates

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libpcap"
-PKG_VERSION="1.10.0"
-PKG_SHA256="8d12b42623eeefee872f123bd0dc85d535b00df4d42e865f993c40f7bfc92b1e"
+PKG_VERSION="1.10.1"
+PKG_SHA256="ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tcpdump.org/"
 PKG_URL="http://www.tcpdump.org/release/libpcap-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tcpdump"
-PKG_VERSION="4.99.0"
-PKG_SHA256="8cf2f17a9528774a7b41060323be8b73f76024f7778f59c34efa65d49d80b842"
+PKG_VERSION="4.99.1"
+PKG_SHA256="79b36985fb2703146618d87c4acde3e068b91c553fb93f021a337f175fd10ebe"
 PKG_SITE="http://www.tcpdump.org/"
 PKG_URL="http://www.tcpdump.org/release/tcpdump-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libpcap libtirpc"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.12.09"
-PKG_SHA256="cffac091082c7adbfec649be3c66941c3d622f8b96795656bcce2e20d669cfeb"
+PKG_VERSION="0.12.11"
+PKG_SHA256="971393075321c24c3d5769acfabb705911d1f411ced5937b7cfea58528c1b4e6"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://kernel.ubuntu.com/~cking/stress-ng/"
 PKG_URL="https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="unrar"
-PKG_VERSION="6.0.6"
-PKG_SHA256="011ef7290d3394a62bb5bfced914cd510a7eea7255cf69417f9c952bb6056588"
+PKG_VERSION="6.0.7"
+PKG_SHA256="a7029942006cbcced3f3b7322ec197683f8e7be408972ca08099b196c038f518"
 PKG_LICENSE="free"
 PKG_SITE="https://www.rarlab.com/rar_add.htm"
 PKG_URL="https://www.rarlab.com/rar/unrarsrc-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vim"
-PKG_VERSION="8.2.2879"
-PKG_SHA256="b14d0cab60e1f0562e269a7ff80476b73fcf8ee357cd90d2839e0210bfb8d001"
+PKG_VERSION="8.2.3095"
+PKG_SHA256="31588e2a074e2e2ea170704e5a40c61413f2a825788db325d1419c334e6d50b6"
 PKG_LICENSE="VIM"
 PKG_SITE="http://www.vim.org/"
 PKG_URL="https://github.com/vim/vim/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/network-tools/changelog.txt
+++ b/packages/addons/tools/network-tools/changelog.txt
@@ -1,3 +1,7 @@
+110
+- libpcap: update to 1.10.1
+- tcpdump: update to 4.99.1
+
 109
 - irssi: update to 1.2.3
 - lftp: update to 4.9.2

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="109"
+PKG_REV="110"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,8 @@
+123
+- Update stress-ng to 0.12.11
+- Update unrar to 6.0.7
+- Update vim to 8.2.2879
+
 122
 - Added bottom (btm) (successor to ytop) - all arch except Generic
 - Update file to 5.40
@@ -7,7 +12,6 @@
 - Update stress-ng to 0.12.09
 - Update unrar to 6.0.6
 - Update vim to 8.2.2879
-
 
 121
 - remove strace

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="122"
+PKG_REV="123"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
Updates:
- network-tools: update to 110
- system-tools: update to 123

Packages:
- libpcap: update to 1.10.1
- stress-ng: update to 0.12.11
- tcpdump: update to 4.99.1
- unrar: update to 6.0.7
- vim: update to 8.2.3095