### PR TITLE
update (debug/performance tools): glmark2 and vadumpcaps packages

### DIFF
--- a/packages/debug/vadumpcaps/package.mk
+++ b/packages/debug/vadumpcaps/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vadumpcaps"
-PKG_VERSION="fb4dfef76c0fa08f853af377d5d4945d5fb3001c"
-PKG_SHA256="4362084e366ef66dc6bd9336baa570a5b459dade57783b24001b2847818a8b69"
+PKG_VERSION="38a446e33de5e65f0e5d263dd9a262a4e316a461"
+PKG_SHA256="04847fcae7ed5529371c3ff27518e6ef4623db65955ad6c7633a538c6b2aeae8"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/fhvwy/vadumpcaps"
 PKG_URL="https://github.com/fhvwy/vadumpcaps/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/glmark2/package.mk
+++ b/packages/graphics/glmark2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glmark2"
-PKG_VERSION="2021.02"
-PKG_SHA256="bebadb78c13aea5e88ed892e5563101ccb745b75f1dc86a8fc7229f00d78cbf1"
+PKG_VERSION="2021.12"
+PKG_SHA256="9f111284b2ef1d3fce91928e249e6ca00796a036831b063a549a0f3b03557a95"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/glmark2/glmark2"
 PKG_URL="https://github.com/glmark2/glmark2/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- glmark2: update to 2021.12
- vadumpcaps: update githash to 2022-01-01