### PR TITLE
Security package updates

### DIFF
--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.7.4"
-PKG_SHA256="e6adbebcfbc95867de01060d93c789938cf89cc1d1f6ef9ef661890f6217451f"
+PKG_VERSION="3.7.6"
+PKG_SHA256="77065719a345bfb18faa250134be4c53bef70c1bd61f6c0c23ceb8b44f0262ff"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/security/nspr/package.mk
+++ b/packages/security/nspr/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nspr"
-PKG_VERSION="4.32"
+PKG_VERSION="4.34"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/svn/general/nspr.html"
 PKG_DEPENDS_HOST="ccache:host"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.78"
-PKG_SHA256="3e798c4c5d101897de60337dc429252d95369b096e8483107751d697ddd61526"
+PKG_VERSION="3.79"
+PKG_SHA256="5369ed274a19f480ec94e1faef04da63e3cbac1a82e15bb1751e58b2f274b835"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
- gnutls: update to 3.7.6
  - https://lists.gnupg.org/pipermail/gnutls-help/2022-May/004743.html
  - https://lists.gnupg.org/pipermail/gnutls-help/2022-May/004744.html
- nspr: update to 4.34
- nss: update to 3.79
  - https://hg.mozilla.org/projects/nss/file/tip/doc/rst/releases/nss_3_79.rst