### PR TITLE
[le11] package updates

### DIFF
--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libarchive"
-PKG_VERSION="3.5.2"
-PKG_SHA256="f0b19ff39c3c9a5898a219497ababbadab99d8178acc980155c7e1271089b5a0"
+PKG_VERSION="3.6.1"
+PKG_SHA256="5a411aceb978f43e626f0c2d1812ddd8807b645ed892453acabd532376c148e6"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libarchive.org"
 PKG_URL="https://www.libarchive.org/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.38.3"
+PKG_VERSION="3.38.4"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="61f2dd93a2e38c33468b7125967c3218bf9f4dd8365def6025e314f905dc942e"
+PKG_SHA256="1935751066c2fd447404caa78cfb8b2b701fad3f6b1cf40b3d658440f6cc7563"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2022/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"

--- a/packages/print/freetype/package.mk
+++ b/packages/print/freetype/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="freetype"
-PKG_VERSION="2.12.0"
-PKG_SHA256="ef5c336aacc1a079ff9262d6308d6c2a066dd4d2a905301c4adda9b354399033"
+PKG_VERSION="2.12.1"
+PKG_SHA256="4766f20157cc4cf0cd292f80bf917f92d1c439b243ac3018debf6b9140c41a7f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://freetype.org"
-PKG_URL="http://download.savannah.gnu.org/releases/freetype/freetype-${PKG_VERSION}.tar.xz"
+PKG_URL="https://download.savannah.gnu.org/releases/freetype/freetype-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain zlib libpng"
 PKG_LONGDESC="The FreeType engine is a free and portable TrueType font rendering engine."

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="0.62.0"
-PKG_SHA256="06f8c1cfa51bfdb533c82623ffa524cacdbea02ace6d709145e33aabdad6adcb"
+PKG_VERSION="0.62.1"
+PKG_SHA256="a0f5caa1e70da12d5e63aa6a9504273759b891af36c8d87de381a4ed1380e845"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpg-error"
-PKG_VERSION="1.44"
-PKG_SHA256="8e3d2da7a8b9a104dd8e9212ebe8e0daf86aa838cc1314ba6bc4de8f2d8a1ff9"
+PKG_VERSION="1.45"
+PKG_SHA256="570f8ee4fb4bff7b7495cff920c275002aea2147e9a1d220c068213267f80a26"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.gnupg.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libgpg-error/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="systemd"
-PKG_VERSION="250.4"
-PKG_SHA256="d2bda9d225da11dc9ff48b48e59fc36798d3e66902ed400a9f78fa370c596864"
+PKG_VERSION="250.5"
+PKG_SHA256="63f596e1b22ae63aa737b6faf4b49281b4049ab8acb6c0614c1a150a87a356a5"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd-stable/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.9.13"
-PKG_SHA256="22b6218a2fdfb3dfaabeac22c20f01e9ae94dc7d970f8b8e6c57451fea770a45"
+PKG_VERSION="2.9.14"
+PKG_SHA256="9bd7dae7690b2112033ddb6ad4f454e036fff2d38505c3a5b80427669484c0a4"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- freetype: update to 2.12.1 and HTTPS
- libarchive: update to 3.6.1
- libgpg-error: update to 1.45
- libxml2: update to 2.9.14
- meson: update to 0.62.1
- sqlite: update to 3.38.4
- systemd: update to 250.5