### PR TITLE
kodi: update to latest master

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="9f7e9e02313cd935f93ee47b30758de051c09d91"
-PKG_SHA256="3f68f4871d3aa3ade7b2738d7dd904709ead6cd5b156539de74124457d350d81"
+PKG_VERSION="3066d800934f39c28b951c69930d3cbee5fd6308"
+PKG_SHA256="926ec59ab5ad183041dae63cb940e04463fc00d25b5cb721817e105dae7e51de"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/kodi-100.07-disable-minimize.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.07-disable-minimize.patch
@@ -1,15 +1,17 @@
-From f5f78dda7b1161779ce7a0c495f54e30f971776a Mon Sep 17 00:00:00 2001
+From c32d80cbfd5eb6ae9b5a36b3e9a8ec6e9d825837 Mon Sep 17 00:00:00 2001
 From: Stefan Saraev <stefan@saraev.ca>
 Date: Sat, 18 Apr 2015 14:59:29 +0300
-Subject: [PATCH 07/13] disable minimize
+Subject: [PATCH] disable minimize
 
 ---
- xbmc/Application.cpp | 1 -
+ xbmc/application/Application.cpp | 1 -
  1 file changed, 1 deletion(-)
 
---- a/xbmc/Application.cpp
-+++ b/xbmc/Application.cpp
-@@ -2171,7 +2171,6 @@ void CApplication::OnApplicationMessage(
+diff --git a/xbmc/application/Application.cpp b/xbmc/application/Application.cpp
+index 27b7bc80cb..bafb5de064 100644
+--- a/xbmc/application/Application.cpp
++++ b/xbmc/application/Application.cpp
+@@ -1572,7 +1572,6 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
      break;
  
    case TMSG_MINIMIZE:
@@ -17,3 +19,6 @@ Subject: [PATCH 07/13] disable minimize
      break;
  
    case TMSG_EXECUTE_OS:
+-- 
+2.34.1
+

--- a/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
@@ -1,4 +1,4 @@
-From f0bca779d21f12be077d97891aa321f02064a089 Mon Sep 17 00:00:00 2001
+From de3a1d59836496b786ce31e9f2ce77c0c9db545b Mon Sep 17 00:00:00 2001
 From: MilhouseVH <milhouseVH.github@nmacleod.com>
 Date: Sun, 3 Apr 2022 11:31:07 +0200
 Subject: [PATCH] handle SIGTERM
@@ -15,16 +15,16 @@ so, when shutdown/reboot is requested:
 6. addons / pvrmanager / cec / everything else.. are free to deadlock / crash now, we dont care
 7. KILL
 ---
- xbmc/Application.cpp                          | 24 ++++++++++++++-----
- xbmc/Application.h                            |  2 ++
+ xbmc/application/Application.cpp              | 24 ++++++++++++++-----
+ xbmc/application/Application.h                |  2 ++
  .../powermanagement/LogindUPowerSyscall.cpp   |  2 --
  3 files changed, 20 insertions(+), 8 deletions(-)
 
-diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
-index bc5b15523d..3049d6ca61 100644
---- a/xbmc/Application.cpp
-+++ b/xbmc/Application.cpp
-@@ -1432,12 +1432,12 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
+diff --git a/xbmc/application/Application.cpp b/xbmc/application/Application.cpp
+index bafb5de064..c5f39217cc 100644
+--- a/xbmc/application/Application.cpp
++++ b/xbmc/application/Application.cpp
+@@ -1444,12 +1444,12 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
    switch (msg)
    {
    case TMSG_POWERDOWN:
@@ -39,7 +39,7 @@ index bc5b15523d..3049d6ca61 100644
      break;
  
    case TMSG_SHUTDOWN:
-@@ -1458,12 +1458,13 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
+@@ -1470,12 +1470,13 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
  
    case TMSG_RESTART:
    case TMSG_RESET:
@@ -54,7 +54,7 @@ index bc5b15523d..3049d6ca61 100644
      Stop(EXITCODE_RESTARTAPP);
  #endif
      break;
-@@ -2024,7 +2025,7 @@ bool CApplication::Stop(int exitCode)
+@@ -2039,7 +2040,7 @@ bool CApplication::Stop(int exitCode)
      m_frameMoveGuard.unlock();
  
      CVariant vExitCode(CVariant::VariantTypeObject);
@@ -63,7 +63,7 @@ index bc5b15523d..3049d6ca61 100644
      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnQuit", vExitCode);
  
      // Abort any active screensaver
-@@ -2056,7 +2057,6 @@ bool CApplication::Stop(int exitCode)
+@@ -2071,7 +2072,6 @@ bool CApplication::Stop(int exitCode)
      // Needs cleaning up
      CServiceBroker::GetAppMessenger()->Stop();
      m_AppFocused = false;
@@ -71,7 +71,7 @@ index bc5b15523d..3049d6ca61 100644
      CLog::Log(LOGINFO, "Stopping all");
  
      // cancel any jobs from the jobmanager
-@@ -2580,6 +2580,18 @@ void CApplication::StopPlaying()
+@@ -2602,6 +2602,18 @@ void CApplication::StopPlaying()
    }
  }
  
@@ -90,7 +90,7 @@ index bc5b15523d..3049d6ca61 100644
  bool CApplication::OnMessage(CGUIMessage& message)
  {
    switch ( message.GetMessage() )
-@@ -3056,7 +3068,7 @@ void CApplication::ProcessSlow()
+@@ -3114,7 +3126,7 @@ void CApplication::ProcessSlow()
    if (CPlatformPosix::TestQuitFlag())
    {
      CLog::Log(LOGINFO, "Quitting due to POSIX signal");
@@ -99,11 +99,11 @@ index bc5b15523d..3049d6ca61 100644
    }
  #endif
  
-diff --git a/xbmc/Application.h b/xbmc/Application.h
-index c938d0a9b3..2fe138b437 100644
---- a/xbmc/Application.h
-+++ b/xbmc/Application.h
-@@ -135,6 +135,7 @@ public:
+diff --git a/xbmc/application/Application.h b/xbmc/application/Application.h
+index 710ea9923b..59763464ab 100644
+--- a/xbmc/application/Application.h
++++ b/xbmc/application/Application.h
+@@ -120,6 +120,7 @@ public:
    bool CreateGUI();
    bool InitWindow(RESOLUTION res = RES_INVALID);
  
@@ -111,7 +111,7 @@ index c938d0a9b3..2fe138b437 100644
    bool Stop(int exitCode);
    void ReloadSkin(bool confirm = false);
    const std::string& CurrentFile();
-@@ -286,6 +287,7 @@ private:
+@@ -274,6 +275,7 @@ private:
    CApplicationPlayer m_appPlayer;
    CApplicationStackHelper m_stackHelper;
    int m_ExitCode{EXITCODE_QUIT};
@@ -133,5 +133,5 @@ index 34eed6e41b..c374dbdbd3 100644
  }
  
 -- 
-2.30.2
+2.34.1
 


### PR DESCRIPTION
spdlog PR finally got merged, so spdlog is no longer used in header-only mode. This seems to have sped up kodi rebuild by about 10%

Our disable minimimize and sigterm patches are adatped to the recent kodi changes (moving Application.h/cpp)

Runtime tested on RPi4 and RPi3B+