### PR TITLE
[RFC] use kconfig for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ tools/mkpkg/*.git
 
 # ignore old linux configs
 projects/**/*.old
+
+# build configs
+*.config*

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Team LibreELEC (https://libreelec.tv)
+
+mainmenu "LibreELEC Configuration"
+
+source "config/Kconfig"

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,9 @@ distclean:
 
 src-pkg:
 	tar cvJf sources.tar.xz sources
+
+menuconfig:
+	./scripts/make_config menuconfig
+
+olddefconfig:
+	./scripts/make_config olddefconfig

--- a/config/Kconfig
+++ b/config/Kconfig
@@ -1,0 +1,558 @@
+menu "Basic Options"
+
+config DISTRO
+	string "Distro to use"
+	option env="DISTRO"
+	default "LibreELEC"
+
+config PROJECT
+	string "Project to build"
+	option env="PROJECT"
+	default "Generic"
+
+config DEVICE
+	string "Device to build"
+	option env="DEVICE"
+	default "Generic" if PROJECT = "Generic"
+
+config ARCH
+	string "Arch to build for"
+	option env="ARCH"
+	default "x86_64" if PROJECT = "Generic"
+
+endmenu
+
+menu "Distro Features"
+
+config DISTRONAME
+	string "Distro Name"
+	default ""
+	help
+	  Name of the Distro to build (full name, without special characters)
+
+config DESCRIPTION
+	string "Project Description"
+	default ""
+	help
+	  short project description
+
+config GREETING0
+	string "Greeting Line 0"
+	default ""
+
+config GREETING1
+        string "Greeting Line 1"
+        default ""
+
+config GREETING2
+        string "Greeting Line 2"
+        default ""
+
+config GREETING3
+        string "Greeting Line 3"
+        default ""
+
+config GREETING4
+        string "Greeting Line 4"
+        default ""
+
+config ROOT_PASSWORD
+	string "Root Password"
+	default ""
+	help
+	  Root password to integrate in the target system
+
+config DISTRO_BOOTLABEL
+	string "Boot Partition Label"
+	default "boot"
+
+config DISTRO_DISKLABEL
+	string "Disk Partition Label"
+	default "disk"
+
+endmenu
+
+menu "Buildsystem Settings"
+
+config LTO_SUPPORT
+	string "LTO (Link Time Optimization) support"
+	default "yes"
+
+config GOLD_SUPPORT
+	string "GOLD (Google Linker) support"
+	default "yes"
+
+config HARDENING_SUPPORT
+	string "Extra hardening options"
+	default "no"
+	help
+	  HARDENING (security relevant linker and compiler flags) support
+
+config GET_HANDLER_SUPPORT
+	string "Default supported get handlers"
+	default "archive"
+
+config CCACHE_CACHE_SIZE
+	string "ccache cache size"
+	default "10G"
+	help
+	  Set the maximum size of the files stored in the cache. You can specify a
+          value in gigabytes, megabytes or kilobytes by appending a G, M or K to the
+          value. The default is gigabytes. The actual value stored is rounded down to
+          the nearest multiple of 16 kilobytes.  Keep in mind this per project .ccache
+          directory.
+
+config VERBOSE
+	string "increase build verbosity"
+	default "yes"
+
+config LOCAL_CC
+	string "local CC"
+	default "$(shell,command -v gcc)"
+
+config LOCAL_CXX
+	string "local CXX"
+	default "$(shell,command -v g++)"
+
+config DISTRO_SRC
+	string "distro source url"
+	default "http://sources.libreelec.tv/$LIBREELEC_VERSION"
+
+config DISTRO_MIRROR
+	string "distro source mirror url"
+	default "http://sources.libreelec.tv/mirror"
+
+endmenu
+
+menu "OS Features"
+
+config ARM_MEM_SUPPORT
+	string "build and install arm-mem support"
+	default "yes" if ARCH = "arm"
+
+config GLIBC_LOCALES
+	string "Install glibc locales to the build"
+	default "yes"
+
+config ADDITIONAL_DRIVERS
+	string "additional drivers to install"
+	default ""
+	help
+	  for a list of additional drivers see packages/linux-drivers.
+          Space separated list is supported.
+
+config ADDITIONAL_DRIVERS_PROJECT
+	string "additional drivers to install (project specific)"
+	default ""
+	help
+          for a list of additional drivers see packages/linux-drivers.
+          Space separated list is supported.
+
+config SYSTEM_SIZE
+	string "System Partition Size in Mega Bytes"
+	default "512"
+	help
+	  Default size of system partition, in MB, eg. 512
+
+config SYSTEM_PART_START
+	string "System Partition Offset"
+	default "8192"
+	help
+	  Default system partition offset, in sectors, eg. 2048
+
+config SWAP_SUPPORT
+	string "Swap Support"
+	default "yes"
+
+config SWAP_ENABLED_DEFAULT
+	string "Swap Support Enabled"
+	default "no"
+	depends on SWAP_SUPPORT = "yes"
+
+config SWAPFILESIZE
+	string "Swap File Size in MB"
+	default "128"
+	depends on SWAP_SUPPORT = "yes"
+
+config DEBUG_TTY
+	string "Debug TTY Path"
+	default ""
+
+endmenu
+
+config MEDIACENTER
+	string "Mediacenter to use"
+	default "kodi"
+
+if MEDIACENTER = kodi
+
+menu "Kodi Settings"
+
+config SKINS
+	string "Skins to install"
+	default "Estuary"
+	help
+	  Space separated list is supported
+
+config SKIN_DEFAULT
+	string "Default Skin"
+	default "Estuary"
+
+config KODI_EXTRA_FONTS
+	string "install extra subtitle Fonts for KODI"
+	default "yes"
+
+config KODI_ALSA_SUPPORT
+	string "build kodi with alsa support"
+	default "yes"
+
+config KODI_PULSEAUDIO_SUPPORT
+	string "build kodi with pulseaudio support"
+	default "yes"
+
+config KODI_PIPEWIRE_SUPPORT
+	string "build kodi with pipewire support"
+	default "no"
+
+config KODI_BLURAY_SUPPORT
+	string "Enable BluRay support"
+	default "yes"
+	help
+	  "build and install with BluRay support"
+
+config BLURAY_BDPLUS_SUPPORT
+	string "Enable BD+ Support"
+	default "yes"
+	depends on KODI_BLURAY_SUPPORT = "yes"
+	help
+	  "build and install with BD+ support"
+
+config BLURAY_AACS_SUPPORT
+	string "Enable Bluray AACS Support"
+	default "yes"
+	depends on KODI_BLURAY_SUPPORT = "yes"
+	help
+	  build and install with AACS support
+
+config KODI_DVDCSS_SUPPORT
+	string "Enable dvdcss Support"
+	default "yes"
+	help
+	  build and install with DVDCSS support
+
+config KODI_WEBSERVER_SUPPORT
+	string "Enable Kodi webserver"
+	default "yes"
+	help
+	  build and install with KODI webfrontend
+
+config KODI_UPNP_SUPPORT
+	string "Enable Kodi UPnP Support"
+	default "yes"
+	help
+	  build with UPnP support
+
+config KODI_MYSQL_SUPPORT
+	string "Enable mysql support"
+	default "mariadb"
+	help
+	  build with MySQL support
+
+config KODI_OPTICAL_SUPPORT
+	string "Enable Kodi optical drive support"
+	default "yes"
+
+config KODI_AIRPLAY_SUPPORT
+	string "Enable Kodi airplay support"
+	default "yes"
+	help
+	  build with AirPlay support (stream videos from iDevices to KODI
+
+config KODI_AIRTUNES_SUPPORT
+	string "Enable Kodi airtunes support"
+	default "yes"
+	help
+	  build with AirTunes support (stream music from iDevices to KODI)
+
+config KODI_NFS_SUPPORT
+	string "Enable Kodi NFS support"
+	default "yes"
+	help
+	  build with libnfs support (mounting nfs shares with KODI)
+
+config KODI_SAMBA_SUPPORT
+	string "Enable Kodi SMB support"
+	default "yes"
+	help
+	  build with Samba Client support (mounting SAMBA shares with KODI)
+
+config DISTRO_PKG_SETTINGS
+	string "distro settings package"
+	default "LibreELEC-settings"
+
+config DISTRO_PKG_SETTINGS_ID
+	string "distro settings add-on id"
+	default "service.libreelec.settings"
+
+endmenu
+
+endif # MEDIACENTER = kodi
+
+menu "Package Features"
+
+config ALSA_SUPPORT
+	string "ALSA Support"
+	default "yes"
+	help
+	  This option enables alsa support
+
+config BLUETOOTH_SUPPORT
+	string "Bluetooth Support"
+	default "yes"
+	help
+	  This option enables bluetooth support
+
+config PULSEAUDIO_SUPPORT
+	string "Pulseaudio Support"
+	default "yes"
+	help
+	  build and install PulseAudio support
+
+config PIPEWIRE_SUPPORT
+	string "pipewire support"
+	default "no"
+	help
+	  build and install pipewire support
+
+config ESPEAK_SUPPORT
+	string "Espeak Support"
+	default "no"
+	help
+	  build and install eSpeak-NG support
+
+config AVAHI_DAEMON
+	string "Avahi Support"
+	default "yes"
+	help
+	  build and install Avahi Support
+
+config WIRELESS_DAEMON
+	string "Wireless daemon to use"
+	default "iwd"
+
+config ISCSI_SUPPORT
+	string "build and install iscsi support"
+	default "no"
+
+config NFS_SUPPORT
+	string "build with NFS support"
+	default "yes"
+	help
+	  build with NFS support (mounting nfs shares via the OS)
+
+config SAMBA_SUPPORT
+	string "build with SMB support"
+	default "yes"
+	help
+	  build with Samba Client support (mounting samba shares via the OS)
+
+config SAMBA_SERVER
+	string "build and install samba server"
+	default "yes"
+	depends on SAMBA_SUPPORT = "yes"
+
+config SFTP_SERVER
+	string "build and install sftp server"
+	default "yes"
+
+config OPENVPN_SUPPORT
+	string "build and install openvpn support"
+	default "yes"
+
+config WIREGUARD_SUPPORT
+	string "build and install wireguard support"
+	default "yes"
+
+config UDEVIL
+	string "build and install diskmounter support"
+	default "yes"
+	help
+	  this service provide auto mounting support for external drives in the mediacenter also automount internally drives at boottime via udev
+
+config INITRAMFS_PARTED_SUPPORT
+	string "Install parted in initramfs"
+	default "no"
+	help
+	  Support for partitioning and formating disks in initramfs
+	  This adds support for parted and mkfs.ext3/4 to initramfs for OEM usage
+
+config HFSTOOLS
+	string "build and install hfs filesystem utilities"
+	default "yes"
+
+config NANO_EDITOR
+	string "build and install nano text editor"
+	default "yes"
+
+config CRON_SUPPORT
+	string "cron support"
+	default "yes"
+
+config INSTALLER_SUPPORT
+	string "build with installer"
+	default "yes"
+
+config REMOTE_SUPPORT
+	string "build and install remote support"
+	default "yes"
+
+config IR_REMOTE_KEYMAPS
+	string "ir remote keymaps supported in default config"
+	default "rc6_mce xbox_360 xbox_one"
+
+config JOYSTICK_SUPPORT
+	string "build and install joystick support"
+	default "yes"
+
+config CEC_SUPPORT
+	string "build and install CEC adapter support"
+	default "yes"
+
+config CEC_FRAMEWORK_SUPPORT
+	string "build and install CEC framework support"
+	default "no"
+
+config OEM_SUPPORT
+	string "Install OEM packages"
+	default "no"
+
+config ADDITIONAL_PACKAGES
+	string "additional packages to install"
+	help
+	  Space separated list is supported
+
+endmenu
+
+menu "Device Options"
+
+config ADDON_PROJECT
+	string "Addon project"
+
+config ATF_PLATFORM
+	string "ATF Platform"
+
+config BOOTLOADER
+	string "Bootloader"
+
+config DISPLAYSERVER
+	string "Displayserver"
+
+config DRIVER_ADDONS
+	string "Driver add-ons"
+
+config DRIVER_ADDONS_SUPPORT
+	string "Enable driver add-ons"	
+
+config EXTRA_CMDLINE
+	string "Extra cmdline params"
+
+config FIRMWARE
+	string "firmware"
+
+config FIRMWARE_DEVICE
+	string "device specific firmware packages"
+
+config GRAPHIC_DRIVERS
+	string "Graphic Drivers"
+
+config KERNEL_EXTRA_DEPENDS_TARGET
+	string "kernel extra depends"
+
+config KERNEL_MAKE_EXTRACMD
+	string "kernel make extra"
+
+config KERNEL_NAME
+	string "Project Specfic linux kernel name"
+	default "KERNEL"
+
+config KERNEL_TARGET
+	string "Kernel Target"
+
+config KERNEL_UIMAGE_ENTRYADDR
+	string "Kernel uImage entry address"
+
+config KERNEL_UIMAGE_LOADADDR
+	string "Kernel uImage load address"
+
+config KODIPLAYER_DRIVER
+	string "Kodi player driver"
+
+config LINUX
+	string "Project Specfic linux version name"
+
+config MALI_FAMILY
+	string "Mali family"
+
+config NOOBS_HEX
+	string "Noobs hex"
+
+config NOOBS_SUPPORTED_MODELS
+	string "Noobs supported models"
+
+config OPENGL
+	string "OpenGL Support"
+	default "no"
+
+config OPENGLES
+	string "OpenGLES Support"
+	default "no"
+
+config OVA_SIZE
+	string "OVA size"
+	default "4096"
+
+config PROJECT_CFLAGS
+	string "Project specific CFLAGS"
+
+config SQUASHFS_COMPRESSION
+	string "SquashFS compression Method"
+
+config TARGET_KERNEL_PATCH_ARCH
+	string "Target kernel patch arch"
+
+config UBOOT_FIRMWARE
+	string "u-boot firmware"
+
+config UBOOT_TARGET
+	string "u-boot target"
+
+config UVESAFB_SUPPORT
+	string "uvesafb support"
+
+config VULKAN
+        string "Vulkan Support"
+	default "no"
+
+config WINDOWMANAGER
+	string "WindowManager"
+
+endmenu
+
+menu "Arch Configuration"
+
+config TARGET_CPU
+        string "Target CPU"
+
+config TARGET_CPU_FLAGS
+        string "Target CPU Flags"
+
+config TARGET_FLOAT
+        string "Target Float"
+
+config TARGET_FPU
+        string "Target FPU"
+
+config TARGET_KERNEL_ARCH
+        string "Target Kernel Arch"
+
+endmenu

--- a/config/options
+++ b/config/options
@@ -15,32 +15,8 @@ fi
 # set default language for buildsystem
 export LC_ALL=C
 
-# set default independent variables
-ROOT="${PWD}"
-DISTRO_DIR="${ROOT}/distributions"
-PROJECT_DIR="${ROOT}/projects"
-
-# determines DISTRO, if not forced by user
-DISTRO="${DISTRO:-LibreELEC}"
-
-# determines PROJECT, if not forced by user
-export PROJECT="${PROJECT:-Generic}"
-
-# default to Generic device if building Generic project without device set
-if [ "${PROJECT}" = "Generic" -a -z "${DEVICE}" ]; then
-  export DEVICE="Generic"
-fi
-
-# determines TARGET_ARCH, if not forced by user
-export ARCH="${ARCH:-x86_64}"
-TARGET_ARCH="${ARCH}"
-
-# include arm-mem package on arm
-if [ "${TARGET_ARCH}" = "arm" ]; then
-  ARM_MEM_SUPPORT="yes"
-else
-  ARM_MEM_SUPPORT="no"
-fi
+# include required variables
+. config/required_options
 
 # include helper functions
 . config/functions
@@ -48,60 +24,33 @@ fi
 # read DISTRO version information
 . "${DISTRO_DIR}/${DISTRO}/version" || die "\nERROR: No distro version present\n"
 
-# read DISTRO options
-if [ -f "${DISTRO_DIR}/${DISTRO}/options" ]; then
-  . "${DISTRO_DIR}/${DISTRO}/options"
+if [ ! -f "${ROOT}/${DISTRO}-${PROJECT}-${DEVICE}-${TARGET_ARCH}.config" ]; then
+  ${ROOT}/scripts/make_config olddefconfig
 fi
 
-# read PROJECT options
-if [ -f "${PROJECT_DIR}/${PROJECT}/options" ]; then
-  . "${PROJECT_DIR}/${PROJECT}/options"
-fi
+. "${ROOT}/${DISTRO}-${PROJECT}-${DEVICE}-${TARGET_ARCH}.config"
 
-# read DEVICE options
-if [ -f "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/options" ]; then
-  . "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/options"
-fi
-
-# read architecture defaults
+# read architecture defaults  
 if [ -f "config/arch.${TARGET_ARCH}" ]; then
   . "config/arch.${TARGET_ARCH}"
 fi
 
-# projects can set KERNEL_NAME (kernel.img)
-KERNEL_NAME="${KERNEL_NAME:-KERNEL}"
+if [ -n "${FIRMWARE_DEVICE}" ]; then
+  FIRMWARE="${FIRMWARE} ${FIRMWARE_DEVICE}"
+fi
+
+if [ -n "${ADDITIONAL_DRIVERS_PROJECT}" ]; then
+  ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS} ${ADDITIONAL_DRIVERS_PROJECT}"
+fi
 
 LINUX_DEPENDS="${PROJECT_DIR}/${PROJECT}/linux ${PROJECT_DIR}/${PROJECT}/patches/linux ${PROJECT_DIR}/${PROJECT}/packages/linux ${ROOT}/packages/linux"
 [ -n "${DEVICE}" ] && LINUX_DEPENDS+=" ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/linux ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/patches/linux ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/packages/linux"
-
-# Need to point to your actual cc
-# If you have ccache installed, take care that LOCAL_CC does not point to it
-[ -z "${LOCAL_CC}" ] && export LOCAL_CC="$(command -v gcc)"
-
-if [ -z "${LOCAL_CC}" ]; then
-  die "***** Please install gcc - run scripts/checkdeps *****" "127"
-fi
-
-# Need to point to your actual g++
-# If you have ccache installed, take care that LOCAL_CXX does not point to it
-[ -z "${LOCAL_CXX}" ] && export LOCAL_CXX="$(command -v g++)"
-
-# verbose compilation mode (yes/no)
-VERBOSE="${VERBOSE:-yes}"
 
 # Concurrency make level (-j option)
 #  Try values between 1 and number of processor cores present.
 #  default: use all cores
 [ -z "${CONCURRENCY_MAKE_LEVEL}" ] && export CONCURRENCY_MAKE_LEVEL=$(nproc)
 [ -z "${CONCURRENCY_LOAD}" ] && export CONCURRENCY_LOAD=$(python3 -c "import os; print(f'{os.cpu_count() * 1.5:.2f}')")
-
-# cache size for ccache
-# Set the maximum size of the files stored in the cache. You can specify a
-# value in gigabytes, megabytes or kilobytes by appending a G, M or K to the
-# value. The default is gigabytes. The actual value stored is rounded down to
-# the nearest multiple of 16 kilobytes.  Keep in mind this per project .ccache
-# directory.
-CCACHE_CACHE_SIZE="10G"
 
 # set addon paths
 if [ -z "$ADDON_PATH" ]; then
@@ -115,20 +64,18 @@ if [ -z "$ADDON_URL" ]; then
   ADDON_URL="$ADDON_SERVER_URL/$ADDON_PATH"
 fi
 
-# read local persistent options from $ROOT if available
-if [ -f "${ROOT}/.libreelec/options" ]; then
-  . "${ROOT}/.libreelec/options"
-fi
-
-# read global persistent options from $HOME if available
-if [ -f "${HOME}/.libreelec/options" ]; then
-  . "${HOME}/.libreelec/options"
-fi
-
 # overwrite OEM_SUPPORT via commandline
 if [ "${OEM}" = "yes" -o "${OEM}" = "no" ]; then
   OEM_SUPPORT="${OEM}"
 fi
+
+if [ -z "${LOCAL_CC}" ]; then
+  die "***** Please install gcc - run scripts/checkdeps *****" "127"
+fi
+
+# Need to point to your actual g++
+# If you have ccache installed, take care that LOCAL_CXX does not point to it
+[ -z "${LOCAL_CXX}" ] && export LOCAL_CXX="$(command -v g++)"
 
 check_config
 

--- a/config/path
+++ b/config/path
@@ -79,7 +79,7 @@ export BUILD_INDENT_SIZE=4
 SILENT_OUT=3
 VERBOSE_OUT=4
 
-if [ "$VERBOSE" = "yes" ]; then
+if [ "$VERBOSE" = yes ]; then
   exec 3>&1
   exec 4>&1
 else

--- a/config/path
+++ b/config/path
@@ -79,7 +79,7 @@ export BUILD_INDENT_SIZE=4
 SILENT_OUT=3
 VERBOSE_OUT=4
 
-if [ "$VERBOSE" = yes ]; then
+if [ "$VERBOSE" = "yes" ]; then
   exec 3>&1
   exec 4>&1
 else

--- a/config/required_options
+++ b/config/required_options
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# set default independent variables
+ROOT="${PWD}"
+DISTRO_DIR="${ROOT}/distributions"
+PROJECT_DIR="${ROOT}/projects"
+
+# determines DISTRO, if not forced by user
+export DISTRO="${DISTRO:-LibreELEC}"
+
+# determines PROJECT, if not forced by user
+export PROJECT="${PROJECT:-Generic}"
+
+# default to Generic device if building Generic project without device set
+if [ "${PROJECT}" = "Generic" -a -z "${DEVICE}" ]; then
+  export DEVICE="Generic"
+fi
+
+# determines TARGET_ARCH, if not forced by user
+export ARCH="${ARCH:-x86_64}"
+TARGET_ARCH="${ARCH}"

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -1,246 +1,60 @@
-### DISTRO INFORMATION ###
-
-# Name of the Distro to build (full name, without special characters)
-  DISTRONAME="LibreELEC"
-
-# short project description
-  DESCRIPTION="LibreELEC is a fast and user-friendly Kodi Entertainment Center distribution."
-
-
-### USER INTERFACE SETTINGS ###
-
-# Welcome Message for e.g. SSH Server (up to 5 Lines)
-  GREETING0="##############################################"
-  GREETING1="#                 LibreELEC                  #"
-  GREETING2="#            https://libreelec.tv            #"
-  GREETING3="##############################################"
-  GREETING4=""
-
-# Root password to integrate in the target system
-  ROOT_PASSWORD="libreelec"
-
-# Partition labels for USB/SD installation media
-  DISTRO_BOOTLABEL="LIBREELEC"
-  DISTRO_DISKLABEL="STORAGE"
-
-
-### BUILDSYSTEM SETTINGS ####
-
-# LTO (Link Time Optimization) support
-  LTO_SUPPORT="yes"
-
-# GOLD (Google Linker) support
-  GOLD_SUPPORT="yes"
-
-# HARDENING (security relevant linker and compiler flags) support
-  HARDENING_SUPPORT="no"
-
-# Default supported get handlers (archive, git, file etc.)
-  GET_HANDLER_SUPPORT="archive"
-
-
-### OS CONFIGURATION ###
-
-# Install glibc locales to the build (yes / no)
-  GLIBC_LOCALES="yes"
-
-# additional drivers to install:
-# for a list of additional drivers see packages/linux-drivers
-# Space separated list is supported,
-# e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192DU RTL8812AU"
-
-# Default size of system partition, in MB, eg. 512
-  SYSTEM_SIZE=512
-
-# Default system partition offset, in sectors, eg. 2048
-  SYSTEM_PART_START=8192
-
-# build with swap support (yes / no)
-  SWAP_SUPPORT="yes"
-
-# swap support enabled per default (yes / no)
-  SWAP_ENABLED_DEFAULT="no"
-
-# swapfile size if SWAP_SUPPORT=yes in MB
-  SWAPFILESIZE="128"
-
-# debug tty path
-  DEBUG_TTY="/dev/tty3"
-
-
-### KODI SETTINGS ###
-# Mediacenter to use (kodi / no)
-  MEDIACENTER="kodi"
-
-# Skins to install (Estuary)
-# Space separated list is supported,
-# e.g. SKINS="Estuary"
-  SKINS="Estuary"
-
-# Default Skin (Estuary)
-  SKIN_DEFAULT="Estuary"
-
-# install extra subtitle Fonts for KODI (yes / no)
-  KODI_EXTRA_FONTS="yes"
-
-# build and install PulseAudio support (yes / no)
-  PULSEAUDIO_SUPPORT="yes"
-
-# build and install pipewire support (yes / no)
-  PIPEWIRE_SUPPORT="no"
-
-# build and install eSpeak-NG support (yes / no)
-  ESPEAK_SUPPORT="no"
-
-# build and install with BluRay support (yes / no)
-  KODI_BLURAY_SUPPORT="yes"
-
-# build and install with BD+ support
-# (BD+ decryption support in KODI) (yes / no)
-  BLURAY_BDPLUS_SUPPORT="yes"
-
-# build and install with AACS support
-# (BD decryption support in KODI) (yes / no)
-  BLURAY_AACS_SUPPORT="yes"
-
-# build and install with DVDCSS support
-# (DVD decryption support in KODI) (yes / no)
-  KODI_DVDCSS_SUPPORT="yes"
-
-# build and install bluetooth support (yes / no)
-  BLUETOOTH_SUPPORT="yes"
-
-# build and install with KODI webfrontend (yes / no)
-  KODI_WEBSERVER_SUPPORT="yes"
-
-# build and install Avahi (Zeroconf) daemon (yes / no)
-  AVAHI_DAEMON="yes"
-
-# build with UPnP support (yes / no)
-  KODI_UPNP_SUPPORT="yes"
-
-# build with MySQL support (mariadb / none)
-  KODI_MYSQL_SUPPORT="mariadb"
-
-# build xbmc with optical drive support (yes / no)
-  KODI_OPTICAL_SUPPORT="yes"
-
-# build with AirPlay support (stream videos from iDevices to KODI) (yes / no)
-  KODI_AIRPLAY_SUPPORT="yes"
-
-# build with AirTunes support (stream music from iDevices to KODI) (yes / no)
-  KODI_AIRTUNES_SUPPORT="yes"
-
-# build with libnfs support (mounting nfs shares with KODI) (yes / no)
-  KODI_NFS_SUPPORT="yes"
-
-# build with Samba Client support (mounting SAMBA shares with KODI) (yes / no)
-  KODI_SAMBA_SUPPORT="yes"
-
-# build kodi with alsa support (yes/no)
-  KODI_ALSA_SUPPORT="yes"
-
-# build kodi with pulseaudio support (yes/no)
-  KODI_PULSEAUDIO_SUPPORT="yes"
-
-# build kodi with pipewire support (yes/no)
-  KODI_PIPEWIRE_SUPPORT="no"
-
-### KODI ADDONS ###
-
-# Distribution Specific source location
-  DISTRO_MIRROR="http://sources.libreelec.tv/mirror"
-  DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
-
-# Addon Server Url
-  ADDON_SERVER_URL="https://addons.libreelec.tv"
-
-# set the default addon project
-  ADDON_PROJECT="${DEVICE:-$PROJECT}"
-
-# Settings package name - blank if not required
-  DISTRO_PKG_SETTINGS="LibreELEC-settings"
-  DISTRO_PKG_SETTINGS_ID="service.libreelec.settings"
-
-
-### ADDITIONAL PROGRAMS / FUNCTIONS ###
-
-# Testpackages for development (yes / no)
-  TESTING="no"
-
-# Configure debug groups (space delimited key=value pairs, with each value comma-delimited) and default group when DEBUG=yes
-# Use ! or - prefix to prevent a dependent package from being built with debug. Add + suffix to build dependenencies with debug.
-  DEBUG_GROUPS="kodi+=kodi+,kodi-platform+,p8-platform+,!mesa"
-  DEBUG_GROUP_YES="kodi+"
-
-# wireless daemon to use (wpa_supplicant/iwd)
-  WIRELESS_DAEMON="iwd"
-
-# build and install iSCSI support - iscsistart (yes / no)
-  ISCSI_SUPPORT="no"
-
-# build with NFS support (mounting nfs shares via the OS) (yes / no)
-  NFS_SUPPORT="yes"
-
-# build with Samba Client support (mounting samba shares via the OS) (yes / no)
-  SAMBA_SUPPORT="yes"
-
-# build and install Samba Server (yes / no)
-  SAMBA_SERVER="yes"
-
-# build and install SFTP Server (yes / no)
-  SFTP_SERVER="yes"
-
-# build and install OpenVPN support (yes / no)
-  OPENVPN_SUPPORT="yes"
-
-# build and install WireGuard support (yes / no)
-  WIREGUARD_SUPPORT="yes"
-
-# build and install diskmounter support (udevil)
-# this service provide auto mounting support for external drives in the
-# mediacenter also automount internally drives at boottime via udev (yes / no)
-  UDEVIL="yes"
-
-# Support for partitioning and formating disks in initramfs (yes / no)
-# This adds support for parted and mkfs.ext3/4 to initramfs for OEM usage
-  INITRAMFS_PARTED_SUPPORT="no"
-
-# build and install hfs filesystem utilities (yes / no)
-  HFSTOOLS="yes"
-
-# build and install nano text editor (yes / no)
-  NANO_EDITOR="yes"
-
-# cron support (yes / no)
-  CRON_SUPPORT="yes"
-
-# build with installer (yes / no)
-  INSTALLER_SUPPORT="yes"
-
-# build and install remote support (yes / no)
-  REMOTE_SUPPORT="yes"
-
-# IR remote keymaps supported in default config
-  IR_REMOTE_KEYMAPS="rc6_mce xbox_360 xbox_one"
-
-# build and install Joystick support (yes / no)
-  JOYSTICK_SUPPORT="yes"
-
-# build and install CEC adapter support (yes / no)
-  CEC_SUPPORT="yes"
-
-# build and install CEC framework support (yes / no)
-  CEC_FRAMEWORK_SUPPORT="no"
-
-# OEM packages for OEM's (yes / no)
-  OEM_SUPPORT="no"
-
-# build and install ALSA Audio support (yes / no)
-  ALSA_SUPPORT="yes"
-
-# additional packages to install:
-# Space separated list is supported,
-# e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
-  ADDITIONAL_PACKAGES=""
+DISTRONAME="LibreELEC"
+DESCRIPTION="LibreELEC is a fast and user-friendly Kodi Entertainment Center distribution."
+GREETING0="##############################################"
+GREETING1="#                 LibreELEC                  #"
+GREETING2="#            https://libreelec.tv            #"
+GREETING3="##############################################"
+GREETING4=""
+ROOT_PASSWORD="libreelec"
+DISTRO_BOOTLABEL="LIBREELEC"
+DISTRO_DISKLABEL="STORAGE"
+LTO_SUPPORT="yes"
+GOLD_SUPPORT="yes"
+GET_HANDLER_SUPPORT="archive"
+GLIBC_LOCALES="yes"
+ADDITIONAL_DRIVERS="RTL8192DU RTL8812AU"
+SYSTEM_SIZE="512"
+SYSTEM_PART_START="8192"
+SWAP_SUPPORT="yes"
+SWAPFILESIZE="128"
+MEDIACENTER="kodi"
+SKINS="Estuary"
+SKIN_DEFAULT="Estuary"
+KODI_EXTRA_FONTS="yes"
+PULSEAUDIO_SUPPORT="yes"
+KODI_BLURAY_SUPPORT="yes"
+BLURAY_BDPLUS_SUPPORT="yes"
+BLURAY_AACS_SUPPORT="yes"
+KODI_DVDCSS_SUPPORT="yes"
+BLUETOOTH_SUPPORT="yes"
+KODI_WEBSERVER_SUPPORT="yes"
+AVAHI_DAEMON="yes"
+KODI_UPNP_SUPPORT="yes"
+KODI_MYSQL_SUPPORT="mariadb"
+KODI_OPTICAL_SUPPORT="yes"
+KODI_AIRPLAY_SUPPORT="yes"
+KODI_AIRTUNES_SUPPORT="yes"
+KODI_NFS_SUPPORT="yes"
+KODI_SAMBA_SUPPORT="yes"
+DISTRO_MIRROR="http://sources.libreelec.tv/mirror"
+DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
+ADDON_SERVER_URL="https://addons.libreelec.tv"
+DISTRO_PKG_SETTINGS="LibreELEC-settings"
+DISTRO_PKG_SETTINGS_ID="service.libreelec.settings"
+DEBUG_GROUPS="kodi+=kodi+,kodi-platform+,p8-platform+,!mesa"
+DEBUG_GROUP_YES="kodi+"
+WIRELESS_DAEMON="iwd"
+NFS_SUPPORT="yes"
+SAMBA_SUPPORT="yes"
+SAMBA_SERVER="yes"
+SFTP_SERVER="yes"
+OPENVPN_SUPPORT="yes"
+WIREGUARD_SUPPORT="yes"
+UDEVIL="yes"
+HFSTOOLS="yes"
+NANO_EDITOR="yes"
+CRON_SUPPORT="yes"
+REMOTE_SUPPORT="yes"
+IR_REMOTE_KEYMAPS="rc6_mce xbox_360 xbox_one"
+JOYSTICK_SUPPORT="yes"
+CEC_SUPPORT="yes"

--- a/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
@@ -11,7 +11,7 @@ PKG_URL="ftp://ftp.alsa-project.org/pub/plugins/${PKG_NAME}-${PKG_VERSION}.tar.b
 PKG_DEPENDS_TARGET="toolchain alsa-lib"
 PKG_LONGDESC="Alsa plugins."
 
-if [ "${PULSEAUDIO_SUPPORT}" = yes ]; then
+if [ "${PULSEAUDIO_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" pulseaudio"
   SUBDIR_PULSEAUDIO="pulse"
 fi

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -112,7 +112,7 @@ post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/share/i18n/charmaps
     cp -PR ${INSTALL}/.noinstall/charmaps/UTF-8.gz ${INSTALL}/usr/share/i18n/charmaps
 
-  if [ ! "${GLIBC_LOCALES}" = yes ]; then
+  if [ ! "${GLIBC_LOCALES}" = "yes" ]; then
     safe_remove ${INSTALL}/usr/share/i18n/locales
 
     mkdir -p ${INSTALL}/usr/share/i18n/locales

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -112,22 +112,22 @@ pre_make_target() {
   ${PKG_BUILD}/scripts/config --set-str CONFIG_DEFAULT_HOSTNAME "${DISTRONAME}"
 
   # disable swap support if not enabled
-  if [ ! "${SWAP_SUPPORT}" = yes ]; then
+  if [ ! "${SWAP_SUPPORT}" = "yes" ]; then
     ${PKG_BUILD}/scripts/config --disable CONFIG_SWAP
   fi
 
   # disable nfs support if not enabled
-  if [ ! "${NFS_SUPPORT}" = yes ]; then
+  if [ ! "${NFS_SUPPORT}" = "yes" ]; then
     ${PKG_BUILD}/scripts/config --disable CONFIG_NFS_FS
   fi
 
   # disable cifs support if not enabled
-  if [ ! "${SAMBA_SUPPORT}" = yes ]; then
+  if [ ! "${SAMBA_SUPPORT}" = "yes" ]; then
     ${PKG_BUILD}/scripts/config --disable CONFIG_CIFS
   fi
 
   # disable iscsi support if not enabled
-  if [ ! "${ISCSI_SUPPORT}" = yes ]; then
+  if [ ! "${ISCSI_SUPPORT}" = "yes" ]; then
     ${PKG_BUILD}/scripts/config --disable CONFIG_SCSI_ISCSI_ATTRS
     ${PKG_BUILD}/scripts/config --disable CONFIG_ISCSI_TCP
     ${PKG_BUILD}/scripts/config --disable CONFIG_ISCSI_BOOT_SYSFS
@@ -142,7 +142,7 @@ pre_make_target() {
   fi
 
   # disable wireguard support if not enabled
-  if [ ! "${WIREGUARD_SUPPORT}" = yes ]; then
+  if [ ! "${WIREGUARD_SUPPORT}" = "yes" ]; then
     ${PKG_BUILD}/scripts/config --disable CONFIG_WIREGUARD
   fi
 

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -44,29 +44,29 @@ configure_package() {
     PKG_DEPENDS_TARGET+=" ${OPENGL} glu"
   fi
 
-  if [ "${OPENGLES_SUPPORT}" = yes ]; then
+  if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" ${OPENGLES}"
   fi
 
-  if [ "${KODI_ALSA_SUPPORT}" = yes ]; then
+  if [ "${KODI_ALSA_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" alsa-lib"
     KODI_ALSA="-DENABLE_ALSA=ON"
   else
     KODI_ALSA="-DENABLE_ALSA=OFF"
  fi
 
-  if [ "${KODI_PULSEAUDIO_SUPPORT}" = yes ]; then
+  if [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" pulseaudio"
     KODI_PULSEAUDIO="-DENABLE_PULSEAUDIO=ON"
   else
     KODI_PULSEAUDIO="-DENABLE_PULSEAUDIO=OFF"
   fi
 
-  if [ "${ESPEAK_SUPPORT}" = yes ]; then
+  if [ "${ESPEAK_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" espeak-ng"
   fi
 
-  if [ "${KODI_PIPEWIRE_SUPPORT}" = yes ]; then
+  if [ "${KODI_PIPEWIRE_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" pipewire"
     KODI_PIPEWIRE="-DENABLE_PIPEWIRE=ON"
 
@@ -77,7 +77,7 @@ configure_package() {
     KODI_PIPEWIRE="-DENABLE_PIPEWIRE=OFF"
   fi
 
-  if [ "${CEC_SUPPORT}" = yes ]; then
+  if [ "${CEC_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" libcec"
     KODI_CEC="-DENABLE_CEC=ON"
   else
@@ -88,27 +88,27 @@ configure_package() {
     PKG_PATCH_DIRS+=" cec-framework"
   fi
 
-  if [ "${KODI_OPTICAL_SUPPORT}" = yes ]; then
+  if [ "${KODI_OPTICAL_SUPPORT}" = "yes" ]; then
     KODI_OPTICAL="-DENABLE_OPTICAL=ON"
   else
     KODI_OPTICAL="-DENABLE_OPTICAL=OFF"
   fi
 
-  if [ "${KODI_DVDCSS_SUPPORT}" = yes ]; then
+  if [ "${KODI_DVDCSS_SUPPORT}" = "yes" ]; then
     KODI_DVDCSS="-DENABLE_DVDCSS=ON \
                  -DLIBDVDCSS_URL=${SOURCES}/libdvdcss/libdvdcss-$(get_pkg_version libdvdcss).tar.gz"
   else
     KODI_DVDCSS="-DENABLE_DVDCSS=OFF"
   fi
 
-  if [ "${KODI_BLURAY_SUPPORT}" = yes ]; then
+  if [ "${KODI_BLURAY_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" libbluray"
     KODI_BLURAY="-DENABLE_BLURAY=ON"
   else
     KODI_BLURAY="-DENABLE_BLURAY=OFF"
   fi
 
-  if [ "${AVAHI_DAEMON}" = yes ]; then
+  if [ "${AVAHI_DAEMON}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" avahi nss-mdns"
     KODI_AVAHI="-DENABLE_AVAHI=ON"
   else
@@ -125,39 +125,39 @@ configure_package() {
     *)       KODI_MYSQL="-DENABLE_MYSQLCLIENT=OFF -DENABLE_MARIADBCLIENT=OFF"
   esac
 
-  if [ "${KODI_AIRPLAY_SUPPORT}" = yes ]; then
+  if [ "${KODI_AIRPLAY_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" libplist"
     KODI_AIRPLAY="-DENABLE_PLIST=ON"
   else
     KODI_AIRPLAY="-DENABLE_PLIST=OFF"
   fi
 
-  if [ "${KODI_AIRTUNES_SUPPORT}" = yes ]; then
+  if [ "${KODI_AIRTUNES_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" libshairplay"
     KODI_AIRTUNES="-DENABLE_AIRTUNES=ON"
   else
     KODI_AIRTUNES="-DENABLE_AIRTUNES=OFF"
   fi
 
-  if [ "${KODI_NFS_SUPPORT}" = yes ]; then
+  if [ "${KODI_NFS_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" libnfs"
     KODI_NFS="-DENABLE_NFS=ON"
   else
     KODI_NFS="-DENABLE_NFS=OFF"
   fi
 
-  if [ "${KODI_SAMBA_SUPPORT}" = yes ]; then
+  if [ "${KODI_SAMBA_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" samba"
     KODI_SAMBA="-DENABLE_SMBCLIENT=ON"
   else
     KODI_SAMBA="-DENABLE_SMBCLIENT=OFF"
   fi
 
-  if [ "${KODI_WEBSERVER_SUPPORT}" = yes ]; then
+  if [ "${KODI_WEBSERVER_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" libmicrohttpd"
   fi
 
-  if [ "${KODI_UPNP_SUPPORT}" = yes ]; then
+  if [ "${KODI_UPNP_SUPPORT}" = "yes" ]; then
     KODI_UPNP="-DENABLE_UPNP=ON"
   else
     KODI_UPNP="-DENABLE_UPNP=OFF"
@@ -176,7 +176,7 @@ configure_package() {
     KODI_VDPAU="-DENABLE_VDPAU=OFF"
   fi
 
-  if [ "${VAAPI_SUPPORT}" = yes ]; then
+  if [ "${VAAPI_SUPPORT}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" libva"
     KODI_VAAPI="-DENABLE_VAAPI=ON"
   else
@@ -376,7 +376,7 @@ post_makeinstall_target() {
       -e "s:CMAKE_MODULE_PATH /usr/lib/kodi /usr/share/kodi/cmake:CMAKE_MODULE_PATH ${SYSROOT_PREFIX}/usr/share/kodi/cmake:g" \
       -i ${SYSROOT_PREFIX}/usr/lib/kodi/cmake/KodiConfig.cmake
 
-  if [ "${KODI_EXTRA_FONTS}" = yes ]; then
+  if [ "${KODI_EXTRA_FONTS}" = "yes" ]; then
     mkdir -p ${INSTALL}/usr/share/kodi/media/Fonts
       cp ${PKG_DIR}/fonts/*.ttf ${INSTALL}/usr/share/kodi/media/Fonts
   fi

--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -77,7 +77,7 @@ else
                          -DVIDEO_X11=OFF"
 fi
 
-if [ ! "${OPENGL}" = "no" ]; then
+if [ "${OPENGL}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL}"
 
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_TARGET} \
@@ -89,7 +89,7 @@ else
                          -DVIDEO_OPENGLES=ON"
 fi
 
-if [ "${PULSEAUDIO_SUPPORT}" = yes ]; then
+if [ "${PULSEAUDIO_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" pulseaudio"
 
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_TARGET} \

--- a/packages/multimedia/libdvdread/package.mk
+++ b/packages/multimedia/libdvdread/package.mk
@@ -12,6 +12,6 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="libdvdread is a library which provides a simple foundation for reading DVDs."
 PKG_TOOLCHAIN="manual"
 
-if [ "${KODI_DVDCSS_SUPPORT}" = yes ]; then
+if [ "${KODI_DVDCSS_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" libdvdcss"
 fi

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -16,7 +16,7 @@ PKG_BUILD_FLAGS="-gold"
 configure_package() {
   #PKG_WAF_VERBOSE="-v"
 
-  if [ "${AVAHI_DAEMON}" = yes ]; then
+  if [ "${AVAHI_DAEMON}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" avahi"
     SMB_AVAHI="--enable-avahi"
   else

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -20,7 +20,7 @@ if [ "${NANO_EDITOR}" = "yes" ]; then
 fi
 
 # nfs support
-if [ "${NFS_SUPPORT}" = yes ]; then
+if [ "${NFS_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" rpcbind"
 fi
 
@@ -65,7 +65,7 @@ configure_target() {
       sed -i -e "s|^CONFIG_FEATURE_CROND_SPECIAL_TIMES=.*$|# CONFIG_FEATURE_CROND_SPECIAL_TIMES is not set|" .config
     fi
 
-    if [ ! "${SAMBA_SUPPORT}" = yes ]; then
+    if [ ! "${SAMBA_SUPPORT}" = "yes" ]; then
       sed -i -e "s|^CONFIG_FEATURE_MOUNT_CIFS=.*$|# CONFIG_FEATURE_MOUNT_CIFS is not set|" .config
     fi
 

--- a/packages/virtual/initramfs/package.mk
+++ b/packages/virtual/initramfs/package.mk
@@ -12,11 +12,11 @@ PKG_DEPENDS_TARGET="toolchain initramfs:init"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Metapackage for installing initramfs"
 
-if [ "${ISCSI_SUPPORT}" = yes ]; then
+if [ "${ISCSI_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_INIT+=" open-iscsi:init"
 fi
 
-if [ "${INITRAMFS_PARTED_SUPPORT}" = yes ]; then
+if [ "${INITRAMFS_PARTED_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_INIT+=" parted:init"
 fi
 

--- a/projects/ARM/devices/ARMv7/options
+++ b/projects/ARM/devices/ARMv7/options
@@ -1,21 +1,7 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    TARGET_CPU="cortex-a8"
-    TARGET_FLOAT="hard"
-    TARGET_FPU="neon-vfpv3"
-
-  # OpenGL-ES implementation to use
-    OPENGLES="mesa"
-
-  # Graphic drivers to use
-    GRAPHIC_DRIVERS="lima"
-
-  # KODI Player implementation to use
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # Mali GPU family
-    MALI_FAMILY="450"
+TARGET_CPU="cortex-a8"
+TARGET_FLOAT="hard"
+TARGET_FPU="neon-vfpv3"
+OPENGLES="mesa"
+GRAPHIC_DRIVERS="lima"
+KODIPLAYER_DRIVER="$OPENGLES"
+MALI_FAMILY="450"

--- a/projects/ARM/devices/ARMv8/options
+++ b/projects/ARM/devices/ARMv8/options
@@ -1,32 +1,9 @@
-################################################################################
-# setup device defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT="hard"
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="neon-fp-armv8"
-        ;;
-    esac
-
-  # OpenGL-ES implementation to use
-    OPENGLES="mesa"
-
-  # Graphic drivers to use
-    GRAPHIC_DRIVERS="lima"
-
-  # KODI Player implementation to use
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # Mali GPU family
-    MALI_FAMILY="450"
-    
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT="hard"
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="neon-fp-armv8"
+OPENGLES="mesa"
+GRAPHIC_DRIVERS="lima"
+KODIPLAYER_DRIVER="$OPENGLES"
+MALI_FAMILY="450"

--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -1,151 +1,47 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
-    BOOTLOADER="u-boot"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD=""
-
-  # Kernel to use. values can be:
-    LINUX="default"
-
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz / zstd)
-    SQUASHFS_COMPRESSION="zstd"
-
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # install extra subtitle Fonts for KODI (yes / no)
-    KODI_EXTRA_FONTS="no"
-
-  # build and install PulseAudio support (yes / no)
-    PULSEAUDIO_SUPPORT="yes"
-
-  # build and install with BluRay support (yes / no)
-    KODI_BLURAY_SUPPORT="no"
-
-  # build and install with BD+ support
-    BLURAY_BDPLUS_SUPPORT="no"
-
-  # build and install with AACS support
-    BLURAY_AACS_SUPPORT="no"
-
-  # build and install with DVDCSS support
-    KODI_DVDCSS_SUPPORT="no"
-
-  # additional drivers to install
-    ADDITIONAL_DRIVERS=""
-
-  # build and install bluetooth support (yes / no)
-    BLUETOOTH_SUPPORT="no"
-
-  # build and install with KODI webfrontend (yes / no)
-    KODI_WEBSERVER_SUPPORT="no"
-
-  # build and install Avahi (Zeroconf) daemon (yes / no)
-    AVAHI_DAEMON="no"
-
-  # build with UPnP support (yes / no)
-    KODI_UPNP_SUPPORT="no"
-
-  # build with MySQL support (mariadb / none)
-    KODI_MYSQL_SUPPORT="no"
-
-  # build xbmc with optical drive support (yes / no)
-    KODI_OPTICAL_SUPPORT="no"
-
-  # build with AirPlay support (stream videos from iDevices to KODI) (yes / no)
-    KODI_AIRPLAY_SUPPORT="no"
-
-  # build with AirTunes support (stream music from iDevices to KODI) (yes / no)
-    KODI_AIRTUNES_SUPPORT="no"
-
-  # build with libnfs support (mounting nfs shares with KODI) (yes / no)
-    KODI_NFS_SUPPORT="no"
-
-  # build with Samba Client support (mounting SAMBA shares with KODI) (yes / no)
-    KODI_SAMBA_SUPPORT="no"
-
-  # build with NFS support (mounting nfs shares via the OS) (yes / no)
-    NFS_SUPPORT="no"
-
-  # build with Samba Client support (mounting samba shares via the OS) (yes / no)
-    SAMBA_SUPPORT="no"
-
-  # build and install Samba Server (yes / no)
-    SAMBA_SERVER="no"
-
-  # build and install SFTP Server (yes / no)
-    SFTP_SERVER="no"
-
-  # build and install OpenVPN support (yes / no)
-    OPENVPN_SUPPORT="no"
-
-  # build and install WireGuard support (yes / no)
-    WIREGUARD_SUPPORT="no"
-
-  # build and install diskmounter support (udevil)
-    UDEVIL="no"
-
-  # build and install hfs filesystem utilities (yes / no)
-    HFSTOOLS="no"
-
-  # Xorg Graphic drivers to use (all / r300,r600,nvidia)
-    GRAPHIC_DRIVERS="mesa"
-
-  # build and install remote support (yes / no)
-    REMOTE_SUPPORT="no"
-
-  # build and install Joystick support (yes / no)
-    JOYSTICK_SUPPORT="no"
-
-  # build and install CEC adapter support (yes / no)
-    CEC_SUPPORT="no"
-
-  # build and install CEC framework support (yes / no)
-    CEC_FRAMEWORK_SUPPORT="no"
-
-  # build and install iSCSI support - iscsistart (yes / no)
-    ISCSI_SUPPORT="no"
-
-  # build with swap support (yes / no)
-    SWAP_SUPPORT="no"
-
-  # additional packages to install
-    ADDITIONAL_PACKAGES=""
-
-  # build with installer (yes / no)
-    INSTALLER_SUPPORT="no"
-
-  # build and install nano text editor (yes / no)
-    NANO_EDITOR="no"
-
-  # cron support (yes / no)
-    CRON_SUPPORT="no"
-
-  # OpenGL(X) implementation to use (no / mesa)
-    OPENGL="no"
-
-  # Vulkan implementation to use (vulkan-loader / no)
-    VULKAN="no"
-
-  # Displayserver to use (wl / no)
-    DISPLAYSERVER="no"
-
-  # Windowmanager to use (weston / no)
-    WINDOWMANAGER="no"
-
-  # additional Firmware to use
-    FIRMWARE=""
+BOOTLOADER="u-boot"
+KERNEL_MAKE_EXTRACMD=""
+LINUX="default"
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+KODI_EXTRA_FONTS="no"
+PULSEAUDIO_SUPPORT="yes"
+KODI_BLURAY_SUPPORT="no"
+BLURAY_BDPLUS_SUPPORT="no"
+BLURAY_AACS_SUPPORT="no"
+KODI_DVDCSS_SUPPORT="no"
+ADDITIONAL_DRIVERS=""
+BLUETOOTH_SUPPORT="no"
+KODI_WEBSERVER_SUPPORT="no"
+AVAHI_DAEMON="no"
+KODI_UPNP_SUPPORT="no"
+KODI_MYSQL_SUPPORT="no"
+KODI_OPTICAL_SUPPORT="no"
+KODI_AIRPLAY_SUPPORT="no"
+KODI_AIRTUNES_SUPPORT="no"
+KODI_NFS_SUPPORT="no"
+KODI_SAMBA_SUPPORT="no"
+NFS_SUPPORT="no"
+SAMBA_SUPPORT="no"
+SAMBA_SERVER="no"
+SFTP_SERVER="no"
+OPENVPN_SUPPORT="no"
+WIREGUARD_SUPPORT="no"
+UDEVIL="no"
+HFSTOOLS="no"
+GRAPHIC_DRIVERS="mesa"
+REMOTE_SUPPORT="no"
+JOYSTICK_SUPPORT="no"
+CEC_SUPPORT="no"
+CEC_FRAMEWORK_SUPPORT="no"
+ISCSI_SUPPORT="no"
+SWAP_SUPPORT="no"
+ADDITIONAL_PACKAGES=""
+INSTALLER_SUPPORT="no"
+NANO_EDITOR="no"
+CRON_SUPPORT="no"
+ALSA_SUPPORT="no"
+OPENGL="no"
+VULKAN="no"
+DISPLAYSERVER="no"
+WINDOWMANAGER="no"
+FIRMWARE=""

--- a/projects/Allwinner/devices/A64/options
+++ b/projects/Allwinner/devices/A64/options
@@ -1,40 +1,12 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc+crypto"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT="hard"
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="crypto-neon-fp-armv8"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="Image"
-
-  # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="atf crust"
-
-  # ATF platform
-    ATF_PLATFORM="sun50i_a64"
-
-  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
-    OPENGLES="mesa"
-
-  # Mali GPU family
-    MALI_FAMILY="400"
-
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv8"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT="hard"
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="crypto-neon-fp-armv8"
+KERNEL_TARGET="Image"
+UBOOT_FIRMWARE="atf crust"
+ATF_PLATFORM="sun50i_a64"
+OPENGLES="mesa"
+MALI_FAMILY="400"
+KODIPLAYER_DRIVER="$OPENGLES"
+ADDON_PROJECT="ARMv8"

--- a/projects/Allwinner/devices/H2-plus/options
+++ b/projects/Allwinner/devices/H2-plus/options
@@ -1,53 +1,9 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      arm)
-        # TARGET_CPU:
-        # arm2 arm250 arm3 arm6 arm60 arm600 arm610 arm620 arm7 arm7m arm7d
-        # arm7dm arm7di arm7dmi arm70 arm700 arm700i arm710 arm710c
-        # arm7100 arm720 arm7500 arm7500fe arm7tdmi arm7tdmi-s arm710t
-        # arm720t arm740t strongarm strongarm110 strongarm1100
-        # strongarm1110 arm8 arm810 arm9 arm9e arm920 arm920t arm922t
-        # arm946e-s arm966e-s arm968e-s arm926ej-s arm940t arm9tdmi
-        # arm10tdmi arm1020t arm1026ej-s arm10e arm1020e arm1022e
-        # arm1136j-s arm1136jf-s mpcore mpcorenovfp arm1156t2-s
-        # arm1176jz-s arm1176jzf-s cortex-a8 cortex-a9 cortex-r4
-        # cortex-r4f cortex-m3 cortex-m1 xscale iwmmxt iwmmxt2 ep9312.
-        TARGET_CPU="cortex-a7"
-
-        # TARGET_FLOAT:
-        # Specifies which floating-point ABI to use. Permissible values are:
-        # soft hard
-        TARGET_FLOAT="hard"
-
-        # TARGET_FPU:
-        # This specifies what floating point hardware (or hardware emulation) is
-        # available on the target. Permissible names are:
-        # fpa fpe2 fpe3 maverick vfp vfpv3 vfpv3-fp16 vfpv3-d16 vfpv3-d16-fp16
-        # vfpv3xd vfpv3xd-fp16 neon neon-fp16 vfpv4 vfpv4-d16 fpv4-sp-d16
-        # neon-vfpv4.
-        TARGET_FPU="neon-vfpv4"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="zImage"
-
-  # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="crust"
-
-  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
-    OPENGLES="mesa"
-
-  # Mali GPU family
-    MALI_FAMILY="400"
-
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv7"
+TARGET_CPU="cortex-a7"
+TARGET_FLOAT="hard"
+TARGET_FPU="neon-vfpv4"
+KERNEL_TARGET="zImage"
+UBOOT_FIRMWARE="crust"
+OPENGLES="mesa"
+MALI_FAMILY="400"
+KODIPLAYER_DRIVER="$OPENGLES"
+ADDON_PROJECT="ARMv7"

--- a/projects/Allwinner/devices/H3/options
+++ b/projects/Allwinner/devices/H3/options
@@ -1,53 +1,9 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      arm)
-        # TARGET_CPU:
-        # arm2 arm250 arm3 arm6 arm60 arm600 arm610 arm620 arm7 arm7m arm7d
-        # arm7dm arm7di arm7dmi arm70 arm700 arm700i arm710 arm710c
-        # arm7100 arm720 arm7500 arm7500fe arm7tdmi arm7tdmi-s arm710t
-        # arm720t arm740t strongarm strongarm110 strongarm1100
-        # strongarm1110 arm8 arm810 arm9 arm9e arm920 arm920t arm922t
-        # arm946e-s arm966e-s arm968e-s arm926ej-s arm940t arm9tdmi
-        # arm10tdmi arm1020t arm1026ej-s arm10e arm1020e arm1022e
-        # arm1136j-s arm1136jf-s mpcore mpcorenovfp arm1156t2-s
-        # arm1176jz-s arm1176jzf-s cortex-a8 cortex-a9 cortex-r4
-        # cortex-r4f cortex-m3 cortex-m1 xscale iwmmxt iwmmxt2 ep9312.
-        TARGET_CPU="cortex-a7"
-
-        # TARGET_FLOAT:
-        # Specifies which floating-point ABI to use. Permissible values are:
-        # soft hard
-        TARGET_FLOAT="hard"
-
-        # TARGET_FPU:
-        # This specifies what floating point hardware (or hardware emulation) is
-        # available on the target. Permissible names are:
-        # fpa fpe2 fpe3 maverick vfp vfpv3 vfpv3-fp16 vfpv3-d16 vfpv3-d16-fp16
-        # vfpv3xd vfpv3xd-fp16 neon neon-fp16 vfpv4 vfpv4-d16 fpv4-sp-d16
-        # neon-vfpv4.
-        TARGET_FPU="neon-vfpv4"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="zImage"
-
-  # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="crust"
-
-  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
-    OPENGLES="mesa"
-
-  # Mali GPU family
-    MALI_FAMILY="400"
-
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv7"
+TARGET_CPU="cortex-a7"
+TARGET_FLOAT="hard"
+TARGET_FPU="neon-vfpv4"
+KERNEL_TARGET="zImage"
+UBOOT_FIRMWARE="crust"
+OPENGLES="mesa"
+MALI_FAMILY="400"
+KODIPLAYER_DRIVER="$OPENGLES"
+ADDON_PROJECT="ARMv7"

--- a/projects/Allwinner/devices/H5/options
+++ b/projects/Allwinner/devices/H5/options
@@ -1,40 +1,12 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc+crypto"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT="hard"
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="crypto-neon-fp-armv8"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="Image"
-
-  # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="atf crust"
-
-  # ATF platform
-    ATF_PLATFORM="sun50i_a64"
-
-  # OpenGL-ES implementation to use
-    OPENGLES="mesa"
-
-  # Mali GPU family
-    MALI_FAMILY="450"
-
-  # KODI Player implementation to use
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv8"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT="hard"
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="crypto-neon-fp-armv8"
+KERNEL_TARGET="Image"
+UBOOT_FIRMWARE="atf crust"
+ATF_PLATFORM="sun50i_a64"
+OPENGLES="mesa"
+MALI_FAMILY="450"
+KODIPLAYER_DRIVER="$OPENGLES"
+ADDON_PROJECT="ARMv8"

--- a/projects/Allwinner/devices/H6/options
+++ b/projects/Allwinner/devices/H6/options
@@ -1,37 +1,11 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc+crypto"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT="hard"
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="crypto-neon-fp-armv8"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="Image"
-
-  # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="atf crust"
-
-  # ATF platform
-    ATF_PLATFORM="sun50i_h6"
-
-  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
-    OPENGLES="mesa"
-
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv8"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT="hard"
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="crypto-neon-fp-armv8"
+KERNEL_TARGET="Image"
+UBOOT_FIRMWARE="atf crust"
+ATF_PLATFORM="sun50i_h6"
+OPENGLES="mesa"
+KODIPLAYER_DRIVER="$OPENGLES"
+ADDON_PROJECT="ARMv8"

--- a/projects/Allwinner/devices/R40/options
+++ b/projects/Allwinner/devices/R40/options
@@ -1,50 +1,8 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      arm)
-        # TARGET_CPU:
-        # arm2 arm250 arm3 arm6 arm60 arm600 arm610 arm620 arm7 arm7m arm7d
-        # arm7dm arm7di arm7dmi arm70 arm700 arm700i arm710 arm710c
-        # arm7100 arm720 arm7500 arm7500fe arm7tdmi arm7tdmi-s arm710t
-        # arm720t arm740t strongarm strongarm110 strongarm1100
-        # strongarm1110 arm8 arm810 arm9 arm9e arm920 arm920t arm922t
-        # arm946e-s arm966e-s arm968e-s arm926ej-s arm940t arm9tdmi
-        # arm10tdmi arm1020t arm1026ej-s arm10e arm1020e arm1022e
-        # arm1136j-s arm1136jf-s mpcore mpcorenovfp arm1156t2-s
-        # arm1176jz-s arm1176jzf-s cortex-a8 cortex-a9 cortex-r4
-        # cortex-r4f cortex-m3 cortex-m1 xscale iwmmxt iwmmxt2 ep9312.
-        TARGET_CPU="cortex-a7"
-
-        # TARGET_FLOAT:
-        # Specifies which floating-point ABI to use. Permissible values are:
-        # soft hard
-        TARGET_FLOAT="hard"
-
-        # TARGET_FPU:
-        # This specifies what floating point hardware (or hardware emulation) is
-        # available on the target. Permissible names are:
-        # fpa fpe2 fpe3 maverick vfp vfpv3 vfpv3-fp16 vfpv3-d16 vfpv3-d16-fp16
-        # vfpv3xd vfpv3xd-fp16 neon neon-fp16 vfpv4 vfpv4-d16 fpv4-sp-d16
-        # neon-vfpv4.
-        TARGET_FPU="neon-vfpv4"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="zImage"
-
-  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q)
-    OPENGLES="mesa"
-
-  # Mali GPU family
-    MALI_FAMILY="400"
-
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv7"
+TARGET_CPU="cortex-a7"
+TARGET_FLOAT="hard"
+TARGET_FPU="neon-vfpv4"
+KERNEL_TARGET="zImage"
+OPENGLES="mesa"
+MALI_FAMILY="400"
+KODIPLAYER_DRIVER="$OPENGLES"
+ADDON_PROJECT="ARMv7"

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -1,66 +1,18 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
-    BOOTLOADER="u-boot"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD="dtbs"
-
-  # Additional kernel dependencies
-    KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
-
-  # Kernel to use. values can be:
-  # default:  default mainline kernel
-    LINUX="default"
-
-    EXTRA_CMDLINE="console=ttyS0,115200 console=tty1"
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz / zstd)
-    SQUASHFS_COMPRESSION="zstd"
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # OpenGL(X) implementation to use (no / mesa)
-    OPENGL="no"
-
-  # Vulkan implementation to use (vulkan-loader / no)
-    VULKAN="no"
-
-  # Displayserver to use (wl / no)
-    DISPLAYSERVER="no"
-
-  # Windowmanager to use (weston / no)
-    WINDOWMANAGER="no"
-
-  # Xorg Graphic drivers to use (all / lima,panfrost)
-  # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="lima panfrost"
-    GRAPHIC_DRIVERS="lima panfrost"
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-  # Space separated list is supported,
-  # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware"
-
-  # build and install CEC framework support (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
-
-  # build with installer (yes / no)
-    INSTALLER_SUPPORT="no"
-
-  # debug tty path
-    DEBUG_TTY="/dev/console"
-
-  # additional packages to install:
-    ADDITIONAL_PACKAGES="dt-overlays"
+BOOTLOADER="u-boot"
+KERNEL_MAKE_EXTRACMD="dtbs"
+KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
+LINUX="default"
+EXTRA_CMDLINE="console=ttyS0,115200 console=tty1"
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+ALSA_SUPPORT="yes"
+OPENGL="no"
+VULKAN="no"
+DISPLAYSERVER="no"
+WINDOWMANAGER="no"
+GRAPHIC_DRIVERS="lima panfrost"
+FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware"
+CEC_FRAMEWORK_SUPPORT="yes"
+INSTALLER_SUPPORT="no"
+DEBUG_TTY="/dev/console"
+ADDITIONAL_PACKAGES="dt-overlays"

--- a/projects/Amlogic/devices/AMLGX/options
+++ b/projects/Amlogic/devices/AMLGX/options
@@ -1,34 +1,10 @@
-################################################################################
-# setup device defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc+fp+simd"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT="hard"
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="neon-fp-armv8"
-        ;;
-    esac
-
-  # OpenGL-ES implementation to use
-    OPENGLES="mesa"
-
-  # Graphic drivers to use
-    GRAPHIC_DRIVERS="lima panfrost"
-
-  # KODI Player implementation to use
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # Mali GPU family
-    MALI_FAMILY="450 t820 g31 g52"
-
-  # Set the addon project
-    ADDON_PROJECT="ARMv8"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT="hard"
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="neon-fp-armv8"
+OPENGLES="mesa"
+GRAPHIC_DRIVERS="lima panfrost"
+KODIPLAYER_DRIVER="$OPENGLES"
+MALI_FAMILY="450 t820 g31 g52"
+ADDON_PROJECT="ARMv8"

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -1,84 +1,23 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
-    BOOTLOADER="u-boot"
-
-  # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="amlogic-boot-fip u-boot-script"
-
-  # Kernel to use
-    LINUX="amlogic"
-
-  # Kernel target
-    KERNEL_TARGET="uImage.lzo"
-
-  # Kernel uImage load address
-    KERNEL_UIMAGE_LOADADDR="0x1080000"
-
-  # Kernel uImage entry address
-    KERNEL_UIMAGE_ENTRYADDR="0x1080000"
-
-  # Additional kernel make parameters
-    KERNEL_MAKE_EXTRACMD="dtbs"
-
-  # kernel serial console
-    EXTRA_CMDLINE="systemd.debug_shell=ttyAML0 console=ttyAML0,115200n8 console=tty0"
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz / zstd)
-    SQUASHFS_COMPRESSION="zstd"
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # OpenGL(X) implementation to use (no / mesa)
-    OPENGL="no"
-
-  # Vulkan implementation to use (vulkan-loader / no)
-    VULKAN="no"
-
-  # Displayserver to use (wl / no)
-    DISPLAYSERVER="no"
-
-  # Windowmanager to use (weston / no)
-    WINDOWMANAGER="no"
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-  # Space separated list is supported,
-  # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="dvb-firmware brcmfmac_sdio-firmware kernel-firmware"
-
-  # build with installer (yes / no)
-    INSTALLER_SUPPORT="no"
-
-  # additional drivers to install:
-  # for a list of additional drivers see packages/linux-drivers
-  # Space separated list is supported,
-  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS=""
-
-  # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
-
-  # driver addons to install:
-  # for a list of additional drivers see packages/linux-driver-addons
-  # Space separated list is supported,
-    DRIVER_ADDONS="crazycat dvb-latest"
-
-  # additional packages to install:
-    ADDITIONAL_PACKAGES="dtc ethmactool emmctool flashrom"
-
-  # use the kernel CEC framework for libcec (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
-
-  # debug tty path
-    DEBUG_TTY="/dev/ttyAML0"
+BOOTLOADER="u-boot"
+UBOOT_FIRMWARE="amlogic-boot-fip u-boot-script"
+LINUX="amlogic"
+KERNEL_TARGET="uImage.lzo"
+KERNEL_UIMAGE_LOADADDR="0x1080000"
+KERNEL_UIMAGE_ENTRYADDR="0x1080000"
+KERNEL_MAKE_EXTRACMD="dtbs"
+EXTRA_CMDLINE="systemd.debug_shell=ttyAML0 console=ttyAML0,115200n8 console=tty0"
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+ALSA_SUPPORT="yes"
+OPENGL="no"
+VULKAN="no"
+DISPLAYSERVER="no"
+WINDOWMANAGER="no"
+FIRMWARE="dvb-firmware brcmfmac_sdio-firmware kernel-firmware"
+INSTALLER_SUPPORT="no"
+ADDITIONAL_DRIVERS=""
+DRIVER_ADDONS_SUPPORT="no"
+DRIVER_ADDONS="crazycat dvb-latest"
+ADDITIONAL_PACKAGES="dtc ethmactool emmctool flashrom"
+CEC_FRAMEWORK_SUPPORT="yes"
+DEBUG_TTY="/dev/ttyAML0"

--- a/projects/Generic/devices/gbm/options
+++ b/projects/Generic/devices/gbm/options
@@ -1,25 +1,8 @@
-# OpenGL(X) implementation to use (mesa / no)
-  OPENGL="no"
-
-# OpenGL-ES implementation to use (mesa / no)
-  OPENGLES="mesa"
-
-# Vulkan implementation to use (vulkan-loader / no)
-  VULKAN="no"
-
-# Displayserver to use (weston / x11 / no)
-  DISPLAYSERVER="no"
-
-# Windowmanager to use (fluxbox / weston / no)
-  WINDOWMANAGER="no"
-
-# KODI Player implementation to use (mesa / default)
-  KODIPLAYER_DRIVER="mesa"
-
-# set the addon project
-  ADDON_PROJECT="Generic"
-
-# Mesa 3D Graphic drivers to use (all / crocus,i915,iris,r300,r600,radeonsi,vmware,virtio)
-# Space separated list is supported,
-# e.g. GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"
-  GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"
+OPENGL="no"
+OPENGLES="mesa"
+VULKAN="no"
+DISPLAYSERVER="no"
+WINDOWMANAGER="no"
+KODIPLAYER_DRIVER="mesa"
+ADDON_PROJECT="Generic"
+GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"

--- a/projects/Generic/devices/wayland/options
+++ b/projects/Generic/devices/wayland/options
@@ -1,25 +1,8 @@
-# OpenGL(X) implementation to use (mesa / no)
-  OPENGL="no"
-
-# OpenGL-ES implementation to use (mesa / no)
-  OPENGLES="mesa"
-
-# Vulkan implementation to use (vulkan-loader / no)
-  VULKAN="no"
-
-# Displayserver to use (wl / x11 / no)
-  DISPLAYSERVER="wl"
-
-# Windowmanager to use (fluxbox / sway / weston / no)
-  WINDOWMANAGER="sway"
-
-# KODI Player implementation to use (mesa / default)
-  KODIPLAYER_DRIVER="mesa"
-
-# set the addon project
-  ADDON_PROJECT="Generic"
-
-# Mesa 3D Graphic / NVIDIA drivers to use (all / crocus,i915,iris,nvidia-ng,r300,r600,radeonsi,vmware,virtio)
-# Space separated list is supported,
-# e.g. GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"
-  GRAPHIC_DRIVERS="crocus i915 iris nvidia-ng r300 r600 radeonsi vmware virtio"
+OPENGL="no"
+OPENGLES="mesa"
+VULKAN="no"
+DISPLAYSERVER="wl"
+WINDOWMANAGER="sway"
+KODIPLAYER_DRIVER="mesa"
+ADDON_PROJECT="Generic"
+GRAPHIC_DRIVERS="crocus i915 iris nvidia-ng r300 r600 radeonsi vmware virtio"

--- a/projects/Generic/devices/x11/options
+++ b/projects/Generic/devices/x11/options
@@ -1,25 +1,8 @@
-# OpenGL(X) implementation to use (mesa / no)
-  OPENGL="mesa"
-
-# OpenGL-ES implementation to use (mesa / no)
-  OPENGLES="no"
-
-# Vulkan implementation to use (vulkan-loader / no)
-  VULKAN="no"
-
-# Displayserver to use (weston / x11 / no)
-  DISPLAYSERVER="x11"
-
-# Windowmanager to use (fluxbox / weston / no)
-  WINDOWMANAGER="fluxbox"
-
-# KODI Player implementation to use (mesa / default)
-  KODIPLAYER_DRIVER="default"
-
-# set the addon project
-  ADDON_PROJECT="Generic"
-
-# Mesa 3D / Xorg Graphic drivers to use (all / crocus,i915,iris,r300,r600,radeonsi,nvidia,nvidia-legacy,vmware,virtio)
-# Space separated list is supported,
-# e.g. GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi nvidia nvidia-legacy vmware virtio"
-  GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi nvidia nvidia-legacy vmware virtio"
+OPENGL="mesa"
+OPENGLES="no"
+VULKAN="no"
+DISPLAYSERVER="x11"
+WINDOWMANAGER="fluxbox"
+KODIPLAYER_DRIVER="default"
+ADDON_PROJECT="Generic"
+GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi nvidia nvidia-legacy vmware virtio"

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -1,69 +1,12 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      x86_64)
-        # (AMD CPUs)    k8 k8-sse3 opteron opteron-sse3 athlon64 athlon64-sse3
-        #               athlon-fx amdfam10 barcelona
-        # (Intel CPUs)  atom core2 nocona
-        #
-        TARGET_CPU="x86-64"
-        ;;
-    esac
-
-  # Bootloader to use (syslinux / u-boot)
-    BOOTLOADER="syslinux"
-
-  # Kernel target
-    KERNEL_TARGET="bzImage"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD=""
-
-  # Additional kernel dependencies
-    KERNEL_EXTRA_DEPENDS_TARGET=""
-
-  # Kernel to use. values can be:
-  # default:  default mainline kernel
-    LINUX="default"
-
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz / zstd)
-    SQUASHFS_COMPRESSION="zstd"
-
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-  # Space separated list is supported,
-  # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="misc-firmware wlan-firmware dvb-firmware iwlwifi-firmware"
-
-  # additional drivers to install:
-  # for a list of additional drivers see packages/linux-drivers
-  # Space separated list is supported,
-  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm_sta"
-
-  # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
-
-  # driver addons to install:
-  # for a list of additional drivers see packages/linux-driver-addons
-  # Space separated list is supported,
-    DRIVER_ADDONS="crazycat digital_devices dvb-latest"
-
-  # Default size of the ova image, in MB, eg. 4096
-    OVA_SIZE="4096"
+TARGET_CPU="x86-64"
+BOOTLOADER="syslinux"
+KERNEL_TARGET="bzImage"
+KERNEL_MAKE_EXTRACMD=""
+KERNEL_EXTRA_DEPENDS_TARGET=""
+LINUX="default"
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+FIRMWARE="misc-firmware wlan-firmware dvb-firmware iwlwifi-firmware"
+ADDITIONAL_DRIVERS_PROJECT="bcm_sta"
+DRIVER_ADDONS="crazycat digital_devices dvb-latest"
+OVA_SIZE="4096"

--- a/projects/NXP/devices/iMX6/options
+++ b/projects/NXP/devices/iMX6/options
@@ -1,26 +1,7 @@
-################################################################################
-# setup device defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      arm)
-        TARGET_CPU="cortex-a9"
-        TARGET_FLOAT="hard"
-        TARGET_FPU="neon-vfpv3"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="zImage"
-
-  # kernel serial console
-    EXTRA_CMDLINE="console=ttymxc0,115200 console=tty0"
-
-  # debug tty path
-    DEBUG_TTY="/dev/ttymxc0"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv7"
-
+TARGET_CPU="cortex-a9"
+TARGET_FLOAT="hard"
+TARGET_FPU="neon-vfpv3"
+KERNEL_TARGET="zImage"
+EXTRA_CMDLINE="console=ttymxc0,115200 console=tty0"
+DEBUG_TTY="/dev/ttymxc0"
+ADDON_PROJECT="ARMv7"

--- a/projects/NXP/devices/iMX8/options
+++ b/projects/NXP/devices/iMX8/options
@@ -1,40 +1,12 @@
-################################################################################
-# setup device defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc+fp+simd"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT=hard
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="neon-fp-armv8"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="Image"
-
-  # kernel serial console
-    EXTRA_CMDLINE="console=ttymxc0,115200 console=tty0"
-
-  # debug tty path
-    DEBUG_TTY="/dev/ttymxc0"
-
-  # ATF platform
-    ATF_PLATFORM="imx8mq"
-
-  # uboot firmware
-    UBOOT_FIRMWARE="atf firmware-imx"
-
-  # uboot target
-    UBOOT_TARGET="flash.bin"
-
-  # Set the addon project
-    ADDON_PROJECT="ARMv8"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT=hard
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="neon-fp-armv8"
+KERNEL_TARGET="Image"
+EXTRA_CMDLINE="console=ttymxc0,115200 console=tty0"
+DEBUG_TTY="/dev/ttymxc0"
+ATF_PLATFORM="imx8mq"
+UBOOT_FIRMWARE="atf firmware-imx"
+UBOOT_TARGET="flash.bin"
+ADDON_PROJECT="ARMv8"

--- a/projects/NXP/options
+++ b/projects/NXP/options
@@ -1,72 +1,19 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
-    BOOTLOADER="u-boot"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD="dtbs"
-
-  # Kernel to use. values can be:
-  # default:  default mainline kernel
-    LINUX="default"
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz)
-    SQUASHFS_COMPRESSION="zstd"
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # OpenGL(X) implementation to use (no / mesa)
-    OPENGL="no"
-
-  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q / opengl-meson6)
-    OPENGLES="mesa"
-
-  # Vulkan implementation to use (vulkan-loader / no)
-    VULKAN="no"
-
-  # include uvesafb support (yes / no)
-    UVESAFB_SUPPORT="no"
-
-  # Displayserver to use (wl / no)
-    DISPLAYSERVER="no"
-
-  # Windowmanager to use (weston / no)
-    WINDOWMANAGER="no"
-
-  # Xorg Graphic drivers to use (all / etnaviv)
-  # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="etnaviv"
-    GRAPHIC_DRIVERS="etnaviv"
-
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
-    KODIPLAYER_DRIVER="mesa"
-
-  # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
-
-  # driver addons to install:
-  # for a list of additional drivers see packages/linux-driver-addons
-  # Space separated list is supported,
-    DRIVER_ADDONS="crazycat dvb-latest"
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-  # Space separated list is supported,
-  # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware"
-
-  # build with installer (yes / no)
-    INSTALLER_SUPPORT="no"
-
-  # use the kernel CEC framework for libcec (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
+BOOTLOADER="u-boot"
+KERNEL_MAKE_EXTRACMD="dtbs"
+LINUX="default"
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+ALSA_SUPPORT="yes"
+OPENGL="no"
+OPENGLES="mesa"
+VULKAN="no"
+UVESAFB_SUPPORT="no"
+DISPLAYSERVER="no"
+WINDOWMANAGER="no"
+GRAPHIC_DRIVERS="etnaviv"
+KODIPLAYER_DRIVER="mesa"
+DRIVER_ADDONS_SUPPORT="no"
+DRIVER_ADDONS="crazycat dvb-latest"
+FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware"
+INSTALLER_SUPPORT="no"
+CEC_FRAMEWORK_SUPPORT="yes"

--- a/projects/Qualcomm/devices/Dragonboard/options
+++ b/projects/Qualcomm/devices/Dragonboard/options
@@ -1,106 +1,30 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc+fp+simd"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT=hard
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="neon-fp-armv8"
-        ;;
-    esac
-
-  # Bootloader to use (syslinux / u-boot / atv-bootloader / bcm2835-bootloader)
-    BOOTLOADER="u-boot"
-
-  # U-Boot firmware package(s) to use (this is a bit of a hack as mkbootimg isn't firmware but is needed by the host to build the u-boot uImage)
-    UBOOT_FIRMWARE="mkbootimg:host"
-
-  # Kernel target
-    KERNEL_TARGET="Image"
-
-  # Kernel uImage load address
-    KERNEL_UIMAGE_LOADADDR="0x80080000"
-
-  # Kernel uImage entry address
-    KERNEL_UIMAGE_ENTRYADDR="0x80080000"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD="dtbs"
-
-  # Kernel to use. values can be:
-  # default:  default mainline kernel
-    LINUX="default"
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz)
-    SQUASHFS_COMPRESSION="zstd"
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # OpenGL(X) implementation to use (no / Mesa)
-    OPENGL="no"
-
-  # OpenGL-ES implementation to use (no / bcm2835-driver / gpu-viv-bin-mx6q / opengl-meson6)
-    OPENGLES="mesa"
-
-  # Vulkan implementation to use (vulkan-loader / no)
-    VULKAN="no"
-
-  # include uvesafb support (yes / no)
-    UVESAFB_SUPPORT="no"
-
-  # Displayserver to use (wl / no)
-    DISPLAYSERVER="no"
-
-  # Windowmanager to use (weston / no)
-    WINDOWMANAGER="no"
-
-  # Xorg Graphic drivers to use (all / freedreno)
-  # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="freedreno"
-    GRAPHIC_DRIVERS="freedreno"
-
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap / libamcodec)
-    KODIPLAYER_DRIVER="mesa"
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-  # Space separated list is supported,
-  # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="misc-firmware wlan-firmware dvb-firmware firmware-dragonboard"
-
-  # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
-
-  # driver addons to install:
-  # for a list of additional drivers see packages/linux-driver-addons
-  # Space separated list is supported,
-    DRIVER_ADDONS="crazycat dvb-latest"
-
-  # build with installer (yes / no)
-    INSTALLER_SUPPORT="no"
-
-  # kernel serial console
-    EXTRA_CMDLINE="console=ttyMSM0,115200n8 console=tty0"
-
-  # debug tty path
-    DEBUG_TTY="/dev/ttyMSM0"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv8"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT=hard
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="neon-fp-armv8"
+BOOTLOADER="u-boot"
+UBOOT_FIRMWARE="mkbootimg:host"
+KERNEL_TARGET="Image"
+KERNEL_UIMAGE_LOADADDR="0x80080000"
+KERNEL_UIMAGE_ENTRYADDR="0x80080000"
+KERNEL_MAKE_EXTRACMD="dtbs"
+LINUX="default"
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+ALSA_SUPPORT="yes"
+OPENGL="no"
+OPENGLES="mesa"
+VULKAN="no"
+UVESAFB_SUPPORT="no"
+DISPLAYSERVER="no"
+WINDOWMANAGER="no"
+GRAPHIC_DRIVERS="freedreno"
+KODIPLAYER_DRIVER="mesa"
+FIRMWARE="misc-firmware wlan-firmware dvb-firmware firmware-dragonboard"
+DRIVER_ADDONS_SUPPORT="no"
+DRIVER_ADDONS="crazycat dvb-latest"
+INSTALLER_SUPPORT="no"
+EXTRA_CMDLINE="console=ttyMSM0,115200n8 console=tty0"
+DEBUG_TTY="/dev/ttyMSM0"
+ADDON_PROJECT="ARMv8"

--- a/projects/RPi/devices/RPi/options
+++ b/projects/RPi/devices/RPi/options
@@ -1,9 +1,5 @@
-################################################################################
-# Device defaults
-################################################################################
-
-  # NOOBS supported hex versions (legacy)
-    NOOBS_HEX="2,3,4,5,6,7,8,9,d,e,f,10,11,12,14,19,0092,0093"
-
-  # NOOBS supported model versions
-    NOOBS_SUPPORTED_MODELS='"Pi Model","Pi Compute Module","Pi Zero"'
+TARGET_CPU="arm1176jzf-s"
+TARGET_FLOAT="hard"
+TARGET_FPU="vfp"
+NOOBS_HEX="2,3,4,5,6,7,8,9,d,e,f,10,11,12,14,19,0092,0093"
+NOOBS_SUPPORTED_MODELS='"Pi Model","Pi Compute Module","Pi Zero"'

--- a/projects/RPi/devices/RPi2/options
+++ b/projects/RPi/devices/RPi2/options
@@ -1,12 +1,6 @@
-################################################################################
-# Device defaults
-################################################################################
-
-  # NOOBS supported hex versions (legacy)
-    NOOBS_HEX="1040,1041,2082"
-
-  # NOOBS supported model versions
-    NOOBS_SUPPORTED_MODELS='"Pi 2","Pi 3"'
-
-  # set the addon project
-    ADDON_PROJECT="ARMv7"
+TARGET_CPU="cortex-a7"
+TARGET_FLOAT="hard"
+TARGET_FPU="neon-vfpv4"
+NOOBS_HEX="1040,1041,2082"
+NOOBS_SUPPORTED_MODELS='"Pi 2","Pi 3"'
+ADDON_PROJECT="ARMv7"

--- a/projects/RPi/devices/RPi4/options
+++ b/projects/RPi/devices/RPi4/options
@@ -1,26 +1,10 @@
-################################################################################
-# Device defaults
-################################################################################
-
-  # NOOBS supported hex versions (legacy) is not relevant for RPi4
-    unset NOOBS_HEX
-
-  # NOOBS supported model versions
-    NOOBS_SUPPORTED_MODELS='"Pi 4"'
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-    FIRMWARE="${FIRMWARE} rpi-eeprom"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv8"
-
-  # build 64bit kernel
-    case $TARGET_ARCH in
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_KERNEL_PATCH_ARCH="aarch64"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="Image"
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FLOAT="hard"
+TARGET_FPU="neon-fp-armv8"
+NOOBS_SUPPORTED_MODELS="Pi 4"
+FIRMWARE_DEVICE="rpi-eeprom"
+ADDON_PROJECT="ARMv8"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_KERNEL_PATCH_ARCH="aarch64"
+KERNEL_TARGET="Image"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -1,125 +1,18 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      arm)
-        # Valid TARGET_CPU for Raspberry Pi based devices are:
-        # arm1176jzf-s cortex-a7 cortex-a53
-        if [ "$DEVICE" = "RPi" ]; then
-          TARGET_CPU="arm1176jzf-s"
-        elif [ "$DEVICE" = "RPi2" ]; then
-          TARGET_CPU="cortex-a7"
-        elif [ "$DEVICE" = "RPi4" ]; then
-          TARGET_CPU="cortex-a53"
-          TARGET_CPU_FLAGS="+crc"
-        fi
-
-        # TARGET_FLOAT:
-        # Specifies which floating-point ABI to use. Permissible values are:
-        # soft hard
-        TARGET_FLOAT="hard"
-
-        # Valid TARGET_FPU for Raspberry Pi based devices:
-        # This specifies what floating point hardware (or hardware emulation) is
-        # available on the target. Permissible names are:
-        # vfp neon-vfpv4 neon-fp-armv8
-        if [ "$DEVICE" = "RPi" ]; then
-          TARGET_FPU="vfp"
-        elif [ "$DEVICE" = "RPi2" ]; then
-          TARGET_FPU="neon-vfpv4"
-        elif [ "$DEVICE" = "RPi4" ]; then
-          TARGET_FPU="neon-fp-armv8"
-        fi
-        ;;
-    esac
-
-  # Bootloader to use (bcm2835-bootloader)
-    BOOTLOADER="bcm2835-bootloader"
-
-  # Kernel target
-    KERNEL_TARGET="zImage"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD="dtbs"
-
-  # Additional kernel dependencies
-    KERNEL_EXTRA_DEPENDS_TARGET=""
-
-  # Kernel to use. values can be:
-  # default:  default mainline kernel
-    LINUX="raspberrypi"
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz / zstd)
-    SQUASHFS_COMPRESSION="zstd"
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # OpenGL(X) implementation to use (no / mesa)
-    OPENGL="no"
-
-  # OpenGL-ES implementation to use (no / bcm2835-driver / mesa)
-    OPENGLES="mesa"
-
-  # Vulkan implementation to use (vulkan-loader / no)
-    VULKAN="no"
-
-  # Displayserver to use (wl / no)
-    DISPLAYSERVER="no"
-
-  # Windowmanager to use (weston / no)
-    WINDOWMANAGER="no"
-
-  # Xorg Graphic drivers to use (all / vc4 / none)
-  # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="vc4"
-    GRAPHIC_DRIVERS="vc4"
-
-  # KODI Player implementation to use (default / bcm2835-driver / mesa)
-    KODIPLAYER_DRIVER="mesa"
-
-  # use the kernel CEC framework for libcec (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-  # Space separated list is supported,
-  # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware-rpi"
-
-  # build with installer (yes / no)
-    INSTALLER_SUPPORT="no"
-
-  # kernel image name
-    KERNEL_NAME="kernel.img"
-
-  # additional drivers to install:
-  # for a list of additional drivers see packages/linux-drivers
-  # Space separated list is supported,
-  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm2835-driver"
-
-    if [ "${ALSA_SUPPORT}" = "yes" ]; then
-      ADDITIONAL_DRIVERS+=" rpi-cirrus-config"
-    fi
-
-  # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
-
-  # driver addons to install:
-  # for a list of additional drivers see packages/linux-driver-addons
-  # Space separated list is supported,
-    DRIVER_ADDONS="crazycat dvb-latest"
-
-  # debug tty path
-    DEBUG_TTY="/dev/console"
+BOOTLOADER="bcm2835-bootloader"
+KERNEL_MAKE_EXTRACMD="dtbs"
+KERNEL_EXTRA_DEPENDS_TARGET=""
+LINUX="raspberrypi"
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+ALSA_SUPPORT="yes"
+OPENGLES="mesa"
+GRAPHIC_DRIVERS="vc4"
+KODIPLAYER_DRIVER="mesa"
+CEC_FRAMEWORK_SUPPORT="yes"
+FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware-rpi"
+KERNEL_NAME="kernel.img"
+ADDITIONAL_DRIVERS_PROJECT="rpi-cirrus-config bcm2835-driver"
+DRIVER_ADDONS="crazycat dvb-latest"
+DEBUG_TTY="/dev/console"
+INSTALLER_SUPPORT="no"
+DISPLAYSERVER="no"

--- a/projects/Rockchip/devices/RK3288/options
+++ b/projects/Rockchip/devices/RK3288/options
@@ -1,32 +1,12 @@
-################################################################################
-# setup device defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      arm)
-        TARGET_FLOAT="hard"
-        TARGET_CPU="cortex-a17"
-        TARGET_FPU="neon-vfpv4"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="zImage"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD=""
-    KERNEL_MAKE_EXTRACMD+=" rk3288-miqi.dtb"
-    KERNEL_MAKE_EXTRACMD+=" rk3288-tinker.dtb"
-    KERNEL_MAKE_EXTRACMD+=" rk3288-tinker-s.dtb"
-
-  # Mali GPU family
-    MALI_FAMILY="t760"
-    GRAPHIC_DRIVERS="panfrost"
-
-  # kernel serial console
-    EXTRA_CMDLINE="console=uart8250,mmio32,0xff690000 console=tty0 coherent_pool=2M cec.debounce_ms=5000"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv7"
+TARGET_FLOAT="hard"
+TARGET_CPU="cortex-a17"
+TARGET_FPU="neon-vfpv4"
+KERNEL_TARGET="zImage"
+KERNEL_MAKE_EXTRACMD=""
+KERNEL_MAKE_EXTRACMD+=" rk3288-miqi.dtb"
+KERNEL_MAKE_EXTRACMD+=" rk3288-tinker.dtb"
+KERNEL_MAKE_EXTRACMD+=" rk3288-tinker-s.dtb"
+MALI_FAMILY="t760"
+GRAPHIC_DRIVERS="panfrost"
+EXTRA_CMDLINE="console=uart8250,mmio32,0xff690000 console=tty0 coherent_pool=2M cec.debounce_ms=5000"
+ADDON_PROJECT="ARMv7"

--- a/projects/Rockchip/devices/RK3328/options
+++ b/projects/Rockchip/devices/RK3328/options
@@ -1,35 +1,13 @@
-################################################################################
-# setup device defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc+crypto"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT="hard"
-        TARGET_CPU="cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="crypto-neon-fp-armv8"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="Image"
-
-  # Mali GPU family
-    MALI_FAMILY="450"
-    GRAPHIC_DRIVERS="lima"
-
-  # kernel serial console
-    EXTRA_CMDLINE="console=tty0 coherent_pool=2M cec.debounce_ms=5000"
-    if [ "$UBOOT_SYSTEM" != "box-trn9" ]; then
-      EXTRA_CMDLINE="console=uart8250,mmio32,0xff130000 $EXTRA_CMDLINE"
-    fi
-
-  # set the addon project
-    ADDON_PROJECT="ARMv8"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT="hard"
+TARGET_CPU="cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="crypto-neon-fp-armv8"
+KERNEL_TARGET="Image"
+MALI_FAMILY="450"
+GRAPHIC_DRIVERS="lima"
+EXTRA_CMDLINE="console=tty0 coherent_pool=2M cec.debounce_ms=5000"
+if [ "$UBOOT_SYSTEM" != "box-trn9" ]; then
+EXTRA_CMDLINE="console=uart8250,mmio32,0xff130000 $EXTRA_CMDLINE"
+fi
+ADDON_PROJECT="ARMv8"

--- a/projects/Rockchip/devices/RK3399/options
+++ b/projects/Rockchip/devices/RK3399/options
@@ -1,35 +1,11 @@
-################################################################################
-# setup device defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      aarch64)
-        TARGET_CPU="cortex-a72.cortex-a53"
-        TARGET_CPU_FLAGS="+crc+crypto"
-        ;;
-      arm)
-        TARGET_KERNEL_ARCH="arm64"
-        TARGET_FLOAT="hard"
-        TARGET_CPU="cortex-a72.cortex-a53"
-        TARGET_CPU_FLAGS="+crc"
-        TARGET_FPU="crypto-neon-fp-armv8"
-        ;;
-    esac
-
-  # Kernel target
-    KERNEL_TARGET="Image"
-
-  # Mali GPU family
-    MALI_FAMILY="t860"
-    GRAPHIC_DRIVERS="panfrost"
-
-  # kernel serial console
-    EXTRA_CMDLINE="console=uart8250,mmio32,0xff1a0000 console=tty0 coherent_pool=2M cec.debounce_ms=5000"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv8"
-
-  # additional packages
-    ADDITIONAL_PACKAGES+=" pciutils"
+TARGET_KERNEL_ARCH="arm64"
+TARGET_FLOAT="hard"
+TARGET_CPU="cortex-a72.cortex-a53"
+TARGET_CPU_FLAGS="+crc"
+TARGET_FPU="crypto-neon-fp-armv8"
+KERNEL_TARGET="Image"
+MALI_FAMILY="t860"
+GRAPHIC_DRIVERS="panfrost"
+EXTRA_CMDLINE="console=uart8250,mmio32,0xff1a0000 console=tty0 coherent_pool=2M cec.debounce_ms=5000"
+ADDON_PROJECT="ARMv8"
+ADDITIONAL_PACKAGES+=" pciutils"

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -1,87 +1,23 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
-    BOOTLOADER="u-boot"
-
-  # U-Boot make target
-    UBOOT_TARGET="u-boot-dtb.bin"
-
-  # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="rkbin"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD="dtbs"
-
-  # Additional kernel dependencies
-    KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
-
-  # Kernel to use. values can be:
-  # default:  default mainline kernel
-    LINUX="${LINUX:-default}"
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz / zstd)
-    SQUASHFS_COMPRESSION="zstd"
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # OpenGL(X) implementation to use (no / mesa)
-    OPENGL="no"
-
-  # OpenGL-ES implementation to use (no / libmali / mesa)
-    OPENGLES="${OPENGLES:-mesa}"
-
-  # Vulkan implementation to use (vulkan-loader / no)
-    VULKAN="no"
-
-  # Displayserver to use (wl / no)
-    DISPLAYSERVER="no"
-
-  # Windowmanager to use (weston / no)
-    WINDOWMANAGER="no"
-
-  # Xorg Graphic drivers to use (all / lima,panfrost)
-  # Space separated list is supported,
-  # e.g. GRAPHIC_DRIVERS="lima panfrost"
-    GRAPHIC_DRIVERS=""
-
-  # KODI Player implementation to use (default / bcm2835-driver / libfslvpuwrap)
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-  # Space separated list is supported,
-  # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware"
-
-  # additional packages to install
-    ADDITIONAL_PACKAGES="dtc"
-
-  # build and install CEC framework support (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
-
-  # build with installer (yes / no)
-    INSTALLER_SUPPORT="no"
-
-  # Start boot partition at 16MiB, same as https://github.com/rockchip-linux/build images
-    SYSTEM_PART_START=32768
-
-  # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
-
-  # driver addons to install:
-  # for a list of additinoal drivers see packages/linux-driver-addons
-  # Space separated list is supported,
-    DRIVER_ADDONS="dvb-latest"
-
-  # debug tty path
-    DEBUG_TTY="/dev/ttyS2"
+BOOTLOADER="u-boot"
+UBOOT_TARGET="u-boot-dtb.bin"
+UBOOT_FIRMWARE="rkbin"
+KERNEL_MAKE_EXTRACMD="dtbs"
+KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+ALSA_SUPPORT="yes"
+OPENGL="no"
+OPENGLES="${OPENGLES:-mesa}"
+VULKAN="no"
+DISPLAYSERVER="no"
+WINDOWMANAGER="no"
+GRAPHIC_DRIVERS=""
+KODIPLAYER_DRIVER="$OPENGLES"
+FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware"
+ADDITIONAL_PACKAGES="dtc"
+CEC_FRAMEWORK_SUPPORT="yes"
+INSTALLER_SUPPORT="no"
+SYSTEM_PART_START=32768
+DRIVER_ADDONS_SUPPORT="no"
+DRIVER_ADDONS="dvb-latest"
+DEBUG_TTY="/dev/ttyS2"

--- a/projects/Samsung/devices/Exynos/options
+++ b/projects/Samsung/devices/Exynos/options
@@ -1,25 +1,7 @@
-################################################################################
-# setup device defaults
-################################################################################
-
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      arm)
-        TARGET_CPU="cortex-a15.cortex-a7"
-        TARGET_FLOAT="hard"
-        TARGET_FPU="neon-vfpv4"
-        ;;
-    esac
-
-  # OpenGL-ES implementation to use
-    OPENGLES="libmali"
-
-  # Graphic drivers to use
-    GRAPHIC_DRIVERS="mali"
-
-  # KODI Player implementation to use
-    KODIPLAYER_DRIVER="$OPENGLES"
-
-  # Mali GPU family
-    MALI_FAMILY="t620"
+TARGET_CPU="cortex-a15.cortex-a7"
+TARGET_FLOAT="hard"
+TARGET_FPU="neon-vfpv4"
+OPENGLES="libmali"
+GRAPHIC_DRIVERS="mali"
+KODIPLAYER_DRIVER="$OPENGLES"
+MALI_FAMILY="t620"

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -1,91 +1,24 @@
-################################################################################
-# setup system defaults
-################################################################################
-
-  # Bootloader to use (syslinux / u-boot / bcm2835-bootloader)
-    BOOTLOADER="u-boot"
-
-  # U-Boot firmware package(s) to use
-    UBOOT_FIRMWARE="exynos-boot-fip"
-
-  # Kernel target for u-boot (default 'uImage' if BOOTLOADER=u-boot) (uImage / zImage)
-    KERNEL_TARGET="zImage"
-
-  # Additional kernel dependencies
-    KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
-
-  # Additional kernel make parameters (for example to specify the u-boot loadaddress)
-    KERNEL_MAKE_EXTRACMD="dtbs"
-
-  # Kernel to use:
-    LINUX="samsung"
-
-  # kernel serial console
-    EXTRA_CMDLINE="quiet systemd.debug_shell=ttySAC2 console=ttySAC2,115200n8 console=tty0"
-
-  # Default system partition offset in sectors
-    SYSTEM_PART_START=3072
-
-
-################################################################################
-# setup build defaults
-################################################################################
-
-  # Project CFLAGS
-    PROJECT_CFLAGS=""
-
-  # SquashFS compression method (gzip / lzo / xz)
-    SQUASHFS_COMPRESSION="zstd"
-
-
-################################################################################
-# setup project defaults
-################################################################################
-
-  # OpenGL(X) implementation to use (no / mesa)
-    OPENGL="no"
-
-  # Vulkan implementation to use (vulkan-loader / no)
-    VULKAN="no"
-
-  # Displayserver to use (wl / no)
-    DISPLAYSERVER="no"
-
-  # Windowmanager to use (weston / no)
-    WINDOWMANAGER="no"
-
-  # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-  # Space separated list is supported,
-  # e.g. FIRMWARE="dvb-firmware misc-firmware wlan-firmware"
-    FIRMWARE="kernel-firmware wlan-firmware"
-
-  # build with installer (yes / no)
-    INSTALLER_SUPPORT="no"
-
-  # additional packages to install:
-  # Space separated list is supported,
-  # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
-    ADDITIONAL_PACKAGES="dtc"
-
-  # additional drivers to install:
-  # for a list of additional drivers see packages/linux-drivers
-  # Space separated list is supported,
-  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS=""
-
-  # build and install driver addons (yes / no)
-    DRIVER_ADDONS_SUPPORT="no"
-
-  # driver addons to install:
-  # for a list of additional drivers see packages/linux-driver-addons
-  # Space separated list is supported,
-    DRIVER_ADDONS="crazycat dvb-latest"
-
-  # use the kernel CEC framework for libcec (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
-
-  # debug tty path
-    DEBUG_TTY="/dev/ttySAC2"
-
-  # set the addon project
-    ADDON_PROJECT="ARMv7"
+BOOTLOADER="u-boot"
+UBOOT_FIRMWARE="exynos-boot-fip"
+KERNEL_TARGET="zImage"
+KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
+KERNEL_MAKE_EXTRACMD="dtbs"
+LINUX="samsung"
+EXTRA_CMDLINE="quiet systemd.debug_shell=ttySAC2 console=ttySAC2,115200n8 console=tty0"
+SYSTEM_PART_START=3072
+PROJECT_CFLAGS=""
+SQUASHFS_COMPRESSION="zstd"
+ALSA_SUPPORT="yes"
+OPENGL="no"
+VULKAN="no"
+DISPLAYSERVER="no"
+WINDOWMANAGER="no"
+FIRMWARE="kernel-firmware wlan-firmware"
+INSTALLER_SUPPORT="no"
+ADDITIONAL_PACKAGES="dtc"
+ADDITIONAL_DRIVERS=""
+DRIVER_ADDONS_SUPPORT="no"
+DRIVER_ADDONS="crazycat dvb-latest"
+CEC_FRAMEWORK_SUPPORT="yes"
+DEBUG_TTY="/dev/ttySAC2"
+ADDON_PROJECT="ARMv7"

--- a/scripts/make_config
+++ b/scripts/make_config
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [ -z "${1}" -a "${1}" != "--help" -a "${1}" != "-h" ]; then
+  echo -e "A kconfig command must be specified:\n"
+  echo -e "${0} menuconfig"
+  exit
+fi
+
+CONFIG_COMMAND="${1}"
+
+# include required variables
+. config/required_options
+
+export KCONFIG_CONFIG="${DISTRO}-${PROJECT}-${DEVICE}-${TARGET_ARCH}.config"
+
+# read DISTRO options
+if [ -f "${DISTRO_DIR}/${DISTRO}/options" ]; then
+  cat "${DISTRO_DIR}/${DISTRO}/options" > "${ROOT}/${KCONFIG_CONFIG}"
+fi
+
+# read PROJECT options
+if [ -f "${PROJECT_DIR}/${PROJECT}/options" ]; then
+  cat "${PROJECT_DIR}/${PROJECT}/options" >> "${ROOT}/${KCONFIG_CONFIG}"
+fi
+
+# read DEVICE options
+if [ -f "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/options" ]; then
+  cat "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/options" >> "${ROOT}/${KCONFIG_CONFIG}"
+fi
+
+# read local persistent options from $ROOT if available
+if [ -f "${ROOT}/.libreelec/options" ]; then
+  cat "${ROOT}/.libreelec/options" >> "${ROOT}/${KCONFIG_CONFIG}"
+fi
+
+# read global persistent options from $HOME if available
+if [ -f "${HOME}/.libreelec/options" ]; then
+  cat "${HOME}/.libreelec/options" >> "${ROOT}/${KCONFIG_CONFIG}"
+fi
+
+# hack until we change to CONFIG_ prefix (or maybe something else)
+export CONFIG_=""
+
+${CONFIG_COMMAND}


### PR DESCRIPTION
This allows tracking the LibreELEC configuration options through kconfig.

For this purpose I have been testing with [Kconfiglib](https://github.com/ulfalizer/Kconfiglib). It can be easily installed with pip.
```
pip3 install kconfiglib
```

The main reason I wanted to do this was to have a uniform and central location for all configuration options. This allows us to have better help, and dependency tracking for config options. Options will be able to depend on other options instead of having to handle that in shell scripts.

This also allow one to use `menuconfig` (and other kconfig utilities) to configure the options. This is quite nice.
This can be invoked with
```
$ PROJECT=RPi ARCH=arm DEVICE=RPi4 make menuconfig
```
or similar.
I have created a helper script that is also available to call directly (for other kconfig utilities).

```
$ PROJECT=RPi ARCH=arm DEVICE=RPi4 ./scripts/make_config olddefconfig
```

Basically all options files are merged into a single file during the build and `olddefconfig` is used to create a final config file which is then sourced by the shell scripts. This is nice because it tells you if options are wrong or specified multiple times.

I've made this PR just to get some feedback if people like this idea or not. I didn't want to commit a bunch of time to writing a bunch of documentation and changing all the current shell logic to use `y` instead of `yes`. I have also (ab)used the use of strings in kconfig when a lot of them should really be booleans. This can be improved if we decide we like this direction.

I've only built for Generic-gbm and RPI4, I haven't tested the other projects/devices.

Projects that use kconfig (of some kind)
 - linux
 - u-boot
 - busybox
 - crosstool-ng

some screenshots

<img width="632" alt="Screen Shot 2022-06-07 at 8 02 59 PM" src="https://user-images.githubusercontent.com/1616460/172523034-2ac804ce-7f70-44b4-a6a5-33c14e7fbd47.png">

<img width="632" alt="Screen Shot 2022-06-07 at 8 03 42 PM" src="https://user-images.githubusercontent.com/1616460/172523056-dbec6b96-c4f3-43c4-9054-87524196a088.png">

<img width="632" alt="Screen Shot 2022-06-07 at 8 03 57 PM" src="https://user-images.githubusercontent.com/1616460/172523071-88a33a84-08af-4de4-a84d-00d4223f40f3.png">

<img width="632" alt="Screen Shot 2022-06-07 at 8 04 03 PM" src="https://user-images.githubusercontent.com/1616460/172523086-0c540609-96b3-4452-94dc-1ed08ec52716.png">

<img width="632" alt="Screen Shot 2022-06-07 at 8 04 13 PM" src="https://user-images.githubusercontent.com/1616460/172523101-dc1d313f-a2b8-4af5-bfa7-9c6dceebbcfa.png">


Thanks for reading.
