### PR TITLE
gdb: Fix ctrl-c handling with gdbserver

### DIFF
--- a/packages/debug/gdb/patches/0001-gdbserver-ctrl-c-handling.patch
+++ b/packages/debug/gdb/patches/0001-gdbserver-ctrl-c-handling.patch
@@ -1,0 +1,40 @@
+From 589e7f396af4c8e4a33dcd1b22be481f150b4fc0 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 29 Nov 2018 18:00:23 -0800
+Subject: [PATCH] gdbserver ctrl-c handling
+
+This problem was created by the upstream commit 78708b7c8c
+After applying the commit, it will send SIGINT to the process
+group(-signal_pid).
+But if we use gdbserver send SIGINT, and the attached process is not a
+process
+group leader, then the "kill (-signal_pid, SIGINT)" returns error and
+fails  to
+interrupt the attached process.
+
+Upstream-Status: Submitted
+[https://sourceware.org/bugzilla/show_bug.cgi?id=18945]
+
+Author: Josh Gao
+Signed-off-by: Zhixiong Chi <zhixiong.chi@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ gdbserver/linux-low.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdbserver/linux-low.cc b/gdbserver/linux-low.cc
+index 8b8614f6ed4..e71e6667c51 100644
+--- a/gdbserver/linux-low.cc
++++ b/gdbserver/linux-low.cc
+@@ -5465,7 +5465,7 @@ linux_process_target::request_interrupt ()
+ {
+   /* Send a SIGINT to the process group.  This acts just like the user
+      typed a ^C on the controlling terminal.  */
+-  ::kill (-signal_pid, SIGINT);
++  ::kill (signal_pid, SIGINT);
+ }
+ 
+ bool
+-- 
+2.25.1
+


### PR DESCRIPTION
See: https://sourceware.org/bugzilla/show_bug.cgi?id=18772
Signed-off-by: Dom Cobley <popcornmix@gmail.com>