### PR TITLE
sed: update package URL

### DIFF
--- a/packages/sysutils/sed/package.mk
+++ b/packages/sysutils/sed/package.mk
@@ -7,7 +7,7 @@ PKG_VERSION="4.9"
 PKG_SHA256="6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/sed/"
-PKG_URL="http://ftpmirror.gnu.org/sed/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://mirrors.kernel.org/gnu/sed/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_LONGDESC="The sed (Stream EDitor) editor is a stream or batch (non-interactive) editor."
 


### PR DESCRIPTION
Doing a clean rebuild to test the Amlogic kernel bump the sed package download failed. This updates PKG_URL to a working one (also https).