### PR TITLE
Fix Chrome addon build due to file name changes bz2 to xz 

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/chrome-libXcomposite/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libXcomposite/package.mk
@@ -15,5 +15,5 @@ PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} \
 
 unpack() {
   mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.bz2 -C ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
 }

--- a/packages/addons/addon-depends/chrome-depends/chrome-libXdamage/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libXdamage/package.mk
@@ -15,5 +15,5 @@ PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} \
 
 unpack() {
   mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.bz2 -C ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
 }


### PR DESCRIPTION
- chrome-libXcomposite: fix source file name from bz2 to xz
- chrome-libXdamage: fix source file name from bz2 to xz