### PR TITLE
Update OSMC hwdb remapping

### DIFF
--- a/packages/sysutils/systemd/config/hwdb.d/99-osmcrf.hwdb
+++ b/packages/sysutils/systemd/config/hwdb.d/99-osmcrf.hwdb
@@ -1,3 +1,15 @@
+evdev:input:b0003v2252p1069*
+ KEYBOARD_KEY_7002e=volumeup
+ KEYBOARD_KEY_7002d=volumedown
+ KEYBOARD_KEY_7000c=kpleftparen
+ KEYBOARD_KEY_70006=kprightparen
+
+evdev:input:b0003v2017p1690*
+ KEYBOARD_KEY_7002e=volumeup
+ KEYBOARD_KEY_7002d=volumedown
+ KEYBOARD_KEY_7000c=kpleftparen
+ KEYBOARD_KEY_70006=kprightparen
+
 evdev:input:b0003v2017p1689*
  KEYBOARD_KEY_7002e=volumeup
  KEYBOARD_KEY_7002d=volumedown


### PR DESCRIPTION
As requested by users, this adds support for two missing VID/PID HW remaps that are missing in LE.