### PR TITLE
rsync: fix potentially wrong rolling checksum values on ARM

### DIFF
--- a/packages/network/rsync/patches/rsync-schar-fix-3.2.4.patch
+++ b/packages/network/rsync/patches/rsync-schar-fix-3.2.4.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 24e383a9..5a53d339 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1117,7 +1117,7 @@ else
+ fi
+ 
+ AC_CACHE_CHECK([for unsigned char],rsync_cv_SIGNED_CHAR_OK,[
+-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[signed char *s = ""]])],[rsync_cv_SIGNED_CHAR_OK=yes],[rsync_cv_SIGNED_CHAR_OK=no])])
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[signed char *s = (signed char *)""]])],[rsync_cv_SIGNED_CHAR_OK=yes],[rsync_cv_SIGNED_CHAR_OK=no])])
+ if test x"$rsync_cv_SIGNED_CHAR_OK" = x"yes"; then
+     AC_DEFINE(SIGNED_CHAR_OK, 1, [Define to 1 if "signed char" is a valid type])
+ fi


### PR DESCRIPTION
See:
- https://lists.samba.org/archive/rsync-announce/2022/000111.html
- https://github.com/WayneD/rsync/commit/4f741addbd5fd59de2c2655e5a044d6c2fe44aa5
- https://github.com/WayneD/rsync/issues/317