### PR TITLE
[le10] update rpi-eeprom to latest default version

### DIFF
--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="d995c13dd99c8060fa61adebc5714a693166b01d"
-PKG_SHA256="b24f0e169d901c5aecec41ded7751436e72d0fd2a9620da6e5b3a466a2d755bb"
+PKG_VERSION="092f87659594a48cf52a18a6f2dee9ebf4dcaedf"
+PKG_SHA256="0d90a7317f56b7f4139fbeb9732c5c9922b2d749c8999a83b2615cad171ea06e"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="1197a4ae319e2ccf69e1b2e4c438f3fd68bd61ea"
-PKG_SHA256="1bd76310f1223bdfbdb999fd419629489f7ed22702b25e3712a0f6ff885e2ded"
+PKG_VERSION="9269d78320c542935a87f07675893537e672908d"
+PKG_SHA256="bd9572e5c716db4fb3f84297de9f9da5e0c871b779dccfedbd7a0dab93069dba"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="19362b763fe69582b469022042b55e586dfb343f"
-PKG_SHA256="89974db11b1fa3140af596049427b41f64988f37d5c3026a8cfc177a60abe6d9"
+PKG_VERSION="d995c13dd99c8060fa61adebc5714a693166b01d"
+PKG_SHA256="b24f0e169d901c5aecec41ded7751436e72d0fd2a9620da6e5b3a466a2d755bb"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="3f85bc0126e271c8b84b99842fcad746bc68f1fd"
-PKG_SHA256="a5b6eb3b4a694ab6c0fcb09d1e57aa6bc5678e0415140886861efb5291a2f646"
+PKG_VERSION="272d1573e37d12d1914bd652ae365baa039c8ff0"
+PKG_SHA256="c02ba6cec7d0cad88ee0469811e19c9bd93f800c3f370fdccab9eb4b0f97c9df"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="092f87659594a48cf52a18a6f2dee9ebf4dcaedf"
-PKG_SHA256="0d90a7317f56b7f4139fbeb9732c5c9922b2d749c8999a83b2615cad171ea06e"
+PKG_VERSION="1197a4ae319e2ccf69e1b2e4c438f3fd68bd61ea"
+PKG_SHA256="1bd76310f1223bdfbdb999fd419629489f7ed22702b25e3712a0f6ff885e2ded"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="272d1573e37d12d1914bd652ae365baa039c8ff0"
-PKG_SHA256="c02ba6cec7d0cad88ee0469811e19c9bd93f800c3f370fdccab9eb4b0f97c9df"
+PKG_VERSION="19362b763fe69582b469022042b55e586dfb343f"
+PKG_SHA256="89974db11b1fa3140af596049427b41f64988f37d5c3026a8cfc177a60abe6d9"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="2efe9daef66bbca33f6848a63355febe8681145a"
-PKG_SHA256="6e8b567155f16ccd2931b5cef107a4c5565a2b672172c0bee93b02983c30eb49"
+PKG_VERSION="3f85bc0126e271c8b84b99842fcad746bc68f1fd"
+PKG_SHA256="a5b6eb3b4a694ab6c0fcb09d1e57aa6bc5678e0415140886861efb5291a2f646"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="9269d78320c542935a87f07675893537e672908d"
-PKG_SHA256="bd9572e5c716db4fb3f84297de9f9da5e0c871b779dccfedbd7a0dab93069dba"
+PKG_VERSION="7bbbd9407fcef5af9a79cd82aa904f0bff1b5636"
+PKG_SHA256="1d5adf26178a47065a2a210c7db58c873991b48c392777ffddfb009518d292f2"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="7bbbd9407fcef5af9a79cd82aa904f0bff1b5636"
-PKG_SHA256="1d5adf26178a47065a2a210c7db58c873991b48c392777ffddfb009518d292f2"
+PKG_VERSION="e86fc31d7abc895d05361c95fc2a37b371d7a86f"
+PKG_SHA256="cc0338158854e963e007cccdef6a58ec8dfbacb600c4e64772c539da0685aa2c"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="e86fc31d7abc895d05361c95fc2a37b371d7a86f"
-PKG_SHA256="cc0338158854e963e007cccdef6a58ec8dfbacb600c4e64772c539da0685aa2c"
+PKG_VERSION="6e79e995bbc75c5fdd5305bd7fe029758cfade2f"
+PKG_SHA256="6ea9d62c7b04736d2f480ed9b35cba23a15c1bd6ae883fe795b546889ca68be5"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"


### PR DESCRIPTION
This is a backport of LE master and updates rpi-eeprom to the latest default version (2022-12-07)