### PR TITLE
[le11] Update addons (mpd, btrfs-progs)

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpv-drmprime"
-PKG_VERSION="0.33.1"
-PKG_SHA256="100a116b9f23bdcda3a596e9f26be3a69f166a4f1d00910d1789b6571c46f3a9"
+PKG_VERSION="0.34.0"
+PKG_SHA256="f654fb6275e5178f57e055d20918d7d34e19949bc98ebbf4a7371902e88ce309"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mpv.io/"
 PKG_URL="https://github.com/mpv-player/mpv/archive/v${PKG_VERSION}.tar.gz"
@@ -12,22 +12,22 @@ PKG_LONGDESC="A media player based on MPlayer and mplayer2. It supports a wide v
 PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="-sysroot"
 
-PKG_CONFIGURE_OPTS_TARGET="--prefix=/usr \
-                           --disable-libarchive \
-                           --disable-lua \
-                           --disable-javascript \
-                           --disable-uchardet \
-                           --disable-rubberband \
-                           --disable-lcms2 \
-                           --disable-vapoursynth \
-                           --disable-jack \
-                           --disable-wayland \
-                           --disable-x11 \
-                           --disable-vulkan \
-                           --disable-caca \
-                           --enable-drm \
-                           --enable-gbm \
-                           --enable-egl-drm"
+PKG_MANUAL_OPTS_TARGET="--prefix=/usr \
+                        --disable-libarchive \
+                        --disable-lua \
+                        --disable-javascript \
+                        --disable-uchardet \
+                        --disable-rubberband \
+                        --disable-lcms2 \
+                        --disable-vapoursynth \
+                        --disable-jack \
+                        --disable-wayland \
+                        --disable-x11 \
+                        --disable-vulkan \
+                        --disable-caca \
+                        --enable-drm \
+                        --enable-gbm \
+                        --enable-egl-drm"
 
 if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGLES}"
@@ -39,27 +39,27 @@ fi
 
 if [ "${VAAPI_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" libva"
-  PKG_CONFIGURE_OPTS_TARGET+=" --enable-vaapi --enable-vaapi-drm"
+  PKG_MANUAL_OPTS_TARGET+=" --enable-vaapi --enable-vaapi-drm"
 else
-  PKG_CONFIGURE_OPTS_TARGET+=" --disable-vaapi"
+  PKG_MANUAL_OPTS_TARGET+=" --disable-vaapi"
 fi
 
 if [ "${PULSEAUDIO_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" pulseaudio"
-  PKG_CONFIGURE_OPTS_TARGET+=" --enable-pulse"
+  PKG_MANUAL_OPTS_TARGET+=" --enable-pulse"
 else
-  PKG_CONFIGURE_OPTS_TARGET+=" --disable-pulse"
+  PKG_MANUAL_OPTS_TARGET+=" --disable-pulse"
 fi
 
 if [ "${KODI_BLURAY_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" libbluray"
-  PKG_CONFIGURE_OPTS_TARGET+=" --enable-libbluray"
+  PKG_MANUAL_OPTS_TARGET+=" --enable-libbluray"
 else
-  PKG_CONFIGURE_OPTS_TARGET+=" --disable-libbluray"
+  PKG_MANUAL_OPTS_TARGET+=" --disable-libbluray"
 fi
 
 configure_target() {
-  waf configure ${PKG_CONFIGURE_OPTS_TARGET}
+  waf configure ${PKG_MANUAL_OPTS_TARGET}
 }
 
 make_target() {

--- a/packages/addons/service/mpd/changelog.txt
+++ b/packages/addons/service/mpd/changelog.txt
@@ -1,3 +1,6 @@
+112
+- Update to version 0.23.3
+
 111
 - include wavpack support
 - Update to version 0.22.9

--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -3,16 +3,16 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpd"
-PKG_VERSION="0.22.9"
-PKG_SHA256="f937403297c2240bd4a569f4b937ee7ab17398a5284ba9df4d6d4c3a0512bc64"
-PKG_REV="111"
+PKG_VERSION="0.23.3"
+PKG_SHA256="b300625701005c6b14649f11dac118d05540529a5385d05b7c3062c0ce08f399"
+PKG_REV="112"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"
 PKG_URL="http://www.musicpd.org/download/mpd/$(get_pkg_version_maj_min)/mpd-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain alsa-lib avahi boost curl faad2 ffmpeg flac glib lame libcdio libgcrypt \
-                    libiconv libid3tag libmad libmpdclient libsamplerate libvorbis libnfs libogg \
-                    mpd-mpc opus pulseaudio samba wavpack yajl"
+PKG_DEPENDS_TARGET="toolchain alsa-lib avahi boost curl faad2 ffmpeg flac glib lame libcdio libfmt \
+                    libgcrypt libiconv libid3tag libmad libmpdclient libsamplerate libvorbis \
+                    libnfs libogg mpd-mpc opus pulseaudio samba wavpack yajl"
 PKG_SECTION="service.multimedia"
 PKG_SHORTDESC="Music Player Daemon (MPD): a free and open Music Player Server"
 PKG_LONGDESC="Music Player Daemon (${PKG_VERSION}) is a flexible and powerful server-side application for playing music"
@@ -84,7 +84,6 @@ PKG_MESON_OPTS_TARGET=" \
   -Dsyslog=disabled \
   -Dsystemd=disabled \
   -Dtest=false \
-  -Dtidal=enabled \
   -Dtwolame=disabled \
   -Dupnp=disabled \
   -Dvorbis=enabled \

--- a/packages/addons/tools/btrfs-progs/changelog.txt
+++ b/packages/addons/tools/btrfs-progs/changelog.txt
@@ -1,3 +1,6 @@
+104
+- update to 5.15
+
 103
 - rebuild with --disable-zstd
 

--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="btrfs-progs"
-PKG_VERSION="4.15.1"
-PKG_SHA256="9cb985b3466e2e0ca712ef8570d7eb2f94b56592221baf0fc76622f413852445"
-PKG_REV="103"
+PKG_VERSION="5.15"
+PKG_SHA256="ffa2df3ce6de19cbc2ab58a27018662e3558f16c9cb43eafab3203df2b0f008d"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.wiki.kernel.org/index.php/Main_Page"
@@ -24,6 +24,7 @@ PKG_ADDON_TYPE="xbmc.python.script"
 PKG_CONFIGURE_OPTS_TARGET="--disable-backtrace \
                            --disable-convert \
                            --disable-documentation \
+                           --disable-python \
                            --disable-zstd"
 
 pre_configure_target() {
@@ -32,5 +33,5 @@ pre_configure_target() {
 
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
-    cp -P ${PKG_INSTALL}/usr/bin/{btrfs,btrfsck,btrfstune,btrfs-zero-log,fsck.btrfs,mkfs.btrfs} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P ${PKG_INSTALL}/usr/bin/{btrfs,btrfsck,btrfstune,fsck.btrfs,mkfs.btrfs} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 }


### PR DESCRIPTION
Updates of 2 addon and the currently unused mpv-drmprime.

- mpd: update to 0.23.3 and addon (112)
  - regular update (and fix meson build removing tidal option - no longer valid)
- mpv-drmprime: update to 0.34.0
  - fix build failure due to PKG_CONFIGURE variable not match “manual” build
  - update package
- btrfs-progs: update to 5.15 and addon (104)
  - don’t build unnecessary python support
  - Remove now obsolete command `btrfs-zero-log` 
  - Updated command is `btrfs rescue zero-log`