### PR TITLE
[le11] openssh: update to 8.9p1

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="8.8p1"
-PKG_SHA256="4590890ea9bb9ace4f71ae331785a3a5823232435161960ed5fc86588f331fe9"
+PKG_VERSION="8.9p1"
+PKG_SHA256="fd497654b7ab1686dac672fb83dfb4ba4096e8b5ffcdaccd262380ae58bec5e7"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/openssh/patches/openssh-8.9p1-keydir.patch
+++ b/packages/network/openssh/patches/openssh-8.9p1-keydir.patch
@@ -1,7 +1,7 @@
 diff -u a/configure.ac b/configure.ac
 --- a/configure.ac	2018-10-16 20:01:20.000000000 -0400
 +++ b/configure.ac	2018-12-06 04:08:42.718993760 -0500
-@@ -4903,6 +4903,19 @@
+@@ -5185,6 +5185,19 @@
  )
  
  
@@ -21,7 +21,7 @@ diff -u a/configure.ac b/configure.ac
  AC_MSG_CHECKING([if we need to convert IPv4 in IPv6-mapped addresses])
  IPV4_IN6_HACK_MSG="no"
  AC_ARG_WITH(4in6,
-@@ -5277,6 +5290,7 @@
+@@ -5565,6 +5578,7 @@
  H=`eval echo ${PRIVSEP_PATH}` ; H=`eval echo ${H}`
  I=`eval echo ${user_path}` ; I=`eval echo ${I}`
  J=`eval echo ${superuser_path}` ; J=`eval echo ${J}`
@@ -29,7 +29,7 @@ diff -u a/configure.ac b/configure.ac
  
  echo ""
  echo "OpenSSH has been configured with the following options:"
-@@ -5300,6 +5314,9 @@
+@@ -5588,6 +5602,9 @@
  if test ! -z "$superuser_path" ; then
  echo "          sshd superuser user PATH: $J"
  fi
@@ -43,10 +43,10 @@ Common subdirectories: a/contrib and b/contrib
 diff -u a/Makefile.in b/Makefile.in
 --- a/Makefile.in	2018-10-16 20:01:20.000000000 -0400
 +++ b/Makefile.in	2018-12-06 04:00:04.301968236 -0500
-@@ -28,8 +28,10 @@
- SSH_PRIVSEP_USER=@SSH_PRIVSEP_USER@
+@@ -32,8 +32,10 @@
  STRIP_OPT=@STRIP_OPT@
  TEST_SHELL=@TEST_SHELL@
+ BUILDDIR=@abs_top_builddir@
 +KEYDIR=@KEYDIR@
  
  PATHS= -DSSHDIR=\"$(sysconfdir)\" \
@@ -54,7 +54,7 @@ diff -u a/Makefile.in b/Makefile.in
  	-D_PATH_SSH_PROGRAM=\"$(SSH_PROGRAM)\" \
  	-D_PATH_SSH_ASKPASS_DEFAULT=\"$(ASKPASS_PROGRAM)\" \
  	-D_PATH_SFTP_SERVER=\"$(SFTP_SERVER)\" \
-@@ -133,11 +135,11 @@
+@@ -168,11 +170,11 @@
  	-e 's|/etc/ssh/sshd_config|$(sysconfdir)/sshd_config|g' \
  	-e 's|/usr/libexec|$(libexecdir)|g' \
  	-e 's|/etc/shosts.equiv|$(sysconfdir)/shosts.equiv|g' \
@@ -98,7 +98,7 @@ diff -u a/pathnames.h b/pathnames.h
  
  /*
   * Of these, ssh_host_key must be readable only by root, whereas ssh_config
-@@ -36,11 +40,11 @@
+@@ -36,12 +40,12 @@
   */
  #define _PATH_SERVER_CONFIG_FILE	SSHDIR "/sshd_config"
  #define _PATH_HOST_CONFIG_FILE		SSHDIR "/ssh_config"


### PR DESCRIPTION
release notes:
- https://www.openssh.com/releasenotes.html

```
nuc11:~ # ssh -V
OpenSSH_8.9p1, OpenSSL 3.0.1 14 Dec 2021
```