### PR TITLE
[LE11] Allwinner: linux: Fix H5 CVBS patch

### DIFF
--- a/projects/Allwinner/patches/linux/0036-wip-h3-h5-cvbs.patch
+++ b/projects/Allwinner/patches/linux/0036-wip-h3-h5-cvbs.patch
@@ -1,19 +1,68 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 24545292c40900c0871381b8697ade70aa9e3bdf Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Wed, 20 Jan 2021 22:15:36 +0100
 Subject: [PATCH] wip h3/h5 cvbs
 
 ---
- arch/arm/boot/dts/sunxi-h3-h5.dtsi         | 111 ++++++++++++++++++++-
- drivers/clk/sunxi-ng/ccu-sun8i-h3.c        |  14 ++-
- drivers/gpu/drm/sun4i/Makefile             |   2 +-
- drivers/gpu/drm/sun4i/sun8i_mixer.c        |  42 +++++++-
- drivers/gpu/drm/sun4i/sun8i_mixer.h        |   5 +-
- 6 files changed, 169 insertions(+), 9 deletions(-)
+ arch/arm/boot/dts/sun8i-h3.dtsi              | 22 +++++
+ arch/arm/boot/dts/sunxi-h3-h5.dtsi           | 95 +++++++++++++++++++-
+ arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi | 22 +++++
+ drivers/clk/sunxi-ng/ccu-sun8i-h3.c          | 14 ++-
+ drivers/gpu/drm/sun4i/Makefile               |  2 +-
+ drivers/gpu/drm/sun4i/sun4i_tv.c             | 35 +++++++-
+ drivers/gpu/drm/sun4i/sun8i_mixer.c          | 44 ++++++++-
+ drivers/gpu/drm/sun4i/sun8i_mixer.h          |  5 +-
+ 8 files changed, 227 insertions(+), 12 deletions(-)
 
+diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
+index 448dd325f8c3..d896dc5502f5 100644
+--- a/arch/arm/boot/dts/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/sun8i-h3.dtsi
+@@ -252,6 +252,20 @@ ths: thermal-sensor@1c25000 {
+ 			nvmem-cell-names = "calibration";
+ 			#thermal-sensor-cells = <0>;
+ 		};
++
++		tve: tv-encoder@1e00000 {
++			compatible = "allwinner,sun8i-h3-tv-encoder";
++			reg = <0x01e00000 0x1000>;
++			clocks = <&ccu CLK_BUS_TVE>;
++			resets = <&ccu RST_BUS_TVE>;
++			status = "disabled";
++
++			port {
++				tve_in_tcon1: endpoint {
++					remote-endpoint = <&tcon1_out_tve>;
++				};
++			};
++		};
+ 	};
+ 
+ 	thermal-zones {
+@@ -299,6 +313,10 @@ &mbus {
+ 	compatible = "allwinner,sun8i-h3-mbus";
+ };
+ 
++&mixer1 {
++	resets = <&display_clocks RST_WB>;
++};
++
+ &mmc0 {
+ 	compatible = "allwinner,sun7i-a20-mmc";
+ 	clocks = <&ccu CLK_BUS_MMC0>,
+@@ -346,3 +364,7 @@ &rtc {
+ &sid {
+ 	compatible = "allwinner,sun8i-h3-sid";
+ };
++
++&tcon1_out_tve {
++	remote-endpoint = <&tve_in_tcon1>;
++};
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index 3d37a6a586b6..152029413784 100644
 --- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
 +++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
-@@ -119,7 +119,7 @@
+@@ -119,7 +119,7 @@ osc32k: osc32k_clk {
  
  	de: display-engine {
  		compatible = "allwinner,sun8i-h3-display-engine";
@@ -22,7 +71,7 @@ Subject: [PATCH] wip h3/h5 cvbs
  		status = "disabled";
  	};
  
-@@ -163,11 +163,50 @@
+@@ -163,11 +163,50 @@ ports {
  				#size-cells = <0>;
  
  				mixer0_out: port@1 {
@@ -51,7 +100,7 @@ Subject: [PATCH] wip h3/h5 cvbs
 +				 <&display_clocks CLK_MIXER1>;
 +			clock-names = "bus",
 +				      "mod";
-+			resets = <&display_clocks RST_WB>;
++			/* reset is added by SoC dtsi */
 +
 +			ports {
 +				#address-cells = <1>;
@@ -74,7 +123,7 @@ Subject: [PATCH] wip h3/h5 cvbs
  				};
  			};
  		};
-@@ -196,11 +235,19 @@
+@@ -196,11 +235,19 @@ ports {
  				#size-cells = <0>;
  
  				tcon0_in: port@0 {
@@ -95,7 +144,7 @@ Subject: [PATCH] wip h3/h5 cvbs
  				};
  
  				tcon0_out: port@1 {
-@@ -216,6 +263,49 @@
+@@ -216,6 +263,48 @@ tcon0_out_hdmi: endpoint@1 {
  			};
  		};
  
@@ -136,7 +185,6 @@ Subject: [PATCH] wip h3/h5 cvbs
 +
 +					tcon1_out_tve: endpoint@1 {
 +						reg = <1>;
-+						remote-endpoint = <&tve_in_tcon1>;
 +					};
 +				};
 +			};
@@ -145,14 +193,18 @@ Subject: [PATCH] wip h3/h5 cvbs
  		mmc0: mmc@1c0f000 {
  			/* compatible and clocks are in per SoC .dtsi file */
  			reg = <0x01c0f000 0x1000>;
-@@ -831,6 +921,21 @@
- 			status = "disabled";
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+index 4f00ae227cce..d30c85948ac5 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+@@ -197,6 +197,20 @@ ths: thermal-sensor@1c25000 {
+ 			nvmem-cell-names = "calibration";
+ 			#thermal-sensor-cells = <1>;
  		};
- 
-+		tve: tv-encoder@1e00000 {
-+			compatible = "allwinner,sun8i-h3-tv-encoder",
-+				     "allwinner,sun4i-a10-tv-encoder";
-+			reg = <0x01e00000 0x1000>;
++
++		tve: tv-encoder@1e40000 {
++			compatible = "allwinner,sun50i-h5-tv-encoder";
++			reg = <0x01e40000 0x1000>;
 +			clocks = <&ccu CLK_BUS_TVE>;
 +			resets = <&ccu RST_BUS_TVE>;
 +			status = "disabled";
@@ -163,13 +215,33 @@ Subject: [PATCH] wip h3/h5 cvbs
 +				};
 +			};
 +		};
+ 	};
+ 
+ 	thermal-zones {
+@@ -250,6 +264,10 @@ &mbus {
+ 	compatible = "allwinner,sun50i-h5-mbus";
+ };
+ 
++&mixer1 {
++	resets = <&display_clocks RST_MIXER1>;
++};
 +
- 		hdmi: hdmi@1ee0000 {
- 			#sound-dai-cells = <0>;
- 			compatible = "allwinner,sun8i-h3-dw-hdmi",
+ &mmc0 {
+ 	compatible = "allwinner,sun50i-h5-mmc",
+ 		     "allwinner,sun50i-a64-mmc";
+@@ -285,3 +303,7 @@ &rtc {
+ &sid {
+ 	compatible = "allwinner,sun50i-h5-sid";
+ };
++
++&tcon1_out_tve {
++	remote-endpoint = <&tve_in_tcon1>;
++};
+diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+index e058cf691aea..0b0df6d6bc9c 100644
 --- a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
 +++ b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
-@@ -456,8 +456,18 @@ static SUNXI_CCU_M_WITH_MUX_GATE(tcon_cl
+@@ -458,8 +458,18 @@ static SUNXI_CCU_M_WITH_MUX_GATE(tcon_clk, "tcon", tcon_parents,
  				 CLK_SET_RATE_PARENT);
  
  static const char * const tve_parents[] = { "pll-de", "pll-periph1" };
@@ -190,9 +262,11 @@ Subject: [PATCH] wip h3/h5 cvbs
  
  static const char * const deinterlace_parents[] = { "pll-periph0", "pll-periph1" };
  static SUNXI_CCU_M_WITH_MUX_GATE(deinterlace_clk, "deinterlace", deinterlace_parents,
+diff --git a/drivers/gpu/drm/sun4i/Makefile b/drivers/gpu/drm/sun4i/Makefile
+index 0d04f2447b01..7b151994e904 100644
 --- a/drivers/gpu/drm/sun4i/Makefile
 +++ b/drivers/gpu/drm/sun4i/Makefile
-@@ -16,7 +16,7 @@ sun8i-drm-hdmi-y		+= sun8i_hdmi_phy_clk.
+@@ -16,7 +16,7 @@ sun8i-drm-hdmi-y		+= sun8i_hdmi_phy_clk.o
  
  sun8i-mixer-y			+= sun8i_mixer.o sun8i_ui_layer.o \
  				   sun8i_vi_layer.o sun8i_ui_scaler.o \
@@ -201,6 +275,97 @@ Subject: [PATCH] wip h3/h5 cvbs
  
  sun4i-tcon-y			+= sun4i_crtc.o
  sun4i-tcon-y			+= sun4i_dotclock.o
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tv.c b/drivers/gpu/drm/sun4i/sun4i_tv.c
+index 94883abe0dfd..9c7090a0d52a 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tv.c
+@@ -10,6 +10,7 @@
+ #include <linux/component.h>
+ #include <linux/module.h>
+ #include <linux/of_address.h>
++#include <linux/of_device.h>
+ #include <linux/platform_device.h>
+ #include <linux/regmap.h>
+ #include <linux/reset.h>
+@@ -167,6 +168,11 @@ struct tv_mode {
+ 	const struct resync_parameters	*resync_params;
+ };
+ 
++struct sun4i_tv_quirks {
++	unsigned int calibration;
++	unsigned int unknown : 1;
++};
++
+ struct sun4i_tv {
+ 	struct drm_connector	connector;
+ 	struct drm_encoder	encoder;
+@@ -527,7 +533,7 @@ static const struct regmap_config sun4i_tv_regmap_config = {
+ 	.reg_bits	= 32,
+ 	.val_bits	= 32,
+ 	.reg_stride	= 4,
+-	.max_register	= SUN4I_TVE_WSS_DATA2_REG,
++	.max_register	= 0x400,
+ 	.name		= "tv-encoder",
+ };
+ 
+@@ -537,13 +543,19 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+ 	struct platform_device *pdev = to_platform_device(dev);
+ 	struct drm_device *drm = data;
+ 	struct sun4i_drv *drv = drm->dev_private;
++	const struct sun4i_tv_quirks *quirks;
+ 	struct sun4i_tv *tv;
+ 	void __iomem *regs;
+ 	int ret;
+ 
++	quirks = of_device_get_match_data(dev);
++	if (!quirks)
++		return -EINVAL;
++
+ 	tv = devm_kzalloc(dev, sizeof(*tv), GFP_KERNEL);
+ 	if (!tv)
+ 		return -ENOMEM;
++
+ 	tv->drv = drv;
+ 	dev_set_drvdata(dev, tv);
+ 
+@@ -580,6 +592,11 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+ 	}
+ 	clk_prepare_enable(tv->clk);
+ 
++	if (quirks->calibration)
++		regmap_write(tv->regs, 0x304, quirks->calibration);
++	if (quirks->unknown)
++		regmap_write(tv->regs, 0x30c, 0x00101110);
++
+ 	drm_encoder_helper_add(&tv->encoder,
+ 			       &sun4i_tv_helper_funcs);
+ 	ret = drm_simple_encoder_init(drm, &tv->encoder,
+@@ -648,8 +665,22 @@ static int sun4i_tv_remove(struct platform_device *pdev)
+ 	return 0;
+ }
+ 
++static const struct sun4i_tv_quirks a10_quirks = {
++};
++
++static const struct sun4i_tv_quirks h3_quirks = {
++	.calibration = 0x02000c00,
++};
++
++static const struct sun4i_tv_quirks h5_quirks = {
++	.calibration = 0x02850000,
++	.unknown = 1,
++};
++
+ static const struct of_device_id sun4i_tv_of_table[] = {
+-	{ .compatible = "allwinner,sun4i-a10-tv-encoder" },
++	{ .compatible = "allwinner,sun4i-a10-tv-encoder", .data = &a10_quirks },
++	{ .compatible = "allwinner,sun8i-h3-tv-encoder", .data = &h3_quirks },
++	{ .compatible = "allwinner,sun50i-h5-tv-encoder", .data = &h5_quirks },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, sun4i_tv_of_table);
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.c b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+index f5291170bf5e..490e8e74450f 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_mixer.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_mixer.c
 @@ -32,6 +32,12 @@ struct de2_fmt_info {
@@ -216,7 +381,7 @@ Subject: [PATCH] wip h3/h5 cvbs
  static const struct de2_fmt_info de2_formats[] = {
  	{
  		.drm_fmt = DRM_FORMAT_ARGB8888,
-@@ -341,10 +347,29 @@ static void sun8i_mixer_mode_set(struct
+@@ -327,10 +333,29 @@ static void sun8i_mixer_mode_set(struct sunxi_engine *engine,
  			 interlaced ? "on" : "off");
  }
  
@@ -249,7 +414,7 @@ Subject: [PATCH] wip h3/h5 cvbs
  };
  
  static bool sun8i_mixer_volatile_reg(struct device *dev, unsigned int reg)
-@@ -608,6 +633,15 @@ static const struct sun8i_mixer_cfg sun8
+@@ -600,6 +625,15 @@ static const struct sun8i_mixer_cfg sun8i_h3_mixer0_cfg = {
  	.vi_num		= 1,
  };
  
@@ -263,22 +428,24 @@ Subject: [PATCH] wip h3/h5 cvbs
 +};
 +
  static const struct sun8i_mixer_cfg sun8i_r40_mixer0_cfg = {
- 	.ccsc		= 0,
+ 	.ccsc		= CCSC_MIXER0_LAYOUT,
  	.mod_rate	= 297000000,
-@@ -677,6 +711,10 @@ static const struct of_device_id sun8i_m
+@@ -686,6 +720,10 @@ static const struct of_device_id sun8i_mixer_of_table[] = {
+ 		.compatible = "allwinner,sun8i-h3-de2-mixer-0",
  		.data = &sun8i_h3_mixer0_cfg,
  	},
- 	{
++	{
 +		.compatible = "allwinner,sun8i-h3-de2-mixer-1",
 +		.data = &sun8i_h3_mixer1_cfg,
 +	},
-+	{
+ 	{
  		.compatible = "allwinner,sun8i-r40-de2-mixer-0",
  		.data = &sun8i_r40_mixer0_cfg,
- 	},
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.h b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+index 85c94884fb9a..28cdaf0044d9 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_mixer.h
 +++ b/drivers/gpu/drm/sun4i/sun8i_mixer.h
-@@ -120,6 +120,10 @@
+@@ -118,6 +118,10 @@
  /* format 20 is packed YVU444 10-bit */
  /* format 21 is packed YUV444 10-bit */
  
@@ -289,7 +456,7 @@ Subject: [PATCH] wip h3/h5 cvbs
  /*
   * Sub-engines listed bellow are unused for now. The EN registers are here only
   * to be used to disable these sub-engines.
-@@ -130,7 +134,6 @@
+@@ -128,7 +132,6 @@
  #define SUN8I_MIXER_PEAK_EN			0xa6000
  #define SUN8I_MIXER_ASE_EN			0xa8000
  #define SUN8I_MIXER_FCC_EN			0xaa000
@@ -297,3 +464,6 @@ Subject: [PATCH] wip h3/h5 cvbs
  
  #define SUN50I_MIXER_FCE_EN			0x70000
  #define SUN50I_MIXER_PEAK_EN			0x70800
+-- 
+2.37.3
+


### PR DESCRIPTION
As it turns out, H5 CVBS output doesn't work. I thought it's same as on H3, but it has some specifics, which need different handling. Update patch so there is at least some image displayed.

While testing, both me and forum user experienced some issues. However, they are different. CVBS works well for me but not the user. I experienced Kodi crashes, but user presumably didn't (not 100% sure).

NOTE: This means that H5 CVBS output on LE10 is totally broken. However, I'm hesitant to backport this patch because resulting image doesn't work well. While issues in my case doesn't seem really connected to CVBS (Kodi crash), they can be observed only when CVBS is enabled and HDMI unplugged.

Ref: https://forum.libreelec.tv/thread/26022-cvbs-out-on-orange-pi-pc-2/