### PR TITLE
[le10] docker: update addon to (134)

### DIFF
--- a/packages/addons/addon-depends/containerd/package.mk
+++ b/packages/addons/addon-depends/containerd/package.mk
@@ -3,17 +3,17 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.3.9"
-PKG_SHA256="9244212589c84b12262769dca6fb985c0c680cb5259c8904b29c511d81fd62d0"
+PKG_VERSION="1.6.6"
+PKG_SHA256="27afb673c20d53aa5c31aec07b38eb7e4dc911e7e1f0c76fac9513bbf070bd24"
 PKG_LICENSE="APL"
-PKG_SITE="https://containerd.tools/"
+PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain go:host"
 PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-PKG_GIT_COMMIT="8fba4e9a7d01810a393d5d25a3621dc101981175"
+PKG_GIT_COMMIT="10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/libnetwork/package.mk
+++ b/packages/addons/addon-depends/libnetwork/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnetwork"
-PKG_VERSION="a543cbc4871f904b0efe205708eb45d72e65fd8b"
-PKG_SHA256="3e3b0048aa468de0fe33ad2c08bf3891ac1a72fca434f92620312da51f344488"
+PKG_VERSION="339b972b464ee3d401b5788b2af9e31d09d6b7da" # 2022-03-16
+PKG_SHA256="335851e924078a8e274f0c27cb80aaba32d0c1059068740496f1eb31b55a6ec4"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/docker/libnetwork"
 PKG_URL="https://github.com/docker/libnetwork/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.0.0-rc93"
-PKG_SHA256="e42456078d2f76c925cdd656e4f423b918525d8188521de05e893b6bb473a6f8"
+PKG_VERSION="1.1.3"
+PKG_SHA256="fc1c70e095d662e38a5889bc6de41857762ce022caaf8be2852663198c533a63"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-PKG_GIT_COMMIT="12644e614e25b05da6fd08a38ffa0cfe1903fdec"
+PKG_GIT_COMMIT="6724737f999df9ee0d8ca5c6d7b81f97adc34374"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,8 @@
+134
+- containerd: update to 1.6.6
+- libnetwork: update to 2022-03-16
+- runc: update to 1.1.3
+
 133
 - Update to docker 19.03.15
 - runc: update to 1.0.0-rc93

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="docker"
 PKG_VERSION="19.03.15"
 PKG_SHA256="f2f31dd4137eaa735a26e590c9718fb06867afff4d8415cc80feb6cdc9e4a8cd"
-PKG_REV="133"
+PKG_REV="134"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
- backport of #6563 and #6582

Packages updates:
- containerd: update to 1.6.6
- libnetwork: update to 2022-03-16
- runc: update to 1.1.3