### PR TITLE
packages/security

### DIFF
--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.14.1"
-PKG_SHA256="2da3d5c2ecd3c3b73946ef00dc585d590e869deacdfe464cefba96f50d13682f"
+PKG_VERSION="3.15.0"
+PKG_SHA256="10356f1e0a76d87688482d497a490e10759d1c7e915731d1932c95030bd48241"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pycryptodome"
 PKG_URL="https://github.com/Legrandin/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.79"
-PKG_SHA256="5369ed274a19f480ec94e1faef04da63e3cbac1a82e15bb1751e58b2f274b835"
+PKG_VERSION="3.80"
+PKG_SHA256="ab280c0231ab7b05c5a630dff36afdc388035ad2011f6535056c83c0f6855ce2"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
Update security packages:
- [nss: update to 3.80](https://github.com/LibreELEC/LibreELEC.tv/commit/c24dbd555d2c48a2ba6baff120e875f811e18fef)
  - https://firefox-source-docs.mozilla.org/security/nss/releases/nss_3_80.html

- [pycryptodome: update to 3.15.0](https://github.com/LibreELEC/LibreELEC.tv/commit/2a52cf3814c62b2bd63eae949431baad05344cde)

  - https://www.pycryptodome.org/en/latest/src/changelog.html#june-2022