### PR TITLE
squashfs-tools: update to 4.5.1

### DIFF
--- a/packages/sysutils/squashfs-tools/package.mk
+++ b/packages/sysutils/squashfs-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squashfs-tools"
-PKG_VERSION="4.5"
-PKG_SHA256="b9e16188e6dc1857fe312633920f7d71cc36b0162eb50f3ecb1f0040f02edddd"
+PKG_VERSION="4.5.1"
+PKG_SHA256="277b6e7f75a4a57f72191295ae62766a10d627a4f5e5f19eadfbc861378deea7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/plougher/squashfs-tools"
 PKG_URL="https://github.com/plougher/squashfs-tools/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
minor updates:- https://github.com/plougher/squashfs-tools/releases/tag/4.5.1

### SQUASHFS CHANGE LOG

4.5.1	17 MAR 2022	New Manpages, Fix CVE-2021-41072 and miscellaneous improvements and bug fixes

1. Major improvements

		1.1 This release adds Manpages for Mksquashfs(1), Unsquashfs(1),
		    Sqfstar(1) and Sqfscat(1).
		1.2 The -help text output from the utilities has been improved
		    and extended as well (but the Manpages are now more
		    comprehensive).
		1.3 CVE-2021-41072 which is a writing outside of destination
		    exploit, has been fixed.

2. Minor improvements

		2.1 The number of hard-links in the filesystem is now also
		    displayed by Mksquashfs in the output summary.
		2.2 The number of hard-links written by Unsquashfs is now
		    also displayed in the output summary.
		2.3 Unsquashfs will now write to a pre-existing destination
		    directory, rather than aborting.
		2.4 Unsquashfs now allows "." to used as the destination, to
		    extract to the current directory.
		2.5 The Unsquashfs progress bar now tracks empty files and
		    hardlinks, in addition to data blocks.
		2.6 -no-hardlinks option has been implemented for Sqfstar.
		2.7 More sanity checking for "corrupted" filesystems, including
		    checks for multiply linked directories and directory loops.
		2.8 Options that may cause filesystems to be unmountable have
		    been moved into a new "experts" category in the Mksquashfs
		    help text (and Manpage).

3. Bug fixes

		3.1 Maximum cpiostyle filename limited to PATH_MAX.  This
		    prevents attempts to overflow the stack, or cause system
		    calls to fail with a too long pathname.
		3.2 Don't always use "max open file limit" when calculating
		    length of queues, as a very large file limit can cause
		    Unsquashfs to abort.  Instead use the smaller of max open
		    file limit and cache size.
		3.3 Fix Mksquashfs silently ignoring Pseudo file definitions
		    when appending.
		3.4 Don't abort if no XATTR support has been built in, and
		    there's XATTRs in the filesystem.  This is a regression
		    introduced in 2019 in Version 4.4.
		3.5 Fix duplicate check when the last file block is sparse.