### PR TITLE
Intel Updates (minors)

### DIFF
--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva-utils"
-PKG_VERSION="2.17.0"
-PKG_SHA256="607447143f08c6221f3bd5ab7aad874a4e220b6e04254b67433a7b2e97ff98ba"
+PKG_VERSION="2.17.1"
+PKG_SHA256="6ea5993c3eba230a979fa9d35b4cad8df06d4474a773dc0918033bf50353f966"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"
 PKG_URL="https://github.com/intel/libva-utils/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.3.2"
-PKG_SHA256="f725fbb4291ab67bbc7b31e1a268f523df384667360c931b40144db861be53d7"
+PKG_VERSION="22.3.3"
+PKG_SHA256="86651bd2803c9f0afd82471bec784e65d2b418dee315a053d22215eb2a679be7"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.6.5"
-PKG_SHA256="cbb6a514564f8c3349b1f78fc0906b636ea2074d7605cb0e820c5b727ce88cdc"
+PKG_VERSION="22.6.6"
+PKG_SHA256="b553290e829dfd824eb62295c9f07dbe8062ce7998f7c527cc92856d0792562d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
media-driver: update to 22.6.6
- 1 revert for Discrete Intel DG/ARC cards
- https://github.com/intel/media-driver/commit/3c2063c6af0c2d2f994d79957a67bde978c722ec 
- https://github.com/intel/media-driver/compare/intel-media-22.6.5...intel-media-22.6.6

gmmlib: update to 22.3.3
- https://github.com/intel/gmmlib/compare/intel-gmmlib-22.3.2...intel-gmmlib-22.3.3

libva-utils: update to 2.17.1
- https://github.com/intel/libva-utils/compare/2.17.0...2.17.1