### PR TITLE
make: fails to execute extraordinarily long command lines - further fix

### DIFF
--- a/packages/devel/make/patches/make-02-fix-large-command-line-on-POSIX-systems.patch
+++ b/packages/devel/make/patches/make-02-fix-large-command-line-on-POSIX-systems.patch
@@ -44,14 +44,12 @@ diff --git a/src/job.c b/src/job.c
 index 3bcec38..734c591 100644
 --- a/src/job.c
 +++ b/src/job.c
-@@ -26,6 +26,14 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
+@@ -26,6 +26,12 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
  #include "variable.h"
  #include "os.h"
  
-+#if defined (HAVE_LINUX_BINFMTS_H) && defined (HAVE_SYS_USER_H)
 +#include <sys/user.h>
 +#include <linux/binfmts.h>
-+#endif
 +#ifndef PAGE_SIZE
 +# define PAGE_SIZE (sysconf(_SC_PAGESIZE))
 +#endif


### PR DESCRIPTION
Further Fix for
- #6452
- #6461 

fixed with a small patch.
`features/long_command_line .............................. ok     (1 passed) `

as we can’t patch `configure.ac` without a dependency loop. 
- and with the #6461 thus not defining `HAVE_LINUX_BINFMTS_H` and `HAVE_SYS_USER_H` 

The below patch always includes the required `#include` files.
```
diff --git a/packages/devel/make/patches/make-02-fix-large-command-line-on-POSIX-systems.patch b/packages/devel/make/patches/make-02-fix-l
arge-command-line-on-POSIX-systems.patch
index 0e4cc274306..12ac8b767a2 100644
--- a/packages/devel/make/patches/make-02-fix-large-command-line-on-POSIX-systems.patch
+++ b/packages/devel/make/patches/make-02-fix-large-command-line-on-POSIX-systems.patch
@@ -44,14 +44,12 @@ diff --git a/src/job.c b/src/job.c
 index 3bcec38..734c591 100644
 --- a/src/job.c
 +++ b/src/job.c
-@@ -26,6 +26,14 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
+@@ -26,6 +26,12 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
  #include "variable.h"
  #include "os.h"
  
-+#if defined (HAVE_LINUX_BINFMTS_H) && defined (HAVE_SYS_USER_H)
 +#include <sys/user.h>
 +#include <linux/binfmts.h>
-+#endif
 +#ifndef PAGE_SIZE
 +# define PAGE_SIZE (sysconf(_SC_PAGESIZE))
 +#endif 
```

- https://github.com/LibreELEC/LibreELEC.tv/pull/6423#issuecomment-1126655088
- https://github.com/LibreELEC/LibreELEC.tv/pull/6423#issuecomment-1126658473