### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="850417841fa684e8422970e3265eefdee983f3bfdc0b7ad9c19bd81b3c10617f"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="27cf74e46a2ff8cfc9bc9d4c4542aa0820ed0c83065ea1f7259906e1e542524d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="4a1d748e3ab8cd27c288d9b3d537ede000e6a4decf9683b4ebb85526cf295d69"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="8f0b97c70fc23cb4c7e01a03180f5f642a4c257538afa1e5aa90e6e8e958cb47"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvblink"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="e5933dc04dbc3b91b5761fc7bcd9841c8388a20098c579c664001c90796d746d"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="f74e8e58bdbb43d5eace73ed1594c11cf5612cfb19304200da8b200fb220b736"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvbviewer"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="98cda310a27b618308ee1effa5a4cb2f8100b54cc23282acbf4fd038e985bb11"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="9b455cc2e36442e5d2045bb90763fa19d532bb7a2af440da9cde81891989aa1f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.filmon"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="9e00e8c9b8eb7e4aa613de71ad1e859cfdff8ae6ab79a2bdf44c6603e6ed9f92"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="a0dde4e99f5a8278b42c9728437ca47e68b727b517c72ab580eb773a549125d2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.freebox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.freebox/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.freebox"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="67da13a4ae749bc615c1b4594d7ceed078cfa8769b65fad97a6531bf770a82c7"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="74d5db15763d8b8fbe86e1302d444781b728544c5b73ed42b77375c6dec2d2e3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hdhomerun"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="739a4b6510750398c15beefe987df373ca6f062ef4016c7b59c887fb857c5884"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="78b06f509b3de8a1adeeb843566a848814a7aa315789ab437a4a2b40ed98f9dd"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="6d86285ff023a6d7e412927db70a6e9ac83ddd21dcae4c71713ebe032002d4a8"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="734dfef3eee41e5182396399be365bd568e22bce12761bc78801677d89743d86"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="700816ea6d92341d1ca201480c6d134efcb121c102a74bd0184ed04f846379ff"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="5bdbd9d54d7a9c48aec98554aa8a6472ceaab6bb2c3f9868bfcd129f7ad04dd0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="8aa74e28681e43fa20b9f63c0f4e55518fa5c9f6fb51237b2ea96e0228c8f515"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="dc53428e71d0e5c8b6b8aedc83fe5d78431d31a6d25d18f57f406b6830dd841d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.njoy"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="440d0863a4793232f99535265ab21a4ff672346b116f23da1b0eabaf0eab5a43"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="5762067b7fd574e188c53ffc3459e39114b14d17f94efa745a765e28fb3341e0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.octonet"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="7f978cdc0e19115ef689e87676ecc6f78ee096945ff1214ae5e523148374cc3d"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="2750b6d344d21e6082c46a917bed85c9ded7fab0af305bcdf431b51adf477f50"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.pctv"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="931a3471d43e8600253a5b42e05b2bda70925affb81d626a57767eab0a19bb7c"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="498fe7bc50d344e1d12759d3a14d9e7d7985092b7a90ed7038c20fe0194f560e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.sledovanitv.cz"
-PKG_VERSION="20.0.1-Nexus"
-PKG_SHA256="be4606a1fcedfd87683bbd4e7252e0ff8202a8449832476a030daca805c5ade6"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="df3beba1fabf36f2bcf9e31315ce3dfb843f09676a51b3b668093c162acf55fa"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="51372f004d1e5f099e52e7e1546d1b34a159d97fb8d870a0f50a77fceccafee9"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="f47f2f0cd7b8ce37e8e0674534ba31b823e11ed44307207f94a162a8cf381ea3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.teleboy"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="3ad87720e5cb3e54c8fdd31bbb980d4fcc76ef581a6945e4156f9f6893fc839f"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="0a0a95e05dd3b1b23a49ba8875363c364888ca43377c2104b709df0fbe4a809d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vbox"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="ce8086a5df9d3d41566577207a4741058d993febe67aa73b85d00a8005d75f82"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="319aeb45b3adaf0f4527feb59825360e7d3fb04d319eca71651b0240f93b4e3f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="1d8143372b4e37fc8e91c20a23922750ab613bd411b2adf056f2d81c384a30d3"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="cbdccf7edc61a51bacae2d0609850651dced4d5aa026735dcdd939660d1dec37"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="ae9f4419a843493adb76c80efca8f07824fac7032ad1ba7b7ce23dfce69a74ad"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="58686c4815c512fb400faba36b1241354d2df9c95535575328d1e06a199450bc"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="637017ed449e4e23bda3b10242c8138b7636f5b841c04b0ee9d422edf20aab77"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="93c8347dd05ce4d5ea815df74a8fa6da48b3367d9dd6bf4961ab3b3ebd5d2e61"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="8c53108ec9a8a52adad5f32cd59a76d6fb1faf8253d610f916a06e6a6bbbe383"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="a30bf3c66ab3715eaaa0c12d9da99ff00fd95bbdc151a291d5dbe4d0b824c51d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- pvr.argustv: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.demo: update 20.1.0-Nexus to 20.2.0-Nexus
- pvr.dvblink: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.dvbviewer: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.filmon: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.freebox: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.hdhomerun: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.hts: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.mediaportal.tvserver: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.nextpvr: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.njoy: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.octonet: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.pctv: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.sledovanitv.cz: update 20.0.1-Nexus to 20.1.0-Nexus
- pvr.stalker: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.teleboy: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.vbox: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.vdr.vnsi: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.vuplus: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.wmc: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.zattoo: update 20.0.0-Nexus to 20.1.0-Nexus