### PR TITLE
Audio package updates

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/alsa-plugins/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-plugins"
-PKG_VERSION="1.2.6"
-PKG_SHA256="068818a4b55d8c029daa00015d853d45113f56b224b7c64e1e117988c825b2a0"
+PKG_VERSION="1.2.7.1"
+PKG_SHA256="8c337814954bb7c167456733a6046142a2931f12eccba3ec2a4ae618a3432511"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.alsa-project.org/"
 PKG_URL="ftp://ftp.alsa-project.org/pub/plugins/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-lib"
-PKG_VERSION="1.2.7"
-PKG_SHA256="8814e61f7ec6812c76e23a85cab00e0b0d3bba40816af36b726beb1bc04c74a7"
+PKG_VERSION="1.2.7.1"
+PKG_SHA256="046dc42dfcfad269217be05954686137e5e7397f3041372f8c6dcd7d79461e61"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.alsa-project.org/"
 PKG_URL="https://www.alsa-project.org/files/pub/lib/alsa-lib-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/alsa-ucm-conf/package.mk
+++ b/packages/audio/alsa-ucm-conf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-ucm-conf"
-PKG_VERSION="1.2.7"
-PKG_SHA256="b97f2395ca2c1fd9bfab7627f0178f9069868e2a42a35894dacd280e7e40680e"
+PKG_VERSION="1.2.7.1"
+PKG_SHA256="ac5b2a1275783eff07e1cb34c36c6c5987742679a340037507c04a9dc1d22cac"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="https://www.alsa-project.org/"
 PKG_URL="https://www.alsa-project.org/files/pub/lib/alsa-ucm-conf-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/espeak-ng/package.mk
+++ b/packages/audio/espeak-ng/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="espeak-ng"
-PKG_VERSION="1.50"
-PKG_SHA256="80ee6cd06fcd61888951ab49362b400e80dd1fac352a8b1131d90cfe8a210edb"
+PKG_VERSION="1.51"
+PKG_SHA256="027fa5dfa8616d5cc13f883209ff5f735eee6559f7689a019d5b2d01d290cd39"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/espeak-ng/espeak-ng"
-PKG_URL="https://github.com/espeak-ng/espeak-ng/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tgz"
+PKG_URL="https://github.com/espeak-ng/espeak-ng/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="gcc:host "
 PKG_DEPENDS_TARGET="toolchain espeak-ng:host"
 PKG_LONGDESC="eSpeak NG is an open source speech synthesizer that supports more than a hundred languages and accents"

--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.2.3"
-PKG_SHA256="b31807cb0f88e97f3096e2b378c9815a6acfdc20b0b14f97936d905b536965c4"
+PKG_VERSION="2.2.7"
+PKG_SHA256="460d86d8d687f567dc4780890b72538c7ff6b2082080ef2f9359d41670a309cf"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.5.15"
-PKG_SHA256="bca80f897b479d39926e16058db4fb9fd618ab8be6cbe96608736628bfd8b15c"
+PKG_VERSION="0.6.4"
+PKG_SHA256="e09fb845c3292700a7ac13c3b31d669ecd3bdbebcbfe1328eba2376cebe40162"
 PKG_LICENSE="BSD"
 PKG_SITE="https://lib.openmpt.org/libopenmpt/"
 PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/audio/libsndfile/package.mk
+++ b/packages/audio/libsndfile/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libsndfile"
-PKG_VERSION="1.0.31"
-PKG_SHA256="8cdee0acb06bb0a3c1a6ca524575643df8b1f3a55a0893b4dd9f829d08263785"
+PKG_VERSION="1.1.0"
+PKG_SHA256="642a876bd61b63f9346628dba5f8a0356a3ad750c7f6f42019d26ce60ba6a15b"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://libsndfile.github.io/libsndfile/"
 PKG_URL="https://github.com/libsndfile/libsndfile/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/libsndfile/patches/libsndfile-add-required-static-libaries-to-pkg-config.patch
+++ b/packages/audio/libsndfile/patches/libsndfile-add-required-static-libaries-to-pkg-config.patch
@@ -1,9 +1,10 @@
---- a/sndfile.pc	2021-01-24 23:22:23.000000000 +1100
+--- a/sndfile.pc.in	2021-01-24 23:22:23.000000000 +1100
 +++ b/sndfile.pc.in	2021-09-12 14:30:47.763655089 +1000
-@@ -8,5 +8,5 @@
+@@ -8,6 +8,6 @@
  Requires:
- Requires.private: @EXTERNAL_XIPH_REQUIRE@
+ Requires.private: @EXTERNAL_XIPH_REQUIRE@ @EXTERNAL_MPEG_REQUIRE@
  Version: @VERSION@
 -Libs: -L${libdir} -lsndfile
 +Libs: -L${libdir} -lsndfile -lFLAC -lvorbis -logg -lvorbisenc -lopus
+ Libs.private: @EXTERNAL_MPEG_LIBS@
  Cflags: -I${includedir}

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.51"
-PKG_SHA256="f18e7a2cd2fcd75482c3df4e736e01435bd20779ddf63da63b0a086d3a9735ac"
+PKG_VERSION="0.3.52"
+PKG_SHA256="024ec4b2f77e6049ba3acb569250943f736a366a05f4b8fce42e09e678b43039"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/speex/package.mk
+++ b/packages/audio/speex/package.mk
@@ -3,10 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="speex"
-PKG_VERSION="1.2.0"
-PKG_SHA256="eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
+PKG_VERSION="1.2.1"
+PKG_SHA256="cc55cce69d8753940d56936f7a1fe6db4b302df144aec93a92de1c65b1a87681"
 PKG_LICENSE="BSD"
 PKG_SITE="https://speex.org"
-PKG_URL="http://downloads.us.xiph.org/releases/speex/speex-${PKG_VERSION}.tar.gz"
+PKG_URL="https://gitlab.xiph.org/xiph/speex/-/archive/Speex-${PKG_VERSION}/speex-Speex-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="An Open Source Software patent-free audio compression format designed for speech."
+PKG_TOOLCHAIN="autotools"

--- a/packages/audio/speexdsp/package.mk
+++ b/packages/audio/speexdsp/package.mk
@@ -2,10 +2,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="speexdsp"
-PKG_VERSION="1.2.0"
-PKG_SHA256="682042fc6f9bee6294ec453f470dadc26c6ff29b9c9e9ad2ffc1f4312fd64771"
+PKG_VERSION="1.2.1"
+PKG_SHA256="b36d4f16e42b7103b7fc3e4a8f98b6bf889dd1f70f65c2365af07be82844db29"
 PKG_LICENSE="BSD"
 PKG_SITE="https://speex.org"
-PKG_URL="http://downloads.us.xiph.org/releases/speex/speexdsp-${PKG_VERSION}.tar.gz"
+PKG_URL="https://gitlab.xiph.org/xiph/speexdsp/-/archive/SpeexDSP-${PKG_VERSION}/speexdsp-SpeexDSP-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Speex audio processing library"
+PKG_TOOLCHAIN="autotools"


### PR DESCRIPTION
- alsa-lib: update to 1.2.7.1
- alsa-plugins: update to 1.2.7.1
- alsa-ucm-conf: update to 1.2.7.1
- espeak-ng: update to 1.51
- fluidsynth: update to 2.2.7
- libopenmpt: update to 0.6.4
- libsndfile: update to 1.1.0
- pipewire: update to 0.3.52
- speexdsp: update to 1.2.1
- speex: update to 1.2.1