### PR TITLE
[le10] tz: update to 2021d

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2021c"
-PKG_SHA256="43e657d877c73bd130dc3ddba83f64d654e8269d38f731b13d5cb23b79befeb1"
+PKG_VERSION="2021d"
+PKG_SHA256="2e6b14cfe3ee389f67887c36436cc40ff11266e5c2213295c1528f42a65dc98e"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
backport of #5768 

ann: http://mm.icann.org/pipermail/tz-announce/2021-October/000068.html

This release reflects the following changes, which were either
circulated on the tz mailing list or are relatively minor technical or
administrative changes:

   Briefly:
     Fiji suspends DST for the 2021/2022 season.
     'zic -r' marks unspecified timestamps with "-00".

   Changes to future timestamps

     Fiji will suspend observance of DST for the 2021/2022 season.
     Assume for now that it will return next year.  (Thanks to Jashneel
     Kumar and P Chan.)

   Changes to code

     'zic -r' now uses "-00" time zone abbreviations for intervals
     with UT offsets that are unspecified due to -r truncation.
     This implements a change in draft Internet RFC 8536bis.