### PR TITLE
kodi-theme-Estuary: add unpack dependency on kodi

### DIFF
--- a/packages/mediacenter/kodi-theme-Estuary/package.mk
+++ b/packages/mediacenter/kodi-theme-Estuary/package.mk
@@ -7,6 +7,7 @@ PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL=""
 PKG_DEPENDS_TARGET="kodi"
+PKG_DEPENDS_UNPACK="kodi"
 PKG_LONGDESC="Kodi Mediacenter default theme."
 PKG_TOOLCHAIN="manual"
 


### PR DESCRIPTION
This fixes old Estuary skin in image after kodi bump when doing
unclean builds.