### PR TITLE
Python3: update to 3.9.14

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.9.13"
-PKG_SHA256="125b0c598f1e15d2aa65406e83f792df7d171cdf38c16803b149994316a3080f"
+PKG_VERSION="3.9.14"
+PKG_SHA256="651304d216c8203fe0adf1a80af472d8e92c3b0e0a7892222ae4d9f3ae4debcf"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.python.org/"
 PKG_URL="https://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
changelog:
- https://docs.python.org/3.9/whatsnew/changelog.html


```
=== tested on ===
Generic.x86_64-devel-20220908121749-e843efd
Linux nuc11 6.0.0-rc4 #1 SMP Thu Sep 8 11:56:34 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:1ade57db993d29ea314420c416b77b028d142135). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-09-08 by GCC 12.2.0 for Linux x86 64-bit version 6.0.0 (393216)
Running on LibreELEC (heitbaum): devel-20220908121749-e843efd 11.0, kernel: Linux x86 64-bit version 6.0.0-rc4
FFmpeg version/source: 4.4.1-Kodi
Host CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz, 8 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC11PAHi7/NUC11PABi7, BIOS PATGL357.0046.2022.0608.1909 06/08/2022
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Xe Graphics (TGL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.2.0-rc3
libva info: VA-API version 1.15.0
vainfo: VA-API version: 1.15 (libva 2.15.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.5.3 (e843efdebc)
```
nuc11:~ # python --version
Python 3.9.14
