### PR TITLE
[le11] mariadb: update to 10.9.3 and addon (107)

### DIFF
--- a/packages/addons/service/mariadb/changelog.txt
+++ b/packages/addons/service/mariadb/changelog.txt
@@ -1,3 +1,8 @@
+107
+- update MariaDB to 10.9.3
+- supports openssl
+- migrated to pcre2
+
 106
 - update MariaDB to 10.4.22
 - drop support for TokuDB, it is deprecated in 10.5.y and is not

--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,14 +2,14 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="10.4.22"
-PKG_REV="106"
-PKG_SHA256="44bdc36eeb02888296e961718bae808f3faab268ed49160a785248db60500c00"
+PKG_VERSION="10.9.3"
+PKG_REV="107"
+PKG_SHA256="9a1e229972fcccc8270e633f68d3fb824da151dcf4f53da1df8d947aca876bee"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://downloads.mariadb.com/MariaDB/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host ncurses:host openssl:host"
-PKG_DEPENDS_TARGET="toolchain binutils bzip2 libaio libxml2 lzo ncurses openssl systemd zlib mariadb:host"
+PKG_DEPENDS_TARGET="toolchain binutils boost bzip2 libaio libxml2 lz4 lzo ncurses openssl pcre2 systemd zlib mariadb:host"
 PKG_SHORTDESC="MariaDB is a community-developed fork of the MySQL."
 PKG_LONGDESC="MariaDB (${PKG_VERSION}) is a fast SQL database server and a drop-in replacement for MySQL."
 PKG_TOOLCHAIN="cmake"
@@ -35,8 +35,7 @@ configure_package() {
     -DCMAKE_INSTALL_MESSAGE=NEVER \
     -DSTACK_DIRECTION=-1 \
     -DHAVE_IB_GCC_ATOMIC_BUILTINS=1 \
-    -DCMAKE_CROSSCOMPILING=OFF \
-    import_executables"
+    -DCMAKE_CROSSCOMPILING=OFF"
 
   PKG_CMAKE_OPTS_TARGET=" \
     -DCMAKE_INSTALL_MESSAGE=NEVER \
@@ -53,7 +52,7 @@ configure_package() {
     -DWITH_SSL=${SYSROOT_PREFIX}/usr \
     -DWITH_JEMALLOC=OFF \
     -DWITHOUT_TOKUDB=1 \
-    -DWITH_PCRE=bundled \
+    -DWITH_PCRE=system \
     -DWITH_ZLIB=bundled \
     -DWITH_EDITLINE=bundled \
     -DWITH_LIBEVENT=bundled \
@@ -71,7 +70,13 @@ configure_package() {
     -DENABLE_STATIC_LIBS=OFF \
     -DMYSQL_UNIX_ADDR=/var/run/mysqld/mysqld.sock \
     -DWITH_SAFEMALLOC=OFF \
-    -DWITHOUT_AUTH_EXAMPLES=ON"
+    -DWITHOUT_AUTH_EXAMPLES=ON \
+    -DLSTAT_FOLLOWS_SLASHED_SYMLINK_EXITCODE=0 \
+    -DLSTAT_FOLLOWS_SLASHED_SYMLINK_EXITCODE__TRYRUN_OUTPUT='' \
+    -DMASK_LONGDOUBLE_EXITCODE=0 \
+    -DMASK_LONGDOUBLE_EXITCODE__TRYRUN_OUTPUT='' \
+    -DSTAT_EMPTY_STRING_BUG_EXITCODE=0 \
+    -DSTAT_EMPTY_STRING_BUG_EXITCODE__TRYRUN_OUTPUT=''"
 }
 
 make_host() {
@@ -93,8 +98,8 @@ addon() {
   mkdir -p ${ADDON}/bin
   mkdir -p ${ADDON}/config
 
-  cp ${MARIADB}/bin/mysql \
-     ${MARIADB}/bin/mysqld \
+  cp ${MARIADB}/bin/mariadbd \
+     ${MARIADB}/bin/mysql \
      ${MARIADB}/bin/mysqladmin \
      ${MARIADB}/bin/mysqldump \
      ${MARIADB}/bin/mysql_secure_installation \

--- a/packages/addons/service/mariadb/source/bin/mariadb.start
+++ b/packages/addons/service/mariadb/source/bin/mariadb.start
@@ -10,7 +10,7 @@ oe_setup_addon service.mariadb
 mkdir -p /var/run/mysqld
 
 # exit if already running
-PID=$(ps aux | awk '/\/bin\/mysqld/ {print $1; exit 0}')
+PID=$(ps aux | awk '/\/bin\/mariadbd/ {print $1; exit 0}')
 if [ -n "$PID" ]; then
   echo "MariaDB server is already running"
   exit 0
@@ -23,6 +23,7 @@ fi
 
 # install database
 if [ ! -d "$ADDON_HOME/data/mysql" ]; then
+  mkdir -p $ADDON_HOME/data
   echo "Installing database"
   $ADDON_DIR/bin/mysql_install_db --basedir=$ADDON_DIR --datadir=$ADDON_HOME/data
 fi
@@ -54,5 +55,5 @@ SQL_DATA
   init_file="--init-file=$ADDON_HOME/set_mysql_passwords.sql"
 fi
 
-echo "Starting mysqld"
-MYSQL_HOME="$ADDON_HOME" exec $ADDON_DIR/bin/mysqld $init_file &
+echo "Starting mariadbd"
+MYSQL_HOME="$ADDON_HOME" exec $ADDON_DIR/bin/mariadbd $init_file &


### PR DESCRIPTION
compatibility issues with the le11 build environment are why the intermediate 10.6 were not compiled for le11. This release could be backported to le10 if required to be.

manage build cross compile build errors:
- CMake Error: try_run() invoked in cross-compiling mode, please set the following cache variables appropriately

variables required to be defined

    LSTAT_FOLLOWS_SLASHED_SYMLINK_EXITCODE=0
    LSTAT_FOLLOWS_SLASHED_SYMLINK_EXITCODE__TRYRUN_OUTPUT=““
    MASK_LONGDOUBLE_EXITCODE=0
    MASK_LONGDOUBLE_EXITCODE__TRYRUN_OUTPUT=“”
    STAT_EMPTY_STRING_BUG_EXITCODE=0
    STAT_EMPTY_STRING_BUG_EXITCODE__TRYRUN_OUTPUT=“”