### PR TITLE
curl: update to 7.88.1 and nghttp2: update to 1.52.0

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="curl"
-PKG_VERSION="7.86.0"
-PKG_SHA256="2d61116e5f485581f6d59865377df4463f2e788677ac43222b496d4e49fb627b"
+PKG_VERSION="7.88.1"
+PKG_SHA256="1dae31b2a7c1fe269de99c0c31bb488346aab3459b5ffca909d6938249ae415f"
 PKG_LICENSE="MIT"
 PKG_SITE="https://curl.haxx.se"
 PKG_URL="https://curl.haxx.se/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.51.0"
-PKG_SHA256="66aa76d97c143f42295405a31413e5e7d157968dad9f957bb4b015b598882e6b"
+PKG_VERSION="1.52.0"
+PKG_SHA256="3ea9f0439e60469ad4d39cb349938684ffb929dd7e8e06a7bffe9f9d21f8ba7d"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
### curl: update to 7.88.1

changes:
- https://curl.se/changes.html
- Mostly bugfixes and a security fix. 
- regular 56 day release

new / changed functionality 
- [curl: add --url-query](https://curl.se/bug/?i=9691)
- [CURLOPT_QUICK_EXIT: don't wait for DNS thread on exit](https://curl.se/bug/?i=2975)
- [lib: add CURL_WRITEFUNC_ERROR to signal write callback error](https://curl.se/bug/?i=9874)
- [openssl: reduce CA certificate bundle reparsing by caching](https://curl.se/bug/?i=9620)
- [version: add a feature names array to curl_version_info_data](https://curl.se/bug/?i=9583)
- 
- [curl.h: add CURL_HTTP_VERSION_3ONLY](https://curl.se/bug/?i=10264)
- [share: add sharing of HSTS cache among handles](https://curl.se/bug/?i=10138)
- [src: add --http3-only](https://curl.se/bug/?i=10264)
tool_operate: share HSTS between handles
- [urlapi: add CURLU_PUNYCODE](https://curl.se/bug/?i=10109)
- [writeout: add %{certs} and %{num_certs}](https://curl.se/bug/?i=10019)

### nghttp2: update to 1.52.0
release notes:
- https://github.com/nghttp2/nghttp2/releases/tag/v1.52.0