### PR TITLE
migrate to cmake and meson builds

### DIFF
--- a/packages/graphics/lcms2/package.mk
+++ b/packages/graphics/lcms2/package.mk
@@ -10,7 +10,5 @@ PKG_URL="https://github.com/mm2/Little-CMS/releases/download/lcms${PKG_VERSION}/
 PKG_DEPENDS_TARGET="toolchain tiff"
 PKG_LONGDESC="An small-footprint color management engine, with special focus on accuracy and performance."
 PKG_BUILD_FLAGS="+pic"
-PKG_TOOLCHAIN="autotools"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
-                           --enable-static"
+PKG_MESON_OPTS_TARGET="--default-library static"

--- a/packages/textproc/jsoncpp/package.mk
+++ b/packages/textproc/jsoncpp/package.mk
@@ -10,11 +10,7 @@ PKG_SITE="https://github.com/open-source-parsers/jsoncpp/"
 PKG_URL="https://github.com/open-source-parsers/jsoncpp/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A C++ library for interacting with JSON."
-PKG_TOOLCHAIN="cmake"
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CMAKE_OPTS_TARGET="-DJSONCPP_WITH_TESTS=OFF \
-                       -DJSONCPP_WITH_EXAMPLE=OFF \
-                       -DBUILD_SHARED_LIBS=OFF \
-                       -DBUILD_STATIC_LIBS=ON \
-                       -DBUILD_OBJECT_LIBS=OFF"
+PKG_MESON_OPTS_TARGET="-Dtests=false \
+                       --default-library static"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -9,9 +9,12 @@ PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="nghttp2 is an implementation of HTTP/2 and its header compression algorithm, HPACK."
-PKG_TOOLCHAIN="configure"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-lib-only"
+PKG_CMAKE_OPTS_TARGET="-DENABLE_DOC=OFF \
+                       -DENABLE_FAILMALLOC=OFF \
+                       -DENABLE_LIB_ONLY=ON \
+                       -DENABLE_SHARED_LIB=ON \
+                       -DENABLE_STATIC_LIB=OFF"
 
 post_makeinstall_target() {
   rm -r "${INSTALL}/usr/share"


### PR DESCRIPTION
- [lcms2: migrate to meson build](https://github.com/LibreELEC/LibreELEC.tv/commit/a260370bbf2b650fd764b2b0bcdacf653813f890)
  - 768k meson
  - 3772k autotools (768k after removing bin files)
- [jsoncpp: migrate to meson build](https://github.com/LibreELEC/LibreELEC.tv/commit/c2ca0ff90e879f60030f23d75d6b2900c96a9f3e)
  - 552k cmake release
  - 520k meson
- [nghttp2: migrate to cmake build](https://github.com/LibreELEC/LibreELEC.tv/commit/833b671f5c09625b0f63b6485d7861a2a35857ca)
  - 408k cmake release 
  - 412k configure



- part of #5970 