### PR TITLE
[le11] config/functions: improve error message when there in not a device directory

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -767,8 +767,15 @@ check_project() {
 
 check_device() {
   local dashes="===========================" device_err_msg
-  if [ \( -z "${DEVICE}" -a -d "${PROJECT_DIR}/${PROJECT}/devices" \) -o \
-       \( -n "${DEVICE}" -a ! -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}" \) ]; then
+  if [ -n "${DEVICE}" -a ! -d "${PROJECT_DIR}/${PROJECT}/devices" ]; then
+    device_err_msg="\n $dashes$dashes$dashes"
+    device_err_msg+="\n ERROR: You must not specify DEVICE for the $PROJECT project"
+    device_err_msg+="\n $dashes$dashes$dashes"
+    device_err_msg+="\n\n There are no devices for project: ${PROJECT}"
+
+    die "${device_err_msg}"
+  elif [ \( -z "${DEVICE}" -a -d "${PROJECT_DIR}/${PROJECT}/devices" \) -o \
+         \( -n "${DEVICE}" -a ! -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}" \) ]; then
     device_err_msg="\n ${dashes}${dashes}${dashes}"
     device_err_msg+="\n ERROR: Specify a valid device for the ${PROJECT} project"
     device_err_msg+="\n ${dashes}${dashes}${dashes}"


### PR DESCRIPTION
### BEFORE Patch

note how the ouput below displays * as a device because it can’t expand. The proposed fix reports the the device directory is not there.

https://github.com/LibreELEC/LibreELEC.tv/blob/812b14eaf93fea4d5446980100371157ae6609c1/config/functions#L777-L779

```
docker@af7b5ccc9042:/var/media/DATA/home-rudi/LibreELEC.master$ mv projects/Generic/devices projects/Generic/devicesx
docker@af7b5ccc9042:/var/media/DATA/home-rudi/LibreELEC.master$ PROJECT=Generic ARCH=x86_64 DEVICE=x  make image
./scripts/image mkimage

 =================================================================================
 ERROR: Specify a valid device for the Generic project
 =================================================================================

 Valid devices for project: Generic
 - *
*********** FAILED COMMAND ***********
. config/options ""
**************************************
make: *** [Makefile:10: image] Error 1
```

### AFTER Patch
```
docker@af7b5ccc9042:/var/media/DATA/home-rudi/LibreELEC.master$ mv projects/Generic/devices/ projects/Generic/devicesx
docker@af7b5ccc9042:/var/media/DATA/home-rudi/LibreELEC.master$ PROJECT=Generic ARCH=x86_64 DEVICE=x  make image
./scripts/image mkimage

 =================================================================================
 ERROR: You must not specify DEVICE for the Generic project
 =================================================================================

 There are no devices for project: Generic
*********** FAILED COMMAND ***********
. config/options ""
**************************************
make: *** [Makefile:10: image] Error 1

docker@af7b5ccc9042:/var/media/DATA/home-rudi/LibreELEC.master$ PROJECT=Allwinner ARCH=arm DEVICE=x  make image
./scripts/image mkimage

 =================================================================================
 ERROR: Specify a valid device for the Allwinner project
 =================================================================================

 Valid devices for project: Allwinner
 - A64
 - H2-plus
 - H3
 - H5
 - H6
 - R40
*********** FAILED COMMAND ***********
. config/options ""
**************************************
make: *** [Makefile:10: image] Error 1
docker@af7b5ccc9042:/var/media/DATA/home-rudi/LibreELEC.master$ 
```