### PR TITLE
libretro-mame2015: update for python3 and enable override on OBJDUMP

### DIFF
--- a/packages/emulation/libretro-mame2015/patches/libretro-mame2015-100.01-cross-compile.patch
+++ b/packages/emulation/libretro-mame2015/patches/libretro-mame2015-100.01-cross-compile.patch
@@ -30,15 +30,6 @@ index 54a6f648c8..4a933d1d01 100644
        PTR64 = 1
     endif
     ifneq (,$(findstring ppc,$(UNAME)))
-@@ -487,7 +487,7 @@ endif
- # utilities
- MD = -mkdir$(EXE_EXT)
- RM = @rm -f
--OBJDUMP = @objdump
-+OBJDUMP ?= @objdump
- PYTHON ?= @python2
- 
- #-------------------------------------------------
 -- 
 2.17.1
 

--- a/packages/emulation/libretro-mame2015/patches/libretro-mame2015-900.01-update-for-python3-and-enable-override-on-objdump.patch
+++ b/packages/emulation/libretro-mame2015/patches/libretro-mame2015-900.01-update-for-python3-and-enable-override-on-objdump.patch
@@ -1,0 +1,24 @@
+From 988a94f2a2c33568090b5dc29e6ad599a95dc92d Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Thu, 13 Jan 2022 07:17:57 +0000
+Subject: [PATCH] Makefile: update for python3 and enable override on OBJDUMP
+
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 13f612c7ec..410360f156 100644
+--- a/Makefile
++++ b/Makefile
+@@ -524,8 +524,8 @@ endif
+ # utilities
+ MD = -mkdir$(EXE_EXT)
+ RM = @rm -f
+-OBJDUMP = @objdump
+-PYTHON ?= @python2
++OBJDUMP ?= @objdump
++PYTHON ?= @python3
+ 
+ #-------------------------------------------------
+ # form the name of the executable


### PR DESCRIPTION
backport of:
- https://github.com/libretro/mame2015-libretro/pull/91