### PR TITLE
libhdhomerun: make lib static

### DIFF
--- a/packages/addons/addon-depends/libhdhomerun/package.mk
+++ b/packages/addons/addon-depends/libhdhomerun/package.mk
@@ -14,15 +14,9 @@ PKG_LONGDESC="The library provides functionality to setup the HDHomeRun."
 PKG_MAKE_OPTS_TARGET="CROSS_COMPILE=${TARGET_PREFIX}"
 
 makeinstall_target() {
-  mkdir -p ${INSTALL}/usr/bin
-    cp -PR hdhomerun_config ${INSTALL}/usr/bin
-
-  mkdir -p ${INSTALL}/usr/lib/
-    cp -PR libhdhomerun.so ${INSTALL}/usr/lib/
-
   mkdir -p ${SYSROOT_PREFIX}/usr/include/hdhomerun
     cp *.h ${SYSROOT_PREFIX}/usr/include/hdhomerun
 
   mkdir -p ${SYSROOT_PREFIX}/usr/lib
-    cp libhdhomerun.so ${SYSROOT_PREFIX}/usr/lib
+    cp libhdhomerun.a ${SYSROOT_PREFIX}/usr/lib
 }

--- a/packages/addons/addon-depends/libhdhomerun/patches/shared-to-static.patch
+++ b/packages/addons/addon-depends/libhdhomerun/patches/shared-to-static.patch
@@ -1,0 +1,54 @@
+diff --git a/Makefile b/Makefile
+index 39cad38c44e1..e98df0336db2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,16 +1,17 @@
+ 
+-LIBSRCS += hdhomerun_channels.c
+-LIBSRCS += hdhomerun_channelscan.c
+-LIBSRCS += hdhomerun_control.c
+-LIBSRCS += hdhomerun_debug.c
+-LIBSRCS += hdhomerun_device.c
+-LIBSRCS += hdhomerun_device_selector.c
+-LIBSRCS += hdhomerun_discover.c
+-LIBSRCS += hdhomerun_os_posix.c
+-LIBSRCS += hdhomerun_pkt.c
+-LIBSRCS += hdhomerun_sock_posix.c
+-LIBSRCS += hdhomerun_video.c
++LIBSRCS += hdhomerun_channels.o
++LIBSRCS += hdhomerun_channelscan.o
++LIBSRCS += hdhomerun_control.o
++LIBSRCS += hdhomerun_debug.o
++LIBSRCS += hdhomerun_device.o
++LIBSRCS += hdhomerun_device_selector.o
++LIBSRCS += hdhomerun_discover.o
++LIBSRCS += hdhomerun_os_posix.o
++LIBSRCS += hdhomerun_pkt.o
++LIBSRCS += hdhomerun_sock_posix.o
++LIBSRCS += hdhomerun_video.o
+ 
++AR    := $(CROSS_COMPILE)ar
+ CC    := $(CROSS_COMPILE)gcc
+ STRIP := $(CROSS_COMPILE)strip
+ 
+@@ -38,14 +39,17 @@ else
+   endif
+ endif
+ 
+-all : hdhomerun_config$(BINEXT) libhdhomerun$(LIBEXT)
++all : hdhomerun_config$(BINEXT) libhdhomerun.a
++
++%.o: %.c
++	$(CC) $(CFLAGS) -fPIC -c -o $@ $<
+ 
+ hdhomerun_config$(BINEXT) : hdhomerun_config.c $(LIBSRCS)
+ 	$(CC) $(CFLAGS) $+ $(LDFLAGS) -o $@
+ 	$(STRIP) $@
+ 
+-libhdhomerun$(LIBEXT) : $(LIBSRCS)
+-	$(CC) $(CFLAGS) -fPIC -DDLL_EXPORT $(SHARED) $+ $(LDFLAGS) -o $@
++libhdhomerun.a : $(LIBSRCS)
++	$(AR) rcs libhdhomerun.a $(LIBSRCS)
+ 
+ clean :
+ 	-rm -f hdhomerun_config$(BINEXT)


### PR DESCRIPTION
Several addons (pvr.hdhomerun, tvheadend42, tvheadend43) link against libhdhomerun shared library. However, that doesn't work in our case, because addons don't carry shared libraries. This PR transforms libhdhomerun to static library so addons include all needed functions directly into them.

Note that only downside now is that there is no hdhomerun_config program. If there is a need, we can always make separate addon for it. 

Not sure if addons need to be bumped. At least they need to be rebuilt.

@CvH @heitbaum please test