### PR TITLE
linux (RPi): update to 6.1.7

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="3ce39f16c50c9468d42ba55c1622104473f16345"
-PKG_SHA256="9c6e3617985027ec5fe1afd1c66e9f8d4dd4f074a05f51f4aa2c5a4d75f369e9"
+PKG_VERSION="5a3c2535acfd20dbcaabcf95a7dce92ad7cdf2a2"
+PKG_SHA256="ac12eab0bfda8b89de6ea67b13a90759fa28de63f8fac5d6d4a1c3a0c44f4f72"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="5a3c2535acfd20dbcaabcf95a7dce92ad7cdf2a2"
-PKG_SHA256="ac12eab0bfda8b89de6ea67b13a90759fa28de63f8fac5d6d4a1c3a0c44f4f72"
+PKG_VERSION="2578acb89b6b40c483db537c4fd2eef593543fb8"
+PKG_SHA256="2e352ed1c6ef704f19667b9f500f43e4bcdaaacd1ed3a9a6f44e72fb190bf10d"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
 PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="2c11bb09335749c602b6973d02542021f92f091d" # 6.1.6
-    PKG_SHA256="535edcd75c7b624fea1274b21c5c75ba6f14e751c4964e9b9eb0c46b56c36c84"
+    PKG_VERSION="2510d79b0a41095ef4a8b3c59e4b6d946c65da56" # 6.1.7
+    PKG_SHA256="3128dab6981eb429693ba905b5c4ed4a4450100966010932cb92e054d4ad4870"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="ace711d24ad37fa2611e2e39f71121f8ef278a3b" # 6.1.5
-    PKG_SHA256="a35ba2faed9764c4a301bd6d862e7ee883fca782906c52d6dae317d2fcbcb5a4"
+    PKG_VERSION="2c11bb09335749c602b6973d02542021f92f091d" # 6.1.6
+    PKG_SHA256="535edcd75c7b624fea1274b21c5c75ba6f14e751c4964e9b9eb0c46b56c36c84"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="b5d289f4c8458f48d0e6b1c2ccfa2416287f7973" # 6.1.4
-    PKG_SHA256="eebe27e5f7c9121a01da52f302fd484eae6290a2f1804331c3325cfc222686d8"
+    PKG_VERSION="5c0a4f4cac7f6ea9722af7ff45f0f4c0ab227d30" # 6.1.4
+    PKG_SHA256="51bc22607d5ec50fb8b40dac2752edb5aa5a96d3e69cf916e8fd6fc9560f3d2e"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="5c0a4f4cac7f6ea9722af7ff45f0f4c0ab227d30" # 6.1.4
-    PKG_SHA256="51bc22607d5ec50fb8b40dac2752edb5aa5a96d3e69cf916e8fd6fc9560f3d2e"
+    PKG_VERSION="ace711d24ad37fa2611e2e39f71121f8ef278a3b" # 6.1.5
+    PKG_SHA256="a35ba2faed9764c4a301bd6d862e7ee883fca782906c52d6dae317d2fcbcb5a4"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="2373697d13279675f46a4200ad96796dead8797e" # 6.1.3
-    PKG_SHA256="d382cad75c82dfe4c013a17c127b5183b710f5c68282a119454fdfc1b70b13d9"
+    PKG_VERSION="b5d289f4c8458f48d0e6b1c2ccfa2416287f7973" # 6.1.4
+    PKG_SHA256="eebe27e5f7c9121a01da52f302fd484eae6290a2f1804331c3325cfc222686d8"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="2510d79b0a41095ef4a8b3c59e4b6d946c65da56" # 6.1.7
-    PKG_SHA256="3128dab6981eb429693ba905b5c4ed4a4450100966010932cb92e054d4ad4870"
+    PKG_VERSION="2c69ae1412faa66018abc9c86c521111d30de095" # 6.1.7
+    PKG_SHA256="5dce685614844c3054a831832dbd66aba6b94930f471634cc90b99983d8a7897"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="3ce39f16c50c9468d42ba55c1622104473f16345"
-PKG_SHA256="89344f8c954d5be0d997156541bee9766ec1c0c043ab7fa6a5f0a0447f566f94"
+PKG_VERSION="5a3c2535acfd20dbcaabcf95a7dce92ad7cdf2a2"
+PKG_SHA256="0adfea45389b8ed34f380a0441074fa2f5165c50b1ba2531b03da52a68c4c2b1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="5a3c2535acfd20dbcaabcf95a7dce92ad7cdf2a2"
-PKG_SHA256="0adfea45389b8ed34f380a0441074fa2f5165c50b1ba2531b03da52a68c4c2b1"
+PKG_VERSION="2578acb89b6b40c483db537c4fd2eef593543fb8"
+PKG_SHA256="0627a2e21aca5939909b31e0ee55bad869eea63efb56b5de83f73f3ffa62ed3d"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="b4b4605c7de485a6604fb5b9f295eb87d878f848"
-PKG_SHA256="6095ae920a5cd772a6c3ddb585852dc31b94dd08bafcf5ec0b736d0878b41c78"
+PKG_VERSION="e2fc5b19933e8dd7c5677fec08cdeec54934b29b"
+PKG_SHA256="ff7a0cf4dd286be1fb58b85103961bd5e2832672fcb644f0aabb1bc4c76e57e2"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="e2fc5b19933e8dd7c5677fec08cdeec54934b29b"
-PKG_SHA256="ff7a0cf4dd286be1fb58b85103961bd5e2832672fcb644f0aabb1bc4c76e57e2"
+PKG_VERSION="bf7419c961e8b65854fd73ec29fbc515087539e8"
+PKG_SHA256="49c2e92accc58d10ddcf0a7a7eb2385c674ac57610c0f5b1e4dfea0e9983f353"
 PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.2 Kernel Configuration
+# Linux/arm 6.1.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3168,6 +3168,7 @@ CONFIG_VIDEO_IR_I2C=m
 # CONFIG_VIDEO_IMX355 is not set
 # CONFIG_VIDEO_IMX412 is not set
 # CONFIG_VIDEO_IMX519 is not set
+# CONFIG_VIDEO_IMX708 is not set
 # CONFIG_VIDEO_MT9M001 is not set
 # CONFIG_VIDEO_MT9M032 is not set
 # CONFIG_VIDEO_MT9M111 is not set

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.4 Kernel Configuration
+# Linux/arm 6.1.6 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -137,6 +137,7 @@ CONFIG_GENERIC_SCHED_CLOCK=y
 # end of Scheduler features
 
 CONFIG_CC_IMPLICIT_FALLTHROUGH="-Wimplicit-fallthrough=5"
+CONFIG_GCC11_NO_ARRAY_BOUNDS=y
 CONFIG_GCC12_NO_ARRAY_BOUNDS=y
 CONFIG_CGROUPS=y
 CONFIG_PAGE_COUNTER=y

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.2 Kernel Configuration
+# Linux/arm 6.1.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3302,6 +3302,7 @@ CONFIG_VIDEO_IR_I2C=m
 # CONFIG_VIDEO_IMX355 is not set
 # CONFIG_VIDEO_IMX412 is not set
 # CONFIG_VIDEO_IMX519 is not set
+# CONFIG_VIDEO_IMX708 is not set
 # CONFIG_VIDEO_MT9M001 is not set
 # CONFIG_VIDEO_MT9M032 is not set
 # CONFIG_VIDEO_MT9M111 is not set

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.4 Kernel Configuration
+# Linux/arm 6.1.6 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -149,6 +149,7 @@ CONFIG_GENERIC_SCHED_CLOCK=y
 # end of Scheduler features
 
 CONFIG_CC_IMPLICIT_FALLTHROUGH="-Wimplicit-fallthrough=5"
+CONFIG_GCC11_NO_ARRAY_BOUNDS=y
 CONFIG_GCC12_NO_ARRAY_BOUNDS=y
 CONFIG_CGROUPS=y
 CONFIG_PAGE_COUNTER=y

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.2 Kernel Configuration
+# Linux/arm64 6.1.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3891,6 +3891,7 @@ CONFIG_VIDEO_IR_I2C=m
 # CONFIG_VIDEO_IMX355 is not set
 # CONFIG_VIDEO_IMX412 is not set
 # CONFIG_VIDEO_IMX519 is not set
+# CONFIG_VIDEO_IMX708 is not set
 # CONFIG_VIDEO_MT9M001 is not set
 # CONFIG_VIDEO_MT9M032 is not set
 # CONFIG_VIDEO_MT9M111 is not set

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.4 Kernel Configuration
+# Linux/arm64 6.1.6 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -147,6 +147,7 @@ CONFIG_GENERIC_SCHED_CLOCK=y
 CONFIG_ARCH_SUPPORTS_NUMA_BALANCING=y
 CONFIG_CC_HAS_INT128=y
 CONFIG_CC_IMPLICIT_FALLTHROUGH="-Wimplicit-fallthrough=5"
+CONFIG_GCC11_NO_ARRAY_BOUNDS=y
 CONFIG_GCC12_NO_ARRAY_BOUNDS=y
 CONFIG_ARCH_SUPPORTS_INT128=y
 CONFIG_CGROUPS=y


### PR DESCRIPTION
Runtime tested on RPi4 and RPi3B+

Default bootloader version now contains VL805 firmware fixes and HID fixes