### PR TITLE
Packages updates

### DIFF
--- a/packages/audio/wavpack/package.mk
+++ b/packages/audio/wavpack/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wavpack"
-PKG_VERSION="5.5.0"
-PKG_SHA256="ef749d98df46925bc2916993e601cc7ee9114d99653e63e0e304f031ba73b8e6"
+PKG_VERSION="5.6.0"
+PKG_SHA256="af8035f457509c3d338b895875228a9b81de276c88c79bb2d3e31d9b605da9a9"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.wavpack.com"
 PKG_URL="https://www.wavpack.com/wavpack-${PKG_VERSION}.tar.xz"

--- a/packages/compress/xz/package.mk
+++ b/packages/compress/xz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xz"
-PKG_VERSION="5.2.8"
-PKG_SHA256="2424b2711b1d40d2129645d550363896c6853c97528f085f7765092fe68679d4"
+PKG_VERSION="5.2.9"
+PKG_SHA256="287ef163e7e57561e9de590b2a9037457af24f03a46bbd12bf84f3263679e8d2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://tukaani.org/xz/"
 PKG_URL="https://tukaani.org/xz/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.25.0"
-PKG_SHA256="306463f541555da0942e6f5a0736560f70c487178b9d94a5ae7f34d0538cdd48"
+PKG_VERSION="3.25.1"
+PKG_SHA256="1c511d09516af493694ed9baf13c55947a36389674d657a2d5e0ccedc6b291d8"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/devel/swig/package.mk
+++ b/packages/devel/swig/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="swig"
-PKG_VERSION="4.1.0"
-PKG_SHA256="d6a9a8094e78f7cfb6f80a73cc271e1fe388c8638ed22668622c2c646df5bb3d"
+PKG_VERSION="4.1.1"
+PKG_SHA256="2af08aced8fcd65cdb5cc62426768914bedc735b1c250325203716f78e39ac9b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.swig.org"
 PKG_URL="${SOURCEFORGE_SRC}/swig/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/libass/package.mk
+++ b/packages/multimedia/libass/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libass"
-PKG_VERSION="0.16.0"
-PKG_SHA256="5dbde9e22339119cf8eed59eea6c623a0746ef5a90b689e68a090109078e3c08"
+PKG_VERSION="0.17.0"
+PKG_SHA256="971e2e1db59d440f88516dcd1187108419a370e64863f70687da599fdf66cc1a"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/libass/libass"
 PKG_URL="https://github.com/libass/libass/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -13,6 +13,7 @@ PKG_LONGDESC="A portable subtitle renderer for the ASS/SSA (Advanced Substation 
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-test \
                            --enable-fontconfig \
+                           --disable-libunibreak \
                            --disable-silent-rules \
                            --with-gnu-ld"
 

--- a/packages/sysutils/pciutils/package.mk
+++ b/packages/sysutils/pciutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pciutils"
-PKG_VERSION="3.8.0"
-PKG_SHA256="91edbd0429a84705c9ad156d4ff38ccc724d41ea54c4c5b88e38e996f8a34f05"
+PKG_VERSION="3.9.0"
+PKG_SHA256="cdea7ae97239dee23249a09c68a19a287a3f109fbeb2c232ebb616cb38599012"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mj.ucw.cz/pciutils.shtml"
 PKG_URL="https://www.kernel.org/pub/software/utils/pciutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Package updates
- cmake: update to 3.25.1
- libass: update to 0.17.0
- pciutils: update to 3.9.0
- swig: update to 4.1.1
- wavpack: update to 5.6.0
- xz: update to 5.2.9