### PR TITLE
[le11] btrfs-progs: update to 5.18.1

### DIFF
--- a/packages/addons/tools/btrfs-progs/changelog.txt
+++ b/packages/addons/tools/btrfs-progs/changelog.txt
@@ -1,3 +1,6 @@
+108
+- update to 5.18.1
+
 107
 - update to 5.18
 

--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="btrfs-progs"
-PKG_VERSION="5.18"
-PKG_SHA256="881c7382846e37a72e46d65dc71e6b2ba1457c4b0b7af5faab2dd38f502ed5d8"
-PKG_REV="107"
+PKG_VERSION="5.18.1"
+PKG_SHA256="8a8ad6bc2b5ccd870fa2b18a822ef354222c8d06b1ca98bf81d9da68bd9df2b3"
+PKG_REV="108"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.wiki.kernel.org/index.php/Main_Page"


### PR DESCRIPTION
[btrfs-progs-5.18.1 (2022-06-06)](https://btrfs.readthedocs.io/en/latest/CHANGES.html#btrfs-progs-5-18-1-2022-06-06)

Minors:
- fixes:
  - convert: fix self reference of toplevel directory

  - build: make kernel lib headers compatible with C++

- zoned mode: verify minimum zone size 4MiB

- libbtrfs: clean-ups, merge headers and remove declarations of unexported symbols

- other: documentation updates