### PR TITLE
support early stage host package builds with ccache from buildhost

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -495,6 +495,11 @@ setup_toolchain() {
       if [ "$1" = "host" ] && flag_enabled "local-cc" "no"; then
         export CC="${LOCAL_CC}"
         export CXX="${LOCAL_CXX}"
+        if [ -n "${LOCAL_CCACHE}" ]; then
+          export CCACHE_DIR="${LOCAL_CCACHE_DIR}"
+          export CC="${LOCAL_CCACHE} ${CC}";
+          export CXX="${LOCAL_CCACHE} ${CXX}";
+        fi
       else
         export CC="$TOOLCHAIN/bin/host-gcc"
         export CXX="$TOOLCHAIN/bin/host-g++"

--- a/config/functions
+++ b/config/functions
@@ -492,8 +492,13 @@ setup_toolchain() {
     host:*|bootstrap:*)
       export DESTIMAGE="host"
       export AWK="gawk"
-      export CC="$TOOLCHAIN/bin/host-gcc"
-      export CXX="$TOOLCHAIN/bin/host-g++"
+      if [ "$1" = "host" ] && flag_enabled "local-cc" "no"; then
+        export CC="${LOCAL_CC}"
+        export CXX="${LOCAL_CXX}"
+      else
+        export CC="$TOOLCHAIN/bin/host-gcc"
+        export CXX="$TOOLCHAIN/bin/host-g++"
+      fi
       export CPP="cpp"
       export LD="ld"
       export AS="as"

--- a/config/path
+++ b/config/path
@@ -70,6 +70,14 @@ if [ -z "$CCACHE_DIR" ]; then
   export CCACHE_DIR=$BUILD/.ccache
 fi
 
+# keep a copy of ccache dir used for toolchain ccache
+export BUILD_CCACHE_DIR="${CCACHE_DIR}"
+
+# local ccache dir in case we build early packages with local ccache
+if [ -z "${LOCAL_CCACHE_DIR}" ]; then
+  export LOCAL_CCACHE_DIR="${BUILD}/.ccache-local"
+fi
+
 if [[ -z "$PATH" || ( "$PATH" != "$TOOLCHAIN/bin:$TOOLCHAIN/sbin" && "$PATH" = "${PATH#$TOOLCHAIN/bin:$TOOLCHAIN/sbin:}" ) ]]; then
   export PATH="$TOOLCHAIN/bin:$TOOLCHAIN/sbin${PATH:+":$PATH"}"
 fi

--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -17,7 +17,7 @@ PKG_CONFIGURE_OPTS_HOST="--with-bundled-zlib"
 post_makeinstall_host() {
 # setup ccache
   if [ -z "${CCACHE_DISABLE}" ]; then
-    ${TOOLCHAIN}/bin/ccache --max-size=${CCACHE_CACHE_SIZE}
+    CCACHE_DIR="${BUILD_CCACHE_DIR}" ${TOOLCHAIN}/bin/ccache --max-size=${CCACHE_CACHE_SIZE}
   fi
 
   cat > ${TOOLCHAIN}/bin/host-gcc <<EOF

--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -10,13 +10,9 @@ PKG_SITE="https://ccache.dev/download.html"
 PKG_URL="https://github.com/ccache/ccache/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="make:host"
 PKG_LONGDESC="A compiler cache to speed up re-compilation of C/C++ code by caching."
+PKG_BUILD_FLAGS="+local-cc"
 
 PKG_CONFIGURE_OPTS_HOST="--with-bundled-zlib"
-
-pre_configure_host() {
-  export CC=${LOCAL_CC}
-  export CXX=${LOCAL_CXX}
-}
 
 post_makeinstall_host() {
 # setup ccache
@@ -26,14 +22,14 @@ post_makeinstall_host() {
 
   cat > ${TOOLCHAIN}/bin/host-gcc <<EOF
 #!/bin/sh
-${TOOLCHAIN}/bin/ccache ${CC} "\$@"
+${TOOLCHAIN}/bin/ccache ${LOCAL_CC} "\$@"
 EOF
 
   chmod +x ${TOOLCHAIN}/bin/host-gcc
 
   cat > ${TOOLCHAIN}/bin/host-g++ <<EOF
 #!/bin/sh
-${TOOLCHAIN}/bin/ccache ${CXX} "\$@"
+${TOOLCHAIN}/bin/ccache ${LOCAL_CXX} "\$@"
 EOF
 
   chmod +x ${TOOLCHAIN}/bin/host-g++

--- a/packages/devel/make/package.mk
+++ b/packages/devel/make/package.mk
@@ -10,10 +10,7 @@ PKG_SITE="https://www.gnu.org/software/make/"
 PKG_URL="http://ftpmirror.gnu.org/make/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST=""
 PKG_LONGDESC="Utility to maintain groups of programs."
-
-pre_configure_host() {
-  export CC=${LOCAL_CC}
-}
+PKG_BUILD_FLAGS="+local-cc"
 
 post_makeinstall_host() {
   ln -sf make ${TOOLCHAIN}/bin/gmake

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -132,6 +132,7 @@ Set the variable `PKG_BUILD_FLAGS` in the `package.mk` to enable/disable the sin
 | parallel | enabled  | all | `make` or `ninja` builds with multiple threads/processes (or not) |
 | strip    | enabled  | target | strips executables (or not) |
 | sysroot  | enabled  | target | installs the package to the sysroot folder (or not) |
+| local-cc | disabled | host | use compiler from buildhost instead of host-gcc/g++ in toolchain |
 
 ###### Example
 ```

--- a/scripts/build
+++ b/scripts/build
@@ -238,6 +238,23 @@ if [ -f "${PKG_CONFIGURE_SCRIPT}" -o -f "${PKG_CMAKE_SCRIPT}" -o -f "${PKG_MESON
   MESON_CONF="${PKG_REAL_BUILD}/meson.conf"
 fi
 
+# create wrapper scripts in build dir and use them for CC/CXX when
+# building for host and local-cc build flag is set
+if [ "${TARGET}" = "host" ] && flag_enabled "local-cc" "no"; then
+  cat > libreelec-local-cc << EOF
+#!/bin/sh
+exec ${CC} "\$@"
+EOF
+  chmod +x libreelec-local-cc
+  export CC=$(pwd)/libreelec-local-cc
+  cat > libreelec-local-cxx << EOF
+#!/bin/sh
+exec ${CXX} "\$@"
+EOF
+  chmod +x libreelec-local-cxx
+  export CXX=$(pwd)/libreelec-local-cxx
+fi
+
 # configure
 if [ -n "${PKG_DEPENDS_CONFIG}" -a -n "${PKG_INSTALL}" ]; then
   for pkg in ${PKG_DEPENDS_CONFIG}; do


### PR DESCRIPTION
In very early stages of the build we don't have ccache available in toolchain which means those packages will always have to be rebuilt on clean builds with hot ccache.

At the moment this isn't a big deal as only make and ccache are affected by that - and they build in a few seconds.

But this has changed drastically as more and more packages, like ccache 4, have dropped support for simple configure/make and now start to require cmake for configuring.

cmake, unfortunately, has become a monster and takes ages to build - about 7 minutes with all dependencies on my HP Z240 workstation - so when switching to ccache 4 this means every clean rebuild would take that hit.

To mitigate that let's add support for optionally building early stage packages with ccache from the build host:

Simply set `LOCAL_CCACHE` to the local ccache you want to use (either in environment or ~/.libreelec/options) and optionally point `LOCAL_CCACHE_DIR` to a different directory if you don't want to use .ccache-local in the build folder for it.

I've also refactored the early stage build handling currently present in make and ccache packages, which had to manually change CC/CXX to the actual compilers on the build host, with a simple `local-cc` build flag that will also setup wrapper scripts (which will be needed for cmake) so that packages don't need to worry about setting CC/CXX themselves - and with the wrappers also ccache from build host will work