### PR TITLE
mesa: update to 21.3.5

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="21.3.4"
-PKG_SHA256="77104fd4a93bce69da3b0982f8ee88ba7c4fb98cfc491a669894339cdcd4a67d"
+PKG_VERSION="21.3.5"
+PKG_SHA256="d93b2a9d2464ee856d7637a07dff6b7cd950f295ad58518bb959f76882cf4a4c"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
### Bug fixes in 21.3.5

- glGetActiveUniform failing with GL_INVALID_VALUE for no reason
- CopelliaSim crashes on adding vision sensor to a scene on Ubuntu 20+, runs fine on Ubuntu 18.04
- Dirt Rally: Flickering glitches on certain foliage going from Mesa 21.2.5 to 21.3.0
- FrontFacing input is broken on Intel/Vulkan
- llvmpipe: Unimplemented get_driver_uuid/get_device_uuid causes segfaults in e.g. Wine

release notes: 
- https://docs.mesa3d.org/relnotes/21.3.5.html

```
=== tested on ===
Generic.x86_64-devel-20220128110147-f20fbb1
Linux nuc11 5.16.4-rc1 #1 SMP Fri Jan 28 11:03:53 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.101) Git:e976cd0e3ad9ed0e4ff80e2f97e2fce1922717be). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-01-20 by GCC 10.3.0 for Linux x86 64-bit version 5.16.2 (331778)
Running on LibreELEC (heitbaum): devel-20220128110147-f20fbb1 11.0, kernel: Linux x86 64-bit version 5.16.4-rc1
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0041.2021.0811.1505 08/11/2021
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 21.3.5
libva info: VA-API version 1.13.0
vainfo: VA-API version: 1.13 (libva 2.13.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.1.1 (6797a24628)
```