### PR TITLE
Allwinner: linux: fix 4k60 mode on H6 with some HW

### DIFF
--- a/projects/Allwinner/patches/linux/0065-wip-fix-H6-4k-60.patch
+++ b/projects/Allwinner/patches/linux/0065-wip-fix-H6-4k-60.patch
@@ -1,0 +1,75 @@
+From edc858b1d62ce5ffd8b8d10cc62425af15d48a91 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Wed, 8 Dec 2021 20:42:45 +0100
+Subject: [PATCH] wip: fix H6 4k@60
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 7 +++++++
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.h | 4 ++++
+ drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c    | 2 +-
+ 3 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index f08d0fded61f..bcd839a3ce80 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -1488,6 +1488,8 @@ static int hdmi_phy_configure_dwc_hdmi_3d_tx(struct dw_hdmi *hdmi,
+ 	/* Override and disable clock termination. */
+ 	dw_hdmi_phy_i2c_write(hdmi, HDMI_3D_TX_PHY_CKCALCTRL_OVERRIDE,
+ 			      HDMI_3D_TX_PHY_CKCALCTRL);
++	if (mpixelclock == 594000000)
++		dw_hdmi_phy_i2c_write(hdmi, 0x8006, HDMI_3D_TX_PHY_MSM_CTRL);
+ 
+ 	return 0;
+ }
+@@ -2166,6 +2168,8 @@ static int dw_hdmi_setup(struct dw_hdmi *hdmi,
+ 	hdmi->hdmi_data.hdcp_enable = 0;
+ 	hdmi->hdmi_data.video_mode.mdataenablepolarity = true;
+ 
++	hdmi_writeb(hdmi, HDMI_FC_GCP_SET_AVMUTE, HDMI_FC_GCP);
++
+ 	/* HDMI Initialization Step B.1 */
+ 	hdmi_av_composer(hdmi, &connector->display_info, mode);
+ 
+@@ -2205,6 +2209,9 @@ static int dw_hdmi_setup(struct dw_hdmi *hdmi,
+ 	hdmi_video_sample(hdmi);
+ 	hdmi_tx_hdcp_config(hdmi);
+ 
++	msleep(100);
++	hdmi_writeb(hdmi, HDMI_FC_GCP_CLEAR_AVMUTE, HDMI_FC_GCP);
++
+ 	dw_hdmi_clear_overflow(hdmi);
+ 
+ 	return 0;
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.h b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.h
+index 1999db05bc3b..05182418efbb 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.h
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.h
+@@ -842,6 +842,10 @@ enum {
+ 	HDMI_FC_AVICONF3_QUANT_RANGE_LIMITED = 0x00,
+ 	HDMI_FC_AVICONF3_QUANT_RANGE_FULL = 0x04,
+ 
++/* HDMI_FC_GCP */
++	HDMI_FC_GCP_SET_AVMUTE = 0x2,
++	HDMI_FC_GCP_CLEAR_AVMUTE = 0x1,
++
+ /* FC_DBGFORCE field values */
+ 	HDMI_FC_DBGFORCE_FORCEAUDIO = 0x10,
+ 	HDMI_FC_DBGFORCE_FORCEVIDEO = 0x1,
+diff --git a/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c b/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
+index b64d93da651d..b70bc9de761f 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
++++ b/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
+@@ -90,7 +90,7 @@ static const struct dw_hdmi_mpll_config sun50i_h6_mpll_cfg[] = {
+ 		},
+ 	},  {
+ 		594000000, {
+-			{ 0x1a40, 0x0003 },
++			{ 0x1a7c, 0x0003 },
+ 			{ 0x3b4c, 0x0003 },
+ 			{ 0x5a64, 0x0003 },
+ 		},
+-- 
+2.34.1
+


### PR DESCRIPTION
With some TV and H6 board combinations, 4k@60 mode didn't work. TV didn't detect any HDMI signal. This PR fixes this issue.