### PR TITLE
[le11] system-tools: update to addon (134)

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/depends/libmtp/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/libmtp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmtp"
-PKG_VERSION="1.1.19"
-PKG_SHA256="deb4af6f63f5e71215cfa7fb961795262920b4ec6cb4b627f55b30b18aa33228"
+PKG_VERSION="1.1.20"
+PKG_SHA256="c9191dac2f5744cf402e08641610b271f73ac21a3c802734ec2cedb2c6bc56d0"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libmtp.sourceforge.net/"
 PKG_URL="${SOURCEFORGE_SRC}/project/${PKG_NAME}/${PKG_NAME}/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/efibootmgr/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/efibootmgr/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="efibootmgr"
-PKG_VERSION="b9fedd6b6f57055164bc361bc5cf16a602843c6e" # Nov 5, 2021
-PKG_SHA256="06061ebf96d28522f5a20b592305e71b91d3fb479ddcce41dadb5180da16d8d8"
+PKG_VERSION="18"
+PKG_SHA256="442867d12f8525034a404fc8af3036dba8e1fc970998af2486c3b940dfad0874"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rhboot/efibootmgr"

--- a/packages/addons/addon-depends/system-tools-depends/fdupes/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/fdupes/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fdupes"
-PKG_VERSION="2.1.2"
-PKG_SHA256="cd5cb53b6d898cf20f19b57b81114a5b263cc1149cd0da3104578b083b2837bd"
+PKG_VERSION="2.2.1"
+PKG_SHA256="846bb79ca3f0157856aa93ed50b49217feb68e1b35226193b6bc578be0c5698d"
 PKG_LICENSE="GPL"
-PKG_SITE="http://premium.caribe.net/~adrian2/fdupes.html"
+PKG_SITE="https://github.com/adrianlopezroche/fdupes"
 PKG_URL="https://github.com/adrianlopezroche/fdupes/releases/download/v${PKG_VERSION}/fdupes-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="A program for identifying or deleting duplicate files residing within specified directories."

--- a/packages/addons/addon-depends/system-tools-depends/file/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/file/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="file"
-PKG_VERSION="5.41"
-PKG_SHA256="088fd09e8f2f7e8fda05e07ba9586df8708e1676a44db207b4496bd44e7f49f4"
+PKG_VERSION="5.43"
+PKG_SHA256="58da4fd66c858a1a883105d593320906d64f8835311683184952a33defc9da6d"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.darwinsys.com/file/"
 PKG_URL="https://github.com/file/file/archive/FILE${PKG_VERSION/./_}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/inotify-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/inotify-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inotify-tools"
-PKG_VERSION="3.22.1.0"
-PKG_SHA256="da81010756866966e6dfb1521c2be2f0946e7626fa29122e1672dc654fc89ff3"
+PKG_VERSION="3.22.6.0"
+PKG_SHA256="c6b7e70f1df09e386217102a1fe041cfc15fa4f3d683d2970140b6814cf2ed12"
 PKG_LICENSE="GPLv2"
 PKG_SITE="http://wiki.github.com/inotify-tools/inotify-tools/"
 PKG_URL="https://github.com/inotify-tools/inotify-tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/mmc-utils/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mmc-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mmc-utils"
-PKG_VERSION="4303889c8bd9a2357587eb6ebacecb70098a264d"
-PKG_SHA256="283bab1925a46eb896a9d114650923ce6a39dbb97050daa36bd0bdb6fa703d12"
+PKG_VERSION="c62dd8e415b12cc7f9a362db23cd384caf77ff03" # 2022-11-09
+PKG_SHA256="181ec6a2657f19472672372a80488a624be3e9368176b836404ca29c1405374a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/doc/html/latest/driver-api/mmc/mmc-tools.html"
 PKG_URL="https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/st/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/st/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="st"
-PKG_VERSION="0.8.5"
-PKG_SHA256="ea6832203ed02ff74182bcb8adaa9ec454c8f989e79232cb859665e2f544ab37"
+PKG_VERSION="0.9"
+PKG_SHA256="f36359799734eae785becb374063f0be833cf22f88b4f169cd251b99324e08e7"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://st.suckless.org/"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.14.03"
-PKG_SHA256="95012c62883ab5826e6157557a075df98cce3cbce2a48bb40851bcc968a8441a"
+PKG_VERSION="0.14.06"
+PKG_SHA256="54f6c3f84b20efedafd3394ec168e53632a685cfdd76f24270653e898d9ede08"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="unrar"
-PKG_VERSION="6.1.7"
-PKG_SHA256="de75b6136958173fdfc530d38a0145b72342cf0d3842bf7bb120d336602d88ed"
+PKG_VERSION="6.2.2"
+PKG_SHA256="477d6ca7e246caec5412cc83b36c15a4ac837726a892df022919800129107cd5"
 PKG_LICENSE="free"
 PKG_SITE="https://www.rarlab.com/rar_add.htm"
 PKG_URL="https://www.rarlab.com/rar/unrarsrc-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vim"
-PKG_VERSION="9.0.0453"
-PKG_SHA256="b90063706a2a9ee234275e0dd4b71a11e24867c33203c432fd6e9799fdc3bff9"
+PKG_VERSION="9.0.0905"
+PKG_SHA256="7503d2fcefa79d1f7f4493eeaf2e9187dd09c071cc072179cfdc4a0246c27c51"
 PKG_LICENSE="VIM"
 PKG_SITE="http://www.vim.org/"
 PKG_URL="https://github.com/vim/vim/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,3 +1,16 @@
+134
+- efibootmgr: update to 18
+- fdupes: update to 2.2.1
+- file: update to 5.43
+- inotify-tools: update to 3.22.6.0
+- kmsxx: update to githash 2022-11-05
+- libmtp: update to 1.1.20
+- mmc-utils: update to 2022-11-09
+- stress-ng: update to 0.14.06
+- st: update to 0.9
+- unrar: update to 6.2.2
+- vim: update to 9.0.0905
+
 133
 - include fuse
 

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="133"
+PKG_REV="134"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/graphics/kmsxx/package.mk
+++ b/packages/graphics/kmsxx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kmsxx"
-PKG_VERSION="2236a8ccacdfed5ff5f6873ed6618eccf570193d"
-PKG_SHA256="774d25c7da4989b3183b50c04c80d8894e962f99215be7f0b01c593edf8afb20"
+PKG_VERSION="adc05b66548d10ad8c4a400fb8e8b072a2fd8e2c" # 2022-11-05
+PKG_SHA256="a88cbaabac63738a51aabe62c1de11960a72ec2c2a29c436c820ae8c22a92b49"
 PKG_LICENSE="MPL-2.0"
 PKG_SITE="https://github.com/tomba/kmsxx"
 PKG_URL="https://github.com/tomba/kmsxx/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- efibootmgr: update to 18
- fdupes: update to 2.2.1
- file: update to 5.43
- inotify-tools: update to 3.22.6.0
- kmsxx: update to githash 2022-11-05
- libmtp: update to 1.1.20
- mmc-utils: update to 2022-11-09
- stress-ng: update to 0.14.06
- st: update to 0.9
- unrar: update to 6.2.2
- vim: update to 9.0.0905