### PR TITLE
dotnet-runtime: Update .NET and ASP.NET 6.x to 6.0.5 and addon (117)

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet6-runtime"
-PKG_VERSION="6.0.4"
+PKG_VERSION="6.0.5"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="6d66bf5494f4a54f6f20fe0de1e7a64a6e4eb5e6136b1496ac347d027fd35abe"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/ba1662bf-50e6-451a-957f-0d55bc6e5713/921fe0e68428ac47c098e97418d3126a/aspnetcore-runtime-6.0.4-linux-arm64.tar.gz"
+    PKG_SHA256="70dc0a73b71761a2f717bf8917f7ea4a1be4c41d2cffbe29df68f38d26e8061e"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/8ba7087e-4513-41e5-8359-a4bcd2a3661f/e6828f0d8cf1ecc63074c9ff57685e27/aspnetcore-runtime-6.0.5-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="f3b41cb4fa50bb195957c53f096817e1ab19f29858a677180145eba064ea49f6"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/adc5bbf5-6cf6-4da6-be27-60de0b8739e5/fecb289bd70834203f2397c18c82bbde/aspnetcore-runtime-6.0.4-linux-arm.tar.gz"
+    PKG_SHA256="cfc2046f516d89cec3b0052029044691448f8dcd0a3e8779776a234124846308"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/eda01ff6-fb9f-49ce-bdc1-67c688f9f1fa/75b195f97f4b219fccbac4432a6afaf0/aspnetcore-runtime-6.0.5-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="ca3dc696af0a9fc5c7ce052eba38ecf723cbc30d1dc29d8f85c201eff534d73b"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/de3f6658-5d5b-4986-aeb1-7efdf5818437/7df572051df15117a0f52be1b79e1823/aspnetcore-runtime-6.0.4-linux-x64.tar.gz"
+    PKG_SHA256="95a3cc7c4e7de792e39e40ffda72127ba49a49604b61fee18d50f970c9c1e903"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/a0e9ceb8-04eb-4510-876c-795a6a123dda/6141e57558eddc2d4629c7c14c2c6fa1/aspnetcore-runtime-6.0.5-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/dotnet-runtime-depends/dotnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/dotnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet6-runtime"
-PKG_VERSION="6.0.4"
+PKG_VERSION="6.0.5"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="672f8e8ffcf012059aef6c2f7edfe34ea307559fa2d8821bb5a4d07a4fbbbed6"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/3641affa-8bb0-486f-93d9-68adff4f4af7/1e3df9fb86cba7299b9e575233975734/dotnet-runtime-6.0.4-linux-arm64.tar.gz"
+    PKG_SHA256="0e61cffb7ef9ceed54ad759f253287ef09523825cd87ed9e84f608701abba325"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/b7bfeef6-3df9-46a1-8cc9-5b2a3121a1d7/44287ecada25d3f0bd8610550e08246d/dotnet-runtime-6.0.5-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="11b8c2952210e226ec9c2a996d7a6b24f4b8ddd8ae0590080bfea5362fb7e0af"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/f8e1ab66-58f7-4ebb-a9bb-9decfa03501f/88e1fb49af6f75dc54c23383162409c5/dotnet-runtime-6.0.4-linux-arm.tar.gz"
+    PKG_SHA256="48aef75040b082f7c7d4222c5726f9dbf4da0d1dd8511a236fa112d2e8eac77c"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/36a5510d-e454-4f46-aeaa-ed2c9521e12e/1d60cf7759fd938f2e6c9730d0792b9d/dotnet-runtime-6.0.5-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="02e2c5b5950e3fc1fe4dd146175758f198c711e495883f7f286d575437fd82c4"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/5b08d331-15ac-4a53-82a5-522fa45b1b99/65ae300dd160ae0b88b91dd78834ce3e/dotnet-runtime-6.0.4-linux-x64.tar.gz"
+    PKG_SHA256="688694c604bbd810d28446752131e20468390a071aa2a5157a4e2d87a43dfa3c"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/56d9250f-97df-4786-b33e-a8e34b349e86/dcf054ca00899a70a80aa1a7d3072b52/dotnet-runtime-6.0.5-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="dotnet-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/tools/dotnet-runtime/changelog.txt
+++ b/packages/addons/tools/dotnet-runtime/changelog.txt
@@ -1,4 +1,8 @@
 116
+- Update .NET Runtime 6.0.5
+- Update ASP.NET Core Runtime 6.0.5
+
+116
 - Update .NET Runtime 6.0.4
 - Update ASP.NET Core Runtime 6.0.4
 

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="116"
+PKG_REV="117"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"


### PR DESCRIPTION
Refer:
- https://forum.libreelec.tv/core/conversation/5928-dotnet-6-0-on-arm32/
- https://dotnet.microsoft.com/en-us/download/dotnet/6.0
- Release notes:
  - https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.5/6.0.5.md


