### PR TITLE
Miscellaneous package updates

### DIFF
--- a/packages/devel/flatbuffers/package.mk
+++ b/packages/devel/flatbuffers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flatbuffers"
-PKG_VERSION="22.10.26"
-PKG_SHA256="34f1820cfd78a3d92abc880fbb1a644c7fb31a71238995f4ed6b5915a1ad4e79"
+PKG_VERSION="22.11.23"
+PKG_SHA256="8e9bacc942db59ca89a383dd7923f3e69a377d6e579d1ba13557de1fdfddf56a"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/google/flatbuffers"
 PKG_URL="https://github.com/google/flatbuffers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.24.1"
-PKG_SHA256="bc121588b1105065598ce38078026a414c28ea95e66ed2adab4c44d80b309e1b"
+PKG_VERSION="2.26.0"
+PKG_SHA256="8000d7169febce93c84b6bdf376631f8179132fd69f7015d4dadb8b9c2bdb295"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
 PKG_URL="https://www.libsdl.org/release/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/libnftnl/package.mk
+++ b/packages/network/libnftnl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnftnl"
-PKG_VERSION="1.2.3"
-PKG_SHA256="e916ea9b79f9518560b9a187251a7c042442a9ecbce7f36be7908888605d0255"
+PKG_VERSION="1.2.4"
+PKG_SHA256="c0fe233be4cdfd703e7d5977ef8eb63fcbf1d0052b6044e1b23d47ca3562477f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://netfilter.org/projects/libnftnl"
 PKG_URL="https://netfilter.org/projects/libnftnl/files/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/sysutils/fuse3/package.mk
+++ b/packages/sysutils/fuse3/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fuse3"
-PKG_VERSION="3.11.0"
-PKG_SHA256="8982c4c521daf3974dda8a5d55d575c988da13a571970f00aea149eb54fdf14c"
+PKG_VERSION="3.12.0"
+PKG_SHA256="33b8a92d6f7a88e6a889f0009206933482f48f3eb85d88cf09ef551313ac7373"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libfuse/libfuse/"
 PKG_URL="https://github.com/libfuse/libfuse/releases/download/fuse-${PKG_VERSION}/fuse-${PKG_VERSION}.tar.xz"

--- a/packages/tools/newt/package.mk
+++ b/packages/tools/newt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="newt"
-PKG_VERSION="0.52.21"
-PKG_SHA256="265eb46b55d7eaeb887fca7a1d51fe115658882dfe148164b6c49fccac5abb31"
+PKG_VERSION="0.52.22"
+PKG_SHA256="a15efa37e86610b68a942b19a138b44ccb501c234e4c82dab2f5a9b19f7c9e79"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pagure.io/newt"
 PKG_URL="https://releases.pagure.org/newt/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- fuse3: update to 3.12.0
- libnftnl: update to 1.2.4
- newt: update to 0.52.22
- SDL2: update to 2.26.0