### PR TITLE
[le11] Add support for building with MOLD linker v2

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -270,7 +270,7 @@ linker_allowed() {
 get_target_linker() {
   # all known linkers, in descending order of priority
   # those are candidates for explicit opt-in via PKG_BUILD_FLAGS
-  local all_linkers="gold bfd"
+  local all_linkers="mold gold bfd"
 
   # linkers to choose from unless disabled via PKG_BUILD_FLAGS
   local linker_candidates="${DEFAULT_LINKER:-bfd} ${all_linkers}"

--- a/config/optimize
+++ b/config/optimize
@@ -31,6 +31,7 @@ LDFLAGS_OPTIM_LTO_COMMON="-fuse-linker-plugin"
 LDFLAGS_OPTIM_LINKER_COMPILER_DEFAULT=""
 LDFLAGS_OPTIM_LINKER_BFD="-fuse-ld=bfd"
 LDFLAGS_OPTIM_LINKER_GOLD="-fuse-ld=gold"
+LDFLAGS_OPTIM_LINKER_MOLD="-fuse-ld=mold"
 
 # default compiler optimization
 CFLAGS_OPTIM_DEFAULT="-O2 -fomit-frame-pointer -DNDEBUG"

--- a/config/show_config
+++ b/config/show_config
@@ -31,6 +31,7 @@ show_config() {
   config_message+="\n - CPU features:\t\t\t ${TARGET_FEATURES}"
   config_message+="\n - LTO (Link Time Optimization) support: ${LTO_SUPPORT}"
   config_message+="\n - GOLD (Google Linker) Support:\t ${GOLD_SUPPORT}"
+  config_message+="\n - MOLD (Modern Linker) Support:\t ${MOLD_SUPPORT}"
   config_message+="\n - Default Linker:\t\t\t ${DEFAULT_LINKER}"
   config_message+="\n - LLVM support:\t\t\t ${LLVM_SUPPORT}"
   config_message+="\n - DEBUG:\t\t\t\t ${DEBUG:-no}"

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -32,7 +32,10 @@
 # GOLD (Google Linker) support
   GOLD_SUPPORT="yes"
 
-# default linker (bfd / gold)
+# MOLD (Modern Linker) support
+  MOLD_SUPPORT="no"
+
+# default linker (bfd / gold / mold)
   DEFAULT_LINKER="gold"
 
 # HARDENING (security relevant linker and compiler flags) support

--- a/packages/devel/mimalloc/package.mk
+++ b/packages/devel/mimalloc/package.mk
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="mimalloc"
+PKG_VERSION="2.0.6"
+PKG_SHA256="9f05c94cc2b017ed13698834ac2a3567b6339a8bde27640df5a1581d49d05ce5"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/microsoft/mimalloc"
+PKG_URL="https://github.com/microsoft/mimalloc/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="cmake:host ninja:host"
+PKG_LONGDESC="mimalloc (pronounced "me-malloc") is a general purpose allocator with excellent performance characteristics"
+
+PKG_CMAKE_OPTS_HOST="-DMI_SECURE=OFF \
+                     -DMI_DEBUG_FULL=OFF \
+                     -DMI_OVERRIDE=ON \
+                     -DMI_XMALLOC=OFF \
+                     -DMI_SHOW_ERRORS=OFF \
+                     -DMI_USE_CXX=OFF \
+                     -DMI_SEE_ASM=OFF \
+                     -DMI_LOCAL_DYNAMIC_TLS=OFF \
+                     -DMI_BUILD_SHARED=ON \
+                     -DMI_BUILD_STATIC=OFF \
+                     -DMI_BUILD_OBJECT=OFF \
+                     -DMI_BUILD_TESTS=OFF \
+                     -DMI_DEBUG_TSAN=OFF \
+                     -DMI_DEBUG_UBSAN=OFF \
+                     -DMI_SKIP_COLLECT_ON_EXIT=OFF"

--- a/packages/devel/mold/package.mk
+++ b/packages/devel/mold/package.mk
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="mold"
+PKG_VERSION="1.5.1"
+PKG_SHA256="ec94aa74758f1bc199a732af95c6304ec98292b87f2f4548ce8436a7c5b054a1"
+PKG_LICENSE="AGPL-3.0-or-later"
+PKG_SITE="https://github.com/rui314/mold"
+PKG_URL="https://github.com/rui314/mold/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="cmake:host zlib:host zstd:host openssl:host tbb:host mimalloc:host"
+PKG_LONGDESC="mold is a faster drop-in replacement for existing Unix linkers"
+
+PKG_CMAKE_OPTS_HOST="-DCMAKE_INSTALL_LIBDIR="${TOOLCHAIN}/${TARGET_NAME}/lib"
+                     -DCMAKE_INSTALL_BINDIR="${TARGET_NAME}/bin" \
+                     -DCMAKE_INSTALL_LIBEXECDIR="${TARGET_NAME}" \
+                     -DMOLD_LTO=ON \
+                     -DMOLD_MOSTLY_STATIC=ON \
+                     -DMOLD_USE_SYSTEM_MIMALLOC=ON \
+                     -DMOLD_USE_SYSTEM_TBB=ON"
+
+post_makeinstall_host() {
+  ln -sf ${TOOLCHAIN}/${TARGET_NAME}/bin/mold ${TARGET_PREFIX}ld.mold
+}

--- a/packages/devel/mold/patches/mold-999.01-PR740-allow-custom-mold-binary-install-path.patch
+++ b/packages/devel/mold/patches/mold-999.01-PR740-allow-custom-mold-binary-install-path.patch
@@ -1,0 +1,24 @@
+From f7f2ef6182d058f7c58401d9278aa3136cb996f5 Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Thu, 29 Sep 2022 11:49:57 +0200
+Subject: [PATCH] CMakeLists: allow custom mold binary install path
+
+- https://cmake.org/cmake/help/latest/command/install.html
+- ${CMAKE_INSTALL_BINDIR} defaults to bin if not set
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7136cf2b..4542f915 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -287,7 +287,7 @@ if(BUILD_TESTING)
+ endif()
+ 
+ if(NOT CMAKE_SKIP_INSTALL_RULES)
+-  install(TARGETS mold RUNTIME DESTINATION bin)
++  install(TARGETS mold RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+   install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+   install(FILES docs/mold.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)
+   install(CODE "

--- a/packages/devel/spdlog/package.mk
+++ b/packages/devel/spdlog/package.mk
@@ -12,6 +12,7 @@ PKG_LONGDESC="Very fast, header only, C++ logging library."
 
 PKG_CMAKE_OPTS_TARGET="-DCMAKE_CXX_STANDARD=14 \
                        -DCMAKE_CXX_EXTENSIONS:BOOL=OFF \
+                       -DSPDLOG_BUILD_SHARED=ON \
                        -DSPDLOG_FMT_EXTERNAL=ON \
                        -DSPDLOG_BUILD_EXAMPLE=OFF \
                        -DSPDLOG_BUILD_TESTS=OFF"

--- a/packages/devel/tbb/package.mk
+++ b/packages/devel/tbb/package.mk
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="tbb"
+PKG_VERSION="2021.6.0"
+PKG_SHA256="4897dd106d573e9dacda8509ca5af1a0e008755bf9c383ef6777ac490223031f"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://github.com/oneapi-src/oneTBB"
+PKG_URL="https://github.com/oneapi-src/oneTBB/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="cmake:host ninja:host"
+PKG_LONGDESC="oneTBB is a flexible C++ library that simplifies the work of adding parallelism to complex applications"
+
+PKG_CMAKE_OPTS_HOST="-DTBB_TEST=OFF \
+                     -DTBB_EXAMPLES=OFF \
+                     -DTBB_STRICT=OFF \
+                     -DTBB4PY_BUILD=OFF \
+                     -DTBB_BUILD=ON \
+                     -DTBBMALLOC_BUILD=ON \
+                     -DTBBMALLOC_PROXY_BUILD=ON \
+                     -DTBB_CPF=OFF \
+                     -DTBB_FIND_PACKAGE=OFF \
+                     -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=OFF \
+                     -DTBB_ENABLE_IPO=ON"
+
+pre_configure_host() {
+  export CXXFLAGS+=" -D__TBB_DYNAMIC_LOAD_ENABLED=0"
+}

--- a/packages/devel/tbb/patches/tbb-999.01-PR824-retry-if-pthread_create-fails-with-EAGAIN.patch
+++ b/packages/devel/tbb/patches/tbb-999.01-PR824-retry-if-pthread_create-fails-with-EAGAIN.patch
@@ -1,0 +1,63 @@
+From f12c93efd04991bc982a27e2fa6142538c33ca82 Mon Sep 17 00:00:00 2001
+From: Rui Ueyama <ruiu@cs.stanford.edu>
+Date: Sat, 7 May 2022 19:55:24 +0800
+Subject: [PATCH] Retry if pthread_create fails with EAGAIN
+
+On many Unix-like systems, pthread_create can fail spuriously even if
+the running machine has enough resources to spawn a new thread.
+Therefore, if EAGAIN is returned from pthread_create, we actually have
+to try again.
+
+I observed this issue when running the mold linker
+(https://github.com/rui314/mold) under a heavy load. mold uses OneTBB
+for parallelization.
+
+As another data point, Go has the same logic to retry on EAGAIN:
+https://go-review.googlesource.com/c/go/+/33894/
+
+nanosleep is defined in POSIX 2001, so I believe that all Unix-like
+systems support it.
+
+Signed-off-by: Rui Ueyama <ruiu@cs.stanford.edu>
+---
+ src/tbb/rml_thread_monitor.h | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/src/tbb/rml_thread_monitor.h b/src/tbb/rml_thread_monitor.h
+index 13b556380..5b844b232 100644
+--- a/src/tbb/rml_thread_monitor.h
++++ b/src/tbb/rml_thread_monitor.h
+@@ -31,6 +31,7 @@
+ #include <pthread.h>
+ #include <cstring>
+ #include <cstdlib>
++#include <time.h>
+ #else
+ #error Unsupported platform
+ #endif
+@@ -191,8 +192,24 @@ inline thread_monitor::handle_type thread_monitor::launch( void* (*thread_routin
+     check(pthread_attr_init( &s ), "pthread_attr_init has failed");
+     if( stack_size>0 )
+         check(pthread_attr_setstacksize( &s, stack_size ), "pthread_attr_setstack_size has failed" );
++
+     pthread_t handle;
+-    check( pthread_create( &handle, &s, thread_routine, arg ), "pthread_create has failed" );
++    int tries = 0;
++    for (;;) {
++      int error_code = pthread_create(&handle, &s, thread_routine, arg);
++      if (!error_code)
++        break;
++      if (error_code != EAGAIN || tries++ > 20) {
++        handle_perror(error_code, "pthread_create has failed");
++        break;
++      }
++
++      // pthreaed_create can spuriously fail on many Unix-like systems.
++      // Retry after tries * 1 millisecond.
++      struct timespec ts = {0, tries * 1000 * 1000};
++      nanosleep(&ts, NULL);
++    }
++
+     check( pthread_attr_destroy( &s ), "pthread_attr_destroy has failed" );
+     return handle;
+ }

--- a/packages/lang/gcc-aarch64/package.mk
+++ b/packages/lang/gcc-aarch64/package.mk
@@ -11,6 +11,10 @@ PKG_LONGDESC="This package contains the GNU Compiler Collection for 64-bit ARM."
 PKG_DEPENDS_UNPACK+=" gcc"
 PKG_PATCH_DIRS+=" $(get_pkg_directory gcc)/patches"
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+=" mold:host"
+fi
+
 PKG_CONFIGURE_OPTS_HOST="--target=aarch64-none-elf \
                          --with-sysroot=${SYSROOT_PREFIX} \
                          --with-gmp=${TOOLCHAIN} \

--- a/packages/lang/gcc-arm-none-eabi/package.mk
+++ b/packages/lang/gcc-arm-none-eabi/package.mk
@@ -11,6 +11,10 @@ PKG_LONGDESC="This package contains the GNU Compiler Collection for ARM Cortex-R
 PKG_DEPENDS_UNPACK+=" gcc"
 PKG_PATCH_DIRS+=" $(get_pkg_directory gcc)/patches"
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+=" mold:host"
+fi
+
 PKG_CONFIGURE_OPTS_HOST="--target=arm-none-eabi \
                          --with-sysroot=${SYSROOT_PREFIX} \
                          --with-gmp=${TOOLCHAIN} \

--- a/packages/lang/gcc-bpf/package.mk
+++ b/packages/lang/gcc-bpf/package.mk
@@ -11,6 +11,10 @@ PKG_LONGDESC="This package contains the GNU Compiler Collection for 64-bit ARM."
 PKG_DEPENDS_UNPACK+=" gcc"
 PKG_PATCH_DIRS+=" $(get_pkg_directory gcc)/patches"
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+=" mold:host"
+fi
+
 PKG_CONFIGURE_OPTS_HOST="--target=bpf \
                          --with-sysroot=${SYSROOT_PREFIX} \
                          --with-gmp=${TOOLCHAIN} \

--- a/packages/lang/gcc-or1k/package.mk
+++ b/packages/lang/gcc-or1k/package.mk
@@ -11,6 +11,10 @@ PKG_LONGDESC="This package contains the GNU Compiler Collection for OpenRISC 100
 PKG_DEPENDS_UNPACK+=" gcc"
 PKG_PATCH_DIRS+=" $(get_pkg_directory gcc)/patches"
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+=" mold:host"
+fi
+
 PKG_CONFIGURE_OPTS_HOST="--target=or1k-none-elf \
                          --with-sysroot=${SYSROOT_PREFIX} \
                          --with-gmp=${TOOLCHAIN} \

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -14,6 +14,10 @@ PKG_DEPENDS_HOST="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc
 PKG_DEPENDS_INIT="toolchain"
 PKG_LONGDESC="This package contains the GNU Compiler Collection."
 
+if [ "${MOLD_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_HOST+=" mold:host"
+fi
+
 case ${TARGET_ARCH} in
   arm|riscv64)
     OPTS_LIBATOMIC="--enable-libatomic"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -25,6 +25,11 @@ configure_package() {
       PKG_KODI_LINKER="-DENABLE_GOLD=ON \
                        -DENABLE_MOLD=OFF"
       ;;
+    mold)
+      PKG_KODI_LINKER="-DENABLE_GOLD=OFF \
+                       -DENABLE_MOLD=ON \
+                       -DMOLD_EXECUTABLE=${TOOLCHAIN}/${TARGET_NAME}/bin/mold"
+      ;;
     *)
       PKG_KODI_LINKER="-DENABLE_GOLD=OFF \
                        -DENABLE_MOLD=OFF"

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -128,6 +128,7 @@ Set the variable `PKG_BUILD_FLAGS` in the `package.mk` to enable/disable the sin
 | lto-off  | disabled | target, init      | explicitly disable LTO in the compiler and linker |
 | bfd      | - | target, init | `+bfd` prefers bfd linker over default linker, `-bfd` disables using bfd |
 | gold     | - | target, init | `+gold` prefers gold linker over default linker, `-gold` disables using gold |
+| mold     | - | target, init | `+mold` prefers mold linker over default linker, `-mold` disables using gold |
 | parallel | enabled  | all | `make` or `ninja` builds with multiple threads/processes (or not) |
 | strip    | enabled  | target | strips executables (or not) |
 | sysroot  | enabled  | target | installs the package to the sysroot folder (or not) |


### PR DESCRIPTION
The basic idea is based on this PR https://github.com/LibreELEC/LibreELEC.tv/pull/6665 which is somewhat stalled, not completely functional & needs rebase. Since mold linker benchmarks show nice performance gains it could speed up the compilation of the distro image on systems with a lot of cores/threads see https://github.com/rui314/mold#readme & https://github.com/xbmc/xbmc/pull/20891 for details.

- build `mold:host` conditionally as `gcc` packages dependency
- add `MOLD_SUPPORT` distro var
- build `spdlog` as shared lib to fix Kodi linking by mold 
- add `Kodi` support for `mold` linking in pkg build opts

EDIT: rebased on https://github.com/LibreELEC/LibreELEC.tv/pull/6928