### PR TITLE
Python3: update to 3.8.12

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.8.11"
-PKG_SHA256="fb1a1114ebfe9e97199603c6083e20b236a0e007a2c51f29283ffb50c1420fb2"
+PKG_VERSION="3.8.12"
+PKG_SHA256="b1d3a76420375343b5e8a22fceb1ac65b77193e9ed27146524f0a9db058728ea"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.python.org/"
 PKG_URL="https://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update 3.8.11 (2021-06-28) to 3.8.12 (2021-08-30)

release notes: (security release)
- https://docs.python.org/release/3.8.12/whatsnew/changelog.html#changelog

release schedule:
- https://www.python.org/dev/peps/pep-0569/