### PR TITLE
vdr-addon: update to 2.4.8 and addon (117)

### DIFF
--- a/packages/addons/addon-depends/libzip/package.mk
+++ b/packages/addons/addon-depends/libzip/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libzip"
-PKG_VERSION="1.7.3"
-PKG_SHA256="a60473ffdb7b4260c08bfa19c2ccea0438edac11193c3afbbb1f17fbcf6c6132"
+PKG_VERSION="1.8.0"
+PKG_SHA256="f0763bda24ba947e80430be787c4b068d8b6aa6027a26a19923f0acfa3dac97e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libzip.org/"
 PKG_URL="https://libzip.org/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/libzip/patches/libzip-001-fix-typo-which-prevents-expansion-of-libdir-in-pkgconfig.patch
+++ b/packages/addons/addon-depends/libzip/patches/libzip-001-fix-typo-which-prevents-expansion-of-libdir-in-pkgconfig.patch
@@ -1,0 +1,105 @@
+From ca61524e05d785f0d14f40802c6a1a54a46b74bb Mon Sep 17 00:00:00 2001
+From: rezso <rezso@rezso.net>
+Date: Sat, 19 Jun 2021 01:50:26 +0200
+Subject: [PATCH] CMakeLists.txt: add missing regex for zstd
+
+Currently cmake provides an pc file with:
+Libs.private:  -lbz2 -llzma -lZstd::Zstd -lz
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 93b46a61..defc8745 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -299,6 +299,7 @@ foreach(LIB ${LIBS_PRIVATE})
+ endforeach()
+ string(REGEX REPLACE "-lBZip2::BZip2" "-lbz2" LIBS ${LIBS})
+ string(REGEX REPLACE "-lLibLZMA::LibLZMA" "-llzma" LIBS ${LIBS})
++string(REGEX REPLACE "-lZstd::Zstd" "-lzstd" LIBS ${LIBS})
+ string(REGEX REPLACE "-lOpenSSL::Crypto" "-lssl -lcrypto" LIBS ${LIBS})
+ string(REGEX REPLACE "-lZLIB::ZLIB" "-lz" LIBS ${LIBS})
+ string(REGEX REPLACE "-lGnuTLS::GnuTLS" "-lgnutls" LIBS ${LIBS})
+
+From c4af9182efd9cbb127bb43486b55d9ddf4a521ca Mon Sep 17 00:00:00 2001
+From: Thomas Klausner <tk@giga.or.at>
+Date: Mon, 28 Jun 2021 11:52:15 +0200
+Subject: [PATCH] Try having relative paths in pkg-config file.
+
+Addresses #248
+---
+ CMakeLists.txt | 11 ++++++-----
+ libzip.pc.in   |  7 +++----
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8611a405..93f89df1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -281,11 +281,12 @@ endif()
+ 
+ 
+ # pkgconfig file
+-set(prefix ${CMAKE_INSTALL_PREFIX})
+-set(exec_prefix \${prefix})
+-SET(bindir ${CMAKE_INSTALL_FULL_BINDIR})
+-SET(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+-SET(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
++file(RELATIVE_PATH pc_relative_bindir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_BINDIR})
++set(bindir "\${prefix}/${pc_relative_bindir}")
++file(RELATIVE_PATH pc_relative_libdir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_LIBDIR})
++set(libdir "\${prefix)/${pc_relative_libdir}")
++file(RELATIVE_PATH pc_relative_includedir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_INCLUDEDIR})
++set(includedir "\${prefix}/${pc_relative_includedir}")
+ if(CMAKE_SYSTEM_NAME MATCHES BSD)
+   set(PKG_CONFIG_RPATH "-Wl,-R\${libdir}")
+ endif(CMAKE_SYSTEM_NAME MATCHES BSD)
+diff --git a/libzip.pc.in b/libzip.pc.in
+index 58b3dca7..d51b0ab6 100644
+--- a/libzip.pc.in
++++ b/libzip.pc.in
+@@ -1,10 +1,10 @@
+-prefix=@prefix@
+-exec_prefix=@exec_prefix@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=${prefix}
+ bindir=@bindir@
+ libdir=@libdir@
+ includedir=@includedir@
+ 
+-zipcmp=@bindir@/zipcmp
++zipcmp=${bindir}/zipcmp
+ 
+ Name: libzip
+ Description: library for handling zip archives
+@@ -12,4 +12,3 @@ Version: @PROJECT_VERSION@
+ Libs: @PKG_CONFIG_RPATH@ -L${libdir} -lzip
+ Libs.private: @LIBS@
+ Cflags: -I${includedir}
+-
+
+From 28951cbf403ea3a788f823377bbc171d1e1359ba Mon Sep 17 00:00:00 2001
+From: Michael Heimpold <mhei@heimpold.de>
+Date: Sat, 3 Jul 2021 00:04:14 +0200
+Subject: [PATCH] Fix typo which prevents expansion of libdir in pkgconfig
+ files
+
+Signed-off-by: Michael Heimpold <mhei@heimpold.de>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 93f89df1..2fb87165 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -284,7 +284,7 @@ endif()
+ file(RELATIVE_PATH pc_relative_bindir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_BINDIR})
+ set(bindir "\${prefix}/${pc_relative_bindir}")
+ file(RELATIVE_PATH pc_relative_libdir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_LIBDIR})
+-set(libdir "\${prefix)/${pc_relative_libdir}")
++set(libdir "\${prefix}/${pc_relative_libdir}")
+ file(RELATIVE_PATH pc_relative_includedir ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+ set(includedir "\${prefix}/${pc_relative_includedir}")
+ if(CMAKE_SYSTEM_NAME MATCHES BSD)

--- a/packages/addons/addon-depends/vdr/package.mk
+++ b/packages/addons/addon-depends/vdr/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr"
-PKG_VERSION="2.4.7"
-PKG_SHA256="8d2b34ea3b1139d1d92826477c4afe8db7c7bf4a0cc67ab34062480aaca443cf"
+PKG_VERSION="2.4.8"
+PKG_SHA256="4dce19d99c0ab04c032ce33e7b27a84c73b004d520c28baef572466f43b066d5"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvdr.de"
 PKG_URL="http://git.tvdr.de/?p=vdr.git;a=snapshot;h=refs/tags/${PKG_VERSION};sf=tbz2"

--- a/packages/addons/service/vdr-addon/changelog.txt
+++ b/packages/addons/service/vdr-addon/changelog.txt
@@ -1,3 +1,7 @@
+117
+- update VDR to 2.4.8
+- update libzip to 1.8.0
+
 116
 - update VDR to 2.4.7
 - update eepg to f8698d8

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-addon"
-PKG_VERSION="2.4.7"
-PKG_REV="116"
+PKG_VERSION="2.4.8"
+PKG_REV="117"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- libzip: update to 1.8.0
  - and patch to fix pkgconfig
- vdr-addon: update to 2.4.8 and addon (117)
- vdr: update to 2.4.8
  - http://git.tvdr.de/?p=vdr.git;a=log;h=cea1e4061fa2e5a33c5cc4aab65fa385125252aa
  - Minor update to stable.

**2021-12-27: Version 2.4.8**
- Fixed a possible crash in the Schedule menu, in case Setup.EPGLinger is 0.
- Fixed cTsPayload::AtPayloadStart() to ignore TS packets from other PIDs.
- Fixed unlocking vs. call to EpgHandlers.EndSegmentTransfer() (reported by Christoph  Haubrich).
- Fixed a memory leak in handling the NIT (thanks to Helmut Binder).
- Fixed a possible memory leak in creating fonts (reported by Helmut Binder).
- Fixed calculating the disk use percentage if there's more than 20TB of recordings  (reported by Timo Weingärtner).
- Official release.