### PR TITLE
[le10] libfmt: update to 9.1.0

### DIFF
--- a/packages/addons/addon-depends/mpd-mpc/package.mk
+++ b/packages/addons/addon-depends/mpd-mpc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpd-mpc"
-PKG_VERSION="0.33"
-PKG_SHA256="4f40ccbe18f5095437283cfc525a97815e983cbfd3a29e48ff610fa4f1bf1296"
+PKG_VERSION="0.34"
+PKG_SHA256="691e3f3654bc10d022bb0310234d0bc2d8c075a698f09924d9ebed8f506fda20"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"
 PKG_URL="https://www.musicpd.org/download/mpc/0/mpc-${PKG_VERSION}.tar.xz"

--- a/packages/addons/service/mpd/changelog.txt
+++ b/packages/addons/service/mpd/changelog.txt
@@ -1,3 +1,7 @@
+114
+- Update to version 0.23.8
+- mpd-mpc: update to 0.34
+
 113
 - Update to version 0.23.5
 - libmpdclient: update to 2.20

--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpd"
-PKG_VERSION="0.23.5"
-PKG_SHA256="f22c2c25093a05f4566f9cd7207cfbcd8405af67ed29a989bcf8905f80b7a299"
-PKG_REV="113"
+PKG_VERSION="0.23.8"
+PKG_SHA256="86bb569bf3b519821f36f6bb5564e484e85d2564411b34b200fe2cd3a04e78cf"
+PKG_REV="114"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"

--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libfmt"
-PKG_VERSION="7.1.3"
-PKG_SHA256="5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc"
+PKG_VERSION="9.1.0"
+PKG_SHA256="5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/fmtlib/fmt"
 PKG_URL="https://github.com/fmtlib/fmt/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/spdlog/package.mk
+++ b/packages/devel/spdlog/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spdlog"
-PKG_VERSION="1.8.2"
-PKG_SHA256="e20e6bd8f57e866eaf25a5417f0a38a116e537f1a77ac7b5409ca2b180cec0d5"
+PKG_VERSION="1.10.0"
+PKG_SHA256="697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/gabime/spdlog"
 PKG_URL="https://github.com/gabime/spdlog/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
As of https://github.com/xbmc/xbmc/pull/21674 - Kodi Matrix now supports libfmt 9. Backport libfmt 9 to LE10.

To support libfmt 9 - the following minimum updates to other packages are also required:
- spdlog - 1.9.2
- mpd - 0.23.8 (addon)

The following packages are updated in this PR:
- libfmt: update to 9.1.0
- spdlog: update to 1.10.0
- mpd: update to 0.23.8 and addon (114)
- mpd-mpc: update to 0.34 — used by mpd

