### PR TITLE
Allwinner: linux: Fix OrangePi 3 DT

### DIFF
--- a/projects/Allwinner/patches/linux/0058-WIP-OPi3-DT-fixes.patch
+++ b/projects/Allwinner/patches/linux/0058-WIP-OPi3-DT-fixes.patch
@@ -1,0 +1,136 @@
+From 59cc76036f42c7f7baa17cb46e6e19cf3a6a62bb Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Sun, 26 Sep 2021 09:31:45 +0200
+Subject: [PATCH] WIP: OPi3 DT fixes
+
+---
+ .../dts/allwinner/sun50i-h6-orangepi-3.dts    | 72 +++++++++----------
+ 1 file changed, 35 insertions(+), 37 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
+index c45d7b7fb39a..af92d92d85a3 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
+@@ -63,27 +63,7 @@ reg_vcc5v: vcc5v {
+ 		regulator-max-microvolt = <5000000>;
+ 		regulator-always-on;
+ 	};
+-
+-	reg_vcc33_wifi: vcc33-wifi {
+-		/* Always on 3.3V regulator for WiFi and BT */
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc33-wifi";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		regulator-always-on;
+-		vin-supply = <&reg_vcc5v>;
+-	};
+-
+-	reg_vcc_wifi_io: vcc-wifi-io {
+-		/* Always on 1.8V/300mA regulator for WiFi and BT IO */
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc-wifi-io";
+-		regulator-min-microvolt = <1800000>;
+-		regulator-max-microvolt = <1800000>;
+-		regulator-always-on;
+-		vin-supply = <&reg_vcc33_wifi>;
+-	};
+-
++	
+ 	wifi_pwrseq: wifi-pwrseq {
+ 		compatible = "mmc-pwrseq-simple";
+ 		clocks = <&rtc 1>;
+@@ -136,8 +116,8 @@ &mmc0 {
+ };
+ 
+ &mmc1 {
+-	vmmc-supply = <&reg_vcc33_wifi>;
+-	vqmmc-supply = <&reg_vcc_wifi_io>;
++	vmmc-supply = <&reg_cldo2>;
++	vqmmc-supply = <&reg_bldo3>;
+ 	mmc-pwrseq = <&wifi_pwrseq>;
+ 	bus-width = <4>;
+ 	non-removable;
+@@ -172,13 +152,17 @@ &ohci3 {
+ &pio {
+ 	vcc-pc-supply = <&reg_bldo2>;
+ 	vcc-pd-supply = <&reg_cldo1>;
+-	vcc-pg-supply = <&reg_vcc_wifi_io>;
++	vcc-pg-supply = <&reg_bldo3>;
+ };
+ 
+ &r_ir {
+ 	status = "okay";
+ };
+ 
++&r_pio {
++	vcc-pm-supply = <&reg_bldo3>;
++};
++
+ &r_rsb {
+ 	status = "okay";
+ 
+@@ -234,13 +218,12 @@ reg_bldo2: bldo2 {
+ 				regulator-max-microvolt = <1800000>;
+ 				regulator-name = "vcc-efuse-pcie-hdmi-pc";
+ 			};
+-
+-			bldo3 {
+-				/* unused */
+-			};
+-
+-			bldo4 {
+-				/* unused */
++			
++			reg_bldo3: bldo3 {
++				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc-dcxoio";
+ 			};
+ 
+ 			reg_cldo1: cldo1 {
+@@ -250,19 +233,34 @@ reg_cldo1: cldo1 {
+ 				regulator-name = "vcc33-io-pd-emmc-sd-usb-uart-2";
+ 			};
+ 
+-			cldo2 {
+-				/* unused */
++			reg_cldo2: cldo2 {
++				/*
++				 * This regulator is connected with CLDO3.
++				 * Before the kernel can support synchronized
++				 * enable of coupled regulators, keep them
++				 * both always on as a ugly hack.
++				 */
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc-wifi-1";
+ 			};
+ 
+ 			cldo3 {
+-				/* unused */
++				/*
++				 * This regulator is connected with CLDO2.
++				 * See the comments for CLDO2.
++				 */
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc-wifi-2";
+ 			};
+ 
+ 			reg_dcdca: dcdca {
+ 				regulator-always-on;
+-				regulator-min-microvolt = <800000>;
+-				regulator-max-microvolt = <1160000>;
+-				regulator-ramp-delay = <2500>;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <1080000>;
+ 				regulator-name = "vdd-cpu";
+ 			};
+ 
+-- 
+2.33.0
+


### PR DESCRIPTION
As discussed on forum (https://forum.libreelec.tv/thread/24344-orange-pi-3-irregular-system-freezing/), OrangePi 3 image is unstable. In some cases Kodi crashes without apparent reason. It was discovered that adjusting CPU voltage range in DT fixes this instability.