### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.sacd"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="2576360c1a982d1e2e2a4fa38f338a31f18c51393ca50058098fafb86288f76f"
-PKG_REV="3"
+PKG_VERSION="20.3.0-Nexus"
+PKG_SHA256="6d54f6cf81e13aadcec1b43689551feba6e9426453a758d955e96348ba996277"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.sacd"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.asteroids"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="c1923a60e0495b7505157d5bd56574880449eedb4a12d31beab7728b50477232"
-PKG_REV="3"
+PKG_VERSION="20.2.0-Nexus"
+PKG_SHA256="492d826efa7a252ce62a1bebf075fe9b0c0cf452929f4cd6f228003f6e445b82"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.asteroids"

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.libarchive"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="64d963285811cc3326f84bce8a8e051bafe3930df450973e3e6df700be9bc695"
-PKG_REV="3"
+PKG_VERSION="20.3.0-Nexus"
+PKG_SHA256="06be9bfcda3e676e0757ea9602351d67f2bf0aa9aa9e408b14d947772a615e4f"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/vfs.libarchive"


### PR DESCRIPTION
- audiodecoder.sacd: update 20.2.0-Nexus to 20.3.0-Nexus
- screensaver.asteroids: update 20.1.0-Nexus to 20.2.0-Nexus
- vfs.libarchive: update 20.2.0-Nexus to 20.3.0-Nexus