### PR TITLE
[le11] glib: update to 2.75.4

### DIFF
--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.75.2"
-PKG_SHA256="360d6fb75202c0eb0d07f0ab812b19b526f1c05ccc0a8ed7e5d2c988616d343a"
+PKG_VERSION="2.75.4"
+PKG_SHA256="16ce24bb8f3c0ea3bdbda937c090b93bb8b5ad2d417e5e5e42c14aa4cf6b6ad1"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
changelog:
- https://gitlab.gnome.org/GNOME/glib/-/commit/b65044c52b78fab65a0415e2148f4b98a1680da2
- https://gitlab.gnome.org/GNOME/glib/-/commit/084a35620c1d886650223555c4dd647824c0ce64
- Backport of #7576