### PR TITLE
[le11] use Meson native build for package:host

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -485,10 +485,16 @@ pkgconfig = '$PKG_CONFIG'
 llvm-config = '$TOOLCHAIN/bin/llvm-config-host'
 libgcrypt-config = '$SYSROOT_PREFIX/usr/bin/libgcrypt-config'
 
+[build_machine]
+system = 'linux'
+cpu_family = '${MACHINE_HARDWARE_NAME}'
+cpu = '${MACHINE_HARDWARE_CPU}'
+endian = 'little'
+
 [host_machine]
 system = 'linux'
-cpu_family = '$TARGET_ARCH'
-cpu = '$TARGET_SUBARCH'
+cpu_family = '${MACHINE_HARDWARE_NAME}'
+cpu = '${MACHINE_HARDWARE_CPU}'
 endian = 'little'
 
 [built-in options]
@@ -516,6 +522,12 @@ strip = '$TARGET_STRIP'
 pkgconfig = '$PKG_CONFIG'
 llvm-config = '$TOOLCHAIN/bin/llvm-config-host'
 libgcrypt-config = '$SYSROOT_PREFIX/usr/bin/libgcrypt-config'
+
+[build_machine]
+system = 'linux'
+cpu_family = '${MACHINE_HARDWARE_NAME}'
+cpu = '${MACHINE_HARDWARE_CPU}'
+endian = 'little'
 
 [host_machine]
 system = 'linux'

--- a/config/optimize
+++ b/config/optimize
@@ -65,6 +65,7 @@ if [ -z "$HOST_LIBDIR" ]; then
   HOST_LIBDIR="$TOOLCHAIN/lib"
 
   # ubuntu/debian specific "multiarch support"
+  export MACHINE_HARDWARE_CPU="$(uname -p)"
   export MACHINE_HARDWARE_NAME="$(uname -m)"
   export MACHINE_HARDWARE_PLATFORM="$(uname -i)"
   FAMILY_TRIPLET=$($LOCAL_CC -print-multiarch)

--- a/scripts/build
+++ b/scripts/build
@@ -264,8 +264,8 @@ else
       ;;
     "meson:host")
       create_meson_conf_host ${TARGET} ${MESON_CONF}
-      echo "Executing (host): meson ${HOST_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_HOST} ${PKG_MESON_SCRIPT%/*}" | tr -s " "
-      meson ${HOST_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_HOST} ${PKG_MESON_SCRIPT%/*}
+      echo "Executing (host): meson ${HOST_MESON_OPTS} --native-file=${MESON_CONF} ${PKG_MESON_OPTS_HOST} ${PKG_MESON_SCRIPT%/*}" | tr -s " "
+      meson ${HOST_MESON_OPTS} --native-file=${MESON_CONF} ${PKG_MESON_OPTS_HOST} ${PKG_MESON_SCRIPT%/*}
       ;;
     "meson:init")
       create_meson_conf_target ${TARGET} ${MESON_CONF}
@@ -274,8 +274,8 @@ else
       ;;
     "meson:bootstrap")
       create_meson_conf_host ${TARGET} ${MESON_CONF}
-      echo "Executing (bootstrap): meson ${BOOTSTRAP_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_BOOTSTRAP} ${PKG_MESON_SCRIPT%/*}" | tr -s " "
-      meson ${BOOTSTRAP_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_BOOTSTRAP} ${PKG_MESON_SCRIPT%/*}
+      echo "Executing (bootstrap): meson ${BOOTSTRAP_MESON_OPTS} ----native-file=${MESON_CONF} ${PKG_MESON_OPTS_BOOTSTRAP} ${PKG_MESON_SCRIPT%/*}" | tr -s " "
+      meson ${BOOTSTRAP_MESON_OPTS} --native-file=${MESON_CONF} ${PKG_MESON_OPTS_BOOTSTRAP} ${PKG_MESON_SCRIPT%/*}
       ;;
 
     # cmake builds with ninja


### PR DESCRIPTION
Meson 0.49 introduduced an option for describing [native environments](https://mesonbuild.com/Native-environments.html) which allows to build `package:host` with native args & `package:target` with cross compile args. Currently all packages were build as "cross compile" which results in build failures if `meson.build` files use statements like `if meson.is_cross_build()`  e.g.: https://gitlab.freedesktop.org/wayland/wayland/-/issues/256

- added `[build_machine]` section to host & target meson conf
- updated the `[host_machine]` section for meson conf to match build machine cpu
- added `MACHINE_HARDWARE_CPU` determined by `uname -p` 
- updated build script to load meson host conf per `--native-file` instead `--cross-file`

Build tested for Generic & RK3399, runtested on Intel APL (wayland build)

### wayland:host
```
BUILD      wayland (host)
    TOOLCHAIN      meson (auto-detect)
Executing (host): meson --prefix=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain --bindir=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin --sbindir=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/sbin --sysconfdir=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/etc --libdir=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/lib --libexecdir=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/lib --localstatedir=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/var --buildtype=plain --native-file=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/build/wayland-1.19.0/.x86_64-linux-gnu/meson.conf -Dlibraries=false -Dscanner=true -Ddocumentation=false -Ddtd_validation=false /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/build/wayland-1.19.0
The Meson build system
Version: 0.59.2
Source dir: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/build/wayland-1.19.0
Build dir: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/build/wayland-1.19.0/.x86_64-linux-gnu
Build type: native build
Project name: wayland
Project version: 1.19.0
C compiler for the host machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/host-gcc (gcc 9.3.0 "gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0")
C linker for the host machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/host-gcc ld.bfd 2.34
C++ compiler for the host machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/host-g++ (gcc 9.3.0 "g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0")
C++ linker for the host machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/host-g++ ld.bfd 2.34
Host machine cpu family: x86_64
Host machine cpu: x86_64
```

### wayland:target
```
BUILD      wayland (target)
    TOOLCHAIN      meson (auto-detect)
Executing (target): meson --prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --libdir=/usr/lib --libexecdir=/usr/lib --localstatedir=/var --buildtype=plain -Dstrip=true --cross-file=/build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/build/wayland-1.19.0/.x86_64-libreelec-linux-gnu/meson.conf -Dlibraries=true -Dscanner=false -Ddocumentation=false -Ddtd_validation=false /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/build/wayland-1.19.0
The Meson build system
Version: 0.59.2
Source dir: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/build/wayland-1.19.0
Build dir: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/build/wayland-1.19.0/.x86_64-libreelec-linux-gnu
Build type: cross build
Project name: wayland
Project version: 1.19.0
C compiler for the host machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc (gcc 10.3.0 "x86_64-libreelec-linux-gnu-gcc-10.3.0 (GCC) 10.3.0")
C linker for the host machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc ld.bfd 2.35.1
C++ compiler for the host machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ (gcc 10.3.0 "x86_64-libreelec-linux-gnu-g++-10.3.0 (GCC) 10.3.0")
C++ linker for the host machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ ld.bfd 2.35.1
C compiler for the build machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/host-gcc (gcc 9.3.0 "gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0")
C linker for the build machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/host-gcc ld.bfd 2.34
C++ compiler for the build machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/host-g++ (gcc 9.3.0 "g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0")
C++ linker for the build machine: /build/LibreELEC-RR/build.LibreELEC-wayland.x86_64-11.0-devel/toolchain/bin/host-g++ ld.bfd 2.34
Build machine cpu family: x86_64
Build machine cpu: x86_64
Host machine cpu family: x86_64
Host machine cpu: x86_64
Target machine cpu family: x86_64
Target machine cpu: x86_64
```