### PR TITLE
fixed oe_setup_addon unsafe with user inputs from addons settings

### DIFF
--- a/packages/mediacenter/kodi/profile.d/00-addons.conf
+++ b/packages/mediacenter/kodi/profile.d/00-addons.conf
@@ -31,9 +31,9 @@ oe_setup_addon() {
       if [ -f "$xml_file" ]; then
         XML_SETTINGS_VER="$(xmlstarlet sel -t -m settings -v @version $xml_file)"
         if [ "$XML_SETTINGS_VER" = "2" ]; then
-          eval $(xmlstarlet sel -t -m settings/setting -v @id -o "=\"" -v . -o "\"" -n "$xml_file")
+          eval $(xmlstarlet sel -t -m settings/setting -v @id -o "=" -v . -n "$xml_file" | sed -e "s/'/'\\\\''/g; s/=/='/; s/$/'/")
         else
-          eval $(xmlstarlet sel -t -m settings -m setting -v @id -o "=\"" -v @value -o "\"" -n "$xml_file")
+          eval $(xmlstarlet sel -t -m settings -m setting -v @id -o "=" -v @value -n "$xml_file" | sed -e "s/'/'\\\\''/g; s/=/='/; s/$/'/")
         fi
       fi
     done


### PR DESCRIPTION
If user input in an addon setting text field includes a double quote, call to `oe_setup_addon` will fail with error, as current function tries to `eval $(var="someinputwith"doublequotes")` which includes additional unescaped double quote, resulting in unfinished string.
Proposed modification uses `sed` to single quote all strings and escape possible single quotes included in original input, avoiding also possible security issues.