### PR TITLE
mesa: Revert "pan/bi: Require ATEST coverage mask input in R60"

### DIFF
--- a/packages/graphics/mesa/patches/mesa-0001-22-1-5-Revert-pan-bi-Require-ATEST-coverage-mask-input-in-R60.patch
+++ b/packages/graphics/mesa/patches/mesa-0001-22-1-5-Revert-pan-bi-Require-ATEST-coverage-mask-input-in-R60.patch
@@ -1,0 +1,52 @@
+From c69f1dba5c2b51614d69580249d52eb62dddaf62 Mon Sep 17 00:00:00 2001
+From: Eric Engestrom <eric@engestrom.ch>
+Date: Wed, 10 Aug 2022 16:43:24 +0100
+Subject: [PATCH] Revert "pan/bi: Require ATEST coverage mask input in R60"
+
+This reverts commit 7ead256891cec7a301d2fd415405a7f9106b1f46.
+
+See https://gitlab.freedesktop.org/mesa/mesa/-/issues/7025 for the
+details, but the short version is that this was causing a segfault.
+---
+ .pick_status.json            |  2 +-
+ src/panfrost/bifrost/bi_ra.c | 11 -----------
+ 2 files changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/.pick_status.json b/.pick_status.json
+index f33cb9b8538a..2dec29fd3e76 100644
+--- a/.pick_status.json
++++ b/.pick_status.json
+@@ -6349,7 +6349,7 @@
+         "description": "pan/bi: Require ATEST coverage mask input in R60",
+         "nominated": true,
+         "nomination_type": 0,
+-        "resolution": 1,
++        "resolution": 2,
+         "main_sha": null,
+         "because_sha": null
+     },
+diff --git a/src/panfrost/bifrost/bi_ra.c b/src/panfrost/bifrost/bi_ra.c
+index 7472c2e550b5..8b14c0ec79a9 100644
+--- a/src/panfrost/bifrost/bi_ra.c
++++ b/src/panfrost/bifrost/bi_ra.c
+@@ -334,17 +334,6 @@ bi_allocate_registers(bi_context *ctx, bool *success, bool full_regs)
+                         if (node < node_count)
+                                 l->solutions[node] = 4;
+                 }
+-
+-                /* Experimentally, it seems coverage masks inputs to ATEST must
+-                 * be in R60. Otherwise coverage mask writes do not work with
+-                 * early-ZS with pixel-frequency-shading (this combination of
+-                 * settings is legal if depth/stencil writes are disabled).
+-                 */
+-                if (ins->op == BI_OPCODE_ATEST) {
+-                        unsigned node = bi_get_node(ins->src[0]);
+-                        assert(node < node_count);
+-                        l->solutions[node] = 60;
+-                }
+         }
+ 
+         bi_compute_interference(ctx, l, full_regs);
+-- 
+GitLab
+


### PR DESCRIPTION
Revert "pan/bi: Require ATEST coverage mask input in R60"
This reverts commit [7ead2568](https://gitlab.freedesktop.org/mesa/mesa/-/commit/7ead256891cec7a301d2fd415405a7f9106b1f46).

See [7025](https://gitlab.freedesktop.org/mesa/mesa/-/issues/7025) for the
details, but the short version is that this was causing a segfault.