### PR TITLE
intel-ucode: update to 20221108

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20220809"
-PKG_SHA256="084463c82fbcb679e7fa211e676fd12a8ae464fed7d445e92ccc67101ced5a94"
+PKG_VERSION="20221108"
+PKG_SHA256="8d14a914815f56c27b1f41be0fd699d1afcfdbc05432056427e455100798975e"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"


### PR DESCRIPTION
release notes:
- https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20221108

```
nuc12:~ # dmesg | head
[    0.000000] microcode: microcode updated early to revision 0x424, date = 2022-09-19
[    0.000000] Linux version 6.1.0-rc4 (docker@c22ecb9022af) (x86_64-libreelec-linux-gnu-gcc-12.2.0 (GCC) 12.2.0, GNU ld (GNU Binutils) 2.39) #1 SMP Wed Nov  9 04:44:40 UTC 2022
```