### PR TITLE
openvpn: update to 2.5.7

### DIFF
--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.5.6"
-PKG_SHA256="333a7ef3d5b317968aca2c77bdc29aa7c6d6bb3316eb3f79743b59c53242ad3d"
+PKG_VERSION="2.5.7"
+PKG_SHA256="08340a389905c84196b6cd750add1bc0fa2d46a1afebfd589c24120946c13e68"
 PKG_LICENSE="GPL"
 PKG_SITE="https://openvpn.net"
 PKG_URL="https://swupdate.openvpn.org/community/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
https://openvpn.net/community-downloads/

The OpenVPN community project team is proud to release OpenVPN 2.5.7.
This is mostly a bugfix release, but adds limited support for OpenSSL
3.0. Full support will arrive in OpenVPN 2.6.