### PR TITLE
pcre: update to 8.45 and PKG_URL

### DIFF
--- a/packages/devel/pcre/package.mk
+++ b/packages/devel/pcre/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcre"
-PKG_VERSION="8.44"
-PKG_SHA256="19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d"
+PKG_VERSION="8.45"
+PKG_SHA256="4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.pcre.org/"
-PKG_URL="https://ftp.pcre.org/pub/pcre/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="https://downloads.sourceforge.net/project/pcre/pcre/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain pcre:host"
 PKG_LONGDESC="A set of functions that implement regular expression pattern matching."


### PR DESCRIPTION
Update 8.44 to 8.45

website https://ftp.pcre.org/pub/pcre/ no longer working as per the note on http://www.pcre.org/. Downloads should be done from soureforge.

### Changelog:

http://www.rexegg.com/pcre-doc/ChangeLog

Version 8.45 15-June-2021

This is the final release of PCRE1. A few minor tidies are included.
1. CMakeLists.txt has two user-supplied patches applied, one to allow for the setting of MODULE_PATH, and the other to support the generation of pcre-config file and libpcre*.pc files.
2. There was a memory leak if a compile error occurred when there were more than 20 named groups (Bugzilla 2613).
3. Fixed some typos in code and documentation.
4. Fixed a small (*MARK) bug in the interpreter (Bugzilla 2771).
