### PR TITLE
linux: update to 5.10.y

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="5.10.156"
-    PKG_SHA256="679e9964ca720027967391b61db990ceb7868e93e203f87724f18310f4955923"
+    PKG_VERSION="5.10.161"
+    PKG_SHA256="7aaaf6d0bcd8a2cfa14ad75f02ca62bb2de08aad3bee3eff198de49ea5254079"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v5.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Allwinner/linux/linux.aarch64.conf
+++ b/projects/Allwinner/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.152 Kernel Configuration
+# Linux/arm64 5.10.157-rc1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-none-linux-gnu-gcc.real (GNU Toolchain for the A-profile Architecture 10.2-2020.11 (arm-10.16)) 10.2.1 20201103"
 CONFIG_CC_IS_GCC=y
@@ -875,6 +875,7 @@ CONFIG_INET_ESP=y
 # CONFIG_INET_ESP_OFFLOAD is not set
 # CONFIG_INET_ESPINTCP is not set
 # CONFIG_INET_IPCOMP is not set
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_TUNNEL=y
 CONFIG_INET_DIAG=y
 CONFIG_INET_TCP_DIAG=y

--- a/projects/Allwinner/linux/linux.arm.conf
+++ b/projects/Allwinner/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.10.143-rc1 Kernel Configuration
+# Linux/arm 5.10.157-rc1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7ve-libreelec-linux-gnueabihf-gcc-10.2.0 (GCC) 10.2.0"
 CONFIG_CC_IS_GCC=y
@@ -858,6 +858,7 @@ CONFIG_INET_ESP=m
 # CONFIG_INET_ESP_OFFLOAD is not set
 # CONFIG_INET_ESPINTCP is not set
 # CONFIG_INET_IPCOMP is not set
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_TUNNEL=y
 # CONFIG_INET_DIAG is not set
 # CONFIG_TCP_CONG_ADVANCED is not set

--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.10.143-rc1 Kernel Configuration
+# Linux/x86 5.10.157-rc1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-libreelec-linux-gnu-gcc-10.2.0 (GCC) 10.2.0"
 CONFIG_CC_IS_GCC=y
@@ -974,6 +974,7 @@ CONFIG_NET_FOU=m
 # CONFIG_INET_AH is not set
 # CONFIG_INET_ESP is not set
 # CONFIG_INET_IPCOMP is not set
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_TUNNEL=m
 # CONFIG_INET_DIAG is not set
 CONFIG_TCP_CONG_ADVANCED=y

--- a/projects/Rockchip/devices/RK3288/linux/default/linux.arm.conf
+++ b/projects/Rockchip/devices/RK3288/linux/default/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.10.143-rc1 Kernel Configuration
+# Linux/arm 5.10.157-rc1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7ve-libreelec-linux-gnueabihf-gcc-10.2.0 (GCC) 10.2.0"
 CONFIG_CC_IS_GCC=y
@@ -862,6 +862,7 @@ CONFIG_NET_FOU=m
 # CONFIG_INET_AH is not set
 # CONFIG_INET_ESP is not set
 # CONFIG_INET_IPCOMP is not set
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_TUNNEL=y
 CONFIG_INET_DIAG=y
 CONFIG_INET_TCP_DIAG=y

--- a/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.152 Kernel Configuration
+# Linux/arm64 5.10.157-rc1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-none-linux-gnu-gcc.real (GNU Toolchain for the A-profile Architecture 10.2-2020.11 (arm-10.16)) 10.2.1 20201103"
 CONFIG_CC_IS_GCC=y
@@ -924,6 +924,7 @@ CONFIG_NET_FOU=m
 # CONFIG_INET_AH is not set
 # CONFIG_INET_ESP is not set
 # CONFIG_INET_IPCOMP is not set
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_TUNNEL=m
 CONFIG_INET_DIAG=y
 CONFIG_INET_TCP_DIAG=y

--- a/projects/Rockchip/devices/RK3399/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3399/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.152 Kernel Configuration
+# Linux/arm64 5.10.157-rc1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-none-linux-gnu-gcc.real (GNU Toolchain for the A-profile Architecture 10.2-2020.11 (arm-10.16)) 10.2.1 20201103"
 CONFIG_CC_IS_GCC=y
@@ -924,6 +924,7 @@ CONFIG_NET_FOU=m
 # CONFIG_INET_AH is not set
 # CONFIG_INET_ESP is not set
 # CONFIG_INET_IPCOMP is not set
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_TUNNEL=m
 CONFIG_INET_DIAG=y
 CONFIG_INET_TCP_DIAG=y

--- a/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
+++ b/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
@@ -2146,6 +2146,11 @@ index ab2a97574fa7..b382fc2f8156 100644
 @@ -2620,40 +2632,51 @@ static u32 *dw_hdmi_bridge_atomic_get_output_bus_fmts(struct drm_bridge *bridge,
  	 */
  
+ 	/* Default 8bit RGB fallback */
+-	output_fmts[i++] = MEDIA_BUS_FMT_RGB888_1X24;
++	if (is_tmds_allowed(info, mode, MEDIA_BUS_FMT_RGB888_1X24))
++		output_fmts[i++] = MEDIA_BUS_FMT_RGB888_1X24;
+ 
  	if (max_bpc >= 16 && info->bpc == 16) {
 -		if (info->color_formats & DRM_COLOR_FORMAT_YCRCB444)
 +		if ((info->color_formats & DRM_COLOR_FORMAT_YCRCB444) &&
@@ -2198,11 +2203,6 @@ index ab2a97574fa7..b382fc2f8156 100644
 +	if ((info->color_formats & DRM_COLOR_FORMAT_YCRCB444) &&
 +	    is_tmds_allowed(info, mode, MEDIA_BUS_FMT_YUV8_1X24))
  		output_fmts[i++] = MEDIA_BUS_FMT_YUV8_1X24;
- 
- 	/* Default 8bit RGB fallback */
--	output_fmts[i++] = MEDIA_BUS_FMT_RGB888_1X24;
-+	if (is_tmds_allowed(info, mode, MEDIA_BUS_FMT_RGB888_1X24))
-+		output_fmts[i++] = MEDIA_BUS_FMT_RGB888_1X24;
  
  	*num_output_fmts = i;
  


### PR DESCRIPTION
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.157
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.158
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.159
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.160
- https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.10.161

5.10.157 - 162 patches
5.10.158 - 92 patches
5.10.159 - 98 patches
5.10.160 - 15 patches
5.10.161 - 18 patches

errors / fixes / issues / regressions
- https://seclists.org/oss-sec/2022/q4/163
- Security sensitive bug in the i915 kernel driver (CVE-2022-4139)
- drm: bridge: dw_hdmi: fix preference of RGB modes over YUV420

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.10.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-5.10.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/5.10

### 5.10.161 Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=Generic ARCH=x86_64 s/build linux

### 5.10.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel SKL - NUC6) - 5.10.161 - heitbaum
- RK all - tested - TBA - knaerzche