### PR TITLE
image: calculate number of tracks based on SYSTEM_SIZE

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -10,6 +10,13 @@ unset _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL _DEBUG_DEPENDS_LIST _DEBUG_PACK
 . config/multithread
 . config/show_config
 
+# Check if SYSTEM_SIZE is multipe of 32
+if [ ! $(( ${SYSTEM_SIZE} % 32 )) -eq 0 ] ; then
+  echo "Invalid value for SYSTEM_SIZE (${SYSTEM_SIZE}). Use value which is multiple of 32."
+  echo "Suggested value based on current SYSTEM_SIZE: "$(( ( ${SYSTEM_SIZE} / 32 + 1) * 32 ))
+  exit 1
+fi
+
 # Validate UBOOT_SYSTEM if it is specified
 if [ "${BOOTLOADER}" = "u-boot" -a -n "${DEVICE}" ]; then
   if [ -z "${UBOOT_SYSTEM}" ]; then

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -98,7 +98,7 @@ fi
 echo "image: creating filesystem on part1..."
 OFFSET=$(( ${SYSTEM_PART_START} * 512 ))
 HEADS=4
-TRACKS=32
+TRACKS=$(( ${SYSTEM_SIZE} / ${HEADS} / 4 ))
 SECTORS=$(( ${SYSTEM_SIZE} * 1024 * 1024 / 512 / ${HEADS} / ${TRACKS} ))
 
 shopt -s expand_aliases  # enables alias expansion in script


### PR DESCRIPTION
In case `SYSTEM_SIZE` is >= 1024, `mcopy`/`mmd` fail to copy files / create folders in the FAT32 partition with a message

     The devil is in the details: zero number of heads or sectors

The image is still created, but the files/folders are missing in the image. Another workaround is adding

     export MTOOLS_SKIP_CHECK=1

before any mtools commands are called. In such case correct image is created.

I added a check to verify, that `SYSTEM_SIZE` is multiple of 32, so there are no odd results. *16 would be fine as well, but I find 32 more of a round value than 16 :-)*