### PR TITLE
parted: update that if INITRAMFS_PARTED_SUPPORT is set to "yes" then files are placed in /usr/sbin

### DIFF
--- a/packages/sysutils/parted/package.mk
+++ b/packages/sysutils/parted/package.mk
@@ -34,9 +34,9 @@ make_init() {
 }
 
 makeinstall_init() {
-  mkdir -p ${INSTALL}/sbin
-    cp ../.${TARGET_NAME}/parted/parted ${INSTALL}/sbin
-    cp ../.${TARGET_NAME}/partprobe/partprobe ${INSTALL}/sbin
+  mkdir -p ${INSTALL}/usr/sbin
+    cp ../.${TARGET_NAME}/parted/parted ${INSTALL}/usr/sbin
+    cp ../.${TARGET_NAME}/partprobe/partprobe ${INSTALL}/usr/sbin
 }
 
 pre_configure_target() {


### PR DESCRIPTION
**discovered this issue whilst bringing up RiscV but issue occurring on all**
First assumuption of the PATH not working was proved wrong. The actual issue was that `parted:init` when INITRAMFS_PARTED_SUPPORT is set to "yes" would not allow the link `ln -sfn /usr/sbin ${INSTALL}/sbin`

~~_PATH was set to include /usr/sbin, but not honoured without specifying as below._~~

~~The fsck step in init fails as fsck.ext4 can't be found.
Update the script to set the path for fsck to PATH=/usr/sbin~~

~~This fixes the below error.~~

~~```~~
~~+/usr/sbin/fsck -T -M -p -a 'UUID=1408-4055' 'UUID=01c82ea0-a853-4848-aa03-cb8702e48869'~~
~~+FSCK_RET=8~~
~~+cat /dev/fsck.latest~~
~~+'[' 8 -ge 16 ]~~
~~+'[' 8 -eq 8 ]~~
~~+'[' 0 -eq 0 ]~~
~~```~~

~~`[   22.919572] fsck: fsck: error 2 (No such file or directory) while executing fsck.ext4 for /dev/mmcblk0p2`~~

~~The /usr/sbin directory contains the following:~~

~~```~~
~# # ls -la /usr/sbin~~
~~-rwxr-xr-x    1    527248 e2fsck~~
~~-rwxr-xr-x    1     43976 fsck~~
~~lrwxrwxrwx    1         6 fsck.ext2 -> e2fsck~~
~~lrwxrwxrwx    1         6 fsck.ext3 -> e2fsck~~
~~lrwxrwxrwx    1         6 fsck.ext4 -> e2fsck~~
~~-rwxr-xr-x    1     59720 fsck.fat~~
~~lrwxrwxrwx    1         8 fsck.msdos -> fsck.fat~~
~~lrwxrwxrwx    1         8 fsck.vfat -> fsck.fat~~
~~-rwxr-xr-x    1     10192 mkfs~~
~~drwxr-xr-x    6       120 ..~~
~~drwxr-xr-x    2       220 .~~
~~```~~

~~Test using break=all :-~~
~~```~~
~~ ~# pwd~~
~~/~~
~~ ~# echo $PATH~~
~~/sbin:/usr/sbin:/bin:/usr/bin~~
~~ ~# fsck /dev/mmcblk0p2~~
~~fsck from util-linux 2.37.1~~
~~fsck: error 2 (No such file or directory) while executing fsck.ext4 for /dev/mmcblk0p2~~
~~ ~# PATH=/usr/sbin fsck /dev/mmcblk0p2~~
~~fsck from util-linux 2.37.1~~
~~e2fsck 1.46.3 (27-Jul-2021)~~
~~/dev/mmcblk0p2 is mounted.~~
~~e2fsck: Cannot continue, aborting.~~
~~```~~