### PR TITLE
kodi: update to latest

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="aff7e96baad0cadabb378817a078166cc2031cdf"
-PKG_SHA256="f5136e1e225c134c3e58680a2c864776927d3181d564d1418e7a27913e1fe9b8"
+PKG_VERSION="08b7599d63e063545e34a24bb17fc3738cd4dde7"
+PKG_SHA256="b673a0a0e0db95ead29387b3c1273e77de160b69ff39c18f040c142614314e6a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
@@ -3,7 +3,7 @@ Subject: disable online check
 ---
 --- a/xbmc/GUIInfoManager.cpp
 +++ b/xbmc/GUIInfoManager.cpp
-@@ -1774,7 +1774,6 @@ const infomap system_labels[] = {{"hasne
+@@ -1782,7 +1782,6 @@ const infomap system_labels[] = {{"hasne
                                   {"currentcontrol", SYSTEM_CURRENT_CONTROL},
                                   {"currentcontrolid", SYSTEM_CURRENT_CONTROL_ID},
                                   {"dvdlabel", SYSTEM_DVD_LABEL},
@@ -21,7 +21,7 @@ Subject: disable online check
    m_info.videoEncoder      = GetVideoEncoder();
    m_info.cpuFrequency =
        StringUtils::Format("{:4.0f} MHz", CServiceBroker::GetCPUInfo()->GetCPUFrequency());
-@@ -1011,9 +1010,7 @@ int CSysInfo::GetXbmcBitness(void)
+@@ -1016,9 +1015,7 @@ int CSysInfo::GetXbmcBitness(void)
  
  bool CSysInfo::HasInternet()
  {

--- a/packages/mediacenter/kodi/patches/kodi-100.09-use-a-wrapper-to-setup-service-addons.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.09-use-a-wrapper-to-setup-service-addons.patch
@@ -81,10 +81,10 @@
    if (GetAddon(id, addon, ADDON_UNKNOWN, OnlyEnabled::NO) && addon != NULL)
    {
 +    ADDON::LEAddonHook(addon, ADDON::LE_ADDON_DISABLED);
-     CServiceBroker::GetEventLog().Add(EventPtr(new CAddonManagementEvent(addon, 24141)));
-   }
- 
-@@ -874,6 +875,7 @@ bool CAddonMgr::EnableSingle(const std::
+     auto eventLog = CServiceBroker::GetEventLog();
+     if (eventLog)
+       eventLog->Add(EventPtr(new CAddonManagementEvent(addon, 24141)));
+@@ -880,6 +881,7 @@ bool CAddonMgr::EnableSingle(const std::
    if (!m_database.EnableAddon(id))
      return false;
    m_disabled.erase(id);

--- a/packages/mediacenter/kodi/patches/kodi-100.26-disable-internal-texturepacker.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.26-disable-internal-texturepacker.patch
@@ -1,0 +1,13 @@
+--- a/cmake/modules/FindTexturePacker.cmake
++++ b/cmake/modules/FindTexturePacker.cmake
+@@ -52,10 +52,6 @@ if(NOT TARGET TexturePacker::TexturePack
+       endif()
+     endif()
+ 
+-    # Ship TexturePacker only on Linux and FreeBSD
+-    if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-      set(INTERNAL_TEXTUREPACKER_INSTALLABLE TRUE)
+-    endif()
+ 
+     # Use it during build if build architecture is same as host
+     # (not cross-compiling) and TEXTUREPACKER_EXECUTABLE is not found

--- a/packages/mediacenter/kodi/patches/kodi-995.01-fix-missing-wayland-scanner-pkg-config.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.01-fix-missing-wayland-scanner-pkg-config.patch
@@ -7,11 +7,9 @@ Subject: [PATCH] cmake: allow providing WAYLANDPP_SCANNER in a cross compile
  cmake/modules/FindWaylandpp.cmake | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/cmake/modules/FindWaylandpp.cmake b/cmake/modules/FindWaylandpp.cmake
-index ba229d7ffcb3f..b874cd0ba3218 100644
 --- a/cmake/modules/FindWaylandpp.cmake
 +++ b/cmake/modules/FindWaylandpp.cmake
-@@ -22,6 +22,8 @@ pkg_check_modules(PC_WAYLANDPP_SCANNER wayland-scanner++ QUIET)
+@@ -22,6 +22,8 @@ pkg_check_modules(PC_WAYLANDPP_SCANNER w
  
  if(PC_WAYLANDPP_SCANNER_FOUND)
    pkg_get_variable(PC_WAYLANDPP_SCANNER wayland-scanner++ wayland_scannerpp)


### PR DESCRIPTION
- latest kodi 20
- added workaround for ?hack introduced at https://github.com/xbmc/xbmc/pull/20413
- supersedes https://github.com/LibreELEC/LibreELEC.tv/pull/5872
if a better solution is found  the workaround could be replaced, for now it looks working


build + runs for generic