### PR TITLE
kodi: cleanup samba client timeout

### DIFF
--- a/packages/mediacenter/kodi/config/advancedsettings.xml
+++ b/packages/mediacenter/kodi/config/advancedsettings.xml
@@ -4,7 +4,4 @@
 
   <showexitbutton>false</showexitbutton>
   <remotedelay>1</remotedelay>
-  <samba>
-    <clienttimeout>30</clienttimeout>
-  </samba>
 </advancedsettings>


### PR DESCRIPTION
- the timeout of 30sec is already default at Kodi since K18 https://github.com/xbmc/xbmc/commit/73be9522c13601f17bd2800ac379fa32611f9cfe