### PR TITLE
mesa: update to 21.3.7

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="21.3.6"
-PKG_SHA256="96bb761fd546e9aa41d025fcc025225c5668443839dae21e3731959beb096736"
+PKG_VERSION="21.3.7"
+PKG_SHA256="b4fa9db7aa61bf209ef0b40bef83080999d86ad98df8b8b4fada7c128a1efc3d"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
release-notes:
- https://gitlab.freedesktop.org/mesa/mesa/-/blob/21.3/docs/relnotes/21.3.7.rst

### Mesa 21.3.7 Release Notes / 2022-02-23

Mesa 21.3.7 is a bug fix release which fixes bugs found since the 21.3.6 release.
Mesa 21.3.7 implements the OpenGL 4.6 API, but the version reported by
glGetString(GL_VERSION) or glGetIntegerv(GL_MAJOR_VERSION) /
glGetIntegerv(GL_MINOR_VERSION) depends on the particular driver being used.
Some drivers don't support all the features required in OpenGL 4.6.
OpenGL 4.6 is only available if requested at context creation.
Compatibility contexts may report a lower version depending on each driver.
Mesa 21.3.7 implements the Vulkan 1.2 API, but the version reported by
the apiVersion property of the VkPhysicalDeviceProperties struct
depends on the particular driver being used.

New features

None

Bug fixes
- lavapipe: dEQP-VK.spirv_assembly.instruction.compute.float16.arithmetic_3.step fails
- ANV: Bad output from TransformFeedback . Regression from Mesa 21. Something to do with VB+XFB -> VB+XFB dependency?