### PR TITLE
Intel Graphics updates

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.0.1"
-PKG_SHA256="341eb3fa478e427e5a6f03d4cbc97bc2b02c52728dcf06c4794661d34b7c6e5c"
+PKG_VERSION="22.0.2"
+PKG_SHA256="7cc044dc0979269abe825054ba6cc1b67169dc7a7f4192898e2dd04142a633fa"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.1.1"
-PKG_SHA256="6eaa4a9caf58faa8934b253adb4b0ece1c7d5de6f084167d5138b4e3ba423683"
+PKG_VERSION="22.2.0"
+PKG_SHA256="99d6866fdc31a554a4238635b3d09553d97fb4cfdd3a034aa0767f787304bc0f"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
**Mesa 21.3.6,22.0.0-rc1,22.0.0-rc2 have been tested with these updates**

- gmmlib: update to 22.0.2
- media-driver: update to 22.2.0

[Media Common] Fix mos_query_engines_count issue
1. Previous length is the size for allocating membar to get engine count, add correct flow to get engine count

```
=== tested on ===
Generic.x86_64-devel-20220209091907-ac278fc
Linux nuc11 5.16.8 #1 SMP Wed Feb 9 09:19:18 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.101) Git:e976cd0e3ad9ed0e4ff80e2f97e2fce1922717be). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-02-04 by GCC 10.3.0 for Linux x86 64-bit version 5.16.5 (331781)
Running on LibreELEC (heitbaum): devel-20220209091907-ac278fc 11.0, kernel: Linux x86 64-bit version 5.16.8
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0041.2021.0811.1505 08/11/2021
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.0.0-rc1
libva info: VA-API version 1.13.0
vainfo: VA-API version: 1.13 (libva 2.13.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.2.0 (ac278fce0f)
```