### PR TITLE
Miscellaneous package updates

### DIFF
--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -2,20 +2,20 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.2.5"
-PKG_SHA256="edf1e1035c020c23874561cab3f97fd1d8ed11221c47177a1bc178eb971fd351"
+PKG_VERSION="3.2.7"
+PKG_SHA256="3c91df959d61cf64957faf633569ccd78e207abd600a2907081845fa47dff5ee"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://mariadb.org/"
-PKG_URL="https://github.com/MariaDB/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain zlib openssl"
 PKG_LONGDESC="mariadb-connector: library to conntect to mariadb/mysql database server"
 PKG_BUILD_FLAGS="-gold"
 
 PKG_CMAKE_OPTS_TARGET="-DWITH_EXTERNAL_ZLIB=ON
-                       -DAUTH_CLEARTEXT=STATIC
-                       -DAUTH_DIALOG=STATIC
-                       -DAUTH_OLDPASSWORD=STATIC
-                       -DREMOTEIO=OFF
+                       -DCLIENT_PLUGIN_DIALOG=STATIC
+                       -DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=STATIC
+                       -DCLIENT_PLUGIN_MYSQL_OLD_PASSWORD=STATIC
+                       -DCLIENT_PLUGIN_REMOTE_IO=OFF
                       "
 
 post_makeinstall_target() {

--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="boost"
-PKG_VERSION="1.79.0"
-PKG_SHA256="475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39"
+PKG_VERSION="1.80.0"
+PKG_SHA256="1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.boost.org/"
 PKG_URL="https://boostorg.jfrog.io/artifactory/main/release/${PKG_VERSION}/source/${PKG_NAME}_${PKG_VERSION//./_}.tar.bz2"
@@ -21,7 +21,7 @@ make_host() {
 
 makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/bin
-    cp bjam ${TOOLCHAIN}/bin
+    cp b2 ${TOOLCHAIN}/bin
 }
 
 pre_configure_target() {
@@ -31,7 +31,7 @@ pre_configure_target() {
 
 configure_target() {
   sh bootstrap.sh --prefix=/usr \
-                  --with-bjam=${TOOLCHAIN}/bin/bjam \
+                  --with-bjam=${TOOLCHAIN}/bin/b2 \
                   --with-python=${TOOLCHAIN}/bin/python \
                   --with-python-root=${SYSROOT_PREFIX}/usr
 
@@ -42,19 +42,19 @@ configure_target() {
 }
 
 makeinstall_target() {
-  ${TOOLCHAIN}/bin/bjam -d2 --ignore-site-config \
-                          --layout=system \
-                          --prefix=${SYSROOT_PREFIX}/usr \
-                          --toolset=gcc link=static \
-                          --with-chrono \
-                          --with-date_time \
-                          --with-filesystem \
-                          --with-iostreams \
-                          --with-python \
-                          --with-random \
-                          --with-regex -sICU_PATH="${SYSROOT_PREFIX}/usr" \
-                          --with-serialization \
-                          --with-system \
-                          --with-thread \
-                          install
+  ${TOOLCHAIN}/bin/b2 -d2 --ignore-site-config \
+                      --layout=system \
+                      --prefix=${SYSROOT_PREFIX}/usr \
+                      --toolset=gcc link=static \
+                      --with-chrono \
+                      --with-date_time \
+                      --with-filesystem \
+                      --with-iostreams \
+                      --with-python \
+                      --with-random \
+                      --with-regex -sICU_PATH="${SYSROOT_PREFIX}/usr" \
+                      --with-serialization \
+                      --with-system \
+                      --with-thread \
+                      install
 }

--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.0.22"
-PKG_SHA256="fe7cbf3127882e3fc7259a75a0cb585620272c51745d3852ab9dd87960697f2e"
+PKG_VERSION="2.24.0"
+PKG_SHA256="91e4c34b1768f92d399b078e171448c6af18cafda743987ed2064a28954d6d97"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
 PKG_URL="https://www.libsdl.org/release/${PKG_NAME}-${PKG_VERSION}.tar.gz"
@@ -14,91 +14,88 @@ PKG_BUILD_FLAGS="+pic"
 
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" nasm:host"
-  PKG_SDL2_X86ASM="-DASSEMBLY=ON"
+  PKG_SDL2_X86ASM="-DSDL_ASSEMBLY=ON"
 else
   # Only x86(-64) and ppc assembly present as of 2.0.8
-  PKG_SDL2_X86ASM="-DASSEMBLY=OFF"
+  PKG_SDL2_X86ASM="-DSDL_ASSEMBLY=OFF"
 fi
 
 PKG_CMAKE_OPTS_TARGET="-DSDL_STATIC=ON \
                        -DSDL_SHARED=OFF \
-                       -DLIBC=ON \
-                       -DGCC_ATOMICS=ON \
+                       -DSDL_LIBC=ON \
+                       -DSDL_GCC_ATOMICS=ON \
                        ${PKG_SDL2_X86ASM} \
-                       -DALTIVEC=OFF \
-                       -DOSS=OFF \
-                       -DALSA=ON \
-                       -DALSA_SHARED=ON \
-                       -DESD=OFF \
-                       -DESD_SHARED=OFF \
-                       -DARTS=OFF \
-                       -DARTS_SHARED=OFF \
-                       -DNAS=OFF \
-                       -DNAS_SHARED=ON \
-                       -DSNDIO=OFF \
-                       -DDISKAUDIO=OFF \
-                       -DDUMMYAUDIO=OFF \
-                       -DVIDEO_WAYLAND=OFF \
-                       -DVIDEO_WAYLAND_QT_TOUCH=ON \
-                       -DWAYLAND_SHARED=OFF \
-                       -DVIDEO_MIR=OFF \
-                       -DMIR_SHARED=OFF \
-                       -DVIDEO_COCOA=OFF \
-                       -DVIDEO_DIRECTFB=OFF \
-                       -DDIRECTFB_SHARED=OFF \
-                       -DFUSIONSOUND=OFF \
-                       -DFUSIONSOUND_SHARED=OFF \
-                       -DVIDEO_DUMMY=OFF \
-                       -DINPUT_TSLIB=OFF \
-                       -DPTHREADS=ON \
-                       -DPTHREADS_SEM=ON \
-                       -DDIRECTX=OFF \
-                       -DSDL_DLOPEN=ON \
-                       -DCLOCK_GETTIME=OFF \
-                       -DRPATH=OFF \
-		       -DVIDEO_KMSDRM=OFF \
-                       -DRENDER_D3D=OFF"
+                       -DSDL_ALTIVEC=OFF \
+                       -DSDL_OSS=OFF \
+                       -DSDL_ALSA=ON \
+                       -DSDL_ALSA_SHARED=ON \
+                       -DSDL_ESD=OFF \
+                       -DSDL_ESD_SHARED=OFF \
+                       -DSDL_ARTS=OFF \
+                       -DSDL_ARTS_SHARED=OFF \
+                       -DSDL_NAS=OFF \
+                       -DSDL_NAS_SHARED=ON \
+                       -DSDL_SNDIO=OFF \
+                       -DSDL_DISKAUDIO=OFF \
+                       -DSDL_DUMMYAUDIO=OFF \
+                       -DSDL_WAYLAND=OFF \
+                       -DSDL_WAYLAND_QT_TOUCH=ON \
+                       -DSDL_WAYLAND_SHARED=OFF \
+                       -DSDL_COCOA=OFF \
+                       -DSDL_DIRECTFB=OFF \
+                       -DSDL_DIRECTFB_SHARED=OFF \
+                       -DSDL_FUSIONSOUND=OFF \
+                       -DSDL_FUSIONSOUND_SHARED=OFF \
+                       -DSDL_DUMMYVIDEO=OFF \
+                       -DSDL_PTHREADS=ON \
+                       -DSDL_PTHREADS_SEM=ON \
+                       -DSDL_DIRECTX=OFF \
+                       -DSDL_LOADSO=ON \
+                       -DSDL_CLOCK_GETTIME=OFF \
+                       -DSDL_RPATH=OFF \
+                       -DSDL_KMSDRM=OFF \
+                       -DSDL_RENDER_D3D=OFF"
 
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET+=" libX11 libXrandr"
 
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_TARGET} \
-                         -DVIDEO_X11=ON \
-                         -DX11_SHARED=ON \
-                         -DVIDEO_X11_XCURSOR=OFF \
-                         -DVIDEO_X11_XINERAMA=OFF \
-                         -DVIDEO_X11_XINPUT=OFF \
-                         -DVIDEO_X11_XRANDR=ON \
-                         -DVIDEO_X11_XSCRNSAVER=OFF \
-                         -DVIDEO_X11_XSHAPE=OFF \
-                         -DVIDEO_X11_XVM=OFF"
+                         -DSDL_X11=ON \
+                         -DSDL_X11_SHARED=ON \
+                         -DSDL_X11_XCURSOR=OFF \
+                         -DSDL_X11_XINERAMA=OFF \
+                         -DSDL_X11_XINPUT=OFF \
+                         -DSDL_X11_XRANDR=ON \
+                         -DSDL_X11_XSCRNSAVER=OFF \
+                         -DSDL_X11_XSHAPE=OFF \
+                         -DSDL_X11_XVM=OFF"
 else
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_TARGET} \
-                         -DVIDEO_X11=OFF"
+                         -DSDL_X11=OFF"
 fi
 
 if [ ! "${OPENGL}" = "no" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL}"
 
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_TARGET} \
-                         -DVIDEO_OPENGL=ON \
-                         -DVIDEO_OPENGLES=OFF"
+                         -DSDL_OPENGL=ON \
+                         -DSDL_OPENGLES=OFF"
 else
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_TARGET} \
-                         -DVIDEO_OPENGL=OFF \
-                         -DVIDEO_OPENGLES=ON"
+                         -DSDL_OPENGL=OFF \
+                         -DSDL_OPENGLES=ON"
 fi
 
 if [ "${PULSEAUDIO_SUPPORT}" = yes ]; then
   PKG_DEPENDS_TARGET+=" pulseaudio"
 
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_TARGET} \
-                         -DPULSEAUDIO=ON \
-                         -DPULSEAUDIO_SHARED=ON"
+                         -DSDL_PULSEAUDIO=ON \
+                         -DSDL_PULSEAUDIO_SHARED=ON"
 else
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_TARGET} \
-                         -DPULSEAUDIO=OFF \
-                         -DPULSEAUDIO_SHARED=OFF"
+                         -DSDL_PULSEAUDIO=OFF \
+                         -DSDL_PULSEAUDIO_SHARED=OFF"
 fi
 
 post_makeinstall_target() {

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.9.14"
-PKG_SHA256="9bd7dae7690b2112033ddb6ad4f454e036fff2d38505c3a5b80427669484c0a4"
+PKG_VERSION="2.10.0"
+PKG_SHA256="c44124d025162767a1d3fe35b556c5855e6be7240e3dc3159490e91d5cadbba3"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"

--- a/packages/textproc/libxslt/package.mk
+++ b/packages/textproc/libxslt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxslt"
-PKG_VERSION="1.1.35"
-PKG_SHA256="2da1c2954f8a4e844f9d4e9110d1b31d45e7a5f8e9edc61823984861505e6e5d"
+PKG_VERSION="1.1.36"
+PKG_SHA256="9798e44a5fb0720cbda8a2323bb0e1db219659e9cd14fa4d73ee251ec281b3d4"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org/xslt/"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- mariadb-connector-c: update to 3.2.7 and fix cmake build options
- SDL2: update to 2.24.0 and clean up build options
- boost: update to 1.80.0 and swap from bjam (deprecated) to b2
  - https://www.boost.org/users/history/version_1_80_0.html
- libxslt: update to 1.1.36
  - https://gitlab.gnome.org/GNOME/libxslt/-/commit/bcd17763a9f371ec5c9bdce0ffa2f2eb3ef74c43
- libxml2: update to 2.10.0
  - https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/NEWS
