### PR TITLE
upnp: fix-folder-definitions-for-upnproot and add-quirk-for-Samsung TVs

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.25-upnp-fix-folder-definitions-for-upnproot-and-video-m.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.25-upnp-fix-folder-definitions-for-upnproot-and-video-m.patch
@@ -1,0 +1,52 @@
+From 6f0d96b128668d8b7b38997eec92a0bc4a04b6c0 Mon Sep 17 00:00:00 2001
+From: Miguel Borges de Freitas <92enen@gmail.com>
+Date: Tue, 21 Feb 2023 21:55:56 +0000
+Subject: [PATCH 1/2] [upnp] fix folder definitions for upnproot and
+ video/music library
+
+---
+ xbmc/network/upnp/UPnPServer.cpp | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/network/upnp/UPnPServer.cpp b/xbmc/network/upnp/UPnPServer.cpp
+index 09079e4769..8b4fad7892 100644
+--- a/xbmc/network/upnp/UPnPServer.cpp
++++ b/xbmc/network/upnp/UPnPServer.cpp
+@@ -272,8 +272,9 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+ 
+     m_logger->debug("Preparing upnp object for item '{}'", (const char*)path);
+ 
+-    if (path == "virtualpath://upnproot") {
++    if (path.StartsWith("virtualpath://upnproot")) {
+         path.TrimRight("/");
++        item->m_bIsFolder =  true;
+         if (path.StartsWith("virtualpath://")) {
+             object = new PLT_MediaContainer;
+             object->m_Title = item->GetLabel().c_str();
+@@ -331,6 +332,11 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+                     }
+                 }
+ 
++                // all items appart from songs (artists, albums, etc) are folders
++                if (!item->HasMusicInfoTag() || item->GetMusicInfoTag()->GetType() != MediaTypeSong)
++                {
++                    item->m_bIsFolder = true;
++                }
+ 
+                 if (item->GetLabel().empty()) {
+                     /* if no label try to grab it from node type */
+@@ -380,6 +386,11 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+                     item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("totalepisodes").asInteger();
+                     item->GetVideoInfoTag()->SetPlayCount(static_cast<int>(item->GetProperty("watchedepisodes").asInteger()));
+                 }
++                // if this is an item in the library without a playable path it most be a folder
++                else if (item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
++                {
++                    item->m_bIsFolder = true;
++                }
+ 
+                 // try to grab title from tag
+                 if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_strTitle.empty()) {
+-- 
+2.39.2
+

--- a/packages/mediacenter/kodi/patches/kodi-999.26-upnp-add-quirk-for-Samsung-1.0-UPnP-1.0.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.26-upnp-add-quirk-for-Samsung-1.0-UPnP-1.0.patch
@@ -1,0 +1,26 @@
+From 7f5c291395d1245a2c10b776cc784083b21e11e4 Mon Sep 17 00:00:00 2001
+From: Miguel Borges de Freitas <92enen@gmail.com>
+Date: Wed, 22 Feb 2023 22:25:44 +0000
+Subject: [PATCH 2/2] [upnp] add quirk for Samsung/1.0 UPnP/1.0
+
+---
+ xbmc/network/upnp/UPnPInternal.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/network/upnp/UPnPInternal.cpp b/xbmc/network/upnp/UPnPInternal.cpp
+index f4ba92ae05..06abb4c506 100644
+--- a/xbmc/network/upnp/UPnPInternal.cpp
++++ b/xbmc/network/upnp/UPnPInternal.cpp
+@@ -73,7 +73,8 @@ EClientQuirks GetClientQuirks(const PLT_HttpRequestContext* context)
+ 
+   if (user_agent) {
+       if (user_agent->Find("XBox", 0, true) >= 0 ||
+-          user_agent->Find("Xenon", 0, true) >= 0)
++          user_agent->Find("Xenon", 0, true) >= 0 ||
++          user_agent->Find("Samsung/1.0 UPnP/1.0", 0, true) >= 0)
+           quirks |= ECLIENTQUIRKS_ONLYSTORAGEFOLDER | ECLIENTQUIRKS_BASICVIDEOCLASS;
+ 
+       if (user_agent->Find("Windows-Media-Player", 0, true) >= 0)
+-- 
+2.39.2
+


### PR DESCRIPTION
Samsung Smart TVs are unable to use most of kodi-20s DLNA. 
see: https://github.com/xbmc/xbmc/issues/22828

Thanks to @enen92!
This might find its way into upstream.