### PR TITLE
xorg-intel-gpu-tools: upstream fix from meson 0.60.0 build

### DIFF
--- a/packages/debug/xorg-intel-gpu-tools/patches/xorg-intel-gpu-tools-1-26-meson-build.patch
+++ b/packages/debug/xorg-intel-gpu-tools/patches/xorg-intel-gpu-tools-1-26-meson-build.patch
@@ -1,0 +1,37 @@
+From patchwork Thu Oct 28 08:05:31 2021
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Subject: [i-g-t,1/1] lib/meson.build: Fix underscorify call
+From: Petri Latvala <petri.latvala@intel.com>
+X-Patchwork-Id: 461649
+Message-Id: <20211028080531.8223-1-petri.latvala@intel.com>
+To: igt-dev@lists.freedesktop.org
+Cc: Petri Latvala <petri.latvala@intel.com>,
+	Arkadiusz Hiler <arek@hiler.eu>
+Date: Thu, 28 Oct 2021 11:05:31 +0300
+
+f.underscorify() is correct, f.underscorify(f) is an error that later
+meson versions don't like at all.
+
+Closes: https://gitlab.freedesktop.org/drm/igt-gpu-tools/-/issues/107
+Fixes: 588555f77909 ("lib/i915: Extract helpers for determining scheduler capabilities")
+Cc: Arkadiusz Hiler <arek@hiler.eu>
+Signed-off-by: Petri Latvala <petri.latvala@intel.com>
+---
+ lib/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/meson.build b/lib/meson.build
+index c3080fc8..297b0ad2 100644
+--- a/lib/meson.build
++++ b/lib/meson.build
+@@ -155,7 +155,7 @@ lib_version = vcs_tag(input : 'version.h.in', output : 'version.h',
+ 
+ lib_intermediates = []
+ foreach f: lib_sources
+-    name = f.underscorify(f)
++    name = f.underscorify()
+     lib = static_library('igt-' + name,
+ 	[ f, lib_version ],
+ 	include_directories: inc,


### PR DESCRIPTION
Upstream patch to fix meson builds.