### PR TITLE
iwd: update to 1.17

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="1.11"
-PKG_SHA256="db854f569cfa94dc32120d8cf2e7d483a16679f238e1a4794837d0e455ea7aa9"
+PKG_VERSION="1.17"
+PKG_SHA256="6f946f823b0dc3205e4e72becf8ad1915448d194f5b10d8003e4c8c5a18e4ef7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update 1.11 (2021-01-07) to 1.17 (2021-08-22)
changelog: https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/ChangeLog

ver 1.17:
- Fix issue with sending additional and vendor IEs.
- Fix issue with IE ordering for 802.11-2020 support.
- Fix issue with frequency update on channel switch events.
- Fix issue with drivers and handling of IF_OPER_UP setting.

ver 1.16:
- Fix issue with writing provisioning files with a passphrase.
- Add support for Authenticator & Supplicant RSN Extension elements.
- Add support for handling Transition Disable info.
- Add support for SAE Hash-to-Element feature.

ver 1.15:
- Add support for FT-over-DS procedure with multiple BSS.
- Add support for estimation of VHT RX data rate.
- Add support for exporting Daemon information.

ver 1.14:
- Fix issue with scanning property and quick scan cancellation.
- Fix issue with handling authentication timeouts from SAE.
- Fix issue with handling association timeouts and retries.
- Fix issue with handling roaming frequencies after roaming.
- Fix issue with requesting neighbor report after roaming.
- Add support for handling PSK offload connections.

ver 1.13:
- Fix issue with EAPoL protocol version 2010 handling.
- Fix issue with authenticator method logic handling.
- Fix issue with getting scan results from firmware.
- Add support for handling SAE offload connections.
- Add support for roaming with FullMAC devices.

ver 1.12:
- Fix issue with handling retry roaming without higher RSSI.
- Fix issue with WPA3, OWE and FILS authentication handling.
- Fix issue with handling locally generated deauth frames.
- Fix issue with quick scanning and connect interaction.
- Add support for diagnostic D-Bus interfaces.