### PR TITLE
config/functions: add get_pkg_sha256

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1003,6 +1003,10 @@ get_pkg_version() {
   get_pkg_variable "$1" PKG_VERSION
 }
 
+get_pkg_sha256() {
+  get_pkg_variable "$1" PKG_SHA256
+}
+
 get_pkg_version_maj_min() {
   local pkg_version
 


### PR DESCRIPTION
- returns the `PKG_SHA256` hash of a given package file
- useful if you reuse a base package as source & if you want to keep it synced