### PR TITLE
automake: further fix race in parallel builds

### DIFF
--- a/packages/devel/automake/package.mk
+++ b/packages/devel/automake/package.mk
@@ -9,6 +9,7 @@ PKG_SITE="http://sources.redhat.com/automake/"
 PKG_URL="http://ftpmirror.gnu.org/automake/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host autoconf:host"
 PKG_LONGDESC="A GNU tool for automatically creating Makefiles."
+PKG_BUILD_FLAGS="-parallel"
 
 PKG_CONFIGURE_OPTS_HOST="--target=${TARGET_NAME} --disable-silent-rules"
 


### PR DESCRIPTION
fix race in parallel builds

```
Executing (host): make
 cd /build/build.LibreELEC-Generic.x86_64-11.0-devel/build/automake-1.16.5 && "/build/build.LibreELEC-Generic.x86_64-11.0-devel/build/automake-1.16.5/.x86_64-linux-gnu/pre-inst-env" automake-1.16 --gnu --ignore-deps Makefile
/build/build.LibreELEC-Generic.x86_64-11.0-devel/build/automake-1.16.5/.x86_64-linux-gnu/pre-inst-env: 41: exec: automake-1.16: not found
make: *** [Makefile:2485: /build/build.LibreELEC-Generic.x86_64-11.0-devel/build/automake-1.16.5/Makefile.in] Error 127
FAILURE: scripts/build automake:host during make_host (default)
```