### PR TITLE
devtools: minor updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.17.4"
-PKG_SHA256="91736588a47917aaa424dfdf482d8efcb44403a768e7a947c272a98881053386"
+PKG_VERSION="1.17.5"
+PKG_SHA256="f07fd8fcb02c8328d9abbf038f5a24c684214cdbd1179f736867614fc874864f"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
+++ b/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="apache-ant"
-PKG_VERSION="1.10.11"
-PKG_SHA256="baa049855cdecbefa62539555824058e52412e5ebe8f102e1db944cb762e06d9"
+PKG_VERSION="1.10.12"
+PKG_SHA256="6115c940367e50755cf806de5816f20a1db1321b1cb734e2c34ab20ef6682b9b"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://ant.apache.org/"
 PKG_URL="https://downloads.apache.org/ant/binaries/${PKG_NAME}-${PKG_VERSION}-bin.tar.xz"

--- a/packages/addons/addon-depends/librespot-depends/rust/package.mk
+++ b/packages/addons/addon-depends/librespot-depends/rust/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.54.0"
+PKG_VERSION="1.57.0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_DEPENDS_TARGET="toolchain rustup.rs"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.22.0"
-PKG_SHA256="998c7ba34778d2dfdb3df8a695469e24b11e2bfa21fbe41b361a3f45e1c9345e"
+PKG_VERSION="3.22.1"
+PKG_SHA256="0e998229549d7b3f368703d20e248e7ee1f853910d42704aa87918c213ea82c0"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- apache-ant: update to 1.10.12
- cmake: update to 3.22.1
- go: update to 1.17.5
- rust: 1.57.0