### PR TITLE
connman: update to 1.40

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="3fed7f91ee8acb934f9f795c79640533d1f268ca" # 1.39 + 2021-03-27
-PKG_SHA256="79f78144972621f34888292903e042888607b184e1cb3ce9c22bfcd98588e828"
+PKG_VERSION="1.40"
+PKG_SHA256="5a95f36eb66ed8e8270b12df65349444a506e2fc68ba0313b0787ccc00004c27"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-${PKG_VERSION}.tar.gz"

--- a/packages/network/connman/patches/connman-01-do-not-cleanup-routes.patch
+++ b/packages/network/connman/patches/connman-01-do-not-cleanup-routes.patch
@@ -2,8 +2,8 @@ diff --git a/src/device.c b/src/device.c
 index 0fda950..eb09e53 100644
 --- a/src/device.c
 +++ b/src/device.c
-@@ -1247,8 +1247,6 @@ int __connman_device_init(const char *device, const char *nodevice)
- 	if (nodevice != NULL)
+@@ -1490,8 +1490,6 @@ int __connman_device_init(const char *device, const char *nodevice)
+ 	if (nodevice)
  		nodevice_filter = g_strsplit(nodevice, ",", -1);
  
 -	cleanup_devices();

--- a/packages/network/connman/patches/connman-04-ipv6-disabled-by-default.patch
+++ b/packages/network/connman/patches/connman-04-ipv6-disabled-by-default.patch
@@ -8,8 +8,8 @@ diff --git a/src/ipconfig.c b/src/ipconfig.c
 index fbeff8f..3eb61c4 100644
 --- a/src/ipconfig.c
 +++ b/src/ipconfig.c
-@@ -1123,10 +1123,7 @@ static struct connman_ipconfig *create_ipv6config(int index)
- 	ipv6config->enabled = false;
+@@ -1243,10 +1243,7 @@ static struct connman_ipconfig *create_ipv6config(int index)
+ 	ipv6config->index = index;
  	ipv6config->type = CONNMAN_IPCONFIG_TYPE_IPV6;
  
 -	if (!is_ipv6_supported)
@@ -19,4 +19,4 @@ index fbeff8f..3eb61c4 100644
 +	ipv6config->method = CONNMAN_IPCONFIG_METHOD_OFF;
  
  	ipdevice = g_hash_table_lookup(ipdevice_hash, GINT_TO_POINTER(index));
- 	if (ipdevice != NULL)
+ 	if (ipdevice)

--- a/packages/network/connman/patches/connman-05_link-against-ncurses.patch
+++ b/packages/network/connman/patches/connman-05_link-against-ncurses.patch
@@ -11,7 +11,7 @@ diff --git a/Makefile.am b/Makefile.am
 index 41efc1f..d1d3ddc 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -252,7 +252,7 @@ client_connmanctl_SOURCES = client/dbus_helpers.h client/dbus_helpers.c \
+@@ -312,7 +312,7 @@ client_connmanctl_SOURCES = client/dbus_helpers.h client/dbus_helpers.c \
  			client/main.c
  
  client_connmanctl_LDADD = gdbus/libgdbus-internal.la @DBUS_LIBS@ @GLIB_LIBS@ \
@@ -19,7 +19,7 @@ index 41efc1f..d1d3ddc 100644
 +				-lreadline -lncurses -ldl
  endif
  
- noinst_PROGRAMS += unit/test-pbkdf2-sha1 unit/test-prf-sha1 unit/test-ippool
+ noinst_PROGRAMS += unit/test-ippool
 -- 
 1.7.10.4
 


### PR DESCRIPTION
Update of githash to release incorporating post 1.39 patches that were necessary bugfixes.

- patches post 1.40 do not look applicable
- tidy up of patches (fuzz)