### PR TITLE
[le11] config/arch.x86_64: updated TARGET_CPU & TARGET_FEATURES

### DIFF
--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -1,24 +1,30 @@
 # determines TARGET_CPU, if not forced by user
-  if [ -z "$TARGET_CPU" ]; then
-    TARGET_CPU=core2
-  fi
-
-  # 64bit userland
-  if [ -z "${TARGET_FEATURES}" ]; then
-    TARGET_FEATURES="64bit"
-  else
-    TARGET_FEATURES+=" 64bit"
+  if [ -z "${TARGET_CPU}" ]; then
+    TARGET_CPU="x86-64"
   fi
 
 # determine architecture's family
-  TARGET_SUBARCH=x86_64
+  TARGET_SUBARCH="x86_64"
 
   TARGET_GCC_ARCH="${TARGET_SUBARCH/-/}"
-  TARGET_KERNEL_ARCH=x86
+  TARGET_KERNEL_ARCH="x86"
 
 # setup ARCH specific *FLAGS
-  TARGET_CFLAGS="-march=$TARGET_CPU"
-  TARGET_LDFLAGS="-march=$TARGET_CPU"
+  TARGET_CFLAGS="-march=${TARGET_CPU}"
+  TARGET_LDFLAGS="-march=${TARGET_CPU}"
 
-# build with SIMD support ( yes / no )
-  TARGET_FEATURES+=" mmx sse sse2"
+# build with microarchitecture feature support defined by the TARGET_CPU value
+# see https://gitlab.com/x86-psABIs/x86-64-ABI/-/wikis/home for further details
+  TARGET_FEATURES="64bit cmov cx8 fpu fxsr mmx osfxsr sce sse sse2"
+  TARGET_FEATURES_X86_64_V2="cmpxchg16b lahf-sahf popcnt sse3 sse4_1 sse4_2 ssse3"
+  TARGET_FEATURES_X86_64_V3="avx avx2 bmi1 bmi2 f16c fma lzcnt movbe osxsave"
+  if [ "${TARGET_CPU}" = "x86-64" ]; then
+    TARGET_FEATURES+=" no_sahf"
+  elif [ "${TARGET_CPU}" = "x86-64-v2" ]; then
+    TARGET_FEATURES+=" ${TARGET_FEATURES_X86_64_V2}"
+  elif [ "${TARGET_CPU}" = "x86-64-v3" ]; then
+    TARGET_FEATURES+=" ${TARGET_FEATURES_X86_64_V2} ${TARGET_FEATURES_X86_64_V3}"
+  else
+    TARGET_FEATURES+=" UNKNOWN_ADDITIONAL_CPU_SPECIFIC_FEATURES"
+  fi
+  TARGET_FEATURES="$(echo ${TARGET_FEATURES} | xargs -n1 | sort -u | xargs)"

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -6,10 +6,15 @@
   # generated code.
     case $TARGET_ARCH in
       x86_64)
-        # (AMD CPUs)    k8 k8-sse3 opteron opteron-sse3 athlon64 athlon64-sse3
-        #               athlon-fx amdfam10 barcelona
-        # (Intel CPUs)  atom core2 nocona
+        # Valid TARGET_CPU values as defined at:
+        # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+        # x86-64       A generic CPU with 64-bit extensions.
         #
+        # x86-64-v2    e.g. AMD CPU - Bulldozer - (bdver1)
+        #                   Intel CPU - Nehalem - (nehalem)
+        #
+        # x86-64-v3    e.g. AMD CPU - Bulldozer GEN4 - (bdver4)
+        #                   Intel CPU - Haswell - (haswell)
         TARGET_CPU="x86-64"
         ;;
     esac


### PR DESCRIPTION
- first things first: this should not change the current build behaviour/result
- set default `TARGET_CPU` to `x86-64` instead `core2` if none was specified
- [GCC 11 introduced x86-64 microarchitecture feature levels](https://www.phoronix.com/scan.php?page=news_item&px=GCC-11-x86-64-Feature-Levels) so we can depend on them
- Generic is always 64bit nowadays so git rid of additional 64bit userland opts & add it  to `TARGET_FEATURES`
- clean up the "SIMD support" leftovers after https://github.com/LibreELEC/LibreELEC.tv/pull/2577
- replace them with the actual target cpu feature set defined by [GCC](https://github.com/gcc-mirror/gcc/blob/releases/gcc-11.2.0/gcc/config/i386/i386.h#L2520-L2521)
- If necessary it also allows to fine tune packages for target features like https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/x11/lib/pixman/package.mk#L25-L27 by adding SSE/AVX build opts dependent on the cpu feature set
- compiling with `x86-64-v2` [speeds things up](https://fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0073_x86_64_platform_requirement#performance) - so most likely interesting for downstream projetcs and/or LE if we drop support for ancient hardware (~pre 2011 AMD stuff / 2008 Intel stuff)
- https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level#

If you decide to compile for e.g. `x86-64-v3` config will list all the expected target cpu features to run the binaries/build. 

### x86-64
```
 =================================================================================
 Configuration for LibreELEC (community)
 =================================================================================

 Buildsystem configuration:
 ======================================================
 - CPU:					 x86-64
 - Kernel Architecture:			 x86
 - Userland Architecture:		 x86_64
 - CPU features:			 64bit cmov cx8 fpu fxsr mmx no_sahf osfxsr sce sse sse2
 - LTO (Link Time Optimization) support: yes
 - GOLD (Google Linker) Support:	 yes
 - LLVM support:			 yes
 - DEBUG:				 no
 - CFLAGS:				 -march=x86-64 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG
 - LDFLAGS:				 -march=x86-64 -Wl,--as-needed -fuse-ld=gold
```

### x86-64-v2
```
 =================================================================================
 Configuration for LibreELEC (community)
 =================================================================================

 Buildsystem configuration:
 ======================================================
 - CPU:					 x86-64-v2
 - Kernel Architecture:			 x86
 - Userland Architecture:		 x86_64
 - CPU features:			 64bit cmov cmpxchg16b cx8 fpu fxsr lahf-sahf mmx osfxsr popcnt sce sse sse2 sse3 sse4_1 sse4_2 ssse3
 - LTO (Link Time Optimization) support: yes
 - GOLD (Google Linker) Support:	 yes
 - LLVM support:			 yes
 - DEBUG:				 no
 - CFLAGS:				 -march=x86-64-v2 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG
 - LDFLAGS:				 -march=x86-64-v2 -Wl,--as-needed -fuse-ld=gold
```

### x86-64-v3
```
 =================================================================================
 Configuration for LibreELEC (community)
 =================================================================================

 Buildsystem configuration:
 ======================================================
 - CPU:					 x86-64-v3
 - Kernel Architecture:			 x86
 - Userland Architecture:		 x86_64
 - CPU features:			 64bit avx avx2 bmi1 bmi2 cmov cmpxchg16b cx8 f16c fma fpu fxsr lahf-sahf lzcnt mmx movbe osfxsr osxsave popcnt sce sse sse2 sse3 sse4_1 sse4_2 ssse3
 - LTO (Link Time Optimization) support: yes
 - GOLD (Google Linker) Support:	 yes
 - LLVM support:			 yes
 - DEBUG:				 no
 - CFLAGS:				 -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG
 - LDFLAGS:				 -march=x86-64-v3 -Wl,--as-needed -fuse-ld=gold
``` 

### haswell
```
 =================================================================================
 Configuration for LibreELEC (community)
 =================================================================================

 Buildsystem configuration:
 ======================================================
 - CPU:					 haswell
 - Kernel Architecture:			 x86
 - Userland Architecture:		 x86_64
 - CPU features:			 64bit UNKNOWN_ADDITIONAL_CPU_SPECIFIC_FEATURES cmov cx8 fpu fxsr mmx osfxsr sce sse sse2
 - LTO (Link Time Optimization) support: yes
 - GOLD (Google Linker) Support:	 yes
 - LLVM support:			 yes
 - DEBUG:				 no
 - CFLAGS:				 -march=haswell -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG
 - LDFLAGS:				 -march=haswell -Wl,--as-needed -fuse-ld=gold
``` 