### PR TITLE
mesa: update to 21.3.6

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="21.3.5"
-PKG_SHA256="d93b2a9d2464ee856d7637a07dff6b7cd950f295ad58518bb959f76882cf4a4c"
+PKG_VERSION="21.3.6"
+PKG_SHA256="96bb761fd546e9aa41d025fcc025225c5668443839dae21e3731959beb096736"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release notes:
- https://docs.mesa3d.org/relnotes/21.3.6.html


Bug fixes
- radv: CullDistance fail
- i965: Segmentation fault during glinfo context destruction, regression in 21.3.x
- Vulkan Wayland WSI returns empty surface formats
- [REGRESSION][BISECTED] iris: Qutebrowser/QtWebEngine sporadically flashes the window in white
- Flickering Intel Uhd 620 Graphics
- Broken Terraria & Glitches in Forza Horizon 4
