### PR TITLE
Allwinner: linux: Fix VP9 decoding

### DIFF
--- a/projects/Allwinner/patches/linux/0087-media-hantro-sunxi-Fix-VP9-steps.patch
+++ b/projects/Allwinner/patches/linux/0087-media-hantro-sunxi-Fix-VP9-steps.patch
@@ -1,0 +1,33 @@
+From 837c5a2d79984be3732751b1bfc6ec609ba82e2b Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Fri, 28 Jan 2022 17:03:04 +0100
+Subject: [PATCH] media: hantro: sunxi: Fix VP9 steps
+
+It turns out postproc for VP9 needs width and height to be multiple of
+32.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ drivers/staging/media/hantro/sunxi_vpu_hw.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/staging/media/hantro/sunxi_vpu_hw.c b/drivers/staging/media/hantro/sunxi_vpu_hw.c
+index 90633406c4eb..c0edd5856a0c 100644
+--- a/drivers/staging/media/hantro/sunxi_vpu_hw.c
++++ b/drivers/staging/media/hantro/sunxi_vpu_hw.c
+@@ -29,10 +29,10 @@ static const struct hantro_fmt sunxi_vpu_dec_fmts[] = {
+ 		.frmsize = {
+ 			.min_width = 48,
+ 			.max_width = 3840,
+-			.step_width = MB_DIM,
++			.step_width = 32,
+ 			.min_height = 48,
+ 			.max_height = 2160,
+-			.step_height = MB_DIM,
++			.step_height = 32,
+ 		},
+ 	},
+ };
+-- 
+2.35.0
+


### PR DESCRIPTION
Fix for VP9 decoding videos which have width or height which is not multiple of 32.