### PR TITLE
Allwinner: linux: fix Cedrus patch

### DIFF
--- a/projects/Allwinner/patches/linux/0023-media-cedrus-add-check-for-H264-and-HEVC-limitations.patch
+++ b/projects/Allwinner/patches/linux/0023-media-cedrus-add-check-for-H264-and-HEVC-limitations.patch
@@ -78,16 +78,14 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
  		},
  		.codec		= CEDRUS_CODEC_H265,
  	},
-@@ -556,7 +602,8 @@ static const struct cedrus_variant sun50
+@@ -556,6 +602,7 @@ static const struct cedrus_variant sun50
  			  CEDRUS_CAPABILITY_MPEG2_DEC |
  			  CEDRUS_CAPABILITY_H264_DEC |
  			  CEDRUS_CAPABILITY_H265_DEC |
--			  CEDRUS_CAPABILITY_VP8_DEC,
-+			  CEDRUS_CAPABILITY_H265_DEC |
-+			  CEDRUS_CAPABILITY_H265_10_DEC,
++			  CEDRUS_CAPABILITY_H265_10_DEC |
+ 			  CEDRUS_CAPABILITY_VP8_DEC,
  	.mod_rate	= 600000000,
  };
- 
 --- a/drivers/staging/media/sunxi/cedrus/cedrus.h
 +++ b/drivers/staging/media/sunxi/cedrus/cedrus.h
 @@ -32,6 +32,7 @@


### PR DESCRIPTION
This again enables VP8 HW decoding on H6 after a mistake at patch rebase for kernel 5.14.