### PR TITLE
u-boot: Prevent /usr/include/libfdt_env.h from being included

### DIFF
--- a/packages/tools/u-boot/patches/rockchip/u-boot-0018-fix-libfdt-compilation.patch
+++ b/packages/tools/u-boot/patches/rockchip/u-boot-0018-fix-libfdt-compilation.patch
@@ -1,0 +1,12 @@
+diff --git a/include/libfdt_env.h b/include/libfdt_env.h
+index 273b5d30f8..bbb6d6a759 100644
+--- a/include/libfdt_env.h
++++ b/include/libfdt_env.h
+@@ -9,6 +9,7 @@
+ #ifndef _LIBFDT_ENV_H
+ #define _LIBFDT_ENV_H
+ 
++#define LIBFDT_ENV_H
+ #include "compiler.h"
+ #include "linux/types.h"
+ 


### PR DESCRIPTION
u-boot compilation for arm64 seems to fail due to existing /usr/include/libfdt_env.h which re-defines few of the types defined in this file.
The define in the patch prevents that file from being included.