### PR TITLE
vulkan-loader: add libXrandr dependency to fix X11 build

### DIFF
--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="Vulkan Installable Client Driver (ICD) Loader."
 configure_package() {
   # Displayserver Support
   if [ "${DISPLAYSERVER}" = "x11" ]; then
-    PKG_DEPENDS_TARGET+=" libxcb libX11"
+    PKG_DEPENDS_TARGET+=" libxcb libX11 libXrandr"
   elif [ "${DISPLAYSERVER}" = "wl" ]; then
     PKG_DEPENDS_TARGET+=" wayland"
   fi


### PR DESCRIPTION
- fixes build failure, if Xrandr.h headers is missing for X11 builds:
```
[1/20] Building C object loader/CMakeFiles/asm_offset.dir/asm_offset.c.o
FAILED: loader/CMakeFiles/asm_offset.dir/asm_offset.c.o 
/mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc -DAPI_NAME=\"Vulkan\" -DFALLBACK_CONFIG_DIRS=\"/etc/xdg\" -DFALLBACK_DATA_DIRS=\"/usr/local/share:/usr/share\" -DHAVE_ALLOCA_H -DHAVE_CET_H -DHAVE_SECURE_GETENV -DLOADER_ENABLE_LINUX_SORT -DSYSCONFDIR=\"/etc\" -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_XLIB_XRANDR_EXT -D_GNU_SOURCE -I/mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/vulkan-loader-1.3.237/loader -I/mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/vulkan-loader-1.3.237/loader/generated -I/mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/vulkan-loader-1.3.237/.x86_64-libreelec-linux-gnu/loader -march=x86-64-v2 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -O3 -DNDEBUG -save-temps=obj -Werror -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-missing-field-initializers -fno-strict-aliasing -fno-builtin-memcmp -Wno-stringop-truncation -Wno-stringop-overflow -fvisibility=hidden -Wpointer-arith -std=c99 -MD -MT loader/CMakeFiles/asm_offset.dir/asm_offset.c.o -MF loader/CMakeFiles/asm_offset.dir/asm_offset.c.o.d -o loader/CMakeFiles/asm_offset.dir/asm_offset.c.o -c /mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/vulkan-loader-1.3.237/loader/asm_offset.c
x86_64-libreelec-linux-gnu-gcc-12.2.0: warning: '-pipe' ignored because '-save-temps' specified
In file included from /mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/vulkan-loader-1.3.237/loader/loader_common.h:33,
                 from /mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/vulkan-loader-1.3.237/loader/asm_offset.c:26:
/mnt/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/vulkan/vulkan.h:71:10: fatal error: X11/extensions/Xrandr.h: No such file or directory
   71 | #include <X11/extensions/Xrandr.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
```