### PR TITLE
package updates and tidy ups

### DIFF
--- a/packages/debug/edid-decode/package.mk
+++ b/packages/debug/edid-decode/package.mk
@@ -2,15 +2,16 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="edid-decode"
-PKG_VERSION="770cfb947ea9d9eb5cda57a87dc66d13c60cfefc"
-PKG_SHA256="eb6a766b89ef5f7d06d6649fc442ee57377ee7add801cde0a5ba6b636da78075"
+PKG_VERSION="9ba4e90f3c0705351d32f526653e3e765fa2cf64" # 2022-09-23
+PKG_SHA256="8b55a1c09a32c4c39ea0092e1f468f545a535323eb36016e042e0bf156833a1b"
 PKG_LICENSE="None"
 PKG_SITE="https://git.linuxtv.org/edid-decode.git/"
 PKG_URL="https://repo.or.cz/edid-decode.git/snapshot/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Decode EDID data in human-readable format"
 
-EDID_SOURCES="edid-decode.cpp parse-base-block.cpp parse-cta-block.cpp \
+EDID_SOURCES="calc-gtf-cvt.cpp calc-ovt.cpp \
+              edid-decode.cpp parse-base-block.cpp parse-cta-block.cpp \
               parse-displayid-block.cpp parse-ls-ext-block.cpp \
               parse-di-ext-block.cpp parse-vtb-ext-block.cpp"
 

--- a/packages/devel/configtools/package.mk
+++ b/packages/devel/configtools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="configtools"
-PKG_VERSION="c8ddc8472f8efcadafc1ef53ca1d863415fddd5f" # 2020-12-22
-PKG_SHA256="6389d62e4e55554c764c2c0deb5b42767f34d7f274728c28355fedbaa337165b"
+PKG_VERSION="20403c5701973a4cbd7e0b4bbeb627fcd424a0f1" # 2022-08-01
+PKG_SHA256="d89be2c5a06d45e4a8731404cd6eb52ddde393480a56754a68b44f36753e38d7"
 PKG_LICENSE="GPL"
 PKG_SITE="http://git.savannah.gnu.org/cgit/config.git"
 PKG_URL="http://git.savannah.gnu.org/cgit/config.git/snapshot/config-${PKG_VERSION}.tar.gz"

--- a/packages/devel/libcap/package.mk
+++ b/packages/devel/libcap/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcap"
-PKG_VERSION="2.65"
-PKG_SHA256="73e350020cc31fe15360879d19384ffa3395a825f065fcf6bda3a5cdf965bebd"
+PKG_VERSION="2.66"
+PKG_SHA256="15c40ededb3003d70a283fe587a36b7d19c8b3b554e33f86129c059a4bb466b2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libcap/libcap.git/log/"
 PKG_URL="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/lang/lua54/package.mk
+++ b/packages/lang/lua54/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lua54"
-PKG_VERSION="5.4.3"
-PKG_SHA256="f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb"
+PKG_VERSION="5.4.4"
+PKG_SHA256="164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.lua.org"
 PKG_URL="http://www.lua.org/ftp/lua-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Mako"
-PKG_VERSION="1.2.2"
-PKG_SHA256="3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f"
+PKG_VERSION="1.2.3"
+PKG_SHA256="7fde96466fcfeedb0eed94f187f20b23d85e4cb41444be0e542e2c8c65c396cd"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/Mako"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/tools/mtools/package.mk
+++ b/packages/tools/mtools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mtools"
-PKG_VERSION="4.0.40"
-PKG_SHA256="a22fca42354011dd2293a7f51f228b46ebbd802e7740b0975912afecb79d5df4"
+PKG_VERSION="4.0.41"
+PKG_SHA256="2542152264fb3eff7ed70662abf4f4eef8133bc37d0b7a686c240df2b5f80a13"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/mtools/"
 PKG_URL="http://ftpmirror.gnu.org/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- mtools: update to 4.0.41
  - https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00011.html
- Mako: update to 1.2.3
  - https://docs.makotemplates.org/en/latest/changelog.html#id1
- configtools: update to 2022-08-01
- edid-decode: update to 2022-09-23
- libcap: update to 2.66
- lua54: update to 5.4.4
  - https://www.lua.org/bugs.html
  - https://www.lua.org/work/diffs-lua-5.4.3-lua-5.4.4.html