### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.lame"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="a9d2e34cc40052109c1542604b092533ddbb3db562af471116df42f2d068bbb9"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="f0e51eced02f9d0fcb8d301907b33d94d111ca8034c4a26290af18a6f26bc92a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="20.3.0-Nexus"
-PKG_SHA256="da2ee12e467381dce8fc8da772f907432629a761d3cb4cf1ab791e4e52a7da03"
+PKG_VERSION="20.3.1-Nexus"
+PKG_SHA256="c0d3c17addf2dfbb44849eb060effbc01fa2ddcdcfb955e487f74ea22dc38769"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="20.1.1-Nexus"
-PKG_SHA256="1fe5b424bdeafc32a6f78bdcd6d23b7b3913bacfbd11ac3638eb2a11a1174c76"
+PKG_VERSION="20.1.2-Nexux"
+PKG_SHA256="fcf350f76a53a78d48f74bf693ccdea811888ab6e6cd14194cf6dad87367593d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- audioencoder.lame: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.demo: update 20.3.0-Nexus to 20.3.1-Nexus
- pvr.nextpvr: update 20.1.1-Nexus to 20.1.2-Nexux