### PR TITLE
Vulkan update to 1.3.223

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.222"
-PKG_SHA256="e4521bd92f704d0dd2586d6d164857667e0eee04db7e19643a1a3627d9153ea7"
+PKG_VERSION="1.3.223"
+PKG_SHA256="da6b5604e6f5be48c97fbb122fd7ffdde97e6f1442c5ddbb854d50c3dda962fc"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.222"
-PKG_SHA256="56c79dfdc22eab8d8339fa01fe5aebc00d5ba2a1e793ae3c200c9fabbabd7e61"
+PKG_VERSION="1.3.223"
+PKG_SHA256="21fe0e38e0c2343046345c6323d51a9300ba4a522b783221a8d7f873b2337868"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.222"
-PKG_SHA256="8289e5ce0a31d68661d4d8094009d31ae9a906779996f24903a1f53ed57d837c"
+PKG_VERSION="1.3.223"
+PKG_SHA256="6a468448e370a687285750925de760cf5afe9ee678339adfecf282bd9274f74c"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Vulkan update to 1.3.223
- https://github.com/KhronosGroup/Vulkan-Docs/commit/9ecfc67442754c9e4c4fecf5e61c48483608a074

- vulkan-headers: update to 1.3.223
- vulkan-loader: update to 1.3.223
- vulkan-tools: update to 1.3.223