### PR TITLE
[le11] proftpd: update to 1.3.7c

### DIFF
--- a/packages/addons/addon-depends/whois/package.mk
+++ b/packages/addons/addon-depends/whois/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="whois"
-PKG_VERSION="5.5.7"
-PKG_SHA256="ae389c1486cdeae99f5f02940f98f5d7ff1f08ac0f96810365159b27b0189b5e"
+PKG_VERSION="5.5.11"
+PKG_SHA256="e0e051773df982f12d000566b5eea433f7055b965f76bb6febda04ba5bf213fa"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.linux.it/~md/software/"
 PKG_URL="https://github.com/rfc1036/whois/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/proftpd/changelog.txt
+++ b/packages/addons/service/proftpd/changelog.txt
@@ -1,3 +1,7 @@
+104
+- update to proftpd 1.3.7c
+- update to whois 5.5.11
+
 103
 - update to proftpd 1.3.7a
 

--- a/packages/addons/service/proftpd/package.mk
+++ b/packages/addons/service/proftpd/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="proftpd"
-PKG_VERSION="1.3.7a"
-PKG_SHA256="8b7bbf9757988935352d9dec5ebf96b6a1e6b63a6cdac2e93202ac6c42c4cd96"
-PKG_REV="103"
+PKG_VERSION="1.3.7c"
+PKG_SHA256="7070968b9b6cf614ce7f756c8c1a66c32c1afa4f961784a62301790a801400da"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.proftpd.org/"


### PR DESCRIPTION
- proftpd: update to 1.3.7c
  - release notes:
    - http://www.proftpd.org/docs/RELEASE_NOTES-1.3.7c
- whois: update to 5.5.11