### PR TITLE
[le10] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.freebox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.freebox/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.freebox"
-PKG_VERSION="6.1.4-Matrix"
-PKG_SHA256="ddbfa193714390eb76cf635bf686a8ada46e0764f982319cb8fdba0848ce015a"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="64f614afc4747935170d3e63023c98e9d783090ff4b21c4a1e8eac3887b09baa"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="7.3.4-Matrix"
-PKG_SHA256="8adfda3b257debf231b313b8d825afae5ae98c67afd4655d69d2ea40acd9861b"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="14d76fda4b9c8e7ac068071e322432fe585357154a2b2bae23d051def766f06d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.waipu"
-PKG_VERSION="19.0.0-Matrix"
-PKG_SHA256="7a9fe1a9bf3ba7fab0755e6e8a8442909d33f373cee0ada73d5c8e2bf2c7a099"
+PKG_VERSION="19.0.1-Matrix"
+PKG_SHA256="19e7a9b1d332d18e7e539062d0de1ef35d78c9beadb67f1ac9b95ab204aa5bce"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
this is Matrix binary addons - this is no longer lockstep or a back port of the LE11 PRs. The binary add ons are now a different branch.

https://github.com/LibreELEC/LibreELEC.tv/pull/5637#issuecomment-932786242

- pvr.freebox: update 6.1.4-Matrix to 19.0.0-Matrix
- pvr.mythtv: update 7.3.4-Matrix to 19.0.0-Matrix
- pvr.waipu: update 19.0.0-Matrix to 19.0.1-Matrix