### PR TITLE
libheif: fix compile error with -Wunused-variable

### DIFF
--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -17,3 +17,7 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-go \
                            --disable-examples \
                            --disable-tests"
+
+pre_configure_target() {
+  export CXXFLAGS="${CXXFLAGS} -Wno-unused-variable"
+}


### PR DESCRIPTION
With update to build environment to be more pedantic, libheif is failing with below. Use `-Wno-unused-variable` to ignore error. Unused variables still present in 1.11.0 and 1.12.0 as the logs show below. This PR does not introduce a package bump, just the compile fix “workaround.”

```
/bin/bash ../libtool  --tag=CXX   --mode=compile /var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/toolchain/bin/armv7ve-libreelec-linux-gnueabihf-g++ -DHAVE_CONFIG_H -I. -I/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/build/libheif-1.12.0/libheif -I..    -fvisibility=hidden  -I/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/toolchain/armv7ve-libreelec-linux-gnueabihf/sysroot/usr/include  -I/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/toolchain/armv7ve-libreelec-linux-gnueabihf/sysroot/usr/include  -DLIBHEIF_EXPORTS -I/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/build/libheif-1.12.0 -DHAVE_VISIBILITY -march=armv7ve -mtune=cortex-a15.cortex-a7 -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -mfloat-abi=hard -mfpu=neon-vfpv4 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -fPIC -DPIC -Wall -Werror -Wsign-compare -Wconversion -Wno-sign-conversion -Wno-error=conversion -Wno-error=unused-parameter -Wno-error=deprecated-declarations -MT libheif_la-heif_hevc.lo -MD -MP -MF .deps/libheif_la-heif_hevc.Tpo -c -o libheif_la-heif_hevc.lo `test -f 'heif_hevc.cc' || echo '/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/build/libheif-1.12.0/libheif/'`heif_hevc.cc
/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/build/libheif-1.12.0/libheif/file_fuzzer.cc: In function 'void TestDecodeImage(heif_context*, const heif_image_handle*, size_t)':
/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/build/libheif-1.12.0/libheif/file_fuzzer.cc:37:7: error: unused variable 'width' [-Werror=unused-variable]
   37 |   int width = heif_image_handle_get_width(handle);
      |       ^~~~~
/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/build/libheif-1.12.0/libheif/file_fuzzer.cc:38:7: error: unused variable 'height' [-Werror=unused-variable]
   38 |   int height = heif_image_handle_get_height(handle);
      |       ^~~~~~
/var/media/DATA/home-rudi/LibreELEC.master/build.LibreELEC-Exynos.arm-11.0-devel/build/libheif-1.12.0/libheif/file_fuzzer.cc:46:7: error: unused variable 'metadata_ids_count' [-Werror=unused-variable]
   46 |   int metadata_ids_count = heif_image_handle_get_list_of_metadata_block_IDs(handle, nullptr, metadata_ids,
      |       ^~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [Makefile:1112: file_fuzzer.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```