### PR TITLE
intel-ucode: update to 20220510

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20220419"
-PKG_SHA256="b8838d300e749c1dd55d8865bdd49dee5153beb5e29d4b0e613aee475e0c0881"
+PKG_VERSION="20220510"
+PKG_SHA256="254ddc71b598fbb8dbb200ceb3af29aeb22f6bf50bc609e8f953cf9c8d286d2a"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"


### PR DESCRIPTION
### tested on:
```
[    0.000000] microcode: microcode updated early to revision 0xa4, date = 2022-02-01
[    0.000000] Linux version 5.18.0-rc6 (docker@b96190ee693f) (x86_64-libreelec-linux-gnu-gcc-12.1.0 (GCC) 12.1.0, GNU ld (GNU Binutils) 2.38) #1 SMP Wed May 11 01:10:30 UTC 2022
```
![image](https://user-images.githubusercontent.com/6086324/167751248-602aac0e-0153-4a8e-97f2-41f41805d3c3.png)


release notes:
- https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00617.html
- https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20220510 
