### PR TITLE
Intel Graphics updates

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.1.6"
-PKG_SHA256="d60d9d2a8740f95a244b6e2113265ba6e6c915eaada6d644ecc4c8d436344a6e"
+PKG_VERSION="22.1.7"
+PKG_SHA256="08a378671971a1777ca60f87e39fd7d7cbba94e485a1f5f64fe4840ff9d2ac2d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.5.0"
-PKG_SHA256="7cfa02442711f4ffa7fc1bd6effda49446a005422a3db4083bbc1a621815f672"
+PKG_VERSION="22.5.1"
+PKG_SHA256="17905258374dafe2051073fee5722527c6b756c111b2962af051b37d1fc0df56"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
- [gmmlib: update to 22.1.7](https://github.com/LibreELEC/LibreELEC.tv/commit/c00c2e234b52e1f1132a6972eda23825cac211c4)
- [media-driver: update to 22.5.1](https://github.com/LibreELEC/LibreELEC.tv/commit/0630f7997b355e8ba50d8fa8636a5e1141ecefec)

```
=== tested on ===
Generic.x86_64-devel-20220729070645-1400f6c
Linux nuc11 5.19.0-rc8 #1 SMP Wed Jul 27 10:54:42 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:80f18db9500c0738d3522f4efdf789aa012e9930). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-07-27 by GCC 12.1.0 for Linux x86 64-bit version 5.19.0 (332544)
Running on LibreELEC (heitbaum): devel-20220729070645-1400f6c 11.0, kernel: Linux x86 64-bit version 5.19.0-rc8
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0046.2022.0608.1909 06/08/2022
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.1.4
libva info: VA-API version 1.15.0
vainfo: VA-API version: 1.15 (libva 2.15.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.5.1 (89fde27425)
```