### PR TITLE
docker: update to 23.0.0-beta.1 and addon (2)

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="2f5949173515b70daa0b78fea7185ffd219ca31f7381a0e1218eeefc7f70199c"
+PKG_SHA256="a51348d961d959473c701dcfd291bda8b78a9652ec7692f517b44858a5593da2"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/docker/cli/releases
-export PKG_GIT_COMMIT="3e9117b7e241439e314eaf6fe944b4019fbaa941"
+export PKG_GIT_COMMIT="65d3f7830d8f73aeabe649ca17386f5ae5655210"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="22.06.0-beta.0"
-PKG_SHA256="d0221f0b1c0eda2629ed8b7f08b4ec86e61cf38e0cf699f5bd01a2b662273b87"
+PKG_VERSION="23.0.0-beta.1"
+PKG_SHA256="cae782316ce3e699912260ac117c5b279496009a6ede761fd0418fa9d2b5b8a5"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/docker/source/bin/docker-config
+++ b/packages/addons/service/docker/source/bin/docker-config
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Lukas Rusak (lrusak@libreelec.tv)
+# Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 ADDON_DIR="/storage/.kodi/addons/service.system.docker"
 ADDON_HOME_DIR="/storage/.kodi/userdata/addon_data/service.system.docker"
@@ -12,6 +13,10 @@ fi
 
 if [ ! -f "$ADDON_HOME_DIR/config/docker.conf" ]; then
   cp $ADDON_DIR/config/docker.conf $ADDON_HOME_DIR/config/docker.conf
+else
+  # previous deprecated options before v23.0.0 need to be updated
+  sed -i -e 's/--storage-opt overlay2.override_kernel_check=1//' \
+         -e 's/--graph=/--data-root=/' $ADDON_HOME_DIR/config/docker.conf
 fi
 
 if [ ! -d "$ADDON_HOME_DIR/docker" ]; then

--- a/packages/addons/service/docker/source/config/docker.conf
+++ b/packages/addons/service/docker/source/config/docker.conf
@@ -1,2 +1,2 @@
 DOCKER_DAEMON_OPTS="--data-root=/storage/.kodi/userdata/addon_data/service.system.docker/docker"
-DOCKER_STORAGE_OPTS="--storage-driver=overlay2 --storage-opt overlay2.override_kernel_check=1"
+DOCKER_STORAGE_OPTS="--storage-driver=overlay2"


### PR DESCRIPTION
- cli: update to 23.0.0-beta.1
- docker: update to 23.0.0-beta.1 and addon (2)
- moby: update to 23.0.0-beta.1
- docker: update docker.conf

```
# docker version
Client:
 Version:           23.0.0-beta.1
 API version:       1.42
 Go version:        go1.19.4
 Git commit:        65d3f7830d8f73aeabe649ca17386f5ae5655210
 Built:             Sat Dec 17 20:45:32 UTC 2022
 OS/Arch:           linux/amd64
 Context:           default

Server:
 Engine:
  Version:          library-import
  API version:      1.42 (minimum version 1.12)
  Go version:       go1.19.4
  Git commit:       library-import
  Built:            library-import
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.13
  GitCommit:        78f51771157abb6c9ed224c22013cdf09962315d
 runc:
  Version:          1.1.4
  GitCommit:        6724737f999df9ee0d8ca5c6d7b81f97adc34374
 docker-init:
  Version:          0.19.0
  GitCommit:
```