### PR TITLE
linux (Rockchip): media: rkvdec-hevc: Use vb2_find_buffer

### DIFF
--- a/projects/Rockchip/patches/linux/default/linux-2000-v4l2-wip-rkvdec-hevc.patch
+++ b/projects/Rockchip/patches/linux/default/linux-2000-v4l2-wip-rkvdec-hevc.patch
@@ -10,11 +10,11 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
 Signed-off-by: Alex Bee <knaerzche@gmail.com>
 ---
  drivers/staging/media/rkvdec/Makefile      |    2 +-
- drivers/staging/media/rkvdec/rkvdec-hevc.c | 2573 ++++++++++++++++++++
+ drivers/staging/media/rkvdec/rkvdec-hevc.c | 2572 ++++++++++++++++++++
  drivers/staging/media/rkvdec/rkvdec-regs.h |    1 +
  drivers/staging/media/rkvdec/rkvdec.c      |   73 +-
  drivers/staging/media/rkvdec/rkvdec.h      |    1 +
- 5 files changed, 2648 insertions(+), 2 deletions(-)
+ 5 files changed, 2647 insertions(+), 2 deletions(-)
  create mode 100644 drivers/staging/media/rkvdec/rkvdec-hevc.c
 
 diff --git a/drivers/staging/media/rkvdec/Makefile b/drivers/staging/media/rkvdec/Makefile
@@ -31,7 +31,7 @@ new file mode 100644
 index 000000000000..fd87cbf9c1f8
 --- /dev/null
 +++ b/drivers/staging/media/rkvdec/rkvdec-hevc.c
-@@ -0,0 +1,2573 @@
+@@ -0,0 +1,2572 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Rockchip Video Decoder HEVC backend
@@ -2316,20 +2316,19 @@ index 000000000000..fd87cbf9c1f8
 +	const struct v4l2_ctrl_hevc_decode_params *decode_params = run->decode_params;
 +	const struct v4l2_hevc_dpb_entry *dpb = decode_params->dpb;
 +	struct vb2_queue *cap_q = &m2m_ctx->cap_q_ctx.q;
-+	int buf_idx = -1;
++	struct vb2_buffer *vb2_buf;
 +
 +	if (dpb_idx < decode_params->num_active_dpb_entries)
-+		buf_idx = vb2_find_timestamp(cap_q,
-+					     dpb[dpb_idx].timestamp, 0);
++		vb2_buf = vb2_find_buffer(cap_q, dpb[dpb_idx].timestamp);
 +
 +	/*
 +	 * If a DPB entry is unused or invalid, address of current destination
 +	 * buffer is returned.
 +	 */
-+	if (buf_idx < 0)
++	if (!vb2_buf)
 +		return &run->base.bufs.dst->vb2_buf;
 +
-+	return vb2_get_buffer(cap_q, buf_idx);
++	return vb2_buf;
 +}
 +
 +static void config_registers(struct rkvdec_ctx *ctx,


### PR DESCRIPTION
Update patch to support both Linux 6.0 and 6.1. vb2_find_timestamp is dropped in 6.1-rc1