### PR TITLE
Revert "kodi: remove X11 patch"

### DIFF
--- a/projects/Generic/devices/x11/patches/kodi/kodi-100.06-dont-set-_NET_WM_STATE_FULLSCREEN.patch
+++ b/projects/Generic/devices/x11/patches/kodi/kodi-100.06-dont-set-_NET_WM_STATE_FULLSCREEN.patch
@@ -1,0 +1,28 @@
+From c16e99234ce40f201e58a2595e6dfa0703cf554c Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Wed, 11 Mar 2015 20:56:15 +0200
+Subject: [PATCH 06/13] dont set _NET_WM_STATE_FULLSCREEN
+
+Start X11 applications like 'chrome' or 'st' on top of kodi.
+
+Outdated comment:
+## I dont remember why I added this. I guess it was for
+## some 3rdparty stuff that needed to go fullscreen but
+## xbmc was acting weird..
+## 
+## this should probably be removed after OE 6
+---
+ xbmc/windowing/X11/WinSystemX11.cpp | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/xbmc/windowing/X11/WinSystemX11.cpp
++++ b/xbmc/windowing/X11/WinSystemX11.cpp
+@@ -765,8 +765,6 @@ bool CWinSystemX11::SetWindow(int width,
+ 
+     if (fullscreen && hasWM)
+     {
+-      Atom fs = XInternAtom(m_dpy, "_NET_WM_STATE_FULLSCREEN", True);
+-      XChangeProperty(m_dpy, m_mainWindow, XInternAtom(m_dpy, "_NET_WM_STATE", True), XA_ATOM, 32, PropModeReplace, (unsigned char *) &fs, 1);
+       // disable desktop compositing for KDE, when Kodi is in full-screen mode
+       int one = 1;
+       Atom composite = XInternAtom(m_dpy, "_KDE_NET_WM_BLOCK_COMPOSITING", True);


### PR DESCRIPTION
... and move patch to Generic-x11

This reverts commit 40661a4054158f135b9fb1c5d817c816519426b6.

The patch is required to start X11 applications like 'chrome' or 'st' on top of kodi.