### PR TITLE
[le10] fluidsynth: update to 2.2.3 and use with audiodecoder.fluidsynth 19.0.1-Matrix

### DIFF
--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,17 +3,18 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="1.1.6"
-PKG_SHA256="d28b47dfbf7f8e426902ae7fa2981d821fbf84f41da9e1b85be933d2d748f601"
+PKG_VERSION="2.2.3"
+PKG_SHA256="b31807cb0f88e97f3096e2b378c9815a6acfdc20b0b14f97936d905b536965c4"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
-PKG_URL="${SOURCEFORGE_SRC}/project/fluidsynth/fluidsynth-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain glib"
+PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain glib libsndfile"
 PKG_LONGDESC="FluidSynth renders midi music files as raw audio data, for playing or conversion."
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=0 \
                        -DLIB_SUFFIX= \
-                       -Denable-readline=0 \
+                       -Denable-libsndfile=1 \
+                       -Denable-pkgconfig=1 \
                        -Denable-pulseaudio=0 \
-                       -Denable-libsndfile=0"
+                       -Denable-readline=0"

--- a/packages/audio/fluidsynth/patches/libsndfile-use-static-libraries.patch
+++ b/packages/audio/fluidsynth/patches/libsndfile-use-static-libraries.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	2021-09-12 13:53:14.192948082 +1000
++++ b/CMakeLists.txt	2021-09-12 13:54:27.389413149 +1000
+@@ -535,6 +535,7 @@
+              LIBSNDFILE_STATIC_LDFLAGS MATCHES "vorbis" OR
+              LIBSNDFILE_STATIC_LDFLAGS_OTHER MATCHES "vorbis" )
+           set ( LIBSNDFILE_HASVORBIS 1 )
++          set ( LIBSNDFILE_LIBRARIES ${LIBSNDFILE_STATIC_LIBRARIES} )
+         else ()
+           message ( NOTICE "Seems like libsndfile was compiled without OGG/Vorbis support." )
+         endif ()

--- a/packages/audio/libsndfile/package.mk
+++ b/packages/audio/libsndfile/package.mk
@@ -1,28 +1,20 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libsndfile"
-PKG_VERSION="1.0.28"
-PKG_SHA256="1ff33929f042fa333aed1e8923aa628c3ee9e1eb85512686c55092d1e5a9dfa9"
-PKG_LICENSE="LGPL"
-PKG_SITE="http://www.mega-nerd.com/libsndfile/"
-PKG_URL="http://www.mega-nerd.com/${PKG_NAME}/files/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_VERSION="1.0.31"
+PKG_SHA256="8cdee0acb06bb0a3c1a6ca524575643df8b1f3a55a0893b4dd9f829d08263785"
+PKG_LICENSE="LGPL-2.1-or-later"
+PKG_SITE="https://libsndfile.github.io/libsndfile/"
+PKG_URL="https://github.com/libsndfile/libsndfile/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain alsa-lib"
-PKG_LONGDESC="A library for accessing various audio file formats."
-PKG_TOOLCHAIN="configure"
+PKG_LONGDESC="A C library for reading and writing sound files containing sampled audio data."
+PKG_BUILD_FLAGS="+pic"
 
-# package specific configure options
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
-                           --disable-silent-rules \
-                           --disable-sqlite \
-                           --enable-alsa \
-                           --disable-external-libs \
-                           --disable-experimental \
-                           --disable-test-coverage \
-                           --enable-largefile \
-                           --with-gnu-ld \
-                           --with-pic"
-
-post_makeinstall_target() {
-  rm -rf ${INSTALL}/usr/bin
-}
+PKG_CMAKE_OPTS_TARGET="-DBUILD_PROGRAMS=OFF \
+                       -DBUILD_EXAMPLES=OFF \
+                       -DBUILD_TESTING=OFF \
+                       -DBUILD_REGTEST=OFF \
+                       -DENABLE_EXTERNAL_LIBS=OFF \
+                       -DINSTALL_MANPAGES=OFF"

--- a/packages/audio/libsndfile/package.mk
+++ b/packages/audio/libsndfile/package.mk
@@ -8,13 +8,20 @@ PKG_SHA256="8cdee0acb06bb0a3c1a6ca524575643df8b1f3a55a0893b4dd9f829d08263785"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://libsndfile.github.io/libsndfile/"
 PKG_URL="https://github.com/libsndfile/libsndfile/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain alsa-lib"
+PKG_DEPENDS_TARGET="toolchain alsa-lib flac libogg libvorbis opus"
 PKG_LONGDESC="A C library for reading and writing sound files containing sampled audio data."
 PKG_BUILD_FLAGS="+pic"
 
+# As per notes in configure.ac:
+#  One or more of the external libraries (ie libflac, libogg, libvorbis and libopus)
+#  is either missing ... Unfortunately, for ease of maintenance, the external libs
+#  are an all or nothing affair.
+# So all of flac, libogg, libvorbis, opus are required.
+
 PKG_CMAKE_OPTS_TARGET="-DBUILD_PROGRAMS=OFF \
                        -DBUILD_EXAMPLES=OFF \
-                       -DBUILD_TESTING=OFF \
                        -DBUILD_REGTEST=OFF \
-                       -DENABLE_EXTERNAL_LIBS=OFF \
-                       -DINSTALL_MANPAGES=OFF"
+                       -DBUILD_TESTING=OFF \
+                       -DENABLE_EXTERNAL_LIBS=ON \
+                       -DINSTALL_MANPAGES=OFF \
+                       -DINSTALL_PKGCONFIG_MODULE=ON"

--- a/packages/audio/libsndfile/patches/libsndfile-add-required-static-libaries-to-pkg-config.patch
+++ b/packages/audio/libsndfile/patches/libsndfile-add-required-static-libaries-to-pkg-config.patch
@@ -1,0 +1,9 @@
+--- a/sndfile.pc	2021-01-24 23:22:23.000000000 +1100
++++ b/sndfile.pc.in	2021-09-12 14:30:47.763655089 +1000
+@@ -8,5 +8,5 @@
+ Requires:
+ Requires.private: @EXTERNAL_XIPH_REQUIRE@
+ Version: @VERSION@
+-Libs: -L${libdir} -lsndfile
++Libs: -L${libdir} -lsndfile -lFLAC -logg -lvorbis -lvorbisenc -lopus
+ Cflags: -I${includedir}

--- a/packages/audio/soxr/package.mk
+++ b/packages/audio/soxr/package.mk
@@ -13,6 +13,7 @@ PKG_LONGDESC="The SoX Resampler library performs one-dimensional sample-rate con
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_EXAMPLES=OFF \
+                       -DWITH_OPENMP=OFF \
                        -DBUILD_SHARED_LIBS=OFF \
                        -DBUILD_TESTS=OFF \
                        -DWITH_AVFFT=OFF"


### PR DESCRIPTION
With recent kodi-binary-addons: update to latest versions `audiodecoder.fluidsynth: update 3.0.0-Matrix to 19.0.0-Matrix` #5575 the build fails due to new dependency on libgomp

refs: (Thanks @HiassofT)
- https://github.com/xbmc/audiodecoder.fluidsynth/commit/192203d4756772b57ebfecbcc23f5f8007e16f37
- https://github.com/xbmc/audiodecoder.fluidsynth/commit/2978ef181cfb925198c2237509425b95efd3b8a3

Build fails with:
```
/var/lib/jenkins/LE/build4/workspace/Addons/All_Addons-ARMv7/LibreELEC.tv/build.LibreELEC-ARMv7.arm-11.0-devel/toolchain/lib/gcc/armv7a-libreelec-linux-gnueabihf/10.3.0/../../../../armv7a-libreelec-linux-gnueabihf/bin/ld.gold: error: cannot find -lgomp
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
FAILURE: scripts/build audiodecoder.fluidsynth:target during make_target (default)
```

### fluidsynth
update 1.1.6 (25 Jun 2017) to 2.2.3 (12 Sep 2021)
changelog: https://github.com/FluidSynth/fluidsynth/releases

release notes:
- https://github.com/FluidSynth/fluidsynth/releases/tag/v2.1.8
- https://github.com/FluidSynth/fluidsynth/releases/tag/v2.2.0
- https://github.com/FluidSynth/fluidsynth/releases/tag/v2.2.1
- https://github.com/FluidSynth/fluidsynth/releases/tag/v2.2.2
- https://github.com/FluidSynth/fluidsynth/releases/tag/v2.2.3