### PR TITLE
nettle: update to 3.8 and HTTPS

### DIFF
--- a/packages/security/nettle/package.mk
+++ b/packages/security/nettle/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nettle"
-PKG_VERSION="3.7.3"
-PKG_SHA256="661f5eb03f048a3b924c3a8ad2515d4068e40f67e774e8a26827658007e3bcf0"
+PKG_VERSION="3.8"
+PKG_SHA256="7576c68481c198f644b08c160d1a4850ba9449e308069455b5213319f234e8e6"
 PKG_LICENSE="GPL2"
 PKG_SITE="http://www.lysator.liu.se/~nisse/nettle"
-PKG_URL="http://ftpmirror.gnu.org/gnu/nettle/nettle-${PKG_VERSION}.tar.gz"
+PKG_URL="https://ftp.gnu.org/gnu/nettle/nettle-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain gmp"
 PKG_LONGDESC="A low-level cryptographic library."
 


### PR DESCRIPTION
news:
- https://git.lysator.liu.se/nettle/nettle/-/commit/a2be57f0502bae7869956c83d1ba620bfab051b3

of note - for aarch64:
          New ARM64 implementation of AES, GCM, Chacha, SHA1 and
	  SHA256, for processors supporting crypto extensions. Great
	  speedups, and fat builds are supported. Contributed by
	  Mamone Tarsha.