### PR TITLE
[LE11] Allwinner: linux: arm: Enable spidev

### DIFF
--- a/projects/Allwinner/linux/linux.arm.conf
+++ b/projects/Allwinner/linux/linux.arm.conf
@@ -2347,7 +2347,7 @@ CONFIG_SPI_SUN6I=y
 #
 # SPI Protocol Masters
 #
-# CONFIG_SPI_SPIDEV is not set
+CONFIG_SPI_SPIDEV=m
 # CONFIG_SPI_LOOPBACK_TEST is not set
 # CONFIG_SPI_TLE62X0 is not set
 # CONFIG_SPI_SLAVE is not set


### PR DESCRIPTION
It seems that spidev is useful to users. Enable it for arm kernel. It's already enabled for arm64.