### PR TITLE
bluez: install empty bluez.pc

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -64,6 +64,10 @@ post_makeinstall_target() {
 
   # bluez looks in /etc/firmware/
     ln -sf /usr/lib/firmware ${INSTALL}/etc/firmware
+
+  # pulseaudio checks for bluez via pkgconfig but lib is not actually needed
+    sed -i 's/-lbluetooth//g' ${PKG_BUILD}/lib/bluez.pc
+    cp -P ${PKG_BUILD}/lib/bluez.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig
 }
 
 post_install() {


### PR DESCRIPTION
bluez.pc is needed to convience pulseaudio that bluez is present. Another alternative would be to enable library, but it's not needed and it would increase size for around 186 KiB on ARM.