### PR TITLE
sshpass: add initial package and include with network-tools bundle

### DIFF
--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="112"
+PKG_REV="113"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of network tools and programs"
-PKG_LONGDESC="This bundle currently includes bwm-ng, iftop, iperf, irssi, lftp, ncftp, ngrep, nmap, rar2fs, rsync, sshfs, tcpdump, udpxy and wireless_tools."
+PKG_LONGDESC="This bundle currently includes bwm-ng, iftop, iperf, irssi, lftp, ncftp, ngrep, nmap, rar2fs, rsync, sshfs, sshpass, tcpdump, udpxy and wireless_tools."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Network Tools"
@@ -29,6 +29,7 @@ PKG_DEPENDS_TARGET="toolchain \
                     rar2fs \
                     rsync \
                     sshfs \
+                    sshpass \
                     tcpdump \
                     udpxy \
                     wireless_tools"
@@ -73,6 +74,9 @@ addon() {
 
     # sshfs
     cp -P $(get_install_dir sshfs)/usr/bin/sshfs ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+
+    # sshpass
+    cp -P $(get_install_dir sshpass)/usr/bin/sshpass ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # tcpdump
     cp -P $(get_install_dir tcpdump)/usr/bin/tcpdump ${ADDON_BUILD}/${PKG_ADDON_ID}/bin

--- a/packages/network/sshpass/package.mk
+++ b/packages/network/sshpass/package.mk
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="sshpass"
+PKG_VERSION="1.09"
+PKG_SHA256="71746e5e057ffe9b00b44ac40453bf47091930cba96bbea8dc48717dedc49fb7"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://sourceforge.net/p/sshpass"
+PKG_URL="https://downloads.sourceforge.net/sshpass/sshpass-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="sshpass: a tool for non-interactive ssh password auth"
+
+pre_configure_target(){
+  if [ "${ARCH}" != "x86_64" ]; then
+    export ac_cv_func_malloc_0_nonnull=yes
+    export ac_cv_func_realloc_0_nonnull=yes
+  fi
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+    cp sshpass ${INSTALL}/usr/bin
+}


### PR DESCRIPTION
sshpass is useful for running rsync over ssh when the remote target is not running an rsync daemon