### PR TITLE
busybox: add vfd-clock script/service

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -120,6 +120,7 @@ makeinstall_target() {
     cp ${PKG_DIR}/scripts/sudo ${INSTALL}/usr/bin/
     cp ${PKG_DIR}/scripts/pastebinit ${INSTALL}/usr/bin/
       ln -sf pastebinit ${INSTALL}/usr/bin/paste
+    cp ${PKG_DIR}/scripts/vfd-clock ${INSTALL}/usr/bin/
 
   mkdir -p ${INSTALL}/usr/sbin
     cp ${PKG_DIR}/scripts/kernel-overlays-setup ${INSTALL}/usr/sbin
@@ -170,6 +171,7 @@ post_install() {
   enable_service ledfix.service
   enable_service shell.service
   enable_service show-version.service
+  enable_service vfd-clock.service
   enable_service var.mount
   enable_service locale.service
   listcontains "${FIRMWARE}" "rpi-eeprom" && enable_service rpi-flash-firmware.service

--- a/packages/sysutils/busybox/scripts/vfd-clock
+++ b/packages/sysutils/busybox/scripts/vfd-clock
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+do_start(){
+  while sleep 1
+  do
+    printf "%4s" "$(date +'%l %M' | tr -d '[:space:]')" > "$LED_PATH_TEXT"
+    if [ "$LED_COLON" = "off" ]; then
+      echo "1" > "$LED_PATH_COLON"
+      LED_COLON="on"
+    else
+      echo "0" > "$LED_PATH_COLON"
+      LED_COLON="off"
+    fi
+  done
+}
+
+do_stop(){
+  echo "0" > "$LED_PATH_COLON"
+  echo " " > "$LED_PATH_TEXT"
+}
+
+case $(dtname) in
+  oranth,tx3-mini)
+    LED_PATH_COLON="/sys/devices/platform/spi/spi_master/spi0/spi0.0/leds/:colon/brightness"
+    LED_PATH_TEXT="/sys/devices/platform/spi/spi_master/spi0/spi0.0/display_text"
+    ;;
+  default|*)
+    # noop
+    ;;
+esac
+
+if [ -n "$LED_PATH_COLON" ] && [ -n "$LED_PATH_TEXT" ]; then
+  case $1 in
+    start)
+      do_start
+      ;;
+    stop)
+      do_stop
+      ;;
+  esac
+else
+  exit 0
+fi

--- a/packages/sysutils/busybox/system.d/vfd-clock.service
+++ b/packages/sysutils/busybox/system.d/vfd-clock.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=VFD Clock Service
+After=network-online.target graphical.target
+Requires=graphical.target
+Wants=kodi.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh /usr/bin/vfd-clock start
+ExecStopPost=/bin/sh /usr/bin/vfd-clock stop
+RemainAfterExit=yes
+StartLimitInterval=0
+
+[Install]
+WantedBy=kodi.target


### PR DESCRIPTION
This adds a small vfd-clock script/service to overwrite 'boot' text on the Tanix TX3 VFD display with a clock, leveraging the bitbang 7-segment display driver that's in the process of being upstreamed to the kernel. It should be expandable to other devices given time for fiddling and experiments.