### PR TITLE
[LE10] linux (RPi): fix dirty pipe CVE-2022-0847

### DIFF
--- a/packages/linux/patches/raspberrypi/linux-999.03-fix-dirty-pipe.patch
+++ b/packages/linux/patches/raspberrypi/linux-999.03-fix-dirty-pipe.patch
@@ -1,0 +1,40 @@
+From 9d2231c5d74e13b2a0546fee6737ee4446017903 Mon Sep 17 00:00:00 2001
+From: Max Kellermann <max.kellermann@ionos.com>
+Date: Mon, 21 Feb 2022 11:03:13 +0100
+Subject: [PATCH] lib/iov_iter: initialize "flags" in new pipe_buffer
+
+The functions copy_page_to_iter_pipe() and push_pipe() can both
+allocate a new pipe_buffer, but the "flags" member initializer is
+missing.
+
+Fixes: 241699cd72a8 ("new iov_iter flavour: pipe-backed")
+To: Alexander Viro <viro@zeniv.linux.org.uk>
+To: linux-fsdevel@vger.kernel.org
+To: linux-kernel@vger.kernel.org
+Cc: stable@vger.kernel.org
+Signed-off-by: Max Kellermann <max.kellermann@ionos.com>
+Signed-off-by: Al Viro <viro@zeniv.linux.org.uk>
+---
+ lib/iov_iter.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/iov_iter.c b/lib/iov_iter.c
+index b0e0acdf96c15e..6dd5330f7a9957 100644
+--- a/lib/iov_iter.c
++++ b/lib/iov_iter.c
+@@ -414,6 +414,7 @@ static size_t copy_page_to_iter_pipe(struct page *page, size_t offset, size_t by
+ 		return 0;
+ 
+ 	buf->ops = &page_cache_pipe_buf_ops;
++	buf->flags = 0;
+ 	get_page(page);
+ 	buf->page = page;
+ 	buf->offset = offset;
+@@ -577,6 +578,7 @@ static size_t push_pipe(struct iov_iter *i, size_t size,
+ 			break;
+ 
+ 		buf->ops = &default_pipe_buf_ops;
++		buf->flags = 0;
+ 		buf->page = page;
+ 		buf->offset = 0;
+ 		buf->len = min_t(ssize_t, left, PAGE_SIZE);


### PR DESCRIPTION
Fix for https://dirtypipe.cm4all.com/
- build tested for RPi2, RPi4
- runtime tested for RPi4

In case for RPi it is not as easy as for the rest of LE10 to update the kernel to at least 5.10.102 is here just the dirty pipe fix.