### PR TITLE
devtool package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.17.8"
-PKG_SHA256="1a6981027aad32e14fcfe141eb31eb7ce0736925dc68c3eafb0e94dbad5ce1b3"
+PKG_VERSION="1.18"
+PKG_SHA256="63e5cab48f97c63dc2737eb35582316acf77084d109ac0571651cedaf40987c0"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/Jinja2/package.mk
+++ b/packages/python/devel/Jinja2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Jinja2"
-PKG_VERSION="3.0.3"
-PKG_SHA256="611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
+PKG_VERSION="3.1.1"
+PKG_SHA256="640bed4bb501cbd17194b3cace1dc2126f5b619cf068a726b98192a0fde74ae9"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/Jinja2/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="0.61.2"
-PKG_SHA256="0233a7f8d959079318f6052b0939c27f68a5de86ba601f25c9ee6869fb5f5889"
+PKG_VERSION="0.62.0"
+PKG_SHA256="06f8c1cfa51bfdb533c82623ffa524cacdbea02ace6d709145e33aabdad6adcb"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/tools/mtools/package.mk
+++ b/packages/tools/mtools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mtools"
-PKG_VERSION="4.0.37"
-PKG_SHA256="799b197e23e47b61259628810b27790efb7a1fe36037ef1da8a27b0ae4fa8342"
+PKG_VERSION="4.0.38"
+PKG_SHA256="7b94485f486e7df08cca68b00a164a13cd38f4c63cb8684d188759ee7bc5e729"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/mtools/"
 PKG_URL="http://ftpmirror.gnu.org/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- mtools: update to 4.0.38
- Jinja2: update to 3.1.1
- meson: update to 0.62.0
- go: update to 1.18