### PR TITLE
binutils-yyy: do not build documentation

### DIFF
--- a/packages/devel/binutils-aarch64/package.mk
+++ b/packages/devel/binutils-aarch64/package.mk
@@ -42,11 +42,11 @@ pre_configure_host() {
 
 make_host() {
   make configure-host
-  make
+  make MAKEINFO=true
 }
 
 makeinstall_host() {
   cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
   make -C bfd install # fix parallel build with libctf requiring bfd
-  make install
+  make MAKEINFO=true install
 }

--- a/packages/devel/binutils-bpf/package.mk
+++ b/packages/devel/binutils-bpf/package.mk
@@ -42,11 +42,11 @@ pre_configure_host() {
 
 make_host() {
   make configure-host
-  make
+  make MAKEINFO=true
 }
 
 makeinstall_host() {
   cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
   make -C bfd install # fix parallel build with libctf requiring bfd
-  make install
+  make MAKEINFO=true install
 }

--- a/packages/devel/binutils-or1k/package.mk
+++ b/packages/devel/binutils-or1k/package.mk
@@ -42,11 +42,11 @@ pre_configure_host() {
 
 make_host() {
   make configure-host
-  make
+  make MAKEINFO=true
 }
 
 makeinstall_host() {
   cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
   make -C bfd install # fix parallel build with libctf requiring bfd
-  make install
+  make MAKEINFO=true install
 }


### PR DESCRIPTION
- binutils-or1k: do not build documentation
- binutils-bpf: do not build documentation
- binutils-aarch64: do not build documentation

Fixes
- Fixes introduced error in #6361

building of the following now work.
- binutils-aarch64:host
- binutils-bpf:host
- binutils-or1k:host