### PR TITLE
Wireless updates

### DIFF
--- a/packages/network/iw/package.mk
+++ b/packages/network/iw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iw"
-PKG_VERSION="5.9"
-PKG_SHA256="293a07109aeb7e36267cf59e3ce52857e9ffae3a6666eb8ac77894b1839fe1f2"
+PKG_VERSION="5.16"
+PKG_SHA256="4c44e42762f903f9094ba5a598998c800a97a62afd6fd31ec1e0a799e308659c"
 PKG_LICENSE="PUBLIC_DOMAIN"
 PKG_SITE="http://wireless.kernel.org/en/users/Documentation/iw"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="1.18"
-PKG_SHA256="0225ab81579f027e0fcbf255517f432fcf355d14f3645c36813c71a441dfab55"
+PKG_VERSION="1.20"
+PKG_SHA256="7d51e2ccabe7c500e44061ac725dbd4f6b0fb518b5e3de1681063d0f15d3050f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- iw: update to 5.16
  - https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/log/
  - update 5.9 to 5.16
- iwd: update to 1.20
  - https://git.kernel.org/pub/scm/network/wireless/iwd.git/log/
  - **ver 1.20:**
  -  Fix issue with handling Hotspot 2.0 requirements.
  -  Add support for evict_nocarrier setting during roaming.
  -  Add support for experimental NetworkConfigurationAgent API.
  - **ver 1.19:**
  -  Fix issue with handling OCV if offloading is supported.
  -  Fix issue with handling SA Query on channel switch event.
  - Fix issue with starting FT-over-DS actions after roaming.
  -  Add support for OWE transition networks.
  -  Add support for extended key IDs.