### PR TITLE
qemu and boost package updates

### DIFF
--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="boost"
-PKG_VERSION="1.80.0"
-PKG_SHA256="1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0"
+PKG_VERSION="1.81.0"
+PKG_SHA256="71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.boost.org/"
 PKG_URL="https://boostorg.jfrog.io/artifactory/main/release/${PKG_VERSION}/source/${PKG_NAME}_${PKG_VERSION//./_}.tar.bz2"

--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qemu"
-PKG_VERSION="7.1.0"
-PKG_SHA256="a0634e536bded57cf38ec8a751adb124b89c776fe0846f21ab6c6728f1cbbbe6"
+PKG_VERSION="7.2.0"
+PKG_SHA256="5b49ce2687744dad494ae90a898c52204a3406e84d072482a1e1be854eeb2157"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.qemu.org"
 PKG_URL="https://download.qemu.org/qemu-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- boost: update to 1.81.0
  - https://www.boost.org/users/history/version_1_81_0.html
- qemu: update to 7.2.0
  - https://www.qemu.org/2022/12/14/qemu-7-2-0/