### PR TITLE
upnp: make kodis DLNA useable for TVs (and maybe other devices)

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.25-UPnP-Use-base64-encoded-values-for-objectIds.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.25-UPnP-Use-base64-encoded-values-for-objectIds.patch
@@ -1,0 +1,305 @@
+From 53bc148567607bfe6361de4290dec6d631f344b7 Mon Sep 17 00:00:00 2001
+From: Miguel Borges de Freitas <92enen@gmail.com>
+Date: Sat, 25 Feb 2023 13:10:33 +0000
+Subject: [PATCH] [UPnP] Use base64 encoded values for objectIds
+
+---
+ xbmc/network/upnp/UPnPInternal.cpp | 66 ++++++++++++++++++++++++------
+ xbmc/network/upnp/UPnPInternal.h   | 16 ++++++++
+ xbmc/network/upnp/UPnPServer.cpp   | 35 ++++++++--------
+ 3 files changed, 87 insertions(+), 30 deletions(-)
+
+diff --git a/xbmc/network/upnp/UPnPInternal.cpp b/xbmc/network/upnp/UPnPInternal.cpp
+index f4ba92ae05..487ab85799 100644
+--- a/xbmc/network/upnp/UPnPInternal.cpp
++++ b/xbmc/network/upnp/UPnPInternal.cpp
+@@ -22,6 +22,7 @@
+ #include "settings/Settings.h"
+ #include "settings/SettingsComponent.h"
+ #include "settings/lib/Setting.h"
++#include "utils/Base64.h"
+ #include "utils/ContentUtils.h"
+ #include "utils/LangCodeExpander.h"
+ #include "utils/StringUtils.h"
+@@ -255,7 +256,7 @@ PopulateObjectFromTag(CMusicInfoTag&         tag,
+       object.m_Creator = tag.GetAlbumArtistString().c_str();
+     object.m_MiscInfo.original_track_number = tag.GetTrackNumber();
+     if(tag.GetDatabaseId() >= 0) {
+-      object.m_ReferenceID = NPT_String::Format("musicdb://songs/%i%s", tag.GetDatabaseId(), URIUtils::GetExtension(tag.GetURL()).c_str());
++       object.m_ReferenceID = EncodeObjectId(StringUtils::Format("musicdb://songs/{}{}", tag.GetDatabaseId(), URIUtils::GetExtension(tag.GetURL())));
+     }
+     if (object.m_ReferenceID == object.m_ObjectID)
+         object.m_ReferenceID = "";
+@@ -291,12 +292,12 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
+           object.m_Affiliation.album = tag.m_strAlbum.c_str();
+           object.m_Title = tag.m_strTitle.c_str();
+           object.m_Date = tag.GetPremiered().GetAsW3CDate().c_str();
+-          object.m_ReferenceID = NPT_String::Format("videodb://musicvideos/titles/%i", tag.m_iDbId);
++          object.m_ReferenceID = EncodeObjectId(StringUtils::Format("videodb://musicvideos/titles/{}", tag.m_iDbId));
+         } else if (tag.m_type == MediaTypeMovie) {
+           object.m_ObjectClass.type = "object.item.videoItem.movie";
+           object.m_Title = tag.m_strTitle.c_str();
+           object.m_Date = tag.GetPremiered().GetAsW3CDate().c_str();
+-          object.m_ReferenceID = NPT_String::Format("videodb://movies/titles/%i", tag.m_iDbId);
++          object.m_ReferenceID = EncodeObjectId(StringUtils::Format("videodb://movies/titles/{}", tag.m_iDbId));
+         } else {
+           object.m_Recorded.series_title = tag.m_strShowTitle.c_str();
+ 
+@@ -309,7 +310,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
+                   object.m_Date = CDateTime(tag.GetYear(), 1, 1, 0, 0, 0).GetAsW3CDate().c_str();
+               else
+                   object.m_Date = tag.m_premiered.GetAsW3CDate().c_str();
+-              object.m_ReferenceID = NPT_String::Format("videodb://tvshows/titles/%i", tag.m_iDbId);
++              object.m_ReferenceID = EncodeObjectId(StringUtils::Format("videodb://tvshows/titles/{}", tag.m_iDbId));
+           } else if (tag.m_type == MediaTypeSeason) {
+               object.m_ObjectClass.type = "object.container.album.videoAlbum.videoBroadcastSeason";
+               object.m_Title = tag.m_strTitle.c_str();
+@@ -319,7 +320,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
+                   object.m_Date = CDateTime(tag.GetYear(), 1, 1, 0, 0, 0).GetAsW3CDate().c_str();
+               else
+                   object.m_Date = tag.m_premiered.GetAsW3CDate().c_str();
+-              object.m_ReferenceID = NPT_String::Format("videodb://tvshows/titles/%i/%i", tag.m_iIdShow, tag.m_iSeason);
++              object.m_ReferenceID = EncodeObjectId(StringUtils::Format("videodb://tvshows/titles/{}/{}", tag.m_iIdShow, tag.m_iSeason));
+           } else {
+               object.m_ObjectClass.type = "object.item.videoItem.videoBroadcast";
+               object.m_Recorded.program_title  = "S" + ("0" + NPT_String::FromInteger(tag.m_iSeason)).Right(2);
+@@ -328,7 +329,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
+               object.m_Recorded.episode_number = tag.m_iEpisode;
+               object.m_Recorded.episode_season = tag.m_iSeason;
+               object.m_Title = object.m_Recorded.series_title + " - " + object.m_Recorded.program_title;
+-              object.m_ReferenceID = NPT_String::Format("videodb://tvshows/titles/%i/%i/%i", tag.m_iIdShow, tag.m_iSeason, tag.m_iDbId);
++              object.m_ReferenceID = EncodeObjectId(StringUtils::Format("videodb://tvshows/titles/{}/{}/{}", tag.m_iIdShow, tag.m_iSeason, tag.m_iDbId));
+               object.m_Date = tag.m_firstAired.GetAsW3CDate().c_str();
+           }
+         }
+@@ -402,7 +403,7 @@ BuildObject(CFileItem&                    item,
+   PLT_MediaObject* object = NULL;
+   std::string thumb;
+ 
+-  logger->debug("Building didl for object '{}'", item.GetPath());
++  logger->debug("Building didl for plain object '{}' (encoded value: '{}')", item.GetPath(), EncodeObjectId(item.GetPath()).GetChars());
+ 
+   auto settingsComponent = CServiceBroker::GetSettingsComponent();
+   if (!settingsComponent)
+@@ -433,7 +434,7 @@ BuildObject(CFileItem&                    item,
+ 
+     if (!item.m_bIsFolder) {
+         object = new PLT_MediaItem();
+-        object->m_ObjectID = item.GetPath().c_str();
++        object->m_ObjectID = EncodeObjectId(item.GetPath());
+ 
+         /* Setup object type */
+         if (item.IsMusicDb() || item.IsAudio()) {
+@@ -499,14 +500,14 @@ BuildObject(CFileItem&                    item,
+ 
+         // Some upnp clients expect all audio items to have parent root id 4
+ #ifdef WMP_ID_MAPPING
+-        object->m_ParentID = "4";
++        object->m_ParentID = EncodeObjectId("4");
+ #endif
+     } else {
+         PLT_MediaContainer* container = new PLT_MediaContainer;
+         object = container;
+ 
+         /* Assign a title and id for this container */
+-        container->m_ObjectID = item.GetPath().c_str();
++        container->m_ObjectID = EncodeObjectId(item.GetPath());
+         container->m_ObjectClass.type = "object.container";
+         container->m_ChildrenCount = -1;
+ 
+@@ -525,7 +526,7 @@ BuildObject(CFileItem&                    item,
+                       }
+ #ifdef WMP_ID_MAPPING
+                       // Some upnp clients expect all artists to have parent root id 107
+-                      container->m_ParentID = "107";
++                      container->m_ParentID = EncodeObjectId("107");
+ #endif
+                   }
+                   break;
+@@ -543,7 +544,7 @@ BuildObject(CFileItem&                    item,
+                       }
+ #ifdef WMP_ID_MAPPING
+                       // Some upnp clients expect all albums to have parent root id 7
+-                      container->m_ParentID = "7";
++                      container->m_ParentID = EncodeObjectId("7");
+ #endif
+                   }
+                   break;
+@@ -597,7 +598,7 @@ BuildObject(CFileItem&                    item,
+ 
+         /* Get the number of children for this container */
+         if (with_count && upnp_server) {
+-            if (object->m_ObjectID.StartsWith("virtualpath://")) {
++            if (StringUtils::StartsWithNoCase(DecodeObjectId(object->m_ObjectID.GetChars()), "virtualpath://")) {
+                 NPT_LargeSize count = 0;
+                 NPT_CHECK_LABEL(NPT_File::GetSize(file_path, count), failure);
+                 container->m_ChildrenCount = (NPT_Int32)count;
+@@ -1218,5 +1219,44 @@ std::shared_ptr<CFileItem> GetFileItem(const NPT_String& uri, const NPT_String&
+     return item;
+ }
+ 
++NPT_String EncodeObjectId(const std::string& id)
++{
++  if (id.empty())
++  {
++    CLog::LogF(LOGWARNING, "Failed to encode object id, provided object id is empty");
++    return {};
++  }
++  // we use integers in some special cases like virtualpath://upnproot or whenever clients with
++  // quirks expect to receive integer ids for some parent containers
++  if (StringUtils::IsInteger(id))
++  {
++    return id.c_str();
++  }
++
++  return Base64::Encode(id).c_str();
++}
++
++NPT_String DecodeObjectId(const std::string& id)
++{
++  if (id.empty())
++  {
++    CLog::LogF(LOGWARNING, "Failed to decode object id, provided object id is empty");
++    return {};
++  }
++  // we use integers in some special cases like virtualpath://upnproot or whenever clients with
++  // quirks expect to receive integer ids for some parent containers
++  if (StringUtils::IsInteger(id))
++  {
++    return id.c_str();
++  }
++  std::string decodedObjectId = Base64::Decode(id);
++  if (decodedObjectId.empty())
++  {
++    CLog::LogF(LOGERROR, "Failed to decode object id {}, not properly Base64 encoded", decodedObjectId);
++  }
++
++  return decodedObjectId.c_str();
++}
++
+ } /* namespace UPNP */
+ 
+diff --git a/xbmc/network/upnp/UPnPInternal.h b/xbmc/network/upnp/UPnPInternal.h
+index 5723e22761..098c871fe6 100644
+--- a/xbmc/network/upnp/UPnPInternal.h
++++ b/xbmc/network/upnp/UPnPInternal.h
+@@ -118,5 +118,21 @@ namespace UPNP
+ 
+   bool             GetResource(const PLT_MediaObject* entry, CFileItem& item);
+   std::shared_ptr<CFileItem> GetFileItem(const NPT_String& uri, const NPT_String& meta);
++
++  /*!
++   * @brief Provided a given object id, encode it into a safe format to provide to UPnP clients
++   * @Note base64 is currently used as the safe format
++   * @param id the object it to encode
++   * @return the encoded object id
++  */
++  NPT_String EncodeObjectId(const std::string& id);
++
++  /*!
++   * @brief Provided a given encoded object id, decode it into a format known by the application
++   * @Note base64 is currently used as the expected input format
++   * @param id the object it to decode
++   * @return the decoded object id
++  */
++  NPT_String DecodeObjectId(const std::string& id);
+ }
+ 
+diff --git a/xbmc/network/upnp/UPnPServer.cpp b/xbmc/network/upnp/UPnPServer.cpp
+index 09079e4769..d068063303 100644
+--- a/xbmc/network/upnp/UPnPServer.cpp
++++ b/xbmc/network/upnp/UPnPServer.cpp
+@@ -278,11 +278,11 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+             object = new PLT_MediaContainer;
+             object->m_Title = item->GetLabel().c_str();
+             object->m_ObjectClass.type = "object.container";
+-            object->m_ObjectID = path;
++            object->m_ObjectID = EncodeObjectId(path.GetChars());
+ 
+             // root
+-            object->m_ObjectID = "0";
+-            object->m_ParentID = "-1";
++            object->m_ObjectID = EncodeObjectId("0");
++            object->m_ParentID = EncodeObjectId("-1");
+             // root has 5 children
+ 
+             //This is dead code because of the HACK a few lines up setting with_count to false
+@@ -405,18 +405,18 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+ 
+         // set parent id if passed, otherwise it should have been determined
+         if (object && parent_id) {
+-            object->m_ParentID = parent_id;
++            object->m_ParentID = EncodeObjectId(parent_id);
+         }
+     }
+ 
+     if (object) {
+         // remap Root virtualpath://upnproot/ to id "0"
+-        if (object->m_ObjectID == "virtualpath://upnproot/")
+-            object->m_ObjectID = "0";
++        if (StringUtils::EqualsNoCase(object->m_ObjectID, EncodeObjectId("virtualpath://upnproot/")))
++            object->m_ObjectID = EncodeObjectId("0");
+ 
+         // remap Parent Root virtualpath://upnproot/ to id "0"
+-        if (object->m_ParentID == "virtualpath://upnproot/")
+-            object->m_ParentID = "0";
++        if (StringUtils::EqualsNoCase(object->m_ParentID, EncodeObjectId("virtualpath://upnproot/")))
++            object->m_ParentID = EncodeObjectId("0");
+     }
+ 
+     return object;
+@@ -560,11 +560,12 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
+ 
+     NPT_String                     didl;
+     NPT_Reference<PLT_MediaObject> object;
+-    NPT_String id = TranslateWMPObjectId(object_id, m_logger);
+     CFileItemPtr                   item;
+     NPT_Reference<CThumbLoader>    thumb_loader;
+ 
+-    m_logger->info("Received UPnP Browse Metadata request for object '{}'", object_id);
++    m_logger->info("Received UPnP Browse Metadata request for encoded object '{}' (plain value: '{}')", object_id, DecodeObjectId(object_id).GetChars());
++
++    NPT_String id = TranslateWMPObjectId(DecodeObjectId(object_id), m_logger);
+ 
+     if(NPT_FAILED(ObjectIDValidate(id))) {
+         action->SetError(701, "Incorrect ObjectID.");
+@@ -579,7 +580,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
+             item->SetLabel("Root");
+             item->SetLabelPreformatted(true);
+             object = Build(item, true, context, thumb_loader);
+-            object->m_ParentID = "-1";
++            object->m_ParentID = EncodeObjectId("-1");
+         } else {
+             return NPT_FAILURE;
+         }
+@@ -659,10 +660,10 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
+                                     const PLT_HttpRequestContext& context)
+ {
+     CFileItemList items;
+-    NPT_String parent_id = TranslateWMPObjectId(object_id, m_logger);
++    m_logger->info("Received Browse DirectChildren request for encoded object '{}' (plain value: '{}'), with sort criteria {}",
++                   object_id, DecodeObjectId(object_id).GetChars(), sort_criteria);
+ 
+-    m_logger->info("Received Browse DirectChildren request for object '{}', with sort criteria {}",
+-                   object_id, sort_criteria);
++    NPT_String parent_id = TranslateWMPObjectId(DecodeObjectId(object_id), m_logger);
+ 
+     if(NPT_FAILED(ObjectIDValidate(parent_id))) {
+         action->SetError(701, "Incorrect ObjectID.");
+@@ -872,10 +873,10 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
+                                const char*                   sort_criteria,
+                                const PLT_HttpRequestContext& context)
+ {
+-  m_logger->debug("Received Search request for object '{}' with search '{}'", object_id,
+-                  search_criteria);
++  m_logger->debug("Received Search request for encoded object '{}' (plain value: '{}') with search '{}'",
++                  object_id, DecodeObjectId(object_id).GetChars(), search_criteria);
+ 
+-  NPT_String id = object_id;
++  NPT_String id = DecodeObjectId(object_id);
+   NPT_String searchClass = NPT_String(search_criteria);
+   if (id.StartsWith("musicdb://")) {
+       // we browse for all tracks given a genre, artist or album
+-- 
+2.39.2
+

--- a/packages/mediacenter/kodi/patches/kodi-999.25-upnp-fix-regressions-for-folder-definitions.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.25-upnp-fix-regressions-for-folder-definitions.patch
@@ -1,0 +1,73 @@
+From 0b987d55f3124509448d43626b8c7c3898606687 Mon Sep 17 00:00:00 2001
+From: Miguel Borges de Freitas <92enen@gmail.com>
+Date: Tue, 21 Feb 2023 21:55:56 +0000
+Subject: [PATCH] [upnp] fix regressions for folder definitions
+
+---
+ xbmc/network/upnp/UPnPServer.cpp | 26 +++++++++++++++++++++++++-
+ 1 file changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/network/upnp/UPnPServer.cpp b/xbmc/network/upnp/UPnPServer.cpp
+index 09079e4769..8e8432e406 100644
+--- a/xbmc/network/upnp/UPnPServer.cpp
++++ b/xbmc/network/upnp/UPnPServer.cpp
+@@ -272,8 +272,9 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+ 
+     m_logger->debug("Preparing upnp object for item '{}'", (const char*)path);
+ 
+-    if (path == "virtualpath://upnproot") {
++    if (path.StartsWith("virtualpath://upnproot")) {
+         path.TrimRight("/");
++        item->m_bIsFolder =  true;
+         if (path.StartsWith("virtualpath://")) {
+             object = new PLT_MediaContainer;
+             object->m_Title = item->GetLabel().c_str();
+@@ -331,6 +332,11 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+                     }
+                 }
+ 
++                // all items appart from songs (artists, albums, etc) are folders
++                if (!item->HasMusicInfoTag() || item->GetMusicInfoTag()->GetType() != MediaTypeSong)
++                {
++                    item->m_bIsFolder = true;
++                }
+ 
+                 if (item->GetLabel().empty()) {
+                     /* if no label try to grab it from node type */
+@@ -380,6 +386,11 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+                     item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("totalepisodes").asInteger();
+                     item->GetVideoInfoTag()->SetPlayCount(static_cast<int>(item->GetProperty("watchedepisodes").asInteger()));
+                 }
++                // if this is an item in the library without a playable path it most be a folder
++                else if (item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
++                {
++                    item->m_bIsFolder = true;
++                }
+ 
+                 // try to grab title from tag
+                 if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_strTitle.empty()) {
+@@ -397,8 +408,21 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
+                 }
+             }
+         }
++        // playlists are folders
++        else if (item->IsPlayList())
++        {
++            item->m_bIsFolder = true;
++        }
++        // audio and not a playlist -> song, so it's not a folder
++        else if (item->IsAudio())
++        {
++            item->m_bIsFolder = false;
++        }
++        // any other type of item -> delegate to CDirectory
+         else
++        {
+             item->m_bIsFolder = CDirectory::Exists(item->GetPath());
++        }
+ 
+         // not a virtual path directory, new system
+         object = BuildObject(*item.get(), file_path, with_count, thumb_loader, &context, this, UPnPContentDirectory);
+-- 
+2.39.2
+


### PR DESCRIPTION
At the moment Samsung and Philips TVs are unable to use kodis DLNA (no content).

With theses changes those TVs are can see content and stream it.

However:
It can have negative side effects for other DLNA clients (yatse UPnP Search)
see: https://github.com/xbmc/xbmc/pull/22869

Thanks to @enen92

