### PR TITLE
[le11] kodi-binary-addons: update to latest versions - inputstream.*

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="20.1.2-Nexus"
-PKG_SHA256="750749b4587f0d6010da370bfe79ef3f8269e4303352073d3c3ed675fafcb055"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="5e4307edfe20e03c9e4a0bc4515142f9b0cc698d18f365da33f655ddeb76956e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="9860f0db3f665bc6a8653a861c2b4a75ebb1433392bf271d884b2301d917f7c5"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="0d3f70825c6d4c89aad08d41153d45b55fab7af960744182977126dc71208880"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.rtmp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.rtmp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.rtmp"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="9790dddad82dc22737e4a9b8cb51772ed0c8fffd71d936b91ec8623eebf9e1e1"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="3f9c3b48c3db87b7947529b0c60f621a07c1cb6f1ce2e0d28bc9552d04ff3725"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 20.1.2-Nexus to 20.2.0-Nexus
- inputstream.ffmpegdirect: update 20.1.0-Nexus to 20.2.0-Nexus
- inputstream.rtmp: update 20.1.0-Nexus to 20.2.0-Nexus