### PR TITLE
linux: Improve 8bitdo pro 2 wired controller support

### DIFF
--- a/packages/linux/patches/default/linux-150-dev_input_xpad_add_8bitdo_pro_2_wired_controller_support.patch
+++ b/packages/linux/patches/default/linux-150-dev_input_xpad_add_8bitdo_pro_2_wired_controller_support.patch
@@ -1,0 +1,43 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH] Input: xpad - add 8BitDo Pro 2 Wired Controller support
+From: John Butler <radon86dev@gmail.com>
+Date: Tue, 24 Jan 2023 00:52:06 +0000
+Message-Id: <20230124005206.80706-1-radon86dev@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+Add VID and PID to the xpad_device table to allow driver
+to use the 8BitDo Pro 2 Wired Controller, which is
+XTYPE_XBOX360 compatible by default.
+
+Signed-off-by: John Butler <radon86dev@gmail.com>
+Cc: linux-input@vger.kernel.org
+Reviewed-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>
+---
+ drivers/input/joystick/xpad.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/input/joystick/xpad.c b/drivers/input/joystick/xpad.c
+index 2959d80f7fdb..f642ec8e92dd 100644
+--- a/drivers/input/joystick/xpad.c
++++ b/drivers/input/joystick/xpad.c
+@@ -359,6 +359,7 @@ static const struct xpad_device {
+ 	{ 0x24c6, 0xfafe, "Rock Candy Gamepad for Xbox 360", 0, XTYPE_XBOX360 },
+ 	{ 0x2563, 0x058d, "OneXPlayer Gamepad", 0, XTYPE_XBOX360 },
+ 	{ 0x2dc8, 0x2000, "8BitDo Pro 2 Wired Controller fox Xbox", 0, XTYPE_XBOXONE },
++	{ 0x2dc8, 0x3106, "8BitDo Pro 2 Wired Controller", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1100, "Wooting One", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1200, "Wooting Two", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1210, "Wooting Lekker", 0, XTYPE_XBOX360 },
+@@ -492,6 +493,7 @@ static const struct usb_device_id xpad_table[] = {
+ 	XPAD_XBOXONE_VENDOR(0x24c6),		/* PowerA Controllers */
+ 	XPAD_XBOX360_VENDOR(0x2563),		/* OneXPlayer Gamepad */
+ 	XPAD_XBOX360_VENDOR(0x260d),		/* Dareu H101 */
++	XPAD_XBOX360_VENDOR(0x2dc8),            /* 8BitDo Pro 2 Wired Controller */
+ 	XPAD_XBOXONE_VENDOR(0x2dc8),		/* 8BitDo Pro 2 Wired Controller for Xbox */
+ 	XPAD_XBOXONE_VENDOR(0x2e24),		/* Hyperkin Duke X-Box One pad */
+ 	XPAD_XBOX360_VENDOR(0x2f24),		/* GameSir Controllers */
+-- 
+2.39.1
+


### PR DESCRIPTION
This should improve support for popular controller.