### PR TITLE
mesa: remove "prefer-crocus=true" opt

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -65,10 +65,6 @@ else
   PKG_MESON_OPTS_TARGET+=" -Dgallium-va=disabled"
 fi
 
-if listcontains "${GRAPHIC_DRIVERS}" "crocus"; then
-  PKG_MESON_OPTS_TARGET+=" -Dprefer-crocus=true"
-fi
-
 if listcontains "${GRAPHIC_DRIVERS}" "vmware"; then
   PKG_MESON_OPTS_TARGET+=" -Dgallium-xa=enabled"
 else


### PR DESCRIPTION
no longer necessary since all classic drivers have been removed