### PR TITLE
[le10] update addons

### DIFF
--- a/packages/addons/service/inadyn/changelog.txt
+++ b/packages/addons/service/inadyn/changelog.txt
@@ -1,3 +1,6 @@
+108
+- Update to 2.9.1
+
 107
 - Update to 2.8.1
 

--- a/packages/addons/service/inadyn/package.mk
+++ b/packages/addons/service/inadyn/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inadyn"
-PKG_VERSION="2.8.1"
-PKG_SHA256="bf575d2c4330821f834f947ff7a30afb83538f0f5802924e8e645a03922a8036"
-PKG_REV="107"
+PKG_VERSION="2.9.1"
+PKG_SHA256="a5e5039a2eb5cd15799490e3ae54127c381a8a0ed05e1a78e798627895d8ab99"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="http://troglobit.com/inadyn.html"

--- a/packages/addons/service/rsyslog/changelog.txt
+++ b/packages/addons/service/rsyslog/changelog.txt
@@ -1,3 +1,6 @@
+109
+- rsyslog: update to 8.2112.0
+
 108
 - rsyslog: update to 8.2106.0
 

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -2,13 +2,13 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rsyslog"
-PKG_VERSION="8.2106.0"
-PKG_SHA256="faf45c25a2265c001739e8888b3652cf685eb3f35cd65d17d5c38fd44b9ddd81"
-PKG_REV="108"
+PKG_VERSION="8.2112.0"
+PKG_SHA256="6a2a973861e9266db37bd2b7b9f672b6b970bfcd743a397b8eee6b0dc4852c41"
+PKG_REV="109"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rsyslog"
-PKG_URL="http://www.rsyslog.com/files/download/rsyslog/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_URL="https://www.rsyslog.com/files/download/rsyslog/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain curl libestr libfastjson libgcrypt liblogging liblognorm librelp util-linux zlib"
 PKG_SECTION="service"
 PKG_SHORTDESC="Rsyslog: a rocket-fast system for log processing."

--- a/packages/addons/tools/btrfs-progs/changelog.txt
+++ b/packages/addons/tools/btrfs-progs/changelog.txt
@@ -1,3 +1,6 @@
+105
+- update to 5.15.1
+
 104
 - update to 5.15
 

--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="btrfs-progs"
-PKG_VERSION="5.15"
-PKG_SHA256="ffa2df3ce6de19cbc2ab58a27018662e3558f16c9cb43eafab3203df2b0f008d"
-PKG_REV="104"
+PKG_VERSION="5.15.1"
+PKG_SHA256="6e7f1155ba8b06ee144bf16e07a22bc1b9ea4f70503e7abc6ee174972cae28c4"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.wiki.kernel.org/index.php/Main_Page"


### PR DESCRIPTION
btrfs-progs: update to 5.15.1
inadyn: update to 2.9.1 and addon (108)
rsyslog: update to 8.2112.0 and addon to (109) and update PKG_URL to

backport of #6038 
- ~~prometheus-node-exporter: update to 1.3.1 and addon (101)~~
  - not included as it is not backported.