### PR TITLE
Intel media-driver: update to 22.5.2

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.5.1"
-PKG_SHA256="17905258374dafe2051073fee5722527c6b756c111b2962af051b37d1fc0df56"
+PKG_VERSION="22.5.2"
+PKG_SHA256="3b53bb6fb7793ef6c498ff086327ceefeef0a72d1f41b1fcaeae552a694fbcd8"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
Log:
- https://github.com/intel/media-driver/compare/intel-media-22.5.1...intel-media-22.5.2

```
=== tested on ===
Generic.x86_64-devel-20220811100323-9998288
Linux nuc11 5.19.1-rc1 #1 SMP Wed Aug 10 13:46:15 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:80f18db9500c0738d3522f4efdf789aa012e9930). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-08-08 by GCC 12.1.1 for Linux x86 64-bit version 5.19.0 (332544)
Running on LibreELEC (heitbaum): devel-20220811100323-9998288 11.0, kernel: Linux x86 64-bit version 5.19.1-rc1
FFmpeg version/source: 4.4-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0046.2022.0608.1909 06/08/2022
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.1.6
libva info: VA-API version 1.15.0
vainfo: VA-API version: 1.15 (libva 2.15.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.5.2 (99982882fb)
```
