### PR TITLE
gstreamer: update PKG_DEPENDS_TARGET

### DIFF
--- a/packages/multimedia/gstreamer/gstreamer/package.mk
+++ b/packages/multimedia/gstreamer/gstreamer/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="9a41769bcbbb2d5ed015660c3b80902af758a884c4e30592752a3ae27b22307a"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org"
 PKG_URL="https://gstreamer.freedesktop.org/src/gstreamer/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain glib glib:host"
 PKG_LONGDESC="GStreamer open-source multimedia framework core library"
 
 pre_configure_target() {


### PR DESCRIPTION
Build was failing when doing standalone build of `gstreamer` from `make clean` while checking https://forum.libreelec.tv/thread/26238-package-dependency-not-building/