### PR TITLE
sqlite: update to 3.39.2

### DIFF
--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.39.1"
+PKG_VERSION="3.39.2"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="87c8e7a7fa0c68ab28e208ba49f3a22a56000dbf53a6f90206e2bc5843931cc4"
+PKG_SHA256="852be8a6183a17ba47cee0bbff7400b7aa5affd283bf3beefc34fcd088a239de"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2022/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"


### PR DESCRIPTION
### Release notes:
- https://www.sqlite.org/releaselog/3_39_2.html

### SQLite Release 3.39.2 On 2022-07-21

### Changes in version 3.39.0 (2022-06-25):

- Add (long overdue) support for [RIGHT and FULL OUTER JOIN](https://www.sqlite.org/lang_select.html#rjoin).
- Add new binary comparison operators [IS NOT DISTINCT FROM](https://www.sqlite.org/lang_expr.html#isdf) and [IS DISTINCT FROM](https://www.sqlite.org/lang_expr.html#isdf) that are equivalent to IS and IS NOT, respective, for compatibility with PostgreSQL and SQL standards.
- Add a new return code (value "3") from the [sqlite3_vtab_distinct()](https://www.sqlite.org/c3ref/vtab_distinct.html) interface that indicates a query that has both DISTINCT and ORDER BY clauses.
- Added the [sqlite3_db_name()](https://www.sqlite.org/c3ref/db_name.html) interface.
- The unix os interface resolves all symbolic links in database filenames to create a canonical name for the database before the file is opened. If the [SQLITE_OPEN_NOFOLLOW](https://www.sqlite.org/c3ref/c_open_autoproxy.html) flag is used with [sqlite3_open_v2()](https://www.sqlite.org/c3ref/open.html) or similar, the open will fail if any element of the path is a symbolic link.
- Defer materializing views until the materialization is actually needed, thus avoiding unnecessary work if the materialization turns out to never be used.
- The [HAVING clause](https://www.sqlite.org/lang_select.html#resultset) of a [SELECT statement](https://www.sqlite.org/lang_select.html) is now allowed on any aggregate query, even queries that do not have a [GROUP BY clause](https://www.sqlite.org/lang_select.html#resultset).
- Many [microoptimizations](https://www.sqlite.org/cpu.html#microopt) collectively reduce CPU cycles by about 2.3%.
