### PR TITLE
mali-midgard: update to 055a545

### DIFF
--- a/packages/linux-drivers/mali-midgard/package.mk
+++ b/packages/linux-drivers/mali-midgard/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mali-midgard"
-PKG_VERSION="2815552cc83e928d3ca3811f18e2c60d8c9eba0d" # TX011-SW-99002-r28p0-01rel0
-PKG_SHA256="3572c819df7afafd99a6af20c9695519b37807487899bb9884f06b2f63f79e17"
+PKG_VERSION="055a54556037dce5036cd7470eb9c877c0147f0b" # TX011-SW-99002-r28p0-01rel0
+PKG_SHA256="d39e32cfece97084a3a6ef4eb9f494507c36c0b27c39f3dd154eb8eff8666248"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://developer.arm.com/products/software/mali-drivers/"


### PR DESCRIPTION
Include the following fixes to compile with kernel 5.14

- struct mm_struct: update from mmap_sem to mmap_lock (5.7 --> 5.8)
- get_user_pages_remote: support kernel 5.9 (5.8 --> 5.9)
- add_mm_counter: update to support 5.5
  - from https://forum.odroid.com/viewtopic.php?f=184&t=41300