### PR TITLE
Mesa and Intel updates

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="21.2.5"
-PKG_SHA256="8e49585fb760d973723dab6435d0c86f7849b8305b1e6d99f475138d896bacbb"
+PKG_VERSION="21.3.0"
+PKG_SHA256="a2753c09deef0ba14d35ae8a2ceff3fe5cd13698928c7bb62c2ec8736eb09ce1"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="21.3.2"
-PKG_SHA256="a6a61ff7e66cb710be1593f2afbda3b21c679fe953bf5e80a5b3f047c1cbdb6c"
+PKG_VERSION="21.3.3"
+PKG_SHA256="77473df5440915e7c487a0f1c3f6236a8c29610528c6f0833da9caae834a1741"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="21.4.0"
-PKG_SHA256="7b9a5b72b3b66baa2efe743d7864e31b14b4f178e09bc648714dc3bd2f0c04dd"
+PKG_VERSION="21.4.1"
+PKG_SHA256="4cd9f2b4da82883a8ed4fb45ba8f186c32941b5f4f3b7d61f2b2b8c19e634281"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
### Intel updates
- gmmlib: update to 21.3.3  
- media-driver: update to 21.4.1

### Mesa
- mesa: update to 21.3.0
  - https://gitlab.freedesktop.org/mesa/mesa/-/blob/9ca91d9bbe30bd2a6792ce353439367e5ae37054/docs/relnotes/21.3.0.rst

### Mesa 21.3.0 Release Notes / 2021-11-17
Mesa 21.3.0 is a new development release. People who are concerned
with stability and reliability should stick with a previous release or
wait for Mesa 21.3.1.

Mesa 21.3.0 implements the OpenGL 4.6 API, but the version reported by
glGetString(GL_VERSION) or glGetIntegerv(GL_MAJOR_VERSION) /
glGetIntegerv(GL_MINOR_VERSION) depends on the particular driver being used.
Some drivers don't support all the features required in OpenGL 4.6. OpenGL
4.6 is only available if requested at context creation.
Compatibility contexts may report a lower version depending on each driver.

Mesa 21.3.0 implements the Vulkan 1.2 API, but the version reported by
the apiVersion property of the VkPhysicalDeviceProperties struct
depends on the particular driver being used.

```
=== tested on ===
Generic.x86_64-devel-20211118191520-6f2f9e7
Linux nuc11 5.16.0-rc1 #1 SMP PREEMPT Wed Nov 17 14:42:00 AEDT 2021 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.101) Git:aff7e96baad0cadabb378817a078166cc2031cdf). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2021-11-18 by GCC 10.3.0 for Linux x86 64-bit version 5.16.0 (331776)
Running on LibreELEC (heitbaum): devel-20211118191520-6f2f9e7 11.0, kernel: Linux x86 64-bit version 5.16.0-rc1
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0041.2021.0811.1505 08/11/2021
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 21.3.0
libva info: VA-API version 1.13.0
vainfo: VA-API version: 1.13 (libva 2.13.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 21.4.1 (6f2f9e7a75)
```