### PR TITLE
samba: fix dcerpc and srvsvc browsing

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -84,7 +84,7 @@ configure_package() {
   PKG_SAMBA_TARGET="smbclient,client/smbclient,smbtree,nmblookup,testparm"
 
   if [ "${SAMBA_SERVER}" = "yes" ]; then
-    PKG_SAMBA_TARGET+=",smbd/smbd,nmbd,smbpasswd"
+    PKG_SAMBA_TARGET+=",nmbd,rpcd_classic,rpcd_epmapper,rpcd_winreg,samba-dcerpcd,smbpasswd,smbd/smbd"
   fi
 }
 
@@ -155,6 +155,12 @@ perform_manual_install() {
     mkdir -p ${INSTALL}/usr/sbin
       cp -L ${PKG_BUILD}/bin/smbd ${INSTALL}/usr/sbin
       cp -L ${PKG_BUILD}/bin/nmbd ${INSTALL}/usr/sbin
+
+    mkdir -p ${INSTALL}/usr/libexec/samba
+      cp -PR bin/default/source3/rpc_server/samba-dcerpcd ${INSTALL}/usr/libexec/samba
+      cp -PR bin/default/source3/rpc_server/rpcd_classic ${INSTALL}/usr/libexec/samba
+      cp -PR bin/default/source3/rpc_server/rpcd_epmapper ${INSTALL}/usr/libexec/samba
+      cp -PR bin/default/source3/rpc_server/rpcd_winreg ${INSTALL}/usr/libexec/samba
   fi
 }
 


### PR DESCRIPTION
Samba browsing in LibreELEC 11.0 has been not working since samba 4.16.

- fix #6241 and #6719 

by adding the `samba-dcerpcd` to support `DCERPC` in the member server setup.

DCERPC services have been broken out from smbd, the new samba-dcerpcd binary has been created.

It is invoked (in LE) on demand from smbd to serve DCERPC over named pipes. The required rpc_ service binaries are also required. 

```
# smbclient -U libreelec -L localhost
Password for [WORKGROUP\libreelec]:

        Sharename       Type      Comment
        ---------       ----      -------
        Update          Disk      
        Videos          Disk      
        Music           Disk      
        TV Shows        Disk      
        Recordings      Disk
…
```