### PR TITLE
[le11] More Fixes to meson: unknown options are now always fatal

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -11,8 +11,8 @@ PKG_URL="https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/${PKG_VERSION:0:4}
 PKG_DEPENDS_TARGET="toolchain atk dbus glib libXtst"
 PKG_LONGDESC="Protocol definitions and daemon for D-Bus at-spi."
 
-PKG_MESON_OPTS_TARGET="-Denable_docs=false \
-                       -Denable-introspection=no \
+PKG_MESON_OPTS_TARGET="-Ddocs=false \
+                       -Dintrospection=no \
                        -Ddbus_daemon=/usr/bin/dbus-daemon"
 
 pre_configure_target() {

--- a/packages/addons/addon-depends/chrome-depends/chrome-libxkbcommon/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libxkbcommon/package.mk
@@ -9,10 +9,6 @@ PKG_URL=""
 PKG_DEPENDS_UNPACK+=" libxkbcommon"
 PKG_BUILD_FLAGS="-sysroot"
 
-PKG_MESON_OPTS_TARGET="${PKG_MESON_OPTS_TARGET} \
-                           -Denable-static=false \
-                           -Denable-shared=true"
-
 unpack() {
   mkdir -p ${PKG_BUILD}
   tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}

--- a/packages/addons/addon-depends/chrome-depends/gdk-pixbuf/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gdk-pixbuf/package.mk
@@ -13,6 +13,6 @@ PKG_DEPENDS_CONFIG="shared-mime-info"
 PKG_LONGDESC="GdkPixbuf is a a GNOME library for image loading and manipulation."
 
 PKG_MESON_OPTS_TARGET="-Ddocs=false \
-                       -Dgir=false \
+                       -Dintrospection=disabled \
                        -Dman=false \
                        -Drelocatable=false"

--- a/packages/addons/addon-depends/chrome-depends/pango/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/pango/package.mk
@@ -14,5 +14,5 @@ PKG_LONGDESC="The Pango library for layout and rendering of internationalized te
 PKG_TOOLCHAIN="meson"
 PKG_BUILD_FLAGS="-sysroot"
 
-PKG_MESON_OPTS_TARGET="-Denable_docs=false \
-                       -Dgir=false"
+PKG_MESON_OPTS_TARGET="-Dgtk_doc=false \
+                       -Dintrospection=disabled"


### PR DESCRIPTION
- at-spi2-core: correct meson build options
- chrome-libxkbcommon: correct meson build options
- gdk-pixbuf: correct meson build options
- pango: correct meson build options

further to #5799