### PR TITLE
llvm: fix build issue with llvm-config

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -38,7 +38,8 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_APPEND_VC_REV=OFF \
                        -DLLVM_ENABLE_RTTI=ON \
                        -DLLVM_ENABLE_UNWIND_TABLES=OFF \
-                       -DLLVM_ENABLE_Z3_SOLVER=OFF"
+                       -DLLVM_ENABLE_Z3_SOLVER=OFF \
+                       -DCMAKE_SKIP_RPATH=ON"
 
 pre_configure_host() {
   case "${TARGET_ARCH}" in


### PR DESCRIPTION
- fix bug introduced in #6502 

Error occuring - due to RPATH/RUNPATH

```
./build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/bin/llvm-config:
  symbol lookup error:
    ./build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/bin/../lib/libc.so.6:
      undefined symbol: _dl_fatal_printf, version GLIBC_PRIVATE
```

Before fix

$ ldd
build.LibreELEC-gbm.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/bin/llvm-config
	linux-vdso.so.1 (0x00007ffc515d6000)
	libLLVM-13.so => /home/lukas/git/libreelec/build.LibreELEC-gbm.x86_64-11.0-devel/toolchain/lib/libLLVM-13.so (0x00007fedc6fdb000)
	libstdc++.so.6 => /home/lukas/git/libreelec/build.LibreELEC-gbm.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/bin/../lib/libstdc++.so.6 (0x00007fedc6dd0000)
	libm.so.6 => /home/lukas/git/libreelec/build.LibreELEC-gbm.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/bin/../lib/libm.so.6 (0x00007fedc6cf6000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fedc6cd3000)
	libc.so.6 => /home/lukas/git/libreelec/build.LibreELEC-gbm.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/bin/../lib/libc.so.6 (0x00007fedc6aec000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fedcb676000)

After fix:

$ ldd
build.LibreELEC-gbm.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/bin/llvm-config
	linux-vdso.so.1 (0x00007ffd0cbce000)
	libLLVM-13.so => /home/lukas/git/libreelec/build.LibreELEC-gbm.x86_64-11.0-devel/toolchain/lib/libLLVM-13.so (0x00007f3399969000)
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f3399741000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f3399665000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f339964b000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f3399441000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f339e004000)