### PR TITLE
bento4: update to 1.6.0-639-4-Nexus

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="inputstream.adaptive"
 PKG_VERSION="20.3.1-Nexus"
 PKG_SHA256="e05639a1b32cec9b9bdef364a05ee91bfa17fe5cf1c00e31a98c8b31ddfcb658"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/inputstream.adaptive"

--- a/packages/multimedia/bento4/package.mk
+++ b/packages/multimedia/bento4/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bento4"
-PKG_VERSION="1.6.0-639-Nexus"
-PKG_SHA256="adb44aa29d0545795225735dece3665a58c3b9d194825b029cc05669620c50a4"
+PKG_VERSION="1.6.0-639-4-Nexus"
+PKG_SHA256="8488d47e142c4d85a0c6aa6caefef0575fc1216a77e62db88cc48ed2c61ec06c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.bento4.com"
 PKG_URL="https://github.com/xbmc/Bento4/archive/refs/tags/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update Bento4 to match version used in inputstream.adaptive tree: https://github.com/xbmc/inputstream.adaptive/blob/20.3.1-Nexus/depends/common/bento4/bento4.txt

Update commit log: https://github.com/xbmc/Bento4/compare/1.6.0-639-Nexus...1.6.0-639-4-Nexus

The update should resolve a crash in inputstream.adaptive, so bump its PKG_REV.