### PR TITLE
Intel updates

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.1.5"
-PKG_SHA256="b429cdff2c236274f2b9a32ac4ac2ed5d1655d3c87c557fe0fb7de6b6c906f18"
+PKG_VERSION="22.1.6"
+PKG_SHA256="d60d9d2a8740f95a244b6e2113265ba6e6c915eaada6d644ecc4c8d436344a6e"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.4.4"
-PKG_SHA256="19c3ef965ca155913719d138e297963b759f9b9d34d4ea85414d1c7b9d204253"
+PKG_VERSION="22.5.0"
+PKG_SHA256="7cfa02442711f4ffa7fc1bd6effda49446a005422a3db4083bbc1a621815f672"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
[media-driver: update to 22.5.0](https://github.com/LibreELEC/LibreELEC.tv/commit/f7fda61824efbac64d96e17bea960bbc9d46bad4)
- https://github.com/intel/media-driver/compare/intel-media-22.4.4...intel-media-22.5.0

[gmmlib: update to 22.1.6](https://github.com/LibreELEC/LibreELEC.tv/commit/6ec0bfbc9292e508eb01561dfc27f21399bc4288)
- minor
  - https://github.com/intel/gmmlib/compare/intel-gmmlib-22.1.5...intel-gmmlib-22.1.6

```
=== tested on ===
Generic.x86_64-devel-20220717053735-0ed554b
Linux nuc11 5.19.0-rc6 #1 SMP Sat Jul 16 11:10:01 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:20.0a2-Nexus). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-07-14 by GCC 12.1.0 for Linux x86 64-bit version 5.18.11 (332299)
Running on LibreELEC (heitbaum): devel-20220717053735-0ed554b 11.0, kernel: Linux x86 64-bit version 5.19.0-rc6
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0046.2022.0608.1909 06/08/2022
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.1.4
libva info: VA-API version 1.15.0
vainfo: VA-API version: 1.15 (libva 2.15.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.5.0 (0ed554bf10)
```