### PR TITLE
GStreamer updates

### DIFF
--- a/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-bad"
-PKG_VERSION="1.18.5"
-PKG_SHA256="a164923b94f0d08578a6fcaeaac6e0c05da788a46903a1086870e9ca45ad678e"
+PKG_VERSION="1.20.1"
+PKG_SHA256="09d3c2cf5911f0bc7da6bf557a55251779243d3de216b6a26cc90c445b423848"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-bad.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-bad/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -11,7 +11,7 @@ PKG_DEPENDS_TARGET="toolchain gst-plugins-base"
 PKG_LONGDESC="GStreamer Bad Plug-ins is a set of plug-ins that aren't up to par compared to the rest."
 
 pre_configure_target() {
-  PKG_MESON_OPTS_TARGET="-Dgst_player_tests=false \
+  PKG_MESON_OPTS_TARGET="-Dgst_play_tests=false \
                          -Daccurip=disabled \
                          -Dadpcmdec=disabled \
                          -Dadpcmenc=disabled \
@@ -117,7 +117,6 @@ pre_configure_target() {
                          -Dkms=disabled \
                          -Dladspa=disabled \
                          -Dlibde265=disabled \
-                         -Dlibmms=disabled \
                          -Dlv2=disabled \
                          -Dmediafoundation=disabled \
                          -Dmicrodns=disabled \
@@ -128,7 +127,6 @@ pre_configure_target() {
                          -Dmusepack=disabled \
                          -Dneon=disabled \
                          -Dnvcodec=disabled \
-                         -Dofa=disabled \
                          -Dopenal=disabled \
                          -Dopenexr=disabled \
                          -Dopenh264=disabled \
@@ -183,16 +181,17 @@ pre_configure_target() {
                          -Dgobject-cast-checks=disabled \
                          -Dglib-asserts=disabled \
                          -Dglib-checks=disabled \
-                         -Dpackage-name="gst-plugins-bad"
-                         -Dpackage-origin="LibreELEC.tv"
+                         -Dpackage-name=gst-plugins-bad \
+                         -Dpackage-origin=LibreELEC.tv \
                          -Ddoc=disabled"
 }
 
-post_makeinstall_target(){
+post_makeinstall_target() {
   # clean up
   safe_remove ${INSTALL}/usr/bin
   for PKG_GST_PLUGINS_BAD in \
-    libgstadaptivedemux libgstbadaudio libgstbasecamerabinsrc libgstcodecs libgstinsertbin libgstisoff libgstmpegts libgstphotography libgstplayer \
+    libgstadaptivedemux libgstbadaudio libgstbasecamerabinsrc libgstcodecs \
+    libgstinsertbin libgstisoff libgstmpegts libgstphotography libgstplayer \
     libgstsctp libgsttranscoder libgsturidownloader libgstwebrtc
   do
     safe_remove ${INSTALL}/usr/lib/${PKG_GST_PLUGINS_BAD}-1.0*

--- a/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-base"
-PKG_VERSION="1.18.5"
-PKG_SHA256="960b7af4585700db0fdd5b843554e11e2564fed9e061f591fae88a7be6446fa3"
+PKG_VERSION="1.20.1"
+PKG_SHA256="96d8a6413ba9394fbec1217aeef63741a729d476a505a797c1d5337d8fa7c204"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-base.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-base/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -57,12 +57,12 @@ pre_configure_target() {
                          -Dgobject-cast-checks=disabled \
                          -Dglib-asserts=disabled \
                          -Dglib-checks=disabled \
-                         -Dpackage-name="gst-plugins-base"
-                         -Dpackage-origin="LibreELEC.tv"
+                         -Dpackage-name=gst-plugins-base \
+                         -Dpackage-origin=LibreELEC.tv \
                          -Ddoc=disabled"
 }
 
-post_makeinstall_target(){
+post_makeinstall_target() {
   # clean up
   safe_remove ${INSTALL}
 }

--- a/packages/multimedia/gstreamer/gstreamer/package.mk
+++ b/packages/multimedia/gstreamer/gstreamer/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gstreamer"
-PKG_VERSION="1.18.5"
-PKG_SHA256="55862232a63459bbf56abebde3085ca9aec211b478e891dacea4d6df8cafe80a"
+PKG_VERSION="1.20.1"
+PKG_SHA256="de094a404a3ad8f4977829ea87edf695a4da0b5c8f613ebe54ab414bac89f031"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org"
 PKG_URL="https://gstreamer.freedesktop.org/src/gstreamer/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -27,7 +27,7 @@ pre_configure_target() {
                          -Dtests=disabled \
                          -Dbenchmarks=disabled \
                          -Dtools=disabled \
-                         -Dgtk_doc=disabled \
+                         -Ddoc=disabled \
                          -Dintrospection=disabled \
                          -Dnls=disabled \
                          -Dgobject-cast-checks=disabled \


### PR DESCRIPTION
Update to GStreamer 1.20.1:
- gst-plugins-bad: update to 1.20.1
- gst-plugins-base: update to 1.20.1
- gstreamer: update to 1.20.1

Release notes:
https://gstreamer.freedesktop.org/releases/1.20/#1.20.1
