### PR TITLE
[le11] add Vulkan API support

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -1,5 +1,6 @@
 [ -z "${OPENGL}" ] && OPENGL="no"
 [ -z "${OPENGLES}" ] && OPENGLES="no"
+[ -z "${VULKAN}" ] && VULKAN="no"
 
 if [ "${OPENGL}" = "no" ]; then
   OPENGL_SUPPORT="no"
@@ -13,11 +14,19 @@ else
   OPENGLES_SUPPORT="yes"
 fi
 
+if [ "${VULKAN}" = "no" ]; then
+  VULKAN_SUPPORT="no"
+else
+  VULKAN_SUPPORT="yes"
+fi
+
 get_graphicdrivers() {
 
   # set defaults
   GALLIUM_DRIVERS=""
   XORG_DRIVERS=""
+  VULKAN_DRIVERS_CONFIG=""
+  VULKAN_DRIVERS_MESA=""
   LLVM_SUPPORT="no"
   COMPOSITE_SUPPORT="no"
   VDPAU_SUPPORT="no"
@@ -59,6 +68,7 @@ get_graphicdrivers() {
   if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
     GALLIUM_DRIVERS+=" iris"
     XORG_DRIVERS+=" intel"
+    VULKAN_DRIVERS_MESA+=" intel"
     COMPOSITE_SUPPORT="yes"
     VAAPI_SUPPORT="yes"
   fi
@@ -74,6 +84,7 @@ get_graphicdrivers() {
 
   if listcontains "${GRAPHIC_DRIVERS}" "nvidia"; then
     XORG_DRIVERS+=" nvidia"
+    VULKAN_DRIVERS_CONFIG+=" nvidia"
     VDPAU_SUPPORT="yes"
   fi
 
@@ -84,6 +95,7 @@ get_graphicdrivers() {
 
   if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
     GALLIUM_DRIVERS+=" kmsro panfrost"
+    VULKAN_DRIVERS_MESA+=" panfrost"
     V4L2_SUPPORT="yes"
   fi
 
@@ -107,6 +119,7 @@ get_graphicdrivers() {
   if listcontains "${GRAPHIC_DRIVERS}" "radeonsi"; then
     GALLIUM_DRIVERS+=" radeonsi"
     XORG_DRIVERS+=" ati amdgpu"
+    VULKAN_DRIVERS_MESA+=" amd"
     LLVM_SUPPORT="yes"
     COMPOSITE_SUPPORT="yes"
     VDPAU_SUPPORT="yes"
@@ -115,6 +128,7 @@ get_graphicdrivers() {
 
   if listcontains "${GRAPHIC_DRIVERS}" "vc4"; then
     GALLIUM_DRIVERS+=" vc4 v3d kmsro"
+    VULKAN_DRIVERS_MESA+=" broadcom"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
@@ -139,4 +153,7 @@ get_graphicdrivers() {
   GALLIUM_DRIVERS="$(echo ${GALLIUM_DRIVERS} | xargs -n1 | sort -u | xargs)"
   GRAPHIC_DRIVERS="$(echo ${GRAPHIC_DRIVERS} | xargs -n1 | sort -u | xargs)"
   XORG_DRIVERS="$(echo ${XORG_DRIVERS} | xargs -n1 | sort -u | xargs)"
+  VULKAN_DRIVERS_MESA="$(echo ${VULKAN_DRIVERS_MESA} | xargs -n1 | sort -u | xargs)"
+  VULKAN_DRIVERS_CONFIG+=" ${VULKAN_DRIVERS_MESA}"
+  VULKAN_DRIVERS_CONFIG="$(echo ${VULKAN_DRIVERS_CONFIG} | xargs -n1 | sort -u | xargs)"
 }

--- a/config/show_config
+++ b/config/show_config
@@ -99,6 +99,10 @@ show_config() {
   config_message+="\n - Window Manager / Compositor:\t\t ${WINDOWMANAGER}"
   config_message+="\n - OpenGL (GLX) support (provider):\t ${OPENGL_SUPPORT} (${OPENGL})"
   config_message+="\n - OpenGL ES support (provider):\t ${OPENGLES_SUPPORT} (${OPENGLES})"
+  config_message+="\n - Vulkan API support (provider):\t ${VULKAN_SUPPORT} (${VULKAN})"
+  if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+    config_message+="\n - Vulkan Graphic Drivers:\t\t ${VULKAN_DRIVERS_CONFIG}"
+  fi
 
   # Video Acceleration configuration
 

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -21,7 +21,6 @@ PKG_MESON_OPTS_TARGET="-Ddri-drivers= \
                        -Dgallium-omx=disabled \
                        -Dgallium-nine=false \
                        -Dgallium-opencl=disabled \
-                       -Dvulkan-drivers= \
                        -Dshader-cache=enabled \
                        -Dshared-glapi=enabled \
                        -Dopengl=true \
@@ -82,3 +81,9 @@ else
   PKG_MESON_OPTS_TARGET+=" -Dgles1=disabled -Dgles2=disabled"
 fi
 
+if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${VULKAN} vulkan-tools"
+  PKG_MESON_OPTS_TARGET+=" -Dvulkan-drivers=${VULKAN_DRIVERS_MESA// /,}"
+else
+  PKG_MESON_OPTS_TARGET+=" -Dvulkan-drivers="
+fi

--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Frank Hartung (supervisedthinking (@) gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="glslang"
+PKG_VERSION="11.7.0"
+PKG_SHA256="b6c83864c3606678d11675114fa5f358c519fe1dad9a781802bcc87fb8fa32d5"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://github.com/KhronosGroup/glslang"
+PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="toolchain:host Python3:host spirv-tools:host spirv-headers:host"
+PKG_LONGDESC="Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator."
+
+pre_configure_host() {
+  PKG_CMAKE_OPTS_HOST="-DBUILD_SHARED_LIBS=OFF \
+                       -DBUILD_EXTERNAL=ON \
+                       -DENABLE_SPVREMAPPER=OFF \
+                       -DENABLE_GLSLANG_JS=OFF \
+                       -DENABLE_RTTI=OFF \
+                       -DENABLE_EXCEPTIONS=OFF \
+                       -DENABLE_OPT=ON \
+                       -DENABLE_PCH=ON \
+                       -DENABLE_CTEST=OFF \
+                       -DENABLE_RTTI=OFF \
+                       -Wno-dev"
+
+  # The SPIRV-Tools & SPIRV-Headers have to be specific versions matching the pkg version
+  # https://github.com/KhronosGroup/glslang/blob/master/known_good.json
+  mkdir -p ${PKG_BUILD}/External/spirv-tools/external/spirv-headers
+    cp -R $(get_build_dir spirv-tools)/* ${PKG_BUILD}/External/spirv-tools
+    cp -R $(get_build_dir spirv-headers)/* ${PKG_BUILD}/External/spirv-tools/external/spirv-headers
+}

--- a/packages/graphics/vulkan/spirv-headers/package.mk
+++ b/packages/graphics/vulkan/spirv-headers/package.mk
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Frank Hartung (supervisedthinking (@) gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="spirv-headers"
+# The SPIRV-Headers have to be specific versions matching the glslang pkg version
+# https://github.com/KhronosGroup/glslang/blob/master/known_good.json
+PKG_VERSION="814e728b30ddd0f4509233099a3ad96fd4318c07"
+PKG_SHA256="c262d3c0c36ad5c87fbe3572aa292d2aed4dcd9b1ca4868eff9ec180e3f994f2"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
+PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST=""
+PKG_LONGDESC="SPIRV-Headers"
+PKG_TOOLCHAIN="manual"

--- a/packages/graphics/vulkan/spirv-tools/package.mk
+++ b/packages/graphics/vulkan/spirv-tools/package.mk
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Frank Hartung (supervisedthinking (@) gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="spirv-tools"
+# The SPIRV-Tools have to be specific versions matching the glslang pkg version
+# https://github.com/KhronosGroup/glslang/blob/master/known_good.json
+PKG_VERSION="21e3f681e2004590c7865bc8c0195a4ab8e66c88"
+PKG_SHA256="1253ada1d3af912d43f7a9acff86c74afbdb6bdf1acd92bd61e0010c103bc050"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
+PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST=""
+PKG_LONGDESC="The SPIR-V Tools project provides an API and commands for processing SPIR-V modules."
+PKG_TOOLCHAIN="manual"

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Frank Hartung (supervisedthinking (@) gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="vulkan-headers"
+PKG_VERSION="1.2.201"
+PKG_SHA256="6b7f9c809acff4f0877e2e7722e02a08f2e17e06c6e2e8c84081631d15490009"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
+PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Vulkan Header files and API registry"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Frank Hartung (supervisedthinking (@) gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="vulkan-loader"
+PKG_VERSION="1.2.201"
+PKG_SHA256="465e8a35e875ddebde7cb59f15b0e2cdfae9c3826680c775d7d5b731d95ee1d6"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
+PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain vulkan-headers"
+PKG_LONGDESC="Vulkan Installable Client Driver (ICD) Loader."
+
+configure_package() {
+  # Displayserver Support
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    PKG_DEPENDS_TARGET+=" libxcb libX11"
+  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+    PKG_DEPENDS_TARGET+=" wayland"
+  fi
+}
+
+pre_configure_target() {
+  PKG_CMAKE_OPTS_TARGET="-DBUILD_TESTS=OFF"
+
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    PKG_CMAKE_OPTS_TARGET+=" -DBUILD_WSI_XCB_SUPPORT=ON \
+                             -DBUILD_WSI_XLIB_SUPPORT=ON \
+                             -DBUILD_WSI_WAYLAND_SUPPORT=OFF"
+  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+    PKG_CMAKE_OPTS_TARGET+=" -DBUILD_WSI_XCB_SUPPORT=OFF \
+                             -DBUILD_WSI_XLIB_SUPPORT=OFF \
+                             -DBUILD_WSI_WAYLAND_SUPPORT=ON"
+  else
+    PKG_CMAKE_OPTS_TARGET+=" -DBUILD_WSI_XCB_SUPPORT=OFF \
+                             -DBUILD_WSI_XLIB_SUPPORT=OFF \
+                             -DBUILD_WSI_WAYLAND_SUPPORT=OFF"
+  fi
+}

--- a/packages/graphics/vulkan/vulkan-loader/patches/vulkan-loader-995.01-fix-cross-compile.patch
+++ b/packages/graphics/vulkan/vulkan-loader/patches/vulkan-loader-995.01-fix-cross-compile.patch
@@ -1,0 +1,23 @@
+From 4b90138ea1c28246e6a2b8d9b7568836cc4f3782 Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Wed, 18 Sep 2019 20:24:48 +0200
+Subject: [PATCH] loader/CMakeList.txt: fix execution of asm_offset
+
+---
+ loader/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/loader/CMakeLists.txt b/loader/CMakeLists.txt
+index ed78054a1..0af792501 100644
+--- a/loader/CMakeLists.txt
++++ b/loader/CMakeLists.txt
+@@ -246,7 +246,7 @@
+         add_executable(asm_offset asm_offset.c)
+         target_link_libraries(asm_offset Vulkan::Headers)
+         target_compile_definitions(asm_offset PRIVATE _GNU_SOURCE)
+-        add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset GAS)
++        add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND ./asm_offset GAS)
+         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
+     else()
+         if(USE_GAS)
+

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2018-present Frank Hartung (supervisedthinking (@) gmail.com)
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="vulkan-tools"
+PKG_VERSION="1.2.201"
+PKG_SHA256="a259667fba1260352a872e70f325fe0a9a04f1caa5ef353e379acf04b1d2a15a"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
+PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain vulkan-loader glslang:host"
+PKG_LONGDESC="This project provides Khronos official Vulkan Tools and Utilities."
+
+configure_package() {
+  # Displayserver Support
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    PKG_DEPENDS_TARGET+=" libxcb libX11"
+  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+    PKG_DEPENDS_TARGET+=" wayland"
+  fi
+}
+
+pre_configure_target() {
+  PKG_CMAKE_OPTS_TARGET="-DBUILD_VULKANINFO=ON \
+                         -DBUILD_ICD=OFF \
+                         -DINSTALL_ICD=OFF \
+                         -DBUILD_WSI_DIRECTFB_SUPPORT=OFF \
+                         -Wno-dev"
+
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    PKG_CMAKE_OPTS_TARGET+=" -DBUILD_CUBE=ON \
+                             -DBUILD_WSI_XCB_SUPPORT=ON \
+                             -DBUILD_WSI_XLIB_SUPPORT=ON \
+                             -DBUILD_WSI_WAYLAND_SUPPORT=OFF \
+                             -DCUBE_WSI_SELECTION=XCB"
+  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+    PKG_CMAKE_OPTS_TARGET+=" -DBUILD_CUBE=ON \
+                             -DBUILD_WSI_XCB_SUPPORT=OFF \
+                             -DBUILD_WSI_XLIB_SUPPORT=OFF \
+                             -DBUILD_WSI_WAYLAND_SUPPORT=ON
+                             -DCUBE_WSI_SELECTION=WAYLAND"
+  else
+    PKG_CMAKE_OPTS_TARGET+=" -DBUILD_CUBE=ON \
+                             -DBUILD_WSI_XCB_SUPPORT=OFF \
+                             -DBUILD_WSI_XLIB_SUPPORT=OFF \
+                             -DBUILD_WSI_WAYLAND_SUPPORT=OFF \
+                             -DCUBE_WSI_SELECTION=DISPLAY"
+  fi
+}
+
+pre_make_target() {
+  # Fix cross compiling
+  find ${PKG_BUILD} -name flags.make -exec sed -i  "s:isystem :I:g" \{} \;
+  find ${PKG_BUILD} -name build.ninja -exec sed -i "s:isystem :I:g" \{} \;
+}

--- a/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.01-cmakelists-opts.patch
+++ b/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.01-cmakelists-opts.patch
@@ -1,0 +1,26 @@
+From c9c7423f2d0ecfc7ab354d2a3d9ea9c2e4998416 Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Thu, 18 Nov 2021 15:02:55 +0100
+Subject: [PATCH] CMakeLists: add CMake options for cube & vulkaninfo
+
+---
+ CMakeLists.txt | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 422b7d2cc..d123c9dc5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,6 +41,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+ option(BUILD_CUBE "Build cube" ON)
+ option(BUILD_VULKANINFO "Build vulkaninfo" ON)
+ option(BUILD_ICD "Build icd" ON)
++option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
++option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
++option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
++option(BUILD_WSI_DIRECTFB_SUPPORT "Build DirectFB WSI support" OFF)
++set(CUBE_WSI_SELECTION "XCB" CACHE STRING "Select WSI target for vkcube (XCB, XLIB, WAYLAND, DIRECTFB, DISPLAY)")
++
+ # Installing the Mock ICD to system directories is probably not desired since this ICD is not a very complete implementation.
+ # Require the user to ask that it be installed if they really want it.
+ option(INSTALL_ICD "Install icd" OFF)

--- a/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.02-fix-find-pkg-wayland-protocols.patch
+++ b/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.02-fix-find-pkg-wayland-protocols.patch
@@ -1,0 +1,25 @@
+From 3f2debf2710f84f42b999da2b7eb1f168205695f Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Thu, 18 Nov 2021 13:28:38 +0100
+Subject: [PATCH] cmake/FindWaylandProtocols: fix wayland protocol path
+ generation for cross compile
+
+---
+ cmake/FindWaylandProtocols.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/FindWaylandProtocols.cmake b/cmake/FindWaylandProtocols.cmake
+index 17859ed7c..6941f6024 100644
+--- a/cmake/FindWaylandProtocols.cmake
++++ b/cmake/FindWaylandProtocols.cmake
+@@ -6,8 +6,8 @@
+ 
+ if(NOT WIN32)
+     find_package(PkgConfig)
+-    pkg_check_modules(PKG_WAYLAND_PROTOCOLS QUIET wayland-protocols)
+-    set(WAYLAND_PROTOCOLS_PATH ${PKG_WAYLAND_PROTOCOLS_PREFIX}/share/wayland-protocols)
++    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir wayland-protocols
++       OUTPUT_VARIABLE WAYLAND_PROTOCOLS_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+     find_package_handle_standard_args(WAYLAND DEFAULT_MSG WAYLAND_PROTOCOLS_PATH)
+     mark_as_advanced(WAYLAND_PROTOCOLS_PATH)
+ endif()

--- a/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.03-fix-cube-cross-compile.patch
+++ b/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.03-fix-cube-cross-compile.patch
@@ -1,0 +1,45 @@
+From b5ccef606aa9cb8bc96acfeba3b586da0617e80a Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Fri, 19 Nov 2021 19:46:26 +0100
+Subject: [PATCH] cube: allow cross compile
+
+---
+ cube/CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/cube/CMakeLists.txt b/cube/CMakeLists.txt
+index d59eb4366..c0c9ddad6 100644
+--- a/cube/CMakeLists.txt
++++ b/cube/CMakeLists.txt
+@@ -228,7 +228,6 @@ include_directories(${CUBE_INCLUDE_DIRS})
+ if(APPLE)
+     include(macOS/cube/cube.cmake)
+ elseif(NOT WIN32)
+-    if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR})
+         add_executable(vkcube
+                        cube.c
+                        ${PROJECT_SOURCE_DIR}/cube/cube.vert
+@@ -242,7 +241,6 @@ elseif(NOT WIN32)
+         if (NEED_RT)
+             target_link_libraries(vkcube rt)
+         endif()
+-    endif()
+ else()
+     if(CMAKE_CL_64)
+         set(LIB_DIR "Win64")
+@@ -279,7 +277,6 @@ endif()
+ if(APPLE)
+     include(macOS/cubepp/cubepp.cmake)
+ elseif(NOT WIN32)
+-    if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR})
+         add_executable(vkcubepp
+                        cube.cpp
+                        ${PROJECT_SOURCE_DIR}/cube/cube.vert
+@@ -288,7 +285,6 @@ elseif(NOT WIN32)
+                        cube.frag.inc
+                        ${OPTIONAL_WAYLAND_DATA_FILES})
+         target_link_libraries(vkcubepp Vulkan::Vulkan)
+-    endif()
+ else()
+     if(CMAKE_CL_64)
+         set(LIB_DIR "Win64")

--- a/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.04-fix-glslangValidator-logik.patch
+++ b/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.04-fix-glslangValidator-logik.patch
@@ -1,0 +1,67 @@
+From a1894dc9f650ab94fb7e348e1b06ee75a1e9728b Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Sat, 20 Nov 2021 18:39:04 +0100
+Subject: [PATCH] CMakeLists: updated glslangValidator logik
+
+---
+ cube/CMakeLists.txt | 43 +++++++++++++++++++++++++++----------------
+ 1 file changed, 27 insertions(+), 16 deletions(-)
+
+diff --git a/cube/CMakeLists.txt b/cube/CMakeLists.txt
+index d59eb4366..a684fc4f0 100644
+--- a/cube/CMakeLists.txt
++++ b/cube/CMakeLists.txt
+@@ -26,26 +26,37 @@ endif()
+ if(GLSLANG_INSTALL_DIR)
+     message(STATUS "Using GLSLANG_INSTALL_DIR to look for glslangValidator")
+     find_program(GLSLANG_VALIDATOR names glslangValidator HINTS "${GLSLANG_INSTALL_DIR}/bin")
++
+ else()
+     set(GLSLANG_VALIDATOR_NAME "glslangValidator")
+-    message(STATUS "Using cmake find_program to look for glslangValidator")
+-    if(WIN32)
+-        execute_process(
+-            COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/fetch_glslangvalidator.py glslang-master-windows-x64-Release.zip)
+-        set(GLSLANG_VALIDATOR_NAME "glslangValidator.exe")
+-    elseif(APPLE)
+-        execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/fetch_glslangvalidator.py glslang-master-osx-Release.zip)
+-    elseif(UNIX AND NOT APPLE) # i.e. Linux
+-        execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/fetch_glslangvalidator.py glslang-master-linux-Release.zip)
+-    endif()
+-    if (WIN32)
+-        set(PLATFORM_DIR "${PROJECT_SOURCE_DIR}/glslang/windows/bin")
+-    elseif(APPLE)
+-        set(PLATFORM_DIR "${PROJECT_SOURCE_DIR}/glslang/darwin/bin")
++    message(CHECK_START "Looking for glslangValidator")
++    find_program(GLSLANG_VALIDATOR NAMES ${GLSLANG_VALIDATOR_NAME} HINTS ${PLATFORM_DIR})
++    if(GLSLANG_VALIDATOR)
++        message(CHECK_PASS ${GLSLANG_VALIDATOR})
+     else()
+-        set(PLATFORM_DIR "${PROJECT_SOURCE_DIR}/glslang/linux/bin")
++        if(WIN32)
++            execute_process(
++                COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/fetch_glslangvalidator.py glslang-master-windows-x64-Release.zip)
++            set(GLSLANG_VALIDATOR_NAME "glslangValidator.exe")
++        elseif(APPLE)
++            execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/fetch_glslangvalidator.py glslang-master-osx-Release.zip)
++        elseif(UNIX AND NOT APPLE) # i.e. Linux
++            execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/fetch_glslangvalidator.py glslang-master-linux-Release.zip)
++        endif()
++        if (WIN32)
++            set(PLATFORM_DIR "${PROJECT_SOURCE_DIR}/glslang/windows/bin")
++        elseif(APPLE)
++            set(PLATFORM_DIR "${PROJECT_SOURCE_DIR}/glslang/darwin/bin")
++        else()
++            set(PLATFORM_DIR "${PROJECT_SOURCE_DIR}/glslang/linux/bin")
++        endif()
++        find_program(GLSLANG_VALIDATOR NAMES ${GLSLANG_VALIDATOR_NAME} HINTS ${PLATFORM_DIR})
++        if(GLSLANG_VALIDATOR)
++            message(CHECK_PASS ${GLSLANG_VALIDATOR})
++        else()
++            message(FATAL_ERROR "no glslangValidator binary found")
++        endif()
+     endif()
+-    find_program(GLSLANG_VALIDATOR NAMES ${GLSLANG_VALIDATOR_NAME} HINTS ${PLATFORM_DIR})
+ endif()
+ 
+ if(UNIX AND NOT APPLE) # i.e. Linux

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -32,8 +32,13 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-backlight \
                            --disable-tear-free \
                            --disable-create2 \
                            --disable-async-swap \
-                           --with-default-dri=2 \
                            --with-xorg-module-dir=${XORG_PATH_MODULES}"
+
+if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+  PKG_CONFIGURE_OPTS_TARGET+=" --with-default-dri=3"
+else
+  PKG_CONFIGURE_OPTS_TARGET+=" --with-default-dri=2"
+fi
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/share/polkit-1

--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -18,6 +18,10 @@ PKG_TOOLCHAIN="manual"
 
 PKG_IS_KERNEL_PKG="yes"
 
+if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${VULKAN} vulkan-tools"
+fi
+
 unpack() {
   [ -d ${PKG_BUILD} ] && rm -rf ${PKG_BUILD}
 
@@ -71,4 +75,14 @@ makeinstall_target() {
     cp libvdpau_nvidia.so* ${INSTALL}/usr/lib/vdpau/libvdpau_nvidia-main.so.1
     ln -sf /var/lib/libvdpau_nvidia.so ${INSTALL}/usr/lib/vdpau/libvdpau_nvidia.so
     ln -sf /var/lib/libvdpau_nvidia.so.1 ${INSTALL}/usr/lib/vdpau/libvdpau_nvidia.so.1
+
+  # Install Vulkan ICD & SPIR-V lib
+  if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+    mkdir -p ${INSTALL}/usr/lib
+      cp -P libnvidia-glvkspirv.so.${PKG_VERSION} ${INSTALL}/usr/lib 
+    mkdir -p ${INSTALL}/usr/share/vulkan/icd.d
+      cp -P nvidia_icd.json ${INSTALL}/usr/share/vulkan/icd.d
+    mkdir -p ${INSTALL}/usr/share/vulkan/implicit_layer.d
+      cp -P nvidia_layers.json ${INSTALL}/usr/share/vulkan/icd.d
+  fi
 }

--- a/packages/x11/lib/libxcb/package.mk
+++ b/packages/x11/lib/libxcb/package.mk
@@ -12,9 +12,7 @@ PKG_DEPENDS_TARGET="toolchain util-macros Python3:host xcb-proto libpthread-stub
 PKG_LONGDESC="X C-language Bindings library."
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared \
-                           --disable-screensaver \
+PKG_CONFIGURE_OPTS_TARGET="--disable-screensaver \
                            --disable-xprint \
                            --disable-selinux \
                            --disable-xvmc"

--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -141,6 +141,9 @@
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
+  # Vulkan implementation to use (vulkan-loader / no)
+    VULKAN="no"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -37,6 +37,9 @@
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
+  # Vulkan implementation to use (vulkan-loader / no)
+    VULKAN="no"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -46,6 +46,9 @@
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
+  # Vulkan implementation to use (vulkan-loader / no)
+    VULKAN="no"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 

--- a/projects/Generic/devices/Generic/options
+++ b/projects/Generic/devices/Generic/options
@@ -4,6 +4,9 @@
 # OpenGL-ES implementation to use (mesa / no)
   OPENGLES="mesa"
 
+# Vulkan implementation to use (vulkan-loader / no)
+  VULKAN="no"
+
 # Displayserver to use (weston / x11 / no)
   DISPLAYSERVER="no"
 

--- a/projects/Generic/devices/wayland/options
+++ b/projects/Generic/devices/wayland/options
@@ -4,6 +4,9 @@
 # OpenGL-ES implementation to use (mesa / no)
   OPENGLES="mesa"
 
+# Vulkan implementation to use (vulkan-loader / no)
+  VULKAN="no"
+
 # Displayserver to use (wl / x11 / no)
   DISPLAYSERVER="wl"
 

--- a/projects/Generic/devices/x11/options
+++ b/projects/Generic/devices/x11/options
@@ -4,6 +4,9 @@
 # OpenGL-ES implementation to use (mesa / no)
   OPENGLES="no"
 
+# Vulkan implementation to use (vulkan-loader / no)
+  VULKAN="no"
+
 # Displayserver to use (weston / x11 / no)
   DISPLAYSERVER="x11"
 

--- a/projects/NXP/options
+++ b/projects/NXP/options
@@ -35,6 +35,9 @@
   # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q / opengl-meson6)
     OPENGLES="mesa"
 
+  # Vulkan implementation to use (vulkan-loader / no)
+    VULKAN="no"
+
   # include uvesafb support (yes / no)
     UVESAFB_SUPPORT="no"
 

--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -63,6 +63,9 @@
   # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q / opengl-meson6)
     OPENGLES="mesa"
 
+  # Vulkan implementation to use (vulkan-loader / no)
+    VULKAN="no"
+
   # include uvesafb support (yes / no)
     UVESAFB_SUPPORT="no"
 

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -75,6 +75,9 @@
   # OpenGL-ES implementation to use (no / bcm2835-driver / mesa)
     OPENGLES="mesa"
 
+  # Vulkan implementation to use (vulkan-loader / no)
+    VULKAN="no"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -44,6 +44,9 @@
   # OpenGL-ES implementation to use (no / libmali / mesa)
     OPENGLES="${OPENGLES:-mesa}"
 
+  # Vulkan implementation to use (vulkan-loader / no)
+    VULKAN="no"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -48,6 +48,9 @@
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
+  # Vulkan implementation to use (vulkan-loader / no)
+    VULKAN="no"
+
   # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 


### PR DESCRIPTION
This PR provides the necessary packages to use [Vulkan](https://www.vulkan.org/) for all projects with supported hardware e.g. AMD, Intel & Nvidia GPUs, RPi4 & hopefully sooner or later all SBCs covered by panfrost. I guess Vulkan can be useful once [Vulkan Video](https://www.phoronix.com/scan.php?page=news_item&px=FFmpeg-Branch-Vulkan-Video) is supported by FFmpeg and [Kodi might also support Vulkan](https://github.com/lrusak/xbmc/tree/vulkan).
 
- added Vulkan packages
- added glslang package + tool/header dependencies to allow offline build of vulkan-tools
- updated mesa & nvidia opts to build/install Vulkan ICD & libs
- xf86-video-intel conditionally default to DRI3 if Vulkan support is enabled
- added Vulkan to show config:
 ```
 - Vulkan API support (provider):	 yes (vulkan-loader)
 - Vulkan Graphic Drivers:		 amd intel nvidia
```
- added Vulkan to graphic config & set default for OpenGL/ES if not defined in project options
- libxcb build shared for `vulkaninfo` (vulkan-tools) / fails to work with XLIB & does not link against static XCB
- added Vulkan opts to all projects, disabled by default, can be enabled by changing `VULKAN="no"` to `VULKAN="vulkan-loader"`

Mesa builds the Vulkan drivers according to the drivers listed in device options. Not all GPU/SOCs support Vulkan so I've only added Vulkan to those which actually can run Vulkan e.g. GPUs supported by amdgpu, iris, i965. You can enable Vulkan for arm builds too but the panfrost driver is WIP but at least returns some summary if you pass `PAN_I_WANT_A_BROKEN_VULKAN_DRIVER=1 vulkaninfo --summary` while the RPi4 should run quite fine with it's `broadcom` Vulkan driver according to the Lakka guys @Ntemis

To discuss:
- the PR should be good to go, I've used it in a similar way for years with my emulation packages, but some testing on AMD or RPi4 devices is appreciated
- default DRI3 for [xf86-video-ati](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/x11/driver/xf86-video-ati/config/xorg-radeon.conf#L5-L7)
- default to DRI3 for [xf86-video-intel ](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/x11/driver/xf86-video-intel/package.mk#L35) I've enabled DRI3 for the Intel driver, are there still issues with these settings? @lrusak 
- if this PR is merged https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/addons/addon-depends/chrome-depends/chrome-libxcb/package.mk & https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/addons/browser/chrome/package.mk#L14 is probably superfluous @CvH 
 

Tested on J3455-ITX with gbm, wayland & x11 builds - all run vkcube fine & `vulkaninfo --summary` returns:

### GBM
```
==========
VULKANINFO
==========

Vulkan Instance Version: 1.2.199


Instance Extensions: count = 15
-------------------------------
VK_EXT_acquire_drm_display             : extension revision 1
VK_EXT_debug_report                    : extension revision 10
VK_EXT_debug_utils                     : extension revision 2
VK_EXT_direct_mode_display             : extension revision 1
VK_EXT_display_surface_counter         : extension revision 1
VK_KHR_device_group_creation           : extension revision 1
VK_KHR_display                         : extension revision 23
VK_KHR_external_fence_capabilities     : extension revision 1
VK_KHR_external_memory_capabilities    : extension revision 1
VK_KHR_external_semaphore_capabilities : extension revision 1
VK_KHR_get_display_properties2         : extension revision 1
VK_KHR_get_physical_device_properties2 : extension revision 2
VK_KHR_get_surface_capabilities2       : extension revision 1
VK_KHR_surface                         : extension revision 25
VK_KHR_surface_protected_capabilities  : extension revision 1

Instance Layers:
----------------

Devices:
========
GPU0:
	apiVersion         = 4202691 (1.2.195)
	driverVersion      = 88092672 (0x5403000)
	vendorID           = 0x8086
	deviceID           = 0x5a85
	deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
	deviceName         = Intel(R) HD Graphics 500 (APL 2)
	driverID           = DRIVER_ID_INTEL_OPEN_SOURCE_MESA
	driverName         = Intel open-source Mesa driver
	driverInfo         = Mesa 21.3.0
	conformanceVersion = 1.2.0.0
```
### Wayland
```
==========
VULKANINFO
==========

Vulkan Instance Version: 1.2.199


Instance Extensions: count = 16
-------------------------------
VK_EXT_acquire_drm_display             : extension revision 1
VK_EXT_debug_report                    : extension revision 10
VK_EXT_debug_utils                     : extension revision 2
VK_EXT_direct_mode_display             : extension revision 1
VK_EXT_display_surface_counter         : extension revision 1
VK_KHR_device_group_creation           : extension revision 1
VK_KHR_display                         : extension revision 23
VK_KHR_external_fence_capabilities     : extension revision 1
VK_KHR_external_memory_capabilities    : extension revision 1
VK_KHR_external_semaphore_capabilities : extension revision 1
VK_KHR_get_display_properties2         : extension revision 1
VK_KHR_get_physical_device_properties2 : extension revision 2
VK_KHR_get_surface_capabilities2       : extension revision 1
VK_KHR_surface                         : extension revision 25
VK_KHR_surface_protected_capabilities  : extension revision 1
VK_KHR_wayland_surface                 : extension revision 6

Instance Layers:
----------------

Devices:
========
GPU0:
	apiVersion         = 4202691 (1.2.195)
	driverVersion      = 88092672 (0x5403000)
	vendorID           = 0x8086
	deviceID           = 0x5a85
	deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
	deviceName         = Intel(R) HD Graphics 500 (APL 2)
	driverID           = DRIVER_ID_INTEL_OPEN_SOURCE_MESA
	driverName         = Intel open-source Mesa driver
	driverInfo         = Mesa 21.3.0
	conformanceVersion = 1.2.0.0
```
### X11
```
==========
VULKANINFO
==========

Vulkan Instance Version: 1.2.199


Instance Extensions: count = 18
-------------------------------
VK_EXT_acquire_drm_display             : extension revision 1
VK_EXT_acquire_xlib_display            : extension revision 1
VK_EXT_debug_report                    : extension revision 10
VK_EXT_debug_utils                     : extension revision 2
VK_EXT_direct_mode_display             : extension revision 1
VK_EXT_display_surface_counter         : extension revision 1
VK_KHR_device_group_creation           : extension revision 1
VK_KHR_display                         : extension revision 23
VK_KHR_external_fence_capabilities     : extension revision 1
VK_KHR_external_memory_capabilities    : extension revision 1
VK_KHR_external_semaphore_capabilities : extension revision 1
VK_KHR_get_display_properties2         : extension revision 1
VK_KHR_get_physical_device_properties2 : extension revision 2
VK_KHR_get_surface_capabilities2       : extension revision 1
VK_KHR_surface                         : extension revision 25
VK_KHR_surface_protected_capabilities  : extension revision 1
VK_KHR_xcb_surface                     : extension revision 6
VK_KHR_xlib_surface                    : extension revision 6

Instance Layers:
----------------

Devices:
========
GPU0:
	apiVersion         = 4202691 (1.2.195)
	driverVersion      = 88092672 (0x5403000)
	vendorID           = 0x8086
	deviceID           = 0x5a85
	deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
	deviceName         = Intel(R) HD Graphics 500 (APL 2)
	driverID           = DRIVER_ID_INTEL_OPEN_SOURCE_MESA
	driverName         = Intel open-source Mesa driver
	driverInfo         = Mesa 21.3.0
	conformanceVersion = 1.2.0.0
```