### PR TITLE
gstreamer and vulkan updates

### DIFF
--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers pkg_version/s need to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools & spirv-headers pkg_version/s.
-PKG_VERSION="11.13.0"
-PKG_SHA256="592c98aeb03b3e81597ddaf83633c4e63068d14b18a766fd11033bad73127162"
+PKG_VERSION="12.0.0"
+PKG_SHA256="7cb45842ec1d4b6ea775d624c3d2d8ba9450aa416b0482b0cc7e4fdd399c3d75"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-headers/package.mk
+++ b/packages/graphics/vulkan/spirv-headers/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-headers"
 # The SPIRV-Headers pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-headers pkg_version.
-PKG_VERSION="1d31a100405cf8783ca7a31e31cdd727c9fc54c3"
-PKG_SHA256="ec09b682c93bffc6e3d58459840a0306b6b9360e56e797c4243d2d7b785dea74"
+PKG_VERSION="d13b52222c39a7e9a401b44646f0ca3a640fbd47"
+PKG_SHA256="9dd5ae25bcec65db633990477e5b9a9b84cdbc0aa87eaaea159813a5d707fb31"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-tools/package.mk
+++ b/packages/graphics/vulkan/spirv-tools/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-tools"
 # The SPIRV-Tools pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools pkg_version.
-PKG_VERSION="40f5bf59c6acb4754a0bffd3c53a715732883a12"
-PKG_SHA256="b99c91307a4b466754ffeaaaa6086bda55780ccf1557592004a1736fb9aa7ce7"
+PKG_VERSION="63de608daeb7e91fbea6d7477a50debe7cac57ce"
+PKG_SHA256="f223272718ffa622feff49f3f1b4caf754c57634be70ef6eadfa3f74f2938e53"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.237"
-PKG_SHA256="3f0d9a01a7859efbf312f34140259fc90aa0ba04f635e98f8f36321de4bd509b"
+PKG_VERSION="1.3.239"
+PKG_SHA256="86ef8969b96cf391dc86b9c4e5745b8ecaa12ebdaaefd3d8e38bc98e15f30653"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.237"
-PKG_SHA256="03cfe1cb3dc5623304f64a2d0e8714dd8b51702da71365dacb9fbdc1f9ac138e"
+PKG_VERSION="1.3.239"
+PKG_SHA256="dcdbe3f5362035ecc5ffce2140393de377038c44e00dfb8bae43816eec57dfc6"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.237"
-PKG_SHA256="af35d59e601d20a83b9c2b555994cc8e9b5994b23d1b9702c2a1c354e223d593"
+PKG_VERSION="1.3.239"
+PKG_SHA256="39d3798ef957d7bdb1bc2cf6288311eb84e5d11d00847612781b597e773409e7"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-bad"
-PKG_VERSION="1.21.3"
-PKG_SHA256="4f7c9620e3b4bd6e868b6341af4738952f696c761755db1535d5372f0003ca48"
+PKG_VERSION="1.22.0"
+PKG_SHA256="3c9d9300f5f4fb3e3d36009379d1fb6d9ecd79c1a135df742b8a68417dd663a1"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-bad.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-bad/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-base"
-PKG_VERSION="1.21.3"
-PKG_SHA256="953d507db08d74ab0b4531eed7545a1756c45966237049c06bd7e4e5d5265c6c"
+PKG_VERSION="1.22.0"
+PKG_SHA256="f53672294f3985d56355c8b1df8f6b49c8c8721106563e19f53be3507ff2229d"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-base.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-base/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gstreamer/gstreamer/package.mk
+++ b/packages/multimedia/gstreamer/gstreamer/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gstreamer"
-PKG_VERSION="1.21.3"
-PKG_SHA256="27a75236bce2b10b188fe0c0087c6ceb9ee13c18fe9bf7437e0234a0e4afa226"
+PKG_VERSION="1.22.0"
+PKG_SHA256="78d21b5469ac93edafc6d8ceb63bc82f6cbbee94d2f866cca6b9252157ee0a09"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org"
 PKG_URL="https://gstreamer.freedesktop.org/src/gstreamer/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/util/wlr-randr/package.mk
+++ b/packages/wayland/util/wlr-randr/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wlr-randr"
-PKG_VERSION="0.2.0"
-PKG_SHA256="12745bc8050a56603bf9bdee70c798b5d6502cf00a795c59fd03e1d786c17ce3"
+PKG_VERSION="0.3.0"
+PKG_SHA256="f6e0bea3b41673adbc0ab707d5d93bfdcd3fc6f43c46377565865c3440f81eb4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://git.sr.ht/~emersion/wlr-randr"
 PKG_URL="https://git.sr.ht/~emersion/wlr-randr/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- glslang: update to 12.0.0
- gst-plugins-bad: update to 1.22.0
- gst-plugins-base: update to 1.22.0
- gstreamer: update to 1.22.0
- spirv-headers: update to d13b522
- spirv-tools: update to 63de608
- vulkan-headers: update to 1.3.239
- vulkan-loader: update to 1.3.239
- vulkan-tools: update to 1.3.239
- wlr-randr: update to 0.3.0
  - https://git.sr.ht/~emersion/wlr-randr/log
  - https://git.sr.ht/~emersion/wlr-randr/refs/v0.3.0