### PR TITLE
linux: gzip 64bit kernels on RPi

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -282,6 +282,12 @@ makeinstall_target() {
       fi
     done
   elif [ "${BOOTLOADER}" = "bcm2835-bootloader" ]; then
+    # RPi firmware will decompress gzipped kernels prior to booting
+    if [ "${TARGET_KERNEL_ARCH}" = "arm64" ]; then
+      pigz --best --force ${INSTALL}/.image/${KERNEL_TARGET}
+      mv ${INSTALL}/.image/${KERNEL_TARGET}.gz ${INSTALL}/.image/${KERNEL_TARGET}
+    fi
+
     mkdir -p ${INSTALL}/usr/share/bootloader/overlays
 
     # install platform dtbs, but remove upstream kernel dtbs (i.e. without downstream


### PR DESCRIPTION
RPi firmware since around September 2020 is able to decompress gzipped kernels prior to handing over control. Arm64 kernels do not do self-decompression, so use the firmware's capability.

I don't know exactly which firmware release allows this as the release notes are rather concise. I found this mentioned in this comment: https://github.com/raspberrypi/firmware/issues/1467#issuecomment-693327677

Reduces my .tar by ~11MB on RPi3.