### PR TITLE
librespot: add new setting for zerconf port

### DIFF
--- a/packages/addons/service/librespot/changelog.txt
+++ b/packages/addons/service/librespot/changelog.txt
@@ -1,3 +1,6 @@
+129
+- Python: add new setting for zeroconf port
+
 128
 - Python: fix Librespot output is utf-8
 

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="librespot"
 PKG_VERSION="0.1.6"
 PKG_SHA256="7506b4448d3ae0eba063cd711baebdc23444c706c87d0551d5a4cbc623e70f30"
-PKG_REV="128"
+PKG_REV="129"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/librespot-org/librespot/"

--- a/packages/addons/service/librespot/source/resources/language/English/strings.po
+++ b/packages/addons/service/librespot/source/resources/language/English/strings.po
@@ -30,3 +30,7 @@ msgstr ""
 msgctxt "#30106"
 msgid "RTP Port"
 msgstr ""
+
+msgctxt "#30107" 
+msgid "Connect Port"
+msgstr ""

--- a/packages/addons/service/librespot/source/resources/lib/ls_addon.py
+++ b/packages/addons/service/librespot/source/resources/lib/ls_addon.py
@@ -15,6 +15,7 @@ DEFAULTS = dict(
     password='',
     rtp_dest='127.0.0.1',
     rtp_port='24642',
+    connect_port='0',
     username='',
 )
 

--- a/packages/addons/service/librespot/source/resources/lib/ls_librespot.py
+++ b/packages/addons/service/librespot/source/resources/lib/ls_librespot.py
@@ -37,6 +37,8 @@ class Librespot(xbmc.Player):
         settings = get_settings()
         quoted = {k: shlex.quote(v) for (k, v) in settings.items()}
         command = LIBRESPOT
+        if settings['connect_port'] != "0":
+            command += ' --zeroconf-port %s ' % settings['connect_port']
         if settings['autoplay'] == 'true':
             command += LIBRESPOT_AUTOPLAY
         if (settings['discovery'] == 'false' and

--- a/packages/addons/service/librespot/source/resources/settings.xml
+++ b/packages/addons/service/librespot/source/resources/settings.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category  label="30100">
-    <setting label="30101" id="autoplay"  type="bool"   default="true"         />
-    <setting label="30102" id="discovery" type="bool"   default="true"         />
-    <setting label="30103" id="username"  type="text"   default=""             subsetting="true" visible="eq(-1,false)" />
-    <setting label="30104" id="password"  type="text"   default=""             subsetting="true" visible="eq(-2,false)" option="hidden" />
-    <setting label="30105" id="name"      type="text"   default="Librespot@{}" />
-    <setting label="30106" id="rtp_port"  type="number" default="24642"        />
+    <setting label="30101" id="autoplay"     type="bool"   default="true"         />
+    <setting label="30102" id="discovery"    type="bool"   default="true"         />
+    <setting label="30103" id="username"     type="text"   default=""             subsetting="true" visible="eq(-1,false)" />
+    <setting label="30104" id="password"     type="text"   default=""             subsetting="true" visible="eq(-2,false)" option="hidden" />
+    <setting label="30105" id="name"         type="text"   default="Librespot@{}" />
+    <setting label="30106" id="rtp_port"     type="number" default="24642"        />
+    <setting label="30107" id="connect_port" type="number" default="0"        />
   </category>
 </settings>


### PR DESCRIPTION
Running librespot behind a firewall requires a predefined port for Spotify Connect. This PR adds a new setting to set the "Connect Port", keeping the default value of '0' falls back to the current behavior (automatic port assignment).