### PR TITLE
zstd: update to 1.5.4

### DIFF
--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.5.2"
-PKG_SHA256="3ea06164971edec7caa2045a1932d757c1815858e4c2b68c7ef812647535c23f"
+PKG_VERSION="1.5.4"
+PKG_SHA256="6925880b84aca086308c27036ef1c16e76817372301ead7c37f90e23567f704e"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"
 PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.zst"


### PR DESCRIPTION
Release notes: https://github.com/facebook/zstd/releases/tag/v1.5.4

