### PR TITLE
Intel Graphics updates

### DIFF
--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.113"
-PKG_SHA256="7fd7eb2967f63beb4606f22d50e277d993480d05ef75dd88a9bd8e677323e5e1"
+PKG_VERSION="2.4.114"
+PKG_SHA256="3049cf843a47d12e5eeefbc3be3496d782fa09f42346bf0b7defe3d1e598d026"
 PKG_LICENSE="GPL"
 PKG_SITE="https://dri.freedesktop.org"
 PKG_URL="https://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.2.0"
-PKG_SHA256="0b2253894c6fc8455b6d7c5e87e6504a76d6f60ea192e1445c2f93164bf529c0"
+PKG_VERSION="22.3.0"
+PKG_SHA256="c1f33e1519edfc527127baeb0436b783430dfd256c643130169a3a71dc86aff9"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.5.4"
-PKG_SHA256="08d8d041f94b094a2dd5c4739c413b75185521c7f788a02411395ff374ee4ead"
+PKG_VERSION="22.6.2"
+PKG_SHA256="a59c4c9facf567ccbea3aab36b150d961c56e48461283a2aa7c438a311b4d2d0"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"
@@ -15,4 +15,5 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_CMRTLIB=OFF \
                        -DBUILD_KERNELS=ON \
                        -DBUILD_TYPE=release \
                        -DENABLE_NONFREE_KERNELS=ON \
+                       -DMEDIA_BUILD_FATAL_WARNINGS=ON \
                        -DMEDIA_RUN_TEST_SUITE=OFF"


### PR DESCRIPTION
- gmmlib: update to 22.3.0
- media-driver: update to 2.6.2
- libdrm: update to 2.4.114

build error and warnings: (included in 2.6.2)
- https://github.com/intel/media-driver/issues/1519
- https://github.com/intel/media-driver/issues/1520

nuc12:~ # sh scripts/testedon.sh
```
=== tested on ===
Generic.x86_64-devel-20221023030937-7b50cdc
Linux nuc12 6.0.3 #1 SMP Sun Oct 23 03:11:51 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA3 (19.90.710) Git:92a0283f169270dc205834b470c09c84e845dfc1). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-10-23 by GCC 12.2.0 for Linux x86 64-bit version 6.0.3 (393219)
Running on LibreELEC (heitbaum): devel-20221023030937-7b50cdc 11.0, kernel: Linux x86 64-bit version 6.0.3
FFmpeg version/source: 4.4.1-Nexus-Alpha1-Kodi
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0085.2022.0718.1739 07/18/2022
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.2.2
libva info: VA-API version 1.16.0
vainfo: VA-API version: 1.16 (libva 2.16.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.6.0 (7b50cdce96)
```