### PR TITLE
[le10] crust: allow override of BUILDCC and u-boot: fix make config with HOSTCC

### DIFF
--- a/packages/tools/crust/package.mk
+++ b/packages/tools/crust/package.mk
@@ -39,7 +39,7 @@ make_target() {
   # Boards with a PMIC need to disable CONFIG_PMIC_SHUTDOWN to get CIR wakeup from suspend
   echo "CONFIG_PMIC_SHUTDOWN=n" >> configs/${CRUST_CONFIG}
   echo "CONFIG_CIR=y" >> configs/${CRUST_CONFIG}
-  make ${CRUST_CONFIG}
+  make ${CRUST_CONFIG} BUILDCC=host-gcc
   make scp
 }
 

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -59,7 +59,7 @@ make_target() {
     [ "${BUILD_WITH_DEBUG}" = "yes" ] && PKG_DEBUG=1 || PKG_DEBUG=0
     DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm make mrproper
     [ -n "${UBOOT_FIRMWARE}" ] && find_file_path bootloader/firmware && . ${FOUND_PATH}
-    DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm make $(${ROOT}/${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} config)
+    DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm make HOSTCC="${HOST_CC}" HOSTCFLAGS="-I${TOOLCHAIN}/include" HOSTLDFLAGS="${HOST_LDFLAGS}" $(${ROOT}/${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} config)
     DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm _python_sysroot="${TOOLCHAIN}" _python_prefix=/ _python_exec_prefix=/ make ${UBOOT_TARGET} HOSTCC="${HOST_CC}" HOSTLDFLAGS="-L${TOOLCHAIN}/lib" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"
   fi
 }


### PR DESCRIPTION
- backport of #5953 using upstreamed patch
- backport of #5923 dfac76b2fb14e4e54525987de7e6ffc5a0d86c60

### Fix the crust build on minimal Ubuntu 20.04 image
- `PROJECT=Allwinner ARCH=arm DEVICE=A64 make image`

crust build fails when cc link is missing (e.g. minimal Ubuntu 20.04)
use host-gcc from the toolchain instead.
addition of the patch fixes the following error.

BUILD      crust (target)
    TOOLCHAIN      manual
...
  HOSTCC  build/3rdparty/kconfig/conf.o
/bin/sh: 1: exec: cc: not found
make[1]: *** [Makefile:170: build/3rdparty/kconfig/conf.o] Error 127
...

required update the `package.mk` to override **BUILDCC**

### AND

Whilst tidying up my build environment (and moving to the focal docker build) - the `Makefile.host` is trying to use cc (as HOSTCC is not being past through.) update the package.mk to pass HOSTCC and other HOSTxxx variables through to the `u-boot` make.