### PR TITLE
[le11] wireless-regdb: update to 2022.06.06

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2022.04.08"
-PKG_SHA256="884ba2e3c1e8b98762b6dc25ff60b5ec75c8d33a39e019b3ed4aa615491460d3"
+PKG_VERSION="2022.06.06"
+PKG_SHA256="ac00f97efecce5046ed069d1d93f3365fdf994c7c7854a8fc50831e959537230"
 PKG_LICENSE="GPL"
 PKG_SITE="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- wireless-regdb: update regulatory database based on preceding changes
- wireless-regdb: Unify 6 GHz rules for EU contries
- wireless-regdb: Remove AUTO-BW from 6 GHz rules
- wireless-regdb: update regulatory rules for Bulgaria (BG) on 6GHz
- Regulatory update for 6 GHz operation in FI
- Regulatory update for 6 GHz operation in United States (US)
- Regulatory update for 6 GHz operation in Canada (CA)