### PR TITLE
fix ccache handling of kodi and gcc:bootstrap

### DIFF
--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -78,6 +78,28 @@ PKG_CONFIGURE_OPTS_HOST="${GCC_COMMON_CONFIGURE_OPTS} \
                          --enable-clocale=gnu \
                          ${TARGET_ARCH_GCC_OPTS}"
 
+post_makeinstall_bootstrap() {
+  GCC_VERSION=$(${TOOLCHAIN}/bin/${TARGET_NAME}-gcc -dumpversion)
+  DATE="0401$(echo ${GCC_VERSION} | sed 's/\./0/g')"
+  CROSS_CC=${TARGET_PREFIX}gcc-${GCC_VERSION}
+
+  rm -f ${TARGET_PREFIX}gcc
+
+cat > ${TARGET_PREFIX}gcc <<EOF
+#!/bin/sh
+${TOOLCHAIN}/bin/ccache ${CROSS_CC} "\$@"
+EOF
+
+  chmod +x ${TARGET_PREFIX}gcc
+
+  # To avoid cache trashing
+  touch -c -t ${DATE} ${CROSS_CC}
+
+  # install lto plugin for binutils
+  mkdir -p ${TOOLCHAIN}/lib/bfd-plugins
+    ln -sf ../gcc/${TARGET_NAME}/${GCC_VERSION}/liblto_plugin.so ${TOOLCHAIN}/lib/bfd-plugins
+}
+
 pre_configure_host() {
   unset CPP
 }

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -229,7 +229,7 @@ configure_package() {
                          -DENABLE_UDEV=ON \
                          -DENABLE_DBUS=ON \
                          -DENABLE_XSLT=ON \
-                         -DENABLE_CCACHE=ON \
+                         -DENABLE_CCACHE=OFF \
                          -DENABLE_LIRCCLIENT=ON \
                          -DENABLE_EVENTCLIENTS=ON \
                          -DENABLE_LDGOLD=ON \


### PR DESCRIPTION
Kodi's own ccache support was incorrectly enabled when switching from configure to cmake builds in commit 98a96ef1f721e8a444a7769321a6185f156b6f46

This resulted in ccache misses on clean rebuilds and about 1GB of data being added to the cache on each clean rebuild and longer rebuild times.

Restore the old behavior to speed things up again.

Also gcc:bootstrap didn't install a ccache wrapper so glibc was being rebuilt without ccache. Add the wrapper to speed up builds.

I'm now getting a 99.67% cache hit rate on clean RPi4 rebuilds (with ccache intact) and roughly 15-20% faster rebuilds.