### PR TITLE
kodi-config: LIBC_WIDEVINE_PATCHLEVEL is obsolete since script.module…

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi-config
+++ b/packages/mediacenter/kodi/scripts/kodi-config
@@ -43,11 +43,6 @@ else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf
 fi
 
-# required for inputstreamhelper to detect TLS 64-bytes support
-if [ -n "$(uname -m | grep arm)" ] || [ "$(uname -m)" == "aarch64" ]; then
-  echo "LIBC_WIDEVINE_PATCHLEVEL=1" >> /run/libreelec/kodi.conf
-fi
-
 if [ -f /storage/.config/kodi.conf ] ; then
   cat /storage/.config/kodi.conf >>/run/libreelec/kodi.conf
 fi


### PR DESCRIPTION
….inputstreamhelper v0.5.8