### PR TITLE
Wayland updates

### DIFF
--- a/packages/wayland/lib/fcft/package.mk
+++ b/packages/wayland/lib/fcft/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fcft"
-PKG_VERSION="3.1.4"
-PKG_SHA256="37363f7af0430161902b8d194016366b0fbca3b8353ee26b70c5b7ad8e9602c8"
+PKG_VERSION="3.1.5"
+PKG_SHA256="8a7e09c887edce97f8780dba8a060026c3551da48252819400d7af1c5eacf871"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/fcft"
 PKG_URL="https://codeberg.org/dnkl/fcft/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/util/bemenu/package.mk
+++ b/packages/wayland/util/bemenu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bemenu"
-PKG_VERSION="0.6.10"
-PKG_SHA256="9d47557ed4572fa66e6a80364b95e4dd7a588ca75fe89c68c029b7f240b56a60"
+PKG_VERSION="0.6.12"
+PKG_SHA256="103c1650a55da57a6ec1acabc9490d5eedd5566d34f1c1823a7cef83d3e34ed1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Cloudef/bemenu"
 PKG_URL="https://github.com/Cloudef/bemenu/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.26"
-PKG_SHA256="c553384c1c68afd762fa537a2569cc9074fe7600da12d3472761e77a2ba56f13"
+PKG_VERSION="1.27"
+PKG_SHA256="9046f10a425d4e2a00965a03acfb6b3fb575a56503ac72c2b86821c69653375c"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
-PKG_URL="https://wayland.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://gitlab.freedesktop.org/wayland/${PKG_NAME}/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain wayland:host"
 PKG_LONGDESC="Specifications of extended Wayland protocols"
 

--- a/packages/wayland/weston/package.mk
+++ b/packages/wayland/weston/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="weston"
-PKG_VERSION="10.0.2"
-PKG_SHA256="89646ca0d9f8d413c2767e5c3828eaa3fa149c2a105b3729a6894fa7cf1549e7"
+PKG_VERSION="11.0.0"
+PKG_SHA256="a6138d4dc9554560ac304312df456019f4be025ec79130f05fb5f2e41c091e1d"
 PKG_LICENSE="MIT"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/weston/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -17,10 +17,8 @@ PKG_MESON_OPTS_TARGET="-Dbackend-drm=true \
                        -Dscreenshare=false \
                        -Dbackend-wayland=false \
                        -Dbackend-x11=false \
-                       -Ddeprecated-backend-fbdev=false \
                        -Dbackend-default=drm \
                        -Drenderer-gl=true \
-                       -Ddeprecated-weston-launch=false \
                        -Dxwayland=false \
                        -Dsystemd=true \
                        -Dremoting=false \
@@ -30,9 +28,7 @@ PKG_MESON_OPTS_TARGET="-Dbackend-drm=true \
                        -Dshell-ivi=false \
                        -Dshell-kiosk=false \
                        -Ddesktop-shell-client-default="weston-desktop-shell" \
-                       -Ddeprecated-wl-shell=false \
                        -Dcolor-management-lcms=false \
-                       -Dcolor-management-colord=false \
                        -Dlauncher-logind=false \
                        -Dlauncher-libseat=true \
                        -Dimage-jpeg=true \
@@ -44,7 +40,6 @@ PKG_MESON_OPTS_TARGET="-Dbackend-drm=true \
                        -Dwcap-decode=false \
                        -Dtest-junit-xml=false \
                        -Dtest-skip-is-failure=false \
-                       -Dtest-gl-renderer=false \
                        -Ddoc=false"
 
 pre_configure_target() {


### PR DESCRIPTION
- [fcft: update to 3.1.5](https://github.com/LibreELEC/LibreELEC.tv/commit/4ef2b8c88be86b88bf15b944cafe15f69ed129e5)
  - https://codeberg.org/dnkl/fcft/src/branch/master/CHANGELOG.md
- [weston: update to 11.0.0](https://github.com/LibreELEC/LibreELEC.tv/commit/b80a350a8b03df23da2372babb305b423d70b4ff)
- bemenu: update to 0.6.12
  - https://github.com/Cloudef/bemenu/releases
- wayland-protocols: update to 1.27