### PR TITLE
estouchy: build standalone

### DIFF
--- a/packages/addons/skin/estouchy/package.mk
+++ b/packages/addons/skin/estouchy/package.mk
@@ -8,7 +8,8 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="kodi"
+PKG_DEPENDS_TARGET="TexturePacker:host"
+PKG_DEPENDS_UNPACK="kodi"
 PKG_SECTION="skin"
 PKG_SHORTDESC="Kodi skin Estouchy"
 PKG_LONGDESC="Kodi skin Estouchy"
@@ -18,7 +19,13 @@ PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Estouchy"
 PKG_ADDON_TYPE="xbmc.gui.skin"
 
+make_target() {
+  TexturePacker -dupecheck -input $(get_build_dir kodi)/addons/skin.estouchy/media/ -output Textures.xbt
+}
+
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}
-    cp -a $(get_install_dir kodi)/.noinstall/skin.estouchy/* ${ADDON_BUILD}/${PKG_ADDON_ID}
+    cp -a $(get_build_dir kodi)/addons/skin.estouchy/* ${ADDON_BUILD}/${PKG_ADDON_ID}
+	rm -rf ${ADDON_BUILD}/${PKG_ADDON_ID}/media/*
+	cp ${PKG_BUILD}/Textures.xbt ${ADDON_BUILD}/${PKG_ADDON_ID}/media
 }


### PR DESCRIPTION
Build estouchy standalone rather that kodi builds it and we copy it from the kodi build dir.
- Kodi is now not required to build estouchy addon
- use TexturePacker to create texture.xbt

Allows #6425 to drop additional deps.


Could not check yet with a full build LE but should work there too.