### PR TITLE
glibc: fix / workaround "CPU ISA level is lower than required"

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -77,6 +77,7 @@ libc_cv_c_cleanup=yes
 libc_cv_ssp=no
 libc_cv_ssp_strong=no
 libc_cv_slibdir=/usr/lib
+libc_cv_include_x86_isa_level=no
 EOF
 
   cat >configparms <<EOF


### PR DESCRIPTION
If your build system does not meet the chosen `-march=xxx` target CPU features some packages will fail to run binaries which were linked against target glibc with `CPU ISA level is lower than required` in the build process, even if you work around this by lowering the `-march` for this specific package.
Happened to me when I was building x86-64-v3 on a SandyBridge 2nd Gen Intel Core system, a 7th Gen system with AVX2 support won't fail. Technically this could be worked around by a host build but that's not possible for all packages without extreme hacks.

- follow up of https://github.com/LibreELEC/LibreELEC.tv/pull/6606
- https://bugs.archlinux.org/task/69624#comment196706
- https://www.linuxfromscratch.org/~xry111/usr-move/r10.1-89-gc7ef5-sysv/chapter05/glibc.html