### PR TITLE
Addon fixes from devtools update

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/depends/libstatgrab/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/depends/libstatgrab/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libstatgrab"
-PKG_VERSION="0.92"
-PKG_SHA256="5bf1906aff9ffc3eeacf32567270f4d819055d8386d98b9c8c05519012d5a196"
-PKG_SITE="http://www.i-scream.org/libstatgrab/"
-PKG_URL="http://ftp.i-scream.org/pub/i-scream/libstatgrab/libstatgrab-${PKG_VERSION}.tar.gz"
+PKG_VERSION="0.92.1"
+PKG_SHA256="5688aa4a685547d7174a8a373ea9d8ee927e766e3cc302bdee34523c2c5d6c11"
+PKG_SITE="https://libstatgrab.org"
+PKG_URL="https://github.com/libstatgrab/libstatgrab/releases/download/LIBSTATGRAB_${PKG_VERSION//./_}/libstatgrab-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION=libs
 PKG_LONGDESC="A library that provides cross platform access to statistics about the system on which it's run."

--- a/packages/addons/addon-depends/network-tools-depends/iperf/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/iperf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iperf"
-PKG_VERSION="3.9"
-PKG_SHA256="c6d8076b800f2b51f92dc941b0a9b77fbf2a867f623b5cb3cbf4754dabc40899"
+PKG_VERSION="3.10.1"
+PKG_SHA256="6a4bb4d5c124b3fa64dfbda469ab16857ad6565310bcaa3dd8cd32f96c2fc473"
 PKG_LICENSE="BSD"
 PKG_SITE="http://software.es.net/iperf/"
 PKG_URL="https://github.com/esnet/iperf/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/mariadb/changelog.txt
+++ b/packages/addons/service/mariadb/changelog.txt
@@ -1,3 +1,6 @@
+105
+- update MariaDB to 10.4.21
+
 104
 - update MariaDB to 10.4.17
 

--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="10.4.17"
-PKG_REV="104"
-PKG_SHA256="a7b104e264311cd46524ae546ff0c5107978373e4a01cf7fd8a241454548d16e"
+PKG_VERSION="10.4.21"
+PKG_REV="105"
+PKG_SHA256="94dd2e6f5d286de8a7dccffe984015d4253a0568281c7440e772cfbe098a291d"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://downloads.mariadb.com/MariaDB/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/minidlna/changelog.txt
+++ b/packages/addons/service/minidlna/changelog.txt
@@ -1,3 +1,6 @@
+103
+- fix build
+
 102
 - update to 1.3.0
 

--- a/packages/addons/service/minidlna/package.mk
+++ b/packages/addons/service/minidlna/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="minidlna"
 PKG_VERSION="1.3.0"
 PKG_SHA256="47d9b06b4c48801a4c1112ec23d24782728b5495e95ec2195bbe5c81bc2d3c63"
-PKG_REV="102"
+PKG_REV="103"
 PKG_ARCH="any"
 PKG_LICENSE="BSD-3c/GPLv2"
 PKG_SITE="https://sourceforge.net/projects/minidlna/"

--- a/packages/addons/service/minidlna/patches/minidlna-02-fix-autoconf-271.patch
+++ b/packages/addons/service/minidlna/patches/minidlna-02-fix-autoconf-271.patch
@@ -1,0 +1,31 @@
+--- a/configure.ac	2021-09-14 20:57:49.719326718 +1000
++++ b/configure.ac	2021-09-14 20:57:24.852784827 +1000
+@@ -404,7 +404,7 @@
+     AC_CHECK_LIB([exif], [exif_data_new_from_file], [LIBEXIF_LIBS="-lexif"], [unset ac_cv_lib_exif_exif_data_new_from_file; LDFLAGS="$LDFLAGS_SAVE"; continue])
+     break
+ done
+-test x"$ac_cv_lib_jpeg_jpeg_set_defaults" = x"yes" || AC_MSG_ERROR([Could not find libexif])
++test x"$ac_cv_lib_exif_exif_data_new_from_file" = x"yes" || AC_MSG_ERROR([Could not find libexif])
+ AC_SUBST(LIBEXIF_LIBS)
+ 
+ LDFLAGS_SAVE="$LDFLAGS"
+@@ -415,7 +415,7 @@
+     AC_CHECK_LIB([id3tag -lz], [id3_file_open], [LIBID3TAG_LIBS="-lid3tag -lz"], [unset ac_cv_lib_id3tag_id3_file_open; LDFLAGS="$LDFLAGS_SAVE"; continue])
+     break
+ done
+-test x"$ac_cv_lib_id3tag__lz___id3_file_open" = x"yes" || AC_MSG_ERROR([Could not find libid3tag])
++test x"$ac_cv_lib_id3tag__lz_id3_file_open" = x"yes" || AC_MSG_ERROR([Could not find libid3tag])
+ AC_SUBST(LIBID3TAG_LIBS)
+ 
+ LDFLAGS_SAVE="$LDFLAGS"
+@@ -441,8 +441,8 @@
+ 		  [unset ac_cv_lib_avformat_av_open_input_file; unset ac_cv_lib_avformat_avformat_open_input; LDFLAGS="$LDFLAGS_SAVE"; continue])])
+     break
+ done
+-if test x"$ac_cv_lib_avformat__lavcodec__lavutil__lz___av_open_input_file" != x"yes" &&
+-   test x"$ac_cv_lib_avformat__lavcodec__lavutil__lz___avformat_open_input" != x"yes"; then
++if test x"$ac_cv_lib_avformat__lavcodec__lavutil__lz_av_open_input_file" != x"yes" &&
++   test x"$ac_cv_lib_avformat__lavcodec__lavutil__lz_avformat_open_input" != x"yes"; then
+    AC_MSG_ERROR([Could not find libavformat - part of ffmpeg])
+ fi
+ AC_SUBST(LIBAVFORMAT_LIBS)

--- a/packages/addons/tools/network-tools/changelog.txt
+++ b/packages/addons/tools/network-tools/changelog.txt
@@ -1,3 +1,7 @@
+111
+- iperf: update to 3.10.1
+- libstatgrab: update to 0.92.1
+
 110
 - libpcap: update to 1.10.1
 - tcpdump: update to 4.99.1

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="110"
+PKG_REV="111"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- mariadb: update to 10.4.21 and addon (105)  …
  - update from 10.4.18 (2021-02-22) to 10.4.21 (2021-08-06)
  - release notes and changelog:
  - https://mariadb.com/kb/en/changes-improvements-in-mariadb-104/
- minidlna: fix build with autoconf 2.71 and addon (103)
- network-tools: update addon (111)
  - iperf: update to 3.10.1
    - https://github.com/esnet/iperf/blob/master/RELNOTES.md
    - http://software.es.net/iperf/news.html#iperf-3-10-1-released
    - iperf 3.10 is principally a bugfix release.
    - A few new features have been added (--time-skew-threshold, --bind-dev, --rcv-timeout, and --dont-fragment).
    - More information on these new features can be found in the release notes.
  - libstatgrab: update to 0.92.1
    - https://libstatgrab.org/#current-version
    - The current release is libstatgrab 0.92.1 released on 27 July 2021.
    - This release includes minor bugfixes and is API and ABI compatible with 0.92.
    - Fix build with autoconf 2.70+.
    - Fix CPU stats on older Linux kernels.
    - Make sure to count processes in an unknown state.
    - Check if -ltinfo is needed when linking ncurses.
    - Fixes to build when cross-compiling.
    - Fix build with -DNDEBUG.

  #5561