### PR TITLE
mesa: update to 22.3.6

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="22.3.5"
-PKG_SHA256="3eed2ecae2bc674494566faab9fcc9beb21cd804c7ba2b59a1694f3d7236e6a9"
+PKG_VERSION="22.3.6"
+PKG_SHA256="4ec8ec65dbdb1ee9444dba72970890128a19543a58cf05931bd6f54f124e117f"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release notes:
- https://gitlab.freedesktop.org/mesa/mesa/-/blob/22.3/docs/relnotes/22.3.6.rst

```
=== tested on ===
Generic.x86_64-devel-20230223104503-68224ac
Linux nuc12 6.1.13-rc1 #1 SMP Tue Feb 21 13:28:17 UTC 2023 x86_64 GNU/Linux
Starting Kodi (20.0 (20.0.0) Git:20.0-Nexus). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2023-02-14 by GCC 12.2.0 for Linux x86 64-bit version 6.1.12 (393484)
Running on LibreELEC (heitbaum): devel-20230223104503-68224ac 11.0, kernel: Linux x86 64-bit version 6.1.13-rc1
FFmpeg version/source: 4.4.1-Kodi
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0085.2022.0718.1739 07/18/2022
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 22.3.6
libva info: VA-API version 1.17.0
vainfo: VA-API version: 1.17 (libva 2.17.1)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.1.2 (c780dedec2)
```