### PR TITLE
scripts/build: add option to delete build directory after package has been installed

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -230,3 +230,8 @@
 # Space separated list is supported,
 # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
   ADDITIONAL_PACKAGES=""
+
+# Remove build directories while building to help reduce space requirements (no /yes)
+# This only works for packages that are built in a separate directory from the source (most packages).
+# Defaults to off as this may cause unexpected build errors. Be warned!
+  RM_WORK="no"

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -11,7 +11,7 @@ PKG_URL="https://ftp.gnu.org/pub/gnu/glibc/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap pigz:host Python3:host"
 PKG_DEPENDS_INIT="glibc"
 PKG_LONGDESC="The Glibc package contains the main C library."
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="-gold -rmwork"
 
 PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            ac_cv_path_PERL=no \

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -13,6 +13,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_HOST="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc:host zstd:host glibc"
 PKG_DEPENDS_INIT="toolchain"
 PKG_LONGDESC="This package contains the GNU Compiler Collection."
+PKG_BUILD_FLAGS="-rmwork"
 
 case ${TARGET_ARCH} in
   arm|riscv64)

--- a/scripts/build
+++ b/scripts/build
@@ -461,6 +461,11 @@ for i in $(find "${SYSROOT_PREFIX}" -type l 2>/dev/null); do
   fi
 done
 
+if [ "${RM_WORK}" == "yes" -a -n "${PKG_REAL_BUILD}" -a -d "${PKG_REAL_BUILD}" ] && flag_enabled "rmwork" "yes"; then
+  print_color CLR_CLEAN "[RM_WORK] removing build directory: ${PKG_REAL_BUILD}\n"
+  rm -rf "${PKG_REAL_BUILD}"
+fi
+
 # Transfer the new sysroot content to the shared sysroot
 acquire_update_lock sysroot
 


### PR DESCRIPTION
This adds the option to remove the build directory after a package has been installed.

This helps reduce disk usage by removing redundant files. This is similar to the RM_WORK feature from yocto.

I've disabled it by default as it may cause build failures that I haven't tested for (add-ons will be a problem).

This also may be a good way to show how we are packaging/installing package in a bad way.

Using the `-rmwork` flag you can disable removing the build folder (needed for glibc and gcc so far).

| Pros | Cons |
| --- | --- |
| Reduced disk usage | can't look back at built files (in build folder) |
| | added complexity |
| | possible non obvious build failures |

----

Size comparison with custom RPi4 build:
| With RM_WORK | Without RM_WORK |
| --- | --- |
| 15409416KB (15.4GB) | 19610980KB (19.61GB) |


Generic GBM build:
| With RM_WORK | Without RM_WORK |
| --- | --- |
| 19059560KB (19.06GB) | 27944572KB (27.94GB) |