### PR TITLE
Add aarch64 userland to RPi

### DIFF
--- a/packages/tools/bcm2835-userland/package.mk
+++ b/packages/tools/bcm2835-userland/package.mk
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="bcm2835-userland"
+PKG_VERSION="54fd97ae4066a10b6b02089bc769ceed328737e0"
+PKG_SHA256="b5718b34730069b7c3748cefb528696267c5bf9ba1e12df4f668640c50849125"
+PKG_ARCH="arm aarch64"
+PKG_LICENSE="BSD-3-Clause"
+PKG_SITE="https://github.com/raspberrypi/userland"
+PKG_URL="https://github.com/raspberrypi/userland/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="gcc:host"
+PKG_LONGDESC="Source code for ARM side libraries for interfacing to Raspberry Pi GPU"
+PKG_TOOLCHAIN="cmake"
+
+if [ ${TARGET_ARCH} = "aarch64" ]; then
+  PKG_CMAKE_OPTS_TARGET="-DARM64=ON"
+else
+  PKG_CMAKE_OPTS_TARGET="-DARM64=OFF"
+fi
+
+makeinstall_target() {
+  # libraries used by below binaries
+  mkdir -p ${INSTALL}/usr/lib
+#    cp -PRv ${PKG_BUILD}/build/lib/libbcm_host.so ${INSTALL}/usr/lib
+#    cp -PRv ${PKG_BUILD}/build/lib/libdebug_sym.so ${INSTALL}/usr/lib
+    cp -PRv ${PKG_BUILD}/build/lib/libdtovl.so ${INSTALL}/usr/lib
+    cp -PRv ${PKG_BUILD}/build/lib/libvchiq_arm.so ${INSTALL}/usr/lib
+    cp -PRv ${PKG_BUILD}/build/lib/libvcos.so ${INSTALL}/usr/lib
+#    cp -PRv ${PKG_BUILD}/build/lib/libdebug_sym_static.a ${INSTALL}/usr/lib
+#    cp -PRv ${PKG_BUILD}/build/lib/libfdt.a ${INSTALL}/usr/lib
+#    cp -PRv ${PKG_BUILD}/build/lib/libvchostif.a ${INSTALL}/usr/lib
+
+  mkdir -p ${INSTALL}/usr/bin
+    cp -PRv ${PKG_BUILD}/build/bin/dtoverlay ${INSTALL}/usr/bin
+    ln -s dtoverlay                          ${INSTALL}/usr/bin/dtparam
+    cp -PRv ${PKG_BUILD}/build/bin/vcgencmd  ${INSTALL}/usr/bin
+    cp -PRv ${PKG_BUILD}/build/bin/vcmailbox ${INSTALL}/usr/bin
+# tvservice does nothing when using vc4 driver
+#    cp -PRv ${PKG_BUILD}/build/bin/tvservice ${INSTALL}/usr/bin
+}

--- a/packages/tools/bcm2835-utils/package.mk
+++ b/packages/tools/bcm2835-utils/package.mk
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="bcm2835-utils"
+PKG_VERSION="5db3e694d27431403bebb13404f5d85899b571e0"
+PKG_SHA256="ab8a9f7632fe979533b801644f30211f916cd8280f476471b5d323d420d7a146"
+PKG_ARCH="arm aarch64"
+PKG_LICENSE="BSD-3-Clause"
+PKG_SITE="https://github.com/raspberrypi/utils"
+PKG_URL="https://github.com/raspberrypi/utils/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="gcc:host"
+PKG_LONGDESC="Raspberry Pi related collection of scripts and simple applications"
+PKG_TOOLCHAIN="cmake"
+
+# only going to use vclog so don't build everything else
+make_target() {
+  mkdir -p ${PKG_BUILD}/.${TARGET_NAME}/vclog/build
+  cd ${PKG_BUILD}/.${TARGET_NAME}/vclog/build
+  cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CONF} -DCMAKE_C_FLAGS="${TARGET_CFLAGS}" -S ${PKG_BUILD}/vclog
+  make
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp -PRv ${PKG_BUILD}/.${TARGET_NAME}/vclog/build/vclog ${INSTALL}/usr/bin
+}

--- a/projects/RPi/devices/RPi/options
+++ b/projects/RPi/devices/RPi/options
@@ -2,6 +2,16 @@
 # Device defaults
 ################################################################################
 
+  # The TARGET_CPU variable controls which processor should be targeted for
+  # generated code.
+    case $TARGET_ARCH in
+      arm)
+        TARGET_FLOAT="hard"
+        TARGET_CPU="arm1176jzf-s"
+        TARGET_FPU="vfp"
+        ;;
+    esac
+
   # NOOBS supported hex versions (legacy)
     NOOBS_HEX="2,3,4,5,6,7,8,9,d,e,f,10,11,12,14,19,0092,0093"
 

--- a/projects/RPi/devices/RPi2/options
+++ b/projects/RPi/devices/RPi2/options
@@ -2,6 +2,16 @@
 # Device defaults
 ################################################################################
 
+  # The TARGET_CPU variable controls which processor should be targeted for
+  # generated code.
+    case $TARGET_ARCH in
+      arm)
+        TARGET_CPU="cortex-a7"
+        TARGET_FPU="neon-vfpv4"
+        TARGET_FLOAT="hard"
+        ;;
+    esac
+
   # NOOBS supported hex versions (legacy)
     NOOBS_HEX="1040,1041,2082"
 

--- a/projects/RPi/devices/RPi4/options
+++ b/projects/RPi/devices/RPi4/options
@@ -14,11 +14,21 @@
   # set the addon project
     ADDON_PROJECT="ARMv8"
 
-  # build 64bit kernel
+  # The TARGET_CPU variable controls which processor should be targeted for
+  # generated code.
     case $TARGET_ARCH in
+      aarch64)
+        TARGET_CPU="cortex-a72"
+        TARGET_CPU_FLAGS="+crc"
+        ;;
       arm)
         TARGET_KERNEL_ARCH="arm64"
         TARGET_KERNEL_PATCH_ARCH="aarch64"
+        TARGET_FLOAT="hard"
+        # cortex-a72 caused issues in the past, so use a53
+        TARGET_CPU="cortex-a53"
+        TARGET_CPU_FLAGS="+crc"
+        TARGET_FPU="neon-fp-armv8"
         ;;
     esac
 

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -2,40 +2,6 @@
 # setup system defaults
 ################################################################################
 
-  # The TARGET_CPU variable controls which processor should be targeted for
-  # generated code.
-    case $TARGET_ARCH in
-      arm)
-        # Valid TARGET_CPU for Raspberry Pi based devices are:
-        # arm1176jzf-s cortex-a7 cortex-a53
-        if [ "$DEVICE" = "RPi" ]; then
-          TARGET_CPU="arm1176jzf-s"
-        elif [ "$DEVICE" = "RPi2" ]; then
-          TARGET_CPU="cortex-a7"
-        elif [ "$DEVICE" = "RPi4" ]; then
-          TARGET_CPU="cortex-a53"
-          TARGET_CPU_FLAGS="+crc"
-        fi
-
-        # TARGET_FLOAT:
-        # Specifies which floating-point ABI to use. Permissible values are:
-        # soft hard
-        TARGET_FLOAT="hard"
-
-        # Valid TARGET_FPU for Raspberry Pi based devices:
-        # This specifies what floating point hardware (or hardware emulation) is
-        # available on the target. Permissible names are:
-        # vfp neon-vfpv4 neon-fp-armv8
-        if [ "$DEVICE" = "RPi" ]; then
-          TARGET_FPU="vfp"
-        elif [ "$DEVICE" = "RPi2" ]; then
-          TARGET_FPU="neon-vfpv4"
-        elif [ "$DEVICE" = "RPi4" ]; then
-          TARGET_FPU="neon-fp-armv8"
-        fi
-        ;;
-    esac
-
   # Bootloader to use (bcm2835-bootloader)
     BOOTLOADER="bcm2835-bootloader"
 

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -73,7 +73,11 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS+=" DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS+=" bcm2835-driver"
+    if [ ${TARGET_ARCH} = "aarch64" ]; then
+      ADDITIONAL_PACKAGES+=" bcm2835-userland"
+    else
+      ADDITIONAL_DRIVERS+=" bcm2835-driver"
+    fi
 
     if [ "${ALSA_SUPPORT}" = "yes" ]; then
       ADDITIONAL_DRIVERS+=" rpi-cirrus-config"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -89,7 +89,7 @@
     DRIVER_ADDONS="crazycat dvb-latest"
 
   # additional packages to install:
-    ADDITIONAL_PACKAGES+=" bcm2835-userland"
+    ADDITIONAL_PACKAGES+=" bcm2835-userland bcm2835-utils"
 
   # debug tty path
     DEBUG_TTY="/dev/console"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -73,11 +73,8 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS+=" DRIVER1 DRIVER2"
-    if [ ${TARGET_ARCH} = "aarch64" ]; then
-      ADDITIONAL_PACKAGES+=" bcm2835-userland"
-    else
-      ADDITIONAL_DRIVERS+=" bcm2835-driver"
-    fi
+# Comment ADDITIONAL_PACKAGES below if using bcm2835-driver
+#    ADDITIONAL_DRIVERS+=" bcm2835-driver"
 
     if [ "${ALSA_SUPPORT}" = "yes" ]; then
       ADDITIONAL_DRIVERS+=" rpi-cirrus-config"
@@ -90,6 +87,9 @@
   # for a list of additional drivers see packages/linux-driver-addons
   # Space separated list is supported,
     DRIVER_ADDONS="crazycat dvb-latest"
+
+  # additional packages to install:
+    ADDITIONAL_PACKAGES+=" bcm2835-userland"
 
   # debug tty path
     DEBUG_TTY="/dev/console"


### PR DESCRIPTION
This adds the foundation for a usable/testable image for RPi using an aarch64 userland, meaning it boots, runs Kodi, and plays media. There are no prebuilt addons from LE being distributed for such a platform at this time.

Regarding bcm2835-drivers v. bcm2835-userland:

bcm2835-drivers has everything bcm2835-userland does and then some, but it's distributed pre-built for arm. bcm2835-userland is distributed in source form so it may build for aarch64. This gets the useful commands vcgencmd, dtoverlay, dtparam, and their needed libraries. Other libraries are available (listed and commented in package), but I haven't identified a use for them, so left them out. (Thanks @ToKe79 for pointing me in this direction.)

This is split from an RPi3 device branch. I expect it to be fine as a start for RPi4.