### PR TITLE
sqlite: update to 3.38.2

### DIFF
--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.37.1"
+PKG_VERSION="3.38.2"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="40f22a13bf38bbcd4c7ac79bcfb42a72d5aa40930c1f3f822e30ccce295f0f2e"
+PKG_SHA256="e7974aa1430bad690a5e9f79a6ee5c8492ada8269dc675875ad0fb747d7cada4"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
-PKG_URL="https://www.sqlite.org/2021/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"
+PKG_URL="https://www.sqlite.org/2022/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"
 PKG_DEPENDS_HOST="ccache:host autoconf:host automake:host"
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="An Embeddable SQL Database Engine."


### PR DESCRIPTION
update 3.37.1 to 3.38.2

release logs:
- https://www.sqlite.org/releaselog/3_37_2.html
- https://www.sqlite.org/releaselog/3_38_2.html

Additional changes in version 3.37.2 (2022-01-06):

Fix a bug introduced in version 3.35.0 (2021-03-12) that can cause
database corruption if a SAVEPOINT is rolled back while in PRAGMA
temp_store=MEMORY mode, and other changes are made, and then the outer
transaction commits. Check-in 73c2b50211d3ae26

Fix a long-standing problem with ON DELETE CASCADE and ON UPDATE CASCADE
in which a cache of the bytecode used to implement the cascading change
was not being reset following a local DDL change. Check-in
5232c9777fe4fb13.

Other minor fixes that should not impact production builds.

Changes in version 3.38.0 (2022-02-22):

Added the -> and ->> operators for easier processing of JSON. The new
operators are compatible with MySQL and PostgreSQL.
The JSON functions are now built-ins. It is no longer necessary to use
the -DSQLITE_ENABLE_JSON1 compile-time option to enable JSON support.
JSON is on by default. Disable the JSON interface using the new
-DSQLITE_OMIT_JSON compile-time option.
Enhancements to date and time functions:
Added the unixepoch() function.
Added the auto modifier and the julianday modifier.
Rename the printf() SQL function to format() for better compatibility.
The original printf() name is retained as an alias for backwards
compatibility.
Added the sqlite3_error_offset() interface, which can sometimes help to
localize an SQL error to a specific character in the input SQL text, so
that applications can provide better error messages.
Enhanced the interface to virtual tables as follows:
Added the sqlite3_vtab_distinct() interface.
Added the sqlite3_vtab_rhs_value() interface.
Added new operator types SQLITE_INDEX_CONSTRAINT_LIMIT and
SQLITE_INDEX_CONSTRAINT_OFFSET.
Added the sqlite3_vtab_in() interface (and related) to enable a virtual
table to process IN operator constraints all at once, rather than
processing each value of the right-hand side of the IN operator
separately.
CLI enhancements:
Columnar output modes are enhanced to correctly handle tabs and newlines
embedded in text.
Added options like "--wrap N", "--wordwrap on", and "--quote" to the
columnar output modes.
Added the .mode qbox alias.
The .import command automatically disambiguates column names.
Use the new sqlite3_error_offset() interface to provide better error
messages.
Query planner enhancements:
Use a Bloom filter to speed up large analytic queries.
Use a balanced merge tree to evaluate UNION or UNION ALL compound SELECT
statements that have an ORDER BY clause.
The ALTER TABLE statement is changed to silently ignores entries in the
sqlite_schema table that do not parse when PRAGMA writable_schema=ON.

Additional changes in version 3.38.1 (2022-03-12):

Fix problems with the new Bloom filter optimization that might cause
some obscure queries to get an incorrect answer.
Fix the localtime modifier of the date and time functions so that it
preserves fractional seconds.
Fix the sqlite_offset SQL function so that it works correctly even in
corner cases such as when the argument is a virtual column or the column
of a view.
Fix row value IN operator constraints on virtual tables so that they
work correctly even if the virtual table implementation relies on
bytecode to filter rows that do not satisfy the constraint.
Other minor fixes to assert() statements, test cases, and documentation.
See the source code timeline for details.

Additional changes in version 3.38.2 (2022-03-26):

Fix another user-discovered problem with the new Bloom filter
optimization that might cause an incorrect answer when doing a LEFT JOIN
with a WHERE clause constraint that says that one of the columns on the
right table of the LEFT JOIN is NULL. See forum thread 031e262a89b6a9d2.
Other minor patches. See the timeline for details.