### PR TITLE
waf: use binary from source archive

### DIFF
--- a/packages/python/devel/waf/package.mk
+++ b/packages/python/devel/waf/package.mk
@@ -10,12 +10,6 @@ PKG_URL="https://waf.io/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_LONGDESC="The Waf build system"
 PKG_TOOLCHAIN="manual"
 
-unpack() {
-  mkdir -p ${PKG_BUILD}
-    cp ${SOURCES}/${PKG_NAME}/${PKG_SOURCE_NAME} ${PKG_BUILD}/waf
-    chmod a+x ${PKG_BUILD}/waf
-}
-
 makeinstall_host() {
-  cp -pf waf ${TOOLCHAIN}/bin/
+  cp -pf ${PKG_BUILD}/waf ${TOOLCHAIN}/bin/
 }


### PR DESCRIPTION
Commit bde858fe3cedb3b823c4e72f322e269784c42479 changed waf package URL to
tar.bz2 source archive, but unpack() and makeinstall_host() assumes waf
executable file is downloaded directly.

Revert to direct executable download and adjust SHA256 accordingly.