### PR TITLE
Update kernel support network packages

### DIFF
--- a/packages/network/ethtool/package.mk
+++ b/packages/network/ethtool/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ethtool"
-PKG_VERSION="5.10"
-PKG_SHA256="817d5396a9307b4c637b435d4c558b8f5f964a1464a035ca3c0180f4cc93cfcf"
+PKG_VERSION="5.14"
+PKG_SHA256="bb13db91915cacd7a492b65b65df07a67e4b974ddbeaf76205b1945a23d27686"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.kernel.org/pub/software/network/ethtool/"
-PKG_URL="http://www.kernel.org/pub/software/network/ethtool/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.kernel.org/pub/software/network/ethtool/"
+PKG_URL="https://www.kernel.org/pub/software/network/ethtool/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libmnl"
 PKG_LONGDESC="Ethtool is used for querying settings of an ethernet device and changing them."

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="1.17"
-PKG_SHA256="6f946f823b0dc3205e4e72becf8ad1915448d194f5b10d8003e4c8c5a18e4ef7"
+PKG_VERSION="1.18"
+PKG_SHA256="0225ab81579f027e0fcbf255517f432fcf355d14f3645c36813c71a441dfab55"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"

--- a/packages/network/wireguard-tools/package.mk
+++ b/packages/network/wireguard-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-tools"
-PKG_VERSION="1.0.20210424"
-PKG_SHA256="98140aa91ea04018ebd874c14ab9b6994f48cdaf9a219ccf7c0cd3e513c7428a"
+PKG_VERSION="1.0.20210914"
+PKG_SHA256="69de713458a887cddb46b2fd1d43bf20548f693136af95792e65ec925538c770"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-v${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Update kernel support network packages

- ethtool: update to 5.14 and HSTS
- iwd: update to 1.18
- wireguard-tools: update to 1.0.20210914
