### PR TITLE
mariadb-connector-c: update to 3.3.4

### DIFF
--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.3.3"
-PKG_SHA256="98b69221b0011da1e658191756668c5e81101f759886290e6ae0a91615589987"
+PKG_VERSION="3.3.4"
+PKG_SHA256="ea6a23850d6a2f6f2e0d9e9fdb7d94fe905a4317f73842272cf121ed25903e1f"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
release notes:
- https://mariadb.com/kb/en/mariadb-connector-c-3-3-4-release-notes/

changelog
- https://mariadb.com/kb/en/mariadb-connector-c-3-3-4-changelog/