### PR TITLE
[le11] kodi: add shutdown hook to autostart

### DIFF
--- a/packages/mediacenter/kodi/system.d/kodi-autostart.service
+++ b/packages/mediacenter/kodi/system.d/kodi-autostart.service
@@ -2,13 +2,14 @@
 Description=Kodi user autostart script
 Before=kodi.service
 After=network-online.target graphical.target
-ConditionPathExists=/storage/.config/autostart.sh
 
 [Service]
 Type=oneshot
 Environment=HOME=/storage
-ExecStart=-/bin/sh -c ". /etc/profile; exec /bin/sh /storage/.config/autostart.sh"
+ExecStart=-/bin/sh -c ". /etc/profile; test -f /storage/.config/autostart.sh && exec /bin/sh /storage/.config/autostart.sh"
+ExecStop=-/bin/sh -c ". /etc/profile; test -f /storage/.config/autostop.sh && exec /bin/sh /storage/.config/autostop.sh"
 RemainAfterExit=yes
+TimeoutStopSec=5min
 
 [Install]
 WantedBy=kodi.service


### PR DESCRIPTION
This adds an "autostop.sh" script, which is based on the conversation and related threads [here](https://forum.libreelec.tv/thread/25150-solved-kodi-on-rpi4-on-libreelec-run-custom-script-upon-kodi-power-off/?postID=165518#post165518).

The kodi-autostart.service already has RemainAfterExit set, so the service already fires a "stop" at shutdown.  So just added the ExecStop with a shell test for "/storage/.config/autostop.sh" and TimeoutStopSec=5min to allow the stop script to run up to 5 minutes.

The script itself is implemented just like autostart.sh, and would run at stopping of kodi-autostart.service which normally would happen before poweroff.target is met (while networking is still available).  This gives you an opportunity to run some shutdown scripts before the network is shutdown.

Tested by adding script /storage/.config/autostop.sh:
```sh
#!/bin/sh

echo "stop $(date)" >> /storage/autostart.log
ping -c 1 192.168.0.1 >> /storage/autostart.log
```

And rebooting LE.  Permissions should be set executable, same as autostart.sh.


One fault I can see is autostop.sh would not run unless there is an autostart.sh, you could call that a feature or a fault.  :)  Let me know what you think on that, can remove the "ConditionPathExists" and add a shell test for autostart.sh.