### PR TITLE
openvpn: update to 2.5.3

### DIFF
--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.4.10"
-PKG_SHA256="cf285395a679f0b68c0acde2cb2480e8ead6ca07ff14c1bc52ae65a1243aa377"
+PKG_VERSION="2.5.3"
+PKG_SHA256="fb6a9943c603a1951ca13e9267653f8dd650c02f84bccd2b9d20f06a4c9c9a7e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://openvpn.net"
 PKG_URL="https://swupdate.openvpn.org/community/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update 2.4.10 (2020-12-09) to 2.5.3 (2021-06-17)

update to current OpenVPN 2.5.x stream.

Changes: https://github.com/OpenVPN/openvpn/blob/master/Changes.rst