### PR TITLE
devel package updates

### DIFF
--- a/packages/devel/flatbuffers/package.mk
+++ b/packages/devel/flatbuffers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flatbuffers"
-PKG_VERSION="2.0.8"
-PKG_SHA256="f97965a727d26386afaefff950badef2db3ab6af9afe23ed6d94bfb65f95f37e"
+PKG_VERSION="22.10.26"
+PKG_SHA256="34f1820cfd78a3d92abc880fbb1a644c7fb31a71238995f4ed6b5915a1ad4e79"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/google/flatbuffers"
 PKG_URL="https://github.com/google/flatbuffers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="heimdal"
-PKG_VERSION="c0bc8beb07d9733d4c8c17d120916552fe172f50"
-PKG_SHA256="601e9a772063c72b391d593df8ae5e05ec779fefdf1502b7d88fbbe016ceb4dd"
+PKG_VERSION="f4faaeaba371fff3f8d1bc14389f5e6d70ca8e17"
+PKG_SHA256="2576c5e2d793db53c86e108fd117b278437bb02d6c6db2bec4d1b86958f1980a"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="http://www.h5l.org/"
 PKG_URL="https://github.com/heimdal/heimdal/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/libffi/package.mk
+++ b/packages/devel/libffi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libffi"
-PKG_VERSION="3.4.2"
-PKG_SHA256="540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620"
+PKG_VERSION="3.4.4"
+PKG_SHA256="d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676"
 PKG_LICENSE="GPL"
 PKG_SITE="http://sourceware.org/${PKG_NAME}/"
 PKG_URL="https://github.com/libffi/libffi/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/devel/mimalloc/package.mk
+++ b/packages/devel/mimalloc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mimalloc"
-PKG_VERSION="2.0.6"
-PKG_SHA256="9f05c94cc2b017ed13698834ac2a3567b6339a8bde27640df5a1581d49d05ce5"
+PKG_VERSION="2.0.7"
+PKG_SHA256="f23aac6c73594e417af50cb38f1efed88ef1dc14a490f0eff07c7f7b079810a4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/microsoft/mimalloc"
 PKG_URL="https://github.com/microsoft/mimalloc/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/mpfr/package.mk
+++ b/packages/devel/mpfr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpfr"
-PKG_VERSION="4.1.0"
-PKG_SHA256="0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
+PKG_VERSION="4.1.1"
+PKG_SHA256="ffd195bd567dbaffc3b98b23fd00aad0537680c9896171e44fe3ff79e28ac33d"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.mpfr.org/"
 PKG_URL="http://ftpmirror.gnu.org/mpfr/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/spdlog/package.mk
+++ b/packages/devel/spdlog/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spdlog"
-PKG_VERSION="1.10.0"
-PKG_SHA256="697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224"
+PKG_VERSION="1.11.0"
+PKG_SHA256="ca5cae8d6cac15dae0ec63b21d6ad3530070650f68076f3a4a862ca293a858bb"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/gabime/spdlog"
 PKG_URL="https://github.com/gabime/spdlog/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/swig/package.mk
+++ b/packages/devel/swig/package.mk
@@ -3,13 +3,14 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="swig"
-PKG_VERSION="4.0.2"
-PKG_SHA256="d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
+PKG_VERSION="4.1.0"
+PKG_SHA256="d6a9a8094e78f7cfb6f80a73cc271e1fe388c8638ed22668622c2c646df5bb3d"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.swig.org"
 PKG_URL="${SOURCEFORGE_SRC}/swig/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_LONGDESC="SWIG is a software development tool that connects programs written in C and C++ with a variety of high-level programming languages."
+PKG_TOOLCHAIN="configure"
 
 PKG_CONFIGURE_OPTS_HOST="--program-suffix=4.0 \
                          --with-pcre-prefix=${TOOLCHAIN} \


### PR DESCRIPTION
- flatbuffers: update to 22.10.26
- heimdal: update to githash 2022-11-17
- libffi: update to 3.4.4
- mimalloc: update to 2.0.7
- mpfr: update to 4.1.1
- spdlog: update to 1.11.0
- swig: update to 4.1.0