### PR TITLE
libbpf: update to 0.8.0

### DIFF
--- a/packages/devel/libbpf/package.mk
+++ b/packages/devel/libbpf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libbpf"
-PKG_VERSION="0.6.1"
-PKG_SHA256="ce3a8eb32d85ac48490256597736d8b27e0a5e947a0731613b7aba6b4ae43ac0"
+PKG_VERSION="0.8.0"
+PKG_SHA256="f4480242651a93c101ece320030f6b2b9b437f622f807719c13cb32569a6d65a"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/libbpf/libbpf"
 PKG_URL="https://github.com/libbpf/libbpf/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/libbpf/patches/libbpf-fix-crosscompile-and-sysroot.patch
+++ b/packages/devel/libbpf/patches/libbpf-fix-crosscompile-and-sysroot.patch
@@ -1,6 +1,8 @@
---- a/src/Makefile	2021-09-09 09:01:51.000000000 +1000
-+++ b/src/Makefile	2021-10-17 17:49:02.868557327 +1100
-@@ -61,15 +61,12 @@
+diff --git a/src/Makefile b/src/Makefile
+index 81ea6b8..7ab5f13 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -67,15 +67,12 @@ INSTALL = install
  
  DESTDIR ?=
  
@@ -18,18 +20,20 @@
  	LIBDIR_PC := $$\{prefix\}/$(LIBSUBDIR)
  else
  	LIBDIR_PC := $(LIBDIR)
-@@ -100,7 +97,7 @@
+@@ -106,7 +103,7 @@ $(OBJDIR)/libbpf.so.$(LIBBPF_VERSION): $(SHARED_OBJS)
  		  $^ $(ALL_LDFLAGS) -o $@
  
- $(OBJDIR)/libbpf.pc:
+ $(OBJDIR)/libbpf.pc: force
 -	$(Q)sed -e "s|@PREFIX@|$(PREFIX)|" \
 +	$(Q)sed -e "s|@PREFIX@|$(PREFIX_PC)|" \
  		-e "s|@LIBDIR@|$(LIBDIR_PC)|" \
  		-e "s|@VERSION@|$(LIBBPF_VERSION)|" \
  		< libbpf.pc.template > $@
---- a/src/libbpf.pc.template	2021-09-09 09:01:51.000000000 +1000
-+++ b/src/libbpf.pc.template	2021-10-17 18:03:19.681346272 +1100
-@@ -7,6 +7,6 @@
+diff --git a/src/libbpf.pc.template b/src/libbpf.pc.template
+index b45ed53..fe6ddde 100644
+--- a/src/libbpf.pc.template
++++ b/src/libbpf.pc.template
+@@ -7,6 +7,6 @@ includedir=${prefix}/include
  Name: libbpf
  Description: BPF library
  Version: @VERSION@


### PR DESCRIPTION
This fixes loading the raw bpf IR decoder which was broken with 0.6.1.

Note: #6510 is still needed to have working IR BPF decoders

Runtime tested on RPi4 with raw and pulse-distance IR BPF decoders