### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="1.21.3-Matrix"
-PKG_SHA256="f871010d3f62c4f5c1a294c898802a0ef8456e3e9eb96f7cd69be07916981a6b"
+PKG_VERSION="1.21.4-Matrix"
+PKG_SHA256="a26811689d5ada1254ab1e91d9148a7e6b4b87d227772daff2d98a4ba961bc76"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="7.1.3-Matrix"
-PKG_SHA256="83509dde2d37e15e910b1b90baa0dc96b4c92dcb7603c87d4b26a00ffd7ba9ed"
+PKG_VERSION="7.1.4-Matrix"
+PKG_SHA256="a6ef1f57600ad4e021fe405822a3d9d2a6f014b5552a09d3acc852bfa2f8601c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="7.6.6-Matrix"
-PKG_SHA256="03014900663b0ba323b651169b2da1ff4e909622618ee09100ce3b63cc93e79c"
+PKG_VERSION="7.6.7-Matrix"
+PKG_SHA256="86ea2dba6a99dec2b1968e1e73139b7d96cb0dd7c0ffd01bda414a6be0cf3050"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.ffmpegdirect: 1.21.3-Matrix to 1.21.4-Matrix
- pvr.demo: 7.1.3-Matrix to 7.1.4-Matrix
- pvr.iptvsimple: 7.6.6-Matrix to 7.6.7-Matrix