### PR TITLE
kodi: fix for changed return value of smbc_getxattr() for Samba >= 4.17.5

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-995.11-smbc_getxattr.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.11-smbc_getxattr.patch
@@ -1,0 +1,11 @@
+--- ./xbmc/platform/posix/filesystem/SMBDirectory.cpp.orig	2023-02-03 14:31:42.518877830 +0100
++++ ./xbmc/platform/posix/filesystem/SMBDirectory.cpp	2023-02-03 14:36:27.357905849 +0100
+@@ -171,7 +171,7 @@
+             char value[20];
+             // We poll for extended attributes which symbolizes bits but split up into a string. Where 0x02 is hidden and 0x12 is hidden directory.
+             // According to the libsmbclient.h it's supposed to return 0 if ok, or the length of the string. It seems always to return the length which is 4
+-            if (smbc_getxattr(strFullName.c_str(), "system.dos_attr.mode", value, sizeof(value)) > 0)
++            if (smbc_getxattr(strFullName.c_str(), "system.dos_attr.mode", value, sizeof(value)) >= 0)
+             {
+               long longvalue = strtol(value, NULL, 16);
+               if (longvalue & SMBC_DOS_MODE_HIDDEN)


### PR DESCRIPTION
Since a couple of days I noticed strange errors in kodi.log when accessing files from my NAS via Samba:
```
2023-02-02 18:22:41.039 T:1091    error <general>: Getting extended attributes for the share: 'smb://nas/videos/TV%20Shows/Doctor%20Who'
                                                   unix_err:'5f' error: 'Operation not supported' return: 0
2023-02-02 18:22:41.044 T:1091    error <general>: Getting extended attributes for the share: 'smb://nas/videos/TV%20Shows/Frieden%20(2020)'
                                                   unix_err:'4b' error: 'Value too large for defined data type' return: 0
2023-02-02 18:22:41.048 T:1091    error <general>: Getting extended attributes for the share: 'smb://nas/videos/TV%20Shows/Mum'
                                                   unix_err:'4b' error: 'Value too large for defined data type' return: 0
2023-02-02 18:22:41.053 T:1091    error <general>: Getting extended attributes for the share: 'smb://nas/videos/TV%20Shows/Borgen'
                                                   unix_err:'4b' error: 'Value too large for defined data type' return: 0
```
These originate from https://github.com/xbmc/xbmc/blob/1b98faae545f30433bd3c4f07ba87a056821c416/xbmc/platform/posix/filesystem/SMBDirectory.cpp#L172-L184
There, the return value from smbc_getxattr is supposed to be > 0 if successful (contrary to the documentation: 0 on success and -1 on failure). I tweaked the error message to show the actual return value, shown above as `return:...`.
But in latest Samba (4.17.5), the return value was fixed to align with the documentation, see https://www.samba.org/samba/history/samba-4.17.5.html and https://bugzilla.samba.org/show_bug.cgi?id=14808 
Checking  the return value for `== 0` is the correct fix, but `>= 0` should be OK and also works for older versions of Samba.