### PR TITLE
package updates: networking and bluetooth

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bluez"
-PKG_VERSION="5.62"
-PKG_SHA256="38090a5b750e17fc08d3e52178ed8d3254c5f4bd2c48830d5c1955b88e3bc0c2"
+PKG_VERSION="5.63"
+PKG_SHA256="9349e11e8160bb3d720835d271250d8a7424d3690f5289e6db6fe07cc66c6d76"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/ethtool/package.mk
+++ b/packages/network/ethtool/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ethtool"
-PKG_VERSION="5.15"
-PKG_SHA256="686fd6110389d49c2a120f00c3cd5dfe43debada8e021e4270d74bbe452a116d"
+PKG_VERSION="5.16"
+PKG_SHA256="aa2fef1936dd4a11755dfa0bdb93f0ec5bea45208d27c9754bc3abe1aa42c1cb"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/pub/software/network/ethtool/"
 PKG_URL="https://www.kernel.org/pub/software/network/ethtool/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="1.23"
-PKG_SHA256="9db66205aeccb87874cec478546d2e3aa71a5b6773326f0b950949018444393f"
+PKG_VERSION="1.25"
+PKG_SHA256="3f138e03301beb2afc7b385a62f56db17059137857ab579f269c4e441783e760"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"

--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.5.3"
-PKG_SHA256="fb6a9943c603a1951ca13e9267653f8dd650c02f84bccd2b9d20f06a4c9c9a7e"
+PKG_VERSION="2.5.5"
+PKG_SHA256="119bd69fa0210838f6cdaa273696dc738efa200f454dbe11eb6dfb75dfb6003b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://openvpn.net"
 PKG_URL="https://swupdate.openvpn.org/community/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/rpcbind/package.mk
+++ b/packages/network/rpcbind/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpcbind"
-PKG_VERSION="1.2.5"
-PKG_SHA256="2ce360683963b35c19c43f0ee2c7f18aa5b81ef41c3fdbd15ffcb00b8bffda7a"
+PKG_VERSION="1.2.6"
+PKG_SHA256="5613746489cae5ae23a443bb85c05a11741a5f12c8f55d2bb5e83b9defeee8de"
 PKG_LICENSE="OSS"
 PKG_SITE="http://rpcbind.sourceforge.net/"
 PKG_URL="${SOURCEFORGE_SRC}/rpcbind/rpcbind/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/network/rpcbind/patches/rpcbind-1.2.6-vulnerability_fixes-1.patch
+++ b/packages/network/rpcbind/patches/rpcbind-1.2.6-vulnerability_fixes-1.patch
@@ -1,0 +1,29 @@
+Submitted By: Ken Moffat <ken at linuxfromscratch dot org>
+Date: 2017-05-29
+Initial Package Version: 0.2.4 (also affects earlier versions)
+Upstream Status: Unknown
+Origin: Guido Vranken
+Description: Fixes CVE-2017-8779 (DOS by remote attackers - memory consumption
+without subsequent free).
+
+diff --git a/src/rpcb_svc_com.c b/src/rpcb_svc_com.c
+index 5862c26..e11f61b 100644
+--- a/src/rpcb_svc_com.c
++++ b/src/rpcb_svc_com.c
+@@ -48,6 +48,7 @@
+ #include <rpc/rpc.h>
+ #include <rpc/rpcb_prot.h>
+ #include <rpc/svc_dg.h>
++#include <rpc/rpc_com.h>
+ #include <netconfig.h>
+ #include <errno.h>
+ #include <syslog.h>
+@@ -432,7 +433,7 @@ rpcbproc_taddr2uaddr_com(void *arg, struct svc_req *rqstp /*__unused*/,
+ static bool_t
+ xdr_encap_parms(XDR *xdrs, struct encap_parms *epp)
+ {
+-	return (xdr_bytes(xdrs, &(epp->args), (u_int *) &(epp->arglen), ~0));
++	return (xdr_bytes(xdrs, &(epp->args), (u_int *) &(epp->arglen), RPC_MAXDATASIZE));
+ }
+ 
+ /*

--- a/packages/network/wpa_supplicant/package.mk
+++ b/packages/network/wpa_supplicant/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wpa_supplicant"
-PKG_VERSION="2.9"
-PKG_SHA256="fcbdee7b4a64bea8177973299c8c824419c413ec2e3a95db63dd6a5dc3541f17"
+PKG_VERSION="2.10"
+PKG_SHA256="20df7ae5154b3830355f8ab4269123a87affdea59fe74fe9292a91d0d7e17b2f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://w1.fi/wpa_supplicant/"
 PKG_URL="https://w1.fi/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/wpa_supplicant/patches/wpa_supplicant-2.4-libnl3-includes.patch
+++ b/packages/network/wpa_supplicant/patches/wpa_supplicant-2.4-libnl3-includes.patch
@@ -5,8 +5,8 @@ diff -Naur wpa_supplicant-2.4/src/drivers/drivers.mk wpa_supplicant-2.4.patch/sr
  ifdef CONFIG_LIBNL32
    DRV_LIBS += -lnl-3
    DRV_LIBS += -lnl-genl-3
--  DRV_CFLAGS += -DCONFIG_LIBNL20 -I/usr/include/libnl3
-+  DRV_CFLAGS += -DCONFIG_LIBNL20 `pkg-config --cflags libnl-3.0`
+-  DRV_CFLAGS += -I/usr/include/libnl3
++  DRV_CFLAGS += `pkg-config --cflags libnl-3.0`
  ifdef CONFIG_LIBNL3_ROUTE
    DRV_LIBS += -lnl-route-3
    DRV_CFLAGS += -DCONFIG_LIBNL3_ROUTE

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.46.0"
-PKG_SHA256="1a68cc4a5732afb735baf50aaac3cb3a6771e49f744bd5db6c49ab5042f12a43"
+PKG_VERSION="1.47.0"
+PKG_SHA256="68271951324554c34501b85190f22f2221056db69f493afc3bbac8e7be21e7cc"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- bluez: update to 5.63
- ethtool: update to 5.16
- iwd: update to 1.25
- nghttp2: update to 1.47.0
- openvpn: update to 2.5.5
- rpcbind: update to 1.2.6
- wpa_supplicant: update to 2.10