### PR TITLE
gmmlib: update to 22.1.4

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.1.3"
-PKG_SHA256="81dbb4ddec98bb18c3a038cd40222046ae7f5b24b2d5acbfb2400f39f02f2aaf"
+PKG_VERSION="22.1.4"
+PKG_SHA256="18f291b6d5c9a170468e050e301f23760bb5b20b79d28a49a791ace2f22880c9"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"
@@ -12,4 +12,5 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="gmmlib: The Intel(R) Graphics Memory Management Library provides device specific and buffer management for the Intel(R) Graphics Compute Runtime for OpenCL(TM) and the Intel(R) Media Driver for VAAPI."
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_TYPE=release \
-                       -DRUN_TEST_SUITE=OFF"
+                       -DRUN_TEST_SUITE=OFF \
+                       -DCMAKE_BUILD_TYPE=Release"


### PR DESCRIPTION
Log:
- https://github.com/intel/gmmlib/compare/intel-gmmlib-22.1.3...intel-gmmlib-22.1.4


With the change in the gmmlib Cmakefiles
- https://github.com/intel/gmmlib/commit/19963011a40afd62c2a90e54d750fc3c60482ab7
- It was necessary to set the **CMAKE_BUILD_TYPE** to **Release**
  - #6422
  - would make it unnecessary set `-DCMAKE_BUILD_TYPE=Release`
```
CMake Error at Tools/bldsys/include/bs_base_utils.cmake:48 (message):
  Build Type: MinSizeRel is undefined, Please enter correct value - exiting!
Call Stack (most recent call first):
  Tools/bldsys/include/bs_base_utils.cmake:67 (bs_compare_build_type)
  Tools/bldsys/bs_init.cmake:33 (bs_check_build_type)
  Source/GmmLib/CMakeLists.txt:114 (include)
```