### PR TITLE
kernel-firmware: add rtw88/* to image

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -20,3 +20,4 @@ ath9k_htc/*
 brcm/*
 rtl_bt/*
 rtlwifi/*
+rtw88/*


### PR DESCRIPTION
Add rtw88 firmware to image for both pci devices and future USB/SDIO devices.

kernel modules are already in place.

```
[    5.061961] rtw_8822be 0000:03:00.0: enabling device (0100 -> 0103)                                                                       
[    5.062027] rtw_8822be 0000:03:00.0: Direct firmware load for rtw88/rtw8822b_fw.bin failed with error -2                                  
[    5.062033] rtw_8822be 0000:03:00.0: failed to request firmware                                                                          
[    5.068176] rtw_8822be 0000:03:00.0: failed to load firmware                                                                              
[    5.068186] rtw_8822be 0000:03:00.0: failed to setup chip efuse info                                                                      
[    5.068189] rtw_8822be 0000:03:00.0: failed to setup chip information                                                                     
[    5.086170] rtw_8822be: probe of 0000:03:00.0 failed with error -22

03:00.0 Network controller: Realtek Semiconductor Co., Ltd. RTL8822BE 802.11a/b/g/n/ac WiFi adapter
```

- will be used for #6649 too