### PR TITLE
[le10] vfs.sftp: update PKG_REV to build with libssh-0.9.6

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="vfs.sftp"
 PKG_VERSION="2.0.0-Matrix"
 PKG_SHA256="b15c5dde7b3aadb3e82e61cb9b0440812b6c2f65b38c6c25aef726f97e746f68"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/xbmc/vfs.sftp"

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libssh"
-PKG_VERSION="0.9.5"
-PKG_SHA256="acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718"
+PKG_VERSION="0.9.6"
+PKG_SHA256="86bcf885bd9b80466fe0e05453c58b877df61afa8ba947a58c356d7f0fab829b"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libssh.org/"
 PKG_URL="https://www.libssh.org/files/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
A security release has been issued for libssh. Update the vfs.sftp addon to use this updated package.

libssh security release:
- https://www.libssh.org/2021/08/26/libssh-0-9-6-security-release/

**libssh is only used by `vfs.sftp`**
```
# git grep libssh | grep -v -e libssh2 -e packages/network/libssh/package.mk
packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk:PKG_DEPENDS_TARGET="toolchain kodi-platform libssh"
```

Upstream #5581