### PR TITLE
[LE10] Backport: LibreELEC-settings: update to d6c41d4

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="1bc83885ec089273e448006dc6ab16c0bb0bda91"
-PKG_SHA256="b711bfaf2556dec4b368b0b8360c7c32cd161db8bca78c2326530abd6cb256aa"
+PKG_VERSION="d6c41d41b4090d3d6a3cf1c4913b4e68ede316a4"
+PKG_SHA256="ea89930f9d0e67738339d09faf6161da844d612840b3d425cb29c5a036ef1e03"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Backport of #6882 


Changes since d6c41d4:

Update translations from Weblate
Rework manual update for new infrastructure