### PR TITLE
Web package updates

### DIFF
--- a/packages/web/libmicrohttpd/package.mk
+++ b/packages/web/libmicrohttpd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmicrohttpd"
-PKG_VERSION="0.9.74"
-PKG_SHA256="42035d0261373324bfb434018f4ab892514b10253d1af232e41b4cc2c11e650b"
+PKG_VERSION="0.9.75"
+PKG_SHA256="9278907a6f571b391aab9644fd646a5108ed97311ec66f6359cebbedb0a4e3bb"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="http://www.gnu.org/software/libmicrohttpd/"
 PKG_URL="http://ftpmirror.gnu.org/libmicrohttpd/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.45.1"
-PKG_SHA256="abdc4addccadbc7d89abe27c4d6427d78e57d139f69c1f45749227393c68bf79"
+PKG_VERSION="1.46.0"
+PKG_SHA256="1a68cc4a5732afb735baf50aaac3cb3a6771e49f744bd5db6c49ab5042f12a43"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- libmicrohttpd: update to 0.9.75
  - https://lists.gnu.org/archive/html/info-gnu/2021-12/msg00010.html
- nghttp2: update to 1.46.0
  - https://nghttp2.org/blog/2021/10/19/nghttp2-v1-46-0/
  - https://github.com/nghttp2/nghttp2/releases/tag/v1.46.0