### PR TITLE
Allwinner: H3: linux: Fix CEC patch

### DIFF
--- a/projects/Allwinner/devices/H3/patches/linux/0001-HACK-SW-CEC-implementation-for-H3.patch
+++ b/projects/Allwinner/devices/H3/patches/linux/0001-HACK-SW-CEC-implementation-for-H3.patch
@@ -82,7 +82,7 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
  	struct clk			*clk_phy;
 --- a/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
-@@ -505,8 +505,9 @@ static void sun8i_hdmi_phy_init_h3(struc
+@@ -498,8 +498,9 @@ static void sun8i_hdmi_phy_init_h3(struc
  	regmap_update_bits(phy->regs, SUN8I_HDMI_PHY_PLL_CFG1_REG,
  			   SUN8I_HDMI_PHY_PLL_CFG1_CKIN_SEL_MSK, 0);
  
@@ -94,7 +94,7 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
  
  	/* read calibration data */
  	regmap_read(phy->regs, SUN8I_HDMI_PHY_ANA_STS_REG, &val);
-@@ -532,8 +533,47 @@ void sun8i_hdmi_phy_set_ops(struct sun8i
+@@ -525,8 +526,47 @@ void sun8i_hdmi_phy_set_ops(struct sun8i
  		plat_data->cur_ctr = variant->cur_ctr;
  		plat_data->phy_config = variant->phy_cfg;
  	}
@@ -142,7 +142,7 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
  static const struct regmap_config sun8i_hdmi_phy_regmap_config = {
  	.reg_bits	= 32,
  	.val_bits	= 32,
-@@ -550,6 +590,7 @@ static const struct sun8i_hdmi_phy_varia
+@@ -543,6 +583,7 @@ static const struct sun8i_hdmi_phy_varia
  };
  
  static const struct sun8i_hdmi_phy_variant sun8i_h3_hdmi_phy = {
@@ -150,7 +150,7 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
  	.has_phy_clk = true,
  	.is_custom_phy = true,
  	.phy_init = &sun8i_hdmi_phy_init_h3,
-@@ -712,10 +753,36 @@ int sun8i_hdmi_phy_probe(struct sun8i_dw
+@@ -725,10 +766,36 @@ static int sun8i_hdmi_phy_probe(struct p
  		clk_prepare_enable(phy->clk_phy);
  	}
  
@@ -174,7 +174,7 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
 +			goto err_put_cec_notifier;
 +	}
 +
- 	hdmi->phy = phy;
+ 	platform_set_drvdata(pdev, phy);
  
  	return 0;
  
@@ -187,9 +187,9 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
  err_disable_clk_mod:
  	clk_disable_unprepare(phy->clk_mod);
  err_disable_clk_bus:
-@@ -740,6 +807,9 @@ void sun8i_hdmi_phy_remove(struct sun8i_
+@@ -753,6 +820,9 @@ static int sun8i_hdmi_phy_remove(struct
  {
- 	struct sun8i_hdmi_phy *phy = hdmi->phy;
+ 	struct sun8i_hdmi_phy *phy = platform_get_drvdata(pdev);
  
 +	cec_notifier_cec_adap_unregister(phy->cec_notifier, phy->cec_adapter);
 +	cec_unregister_adapter(phy->cec_adapter);


### PR DESCRIPTION
This PR fixes H3 build failure after recent Linux update to 5.10.47.