### PR TITLE
bluez: update to 5.64

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bluez"
-PKG_VERSION="5.63"
-PKG_SHA256="9349e11e8160bb3d720835d271250d8a7424d3690f5289e6db6fe07cc66c6d76"
+PKG_VERSION="5.64"
+PKG_SHA256="ae437e65b6b3070c198bc5b0109fe9cdeb9eaa387380e2072f9de65fe8a1de34"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release of BlueZ 5.64
- 19th March 2022, 06:18 am by Tedd Ho-Jeong An

This is another release mostly with the bug fixes on HOG, GATT, A2DP,
Media, AVDTP, AVRCP, and scanning failure. Also, this release includes a
fix for building with old glibc (< 2.25), and other minor issues found
with the static code analyzing tool. ISO packet support is added to the
emulator as a part of LE Audio development.