### PR TITLE
shairport-sync: update the build to use pkg-config

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/shairport-sync/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/shairport-sync/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="c92f9a2d86dd1138673abc66e0010c94412ad6a46da8f36c3d538f4fa6b9faca"
 PKG_LICENSE="OSS"
 PKG_SITE="https://github.com/mikebrady/shairport-sync"
 PKG_URL="https://github.com/mikebrady/shairport-sync/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain alsa-lib avahi libconfig libdaemon openssl popt pulseaudio soxr"
+PKG_DEPENDS_TARGET="toolchain alsa-lib avahi libconfig libdaemon libsndfile openssl popt pulseaudio soxr"
 PKG_LONGDESC="AirPlay audio player."
 PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="-sysroot"
@@ -18,6 +18,7 @@ PKG_CONFIGURE_OPTS_TARGET="--with-alsa \
                            --with-metadata \
                            --with-pa \
                            --with-pipe \
+                           --with-pkg-config \
                            --with-soxr \
                            --with-ssl=openssl \
                            --with-stdout \

--- a/packages/addons/addon-depends/snapcast-depends/shairport-sync/patches/fix-libsnfile-dependencies.patch
+++ b/packages/addons/addon-depends/snapcast-depends/shairport-sync/patches/fix-libsnfile-dependencies.patch
@@ -1,0 +1,20 @@
+--- a/configure.ac	2021-04-26 20:35:11.000000000 +1000
++++ b/configure.ac	2021-09-29 20:31:32.372329878 +1000
+@@ -302,9 +302,16 @@
+ # Look for Convolution flag
+ AC_ARG_WITH(convolution, [AS_HELP_STRING([--with-convolution],[choose audio DSP convolution support])])
+ if test "x$with_convolution" = "xyes" ; then
++  if test "x${with_pkg_config}" = "xyes" ; then
++    PKG_CHECK_MODULES(
++      [sndfile], [sndfile],
++      [CFLAGS="${sndfile_CFLAGS} ${CFLAGS}"
++      LIBS="${sndfile_LIBS} ${LIBS}"], AC_MSG_ERROR(Convolution support requires the sndfile library.))
++  else
++    AC_CHECK_LIB([sndfile], [sf_open], , AC_MSG_ERROR(Convolution support requires the sndfile library -- libsndfile1-dev suggested!))
++  fi
+   AM_INIT_AUTOMAKE([subdir-objects])
+   AC_DEFINE([CONFIG_CONVOLUTION], 1, [Include audio DSP convolution support.])
+-  AC_CHECK_LIB([sndfile], [sf_open], , AC_MSG_ERROR(Convolution support requires the sndfile library -- libsndfile1-dev suggested!))
+ fi
+ AM_CONDITIONAL([USE_CONVOLUTION], [test "x$with_convolution" = "xyes"])
+ 

--- a/packages/audio/libsndfile/patches/libsndfile-add-required-static-libaries-to-pkg-config.patch
+++ b/packages/audio/libsndfile/patches/libsndfile-add-required-static-libaries-to-pkg-config.patch
@@ -5,5 +5,5 @@
  Requires.private: @EXTERNAL_XIPH_REQUIRE@
  Version: @VERSION@
 -Libs: -L${libdir} -lsndfile
-+Libs: -L${libdir} -lsndfile -lFLAC -logg -lvorbis -lvorbisenc -lopus
++Libs: -L${libdir} -lsndfile -lFLAC -lvorbis -logg -lvorbisenc -lopus
  Cflags: -I${includedir}


### PR DESCRIPTION
- shairport-sync: update to using pkg-config
- libsndfile: reorder static libraries

Issue due to static libraries not being included 

Upstreamed PR: https://github.com/mikebrady/shairport-sync/pull/1303