### PR TITLE
rust: update to 1.67.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cargo-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="a636f83eb2327a66f484b9592ab305c6642df16fc80d0d1cb727e766a60da904"
+PKG_SHA256="7ddc4f7027653b4366037206ef438c704513c1565ce6eb2422d9d47146782c3b"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rust-std-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="c5e2c9b160bd8d99514f13cfbc0e42a722fd9ca14e6aaca4b9b77731a7a48377"
+PKG_SHA256="8f03b271bba56b0245833f2cb08044865068ce8721d6a736d3ef7056aa109daa"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.66.1"
-PKG_SHA256="5b3c933a94c72187705d4ee293198babfdd09442f5937fbd685db3a81f4959ba"
+PKG_VERSION="1.67.0"
+PKG_SHA256="d029f14fce45a2ec7a9a605d2a0a40aae4739cb2fdae29ee9f7a6e9025a7fde4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rust/patches/rust-0001-105624.patch
+++ b/packages/rust/rust/patches/rust-0001-105624.patch
@@ -1,0 +1,38 @@
+From 675fa0b3dd5fe14b43ad5b7862f4528df7322468 Mon Sep 17 00:00:00 2001
+From: Michael Goulet <michael@errs.io>
+Date: Mon, 12 Dec 2022 18:29:33 +0000
+Subject: [PATCH] =?UTF-8?q?=F0=9F=9A=A8=20fix=20unsoundness=20in=20bootstr?=
+ =?UTF-8?q?ap=20cache=20code?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+---
+ src/bootstrap/cache.rs | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/bootstrap/cache.rs b/src/bootstrap/cache.rs
+index be5c9bb078808..05f25af68ea8f 100644
+--- a/src/bootstrap/cache.rs
++++ b/src/bootstrap/cache.rs
+@@ -89,16 +89,16 @@ impl<T: Internable + Hash> Hash for Interned<T> {
+ 
+ impl<T: Internable + Deref> Deref for Interned<T> {
+     type Target = T::Target;
+-    fn deref(&self) -> &'static Self::Target {
++    fn deref(&self) -> &Self::Target {
+         let l = T::intern_cache().lock().unwrap();
+-        unsafe { mem::transmute::<&Self::Target, &'static Self::Target>(l.get(*self)) }
++        unsafe { mem::transmute::<&Self::Target, &Self::Target>(l.get(*self)) }
+     }
+ }
+ 
+ impl<T: Internable + AsRef<U>, U: ?Sized> AsRef<U> for Interned<T> {
+-    fn as_ref(&self) -> &'static U {
++    fn as_ref(&self) -> &U {
+         let l = T::intern_cache().lock().unwrap();
+-        unsafe { mem::transmute::<&U, &'static U>(l.get(*self).as_ref()) }
++        unsafe { mem::transmute::<&U, &U>(l.get(*self).as_ref()) }
+     }
+ }
+ 

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rustc-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="242855e2626860aede6957dc56481cc02acf8cad12fa5bbbcbd93f9c51f0b3ad"
+PKG_SHA256="7a9c5890f8b573cd0c584b590b86eb02c38c00b9c3ba74b21917ba97d1fa3d12"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"


### PR DESCRIPTION
Rust toolchain only used for addons
- rust: update to 1.67.0
- rustc-snapshot: update to 1.67.0
- rust-std-snapshot: update to 1.67.0
- cargo-snapshot: update to 1.67.0
