### PR TITLE
Audio package updates

### DIFF
--- a/packages/audio/flac/package.mk
+++ b/packages/audio/flac/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flac"
-PKG_VERSION="1.4.0"
-PKG_SHA256="af41c0733c93c237c3e52f64dd87e3b0d9af38259f1c7d11e8cbf583c48c2506"
+PKG_VERSION="1.4.2"
+PKG_SHA256="e322d58a1f48d23d9dd38f432672865f6f79e73a6f9cc5a5f57fcaa83eb5a8e4"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://xiph.org/flac/"
 PKG_URL="https://downloads.xiph.org/releases/flac/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.2.9"
-PKG_SHA256="bc62494ec2554fdcfc01512a2580f12fc1e1b01ce37a18b370dd7902af7a8159"
+PKG_VERSION="2.3.0"
+PKG_SHA256="1df5a1afb91acf3b945b7fdb89ac0d99877622161d9b5155533da59113eaaa20"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/audio/fluidsynth/patches/libsndfile-use-static-libraries.patch
+++ b/packages/audio/fluidsynth/patches/libsndfile-use-static-libraries.patch
@@ -1,10 +1,10 @@
 --- a/CMakeLists.txt	2021-09-12 13:53:14.192948082 +1000
 +++ b/CMakeLists.txt	2021-09-12 13:54:27.389413149 +1000
 @@ -535,6 +535,7 @@
-              LIBSNDFILE_STATIC_LDFLAGS MATCHES "vorbis" OR
-              LIBSNDFILE_STATIC_LDFLAGS_OTHER MATCHES "vorbis" )
-           set ( LIBSNDFILE_HASVORBIS 1 )
-+          set ( LIBSNDFILE_LIBRARIES ${LIBSNDFILE_STATIC_LIBRARIES} )
-         else ()
-           message ( NOTICE "Seems like libsndfile was compiled without OGG/Vorbis support." )
-         endif ()
+            LIBSNDFILE_STATIC_LDFLAGS MATCHES "vorbis" OR
+            LIBSNDFILE_STATIC_LDFLAGS_OTHER MATCHES "vorbis" )
+         set ( LIBSNDFILE_HASVORBIS 1 )
++        set ( LIBSNDFILE_LIBRARIES ${LIBSNDFILE_STATIC_LIBRARIES} )
+     else ()
+         message ( NOTICE "Seems like libsndfile was compiled without OGG/Vorbis support." )
+     endif ()

--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.6.5"
-PKG_SHA256="f22abe977cdae405f685b75150e7fb155b2c7896b4700fd54abe68840f66e9c0"
+PKG_VERSION="0.6.6"
+PKG_SHA256="6ddb9e26a430620944891796fefb1bbb38bd9148f6cfc558810c0d3f269876c7"
 PKG_LICENSE="BSD"
 PKG_SITE="https://lib.openmpt.org/libopenmpt/"
 PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/audio/taglib/package.mk
+++ b/packages/audio/taglib/package.mk
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="taglib"
-PKG_VERSION="1.12"
-PKG_SHA256="7fccd07669a523b07a15bd24c8da1bbb92206cb19e9366c3692af3d79253b703"
+PKG_VERSION="1.13"
+PKG_SHA256="58f08b4db3dc31ed152c04896ee9172d22052bc7ef12888028c01d8b1d60ade0"
 PKG_LICENSE="LGPL"
-PKG_SITE="http://taglib.github.com/"
-PKG_URL="http://taglib.github.io/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_SITE="https://taglib.org"
+PKG_URL="https://taglib.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain cmake:host zlib"
 PKG_LONGDESC="TagLib is a library for reading and editing the meta-data of several popular audio formats."
 
-PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
-                       -DWITH_MP4=ON \
-                       -DWITH_ASF=ON"
+PKG_CMAKE_OPTS_TARGET="-DBUILD_EXAMPLES=OFF \
+                       -DBUILD_SHARED_LIBS=OFF \
+                       -DBUILD_TESTING=OFF \
+                       -DENABLE_CCACHE=ON \
+                       -DWITH_ZLIB=ON"
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin


### PR DESCRIPTION
- taglib: update to 1.13 and Urls and cmake options
- flac: update to 1.4.2
- libopenmpt: update to 0.6.6
- fluidsynth: update to 2.3.0