### PR TITLE
pvr.waipu: update to 20.4.0-Nexus

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.waipu"
-PKG_VERSION="20.3.0-Nexus"
-PKG_SHA256="ccdc2ea79fa99f1633b999c794d0e37930630eba5fe64d65d9e61c9e010bb470"
+PKG_VERSION="20.4.0-Nexus"
+PKG_SHA256="c4e6aed46cd4160a7a29e80119895570598cf6e1ee089eb07864d52beb928e97"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
This PR updates the binary addon pvr.waipu to version 20.4.0-Nexus.

Changes in this release:
* Implement Device Authentication

Since I need some testers before backporting to Matrix, it would be great if you could upload this package to the repo soon @CvH 