### PR TITLE
Intel Graphic Updates

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.1.0"
-PKG_SHA256="b19edb4d6f2a21a64d109d08c4327d92ffc7993306c1714f4df16ef1c7a0e5b0"
+PKG_VERSION="22.1.2"
+PKG_SHA256="3b9a6d5e7e3f5748b3d0a2fb0e980ae943907fece0980bd9c0508e71c838e334"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.3.0"
-PKG_SHA256="89940ae2f7e5c7ec182f0d4d0ce8e149ae614876edd5bdad2b852e699a29b3f9"
+PKG_VERSION="22.3.1"
+PKG_SHA256="0fdccad95a561178bd19fba69ab94be23bd4a3072e68aa18c3304c990d87d7d8"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
- gmmlib: update to 22.1.2
  - minors
  - https://github.com/intel/gmmlib/compare/intel-gmmlib-22.1.0...intel-gmmlib-22.1.2
- media-driver: update to 22.3.1
  - https://github.com/intel/media-driver/compare/intel-media-22.3.0...intel-media-22.3.1

```
=== tested on ===
Generic.x86_64-devel-20220331150530-2ba6e2f
Linux nuc11 5.17.1 #1 SMP Wed Mar 30 09:33:15 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.101) Git:2f11e994f322f7376476b186293a3df34246b9a7). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-03-30 by GCC 12.0.1 for Linux x86 64-bit version 5.17.1 (332033)
Running on LibreELEC (heitbaum): devel-20220331150530-2ba6e2f 11.0, kernel: Linux x86 64-bit version 5.17.1
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0042.2021.1213.1702 12/13/2021
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.0.1
libva info: VA-API version 1.14.0
vainfo: VA-API version: 1.14 (libva 2.14.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.3.1 (2ba6e2f7d5)
```