### PR TITLE
jellyfin: update to 10.8.0-beta1 and addon (101)

### DIFF
--- a/packages/addons/service/jellyfin/changelog.txt
+++ b/packages/addons/service/jellyfin/changelog.txt
@@ -1,2 +1,5 @@
+101
+- Update to Jellyfin 10.8.0-beta1
+
 100
 - Initial release

--- a/packages/addons/service/jellyfin/package.mk
+++ b/packages/addons/service/jellyfin/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="jellyfin"
 PKG_VERSION="1.0"
-PKG_VERSION_NUMBER="10.7.6"
-PKG_REV="100"
+PKG_VERSION_NUMBER="10.8.0-beta1"
+PKG_REV="101"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://jellyfin.org/"

--- a/packages/addons/service/jellyfin/source/bin/jellyfin-downloader
+++ b/packages/addons/service/jellyfin/source/bin/jellyfin-downloader
@@ -42,7 +42,7 @@ echo "Downloading Jellyfin"
 # download Jellyfin
 rm -f ${CONTROL_FILE} ${DATA_FILE}
 (
-  curl -L -# -O -C - https://repo.jellyfin.org/releases/server/portable/versions/stable/combined/@JELLYFIN_VERSION@/${JELLYFIN_FILE} 2>${DATA_FILE}
+  curl -L -# -O -C - https://repo.jellyfin.org/releases/server/portable/stable-pre/@JELLYFIN_VERSION@/combined/${JELLYFIN_FILE} 2>${DATA_FILE}
   touch ${CONTROL_FILE}
 ) | \
   while [ : ]; do


### PR DESCRIPTION
Jellyfin 10.8.0 for LE11 support.

- #6064
- #6065
- #6066