### PR TITLE
[le11] multimedia-tools: update addon to (117)

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmediainfo"
-PKG_VERSION="21.09"
-PKG_SHA256="69be9444f6a03a1bdf56713ee31d56e987c502a7ec18eb54ee70fcc171b7f126"
+PKG_VERSION="22.09"
+PKG_SHA256="b394d48285730cda53a41f41c82fd5ebf074c7158e1d6d4543777bfde0aa6927"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/libmediainfo/${PKG_VERSION}/libmediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mediainfo"
-PKG_VERSION="21.09"
-PKG_SHA256="7b8fd9a502ec64afe1315072881b6385ba57ca69f2f82c625b1672e151c50c57"
+PKG_VERSION="22.09"
+PKG_SHA256="67f301276a2b82d76cb9f4bd525caa51d2dc6d4359fce774fbd5f25f1d513044"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/mediainfo/${PKG_VERSION}/mediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpg123"
-PKG_VERSION="1.29.3"
-PKG_SHA256="963885d8cc77262f28b77187c7d189e32195e64244de2530b798ddf32183e847"
+PKG_VERSION="1.30.2"
+PKG_SHA256="c7ea863756bb79daed7cba2942ad3b267a410f26d2dfbd9aaf84451ff28a05d7"
 PKG_LICENSE="LGPLv2"
 PKG_SITE="http://www.mpg123.org/"
-PKG_URL="http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${PKG_VERSION}.tar.bz2"
+PKG_URL="https://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain alsa-lib"
 PKG_LONGDESC="A console based real time MPEG Audio Player for Layer 1, 2 and 3."
 PKG_BUILD_FLAGS="-sysroot"

--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squeezelite"
-PKG_VERSION="874e4f97d979fbe9b396c1997730a1a2d6797964" # 2022-01-06 # 1.9.9.1395
-PKG_SHA256="b33d9da532e000fe69ca76fa737a54d6215bd8ffac3e348b76763940449650ca"
+PKG_VERSION="bc72c0de3fff771540a2a45aaafafed539387b3c" # 2022-04-10 # 1.9.9.1403
+PKG_SHA256="5aa312d678a593b9a08f79e080a6ebe329d8fc40e6507e28b6705807c408bf7a"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ralph-irving/squeezelite"
 PKG_URL="https://github.com/ralph-irving/squeezelite/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/multimedia-tools/changelog.txt
+++ b/packages/addons/tools/multimedia-tools/changelog.txt
@@ -1,3 +1,9 @@
+117
+- mediainfo: update to 22.09
+- libmediainfo: update to 22.09
+- mpg123: update to 1.30.2 and https
+- squeezelite: update to 2022-04-10 (1.9.9.1403)
+
 116
 - libmediainfo: update to 21.09
 - mediainfo: update to 21.09

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="116"
+PKG_REV="117"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- mediainfo: update to 22.09
- libmediainfo: update to 22.09
- mpg123: update to 1.30.2 and https
- squeezelite: update to 2022-04-10 (1.9.9.1403)