### PR TITLE
xz: update to 5.2.7

### DIFF
--- a/packages/compress/xz/package.mk
+++ b/packages/compress/xz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xz"
-PKG_VERSION="5.2.6"
-PKG_SHA256="e076ba3439cb7cfc45b908c869f51a8c89f3c9ee9ee982fde28849c015e723a7"
+PKG_VERSION="5.2.7"
+PKG_SHA256="8712e9acb0b6b49a97d443458a3067dc5c08a025e02dc5f773176c51dd7cfc69"
 PKG_LICENSE="GPL"
 PKG_SITE="https://tukaani.org/xz/"
 PKG_URL="https://tukaani.org/xz/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -12,6 +12,7 @@ PKG_DEPENDS_HOST="ccache:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A free general-purpose data compression software with high compression ratio."
 PKG_BUILD_FLAGS="+pic +pic:host"
+PKG_TOOLCHAIN="configure"
 
 # never build shared or k0p happens when building
 # on fedora due to host selinux/liblzma
@@ -19,10 +20,12 @@ PKG_CONFIGURE_OPTS_HOST="--disable-shared --enable-static \
                          --disable-lzmadec \
                          --disable-lzmainfo \
                          --enable-lzma-links \
+                         --disable-nls \
                          --disable-scripts \
-                         --disable-nls"
+                         --enable-symbol-versions=no"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static \
+                           --enable-symbol-versions=no"
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}


### PR DESCRIPTION
### xz: update to 5.2.7
- set PKG_TOOLCHAIN="configure" as the cmake support in xz is experimental

- due to https://git.tukaani.org/?p=xz.git;a=commit;h=31d80c6b261b24220776dfaeb8a04f80f80e0a24 and the static builds of xz - --enable-symbol-versions=no needs to be set to compile Python3

- tested builds of dependant addons too.

### ann:
- https://tukaani.org/xz/

### release notes:
- https://git.tukaani.org/?p=xz.git;a=blob;f=NEWS;h=0205423e79ce8297102096b0fc8b030ddf5b2023;hb=d2003362dd42004355a5550ee7a60ace3b3ea2d8

### 5.2.7 (2022-09-30)

    * liblzma:

        - Made lzma_filters_copy() to never modify the destination
          array if an error occurs. lzma_stream_encoder() and
          lzma_stream_encoder_mt() already assumed this. Before this
          change, if a tiny memory allocation in lzma_filters_copy()
          failed it would lead to a crash (invalid free() or invalid
          memory reads) in the cleanup paths of these two encoder
          initialization functions.

        - Added missing integer overflow check to lzma_index_append().
          This affects xz --list and other applications that decode
          the Index field from .xz files using lzma_index_decoder().
          Normal decompression of .xz files doesn't call this code
          and thus most applications using liblzma aren't affected
          by this bug.

        - Single-threaded .xz decoder (lzma_stream_decoder()): If
          lzma_code() returns LZMA_MEMLIMIT_ERROR it is now possible
          to use lzma_memlimit_set() to increase the limit and continue
          decoding. This was supposed to work from the beginning
          but there was a bug. With other decoders (.lzma or
          threaded .xz decoder) this already worked correctly.

        - Fixed accumulation of integrity check type statistics in
          lzma_index_cat(). This bug made lzma_index_checks() return
          only the type of the integrity check of the last Stream
          when multiple lzma_indexes were concatenated. Most
          applications don't use these APIs but in xz it made
          xz --list not list all check types from concatenated .xz
          files. In xz --list --verbose only the per-file "Check:"
          lines were affected and in xz --robot --list only the "file"
          line was affected.

        - Added ABI compatibility with executables that were linked
          against liblzma in RHEL/CentOS 7 or other liblzma builds
          that had copied the problematic patch from RHEL/CentOS 7
          (xz-5.2.2-compat-libs.patch). For the details, see the
          comment at the top of src/liblzma/validate_map.sh.

          WARNING: This uses __symver__ attribute with GCC >= 10.
          In other cases the traditional __asm__(".symver ...")
          is used. Using link-time optimization (LTO, -flto) with
          GCC versions older than 10 can silently result in
          broken liblzma.so.5 (incorrect symbol versions)! If you
          want to use -flto with GCC, you must use GCC >= 10.
          LTO with Clang seems to work even with the traditional
          __asm__(".symver ...") method.

    * xzgrep: Fixed compatibility with old shells that break if
      comments inside command substitutions have apostrophes (').
      This problem was introduced in 5.2.6.

    * Build systems:

        - New #define in config.h: HAVE_SYMBOL_VERSIONS_LINUX

        - Windows: Fixed liblzma.dll build with Visual Studio project
          files. It broke in 5.2.6 due to a change that was made to
          improve CMake support.

        - Windows: Building liblzma with UNICODE defined should now
          work.

        - CMake files are now actually included in the release tarball.
          They should have been in 5.2.5 already.

        - Minor CMake fixes and improvements.

    * Added a new translation: Turkish