### PR TITLE
nextpvr: add default settings file

### DIFF
--- a/packages/addons/service/nextpvr/changelog.txt
+++ b/packages/addons/service/nextpvr/changelog.txt
@@ -1,1 +1,5 @@
+1
+Fix for variables that aren't initialized by Kodi
+
+0
 initial release

--- a/packages/addons/service/nextpvr/package.mk
+++ b/packages/addons/service/nextpvr/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="nextpvr"
 PKG_VERSION="6.1.1~Nexus"
-PKG_ADDON_VERSION="6.1.1"
-PKG_REV="0"
+PKG_ADDON_VERSION="6.1.1~1"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="NextPVR"
 PKG_SITE="https://nextpvr.com"

--- a/packages/addons/service/nextpvr/source/bin/nextpvr-downloader
+++ b/packages/addons/service/nextpvr/source/bin/nextpvr-downloader
@@ -9,7 +9,8 @@ oe_setup_addon service.nextpvr
 ICON="${ADDON_DIR}/resources/icon.png"
 CONTROL_FILE="/tmp/curl.nextpvr.done"
 DATA_FILE="/tmp/curl.nextpvr.data"
-NEXTPVR_FILE="NPVR-@NEXTPVR_VERSION@.zip"
+NEXTPVR_VERSION="@NEXTPVR_VERSION@"
+NEXTPVR_FILE="NPVR-${NEXTPVR_VERSION%~*}.zip"
 
 # check for enough free disk space
 if [ $(df . | awk 'END {print $4}') -lt 400000 ]; then
@@ -39,7 +40,7 @@ echo "Downloading NextPVR"
 # download NextPVR
 rm -f ${CONTROL_FILE} ${DATA_FILE}
 (
-  curl -# -O -C - https://nextpvr.com/stable/linux/${NEXTPVR_FILE} 2>${DATA_FILE}
+  curl -L -# -O -C - https://github.com/sub3/releases/releases/download/${NEXTPVR_VERSION}%~*/${NEXTPVR_FILE}  2>${DATA_FILE}
   touch ${CONTROL_FILE}
 ) |
   while [ : ]; do

--- a/packages/addons/service/nextpvr/source/settings-default.xml
+++ b/packages/addons/service/nextpvr/source/settings-default.xml
@@ -1,0 +1,4 @@
+<settings version="2">
+    <setting id="waitfor" default="true">5</setting>
+    <setting id="satiprtsp" default="true">554</setting>
+</settings>


### PR DESCRIPTION
Kodi doesn't pass environment variables to the startup script unless the user saves a configuration via settings configuration, even if it is defaults.  The service starts before the user has a chance to save settings and the setting for the NextPVR service are optional.

<del>Ideally Kodi should pass the default values from the global settings.xml</del>  

As pointed out by @mglae the reason for this issue is the addon wasn't including settings-default.xml.  This PR adds the required file.