### PR TITLE
linux: update to 5.10.y

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="5.10.135"
-    PKG_SHA256="e499a61be9ce670716dd27b5124bb9ef6c6bc0e8fab443abf717a77136543344"
+    PKG_VERSION="5.10.142"
+    PKG_SHA256="3f47ebdb9afe152a0c32c1157336ef13fa5cc08ac6d884dfc1f6ddc2b7dba268"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v5.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Allwinner/patches/linux/crust/0036-firmware-arm_scpi-Support-unidirectional-mailbox-cha.patch
+++ b/projects/Allwinner/patches/linux/crust/0036-firmware-arm_scpi-Support-unidirectional-mailbox-cha.patch
@@ -55,13 +55,13 @@ Signed-off-by: Samuel Holland <samuel@sholland.org>
  
  static int scpi_remove(struct platform_device *pdev)
 @@ -903,6 +909,7 @@ static int scpi_probe(struct platform_de
- 	struct resource res;
  	struct device *dev = &pdev->dev;
  	struct device_node *np = dev->of_node;
+ 	struct scpi_drvinfo *scpi_drvinfo;
 +	bool use_mbox_names = false;
  
- 	scpi_info = devm_kzalloc(dev, sizeof(*scpi_info), GFP_KERNEL);
- 	if (!scpi_info)
+ 	scpi_drvinfo = devm_kzalloc(dev, sizeof(*scpi_drvinfo), GFP_KERNEL);
+ 	if (!scpi_drvinfo)
 @@ -916,6 +923,14 @@ static int scpi_probe(struct platform_de
  		dev_err(dev, "no mboxes property in '%pOF'\n", np);
  		return -ENODEV;


### PR DESCRIPTION
- 5.10.136
  - https://lore.kernel.org/lkml/20220809175512.853274191@linuxfoundation.org/
  - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.136
- 5.10.137 - 541 patches
  - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.137
- 5.10.138 - 157 patches
  - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.138
- 5.10.139 - 1 patch
  - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.139
- 5.10.140 - 86 patches
  - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.140
- 5.10.141 - 37 patches
  - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.141
- 5.10.142 - 80 patches
  - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.14#

errors / fixes / issues / regressions
- more speculation fixes https://www.phoronix.com/news/Linux-PBRSB-Mitigation

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.10.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-5.10.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/5.10

### 5.10.142-rc1 Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=Generic ARCH=x86_64 s/build linux
```

### 5.10.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel SKL - NUC6) - 5.10.142-rc1 - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche