### PR TITLE
linux: print warning if config is different than what is processed

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -171,6 +171,33 @@ pre_make_target() {
 
   kernel_make oldconfig
 
+  KERNEL_CONFIG_DIFF="$(${PKG_BUILD}/scripts/diffconfig ${PKG_KERNEL_CFG_FILE} .config)"
+
+  KERNEL_CONFIG_DIFF_WHITELIST="CONFIG_INITRAMFS_SOURCE \
+                                CONFIG_DEFAULT_HOSTNAME \
+                                CONFIG_SWAP \
+                                CONFIG_NFS_FS \
+                                CONFIG_CIFS \
+                                CONFIG_SCSI_ISCSI_ATTRS \
+                                CONFIG_ISCSI_TCP \
+                                CONFIG_ISCSI_BOOT_SYSFS \
+                                CONFIG_ISCSI_IBFT_FIND \
+                                CONFIG_ISCSI_IBFT \
+                                CONFIG_DRM_LIMA \
+                                CONFIG_DRM_PANFROST \
+                                CONFIG_WIREGUARD \
+                                CONFIG_EXTRA_FIRMWARE \
+                                CONFIG_EXTRA_FIRMWARE_DIR \
+                               "
+
+  for CONFIG_OPTION in ${KERNEL_CONFIG_DIFF_WHITELIST}; do
+    KERNEL_CONFIG_DIFF="$(echo "${KERNEL_CONFIG_DIFF}" | sed "/${CONFIG_OPTION/CONFIG_}/d")"
+  done
+
+  if [ -n "${KERNEL_CONFIG_DIFF}" ]; then
+    print_color CLR_WARNING "LINUX: kernel options diff detected: \n\n${KERNEL_CONFIG_DIFF}\n\nPlease run ./tools/check_kernel_config\n"
+  fi
+
   if [ -f "${DISTRO_DIR}/${DISTRO}/kernel_options" ]; then
     while read OPTION; do
       [ -z "${OPTION}" -o -n "$(echo "${OPTION}" | grep '^#')" ] && continue


### PR DESCRIPTION
This is an alternative to #6459 

The idea here is to catch changes to the diff that may be processed from oldconfig.

We really want all selectable options to be checked in.

This works by adding a _whitelist_ of config options that are allowed to be changed. We need this because we change some kernel config options based on our LibreELEC configuration options.

This runs the linux kernel diffconfig script located in the kernel sources `scripts/diffconfig`. This compares the output of oldconfig to what is checked in for the project.

In the future I would like to add this as a QA check with #6666 so that we can catch kernel config differences easier. Currently there is no functional change and just prints a warning to the console.

For example (RPi4)
```
LINUX: kernel options diff detected: 

-BROKEN_GAS_INST y
-CC_CAN_LINK y
-CC_CAN_LINK_STATIC y
 AS_VERSION 23502 -> 23800
 CC_VERSION_TEXT "gcc (Debian 10.2.1-6) 10.2.1 20210110" -> "aarch64-none-elf-gcc-11.3.0 (GCC) 11.3.0"
 CRYPTO_LIB_ARC4 y -> m
 GCC_VERSION 100201 -> 110300
 LD_VERSION 23502 -> 23800
+ARCH_USES_HIGH_VMA_FLAGS y
+ARM64_AS_HAS_MTE y
+ARM64_BTI_KERNEL y
+ARM64_LD_HAS_FIX_ERRATUM_843419 y
+ARM64_LSE_ATOMICS y
+ARM64_MTE y
+ARM64_PTR_AUTH_KERNEL y
+ARM64_TLB_RANGE y
+AS_HAS_ARMV8_4 y
+AS_HAS_ARMV8_5 y
+AS_HAS_LDAPR y
+AS_HAS_LSE_ATOMICS y
+AS_HAS_PAC y
+CC_HAS_ASM_GOTO_OUTPUT y
+CC_HAS_BRANCH_PROT_PAC_RET y
+CC_HAS_BRANCH_PROT_PAC_RET_BTI y
+CC_HAS_KASAN_SW_TAGS y
+CC_HAS_SIGN_RETURN_ADDRESS y
+CC_HAS_ZERO_CALL_USED_REGS y
+CC_HAVE_STACKPROTECTOR_SYSREG y
+GCC_PLUGINS y
+GCC_PLUGIN_CYC_COMPLEXITY n
+GCC_PLUGIN_LATENT_ENTROPY n
+GCC_PLUGIN_RANDSTRUCT n
+GCC_PLUGIN_STACKLEAK n
+GCC_PLUGIN_STRUCTLEAK_BYREF n
+GCC_PLUGIN_STRUCTLEAK_BYREF_ALL n
+GCC_PLUGIN_STRUCTLEAK_USER n
+HAVE_ARCH_KASAN_HW_TAGS y
+HAVE_KCSAN_COMPILER y
+STACKPROTECTOR_PER_TASK y
+ZERO_CALL_USED_REGS n

Please run ./tools/check_kernel_config
```
