### PR TITLE
[le10] ttyd: update to 1.7.1 and addon (106)

### DIFF
--- a/packages/addons/addon-depends/ttyd-depends/libuv/package.mk
+++ b/packages/addons/addon-depends/ttyd-depends/libuv/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libuv"
-PKG_VERSION="1.42.0"
-PKG_SHA256="371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764"
+PKG_VERSION="1.44.2"
+PKG_SHA256="e6e2ba8b4c349a4182a33370bb9be5e23c51b32efb9b9e209d0e8556b73a48da"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libuv/libuv"
 PKG_URL="https://github.com/libuv/libuv/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/ttyd-depends/libwebsockets/package.mk
+++ b/packages/addons/addon-depends/ttyd-depends/libwebsockets/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libwebsockets"
-PKG_VERSION="4.3.0"
-PKG_SHA256="ceef46e3bffb368efe4959202f128fd93d74e10cd2e6c3ac289a33b075645c3b"
+PKG_VERSION="4.3.2"
+PKG_SHA256="6a85a1bccf25acc7e8e5383e4934c9b32a102880d1e4c37c70b27ae2a42406e1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://libwebsockets.org"
 PKG_URL="https://github.com/warmcat/libwebsockets/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/ttyd/changelog.txt
+++ b/packages/addons/service/ttyd/changelog.txt
@@ -1,3 +1,8 @@
+106
+- update to 1.7.0
+- libuv: update to 1.44.2
+- libwebsockets: update to 4.3.2
+
 105
 - fix ttyd to include missing evlib_uv library
 

--- a/packages/addons/service/ttyd/package.mk
+++ b/packages/addons/service/ttyd/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ttyd"
-PKG_VERSION="1.6.3"
-PKG_SHA256="1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9"
-PKG_REV="105"
+PKG_VERSION="1.7.1"
+PKG_SHA256="e1e9993b1320c8623447304ae27031502569a1e37227ec48d4e21dae7db6eb66"
+PKG_REV="106"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/tsl0922/ttyd"


### PR DESCRIPTION
Updates
-  ttyd: update to 1.7.1 and addon (106)
- libuv: update to 1.44.2
- libwebsockets: update to 4.3.2

backport 
- of #6943 