### PR TITLE
Alsa updates to 1.2.8

### DIFF
--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-lib"
-PKG_VERSION="1.2.7.2"
-PKG_SHA256="8a35b7218e50f2a2c79342d0de98ded81439ce19e12809385ec9be9596de7c2f"
+PKG_VERSION="1.2.8"
+PKG_SHA256="1ab01b74e33425ca99c2e36c0844fd6888273193bd898240fe8f93accbcbf347"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.alsa-project.org/"
 PKG_URL="https://www.alsa-project.org/files/pub/lib/alsa-lib-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/alsa-ucm-conf/package.mk
+++ b/packages/audio/alsa-ucm-conf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-ucm-conf"
-PKG_VERSION="1.2.7.2"
-PKG_SHA256="53ef5639c4097b228e8f5cfaa2e7b829d04b5de2dc9a38d54efa8aa350d3f5fd"
+PKG_VERSION="1.2.8"
+PKG_SHA256="fee4a737830fd25f969d83da46a2b231beb086efd966fcc07d225e7823260ae8"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="https://www.alsa-project.org/"
 PKG_URL="https://www.alsa-project.org/files/pub/lib/alsa-ucm-conf-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-utils"
-PKG_VERSION="1.2.7"
-PKG_SHA256="e906bf2404ff04c448eaa3d226d283a62b9a283f12e4fd8457fb24bac274e678"
+PKG_VERSION="1.2.8"
+PKG_SHA256="e140fa604c351f36bd72167c8860c69d81b964ae6ab53992d6434dde38e9333c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.alsa-project.org/"
 PKG_URL="https://www.alsa-project.org/files/pub/utils/alsa-utils-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- alsa-utils: update to 1.2.8
- alsa-lib: update to 1.2.8
- alsa-ucm-conf: update to 1.2.8

release notes:
- https://www.alsa-project.org/wiki/Changes_v1.2.7.2_v1.2.8


