### PR TITLE
Generic kernel config: enable sienna_cichlid support 

### DIFF
--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -4135,7 +4135,7 @@ CONFIG_DRM_AMD_ACP=y
 #
 CONFIG_DRM_AMD_DC=y
 CONFIG_DRM_AMD_DC_DCN=y
-# CONFIG_DRM_AMD_DC_DCN3_0 is not set
+CONFIG_DRM_AMD_DC_DCN3_0=y
 # CONFIG_DRM_AMD_DC_HDCP is not set
 # CONFIG_DRM_AMD_DC_SI is not set
 # end of Display Engine Configuration


### PR DESCRIPTION
AMD sienna_cichlid  GPU support is missing in Generic kernel although possible. Enable:

```
config DRM_AMD_DC_DCN3_0
        bool "DCN 3.0 family"
        depends on DRM_AMD_DC && X86
        depends on DRM_AMD_DC_DCN
        help
            Choose this option if you want to have
            sienna_cichlid support for display engine
```

Reported in forum: https://forum.libreelec.tv/thread/26124-no-screen-after-gpu-upgrade/

Let's test in nightlys. 