### PR TITLE
libbpf: update to 1.1.0

### DIFF
--- a/packages/devel/libbpf/package.mk
+++ b/packages/devel/libbpf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libbpf"
-PKG_VERSION="1.0.1"
-PKG_SHA256="3d6afde67682c909e341bf194678a8969f17628705af25f900d5f68bd299cb03"
+PKG_VERSION="1.1.0"
+PKG_SHA256="5da826c968fdb8a2f714701cfef7a4b7078be030cf58b56143b245816301cbb8"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/libbpf/libbpf"
 PKG_URL="https://github.com/libbpf/libbpf/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/libbpf/patches/libbpf-fix-crosscompile-and-sysroot.patch
+++ b/packages/devel/libbpf/patches/libbpf-fix-crosscompile-and-sysroot.patch
@@ -3,10 +3,10 @@ index 81ea6b8..7ab5f13 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -67,15 +67,12 @@ INSTALL = install
- 
  DESTDIR ?=
  
--ifeq ($(filter-out %64 %64be %64eb %64le %64el s390x, $(shell uname -m)),)
+ HOSTARCH = $(firstword $(subst -, ,$(shell $(CC) -dumpmachine)))
+-ifeq ($(filter-out %64 %64be %64eb %64le %64el s390x, $(HOSTARCH)),)
 -	LIBSUBDIR := lib64
 -else
 -	LIBSUBDIR := lib


### PR DESCRIPTION
release notes:
- https://github.com/libbpf/libbpf/releases/tag/v1.1.0
- https://github.com/libbpf/libbpf/compare/v1.0.1...v1.1.0

@HiassofT - I had not planned to PR this for LE11 - but in review of changelog and kernel support …. Do we require this. Or add to LE12 queue?