### PR TITLE
scripts/get_archive: allow changing sha256 on the fly

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -39,8 +39,13 @@ while [ ${NBWGET} -gt 0 -a ${NBCHKS} -gt 0 ]; do
 
       [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2
 
-      build_msg "CLR_WARNING" "WARNING" "Incorrect checksum calculated on downloaded file: got ${CALC_SHA256} wanted ${PKG_SHA256}"
-      NBCHKS=$((NBCHKS - 1))
+      if [ "${CHANGE_HASH}" = "yes" ]; then
+        sed -e "s|^PKG_SHA256=.*|PKG_SHA256=\"${CALC_SHA256}\"|" -i "${PKG_DIR}/package.mk"
+        break 2
+      else
+        build_msg "CLR_WARNING" "WARNING" "Incorrect checksum calculated on downloaded file: got ${CALC_SHA256} wanted ${PKG_SHA256}"
+        NBCHKS=$((NBCHKS - 1))
+      fi
     fi
   done
   NBWGET=$((NBWGET - 1))


### PR DESCRIPTION
Allows to change just the commit hash at bumping a package. The hash of the downloaded file gets pushed to the package.mk after first download.

Background:
If you change the githash at a package and run scripts/build|unpack... you get an error message that the hash is wrong (obviusly). So you need to generate/copy the hash from the downloaded file and edit the package.mk to make it work. 
After the change you need to download it again.

Adding CHANGE_HASH to parameter or .libreelec allows to work at packages without manually changing file hashes and avoiding redownload the file again.
`PROJECT=Generic ARCH=x86_64 scripts/build kodi` -> `PROJECT=Generic ARCH=x86_64 CHANGE_HASH=yes scripts/build kodi`