### PR TITLE
Intel graphics updates

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.1.2"
-PKG_SHA256="3b9a6d5e7e3f5748b3d0a2fb0e980ae943907fece0980bd9c0508e71c838e334"
+PKG_VERSION="22.1.3"
+PKG_SHA256="81dbb4ddec98bb18c3a038cd40222046ae7f5b24b2d5acbfb2400f39f02f2aaf"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"
@@ -11,4 +11,5 @@ PKG_URL="https://github.com/intel/gmmlib/archive/intel-gmmlib-${PKG_VERSION}.tar
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="gmmlib: The Intel(R) Graphics Memory Management Library provides device specific and buffer management for the Intel(R) Graphics Compute Runtime for OpenCL(TM) and the Intel(R) Media Driver for VAAPI."
 
-PKG_CMAKE_OPTS_TARGET="-DRUN_TEST_SUITE=OFF"
+PKG_CMAKE_OPTS_TARGET="-DBUILD_TYPE=release \
+                       -DRUN_TEST_SUITE=OFF"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.4.1"
-PKG_SHA256="5589d4e0142ae957d58798e3fba08d9e5e096e92eed422d40a82d45a14e6042f"
+PKG_VERSION="22.4.2"
+PKG_SHA256="e8e7faeb40e523b0daf61336853e09f59f810598093d65737cd119107cf933f8"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
- media-driver: update to 22.4.2
  - changes between 22.4.1 and 22.4.2
  - https://github.com/intel/media-driver/compare/intel-media-22.4.1...intel-media-22.4.2
- gmmlib: update to 22.1.3

```
=== tested on ===
Generic.x86_64-devel-20220524112757-3d15196
Linux nuc11 5.18.0 #1 SMP Mon May 23 07:38:22 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.701) Git:20.0a1-Nexus). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-05-22 by GCC 12.1.0 for Linux x86 64-bit version 5.18.0 (332288)
Running on LibreELEC (heitbaum): devel-20220524112757-3d15196 11.0, kernel: Linux x86 64-bit version 5.18.0
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0042.2021.1213.1702 12/13/2021
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.1.0
libva info: VA-API version 1.14.0
vainfo: VA-API version: 1.14 (libva 2.14.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.4.2 (3d15196c839)
```