### PR TITLE
llvm: update to 14.0.1

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="13.0.1"
-PKG_SHA256="ec6b80d82c384acad2dc192903a6cf2cdbaffb889b84bfb98da9d71e630fc834"
+PKG_VERSION="14.0.1"
+PKG_SHA256="5b89017dec2729311ab143402f03da1dea6d0c79dd5c701bc939cf8b34f01ec2"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
@@ -22,6 +22,7 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_INCLUDE_TESTS=OFF \
                        -DLLVM_INCLUDE_GO_TESTS=OFF \
                        -DLLVM_BUILD_BENCHMARKS=OFF \
+                       -DLLVM_INCLUDE_BENCHMARKS=OFF \
                        -DLLVM_BUILD_DOCS=OFF \
                        -DLLVM_INCLUDE_DOCS=OFF \
                        -DLLVM_ENABLE_DOXYGEN=OFF \
@@ -34,13 +35,18 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_ENABLE_WERROR=OFF \
                        -DLLVM_ENABLE_ZLIB=ON \
                        -DLLVM_ENABLE_LIBXML2=OFF \
-                       -DLLVM_BUILD_LLVM_DYLIB=ON \
-                       -DLLVM_LINK_LLVM_DYLIB=ON \
+                       -DBUILD_SHARED_LIBS=ON \
                        -DLLVM_OPTIMIZED_TABLEGEN=ON \
                        -DLLVM_APPEND_VC_REV=OFF \
                        -DLLVM_ENABLE_RTTI=ON \
                        -DLLVM_ENABLE_UNWIND_TABLES=OFF \
                        -DLLVM_ENABLE_Z3_SOLVER=OFF"
+
+post_unpack() {
+  # the cmake/Modules/*.cmake are appended to the tar archive file.
+  # move these into llvm-pkgver/cmake/modules directory.
+  mv -n ${PKG_BUILD}/Modules/*.cmake ${PKG_BUILD}/cmake/modules/
+}
 
 pre_configure_host() {
   CXXFLAGS+=" -DLLVM_CONFIG_EXEC_PREFIX=\\\"${SYSROOT_PREFIX}/usr\\\""
@@ -58,7 +64,8 @@ make_host() {
 }
 
 makeinstall_host() {
-  cp -a lib/libLLVM-*.so ${TOOLCHAIN}/lib
+  cp -a lib/libLLVM*.so ${TOOLCHAIN}/lib
+  cp -a lib/libLLVM*.so.14 ${TOOLCHAIN}/lib
   cp -a bin/llvm-config ${TOOLCHAIN}/bin/llvm-config-host
   cp -a bin/llvm-tblgen ${TOOLCHAIN}/bin
 }

--- a/packages/lang/llvm/patches/llvm-14.0.0-disable-benchmarks.patch
+++ b/packages/lang/llvm/patches/llvm-14.0.0-disable-benchmarks.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2022-04-02 06:26:04.688530539 +0000
++++ b/CMakeLists.txt	2022-04-02 06:44:00.015717360 +0000
+@@ -616,7 +616,7 @@
+ 
+ option(LLVM_BUILD_BENCHMARKS "Add LLVM benchmark targets to the list of default
+ targets. If OFF, benchmarks still could be built using Benchmarks target." OFF)
+-option(LLVM_INCLUDE_BENCHMARKS "Generate benchmark targets. If OFF, benchmarks can't be built." ON)
++option(LLVM_INCLUDE_BENCHMARKS "Generate benchmark targets. If OFF, benchmarks can't be built." OFF)
+ 
+ option (LLVM_BUILD_DOCS "Build the llvm documentation." OFF)
+ option (LLVM_INCLUDE_DOCS "Generate build targets for llvm documentation." ON)


### PR DESCRIPTION
Update to llvm version 14.0.1

### Missing .cmake files in cmake/modules

Workaround included for the issue identified in:
- https://github.com/llvm/llvm-project/issues/53281

Because of the way the `llvm` project packages the standalone llvm it assumes that ../cmake will be available. We remove the first directory from the tar file and place it in our own `unpack` directory. Thus `Modules` ends up in `llvm-14.0.1/`

**See the below tar file.** 

```
$ tar --list -f sources/llvm/llvm-14.0.1.src.tar.xz | tail -12
llvm-14.0.1.src/utils/yaml-bench/CMakeLists.txt
llvm-14.0.1.src/utils/yaml-bench/YAMLBench.cpp
cmake/
cmake/Modules/
cmake/Modules/EnableLanguageNolink.cmake
cmake/Modules/ExtendPath.cmake
cmake/Modules/FindPrefixFromConfig.cmake
cmake/Modules/HandleCompilerRT.cmake
cmake/Modules/HandleOutOfTreeLLVM.cmake
cmake/Modules/LLVMCheckCompilerLinkerFlag.cmake
cmake/Modules/SetPlatformToolchainTools.cmake
cmake/README.rst
```

### LLVM_INCLUDE_BENCHMARKS with llvm 14.0.1 failing to build.

without the benchmark patch the follow build error occurs with llvm:host. It appears to be that the `if (LLVM_INCLUDE_BENCHMARKS)` is expanded before the make option is overridden. Unsure if this is a cmake BUG / FEATURE or an error in the `llvm/CMakeLists.txt` file. If you run `scripts/build llvm:host`a 2nd time straight away - it successfully compiles. The CMakeCache.txt file has the correct option in it `LLVM_INCLUDE_BENCHMARKS:BOOL=OFF` 
so the option `-DLLVM_INCLUDE_BENCHMARKS=OFF` is correctly being past from the command line.
```
-- Registering Bye as a pass plugin (static build: OFF)
CMake Error at CMakeLists.txt:1256 (add_subdirectory):
  add_subdirectory given source
  "/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/build/llvm-14.0.1/../third-party/benchmark"
  which is not an existing directory.


-- Configuring incomplete, errors occurred!
```
Raised as upstream https://github.com/llvm/llvm-project/issues/54941


### llvm 14.0.1 fails to build shared objects (build issue - DYLIB)
https://github.com/llvm/llvm-project/commit/85e2731aa3d440384067001a9a460a889037eb11 describes the bug building flang and not working with DYLIB. With updating our LE package from 13.0.1 to 14.0.1 we need to use `BUILD_SHARED_LIBS=ON` as the `DYLIB` options are not working.

Doing a build of llvm-13.0.1 with 
-DLLVM_BUILD_LLVM_DYLIB=ON
-DLLVM_LINK_LLVM_DYLIB=ON
correctly builds the .so files.

Current workaround is to use the NOT recommended option with llvm-14.0.1
-DBUILD_SHARED_LIBS=ON
to build the .so files.

Raised as upstream https://github.com/llvm/llvm-project/issues/54940