### PR TITLE
glslang: update to 11.12.0

### DIFF
--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers pkg_version/s need to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools & spirv-headers pkg_version/s.
-PKG_VERSION="11.11.0"
-PKG_SHA256="26c216c3062512c018cbdd752224b8dad703b7e5bb90bf338ba2dbb5d4f11438"
+PKG_VERSION="11.12.0"
+PKG_SHA256="7795a97450fecd9779f3d821858fbc2d1a3bf1dd602617d95b685ccbcabc302f"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-headers/package.mk
+++ b/packages/graphics/vulkan/spirv-headers/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-headers"
 # The SPIRV-Headers pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-headers pkg_version.
-PKG_VERSION="b2a156e1c0434bc8c99aaebba1c7be98be7ac580"
-PKG_SHA256="b200990e1c07894906e298368e7e56d5ab9d728d851f9292587ec740c2b4d409"
+PKG_VERSION="85a1ed200d50660786c1a88d9166e871123cce39"
+PKG_SHA256="9729304d0915e758c5ea2a1c60b55a123d976f172c0a8dae3162ad23c77ef33b"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-tools/package.mk
+++ b/packages/graphics/vulkan/spirv-tools/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-tools"
 # The SPIRV-Tools pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools pkg_version.
-PKG_VERSION="5e61ea2098220059e89523f1f47b0bcd8c33b89a"
-PKG_SHA256="527f51a40396a283a4fbff1af22e17ce7457f9af17e9d738b9e559c1a7e5c6de"
+PKG_VERSION="eb0a36633d2acf4de82588504f951ad0f2cecacb"
+PKG_SHA256="9f7c423c9dad6c9e664e0600226646232a328051f73f30d6795360370aa06a2f"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- [spirv-tools: update githash to 2022-10-13](https://github.com/LibreELEC/LibreELEC.tv/commit/7dd0d7b342a69d8781b757c694471fb27c0a8e2d)
- [spirv-headers: update githash to 2022-10-06](https://github.com/LibreELEC/LibreELEC.tv/commit/dc69aa3af98e79cef8d58ad49a4eb5c4c9c8e121)
- [glslang: update to 11.12.0](https://github.com/LibreELEC/LibreELEC.tv/commit/6c79cb246e6277bc9da2bd262688543235541732)