### PR TITLE
Update Alsa from 1.2.5 (2021-06) to 1.2.6 (2021-12)

### DIFF
--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-lib"
-PKG_VERSION="1.2.5.1"
-PKG_SHA256="628421d950cecaf234de3f899d520c0a6923313c964ad751ffac081df331438e"
+PKG_VERSION="1.2.6.1"
+PKG_SHA256="ad582993d52cdb5fb159a0beab60a6ac57eab0cc1bdf85dc4db6d6197f02333f"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/lib/alsa-lib-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/alsa-ucm-conf/package.mk
+++ b/packages/audio/alsa-ucm-conf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-ucm-conf"
-PKG_VERSION="1.2.5.1"
-PKG_SHA256="5841a444166dcbf479db751303dbc3556f685085ac7e00f0c9e7755676195d97"
+PKG_VERSION="1.2.6.3"
+PKG_SHA256="b8a03aa387a624a2f65edc201bf777421190b60529a92087646823afbd96c5cd"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/lib/alsa-ucm-conf-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-utils"
-PKG_VERSION="1.2.5.1"
-PKG_SHA256="9c169ae37a49295f9b97b92ace772803daf6b6510a19574e0b78f87e562118d0"
+PKG_VERSION="1.2.6"
+PKG_SHA256="6a1efd8a1f1d9d38e489633eaec1fffa5c315663b316cab804be486887e6145d"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/utils/alsa-utils-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
Alsa website: https://www.alsa-project.org/wiki/Main_Page

update Alsa to 1.2.6
- alsa-ucm-conf: update to 1.2.6.3
- alsa-lib: update to 1.2.6.1
- alsa-utils: update to 1.2.6

