### PR TITLE
[le11] projects/Generic: clean up & add crocus graphic driver

### DIFF
--- a/projects/Generic/devices/Generic-legacy/options
+++ b/projects/Generic/devices/Generic-legacy/options
@@ -1,19 +1,19 @@
-# OpenGL(X) implementation to use (no / mesa)
+# OpenGL(X) implementation to use (mesa / no)
   OPENGL="mesa"
 
-# OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
+# OpenGL-ES implementation to use (mesa / no)
   OPENGLES="no"
 
-# Displayserver to use (x11 / no)
+# Displayserver to use (weston / x11 / no)
   DISPLAYSERVER="x11"
 
-# KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
+# KODI Player implementation to use (mesa / default)
   KODIPLAYER_DRIVER="default"
 
 # set the addon project
   ADDON_PROJECT="Generic"
 
-# Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
+# Mesa 3D / Xorg Graphic drivers to use (all / crocus,i915,i965,iris,r200,r300,r600,radeonsi,nvidia,nvidia-legacy,vmware,virtio)
 # Space separated list is supported,
 # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
-  GRAPHIC_DRIVERS="r300 r600 radeonsi iris i915 i965 nvidia nvidia-legacy vmware virtio"
+  GRAPHIC_DRIVERS="r300 r600 radeonsi crocus iris i915 i965 nvidia nvidia-legacy vmware virtio"

--- a/projects/Generic/devices/Generic/options
+++ b/projects/Generic/devices/Generic/options
@@ -1,19 +1,19 @@
-# OpenGL(X) implementation to use (no / mesa)
+# OpenGL(X) implementation to use (mesa / no)
   OPENGL="no"
 
-# OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
+# OpenGL-ES implementation to use (mesa / no)
   OPENGLES="mesa"
 
-# Displayserver to use (x11 / no)
+# Displayserver to use (weston / x11 / no)
   DISPLAYSERVER="no"
 
-# KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
+# KODI Player implementation to use (mesa / default)
   KODIPLAYER_DRIVER="mesa"
 
 # set the addon project
   ADDON_PROJECT="Generic"
 
-# Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
+# Mesa 3D Graphic drivers to use (all / crocus,i915,i965,iris,r200,r300,r600,radeonsi,vmware,virtio)
 # Space separated list is supported,
-# e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
-  GRAPHIC_DRIVERS="r300 r600 radeonsi iris i915 i965 vmware virtio"
+# e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi"
+  GRAPHIC_DRIVERS="r300 r600 radeonsi crocus iris i915 i965 vmware virtio"


### PR DESCRIPTION
As follow up to https://github.com/LibreELEC/LibreELEC.tv/pull/5814 & https://github.com/LibreELEC/LibreELEC.tv/pull/5881 we should add crocus to graphic drivers. The i965 driver can be dropped later if there are no issues. 
FYI [_i965_ supports gen4-gen12](https://wiki.gentoo.org/wiki/Intel#Feature_support) Intel GPUs but is superseded by Gallium drivers _crocus_ (gen4-gen7.5)  & _iris_ (gen8+)

- added crocus to Generic project graphic drivers
- clean up