### PR TITLE
makefile_helper: only source necessary values from buildsystem's config

### DIFF
--- a/scripts/makefile_helper
+++ b/scripts/makefile_helper
@@ -6,13 +6,16 @@
 set -e
 
 # If config/options can't be sourced, abort. PWD isn't the expected ROOT.
-. config/options ""
+# Only source from config/options what will be used
+BUILD_ROOT=$(PROJECT= DEVICE= ARCH= . config/options "" && echo "${BUILD_ROOT}")
+BUILD_BASE=$(PROJECT= DEVICE= ARCH= . config/options "" && echo "${BUILD_BASE}")
 
 if [ -z "${BUILD_BASE}" -o -z "${BUILD_ROOT}" ]; then
   # make sure variables are set before running an rm
   echo "error: ${0}: both BUILD_BASE and BUILD_ROOT must be set when running \"[clean|distclean]\"; aborting"
   exit 1
 fi
+
 # task handling
 case $1 in
   --clean)


### PR DESCRIPTION
Hopefully a workaround for Jenkin's build setup. (Trying to build RPi2.x86_64?)