### PR TITLE
iw: fix condition of regdomain udev rule

### DIFF
--- a/packages/network/iw/udev.d/60-iw-regdomain.rules
+++ b/packages/network/iw/udev.d/60-iw-regdomain.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="ieee80211", ACTION=="add", RUN+="/usr/lib/iw/setregdomain"
+KERNEL=="regulatory*", ACTION=="add", SUBSYSTEM=="platform", RUN+="/usr/lib/iw/setregdomain"


### PR DESCRIPTION
Reported in the [forum](https://forum.libreelec.tv/thread/23676-libreelec-10-beta-5ghz-wifi-issue/?postID=157916#post157916): regdomain can be set in Settings addon, but disappear on reboot.

Update udev condition to recent kernels.