### PR TITLE
[le10] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.sacd"
-PKG_VERSION="0.1.2-Matrix"
-PKG_SHA256="6bcd40d82982d85ed3e46e9b1363322eadfb61f1603054e39f0be60e677ec11a"
-PKG_REV="4"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="2021ef42630a690fdfcd48046c5d5cd13e23cbae94d5956b8d3f5f2aadf955f4"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.sacd"


### PR DESCRIPTION
- audiodecoder.sacd: update 0.1.2-Matrix to 19.0.0-Matrix