### PR TITLE
nss and nspr: update packages

### DIFF
--- a/packages/security/nspr/package.mk
+++ b/packages/security/nspr/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nspr"
-PKG_VERSION="4.30"
+PKG_VERSION="4.32"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/svn/general/nspr.html"
 PKG_DEPENDS_HOST="ccache:host"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.64"
-PKG_SHA256="2ff04af68135b5777aed558fe8a895d6cf855cbbdef6738d87f1ac3c8cbb2785"
+PKG_VERSION="3.73"
+PKG_SHA256="07a9e5b70f121a62706140d4cacc3006d3efb869da40f3a2bf7a65d37847f4d9"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
- nspr: update to 4.32
  - https://groups.google.com/a/mozilla.org/g/dev-tech-crypto/c/4eyMP8SrUGk/m/Oywjzs4SAAAJ
  - https://groups.google.com/a/mozilla.org/g/dev-tech-crypto/c/M01xJ10PkAc/m/S2FWp3KHAQAJ
- nss: update to 3.73
  - https://groups.google.com/a/mozilla.org/g/dev-tech-crypto/c/vy9284s8APM
  - https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
  - https://firefox-source-docs.mozilla.org/security/nss/releases/index.html