### PR TITLE
openssl: update to 3.0.4

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="3.0.3"
-PKG_SHA256="ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b"
+PKG_VERSION="3.0.4"
+PKG_SHA256="2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://www.openssl.org"
 PKG_URL="https://www.openssl.org/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/security/openssl/patches/openssl-3-0-4-0001-fix-compile-issues-in-test-v3ext-c-with-no-rfc3779.patch
+++ b/packages/security/openssl/patches/openssl-3-0-4-0001-fix-compile-issues-in-test-v3ext-c-with-no-rfc3779.patch
@@ -1,0 +1,40 @@
+From 65d6793e240643116037b4bb758e40b7db5cc7ee Mon Sep 17 00:00:00 2001
+From: Bernd Edlinger <bernd.edlinger@hotmail.de>
+Date: Fri, 17 Jun 2022 10:25:24 +0200
+Subject: [PATCH] Fix compile issues in test/v3ext.c with no-rfc3779
+
+There are no ASIdentifiers if OPENSSL_NO_RFC3779 is defined,
+therefore the test cannot be compiled.
+---
+ test/v3ext.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/test/v3ext.c b/test/v3ext.c
+index 0d371ec280f1..29e33d16a5fa 100644
+--- a/test/v3ext.c
++++ b/test/v3ext.c
+@@ -37,6 +37,7 @@ static int test_pathlen(void)
+     return ret;
+ }
+ 
++#ifndef OPENSSL_NO_RFC3779
+ static int test_asid(void)
+ {
+     ASN1_INTEGER *val1 = NULL, *val2 = NULL;
+@@ -113,6 +114,7 @@ static int test_asid(void)
+     ASIdentifiers_free(asid4);
+     return testresult;
+ }
++#endif /* OPENSSL_NO_RFC3779 */
+ 
+ OPT_TEST_DECLARE_USAGE("cert.pem\n")
+ 
+@@ -127,6 +129,8 @@ int setup_tests(void)
+         return 0;
+ 
+     ADD_TEST(test_pathlen);
++#ifndef OPENSSL_NO_RFC3779
+     ADD_TEST(test_asid);
++#endif /* OPENSSL_NO_RFC3779 */
+     return 1;
+ }


### PR DESCRIPTION
upstream patches for build:
- https://github.com/openssl/openssl/issues/18619
- https://github.com/openssl/openssl/pull/18188
- https://github.com/openssl/openssl/pull/18634 <—— this is included in the PR.

https://www.openssl.org/news/changelog.html

### Changes between 3.0.3 and 3.0.4 [21 June 2022]

In addition to the c_rehash shell command injection identified in CVE-2022-1292, further bugs where the c_rehash script does not properly sanitise shell metacharacters to prevent command injection have been fixed.

When the CVE-2022-1292 was fixed it was not discovered that there are other places in the script where the file names of certificates being hashed were possibly passed to a command executed through the shell.

This script is distributed by some operating systems in a manner where it is automatically executed. On such operating systems, an attacker could execute arbitrary commands with the privileges of the script.

Use of the c_rehash script is considered obsolete and should be replaced by the OpenSSL rehash command line tool. (CVE-2022-2068)

Daniel Fiala, Tomáš Mráz

Case insensitive string comparison no longer uses locales. It has instead been directly implemented.

Paul Dale