### PR TITLE
Allwinner: linux: fix H264 buffer size

### DIFF
--- a/projects/Allwinner/patches/linux/0090-media-cedrus-h264-Fix-neighbour-info-buffer-size.patch
+++ b/projects/Allwinner/patches/linux/0090-media-cedrus-h264-Fix-neighbour-info-buffer-size.patch
@@ -1,0 +1,38 @@
+From df20a1d7586c8986c986624ca8a9c322f524b515 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Mon, 14 Feb 2022 20:01:26 +0100
+Subject: [PATCH] media: cedrus: h264: Fix neighbour info buffer size
+
+According to BSP library source, H264 neighbour info buffer size needs
+to be 32 kiB for H6. This is similar to H265 decoding, which also needs
+double buffer size in comparison to older Cedrus core generations.
+
+Increase buffer size to cover H6 needs. Since increase is not that big
+in absolute numbers, it doesn't make sense to complicate logic for older
+generations.
+
+Issue was discovered using iommu and cross checked with BSP library
+source.
+
+Fixes: 6eb9b758e307 ("media: cedrus: Add H264 decoding support")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ drivers/staging/media/sunxi/cedrus/cedrus_h264.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+index b4173a8926d6..d8fb93035470 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+@@ -38,7 +38,7 @@ struct cedrus_h264_sram_ref_pic {
+ 
+ #define CEDRUS_H264_FRAME_NUM		18
+ 
+-#define CEDRUS_NEIGHBOR_INFO_BUF_SIZE	(16 * SZ_1K)
++#define CEDRUS_NEIGHBOR_INFO_BUF_SIZE	(32 * SZ_1K)
+ #define CEDRUS_MIN_PIC_INFO_BUF_SIZE       (130 * SZ_1K)
+ 
+ static void cedrus_h264_write_sram(struct cedrus_dev *dev,
+-- 
+2.35.1
+


### PR DESCRIPTION
It turns out that H264 decoding on Allwinner H6 has same issue as HEVC - one of the auxiliary buffers is too small. Fix that.