### PR TITLE
kernel firmware and rtw88 upstream patches

### DIFF
--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="20230117"
-PKG_SHA256="df11e25ba2fb4d5343473757e17a3b4cef599250a26b1f7e0f038850f0cb3d64"
+PKG_VERSION="20230210"
+PKG_SHA256="6e3d9e8d52cffc4ec0dbe8533a8445328e0524a20f159a5b61c2706f983ce38a"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-${PKG_VERSION}.tar.xz"

--- a/packages/linux/patches/default/linux-122-rtw88-USB-fixes.patch
+++ b/packages/linux/patches/default/linux-122-rtw88-USB-fixes.patch
@@ -1,0 +1,231 @@
+From: Sascha Hauer <s.hauer@pengutronix.de>
+To: linux-wireless@vger.kernel.org
+Cc: Neo Jou <neojou@gmail.com>, Hans Ulli Kroll <linux@ulli-kroll.de>,
+        Ping-Ke Shih <pkshih@realtek.com>,
+        Yan-Hsuan Chuang <tony0620emma@gmail.com>,
+        Kalle Valo <kvalo@kernel.org>, netdev@vger.kernel.org,
+        linux-kernel@vger.kernel.org,
+        Martin Blumenstingl <martin.blumenstingl@googlemail.com>,
+        kernel@pengutronix.de, Alexander Hochbaum <alex@appudo.com>,
+        Da Xue <da@libre.computer>, Po-Hao Huang <phhuang@realtek.com>,
+        Andreas Henriksson <andreas@fatal.se>,
+        Viktor Petrenko <g0000ga@gmail.com>,
+        Sascha Hauer <s.hauer@pengutronix.de>
+Subject: [PATCH v2 0/3] wifi: rtw88: USB fixes
+Date: Fri, 10 Feb 2023 12:16:29 +0100
+Message-Id: <20230210111632.1985205-1-s.hauer@pengutronix.de>
+X-Mailer: git-send-email 2.30.2
+MIME-Version: 1.0
+X-SA-Exim-Connect-IP: 2a0a:edc0:0:c01:1d::a2
+X-SA-Exim-Mail-From: sha@pengutronix.de
+X-SA-Exim-Scanned: No (on metis.ext.pengutronix.de);
+ SAEximRunCond expanded to false
+X-PTX-Original-Recipient: linux-wireless@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-wireless.vger.kernel.org>
+X-Mailing-List: linux-wireless@vger.kernel.org
+
+This series addresses issues for the recently added RTW88 USB support
+reported by Andreas Henriksson and also our customer.
+
+The hardware can't handle urbs that have a size of multiple of the
+bulkout_size (usually 512 bytes). The symptom is that the hardware
+stalls completely. The issue can be reproduced by sending a suitably
+sized ping packet from the device:
+
+ping -s 394 <somehost>
+
+(It's 394 bytes here on a RTL8822CU and RTL8821CU, the actual size may
+differ on other chips, it was 402 bytes on a RTL8723DU)
+
+Other than that qsel was not set correctly. The sympton here is that
+only one of multiple bulk endpoints was used to send data.
+
+Changes since v1:
+- Use URB_ZERO_PACKET to let the USB host controller handle it automatically
+  rather than working around the issue.
+
+Sascha Hauer (3):
+  wifi: rtw88: usb: Set qsel correctly
+  wifi: rtw88: usb: send Zero length packets if necessary
+  wifi: rtw88: usb: drop now unnecessary URB size check
+
+ drivers/net/wireless/realtek/rtw88/usb.c | 18 +++---------------
+ 1 file changed, 3 insertions(+), 15 deletions(-)
+Reported-by: Andreas Henriksson <andreas@fatal.se>
+Tested-by: Andreas Henriksson <andreas@fatal.se>
+
+From: Sascha Hauer <s.hauer@pengutronix.de>
+To: linux-wireless@vger.kernel.org
+Cc: Neo Jou <neojou@gmail.com>, Hans Ulli Kroll <linux@ulli-kroll.de>,
+        Ping-Ke Shih <pkshih@realtek.com>,
+        Yan-Hsuan Chuang <tony0620emma@gmail.com>,
+        Kalle Valo <kvalo@kernel.org>, netdev@vger.kernel.org,
+        linux-kernel@vger.kernel.org,
+        Martin Blumenstingl <martin.blumenstingl@googlemail.com>,
+        kernel@pengutronix.de, Alexander Hochbaum <alex@appudo.com>,
+        Da Xue <da@libre.computer>, Po-Hao Huang <phhuang@realtek.com>,
+        Andreas Henriksson <andreas@fatal.se>,
+        Viktor Petrenko <g0000ga@gmail.com>,
+        Sascha Hauer <s.hauer@pengutronix.de>
+Subject: [PATCH v2 1/3] wifi: rtw88: usb: Set qsel correctly
+Date: Fri, 10 Feb 2023 12:16:30 +0100
+Message-Id: <20230210111632.1985205-2-s.hauer@pengutronix.de>
+X-Mailer: git-send-email 2.30.2
+In-Reply-To: <20230210111632.1985205-1-s.hauer@pengutronix.de>
+References: <20230210111632.1985205-1-s.hauer@pengutronix.de>
+MIME-Version: 1.0
+X-SA-Exim-Connect-IP: 2a0a:edc0:0:c01:1d::a2
+X-SA-Exim-Mail-From: sha@pengutronix.de
+X-SA-Exim-Scanned: No (on metis.ext.pengutronix.de);
+ SAEximRunCond expanded to false
+X-PTX-Original-Recipient: linux-wireless@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-wireless.vger.kernel.org>
+X-Mailing-List: linux-wireless@vger.kernel.org
+
+We have to extract qsel from the skb before doing skb_push() on it,
+otherwise qsel will always be 0.
+
+Fixes: a82dfd33d1237 ("wifi: rtw88: Add common USB chip support")
+Signed-off-by: Sascha Hauer <s.hauer@pengutronix.de>
+---
+ drivers/net/wireless/realtek/rtw88/usb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index 4ef38279b64c9..d9e995544e405 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -471,9 +471,9 @@ static int rtw_usb_tx_write(struct rtw_dev *rtwdev,
+ 	u8 *pkt_desc;
+ 	int ep;
+ 
++	pkt_info->qsel = rtw_usb_tx_queue_mapping_to_qsel(skb);
+ 	pkt_desc = skb_push(skb, chip->tx_pkt_desc_sz);
+ 	memset(pkt_desc, 0, chip->tx_pkt_desc_sz);
+-	pkt_info->qsel = rtw_usb_tx_queue_mapping_to_qsel(skb);
+ 	ep = qsel_to_ep(rtwusb, pkt_info->qsel);
+ 	rtw_tx_fill_tx_desc(pkt_info, skb);
+ 	rtw_tx_fill_txdesc_checksum(rtwdev, pkt_info, skb->data);
+
+From: Sascha Hauer <s.hauer@pengutronix.de>
+To: linux-wireless@vger.kernel.org
+Cc: Neo Jou <neojou@gmail.com>, Hans Ulli Kroll <linux@ulli-kroll.de>,
+        Ping-Ke Shih <pkshih@realtek.com>,
+        Yan-Hsuan Chuang <tony0620emma@gmail.com>,
+        Kalle Valo <kvalo@kernel.org>, netdev@vger.kernel.org,
+        linux-kernel@vger.kernel.org,
+        Martin Blumenstingl <martin.blumenstingl@googlemail.com>,
+        kernel@pengutronix.de, Alexander Hochbaum <alex@appudo.com>,
+        Da Xue <da@libre.computer>, Po-Hao Huang <phhuang@realtek.com>,
+        Andreas Henriksson <andreas@fatal.se>,
+        Viktor Petrenko <g0000ga@gmail.com>,
+        Sascha Hauer <s.hauer@pengutronix.de>
+Subject: [PATCH v2 2/3] wifi: rtw88: usb: send Zero length packets if
+ necessary
+Date: Fri, 10 Feb 2023 12:16:31 +0100
+Message-Id: <20230210111632.1985205-3-s.hauer@pengutronix.de>
+X-Mailer: git-send-email 2.30.2
+In-Reply-To: <20230210111632.1985205-1-s.hauer@pengutronix.de>
+References: <20230210111632.1985205-1-s.hauer@pengutronix.de>
+MIME-Version: 1.0
+X-SA-Exim-Connect-IP: 2a0a:edc0:0:c01:1d::a2
+X-SA-Exim-Mail-From: sha@pengutronix.de
+X-SA-Exim-Scanned: No (on metis.ext.pengutronix.de);
+ SAEximRunCond expanded to false
+X-PTX-Original-Recipient: linux-wireless@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-wireless.vger.kernel.org>
+X-Mailing-List: linux-wireless@vger.kernel.org
+
+Zero length packets are necessary when sending URBs with size
+multiple of bulkout_size, otherwise the hardware just stalls.
+
+Fixes: a82dfd33d1237 ("wifi: rtw88: Add common USB chip support")
+Signed-off-by: Sascha Hauer <s.hauer@pengutronix.de>
+---
+ drivers/net/wireless/realtek/rtw88/usb.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index d9e995544e405..1a09c9288198a 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -271,6 +271,7 @@ static int rtw_usb_write_port(struct rtw_dev *rtwdev, u8 qsel, struct sk_buff *s
+ 		return -ENOMEM;
+ 
+ 	usb_fill_bulk_urb(urb, usbd, pipe, skb->data, skb->len, cb, context);
++	urb->transfer_flags |= URB_ZERO_PACKET;
+ 	ret = usb_submit_urb(urb, GFP_ATOMIC);
+ 
+ 	usb_free_urb(urb);
+
+From: Sascha Hauer <s.hauer@pengutronix.de>
+To: linux-wireless@vger.kernel.org
+Cc: Neo Jou <neojou@gmail.com>, Hans Ulli Kroll <linux@ulli-kroll.de>,
+        Ping-Ke Shih <pkshih@realtek.com>,
+        Yan-Hsuan Chuang <tony0620emma@gmail.com>,
+        Kalle Valo <kvalo@kernel.org>, netdev@vger.kernel.org,
+        linux-kernel@vger.kernel.org,
+        Martin Blumenstingl <martin.blumenstingl@googlemail.com>,
+        kernel@pengutronix.de, Alexander Hochbaum <alex@appudo.com>,
+        Da Xue <da@libre.computer>, Po-Hao Huang <phhuang@realtek.com>,
+        Andreas Henriksson <andreas@fatal.se>,
+        Viktor Petrenko <g0000ga@gmail.com>,
+        Sascha Hauer <s.hauer@pengutronix.de>
+Subject: [PATCH v2 3/3] wifi: rtw88: usb: drop now unnecessary URB size check
+Date: Fri, 10 Feb 2023 12:16:32 +0100
+Message-Id: <20230210111632.1985205-4-s.hauer@pengutronix.de>
+X-Mailer: git-send-email 2.30.2
+In-Reply-To: <20230210111632.1985205-1-s.hauer@pengutronix.de>
+References: <20230210111632.1985205-1-s.hauer@pengutronix.de>
+MIME-Version: 1.0
+X-SA-Exim-Connect-IP: 2a0a:edc0:0:c01:1d::a2
+X-SA-Exim-Mail-From: sha@pengutronix.de
+X-SA-Exim-Scanned: No (on metis.ext.pengutronix.de);
+ SAEximRunCond expanded to false
+X-PTX-Original-Recipient: linux-wireless@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-wireless.vger.kernel.org>
+X-Mailing-List: linux-wireless@vger.kernel.org
+
+Now that we send URBs with the URB_ZERO_PACKET flag set we no longer
+need to make sure that the URB sizes are not multiple of the
+bulkout_size. Drop the check.
+
+Signed-off-by: Sascha Hauer <s.hauer@pengutronix.de>
+---
+ drivers/net/wireless/realtek/rtw88/usb.c | 15 +--------------
+ 1 file changed, 1 insertion(+), 14 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index 1a09c9288198a..2a8336b1847a5 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -414,24 +414,11 @@ static int rtw_usb_write_data_rsvd_page(struct rtw_dev *rtwdev, u8 *buf,
+ 					u32 size)
+ {
+ 	const struct rtw_chip_info *chip = rtwdev->chip;
+-	struct rtw_usb *rtwusb;
+ 	struct rtw_tx_pkt_info pkt_info = {0};
+-	u32 len, desclen;
+-
+-	rtwusb = rtw_get_usb_priv(rtwdev);
+ 
+ 	pkt_info.tx_pkt_size = size;
+ 	pkt_info.qsel = TX_DESC_QSEL_BEACON;
+-
+-	desclen = chip->tx_pkt_desc_sz;
+-	len = desclen + size;
+-	if (len % rtwusb->bulkout_size == 0) {
+-		len += RTW_USB_PACKET_OFFSET_SZ;
+-		pkt_info.offset = desclen + RTW_USB_PACKET_OFFSET_SZ;
+-		pkt_info.pkt_offset = 1;
+-	} else {
+-		pkt_info.offset = desclen;
+-	}
++	pkt_info.offset = chip->tx_pkt_desc_sz;
+ 
+ 	return rtw_usb_write_data(rtwdev, &pkt_info, buf);
+ }


### PR DESCRIPTION
- linux: rtw88: upstream patches
  - https://forum.libreelec.tv/thread/23001-0bda-b812-rtl88x2bu-kernel-module/?postID=176876#post176876
- kernel-firmware: update to 20230210
  - https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/
  - Includes 8822cs Firmware version 9.9.14 - as below

### TX6 with 8822bs
```
LibreELEC:~ # dmesg | grep -e rtw -e wlan -e hci0 -e 6.1.11
[    0.000000] Linux version 6.1.11 (docker@ed6f8f34d420) (aarch64-none-elf-gcc-12.2.0 (GCC) 12.2.0, GNU ld (GNU Binutils) 2.39) #1 SMP PREEMPT Sat Feb 11 04:18:21 UTC 2023
[    0.000000] Machine model: Tanix TX6
[    3.236950] kernel-overlays-setup: added modules from /usr/lib/kernel-overlays/base/lib/modules/6.1.11
[    9.345695] rtw_8822bs mmc1:0001:1: Firmware version 27.2.0, H2C version 13
[    9.372739] Bluetooth: hci0: RTL: examining hci_ver=07 hci_rev=000b lmp_ver=07 lmp_subver=8822
[    9.376905] Bluetooth: hci0: RTL: rom_version status=0 version=2
[    9.376960] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822bs_fw.bin
[    9.403375] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822bs_config.bin
[    9.426475] Bluetooth: hci0: RTL: cfg_sz 75, total sz 24543
[   10.721960] Bluetooth: hci0: RTL: fw version 0xaa89f793
[   31.093707] wlan0: authenticate with
[   32.490762] wlan0: send auth to (try 1/3)
[   32.496042] wlan0: authenticated
[   32.502320] wlan0: associate with (try 1/3)
[   32.523126] wlan0: RX AssocResp from (capab=0x111 status=0 aid=5)
[   32.621221] wlan0: associated
[   32.813219] wlan0: Limiting TX power to 12 (15 - 3) dBm as advertised by
```

### TX6 with 8822cs
```
tx6:~ # dmesg | grep -e rtw -e wlan -e hci0 -e 6.1.11 -e Tanix
[    0.000000] Linux version 6.1.11 (docker@ed6f8f34d420) (aarch64-none-elf-gcc-12.2.0 (GCC) 12.2.0, GNU ld (GNU Binutils) 2.39) #1 SMP PREEMPT Sat Feb 11 04:18:21 UTC 2023
[    0.000000] Machine model: Tanix TX6
[    2.364093] kernel-overlays-setup: added modules from /usr/lib/kernel-overlays/base/lib/modules/6.1.11
[    6.161194] dwmac-sun8i 5020000.ethernet: IRQ eth_wake_irq not found
[    6.981396] rtw_8822cs mmc1:0001:1: WOW Firmware version 9.9.4, H2C version 15
[    6.982373] rtw_8822cs mmc1:0001:1: Firmware version 9.9.14, H2C version 15
[    7.047298] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
[    7.052258] Bluetooth: hci0: RTL: rom_version status=0 version=3
[    7.052301] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_fw.bin
[    7.070317] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_config.bin
[    7.095141] Bluetooth: hci0: RTL: cfg_sz 33, total sz 36529
[    7.619759] Bluetooth: hci0: RTL: fw version 0xffb8abd6
[   35.522390] wlan0: authenticate with
[   40.415987] wlan0: send auth to (try 1/3)
[   40.419876] wlan0: authenticated
[   40.422875] wlan0: associate with (try 1/3)
[   40.441449] wlan0: RX AssocResp from (capab=0x111 status=0 aid=8)
[   40.532882] wlan0: associated
[   40.627881] wlan0: Limiting TX power to 12 (15 - 3) dBm as advertised by
```