### PR TITLE
syncthing: update to 1.20.1 and addon (120)

### DIFF
--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,6 @@
+120
+- update to 1.20.1
+
 119
 - update to 1.20.0
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.20.0"
-PKG_SHA256="6dc78dbe046f2fa9a4f70b04cf2500705d3a22618f5cf430ffcb7338cce968c7"
-PKG_REV="119"
+PKG_VERSION="1.20.1"
+PKG_SHA256="a88fabaea11a8df5cc134075c37dc87f1fb33b48d3d8afb1dc8ea11b3c0925bc"
+PKG_REV="120"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"


### PR DESCRIPTION
source files for 1.20.0 have been removed.

release notes:
- https://github.com/syncthing/syncthing/releases/tag/v1.20.1

bug fixes:
- Spurious failure of new connections ("unknown (newer?) version of the protocol" etc)
- 
Replaces #6455