### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.flac"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="3be387d383817879496ec6ebcb3767ae5d97b5a019df05dad8d0ecd6a8a64dad"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="1bbb253ce22ba2c253f43f5917e2a5602f4e429313278f827b9157328f18e2b8"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.lame"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="f0e51eced02f9d0fcb8d301907b33d94d111ca8034c4a26290af18a6f26bc92a"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="81d71fcb8674be3438a4adaf888163e683a6cfcf50dd822d038fc973f9e01eb5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.vorbis"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="db5bba8e7b95de70f8db21f096d7a3590210f188570ac8fd31cdbb9efa5f5bc1"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="d1a04ce334ea73a881787314c9b6f91dba62eaecbae0e314d9c88ccc16b4d224"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.wav/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.wav/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.wav"
-PKG_VERSION="20.0.0-Nexus"
-PKG_SHA256="b5a7f4e13b84abefe5b22411897624af908e0be8b1e121dd1f84f1a2ff056b90"
+PKG_VERSION="20.1.0-Nexus"
+PKG_SHA256="36605fd401a21c2fc17f32b47d6508681c1e82d69140026a309b1a46dea7cf6a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- audioencoder.flac: update 20.0.0-Nexus to 20.1.0-Nexus
- audioencoder.lame: update 20.1.0-Nexus to 20.2.0-Nexus
- audioencoder.vorbis: update 20.0.0-Nexus to 20.1.0-Nexus
- audioencoder.wav: update 20.0.0-Nexus to 20.1.0-Nexus