### PR TITLE
RPi: update vc4-hdmi ALSA card conf to version sent upstream

### DIFF
--- a/projects/RPi/filesystem/usr/share/alsa/cards/vc4-hdmi.conf
+++ b/projects/RPi/filesystem/usr/share/alsa/cards/vc4-hdmi.conf
@@ -1,7 +1,10 @@
+#
 # Configuration for the VC4-HDMI sound card using software IEC958
 # subframe conversion
+#
 
 <confdir:pcm/hdmi.conf>
+
 vc4-hdmi.pcm.hdmi.0 {
 	@args [ CARD AES0 AES1 AES2 AES3 ]
 	@args.CARD {
@@ -18,7 +21,6 @@ vc4-hdmi.pcm.hdmi.0 {
 	}
 	@args.AES3 {
 		type integer
-		default 0x01	# IEC958_AES3_CON_FS_NOTID
 	}
 	type iec958
 	slave {
@@ -49,29 +51,32 @@ vc4-hdmi.pcm.hdmi.0 {
 	hdmi_mode true
 }
 
-# default with plug
+# default with plug and softvol
 vc4-hdmi.pcm.default {
 	@args [ CARD ]
 	@args.CARD {
 		type string
 	}
-	type plug
-	slave.pcm {
-		type softvol
+	type asym
+	playback.pcm {
+		type plug
 		slave.pcm {
-			@func concat
-			strings [
-				"hdmi:"
-				"CARD=" $CARD ","
-				"AES0=0x00,"	# IEC958_AES0_CON_EMPHASIS_NONE
-				"AES1=0x82,"	# IEC958_AES1_CON_ORIGINAL | IEC958_AES1_CON_PCM_CODER
-				"AES2=0x00,"	# IEC958_AES2_CON_SOURCE_UNSPEC | IEC958_AES2_CON_CHANNEL_UNSPEC
-				"AES3=0x01"	# IEC958_AES3_CON_FS_NOTID
-			]
-		}
-		control {
-			name "PCM Playback Volume"
-			card $CARD
+			type softvol
+			slave.pcm {
+				@func concat
+				strings [
+					"cards.vc4-hdmi.pcm.hdmi.0:"
+					"CARD=" $CARD ","
+					"AES0=0x04,"	# IEC958_AES0_CON_NOT_COPYRIGHT | IEC958_AES0_CON_EMPHASIS_NONE
+					"AES1=0x82,"	# IEC958_AES1_CON_ORIGINAL | IEC958_AES1_CON_PCM_CODER
+					"AES2=0x00,"	# IEC958_AES2_CON_SOURCE_UNSPEC | IEC958_AES2_CON_CHANNEL_UNSPEC
+					"AES3=0x01"	# IEC958_AES3_CON_FS_NOTID (iec958 plugin will fill in actual rate)
+				]
+			}
+			control {
+				name "PCM Playback Volume"
+				card $CARD
+			}
 		}
 	}
 }


### PR DESCRIPTION
See https://mailman.alsa-project.org/pipermail/alsa-devel/2022-April/200025.html

Only a few minor cleanups compared to our current version.

Runtime tested on RPi4 and RPi3B+