### PR TITLE
cmake: update to 3.25.0

### DIFF
--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.24.2"
-PKG_SHA256="0d9020f06f3ddf17fb537dc228e1a56c927ee506b486f55fe2dc19f69bf0c8db"
+PKG_VERSION="3.25.0"
+PKG_SHA256="306463f541555da0942e6f5a0736560f70c487178b9d94a5ae7f34d0538cdd48"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://cmake.org/cmake/help/v3.25/release/3.25.html

have been tracking this since rc1