### PR TITLE
Security package updates

### DIFF
--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpg-error"
-PKG_VERSION="1.45"
-PKG_SHA256="570f8ee4fb4bff7b7495cff920c275002aea2147e9a1d220c068213267f80a26"
+PKG_VERSION="1.46"
+PKG_SHA256="b7e11a64246bbe5ef37748de43b245abd72cfcd53c9ae5e7fc5ca59f1c81268d"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.gnupg.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libgpg-error/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/security/nspr/package.mk
+++ b/packages/security/nspr/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nspr"
-PKG_VERSION="4.34.1"
+PKG_VERSION="4.35"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/svn/general/nspr.html"
 PKG_DEPENDS_HOST="ccache:host"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.83"
-PKG_SHA256="b1e1198fa7ee4e0fe4fa6937245c94820fd3c3c6897779493858af1bf6310b30"
+PKG_VERSION="3.84"
+PKG_SHA256="0342347a01545a990860849d39e62aec901c8fabbd614e768c6a5df5d18debeb"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
- nss: update to 3.84
- b6ff216ad9 nspr: update to 4.35
- d463d6fef1 libgpg-error: update to 1.46