### PR TITLE
[le10] lirc: backport fixes from master

### DIFF
--- a/packages/sysutils/lirc/patches/0006-lirc-gpio-ir-0.10.patch
+++ b/packages/sysutils/lirc/patches/0006-lirc-gpio-ir-0.10.patch
@@ -1,0 +1,178 @@
+Origin: https://github.com/neuralassembly/raspi/blob/master/lirc-gpio-ir-0.10.patch
+Bug-Debian: bugs.debian.org/931078
+
+diff -ruN lirc-0.10.1.orig/lib/config_file.c lirc-0.10.1/lib/config_file.c
+--- lirc-0.10.1.orig/lib/config_file.c	2017-09-10 17:52:19.000000000 +0900
++++ lirc-0.10.1/lib/config_file.c	2019-06-26 00:39:45.734320696 +0900
+@@ -71,7 +71,7 @@
+ typedef void* (*array_guest_func)(void* item, void* arg);
+ 
+ 
+-#define LINE_LEN 1024
++#define LINE_LEN 4096
+ #define MAX_INCLUDES 10
+ 
+ const char* whitespace = " \t";
+diff -ruN lirc-0.10.1.orig/lib/ir_remote.h lirc-0.10.1/lib/ir_remote.h
+--- lirc-0.10.1.orig/lib/ir_remote.h	2017-09-10 17:52:19.000000000 +0900
++++ lirc-0.10.1/lib/ir_remote.h	2019-06-26 00:39:45.714321224 +0900
+@@ -110,12 +110,17 @@
+ 
+ static inline int is_pulse(lirc_t data)
+ {
+-	return data & PULSE_BIT ? 1 : 0;
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_PULSE) ? 1 : 0;
+ }
+ 
+ static inline int is_space(lirc_t data)
+ {
+-	return !is_pulse(data);
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_SPACE) ? 1 : 0;
++}
++
++static inline int is_timeout(lirc_t data)
++{
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_TIMEOUT) ? 1 : 0;
+ }
+ 
+ static inline int has_repeat(const struct ir_remote* remote)
+diff -ruN lirc-0.10.1.orig/lib/irrecord.c lirc-0.10.1/lib/irrecord.c
+--- lirc-0.10.1.orig/lib/irrecord.c	2017-09-10 17:52:19.000000000 +0900
++++ lirc-0.10.1/lib/irrecord.c	2019-06-26 00:39:45.724320960 +0900
+@@ -1398,9 +1398,16 @@
+ 		state->retval = 0;
+ 		return STS_LEN_TIMEOUT;
+ 	}
++	if (is_timeout(state->data)) {
++		return STS_LEN_AGAIN;
++	}
+ 	state->count++;
+ 	if (state->mode == MODE_GET_GAP) {
+-		state->sum += state->data & PULSE_MASK;
++		if (state->sum != 0 || is_pulse(state->data)) {
++			state->sum += state->data & PULSE_MASK;
++		}else{
++			return STS_LEN_AGAIN;
++		}
+ 		if (state->average == 0 && is_space(state->data)) {
+ 			if (state->data > 100000) {
+ 				state->sum = 0;
+@@ -1472,6 +1479,10 @@
+ 		state->keypresses = lastmaxcount;
+ 		return STS_LEN_AGAIN;
+ 	} else if (state->mode == MODE_HAVE_GAP) {
++		if (state->count==1 && is_space(state->data))  {
++			state->count = 0;
++			return STS_LEN_AGAIN;
++		}
+ 		if (state->count <= MAX_SIGNALS) {
+ 			signals[state->count - 1] = state->data & PULSE_MASK;
+ 		} else {
+@@ -1510,7 +1521,7 @@
+ 			/* such long pulses may appear with
+ 			 * crappy hardware (receiver? / remote?)
+ 			 */
+-			else {
++			else if(is_pulse(state->data)) {
+ 				remote->gap = 0;
+ 				return STS_LEN_NO_GAP_FOUND;
+ 			}
+@@ -1811,22 +1822,24 @@
+ 
+ static int raw_data_ok(struct button_state* btn_state)
+ {
+-	int r;
++	int r = 0;
+ 	int ref;
+ 
+-	if (!is_space(btn_state->data)) {
++	if (is_pulse(btn_state->data)) {
+ 		r = 0;
+-	} else if (is_const(&remote)) {
+-		if (remote.gap > btn_state->sum) {
+-			ref = (remote.gap - btn_state->sum);
+-			ref *= (100 - remote.eps);
+-			ref /= 100;
++	} else if (is_space(btn_state->data)) {
++		if (is_const(&remote)) {
++			if (remote.gap > btn_state->sum) {
++				ref = (remote.gap - btn_state->sum);
++				ref *= (100 - remote.eps);
++				ref /= 100;
++			} else {
++				ref = 0;
++			}
++			r = btn_state->data > ref;
+ 		} else {
+-			ref = 0;
++			r = btn_state->data > (remote.gap * (100 - remote.eps)) / 100;
+ 		}
+-		r = btn_state->data > ref;
+-	} else {
+-		r = btn_state->data > (remote.gap * (100 - remote.eps)) / 100;
+ 	}
+ 	return r;
+ }
+@@ -1970,7 +1983,7 @@
+ 				btn_state->data = remote.gap;
+ 			}
+ 			if (btn_state->count == 0) {
+-				if (!is_space(btn_state->data)
++				if (is_pulse(btn_state->data)
+ 				    || btn_state->data <
+ 				    remote.gap - remote.gap * remote.eps /
+ 				    100) {
+diff -ruN lirc-0.10.1.orig/lib/lirc/ir_remote.h lirc-0.10.1/lib/lirc/ir_remote.h
+--- lirc-0.10.1.orig/lib/lirc/ir_remote.h	2017-09-10 17:52:58.000000000 +0900
++++ lirc-0.10.1/lib/lirc/ir_remote.h	2019-06-26 00:39:45.724320960 +0900
+@@ -110,12 +110,17 @@
+ 
+ static inline int is_pulse(lirc_t data)
+ {
+-	return data & PULSE_BIT ? 1 : 0;
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_PULSE) ? 1 : 0;
+ }
+ 
+ static inline int is_space(lirc_t data)
+ {
+-	return !is_pulse(data);
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_SPACE) ? 1 : 0;
++}
++
++static inline int is_timeout(lirc_t data)
++{
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_TIMEOUT) ? 1 : 0;
+ }
+ 
+ static inline int has_repeat(const struct ir_remote* remote)
+diff -ruN lirc-0.10.1.orig/tools/mode2.cpp lirc-0.10.1/tools/mode2.cpp
+--- lirc-0.10.1.orig/tools/mode2.cpp	2017-09-10 17:52:19.000000000 +0900
++++ lirc-0.10.1/tools/mode2.cpp	2019-06-26 00:45:38.840404976 +0900
+@@ -326,12 +326,24 @@
+ void print_mode2_data(unsigned int data)
+ {
+ 	static int bitno = 1;
++	static bool leading_space = true;
++	unsigned int msg = data & LIRC_MODE2_MASK;
+ 
+ 	switch (opt_dmode) {
+ 	case 0:
+-		printf("%s %u\n", (
+-			       data & PULSE_BIT) ? "pulse" : "space",
+-		       (uint32_t)(data & PULSE_MASK));
++		if (leading_space && msg == LIRC_MODE2_SPACE ) {
++			break;
++		} else {
++			leading_space = false;
++		}
++		if (msg == LIRC_MODE2_PULSE) {
++			printf("pulse %u\n", (__u32)(data & PULSE_MASK));
++		} else if (msg == LIRC_MODE2_SPACE) {
++			printf("space %u\n", (__u32)(data & PULSE_MASK));
++		} else if (msg == LIRC_MODE2_TIMEOUT) {
++			printf("timeout %u\n", (__u32)(data & PULSE_MASK));
++			leading_space = true;
++		}
+ 		break;
+ 	case 1: {
+ 		/* print output like irrecord raw config file data */

--- a/packages/sysutils/lirc/patches/lirc-0101-kernel-5.18-fix.patch
+++ b/packages/sysutils/lirc/patches/lirc-0101-kernel-5.18-fix.patch
@@ -1,0 +1,76 @@
+From 849858f47f1038c85ba5a5a61a787f8d872dbfad Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Mon, 18 Apr 2022 23:20:20 +0200
+Subject: [PATCH] remove dead feature code
+
+LIRC_CAN_SET_REC_FILTER and LIRC_CAN_NOTIFY_DECODE flags were removed
+in linux 5.18 as no driver implemented those features.
+
+Drop the dead code dealing with that to fix build.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ daemons/lircd.cpp        | 6 +-----
+ tools/lirc-lsplugins.cpp | 8 +++-----
+ 2 files changed, 4 insertions(+), 10 deletions(-)
+
+diff --git a/daemons/lircd.cpp b/daemons/lircd.cpp
+index d5be7088..eb48da23 100644
+--- a/daemons/lircd.cpp
++++ b/daemons/lircd.cpp
+@@ -485,8 +485,7 @@ static int setup_hardware(void)
+ 
+ 	if (curr_driver->fd != -1 && curr_driver->drvctl_func) {
+ 		if ((curr_driver->features & LIRC_CAN_SET_REC_CARRIER)
+-		    || (curr_driver->features & LIRC_CAN_SET_REC_TIMEOUT)
+-		    || (curr_driver->features & LIRC_CAN_SET_REC_FILTER)) {
++		    || (curr_driver->features & LIRC_CAN_SET_REC_TIMEOUT)) {
+ 				ret = setup_frequency() && setup_timeout();
+ 		}
+ 	}
+@@ -2066,9 +2065,6 @@ void loop(void)
+ 			const char* button_name;
+ 			int reps;
+ 
+-			if (curr_driver->drvctl_func && (curr_driver->features & LIRC_CAN_NOTIFY_DECODE))
+-				curr_driver->drvctl_func(DRVCTL_NOTIFY_DECODE, NULL);
+-
+ 			get_release_data(&remote_name, &button_name, &reps);
+ 
+ 			input_message(message, remote_name, button_name, reps, 0);
+diff --git a/tools/lirc-lsplugins.cpp b/tools/lirc-lsplugins.cpp
+index ba67a3cb..79c61792 100644
+--- a/tools/lirc-lsplugins.cpp
++++ b/tools/lirc-lsplugins.cpp
+@@ -57,8 +57,7 @@
+ 	"#    c: LIRC_CAN_SET_SEND_CARRIER\n" \
+ 	"#    d: LIRC_CAN_SET_SEND_DUTY_CYCLE\n" \
+ 	"#    t: LIRC_CAN_SET_TRANSMITTER_MASK\n" \
+-	"#    C: LIRC_CAN_MEASURE_CARRIER\n" \
+-	"#    D: LIRC_CAN_NOTIFY_DECODE\n"
++	"#    C: LIRC_CAN_MEASURE_CARRIER\n"
+ 
+ const struct option options[] = {
+ 	{ "plugindir",	  required_argument, NULL, 'U' },
+@@ -291,7 +290,7 @@ static void format_features(struct driver* hw, line_t* line)
+ 	char buff[256];
+ 
+ 	snprintf(buff, sizeof(buff),
+-		 "%c%c%c%c%c%c%c%c%c%c%c%c%c ",
++		 "%c%c%c%c%c%c%c%c%c%c%c%c ",
+ 		 get(LIRC_CAN_SEND_RAW, 'R', hw),
+ 		 get(LIRC_CAN_SEND_PULSE, 'P', hw),
+ 		 get(LIRC_CAN_SEND_MODE2, 'M', hw),
+@@ -303,8 +302,7 @@ static void format_features(struct driver* hw, line_t* line)
+ 		 get(LIRC_CAN_SET_SEND_CARRIER, 'c', hw),
+ 		 get(LIRC_CAN_SET_SEND_DUTY_CYCLE, 'd', hw),
+ 		 get(LIRC_CAN_SET_TRANSMITTER_MASK, 't', hw),
+-		 get(LIRC_CAN_MEASURE_CARRIER, 'C', hw),
+-		 get(LIRC_CAN_NOTIFY_DECODE, 'D', hw)
++		 get(LIRC_CAN_MEASURE_CARRIER, 'C', hw)
+ 		 );
+ 	line->features = strdup(buff);
+ }
+-- 
+2.30.2
+


### PR DESCRIPTION
This is a backport of https://github.com/LibreELEC/LibreELEC.tv/pull/6419 which I should have PR'ed about half a year ago but somehow managed to slip through.

The Debian gpio-ir patch fixes irrecord not working properly with 5.10 (and later kernels)