### PR TITLE
kodi: move settings icon in estuary

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.40-estuary-settings-icon.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.40-estuary-settings-icon.patch
@@ -1,0 +1,52 @@
+From 2adc7ac23db3b8c7dca857456477df886b7dbeaa Mon Sep 17 00:00:00 2001
+From: chewitt <christianshewitt@gmail.com>
+Date: Sat, 19 Sep 2020 16:25:19 +0000
+Subject: [PATCH] skin.estuary: make event log conditional and move LE settings
+
+Move the LE settings icon from the fourth row to the top replacing
+the event log viewer when service.libreelec.settings exists, so we
+keep the 3x3 grid layout.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ addons/skin.estuary/xml/Settings.xml | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/addons/skin.estuary/xml/Settings.xml b/addons/skin.estuary/xml/Settings.xml
+index fa63b174b8..e25d96dec2 100644
+--- a/addons/skin.estuary/xml/Settings.xml
++++ b/addons/skin.estuary/xml/Settings.xml
+@@ -54,10 +54,17 @@
+ 						<onclick>ActivateWindow(systeminfo)</onclick>
+ 						<icon>icons/settings/sysinfo.png</icon>
+ 					</item>
++					<item>
++						<label>LibreELEC</label>
++						<onclick>RunAddon(service.libreelec.settings)</onclick>
++						<icon>icons/settings/libreelec.png</icon>
++						<visible>System.AddonIsEnabled(service.libreelec.settings)</visible>
++					</item>
+ 					<item>
+ 						<label>$LOCALIZE[31067]</label>
+ 						<onclick>ActivateWindow(eventlog)</onclick>
+ 						<icon>icons/settings/eventlog.png</icon>
++						<visible>!System.HasAddon(service.libreelec.settings)</visible>
+ 					</item>
+ 				</content>
+ 			</control>
+@@ -111,12 +118,6 @@
+ 						<onclick>ActivateWindow(SystemSettings)</onclick>
+ 						<icon>icons/settings/system.png</icon>
+ 					</item>
+-					<item>
+-						<label>LibreELEC</label>
+-						<onclick>RunAddon(service.libreelec.settings)</onclick>
+-						<icon>icons/settings/libreelec.png</icon>
+-						<visible>System.AddonIsEnabled(service.libreelec.settings)</visible>
+-					</item>
+ 				</content>
+ 			</control>
+ 		</control>
+-- 
+2.34.1
+


### PR DESCRIPTION
This relocates the LE settings icon from it's current awkward position on the fourth row to top-right, displacing the event viewer which has never shown any interesting or useful content, at least for me, and restoring a 3x3 grid layout:

![image](https://user-images.githubusercontent.com/251794/213912665-21df32c3-b860-4b87-9ecc-bf7b21972510.png)
