### PR TITLE
Rockchip: linux: Fix HEVC decoding

### DIFF
--- a/projects/Rockchip/patches/linux/default/linux-2000-v4l2-wip-rkvdec-hevc.patch
+++ b/projects/Rockchip/patches/linux/default/linux-2000-v4l2-wip-rkvdec-hevc.patch
@@ -2316,7 +2316,7 @@ index 000000000000..fd87cbf9c1f8
 +	const struct v4l2_ctrl_hevc_decode_params *decode_params = run->decode_params;
 +	const struct v4l2_hevc_dpb_entry *dpb = decode_params->dpb;
 +	struct vb2_queue *cap_q = &m2m_ctx->cap_q_ctx.q;
-+	struct vb2_buffer *vb2_buf;
++	struct vb2_buffer *vb2_buf = NULL;
 +
 +	if (dpb_idx < decode_params->num_active_dpb_entries)
 +		vb2_buf = vb2_find_buffer(cap_q, dpb[dpb_idx].timestamp);


### PR DESCRIPTION
Since https://github.com/LibreELEC/LibreELEC.tv/pull/7017 HEVC decoding is failing for Rockchip, since the `vb2_buffer` is not correctly initalized.
Fix it.