### PR TITLE
curl: update to 7.84.0

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="curl"
-PKG_VERSION="7.83.1"
-PKG_SHA256="2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4"
+PKG_VERSION="7.84.0"
+PKG_SHA256="2d118b43f547bfe5bae806d8d47b4e596ea5b25a6c1f080aef49fbcd817c5db8"
 PKG_LICENSE="MIT"
 PKG_SITE="https://curl.haxx.se"
 PKG_URL="https://curl.haxx.se/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
### changes:
- https://curl.se/changes.html#7_84_0

### Changelog

Fixed in 7.84.0 - June 27 2022

**Changes:**

[curl: add --rate to set max request rate per time unit](https://curl.se/bug/?i=8671)
[curl: deprecate --random-file and --egd-file](https://curl.se/bug/?i=8670)
[curl_version_info: add CURL_VERSION_THREADSAFE](https://curl.se/bug/?i=8680)
[CURLINFO_CAPATH/CAINFO: get the default CA paths from libcurl](https://curl.se/bug/?i=8888)
[lib: make curl_global_init() threadsafe when possible](https://curl.se/bug/?i=8680)
[libssh2: add CURLOPT_SSH_HOSTKEYFUNCTION](https://curl.se/bug/?i=7959)
[opts: deprecate RANDOM_FILE and EGDSOCKET](https://curl.se/bug/?i=8670)
[socks: support unix sockets for socks proxy](https://curl.se/bug/?i=8668)

**Bugfixes:**

[aws-sigv4: fix potentional NULL pointer arithmetic](https://curl.se/bug/?i=8814)
[bindlocal: don't use a random port if port number would wrap](https://curl.se/bug/?i=8862)
[c-hyper: mark status line as status for Curl_client_write()](https://curl.se/bug/?i=8894)
[ci: avoid `cmake -Hpath`](https://curl.se/bug/?i=9008)
[CI: bump FreeBSD 13.0 to 13.1](https://curl.se/bug/?i=8815)
[ci: update github actions](https://curl.se/bug/?i=8843)
[cmake: add libpsl support](https://curl.se/bug/?i=8865)
[cmake: do not add libcurl.rc to the static libcurl library](https://curl.se/bug/?i=8918)
[cmake: enable curl.rc for all Windows targets](https://curl.se/bug/?i=8918)
[cmake: fix detecting libidn2](https://curl.se/bug/?i=8917)
[cmake: support adding a suffix to the OS value](https://curl.se/bug/?i=8919)
[configure: skip libidn2 detection when winidn is used](https://curl.se/bug/?i=8934)
[configure: use the SED value to invoke sed](https://curl.se/bug/?i=8891)
[configure: warn about rustls being experimental](https://curl.se/bug/?i=9019)
[content_encoding: return error on too many compression steps](https://curl.se/docs/CVE-2022-32206.html)
[cookie: address secure domain overlay](https://hackerone.com/reports/1560324)
[cookie: apply limits](https://curl.se/docs/CVE-2022-32205.html)
[copyright.pl: parse and use .reuse/dep5 for skips](https://curl.se/bug/?i=9006)
[copyright: make repository REUSE compliant](https://curl.se/bug/?i=8869)
[curl.1: add a few see also --tls-max](https://curl.se/bug/?i=8929)
[curl.1: mention exit code zero too](https://curl.se/bug/?i=8833)
[curl: re-enable --no-remote-name](https://curl.se/bug/?i=8931)
[curl_easy_pause.3: remove explanation of progress function](https://curl.se/bug/?i=9015)
[curl_getdate.3: document that some illegal dates pass through](https://curl.se/bug/?i=8938)
[Curl_parsenetrc: don't access local pwbuf outside of scope](https://curl.se/bug/?i=8850)
[curl_url_set.3: clarify by default using known schemes only](https://curl.se/bug/?i=8994)
[CURLOPT_ALTSVC.3: document the file format](https://curl.se/bug/?i=9033)
CURLOPT_FILETIME.3: fix the protocols this works with
[CURLOPT_HTTPHEADER.3: improve comment in example](https://curl.se/bug/?i=9025)
CURLOPT_NETRC.3: document the .netrc file format
[CURLOPT_PORT.3: We discourage using this option](https://curl.se/bug/?i=8941)
[CURLOPT_RANGE.3: remove ranged upload advice](https://curl.se/bug/?i=8969)
[digest: added detection of more syntax error in server headers](https://curl.se/bug/?i=8912)
[digest: tolerate missing "realm"](https://curl.se/bug/?i=8912)
[digest: unquote realm and nonce before processing](https://curl.se/bug/?i=8912)
DISABLED: disable 1021 for hyper again
[docs/cmdline-opts: add copyright and license identifier to each file](https://curl.se/bug/?i=9002)
[docs/CONTRIBUTE.md: document the 'needs-votes' concept](https://curl.se/bug/?i=8910)
[docs: clarify data replacement policy for MIME API](https://curl.se/bug/?i=8860)
[doh: remove UNITTEST macro definition](https://curl.se/bug/?i=8902)
[examples/crawler.c: use the curl license](https://curl.se/bug/?i=8950)
[examples: remove fopen.c and rtsp.c](https://curl.se/bug/?i=8949)
[FAQ: Clarify Windows double quote usage](https://curl.se/bug/?i=8823)
[fopen: add Curl_fopen() for better overwriting of files](https://curl.se/docs/CVE-2022-32207.html)
[ftp: restore protocol state after http proxy CONNECT](https://curl.se/bug/?i=8737)
[ftp: when failing to do a secure GSSAPI login, fail hard](https://hackerone.com/reports/1590102)
GHA/hyper: enable debug in the build
[gssapi: improve handling of errors from gss_display_status](https://curl.se/bug/?i=8832)
gssapi: initialize gss_buffer_desc strings
[headers api: remove EXPERIMENTAL tag](https://curl.se/bug/?i=8900)
[http2: always debug print stream id in decimal with %u](https://curl.se/bug/?i=8808)
[http2: reject overly many push-promise headers](https://hackerone.com/reports/1589847)
[http: restore header folding behavior](https://curl.se/bug/?i=8844)
[hyper: use 'alt-used'](https://curl.se/bug/?i=8898)
[krb5: return error properly on decode errors](https://curl.se/docs/CVE-2022-32208.html)
[lib: make more protocol specific struct fields #ifdefed](https://curl.se/bug/?i=8944)
[libcurl-security.3: add "Secrets in memory"](https://curl.se/bug/?i=8881)
[libcurl-security.3: document CRLF header injection](https://curl.se/bug/?i=8964)
[libssh: skip the fake-close when libssh does the right thing](https://curl.se/bug/?i=9021)
[links: update dead links to the curl-wiki](https://curl.se/bug/?i=8897)
[log2changes: do not indent empty lines [ci skip]](https://curl.se/bug/?i=8887)
[macos9: remove partial support](https://curl.se/bug/?i=8836)
[Makefile.am: fix portability issues](https://curl.se/mail/lib-2022-05/0024.html)
[Makefile.m32: delete obsolete options, improve -On [ci skip]](https://curl.se/bug/?i=8904)
[Makefile.m32: delete two obsolete OpenSSL options [ci skip]](https://curl.se/bug/?i=8884)
[Makefile.m32: stop forcing XP target with ipv6 enabled [ci skip]](https://curl.se/bug/?i=9035)
[max-time.d: clarify max-time sets max transfer time](https://curl.se/bug/?i=8877)
[mprintf: ignore clang non-literal format string](https://curl.se/bug/?i=8740)
[netrc: check %USERPROFILE% as well on Windows](https://curl.se/bug/?i=8855)
[netrc: support quoted strings](https://curl.se/bug/?i=8908)
[ngtcp2: allow curl to send larger UDP datagrams](https://curl.se/bug/?i=8883)
[ngtcp2: correct use of ngtcp2 and nghttp3 signed integer types](https://curl.se/bug/?i=8851)
[ngtcp2: enable Linux GSO](https://curl.se/bug/?i=8909)
[ngtcp2: extend QUIC transport parameters buffer](https://curl.se/bug/?i=8872)
[ngtcp2: fix alert_read_func return value](https://curl.se/bug/?i=8852)
[ngtcp2: fix typo in preprocessor condition](https://curl.se/bug/?i=8981)
[ngtcp2: handle error from ngtcp2_conn_submit_crypto_data](https://curl.se/bug/?i=8871)
[ngtcp2: send appropriate connection close error code](https://curl.se/bug/?i=8870)
[ngtcp2: support boringssl crypto backend](https://curl.se/bug/?i=8789)
[ngtcp2: use helper funcs to simplify TLS handshake integration](https://curl.se/bug/?i=8968)
[ntlm: provide a fixed fake host name](https://curl.se/bug/?i=8859)
[projects: fix third-party SSL library build paths for Visual Studio](https://curl.se/bug/?i=8991)
[quic: add Curl_quic_idle](https://curl.se/bug/?i=8698)
[quiche: support ca-fallback](https://curl.se/bug/?i=8696)
[rand: stop detecting /dev/urandom in cross-builds](https://curl.se/bug/?i=9038)
[remote-name.d: mention --output-dir](https://curl.se/bug/?i=8945)
[runtests.pl: add the --repeat parameter to the --help output](https://curl.se/bug/?i=8959)
[runtests: fix skipping tests not done event-based](https://curl.se/bug/?i=8977)
[runtests: skip starting the ssh server if user name is lacking](https://curl.se/bug/?i=9013)
[scripts/copyright.pl: fix the exclusion to not ignore man pages](https://curl.se/bug/?i=8952)
[sectransp: check for a function defined when __BLOCKS__ is undefined](https://curl.se/bug/?i=8846)
[select: return error from "lethal" poll/select errors](https://curl.se/bug/?i=8921)
server/sws: support spaces in the HTTP request path
[speed-limit/time.d: mention these affect transfers in either direction](https://curl.se/bug/?i=8948)
[strcase: some optimisations](https://curl.se/bug/?i=8875)
[test 2081: add a valid reply for the second request](https://curl.se/bug/?i=8959)
[test 675: add missing CR so the test passes when run through Privoxy](https://curl.se/bug/?i=8959)
[test414: add the '--resolve' keyword](https://curl.se/bug/?i=8959)
[test681: verify --no-remote-name](https://curl.se/bug/?i=8942)
tests 266, 116 and 1540: add a small write delay
[tests/data/test1501: kill ftp server after slow LIST response](https://curl.se/bug/?i=8907)
tests/getpart: fix getpartattr to work with "data" and "data2"
[tests/server/sws.c: change the HTTP writedelay unit to milliseconds](https://curl.se/bug/?i=8827)
[test{440,441,493,977}: add "HTTP proxy" keywords](https://curl.se/bug/?i=8959)
[tool_getparam: fix --parallel-max maximum value constraint](https://curl.se/bug/?i=8930)
[tool_operate: make sure --fail-with-body works with --retry](https://curl.se/bug/?i=8845)
[transfer: fix potential NULL pointer dereference](https://curl.se/bug/?i=8857)
[transfer: maintain --path-as-is after redirects](https://curl.se/bug/?i=8974)
[transfer: upload performance; avoid tiny send](https://curl.se/bug/?i=8965)
[url: free old conn better on reuse](https://curl.se/bug/?i=8841)
url: remove redundant #ifdefs in allocate_conn()
url: URL encode the path when extracted, if spaces were set
[urlapi: make curl_url_set(url, CURLUPART_URL, NULL, 0) clear all parts](https://curl.se/bug/?i=9028)
urlapi: support CURLU_URLENCODE for curl_url_get()
[urldata: reduce size of a few struct fields](https://curl.se/bug/?i=8940)
[urldata: remove three unused booleans from struct UserDefined](https://curl.se/bug/?i=8940)
[urldata: store tcp_keepidle and tcp_keepintvl as ints](https://curl.se/bug/?i=8940)
[version: allow stricmp() for sorting the feature list](https://curl.se/bug/?i=8916)
[vtls: make curl_global_sslset thread-safe](https://curl.se/bug/?i=9016)
[wolfssh.h: removed](https://curl.se/bug/?i=8863)
[wolfssl: correct the failf() message when a handle can't be made](https://curl.se/bug/?i=8885)
[wolfSSL: explicitly use compatibility layer](https://curl.se/bug/?i=8864)
[x509asn1: mark msnprintf return as unchecked](https://curl.se/bug/?i=8831)