### PR TITLE
linux: remove make headers_check

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -82,14 +82,7 @@ post_patch() {
 }
 
 make_host() {
-  make \
-    ARCH=${HEADERS_ARCH:-${TARGET_KERNEL_ARCH}} \
-    HOSTCC="${TOOLCHAIN}/bin/host-gcc" \
-    HOSTCXX="${TOOLCHAIN}/bin/host-g++" \
-    HOSTCFLAGS="${HOST_CFLAGS}" \
-    HOSTCXXFLAGS="${HOST_CXXFLAGS}" \
-    HOSTLDFLAGS="${HOST_LDFLAGS}" \
-    headers_check
+  :
 }
 
 makeinstall_host() {


### PR DESCRIPTION
With the latest kernels - the following error is displayed instead of the no-op.

```
...
BUILD      linux (host)
    TOOLCHAIN      make (auto-detect)
make[1]: Entering directory LibreELEC.tv/build.LibreELEC- ...
=================== WARNING ===================
Since Linux 5.5, 'make headers_check' is no-op,
and will be removed after Linux 5.15 release.
Please remove headers_check from your scripts.
===============================================
...
```
### Replace the make_host() with our own no-op