### PR TITLE
update scripts: rework tag fetching with GitHub API

### DIFF
--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -127,7 +127,9 @@ for addontxt in ${ADDONS_REPO_LOCATION}/*-addons.txt ; do
         git_clone ${GIT_REPO} ${GIT_DIR} ${GIT_BRANCH}
         PARAMS="resolve_tag_in_branch ${GIT_DIR} ${GIT_BRANCH}"
       else
-        PARAMS="resolve_tag_on_gh ${GIT_REPO} ${GIT_BRANCH}"
+        REPO=$(basename "${GIT_REPO}")
+        OWNER=$(basename "${GIT_REPO%/${REPO}*}")
+        PARAMS="resolve_tag_on_gh ${OWNER} ${REPO} ${GIT_BRANCH}"
       fi
       NEW_VERSION=$(${PARAMS})
 

--- a/tools/mkpkg/update_common_functions
+++ b/tools/mkpkg/update_common_functions
@@ -84,17 +84,27 @@ resolve_tag_in_branch() {
 resolve_tag_on_gh() {
   local tag
 
-  tag=$(curl -s -L -H "Authorization: token ${GITHUB_API_TOKEN}" \
-          "${1/*github.com/https:\/\/api.github.com\/repos}/releases" | \
-          jq -r '[.[] | select(.target_commitish == "'$2'")][0].tag_name | select (.!=null)')
+  local QUERY=$(tr '\n' ' ' <<EOF
+{
+  repository(owner: \\"${1}\\", name: \\"${2}\\") {
+    refs(refPrefix: \\"refs/tags/\\", first: 100, orderBy: {field: TAG_COMMIT_DATE, direction: DESC}) {
+      edges {
+        node {
+          name
+       }
+      }
+    }
+  }
+}
+EOF
+)
 
-  if [ -z "$tag" ] ; then
-    tag=$(curl -s -L -H "Authorization: token ${GITHUB_API_TOKEN}" \
-            "${1/*github.com/https:\/\/api.github.com\/repos}/tags" | \
-            jq -r '[.[] | select(.name | contains("'$2'"))][0].name | select (.!=null)')
-  fi
+  tag=$(curl -s -L -H 'Content-Type: application/json' \
+          -H "Authorization: bearer ${GITHUB_API_TOKEN}" \
+          -X POST -d "{ \"query\": \"${QUERY}\" }" https://api.github.com/graphql | \
+          jq -r '[.data.repository.refs.edges[] | select(.node.name | contains("'${3}'"))][0].node.name | select (.!=null)')
 
-  echo "$tag"
+  echo "${tag}"
 }
 
 check_package_excluded() {

--- a/tools/mkpkg/update_retroplayer-addons
+++ b/tools/mkpkg/update_retroplayer-addons
@@ -126,7 +126,9 @@ for addon in ${ADDONS_DIR}/*.*/ ; do
     git_clone "${GAME_GIT_REPO}" "${GAME_GIT_DIR}"
     GAME_NEW_VERSION=$(resolve_tag_in_branch "${GAME_GIT_DIR}" "${GAME_GIT_BRANCH}" "*-${KODI_BRANCH}")
   else
-    GAME_NEW_VERSION=$(resolve_tag_on_gh "${GAME_GIT_REPO}" "-${KODI_BRANCH}")
+    REPO=$(basename "${GAME_GIT_REPO}")
+    OWNER=$(basename "${GAME_GIT_REPO%/${REPO}*}")
+    GAME_NEW_VERSION=$(resolve_tag_on_gh "${OWNER}" "${REPO}" "-${KODI_BRANCH}")
   fi
 
   if [ -z "${GAME_NEW_VERSION}" ]; then


### PR DESCRIPTION
Use GitHub GraphQL API to sort fetched tags by date instead by version number.