### PR TITLE
Miscellaneous package updates

### DIFF
--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.38.5"
+PKG_VERSION="3.39.0"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c"
+PKG_SHA256="e90bcaef6dd5813fcdee4e867f6b65f3c9bfd0aec0f1017f9f3bbce1e4ed09e2"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2022/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"

--- a/packages/devel/binutils-aarch64/package.mk
+++ b/packages/devel/binutils-aarch64/package.mk
@@ -42,11 +42,13 @@ pre_configure_host() {
 
 make_host() {
   make configure-host
+  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true
 }
 
 makeinstall_host() {
   cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
   make -C bfd install # fix parallel build with libctf requiring bfd
+  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true install
 }

--- a/packages/devel/binutils-bpf/package.mk
+++ b/packages/devel/binutils-bpf/package.mk
@@ -42,11 +42,13 @@ pre_configure_host() {
 
 make_host() {
   make configure-host
+  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true
 }
 
 makeinstall_host() {
   cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
   make -C bfd install # fix parallel build with libctf requiring bfd
+  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true install
 }

--- a/packages/devel/binutils-or1k/package.mk
+++ b/packages/devel/binutils-or1k/package.mk
@@ -42,11 +42,13 @@ pre_configure_host() {
 
 make_host() {
   make configure-host
+  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true
 }
 
 makeinstall_host() {
   cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
   make -C bfd install # fix parallel build with libctf requiring bfd
+  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true install
 }

--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -56,12 +56,14 @@ pre_configure_host() {
 
 make_host() {
   make configure-host
+  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true
 }
 
 makeinstall_host() {
   cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
   make -C bfd install # fix parallel build with libctf requiring bfd
+  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true install
 }
 

--- a/packages/devel/flatbuffers/package.mk
+++ b/packages/devel/flatbuffers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flatbuffers"
-PKG_VERSION="2.0.0"
-PKG_SHA256="9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4"
+PKG_VERSION="2.0.6"
+PKG_SHA256="e2dc24985a85b278dd06313481a9ca051d048f9474e0f199e372fea3ea4248c9"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/google/flatbuffers"
 PKG_URL="https://github.com/google/flatbuffers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/kmod/package.mk
+++ b/packages/sysutils/kmod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="kmod"
-PKG_VERSION="29"
-PKG_SHA256="0b80eea7aa184ac6fd20cafa2a1fdf290ffecc70869a797079e2cc5c6225a52a"
+PKG_VERSION="30"
+PKG_SHA256="f897dd72698dc6ac1ef03255cd0a5734ad932318e4adbaebc7338ef2f5202f9f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
 PKG_URL="https://www.kernel.org/pub/linux/utils/kernel/kmod/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/textproc/nlohmann-json/package.mk
+++ b/packages/textproc/nlohmann-json/package.mk
@@ -9,6 +9,3 @@ PKG_SITE="https://nlohmann.github.io/json/"
 PKG_URL="https://github.com/nlohmann/json/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="JSON for Modern C++"
-PKG_TOOLCHAIN="cmake"
-
-PKG_CMAKE_OPTS_TARGET="-DBUILD_TESTING:BOOL=OFF"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.47.0"
-PKG_SHA256="68271951324554c34501b85190f22f2221056db69f493afc3bbac8e7be21e7cc"
+PKG_VERSION="1.48.0"
+PKG_SHA256="47d8f30ee4f1bc621566d10362ca1b3ac83a335c63da7144947c806772d016e4"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Documentation changes only
- binutils-aarch64: add comments on MAKEINFO usage
- binutils-bpf: add comments on MAKEINFO usag
- binutils-or1k: add comments on MAKEINFO usage
- binutils: add comments on MAKEINFO usage

Toolchain
- nlohmann-json: build using meson

Package updates
- kmod: update to 30
- flatbuffers: update to 2.0.6
- sqlite: update to 3.39.0
- nghttp2: update to 1.48.0