### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="5e4307edfe20e03c9e4a0bc4515142f9b0cc698d18f365da33f655ddeb76956e"
+PKG_VERSION="20.2.1-Nexus"
+PKG_SHA256="5635c0503d410915aeb9334ad31e4dee2083f6ac77ccaa46eb641a7271f1c33e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="0d3f70825c6d4c89aad08d41153d45b55fab7af960744182977126dc71208880"
+PKG_VERSION="20.2.1-Nexus"
+PKG_SHA256="224d0d1a043a48c41b4fe35ade10f95ecb66a2f8778511016cffd8441a977a1d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.libarchive"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="2c38978d8c2a0911c0030e1308b2316493add0fdf8f33e65401e60052d16826a"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="64d963285811cc3326f84bce8a8e051bafe3930df450973e3e6df700be9bc695"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 20.2.0-Nexus to 20.2.1-Nexus
- inputstream.ffmpegdirect: update 20.2.0-Nexus to 20.2.1-Nexus
- vfs.libarchive: update 20.1.0-Nexus to 20.2.0-Nexus