### PR TITLE
[LE10] eSpeak-NG: initial package

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -87,6 +87,9 @@
 # build and install PulseAudio support (yes / no)
   PULSEAUDIO_SUPPORT="yes"
 
+# build and install eSpeak-NG support (yes / no)
+  ESPEAK_SUPPORT="yes"
+
 # build and install with BluRay support (yes / no)
   KODI_BLURAY_SUPPORT="yes"
 

--- a/packages/audio/espeak-ng/package.mk
+++ b/packages/audio/espeak-ng/package.mk
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="espeak-ng"
+PKG_VERSION="1.50"
+PKG_SHA256="80ee6cd06fcd61888951ab49362b400e80dd1fac352a8b1131d90cfe8a210edb"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/espeak-ng/espeak-ng"
+PKG_URL="https://github.com/espeak-ng/espeak-ng/releases/download/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tgz"
+PKG_DEPENDS_HOST="gcc:host "
+PKG_DEPENDS_TARGET="toolchain espeak-ng:host"
+PKG_LONGDESC="eSpeak NG is an open source speech synthesizer that supports more than a hundred languages and accents"
+PKG_TOOLCHAIN="configure"
+
+pre_configure() {
+  cd ..
+  make distclean
+  ./autogen.sh
+}
+
+make_host() {
+  make -j1
+}
+
+make_target() {
+  make src/espeak-ng src/speak-ng
+}
+
+makeinstall_target() {
+  make src/espeak-ng src/speak-ng
+  make install-exec DESTDIR=$INSTALL
+  mkdir -p $INSTALL/usr/share/espeak-ng-data
+  cp -prf $TOOLCHAIN/share/espeak-ng-data $INSTALL/usr/share
+}
+

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -60,6 +60,10 @@ configure_package() {
     KODI_PULSEAUDIO="-DENABLE_PULSEAUDIO=OFF"
   fi
 
+  if [ "$ESPEAK_SUPPORT" = yes ]; then
+    PKG_DEPENDS_TARGET+=" espeak-ng"
+  fi
+
   if [ "${CEC_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" libcec"
     KODI_CEC="-DENABLE_CEC=ON"


### PR DESCRIPTION
The eSpeak program was removed for unknown reasons, and it makes impossible to make LibreELEC accessible without a default TTS. Added eSpeak-NG, the improved and updated version of eSpeak.