### PR TITLE
kmsxx: add new package providing KMS utilities

### DIFF
--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,6 @@
+131
+- Add kmsxx (kmsprint, kmstest)
+
 130
 - bottom: update to 0.6.8
 - efivar: update to 38

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="130"
+PKG_REV="131"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of system tools and programs"
-PKG_LONGDESC="This bundle currently includes autossh, bottom, diffutils, dstat, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, libgpiod, lm_sensors, lshw, mc, mmc-utils, mtpfs, nmon, p7zip, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
+PKG_LONGDESC="This bundle currently includes autossh, bottom, diffutils, dstat, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, kmsxx, libgpiod, lm_sensors, lshw, mc, mmc-utils, mtpfs, nmon, p7zip, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="System Tools"
@@ -35,6 +35,7 @@ PKG_DEPENDS_TARGET="toolchain \
                     i2c-tools \
                     inotify-tools \
                     jq \
+                    kmsxx \
                     libgpiod \
                     lm_sensors \
                     lshw \
@@ -120,6 +121,9 @@ addon() {
     # jq
     cp -P $(get_install_dir jq)/usr/bin/jq ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir oniguruma)/usr/lib/{libonig.so,libonig.so.5,libonig.so.5.*.*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+
+    # kmsxx
+    cp -P $(get_install_dir kmsxx)/usr/bin/{kmsblank,kmsprint,kmstest} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # libgpiod
     cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpiofind,gpioget,gpioinfo,gpiomon,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin

--- a/packages/graphics/kmsxx/package.mk
+++ b/packages/graphics/kmsxx/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="kmsxx"
+PKG_VERSION="2236a8ccacdfed5ff5f6873ed6618eccf570193d"
+PKG_SHA256="774d25c7da4989b3183b50c04c80d8894e962f99215be7f0b01c593edf8afb20"
+PKG_LICENSE="MPL-2.0"
+PKG_SITE="https://github.com/tomba/kmsxx"
+PKG_URL="https://github.com/tomba/kmsxx/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libdrm libfmt"
+PKG_LONGDESC="Library and utilities for kernel mode setting"
+PKG_BUILD_FLAGS="-sysroot"
+
+PKG_MESON_OPTS_TARGET="-Ddefault_library=static \
+                       -Dkmscube=false \
+                       -Domap=disabled \
+                       -Dpykms=disabled"
+


### PR DESCRIPTION
Especially kmsprint is very handy.

Note: kmsxx isn't included in images by default ATM, you have to add it to ADDITIONAL_PACKAGES. I'm wondering though if we should include it as it's rather small and kmsprint output is so much more readable than modetest output