### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.organya"
-PKG_VERSION="3.0.0-Matrix"
-PKG_SHA256="01320cb45995db26230ddd975a802114e7e8dee7e78baa76241119a330eec7d3"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="a2877f4baf2ba084367cb996be5d93c2ca08cb842ca145e446ab4488516267ce"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.organya"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.heif"
-PKG_VERSION="1.4.0-Matrix"
-PKG_SHA256="0ab56bb77777dd348117586474a3fc3c398b27de971e104bddb963b54751c59e"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="2f408a58560a8813693bd7a6f8d4c05589c9932f5f82e5ec05d57e2c704643cf"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.mpo"
-PKG_VERSION="2.0.1-Matrix"
-PKG_SHA256="6f93361ba15b44ca86d7bb46772c0116e2a820ca2bf0021e6392be11fc372576"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="bbac3211c521d6da2f38408b188e86df1eb75381540c7c6e6f1793e168d95c59"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.mpo"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.filmon"
-PKG_VERSION="6.1.2-Matrix"
-PKG_SHA256="3ede4930bce246f15cdc4a063086327c28c412b923d0c1030e2fd3ba8a63e138"
+PKG_VERSION="6.1.3-Matrix"
+PKG_SHA256="e8cf22398e2ab2da9873dc84a3fa5fcc27c7726adfedd813ebdd9b8d41066fec"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="7.6.9-Matrix"
-PKG_SHA256="b968b38d09299a9784b82d3fb82f461db1544901b450e374d270dd5c2be0c6d1"
+PKG_VERSION="7.6.10-Matrix"
+PKG_SHA256="7c6a08f77f8e8ba64d4a7608a8ef7baace10eefc8d0dace1e4c7ae58776e5f94"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="7.4.9-Matrix"
-PKG_SHA256="c6032c7b79e45a83523c6fb32a7b097e8c8fa81de76996babdd160b2288061a4"
+PKG_VERSION="7.4.11-Matrix"
+PKG_SHA256="49d673277205b38df3be09d450934bdca4be5bd80a184d4195d3406a8d5e8a8c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- audiodecoder.organya: update 3.0.0-Matrix to 19.0.0-Matrix
- imagedecoder.heif: update 1.4.0-Matrix to 19.0.0-Matrix
- imagedecoder.mpo: update 2.0.1-Matrix to 19.0.0-Matrix
- pvr.filmon: update 6.1.2-Matrix to 6.1.3-Matrix
- pvr.iptvsimple: update 7.6.9-Matrix to 7.6.10-Matrix
- pvr.vuplus: update 7.4.9-Matrix to 7.4.11-Matrix

Downstream ref: #5584