### PR TITLE
[le11] Python3 updates

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.9.10"
-PKG_SHA256="0a8fbfb5287ebc3a13e9baf3d54e08fa06778ffeccf6311aef821bb3a6586cc8"
+PKG_VERSION="3.9.11"
+PKG_SHA256="66767a35309d724f370df9e503c172b4ee444f49d62b98bc4eca725123e26c49"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.python.org/"
 PKG_URL="https://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"

--- a/packages/lang/Python3/patches/Python3-0100-buildroot-patches.patch
+++ b/packages/lang/Python3/patches/Python3-0100-buildroot-patches.patch
@@ -489,45 +489,6 @@ index 2602fe24c0..a1bc3cd5f7 100644
 -- 
 2.20.1
 
-From a9affe1f3f98342b682848c9b3f862ee194ff625 Mon Sep 17 00:00:00 2001
-From: Samuel Cabrero <samuelcabrero@gmail.com>
-Date: Wed, 23 Dec 2015 11:45:48 +0100
-Subject: [PATCH] Override system locale and set to default when adding gcc
- paths
-
-Forces the use of the default locale in the function
-add_gcc_paths, which is called when cross compiling to add the
-include and library paths. This is necessary because otherwise
-the gcc output is localized and the output parsing fails, which
-results in no paths added and detect_modules not able to find
-any system library (eg. libz, libssl, etc.)
-
-[Thomas: patch taken from https://bugs.python.org/issue23767.]
-
-Signed-off-by: Samuel Cabrero <samuelcabrero@gmail.com>
-Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
-[james.hilliard1@gmail.com: adapt to python 3.9]
-Signed-off-by: James Hilliard <james.hilliard1@gmail.com>
----
- setup.py | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/setup.py b/setup.py
-index 8fda3b4d47..bb7eb44213 100644
---- a/setup.py
-+++ b/setup.py
-@@ -686,7 +686,7 @@ class PyBuildExt(build_ext):
-         tmpfile = os.path.join(self.build_temp, 'ccpaths')
-         if not os.path.exists(self.build_temp):
-             os.makedirs(self.build_temp)
--        ret = run_command('%s -E -v - </dev/null 2>%s 1>/dev/null' % (CC, tmpfile))
-+        ret = run_command('LC_ALL=C %s -E -v - </dev/null 2>%s 1>/dev/null' % (CC, tmpfile))
-         is_gcc = False
-         is_clang = False
-         in_incdirs = False
--- 
-2.20.1
-
 From c50b8e7fb9b2e61d4d195a055cd1bbf993cc455f Mon Sep 17 00:00:00 2001
 From: Christophe Vu-Brugier <cvubrugier@fastmail.fm>
 Date: Wed, 22 Feb 2017 16:48:49 -0800

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Mako"
-PKG_VERSION="1.1.6"
-PKG_SHA256="4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2"
+PKG_VERSION="1.2.0"
+PKG_SHA256="9a7c7e922b87db3686210cf49d5d767033a41d4010b284e747682c92bddd8b39"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/Mako"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/MarkupSafe/package.mk
+++ b/packages/python/devel/MarkupSafe/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="MarkupSafe"
-PKG_VERSION="2.1.0"
-PKG_SHA256="80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f"
+PKG_VERSION="2.1.1"
+PKG_SHA256="7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/MarkupSafe/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- Python3: update 3.9.10 to 3.9.11
  - https://www.python.org/downloads/release/python-3911/
  - One of the buildroot patches was upstreamed
- MarkupSafe: update 2.1.0 to 2.1.1
- Mako: update 1.1.0 to 1.2.0

```
nuc11:~ # python -V
Python 3.9.11
```