### PR TITLE
Add support for building with MOLD linker

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -284,6 +284,12 @@ setup_toolchain() {
     have_gold="yes"
   fi
 
+  # mold flag
+  if flag_enabled "mold" "${MOLD_SUPPORT}" "only-disable"; then
+    TARGET_LDFLAGS+=" ${LDFLAGS_OPTIM_MOLD}"
+    have_mold="yes"
+  fi
+
   # compiler optimization, descending priority: speed, size, default
   if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
     if [ "${SPLIT_DEBUG_INFO}" = "yes" -a "${have_gold}" = "yes" ]; then

--- a/config/optimize
+++ b/config/optimize
@@ -30,6 +30,9 @@ LDFLAGS_OPTIM_LTO_COMMON="-fuse-linker-plugin"
 # gold flags
 LDFLAGS_OPTIM_GOLD="-fuse-ld=gold"
 
+# mold flags (todo: update after gcc 12.1.0)"
+LDFLAGS_OPTIM_MOLD="-B${TOOLCHAIN}/libexec/mold"
+
 # default compiler optimization
 CFLAGS_OPTIM_DEFAULT="-O2 -fomit-frame-pointer -DNDEBUG"
 CXXFLAGS_OPTIM_DEFAULT="$CFLAGS_OPTIM_DEFAULT"

--- a/config/show_config
+++ b/config/show_config
@@ -31,6 +31,7 @@ show_config() {
   config_message+="\n - CPU features:\t\t\t ${TARGET_FEATURES}"
   config_message+="\n - LTO (Link Time Optimization) support: ${LTO_SUPPORT}"
   config_message+="\n - GOLD (Google Linker) Support:\t ${GOLD_SUPPORT}"
+  config_message+="\n - MOLD (Modern Linker) Support:\t ${MOLD_SUPPORT}"
   config_message+="\n - LLVM support:\t\t\t ${LLVM_SUPPORT}"
   config_message+="\n - DEBUG:\t\t\t\t ${DEBUG:-no}"
   config_message+="\n - CFLAGS:\t\t\t\t ${TARGET_CFLAGS}"

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -32,6 +32,9 @@
 # GOLD (Google Linker) support
   GOLD_SUPPORT="yes"
 
+# MOLD (Modern Linker) support
+  MOLD_SUPPORT="no"
+
 # HARDENING (security relevant linker and compiler flags) support
   HARDENING_SUPPORT="no"
 

--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -9,7 +9,7 @@ PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain zlib openssl"
 PKG_LONGDESC="mariadb-connector: library to conntect to mariadb/mysql database server"
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="-gold -mold"
 
 PKG_CMAKE_OPTS_TARGET="-DWITH_EXTERNAL_ZLIB=ON
                        -DCLIENT_PLUGIN_DIALOG=STATIC

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -11,7 +11,7 @@ PKG_URL="https://ftp.gnu.org/pub/gnu/glibc/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap pigz:host Python3:host"
 PKG_DEPENDS_INIT="glibc"
 PKG_LONGDESC="The Glibc package contains the main C library."
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="-gold -mold"
 
 PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            ac_cv_path_PERL=no \

--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -10,6 +10,7 @@ PKG_SITE="http://libcec.pulse-eight.com/"
 PKG_URL="https://github.com/Pulse-Eight/libcec/archive/libcec-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain systemd p8-platform swig:host"
 PKG_LONGDESC="libCEC is an open-source dual licensed library designed for communicating with the Pulse-Eight USB - CEC Adaptor."
+PKG_BUILD_FLAGS="-mold"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=1 \
                        -DCMAKE_INSTALL_LIBDIR:STRING=lib \

--- a/packages/devel/mimalloc/package.mk
+++ b/packages/devel/mimalloc/package.mk
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022 Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="mimalloc"
+PKG_VERSION="2.0.6"
+PKG_SHA256="9f05c94cc2b017ed13698834ac2a3567b6339a8bde27640df5a1581d49d05ce5"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/microsoft/mimalloc"
+PKG_URL="https://github.com/microsoft/mimalloc/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="cmake:host ninja:host"
+PKG_LONGDESC="mimalloc (pronounced "me-malloc") is a general purpose allocator with excellent performance characteristics"
+
+PKG_CMAKE_OPTS_HOST="-DMI_SECURE=OFF \
+                     -DMI_DEBUG_FULL=OFF \
+                     -DMI_OVERRIDE=ON \
+                     -DMI_XMALLOC=OFF \
+                     -DMI_SHOW_ERRORS=OFF \
+                     -DMI_USE_CXX=OFF \
+                     -DMI_SEE_ASM=OFF \
+                     -DMI_LOCAL_DYNAMIC_TLS=OFF \
+                     -DMI_BUILD_SHARED=ON \
+                     -DMI_BUILD_STATIC=OFF \
+                     -DMI_BUILD_OBJECT=OFF \
+                     -DMI_BUILD_TESTS=OFF \
+                     -DMI_DEBUG_TSAN=OFF \
+                     -DMI_DEBUG_UBSAN=OFF \
+                     -DMI_SKIP_COLLECT_ON_EXIT=OFF"

--- a/packages/devel/mimalloc/package.mk
+++ b/packages/devel/mimalloc/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2022 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mimalloc"
 PKG_VERSION="2.0.6"

--- a/packages/devel/mold/package.mk
+++ b/packages/devel/mold/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2022 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2022=present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mold"
 PKG_VERSION="1.3.0"

--- a/packages/devel/mold/package.mk
+++ b/packages/devel/mold/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022 Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="mold"
+PKG_VERSION="1.3.0"
+PKG_SHA256="02132ae717d7f22f8bc7e5c22642ad41541ec4c535fa85f095c60ecc81465a3d"
+PKG_LICENSE="AGPLv3"
+PKG_SITE="https://github.com/rui314/mold"
+PKG_URL="https://github.com/rui314/mold/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="tbb:host mimalloc:host zlib:host"
+PKG_LONGDESC="mold is a faster drop-in replacement for existing Unix linkers"
+PKG_TOOLCHAIN="manual"
+
+PKG_MAKE_OPTS_HOST="PREFIX=/ SYSTEM_MIMALLOC=1 SYSTEM_TBB=1"
+
+make_host() {
+  make ${PKG_MAKE_OPTS_HOST} CXXFLAGS="${CXXFLAGS} -I${TOOLCHAIN}/include/tbb -I${TOOLCHAIN}/include/mimalloc-2.0"
+}
+
+makeinstall_host() {
+  DESTDIR=${TOOLCHAIN} make install ${PKG_MAKE_OPTS_HOST}
+}

--- a/packages/devel/tbb/package.mk
+++ b/packages/devel/tbb/package.mk
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022 Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="tbb"
+PKG_VERSION="2021.5.0"
+PKG_SHA256="e5b57537c741400cf6134b428fc1689a649d7d38d9bb9c1b6d64f092ea28178a"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://github.com/oneapi-src/oneTBB"
+PKG_URL="https://github.com/oneapi-src/oneTBB/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="cmake:host ninja:host"
+PKG_LONGDESC="oneTBB is a flexible C++ library that simplifies the work of adding parallelism to complex applications"
+
+PKG_CMAKE_OPTS_HOST="-DTBB_TEST=OFF \
+                     -DTBB_EXAMPLES=ON \
+                     -DTBB_STRICT=OFF \
+                     -DTBB4PY_BUILD=OFF \
+                     -DTBB_BUILD=ON \
+                     -DTBBMALLOC_BUILD=ON \
+                     -DTBBMALLOC_PROXY_BUILD=ON \
+                     -DTBB_CPF=OFF \
+                     -DTBB_FIND_PACKAGE=OFF \
+                     -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=OFF \
+                     -DTBB_ENABLE_IPO=ON"
+
+pre_configure_host() {
+  export CXXFLAGS+=" -D__TBB_DYNAMIC_LOAD_ENABLED=0"
+}

--- a/packages/devel/tbb/package.mk
+++ b/packages/devel/tbb/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2022 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tbb"
 PKG_VERSION="2021.5.0"

--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -11,7 +11,7 @@ PKG_URL="https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${PKG_VERSION}.t
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A high-speed version of libjpeg for x86 and x86-64 processors which uses SIMD."
-PKG_BUILD_FLAGS="+pic +pic:host"
+PKG_BUILD_FLAGS="+pic +pic:host -mold"
 
 PKG_CMAKE_OPTS_HOST="-DENABLE_STATIC=ON \
                      -DENABLE_SHARED=OFF \

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -10,6 +10,7 @@ PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain expat libdrm Mako:host"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API."
+PKG_BUILD_FLAGS="-mold"
 
 get_graphicdrivers
 

--- a/packages/graphics/tiff/package.mk
+++ b/packages/graphics/tiff/package.mk
@@ -10,7 +10,7 @@ PKG_SITE="http://www.remotesensing.org/libtiff/"
 PKG_URL="http://download.osgeo.org/libtiff/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libjpeg-turbo zlib"
 PKG_LONGDESC="libtiff is a library for reading and writing TIFF files."
-PKG_BUILD_FLAGS="+pic -gold"
+PKG_BUILD_FLAGS="+pic -gold -mold"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
                        -Dtiff-tools=OFF \

--- a/packages/lang/gcc-aarch64/package.mk
+++ b/packages/lang/gcc-aarch64/package.mk
@@ -11,6 +11,10 @@ PKG_LONGDESC="This package contains the GNU Compiler Collection for 64-bit ARM."
 PKG_DEPENDS_UNPACK+=" gcc"
 PKG_PATCH_DIRS+=" $(get_pkg_directory gcc)/patches"
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+= "mold:host"
+fi
+
 PKG_CONFIGURE_OPTS_HOST="--target=aarch64-none-elf \
                          --with-sysroot=${SYSROOT_PREFIX} \
                          --with-gmp=${TOOLCHAIN} \

--- a/packages/lang/gcc-bpf/package.mk
+++ b/packages/lang/gcc-bpf/package.mk
@@ -11,6 +11,10 @@ PKG_LONGDESC="This package contains the GNU Compiler Collection for 64-bit ARM."
 PKG_DEPENDS_UNPACK+=" gcc"
 PKG_PATCH_DIRS+=" $(get_pkg_directory gcc)/patches"
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+= "mold:host"
+fi
+
 PKG_CONFIGURE_OPTS_HOST="--target=bpf \
                          --with-sysroot=${SYSROOT_PREFIX} \
                          --with-gmp=${TOOLCHAIN} \

--- a/packages/lang/gcc-or1k/package.mk
+++ b/packages/lang/gcc-or1k/package.mk
@@ -11,6 +11,10 @@ PKG_LONGDESC="This package contains the GNU Compiler Collection for OpenRISC 100
 PKG_DEPENDS_UNPACK+=" gcc"
 PKG_PATCH_DIRS+=" $(get_pkg_directory gcc)/patches"
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+= "mold:host"
+fi
+
 PKG_CONFIGURE_OPTS_HOST="--target=or1k-none-elf \
                          --with-sysroot=${SYSROOT_PREFIX} \
                          --with-gmp=${TOOLCHAIN} \

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -14,6 +14,10 @@ PKG_DEPENDS_HOST="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc
 PKG_DEPENDS_INIT="toolchain"
 PKG_LONGDESC="This package contains the GNU Compiler Collection."
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+= "mold:host"
+fi
+
 case ${TARGET_ARCH} in
   arm|riscv64)
     OPTS_LIBATOMIC="--enable-libatomic"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -14,7 +14,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform p8-platform systemd"
 PKG_SECTION=""
 PKG_SHORTDESC="peripheral.joystick: Joystick support in Kodi"
 PKG_LONGDESC="peripheral.joystick provides joystick support and button mapping"
-PKG_BUILD_FLAGS="+lto"
+PKG_BUILD_FLAGS="+lto -mold"
 
 PKG_IS_ADDON="embedded"
 PKG_ADDON_TYPE="kodi.peripheral"

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -7,7 +7,7 @@ PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex"
 PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="-gold -mold"
 
 case "${PROJECT}" in
   Amlogic)

--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -11,6 +11,7 @@ PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar
 PKG_DEPENDS_TARGET="toolchain Python3 distutilscross:host zlib freetype libjpeg-turbo tiff"
 PKG_LONGDESC="The Python Imaging Library adds image processing capabilities to your Python interpreter."
 PKG_TOOLCHAIN="manual"
+PKG_BUILD_FLAGS="-mold"
 
 pre_make_target() {
   export PYTHONXCPREFIX="${SYSROOT_PREFIX}/usr"

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -127,6 +127,7 @@ Set the variable `PKG_BUILD_FLAGS` in the `package.mk` to enable/disable the sin
 | lto-fat  | disabled | target, init      | same as `lto` but compile fat LTO objects (bytecode plus optimized assembly). This increases compile time but can be useful to create static libraries suitable both for LTO and non-LTO linking |
 | lto-off  | disabled | target, init      | explicitly disable LTO in the compiler and linker |
 | gold     | enabled by `GOLD_SUPPORT` | target, init | do not use GOLD-Llinker (can only disable) |
+| mold     | enabled by `MOLD_SUPPORT` | target, init | do not use the MOLD linker (can only disable) |
 | parallel | enabled  | all | `make` or `ninja` builds with multiple threads/processes (or not) |
 | strip    | enabled  | target | strips executables (or not) |
 | sysroot  | enabled  | target | installs the package to the sysroot folder (or not) |


### PR DESCRIPTION
This adds support for using the mold linker, similar to how we support the GOLD linker.

This isn't enabled by default so shouldn't be much concern. You cannot have both `GOLD_SUPPORT` and `MOLD_SUPPORT` enabled at the same time though there isn't anything stopping you from doing so.

ref: https://github.com/rui314/mold

There is a few packages that don't compile with MOLD and I plan on submitting bug reports for those.