### PR TITLE
peripheral.joystick URL update

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,13 +3,13 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="v20.1.2-Nexus"
+PKG_VERSION="20.1.2-Nexus"
 PKG_SHA256="32c4c94842ad4ea470d188a627abc74cbd6bc314fef3b04a885e1055d4b80538"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/peripheral.joystick"
-PKG_URL="https://github.com/xbmc/peripheral.joystick/archive/${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/xbmc/peripheral.joystick/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain kodi-platform p8-platform systemd"
 PKG_SECTION=""
 PKG_SHORTDESC="peripheral.joystick: Joystick support in Kodi"


### PR DESCRIPTION
Update peripheral.joystick package URL as the existing one returns 404.