### PR TITLE
go: update to 1.17.7 (lang - for addons)

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.17.6"
-PKG_SHA256="de00bf818cda9e4712e9b3438c9c3d4f8318beb598d11abb0ba9d515883f6320"
+PKG_VERSION="1.17.7"
+PKG_SHA256="561ccb5bbe584095bebb75b8b59d42a149a2cce55d0727e395815d41d4f91e4f"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
go1.17.7 (released 2022-02-10) includes security fixes to the
crypto/elliptic, math/big packages and to the go command, as well as bug
fixes to the compiler, linker, runtime, the go command, and the
debug/macho, debug/pe, and net/http/httptest packages. See the Go 1.17.7
milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.17.7+label%3ACherryPickApproved