### PR TITLE
linux: update to 6.1.y

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,8 +29,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.1.14"
-    PKG_SHA256="a27076011efec7ad11e9ed0644f512c34cab4c5ed5ba42cfe71c83fabebe810d"
+    PKG_VERSION="6.1.16"
+    PKG_SHA256="a6849c55580b5515a07b6ad21861c450fa20345c66624eecb89e8873816da3c5"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/packages/linux/patches/default/linux-122-rtw88-rfc-v1.patch
+++ b/packages/linux/patches/default/linux-122-rtw88-rfc-v1.patch
@@ -1547,7 +1547,7 @@ diff --git a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/rea
 index 4e5c194aac29..bf1291902661 100644
 --- a/drivers/net/wireless/realtek/rtw88/mac.c
 +++ b/drivers/net/wireless/realtek/rtw88/mac.c
-@@ -269,10 +269,18 @@ static int rtw_mac_power_switch(struct rtw_dev *rtwdev, bool pwr_on)
+@@ -269,15 +269,23 @@ static int rtw_mac_power_switch(struct rtw_dev *rtwdev, bool pwr_on)
  	if (pwr_on == cur_pwr)
  		return -EALREADY;
  
@@ -1560,6 +1560,11 @@ index 4e5c194aac29..bf1291902661 100644
  	pwr_seq = pwr_on ? chip->pwr_on_seq : chip->pwr_off_seq;
  	if (rtw_pwr_seq_parser(rtwdev, pwr_seq))
  		return -EINVAL;
+
+ 	if (pwr_on)
+ 		set_bit(RTW_FLAG_POWERON, rtwdev->flags);
+ 	else
+ 		clear_bit(RTW_FLAG_POWERON, rtwdev->flags);
  
 +	rtw_hci_power_switch(rtwdev, pwr_on);
 +
@@ -1826,7 +1831,7 @@ index 8e1fa824b32b..ad71f9838d1d 100644
  	u8 rpwm;
  	bool cur_pwr;
  
-@@ -278,12 +301,19 @@ static int rtw_mac_power_switch(struct rtw_dev *rtwdev, bool pwr_on)
+@@ -278,17 +301,24 @@ static int rtw_mac_power_switch(struct rtw_dev *rtwdev, bool pwr_on)
  	 */
  	rtw_hci_power_switch(rtwdev, false);
  
@@ -1839,6 +1844,11 @@ index 8e1fa824b32b..ad71f9838d1d 100644
 +		rtw_write32(rtwdev, REG_SDIO_HIMR, imr);
  		return -EINVAL;
 +	}
+ 
+ 	if (pwr_on)
+ 		set_bit(RTW_FLAG_POWERON, rtwdev->flags);
+ 	else
+ 		clear_bit(RTW_FLAG_POWERON, rtwdev->flags);
  
  	rtw_hci_power_switch(rtwdev, pwr_on);
  


### PR DESCRIPTION
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.15
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.16

6.1.15 - 42 patches
6.1.16 - 887 patches

errors / fixes / issues / regressions
-

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.1.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.1
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/


### 6.1.16 Build tested on all of:

```
PROJECT=Allwinner ARCH=arm DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H6 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=arm DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.1.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - 6.1.16-rc2  - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.1.16 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - 6.1.4-rc1 - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum