### PR TITLE
[le10] tools.ffmpeg-tools: fix missing libraries and addon (118)

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="https://ffmpeg.org/releases/ffmpeg-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain aom bzip2 gnutls lame libvorbis opus x264 x265 zlib"
+PKG_DEPENDS_TARGET="toolchain aom bzip2 gnutls lame libvorbis opus x264 zlib"
 PKG_LONGDESC="FFmpegx is an complete FFmpeg build to support encoding and decoding."
 PKG_BUILD_FLAGS="-gold -sysroot"
 
@@ -99,6 +99,12 @@ pre_configure_target() {
     --enable-libxcb-shm \
     --enable-libxcb-xfixes \
     --enable-libxcb-shape"
+  else
+    PKG_FFMPEG_X11_GRAB="\
+    --disable-libxcb \
+    --disable-libxcb-shm \
+    --disable-libxcb-xfixes \
+    --disable-libxcb-shape"
   fi
 }
 

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="117"
+PKG_REV="118"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -18,6 +18,13 @@ PKG_ADDON_NAME="FFmpeg Tools"
 PKG_ADDON_TYPE="xbmc.python.script"
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+
   cp -L $(get_install_dir ffmpegx)/usr/local/bin/* ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+
+  # libs
+  if [ "${TARGET_ARCH}" = "x86_64" ]; then
+    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.199 \
+           ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  fi
 }


### PR DESCRIPTION
Update the packages for both of these to handle the shared library and the potentially unneeded libxcb

- [ffmpegx: disable libxcb for non X11 builds](https://github.com/LibreELEC/LibreELEC.tv/commit/6f6a534ef51b34c0cd1eb9762de5c71f823c3ac4)

- [tools.ffmpeg-tools: fix missing libraries and addon (118)](https://github.com/LibreELEC/LibreELEC.tv/commit/d2c70cc46128cfd4511090dd876de4c15f95a866)

Fix for: https://forum.libreelec.tv/thread/25834-ffmpeg-tools-addon-is-it-broken/

Run tested on LE10 x86_64 and build tested for ARMv8

- Backport of #6406


WAS:
```
nuc6:~ # ffmpeg
ffmpeg: error while loading shared libraries: libx265.so.199: cannot open shared object file: No such file or directory
```
IS:
```
nuc6:~ # ffmpeg
ffmpeg version 4.4 Copyright (c) 2000-2021 the FFmpeg developers
  built with gcc 10.2.0 (GCC)
  configuration: --enable-ffmpeg --disable-ffplay --enable-ffprobe --enable-static --pkg-config-flags=--static --disable-shared --enable-gpl --disable-doc --enable-encoder=h264_vaapi --enable-encoder=hevc_vaapi --enable-encoder=mjpeg_vaapi --enable-encoder=mpeg2_vaapi --enable-encoder=vp8_vaapi --enable-encoder=vp9_vaapi --disable-encoder=h264_nvenc --disable-encoder=hevc_nvenc --enable-hwaccel=h263_vaapi --enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --enable-hwaccel=mjpeg_vaapi --enable-hwaccel=mpeg2_vaapi --enable-hwaccel=mpeg4_vaapi --enable-hwaccel=vc1_vaapi --enable-hwaccel=vp8_vaapi --enable-hwaccel=vp9_vaapi --enable-hwaccel=wmv3_vaapi --enable-libvpx --enable-encoder=libvpx_vp8 --enable-encoder=libvpx_vp9 --enable-libx264 --enable-encoder=x264 --enable-libx265 --enable-encoder=x265 --enable-libaom --enable-encoder=libaom_av1 --enable-encoder=aac --enable-encoder=ac3 --enable-encoder=eac3 --enable-encoder=flac --enable-libmp3lame --enable-encoder=libmp3lame --enable-libopus --enable-encoder=libopus --enable-libvorbis --enable-encoder=libvorbis --enable-avresample --disable-lzma --disable-alsa --enable-libxcb --enable-libxcb-shm --enable-libxcb-xfixes --enable-libxcb-shape --arch=x86_64 --cpu=x86-64 --cross-prefix=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu- --enable-cross-compile --sysroot=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot --sysinclude=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include --target-os=linux --nm=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-nm --ar=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-ar --as=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc --cc=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc --ld=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc --pkg-config=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/bin/pkg-config --host-cc=/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/bin/host-gcc --host-cflags='-march=native -O2 -Wall -pipe -I/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/include -Wno-format-security' --host-ldflags='-Wl,-rpath,/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/lib -L/var/media/DATA/home-rudi/LibreELEC.libreelec-10.0/build.LibreELEC-Generic.x86_64-10.0-devel/toolchain/lib' --host-extralibs=-lm --extra-cflags='-march=x86-64 -m64 -mmmx -msse -msse2 -mfpmath=sse -Wall -pipe -O2 -fomit-frame-pointer' --extra-ldflags='-march=x86-64 -m64 -Wl,--as-needed' --extra-libs=' -lX11' --enable-pic --enable-gnutls --disable-openssl --disable-hardcoded-tables
  libavutil      56. 70.100 / 56. 70.100
  libavcodec     58.134.100 / 58.134.100
  libavformat    58. 76.100 / 58. 76.100
  libavdevice    58. 13.100 / 58. 13.100
  libavfilter     7.110.100 /  7.110.100
  libavresample   4.  0.  0 /  4.  0.  0
  libswscale      5.  9.100 /  5.  9.100
  libswresample   3.  9.100 /  3.  9.100
  libpostproc    55.  9.100 / 55.  9.100
Hyper fast Audio and Video encoder
usage: ffmpeg [options] [[infile options] -i infile]... {[outfile options] outfile}...

Use -h to get full help or, even better, run 'man ffmpeg'
```
