### PR TITLE
rust: update to 1.66.1

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cargo-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="bede77d09248fbcf036ff54ab84768696cdb093d52fb3653b77eeb05dac2b464"
+PKG_SHA256="a636f83eb2327a66f484b9592ab305c6642df16fc80d0d1cb727e766a60da904"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rust-std-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="c59ca7959a019f3f660c1f46bea3c13e7769b67732731469c0c42d02f28d08e7"
+PKG_SHA256="c5e2c9b160bd8d99514f13cfbc0e42a722fd9ca14e6aaca4b9b77731a7a48377"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.66.0"
-PKG_SHA256="3b3cd3ea5a82a266e75d0b35f0b54c16021576d9eb78d384052175a772935a48"
+PKG_VERSION="1.66.1"
+PKG_SHA256="5b3c933a94c72187705d4ee293198babfdd09442f5937fbd685db3a81f4959ba"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rustc-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="5d76d653a745cbefcdc13e3976a3e56798af5ca98bf102bb317a0e61702ab90c"
+PKG_SHA256="242855e2626860aede6957dc56481cc02acf8cad12fa5bbbcbd93f9c51f0b3ad"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"


### PR DESCRIPTION
release notes:
- https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1661-2023-01-10
- https://blog.rust-lang.org/2023/01/10/Rust-1.66.1.html