### PR TITLE
go: update to 1.16.6

### DIFF
--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -23,6 +23,7 @@ pre_make_target() {
   export CONTAINERD_REVISION=${PKG_GIT_COMMIT}
   export CONTAINERD_PKG=github.com/containerd/containerd
   export LDFLAGS="-w -extldflags -static -X ${CONTAINERD_PKG}/version.Version=${CONTAINERD_VERSION} -X ${CONTAINERD_PKG}/version.Revision=${CONTAINERD_REVISION} -X ${CONTAINERD_PKG}/version.Package=${CONTAINERD_PKG} -extld ${CC}"
+  export GO111MODULE=off
 
   mkdir -p ${GOPATH}
   if [ -d ${PKG_BUILD}/vendor ]; then

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.14.15"
-PKG_SHA256="8167eeb636eeef6010dc004e5ab4a0af77ea3e1c9fe8b3c2fef38c3ddb72bc7d"
+PKG_VERSION="1.16.6"
+PKG_SHA256="498cd89c5c965ea2f2e23eef589e0a2dcb4b94f31c3f7dac575d4c35ae89caf7"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/go/patches/go-0001-add-ca-cert-location.patch
+++ b/packages/addons/addon-depends/go/patches/go-0001-add-ca-cert-location.patch
@@ -1,10 +1,10 @@
---- a/src/crypto/x509/root_unix.go
-+++ b/src/crypto/x509/root_unix.go
-@@ -20,6 +20,7 @@
+diff --git a/src/crypto/x509/root_linux.go b/src/crypto/x509/root_linux.go
+index ad6ce5cae7..763c686fed 100644
+--- a/src/crypto/x509/root_linux.go
++++ b/src/crypto/x509/root_linux.go
+@@ -20,4 +20,5 @@ var certDirectories = []string{
+ 	"/etc/ssl/certs",               // SLES10/SLES11, https://golang.org/issue/12139
  	"/etc/pki/tls/certs",           // Fedora/RHEL
- 	"/etc/openssl/certs",           // NetBSD
- 	"/var/ssl/certs",               // AIX
-+    "/etc/ssl",                     // LibreELEC
+ 	"/system/etc/security/cacerts", // Android
++	"/etc/ssl",                     // LibreELEC
  }
- 
- const (

--- a/packages/addons/addon-depends/libnetwork/package.mk
+++ b/packages/addons/addon-depends/libnetwork/package.mk
@@ -17,6 +17,7 @@ pre_make_target() {
 
   export CGO_ENABLED=0
   export LDFLAGS="-extld ${CC}"
+  export GO111MODULE=off
 
   mkdir -p ${GOPATH}
   if [ -d ${PKG_BUILD}/vendor ]; then

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -36,6 +36,7 @@ configure_target() {
   PKG_GOPATH_ENGINE=${GOPATH}
   PKG_GOPATH_CLI=${GOPATH}_cli
   export GOPATH=${PKG_GOPATH_CLI}:${PKG_GOPATH_ENGINE}
+  export GO111MODULE=off
 
   export LDFLAGS="-w -linkmode external -extldflags -Wl,--unresolved-symbols=ignore-in-shared-libs -extld ${CC}"
 


### PR DESCRIPTION
GO111MODULE set to "off" for libnetwork / containerd/ docker because old go sources need this to continue compiling.

https://maelvls.dev/go111module-everywhere/