### PR TITLE
Allwinner: linux: Adjust invalidating CEC address

### DIFF
--- a/projects/Allwinner/patches/linux/0060-WIP-drm-bridge-synopsys-Fix-CEC-not-working-after-power.patch
+++ b/projects/Allwinner/patches/linux/0060-WIP-drm-bridge-synopsys-Fix-CEC-not-working-after-power.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Bee <knaerzche@gmail.com>
+Date: Fri, 22 Oct 2021 11:17:30 +0200
+Subject: [PATCH] WIP: drm/bridge: synopsys: Fix CEC not working after
+ power-cyclying
+
+This fixes standby -> power-on on Rockchip platform for, at least,
+RK3288/RK3328/RK3399 where CEC wasn't working after powering on again.
+It might differ for other phy implementations:
+The whole HPD-detection part shoud be reworked and we should in general
+avoid to rely in RX_SENSE phy status (at least for HDMI), since it differs
+depending on sink's implementation.
+
+Signed-off-by: Alex Bee <knaerzche@gmail.com>
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index 84cc52858ffb..3c20ef3bd3c1 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -3036,18 +3036,11 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
+ 	 * ask the source to re-read the EDID.
+ 	 */
+ 	if (intr_stat &
+-	    (HDMI_IH_PHY_STAT0_RX_SENSE | HDMI_IH_PHY_STAT0_HPD)) {
++	    (HDMI_IH_PHY_STAT0_RX_SENSE | HDMI_IH_PHY_STAT0_HPD))
+ 		dw_hdmi_setup_rx_sense(hdmi,
+ 				       phy_stat & HDMI_PHY_HPD,
+ 				       phy_stat & HDMI_PHY_RX_SENSE);
+ 
+-		if ((phy_stat & (HDMI_PHY_RX_SENSE | HDMI_PHY_HPD)) == 0) {
+-			mutex_lock(&hdmi->cec_notifier_mutex);
+-			cec_notifier_phys_addr_invalidate(hdmi->cec_notifier);
+-			mutex_unlock(&hdmi->cec_notifier_mutex);
+-		}
+-	}
+-
+ 	if (intr_stat & HDMI_IH_PHY_STAT0_HPD) {
+ 		enum drm_connector_status status = phy_int_pol & HDMI_PHY_HPD
+ 						 ? connector_status_connected
+@@ -3061,6 +3054,13 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
+ 			drm_helper_hpd_irq_event(hdmi->bridge.dev);
+ 			drm_bridge_hpd_notify(&hdmi->bridge, status);
+ 		}
++
++		if (status == connector_status_disconnected &&
++		    (phy_stat & HDMI_PHY_RX_SENSE)) {
++			mutex_lock(&hdmi->cec_notifier_mutex);
++			cec_notifier_phys_addr_invalidate(hdmi->cec_notifier);
++			mutex_unlock(&hdmi->cec_notifier_mutex);
++		}
+ 	}
+ 
+ 	hdmi_writeb(hdmi, intr_stat, HDMI_IH_PHY_STAT0);


### PR DESCRIPTION
This PR applies same DW HDMI CEC fix to AW as @knaerzche did for RK in #5791

Related issue: #5671 

I guess backport is warranted, but let's see if it fix anything first.