### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="8.4.0-Matrix"
-PKG_SHA256="a8fec6749481999981903f2de48bd9a71ca5b4828eab91b8b115238f66e68140"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="1e98a88b9c5c05716501e08d882d3275f5635e3304ef3d3953ea425ed5ef3ddf"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="7.6.13-Matrix"
-PKG_SHA256="e079f24d8b70fecc6d7f39cea1a3cc0e4d6f23386a1729f73e8a312394545946"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="665441cfe6a83a72d1cbbe3e8adf2a121e5c78a1156830a0036496702a4fce3e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="8.2.1-Matrix"
-PKG_SHA256="2051aea6d4c94c963699f4e7bd84e0083d8355dc465df0673f6b67d1f4d6198b"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="05cc8722b7f35c230726941ae7e3082bbc13ed4d061775696fb8bad4abb7b847"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="8.2.9-Matrix"
-PKG_SHA256="d5999da48a319ead260ebca189f2b7a687206b61f18c2575e6968efdb56f6701"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="977131a4135aff8686c6a1b779d6637900630ba6483b3e46f0e221c8d01b8d6c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.waipu"
-PKG_VERSION="2.9.4-Matrix"
-PKG_SHA256="e47d4afa9cc4184dad2fe7236667f227dd9dd3677a17360df0d4bdf594f64d91"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="7a9fe1a9bf3ba7fab0755e6e8a8442909d33f373cee0ada73d5c8e2bf2c7a099"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- pvr.hts: update 8.4.0-Matrix to 19.0.0-Matrix
- pvr.iptvsimple: update 7.6.13-Matrix to 19.0.0-Matrix
- pvr.mediaportal.tvserver: update 8.2.1-Matrix to 19.0.0-Matrix
- pvr.nextpvr: update 8.2.9-Matrix to 19.0.0-Matrix
- pvr.waipu: update 2.9.4-Matrix to 19.0.0-Matrix

this is the backport of #5657