### PR TITLE
[le11] Addon updates

### DIFF
--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="btrfs-progs"
-PKG_VERSION="6.0.2"
-PKG_SHA256="561a99d402d2788586756fb2b90295f709ec339bd4466c05a6e7c439dd0fe2f4"
-PKG_REV="0"
+PKG_VERSION="6.1"
+PKG_SHA256="8112ae56840c32bef2157351ef2031e1d8894089b1ea74618d4ee7c83ef3510c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.wiki.kernel.org/index.php/Main_Page"

--- a/packages/graphics/libraw/package.mk
+++ b/packages/graphics/libraw/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libraw"
-PKG_VERSION="0.20.2"
-PKG_SHA256="dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6"
+PKG_VERSION="0.21.0"
+PKG_SHA256="8747b34e8534cc2dd7ef8c92c436414b3578904fd4bf9b87ea60f17aa99fb0bd"
 PKG_LICENSE="LGPL"
-PKG_SITE="http://www.libraw.org/"
-PKG_URL="http://www.libraw.org/data/LibRaw-${PKG_VERSION}.tar.gz"
+PKG_SITE="https://www.libraw.org/"
+PKG_URL="https://www.libraw.org/data/LibRaw-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libjpeg-turbo lcms2"
 PKG_LONGDESC="A library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)"
 PKG_BUILD_FLAGS="+pic"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.raw"
 PKG_VERSION="20.1.0-Nexus"
 PKG_SHA256="6235c0be431bbb814b3e464753af9ad17febf6001f77cbf030e6c6e1cdc41a04"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.raw"


### PR DESCRIPTION
- imagedecoder.raw: rebuild with libraw 0.21.0 and addon (4)
- btrfs-progs: update to 6.1 and addon (1)
- libraw: update to 0.21.0 and HSTS