### PR TITLE
distro: disable iscsi support

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -167,7 +167,7 @@
   WIRELESS_DAEMON="wpa_supplicant"
 
 # build and install iSCSI support - iscsistart (yes / no)
-  ISCSI_SUPPORT="yes"
+  ISCSI_SUPPORT="no"
 
 # build with NFS support (mounting nfs shares via the OS) (yes / no)
   NFS_SUPPORT="yes"


### PR DESCRIPTION
This adds a one minute pause when mounting iSCSI devices during busybox's init to present a deprecation notice.

My understanding from past discussion is no one within LE uses iSCSI and consensus was to remove this feature in a future release. This PR is meant to either encourage people to move off iSCSI prior to its outright removal in LE11 (or later), or to have someone that uses iSCSI step up to maintain it.