### PR TITLE
config/functions: fix file get_handler_support with manual toolchain

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -218,7 +218,7 @@ check_toolchain_config() {
     toolchain="CMAKE"
   fi
   for var in "${!PKG_@}"; do
-    if [[ "${var}" =~ INSTALL_OPTS_ || "${var}" =~ _MAKE_OPTS ]]; then
+    if [[ "${var}" =~ INSTALL_OPTS_ || "${var}" =~ _MAKE_OPTS || "${var}" =~ _TAR_COPY_OPTS ]]; then
       continue
     fi
     if [[ "${var}" =~ _OPTS_${target}$ \


### PR DESCRIPTION
Currently building a package with

GET_HANDLER_SUPPORT="file"
PKG_URL="file:///some_path_to_file_with_sources"

throws an error

ERROR: using manual toolchain but PKG_TAR_COPY_OPTS is configured.