### PR TITLE
samba: update to 4.17.3

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.2"
-PKG_SHA256="e55ddf4d5178f8c84316abf53c5edd7b35399e3b7d86bcb81b75261c827bb3b8"
+PKG_VERSION="4.17.3"
+PKG_SHA256="5d1c420cb31ec613c786f98537f959659081edc6be8373e68e87140868938e26"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
release notes:
- https://www.samba.org/samba/history/samba-4.17.3.html

                   ==============================
                   Release Notes for Samba 4.17.3
                         November 15, 2022
                   ==============================


This is a security release in order to address the following defects:


o CVE-2022-42898: Samba's Kerberos libraries and AD DC failed to guard against
                  integer overflows when parsing a PAC on a 32-bit system, which
                  allowed an attacker with a forged PAC to corrupt the heap.
                  https://www.samba.org/samba/security/CVE-2022-42898.html

Changes since 4.17.2
--------------------
o  Joseph Sutton <josephsutton@catalyst.net.nz>
   * BUG 15203: CVE-2022-42898

o  Nicolas Williams <nico@twosigma.com>
   * BUG 15203: CVE-2022-42898