### PR TITLE
update_common_functions: allow assigning PROJECT and ARCH values

### DIFF
--- a/tools/mkpkg/update_common_functions
+++ b/tools/mkpkg/update_common_functions
@@ -5,7 +5,7 @@
 msg_color() {
   echo $(
     cd "${ROOT}"
-    PROJECT=Generic ARCH=x86_64 . config/options ""
+    PROJECT="${PROJECT:-Generic}" ARCH="${ARCH:-x86_64}" . config/options ""
     echo $(print_color "$1" "$2")
   )
 }
@@ -42,7 +42,7 @@ git_clone() {
 get_pkg_var() {
   local pkg_name="$1" pkg_var="$2"
   cd "${ROOT}"
-  PROJECT=Generic ARCH=x86_64 source config/options ${pkg_name} &>/dev/null
+  PROJECT="${PROJECT:-Generic}" ARCH="${ARCH:-x86_64}" source config/options ${pkg_name} &>/dev/null
   echo "${!pkg_var}"
 }
 


### PR DESCRIPTION
Make script more generic by remove hardcoded values.