### PR TITLE
[le10] syncthing: update to 1.22.0 and addon (122) and dependent golang

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.16.6"
-PKG_SHA256="498cd89c5c965ea2f2e23eef589e0a2dcb4b94f31c3f7dac575d4c35ae89caf7"
+PKG_VERSION="1.19.2"
+PKG_SHA256="8763d8e6bb595c3e2ad383e591f3009401df38ff682ef66b84efbe3ec62cf5f3"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,9 @@
+122
+- update to 1.22.0
+
+118-121
+- not released for LibreELEC 10
+
 118
 - update to 1.18.5
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.18.5"
-PKG_SHA256="c64db4d5fe6ae6525d2333fdd5cb41243e56430ced377c59ca69731a1183df1f"
-PKG_REV="118"
+PKG_VERSION="1.22.0"
+PKG_SHA256="b9644e814b4c7844a59e4e7705c550361cb4ed6c36bf9b46617de386ee2dad45"
+PKG_REV="122"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"


### PR DESCRIPTION
these are backports of LE11

Package updates
- go: update to 1.19.2
- syncthing: update to 1.22.0 and addon (122)
  - requires 1.18 or 1.19 golang.

build of all go:host dependencies completed.
```
s/create_addon service.docker
s/create_addon service.prometheus-node-exporter
s/create_addon service.syncthing
```