### PR TITLE
libbpf update to 1.0.1 and patch v4l-utils to support build with libbpf 1.0.1 

### DIFF
--- a/packages/devel/libbpf/package.mk
+++ b/packages/devel/libbpf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libbpf"
-PKG_VERSION="0.8.1"
-PKG_SHA256="7bda8187efc619d1eb20a1ba5ab949dd68d40dd44945310c91ac0f915fa4a42b"
+PKG_VERSION="1.0.1"
+PKG_SHA256="3d6afde67682c909e341bf194678a8969f17628705af25f900d5f68bd299cb03"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/libbpf/libbpf"
 PKG_URL="https://github.com/libbpf/libbpf/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/v4l-utils/patches/v4l-utils-002-support-libbpf-1-0-0.patch
+++ b/packages/sysutils/v4l-utils/patches/v4l-utils-002-support-libbpf-1-0-0.patch
@@ -1,0 +1,140 @@
+From dce0e3e1e4ea91d3e46098362a880371ec5afe1b Mon Sep 17 00:00:00 2001
+From: Sudip Mukherjee <sudipm.mukherjee@gmail.com>
+Date: Tue, 1 Nov 2022 20:25:28 +0000
+Subject: keytable: Convert deprecated libbpf API
+
+The libbpf APIs bpf_load_program_xattr(), bpf_create_map_node() and
+bpf_create_map_in_map_node() have been deprecated since v0.7. Convert
+them to use bpf_prog_load() and bpf_map_create().
+Also, modify config script to add a check for libbpf version.
+
+Signed-off-by: Sudip Mukherjee <sudipm.mukherjee@gmail.com>
+Signed-off-by: Sean Young <sean@mess.org>
+---
+ configure.ac              |  2 +-
+ utils/keytable/bpf_load.c | 59 ++++++++++++++++++++++++++---------------------
+ 2 files changed, 34 insertions(+), 27 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 05298981..9b7c371d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -564,7 +564,7 @@ AM_CONDITIONAL([WITH_V4L2_CTL_32], [test x${enable_v4l2_ctl_32} = xyes])
+ AM_CONDITIONAL([WITH_V4L2_COMPLIANCE], [test x$ac_cv_func_fork = xyes])
+ AM_CONDITIONAL([WITH_V4L2_COMPLIANCE_LIBV4L], [test x$ac_cv_func_fork = xyes -a x${enable_v4l2_compliance_libv4l} != xno])
+ AM_CONDITIONAL([WITH_V4L2_COMPLIANCE_32], [test x$ac_cv_func_fork = xyes -a x${enable_v4l2_compliance_32} = xyes])
+-PKG_CHECK_MODULES([LIBBPF], [libbpf], [bpf_pc=yes], [bpf_pc=no])
++PKG_CHECK_MODULES([LIBBPF], [libbpf >= 0.7], [bpf_pc=yes], [bpf_pc=no])
+ AM_CONDITIONAL([WITH_BPF],          [test x$enable_bpf != xno -a x$libelf_pkgconfig = xyes -a x$CLANG = xclang -a x$bpf_pc = xyes])
+ 
+ # append -static to libtool compile and link command to enforce static libs
+diff --git a/utils/keytable/bpf_load.c b/utils/keytable/bpf_load.c
+index 7c633dac..06098fc3 100644
+--- a/utils/keytable/bpf_load.c
++++ b/utils/keytable/bpf_load.c
+@@ -63,19 +63,17 @@ struct bpf_file {
+ 
+ static int load_and_attach(int lirc_fd, struct bpf_file *bpf_file, struct bpf_insn *prog, int size)
+ {
+-	struct bpf_load_program_attr load_attr;
+-	int fd, err;
++	LIBBPF_OPTS(bpf_prog_load_opts, opts);
++	int fd, err, insn_cnt;
+ 
+-	memset(&load_attr, 0, sizeof(struct bpf_load_program_attr));
++	insn_cnt = size / sizeof(struct bpf_insn);
+ 
+-	load_attr.prog_type = BPF_PROG_TYPE_LIRC_MODE2;
+-	load_attr.expected_attach_type = BPF_LIRC_MODE2;
+-	load_attr.name = bpf_file->name;
+-	load_attr.insns = prog;
+-	load_attr.insns_cnt = size / sizeof(struct bpf_insn);
+-	load_attr.license = bpf_file->license;
++	opts.expected_attach_type = BPF_LIRC_MODE2;
++	opts.log_buf = bpf_log_buf;
++	opts.log_size = LOG_BUF_SIZE;
+ 
+-	fd = bpf_load_program_xattr(&load_attr, bpf_log_buf, LOG_BUF_SIZE);
++	fd = bpf_prog_load(BPF_PROG_TYPE_LIRC_MODE2, bpf_file->name,
++				bpf_file->license, prog, insn_cnt, &opts);
+ 	if (fd < 0) {
+ 		printf("bpf_load_program() err=%m\n%s", bpf_log_buf);
+ 		return -1;
+@@ -95,6 +93,9 @@ static int build_raw_map(struct bpf_map_data *map, struct raw_entry *raw, int nu
+ 	int no_patterns, value_size, fd, key, i;
+ 	struct raw_entry *e;
+ 	struct raw_pattern *p;
++	LIBBPF_OPTS(bpf_map_create_opts, opts,
++		.map_flags = map->def.map_flags,
++	);
+ 
+ 	no_patterns = 0;
+ 
+@@ -110,14 +111,13 @@ static int build_raw_map(struct bpf_map_data *map, struct raw_entry *raw, int nu
+ 
+ 	value_size = sizeof(struct raw_pattern) + max_length * sizeof(short);
+ 
+-	fd = bpf_create_map_node(map->def.type,
+-				 map->name,
+-				 map->def.key_size,
+-				 value_size,
+-				 no_patterns,
+-				 map->def.map_flags,
+-				 numa_node);
+-
++	opts.numa_node = numa_node;
++	fd = bpf_map_create(map->def.type,
++			    map->name,
++			    map->def.key_size,
++			    value_size,
++			    no_patterns,
++			    &opts);
+ 	if (fd < 0) {
+ 		printf(_("failed to create a map: %d %s\n"),
+ 		       errno, strerror(errno));
+@@ -174,27 +174,34 @@ static int load_maps(struct bpf_file *bpf_file, struct raw_entry *raw)
+ 
+ 		if (maps[i].def.type == BPF_MAP_TYPE_ARRAY_OF_MAPS ||
+ 		    maps[i].def.type == BPF_MAP_TYPE_HASH_OF_MAPS) {
+-			int inner_map_fd = bpf_file->map_fd[maps[i].def.inner_map_idx];
++			LIBBPF_OPTS(bpf_map_create_opts, opts,
++				.inner_map_fd = bpf_file->map_fd[maps[i].def.inner_map_idx],
++				.map_flags = maps[i].def.map_flags,
++				.numa_node = numa_node,
++			);
+ 
+-			bpf_file->map_fd[i] = bpf_create_map_in_map_node(
++			bpf_file->map_fd[i] = bpf_map_create(
+ 							maps[i].def.type,
+ 							maps[i].name,
+ 							maps[i].def.key_size,
+-							inner_map_fd,
++							4,
+ 							maps[i].def.max_entries,
+-							maps[i].def.map_flags,
+-							numa_node);
++							&opts);
+ 		} else if (!strcmp(maps[i].name, "raw_map")) {
+ 			bpf_file->map_fd[i] = build_raw_map(&maps[i], raw, numa_node);
+ 		} else {
+-			bpf_file->map_fd[i] = bpf_create_map_node(
++			LIBBPF_OPTS(bpf_map_create_opts, opts,
++				.map_flags = maps[i].def.map_flags,
++				.numa_node = numa_node,
++			);
++
++			bpf_file->map_fd[i] = bpf_map_create(
+ 							maps[i].def.type,
+ 							maps[i].name,
+ 							maps[i].def.key_size,
+ 							maps[i].def.value_size,
+ 							maps[i].def.max_entries,
+-							maps[i].def.map_flags,
+-							numa_node);
++							&opts);
+ 		}
+ 
+ 		if (bpf_file->map_fd[i] < 0) {
+-- 
+cgit v1.2.1
+

--- a/packages/sysutils/v4l-utils/patches/v4l-utils-003-enable-bpf-without-clang.patch
+++ b/packages/sysutils/v4l-utils/patches/v4l-utils-003-enable-bpf-without-clang.patch
@@ -16,7 +16,7 @@ index 3bb1d2a5..7b633473 100644
 @@ -565,7 +565,7 @@
  AM_CONDITIONAL([WITH_V4L2_COMPLIANCE_LIBV4L], [test x$ac_cv_func_fork = xyes -a x${enable_v4l2_compliance_libv4l} != xno])
  AM_CONDITIONAL([WITH_V4L2_COMPLIANCE_32], [test x$ac_cv_func_fork = xyes -a x${enable_v4l2_compliance_32} = xyes])
- PKG_CHECK_MODULES([LIBBPF], [libbpf], [bpf_pc=yes], [bpf_pc=no])
+ PKG_CHECK_MODULES([LIBBPF], [libbpf >= 0.7], [bpf_pc=yes], [bpf_pc=no])
 -AM_CONDITIONAL([WITH_BPF],          [test x$enable_bpf != xno -a x$libelf_pkgconfig = xyes -a x$CLANG = xclang -a x$bpf_pc = xyes])
 +AM_CONDITIONAL([WITH_BPF],          [test x$enable_bpf != xno -a x$libelf_pkgconfig = xyes -a x$bpf_pc = xyes])
  


### PR DESCRIPTION
- v4l-utils: support build with libbpf 1.0.1
  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1018915
- libbpf: update to 1.0.1

https://git.linuxtv.org/v4l-utils.git/log/