### PR TITLE
[le11] docker: update addon to (137)

### DIFF
--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.6.5"
-PKG_SHA256="f7fe74839b470a38230fac0a3c51c387cdd6846692bce00eec530bbe5ff0a86f"
+PKG_VERSION="1.6.6"
+PKG_SHA256="27afb673c20d53aa5c31aec07b38eb7e4dc911e7e1f0c76fac9513bbf070bd24"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-PKG_GIT_COMMIT="8686ededfc90076914c5238eb96c883ea093a8ba"
+PKG_GIT_COMMIT="10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/runc/package.mk
+++ b/packages/addons/addon-depends/docker/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.1.2"
-PKG_SHA256="0ccce82b1d9c058d8fd7443d261c96fd7a803f2775bcb1fec2bdb725bc7640f6"
+PKG_VERSION="1.1.3"
+PKG_SHA256="fc1c70e095d662e38a5889bc6de41857762ce022caaf8be2852663198c533a63"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-PKG_GIT_COMMIT="2c7861bc5e1b3e756392236553ec14a78a09f8bf"
+PKG_GIT_COMMIT="6724737f999df9ee0d8ca5c6d7b81f97adc34374"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/service/docker/changelog.txt
+++ b/packages/addons/service/docker/changelog.txt
@@ -1,3 +1,7 @@
+137
+- containerd: update to 1.6.6
+- runc: update to 1.1.3
+
 136
 - moby: update to 22.06.0-beta.0
 - cli: update to 22.06.0-beta.0

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="136"
+PKG_REV="137"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
Minor security update: 
- containerd: update to 1.6.6
- https://github.com/containerd/containerd/releases/tag/v1.6.6
- The sixth patch release for containerd 1.6 includes a fix for
[CVE-2022-31030](https://github.com/containerd/containerd/security/advisories/GHSA-5ffw-gxpp-mxpf).
- runc: update 1.1.3
