### PR TITLE
[le11] config/show_config: ident cflags/ldflags

### DIFF
--- a/config/show_config
+++ b/config/show_config
@@ -33,8 +33,8 @@ show_config() {
   config_message+="\n - GOLD (Google Linker) Support:\t ${GOLD_SUPPORT}"
   config_message+="\n - LLVM support:\t\t\t ${LLVM_SUPPORT}"
   config_message+="\n - DEBUG:\t\t\t\t ${DEBUG:-no}"
-  config_message+="\n - CFLAGS:\t ${TARGET_CFLAGS}"
-  config_message+="\n - LDFLAGS:\t ${TARGET_LDFLAGS}"
+  config_message+="\n - CFLAGS:\t\t\t\t ${TARGET_CFLAGS}"
+  config_message+="\n - LDFLAGS:\t\t\t\t ${TARGET_LDFLAGS}"
 
   # Misc. hardware configuration
 


### PR DESCRIPTION

```
=================================================================================
 Configuration for LibreELEC (community)
 =================================================================================

 Buildsystem configuration:
 ======================================================
 - CPU:					 x86-64
 - Kernel Architecture:			 x86
 - Userland Architecture:		 x86_64
 - CPU features:			 64bit mmx sse sse2
 - LTO (Link Time Optimization) support: yes
 - GOLD (Google Linker) Support:	 yes
 - LLVM support:			 yes
 - DEBUG:				 no
 - CFLAGS:				 -march=x86-64 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG
 - LDFLAGS:				 -march=x86-64 -Wl,--as-needed -fuse-ld=gold
```