### PR TITLE
pipewire: update to 0.3.65

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.64"
-PKG_SHA256="a1ab25d4ff85aefa3da3452cb41e972487b1a2da613ccd207a5d312e5c241d7c"
+PKG_VERSION="0.3.65"
+PKG_SHA256="bb76f938136d0ce8c35bffa99e002dc2dbaeab5e14c6c34154e7f750013d1d6b"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log
- https://github.com/PipeWire/pipewire/compare/0.3.64...0.3.65

News
- https://github.com/PipeWire/pipewire/blob/master/NEWS