### PR TITLE
Package Updates Dec 2021

### DIFF
--- a/packages/audio/libogg/package.mk
+++ b/packages/audio/libogg/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libogg"
-PKG_VERSION="1.3.4"
-PKG_SHA256="c163bc12bc300c401b6aa35907ac682671ea376f13ae0969a220f7ddf71893fe"
+PKG_VERSION="1.3.5"
+PKG_SHA256="c4d91be36fc8e54deae7575241e03f4211eb102afb3fc0775fbbc1b740016705"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.xiph.org/ogg/"
 PKG_URL="http://downloads.xiph.org/releases/ogg/libogg-${PKG_VERSION}.tar.xz"

--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libarchive"
-PKG_VERSION="3.5.1"
-PKG_SHA256="0e17d3a8d0b206018693b27f08029b598f6ef03600c2b5d10c94ce58692e299b"
+PKG_VERSION="3.5.2"
+PKG_SHA256="f0b19ff39c3c9a5898a219497ababbadab99d8178acc980155c7e1271089b5a0"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libarchive.org"
 PKG_URL="https://www.libarchive.org/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/textproc/libidn2/package.mk
+++ b/packages/textproc/libidn2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libidn2"
-PKG_VERSION="2.3.0"
-PKG_SHA256="e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5"
+PKG_VERSION="2.3.2"
+PKG_SHA256="76940cd4e778e8093579a9d195b25fff5e936e9dc6242068528b437a76764f91"
 PKG_LICENSE="LGPL3"
 PKG_SITE="https://www.gnu.org/software/libidn/"
 PKG_URL="http://ftpmirror.gnu.org/gnu/libidn/libidn2-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Bugfix releases for a few mixed packages.

libogg 1.3.5: https://github.com/xiph/ogg/releases/tag/v1.3.5

libarchive 3.5.2: https://github.com/libarchive/libarchive/releases/tag/v3.5.2

libidn2 2.3.1: https://lists.gnu.org/archive/html/info-gnu/2021-05/msg00009.html
libidn2 2.3.2: https://lists.gnu.org/archive/html/info-gnu/2021-07/msg00008.html