### PR TITLE
persistent-journal: new addon 

### DIFF
--- a/packages/addons/service/persistent-journal/changelog.txt
+++ b/packages/addons/service/persistent-journal/changelog.txt
@@ -1,0 +1,2 @@
+100
+- Initial version

--- a/packages/addons/service/persistent-journal/package.mk
+++ b/packages/addons/service/persistent-journal/package.mk
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="persistent-journal"
+PKG_VERSION="0"
+PKG_REV="100"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://libreelec.tv"
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="service"
+PKG_SHORTDESC="Configure a persistent journal"
+PKG_LONGDESC="Configure a persistent journal on LibreELEC. Reboot required to apply changes."
+PKG_TOOLCHAIN="manual"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_NAME="LibreELEC Persistent Journal"
+PKG_ADDON_TYPE="xbmc.service"
+
+addon() {
+  :
+}

--- a/packages/addons/service/persistent-journal/source/bin/persistent-journal.config
+++ b/packages/addons/service/persistent-journal/source/bin/persistent-journal.config
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+. /etc/profile
+
+oe_setup_addon service.persistent-journal
+
+PERSIST_CONF=/run/systemd/journald.conf.d/journald-persist.conf
+
+mkdir -p /var/log
+mkdir -p /run/systemd/journald.conf.d
+mkdir -p /storage/.kodi/userdata/addon_data/service.persistent-journal/journal
+
+ln -sf /storage/.kodi/userdata/addon_data/service.persistent-journal/journal /var/log/
+
+cat <<-EOF >${PERSIST_CONF}
+	[Journal]
+	SystemMaxUse=${JOURNAL_SIZE}M
+	MaxRetentionSec=0
+	EOF
+
+if [ "${DISABLE_RATE_LIMIT}" = "true" ]; then
+  cat <<-EOF >>${PERSIST_CONF}
+	RateLimitInterval=0
+	RateLimitBurst=0
+	EOF
+fi
+
+exit 0

--- a/packages/addons/service/persistent-journal/source/default.py
+++ b/packages/addons/service/persistent-journal/source/default.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+import xbmc
+
+
+class Monitor(xbmc.Monitor):
+
+   def __init__(self, *args, **kwargs):
+      xbmc.Monitor.__init__(self)
+
+if __name__ == "__main__":
+   Monitor().waitForAbort()

--- a/packages/addons/service/persistent-journal/source/resources/language/English/strings.po
+++ b/packages/addons/service/persistent-journal/source/resources/language/English/strings.po
@@ -1,0 +1,17 @@
+# Kodi Media Center language file
+# Addon id: service.persistent.journal
+# Addon Provider: Team LibreELEC
+msgid ""
+msgstr ""
+
+msgctxt "#30000"
+msgid "Settings"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Journal size in MiBytes"
+msgstr ""
+
+msgctxt "#30002"
+msgid "Disable rate limit"
+msgstr ""

--- a/packages/addons/service/persistent-journal/source/resources/settings.xml
+++ b/packages/addons/service/persistent-journal/source/resources/settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+    <category label="30000">
+        <setting id="JOURNAL_SIZE" type="slider" option="int" range="30,300" label="30001" default="30" />
+        <setting id="DISABLE_RATE_LIMIT" type="bool" label="30002" default="true" />
+    </category>
+</settings>

--- a/packages/addons/service/persistent-journal/source/settings-default.xml
+++ b/packages/addons/service/persistent-journal/source/settings-default.xml
@@ -1,0 +1,4 @@
+<settings version="2">
+    <setting id="JOURNAL_SIZE" default="true">30</setting>
+    <setting id="DISABLE_RATE_LIMIT" default="true">true</setting>
+</settings>

--- a/packages/addons/service/persistent-journal/source/system.d/service.persistent-journal.service
+++ b/packages/addons/service/persistent-journal/source/system.d/service.persistent-journal.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Persistent /var/log/journal symlink
+DefaultDependencies=false
+After=var.mount systemd-tmpfiles.service
+Before=systemd-journald.service shutdown.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/storage/.kodi/addons/service.persistent-journal/bin/persistent-journal.config
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -82,7 +82,7 @@ fi
 
   cat_file "${LOG_FILE}"
 
-  journalctl -a -o short-precise | cat_data "journalctl -a"
+  journalctl -a -b -0 -o short-precise | cat_data "journalctl -a -b -0"
 
   if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then
     vcgencmd bootloader_version | cat_data "Bootloader version"


### PR DESCRIPTION
Easily configure persistent journal via addon.

While looking at #5505 I got the requirement again to use a larger and persistent journal. After having added the needed files used before to track some shutdown issues I got the idea to simplify it with an addon.

This is a RFC if this functionality is wanted in the repo for test and development cases.
