### PR TITLE
tools/docker: update focal/Dockerfile to install golang-1.18

### DIFF
--- a/tools/docker/focal/Dockerfile
+++ b/tools/docker/focal/Dockerfile
@@ -21,8 +21,9 @@ RUN apt-get update && apt-get install -y \
     wget bash bc gcc-10 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-10 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
-      golang-go git openssh-client \
+      golang-1.18-go git openssh-client \
     --no-install-recommends \
+ && ln -s /usr/lib/go-1.18 /usr/lib/go \
  && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \


### PR DESCRIPTION
use recent release of golang for bootstrap builds. 
- updates from golang-1.13 to golang-1.18