### PR TITLE
mesa GRAPHIC_DRIVERS: delete classic drivers (DRI)

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -14,7 +14,6 @@ get_graphicdrivers() {
 
   # set defaults
   GALLIUM_DRIVERS=""
-  DRI_DRIVERS=""
   XORG_DRIVERS=""
   LLVM_SUPPORT="no"
   COMPOSITE_SUPPORT="no"
@@ -23,7 +22,7 @@ get_graphicdrivers() {
   V4L2_SUPPORT="no"
 
   if [ "${GRAPHIC_DRIVERS}" = "all" ]; then
-    GRAPHIC_DRIVERS="crocus iris i915 i965 r200 r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
+    GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "crocus"; then
@@ -48,14 +47,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "i915"; then
-    DRI_DRIVERS+=" i915"
-    XORG_DRIVERS+=" intel"
-    COMPOSITE_SUPPORT="yes"
-    VAAPI_SUPPORT="yes"
-  fi
-
-  if listcontains "${GRAPHIC_DRIVERS}" "i965"; then
-    DRI_DRIVERS+=" i965"
+    GALLIUM_DRIVERS+=" i915"
     XORG_DRIVERS+=" intel"
     COMPOSITE_SUPPORT="yes"
     VAAPI_SUPPORT="yes"
@@ -90,12 +82,6 @@ get_graphicdrivers() {
   if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
     GALLIUM_DRIVERS+=" kmsro panfrost"
     V4L2_SUPPORT="yes"
-  fi
-
-  if listcontains "${GRAPHIC_DRIVERS}" "r200"; then
-    DRI_DRIVERS+=" r200"
-    XORG_DRIVERS+=" ati"
-    COMPOSITE_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "r300"; then
@@ -144,5 +130,4 @@ get_graphicdrivers() {
   # remove duplicate entries
   GALLIUM_DRIVERS="$(echo ${GALLIUM_DRIVERS} | xargs -n1 | sort -u | xargs)"
   XORG_DRIVERS="$(echo ${XORG_DRIVERS} | xargs -n1 | sort -u | xargs)"
-  DRI_DRIVERS="$(echo ${DRI_DRIVERS} | xargs -n1 | sort -u | xargs)"
 }

--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -17,7 +17,7 @@ get_graphicdrivers
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" nasm:host x265"
 
-  if listcontains "${GRAPHIC_DRIVERS}" "(crocus|iris|i915|i965)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "(crocus|i915|iris)"; then
     PKG_DEPENDS_TARGET+=" intel-vaapi-driver"
   fi
 fi

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -26,10 +26,10 @@ PKG_MESON_OPTS_TARGET="-Dlibkms=false \
                        -Dinstall-test-programs=false \
                        -Dudev=false"
 
-listcontains "${GRAPHIC_DRIVERS}" "(crocus|iris|i915|i965)" &&
+listcontains "${GRAPHIC_DRIVERS}" "(crocus|i915|iris)" &&
   PKG_MESON_OPTS_TARGET+=" -Dintel=true" || PKG_MESON_OPTS_TARGET+=" -Dintel=false"
 
-listcontains "${GRAPHIC_DRIVERS}" "(r200|r300|r600|radeonsi)" &&
+listcontains "${GRAPHIC_DRIVERS}" "(r300|r600|radeonsi)" &&
   PKG_MESON_OPTS_TARGET+=" -Dradeon=true" || PKG_MESON_OPTS_TARGET+=" -Dradeon=false"
 
 listcontains "${GRAPHIC_DRIVERS}" "radeonsi" &&

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -14,7 +14,7 @@ PKG_TOOLCHAIN="meson"
 
 get_graphicdrivers
 
-PKG_MESON_OPTS_TARGET="-Ddri-drivers=${DRI_DRIVERS// /,} \
+PKG_MESON_OPTS_TARGET="-Ddri-drivers= \
                        -Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
                        -Dgallium-xvmc=disabled \

--- a/packages/virtual/mediacenter/package.mk
+++ b/packages/virtual/mediacenter/package.mk
@@ -39,7 +39,7 @@ if [ "${MEDIACENTER}" = "kodi" ]; then
   fi
 
   get_graphicdrivers
-  if listcontains "${GRAPHIC_DRIVERS}" "(crocus|iris|i915|i965)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "(crocus|i915|iris)"; then
     PKG_DEPENDS_TARGET+=" intel-vaapi-driver media-driver"
   fi
 

--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -108,7 +108,7 @@
   # Windowmanager to use (fluxbox / none)
     WINDOWMANAGER="none"
 
-  # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
+  # Xorg Graphic drivers to use (all / r300,r600,nvidia)
     GRAPHIC_DRIVERS="mesa"
 
   # build and install remote support (yes / no)

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -43,9 +43,9 @@
   # Windowmanager to use (ratpoison / fluxbox / none)
     WINDOWMANAGER="none"
 
-  # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
+  # Xorg Graphic drivers to use (all / lima,panfrost)
   # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
+  # e.g. GRAPHIC_DRIVERS="lima panfrost"
     GRAPHIC_DRIVERS="lima panfrost"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)

--- a/projects/Generic/devices/Generic-legacy/options
+++ b/projects/Generic/devices/Generic-legacy/options
@@ -13,7 +13,7 @@
 # set the addon project
   ADDON_PROJECT="Generic"
 
-# Mesa 3D / Xorg Graphic drivers to use (all / crocus,i915,i965,iris,r200,r300,r600,radeonsi,nvidia,nvidia-legacy,vmware,virtio)
+# Mesa 3D / Xorg Graphic drivers to use (all / crocus,i915,iris,r300,r600,radeonsi,nvidia,nvidia-legacy,vmware,virtio)
 # Space separated list is supported,
-# e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
-  GRAPHIC_DRIVERS="r300 r600 radeonsi crocus iris i915 i965 nvidia nvidia-legacy vmware virtio"
+# e.g. GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi nvidia nvidia-legacy vmware virtio"
+  GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi nvidia nvidia-legacy vmware virtio"

--- a/projects/Generic/devices/Generic/options
+++ b/projects/Generic/devices/Generic/options
@@ -13,7 +13,7 @@
 # set the addon project
   ADDON_PROJECT="Generic"
 
-# Mesa 3D Graphic drivers to use (all / crocus,i915,i965,iris,r200,r300,r600,radeonsi,vmware,virtio)
+# Mesa 3D Graphic drivers to use (all / crocus,i915,iris,r300,r600,radeonsi,vmware,virtio)
 # Space separated list is supported,
-# e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi"
-  GRAPHIC_DRIVERS="r300 r600 radeonsi crocus iris i915 i965 vmware virtio"
+# e.g. GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"
+  GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"

--- a/projects/NXP/options
+++ b/projects/NXP/options
@@ -44,9 +44,9 @@
   # Windowmanager to use (ratpoison / fluxbox / none)
     WINDOWMANAGER="none"
 
-  # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
+  # Xorg Graphic drivers to use (all / etnaviv)
   # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
+  # e.g. GRAPHIC_DRIVERS="etnaviv"
     GRAPHIC_DRIVERS="etnaviv"
 
   # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)

--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -72,9 +72,9 @@
   # Windowmanager to use (ratpoison / fluxbox / none)
     WINDOWMANAGER="none"
 
-  # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia,nouveau)
+  # Xorg Graphic drivers to use (all / freedreno)
   # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia nouveau"
+  # e.g. GRAPHIC_DRIVERS="freedreno"
     GRAPHIC_DRIVERS="freedreno"
 
   # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap / libamcodec)

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -50,9 +50,9 @@
   # Windowmanager to use (fluxbox / none)
     WINDOWMANAGER="none"
 
-  # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,nvidia)
+  # Xorg Graphic drivers to use (all / lima,panfrost)
   # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeonsi nvidia"
+  # e.g. GRAPHIC_DRIVERS="lima panfrost"
     GRAPHIC_DRIVERS=""
 
   # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)


### PR DESCRIPTION
mesa GRAPHIC_DRIVERS: delete classic drivers (DRI) 
- in preparation for Mesa 22.0.0
- this removes the classic Mesa drivers.
  - https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/10153
- mesa GRAPHIC_DRIVERS: 
  - remove classic DRI drivers (i915, i965, r100, r200, nouveau)
  - add the i915g driver

The following **gallium** drivers are available in mesa
- https://gitlab.freedesktop.org/mesa/mesa/-/tree/main/src/gallium/drivers
- Enable the i915 gallium driver
- The i965 driver has been replaced with the crocus driver
- nouveau is available as a gallium driver
- r200 has NO replacement

#5885 added the crocus driver to Generic and Generic-legacy