### PR TITLE
systemd: update to 247.10

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="systemd"
-PKG_VERSION="247.9"
-PKG_SHA256="629b8c895efa000b921092c7a565680c66dcd0ec74ed11cb2dd2b6701492675d"
+PKG_VERSION="247.10"
+PKG_SHA256="8ce78a664ac0090934ee3b576dc1cfc0a9bbf7fa166aa59c6237915ef2a35b74"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd-stable/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update from 249.9 to 249.10

fix: 
- Drop bundled copy of linux/if_arp.h - https://github.com/systemd/systemd-stable/commit/06dea04b38ce506c1436cd4fef9bf9919a34f441
- basic/linux: Sync if_arp.h with Linux 5.14 - https://github.com/systemd/systemd-stable/commit/1d4d6fa45e724dd082a56c7ddf57f0d3655dd31e

needed for updated kernels (5.14/5.15)

full changelog here:
- https://github.com/systemd/systemd-stable/compare/v247.9...v247.10