### PR TITLE
kodi.sh: never delete just created crash log

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi.sh
+++ b/packages/mediacenter/kodi/scripts/kodi.sh
@@ -154,8 +154,8 @@ if [ $(( ($RET >= 131 && $RET <= 136) || $RET == 139 )) = "1" ] ; then
   # Crashed with core dump
   print_crash_report
 
-  # Cleanup. Keep only youngest 10 reports
-  rm -f $(ls -1t $CRASHLOG_DIR/kodi_crashlog_*.log | tail -n +11)
+  # Cleanup. Keep only youngest 10 reports but current in any case
+  rm -f $(ls -1t $CRASHLOG_DIR/kodi_crashlog_*.log | grep -v "$FILE" | tail -n +10)
 
   # Enable safe mode if a crash loop is detected
   detect_crash_loop && activate_safe_mode


### PR DESCRIPTION
f system time was not set via NTP on RTC-less devices, current crash log may have the oldest time stamp and is deleted.

Seen in the forum after [requesting logs](https://forum.libreelec.tv/thread/23717-le-9-95-1-backup-reboot-libreelec-on-rp4/?postID=160278#post160278) of an RPI4. 

Backport of #5648