### PR TITLE
rsync: cleanup options

### DIFF
--- a/packages/network/rsync/package.mk
+++ b/packages/network/rsync/package.mk
@@ -7,24 +7,27 @@ PKG_SHA256="6f761838d08052b0b6579cf7f6737d93e47f01f4da04c5d24d3447b7f2a5fad1"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://rsync.samba.org"
 PKG_URL="https://download.samba.org/pub/rsync/src/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_HOST="autotools:host zlib:host zstd:host"
+PKG_DEPENDS_HOST="autotools:host zlib:host"
 PKG_DEPENDS_TARGET="toolchain zlib openssl"
 PKG_LONGDESC="A very fast method for bringing remote files into sync."
 PKG_BUILD_FLAGS="-sysroot"
 
-PKG_CONFIGURE_OPTS_HOST="--with-included-popt \
-                         --without-included-zlib \
+PKG_CONFIGURE_OPTS_HOST="--disable-md2man \
+                         --disable-ipv6 \
                          --disable-openssl \
+                         --disable-xxhash \
+                         --disable-zstd \
                          --disable-lz4 \
-                         --enable-zstd \
-                         --disable-xxhash"
+                         --disable-iconv \
+                         --with-included-popt \
+                         --without-included-zlib"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-acl-support \
-                           --disable-asm \
+                           --disable-md5-asm \
                            --enable-openssl \
                            --disable-lz4 \
                            --disable-md2man \
-                           --disable-simd \
+                           --disable-roll-simd \
                            --disable-xattr-support \
                            --disable-xxhash \
                            --disable-zstd \


### PR DESCRIPTION
This pares down rsync:host as it's only used for file copying while building linux.

For rsync:host,

disable-md2man disables manpage creation
disable-ipv6 disables ipv6 support
disable-iconv disables the --iconv option, which does character conversion
reorders options to match how they appear in configure output

For rsync:target, some options were renamed in 3.2.4's release.