### PR TITLE
[le11] linux (RPi): update to 5.15.32-ddd39a7

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="7cb1aa0ff575959163e1cea042e5e3ab5a7a90d2"
-PKG_SHA256="781356e76352d12b0f247f98b19aefc1abe624bae7f02a498fef2c909b6b84e8"
+PKG_VERSION="ea4c803c57697aad951a27fcd64c01ef16f9fe7f"
+PKG_SHA256="c1287239c85df1ad804c573653439553e5c50fab6459909513445140a9bdabd5"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="6f921e98008589258f97243fb6658d09750f0a2f" # 5.15.32
-    PKG_SHA256="552ea1a61373581ff1c53b8cf05f8f4d33d84fdae9a48dffc0b3f09d0270490a"
+    PKG_VERSION="ddd39a7758e71196f1ab1682d29ee17806f20019" # 5.15.32
+    PKG_SHA256="86391f1c87f6236b931339bf305c48499919063b77994034c9a6ecf3593880e4"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="87ed6172fdf2f5502b7c9372d9402ecbb6d78178" # 5.15.30
-    PKG_SHA256="c7092426bc7f1baaa06671c09a3fe92ef59ade4e41709d2ee85a78470c62d09b"
+    PKG_VERSION="a6859e642d3c5819eba1555f04d7a3401969e02f" # 5.15.30
+    PKG_SHA256="a88f07f0f7329436b0b8c8d8e201d30194f4831d90d0f51333ddf523ee17aabf"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="a6859e642d3c5819eba1555f04d7a3401969e02f" # 5.15.30
-    PKG_SHA256="a88f07f0f7329436b0b8c8d8e201d30194f4831d90d0f51333ddf523ee17aabf"
+    PKG_VERSION="6f921e98008589258f97243fb6658d09750f0a2f" # 5.15.32
+    PKG_SHA256="552ea1a61373581ff1c53b8cf05f8f4d33d84fdae9a48dffc0b3f09d0270490a"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="53c0d5c6893c940cb762d3a474103706b1e5e383" # 5.15.28
-    PKG_SHA256="f3077223df9f0781aafb014763f71acf2cb6727b0eec0409567eca9f2ee531d1"
+    PKG_VERSION="87ed6172fdf2f5502b7c9372d9402ecbb6d78178" # 5.15.30
+    PKG_SHA256="c7092426bc7f1baaa06671c09a3fe92ef59ade4e41709d2ee85a78470c62d09b"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="7cb1aa0ff575959163e1cea042e5e3ab5a7a90d2"
-PKG_SHA256="87750a6696e56d4331c5d1f1d458f06fdb4632cab89a8106e617e33ad75a0db4"
+PKG_VERSION="ea4c803c57697aad951a27fcd64c01ef16f9fe7f"
+PKG_SHA256="69fa1fd9546dbe7a8593735400ab8815bbbcdac3efc76707b0fc8b9b121613c5"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.28 Kernel Configuration
+# Linux/arm 5.15.30 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.30 Kernel Configuration
+# Linux/arm 5.15.32 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y
@@ -3574,6 +3574,7 @@ CONFIG_DRM_VC4_HDMI_CEC=y
 # CONFIG_DRM_MXSFB is not set
 # CONFIG_DRM_ARCPGU is not set
 # CONFIG_DRM_GM12U320 is not set
+# CONFIG_DRM_PANEL_MIPI_DBI is not set
 # CONFIG_DRM_SIMPLEDRM is not set
 # CONFIG_TINYDRM_HX8357D is not set
 # CONFIG_TINYDRM_ILI9225 is not set

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.28 Kernel Configuration
+# Linux/arm 5.15.30 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.30 Kernel Configuration
+# Linux/arm 5.15.32 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y
@@ -3713,6 +3713,7 @@ CONFIG_DRM_VC4_HDMI_CEC=y
 # CONFIG_DRM_MXSFB is not set
 # CONFIG_DRM_ARCPGU is not set
 # CONFIG_DRM_GM12U320 is not set
+# CONFIG_DRM_PANEL_MIPI_DBI is not set
 # CONFIG_DRM_SIMPLEDRM is not set
 # CONFIG_TINYDRM_HX8357D is not set
 # CONFIG_TINYDRM_ILI9225 is not set

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.30 Kernel Configuration
+# Linux/arm64 5.15.32 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y
@@ -4265,6 +4265,7 @@ CONFIG_DRM_VC4_HDMI_CEC=y
 # CONFIG_DRM_BOCHS is not set
 # CONFIG_DRM_CIRRUS_QEMU is not set
 # CONFIG_DRM_GM12U320 is not set
+# CONFIG_DRM_PANEL_MIPI_DBI is not set
 # CONFIG_DRM_SIMPLEDRM is not set
 # CONFIG_TINYDRM_HX8357D is not set
 # CONFIG_TINYDRM_ILI9225 is not set

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.28 Kernel Configuration
+# Linux/arm64 5.15.30 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Debian 10.2.1-6) 10.2.1 20210110"
 CONFIG_CC_IS_GCC=y
@@ -384,7 +384,6 @@ CONFIG_HZ=300
 CONFIG_SCHED_HRTICK=y
 CONFIG_ARCH_SPARSEMEM_ENABLE=y
 CONFIG_HW_PERF_EVENTS=y
-CONFIG_ARCH_HAS_FILTER_PGPROT=y
 # CONFIG_PARAVIRT is not set
 # CONFIG_PARAVIRT_TIME_ACCOUNTING is not set
 # CONFIG_KEXEC_FILE is not set


### PR DESCRIPTION
This fixes wifi channels 12+13 not working with the brcmfmac driver.

Runtime tested on RPi4