### PR TITLE
Add support for logging and reporting QA Checks

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -150,6 +150,33 @@ build_msg() {
   fi
 }
 
+print_qa_checks() {
+  if [ -n "${PKG_NAME}" ]; then
+    if [ -d "${PKG_QA_CHECKS}" ]; then
+      for qa_check in ${PKG_QA_CHECKS}/*; do
+        print_color CLR_WARNING "[QA CHECK] [${PKG_NAME}] [$(basename ${qa_check})]:\n$(cat ${qa_check})\n\n"
+      done
+    fi
+  fi
+}
+
+log_qa_check() {
+  local qa_check_title="${1}"
+  local qa_check_message="${2}"
+
+  if [ -n "${qa_check_title}" -a -n "${qa_check_message}" ]; then
+    if [ -n "${PKG_NAME}" ]; then
+      print_color CLR_WARNING "[QA CHECK] [${PKG_NAME}] [${qa_check_title}]:\n${qa_check_message}\n"
+      mkdir -p "${PKG_QA_CHECKS}"
+      echo -e "${qa_check_message}" >> ${PKG_QA_CHECKS}/${qa_check_title}
+    else
+      print_color CLR_WARNING "[QA CHECK] [general] [${qa_check_title}]:\n${qa_check_message}\n"
+      mkdir -p "${BUILD}/qa_checks/general"
+      echo -e "${qa_check_message}" >> ${BUILD}/qa_checks/general/${qa_check_title}
+    fi
+  fi
+}
+
 # prints a warning if the file slated for removal doesn't exist
 # this allows us to continue instead of bailing out with just "rm"
 safe_remove() {
@@ -1256,6 +1283,8 @@ source_package() {
     elif [[ "${1}" =~ :init$ ]]; then
       PKG_INSTALL="$BUILD/install_init/${PKG_NAME}-${PKG_VERSION}"
     fi
+
+    PKG_QA_CHECKS="${BUILD}/qa_checks/${PKG_NAME}-${PKG_VERSION}"
   fi
 
   build_with_debug && BUILD_WITH_DEBUG="yes" || BUILD_WITH_DEBUG="no"

--- a/config/functions
+++ b/config/functions
@@ -185,10 +185,8 @@ safe_remove() {
   for path in "$@" ; do
     if [ -e "${path}" -o -L "${path}" ]; then
       rm -r "${path}"
-    elif [ -n "${PKG_NAME}" ]; then
-      print_color CLR_WARNING "safe_remove: path does not exist: [${PKG_NAME}]: ${path}\n"
     else
-      print_color CLR_WARNING "safe_remove: path does not exist: ${path}\n"
+     log_qa_check "safe_remove" "path does not exist: ${path}"
     fi
   done
 }

--- a/scripts/clean
+++ b/scripts/clean
@@ -33,6 +33,12 @@ clean_package() {
       fi
     fi
   done
+
+  for i in "${BUILD}/qa_checks/${1}-"*; do
+    build_msg "CLR_WARNING" "*" "$(print_color "CLR_WARNING_DIM" "Removing ${i} ...")"
+    rm -rf "${i}"
+  done
+
   rm -f "${STAMPS}/${1}/build_"*
 }
 

--- a/scripts/image
+++ b/scripts/image
@@ -123,6 +123,7 @@ chmod +x ${FAKEROOT_SCRIPT} # make ${FAKEROOT_SCRIPT} executable
 echo "chown -R 0:0 ${INSTALL}" >> ${FAKEROOT_SCRIPT}
 
 # Clean old install dirs
+rm -rf ${BUILD}/qa_checks/general
 rm -rf ${INSTALL}
 rm -rf ${STAMPS_INSTALL}
 mkdir -p ${INSTALL}
@@ -475,3 +476,8 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
     rm -rf ${RELEASE_DIR}
   fi
 fi
+
+if [ -d "${BUILD}/qa_checks" -a -n "$(ls -1 ${BUILD}/qa_checks/)" ]; then
+  log_qa_check "qa_issues" "QA issues present, please fix!\n$(find ${BUILD}/qa_checks/* -type f ! -name qa_issues)\n"
+fi
+

--- a/scripts/install
+++ b/scripts/install
@@ -64,6 +64,8 @@ pkg_lock_status "ACTIVE" "${PKG_NAME}:${TARGET}" "install"
 
 build_msg "CLR_INSTALL" "INSTALL" "${PKG_NAME} $(print_color CLR_TARGET "(${TARGET})")" "indent"
 
+print_qa_checks
+
 acquire_update_lock image
 
 mkdir -p ${INSTALL}


### PR DESCRIPTION
This adds support for logging QA checks via a new `log_qa_check` function. This function takes a title (of the check) and a message that explains the issues and possibly how to solve it.

This is needed so we can catch some simple problems that seems to keep making their way into master.

This changes `safe_remove` to be a qa check and logs anything that `safe_remove` flags.

The QA checks are logged in `${BUILD}/qa_checks/${PKG_NAME}-${PKG_VERSION}/`

These checks are then printed at the end of a build.

I plan to add more qa checks in the future that are related to kernel configs and rpaths and some other things. This PR just lays the base of this expansion.

I would be in favour of killing the build when encountering a QA issue but it's not possible until all the QA issues are solved.

For example:
```
Successful build, creating image...
Parallel mksquashfs: Using 12 processors
Creating 4.0 filesystem on /home/lukas/git/libreelec/target/LibreELEC-RPi4.arm-11.0-devel-20220701101813-27b48dd.system, block size 1048576.
[=========================================================================================================================================================================================-] 8250/8250 100%

<snip>

[QA CHECK] [general] [qa_issues]:
QA issues present, please fix!
/home/lukas/git/libreelec/build.LibreELEC-RPi4.arm-11.0-devel/qa_checks/glibc-2.35/safe_remove
/home/lukas/git/libreelec/build.LibreELEC-RPi4.arm-11.0-devel/qa_checks/libdrm-2.4.111/safe_remove
```

You can then read the files for the issue
```
$ cat build.LibreELEC-RPi4.arm-11.0-devel/qa_checks/libdrm-2.4.111/safe_remove

path does not exist: /home/lukas/git/libreelec/build.LibreELEC-RPi4.arm-11.0-devel/install_pkg/libdrm-2.4.111/usr/bin/amdgpu_stress
path does not exist: /home/lukas/git/libreelec/build.LibreELEC-RPi4.arm-11.0-devel/install_pkg/libdrm-2.4.111/usr/bin/kms-steal-crtc
path does not exist: /home/lukas/git/libreelec/build.LibreELEC-RPi4.arm-11.0-devel/install_pkg/libdrm-2.4.111/usr/bin/kms-universal-planes
```