### PR TITLE
Vulkan updates

### DIFF
--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -4,10 +4,10 @@
 
 PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers have to be specific versions matching the pkg version
-# https://github.com/KhronosGroup/glslang/blob/${PKG_VERSION}/known_good.json
+# https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # if you update glslang make sure spirv-tools & spirv-headers versions a known good
-PKG_VERSION="11.8.0"
-PKG_SHA256="9e5fbe5b844d203da5e61bcd84eda76326e0ff5dc696cb862147bbe01d2febb0"
+PKG_VERSION="11.9.0"
+PKG_SHA256="d5744adba19eef9ad3d73f524226b39fec559d94cb582cd442e3c5de930004b2"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-headers/package.mk
+++ b/packages/graphics/vulkan/spirv-headers/package.mk
@@ -4,10 +4,10 @@
 
 PKG_NAME="spirv-headers"
 # The SPIRV-Headers have to be specific versions matching the glslang pkg version
-# https://github.com/KhronosGroup/glslang/blob/11.8.0/known_good.json
+# https://github.com/KhronosGroup/glslang/blob/11.9.0/known_good.json
 # if you update glslang make sure spirv-tools & spirv-headers versions a known good
-PKG_VERSION="b42ba6d92faf6b4938e6f22ddd186dbdacc98d78"
-PKG_SHA256="d58e8e65ea4b4f1e421caaad68f88ce7b713ac3519bd49e7b71b6a5690489eb6"
+PKG_VERSION="4995a2f2723c401eb0ea3e10c81298906bf1422b"
+PKG_SHA256="2c9fe1bbd74a74fdabe40a7ffb322527dfc008c79e1d19d3cf41a5f006d9ab60"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-tools/package.mk
+++ b/packages/graphics/vulkan/spirv-tools/package.mk
@@ -4,10 +4,10 @@
 
 PKG_NAME="spirv-tools"
 # The SPIRV-Tools have to be specific versions matching the glslang pkg version
-# https://github.com/KhronosGroup/glslang/blob/11.8.0/known_good.json
+# https://github.com/KhronosGroup/glslang/blob/11.9.0/known_good.json
 # if you update glslang make sure spirv-tools & spirv-headers versions a known good
-PKG_VERSION="73735db943d7165d725883a1da0ad9eac79c1e34"
-PKG_SHA256="28551980e0b69c2d188f9705747e7e3b0836a957e1ddce14ad1dfa621bed1ace"
+PKG_VERSION="eed5c76a57bb965f2e1b56d1dc40b50910b5ec1d"
+PKG_SHA256="9697fcdab26b2622bf81a8d81f9ebc6cab5a5a7ac32b0eb61e51684a5627a4b6"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
**Update glslang to 11.9.0:**
- spirv-headers: update githash to 2022-03-16
- spirv-tools: update githash to 2022-04-05
- glslang: update to 11.9.0

[CHANGES.md](https://github.com/KhronosGroup/glslang/blob/11.9.0/CHANGES.md#other-changes)
**11.9.0 2022-04-06**
Other changes
Add GLSL version override functionality
Add eliminate-dead-input-components to -Os
Add enhanced-msgs option
Explicitly use Python 3 for builds
