### PR TITLE
misc packages updates

### DIFF
--- a/packages/audio/libsndfile/package.mk
+++ b/packages/audio/libsndfile/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libsndfile"
-PKG_VERSION="1.1.0"
-PKG_SHA256="642a876bd61b63f9346628dba5f8a0356a3ad750c7f6f42019d26ce60ba6a15b"
+PKG_VERSION="1.2.0"
+PKG_SHA256="0e30e7072f83dc84863e2e55f299175c7e04a5902ae79cfb99d4249ee8f6d60a"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://libsndfile.github.io/libsndfile/"
-PKG_URL="https://github.com/libsndfile/libsndfile/archive/${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/libsndfile/libsndfile/releases/download/${PKG_VERSION}/libsndfile-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain alsa-lib flac libogg libvorbis opus"
 PKG_LONGDESC="A C library for reading and writing sound files containing sampled audio data."
 PKG_BUILD_FLAGS="+pic"

--- a/packages/devel/mpfr/package.mk
+++ b/packages/devel/mpfr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpfr"
-PKG_VERSION="4.1.1"
-PKG_SHA256="ffd195bd567dbaffc3b98b23fd00aad0537680c9896171e44fe3ff79e28ac33d"
+PKG_VERSION="4.2.0"
+PKG_SHA256="06a378df13501248c1b2db5aa977a2c8126ae849a9d9b7be2546fb4a9c26d993"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.mpfr.org/"
 PKG_URL="http://ftpmirror.gnu.org/mpfr/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ncurses"
-PKG_VERSION="6.3"
-PKG_SHA256="97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059"
+PKG_VERSION="6.4"
+PKG_SHA256="6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.gnu.org/software/ncurses/"
 PKG_URL="http://invisible-mirror.net/archives/ncurses/ncurses-${PKG_VERSION}.tar.gz"

--- a/packages/devel/ncurses/patches/ncurses-004-fix_configure_pkgconfig.patch
+++ b/packages/devel/ncurses/patches/ncurses-004-fix_configure_pkgconfig.patch
@@ -3,11 +3,11 @@ Fix configure option --with-pkg-config-libdir is broken for cross compilation
 --- a/configure	2021-10-17 17:12:23.000000000 +0200
 +++ b/configure	2021-11-26 00:27:00.224815736 +0100
 @@ -4229,7 +4229,7 @@ echo $ECHO_N "checking for first directo
- cf_pkg_config_path=none
- for cf_config in $cf_search_path
- do
--	if test -d "$cf_config"
-+	if test -n "$cf_config"
- 	then
- 		cf_pkg_config_path=$cf_config
- 		break
+ 	cf_pkg_config_path=none
+ 	for cf_config in $cf_search_path
+ 	do
+-		if test -d "$cf_config"
++		if test -n "$cf_config"
+ 		then
+ 			cf_pkg_config_path=$cf_config
+ 			break

--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nano"
-PKG_VERSION="7.1"
-PKG_SHA256="57ba751e9b7519f0f6ddee505202e387c75dde440c1f7aa1b9310cc381406836"
+PKG_VERSION="7.2"
+PKG_SHA256="86f3442768bd2873cec693f83cdf80b4b444ad3cc14760b74361474fc87a4526"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.nano-editor.org/"
 PKG_URL="https://www.nano-editor.org/dist/v${PKG_VERSION%%.*}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
### Misc package updates (not addons)
- nano: update to 7.2
- ncurses: update to 6.4
- libsndfile: update to 1.2.0 and PKG_URL
- mpfr: update to 4.2.0