### PR TITLE
X11 updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.45.1"
-PKG_SHA256="ba95f346e93108fbb3462c62437081d582154db279b4052dedc52a706828b192"
+PKG_VERSION="2.46.0"
+PKG_SHA256="aa0c86c79f7a8d67bae49a5b7a5ab08430c608cffe6e33bf47a72f41ab03c3d0"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.gnome.org/"
+PKG_SITE="https://www.gnome.org/"
 PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain atk dbus glib libXtst"
 PKG_LONGDESC="Protocol definitions and daemon for D-Bus at-spi."

--- a/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gtk3"
-PKG_VERSION="3.24.34"
-PKG_SHA256="dbc69f90ddc821b8d1441f00374dc1da4323a2eafa9078e61edbe5eeefa852ec"
+PKG_VERSION="3.24.35"
+PKG_SHA256="ec10fe6d712ef0b3c63b5f932639c9d1ae99fce94f500f6f06965629fef60bd1"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gtk+/${PKG_VERSION:0:4}/gtk+-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/libXScrnSaver/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/libXScrnSaver/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXScrnSaver"
-PKG_VERSION="1.2.3"
-PKG_SHA256="f917075a1b7b5a38d67a8b0238eaab14acd2557679835b154cf2bca576e89bf8"
+PKG_VERSION="1.2.4"
+PKG_SHA256="75cd2859f38e207a090cac980d76bc71e9da99d48d09703584e00585abc920fe"
 PKG_LICENSE="GPL"
-PKG_SITE="http://xorg.freedesktop.org/"
-PKG_URL="https://xorg.freedesktop.org/releases/individual/lib/libXScrnSaver-${PKG_VERSION}.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain scrnsaverproto"
+PKG_SITE="https://xorg.freedesktop.org/"
+PKG_URL="https://xorg.freedesktop.org/releases/individual/lib/libXScrnSaver-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain libXext scrnsaverproto"
 PKG_LONGDESC="X11 Screen Saver extension client library."
 PKG_BUILD_FLAGS="-sysroot"
 

--- a/packages/addons/addon-depends/chrome-depends/libXft/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/libXft/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXft"
-PKG_VERSION="2.3.4"
-PKG_SHA256="57dedaab20914002146bdae0cb0c769ba3f75214c4c91bd2613d6ef79fc9abdd"
+PKG_VERSION="2.3.6"
+PKG_SHA256="60a6e7319fc938bbb8d098c9bcc86031cc2327b5d086d3335fc5c76323c03022"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXft-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXft-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain fontconfig freetype libXrender util-macros xorgproto"
 PKG_LONGDESC="X FreeType library."
 PKG_BUILD_FLAGS="+pic -sysroot"

--- a/packages/addons/addon-depends/chrome-depends/libxss/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/libxss/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxss"
-PKG_VERSION="1.2.3"
-PKG_SHA256="f917075a1b7b5a38d67a8b0238eaab14acd2557679835b154cf2bca576e89bf8"
+PKG_VERSION="1.2.4"
+PKG_SHA256="75cd2859f38e207a090cac980d76bc71e9da99d48d09703584e00585abc920fe"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXScrnSaver-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXScrnSaver-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libXext scrnsaverproto"
 PKG_LONGDESC="X11 Screen Saver extension library."
 PKG_BUILD_FLAGS="+pic -sysroot"

--- a/packages/x11/app/xkbcomp/package.mk
+++ b/packages/x11/app/xkbcomp/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xkbcomp"
-PKG_VERSION="1.4.5"
-PKG_SHA256="6851086c4244b6fd0cc562880d8ff193fb2bbf1e141c73632e10731b31d4b05e"
+PKG_VERSION="1.4.6"
+PKG_SHA256="fa50d611ef41e034487af7bd8d8c718df53dd18002f591cca16b0384afc58e98"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11 libxkbfile"
 PKG_LONGDESC="The xkbcomp keymap compiler converts a description of an XKB keymap into one of several output formats."
 

--- a/packages/x11/app/xrandr/package.mk
+++ b/packages/x11/app/xrandr/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xrandr"
-PKG_VERSION="1.5.1"
-PKG_SHA256="7bc76daf9d72f8aff885efad04ce06b90488a1a169d118dea8a2b661832e8762"
+PKG_VERSION="1.5.2"
+PKG_SHA256="c8bee4790d9058bacc4b6246456c58021db58a87ddda1a9d0139bf5f18f1f240"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libXrandr"
 PKG_LONGDESC="Xrandr is a primitive command line interface to the RandR extension and used to set the screen size, orientation and/or reflection."
 

--- a/packages/x11/lib/libICE/package.mk
+++ b/packages/x11/lib/libICE/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libICE"
-PKG_VERSION="1.0.10"
-PKG_SHA256="6f86dce12cf4bcaf5c37dddd8b1b64ed2ddf1ef7b218f22b9942595fb747c348"
+PKG_VERSION="1.1.0"
+PKG_SHA256="02d2fc40d81180bd4aae73e8356acfa2a7671e8e8b472e6a7bfa825235ab225b"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros xtrans"
 PKG_LONGDESC="X Inter-Client Exchange (ICE) protocol library."
 

--- a/packages/x11/lib/libICE/package.mk
+++ b/packages/x11/lib/libICE/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libICE"
-PKG_VERSION="1.1.0"
-PKG_SHA256="02d2fc40d81180bd4aae73e8356acfa2a7671e8e8b472e6a7bfa825235ab225b"
+PKG_VERSION="1.1.1"
+PKG_SHA256="03e77afaf72942c7ac02ccebb19034e6e20f456dcf8dddadfeb572aa5ad3e451"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXau/package.mk
+++ b/packages/x11/lib/libXau/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXau"
-PKG_VERSION="1.0.10"
-PKG_SHA256="8be6f292334d2f87e5b919c001e149a9fdc27005d6b3e053862ac6ebbf1a0c0a"
+PKG_VERSION="1.0.11"
+PKG_SHA256="f3fa3282f5570c3f6bd620244438dbfbdd580fc80f02f549587a0f8ab329bbeb"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXcomposite/package.mk
+++ b/packages/x11/lib/libXcomposite/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXcomposite"
-PKG_VERSION="0.4.5"
-PKG_SHA256="b3218a2c15bab8035d16810df5b8251ffc7132ff3aa70651a1fba0bfe9634e8f"
+PKG_VERSION="0.4.6"
+PKG_SHA256="fe40bcf0ae1a09070eba24088a5eb9810efe57453779ec1e20a55080c6dc2c87"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libXfixes libXext libX11"
 PKG_LONGDESC="X Composite Library"
 PKG_BUILD_FLAGS="+pic"

--- a/packages/x11/lib/libXdamage/package.mk
+++ b/packages/x11/lib/libXdamage/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXdamage"
-PKG_VERSION="1.1.5"
-PKG_SHA256="b734068643cac3b5f3d2c8279dd366b5bf28c7219d9e9d8717e1383995e0ea45"
+PKG_VERSION="1.1.6"
+PKG_SHA256="52733c1f5262fca35f64e7d5060c6fcd81a880ba8e1e65c9621cf0727afb5d11"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11 libXfixes"
 PKG_LONGDESC="LibXdamage provides an X Window System client interface to the DAMAGE extension to the X protocol."
 PKG_BUILD_FLAGS="+pic"

--- a/packages/x11/lib/libfontenc/package.mk
+++ b/packages/x11/lib/libfontenc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libfontenc"
-PKG_VERSION="1.1.6"
-PKG_SHA256="ea8606ed5255dda8f570b7d1a74d59ee8d198675b2f114d07807431e6ba1d111"
+PKG_VERSION="1.1.7"
+PKG_SHA256="c0d36991faee06551ddbaf5d99266e97becdc05edfae87a833c3ff7bf73cfec2"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libxkbfile/package.mk
+++ b/packages/x11/lib/libxkbfile/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbfile"
-PKG_VERSION="1.1.1"
-PKG_SHA256="8623dc26e7aac3c5ad8a25e57b566f4324f5619e5db38457f0804ee4ed953443"
+PKG_VERSION="1.1.2"
+PKG_SHA256="b8a3784fac420b201718047cfb6c2d5ee7e8b9481564c2667b4215f6616644b1"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libxshmfence/package.mk
+++ b/packages/x11/lib/libxshmfence/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxshmfence"
-PKG_VERSION="1.3.1"
-PKG_SHA256="1129f95147f7bfe6052988a087f1b7cb7122283d2c47a7dbf7135ce0df69b4f8"
+PKG_VERSION="1.3.2"
+PKG_SHA256="870df257bc40b126d91b5a8f1da6ca8a524555268c50b59c0acd1a27f361606f"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- at-spi2-core: update to 2.46.0 and https
- gtk3: update to 3.24.35
- libICE: update to 1.1.1 and https
- libXau: update to 1.0.11
- libXcomposite: update to 0.4.6 and https
- libXdamage: update to 1.1.6 and https
- libXft: update to 2.3.6 and https
- libXScrnSaver: update to 1.2.4
- libfontenc: update to 1.1.7
- libxkbfile: update to 1.1.2
- libxshmfence: update to 1.3.2
- libxss: update to 1.2.4
- xkbcomp: update to 1.4.6 and https
- xrandr: update to 1.5.2 and https