### PR TITLE
tz: update to 2022c

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2022b"
-PKG_SHA256="5da3fd3eb51d51d2aa4c599db8a1dd8dff453d79f4881131e35d40707ae1f838"
+PKG_VERSION="2022c"
+PKG_SHA256="067f0f4bee8e509b3eca502c5bd7c8f98073ab49b6c05654a157cbffd07aa3a4"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Minor update
- https://mm.icann.org/pipermail/tz-announce/2022-August/000072.html

The 2022c release of the tz code and data is available.

This release reflects the following changes, which do not affect
timestamps unless your system has the awk bug mentioned below:

   Briefly:
     Work around awk bug in FreeBSD, macOS, etc.
     Improve tzselect on intercontinental Zones.

   Changes to code

     Work around a bug in onetrueawk that broke commands like
     'make traditional_tarballs' on FreeBSD, macOS, etc.
     (Problem reported by Deborah Goldsmith.)

     Add code to tzselect that uses experimental structured comments in
     zone1970.tab to clarify whether Zones like Africa/Abidjan and
     Europe/Istanbul cross continent or ocean boundaries.
     (Inspired by a problem reported by Peter Krefting.)

     Fix bug with 'zic -d /a/b/c' when /a is unwritable but the
     directory /a/b already exists.

     Remove zoneinfo2tdf.pl, as it was unused and triggered false
     malware alarms on some email servers.