### PR TITLE
libfmt: update to 8.1.1

### DIFF
--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libfmt"
-PKG_VERSION="8.0.1"
-PKG_SHA256="b06ca3130158c625848f3fb7418f235155a4d389b2abc3a6245fb01cb0eb1e01"
+PKG_VERSION="8.1.1"
+PKG_SHA256="3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/fmtlib/fmt"
 PKG_URL="https://github.com/fmtlib/fmt/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Kodi has been updated to support 8.1.1

- https://github.com/fmtlib/fmt/releases/tag/8.1.0
- https://github.com/fmtlib/fmt/releases/tag/8.1.1