### PR TITLE
busybox: hwclock: add settimeofday() fix

### DIFF
--- a/packages/sysutils/busybox/patches/busybox-07-hwclock_fix_settimeofday.patch
+++ b/packages/sysutils/busybox/patches/busybox-07-hwclock_fix_settimeofday.patch
@@ -1,0 +1,58 @@
+From 1a5d6fcbb5e606ab4acdf22afa26361a25f1d43b Mon Sep 17 00:00:00 2001
+From: Eddie James <eajames@linux.ibm.com>
+Date: Mon, 10 Aug 2020 09:59:02 -0500
+Subject: hwclock: Fix settimeofday for glibc v2.31+
+
+The glibc implementation changed for settimeofday, resulting in "invalid
+argument" error when attempting to set both timezone and time with a single
+call. Fix this by calling settimeofday twice
+
+Signed-off-by: Eddie James <eajames@linux.ibm.com>
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ util-linux/hwclock.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/util-linux/hwclock.c b/util-linux/hwclock.c
+index 357906cca..e85bca2b2 100644
+--- a/util-linux/hwclock.c
++++ b/util-linux/hwclock.c
+@@ -121,16 +121,20 @@ static void to_sys_clock(const char **pp_rtcname, int utc)
+ 	struct timeval tv;
+ 	struct timezone tz;
+ 
+-	tz.tz_minuteswest = timezone/60;
++	tz.tz_minuteswest = timezone / 60;
+ 	/* ^^^ used to also subtract 60*daylight, but it's wrong:
+ 	 * daylight!=0 means "this timezone has some DST
+ 	 * during the year", not "DST is in effect now".
+ 	 */
+ 	tz.tz_dsttime = 0;
+ 
++	/* glibc v2.31+ returns an error if both args are non-NULL */
++	if (settimeofday(NULL, &tz))
++		bb_simple_perror_msg_and_die("settimeofday");
++
+ 	tv.tv_sec = read_rtc(pp_rtcname, NULL, utc);
+ 	tv.tv_usec = 0;
+-	if (settimeofday(&tv, &tz))
++	if (settimeofday(&tv, NULL))
+ 		bb_simple_perror_msg_and_die("settimeofday");
+ }
+ 
+@@ -282,7 +286,11 @@ static void set_system_clock_timezone(int utc)
+ 	gettimeofday(&tv, NULL);
+ 	if (!utc)
+ 		tv.tv_sec += tz.tz_minuteswest * 60;
+-	if (settimeofday(&tv, &tz))
++
++	/* glibc v2.31+ returns an error if both args are non-NULL */
++	if (settimeofday(NULL, &tz))
++		bb_simple_perror_msg_and_die("settimeofday");
++	if (settimeofday(&tv, NULL))
+ 		bb_simple_perror_msg_and_die("settimeofday");
+ }
+ 
+-- 
+cgit v1.2.3
+


### PR DESCRIPTION
As reported in the [forum](https://forum.libreelec.tv/thread/25472-le11-rpi4-rtc-hwclock-not-working/?postID=168162#post168162)  using `hwclock --hctosys ...` result in 
```
hwclock: settimeofday: Invalid argument
```

Add upstream busybox patch for glib v2.31+ compatibility.

Fix for master branch is included in #6154