### PR TITLE
[le10] system-tools: update to (127)

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bottom"
-PKG_VERSION="0.6.1"
-PKG_SHA256="aa9c26e7e8e1300e9827c098317efa28cc28ae8acabfdb12f14e4ba65f42a57c"
+PKG_VERSION="0.6.6"
+PKG_SHA256="102932d73a5b053c81bb7d9a7a8af35a0da1f9f391a62a58ba5cd1702daf4429"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ClementTsang/bottom"
 PKG_URL="https://github.com/ClementTsang/bottom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/depends/efivar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/efivar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="efivar"
-PKG_VERSION="cff88dd96b9d43e2c5875a24ba6180b196890ded" # 16 Oct 2020
-PKG_SHA256="016dfae596b691c8d38e488f8bfac3ba437befc260a6f32e60dd390595c9f3e9"
+PKG_VERSION="b920a6ca82250504167066d24aa8731ad29a0de8" # 10 Dec 2021
+PKG_SHA256="def327792854bdb5bc442e2907e1871c954e55e33d67045dcd2d2988f8a08afd"
 PKG_ARCH="x86_64"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://github.com/rhboot/efivar"
@@ -11,6 +11,7 @@ PKG_URL="https://github.com/rhboot/efivar/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain efivar:host"
 PKG_LONGDESC="Tools and library to manipulate EFI variables."
+PKG_BUILD_FLAGS="-gold"
 
 pre_make_host() {
   export TOPDIR=${PKG_BUILD}
@@ -26,7 +27,7 @@ pre_make_target() {
 }
 
 make_target() {
-  make -C src/ libefivar.a libefiboot.a efivar.h efivar
+  make CROSS_COMPILE=${TARGET_NAME}- -C src/ libefivar.a libefiboot.a efivar.h efivar
 }
 
 makeinstall_host() {

--- a/packages/addons/addon-depends/system-tools-depends/depends/efivar/patches/efivar-01-static_lib.patch
+++ b/packages/addons/addon-depends/system-tools-depends/depends/efivar/patches/efivar-01-static_lib.patch
@@ -1,11 +1,11 @@
 --- a/src/Makefile	2018-10-01 21:30:06.000000000 +0200
 +++ b/src/Makefile	2018-10-17 14:16:46.000000000 +0200
-@@ -69,7 +69,7 @@ libefivar.so : | $(GENERATED_SOURCES) li
+@@ -93,7 +93,7 @@
  libefivar.so : LIBS=dl
  libefivar.so : MAP=libefivar.map
  
--efivar : efivar.c | libefivar.so
-+efivar : efivar.c | libefivar.a
+-efivar : $(EFIVAR_OBJECTS) | libefivar.so
++efivar : $(EFIVAR_OBJECTS) | libefivar.a
  efivar : LIBS=efivar dl
  
- efivar-static : efivar.c $(patsubst %.o,%.static.o,$(LIBEFIVAR_OBJECTS))
+ efivar-static : $(EFIVAR_OBJECTS) $(patsubst %.o,%.static.o,$(LIBEFIVAR_OBJECTS))

--- a/packages/addons/addon-depends/system-tools-depends/depends/libmtp/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/libmtp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmtp"
-PKG_VERSION="1.1.18"
-PKG_SHA256="7280fe50c044c818a06667f45eabca884deab3193caa8682e0b581e847a281f0"
+PKG_VERSION="1.1.19"
+PKG_SHA256="deb4af6f63f5e71215cfa7fb961795262920b4ec6cb4b627f55b30b18aa33228"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libmtp.sourceforge.net/"
 PKG_URL="${SOURCEFORGE_SRC}/project/${PKG_NAME}/${PKG_NAME}/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/depends/libssh2/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/libssh2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libssh2"
-PKG_VERSION="1.9.0"
-PKG_SHA256="d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd"
+PKG_VERSION="1.10.0"
+PKG_SHA256="2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.libssh2.org"
 PKG_URL="https://www.libssh2.org/download/libssh2-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/diffutils/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/diffutils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="diffutils"
-PKG_VERSION="3.7"
-PKG_SHA256="b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26"
+PKG_VERSION="3.8"
+PKG_SHA256="a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/diffutils/"
 PKG_URL="http://ftpmirror.gnu.org/diffutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/system-tools-depends/efibootmgr/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/efibootmgr/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="efibootmgr"
-PKG_VERSION="edc8b9b6ec1c7751ccb9a483405c99141ba237fc" # Apr 28, 2020
-PKG_SHA256="e951ce9e0534c63bb71ba8b2a3830d4402e51440cb4d524d18c1ef40ae5ee218"
+PKG_VERSION="b9fedd6b6f57055164bc361bc5cf16a602843c6e" # Nov 5, 2021
+PKG_SHA256="06061ebf96d28522f5a20b592305e71b91d3fb479ddcce41dadb5180da16d8d8"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rhboot/efibootmgr"

--- a/packages/addons/addon-depends/system-tools-depends/file/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/file/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="file"
-PKG_VERSION="5.40"
-PKG_SHA256="35488116b068042320374f60e505e37c2c61b899402f9968e070b63dc39286d4"
+PKG_VERSION="5.41"
+PKG_SHA256="088fd09e8f2f7e8fda05e07ba9586df8708e1676a44db207b4496bd44e7f49f4"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.darwinsys.com/file/"
 PKG_URL="https://github.com/file/file/archive/FILE${PKG_VERSION/./_}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/htop/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/htop/package.mk
@@ -14,3 +14,7 @@ PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-unicode \
                            HTOP_NCURSES_CONFIG_SCRIPT=ncurses-config"
+
+pre_configure_target() {
+  export LDFLAGS="${LDFLAGS} -pthread"
+}

--- a/packages/addons/addon-depends/system-tools-depends/htop/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/htop/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="htop"
-PKG_VERSION="3.0.5"
-PKG_SHA256="4c2629bd50895bd24082ba2f81f8c972348aa2298cc6edc6a21a7fa18b73990c"
+PKG_VERSION="3.1.2"
+PKG_SHA256="fe9559637c8f21f5fd531a4c072048a404173806acbdad1359c6b82fd87aa001"
 PKG_LICENSE="GPL"
 PKG_SITE="https://hisham.hm/htop"
 PKG_URL="https://github.com/htop-dev/htop/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="i2c-tools"
 PKG_VERSION="4.3"
-PKG_SHA256="6db1a5f2743d97900f5fdb085f66d5153322b1eff9e67c2580610aa280e05d59"
+PKG_SHA256="1f899e43603184fac32f34d72498fc737952dbc9c97a8dd9467fadfdf4600cf9"
 PKG_LICENSE="GPL"
 PKG_SITE="https://i2c.wiki.kernel.org/index.php/I2C_Tools"
 PKG_URL="https://www.kernel.org/pub/software/utils/i2c-tools/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="i2c-tools"
-PKG_VERSION="4.2"
-PKG_SHA256="37f2dabc7082d185903ff21d1f584b5dcb4dd2eb2c879bbd8d7c50ae900dacd6"
+PKG_VERSION="4.3"
+PKG_SHA256="6db1a5f2743d97900f5fdb085f66d5153322b1eff9e67c2580610aa280e05d59"
 PKG_LICENSE="GPL"
 PKG_SITE="https://i2c.wiki.kernel.org/index.php/I2C_Tools"
 PKG_URL="https://www.kernel.org/pub/software/utils/i2c-tools/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -37,6 +37,7 @@ makeinstall_target() {
   make  EXTRA="py-smbus" \
         DESTDIR=${INSTALL} \
         PREFIX="/usr" \
+        prefix="/usr" \
         PYTHON=${TOOLCHAIN}/bin/python3 \
         install
 }

--- a/packages/addons/addon-depends/system-tools-depends/inotify-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/inotify-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inotify-tools"
-PKG_VERSION="3.20.11.0"
-PKG_SHA256="58a3cde89e4a5111a87ac16b56b06a8f885460fca0aea51b69c856ce30a37a14"
+PKG_VERSION="3.21.9.6"
+PKG_SHA256="0ca3d5a632149e26375bbb0b542193698bc44da027925f7b7473a5617984d7e3"
 PKG_LICENSE="GPLv2"
 PKG_SITE="http://wiki.github.com/inotify-tools/inotify-tools/"
 PKG_URL="https://github.com/inotify-tools/inotify-tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/inotify-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/inotify-tools/package.mk
@@ -15,5 +15,5 @@ PKG_BUILD_FLAGS="-sysroot"
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --disable-doxygen"
 
 pre_configure_target() {
-  CFLAGS+=" -Wno-error=misleading-indentation"
+  CFLAGS+=" -Wno-error=misleading-indentation -Wno-error=unused-parameter"
 }

--- a/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libgpiod"
+PKG_VERSION="1.6.3"
+PKG_SHA256="eb446070be1444fd7d32d32bbca53c2f3bbb0a21193db86198cf6050b7a28441"
+PKG_LICENSE="GPLv2+"
+PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
+PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Tools for interacting with the linux GPIO character device."
+PKG_TOOLCHAIN="autotools"
+PKG_CONFIGURE_OPTS_TARGET="--enable-tools --disable-shared"

--- a/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
@@ -6,8 +6,11 @@ PKG_VERSION="1.6.3"
 PKG_SHA256="eb446070be1444fd7d32d32bbca53c2f3bbb0a21193db86198cf6050b7a28441"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
-PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-$PKG_VERSION.tar.gz"
+PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Tools for interacting with the linux GPIO character device."
 PKG_TOOLCHAIN="autotools"
-PKG_CONFIGURE_OPTS_TARGET="--enable-tools --disable-shared"
+
+PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
+                           --enable-tools \
+                           --disable-shared"

--- a/packages/addons/addon-depends/system-tools-depends/nmon/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/nmon/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nmon"
-PKG_VERSION="16m" # 25 Sep 2019
-PKG_SHA256="2bed4d45fdfdf1d1387ec91e139c04975d5f838e3e0d53c0fe2d803a707e5fc1"
+PKG_VERSION="16n"
+PKG_SHA256="c0012cc2d925dee940c37ceae297abac64ba5a5c30e575e7418b04028613f5f2"
 PKG_LICENSE="GPL"
 PKG_SITE="http://nmon.sourceforge.net/pmwiki.php?n=Site.CompilingNmon"
-PKG_URL="http://sourceforge.net/projects/nmon/files/lmon16m.c"
+PKG_URL="http://sourceforge.net/projects/nmon/files/lmon16n.c"
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="Systems administrator, tuner, benchmark tool gives you a huge amount of important performance information in one go."
 PKG_TOOLCHAIN="manual"

--- a/packages/addons/addon-depends/system-tools-depends/pv/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/pv/package.mk
@@ -2,13 +2,13 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pv"
-PKG_VERSION="1.6.6"
-PKG_SHA256="608ef935f7a377e1439c181c4fc188d247da10d51a19ef79bcdee5043b0973f1"
+PKG_VERSION="1.6.20"
+PKG_SHA256="e831951eff0718fba9b1ef286128773b9d0e723e1fbfae88d5a3188814fdc603"
 PKG_LICENSE="GNU"
 PKG_SITE="http://www.ivarch.com/programs/pv.shtml"
 PKG_URL="http://www.ivarch.com/programs/sources/pv-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
-PKG_LONGDESC="Pipe Viwer can be inserted into any normal pipeline between two processes."
+PKG_LONGDESC="Pipe Viewer can be inserted into any normal pipeline between two processes."
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static-nls"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -3,10 +3,10 @@
 
 PKG_NAME="stress-ng"
 PKG_VERSION="0.13.05"
-PKG_SHA256="f058c8fba37596ab32c3a4b2aedbdbf5f2b8a8ba1d312059e733290543ad00ac"
+PKG_SHA256="3de49e1100866634f549e99c1644283d0cde817b844a69dcf7f80afa2227d350"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
-PKG_URL="https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-${PKG_VERSION}.tar.xz"
+PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain attr keyutils libaio libcap zlib"
 PKG_LONGDESC="stress-ng will stress test a computer system in various selectable ways"
 PKG_BUILD_FLAGS="-sysroot"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.12.11"
-PKG_SHA256="971393075321c24c3d5769acfabb705911d1f411ced5937b7cfea58528c1b4e6"
+PKG_VERSION="0.13.05"
+PKG_SHA256="f058c8fba37596ab32c3a4b2aedbdbf5f2b8a8ba1d312059e733290543ad00ac"
 PKG_LICENSE="GPLv2"
-PKG_SITE="https://kernel.ubuntu.com/~cking/stress-ng/"
+PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain attr keyutils libaio libcap zlib"
 PKG_LONGDESC="stress-ng will stress test a computer system in various selectable ways"

--- a/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="unrar"
-PKG_VERSION="6.0.7"
-PKG_SHA256="a7029942006cbcced3f3b7322ec197683f8e7be408972ca08099b196c038f518"
+PKG_VERSION="6.1.3"
+PKG_SHA256="d05022442009202a792e588bec58921c123ff046fc755f7f2272871a5bd79636"
 PKG_LICENSE="free"
 PKG_SITE="https://www.rarlab.com/rar_add.htm"
 PKG_URL="https://www.rarlab.com/rar/unrarsrc-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vim"
-PKG_VERSION="8.2.3095"
-PKG_SHA256="31588e2a074e2e2ea170704e5a40c61413f2a825788db325d1419c334e6d50b6"
+PKG_VERSION="8.2.3878"
+PKG_SHA256="0c571c9bf434b7d70b019d70e8c15e0d9fbdc835cdf92de27507d2398bd58ffc"
 PKG_LICENSE="VIM"
 PKG_SITE="http://www.vim.org/"
 PKG_URL="https://github.com/vim/vim/archive/v${PKG_VERSION}.tar.gz"
@@ -22,6 +22,7 @@ PKG_CONFIGURE_OPTS_TARGET="vim_cv_getcwd_broken=no \
                            ac_cv_sizeof_int=4 \
                            ac_cv_small_wchar_t=no \
                            --datarootdir=/storage/.kodi/addons/virtual.system-tools/data \
+                           --disable-canberra \
                            --disable-nls \
                            --enable-selinux=no \
                            --enable-gui=no \

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,24 @@
+127
+- Update bottom to 0.6.6
+- Update diffutils to 3.8
+- Update efibootmgr to githash 2021-11-05
+- Update efivar to githash 2021-12-10
+- Update file to 5.41
+- Update htop to 3.1.2
+- Update i2c-tools to 4.3 and fix build prefix
+- Update inotify-tools to 3.21.9.6
+- Add libgpiod (1.6.3)
+- Update libmtp to 1.1.19
+- Update libssh2 to 1.10.0
+- Update nmon to 16n
+- Update pv to 1.6.20
+- Update stress-ng to 0.13.05 and the PKG_URL
+- Update unrar to 6.1.3
+- Update vim to 8.2.3878
+
+126
+- not released for LE10
+
 125
 - Update mc to 4.8.27
 

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of system tools and programs"
-PKG_LONGDESC="This bundle currently includes autossh, bottom, diffutils, dstat, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, lm_sensors, lshw, mc, mtpfs, nmon, p7zip, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
+PKG_LONGDESC="This bundle currently includes autossh, bottom, diffutils, dstat, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, libgpiod, lm_sensors, lshw, mc, mtpfs, nmon, p7zip, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="System Tools"
@@ -35,6 +35,7 @@ PKG_DEPENDS_TARGET="toolchain \
                     i2c-tools \
                     inotify-tools \
                     jq \
+                    libgpiod \
                     lm_sensors \
                     lshw \
                     mc \
@@ -117,6 +118,9 @@ addon() {
     # jq
     cp -P $(get_install_dir jq)/usr/bin/jq ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir oniguruma)/usr/lib/{libonig.so,libonig.so.5,libonig.so.5.2.0} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+
+    # libgpiod
+    cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpiofind,gpioget,gpioinfo,gpiomon,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # lm_sensors
     cp -P $(get_install_dir lm_sensors)/usr/bin/sensors ${ADDON_BUILD}/${PKG_ADDON_ID}/bin 2>/dev/null || :

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="125"
+PKG_REV="127"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -107,9 +107,9 @@ addon() {
     # i2c-tools
     cp -P $(get_install_dir i2c-tools)/usr/sbin/{i2cdetect,i2cdump,i2cget,i2cset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir i2c-tools)/usr/lib/${PKG_PYTHON_VERSION}/site-packages/smbus.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0.1.1
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.0 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.0 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.0 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0.1.0
 
     # inotify-tools
     cp -P $(get_install_dir inotify-tools)/usr/bin/{inotifywait,inotifywatch} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -107,9 +107,9 @@ addon() {
     # i2c-tools
     cp -P $(get_install_dir i2c-tools)/usr/sbin/{i2cdetect,i2cdump,i2cget,i2cset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir i2c-tools)/usr/lib/${PKG_PYTHON_VERSION}/site-packages/smbus.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.0 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.0 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.0 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0.1.0
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0.1.1
 
     # inotify-tools
     cp -P $(get_install_dir inotify-tools)/usr/bin/{inotifywait,inotifywatch} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin


### PR DESCRIPTION
backport of
- #5767
- #5775
- #5787
- #5915
- #6019


### Updates

- Update bottom to 0.6.6
- Update diffutils to 3.8
- Update efibootmgr to githash 2021-11-05
- Update efivar to githash 2021-12-10
- Update file to 5.41
- Update htop to 3.1.2
- Update i2c-tools to 4.3 and fix build prefix
- Update inotify-tools to 3.21.9.6
- Add libgpiod (1.6.3)
- Update libmtp to 1.1.19
- Update libssh2 to 1.10.0
- Update nmon to 16n
- Update pv to 1.6.20
- Update stress-ng to 0.13.05 and the PKG_URL
- Update unrar to 6.1.3
- Update vim to 8.2.3878