### PR TITLE
dtc: update to 1.6.1

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -3,30 +3,45 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dtc"
-PKG_VERSION="1.6.0"
-PKG_SHA256="af720893485b02441f8812773484b286f969d1b8c98769d435a75c6ad524104b"
+PKG_VERSION="1.6.1"
+PKG_SHA256="264d355e2e547a4964d55b83b113f89be1aea5e61dbe0547ab798d0fde2be180"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/"
 PKG_URL="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="The Device Tree Compiler"
+PKG_TOOLCHAIN="make"
 
 PKG_MAKE_OPTS_TARGET="dtc fdtput fdtget libfdt"
 PKG_MAKE_OPTS_HOST="dtc libfdt"
 
+pre_make_host() {
+  mkdir -p ${PKG_BUILD}/.${HOST_NAME}
+    cp -a ${PKG_BUILD}/* ${PKG_BUILD}/.${HOST_NAME}
+
+  cd ${PKG_BUILD}/.${HOST_NAME}
+}
+
 makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/bin
-    cp -P ${PKG_BUILD}/dtc ${TOOLCHAIN}/bin
+    cp -P ${PKG_BUILD}/.${HOST_NAME}/dtc ${TOOLCHAIN}/bin
   mkdir -p ${TOOLCHAIN}/lib
-    cp -P ${PKG_BUILD}/libfdt/{libfdt.so,libfdt.so.1} ${TOOLCHAIN}/lib
+    cp -P ${PKG_BUILD}/.${HOST_NAME}/libfdt/{libfdt.so,libfdt.so.1} ${TOOLCHAIN}/lib
+}
+
+pre_make_target() {
+  mkdir -p ${PKG_BUILD}/.${TARGET_NAME}
+    cp -a ${PKG_BUILD}/* ${PKG_BUILD}/.${TARGET_NAME}
+
+  cd ${PKG_BUILD}/.${TARGET_NAME}
 }
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
-    cp -P ${PKG_BUILD}/dtc ${INSTALL}/usr/bin
-    cp -P ${PKG_BUILD}/fdtput ${INSTALL}/usr/bin/
-    cp -P ${PKG_BUILD}/fdtget ${INSTALL}/usr/bin/
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/dtc ${INSTALL}/usr/bin
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/fdtput ${INSTALL}/usr/bin/
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/fdtget ${INSTALL}/usr/bin/
   mkdir -p ${INSTALL}/usr/lib
-    cp -P ${PKG_BUILD}/libfdt/{libfdt.so,libfdt.so.1} ${INSTALL}/usr/lib/
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/libfdt/{libfdt.so,libfdt.so.1} ${INSTALL}/usr/lib/
 }

--- a/packages/tools/dtc/patches/dtc-0001-libfdt-soname-version.patch
+++ b/packages/tools/dtc/patches/dtc-0001-libfdt-soname-version.patch
@@ -4,7 +4,7 @@ index e546397..dd71746 100644
 +++ b/libfdt/Makefile.libfdt
 @@ -10,7 +10,7 @@ LIBFDT_VERSION = version.lds
  LIBFDT_SRCS = fdt.c fdt_ro.c fdt_wip.c fdt_sw.c fdt_rw.c fdt_strerror.c fdt_empty_tree.c \
- 	fdt_addresses.c fdt_overlay.c
+ 	fdt_addresses.c fdt_overlay.c fdt_check.c
  LIBFDT_OBJS = $(LIBFDT_SRCS:%.c=%.o)
 -LIBFDT_LIB = libfdt-$(DTC_VERSION).$(SHAREDLIB_EXT)
 +LIBFDT_LIB = libfdt.$(SHAREDLIB_EXT)


### PR DESCRIPTION
### dtc: update to 1.6.1
- superceeds #5050
- Incorporates comments on #5050
- Updates 1.6.0 to 1.6.1
- Did not update to meson at this time (as it has not yet been update to include version number, etc …) to review on next update.

### Log: 
- https://git.kernel.org/pub/scm/utils/dtc/dtc.git/log/

### commit message:
- A number of fixes have accumulated, so rolling up another release. 
- https://git.kernel.org/pub/scm/utils/dtc/dtc.git/commit/?id=b6910bec11614980a21e46fbccc35934b671bd81