### PR TITLE
bento4: switch to xbmc fork

### DIFF
--- a/packages/multimedia/bento4/package.mk
+++ b/packages/multimedia/bento4/package.mk
@@ -2,16 +2,14 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bento4"
-PKG_VERSION="1.6.0-639"
-PKG_SHA256="9f3eb912207d7ed9c1e6e05315083404b32a11f8aacd604a9b2bdcb10bf79eb9"
+PKG_VERSION="1.6.0-639-Nexus"
+PKG_SHA256="adb44aa29d0545795225735dece3665a58c3b9d194825b029cc05669620c50a4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.bento4.com"
-PKG_URL="https://github.com/axiomatic-systems/Bento4/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/xbmc/Bento4/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_UNPACK="inputstream.adaptive"
 PKG_LONGDESC="C++ class library and tools designed to read and write ISO-MP4 files"
 PKG_BUILD_FLAGS="+pic"
-
-PKG_PATCH_DIRS="$(get_build_dir inputstream.adaptive)/depends/common/bento4"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_APPS=OFF"


### PR DESCRIPTION
inputstream.adaptive is switching bento4 to the kodi fork, next release will use that and have all patches removed - see https://github.com/xbmc/inputstream.adaptive/pull/1017

This is not an immediate issue now but will become one at the next i.a update.

Only build tested for now