### PR TITLE
pipewire: update to 0.3.66

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.65"
-PKG_SHA256="bb76f938136d0ce8c35bffa99e002dc2dbaeab5e14c6c34154e7f750013d1d6b"
+PKG_VERSION="0.3.66"
+PKG_SHA256="36b6028434c16aacfc6695073b7ca4996c5476eb92833340566d27538b635508"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/08b0ed65765a1033424a5c0d897a392a61f8a2a3