### PR TITLE
packages updates: python

### DIFF
--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="8.4.0"
-PKG_SHA256="a726a4246cf1f26a5024b57c5d5fa0e98789262799860ed554ec028e2698f2c0"
+PKG_VERSION="9.0.1"
+PKG_SHA256="01305f0befb644ce7fe90aa0c87573b9163a21d0e65149e8166c24974d9d37d2"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.12.0"
-PKG_SHA256="d08b9799b6c5b9c99219b775066234d73f3007f5dab4189e33a7c3581507ee57"
+PKG_VERSION="3.14.1"
+PKG_SHA256="2da3d5c2ecd3c3b73946ef00dc585d590e869deacdfe464cefba96f50d13682f"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pycryptodome"
 PKG_URL="https://github.com/Legrandin/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- Pillow: update to 9.0.1
  - update from 8.4.0 to 9.0.1
  - https://pillow.readthedocs.io/en/latest/releasenotes/9.0.0.html
  - https://pillow.readthedocs.io/en/latest/releasenotes/9.0.1.html
- pycryptodome: update to 3.14.1
  - update from 3.12.0 to 3.14.1
  - https://github.com/Legrandin/pycryptodome/blob/master/Changelog.rst