### PR TITLE
libprojectM: update to 3.1.12

### DIFF
--- a/packages/graphics/libprojectM/package.mk
+++ b/packages/graphics/libprojectM/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libprojectM"
-PKG_VERSION="3.1.7"
-PKG_SHA256="968551c5d6292179838bf5d3ab85f5bd785c6fec7c1de42c0cf5ec3dbf4b04f9"
+PKG_VERSION="3.1.12"
+PKG_SHA256="b6b99dde5c8f0822ae362606a0429628ee478f4ec943a156723841b742954707"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/projectM-visualizer/projectm"
-PKG_URL="https://github.com/projectM-visualizer/projectm/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/projectM-visualizer/projectm/releases/download/v${PKG_VERSION}/projectM-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain freetype glm ${OPENGL}"
 PKG_LONGDESC="A MilkDrop compatible opensource music visualizer."
 PKG_TOOLCHAIN="configure"
@@ -18,9 +18,5 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
                            --disable-qt \
                            --disable-pulseaudio \
                            --disable-jack \
+                           --disable-threading \
                            --enable-preset-subdirs"
-
-# workaround due broken release files, remove at next bump
-pre_configure_target() {
-  ./autogen.sh
-}

--- a/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.projectm"
-PKG_VERSION="19.0.0-Matrix"
-PKG_SHA256="0fc728a75e65e58089b5ef5ec86b82fdbe3ddc00496a3995625abf5b43e9204f"
+PKG_VERSION="19.0.1-Matrix"
+PKG_SHA256="077bd78405e079ada480a3ba623649ff9162027eb5aae6c80dd050cac54eb5a1"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
This bumps the version of projectM to the latest version.

This is unfortunately untested as 

    PROJECT=Generic ARCH=x86_64 scripts/create_addon visualization.projectm

just gets me

```
ERROR: no addons matched for filter visualization.projectm
For more information type: ./scripts/create_addon --help
*********** FAILED COMMAND ***********
addons+=" $(get_addons ${1})"
**************************************
```

and `visualization.projectm` is also not included in `visualization.*` - not sure what I'm doing wrong here (this is also on `master`)