### PR TITLE
inputstream.adaptive: update to 20.3.4-Nexus

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="20.3.3-Nexus"
-PKG_SHA256="7828f3a12206aebc9edc34e7ca2da580565209092e3451aed67b58b3f2cd2246"
+PKG_VERSION="20.3.4-Nexus"
+PKG_SHA256="49fe8dc908166d4b0c5130d3201d3221f24e860a7a05c5b0db3491f64422c14f"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
v20.3.4 (2023-02-23)

    overhaul url utils to follow RFC 3986
    [Debug] option to save manifests to disk for debugging purposes
    [DRM] fix bug when supplying license_data property
    translation updates
