### PR TITLE
dav1d: update to 0.9.2

### DIFF
--- a/packages/multimedia/dav1d/package.mk
+++ b/packages/multimedia/dav1d/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dav1d"
-PKG_VERSION="0.9.1"
-PKG_SHA256="fb2a050e6c2410c99104f631e202a02697dfe1a2fc9acc3c50a16422aefb004c"
+PKG_VERSION="0.9.2"
+PKG_SHA256="0d198c4fe63fe7f0395b1b17de75b21c8c4508cd3204996229355759efa30ef8"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.jbkempf.com/blog/post/2018/Introducing-dav1d"
 PKG_URL="https://code.videolan.org/videolan/dav1d/-/archive/${PKG_VERSION}/dav1d-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
Release announce: https://code.videolan.org/videolan/dav1d/-/releases/0.9.2

This is expected to be the final (noticeable) performance improvements for ssse3, avx2 and neon.