### PR TITLE
linux (RPi): update to 5.10.46-69b899c

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="5ceac9414fd634dbc0762d80677744465634af2f"
-PKG_SHA256="5e9f690ffb378748c8b4e9f3d8e8688701932b50db9202842cd8df2808993f70"
+PKG_VERSION="19272ccd69049aaf42c78a235a0bf37dbabd5ea7"
+PKG_SHA256="09d9b324b936a8171627f2b912e972b75caece1e1187e878ff59ab22165d6dce"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="9b672c5441497337f286686122a6f17fd7985cc2" # 5.10.46
-    PKG_SHA256="5f620ce59d6f27dd77f7675517c3f691b40c4b9cce6d608f3bbfd3e449f9125c"
+    PKG_VERSION="69b899ca24c83d5bb486e19aef4c4ef6938aa9c9" # 5.10.46
+    PKG_SHA256="34089a27fba08bfe74974d5476aeb359d628f59a7d759b1206015d0e382d633f"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="5ceac9414fd634dbc0762d80677744465634af2f"
-PKG_SHA256="6ae8d2ea912cf6cc52f4fc9bc01a823b00a9f8c2ecb61d261bb0d12bee379c9e"
+PKG_VERSION="19272ccd69049aaf42c78a235a0bf37dbabd5ea7"
+PKG_SHA256="42b6b94462cd13ae12f2dd99f5e386d0814865e50cd49a9477b182882f03b438"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/projects/RPi/devices/RPi4/config/distroconfig.txt
+++ b/projects/RPi/devices/RPi4/config/distroconfig.txt
@@ -6,6 +6,3 @@ dtoverlay=vc4-kms-v3d,cma-512
 dtoverlay=rpivid-v4l2
 disable_overscan=1
 disable_fw_kms_setup=1
-# temporarily limit framebuffer size to avoid gpu memory issues at 4kp60
-max_framebuffer_width=1920
-max_framebuffer_width=1080


### PR DESCRIPTION
Updated kernel and firmware now correctly release the firmware-allocated framebuffer when KMS takes over and we can drop the temporary workaround

Runtime tested on RPi4 and RPi3B+