### PR TITLE
[network] bcm_sta: improve kernel 5.17 patch / connman: 4388028 (1.41+/2022-05-25)

### DIFF
--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-0600-kernel-5.17-fix.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-0600-kernel-5.17-fix.patch
@@ -1,26 +1,80 @@
---- a/x86-64/src/wl/sys/wl_linux.c	2022-02-19 15:22:05.006428601 +0000
-+++ b/x86-64/src/wl/sys/wl_linux.c	2022-02-19 21:55:03.290519415 +0000
-@@ -3287,7 +3287,11 @@
- static ssize_t
- wl_proc_read(struct file *filp, char __user *buffer, size_t length, loff_t *offp)
- {
-+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
- 	wl_info_t * wl = PDE_DATA(file_inode(filp));
-+#else
-+	wl_info_t * wl = file_inode(filp)->i_private;
+From 31b7849092c43805c7fbaf7518b99874aa1b310c Mon Sep 17 00:00:00 2001
+From: Joan Bruguera <joanbrugueram@gmail.com>
+Date: Wed, 12 Jan 2022 20:49:20 +0100
+Subject: [PATCH] Tentative fix for broadcom-wl 6.30.223.271 driver for Linux 5.17-rc1
+
+Set netdev->dev_addr through dev_addr_mod + PDE_DATA fix
+
+Since Linux 5.17 netdev->dev_addr is const and must be changed through
+dev_addr_mod, otherwise a warning is logged in dmesg and bad things may happen.
+
+NB: The #if is not wrong, dev_addr_mod is defined since Linux 5.15-rc1
+
+Plus a trivial fix for PDE_DATA.
+
+Applies on top of all the patches applied to broadcom-wl-dkms 6.30.223.271-28 on Arch Linux.
+
+See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=adeef3e32146a8d2a73c399dc6f5d76a449131b1
+          https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=359745d78351c6f5442435f81549f0207ece28aa
+---
+ src/wl/sys/wl_linux.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index e491df7..e4614fb 100644
+--- a/x86-64/src/wl/sys/wl_linux.c
++++ b/x86-64/src/wl/sys/wl_linux.c
+@@ -93,6 +93,10 @@ struct iw_statistics *wl_get_wireless_stats(struct net_device *dev);
+ 
+ #include <wlc_wowl.h>
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0))
++#define PDE_DATA pde_data
 +#endif
++
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
+ static void wl_timer(struct timer_list *tl);
+ #else
+@@ -490,6 +494,12 @@ wl_if_setup(struct net_device *dev)
  #endif
- 	int bcmerror, len;
- 	int to_user = 0;
-@@ -3344,7 +3348,11 @@
- static ssize_t
- wl_proc_write(struct file *filp, const char __user *buff, size_t length, loff_t *offp)
- {
-+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
- 	wl_info_t * wl = PDE_DATA(file_inode(filp));
-+#else
-+	wl_info_t * wl = file_inode(filp)->i_private;
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
++static inline void eth_hw_addr_set(struct net_device *dev, const void *addr) {
++	memcpy(dev->dev_addr, addr, ETHER_ADDR_LEN);
++}
 +#endif
- #endif
- 	int from_user = 0;
- 	int bcmerror;
++
+ static wl_info_t *
+ wl_attach(uint16 vendor, uint16 device, ulong regs,
+ 	uint bustype, void *btparam, uint irq, uchar* bar1_addr, uint32 bar1_size)
+@@ -634,7 +644,7 @@ wl_attach(uint16 vendor, uint16 device, ulong regs,
+ 			WL_ERROR(("wl%d: Error setting MAC ADDRESS\n", unit));
+ 	}
+ #endif 
+-	bcopy(&wl->pub->cur_etheraddr, dev->dev_addr, ETHER_ADDR_LEN);
++	eth_hw_addr_set(dev, wl->pub->cur_etheraddr.octet);
+ 
+ 	online_cpus = 1;
+ 
+@@ -1835,7 +1845,7 @@ wl_set_mac_address(struct net_device *dev, void *addr)
+ 
+ 	WL_LOCK(wl);
+ 
+-	bcopy(sa->sa_data, dev->dev_addr, ETHER_ADDR_LEN);
++	eth_hw_addr_set(dev, sa->sa_data);
+ 	err = wlc_iovar_op(wl->wlc, "cur_etheraddr", NULL, 0, sa->sa_data, ETHER_ADDR_LEN,
+ 		IOV_SET, (WL_DEV_IF(dev))->wlcif);
+ 	WL_UNLOCK(wl);
+@@ -3010,7 +3020,7 @@ _wl_add_monitor_if(wl_task_t *task)
+ 	else
+ 		dev->type = ARPHRD_IEEE80211_RADIOTAP;
+ 
+-	bcopy(wl->dev->dev_addr, dev->dev_addr, ETHER_ADDR_LEN);
++	eth_hw_addr_set(dev, wl->dev->dev_addr);
+ 
+ #if defined(WL_USE_NETDEV_OPS)
+ 	dev->netdev_ops = &wl_netdev_monitor_ops;
+-- 
+2.35.1
+

--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="1.41"
-PKG_SHA256="29e7062735382f8112ccf0cf6aaa8ee4a2633ce9522d1a0b1032daa65fc47563"
+PKG_VERSION="1e1d2af009efc8a8b65eccc06188bd6b28271af7" # 1.41+ / 2022-05-25
+PKG_SHA256="bfdc7a8261c476c003df59a2952090dacf67c78b97027f06db3280edce0d4ee5"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
This PR relate to issues seen in https://forum.libreelec.tv/thread/25714-adding-boot-parameters-to-the-rpi-and-any-arm-build-probably/

#### bc_sta/wl

Starting with kernel 5.17 netdev->dev_addr is const and must be changed through a helper function. Update the patch using a solution around.

Warning in the log http://ix.io/40Bd:
```
Jun 21 19:02:32 nightly kernel: wl 0000:04:00.0 wlan0: Current addr:  00 25 56 b6 4e 4a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Jun 21 19:02:32 nightly kernel: wl 0000:04:00.0 wlan0: Expected addr: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Jun 21 19:02:32 nightly kernel: ------------[ cut here ]------------
Jun 21 19:02:32 nightly kernel: netdevice: wlan0: Incorrect netdev->dev_addr
Jun 21 19:02:32 nightly kernel: WARNING: CPU: 0 PID: 337 at net/core/dev_addr_lists.c:517 dev_addr_check.cold+0x43/0x7d
Jun 21 19:02:32 nightly kernel: Modules linked in: wl(PO+) snd_hda_codec_conexant snd_hda_codec_generic uvcvideo videobuf2_vmalloc ledtrig_audio videobuf2_memops videobuf2_v4l2 videobuf2_common snd_hda_intel videodev snd_hda_codec mc cfg80211 snd_hwdep snd_intel_dspcfg snd_hda_core rfkill pkcs8_key_parser fuse
Jun 21 19:02:32 nightly kernel: CPU: 0 PID: 337 Comm: iwd Tainted: P           O      5.18.5 #1
Jun 21 19:02:32 nightly kernel: Hardware name: LENOVO 20023               /KIWA7, BIOS 18CN19WW(V1.05)          05/27/2009
Jun 21 19:02:32 nightly kernel: RIP: 0010:dev_addr_check.cold+0x43/0x7d
[...]
```

Only build tested because not owning such a hardware.

#### connman
Since connman 1.41 release 5 monthts ago there have been four iwd related commits added to commnan:

```
2022-05-25	wispr: Prevent use-after-free from __connman_wispr_stop()HEADmaster	Seung-Woo Kim
2022-05-25	doc: Add note SingleConnectedTechnology can't be used with VPN	Daniel Wagner
2022-05-16	service: Add "Ethernet" property for VPN into n.c.Manager GetServices	Jakub Jirutka
2022-05-16	clock: fix time update transition auto->manual	Ryan Smith
2022-04-14	wispr: Fix online check when using WPAD/PAC	Ryan Smith
2022-04-14	dhcp: Set proxy properly when applying DHCP lease	Ryan Smith
2022-04-14	gdhcp: fix server address byte order	Ryan Smith
2022-04-14	iwd: Fix connection with invalid passphrase format	Emmanuel VAUTRIN
2022-04-08	AUTHORS: Mention Daniel's contributions	Daniel Wagner
2022-04-08	vpn: Replace hardcoded paths with RUNSTATEDIR	Daniel Linjama
2022-04-08	build: Support configurable run dir with RUNSTATEDIR	Daniel Linjama
2022-04-08	ofono: Do not change regdom when it follows timezone	Jussi Laakkonen
2022-04-08	timezone: Change regdom along timezone, use localtime config	Jussi Laakkonen
2022-04-08	main: Add RegdomFollowsTimezone option for regdom changes	Jussi Laakkonen
2022-04-08	main: Add path to localtime to config options.	Jussi Laakkonen
2022-04-08	timeserver: include the reason why a timeserver sync is requested	Nicky Geerts
2022-03-07	timeserver: refresh the nameservers before each lookup	Nicky Geerts
2022-03-04	iwd: Forget network on service removal	Emmanuel VAUTRIN
2022-03-04	dnsproxy: add standalone test version of dnsproxy and a test script for it	Matthias Gerstner
2022-02-27	service: Check if hidden service has a pending request on agent	Jussi Laakkonen
2022-02-27	agent: Add support to check for active pending requests	Jussi Laakkonen
2022-02-27	AUTHORS: Mention Sebastian's contributions	Daniel Wagner
2022-02-27	vpn/vpn-polkit.policy: Replace unsupported "auth_*_keep_session" by "auth_*_k...	Sebastian Pipping
2022-02-27	iwd: Fix disabling tethering not working for brcmfmac	Jonathan Liu
2022-02-27	main: Set default online check URL also when no config provided	Daniel Wagner
2022-02-21	dnsproxy-test: support command line specification of dnsproxy port	Matthias Gerstner
2022-02-21	dnsproxy: support programmatic configuration of the default listen port	Matthias Gerstner
2022-02-21	.gitignore: also ignore emacs backup files	Matthias Gerstner
2022-02-21	dnsproxy: protocol_offset: remove error return case and return size_t	Matthias Gerstner
2022-02-21	dnsproxy: remove unnecessarily shadowed variable	Matthias Gerstner
2022-02-21	dnsproxy: remove unused domain parameter from `remove_server()`	Matthias Gerstner
2022-02-21	iwd: Use same signal strength calculation as wpa_supplicant	Jonathan Liu
2022-02-21	iwd: Fix typo in warning message when enabling AccessPoint mode	Jonathan Liu
2022-02-21	wifi: Duplicate GSupplicantSSID pointer members	Niel Fourie
2022-01-28	Release 1.41	Marcel Holtmann
```

Update to master HEAD to see if there is any improvement to the issue in the forum thread (connman is still working fine using Generic in my environment). 