### PR TITLE
[le11] samba: update to 4.13.17

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.13.16"
-PKG_SHA256="3fec748cd89961131959fca836d24bbc4843385ea7235a4295b5e129e250c041"
+PKG_VERSION="4.13.17"
+PKG_SHA256="17bdb9ea60d30af22851c8e134d67b43a22fb1e20f159152a647c69dc2a58a68"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
release notes:
- https://www.samba.org/samba/history/samba-4.13.17.html

                   ===============================
                   Release Notes for Samba 4.13.17
                          January 31, 2022
                   ===============================

This is a security release in order to address the following defects:

o CVE-2021-44142: Out-of-Bound Read/Write on Samba vfs_fruit module.
                  https://www.samba.org/samba/security/CVE-2021-44142.html

o CVE-2022-0336:  Re-adding an SPN skips subsequent SPN conflict checks.
                  https://www.samba.org/samba/security/CVE-2022-0336.html

Changes since 4.13.16
---------------------

o  Ralph Boehme <slow@samba.org>
   * BUG 14914: CVE-2021-44142

o  Joseph Sutton <josephsutton@catalyst.net.nz>
   * BUG 14950: CVE-2022-0336