### PR TITLE
add nouveau - opensource nvidia driver

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -22,7 +22,7 @@ get_graphicdrivers() {
   V4L2_SUPPORT="no"
 
   if [ "${GRAPHIC_DRIVERS}" = "all" ]; then
-    GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi nvidia nvidia-legacy vmware virtio vc4"
+    GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi nouveau nvidia nvidia-legacy vmware virtio vc4"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "crocus"; then
@@ -67,6 +67,12 @@ get_graphicdrivers() {
 
   if listcontains "${GRAPHIC_DRIVERS}" "mali"; then
     V4L2_SUPPORT="yes"
+  fi
+
+  if listcontains "${GRAPHIC_DRIVERS}" "nouveau"; then
+    GALLIUM_DRIVERS+=" nouveau"
+    XORG_DRIVERS+=" nouveau"
+    VDPAU_SUPPORT="yes"
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "nvidia"; then

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -15,7 +15,6 @@ PKG_TOOLCHAIN="meson"
 get_graphicdrivers
 
 PKG_MESON_OPTS_TARGET="-Dlibkms=false \
-                       -Dnouveau=false \
                        -Domap=false \
                        -Dexynos=false \
                        -Dtegra=false \
@@ -46,6 +45,9 @@ listcontains "${GRAPHIC_DRIVERS}" "freedreno" &&
 
 listcontains "${GRAPHIC_DRIVERS}" "etnaviv" &&
   PKG_MESON_OPTS_TARGET+=" -Detnaviv=true" || PKG_MESON_OPTS_TARGET+=" -Detnaviv=false"
+
+listcontains "${GRAPHIC_DRIVERS}" "nouveau" &&
+  PKG_MESON_OPTS_TARGET+=" -Dnouveau=true" || PKG_MESON_OPTS_TARGET+=" -Dnouveau=false"
 
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -74,6 +74,11 @@ makeinstall_target() {
   # brcm pcie firmware is only needed by x86_64
   [ "${TARGET_ARCH}" != "x86_64" ] && rm -fr ${FW_TARGET_DIR}/brcm/*-pcie.*
 
+  # add nvidia firmware for nouveau
+  if listcontains "${GRAPHIC_DRIVERS}" "nouveau"; then
+    cp -Lrv ${PKG_FW_SOURCE}/nvidia ${FW_TARGET_DIR}/
+  fi
+
   # Cleanup - which may be project or device specific
   find_file_path scripts/cleanup.sh && ${FOUND_PATH} ${FW_TARGET_DIR} || true
 }

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -146,6 +146,14 @@ pre_make_target() {
     ${PKG_BUILD}/scripts/config --disable CONFIG_WIREGUARD
   fi
 
+  # enable nouveau driver when required
+  if listcontains "${GRAPHIC_DRIVERS}" "nouveau"; then
+    ${PKG_BUILD}/scripts/config --enable CONFIG_DRM_NOUVEAU
+    ${PKG_BUILD}/scripts/config --enable CONFIG_DRM_NOUVEAU_BACKLIGHT
+    ${PKG_BUILD}/scripts/config --set-val CONFIG_NOUVEAU_DEBUG 5
+    ${PKG_BUILD}/scripts/config --set-val CONFIG_NOUVEAU_DEBUG_DEFAULT 3
+  fi
+
   if [ "${TARGET_ARCH}" = "x86_64" ]; then
     # copy some extra firmware to linux tree
     mkdir -p ${PKG_BUILD}/external-firmware

--- a/packages/x11/driver/xf86-video-nouveau/package.mk
+++ b/packages/x11/driver/xf86-video-nouveau/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="xf86-video-nouveau"
+PKG_VERSION="3ee7cbca8f9144a3bb5be7f71ce70558f548d268"
+PKG_SHA256="941f1ce75a1dba0baf757c0add19898657886c2f826a76056abf4972c41f1a66"
+PKG_ARCH="x86_64"
+PKG_LICENSE="OSS"
+PKG_SITE="https://nouveau.freedesktop.org/"
+PKG_URL="https://gitlab.freedesktop.org/xorg/driver/${PKG_NAME}/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_DEPENDS_TARGET="toolchain libXcomposite libXxf86vm libXdamage libdrm util-macros systemd xorg-server"
+PKG_LONGDESC="Open-source Xorg graphics driver for Nvidia graphics."
+PKG_TOOLCHAIN="autotools"
+
+PKG_CONFIGURE_OPTS_TARGET="--with-xorg-module-dir=${XORG_PATH_MODULES}"


### PR DESCRIPTION
I am not sure if it is relevant for LibreELEC, but maybe for the Generic (non-legacy) image.

I did not test the legacy image, as I don't have nvidia card, but @gouchi tested the non-legacy image (many thanks!) and the legacy image is using official nvidia driver anyway (so maybe `XORG_DRIVER+=" nouveau"` and the package `xf86-video-nouveau` can be removed?). Also not sure if `nouveau` AND `nvidia` should be included in `GRAPHIC_DRIVERS` at the same time (e.g. when `GRAPHIC_DRIVERS="all"` is used - not tested).

To build image with `nouveau` just add `nouveau` to the target `GRAPHIC_DRIVERS` list. My test image is [here](https://nightly.builds.lakka.tv/members/vudiq/LibreELEC-master-nouveau/).

Thank you for your consideration. Feel free to request changes or even reject, when not relevant for you :-)
