### PR TITLE
rpcbind: NFS discovery fix

### DIFF
--- a/packages/network/rpcbind/package.mk
+++ b/packages/network/rpcbind/package.mk
@@ -14,6 +14,7 @@ PKG_LONGDESC="The rpcbind utility is a server that converts RPC program numbers 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_rpcsvc_mount_h=no \
                            --disable-warmstarts \
                            --disable-libwrap \
+                           --enable-rmtcalls \
                            --with-statedir=/tmp \
                            --with-rpcuser=root"
 


### PR DESCRIPTION
After rpcbind was updated to 1.2.5 NFS servers discovery doesn't work anymore.
In this build added a new configuration flag --enable-rmtcalls which will be needed to enable the remote call functionality.
After this change NFS server could be discoverable again.