### PR TITLE
[le10] dotnet-runtime: Update ASP.NET 6.x to 6.0.12 and addon (124)

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet6-runtime"
-PKG_VERSION="6.0.10"
+PKG_VERSION="6.0.12"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="6ef235a35a3ea8773b0b0eba011d182af08d972deb331c2259db4277fd4f0a80"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/c37e7250-886d-47e1-840e-fc0ae2aad195/81f019f66f158b7ccb3511d2fa5dec53/aspnetcore-runtime-6.0.10-linux-arm64.tar.gz"
+    PKG_SHA256="0090d031615b7d49855186cff7e4cbc99636ba664880780f84ce0d5ce25e4b0b"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/8072e219-57e4-48c3-b138-2b4067844ab2/b0712ad06fd0740963bf4ba2eff7f5ea/aspnetcore-runtime-6.0.12-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="91c7008433d6859e9402427b2465b412c10525f86268e938ccb39cfadcacb004"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/eb049d47-1cd1-4a76-8b4c-3efee9890f2a/53441bce40b9ac8d073fb4742d823c3b/aspnetcore-runtime-6.0.10-linux-arm.tar.gz"
+    PKG_SHA256="2131903c85087017ec680e44676c4eb46e7bd0a12f0683c2a7790ec75b243d75"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/57b2bdaf-8455-4b1a-b25b-5950c950bd38/471d6de036e6f367f3a4aae5252d885a/aspnetcore-runtime-6.0.12-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="17685d3e8fa7aa9c1a658f7ca5e176bec7bb4c189b0352ac5abfed98135b93d9"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/7d44ddeb-ad35-41a8-a581-03b151afbd80/6888586c28836b1e1f71df879184550b/aspnetcore-runtime-6.0.10-linux-x64.tar.gz"
+    PKG_SHA256="dd60c551d63eb66cd9bdc7ef223c00f49341e67f8ddda2e4ab412c3ee8997765"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/4ba0f30d-0a77-4997-8d8d-1b113d60253b/5caeeb07572b0b6a26f2a82f7a4eb31d/aspnetcore-runtime-6.0.12-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/tools/dotnet-runtime/changelog.txt
+++ b/packages/addons/tools/dotnet-runtime/changelog.txt
@@ -1,3 +1,6 @@
+124
+- Update ASP.NET Core Runtime 6.0.12
+
 123
 - Update ASP.NET Core Runtime 6.0.10
 

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="123"
+PKG_REV="124"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"


### PR DESCRIPTION
- dotnet-runtime: Update ASP.NET 6.x to 6.0.12 and addon (1)
- aspnet6-runtime: update to 6.0.12 


Backport of 
- #7248 