### PR TITLE
scripts/check_kernel_config: handle string options

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -179,7 +179,7 @@ pre_make_target() {
         continue
       fi
 
-      if [ "$(${PKG_BUILD}/scripts/config --state ${OPTION%%=*})" != "${OPTION##*=}" ]; then
+      if [ "$(${PKG_BUILD}/scripts/config --state ${OPTION%%=*})" != "$(echo ${OPTION##*=} | tr -d '"')" ]; then
         MISSING_KERNEL_OPTIONS+="\t${OPTION}\n"
       fi
     done < ${DISTRO_DIR}/${DISTRO}/kernel_options

--- a/tools/check_kernel_config
+++ b/tools/check_kernel_config
@@ -26,6 +26,12 @@ if [ -f "${DISTRO_DIR}/${DISTRO}/kernel_options" ]; then
       $PKG_BUILD/scripts/config --file $PKG_KERNEL_CFG_FILE --disable ${OPTION%%=*}
     fi
 
+    # must be a string if it contains double quotes
+    if [ -n "$(echo ${OPTION##*=} | grep '"')" ]; then
+      echo "[${OPTION##*=}] ${OPTION%%=*}"
+      $PKG_BUILD/scripts/config --file $PKG_KERNEL_CFG_FILE --set-str ${OPTION%%=*} $(echo ${OPTION##*=} | tr -d '"')
+    fi
+
   done < ${DISTRO_DIR}/${DISTRO}/kernel_options
 else
   echo "kernel options file doesn't exist: ${DISTRO_DIR}/${DISTRO}/kernel_options"


### PR DESCRIPTION
This fixes an issue where string options aren't checked properly:

```
LINUX: kernel options not correct: 
	CONFIG_NLS_DEFAULT="utf8"

Please run ./tools/check_kernel_config
```
