### PR TITLE
waylandpp and wayland-protocols: dependancies

### DIFF
--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="6c0af1915f96f615927a6270d025bd973ff1c58e521e4ca1fc9abfc914633f76"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain wayland:host"
 PKG_LONGDESC="Specifications of extended Wayland protocols"
 
 PKG_MESON_OPTS_TARGET="-Dtests=false"

--- a/packages/wayland/waylandpp/package.mk
+++ b/packages/wayland/waylandpp/package.mk
@@ -8,7 +8,7 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/NilsBrause/waylandpp"
 PKG_URL="https://github.com/NilsBrause/waylandpp/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host pugixml:host"
-PKG_DEPENDS_TARGET="toolchain pugixml:host waylandpp:host"
+PKG_DEPENDS_TARGET="toolchain pugixml:host waylandpp:host wayland"
 PKG_LONGDESC="Wayland C++ bindings"
 
 configure_package() {


### PR DESCRIPTION
Minor tidy up to allow build of waylandpp and wayland-protocols independently. dependancies added. 

tested the following.
```
make clean
scripts/build waylandpp
make clean
scripts/build wayland-protocols
```

following on from #5864