### PR TITLE
mesa: update to 22.3.1

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="22.3.0"
-PKG_SHA256="644bf936584548c2b88762111ad58b4aa3e4688874200e5a4eb74e53ce301746"
+PKG_VERSION="22.3.1"
+PKG_SHA256="3c9cd611c0859d307aba0659833386abdca4c86162d3c275ba5be62d16cf31eb"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
ann:
- https://lists.freedesktop.org/archives/mesa-dev/2022-December/225902.html

```
=== tested on ===
Generic.x86_64-devel-20221215102014-d77dc53
Linux nuc12 6.1.0 #1 SMP Thu Dec 15 10:23:51 UTC 2022 x86_64 GNU/Linux
Starting Kodi (20.0-RC1 (19.90.901) Git:20.0rc1-Nexus). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2022-12-12 by GCC 12.2.0 for Linux x86 64-bit version 6.1.0 (393472)
Running on LibreELEC (heitbaum): devel-20221215102014-d77dc53 11.0, kernel: Linux x86 64-bit version 6.1.0
FFmpeg version/source: 4.4.1-Kodi
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0085.2022.0718.1739 07/18/2022
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.3.1
libva info: VA-API version 1.16.0
vainfo: VA-API version: 1.16 (libva 2.16.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 22.6.4 (38ae184a3d)
```