### PR TITLE
samba: update to 4.16.4

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.16.3"
-PKG_SHA256="7a6565d7c0a98eac7a5a283fa94d9266dd39ea62f262ccdc5a634a580d549c58"
+PKG_VERSION="4.16.4"
+PKG_SHA256="9532f848fb125a17e4e5d98e1ae8b42f210ed4433835e815b97c5dde6dc4702f"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
ann:
- https://lists.samba.org/archive/samba/2022-July/241442.html

release notes:
- https://www.samba.org/samba/history/samba-4.16.4.html