### PR TITLE
Migrate to fuse3

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/sshfs/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/sshfs/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sshfs"
-PKG_VERSION="2.10"
-PKG_SHA256="70845dde2d70606aa207db5edfe878e266f9c193f1956dd10ba1b7e9a3c8d101"
+PKG_VERSION="3.7.3"
+PKG_SHA256="5218ce7bdd2ce0a34137a0d7798e0f6d09f0e6d21b1e98ee730a18b0699c2e99"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libfuse/sshfs"
-PKG_URL="https://github.com/libfuse/sshfs/releases/download/sshfs-${PKG_VERSION}/sshfs-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain fuse glib"
+PKG_URL="https://github.com/libfuse/sshfs/releases/download/sshfs-${PKG_VERSION}/sshfs-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain fuse3 glib"
 PKG_LONGDESC="A filesystem client based on the SSH File Transfer Protocol."
 PKG_BUILD_FLAGS="-sysroot"

--- a/packages/addons/tools/network-tools/changelog.txt
+++ b/packages/addons/tools/network-tools/changelog.txt
@@ -1,3 +1,7 @@
+118
+- sshfs: update to 3.7.3
+- include fuse and fuse3
+
 117
 - iperf: update to 3.12
 - nmap: update to 7.93

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="117"
+PKG_REV="118"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -35,9 +35,19 @@ PKG_DEPENDS_TARGET="toolchain \
                     wireless_tools"
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
     # bwm-ng
     cp -P $(get_install_dir bwm-ng)/usr/bin/bwm-ng ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+
+    # fuse
+    cp -P $(get_install_dir fuse)/usr/bin/{fusermount,ulockmgr_server} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P $(get_install_dir fuse)/usr/sbin/mount.fuse ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P $(get_install_dir fuse)/usr/lib/{libfuse.so*,libulockmgr.so*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+
+    # fuse3
+    cp -P $(get_install_dir fuse3)/usr/bin/fusermount3 ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P $(get_install_dir fuse3)/usr/sbin/mount.fuse3  ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P $(get_install_dir fuse3)/usr/lib/libfuse3.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
 
     # iftop
     cp -P $(get_install_dir iftop)/usr/sbin/iftop ${ADDON_BUILD}/${PKG_ADDON_ID}/bin

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,6 @@
+133
+- include fuse
+
 132
 - vim: update to 9.0.0453
 

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="132"
+PKG_REV="133"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -91,6 +91,11 @@ addon() {
     # file
     cp -P $(get_install_dir file)/usr/bin/file ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir file)/usr/share/misc/magic.mgc ${ADDON_BUILD}/${PKG_ADDON_ID}/data
+
+    # fuse
+    cp -P $(get_install_dir fuse)/usr/bin/{fusermount,ulockmgr_server} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P $(get_install_dir fuse)/usr/sbin/mount.fuse ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P $(get_install_dir fuse)/usr/lib/{libfuse.so*,libulockmgr.so*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
 
     # getscancodes
     cp -P $(get_install_dir getscancodes)/usr/bin/getscancodes ${ADDON_BUILD}/${PKG_ADDON_ID}/bin

--- a/packages/sysutils/fuse3/package.mk
+++ b/packages/sysutils/fuse3/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="fuse3"
+PKG_VERSION="3.11.0"
+PKG_SHA256="8982c4c521daf3974dda8a5d55d575c988da13a571970f00aea149eb54fdf14c"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/libfuse/libfuse/"
+PKG_URL="https://github.com/libfuse/libfuse/releases/download/fuse-${PKG_VERSION}/fuse-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="FUSE is an interface for userspace programs to export a filesystem to the Linux kernel."
+
+PKG_MESON_OPTS_TARGET="-Ddisable-mtab=false \
+                       -Dutils=true \
+                       -Dexamples=false \
+                       -Duseroot=false \
+                       -Dtests=false"
+
+post_makeinstall_target() {
+  rm -rf ${INSTALL}/etc
+  rm -rf ${INSTALL}/usr/lib/udev
+}

--- a/packages/sysutils/fuse3/package.mk
+++ b/packages/sysutils/fuse3/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="8982c4c521daf3974dda8a5d55d575c988da13a571970f00aea149eb54fdf14c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libfuse/libfuse/"
 PKG_URL="https://github.com/libfuse/libfuse/releases/download/fuse-${PKG_VERSION}/fuse-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain systemd"
 PKG_LONGDESC="FUSE is an interface for userspace programs to export a filesystem to the Linux kernel."
 
 PKG_MESON_OPTS_TARGET="-Ddisable-mtab=false \

--- a/packages/sysutils/open-vm-tools/package.mk
+++ b/packages/sysutils/open-vm-tools/package.mk
@@ -10,7 +10,7 @@ PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/vmware/open-vm-tools"
 PKG_URL="https://github.com/vmware/open-vm-tools/archive/stable-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain fuse glib:host glib libdnet libtirpc"
+PKG_DEPENDS_TARGET="toolchain fuse3 glib:host glib libdnet libtirpc"
 PKG_LONGDESC="open-vm-tools: open source implementation of VMware Tools"
 PKG_TOOLCHAIN="autotools"
 
@@ -26,6 +26,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-docs \
                            --without-xerces \
                            --without-icu \
                            --without-kernel-modules \
+                           --with-fuse=fuse3 \
                            --with-udev-rules-dir=/usr/lib/udev/rules.d/ \
                            --with-sysroot=${SYSROOT_PREFIX}"
 


### PR DESCRIPTION
Fixes #5996

fuse3 is only supported by `open-vm-tools` and `sshfs` in the addons made available to LibreELEC. Remaining packages using fuse (fuse2) do not have planned fuse3 upgrades.

fuse was dropped from the LE11 base because ntfs3g (which used fuse2) was replaced by the kernel ntfs3. Thus fuse was no longer included; unless open-vm-tools was included. So the libfuse was only included on x86_64.

In addition to migrating to fuse3 (where possible); the fuse libraries have been included in the `system-tools` and `network-tools` addons. 

- fuse3: initial package
- open-vm-tools: migrate to fuse3 
- sshfs: update to 3.7.3 and fuse3
- network-tools: add fuse and fuse3 to addon and sshfs to 3.7.3 and addon to (116)
- system-tools: add fuse to addon and addon to (132)

The libfuse3 libraries are included in the base x86_64 build - because open-vm-tools includes them.

```
nuc11:~ # ls -l /usr/lib/libfuse3.so*
lrwxrwxrwx    1 root     root            13 Jul 18 21:02 /usr/lib/libfuse3.so -> libfuse3.so.3
lrwxrwxrwx    1 root     root            18 Jul 18 21:02 /usr/lib/libfuse3.so.3 -> libfuse3.so.3.11.0
-rwxr-xr-x    1 root     root        245808 Jul 18 21:02 /usr/lib/libfuse3.so.3.11.0
```

sshfs 3.7.3 could be back ported along with fuse3 as LE10:network-tools.