### PR TITLE
[le11] Addons updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/chrome-libxshmfence/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libxshmfence/package.mk
@@ -15,5 +15,5 @@ PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} \
 
 unpack() {
   mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.bz2 -C ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
 }

--- a/packages/addons/addon-depends/faad2/package.mk
+++ b/packages/addons/addon-depends/faad2/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="faad2"
-PKG_VERSION="2.10.0"
-PKG_SHA256="0c6d9636c96f95c7d736f097d418829ced8ec6dbd899cc6cc82b728480a84bfb"
+PKG_VERSION="2.10.1"
+PKG_SHA256="4c16c71295ca0cbf7c3dfe98eb11d8fa8d0ac3042e41604cfd6cc11a408cf264"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/knik0/faad2/"
-PKG_URL="https://github.com/knik0/faad2/archive/${PKG_VERSION//./_}.tar.gz"
+PKG_URL="https://github.com/knik0/faad2/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="An MPEG-4 AAC decoder."
 PKG_TOOLCHAIN="configure"

--- a/packages/addons/addon-depends/game-tools/linuxconsoletools/package.mk
+++ b/packages/addons/addon-depends/game-tools/linuxconsoletools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="linuxconsoletools"
-PKG_VERSION="1.7.1"
-PKG_SHA256="bd4d4b7e37da02fc67e47ddf20b6f1243c0a7af7b02b918d5e72138ea8727547"
+PKG_VERSION="1.8.1"
+PKG_SHA256="4da29745c782b7db18f5f37c49e77bf163121dd3761e2fc7636fa0cbf35c2456"
 PKG_LICENSE="GPL"
 PKG_SITE="http://sourceforge.net/projects/linuxconsole/"
 PKG_URL="http://prdownloads.sourceforge.net/linuxconsole/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/game-tools/linuxconsoletools/patches/linuxconsoletools-0001-disable-building-ffmvforce.patch
+++ b/packages/addons/addon-depends/game-tools/linuxconsoletools/patches/linuxconsoletools-0001-disable-building-ffmvforce.patch
@@ -1,12 +1,12 @@
 diff -Naur a/utils/Makefile b/utils/Makefile
---- a/utils/Makefile	2016-04-19 13:20:50.000000000 -0700
-+++ b/utils/Makefile	2016-10-20 00:31:34.238941511 -0700
-@@ -27,7 +27,7 @@
+--- a/utils/Makefile	2022-05-21 09:44:47.000000000 +0000
++++ b/utils/Makefile	2022-05-21 18:58:51.363206817 +0000
+@@ -37,7 +37,7 @@
+ endif
  
- CFLAGS		?= -g -O2 -Wall
- 
--PROGRAMS	= inputattach jstest jscal fftest ffmvforce ffset \
-+PROGRAMS	= inputattach jstest jscal fftest ffset \
- 		  ffcfstress jscal-restore jscal-store evdev-joystick
+ ifndef DISABLE_FORCEFEEDBACK
+-PROGRAMS	+= fftest ffmvforce ffset ffcfstress
++PROGRAMS	+= fftest ffset ffcfstress
+ endif
  
  PREFIX          ?= /usr/local

--- a/packages/addons/service/mpd/changelog.txt
+++ b/packages/addons/service/mpd/changelog.txt
@@ -1,3 +1,7 @@
+115
+- Update to version 0.23.10
+- faad2: update to 2.10.1
+
 114
 - Update to version 0.23.8
 - mpd-mpc: update to 0.34

--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpd"
-PKG_VERSION="0.23.8"
-PKG_SHA256="86bb569bf3b519821f36f6bb5564e484e85d2564411b34b200fe2cd3a04e78cf"
-PKG_REV="114"
+PKG_VERSION="0.23.10"
+PKG_SHA256="605c8ceb42cc48144cbdbe9e9682b6dc0df0348258a4a62bde095a02ca24e6a8"
+PKG_REV="115"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"

--- a/packages/addons/service/rsyslog/changelog.txt
+++ b/packages/addons/service/rsyslog/changelog.txt
@@ -1,3 +1,6 @@
+113
+- rsyslog: update to 8.2210.0
+
 112
 - rsyslog: update to 8.2208.0
 

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rsyslog"
-PKG_VERSION="8.2208.0"
-PKG_SHA256="14de68e7b8e5ab0c5d734f82e2dc9fff22cd7f4710ad690727eb10a7b9b3df5e"
-PKG_REV="112"
+PKG_VERSION="8.2210.0"
+PKG_SHA256="643ee279139d694a07c9ff3ff10dc5213bdf874983d27d373525e95e05fa094d"
+PKG_REV="113"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rsyslog"

--- a/packages/addons/service/syncthing/changelog.txt
+++ b/packages/addons/service/syncthing/changelog.txt
@@ -1,3 +1,6 @@
+122
+- update to 1.22.0
+
 121
 - update to 1.21.0
 

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.21.0"
-PKG_SHA256="e70d70c7962383973acdbc2eb184548ae87de22ac6854045982c7960b8260450"
-PKG_REV="121"
+PKG_VERSION="1.22.0"
+PKG_SHA256="b9644e814b4c7844a59e4e7705c550361cb4ed6c36bf9b46617de386ee2dad45"
+PKG_REV="122"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/tools/game-tools/changelog.txt
+++ b/packages/addons/tools/game-tools/changelog.txt
@@ -1,3 +1,6 @@
+104
+- linuxconsoletools: update to 1.8.1
+
 103
 - linuxconsoletools: update to 1.7.1
 

--- a/packages/addons/tools/game-tools/package.mk
+++ b/packages/addons/tools/game-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="game-tools"
 PKG_VERSION=""
-PKG_REV="103"
+PKG_REV="104"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""


### PR DESCRIPTION
- [syncthing: update to 1.22.0 and addon (122)](https://github.com/LibreELEC/LibreELEC.tv/commit/969a9c4ffdcb7eb415c11b3276cec9b35f51247f)
- [rsyslog: update to 8.2210.0 and addon (113)](https://github.com/LibreELEC/LibreELEC.tv/commit/e313518be0521c1dfcb124cf9849403c5b00d0c4)
- [game-tools: update addons tools (104)](https://github.com/LibreELEC/LibreELEC.tv/commit/c6b31de98d32018aec75f21abc9873a9cf5672c0)
  - [linuxconsoletools: update to 1.8.1](https://github.com/LibreELEC/LibreELEC.tv/commit/c7ab1c7e7acb7847a02d28204d23f6aca2591aa2)
- [mpd: update to 0.23.10 and addon (115)](https://github.com/LibreELEC/LibreELEC.tv/commit/99b928bc4cddb5a5f16c0f4d6b0653600faddba1)
  - [faad2: update to 2.10.1](https://github.com/LibreELEC/LibreELEC.tv/commit/03a402191e86041374fc8d86d230e96dc7b967a8)
- Fix: chrome-libxshmfence: update unpack file