### PR TITLE
Intel driver updates

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.1.8"
-PKG_SHA256="bf23e9a3742b4fb98c7666c9e9b29f3219e4b2fb4d831aaf4eed71f5e2d17368"
+PKG_VERSION="22.2.0"
+PKG_SHA256="0b2253894c6fc8455b6d7c5e87e6504a76d6f60ea192e1445c2f93164bf529c0"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.5.3"
-PKG_SHA256="65652b365d48be3c9f0b3c561502952b92ee5fcc587520b88d0d752cf2a6a3b5"
+PKG_VERSION="22.5.4"
+PKG_SHA256="08d8d041f94b094a2dd5c4739c413b75185521c7f788a02411395ff374ee4ead"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/sysutils/open-vm-tools/package.mk
+++ b/packages/sysutils/open-vm-tools/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="open-vm-tools"
-PKG_VERSION="12.0.5"
-PKG_SHA256="19ec67984347bb5f867a5646658c7695352cef772c4bee212a0d9216f02ebd93"
+PKG_VERSION="12.1.0"
+PKG_SHA256="4c867a3f8b6c636eb98c9faa76c4280b0fdb75e2923dc0deec77dd24dd3f43b1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/vmware/open-vm-tools"


### PR DESCRIPTION
- media-driver: update to 22.5.4
  - https://github.com/intel/media-driver/compare/intel-media-22.5.3...intel-media-22.5.4
- gmmlib: update to 22.2.0
  - https://github.com/intel/gmmlib/compare/intel-gmmlib-22.1.8...intel-gmmlib-22.2.0
- open-vm-tools: update to 12.1.0
  - https://github.com/vmware/open-vm-tools/releases/tag/stable-12.1.0


```
=== tested on ===
Generic.x86_64-devel-20221001030611-6655a24
Linux nuc12 6.0.0-rc7 #1 SMP Sat Oct 1 03:08:07 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA3 (19.90.710) Git:9f7e9e02313cd935f93ee47b30758de051c09d91). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-10-01 by GCC 12.2.0 for Linux x86 64-bit version 6.0.0 (393216)
Running on LibreELEC (heitbaum): devel-20221001030611-6655a24 11.0, kernel: Linux x86 64-bit version 6.0.0-rc7
FFmpeg version/source: 4.4.1-Nexus-Alpha1-Kodi
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0085.2022.0718.1739 07/18/2022
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.2.0
libva info: VA-API version 1.15.0
vainfo: VA-API version: 1.15 (libva 2.15.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.5.4 (6655a24f89)
```
