### PR TITLE
[LE11] system-tools: include mmc-utils

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/mmc-utils/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mmc-utils/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="mmc-utils"
+PKG_VERSION="4303889c8bd9a2357587eb6ebacecb70098a264d"
+PKG_SHA256="283bab1925a46eb896a9d114650923ce6a39dbb97050daa36bd0bdb6fa703d12"
+PKG_LICENSE="GPL"
+PKG_SITE="https://www.kernel.org/doc/html/latest/driver-api/mmc/mmc-tools.html"
+PKG_URL="https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Configure MMC storage devices from userspace."
+PKG_BUILD_FLAGS="-sysroot"

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,6 @@
+128
+- Add mmc-utils
+
 127
 - Update bottom to 0.6.6
 - Update efibootmgr to githash 2021-11-05

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="127"
+PKG_REV="128"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of system tools and programs"
-PKG_LONGDESC="This bundle currently includes autossh, bottom, diffutils, dstat, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, libgpiod, lm_sensors, lshw, mc, mtpfs, nmon, p7zip, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
+PKG_LONGDESC="This bundle currently includes autossh, bottom, diffutils, dstat, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, libgpiod, lm_sensors, lshw, mc, mmc-utils, mtpfs, nmon, p7zip, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="System Tools"
@@ -39,6 +39,7 @@ PKG_DEPENDS_TARGET="toolchain \
                     lm_sensors \
                     lshw \
                     mc \
+                    mmc-utils \
                     mtpfs \
                     nmon \
                     p7zip \
@@ -131,6 +132,9 @@ addon() {
     # mc
     cp -Pa $(get_install_dir mc)/usr/bin/* ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
     cp -Pa $(get_install_dir mc)/storage/.kodi/addons/virtual.system-tools/* ${ADDON_BUILD}/${PKG_ADDON_ID}
+
+    # mmc-utils
+    cp -P $(get_install_dir mmc-utils)/usr/local/bin/mmc ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # mtpfs
     cp -P $(get_install_dir mtpfs)/usr/bin/mtpfs ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/


### PR DESCRIPTION
Include the `mmc` utility in the system-tools
- https://www.kernel.org/doc/html/latest/driver-api/mmc/mmc-tools.html" 