### PR TITLE
[le11] jellyfin: update to 10.8.0-beta2

### DIFF
--- a/packages/addons/service/jellyfin/changelog.txt
+++ b/packages/addons/service/jellyfin/changelog.txt
@@ -1,3 +1,6 @@
+102
+- Update to Jellyfin 10.8.0-beta2
+
 101
 - Update to Jellyfin 10.8.0-beta1
 

--- a/packages/addons/service/jellyfin/package.mk
+++ b/packages/addons/service/jellyfin/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="jellyfin"
 PKG_VERSION="1.0"
-PKG_VERSION_NUMBER="10.8.0-beta1"
-PKG_REV="101"
+PKG_VERSION_NUMBER="10.8.0-beta2"
+PKG_REV="102"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://jellyfin.org/"


### PR DESCRIPTION
Tested on x86_64 LE11