### PR TITLE
samba: add blank line to smb.conf for autoshare entries

### DIFF
--- a/packages/network/samba/scripts/smbd-config
+++ b/packages/network/samba/scripts/smbd-config
@@ -28,6 +28,11 @@ if [ "$SAMBA_AUTOSHARE" == "true" ] ; then
   for dir in /media/* ; do
     if [ -d "$dir" ] ; then
       name=$(basename "$dir")
+      # insert a blank line as needed before adding entries
+      last_line=$(tail -1 $SMB_TMP)
+      if [ -n "${last_line}" ]; then
+        echo -e "\n" >> $SMB_TMP
+      fi
       echo -e "[$name]\n  path = $dir\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_TMP
     fi
   done
@@ -35,6 +40,11 @@ fi
 
 # Allow access to a "failed" (safe mode) Kodi installation
 if [ -d /storage/.kodi.FAILED ]; then
+  # insert a blank line as needed before adding entries
+  last_line=$(tail -1 $SMB_TMP)
+  if [ -n "${last_line}" ]; then
+    echo -e "\n" >> $SMB_TMP
+  fi
   echo -e "[Kodi-Failed]\n  path = /storage/.kodi.FAILED\n  available = yes\n  browseable = yes\n  public = yes\n  writeable = yes\n" >> $SMB_TMP
 fi
 


### PR DESCRIPTION
This should resolve:

- #7038 

smb.conf before (partial, stock smb.conf, usb drive inserted):
```
[Picons]
  path = /storage/picons
  available = yes
  browseable = yes
  public = yes
  writeable = yes
  root preexec = mkdir -p /storage/picons/tvh /storage/picons/vdr
[CORSAIR]
  path = /media/CORSAIR
  available = yes
  browseable = yes
  public = yes
  writeable = yes
```

smb.conf after (partial, stock smb.conf, usb drive inserted):

```
[Picons]
  path = /storage/picons
  available = yes
  browseable = yes
  public = yes
  writeable = yes
  root preexec = mkdir -p /storage/picons/tvh /storage/picons/vdr


[CORSAIR]
  path = /media/CORSAIR
  available = yes
  browseable = yes
  public = yes
  writeable = yes
```

That is an extra linebreak between the [Picons] and [CORSAIR] entry. I haven't identified why, but it's a cosmetic issue, rather than a "shares are broken" issue of the original bug. My best guess for what causes the underlying bug is custom samba configuration written using a non-POSIX editor (ie on Windows) so that the last line doesn't end in a line break for the next entry. I have not been able to recreate the original bug to verify this resolves it.

The proposed change is "If the last line is not blank, add a blank one." Repeat the same fix where it may be inserting the kodi failed share.

If someone else has an idea on where the extra line break is coming from, I may have just been staring at it too long. 