### PR TITLE
move kmsxx from addon to image and include kmsprint output in pastekodi log

### DIFF
--- a/packages/addons/tools/system-tools/changelog.txt
+++ b/packages/addons/tools/system-tools/changelog.txt
@@ -1,1 +1,4 @@
+1
+- remove kmsxx
+
 initial release

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of system tools and programs"
-PKG_LONGDESC="This bundle currently includes autossh, bottom, diffutils, dstat, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, kmsxx, libgpiod, lm_sensors, lshw, mc, mmc-utils, mtpfs, nmon, p7zip, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
+PKG_LONGDESC="This bundle currently includes autossh, bottom, diffutils, dstat, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, libgpiod, lm_sensors, lshw, mc, mmc-utils, mtpfs, nmon, p7zip, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="System Tools"
@@ -35,7 +35,6 @@ PKG_DEPENDS_TARGET="toolchain \
                     i2c-tools \
                     inotify-tools \
                     jq \
-                    kmsxx \
                     libgpiod \
                     lm_sensors \
                     lshw \
@@ -126,9 +125,6 @@ addon() {
     # jq
     cp -P $(get_install_dir jq)/usr/bin/jq ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir oniguruma)/usr/lib/{libonig.so,libonig.so.5,libonig.so.5.*.*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-
-    # kmsxx
-    cp -P $(get_install_dir kmsxx)/usr/bin/{kmsblank,kmsprint,kmstest} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # libgpiod
     cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpiofind,gpioget,gpioinfo,gpiomon,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin

--- a/packages/graphics/kmsxx/package.mk
+++ b/packages/graphics/kmsxx/package.mk
@@ -11,7 +11,7 @@ PKG_DEPENDS_TARGET="toolchain libdrm libfmt"
 PKG_LONGDESC="Library and utilities for kernel mode setting"
 PKG_BUILD_FLAGS="-sysroot"
 
-PKG_MESON_OPTS_TARGET="-Ddefault_library=static \
+PKG_MESON_OPTS_TARGET="-Ddefault_library=shared \
                        -Dkmscube=false \
                        -Domap=disabled \
                        -Dpykms=disabled"

--- a/packages/graphics/kmsxx/package.mk
+++ b/packages/graphics/kmsxx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kmsxx"
-PKG_VERSION="adc05b66548d10ad8c4a400fb8e8b072a2fd8e2c" # 2022-11-05
-PKG_SHA256="a88cbaabac63738a51aabe62c1de11960a72ec2c2a29c436c820ae8c22a92b49"
+PKG_VERSION="2bd85abc108e0688384f42b0ec83dcd5a622d50d"
+PKG_SHA256="b8746018d076f1474b48211ff5c1895dc668d93d206d0b2dbd03da1a3d5bb12b"
 PKG_LICENSE="MPL-2.0"
 PKG_SITE="https://github.com/tomba/kmsxx"
 PKG_URL="https://github.com/tomba/kmsxx/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -84,6 +84,8 @@ fi
 
   journalctl -a -b -0 -o short-precise | cat_data "journalctl -a -b -0"
 
+  kmsprint | cat_data "kmsprint"
+
   if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then
     vcgencmd bootloader_version | cat_data "Bootloader version"
   fi

--- a/packages/virtual/debug/package.mk
+++ b/packages/virtual/debug/package.mk
@@ -6,7 +6,7 @@ PKG_VERSION=""
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain gdb edid-decode memtester strace"
+PKG_DEPENDS_TARGET="toolchain gdb edid-decode memtester strace kmsxx"
 PKG_SECTION="virtual"
 PKG_LONGDESC="debug is a Metapackage for installing debugging tools"
 


### PR DESCRIPTION
modetest output is practically unreadable for normal users and also way too chatty to be included in pastekodi - which makes it hard to debug "no display after boot" issues.

kmsprint however produces nice, terse output which is also something normal users can cope with, gives us some useful information to point users in the right direction (eg wrong HDMI port used, no display detected, or odd weird non-default mode set) and it's short enough to be included in pastekodi logs.

eg here on RPi4:
```
LibreELEC:~ # modetest | wc
     2913      8204     79487
LibreELEC:~ # kmsprint | wc
        7        82       489
LibreELEC:~ # kmsprint
Connector 0 (32) HDMI-A-1 (connected)
  Encoder 0 (31) TMDS
    Crtc 3 (96) 1920x1200@59.95 154.000 1920/48/32/80/+ 1200/3/6/26/- 60 (59.95) P|D 
      Plane 6 (119) fb-id: 344 (crtcs: 0 1 2 3 4 5) 0,0 1920x1200 -> 0,0 1920x1200 (XR24 AR24 AB24 XB24 RG16 BG16 AR15 XR15 RG24 BG24 YU16 YV16 YU12 YV12 NV12 NV21 NV16 NV61 P030 XR30 AR30 AB30 XB30 RGB8 BGR8 XR12 AR12 XB12 AB12 BX12 BA12 RX12 RA12)
        FB 344 1920x1200 XR24
Connector 1 (42) HDMI-A-2 (disconnected)
  Encoder 1 (41) TMDS
```

With that info in pastekodi we can switch to a much simpler workflow to analyze "no signal" reports on the forum. Simply tell users to
- add `ssh` to kernel command line
- ssh in
- run `pastekodi` and post the URL

and we should have some starting point