### PR TITLE
parted: update parted:init to use /usr/sbin

### DIFF
--- a/packages/sysutils/parted/package.mk
+++ b/packages/sysutils/parted/package.mk
@@ -34,9 +34,9 @@ make_init() {
 }
 
 makeinstall_init() {
-  mkdir -p ${INSTALL}/sbin
-    cp ../.${TARGET_NAME}/parted/parted ${INSTALL}/sbin
-    cp ../.${TARGET_NAME}/partprobe/partprobe ${INSTALL}/sbin
+  mkdir -p ${INSTALL}/usr/sbin
+    cp ../.${TARGET_NAME}/parted/parted ${INSTALL}/usr/sbin
+    cp ../.${TARGET_NAME}/partprobe/partprobe ${INSTALL}/usr/sbin
 }
 
 pre_configure_target() {


### PR DESCRIPTION
Backport of #5566 

**discovered this issue whilst bringing up RiscV but issue occurring on all**

The issue is that `parted:init` when INITRAMFS_PARTED_SUPPORT is set to "yes" would not allow the link `ln -sfn /usr/sbin ${INSTALL}/sbin` to be created as the /sbin directory already existed with the `parted` and `partprobe` files in it.