### PR TITLE
syncthing: update to 1.21.0 and addon (121)

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.18.5"
-PKG_SHA256="30c07c08c9b9a79d652272ac3298c249a810a4c908e8937cf5e58d2414af1cc3"
+PKG_VERSION="1.19.1"
+PKG_SHA256="884439c3de751c705e47a120af6b92b65770a952a7b8788244bc6d73b2548c3e"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,6 @@
+121
+- update to 1.21.0
+
 120
 - update to 1.20.1
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.20.1"
-PKG_SHA256="a88fabaea11a8df5cc134075c37dc87f1fb33b48d3d8afb1dc8ea11b3c0925bc"
-PKG_REV="120"
+PKG_VERSION="1.21.0"
+PKG_SHA256="e70d70c7962383973acdbc2eb184548ae87de22ac6854045982c7960b8260450"
+PKG_REV="121"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"


### PR DESCRIPTION
- [syncthing: update to 1.21.0 and addon (121)](https://github.com/LibreELEC/LibreELEC.tv/commit/dcd1e66913b3bf415d09b934015a941055053638)
- [go: update to 1.19.1](https://github.com/LibreELEC/LibreELEC.tv/commit/596aaff80d1b9f55515435c0123b1203649d4c28)
  - all other go packages already tested building with go 1.19 (Syncthing was the remaining package that needed to be updated - to support go 1.19)