### PR TITLE
[le11] docker: update addon to (134)

### DIFF
--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.3.9"
-PKG_SHA256="9244212589c84b12262769dca6fb985c0c680cb5259c8904b29c511d81fd62d0"
+PKG_VERSION="1.5.6"
+PKG_SHA256="144612f9400c2fc52b2abc7b1ef33bf708d322dad9b3afdc1ae9d02fa034753b"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.tools/"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-PKG_GIT_COMMIT="8fba4e9a7d01810a393d5d25a3621dc101981175"
+PKG_GIT_COMMIT="1a1b383ad5b520349f13f9715e0cd1e2f132c087"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/libnetwork/package.mk
+++ b/packages/addons/addon-depends/libnetwork/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnetwork"
-PKG_VERSION="a543cbc4871f904b0efe205708eb45d72e65fd8b"
-PKG_SHA256="3e3b0048aa468de0fe33ad2c08bf3891ac1a72fca434f92620312da51f344488"
+PKG_VERSION="64b7a4574d1426139437d20e81c0b6d391130ec8" # 2021-05-25
+PKG_SHA256="ede21e645ff6552b3a508f6186d3f34d267015ec0f96eefecf6d08c03cbd2987"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/docker/libnetwork"
 PKG_URL="https://github.com/docker/libnetwork/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.0.0-rc93"
-PKG_SHA256="e42456078d2f76c925cdd656e4f423b918525d8188521de05e893b6bb473a6f8"
+PKG_VERSION="1.0.2"
+PKG_SHA256="6c3cca4bbeb5d9b2f5e3c0c401c9d27bc8a5d2a0db8a2f6a06efd03ad3c38a33"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-PKG_GIT_COMMIT="12644e614e25b05da6fd08a38ffa0cfe1903fdec"
+PKG_GIT_COMMIT="2c7861bc5e1b3e756392236553ec14a78a09f8bf"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,8 @@
+134
+- containerd: update to 1.5.6
+- libnetwork: update to 2021-05-25
+- runc: update to 1.0.2
+
 133
 - Update to docker 19.03.15
 - runc: update to 1.0.0-rc93

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="docker"
 PKG_VERSION="19.03.15"
 PKG_SHA256="f2f31dd4137eaa735a26e590c9718fb06867afff4d8415cc80feb6cdc9e4a8cd"
-PKG_REV="133"
+PKG_REV="134"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
update docker addon (134) utilising updated supporting packages
- containerd: update to 1.5.6
- libnetwork: update to 2021-05-25
- runc: update to 1.0.2