### PR TITLE
mesa: update to 22.2.3

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="22.2.2"
-PKG_SHA256="2de11fb74fc5cc671b818e49fe203cea0cd1d8b69756e97cdb06a2f4e78948f9"
+PKG_VERSION="22.2.3"
+PKG_SHA256="ee7d026f7b1991dbae0861d359b671145c3a86f2a731353b885d2ea2d5c098d6"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20221107203947-d4a959c
Linux nuc12 6.1.0-rc4 #1 SMP Mon Nov  7 09:24:50 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-ALPHA3 (19.90.710) Git:92a0283f169270dc205834b470c09c84e845dfc1). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-11-06 by GCC 12.2.0 for Linux x86 64-bit version 6.1.0 (393472)
Running on LibreELEC (heitbaum): devel-20221107203947-d4a959c 11.0, kernel: Linux x86 64-bit version 6.1.0-rc4
FFmpeg version/source: 4.4.1-Nexus-Alpha1-Kodi
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0085.2022.0718.1739 07/18/2022
CApplication::CreateGUI - trying to init gbm windowing system
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.2.3
libva info: VA-API version 1.16.0
vainfo: VA-API version: 1.16 (libva 2.16.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.6.1 (618646fc4b)
```