### PR TITLE
kodi: update to latest Matrix version

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="19.3-Matrix"
-PKG_SHA256="440f47e475dd8a48e0a6d41349e83b74890f3fbe8275d3e401d3c50f5b9ea09b"
+PKG_VERSION="e8cdc30b9da3125c62094b062c6c2f0f6b5acfb1"
+PKG_SHA256="cbc896cda55a31731e4a7d512466e3aafd730aac937ba157eb86e92cdb5ffb6e"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
@@ -21,7 +21,7 @@ Subject: disable online check
    m_info.videoEncoder      = GetVideoEncoder();
    m_info.cpuFrequency =
        StringUtils::Format("%4.0f MHz", CServiceBroker::GetCPUInfo()->GetCPUFrequency());
-@@ -1007,9 +1006,7 @@ int CSysInfo::GetXbmcBitness(void)
+@@ -1012,9 +1011,7 @@ int CSysInfo::GetXbmcBitness(void)
  
  bool CSysInfo::HasInternet()
  {

--- a/packages/mediacenter/kodi/patches/kodi-100.26-disable-internal-texturepacker.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.26-disable-internal-texturepacker.patch
@@ -1,0 +1,13 @@
+--- a/cmake/modules/FindTexturePacker.cmake
++++ b/cmake/modules/FindTexturePacker.cmake
+@@ -52,10 +52,6 @@ if(NOT TARGET TexturePacker::TexturePack
+       endif()
+     endif()
+ 
+-    # Ship TexturePacker only on Linux and FreeBSD
+-    if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-      set(INTERNAL_TEXTUREPACKER_INSTALLABLE TRUE)
+-    endif()
+ 
+     # Use it during build if build architecture is same as host
+     # (not cross-compiling) and TEXTUREPACKER_EXECUTABLE is not found

--- a/packages/mediacenter/kodi/patches/kodi-100.26-disable-internal-texturepacker.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.26-disable-internal-texturepacker.patch
@@ -1,6 +1,6 @@
 --- a/cmake/modules/FindTexturePacker.cmake
 +++ b/cmake/modules/FindTexturePacker.cmake
-@@ -52,10 +52,6 @@ if(NOT TARGET TexturePacker::TexturePack
+@@ -53,10 +53,6 @@ if(NOT TARGET TexturePacker::TexturePack
        endif()
      endif()
  


### PR DESCRIPTION
We haven't bumped kodi for quite some time, so bring it up to date while we wait for 19.4.

The "Set demuxer speed to normal on flush" should help with issues after seek which have been reported on our forums, too.

Runtime tested on RPi4