### PR TITLE
Kodi: dynamically set KODI_AE_SINK env from build options

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -138,6 +138,9 @@
 # build kodi with alsa support (yes/no)
   KODI_ALSA_SUPPORT="yes"
 
+# build kodi with pulseaudio support (yes/no)
+  KODI_PULSEAUDIO_SUPPORT="yes"
+
 ### KODI ADDONS ###
 
 # Distribution Specific source location

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -135,6 +135,8 @@
 # build with Samba Client support (mounting SAMBA shares with KODI) (yes / no)
   KODI_SAMBA_SUPPORT="yes"
 
+# build kodi with alsa support (yes/no)
+  KODI_ALSA_SUPPORT="yes"
 
 ### KODI ADDONS ###
 

--- a/packages/mediacenter/kodi/config/kodi.conf.in
+++ b/packages/mediacenter/kodi/config/kodi.conf.in
@@ -1,4 +1,4 @@
-KODI_AE_SINK=ALSA+PULSE
+KODI_AE_SINK=@KODI_AE_SINK@
 HOME=/storage
 KODI_TEMP=/storage/.kodi/temp
 KODI_HOME=/usr/share/kodi/

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -55,7 +55,7 @@ configure_package() {
     KODI_ALSA="-DENABLE_ALSA=OFF"
  fi
 
-  if [ "${PULSEAUDIO_SUPPORT}" = yes ]; then
+  if [ "${KODI_PULSEAUDIO_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" pulseaudio"
     KODI_PULSEAUDIO="-DENABLE_PULSEAUDIO=ON"
   else

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -275,7 +275,16 @@ post_makeinstall_target() {
         -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
         -i ${INSTALL}/usr/lib/kodi/kodi.sh
 
-    cp ${PKG_DIR}/config/kodi.conf ${INSTALL}/usr/lib/kodi/kodi.conf
+    if [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+      KODI_AE_SINK="ALSA+PULSE"
+    elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
+      KODI_AE_SINK="PULSE"
+    elif [ "${KODI_PULSEAUDIO_SUPPORT}" != "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+      KODI_AE_SINK="ALSA"
+    fi
+
+    # adjust audio output device to what was built
+    sed "s/@KODI_AE_SINK@/${KODI_AE_SINK}/" ${PKG_DIR}/config/kodi.conf.in > ${INSTALL}/usr/lib/kodi/kodi.conf
 
     # set default display environment
     if [ "${DISPLAYSERVER}" = "x11" ]; then

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -239,7 +239,9 @@ configure_package() {
                          ${KODI_AIRTUNES} \
                          ${KODI_OPTICAL} \
                          ${KODI_BLURAY} \
-                         ${KODI_PLAYER}"
+                         ${KODI_PLAYER} \
+                         ${KODI_ALSA} \
+                         ${KODI_PULSEAUDIO}"
 }
 
 pre_configure_target() {

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -48,7 +48,7 @@ configure_package() {
     PKG_DEPENDS_TARGET+=" ${OPENGLES}"
   fi
 
-  if [ "${ALSA_SUPPORT}" = yes ]; then
+  if [ "${KODI_ALSA_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" alsa-lib"
     KODI_ALSA="-DENABLE_ALSA=ON"
   else

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -17,6 +17,8 @@ PKG_LONGDESC="Root package used to build and create complete image"
 # Sound support
 [ "${ALSA_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" alsa"
 
+[ "${PULSEAUDIO_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" pulseaudio"
+
 # Automounter support
 [ "${UDEVIL}" = "yes" ] && PKG_DEPENDS_TARGET+=" udevil"
 


### PR DESCRIPTION
This PR aims to improve separation between audio programs and kodi build options.

This creates the ability to build kodi with out `ALSA` support but to keep alsa included in the build. The same is true for pulseaudio. This will also be true for the pipewire PR I have for after this.

This doesn't change any default behaviour and just make the build system more flexible.