### PR TITLE
pulseaudio: update to 16.0

### DIFF
--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pulseaudio"
-PKG_VERSION="15.0"
-PKG_SHA256="a40b887a3ba98cc26976eb11bdb6613988f145b19024d1b6555c6a03c9cba1a0"
+PKG_VERSION="16.0"
+PKG_SHA256="b4ec6271910a1a86803f165056547f700dfabaf8d5c6c69736f706b5bb889f47"
 PKG_LICENSE="GPL"
 PKG_SITE="http://pulseaudio.org/"
 PKG_URL="http://www.freedesktop.org/software/pulseaudio/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
### Release Notes:
- https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/16.0/

```
nuc11:~ # pulseaudio --version
pulseaudio 16.0

=== build tested with ===
Generic.x86_64-devel-20220529091040-85eb4c7
Linux nuc11 5.18.0 #1 SMP Sun May 29 09:24:58 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA1 (19.90.701) Git:20.0a1-Nexus). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-05-29 by GCC 12.1.0 for Linux x86 64-bit version 5.18.0 (332288)
Running on LibreELEC (heitbaum): devel-20220529091040-85eb4c7 11.0, kernel: Linux x86 64-bit version 5.18.0
```

ref:
[1] https://www.systutorials.com/docs/linux/man/1-pulseaudio/

> pulseaudio isn't used by default and needs be tested as Bluetooth audio (main use case),
> and/or stop Kodi and pactl load-module module-udev-detect, then start Kodi and test actual audio output.

### Run testing required