### PR TITLE
package/audio updates

### DIFF
--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.2.7"
-PKG_SHA256="460d86d8d687f567dc4780890b72538c7ff6b2082080ef2f9359d41670a309cf"
+PKG_VERSION="2.2.8"
+PKG_SHA256="7c29a5cb7a2755c8012d941d1335da7bda957bbb0a86b7c59215d26773bb51fe"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.54"
-PKG_SHA256="11a856ac3eb70b7cbeef12407f50d240d212016b6de3bb692e462251571f050e"
+PKG_VERSION="0.3.55"
+PKG_SHA256="666260961a242239a940b7f6130e5e9cb51ad76f9ebf6b5403198ee5efa69344"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/wavpack/package.mk
+++ b/packages/audio/wavpack/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wavpack"
-PKG_VERSION="5.4.0"
-PKG_SHA256="4bde6a6b2a86614a6bd2579e60dcc974e2c8f93608d2281110a717c1b3c28b79"
+PKG_VERSION="5.5.0"
+PKG_SHA256="ef749d98df46925bc2916993e601cc7ee9114d99653e63e0e304f031ba73b8e6"
 PKG_LICENSE="BSD"
-PKG_SITE="http://www.wavpack.com"
-PKG_URL="http://www.wavpack.com/wavpack-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.wavpack.com"
+PKG_URL="https://www.wavpack.com/wavpack-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libiconv"
 PKG_LONGDESC="Audio compression format providing lossless, high-quality lossy and hybrid compression mode."
 


### PR DESCRIPTION
- [pipewire: update to 0.3.55](https://github.com/LibreELEC/LibreELEC.tv/commit/7241c4b5a295e223ff2a8cbfbb59a2b0be9bd08c)
- [fluidsynth: update to 2.2.8](https://github.com/LibreELEC/LibreELEC.tv/commit/00cc89f1f1e341ed7402200359148a6be43757a4)
- [wavpack: update to 5.5.0 and https](https://github.com/LibreELEC/LibreELEC.tv/commit/9be2d64ad693390d6d4a2c9df60c320b24250546)
