### PR TITLE
Update dbus and dbussy packages

### DIFF
--- a/packages/python/system/dbussy/package.mk
+++ b/packages/python/system/dbussy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dbussy"
-PKG_VERSION="a694e3b525e988dc5362f2278e2aacdf06b3a179"   # 2021-11-07
-PKG_SHA256="862df448c4bccb3f08e21ed855e5c825c241d2071e923245d7d969dc2c2451f7"
+PKG_VERSION="60d3c155d07ce11bdf89a201ae0026525ac65aca"   # 2022-01-28
+PKG_SHA256="0e9fd148e2d85404edb801d65236c78c1029edc413cdd40fdd31e4edc2c5647b"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://gitlab.com/ldo/dbussy"
 PKG_URL="https://github.com/ldo/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/dbus/package.mk
+++ b/packages/sysutils/dbus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dbus"
-PKG_VERSION="1.13.20"
-PKG_SHA256="a9c4b7bad9f49ffa4f199a12aedcdad5d5dcef875d794829fd1378153e072963"
+PKG_VERSION="1.13.22"
+PKG_SHA256="fbe79fa621ccc01317032bd0d6a31542df429b5c293e075620e2c00fbf2e9c17"
 PKG_LICENSE="GPL"
 PKG_SITE="https://dbus.freedesktop.org"
 PKG_URL="https://dbus.freedesktop.org/releases/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- dbus: update to 1.13.22
  - announcement - https://lists.freedesktop.org/archives/dbus/2022-February/018129.html
  - https://gitlab.freedesktop.org/dbus/dbus/-/blob/master/NEWS
- dbussy: update to 60d3c15
  - 2 minor commits
  - No functional change 
  - https://github.com/ldo/dbussy/compare/a694e3b525e988dc5362f2278e2aacdf06b3a179...6325cbfd99138b7fba320265d5dcd4faff8fb457