### PR TITLE
glib: update to 2.75.1

### DIFF
--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.75.0"
-PKG_SHA256="6dde8e55cc4a2c83d96797120b08bcffb5f645b2e212164ae22d63c40e0e6360"
+PKG_VERSION="2.75.1"
+PKG_SHA256="96fd22355a542cca96c31082f2d09b72cb5a3454b6ea60c1be17c987a18a6b93"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
log:
- https://gitlab.gnome.org/GNOME/glib/-/releases
- (Bug fix release)