### PR TITLE
X11 updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gtk3"
-PKG_VERSION="3.24.35"
-PKG_SHA256="ec10fe6d712ef0b3c63b5f932639c9d1ae99fce94f500f6f06965629fef60bd1"
+PKG_VERSION="3.24.36"
+PKG_SHA256="27a6ef157743350c807ffea59baa1d70226dbede82a5e953ffd58ea6059fe691"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gtk+/${PKG_VERSION:0:4}/gtk+-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
gtk3: update to 3.24.36
news:
- https://download.gnome.org/sources/gtk+/3.24/gtk%2B-3.24.36.news