### PR TITLE
Have make clean/distclean respect builder's set BUILD_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-BUILD_DIRS=build.*
-
 all: release
 
 system:
@@ -15,10 +13,10 @@ noobs:
 	./scripts/image noobs
 
 clean:
-	rm -rf $(BUILD_DIRS)/* $(BUILD_DIRS)/.stamps
+	./scripts/makefile_helper --clean
 
 distclean:
-	rm -rf ./.ccache ./$(BUILD_DIRS)
+	./scripts/makefile_helper --distclean
 
 src-pkg:
 	tar cvJf sources.tar.xz sources

--- a/scripts/makefile_helper
+++ b/scripts/makefile_helper
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+set -e
+
+# If config/options can't be sourced, abort. PWD isn't the expected ROOT.
+. config/options ""
+
+# task handling
+case $1 in
+  --clean)
+    rm -rf "${BUILD_ROOT}/${BUILD_BASE}."*/* "${BUILD_ROOT}/${BUILD_BASE}."*/.stamps
+  ;;
+  --distclean)
+    rm -rf "${BUILD_ROOT}/.ccache" "${BUILD_ROOT}/${BUILD_BASE}."*
+  ;;
+  *)
+    echo "error: ${0}: unsupported option on CLI; aborting"
+    exit 1
+  ;;
+esac


### PR DESCRIPTION
This adds a script to handle sourcing of BUILD_DIR from `${ROOT}/.librelec/options` or `${HOME}/.libreelec/options` when running `make clean` or `make distclean`. I understand that there are additional places that BUILD_DIR could be set, but I believe these are the most likely places that a builder would use.

Closes #6292.