### PR TITLE
options: allow using  ADDITIONAL_DRIVERS and ADDITIONAL_PACKAGES of distribution

### DIFF
--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -124,7 +124,7 @@
     SWAP_SUPPORT="no"
 
   # additional packages to install
-    ADDITIONAL_PACKAGES=""
+    ADDITIONAL_PACKAGES+=""
 
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"

--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -46,7 +46,7 @@
     KODI_DVDCSS_SUPPORT="no"
 
   # additional drivers to install
-    ADDITIONAL_DRIVERS=""
+    ADDITIONAL_DRIVERS+=""
 
   # build and install bluetooth support (yes / no)
     BLUETOOTH_SUPPORT="no"

--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -63,4 +63,4 @@
     DEBUG_TTY="/dev/console"
 
   # additional packages to install:
-    ADDITIONAL_PACKAGES="dt-overlays"
+    ADDITIONAL_PACKAGES+=" dt-overlays"

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -75,7 +75,7 @@
     DRIVER_ADDONS="crazycat dvb-latest"
 
   # additional packages to install:
-    ADDITIONAL_PACKAGES="dtc ethmactool emmctool flashrom"
+    ADDITIONAL_PACKAGES+=" dtc ethmactool emmctool flashrom"
 
   # use the kernel CEC framework for libcec (yes / no)
     CEC_FRAMEWORK_SUPPORT="yes"

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -63,8 +63,8 @@
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
-  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS=""
+  # e.g. ADDITIONAL_DRIVERS+=" DRIVER1 DRIVER2"
+    ADDITIONAL_DRIVERS+=""
 
   # build and install driver addons (yes / no)
     DRIVER_ADDONS_SUPPORT="no"

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -59,8 +59,8 @@
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
-  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm_sta"
+  # e.g. ADDITIONAL_DRIVERS+=" DRIVER1 DRIVER2"
+    ADDITIONAL_DRIVERS+=" bcm_sta"
 
   # build and install driver addons (yes / no)
     DRIVER_ADDONS_SUPPORT="no"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -106,8 +106,8 @@
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
-  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS bcm2835-driver"
+  # e.g. ADDITIONAL_DRIVERS+=" DRIVER1 DRIVER2"
+    ADDITIONAL_DRIVERS+=" bcm2835-driver"
 
     if [ "${ALSA_SUPPORT}" = "yes" ]; then
       ADDITIONAL_DRIVERS+=" rpi-cirrus-config"

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -62,7 +62,7 @@
     FIRMWARE="misc-firmware wlan-firmware dvb-firmware brcmfmac_sdio-firmware"
 
   # additional packages to install
-    ADDITIONAL_PACKAGES="dtc"
+    ADDITIONAL_PACKAGES+=" dtc"
 
   # build and install CEC framework support (yes / no)
     CEC_FRAMEWORK_SUPPORT="yes"

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -64,8 +64,8 @@
 
   # additional packages to install:
   # Space separated list is supported,
-  # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
-    ADDITIONAL_PACKAGES="dtc emmctool"
+  # e.g. ADDITIONAL_PACKAGES+=" PACKAGE1 PACKAGE2"
+    ADDITIONAL_PACKAGES+=" dtc emmctool"
 
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -70,8 +70,8 @@
   # additional drivers to install:
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
-  # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS=""
+  # e.g. ADDITIONAL_DRIVERS+=" DRIVER1 DRIVER2"
+    ADDITIONAL_DRIVERS+=""
 
   # build and install driver addons (yes / no)
     DRIVER_ADDONS_SUPPORT="no"


### PR DESCRIPTION
Some project's option files do erase ADDITIONAL_DRIVERS and/or ADDITIONAL_PACKAGES.

Packages RTL8192DU and  RTL8812AU of ADDITIONAL_DRIVERS are not build on these projects. Furthermore  ADDITIONAL_PACKAGES cannot be used in distribution either.

Fixes #7375
