### PR TITLE
wireless-regdb: update to 2021.08.28

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2021.04.21"
-PKG_SHA256="9e4c02b2a9710df4dbdb327c39612e8cbbae6495987afeddaebab28c1ea3d8fa"
+PKG_VERSION="2021.08.28"
+PKG_SHA256="cff370c410d1e6d316ae0a7fa8ac6278fdf1efca5d3d664aca7cfd2aafa54446"
 PKG_LICENSE="GPL"
 PKG_SITE="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update 2021.04.21 to 2021.08.28

Release notes:

2021-08-28: Released
2021-08-28 wireless-regdb: update regulatory database based on preceding changes
2021-08-27 Update regulatory rules for Ecuador (EC)
2021-08-06 wireless-regdb: Update regulatory rules for Norway (NO) on 6 and 60 GHz
2021-08-02 wireless-regdb: Update regulatory rules for Germany (DE) on 6GHz
2021-07-14: Released
2021-07-14 wireless-regdb: update regulatory database based on preceding changes
2021-07-14 wireless-regdb: reduce bandwidth for 5730-5850 and 5850-5895 MHz in US
2021-07-08 wireless-regdb: remove PTMP-ONLY from 5850-5895 MHz for US
2021-07-06 wireless-regdb: recent FCC report and order allows 5850-5895 immediately
2021-06-08 wireless-regdb: update 5725-5850 MHz rule for GB