### PR TITLE
system-tools: rev 129; Set executable flag of 7z/7za

### DIFF
--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,6 @@
+129
+- Fix (set) 7z/7za executable flag
+
 128
 - Add mmc-utils
 

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="128"
+PKG_REV="129"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/source/bin/7z
+++ b/packages/addons/tools/system-tools/source/bin/7z
@@ -1,2 +1,4 @@
 #!/bin/sh
-exec /storage/.kodi/addons/virtual.system-tools/lib/p7zip/7z "$@"
+file=/storage/.kodi/addons/virtual.system-tools/lib/p7zip/7z
+[ ! -x ${file} ] && chmod +x ${file}
+exec ${file} "$@"

--- a/packages/addons/tools/system-tools/source/bin/7za
+++ b/packages/addons/tools/system-tools/source/bin/7za
@@ -1,2 +1,4 @@
 #!/bin/sh
-exec /storage/.kodi/addons/virtual.system-tools/lib/p7zip/7za "$@"
+file=/storage/.kodi/addons/virtual.system-tools/lib/p7zip/7za
+[ ! -x ${file} ] && chmod +x ${file}
+exec ${file} "$@"


### PR DESCRIPTION
- Fix for #6296 using missed fix from https://github.com/LibreELEC/LibreELEC.tv/pull/4441#commitcomment-55580567.
- Revision bump.

Partial backport of #6316