### PR TITLE
[le11] samba: update to 4.13.13

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.13.12"
-PKG_SHA256="4187d616c0a53f8ad6a0f63b75533fb36e6ded1f1a0b9fc01e685a7e78286b1a"
+PKG_VERSION="4.13.13"
+PKG_SHA256="2a6d9ddad5c06b3c5b593f8981a2ff3a201095c912d9ae68e7d4fe7cb5aa5f3f"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Backport #5831 done

update 4.13.12 (2021-09-22) to 4.13.13 (2021-10-29)

release notes:
- https://www.samba.org/samba/history/samba-4.13.13.html

Changes since 4.13.12
---------------------

o  Douglas Bagnall <douglas.bagnall@catalyst.net.nz>
   * BUG 14868: rodc_rwdc test flaps.
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  Andrew Bartlett <abartlet@samba.org>
   * BUG 14642: Provide a fix for MS CVE-2020-17049 in Samba [SECURITY] 'Bronze
     bit' S4U2Proxy Constrained Delegation bypass in Samba with
     embedded Heimdal.
   * BUG 14836: Python ldb.msg_diff() memory handling failure.
   * BUG 14845: "in" operator on ldb.Message is case sensitive.
   * BUG 14848: Release LDB 2.3.1 for Samba 4.14.9.
   * BUG 14871: Fix Samba support for UF_NO_AUTH_DATA_REQUIRED.
   * BUG 14874: Allow special chars like "@" in samAccountName when generating
     the salt.
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  Isaac Boukris <iboukris@gmail.com>
   * BUG 14642: Provide a fix for MS CVE-2020-17049 in Samba [SECURITY] 'Bronze
     bit' S4U2Proxy Constrained Delegation bypass in Samba with embedded Heimdal.
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  Viktor Dukhovni <viktor@twosigma.com>
   * BUG 12998: Fix transit path validation.
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  Luke Howard <lukeh@padl.com>
   * BUG 14642: Provide a fix for MS CVE-2020-17049 in Samba [SECURITY] 'Bronze
     bit' S4U2Proxy Constrained Delegation bypass in Samba with embedded Heimdal.
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  Stefan Metzmacher <metze@samba.org>
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  David Mulder <dmulder@suse.com>
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  Andreas Schneider <asn@samba.org>
   * BUG 14870: Prepare to operate with MIT krb5 >= 1.20.
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  Joseph Sutton <josephsutton@catalyst.net.nz>
   * BUG 14642: Provide a fix for MS CVE-2020-17049 in Samba [SECURITY] 'Bronze
     bit' S4U2Proxy Constrained Delegation bypass in Samba with embedded Heimdal.
   * BUG 14645: rpcclient NetFileEnum and net rpc file both cause lock order
     violation: brlock.tdb, share_entries.tdb.
   * BUG 14836: Python ldb.msg_diff() memory handling failure.
   * BUG 14845: "in" operator on ldb.Message is case sensitive.
   * BUG 14848: Release LDB 2.3.1 for Samba 4.14.9.
   * BUG 14868: rodc_rwdc test flaps.
   * BUG 14871: Fix Samba support for UF_NO_AUTH_DATA_REQUIRED.
   * BUG 14874: Allow special chars like "@" in samAccountName when generating
     the salt.
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.

o  Nicolas Williams <nico@twosigma.com>
   * BUG 14642: Provide a fix for MS CVE-2020-17049 in Samba [SECURITY] 'Bronze
     bit' S4U2Proxy Constrained Delegation bypass in Samba with embedded Heimdal.
   * BUG 14881: Backport bronze bit fixes, tests, and selftest improvements.