### PR TITLE
[le10] wireless-regdb: update to 2022.02.18

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2021.08.28"
-PKG_SHA256="cff370c410d1e6d316ae0a7fa8ac6278fdf1efca5d3d664aca7cfd2aafa54446"
+PKG_VERSION="2022.02.18"
+PKG_SHA256="8828c25a4ee25020044004f57374bb9deac852809fad70f8d3d01770bf9ac97f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
### Backport of:
- #6256

### Log 
(https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/log/):

- Update regulatory rules for the Netherlands (NL) on 6GHz
- Update regulatory rules for China (CN)
- Update regulatory rules for South Korea (KR)
- Revert "wireless-regdb: Update regulatory rules for South Korea (KR)"
- Update regulatory rules for Spain (ES) on 6GHz
- add 802.11ah bands to world regulatory domain
- add support for US S1G channels
- Update regulatory rules for France (FR) on 6 and 60 GHz
- Update regulatory rules for South Korea (KR)
- Update regulatory rules for Croatia (HR) on 6GHz
- Raise DFS TX power limit to 250 mW (24 dBm) for the US