### PR TITLE
iwd: update to 2.0

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="1.30"
-PKG_SHA256="9fd13512dc27d83efb8d341f7df98f5488f70131686021fcd0d93fc97af013b8"
+PKG_VERSION="2.0"
+PKG_SHA256="5a0bfbc567092476d60a8f9700f68a273e39fd46e7177ce2d69bbc74255a930c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
ver 2.0:
	Fix issue with handling P2P and limiting ciphers to CCMP.
	Fix issue with scanning before forced roaming action.
	Fix issue with provided scan frequencies from RRM.
	Fix issue with handling Michael MIC failure message.
	Fix issue with handling timestamp size in MPDU frames.
	Fix issue with handling enablement of OCVC for FT AKMs.
	Fix issue with handling FT work as highest priority.
	Fix issue with handling roaming events and Multi-BSS.
	Add support for utilizing roaming candidates list.
	Add support for utilizing TLS session caching.
	Add support for ciphers with 256 bits key size.
	Add support for Access Point mode with legacy TKIP.
	Add support for MAC address changes while powered.
	Add support for IPv4 and IPv6 network configuration.