### PR TITLE
[le11] add default linker build opts

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -278,11 +278,19 @@ setup_toolchain() {
     TARGET_LDFLAGS+=" $FLAGS_OPTIM_LTO_OFF"
   fi
 
+  # Linker flags
+  DEFAULT_LINKER="${DEFAULT_LINKER:-bfd}"
+  TARGET_LINKER_FLAGS="-fuse-ld=${DEFAULT_LINKER}"
+
+  # bfd flag
+  if flag_enabled "bfd" "no"; then
+    TARGET_LINKER_FLAGS=" ${LDFLAGS_OPTIM_BFD}"
   # gold flag
-  if flag_enabled "gold" "$GOLD_SUPPORT" "only-disable"; then
-    TARGET_LDFLAGS+=" $LDFLAGS_OPTIM_GOLD"
+  elif flag_enabled "gold" "no"; then
+    TARGET_LINKER_FLAGS=" ${LDFLAGS_OPTIM_GOLD}"
     have_gold="yes"
   fi
+  TARGET_LDFLAGS+=" ${TARGET_LINKER_FLAGS}"
 
   # compiler optimization, descending priority: speed, size, default
   if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then

--- a/config/optimize
+++ b/config/optimize
@@ -27,6 +27,9 @@ FLAGS_OPTIM_LTO_FAT="-ffat-lto-objects"
 FLAGS_OPTIM_LTO_OFF="-fno-lto"
 LDFLAGS_OPTIM_LTO_COMMON="-fuse-linker-plugin"
 
+# bfd flags
+LDFLAGS_OPTIM_BFD="-fuse-ld=bfd"
+
 # gold flags
 LDFLAGS_OPTIM_GOLD="-fuse-ld=gold"
 

--- a/config/show_config
+++ b/config/show_config
@@ -30,7 +30,7 @@ show_config() {
   fi
   config_message+="\n - CPU features:\t\t\t ${TARGET_FEATURES}"
   config_message+="\n - LTO (Link Time Optimization) support: ${LTO_SUPPORT}"
-  config_message+="\n - GOLD (Google Linker) Support:\t ${GOLD_SUPPORT}"
+  config_message+="\n - Default Linker (bfd/gold):\t ${DEFAULT_LINKER}"
   config_message+="\n - LLVM support:\t\t\t ${LLVM_SUPPORT}"
   config_message+="\n - DEBUG:\t\t\t\t ${DEBUG:-no}"
   config_message+="\n - CFLAGS:\t\t\t\t ${TARGET_CFLAGS}"

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -29,8 +29,8 @@
 # LTO (Link Time Optimization) support
   LTO_SUPPORT="yes"
 
-# GOLD (Google Linker) support
-  GOLD_SUPPORT="yes"
+# Default Linker (bfd/gold)
+  DEFAULT_LINKER="gold"
 
 # HARDENING (security relevant linker and compiler flags) support
   HARDENING_SUPPORT="no"

--- a/packages/addons/addon-depends/system-tools-depends/depends/efivar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/efivar/package.mk
@@ -11,7 +11,7 @@ PKG_URL="https://github.com/rhboot/efivar/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain efivar:host"
 PKG_LONGDESC="Tools and library to manipulate EFI variables."
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="+bfd"
 
 pre_make_host() {
   export TOPDIR=${PKG_BUILD}

--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -13,7 +13,7 @@ PKG_DEPENDS_TARGET="toolchain binutils boost bzip2 libaio libfmt libxml2 lz4 lzo
 PKG_SHORTDESC="MariaDB is a community-developed fork of the MySQL."
 PKG_LONGDESC="MariaDB (${PKG_VERSION}) is a fast SQL database server and a drop-in replacement for MySQL."
 PKG_TOOLCHAIN="cmake"
-PKG_BUILD_FLAGS="-gold -sysroot"
+PKG_BUILD_FLAGS="+bfd -sysroot"
 
 PKG_IS_ADDON="yes"
 PKG_SECTION="service"

--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -9,7 +9,7 @@ PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain zlib openssl"
 PKG_LONGDESC="mariadb-connector: library to conntect to mariadb/mysql database server"
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="+bfd"
 
 PKG_CMAKE_OPTS_TARGET="-DWITH_EXTERNAL_ZLIB=ON
                        -DCLIENT_PLUGIN_DIALOG=STATIC

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -11,7 +11,7 @@ PKG_URL="https://ftp.gnu.org/pub/gnu/glibc/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap pigz:host Python3:host"
 PKG_DEPENDS_INIT="glibc"
 PKG_LONGDESC="The Glibc package contains the main C library."
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="+bfd"
 
 PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            ac_cv_path_PERL=no \

--- a/packages/emulation/libretro-fbneo/package.mk
+++ b/packages/emulation/libretro-fbneo/package.mk
@@ -10,7 +10,7 @@ PKG_URL="https://github.com/libretro/FBNeo/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_LONGDESC="game.libretro.fbneo: FinalBurn Neo GameClient for Kodi"
 PKG_TOOLCHAIN="make"
-PKG_BUILD_FLAGS="-gold +lto"
+PKG_BUILD_FLAGS="+bfd +lto"
 
 PKG_LIBNAME="fbneo_libretro.so"
 PKG_LIBPATH="src/burner/libretro/${PKG_LIBNAME}"

--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -10,7 +10,7 @@ PKG_URL="https://github.com/libretro/pcsx_rearmed/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_LONGDESC="game.libretro.pcsx-rearmed: PCSX Rearmed for Kodi"
 PKG_TOOLCHAIN="manual"
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="+bfd"
 
 PKG_LIBNAME="pcsx_rearmed_libretro.so"
 PKG_LIBPATH="${PKG_LIBNAME}"

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -12,7 +12,7 @@ PKG_DEPENDS_TARGET="toolchain kodi-platform ${PKG_NAME}:host"
 PKG_DEPENDS_UNPACK="cyclone68000"
 PKG_LONGDESC="Fast MegaDrive/MegaCD/32X emulator"
 PKG_TOOLCHAIN="manual"
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="+bfd"
 
 PKG_LIBNAME="picodrive_libretro.so"
 PKG_LIBPATH="${PKG_LIBNAME}"

--- a/packages/graphics/tiff/package.mk
+++ b/packages/graphics/tiff/package.mk
@@ -10,7 +10,7 @@ PKG_SITE="http://www.remotesensing.org/libtiff/"
 PKG_URL="http://download.osgeo.org/libtiff/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libjpeg-turbo zlib"
 PKG_LONGDESC="libtiff is a library for reading and writing TIFF files."
-PKG_BUILD_FLAGS="+pic -gold"
+PKG_BUILD_FLAGS="+pic +bfd"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
                        -Dtiff-tools=OFF \

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -19,8 +19,8 @@ configure_package() {
     PKG_KODI_USE_LTO="-DUSE_LTO=${CONCURRENCY_MAKE_LEVEL}"
   fi
 
-  # Set linker options
-  if [ "${GOLD_SUPPORT}" = "yes" ]; then
+  # Set linker matching DEFAULT_LINKER
+  if [ "${DEFAULT_LINKER}" = "gold" ]; then
     PKG_KODI_LINKER="-DENABLE_GOLD=ON \
                      -DENABLE_MOLD=OFF"
   else

--- a/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -9,7 +9,7 @@ PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-base.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-base/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain gstreamer"
 PKG_LONGDESC="Base GStreamer plugins and helper libraries"
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="+bfd"
 
 pre_configure_target() {
   PKG_MESON_OPTS_TARGET="-Dgl=disabled \

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -126,14 +126,15 @@ Set the variable `PKG_BUILD_FLAGS` in the `package.mk` to enable/disable the sin
 | lto-parallel | disabled | target, init  | same as `lto` but enables parallel optimization at link stage. Only enable this if the package build doesn't run multiple linkers in parallel otherwise this can result in lots of parallel processes! |
 | lto-fat  | disabled | target, init      | same as `lto` but compile fat LTO objects (bytecode plus optimized assembly). This increases compile time but can be useful to create static libraries suitable both for LTO and non-LTO linking |
 | lto-off  | disabled | target, init      | explicitly disable LTO in the compiler and linker |
-| gold     | enabled by `GOLD_SUPPORT` | target, init | do not use GOLD-Llinker (can only disable) |
+| bfd   | disabled | target, init | use the BFD-Linker (can only enable) |
+| gold  | disabled | target, init | use the GOLD-Linker (can only enable) |
 | parallel | enabled  | all | `make` or `ninja` builds with multiple threads/processes (or not) |
 | strip    | enabled  | target | strips executables (or not) |
 | sysroot  | enabled  | target | installs the package to the sysroot folder (or not) |
 
 ###### Example
 ```
-PKG_BUILD_FLAGS="+pic -gold"
+PKG_BUILD_FLAGS="+pic +bfd"
 PKG_BUILD_FLAGS="-parallel"
 ```
 
@@ -293,7 +294,7 @@ PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/MariaDB/mariadb-connector-c/archive/v$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain zlib openssl"
 PKG_LONGDESC="mariadb-connector: library to conntect to mariadb/mysql database server"
-PKG_BUILD_FLAGS="-gold"
+PKG_BUILD_FLAGS="+bfd"
 
 PKG_CMAKE_OPTS_TARGET="-DWITH_EXTERNAL_ZLIB=ON \
                        -DAUTH_CLEARTEXT=STATIC \


### PR DESCRIPTION
- this recycles the default linker opts of https://github.com/LibreELEC/LibreELEC.tv/pull/6875
- once this is merged we can later add any linker we need
- the default behaviour (=link with gold) should not be changed 