### PR TITLE
libconfig: disable build of doc and tests

### DIFF
--- a/packages/addons/addon-depends/libconfig/package.mk
+++ b/packages/addons/addon-depends/libconfig/package.mk
@@ -13,7 +13,9 @@ PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \
+                           --disable-doc \
                            --disable-examples \
+                           --disable-tests \
                            --with-sysroot=${SYSROOT_PREFIX}"
 
 pre_configure_target() {


### PR DESCRIPTION
This PR fixes the call on the build server to rebuild .texi files. This matches the functionality of 1.7.2 - but uses the --disable-doc syntax, instead of the patch.