### PR TITLE
linux (Allwinner): Bluetooth: btrtl: Add support for RTL8822BS UART

### DIFF
--- a/packages/linux-firmware/wlan-firmware/package.mk
+++ b/packages/linux-firmware/wlan-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="wlan-firmware"
-PKG_VERSION="4d3eab2b6a581a96acddc99a6c24a1308fe1d3ad"
-PKG_SHA256="a26dcdf9bd3ecaa38870f5f94c75a4d027d3a58bbeae6f965cc457842b34dcd7"
+PKG_VERSION="1a59915bf0dcf8f43bc05d8bcc2da112a2743295"
+PKG_SHA256="4b77e9bccdbd1b7e5f79c995e7f568c7b04031c34eb422a61c92bc5b6837ebe9"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/wlan-firmware"
 PKG_URL="https://github.com/LibreELEC/wlan-firmware/archive/${PKG_VERSION}.tar.gz"

--- a/projects/Allwinner/patches/linux/0101-Bluetooth-Add-new-quirk-for-broken-local-ext-features.patch
+++ b/projects/Allwinner/patches/linux/0101-Bluetooth-Add-new-quirk-for-broken-local-ext-features.patch
@@ -1,0 +1,74 @@
+From: Bastian Germann <bage@debian.org>
+To: Rob Herring <robh+dt@kernel.org>,
+        Maxime Ripard <mripard@kernel.org>,
+        Chen-Yu Tsai <wens@csie.org>,
+        Marcel Holtmann <marcel@holtmann.org>,
+        Johan Hedberg <johan.hedberg@gmail.com>,
+        "David S . Miller" <davem@davemloft.net>,
+        Jakub Kicinski <kubakici@wp.pl>, devicetree@vger.kernel.org,
+        linux-arm-kernel@lists.infradead.org, linux-kernel@vger.kernel.org,
+        linux-bluetooth@vger.kernel.org, netdev@vger.kernel.org
+Cc: Vasily Khoruzhick <anarsoul@gmail.com>,
+        Bastian Germann <bage@debian.org>
+Message-ID: <20220524212155.16944-2-bage@debian.org>
+Subject: [PATCH v2 1/3] Bluetooth: Add new quirk for broken local ext features
+ max_page
+Date: Tue, 24 May 2022 23:21:52 +0200
+X-Mailer: git-send-email 2.36.1
+In-Reply-To: <20220524212155.16944-1-bage@debian.org>
+References: <20220524212155.16944-1-bage@debian.org>
+MIME-Version: 1.0
+Precedence: bulk
+List-ID: <netdev.vger.kernel.org>
+X-Mailing-List: netdev@vger.kernel.org
+X-Patchwork-Delegate: kuba@kernel.org
+
+From: Vasily Khoruzhick <anarsoul@gmail.com>
+
+Some adapters (e.g. RTL8723CS) advertise that they have more than
+2 pages for local ext features, but they don't support any features
+declared in these pages. RTL8723CS reports max_page = 2 and declares
+support for sync train and secure connection, but it responds with
+either garbage or with error in status on corresponding commands.
+
+Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
+[rebase on current tree]
+Signed-off-by: Bastian Germann <bage@debian.org>
+---
+ include/net/bluetooth/hci.h | 7 +++++++
+ net/bluetooth/hci_event.c   | 4 +++-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/include/net/bluetooth/hci.h b/include/net/bluetooth/hci.h
+index 69ef31cea582..af26e8051905 100644
+--- a/include/net/bluetooth/hci.h
++++ b/include/net/bluetooth/hci.h
+@@ -265,6 +265,13 @@ enum {
+ 	 * during the hdev->setup vendor callback.
+ 	 */
+ 	HCI_QUIRK_BROKEN_MWS_TRANSPORT_CONFIG,
++
++	/* When this quirk is set, max_page for local extended features
++	 * is set to 1, even if controller reports higher number. Some
++	 * controllers (e.g. RTL8822BS, RTL8723CS) report more pages,
++	 * but they don't actually support features declared there.
++	 */
++	HCI_QUIRK_BROKEN_LOCAL_EXT_FTR_MAX_PAGE,
+ };
+ 
+ /* HCI device flags */
+diff --git a/net/bluetooth/hci_event.c b/net/bluetooth/hci_event.c
+index 66451661283c..52b358c33344 100644
+--- a/net/bluetooth/hci_event.c
++++ b/net/bluetooth/hci_event.c
+@@ -837,7 +837,9 @@ static u8 hci_cc_read_local_ext_features(struct hci_dev *hdev, void *data,
+ 	if (rp->status)
+ 		return rp->status;
+ 
+-	if (hdev->max_page < rp->max_page)
++	if (!test_bit(HCI_QUIRK_BROKEN_LOCAL_EXT_FTR_MAX_PAGE,
++		      &hdev->quirks) &&
++	    hdev->max_page < rp->max_page)
+ 		hdev->max_page = rp->max_page;
+ 
+ 	if (rp->page < HCI_MAX_PAGES)

--- a/projects/Allwinner/patches/linux/0102-Bluetooth-btrtl-Add-support-for-RTL8822BS-UART.patch
+++ b/projects/Allwinner/patches/linux/0102-Bluetooth-btrtl-Add-support-for-RTL8822BS-UART.patch
@@ -1,0 +1,63 @@
+From db71696da000fd8cc7db992940fcb922e771b3d0 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 8 Jan 2023 04:22:27 +0000
+Subject: [PATCH 1/2] Bluetooth: btrtl: Add support for RTL8822BS UART
+
+Add a RTL8822BS UART with hci_ver = 0x07. This is similar to RTL8822CS
+observed on the Tanix TX6 Android set-top box. But the previous
+generation of chip.
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ drivers/bluetooth/btrtl.c  | 10 +++++++++-
+ drivers/bluetooth/hci_h5.c |  6 ++++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/bluetooth/btrtl.c b/drivers/bluetooth/btrtl.c
+index fb52313a1d45..011857e303b6 100644
+--- a/drivers/bluetooth/btrtl.c
++++ b/drivers/bluetooth/btrtl.c
+@@ -174,7 +174,15 @@ static const struct id_table ic_id_table[] = {
+ 	  .fw_name  = "rtl_bt/rtl8822cu_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8822cu_config" },
+ 
+-	/* 8822B */
++	/* 8822BS with UART interface */
++	{ IC_INFO(RTL_ROM_LMP_8822B, 0xb, 0x7, HCI_UART),
++	  .config_needed = true,
++	  .has_rom_version = true,
++	  .has_msft_ext = true,
++	  .fw_name  = "rtl_bt/rtl8822bs_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8822bs_config" },
++
++	/* 8822BU with USB interface */
+ 	{ IC_INFO(RTL_ROM_LMP_8822B, 0xb, 0x7, HCI_USB),
+ 	  .config_needed = true,
+ 	  .has_rom_version = true,
+diff --git a/drivers/bluetooth/hci_h5.c b/drivers/bluetooth/hci_h5.c
+index c5a0409ef84f..a8bc2097bc2c 100644
+--- a/drivers/bluetooth/hci_h5.c
++++ b/drivers/bluetooth/hci_h5.c
+@@ -1068,6 +1068,10 @@ static struct h5_vnd rtl_vnd = {
+ 	.acpi_gpio_map	= acpi_btrtl_gpios,
+ };
+ 
++static const struct h5_device_data h5_data_rtl8822bs = {
++	.vnd = &rtl_vnd,
++};
++
+ static const struct h5_device_data h5_data_rtl8822cs = {
+ 	.vnd = &rtl_vnd,
+ };
+@@ -1096,6 +1100,8 @@ static const struct dev_pm_ops h5_serdev_pm_ops = {
+ 
+ static const struct of_device_id rtl_bluetooth_of_match[] = {
+ #ifdef CONFIG_BT_HCIUART_RTL
++	{ .compatible = "realtek,rtl8822bs-bt",
++	  .data = (const void *)&h5_data_rtl8822bs },
+ 	{ .compatible = "realtek,rtl8822cs-bt",
+ 	  .data = (const void *)&h5_data_rtl8822cs },
+ 	{ .compatible = "realtek,rtl8723bs-bt",
+-- 
+2.25.1
+

--- a/projects/Allwinner/patches/linux/0103-arm64-dts-allwinner-h6-tanix-tx6-Add-compatible-blue.patch
+++ b/projects/Allwinner/patches/linux/0103-arm64-dts-allwinner-h6-tanix-tx6-Add-compatible-blue.patch
@@ -1,0 +1,30 @@
+From ff42342f60874ac772edc5e5af25836b1d304a3d Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 9 Jan 2023 00:35:55 +0000
+Subject: [PATCH 2/2] arm64: dts: allwinner: h6: tanix-tx6: Add compatible
+ bluetooth
+
+Tanix TX6 comes either with RTL8822BS or RTL8822CS wifi+bt combo module.
+Add compatible for RTL8822BS as it uses different firmware.
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
+index 9a38ff9b3fc7..9460ccbc247d 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-tanix-tx6.dts
+@@ -21,7 +21,7 @@ &uart1 {
+ 	status = "okay";
+ 
+ 	bluetooth {
+-		compatible = "realtek,rtl8822cs-bt";
++		compatible = "realtek,rtl8822bs-bt", "realtek,rtl8822cs-bt";
+ 		device-wake-gpios = <&r_pio 1 2 GPIO_ACTIVE_HIGH>; /* PM2 */
+ 		host-wake-gpios = <&r_pio 1 1 GPIO_ACTIVE_HIGH>; /* PM1 */
+ 		enable-gpios = <&r_pio 1 4 GPIO_ACTIVE_HIGH>; /* PM4 */
+-- 
+2.25.1
+

--- a/projects/Allwinner/patches/linux/0104-Bluetooth-btrtl-set-HCI_QUIRK_BROKEN_LOCAL_EXT_FTR_M.patch
+++ b/projects/Allwinner/patches/linux/0104-Bluetooth-btrtl-set-HCI_QUIRK_BROKEN_LOCAL_EXT_FTR_M.patch
@@ -1,0 +1,26 @@
+From 2dafb9ddd4488521026d4a29e49164f1df108cef Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 9 Jan 2023 07:47:01 +0000
+Subject: [PATCH] Bluetooth: btrtl: set HCI_QUIRK_BROKEN_LOCAL_EXT_FTR_MAX_PAGE
+ for  RTL8822BS
+
+---
+ drivers/bluetooth/btrtl.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/bluetooth/btrtl.c b/drivers/bluetooth/btrtl.c
+index 011857e303b6..c889b405c9aa 100644
+--- a/drivers/bluetooth/btrtl.c
++++ b/drivers/bluetooth/btrtl.c
+@@ -791,6 +791,8 @@ void btrtl_set_quirks(struct hci_dev *hdev, struct btrtl_device_info *btrtl_dev)
+ 		set_bit(HCI_QUIRK_WIDEBAND_SPEECH_SUPPORTED, &hdev->quirks);
+ 		hci_set_aosp_capable(hdev);
+ 		break;
++	case CHIP_ID_8822B:
++		set_bit(HCI_QUIRK_BROKEN_LOCAL_EXT_FTR_MAX_PAGE, &hdev->quirks);
+ 	default:
+ 		rtl_dev_dbg(hdev, "Central-peripheral role not enabled.");
+ 		rtl_dev_dbg(hdev, "WBS supported not enabled.");
+-- 
+2.25.1
+


### PR DESCRIPTION
Found in some variants of Tanix TX6

Before:
[    7.512876] rtw_8822bs mmc2:0001:1: Firmware version 27.2.0, H2C version 13
[    8.219545] Bluetooth: hci0: RTL: examining hci_ver=07 hci_rev=000b lmp_ver=07 lmp_subver=8822
[    8.430833] Bluetooth: hci0: RTL: examining hci_ver=07 hci_rev=000b lmp_ver=07 lmp_subver=8822
[    8.430866] Bluetooth: hci0: RTL: unknown IC info, lmp subver 8822, hci rev 000b, hci ver 0007
After:
[    8.958224] rtw_8822bs mmc2:0001:1: Firmware version 27.2.0, H2C version 13
[    9.017294] Bluetooth: hci0: RTL: examining hci_ver=07 hci_rev=000b lmp_ver=07 lmp_subver=8822
[    9.021399] Bluetooth: hci0: RTL: rom_version status=0 version=2
[    9.021428] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822bs_fw.bin
[    9.024180] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822bs_config.bin
[    9.048050] Bluetooth: hci0: RTL: cfg_sz 75, total sz 24543
[   10.316891] Bluetooth: hci0: RTL: fw version 0xaa89f793