### PR TITLE
[le10] kodi: update to latest Matrix and include DVD menu fix PR

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="19.4-Matrix"
-PKG_SHA256="cc026f59fd6e37ae90f3449df50810f1cefa37da9444e1188302d910518710da"
+PKG_VERSION="181070c647425a8730fb7d8f1c349cd750e40021"
+PKG_SHA256="597b8681fb745779a43da667dbc55a6139aabce692c6c86505840363a7a3f7ab"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -339,7 +339,7 @@ post_makeinstall_target() {
   # more binaddons cross compile badness meh
   sed -e "s:INCLUDE_DIR /usr/include/kodi:INCLUDE_DIR ${SYSROOT_PREFIX}/usr/include/kodi:g" \
       -e "s:CMAKE_MODULE_PATH /usr/lib/kodi /usr/share/kodi/cmake:CMAKE_MODULE_PATH ${SYSROOT_PREFIX}/usr/share/kodi/cmake:g" \
-      -i ${SYSROOT_PREFIX}/usr/share/kodi/cmake/KodiConfig.cmake
+      -i ${SYSROOT_PREFIX}/usr/lib/kodi/cmake/KodiConfig.cmake
 
   if [ "${KODI_EXTRA_FONTS}" = yes ]; then
     mkdir -p ${INSTALL}/usr/share/kodi/media/Fonts

--- a/packages/mediacenter/kodi/patches/kodi-001-pr21673-drmprime-fix-dvd-menu.patch
+++ b/packages/mediacenter/kodi/patches/kodi-001-pr21673-drmprime-fix-dvd-menu.patch
@@ -1,0 +1,69 @@
+From e425b4fc3d209c91e130004a67d16b9c46408788 Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Thu, 7 Jul 2022 15:41:58 +0100
+Subject: [PATCH 1/2] CDVDVideoCodecDRMPRIME: Move picture release after
+ avcodec_receive_frame
+
+This matches the code order of DVDVideoCodecFFMPEG and is required
+for working DVD menus
+---
+ .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp        | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index b27db92b5f7d7..a7407e76afb6b 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+@@ -536,12 +536,6 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
+   if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
+     Drain();
+ 
+-  if (pVideoPicture->videoBuffer)
+-  {
+-    pVideoPicture->videoBuffer->Release();
+-    pVideoPicture->videoBuffer = nullptr;
+-  }
+-
+   int ret = avcodec_receive_frame(m_pCodecContext, m_pFrame);
+   if (ret == AVERROR(EAGAIN))
+     return VC_BUFFER;
+@@ -566,6 +560,12 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
+ 
+   SetPictureParams(pVideoPicture);
+ 
++  if (pVideoPicture->videoBuffer)
++  {
++    pVideoPicture->videoBuffer->Release();
++    pVideoPicture->videoBuffer = nullptr;
++  }
++
+   if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
+   {
+     CVideoBufferDRMPRIMEFFmpeg* buffer =
+
+From 325e745a0a609367007ba814f6eb1829d3d082e7 Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Thu, 7 Jul 2022 12:31:12 +0100
+Subject: [PATCH 2/2] RendererDRMPRIME: Remove NeedBuffer check for valid fd
+
+This check breaks DVD menus. All calls return true which prevents
+new pictures being released, stalling DVD menus
+---
+ .../VideoRenderers/HwDecRender/RendererDRMPRIME.cpp           | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+index 36e4093cbe36b..a8667bdbf48e5 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+@@ -172,10 +172,6 @@ bool CRendererDRMPRIME::NeedBuffer(int index)
+   if (m_iLastRenderBuffer == index)
+     return true;
+ 
+-  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
+-  if (buffer && buffer->m_fb_id)
+-    return true;
+-
+   return false;
+ }
+ 

--- a/projects/RPi/patches/kodi/kodi-001-deinterlace.patch
+++ b/projects/RPi/patches/kodi/kodi-001-deinterlace.patch
@@ -1,15 +1,15 @@
-From d9289be2540afc91f488cedf18da30b0b24edc01 Mon Sep 17 00:00:00 2001
+From 5a9de3cccae2180ac51221185eca141c05b09a52 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 20 Oct 2019 17:10:07 +0000
 Subject: [PATCH 1/8] WIP: DVDVideoCodecDRMPRIME: add support for filters
 
 ---
- .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 68 ++++++++++++++++---
+ .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 62 +++++++++++++++++--
  .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.h   | 10 +++
- 2 files changed, 69 insertions(+), 9 deletions(-)
+ 2 files changed, 66 insertions(+), 6 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index c7d487570b..187c03b8df 100644
+index c70a114d30..5d9867a118 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 @@ -27,6 +27,8 @@
@@ -21,7 +21,7 @@ index c7d487570b..187c03b8df 100644
  #include <libavutil/error.h>
  #include <libavutil/imgutils.h>
  #include <libavutil/opt.h>
-@@ -545,18 +547,30 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+@@ -545,12 +547,30 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
    pVideoPicture->dts = DVD_NOPTS_VALUE;
  }
  
@@ -32,19 +32,16 @@ index c7d487570b..187c03b8df 100644
 -    Drain();
 +  if (!m_pFilterIn)
 +    return VC_PICTURE;
- 
--  if (pVideoPicture->videoBuffer)
++
 +  int ret = av_buffersrc_add_frame(m_pFilterIn, m_pFrame);
 +  if (ret < 0)
-   {
--    pVideoPicture->videoBuffer->Release();
--    pVideoPicture->videoBuffer = nullptr;
++  {
 +    char err[AV_ERROR_MAX_STRING_SIZE] = {};
 +    av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
 +    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - buffersrc add frame failed: {} ({})",
 +              __FUNCTION__, err, ret);
 +    return VC_ERROR;
-   }
++  }
  
 -  int ret = avcodec_receive_frame(m_pCodecContext, m_pFrame);
 +  return ProcessFilterOut();
@@ -59,7 +56,7 @@ index c7d487570b..187c03b8df 100644
    if (ret == AVERROR(EAGAIN))
      return VC_BUFFER;
    else if (ret == AVERROR_EOF)
-@@ -573,11 +587,47 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
+@@ -567,11 +587,41 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
    {
      char err[AV_ERROR_MAX_STRING_SIZE] = {};
      av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
@@ -77,12 +74,6 @@ index c7d487570b..187c03b8df 100644
 +{
 +  if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
 +    Drain();
-+
-+  if (pVideoPicture->videoBuffer)
-+  {
-+    pVideoPicture->videoBuffer->Release();
-+    pVideoPicture->videoBuffer = nullptr;
-+  }
 +
 +  auto result = ProcessFilterOut();
 +  if (result != VC_PICTURE)
@@ -108,7 +99,7 @@ index c7d487570b..187c03b8df 100644
 +
    SetPictureParams(pVideoPicture);
  
-   if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
+   if (pVideoPicture->videoBuffer)
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
 index 9d70893b70..48bbae40fc 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -144,21 +135,21 @@ index 9d70893b70..48bbae40fc 100644
    std::shared_ptr<IVideoBufferPool> m_videoBufferPool;
  };
 -- 
-2.30.2
+2.34.1
 
 
-From 023c723c3ad241b8b606705c17d0464d6d555ff9 Mon Sep 17 00:00:00 2001
+From fec8b50d3d04bc59bfc043eb9ce23bfa682feb3f Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Thu, 26 Dec 2019 11:01:51 +0100
 Subject: [PATCH 2/8] WIP: DRMPRIME deinterlace filter
 
 ---
- .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 368 +++++++++++++++---
+ .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 378 +++++++++++++++---
  .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.h   |   9 +-
- 2 files changed, 322 insertions(+), 55 deletions(-)
+ 2 files changed, 327 insertions(+), 60 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 187c03b8df..3ab860937a 100644
+index 5d9867a118..f9755bc292 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 @@ -80,12 +80,15 @@ CDVDVideoCodecDRMPRIME::CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo)
@@ -216,10 +207,16 @@ index 187c03b8df..3ab860937a 100644
  {
    pVideoPicture->iWidth = m_pFrame->width;
    pVideoPicture->iHeight = m_pFrame->height;
-@@ -545,13 +561,232 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+@@ -545,13 +561,238 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
                             ? DVD_NOPTS_VALUE
                             : static_cast<double>(pts) * DVD_TIME_BASE / AV_TIME_BASE;
    pVideoPicture->dts = DVD_NOPTS_VALUE;
++
++  if (pVideoPicture->videoBuffer)
++  {
++    pVideoPicture->videoBuffer->Release();
++    pVideoPicture->videoBuffer = nullptr;
++  }
 +
 +  if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
 +  {
@@ -452,7 +449,7 @@ index 187c03b8df..3ab860937a 100644
    int ret = av_buffersrc_add_frame(m_pFilterIn, m_pFrame);
    if (ret < 0)
    {
-@@ -567,21 +802,14 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
+@@ -567,21 +808,14 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
  
  CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterOut()
  {
@@ -478,7 +475,7 @@ index 187c03b8df..3ab860937a 100644
    }
    else if (ret)
    {
-@@ -592,9 +820,27 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterOut()
+@@ -592,71 +826,97 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterOut()
      return VC_ERROR;
    }
  
@@ -506,9 +503,7 @@ index 187c03b8df..3ab860937a 100644
  CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideoPicture)
  {
    if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
-@@ -606,57 +852,71 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
-     pVideoPicture->videoBuffer = nullptr;
-   }
+     Drain();
  
 -  auto result = ProcessFilterOut();
 -  if (result != VC_PICTURE)
@@ -531,23 +526,29 @@ index 187c03b8df..3ab860937a 100644
 +      if (!SetPictureParams(pVideoPicture))
 +        return VC_ERROR;
 +      return VC_PICTURE;
-     }
++    }
 +    else if (ret != VC_BUFFER)
 +    {
 +      return ret;
-+    }
-+  }
- 
+     }
+-
 -    result = ProcessFilterIn();
 -    if (result != VC_PICTURE)
 -      return result;
+   }
+ 
+-  SetPictureParams(pVideoPicture);
+-
+-  if (pVideoPicture->videoBuffer)
 +  int ret = avcodec_receive_frame(m_pCodecContext, m_pFrame);
 +  if (ret == AVERROR(EAGAIN))
 +    return VC_BUFFER;
 +  else if (ret == AVERROR_EOF)
 +    return VC_EOF;
 +  else if (ret)
-+  {
+   {
+-    pVideoPicture->videoBuffer->Release();
+-    pVideoPicture->videoBuffer = nullptr;
 +    char err[AV_ERROR_MAX_STRING_SIZE] = {};
 +    av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
 +    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - receive frame failed: {} ({})",
@@ -555,11 +556,10 @@ index 187c03b8df..3ab860937a 100644
 +    return VC_ERROR;
    }
  
--  SetPictureParams(pVideoPicture);
+-  if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
 +  if (!m_processInfo.GetVideoInterlaced() && m_pFrame->interlaced_frame)
 +    m_processInfo.SetVideoInterlaced(true);
- 
--  if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
++
 +  std::string filterChain = GetFilterChain(m_pFrame->interlaced_frame);
 +  if (!filterChain.empty())
    {
@@ -648,10 +648,10 @@ index 48bbae40fc..c0478f0072 100644
    AVFilterContext* m_pFilterIn = nullptr;
    AVFilterContext* m_pFilterOut = nullptr;
 -- 
-2.30.2
+2.34.1
 
 
-From a0ead6998a8c75f8390617a9fe7aa17f91258520 Mon Sep 17 00:00:00 2001
+From 8a9e0f132ee4a42ab98b9e723fcecdca7abee2e2 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 27 Aug 2021 20:29:50 +0100
 Subject: [PATCH 3/8] DVDVideoCodecDRMPRIME: Avoid exception with
@@ -662,10 +662,10 @@ Subject: [PATCH 3/8] DVDVideoCodecDRMPRIME: Avoid exception with
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 3ab860937a..cc070725c0 100644
+index f9755bc292..d2c10a58d3 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -585,7 +585,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+@@ -591,7 +591,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
    if (!pVideoPicture->videoBuffer)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - videoBuffer:nullptr format:{}", __FUNCTION__,
@@ -675,10 +675,10 @@ index 3ab860937a..cc070725c0 100644
      return false;
    }
 -- 
-2.30.2
+2.34.1
 
 
-From 1dccab74e24b420838c0cd40da4343d41b0a4766 Mon Sep 17 00:00:00 2001
+From 641ebd4de71588feefdaf70a874db878534e492e Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Tue, 14 Sep 2021 18:22:52 +0100
 Subject: [PATCH 4/8] CDVDVideoCodecDRMPRIME: Fix Format calls and some logging
@@ -689,10 +689,10 @@ Subject: [PATCH 4/8] CDVDVideoCodecDRMPRIME: Fix Format calls and some logging
  2 files changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index cc070725c0..08872a6fb3 100644
+index d2c10a58d3..83d17e04ff 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -642,8 +642,8 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -648,8 +648,8 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    const AVFilter* outFilter = avfilter_get_by_name("buffersink");
    enum AVPixelFormat pix_fmts[] = { AV_PIX_FMT_DRM_PRIME, AV_PIX_FMT_NONE };
  
@@ -703,7 +703,7 @@ index cc070725c0..08872a6fb3 100644
                                           m_pCodecContext->width,
                                           m_pCodecContext->height,
                                           m_pCodecContext->pix_fmt,
-@@ -763,7 +763,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -769,7 +769,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      char* graphDump = avfilter_graph_dump(m_pFilterGraph, nullptr);
      if (graphDump)
      {
@@ -798,10 +798,10 @@ index 6ebf7501ad..2040f8f54c 100644
    }
  
 -- 
-2.30.2
+2.34.1
 
 
-From 4a8d56d9585a19fc807e5c6427cdb47fa17d7e73 Mon Sep 17 00:00:00 2001
+From c9b21464132653f921852f7239069ec237b3eb02 Mon Sep 17 00:00:00 2001
 From: Dom Cobley <popcornmix@gmail.com>
 Date: Wed, 24 Nov 2021 20:21:28 +0000
 Subject: [PATCH 5/8] DVDVideoCodecDRMPRIME: Close deinterlace filter on error
@@ -812,10 +812,10 @@ Otherwise we crash later with an invalid m_pFilterGraph pointer
  1 file changed, 7 insertions(+)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 08872a6fb3..ff8ebe1a21 100644
+index 83d17e04ff..360018e5e5 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -665,6 +665,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -671,6 +671,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: src: {} ({})",
                err, result);
@@ -823,7 +823,7 @@ index 08872a6fb3..ff8ebe1a21 100644
      return false;
    }
  
-@@ -672,6 +673,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -678,6 +679,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (!par)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - unable to alloc buffersrc");
@@ -831,7 +831,7 @@ index 08872a6fb3..ff8ebe1a21 100644
      return false;
    }
  
-@@ -687,6 +689,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -693,6 +695,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - av_buffersrc_parameters_set:  {} ({})",
                err, result);
@@ -839,7 +839,7 @@ index 08872a6fb3..ff8ebe1a21 100644
      return false;
    }
    av_freep(&par);
-@@ -700,6 +703,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -706,6 +709,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: out: {} ({})",
                err, result);
@@ -847,7 +847,7 @@ index 08872a6fb3..ff8ebe1a21 100644
      return false;
    }
  
-@@ -708,6 +712,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -714,6 +718,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (result < 0)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - failed settings pix formats");
@@ -855,7 +855,7 @@ index 08872a6fb3..ff8ebe1a21 100644
      return false;
    }
  
-@@ -731,6 +736,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -737,6 +742,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (result < 0)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_parse");
@@ -863,7 +863,7 @@ index 08872a6fb3..ff8ebe1a21 100644
      return false;
    }
  
-@@ -740,6 +746,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -746,6 +752,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      av_strerror(result, err, AV_ERROR_MAX_STRING_SIZE);
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_config:  {} ({})",
                err, result);
@@ -872,10 +872,10 @@ index 08872a6fb3..ff8ebe1a21 100644
    }
  
 -- 
-2.30.2
+2.34.1
 
 
-From b6cf9aae750089099cd319b748dbc4c36daadccb Mon Sep 17 00:00:00 2001
+From 0a49d665442b4b50b0faead0248285cab140524f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 11 Sep 2021 14:03:05 +0100
 Subject: [PATCH 6/8] CDVDVideoCodecDRMPRIME: Also support YUV420 buffers
@@ -888,19 +888,19 @@ Need to call SetDimensions earlier and store the drm descriptor in expected plac
  1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index ff8ebe1a21..2ad15f5e6f 100644
+index 360018e5e5..0c90e223a1 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -562,7 +562,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
-                            : static_cast<double>(pts) * DVD_TIME_BASE / AV_TIME_BASE;
-   pVideoPicture->dts = DVD_NOPTS_VALUE;
+@@ -568,7 +568,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+     pVideoPicture->videoBuffer = nullptr;
+   }
  
 -  if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
 +  if (m_pFrame->format == AV_PIX_FMT_DRM_PRIME)
    {
      CVideoBufferDRMPRIMEFFmpeg* buffer =
          dynamic_cast<CVideoBufferDRMPRIMEFFmpeg*>(m_videoBufferPool->Get());
-@@ -640,7 +640,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -646,7 +646,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
  
    const AVFilter* srcFilter = avfilter_get_by_name("buffer");
    const AVFilter* outFilter = avfilter_get_by_name("buffersink");
@@ -909,7 +909,7 @@ index ff8ebe1a21..2ad15f5e6f 100644
  
    std::string args = StringUtils::Format("video_size={}x{}:pix_fmt={}:time_base={}/{}:"
                                           "pixel_aspect={}/{}:sws_param=flags=2",
-@@ -794,6 +794,16 @@ void CDVDVideoCodecDRMPRIME::FilterClose()
+@@ -800,6 +800,16 @@ void CDVDVideoCodecDRMPRIME::FilterClose()
  
  CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
  {
@@ -927,10 +927,10 @@ index ff8ebe1a21..2ad15f5e6f 100644
    if (ret < 0)
    {
 -- 
-2.30.2
+2.34.1
 
 
-From 0d49d845f7d3042584b8683aafb13257b39ee81d Mon Sep 17 00:00:00 2001
+From 49d2e74084f1bd7e1b499bc79a89e90a8fd6264f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 17 Sep 2021 15:23:16 +0100
 Subject: [PATCH 7/8] DVDVideoCodecDRMPRIME: Leave deinterlace filter active on
@@ -946,10 +946,10 @@ be just copied by deinterlace filter
  1 file changed, 4 insertions(+)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 2ad15f5e6f..8e4715dfc0 100644
+index 0c90e223a1..60015ecdc0 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -852,6 +852,10 @@ std::string CDVDVideoCodecDRMPRIME::GetFilterChain(bool interlaced)
+@@ -858,6 +858,10 @@ std::string CDVDVideoCodecDRMPRIME::GetFilterChain(bool interlaced)
    if (!m_processInfo.Supports(mInt))
      mInt = m_processInfo.GetFallbackDeintMethod();
  
@@ -961,10 +961,10 @@ index 2ad15f5e6f..8e4715dfc0 100644
      filterChain += m_deintFilterName;
  
 -- 
-2.30.2
+2.34.1
 
 
-From ba221cd2eff3c447f45bcdf753a9c22a151bb68b Mon Sep 17 00:00:00 2001
+From 36c622c3b6cf736867be3ae56211ef1369a39372 Mon Sep 17 00:00:00 2001
 From: Dom Cobley <popcornmix@gmail.com>
 Date: Tue, 30 Nov 2021 16:05:06 +0000
 Subject: [PATCH 8/8] SetVideoInterlaced: Set and unset deinterlace method name
@@ -975,10 +975,10 @@ Subject: [PATCH 8/8] SetVideoInterlaced: Set and unset deinterlace method name
  1 file changed, 2 insertions(+), 8 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 8e4715dfc0..9977aae914 100644
+index 60015ecdc0..2c22da30de 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -756,14 +756,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -762,14 +762,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      return true;
    }
  
@@ -994,7 +994,7 @@ index 8e4715dfc0..9977aae914 100644
  
    if (CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
    {
-@@ -781,6 +774,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -787,6 +780,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
  
  void CDVDVideoCodecDRMPRIME::FilterClose()
  {
@@ -1003,5 +1003,5 @@ index 8e4715dfc0..9977aae914 100644
    {
      CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecDRMPRIME::FilterClose - Freeing filter graph");
 -- 
-2.30.2
+2.34.1
 


### PR DESCRIPTION
This PR includes https://github.com/xbmc/xbmc/pull/21673 which can be dropped when it's merged in kodi.

Quick runtime test on RPi4 looks good, DVD menus and deinterlace are working fine