### PR TITLE
Font updates

### DIFF
--- a/packages/print/freetype/package.mk
+++ b/packages/print/freetype/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="freetype"
-PKG_VERSION="2.12.1"
-PKG_SHA256="4766f20157cc4cf0cd292f80bf917f92d1c439b243ac3018debf6b9140c41a7f"
+PKG_VERSION="2.13.0"
+PKG_SHA256="5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://freetype.org"
 PKG_URL="https://download.savannah.gnu.org/releases/freetype/freetype-${PKG_VERSION}.tar.xz"

--- a/packages/x11/font/encodings/package.mk
+++ b/packages/x11/font/encodings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="encodings"
-PKG_VERSION="1.0.6"
-PKG_SHA256="77e301de661f35a622b18f60b555a7e7d8c4d5f43ed41410e830d5ac9084fc26"
+PKG_VERSION="1.0.7"
+PKG_SHA256="3a39a9f43b16521cdbd9f810090952af4f109b44fa7a865cd555f8febcea70a4"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/font/font-bitstream-type1/package.mk
+++ b/packages/x11/font/font-bitstream-type1/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="font-bitstream-type1"
-PKG_VERSION="1.0.3"
-PKG_SHA256="c6ea0569adad2c577f140328dc3302e729cb1b1ea90cd0025caf380625f8a688"
+PKG_VERSION="1.0.4"
+PKG_SHA256="de2f238b4cd72db4228a0ba67829d76a2b7c039e22993d66a722ee385248c628"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros font-xfree86-type1"
 PKG_LONGDESC="Bitstream font family."
 

--- a/packages/x11/font/font-cursor-misc/package.mk
+++ b/packages/x11/font/font-cursor-misc/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="font-cursor-misc"
-PKG_VERSION="1.0.3"
-PKG_SHA256="17363eb35eece2e08144da5f060c70103b59d0972b4f4d77fd84c9a7a2dba635"
+PKG_VERSION="1.0.4"
+PKG_SHA256="25d9c9595013cb8ca08420509993a6434c917e53ca1fec3f63acd45a19d4f982"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros font-util:host"
 PKG_LONGDESC="X11 cursor fonts."
 

--- a/packages/x11/font/font-misc-misc/package.mk
+++ b/packages/x11/font/font-misc-misc/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="font-misc-misc"
-PKG_VERSION="1.1.2"
-PKG_SHA256="b8e77940e4e1769dc47ef1805918d8c9be37c708735832a07204258bacc11794"
+PKG_VERSION="1.1.3"
+PKG_SHA256="79abe361f58bb21ade9f565898e486300ce1cc621d5285bec26e14b6a8618fed"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros font-util font-cursor-misc"
 PKG_LONGDESC="A misc. public domain font."
 

--- a/packages/x11/font/font-util/package.mk
+++ b/packages/x11/font/font-util/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="font-util"
-PKG_VERSION="1.3.3"
-PKG_SHA256="e791c890779c40056ab63aaed5e031bb6e2890a98418ca09c534e6261a2eebd2"
+PKG_VERSION="1.4.0"
+PKG_SHA256="9f724bf940128c7e39f7252bd961cd38cfac2359de2100a8bed696bf40d40f7d"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/font/font-xfree86-type1/package.mk
+++ b/packages/x11/font/font-xfree86-type1/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="font-xfree86-type1"
-PKG_VERSION="1.0.4"
-PKG_SHA256="caebf42aec7be7f3bd40e0f232d6f34881b853dc84acfcdf7458358701fbe34a"
+PKG_VERSION="1.0.5"
+PKG_SHA256="a93c2c788a5ea1c002af7c8662cf9d9821fb1df51b8d2b2c5e0026dfdfea4837"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/releases/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/releases/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros"
 PKG_LONGDESC="A Xfree86 Inc. Type1 font."
 

--- a/packages/x11/other/fontconfig/package.mk
+++ b/packages/x11/other/fontconfig/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fontconfig"
-PKG_VERSION="2.14.1"
-PKG_SHA256="ae480e9ca34382790312ff062c625ec70df94d6d9a9366e2b2b3d525f7f90387"
+PKG_VERSION="2.14.2"
+PKG_SHA256="3ba2dd92158718acec5caaf1a716043b5aa055c27b081d914af3ccb40dce8a55"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.freedesktop.org/wiki/Software/fontconfig/"
 PKG_URL="https://www.freedesktop.org/software/fontconfig/release/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/x11/util/util-macros/package.mk
+++ b/packages/x11/util/util-macros/package.mk
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="util-macros"
-PKG_VERSION="1.19.3"
-PKG_SHA256="0f812e6e9d2786ba8f54b960ee563c0663ddbe2434bf24ff193f5feab1f31971"
+PKG_VERSION="1.20.0"
+PKG_SHA256="0b86b262dbe971edb4ff233bc370dfad9f241d09f078a3f6d5b7f4b8ea4430db"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/util/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/util/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="X.org autoconf utilities such as M4 macros."
 


### PR DESCRIPTION
- encodings: update to 1.0.7
- font-bitstream-type1: update to 1.0.4 and https
- font-cursor-misc: update to 1.0.4 and https
- font-misc-misc: update to 1.1.3 and https
- font-xfree86-type1: update to 1.0.5 and https
- fontconfig: update to 2.14.2
- freetype: update to 2.13.0
- font-util: update to 1.4.0
- util-macros: update to 1.20.0 and https