### PR TITLE
linux (Allwinner): bluetooth btrtl: add hci_ver 0x8 for rtl8822cs_bt as found on Tanix TX6

### DIFF
--- a/projects/Allwinner/patches/linux/0056-bluetooth-btrtl-add-hci-ver-rtl8822cs.patch
+++ b/projects/Allwinner/patches/linux/0056-bluetooth-btrtl-add-hci-ver-rtl8822cs.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 15 Jan 2022 08:09:20 +0000
+Subject: [PATCH] linux: bluetooth btrtl: add hci_ver 0x8 for rtl8822cs_bt
+
+As found on Tanix TX6.
+
+Add the missing id hci_ver = 0x8 to the ic_id_table[]
+
+Before:
+
+[   11.288818] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
+[   11.512883] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
+[   11.512940] Bluetooth: hci0: RTL: unknown IC info, lmp subver 8822, hci rev 000c, hci ver 0008
+[   11.512957] Bluetooth: hci0: RTL: no config loaded
+
+After:
+
+[   12.642167] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
+[   12.671911] Bluetooth: hci0: RTL: rom_version status=0 version=3
+[   12.671961] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_fw.bin
+[   12.706248] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_config.bin
+[   12.730251] Bluetooth: hci0: RTL: cfg_sz 33, total sz 40737
+[   13.318832] Bluetooth: hci0: RTL: fw version 0x05a91a4a
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ drivers/bluetooth/btrtl.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/bluetooth/btrtl.c b/drivers/bluetooth/btrtl.c
+--- a/drivers/bluetooth/btrtl.c	2022-01-09 22:55:34.000000000 +0000
++++ b/drivers/bluetooth/btrtl.c	2022-01-15 07:12:21.102080089 +0000
+@@ -148,7 +148,15 @@
+ 	  .fw_name  = "rtl_bt/rtl8761bu_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8761bu_config" },
+ 
++ 	/* 8822C (hci ver 0008) with UART interface */
++	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc, 0x8, HCI_UART),
++	  .config_needed = true,
++	  .has_rom_version = true,
++	  .has_msft_ext = true,
++	  .fw_name  = "rtl_bt/rtl8822cs_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8822cs_config" },
++
+-	/* 8822C with UART interface */
++	/* 8822C (hci ver 000a) with UART interface */
+ 	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc, 0xa, HCI_UART),
+ 	  .config_needed = true,
+ 	  .has_rom_version = true,
+--
+2.25.1
+


### PR DESCRIPTION
Add the missing id hci_ver = 0x8 to the ic_id_table[]

Before:

[   11.288818] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
[   11.512883] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
[   11.512940] Bluetooth: hci0: RTL: unknown IC info, lmp subver 8822, hci rev 000c, hci ver 0008
[   11.512957] Bluetooth: hci0: RTL: no config loaded

After:

[   12.642167] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
[   12.671911] Bluetooth: hci0: RTL: rom_version status=0 version=3
[   12.671961] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_fw.bin
[   12.706248] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_config.bin
[   12.730251] Bluetooth: hci0: RTL: cfg_sz 33, total sz 40737
[   13.318832] Bluetooth: hci0: RTL: fw version 0x05a91a4a