### PR TITLE
scripts/build: update TRACE_BUILD_TIMING

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -558,8 +558,8 @@ record_timestamp BUILD_END
 
 if [ -n "${TRACE_BUILD_TIMING}" ]; then
   (
-    echo "build timing details:"
-    show_timestamp_diff "total" BUILD_BEGIN BUILD_END
+    print_color "CLR_AUTOREMOVE" "\nBuild timing details:"
+    print_color "CLR_TARGET" "\n================================\n"  
     show_timestamp_diff "unpack" BUILD_BEGIN BUILD_START
     show_timestamp_diff "pre-build setup" BUILD_START BUILD_CONFIGURE
     show_timestamp_diff "configure" BUILD_CONFIGURE BUILD_MAKE
@@ -567,5 +567,8 @@ if [ -n "${TRACE_BUILD_TIMING}" ]; then
     show_timestamp_diff "make install" BUILD_MAKEINSTALL BUILD_COPY_SYSROOT
     show_timestamp_diff "copy sysroot" BUILD_COPY_SYSROOT BUILD_CLEANUP_INSTALL
     show_timestamp_diff "cleanup install" BUILD_CLEANUP_INSTALL BUILD_END
+    print_color "CLR_TARGET" "--------------------------------\n"  
+    show_timestamp_diff "total time" BUILD_BEGIN BUILD_END
+    echo -e
   ) >&${VERBOSE_OUT}
 fi


### PR DESCRIPTION
- reformatted the build timing details 

#### example output
```
<<< edid-decode:target seq 184 <<<
UNPACK      edid-decode
BUILD      edid-decode (target)
    TOOLCHAIN      make (auto-detect)
/mnt/dev/LibreELEC-RR/build.LibreELEC-RK3399.arm-11.0-devel/toolchain/bin/armv8a-libreelec-linux-gnueabihf-g++  -Wall  -Wl,--as-needed -fuse-ld=mold -g -DSHA=9ba4e90f3c07 -o edid-decode calc-gtf-cvt.cpp calc-ovt.cpp               edid-decode.cpp parse-base-block.cpp parse-cta-block.cpp               parse-displayid-block.cpp parse-ls-ext-block.cpp               parse-di-ext-block.cpp parse-vtb-ext-block.cpp -lm

Build timing details:
================================
              unpack:      0.468
     pre-build setup:      0.027
           configure:      0.005
                make:     13.671
        make install:      0.018
        copy sysroot:      0.036
     cleanup install:      0.094
--------------------------------
          total time:     14.319

INSTALL      edid-decode (target)
>>> edid-decode:target seq 184 >>>
```