### PR TITLE
[le11] libretro-mame2015: simplify cross-compile patch

### DIFF
--- a/packages/emulation/libretro-mame2015/patches/libretro-mame2015-100.01-cross-compile.patch
+++ b/packages/emulation/libretro-mame2015/patches/libretro-mame2015-100.01-cross-compile.patch
@@ -1,14 +1,5 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -138,7 +138,7 @@
-       LIBS += -lGL
-    endif
-    LDFLAGS +=  $(fpic) $(SHARED)
--   REALCC ?= gcc
-+   REALCC ?= $(CC)
-    BASELIBS += -lpthread
-    CXX ?= g++
-    #workaround for mame bug (c++ in .c files)
 @@ -146,23 +146,23 @@
     AR ?= @ar
     LD := $(CXX)


### PR DESCRIPTION
REALCC is already set in package.mk so the hunk can be dropped