### PR TITLE
X11 and wayland updates

### DIFF
--- a/packages/addons/addon-depends/libvncserver/package.mk
+++ b/packages/addons/addon-depends/libvncserver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libvncserver"
-PKG_VERSION="0.9.13"
-PKG_SHA256="0ae5bb9175dc0a602fe85c1cf591ac47ee5247b87f2bf164c16b05f87cbfa81a"
+PKG_VERSION="0.9.14"
+PKG_SHA256="83104e4f7e28b02f8bf6b010d69b626fae591f887e949816305daebae527c9a5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libvnc.github.io/"
 PKG_URL="https://github.com/LibVNC/libvncserver/archive/LibVNCServer-${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/nvidia-vaapi-driver/package.mk
+++ b/packages/multimedia/nvidia-vaapi-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia-vaapi-driver"
-PKG_VERSION="0.0.7"
-PKG_SHA256="c19e35d41cd39a93c2a1af99065d51719a994fdd89f8b0716914cba7e716718e"
+PKG_VERSION="0.0.8"
+PKG_SHA256="a396e8b48ec9bc58cec50d5b049e401ddc59083195edf2b8669e9788f4d44293"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/elFarto/nvidia-vaapi-driver"
 PKG_URL="https://github.com/elFarto/nvidia-vaapi-driver/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/wayland/util/bemenu/package.mk
+++ b/packages/wayland/util/bemenu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bemenu"
-PKG_VERSION="0.6.13"
-PKG_SHA256="6032fae0253363a48171367c20982ef080ba5c163462732f0354dc8b606850f9"
+PKG_VERSION="0.6.14"
+PKG_SHA256="bc945776f94901d0898d19725d3a4c3e1f5bc90712a5bae9ec98d89d24603a9d"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Cloudef/bemenu"
 PKG_URL="https://github.com/Cloudef/bemenu/archive/${PKG_VERSION}.tar.gz"

--- a/packages/x11/lib/libSM/package.mk
+++ b/packages/x11/lib/libSM/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libSM"
-PKG_VERSION="1.2.3"
-PKG_SHA256="2d264499dcb05f56438dee12a1b4b71d76736ce7ba7aa6efbf15ebb113769cbb"
+PKG_VERSION="1.2.4"
+PKG_SHA256="fdcbe51e4d1276b1183da77a8a4e74a137ca203e0bcfb20972dd5f3347e97b84"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros util-linux libICE"
 PKG_LONGDESC="This package provides the main interface to the X11 Session Management library."
 PKG_BUILD_FLAGS="+pic"

--- a/packages/x11/lib/libX11/package.mk
+++ b/packages/x11/lib/libX11/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libX11"
-PKG_VERSION="1.8.2"
-PKG_SHA256="ed91d573d570db83b8ae546f4890dccfcd0b9dfe1e50a1b401b63a74c152ed04"
+PKG_VERSION="1.8.3"
+PKG_SHA256="e31565c84006b6b8e01dc9399c806085739710bc2db2e0930f1511ed9d6585bd"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.x.org/"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xorg-server"
-PKG_VERSION="21.1.5"
-PKG_SHA256="c8dbf311e3fb74387e4167cff3bfc55598330f75cab8c701922c114caa1a8c0f"
+PKG_VERSION="21.1.6"
+PKG_SHA256="1eb86ed674d042b6c8b1f9135e59395cbbca35ed551b122f73a7d8bb3bb22484"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
-PKG_URL="https://github.com/freedesktop/xorg-xserver/archive/refs/tags/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_URL="https://www.x.org/releases/individual/xserver/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros font-util xorgproto libpciaccess libX11 libXfont2 libXinerama libxcvt libxshmfence libxkbfile libdrm openssl freetype pixman systemd xorg-launch-helper"
 PKG_NEED_UNPACK="$(get_pkg_directory xf86-video-nvidia) $(get_pkg_directory xf86-video-nvidia-legacy)"
 PKG_LONGDESC="X.Org Server is the free and open-source implementation of the X Window System display server."


### PR DESCRIPTION
- bemenu: update to 0.6.14
- libSM: update to 1.2.4
- libvncserver: update to 0.9.14
- libX11: update to 1.8.3
- nvidia-vaapi-driver: update to 0.0.8
- xorg-server: update to 21.1.6 and PKG_URL