### PR TITLE
mesa: update to 21.2.2

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="21.2.1"
-PKG_SHA256="2c65e6710b419b67456a48beefd0be827b32db416772e0e363d5f7d54dc01787"
+PKG_VERSION="21.2.2"
+PKG_SHA256="c4aaf1bf974217ed825e1c536de6ab72a4e266d44bcf69fc4ec499039f99e5c4"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
update 21.2.1 to 21.2.2

ann:
- https://lists.freedesktop.org/archives/mesa-dev/2021-September/225490.html

release notes:
- https://gitlab.freedesktop.org/mesa/mesa/-/blob/21.2/docs/relnotes/21.2.2.rst