### PR TITLE
Toolchain Updates

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -32,4 +32,4 @@
 # Disable runtime checking support of ARMv8.0's optional LSE feature. Breaks gdb and mesa compile.
   TARGET_CFLAGS="${TARGET_CFLAGS} -mno-outline-atomics"
   TARGET_LDFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mtune=$TARGET_CPU"
-  GCC_OPTS="--with-abi=lp64 --with-arch=$TARGET_VARIANT"
+  TARGET_ARCH_GCC_OPTS="--with-abi=lp64 --with-arch=$TARGET_VARIANT"

--- a/config/arch.arm
+++ b/config/arch.arm
@@ -72,4 +72,4 @@
   TARGET_CFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated"
   [ -n "$TARGET_FPU" ] && TARGET_CFLAGS="$TARGET_CFLAGS $TARGET_FPU_FLAGS"
   TARGET_LDFLAGS="-march=$TARGET_VARIANT -mtune=$TARGET_CPU"
-  GCC_OPTS="--with-abi=aapcs-linux --with-arch=$TARGET_SUBARCH --with-float=$TARGET_FLOAT --with-fpu=$TARGET_FPU"
+  TARGET_ARCH_GCC_OPTS="--with-abi=aapcs-linux --with-arch=$TARGET_SUBARCH --with-float=$TARGET_FLOAT --with-fpu=$TARGET_FPU"

--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.35.1"
-PKG_SHA256="3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607"
+PKG_VERSION="2.37"
+PKG_SHA256="820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.gnu.org/software/binutils/"
-PKG_URL="http://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.gnu.org/software/binutils/"
+PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host bison:host flex:host linux:host"
 PKG_DEPENDS_TARGET="toolchain zlib binutils:host"
 PKG_LONGDESC="A GNU collection of binary utilities."

--- a/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
+++ b/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
@@ -10,9 +10,9 @@ From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 15 Jan 2016 06:31:09 +0000
 Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 
---- a/ld/ldfile.c	2015-11-13 09:27:42.000000000 +0100
-+++ b/ld/ldfile.c	2016-11-15 19:09:31.658371254 +0100
-@@ -102,6 +102,17 @@ ldfile_add_library_path (const char *nam
+--- a/ld/ldfile.c
++++ b/ld/ldfile.c
+@@ -103,6 +103,17 @@ ldfile_add_library_path (const char *nam
    if (!cmdline && config.only_cmd_line_lib_dirs)
      return;
  

--- a/packages/devel/binutils/patches/nodocs.patch
+++ b/packages/devel/binutils/patches/nodocs.patch
@@ -1,7 +1,6 @@
-diff -ur a/binutils/Makefile.in b/binutils/Makefile.in
---- a/binutils/Makefile.in	2020-02-01 12:50:05.000000000 +0100
-+++ b/binutils/Makefile.in	2020-02-20 00:45:18.792253182 +0100
-@@ -560,7 +560,7 @@
+--- a/binutils/Makefile.in
++++ b/binutils/Makefile.in
+@@ -569,7 +569,7 @@ zlibdir = @zlibdir@
  zlibinc = @zlibinc@
  AUTOMAKE_OPTIONS = dejagnu no-dist foreign subdir-objects
  ACLOCAL_AMFLAGS = -I .. -I ../config -I ../bfd

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glibc"
-PKG_VERSION="2.32"
-PKG_SHA256="1627ea54f5a1a8467032563393e0901077626dc66f37f10ee6363bb722222836"
+PKG_VERSION="2.33"
+PKG_SHA256="2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.gnu.org/software/libc/"
-PKG_URL="http://ftp.gnu.org/pub/gnu/glibc/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.gnu.org/software/libc/"
+PKG_URL="https://ftp.gnu.org/pub/gnu/glibc/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap pigz:host Python3:host"
 PKG_DEPENDS_INIT="glibc"
 PKG_LONGDESC="The Glibc package contains the main C library."
@@ -19,6 +19,7 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --libexecdir=/usr/lib/glibc \
                            --cache-file=config.cache \
                            --disable-profile \
+                           --disable-werror \
                            --disable-sanity-checks \
                            --enable-add-ons \
                            --enable-bind-now \
@@ -32,7 +33,6 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --without-gd \
                            --disable-build-nscd \
                            --disable-nscd \
-                           --enable-lock-elision \
                            --disable-timezone-tools"
 
 if build_with_debug; then

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glibc"
-PKG_VERSION="2.33"
-PKG_SHA256="2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff"
+PKG_VERSION="2.34"
+PKG_SHA256="44d26a1fe20b8853a48f470ead01e4279e869ac149b195dda4e44a195d981ab2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/libc/"
 PKG_URL="https://ftp.gnu.org/pub/gnu/glibc/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/glibc/patches/arm/glibc-add-support-for-SHT_RELR-sections.patch
+++ b/packages/devel/glibc/patches/arm/glibc-add-support-for-SHT_RELR-sections.patch
@@ -26,8 +26,6 @@ been updated to include the new definitions.
  sysdeps/x86_64/dl-machine.h  | 10 +++++++++
  8 files changed, 114 insertions(+), 4 deletions(-)
 
-diff --git a/elf/do-rel.h b/elf/do-rel.h
-index 1d0a1f2c5d..25babef6e1 100644
 --- a/elf/do-rel.h
 +++ b/elf/do-rel.h
 @@ -26,6 +26,12 @@
@@ -43,7 +41,7 @@ index 1d0a1f2c5d..25babef6e1 100644
  #ifndef DO_ELF_MACHINE_REL_RELATIVE
  # define DO_ELF_MACHINE_REL_RELATIVE(map, l_addr, relative) \
    elf_machine_rel_relative (l_addr, relative,				      \
-@@ -46,12 +52,12 @@ elf_dynamic_do_Rel (struct link_map *map,
+@@ -46,12 +52,12 @@ elf_dynamic_do_Rel (struct link_map *map
    const ElfW(Rel) *r = (const void *) reladdr;
    const ElfW(Rel) *end = (const void *) (reladdr + relsize);
    ElfW(Addr) l_addr = map->l_addr;
@@ -58,7 +56,7 @@ index 1d0a1f2c5d..25babef6e1 100644
    /* We never bind lazily during ld.so bootstrap.  Unfortunately gcc is
       not clever enough to see through all the function calls to realize
       that.  */
-@@ -80,8 +86,10 @@ elf_dynamic_do_Rel (struct link_map *map,
+@@ -80,8 +86,10 @@ elf_dynamic_do_Rel (struct link_map *map
    else
  #endif
      {
@@ -69,7 +67,7 @@ index 1d0a1f2c5d..25babef6e1 100644
        const ElfW(Rel) *relative = r;
        r += nrelative;
  
-@@ -108,9 +116,36 @@ elf_dynamic_do_Rel (struct link_map *map,
+@@ -108,9 +116,36 @@ elf_dynamic_do_Rel (struct link_map *map
  	if (l_addr != 0 || ! map->l_info[VALIDX(DT_GNU_PRELINKED)])
  # endif
  #endif
@@ -106,24 +104,22 @@ index 1d0a1f2c5d..25babef6e1 100644
  #ifdef RTLD_BOOTSTRAP
        /* The dynamic linker always uses versioning.  */
        assert (map->l_info[VERSYMIDX (DT_VERSYM)] != NULL);
-@@ -179,6 +214,7 @@ elf_dynamic_do_Rel (struct link_map *map,
- 				 skip_ifunc);
+@@ -180,6 +215,7 @@ elf_dynamic_do_Rel (struct link_map *map
  # endif
  	}
-+#endif
  #endif
++#endif
      }
  }
-@@ -189,3 +225,4 @@ elf_dynamic_do_Rel (struct link_map *map,
+ 
+@@ -189,3 +225,4 @@ elf_dynamic_do_Rel (struct link_map *map
  #undef elf_machine_rel_relative
  #undef DO_ELF_MACHINE_REL_RELATIVE
  #undef DO_RELA
 +#undef DO_RELR
-diff --git a/elf/dynamic-link.h b/elf/dynamic-link.h
-index 6727233e1a..4345df9949 100644
 --- a/elf/dynamic-link.h
 +++ b/elf/dynamic-link.h
-@@ -76,6 +76,11 @@ auto inline void __attribute__((always_inline))
+@@ -76,6 +76,11 @@ auto inline void __attribute__((always_i
  elf_machine_rela_relative (ElfW(Addr) l_addr, const ElfW(Rela) *reloc,
  			   void *const reloc_addr);
  # endif
@@ -135,7 +131,7 @@ index 6727233e1a..4345df9949 100644
  # if ELF_MACHINE_NO_RELA || defined ELF_MACHINE_PLT_REL
  auto inline void __attribute__((always_inline))
  elf_machine_lazy_rel (struct link_map *map,
-@@ -190,6 +195,15 @@ elf_machine_lazy_rel (struct link_map *map,
+@@ -190,6 +195,15 @@ elf_machine_lazy_rel (struct link_map *m
  #  define ELF_DYNAMIC_DO_RELA(map, lazy, skip_ifunc) /* Nothing to do.  */
  # endif
  
@@ -151,7 +147,7 @@ index 6727233e1a..4345df9949 100644
  /* This can't just be an inline function because GCC is too dumb
     to inline functions containing inlines themselves.  */
  # define ELF_DYNAMIC_RELOCATE(map, lazy, consider_profile, skip_ifunc) \
-@@ -198,6 +212,7 @@ elf_machine_lazy_rel (struct link_map *map,
+@@ -198,6 +212,7 @@ elf_machine_lazy_rel (struct link_map *m
  					      (consider_profile));	      \
      ELF_DYNAMIC_DO_REL ((map), edr_lazy, skip_ifunc);			      \
      ELF_DYNAMIC_DO_RELA ((map), edr_lazy, skip_ifunc);			      \
@@ -159,21 +155,19 @@ index 6727233e1a..4345df9949 100644
    } while (0)
  
  #endif
-diff --git a/elf/elf.h b/elf/elf.h
-index 197b557d15..5b6da8e8ae 100644
 --- a/elf/elf.h
 +++ b/elf/elf.h
-@@ -446,7 +446,8 @@ typedef struct
+@@ -443,7 +443,8 @@ typedef struct
  #define SHT_PREINIT_ARRAY 16		/* Array of pre-constructors */
  #define SHT_GROUP	  17		/* Section group */
- #define SHT_SYMTAB_SHNDX  18		/* Extended section indeces */
+ #define SHT_SYMTAB_SHNDX  18		/* Extended section indices */
 -#define	SHT_NUM		  19		/* Number of defined types.  */
 +#define SHT_RELR	  19            /* Relative relocation, only offsets */
 +#define	SHT_NUM		  20		/* Number of defined types.  */
  #define SHT_LOOS	  0x60000000	/* Start OS-specific.  */
  #define SHT_GNU_ATTRIBUTES 0x6ffffff5	/* Object attributes.  */
  #define SHT_GNU_HASH	  0x6ffffff6	/* GNU-style hash table.  */
-@@ -664,6 +665,12 @@ typedef struct
+@@ -662,6 +663,12 @@ typedef struct
    Elf64_Sxword	r_addend;		/* Addend */
  } Elf64_Rela;
  
@@ -186,7 +180,7 @@ index 197b557d15..5b6da8e8ae 100644
  /* How to extract and insert information held in the r_info field.  */
  
  #define ELF32_R_SYM(val)		((val) >> 8)
-@@ -885,7 +892,10 @@ typedef struct
+@@ -887,7 +894,10 @@ typedef struct
  #define DT_PREINIT_ARRAY 32		/* Array with addresses of preinit fct*/
  #define DT_PREINIT_ARRAYSZ 33		/* size in bytes of DT_PREINIT_ARRAY */
  #define DT_SYMTAB_SHNDX	34		/* Address of SYMTAB_SHNDX section */
@@ -198,7 +192,7 @@ index 197b557d15..5b6da8e8ae 100644
  #define DT_LOOS		0x6000000d	/* Start of OS-specific */
  #define DT_HIOS		0x6ffff000	/* End of OS-specific */
  #define DT_LOPROC	0x70000000	/* Start of processor-specific */
-@@ -937,6 +947,7 @@ typedef struct
+@@ -939,6 +949,7 @@ typedef struct
     GNU extension.  */
  #define DT_VERSYM	0x6ffffff0
  
@@ -206,11 +200,9 @@ index 197b557d15..5b6da8e8ae 100644
  #define DT_RELACOUNT	0x6ffffff9
  #define DT_RELCOUNT	0x6ffffffa
  
-diff --git a/elf/get-dynamic-info.h b/elf/get-dynamic-info.h
-index 4f6a86ef37..79ff22f0c0 100644
 --- a/elf/get-dynamic-info.h
 +++ b/elf/get-dynamic-info.h
-@@ -108,6 +108,9 @@ elf_get_dynamic_info (struct link_map *l, ElfW(Dyn) *temp)
+@@ -103,6 +103,9 @@ elf_get_dynamic_info (struct link_map *l
  # if ! ELF_MACHINE_NO_REL
        ADJUST_DYN_INFO (DT_REL);
  # endif
@@ -220,7 +212,7 @@ index 4f6a86ef37..79ff22f0c0 100644
        ADJUST_DYN_INFO (DT_JMPREL);
        ADJUST_DYN_INFO (VERSYMIDX (DT_VERSYM));
        ADJUST_DYN_INFO (ADDRIDX (DT_GNU_HASH));
-@@ -134,6 +137,10 @@ elf_get_dynamic_info (struct link_map *l, ElfW(Dyn) *temp)
+@@ -129,6 +132,10 @@ elf_get_dynamic_info (struct link_map *l
    if (info[DT_REL] != NULL)
      assert (info[DT_RELENT]->d_un.d_val == sizeof (ElfW(Rel)));
  #endif
@@ -231,8 +223,6 @@ index 4f6a86ef37..79ff22f0c0 100644
  #ifdef RTLD_BOOTSTRAP
    /* Only the bind now flags are allowed.  */
    assert (info[VERSYMIDX (DT_FLAGS_1)] == NULL
-diff --git a/sysdeps/aarch64/dl-machine.h b/sysdeps/aarch64/dl-machine.h
-index fde7cfd9e2..eaff6dbc6d 100644
 --- a/sysdeps/aarch64/dl-machine.h
 +++ b/sysdeps/aarch64/dl-machine.h
 @@ -198,6 +198,7 @@ _dl_start_user:								\n\
@@ -243,11 +233,10 @@ index fde7cfd9e2..eaff6dbc6d 100644
  
  #define DL_PLATFORM_INIT dl_platform_init ()
  
-@@ -383,6 +384,15 @@ elf_machine_rela_relative (ElfW(Addr) l_addr,
-   *reloc_addr = l_addr + reloc->r_addend;
+@@ -384,6 +385,15 @@ elf_machine_rela_relative (ElfW(Addr) l_
  }
  
-+inline void
+ inline void
 +__attribute__ ((always_inline))
 +elf_machine_relr_relative (ElfW(Addr) l_addr,
 +			   void *const reloc_addr_arg)
@@ -256,14 +245,13 @@ index fde7cfd9e2..eaff6dbc6d 100644
 +  *reloc_addr += l_addr;
 +}
 +
- inline void
++inline void
  __attribute__ ((always_inline))
  elf_machine_lazy_rel (struct link_map *map,
-diff --git a/sysdeps/arm/dl-machine.h b/sysdeps/arm/dl-machine.h
-index 90856779b1..c586232c9d 100644
+ 		      ElfW(Addr) l_addr,
 --- a/sysdeps/arm/dl-machine.h
 +++ b/sysdeps/arm/dl-machine.h
-@@ -296,6 +296,7 @@ elf_machine_plt_value (struct link_map *map, const Elf32_Rel *reloc,
+@@ -296,6 +296,7 @@ elf_machine_plt_value (struct link_map *
     Prelinked libraries may use Elf32_Rela though.  */
  #define ELF_MACHINE_NO_RELA defined RTLD_BOOTSTRAP
  #define ELF_MACHINE_NO_REL 0
@@ -271,7 +259,7 @@ index 90856779b1..c586232c9d 100644
  
  /* Names of the architecture-specific auditing callback functions.  */
  #define ARCH_LA_PLTENTER arm_gnu_pltenter
-@@ -637,6 +638,15 @@ elf_machine_rel_relative (Elf32_Addr l_addr, const Elf32_Rel *reloc,
+@@ -637,6 +638,15 @@ elf_machine_rel_relative (Elf32_Addr l_a
    *reloc_addr += l_addr;
  }
  
@@ -287,11 +275,9 @@ index 90856779b1..c586232c9d 100644
  # ifndef RTLD_BOOTSTRAP
  auto inline void
  __attribute__ ((always_inline))
-diff --git a/sysdeps/i386/dl-machine.h b/sysdeps/i386/dl-machine.h
-index 672d8f27ce..7c09608913 100644
 --- a/sysdeps/i386/dl-machine.h
 +++ b/sysdeps/i386/dl-machine.h
-@@ -286,6 +286,7 @@ elf_machine_plt_value (struct link_map *map, const Elf32_Rel *reloc,
+@@ -285,6 +285,7 @@ elf_machine_plt_value (struct link_map *
     Prelinked libraries may use Elf32_Rela though.  */
  #define ELF_MACHINE_NO_RELA defined RTLD_BOOTSTRAP
  #define ELF_MACHINE_NO_REL 0
@@ -299,7 +285,7 @@ index 672d8f27ce..7c09608913 100644
  
  #ifdef RESOLVE_MAP
  
-@@ -658,6 +659,15 @@ elf_machine_rel_relative (Elf32_Addr l_addr, const Elf32_Rel *reloc,
+@@ -657,6 +658,15 @@ elf_machine_rel_relative (Elf32_Addr l_a
    *reloc_addr += l_addr;
  }
  
@@ -315,11 +301,9 @@ index 672d8f27ce..7c09608913 100644
  # ifndef RTLD_BOOTSTRAP
  auto inline void
  __attribute__ ((always_inline))
-diff --git a/sysdeps/x86_64/dl-machine.h b/sysdeps/x86_64/dl-machine.h
-index 363a749cb2..10a200ba67 100644
 --- a/sysdeps/x86_64/dl-machine.h
 +++ b/sysdeps/x86_64/dl-machine.h
-@@ -214,6 +214,7 @@ _dl_start_user:\n\
+@@ -209,6 +209,7 @@ _dl_start_user:\n\
  /* The x86-64 never uses Elf64_Rel/Elf32_Rel relocations.  */
  #define ELF_MACHINE_NO_REL 1
  #define ELF_MACHINE_NO_RELA 0
@@ -327,11 +311,10 @@ index 363a749cb2..10a200ba67 100644
  
  /* We define an initialization function.  This is called very early in
     _dl_sysdep_start.  */
-@@ -549,6 +550,15 @@ elf_machine_rela_relative (ElfW(Addr) l_addr, const ElfW(Rela) *reloc,
-     }
+@@ -545,6 +546,15 @@ elf_machine_rela_relative (ElfW(Addr) l_
  }
  
-+auto inline void
+ auto inline void
 +__attribute ((always_inline))
 +elf_machine_relr_relative (ElfW(Addr) l_addr,
 +			   void *const reloc_addr_arg)
@@ -340,9 +323,7 @@ index 363a749cb2..10a200ba67 100644
 +  *reloc_addr += l_addr;
 +}
 +
- auto inline void
++auto inline void
  __attribute ((always_inline))
  elf_machine_lazy_rel (struct link_map *map,
--- 
-2.30.2
-
+ 		      ElfW(Addr) l_addr, const ElfW(Rela) *reloc,

--- a/packages/devel/glibc/patches/arm/glibc-tls-libwidevinecdm.so-since-4.10.2252.0-has-TLS-with.patch
+++ b/packages/devel/glibc/patches/arm/glibc-tls-libwidevinecdm.so-since-4.10.2252.0-has-TLS-with.patch
@@ -10,11 +10,9 @@ Subject: [PATCH] tls: libwidevinecdm.so: since 4.10.2252.0 has TLS with
  elf/dl-tls.c | 5 +++++
  1 file changed, 5 insertions(+)
 
-diff --git a/elf/dl-tls.c b/elf/dl-tls.c
-index 9fa62f5d..d8f2f740 100644
 --- a/elf/dl-tls.c
 +++ b/elf/dl-tls.c
-@@ -213,6 +213,11 @@ void
+@@ -220,6 +220,11 @@ void
  _dl_determine_tlsoffset (void)
  {
    size_t max_align = TLS_TCB_ALIGN;
@@ -26,6 +24,3 @@ index 9fa62f5d..d8f2f740 100644
    size_t freetop = 0;
    size_t freebottom = 0;
  
--- 
-2.31.1
-

--- a/packages/devel/glibc/patches/glibc-fix-dns-with-broken-routers.patch
+++ b/packages/devel/glibc/patches/glibc-fix-dns-with-broken-routers.patch
@@ -6,13 +6,11 @@ Date:   Tue Oct 1 12:09:07 2013 +0300
     
     ref: https://fedoraproject.org/wiki/Networking/NameResolution/ADDRCONFIG
 
-diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
-index 7bb3ded..2085ee5 100644
 --- a/sysdeps/posix/getaddrinfo.c
 +++ b/sysdeps/posix/getaddrinfo.c
-@@ -830,6 +830,38 @@ gaih_inet (const char *name, const struct gaih_service *service,
- 		}
- 	    }
+@@ -730,6 +730,38 @@ gaih_inet (const char *name, const struc
+ 	  if (res_ctx == NULL)
+ 	    no_more = 1;
  
 +	  /* AI_ADDRCONFIG determines whether or not we should suppress any
 +	   * hostname lookups. If the local host has only IPv4 interfaces,
@@ -49,7 +47,7 @@ index 7bb3ded..2085ee5 100644
  	  while (!no_more)
  	    {
  	      no_data = 0;
-@@ -837,7 +869,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+@@ -737,7 +769,7 @@ gaih_inet (const char *name, const struc
  
  	      /* gethostbyname4_r sends out parallel A and AAAA queries and
  		 is thus only suitable for PF_UNSPEC.  */
@@ -58,7 +56,7 @@ index 7bb3ded..2085ee5 100644
  		fct4 = __nss_lookup_function (nip, "gethostbyname4_r");
  
  	      if (fct4 != NULL)
-@@ -942,20 +974,22 @@ gaih_inet (const char *name, const struct gaih_service *service,
+@@ -826,20 +858,22 @@ gaih_inet (const char *name, const struc
  
  		  if (fct != NULL)
  		    {
@@ -90,11 +88,9 @@ index 7bb3ded..2085ee5 100644
  			{
  			  gethosts (AF_INET, struct in_addr);
  
-diff --git a/sysdeps/unix/sysv/linux/check_pf.c b/sysdeps/unix/sysv/linux/check_pf.c
-index 34c2146..be7de0d 100644
 --- a/sysdeps/unix/sysv/linux/check_pf.c
 +++ b/sysdeps/unix/sysv/linux/check_pf.c
-@@ -234,7 +234,8 @@ make_request (int fd, pid_t pid)
+@@ -224,7 +224,8 @@ make_request (int fd, pid_t pid)
  		    }
  		  else
  		    {

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -60,7 +60,7 @@ PKG_CONFIGURE_OPTS_BOOTSTRAP="${GCC_COMMON_CONFIGURE_OPTS} \
                               --without-headers \
                               --with-newlib \
                               --disable-decimal-float \
-                              ${GCC_OPTS}"
+                              ${TARGET_ARCH_GCC_OPTS}"
 
 PKG_CONFIGURE_OPTS_HOST="${GCC_COMMON_CONFIGURE_OPTS} \
                          --enable-languages=c,c++ \
@@ -74,7 +74,7 @@ PKG_CONFIGURE_OPTS_HOST="${GCC_COMMON_CONFIGURE_OPTS} \
                          --disable-libstdcxx-pch \
                          --enable-libstdcxx-time \
                          --enable-clocale=gnu \
-                         ${GCC_OPTS}"
+                         ${TARGET_ARCH_GCC_OPTS}"
 
 pre_configure_host() {
   unset CPP

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -39,7 +39,6 @@ GCC_COMMON_CONFIGURE_OPTS="--target=${TARGET_NAME} \
                            --disable-multilib \
                            --disable-nls \
                            --enable-checking=release \
-                           --with-default-libstdcxx-abi=gcc4-compatible \
                            --without-ppl \
                            --without-cloog \
                            --disable-libada \
@@ -70,7 +69,6 @@ PKG_CONFIGURE_OPTS_HOST="${GCC_COMMON_CONFIGURE_OPTS} \
                          --enable-tls \
                          --enable-shared \
                          --disable-static \
-                         --enable-c99 \
                          --enable-long-long \
                          --enable-threads=posix \
                          --disable-libstdcxx-pch \

--- a/packages/sysutils/fuse/package.mk
+++ b/packages/sysutils/fuse/package.mk
@@ -12,6 +12,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="FUSE provides a simple interface for userspace programs to export a virtual filesystem to the Linux kernel."
 # fuse fails to build with GOLD linker on gcc-4.9
 PKG_BUILD_FLAGS="-gold"
+PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="MOUNT_FUSE_PATH=/usr/sbin \
                            --enable-lib \

--- a/packages/sysutils/fuse/patches/fuse-0003-build-with-glibc-2.34.patch
+++ b/packages/sysutils/fuse/patches/fuse-0003-build-with-glibc-2.34.patch
@@ -1,0 +1,60 @@
+From ae2352bca9b4e607538412da0cc2a9625cd8b692 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Sat, 24 Jul 2021 22:02:45 +0100
+Subject: [PATCH] util/ulockmgr_server.c: conditionally define closefrom (fix
+ glibc-2.34+)
+
+closefrom(3) has joined us in glibc-land from *BSD and Solaris. Since
+it's available in glibc 2.34+, we want to detect it and only define our
+fallback if the libc doesn't provide it.
+
+Bug: https://bugs.gentoo.org/803923
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ configure.ac           | 1 +
+ util/ulockmgr_server.c | 6 ++++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 9946a0efa..a2d481aa9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -55,6 +55,7 @@ fi
+ 
+ AC_CHECK_FUNCS([fork setxattr fdatasync splice vmsplice utimensat])
+ AC_CHECK_FUNCS([posix_fallocate])
++AC_CHECK_FUNCS([closefrom])
+ AC_CHECK_MEMBERS([struct stat.st_atim])
+ AC_CHECK_MEMBERS([struct stat.st_atimespec])
+ 
+diff --git a/util/ulockmgr_server.c b/util/ulockmgr_server.c
+index 273c7d923..a04dac5c6 100644
+--- a/util/ulockmgr_server.c
++++ b/util/ulockmgr_server.c
+@@ -22,6 +22,10 @@
+ #include <sys/socket.h>
+ #include <sys/wait.h>
+ 
++#ifdef HAVE_CONFIG_H
++	#include "config.h"
++#endif
++
+ struct message {
+ 	unsigned intr : 1;
+ 	unsigned nofd : 1;
+@@ -124,6 +128,7 @@ static int receive_message(int sock, void *buf, size_t buflen, int *fdp,
+ 	return res;
+ }
+ 
++#if !defined(HAVE_CLOSEFROM)
+ static int closefrom(int minfd)
+ {
+ 	DIR *dir = opendir("/proc/self/fd");
+@@ -141,6 +146,7 @@ static int closefrom(int minfd)
+ 	}
+ 	return 0;
+ }
++#endif
+ 
+ static void send_reply(int cfd, struct message *msg)
+ {


### PR DESCRIPTION
This updates binutils to 2.37 and glibc to 2.34. Patches were refreshed for both. ~~BlueZ gets updated and~~ fuse gets patched for glibc-2.34 compatibility. Gcc and glibc configure options have been updated. Glibc is removing a nonexistent option, and disabling Werror. gcc is removing a nonexistent option and restoring some defaults since GCC5.

Glibc-2.34 will probably be disruptive. From the release announce: https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html

> In order to support smoother in-place-upgrades and to simplify
  the implementation of the runtime all functionality formerly
  implemented in the libraries libpthread, libdl, libutil, libanl has
  been integrated into libc.  New applications do not need to link with
  -lpthread, -ldl, -lutil, -lanl anymore.  For backwards compatibility,
  empty static archives libpthread.a, libdl.a, libutil.a, libanl.a are
  provided, so that the linker options keep working.  Applications which
  have been linked against glibc 2.33 or earlier continue to load the
  corresponding shared objects (which are now empty).  The integration
  of those libraries into libc means that additional symbols become
  available by default.  This can cause applications that contain weak
  references to take unexpected code paths that would only have been
  used in previous glibc versions when e.g. preloading libpthread.so.0,
  potentially exposing application bugs.

Widevine patches have been refreshed for 2.34, but have not been runtime tested.

This also renames GCC_OPTS to TARGET_ARCH_GCC_OPTS to help prevent confusion that this is set in  the config/arch.$ARCH options. I'm open to another name.

Run tested on RPi3.aarch64. Build tested on RPi2.arm. Draft PR so people can test other arches, and I hopefully have time to test moving from glibc's libcrypt to libxcrypt.