### PR TITLE
mpv-drmprime: enable Lua support for support of built-in stats OSD

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
@@ -7,14 +7,14 @@ PKG_SHA256="32ded8c13b6398310fa27767378193dc1db6d78b006b70dbcbd3123a1445e746"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mpv.io/"
 PKG_URL="https://github.com/mpv-player/mpv/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain waf:host alsa ffmpeg libass libdrm"
+PKG_DEPENDS_TARGET="toolchain waf:host alsa ffmpeg libass libdrm lua52"
 PKG_LONGDESC="A media player based on MPlayer and mplayer2. It supports a wide variety of video file formats, audio and video codecs, and subtitle types."
 PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_MANUAL_OPTS_TARGET="--prefix=/usr \
                         --disable-libarchive \
-                        --disable-lua \
+                        --enable-lua \
                         --disable-javascript \
                         --disable-uchardet \
                         --disable-rubberband \

--- a/packages/lang/lua52/config/lua52.pc
+++ b/packages/lang/lua52/config/lua52.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+libdir=${prefix}/lib
+includedir=${prefix}/include/lua@@VERSION_MM@@
+
+Name: Lua
+Description: An Extensible Extension Language
+Version: @@VERSION@@
+Requires:
+Libs: -L${libdir} -llua@@VERSION_MM@@ -lm
+Cflags: -I${includedir}

--- a/packages/lang/lua52/package.mk
+++ b/packages/lang/lua52/package.mk
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="lua52"
+PKG_VERSION="5.2.4"
+PKG_SHA256="b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b"
+PKG_LICENSE="MIT"
+PKG_SITE="https://www.lua.org"
+PKG_URL="http://www.lua.org/ftp/lua-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Lua is a powerful, efficient, lightweight, embeddable scripting language."
+
+make_target() {
+  make CC=${CC} AR="${AR} rcu" posix
+}
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/include/lua$(get_pkg_version_maj_min)
+  cp src/lua.h src/luaconf.h src/lualib.h src/lauxlib.h ${SYSROOT_PREFIX}/usr/include/lua$(get_pkg_version_maj_min)
+
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib
+  cp src/liblua.a ${SYSROOT_PREFIX}/usr/lib/liblua$(get_pkg_version_maj_min).a
+
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+  cp ${PKG_DIR}/config/lua52.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+  sed -e "s/@@VERSION@@/${PKG_VERSION}/g" \
+      -e "s/@@VERSION_MM@@/$(get_pkg_version_maj_min)/g" \
+      -i ${SYSROOT_PREFIX}/usr/lib/pkgconfig/lua52.pc
+}


### PR DESCRIPTION
**Building with Lua 5.2 library enables mpv support of builtin stats OSD.**

Lua 5.2 is required to enable mpv player support of builtin stats OSD.
MPV doesn't support later Lua versions, newer versions aren't backwards
compatible, thus including version in a package name.
Upstream Lua doesn't include pkg-config file, including one from ArchLinux.

See https://github.com/mpv-player/mpv/wiki/FAQ#Why_does_mpv_not_support_Lua_53_or_newer

Build and run tested on Allwinner.