### PR TITLE
generic: add support for BT2020

### DIFF
--- a/projects/Generic/patches/kodi/0003-CVideoLayerBridgeDRMPRIME-add-colourspace-connector-.patch
+++ b/projects/Generic/patches/kodi/0003-CVideoLayerBridgeDRMPRIME-add-colourspace-connector-.patch
@@ -1,0 +1,87 @@
+From e93a6bc009e660db2746b529149bac8d2e3ae122 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 29 Apr 2019 18:48:45 -0700
+Subject: [PATCH 3/4] CVideoLayerBridgeDRMPRIME add colourspace connector
+ property
+
+---
+ .../Buffers/VideoBufferDRMPRIME.cpp           | 12 ++++++++++++
+ .../VideoPlayer/Buffers/VideoBufferDRMPRIME.h |  1 +
+ .../HwDecRender/VideoLayerBridgeDRMPRIME.cpp  | 19 +++++++++++++++++++
+ 3 files changed, 32 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+index b1c23ffc3d..a5fb7ddf44 100644
+--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+@@ -20,6 +20,18 @@ extern "C"
+ namespace DRMPRIME
+ {
+ 
++std::string GetColorimetry(const VideoPicture& picture)
++{
++  switch (picture.color_space)
++  {
++    case AVCOL_SPC_BT2020_CL:
++    case AVCOL_SPC_BT2020_NCL:
++      return "BT2020_RGB";
++  }
++
++  return "Default";
++}
++
+ std::string GetColorEncoding(const VideoPicture& picture)
+ {
+   switch (picture.color_space)
+diff --git a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+index e77f75b58b..4de9732308 100644
+--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
++++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+@@ -34,6 +34,7 @@ enum hdmi_eotf
+   HDMI_EOTF_BT_2100_HLG,
+ };
+ 
++std::string GetColorimetry(const VideoPicture& picture);
+ std::string GetColorEncoding(const VideoPicture& picture);
+ std::string GetColorRange(const VideoPicture& picture);
+ uint8_t GetEOTF(const VideoPicture& picture);
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+index 726a5b79b7..09701cdbaa 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+@@ -42,6 +42,16 @@ void CVideoLayerBridgeDRMPRIME::Disable()
+   CLog::Log(LOGDEBUG, "CVideoLayerBridgeDRMPRIME::{} - setting max bpc to {} ({})",
+             __FUNCTION__, bpc, result);
+ 
++  uint64_t value;
++  std::tie(result, value) = connector->GetPropertyValue("Colorspace", "Default");
++  if (result)
++  {
++    CLog::Log(LOGDEBUG, "CVideoLayerBridgeDRMPRIME::{} - setting connector colorspace to Default",
++              __FUNCTION__);
++    m_DRM->AddProperty(connector, "Colorspace", value);
++    m_DRM->SetActive(true);
++  }
++
+   m_DRM->AddProperty(plane, "FB_ID", 0);
+   m_DRM->AddProperty(plane, "CRTC_ID", 0);
+ 
+@@ -191,6 +201,15 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
+   CLog::Log(LOGDEBUG, "CVideoLayerBridgeDRMPRIME::{} - setting max bpc to {} ({})", __FUNCTION__,
+             bpc, result);
+ 
++  std::tie(result, value) = connector->GetPropertyValue("Colorspace", GetColorimetry(picture));
++  if (result)
++  {
++    CLog::Log(LOGDEBUG, "CVideoLayerBridgeDRMPRIME::{} - setting connector colorspace to {}",
++              __FUNCTION__, GetColorimetry(picture));
++    m_DRM->AddProperty(connector, "Colorspace", value);
++    m_DRM->SetActive(true);
++  }
++
+ }
+ 
+ void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect)
+-- 
+2.34.1
+


### PR DESCRIPTION
This adds the BT2020 patch for generic, we already carry that patch for RPi and afaik it was long term at the SMP HDR builds.

I have no HW to test it, @smp79 could you test it ?