### PR TITLE
iwd: update to 2.1 and ethtool: update to 6.1

### DIFF
--- a/packages/network/ethtool/package.mk
+++ b/packages/network/ethtool/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ethtool"
-PKG_VERSION="6.0"
-PKG_SHA256="d5446c93de570ce68f3b1ea69dbfa12fcfd67fc19897f655d3f18231e2b818d6"
+PKG_VERSION="6.1"
+PKG_SHA256="c41fc881ffa5a40432d2dd829eb44c64a49dee482e716baacf9262c64daa8f90"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/pub/software/network/ethtool/"
 PKG_URL="https://www.kernel.org/pub/software/network/ethtool/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.0"
-PKG_SHA256="5a0bfbc567092476d60a8f9700f68a273e39fd46e7177ce2d69bbc74255a930c"
+PKG_VERSION="2.1"
+PKG_SHA256="60fc17a6e765545e36ce75abe28d896f822eaf81ac1f61498ca631585cbde227"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
iwd: update to 2.1
- Fix issue with handling FT-over-DS action.
- Fix issue with handling scan and 6 GHz support check.
- Fix issue with handling when periodic scans get aborted.
- Add support for using 5 GHz frequencies in AP mode.

log:
- https://git.kernel.org/pub/scm/network/wireless/iwd.git/log/

ethtool: update to 6.1
- December 19, 2022
* Feature: update link mode tables
* Feature: register dump for NXP ENETC driver (-d)
* Feature: report TCP header-data split (-g)
* Feature: support new message types in pretty print
* Fix: fix compiler warnings
* Fix: man page syntax fixes

log:
- https://git.kernel.org/pub/scm/network/ethtool/ethtool.git/log/