### PR TITLE
nano: update to 6.2

### DIFF
--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nano"
-PKG_VERSION="6.0"
-PKG_SHA256="93ac8cb68b4ad10e0aaeb80a2dd15c5bb89eb665a4844f7ad01c67efcb169ea2"
+PKG_VERSION="6.2"
+PKG_SHA256="2bca1804bead6aaf4ad791f756e4749bb55ed860eec105a97fba864bc6a77cb3"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.nano-editor.org/"
-PKG_URL="http://ftpmirror.gnu.org/nano/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.nano-editor.org/"
+PKG_URL="https://www.nano-editor.org/dist/v6/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="Nano is an enhanced clone of the Pico text editor."
 


### PR DESCRIPTION
### 2022 February 18 - GNU nano 6.2 "Kamperfoelie"

The file browser clears the prompt bar also when using --minibar.
Linting now works also with a newer 'pyflakes'.

### 2022 February 9 - GNU nano 6.1 "Rețelele de socializare sunt ca un frigider" 

The behavior of ^K at a prompt has been enhanced: when there
is text after the cursor, just this text is erased. (In the usual 
situation, however, when the cursor is at the end of the answer,
the behavior is as before: the whole answer is erased.) 
At a prompt, M-6 copies the current answer into the cutbuffer.
Large external pastes into nano are handled more quickly.

