### PR TITLE
connman: bump to include latest changes

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="1e1d2af009efc8a8b65eccc06188bd6b28271af7" # 1.41+ / 2022-05-25
-PKG_SHA256="bfdc7a8261c476c003df59a2952090dacf67c78b97027f06db3280edce0d4ee5"
+PKG_VERSION="19789ae039bb782fe3fbbe9562a54480e4c34c64" # 1.41+ / 2022-10-01
+PKG_SHA256="f503afc371f21625d46e2d23c4b1cb389263dc69aba10251f810daf157284abe"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
This bumps connman to the latest snapshot which includes some CVE fixes.