### PR TITLE
fix cross-compile simplejson

### DIFF
--- a/packages/python/system/simplejson/package.mk
+++ b/packages/python/system/simplejson/package.mk
@@ -14,6 +14,7 @@ PKG_TOOLCHAIN="manual"
 
 pre_make_target() {
   export PYTHONXCPREFIX="${SYSROOT_PREFIX}/usr"
+  export LDSHARED="${CC} -shared"
 }
 
 make_target() {


### PR DESCRIPTION
Compiling the c-extention currently fails, making simplejson fallback to the pure pyton implementation.
Adding the export makes sure the correct compiler is called.

These two package do the same:
`packages/python/graphics/Pillow/package.mk` and `packages/python/security/pycryptodome/package.mk`

Looks like the missing export was lost here: `simplejson: convert to new package format `
https://github.com/LibreELEC/LibreELEC.tv/commit/7cc5c21dd0264610e219569c4d96697711357055


