### PR TITLE
create_addon: jenkins addons include icon.png

### DIFF
--- a/scripts/install_addon
+++ b/scripts/install_addon
@@ -79,7 +79,7 @@ if [ "${ADDON_JENKINS}" = "yes" ]; then
   ADDON_JENKINS_ADDON_NAME="${ADDON_VERSION}-${DEVICE:-${PROJECT}}-${TARGET_ARCH}-${PKG_ADDON_ID}-${ADDONVER}"
   mkdir -p "${ADDON_JENKINS_DIR}"
   cd ${ADDON_INSTALL_DIR}
-  ${TOOLCHAIN}/bin/7za a -l -mx0 -bsp0 -bso0 -tzip ${ADDON_JENKINS_DIR}/${ADDON_JENKINS_ADDON_NAME}.zip ${PKG_ADDON_ID}-${ADDONVER}.zip resources/
+  ${TOOLCHAIN}/bin/7za a -l -mx0 -bsp0 -bso0 -tzip ${ADDON_JENKINS_DIR}/${ADDON_JENKINS_ADDON_NAME}.zip ${PKG_ADDON_ID}-${ADDONVER}.zip icon.png resources/
   ( cd ${ADDON_JENKINS_DIR}
     sha256sum ${ADDON_JENKINS_ADDON_NAME}.zip > ${ADDON_JENKINS_ADDON_NAME}.zip.sha256
   )


### PR DESCRIPTION
should fix kodi errors due missing icon.png
> ERROR <general>: CCurlFile::Stat - Failed: Couldn't connect to server(7) for https://addons.libreelec.tv/10.0.0/ARMv8/arm/pvr.pctv/icon.png