### PR TITLE
libretro-mame2016: fix build with Python 3.9

### DIFF
--- a/packages/emulation/libretro-mame2016/patches/libretro-mame2016-0001-python39.patch
+++ b/packages/emulation/libretro-mame2016/patches/libretro-mame2016-0001-python39.patch
@@ -1,0 +1,27 @@
+From d28c5e3ee58220ec6e17b92be5db0e62101d68b7 Mon Sep 17 00:00:00 2001
+From: Thiago Kenji Okada <thiagokokada@gmail.com>
+Date: Mon, 6 Dec 2021 11:20:25 -0300
+Subject: [PATCH] Fix build on Python 3.9+
+
+array.array.tostring was deprecated since Python 3.2, finally removed on
+Python 3.9.
+---
+ scripts/build/msgfmt.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/build/msgfmt.py b/scripts/build/msgfmt.py
+index deb02ae32b..97d30f4c08 100644
+--- a/scripts/build/msgfmt.py
++++ b/scripts/build/msgfmt.py
+@@ -112,7 +112,10 @@ def generate():
+                          7*4,               # start of key index
+                          7*4+len(keys)*8,   # start of value index
+                          0, 0)              # size and offset of hash table
+-    output += array.array("i", offsets).tostring()
++    if sys.version_info[1] >= 2:
++        output += array.array("i", offsets).tobytes()
++    else:
++        output += array.array("i", offsets).tostring()
+     output += ids
+     output += strs
+     return output


### PR DESCRIPTION
Add upstream patch
- https://github.com/libretro/mame2016-libretro/pull/52

required since python 3.9
- #6227 

Closes 
- #6231 

