### PR TITLE
dotnet-runtime: Update ASP.NET 6.x to 6.0.11 and addon (125)

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet6-runtime"
-PKG_VERSION="6.0.10"
+PKG_VERSION="6.0.11"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="6ef235a35a3ea8773b0b0eba011d182af08d972deb331c2259db4277fd4f0a80"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/c37e7250-886d-47e1-840e-fc0ae2aad195/81f019f66f158b7ccb3511d2fa5dec53/aspnetcore-runtime-6.0.10-linux-arm64.tar.gz"
+    PKG_SHA256="b9960c5a343903e38ef84ee8ef00551330b7a64b3fb4d75d8cd2ddd29a23841e"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/e25f7ff2-9932-41dd-b549-5b4409b5a727/d00786aeabad50cd661e959a576f8777/aspnetcore-runtime-6.0.11-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="91c7008433d6859e9402427b2465b412c10525f86268e938ccb39cfadcacb004"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/eb049d47-1cd1-4a76-8b4c-3efee9890f2a/53441bce40b9ac8d073fb4742d823c3b/aspnetcore-runtime-6.0.10-linux-arm.tar.gz"
+    PKG_SHA256="4bec937852e3a0660a57243c19a5b1d2375047de2aa1df972bc587b410ea660b"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/4072393d-3350-41d2-98e2-dc46fd930fae/6f09e1d7685fbbc01f6d84b1140e1b49/aspnetcore-runtime-6.0.11-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="17685d3e8fa7aa9c1a658f7ca5e176bec7bb4c189b0352ac5abfed98135b93d9"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/7d44ddeb-ad35-41a8-a581-03b151afbd80/6888586c28836b1e1f71df879184550b/aspnetcore-runtime-6.0.10-linux-x64.tar.gz"
+    PKG_SHA256="d499a4af84cc3f9947230392f10d5af5fda65a71e002554f2ea3cd4244538133"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/0a17a9f6-7705-4b47-aead-c0b582cad317/158b62e5183281e416994d56ce81bc0c/aspnetcore-runtime-6.0.11-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/tools/dotnet-runtime/changelog.txt
+++ b/packages/addons/tools/dotnet-runtime/changelog.txt
@@ -1,3 +1,6 @@
+125
+- Update ASP.NET Core Runtime 6.0.11
+
 124
 - Drop ASP.NET Core Runtime 3.1
   .NET Core 3.1 is End of Support - 2022-12-13

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="124"
+PKG_REV="125"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"


### PR DESCRIPTION
Latest release notes:
- https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.11/6.0.11.md?WT.mc_id=dotnet-35129-website 
- https://dotnet.microsoft.com/en-us/download/dotnet/6.0