### PR TITLE
Fix libretro-sameboy build

### DIFF
--- a/packages/emulation/libretro-sameboy/package.mk
+++ b/packages/emulation/libretro-sameboy/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="a8728627d7343abc097d74ff0a0f7ad6ebb5d5b70aba1f7ff81b73ce8f192806"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libretro/sameboy"
 PKG_URL="https://github.com/libretro/sameboy/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_DEPENDS_TARGET="toolchain kodi-platform util-linux:host"
 PKG_LONGDESC="libretro wrapper for SameBoy emulator."
 
 PKG_LIBNAME="sameboy_libretro.so"

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -63,6 +63,7 @@ fi
 
 PKG_CONFIGURE_OPTS_HOST="--enable-static \
                          --disable-shared \
+                         --enable-all-programs \
                          ${UTILLINUX_CONFIG_DEFAULT} \
                          --enable-uuidgen \
                          --enable-libuuid"


### PR DESCRIPTION
fix `hexdump` not found 

```
echo "/* AUTO-GENERATED */" > ../libretro/agb_boot.c
echo "const unsigned char agb_boot[] = {" >> ../libretro/agb_boot.c
hexdump -v -e '/1 "0x%02x, "' ../BootROMs/prebuilt/agb_boot.bin >> ../libretro/agb_boot.c
/bin/sh: 1: hexdump: not found
make: *** [Makefile:371: ../libretro/agb_boot.c] Error 127
```

- libretro-sameboy: update dependency to include util-linux:host as hexdump is needed for the build
-  util-linux: enable all-programs in :host build so that hexdump is available in toolchain/bin