### PR TITLE
[le11] repository.linuxserver.docker: new style

### DIFF
--- a/packages/addons/repository/repository.linuxserver.docker/changelog.txt
+++ b/packages/addons/repository/repository.linuxserver.docker/changelog.txt
@@ -1,3 +1,6 @@
+103
+- bump addon rev for new format
+
 101
 - Change repo location for zips
 

--- a/packages/addons/repository/repository.linuxserver.docker/package.mk
+++ b/packages/addons/repository/repository.linuxserver.docker/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="repository.linuxserver.docker"
 PKG_VERSION="9.0"
-PKG_REV="102"
+PKG_REV="103"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://linuxserver.io"


### PR DESCRIPTION
update to activate:
- kodi: ls.io repository update to new style - 526945a9308

fixes
```
2022-06-04 13:37:46.174 T:80474   ERROR <general>: Repository add-on repository.linuxserver.docker uses old schema definition for the repository extension point! This is no longer supported, please update your addon to use <dir> definitions.
2022-06-04 13:37:46.174 T:80474   ERROR <general>: Repository add-on repository.linuxserver.docker does not have any directory and won't be able to update/serve addons! Please fix the addon.xml definition
```
