### PR TITLE
Vulkan package updates

### DIFF
--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers have to be specific versions matching the pkg version
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # if you update glslang make sure spirv-tools & spirv-headers versions a known good
-PKG_VERSION="11.9.0"
-PKG_SHA256="d5744adba19eef9ad3d73f524226b39fec559d94cb582cd442e3c5de930004b2"
+PKG_VERSION="11.10.0"
+PKG_SHA256="8ffc19c435232d09299dd2c91e247292b3508c1b826a3497c60682e4bbf2d602"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-headers/package.mk
+++ b/packages/graphics/vulkan/spirv-headers/package.mk
@@ -4,10 +4,10 @@
 
 PKG_NAME="spirv-headers"
 # The SPIRV-Headers have to be specific versions matching the glslang pkg version
-# https://github.com/KhronosGroup/glslang/blob/11.9.0/known_good.json
+# https://github.com/KhronosGroup/glslang/blob/11.10.0/known_good.json
 # if you update glslang make sure spirv-tools & spirv-headers versions a known good
-PKG_VERSION="4995a2f2723c401eb0ea3e10c81298906bf1422b"
-PKG_SHA256="2c9fe1bbd74a74fdabe40a7ffb322527dfc008c79e1d19d3cf41a5f006d9ab60"
+PKG_VERSION="5a121866927a16ab9d49bed4788b532c7fcea766"
+PKG_SHA256="ec8ecb471a62672697846c436501638ab25447ae9d4a6761e0bfe8a9a839502a"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-tools/package.mk
+++ b/packages/graphics/vulkan/spirv-tools/package.mk
@@ -4,10 +4,10 @@
 
 PKG_NAME="spirv-tools"
 # The SPIRV-Tools have to be specific versions matching the glslang pkg version
-# https://github.com/KhronosGroup/glslang/blob/11.9.0/known_good.json
+# https://github.com/KhronosGroup/glslang/blob/11.10.0/known_good.json
 # if you update glslang make sure spirv-tools & spirv-headers versions a known good
-PKG_VERSION="eed5c76a57bb965f2e1b56d1dc40b50910b5ec1d"
-PKG_SHA256="9697fcdab26b2622bf81a8d81f9ebc6cab5a5a7ac32b0eb61e51684a5627a4b6"
+PKG_VERSION="b930e734ea198b7aabbbf04ee1562cf6f57962f0"
+PKG_SHA256="9cddc845f99d7daa65940ff9deb6754cd71b67987ec9860bb0ef2af8a8732c84"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.215"
-PKG_SHA256="c9a310f30533484d3832162416aa5c3a64101defc3e20bb4316e78b396bec85c"
+PKG_VERSION="1.3.216"
+PKG_SHA256="93f9a70ed9e956f3e0a1b41b71b6d030428cc3509e7e2b38d0ea6ba89b09f71e"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.215"
-PKG_SHA256="025094bec7ffc80736236465a06be9f0b64e3a478558142c69f10da576d610d3"
+PKG_VERSION="1.3.216"
+PKG_SHA256="006de2ee5bad4ef797ce4c25df166e09f2e5dd136e99cb507da313aa86770c00"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.215"
-PKG_SHA256="2b169514400d048abf7f60cbc3a3cd2f370b92621a3b7427272480ecb05eab3a"
+PKG_VERSION="1.3.216"
+PKG_SHA256="753c03878bb9e9926913d6d22096fbd44bff221af0b2173b81c1189748a8f71b"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- https://github.com/KhronosGroup/Vulkan-Docs/commit/899dd1c16d5de69bd24e108f393d134fa2989512

Packages
- Vulkan updated to 1.3.216
- spirv-tools: update githash to 2022-06-01
- spirv-headers: update githash to 2022-05-26
- glslang: update to 11.10.0