### PR TITLE
sqlite: update to 3.40.1

### DIFF
--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.40.0"
+PKG_VERSION="3.40.1"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="0333552076d2700c75352256e91c78bf5cd62491589ba0c69aed0a81868980e7"
+PKG_SHA256="2c5dea207fa508d765af1ef620b637dcb06572afa6f01f0815bd5bbf864b33d9"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2022/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"


### PR DESCRIPTION
release log:
- https://www.sqlite.org/releaselog/3_40_1.html

Additional changes in version 3.40.1 (2022-12-28):
- Fix the --safe command-line option to the CLI such that it correctly disallows the use of SQL functions like writefile() that can cause harmful side-effects.
- Fix a potential infinite loop in the memsys5 alternative memory allocator. This bug was introduced by a performance optimization in version 3.39.0.
- Various other obscure fixes.