### PR TITLE
linux: update to 5.10.y

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="5.10.146"
-    PKG_SHA256="7bbd97f3278eadb73c19a1ca8c1a655c60afcee9f487b910063cdd15e9ee6dc1"
+    PKG_VERSION="5.10.149"
+    PKG_SHA256="0f6134c537563b9cd0533924e3ce06f577cf874e7a00cf3d8e8b31222ac065d3"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v5.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;


### PR DESCRIPTION
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.147
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.148
- https://lore.kernel.org/lkml/20221016064454.382206984@linuxfoundation.org/
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.149

5.10.147 - 52 patches
5.10.148 - 54 patches (Wifi security)
5.10.149 - 4 patches (Wi-Fi fixes)

errors / fixes / issues / regressions
- wifi fixes https://www.phoronix.com/news/Linux-6.0.2-Point-Releases-WiFi

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.10.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-5.10.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/5.10

### 5.10.148-rc1 Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=Generic ARCH=x86_64 s/build linux

### 5.10.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel SKL - NUC6) - 5.10.149 - heitbaum
- RK all - tested - TBA - knaerzche