### PR TITLE
Library updates

### DIFF
--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.6.4"
-PKG_SHA256="e09fb845c3292700a7ac13c3b31d669ecd3bdbebcbfe1328eba2376cebe40162"
+PKG_VERSION="0.6.5"
+PKG_SHA256="f22abe977cdae405f685b75150e7fb155b2c7896b4700fd54abe68840f66e9c0"
 PKG_LICENSE="BSD"
 PKG_SITE="https://lib.openmpt.org/libopenmpt/"
 PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/graphics/libglvnd/package.mk
+++ b/packages/graphics/libglvnd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libglvnd"
-PKG_VERSION="1.4.0"
-PKG_SHA256="1eb5c2be8d213ad5d31cfb4efbb331d42f3d9f5617c885ce7e89f572ec2bb4b8"
+PKG_VERSION="1.5.0"
+PKG_SHA256="abdf8229c86358f651e35bdc7cfced0fdf67d0a2acdf9197d08a9732ef7b53bc"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/NVIDIA/libglvnd"
 PKG_URL="https://github.com/NVIDIA/libglvnd/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libssh"
-PKG_VERSION="0.9.6"
-PKG_SHA256="86bcf885bd9b80466fe0e05453c58b877df61afa8ba947a58c356d7f0fab829b"
+PKG_VERSION="0.10.0"
+PKG_SHA256="0dc158c534cd838ad0b785a82dec586de40da7e096523ae6c08c9b7bd2af0b57"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libssh.org/"
 PKG_URL="https://www.libssh.org/files/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -14,6 +14,7 @@ PKG_LONGDESC="Library for accessing ssh client services through C libraries."
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
                        -DWITH_SERVER=OFF \
                        -DWITH_GCRYPT=OFF \
+                       -DWITH_EXAMPLES=OFF \
                        -DWITH_GSSAPI=OFF \
                        -DWITH_GEX=OFF \
                        -DWITH_INTERNAL_DOC=OFF"

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.10.0"
-PKG_SHA256="c44124d025162767a1d3fe35b556c5855e6be7240e3dc3159490e91d5cadbba3"
+PKG_VERSION="2.10.1"
+PKG_SHA256="0c9dea77d18ad9a9d77d8cb745365907fc2c0bad64e3cd04dab0bd9d253bac2e"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.10.1"
-PKG_SHA256="0c9dea77d18ad9a9d77d8cb745365907fc2c0bad64e3cd04dab0bd9d253bac2e"
+PKG_VERSION="2.10.2"
+PKG_SHA256="d50e8a55b2797501929d3411b81d5d37ec44e9a4aa58eae9052572977c632d7a"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"

--- a/packages/textproc/libxslt/package.mk
+++ b/packages/textproc/libxslt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxslt"
-PKG_VERSION="1.1.36"
-PKG_SHA256="9798e44a5fb0720cbda8a2323bb0e1db219659e9cd14fa4d73ee251ec281b3d4"
+PKG_VERSION="1.1.37"
+PKG_SHA256="6dbeb21aa8c938e6a39010901c0e84122bb87225b4af31f76feb4e3a5b138a5c"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org/xslt/"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- libglvnd: update to 1.5.0
  - https://github.com/NVIDIA/libglvnd/compare/v1.4.0...v1.5.0
- libxml2: update to 2.10.2
  - https://gitlab.gnome.org/GNOME/libxml2/-/releases
- libxslt: update to 1.1.37
  - https://gitlab.gnome.org/GNOME/libxslt/-/blob/master/NEWS
- libopenmpt: update to 0.6.5
  - https://lib.openmpt.org/libopenmpt/2022/08/21/releases-0.6.5-0.5.19-0.4.31-0.3.39/
- libssh: update to 0.10.0 and dont build examples
  - https://git.libssh.org/projects/libssh.git/tag/?h=libssh-0.10.0
