### PR TITLE
[le11] libdrm: fix QA issues by conditionally removing test programs

### DIFF
--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -48,11 +48,13 @@ listcontains "${GRAPHIC_DRIVERS}" "etnaviv" &&
 
 post_makeinstall_target() {
   # Remove all test programs installed by install-test-programs=true except modetest
-  # Do not "not use" the ninja install and replace this with a simple "cp modetest"
-  # as ninja strips the unnecessary build rpath during the install.
-  safe_remove ${INSTALL}/usr/bin/amdgpu_stress
-  safe_remove ${INSTALL}/usr/bin/drmdevice
-  safe_remove ${INSTALL}/usr/bin/modeprint
-  safe_remove ${INSTALL}/usr/bin/proptest
-  safe_remove ${INSTALL}/usr/bin/vbltest
+  for PKG_LIBDRM_TEST in \
+    drmdevice modeprint proptest vbltest
+  do
+    safe_remove ${INSTALL}/usr/bin/${PKG_LIBDRM_TEST}
+  done
+
+  if listcontains "${GRAPHIC_DRIVERS}" "radeonsi"; then
+    safe_remove ${INSTALL}/usr/bin/amdgpu_stress
+  fi
 }


### PR DESCRIPTION
This hopefully fixes the _incredible important_ QA issues & removes a _blocker_ for a proper future release by conditionally removing `amdgpu_stress` which is only build if radeonsi flag is set. Otherwise e.g. ARM builds yield a QA issue message like:

```
<<< libdrm:target seq 208 <<<
INSTALL      libdrm (target)
[QA CHECK] [libdrm] [safe_remove]:
path does not exist: /build/LibreELEC-RR/build.LibreELEC-AMLGX.arm-11.0-devel/install_pkg/libdrm-2.4.112/usr/bin/amdgpu_stress

>>> libdrm:target seq 208 >>>
[208/441] [DONE] install libdrm:target
```

I'm not sure though if other projects yield different errors, I've tested Generic, RK3399, AMLGX and looks like they're fine.