### PR TITLE
mariadb: update to 10.4.22 and addon (106)

### DIFF
--- a/packages/addons/service/mariadb/changelog.txt
+++ b/packages/addons/service/mariadb/changelog.txt
@@ -1,3 +1,8 @@
+106
+- update MariaDB to 10.4.22
+- drop support for TokuDB, it is deprecated in 10.5.y and is not
+  supported when being cross_compiled
+
 105
 - update MariaDB to 10.4.21
 

--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="10.4.21"
-PKG_REV="105"
-PKG_SHA256="94dd2e6f5d286de8a7dccffe984015d4253a0568281c7440e772cfbe098a291d"
+PKG_VERSION="10.4.22"
+PKG_REV="106"
+PKG_SHA256="44bdc36eeb02888296e961718bae808f3faab268ed49160a785248db60500c00"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://downloads.mariadb.com/MariaDB/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"
@@ -42,6 +42,7 @@ configure_package() {
     -DWITH_SSL=system \
     -DWITH_SSL=${SYSROOT_PREFIX}/usr \
     -DWITH_JEMALLOC=OFF \
+    -DWITHOUT_TOKUDB=1 \
     -DWITH_PCRE=bundled \
     -DWITH_ZLIB=bundled \
     -DWITH_EDITLINE=bundled \


### PR DESCRIPTION
TokuDB's configure script seems somewhat broken when it comes to
cross-compilation so we shall disable it and also disable TokuDB.

Additionally TokuDB has been deprecated in MariaDB 10.5.y.

release notes of MariaDB 10.4.22:
- https://mariadb.com/kb/en/mariadb-10422-release-notes/

note: we haven’t updated to 10.4.24 at this time as there is a build issue with 10.4.24
```
CMake Error at /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find GnuTLS (missing: GNUTLS_LIBRARY GNUTLS_INCLUDE_DIR)
  (Required is at least version "3.3.24")
Call Stack (most recent call first):
  /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/share/cmake-3.23/Modules/FindGnuTLS.cmake:68 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  libmariadb/CMakeLists.txt:311 (FIND_PACKAGE)


-- Configuring incomplete, errors occurred!
```