### PR TITLE
mpv-drmprime: enable Lua support

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
@@ -7,14 +7,14 @@ PKG_SHA256="32ded8c13b6398310fa27767378193dc1db6d78b006b70dbcbd3123a1445e746"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mpv.io/"
 PKG_URL="https://github.com/mpv-player/mpv/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain waf:host alsa ffmpeg libass libdrm"
+PKG_DEPENDS_TARGET="toolchain waf:host alsa ffmpeg libass libdrm lua52"
 PKG_LONGDESC="A media player based on MPlayer and mplayer2. It supports a wide variety of video file formats, audio and video codecs, and subtitle types."
 PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_MANUAL_OPTS_TARGET="--prefix=/usr \
                         --disable-libarchive \
-                        --disable-lua \
+                        --enable-lua \
                         --disable-javascript \
                         --disable-uchardet \
                         --disable-rubberband \


### PR DESCRIPTION
Building with Lua 5.2 library enables mpv support of builtin stats OSD.

Requires merging #6172