### PR TITLE
xkeyboard-config: fix xkb-base path for non-X11 projects

### DIFF
--- a/packages/x11/data/xkeyboard-config/package.mk
+++ b/packages/x11/data/xkeyboard-config/package.mk
@@ -19,11 +19,11 @@ configure_package() {
 
 pre_configure_target() {
   PKG_MESON_OPTS_TARGET="-Dcompat-rules=true \
+                         -Dxkb-base=${XORG_PATH_XKB} \
                          -Ddatadir=lib"
 
   if [ "${DISPLAYSERVER}" = "x11" ]; then
-    PKG_MESON_OPTS_TARGET+=" -Dxkb-base=${XORG_PATH_XKB} \
-                            -Dxorg-rules-symlinks=true"
+    PKG_MESON_OPTS_TARGET+=" -Dxorg-rules-symlinks=true"
   else
     PKG_MESON_OPTS_TARGET+=" -Dxorg-rules-symlinks=false"
   fi


### PR DESCRIPTION
- this stores pkg-config files in `install_pkg/xkeyboard-config-2.37/usr/lib/pkgconfig/xkeyboard-config.pc` and xkb-base files in `install_pkg/xkeyboard-config-2.37/usr/share/X11/xkb` for all projects
-  tested on RK3399 & I can switch key hardware layouts in System -> Input again

@HiassofT please check if your RPi builds are fine with that