### PR TITLE
options: automatically use ccache on build host if it's available

### DIFF
--- a/config/options
+++ b/config/options
@@ -125,6 +125,18 @@ if [ -f "${HOME}/.libreelec/options" ]; then
   . "${HOME}/.libreelec/options"
 fi
 
+if [ "${LOCAL_CCACHE_SUPPORT}" = "yes" ] && [ -z "${CCACHE_DISABLE}" ]; then
+  # like LOCAL_CC check for local ccache only on the very first
+  # call to config/options, before toolchain has been added to the path,
+  # otherwise we might pick up ccache from toolchain/bin here
+  if [ -z "${LOCAL_CCACHE}" ] && [ "${LOCAL_CCACHE_CHECKED}" != "yes" ]; then
+    export LOCAL_CCACHE="$(command -v ccache)"
+    export LOCAL_CCACHE_CHECKED="yes"
+  fi
+else
+  export LOCAL_CCACHE=""
+fi
+
 # overwrite OEM_SUPPORT via commandline
 if [ "${OEM}" = "yes" -o "${OEM}" = "no" ]; then
   OEM_SUPPORT="${OEM}"

--- a/config/show_config
+++ b/config/show_config
@@ -37,6 +37,7 @@ show_config() {
   config_message+="\n - DEBUG:\t\t\t\t ${DEBUG:-no}"
   config_message+="\n - CFLAGS:\t\t\t\t ${TARGET_CFLAGS}"
   config_message+="\n - LDFLAGS:\t\t\t\t ${TARGET_LDFLAGS}"
+  config_message+="\n - Local ccache:\t\t\t ${LOCAL_CCACHE:-no}"
 
   # Misc. hardware configuration
 

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -44,6 +44,9 @@
 # Default supported get handlers (archive, git, file etc.)
   GET_HANDLER_SUPPORT="archive"
 
+# use local ccache on build host, if available, for early package
+# builds before ccache has been built
+  LOCAL_CCACHE_SUPPORT="yes"
 
 ### OS CONFIGURATION ###
 


### PR DESCRIPTION
Use of ccache on build host is now controlled by the LOCAL_CCACHE_SUPPORT option. Setting it to "no" will disable use of local ccache.