### PR TITLE
[le10] snapcast: update to 0.26.0 and addon (108)

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-plugins"
-PKG_VERSION="1.2.2"
-PKG_SHA256="1c0f06450c928d711719686c9dbece2d480184f36fab11b8f0534cb7b41e337d"
+PKG_VERSION="1.2.6"
+PKG_SHA256="068818a4b55d8c029daa00015d853d45113f56b224b7c64e1e117988c825b2a0"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/plugins/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/snapcast-depends/asio/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/asio/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="asio"
-PKG_VERSION="1.18.2"
-PKG_SHA256="9071370beb50f4e974042a2a8604e761397cc34a2021a49b5712571b5e1536d7"
+PKG_VERSION="1.21.0"
+PKG_SHA256="2edd7af3b5aa5746a0e552dfcd68b47d765a81695c4479c70027a378851a1bdc"
 PKG_LICENSE="BSL"
 PKG_SITE="http://think-async.com/Asio"
 PKG_URL="https://github.com/chriskohlhoff/asio/archive/asio-${PKG_VERSION//./-}.zip"

--- a/packages/addons/addon-depends/snapcast-depends/popl/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/popl/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="popl"
-PKG_VERSION="1.2.0"
-PKG_SHA256="dee63eed9bac3da9ec0008902c7ec72caa319461b20fc116e57e45948671a0bf"
+PKG_VERSION="1.3.0"
+PKG_SHA256="7c59554371da3c6c093bd79c2f403f921c1938bd523f1a48682352e0d92883a6"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/badaix/popl"
 PKG_URL="https://github.com/badaix/popl/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/snapcast-depends/snapcast/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/snapcast/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapcast"
-PKG_VERSION="0.25.0"
-PKG_SHA256="c4e449cb693e091261727421f4965492be049632537e034fa9c59c92d091a846"
+PKG_VERSION="0.26.0"
+PKG_SHA256="166353267a5c461a3a0e7cbd05d78c4bfdaebeda078801df3b76820b54f27683"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/badaix/snapcast"
 PKG_URL="https://github.com/badaix/snapcast/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain aixlog alsa-lib asio avahi flac libvorbis popl boost opus"
+PKG_DEPENDS_TARGET="toolchain aixlog alsa-lib asio avahi flac libvorbis popl pulseaudio boost opus"
 PKG_LONGDESC="Synchronous multi-room audio player."
 PKG_TOOLCHAIN="make"
 PKG_BUILD_FLAGS="-sysroot"

--- a/packages/addons/service/snapclient/changelog.txt
+++ b/packages/addons/service/snapclient/changelog.txt
@@ -1,3 +1,9 @@
+108
+- alsa-plugins: update to 1.2.6
+- asio: update to 1.21.0
+- popl: update to 1.3.0
+- snapcast: update to 0.26.0
+
 107
 - asio: update to 1.18.2
 - libconfig: update to 1.7.3

--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapclient"
-PKG_VERSION="0.25.0"
-PKG_REV="107"
+PKG_VERSION="0.26.0"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain alsa-plugins snapcast"

--- a/packages/addons/service/snapserver/changelog.txt
+++ b/packages/addons/service/snapserver/changelog.txt
@@ -1,9 +1,14 @@
+108
+- alsa-plugins: update to 1.2.6
+- asio: update to 1.21.0
+- popl: update to 1.3.0
+- snapcast: update to 0.26.0
+
 107
 - asio: update to 1.18.2
 - libconfig: update to 1.7.3
 - shairport-sync: update to 3.3.8
 - snapcast: update to 0.25.0
-
 
 106
 - Added options to enable and configure the HTTP server

--- a/packages/addons/service/snapserver/package.mk
+++ b/packages/addons/service/snapserver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapserver"
-PKG_VERSION="0.25.0"
-PKG_REV="107"
+PKG_VERSION="0.26.0"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain shairport-sync snapcast"


### PR DESCRIPTION
Backport of #6010 

Release notes:
- https://github.com/badaix/snapcast/releases/tag/v0.26.0 
- update 0.25.0 (2021-05-15) to 0.26.0 (2021-12-23)

Update addons:

- snapclient: update snapcast to 0.26.0 (108)
- snapserver: update snapcast to 0.26.0 (108)

Update packages:

- alsa-plugins: update to 1.2.6
- asio: update to 1.21.0
- popl: update to 1.3.0
- snapcast: update to 0.26.0
  - fixed dependency on pulseaudio

