### PR TITLE
RPi: update to firmware 775e6a7

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="7208c3d557c7cc95bca06aa917dda1f7db91250c"
-PKG_SHA256="f35a02f684877a3099906f1beb1e0ec61deabc15b01bb962cc9ea2fca238560e"
+PKG_VERSION="775e6a7eb1c5630d9e118c250a15614b1be30e0e"
+PKG_SHA256="77dfef413216dfe73e7c02307c2ba6a693c45ccc9ae921de1ce78fecff2eba6e"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="7208c3d557c7cc95bca06aa917dda1f7db91250c"
-PKG_SHA256="25e5deb748e93a198b2fd6496757c587c31eeb5aecf00e7a95fa7db4542c515d"
+PKG_VERSION="775e6a7eb1c5630d9e118c250a15614b1be30e0e"
+PKG_SHA256="47e091f0733780b07cccd4869560c7e354aeedbe068bbce77c5bc23042467bd5"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"


### PR DESCRIPTION
This fixes non-working USB on RPi4 rev 1.4 as reported on the forum https://forum.libreelec.tv/thread/24284-no-usb-on-rpi-4-after-upgrading-to-le10-rc1/
