### PR TITLE
development tools

### DIFF
--- a/packages/sysutils/gptfdisk/package.mk
+++ b/packages/sysutils/gptfdisk/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gptfdisk"
-PKG_VERSION="1.0.6"
-PKG_SHA256="ddc551d643a53f0bd4440345d3ae32c49b04a797e9c01036ea460b6bb4168ca8"
+PKG_VERSION="1.0.8"
+PKG_SHA256="95d19856f004dabc4b8c342b2612e8d0a9eebdd52004297188369f152e9dc6df"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.rodsbooks.com/gdisk/"
 PKG_URL="https://downloads.sourceforge.net/project/${PKG_NAME}/${PKG_NAME}/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="expat"
-PKG_VERSION="2.2.10"
-PKG_SHA256="b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5"
+PKG_VERSION="2.4.1"
+PKG_SHA256="2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40"
 PKG_LICENSE="OSS"
 PKG_SITE="http://expat.sourceforge.net/"
 PKG_URL="https://github.com/libexpat/libexpat/releases/download/R_${PKG_VERSION//./_}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/tools/hdparm/package.mk
+++ b/packages/tools/hdparm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hdparm"
-PKG_VERSION="9.60"
-PKG_SHA256="8397739c73e44d5ab96c4aef28fa9c0147276d53a1b5657ce04c4565cf6635cc"
+PKG_VERSION="9.62"
+PKG_SHA256="2c0f9d75cdbeda928a25a128cd3d0b7120445ec0910c0b29d4c1038ed1be777f"
 PKG_LICENSE="BSD"
 PKG_SITE="http://sourceforge.net/projects/hdparm/"
 PKG_URL="${SOURCEFORGE_SRC}/${PKG_NAME}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qemu"
-PKG_VERSION="6.1.0"
-PKG_SHA256="eebc089db3414bbeedf1e464beda0a7515aad30f73261abc246c9b27503a3c96"
+PKG_VERSION="6.2.0"
+PKG_SHA256="68e15d8e45ac56326e0b9a4afa8b49a3dfe8aba3488221d098c84698bca65b45"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.qemu.org"
 PKG_URL="https://download.qemu.org/qemu-${PKG_VERSION}.tar.xz"
@@ -22,6 +22,7 @@ pre_configure_host() {
     --sbindir=${TOOLCHAIN}/sbin \
     --sysconfdir=${TOOLCHAIN}/etc \
     --enable-tools \
+    --enable-malloc=system \
     --disable-attr \
     --disable-auth-pam \
     --disable-blobs \
@@ -35,7 +36,6 @@ pre_configure_host() {
     --disable-gnutls \
     --disable-libxml2 \
     --disable-system \
-    --disable-tcmalloc \
     --disable-user \
     --disable-vnc \
     --disable-werror \


### PR DESCRIPTION
- expat: update to 2.4.1
- gptfdisk: update to 1.0.8
- hdparm: update to 9.62
- qemu: update to 6.2.0 and configure  