### PR TITLE
[le11] network-tools: update addon (1)

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libpcap"
-PKG_VERSION="1.10.1"
-PKG_SHA256="ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4"
+PKG_VERSION="1.10.2"
+PKG_SHA256="db6d79d4ad03b8b15fb16c42447d093ad3520c0ec0ae3d331104dcfb1ce77560"
 PKG_LICENSE="GPL"
-PKG_SITE="http://www.tcpdump.org/"
-PKG_URL="http://www.tcpdump.org/release/libpcap-${PKG_VERSION}.tar.gz"
+PKG_SITE="https://www.tcpdump.org/"
+PKG_URL="https://www.tcpdump.org/release/libpcap-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A portable framework for low-level network monitoring."
 # use configure, not cmake. review cmake in future release.

--- a/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tcpdump"
-PKG_VERSION="4.99.1"
-PKG_SHA256="79b36985fb2703146618d87c4acde3e068b91c553fb93f021a337f175fd10ebe"
-PKG_SITE="http://www.tcpdump.org/"
-PKG_URL="http://www.tcpdump.org/release/tcpdump-${PKG_VERSION}.tar.gz"
+PKG_VERSION="4.99.2"
+PKG_SHA256="f4304357d34b79d46f4e17e654f1f91f9ce4e3d5608a1badbd53295a26fb44d5"
+PKG_SITE="https://www.tcpdump.org/"
+PKG_URL="https://www.tcpdump.org/release/tcpdump-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libpcap libtirpc"
 PKG_LONGDESC="A program that allows you to dump the traffic on a network."
 PKG_BUILD_FLAGS="-sysroot"

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- libpcap: update to 1.10.2 and HSTS
  - https://git.tcpdump.org/libpcap/blob/HEAD:/CHANGES
- tcpdump: update to 4.99.2 and HSTS
  - https://git.tcpdump.org/tcpdump/blob/HEAD:/CHANGES
  - https://www.tcpdump.org/index.html#latest-releases