### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="2.6.18-Matrix"
-PKG_SHA256="2b79136dfd9468dc4bdfd23725a5cb3bb62e0bb095ffe287bbe707099d977935"
+PKG_VERSION="2.6.22-Matrix"
+PKG_SHA256="48eea3785dc820ee48cf652483ff91a1589d0fabe3f61c740e04595b5a020288"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="1.21.6-Matrix"
-PKG_SHA256="72d07be3705820f264bf9b0942b0ba15f0a40a5867e976c15d017b408b4a122b"
+PKG_VERSION="1.21.8-Matrix"
+PKG_SHA256="c40d05db6f7efae2b3e6c703ad32863f4a11582af7349c8ab940840e4b0fb0a5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="8.3.3-Matrix"
-PKG_SHA256="9d44f4ebee2dd1d67cf30c4cf2e2185ec24b5923a567ce2216f9c1073e53c1c6"
+PKG_VERSION="8.3.4-Matrix"
+PKG_SHA256="98f4250d8d8700741798524ea8a3756c5d02403408c74de2d2d3b22b3f13aa23"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="7.4.7-Matrix"
-PKG_SHA256="7c8c891b4e0e7c8334e5e5eca91a9868e6737e52df12213b888942f940572136"
+PKG_VERSION="7.4.9-Matrix"
+PKG_SHA256="c6032c7b79e45a83523c6fb32a7b097e8c8fa81de76996babdd160b2288061a4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.shadertoy"
-PKG_VERSION="2.3.0-Matrix"
-PKG_SHA256="fbee4d8d4a41013705848eb89d4dcd55fe915a1ff997a60c800aa1bdd157530b"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="6c106c0d8e53f9b0794291a1c53e9a00370ff79be73919d556048dce0bb9785c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.shadertoy"

--- a/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.spectrum"
-PKG_VERSION="3.4.0-Matrix"
-PKG_SHA256="0b08b99c0289a421425a5d3b39eafdf6262021e213bd3093e98704efb410d348"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="32b130c26581c224e9b43672ccb5c947f2f4982e6d2ab12e389b41a9ceeb0e3f"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.spectrum"

--- a/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.starburst"
-PKG_VERSION="2.4.0-Matrix"
-PKG_SHA256="fb991924b8f9a4f86d81b28ec629c131d36364f82914098356184c9ef03e753e"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="b610919fd181dac638cbcea3f88b01a0b3522941415fde8fab51a17a88f536e2"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.starburst"

--- a/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.waveform"
-PKG_VERSION="4.4.0-Matrix"
-PKG_SHA256="d9acf0a3758bfc4ee6fa492bcdcf8764519bbf0f1b6a3b10807b65a0d031e55e"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="c0b20e5d5877c34be107df0db142d46def785acb7269e6525f39a511c5a8e030"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.waveform"


### PR DESCRIPTION
- inputstream.adaptive: update 2.6.18-Matrix to 2.6.22-Matrix
- inputstream.ffmpegdirect: update 1.21.6-Matrix to 1.21.8-Matrix
- pvr.hts: update 8.3.3-Matrix to 8.3.4-Matrix
- pvr.vuplus: update 7.4.7-Matrix to 7.4.9-Matrix
- visualization.shadertoy: update 2.3.0-Matrix to 19.0.0-Matrix
- visualization.spectrum: update 3.4.0-Matrix to 19.0.0-Matrix
- visualization.starburst: update 2.4.0-Matrix to 19.0.0-Matrix
- visualization.waveform: update 4.4.0-Matrix to 19.0.0-Matrix