### PR TITLE
exfatprogs: fix SHA256

### DIFF
--- a/packages/sysutils/exfatprogs/package.mk
+++ b/packages/sysutils/exfatprogs/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="exfatprogs"
 PKG_VERSION="1.2.0"
-PKG_SHA256="49c7177475c0e1759005a245f9877cf2253225cd8267de5f1657aa64fe21ddd6"
+PKG_SHA256="56d9a49465deafc367d428afc71c8098705a30ee19a3cdf3c5320650b8880742"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/exfatprogs/exfatprogs"
 PKG_URL="https://github.com/exfatprogs/exfatprogs/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
```
supervisedthinking@x220l:/mnt/dev/LibreELEC-RR$ scripts/get exfatprogs
GET      exfatprogs (archive)
--2022-10-29 14:47:09--  https://github.com/exfatprogs/exfatprogs/releases/download/1.2.0/exfatprogs-1.2.0.tar.xz
Resolving github.com (github.com)... 140.82.121.4
Connecting to github.com (github.com)|140.82.121.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/234896758/64659926-52bb-4b64-8b6c-dfa775d6d1ba?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221029%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221029T124709Z&X-Amz-Expires=300&X-Amz-Signature=ba39403b64cefeaad585b33935df0b4184605be4c3a0a984760fae2c66bdeeeb&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=234896758&response-content-disposition=attachment%3B%20filename%3Dexfatprogs-1.2.0.tar.xz&response-content-type=application%2Foctet-stream [following]
--2022-10-29 14:47:09--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/234896758/64659926-52bb-4b64-8b6c-dfa775d6d1ba?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221029%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221029T124709Z&X-Amz-Expires=300&X-Amz-Signature=ba39403b64cefeaad585b33935df0b4184605be4c3a0a984760fae2c66bdeeeb&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=234896758&response-content-disposition=attachment%3B%20filename%3Dexfatprogs-1.2.0.tar.xz&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.109.133, 185.199.110.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 272716 (266K) [application/octet-stream]
Saving to: '/mnt/dev/LibreELEC-RR/sources/exfatprogs/exfatprogs-1.2.0.tar.xz'

/mnt/dev/LibreELEC-RR/sources/exfatprogs/e 100%[=====================================================================================>] 266.32K  --.-KB/s    in 0.06s   

2022-10-29 14:47:09 (4.02 MB/s) - '/mnt/dev/LibreELEC-RR/sources/exfatprogs/exfatprogs-1.2.0.tar.xz' saved [272716/272716]

    INFO      Calculated checksum: 56d9a49465deafc367d428afc71c8098705a30ee19a3cdf3c5320650b8880742
```