### PR TITLE
Python3: fix elementtree crash in 3.10ff

### DIFF
--- a/packages/lang/Python3/patches/Python3-0600-pyexpat_revert_24061.patch
+++ b/packages/lang/Python3/patches/Python3-0600-pyexpat_revert_24061.patch
@@ -1,0 +1,109 @@
+From df132206a30bc952f9469aaabb6be59f6d285456 Mon Sep 17 00:00:00 2001
+From: mglae <mglmail@arcor.de>
+Date: Mon, 2 Jan 2023 15:03:02 +0100
+Subject: [PATCH] Revert "bpo-41798: pyexpat: Allocate the expat_CAPI on the
+ heap memory (GH-24061)"
+
+This reverts commit 7c83eaa536d2f436ae46211ca48692f576c732f0.
+
+_elementtree.c still having `static struct PyExpat_CAPI *expat_capi;` can crash
+because of use after free.
+---
+ Modules/pyexpat.c | 67 +++++++++++++++++++----------------------------
+ 1 file changed, 27 insertions(+), 40 deletions(-)
+
+diff --git a/Modules/pyexpat.c b/Modules/pyexpat.c
+index a971342222..a74d8046c4 100644
+--- a/Modules/pyexpat.c
++++ b/Modules/pyexpat.c
+@@ -1886,13 +1886,6 @@ add_features(PyObject *mod)
+ }
+ #endif
+ 
+-static void
+-pyexpat_destructor(PyObject *op)
+-{
+-    void *p = PyCapsule_GetPointer(op, PyExpat_CAPSULE_NAME);
+-    PyMem_Free(p);
+-}
+-
+ static int
+ pyexpat_exec(PyObject *mod)
+ {
+@@ -1980,46 +1973,40 @@ pyexpat_exec(PyObject *mod)
+     MYCONST(XML_PARAM_ENTITY_PARSING_ALWAYS);
+ #undef MYCONST
+ 
+-    struct PyExpat_CAPI *capi = PyMem_Calloc(1, sizeof(struct PyExpat_CAPI));
+-    if (capi == NULL) {
+-        PyErr_NoMemory();
+-        return -1;
+-    }
++    static struct PyExpat_CAPI capi;
+     /* initialize pyexpat dispatch table */
+-    capi->size = sizeof(*capi);
+-    capi->magic = PyExpat_CAPI_MAGIC;
+-    capi->MAJOR_VERSION = XML_MAJOR_VERSION;
+-    capi->MINOR_VERSION = XML_MINOR_VERSION;
+-    capi->MICRO_VERSION = XML_MICRO_VERSION;
+-    capi->ErrorString = XML_ErrorString;
+-    capi->GetErrorCode = XML_GetErrorCode;
+-    capi->GetErrorColumnNumber = XML_GetErrorColumnNumber;
+-    capi->GetErrorLineNumber = XML_GetErrorLineNumber;
+-    capi->Parse = XML_Parse;
+-    capi->ParserCreate_MM = XML_ParserCreate_MM;
+-    capi->ParserFree = XML_ParserFree;
+-    capi->SetCharacterDataHandler = XML_SetCharacterDataHandler;
+-    capi->SetCommentHandler = XML_SetCommentHandler;
+-    capi->SetDefaultHandlerExpand = XML_SetDefaultHandlerExpand;
+-    capi->SetElementHandler = XML_SetElementHandler;
+-    capi->SetNamespaceDeclHandler = XML_SetNamespaceDeclHandler;
+-    capi->SetProcessingInstructionHandler = XML_SetProcessingInstructionHandler;
+-    capi->SetUnknownEncodingHandler = XML_SetUnknownEncodingHandler;
+-    capi->SetUserData = XML_SetUserData;
+-    capi->SetStartDoctypeDeclHandler = XML_SetStartDoctypeDeclHandler;
+-    capi->SetEncoding = XML_SetEncoding;
+-    capi->DefaultUnknownEncodingHandler = PyUnknownEncodingHandler;
++    capi.size = sizeof(capi);
++    capi.magic = PyExpat_CAPI_MAGIC;
++    capi.MAJOR_VERSION = XML_MAJOR_VERSION;
++    capi.MINOR_VERSION = XML_MINOR_VERSION;
++    capi.MICRO_VERSION = XML_MICRO_VERSION;
++    capi.ErrorString = XML_ErrorString;
++    capi.GetErrorCode = XML_GetErrorCode;
++    capi.GetErrorColumnNumber = XML_GetErrorColumnNumber;
++    capi.GetErrorLineNumber = XML_GetErrorLineNumber;
++    capi.Parse = XML_Parse;
++    capi.ParserCreate_MM = XML_ParserCreate_MM;
++    capi.ParserFree = XML_ParserFree;
++    capi.SetCharacterDataHandler = XML_SetCharacterDataHandler;
++    capi.SetCommentHandler = XML_SetCommentHandler;
++    capi.SetDefaultHandlerExpand = XML_SetDefaultHandlerExpand;
++    capi.SetElementHandler = XML_SetElementHandler;
++    capi.SetNamespaceDeclHandler = XML_SetNamespaceDeclHandler;
++    capi.SetProcessingInstructionHandler = XML_SetProcessingInstructionHandler;
++    capi.SetUnknownEncodingHandler = XML_SetUnknownEncodingHandler;
++    capi.SetUserData = XML_SetUserData;
++    capi.SetStartDoctypeDeclHandler = XML_SetStartDoctypeDeclHandler;
++    capi.SetEncoding = XML_SetEncoding;
++    capi.DefaultUnknownEncodingHandler = PyUnknownEncodingHandler;
+ #if XML_COMBINED_VERSION >= 20100
+-    capi->SetHashSalt = XML_SetHashSalt;
++    capi.SetHashSalt = XML_SetHashSalt;
+ #else
+-    capi->SetHashSalt = NULL;
++    capi.SetHashSalt = NULL;
+ #endif
+ 
+     /* export using capsule */
+-    PyObject *capi_object = PyCapsule_New(capi, PyExpat_CAPSULE_NAME,
+-                                          pyexpat_destructor);
++    PyObject *capi_object = PyCapsule_New(&capi, PyExpat_CAPSULE_NAME, NULL);
+     if (capi_object == NULL) {
+-        PyMem_Free(capi);
+         return -1;
+     }
+ 
+-- 
+2.35.3
+


### PR DESCRIPTION
cpython's _elementtree.c can crash kodi by using addons, see https://github.com/xbmc/xbmc/issues/22344.

Revert causing commit until it is fixed upstream.

Upstream issue is https://github.com/python/cpython/issues/100689