### PR TITLE
LibreELEC-settings: update to f369cd1

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="d6c41d41b4090d3d6a3cf1c4913b4e68ede316a4"
-PKG_SHA256="ea89930f9d0e67738339d09faf6161da844d612840b3d425cb29c5a036ef1e03"
+PKG_VERSION="f369cd15cd31d8e072db2ee1d9473174c11baafe"
+PKG_SHA256="a2a2f3455cf75a2d574fe183191773143580d504630fdf4e920fdfcdd9d9d5c1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
This should fix Bluetooth paring / pin entry https://github.com/LibreELEC/service.libreelec.settings/pull/283