### PR TITLE
llvm: update to 14.0.4

### DIFF
--- a/packages/lang/llvm/patches/llvm-14.0.0-force-disable-cmakelist-options.patch
+++ b/packages/lang/llvm/patches/llvm-14.0.0-force-disable-cmakelist-options.patch
@@ -1,0 +1,20 @@
+--- a/llvm/CMakeLists.txt	2022-04-02 06:26:04.688530539 +0000
++++ b/llvm/CMakeLists.txt	2022-04-02 06:44:00.015717360 +0000
+@@ -396,7 +396,7 @@
+ set(LLVM_TARGET_ARCH "host"
+   CACHE STRING "Set target to use for LLVM JIT or use \"host\" for automatic detection.")
+ 
+-option(LLVM_ENABLE_TERMINFO "Use terminfo database if available." ON)
++option(LLVM_ENABLE_TERMINFO "Use terminfo database if available." OFF)
+ 
+ set(LLVM_ENABLE_LIBXML2 "ON" CACHE STRING "Use libxml2 if available. Can be ON, OFF, or FORCE_ON")
+ 
+@@ -616,7 +616,7 @@
+ 
+ option(LLVM_BUILD_BENCHMARKS "Add LLVM benchmark targets to the list of default
+ targets. If OFF, benchmarks still could be built using Benchmarks target." OFF)
+-option(LLVM_INCLUDE_BENCHMARKS "Generate benchmark targets. If OFF, benchmarks can't be built." ON)
++option(LLVM_INCLUDE_BENCHMARKS "Generate benchmark targets. If OFF, benchmarks can't be built." OFF)
+ 
+ option (LLVM_BUILD_DOCS "Build the llvm documentation." OFF)
+ option (LLVM_INCLUDE_DOCS "Generate build targets for llvm documentation." ON)


### PR DESCRIPTION
llvm: update to 14.0.4
- use llvm-project not llvm, due to the packaging changes in v14
- Supersedes #6375
