### PR TITLE
[le12] linux: update to 6.1.19

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,8 +29,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.1.18"
-    PKG_SHA256="842ac15eff0e6fb0c150fdf83f4f6aaf6b4c1239dcf8c14e2227620ec0ae141e"
+    PKG_VERSION="6.1.19"
+    PKG_SHA256="9e991c6e5f6c1ca45eea98c55e82ef6ae3dccc73b3e8a655c8665e585f5a8647"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;


### PR DESCRIPTION
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.19
- Fix for Wireless WPA issues.
- 6.1.19 - 5 patches

commit 7b3eac1950e791c6a52888cd41aef472660d4530
Author: Hector Martin <marcan@marcan.st>
Date:   Sat Mar 11 23:19:14 2023 +0900

    wifi: cfg80211: Partial revert "wifi: cfg80211: Fix use after free for wext"
    
    commit 79d1ed5ca7db67d48e870c979f0e0f6b0947944a upstream.
    
    This reverts part of commit 015b8cc5e7c4 ("wifi: cfg80211: Fix use after
    free for wext")
    
    This commit broke WPA offload by unconditionally clearing the crypto
    modes for non-WEP connections. Drop that part of the patch.
    
    Signed-off-by: Hector Martin <marcan@marcan.st>
    Reported-by: Ilya <me@0upti.me>
    Reported-and-tested-by: Janne Grunau <j@jannau.net>
    Reviewed-by: Eric Curtin <ecurtin@redhat.com>
    Fixes: 015b8cc5e7c4 ("wifi: cfg80211: Fix use after free for wext")
    Cc: stable@kernel.org
    Link: https://lore.kernel.org/linux-wireless/ZAx0TWRBlGfv7pNl@kroah.com/T/#m11e6e0915ab8fa19ce8bc9695ab288c0fe018edf
    Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>