### PR TITLE
install2emmc: use SYSTEM_SIZE and DISTRONAME in script

### DIFF
--- a/projects/Allwinner/filesystem/usr/bin/install2emmc
+++ b/projects/Allwinner/filesystem/usr/bin/install2emmc
@@ -5,7 +5,7 @@
 
 TMP=/tmp/mnt/
 
-SYSTEM_SIZE=512
+SYSTEM_SIZE=@SYSTEM_SIZE@
 UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
 UUID_STORAGE="$(uuidgen)"
 BOOT=$(grep /flash /proc/mounts | awk '{print $1}' | sed 's/p[012]//g')
@@ -30,7 +30,7 @@ fi
 
 echo ""
 echo -e "\033[36m==============================="
-echo "Installing LibreELEC to eMMC"
+echo "Installing @DISTRONAME@ to eMMC"
 echo -e "===============================\033[37m"
 echo ""
 echo "eMMC found at ${DISK}"

--- a/projects/NXP/devices/iMX8/filesystem/usr/bin/install2emmc
+++ b/projects/NXP/devices/iMX8/filesystem/usr/bin/install2emmc
@@ -5,7 +5,7 @@
 
 TMP=/tmp/mnt/
 
-SYSTEM_SIZE=512
+SYSTEM_SIZE=@SYSTEM_SIZE@
 UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
 UUID_STORAGE="$(uuidgen)"
 BOOT=$(grep /flash /proc/mounts | awk '{print $1}' | sed 's/p[012]//g')
@@ -37,7 +37,7 @@ fi
 
 echo ""
 echo -e "\033[36m==============================="
-echo "Installing LibreELEC to eMMC"
+echo "Installing @DISTRONAME@ to eMMC"
 echo -e "===============================\033[37m"
 echo ""
 echo "eMMC found at ${DISK}"

--- a/scripts/image
+++ b/scripts/image
@@ -203,6 +203,14 @@ if [ -n "${DEVICE}" -a -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesyste
   done
 fi
 
+# Replace placeholders with values in install script to eMMC
+if [ -f ${INSTALL}/usr/bin/install2emmc ]; then
+  sed -e "s%@SYSTEM_SIZE@%${SYSTEM_SIZE}%g" \
+      -i ${INSTALL}/usr/bin/install2emmc
+  sed -e "s%@DISTRONAME@%${DISTRONAME}%g" \
+      -i ${INSTALL}/usr/bin/install2emmc
+fi
+
 # Run depmod for base overlay modules
 MODVER=$(basename $(ls -d ${INSTALL}/usr/lib/kernel-overlays/base/lib/modules/*))
 find ${INSTALL}/usr/lib/kernel-overlays/base/lib/modules/${MODVER}/ -name *.ko | \


### PR DESCRIPTION
Script uses arbitrary values for FAT32 partition and name of the
distribution. Using placeholders in the script and replacing them at
build time offers flexibility, i.e. no need to change arbitrary values
in script when SYSTEM_SIZE is changed.