### PR TITLE
RPi: fix non-working USB and ethernet on RPi2

### DIFF
--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -2311,6 +2311,7 @@ CONFIG_RPI_POE_POWER=m
 # CONFIG_BATTERY_MAX17040 is not set
 # CONFIG_BATTERY_MAX17042 is not set
 # CONFIG_BATTERY_MAX1721X is not set
+# CONFIG_CHARGER_ISP1704 is not set
 # CONFIG_CHARGER_MAX8903 is not set
 # CONFIG_CHARGER_LP8727 is not set
 # CONFIG_CHARGER_GPIO is not set
@@ -4285,7 +4286,9 @@ CONFIG_USB_SERIAL_PL2303=m
 #
 # USB Physical Layer drivers
 #
-# CONFIG_NOP_USB_XCEIV is not set
+CONFIG_USB_PHY=y
+CONFIG_NOP_USB_XCEIV=y
+# CONFIG_AM335X_PHY_USB is not set
 # CONFIG_USB_GPIO_VBUS is not set
 # CONFIG_USB_ISP1301 is not set
 # CONFIG_USB_ULPI is not set
@@ -4754,7 +4757,7 @@ CONFIG_RASPBERRYPI_POWER=y
 # end of SOC (System On Chip) specific Drivers
 
 # CONFIG_PM_DEVFREQ is not set
-CONFIG_EXTCON=m
+CONFIG_EXTCON=y
 
 #
 # Extcon Device Drivers

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -2445,6 +2445,7 @@ CONFIG_RPI_POE_POWER=m
 # CONFIG_BATTERY_MAX17040 is not set
 # CONFIG_BATTERY_MAX17042 is not set
 # CONFIG_BATTERY_MAX1721X is not set
+# CONFIG_CHARGER_ISP1704 is not set
 # CONFIG_CHARGER_MAX8903 is not set
 # CONFIG_CHARGER_LP8727 is not set
 # CONFIG_CHARGER_GPIO is not set
@@ -4422,7 +4423,9 @@ CONFIG_USB_SERIAL_PL2303=m
 #
 # USB Physical Layer drivers
 #
-# CONFIG_NOP_USB_XCEIV is not set
+CONFIG_USB_PHY=y
+CONFIG_NOP_USB_XCEIV=y
+# CONFIG_AM335X_PHY_USB is not set
 # CONFIG_USB_GPIO_VBUS is not set
 # CONFIG_USB_ISP1301 is not set
 # CONFIG_USB_ULPI is not set
@@ -4894,7 +4897,7 @@ CONFIG_RASPBERRYPI_POWER=y
 # end of SOC (System On Chip) specific Drivers
 
 # CONFIG_PM_DEVFREQ is not set
-CONFIG_EXTCON=m
+CONFIG_EXTCON=y
 
 #
 # Extcon Device Drivers

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -2954,6 +2954,7 @@ CONFIG_RPI_POE_POWER=m
 # CONFIG_BATTERY_MAX17040 is not set
 # CONFIG_BATTERY_MAX17042 is not set
 # CONFIG_BATTERY_MAX1721X is not set
+# CONFIG_CHARGER_ISP1704 is not set
 # CONFIG_CHARGER_MAX8903 is not set
 # CONFIG_CHARGER_LP8727 is not set
 # CONFIG_CHARGER_GPIO is not set
@@ -5069,7 +5070,8 @@ CONFIG_USB_SERIAL_PL2303=m
 #
 # USB Physical Layer drivers
 #
-# CONFIG_NOP_USB_XCEIV is not set
+CONFIG_USB_PHY=y
+CONFIG_NOP_USB_XCEIV=y
 # CONFIG_USB_GPIO_VBUS is not set
 # CONFIG_USB_ISP1301 is not set
 # CONFIG_USB_ULPI is not set
@@ -5566,7 +5568,7 @@ CONFIG_RASPBERRYPI_POWER=y
 # end of SOC (System On Chip) specific Drivers
 
 # CONFIG_PM_DEVFREQ is not set
-CONFIG_EXTCON=m
+CONFIG_EXTCON=y
 
 #
 # Extcon Device Drivers


### PR DESCRIPTION
Sorry, this slipped through in testing.

Runtime tested on RPi3B+