### PR TITLE
libretro-uae4arm: fix gcc11 build

### DIFF
--- a/packages/emulation/libretro-uae4arm/patches/libretro-fix-ordered-comparison-of-pointer-with-integer-zero.patch
+++ b/packages/emulation/libretro-uae4arm/patches/libretro-fix-ordered-comparison-of-pointer-with-integer-zero.patch
@@ -1,0 +1,56 @@
+From 0f6b2096557a4e25ff98f309d84155bc74e26800 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 12 Apr 2022 18:07:37 +1000
+Subject: [PATCH] libretro: fix ordered comparison of pointer with integer zero
+
+Fixes compile error with gcc 11.2
+
+armv7a-libreelec-linux-gnueabihf-g++ -fPIC -march=armv7-a -mtune=cortex-a8 -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -mfloat-abi=hard -mfpu=neon-vfpv3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -D__NEON_OPT -DGIT_VERSION=6440e1cb65 -O3 -fomit-frame-pointer -finline -fno-builtin -D__LIBRETRO__ -DCPU_arm -DARM_ASSEMBLY -DARMV6_ASSEMBLY -DPANDORA -DROM_PATH_PREFIX=\"./\" -DDATA_PREFIX=\"./data/\" -DSAVE_PREFIX=\"./saves/\" -DRASPBERRY -DPICASSO96 -DUSE_ARMNEON -DINLINE="inline"  -fexceptions -fpermissive   -I./src -I./libretro/osdep -I./src/include -I./libretro -I./libretro/libco -I./libretro/core -I./utils -I./deps/zlib -I./libretro/libco -I./libretro/core -I./libretro/include -I./libretro -I.  -c -o libretro/osdep/pandora.o libretro/osdep/pandora.cpp
+libretro/osdep/pandora.cpp: In function 'int target_cfgfile_load(uae_prefs*, char*, int, int)':
+libretro/osdep/pandora.cpp:361:10: error: ordered comparison of pointer with integer zero ('char*' and 'int')
+  361 |   if(ptr > 0)
+      |      ~~~~^~~
+libretro/osdep/pandora.cpp: In function 'int check_configfile(char*)':
+libretro/osdep/pandora.cpp:407:16: error: ordered comparison of pointer with integer zero ('char*' and 'int')
+  407 |         if(ptr > 0)
+      |            ~~~~^~~
+---
+ libretro/osdep/menu/menu_config.cpp | 2 +-
+ libretro/osdep/pandora.cpp          | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libretro/osdep/menu/menu_config.cpp b/libretro/osdep/menu/menu_config.cpp
+index 662532b12..5392b3938 100644
+--- a/libretro/osdep/menu/menu_config.cpp
++++ b/libretro/osdep/menu/menu_config.cpp
+@@ -403,7 +403,7 @@ int loadconfig_old(struct uae_prefs *p, const char *orgpath)
+   
+   strcpy(path, orgpath);
+ 	char *ptr = strstr(path, ".uae");
+-	if(ptr > 0)
++	if(ptr != 0)
+   {
+     *(ptr + 1) = '\0';
+     strcat(path, "conf");
+diff --git a/libretro/osdep/pandora.cpp b/libretro/osdep/pandora.cpp
+index f5c13e799..f64b17a39 100644
+--- a/libretro/osdep/pandora.cpp
++++ b/libretro/osdep/pandora.cpp
+@@ -358,7 +358,7 @@ int target_cfgfile_load (struct uae_prefs *p, char *filename, int type, int isde
+   discard_prefs(p, type);
+   
+ 	char *ptr = strstr(filename, ".uae");
+-  if(ptr > 0)
++  if(ptr != 0)
+   {
+     int type = CONFIG_TYPE_HARDWARE | CONFIG_TYPE_HOST;
+     result = cfgfile_load(p, filename, &type, 0);
+@@ -404,7 +404,7 @@ int check_configfile(char *file)
+   
+   strcpy(tmp, file);
+ 	char *ptr = strstr(tmp, ".uae");
+-	if(ptr > 0)
++	if(ptr != 0)
+   {
+     *(ptr + 1) = '\0';
+     strcat(tmp, "conf");


### PR DESCRIPTION
Fixes compile error with gcc 11.2

raised as upstream: 
- https://github.com/libretro/uae4arm-libretro/pull/22
```
armv7a-libreelec-linux-gnueabihf-g++ -fPIC -march=armv7-a -mtune=cortex-a8 -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -mfloat-abi=hard -mfpu=neon-vfpv3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -D__NEON_OPT -DGIT_VERSION=6440e1cb65 -O3 -fomit-frame-pointer -finline -fno-builtin -D__LIBRETRO__ -DCPU_arm -DARM_ASSEMBLY -DARMV6_ASSEMBLY -DPANDORA -DROM_PATH_PREFIX=\"./\" -DDATA_PREFIX=\"./data/\" -DSAVE_PREFIX=\"./saves/\" -DRASPBERRY -DPICASSO96 -DUSE_ARMNEON -DINLINE="inline"  -fexceptions -fpermissive   -I./src -I./libretro/osdep -I./src/include -I./libretro -I./libretro/libco -I./libretro/core -I./utils -I./deps/zlib -I./libretro/libco -I./libretro/core -I./libretro/include -I./libretro -I.  -c -o libretro/osdep/pandora.o libretro/osdep/pandora.cpp
libretro/osdep/pandora.cpp: In function 'int target_cfgfile_load(uae_prefs*, char*, int, int)':
libretro/osdep/pandora.cpp:361:10: error: ordered comparison of pointer with integer zero ('char*' and 'int')
  361 |   if(ptr > 0)
      |      ~~~~^~~
libretro/osdep/pandora.cpp: In function 'int check_configfile(char*)':
libretro/osdep/pandora.cpp:407:16: error: ordered comparison of pointer with integer zero ('char*' and 'int')
  407 |         if(ptr > 0)
      |            ~~~~^~~
```