### PR TITLE
media-driver: update to 22.4.1

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.4.0"
-PKG_SHA256="f070527b141174970a17195d0225ed43693c39fec83cd5e6d0effaa88e2a5553"
+PKG_VERSION="22.4.1"
+PKG_SHA256="5589d4e0142ae957d58798e3fba08d9e5e096e92eed422d40a82d45a14e6042f"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
log:
- https://github.com/intel/media-driver/compare/intel-media-22.4.0...intel-media-22.4.1

```
=== tested on ===
Generic.x86_64-devel-20220508090822-195fdfb
Linux nuc11 5.18.0-rc5 #1 SMP Sun May 8 09:10:00 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.101) Git:ee3663fd468ec417ea0bba20b0d18f3448c8980c). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-05-08 by GCC 12.1.0 for Linux x86 64-bit version 5.18.0 (332288)
Running on LibreELEC (heitbaum): devel-20220508090822-195fdfb 11.0, kernel: Linux x86 64-bit version 5.18.0-rc5
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0042.2021.1213.1702 12/13/2021
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.1.0-rc4
libva info: VA-API version 1.14.0
vainfo: VA-API version: 1.14 (libva 2.14.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.4.1 (195fdfb8f0f)
```