### PR TITLE
wireless-regdb: update to 2022-04-08

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2022.02.18"
-PKG_SHA256="8828c25a4ee25020044004f57374bb9deac852809fad70f8d3d01770bf9ac97f"
+PKG_VERSION="2022.04.08"
+PKG_SHA256="884ba2e3c1e8b98762b6dc25ff60b5ec75c8d33a39e019b3ed4aa615491460d3"
 PKG_LICENSE="GPL"
 PKG_SITE="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
log:
- https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/log/