### PR TITLE
Allwinner: linux: Fix audio on 5.14 for H3 and H5

### DIFF
--- a/projects/Allwinner/patches/linux/0034-HACK-h3-h5-Add-HDMI-sound-card.patch
+++ b/projects/Allwinner/patches/linux/0034-HACK-h3-h5-Add-HDMI-sound-card.patch
@@ -35,11 +35,16 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
  	clocks {
  		#address-cells = <1>;
  		#size-cells = <1>;
-@@ -681,7 +699,6 @@
- 			dmas = <&dma 27>;
+@@ -678,10 +696,9 @@
+ 			interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&ccu CLK_BUS_I2S2>, <&ccu CLK_I2S2>;
+ 			clock-names = "apb", "mod";
+-			dmas = <&dma 27>;
++			dmas = <&dma 27>, <&dma 27>;
  			resets = <&ccu RST_BUS_I2S2>;
- 			dma-names = "tx";
+-			dma-names = "tx";
 -			status = "disabled";
++			dma-names = "rx", "tx";
  		};
  
  		codec: codec@1c22c00 {


### PR DESCRIPTION
With Linux 5.14, HDMI audio stopped working on H3 and H5. It turns out that functions, used by I2S driver, require DMA for both directions. Until that's fixed upstream, add dummy RX DMA description (it won't be used anyway).