### PR TITLE
Update media-driver and gmmlib

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="21.2.1"
-PKG_SHA256="912cd86e4cb564b6fa549d69a28b72b9cdcb5a3eab9320955ed70ac37381fc2f"
+PKG_VERSION="21.2.2"
+PKG_SHA256="58ef6ac98fb7acc0002c779ce784926da6089a450f3d752ef27268664fe037cc"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="21.3.1"
-PKG_SHA256="3187d61891b9834e1eb06182aded638e98bc94964b148abae652147e8585047a"
+PKG_VERSION="21.3.2"
+PKG_SHA256="562a99109704d859003ee484fdfd049e7cb1f87c16e2b7376238ae2e3908dff7"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
Update media-driver and gmmlib

- media-driver: update to 21.3.2
  - [Decode] MHW AVC Refactor
  - This is a patch for mhw avc refactor, committing MFX and avc decode related cmds.
  - https://github.com/intel/media-driver/compare/intel-media-21.3.1...intel-media-21.3.2
- gmmlib: update to 21.2.2
  - Intel Graphics Memory Management Library 2021 Q2 Release 2.
  - https://github.com/intel/gmmlib/compare/intel-gmmlib-21.2.1...intel-gmmlib-21.2.2