### PR TITLE
mesa: update to 22.0.1

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="22.0.0"
-PKG_SHA256="e6c41928b5b9917485bd67cec22d15e62cad7a358bf4c711a647979987601250"
+PKG_VERSION="22.0.1"
+PKG_SHA256="c05f9682c54560b36e0afa70896233fc73f1ed715e10d1a028b0eb84fd04426f"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/mesa/patches/mesa-999.01-panfrost-process-scissor-state-earlier.patch
+++ b/packages/graphics/mesa/patches/mesa-999.01-panfrost-process-scissor-state-earlier.patch
@@ -1,0 +1,86 @@
+From d2fb6879a2934de03323b9c72b2f4987b2bc38d9 Mon Sep 17 00:00:00 2001
+From: Alyssa Rosenzweig <alyssa@collabora.com>
+Date: Sat, 15 Jan 2022 10:29:11 -0500
+Subject: [PATCH] panfrost: Process scissor state earlier
+
+Otherwise, if batch->scissor_culls_everything is set for a single draw,
+every draw after it in the batch will be skipped because the new
+scissor/viewport state will never be processed. Process scissor state
+early in draw_vbo to fix this interaction.
+
+We do need to be careful: setting something on the batch can only happen when
+we've decided on a batch. If we have to select a fresh batch due to too many
+draws, that must happen first. This is pretty clear in the code but worth noting
+for the diff.
+
+Signed-off-by: Alyssa Rosenzweig <alyssa@collabora.com>
+Reported-by: Icecream95 <ixn@disroot.org>
+Reviewed-by: Icecream95 <ixn@disroot.org>
+Fixes: 79356b2e ("panfrost: Skip rasterizer discard draws without side effects")
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/5839
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/6136
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/15365>
+---
+ src/gallium/drivers/panfrost/pan_cmdstream.c | 22 ++++++++++++--------
+ src/panfrost/ci/panfrost-g52-fails.txt       |  1 -
+ 2 files changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/src/gallium/drivers/panfrost/pan_cmdstream.c b/src/gallium/drivers/panfrost/pan_cmdstream.c
+index 8af81f4b9f5..0f23da2b12e 100644
+--- a/src/gallium/drivers/panfrost/pan_cmdstream.c
++++ b/src/gallium/drivers/panfrost/pan_cmdstream.c
+@@ -2642,9 +2642,6 @@ panfrost_update_state_3d(struct panfrost_batch *batch)
+ {
+         unsigned dirty = batch->ctx->dirty;
+ 
+-        if (dirty & (PAN_DIRTY_VIEWPORT | PAN_DIRTY_SCISSOR))
+-                batch->viewport = panfrost_emit_viewport(batch);
+-
+         if (dirty & PAN_DIRTY_TLS_SIZE)
+                 panfrost_batch_adjust_stack_size(batch);
+ }
+@@ -3144,6 +3141,19 @@ panfrost_draw_vbo(struct pipe_context *pipe,
+         /* Do some common setup */
+         struct panfrost_batch *batch = panfrost_get_batch_for_fbo(ctx);
+ 
++        /* Don't add too many jobs to a single batch. Hardware has a hard limit
++         * of 65536 jobs, but we choose a smaller soft limit (arbitrary) to
++         * avoid the risk of timeouts. This might not be a good idea. */
++        if (unlikely(batch->scoreboard.job_index > 10000))
++                batch = panfrost_get_fresh_batch_for_fbo(ctx, "Too many draws");
++
++        /* panfrost_batch_skip_rasterization reads
++         * batch->scissor_culls_everything, which is set by
++         * panfrost_emit_viewport, so call that first.
++         */
++        if (ctx->dirty & (PAN_DIRTY_VIEWPORT | PAN_DIRTY_SCISSOR))
++                batch->viewport = panfrost_emit_viewport(batch);
++
+         /* If rasterization discard is enabled but the vertex shader does not
+          * have side effects (including transform feedback), skip the draw
+          * altogether. This is always an optimization. Additionally, this is
+@@ -3160,12 +3170,6 @@ panfrost_draw_vbo(struct pipe_context *pipe,
+                         return;
+         }
+ 
+-        /* Don't add too many jobs to a single batch. Hardware has a hard limit
+-         * of 65536 jobs, but we choose a smaller soft limit (arbitrary) to
+-         * avoid the risk of timeouts. This might not be a good idea. */
+-        if (unlikely(batch->scoreboard.job_index > 10000))
+-                batch = panfrost_get_fresh_batch_for_fbo(ctx, "Too many draws");
+-
+         unsigned zs_draws = ctx->depth_stencil->draws;
+         batch->draws |= zs_draws;
+         batch->resolve |= zs_draws;
+diff --git a/src/panfrost/ci/panfrost-g52-fails.txt b/src/panfrost/ci/panfrost-g52-fails.txt
+index 07be170f72e..68a2d677df8 100644
+--- a/src/panfrost/ci/panfrost-g52-fails.txt
++++ b/src/panfrost/ci/panfrost-g52-fails.txt
+@@ -583,7 +583,6 @@ spec@!opengl 2.1@pbo@test_polygon_stip,Fail
+ spec@!opengl 2.1@polygon-stipple-fs,Fail
+ spec@!opengl 3.0@gl-3.0-vertexattribipointer,Fail
+ spec@!opengl 3.0@required-texture-attachment-formats,Fail
+-spec@!opengl 3.0@viewport-clamp,Crash
+ spec@!opengl 3.1@primitive-restart-xfb flush,Fail
+ spec@!opengl 3.1@primitive-restart-xfb generated,Fail
+ spec@!opengl 3.1@primitive-restart-xfb written,Fail


### PR DESCRIPTION
announce:
https://lists.freedesktop.org/archives/mesa-announce/2022-March/000667.html

```
=== tested on ===
Generic.x86_64-devel-20220329230628-893f7ac
Linux nuc11 5.17.1 #1 SMP Tue Mar 29 04:22:04 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.101) Git:2f11e994f322f7376476b186293a3df34246b9a7). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-03-29 by GCC 12.0.1 for Linux x86 64-bit version 5.17.1 (332033)
Running on LibreELEC (heitbaum): devel-20220329230628-893f7ac 11.0, kernel: Linux x86 64-bit version 5.17.1
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0042.2021.1213.1702 12/13/2021
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.0.1
libva info: VA-API version 1.14.0
vainfo: VA-API version: 1.14 (libva 2.14.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.3.0 (7cd09c4cb8)
```