### PR TITLE
[le10] tz: update to 2021e

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2021d"
-PKG_SHA256="2e6b14cfe3ee389f67887c36436cc40ff11266e5c2213295c1528f42a65dc98e"
+PKG_VERSION="2021e"
+PKG_SHA256="11908a7f18530ca3013c8458d902a54cdd3382276bdd56891db074b1af4a26b8"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
ann:
- http://mm.icann.org/pipermail/tz-announce/2021-October/000069.html

   This release reflects the following changes:
   Changes to future timestamps
     Palestine will fall back 10-29 (not 10-30) at 01:00.
     (Thanks to P Chan and Heba Hemad.)