### PR TITLE
Boot warning: fsck.fat

### DIFF
--- a/packages/sysutils/dosfstools/package.mk
+++ b/packages/sysutils/dosfstools/package.mk
@@ -10,24 +10,19 @@ PKG_SITE="https://github.com/dosfstools/dosfstools"
 PKG_URL="https://github.com/dosfstools/dosfstools/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain"
-PKG_DEPENDS_INIT="toolchain dosfstools"
+PKG_DEPENDS_INIT="toolchain"
 PKG_LONGDESC="dosfstools contains utilities for making and checking MS-DOS FAT filesystems."
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-compat-symlinks"
 PKG_MAKE_OPTS_TARGET="PREFIX=/usr"
 PKG_MAKEINSTALL_OPTS_TARGET="PREFIX=/usr"
 
-configure_init() {
-  : # reuse configure_target()
-}
-
-make_init() {
-  : # reuse make_target()
-}
+PKG_CONFIGURE_OPTS_INIT="--enable-compat-symlinks --without-iconv"
+PKG_MAKE_OPTS_INIT="PREFIX=/usr"
 
 makeinstall_init() {
   mkdir -p ${INSTALL}/usr/sbin
-    cp $(get_install_dir dosfstools:target)/usr/sbin/fsck.fat ${INSTALL}/usr/sbin
+    cp -P src/fsck.fat ${INSTALL}/usr/sbin
     ln -sf fsck.fat ${INSTALL}/usr/sbin/fsck.msdos
     ln -sf fsck.fat ${INSTALL}/usr/sbin/fsck.vfat
 }


### PR DESCRIPTION
resubmitting this PR - now we are on version 2.34 of glibc.
- was #6152
- reverted in #6160 

fsck during boot ERRORs with unable to access the gconv/*.so files. These are dynamically loaded by fsck.fat

whilst this is a harmless error. This adding of the missing libraries removes the error.

```
[    2.527416] fsck: Cannot initialize conversion from codepage 850 to ANSI_X3.4-1968: Invalid argument
[    2.527438] fsck: Cannot initialize conversion from ANSI_X3.4-1968 to codepage 850: Invalid argument
[    2.527450] fsck: Using internal CP850 conversion table
[    2.527459] fsck: fsck.fat 4.2 (2021-01-31)
```

fsck is compiled —with-iconv (gconv) - define this in the `package.mk` file for clarity.

additional files in `init` image.
```
-rwxr-xr-x   1 docker   docker      14376 Jan 18 12:46 /usr/lib/gconv/IBM850.so
-rw-r--r--   1 docker   docker        189 Jan 18 12:46 /usr/lib/gconv/gconv-modules.d/gconv-modules-extra.conf
-rwxr-xr-x   1 docker   docker      26664 Jan 18 12:46 /usr/lib/gconv/ANSI_X3.110.so
```