### PR TITLE
scripts/checkdeps: fedora bdftopcf package name change

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -111,12 +111,20 @@ case "${DISTRO}" in
         [g++]=gcc-c++
         [mkfontscale]=xorg-x11-font-utils
         [mkfontdir]=xorg-x11-font-utils
-        [bdftopcf]=xorg-x11-font-utils
         [xsltproc]=libxslt
         [java]=java-1.8.0-openjdk
         [python3]=python3
         [rpcgen]=rpcgen
       )
+      if [ "${DISTRO}" = "fedora" ]; then
+        dep_map+=(
+          [bdftopcf]=bdftopcf
+        )
+      else
+        dep_map+=(
+          [bdftopcf]=xorg-x11-font-utils
+        )
+      fi
       if [[ ! $(rpm -qa glibc-static) ]]; then
         dep_map+=(
           [glibc-static]=glibc-static


### PR DESCRIPTION
This replaces #6823, which I assume has been abandoned.

Rather than test if it's Fedora version >= 34, it just checks if it's Fedora because Fedora 34 and earlier are EOL (https://docs.fedoraproject.org/en-US/releases/eol/). I assume RHEL and its clones will need a similar change at some point, but as this has been possibly broken since Fedora 34's release 18+ months ago, I just assume wait for a report to show up instead of guess.