### PR TITLE
kodi-binary-addons: update to latest versions (LE11)

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.2sf"
-PKG_VERSION="19.0.0-Matrix"
-PKG_SHA256="c17dc3bdeab626584b2480d83e91cb5c3b21033fdc72e94dd455aeb47a5dfaee"
+PKG_VERSION="19.0.1-Matrix"
+PKG_SHA256="56233081451f600e8a0057eaa4407a7889442e82460b90f83b391f6f103c2259"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.fluidsynth"
-PKG_VERSION="3.0.0-Matrix"
-PKG_SHA256="73d5f5dba2e67df7864fda3f550520d8e50187484175bb637162be6f2edb8271"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="62ca5f38f76b00ed2d69acf04a8ce2419491041cd229545e2187ff5b08145a62"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.fluidsynth"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gsf"
-PKG_VERSION="3.0.0-Matrix"
-PKG_SHA256="2bbc8b82dd8c88d4fd004d48013746bf80d79179227c31e0070123f885275785"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="444d8769a84a89410e2ec3ff2313312323a226280b07dc027b268f4063c52e45"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.ncsf"
-PKG_VERSION="3.0.0-Matrix"
-PKG_SHA256="ba3b11867e1dfc90d7765990122085588001981f762bf7e4d0cf5f41246e23e8"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="5bc7588ffe20d54107917bc5931018236d6ad68c567edc924fea54e43f63e17e"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.ncsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.nosefart"
-PKG_VERSION="3.0.0-Matrix"
-PKG_SHA256="a4be5f6efc46841c9b1689c91b06f69cd695220b583e62ed2948768fa93d09a2"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="4975c65b5acd002cf772707170e54bcbcc48d7898dd2e6b4239bab56636b44e7"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.nosefart"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="7.1.4-Matrix"
-PKG_SHA256="a6ef1f57600ad4e021fe405822a3d9d2a6f014b5552a09d3acc852bfa2f8601c"
+PKG_VERSION="7.1.5-Matrix"
+PKG_SHA256="a8b810dc8186b4b014eca2970a35e31e46ef38fbb77525fe6c013d8b65ab8d0a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- audiodecoder.2sf: update 19.0.0-Matrix to 19.0.1-Matrix
- audiodecoder.fluidsynth: update 3.0.0-Matrix to 19.0.0-Matrix
- audiodecoder.gsf: update 3.0.0-Matrix to 19.0.0-Matrix
- audiodecoder.ncsf: update 3.0.0-Matrix to 19.0.0-Matrix
- audiodecoder.nosefart: update 3.0.0-Matrix to 19.0.0-Matrix
- pvr.demo: update 7.1.4-Matrix to 7.1.5-Matrix

LE10 - #5575 