### PR TITLE
[le11] rework wayland displayserver & windowmanager handling

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -38,7 +38,7 @@ if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr libglvnd"
   export X11_INCLUDES=
   PKG_MESON_OPTS_TARGET+=" -Dplatforms=x11 -Ddri3=enabled -Dglx=dri -Dglvnd=true"
-elif [ "${DISPLAYSERVER}" = "weston" ]; then
+elif [ "${DISPLAYSERVER}" = "wl" ]; then
   PKG_DEPENDS_TARGET+=" wayland wayland-protocols"
   PKG_MESON_OPTS_TARGET+=" -Dplatforms=wayland -Ddri3=disabled -Dglx=disabled -Dglvnd=false"
 else

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -274,7 +274,7 @@ post_makeinstall_target() {
     if [ "${DISPLAYSERVER}" = "x11" ]; then
       echo "DISPLAY=:0.0" >> ${INSTALL}/usr/lib/kodi/kodi.conf
     elif [ "${DISPLAYSERVER}" = "wl" ]; then
-      echo "WAYLAND_DISPLAY=wayland-0" >> ${INSTALL}/usr/lib/kodi/kodi.conf
+      echo "WAYLAND_DISPLAY=wayland-1" >> ${INSTALL}/usr/lib/kodi/kodi.conf
     fi
 
     # nvidia: Enable USLEEP to reduce CPU load while rendering

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -30,7 +30,7 @@ configure_package() {
     PKG_DEPENDS_TARGET+=" libX11 libXext libdrm libXrandr"
     KODI_PLATFORM="-DCORE_PLATFORM_NAME=x11 \
                    -DAPP_RENDER_SYSTEM=gl"
-  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+  elif [ "${DISPLAYSERVER}" = "wl" ]; then
     PKG_DEPENDS_TARGET+=" wayland waylandpp"
     CFLAGS+=" -DEGL_NO_X11"
     CXXFLAGS+=" -DEGL_NO_X11"
@@ -273,7 +273,7 @@ post_makeinstall_target() {
     # set default display environment
     if [ "${DISPLAYSERVER}" = "x11" ]; then
       echo "DISPLAY=:0.0" >> ${INSTALL}/usr/lib/kodi/kodi.conf
-    elif [ "${DISPLAYSERVER}" = "weston" ]; then
+    elif [ "${DISPLAYSERVER}" = "wl" ]; then
       echo "WAYLAND_DISPLAY=wayland-0" >> ${INSTALL}/usr/lib/kodi/kodi.conf
     fi
 

--- a/packages/multimedia/intel-vaapi-driver/package.mk
+++ b/packages/multimedia/intel-vaapi-driver/package.mk
@@ -15,7 +15,7 @@ PKG_TOOLCHAIN="meson"
 
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   DISPLAYSERVER_LIBVA="-Dwith_x11=yes -Dwith_wayland=no"
-elif [ "${DISPLAYSERVER}" = "weston" ]; then
+elif [ "${DISPLAYSERVER}" = "wl" ]; then
   DISPLAYSERVER_LIBVA="-Dwith_x11=no -Dwith_wayland=yes"
 else
   DISPLAYSERVER_LIBVA="-Dwith_x11=no -Dwith_wayland=no"

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -15,7 +15,7 @@ PKG_TOOLCHAIN="meson"
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET="toolchain libX11 libXext libXfixes libdrm"
   DISPLAYSERVER_LIBVA="-Dwith_x11=yes -Dwith_glx=no -Dwith_wayland=no"
-elif [ "${DISPLAYSERVER}" = "weston" ]; then
+elif [ "${DISPLAYSERVER}" = "wl" ]; then
   DISPLAYSERVER_LIBVA="-Dwith_x11=no -Dwith_glx=no -Dwith_wayland=yes"
   PKG_DEPENDS_TARGET="toolchain libdrm wayland"
 else

--- a/packages/virtual/wl/package.mk
+++ b/packages/virtual/wl/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="wl"
+PKG_VERSION=""
+PKG_LICENSE="OSS"
+PKG_SITE="https://wayland.freedesktop.org/"
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="virtual"
+PKG_LONGDESC="Wayland is intended as a simpler replacement for X, easier to develop and maintain."
+
+# Compositor
+if [ -n "${WINDOWMANAGER}" -a "${WINDOWMANAGER}" != "no" ]; then
+  PKG_DEPENDS_TARGET+=" ${WINDOWMANAGER}"
+fi

--- a/packages/virtual/x11/package.mk
+++ b/packages/virtual/x11/package.mk
@@ -20,7 +20,7 @@ PKG_LONGDESC="X11 is the Windowing system"
 # Tools
   PKG_DEPENDS_TARGET+=" xrandr setxkbmap"
 
-if [ -n "${WINDOWMANAGER}" -a "${WINDOWMANAGER}" != "none" ]; then
+if [ -n "${WINDOWMANAGER}" -a "${WINDOWMANAGER}" != "no" ]; then
   PKG_DEPENDS_TARGET+=" ${WINDOWMANAGER}"
 fi
 

--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -16,7 +16,7 @@ PKG_MESON_OPTS_TARGET="-Denable-docs=false"
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_MESON_OPTS_TARGET+=" -Denable-x11=true \
                            -Denable-wayland=false"
-elif [ "${DISPLAYSERVER}" = "weston" ]; then
+elif [ "${DISPLAYSERVER}" = "wl" ]; then
   PKG_MESON_OPTS_TARGET+=" -Denable-x11=false \
                            -Denable-wayland=true"
 else

--- a/packages/wayland/weston/patches/weston-999.01-PR486-avoid-setting-WAYLAND_DISPLAY=wayland-0.patch
+++ b/packages/wayland/weston/patches/weston-999.01-PR486-avoid-setting-WAYLAND_DISPLAY=wayland-0.patch
@@ -1,0 +1,73 @@
+From ae69381b6eb43ab63992906d1bf29ffd2b4df10d Mon Sep 17 00:00:00 2001
+From: Manuel Stoeckl <code@mstoeckl.com>
+Date: Sun, 30 Aug 2020 18:49:18 -0400
+Subject: [PATCH] compositor: avoid setting WAYLAND_DISPLAY=wayland-0
+
+This commit alters the way that Weston picks a Wayland display socket
+name. Instead of using wl_display_add_socket_auto to look for the first
+available name in wayland-0, wayland-1, .... to wayland-32, the code now
+checks names wayland-1, wayland-2, .... up to wayland-32.
+
+This change is a workaround for a suboptimal behavior of
+libwayland-client. If a client program calls wl_display_connect(NULL) and
+the WAYLAND_DISPLAY environment variable is not set, then the program will
+by default try to connect to 'wayland-0'. This is a problem when a
+computer has a running Wayland compositor but is being accessed in some
+other fashion, such as through an X session on a different virtual
+terminal, over ssh, etc. Client programs launched through those means may
+attempt to connect to an unrelated compositor. Changing libwayland
+behavior to remove the default would also work, but a) libraries have
+stronger backward compatibility expectations b) that would likely break
+more people's setups than just changing Weston would.
+
+Signed-off-by: Manuel Stoeckl <code@mstoeckl.com>
+---
+ compositor/main.c | 23 ++++++++++++++---------
+ 1 file changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/compositor/main.c b/compositor/main.c
+index 2554b7627..0c8c8e027 100644
+--- a/compositor/main.c
++++ b/compositor/main.c
+@@ -825,24 +825,29 @@ handle_primary_client_destroyed(struct wl_listener *listener, void *data)
+ static int
+ weston_create_listening_socket(struct wl_display *display, const char *socket_name)
+ {
++	char name_candidate[16];
++
+ 	if (socket_name) {
+ 		if (wl_display_add_socket(display, socket_name)) {
+ 			weston_log("fatal: failed to add socket: %s\n",
+ 				   strerror(errno));
+ 			return -1;
+ 		}
++
++		setenv("WAYLAND_DISPLAY", socket_name, 1);
++		return 0;
+ 	} else {
+-		socket_name = wl_display_add_socket_auto(display);
+-		if (!socket_name) {
+-			weston_log("fatal: failed to add socket: %s\n",
+-				   strerror(errno));
+-			return -1;
++		for (int i = 1; i <= 32; i++) {
++			sprintf(name_candidate, "wayland-%d", i);
++			if (wl_display_add_socket(display, name_candidate) >= 0) {
++				setenv("WAYLAND_DISPLAY", name_candidate, 1);
++				return 0;
++			}
+ 		}
++		weston_log("fatal: failed to add socket: %s\n",
++			   strerror(errno));
++		return -1;
+ 	}
+-
+-	setenv("WAYLAND_DISPLAY", socket_name, 1);
+-
+-	return 0;
+ }
+ 
+ WL_EXPORT void *
+-- 
+GitLab
+

--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -105,9 +105,6 @@
   # build and install hfs filesystem utilities (yes / no)
     HFSTOOLS="no"
 
-  # Windowmanager to use (fluxbox / none)
-    WINDOWMANAGER="none"
-
   # Xorg Graphic drivers to use (all / r300,r600,nvidia)
     GRAPHIC_DRIVERS="mesa"
 
@@ -147,8 +144,11 @@
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
-  # Displayserver to use (x11 / no)
+  # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
+
+  # Windowmanager to use (weston / no)
+    WINDOWMANAGER="no"
 
   # additional Firmware to use
     FIRMWARE=""

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -37,11 +37,11 @@
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
-  # Displayserver to use (x11 / no)
+  # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 
-  # Windowmanager to use (ratpoison / fluxbox / none)
-    WINDOWMANAGER="none"
+  # Windowmanager to use (weston / no)
+    WINDOWMANAGER="no"
 
   # Xorg Graphic drivers to use (all / lima,panfrost)
   # Space separated list is supported,

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -46,11 +46,11 @@
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
-  # Displayserver to use (x11 / no)
+  # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 
-  # Windowmanager to use (fluxbox / none)
-    WINDOWMANAGER="none"
+  # Windowmanager to use (weston / no)
+    WINDOWMANAGER="no"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/Generic/devices/Generic/options
+++ b/projects/Generic/devices/Generic/options
@@ -7,8 +7,8 @@
 # Displayserver to use (weston / x11 / no)
   DISPLAYSERVER="no"
 
-# Windowmanager to use (fluxbox / none)
-  WINDOWMANAGER="none"
+# Windowmanager to use (fluxbox / weston / no)
+  WINDOWMANAGER="no"
 
 # KODI Player implementation to use (mesa / default)
   KODIPLAYER_DRIVER="mesa"

--- a/projects/Generic/devices/wayland/options
+++ b/projects/Generic/devices/wayland/options
@@ -4,11 +4,11 @@
 # OpenGL-ES implementation to use (mesa / no)
   OPENGLES="mesa"
 
-# Displayserver to use (weston / x11 / no)
-  DISPLAYSERVER="weston"
+# Displayserver to use (wl / x11 / no)
+  DISPLAYSERVER="wl"
 
-# Windowmanager to use (fluxbox / none)
-  WINDOWMANAGER="none"
+# Windowmanager to use (fluxbox / weston / no)
+  WINDOWMANAGER="weston"
 
 # KODI Player implementation to use (mesa / default)
   KODIPLAYER_DRIVER="mesa"

--- a/projects/Generic/devices/x11/options
+++ b/projects/Generic/devices/x11/options
@@ -7,7 +7,7 @@
 # Displayserver to use (weston / x11 / no)
   DISPLAYSERVER="x11"
 
-# Windowmanager to use (fluxbox / none)
+# Windowmanager to use (fluxbox / weston / no)
   WINDOWMANAGER="fluxbox"
 
 # KODI Player implementation to use (mesa / default)

--- a/projects/NXP/options
+++ b/projects/NXP/options
@@ -38,11 +38,11 @@
   # include uvesafb support (yes / no)
     UVESAFB_SUPPORT="no"
 
-  # Displayserver to use (x11 / no)
+  # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 
-  # Windowmanager to use (ratpoison / fluxbox / none)
-    WINDOWMANAGER="none"
+  # Windowmanager to use (weston / no)
+    WINDOWMANAGER="no"
 
   # Xorg Graphic drivers to use (all / etnaviv)
   # Space separated list is supported,

--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -66,11 +66,11 @@
   # include uvesafb support (yes / no)
     UVESAFB_SUPPORT="no"
 
-  # Displayserver to use (x11 / no)
+  # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 
-  # Windowmanager to use (ratpoison / fluxbox / none)
-    WINDOWMANAGER="none"
+  # Windowmanager to use (weston / no)
+    WINDOWMANAGER="no"
 
   # Xorg Graphic drivers to use (all / freedreno)
   # Space separated list is supported,

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -75,11 +75,11 @@
   # OpenGL-ES implementation to use (no / bcm2835-driver / mesa)
     OPENGLES="mesa"
 
-  # Displayserver to use (x11 / no)
+  # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 
-  # Windowmanager to use (fluxbox / none)
-    WINDOWMANAGER="none"
+  # Windowmanager to use (weston / no)
+    WINDOWMANAGER="no"
 
   # Xorg Graphic drivers to use (all / vc4 / none)
   # Space separated list is supported,

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -44,11 +44,11 @@
   # OpenGL-ES implementation to use (no / libmali / mesa)
     OPENGLES="${OPENGLES:-mesa}"
 
-  # Displayserver to use (weston / no)
+  # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 
-  # Windowmanager to use (fluxbox / none)
-    WINDOWMANAGER="none"
+  # Windowmanager to use (weston / no)
+    WINDOWMANAGER="no"
 
   # Xorg Graphic drivers to use (all / lima,panfrost)
   # Space separated list is supported,

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -48,11 +48,11 @@
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 
-  # Displayserver to use (x11 / no)
+  # Displayserver to use (wl / no)
     DISPLAYSERVER="no"
 
-  # Windowmanager to use (fluxbox / none)
-    WINDOWMANAGER="none"
+  # Windowmanager to use (weston / no)
+    WINDOWMANAGER="no"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,


### PR DESCRIPTION
This PR decouples Wayland & Weston which allows to alter or replace the windowmanager / compositor if needed without editing other packages beside the project options.

- add backported patch for Weston to use `WAYLAND_DISPLAY=wayland-1` as other compositors do & updated Kodi conf
- use `DISPLAYSERVER="wl"` & `WINDOWMANAGER="weston"` for wayland builds
- set `WINDOWMANAGER="no"` instead `WINDOWMANAGER="none"` for all GBM builds
- added a virtual `wl` package which allows to add dependencies/tools at a central place if necessary
- the virtual package adds the windowmanager dependency instead of adding Weston, or else, as dep.

Build & run tested with generic 