### PR TITLE
Ethtool and Wireless Driver updates

### DIFF
--- a/packages/linux-drivers/RTL8192DU/package.mk
+++ b/packages/linux-drivers/RTL8192DU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8192DU"
-PKG_VERSION="b38a1127eb0fabead2a8e5dcf952e44c09336b6b"
-PKG_SHA256="0b5c7ac16da7bfde3fdc9bf91763a453d1ef05b8d6e2ea07be18ea845cba2465"
+PKG_VERSION="176e190a5af8f6dfe624e67860483b46986bbd47"
+PKG_SHA256="99b905272129e9df5358081f98f113427e1516e1c135ecd190a4c7f2f3bf55fa"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/lwfinger/rtl8192du"
 PKG_URL="https://github.com/lwfinger/rtl8192du/archive/${PKG_VERSION}.tar.gz"

--- a/packages/linux-drivers/RTL8812AU/package.mk
+++ b/packages/linux-drivers/RTL8812AU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8812AU"
-PKG_VERSION="cab4e4ec56884f65e0c279c1b5ceaf70dbe79be0"
-PKG_SHA256="20b498bc597e5343ee6c240eabd45c36894db86c76f6bfc100448c8b9c420733"
+PKG_VERSION="e7a4a390ccbdd768411e1b2a8922c47837f76b47"
+PKG_SHA256="eed4888da9cfdc0f83ad3335beaf73af33ce0796b0a2637aeec102d47e1eb8f0"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/aircrack-ng/rtl8812au"
 PKG_URL="https://github.com/aircrack-ng/rtl8812au/archive/${PKG_VERSION}.tar.gz"

--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-0600-kernel-6.0-fix.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-0600-kernel-6.0-fix.patch
@@ -1,0 +1,17 @@
+diff -Nur a/x86-64/src/wl/sys/wl_cfg80211_hybrid.c b/x86-64/src/wl/sys/wl_cfg80211_hybrid.c
+--- a/x86-64/src/wl/sys/wl_cfg80211_hybrid.c	2022-08-15 14:06:51.943852581 +0000
++++ b/x86-64/src/wl/sys/wl_cfg80211_hybrid.c	2022-08-15 14:24:49.917982457 +0000
+@@ -2393,8 +2393,13 @@
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+ 	{
+ 		struct cfg80211_roam_info roam_info = {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
++			.links[0].channel = &wl->conf->channel,
++			.links[0].bssid = (u8 *)&wl->bssid,
++#else
+ 			.channel = &wl->conf->channel,
+ 			.bssid = (u8 *)&wl->bssid,
++#endif
+ 			.req_ie = conn_info->req_ie,
+ 			.req_ie_len = conn_info->req_ie_len,
+ 			.resp_ie = conn_info->resp_ie,

--- a/packages/network/ethtool/package.mk
+++ b/packages/network/ethtool/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ethtool"
-PKG_VERSION="5.18"
-PKG_SHA256="9577b2ffbce710b659fb239598ec92bced1ca400ca0f1286762bfa44e4784270"
+PKG_VERSION="5.19"
+PKG_SHA256="3b752a3329827907ac3812f2831dfecf51c8c41c55d2d69cfb9c53ca06449fc6"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/pub/software/network/ethtool/"
 PKG_URL="https://www.kernel.org/pub/software/network/ethtool/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- ethtool: update to 5.19
  - LOG: https://git.kernel.org/pub/scm/network/ethtool/ethtool.git
- bcm_sta: patch to compile with Linux 6.0
- RTL8812AU: update to githash 20220827
  - also supports kernels 5.19.2 and 6.0 
- RTL8192DU: update to githash 20220819
  - also supports kernels 5.19.2 and 6.0