### PR TITLE
[le10] prometheus-node-exporter: update to 1.4.0 and addon (102)

### DIFF
--- a/packages/addons/service/prometheus-node-exporter/changelog.txt
+++ b/packages/addons/service/prometheus-node-exporter/changelog.txt
@@ -1,3 +1,6 @@
+102
+- prometheus-node-exporter: update to 1.4.0
+
 101
 - prometheus-node-exporter: update to 1.3.1
 

--- a/packages/addons/service/prometheus-node-exporter/package.mk
+++ b/packages/addons/service/prometheus-node-exporter/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="prometheus-node-exporter"
-PKG_VERSION="1.3.1"
-PKG_SHA256="66856b6b8953e094c46d7dd5aabd32801375cf4d13d9fe388e320cbaeaff573a"
-PKG_REV="101"
+PKG_VERSION="1.4.0"
+PKG_SHA256="96f749928e3d6c952221aaca852d4c38545eaae03adc6bb925745bc3f2f827ca"
+PKG_REV="102"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://github.com/prometheus/node_exporter"
 PKG_URL="https://github.com/prometheus/node_exporter/archive/refs/tags/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
release notes:
- https://github.com/prometheus/node_exporter/releases/tag/v1.4.0

- backport of #6955