### PR TITLE
Kodi GBM: fix flickering during channel switching

### DIFF
--- a/projects/Generic/patches/kodi/kodi-100-revert-6f3a6fc.patch
+++ b/projects/Generic/patches/kodi/kodi-100-revert-6f3a6fc.patch
@@ -1,0 +1,103 @@
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index 06879dd..8b3541a 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -356,68 +356,6 @@ void CLinuxRendererGLES::Update()
+   ValidateRenderTarget();
+ }
+ 
+-void CLinuxRendererGLES::DrawBlackBars()
+-{
+-  CRect windowRect(0, 0, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
+-                   CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight());
+-
+-  auto quads = windowRect.SubtractRect(m_destRect);
+-
+-  struct Svertex
+-  {
+-    float x, y;
+-  };
+-
+-  std::vector<Svertex> vertices(6 * quads.size());
+-
+-  GLubyte count = 0;
+-  for (const auto& quad : quads)
+-  {
+-    vertices[count + 1].x = quad.x1;
+-    vertices[count + 1].y = quad.y1;
+-
+-    vertices[count + 0].x = vertices[count + 5].x = quad.x1;
+-    vertices[count + 0].y = vertices[count + 5].y = quad.y2;
+-
+-    vertices[count + 2].x = vertices[count + 3].x = quad.x2;
+-    vertices[count + 2].y = vertices[count + 3].y = quad.y1;
+-
+-    vertices[count + 4].x = quad.x2;
+-    vertices[count + 4].y = quad.y2;
+-
+-    count += 6;
+-  }
+-
+-  glDisable(GL_BLEND);
+-
+-  CRenderSystemGLES* renderSystem =
+-      dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+-  if (!renderSystem)
+-    return;
+-
+-  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_DEFAULT);
+-  GLint posLoc = renderSystem->GUIShaderGetPos();
+-  GLint uniCol = renderSystem->GUIShaderGetUniCol();
+-
+-  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+-
+-  GLuint vertexVBO;
+-  glGenBuffers(1, &vertexVBO);
+-  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+-  glBufferData(GL_ARRAY_BUFFER, sizeof(Svertex) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
+-
+-  glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, sizeof(Svertex), 0);
+-  glEnableVertexAttribArray(posLoc);
+-
+-  glDrawArrays(GL_TRIANGLES, 0, vertices.size());
+-
+-  glDisableVertexAttribArray(posLoc);
+-  glBindBuffer(GL_ARRAY_BUFFER, 0);
+-  glDeleteBuffers(1, &vertexVBO);
+-
+-  renderSystem->DisableGUIShader();
+-}
+-
+ void CLinuxRendererGLES::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
+ {
+   m_iYV12RenderBuffer = index;
+@@ -450,14 +388,9 @@ void CLinuxRendererGLES::RenderUpdate(int index, int index2, bool clear, unsigne
+ 
+   if (clear)
+   {
+-    if (alpha == 255)
+-      DrawBlackBars();
+-    else
+-    {
+-      glClearColor(m_clearColour, m_clearColour, m_clearColour, 0);
+-      glClear(GL_COLOR_BUFFER_BIT);
+-      glClearColor(0, 0, 0, 0);
+-    }
++    glClearColor(m_clearColour, m_clearColour, m_clearColour, 0);
++    glClear(GL_COLOR_BUFFER_BIT);
++    glClearColor(0,0,0,0);
+   }
+ 
+   if (alpha < 255)
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+index f9be67d..a638f6c 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+@@ -210,7 +210,4 @@ protected:
+   // clear colour for "black" bars
+   float m_clearColour{0.0f};
+   CRect m_viewRect;
+-
+-private:
+-  void DrawBlackBars();
+ };


### PR DESCRIPTION
This patch reverses commit [6f3a6fc2f737671f830f06748962083e9648cfcc](https://github.com/xbmc/xbmc/pull/18812/commits/6f3a6fc2f737671f830f06748962083e9648cfcc). This commit is causing GUI flickering during channel switching, as described [here](https://github.com/LibreELEC/LibreELEC.tv/issues/6180#issuecomment-1027400840) and [here](https://github.com/xbmc/xbmc/pull/18812#issuecomment-734903719).