### PR TITLE
Rockchip: linux: fix CEC-fix

### DIFF
--- a/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
+++ b/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
@@ -3673,7 +3673,7 @@ depending on sink's implementation.
 Signed-off-by: Alex Bee <knaerzche@gmail.com>
 ---
  drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 16 ++++++++--------
- 1 file changed, 8 insertions(+), 8 deletions(-)
+ 1 file changed, 9 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
 index 84cc52858ffb..3c20ef3bd3c1 100644
@@ -3699,13 +3699,14 @@ index 84cc52858ffb..3c20ef3bd3c1 100644
  	if (intr_stat & HDMI_IH_PHY_STAT0_HPD) {
  		enum drm_connector_status status = phy_int_pol & HDMI_PHY_HPD
  						 ? connector_status_connected
-@@ -3061,6 +3054,13 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
+@@ -3061,6 +3054,14 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
  			drm_helper_hpd_irq_event(hdmi->bridge.dev);
  			drm_bridge_hpd_notify(&hdmi->bridge, status);
  		}
 +
 +		if (status == connector_status_disconnected &&
-+		    (phy_stat & HDMI_PHY_RX_SENSE)) {
++		    (phy_stat & HDMI_PHY_RX_SENSE) &&
++		    (phy_int_pol & HDMI_PHY_RX_SENSE)) {
 +			mutex_lock(&hdmi->cec_notifier_mutex);
 +			cec_notifier_phys_addr_invalidate(hdmi->cec_notifier);
 +			mutex_unlock(&hdmi->cec_notifier_mutex);


### PR DESCRIPTION
It turns out with the recent PR https://github.com/LibreELEC/LibreELEC.tv/pull/5791, I dead-fixed CEC when powercycling for my own use-case - where it was working before. It kicked in, because of the addtion of cec-debounce-ms patch, which is  more-or-less accepted upstream already and I'd like to keep and re-submit it.

I'm not expecting any regression for other users: When in doubt it won't invalidate the CEC address, which is the culprit of the reported issue.