### PR TITLE
syncthing: update to 1.18.1

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.12.6"
-PKG_SHA256="d61ff8fa5685b911653c8153de6e6501728ec3aee26a9d5a56880bab3120426b"
+PKG_VERSION="1.14.15"
+PKG_SHA256="8167eeb636eeef6010dc004e5ab4a0af77ea3e1c9fe8b3c2fef38c3ddb72bc7d"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,6 @@
+110
+- Update to 1.18.1
+
 109
 - Update to 1.4.2
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.4.2"
-PKG_SHA256="061af43c1bbfcdf949499cdc50a325fff7cd67fb48f9d270adb52b4decbab899"
-PKG_REV="109"
+PKG_VERSION="1.18.1"
+PKG_SHA256="3f6b8e87a59e72ab3389d89364524e6abec454d4c36aaf3e334ac6fe37915584"
+PKG_REV="110"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"
@@ -12,7 +12,7 @@ PKG_URL="https://github.com/syncthing/syncthing/releases/download/v${PKG_VERSION
 PKG_DEPENDS_TARGET="toolchain go:host"
 PKG_SECTION="service/system"
 PKG_SHORTDESC="Syncthing: open source continuous file synchronization"
-PKG_LONGDESC="Syncthing ($PKG_VERSION) replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet."
+PKG_LONGDESC="Syncthing (${PKG_VERSION}) replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet."
 PKG_TOOLCHAIN="manual"
 
 PKG_IS_ADDON="yes"
@@ -53,10 +53,11 @@ configure_target() {
 }
 
 make_target() {
-  ${GOLANG} build -v -o bin/syncthing -a -ldflags "${LDFLAGS}" ./cmd/syncthing
+  ${GOLANG} build -a -ldflags "${LDFLAGS}" -o bin/syncthing -v ./cmd/syncthing
 }
 
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-  cp -P ${PKG_BUILD}/bin/syncthing ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P ${PKG_BUILD}/bin/syncthing \
+        ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 }


### PR DESCRIPTION
Syncthing has been upgraded significantly since 1.4.2 (2020-04-08). Its dependancies have been that golang 1.12 which supported 1.4.2 now needs to be updated to 1.14.x to support any version of syncthing since 1.8.0.
- https://github.com/syncthing/syncthing/releases

The PR updates:
- syncthing: update to 1.18.1
- go: update to 1.14.15

Docker (runc,containerd,libnetwork) are the only other packages using golang.

The PR has been tested with the following compiles:
`scripts/create_addon syncthing` and `scripts/create_addon docker` on x86_64

Testing of the addons will need to be undertaken before this can be released from Draft.