### PR TITLE
[le10] util-linux: set all-programs option in init and target not common

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -18,7 +18,6 @@ UTILLINUX_CONFIG_DEFAULT="--disable-gtk-doc \
                           --disable-nls \
                           --disable-rpath \
                           --enable-tls \
-                          --disable-all-programs \
                           --enable-chsh-only-listed \
                           --disable-bash-completion \
                           --disable-colors-default \
@@ -46,6 +45,7 @@ UTILLINUX_CONFIG_DEFAULT="--disable-gtk-doc \
                           --without-systemdsystemunitdir"
 
 PKG_CONFIGURE_OPTS_TARGET="${UTILLINUX_CONFIG_DEFAULT} \
+                           --disable-all-programs \
                            --enable-libuuid \
                            --enable-libblkid \
                            --enable-libmount \
@@ -68,6 +68,7 @@ PKG_CONFIGURE_OPTS_HOST="--enable-static \
                          --enable-libuuid"
 
 PKG_CONFIGURE_OPTS_INIT="${UTILLINUX_CONFIG_DEFAULT} \
+                         --disable-all-programs \
                          --enable-libblkid \
                          --enable-libmount \
                          --enable-fsck"


### PR DESCRIPTION
so that in :host hexdump is available in toolchain/bin

- back port of #6532 