### PR TITLE
kernel-firmware: include cypress blobs

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -18,5 +18,6 @@ mediatek/mt7610u.bin
 ath6k/AR6004/hw1.?/bdata.bin
 ath9k_htc/*
 brcm/*
+cypress/*
 rtl_bt/*
 rtlwifi/*


### PR DESCRIPTION
brcm firmwares were removed and replaced by cypress:
https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/brcm?h=20211216&id=0f0aefd733f70beae4c0246edbd2c158d5ce974c

They are automatically symlinked to `brcm` directory.