### PR TITLE
linux: update to 6.1.y

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -28,8 +28,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.1.6"
-    PKG_SHA256="3e4d8e561da5703a205ae8d7b2bed6c5c64fc4299eebcbfd20481e63b57d5ee3"
+    PKG_VERSION="6.1.7"
+    PKG_SHA256="4ab048bad2e7380d3b827f1fad5ad2d2fc4f2e80e1c604d85d1f8781debe600f"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;


### PR DESCRIPTION
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.7

6.1.7 - 176 patches

errors / fixes / issues / regressions
- a couple of reported Null panics 

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.1.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.1
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/


### 6.1.7 Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=arm DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.1.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - 6.1.7 - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.1.7 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - 6.1.4-rc1 - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum 