### PR TITLE
[le11] ttyd: include missing evlib_uv library and addon (105)

### DIFF
--- a/packages/addons/service/ttyd/changelog.txt
+++ b/packages/addons/service/ttyd/changelog.txt
@@ -1,3 +1,6 @@
+105
+- fix ttyd to include missing evlib_uv library
+
 104
 - libuv: update to 1.42.0
 

--- a/packages/addons/service/ttyd/package.mk
+++ b/packages/addons/service/ttyd/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="ttyd"
 PKG_VERSION="1.6.3"
 PKG_SHA256="1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9"
-PKG_REV="104"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/tsl0922/ttyd"
@@ -25,5 +25,6 @@ addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
   cp -p $(get_install_dir json-c)/usr/lib/libjson-c.so.5 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
   cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets.so.19 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets-evlib_uv.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
   cp -p $(get_install_dir libuv)/usr/lib/libuv.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
 }


### PR DESCRIPTION
fix for reported bug at:
- https://forum.libreelec.tv/thread/25517-service-ttyd-web-ssh-terminal-missing-libraries-on-10-0-2-on-raspberry/?postID=168543

### before:
```
LD_LIBRARY_PATH=$LD_LIBARY_PATH:.kodi/addons/service.ttyd/lib .kodi/addons/service.ttyd/bin/ttyd -O -T xterm256 -p 11111 login root
[2022/04/17 19:55:12:4690] N: ttyd 1.6.3 (libwebsockets 4.3.0-10.0.0-2468-g5197a00a90)
[2022/04/17 19:55:12:4691] N: tty configuration:
[2022/04/17 19:55:12:4691] N:   start command: login root
[2022/04/17 19:55:12:4691] N:   close signal: SIGHUP (1)
[2022/04/17 19:55:12:4691] N:   terminal type: xterm256
[2022/04/17 19:55:12:4692] N:   check origin: true
[2022/04/17 19:55:12:4699] E: lws_create_context: failed to load evlib_uv
[2022/04/17 19:55:12:4699] E: libwebsockets context creation failed
```

### after:
```
# ls -la .kodi/addons/service.ttyd/lib
total 660
drwxr-xr-x    2 root     root          4096 Apr 17 20:04 .
drwxr-xr-x    6 root     root          4096 Apr 17 20:04 ..
-rw-r--r--    1 root     root         64248 Apr 17 20:04 libjson-c.so.5
-rw-r--r--    1 root     root        172392 Apr 17 20:04 libuv.so.1
-rw-r--r--    1 root     root         18936 Apr 17 20:04 libwebsockets-evlib_uv.so  # <--------------- FIX
-rw-r--r--    1 root     root        403856 Apr 17 20:04 libwebsockets.so.19
nuc11:~ # LD_LIBRARY_PATH=$LD_LIBARY_PATH:.kodi/addons/service.ttyd/lib .kodi/addons/service.ttyd/bin/ttyd -O -T xterm256 -p 11111 login root
[2022/04/17 20:04:55:4961] N: ttyd 1.6.3 (libwebsockets 4.3.0-10.0.0-2468-g5197a00a90)
[2022/04/17 20:04:55:4962] N: tty configuration:
[2022/04/17 20:04:55:4962] N:   start command: login root
[2022/04/17 20:04:55:4962] N:   close signal: SIGHUP (1)
[2022/04/17 20:04:55:4962] N:   terminal type: xterm256
[2022/04/17 20:04:55:4963] N:   check origin: true
[2022/04/17 20:04:55:4964] N:    .kodi/addons/service.ttyd/lib/libwebsockets-evlib_uv.so
[2022/04/17 20:04:55:4970] N: lws_create_context: LWS: 4.3.0-10.0.0-2468-g5197a00a90, NET CLI SRV H1 H2 WS ConMon IPv6-absent
[2022/04/17 20:04:55:4971] N: elops_init_pt_uv:  Using foreign event loop...
[2022/04/17 20:04:55:4971] N: __lws_lc_tag:  ++ [wsi|0|pipe] (1)
[2022/04/17 20:04:55:4971] N: __lws_lc_tag:  ++ [vh|0|netlink] (1)
[2022/04/17 20:04:55:4972] N: __lws_lc_tag:  ++ [vh|1|default||11111] (2)
[2022/04/17 20:04:55:4972] E: [null wsi]: lws_socket_bind: ERROR on binding fd 12 to port 11111 (-1 98)
[2022/04/17 20:04:55:4972] N:  Listening on port: 11111
^C
[2022/04/17 20:04:59:7634] N: received signal: SIGINT (2), exiting...
[2022/04/17 20:04:59:7635] N: send ^C to force exit.
```
