### PR TITLE
Minor package updates

### DIFF
--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.26.0"
-PKG_SHA256="8000d7169febce93c84b6bdf376631f8179132fd69f7015d4dadb8b9c2bdb295"
+PKG_VERSION="2.26.1"
+PKG_SHA256="02537cc7ebd74071631038b237ec4bfbb3f4830ba019e569434da33f42373e04"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
 PKG_URL="https://www.libsdl.org/release/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/usbutils/package.mk
+++ b/packages/sysutils/usbutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="usbutils"
-PKG_VERSION="014"
-PKG_SHA256="3a079cfad60560227b67192482d7813bf96326fcbb66c04254839715f276fc69"
+PKG_VERSION="015"
+PKG_SHA256="c3b451bb1f4ff9f6356cac5a6956a9ac8e85d81651af56a29e689f94fa6fda6e"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.linux-usb.org/"
 PKG_URL="http://kernel.org/pub/linux/utils/usb/usbutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
SDL2: update to 2.26.1
- https://github.com/libsdl-org/SDL/releases/tag/release-2.26.1

usbutils: update to 015
- log: https://github.com/gregkh/usbutils/compare/v014...v015

usbutils 015
============

Greg Kroah-Hartman (6):
      usb-devices: list the root devices in numerical order
      usb-devices: use 'local' variable type to handle recursion
      lsusb: remove unused wireless check
      lsusb: remove wireless descriptor information
      usb-devices: fix field width on device speed field
      lsusb: fix up Midi Device specification devices

Han Han (1):
      Fix an runtime error reported by undefind sanitizer

Robert Hancock (1):
      lsusb: Improve status display for SuperSpeedPlus hubs

Tan Li Boon (1):
      lsusb-t: Fix recursive sorting on child devices.