### PR TITLE
vim: update to 9.0.0453

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vim"
-PKG_VERSION="8.2.5052"
-PKG_SHA256="e96be06c4955cd5b75f0ea026d7845e136d435b9e7621f9534a1034c1a0ca724"
+PKG_VERSION="9.0.0453"
+PKG_SHA256="b90063706a2a9ee234275e0dd4b71a11e24867c33203c432fd6e9799fdc3bff9"
 PKG_LICENSE="VIM"
 PKG_SITE="http://www.vim.org/"
 PKG_URL="https://github.com/vim/vim/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,6 @@
+132
+- vim: update to 9.0.0453
+
 131
 - Add kmsxx (kmsprint, kmstest)
 

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="131"
+PKG_REV="132"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
Upgrade vim from version 8.2.5052 to 9.0.0453. This is the latest version as reported by script tools/update-scan.
To build this change :
  docker run --rm --log-driver none -v `pwd`:/build -w /build -it libreelec scripts/create_addon system-tools
To test this change on the target:
1.  Install addon from zip file. Located at target/addons/10.80.8/Generic/x86_64/virtual.system-tools/virtual.system-tools-10.80.8.132.zip
2. ssh into the target and type in:
  vim --version. 
It should display VIM - Vi IMproved 9.0