### PR TITLE
llvm: update to 15.0.7

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="15.0.6"
-PKG_SHA256="9d53ad04dc60cb7b30e810faf64c5ab8157dadef46c8766f67f286238256ff92"
+PKG_VERSION="15.0.7"
+PKG_SHA256="8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
 PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION}.src.tar.xz"

--- a/packages/lang/llvm/patches/llvm-15.0.0-D108864-misleading-indentation.patch
+++ b/packages/lang/llvm/patches/llvm-15.0.0-D108864-misleading-indentation.patch
@@ -1,0 +1,17 @@
+diff --git a/llvm/cmake/modules/HandleLLVMOptions.cmake b/llvm/cmake/modules/HandleLLVMOptions.cmake
+--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
++++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
+@@ -789,7 +789,11 @@
+   add_flag_if_supported("-Wstring-conversion" STRING_CONVERSION_FLAG)
+ 
+   # Prevent bugs that can happen with llvm's brace style.
+-  add_flag_if_supported("-Wmisleading-indentation" MISLEADING_INDENTATION_FLAG)
++  if (CMAKE_COMPILER_IS_GNUCXX)
++    add_flag_if_supported("-Wno-misleading-indentation" MISLEADING_INDENTATION_FLAG)
++  else()
++    add_flag_if_supported("-Wmisleading-indentation" MISLEADING_INDENTATION_FLAG)
++  endif()
+ endif (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
+ 
+ if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND NOT LLVM_ENABLE_WARNINGS)
+


### PR DESCRIPTION
add patch to "not warn" during build for missing indentation.
- https://reviews.llvm.org/D108864

release notes
- https://discourse.llvm.org/t/llvm-15-0-7-release/67638