### PR TITLE
[le11] scripts/checkdeps: add EndeavourOS & fix Java

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -162,14 +162,14 @@ case "${DISTRO}" in
         [XML::Parser]=XML-Parser
       )
       ;;
-    arch)
+    arch|endeavouros)
       dep_map+=(
         [g++]=g++
         [mkfontscale]=xorg-mkfontscale
         [mkfontdir]=xorg-mkfontdir
         [bdftopcf]=xorg-bdftopcf
         [xsltproc]=libxslt
-        [java]="java-runtime-common jdk8-openjdk"
+        [java]=jdk8-openjdk
         [python3]=python3
         [rpcgen]=rpcsvc-proto
       )
@@ -265,7 +265,7 @@ if [ "${#need_map[@]}" -gt 0 ]; then
       mageia)
         get_yes_no && sudo urpmi "${need_map[@]}"
         ;;
-      arch)
+      arch|endeavouros)
         get_yes_no && sudo pacman -Sy "${need_map[@]}"
         ;;
       opensuse)


### PR DESCRIPTION
Tested on a clean install/fresh installation and works ootb.

- adds arch based https://endeavouros.com/
- fixes Java by pacman installing [`[java]=jdk8-openjdk`](https://archlinux.org/packages/extra/x86_64/jdk-openjdk/) which also provides https://archlinux.org/packages/extra/any/java-environment-common/