### PR TITLE
libmicrohttpd: disable examples / fix build

### DIFF
--- a/packages/web/libmicrohttpd/package.mk
+++ b/packages/web/libmicrohttpd/package.mk
@@ -13,6 +13,7 @@ PKG_LONGDESC="A small C library that is supposed to make it easy to run an HTTP 
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
                            --enable-static \
+                           --disable-examples \
                            --disable-curl \
                            --enable-https"
 


### PR DESCRIPTION
- the examples link against host glibc 2.35 which fails, fixes 
```
libtool: link: /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc -march=x86-64 -Wall -pipe -O2 -fomit-frame-pointer -DNDEBUG -fno-strict-aliasing -march=x86-64 -Wl,--as-needed -fuse-ld=gold -o benchmark benchmark-benchmark.o  ../../src/microhttpd/.libs/libmicrohttpd.a -L/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -lpthread /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libgnutls.so -L/usr/lib -lz /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libidn2.so -lnettle -lhogweed /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libgmp.so -pthread -Wl,-rpath -Wl,/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -Wl,-rpath -Wl,/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib
/usr/lib/libgcc_s.so.1: error: undefined reference to '_dl_find_object', version 'GLIBC_2.35'
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:934: benchmark] Error 1
make[5]: Leaving directory '/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/libmicrohttpd-0.9.75/.x86_64-libreelec-linux-gnu/src/examples'
make[4]: *** [Makefile:1220: all-recursive] Error 1
make[4]: Leaving directory '/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/libmicrohttpd-0.9.75/.x86_64-libreelec-linux-gnu/src/examples'
make[3]: *** [Makefile:460: all-recursive] Error 1
make[3]: Leaving directory '/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/libmicrohttpd-0.9.75/.x86_64-libreelec-linux-gnu/src'
make[2]: *** [Makefile:608: all-recursive] Error 1
make[2]: Leaving directory '/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/libmicrohttpd-0.9.75/.x86_64-libreelec-linux-gnu'
make[1]: *** [Makefile:515: all] Error 2
make[1]: Leaving directory '/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/libmicrohttpd-0.9.75/.x86_64-libreelec-linux-gnu'
FAILURE: scripts/build libmicrohttpd:target during make_target (default)
```