### PR TITLE
ffmpeg: clean up & change license to GPL-3.0-only

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -3,14 +3,13 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ffmpeg"
-PKG_LICENSE="LGPLv2.1+"
-PKG_SITE="https://ffmpeg.org"
-PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex"
-PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
-
 PKG_VERSION="4.4.1"
 PKG_SHA256="eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02"
+PKG_LICENSE="GPL-3.0-only"
+PKG_SITE="https://ffmpeg.org"
 PKG_URL="http://ffmpeg.org/releases/ffmpeg-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex"
+PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
 PKG_PATCH_DIRS="kodi libreelec"
 
 case "${PROJECT}" in


### PR DESCRIPTION
- license should match https://spdx.org/licenses/GPL-3.0-or-later.html or https://spdx.org/licenses/LGPL-3.0-or-later.html because of those configure [opts](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/multimedia/ffmpeg/package.mk#L157-L158)