### PR TITLE
[le10] ttyd: include missing evlib_uv library and addon (105)

### DIFF
--- a/packages/addons/service/ttyd/changelog.txt
+++ b/packages/addons/service/ttyd/changelog.txt
@@ -1,3 +1,6 @@
+105
+- fix ttyd to include missing evlib_uv library
+
 104
 - libuv: update to 1.42.0
 - libwebsockets: update to 4.3.0

--- a/packages/addons/service/ttyd/package.mk
+++ b/packages/addons/service/ttyd/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="ttyd"
 PKG_VERSION="1.6.3"
 PKG_SHA256="1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9"
-PKG_REV="104"
+PKG_REV="105"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/tsl0922/ttyd"
@@ -25,5 +25,6 @@ addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
   cp -p $(get_install_dir json-c)/usr/lib/libjson-c.so.5 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
   cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets.so.19 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets-evlib_uv.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
   cp -p $(get_install_dir libuv)/usr/lib/libuv.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
 }


### PR DESCRIPTION
backport of 
- #6402 