### PR TITLE
[le10] rsyslog: update to 8.2208.0

### DIFF
--- a/packages/addons/service/rsyslog/changelog.txt
+++ b/packages/addons/service/rsyslog/changelog.txt
@@ -1,3 +1,9 @@
+112
+- rsyslog: update to 8.2208.0
+
+111
+- not released for LibreELEC 10
+
 110
 - rsyslog: update to 8.2204.0
 

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rsyslog"
-PKG_VERSION="8.2204.0"
-PKG_SHA256="7eb52db775f87f6975b70a5fbff982507c68ba3306ae05ff967443258442245d"
-PKG_REV="109"
+PKG_VERSION="8.2208.0"
+PKG_SHA256="14de68e7b8e5ab0c5d734f82e2dc9fff22cd7f4710ad690727eb10a7b9b3df5e"
+PKG_REV="112"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rsyslog"


### PR DESCRIPTION
- backport of #6941 

Changelog:
- https://github.com/rsyslog/rsyslog/blob/master/ChangeLog