### PR TITLE
kodi: update to 20.0b1-Nexus / v20 beta1

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="92a0283f169270dc205834b470c09c84e845dfc1"
-PKG_SHA256="51e2a51d98098662c138ffbcf8c08038e10f9b8b6b933b1a1180f3ec17950f96"
+PKG_VERSION="20.0b1-Nexus"
+PKG_SHA256="dc714f4730ad213f8b1dffdea6b93dc88d8e3c7985f45889fcc0fd46951eee27"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- https://github.com/xbmc/xbmc/releases/tag/20.0b1-Nexus

```
=== tested on ===
AMLG12B.arm-RR-20221109-1bcd80b
Linux vim3 5.19.14 #1 SMP PREEMPT Tue Nov 8 15:13:13 CET 2022 aarch64 GNU/Linux
Starting Kodi (20.0-BETA1 (19.90.801) Git:20.0b1-Nexus). Platform: Linux ARM 32-bit
Using Release Kodi x32
Kodi compiled 2022-11-09 by GCC 12.2.0 for Linux ARM 32-bit version 5.19.14 (332558)
Running on Amlogic Meson G12B (A311D) Khadas VIM3 with LibreELEC (ST): RR-20221109-1bcd80b 11.0, kernel: Linux ARM 64-bit version 5.19.14
FFmpeg version/source: dev/4.4/rpi_import_1-f9638b6
Host CPU: ARMv8 Processor rev 4 (v8l), 6 cores available
ARM Features: Neon enabled
RetroPlayer[PROCESS]: Registering process control for GBM
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_VERSION = OpenGL ES 3.1 Mesa 22.3.0-rc1
```
