### PR TITLE
slang: add pcre dependency 

### DIFF
--- a/packages/devel/slang/package.mk
+++ b/packages/devel/slang/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="fc9e3b0fc4f67c3c1f6d43c90c16a5c42d117b8e28457c5b46831b8b5d3ae31a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.jedsoft.org/slang/"
 PKG_URL="https://www.jedsoft.org/releases/slang/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain pcre"
 PKG_LONGDESC="A library designed to allow a developer to create robust multi-platform software."
 PKG_BUILD_FLAGS="-parallel"
 


### PR DESCRIPTION
A make -j17 release looks to have caused an race/out-of-order build. Add corrected dependency.