### PR TITLE
curl: add patch to fix build for 7.84.0

### DIFF
--- a/packages/web/curl/patches/0001-easy_lock.h-include-sched.h-if-available-to-fix-buil.patch
+++ b/packages/web/curl/patches/0001-easy_lock.h-include-sched.h-if-available-to-fix-buil.patch
@@ -1,0 +1,29 @@
+From e2e7f54b7bea521fa8373095d0f43261a720cda0 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 27 Jun 2022 08:46:21 +0200
+Subject: [PATCH] easy_lock.h: include sched.h if available to fix build
+
+Patched-by: Harry Sintonen
+
+Closes #9054
+---
+ lib/easy_lock.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/easy_lock.h b/lib/easy_lock.h
+index 819f50ce8..1f54289ce 100644
+--- a/lib/easy_lock.h
++++ b/lib/easy_lock.h
+@@ -36,6 +36,9 @@
+ 
+ #elif defined (HAVE_ATOMIC)
+ #include <stdatomic.h>
++#if defined(HAVE_SCHED_YIELD)
++#include <sched.h>
++#endif
+ 
+ #define curl_simple_lock atomic_bool
+ #define CURL_SIMPLE_LOCK_INIT false
+-- 
+2.34.1
+


### PR DESCRIPTION
Building curl currently fails for arm32 userspace and needs to be patched: See https://github.com/curl/curl/issues/9159