### PR TITLE
X11: build shared and/or enable position independent code (pic)

### DIFF
--- a/packages/x11/lib/libICE/package.mk
+++ b/packages/x11/lib/libICE/package.mk
@@ -10,6 +10,7 @@ PKG_SITE="http://www.X.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain util-macros xtrans"
 PKG_LONGDESC="X Inter-Client Exchange (ICE) protocol library."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/x11/lib/libSM/package.mk
+++ b/packages/x11/lib/libSM/package.mk
@@ -10,6 +10,7 @@ PKG_SITE="http://www.X.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_TARGET="toolchain util-macros util-linux libICE"
 PKG_LONGDESC="This package provides the main interface to the X11 Session Management library."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/x11/lib/libXcomposite/package.mk
+++ b/packages/x11/lib/libXcomposite/package.mk
@@ -12,8 +12,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros libXfixes libXext libX11"
 PKG_LONGDESC="X Composite Library"
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
 post_configure_target() {
   libtool_remove_rpath libtool
 }

--- a/packages/x11/lib/libXdamage/package.mk
+++ b/packages/x11/lib/libXdamage/package.mk
@@ -12,8 +12,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros libX11 libXfixes"
 PKG_LONGDESC="LibXdamage provides an X Window System client interface to the DAMAGE extension to the X protocol."
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
 post_configure_target() {
   libtool_remove_rpath libtool
 }

--- a/packages/x11/lib/libXfixes/package.mk
+++ b/packages/x11/lib/libXfixes/package.mk
@@ -12,8 +12,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros libX11"
 PKG_LONGDESC="X Fixes Library"
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
-
 post_configure_target() {
   libtool_remove_rpath libtool
 }

--- a/packages/x11/lib/libXi/package.mk
+++ b/packages/x11/lib/libXi/package.mk
@@ -12,8 +12,7 @@ PKG_DEPENDS_TARGET="toolchain util-macros libX11 libXfixes libXext"
 PKG_LONGDESC="LibXi provides an X Window System client interface to the XINPUT extension to the X protocol."
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
-                           --enable-malloc0returnsnull \
+PKG_CONFIGURE_OPTS_TARGET="--enable-malloc0returnsnull \
                            --disable-silent-rules \
                            --disable-docs \
                            --disable-specs \

--- a/packages/x11/lib/libXrender/package.mk
+++ b/packages/x11/lib/libXrender/package.mk
@@ -12,7 +12,7 @@ PKG_DEPENDS_TARGET="toolchain util-macros libX11"
 PKG_LONGDESC="The X Rendering Extension introduces digital image composition within the X Window System."
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --enable-malloc0returnsnull"
+PKG_CONFIGURE_OPTS_TARGET="--enable-malloc0returnsnull"
 
 post_configure_target() {
   libtool_remove_rpath libtool

--- a/packages/x11/lib/libXtst/package.mk
+++ b/packages/x11/lib/libXtst/package.mk
@@ -11,7 +11,7 @@ PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VE
 PKG_DEPENDS_TARGET="toolchain util-macros libXext libXi libX11"
 PKG_LONGDESC="The Xtst Library"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --with-gnu-ld --without-xmlto"
+PKG_CONFIGURE_OPTS_TARGET="--with-gnu-ld --without-xmlto"
 
 post_configure_target() {
   libtool_remove_rpath libtool

--- a/packages/x11/lib/libxshmfence/package.mk
+++ b/packages/x11/lib/libxshmfence/package.mk
@@ -12,5 +12,3 @@ PKG_DEPENDS_TARGET="toolchain util-macros xorgproto"
 PKG_LONGDESC="libxshmfence is the Shared memory 'SyncFence' synchronization primitive."
 PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="+pic"
-
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"


### PR DESCRIPTION
#### Most if not all libs were used several times e.g.:
 - libXcomposite by xf86-video-intel & xorg-server
 - libXdamage by xf86-video-intel & mesa
 - libXfixes by mesa, libva, libXcomposite, libXdamage, libXi
 - (...)

And all will be used by Chrome so it makes sense to build them shared instead static. In a follow up PR the chrome dependencies can be cleaned up.