### PR TITLE
mesa: update to 22.1.5

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="22.1.4"
-PKG_SHA256="670d8cbe8b72902a45ea2da68a9da4dc4a5d99c5953a926177adbce1b1640b76"
+PKG_VERSION="22.1.5"
+PKG_SHA256="6fd60d38efdd25317948c61494b5117e01d42da695278728b1faef9f5f9a47ba"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release Notes:
- https://gitlab.freedesktop.org/mesa/mesa/-/blob/22.1/docs/relnotes/22.1.5.rst

```
=== tested on ===
Generic.x86_64-devel-20220804123859-9c53e09
Linux nuc11 5.19.0 #1 SMP Thu Aug 4 12:39:09 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:80f18db9500c0738d3522f4efdf789aa012e9930). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-08-01 by GCC 12.1.1 for Linux x86 64-bit version 5.19.0 (332544)
Running on LibreELEC (heitbaum): devel-20220804123859-9c53e09 11.0, kernel: Linux x86 64-bit version 5.19.0
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0046.2022.0608.1909 06/08/2022
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.1.5
libva info: VA-API version 1.15.0
vainfo: VA-API version: 1.15 (libva 2.15.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.5.1 (413ccef0a9)
```