### PR TITLE
build with -fPIC: aom and opus

### DIFF
--- a/packages/addons/addon-depends/opus/package.mk
+++ b/packages/addons/addon-depends/opus/package.mk
@@ -10,6 +10,7 @@ PKG_URL="https://archive.mozilla.org/pub/opus/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Codec designed for interactive speech and audio transmission over the Internet."
 PKG_TOOLCHAIN="configure"
+PKG_BUILD_FLAGS="+pic"
 
 if [ "${TARGET_ARCH}" = "arm" ]; then
   PKG_FIXED_POINT="--enable-fixed-point"

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -9,6 +9,7 @@ PKG_SITE="https://www.webmproject.org"
 PKG_URL="http://repo.or.cz/aom.git/snapshot/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="AV1 Codec Library"
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DENABLE_CCACHE=1 \
                        -DENABLE_DOCS=0 \


### PR DESCRIPTION
With recent updates to the build environment, both aom and opus require -fPIC to compile tvheadend42 and tvheadend43 successfully.

- aom: build with -fPIC
- opus: build with -fPIC

`
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/lib/gcc/x86_64-libreelec-linux-gnu/10.3.0/../../../../x86_64-libreelec-linux-gnu/bin/ld.gold: error: /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libaom.a(av1_fwd_txfm1d_sse4.c.o): requires unsupported dynamic reloc 11; recompile with -fPIC
`

`
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/lib/gcc/x86_64-libreelec-linux-gnu/10.3.0/../../../../x86_64-libreelec-linux-gnu/bin/ld.gold: error: /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libopus.a(NLSF_VQ.o): requires dynamic R_X86_64_32 reloc which may overflow at runtime; recompile with -fPIC
`