### PR TITLE
exfatprogs: add standard utilities for creating and fixing and debugging exfat filesystems

### DIFF
--- a/packages/sysutils/exfatprogs/package.mk
+++ b/packages/sysutils/exfatprogs/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="exfatprogs"
+PKG_VERSION="1.1.2"
+PKG_SHA256="b95dd447b657eaab05edb444c181b1ef10601fc98bcf5645a4b91f5b4a77f83c"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/exfatprogs/exfatprogs"
+PKG_URL="https://github.com/exfatprogs/exfatprogs/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="userspace utilities that contain all of the standard utilities for creating and fixing and debugging exfat filesystems."
+PKG_TOOLCHAIN="autotools"
+
+post_makeinstall_target() {
+  rm -rf ${INSTALL}/usr/share
+}

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="image"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
-PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host kmod:host mtools:host populatefs:host libc gcc linux linux-drivers linux-firmware ${BOOTLOADER} busybox util-linux corefonts network misc-packages debug"
+PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host kmod:host mtools:host populatefs:host libc gcc linux linux-drivers linux-firmware ${BOOTLOADER} busybox util-linux corefonts network misc-packages debug exfatprogs"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Root package used to build and create complete image"
 


### PR DESCRIPTION
Add the userspace utilities that contain all of the standard utilities for creating and fixing and debugging exfat filesystems. https://github.com/exfatprogs/exfatprogs/

RFQs:
- which tools **shouldn’t** be included?
- should the tools be included in `init` as well?
- Is `packages/virtual/image/package.mk` the right `package.mk` for the dependency?

These are the file sizes on x86_64:
```
exfatprogs-1.1.2$ ls -l ./usr/sbin/
-rwxr-xr-x 1 docker docker 18952 Nov  7 19:55 dump.exfat
-rwxr-xr-x 1 docker docker 19016 Nov  7 19:55 exfatlabel
-rwxr-xr-x 1 docker docker 35680 Nov  7 19:55 fsck.exfat
-rwxr-xr-x 1 docker docker 31120 Nov  7 19:55 mkfs.exfat
-rwxr-xr-x 1 docker docker 19144 Nov  7 19:55 tune.exfat
```