### PR TITLE
[le10] tz: update to 2022d

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2022c"
-PKG_SHA256="067f0f4bee8e509b3eca502c5bd7c8f98073ab49b6c05654a157cbffd07aa3a4"
+PKG_VERSION="2022d"
+PKG_SHA256="797ebde2d30259f8c008fffb5916e58c7f885db856d96c8abfe9e99404422ecb"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release 2022d - 2022-09-23 12:02:57 -0700

  Briefly:
    Palestine transitions are now Saturdays at 02:00.
    Simplify three Ukraine zones into one.

  Changes to future timestamps

    Palestine now springs forward and falls back at 02:00 on the
    first Saturday on or after March 24 and October 24, respectively.
    This means 2022 falls back 10-29 at 02:00, not 10-28 at 01:00.
    (Thanks to Heba Hamad.)

  Changes to past timestamps

    Simplify three Ukraine zones to one, since the post-1970
    differences seem to have been imaginary.  Move Europe/Uzhgorod and
    Europe/Zaporozhye to 'backzone'; backward-compatibility links
    still work, albeit with different timestamps before October 1991.