### PR TITLE
linux: update to 6.0.y

### DIFF
--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwlwifi-firmware"
-PKG_VERSION="9c65a729599eda5cd4ffcae6acc64e00d2f8a058"
-PKG_SHA256="d34bb99563f60ce6a1c1ca645da0a9dbf476a21230c58f5353c5db4472d5ed4e"
+PKG_VERSION="2eb6baa08b3a3c9bf3f9f12ec6d9b94eca1d36e7"
+PKG_SHA256="2641d8587536f646e28468dad6cda962fbdee9c45571075546135c4ca8776162"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/iwlwifi-firmware"
 PKG_URL="https://github.com/LibreELEC/iwlwifi-firmware/archive/${PKG_VERSION}.tar.gz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.0.3"
-    PKG_SHA256="b0d522241805794d8af3a67d331ba063a16496c6fb6d365d48f7ed78ee1c3dcf"
+    PKG_VERSION="6.0.6"
+    PKG_SHA256="864b05af2d869ba73d61a9c5959e4531a141ab2bd7b217483671f625f9747faa"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Allwinner/patches/linux/0060-WIP-drm-bridge-synopsys-Fix-CEC-not-working-after-power.patch
+++ b/projects/Allwinner/patches/linux/0060-WIP-drm-bridge-synopsys-Fix-CEC-not-working-after-power.patch
@@ -13,20 +13,14 @@ depending on sink's implementation.
 
 Signed-off-by: Alex Bee <knaerzche@gmail.com>
 ---
- drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 16 ++++++++--------
- 1 file changed, 9 insertions(+), 8 deletions(-)
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
-index 84cc52858ffb..3c20ef3bd3c1 100644
+index 92e621f2714f..7551e3ab77d6 100644
 --- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
-@@ -3036,24 +3036,11 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
- 	 * ask the source to re-read the EDID.
- 	 */
- 	if (intr_stat &
--	    (HDMI_IH_PHY_STAT0_RX_SENSE | HDMI_IH_PHY_STAT0_HPD)) {
-+	    (HDMI_IH_PHY_STAT0_RX_SENSE | HDMI_IH_PHY_STAT0_HPD))
- 		dw_hdmi_setup_rx_sense(hdmi,
+@@ -3179,12 +3179,6 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
  				       phy_stat & HDMI_PHY_HPD,
  				       phy_stat & HDMI_PHY_RX_SENSE);
  
@@ -36,17 +30,10 @@ index 84cc52858ffb..3c20ef3bd3c1 100644
 -			mutex_unlock(&hdmi->cec_notifier_mutex);
 -		}
 -
--		if (phy_stat & HDMI_PHY_HPD)
--			status = connector_status_connected;
--
--		if (!(phy_stat & (HDMI_PHY_HPD | HDMI_PHY_RX_SENSE)))
--			status = connector_status_disconnected;
--	}
--
- 	if (status != connector_status_unknown) {
- 		dev_dbg(hdmi->dev, "EVENT=%s\n",
- 			status == connector_status_connected ?
-@@ -3061,6 +3054,14 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
+ 		if (phy_stat & HDMI_PHY_HPD)
+ 			status = connector_status_connected;
+ 
+@@ -3201,6 +3195,14 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
  			drm_helper_hpd_irq_event(hdmi->bridge.dev);
  			drm_bridge_hpd_notify(&hdmi->bridge, status);
  		}


### PR DESCRIPTION
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.0.4
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.0.5
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.0.6

6.0.4 - 30 patches
6.0.5 - 2 patches
6.0.6 - 94 patches

errors / fixes / issues / regressions
- iwlwifi-firmware: update to 2eb6baa (Version 72) - latest for both kernel 6.0 and kernel 6.1

```
[    7.255232] iwlwifi 0000:00:14.3: enabling device (0000 -> 0002)
[    7.260694] iwlwifi 0000:00:14.3: api flags index 2 larger than supported by driver
[    7.260702] iwlwifi 0000:00:14.3: TLV_FW_FSEQ_VERSION: FSEQ Version: 0.0.2.36
[    7.260885] iwlwifi 0000:00:14.3: loaded firmware version 72.daa05125.0 so-a0-gf-a0-72.ucode op_mode iwlmvm
[    7.294529] iwlwifi 0000:00:14.3: Detected Intel(R) Wi-Fi 6E AX211 160MHz, REV=0x370
[    7.458687] iwlwifi 0000:00:14.3: loaded PNVM version dbd9582f
[    7.470235] iwlwifi 0000:00:14.3: Detected RF GF, rfid=0x2010d000
[    7.541465] iwlwifi 0000:00:14.3: base HW address:
```

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.0.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.0.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.0

### 6.0.6-rc1 Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=arm DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux`

### 6.0.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.0.6-rc1 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum