### PR TITLE
rust: update to 1.66.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cargo-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="82547aacaf42fc3c2970ec31b96751dfbeba3dffe1a042a3780bd670c29a89bf"
+PKG_SHA256="bede77d09248fbcf036ff54ab84768696cdb093d52fb3653b77eeb05dac2b464"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rust-std-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="2b588cd2d49688c0c33b7466614123e8fe4c910f4d802fc0ff0662b1772816a9"
+PKG_SHA256="c59ca7959a019f3f660c1f46bea3c13e7769b67732731469c0c42d02f28d08e7"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.65.0"
-PKG_SHA256="5828bb67f677eabf8c384020582b0ce7af884e1c84389484f7f8d00dd82c0038"
+PKG_VERSION="1.66.0"
+PKG_SHA256="3b3cd3ea5a82a266e75d0b35f0b54c16021576d9eb78d384052175a772935a48"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rustc-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="62b89786e195fc5a8a262f83118d6689832b24228c9d303cba8ac14dc1e9adc8"
+PKG_SHA256="5d76d653a745cbefcdc13e3976a3e56798af5ca98bf102bb317a0e61702ab90c"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"


### PR DESCRIPTION
Ann:
- https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html