### PR TITLE
mesa: update to 21.3.4

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="21.3.3"
-PKG_SHA256="ad7f4613ea7c5d08d9fcb5025270199e6ceb9aa99fd72ee572b70342240a8121"
+PKG_VERSION="21.3.4"
+PKG_SHA256="77104fd4a93bce69da3b0982f8ee88ba7c4fb98cfc491a669894339cdcd4a67d"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
release notes:
- https://docs.mesa3d.org/relnotes/21.3.4.html
- https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/docs/relnotes/21.3.4.rst

Bug fixes
- i965: gen5 exposes EXT_texture_integer incorrectly
- [radeonsi, regression, bisected]: Rendering issues with Factorio
- mesa >= 21.x (with llvmpipe) will break the game JVGS
- Panfrost - RK3399 - FACTORIO - glitches everywhere
- Baldurs Gate 3 (Patch 6) - ribbon-like artifacts on textures
- Game Starsector crashes under certain circumstances with mesa 21.3.+
- FreeSpace models incorrectly rendered on Polaris cards, causing system freeze
- Incomplete evaluation of nested DEFINE macros
- [r300g, bisected] piglit glsl-fs-discard-04 fails
- Panfrost G52 Firefox terrible glitches on youtube playback