### PR TITLE
ntfs-3g_ntfsprogs: update to 2021.8.22

### DIFF
--- a/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
+++ b/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ntfs-3g_ntfsprogs"
-PKG_VERSION="2017.3.23AR.5"
-PKG_SHA256="04ccf583b495806cefb71850e5899e50aed5e7bf23365259f2badaa9af21e5ed"
+PKG_VERSION="2021.8.22"
+PKG_SHA256="55b883aa05d94b2ec746ef3966cb41e66bed6db99f22ddd41d1b8b94bb202efb"
 PKG_LICENSE="GPL"
-PKG_SITE="https://jp-andre.pagesperso-orange.fr/"
-PKG_URL="https://jp-andre.pagesperso-orange.fr/${PKG_NAME}-${PKG_VERSION}.tgz"
+PKG_SITE="https://github.com/tuxera/ntfs-3g"
+PKG_URL="https://tuxera.com/opensource/${PKG_NAME}-${PKG_VERSION}.tgz"
 PKG_DEPENDS_TARGET="toolchain fuse libgcrypt"
 PKG_LONGDESC="A NTFS driver with read and write support."
 PKG_TOOLCHAIN="autotools"


### PR DESCRIPTION
Update of LE11 until ntfs3 replaces with 5.15 kernel. ntfs3 has been relocated to GitHub as per notes below, and a renewed update cycle - would be appropriate to backport to LE10 👍 after testing in :master.

update 2017.3.23AR.5 (April 1, 2020) to 2021.8.22 (August 30, 2021)

Changelog since 2017.3.23AR.5:
- https://github.com/tuxera/ntfs-3g/releases
- Fixed compile error when building with libfuse < 2.8.0
- Fixed obsolete macros in configure.ac
- Signalled support of UTIME_OMIT to external libfuse2
- Fixed an improper macro usage in ntfscp.c
- Updated the repository change in the README
- Fixed vulnerability threats caused by maliciously tampered NTFS partitions
- Used kernel cacheing on read-only mounts or with lowntfs-3g
- Avoided information leak when processing garbled compressed data
- Defined option posix_nlink to compute a Posix compliant st_nlink
- Recovered space when an index root is shortened
- Replaced ENODATA with ENOATTR in xattrs functions for macOS
- Added support for 'position' argument in macOS xattr functions
- Changed default xattr access method to 'openxattr' for macOS builds
- Allowed redefining the target location of the ntfsprogs tools
- Fixed updating the allocated size when attribute lies in an extent
- Enabled actions on directories in reparse plugins
- Inserted the reparse tag in the bad reparse symlink
- Supported use of WSL special files
- Dropped rejecting having both EA and reparse data
- Enabled Creating special files the same way as WSL
- Checked the locations of MFT and MFTMirr at startup

references:
- https://jp-andre.pagesperso-orange.fr/advanced-ntfs-3g.html
- https://github.com/tuxera/ntfs-3g/wiki

While the NTFS-3G project globally aims at providing a stable NTFS
driver for several operating systems such as Linux, FreeBSD, macOS, and
more, the project's advanced branch has specifically aimed at
developing, maturing, and releasing features to get user feedback prior
to feature integration into the project's main branch.

The parallel existence of both a stable and an advanced variant
maintained across several locations has caused some confusion. In
particular, the Linux distributions observed different policies in
selecting which version they use for their packaging. The led to users
questioning the differences between features and to additional
challenges in providing support.

We've decided to merge the two projects and maintain a single repository
for source code and documentation on GitHub. As the projects have always
remained in close contact, this induces no discontinuity in the released
features while enabling smoother support. The former repository on
Sourceforge will be discontinued after a grace period for the users to
adapt to the project's new state.

Thank you for your confidence in NTFS-3G.