### PR TITLE
[le11] tools.ffmpeg-tools: fix missing libraries and addon (118)

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="https://ffmpeg.org/releases/ffmpeg-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain aom bzip2 gnutls lame libvorbis opus x264 x265 zlib"
+PKG_DEPENDS_TARGET="toolchain aom bzip2 gnutls lame libvorbis opus x264 zlib"
 PKG_LONGDESC="FFmpegx is an complete FFmpeg build to support encoding and decoding."
 PKG_BUILD_FLAGS="-gold -sysroot"
 
@@ -99,6 +99,12 @@ pre_configure_target() {
     --enable-libxcb-shm \
     --enable-libxcb-xfixes \
     --enable-libxcb-shape"
+  else
+    PKG_FFMPEG_X11_GRAB="\
+    --disable-libxcb \
+    --disable-libxcb-shm \
+    --disable-libxcb-xfixes \
+    --disable-libxcb-shape"
   fi
 }
 

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="117"
+PKG_REV="118"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -18,6 +18,17 @@ PKG_ADDON_NAME="FFmpeg Tools"
 PKG_ADDON_TYPE="xbmc.python.script"
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+
   cp -L $(get_install_dir ffmpegx)/usr/local/bin/* ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+
+  # libs
+  if [ "${TARGET_ARCH}" = "x86_64" ]; then
+    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.199 \
+           ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  fi
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    cp -PL $(get_install_dir libxcb)/usr/lib/{libxcb.so.1,libxcb-shm.so.0,libxcb-shape.so.0,libxcb-xfixes.so.0} \
+           ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  fi
 }


### PR DESCRIPTION
The buildhost had the shared libraries libxcb available, and FFmpegx has been picking them up. This updates the ffmpegx packages to not use libxcb unless explicitly compiled with x11. 

In addition x265 was being included in both the `PKG_DEPENDS_TARGET` and the specific **x86_64** `PKG_DEPENDS_TARGET` - removed from the main `PKG_DEPENDS_TARGET`.

the `ffmpeg-tools` addon has been updated to included the required shared libraries. Currently ffmpeg errors unable to find libxcb-shm.

