### PR TITLE
crust: use host-gcc from toolchain not cc

### DIFF
--- a/packages/tools/crust/patches/fix-cc.patch
+++ b/packages/tools/crust/patches/fix-cc.patch
@@ -1,0 +1,11 @@
+--- a/Makefile	2021-11-04 02:18:49.000000000 +0000
++++ b/Makefile	2021-12-07 11:30:53.188269898 +0000
+@@ -8,7 +8,7 @@
+ TGT		 = $(OBJ)/scp
+ 
+ BUILDAR		 = ar
+-BUILDCC		 = cc
++BUILDCC		 = host-gcc
+ 
+ HOST_COMPILE	?= aarch64-linux-musl-
+ HOSTAR		 = $(HOST_COMPILE)gcc-ar


### PR DESCRIPTION
### Fix the crust build on minimal Ubuntu 20.04 image
- `PROJECT=Allwinner ARCH=arm DEVICE=A64 make image`

crust build fails when cc link is missing (e.g. minimal Ubuntu 20.04)
use host-gcc from the toolchain instead.
addition of the patch fixes the following error.

BUILD      crust (target)
    TOOLCHAIN      manual
...
  HOSTCC  build/3rdparty/kconfig/conf.o
/bin/sh: 1: exec: cc: not found
make[1]: *** [Makefile:170: build/3rdparty/kconfig/conf.o] Error 127
...

### Potential alternative patch (upstreamable) would be:
```
-BUILDCC		 = cc
+BUILDCC		 ?= cc
```
And update the `package.mk` to override **BUILDCC**