### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.2sf"
-PKG_VERSION="20.0.1-Nexus"
-PKG_SHA256="ef06c385b811e8989b4307169abcad790a5a87d93d3626b33016226a391112a7"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="ae5cf3fcb35479d7f168c1096139782aed3e9d504b24bcc0534ad50160df712e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.asap"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="d54d439b98b9e1b1a5b831711309447a537c486605afb9ed0376c9419b70963d"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="3f47da7f2e189cc87cee4646094f95edc0490ee4a04aae926a4abe945b7aa435"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.dumb"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="cb0362818c31f5a498049fabab24258033ee0020a908f0262903062ddac35b44"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="7738701bc162edca354a851c504067d1cbe5880c4d6ed0684678fb4944e03ab3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gme"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="2f808ab567346fdee3cbbbe487e0a6c04c0f44137f9c2a980213b4c8105f6b16"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="64d02e4c9088dd3c0c8168204fd6652395139d3c2834302f1eeafdcedfa4b64b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gsf"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="3febd77e14ed3a4af2eef4b28f9d15e05c0a014bb996676debfab6fe550efef6"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="fa282132e35958274d6cf8f7b83b96a70d173728cc6741405abebbd567106361"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.modplug/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.modplug/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.modplug"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="1c9971f24e42b61e205ca240f3a53e06a85dc2651b3ee1a72ffa9c896147e43e"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="f29e46a9743bea4e311505d80f125cd267939de7ccd3eaeb9ffaec1a0521e637"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.ncsf"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="5e9348501997b6b7d5dd85f3cd2c8899916c21e97de97b042cd82012bcd30e11"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="104532b39319897c4e5750f31a2eed4e81e40d47aac87dae57278c4a592ab959"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.nosefart"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="a57edb71fb23e98bba3e678687f4cd59300419ed542cce8fdd137c3ae504f21d"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="58e0ead20537589deb3926c04cddce079d19f2b0358dd995cfd825a5b1f60446"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.openmpt"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="ad9a906aee96c21072385e231cb166736202aeec7947ed198da285485ac99359"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="279130b6b19f4e3ed0ed4a1b7c5a76644c69bb08308444e36eb2c5daddbde732"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.organya"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="8bdddf6e210c1b1a06170a66b57509a5a1fc6514f727c3d8ca436b4c0f95c22c"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="cdb13db6980b668f0e00926e48c01152b970c9f5f1473a73b3a9dc08d019f1c2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.qsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.qsf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.qsf"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="5c60a82b6a405e0432ff9b7f864eb8d243af21e690cd962e9c7633cace4e0175"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="7e6bc0b90642a5747a01b8b9144470993c4026f5cda580ab0532254520c6c4a4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.sacd"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="053709b1cd71eddb8e0a668252ea43fbfde8d2e59398f7738d46dd5914c575d7"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="9835af67f0c9fe4c3656587ee898f706570a413e88e00bfa57eb6d0b2cc6b436"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.sidplay"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="89c41d4ac5b5ef7eceb1c17eeadbce6a6fd14c27cfb91a53653f89eee041bf0d"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="a1a84f69101628e20710c67590f1c0058e84281c8747f111e5e6536f4f10ee34"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.snesapu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.snesapu/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.snesapu"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="9b48d435a4529f2f03f5e4167367ccf8ea84ee20a32cfbf2afec5b0eb30299eb"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="c201d1473c036eab4e8685c4c94b482255cbd44d9e6b0aa148fbcaa64357773b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ssf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ssf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.ssf"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="bf6e92b4e92f8899f46948b2c46d90ac61f08d8f4afd5386fe883e3fc711b73c"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="347fd79412e0e67c644647f9a78b08870908b0e054a8db6f7e9578eb6f6c9c51"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.stsound/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.stsound/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.stsound"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="a1a7e0bf0497fce108d1d6468345b963d15d2ba08176bb7a442890ccacc3755d"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="88ce495851026fc0d21657e529ab96bb719b29610d9b2c81913175b0ce1fe08f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.timidity"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="09c3661aa6bf156bf0feaafdd368c0746b6ef5d9d98921a6a57053a6fc2f44e0"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="08d9bc32e91d071c8f64c73c8b306a2b5989e654ce5c2bfc68cf6dc24d9f7ff1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.upse"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="e1c00ae3bb5e804f0bc7553bab98a5e64181ae985a627235372426d2cdccc19d"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="25f955739360c55e4cd3dcb3358fb2b81c28dc6dca4bce9f32870b8305f334ff"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.usf"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="272f3a2877f1aac723996a8bfd544d5de7c8df53da43b7685112db4ca9d62993"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="6df1bb7046fa4d628b06abd763b409ea58c8a2f646ad21de579ff9703900db2b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.vgmstream"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="27f0d0e07648fee9a6136ab74711441d2c9011c02289a114847c6eca53b3a1a0"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="dfa17098ea786049fc1cc3df6b288c001e2a2fae3fa7a430adeeac90fa71bd47"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.wsr"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="3e9d6bad732d91201660a4d7372ae697249a1093e3d93f8f79116ecbd01279dc"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="bdf39a8c3d4fc252d5f28decf74fd602ba2d5cda4f4aeb92a74c934829937536"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="93c8347dd05ce4d5ea815df74a8fa6da48b3367d9dd6bf4961ab3b3ebd5d2e61"
+PKG_VERSION="20.1.1-Nexus"
+PKG_SHA256="fa092e6c7707df67f74538c1bebca5644277ae602996b395fa21339ca3a6077f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
kodi-binary-addons: update to latest versions
- audiodecoder.2sf: update 20.0.1-Nexus to 20.1.0-Nexus
- audiodecoder.asap: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.dumb: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.gme: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.gsf: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.modplug: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.ncsf: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.nosefart: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.openmpt: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.organya: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.qsf: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.sacd: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.sidplay: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.snesapu: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.ssf: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.stsound: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.timidity: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.upse: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.usf: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.vgmstream: update 20.0.0-Nexus to 20.1.0-Nexus
- audiodecoder.wsr: update 20.0.0-Nexus to 20.1.0-Nexus
- pvr.wmc: update 20.1.0-Nexus to 20.1.1-Nexus