### PR TITLE
intel-ucode: update to 20230214

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20221108"
-PKG_SHA256="8d14a914815f56c27b1f41be0fd699d1afcfdbc05432056427e455100798975e"
+PKG_VERSION="20230214"
+PKG_SHA256="3a3cfe2c7642339af9f4c2ad69f5f367dfa4cd1f7f9fd4124dedefb7803591d4"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"


### PR DESCRIPTION
release notes:
- https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20230214

tested with:
```
Before
[    0.000000] microcode: microcode updated early to revision 0x424, date = 2022-09-19
After
[    0.000000] microcode: microcode updated early to revision 0x429, date = 2023-01-11
[    0.163557] smpboot: CPU0: 12th Gen Intel(R) Core(TM) i7-1260P (family: 0x6, model: 0x9a, stepping: 0x3)
```