### PR TITLE
Kodi: NFS timeout to 30 secs

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.01-nfs-timeout-to-15sec.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.01-nfs-timeout-to-15sec.patch
@@ -1,0 +1,11 @@
+--- a/xbmc/settings/AdvancedSettings.cpp
++++ b/xbmc/settings/AdvancedSettings.cpp
+@@ -426,7 +426,7 @@ void CAdvancedSettings::Initialize()
+ 
+   m_userAgent = g_sysinfo.GetUserAgent();
+ 
+-  m_nfsTimeout = 5;
++  m_nfsTimeout = 30;
+   m_nfsRetries = -1;
+ 
+   m_initialized = true;


### PR DESCRIPTION
backport of https://github.com/xbmc/xbmc/pull/20475
If the NAS uses HDD spin up/down the nfs timeout was too short to allow a spinup without creating errors at the gui.
SMB has a 30sec timeout.