### PR TITLE
systemd: use unified cgroups

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -15,7 +15,7 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Drootprefix=/usr \
                        -Dsplit-usr=false \
                        -Dsplit-bin=true \
-                       -Ddefault-hierarchy=hybrid \
+                       -Ddefault-hierarchy=unified \
                        -Dtty-gid=5 \
                        -Dtests=false \
                        -Dseccomp=false \


### PR DESCRIPTION
This enables use of cgroups v2 by default. I believe the only reason we needed the legacy version was because of docker. Docker needs to be at least 20.10 to use cgroups v2. The PR is in at #6577 

ref:
https://www.phoronix.com/scan.php?page=news_item&px=Ubuntu-21.10-systemd-cgroup
https://wiki.archlinux.org/title/cgroups
https://systemd.io/CGROUP_DELEGATION/
https://docs.docker.com/engine/release-notes/#20100
