### PR TITLE
Vulkan updates: 1.3.213

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.212"
-PKG_SHA256="deea32809940711be36258e17ac887818f6261c96be27b24a1b82ac6718f0b2b"
+PKG_VERSION="1.3.213"
+PKG_SHA256="7f4a6118dc3524703c1ce0a44089379e89eeb930fbe28188b90fdac1f10ef676"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.212"
-PKG_SHA256="70165622606ed8face4382a23cb8b4cf9dfa023001b01cbc286e0fa40b91047a"
+PKG_VERSION="1.3.213"
+PKG_SHA256="3cacac2a39026ce74ff96d2bf5d2c85f2729218182cf0be07ae62f58a5301a39"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.212"
-PKG_SHA256="2c01e763fabd79cc7d48bba4fab37fd5bc7d548b2f67535224aa275a08fa8125"
+PKG_VERSION="1.3.213"
+PKG_SHA256="2b20b9c8cefe26f8d7df5f6b270c6a6d4dcf5fe0995f779abac2f0fa658c5798"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.05-cubepp-fix-VK-KHR-display-compile-error.patch
+++ b/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.05-cubepp-fix-VK-KHR-display-compile-error.patch
@@ -1,0 +1,28 @@
+From 0b9e94639152f3d4f5c13a6ff46087dc51258996 Mon Sep 17 00:00:00 2001
+From: Mike Schuchardt <mikes@lunarg.com>
+Date: Wed, 11 May 2022 15:43:28 -0700
+Subject: [PATCH] cubepp: Fix VK_KHR_display compile error
+
+Vulkan-Hpp Implicit-cast operators on vk::ResultValue were previously
+deprecated and finally removed in the v1.3.213 headers. Fix the
+resulting compiler error in cubepp by explicitly using the value member
+of vk:ResultValue.
+
+Change-Id: Ie441bd56dfb9dfe26e966e0ec3fb3139712a351a
+---
+ cube/cube.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cube/cube.cpp b/cube/cube.cpp
+index 03fd65b46..e984fabb4 100644
+--- a/cube/cube.cpp
++++ b/cube/cube.cpp
+@@ -2962,7 +2962,7 @@ vk::Result Demo::create_display_surface() {
+         exit(1);
+     }
+ 
+-    vk::DisplayPlaneCapabilitiesKHR planeCaps = gpu.getDisplayPlaneCapabilitiesKHR(display_mode_prop.displayMode, plane_found);
++    vk::DisplayPlaneCapabilitiesKHR planeCaps = gpu.getDisplayPlaneCapabilitiesKHR(display_mode_prop.displayMode, plane_found).value;
+     // Find a supported alpha mode
+     vk::DisplayPlaneAlphaFlagBitsKHR alphaMode = vk::DisplayPlaneAlphaFlagBitsKHR::eOpaque;
+     std::array<vk::DisplayPlaneAlphaFlagBitsKHR, 4> alphaModes = {


### PR DESCRIPTION
### vulkan updates
- vulkan-loader: update to 1.3.213
- vulkan-tools: update to 1.3.213
- vulkan-headers: update to 1.3.213

Reference:
- https://github.com/KhronosGroup/Vulkan-Tools/pull/650
- https://github.com/KhronosGroup/Vulkan-Docs/commit/71decb7f868d3891974eab139f03c7c6c87fea4d#

### Change log for May 10, 2022 Vulkan 1.3.213 spec update:
  * Update release number to 213 for this update.

Public Issues:

  * Replace the list of <<formats-packed, Packed Formats>> with a generated
    version, and update the format generator script to support conditionals
    (public pull request 1823).
  * Fix typo in apiext:VK_INTEL_performance_query (public issue 1845).

Internal Issues:

  * Add valid usage statement limiting
    slink:VkDisplaySurfaceCreateInfoKHR::pname:transform to a single,
    supported transformation (internal merge request 5166).
  * Update sample code for apiext:VK_KHR_ray_query in the extension appendix
    (internal issue 3066).
  * Fix some `limittype` attributes for
    slink:VkPhysicalDeviceTransformFeedbackPropertiesEXT and
    slink:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV members in
    `vk.xml` (internal merge requests 5173 and 5174).

New Extensions:

  * apiext:VK_EXT_image_compression_control
  * apiext:VK_EXT_pipeline_properties
  * apiext:VK_EXT_subpass_merge_feedback
  * apiext:VK_KHR_ray_tracing_maintenance1