### PR TITLE
Allwinner: linux: avoid printing error message

### DIFF
--- a/projects/Allwinner/patches/linux/0059-bus-sun50i-de2-Adjust-printing-error-message.patch
+++ b/projects/Allwinner/patches/linux/0059-bus-sun50i-de2-Adjust-printing-error-message.patch
@@ -1,0 +1,38 @@
+From 215e40242ae4348b97011b25a7f8f1bb6fb638ba Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Sun, 10 Oct 2021 09:11:00 +0200
+Subject: [PATCH] bus: sun50i-de2: Adjust printing error message
+
+SRAM driver often returns -EPROBE_DEFER and thus this bus driver often
+prints error message, even if it probes successfully later. This is
+confusing for users and they often think that something is wrong.
+
+Use dev_err_probe() helper for printing error message. It handles
+-EPROBE_DEFER automatically.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ drivers/bus/sun50i-de2.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/bus/sun50i-de2.c b/drivers/bus/sun50i-de2.c
+index 672518741f86..414f29cdedf0 100644
+--- a/drivers/bus/sun50i-de2.c
++++ b/drivers/bus/sun50i-de2.c
+@@ -15,10 +15,9 @@ static int sun50i_de2_bus_probe(struct platform_device *pdev)
+ 	int ret;
+ 
+ 	ret = sunxi_sram_claim(&pdev->dev);
+-	if (ret) {
+-		dev_err(&pdev->dev, "Error couldn't map SRAM to device\n");
+-		return ret;
+-	}
++	if (ret)
++		return dev_err_probe(&pdev->dev, ret,
++				     "Couldn't map SRAM to device\n");
+ 
+ 	of_platform_populate(np, NULL, NULL, &pdev->dev);
+ 
+-- 
+2.33.0
+


### PR DESCRIPTION
Users sometimes look into dmesg on A64 and H6 and report error "Error couldn't map SRAM to device". This is completely harmless most of the times, but confusing nevertheless.

Avoid confusion with printing error message only when something is really wrong.