### PR TITLE
reverts #6152

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -155,12 +155,6 @@ makeinstall_init() {
     if [ "${TARGET_ARCH}" = "arm" -a "${TARGET_FLOAT}" = "hard" ]; then
       ln -sf ld.so ${INSTALL}/usr/lib/ld-linux.so.3
     fi
-
-  mkdir -p ${INSTALL}/usr/lib/gconv/gconv-modules.d/
-    cp -PR ${PKG_BUILD}/.${TARGET_NAME}/iconvdata/ANSI_X3.110.so ${INSTALL}/usr/lib/gconv
-    cp -PR ${PKG_BUILD}/.${TARGET_NAME}/iconvdata/IBM850.so ${INSTALL}/usr/lib/gconv
-    grep IBM850 ${PKG_BUILD}/.${TARGET_NAME}/iconvdata/gconv-modules.d/gconv-modules-extra.conf > \
-      ${INSTALL}/usr/lib/gconv/gconv-modules.d/gconv-modules-extra.conf
 }
 
 post_makeinstall_init() {

--- a/packages/sysutils/dosfstools/package.mk
+++ b/packages/sysutils/dosfstools/package.mk
@@ -13,7 +13,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_INIT="toolchain dosfstools"
 PKG_LONGDESC="dosfstools contains utilities for making and checking MS-DOS FAT filesystems."
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-compat-symlinks --with-iconv"
+PKG_CONFIGURE_OPTS_TARGET="--enable-compat-symlinks"
 PKG_MAKE_OPTS_TARGET="PREFIX=/usr"
 PKG_MAKEINSTALL_OPTS_TARGET="PREFIX=/usr"
 


### PR DESCRIPTION
looks like it breaks all ARM builds, revert #6152 till it is fixed

```
BUILD      glibc (init)
    TOOLCHAIN      configure (auto-detect)
grep: /LE/build.LibreELEC-RPi4.arm-11.0-devel/build/glibc-2.32/.armv8a-libreelec-linux-gnueabihf/iconvdata/gconv-modules.d/gconv-modules-extra.conf: No such file or directory
FAILURE: scripts/build glibc:init during makeinstall_init (package.mk)
*********** FAILED COMMAND ***********
grep IBM850 ${PKG_BUILD}/.${TARGET_NAME}/iconvdata/gconv-modules.d/gconv-modules-extra.conf > ${INSTALL}/usr/lib/gconv/gconv-modules.d/gconv-modules-extra.conf
**************************************
FAILURE: scripts/build glibc:init has failed!
```