### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="2.6.23-Matrix"
-PKG_SHA256="eeb68250725c4e6c990fdb24365188733b6ef944965792bb5b0e42ce306ad836"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="10d0e79a301094cdaa35b3e92c4da6b693fc0b5661ea3b459329245fcdfa2f65"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="7.1.2-Matrix"
-PKG_SHA256="4f6aaa28ff3437246a5cd77988076af55405a2689ddc0f8c48663423a9fc933b"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="f918a526813f06ed522d8e12593556ced0282c9ff2d26a41bceba2ada68d3c6c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvblink"
-PKG_VERSION="9.1.2-Matrix"
-PKG_SHA256="e4491b7f4ee7f565f5b13ca4ea52640c2be076271d22de1fb4e35e69dc8c2bbf"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="2bdd6475b9c848300c0058d4ffe284ee26b8af44df534ee45cfeeb51cc80a6ba"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="8.2.8-Matrix"
-PKG_SHA256="c6ed3806f32ffccae35cf66320e4754ee3bc45c2bb5eaa55bbbbc2d62c701528"
+PKG_VERSION="8.2.9-Matrix"
+PKG_SHA256="d5999da48a319ead260ebca189f2b7a687206b61f18c2575e6968efdb56f6701"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.njoy"
-PKG_VERSION="7.1.1-Matrix"
-PKG_SHA256="6a7edf45bfe0e9bad0fe460accf9a9c0bbb93a907c2becf5e48dcc79a803cc8b"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="55644b3e7b09f0ae14ccbe55b569b5add782b72fb973e1545414f17c2613a4a8"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.pctv"
-PKG_VERSION="6.1.1-Matrix"
-PKG_SHA256="2692fc0387762f62e8fc9e57f21d613e4c2e52553d3eb30ee042f91cc61155ac"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="004d9f8801e9c5d2d76c0c84d0844c4560ede7e2ed02c4c43286991a54d720c9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="7.1.1-Matrix"
-PKG_SHA256="4450dcdacfb471d8d10e3a487bace8c57f1cab4629f1be1c57adae2165fcc5b8"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="6161f0593feb67865e78f9aecc8c59019933ddda273e495ffadb0bdb42dde2a3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vbox"
-PKG_VERSION="8.1.2-Matrix"
-PKG_SHA256="b53943101401b97e6a3f63f7e4d3bffc78d892329b8fd9ef5cfb0833277456ea"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="a87926702c51e52043e595ceae530a9101761cc15e8e3cadec85ac8cc9ba8f2b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="8.2.3-Matrix"
-PKG_SHA256="702410caf142c76434ed716900221f1292b3713501e3744330df6c2feb890614"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="ab7ba632438d12001cb1e10c2ccb75816be9a9181ec2fdb739bd8eb2f173cf7f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="7.4.11-Matrix"
-PKG_SHA256="49d673277205b38df3be09d450934bdca4be5bd80a184d4195d3406a8d5e8a8c"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="59e8b63e3b5a6dd4500fd2c1426e021b5b243909d326e173e84804618a6c2fc6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="6.1.2-Matrix"
-PKG_SHA256="4e534ca49390b0fcb62c23f1076235e1664358ee67bd3f8ed04660d16094053a"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="d3cfa954c01ddec0f69e6777a12fca6314ee579d770a4be8728657e323a8eb8c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 2.6.23-Matrix to 19.0.0-Matrix
- pvr.argustv: update 7.1.2-Matrix to 19.0.0-Matrix
- pvr.dvblink: update 9.1.2-Matrix to 19.0.0-Matrix
- pvr.nextpvr: update 8.2.8-Matrix to 8.2.9-Matrix
- pvr.njoy: update 7.1.1-Matrix to 19.0.0-Matrix
- pvr.pctv: update 6.1.1-Matrix to 19.0.0-Matrix
- pvr.stalker: update 7.1.1-Matrix to 19.0.0-Matrix
- pvr.vbox: update 8.1.2-Matrix to 19.0.0-Matrix
- pvr.vdr.vnsi: update 8.2.3-Matrix to 19.0.0-Matrix
- pvr.vuplus: update 7.4.11-Matrix to 19.0.0-Matrix
- pvr.wmc: update 6.1.2-Matrix to 19.0.0-Matrix