### PR TITLE
[LE11] Decouple addons build

### DIFF
--- a/packages/emulation/libretro-vecx/package.mk
+++ b/packages/emulation/libretro-vecx/package.mk
@@ -14,6 +14,14 @@ PKG_LIBNAME="vecx_libretro.so"
 PKG_LIBPATH="${PKG_LIBNAME}"
 PKG_LIBVAR="VECX_LIB"
 
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+fi
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+fi
+
 make_target() {
   if [ "${OPENGL_SUPPORT}" = no ]; then
     HAS_GLES=1 make

--- a/packages/graphics/glm/package.mk
+++ b/packages/graphics/glm/package.mk
@@ -11,6 +11,16 @@ PKG_SOURCE_DIR="glm"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="OpenGL Mathematics (GLM)"
 
+# Not needed by GLM itself, but users will need it. So instead of adding this
+# to every user, put it here once.
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+fi
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+fi
+
 # Hack install solution until cmake install restored in upstream package
 makeinstall_target() {
   target_has_feature 32bit && PKG_VOID_SIZE=4 || PKG_VOID_SIZE=8

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -17,3 +17,11 @@ PKG_LONGDESC="pvr.vdr.vnsi"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.pvrclient"
+
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+fi
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+fi

--- a/packages/mediacenter/kodi-platform/package.mk
+++ b/packages/mediacenter/kodi-platform/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="159165ae641da5eb273885ce53b8a4b84e62a595c4974f9d12c1b5d1428ef25c"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/kodi-platform/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER} p8-platform"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host p8-platform"
 PKG_LONGDESC="kodi-platform:"
 
 PKG_CMAKE_OPTS_TARGET="-DCMAKE_INSTALL_LIBDIR:STRING=lib \

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -192,7 +192,7 @@ configure_package() {
   if [ ! "${KODIPLAYER_DRIVER}" = "default" -a "${DISPLAYSERVER}" = "no" ]; then
     PKG_DEPENDS_TARGET+=" ${KODIPLAYER_DRIVER} libinput libxkbcommon"
     if [ "${OPENGLES_SUPPORT}" = yes -a "${KODIPLAYER_DRIVER}" = "${OPENGLES}" ]; then
-      KODI_PLAYER="-DCORE_PLATFORM_NAME=gbm -DAPP_RENDER_SYSTEM=gles"
+      KODI_PLATFORM="-DCORE_PLATFORM_NAME=gbm -DAPP_RENDER_SYSTEM=gles"
       CFLAGS+=" -DEGL_NO_X11"
       CXXFLAGS+=" -DEGL_NO_X11"
       if [ "${PROJECT}" = "Generic" ]; then
@@ -255,7 +255,6 @@ configure_package() {
                          ${KODI_AIRTUNES} \
                          ${KODI_OPTICAL} \
                          ${KODI_BLURAY} \
-                         ${KODI_PLAYER} \
                          ${KODI_ALSA} \
                          ${KODI_PULSEAUDIO} \
                          ${KODI_PIPEWIRE}"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -9,6 +9,7 @@ PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre swig:host libass curl fontconfig fribidi tinyxml libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid libdvdnav libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog"
+PKG_DEPENDS_HOST="toolchain"
 PKG_LONGDESC="A free and open source cross-platform media player."
 PKG_BUILD_FLAGS="+speed"
 
@@ -258,6 +259,31 @@ configure_package() {
                          ${KODI_ALSA} \
                          ${KODI_PULSEAUDIO} \
                          ${KODI_PIPEWIRE}"
+}
+
+configure_host() {
+  setup_toolchain target:cmake
+  cmake ${CMAKE_GENERATOR_NINJA} \
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CONF} \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+        -DHEADERS_ONLY=ON \
+        ${KODI_ARCH} \
+        ${KODI_NEON} \
+        ${KODI_PLATFORM} ..
+}
+
+make_host() {
+  :
+}
+
+makeinstall_host() {
+  DESTDIR=${SYSROOT_PREFIX} cmake -DCMAKE_INSTALL_COMPONENT="kodi-addon-dev" -P cmake_install.cmake
+
+  # more binaddons cross compile badness meh
+  sed -e "s:INCLUDE_DIR /usr/include/kodi:INCLUDE_DIR ${SYSROOT_PREFIX}/usr/include/kodi:g" \
+      -e "s:CMAKE_MODULE_PATH /usr/lib/kodi /usr/share/kodi/cmake:CMAKE_MODULE_PATH ${SYSROOT_PREFIX}/usr/share/kodi/cmake:g" \
+      -i ${SYSROOT_PREFIX}/usr/lib/kodi/cmake/KodiConfig.cmake
 }
 
 pre_configure_target() {

--- a/packages/mediacenter/kodi/patches/kodi-999.20-headers-only.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.20-headers-only.patch
@@ -1,0 +1,48 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e5824f0d20b7..cf17e1563a7f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,6 +45,7 @@ include(ExternalProject)
+ 
+ 
+ # general
++option(HEADERS_ONLY       "Skip building" OFF)
+ option(VERBOSE            "Enable verbose output?" OFF)
+ option(ENABLE_CLANGTIDY   "Enable clang-tidy support?" OFF)
+ option(ENABLE_CPPCHECK    "Enable cppcheck support?" OFF)
+@@ -95,6 +96,7 @@ endif()
+ 
+ core_find_git_rev(APP_SCMID FULL)
+ 
++if(NOT HEADERS_ONLY)
+ # Dynamically loaded libraries built with the project
+ add_custom_target(${APP_NAME_LC}-libraries)
+ set(LIBRARY_FILES "" CACHE STRING "" FORCE)
+@@ -458,6 +460,7 @@ endif()
+ if(FFMPEG_CREATE_SHARED_LIBRARY)
+   set(CMAKE_CXX_CREATE_SHARED_LIBRARY "${FFMPEG_CREATE_SHARED_LIBRARY}")
+ endif()
++endif()
+ 
+ # Platform specific additional extra targets
+ if(EXISTS ${CMAKE_SOURCE_DIR}/cmake/scripts/${CORE_SYSTEM_NAME}/ExtraTargets.cmake)
+diff --git a/cmake/scripts/linux/Install.cmake b/cmake/scripts/linux/Install.cmake
+index 331722cb5616..cc00c55fa27c 100644
+--- a/cmake/scripts/linux/Install.cmake
++++ b/cmake/scripts/linux/Install.cmake
+@@ -51,6 +51,7 @@ configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi.desktop.in
+ configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi.metainfo.xml.in
+                ${CORE_BUILD_DIR}/${APP_PACKAGE}.metainfo.xml @ONLY)
+ 
++if(NOT HEADERS_ONLY)
+ # Install app
+ install(TARGETS ${APP_NAME_LC}
+         DESTINATION ${libdir}/${APP_NAME_LC}
+@@ -160,6 +161,7 @@ if(INTERNAL_TEXTUREPACKER_INSTALLABLE)
+           RENAME "${APP_NAME_LC}-TexturePacker"
+           COMPONENT kodi-tools-texturepacker)
+ endif()
++endif()
+ 
+ # Install kodi-addon-dev headers
+ include(${CMAKE_SOURCE_DIR}/xbmc/addons/AddonBindings.cmake)


### PR DESCRIPTION
This PR intends to avoid full Kodi build with all dependencies just to build one simple addon. With these changes, this works pretty well. Amount of packages for pvr.iptvsimple went down from 173 to 51. However, if all addons are built, this effect is greatly diminished. Building them for Allwinner H6, there are only 2 packages less to build (638 -> 636). This is because Estouchy skin requires Kodi to be build. If it is disabled, amount of packages goes down from 636 to 601.

Downside of this PR is that many addons don't list all dependencies, because they were already build for Kodi. This is the reason why this is WIP. Currently problematic addons:
audiodecoder.2sf
btrfs-progs
audiodecoder.fluidsynth
game.libretro.vecx
hyperion
pvr.vdr.vnsi
syncthing
screensaver.asteroids
visualization.fishbmc
visualization.goom
visualization.spectrum
visualization.starburst
visualization.waveform

I think main issue here is missing mesa dependency, but I didn't check yet.
