### PR TITLE
Account for setup_toolchain in show_config's reported CFLAGS/LDFLAGS

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -19,14 +19,14 @@ if [ "${BOOTLOADER}" = "u-boot" -a -n "${DEVICE}" ]; then
   fi
 fi
 
-show_config
-
 ${SCRIPTS}/checkdeps
 
 # Setup both toolchain cmake configs to avoid potentially racy behaviour later.
 # Use a fork for host to isolate any variable modifications.
 ( setup_toolchain host )
 setup_toolchain target
+
+show_config
 
 function do_mkimage() {
   # Variables used in mkimage script must be passed

--- a/tools/viewconfig
+++ b/tools/viewconfig
@@ -6,4 +6,7 @@
 . config/options ""
 . config/show_config
 
+# Needed to obtain some CFLAGS/LDFLAGS
+setup_toolchain target
+
 show_config


### PR DESCRIPTION
config/functions: `setup_toolchain` will add some additional values to TARGET_CFLAGS and TARGET_LDFLAGS. Move `show_config` to after this occurs to improve accuracy of reported CFLAGS/LDFLAGS. Packages may still alter these flags and I don't intend to do any further changes to report those alterations.

Should close #5517.