### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gsf"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="ee32c5c279778ed91562591a4c5d297e03c46d21895e3b42f20293ee85a7e629"
+PKG_VERSION="20.2.1-Nexus"
+PKG_SHA256="b09dcb379bdc536117a956b10b37cf50c8afaa65337993c44a6847d382d7e2a5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="20.3.0-Nexus"
-PKG_SHA256="03010df42a91edfabd541d210bc450f4c14a4bb4a488a7d7a09f2fd4f2dc13c4"
+PKG_VERSION="20.3.1-Nexus"
+PKG_SHA256="587b3763dd37e4b35e2bac66201e25da6021977379daeaf5aaed6398dd161b3c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- audiodecoder.gsf: update 20.2.0-Nexus to 20.2.1-Nexus
- pvr.vuplus: update 20.3.0-Nexus to 20.3.1-Nexus