### PR TITLE
Remove libtool preserved temporary RPATH/RUNPATH from "shared object" ELF binaries (libraries/executables)

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -873,6 +873,11 @@ is_sequential_build() {
   [ "${MTWITHLOCKS}" != "yes" ] && return 0 || return 1
 }
 
+# arg1: filename (libtool) to remove hardcode rpath when --disable-rpath is not supported by configure
+libtool_remove_rpath() {
+  sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' ${1}
+  sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' ${1}
+}
 
 ### PACKAGE HELPERS ###
 # get variable ($2) for package ($1).

--- a/packages/addons/addon-depends/ccid/package.mk
+++ b/packages/addons/addon-depends/ccid/package.mk
@@ -14,6 +14,10 @@ PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --enable-twinserial"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 make_target() {
   make
   make -C src/ Info.plist

--- a/packages/addons/addon-depends/chrome-depends/libXcursor/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/libXcursor/package.mk
@@ -11,3 +11,7 @@ PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXcursor-${PKG_VE
 PKG_DEPENDS_TARGET="toolchain libX11 libXfixes libXrender"
 PKG_LONGDESC="X11 Cursor management library.s"
 PKG_BUILD_FLAGS="+pic -sysroot"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/addons/addon-depends/chrome-depends/libxss/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/libxss/package.mk
@@ -12,3 +12,7 @@ PKG_LONGDESC="X11 Screen Saver extension library."
 PKG_BUILD_FLAGS="+pic -sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-malloc0returnsnull"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/addons/addon-depends/libimobiledevice/package.mk
+++ b/packages/addons/addon-depends/libimobiledevice/package.mk
@@ -16,6 +16,10 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --without-cython \
                            --disable-largefile"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   mkdir -p "${SYSROOT_PREFIX}/usr/include/lib/libimobiledevice"
     cp ${PKG_BUILD}/common/utils.h "${SYSROOT_PREFIX}/usr/include/libimobiledevice"

--- a/packages/addons/addon-depends/libusbmuxd/package.mk
+++ b/packages/addons/addon-depends/libusbmuxd/package.mk
@@ -14,3 +14,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            ac_cv_func_realloc_0_nonnull=yes \
                            --enable-static \
                            --disable-shared"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/addons/addon-depends/network-tools-depends/lftp/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/lftp/package.mk
@@ -12,7 +12,12 @@ PKG_LONGDESC="A sophisticated ftp/http client, and a file transfer program suppo
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-nls \
+                           --disable-rpath \
                            --without-gnutls \
                            --with-openssl \
                            --with-readline=${SYSROOT_PREFIX}/usr \
                            --with-zlib=${SYSROOT_PREFIX}/usr"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/addons/addon-depends/pcsc-lite/package.mk
+++ b/packages/addons/addon-depends/pcsc-lite/package.mk
@@ -15,3 +15,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
             --disable-libudev \
             --enable-libusb \
             --enable-usbdropdir=/storage/.kodi/addons/service.pcscd/drivers"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
@@ -19,3 +19,7 @@ fi
 PKG_CONFIGURE_OPTS_TARGET="--with-plugindir=/usr/lib/alsa"
 PKG_MAKE_OPTS_TARGET="SUBDIRS=${SUBDIR_PULSEAUDIO}"
 PKG_MAKEINSTALL_OPTS_TARGET="SUBDIRS=${SUBDIR_PULSEAUDIO}"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/addons/addon-depends/system-tools-depends/depends/libmtp/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/libmtp/package.mk
@@ -15,3 +15,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            --disable-shared \
                            --enable-static \
                            --disable-mtpz"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/addons/addon-depends/system-tools-depends/encfs/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/encfs/package.mk
@@ -13,4 +13,5 @@ PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CMAKE_OPTS_TARGET="-DCMAKE_INSTALL_PREFIX=/usr \
                        -DCMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES=${SYSROOT_PREFIX}/usr/include \
-                       -DBUILD_UNIT_TESTS=OFF"
+                       -DBUILD_UNIT_TESTS=OFF \
+                       -DCMAKE_SKIP_RPATH=ON"

--- a/packages/addons/addon-depends/system-tools-depends/lm_sensors/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/lm_sensors/package.mk
@@ -17,6 +17,8 @@ pre_make_target() {
 
   export CFLAGS="${TARGET_CFLAGS}"
   export CPPFLAGS="${TARGET_CPPFLAGS}"
+
+  sed -i 's|^EXLDFLAGS :=.*|EXLDFLAGS :=|' Makefile
 }
 
 pre_makeinstall_target() {

--- a/packages/addons/addon-depends/tntnet/package.mk
+++ b/packages/addons/addon-depends/tntnet/package.mk
@@ -29,6 +29,10 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-unittest \
                            --with-ssl=no \
                            --with-stressjob=no"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin/${PKG_NAME}-config
   cp ${PKG_NAME}-config ${TOOLCHAIN}/bin

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -33,6 +33,10 @@ pre_configure_target() {
   CFLAGS+=" -fcommon"
 }
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
   cp ${PKG_INSTALL}/usr/sbin/rsyslogd \

--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -25,6 +25,7 @@ PKG_CONFIGURE_OPTS_COMMON="bash_cv_have_mbstate_t=set \
                            --with-expat=yes \
                            --disable-source-highlight \
                            --disable-nls \
+                           --disable-rpath \
                            --disable-sim \
                            --without-x \
                            --disable-tui \

--- a/packages/devel/gettext/package.mk
+++ b/packages/devel/gettext/package.mk
@@ -21,3 +21,10 @@ PKG_CONFIGURE_OPTS_HOST="--disable-static --enable-shared \
                          --disable-native-java \
                          --disable-csharp \
                          --without-emacs"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-rpath"
+
+post_configure_target() {
+  libtool_remove_rpath gettext-runtime/libasprintf/libtool
+  libtool_remove_rpath gettext-tools/libtool
+}

--- a/packages/devel/libirman/package.mk
+++ b/packages/devel/libirman/package.mk
@@ -16,6 +16,10 @@ PKG_BUILD_FLAGS="+pic -parallel"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-swtest"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin
 }

--- a/packages/devel/libplist/package.mk
+++ b/packages/devel/libplist/package.mk
@@ -18,6 +18,10 @@ pre_configure_target() {
   export CONFIG_SHELL="/bin/bash"
 }
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin
 }

--- a/packages/devel/slang/package.mk
+++ b/packages/devel/slang/package.mk
@@ -17,6 +17,7 @@ PKG_CONFIGURE_OPTS_TARGET="--without-onig"
 pre_configure_target() {
  # slang fails to build in subdirs
  cd ${PKG_BUILD}
+ sed -i 's|RPATH=".*"|RPATH=""|' configure
  rm -rf .${TARGET_NAME}
 }
 

--- a/packages/graphics/cairo/package.mk
+++ b/packages/graphics/cairo/package.mk
@@ -63,6 +63,7 @@ pre_configure_target() {
                              --enable-pthread \
                              --enable-gobject=yes \
                              --disable-full-testing \
+                             --disable-rpath \
                              --disable-trace \
                              --enable-interpreter \
                              --disable-symbol-lookup \
@@ -97,4 +98,8 @@ pre_configure_target() {
                                  --disable-glesv2 \
                                  --disable-egl"
   fi
+}
+
+post_configure_target() {
+  libtool_remove_rpath libtool
 }

--- a/packages/graphics/libde265/package.mk
+++ b/packages/graphics/libde265/package.mk
@@ -21,3 +21,7 @@ pre_configure_target() {
   cd ..
   ./autogen.sh
 }
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -23,7 +23,7 @@ PKG_MESON_OPTS_TARGET="-Dlibkms=false \
                        -Dman-pages=false \
                        -Dvalgrind=false \
                        -Dfreedreno-kgsl=false \
-                       -Dinstall-test-programs=false \
+                       -Dinstall-test-programs=true \
                        -Dudev=false"
 
 listcontains "${GRAPHIC_DRIVERS}" "(crocus|i915|iris)" &&
@@ -48,6 +48,14 @@ listcontains "${GRAPHIC_DRIVERS}" "etnaviv" &&
   PKG_MESON_OPTS_TARGET+=" -Detnaviv=true" || PKG_MESON_OPTS_TARGET+=" -Detnaviv=false"
 
 post_makeinstall_target() {
-  mkdir -p ${INSTALL}/usr/bin
-    cp -a ${PKG_BUILD}/.${TARGET_NAME}/tests/modetest/modetest ${INSTALL}/usr/bin/
+  # Remove all test programs installed by install-test-programs=true except modetest
+  # Do not "not use" the ninja install and replace this with a simple "cp modetest"
+  # as ninja strips the unnecessary build rpath during the install.
+  safe_remove ${INSTALL}/usr/bin/amdgpu_stress
+  safe_remove ${INSTALL}/usr/bin/drmdevice
+  safe_remove ${INSTALL}/usr/bin/kms-steal-crtc
+  safe_remove ${INSTALL}/usr/bin/kms-universal-planes
+  safe_remove ${INSTALL}/usr/bin/modeprint
+  safe_remove ${INSTALL}/usr/bin/proptest
+  safe_remove ${INSTALL}/usr/bin/vbltest
 }

--- a/packages/multimedia/libaacs/package.mk
+++ b/packages/multimedia/libaacs/package.mk
@@ -18,6 +18,10 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-werror \
                            --with-libgpg-error-prefix=${SYSROOT_PREFIX}/usr \
                            --with-gnu-ld"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/config/aacs
     cp -P ../KEYDB.cfg ${INSTALL}/usr/config/aacs

--- a/packages/multimedia/libass/package.mk
+++ b/packages/multimedia/libass/package.mk
@@ -20,3 +20,7 @@ if [ ${TARGET_ARCH} = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" nasm:host"
   PKG_CONFIGURE_OPTS_TARGET+=" --enable-asm"
 fi
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/multimedia/libbdplus/package.mk
+++ b/packages/multimedia/libbdplus/package.mk
@@ -23,3 +23,7 @@ if [ "${BLURAY_AACS_SUPPORT}" = "yes" ]; then
 else
   PKG_CONFIGURE_OPTS_TARGET+=" --without-libaacs"
 fi
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/multimedia/libbluray/package.mk
+++ b/packages/multimedia/libbluray/package.mk
@@ -39,3 +39,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-werror \
                            --with-fontconfig \
                            --with-libxml2 \
                            --with-gnu-ld"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/network/avahi/package.mk
+++ b/packages/network/avahi/package.mk
@@ -49,6 +49,7 @@ PKG_CONFIGURE_OPTS_TARGET="py_cv_mod_gtk_=yes \
                            --disable-libevent \
                            --enable-compat-libdns_sd \
                            --disable-compat-howl \
+                           --disable-rpath \
                            --with-xml=expat \
                            --with-avahi-user=avahi \
                            --with-avahi-group=avahi \
@@ -56,6 +57,10 @@ PKG_CONFIGURE_OPTS_TARGET="py_cv_mod_gtk_=yes \
 
 pre_configure_target() {
   NOCONFIGURE=1 ./autogen.sh
+}
+
+post_configure_target() {
+  libtool_remove_rpath libtool
 }
 
 post_makeinstall_target() {

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -46,6 +46,10 @@ pre_configure_target() {
   export LIBS="-lncurses"
 }
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/lib/systemd
   safe_remove ${INSTALL}/usr/bin/bluemoon

--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -68,6 +68,10 @@ PKG_MAKE_OPTS_TARGET="storagedir=/storage/.cache/connman \
                       vpn_storagedir=/storage/.config/wireguard \
                       statedir=/run/connman"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/lib/systemd
   rm -rf ${INSTALL}/usr/lib/tmpfiles.d/connman_resolvconf.conf

--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -12,6 +12,10 @@ PKG_DEPENDS_TARGET="toolchain linux:host libmnl libnftnl"
 PKG_LONGDESC="IP packet filter administration."
 PKG_TOOLCHAIN="autotools"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/config/iptables/
     cp -PR ${PKG_DIR}/config/README ${INSTALL}/usr/config/iptables/

--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -16,6 +16,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-doc \
                            --disable-guile \
                            --disable-libdane \
                            --disable-padlock \
+                           --disable-rpath \
                            --disable-tests \
                            --disable-tools \
                            --disable-valgrind-tests \
@@ -25,3 +26,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-doc \
                            --with-included-unistring \
                            --without-p11-kit \
                            --without-tpm"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/sysutils/libusb-compat/package.mk
+++ b/packages/sysutils/libusb-compat/package.mk
@@ -10,7 +10,13 @@ PKG_URL="https://github.com/libusb/libusb-compat-0.1/releases/download/v${PKG_VE
 PKG_DEPENDS_TARGET="toolchain libusb"
 PKG_LONGDESC="The libusb project's aim is to create a Library for use by user level applications to USB devices."
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-log --disable-debug-log --disable-examples-build"
+PKG_CONFIGURE_OPTS_TARGET="--disable-log \
+                           --disable-debug-log \
+                           --disable-examples-build"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin

--- a/packages/sysutils/lirc/package.mk
+++ b/packages/sysutils/lirc/package.mk
@@ -30,6 +30,10 @@ pre_configure_target() {
   fi
 }
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/lib/systemd
   rm -rf ${INSTALL}/lib

--- a/packages/sysutils/open-vm-tools/package.mk
+++ b/packages/sysutils/open-vm-tools/package.mk
@@ -41,6 +41,10 @@ pre_configure_target() {
   export LIBS="-ldnet -ltirpc"
 }
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/sbin
   rm -rf ${INSTALL}/usr/share

--- a/packages/sysutils/parted/package.mk
+++ b/packages/sysutils/parted/package.mk
@@ -25,6 +25,10 @@ pre_configure_init() {
   : # reuse pre_configure_target()
 }
 
+post_configure_init() {
+  : # reuse post_configure_target()
+}
+
 configure_init() {
   : # reuse configure_target()
 }
@@ -41,4 +45,8 @@ makeinstall_init() {
 
 pre_configure_target() {
   export CFLAGS+=" -I${PKG_BUILD}/lib"
+}
+
+post_configure_target() {
+  libtool_remove_rpath libtool
 }

--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -70,6 +70,10 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_lib_rtmp_RTMP_Init=yes \
                            --with-libidn2 \
                            --with-nghttp2"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/share/zsh
 

--- a/packages/x11/driver/xf86-input-synaptics/package.mk
+++ b/packages/x11/driver/xf86-input-synaptics/package.mk
@@ -12,3 +12,7 @@ PKG_LONGDESC="Synaptics touchpad driver for X.Org."
 PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="--with-xorg-module-dir=${XORG_PATH_MODULES}"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/driver/xf86-video-ati/package.mk
+++ b/packages/x11/driver/xf86-video-ati/package.mk
@@ -16,6 +16,10 @@ PKG_TOOLCHAIN="autotools"
 PKG_CONFIGURE_OPTS_TARGET="--enable-glamor \
                            --with-xorg-module-dir=${XORG_PATH_MODULES}"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/etc/X11
     cp ${PKG_DIR}/config/*.conf ${INSTALL}/etc/X11

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -40,6 +40,10 @@ else
   PKG_CONFIGURE_OPTS_TARGET+=" --with-default-dri=2"
 fi
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/share/polkit-1
 }

--- a/packages/x11/driver/xf86-video-vmware/package.mk
+++ b/packages/x11/driver/xf86-video-vmware/package.mk
@@ -15,3 +15,7 @@ PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-vmwarectrl-client \
                            --with-xorg-module-dir=${XORG_PATH_MODULES}"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXcomposite/package.mk
+++ b/packages/x11/lib/libXcomposite/package.mk
@@ -13,3 +13,7 @@ PKG_LONGDESC="X Composite Library"
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXdamage/package.mk
+++ b/packages/x11/lib/libXdamage/package.mk
@@ -13,3 +13,7 @@ PKG_LONGDESC="LibXdamage provides an X Window System client interface to the DAM
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXext/package.mk
+++ b/packages/x11/lib/libXext/package.mk
@@ -12,3 +12,7 @@ PKG_DEPENDS_TARGET="toolchain util-macros libX11"
 PKG_LONGDESC="LibXext provides an X Window System client interface to several extensions to the X protocol."
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-malloc0returnsnull --without-xmlto"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXfixes/package.mk
+++ b/packages/x11/lib/libXfixes/package.mk
@@ -13,3 +13,7 @@ PKG_LONGDESC="X Fixes Library"
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXfont2/package.mk
+++ b/packages/x11/lib/libXfont2/package.mk
@@ -20,3 +20,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-ipv6 \
                            --enable-fc \
                            --with-gnu-ld \
                            --without-xmlto"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXi/package.mk
+++ b/packages/x11/lib/libXi/package.mk
@@ -22,3 +22,7 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
                            --without-xsltproc \
                            --without-asciidoc \
                            --with-gnu-ld"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXinerama/package.mk
+++ b/packages/x11/lib/libXinerama/package.mk
@@ -12,3 +12,7 @@ PKG_DEPENDS_TARGET="toolchain util-macros libXext"
 PKG_LONGDESC="libXinerama is the Xinerama library."
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --enable-malloc0returnsnull"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXrandr/package.mk
+++ b/packages/x11/lib/libXrandr/package.mk
@@ -12,3 +12,7 @@ PKG_DEPENDS_TARGET="toolchain util-macros libX11 libXrender libXext"
 PKG_LONGDESC="Xrandr is a simple library designed to interface the X Resize and Rotate Extension."
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-malloc0returnsnull"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXrender/package.mk
+++ b/packages/x11/lib/libXrender/package.mk
@@ -13,3 +13,7 @@ PKG_LONGDESC="The X Rendering Extension introduces digital image composition wit
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --enable-malloc0returnsnull"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/lib/libXtst/package.mk
+++ b/packages/x11/lib/libXtst/package.mk
@@ -12,3 +12,7 @@ PKG_DEPENDS_TARGET="toolchain util-macros libXext libXi libX11"
 PKG_LONGDESC="The Xtst Library"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --with-gnu-ld --without-xmlto"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/x11/other/fontconfig/package.mk
+++ b/packages/x11/other/fontconfig/package.mk
@@ -17,7 +17,8 @@ PKG_CONFIGURE_OPTS_TARGET="--with-arch=${TARGET_ARCH} \
                            --with-default-fonts=/usr/share/fonts \
                            --without-add-fonts \
                            --disable-dependency-tracking \
-                           --disable-docs"
+                           --disable-docs \
+                           --disable-rpath"
 
 pre_configure_target() {
 # ensure we dont use '-O3' optimization.
@@ -25,6 +26,10 @@ pre_configure_target() {
   CXXFLAGS=$(echo ${CXXFLAGS} | sed -e "s|-O3|-O2|")
   CFLAGS+=" -I${PKG_BUILD}"
   CXXFLAGS+=" -I${PKG_BUILD}"
+}
+
+post_configure_target() {
+  libtool_remove_rpath libtool
 }
 
 post_makeinstall_target() {


### PR DESCRIPTION
This is **Part 1** of the RPATH cleanup
1. Update ”shared object” - `/lib` - to remove incorrect RPATH/RUNPATH 
  - This PR
2. Update “binaries” - `/sbin`,`/bin` - to remove incorrect RPATH/RUNPATH 
  - (included in this PR) #6097
3. Update “addons” - to remove incorrect RPATH/RUNPATH
4. Revisit any missed 1, 2, 3
5. Update buildsystem with `check-rpaths`
6. Review why `ldd` `system search path=` includes variants of hardware / hwcaps  library paths

### Background

The buildhost cross compile hardcoded library paths e.g. `/build/LibreELEC.kernel11/build.LibreELEC-iMX6.arm-11.0-devel/toolchain/armv7a-libreelec-linux-gnueabihf/sysroot/usr/lib` are being included in binaries and libraries. 

This was discovered by accident when I rebooted my system (which is a buildhost) with glib2.32 in the build...-Generic directory after doing a test build of my development branch with a non matching glibc (GLIB_2.33). `systemd` refused to start as it was using the RPATH "shared object" - not `LD_LIBRARY_PATH`. RPATH always comes before `LD_LIBRARY_PATH`

As discussed in the **Fedora Packaging Guidelines** - _...Since the Linux dynamic linker is usually smarter than a hardcoded path, we usually do not permit the use of rpath in Fedora...._ This has not caused issue in LE - given that the JEOS is read only, and that the /lib is a point in time **static** when the image is generated. Though when `-rpath` or `-R` and the subsequent `RPATH`/`RUNPATH` are included in the ELF _binaries/libraries_ and this hardcoded location information is examined by `ld.so` in the beginning of the execution causing the error discovered. The article **Shared Libraries: Understanding Dynamic Loading** by _Amir Rachum_ is a good read to understand how dynamic loading of shared libraries works in Linux systems

The following library search path order is used for the RPATH, LD_LIBRARY_PATH, and RUNPATH:
1. the RPATH binary header (set at build-time) of the library causing the lookup (if any)
2. the RPATH binary header (set at build-time) of the executable
3. the LD_LIBRARY_PATH environment variable (set at run-time)
4. the RUNPATH binary header (set at build-time) of the executable
5. /etc/ld.so.cache
6. base library directories (/lib and /usr/lib)

### Detail of  the PR

This PR updates the "shared object" ELF binaries (libraries) to not have **RPATH** or **RUNPATH** (when it is not necessary.)
- when the RPATH/RUNPATH contains a standard rpath
  - e.g.  '/usr/lib' in `RUNPATH           Library runpath: [/usr/lib]` 
- when RPATH/RUNPATH has the cross compile path embedded
  - e.g. `RUNPATH           Library runpath: [/build/LibreELEC.kernel11/build.LibreELEC-iMX6.arm-11.0-devel/toolchain/armv7a-libreelec-linux-gnueabihf/sysroot/usr/lib]`

In the below example `libcurl` has the build path included in the shared object. This is not correct nor ideal.
```
cubox:~ # readelf --dynamic /lib/libcurl.so | grep PATH
  RUNPATH           Library runpath: [/build/LibreELEC.kernel11/build.LibreELEC-iMX6.arm-11.0-devel/toolchain/armv7a-libreelec-linux-gnueabihf/sysroot/usr/lib]
```

A further solution to be put in place (for the whole build) is the inclusion of something similar to the `check-rpaths` tool from `rpmdevtools`

### Reading
- https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
  - use `CMAKE_SKIP_RPATH`
- https://ftp.gnu.org/old-gnu/Manuals/libtool-1.4.2/html_node/libtool_70.html
- **https://docs.fedoraproject.org/en-US/packaging-guidelines/#_beware_of_rpath**
- **https://amir.rachum.com/blog/2016/09/17/shared-libraries/#rpath-and-runpath**
- https://serverfault.com/questions/720830/building-curl-httpd-and-others-with-custom-openssl-build-while-avoiding-defaul
- https://stackoverflow.com/questions/30398238/cmake-rpath-not-working-could-not-find-shared-object-file
- http://blog.tremily.us/posts/rpath/

### Results
After the PR - the output of the `/usr/lib` shows only the following RPATH/RUNPATH
- further understanding of why `gconv`, `llvm`, and `pulse` use RPATH/RUNPATH will be undertaken in part 4 before these are changed / updated
```
nuc11:~ # find /usr/lib -type f | while read x
do
  file $x | grep "shared object" > /dev/null && \
    a=`readelf --dynamic $x | grep PATH` &&
      printf "$x\t$a\n"
done

/usr/lib/gconv/EUC-CN.so          RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/EUC-JISX0213.so    RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/EUC-JP-MS.so       RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/EUC-JP.so          RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/EUC-KR.so          RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/EUC-TW.so          RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/ISO-2022-CN-EXT.so         RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/ISO-2022-CN.so     RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/ISO-2022-JP-3.so   RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/ISO-2022-JP.so     RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/ISO-2022-KR.so     RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/JOHAB.so   RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/SHIFT_JISX0213.so          RPATH             Library rpath: [$ORIGIN]
/usr/lib/gconv/UHC.so     RPATH             Library rpath: [$ORIGIN]

/usr/lib/libLLVM-13.so    RUNPATH           Library runpath: [$ORIGIN/../lib]
/usr/lib/libLTO.so.13     RUNPATH           Library runpath: [$ORIGIN/../lib]
/usr/lib/libRemarks.so.13         RUNPATH           Library runpath: [$ORIGIN/../lib]

/usr/lib/libpulse-mainloop-glib.so.0.0.6          RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/libpulse-simple.so.0.1.1         RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/libpulse.so.0.24.0       RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/libalsa-util.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/libavahi-wrap.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/libbluez5-util.so          RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/libcli.so          RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/libprotocol-cli.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/libprotocol-http.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/libprotocol-native.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/libprotocol-simple.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/libraop.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/librtp.so          RUNPATH           Library runpath: [/usr/lib/pulseaudio]
/usr/lib/pulse/module-allow-passthrough.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-alsa-card.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-alsa-sink.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-alsa-source.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-always-sink.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-always-source.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-augment-properties.so       RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-bluetooth-discover.so       RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-bluetooth-policy.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-bluez5-device.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-bluez5-discover.so          RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-card-restore.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-cli-protocol-tcp.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-cli-protocol-unix.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-cli.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-combine-sink.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-combine.so          RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-console-kit.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-dbus-protocol.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-default-device-restore.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-detect.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-device-manager.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-device-restore.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-echo-cancel.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-filter-apply.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-filter-heuristics.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-http-protocol-tcp.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-http-protocol-unix.so       RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-intended-roles.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-ladspa-sink.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-loopback.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-match.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-mmkbd-evdev.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-native-protocol-fd.so       RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-native-protocol-tcp.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-native-protocol-unix.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-null-sink.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-null-source.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-pipe-sink.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-pipe-source.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-position-event-sounds.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-raop-discover.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-raop-sink.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-remap-sink.so       RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-remap-source.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-rescue-streams.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-role-cork.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-role-ducking.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-rtp-recv.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-rtp-send.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-rygel-media-server.so       RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-simple-protocol-tcp.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-simple-protocol-unix.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-sine-source.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-sine.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-stream-restore.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-suspend-on-idle.so          RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-switch-on-connect.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-switch-on-port-available.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-systemd-login.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-tunnel-sink-new.so          RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-tunnel-sink.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-tunnel-source-new.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-tunnel-source.so    RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-udev-detect.so      RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-virtual-sink.so     RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-virtual-source.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-volume-restore.so   RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-zeroconf-discover.so        RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulse/module-zeroconf-publish.so         RUNPATH           Library runpath: [/usr/lib/pulseaudio:/usr/lib/pulse]
/usr/lib/pulseaudio/libpulsecore-15.0.so          RUNPATH           Library runpath: [/usr/lib/pulseaudio]
```

show the trace of `libcurl` which correctly finds all its dependancies (without the need to use the `LD_LIBRARY_PATH` - **as expected**)
```
# LD_LIBRARY_PATH= LD_DEBUG=libs ldd -v /usr/lib/libcurl.so
     18139:     find library=libm.so.6 [0]; searching
     18139:      search cache=/etc/ld.so.cache
     18139:      search path=/usr/lib/glibc-hwcaps/x86-64-v4:/usr/lib/glibc-hwcaps/x86-64-v3:/usr/lib/glibc-hwcaps/x86-64-v2:/usr/lib/tls/haswell/avx512_1/x86_64:/usr/lib/tls/haswell/avx512_1:/usr/lib/tls/haswell/x86_64:/usr/lib/tls/haswell:/usr/lib/tls/avx512_1/x86_64:/usr/lib/tls/avx512_1:/usr/lib/tls/x86_64:/usr/lib/tls:/usr/lib/haswell/avx512_1/x86_64:/usr/lib/haswell/avx512_1:/usr/lib/haswell/x86_64:/usr/lib/haswell:/usr/lib/avx512_1/x86_64:/usr/lib/avx512_1:/usr/lib/x86_64:/usr/lib                (system search path)
     18139:       trying file=/usr/lib/glibc-hwcaps/x86-64-v4/libm.so.6
     18139:       trying file=/usr/lib/glibc-hwcaps/x86-64-v3/libm.so.6
     18139:       trying file=/usr/lib/glibc-hwcaps/x86-64-v2/libm.so.6
     18139:       trying file=/usr/lib/tls/haswell/avx512_1/x86_64/libm.so.6
     18139:       trying file=/usr/lib/tls/haswell/avx512_1/libm.so.6
     18139:       trying file=/usr/lib/tls/haswell/x86_64/libm.so.6
     18139:       trying file=/usr/lib/tls/haswell/libm.so.6
     18139:       trying file=/usr/lib/tls/avx512_1/x86_64/libm.so.6
     18139:       trying file=/usr/lib/tls/avx512_1/libm.so.6
     18139:       trying file=/usr/lib/tls/x86_64/libm.so.6
     18139:       trying file=/usr/lib/tls/libm.so.6
     18139:       trying file=/usr/lib/haswell/avx512_1/x86_64/libm.so.6
     18139:       trying file=/usr/lib/haswell/avx512_1/libm.so.6
     18139:       trying file=/usr/lib/haswell/x86_64/libm.so.6
     18139:       trying file=/usr/lib/haswell/libm.so.6
     18139:       trying file=/usr/lib/avx512_1/x86_64/libm.so.6
     18139:       trying file=/usr/lib/avx512_1/libm.so.6
     18139:       trying file=/usr/lib/x86_64/libm.so.6
     18139:       trying file=/usr/lib/libm.so.6
     18139:     
     18139:     find library=libc.so.6 [0]; searching
     18139:      search cache=/etc/ld.so.cache
     18139:      search path=/usr/lib           (system search path)
     18139:       trying file=/usr/lib/libc.so.6
     18139:     
     18139:     
     18139:     calling init: /lib64/ld-linux-x86-64.so.2
     18139:     
     18139:     
     18139:     calling init: /usr/lib/libc.so.6
     18139:     
     18139:     
     18139:     calling init: /usr/lib/libm.so.6
     18139:     
     18139:     
     18139:     initialize program: /bin/bash
     18139:     
     18139:     
     18139:     transferring control: /bin/bash
     18139:     
     18143:     find library=libnghttp2.so.14 [0]; searching
     18143:      search cache=/etc/ld.so.cache
     18143:      search path=/usr/lib/glibc-hwcaps/x86-64-v4:/usr/lib/glibc-hwcaps/x86-64-v3:/usr/lib/glibc-hwcaps/x86-64-v2:/usr/lib/tls/haswell/avx512_1/x86_64:/usr/lib/tls/haswell/avx512_1:/usr/lib/tls/haswell/x86_64:/usr/lib/tls/haswell:/usr/lib/tls/avx512_1/x86_64:/usr/lib/tls/avx512_1:/usr/lib/tls/x86_64:/usr/lib/tls:/usr/lib/haswell/avx512_1/x86_64:/usr/lib/haswell/avx512_1:/usr/lib/haswell/x86_64:/usr/lib/haswell:/usr/lib/avx512_1/x86_64:/usr/lib/avx512_1:/usr/lib/x86_64:/usr/lib                (system search path)
     18143:       trying file=/usr/lib/glibc-hwcaps/x86-64-v4/libnghttp2.so.14
     18143:       trying file=/usr/lib/glibc-hwcaps/x86-64-v3/libnghttp2.so.14
     18143:       trying file=/usr/lib/glibc-hwcaps/x86-64-v2/libnghttp2.so.14
     18143:       trying file=/usr/lib/tls/haswell/avx512_1/x86_64/libnghttp2.so.14
     18143:       trying file=/usr/lib/tls/haswell/avx512_1/libnghttp2.so.14
     18143:       trying file=/usr/lib/tls/haswell/x86_64/libnghttp2.so.14
     18143:       trying file=/usr/lib/tls/haswell/libnghttp2.so.14
     18143:       trying file=/usr/lib/tls/avx512_1/x86_64/libnghttp2.so.14
     18143:       trying file=/usr/lib/tls/avx512_1/libnghttp2.so.14
     18143:       trying file=/usr/lib/tls/x86_64/libnghttp2.so.14
     18143:       trying file=/usr/lib/tls/libnghttp2.so.14
     18143:       trying file=/usr/lib/haswell/avx512_1/x86_64/libnghttp2.so.14
     18143:       trying file=/usr/lib/haswell/avx512_1/libnghttp2.so.14
     18143:       trying file=/usr/lib/haswell/x86_64/libnghttp2.so.14
     18143:       trying file=/usr/lib/haswell/libnghttp2.so.14
     18143:       trying file=/usr/lib/avx512_1/x86_64/libnghttp2.so.14
     18143:       trying file=/usr/lib/avx512_1/libnghttp2.so.14
     18143:       trying file=/usr/lib/x86_64/libnghttp2.so.14
     18143:       trying file=/usr/lib/libnghttp2.so.14
     18143:     
     18143:     find library=libidn2.so.0 [0]; searching
     18143:      search cache=/etc/ld.so.cache
     18143:      search path=/usr/lib           (system search path)
     18143:       trying file=/usr/lib/libidn2.so.0
     18143:     
     18143:     find library=libssl.so.3 [0]; searching
     18143:      search cache=/etc/ld.so.cache
     18143:      search path=/usr/lib           (system search path)
     18143:       trying file=/usr/lib/libssl.so.3
     18143:     
     18143:     find library=libcrypto.so.3 [0]; searching
     18143:      search cache=/etc/ld.so.cache
     18143:      search path=/usr/lib           (system search path)
     18143:       trying file=/usr/lib/libcrypto.so.3
     18143:     
     18143:     find library=libz.so.1 [0]; searching
     18143:      search cache=/etc/ld.so.cache
     18143:      search path=/usr/lib           (system search path)
     18143:       trying file=/usr/lib/libz.so.1
     18143:     
     18143:     find library=libc.so.6 [0]; searching
     18143:      search cache=/etc/ld.so.cache
     18143:      search path=/usr/lib           (system search path)
     18143:       trying file=/usr/lib/libc.so.6
     18143:     
        linux-vdso.so.1 (0x00007ffd99fc8000)
        libnghttp2.so.14 => /usr/lib/libnghttp2.so.14 (0x00007f4cf6d26000)
        libidn2.so.0 => /usr/lib/libidn2.so.0 (0x00007f4cf6cd3000)
        libssl.so.3 => /usr/lib/libssl.so.3 (0x00007f4cf6c39000)
        libcrypto.so.3 => /usr/lib/libcrypto.so.3 (0x00007f4cf6805000)
        libz.so.1 => /usr/lib/libz.so.1 (0x00007f4cf67ed000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f4cf6606000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f4cf6de4000)

        Version information:
        /usr/lib/libcurl.so:
                libcrypto.so.3 (OPENSSL_3.0.0) => /usr/lib/libcrypto.so.3
                libc.so.6 (GLIBC_2.3) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.34) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.3.4) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.33) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.17) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.7) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.2.5) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.14) => /usr/lib/libc.so.6
                libssl.so.3 (OPENSSL_3.0.0) => /usr/lib/libssl.so.3
                libidn2.so.0 (IDN2_0.0.0) => /usr/lib/libidn2.so.0
        /usr/lib/libnghttp2.so.14:
                libc.so.6 (GLIBC_2.2.5) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.14) => /usr/lib/libc.so.6
        /usr/lib/libidn2.so.0:
                libc.so.6 (GLIBC_2.2.5) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.14) => /usr/lib/libc.so.6
        /usr/lib/libssl.so.3:
                libcrypto.so.3 (OPENSSL_3.0.0) => /usr/lib/libcrypto.so.3
                libc.so.6 (GLIBC_2.2.5) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.14) => /usr/lib/libc.so.6
        /usr/lib/libcrypto.so.3:
                libc.so.6 (GLIBC_2.17) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.7) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.33) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.16) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.2.5) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.3.2) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.14) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.25) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.3) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.34) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.3.4) => /usr/lib/libc.so.6
        /usr/lib/libz.so.1:
                libc.so.6 (GLIBC_2.2.5) => /usr/lib/libc.so.6
                libc.so.6 (GLIBC_2.14) => /usr/lib/libc.so.6
        /usr/lib/libc.so.6:
                ld-linux-x86-64.so.2 (GLIBC_2.2.5) => /usr/lib64/ld-linux-x86-64.so.2
                ld-linux-x86-64.so.2 (GLIBC_2.3) => /usr/lib64/ld-linux-x86-64.so.2
                ld-linux-x86-64.so.2 (GLIBC_PRIVATE) => /usr/lib64/ld-linux-x86-64.so.2
```