### PR TITLE
packages/devel updates

### DIFF
--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="boost"
-PKG_VERSION="1.78.0"
-PKG_SHA256="8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
+PKG_VERSION="1.79.0"
+PKG_SHA256="475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.boost.org/"
 PKG_URL="https://boostorg.jfrog.io/artifactory/main/release/${PKG_VERSION}/source/${PKG_NAME}_${PKG_VERSION//./_}.tar.bz2"

--- a/packages/devel/fribidi/package.mk
+++ b/packages/devel/fribidi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fribidi"
-PKG_VERSION="1.0.11"
-PKG_SHA256="30f93e9c63ee627d1a2cedcf59ac34d45bf30240982f99e44c6e015466b4e73d"
+PKG_VERSION="1.0.12"
+PKG_SHA256="0cd233f97fc8c67bb3ac27ce8440def5d3ffacf516765b91c2cc654498293495"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://fribidi.freedesktop.org/"
 PKG_URL="https://github.com/fribidi/fribidi/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/libaio/package.mk
+++ b/packages/devel/libaio/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libaio"
-PKG_VERSION="0.3.112"
-PKG_SHA256="f69e5800425f4ea957426693ac09f9896bb993db5490fa021644454adcc72a32"
+PKG_VERSION="0.3.113"
+PKG_SHA256="716c7059703247344eb066b54ecbc3ca2134f0103307192e6c2b7dab5f9528ab"
 PKG_LICENSE="GPL"
-PKG_SITE="http://lse.sourceforge.net/io/aio.html"
-PKG_URL="http://http.debian.net/debian/pool/main/liba/libaio/${PKG_NAME}_${PKG_VERSION}.orig.tar.xz"
+PKG_SITE="https://pagure.io/libaio"
+PKG_URL="https://pagure.io/${PKG_NAME}/archive/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Kernel Asynchronous I/O (AIO) Support for Linux."
 

--- a/packages/devel/libcap/package.mk
+++ b/packages/devel/libcap/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcap"
-PKG_VERSION="2.63"
-PKG_SHA256="0c637b8f44fc7d8627787e9cf57f15ac06c1ddccb53e41feec5496be3466f77f"
+PKG_VERSION="2.64"
+PKG_SHA256="c8465e1f0b068d5fc06199231135ccac7adb56d662b1de93589252e8cd071e13"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libcap/libcap.git/log/"
 PKG_URL="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/spdlog/package.mk
+++ b/packages/devel/spdlog/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spdlog"
-PKG_VERSION="1.9.2"
-PKG_SHA256="6fff9215f5cb81760be4cc16d033526d1080427d236e86d70bb02994f85e3d38"
+PKG_VERSION="1.10.0"
+PKG_SHA256="697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/gabime/spdlog"
 PKG_URL="https://github.com/gabime/spdlog/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- boost: update to 1.79.0
- fribidi: update to 1.0.12
- libaio: update to 0.3.113 and PKG_ urls
- libcap: update to 2.64
- spdlog: update to 1.10.0