### PR TITLE
systemd: add xaomi remote to 70-local-keyboard.hwdb

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -6,3 +6,7 @@ evdev:input:b0005v0217p0000e0110*
 evdev:input:b0003v2017p1689*
  KEYBOARD_KEY_7002e=f10 # volume up
  KEYBOARD_KEY_7002d=f9 # volume down
+
+# xaomi remote
+evdev:input:b0005v2717p32B9e4A4C*
+ KEYBOARD_KEY_c0041=enter


### PR DESCRIPTION
Adds the evdev mapping for a Xaomi BT remote as reported in the forums: https://forum.libreelec.tv/thread/26261-fix-for-xiaomi-bluetooth-remote-with-nonworking-button/