### PR TITLE
flatbuffers: update to 23.3.3

### DIFF
--- a/packages/devel/flatbuffers/package.mk
+++ b/packages/devel/flatbuffers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flatbuffers"
-PKG_VERSION="22.12.06"
-PKG_SHA256="209823306f2cbedab6ff70997e0d236fcfd1864ca9ad082cbfdb196e7386daed"
+PKG_VERSION="23.3.3"
+PKG_SHA256="8aff985da30aaab37edf8e5b02fda33ed4cbdd962699a8e2af98fdef306f4e4d"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/google/flatbuffers"
 PKG_URL="https://github.com/google/flatbuffers/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://github.com/google/flatbuffers/releases