### PR TITLE
intel-ucode: update to 20220207

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20210608"
-PKG_SHA256="fd85b6b769efd029dec6a2c07106fd18fb4dcb548b7bc4cde09295a8344ef6d7"
+PKG_VERSION="20220207"
+PKG_SHA256="532527bd17f3ea6664452b536699818a3bf896e4ace689a43a73624711b7c921"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"


### PR DESCRIPTION
Security updates for INTEL-SA-00528
Security updates for INTEL-SA-00532

release notes:
- https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20220207

tested on:
```
[    0.000000] microcode: microcode updated early to revision 0x9a, date = 2021-08-06
[    0.000000] Linux version 5.16.8 (docker@57352c438204) (x86_64-libreelec-linux-gnu-gcc-10.3.0 (GCC) 10.3.0, GNU ld (GNU Binutils) 2.37) #1 SMP Wed Feb 9 09:19:18 UTC 2022

was

[    0.000000] microcode: microcode updated early to revision 0x88, date = 2021-03-31
```