### PR TITLE
xf86-video-intel: prefer iris & crocus over classic drivers

### DIFF
--- a/packages/x11/driver/xf86-video-intel/patches/xf86-video-intel-100.01-prefer-iris-and-crocus-over-i965.patch
+++ b/packages/x11/driver/xf86-video-intel/patches/xf86-video-intel-100.01-prefer-iris-and-crocus-over-i965.patch
@@ -1,0 +1,15 @@
+--- /src/sna/sna_dri2.c
++++ /src/sna/sna_dri2.c
+@@ -3707,8 +3707,10 @@
+ 			return has_i830_dri() ? "i830" : "i915";
+ 		else if (sna->kgem.gen < 040)
+ 			return "i915";
++		else if (sna->kgem.gen < 0100)
++			return "crocus";
+ 		else
+-			return "i965";
++			return "iris";
+ 	}
+ 
+ 	return s;
+


### PR DESCRIPTION
- the xf86-video-intel driver is harcoded against the classic i915/i965 drivers: https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/blob/master/src/sna/sna_dri2.c#L3705-3711
- after the removal of them by https://github.com/LibreELEC/LibreELEC.tv/pull/5887 GLX was broken if used on Intel systems since e.g. `i965_dri.so` was missing
- the modesetting driver is not a real alternative because of https://gitlab.freedesktop.org/xorg/xserver/-/issues/928
- this patch loads the gallium drivers depending on the matching generation

Tested on a Skylake system with `iris` - crocus & i915 untested but should work the same way.

### xorg log
```
[     7.268] (II) intel(0): [DRI2] Setup complete
[     7.268] (II) intel(0): [DRI2]   DRI driver: iris
[     7.268] (II) intel(0): [DRI2]   VDPAU driver: va_gl
[     7.268] (II) intel(0): direct rendering: DRI2 DRI3 enabled
[     7.268] (II) intel(0): hardware support for Present enabled
[     7.268] (II) Initializing extension Generic Event Extension
[     7.268] (II) Initializing extension SHAPE
[     7.268] (II) Initializing extension MIT-SHM
[     7.268] (II) Initializing extension XInputExtension
[     7.268] (II) Initializing extension XTEST
[     7.268] (II) Initializing extension BIG-REQUESTS
[     7.268] (II) Initializing extension SYNC
[     7.268] (II) Initializing extension XKEYBOARD
[     7.268] (II) Initializing extension XC-MISC
[     7.268] (II) Initializing extension XFIXES
[     7.268] (II) Initializing extension RENDER
[     7.268] (II) Initializing extension RANDR
[     7.268] (II) Initializing extension COMPOSITE
[     7.268] (II) Initializing extension DAMAGE
[     7.268] (II) Initializing extension DOUBLE-BUFFER
[     7.268] (II) Initializing extension RECORD
[     7.268] (II) Initializing extension DPMS
[     7.268] (II) Initializing extension Present
[     7.268] (II) Initializing extension DRI3
[     7.268] (II) Initializing extension X-Resource
[     7.268] (II) Initializing extension XVideo
[     7.268] (II) Initializing extension XVideo-MotionCompensation
[     7.268] (II) Initializing extension GLX
[     7.536] (II) AIGLX: Loaded and initialized iris
[     7.536] (II) GLX: Initialized DRI2 GL provider for screen 0
[     7.536] (II) Initializing extension XFree86-VidModeExtension
[     7.536] (II) Initializing extension XFree86-DGA
[     7.536] (II) Initializing extension XFree86-DRI
[     7.536] (II) Initializing extension DRI2
```

### glxinfo
```
name of display: :0.0
display: :0  screen: 0
direct rendering: Yes
Extended renderer info (GLX_MESA_query_renderer):
    Vendor: Intel (0x8086)
    Device: Mesa Intel(R) HD Graphics 530 (SKL GT2) (0x1912)
    Version: 21.3.2
    Accelerated: yes
    Video memory: 3072MB
    Unified memory: yes
    Preferred profile: core (0x1)
    Max core profile version: 4.6
    Max compat profile version: 4.6
    Max GLES1 profile version: 1.1
    Max GLES[23] profile version: 3.2
OpenGL vendor string: Intel
OpenGL renderer string: Mesa Intel(R) HD Graphics 530 (SKL GT2)
OpenGL core profile version string: 4.6 (Core Profile) Mesa 21.3.2
OpenGL core profile shading language version string: 4.60
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile

OpenGL version string: 4.6 (Compatibility Profile) Mesa 21.3.2
OpenGL shading language version string: 4.60
OpenGL context flags: (none)
OpenGL profile mask: compatibility profile

OpenGL ES profile version string: OpenGL ES 3.2 Mesa 21.3.2
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
```

