### PR TITLE
systemd: build with -Defi=true on Generic

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -79,7 +79,6 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dhwdb=true \
                        -Drfkill=false \
                        -Dldconfig=false \
-                       -Defi=false \
                        -Dtpm=false \
                        -Dima=false \
                        -Dsmack=false \
@@ -101,6 +100,12 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dumount-path=/usr/bin/umount \
                        -Ddebug-tty=${DEBUG_TTY} \
                        -Dversion-tag=${PKG_VERSION}"
+
+if [ "${PROJECT}" = "Generic" ]; then
+  PKG_MESON_OPTS_TARGET+=" -Defi=true"
+else
+  PKG_MESON_OPTS_TARGET+=" -Defi=false"
+fi
 
 pre_configure_target() {
   export TARGET_CFLAGS="${TARGET_CFLAGS} -fno-schedule-insns -fno-schedule-insns2 -Wno-format-truncation"


### PR DESCRIPTION
With kernel 6.0 the legacy efi vars interface at /sys/firmware/efi/vars was removed (https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit?h=v6.0&id=0f5b2c69a4cbe4166ca24b76d5ada98ed2867741).

The efibootmgr tool requires now to mount the efivarfs pseudo-filesystem on /sys/firmware/efi/efivars. Enabling upstream EFI support for systemd is the easiest way to get it mounted on EFI systems but still having correct (non-)support for legacy boot.

No additional files are added to the image.