### PR TITLE
Minor package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.19.3"
-PKG_SHA256="a26c4e2be235a984a31e466a6cd40c617c5c9ebee07f0c8ca15077dc024e3759"
+PKG_VERSION="1.19.4"
+PKG_SHA256="b8f2440f7835eccf93684450268b0cb1bfa5ad3f4724c8ba0c1ae6cd0886f23d"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/devel/flatbuffers/package.mk
+++ b/packages/devel/flatbuffers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flatbuffers"
-PKG_VERSION="22.11.23"
-PKG_SHA256="8e9bacc942db59ca89a383dd7923f3e69a377d6e579d1ba13557de1fdfddf56a"
+PKG_VERSION="22.12.06"
+PKG_SHA256="209823306f2cbedab6ff70997e0d236fcfd1864ca9ad082cbfdb196e7386daed"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/google/flatbuffers"
 PKG_URL="https://github.com/google/flatbuffers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/pcre2/package.mk
+++ b/packages/devel/pcre2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcre2"
-PKG_VERSION="10.40"
-PKG_SHA256="14e4b83c4783933dc17e964318e6324f7cae1bc75d8f3c79bc6969f00c159d68"
+PKG_VERSION="10.41"
+PKG_SHA256="0f78cebd3e28e346475fb92e95fe9999945b4cbaad5f3b42aca47b887fb53308"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.pcre.org/"
 PKG_URL="https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PKG_VERSION}/pcre2-${PKG_VERSION}.tar.bz2"
@@ -26,6 +26,13 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
                        -DPCRE2_BUILD_PCRE2_16=ON \
                        -DPCRE2_SUPPORT_LIBEDIT=OFF \
                        -DPCRE2_SUPPORT_LIBREADLINE=OFF"
+
+post_unpack() {
+  sed -e 's|^INSTALL(FILES ${man1} DESTINATION man/man1)||' \
+      -e 's|^INSTALL(FILES ${man3} DESTINATION man/man3)||' \
+      -e 's|^INSTALL(FILES ${html} DESTINATION share/doc/pcre2/html)||' \
+      -i ${PKG_BUILD}/CMakeLists.txt
+}
 
 post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/bin

--- a/packages/graphics/jasper/package.mk
+++ b/packages/graphics/jasper/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jasper"
-PKG_VERSION="3.0.6"
-PKG_SHA256="c79961bc00158f5b5dc5f5fcfa792fde9bebb024432689d0f9e3f95a097d0ec3"
+PKG_VERSION="4.0.0"
+PKG_SHA256="977c4c2e4210f4e37313cd2232d99e73d57ab561917b3c060bcdd5e83a0a13f1"
 PKG_LICENSE="OpenSource"
 PKG_SITE="http://www.ece.uvic.ca/~mdadams/jasper/"
 PKG_URL="https://github.com/jasper-software/jasper/archive/refs/tags/version-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- flatbuffers: update to 22.12.06
- go: update to 1.19.4
- jasper: update to 4.0.0
  - move to the packages/graphics directory
- pcre2: update to 10.41
  - don’t install man or docs