### PR TITLE
Addon fixes

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/chrome-libXrender/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libXrender/package.mk
@@ -15,5 +15,5 @@ PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} \
 
 unpack() {
   mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.bz2 -C ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
 }

--- a/packages/addons/addon-depends/chrome-depends/chrome-libXtst/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libXtst/package.mk
@@ -15,5 +15,5 @@ PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} \
 
 unpack() {
   mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.bz2 -C ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
 }


### PR DESCRIPTION
Both chrome-libXrender and chrome-libXtst fail to build because the unpack step refers to the bz2 file which is now an xx file.