### PR TITLE
util-linux: update to 2.38

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="util-linux"
-PKG_VERSION="2.37.4"
-PKG_SHA256="634e6916ad913366c3536b6468e7844769549b99a7b2bf80314de78ab5655b83"
+PKG_VERSION="2.38"
+PKG_SHA256="6d111cbe4d55b336db2f1fbeffbc65b89908704c01136371d32aa9bec373eb64"
 PKG_LICENSE="GPL"
 PKG_URL="https://www.kernel.org/pub/linux/utils/util-linux/v$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host autoconf:host automake:host intltool:host libtool:host pkg-config:host"
@@ -54,7 +54,8 @@ PKG_CONFIGURE_OPTS_TARGET="${UTILLINUX_CONFIG_DEFAULT} \
                            --enable-fsck \
                            --enable-fstrim \
                            --enable-blkid \
-                           --enable-lscpu"
+                           --enable-lscpu \
+                           --enable-lsfd"
 
 if [ "${SWAP_SUPPORT}" = "yes" ]; then
   PKG_CONFIGURE_OPTS_TARGET+=" --enable-swapon"


### PR DESCRIPTION
update 2.37.4 to 2.38

release notes:
- https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.38/v2.38-ReleaseNotes

additionally handle minus '-' in PKG_VERSION="2.38-rc4" in PKG_URL

includes NEW COMMAND: lsfd

  lsfd is a NEW COMMAND. lsfd is intended to be a modern replacement for lsof(8)
  on Linux systems. Unlike lsof, lsfd is specialized to Linux kernel; it supports
  Linux specific features like namespaces with simpler code. lsfd is not a
  drop-in replacement for lsof; they are different in the command line interface
  and output formats. lsfd uses Libsmartcols for output formatting and filtering.
  For example: lsfd -Q 'ASSOC == "exe"' prints all running executables.
  (Thanks to Masatake YAMATO)

/usr/bin/lsfd is 107760 bytes on Generic

man page here:
- https://github.com/util-linux/util-linux/blob/master/misc-utils/lsfd.1.adoc