### PR TITLE
[le11] multimedia-tools: update addon to 116

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmediainfo"
-PKG_VERSION="21.03"
-PKG_SHA256="56b7e9abf80cba48032165cd7a46fd8d43dd63e3af35765f66c3f134caaca4ca"
+PKG_VERSION="21.09"
+PKG_SHA256="69be9444f6a03a1bdf56713ee31d56e987c502a7ec18eb54ee70fcc171b7f126"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/libmediainfo/${PKG_VERSION}/libmediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mediainfo"
-PKG_VERSION="21.03"
-PKG_SHA256="de50ca0b2c607b8999d3c9e542d27c97030a59f31859b612335315be6850021e"
+PKG_VERSION="21.09"
+PKG_SHA256="7b8fd9a502ec64afe1315072881b6385ba57ca69f2f82c625b1672e151c50c57"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/mediainfo/${PKG_VERSION}/mediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpg123"
-PKG_VERSION="1.27.2"
-PKG_SHA256="52f6ceb962c05db0c043bb27acf5a721381f5f356ac4610e5221f50293891b04"
+PKG_VERSION="1.29.3"
+PKG_SHA256="963885d8cc77262f28b77187c7d189e32195e64244de2530b798ddf32183e847"
 PKG_LICENSE="LGPLv2"
 PKG_SITE="http://www.mpg123.org/"
 PKG_URL="http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpv-drmprime"
-PKG_VERSION="0.34.0"
-PKG_SHA256="f654fb6275e5178f57e055d20918d7d34e19949bc98ebbf4a7371902e88ce309"
+PKG_VERSION="0.34.1"
+PKG_SHA256="32ded8c13b6398310fa27767378193dc1db6d78b006b70dbcbd3123a1445e746"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mpv.io/"
 PKG_URL="https://github.com/mpv-player/mpv/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squeezelite"
-PKG_VERSION="556de5689d27b4440adbfeb3c3012da02dbf438e" # 2021-05-14 # 1.9.9.1386
-PKG_SHA256="8de5348b0ee23f4a24371dad589c887d083194e24a0e526585417edcd34a4d86"
+PKG_VERSION="874e4f97d979fbe9b396c1997730a1a2d6797964" # 2022-01-06 # 1.9.9.1395
+PKG_SHA256="b33d9da532e000fe69ca76fa737a54d6215bd8ffac3e348b76763940449650ca"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ralph-irving/squeezelite"
 PKG_URL="https://github.com/ralph-irving/squeezelite/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/multimedia-tools/changelog.txt
+++ b/packages/addons/tools/multimedia-tools/changelog.txt
@@ -1,3 +1,10 @@
+116
+- libmediainfo: update to 21.09
+- mediainfo: update to 21.09
+- mpg123: update to 1.29.3
+- mpv-drmprime: update to 0.34.1
+- squeezelite: update to 2022-01-06 (1.9.9.1395)
+
 115
 - libmediainfo: update to 21.03
 - libzen: update to 0.4.39

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="115"
+PKG_REV="116"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- libmediainfo: update to 21.09
- mediainfo: update to 21.09
- mpg123: update to 1.29.3
- mpv-drmprime: update to 0.34.1
- squeezelite: update to 2022-01-06 (1.9.9.1395)