### PR TITLE
package updates

### DIFF
--- a/packages/compress/zlib/package.mk
+++ b/packages/compress/zlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="zlib"
-PKG_VERSION="1.2.12"
-PKG_SHA256="7db46b8d7726232a621befaab4a1c870f00a90805511c0e0090441dac57def18"
+PKG_VERSION="1.2.13"
+PKG_SHA256="d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.zlib.net"
 PKG_URL="http://zlib.net/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/gettext/package.mk
+++ b/packages/devel/gettext/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gettext"
-PKG_VERSION="0.21"
-PKG_SHA256="d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192"
+PKG_VERSION="0.21.1"
+PKG_SHA256="50dbc8f39797950aa2c98e939947c527e5ac9ebd2c1b99dd7b06ba33a6767ae6"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.gnu.org/s/gettext/"
-PKG_URL="http://ftp.gnu.org/pub/gnu/gettext/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.gnu.org/s/gettext/"
+PKG_URL="https://ftp.gnu.org/pub/gnu/gettext/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A program internationalization library and tools."

--- a/packages/devel/popt/package.mk
+++ b/packages/devel/popt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="popt"
-PKG_VERSION="1.18"
-PKG_SHA256="5159bc03a20b28ce363aa96765f37df99ea4d8850b1ece17d1e6ad5c24fdc5d1"
+PKG_VERSION="1.19"
+PKG_SHA256="c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rpm-software-management/popt"
 PKG_URL="http://ftp.rpm.org/popt/releases/popt-1.x/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.24.0"
-PKG_SHA256="91e4c34b1768f92d399b078e171448c6af18cafda743987ed2064a28954d6d97"
+PKG_VERSION="2.24.1"
+PKG_SHA256="bc121588b1105065598ce38078026a414c28ea95e66ed2adab4c44d80b309e1b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
 PKG_URL="https://www.libsdl.org/release/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="systemd"
-PKG_VERSION="251.5"
-PKG_SHA256="5ac1e9dad7032561e2040ca7e4bacf4be045c4899bab4d72613d041a0401bf5f"
+PKG_VERSION="251.6"
+PKG_SHA256="74d7deb6e20635d58ca8837d917a171ae694a07837db0632b93e27aa3550a2c1"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd-stable/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="expat"
-PKG_VERSION="2.4.8"
-PKG_SHA256="a247a7f6bbb21cf2ca81ea4cbb916bfb9717ca523631675f99b3d4a5678dcd16"
+PKG_VERSION="2.4.9"
+PKG_SHA256="6e8c0728fe5c7cd3f93a6acce43046c5e4736c7b4b68e032e9350daa0efc0354"
 PKG_LICENSE="OSS"
-PKG_SITE="http://expat.sourceforge.net/"
-PKG_URL="https://github.com/libexpat/libexpat/releases/download/R_${PKG_VERSION//./_}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://libexpat.github.io"
+PKG_URL="https://github.com/libexpat/libexpat/releases/download/R_${PKG_VERSION//./_}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Expat is an XML parser library written in C."

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.10.2"
-PKG_SHA256="d50e8a55b2797501929d3411b81d5d37ec44e9a4aa58eae9052572977c632d7a"
+PKG_VERSION="2.10.3"
+PKG_SHA256="302bbb86400b8505bebfbf7b3d1986e9aa05073198979f258eed4be481ff5f83"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- systemd: update to 251.6
- libxml2: update to 2.10.3
- zlib: update to 1.2.13
- gettext: update to 0.21.1 and HSTS
- SDL2: update to 2.24.1
- expat: update to 2.4.9 and URIs
- popt: update to 1.19