### PR TITLE
Revert "gcc-arm-aarch64-none-linux-gnu: update to 11.2-2022.02"

### DIFF
--- a/packages/lang/gcc-arm-aarch64-none-linux-gnu/package.mk
+++ b/packages/lang/gcc-arm-aarch64-none-linux-gnu/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc-arm-aarch64-none-linux-gnu"
-PKG_VERSION="11.2-2022.02"
-PKG_SHA256="52dbac3eb71dbe0916f60a8c5ab9b7dc9b66b3ce513047baa09fae56234e53f3"
+PKG_VERSION="10.3-2021.07"
+PKG_SHA256="1e33d53dea59c8de823bbdfe0798280bdcd138636c7060da9d77a97ded095a84"
 PKG_LICENSE="GPL"
 PKG_SITE="https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a"
-PKG_URL="https://developer.arm.com/-/media/Files/downloads/gnu/${PKG_VERSION}/binrel/gcc-arm-${PKG_VERSION}-x86_64-aarch64-none-linux-gnu.tar.xz"
+PKG_URL="https://developer.arm.com/-/media/Files/downloads/gnu-a/${PKG_VERSION}/binrel/gcc-arm-${PKG_VERSION}-x86_64-aarch64-none-linux-gnu.tar.xz"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_LONGDESC="ARM Aarch64 GNU Linux Binary Toolchain"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
64bit arm kernel builds (RPi4, RK3399, AML) fail with an internal compiler error since kernel gcc was bumped to 11.2. see eg this RPi4 build log of LE master http://ix.io/3UX4 or  #6372

Revert the gcc bump until the issue is resolved

Fixes:  #6372