### PR TITLE
flac: update to 1.3.4 and HSTS

### DIFF
--- a/packages/audio/flac/package.mk
+++ b/packages/audio/flac/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flac"
-PKG_VERSION="1.3.3"
-PKG_SHA256="213e82bd716c9de6db2f98bcadbc4c24c7e2efe8c75939a1a84e28539c4e1748"
+PKG_VERSION="1.3.4"
+PKG_SHA256="8ff0607e75a322dd7cd6ec48f4f225471404ae2730d0ea945127b1355155e737"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://xiph.org/flac/"
-PKG_URL="http://downloads.xiph.org/releases/flac/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://downloads.xiph.org/releases/flac/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libogg"
 PKG_LONGDESC="An Free Lossless Audio Codec."
 PKG_TOOLCHAIN="autotools"


### PR DESCRIPTION
(missed this one in the audio update bunch)

https://xiph.org/flac/changelog.html

FLAC 1.3.4 (20-Feb-2022)
This release mostly fixes (security related) bugs. When building with MSVC, using CMake is preferred, see the README under "Building with CMake" for more information. Building with MSVC using solution files is deprecated and these files will be removed in the future.

- General:
  - Fix 12 decoder bugs found by oss-fuzz, including CVE-2020-0499 (erikd, Martijn van Beurden)
  - Fix encoder bug CVE-2021-0561 (NeelkamalSemwal)
  - Integrate oss-fuzzers (erikd, Guido Vranken)
  - Seeking fixes (NeelkamalSemwal, Robert Kausch)
  - Various fixes and improvements (Andrei Astafev, Rosen Penev, Håkan Kvist, oreo639, erikd, Tamás Zahola, Ulrik Mikaelsson, Tyler Dunn, tmkk)
- FLAC format:
  - (none)
- Ogg FLAC format:
  - (none)
- flac:
  - Various fixes and improvements (Andrei Astafev, Martijn van Beurden)
- metaflac:
  - (none)
- build system:
  - CMake improvements (evpobr, Vitaliy Kirsanov, erikd, Ozkan Sezer, Tyler Dunn, tg-m   - DeadSix27, ericLemanissier, Chocobo1).
  - Fixes for MinGW and MSVC (Ozkan Sezer).
  - Fix for clang (Ozkan Sezer)
  - Fix for PowerPC (Peter Seiderer, Thomas BERNARD)
  - Fix for FreeBSD PowerPC (pkubaj).
- testing/validation:
  - Add Windows target to CI, improve logging (Ralph Giles)
  - CI improvements (Ralph Giles, Ewout ter Hoeven)
- documentation:
  - Doxygen fixes (Tyler Dunn)
  - Fix typos (Tim Gates, maxz)
- Interface changes:
  - libFLAC:
    - (none)
  - libFLAC++:
    - (none)