### PR TITLE
[le11] docker: update addon to (135)

### DIFF
--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -3,17 +3,17 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.5.6"
-PKG_SHA256="144612f9400c2fc52b2abc7b1ef33bf708d322dad9b3afdc1ae9d02fa034753b"
+PKG_VERSION="1.6.5"
+PKG_SHA256="f7fe74839b470a38230fac0a3c51c387cdd6846692bce00eec530bbe5ff0a86f"
 PKG_LICENSE="APL"
-PKG_SITE="https://containerd.tools/"
+PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain go:host"
 PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-PKG_GIT_COMMIT="1a1b383ad5b520349f13f9715e0cd1e2f132c087"
+PKG_GIT_COMMIT="8686ededfc90076914c5238eb96c883ea093a8ba"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/libnetwork/package.mk
+++ b/packages/addons/addon-depends/libnetwork/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnetwork"
-PKG_VERSION="64b7a4574d1426139437d20e81c0b6d391130ec8" # 2021-05-25
-PKG_SHA256="ede21e645ff6552b3a508f6186d3f34d267015ec0f96eefecf6d08c03cbd2987"
+PKG_VERSION="339b972b464ee3d401b5788b2af9e31d09d6b7da" # 2022-03-16
+PKG_SHA256="335851e924078a8e274f0c27cb80aaba32d0c1059068740496f1eb31b55a6ec4"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/docker/libnetwork"
 PKG_URL="https://github.com/docker/libnetwork/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.0.2"
-PKG_SHA256="6c3cca4bbeb5d9b2f5e3c0c401c9d27bc8a5d2a0db8a2f6a06efd03ad3c38a33"
+PKG_VERSION="1.1.2"
+PKG_SHA256="0ccce82b1d9c058d8fd7443d261c96fd7a803f2775bcb1fec2bdb725bc7640f6"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,8 @@
+135
+- containerd: update to 1.6.5
+- libnetwork: update to 2022-03-16
+- runc: update to 1.1.2
+
 134
 - containerd: update to 1.5.6
 - libnetwork: update to 2021-05-25

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="docker"
 PKG_VERSION="19.03.15"
 PKG_SHA256="f2f31dd4137eaa735a26e590c9718fb06867afff4d8415cc80feb6cdc9e4a8cd"
-PKG_REV="134"
+PKG_REV="135"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
- containerd: update to 1.6.5
- libnetwork: update to 2022-03-16
- runc: update to 1.1.2

```
# docker version
Client:
 Version:           19.03.15
 API version:       1.40
 Go version:        go1.18.3
 Git commit:        99e3ed89195c4e551e87aad1e7453b65456b03ad
 Built:             Thu Jun  2 13:43:33 UTC 2022
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          19.03.15
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.18.3
  Git commit:       99e3ed89195c4e551e87aad1e7453b65456b03ad
  Built:            Thu Jun  2 13:43:33 UTC 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.4
  GitCommit:        8686ededfc90076914c5238eb96c883ea093a8ba
 runc:
  Version:          1.1.2
  GitCommit:        2c7861bc5e1b3e756392236553ec14a78a09f8bf
 docker-init:
  Version:          0.19.0
  GitCommit:
```