### PR TITLE
rust: cleaner rust target-applies-to-host fix

### DIFF
--- a/packages/addons/addon-depends/librespot-depends/rust/package.mk
+++ b/packages/addons/addon-depends/librespot-depends/rust/package.mk
@@ -51,8 +51,8 @@ if [ "${HOSTTYPE}" = "${TARGET_ARCH}" ]; then
   # by the cross compiler. Read more here.
   # https://doc.rust-lang.org/cargo/reference/unstable.html#target-applies-to-host
   export __CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS="nightly"
+  export CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST="true"
   export CARGO_TARGET_APPLIES_TO_HOST="false"
-  export CARGO_Z_TARGET_APPLIES_TO_HOST="-Z target-applies-to-host"
 fi
 export PATH="${CARGO_HOME}/bin:${PATH}"
 export PKG_CONFIG_ALLOW_CROSS="1"

--- a/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
@@ -14,7 +14,6 @@ PKG_TOOLCHAIN="manual"
 make_target() {
   . "$(get_build_dir rust)/cargo/env"
   cargo build \
-    ${CARGO_Z_TARGET_APPLIES_TO_HOST} \
     --release \
     --locked \
     --all-features

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -25,7 +25,6 @@ PKG_MAINTAINER="Anton Voyl (awiouy)"
 make_target() {
   . $(get_build_dir rust)/cargo/env
   cargo build \
-    ${CARGO_Z_TARGET_APPLIES_TO_HOST} \
     --release \
     --no-default-features \
     --features "alsa-backend pulseaudio-backend with-dns-sd"


### PR DESCRIPTION
Looks like we can set this without passing a command line option.