### PR TITLE
Fix missing symbols when building with split debug info

### DIFF
--- a/config/optimize
+++ b/config/optimize
@@ -47,9 +47,9 @@ CFLAGS_OPTIM_DEBUG="-ggdb -Og"
 CXXFLAGS_OPTIM_DEBUG="$CFLAGS_OPTIM_DEBUG"
 LDFLAGS_OPTIM_DEBUG="-ggdb"
 # split debug settings (requires gold)
-CFLAGS_OPTIM_DEBUG_SPLIT="-gsplit-dwarf -Og"
+CFLAGS_OPTIM_DEBUG_SPLIT="-gdwarf-4 -gsplit-dwarf -Og"
 CXXFLAGS_OPTIM_DEBUG_SPLIT="$CFLAGS_OPTIM_DEBUG_SPLIT"
-LDFLAGS_OPTIM_DEBUG_SPLIT="-Wl,--gdb-index"
+LDFLAGS_OPTIM_DEBUG_SPLIT="-gdwarf-4 -Wl,--gdb-index"
 
 # position-independent code
 CFLAGS_OPTIM_PIC="-fPIC -DPIC"


### PR DESCRIPTION
Since gcc 11 -gsplit-dwarf no longer implicitly enables -g and needs a separate -g option. For some yet unknown reasons the default DWARF 5 format doesn't work, gdb doesn't show debug info, but DWARF 4 works fine so use that.