### PR TITLE
linux: add udev rule to switch mode on Realtek RTL8821CU devices

### DIFF
--- a/packages/linux/udev.d/40-modeswitch.rules
+++ b/packages/linux/udev.d/40-modeswitch.rules
@@ -8,4 +8,10 @@ SUBSYSTEM!="block", GOTO="end_modeswitch"
 # Atheros Wireless / Netgear WNDA3200
 ATTRS{idVendor}=="0cf3", ATTRS{idProduct}=="20ff", RUN+="/usr/bin/eject '/dev/%k'"
 
+# Realtek RTL8821CU chipset 802.11ac NIC
+#   initial cdrom mode 0bda:1a2b, wlan mode 0bda:c811
+# Odroid WiFi Module 5B
+#   initial cdrom mode 0bda:1a2b, wlan mode 0bda:c820
+ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="1a2b", RUN+="/usr/bin/eject '/dev/%k'"
+
 LABEL="end_modeswitch"


### PR DESCRIPTION
[    2.325991@0] usb 1-1.1: new high-speed USB device number 3 using xhci-hcd
[    2.486315@0] usb 1-1.1: New USB device found, idVendor=0bda, idProduct=1a2b
[    2.486319@0] usb 1-1.1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[    2.486321@0] usb 1-1.1: Product: DISK
[    2.486323@0] usb 1-1.1: Manufacturer: Realtek
[    2.487139@0] usb-storage 1-1.1:1.0: USB Mass Storage device detected
[    2.487397@0] scsi host0: usb-storage 1-1.1:1.0

[    5.906100@2] usb 1-1.1: reset high-speed USB device number 3 using xhci-hcd
[    6.054094@0] usb 1-1.1: device firmware changed
[    6.054633@0] usb 1-1.1: USB disconnect, device number 3
[    6.218828@0] usb 1-1.1: new high-speed USB device number 5 using xhci-hcd
[    6.366480@0] usb 1-1.1: New USB device found, idVendor=0bda, idProduct=c811
[    6.366488@0] usb 1-1.1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[    6.366490@0] usb 1-1.1: Product: 802.11ac NIC
[    6.366493@0] usb 1-1.1: Manufacturer: Realtek
[    6.366495@0] usb 1-1.1: SerialNumber: 123456
[    6.390378@0] usb 1-1.1: Unsupported device
[    6.699679@0] usbcore: registered new interface driver rtl8821cu