### PR TITLE
Vulkan update to 1.3.236

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.235"
-PKG_SHA256="fca90d27e60816b5d72a700c241206c57e7d909e8ab4adfc340f5a5e9a019448"
+PKG_VERSION="1.3.236"
+PKG_SHA256="a86b8c38618b764057b359cf0f18c12a7c81b7760fe6fca1acf9adb471d55d4c"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.235"
-PKG_SHA256="948407ba3662801b87bae170db2ed1a7aebe900bb66405be7d301bf656140595"
+PKG_VERSION="1.3.236"
+PKG_SHA256="c18434976d6e67c3c1d5cfdfa630046e698402d1f666ff5094de1fcd3a012b0d"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.235"
-PKG_SHA256="8d6c4acbb501a9ee9c1c3e0beb8521fdb8983b68b6976b5a1d724087aff6c2ff"
+PKG_VERSION="1.3.236"
+PKG_SHA256="78321e6deffc60d051501d1548f600f23622396d5c8066d03d145be81c552de4"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/commit/db2b908b59b7774da9aa8b07baed4f5d018ae4d9


- vulkan-headers: update to 1.3.236
- vulkan-loader: update to 1.3.236
- vulkan-tools: update to 1.3.236