### PR TITLE
[le11] update to latest kodi master with DRMPRIME DVD fix

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="20.0a2-Nexus"
-PKG_SHA256="f178c6ff41ba79421c422e7ea1803d446bcbba20d08e84e547cb107e2d485e8b"
+PKG_VERSION="80f18db9500c0738d3522f4efdf789aa012e9930"
+PKG_SHA256="9ccb6d041cea12f7c571dae4456a01ebda83c6430c99f180052e44c346658579"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0001-WIP-DVDVideoCodecDRMPRIME-add-support-for-filters.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0001-WIP-DVDVideoCodecDRMPRIME-add-support-for-filters.patch
@@ -1,13 +1,15 @@
-From 6789405cbea23dd0d53ba5a6833dc2266f166ad9 Mon Sep 17 00:00:00 2001
+From a90ad221abf77aa38d34b52edf21a43f85aedac2 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 20 Oct 2019 17:10:07 +0000
 Subject: [PATCH 1/2] WIP: DVDVideoCodecDRMPRIME: add support for filters
 
 ---
- .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 68 ++++++++++++++++---
+ .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 62 +++++++++++++++++--
  .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.h   | 10 +++
- 2 files changed, 69 insertions(+), 9 deletions(-)
+ 2 files changed, 66 insertions(+), 6 deletions(-)
 
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index 80ca60290c..40cde1ba6e 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 @@ -27,6 +27,8 @@
@@ -19,7 +21,7 @@ Subject: [PATCH 1/2] WIP: DVDVideoCodecDRMPRIME: add support for filters
  #include <libavutil/error.h>
  #include <libavutil/imgutils.h>
  #include <libavutil/opt.h>
-@@ -559,18 +561,30 @@ void CDVDVideoCodecDRMPRIME::SetPictureP
+@@ -559,12 +561,30 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
    pVideoPicture->dts = DVD_NOPTS_VALUE;
  }
  
@@ -30,19 +32,16 @@ Subject: [PATCH 1/2] WIP: DVDVideoCodecDRMPRIME: add support for filters
 -    Drain();
 +  if (!m_pFilterIn)
 +    return VC_PICTURE;
- 
--  if (pVideoPicture->videoBuffer)
++
 +  int ret = av_buffersrc_add_frame(m_pFilterIn, m_pFrame);
 +  if (ret < 0)
-   {
--    pVideoPicture->videoBuffer->Release();
--    pVideoPicture->videoBuffer = nullptr;
++  {
 +    char err[AV_ERROR_MAX_STRING_SIZE] = {};
 +    av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
 +    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - buffersrc add frame failed: {} ({})",
 +              __FUNCTION__, err, ret);
 +    return VC_ERROR;
-   }
++  }
  
 -  int ret = avcodec_receive_frame(m_pCodecContext, m_pFrame);
 +  return ProcessFilterOut();
@@ -57,7 +56,7 @@ Subject: [PATCH 1/2] WIP: DVDVideoCodecDRMPRIME: add support for filters
    if (ret == AVERROR(EAGAIN))
      return VC_BUFFER;
    else if (ret == AVERROR_EOF)
-@@ -587,11 +601,47 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecD
+@@ -581,11 +601,41 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
    {
      char err[AV_ERROR_MAX_STRING_SIZE] = {};
      av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
@@ -75,12 +74,6 @@ Subject: [PATCH 1/2] WIP: DVDVideoCodecDRMPRIME: add support for filters
 +{
 +  if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
 +    Drain();
-+
-+  if (pVideoPicture->videoBuffer)
-+  {
-+    pVideoPicture->videoBuffer->Release();
-+    pVideoPicture->videoBuffer = nullptr;
-+  }
 +
 +  auto result = ProcessFilterOut();
 +  if (result != VC_PICTURE)
@@ -106,7 +99,9 @@ Subject: [PATCH 1/2] WIP: DVDVideoCodecDRMPRIME: add support for filters
 +
    SetPictureParams(pVideoPicture);
  
-   if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
+   if (pVideoPicture->videoBuffer)
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+index db49d165e7..b5cacf1a3c 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
 @@ -14,6 +14,11 @@
@@ -139,3 +134,6 @@ Subject: [PATCH 1/2] WIP: DVDVideoCodecDRMPRIME: add support for filters
 +  AVFilterContext* m_pFilterOut = nullptr;
    std::shared_ptr<IVideoBufferPool> m_videoBufferPool;
  };
+-- 
+2.34.1
+

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0001-WIP-DVDVideoCodecDRMPRIME-add-support-for-filters.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0001-WIP-DVDVideoCodecDRMPRIME-add-support-for-filters.patch
@@ -1,7 +1,7 @@
 From a90ad221abf77aa38d34b52edf21a43f85aedac2 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 20 Oct 2019 17:10:07 +0000
-Subject: [PATCH 1/2] WIP: DVDVideoCodecDRMPRIME: add support for filters
+Subject: [PATCH 1/6] WIP: DVDVideoCodecDRMPRIME: add support for filters
 
 ---
  .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 62 +++++++++++++++++--

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0002-WIP-DRMPRIME-deinterlace-filter.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0002-WIP-DRMPRIME-deinterlace-filter.patch
@@ -1,16 +1,18 @@
-From 58f2acdc63d85eb9818d783a9a858b1ecc267fa7 Mon Sep 17 00:00:00 2001
+From 60c20b00749ddf3ffd8cbb7a3cd3778fb8af13fc Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Thu, 26 Dec 2019 11:01:51 +0100
 Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
 
 ---
- .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 368 +++++++++++++++---
+ .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 378 +++++++++++++++---
  .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.h   |   9 +-
- 2 files changed, 322 insertions(+), 55 deletions(-)
+ 2 files changed, 327 insertions(+), 60 deletions(-)
 
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index 40cde1ba6e..6588abec6d 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -79,12 +79,15 @@ CDVDVideoCodecDRMPRIME::CDVDVideoCodecDR
+@@ -79,12 +79,15 @@ CDVDVideoCodecDRMPRIME::CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo)
    : CDVDVideoCodec(processInfo)
  {
    m_pFrame = av_frame_alloc();
@@ -26,7 +28,7 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
    avcodec_free_context(&m_pCodecContext);
  }
  
-@@ -341,8 +344,19 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDSt
+@@ -341,8 +344,19 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
    }
  
    UpdateProcessInfo(m_pCodecContext, m_pCodecContext->pix_fmt);
@@ -65,10 +67,16 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
  {
    pVideoPicture->iWidth = m_pFrame->width;
    pVideoPicture->iHeight = m_pFrame->height;
-@@ -559,13 +575,232 @@ void CDVDVideoCodecDRMPRIME::SetPictureP
+@@ -559,13 +575,238 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
                             ? DVD_NOPTS_VALUE
                             : static_cast<double>(pts) * DVD_TIME_BASE / AV_TIME_BASE;
    pVideoPicture->dts = DVD_NOPTS_VALUE;
++
++  if (pVideoPicture->videoBuffer)
++  {
++    pVideoPicture->videoBuffer->Release();
++    pVideoPicture->videoBuffer = nullptr;
++  }
 +
 +  if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
 +  {
@@ -132,9 +140,7 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
 +}
 +
 +bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
- {
--  if (!m_pFilterIn)
--    return VC_PICTURE;
++{
 +  int result;
 +
 +  if (m_pFilterGraph)
@@ -148,7 +154,7 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
 +    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - unable to alloc filter graph");
 +    return false;
 +  }
- 
++
 +  const AVFilter* srcFilter = avfilter_get_by_name("buffer");
 +  const AVFilter* outFilter = avfilter_get_by_name("buffersink");
 +  enum AVPixelFormat pix_fmts[] = { AV_PIX_FMT_DRM_PRIME, AV_PIX_FMT_NONE };
@@ -284,7 +290,9 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
 +}
 +
 +void CDVDVideoCodecDRMPRIME::FilterClose()
-+{
+ {
+-  if (!m_pFilterIn)
+-    return VC_PICTURE;
 +  if (m_pFilterGraph)
 +  {
 +    CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecDRMPRIME::FilterClose - Freeing filter graph");
@@ -295,13 +303,13 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
 +    m_pFilterOut = nullptr;
 +  }
 +}
-+
+ 
 +CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
 +{
    int ret = av_buffersrc_add_frame(m_pFilterIn, m_pFrame);
    if (ret < 0)
    {
-@@ -581,21 +816,14 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecD
+@@ -581,21 +822,14 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
  
  CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterOut()
  {
@@ -327,7 +335,7 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
    }
    else if (ret)
    {
-@@ -606,9 +834,27 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecD
+@@ -606,71 +840,97 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterOut()
      return VC_ERROR;
    }
  
@@ -355,9 +363,7 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
  CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideoPicture)
  {
    if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
-@@ -620,57 +866,71 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecD
-     pVideoPicture->videoBuffer = nullptr;
-   }
+     Drain();
  
 -  auto result = ProcessFilterOut();
 -  if (result != VC_PICTURE)
@@ -380,23 +386,29 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
 +      if (!SetPictureParams(pVideoPicture))
 +        return VC_ERROR;
 +      return VC_PICTURE;
-     }
++    }
 +    else if (ret != VC_BUFFER)
 +    {
 +      return ret;
-+    }
-+  }
- 
+     }
+-
 -    result = ProcessFilterIn();
 -    if (result != VC_PICTURE)
 -      return result;
+   }
+ 
+-  SetPictureParams(pVideoPicture);
+-
+-  if (pVideoPicture->videoBuffer)
 +  int ret = avcodec_receive_frame(m_pCodecContext, m_pFrame);
 +  if (ret == AVERROR(EAGAIN))
 +    return VC_BUFFER;
 +  else if (ret == AVERROR_EOF)
 +    return VC_EOF;
 +  else if (ret)
-+  {
+   {
+-    pVideoPicture->videoBuffer->Release();
+-    pVideoPicture->videoBuffer = nullptr;
 +    char err[AV_ERROR_MAX_STRING_SIZE] = {};
 +    av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
 +    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - receive frame failed: {} ({})",
@@ -404,11 +416,10 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
 +    return VC_ERROR;
    }
  
--  SetPictureParams(pVideoPicture);
+-  if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
 +  if (!m_processInfo.GetVideoInterlaced() && m_pFrame->interlaced_frame)
 +    m_processInfo.SetVideoInterlaced(true);
- 
--  if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
++
 +  std::string filterChain = GetFilterChain(m_pFrame->interlaced_frame);
 +  if (!filterChain.empty())
    {
@@ -465,6 +476,8 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
  
    return VC_PICTURE;
  }
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+index b5cacf1a3c..fab3431d40 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
 @@ -38,19 +38,26 @@ public:
@@ -495,3 +508,6 @@ Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
    AVFilterGraph* m_pFilterGraph = nullptr;
    AVFilterContext* m_pFilterIn = nullptr;
    AVFilterContext* m_pFilterOut = nullptr;
+-- 
+2.34.1
+

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0002-WIP-DRMPRIME-deinterlace-filter.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0002-WIP-DRMPRIME-deinterlace-filter.patch
@@ -1,7 +1,7 @@
 From 60c20b00749ddf3ffd8cbb7a3cd3778fb8af13fc Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Thu, 26 Dec 2019 11:01:51 +0100
-Subject: [PATCH 2/2] WIP: DRMPRIME deinterlace filter
+Subject: [PATCH 2/6] WIP: DRMPRIME deinterlace filter
 
 ---
  .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 378 +++++++++++++++---

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0003-DVDVideoCodecDRMPRIME-Avoid-exception-with-AV_PIX_FM.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0003-DVDVideoCodecDRMPRIME-Avoid-exception-with-AV_PIX_FM.patch
@@ -1,0 +1,26 @@
+From d4956bedd865a007585fbd59a4b938854b61b47f Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Fri, 27 Aug 2021 20:29:50 +0100
+Subject: [PATCH 3/6] DVDVideoCodecDRMPRIME: Avoid exception with
+ AV_PIX_FMT_NONE
+
+---
+ .../cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index 6588abec6d..0084fcc441 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+@@ -605,7 +605,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+   if (!pVideoPicture->videoBuffer)
+   {
+     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - videoBuffer:nullptr format:{}", __FUNCTION__,
+-              av_get_pix_fmt_name(static_cast<AVPixelFormat>(m_pFrame->format)));
++              m_pFrame->format == AV_PIX_FMT_NONE ? "AV_PIX_FMT_NONE" : av_get_pix_fmt_name(static_cast<AVPixelFormat>(m_pFrame->format)));
+     av_frame_unref(m_pFrame);
+     return false;
+   }
+-- 
+2.34.1
+

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0004-DVDVideoCodecDRMPRIME-Leave-deinterlace-filter-activ.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0004-DVDVideoCodecDRMPRIME-Leave-deinterlace-filter-activ.patch
@@ -1,0 +1,33 @@
+From b577b5358bc9e72550dbba9f12f27973639a8fca Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Fri, 17 Sep 2021 15:23:16 +0100
+Subject: [PATCH 4/6] DVDVideoCodecDRMPRIME: Leave deinterlace filter active on
+ a progressive frame
+
+Interlaced content often has strange mixtures of interlace and progressive frames (e.g. IIPPPPIIPPPP)
+and currently we can be creating and destroying the deinterlace filter graph almost every frame.
+
+If it's been created, then leave it active until end of file. The frames marked as progressive should
+be just copied by deinterlace filter
+---
+ .../VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp     | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index 0084fcc441..26efaabe02 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+@@ -855,6 +855,10 @@ std::string CDVDVideoCodecDRMPRIME::GetFilterChain(bool interlaced)
+   if (!m_processInfo.Supports(mInt))
+     mInt = m_processInfo.GetFallbackDeintMethod();
+ 
++  // avoid disabling deinterlace graph for occasional progressive frames - they will be copied by deinterlace
++  if (!m_filters.empty())
++    interlaced = true;
++
+   if (mInt != VS_INTERLACEMETHOD_NONE && interlaced && !m_deintFilterName.empty())
+     filterChain += m_deintFilterName;
+ 
+-- 
+2.34.1
+

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0005-SetVideoInterlaced-Set-and-unset-deinterlace-method-.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0005-SetVideoInterlaced-Set-and-unset-deinterlace-method-.patch
@@ -1,0 +1,41 @@
+From 622f31900b9c11dca44e40b36d12bff5997da953 Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Tue, 30 Nov 2021 16:05:06 +0000
+Subject: [PATCH 5/6] SetVideoInterlaced: Set and unset deinterlace method name
+ reported
+
+---
+ .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp          | 10 ++--------
+ 1 file changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index 26efaabe02..2ceb7ce02f 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+@@ -769,14 +769,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+     return true;
+   }
+ 
+-  if (filters.find("deinterlace") != std::string::npos)
+-  {
+-    m_processInfo.SetVideoDeintMethod(filters);
+-  }
+-  else
+-  {
+-    m_processInfo.SetVideoDeintMethod("none");
+-  }
++  m_processInfo.SetVideoDeintMethod(filters);
+ 
+   if (CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
+   {
+@@ -794,6 +787,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+ 
+ void CDVDVideoCodecDRMPRIME::FilterClose()
+ {
++  m_processInfo.SetVideoDeintMethod("none");
+   if (m_pFilterGraph)
+   {
+     CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecDRMPRIME::FilterClose - Freeing filter graph");
+-- 
+2.34.1
+

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0006-DVDVideoCodecDRMPRIME-Close-deinterlace-filter-on-er.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0006-DVDVideoCodecDRMPRIME-Close-deinterlace-filter-on-er.patch
@@ -1,0 +1,73 @@
+From be317b043f9308b76b15325fa670802bc969533a Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Wed, 24 Nov 2021 20:21:28 +0000
+Subject: [PATCH 6/6] DVDVideoCodecDRMPRIME: Close deinterlace filter on error
+
+Otherwise we crash later with an invalid m_pFilterGraph pointer
+---
+ .../VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp  | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index 2ceb7ce02f..20a5c24f53 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+@@ -685,6 +685,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+     CLog::Log(LOGERROR,
+               "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: src: {} ({})",
+               err, result);
++    FilterClose();
+     return false;
+   }
+ 
+@@ -692,6 +693,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+   if (!par)
+   {
+     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - unable to alloc buffersrc");
++    FilterClose();
+     return false;
+   }
+ 
+@@ -707,6 +709,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+     CLog::Log(LOGERROR,
+               "CDVDVideoCodecDRMPRIME::FilterOpen - av_buffersrc_parameters_set:  {} ({})",
+               err, result);
++    FilterClose();
+     return false;
+   }
+   av_freep(&par);
+@@ -720,6 +723,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+     CLog::Log(LOGERROR,
+               "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: out: {} ({})",
+               err, result);
++    FilterClose();
+     return false;
+   }
+ 
+@@ -728,6 +732,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+   if (result < 0)
+   {
+     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - failed settings pix formats");
++    FilterClose();
+     return false;
+   }
+ 
+@@ -751,6 +756,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+   if (result < 0)
+   {
+     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_parse");
++    FilterClose();
+     return false;
+   }
+ 
+@@ -760,6 +766,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+     av_strerror(result, err, AV_ERROR_MAX_STRING_SIZE);
+     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_config:  {} ({})",
+               err, result);
++    FilterClose();
+     return false;
+   }
+ 
+-- 
+2.34.1
+

--- a/projects/RPi/patches/kodi/kodi-001-deinterlace.patch
+++ b/projects/RPi/patches/kodi/kodi-001-deinterlace.patch
@@ -1,4 +1,4 @@
-From 312239e6fcd892b1c3e9dbb86d89a1b5079f445e Mon Sep 17 00:00:00 2001
+From d4956bedd865a007585fbd59a4b938854b61b47f Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 27 Aug 2021 20:29:50 +0100
 Subject: [PATCH 1/5] DVDVideoCodecDRMPRIME: Avoid exception with
@@ -9,10 +9,10 @@ Subject: [PATCH 1/5] DVDVideoCodecDRMPRIME: Avoid exception with
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index cb801defc2..7e970bd9a6 100644
+index 6588abec6d..0084fcc441 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -599,7 +599,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+@@ -605,7 +605,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
    if (!pVideoPicture->videoBuffer)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - videoBuffer:nullptr format:{}", __FUNCTION__,
@@ -22,10 +22,10 @@ index cb801defc2..7e970bd9a6 100644
      return false;
    }
 -- 
-2.30.2
+2.34.1
 
 
-From a57ab9736249fff9971ca194a50e8aee5f163883 Mon Sep 17 00:00:00 2001
+From cd6de7970971ee8cafcec4f9c7d5d33268674eba Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 11 Sep 2021 14:03:05 +0100
 Subject: [PATCH 2/5] CDVDVideoCodecDRMPRIME: Also support YUV420 buffers
@@ -38,19 +38,19 @@ Need to call SetDimensions earlier and store the drm descriptor in expected plac
  1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 7e970bd9a6..78d61e1aa2 100644
+index 0084fcc441..9b802d252c 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -576,7 +576,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
-                            : static_cast<double>(pts) * DVD_TIME_BASE / AV_TIME_BASE;
-   pVideoPicture->dts = DVD_NOPTS_VALUE;
+@@ -582,7 +582,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+     pVideoPicture->videoBuffer = nullptr;
+   }
  
 -  if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
 +  if (m_pFrame->format == AV_PIX_FMT_DRM_PRIME)
    {
      CVideoBufferDRMPRIMEFFmpeg* buffer =
          dynamic_cast<CVideoBufferDRMPRIMEFFmpeg*>(m_videoBufferPool->Get());
-@@ -654,7 +654,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -660,7 +660,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
  
    const AVFilter* srcFilter = avfilter_get_by_name("buffer");
    const AVFilter* outFilter = avfilter_get_by_name("buffersink");
@@ -59,7 +59,7 @@ index 7e970bd9a6..78d61e1aa2 100644
  
    std::string args = StringUtils::Format("video_size={}x{}:pix_fmt={}:time_base={}/{}:"
                                           "pixel_aspect={}/{}",
-@@ -801,6 +801,16 @@ void CDVDVideoCodecDRMPRIME::FilterClose()
+@@ -807,6 +807,16 @@ void CDVDVideoCodecDRMPRIME::FilterClose()
  
  CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
  {
@@ -77,10 +77,10 @@ index 7e970bd9a6..78d61e1aa2 100644
    if (ret < 0)
    {
 -- 
-2.30.2
+2.34.1
 
 
-From 6981e216d4ef5c3ca16fe00edeef0dbcb4ef8bd7 Mon Sep 17 00:00:00 2001
+From 885e6343012884c51a49078585a827fbf84dbfe6 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 17 Sep 2021 15:23:16 +0100
 Subject: [PATCH 3/5] DVDVideoCodecDRMPRIME: Leave deinterlace filter active on
@@ -96,10 +96,10 @@ be just copied by deinterlace filter
  1 file changed, 4 insertions(+)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 78d61e1aa2..dde55de7d4 100644
+index 9b802d252c..7775a489a4 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -859,6 +859,10 @@ std::string CDVDVideoCodecDRMPRIME::GetFilterChain(bool interlaced)
+@@ -865,6 +865,10 @@ std::string CDVDVideoCodecDRMPRIME::GetFilterChain(bool interlaced)
    if (!m_processInfo.Supports(mInt))
      mInt = m_processInfo.GetFallbackDeintMethod();
  
@@ -111,10 +111,10 @@ index 78d61e1aa2..dde55de7d4 100644
      filterChain += m_deintFilterName;
  
 -- 
-2.30.2
+2.34.1
 
 
-From f86e4d66f8f49e7ca08679eb1b3de6742f92a1af Mon Sep 17 00:00:00 2001
+From dd30f4f2fb5f33006a5f147bf0f6e2d08c44a3ea Mon Sep 17 00:00:00 2001
 From: Dom Cobley <popcornmix@gmail.com>
 Date: Tue, 30 Nov 2021 16:05:06 +0000
 Subject: [PATCH 4/5] SetVideoInterlaced: Set and unset deinterlace method name
@@ -125,10 +125,10 @@ Subject: [PATCH 4/5] SetVideoInterlaced: Set and unset deinterlace method name
  1 file changed, 2 insertions(+), 8 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index dde55de7d4..2d33a73492 100644
+index 7775a489a4..4c176e43d9 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -763,14 +763,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -769,14 +769,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      return true;
    }
  
@@ -144,7 +144,7 @@ index dde55de7d4..2d33a73492 100644
  
    if (CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
    {
-@@ -788,6 +781,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -794,6 +787,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
  
  void CDVDVideoCodecDRMPRIME::FilterClose()
  {
@@ -153,10 +153,10 @@ index dde55de7d4..2d33a73492 100644
    {
      CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecDRMPRIME::FilterClose - Freeing filter graph");
 -- 
-2.30.2
+2.34.1
 
 
-From c9bd447122ae81919339e2a9583d7798db571b48 Mon Sep 17 00:00:00 2001
+From e10291d897190810bf52dd144e85578059bf1548 Mon Sep 17 00:00:00 2001
 From: Dom Cobley <popcornmix@gmail.com>
 Date: Wed, 24 Nov 2021 20:21:28 +0000
 Subject: [PATCH 5/5] DVDVideoCodecDRMPRIME: Close deinterlace filter on error
@@ -167,10 +167,10 @@ Otherwise we crash later with an invalid m_pFilterGraph pointer
  1 file changed, 7 insertions(+)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 2d33a73492..998ae5f05c 100644
+index 4c176e43d9..a36107c515 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -679,6 +679,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -685,6 +685,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: src: {} ({})",
                err, result);
@@ -178,7 +178,7 @@ index 2d33a73492..998ae5f05c 100644
      return false;
    }
  
-@@ -686,6 +687,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -692,6 +693,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (!par)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - unable to alloc buffersrc");
@@ -186,7 +186,7 @@ index 2d33a73492..998ae5f05c 100644
      return false;
    }
  
-@@ -701,6 +703,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -707,6 +709,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - av_buffersrc_parameters_set:  {} ({})",
                err, result);
@@ -194,7 +194,7 @@ index 2d33a73492..998ae5f05c 100644
      return false;
    }
    av_freep(&par);
-@@ -714,6 +717,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -720,6 +723,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: out: {} ({})",
                err, result);
@@ -202,7 +202,7 @@ index 2d33a73492..998ae5f05c 100644
      return false;
    }
  
-@@ -722,6 +726,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -728,6 +732,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (result < 0)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - failed settings pix formats");
@@ -210,7 +210,7 @@ index 2d33a73492..998ae5f05c 100644
      return false;
    }
  
-@@ -745,6 +750,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -751,6 +756,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (result < 0)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_parse");
@@ -218,7 +218,7 @@ index 2d33a73492..998ae5f05c 100644
      return false;
    }
  
-@@ -754,6 +760,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -760,6 +766,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      av_strerror(result, err, AV_ERROR_MAX_STRING_SIZE);
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_config:  {} ({})",
                err, result);
@@ -227,5 +227,5 @@ index 2d33a73492..998ae5f05c 100644
    }
  
 -- 
-2.30.2
+2.34.1
 

--- a/projects/RPi/patches/kodi/kodi-001-deinterlace.patch
+++ b/projects/RPi/patches/kodi/kodi-001-deinterlace.patch
@@ -1,34 +1,7 @@
-From d4956bedd865a007585fbd59a4b938854b61b47f Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Fri, 27 Aug 2021 20:29:50 +0100
-Subject: [PATCH 1/5] DVDVideoCodecDRMPRIME: Avoid exception with
- AV_PIX_FMT_NONE
-
----
- .../cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 6588abec6d..0084fcc441 100644
---- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -605,7 +605,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
-   if (!pVideoPicture->videoBuffer)
-   {
-     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - videoBuffer:nullptr format:{}", __FUNCTION__,
--              av_get_pix_fmt_name(static_cast<AVPixelFormat>(m_pFrame->format)));
-+              m_pFrame->format == AV_PIX_FMT_NONE ? "AV_PIX_FMT_NONE" : av_get_pix_fmt_name(static_cast<AVPixelFormat>(m_pFrame->format)));
-     av_frame_unref(m_pFrame);
-     return false;
-   }
--- 
-2.34.1
-
-
-From cd6de7970971ee8cafcec4f9c7d5d33268674eba Mon Sep 17 00:00:00 2001
+From 32abc327c2d913e3968a8ef91e41ffcc1a091116 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Sat, 11 Sep 2021 14:03:05 +0100
-Subject: [PATCH 2/5] CDVDVideoCodecDRMPRIME: Also support YUV420 buffers
+Subject: [PATCH] CDVDVideoCodecDRMPRIME: Also support YUV420 buffers
 
 CDVDVideoCodecDRMPRIME: Add support for deinterlace of sw decoded buffers
 
@@ -38,7 +11,7 @@ Need to call SetDimensions earlier and store the drm descriptor in expected plac
  1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 0084fcc441..9b802d252c 100644
+index 20a5c24f53..a36107c515 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 @@ -582,7 +582,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
@@ -59,7 +32,7 @@ index 0084fcc441..9b802d252c 100644
  
    std::string args = StringUtils::Format("video_size={}x{}:pix_fmt={}:time_base={}/{}:"
                                           "pixel_aspect={}/{}",
-@@ -807,6 +807,16 @@ void CDVDVideoCodecDRMPRIME::FilterClose()
+@@ -808,6 +808,16 @@ void CDVDVideoCodecDRMPRIME::FilterClose()
  
  CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
  {
@@ -76,156 +49,6 @@ index 0084fcc441..9b802d252c 100644
    int ret = av_buffersrc_add_frame(m_pFilterIn, m_pFrame);
    if (ret < 0)
    {
--- 
-2.34.1
-
-
-From 885e6343012884c51a49078585a827fbf84dbfe6 Mon Sep 17 00:00:00 2001
-From: popcornmix <popcornmix@gmail.com>
-Date: Fri, 17 Sep 2021 15:23:16 +0100
-Subject: [PATCH 3/5] DVDVideoCodecDRMPRIME: Leave deinterlace filter active on
- a progressive frame
-
-Interlaced content often has strange mixtures of interlace and progressive frames (e.g. IIPPPPIIPPPP)
-and currently we can be creating and destroying the deinterlace filter graph almost every frame.
-
-If it's been created, then leave it active until end of file. The frames marked as progressive should
-be just copied by deinterlace filter
----
- .../VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp     | 4 ++++
- 1 file changed, 4 insertions(+)
-
-diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 9b802d252c..7775a489a4 100644
---- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -865,6 +865,10 @@ std::string CDVDVideoCodecDRMPRIME::GetFilterChain(bool interlaced)
-   if (!m_processInfo.Supports(mInt))
-     mInt = m_processInfo.GetFallbackDeintMethod();
- 
-+  // avoid disabling deinterlace graph for occasional progressive frames - they will be copied by deinterlace
-+  if (!m_filters.empty())
-+    interlaced = true;
-+
-   if (mInt != VS_INTERLACEMETHOD_NONE && interlaced && !m_deintFilterName.empty())
-     filterChain += m_deintFilterName;
- 
--- 
-2.34.1
-
-
-From dd30f4f2fb5f33006a5f147bf0f6e2d08c44a3ea Mon Sep 17 00:00:00 2001
-From: Dom Cobley <popcornmix@gmail.com>
-Date: Tue, 30 Nov 2021 16:05:06 +0000
-Subject: [PATCH 4/5] SetVideoInterlaced: Set and unset deinterlace method name
- reported
-
----
- .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp          | 10 ++--------
- 1 file changed, 2 insertions(+), 8 deletions(-)
-
-diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 7775a489a4..4c176e43d9 100644
---- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -769,14 +769,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
-     return true;
-   }
- 
--  if (filters.find("deinterlace") != std::string::npos)
--  {
--    m_processInfo.SetVideoDeintMethod(filters);
--  }
--  else
--  {
--    m_processInfo.SetVideoDeintMethod("none");
--  }
-+  m_processInfo.SetVideoDeintMethod(filters);
- 
-   if (CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
-   {
-@@ -794,6 +787,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
- 
- void CDVDVideoCodecDRMPRIME::FilterClose()
- {
-+  m_processInfo.SetVideoDeintMethod("none");
-   if (m_pFilterGraph)
-   {
-     CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecDRMPRIME::FilterClose - Freeing filter graph");
--- 
-2.34.1
-
-
-From e10291d897190810bf52dd144e85578059bf1548 Mon Sep 17 00:00:00 2001
-From: Dom Cobley <popcornmix@gmail.com>
-Date: Wed, 24 Nov 2021 20:21:28 +0000
-Subject: [PATCH 5/5] DVDVideoCodecDRMPRIME: Close deinterlace filter on error
-
-Otherwise we crash later with an invalid m_pFilterGraph pointer
----
- .../VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp  | 7 +++++++
- 1 file changed, 7 insertions(+)
-
-diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 4c176e43d9..a36107c515 100644
---- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -685,6 +685,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
-     CLog::Log(LOGERROR,
-               "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: src: {} ({})",
-               err, result);
-+    FilterClose();
-     return false;
-   }
- 
-@@ -692,6 +693,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
-   if (!par)
-   {
-     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - unable to alloc buffersrc");
-+    FilterClose();
-     return false;
-   }
- 
-@@ -707,6 +709,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
-     CLog::Log(LOGERROR,
-               "CDVDVideoCodecDRMPRIME::FilterOpen - av_buffersrc_parameters_set:  {} ({})",
-               err, result);
-+    FilterClose();
-     return false;
-   }
-   av_freep(&par);
-@@ -720,6 +723,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
-     CLog::Log(LOGERROR,
-               "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: out: {} ({})",
-               err, result);
-+    FilterClose();
-     return false;
-   }
- 
-@@ -728,6 +732,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
-   if (result < 0)
-   {
-     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - failed settings pix formats");
-+    FilterClose();
-     return false;
-   }
- 
-@@ -751,6 +756,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
-   if (result < 0)
-   {
-     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_parse");
-+    FilterClose();
-     return false;
-   }
- 
-@@ -760,6 +766,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
-     av_strerror(result, err, AV_ERROR_MAX_STRING_SIZE);
-     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_config:  {} ({})",
-               err, result);
-+    FilterClose();
-     return false;
-   }
- 
 -- 
 2.34.1
 


### PR DESCRIPTION
The filter/deinterlaced patches were rebased by @popcornmix 

Runtime test on RPi4 was fine, DVD menus and deinterlacing still works.

@knaerzche @jernejsk please test on AW/RK