### PR TITLE
devtool updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.18"
-PKG_SHA256="63e5cab48f97c63dc2737eb35582316acf77084d109ac0571651cedaf40987c0"
+PKG_VERSION="1.18.1"
+PKG_SHA256="7b55918522e9cf4849ec02c719b81b97c9f15fa5f7576a399d3c20bd2532ad29"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/debug/valgrind/package.mk
+++ b/packages/debug/valgrind/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="valgrind"
-PKG_VERSION="3.18.1"
-PKG_SHA256="00859aa13a772eddf7822225f4b46ee0d39afbe071d32778da4d99984081f7f5"
+PKG_VERSION="3.19.0"
+PKG_SHA256="dd5e34486f1a483ff7be7300cc16b4d6b24690987877c3278d797534d6738f02"
 PKG_LICENSE="GPL"
-PKG_SITE="http://valgrind.org/"
-PKG_URL="ftp://sourceware.org/pub/valgrind/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://valgrind.org/"
+PKG_URL="https://sourceware.org/pub/valgrind/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A tool to help find memory-management problems in programs"
 

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.22.2"
-PKG_SHA256="3c1c478b9650b107d452c5bd545c72e2fad4e37c09b89a1984b9a2f46df6aced"
+PKG_VERSION="3.23.1"
+PKG_SHA256="33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="9.0.1"
-PKG_SHA256="01305f0befb644ce7fe90aa0c87573b9163a21d0e65149e8166c24974d9d37d2"
+PKG_VERSION="9.1.0"
+PKG_SHA256="f389f702a3f1fb61280b4798b3d079cfa63e5a1402532e8d1b909378efc5f1d3"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/mtools/package.mk
+++ b/packages/tools/mtools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mtools"
-PKG_VERSION="4.0.38"
-PKG_SHA256="7b94485f486e7df08cca68b00a164a13cd38f4c63cb8684d188759ee7bc5e729"
+PKG_VERSION="4.0.39"
+PKG_SHA256="397f1e2b7b7a2a270eb7970fa363e445f956926ec51e8170c3869da85b0987bd"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/mtools/"
 PKG_URL="http://ftpmirror.gnu.org/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- Pillow: update to 9.1.0
- go: update to 1.18.1
- valgrind: update to 3.19.0
-  mtools: update to 4.0.39
- cmake: update to 3.23.1