### PR TITLE
libretro-dosbox: build with -std=gnu++11 to fix gcc11 build

### DIFF
--- a/packages/emulation/libretro-dosbox/package.mk
+++ b/packages/emulation/libretro-dosbox/package.mk
@@ -15,6 +15,10 @@ PKG_LIBNAME="dosbox_libretro.so"
 PKG_LIBPATH="${PKG_LIBNAME}"
 PKG_LIBVAR="DOSBOX_LIB"
 
+pre_make_target() {
+  export CXXFLAGS="${CXXFLAGS} -std=gnu++11"
+}
+
 make_target() {
   make -f Makefile.libretro
 }


### PR DESCRIPTION
reference:
- https://github.com/libretro/dosbox-libretro/issues/137

To fix the following error:

```
/var/lib/jenkins/LE/build4/workspace/Addons/All_Addons-Generic/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -march=x86-64 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -fPIC -DPIC -D__LIBRETRO__ -fPIC -I./src -I./libretro -I./libretro-common/include -I./include -I./src/midi/munt -DC_HAVE_MPROTECT="1" -O3 -DNDEBUG -DGIT_VERSION=\"" 6440e1cb65"\" -DSVN_VERSION=\"\" -c libretro/dosbox.cpp -o libretro/dosbox.o
In file included from libretro/dosbox.cpp:38:
./include/setup.h:92:35: error: ISO C++17 does not allow dynamic exception specifications
   92 |         Value& operator= (Hex in) throw(WrongType)                { return copy(Value(in));}
      |                                   ^~~~~
```

Subsequent to the update to the gcc 11 
- #6253 
