### PR TITLE
atf and crust: support build with binutils 2.39

### DIFF
--- a/packages/tools/atf/package.mk
+++ b/packages/tools/atf/package.mk
@@ -16,9 +16,9 @@ PKG_TOOLCHAIN="manual"
 
 make_target() {
   if [ "${DEVICE}" = "iMX8" ]; then
-    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="--param=min-pagesize=0" make PLAT=${ATF_PLATFORM} bl31
+    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="--no-warn-rwx-segments" CFLAGS="--param=min-pagesize=0" make PLAT=${ATF_PLATFORM} bl31
   else
-    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="" make PLAT=${ATF_PLATFORM} bl31
+    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="--no-warn-rwx-segments" CFLAGS="" make PLAT=${ATF_PLATFORM} bl31
   fi
 }
 

--- a/packages/tools/crust/patches/fix-binutils-2-39.patch
+++ b/packages/tools/crust/patches/fix-binutils-2-39.patch
@@ -1,0 +1,12 @@
+--- a/Makefile	2022-08-09 08:48:15.390323604 +0000
++++ b/Makefile	2022-08-09 08:49:45.623098723 +0000
+@@ -84,7 +84,8 @@
+ 		   -Wl,--fatal-warnings \
+ 		   -Wl,--gc-sections \
+ 		   -Wl,--no-dynamic-linker \
+-		   -Wl,--no-undefined
++		   -Wl,--no-undefined \
++		   -Wl,--no-warn-rwx-segments
+ 
+ ###############################################################################
+ 


### PR DESCRIPTION
Fix build error with binutils-2.39 and atf.

set LDFLAGS="--no-warn-rwx-segments" for build of bl31.elf on iMX8, A64,
H5 and H6 socs. As the link fails with a non-zero exit code (because
of --fatal-warnings).

relevant commit:
- https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=ba951afb99912da01a6e8434126b8fac7aa75107

The ELF linker will now generate a warning message if the stack is made
executable.  Similarly it will warn if the output binary contains a
segment with all three of the read, write and execute permission
bits set.  These warnings are intended to help developers identify
programs which might be vulnerable to attack via these executable
memory regions.  The warnings are enabled by default but can be
disabled via a command line option.

compile error:
LD atf-2.7/build/sun50i_a64/release/bl31/bl31.elf
aarch64-none-elf-ld.bfd: warning: atf-2.7/build/sun50i_a64/release/bl31/bl31.elf has a LOAD segment with RWX permissions