### PR TITLE
wayland-protocols: update to 1.24

### DIFF
--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.23"
-PKG_SHA256="6c0af1915f96f615927a6270d025bd973ff1c58e521e4ca1fc9abfc914633f76"
+PKG_VERSION="1.24"
+PKG_SHA256="bff0d8cffeeceb35159d6f4aa6bab18c807b80642c9d50f66cba52ecf7338bc2"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Announcement:
- https://lists.freedesktop.org/archives/wayland-devel/2021-November/042039.html

### wayland-protocols 1.24 is now available.

This release adds feedback to the DMA buffer protocol, allowing smarter and
more dynamic DMA buffer allocation semantics. Other changes include
documentation improvements and improved testing infrastructure.

This is also the first release of wayland-protocols that do not include a
autotools build description.


Alex Richardson (2):
      tests: allow cross-compiling the tests
      tests: check whether -Wl,--unresolved-symbols=ignore-all is supported

Demi Marie Obenour (2):
      Use “software” instead of “user space”
      Improve tiled_* enum summary

Fabrice Fontaine (1):
      meson.build: wayland-scanner is only needed for tests

Jonas Ådahl (1):
      build: Bump version to 1.24

Simon Ser (4):
      Drop autotools
      linux-dmabuf: add note about pre-multiplied alpha
      unstable/linux-dmabuf: add wp_linux_dmabuf_feedback
      linux-dmabuf: send protocol error on invalid format/modifier