### PR TITLE
Wayland and X11 updates

### DIFF
--- a/packages/multimedia/nvidia-vaapi-driver/package.mk
+++ b/packages/multimedia/nvidia-vaapi-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia-vaapi-driver"
-PKG_VERSION="0.0.6"
-PKG_SHA256="8a64c069200750f12d013c79547e459cbb87b498357478c5f36cb97f710294e0"
+PKG_VERSION="0.0.7"
+PKG_SHA256="c19e35d41cd39a93c2a1af99065d51719a994fdd89f8b0716914cba7e716718e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/elFarto/nvidia-vaapi-driver"
 PKG_URL="https://github.com/elFarto/nvidia-vaapi-driver/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/wayland/util/bemenu/package.mk
+++ b/packages/wayland/util/bemenu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bemenu"
-PKG_VERSION="0.6.12"
-PKG_SHA256="103c1650a55da57a6ec1acabc9490d5eedd5566d34f1c1823a7cef83d3e34ed1"
+PKG_VERSION="0.6.13"
+PKG_SHA256="6032fae0253363a48171367c20982ef080ba5c163462732f0354dc8b606850f9"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Cloudef/bemenu"
 PKG_URL="https://github.com/Cloudef/bemenu/archive/${PKG_VERSION}.tar.gz"

--- a/packages/x11/data/xkeyboard-config/package.mk
+++ b/packages/x11/data/xkeyboard-config/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xkeyboard-config"
-PKG_VERSION="2.36"
-PKG_SHA256="1f1bb1292a161d520a3485d378609277d108cd07cde0327c16811ff54c3e1595"
+PKG_VERSION="2.37"
+PKG_SHA256="eb1383a5ac4b6210d7c7302b9d6fab052abdf51c5d2c9b55f1f779997ba68c6c"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://www.x.org/releases/individual/data/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXmu/package.mk
+++ b/packages/x11/lib/libXmu/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXmu"
-PKG_VERSION="1.1.3"
-PKG_SHA256="9c343225e7c3dc0904f2122b562278da5fed639b1b5e880d25111561bac5b731"
+PKG_VERSION="1.1.4"
+PKG_SHA256="210de3ab9c3e9382572c25d17c2518a854ce6e2c62c5f8315deac7579e758244"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libXext libX11 libXt"
 PKG_LONGDESC="LibXmu provides a set of miscellaneous utility convenience functions for X libraries to use."
 PKG_BUILD_FLAGS="+pic"

--- a/packages/x11/lib/libXrender/package.mk
+++ b/packages/x11/lib/libXrender/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXrender"
-PKG_VERSION="0.9.10"
-PKG_SHA256="c06d5979f86e64cabbde57c223938db0b939dff49fdb5a793a1d3d0396650949"
+PKG_VERSION="0.9.11"
+PKG_SHA256="bc53759a3a83d1ff702fb59641b3d2f7c56e05051fa0cfa93501166fa782dc24"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11"
 PKG_LONGDESC="The X Rendering Extension introduces digital image composition within the X Window System."
 PKG_BUILD_FLAGS="+pic"

--- a/packages/x11/lib/libXtst/package.mk
+++ b/packages/x11/lib/libXtst/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXtst"
-PKG_VERSION="1.2.3"
-PKG_SHA256="4655498a1b8e844e3d6f21f3b2c4e2b571effb5fd83199d428a6ba7ea4bf5204"
+PKG_VERSION="1.2.4"
+PKG_SHA256="84f5f30b9254b4ffee14b5b0940e2622153b0d3aed8286a3c5b7eeb340ca33c8"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libXext libXi libX11"
 PKG_LONGDESC="The Xtst Library"
 

--- a/packages/x11/lib/libXxf86vm/package.mk
+++ b/packages/x11/lib/libXxf86vm/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXxf86vm"
-PKG_VERSION="1.1.4"
-PKG_SHA256="afee27f93c5f31c0ad582852c0fb36d50e4de7cd585fcf655e278a633d85cd57"
+PKG_VERSION="1.1.5"
+PKG_SHA256="247fef48b3e0e7e67129e41f1e789e8d006ba47dba1c0cdce684b9b703f888e7"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11 libXext"
 PKG_LONGDESC="The libxxf86vm provides an interface to the server extension XFree86-VidModeExtension."
 PKG_BUILD_FLAGS="+pic"

--- a/packages/x11/lib/libpciaccess/package.mk
+++ b/packages/x11/lib/libpciaccess/package.mk
@@ -3,13 +3,14 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libpciaccess"
-PKG_VERSION="0.16"
-PKG_SHA256="214c9d0d884fdd7375ec8da8dcb91a8d3169f263294c9a90c575bf1938b9f489"
+PKG_VERSION="0.17"
+PKG_SHA256="74283ba3c974913029e7a547496a29145b07ec51732bbb5b5c58d5025ad95b73"
 PKG_LICENSE="OSS"
-PKG_SITE="http://freedesktop.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://freedesktop.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros zlib"
 PKG_LONGDESC="X.org libpciaccess library."
+PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_asm_mtrr_h=set \
                            --with-pciids-path=/usr/share \

--- a/packages/x11/lib/libxkbfile/package.mk
+++ b/packages/x11/lib/libxkbfile/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbfile"
-PKG_VERSION="1.1.0"
-PKG_SHA256="758dbdaa20add2db4902df0b1b7c936564b7376c02a0acd1f2a331bd334b38c7"
+PKG_VERSION="1.1.1"
+PKG_SHA256="8623dc26e7aac3c5ad8a25e57b566f4324f5619e5db38457f0804ee4ed953443"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11"
 PKG_LONGDESC="Libxkbfile provides an interface to read and manipulate description files for XKB, the X11 keyboard configuration extension."
 

--- a/packages/x11/lib/libxshmfence/package.mk
+++ b/packages/x11/lib/libxshmfence/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxshmfence"
-PKG_VERSION="1.3"
-PKG_SHA256="b884300d26a14961a076fbebc762a39831cb75f92bed5ccf9836345b459220c7"
+PKG_VERSION="1.3.1"
+PKG_SHA256="1129f95147f7bfe6052988a087f1b7cb7122283d2c47a7dbf7135ce0df69b4f8"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros xorgproto"
 PKG_LONGDESC="libxshmfence is the Shared memory 'SyncFence' synchronization primitive."
 PKG_TOOLCHAIN="autotools"

--- a/packages/x11/lib/pixman/package.mk
+++ b/packages/x11/lib/pixman/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pixman"
-PKG_VERSION="0.40.0"
-PKG_SHA256="da8ed9fe2d1c5ef8ce5d1207992db959226bd4e37e3f88acf908fd9a71e2704e"
+PKG_VERSION="0.42.0"
+PKG_SHA256="04bcbff1c6de0a2b7efea4816add7d2854c9a7a3542a21ed73fb438859822ab5"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.x.org/"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.x.org/"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain util-macros"
 PKG_LONGDESC="Pixman is a generic library for manipulating pixel regions, contains low-level pixel manipulation routines."

--- a/packages/x11/other/fontconfig/package.mk
+++ b/packages/x11/other/fontconfig/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fontconfig"
-PKG_VERSION="2.14.0"
-PKG_SHA256="b8f607d556e8257da2f3616b4d704be30fd73bd71e367355ca78963f9a7f0434"
+PKG_VERSION="2.14.1"
+PKG_SHA256="ae480e9ca34382790312ff062c625ec70df94d6d9a9366e2b2b3d525f7f90387"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.fontconfig.org"
-PKG_URL="http://www.freedesktop.org/software/fontconfig/release/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_SITE="https://www.freedesktop.org/wiki/Software/fontconfig/"
+PKG_URL="https://www.freedesktop.org/software/fontconfig/release/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain util-linux util-macros freetype libxml2 zlib expat"
 PKG_LONGDESC="Fontconfig is a library for font customization and configuration."
 PKG_TOOLCHAIN="configure"


### PR DESCRIPTION
- bemenu: update to 0.6.13
- libXxf86vm: update to 1.1.5
- libXtst: update to 1.2.4
- nvidia-vaapi-driver: update to 0.0.7
- xkeyboard-config: update to 2.37
- libXmu: update to 1.1.4 and https
- libpciaccess: update to 0.17 and https
- libxkbfile: update to 1.1.1 and https
- pixman: update to 0.42.0 and https
- libxshmfence: update to 1.3.1 and https
- fontconfig: update to 2.14.1 and https and PKG_SITE
- libXrender: update to 0.9.11