### PR TITLE
mariadb-connector-c: install secure authentication plugins

### DIFF
--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -19,6 +19,15 @@ PKG_CMAKE_OPTS_TARGET="-DWITH_EXTERNAL_ZLIB=ON
                       "
 
 post_makeinstall_target() {
+  # keep modern authentication plugins
+  PLUGINP=${INSTALL}/usr/lib/mariadb/plugin
+  mkdir -p ${INSTALL}/.tmp
+  mv ${PLUGINP}/{caching_sha2_password,client_ed25519,sha256_password}.so ${INSTALL}/.tmp
+
   # drop all unneeded
   rm -rf ${INSTALL}/usr
+
+  mkdir -p ${PLUGINP}
+  mv ${INSTALL}/.tmp/* ${PLUGINP}/
+  rmdir ${INSTALL}/.tmp
 }


### PR DESCRIPTION
Since version 8.0 mysql is using [sha 256 authentication](https://dev.mysql.com/doc/refman/8.0/en/sha256-pluggable-authentication.html) by default.

Deleting the authentication plugins will break access to default configured servers as reported in the [forum](https://forum.libreelec.tv/thread/24678-resolved-can-t-get-mysql-db-to-function/).

With this PR [sha-256](https://mariadb.com/kb/en/authentication-plugin-sha-256/#client-authentication-plugins) and [ed25519](https://mariadb.com/kb/en/authentication-plugin-ed25519/) authentication plugins are installed (in fact not deleted).

Backport of #5773