### PR TITLE
[LE10] rsync: add lchmod workaround patches

### DIFF
--- a/packages/addons/tools/network-tools/changelog.txt
+++ b/packages/addons/tools/network-tools/changelog.txt
@@ -1,3 +1,6 @@
+111
+- rsync: add lchmod workaround patches
+
 110
 - libpcap: update to 1.10.1
 - tcpdump: update to 4.99.1

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="110"
+PKG_REV="111"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/network/rsync/package.mk
+++ b/packages/network/rsync/package.mk
@@ -30,3 +30,12 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-acl-support \
                            --disable-zstd \
                            --with-included-popt \
                            --without-included-zlib"
+
+pre_make_host() {
+  # do not detect LE git version
+  echo "#define RSYNC_GITVER \"${PKG_VERSION}\"" >git-version.h
+}
+
+pre_make_target() {
+  pre_make_host
+}

--- a/packages/network/rsync/patches/0001-Work-around-glibc-s-lchmod-issue-a-better-way.patch
+++ b/packages/network/rsync/patches/0001-Work-around-glibc-s-lchmod-issue-a-better-way.patch
@@ -1,0 +1,65 @@
+From 0b187830db0e88d7d5e21a2d2d6040d64fed34c3 Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayne@opencoder.net>
+Date: Fri, 30 Oct 2020 15:51:24 -0700
+Subject: [PATCH] Work around glibc's lchmod() issue a better way.
+
+---
+ syscall.c | 34 +++++++++++++++++++++-------------
+ 1 file changed, 21 insertions(+), 13 deletions(-)
+
+diff --git a/syscall.c b/syscall.c
+index b9c3b4ef..11d10e4a 100644
+--- a/syscall.c
++++ b/syscall.c
+@@ -227,27 +227,35 @@ int do_open(const char *pathname, int flags, mode_t mode)
+ #ifdef HAVE_CHMOD
+ int do_chmod(const char *path, mode_t mode)
+ {
++	static int switch_step = 0;
+ 	int code;
+ 	if (dry_run) return 0;
+ 	RETURN_ERROR_IF_RO_OR_LO;
++	switch (switch_step) {
+ #ifdef HAVE_LCHMOD
+-	code = lchmod(path, mode & CHMOD_BITS);
+-#else
+-	if (S_ISLNK(mode)) {
++#include "case_N.h"
++		if ((code = lchmod(path, mode & CHMOD_BITS)) == 0 || errno != ENOTSUP)
++			break;
++		switch_step++;
++#endif
++
++#include "case_N.h"
++		if (S_ISLNK(mode)) {
+ # if defined HAVE_SETATTRLIST
+-		struct attrlist attrList;
+-		uint32_t m = mode & CHMOD_BITS; /* manpage is wrong: not mode_t! */
++			struct attrlist attrList;
++			uint32_t m = mode & CHMOD_BITS; /* manpage is wrong: not mode_t! */
+ 
+-		memset(&attrList, 0, sizeof attrList);
+-		attrList.bitmapcount = ATTR_BIT_MAP_COUNT;
+-		attrList.commonattr = ATTR_CMN_ACCESSMASK;
+-		code = setattrlist(path, &attrList, &m, sizeof m, FSOPT_NOFOLLOW);
++			memset(&attrList, 0, sizeof attrList);
++			attrList.bitmapcount = ATTR_BIT_MAP_COUNT;
++			attrList.commonattr = ATTR_CMN_ACCESSMASK;
++			code = setattrlist(path, &attrList, &m, sizeof m, FSOPT_NOFOLLOW);
+ # else
+-		code = 1;
++			code = 1;
+ # endif
+-	} else
+-		code = chmod(path, mode & CHMOD_BITS); /* DISCOURAGED FUNCTION */
+-#endif /* !HAVE_LCHMOD */
++		} else
++			code = chmod(path, mode & CHMOD_BITS); /* DISCOURAGED FUNCTION */
++		break;
++	}
+ 	if (code != 0 && (preserve_perms || preserve_executability))
+ 		return code;
+ 	return 0;
+-- 
+2.33.0
+


### PR DESCRIPTION
Fixes #5675, which is a regression introduced by glibc implementation of lchmod.  It appears that glibc is more or less waiting on a new syscall from the kernel to fix it properly, until then lchmod is broken when /proc is not mounted.

Tested on LE10 using rsync.conf:
```
list = yes
port = 873
log file = /storage/rsyncd.log
timeout = 300

[Synology3_Backup]
comment = Synology3 Video Backup
path = /tmp/test
max connections = 0
read only = false
hosts allow = 192.168.0.1
uid = root
gid = root
```

And running rsync as daemon:
```
mkdir -p /tmp/test
rsync --daemon --config=/storage/rsync.conf
```

And on remote server pushing a directory:
```
rsync -avWH ~/py3/ rsync://libreelec/Synology3_Backup/
```

Permissions should be set on folder structure under /tmp/test.
