### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="20.2.1-Nexus"
-PKG_SHA256="5635c0503d410915aeb9334ad31e4dee2083f6ac77ccaa46eb641a7271f1c33e"
+PKG_VERSION="20.2.2-Nexus"
+PKG_SHA256="d0280c43776a96d1402edcb509d2265f35dfed217eb93887b4503c34d62a96c2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="20.2.1-Nexus"
-PKG_SHA256="224d0d1a043a48c41b4fe35ade10f95ecb66a2f8778511016cffd8441a977a1d"
+PKG_VERSION="20.2.2-Nexus"
+PKG_SHA256="d13e3659965d8cfa6c232c770672fcb3e8c64be1e842e161418eed4cce11984c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"


### PR DESCRIPTION
- inputstream.adaptive: update 20.2.1-Nexus to 20.2.2-Nexus
- inputstream.ffmpegdirect: update 20.2.1-Nexus to 20.2.2-Nexus