### PR TITLE
config/options: default to Generic device when building Generic project

### DIFF
--- a/config/options
+++ b/config/options
@@ -26,6 +26,11 @@ DISTRO="${DISTRO:-LibreELEC}"
 # determines PROJECT, if not forced by user
 export PROJECT="${PROJECT:-Generic}"
 
+# default to Generic device if building Generic project without device set
+if [ "${PROJECT}" = "Generic" -a -z "${DEVICE}" ]; then
+  export DEVICE="Generic"
+fi
+
 # determines TARGET_ARCH, if not forced by user
 export ARCH="${ARCH:-x86_64}"
 TARGET_ARCH="${ARCH}"


### PR DESCRIPTION
This fixes building and calling into build scripts without PROJECT,
DEVICE and ARCH set.