### PR TITLE
Allwinner: linux: workaround for deinterlace driver loading

### DIFF
--- a/projects/Allwinner/patches/linux/0057-HACK-Disable-MBUS-due-to-fw_devlink-on.patch
+++ b/projects/Allwinner/patches/linux/0057-HACK-Disable-MBUS-due-to-fw_devlink-on.patch
@@ -1,0 +1,50 @@
+From a497a69951518aa93bd622755379a6f607e3ce5d Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Sat, 25 Sep 2021 16:21:41 +0200
+Subject: [PATCH] HACK: Disable MBUS due to fw_devlink=on
+
+---
+ arch/arm/boot/dts/sun8i-r40.dtsi              | 1 +
+ arch/arm/boot/dts/sunxi-h3-h5.dtsi            | 1 +
+ arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-r40.dtsi b/arch/arm/boot/dts/sun8i-r40.dtsi
+index 291f4784e86c..173edaff4c9b 100644
+--- a/arch/arm/boot/dts/sun8i-r40.dtsi
++++ b/arch/arm/boot/dts/sun8i-r40.dtsi
+@@ -949,6 +949,7 @@ mbus: dram-controller@1c62000 {
+ 			#size-cells = <1>;
+ 			dma-ranges = <0x00000000 0x40000000 0x80000000>;
+ 			#interconnect-cells = <1>;
++			status = "disabled";
+ 		};
+ 
+ 		tcon_top: tcon-top@1c70000 {
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index c7428df9469e..1cbb871b6628 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -575,6 +575,7 @@ mbus: dram-controller@1c62000 {
+ 			#size-cells = <1>;
+ 			dma-ranges = <0x00000000 0x40000000 0xc0000000>;
+ 			#interconnect-cells = <1>;
++			status = "disabled";
+ 		};
+ 
+ 		spi0: spi@1c68000 {
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi
+index 6ddb717f2f98..f0ec62b4170b 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64.dtsi
+@@ -1135,6 +1135,7 @@ mbus: dram-controller@1c62000 {
+ 			#size-cells = <1>;
+ 			dma-ranges = <0x00000000 0x40000000 0xc0000000>;
+ 			#interconnect-cells = <1>;
++			status = "disabled";
+ 		};
+ 
+ 		csi: csi@1cb0000 {
+-- 
+2.33.0
+


### PR DESCRIPTION
Add a (hacky) patch, which allows loading deinterlace drivers on all but H6 SoCs.

This fixes deinterlacing with current master branch (LE10 works correctly).