### PR TITLE
linux config Generic: add CONFIG_I2C_HID_CORE to fix I2C touchpad regression

### DIFF
--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.0 Kernel Configuration
+# Linux/x86 5.15.5 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-libreelec-linux-gnu-gcc-10.3.0 (GCC) 10.3.0"
 CONFIG_CC_IS_GCC=y
@@ -4949,8 +4949,10 @@ CONFIG_USB_HIDDEV=y
 #
 # I2C HID support
 #
-# CONFIG_I2C_HID_ACPI is not set
+CONFIG_I2C_HID_ACPI=y
 # end of I2C HID support
+
+CONFIG_I2C_HID_CORE=y
 
 #
 # Intel ISH HID support
@@ -5822,7 +5824,6 @@ CONFIG_FS_POSIX_ACL=y
 CONFIG_EXPORTFS=y
 # CONFIG_EXPORTFS_BLOCK_OPS is not set
 CONFIG_FILE_LOCKING=y
-CONFIG_MANDATORY_FILE_LOCKING=y
 # CONFIG_FS_ENCRYPTION is not set
 # CONFIG_FS_VERITY is not set
 CONFIG_FSNOTIFY=y
@@ -5875,9 +5876,6 @@ CONFIG_EXFAT_FS=m
 CONFIG_EXFAT_DEFAULT_IOCHARSET="utf8"
 # CONFIG_NTFS_FS is not set
 # CONFIG_NTFS3_FS is not set
-# CONFIG_NTFS3_64BIT_CLUSTER is not set
-# CONFIG_NTFS3_LZX_XPRESS is not set
-# CONFIG_NTFS3_FS_POSIX_ACL is not set
 # end of DOS/FAT/EXFAT/NT Filesystems
 
 #


### PR DESCRIPTION
CONFIG_I2C_HID_CORE was removed by accident with 221bd5a397d68e65cd23c39fa74f2bf8a0c2bde0 and my I2C connected touchpad is not detected any more.

Add CONFIG_I2C_HID_CORE and CONFIG_I2C_HID_ACPI to let the touchpad work again.

Other changes are result of `make oldconfig`.