### PR TITLE
systemd/busybox: allow configuration of persistent logs and journal

### DIFF
--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -82,7 +82,7 @@ fi
 
   cat_file "${LOG_FILE}"
 
-  journalctl -a -o short-precise | cat_data "journalctl -a"
+  journalctl -a -b -0 -o short-precise | cat_data "journalctl -a -b -0"
 
   if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then
     vcgencmd bootloader_version | cat_data "Bootloader version"

--- a/packages/sysutils/busybox/system.d/storage-log.service
+++ b/packages/sysutils/busybox/system.d/storage-log.service
@@ -1,9 +1,10 @@
 [Unit]
-Description=Create Persistent Log Directory on /storage
+Description=Create Persistent Log Directory on /storage and rotate large logs
 DefaultDependencies=no
 RequiresMountsFor=/storage
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/mkdir -p /storage/.cache/log/journal
+ExecStart=/bin/mkdir -p /storage/.cache/log/journal /storage/.cache/journald.conf.d ; \
+/usr/bin/find /storage/.cache/log/ -maxdepth 1 -type f -size +512k ! -name '*.old' -exec mv {} {}.old \;

--- a/packages/sysutils/busybox/system.d/var-log.mount
+++ b/packages/sysutils/busybox/system.d/var-log.mount
@@ -6,6 +6,7 @@ After=storage-log.service
 ConditionKernelCommandLine=!installer
 ConditionKernelCommandLine=|debugging
 ConditionPathExists=|/storage/.cache/debug.libreelec
+ConditionPathExists=|/storage/.cache/journald.conf.d/00_settings.conf
 
 [Mount]
 What=/storage/.cache/log

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -250,6 +250,9 @@ post_makeinstall_target() {
   ln -sf /storage/.config/hwdb.d ${INSTALL}/etc/udev/hwdb.d
   safe_remove ${INSTALL}/etc/udev/rules.d
   ln -sf /storage/.config/udev.rules.d ${INSTALL}/etc/udev/rules.d
+
+  # journald
+  ln -sf /storage/.cache/journald.conf.d ${INSTALL}/usr/lib/systemd/journald.conf.d
 }
 
 post_install() {


### PR DESCRIPTION
Part of system integration of #5526 suggested by @chewitt 

Allow Settings Addon to enable the existing persistent log feature of the LE "debugging" option and add possibility to configure journald.

Implement simple log rotate to avoid unlimited growing of logs.

For the user interface LibreELEC/service.libreelec.settings#233 is required but this PR can be committed any time and the Settings Addon bumped later. 
