### PR TITLE
media-driver: update to 22.1.1

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.1.0"
-PKG_SHA256="6c1cd5c4c1b7bd1c7785ed4d553b76b17dd7e673619a39e0c3070246aa671024"
+PKG_VERSION="22.1.1"
+PKG_SHA256="6eaa4a9caf58faa8934b253adb4b0ece1c7d5de6f084167d5138b4e3ba423683"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20220114083908-b1f573f
Linux nuc11 5.16.1-rc1 #1 SMP Fri Jan 14 08:40:35 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.101) Git:5ad708b518e6bb3e8ac31a9c7b5a8908573a409f). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-01-13 by GCC 10.3.0 for Linux x86 64-bit version 5.16.0 (331776)
Running on LibreELEC (heitbaum): devel-20220114083908-b1f573f 11.0, kernel: Linux x86 64-bit version 5.16.1-rc1
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0041.2021.0811.1505 08/11/2021
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 21.3.4
libva info: VA-API version 1.13.0
vainfo: VA-API version: 1.13 (libva 2.13.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.1.1 (48f11f7351)
```