### PR TITLE
go: update to 1.19.5

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.19.4"
-PKG_SHA256="b8f2440f7835eccf93684450268b0cb1bfa5ad3f4724c8ba0c1ae6cd0886f23d"
+PKG_VERSION="1.19.5"
+PKG_SHA256="1c24a6a2bf71d64d0ca8e228028d6108521f06b6edc7bf6b34ed6d767a795809"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes
- https://go.dev/doc/devel/release#go1.19.minor