### PR TITLE
gcc: update to 12.1.0

### DIFF
--- a/packages/graphics/assimp/package.mk
+++ b/packages/graphics/assimp/package.mk
@@ -11,4 +11,5 @@ PKG_DEPENDS_TARGET="toolchain zlib"
 PKG_LONGDESC="A library to import and export various 3d-model-formats including scene-post-processing to generate missing render data."
 
 PKG_CMAKE_OPTS_TARGET="-DASSIMP_BUILD_ASSIMP_TOOLS=OFF \
-                       -DASSIMP_BUILD_TESTS=OFF"
+                       -DASSIMP_BUILD_TESTS=OFF \
+                       -DASSIMP_WARNINGS_AS_ERRORS=OFF"

--- a/packages/graphics/glmark2/patches/glmark2-999.01-fix-gcc12.1-build.patch
+++ b/packages/graphics/glmark2/patches/glmark2-999.01-fix-gcc12.1-build.patch
@@ -1,0 +1,24 @@
+From d1ca3f53c96dc8a4048b17dc16147a8fac782d4a Mon Sep 17 00:00:00 2001
+From: Alexandros Frantzis <alexandros.frantzis@collabora.com>
+Date: Mon, 14 Feb 2022 13:54:09 +0200
+Subject: [PATCH] libmatrix: Add missing <utility> include
+
+Fixes compilation with GCC 12.
+
+Fixes #169
+---
+ src/libmatrix/program.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/libmatrix/program.h b/src/libmatrix/program.h
+index f95b470..1c9de08 100644
+--- a/src/libmatrix/program.h
++++ b/src/libmatrix/program.h
+@@ -15,6 +15,7 @@
+ #include <string>
+ #include <vector>
+ #include <map>
++#include <utility>
+ #include "mat.h"
+ 
+ // Simple shader container.  Abstracts all of the OpenGL bits, but leaves

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc"
-PKG_VERSION="11.3.0"
-PKG_SHA256="b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39"
+PKG_VERSION="12.1.0"
+PKG_SHA256="62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b"
 PKG_LICENSE="GPL-2.0-or-later"
-PKG_SITE="http://gcc.gnu.org/"
-PKG_URL="http://ftpmirror.gnu.org/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://gcc.gnu.org/"
+PKG_URL="https://ftpmirror.gnu.org/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_BOOTSTRAP="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc:host zstd:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_HOST="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc:host zstd:host glibc"

--- a/packages/lang/gcc/patches/gcc-crosscompile-badness.patch
+++ b/packages/lang/gcc/patches/gcc-crosscompile-badness.patch
@@ -1,7 +1,7 @@
-Index: gcc-4.4+svnr145550/gcc/incpath.c
+Index: gcc-4.4+svnr145550/gcc/incpath.cc
 ===================================================================
---- gcc-4.4+svnr145550.orig/gcc/incpath.c	2009-04-04 13:48:31.000000000 -0700
-+++ gcc-4.4+svnr145550/gcc/incpath.c	2009-04-04 14:49:29.000000000 -0700
+--- gcc-4.4+svnr145550.orig/gcc/incpath.cc	2009-04-04 13:48:31.000000000 -0700
++++ gcc-4.4+svnr145550/gcc/incpath.cc	2009-04-04 14:49:29.000000000 -0700
 @@ -417,6 +417,26 @@
    p->construct = 0;
    p->user_supplied_p = user_supplied_p;

--- a/packages/tools/atf/package.mk
+++ b/packages/tools/atf/package.mk
@@ -15,7 +15,11 @@ PKG_TOOLCHAIN="manual"
 [ -n "${KERNEL_TOOLCHAIN}" ] && PKG_DEPENDS_TARGET+=" gcc-${KERNEL_TOOLCHAIN}:host"
 
 make_target() {
-  CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="" make PLAT=${ATF_PLATFORM} bl31
+  if [ "${DEVICE}" = "iMX8" ]; then
+    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="--param=min-pagesize=0" make PLAT=${ATF_PLATFORM} bl31
+  else
+    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="" make PLAT=${ATF_PLATFORM} bl31
+  fi
 }
 
 makeinstall_target() {


### PR DESCRIPTION
changes:
- https://gcc.gnu.org/gcc-12/changes.html
- https://gcc.gnu.org

~requires #6469 as a precursor~ - DONE

### this PR is merge blocked / draft until the iMX8 atf code fix is completed.

it is presented as draft so others can test as required.

build of all of:- successful (with the above patches and gcc-12.1.0)
```
    PROJECT=Allwinner ARCH=arm DEVICE=A64 make image
    PROJECT=Allwinner ARCH=arm DEVICE=H3 make image
    PROJECT=Allwinner ARCH=arm DEVICE=H5 make image
    PROJECT=Allwinner ARCH=arm DEVICE=H6 make image
    PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 make image
    PROJECT=Rockchip ARCH=arm DEVICE=RK3288 make image
    PROJECT=Rockchip ARCH=arm DEVICE=RK3328 make image
    PROJECT=Rockchip ARCH=arm DEVICE=RK3399 make image
    PROJECT=NXP ARCH=arm DEVICE=iMX6 make image
    PROJECT=NXP ARCH=arm DEVICE=iMX8 make image 
       ^^^^^ FAILs - see atf workaround below.
    PROJECT=Qualcomm ARCH=arm DEVICE=Dragonboard make image
    PROJECT=Samsung ARCH=arm DEVICE=Exynos make image
    PROJECT=Generic ARCH=x86_64 DEVICE=Generic make image
    PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy make image
    PROJECT=RPi ARCH=arm DEVICE=RPi2 make image
    PROJECT=RPi ARCH=arm DEVICE=RPi4 make image
    PROJECT=Amlogic ARCH=arm DEVICE=AMLGX make image
```

error with gcc-12 iMX8 build is due to atf
- https://developer.trustedfirmware.org/T991
- https://developer.trustedfirmware.org/T984
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
- Draft workaround b0b588a3ff4ad9a1eda057daaf27005044537a26