### PR TITLE
cxxtools: fix compile with gcc11

### DIFF
--- a/packages/addons/addon-depends/cxxtools/patches/cxxtools-2.2.1-make-cxxtools-char-a-trivial-class-by-defining-the-default.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/cxxtools-2.2.1-make-cxxtools-char-a-trivial-class-by-defining-the-default.patch
@@ -1,0 +1,25 @@
+From b773c01fc13d2ae67abc0839888e383be23562fd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tommi=20M=C3=A4kitalo?= <tommi@tntnet.org>
+Date: Sun, 24 Jan 2021 17:20:24 +0100
+Subject: [PATCH] make cxxtools::Char a trivial class by definining the default
+ constructor as default
+
+---
+ include/cxxtools/char.h | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/include/cxxtools/char.h b/include/cxxtools/char.h
+index 1e637317..3a4ed62a 100644
+--- a/include/cxxtools/char.h
++++ b/include/cxxtools/char.h
+@@ -68,9 +68,7 @@ namespace cxxtools
+             typedef int32_t value_type;
+ 
+             //! Constructs a character with a value of 0.
+-            Char()
+-            : _value(0)
+-            {}
++            Char() = default;
+ 
+             //! Constructs a character using the given value as base for the character value.
+             Char(value_type ch)

--- a/packages/addons/addon-depends/cxxtools/patches/cxxtools-2.2.1-make-explicit-cast-in-cxxtools-char-when-moving-or-copying-data.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/cxxtools-2.2.1-make-explicit-cast-in-cxxtools-char-when-moving-or-copying-data.patch
@@ -1,0 +1,31 @@
+From 607073936f5ce1b1c348d432c19234863a072cc7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tommi=20M=C3=A4kitalo?= <tommi@tntnet.org>
+Date: Sat, 2 Jun 2018 15:23:14 +0200
+Subject: [PATCH] Make explicit cast in cxxtools::Char when moving or copying
+ data This removes a warning message from the compiler.
+
+---
+ include/cxxtools/char.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/cxxtools/char.h b/include/cxxtools/char.h
+index 00b91fd3..4ad72883 100644
+--- a/include/cxxtools/char.h
++++ b/include/cxxtools/char.h
+@@ -324,14 +324,14 @@ namespace std {
+     inline char_traits<cxxtools::Char>::char_type*
+     char_traits<cxxtools::Char>::move(char_type* s1, const char_type* s2, int_type n)
+     {
+-        return (cxxtools::Char*)std::memmove(s1, s2, n * sizeof(cxxtools::Char));
++        return static_cast<cxxtools::Char*>(std::memmove(static_cast<void*>(s1), static_cast<const void*>(s2), n * sizeof(cxxtools::Char)));
+     }
+ 
+ 
+     inline char_traits<cxxtools::Char>::char_type*
+     char_traits<cxxtools::Char>::copy(char_type* s1, const char_type* s2, size_t n)
+     {
+-        return (cxxtools::Char*)std::memcpy(s1, s2, n * sizeof(cxxtools::Char));
++        return static_cast<cxxtools::Char*>(std::memcpy(static_cast<void*>(s1), static_cast<const void*>(s2), n * sizeof(cxxtools::Char)));
+     }
+ 
+ 

--- a/packages/addons/addon-depends/cxxtools/patches/cxxtools-2.2.1-superflous-copy-constuctor.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/cxxtools-2.2.1-superflous-copy-constuctor.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tommi=20M=C3=A4kitalo?= <tommi@tntnet.org>
+Date: Fri, 31 Jan 2021 17:20:24 +0100
+Subject: [PATCH] superflous copy constuctor
+
+---
+ include/cxxtools/char.h | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/include/cxxtools/char.h b/include/cxxtools/char.h
+index 1e637317..3a4ed62a 100644
+--- a/include/cxxtools/char.h
++++ b/include/cxxtools/char.h
+@@ -114,9 +112,6 @@
+                 return Char(0);
+             }
+ 
+-            Char& operator=(const Char& ch)
+-            { _value = ch._value; return *this; }
+-
+             /**
+              * @brief Returns the internal value (unsigned 32 bits) of this character.
+              * @return The 32-bit-value of this character.


### PR DESCRIPTION
reference:
- https://github.com/maekitalo/cxxtools/issues/30

To fix the following error:

```
/var/lib/jenkins/LE/build4/workspace/Addons/All_Addons-Generic/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/11.2.0/string_view:101:21: error: static assertion failed
  101 |       static_assert(is_trivial_v<_CharT> && is_standard_layout_v<_CharT>);
      |                     ^~~~~~~~~~~~~~~~~~~~
```

Subsequent to the update to the gcc 11 
- #6253 