### PR TITLE
firmware-imx: update to 8.17 (iMX8 updates)

### DIFF
--- a/packages/linux-firmware/firmware-imx/package.mk
+++ b/packages/linux-firmware/firmware-imx/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="firmware-imx"
-PKG_VERSION="8.14"
-PKG_SHA256="bfe9c57857e8442e7eb26ba3e1020733b09a7c9b83952ad4822980546c58a7f4"
+PKG_VERSION="8.17"
+PKG_SHA256="289a021aa6b7ec56fa02e2d21710179dc33cd59c65cce88b7d9119efafea7a65"
 PKG_ARCH="arm"
 PKG_LICENSE="other"
 PKG_SITE="http://www.freescale.com"


### PR DESCRIPTION
release notes:
- https://www.nxp.com/docs/en/release-note/IMX_LINUX_RELEASE_NOTES.pdf

Binary files updated in this release:
- firmware/ddr/synopsys/lpddr4_dmem_1d_v202201.bin
- firmware/ddr/synopsys/lpddr4_dmem_2d_v202201.bin
- firmware/ddr/synopsys/lpddr4_imem_1d_v202201.bin
- firmware/ddr/synopsys/lpddr4_imem_2d_v202201.bin
- firmware/hdmi/cadence/dp_ls1028a.bin
- firmware/hdmi/cadence/signed_dp_imx8m.bin
- firmware/vpu/vpu_fw_imx8_dec.bin