### PR TITLE
docker: update to 23.0.0 and addon (2)

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="d9131da5e377994bc81062a352cb0aa9e89c35fdfbb763a5c33d44f241e1267e"
+PKG_SHA256="3379d06cd6177832b91f4796c680b6bf15c7895773448716b4c3c5253f611d1b"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/docker/cli/releases
-export PKG_GIT_COMMIT="e1152b2418833c2e39b7114c1ebb12d2278792a3"
+export PKG_GIT_COMMIT="e92dd87c3209361f29b692ab4b8f0f9248779297"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/cli/patches/cli-0001-path-for-cli-plugins.patch
+++ b/packages/addons/addon-depends/docker/cli/patches/cli-0001-path-for-cli-plugins.patch
@@ -1,0 +1,11 @@
+--- a/cli-plugins/manager/manager_unix.go	2023-02-03 11:54:16.746399916 +0000
++++ b/cli-plugins/manager/manager_unix.go	2023-02-03 11:59:04.528175595 +0000
+@@ -4,6 +4,6 @@
+ package manager
+ 
+ var defaultSystemPluginDirs = []string{
+-	"/usr/local/lib/docker/cli-plugins", "/usr/local/libexec/docker/cli-plugins",
+-	"/usr/lib/docker/cli-plugins", "/usr/libexec/docker/cli-plugins",
++	"/storage/.kodi/addons/service.system.docker/cli-plugins",
++	"/storage/.kodi/userdata/addon_data/service.system.docker/docker/cli-plugins",
+ }

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.6.15"
-PKG_SHA256="ee170fa73b258e448f9b6729440d38c77d19cd9bec46e45cd195d4670cd8b004"
+PKG_VERSION="1.6.16"
+PKG_SHA256="e0a893cf67df9dfaecbcde2ba4e896efb3a86ffe48dcfe0d2b26f7cf19b5af3a"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="23.0.0-rc.3"
-PKG_SHA256="e04e6715efd41d96a6c2c9e63821f617eec09fccc4d1688aea6227463c4ababb"
+PKG_VERSION="23.0.0"
+PKG_SHA256="94492508260e57eb93399257d53435cd5308ca6330e173ca6e6f3dbf4c6e12f3"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="9f62b37a6221c4743a883f6674526180b4125e0c"
+export PKG_GIT_COMMIT="d7573ab8672555762688f4c7ab8cc69ae8ec1a47"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
- docker: update to 23.0.0 and addon (2)
  - https://github.com/moby/moby/releases/tag/v23.0.0
- cli: update to 23.0.0
- cli: update path for cli-plugins for LibreELEC image
- moby: update to 23.0.0
- containerd: update to 1.6.16