### PR TITLE
automake: fix race in parallel builds

### DIFF
--- a/packages/devel/automake/patches/automake-02-build-fix-race-in-parallel-builds.patch
+++ b/packages/devel/automake/patches/automake-02-build-fix-race-in-parallel-builds.patch
@@ -1,0 +1,65 @@
+From 592eb55b248a765abfc796fccb68baa3d53745ac Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Thu, 26 Jul 2018 00:58:12 -0700
+Subject: [PATCH] build: fix race in parallel builds
+
+The automake-$(APIVERSION) is a hardlink of automake, if it is
+created later than update_mans executing, there is a failure
+[snip]
+|: && mkdir -p doc && ./pre-inst-env /usr/bin/env perl
+../automake-1.16.1/doc/help2man --output=doc/aclocal-1.16.1
+aclocal-1.16
+|help2man: can't get `--help' info from aclocal-1.16
+|Try `--no-discard-stderr' if option outputs to stderr
+Makefile:3693: recipe for target 'doc/aclocal-1.16.1' failed
+[snip]
+
+The automake_script is required by update_mans and update_mans
+invokes automake-$(APIVERSION) rather than automake to generate
+doc, so we should assign `automake-$(APIVERSION)' to automake_script.
+
+The same reason to tweak aclocal_script.
+
+* bin/local.mk: correct automake_script/aclocal_script
+
+Upstream-Status: Submitted [automake-patches@gnu.org]
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ Makefile.in  | 4 ++--
+ bin/local.mk | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index c3e934c..7cddb8d 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -691,8 +691,8 @@ bin_SCRIPTS = bin/automake bin/aclocal
+ # Used by maintainer checks and such.
+ automake_in = $(srcdir)/bin/automake.in
+ aclocal_in = $(srcdir)/bin/aclocal.in
+-automake_script = bin/automake
+-aclocal_script = bin/aclocal
++automake_script = bin/automake-$(APIVERSION)
++aclocal_script  = bin/aclocal-$(APIVERSION)
+ AUTOMAKESOURCES = $(automake_in) $(aclocal_in)
+ info_TEXINFOS = doc/automake.texi doc/automake-history.texi
+ doc_automake_TEXINFOS = doc/fdl.texi
+diff --git a/bin/local.mk b/bin/local.mk
+index 97b38db..058ca99 100644
+--- a/bin/local.mk
++++ b/bin/local.mk
+@@ -31,8 +31,8 @@ CLEANFILES += \
+ # Used by maintainer checks and such.
+ automake_in = $(srcdir)/%D%/automake.in
+ aclocal_in  = $(srcdir)/%D%/aclocal.in
+-automake_script = %D%/automake
+-aclocal_script  = %D%/aclocal
++automake_script = %D%/automake-$(APIVERSION)
++aclocal_script  = %D%/aclocal-$(APIVERSION)
+ 
+ AUTOMAKESOURCES = $(automake_in) $(aclocal_in)
+ TAGS_FILES += $(AUTOMAKESOURCES)
+-- 
+2.7.4
+


### PR DESCRIPTION
Jenkin build failed with

`
[@]system_acdir[@],/var/lib/jenkins/LE/build4/workspace/H5/LibreELEC.tv/build.LibreELEC-H5.arm-11.0-devel/toolchain/share/aclocal,g'\'' -e '\''s,[@]am__isrc[@],!!@!!am__isrc!!@!!,g'\'' | /bin/bash ./config.status --file=- | sed -e '\''s,!!@!!am__isrc!!@!!,@'\'''\''am__isrc@,g'\'' ) </var/lib/jenkins/LE/build4/workspace/H5/LibreELEC.tv/build.LibreELEC-H5.arm-11.0-devel/build/automake-1.16.5/$in >t/ax/test-defs.sh-t	if LC_ALL=C grep '\''@[a-zA-Z0-9_][a-zA-Z0-9_]*@'\'' t/ax/test-defs.sh-t; then echo "t/ax/test-defs.sh contains unexpanded substitution (see lines above)"; exit 1; fi; chmod a-w t/ax/test-defs.sh-t && mv -f t/ax/test-defs.sh-t t/ax/test-defs.sh	if LC_ALL=C grep '\''@[a-zA-Z0-9_][a-zA-Z0-9_]*@'\'' lib/Automake/Config.pm-t; then echo "lib/Automake/Config.pm contains unexpanded substitution (see lines above)"; exit 1; fi; chmod a-w lib/Automake/Config.pm-t && mv -f lib/Automake/Config.pm-t lib/Automake/Config.pm	rm -f bin/automake-1.16; \	ln bin/automake bin/automake-1.16	: && /bin/mkdir -p doc && ./pre-inst-env /usr/bin/perl /var/lib/jenkins/LE/build4/workspace/H5/LibreELEC.tv/build.LibreELEC-H5.arm-11.0-devel/build/automake-1.16.5/doc/help2man --output=doc/aclocal-1.16.1 --no-discard-stderr aclocal-1.16	help2man: can'\''t get '--help'\'' info from aclocal-1.16	make[1]: *** [Makefile:3741: doc/aclocal-1.16.1] Error 2	make[1]: Leaving directory '\''/var/lib/jenkins/LE/build4/workspace/H5/LibreELEC.tv/build.LibreELEC-H5.arm-11.0-devel/build/automake-1.16.5/.x86_64-linux-gnu'\''	FAILURE: scripts/build automake:host during make_host (default)	*********** FAILED COMMAND ***********	make ${PKG_MAKE_OPTS_HOST}	**************************************	FAILURE: scripts/build automake:host has failed!		The following log for this failure is available:	  /var/lib/jenkins/LE/build4/workspace/H5/LibreELEC.tv/build.LibreELEC-H5.arm-11.0-devel/.threads/logs/32.log		>>> automake:host seq 32 >>>'
`

Add patch from list to address race condition.
- https://lists.gnu.org/archive/html/automake-patches/2018-07/msg00010.html
- Used in yocto and open embedded 