### PR TITLE
freetype: update to 2.11.1

### DIFF
--- a/packages/print/freetype/package.mk
+++ b/packages/print/freetype/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="freetype"
-PKG_VERSION="2.10.4"
-PKG_SHA256="86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784"
+PKG_VERSION="2.11.1"
+PKG_SHA256="3333ae7cfda88429c97a7ae63b7d01ab398076c3b67182e960e5684050f2c5c8"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.freetype.org"
+PKG_SITE="https://freetype.org"
 PKG_URL="http://download.savannah.gnu.org/releases/freetype/freetype-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain zlib libpng"

--- a/packages/print/freetype/patches/freetype-01-fix-pkgconf.patch
+++ b/packages/print/freetype/patches/freetype-01-fix-pkgconf.patch
@@ -11,4 +11,4 @@ diff -Naur freetype-2.6.1/builds/unix/freetype2.in freetype-2.6.1.patch/builds/u
 +includedir=${prefix}/include
  
  Name: FreeType 2
- URL: http://freetype.org
+ URL: https://freetype.org


### PR DESCRIPTION
CHANGES BETWEEN 2.10.4 and 2.11.0

  I. IMPORTANT CHANGES

  - A  new rendering  module has  been  added to  create 8-bit  Signed
    Distance Field (SDF)  bitmaps for both outline  and bitmap glyphs.
    The new  rendering mode is called  `FT_RENDER_MODE_SDF`, the pixel
    mode is  `FT_PIXEL_MODE_GRAY8`, and the corresponding  raster flag
    is `FT_RASTER_FLAG_SDF`.

    This work was Anuj Verma's GSoC 2020 project.

  - A new, experimental API is  now available for surfacing properties
    of 'COLR' v1  color fonts (as the name says,  this is an extension
    to  the  'COLR' table  for  outline  color  fonts using  the  SFNT
    container  format).   'COLR'  v1  fonts are  a  recently  proposed
    addition to OFF and OpenType; specification work currently happens
    in

      https://github.com/googlefonts/colr-gradients-spec/

    'COLR'  v1  is  expected  to   be  merged  to  OpenType;  the  ISO
    standardisation process  for adding 'COLR'  v1 as an  amendment to
    OFF is underway.

    Functions similar  to the  already existing  'COLR' API  have been
    added to access the corresponding data.

      FT_Get_Color_Glyph_Paint
        Retrieve the root paint for a given glyph ID.

      FT_Get_Paint_Layers
        Access the layers of a `PaintColrLayers` table.

      FT_Get_Colorline_Stops
        Retrieve the  'color stops' on a  color line.  As an  input, a
        color stop iterator gets used, which in turn is retrieved from
        a paint.

      FT_Get_Paint
        Dereference  an  `FT_OpaquePaint`   object  and  retrieve  the
        corresponding `FT_COLR_Paint`  object, which  contains details
        on how to draw the respective 'COLR' v1 `Paint` table.

  II. MISCELLANEOUS

  - FreeType has moved its infrastructure to

      https://gitlab.freedesktop.org/freetype

    A  side  effect  is  that  the git  repositories  are  now  called
    `freetype.git` and  `freetype-demos.git`, which by  default expand
    to the directories  `freetype` and `freetype-demos`, respectively.
    The documentation has been updated accordingly.

    FreeType's Savannah  repositories will stay; they  are now mirrors
    of the 'freedesktop.org' repositories.

  - A  new  function  `FT_Get_Transform`  returns  the  values set  by
    `FT_Set_Transform`.

  - A  new configuration  macro `FT_DEBUG_LOGGING`  is available.   It
    provides extended debugging capabilities for FreeType, for example
    showing a time stamp or displaying the component a tracing message
    comes from.  See file `docs/DEBUG` for more information.

    This work was Priyesh Kumar's GSoC 2020 project.

  - The legacy Type 1 and CFF  engines are further demoted due to lack
    of CFF2 charstring support.  You now need to use `FT_Property_Set`
    to  enable  them  besides  the  `T1_CONFIG_OPTION_OLD_ENGINE`  and
    `CFF_CONFIG_OPTION_OLD_ENGINE` options, respectively.

  - The experimental 'warp' mode (AF_CONFIG_OPTION_USE_WARPER) for the
    auto-hinter has been removed.

  - The smooth rasterizer performance has been improved by >10%.  Note
    that  due to  necessary code  changes there  might be  very subtle
    differences  in  rendering.  They  are  not  visible by  the  eye,
    however.

  - PCF bitmap fonts compressed with LZW (these are usually files with
    the extension `.pcf.Z`) are now handled correctly.

  - Improved  Meson  build  files,  including  support  to  build  the
    FreeType demo programs.

  - A new demo program `ftsdf` is available to display Signed Distance
    Fields of glyphs.

  - The `ftlint` demo program has been  extended to do more testing of
    its input.  In particular, it  can display horizontal and vertical
    acutances  for quality  assessment,  together  with computing  MD5
    checksums of rendered glyphs.

    [The acutance measures  how sharply the pixel  coverage changes at
     glyph edges.  For monochrome bitmaps,  it is always 2.0 in either
     X or  Y direction.  For  anti-aliased bitmaps, it depends  on the
     hinting and the shape of a glyph and might approach or even reach
     value 2.0  for glyphs like 'I',  'L', '+', '-', or  '=', while it
     might be lower for glyphs like 'O', 'S', or 'W'.]

  - The `ttdebug`  demo program didn't show  changed point coordinates
    (bug introduced in version 2.10.3).

  - It is now possible to adjust the axis increment for variable fonts
    in the `ftmulti` demo program.

  - It is now possible to change  the hinting engine in the `ftstring`
    demo program.

  - The graphical demo programs work  better now in native color depth
    on win32 and x11.