### PR TITLE
Allwinner: atf: Revert to old workaround

### DIFF
--- a/packages/tools/atf/package.mk
+++ b/packages/tools/atf/package.mk
@@ -23,7 +23,7 @@ make_target() {
   if [ "${DEVICE}" = "iMX8" ]; then
     CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="--no-warn-rwx-segments" CFLAGS="--param=min-pagesize=0" make PLAT=${ATF_PLATFORM} bl31
   else
-    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="--no-warn-rwx-segments" CFLAGS="" make SUNXI_SETUP_REGULATORS=0 PLAT=${ATF_PLATFORM} bl31
+    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="--no-warn-rwx-segments" CFLAGS="" make PLAT=${ATF_PLATFORM} bl31
   fi
 }
 

--- a/projects/Allwinner/patches/atf/0003-sunxi-Don-t-enable-referenced-regulators.patch
+++ b/projects/Allwinner/patches/atf/0003-sunxi-Don-t-enable-referenced-regulators.patch
@@ -1,0 +1,22 @@
+From 89a2da7c8bae95cf9225015489736e2fc434f4d9 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Sat, 2 Jan 2021 16:35:31 +0100
+Subject: [PATCH] sunxi: Don't enable referenced regulators
+
+This break certain devices which need appropriate power on sequence.
+---
+ drivers/allwinner/axp/common.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/drivers/allwinner/axp/common.c
++++ b/drivers/allwinner/axp/common.c
+@@ -112,9 +112,6 @@ static bool should_enable_regulator(const void *fdt,
+ 	if (is_node_disabled(fdt, node)) {
+ 		return false;
+ 	}
+-	if (fdt_getprop(fdt, node, "phandle", NULL) != NULL) {
+-		return true;
+-	}
+ 	if (fdt_getprop(fdt, node, "regulator-always-on", NULL) != NULL) {
+ 		return true;
+ 	}


### PR DESCRIPTION
Now that boot issue found on boards without PMIC is solved, let's re-introduce workaround for OrangePi 3 network instead of keeping all regulators off. It turns out that there is Beelink GS1 variant which need enabling regulators in ATF. Workaround will still keep OrangePi 3 board happy.