### PR TITLE
kodi: update to 2022-04-13

### DIFF
--- a/packages/devel/crossguid/package.mk
+++ b/packages/devel/crossguid/package.mk
@@ -10,16 +10,6 @@ PKG_SITE="https://github.com/graeme-hill/crossguid"
 PKG_URL="https://github.com/graeme-hill/crossguid/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain util-linux"
 PKG_LONGDESC="minimal, cross platform, C++ GUID library"
-PKG_TOOLCHAIN="manual"
 
-make_target() {
-  ${CXX} -c ../src/guid.cpp -o guid.o ${CXXFLAGS} -I../include --std=c++17 -DGUID_LIBUUID
-  ${AR} rvs libcrossguid.a guid.o
-}
-
-makeinstall_target() {
-  mkdir -p ${SYSROOT_PREFIX}/usr/lib/
-  cp libcrossguid.a ${SYSROOT_PREFIX}/usr/lib/
-  mkdir -p ${SYSROOT_PREFIX}/usr/include/
-  cp ../include/crossguid/guid.hpp ${SYSROOT_PREFIX}/usr/include
-}
+PKG_CMAKE_OPTS_TARGET="-DCROSSGUID_TESTS=OFF \
+                       -Wno-dev"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -348,7 +348,7 @@ post_makeinstall_target() {
   # more binaddons cross compile badness meh
   sed -e "s:INCLUDE_DIR /usr/include/kodi:INCLUDE_DIR ${SYSROOT_PREFIX}/usr/include/kodi:g" \
       -e "s:CMAKE_MODULE_PATH /usr/lib/kodi /usr/share/kodi/cmake:CMAKE_MODULE_PATH ${SYSROOT_PREFIX}/usr/share/kodi/cmake:g" \
-      -i ${SYSROOT_PREFIX}/usr/share/kodi/cmake/KodiConfig.cmake
+      -i ${SYSROOT_PREFIX}/usr/lib/kodi/cmake/KodiConfig.cmake
 
   if [ "${KODI_EXTRA_FONTS}" = yes ]; then
     mkdir -p ${INSTALL}/usr/share/kodi/media/Fonts

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="75d8ad548b4563612b79484576315db1b088dd7b"
-PKG_SHA256="cc18facab956c45a8ac5425f8eb6e2ddd32e8858ea2f6624fd0699c47fe45860"
+PKG_VERSION="70d6b0c2e5a63e8076f7e9cf26331c2441ada371"
+PKG_SHA256="6fa01090795b5548db5606e120cade2a93265f65dc4ea3daae5f1ab5701c9fa8"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="2f11e994f322f7376476b186293a3df34246b9a7"
-PKG_SHA256="7268c2900c5b893f331e471b31bfb214ff91473753b78211887247585bb82487"
+PKG_VERSION="75d8ad548b4563612b79484576315db1b088dd7b"
+PKG_SHA256="cc18facab956c45a8ac5425f8eb6e2ddd32e8858ea2f6624fd0699c47fe45860"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
@@ -13,7 +13,7 @@ Subject: disable online check
      {"uptime", SYSTEM_UPTIME},
 --- a/xbmc/utils/SystemInfo.cpp
 +++ b/xbmc/utils/SystemInfo.cpp
-@@ -273,7 +273,6 @@ bool CSysInfoJob::DoWork()
+@@ -275,7 +275,6 @@ bool CSysInfoJob::DoWork()
  {
    m_info.systemUptime      = GetSystemUpTime(false);
    m_info.systemTotalUptime = GetSystemUpTime(true);
@@ -21,7 +21,7 @@ Subject: disable online check
    m_info.videoEncoder      = GetVideoEncoder();
    m_info.cpuFrequency =
        StringUtils::Format("{:4.0f} MHz", CServiceBroker::GetCPUInfo()->GetCPUFrequency());
-@@ -1016,9 +1015,7 @@ int CSysInfo::GetXbmcBitness(void)
+@@ -1021,9 +1020,7 @@ int CSysInfo::GetXbmcBitness(void)
  
  bool CSysInfo::HasInternet()
  {

--- a/packages/mediacenter/kodi/patches/kodi-100.07-disable-minimize.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.07-disable-minimize.patch
@@ -9,7 +9,7 @@ Subject: [PATCH 07/13] disable minimize
 
 --- a/xbmc/Application.cpp
 +++ b/xbmc/Application.cpp
-@@ -2092,7 +2092,6 @@ void CApplication::OnApplicationMessage(
+@@ -2106,7 +2106,6 @@ void CApplication::OnApplicationMessage(
      break;
  
    case TMSG_MINIMIZE:

--- a/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
@@ -107,7 +107,7 @@ so, when shutdown/reboot is requested:
    bool Stop(int exitCode);
    void UnloadSkin();
    bool LoadCustomWindows();
-@@ -458,6 +459,7 @@ private:
+@@ -454,6 +455,7 @@ private:
    CApplicationStackHelper m_stackHelper;
    std::string m_windowing;
    int m_ExitCode{EXITCODE_QUIT};

--- a/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
@@ -1,6 +1,6 @@
-From e658546b32da44813c3a9913fc55c71e1e946b13 Mon Sep 17 00:00:00 2001
+From 244cbd6ac18eb6e2ce2c7a89c95cd33380439caa Mon Sep 17 00:00:00 2001
 From: MilhouseVH <milhouseVH.github@nmacleod.com>
-Date: Thu, 10 Mar 2022 23:20:09 +0100
+Date: Sun, 3 Apr 2022 11:31:07 +0200
 Subject: [PATCH] handle SIGTERM
 
 0. CApplication::Stop cant be trusted. (deadlocks crashes and boo)
@@ -16,15 +16,13 @@ so, when shutdown/reboot is requested:
 7. KILL
 ---
  xbmc/Application.cpp                          | 24 ++++++++++++++-----
- xbmc/Application.h                            |  1 +
- xbmc/XBApplicationEx.cpp                      |  1 +
- xbmc/XBApplicationEx.h                        |  1 +
+ xbmc/Application.h                            |  2 ++
  .../powermanagement/LogindUPowerSyscall.cpp   |  2 --
- 5 files changed, 21 insertions(+), 8 deletions(-)
+ 3 files changed, 20 insertions(+), 8 deletions(-)
 
 --- a/xbmc/Application.cpp
 +++ b/xbmc/Application.cpp
-@@ -1968,12 +1968,12 @@ void CApplication::OnApplicationMessage(
+@@ -1982,12 +1982,12 @@ void CApplication::OnApplicationMessage(
    switch (msg)
    {
    case TMSG_POWERDOWN:
@@ -39,7 +37,7 @@ so, when shutdown/reboot is requested:
      break;
  
    case TMSG_SHUTDOWN:
-@@ -1994,12 +1994,13 @@ void CApplication::OnApplicationMessage(
+@@ -2008,12 +2008,13 @@ void CApplication::OnApplicationMessage(
  
    case TMSG_RESTART:
    case TMSG_RESET:
@@ -54,7 +52,7 @@ so, when shutdown/reboot is requested:
      Stop(EXITCODE_RESTARTAPP);
  #endif
      break;
-@@ -2530,7 +2531,7 @@ bool CApplication::Stop(int exitCode)
+@@ -2598,7 +2599,7 @@ bool CApplication::Stop(int exitCode)
      m_frameMoveGuard.unlock();
  
      CVariant vExitCode(CVariant::VariantTypeObject);
@@ -63,15 +61,15 @@ so, when shutdown/reboot is requested:
      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnQuit", vExitCode);
  
      // Abort any active screensaver
-@@ -2562,7 +2563,6 @@ bool CApplication::Stop(int exitCode)
+@@ -2630,7 +2631,6 @@ bool CApplication::Stop(int exitCode)
      // Needs cleaning up
-     CApplicationMessenger::GetInstance().Stop();
+     CServiceBroker::GetAppMessenger()->Stop();
      m_AppFocused = false;
 -    m_ExitCode = exitCode;
      CLog::Log(LOGINFO, "Stopping all");
  
      // cancel any jobs from the jobmanager
-@@ -3149,6 +3149,18 @@ void CApplication::OnQueueNextItem()
+@@ -3217,6 +3217,18 @@ void CApplication::OnQueueNextItem()
    CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
  }
  
@@ -90,18 +88,18 @@ so, when shutdown/reboot is requested:
  void CApplication::OnPlayBackStopped()
  {
    CLog::LogF(LOGDEBUG, "CApplication::OnPlayBackStopped");
-@@ -4215,7 +4227,7 @@ void CApplication::ProcessSlow()
+@@ -4284,7 +4296,7 @@ void CApplication::ProcessSlow()
    if (CPlatformPosix::TestQuitFlag())
    {
      CLog::Log(LOGINFO, "Quitting due to POSIX signal");
--    CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
-+    CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTARTAPP);
+-    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
++    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RESTARTAPP);
    }
  #endif
  
 --- a/xbmc/Application.h
 +++ b/xbmc/Application.h
-@@ -138,6 +138,7 @@ public:
+@@ -153,6 +153,7 @@ public:
    bool InitWindow(RESOLUTION res = RES_INVALID);
  
    bool IsCurrentThread() const;
@@ -109,26 +107,14 @@ so, when shutdown/reboot is requested:
    bool Stop(int exitCode);
    void UnloadSkin();
    bool LoadCustomWindows();
---- a/xbmc/XBApplicationEx.cpp
-+++ b/xbmc/XBApplicationEx.cpp
-@@ -22,6 +22,7 @@ CXBApplicationEx::CXBApplicationEx()
-   m_bStop = false;
-   m_AppFocused = true;
-   m_ExitCode = EXITCODE_QUIT;
-+  m_ExitCodeSet = false;
-   m_renderGUI = false;
- }
+@@ -458,6 +459,7 @@ private:
+   CApplicationStackHelper m_stackHelper;
+   std::string m_windowing;
+   int m_ExitCode{EXITCODE_QUIT};
++  bool m_ExitCodeSet = false;
+ };
  
---- a/xbmc/XBApplicationEx.h
-+++ b/xbmc/XBApplicationEx.h
-@@ -29,6 +29,7 @@ public:
-   // Variables for timing
-   bool m_bStop;
-   int  m_ExitCode;
-+  bool m_ExitCodeSet;
-   bool m_AppFocused;
-   bool m_renderGUI;
- 
+ XBMC_GLOBAL_REF(CApplication,g_application);
 --- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
 +++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
 @@ -78,8 +78,6 @@ CLogindUPowerSyscall::~CLogindUPowerSysc


### PR DESCRIPTION
- update to latest kodi
- crossguid change to cmake (needed due https://github.com/xbmc/xbmc/pull/20982)
- rebased sigterm patch due https://github.com/xbmc/xbmc/pull/21200
broken again :) @mglae mind a look? 
is this something we could actually upstream ? I am not really understanding why we carry a patch that allows to close kodi at linux
```
/LE/build.LibreELEC-x11.x86_64-11.0-devel/build/kodi-89eeb1432acba1d8e417a29632c8d75fd5ecfaed/xbmc/Application.cpp:3222:8: error: 'm_ExitCodeSet' was not declared in this scope; did you mean 'm_ExitCode'?
 3222 |   if (!m_ExitCodeSet)
      |        ^~~~~~~~~~~~~
      |        m_ExitCode
[826/1604] Building CXX object build/xbmc/CMakeFiles/xbmc.dir/SeekHandler.cpp.o
ninja: build stopped: subcommand failed.
```