### PR TITLE
libdrm: update to 2.4.115

### DIFF
--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.114"
-PKG_SHA256="3049cf843a47d12e5eeefbc3be3496d782fa09f42346bf0b7defe3d1e598d026"
+PKG_VERSION="2.4.115"
+PKG_SHA256="554cfbfe0542bddb391b4e3e05bfbbfc3e282b955bd56218d21c0616481f65eb"
 PKG_LICENSE="GPL"
 PKG_SITE="https://dri.freedesktop.org"
 PKG_URL="https://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
mostly AMD fixes & an Intel tidy up.

log:
- https://gitlab.freedesktop.org/mesa/drm/-/compare/libdrm-2.4.114...libdrm-2.4.115?from_project_id=177&straight=false