### PR TITLE
distro: disable espeak

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -88,7 +88,7 @@
   PULSEAUDIO_SUPPORT="yes"
 
 # build and install eSpeak-NG support (yes / no)
-  ESPEAK_SUPPORT="yes"
+  ESPEAK_SUPPORT="no"
 
 # build and install with BluRay support (yes / no)
   KODI_BLURAY_SUPPORT="yes"


### PR DESCRIPTION
The espeak-ng package doesn't build so disable it until that's fixed