### PR TITLE
X11 and Wayland updates

### DIFF
--- a/packages/multimedia/nvidia-vaapi-driver/package.mk
+++ b/packages/multimedia/nvidia-vaapi-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia-vaapi-driver"
-PKG_VERSION="0.0.5"
-PKG_SHA256="20b424f41c32e2f49729f85c70d7dcfd28e59a62d845024d9823b7f32faf089d"
+PKG_VERSION="0.0.6"
+PKG_SHA256="8a64c069200750f12d013c79547e459cbb87b498357478c5f36cb97f710294e0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/elFarto/nvidia-vaapi-driver"
 PKG_URL="https://github.com/elFarto/nvidia-vaapi-driver/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/wayland/lib/fcft/package.mk
+++ b/packages/wayland/lib/fcft/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fcft"
-PKG_VERSION="3.1.1"
-PKG_SHA256="5f35dbd8a1a81ec61648e86e8f86157c9fd905ee199540d81a031121473204d5"
+PKG_VERSION="3.1.2"
+PKG_SHA256="f571afe693d3fa11fe36e97c7a2ecbbf9313755ee31c1ec3dcc648796b8e6db0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/fcft"
 PKG_URL="https://codeberg.org/dnkl/fcft/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/lib/seatd/package.mk
+++ b/packages/wayland/lib/seatd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="seatd"
-PKG_VERSION="0.6.4"
-PKG_SHA256="3d4ac288114219ba7721239cafee7bfbeb7cf8e1e7fd653602a369e4ad050bd8"
+PKG_VERSION="0.7.0"
+PKG_SHA256="210ddf8efa1149cde4dd35908bef8e9e63c2edaa0cdb5435f2e6db277fafff3c"
 PKG_LICENSE="MIT"
 PKG_SITE="https://git.sr.ht/~kennylevinsen/seatd"
 PKG_URL="https://git.sr.ht/~kennylevinsen/seatd/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.20.0"
-PKG_SHA256="6c1f97892a7d599f97349e5e7c1239901fe00edcd4f6289f410034d5dc06cc85"
+PKG_VERSION="1.20.1"
+PKG_SHA256="08c003f724f361ed21f4dfbfe755a6c115b85385f1418907bb98f185457273f0"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbcommon"
-PKG_VERSION="1.4.0"
-PKG_SHA256="106cec5263f9100a7e79b5f7220f889bc78e7d7ffc55d2b6fdb1efefb8024031"
+PKG_VERSION="1.4.1"
+PKG_SHA256="943c07a1e2198026d8102b17270a1f406e4d3d6bbc4ae105b9e1b82d7d136b39"
 PKG_LICENSE="MIT"
 PKG_SITE="https://xkbcommon.org"
 PKG_URL="https://xkbcommon.org/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/util/swaybg/package.mk
+++ b/packages/wayland/util/swaybg/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="swaybg"
-PKG_VERSION="1.1"
-PKG_SHA256="958f425310514ae2aae064595c3e7efba2187b0d2947136c49188558fdb367b1"
+PKG_VERSION="1.1.1"
+PKG_SHA256="71cc8fc2cb7ae5ad3af772ab286b0b42f1c7cb17bea131e78c2d40a2fb8e6c59"
 PKG_LICENSE="MIT"
 PKG_SITE="https://swaywm.org/"
 PKG_URL="https://github.com/swaywm/swaybg/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/x11/app/setxkbmap/package.mk
+++ b/packages/x11/app/setxkbmap/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setxkbmap"
-PKG_VERSION="1.3.2"
-PKG_SHA256="8ff27486442725e50b02d7049152f51d125ecad71b7ce503cfa09d5d8ceeb9f5"
+PKG_VERSION="1.3.3"
+PKG_SHA256="b560c678da6930a0da267304fa3a41cc5df39a96a5e23d06f14984c87b6f587b"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libX11 libxkbfile"
 PKG_LONGDESC="Setxkbmap sets the keyboard using the X Keyboard Extension."

--- a/packages/x11/driver/xf86-input-libinput/package.mk
+++ b/packages/x11/driver/xf86-input-libinput/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xf86-input-libinput"
-PKG_VERSION="1.2.0"
-PKG_SHA256="f80da3c514fe1cbf57fa1b1bd6ff97f6b0a1f87466ad89247bac59cd0a5869f6"
+PKG_VERSION="1.2.1"
+PKG_SHA256="8151db5b9ddb317c0ce92dcb62da9a8db5079e5b8a95b60abc854da21e7e971b"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libinput/"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/driver/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="http://xorg.freedesktop.org/archive/individual/driver/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libinput"
 PKG_LONGDESC="This is an X driver based on libinput."
 PKG_TOOLCHAIN="autotools"

--- a/packages/x11/driver/xf86-video-amdgpu/package.mk
+++ b/packages/x11/driver/xf86-video-amdgpu/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xf86-video-amdgpu"
-PKG_VERSION="21.0.0"
-PKG_SHA256="607823034defba6152050e5eb1c4df94b38819ef764291abadd81b620bc2ad88"
+PKG_VERSION="22.0.0"
+PKG_SHA256="9d23fb602915dc3ccde92aa4d1e9485e7e54eaae2f41f485e55eb20761778266"
 PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.x.org/wiki/RadeonFeature/"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/driver/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="https://www.x.org/archive/individual/driver/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libdrm xorg-server"
 PKG_LONGDESC="Xorg driver for AMD Radeon GPUs using the amdgpu kernel driver."
 PKG_TOOLCHAIN="autotools"

--- a/packages/x11/lib/libxcb/package.mk
+++ b/packages/x11/lib/libxcb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxcb"
-PKG_VERSION="1.14"
-PKG_SHA256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34"
+PKG_VERSION="1.15"
+PKG_SHA256="cc38744f817cf6814c847e2df37fcb8997357d72fa4bcbc228ae0fe47219a059"
 PKG_LICENSE="OSS"
 PKG_SITE="http://xcb.freedesktop.org"
 PKG_URL="http://xcb.freedesktop.org/dist/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/proto/xcb-proto/package.mk
+++ b/packages/x11/proto/xcb-proto/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xcb-proto"
-PKG_VERSION="1.14.1"
-PKG_SHA256="f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3"
+PKG_VERSION="1.15"
+PKG_SHA256="d34c3b264e8365d16fa9db49179cfa3e9952baaf9275badda0f413966b65955f"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/proto/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/proto/xorgproto/package.mk
+++ b/packages/x11/proto/xorgproto/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xorgproto"
-PKG_VERSION="2021.5"
-PKG_SHA256="aa2f663b8dbd632960b24f7477aa07d901210057f6ab1a1db5158732569ca015"
+PKG_VERSION="2022.1"
+PKG_SHA256="1d2dcc66963f234d2c1e1f8d98a0d3e8725149cdac0a263df4097593c48bc2a6"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/proto/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- fcft: update to 3.1.2
- libinput: update to 1.20.1
- libxcb: update to 1.15
- libxkbcommon: update to 1.4.1
- nvidia-vaapi-driver: update to 0.0.6
- seatd: update to 0.7.0
- setxkbmap: update to 1.3.3
- swaybg: update to 1.1.1
- xcb-proto: update to 1.15
- xf86-input-libinput: update to 1.2.1
- xf86-video-amdgpu: update to 22.0.0
- xorgproto: update to 2022.1