### PR TITLE
kodi: honour KODI_SAMBA_SUPPORT variable

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -131,6 +131,9 @@ configure_package() {
 
   if [ "${KODI_SAMBA_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" samba"
+    KODI_SAMBA="-DENABLE_SMBCLIENT=ON"
+  else
+    KODI_SAMBA="-DENABLE_SMBCLIENT=OFF"
   fi
 
   if [ "${KODI_WEBSERVER_SUPPORT}" = yes ]; then


### PR DESCRIPTION
without -DENABLE_SMBCLIENT=xx the kodi build will include smbclient if it finds it, or will fail if it doesn't. This define should be set so as to match the intention of the KODI_SAMBA_SUPPORT setting.