### PR TITLE
nvidia: update to 520.56.06

### DIFF
--- a/packages/graphics/nvidia/package.mk
+++ b/packages/graphics/nvidia/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia"
-PKG_VERSION="515.76"
-PKG_SHA256="5059943d57f922a7a873356dcdbb596ba034c24431eb5ca88d1e0064bf3fd98a"
+PKG_VERSION="520.56.06"
+PKG_SHA256="e46ae5f497bd75370c8dea19cf3766d1bf4ae62e6343bc3c31b9a6d523f21eb3"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="https://www.nvidia.com/en-us/drivers/unix/"


### PR DESCRIPTION
-  tested with latest wayland + sway 1.8-rc1 = video decoding works fine
- release notes https://www.nvidia.com/Download/driverResults.aspx/193764/en-us/
- 525.60.11 was also released but broke nvidia-vaapi-driver decoding 