### PR TITLE
[le11] package/network updates

### DIFF
--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iptables"
-PKG_VERSION="1.8.7"
-PKG_SHA256="c109c96bb04998cd44156622d36f8e04b140701ec60531a10668cfdff5e8d8f0"
+PKG_VERSION="1.8.8"
+PKG_SHA256="71c75889dc710676631553eb1511da0177bbaaf1b551265b912d236c3f51859f"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.netfilter.org/"
-PKG_URL="http://www.netfilter.org/projects/iptables/files/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.netfilter.org/"
+PKG_URL="https://www.netfilter.org/projects/iptables/files/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain linux:host libmnl libnftnl"
 PKG_LONGDESC="IP packet filter administration."
 PKG_TOOLCHAIN="autotools"
@@ -30,4 +30,3 @@ post_makeinstall_target() {
 post_install() {
   enable_service iptables.service
 }
-

--- a/packages/network/iptables/patches/iptables-0001-xshared-fix-build-for--werror-format-security.patch
+++ b/packages/network/iptables/patches/iptables-0001-xshared-fix-build-for--werror-format-security.patch
@@ -1,0 +1,28 @@
+From b72eb12ea5a61df0655ad99d5048994e916be83a Mon Sep 17 00:00:00 2001
+From: Phil Sutter <phil@nwl.cc>
+Date: Fri, 13 May 2022 16:51:58 +0200
+Subject: xshared: Fix build for -Werror=format-security
+
+Gcc complains about the omitted format string.
+
+Signed-off-by: Phil Sutter <phil@nwl.cc>
+---
+ iptables/xshared.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iptables/xshared.c b/iptables/xshared.c
+index fae5ddd5..a8512d38 100644
+--- a/iptables/xshared.c
++++ b/iptables/xshared.c
+@@ -1307,7 +1307,7 @@ static void check_empty_interface(struct xtables_args *args, const char *arg)
+ 		return;
+ 
+ 	if (args->family != NFPROTO_ARP)
+-		xtables_error(PARAMETER_PROBLEM, msg);
++		xtables_error(PARAMETER_PROBLEM, "%s", msg);
+ 
+ 	fprintf(stderr, "%s", msg);
+ }
+-- 
+cgit v1.2.3
+

--- a/packages/network/iptables/patches/iptables-0002-xshared-fix-for-build-in-sub-directory.patch
+++ b/packages/network/iptables/patches/iptables-0002-xshared-fix-for-build-in-sub-directory.patch
@@ -1,0 +1,11 @@
+--- a/libxtables/xtables.c	2022-05-13 13:26:26.000000000 +0000
++++ b/libxtables/xtables.c	2022-05-14 09:53:20.593250503 +0000
+@@ -49,7 +49,7 @@
+ #include <linux/netfilter_ipv4/ip_tables.h>
+ #include <linux/netfilter_ipv6/ip6_tables.h>
+ #include <libiptc/libxtc.h>
+-#include <libiptc/linux_list.h>
++#include "../libiptc/linux_list.h"
+ 
+ #ifndef NO_SHARED_LIBS
+ #include <dlfcn.h>

--- a/packages/network/iw/package.mk
+++ b/packages/network/iw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iw"
-PKG_VERSION="5.16"
-PKG_SHA256="4c44e42762f903f9094ba5a598998c800a97a62afd6fd31ec1e0a799e308659c"
+PKG_VERSION="5.19"
+PKG_SHA256="f167bbe947dd53bb9ebc0c1dcef5db6ad73ac1d6084f2c6f9376c5c360cc4d4e"
 PKG_LICENSE="PUBLIC_DOMAIN"
 PKG_SITE="http://wireless.kernel.org/en/users/Documentation/iw"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/libmnl/package.mk
+++ b/packages/network/libmnl/package.mk
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmnl"
-PKG_VERSION="1.0.4"
-PKG_SHA256="171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81"
+PKG_VERSION="1.0.5"
+PKG_SHA256="274b9b919ef3152bfb3da3a13c950dd60d6e2bcd54230ffeca298d03b40d0525"
 PKG_LICENSE="GPL"
 PKG_SITE="http://netfilter.org/projects/libmnl"
 PKG_URL="http://netfilter.org/projects/libmnl/files/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/network/libnftnl/package.mk
+++ b/packages/network/libnftnl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnftnl"
-PKG_VERSION="1.1.9"
-PKG_SHA256="e9b21a6f9a41f9e72aff696cc842e4a9a78ec8d281aec188f3e2b7a21db94b9a"
+PKG_VERSION="1.2.1"
+PKG_SHA256="7508a5c414fab13e3cb3ce8262d0ce4f02c1590a8e4f8628ab497b5b4585937c"
 PKG_LICENSE="GPL"
 PKG_SITE="http://netfilter.org/projects/libnftnl"
 PKG_URL="http://netfilter.org/projects/libnftnl/files/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/network/libnl/package.mk
+++ b/packages/network/libnl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnl"
-PKG_VERSION="3.5.0"
-PKG_SHA256="352133ec9545da76f77e70ccb48c9d7e5324d67f6474744647a7ed382b5e05fa"
+PKG_VERSION="3.6.0"
+PKG_SHA256="532155fd011e5a805bd67121b87a01c757e2bb24112ac17e69cb86013b970009"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://github.com/thom311/libnl"
 PKG_URL="https://github.com/thom311/libnl/releases/download/libnl${PKG_VERSION//./_}/libnl-${PKG_VERSION}.tar.gz"

--- a/packages/network/libtirpc/package.mk
+++ b/packages/network/libtirpc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libtirpc"
-PKG_VERSION="1.3.1"
-PKG_SHA256="245895caf066bec5e3d4375942c8cb4366adad184c29c618d97f724ea309ee17"
+PKG_VERSION="1.3.2"
+PKG_SHA256="e24eb88b8ce7db3b7ca6eb80115dd1284abc5ec32a8deccfed2224fc2532b9fd"
 PKG_LICENSE="GPL"
 PKG_SITE="https://sourceforge.net/projects/libtirpc/"
 PKG_URL="https://downloads.sourceforge.net/project/libtirpc/libtirpc/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/network/nss-mdns/package.mk
+++ b/packages/network/nss-mdns/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss-mdns"
-PKG_VERSION="0.14.1"
-PKG_SHA256="4fe54bffd20e410fc41382dc6c4708cdfa3a65f50c3753f262dc4c78fd864a6e"
+PKG_VERSION="0.15.1"
+PKG_SHA256="2d1b8de2e9ed5526f51c8bb627b719c07668465b5315787e7cfeed776ab90b9a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/lathiat/nss-mdns"
 PKG_URL="https://github.com/lathiat/nss-mdns/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/network/wsdd2/package.mk
+++ b/packages/network/wsdd2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wsdd2"
-PKG_VERSION="1.8.6"
-PKG_SHA256="707f9403559de70cc488c6c3deea12baf30d74068da88a59e7c0669a347b4661"
+PKG_VERSION="1.8.7"
+PKG_SHA256="b0b6b31522f4a5e39d075b31d59d57af9a567f543e0b39b2fbdfec324d30310a"
 PKG_LICENSE="GPL 3.0"
 PKG_SITE="https://github.com/Netgear/wsdd2/"
 PKG_URL="https://github.com/Netgear/wsdd2/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- iptables: update to 1.8.8
- iw: update to 5.19
- libmnl: update to 1.0.5
- libnftnl: update to 1.2.1
- libnl: update to 3.6.0
- libtirpc: update to 1.3.2
- nss-mdns: update to 0.15.1
- wsdd2: update to 1.8.7