### PR TITLE
linux (RPi): update to 6.0.8

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="13691cee95902d76bc88a3f658abeb37b3c90b03"
-PKG_SHA256="d9dca126b1d43b3d1cb05c2dd6e8e9189117f3150dbd50f066bd0342d6c78ad0"
+PKG_VERSION="6cbf00359959cf7381f4e3773037c7d5573d94b2"
+PKG_SHA256="8febbda58d38b730050722f8ca72ff02502a5372071a3a8cab0b639135f6f2b6"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="398749b3fd3328b9db434c1d1eb59c57e432a462" # 6.0.7
-    PKG_SHA256="7d3022192e6af3eb929d954c7a5d246f23e7eec23934e46e084350c1c09eb840"
+    PKG_VERSION="e7c0c4cee580ee498561d1a270e4ceb0cc56a57a" # 6.0.7
+    PKG_SHA256="71a36c0b6324d0732d636ca4b5cbca0975e7b122abf6bab70b00891d950aa761"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="e7c0c4cee580ee498561d1a270e4ceb0cc56a57a" # 6.0.7
-    PKG_SHA256="71a36c0b6324d0732d636ca4b5cbca0975e7b122abf6bab70b00891d950aa761"
+    PKG_VERSION="229cc142097f091b7b8318805881f09989c6efd1" # 6.0.8
+    PKG_SHA256="1a8490a86825f6b695f0a54d2145511df2e0b80a1697b2e2e60494f068b2126a"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="8f5ddeb6dd3cb2885273766627e03d63c4dd933f" # 6.0.6
-    PKG_SHA256="c964d2eb789538f7373b1493338f40dc68e2a110e385441348694fbfc55ceefb"
+    PKG_VERSION="398749b3fd3328b9db434c1d1eb59c57e432a462" # 6.0.7
+    PKG_SHA256="7d3022192e6af3eb929d954c7a5d246f23e7eec23934e46e084350c1c09eb840"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="995137e7ea36f56af0072eb940845f918ad6e08e" # 6.0.6
-    PKG_SHA256="f4508994790914b15f3566c633d9e104cd54cdb33986c2ed3cddd87b7dcbd30d"
+    PKG_VERSION="8f5ddeb6dd3cb2885273766627e03d63c4dd933f" # 6.0.6
+    PKG_SHA256="c964d2eb789538f7373b1493338f40dc68e2a110e385441348694fbfc55ceefb"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="13691cee95902d76bc88a3f658abeb37b3c90b03"
-PKG_SHA256="2ad28a8ecdeb1325f4967f115decbcdc1c52218b65ab40da445f733d43454318"
+PKG_VERSION="6cbf00359959cf7381f4e3773037c7d5573d94b2"
+PKG_SHA256="85d8531d0758f3b7a65ce244a0c5a49c41bab38ff0c22dcbfd1b01784e12376a"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="1197a4ae319e2ccf69e1b2e4c438f3fd68bd61ea"
-PKG_SHA256="1bd76310f1223bdfbdb999fd419629489f7ed22702b25e3712a0f6ff885e2ded"
+PKG_VERSION="9269d78320c542935a87f07675893537e672908d"
+PKG_SHA256="bd9572e5c716db4fb3f84297de9f9da5e0c871b779dccfedbd7a0dab93069dba"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="092f87659594a48cf52a18a6f2dee9ebf4dcaedf"
-PKG_SHA256="0d90a7317f56b7f4139fbeb9732c5c9922b2d749c8999a83b2615cad171ea06e"
+PKG_VERSION="1197a4ae319e2ccf69e1b2e4c438f3fd68bd61ea"
+PKG_SHA256="1bd76310f1223bdfbdb999fd419629489f7ed22702b25e3712a0f6ff885e2ded"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"


### PR DESCRIPTION
This adds back the vc4 force_hotplug module parameter which was missing in 6.x kernels 