### PR TITLE
[LE11] Relax or1k toolchain dependency

### DIFF
--- a/packages/devel/binutils-or1k/package.mk
+++ b/packages/devel/binutils-or1k/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/binutils/"
 PKG_URL="https://ftp.gnu.org/gnu/binutils/binutils-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_HOST="toolchain"
+PKG_DEPENDS_HOST="toolchain:host"
 PKG_LONGDESC="A GNU collection of binary utilities for OpenRISC 1000."
 
 PKG_CONFIGURE_OPTS_HOST="--target=or1k-none-elf \

--- a/packages/lang/gcc-or1k/package.mk
+++ b/packages/lang/gcc-or1k/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://gcc.gnu.org/"
 PKG_URL="http://ftpmirror.gnu.org/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_HOST="toolchain ccache:host autoconf:host binutils-or1k:host gmp:host mpfr:host mpc:host zstd:host"
+PKG_DEPENDS_HOST="toolchain:host ccache:host autoconf:host binutils-or1k:host gmp:host mpfr:host mpc:host zstd:host"
 PKG_LONGDESC="This package contains the GNU Compiler Collection for OpenRISC 1000."
 
 PKG_CONFIGURE_OPTS_HOST="--target=or1k-none-elf \


### PR DESCRIPTION
There is no reason to depend on target gcc, so depend on toolchain:host instead of toolchain.