### PR TITLE
strace: update to 5.12

### DIFF
--- a/packages/debug/strace/package.mk
+++ b/packages/debug/strace/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="strace"
-PKG_VERSION="5.11"
-PKG_SHA256="ffe340b10c145a0f85734271e9cce56457d23f21a7ea5931ab32f8cf4e793879"
+PKG_VERSION="5.12"
+PKG_SHA256="29171edf9d252f89c988a4c340dfdec662f458cb8c63d85431d64bab5911e7c4"
 PKG_LICENSE="BSD"
 PKG_SITE="https://strace.io/"
 PKG_URL="https://strace.io/files/${PKG_VERSION}/strace-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Noteworthy changes in strace 5.12 (2021-04-26)

Improvements
- Implemented --secontext[=full] option to display SELinux contexts.
- Implemented decoding of mount_setattr syscall introduced in Linux 5.12.
- Updated decoding of IFLA_BRPORT_* netlink attributes to match Linux 5.12.
- Updated lists of DEVCONF_*, IORING_*, KVM_*, MPOL_*, MTD_*, NFT_MSG_*, RESOLVE_*, RTM_*, ST_*, and V4L2_* constants.
- Updated lists of ioctl commands from Linux 5.12.

Bug fixes
- Fixed build using bionic libc.

Portability
- Added binutils 2.36 support to --enable-mpers builds.