### PR TITLE
PKGCONFIG use ./lib/pkgconfig/ for both host and target

### DIFF
--- a/packages/compress/zlib/package.mk
+++ b/packages/compress/zlib/package.mk
@@ -11,3 +11,7 @@ PKG_DEPENDS_HOST="cmake:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A general purpose (ZIP) data compression library."
 PKG_TOOLCHAIN="cmake-make"
+
+PKG_CMAKE_OPTS_HOST="-DINSTALL_PKGCONFIG_DIR=${TOOLCHAIN}/lib/pkgconfig"
+
+PKG_CMAKE_OPTS_TARGET="-DINSTALL_PKGCONFIG_DIR=/usr/lib/pkgconfig"

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -100,6 +100,7 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dmount-path=/usr/bin/mount \
                        -Dumount-path=/usr/bin/umount \
                        -Ddebug-tty=${DEBUG_TTY} \
+                       -Dpkgconfigdatadir=/usr/lib/pkgconfig \
                        -Dversion-tag=${PKG_VERSION}"
 
 pre_configure_target() {

--- a/packages/x11/data/xkeyboard-config/package.mk
+++ b/packages/x11/data/xkeyboard-config/package.mk
@@ -24,6 +24,7 @@ pre_configure_target() {
                              --disable-runtime-deps \
                              --enable-nls \
                              --disable-rpath \
+                             --datadir=/usr/lib \
                              --with-gnu-ld"
 
   if [ "${DISPLAYSERVER}" = "x11" ]; then

--- a/packages/x11/lib/xtrans/package.mk
+++ b/packages/x11/lib/xtrans/package.mk
@@ -13,6 +13,11 @@ PKG_LONGDESC="Abstract network code for X."
 
 PKG_CONFIGURE_OPTS_TARGET="--without-xmlto"
 
+pre_configure_target() {
+  sed -i 's|^pkgconfigdir = .*|pkgconfigdir = /usr/lib/pkgconfig|' ${PKG_BUILD}/Makefile.am
+  sed -i 's|^pkgconfigdir = .*|pkgconfigdir = /usr/lib/pkgconfig|' ${PKG_BUILD}/Makefile.in
+}
+
 post_makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
     cp xtrans.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig

--- a/packages/x11/proto/xorgproto/package.mk
+++ b/packages/x11/proto/xorgproto/package.mk
@@ -11,4 +11,5 @@ PKG_DEPENDS_TARGET="toolchain util-macros"
 PKG_LONGDESC="combined X.Org X11 Protocol headers"
 PKG_TOOLCHAIN="meson"
 
-PKG_MESON_OPTS_TARGET="-Dlegacy=false"
+PKG_MESON_OPTS_TARGET="-Dlegacy=false \
+                       -Dpkgconfigdatadir=/usr/lib/pkgconfig"

--- a/packages/x11/proto/xorgproto/patches/xorgproto-0001-pkgconfig.patch
+++ b/packages/x11/proto/xorgproto/patches/xorgproto-0001-pkgconfig.patch
@@ -1,0 +1,48 @@
+commit 989e25ecc4dc75c842f13b2b6457df9a3533ac72
+Author: heitbaum <rudi@heitbaum.com>
+Date:   Sun Feb 6 07:56:38 2022 +0000
+
+    meson: enable override of arch-independent pkg-config
+    
+    Add meson_option pkgconfigdatadir to set the directory for
+    arch-independent pkg-config files.
+    
+    Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+
+diff --git a/meson.build b/meson.build
+index 5c15cc9..bb9c7c1 100644
+--- a/meson.build
++++ b/meson.build
+@@ -57,12 +57,14 @@ pc_data = configuration_data()
+ pc_data.set('prefix', get_option('prefix'))
+ # meson does not allow installing the includedir outside of the prefix
+ pc_data.set('includedir', '${prefix}/' + get_option('includedir'))
++# Dirs of external packages
++pkgconfigdatadir = get_option('pkgconfigdatadir') != '' ? get_option('pkgconfigdatadir') : get_option('datadir') / 'pkgconfig'
+ 
+ foreach pc : pcs
+     configure_file(
+         input : pc + '.pc.in',
+         output : pc + '.pc',
+-        install_dir : get_option('datadir') + '/pkgconfig',
++        install_dir : pkgconfigdatadir,
+         configuration : pc_data,
+     )
+ endforeach
+@@ -100,7 +102,7 @@ if get_option('legacy') == true
+         configure_file(
+             input : pc + '.pc.in',
+             output : pc + '.pc',
+-            install_dir : get_option('datadir') + '/pkgconfig',
++            install_dir : pkgconfigdatadir,
+             configuration : pc_data,
+         )
+     endforeach
+diff --git a/meson_options.txt b/meson_options.txt
+index 757cd72..4c80f32 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1 +1,3 @@
+ option('legacy', type: 'boolean', value: false)
++option('pkgconfigdatadir', type : 'string', value : '',
++       description : 'directory for arch-independent pkg-config files')

--- a/packages/x11/util/util-macros/package.mk
+++ b/packages/x11/util/util-macros/package.mk
@@ -10,6 +10,11 @@ PKG_URL="http://xorg.freedesktop.org/archive/individual/util/${PKG_NAME}-${PKG_V
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="X.org autoconf utilities such as M4 macros."
 
+pre_configure_target() {
+  sed -i 's|^pkgconfigdir = .*|pkgconfigdir = /usr/lib/pkgconfig|' ${PKG_BUILD}/Makefile.am
+  sed -i 's|^pkgconfigdir = .*|pkgconfigdir = /usr/lib/pkgconfig|' ${PKG_BUILD}/Makefile.in
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr
 }


### PR DESCRIPTION
Tested built across all except RPi,Amlogic - as below.

Why did I create this PR - whilst testing the current `ncurses 6.3-20220122` release it was noted that only zlib was in the HOST toolchain/share/pkgconfig directory, and that the majority of .pc files are in lib for both TARGET and HOST. The bug identified in 20220122 has been rectified in 20220129 - but the PR is to tidy up the LE build environment.
- https://lists.gnu.org/archive/html/bug-ncurses/2022-01/msg00017.html
- https://lists.gnu.org/archive/html/bug-ncurses/2022-01/msg00018.html

Reading: 
- https://bugs.freedesktop.org/show_bug.cgi?id=89769

Based on the reading - all Independant `.pc` files should be in the `datadir` which is  `share`. But given that the LE build is exclusively a cross compile environment - that statement may be considered wrong. Most `.pc` files were already in `libdir`. Thus standardized on `libdir` for all `.pc` files.

This PR centralizes all the .pc files into the ./lib/pkgconfig/ directories and does not use the `share` directories.

- systemd: set PKGCONFIG directory to /usr/lib/pkgconfig
- util-macros: set PKGCONFIG directory to /usr/lib/pkgconfig
- xkeyboard-config: set PKGCONFIG directory to /usr/lib/pkgconfig
- xorgproto: set PKGCONFIG directory to /usr/lib/pkgconfig
- xtrans: set PKGCONFIG directory to /usr/lib/pkgconfig
- zlib: set PKGCONFIG directories for both host and target to lib/pkgconfig

### e.g.
```
docker@63fc0b982347:/var/media/DATA/home-rudi/LibreELEC.tv$ find . -name zlib.pc
./build.LibreELEC-Generic.x86_64-11.0-devel/build/zlib-1.2.11/.x86_64-linux-gnu/zlib.pc
./build.LibreELEC-Generic.x86_64-11.0-devel/build/zlib-1.2.11/.x86_64-libreelec-linux-gnu/zlib.pc
./build.LibreELEC-Generic.x86_64-11.0-devel/install_pkg/zlib-1.2.11/usr/lib/pkgconfig/zlib.pc
./build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/lib/pkgconfig/zlib.pc
./build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/pkgconfig/zlib.pc
```
### The pkgconfig directories in LE build
```
docker@63fc0b982347:/var/media/DATA/home-rudi/LibreELEC.tv$ find . -type d -name pkgconfig | grep -v -e "/build/" -e "/install_pkg/"
./build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/share/pkgconfig
./build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/lib/pkgconfig
./build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/share/pkgconfig
./build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/pkgconfig
./build.LibreELEC-Generic.x86_64-11.0-devel/install_init/util-linux-2.37.3/usr/lib/pkgconfig
```
### After
```
docker@63fc0b982347:/var/media/DATA/home-rudi/LibreELEC.tv$ ls -la build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/share/pkgconfig build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/share/pkgconfig
build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/share/pkgconfig:
total 8
drwxr-xr-x  2 docker docker 4096 Jan 30 03:50 .
drwxr-xr-x 30 docker docker 4096 Jan 30 04:03 ..

build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/share/pkgconfig:
total 24
drwxr-xr-x  2 docker docker 4096 Jan 30 04:00 .
drwxr-xr-x 52 docker docker 4096 Jan 30 04:06 ..
```

### Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=arm DEVICE=Dragonboard s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
```