### PR TITLE
openssl: enable parallel build

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -12,7 +12,6 @@ PKG_DEPENDS_HOST="ccache:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security"
 PKG_TOOLCHAIN="configure"
-PKG_BUILD_FLAGS="-parallel"
 
 PKG_CONFIGURE_OPTS_SHARED="--libdir=lib \
                            shared \


### PR DESCRIPTION
In the past, openssl didn't provide support for parallel building. However, with the 3.0 release this works well. Let's enable it.

This improves image build time since openssl:host is bottleneck, at least on my system.