### PR TITLE
packages-checker: remove trailing whitespace

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/mtpfs/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mtpfs/package.mk
@@ -14,7 +14,7 @@ PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-mad"
 
-# TODO: mtpfs runs host utils while building, fix and set 
+# TODO: mtpfs runs host utils while building, fix and set
 pre_configure_target() {
   export LIBS="-lusb-1.0 -ludev"
 }

--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -18,7 +18,7 @@ PKG_LIBVAR="PCSX-REARMED_LIB"
 
 make_target() {
   cd ${PKG_BUILD}
-  
+
   if target_has_feature neon; then
     export HAVE_NEON=1
     export BUILTIN_GPU=neon
@@ -28,7 +28,7 @@ make_target() {
 
   # check if this flag is still needed when this package is updated
   export CFLAGS="${CFLAGS} -fcommon"
-  
+
   case ${TARGET_ARCH} in
     aarch64)
       make -f Makefile.libretro DYNAREC=lightrec platform=aarch64 GIT_VERSION=${PKG_VERSION}

--- a/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
+++ b/packages/linux-driver-addons/dvb/depends/media_tree/package.mk
@@ -19,7 +19,7 @@ unpack() {
 
 post_unpack() {
   # hack/workaround for borked upstream kernel/media_build
-  # without removing atomisp there a lot additional includes that 
+  # without removing atomisp there a lot additional includes that
   # slowdown build process after modpost from 3min to 6min
   # even if atomisp is disabled via kernel.conf
   rm -rf ${PKG_BUILD}/drivers/staging/media/atomisp

--- a/packages/linux-driver-addons/dvb/depends/media_tree_cc/package.mk
+++ b/packages/linux-driver-addons/dvb/depends/media_tree_cc/package.mk
@@ -19,7 +19,7 @@ unpack() {
 
 post_unpack() {
   # hack/workaround for borked upstream kernel/media_build
-  # without removing atomisp there a lot additional includes that 
+  # without removing atomisp there a lot additional includes that
   # slowdown build process after modpost from 3min to 6min
   # even if atomisp is disabled via kernel.conf
   rm -rf ${PKG_BUILD}/drivers/staging/media/atomisp

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -179,7 +179,7 @@ pre_make_target() {
         continue
       fi
 
-      if [ "$($PKG_BUILD/scripts/config --state ${OPTION%%=*})" != "${OPTION##*=}" ]; then
+      if [ "$(${PKG_BUILD}/scripts/config --state ${OPTION%%=*})" != "${OPTION##*=}" ]; then
         MISSING_KERNEL_OPTIONS+="\t${OPTION}\n"
       fi
     done < ${DISTRO_DIR}/${DISTRO}/kernel_options

--- a/packages/wayland/weston/package.mk
+++ b/packages/wayland/weston/package.mk
@@ -39,7 +39,7 @@ post_makeinstall_target() {
     cp ${PKG_DIR}/config/weston.ini ${INSTALL}/usr/share/weston
 
   safe_remove ${INSTALL}/usr/share/wayland-sessions
-  safe_remove ${INSTALL}/usr/bin/weston-calibrator 
+  safe_remove ${INSTALL}/usr/bin/weston-calibrator
   safe_remove ${INSTALL}/usr/bin/weston-simple-*
   safe_remove ${INSTALL}/usr/bin/weston-touch-calibrator
 }

--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -39,7 +39,7 @@ makeinstall_target() {
     ln -sf /var/lib/nvidia_drv.so ${INSTALL}/${XORG_PATH_MODULES}/drivers/nvidia_drv.so
 
   mkdir -p ${INSTALL}/${XORG_PATH_MODULES}/extensions
-  # rename to avoid conflicts with X.Org-Server module libglx.so 
+  # rename to avoid conflicts with X.Org-Server module libglx.so
     cp -P libglxserver_nvidia.so.${PKG_VERSION} ${INSTALL}/${XORG_PATH_MODULES}/extensions/libglx_nvidia.so
 
   mkdir -p ${INSTALL}/etc/X11

--- a/tools/packages-checker
+++ b/tools/packages-checker
@@ -10,6 +10,7 @@
 for directory in $(find packages/ -mindepth 1 -maxdepth 1 -type d | sort); do
   for file in $(find "${directory}" -type f -name "package.mk" | sort); do
     tools/fixlecode.py -qw -f "${file}"
+    sed -i 's/[[:blank:]]*$//g' "${file}"
   done
   git commit -qs -m "${directory##*/}: automated code cleanup" "${directory}"
 done

--- a/tools/packages-checker
+++ b/tools/packages-checker
@@ -7,6 +7,13 @@
 # follow certain coding standards used in the project. Corrections are grouped
 # by the subdirectory within the packages feed, and then commited.
 
+# Corrections made:
+# PKG_VAR="$PKG_VAR stuff" -> PKG_VAR+=" stuff"
+# $PKG_VAR -> ${PKG_VAR}
+# result=`subcommand` -> result=$(subcommand)
+# [ test ] ; then -> [ test ]; then
+# trailing whitespace at end of line
+
 for directory in $(find packages/ -mindepth 1 -maxdepth 1 -type d | sort); do
   for file in $(find "${directory}" -type f -name "package.mk" | sort); do
     tools/fixlecode.py -qw -f "${file}"


### PR DESCRIPTION
This adds removal of trailing whitespace to the tasks `tools/packages-checker` does. It also makes a list of the checks it does, and has the current output of the script on the packages tree.