### PR TITLE
generic: enable scsi virtio support

### DIFF
--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1842,7 +1842,7 @@ CONFIG_MEGARAID_SAS=y
 # CONFIG_SCSI_DEBUG is not set
 # CONFIG_SCSI_PMCRAID is not set
 # CONFIG_SCSI_PM8001 is not set
-# CONFIG_SCSI_VIRTIO is not set
+CONFIG_SCSI_VIRTIO=y
 # CONFIG_SCSI_DH is not set
 # end of SCSI device support
 


### PR DESCRIPTION
required in order to be able to detect passthrough scsi devices such as hdds or cdrom in the vm which run Libreelec

Signed-off-by: Dagg Stompler <daggs@gmx.com>