### PR TITLE
wlroots 0.16.1 and 1.8 sway updates

### DIFF
--- a/packages/wayland/compositor/sway/package.mk
+++ b/packages/wayland/compositor/sway/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sway"
-PKG_VERSION="1.7"
-PKG_SHA256="0c64536fb2883ec518e75cfb119f9300115fb49b084e3fde62b794fe2c6c8d84"
+PKG_VERSION="1.8"
+PKG_SHA256="fae0422bca8f528027f77e3a7bbea2be0498bba2ad3f0d22554ff8827e37f04e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://swaywm.org/"
 PKG_URL="https://github.com/swaywm/sway/archive/${PKG_VERSION}.tar.gz"
@@ -24,7 +24,7 @@ PKG_MESON_OPTS_TARGET="-Ddefault-wallpaper=false \
 
 pre_configure_target() {
   # sway does not build without -Wno flags as all warnings being treated as errors
-  export TARGET_CFLAGS=$(echo "${TARGET_CFLAGS} -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-function -Wno-maybe-uninitialized -Wno-stringop-truncation -Wno-address")
+  export TARGET_CFLAGS=$(echo "${TARGET_CFLAGS} -Wno-unused-variable")
 }
 
 post_makeinstall_target() {

--- a/packages/wayland/compositor/sway/patches/sway-100.02-allow-running-as-root.patch
+++ b/packages/wayland/compositor/sway/patches/sway-100.02-allow-running-as-root.patch
@@ -1,13 +1,37 @@
 --- a/sway/main.c
 +++ b/sway/main.c
-@@ -152,6 +152,10 @@ static void log_kernel(void) {
+@@ -151,7 +151,8 @@
+ }
  
- 
- static bool drop_permissions(void) {
-+	if (getuid() == 0 || getgid() == 0) {
+ static bool detect_suid(void) {
+-	if (geteuid() != 0 && getegid() != 0) {
++	if (geteuid() == 0 && getegid() == 0) {
 +		sway_log(SWAY_INFO, "Running sway as root user");
-+		return true;
+ 		return false;
+ 	}
+ 
+@@ -309,11 +310,6 @@
+ 		}
+ 	}
+ 
+-	// SUID operation is deprecated, so block it for now.
+-	if (detect_suid()) {
+-		exit(EXIT_FAILURE);
+-	}
+-
+ 	// Since wayland requires XDG_RUNTIME_DIR to be set, abort with just the
+ 	// clear error message (when not running as an IPC client).
+ 	if (!getenv("XDG_RUNTIME_DIR") && optind == argc) {
+@@ -363,6 +359,11 @@
+ 		return 0;
+ 	}
+ 
++	// SUID operation is deprecated, so block it for now.
++	if (detect_suid()) {
++		exit(EXIT_FAILURE);
 +	}
- 	if (getuid() != geteuid() || getgid() != getegid()) {
- 		sway_log(SWAY_ERROR, "!!! DEPRECATION WARNING: "
- 			"SUID privilege drop will be removed in a future release, please migrate to seatd-launch");
++
+ 	detect_proprietary(allow_unsupported_gpu);
+ 	increase_nofile_limit();
+ 
+

--- a/packages/wayland/compositor/sway/patches/sway-100.03-do-not-use-git-version.patch
+++ b/packages/wayland/compositor/sway/patches/sway-100.03-do-not-use-git-version.patch
@@ -1,0 +1,22 @@
+--- a/meson.build
++++ b/meson.build
+@@ -158,18 +158,6 @@
+ add_project_arguments('-DSYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
+ 
+ version = '"@0@"'.format(meson.project_version())
+-git = find_program('git', native: true, required: false)
+-if git.found()
+-	git_commit = run_command([git, 'rev-parse', '--short', 'HEAD'], check: false)
+-	git_branch = run_command([git, 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
+-	if git_commit.returncode() == 0 and git_branch.returncode() == 0
+-		version = '"@0@-@1@ (" __DATE__ ", branch \'@2@\')"'.format(
+-			meson.project_version(),
+-			git_commit.stdout().strip(),
+-			git_branch.stdout().strip(),
+-		)
+-	endif
+-endif
+ add_project_arguments('-DSWAY_VERSION=@0@'.format(version), language: 'c')
+ 
+ # Compute the relative path used by compiler invocations.
+

--- a/packages/wayland/lib/hwdata/package.mk
+++ b/packages/wayland/lib/hwdata/package.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="hwdata"
+PKG_VERSION="0.365"
+PKG_SHA256="d6ae2436a69c6f5e04d926f5d753a99d90deb864065a2e2f8a8eda87b70dcdd5"
+PKG_LICENSE="GPL-2.0"
+PKG_SITE="https://github.com/vcrhonek/hwdata"
+PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="hwdata contains various hardware identification and configuration data, such as the pci.ids and usb.ids databases"
+
+pre_configure_target() {
+# hwdata fails to build in subdirs
+  cd ${PKG_BUILD}
+    rm -rf .${TARGET_NAME}
+
+    sed -i "s&@prefix@|&@prefix@|${PKG_INSTALL}&" Makefile
+    sed -i "s&prefix=@prefix@&prefix=/usr&" hwdata.pc.in
+}

--- a/packages/wayland/lib/wlroots/package.mk
+++ b/packages/wayland/lib/wlroots/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wlroots"
-PKG_VERSION="0.15.1"
-PKG_SHA256="8bb791aed9405abc20253c570de1a3b7af91ad65bee2b60293fbbab27ea62c8d"
+PKG_VERSION="0.16.0"
+PKG_SHA256="3be91163208577761969a8ae499d737c4dbb764f73c46aa8f76a512ee36b7da4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/wlroots/wlroots/"
 PKG_URL="https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain libinput libxkbcommon pixman libdrm wayland wayland-protocols seatd"
+PKG_DEPENDS_TARGET="toolchain hwdata libinput libxkbcommon pixman libdrm wayland wayland-protocols seatd"
 PKG_LONGDESC="A modular Wayland compositor library"
 
 configure_package() {

--- a/packages/wayland/lib/wlroots/package.mk
+++ b/packages/wayland/lib/wlroots/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wlroots"
-PKG_VERSION="0.16.0"
-PKG_SHA256="3be91163208577761969a8ae499d737c4dbb764f73c46aa8f76a512ee36b7da4"
+PKG_VERSION="0.16.1"
+PKG_SHA256="1ea948d044d7c475f91c89719986482fe427eb48223cfe2ddf9426ff60b94674"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/wlroots/wlroots/"
 PKG_URL="https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/wayland/util/swaybg/package.mk
+++ b/packages/wayland/util/swaybg/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="swaybg"
-PKG_VERSION="1.1.1"
-PKG_SHA256="71cc8fc2cb7ae5ad3af772ab286b0b42f1c7cb17bea131e78c2d40a2fb8e6c59"
+PKG_VERSION="1.2.0"
+PKG_SHA256="cfeab55b983da24352407279556c035b495890422578812d9a9c0bba1dc3ce75"
 PKG_LICENSE="MIT"
 PKG_SITE="https://swaywm.org/"
 PKG_URL="https://github.com/swaywm/swaybg/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- hwdata: initial package
  - dependency for wlroots, they have moved the pci.ids out of the wlroots
  - https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/eec95e3d5e1a4f2e13b1f6b34cc287475ca57daf
- wlroots: update to 0.16.1
- swaybg: update to 1.2.0
- sway: update to 1.8