### PR TITLE
linux (RPi): update to 5.15.10-6f15bf3

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="12bc6e3677348adaffd155e7a04761e2661d4bff"
-PKG_SHA256="72dd2ebb50f5d0c69d010ac5ce9d820a6803692c687ce166fdba81be5e4274ce"
+PKG_VERSION="1a0297bfbf7c970f657c11edc42b22a671170d18"
+PKG_SHA256="8147932ab0a832f71907792d07ec278403fc606751320a80540a240f03af9e4f"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="b12c997cf2c8cad9bb1de234684ce6fea78c5725" # 5.15.5
-    PKG_SHA256="cc7fff474db3efbe4ed1f444deb5f48902d22fc954cc771702400491d16dee9a"
+    PKG_VERSION="d96f98a6967453bf11656808eaf0d1a5b7c43646" # 5.15.5
+    PKG_SHA256="fb07f4057c9449790384df272889128da03b1e3f6b4afa3cd27c965798f87e8a"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="65170647c4a21c5466ff921a2bcfe2ee587c7680" # 5.15.6
-    PKG_SHA256="46bf6331e7df9ae323bf7304001313d09f9d2a05e577803d05f0d2eaa32077ad"
+    PKG_VERSION="167c0972f92b49edc7a62375149dd939e9e85ed2" # 5.15.6
+    PKG_SHA256="fbc069afae258add52b7129ff6d2a21927ea9191b5d2de57d8ba5d438dd28038"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="d96f98a6967453bf11656808eaf0d1a5b7c43646" # 5.15.5
-    PKG_SHA256="fb07f4057c9449790384df272889128da03b1e3f6b4afa3cd27c965798f87e8a"
+    PKG_VERSION="65170647c4a21c5466ff921a2bcfe2ee587c7680" # 5.15.6
+    PKG_SHA256="46bf6331e7df9ae323bf7304001313d09f9d2a05e577803d05f0d2eaa32077ad"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="fb5dfd027a5beec8f77173500abdc902add6db35" # 5.15.8
-    PKG_SHA256="89293ee821407f6ac99b0b4d744f1b069d33a0cd476a73c2b348ff5e0f8410bb"
+    PKG_VERSION="6f15bf31e2885200c17dca637dd417624656b5b4" # 5.15.10
+    PKG_SHA256="6ce0c0bdb24a598751c2d44121e016ac5ed70dae4a95603ea5b717610fc93fd8"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="167c0972f92b49edc7a62375149dd939e9e85ed2" # 5.15.6
-    PKG_SHA256="fbc069afae258add52b7129ff6d2a21927ea9191b5d2de57d8ba5d438dd28038"
+    PKG_VERSION="fb5dfd027a5beec8f77173500abdc902add6db35" # 5.15.8
+    PKG_SHA256="89293ee821407f6ac99b0b4d744f1b069d33a0cd476a73c2b348ff5e0f8410bb"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="12bc6e3677348adaffd155e7a04761e2661d4bff"
-PKG_SHA256="fdd99713fbd53333df5e7c34ae10aeb117f272d3c03694bf4c99f3195bdfd990"
+PKG_VERSION="1a0297bfbf7c970f657c11edc42b22a671170d18"
+PKG_SHA256="41971730d0ec0661b74a68c56743c30a8afc4c62ab8915e9f46e99a18af02fd8"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="86eee571e269e360bafd36128e80117a93838bc7"
-PKG_SHA256="fa4242d1d63bb1ab3d132d00076b1c12b5b2e2077a1d8748e48626cdea314eff"
+PKG_VERSION="91676cba22f0d814f028952c65cfe294491d8bfd"
+PKG_SHA256="6b42bf6a9e81370cd6f5ba36abf367d74aa5863601eaba62e7f08afbce128c25"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="91676cba22f0d814f028952c65cfe294491d8bfd"
-PKG_SHA256="6b42bf6a9e81370cd6f5ba36abf367d74aa5863601eaba62e7f08afbce128c25"
+PKG_VERSION="9ca0e123e67d6b46cf021deb5fe400f27249e858"
+PKG_SHA256="e42fffdfb155f74b51a93eec6cd575bd1ffdf3c3e7b3909ff7b641cbf287f2d5"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.0 Kernel Configuration
+# Linux/arm 5.15.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y
@@ -4964,7 +4964,6 @@ CONFIG_EXFAT_FS=m
 CONFIG_EXFAT_DEFAULT_IOCHARSET="utf8"
 # CONFIG_NTFS_FS is not set
 CONFIG_NTFS3_FS=m
-# CONFIG_NTFS3_64BIT_CLUSTER is not set
 # CONFIG_NTFS3_LZX_XPRESS is not set
 # CONFIG_NTFS3_FS_POSIX_ACL is not set
 # end of DOS/FAT/EXFAT/NT Filesystems

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.0 Kernel Configuration
+# Linux/arm 5.15.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y
@@ -5109,7 +5109,6 @@ CONFIG_EXFAT_FS=m
 CONFIG_EXFAT_DEFAULT_IOCHARSET="utf8"
 # CONFIG_NTFS_FS is not set
 CONFIG_NTFS3_FS=m
-# CONFIG_NTFS3_64BIT_CLUSTER is not set
 # CONFIG_NTFS3_LZX_XPRESS is not set
 # CONFIG_NTFS3_FS_POSIX_ACL is not set
 # end of DOS/FAT/EXFAT/NT Filesystems

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.0 Kernel Configuration
+# Linux/arm64 5.15.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
this adds support for 10/12bit RGB and 12bit YCbCr 4:2:2 video output