### PR TITLE
kodi: fix build with mesa 22.3.0

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.01.fix-mesa-22.3.0-build.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.01.fix-mesa-22.3.0-build.patch
@@ -1,0 +1,12 @@
+--- xbmc/xbmc/windowing/X11/GLContextEGL.h
++++ xbmc/xbmc/windowing/X11/GLContextEGL.h
+@@ -13,7 +13,7 @@
+ #include "threads/CriticalSection.h"
+ 
+ #include <EGL/eglext.h>
+-#include <EGL/eglextchromium.h>
++#include <EGL/eglext_angle.h>
+ #include <X11/Xutil.h>
+ 
+ class CGLContextEGL : public CGLContext
+


### PR DESCRIPTION
- https://gitlab.freedesktop.org/mesa/mesa/-/commit/f5bb9dd738ace274c97507adea073b6c609469b2 removed eglextchromium.h
- fix for https://github.com/xbmc/xbmc/issues/21792 - we don't need checks for older mesa versions