### PR TITLE
Miscellaneous package updates

### DIFF
--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.12.0"
-PKG_SHA256="e1ac2abb354fdc8ccdca71363ebad7503ad731c84022cf460837f0839e171718"
+PKG_VERSION="1.13.0"
+PKG_SHA256="c20ae01bace39e89298f6352f1ff4a54b415b33b9743902da798e8a1e51d7ca1"
 PKG_LICENSE="LGPLv3"
-PKG_SITE="http://www.libde265.org"
+PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libde265 libjpeg-turbo libpng"
 PKG_LONGDESC="A HEIF file format decoder and encoder."

--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.1.7"
-PKG_SHA256="08a378671971a1777ca60f87e39fd7d7cbba94e485a1f5f64fe4840ff9d2ac2d"
+PKG_VERSION="22.1.8"
+PKG_SHA256="bf23e9a3742b4fb98c7666c9e9b29f3219e4b2fb4d831aaf4eed71f5e2d17368"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libssh"
-PKG_VERSION="0.10.0"
-PKG_SHA256="0dc158c534cd838ad0b785a82dec586de40da7e096523ae6c08c9b7bd2af0b57"
+PKG_VERSION="0.10.2"
+PKG_SHA256="15b83d7b74c8c67f758fb32faf1d9a35d5f8f50db523276a419e9876530f098a"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libssh.org/"
 PKG_URL="https://www.libssh.org/files/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Mako"
-PKG_VERSION="1.2.1"
-PKG_SHA256="f054a5ff4743492f1aa9ecc47172cb33b42b9d993cffcc146c9de17e717b0307"
+PKG_VERSION="1.2.2"
+PKG_SHA256="3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/Mako"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/ninja/package.mk
+++ b/packages/python/devel/ninja/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ninja"
-PKG_VERSION="1.11.0"
-PKG_SHA256="3c6ba2e66400fe3f1ae83deb4b235faf3137ec20bd5b08c29bfc368db143e4c6"
+PKG_VERSION="1.11.1"
+PKG_SHA256="31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea"
 PKG_LICENSE="Apache"
 PKG_SITE="https://ninja-build.org/"
 PKG_URL="https://github.com/ninja-build/ninja/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- libssh: update to 0.10.2
- gmmlib: update to 22.1.8
- libheif: update to 1.13.0 and https
- ninja: update to 1.11.1
- Mako: update to 1.2.2