### PR TITLE
functions: fix build_with_debug() to include dependency base packages like "kodi+"

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -744,7 +744,7 @@ build_with_debug() {
     [ "${PKG_IS_KERNEL_PKG}" = "yes" ] && listcontains "${_DEBUG_DEPENDS_LIST}" "linux\+" && return 0
 
     # Build this package with debug if it's a resolved dependency
-    listcontains "${_DEBUG_DEPENDS_LIST}" "${PKG_NAME}" && return 0
+    listcontains "${_DEBUG_DEPENDS_LIST}" "${PKG_NAME}[+]?" && return 0
   fi
 
   return 1


### PR DESCRIPTION
When creating a debug image with `DEBUG=yes` the debug symbols are missing for kodi.

Dependency base packages like "kodi+" have to be matched in build_with_debug().