### PR TITLE
gstreamer: update to 1.20.2

### DIFF
--- a/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-bad"
-PKG_VERSION="1.20.1"
-PKG_SHA256="09d3c2cf5911f0bc7da6bf557a55251779243d3de216b6a26cc90c445b423848"
+PKG_VERSION="1.20.2"
+PKG_SHA256="4adc4c05f41051f8136b80cda99b0d049a34e777832f9fea7c5a70347658745b"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-bad.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-bad/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-base"
-PKG_VERSION="1.20.1"
-PKG_SHA256="96d8a6413ba9394fbec1217aeef63741a729d476a505a797c1d5337d8fa7c204"
+PKG_VERSION="1.20.2"
+PKG_SHA256="ab0656f2ad4d38292a803e0cb4ca090943a9b43c8063f650b4d3e3606c317f17"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-base.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-base/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gstreamer/gstreamer/package.mk
+++ b/packages/multimedia/gstreamer/gstreamer/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gstreamer"
-PKG_VERSION="1.20.1"
-PKG_SHA256="de094a404a3ad8f4977829ea87edf695a4da0b5c8f613ebe54ab414bac89f031"
+PKG_VERSION="1.20.2"
+PKG_SHA256="df24e8792691a02dfe003b3833a51f1dbc6c3331ae625d143b17da939ceb5e0a"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org"
 PKG_URL="https://gstreamer.freedesktop.org/src/gstreamer/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- gstreamer: update to 1.20.2
- gst-plugins-bad: update to 1.20.2
- gst-plugins-base: update to 1.20.2

release notes:
- https://gstreamer.freedesktop.org/
- https://gstreamer.freedesktop.org/releases/1.20/#1.20.2