### PR TITLE
pcre2: fix build on aarch64 without ncurses

### DIFF
--- a/packages/devel/pcre2/package.mk
+++ b/packages/devel/pcre2/package.mk
@@ -13,8 +13,19 @@ PKG_LONGDESC="A set of functions that implement regular expression pattern match
 PKG_TOOLCHAIN="cmake"
 PKG_BUILD_FLAGS="+pic"
 
+PKG_CMAKE_OPTS_HOST="-DBUILD_SHARED_LIBS=OFF \
+                     -DBUILD_STATIC_LIBS=ON \
+                     -DPCRE2_BUILD_PCRE2_8=ON \
+                     -DPCRE2_BUILD_PCRE2_16=ON \
+                     -DPCRE2_BUILD_PCRE2_32=ON \
+                     -DPCRE2_SUPPORT_JIT=ON \
+                     -DPCRE2_BUILD_TESTS=OFF \
+                     -DPCRE2_SUPPORT_LIBEDIT=OFF \
+                     -DPCRE2_SUPPORT_LIBREADLINE=OFF"
+
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
                        -DPCRE2_BUILD_PCRE2_16=ON \
+                       -DPCRE2_SUPPORT_LIBEDIT=OFF \
                        -DPCRE2_SUPPORT_LIBREADLINE=OFF"
 
 post_makeinstall_target() {


### PR DESCRIPTION
- Fixes #6782 build on aarch64 of pcre2

@pretoriano80 please check this works for you too.