### PR TITLE
openssl: update to 3.0.8

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="3.0.7"
-PKG_SHA256="83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e"
+PKG_VERSION="3.0.8"
+PKG_SHA256="6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://www.openssl.org"
 PKG_URL="https://www.openssl.org/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- 07-Feb-2023 | Security Advisory: one high and seven moderate severity fixes
- 07-Feb-2023 | OpenSSL 3.0.8 is now available, including bug and security fixes
  - https://www.openssl.org/news/secadv/20230207.txt