### PR TITLE
nlohmann-json: use cmake toolchain

### DIFF
--- a/packages/textproc/nlohmann-json/package.mk
+++ b/packages/textproc/nlohmann-json/package.mk
@@ -9,3 +9,7 @@ PKG_SITE="https://nlohmann.github.io/json/"
 PKG_URL="https://github.com/nlohmann/json/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="JSON for Modern C++"
+# Meson does not provide nlohmann_json*.cmake files which some projects rely on
+PKG_TOOLCHAIN="cmake"
+
+PKG_CMAKE_OPTS_TARGET="-DJSON_BuildTests=OFF"


### PR DESCRIPTION
- the meson build is rather incomplete & not all packages were satisfied by a pkgconfig file which it provides, those looking for cmake config files e.g by calling `find_package(nlohmann_json 3.8 REQUIRED)` will fail because they rely on `nlohmann_jsonConfig.cmake` `nlohmann_jsonConfigVersion.cmake` `nlohmann_jsonTargets.cmake` located in `/usr/share/cmake/nlohmann_json` which meson does not provide.
- both binary addons `pvr.freebox` & `pvr.freebox` depend on the package were successfully build
- reverts https://github.com/LibreELEC/LibreELEC.tv/commit/4a32a3ded67617cd6b16251c020d00df4ec31d5f