### PR TITLE
installer: fix device detection with pmbr_boot flag set

### DIFF
--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -78,7 +78,7 @@ get_device_unmount() {
   # provides: DEVICES
 
   DEVICES=""
-  DEVICES=$(parted -s -m -l 2>/dev/null | grep -E '^/dev/sd|^/dev/mmcblk|^/dev/nvme' | grep -E -v '.?rpmb|.?boot?' | cut -f1 -d ":")
+  DEVICES=$(parted -s -m -l 2>/dev/null | grep -E '^/dev/sd|^/dev/mmcblk|^/dev/nvme' | grep -E -v '^[^:]*rpmb|^[^:]*boot' | cut -f1 -d ":")
 
   for i in $(cat /proc/mounts | grep -E '^/dev/sd' | cut -f1 -d " " | sed "s/[0-9].*$//"); do
     DEVICES=$(echo $DEVICES | sed -e "s|$i||")


### PR DESCRIPTION
Installer failure was reported with logs in the [forum](https://forum.libreelec.tv/thread/26485-unable-to-install-no-devices-x86-64l). Fixes #7380

Failing on e.g. "/dev/sda:512GB:scsi:512:512:gpt:ATA Samsung SSD 850:pmbr_boot;"

Fixed by only matching the device name when removing rpmb and boot devices

RE was added for MMC support in #9d1d032 and removes special MMC areas like /dev/mmcblk0rmpb or /dev/mmcblk0boot1