### PR TITLE
[le11] samba: update to 4.17.7

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.5"
-PKG_SHA256="ebb7880d474ffc09d73b5fc77bcbd657f6235910337331a9c24d7f69ca11442b"
+PKG_VERSION="4.17.7"
+PKG_SHA256="95c9c16b654a88cfaefd958052dd573e2f85ecdf114e4ecec3187537a094d919"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
release notes:
- https://www.samba.org/samba/history/samba-4.17.6.html
- https://www.samba.org/samba/history/samba-4.17.7.html
- backport of #7574 
- backport of #7716 