### PR TITLE
[le11] Add RTL88x2BU driver for wifi dongle Archer T3U.

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -48,7 +48,7 @@
 # for a list of additional drivers see packages/linux-drivers
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8812AU"
+  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8812AU RTL88x2BU"
 
 # Default size of system partition, in MB, eg. 512
   SYSTEM_SIZE=512

--- a/packages/linux-drivers/RTL88x2BU/package.mk
+++ b/packages/linux-drivers/RTL88x2BU/package.mk
@@ -1,0 +1,26 @@
+PKG_NAME="RTL88x2BU"
+PKG_VERSION="439c7dbd9e43acd91d5704a50b68647716c52505"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/cilynx/rtl88x2bu"
+PKG_URL="https://github.com/cilynx/rtl88x2bu/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_LONGDESC="Realtek RTL88x2BU Linux driver"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make V=1 \
+       ARCH=$TARGET_KERNEL_ARCH \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
+       CONFIG_POWER_SAVING=n
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+    cp *.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME
+}


### PR DESCRIPTION
Add driver for wi-fi dongle TP-Link Archer T3U. Tested with RaspberryPi 4 and it's working.

The wi-fi dongle is more stable than native RaspberryPi 4 wi-fi.