### PR TITLE
brcmfmac_sdio-firmware-rpi: update to b4fa915

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="ea9963f3f77b4bb6cd280577eb115152bdd67e8d"
-PKG_SHA256="e51b717c2a60ca29fcdd8e04e07c00996226cb48fa56a8ad1934b5f4ddee2e3d"
+PKG_VERSION="b4fa91541cd713c721fadf0720e2655db42cc179"
+PKG_SHA256="50a834871457fe2c34c4da29e189a00801552bc90a8039a3e87378629a0dbc4c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"
 PKG_URL="https://github.com/LibreELEC/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Sync with RPi-Distro repo

- Updated 43436P firmware for Zero 2 W
  The shipping firmware for the SYN43436P does not support 4-way
  handshake offloading. This new firmware (version string
  "Version: 9.88.4.77 CRC: 143f9f15 Date: Thu 2022-03-31 17:25:16 CST
  Ucode Ver: 1043.20743 FWID: 01-3b307371") fixes that.

- Updated SYN43436S firmware
  The embedded clm_blob in the previous SYN43436S firmware did not offer
  any channels when the country code was set to KR (Korea). This firmware
  fixes that.

- Braktooth fix for CYW43455
  This updated Bluetooth firmware contains Braktooth fixes for
  CYW43455, addressing the following vulnerabilities:
  https://github.com/advisories/GHSA-7j4h-6cq9-gmjv https://github.com/advisories/GHSA-jg54-6p86-rp5q https://github.com/advisories/GHSA-m739-9w4c-mx4g https://github.com/advisories/GHSA-6539-6fh5-h34x
  Original firmware name: BCM4345C0_003.001.025.0187.0370.hcd