### PR TITLE
 RK3288-MiQi:Add proper cpu and gpu regulator configs and

### DIFF
--- a/projects/Rockchip/patches/linux/default/linux-0001-RK3288-MiQi-Add-proper-cpu-and-gpu-regulator-configs.patch
+++ b/projects/Rockchip/patches/linux/default/linux-0001-RK3288-MiQi-Add-proper-cpu-and-gpu-regulator-configs.patch
@@ -1,0 +1,112 @@
+From 9612a36e1ab248eb1c7953be6fd8640423126590 Mon Sep 17 00:00:00 2001
+From: Demetris Ierokipides <ierokipides.dem@gmail.com>
+Date: Mon, 23 Jan 2023 21:51:16 +0200
+Subject: [PATCH] RK3288-MiQi:Add proper cpu and gpu regulator configs and
+ default cpu frequencies supported by the soc changes cherry picked from the
+ datasheet and applied accordingly
+ https://file.elecfans.com/web2/M00/26/1E/poYBAGG5lKeAM48aACH87zBE10w368.pdf?SYR827/SYR828_SILERGY.pdf
+ - These changes actually need upstreaming - Also add MiQi's fan definition
+ that is needed in order  for the fan to work preventing the board to overheat
+ (gpiochip 0, pin 18) - Rename the leds from green to blue.This is the colour
+ on newer revisions - Also enable miqi's hevc, hevc_mmu and rga nodes
+
+---
+ arch/arm/boot/dts/rk3288-miqi.dts | 42 +++++++++++++++++++++++++++----
+ 1 file changed, 37 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm/boot/dts/rk3288-miqi.dts b/arch/arm/boot/dts/rk3288-miqi.dts
+index db1eb648e..ea0ffde0a 100644
+--- a/arch/arm/boot/dts/rk3288-miqi.dts
++++ b/arch/arm/boot/dts/rk3288-miqi.dts
+@@ -30,9 +30,15 @@ ext_gmac: external-gmac-clock {
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
++		fan {
++		    gpios = <&gpio0 RK_PC2 GPIO_ACTIVE_HIGH>;
++		    label = "miqi:blue:fan";
++		    linux,default-trigger = "default-on";
++		};
++
+ 		work_led: led-0 {
+ 			gpios = <&gpio7 RK_PA2 GPIO_ACTIVE_HIGH>;
+-			label = "miqi:green:user";
++			label = "miqi:blue:user";
+ 			linux,default-trigger = "timer";
+ 		};
+ 	};
+@@ -96,6 +102,17 @@ &cpu3 {
+ 	cpu-supply = <&vdd_cpu>;
+ };
+ 
++&cpu_opp_table {
++	opp-1704000000 {
++		opp-hz = /bits/ 64 <1704000000>;
++		opp-microvolt = <1350000>;
++	};
++	opp-1800000000 {
++		opp-hz = /bits/ 64 <1800000000>;
++		opp-microvolt = <1400000>;
++	};
++};
++
+ &emmc {
+ 	bus-width = <8>;
+ 	cap-mmc-highspeed;
+@@ -133,6 +150,14 @@ &hdmi {
+ 	status = "okay";
+ };
+ 
++&hevc {
++	status = "okay";
++};
++
++&hevc_mmu {
++	status = "okay";
++};
++
+ &i2c0 {
+ 	clock-frequency = <400000>;
+ 	status = "okay";
+@@ -143,11 +168,11 @@ vdd_cpu: syr827@40 {
+ 		reg = <0x40>;
+ 		regulator-name = "vdd_cpu";
+ 		regulator-min-microvolt = <850000>;
+-		regulator-max-microvolt = <1350000>;
++		regulator-max-microvolt = <1500000>;
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		regulator-enable-ramp-delay = <300>;
+-		regulator-ramp-delay = <8000>;
++		regulator-enable-ramp-delay = <400>;
++		regulator-ramp-delay = <1000>;
+ 		vin-supply = <&vcc_sys>;
+ 	};
+ 
+@@ -157,8 +182,11 @@ vdd_gpu: syr828@41 {
+ 		reg = <0x41>;
+ 		regulator-name = "vdd_gpu";
+ 		regulator-min-microvolt = <850000>;
+-		regulator-max-microvolt = <1350000>;
++		regulator-max-microvolt = <1500000>;
++		regulator-enable-ramp-delay = <400>;
++		regulator-ramp-delay = <1000>;
+ 		regulator-always-on;
++		regulator-boot-on;
+ 		vin-supply = <&vcc_sys>;
+ 	};
+ 
+@@ -370,6 +398,10 @@ host_vbus_drv: host-vbus-drv {
+ 	};
+ };
+ 
++&rga {
++	status = "okay";
++};
++
+ &saradc {
+ 	vref-supply = <&vcc_18>;
+ 	status = "okay";
+-- 
+2.34.1
+


### PR DESCRIPTION
Add default CPU frequencies supported by the soc changes cherry picked from the datasheet and applied accordingly
 https://file.elecfans.com/web2/M00/26/1E/poYBAGG5lKeAM48aACH87zBE10w368.pdf?SYR827/SYR828_SILERGY.pdf
 - These changes actually need upstreaming 
 - Also add MiQi's fan definition that is needed in order  for the fan to work preventing the board to overheat (gpiochip0,pin 18)
 - Rename the leds from green to blue.This is the colour on newer revisions
 - Also enable miqi's hevc, hevc_mmu and rga nodes

Signed-off-by: Demetris Ierokipides <ierokipides.dem@gmail.com>