### PR TITLE
kodi: update to e976cd0

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="5ad708b518e6bb3e8ac31a9c7b5a8908573a409f"
-PKG_SHA256="db16e3bdacfbb816a98d99c94720e80d91eeb8024a35c16775b6916089e7eecf"
+PKG_VERSION="e976cd0e3ad9ed0e4ff80e2f97e2fce1922717be"
+PKG_SHA256="a2ebdddcba17906429252355018403b1ab668c943214e05575d7c9b967ee57fe"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
@@ -3,7 +3,7 @@ Subject: disable online check
 ---
 --- a/xbmc/GUIInfoManager.cpp
 +++ b/xbmc/GUIInfoManager.cpp
-@@ -1797,7 +1797,6 @@ const infomap system_labels[] = {{"hasne
+@@ -1832,7 +1832,6 @@ const infomap system_labels[] = {{"hasne
                                   {"currentcontrol", SYSTEM_CURRENT_CONTROL},
                                   {"currentcontrolid", SYSTEM_CURRENT_CONTROL_ID},
                                   {"dvdlabel", SYSTEM_DVD_LABEL},


### PR DESCRIPTION
This fixes the ac3 transcoding bug https://forum.libreelec.tv/thread/24741-librelec-nightly-dolby-digital-transcoding-bug/
 
Runtime tested on RPi4, DTS to AC3 transcoding worked fine