### PR TITLE
[le11] rpi-tools: update to latest and addon (111)

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/RPi.GPIO/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/RPi.GPIO/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RPi.GPIO"
-PKG_VERSION="0.7.1a4"
-PKG_SHA256="21f4378d81525979ad3bbd60e88fc3d9fac1879bcb17151e1c665f32658f9362"
+PKG_VERSION="0.7.1"
+PKG_SHA256="cd61c4b03c37b62bba4a5acfea9862749c33c618e0295e7e90aa4713fb373b70"
 PKG_ARCH="arm"
 PKG_LICENSE="MIT"
-PKG_SITE="http://sourceforge.net/p/raspberry-gpio-python/"
+PKG_SITE="https://sourceforge.net/projects/raspberry-gpio-python/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain Python3 distutilscross:host"
 PKG_LONGDESC="A module to control Raspberry Pi GPIO channels."

--- a/packages/addons/tools/rpi-tools/changelog.txt
+++ b/packages/addons/tools/rpi-tools/changelog.txt
@@ -1,3 +1,6 @@
+111
+- Update RPi.GPIO to 0.7.1
+
 110
 - Update gpiozero to 1.6.2
 - Update RPi.GPIO to 0.7.1a4

--- a/packages/addons/tools/rpi-tools/package.mk
+++ b/packages/addons/tools/rpi-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rpi-tools"
 PKG_VERSION="1.0"
-PKG_REV="110"
+PKG_REV="111"
 PKG_ARCH="arm"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
### RPi.GPIO: update to 0.7.1

Release Notes:
- https://pypi.org/project/RPi.GPIO/0.7.1/

Change Log:
- Better RPi board + peri_addr detection (issue 190 / 191)
- Fix PyEval_InitThreads deprecation warning for Python 3.9 (issue 188)
- Fix build using GCC 10 (issue 187)
- Fix docstrings to not include licence
- Remove Debian/Raspbian stretch packaging support
- Use setuptools instead of distutils
- Added detection of Zero 2 W
- Tested and working with Python 2.7, 3.7, 3.8, 3.9, 3.10


### rpi-tools: update to latest and addon (111)