### PR TITLE
u-boot and u-boot-tools: update to 2022.10

### DIFF
--- a/packages/tools/u-boot-tools/package.mk
+++ b/packages/tools/u-boot-tools/package.mk
@@ -2,13 +2,18 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="u-boot-tools"
-PKG_VERSION="2022.07"
-PKG_SHA256="92b08eb49c24da14c1adbf70a71ae8f37cc53eeb4230e859ad8b6733d13dcf5e"
+PKG_VERSION="$(get_pkg_version u-boot)"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"
-PKG_URL="https://ftp.denx.de/pub/u-boot/u-boot-${PKG_VERSION}.tar.bz2"
+PKG_URL=""
 PKG_DEPENDS_HOST="ccache:host bison:host flex:host openssl:host pkg-config:host"
 PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems."
+PKG_DEPENDS_UNPACK+=" u-boot"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/u-boot/u-boot-${PKG_VERSION}.tar.bz2 -C ${PKG_BUILD}
+}
 
 make_host() {
   make qemu-x86_64_defconfig HOSTCC="${HOST_CC}" HOSTCFLAGS="-I${TOOLCHAIN}/include" HOSTLDFLAGS="${HOST_LDFLAGS}"

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="u-boot"
-PKG_VERSION="2022.07"
-PKG_SHA256="92b08eb49c24da14c1adbf70a71ae8f37cc53eeb4230e859ad8b6733d13dcf5e"
+PKG_VERSION="2022.10"
+PKG_SHA256="50b4482a505bc281ba8470c399a3c26e145e29b23500bc35c50debd7fa46bdf8"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"

--- a/projects/Allwinner/devices/H3/patches/u-boot/0007-sunxi-psci-Add-support-for-H3-CPU-0-hotplug.patch
+++ b/projects/Allwinner/devices/H3/patches/u-boot/0007-sunxi-psci-Add-support-for-H3-CPU-0-hotplug.patch
@@ -174,13 +174,13 @@ index ad1f97632979..a2c74da81aa9 100644
  #ifdef SCP_ADDR
  						    "scp",
  #endif
-diff --git a/include/configs/sun8i.h b/include/configs/sun8i.h
+diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
 index 563635636624..2f0d69bdfce2 100644
---- a/include/configs/sun8i.h
-+++ b/include/configs/sun8i.h
-@@ -14,6 +14,12 @@
- 
+--- a/include/configs/sunxi-common.h
++++ b/include/configs/sunxi-common.h
+@@ -15,6 +15,12 @@
  #include <asm/arch/cpu.h>
+ #include <linux/stringify.h>
  
 +#ifdef SUNXI_SRAM_A2_SIZE
 +#define SUNXI_RESUME_BASE		(CONFIG_ARMV7_SECURE_BASE + \
@@ -188,9 +188,9 @@ index 563635636624..2f0d69bdfce2 100644
 +#define SUNXI_RESUME_SIZE		1024
 +#endif
 +
- /*
-  * Include common sunxi configuration where most the settings are
-  */
+ /* Serial & console */
+ #define CONFIG_SYS_NS16550_SERIAL
+ /* ns16550 reg in the low bits of cpu reg */
 -- 
 2.33.0
 

--- a/projects/Allwinner/devices/H3/patches/u-boot/0010-sunxi-Enable-support-for-SCP-firmware-on-H3.patch
+++ b/projects/Allwinner/devices/H3/patches/u-boot/0010-sunxi-Enable-support-for-SCP-firmware-on-H3.patch
@@ -53,10 +53,10 @@ index 2b7d655678d0..a25cd11f1124 100644
  	return 0;
  }
  
-diff --git a/include/configs/sun8i.h b/include/configs/sun8i.h
+diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
 index 2f0d69bdfce2..fda5b235a3e0 100644
---- a/include/configs/sun8i.h
-+++ b/include/configs/sun8i.h
+--- a/include/configs/sunxi-common.h
++++ b/include/configs/sunxi-common.h
 @@ -26,6 +26,9 @@
  #define SUNXI_RESUME_BASE		(CONFIG_ARMV7_SECURE_BASE + \
  					 CONFIG_ARMV7_SECURE_MAX_SIZE)

--- a/projects/Allwinner/patches/u-boot/0003-sunxi-binman-Enable-SPL-FIT-loading-for-32-bit-SoCs.patch
+++ b/projects/Allwinner/patches/u-boot/0003-sunxi-binman-Enable-SPL-FIT-loading-for-32-bit-SoCs.patch
@@ -152,8 +152,8 @@ index 8a8a971a91e1..374818c05741 100644
  	bool "Remove functionality from SPL FIT loading to reduce size"
  	depends on SPL_FIT
 -	default y if MACH_SUN50I || MACH_SUN50I_H5 || SUN50I_GEN_H6
--	default y if ARCH_IMX8M
-+	default y if ARCH_IMX8M || ARCH_SUNXI
+-	default y if ARCH_IMX8M || ARCH_IMX9
++	default y if ARCH_IMX8M || ARCH_IMX9 || ARCH_SUNXI
  	help
  	  Enable this to reduce the size of the FIT image loading code
  	  in SPL, if space for the SPL binary is very tight.

--- a/projects/Amlogic/patches/u-boot/u-boot-0007-WIP-boards-amlogic-add-WeTek-Hub-defconfig.patch
+++ b/projects/Amlogic/patches/u-boot/u-boot-0007-WIP-boards-amlogic-add-WeTek-Hub-defconfig.patch
@@ -5,8 +5,8 @@ Subject: [PATCH 07/15] WIP: boards: amlogic: add WeTek Hub defconfig
 
 Signed-of-by: Christian Hewitt <christianshewitt@gmail.com>
 ---
- configs/wetek-hub_defconfig | 69 +++++++++++++++++++++++++++++++++++++
- 1 file changed, 69 insertions(+)
+ configs/wetek-hub_defconfig | 71 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 71 insertions(+)
  create mode 100644 configs/wetek-hub_defconfig
 
 diff --git a/configs/wetek-hub_defconfig b/configs/wetek-hub_defconfig
@@ -14,7 +14,7 @@ new file mode 100644
 index 0000000000..73fd7c4211
 --- /dev/null
 +++ b/configs/wetek-hub_defconfig
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,71 @@
 +CONFIG_ARM=y
 +CONFIG_SYS_BOARD="wetek-gxbb"
 +CONFIG_ARCH_MESON=y
@@ -28,6 +28,8 @@ index 0000000000..73fd7c4211
 +CONFIG_IDENT_STRING=" wetek-hub"
 +CONFIG_DEFAULT_DEVICE_TREE="meson-gxbb-wetek-hub"
 +CONFIG_DEBUG_UART=y
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x20000000
 +CONFIG_OF_BOARD_SETUP=y
 +# CONFIG_DISPLAY_CPUINFO is not set
 +CONFIG_MISC_INIT_R=y

--- a/projects/Amlogic/patches/u-boot/u-boot-0008-WIP-boards-amlogic-add-WeTek-Play2-defconfig.patch
+++ b/projects/Amlogic/patches/u-boot/u-boot-0008-WIP-boards-amlogic-add-WeTek-Play2-defconfig.patch
@@ -5,8 +5,8 @@ Subject: [PATCH 08/15] WIP: boards: amlogic: add WeTek Play2 defconfig
 
 Signed-off-by: Christian Hewittt <christianshewitt@gmail.com>
 ---
- configs/wetek-play2_defconfig | 69 +++++++++++++++++++++++++++++++++++
- 1 file changed, 69 insertions(+)
+ configs/wetek-play2_defconfig | 71 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 71 insertions(+)
  create mode 100644 configs/wetek-play2_defconfig
 
 diff --git a/configs/wetek-play2_defconfig b/configs/wetek-play2_defconfig
@@ -14,7 +14,7 @@ new file mode 100644
 index 0000000000..f218ba0e0e
 --- /dev/null
 +++ b/configs/wetek-play2_defconfig
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,71 @@
 +CONFIG_ARM=y
 +CONFIG_SYS_BOARD="wetek-gxbb"
 +CONFIG_ARCH_MESON=y
@@ -28,6 +28,8 @@ index 0000000000..f218ba0e0e
 +CONFIG_IDENT_STRING=" wetek-play2"
 +CONFIG_DEFAULT_DEVICE_TREE="meson-gxbb-wetek-play2"
 +CONFIG_DEBUG_UART=y
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x20000000
 +CONFIG_OF_BOARD_SETUP=y
 +# CONFIG_DISPLAY_CPUINFO is not set
 +CONFIG_MISC_INIT_R=y

--- a/projects/Amlogic/patches/u-boot/u-boot-0010-WIP-boards-amlogic-add-Radxa-Zero2-defconfig.patch
+++ b/projects/Amlogic/patches/u-boot/u-boot-0010-WIP-boards-amlogic-add-Radxa-Zero2-defconfig.patch
@@ -8,8 +8,8 @@ Add a defconfig for the Radxa Zero2 SBC, using an Amlogic A311D chip.
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 ---
  board/amlogic/w400/MAINTAINERS |  1 +
- configs/radxa-zero2_defconfig  | 72 ++++++++++++++++++++++++++++++++++
- 2 files changed, 73 insertions(+)
+ configs/radxa-zero2_defconfig  | 74 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 75 insertions(+)
  create mode 100644 configs/radxa-zero2_defconfig
 
 diff --git a/board/amlogic/w400/MAINTAINERS b/board/amlogic/w400/MAINTAINERS
@@ -27,7 +27,7 @@ new file mode 100644
 index 0000000000..e9bd2a4f13
 --- /dev/null
 +++ b/configs/radxa-zero2_defconfig
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,74 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_MESON=y
 +CONFIG_SYS_TEXT_BASE=0x01000000
@@ -41,6 +41,8 @@ index 0000000000..e9bd2a4f13
 +CONFIG_DEBUG_UART_CLOCK=24000000
 +CONFIG_IDENT_STRING=" radxa-zero2"
 +CONFIG_DEBUG_UART=y
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x20000000
 +CONFIG_OF_BOARD_SETUP=y
 +# CONFIG_DISPLAY_CPUINFO is not set
 +CONFIG_MISC_INIT_R=y

--- a/projects/Amlogic/patches/u-boot/u-boot-0013-WIP-boards-amlogic-add-Beelink-GT1-defconfig.patch
+++ b/projects/Amlogic/patches/u-boot/u-boot-0013-WIP-boards-amlogic-add-Beelink-GT1-defconfig.patch
@@ -7,8 +7,8 @@ Add a board config for Beelink GT1 devices
 
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 ---
- configs/beelink-gt1_defconfig | 69 +++++++++++++++++++++++++++++++++++
- 1 file changed, 69 insertions(+)
+ configs/beelink-gt1_defconfig | 71 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 71 insertions(+)
  create mode 100644 configs/beelink-gt1_defconfig
 
 diff --git a/configs/beelink-gt1_defconfig b/configs/beelink-gt1_defconfig
@@ -16,7 +16,7 @@ new file mode 100644
 index 0000000000..6f6051b675
 --- /dev/null
 +++ b/configs/beelink-gt1_defconfig
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,71 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_MESON=y
 +CONFIG_SYS_TEXT_BASE=0x01000000
@@ -30,6 +30,8 @@ index 0000000000..6f6051b675
 +CONFIG_IDENT_STRING=" beelink-gt1"
 +CONFIG_SYS_LOAD_ADDR=0x1000000
 +CONFIG_DEBUG_UART=y
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x20000000
 +CONFIG_REMAKE_ELF=y
 +CONFIG_OF_BOARD_SETUP=y
 +# CONFIG_DISPLAY_CPUINFO is not set


### PR DESCRIPTION
[ANN] U-Boot v2022.10 released
- https://www.mail-archive.com/u-boot@lists.denx.de/msg452466.html

Releases
- U-Boot v2022.10-rc3 was released on Mon 22 August 2022.
- U-Boot v2022.10-rc4 was released on Mon 05 September 2022.
- U-Boot v2022.10-rc5 was released on Mon 19 September 2022.
- U-Boot v2022.10 was released on Mon 3 October 2022.


Update u-boot (for all)

- u-boot-tools: use u-boot download and version
- u-boot: update to 2022.10
  - rebase Allwinner patch
  - Rebase Allwinner H3 patches
  - Rebase / update amlogic patches

### Issues
- Dragonboard build error with compiler flags


### Build tested - 6.0 + u-boot 2022.10
```
PROJECT=Allwinner ARCH=arm DEVICE=A64 make image
PROJECT=Allwinner ARCH=arm DEVICE=H3 make image
PROJECT=Allwinner ARCH=arm DEVICE=H5 make image
PROJECT=Allwinner ARCH=arm DEVICE=H6 make image
PROJECT=Amlogic ARCH=arm DEVICE=AMLGX make image
PROJECT=NXP ARCH=arm DEVICE=iMX6 make image
PROJECT=NXP ARCH=arm DEVICE=iMX8 make image
PROJECT=Qualcomm ARCH=arm DEVICE=Dragonboard make image (FAILING)
PROJECT=Samsung ARCH=arm DEVICE=Exynos make image
```

### Run testing - 6.0.y + u-boot 2022.10
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - 6.0-rc4 + u-boot 2022.10-rc3 - heitbaum
- Amlogic all - tested - TBA - chewitt
- NXP iMX6 (Cubox-i4Pro) - TBA  - heitbaum
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum

### Images built @ Oct 3 2022
Note: DragonBoard is NOT there
```
$ ls -1 target/*.img.gz
target/LibreELEC-A64.arm-11.0-devel-20221003202641-4fb3312-orangepi-win.img.gz
target/LibreELEC-A64.arm-11.0-devel-20221003202641-4fb3312-pine64.img.gz
target/LibreELEC-A64.arm-11.0-devel-20221003202641-4fb3312-pine64-lts.img.gz
target/LibreELEC-A64.arm-11.0-devel-20221003202641-4fb3312-pine64-plus.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-bananapi-m5.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-box.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-khadas-vim2.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-khadas-vim3.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-khadas-vim3l.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-khadas-vim.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-lafrite.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-lepotato.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-nanopi-k2.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-odroid-c2.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-odroid-c4.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-odroid-hc4.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-odroid-n2.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-radxa-zero2.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-radxa-zero.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-wetek-core2.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-wetek-hub.img.gz
target/LibreELEC-AMLGX.arm-11.0-devel-20221003212428-4fb3312-wetek-play2.img.gz
target/LibreELEC-Exynos.arm-11.0-devel-20221003211438-4fb3312-odroid-xu3.img.gz
target/LibreELEC-Generic-legacy.x86_64-11.0-devel-20221003211842-4fb3312.img.gz
target/LibreELEC-Generic.x86_64-11.0-devel-20221003211640-4fb3312.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-bananapi-m2p.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-beelink-x2.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-libretech-h3.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-nanopi-m1.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-orangepi-2.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-orangepi-pc.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-orangepi-pc-plus.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-orangepi-plus2e.img.gz
target/LibreELEC-H3.arm-11.0-devel-20221003204652-4fb3312-orangepi-plus.img.gz
target/LibreELEC-H5.arm-11.0-devel-20221003205014-4fb3312-orangepi-pc2.img.gz
target/LibreELEC-H5.arm-11.0-devel-20221003205014-4fb3312-tritium-h5.img.gz
target/LibreELEC-H6.aarch64-11.0-devel-20221003205603-4fb3312-beelink-gs1.img.gz
target/LibreELEC-H6.aarch64-11.0-devel-20221003205603-4fb3312-orangepi-3.img.gz
target/LibreELEC-H6.aarch64-11.0-devel-20221003205603-4fb3312-orangepi-lite2.img.gz
target/LibreELEC-H6.aarch64-11.0-devel-20221003205603-4fb3312-orangepi-one-plus.img.gz
target/LibreELEC-H6.aarch64-11.0-devel-20221003205603-4fb3312-pine-h64.img.gz
target/LibreELEC-H6.aarch64-11.0-devel-20221003205603-4fb3312-pine-h64-model-b.img.gz
target/LibreELEC-H6.aarch64-11.0-devel-20221003205603-4fb3312-tanix-tx6.img.gz
target/LibreELEC-H6.arm-11.0-devel-20221003205248-4fb3312-beelink-gs1.img.gz
target/LibreELEC-H6.arm-11.0-devel-20221003205248-4fb3312-orangepi-3.img.gz
target/LibreELEC-H6.arm-11.0-devel-20221003205248-4fb3312-orangepi-lite2.img.gz
target/LibreELEC-H6.arm-11.0-devel-20221003205248-4fb3312-orangepi-one-plus.img.gz
target/LibreELEC-H6.arm-11.0-devel-20221003205248-4fb3312-pine-h64.img.gz
target/LibreELEC-H6.arm-11.0-devel-20221003205248-4fb3312-pine-h64-model-b.img.gz
target/LibreELEC-H6.arm-11.0-devel-20221003205248-4fb3312-tanix-tx6.img.gz
target/LibreELEC-iMX6.arm-11.0-devel-20221003210808-4fb3312-cubox.img.gz
target/LibreELEC-iMX6.arm-11.0-devel-20221003210808-4fb3312-udoo.img.gz
target/LibreELEC-iMX6.arm-11.0-devel-20221003210808-4fb3312-wandboard.img.gz
target/LibreELEC-iMX8.arm-11.0-devel-20221003211029-4fb3312-mq-evk.img.gz
target/LibreELEC-iMX8.arm-11.0-devel-20221003211029-4fb3312-pico-mq.img.gz
target/LibreELEC-RK3288.arm-11.0-devel-20221003205929-4fb3312-miqi.img.gz
target/LibreELEC-RK3288.arm-11.0-devel-20221003205929-4fb3312-tinker.img.gz
target/LibreELEC-RK3328.arm-11.0-devel-20221003210143-4fb3312-a1.img.gz
target/LibreELEC-RK3328.arm-11.0-devel-20221003210143-4fb3312-roc-cc.img.gz
target/LibreELEC-RK3328.arm-11.0-devel-20221003210143-4fb3312-rock64.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-hugsun-x99.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-khadas-edge.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-nanopc-t4.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-nanopi-m4.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-orangepi.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-rock960.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-rock-pi-4.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-rock-pi-4-plus.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-rock-pi-n10.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-rockpro64.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-roc-pc.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-roc-pc-plus.img.gz
target/LibreELEC-RK3399.arm-11.0-devel-20221003210358-4fb3312-sapphire.img.gz
target/LibreELEC-RPi2.arm-11.0-devel-20221003212053-4fb3312.img.gz
target/LibreELEC-RPi4.arm-11.0-devel-20221003212240-4fb3312.img.gz
```

```
=== tested on ===

```

Dragonboard build error occurs between 2022.07 and 2022.10-rc1 - need to bisect.
```
Installing u-boot for board 410c...
CLEAN      u-boot
    *      Removing /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/build/u-boot-2022.10-rc3 ...
    *      Removing /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/install_pkg/u-boot-2022.10-rc3 ...
    *      Removing /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/qa_checks/u-boot-* ...
UNPACK      u-boot
BUILD      u-boot (target)
    TOOLCHAIN      make (auto-detect)
make[1]: Entering directory '/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/build/u-boot-2022.10-rc3'
make[1]: Leaving directory '/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/build/u-boot-2022.10-rc3'
make[1]: Entering directory '/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/build/u-boot-2022.10-rc3'
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
make[1]: Leaving directory '/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/build/u-boot-2022.10-rc3'
make[1]: Entering directory '/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/build/u-boot-2022.10-rc3'
scripts/kconfig/conf  --syncconfig Kconfig
  UPD     include/config.h
  CFG     u-boot.cfg
  GEN     include/autoconf.mk.dep
  GEN     include/autoconf.mk
  UPD     include/generated/dt.h
  ENVC    include/generated/env.txt
  UPD     include/generated/timestamp_autogenerated.h
  UPD     include/config/uboot.release
  ENVP    include/generated/env.in
aarch64-none-elf-gcc-12.2.0: error: unrecognized argument in option '-mabi=aapcs-linux'
aarch64-none-elf-gcc-12.2.0: note: valid arguments to '-mabi=' are: ilp32 lp64
  UPD     include/generated/version_autogenerated.h
  HOSTCC  scripts/dtc/dtc.o
  HOSTCC  scripts/dtc/flattree.o
  HOSTCC  scripts/dtc/fstree.o
  HOSTCC  scripts/dtc/data.o
  HOSTCC  scripts/dtc/livetree.o
  HOSTCC  scripts/dtc/treesource.o
aarch64-none-elf-gcc-12.2.0: error: unrecognized command-line option '-mfloat-abi=hard'
  HOSTCC  scripts/dtc/srcpos.o
  HOSTCC  scripts/dtc/checks.o
  HOSTCC  scripts/dtc/util.o
  LEX     scripts/dtc/dtc-lexer.lex.c
  YACC    scripts/dtc/dtc-parser.tab.h
  YACC    scripts/dtc/dtc-parser.tab.c
aarch64-none-elf-gcc-12.2.0: error: unrecognized command-line option '-mfpu=neon-fp-armv8'
make[1]: *** [Makefile:1875: include/generated/env.in] Error 1
make[1]: *** Waiting for unfinished jobs....
  HOSTCC  scripts/dtc/dtc-parser.tab.o
  HOSTCC  scripts/dtc/dtc-lexer.lex.o
  HOSTLD  scripts/dtc/dtc
make[1]: Leaving directory '/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-Dragonboard.arm-11.0-devel/build/u-boot-2022.10-rc3'
FAILURE: scripts/build u-boot during make_target (package.mk)
*********** FAILED COMMAND ***********
DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm _python_sysroot="${TOOLCHAIN}" _python_prefix=/ _python_exec_prefix=/ make ${UBOOT_TARGET} HOSTCC="${HOST_CC}" HOSTCFLAGS="-I${TOOLCHAIN}/include" HOSTLDFLAGS="${HOST_LDFLAGS}" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"
**************************************
```