### PR TITLE
scripts: suppress qa_check error message when no issues present

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -477,7 +477,7 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
   fi
 fi
 
-if [ -d "${BUILD}/qa_checks" -a -n "$(ls -1 ${BUILD}/qa_checks/)" ]; then
+if [ -n "$(ls -1 ${BUILD}/qa_checks/ 2>/dev/null)" ]; then
   log_qa_check "qa_issues" "QA issues present, please fix!\n$(find ${BUILD}/qa_checks/* -type f ! -name qa_issues)\n"
 fi
 


### PR DESCRIPTION
When no QA issues are present, an error message is output about not being able to `ls` a non-existent directory. This happens because the `[` test operator doesn't short-circuit, so it continues to evaluate the test, even though the first part was false.

This changes it to just route the error message to /dev/null. The alternative would be to use the `[[` operator, which I'm open to, but generally isn't used by the project.

Ref: #6666

