### PR TITLE
libretro-picodrive: revert PicoDrive removal

### DIFF
--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-picodrive"
-PKG_VERSION="67cdfb8c5d407c5a4e8f25ffa0ee7fac716b0690"
-PKG_SHA256="39871c4c5d2af833a4ae56ef83cfe21102edc563b728f00c56d50de9857cbf1e"
+PKG_VERSION="3620f75d20e43abd2f9d793a7c0824c764c3860b"
+PKG_SHA256="cff60412dbdad246cbe8bb6673679b5b0b15f93c9cd4434bc2bb1c56aa5ec551"
 PKG_LICENSE="MAME"
-PKG_SITE="https://github.com/libretro/picodrive"
-PKG_URL="https://github.com/libretro/picodrive/archive/${PKG_VERSION}.tar.gz"
+PKG_SITE="https://github.com/kodi-game/picodrive"
+PKG_URL="https://github.com/kodi-game/picodrive/releases/download/picodrive-${PKG_VERSION}/picodrive-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain kodi-platform ${PKG_NAME}:host"
 PKG_DEPENDS_UNPACK="cyclone68000"

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -45,7 +45,24 @@ post_configure_target() {
 }
 
 make_target() {
-  R= make -f Makefile.libretro
+  if target_has_feature neon; then
+    export HAVE_NEON=1
+    export BUILTIN_GPU=neon
+   else
+    export HAVE_NEON=0
+  fi
+
+  case ${TARGET_ARCH} in
+    aarch64)
+      R= make -f Makefile.libretro platform=aarch64
+      ;;
+    arm)
+      R= make -f Makefile.libretro platform=armv
+      ;;
+    x86_64)
+      R= make -f Makefile.libretro
+      ;;
+  esac
 }
 
 makeinstall_target() {

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-picodrive"
+PKG_VERSION="67cdfb8c5d407c5a4e8f25ffa0ee7fac716b0690"
+PKG_SHA256="39871c4c5d2af833a4ae56ef83cfe21102edc563b728f00c56d50de9857cbf1e"
+PKG_LICENSE="MAME"
+PKG_SITE="https://github.com/libretro/picodrive"
+PKG_URL="https://github.com/libretro/picodrive/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="toolchain:host"
+PKG_DEPENDS_TARGET="toolchain kodi-platform ${PKG_NAME}:host"
+PKG_DEPENDS_UNPACK="cyclone68000"
+PKG_LONGDESC="Fast MegaDrive/MegaCD/32X emulator"
+PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-gold"
+
+PKG_LIBNAME="picodrive_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="PICODRIVE_LIB"
+
+pre_build_host() {
+  cp -a $(get_build_dir cyclone68000)/* ${PKG_BUILD}/cpu/cyclone/
+}
+
+pre_configure_host() {
+  # fails to build in subdirs
+  cd ${PKG_BUILD}
+  rm -rf .${HOST_NAME}
+}
+
+make_host() {
+  if [ "${ARCH}" = "arm" ]; then
+    make -C cpu/cyclone CONFIG_FILE=../cyclone_config.h
+  fi
+}
+
+pre_configure_target() {
+  # fails to build in subdirs
+  cd ${PKG_BUILD}
+  rm -rf .${TARGET_NAME}
+}
+
+post_configure_target() {
+  sed -e "s|^GIT_VERSION :=.*$|GIT_VERSION := \" ${PKG_VERSION:0:7}\"|" -i Makefile.libretro
+}
+
+make_target() {
+  R= make -f Makefile.libretro
+}
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.picodrive"
+PKG_VERSION="1.96.0.16-Matrix"
+PKG_SHA256="b3d30cfb97a377ebb29041b053dda363b0a7d921f2a5e8fc9cbb510ea3b0249d"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.libretro.picodrive"
+PKG_URL="https://github.com/kodi-game/game.libretro.picodrive/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-picodrive"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.picodrive: picodrive for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.picodrive"
-PKG_VERSION="1.96.0.16-Matrix"
-PKG_SHA256="b3d30cfb97a377ebb29041b053dda363b0a7d921f2a5e8fc9cbb510ea3b0249d"
+PKG_VERSION="1.98.0.23-Matrix"
+PKG_SHA256="f05ae0f19795a2fe52795bd7ae6ff4d8dc5337285643db3a22f541135b14d6f1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
The PicoDrive was removed by ba5db73131f35d7d58ba5d68fbe86cc6b51bd410 due to the "missing upstream files".

I'd like to get it back so I reverted it, updated it to the latest version and changed the source URL from https://github.com/libretro/picodrive/ to https://github.com/kodi-game/picodrive/ which seems to have fixed the missing file.

It seems to build fine again but there is a runtime error on ARM platforms which I'd like to fix as well. This runtime error was there for a long time before the package removal:
`ERROR: AddOnLog: Sega - MS/MD/CD/32X (PicoDrive): Unable to load: /storage/.kodi/addons/game.libretro.picodrive/game.libretro.picodrive.so: unexpected reloc type 0x03
`

I've found a reference to the same error but the solution is not explained here:
https://retropie.org.uk/forum/topic/12690/lr-picodrive-segmentation-fault/10

Anyone can give me a hint on how to fix this?
