### PR TITLE
[le11] chrome: update to 96.0.4664.45 and addon (111)

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/pango/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/pango/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pango"
-PKG_VERSION="1.49.1"
-PKG_SHA256="c4266dc06c01bf0133d3815502426d209de5ea7abd895899e73e7edebaf48f6f"
+PKG_VERSION="1.49.3"
+PKG_SHA256="45c403b89910a121ad8eb6d57b5be1d8f19499d39b686435dc6f29b106d2be93"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.pango.org/"
 PKG_URL="https://download.gnome.org/sources/pango/${PKG_VERSION:0:4}/pango-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/shared-mime-info/patches/migrate-from-custom-itstool-to-builtin-msgfmt-for-creating-translated-XML.patch
+++ b/packages/addons/addon-depends/chrome-depends/shared-mime-info/patches/migrate-from-custom-itstool-to-builtin-msgfmt-for-creating-translated-XML.patch
@@ -1,0 +1,71 @@
+From 0944c4d73819fd93a7857d56a967c638beb01141 Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz@archlinux.org>
+Date: Mon, 8 Nov 2021 18:22:47 -0500
+Subject: [PATCH] migrate from custom itstool to builtin msgfmt for creating
+ translated XML
+
+gettext upstream has supported this for a very long time, and using it
+means we don't need to jump through hoops to run ninja inside ninja in
+order to generate the .mo files for itstool.
+
+Although meson 0.60.0 added support for real targets for the built .mo
+files, this changed the rules for output filenames, breaking the script.
+But msgfmt does not care, and anyways comes with builtin meson functions
+for convenient use.
+
+Fixes #170
+---
+ data/freedesktop_generate.sh | 12 ------------
+ data/meson.build             | 16 +++++-----------
+ 2 files changed, 5 insertions(+), 23 deletions(-)
+ delete mode 100755 data/freedesktop_generate.sh
+
+diff --git a/data/freedesktop_generate.sh b/data/freedesktop_generate.sh
+deleted file mode 100755
+index 62ccffa..0000000
+--- a/data/freedesktop_generate.sh
++++ /dev/null
+@@ -1,12 +0,0 @@
+-#!/bin/sh -e
+-
+-src_root="$1"
+-build_root="$2"
+-
+-ninja -C "${build_root}" shared-mime-info-gmo
+-
+-itstool \
+-    --its "${src_root}/data/its/shared-mime-info.its" \
+-    --join "${src_root}/data/freedesktop.org.xml.in" \
+-    -o "${build_root}/data/freedesktop.org.xml" \
+-    "${build_root}/po/"*".gmo"
+diff --git a/data/meson.build b/data/meson.build
+index 24361c9..09ed7a9 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -1,18 +1,12 @@
+ 
+ install_man('update-mime-database.1')
+ 
+-freedesktop_org_xml = custom_target('freedesktop.org.xml',
+-    input : files(
+-        'freedesktop.org.xml.in',
+-        'its/shared-mime-info.its',
+-        'its/shared-mime-info.loc',
+-    ),
++freedesktop_org_xml = i18n.merge_file(
++    input: 'freedesktop.org.xml.in',
+     output: 'freedesktop.org.xml',
+-    command: [
+-        find_program('freedesktop_generate.sh'),
+-        meson.source_root(),
+-        meson.build_root()
+-    ],
++    data_dirs: '.',
++    po_dir: '../po',
++    type: 'xml',
+     install: true,
+     install_dir: get_option('datadir') / 'mime' / 'packages',
+ )
+-- 
+GitLab
+

--- a/packages/addons/addon-depends/chrome-depends/shared-mime-info/patches/no-man-no-html.patch
+++ b/packages/addons/addon-depends/chrome-depends/shared-mime-info/patches/no-man-no-html.patch
@@ -5,10 +5,10 @@ diff -Nur shared-mime-info-2.1.orig/data/meson.build shared-mime-info-2.1/data/m
  
 -install_man('update-mime-database.1')
 -
- freedesktop_org_xml = custom_target('freedesktop.org.xml',
-     input : files(
-         'freedesktop.org.xml.in',
-@@ -21,15 +19,3 @@
+ freedesktop_org_xml = i18n.merge_file(
+     input: 'freedesktop.org.xml.in',
+     output: 'freedesktop.org.xml',
+@@ -15,15 +13,3 @@
    [ 'its/shared-mime-info.loc', 'its/shared-mime-info.its', ],
    install_dir : get_option('datadir') / 'gettext/its'
  )

--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,3 +1,9 @@
+111
+- chrome: update to 96.0.4664.45
+- harfbuzz: update to 3.1.1
+- pango: update to 1.49.3
+- shared-mime-info: update compile for meson 0.60.0
+
 110
 - fix dark mode toggle
 - versions >=91 use new flags to enable hardware accelerated video decode

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -4,8 +4,8 @@
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
 # curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
-PKG_VERSION_NUMBER="95.0.4638.54"
-PKG_REV="110"
+PKG_VERSION_NUMBER="96.0.4664.45"
+PKG_REV="111"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="3.0.0"
-PKG_SHA256="036b0ee118451539783ec7864148bb4106be42a2eb964df4e83e6703ec46f3d9"
+PKG_VERSION="3.1.1"
+PKG_SHA256="f3f3247bdeabf36765acc237a5f651e651e4e9706582b9cc2cf6c9b8102dfa93"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- shared-mime-info: meson fix - migrate itstool to builtin msgfmt
- pango: update to 1.49.3
- harfbuzz: update to 3.1.1
- chrome: update to 96.0.4664.45 and addon (111)