### PR TITLE
e2fsprogs: always support timestamps >2038

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -37,6 +37,12 @@ PKG_CONFIGURE_OPTS_HOST="--prefix=${TOOLCHAIN}/ \
                          --disable-fuse2fs \
                          --with-gnu-ld"
 
+post_unpack() {
+  # Increase minimal inode size to avoid:
+  # "ext4 filesystem being mounted at xxx supports timestamps until 2038 (0x7fffffff)"
+  sed -i 's/inode_size = 128/inode_size = 256/g' ${PKG_BUILD}/misc/mke2fs.conf.in
+}
+
 pre_configure() {
   PKG_CONFIGURE_OPTS_INIT="BUILD_CC=${HOST_CC} \
                            --with-udev-rules-dir=no \


### PR DESCRIPTION
To support timestamps >2038 ext4 FS has to be created with an inode_size of 256.

The recommended method is changing mke2fs.conf, see comment of Theodore Ts'o in [Ubuntu bug report](https://bugs.launchpad.net/ubuntu/+source/e2fsprogs/+bug/1881935).