### PR TITLE
libgpiod: update to 1.6.4

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpiod"
-PKG_VERSION="1.6.3"
-PKG_SHA256="eb446070be1444fd7d32d32bbca53c2f3bbb0a21193db86198cf6050b7a28441"
+PKG_VERSION="1.6.4"
+PKG_SHA256="829d4ac268df07853609d67cfc7f476e9aa736cb2a68a630be99e8fad197be0a"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
 PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Minors:
- https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/log/?h=v1.6.x

Bug fixes:
- fix a typo in bats dependency test
- fix an unterminated double quote in configure
- fix a null-pointer dereference in error path in tests
- fix a build issue related to the AM_PATH_PYTHON() automake macro

Improvements:
- check for the timeout program before running the gpio-tools tests