### PR TITLE
[le11] wireless-regdb: update to 2022.08.12

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2022.06.06"
-PKG_SHA256="ac00f97efecce5046ed069d1d93f3365fdf994c7c7854a8fc50831e959537230"
+PKG_VERSION="2022.08.12"
+PKG_SHA256="59c8f7d17966db71b27f90e735ee8f5b42ca3527694a8c5e6e9b56bd379c3b84"
 PKG_LICENSE="GPL"
 PKG_SITE="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
log:
  wireless-regdb: update regulatory database based on preceding changes
  wireless-regdb: update 5 GHz rules for PK and add 60 GHz rule
  wireless-regdb: add 5 GHz rules for GY