### PR TITLE
LibreELEC-settings: update to 1d458c6

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="f369cd15cd31d8e072db2ee1d9473174c11baafe"
-PKG_SHA256="a2a2f3455cf75a2d574fe183191773143580d504630fdf4e920fdfcdd9d9d5c1"
+PKG_VERSION="1d458c6242668ffca70aa5da56bec1fd548b5e88"
+PKG_SHA256="d08bbf432fc9906eb9365199dfbab2042a7b439a8a704d51e0b220b4b4c97296"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
This is the change to manual update to keep from updating to a lower major version.