### PR TITLE
dbussy: update to a694e3b, status cleanup fix

### DIFF
--- a/packages/python/system/dbussy/package.mk
+++ b/packages/python/system/dbussy/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dbussy"
-PKG_VERSION="1.3"
-PKG_SHA256="30a96caddcbbe7ef9e4f506c01c2d19f529cdaae6d3dac759c103b20e49641fe"
+PKG_VERSION="a694e3b525e988dc5362f2278e2aacdf06b3a179"   # 2021-11-07
+PKG_SHA256="862df448c4bccb3f08e21ed855e5c825c241d2071e923245d7d969dc2c2451f7"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://gitlab.com/ldo/dbussy"
-PKG_URL="https://github.com/ldo/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/ldo/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain Python3 dbus"
 PKG_LONGDESC="DBussy is a wrapper around libdbus, written in pure Python"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
Test the dbussy improvement/fix triggered by LibreELEC/service.libreelec.settings#245 in nightlies.

I've seen no issues while using it in my LE10/LE11 Generic development images.
