### PR TITLE
[le11] chrome: update to 103.0.5060.134 and addon (113)

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.42.0"
-PKG_SHA256="4b5da10e94fa3c6195f95222438f63a0234b99ef9df772c7640e82baeaa6e386"
+PKG_VERSION="2.45.1"
+PKG_SHA256="ba95f346e93108fbb3462c62437081d582154db279b4052dedc52a706828b192"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.gnome.org/"
-PKG_URL="https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"
+PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain atk dbus glib libXtst"
 PKG_LONGDESC="Protocol definitions and daemon for D-Bus at-spi."
 

--- a/packages/addons/addon-depends/chrome-depends/atk/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/atk/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="atk"
-PKG_VERSION="2.36.0"
-PKG_SHA256="fb76247e369402be23f1f5c65d38a9639c1164d934e40f6a9cf3c9e96b652788"
+PKG_VERSION="2.38.0"
+PKG_SHA256="ac4de2a4ef4bd5665052952fe169657e65e895c5057dffb3c2a810f6191a0c36"
 PKG_LICENSE="GPL"
 PKG_SITE="http://library.gnome.org/devel/atk/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/atk/${PKG_VERSION:0:4}/atk-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/cups/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/cups/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cups"
-PKG_VERSION="2.4.0"
-PKG_SHA256="36338ebdc6e8b1d4af26471230c479ce4d691a11f90bb42ac6822d4f2bf002c5"
+PKG_VERSION="2.4.2"
+PKG_SHA256="7095b2977bb728ded5566a5c802866062840d6541fd027836865949a407c3682"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.cups.org"
 PKG_URL="https://github.com/openprinting/cups/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/chrome-depends/gdk-pixbuf/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gdk-pixbuf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gdk-pixbuf"
-PKG_VERSION="2.42.6"
-PKG_SHA256="c4a6b75b7ed8f58ca48da830b9fa00ed96d668d3ab4b1f723dcf902f78bde77f"
+PKG_VERSION="2.42.8"
+PKG_SHA256="84acea3acb2411b29134b32015a5b1aaa62844b19c4b1ef8b8971c6b0759f4c6"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/${PKG_VERSION:0:4}/gdk-pixbuf-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/gdk-pixbuf/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gdk-pixbuf/package.mk
@@ -12,10 +12,21 @@ PKG_DEPENDS_TARGET="toolchain glib libjpeg-turbo libpng jasper shared-mime-info 
 PKG_DEPENDS_CONFIG="shared-mime-info"
 PKG_LONGDESC="GdkPixbuf is a a GNOME library for image loading and manipulation."
 
-PKG_MESON_OPTS_TARGET="-Dbuiltin_loaders=all \
-                       -Dgtk_doc=false \
-                       -Ddocs=false \
-                       -Dintrospection=disabled \
-                       -Dman=false \
-                       -Drelocatable=false \
-                       -Dinstalled_tests=false"
+configure_package() {
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    PKG_DEPENDS_TARGET+=" libX11"
+  fi
+}
+
+pre_configure_target() {
+  PKG_MESON_OPTS_TARGET="-Dgtk_doc=false \
+                         -Ddocs=false \
+                         -Dintrospection=disabled \
+                         -Dman=false \
+                         -Drelocatable=false \
+                         -Dinstalled_tests=false"
+
+  if [ "${DISPLAYSERVER}" != "x11" ]; then
+    PKG_MESON_OPTS_TARGET+=" -Dbuiltin_loaders=all"
+  fi
+}

--- a/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gtk3"
-PKG_VERSION="3.24.31"
-PKG_SHA256="423c3e7fdb4c459ee889e35fd4d71fd2623562541c1041b11c07e5ad1ff10bf9"
+PKG_VERSION="3.24.34"
+PKG_SHA256="dbc69f90ddc821b8d1441f00374dc1da4323a2eafa9078e61edbe5eeefa852ec"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gtk+/${PKG_VERSION:0:4}/gtk+-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/json-glib/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/json-glib/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="bf4d1cd6c343ce13b9258e6703a0411a3b659887b65877e85a2aa488ae18b865"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/GNOME/json-glib"
 PKG_URL="https://github.com/GNOME/json-glib/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain glib"
+PKG_DEPENDS_TARGET="toolchain glib glib:host"
 PKG_LONGDESC="JSON-GLib implements a full suite of JSON-related tools using GLib and GObject."
 
 PKG_MESON_OPTS_TARGET="-Dintrospection=disabled \

--- a/packages/addons/addon-depends/chrome-depends/libXcursor/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/libXcursor/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXcursor"
-PKG_VERSION="1.2.0"
-PKG_SHA256="3ad3e9f8251094af6fe8cb4afcf63e28df504d46bfa5a5529db74a505d628782"
+PKG_VERSION="1.2.1"
+PKG_SHA256="46c143731610bafd2070159a844571b287ac26192537d047a39df06155492104"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
-PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXcursor-${PKG_VERSION}.tar.bz2"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXcursor-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libX11 libXfixes libXrender"
 PKG_LONGDESC="X11 Cursor management library.s"
 PKG_BUILD_FLAGS="+pic -sysroot"

--- a/packages/addons/addon-depends/chrome-depends/pango/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/pango/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pango"
-PKG_VERSION="1.50.3"
-PKG_SHA256="4add05edf51c1fb375a1ccde7498914120e23cb280dd7395b1aeb441f1838a4c"
+PKG_VERSION="1.50.8"
+PKG_SHA256="cf626f59dd146c023174c4034920e9667f1d25ac2c1569516d63136c311255fa"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.pango.org/"
 PKG_URL="https://download.gnome.org/sources/pango/${PKG_VERSION:0:4}/pango-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/icu/package.mk
+++ b/packages/addons/addon-depends/icu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="icu"
-PKG_VERSION="70.1"
-PKG_SHA256="f30d670bdc03ba999638a2d2511952ab94adf204d0e14898666f2e0cacb7fef1"
+PKG_VERSION="71.1"
+PKG_SHA256="d88a4ea7a4a28b445bb073a6cfeb2a296bf49a4a2fe5f1b49f87ecb4fc55c51d"
 PKG_LICENSE="Custom"
 PKG_SITE="https://icu.unicode.org"
 PKG_URL="https://github.com/unicode-org/icu/archive/release-${PKG_VERSION//./-}.tar.gz"

--- a/packages/addons/addon-depends/jasper/package.mk
+++ b/packages/addons/addon-depends/jasper/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jasper"
-PKG_VERSION="2.0.33"
-PKG_SHA256="38b8f74565ee9e7fec44657e69adb5c9b2a966ca5947ced5717cde18a7d2eca6"
+PKG_VERSION="3.0.6"
+PKG_SHA256="c79961bc00158f5b5dc5f5fcfa792fde9bebb024432689d0f9e3f95a097d0ec3"
 PKG_LICENSE="OpenSource"
 PKG_SITE="http://www.ece.uvic.ca/~mdadams/jasper/"
 PKG_URL="https://github.com/jasper-software/jasper/archive/refs/tags/version-${PKG_VERSION}.tar.gz"
@@ -14,4 +14,9 @@ PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DJAS_ENABLE_DOC=false \
                        -DJAS_ENABLE_PROGRAMS=false \
-                       -DJAS_ENABLE_SHARED=false"
+                       -DJAS_ENABLE_SHARED=false \
+                       -DJAS_STDC_VERSION=201710L"
+
+pre_configure_target() {
+  export CFLAGS="${CFLAGS} -std=gnu17"
+}

--- a/packages/addons/browser/chrome/changelog.txt
+++ b/packages/addons/browser/chrome/changelog.txt
@@ -1,6 +1,19 @@
+113
+- at-spi2-core: update to 2.45.1
+- atk: update to 2.38.0
+- chrome: update to 103.0.5060.134
+- cups: update to 2.4.2
+- gdk-pixbuf: update to 2.42.8
+- gtk3: update to 3.24.34
+- harfbuzz: update to 5.0.1
+- icu: update to 71.1
+- jasper: update to 3.0.6
+- libXcursor: update to 1.2.1
+- pango: update to 1.50.8
+
 112
 - chrome: update to 97.0.4692.71
-- cups: update to 2.4.02
+- cups: update to 2.4.0
 - gtk3: update to 3.24.31
 - harfbuzz: update to 3.2.0
 - icu: update to 70.1 and PKG_SITE

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -29,13 +29,10 @@ make_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,config,gdk-pixbuf-modules,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,config,lib}
 
   # config
   cp -P ${PKG_DIR}/config/* ${ADDON_BUILD}/${PKG_ADDON_ID}/config
-
-  # gdk-pixbuf modules
-  cp -PL $(get_install_dir gdk-pixbuf)/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/* ${ADDON_BUILD}/${PKG_ADDON_ID}/gdk-pixbuf-modules
 
   # unclutter
   cp -P $(get_install_dir unclutter)/usr/bin/unclutter ${ADDON_BUILD}/${PKG_ADDON_ID}/bin

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -4,8 +4,8 @@
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
 # curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
-PKG_VERSION_NUMBER="97.0.4692.71"
-PKG_REV="111"
+PKG_VERSION_NUMBER="103.0.5060.134"
+PKG_REV="113"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="4.4.1"
-PKG_SHA256="c5bc33ac099b2e52f01d27cde21cee4281b9d5bfec7684135e268512478bc9ee"
+PKG_VERSION="5.0.1"
+PKG_SHA256="d0094299a36346b9f5540aa159b358425c022b19fcdf72165eaf94046a179166"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Build in LE11 must be done with `PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/create_addon chrome`
- this fixes the `gdk-pixbuf` introduced regression
  - 0cf76756960b6d58a8e24db483792751e9d7daae
  - #6128
  - **chrome** addon wants to install the `/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders`

- at-spi2-core: update to 2.45.1
 - atk: update to 2.38.0
 - chrome: update to 103.0.5060.134
 - cups: update to 2.4.2
 - gdk-pixbuf: update to 2.42.8
 - gtk3: update to 3.24.34
 - icu: update to 71.1
 - libXcursor: update to 1.2.1
 - jasper: update to 3.0.6
 - pango: update to 1.50.8
 - json-glib: build depends on glib-mkenums from glib:host

https://chromestatus.com/roadmap