### PR TITLE
[le11] linux (RPi): update to 5.10.63-a5d2df0

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="5d61ab70ad5dbdc2ac52b5b222ce1e5b6af49662"
-PKG_SHA256="0498f4fa30ad1fc93c66561eafa3e4553412b40fe2e077d50fb1ed0bb0412a04"
+PKG_VERSION="f9bc22444c70d51d964287f8d114c0c8b10b7cf1"
+PKG_SHA256="25c413156bb30d0e7015ff9d9192b8b9a94f492cbb542f80ea86259e02254138"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="d5d14f484cec739901a088a58eed62452b6dadeb"
-PKG_SHA256="987854b028458ffe2731d6163f07a3f8b512593604d2b3aa0afe62418243f0f7"
+PKG_VERSION="5d61ab70ad5dbdc2ac52b5b222ce1e5b6af49662"
+PKG_SHA256="0498f4fa30ad1fc93c66561eafa3e4553412b40fe2e077d50fb1ed0bb0412a04"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="25e2b597ebfb2495eab4816a276758dcc6ea21f1"
-PKG_SHA256="1a35c4a7bf7a7477d0d8bf13b51e6521d2148261afee3c98c0545ca4c0c02b79"
+PKG_VERSION="d5d14f484cec739901a088a58eed62452b6dadeb"
+PKG_SHA256="987854b028458ffe2731d6163f07a3f8b512593604d2b3aa0afe62418243f0f7"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="e4cb65cf23c78b4912786aaf8467aa215d4e1d88" # 5.10.60
-    PKG_SHA256="798764ff5146847adc6641b46be21e1c5f02798405fe1f9de587fb182c38b37e"
+    PKG_VERSION="27f5c22ebb463ebd43ab246e671854197bda4b05" # 5.10.63
+    PKG_SHA256="2ed7a941bc233603d61fc5c5d3081db89b3ac9cbca4230c929b2b30b1d063b6e"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="27f5c22ebb463ebd43ab246e671854197bda4b05" # 5.10.63
-    PKG_SHA256="2ed7a941bc233603d61fc5c5d3081db89b3ac9cbca4230c929b2b30b1d063b6e"
+    PKG_VERSION="a5d2df01fe25d6fce11485c4d8ae0c0a1ddef43a" # 5.10.63
+    PKG_SHA256="678bea81a8ca78932720618399a980ce64decea381125c8fb2b086b0eaa2d51c"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="d5d14f484cec739901a088a58eed62452b6dadeb"
-PKG_SHA256="571d38473933d02557bcacc0515e150cd07ef610ee3a4a4ffb0d05813442b03b"
+PKG_VERSION="5d61ab70ad5dbdc2ac52b5b222ce1e5b6af49662"
+PKG_SHA256="e2b2e70613d0d6221965438e3b51dfd3dab0ab2c3b7eb5429891ce9240843fbb"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="5d61ab70ad5dbdc2ac52b5b222ce1e5b6af49662"
-PKG_SHA256="e2b2e70613d0d6221965438e3b51dfd3dab0ab2c3b7eb5429891ce9240843fbb"
+PKG_VERSION="f9bc22444c70d51d964287f8d114c0c8b10b7cf1"
+PKG_SHA256="265f076a0359087ae74e8dc7e3e1c95ee4f555bb609f3dc3cf5ad51c1457edf2"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="25e2b597ebfb2495eab4816a276758dcc6ea21f1"
-PKG_SHA256="937aa9ad302e417f4220060caa6d3e8a78e3db227762127f1cdbb601e160f856"
+PKG_VERSION="d5d14f484cec739901a088a58eed62452b6dadeb"
+PKG_SHA256="571d38473933d02557bcacc0515e150cd07ef610ee3a4a4ffb0d05813442b03b"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"


### PR DESCRIPTION
This fixes console/splash not shown on HDMI0 if HDMI1 is connected https://github.com/raspberrypi/linux/issues/4540