### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="20.3.4-Nexus"
-PKG_SHA256="49fe8dc908166d4b0c5130d3201d3221f24e860a7a05c5b0db3491f64422c14f"
-PKG_REV="3"
+PKG_VERSION="20.3.5-Nexus"
+PKG_SHA256="3851e1ac48aa38681b6ff6cfb39ab2cc24156b859d1a257be63f3c4d9fd926de"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/inputstream.adaptive"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="20.1.7-Nexus"
-PKG_SHA256="da141fb79474de1346704b1afc67dc3b615aef4f74b14bfb896dfe8dfb91ddc5"
+PKG_VERSION="20.1.8-Nexus"
+PKG_SHA256="6e8fb553309d3ad48fad21d2d6cebdb537a4e2b88878b6fdc43707c7bc37e160"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 20.3.4-Nexus to 20.3.5-Nexus
- peripheral.joystick: update 20.1.7-Nexus to 20.1.8-Nexus