### PR TITLE
[le11] ffmpeg: fix version output

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -11,7 +11,8 @@ PKG_BUILD_FLAGS="-gold"
 
 case "${PROJECT}" in
   Amlogic)
-    PKG_VERSION="0e5290bcac015e52f6a65dafaf41ea125816257f" # dev/4.4/rpi_import_1
+    PKG_VERSION="0e5290bcac015e52f6a65dafaf41ea125816257f"
+    PKG_FFMPEG_BRANCH="dev/4.4/rpi_import_1"
     PKG_SHA256="4bd6e56920b90429bc09e43cda554f5bb9125c4ac090b4331fc459bb709eea68"
     PKG_URL="https://github.com/jc-kynesim/rpi-ffmpeg/archive/${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="libreelec dav1d"
@@ -30,6 +31,15 @@ case "${PROJECT}" in
     PKG_PATCH_DIRS="libreelec v4l2-request v4l2-drmprime"
     ;;
 esac
+
+post_unpack() {
+  # Fix FFmpeg version
+  if [ "${PROJECT}" = "Amlogic" ]; then
+    echo "${PKG_FFMPEG_BRANCH}-${PKG_VERSION:0:7}" > ${PKG_BUILD}/VERSION
+  else
+    echo "${PKG_VERSION}" > ${PKG_BUILD}/RELEASE
+  fi
+}
 
 # Dependencies
 get_graphicdrivers


### PR DESCRIPTION
This PR picks up the pkg version & writes it to the `RELEASE` / `VERSION` file which is picked up by the ffmpeg build

#### before 
`FFmpeg version/source: 9.0.0-10379-g73795073fa`
```
=== tested on ===
AMLGX.arm-RR-20220907-62dd248
Linux vim1 5.19.0 #1 SMP PREEMPT Wed Sep 7 22:21:57 CEST 2022 aarch64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:1ade57db993d29ea314420c416b77b028d142135). Platform: Linux ARM 32-bit
Using Release Kodi x32
Kodi compiled 2022-09-07 by GCC 12.2.0 for Linux ARM 32-bit version 5.19.0 (332544)
Running on Amlogic Meson GXL (S905X) Khadas VIM with LibreELEC (ST): RR-20220907-62dd248 11.0, kernel: Linux ARM 64-bit version 5.19.0
FFmpeg version/source: 9.0.0-10379-g73795073fa
Host CPU: ARMv8 Processor rev 4 (v8l), 4 cores available
ARM Features: Neon enabled
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_VERSION = OpenGL ES 2.0 Mesa 22.2.0-rc3
```
#### after 
`FFmpeg version/source: dev/4.4/rpi_import_1-0e5290b`
```
=== tested on ===
AMLGX.arm-RR-20220909-8e3995e
Linux vim1 5.19.0 #1 SMP PREEMPT Thu Sep 8 17:11:43 CEST 2022 aarch64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:1ade57db993d29ea314420c416b77b028d142135). Platform: Linux ARM 32-bit
Using Release Kodi x32
Kodi compiled 2022-09-08 by GCC 12.2.0 for Linux ARM 32-bit version 5.19.0 (332544)
Running on Amlogic Meson GXL (S905X) Khadas VIM with LibreELEC (ST): RR-20220909-8e3995e 11.0, kernel: Linux ARM 64-bit version 5.19.0
FFmpeg version/source: dev/4.4/rpi_import_1-0e5290b
Host CPU: ARMv8 Processor rev 4 (v8l), 4 cores available
ARM Features: Neon enabled
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_VERSION = OpenGL ES 2.0 Mesa 22.2.0-rc3
```
#### before
`4.4.1-Kodi`
```
=== tested on ===
x11.x86_64-RR-20220908-4a65074
Linux phoenix 5.19.7 #1 SMP Wed Sep 7 22:55:24 CEST 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:1ade57db993d29ea314420c416b77b028d142135). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-09-08 by GCC 12.2.0 for Linux x86 64-bit version 5.19.7 (332551)
Running on LibreELEC (ST): RR-20220908-4a65074 11.0, kernel: Linux x86 64-bit version 5.19.7
FFmpeg version/source: 4.4.1-Kodi
Host CPU: Intel(R) Core(TM) i3-6100 CPU @ 3.70GHz, 4 cores available
[    0.000000] DMI: Gigabyte Technology Co., Ltd. B150N Phoenix-WIFI/B150N Phoenix-WIFI-CF, BIOS F22e 03/09/2018
CApplication::CreateGUI - using the x11 windowing system
RetroPlayer[PROCESS]: Registering process control for X11
CRenderSystemGL::InitRenderSystem - Version: 4.6 (Core Profile) Mesa 22.2.0-rc3, Major: 4, Minor: 6
GL_RENDERER = Mesa Intel(R) HD Graphics 530 (SKL GT2)
GL_VERSION = 4.6 (Core Profile) Mesa 22.2.0-rc3
libva info: VA-API version 1.15.0
vainfo: VA-API version: 1.15 (libva 2.15.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.5.3 (73795073fa)
```

#### after
`4.4.1-Nexus-Alpha1-Kodi`
```
=== tested on ===
x11.x86_64-RR-20220909-8e3995e
Linux phoenix 5.19.7 #1 SMP Wed Sep 7 22:55:24 CEST 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA2 (19.90.705) Git:1ade57db993d29ea314420c416b77b028d142135). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-09-08 by GCC 12.2.0 for Linux x86 64-bit version 5.19.7 (332551)
Running on LibreELEC (ST): RR-20220909-8e3995e 11.0, kernel: Linux x86 64-bit version 5.19.7
FFmpeg version/source: 4.4.1-Nexus-Alpha1-Kodi
Host CPU: Intel(R) Core(TM) i3-6100 CPU @ 3.70GHz, 4 cores available
[    0.000000] DMI: Gigabyte Technology Co., Ltd. B150N Phoenix-WIFI/B150N Phoenix-WIFI-CF, BIOS F22e 03/09/2018
CApplication::CreateGUI - using the x11 windowing system
RetroPlayer[PROCESS]: Registering process control for X11
CRenderSystemGL::InitRenderSystem - Version: 4.6 (Core Profile) Mesa 22.2.0-rc3, Major: 4, Minor: 6
GL_RENDERER = Mesa Intel(R) HD Graphics 530 (SKL GT2)
GL_VERSION = 4.6 (Core Profile) Mesa 22.2.0-rc3
libva info: VA-API version 1.15.0
vainfo: VA-API version: 1.15 (libva 2.15.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.5.3 (73795073fa)
```
