### PR TITLE
[le11] Vulkan: update to 1.2.203 & small fixes

### DIFF
--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glslang"
-PKG_VERSION="11.7.0"
-PKG_SHA256="b6c83864c3606678d11675114fa5f358c519fe1dad9a781802bcc87fb8fa32d5"
+PKG_VERSION="11.7.1"
+PKG_SHA256="ab2e2ddc507bb418b9227cbe6f443eb06e89e2387944f42026d82c0b4ef79b0a"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"
@@ -25,7 +25,7 @@ pre_configure_host() {
                        -Wno-dev"
 
   # The SPIRV-Tools & SPIRV-Headers have to be specific versions matching the pkg version
-  # https://github.com/KhronosGroup/glslang/blob/master/known_good.json
+  # https://github.com/KhronosGroup/glslang/blob/${PKG_VERSION}/known_good.json
   mkdir -p ${PKG_BUILD}/External/spirv-tools/external/spirv-headers
     cp -R $(get_build_dir spirv-tools)/* ${PKG_BUILD}/External/spirv-tools
     cp -R $(get_build_dir spirv-headers)/* ${PKG_BUILD}/External/spirv-tools/external/spirv-headers

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.2.201"
-PKG_SHA256="6b7f9c809acff4f0877e2e7722e02a08f2e17e06c6e2e8c84081631d15490009"
+PKG_VERSION="1.2.203"
+PKG_SHA256="7239108c372f1fbe365bd8d1610ca2bb4e72b73b2151f2551bf9df54dd539639"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.2.201"
-PKG_SHA256="465e8a35e875ddebde7cb59f15b0e2cdfae9c3826680c775d7d5b731d95ee1d6"
+PKG_VERSION="1.2.203"
+PKG_SHA256="a431c627f36f90ce8d1aa752e7a37838db569760a54bb97edaee35dae4743118"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -15,7 +15,7 @@ configure_package() {
   # Displayserver Support
   if [ "${DISPLAYSERVER}" = "x11" ]; then
     PKG_DEPENDS_TARGET+=" libxcb libX11"
-  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+  elif [ "${DISPLAYSERVER}" = "wl" ]; then
     PKG_DEPENDS_TARGET+=" wayland"
   fi
 }
@@ -27,7 +27,7 @@ pre_configure_target() {
     PKG_CMAKE_OPTS_TARGET+=" -DBUILD_WSI_XCB_SUPPORT=ON \
                              -DBUILD_WSI_XLIB_SUPPORT=ON \
                              -DBUILD_WSI_WAYLAND_SUPPORT=OFF"
-  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+  elif [ "${DISPLAYSERVER}" = "wl" ]; then
     PKG_CMAKE_OPTS_TARGET+=" -DBUILD_WSI_XCB_SUPPORT=OFF \
                              -DBUILD_WSI_XLIB_SUPPORT=OFF \
                              -DBUILD_WSI_WAYLAND_SUPPORT=ON"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.2.201"
-PKG_SHA256="a259667fba1260352a872e70f325fe0a9a04f1caa5ef353e379acf04b1d2a15a"
+PKG_VERSION="1.2.203"
+PKG_SHA256="70b50a14c26dc12c71de5b4847055e318d7af77e7ce13250b1b0a4d40a50bbfd"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -15,7 +15,7 @@ configure_package() {
   # Displayserver Support
   if [ "${DISPLAYSERVER}" = "x11" ]; then
     PKG_DEPENDS_TARGET+=" libxcb libX11"
-  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+  elif [ "${DISPLAYSERVER}" = "wl" ]; then
     PKG_DEPENDS_TARGET+=" wayland"
   fi
 }
@@ -33,7 +33,7 @@ pre_configure_target() {
                              -DBUILD_WSI_XLIB_SUPPORT=ON \
                              -DBUILD_WSI_WAYLAND_SUPPORT=OFF \
                              -DCUBE_WSI_SELECTION=XCB"
-  elif [ "${DISPLAYSERVER}" = "weston" ]; then
+  elif [ "${DISPLAYSERVER}" = "wl" ]; then
     PKG_CMAKE_OPTS_TARGET+=" -DBUILD_CUBE=ON \
                              -DBUILD_WSI_XCB_SUPPORT=OFF \
                              -DBUILD_WSI_XLIB_SUPPORT=OFF \

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -53,3 +53,8 @@ pre_make_target() {
   find ${PKG_BUILD} -name flags.make -exec sed -i  "s:isystem :I:g" \{} \;
   find ${PKG_BUILD} -name build.ninja -exec sed -i "s:isystem :I:g" \{} \;
 }
+
+post_makeinstall_target() {
+  # Clean up - two graphic test tools are superflous
+  safe_remove ${INSTALL}/usr/bin/vkcubepp
+}

--- a/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.02-fix-find-pkg-wayland-protocols.patch
+++ b/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.02-fix-find-pkg-wayland-protocols.patch
@@ -1,23 +1,24 @@
-From 3f2debf2710f84f42b999da2b7eb1f168205695f Mon Sep 17 00:00:00 2001
+From 2ee12e8ba3b306b7e8aa71695cbe0e2ff451cf3f Mon Sep 17 00:00:00 2001
 From: SupervisedThinking <supervisedthinking@gmail.com>
-Date: Thu, 18 Nov 2021 13:28:38 +0100
+Date: Tue, 23 Nov 2021 13:18:49 +0100
 Subject: [PATCH] cmake/FindWaylandProtocols: fix wayland protocol path
  generation for cross compile
 
 ---
- cmake/FindWaylandProtocols.cmake | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ cmake/FindWaylandProtocols.cmake | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/cmake/FindWaylandProtocols.cmake b/cmake/FindWaylandProtocols.cmake
-index 17859ed7c..6941f6024 100644
+index 17859ed7c..73d8548a7 100644
 --- a/cmake/FindWaylandProtocols.cmake
 +++ b/cmake/FindWaylandProtocols.cmake
-@@ -6,8 +6,8 @@
+@@ -6,8 +6,9 @@
  
  if(NOT WIN32)
      find_package(PkgConfig)
 -    pkg_check_modules(PKG_WAYLAND_PROTOCOLS QUIET wayland-protocols)
 -    set(WAYLAND_PROTOCOLS_PATH ${PKG_WAYLAND_PROTOCOLS_PREFIX}/share/wayland-protocols)
++    pkg_check_modules(WAYLAND_PROTOCOLS_PATH REQUIRED wayland-protocols)
 +    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir wayland-protocols
 +       OUTPUT_VARIABLE WAYLAND_PROTOCOLS_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
      find_package_handle_standard_args(WAYLAND DEFAULT_MSG WAYLAND_PROTOCOLS_PATH)


### PR DESCRIPTION
- after https://github.com/LibreELEC/LibreELEC.tv/pull/5979 the packages need to check for `wl` instead `weston` as `DISPLAYSERVER` - fix Wayland builds
- just install `vkcube` as test graphic tool instead `vkcube` & `vkcubepp`
- update to Vulkan 1.2.203