### PR TITLE
Minor Graphics updates: glu and gmmlib

### DIFF
--- a/packages/graphics/glu/package.mk
+++ b/packages/graphics/glu/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glu"
-PKG_VERSION="9.0.1"
-PKG_SHA256="f98dff2045e0c557da88553bf4cf9958f49cd5bd40d33d2f8b5e13c8f904d126"
+PKG_VERSION="9.0.2"
+PKG_SHA256="6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4"
 PKG_LICENSE="OSS"
-PKG_SITE="http://cgit.freedesktop.org/mesa/glu/"
-PKG_URL="http://cgit.freedesktop.org/mesa/glu/snapshot/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_SITE="https://gitlab.freedesktop.org/mesa/glu/"
+PKG_URL="https://mesa.freedesktop.org/archive/glu/glu-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain mesa"
 PKG_NEED_UNPACK="$(get_pkg_directory mesa)"
 PKG_LONGDESC="libglu is the The OpenGL utility library"

--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="21.3.3"
-PKG_SHA256="77473df5440915e7c487a0f1c3f6236a8c29610528c6f0833da9caae834a1741"
+PKG_VERSION="21.3.4"
+PKG_SHA256="917a39874c9c4e2b8b42c8cd33a5749da386c0c98b7211add65d13a6d191c759"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
- glu: update to 9.0.2 and HSTS and updated URL
  - https://lists.freedesktop.org/archives/mesa-announce/2021-June/000634.html
- gmmlib: update to 21.3.4
  - Intel Graphics Memory Management Library 2021 Q3 Release 4
  - https://github.com/intel/gmmlib/compare/intel-gmmlib-21.3.3...intel-gmmlib-21.3.4