### PR TITLE
[le11] proftpd: update to 1.3.8 and addon (1)

### DIFF
--- a/packages/addons/service/proftpd/package.mk
+++ b/packages/addons/service/proftpd/package.mk
@@ -3,14 +3,14 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="proftpd"
-PKG_VERSION="1.3.7e"
-PKG_SHA256="6e716a3b53ee069290399fce6dccf4c229fafe6ec2cb14db3778b7aa3f9a8c92"
-PKG_REV="0"
+PKG_VERSION="1.3.8"
+PKG_SHA256="f7139e7377a2cb059b8b9b14d76a6df5f440e3181cb15ae890d43bbcae574748"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.proftpd.org/"
 PKG_URL="https://github.com/proftpd/proftpd/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain libcap openssl ncurses pcre"
+PKG_DEPENDS_TARGET="toolchain libcap openssl ncurses pcre2"
 PKG_SECTION="service"
 PKG_SHORTDESC="ProFTPD: a FTP server for linux"
 PKG_LONGDESC="ProFTPD (${PKG_VERSION}): is a secure and configurable FTP server with SSL/TLS support"
@@ -33,7 +33,7 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --enable-ctrls \
                            --enable-ipv6 \
                            --enable-nls \
-                           --enable-pcre \
+                           --enable-pcre2 \
                            --enable-largefile \
                            install_user=$(id -u) \
                            install_group=$(id -g)"


### PR DESCRIPTION
release notes:
- http://proftpd.org/docs/RELEASE_NOTES-1.3.8

news:
- http://proftpd.org/docs/NEWS-1.3.8

webpage:
- http://proftpd.org/

includes the change of pcre to pcre2 
- #6798