### PR TITLE
Generate and use temporary IPv6 addresses

### DIFF
--- a/packages/linux/sysctl.d/network.conf
+++ b/packages/linux/sysctl.d/network.conf
@@ -1,1 +1,5 @@
 net.ipv4.tcp_no_metrics_save=1
+
+# generate/use temporary IPv6 addresses
+net.ipv6.conf.all.use_tempaddr = 2
+net.ipv6.conf.default.use_tempaddr = 2


### PR DESCRIPTION
Temporary addresses are privacy-preserving for outgoing traffic, as they
don't disclose the MAC address.
See also https://blog.apnic.net/2022/06/10/iot-devices-endanger-ipv6-privacy/

The MAC-derived IPv6 stays, so clients (e.g. IP-based remotes) have a
permanent IPv6 as before.
Servers, including local ones, will see changing IPv6 addresses when
contacted by LibreELEC. Users who don't like this may revert this
setting.

This shouldn't break anything. It only has an effect for IPv6-enabled networks.