### PR TITLE
config/arch.aarch64: drop TARGET_ABI=eabi

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -20,7 +20,6 @@
     generic|cortex-a35|cortex-a53|cortex-a57|cortex-a72|exynos-m1|qdf24xx|thunderx|xgene1|cortex-a57.cortex-a53|cortex-a72.cortex-a53|cortex-a73.cortex-a53)
       TARGET_SUBARCH=aarch64
       TARGET_VARIANT=armv8-a
-      TARGET_ABI=eabi
       ;;
   esac
 


### PR DESCRIPTION
- Fixes #7559

@lrusak - could you please review. Or are there cases where `gnueabi` will be `gnu`?