### PR TITLE
zlib: fix download URL

### DIFF
--- a/packages/compress/zlib/package.mk
+++ b/packages/compress/zlib/package.mk
@@ -3,10 +3,10 @@
 
 PKG_NAME="zlib"
 PKG_VERSION="1.2.13"
-PKG_SHA256="d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98"
+PKG_SHA256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.zlib.net"
-PKG_URL="http://zlib.net/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://zlib.net/fossils/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="cmake:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A general purpose (ZIP) data compression library."


### PR DESCRIPTION
The http://zlib.net/zlib-VERSION link only works for the currently released version and break whenever zlib releases a new version (which happened twice this year). This is also problematic when building older LibreELEC versions as the older zlib can't be downloaded.

Switch PKG_URL to the tar.gz files at https://zlib.net/fossils/ as this location provides all (current and older) releases.