### PR TITLE
kodi: fix build after internal TexturePacker is enabled

### DIFF
--- a/packages/graphics/giflib/package.mk
+++ b/packages/graphics/giflib/package.mk
@@ -12,11 +12,32 @@ PKG_DEPENDS_TARGET="toolchain zlib"
 PKG_LONGDESC="giflib: giflib service library"
 PKG_TOOLCHAIN="manual"
 
+pre_build_host() {
+  mkdir -p ${PKG_BUILD}/.${HOST_NAME}
+  cp -r ${PKG_BUILD}/* ${PKG_BUILD}/.${HOST_NAME}
+}
+
 make_host() {
+  cd ${PKG_BUILD}/.${HOST_NAME}
   make libgif.a CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
 }
 
 makeinstall_host() {
   make install-include PREFIX="${TOOLCHAIN}"
   make install-lib PREFIX="${TOOLCHAIN}"
+}
+
+pre_build_target() {
+  mkdir -p ${PKG_BUILD}/.${TARGET_NAME}
+  cp -r ${PKG_BUILD}/* ${PKG_BUILD}/.${TARGET_NAME}
+}
+
+make_target() {
+  cd ${PKG_BUILD}/.${TARGET_NAME}
+  make libgif.a CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+}
+
+makeinstall_target() {
+  make install-include PREFIX="${SYSROOT_PREFIX}/usr"
+  make install-lib PREFIX="${SYSROOT_PREFIX}/usr"
 }

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="440f47e475dd8a48e0a6d41349e83b74890f3fbe8275d3e401d3c50f5b9ea09b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre swig:host libass curl fontconfig fribidi tinyxml libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid libdvdnav libhdhomerun libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog"
+PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre swig:host libass curl fontconfig fribidi tinyxml libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid libdvdnav libhdhomerun libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog libpng giflib"
 PKG_LONGDESC="A free and open source cross-platform media player."
 PKG_BUILD_FLAGS="+speed"
 

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -346,6 +346,9 @@ post_makeinstall_target() {
   python_compile ${INSTALL}/usr/lib/${PKG_PYTHON_VERSION}/site-packages/kodi
 
   debug_strip ${INSTALL}/usr/lib/kodi/kodi.bin
+
+  # Work around TexturePacker with wrong libc found in sysroot on incremental build
+  rm -f ${SYSROOT_PREFIX}/usr/bin/TexturePacker
 }
 
 post_install() {

--- a/packages/mediacenter/kodi/patches/kodi-100.25-hack-fix-texture-packer-cmake-source-dir.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.25-hack-fix-texture-packer-cmake-source-dir.patch
@@ -1,7 +1,9 @@
 --- a/tools/depends/native/TexturePacker/CMakeLists.txt
 +++ b/tools/depends/native/TexturePacker/CMakeLists.txt
-@@ -1,3 +1,5 @@
-+set(CMAKE_SOURCE_DIR ${CMAKE_SOURCE_DIR}/../../../..)
+@@ -1,3 +1,7 @@
++if(NOT WITH_TEXTUREPACKER)
++  set(CMAKE_SOURCE_DIR ${CMAKE_SOURCE_DIR}/../../../..)
++endif()
 +
  list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
  


### PR DESCRIPTION
Backport of #5872

Internal TexturePacker is enabled in Kodi 19 with commit xbmc/xbmc#20462 breaking our build with missing TexturePacker dependencies and using the kodi-100.25 patch.

This commit intentionally only include the need changes to make a future Kodi bump possible. The changes can be applied to current kodi base without breaking anything, there are only some unused dependencies.