### PR TITLE
glib: remove needs_exe_wrapper from makefile

### DIFF
--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -31,10 +31,6 @@ PKG_MESON_OPTS_TARGET="-Ddefault_library=shared \
                        -Dforce_posix_threads=true \
                        -Dtests=false"
 
-if [ "${MACHINE_HARDWARE_NAME}" = "aarch64" -a "${TARGET_ARCH}" = "arm" ]; then
-  PKG_MESON_PROPERTIES_TARGET="needs_exe_wrapper = true"
-fi
-
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin
   rm -rf ${INSTALL}/usr/lib/gdbus-2.0


### PR DESCRIPTION
Fix build issue since https://github.com/LibreELEC/LibreELEC.tv/commit/ad84c1e24b0860d3eb68899c7b757edd85162e9f 
- meson version 0.60.y now fail on errors.
- The reference of a duplicate line `needs_exe_wrapper ` resulted in the failure #6023
