### PR TITLE
systemd: update to 250.3 and include Jinja2

### DIFF
--- a/packages/python/devel/Jinja2/package.mk
+++ b/packages/python/devel/Jinja2/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="Jinja2"
+PKG_VERSION="3.0.3"
+PKG_SHA256="611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
+PKG_LICENSE="BSD"
+PKG_SITE="https://pypi.org/project/Jinja2/"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="Python3:host setuptools:host MarkupSafe:host"
+PKG_LONGDESC="Jinja is a fast, expressive, extensible templating engine."
+PKG_TOOLCHAIN="manual"
+
+makeinstall_host() {
+  exec_thread_safe python3 setup.py install --prefix=${TOOLCHAIN}
+}

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="systemd"
-PKG_VERSION="247.10"
-PKG_SHA256="8ce78a664ac0090934ee3b576dc1cfc0a9bbf7fa166aa59c6237915ef2a35b74"
+PKG_VERSION="250.3"
+PKG_SHA256="87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd-stable/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain libcap kmod util-linux entropy libidn2 wait-time-sync"
+PKG_DEPENDS_TARGET="toolchain libcap kmod util-linux entropy libidn2 wait-time-sync Jinja2:host"
 PKG_LONGDESC="A system and session manager for Linux, compatible with SysV and LSB init scripts."
 
 PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \

--- a/packages/sysutils/systemd/patches/systemd-0001-move-etc-systemd-system-to-storage-.config-system.d.patch
+++ b/packages/sysutils/systemd/patches/systemd-0001-move-etc-systemd-system-to-storage-.config-system.d.patch
@@ -8,12 +8,12 @@ diff --git a/meson.build b/meson.build
 index dbbddb68e2..4592cd1094 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -205,7 +205,7 @@ memory_accounting_default = get_option('memory-accounting-default')
- status_unit_format_default = get_option('status-unit-format-default')
- 
- conf.set_quoted('PKGSYSCONFDIR',                              pkgsysconfdir)
--conf.set_quoted('SYSTEM_CONFIG_UNIT_DIR',                     join_paths(pkgsysconfdir, 'system'))
+@@ -266,7 +266,7 @@
+ conf.set_quoted('SYSTEMD_UPDATE_HELPER_PATH',                 rootlibexecdir / 'systemd-update-helper')
+ conf.set_quoted('SYSTEMD_USERWORK_PATH',                      rootlibexecdir / 'systemd-userwork')
+ conf.set_quoted('SYSTEMD_VERITYSETUP_PATH',                   rootlibexecdir / 'systemd-veritysetup')
+-conf.set_quoted('SYSTEM_CONFIG_UNIT_DIR',                     pkgsysconfdir / 'system')
 +conf.set_quoted('SYSTEM_CONFIG_UNIT_DIR',                     '/storage/.config/system.d')
- conf.set_quoted('SYSTEM_DATA_UNIT_PATH',                      systemunitdir)
- conf.set_quoted('SYSTEM_SYSVINIT_PATH',                       sysvinit_path)
- conf.set_quoted('SYSTEM_SYSVRCND_PATH',                       sysvrcnd_path)
+ conf.set_quoted('SYSTEM_DATA_UNIT_DIR',                       systemunitdir)
+ conf.set_quoted('SYSTEM_ENV_GENERATOR_DIR',                   systemenvgeneratordir)
+ conf.set_quoted('SYSTEM_GENERATOR_DIR',                       systemgeneratordir)

--- a/packages/sysutils/systemd/patches/systemd-0002-move-hwdb.bin-to-run.patch
+++ b/packages/sysutils/systemd/patches/systemd-0002-move-hwdb.bin-to-run.patch
@@ -4,16 +4,16 @@ Date: Thu, 11 Apr 2019 20:00:05 +0100
 Subject: [PATCH] move hwdb.bin to /run
 
 ---
- src/libsystemd/sd-hwdb/hwdb-util.c   | 2 +-
- src/libsystemd/sd-hwdb/sd-hwdb.c     | 2 +-
+ src/shared/hwdb-util.c   | 2 +-
+ src/libsystemd/sd-hwdb/hwdb-internal.h     | 2 +-
  units/systemd-hwdb-update.service.in | 2 +-
  3 files changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/src/libsystemd/sd-hwdb/hwdb-util.c b/src/libsystemd/sd-hwdb/hwdb-util.c
+diff --git a/src/shared/hwdb-util.c b/src/shared/hwdb-util.c
 index c83575c..6285f3d 100644
---- a/src/libsystemd/sd-hwdb/hwdb-util.c
-+++ b/src/libsystemd/sd-hwdb/hwdb-util.c
-@@ -20,7 +20,7 @@
+--- a/src/shared/hwdb-util.c
++++ b/src/shared/hwdb-util.c
+@@ -21,7 +21,7 @@
  #include "strv.h"
  #include "tmpfile-util.h"
  
@@ -22,27 +22,27 @@ index c83575c..6285f3d 100644
  static const char * const conf_file_dirs[] = {
          "/etc/udev/hwdb.d",
          UDEVLIBEXECDIR "/hwdb.d",
-diff --git a/src/libsystemd/sd-hwdb/sd-hwdb.c b/src/libsystemd/sd-hwdb/sd-hwdb.c
+diff --git a/src/libsystemd/sd-hwdb/hwdb-internal.h b/src/libsystemd/sd-hwdb/hwdb-internal.h
 index 79fe1a8..0acbf71 100644
---- a/src/libsystemd/sd-hwdb/sd-hwdb.c
-+++ b/src/libsystemd/sd-hwdb/sd-hwdb.c
-@@ -299,7 +299,7 @@ static int trie_search_f(sd_hwdb *hwdb, const char *search) {
+--- a/src/libsystemd/sd-hwdb/hwdb-internal.h	2021-07-07 17:41:29.000000000 +0000
++++ b/src/libsystemd/sd-hwdb/hwdb-internal.h	2021-07-08 10:59:13.723718762 +0000
+@@ -83,7 +83,7 @@
  
- static const char hwdb_bin_paths[] =
-         "/etc/systemd/hwdb/hwdb.bin\0"
--        "/etc/udev/hwdb.bin\0"
-+        "/run/hwdb.bin\0"
-         "/usr/lib/systemd/hwdb/hwdb.bin\0"
- #if HAVE_SPLIT_USR
-         "/lib/systemd/hwdb/hwdb.bin\0"
+ #define hwdb_bin_paths                          \
+         "/etc/systemd/hwdb/hwdb.bin\0"          \
+-        "/etc/udev/hwdb.bin\0"                  \
++        "/run/hwdb.bin\0"                       \
+         "/usr/lib/systemd/hwdb/hwdb.bin\0"      \
+         _CONF_PATHS_SPLIT_USR_NULSTR("systemd/hwdb/hwdb.bin") \
+         UDEVLIBEXECDIR "/hwdb.bin\0"
 diff --git a/units/systemd-hwdb-update.service.in b/units/systemd-hwdb-update.service.in
 index 259fe0d..18d617f 100644
 --- a/units/systemd-hwdb-update.service.in
 +++ b/units/systemd-hwdb-update.service.in
-@@ -16,7 +16,7 @@ After=systemd-remount-fs.service
+@@ -16,7 +16,7 @@
  Before=sysinit.target shutdown.target systemd-update-done.service
  ConditionNeedsUpdate=/etc
- ConditionPathExists=|!@udevlibexecdir@/hwdb.bin
+ ConditionPathExists=|!{{UDEVLIBEXECDIR}}/hwdb.bin
 -ConditionPathExists=|/etc/udev/hwdb.bin
 +ConditionPathExists=|/run/hwdb.bin
  ConditionDirectoryNotEmpty=|/etc/udev/hwdb.d/

--- a/packages/sysutils/systemd/patches/systemd-0003-remove-nonexistant-dependency.patch
+++ b/packages/sysutils/systemd/patches/systemd-0003-remove-nonexistant-dependency.patch
@@ -11,7 +11,7 @@ diff --git a/units/graphical.target b/units/graphical.target
 index 87be97e..b01b46d 100644
 --- a/units/graphical.target
 +++ b/units/graphical.target
-@@ -9,7 +9,6 @@
+@@ -11,7 +11,6 @@
  Description=Graphical Interface
  Documentation=man:systemd.special(7)
  Requires=multi-user.target

--- a/packages/sysutils/systemd/patches/systemd-0200-persist-persistent-timer-stamps.patch
+++ b/packages/sysutils/systemd/patches/systemd-0200-persist-persistent-timer-stamps.patch
@@ -11,7 +11,7 @@ diff --git a/src/core/timer.c b/src/core/timer.c
 index 03935ee..bfd5c02 100644
 --- a/src/core/timer.c
 +++ b/src/core/timer.c
-@@ -154,11 +154,11 @@ static int timer_setup_persistent(Timer *t) {
+@@ -144,11 +144,11 @@ static int timer_setup_persistent(Timer *t) {
  
          if (MANAGER_IS_SYSTEM(UNIT(t)->manager)) {
  

--- a/packages/sysutils/systemd/patches/systemd-0300-config-env-unhide-cursor.patch
+++ b/packages/sysutils/systemd/patches/systemd-0300-config-env-unhide-cursor.patch
@@ -11,12 +11,12 @@ diff --git a/units/debug-shell.service.in b/units/debug-shell.service.in
 index 1127e68..4c3e971 100644
 --- a/units/debug-shell.service.in
 +++ b/units/debug-shell.service.in
-@@ -16,8 +16,8 @@ IgnoreOnIsolate=yes
- ConditionPathExists=@DEBUGTTY@
+@@ -15,8 +15,8 @@ IgnoreOnIsolate=yes
+ ConditionPathExists={{DEBUGTTY}}
  
  [Service]
 -Environment=TERM=linux
--ExecStart=@SUSHELL@
+-ExecStart={{SUSHELL}}
 +Environment=ENV=/etc/profile
 +ExecStart=/bin/sh -c 'echo -en "\033[?25h"; exec /bin/sh'
  Restart=always


### PR DESCRIPTION
new build dependency used by systemd v249 

systemd >= v249 requires Jinja2 for templating
- refer: https://github.com/systemd/systemd/pull/19630: Use jinja2 for templating
- m4 use is dropped, and the two parallel substitution systems in meson are unified.

can be added at anytime. 
Not required until systemd v249
Including Jinja2 with the v250 systemd

Systemd NEWS: https://github.com/systemd/systemd/blob/main/NEWS

systemd: update from v247 to v250

issues: 
- FIXED: need to track down error: `systemd-journald[360]: Failed to write entry (22 items, 760 bytes), rotating before retrying: Argument list too long`
- FIXED: why is my docker console output getting into `journalctl -f`
- FIXED: Issue with 250-rc3 - systemd/systemd 21829 - temp patch -
c7f6f36 - fixed in https://github.com/systemd/systemd/pull/21846
