### PR TITLE
zstd: update to 1.5.1

### DIFF
--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.5.0"
-PKG_SHA256="9aa8dfc1ca17f358b28988ca1f6e00ffe1c6f3198853f8d2022799e6f0669180"
+PKG_VERSION="1.5.1"
+PKG_SHA256="444f68cf74d2ee6e1d3e53aa99463570bcabf37734f26f86b8aa3fec99446f96"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"
 PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.zst"


### PR DESCRIPTION
Good for another ~0.5MB reduction of the image for me.

Changelog: https://github.com/facebook/zstd/releases/tag/v1.5.1

