### PR TITLE
mesa: update panfrost: enable Mali T628 support patch for mesa 22.

### DIFF
--- a/projects/Samsung/patches/mesa/panfrost-0001-panfrost-enable-Mali-T628-support.patch
+++ b/projects/Samsung/patches/mesa/panfrost-0001-panfrost-enable-Mali-T628-support.patch
@@ -18,10 +18,10 @@ index 693b475beb5..cdba8db319e 100644
  
  /* Table of supported Mali GPUs */
  const struct panfrost_model panfrost_model_list[] = {
-+        MODEL(0x620, "T620", "T62x", NO_ANISO, {}),
-         MODEL(0x720, "T720", "T72x", NO_ANISO, { .no_hierarchical_tiling = true }),
-         MODEL(0x750, "T760", "T76x", NO_ANISO, {}),
-         MODEL(0x820, "T820", "T82x", NO_ANISO, { .no_hierarchical_tiling = true }),
++        MODEL(0x620, "T620", "T62x", NO_ANISO, 8192, {}),
+         MODEL(0x720, "T720", "T72x", NO_ANISO, 8192, { .no_hierarchical_tiling = true }),
+         MODEL(0x750, "T760", "T76x", NO_ANISO, 8192, {}),
+         MODEL(0x820, "T820", "T82x", NO_ANISO, 8192, { .no_hierarchical_tiling = true }),
 -- 
 2.17.1
 


### PR DESCRIPTION
- Update patch to support #6907

without the updated patch
```
UNPACK      mesa
    APPLY PATCH (project)      projects/Samsung/patches/mesa/panfrost-0001-panfrost-enable-Mali-T628-support.patch
patching file src/panfrost/lib/pan_props.c
Hunk #1 FAILED at 53.
1 out of 1 hunk FAILED -- saving rejects to file src/panfrost/lib/pan_props.c.rej
*********** FAILED COMMAND ***********
patch -d "${PKG_BUILD}" -p1 < ${i} 1>&${VERBOSE_OUT}
**************************************
*********** FAILED COMMAND ***********
${SCRIPTS}/unpack "${PKG_NAME}" "${PARENT_PKG}"
**************************************
```