### PR TITLE
btrfs-progs: enable compile with glibc 2.36

### DIFF
--- a/packages/addons/tools/btrfs-progs/patches/btrfs-progs-01-compile-with-glibc-2.36.patch
+++ b/packages/addons/tools/btrfs-progs/patches/btrfs-progs-01-compile-with-glibc-2.36.patch
@@ -1,0 +1,32 @@
+From 46eb32a019834b0a49ae9744db1a921aaa6a3d63 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 25 Jul 2022 11:58:35 -0700
+Subject: [PATCH] btrfs-progs: use linux mount.h instead of sys/mount.h
+
+This file includes linux/fs.h which includes linux/mount.h and with
+glibc 2.36 linux/mount.h and glibc mount.h are not compatible [1]
+therefore try to avoid including both headers
+
+[1] https://sourceware.org/glibc/wiki/Release/2.36
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: David Sterba <dsterba@suse.com>
+---
+ common/device-utils.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/common/device-utils.c b/common/device-utils.c
+index 617b6746..25a4fb8c 100644
+--- a/common/device-utils.c
++++ b/common/device-utils.c
+@@ -15,7 +15,6 @@
+  */
+ 
+ #include <sys/ioctl.h>
+-#include <sys/mount.h>
+ #include <sys/statfs.h>
+ #include <sys/types.h>
+ #include <stdio.h>
+-- 
+GitLab
+


### PR DESCRIPTION
Missing patch from
- #6684 