### PR TITLE
iwd: Fix buffer overflow due to off-by-one error

### DIFF
--- a/packages/network/iwd/patches/iwd-0001-wiphy-Fix-buffer-overflow-due-to-off-by-one-error.patch
+++ b/packages/network/iwd/patches/iwd-0001-wiphy-Fix-buffer-overflow-due-to-off-by-one-error.patch
@@ -1,0 +1,63 @@
+From 54a06835580bc4e15c453ee87db8c14655e900ef Mon Sep 17 00:00:00 2001
+From: Denis Kenzior <denkenz@gmail.com>
+Date: Thu, 26 Jan 2023 09:59:56 -0600
+Subject: wiphy: Fix buffer overflow due to off-by-one error
+
+Since channels numbers are used as indexes into the array, and given
+that channel numbers start at '1' instead of 0, make sure to allocate a
+buffer large enough to not overflow when the max channel number for a
+given band is accessed.
+
+src/manager.c:manager_wiphy_dump_callback() New wiphy phy1 added (1)
+==22290== Invalid write of size 2
+==22290==    at 0x4624B2: nl80211_parse_supported_frequencies (nl80211util.c:570)
+==22290==    by 0x417CA5: parse_supported_bands (wiphy.c:1636)
+==22290==    by 0x418594: wiphy_parse_attributes (wiphy.c:1805)
+==22290==    by 0x418E20: wiphy_update_from_genl (wiphy.c:1991)
+==22290==    by 0x464589: manager_wiphy_dump_callback (manager.c:564)
+==22290==    by 0x4CBDDA: process_unicast (genl.c:944)
+==22290==    by 0x4CC19C: received_data (genl.c:1056)
+==22290==    by 0x4C7140: io_callback (io.c:120)
+==22290==    by 0x4C5A97: l_main_iterate (main.c:476)
+==22290==    by 0x4C5BDC: l_main_run (main.c:523)
+==22290==    by 0x4C5F0F: l_main_run_with_signal (main.c:645)
+==22290==    by 0x40503B: main (main.c:600)
+==22290==  Address 0x4aa76ec is 0 bytes after a block of size 28 alloc'd
+==22290==    at 0x48417B5: malloc (vg_replace_malloc.c:393)
+==22290==    by 0x4BC4D1: l_malloc (util.c:62)
+==22290==    by 0x417BE4: parse_supported_bands (wiphy.c:1619)
+==22290==    by 0x418594: wiphy_parse_attributes (wiphy.c:1805)
+==22290==    by 0x418E20: wiphy_update_from_genl (wiphy.c:1991)
+==22290==    by 0x464589: manager_wiphy_dump_callback (manager.c:564)
+==22290==    by 0x4CBDDA: process_unicast (genl.c:944)
+==22290==    by 0x4CC19C: received_data (genl.c:1056)
+==22290==    by 0x4C7140: io_callback (io.c:120)
+==22290==    by 0x4C5A97: l_main_iterate (main.c:476)
+==22290==    by 0x4C5BDC: l_main_run (main.c:523)
+==22290==    by 0x4C5F0F: l_main_run_with_signal (main.c:645)
+==22290==
+---
+ src/wiphy.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/wiphy.c b/src/wiphy.c
+index fcdc3ab8..2db2d2cd 100644
+--- a/src/wiphy.c
++++ b/src/wiphy.c
+@@ -1616,8 +1616,12 @@ static void parse_supported_bands(struct wiphy *wiphy,
+ 				continue;
+ 
+ 			band->freq = freq;
++			/*
++			 * Since channels start at 1, allocate one extra in
++			 * order to use channel indexes without arithmetic
++			 */
+ 			band->freq_attrs = l_new(struct band_freq_attrs,
+-							num_channels);
++							num_channels + 1);
+ 			band->freqs_len = num_channels;
+ 
+ 			/* Reset iter to beginning */
+-- 
+cgit 
+


### PR DESCRIPTION
Able to reproduce both the error and can confirm the fix.

Fixes: https://forum.libreelec.tv/thread/26531-wi-fi-usb-ralink-rt2870f-not-work-on-last-nightly-rpi4/?postID=176217#post176217
Patch from: https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/?id=54a06835580bc4e15c453ee87db8c14655e900ef

Fix malloc error as below (introduced in iwd 2.2.)

```
Wireless daemon version 2.2
iwd-2.2/src/main.c:main() Using configuration directory /etc/iwd iwd-2.2/src/storage.c:storage_create_dirs() Using state directory /var/lib/iwd iwd-2.2/src/main.c:nl80211_appeared() Found nl80211 interface iwd-2.2/src/module.c:iwd_modules_init()
station: Network configuration is disabled.
iwd-2.2/src/wsc.c:wsc_init()
iwd-2.2/src/knownnetworks.c:known_network_frequencies_load() No known frequency file found. iwd-2.2/src/eap.c:__eap_method_enable()
iwd-2.2/src/eap-wsc.c:eap_wsc_init()
iwd-2.2/src/eap-md5.c:eap_md5_init()
iwd-2.2/src/eap-tls.c:eap_tls_init()
iwd-2.2/src/eap-ttls.c:eap_ttls_init()
iwd-2.2/src/eap-mschapv2.c:eap_mschapv2_init()
iwd-2.2/src/eap-sim.c:eap_sim_init()
iwd-2.2/src/eap-aka.c:eap_aka_prime_init()
iwd-2.2/src/eap-aka.c:eap_aka_init()
iwd-2.2/src/eap-peap.c:eap_peap_init()
iwd-2.2/src/eap-gtc.c:eap_gtc_init()
iwd-2.2/src/eap-pwd.c:eap_pwd_init()
iwd-2.2/src/manager.c:manager_wiphy_dump_callback() New wiphy phy0 added (0) malloc(): invalid next size (unsorted)
Aborted
```