### PR TITLE
update dotnet 6.0.1 to 6.0.4

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet6-runtime"
-PKG_VERSION="6.0.1"
+PKG_VERSION="6.0.4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="0806f4be544c67b12fe236c7b7bc99e49194a172caa1b340619114fab80e633f"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/01f8a4af-9d6c-40ff-b834-a1d73105a9d5/aba0525a8b8cb745ac70ecd671acf0e0/aspnetcore-runtime-6.0.1-linux-arm64.tar.gz"
+    PKG_SHA256="6d66bf5494f4a54f6f20fe0de1e7a64a6e4eb5e6136b1496ac347d027fd35abe"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/ba1662bf-50e6-451a-957f-0d55bc6e5713/921fe0e68428ac47c098e97418d3126a/aspnetcore-runtime-6.0.4-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="eef8e3c5a65c67d17d2d7da7382044b8f0a48c05d61e8d9e1d7bc4f77e0c7a9f"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/ff3b2714-0dee-4cf9-94ee-cb9f5ded285f/d6bfe8668428f9eb28acdf6b6f5a81bc/aspnetcore-runtime-6.0.1-linux-arm.tar.gz"
+    PKG_SHA256="f3b41cb4fa50bb195957c53f096817e1ab19f29858a677180145eba064ea49f6"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/adc5bbf5-6cf6-4da6-be27-60de0b8739e5/fecb289bd70834203f2397c18c82bbde/aspnetcore-runtime-6.0.4-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="ae7dce00eec4bc5431faacc574193b1a920d8a7e92abc4bec6288c20a8a507f6"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/32230fb9-df1e-4b86-b009-12d889cbfa8a/f57a5d92327bb2936caac94bcf602c22/aspnetcore-runtime-6.0.1-linux-x64.tar.gz"
+    PKG_SHA256="ca3dc696af0a9fc5c7ce052eba38ecf723cbc30d1dc29d8f85c201eff534d73b"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/de3f6658-5d5b-4986-aeb1-7efdf5818437/7df572051df15117a0f52be1b79e1823/aspnetcore-runtime-6.0.4-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/dotnet-runtime-depends/dotnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/dotnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet6-runtime"
-PKG_VERSION="6.0.1"
+PKG_VERSION="6.0.4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="193df0b397d3b154ced255098fdabd017ea8faac00f77485cc1a9fdab7407e4a"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/002742a9-8107-4434-a208-863f07e09397/75884224d828a34b7c5f070df5213553/dotnet-runtime-6.0.1-linux-arm64.tar.gz"
+    PKG_SHA256="672f8e8ffcf012059aef6c2f7edfe34ea307559fa2d8821bb5a4d07a4fbbbed6"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/3641affa-8bb0-486f-93d9-68adff4f4af7/1e3df9fb86cba7299b9e575233975734/dotnet-runtime-6.0.4-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="3aa29dc8f9ada9f61a2b2d77fe385b8ef15e15b8f83d4696ed711f66b02e8df7"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/bdea32df-7ab8-47f5-8f8c-3de28d5771d0/c839293beeace695b6698debaedd345e/dotnet-runtime-6.0.1-linux-arm.tar.gz"
+    PKG_SHA256="11b8c2952210e226ec9c2a996d7a6b24f4b8ddd8ae0590080bfea5362fb7e0af"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/f8e1ab66-58f7-4ebb-a9bb-9decfa03501f/88e1fb49af6f75dc54c23383162409c5/dotnet-runtime-6.0.4-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="f77369477ee8c98402793a2b6ce1f46d663fd0373a93a4cef50eb22d8607773c"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/be8a513c-f3bb-4fbd-b382-6596cf0d67b5/968e205c44eabd205b8ea98be250b880/dotnet-runtime-6.0.1-linux-x64.tar.gz"
+    PKG_SHA256="02e2c5b5950e3fc1fe4dd146175758f198c711e495883f7f286d575437fd82c4"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/5b08d331-15ac-4a53-82a5-522fa45b1b99/65ae300dd160ae0b88b91dd78834ce3e/dotnet-runtime-6.0.4-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="dotnet-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/tools/dotnet-runtime/changelog.txt
+++ b/packages/addons/tools/dotnet-runtime/changelog.txt
@@ -1,3 +1,7 @@
+116
+- Update .NET Runtime 6.0.4
+- Update ASP.NET Core Runtime 6.0.4
+
 115
 - Add .NET Runtime 6.0.1
 - Add ASP.NET Core Runtime 6.0.1

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="115"
+PKG_REV="116"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"


### PR DESCRIPTION
Update:
- [dotnet6-runtime: update to 6.0.4](https://github.com/LibreELEC/LibreELEC.tv/commit/bb4d06d709c5c104a09a06b49d380ceac183f3f8)
- [aspnet6-runtime: update to 6.0.4](https://github.com/LibreELEC/LibreELEC.tv/commit/3ba1dbcf94dd397da30db55c349b361373827020)

As fyi - emby4.7 will require dotnet 6. The bootstrap will need to be checked against 4.7.
- https://github.com/MediaBrowser/Emby.Releases/releases/tag/4.7.0.36
- https://github.com/MediaBrowser/Emby.Releases/releases
- https://emby.media/community/index.php?/topic/21348-emby-latest-versions/