### PR TITLE
linux: update to 5.18.y

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="5.18.5"
-    PKG_SHA256="9c3731d405994f9cd3a1bb72e83140735831b19c7cec18e0d7a8f3046fa034e7"
+    PKG_VERSION="5.18.12"
+    PKG_SHA256="40b74d0942f255da07481710e1083412d06e37e45b8f9d9e34ae856db37b9527"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v5.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;


### PR DESCRIPTION
https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.18.6
https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.18.7
https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.18.8
https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.18.9
https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.18.10
https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.18.11
https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.18.12

5.18.6 - 141 patches
5.18.7 - 11 patches
5.18.8 - 181 patches
5.18.9 - 6 patches
5.18.10 - 102 patches
5.18.11 - 112 patches
5.18.12 - 1 patches

### errors / fixes / issues / regressions
- ~https://comsec.ethz.ch/research/microarch/retbleed/~

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.18.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-5.18.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/5.18

### 5.18.12-rc1 Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=arm DEVICE=Dragonboard s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
```

### 5.18.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - 5.18.11-rc1 - heitbaum
- Generic Generic (Intel TGL - NUC11) - 5.18.12-rc1 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - 5.18.0 - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum (video issue))