### PR TITLE
security package updates

### DIFF
--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.7.3"
-PKG_SHA256="fc59c43bc31ab20a6977ff083029277a31935b8355ce387b634fa433f8f6c49a"
+PKG_VERSION="3.7.4"
+PKG_SHA256="e6adbebcfbc95867de01060d93c789938cf89cc1d1f6ef9ef661890f6217451f"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -20,7 +20,6 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-doc \
                            --disable-tests \
                            --disable-tools \
                            --disable-valgrind-tests \
-                           --enable-local-libopts \
                            --with-idn \
                            --with-included-libtasn1 \
                            --with-included-unistring \

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.75"
-PKG_SHA256="fbc9e1d905e29b993c075400443ae06285981b8ce771d20c2063796e27cd93f0"
+PKG_VERSION="3.76.1"
+PKG_SHA256="9d40942e6a58b2055e19c1d2c3fe53d0410af1c230420013b90b3dc9c1c5dde9"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
gnutls: update to 3.7.4
- https://lists.gnupg.org/pipermail/gnutls-help/2022-March/004738.html
nss: update to 3.76.1
- https://firefox-source-docs.mozilla.org/security/nss/releases/nss_3_76.html
- https://firefox-source-docs.mozilla.org/security/nss/releases/nss_3_76_1.html
  - Bug 1756271 - Remove token member from NSSSlot struct.
  - https://hg.mozilla.org/projects/nss/rev/932ffb74083cee8d5ef2f2934969870b4a354fc8