### PR TITLE
Wayland updates

### DIFF
--- a/packages/wayland/lib/fcft/package.mk
+++ b/packages/wayland/lib/fcft/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fcft"
-PKG_VERSION="3.0.1"
-PKG_SHA256="0d9b9f3add24aef5efcf42a32e8ad0e50060e1441a491e04fff3d79a36a526ea"
+PKG_VERSION="3.1.1"
+PKG_SHA256="5f35dbd8a1a81ec61648e86e8f86157c9fd905ee199540d81a031121473204d5"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/fcft"
 PKG_URL="https://codeberg.org/dnkl/fcft/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/lib/fcft/package.mk
+++ b/packages/wayland/lib/fcft/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fcft"
-PKG_VERSION="2.5.1"
-PKG_SHA256="1b9e9346c884f16bce9548806ea89c5e34ccc98ce27ec6ecff1f5011235de112"
+PKG_VERSION="3.0.1"
+PKG_SHA256="0d9b9f3add24aef5efcf42a32e8ad0e50060e1441a491e04fff3d79a36a526ea"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/fcft"
 PKG_URL="https://codeberg.org/dnkl/fcft/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/lib/seatd/package.mk
+++ b/packages/wayland/lib/seatd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="seatd"
-PKG_VERSION="0.6.3"
-PKG_SHA256="5226850c163b485aebe71da0d3f4941761637e146a5c9393cb40c52617ad84a8"
+PKG_VERSION="0.6.4"
+PKG_SHA256="3d4ac288114219ba7721239cafee7bfbeb7cf8e1e7fd653602a369e4ad050bd8"
 PKG_LICENSE="MIT"
 PKG_SITE="https://git.sr.ht/~kennylevinsen/seatd"
 PKG_URL="https://git.sr.ht/~kennylevinsen/seatd/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.19.2"
-PKG_SHA256="0fc39f0af3ee1a77c60c34bc45391a4d0879169f7c0f7bbbeb5eef590b98b883"
+PKG_VERSION="1.20.0"
+PKG_SHA256="6c1f97892a7d599f97349e5e7c1239901fe00edcd4f6289f410034d5dc06cc85"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.freedesktop.org/wiki/Software/libinput/"
-PKG_URL="http://www.freedesktop.org/software/libinput/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
+PKG_URL="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain systemd libevdev mtdev"
 PKG_LONGDESC="libinput is a library to handle input devices in Wayland compositors and to provide a generic X.Org input driver."
 

--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbcommon"
-PKG_VERSION="1.3.1"
-PKG_SHA256="b3c710d27a2630054e1e1399c85b7f330ef03359b460f0c1b3b587fd01fe9234"
+PKG_VERSION="1.4.0"
+PKG_SHA256="106cec5263f9100a7e79b5f7220f889bc78e7d7ffc55d2b6fdb1efefb8024031"
 PKG_LICENSE="MIT"
-PKG_SITE="http://xkbcommon.org"
-PKG_URL="http://xkbcommon.org/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://xkbcommon.org"
+PKG_URL="https://xkbcommon.org/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain xkeyboard-config libxml2"
 PKG_LONGDESC="xkbcommon is a library to handle keyboard descriptions."
 

--- a/packages/wayland/util/bemenu/package.mk
+++ b/packages/wayland/util/bemenu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bemenu"
-PKG_VERSION="0.6.5"
-PKG_SHA256="9f1eeaf0b5210814f7b230fe20e61d0437c947cd8a595d94e4cc28bf83cb148b"
+PKG_VERSION="0.6.7"
+PKG_SHA256="8982ffbeebb0f642e0a68d3ab5a16078b2f43548ddca70a5ad30a597529ff142"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Cloudef/bemenu"
 PKG_URL="https://github.com/Cloudef/bemenu/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/util/foot/package.mk
+++ b/packages/wayland/util/foot/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="foot"
-PKG_VERSION="1.10.3"
-PKG_SHA256="24f57d9926ead7bea491f1bdd97eaceae5fdc10c1cb3435ee588a8f9c9af805a"
+PKG_VERSION="1.11.0"
+PKG_SHA256="2b4f737eb4d266224e5dd0126168c6d770b0139d4b572078baf158d2f7166e4e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/foot/"
 PKG_URL="https://codeberg.org/dnkl/foot/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/util/foot/package.mk
+++ b/packages/wayland/util/foot/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="foot"
-PKG_VERSION="1.12.0"
-PKG_SHA256="d8c27f735d2f361ee627cce282bee2462545f4df9532ee6ac28fd86a193404fa"
+PKG_VERSION="1.12.1"
+PKG_SHA256="14e307ac89454b682bb9f1bc644043779f4462df656034fcc4c1e72b18fbffdd"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/foot/"
 PKG_URL="https://codeberg.org/dnkl/foot/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/util/foot/package.mk
+++ b/packages/wayland/util/foot/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="foot"
-PKG_VERSION="1.11.0"
-PKG_SHA256="2b4f737eb4d266224e5dd0126168c6d770b0139d4b572078baf158d2f7166e4e"
+PKG_VERSION="1.12.0"
+PKG_SHA256="d8c27f735d2f361ee627cce282bee2462545f4df9532ee6ac28fd86a193404fa"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/foot/"
 PKG_URL="https://codeberg.org/dnkl/foot/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/waylandpp/package.mk
+++ b/packages/wayland/waylandpp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="waylandpp"
-PKG_VERSION="0.2.9"
-PKG_SHA256="9d34acd88149897d587b979fc454fd8e5be8021ba3d09ad24c77a4b7acff2ebd"
+PKG_VERSION="0.2.10"
+PKG_SHA256="10dba6359c41c4485dbf6586aefc5d6485b7d5f0da4f199358a4b5ceff69fb02"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/NilsBrause/waylandpp"
 PKG_URL="https://github.com/NilsBrause/waylandpp/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/waylandpp/package.mk
+++ b/packages/wayland/waylandpp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="waylandpp"
-PKG_VERSION="0.2.10"
-PKG_SHA256="10dba6359c41c4485dbf6586aefc5d6485b7d5f0da4f199358a4b5ceff69fb02"
+PKG_VERSION="1.0.0"
+PKG_SHA256="b20b45917382c6b87e9380130c9a1a1c563da2f498de5830df12fbce326dd9f5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/NilsBrause/waylandpp"
 PKG_URL="https://github.com/NilsBrause/waylandpp/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Wayland updates:
- fcft: update to 3.0.1
- seatd: update to 0.6.4
- bemenu: update to 0.6.7
- foot: update to 1.11.0
- waylandpp: update to 0.2.10
- libxkbcommon: update to 1.4.0 and HSTS
- libinput: update to 1.20.0