### PR TITLE
[le10] kodi-binary-addons: add pvr.plutotv

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.plutotv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.plutotv/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pvr.plutotv"
+PKG_VERSION="19.0.0-Matrix"
+PKG_SHA256="0b85c5c9583239bcecccccc2c43fc6d604bf5a4e4304238c8635410823ab8ae3"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-pvr/pvr.plutotv"
+PKG_URL="https://github.com/kodi-pvr/pvr.plutotv/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform rapidjson"
+PKG_SECTION=""
+PKG_SHORTDESC="pvr.plutotv"
+PKG_LONGDESC="pvr.plutotv"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.pvrclient"


### PR DESCRIPTION
See #5933

This PR adds the new pvr plugin pvr.plutotv.

See: https://github.com/kodi-pvr/pvr.plutotv

It is now official kodi addon: https://github.com/xbmc/repo-binary-addons/pull/152