### PR TITLE
imagedecoder.raw: link against static lcms2

### DIFF
--- a/packages/graphics/lcms2/package.mk
+++ b/packages/graphics/lcms2/package.mk
@@ -9,3 +9,7 @@ PKG_SITE="http://www.littlecms.com"
 PKG_URL="${SOURCEFORGE_SRC}/lcms/lcms/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain tiff"
 PKG_LONGDESC="An small-footprint color management engine, with special focus on accuracy and performance."
+PKG_BUILD_FLAGS="+pic"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
+                           --enable-static"

--- a/packages/graphics/libraw/package.mk
+++ b/packages/graphics/libraw/package.mk
@@ -10,6 +10,7 @@ PKG_URL="http://www.libraw.org/data/LibRaw-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libjpeg-turbo lcms2"
 PKG_LONGDESC="A library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)"
 PKG_BUILD_FLAGS="+pic"
+PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.raw"
 PKG_VERSION="3.0.1-Matrix"
 PKG_SHA256="aeb18567485681631eb518876555555999464480a9854434f465354914ef66c2"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.raw"


### PR DESCRIPTION
- forum bug raised.
  - https://forum.libreelec.tv/thread/22435-libraw-image-decoder-not-working/?postID=158474#post158474
  - lcms2 was compiled as shared and libraw was linking against the shared library and consequently imagedecoder.raw.so.3.0.1 was dependant on liblcms2.so.2

Referenced in bug #5524 

**ldd looks correct now**
```
nuc11:/var/media/DATA/home-rudi/LibreELEC.tv # ldd build.LibreELEC-Generic.x86_64-10.0-devel/addons/imagedecoder.raw:target/imagedecoder.raw/imagedecoder.raw.so.3.0.1
        linux-vdso.so.1 (0x00007ffcabbdf000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f9e352f5000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f9e351b4000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f9e3519a000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f9e34fe2000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f9e35662000)
```

~~Will run test before requesting pull.~~ Test done on TGL with a CR2.
