### PR TITLE
make: update command line patch not to touch configure.ac

### DIFF
--- a/packages/devel/make/patches/make-02-fix-large-command-line-on-POSIX-systems.patch
+++ b/packages/devel/make/patches/make-02-fix-large-command-line-on-POSIX-systems.patch
@@ -35,25 +35,11 @@ headers
 [1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=688601
 [2] https://savannah.gnu.org/bugs/?45763#comment2
 ---
- configure.ac                             |  2 +-
  src/job.c                                | 52 +++++++++++++++++++++++-
  tests/scripts/features/long_command_line | 30 ++++++++++++++
- 3 files changed, 82 insertions(+), 2 deletions(-)
+ 2 files changed, 81 insertions(+), 1 deletions(-)
  create mode 100644 tests/scripts/features/long_command_line
 
-diff --git a/configure.ac b/configure.ac
-index 960991c..32c6894 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -78,7 +78,7 @@ AC_HEADER_STAT
- AC_HEADER_TIME
- AC_CHECK_HEADERS([stdlib.h locale.h unistd.h limits.h fcntl.h string.h \
-                   memory.h sys/param.h sys/resource.h sys/time.h sys/timeb.h \
--                  sys/select.h sys/file.h spawn.h])
-+                  sys/select.h sys/file.h spawn.h sys/user.h linux/binfmts.h])
- 
- AM_PROG_CC_C_O
- AC_C_CONST
 diff --git a/src/job.c b/src/job.c
 index 3bcec38..734c591 100644
 --- a/src/job.c


### PR DESCRIPTION
as aclocal-1.16 may not be available on the build host as make has no
dependancies. remove patch to configure.ac. patch still works as the
required depends are still available.

fix error introduced with #6452 