### PR TITLE
nghttp2: update to 1.50.0

### DIFF
--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.49.0"
-PKG_SHA256="b0cfd492bbf0b131c472e8f6501c9f4ee82b51b68130f47b278c0b7c9848a66e"
+PKG_VERSION="1.50.0"
+PKG_SHA256="af24007e34c18c782393a1dc3685f8fd5b50283e90a9191d25488eb50aa2c825"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
announcement:
- https://nghttp2.org/blog/2022/09/21/nghttp2-v1-50-0/
- https://github.com/nghttp2/nghttp2/releases/tag/v1.50.0