### PR TITLE
Rockchip: linux: fix analog audio for Rock Pi 4

### DIFF
--- a/projects/Rockchip/patches/linux/default/linux-0002-rockchip-from-list.patch
+++ b/projects/Rockchip/patches/linux/default/linux-0002-rockchip-from-list.patch
@@ -435,3 +435,169 @@ index 9db9484ca38f..44def886b391 100644
  		clocks = <&cru ACLK_VCODEC>, <&cru HCLK_VCODEC>;
  		clock-names = "aclk", "hclk";
  		iommus = <&vpu_mmu>;
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Bee <knaerzche@gmail.com>
+Date: Wed, 27 Oct 2021 16:17:26 +0200
+Subject: [PATCH] arm64: dts: rockchip: fix audio-supply for Rock Pi 4
+
+As stated in the schematics [1] and [2] P5 the APIO5 domain is supplied
+by RK808-D Buck4, which in our case vcc1v8_codec - i.e. a 1.8 V regulator.
+
+Currently only white noise comes from the ES8316's output, which - for
+whatever reason - came up only after the the correct switch from i2s0_8ch_bus
+to i2s0_2ch_bus for i2s0's pinctrl was done.
+
+Fix this by setting the correct regulator for audio-supply.
+
+[1] https://dl.radxa.com/rockpi4/docs/hw/rockpi4/rockpi4_v13_sch_20181112.pdf
+[2] https://dl.radxa.com/rockpi4/docs/hw/rockpi4/rockpi_4c_v12_sch_20200620.pdf
+
+Fixes: 1b5715c602fd ("arm64: dts: rockchip: add ROCK Pi 4 DTS support")
+Signed-off-by: Alex Bee <knaerzche@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+index 98136c88fa49..6a434be62819 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+@@ -502,7 +502,7 @@ &io_domains {
+ 	status = "okay";
+ 
+ 	bt656-supply = <&vcc_3v0>;
+-	audio-supply = <&vcc_3v0>;
++	audio-supply = <&vcc1v8_codec>;
+ 	sdmmc-supply = <&vcc_sdio>;
+ 	gpio1830-supply = <&vcc_3v0>;
+ };
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Bee <knaerzche@gmail.com>
+Date: Wed, 27 Oct 2021 14:43:40 +0200
+Subject: [PATCH] arm64: dts: rockchip: add interrupt and headphone-detection
+ for Rock Pi4's audio codec
+
+As Schematics at [1] and [2] show C- and plus-revisions have interrupt and
+headphone detection lines of ES8316 codec connected.
+
+Add them to the respective device trees.
+
+[1] https://dl.radxa.com/rockpi4/docs/hw/rockpi4/rockpi_4c_v12_sch_20200620.pdf
+[2] https://dl.radxa.com/rockpi4/docs/hw/rockpi4/rockpi4b_plus_v16_sch_20200628.pdf
+
+Signed-off-by: Alex Bee <knaerzche@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi   | 12 +++++++++++-
+ .../boot/dts/rockchip/rk3399-rock-pi-4a-plus.dts     | 11 +++++++++++
+ .../boot/dts/rockchip/rk3399-rock-pi-4b-plus.dts     | 11 +++++++++++
+ arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c.dts   | 11 +++++++++++
+ 4 files changed, 44 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+index 6a434be62819..92acf6ea299b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+@@ -36,7 +36,7 @@ sdio_pwrseq: sdio-pwrseq {
+ 		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
+ 	};
+ 
+-	sound {
++	sound: sound {
+ 		compatible = "audio-graph-card";
+ 		label = "Analog";
+ 		dais = <&i2s0_p0>;
+@@ -543,6 +543,16 @@ bt_wake_l: bt-wake-l {
+ 		};
+ 	};
+ 
++	es8316 {
++		hp_detect: hp-detect {
++			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		hp_int: hp-int {
++			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
+ 	pcie {
+ 		pcie_pwr_en: pcie-pwr-en {
+ 			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4a-plus.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4a-plus.dts
+index 281a04b2f5e9..f5a68d8d072d 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4a-plus.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4a-plus.dts
+@@ -12,3 +12,14 @@ / {
+ 	model = "Radxa ROCK Pi 4A+";
+ 	compatible = "radxa,rockpi4a-plus", "radxa,rockpi4", "rockchip,rk3399";
+ };
++
++&es8316 {
++	pinctrl-0 = <&hp_detect &hp_int>;
++	pinctrl-names = "default";
++	interrupt-parent = <&gpio1>;
++	interrupts = <RK_PA1 IRQ_TYPE_LEVEL_HIGH>;
++};
++
++&sound {
++	hp-det-gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4b-plus.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4b-plus.dts
+index dfad13d2ab24..81bea953c891 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4b-plus.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4b-plus.dts
+@@ -17,6 +17,13 @@ aliases {
+ 	};
+ };
+ 
++&es8316 {
++	pinctrl-0 = <&hp_detect &hp_int>;
++	pinctrl-names = "default";
++	interrupt-parent = <&gpio1>;
++	interrupts = <RK_PA1 IRQ_TYPE_LEVEL_HIGH>;
++};
++
+ &sdio0 {
+ 	status = "okay";
+ 
+@@ -31,6 +38,10 @@ brcmf: wifi@1 {
+ 	};
+ };
+ 
++&sound {
++	hp-det-gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++};
++
+ &uart0 {
+ 	status = "okay";
+ 
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c.dts
+index 99169bcd51c0..0ad7b6e22f70 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c.dts
+@@ -17,6 +17,13 @@ aliases {
+ 	};
+ };
+ 
++&es8316 {
++	pinctrl-0 = <&hp_detect &hp_int>;
++	pinctrl-names = "default";
++	interrupt-parent = <&gpio1>;
++	interrupts = <RK_PA1 IRQ_TYPE_LEVEL_HIGH>;
++};
++
+ &sdio0 {
+ 	status = "okay";
+ 
+@@ -31,6 +38,10 @@ brcmf: wifi@1 {
+ 	};
+ };
+ 
++&sound {
++	hp-det-gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++};
++
+ &uart0 {
+ 	status = "okay";
+ 


### PR DESCRIPTION
A recent upstream change, which was also backported, broke analog audio for Rock Pi 4.

Theses patches fixes it and also add headphone-detection, for board revisions which support it.
Both have been submitted upstream.