### PR TITLE
[le11] syncthing: update to 1.20.0 and addon (119)

### DIFF
--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,6 @@
+119
+- update to 1.20.0
+
 118
 - update to 1.18.5
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.18.5"
-PKG_SHA256="c64db4d5fe6ae6525d2333fdd5cb41243e56430ced377c59ca69731a1183df1f"
-PKG_REV="118"
+PKG_VERSION="1.20.0"
+PKG_SHA256="6dc78dbe046f2fa9a4f70b04cf2500705d3a22618f5cf430ffcb7338cce968c7"
+PKG_REV="119"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"


### PR DESCRIPTION
changelog:
- https://github.com/syncthing/syncthing/releases

support for go1.18