### PR TITLE
linux (RPi): update to 6.1.8

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,8 +22,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   raspberrypi)
-    PKG_VERSION="2c69ae1412faa66018abc9c86c521111d30de095" # 6.1.7
-    PKG_SHA256="5dce685614844c3054a831832dbd66aba6b94930f471634cc90b99983d8a7897"
+    PKG_VERSION="9eb3f2dbdd5d0410e237decd64bbaa1dfcae128e" # 6.1.8
+    PKG_SHA256="f1aa75a0d9be8625ee5ec605feeb1c28619e95fdea44be3595a658485ee5969e"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;


### PR DESCRIPTION
This should fix two long standing issues:
- occasional glitches at the bottom of the screen
- no picture after boot on some TVs

Runtime tested on RPi4