### PR TITLE
linux: update to 5.10.y

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="5.10.152"
-    PKG_SHA256="fa0b5c83a4ebfda9f0a52cc693646eb6c24dbade6c37ee2d18b66ee2df15d8a6"
+    PKG_VERSION="5.10.156"
+    PKG_SHA256="679e9964ca720027967391b61db990ceb7868e93e203f87724f18310f4955923"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v5.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;


### PR DESCRIPTION
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.153
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.154
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.155
-  https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.156

5.10.153 - 91 patches
5.10.154 - 117 patches
5.10.155 - 95 patches
5.10.156 - 149 patches

errors / fixes / issues / regressions
- 

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.10.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-5.10.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/5.10

### 5.10.156 Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=Generic ARCH=x86_64 s/build linux

### 5.10.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel SKL - NUC6) - 5.10.156 - heitbaum
- RK all - tested - TBA - knaerzche