### PR TITLE
[le10] fontconfig: remove kodi's font folder from fontconfig dirs

### DIFF
--- a/packages/x11/other/fontconfig/conf.d/05-kodi-fonts.conf
+++ b/packages/x11/other/fontconfig/conf.d/05-kodi-fonts.conf
@@ -1,5 +1,0 @@
-<?xml version="1.0"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-<fontconfig>
-  <dir>/storage/.kodi/media/Fonts</dir>
-</fontconfig>

--- a/packages/x11/other/fontconfig/package.mk
+++ b/packages/x11/other/fontconfig/package.mk
@@ -28,7 +28,4 @@ pre_configure_target() {
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin
-
-  mkdir -p ${INSTALL}/etc/fonts/conf.d
-    cp ${PKG_DIR}/conf.d/*.conf ${INSTALL}/etc/fonts/conf.d
 }


### PR DESCRIPTION
This is no longer needed as kodi Matrix/Nexus already make
.kodi/media/Fonts available to libass.

Large collections of fonts should better be stored in the default
XDG_DATA_HOME fonts location of fontconfig (/storage/.local/share/fonts)
though to avoid slow movie startup and kodi potentially running out
of memory as kodi/libass will load all fonts from .kodi/media/Fonts
into RAM. Making the fonts available to libass via fontconfig avoids
this issue.

Backport of #5704 