### PR TITLE
libva and libva-utils: update to 2.16.0 

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva-utils"
-PKG_VERSION="2.15.0"
-PKG_SHA256="73609a24fe1dbf99e1472e20af1398d910f64c88b8615272f9f3539ffc5d2efc"
+PKG_VERSION="2.16.0"
+PKG_SHA256="646c9bfff6a83504c48de2c786c9514ca30c5e916127faf00f143ef8147ee950"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"
 PKG_URL="https://github.com/intel/libva-utils/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva"
-PKG_VERSION="2.15.0"
-PKG_SHA256="869aaa9b9eccb1cde63e1c5b0ac0881cefc00156010bb49f6dce152471770ba8"
+PKG_VERSION="2.16.0"
+PKG_SHA256="766edf51fd86efe9e836a4467d4ec7c3af690a3c601b3c717237cee856302279"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
Version 2.16.0 - 8.Oct.2022
* trace: print the display being attempted
* ci: upgrade FreeBSD to 13.1
* meson: Search for threads in top-level meson.build
* meson: produce summary() when 0.53.0 is present