### PR TITLE
Rockchip: fixes/improvements

### DIFF
--- a/packages/tools/atf/package.mk
+++ b/packages/tools/atf/package.mk
@@ -14,13 +14,13 @@ PKG_TOOLCHAIN="manual"
 
 [ -n "${KERNEL_TOOLCHAIN}" ] && PKG_DEPENDS_TARGET+=" gcc-${KERNEL_TOOLCHAIN}:host"
 
-if [ "${PROJECT}" = "Rockchip" -a "${DEVICE}" = "RK3399" ]; then
+if [ "${ATF_PLATFORM}" = "rk3399" ]; then
   PKG_DEPENDS_TARGET+=" gcc-arm-none-eabi:host"
   export M0_CROSS_COMPILE="${TOOLCHAIN}/bin/arm-none-eabi-"
 fi
 
 make_target() {
-  if [ "${DEVICE}" = "iMX8" ]; then
+  if [ "${ATF_PLATFORM}" = "imx8mq" ]; then
     CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="--no-warn-rwx-segments" CFLAGS="--param=min-pagesize=0" make PLAT=${ATF_PLATFORM} bl31
   else
     CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="--no-warn-rwx-segments" CFLAGS="" make PLAT=${ATF_PLATFORM} bl31

--- a/projects/Rockchip/README.md
+++ b/projects/Rockchip/README.md
@@ -29,11 +29,15 @@ This project is for Rockchip SoC devices
 * [ROC-RK3399-PC-PLUS](devices/RK3399)
 * [Rockchip Sapphire Board](devices/RK3399)
 
-**My single-board computer is not listed, will it be added in the future?**<br />
+**My single-board computer is not listed, will it be added in the future?**<br>
 If your single-board computer uses a current generation SoC listed on http://opensource.rock-chips.com/wiki_Main_Page the odds are in your favor.
 
-**My Android device is not listed, will it be added in the future?**<br />
+**My Android device is not listed, will it be added in the future?**<br>
 You may have luck if your device vendor is open source friendly, otherwise keep using Android for best support.
+
+**My device does not boot and I don't understand why.**<br>
+If your device has Android or any sort of vendor u-boot preinstalled in EMMC or SPI, make sure to add `ROCKCHIP_LEGACY_BOOT=1` when building an image.
+This is done automatically for supported devices, which are known to come with Android preinstalled.
 
 ## Links
 

--- a/projects/Rockchip/bootloader/firmware
+++ b/projects/Rockchip/bootloader/firmware
@@ -1,4 +1,5 @@
-export ROCKCHIP_LEGACY_BOOT=$("${ROOT}"/"${SCRIPTS}"/uboot_helper "${PROJECT}" "${DEVICE}" "${UBOOT_SYSTEM}" rockchip_legacy_boot) || "${ROCKCHIP_LEGACY_BOOT:-}"
+
+[ -z "${ROCKCHIP_LEGACY_BOOT}" ] && export ROCKCHIP_LEGACY_BOOT=$("${ROOT}/${SCRIPTS}/uboot_helper" "${PROJECT}" "${DEVICE}" "${UBOOT_SYSTEM}" rockchip_legacy_boot)
 
 if [ "${ROCKCHIP_LEGACY_BOOT}" = "1" ]; then
   export UBOOT_TARGET="u-boot-dtb.bin"

--- a/projects/Rockchip/bootloader/install
+++ b/projects/Rockchip/bootloader/install
@@ -3,7 +3,6 @@
 
 PKG_RKBIN="$(get_build_dir rkbin)"
 PKG_SOC="${DEVICE/RK/rk}"
-UBOOT_CONFIG=$("${ROOT}"/"${SCRIPTS}"/uboot_helper "${PROJECT}" "${DEVICE}" "${UBOOT_SYSTEM}" config)
 
 if [ "${ROCKCHIP_LEGACY_BOOT}" = "1" ]; then
   echo "install: building Rockchip legacy boot chain ..."

--- a/projects/Rockchip/bootloader/mkimage
+++ b/projects/Rockchip/bootloader/mkimage
@@ -5,7 +5,7 @@ if [ -n "${UBOOT_SYSTEM}" ]; then
   BOOTLOADER_PATH="${RELEASE_DIR}/3rdparty/bootloader/u-boot-rockchip.bin"
   if [ -f "${BOOTLOADER_PATH}" ]; then
     echo "image: burn bootloader to image..."
-    dd if="${BOOTLOADER_PATH}" of="${DISK}" seek=64 conv=fsync,notrunc >"${SAVE_ERROR}" 2>&1 || show_error
+    dd if="${BOOTLOADER_PATH}" of="${DISK}" bs=32k seek=1 conv=fsync,notrunc >"${SAVE_ERROR}" 2>&1 || show_error
   else
     echo "image: bootloader ${BOOTLOADER_PATH} does not exist.";
     exit 1

--- a/projects/Rockchip/bootloader/update.sh
+++ b/projects/Rockchip/bootloader/update.sh
@@ -59,7 +59,7 @@ fi
 # update bootloader
  if [ -f ${SYSTEM_ROOT}/usr/share/bootloader/u-boot-rockchip.bin ]; then
     echo -n "Updating fit image u-boot-rockchip.bin ... "
-    dd if=${SYSTEM_ROOT}/usr/share/bootloader/u-boot-rockchip.bin of=${BOOT_DISK} seek=64 conv=fsync &>/dev/null
+    dd if=${SYSTEM_ROOT}/usr/share/bootloader/u-boot-rockchip.bin of=${BOOT_DISK} bs=32k seek=1 conv=fsync,notrunc &>/dev/null
     echo "done"
   fi
 

--- a/projects/Rockchip/devices/RK3288/filesystem/usr/bin/cputemp
+++ b/projects/Rockchip/devices/RK3288/filesystem/usr/bin/cputemp
@@ -4,5 +4,5 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-TEMP="$(cat /sys/class/thermal/thermal_zone1/temp)"
+TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
 echo "$(( $TEMP / 1000 )) C"

--- a/projects/Rockchip/devices/RK3288/filesystem/usr/bin/gputemp
+++ b/projects/Rockchip/devices/RK3288/filesystem/usr/bin/gputemp
@@ -4,5 +4,5 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-TEMP="$(cat /sys/class/thermal/thermal_zone2/temp)"
+TEMP="$(cat /sys/class/thermal/thermal_zone1/temp)"
 echo "$(( $TEMP / 1000 )) C"

--- a/projects/Rockchip/patches/linux/default/linux-1002-for-libreelec.patch
+++ b/projects/Rockchip/patches/linux/default/linux-1002-for-libreelec.patch
@@ -196,30 +196,6 @@ index 093ebe070775..a10fe60b7680 100644
  		simple-audio-card,cpu {
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Wed, 10 Feb 2021 18:44:56 +0200
-Subject: [PATCH] HACK: drm/gem: suppress warning about missing vm_flags
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- drivers/gpu/drm/drm_gem.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/drivers/gpu/drm/drm_gem.c b/drivers/gpu/drm/drm_gem.c
-index ad068865ba20..9deb8d1d291d 100644
---- a/drivers/gpu/drm/drm_gem.c
-+++ b/drivers/gpu/drm/drm_gem.c
-@@ -1038,7 +1038,7 @@ int drm_gem_mmap_obj(struct drm_gem_object *obj, unsigned long obj_size,
- 		ret = obj->funcs->mmap(obj, vma);
- 		if (ret)
- 			goto err_drm_gem_object_put;
--		WARN_ON(!(vma->vm_flags & VM_DONTEXPAND));
-+		//WARN_ON(!(vma->vm_flags & VM_DONTEXPAND));
- 	} else {
- 		if (!vma->vm_ops) {
- 			ret = -EINVAL;
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 25 Mar 2018 22:17:06 +0200
 Subject: [PATCH] ASoC: hdmi-codec: fix channel allocation

--- a/scripts/image
+++ b/scripts/image
@@ -184,7 +184,7 @@ ln -sf /etc/issue ${INSTALL}/etc/motd
 
 # Copy PROJECT related files to filesystem
 if [ -d "${PROJECT_DIR}/${PROJECT}/filesystem" ]; then
-  cp -PR ${PROJECT_DIR}/${PROJECT}/filesystem/* ${INSTALL}
+  cp -PR --remove-destination ${PROJECT_DIR}/${PROJECT}/filesystem/* ${INSTALL}
   # Install project specific systemd services
   for service in ${PROJECT_DIR}/${PROJECT}/filesystem/usr/lib/systemd/system/*.service; do
     if [ -f "${service}" ]; then
@@ -195,7 +195,7 @@ fi
 
 # Copy DEVICE related files to filesystem
 if [ -n "${DEVICE}" -a -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem" ]; then
-  cp -PR ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem/* ${INSTALL}
+  cp -PR --remove-destination ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem/* ${INSTALL}
   # Install device specific systemd services
   for service in ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem/usr/lib/systemd/system/*.service; do
     if [ -f "${service}" ]; then


### PR DESCRIPTION
- when copying files to the filesystem in `scripts/image` form PROJECT/DEVICE eventually existing symlinks aren't replaced (which is caused by the necessary `-P` option) - I added `--remove-destination` to `cp` to make sure they replaced as expected. That might be needed in other places, too.
- fixed thermal_zone numbers for RK3288
- dropped a no-longer required panfrost patch for Rockchip
- atf package will now use ATF_PLATFORM instead of PROJECT/DEVICE for platform specific quirks in package.mk
- replaced options for `dd` in Rockchip bootloader scripts used in order to speedup writing the bootloader. thanks for the hint @kwiboo
- allow `ROCKCHIP_LEGACY_BOOT` (used for boards w/o upstream u-boot support or known to have Android preinstalled) to passed from command line when building and document that option in project's README.md