### PR TITLE
Do not set ENABLE_NEON_ for not target aarch64 and arm

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -173,10 +173,14 @@ configure_package() {
     KODI_UPNP="-DENABLE_UPNP=OFF"
   fi
 
-  if target_has_feature neon; then
-    KODI_NEON="-DENABLE_NEON=ON"
+  if [ "${TARGET_ARCH}" = "aarch64" -o "${TARGET_ARCH}" = "arm" ]; then
+    if target_has_feature neon; then
+      KODI_NEON="-DENABLE_NEON=ON"
+    else
+      KODI_NEON="-DENABLE_NEON=OFF"
+    fi
   else
-    KODI_NEON="-DENABLE_NEON=OFF"
+    KODI_NEON=""
   fi
 
   if [ "${VDPAU_SUPPORT}" = "yes" -a "${DISPLAYSERVER}" = "x11" ]; then

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="3.4.0"
-PKG_SHA256="bd754b58c3fa69f3ffd29da77de591bd9c26970e3b18537951336d6c0252e354"
+PKG_VERSION="3.5.0"
+PKG_SHA256="d37dbee372e2430a7efde813984ae6d78bdf1fc4080ebe32457c9115408b0738"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="https://storage.googleapis.com/aom-releases/libaom-${PKG_VERSION}.tar.gz"
@@ -19,8 +19,6 @@ PKG_CMAKE_OPTS_TARGET="-DENABLE_CCACHE=1 \
 
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" nasm:host"
-fi
-
-if ! target_has_feature neon; then
+elif ! target_has_feature neon; then
   PKG_CMAKE_OPTS_TARGET+=" -DENABLE_NEON=0 -DENABLE_NEON_ASM=0"
 fi


### PR DESCRIPTION
- kodi: do not set ENABLE_NEON for target x86_64
  - tidy up cmake warning
  - If ENABLE_NEON is set whilst building x86_64 with cmake. 
  - cmake warns that the variable is not been used.
- aom: update to 3.5.0 and do not set ENABLE_NEON for target x86_64

