### PR TITLE
mold: fix pthread DSO build error

### DIFF
--- a/packages/devel/mold/package.mk
+++ b/packages/devel/mold/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mold"
-PKG_VERSION="1.7.1"
-PKG_SHA256="fa2558664db79a1e20f09162578632fa856b3cde966fbcb23084c352b827dfa9"
+PKG_VERSION="1.8.0"
+PKG_SHA256="7210225478796c2528aae30320232a5a3b93a640292575a8c55aa2b140041b5c"
 PKG_LICENSE="AGPL-3.0-or-later"
 PKG_SITE="https://github.com/rui314/mold"
 PKG_URL="https://github.com/rui314/mold/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/tbb/package.mk
+++ b/packages/devel/tbb/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tbb"
-PKG_VERSION="2021.7.0"
-PKG_SHA256="2cae2a80cda7d45dc7c072e4295c675fff5ad8316691f26f40539f7e7e54c0cc"
+PKG_VERSION="2021.8.0"
+PKG_SHA256="eee380323bb7ce864355ed9431f85c43955faaae9e9bce35c62b372d7ffd9f8b"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/oneapi-src/oneTBB"
 PKG_URL="https://github.com/oneapi-src/oneTBB/archive/refs/tags/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update to mold 1.8.0 and oneTBB 2021.8 instead of the upstream patch

~~Compiling mold 1.7.1 fails during link stage~~

~~fixes:
/usr/bin/ld: build.LibreELEC-yyy/toolchain/lib/libcrypto.a(libcrypto-lib-threads_pthread.o):
 undefined reference to symbol 'pthread_rwlock_destroy@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0:
 error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status~~

~~Upstream mold bugfix to cmake file~~
- ~~https://github.com/rui314/mold/issues/924~~
- ~~https://github.com/rui314/mold/commit/a3a98ac5f581c450756147a043589764625499fc~~