### PR TITLE
util-linux: cleanup mount-swap, add comments to swap.conf

### DIFF
--- a/packages/sysutils/util-linux/config/swap.conf
+++ b/packages/sysutils/util-linux/config/swap.conf
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
-SWAPFILE="$HOME/.cache/swapfile"
+# location with write access and no spaces
+SWAPFILE="${HOME}/.cache/swapfile"
+
+# in MiB
 SWAPFILESIZE="@SWAPFILESIZE@"
+
+# set to "yes" to enable
 SWAP_ENABLED="@SWAP_ENABLED_DEFAULT@"

--- a/packages/sysutils/util-linux/scripts/mount-swap
+++ b/packages/sysutils/util-linux/scripts/mount-swap
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 . /etc/swap.conf
 . /etc/profile
@@ -15,26 +16,26 @@ if [ -e /dev/.storage_netboot ] ; then
   exit 0
 fi
 
-if [ ! "$SWAP_ENABLED" = yes ] ; then
+if [ ! "${SWAP_ENABLED}" = "yes" ] ; then
   logger -t Boot "### swap disabled via configfile ###"
   exit 0
 fi
 
-SWAP=`blkid -t TYPE="swap" -o device`
+SWAP=$(blkid -t TYPE="swap" -o device)
 
 case $1 in
   create)
-    if [ -z "$SWAP" -a ! -f "$SWAPFILE" ]; then
-      mkdir -p `dirname $SWAPFILE`
-      dd if=/dev/zero of=$SWAPFILE bs=1M count=$SWAPFILESIZE
-      chmod 0600 $SWAPFILE
-      mkswap $SWAPFILE
+    if [ -z "${SWAP}" ] && [ ! -f "${SWAPFILE}" ]; then
+      mkdir -p "$(dirname ${SWAPFILE})"
+      dd if=/dev/zero of="${SWAPFILE}" bs=1M count="${SWAPFILESIZE}"
+      chmod 0600 "${SWAPFILE}"
+      mkswap "${SWAPFILE}"
     fi
     ;;
   mount)
-    [ -z "$SWAP" -a -f "$SWAPFILE" ] && SWAP=$SWAPFILE
-    for i in $SWAP; do
-      swapon -p 10000 $i
+    { [ -z "${SWAP}" ] && [ -f "${SWAPFILE}" ]; } && SWAP="${SWAPFILE}"
+    for i in ${SWAP}; do
+      swapon -p 10000 "${i}"
     done
     ;;
   unmount)


### PR DESCRIPTION
These are shellcheck adjustments for mount-swap, and comments in swap.conf to help users set the variables correctly when copying it.