### PR TITLE
kmscube: update to HEAD

### DIFF
--- a/packages/graphics/kmscube/package.mk
+++ b/packages/graphics/kmscube/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kmscube"
-PKG_VERSION="e6386d1b99366ea7559438c0d3abd2ae2d6d61ac"
-PKG_SHA256="0f162bbcef951d5e3fc5e8974f5944c420657edc72bf51e0074f46f30d942722"
+PKG_VERSION="9f63f359fab1b5d8e862508e4e51c9dfe339ccb0"
+PKG_SHA256="896ac76671a9b89836a7014b16cc85b45b041e03fe34a8f529f4718aa2b15cef"
 PKG_LICENSE="GPL"
 PKG_SITE="https://gitlab.freedesktop.org/mesa/kmscube"
 PKG_URL="https://gitlab.freedesktop.org/mesa/kmscube/-/archive/master/kmscube-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Using `tools/download-tool`, download of kmscube fails with 404.
It seems they force-pushed the master branch.
This updates it to current HEAD, allowing download-tool to complete without errors.

PS: I can't find a single reference to kmscube anywhere, so it might just be better to simply remove it?
