### PR TITLE
More migrate to cmake builds

### DIFF
--- a/packages/graphics/libde265/package.mk
+++ b/packages/graphics/libde265/package.mk
@@ -10,18 +10,8 @@ PKG_URL="https://github.com/strukturag/libde265/releases/download/v${PKG_VERSION
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Open h.265 video codec implementation."
 PKG_BUILD_FLAGS="+pic"
-PKG_TOOLCHAIN="configure"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared \
-                           --disable-encoder \
-                           --disable-sherlock265"
-
-pre_configure_target() {
-  cd ..
-  ./autogen.sh
-}
-
-post_configure_target() {
-  libtool_remove_rpath libtool
-}
+PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
+                       -DENABLE_SDL=OFF \
+                       -DENABLE_DECODER=OFF \
+                       -DENABLE_ENCODER=OFF"

--- a/packages/graphics/libde265/patches/libde265-0001-275-Add-CMake-option-ENABLE-SDL.patch
+++ b/packages/graphics/libde265/patches/libde265-0001-275-Add-CMake-option-ENABLE-SDL.patch
@@ -1,0 +1,53 @@
+From 48056f2eb5ed03be0589bbe335dcdaa676604b28 Mon Sep 17 00:00:00 2001
+From: theirix <theirix@gmail.com>
+Date: Sat, 31 Oct 2020 11:57:33 +0300
+Subject: [PATCH 1/2] Add CMake option DISABLE_SDL
+
+---
+ CMakeLists.txt | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e9f64fe6..c836a9a9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,7 +20,12 @@ include (${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
+ include(GNUInstallDirs)
+ include(CheckFunctionExists)
+ 
+-find_package(SDL)
++option(DISABLE_SDL "Disable SDL" OFF)
++
++if (NOT DISABLE_SDL)
++	find_package(SDL)
++endif()
++
+ find_package(Threads REQUIRED)
+ 
+ CHECK_INCLUDE_FILE(malloc.h HAVE_MALLOC_H)
+
+From c754a0342fe9bbd74bbb90d7244777cb6370804a Mon Sep 17 00:00:00 2001
+From: theirix <theirix@gmail.com>
+Date: Mon, 2 Nov 2020 19:03:05 +0300
+Subject: [PATCH 2/2] Use ENABLE_SDL instead of DISABLE_SDL
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c836a9a9..ac9d3ce8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,9 +20,9 @@ include (${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
+ include(GNUInstallDirs)
+ include(CheckFunctionExists)
+ 
+-option(DISABLE_SDL "Disable SDL" OFF)
++option(ENABLE_SDL "Enable SDL" ON)
+ 
+-if (NOT DISABLE_SDL)
++if (ENABLE_SDL)
+ 	find_package(SDL)
+ endif()
+ 

--- a/packages/graphics/libde265/patches/libde265-0002-Add-CMake-option-ENABLE-ENCODER.patch
+++ b/packages/graphics/libde265/patches/libde265-0002-Add-CMake-option-ENABLE-ENCODER.patch
@@ -1,0 +1,26 @@
+commit 657a6ea9161d1afe780bb46c4df0e95473353e6b
+Author: Rudi Heitbaum <rudi@heitbaum.com>
+Date:   Sun Sep 4 00:45:25 2022 +0000
+
+    Add CMake options ENABLE_DECODER and ENABLE_ENCODER
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ff93c52..160dbb1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -68,6 +68,13 @@ if(MSVC)
+   add_definitions(-DHAVE_STDBOOL_H)
+ endif()
+ 
++option(ENABLE_DECODER "Enable Decoder" ON)
++option(ENABLE_ENCODER "Enable Encoder" ON)
++
+ add_subdirectory (libde265)
+-add_subdirectory (dec265)
+-add_subdirectory (enc265)
++if (ENABLE_DECODER)
++  add_subdirectory (dec265)
++endif()
++if (ENABLE_ENCODER)
++  add_subdirectory (enc265)
++endif()

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -10,13 +10,9 @@ PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}
 PKG_DEPENDS_TARGET="toolchain libde265 libjpeg-turbo libpng"
 PKG_LONGDESC="A HEIF file format decoder and encoder."
 PKG_BUILD_FLAGS="+pic"
-PKG_TOOLCHAIN="configure"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared \
-                           --disable-go \
-                           --disable-examples \
-                           --disable-tests"
+PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
+                       -DWITH_EXAMPLES=OFF"
 
 pre_configure_target() {
   export CXXFLAGS="${CXXFLAGS} -Wno-unused-variable"

--- a/packages/graphics/tiff/package.mk
+++ b/packages/graphics/tiff/package.mk
@@ -10,21 +10,17 @@ PKG_SITE="http://www.remotesensing.org/libtiff/"
 PKG_URL="http://download.osgeo.org/libtiff/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libjpeg-turbo zlib"
 PKG_LONGDESC="libtiff is a library for reading and writing TIFF files."
-PKG_BUILD_FLAGS="+pic"
-PKG_TOOLCHAIN="configure"
+PKG_BUILD_FLAGS="+pic -gold"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared \
-                           --disable-mdi \
-                           --disable-jbig \
-                           --disable-lzma \
-                           --disable-zstd \
-                           --disable-webp \
-                           --enable-cxx \
-                           --with-jpeg-lib-dir=${SYSROOT_PREFIX}/usr/lib \
-                           --with-jpeg-include-dir=${SYSROOT_PREFIX}/usr/include \
-                           --without-x"
-
-post_makeinstall_target() {
-  rm -rf ${INSTALL}/usr/bin
-}
+PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
+                       -Dtiff-tools=OFF \
+                       -Dtiff-tests=OFF \
+                       -Dtiff-contrib=OFF \
+                       -Dtiff-docs=OFF \
+                       -Dmdi=OFF \
+                       -Djbig=OFF \
+                       -Dlzma=OFF \
+                       -Dzstd=OFF \
+                       -Dwebp=OFF \
+                       -Dcxx=ON \
+                       -Djpeg=ON"

--- a/packages/graphics/tiff/patches/tiff-0001-only-build-library.patch
+++ b/packages/graphics/tiff/patches/tiff-0001-only-build-library.patch
@@ -1,0 +1,70 @@
+From 1ab0e2696a368a556b793a0941b5365e4d9f56ef Mon Sep 17 00:00:00 2001
+From: Roger Leigh <rleigh@codelibre.net>
+Date: Sun, 29 May 2022 11:18:42 +0100
+Subject: [PATCH] Add options for disabling tools, tests, contrib and docs
+
+---
+ CMakeLists.txt               | 33 +++++++++++++++++++++------
+ 1 files changed
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 770b0fac..d1dd275e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,10 +42,16 @@ message(STATUS "libtiff build date: ${BUILD_DATE}")
+ 
+ set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
+ 
++option(tiff-tools "build TIFF tools" ON)
++option(tiff-tests "build TIFF tests" ON)
++option(tiff-contrib "build TIFF contrib" ON)
++option(tiff-docs "build TIFF documentation" ON)
++option(tiff-deprecated "build TIFF deprecated features" OFF)
+ 
+ # Disable deprecated features to ensure clean build
+-add_definitions(-DTIFF_DISABLE_DEPRECATED)
+-
++if (tiff-deprecated)
++  add_definitions(-DTIFF_DISABLE_DEPRECATED)
++endif()
+ 
+ # Project definition
+ set(CMAKE_C_STANDARD 99)
+@@ -135,12 +141,20 @@ include(Release)
+ # Process subdirectories
+ add_subdirectory(port)
+ add_subdirectory(libtiff)
+-add_subdirectory(tools)
+-add_subdirectory(test)
+-add_subdirectory(contrib)
++if(tiff-tools)
++  add_subdirectory(tools)
++endif()
++if(tiff-tests)
++  add_subdirectory(test)
++endif()
++if(tiff-contrib)
++  add_subdirectory(contrib)
++endif()
+ add_subdirectory(build)
+-add_subdirectory(man)
+-add_subdirectory(html)
++if(tiff-docs)
++  add_subdirectory(man)
++  add_subdirectory(html)
++endif()
+ 
+ # pkg-config support
+ include(PkgConfig)
+@@ -153,6 +167,11 @@ message(STATUS "  Documentation directory:            ${LIBTIFF_DOCDIR}")
+ message(STATUS "  C compiler:                         ${CMAKE_C_COMPILER}")
+ message(STATUS "  C++ compiler:                       ${CMAKE_CXX_COMPILER}")
+ message(STATUS "  Build shared libraries:             ${BUILD_SHARED_LIBS}")
++message(STATUS "  Build tools:                        ${tiff-tools}")
++message(STATUS "  Build tests:                        ${tiff-tests}")
++message(STATUS "  Build contrib:                      ${tiff-contrib}")
++message(STATUS "  Build docs:                         ${tiff-docs}")
++message(STATUS "  Build deprecated features:          ${tiff-deprecated}")
+ message(STATUS "  Enable linker symbol versioning:    ${HAVE_LD_VERSION_SCRIPT}")
+ message(STATUS "  Support Microsoft Document Imaging: ${mdi}")
+ message(STATUS "  Use win32 IO:                       ${USE_WIN32_FILEIO}")


### PR DESCRIPTION
### Notes:
- Cmake patches from upstream.
- libde265 patch submitted upstream
  - https://github.com/strukturag/libde265/pull/331

### updates
Updates
- libde265: migrate to cmake build
  - resulting library `liblibde265.a` is larger, but resulting build of libheif (which uses this library is smaller)
  - Don’t build decoder or encoder binaries (as they are not used)
- libheif: migrate to cmake build
  - resulting build are smaller
- tiff: migrate to cmake build
  - resulting build are smaller

This PR is more of
- #5970 