### PR TITLE
open-iscsi: allow installing utilities for target

### DIFF
--- a/packages/sysutils/open-iscsi/package.mk
+++ b/packages/sysutils/open-iscsi/package.mk
@@ -9,10 +9,15 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/mikechristie/open-iscsi"
 PKG_URL="https://github.com/mikechristie/open-iscsi/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_INIT="toolchain util-linux"
+PKG_DEPENDS_HOST="toolchain:host"
+PKG_DEPENDS_TARGET="toolchain open-iscsi:host"
 PKG_LONGDESC="The open-iscsi package allows you to mount iSCSI targets."
 PKG_TOOLCHAIN="configure"
+PKG_BUILD_FLAGS="-sysroot"
 
 PKG_MAKE_OPTS_INIT="user"
+
+PKG_MAKE_OPTS_TARGET="user"
 
 pre_configure_init() {
   export OPTFLAGS="${CFLAGS} ${LDFLAGS}"
@@ -29,4 +34,54 @@ configure_init() {
 makeinstall_init() {
   mkdir -p ${INSTALL}/usr/sbin
     cp -P ${PKG_BUILD}/usr/iscsistart ${INSTALL}/usr/sbin
+}
+
+pre_configure_host() {
+  export OPTFLAGS="${CFLAGS} ${LDFLAGS}"
+}
+
+configure_host() {
+  :
+}
+
+make_host() {
+  cd ${PKG_BUILD}/utils
+  make iscsi-iname
+}
+
+makeinstall_host() {
+  mkdir -p ${TOOLCHAIN}/bin
+    cp -P ${PKG_BUILD}/utils/iscsi-iname ${TOOLCHAIN}/bin
+}
+
+pre_configure_target() {
+  export OPTFLAGS="${CFLAGS} ${LDFLAGS}"
+}
+
+configure_target() {
+  cd utils/open-isns
+    ./configure --host=${TARGET_NAME} \
+                --build=${HOST_NAME} \
+                --with-security=no
+
+  cd ${PKG_BUILD}
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/sbin
+    cp -P ${PKG_BUILD}/usr/iscsid ${INSTALL}/usr/sbin
+    cp -P ${PKG_BUILD}/usr/iscsiadm ${INSTALL}/usr/sbin
+    cp -P ${PKG_BUILD}/usr/iscsistart ${INSTALL}/usr/sbin
+    cp -P ${PKG_BUILD}/utils/iscsi-iname ${INSTALL}/usr/sbin
+
+  mkdir -p ${INSTALL}/etc/iscsi
+    cp -P ${PKG_BUILD}/etc/iscsid.conf ${INSTALL}/etc/iscsi
+
+    sed -i -e "s:= /sbin/iscsid:= /usr/sbin/iscsid:" ${INSTALL}/etc/iscsi/iscsid.conf
+
+    echo "InitiatorName=$(${TOOLCHAIN}/bin/iscsi-iname)" > ${INSTALL}/etc/iscsi/initiatorname.iscsi
+}
+
+post_install() {
+  enable_service iscsi-initiator.service
 }

--- a/packages/sysutils/open-iscsi/patches/open-iscsi-07-usr-run-for-config.patch
+++ b/packages/sysutils/open-iscsi/patches/open-iscsi-07-usr-run-for-config.patch
@@ -1,0 +1,53 @@
+diff -Naur a/usr/idbm.c b/usr/idbm.c
+--- a/usr/idbm.c	2013-07-29 12:13:36.000000000 -0700
++++ b/usr/idbm.c	2022-05-03 15:16:35.006014572 -0700
+@@ -2647,9 +2647,9 @@
+ int idbm_init(idbm_get_config_file_fn *fn)
+ {
+ 	/* make sure root db dir is there */
+-	if (access(ISCSI_CONFIG_ROOT, F_OK) != 0) {
+-		if (mkdir(ISCSI_CONFIG_ROOT, 0660) != 0) {
+-			log_error("Could not make %s %d\n", ISCSI_CONFIG_ROOT,
++	if (access(ISCSIVAR, F_OK) != 0) {
++		if (mkdir(ISCSIVAR, 0770) != 0) {
++			log_error("Could not make %s %d", ISCSIVAR,
+ 				   errno);
+ 			return errno;
+ 		}
+diff -Naur a/usr/idbm.h b/usr/idbm.h
+--- a/usr/idbm.h	2013-07-29 12:13:36.000000000 -0700
++++ b/usr/idbm.h	2022-05-03 15:17:18.700644189 -0700
+@@ -29,12 +29,13 @@
+ #include "list.h"
+ #include "flashnode.h"
+ 
+-#define NODE_CONFIG_DIR		ISCSI_CONFIG_ROOT"nodes"
+-#define SLP_CONFIG_DIR		ISCSI_CONFIG_ROOT"slp"
+-#define ISNS_CONFIG_DIR		ISCSI_CONFIG_ROOT"isns"
+-#define STATIC_CONFIG_DIR	ISCSI_CONFIG_ROOT"static"
+-#define FW_CONFIG_DIR		ISCSI_CONFIG_ROOT"fw"
+-#define ST_CONFIG_DIR		ISCSI_CONFIG_ROOT"send_targets"
++#define ISCSIVAR		"/run/iscsi/"
++#define NODE_CONFIG_DIR		ISCSIVAR"nodes"
++#define SLP_CONFIG_DIR		ISCSIVAR"slp"
++#define ISNS_CONFIG_DIR		ISCSIVAR"isns"
++#define STATIC_CONFIG_DIR	ISCSIVAR"static"
++#define FW_CONFIG_DIR		ISCSIVAR"fw"
++#define ST_CONFIG_DIR		ISCSIVAR"send_targets"
+ #define ST_CONFIG_NAME		"st_config"
+ #define ISNS_CONFIG_NAME	"isns_config"
+ 
+diff -Naur a/usr/iface.h b/usr/iface.h
+--- a/usr/iface.h	2013-07-29 12:13:36.000000000 -0700
++++ b/usr/iface.h	2022-05-03 15:18:31.164688356 -0700
+@@ -20,7 +20,9 @@
+ #ifndef ISCSI_IFACE_H
+ #define ISCSI_IFACE_H
+ 
+-#define IFACE_CONFIG_DIR	ISCSI_CONFIG_ROOT"ifaces"
++#include "idbm.h"
++
++#define IFACE_CONFIG_DIR	ISCSIVAR"ifaces"
+ 
+ struct iface_rec;
+ struct list_head;

--- a/packages/sysutils/open-iscsi/system.d/iscsi-initiator.service
+++ b/packages/sysutils/open-iscsi/system.d/iscsi-initiator.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Open-iSCSI initiator (i.e. client) service
+After=syslog.target
+
+[Service]
+ExecStart=/usr/sbin/iscsid -f
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/sysutils/open-iscsi/tmpfiles.d/iscsi.conf
+++ b/packages/sysutils/open-iscsi/tmpfiles.d/iscsi.conf
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Team LibreELEC (https://libreelec.tv)
+
+d /run/lock/iscsi 0700 root root -
+f /run/lock/iscsi/lock 0600 root root -

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -26,6 +26,10 @@ if [ "${WIREGUARD_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" wireguard-tools"
 fi
 
+if [ "${ISCSI_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" open-iscsi"
+fi
+
 # nss needed by inputstream.adaptive, chromium etc.
 if [ "${TARGET_ARCH}" = "x86_64" ] || [ "${TARGET_ARCH}" = "arm" ]; then
   PKG_DEPENDS_TARGET+=" nss"


### PR DESCRIPTION
This allows using the iscsiadm at all utilities from userspace.

I added a patch that was adapted from fedora sources (the patch doesn't apply). https://src.fedoraproject.org/rpms/iscsi-initiator-utils/blob/rawhide/f/0006-use-var-for-config.patch
The patch is needed to move configuration to r/w space.

`open-iscsi:target` depends on `open-iscsi:host` because of `iscsi-iname` which is used to create a unique initiator name for the target.

I tested this on my RPi4
```
# uname -a
Linux LibreELEC 5.15.32 #1 SMP Wed May 4 19:30:26 PDT 2022 aarch64 GNU/Linux

# iscsiadm -m discovery -t st -p 192.168.1.108
192.168.1.108:3260,1 iqn.2022-05.fedora-enterprise.xxxxxxxxx.com:lun1

# iscsiadm -m node -T iqn.2022-05.fedora-enterprise.xxxxxxxxx.com:lun1 -l
Logging in to [iface: default, target: iqn.2022-05.fedora-enterprise.xxxxxxxxx.com:lun1, portal: 192.168.1.108,3260] (multiple)
Login to [iface: default, target: iqn.2022-05.fedora-enterprise.xxxxxxxxx.com:lun1, portal: 192.168.1.108,3260] successful.
```