### PR TITLE
bluez: add upstream patch to fix gatt database issue 

### DIFF
--- a/packages/network/bluez/patches/bluez-22-Fix-gatt-db-attribute-get-index.patch
+++ b/packages/network/bluez/patches/bluez-22-Fix-gatt-db-attribute-get-index.patch
@@ -1,0 +1,36 @@
+From 403cfc553e65318c547840516007f4cd4e872aa7 Mon Sep 17 00:00:00 2001
+From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Date: Fri, 1 Apr 2022 14:38:57 -0700
+Subject: [PATCH] shared/gatt-db: Fix gatt_db_attribute_get_index
+
+gatt_db_attribute_get_index was calculating the index based on
+attrib->handle - service->attributes[0]->handle which doesn't work when
+there are gaps in between handles.
+
+Fixes: https://github.com/bluez/bluez/issues/326
+---
+ src/shared/gatt-db.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/shared/gatt-db.c b/src/shared/gatt-db.c
+index be07cdbe4..4f5d10b57 100644
+--- a/src/shared/gatt-db.c
++++ b/src/shared/gatt-db.c
+@@ -1537,12 +1537,12 @@ static int gatt_db_attribute_get_index(struct gatt_db_attribute *attrib)
+ 		return -1;
+ 
+ 	service = attrib->service;
+-	index = attrib->handle - service->attributes[0]->handle;
+-
+-	if (index > (service->num_handles - 1))
+-		return -1;
++	for (index = 0; index < service->num_handles; index++) {
++		if (service->attributes[index] == attrib)
++			return index;
++	}
+ 
+-	return index;
++	return -1;
+ }
+ 
+ static struct gatt_db_attribute *


### PR DESCRIPTION
This PR add a patch to fix a gatt database issue which caused the 2nd Gen Amazon Fire TV remote (the model with volume ,microphone and power buttons) to stop working correctly after bluez 5.64 bump.

Bluez bug report https://github.com/bluez/bluez/issues/326

This PR will also close https://github.com/LibreELEC/LibreELEC.tv/issues/6348