### PR TITLE
rpi-eeprom: clean pkg arch restictions

### DIFF
--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -4,7 +4,6 @@
 PKG_NAME="rpi-eeprom"
 PKG_VERSION="bf7419c961e8b65854fd73ec29fbc515087539e8"
 PKG_SHA256="49c2e92accc58d10ddcf0a7a7eb2385c674ac57610c0f5b1e4dfea0e9983f353"
-PKG_ARCH="arm"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
It's redundant and causes merge issues with other projects

Signed-off-by: Demetris Ierokipides <ierokipides.dem@gmail.com>