### PR TITLE
Update debug tools

### DIFF
--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gdb"
-PKG_VERSION="10.1"
-PKG_SHA256="f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"
+PKG_VERSION="11.1"
+PKG_SHA256="cccfcc407b20d343fb320d4a9a2110776dd3165118ffd41f4b1b162340333f94"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/gdb/"
 PKG_URL="https://ftp.gnu.org/gnu/gdb/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/debug/memtester/package.mk
+++ b/packages/debug/memtester/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="memtester"
-PKG_VERSION="4.5.0"
-PKG_SHA256="8ed52b0d06d4aeb61954994146e2a5b2d20448a8f3ce3ee995120e6dbde2ae37"
+PKG_VERSION="4.5.1"
+PKG_SHA256="1c5fc2382576c084b314cfd334d127a66c20bd63892cac9f445bc1d8b4ca5a47"
 PKG_LICENSE="GPL"
 PKG_SITE="http://pyropus.ca/software/memtester/"
 PKG_URL="http://pyropus.ca/software/memtester/old-versions/memtester-${PKG_VERSION}.tar.gz"

--- a/packages/debug/strace/package.mk
+++ b/packages/debug/strace/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="strace"
-PKG_VERSION="5.12"
-PKG_SHA256="29171edf9d252f89c988a4c340dfdec662f458cb8c63d85431d64bab5911e7c4"
+PKG_VERSION="5.14"
+PKG_SHA256="901bee6db5e17debad4530dd9ffb4dc9a96c4a656edbe1c3141b7cb307b11e73"
 PKG_LICENSE="BSD"
 PKG_SITE="https://strace.io/"
 PKG_URL="https://strace.io/files/${PKG_VERSION}/strace-${PKG_VERSION}.tar.xz"

--- a/packages/debug/valgrind/package.mk
+++ b/packages/debug/valgrind/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="valgrind"
-PKG_VERSION="3.16.1"
-PKG_SHA256="c91f3a2f7b02db0f3bc99479861656154d241d2fdb265614ba918cc6720a33ca"
+PKG_VERSION="3.17.0"
+PKG_SHA256="ad3aec668e813e40f238995f60796d9590eee64a16dff88421430630e69285a2"
 PKG_LICENSE="GPL"
 PKG_SITE="http://valgrind.org/"
 PKG_URL="ftp://sourceware.org/pub/valgrind/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
Update debug tools

- gdb: update to 11.1
- memtester: update to 4.5.1
- strace: update to 5.14
- valgrind: update to 3.17.0
