### PR TITLE
Graphics package updates 

### DIFF
--- a/packages/graphics/gdk-pixbuf/package.mk
+++ b/packages/graphics/gdk-pixbuf/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gdk-pixbuf"
-PKG_VERSION="2.42.8"
-PKG_SHA256="84acea3acb2411b29134b32015a5b1aaa62844b19c4b1ef8b8971c6b0759f4c6"
+PKG_VERSION="2.42.10"
+PKG_SHA256="ee9b6c75d13ba096907a2e3c6b27b61bcd17f5c7ebeab5a5b439d2f2e39fe44b"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/${PKG_VERSION:0:4}/gdk-pixbuf-${PKG_VERSION}.tar.xz"
@@ -24,7 +24,8 @@ pre_configure_target() {
                          -Dintrospection=disabled \
                          -Dman=false \
                          -Drelocatable=false \
-                         -Dinstalled_tests=false"
+                         -Dinstalled_tests=false \
+                         -Dtests=false"
 
   if [ "${DISPLAYSERVER}" != "x11" ]; then
     PKG_MESON_OPTS_TARGET+=" -Dbuiltin_loaders=all"

--- a/packages/graphics/gdk-pixbuf/package.mk
+++ b/packages/graphics/gdk-pixbuf/package.mk
@@ -19,7 +19,8 @@ configure_package() {
 }
 
 pre_configure_target() {
-  PKG_MESON_OPTS_TARGET="-Dgtk_doc=false \
+  PKG_MESON_OPTS_TARGET="--wrap-mode=nodownload \
+                         -Dgtk_doc=false \
                          -Ddocs=false \
                          -Dintrospection=disabled \
                          -Dman=false \

--- a/packages/graphics/lcms2/package.mk
+++ b/packages/graphics/lcms2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lcms2"
-PKG_VERSION="2.13.1"
-PKG_SHA256="d473e796e7b27c5af01bd6d1552d42b45b43457e7182ce9903f38bb748203b88"
+PKG_VERSION="2.14"
+PKG_SHA256="28474ea6f6591c4d4cee972123587001a4e6e353412a41b3e9e82219818d5740"
 PKG_LICENSE="MIT/GPLv3"
 PKG_SITE="http://www.littlecms.com"
 PKG_URL="https://github.com/mm2/Little-CMS/releases/download/lcms${PKG_VERSION}/lcms2-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.13.0"
-PKG_SHA256="c20ae01bace39e89298f6352f1ff4a54b415b33b9743902da798e8a1e51d7ca1"
+PKG_VERSION="1.14.0"
+PKG_SHA256="9a2b969d827e162fa9eba582ebd0c9f6891f16e426ef608d089b1f24962295b5"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/pango/package.mk
+++ b/packages/graphics/pango/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pango"
-PKG_VERSION="1.50.8"
-PKG_SHA256="cf626f59dd146c023174c4034920e9667f1d25ac2c1569516d63136c311255fa"
+PKG_VERSION="1.50.12"
+PKG_SHA256="caef96d27bbe792a6be92727c73468d832b13da57c8071ef79b9df69ee058fe3"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.pango.org/"
 PKG_URL="https://download.gnome.org/sources/pango/${PKG_VERSION:0:4}/pango-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- gdk-pixbuf: prevent downloading wrapped subprojects
- gdk-pixbuf: update to 2.42.10
- lcms2: update to 2.14
- libheif: update to 1.14.0
- pango: update to 1.50.12