### PR TITLE
util-linux: update to 2.37.4

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="util-linux"
-PKG_VERSION="2.37.3"
-PKG_SHA256="590c592e58cd6bf38519cb467af05ce6a1ab18040e3e3418f24bcfb2f55f9776"
+PKG_VERSION="2.37.4"
+PKG_SHA256="634e6916ad913366c3536b6468e7844769549b99a7b2bf80314de78ab5655b83"
 PKG_LICENSE="GPL"
 PKG_URL="https://www.kernel.org/pub/linux/utils/util-linux/v$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host autoconf:host automake:host intltool:host libtool:host pkg-config:host"


### PR DESCRIPTION
util-linux 2.37.4 Release Notes
===============================

This release fixes security issue in chsh(1) and chfn(8):

CVE-2022-0563

  The readline library uses INPUTRC= environment variable to get a path
  to the library config file. When the library cannot parse the
  specified file, it prints an error message containing data from the
  file.

  Unfortunately, the library does not use secure_getenv() (or a similar
  concept), or sanitize the config file path to avoid vulnerabilities that
  could occur if set-user-ID or set-group-ID programs.