### PR TITLE
Revert "RPi4: make 4kp60 enabled per default"

### DIFF
--- a/projects/RPi/devices/RPi4/config/distroconfig.txt
+++ b/projects/RPi/devices/RPi4/config/distroconfig.txt
@@ -9,4 +9,3 @@ dtoverlay=rpivid-v4l2
 dtoverlay=
 disable_overscan=1
 disable_fw_kms_setup=1
-hdmi_enable_4kp60=1


### PR DESCRIPTION
Enabling 4kp60 by default was premature, we got a report that TV shows "no signal" after putting it into standby in 4kp50/60 modes - which isn't great as 4kp60 is the default GUI mode on fresh installations with 4k TVs and 4kp60 enabled.

So better leave 4kp60 disabled for now, we can revisit this topic later again when the issues are resolved.

Also see https://forum.libreelec.tv/thread/24279-pi4-no-screen-after-turning-tv-off-and-on-in-4k-50hz-or-4k-60hz/ and https://github.com/raspberrypi/linux/issues/4486