### PR TITLE
openssl: update to 3.0.2

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="3.0.1"
-PKG_SHA256="c311ad853353bce796edad01a862c50a8a587f62e7e2100ef465ab53ec9b06d1"
+PKG_VERSION="3.0.2"
+PKG_SHA256="98e91ccead4d4756ae3c9cde5e09191a8e586d9f4d50838e7ec09d6411dfdb63"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://www.openssl.org"
 PKG_URL="https://www.openssl.org/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- https://www.openssl.org/news/secadv/20220315.txt
- https://www.openssl.org/news/changelog.html#openssl-30

update 3.0.1 to 3.0.2

### Change Log 

Fixed a bug in the BN_mod_sqrt() function that can cause it to loop forever for non-prime moduli.

Internally this function is used when parsing certificates that contain elliptic curve public keys in compressed form or explicit elliptic curve parameters with a base point encoded in compressed form.

It is possible to trigger the infinite loop by crafting a certificate that has invalid explicit curve parameters.

Since certificate parsing happens prior to verification of the certificate signature, any process that parses an externally supplied certificate may thus be subject to a denial of service attack. The infinite loop can also be reached when parsing crafted private keys as they can contain explicit elliptic curve parameters.

Thus vulnerable situations include:

TLS clients consuming server certificates
TLS servers consuming client certificates
Hosting providers taking certificates or private keys from customers
Certificate authorities parsing certification requests from subscribers
Anything else which parses ASN.1 elliptic curve parameters
Also any other applications that use the BN_mod_sqrt() where the attacker can control the parameter values are vulnerable to this DoS issue. ([CVE-2022-0778])

Tomáš Mráz

Add ciphersuites based on DHE_PSK (RFC 4279) and ECDHE_PSK (RFC 5489) to the list of ciphersuites providing Perfect Forward Secrecy as required by SECLEVEL >= 3.

Dmitry Belyavskiy, Nicola Tuveri

Made the AES constant time code for no-asm configurations optional due to the resulting 95% performance degradation. The AES constant time code can be enabled, for no assembly builds, with: ./config no-asm -DOPENSSL_AES_CONST_TIME

Paul Dale

Fixed PEM_write_bio_PKCS8PrivateKey() to make it possible to use empty passphrase strings.

Darshan Sen

The negative return value handling of the certificate verification callback was reverted. The replacement is to set the verification retry state with the SSL_set_retry_verify() function.

Tomáš Mráz