### PR TITLE
gcc: update to 11.3.0

### DIFF
--- a/packages/lang/gcc-aarch64/package.mk
+++ b/packages/lang/gcc-aarch64/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc-aarch64"
-PKG_VERSION="11.2.0"
-PKG_SHA256="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
+PKG_VERSION="11.3.0"
+PKG_SHA256="b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://gcc.gnu.org/"
 PKG_URL="http://ftpmirror.gnu.org/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.xz"

--- a/packages/lang/gcc-or1k/package.mk
+++ b/packages/lang/gcc-or1k/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc-or1k"
-PKG_VERSION="11.2.0"
-PKG_SHA256="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
+PKG_VERSION="11.3.0"
+PKG_SHA256="b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://gcc.gnu.org/"
 PKG_URL="http://ftpmirror.gnu.org/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.xz"

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc"
-PKG_VERSION="11.2.0"
-PKG_SHA256="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
+PKG_VERSION="11.3.0"
+PKG_SHA256="b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://gcc.gnu.org/"
 PKG_URL="http://ftpmirror.gnu.org/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Update from 11.2.0 (July 28, 2021) to 11.3.0 (April 21, 2022)
- https://gcc.gnu.org/gcc-11/
- 189 bugs fixed
- https://gcc.gnu.org/bugzilla/buglist.cgi?bug_status=RESOLVED&list_id=344738&resolution=FIXED&target_milestone=11.3
- https://gcc.gnu.org/gcc-11/changes.html


