### PR TITLE
brcmfmac_sdio-firmware-rpi: update to 883b726

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="4c47758bed7cd547dff3618a1739dcf64b5a52a7"
-PKG_SHA256="ae665baa465a09dddf7f4bdec67e108a74b2a3787550cc9ee53c2bea9651f327"
+PKG_VERSION="883b72628de1d7efa45b421da0cbf175ac2374f8"
+PKG_SHA256="0e7fcfe75a8990815a184dc55f8fdf5d0644d351a15a7aef865ff90ff4ca8eb4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"
 PKG_URL="https://github.com/LibreELEC/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update CYW43455 bluetooth firmware:
Second Spectra fix for CYW43455 (CVE-2020-10370)