### PR TITLE
harfbuzz: update to 5.3.0 and fix build after 5.2.0 update

### DIFF
--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="5.2.0"
-PKG_SHA256="735a94917b47936575acb4d4fa7e7986522f8a89527e4635721474dee2bc942c"
+PKG_VERSION="5.3.0"
+PKG_SHA256="a05e19e3f52da24ed071522f0fddf872157d7d25e869cfd156cd6f1e81c42152"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/harfbuzz/patches/harfbuzz-100.01-fix-meson-icu-opts.patch
+++ b/packages/graphics/harfbuzz/patches/harfbuzz-100.01-fix-meson-icu-opts.patch
@@ -1,0 +1,12 @@
+--- a/meson.build
++++ b/meson.build
+@@ -109,7 +109,7 @@
+ if not icu_dep.found()
+   # Try cmake name
+   icu_dep = dependency('ICU',
+-                       required: false,
++                       required: get_option('icu'),
+                        components: 'uc',
+                        method: 'cmake')
+ endif
+


### PR DESCRIPTION
- update to 5.3.0
- seems like the ICU detection is "broken" now and pulls in system ICU files which leads to `HAVE_ICU` defined and ends up with a broken build. These [changes](https://github.com/harfbuzz/harfbuzz/commit/53a194aa3f5f7de0b40e879e41fcbe0de6e9fefe#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4R112) lead to:

### meson-log.txt
```
Determining dependency 'ICU' with CMake executable '-DCMAKE_INSTALL_PREFIX=/usr'
Try CMake generator: auto
Calling CMake (['cmake', '-DCMAKE_TOOLCHAIN_FILE=/mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/etc/cmake-x86_64-libreelec-linux-gnu.conf', '-DCMAKE_INSTALL_PREFIX=/usr']) in /mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/harfbuzz-5.2.0/.x86_64-libreelec-linux-gnu/meson-private/cmake_ICU with:
  - "-DNAME=ICU"
  - "-DARCHS=libpyldb-util.cpython-310-x86-64-linux-gnu.so;libpyldb-util.cpython-310-x86-64-linux-gnu.so.2;libpyldb-util.cpython-310-x86-64-linux-gnu.so.2.6.1;libpytalloc-util.cpython-310-x86-64-linux-gnu.so;libpytalloc-util.cpython-310-x86-64-linux-gnu.so.2;libpytalloc-util.cpython-310-x86-64-linux-gnu.so.2.3.4;libsamba-policy.cpython-310-x86-64-linux-gnu.so;libsamba-policy.cpython-310-x86-64-linux-gnu.so.0;libsamba-policy.cpython-310-x86-64-linux-gnu.so.0.0.1"
  - "-DVERSION="
  - "-DCOMPS=uc"
  - "--trace-expand"
  - "--trace-format=json-v1"
  - "--no-warn-unused-cli"
  - "--trace-redirect=cmake_trace.txt"
  - "-DCMAKE_TOOLCHAIN_FILE=/mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/harfbuzz-5.2.0/.x86_64-libreelec-linux-gnu/meson-private/cmake_ICU/CMakeMesonToolchainFile.cmake"
  - "."
WARNING: Could not find and exact match for the CMake dependency ICU.

However, Meson found the following partial matches:

    ['ICU::uc']

Using imported is recommended, since this approach is less error prone
and better supported by Meson. Consider explicitly specifying one of
these in the dependency call with:

    dependency('ICU', modules: ['ICU::<name>', ...])

Meson will now continue to use the old-style ICU_LIBRARIES CMake
variables to extract the dependency information since no explicit
target is currently specified.


More info for the partial match targets:
CMake TARGET:
  -- name:      ICU::uc
  -- type:      UNKNOWN
  -- imported:  True
  -- properties: {
      'INTERFACE_INCLUDE_DIRECTORIES': ['/usr/include']
      'IMPORTED_LINK_INTERFACE_LANGUAGES': ['CXX']
      'IMPORTED_LOCATION': ['/usr/lib/libicuuc.so']
      'IMPORTED_CONFIGURATIONS': ['RELEASE']
      'IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE': ['CXX']
      'IMPORTED_LOCATION_RELEASE': ['/usr/lib/libicuuc.so']
      'INTERFACE_LINK_LIBRARIES': ['dl']
     }
  -- tline: CMake TRACE: /mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/share/cmake-3.24/Modules/FindICU.cmake:359 add_library(['ICU::uc', 'UNKNOWN', 'IMPORTED'])
using old-style CMake variables for dependency ICU
Include Dirs:         ['/usr/include']
Compiler Definitions: []
Libraries:            ['/usr/lib/libicuuc.so']
Run-time dependency icu found: YES 71.1
```

Because they ignore our icu meson opt which eventually leads to:

### build log
```
[69/79] Compiling C++ object src/libharfbuzz-icu.so.0.50200.0.p/hb-icu.cc.o
FAILED: src/libharfbuzz-icu.so.0.50200.0.p/hb-icu.cc.o
/mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -Isrc/libharfbuzz-icu.so.0.50200.0.p -Isrc -I../src -I. -I.. -I/usr/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++11 -fno-rtti -O0 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fvisibility-inlines-hidden -DHAVE_CONFIG_H -march=x86-64-v2 -Wall -pipe -O2 -fomit-frame-pointer -DNDEBUG -fPIC -Wno-non-virtual-dtor -MD -MQ src/libharfbuzz-icu.so.0.50200.0.p/hb-icu.cc.o -MF src/libharfbuzz-icu.so.0.50200.0.p/hb-icu.cc.o.d -o src/libharfbuzz-icu.so.0.50200.0.p/hb-icu.cc.o -c ../src/hb-icu.cc
CROSS COMPILE Badness: /usr/include in INCLUDEPATH: /usr/include
cc1plus: internal compiler error: in add_path, at incpath.cc:481
0x6b83d4 _start
	../sysdeps/x86_64/start.S:115
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugs/> for instructions.
```