### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="v20.1.2-Nexus"
-PKG_SHA256="32c4c94842ad4ea470d188a627abc74cbd6bc314fef3b04a885e1055d4b80538"
-PKG_REV="2"
+PKG_VERSION="20.1.3-Nexus"
+PKG_SHA256="cc646bbc7a9a5b434980bf77717756922ceac89d9d8deca474ae46330fdbd19e"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/peripheral.joystick"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.xarcade"
-PKG_VERSION="20.1.2-Nexus"
-PKG_SHA256="df2c75a098b4a62a853e309de38126b45c43003283b52b64ebb79a7e9c345c79"
-PKG_REV="3"
+PKG_VERSION="20.1.3-Nexus"
+PKG_SHA256="e6be386ebba44e214b91784ba6e1560020daac82024c18bea7be4719340b12bd"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/peripheral.xarcade"

--- a/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.teleboy"
-PKG_VERSION="20.3.1-Nexus"
-PKG_SHA256="7e278a01bd1c85e65edc7387ef6e4d8a221b1373a9433231245f85b018b2315d"
+PKG_VERSION="20.3.3-Nexus"
+PKG_SHA256="b36bb08916a3effb382cdeb39d8c6fddf3f61022e46b6830ee1e191b3286f4c2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="20.3.1-Nexus"
-PKG_SHA256="e2798067c876aa98f7e873a5dd6cf93d43edc87a76db21b0ff302319b989f1ae"
+PKG_VERSION="20.3.3-Nexus"
+PKG_SHA256="68946cc469978e7972c8d0d9532125cf80fb0e33932a2a440809d360338fb3c9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- peripheral.joystick: update v20.1.2-Nexus to 20.1.3-Nexus
- peripheral.xarcade: update 20.1.2-Nexus to 20.1.3-Nexus
- pvr.teleboy: update 20.3.1-Nexus to 20.3.3-Nexus
- pvr.zattoo: update 20.3.1-Nexus to 20.3.3-Nexus