### PR TITLE
move ALSA_SUPPORT from project options to distro options

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -226,6 +226,9 @@
 # OEM packages for OEM's (yes / no)
   OEM_SUPPORT="no"
 
+# build and install ALSA Audio support (yes / no)
+  ALSA_SUPPORT="yes"
+
 # additional packages to install:
 # Space separated list is supported,
 # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"

--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -135,9 +135,6 @@
   # cron support (yes / no)
     CRON_SUPPORT="no"
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="no"
-
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -31,9 +31,6 @@
 # setup project defaults
 ################################################################################
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="yes"
-
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -40,9 +40,6 @@
 # setup project defaults
 ################################################################################
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="yes"
-
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -46,9 +46,6 @@
 # setup project defaults
 ################################################################################
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="yes"
-
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,
   # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"

--- a/projects/NXP/options
+++ b/projects/NXP/options
@@ -26,9 +26,6 @@
 # setup project defaults
 ################################################################################
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="yes"
-
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 

--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -54,9 +54,6 @@
 # setup project defaults
 ################################################################################
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="yes"
-
   # OpenGL(X) implementation to use (no / Mesa)
     OPENGL="no"
 

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -107,7 +107,11 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS rpi-cirrus-config bcm2835-driver"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm2835-driver"
+
+    if [ "${ALSA_SUPPORT}" = "yes" ]; then
+      ADDITIONAL_DRIVERS+=" rpi-cirrus-config"
+    fi
 
   # build and install driver addons (yes / no)
     DRIVER_ADDONS_SUPPORT="no"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -66,9 +66,6 @@
 # setup project defaults
 ################################################################################
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="yes"
-
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -35,9 +35,6 @@
 # setup project defaults
 ################################################################################
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="yes"
-
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -42,9 +42,6 @@
 # setup project defaults
 ################################################################################
 
-  # build and install ALSA Audio support (yes / no)
-    ALSA_SUPPORT="yes"
-
   # OpenGL(X) implementation to use (no / mesa)
     OPENGL="no"
 


### PR DESCRIPTION
`ALSA_SUPPORT` is a staple of the distro it should be included in the distro options.

This also fixes an issue with `rpi-cirrus-config` always including `alsa-utils` even when `ALSA_SUPPORT="no"`