### PR TITLE
openssl: update to 1.1.1s

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="1.1.1q"
-PKG_SHA256="d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca"
+PKG_VERSION="1.1.1s"
+PKG_SHA256="c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.openssl.org"
 PKG_URL="https://www.openssl.org/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
release notes:
- https://www.openssl.org/news/cl111.txt

 Changes between 1.1.1r and 1.1.1s [1 Nov 2022]

  *) Fixed a regression introduced in 1.1.1r version not refreshing the certificate data to be signed before signing the certificate.

     [Gibeom Gwon]

 Changes between 1.1.1q and 1.1.1r [11 Oct 2022]

  *) Fixed the linux-mips64 Configure target which was missing the SIXTY_FOUR_BIT bn_ops flag. This was causing heap corruption on that platform. [Adam Joseph]

  *) Fixed a strict aliasing problem in bn_nist. Clang-14 optimisation was causing incorrect results in some cases as a result. [Paul Dale]

  *) Fixed SSL_pending() and SSL_has_pending() with DTLS which were failing to report correct results in some cases [Matt Caswell]

  *) Fixed a regression introduced in 1.1.1o for re-signing certificates with different key sizes [Todd Short]

  *) Added the loongarch64 target [Shi Pujin]

  *) Fixed a DRBG seed propagation thread safety issue [Bernd Edlinger]

  *) Fixed a memory leak in tls13_generate_secret [Bernd Edlinger]

  *) Fixed reported performance degradation on aarch64. Restored the implementation prior to commit 2621751 ("aes/asm/aesv8-armx.pl: avoid 32-bit lane assignment in CTR mode") for 64bit targets only, since it is reportedly 2-17% slower and the silicon errata only affects 32bit targets. The new algorithm is still used for 32 bit targets. [Bernd Edlinger]

  *) Added a missing header for memcmp that caused compilation failure on some platforms [Gregor Jasny]