### PR TITLE
samba: update to 4.17.2

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.1"
-PKG_SHA256="1b939d03f8ca57194c413ed863014a3850c9ce9f9e31c2a7df706806fba77c01"
+PKG_VERSION="4.17.2"
+PKG_SHA256="e55ddf4d5178f8c84316abf53c5edd7b35399e3b7d86bcb81b75261c827bb3b8"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Security release:
https://www.samba.org/samba/history/samba-4.17.2.html