### PR TITLE
[le10] Addon updates - oscam and pcscd

### DIFF
--- a/packages/addons/addon-depends/ccid/package.mk
+++ b/packages/addons/addon-depends/ccid/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccid"
-PKG_VERSION="1.4.34"
-PKG_SHA256="e6f7645b59a9a2844eb4b1a7eff512960d7f04a4654af02f7fd2f8aded5db40a"
+PKG_VERSION="1.5.1"
+PKG_SHA256="e7a78c398ec0d617a4f98bac70d5b64f78689284dd0ae87d4692e2857f117377"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://ccid.apdu.fr"
 PKG_URL="https://ccid.apdu.fr/files/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/pcsc-lite/package.mk
+++ b/packages/addons/addon-depends/pcsc-lite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcsc-lite"
-PKG_VERSION="1.9.0"
-PKG_SHA256="0148d403137124552c5d0f10f8cdab2cbb8dfc7c6ce75e018faf667be34f2ef9"
+PKG_VERSION="1.9.9"
+PKG_SHA256="cbcc3b34c61f53291cecc0d831423c94d437b188eb2b97b7febc08de1c914e8a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pcsclite.apdu.fr"
 PKG_URL="https://pcsclite.apdu.fr/files/pcsc-lite-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/service/oscam/changelog.txt
+++ b/packages/addons/service/oscam/changelog.txt
@@ -1,3 +1,6 @@
+112
+- Update to version 11715
+
 111
 - Update to version 11693
 

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,14 +2,14 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="4b1c46857d95b4242d77986ff80d9c8092c15cfa"
-PKG_SHA256="9fe8be8c1bf2f89630d8adc279088d31d9852bfe226052f6d9dc11ef2fe149f3"
-PKG_VERSION_NUMBER="11693"
-PKG_REV="111"
+PKG_VERSION="db7c4cbdbd34a9b0464070b1a46e146e6029a2cb" # 2022-10-22
+PKG_SHA256="b5dd1d0dc71553c8504d6982b6bae437d6bef17c6cd8a38ac4710a38300018cf"
+PKG_VERSION_NUMBER="11715"
+PKG_REV="112"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.streamboard.tv/oscam/wiki"
-PKG_URL="http://repo.or.cz/oscam.git/snapshot/${PKG_VERSION}.tar.gz"
+PKG_SITE="https://www.streamboard.tv/oscam/wiki"
+PKG_URL="https://repo.or.cz/oscam.git/snapshot/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain openssl pcsc-lite"
 PKG_SECTION="service.softcam"
 PKG_SHORTDESC="OSCam: an Open Source Conditional Access Modul"

--- a/packages/addons/service/pcscd/changelog.txt
+++ b/packages/addons/service/pcscd/changelog.txt
@@ -1,3 +1,7 @@
+102
+- ccid: update to 1.5.1
+- pcsc-lite: update to 1.9.9
+
 101
 - ccid: update to 1.4.34
 

--- a/packages/addons/service/pcscd/package.mk
+++ b/packages/addons/service/pcscd/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="pcscd"
 PKG_VERSION="1.0"
-PKG_REV="101"
+PKG_REV="102"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
Back port of:
- #7175 

package updates
- ccid: update to 1.5.1
- oscam: update to 11715 and addon (112)
- pcscd: update to addon (102)
- pcsc-lite: update to 1.9.9