### PR TITLE
scripts/makefile_helper: make sure variables are set before running an rm

### DIFF
--- a/scripts/makefile_helper
+++ b/scripts/makefile_helper
@@ -8,6 +8,11 @@ set -e
 # If config/options can't be sourced, abort. PWD isn't the expected ROOT.
 . config/options ""
 
+if [ -z "${BUILD_BASE}" -o -z "${BUILD_ROOT}" ]; then
+  # make sure variables are set before running an rm
+  echo "error: ${0}: both BUILD_BASE and BUILD_ROOT must be set when running \"[clean|distclean]\"; aborting"
+  exit 1
+fi
 # task handling
 case $1 in
   --clean)


### PR DESCRIPTION
Add a check for the 2 variables, if for whatever reason they weren’t set 
`rm -rf /.*/*` evaluates equivalent of `rm -rf /`
