### PR TITLE
Boot warning: fsck.fat

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -155,6 +155,12 @@ makeinstall_init() {
     if [ "${TARGET_ARCH}" = "arm" -a "${TARGET_FLOAT}" = "hard" ]; then
       ln -sf ld.so ${INSTALL}/usr/lib/ld-linux.so.3
     fi
+
+  mkdir -p ${INSTALL}/usr/lib/gconv/gconv-modules.d/
+    cp -PR ${PKG_BUILD}/.${TARGET_NAME}/iconvdata/ANSI_X3.110.so ${INSTALL}/usr/lib/gconv
+    cp -PR ${PKG_BUILD}/.${TARGET_NAME}/iconvdata/IBM850.so ${INSTALL}/usr/lib/gconv
+    grep IBM850 ${PKG_BUILD}/.${TARGET_NAME}/iconvdata/gconv-modules.d/gconv-modules-extra.conf > \
+      ${INSTALL}/usr/lib/gconv/gconv-modules.d/gconv-modules-extra.conf
 }
 
 post_makeinstall_init() {

--- a/packages/sysutils/dosfstools/package.mk
+++ b/packages/sysutils/dosfstools/package.mk
@@ -13,7 +13,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_INIT="toolchain dosfstools"
 PKG_LONGDESC="dosfstools contains utilities for making and checking MS-DOS FAT filesystems."
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-compat-symlinks"
+PKG_CONFIGURE_OPTS_TARGET="--enable-compat-symlinks --with-iconv"
 PKG_MAKE_OPTS_TARGET="PREFIX=/usr"
 PKG_MAKEINSTALL_OPTS_TARGET="PREFIX=/usr"
 


### PR DESCRIPTION
fsck during boot ERRORs with unable to access the gconv/*.so files. These are dynamically loaded by fsck.fat

whilst this is a harmless error. This adding of the missing libraries removes the error.

```
[    2.527416] fsck: Cannot initialize conversion from codepage 850 to ANSI_X3.4-1968: Invalid argument
[    2.527438] fsck: Cannot initialize conversion from ANSI_X3.4-1968 to codepage 850: Invalid argument
[    2.527450] fsck: Using internal CP850 conversion table
[    2.527459] fsck: fsck.fat 4.2 (2021-01-31)
```

fsck is compiled —with-iconv (gconv) - define this in the `package.mk` file for clarity.

additional files in `init` image.
```
-rwxr-xr-x   1 docker   docker      14376 Jan 18 12:46 /usr/lib/gconv/IBM850.so
-rw-r--r--   1 docker   docker        189 Jan 18 12:46 /usr/lib/gconv/gconv-modules.d/gconv-modules-extra.conf
-rwxr-xr-x   1 docker   docker      26664 Jan 18 12:46 /usr/lib/gconv/ANSI_X3.110.so
```