### PR TITLE
pipewire updates

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.53"
-PKG_SHA256="d05aef5c021d2555ad59de4f84b50523dcccc5d753e8d5f63dfc75f8eb7e38a7"
+PKG_VERSION="0.3.54"
+PKG_SHA256="11a856ac3eb70b7cbeef12407f50d240d212016b6de3bb692e462251571f050e"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.4.10"
-PKG_SHA256="bddc5bb3c47e97c170d27c712bc3c7912592aea1ea9df747e92685f5194456d4"
+PKG_VERSION="0.4.11"
+PKG_SHA256="cf5df4e4d2ab5402b4ede3bfa8931ff758359a46b6676541faebf3055d5a1fc6"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- pipewire: update to 0.3.54
  - https://github.com/PipeWire/pipewire/blob/master/NEWS
- wireplumber: update to 0.4.11
  - https://gitlab.freedesktop.org/pipewire/wireplumber/-/blob/master/NEWS.rst