### PR TITLE
crocus: add Mesa Gallium driver for older Intel GPUs

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -23,7 +23,14 @@ get_graphicdrivers() {
   V4L2_SUPPORT="no"
 
   if [ "${GRAPHIC_DRIVERS}" = "all" ]; then
-    GRAPHIC_DRIVERS="iris i915 i965 r200 r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
+    GRAPHIC_DRIVERS="crocus iris i915 i965 r200 r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
+  fi
+
+  if listcontains "${GRAPHIC_DRIVERS}" "crocus"; then
+    GALLIUM_DRIVERS+=" crocus"
+    XORG_DRIVERS+=" intel"
+    COMPOSITE_SUPPORT="yes"
+    VAAPI_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then

--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -17,7 +17,7 @@ get_graphicdrivers
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" nasm:host x265"
 
-  if listcontains "${GRAPHIC_DRIVERS}" "(iris|i915|i965)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "(crocus|iris|i915|i965)"; then
     PKG_DEPENDS_TARGET+=" intel-vaapi-driver"
   fi
 fi

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -26,7 +26,7 @@ PKG_MESON_OPTS_TARGET="-Dlibkms=false \
                        -Dinstall-test-programs=false \
                        -Dudev=false"
 
-listcontains "${GRAPHIC_DRIVERS}" "(iris|i915|i965)" &&
+listcontains "${GRAPHIC_DRIVERS}" "(crocus|iris|i915|i965)" &&
   PKG_MESON_OPTS_TARGET+=" -Dintel=true" || PKG_MESON_OPTS_TARGET+=" -Dintel=false"
 
 listcontains "${GRAPHIC_DRIVERS}" "(r200|r300|r600|radeonsi)" &&

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -66,6 +66,10 @@ else
   PKG_MESON_OPTS_TARGET+=" -Dgallium-va=disabled"
 fi
 
+if listcontains "${GRAPHIC_DRIVERS}" "crocus"; then
+  PKG_MESON_OPTS_TARGET+=" -Dprefer-crocus=true"
+fi
+
 if listcontains "${GRAPHIC_DRIVERS}" "vmware"; then
   PKG_MESON_OPTS_TARGET+=" -Dgallium-xa=enabled"
 else

--- a/packages/virtual/mediacenter/package.mk
+++ b/packages/virtual/mediacenter/package.mk
@@ -39,7 +39,7 @@ if [ "${MEDIACENTER}" = "kodi" ]; then
   fi
 
   get_graphicdrivers
-  if listcontains "${GRAPHIC_DRIVERS}" "(iris|i915|i965)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "(crocus|iris|i915|i965)"; then
     PKG_DEPENDS_TARGET+=" intel-vaapi-driver media-driver"
   fi
 


### PR DESCRIPTION
Since Mesa version 21.2 new driver called `crocus` was added to the Mesa release, which is aimed at older Intel GPUs and offers better performance. The `crocus` driver is currently being used in Lakka and there were no complaints, apart from that, that we missed `-Dprefer-crocus=true` in earlier releases (workaround was to add `MESA_LOADER_DRIVER_OVERRIDE=crocus`), and we added this meson build option today. This was also tested by myself and RetroArch / MESA_LOADER does does not complain anymore about missing `i965` driver (we do not build the `i965` driver for Lakka).

I hope I did not miss any place that needs to be updated. Feel free to modify/request changes/reject.

**EDIT:** I did not add the driver to any of the Generic device options on purpose, as I am not sure if LibreELEC is interested in using this driver.