### PR TITLE
grub: fix builds on non x86_64 build hosts by using TARGET_ for build

### DIFF
--- a/packages/tools/grub/package.mk
+++ b/packages/tools/grub/package.mk
@@ -46,6 +46,13 @@ pre_configure_target() {
 
   mkdir -p .${TARGET_NAME}
     cd .${TARGET_NAME}
+
+  # configure requires explicit TARGET_PREFIX binaries when cross compiling.
+  export TARGET_CC="${TARGET_PREFIX}gcc"
+  export TARGET_OBJCOPY="${TARGET_PREFIX}objcopy"
+  export TARGET_STRIP="${TARGET_PREFIX}strip"
+  export TARGET_NM="${TARGET_PREFIX}nm"
+  export TARGET_RANLIB="${TARGET_PREFIX}ranlib"
 }
 
 make_target() {


### PR DESCRIPTION
With these changes configure_target no longer complains about no-prefix
on cross compiling. On an aarch64 build host the target_ compile fails
when the build host gcc is used with the -m32 option. On an x86_64 build
host, the host gcc compiles grub (-m32 and assembly) successfully.

before:

```
checking for i386-pc-linux-gcc... no
checking for i386-pc-linux-egcs... no
checking for i386-pc-linux-cc... no
checking for gcc... gcc
configure: WARNING: using cross tools not prefixed with host triplet
checking for i386-pc-linux-objcopy... no
checking for objcopy... objcopy
checking for i386-pc-linux-strip... no
checking for strip... strip
checking for i386-pc-linux-nm... no
checking for nm... nm
checking for i386-pc-linux-ranlib... no
checking for ranlib... ranlib
checking which extra warnings work...
checking if compiling with clang... yes
checking for options to compile assembly... configure: error: could not compile assembly
```

after:

```
checking for i386-pc-linux-gcc...  /build/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc
checking for i386-pc-linux-objcopy...  /build/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-objcopy
checking for i386-pc-linux-strip...  /build/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-strip
checking for i386-pc-linux-nm...  /build/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-nm
checking for i386-pc-linux-ranlib...  /build/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-ranlib
```