### PR TITLE
ffmpeg: update v4l2-request patch

### DIFF
--- a/packages/multimedia/ffmpeg/patches/v4l2-request/ffmpeg-001-v4l2-request.patch
+++ b/packages/multimedia/ffmpeg/patches/v4l2-request/ffmpeg-001-v4l2-request.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  2 files changed, 18 insertions(+)
 
 diff --git a/libavutil/buffer.c b/libavutil/buffer.c
-index 858633e8c73..41555d99825 100644
+index 858633e8c7..41555d9982 100644
 --- a/libavutil/buffer.c
 +++ b/libavutil/buffer.c
 @@ -305,6 +305,19 @@ static void buffer_pool_free(AVBufferPool *pool)
@@ -36,7 +36,7 @@ index 858633e8c73..41555d99825 100644
  {
      AVBufferPool *pool;
 diff --git a/libavutil/buffer.h b/libavutil/buffer.h
-index 241a80ed670..f41363faf1d 100644
+index 241a80ed67..f41363faf1 100644
 --- a/libavutil/buffer.h
 +++ b/libavutil/buffer.h
 @@ -315,6 +315,11 @@ AVBufferPool *av_buffer_pool_init2(size_t size, void *opaque,
@@ -69,7 +69,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  create mode 100644 libavcodec/v4l2_request.h
 
 diff --git a/configure b/configure
-index d7a3f507e83..f2e203d1346 100755
+index d7a3f507e8..f2e203d134 100755
 --- a/configure
 +++ b/configure
 @@ -279,6 +279,7 @@ External library support:
@@ -141,7 +141,7 @@ index d7a3f507e83..f2e203d1346 100755
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
  
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 33a280cf695..90dfffcb200 100644
+index 33a280cf69..90dfffcb20 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
 @@ -155,6 +155,7 @@ OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
@@ -153,7 +153,7 @@ index 33a280cf695..90dfffcb200 100644
  OBJS-$(CONFIG_WMV2DSP)                 += wmv2dsp.o
  
 diff --git a/libavcodec/hwconfig.h b/libavcodec/hwconfig.h
-index f421dc909f4..ee78d8ab8e8 100644
+index f421dc909f..ee78d8ab8e 100644
 --- a/libavcodec/hwconfig.h
 +++ b/libavcodec/hwconfig.h
 @@ -80,6 +80,8 @@ typedef struct AVCodecHWConfigInternal {
@@ -167,7 +167,7 @@ index f421dc909f4..ee78d8ab8e8 100644
      &(const AVCodecHWConfigInternal) { \
 diff --git a/libavcodec/v4l2_request.c b/libavcodec/v4l2_request.c
 new file mode 100644
-index 00000000000..5234b5049b0
+index 0000000000..5234b5049b
 --- /dev/null
 +++ b/libavcodec/v4l2_request.c
 @@ -0,0 +1,984 @@
@@ -1157,7 +1157,7 @@ index 00000000000..5234b5049b0
 +}
 diff --git a/libavcodec/v4l2_request.h b/libavcodec/v4l2_request.h
 new file mode 100644
-index 00000000000..58d2aa70af8
+index 0000000000..58d2aa70af
 --- /dev/null
 +++ b/libavcodec/v4l2_request.h
 @@ -0,0 +1,77 @@
@@ -1254,7 +1254,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/h264_slice.c b/libavcodec/h264_slice.c
-index 2d0605c7f4f..c3a7338a704 100644
+index 2d0605c7f4..c3a7338a70 100644
 --- a/libavcodec/h264_slice.c
 +++ b/libavcodec/h264_slice.c
 @@ -1830,7 +1830,7 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
@@ -1267,7 +1267,7 @@ index 2d0605c7f4f..c3a7338a704 100644
      if (sps->poc_type == 0) {
          sl->poc_lsb = get_bits(&sl->gb, sps->log2_max_poc_lsb);
 diff --git a/libavcodec/h264dec.h b/libavcodec/h264dec.h
-index b7b19ba4f16..0698ab95ba5 100644
+index b7b19ba4f1..0698ab95ba 100644
 --- a/libavcodec/h264dec.h
 +++ b/libavcodec/h264dec.h
 @@ -336,6 +336,7 @@ typedef struct H264SliceContext {
@@ -1295,7 +1295,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  2 files changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/h264_slice.c b/libavcodec/h264_slice.c
-index c3a7338a704..c28b58cd5d9 100644
+index c3a7338a70..c28b58cd5d 100644
 --- a/libavcodec/h264_slice.c
 +++ b/libavcodec/h264_slice.c
 @@ -1748,7 +1748,7 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
@@ -1336,7 +1336,7 @@ index c3a7338a704..c28b58cd5d9 100644
  
      if (sl->slice_type_nos != AV_PICTURE_TYPE_I && pps->cabac) {
 diff --git a/libavcodec/h264dec.h b/libavcodec/h264dec.h
-index 0698ab95ba5..2b39e82c3b0 100644
+index 0698ab95ba..2b39e82c3b 100644
 --- a/libavcodec/h264dec.h
 +++ b/libavcodec/h264dec.h
 @@ -329,6 +329,7 @@ typedef struct H264SliceContext {
@@ -1356,7 +1356,7 @@ index 0698ab95ba5..2b39e82c3b0 100644
  
  /**
 
-From 5a8628cf6368fe18457d02bf551d5935609efab5 Mon Sep 17 00:00:00 2001
+From 68883e0cd0c7e4ef6bcccaa1af2e7becf59f8556 Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Sat, 15 Dec 2018 22:32:16 +0100
 Subject: [PATCH 05/17] Add V4L2 request API h264 hwaccel
@@ -1374,7 +1374,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  create mode 100644 libavcodec/v4l2_request_h264.c
 
 diff --git a/configure b/configure
-index f2e203d1346..b17e4108c1b 100755
+index f2e203d134..b17e4108c1 100755
 --- a/configure
 +++ b/configure
 @@ -2951,6 +2951,8 @@ h264_dxva2_hwaccel_deps="dxva2"
@@ -1395,7 +1395,7 @@ index f2e203d1346..b17e4108c1b 100755
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 90dfffcb200..426c7528e90 100644
+index 90dfffcb20..426c7528e9 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
 @@ -935,6 +935,7 @@ OBJS-$(CONFIG_H264_D3D11VA_HWACCEL)       += dxva2_h264.o
@@ -1407,7 +1407,7 @@ index 90dfffcb200..426c7528e90 100644
  OBJS-$(CONFIG_H264_VDPAU_HWACCEL)         += vdpau_h264.o
  OBJS-$(CONFIG_H264_VIDEOTOOLBOX_HWACCEL)  += videotoolbox.o
 diff --git a/libavcodec/h264_slice.c b/libavcodec/h264_slice.c
-index c28b58cd5d9..0a10d00aad9 100644
+index c28b58cd5d..0a10d00aad 100644
 --- a/libavcodec/h264_slice.c
 +++ b/libavcodec/h264_slice.c
 @@ -768,6 +768,7 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
@@ -1429,7 +1429,7 @@ index c28b58cd5d9..0a10d00aad9 100644
              if (h->avctx->codec->pix_fmts)
                  choices = h->avctx->codec->pix_fmts;
 diff --git a/libavcodec/h264dec.c b/libavcodec/h264dec.c
-index 0a999bef43d..d78e3eaee3a 100644
+index 0a999bef43..d78e3eaee3 100644
 --- a/libavcodec/h264dec.c
 +++ b/libavcodec/h264dec.c
 @@ -1076,6 +1076,9 @@ AVCodec ff_h264_decoder = {
@@ -1443,7 +1443,7 @@ index 0a999bef43d..d78e3eaee3a 100644
                                 NULL
                             },
 diff --git a/libavcodec/hwaccels.h b/libavcodec/hwaccels.h
-index 8e54cf73f90..969a1da0f4b 100644
+index 8e54cf73f9..969a1da0f4 100644
 --- a/libavcodec/hwaccels.h
 +++ b/libavcodec/hwaccels.h
 @@ -32,6 +32,7 @@ extern const AVHWAccel ff_h264_d3d11va_hwaccel;
@@ -1456,7 +1456,7 @@ index 8e54cf73f90..969a1da0f4b 100644
  extern const AVHWAccel ff_h264_videotoolbox_hwaccel;
 diff --git a/libavcodec/v4l2_request_h264.c b/libavcodec/v4l2_request_h264.c
 new file mode 100644
-index 00000000000..88da8f0a2db
+index 0000000000..394bae0550
 --- /dev/null
 +++ b/libavcodec/v4l2_request_h264.c
 @@ -0,0 +1,456 @@
@@ -1528,7 +1528,7 @@ index 00000000000..88da8f0a2db
 +{
 +    entry->reference_ts = ff_v4l2_request_get_capture_timestamp(pic->f);
 +    entry->pic_num = pic->pic_id;
-+    entry->frame_num = pic->frame_num;
++    entry->frame_num = pic->long_ref ? pic->pic_id : pic->frame_num;
 +    entry->fields = pic->reference & V4L2_H264_FRAME_REF;
 +    entry->flags = V4L2_H264_DPB_ENTRY_FLAG_VALID;
 +    if (entry->fields)
@@ -1917,7 +1917,7 @@ index 00000000000..88da8f0a2db
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 
-From 02b8fb17c2a019463dcab4baa1cb0bec63353183 Mon Sep 17 00:00:00 2001
+From 694f0e61125d4d6b2d5b950023e7f8623bfc58f2 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 15 Dec 2018 22:32:16 +0100
 Subject: [PATCH 06/17] Add V4L2 request API mpeg2 hwaccel
@@ -1933,7 +1933,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  create mode 100644 libavcodec/v4l2_request_mpeg2.c
 
 diff --git a/configure b/configure
-index b17e4108c1b..ec141fabbdc 100755
+index b17e4108c1..ec141fabbd 100755
 --- a/configure
 +++ b/configure
 @@ -2995,6 +2995,8 @@ mpeg2_dxva2_hwaccel_deps="dxva2"
@@ -1954,7 +1954,7 @@ index b17e4108c1b..ec141fabbdc 100755
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 426c7528e90..02c023a4477 100644
+index 426c7528e9..02c023a447 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
 @@ -955,6 +955,7 @@ OBJS-$(CONFIG_MPEG2_D3D11VA_HWACCEL)      += dxva2_mpeg2.o
@@ -1966,7 +1966,7 @@ index 426c7528e90..02c023a4477 100644
  OBJS-$(CONFIG_MPEG2_VDPAU_HWACCEL)        += vdpau_mpeg12.o
  OBJS-$(CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL) += videotoolbox.o
 diff --git a/libavcodec/hwaccels.h b/libavcodec/hwaccels.h
-index 969a1da0f4b..a8ae1483d8e 100644
+index 969a1da0f4..a8ae1483d8 100644
 --- a/libavcodec/hwaccels.h
 +++ b/libavcodec/hwaccels.h
 @@ -53,6 +53,7 @@ extern const AVHWAccel ff_mpeg2_d3d11va_hwaccel;
@@ -1978,7 +1978,7 @@ index 969a1da0f4b..a8ae1483d8e 100644
  extern const AVHWAccel ff_mpeg2_vdpau_hwaccel;
  extern const AVHWAccel ff_mpeg2_videotoolbox_hwaccel;
 diff --git a/libavcodec/mpeg12dec.c b/libavcodec/mpeg12dec.c
-index 94221da2c15..4b0176f6cb1 100644
+index 94221da2c1..4b0176f6cb 100644
 --- a/libavcodec/mpeg12dec.c
 +++ b/libavcodec/mpeg12dec.c
 @@ -1147,6 +1147,9 @@ static const enum AVPixelFormat mpeg2_hwaccel_pixfmt_list_420[] = {
@@ -2003,7 +2003,7 @@ index 94221da2c15..4b0176f6cb1 100644
                      },
 diff --git a/libavcodec/v4l2_request_mpeg2.c b/libavcodec/v4l2_request_mpeg2.c
 new file mode 100644
-index 00000000000..84d53209c79
+index 0000000000..84d53209c7
 --- /dev/null
 +++ b/libavcodec/v4l2_request_mpeg2.c
 @@ -0,0 +1,159 @@
@@ -2167,7 +2167,7 @@ index 00000000000..84d53209c79
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 
-From 1cd61e5730acc12c39c964bcf13c73a54203a390 Mon Sep 17 00:00:00 2001
+From fdacf119ed7ed75197dbc2003cdd9bad6e74764f Mon Sep 17 00:00:00 2001
 From: Boris Brezillon <boris.brezillon@collabora.com>
 Date: Wed, 22 May 2019 14:46:58 +0200
 Subject: [PATCH 07/17] Add V4L2 request API vp8 hwaccel
@@ -2185,7 +2185,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  create mode 100644 libavcodec/v4l2_request_vp8.c
 
 diff --git a/configure b/configure
-index ec141fabbdc..f16bed65a3a 100755
+index ec141fabbd..f16bed65a3 100755
 --- a/configure
 +++ b/configure
 @@ -3027,6 +3027,8 @@ vc1_vdpau_hwaccel_deps="vdpau"
@@ -2206,7 +2206,7 @@ index ec141fabbdc..f16bed65a3a 100755
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 02c023a4477..c79d678eb3e 100644
+index 02c023a447..c79d678eb3 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
 @@ -971,6 +971,7 @@ OBJS-$(CONFIG_VC1_QSV_HWACCEL)            += qsvdec.o
@@ -2218,7 +2218,7 @@ index 02c023a4477..c79d678eb3e 100644
  OBJS-$(CONFIG_VP9_D3D11VA_HWACCEL)        += dxva2_vp9.o
  OBJS-$(CONFIG_VP9_DXVA2_HWACCEL)          += dxva2_vp9.o
 diff --git a/libavcodec/hwaccels.h b/libavcodec/hwaccels.h
-index a8ae1483d8e..9f8d41e367e 100644
+index a8ae1483d8..9f8d41e367 100644
 --- a/libavcodec/hwaccels.h
 +++ b/libavcodec/hwaccels.h
 @@ -69,6 +69,7 @@ extern const AVHWAccel ff_vc1_nvdec_hwaccel;
@@ -2231,7 +2231,7 @@ index a8ae1483d8e..9f8d41e367e 100644
  extern const AVHWAccel ff_vp9_d3d11va2_hwaccel;
 diff --git a/libavcodec/v4l2_request_vp8.c b/libavcodec/v4l2_request_vp8.c
 new file mode 100644
-index 00000000000..bc0fc400727
+index 0000000000..bc0fc40072
 --- /dev/null
 +++ b/libavcodec/v4l2_request_vp8.c
 @@ -0,0 +1,180 @@
@@ -2416,7 +2416,7 @@ index 00000000000..bc0fc400727
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 diff --git a/libavcodec/vp8.c b/libavcodec/vp8.c
-index d16e7b6aa34..8ee768d875a 100644
+index d16e7b6aa3..8ee768d875 100644
 --- a/libavcodec/vp8.c
 +++ b/libavcodec/vp8.c
 @@ -176,6 +176,9 @@ static enum AVPixelFormat get_pixel_format(VP8Context *s)
@@ -2440,24 +2440,25 @@ index d16e7b6aa34..8ee768d875a 100644
                                 NULL
                             },
 
-From 41c38b001277f252c052ba0493546184760a0a8e Mon Sep 17 00:00:00 2001
+From 8d663e7b4c006f9e0a775dce2a69c8b6c4f7d4fa Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Sat, 15 Dec 2018 22:32:16 +0100
 Subject: [PATCH 08/17] Add V4L2 request API hevc hwaccel
 
 Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
 Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Signed-off-by: Benjamin Gaignard <benjamin.gaignard@collabora.com>
 ---
  configure                      |   3 +
  libavcodec/Makefile            |   1 +
  libavcodec/hevcdec.c           |  10 +
  libavcodec/hwaccels.h          |   1 +
- libavcodec/v4l2_request_hevc.c | 580 +++++++++++++++++++++++++++++++++
- 5 files changed, 595 insertions(+)
+ libavcodec/v4l2_request_hevc.c | 579 +++++++++++++++++++++++++++++++++
+ 5 files changed, 594 insertions(+)
  create mode 100644 libavcodec/v4l2_request_hevc.c
 
 diff --git a/configure b/configure
-index f16bed65a3a..02a80cf27fd 100755
+index f16bed65a3..02a80cf27f 100755
 --- a/configure
 +++ b/configure
 @@ -2967,6 +2967,8 @@ hevc_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_HEVC"
@@ -2478,7 +2479,7 @@ index f16bed65a3a..02a80cf27fd 100755
  check_cc vp8_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_VP8_FRAME;"
  
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index c79d678eb3e..0059074530c 100644
+index c79d678eb3..0059074530 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
 @@ -943,6 +943,7 @@ OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
@@ -2490,7 +2491,7 @@ index c79d678eb3e..0059074530c 100644
  OBJS-$(CONFIG_HEVC_VDPAU_HWACCEL)         += vdpau_hevc.o h265_profile_level.o
  OBJS-$(CONFIG_MJPEG_NVDEC_HWACCEL)        += nvdec_mjpeg.o
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index 2231aed2599..7507966d716 100644
+index 2231aed259..7507966d71 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
 @@ -392,6 +392,7 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
@@ -2532,7 +2533,7 @@ index 2231aed2599..7507966d716 100644
                                 NULL
                             },
 diff --git a/libavcodec/hwaccels.h b/libavcodec/hwaccels.h
-index 9f8d41e367e..ffb9fa5087d 100644
+index 9f8d41e367..ffb9fa5087 100644
 --- a/libavcodec/hwaccels.h
 +++ b/libavcodec/hwaccels.h
 @@ -40,6 +40,7 @@ extern const AVHWAccel ff_hevc_d3d11va_hwaccel;
@@ -2545,10 +2546,10 @@ index 9f8d41e367e..ffb9fa5087d 100644
  extern const AVHWAccel ff_hevc_videotoolbox_hwaccel;
 diff --git a/libavcodec/v4l2_request_hevc.c b/libavcodec/v4l2_request_hevc.c
 new file mode 100644
-index 00000000000..fd253661086
+index 0000000000..6caf36f1a9
 --- /dev/null
 +++ b/libavcodec/v4l2_request_hevc.c
-@@ -0,0 +1,580 @@
+@@ -0,0 +1,579 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2632,6 +2633,25 @@ index 00000000000..fd253661086
 +    }
 +}
 +
++static uint8_t get_ref_pic_index(const HEVCContext *h, const HEVCFrame *frame,
++                                 struct v4l2_ctrl_hevc_decode_params *dec_params)
++{
++    uint64_t timestamp;
++
++    if (!frame)
++        return 0;
++
++    timestamp = ff_v4l2_request_get_capture_timestamp(frame->frame);
++
++    for (uint8_t i = 0; i < dec_params->num_active_dpb_entries; i++) {
++        struct v4l2_hevc_dpb_entry *entry = &dec_params->dpb[i];
++        if (entry->timestamp == timestamp)
++            return i;
++    }
++
++    return 0;
++}
++
 +static void fill_dec_params(struct v4l2_ctrl_hevc_decode_params *dec_params, const HEVCContext *h)
 +{
 +    const HEVCFrame *pic = h->ref;
@@ -2674,31 +2694,11 @@ index 00000000000..fd253661086
 +    if (sh->no_output_of_prior_pics_flag)
 +        dec_params->flags |= V4L2_HEVC_DECODE_PARAM_FLAG_NO_OUTPUT_OF_PRIOR;
 +
-+    /*
-+     * TODO: fill
-+     * dec_params->poc_st_curr_before[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
-+     * dec_params->poc_st_curr_after[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
-+     * dec_params->poc_lt_curr[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
-+     */
-+}
-+
-+static uint8_t get_ref_pic_index(const HEVCContext *h, const HEVCFrame *frame,
-+                                 struct v4l2_ctrl_hevc_decode_params *dec_params)
-+{
-+    uint64_t timestamp;
-+
-+    if (!frame)
-+        return 0;
-+
-+    timestamp = ff_v4l2_request_get_capture_timestamp(frame->frame);
-+
-+    for (uint8_t i = 0; i < dec_params->num_active_dpb_entries; i++) {
-+        struct v4l2_hevc_dpb_entry *entry = &dec_params->dpb[i];
-+        if (entry->timestamp == timestamp)
-+            return i;
++    for (i = 0; i < V4L2_HEVC_DPB_ENTRIES_NUM_MAX; i++) {
++        dec_params->poc_st_curr_before[i] = get_ref_pic_index(h, h->rps[ST_CURR_BEF].ref[i], dec_params);
++        dec_params->poc_st_curr_after[i] = get_ref_pic_index(h, h->rps[ST_CURR_AFT].ref[i], dec_params);
++        dec_params->poc_lt_curr[i] = get_ref_pic_index(h, h->rps[LT_CURR].ref[i], dec_params);
 +    }
-+
-+    return 0;
 +}
 +
 +static void v4l2_request_hevc_fill_slice_params(const HEVCContext *h,
@@ -2793,7 +2793,7 @@ index 00000000000..fd253661086
 +        .pic_width_in_luma_samples = sps->width,
 +        .pic_height_in_luma_samples = sps->height,
 +        .bit_depth_luma_minus8 = sps->bit_depth - 8,
-+        .bit_depth_chroma_minus8 = sps->bit_depth - 8,
++        .bit_depth_chroma_minus8 = sps->bit_depth_chroma - 8,
 +        .log2_max_pic_order_cnt_lsb_minus4 = sps->log2_max_poc_lsb - 4,
 +        .sps_max_dec_pic_buffering_minus1 = sps->temporal_layer[sps->max_sub_layers - 1].max_dec_pic_buffering - 1,
 +        .sps_max_num_reorder_pics = sps->temporal_layer[sps->max_sub_layers - 1].num_reorder_pics,
@@ -3130,7 +3130,7 @@ index 00000000000..fd253661086
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 
-From 3c9c4c99eccdda102064ea67a04c8cbf8083ad1a Mon Sep 17 00:00:00 2001
+From 9a3b291671c06ae4b23d890c1820b8d061aa00df Mon Sep 17 00:00:00 2001
 From: Boris Brezillon <boris.brezillon@collabora.com>
 Date: Thu, 12 Dec 2019 16:13:55 +0100
 Subject: [PATCH 09/17] Add V4L2 request API VP9 hwaccel
@@ -3149,7 +3149,7 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
  create mode 100644 libavcodec/v4l2_request_vp9.c
 
 diff --git a/configure b/configure
-index 02a80cf27fd..0b238c051df 100755
+index 02a80cf27f..0b238c051d 100755
 --- a/configure
 +++ b/configure
 @@ -3041,6 +3041,8 @@ vp9_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_VP9"
@@ -3170,7 +3170,7 @@ index 02a80cf27fd..0b238c051df 100755
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 0059074530c..38edf1cfe5e 100644
+index 0059074530..38edf1cfe5 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
 @@ -977,6 +977,7 @@ OBJS-$(CONFIG_VP8_VAAPI_HWACCEL)          += vaapi_vp8.o
@@ -3182,7 +3182,7 @@ index 0059074530c..38edf1cfe5e 100644
  OBJS-$(CONFIG_VP9_VDPAU_HWACCEL)          += vdpau_vp9.o
  OBJS-$(CONFIG_VP8_QSV_HWACCEL)            += qsvdec.o
 diff --git a/libavcodec/hwaccels.h b/libavcodec/hwaccels.h
-index ffb9fa5087d..fc5d0b0479b 100644
+index ffb9fa5087..fc5d0b0479 100644
 --- a/libavcodec/hwaccels.h
 +++ b/libavcodec/hwaccels.h
 @@ -76,6 +76,7 @@ extern const AVHWAccel ff_vp9_d3d11va_hwaccel;
@@ -3195,7 +3195,7 @@ index ffb9fa5087d..fc5d0b0479b 100644
  extern const AVHWAccel ff_wmv3_d3d11va_hwaccel;
 diff --git a/libavcodec/v4l2_request_vp9.c b/libavcodec/v4l2_request_vp9.c
 new file mode 100644
-index 00000000000..9b95c76cdb8
+index 0000000000..9b95c76cdb
 --- /dev/null
 +++ b/libavcodec/v4l2_request_vp9.c
 @@ -0,0 +1,268 @@
@@ -3468,7 +3468,7 @@ index 00000000000..9b95c76cdb8
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 diff --git a/libavcodec/vp9.c b/libavcodec/vp9.c
-index 4659f94ee8b..1b2f1eeaf69 100644
+index 4659f94ee8..1b2f1eeaf6 100644
 --- a/libavcodec/vp9.c
 +++ b/libavcodec/vp9.c
 @@ -191,6 +191,7 @@ static int update_size(AVCodecContext *avctx, int w, int h)
@@ -3831,7 +3831,7 @@ index 4659f94ee8b..1b2f1eeaf69 100644
                                 NULL
                             },
 diff --git a/libavcodec/vp9dec.h b/libavcodec/vp9dec.h
-index d82b258a3d8..8d2c341e0b9 100644
+index d82b258a3d..8d2c341e0b 100644
 --- a/libavcodec/vp9dec.h
 +++ b/libavcodec/vp9dec.h
 @@ -131,6 +131,10 @@ typedef struct VP9Context {
@@ -3846,7 +3846,7 @@ index d82b258a3d8..8d2c341e0b9 100644
      // contextual (above) cache
      uint8_t *above_partition_ctx;
 diff --git a/libavcodec/vp9shared.h b/libavcodec/vp9shared.h
-index 54726df742f..fee3568736f 100644
+index 54726df742..fee3568736 100644
 --- a/libavcodec/vp9shared.h
 +++ b/libavcodec/vp9shared.h
 @@ -131,6 +131,7 @@ typedef struct VP9BitstreamHeader {
@@ -3858,7 +3858,7 @@ index 54726df742f..fee3568736f 100644
          uint8_t pred_prob[3];
          struct {
 
-From 3d23a6cb94067e5c2529955551d6a8fcc8e48acd Mon Sep 17 00:00:00 2001
+From 96052082ce698560e5b3f85e58089d794e6f1330 Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Thu, 14 Feb 2019 23:20:05 +0100
 Subject: [PATCH 10/17] Add and use private linux v5.18 headers for V4L2
@@ -3874,7 +3874,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  create mode 100644 libavcodec/hevc-ctrls.h
 
 diff --git a/configure b/configure
-index 0b238c051df..1c1929d2c28 100755
+index 0b238c051d..1c1929d2c2 100755
 --- a/configure
 +++ b/configure
 @@ -2967,7 +2967,7 @@ hevc_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_HEVC"
@@ -3888,7 +3888,7 @@ index 0b238c051df..1c1929d2c28 100755
  hevc_vaapi_hwaccel_select="hevc_decoder"
 diff --git a/libavcodec/hevc-ctrls.h b/libavcodec/hevc-ctrls.h
 new file mode 100644
-index 00000000000..01ccda48d8c
+index 0000000000..01ccda48d8
 --- /dev/null
 +++ b/libavcodec/hevc-ctrls.h
 @@ -0,0 +1,250 @@
@@ -4143,7 +4143,7 @@ index 00000000000..01ccda48d8c
 +
 +#endif
 diff --git a/libavcodec/v4l2_request_hevc.c b/libavcodec/v4l2_request_hevc.c
-index fd253661086..949df3811ac 100644
+index 6caf36f1a9..eee33ca8bf 100644
 --- a/libavcodec/v4l2_request_hevc.c
 +++ b/libavcodec/v4l2_request_hevc.c
 @@ -19,6 +19,7 @@
@@ -4155,7 +4155,7 @@ index fd253661086..949df3811ac 100644
  #define MAX_SLICES 16
  
 
-From bb3cf90c0533a0096dff74b416f55832814293e0 Mon Sep 17 00:00:00 2001
+From 6cb39c865d85e66bc2d82504046a7e7829288b99 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Mon, 29 Apr 2019 22:08:59 +0000
 Subject: [PATCH 11/17] HACK: hwcontext_drm: do not require drm device
@@ -4166,7 +4166,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  1 file changed, 5 insertions(+)
 
 diff --git a/libavutil/hwcontext_drm.c b/libavutil/hwcontext_drm.c
-index 7a9fdbd263d..6297d1f9b61 100644
+index 7a9fdbd263..6297d1f9b6 100644
 --- a/libavutil/hwcontext_drm.c
 +++ b/libavutil/hwcontext_drm.c
 @@ -53,6 +53,11 @@ static int drm_device_create(AVHWDeviceContext *hwdev, const char *device,
@@ -4182,7 +4182,7 @@ index 7a9fdbd263d..6297d1f9b61 100644
      if (hwctx->fd < 0)
          return AVERROR(errno);
 
-From 0a9c478c1e826eb1ecff27da1206542614449de5 Mon Sep 17 00:00:00 2001
+From c06fd04826b5a2bc90700896672f04efa9151ffe Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Sat, 15 Dec 2018 22:32:16 +0100
 Subject: [PATCH 12/17] WIP: hevc entry point offsets
@@ -4194,7 +4194,7 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
  2 files changed, 12 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/hevc-ctrls.h b/libavcodec/hevc-ctrls.h
-index 01ccda48d8c..00bae349d34 100644
+index 01ccda48d8..00bae349d3 100644
 --- a/libavcodec/hevc-ctrls.h
 +++ b/libavcodec/hevc-ctrls.h
 @@ -200,7 +200,9 @@ struct v4l2_ctrl_hevc_slice_params {
@@ -4209,10 +4209,10 @@ index 01ccda48d8c..00bae349d34 100644
  	/* ISO/IEC 23008-2, ITU-T Rec. H.265: Weighted prediction parameter */
  	struct v4l2_hevc_pred_weight_table pred_weight_table;
 diff --git a/libavcodec/v4l2_request_hevc.c b/libavcodec/v4l2_request_hevc.c
-index 949df3811ac..b74244f3be6 100644
+index eee33ca8bf..ac9a72b6b1 100644
 --- a/libavcodec/v4l2_request_hevc.c
 +++ b/libavcodec/v4l2_request_hevc.c
-@@ -232,6 +232,15 @@ static void v4l2_request_hevc_fill_slice_params(const HEVCContext *h,
+@@ -231,6 +231,15 @@ static void v4l2_request_hevc_fill_slice_params(const HEVCContext *h,
      }
  
      v4l2_request_hevc_fill_pred_table(h, &slice_params->pred_weight_table);
@@ -4229,7 +4229,7 @@ index 949df3811ac..b74244f3be6 100644
  
  static void fill_sps(struct v4l2_ctrl_hevc_sps *ctrl, const HEVCContext *h)
 
-From 154405d2d8987c741e722f59430fda9326c8cdef Mon Sep 17 00:00:00 2001
+From a65269d7347654905aa81fec87f0b7de2389d679 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Fri, 15 May 2020 16:54:05 +0000
 Subject: [PATCH 13/17] WIP: add NV15 and NV20 support
@@ -4241,7 +4241,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  2 files changed, 35 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/h264_slice.c b/libavcodec/h264_slice.c
-index 0a10d00aad9..45057fd049b 100644
+index 0a10d00aad..45057fd049 100644
 --- a/libavcodec/h264_slice.c
 +++ b/libavcodec/h264_slice.c
 @@ -794,10 +794,17 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
@@ -4275,7 +4275,7 @@ index 0a10d00aad9..45057fd049b 100644
                  *fmt++ = AV_PIX_FMT_YUVJ422P;
              else
 diff --git a/libavcodec/v4l2_request.c b/libavcodec/v4l2_request.c
-index 5234b5049b0..0b294feff2e 100644
+index 5234b5049b..0b294feff2 100644
 --- a/libavcodec/v4l2_request.c
 +++ b/libavcodec/v4l2_request.c
 @@ -188,6 +188,13 @@ const uint32_t v4l2_request_capture_pixelformats[] = {
@@ -4316,7 +4316,7 @@ index 5234b5049b0..0b294feff2e 100644
      default:
          return -1;
 
-From d7933e19a712a59af418f6b029c0984d5b29afe9 Mon Sep 17 00:00:00 2001
+From 46639ec9e31055e49086a141f715f748605800e1 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Mon, 27 Jul 2020 23:15:45 +0000
 Subject: [PATCH 14/17] HACK: define drm NV15 and NV20 format
@@ -4326,7 +4326,7 @@ Subject: [PATCH 14/17] HACK: define drm NV15 and NV20 format
  1 file changed, 8 insertions(+)
 
 diff --git a/libavcodec/v4l2_request.c b/libavcodec/v4l2_request.c
-index 0b294feff2e..a8f0ee79eee 100644
+index 0b294feff2..a8f0ee79ee 100644
 --- a/libavcodec/v4l2_request.c
 +++ b/libavcodec/v4l2_request.c
 @@ -30,6 +30,14 @@
@@ -4345,7 +4345,7 @@ index 0b294feff2e..a8f0ee79eee 100644
  {
      V4L2RequestDescriptor *req = (V4L2RequestDescriptor*)frame->data[0];
 
-From 7ebf970204f1aaabc3d0ca0c81d8d4dd99916c56 Mon Sep 17 00:00:00 2001
+From aaf15ef32d3adf01139c795ae8c1f253a74124a1 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Wed, 13 May 2020 22:51:21 +0000
 Subject: [PATCH 15/17] WIP: hevc rkvdec fields
@@ -4357,7 +4357,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  2 files changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/hevc-ctrls.h b/libavcodec/hevc-ctrls.h
-index 00bae349d34..2ecec618669 100644
+index 00bae349d3..2ecec61866 100644
 --- a/libavcodec/hevc-ctrls.h
 +++ b/libavcodec/hevc-ctrls.h
 @@ -58,6 +58,8 @@ enum v4l2_mpeg_video_hevc_start_code {
@@ -4407,10 +4407,10 @@ index 00bae349d34..2ecec618669 100644
  	__u32	entry_point_offset_minus1[256];
  	__u8	padding[8];
 diff --git a/libavcodec/v4l2_request_hevc.c b/libavcodec/v4l2_request_hevc.c
-index b74244f3be6..093700c4063 100644
+index ac9a72b6b1..109943d015 100644
 --- a/libavcodec/v4l2_request_hevc.c
 +++ b/libavcodec/v4l2_request_hevc.c
-@@ -190,6 +190,9 @@ static void v4l2_request_hevc_fill_slice_params(const HEVCContext *h,
+@@ -189,6 +189,9 @@ static void v4l2_request_hevc_fill_slice_params(const HEVCContext *h,
  
          /* ISO/IEC 23008-2, ITU-T Rec. H.265: Picture timing SEI message */
          .pic_struct = h->sei.picture_timing.picture_struct,
@@ -4420,7 +4420,7 @@ index b74244f3be6..093700c4063 100644
      };
  
      if (sh->slice_sample_adaptive_offset_flag[0])
-@@ -246,9 +249,12 @@ static void v4l2_request_hevc_fill_slice_params(const HEVCContext *h,
+@@ -245,9 +248,12 @@ static void v4l2_request_hevc_fill_slice_params(const HEVCContext *h,
  static void fill_sps(struct v4l2_ctrl_hevc_sps *ctrl, const HEVCContext *h)
  {
      const HEVCSPS *sps = h->ps.sps;
@@ -4433,7 +4433,7 @@ index b74244f3be6..093700c4063 100644
          .pic_width_in_luma_samples = sps->width,
          .pic_height_in_luma_samples = sps->height,
          .bit_depth_luma_minus8 = sps->bit_depth - 8,
-@@ -312,6 +318,7 @@ static int v4l2_request_hevc_start_frame(AVCodecContext *avctx,
+@@ -311,6 +317,7 @@ static int v4l2_request_hevc_start_frame(AVCodecContext *avctx,
                              &pps->scaling_list :
                              sps->scaling_list_enable_flag ?
                              &sps->scaling_list : NULL;
@@ -4441,7 +4441,7 @@ index b74244f3be6..093700c4063 100644
      V4L2RequestControlsHEVC *controls = h->ref->hwaccel_picture_private;
  
      fill_sps(&controls->sps, h);
-@@ -335,6 +342,9 @@ static int v4l2_request_hevc_start_frame(AVCodecContext *avctx,
+@@ -334,6 +341,9 @@ static int v4l2_request_hevc_start_frame(AVCodecContext *avctx,
  
      /* ISO/IEC 23008-2, ITU-T Rec. H.265: Picture parameter set */
      controls->pps = (struct v4l2_ctrl_hevc_pps) {
@@ -4451,7 +4451,7 @@ index b74244f3be6..093700c4063 100644
          .num_extra_slice_header_bits = pps->num_extra_slice_header_bits,
          .num_ref_idx_l0_default_active_minus1 = pps->num_ref_idx_l0_default_active - 1,
          .num_ref_idx_l1_default_active_minus1 = pps->num_ref_idx_l1_default_active - 1,
-@@ -464,6 +474,8 @@ static int v4l2_request_hevc_queue_decode(AVCodecContext *avctx, int last_slice)
+@@ -463,6 +473,8 @@ static int v4l2_request_hevc_queue_decode(AVCodecContext *avctx, int last_slice)
      if (ctx->decode_mode == V4L2_MPEG_VIDEO_HEVC_DECODE_MODE_SLICE_BASED)
          return ff_v4l2_request_decode_slice(avctx, h->ref->frame, control, FF_ARRAY_ELEMS(control), controls->first_slice, last_slice);
  
@@ -4461,18 +4461,18 @@ index b74244f3be6..093700c4063 100644
  }
  
 
-From c9ae9a29ef84096bb2e4d37fbdea6c3b3d20fff7 Mon Sep 17 00:00:00 2001
+From 326d9cddaef1505b6c662dcf89148e29ee0b32f1 Mon Sep 17 00:00:00 2001
 From: Alex Bee <knaerzche@gmail.com>
 Date: Sun, 19 Sep 2021 13:10:55 +0200
 Subject: [PATCH 16/17] v4l2_request: validate supported framesizes
 
 Signed-off-by: Alex Bee <knaerzche@gmail.com>
 ---
- libavcodec/v4l2_request.c | 38 +++++++++++++++++++++++++++++++++++++-
- 1 file changed, 37 insertions(+), 1 deletion(-)
+ libavcodec/v4l2_request.c | 43 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 43 insertions(+)
 
 diff --git a/libavcodec/v4l2_request.c b/libavcodec/v4l2_request.c
-index a8f0ee79eee..2fbe1663416 100644
+index a8f0ee79ee..824dcaa8e9 100644
 --- a/libavcodec/v4l2_request.c
 +++ b/libavcodec/v4l2_request.c
 @@ -376,6 +376,42 @@ int ff_v4l2_request_decode_frame(AVCodecContext *avctx, AVFrame *frame, struct v
@@ -4518,17 +4518,22 @@ index a8f0ee79eee..2fbe1663416 100644
  static int v4l2_request_try_format(AVCodecContext *avctx, enum v4l2_buf_type type, uint32_t pixelformat)
  {
      V4L2RequestContext *ctx = avctx->internal->hwaccel_priv_data;
-@@ -404,7 +440,7 @@ static int v4l2_request_try_format(AVCodecContext *avctx, enum v4l2_buf_type typ
- 
-     while (ioctl(ctx->video_fd, VIDIOC_ENUM_FMT, &fmtdesc) >= 0) {
-         if (fmtdesc.pixelformat == pixelformat)
--            return 0;
-+            return v4l2_request_try_framesize(avctx, pixelformat);
- 
-         fmtdesc.index++;
+@@ -543,6 +579,13 @@ static int v4l2_request_probe_video_device(struct udev_device *device, AVCodecCo
+         goto fail;
      }
+ 
++    ret = v4l2_request_try_framesize(avctx, pixelformat);
++    if (ret < 0) {
++        av_log(avctx, AV_LOG_WARNING, "%s: try framesize failed\n", __func__);
++        ret = AVERROR(EINVAL);
++        goto fail;
++    }
++
+     ret = v4l2_request_set_format(avctx, ctx->output_type, pixelformat, buffersize);
+     if (ret < 0) {
+         av_log(avctx, AV_LOG_ERROR, "%s: set output format failed, %s (%d)\n", __func__, strerror(errno), errno);
 
-From c415926540fe04141bb1e8cabd24049b61752d4f Mon Sep 17 00:00:00 2001
+From ab65af8bee5ff6cb6b886223f3e7d9a2fedfe972 Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@gmail.com>
 Date: Sun, 27 Feb 2022 18:54:21 +0100
 Subject: [PATCH 17/17] Improve VP9 decoding
@@ -4538,7 +4543,7 @@ Subject: [PATCH 17/17] Improve VP9 decoding
  1 file changed, 62 insertions(+), 48 deletions(-)
 
 diff --git a/libavcodec/v4l2_request_vp9.c b/libavcodec/v4l2_request_vp9.c
-index 9b95c76cdb8..ec0300f66db 100644
+index 9b95c76cdb..ec0300f66d 100644
 --- a/libavcodec/v4l2_request_vp9.c
 +++ b/libavcodec/v4l2_request_vp9.c
 @@ -22,78 +22,62 @@


### PR DESCRIPTION
Patch created using revisions 081225c..ab65af8
from branch v4l2-request-hwaccel-4.4 of https://github.com/jernejsk/FFmpeg

It's required for both hantro G1 (RK SoCs) and G2 (AW) to work correctly with https://github.com/LibreELEC/LibreELEC.tv/pull/6658