### PR TITLE
Add Pipewire Support

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -144,6 +144,9 @@
 # build kodi with pulseaudio support (yes/no)
   KODI_PULSEAUDIO_SUPPORT="yes"
 
+# build kodi with pipewire support (yes/no)
+  KODI_PIPEWIRE_SUPPORT="no"
+
 ### KODI ADDONS ###
 
 # Distribution Specific source location

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -138,6 +138,9 @@
 # build kodi with alsa support (yes/no)
   KODI_ALSA_SUPPORT="yes"
 
+# build kodi with pulseaudio support (yes/no)
+  KODI_PULSEAUDIO_SUPPORT="yes"
+
 ### KODI ADDONS ###
 
 # Distribution Specific source location

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -87,6 +87,9 @@
 # build and install PulseAudio support (yes / no)
   PULSEAUDIO_SUPPORT="yes"
 
+# build and install pipewire support (yes / no)
+  PIPEWIRE_SUPPORT="no"
+
 # build and install eSpeak-NG support (yes / no)
   ESPEAK_SUPPORT="no"
 

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -135,6 +135,8 @@
 # build with Samba Client support (mounting SAMBA shares with KODI) (yes / no)
   KODI_SAMBA_SUPPORT="yes"
 
+# build kodi with alsa support (yes/no)
+  KODI_ALSA_SUPPORT="yes"
 
 ### KODI ADDONS ###
 

--- a/packages/audio/ldacBT/package.mk
+++ b/packages/audio/ldacBT/package.mk
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="ldacBT"
+PKG_VERSION="2.0.2.3"
+PKG_SHA256="c02998718f9c4620437d7594b4d121b3ab4c5cfeba8d41fa31dd5c71db09edca"
+PKG_LICENSE="Apache"
+PKG_SITE="https://github.com/EHfive/ldacBT"
+PKG_URL="https://github.com/EHfive/ldacBT/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_UNPACK="libldac"
+PKG_LONGDESC="LDAC Bluetooth encoder library (build tools)"
+
+PKG_CMAKE_OPTS_TARGET="-DLDAC_SOFT_FLOAT=OFF"
+
+post_unpack() {
+  rm -rf ${PKG_BUILD}/libldac
+  ln -sf $(get_build_dir libldac) ${PKG_BUILD}/libldac
+}

--- a/packages/audio/libfreeaptx/package.mk
+++ b/packages/audio/libfreeaptx/package.mk
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libfreeaptx"
+PKG_VERSION="0.1.1"
+PKG_SHA256="7acf514446cae59585d9bc21e4f98f4a3856f4741c3a7a09d06e8ac5bf2f7315"
+PKG_LICENSE="LGPL"
+PKG_SITE="https://github.com/iamthehorker/libfreeaptx"
+PKG_URL="https://github.com/iamthehorker/libfreeaptx/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Open Source aptX codec library"
+PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="+pic"
+
+make_target() {
+  ${CC} ${CFLAGS} -I${PKG_BUILD} -c -o ${PKG_NAME##*lib}.o ${PKG_NAME##*lib}.c
+  ${AR} -rcs ${PKG_NAME}.a ${PKG_NAME##*lib}.o
+}
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib
+    cp -a ${PKG_NAME}.a ${SYSROOT_PREFIX}/usr/lib/
+
+  mkdir -p ${SYSROOT_PREFIX}/usr/include
+    cp -a ${PKG_NAME##*lib}.h ${SYSROOT_PREFIX}/usr/include/
+
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+    cat > ${SYSROOT_PREFIX}/usr/lib/pkgconfig/${PKG_NAME}.pc << EOF
+prefix=/usr
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: ${PKG_NAME}
+Description: Open Source aptX codec library
+Version: ${PKG_VERSION}
+Libs: -Wl,-rpath=\${libdir} -L\${libdir} -l${PKG_NAME##*lib}
+Cflags: -I\${includedir}
+EOF
+}

--- a/packages/audio/libldac/package.mk
+++ b/packages/audio/libldac/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libldac"
+PKG_VERSION="82b6a1abee84787b8fa167efe20290073f60db2d"
+PKG_SHA256="d61edcd3bfc4b71123136895fe71e7ba974f4a91f16a158f0ec8d5eb1913c51a"
+PKG_LICENSE="Apache"
+PKG_SITE="https://android.googlesource.com/platform/external/libldac"
+PKG_URL="https://github.com/brucehw/libldac/archive/${PKG_VERSION}.tar.gz"
+PKG_LONGDESC="LDAC Bluetooth encoder library"
+PKG_TOOLCHAIN="manual"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pipewire"
+PKG_VERSION="0.3.51"
+PKG_SHA256="f18e7a2cd2fcd75482c3df4e736e01435bd20779ddf63da63b0a086d3a9735ac"
+PKG_LICENSE="LGPL"
+PKG_SITE="https://pipewire.org"
+PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libpthread-stubs dbus ncurses alsa-lib systemd libsndfile libusb"
+PKG_LONGDESC="PipeWire is a server and user space API to deal with multimedia pipeline"
+PKG_TOOLCHAIN="meson"
+
+if [ "${BLUETOOTH_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" bluez sbc ldacBT libfreeaptx"
+  PKG_PIPEWIRE_BLUETOOTH="-Dbluez5=enabled \
+                          -Dbluez5-backend-hsp-native=disabled \
+                          -Dbluez5-backend-hfp-native=disabled \
+                          -Dbluez5-backend-ofono=disabled \
+                          -Dbluez5-backend-hsphfpd=disabled \
+                          -Dbluez5-codec-aptx=enabled \
+                          -Dbluez5-codec-ldac=enabled \
+                          -Dbluez5-codec-aac=disabled"
+else
+  PKG_PIPEWIRE_BLUETOOTH="-Dbluez5=disabled"
+fi
+
+PKG_MESON_OPTS_TARGET="-Ddocs=disabled \
+                       -Dexamples=disabled \
+                       -Dman=disabled \
+                       -Dtests=disabled \
+                       -Dinstalled_tests=disabled \
+                       -Dgstreamer=disabled \
+                       -Dgstreamer-device-provider=disabled \
+                       -Dsystemd=enabled \
+                       -Dsystemd-system-service=enabled \
+                       -Dsystemd-user-service=disabled \
+                       -Dpipewire-alsa=enabled \
+                       -Dpipewire-jack=disabled \
+                       -Dpipewire-v4l2=disabled \
+                       -Djack-devel=false
+                       -Dspa-plugins=enabled \
+                       -Dalsa=enabled \
+                       -Daudiomixer=enabled \
+                       -Daudioconvert=enabled \
+                       ${PKG_PIPEWIRE_BLUETOOTH} \
+                       -Dcontrol=enabled \
+                       -Daudiotestsrc=disabled \
+                       -Dffmpeg=disabled \
+                       -Djack=disabled \
+                       -Dsupport=enabled \
+                       -Devl=disabled \
+                       -Dtest=disabled \
+                       -Dv4l2=disabled \
+                       -Ddbus=enabled \
+                       -Dlibcamera=disabled \
+                       -Dvideoconvert=disabled \
+                       -Dvideotestsrc=disabled \
+                       -Dvolume=enabled \
+                       -Dvulkan=disabled \
+                       -Dpw-cat=enabled \
+                       -Dudev=enabled \
+                       -Dudevrulesdir=/usr/lib/udev/rules.d \
+                       -Dsdl2=disabled \
+                       -Dsndfile=enabled \
+                       -Dlibpulse=disabled \
+                       -Droc=disabled \
+                       -Davahi=disabled \
+                       -Decho-cancel-webrtc=disabled \
+                       -Dlibusb=enabled \
+                       -Dsession-managers=[] \
+                       -Draop=disabled \
+                       -Dlv2=disabled \
+                       -Dx11=disabled \
+                       -Dx11-xfixes=disabled \
+                       -Dlibcanberra=disabled \
+                       -Dlegacy-rtkit=false"
+
+post_makeinstall_target() {
+  # connect to the system bus
+  sed '/^\[Service\]/a Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket' -i ${INSTALL}/usr/lib/systemd/system/pipewire.service
+}
+
+post_install() {
+  add_user pipewire x 982 980 "pipewire-daemon" "/var/run/pipewire" "/bin/sh"
+  add_group pipewire 980
+  # note that the pipewire user is added to the audio and video groups in systemd/package.mk
+  # todo: maybe there is a better way to add users to groups in the future?
+
+  enable_service pipewire.socket
+  enable_service pipewire.service
+}

--- a/packages/audio/sbc/package.mk
+++ b/packages/audio/sbc/package.mk
@@ -16,3 +16,8 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \
                            --disable-tools \
                            --disable-tester"
+
+post_makeinstall_target() {
+  # fix static library
+  sed -i 's/-lsbc/-lsbc -lbluetooth/' ${SYSROOT_PREFIX}/usr/lib/pkgconfig/sbc.pc
+}

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="wireplumber"
+PKG_VERSION="0.4.10"
+PKG_SHA256="bddc5bb3c47e97c170d27c712bc3c7912592aea1ea9df747e92685f5194456d4"
+PKG_LICENSE="MIT"
+PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
+PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="pipewire glib lua54 glib:host"
+PKG_LONGDESC="Session / policy manager implementation for PipeWire"
+
+PKG_MESON_OPTS_TARGET="-Dintrospection=disabled \
+                       -Ddoc=disabled \
+                       -Dsystem-lua=true \
+                       -Delogind=disabled \
+                       -Dsystemd=enabled \
+                       -Dsystemd-system-service=true \
+                       -Dsystemd-user-service=false \
+                       -Dsystemd-system-unit-dir=/usr/lib/systemd/system \
+                       -Dtests=false"
+
+post_makeinstall_target() {
+  # connect to the system bus
+  sed '/^\[Service\]/a Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket' -i ${INSTALL}/usr/lib/systemd/system/wireplumber.service
+
+  # ref https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/0da29f38181e391160fa8702623050b8544ec775
+  cat > ${INSTALL}/usr/share/wireplumber/main.lua.d/89-disable-session-dbus-dependent-features.lua << EOF
+alsa_monitor.properties["alsa.reserve"] = false
+default_access.properties["enable-flatpak-portal"] = false
+EOF
+
+  cat > ${INSTALL}/usr/share/wireplumber/main.lua.d/89-disable-v4l2.lua << EOF
+v4l2_monitor.enabled = false
+EOF
+
+  cat > ${INSTALL}/usr/share/wireplumber/bluetooth.lua.d/89-disable-session-dbus-dependent-features.lua << EOF
+bluez_monitor.properties["with-logind"] = false
+EOF
+
+  cat > ${INSTALL}/usr/share/wireplumber/bluetooth.lua.d/89-disable-bluez-hfphsp-backend.lua << EOF
+bluez_monitor.properties["bluez5.hfphsp-backend"] = "none"
+EOF
+}
+
+post_install() {
+  enable_service wireplumber.service
+}

--- a/packages/devel/readline/package.mk
+++ b/packages/devel/readline/package.mk
@@ -18,5 +18,8 @@ PKG_CONFIGURE_OPTS_TARGET="bash_cv_wcwidth_broken=no \
                            --with-curses"
 
 post_makeinstall_target() {
+  # fix static library
+  sed -i 's/-lreadline/-lreadline -lncursesw/' ${SYSROOT_PREFIX}/usr/lib/pkgconfig/readline.pc
+
   rm -rf ${INSTALL}/usr/share/readline
 }

--- a/packages/lang/lua54/config/lua54.pc
+++ b/packages/lang/lua54/config/lua54.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+libdir=${prefix}/lib
+includedir=${prefix}/include/lua@@VERSION_MM@@
+
+Name: Lua
+Description: An Extensible Extension Language
+Version: @@VERSION@@
+Requires:
+Libs: -L${libdir} -llua@@VERSION_MM@@ -lm
+Cflags: -I${includedir}

--- a/packages/lang/lua54/package.mk
+++ b/packages/lang/lua54/package.mk
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="lua54"
+PKG_VERSION="5.4.3"
+PKG_SHA256="f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb"
+PKG_LICENSE="MIT"
+PKG_SITE="https://www.lua.org"
+PKG_URL="http://www.lua.org/ftp/lua-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Lua is a powerful, efficient, lightweight, embeddable scripting language."
+
+make_target() {
+  make CC=${CC} AR="${AR} rcu" MYCFLAGS="-fPIC" posix
+}
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/include/lua$(get_pkg_version_maj_min)
+  cp src/lua.h src/luaconf.h src/lualib.h src/lauxlib.h ${SYSROOT_PREFIX}/usr/include/lua$(get_pkg_version_maj_min)
+
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib
+  cp src/liblua.a ${SYSROOT_PREFIX}/usr/lib/liblua$(get_pkg_version_maj_min).a
+
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+  cp ${PKG_DIR}/config/lua54.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+  sed -e "s/@@VERSION@@/${PKG_VERSION}/g" \
+      -e "s/@@VERSION_MM@@/$(get_pkg_version_maj_min)/g" \
+      -i ${SYSROOT_PREFIX}/usr/lib/pkgconfig/lua54.pc
+}

--- a/packages/mediacenter/kodi/config/kodi.conf.in
+++ b/packages/mediacenter/kodi/config/kodi.conf.in
@@ -1,4 +1,4 @@
-KODI_AE_SINK=ALSA+PULSE
+KODI_AE_SINK=@KODI_AE_SINK@
 HOME=/storage
 KODI_TEMP=/storage/.kodi/temp
 KODI_HOME=/usr/share/kodi/

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -55,7 +55,7 @@ configure_package() {
     KODI_ALSA="-DENABLE_ALSA=OFF"
  fi
 
-  if [ "${PULSEAUDIO_SUPPORT}" = yes ]; then
+  if [ "${KODI_PULSEAUDIO_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" pulseaudio"
     KODI_PULSEAUDIO="-DENABLE_PULSEAUDIO=ON"
   else

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -275,7 +275,16 @@ post_makeinstall_target() {
         -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
         -i ${INSTALL}/usr/lib/kodi/kodi.sh
 
-    cp ${PKG_DIR}/config/kodi.conf ${INSTALL}/usr/lib/kodi/kodi.conf
+    if [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+      KODI_AE_SINK="ALSA+PULSE"
+    elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
+      KODI_AE_SINK="PULSE"
+    elif [ "${KODI_PULSEAUDIO_SUPPORT}" != "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+      KODI_AE_SINK="ALSA"
+    fi
+
+    # adjust audio output device to what was built
+    sed "s/@KODI_AE_SINK@/${KODI_AE_SINK}/" ${PKG_DIR}/config/kodi.conf.in > ${INSTALL}/usr/lib/kodi/kodi.conf
 
     # set default display environment
     if [ "${DISPLAYSERVER}" = "x11" ]; then

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -239,7 +239,9 @@ configure_package() {
                          ${KODI_AIRTUNES} \
                          ${KODI_OPTICAL} \
                          ${KODI_BLURAY} \
-                         ${KODI_PLAYER}"
+                         ${KODI_PLAYER} \
+                         ${KODI_ALSA} \
+                         ${KODI_PULSEAUDIO}"
 }
 
 pre_configure_target() {

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -48,7 +48,7 @@ configure_package() {
     PKG_DEPENDS_TARGET+=" ${OPENGLES}"
   fi
 
-  if [ "${ALSA_SUPPORT}" = yes ]; then
+  if [ "${KODI_ALSA_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" alsa-lib"
     KODI_ALSA="-DENABLE_ALSA=ON"
   else

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -66,6 +66,17 @@ configure_package() {
     PKG_DEPENDS_TARGET+=" espeak-ng"
   fi
 
+  if [ "${KODI_PIPEWIRE_SUPPORT}" = yes ]; then
+    PKG_DEPENDS_TARGET+=" pipewire"
+    KODI_PIPEWIRE="-DENABLE_PIPEWIRE=ON"
+
+    if [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -o "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+      die "KODI_PULSEAUDIO_SUPPORT and KODI_ALSA_SUPPORT cannot be used with KODI_PIPEWIRE_SUPPORT"
+    fi
+  else
+    KODI_PIPEWIRE="-DENABLE_PIPEWIRE=OFF"
+  fi
+
   if [ "${CEC_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" libcec"
     KODI_CEC="-DENABLE_CEC=ON"
@@ -241,7 +252,8 @@ configure_package() {
                          ${KODI_BLURAY} \
                          ${KODI_PLAYER} \
                          ${KODI_ALSA} \
-                         ${KODI_PULSEAUDIO}"
+                         ${KODI_PULSEAUDIO} \
+                         ${KODI_PIPEWIRE}"
 }
 
 pre_configure_target() {
@@ -275,7 +287,9 @@ post_makeinstall_target() {
         -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
         -i ${INSTALL}/usr/lib/kodi/kodi.sh
 
-    if [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+    if [ "${KODI_PIPEWIRE_SUPPORT}" = "yes" ]; then
+      KODI_AE_SINK="PIPEWIRE"
+    elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
       KODI_AE_SINK="ALSA+PULSE"
     elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
       KODI_AE_SINK="PULSE"

--- a/packages/mediacenter/kodi/patches/0001-CPlatformLinux-ifdef-alsa-support.patch
+++ b/packages/mediacenter/kodi/patches/0001-CPlatformLinux-ifdef-alsa-support.patch
@@ -1,0 +1,62 @@
+From 4839aa9e65478bab3a1f61bab06419348daa061c Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Tue, 17 May 2022 10:43:44 -0700
+Subject: [PATCH] CPlatformLinux: ifdef alsa support
+
+---
+ xbmc/platform/linux/PlatformLinux.cpp | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/xbmc/platform/linux/PlatformLinux.cpp b/xbmc/platform/linux/PlatformLinux.cpp
+index dd2e35f2e2..4a1e104eb9 100644
+--- a/xbmc/platform/linux/PlatformLinux.cpp
++++ b/xbmc/platform/linux/PlatformLinux.cpp
+@@ -8,11 +8,17 @@
+ 
+ #include "PlatformLinux.h"
+ 
++#if defined(HAS_ALSA)
+ #include "cores/AudioEngine/Sinks/alsa/ALSADeviceMonitor.h"
+ #include "cores/AudioEngine/Sinks/alsa/ALSAHControlMonitor.h"
++#endif
++
+ #include "utils/StringUtils.h"
+ 
++#if defined(HAS_ALSA)
+ #include "platform/linux/FDEventMonitor.h"
++#endif
++
+ #include "platform/linux/powermanagement/LinuxPowerSyscall.h"
+ 
+ // clang-format off
+@@ -122,6 +128,7 @@ bool CPlatformLinux::InitStageOne()
+ 
+   m_lirc.reset(OPTIONALS::LircRegister());
+ 
++#if defined(HAS_ALSA)
+   RegisterService(std::make_shared<CFDEventMonitor>());
+ #if defined(HAVE_LIBUDEV)
+   RegisterService(std::make_shared<CALSADeviceMonitor>());
+@@ -129,11 +136,13 @@ bool CPlatformLinux::InitStageOne()
+ #if !defined(HAVE_X11)
+   RegisterService(std::make_shared<CALSAHControlMonitor>());
+ #endif
++#endif // HAS_ALSA
+   return true;
+ }
+ 
+ void CPlatformLinux::DeinitStageOne()
+ {
++#if defined(HAS_ALSA)
+ #if !defined(HAVE_X11)
+   DeregisterService(typeid(CALSAHControlMonitor));
+ #endif
+@@ -141,4 +150,5 @@ void CPlatformLinux::DeinitStageOne()
+   DeregisterService(typeid(CALSADeviceMonitor));
+ #endif
+   DeregisterService(typeid(CFDEventMonitor));
++#endif // HAS_ALSA
+ }
+-- 
+2.35.3
+

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -23,13 +23,14 @@ BLUEZ_CONFIG+=" --enable-monitor --enable-test"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-dependency-tracking \
                            --disable-silent-rules \
-                           --disable-library \
+                           --enable-library \
                            --enable-udev \
                            --disable-cups \
                            --disable-obex \
                            --enable-client \
                            --enable-systemd \
-                           --enable-tools --enable-deprecated \
+                           --enable-tools \
+                           --enable-deprecated \
                            --enable-datafiles \
                            --disable-manpages \
                            --disable-experimental \

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -259,7 +259,7 @@ post_install() {
   add_group systemd-network 193
   add_user systemd-network x 193 193 "systemd-network" "/" "/bin/sh"
 
-  add_group audio 63
+  add_group audio 63 pipewire
   add_group cdrom 11
   add_group dialout 18
   add_group disk 6
@@ -270,7 +270,7 @@ post_install() {
   add_group render 12
   add_group tape 33
   add_group tty 5
-  add_group video 39
+  add_group video 39 pipewire
   add_group utmp 22
   add_group input 199
 

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -19,6 +19,12 @@ PKG_LONGDESC="Root package used to build and create complete image"
 
 [ "${PULSEAUDIO_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" pulseaudio"
 
+[ "${PIPEWIRE_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" pipewire wireplumber"
+
+if [ "${PULSEAUDIO_SUPPORT}" = "yes" -a "${PIPEWIRE_SUPPORT}" = "yes" ]; then
+  die "PULSEAUDIO_SUPPORT and PIPEWIRE_SUPPORT cannot be enabled together"
+fi
+
 # Automounter support
 [ "${UDEVIL}" = "yes" ] && PKG_DEPENDS_TARGET+=" udevil"
 

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -17,6 +17,8 @@ PKG_LONGDESC="Root package used to build and create complete image"
 # Sound support
 [ "${ALSA_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" alsa"
 
+[ "${PULSEAUDIO_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" pulseaudio"
+
 # Automounter support
 [ "${UDEVIL}" = "yes" ] && PKG_DEPENDS_TARGET+=" udevil"
 


### PR DESCRIPTION
This PR adds pipewire support to LibreELEC and kodi (if enabled). It defaults to off as it isn't configured as a pulse alternative. I have a branch to change pulse to use pipewire but I'd rather get this in first and I can figure out pulseaudio later.

This has some commits that are part of #6501 and will need that to be merged first, then I'll rebase this PR. I wanted to PR it early while I had some spare time.

Currently Kodi is broken while building without ALSA so I added my patch that was submitted upstream https://github.com/xbmc/xbmc/pull/21415

Pipewire requires the bluez libbluetooth library. That could probably be conditional on `PIPEWIRE_SUPPORT` but I didn't bother for now.

I also added a couple fixes to `readline` and `sbc` to allow pipewire to build and link properly with static libraries.