### PR TITLE
libfmt: update to 9.0.0

### DIFF
--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libfmt"
-PKG_VERSION="8.1.1"
-PKG_SHA256="3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346"
+PKG_VERSION="9.0.0"
+PKG_SHA256="9a1e0e9e843a356d65c7604e2c8bf9402b50fe294c355de0095ebd42fb9bd2c5"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/fmtlib/fmt"
 PKG_URL="https://github.com/fmtlib/fmt/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
changelog:
- https://github.com/fmtlib/fmt/blob/master/ChangeLog.rst

supported since:
- #6717 
- https://github.com/xbmc/xbmc/pull/21649