### PR TITLE
Update Intel media-driver and libdrm

### DIFF
--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.107"
-PKG_SHA256="c554cef03b033636a975543eab363cc19081cb464595d3da1ec129f87370f888"
+PKG_VERSION="2.4.109"
+PKG_SHA256="629352e08c1fe84862ca046598d8a08ce14d26ab25ee1f4704f993d074cb7f26"
 PKG_LICENSE="GPL"
 PKG_SITE="http://dri.freedesktop.org"
 PKG_URL="http://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="21.4.1"
-PKG_SHA256="4cd9f2b4da82883a8ed4fb45ba8f186c32941b5f4f3b7d61f2b2b8c19e634281"
+PKG_VERSION="21.4.2"
+PKG_SHA256="d62cc04254f57c62149cd8bc135e3562b8dc05c0815362b9a83adf200522e777"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
Update packages

- media-driver: update to 21.4.2
- libdrm: update to 2.4.109 


```
=== tested on ===
Generic.x86_64-devel-20211126090242-6168d44
Linux nuc11 5.15.5 #1 SMP Fri Nov 26 08:42:07 UTC 2021 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.101) Git:08b7599d63e063545e34a24bb17fc3738cd4dde7). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2021-11-26 by GCC 10.3.0 for Linux x86 64-bit version 5.15.5 (331525)
Running on LibreELEC (heitbaum): devel-20211126090242-6168d44 11.0, kernel: Linux x86 64-bit version 5.15.5
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0041.2021.0811.1505 08/11/2021
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 21.3.0
libva info: VA-API version 1.13.0
vainfo: VA-API version: 1.13 (libva 2.13.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 21.4.2 (6168d446a6)
```