### PR TITLE
packages/security updates

### DIFF
--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.7.6"
-PKG_SHA256="77065719a345bfb18faa250134be4c53bef70c1bd61f6c0c23ceb8b44f0262ff"
+PKG_VERSION="3.7.7"
+PKG_SHA256="be9143d0d58eab64dba9b77114aaafac529b6c0d7e81de6bdf1c9b59027d2106"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/security/nettle/package.mk
+++ b/packages/security/nettle/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nettle"
-PKG_VERSION="3.8"
-PKG_SHA256="7576c68481c198f644b08c160d1a4850ba9449e308069455b5213319f234e8e6"
+PKG_VERSION="3.8.1"
+PKG_SHA256="364f3e2b77cd7dcde83fd7c45219c834e54b0c75e428b6f894a23d12dd41cbfe"
 PKG_LICENSE="GPL2"
 PKG_SITE="http://www.lysator.liu.se/~nisse/nettle"
 PKG_URL="https://ftp.gnu.org/gnu/nettle/nettle-${PKG_VERSION}.tar.gz"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.80"
-PKG_SHA256="ab280c0231ab7b05c5a630dff36afdc388035ad2011f6535056c83c0f6855ce2"
+PKG_VERSION="3.81"
+PKG_SHA256="12f9678a3000f54f16240bb20c76cb71dc098b2942661ac94237e07fa47ca443"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
- [nss: update to 3.81](https://github.com/LibreELEC/LibreELEC.tv/commit/6dbd9f42733418e1b80e270a54ed7c327d9898b6)
  - https://groups.google.com/a/mozilla.org/g/dev-tech-crypto/c/jYrL4b47r3A
- [nettle: update to 3.8.1](https://github.com/LibreELEC/LibreELEC.tv/commit/e0c3023d184bda61584ba6744b0ae446f394f96f)
  - https://lists.gnu.org/archive/html/info-gnu/2022-07/msg00010.html
- [gnutls: update to 3.7.7](https://github.com/LibreELEC/LibreELEC.tv/commit/a43d3dc77a57531fde00747d31631c205ad5cd94)
  - https://lists.gnupg.org/pipermail/gnutls-help/2022-July/004746.html