### PR TITLE
github: add opencollective sponsorship link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: libreelec


### PR DESCRIPTION
This adds an OC sponsorship link to our main repo.