### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.2sf"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="ae5cf3fcb35479d7f168c1096139782aed3e9d504b24bcc0534ad50160df712e"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="2eb33ed5055666f08745ad843441a413b0156667065956b3a1cadc261f4f287b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.asap"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="3f47da7f2e189cc87cee4646094f95edc0490ee4a04aae926a4abe945b7aa435"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="3e7b8ce4e084aced8a6e1b8ece9139ab6a54ebcba90ba5243cce64c352e11ce0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.dumb"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="7738701bc162edca354a851c504067d1cbe5880c4d6ed0684678fb4944e03ab3"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="95c66c7ada23b48bb49f9a28e93d8f1d1a23c04638db5a5949dbfe77f1a4d45c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gme"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="64d02e4c9088dd3c0c8168204fd6652395139d3c2834302f1eeafdcedfa4b64b"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="09d89e528fd524ec53524d16c9f41234b84dd3352ae059a9424f987ff97bf5f4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gsf"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="fa282132e35958274d6cf8f7b83b96a70d173728cc6741405abebbd567106361"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="ee32c5c279778ed91562591a4c5d297e03c46d21895e3b42f20293ee85a7e629"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="27cf74e46a2ff8cfc9bc9d4c4542aa0820ed0c83065ea1f7259906e1e542524d"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="7382018b2d459b91f82a31c57ba70e1307d27a5185bfb33ab5665ea2b3a09cd1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- audiodecoder.2sf: update 20.1.0-Nexus to 20.2.0-Nexus
- audiodecoder.asap: update 20.1.0-Nexus to 20.2.0-Nexus
- audiodecoder.dumb: update 20.1.0-Nexus to 20.2.0-Nexus
- audiodecoder.gme: update 20.1.0-Nexus to 20.2.0-Nexus
- audiodecoder.gsf: update 20.1.0-Nexus to 20.2.0-Nexus
- pvr.argustv: update 20.1.0-Nexus to 20.2.0-Nexus