### PR TITLE
[le11] btrfs-progs: update to 5.18

### DIFF
--- a/packages/addons/tools/btrfs-progs/changelog.txt
+++ b/packages/addons/tools/btrfs-progs/changelog.txt
@@ -1,3 +1,6 @@
+107
+- update to 5.18
+
 106
 - update to 5.17
 

--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="btrfs-progs"
-PKG_VERSION="5.17"
-PKG_SHA256="a43aa58b06b025d205dc788522daab1b615b482497c05641261d0c02f16a4ad4"
-PKG_REV="106"
+PKG_VERSION="5.18"
+PKG_SHA256="881c7382846e37a72e46d65dc71e6b2ba1457c4b0b7af5faab2dd38f502ed5d8"
+PKG_REV="107"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.wiki.kernel.org/index.php/Main_Page"


### PR DESCRIPTION
changelog:
- https://github.com/kdave/btrfs-progs/blob/master/CHANGES

```
btrfs-progs-5.18 (2022-05-25)
-----------------------------
   * fixes:
      * dump-tree: don't print traling zeros in checksums
      * recognize paused balance as exclusive operation state, allow to start
        device add
      * convert: properly initialize target filesystem label
      * mkfs: don't create free space bitmaps for empty filesystem
   * restore: make lzo support build-time configurable, print supported
     compression in help text
   * update kernel-lib sources
   * other:
      * documentation updates, finish conversion to RST, CHANGES and INSTALL
        could be included into RST
      * fix build detection of experimental mode
      * new tests
```