### PR TITLE
devtool package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.17.7"
-PKG_SHA256="561ccb5bbe584095bebb75b8b59d42a149a2cce55d0727e395815d41d4f91e4f"
+PKG_VERSION="1.17.8"
+PKG_SHA256="1a6981027aad32e14fcfe141eb31eb7ce0736925dc68c3eafb0e94dbad5ce1b3"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/librespot-depends/rust/package.mk
+++ b/packages/addons/addon-depends/librespot-depends/rust/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.58.1"
+PKG_VERSION="1.59.0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_DEPENDS_TARGET="toolchain rustup.rs"

--- a/packages/devel/autoconf-archive/package.mk
+++ b/packages/devel/autoconf-archive/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="autoconf-archive"
-PKG_VERSION="2021.02.19"
-PKG_SHA256="e8a6eb9d28ddcba8ffef3fa211653239e9bf239aba6a01a6b7cfc7ceaec69cbd"
+PKG_VERSION="2022.02.11"
+PKG_SHA256="78a61b611e2eeb55a89e0398e0ce387bcaf57fe2dd53c6fe427130f777ad1e8c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/autoconf-archive/"
 PKG_URL="http://ftpmirror.gnu.org/autoconf-archive/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/autoconf-archive/patches/autoconf-archive-0001-AX_CC_MAXOPT-Fix-nvhpc-case.patch
+++ b/packages/devel/autoconf-archive/patches/autoconf-archive-0001-AX_CC_MAXOPT-Fix-nvhpc-case.patch
@@ -1,0 +1,30 @@
+From ecbf509871f16438d69ae157c690b7d9bedd62f0 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 27 Feb 2022 03:07:58 +0000
+Subject: [PATCH] AX_CC_MAXOPT: Fix nvhpc case
+
+Missing ;; in the ax_cv_c_compiler_vendor case statement causing
+syntax error with libffi configure:
+  line y: syntax error near unexpected token `)'
+  line y: `    gnu)'
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ m4/ax_cc_maxopt.m4 | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/m4/ax_cc_maxopt.m4 b/m4/ax_cc_maxopt.m4
+index 05218e3..58e267b 100644
+--- a/m4/ax_cc_maxopt.m4
++++ b/m4/ax_cc_maxopt.m4
+@@ -146,6 +146,7 @@ if test "x$ac_test_CFLAGS" = "x"; then
+     nvhpc)
+      # default optimization flags for nvhpc
+      CFLAGS="$CFLAGS -O3"
++     ;;
+ 
+     gnu)
+      # default optimization flags for gcc on all systems
+-- 
+2.25.1
+

--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fakeroot"
-PKG_VERSION="1.27"
-PKG_SHA256="3c45eb2d1802a2762069e2e9d21bdd6fb533592bc0cda74c9aff066ab01caddc"
+PKG_VERSION="1.28"
+PKG_SHA256="56d405e36ff685f83879be08fdd654255ab9aa38632b4605a98e896ad63990c2"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://tracker.debian.org/pkg/fakeroot"
 PKG_URL="http://ftp.debian.org/debian/pool/main/f/fakeroot/${PKG_NAME}_${PKG_VERSION}.orig.tar.gz"

--- a/packages/python/devel/MarkupSafe/package.mk
+++ b/packages/python/devel/MarkupSafe/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="MarkupSafe"
-PKG_VERSION="2.0.1"
-PKG_SHA256="594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
+PKG_VERSION="2.1.0"
+PKG_SHA256="80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/MarkupSafe/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="0.61.1"
-PKG_SHA256="feb2cefb325b437dbf36146df7c6b87688ddff0b0205caa31dc64055c6da410c"
+PKG_VERSION="0.61.2"
+PKG_SHA256="0233a7f8d959079318f6052b0939c27f68a5de86ba601f25c9ee6869fb5f5889"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- autoconf-archive: update to 2022.02.11
- fakeroot: update to 1.28
- go: update to 1.17.8
- MarkupSafe: update to 2.1.0
- meson: update to 0.61.2
- rust: update to 1.59.0
