### PR TITLE
x86 driver updates

### DIFF
--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.3.3"
-PKG_SHA256="86651bd2803c9f0afd82471bec784e65d2b418dee315a053d22215eb2a679be7"
+PKG_VERSION="22.3.4"
+PKG_SHA256="c42b5fa1f5f7c165621099b3787de4c052688cd93c6ef986589ab24fff09b659"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="22.6.6"
-PKG_SHA256="b553290e829dfd824eb62295c9f07dbe8062ce7998f7c527cc92856d0792562d"
+PKG_VERSION="23.1.3"
+PKG_SHA256="3b9a809f618cfd0a7835060dfec777a7bdd76f85d170c83116078bf7d4e3d427"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/nv-codec-headers/package.mk
+++ b/packages/multimedia/nv-codec-headers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nv-codec-headers"
-PKG_VERSION="11.1.5.2"
-PKG_SHA256="576df78bad704e2854991100bea99e974759304ac1411c02707ebc95a425191b"
+PKG_VERSION="12.0.16.0"
+PKG_SHA256="2a1533b65f55f9da52956faf0627ed3b74868ac0c7f269990edd21369113b48f"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/FFmpeg/nv-codec-headers"
 PKG_URL="https://github.com/FFmpeg/nv-codec-headers/archive/n${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/nvidia-vaapi-driver/package.mk
+++ b/packages/multimedia/nvidia-vaapi-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia-vaapi-driver"
-PKG_VERSION="0.0.8"
-PKG_SHA256="a396e8b48ec9bc58cec50d5b049e401ddc59083195edf2b8669e9788f4d44293"
+PKG_VERSION="0.0.9"
+PKG_SHA256="4d14302be650bb63a701b61062d31fa70bfef2f622f3b1f52c93fb9cab6ae698"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/elFarto/nvidia-vaapi-driver"
 PKG_URL="https://github.com/elFarto/nvidia-vaapi-driver/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/open-vm-tools/package.mk
+++ b/packages/sysutils/open-vm-tools/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="open-vm-tools"
-PKG_VERSION="12.1.5"
-PKG_SHA256="678d08b46fba15f2b4c39245b5bc4deec30284d6f13ee279c233bc3d3627ec8a"
+PKG_VERSION="12.2.0"
+PKG_SHA256="5127dd8643e4c89a22a93728ea5420d236cd4083bc07d665f70fee08a581d635"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/vmware/open-vm-tools"

--- a/packages/x11/driver/xf86-video-amdgpu/package.mk
+++ b/packages/x11/driver/xf86-video-amdgpu/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xf86-video-amdgpu"
-PKG_VERSION="22.0.0"
-PKG_SHA256="9d23fb602915dc3ccde92aa4d1e9485e7e54eaae2f41f485e55eb20761778266"
+PKG_VERSION="23.0.0"
+PKG_SHA256="4f04f0ea66f3ced0dcc58f617409860163a19c4e8c285cfb5285f36ba09cc061"
 PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.x.org/wiki/RadeonFeature/"

--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xf86-video-intel"
-PKG_VERSION="31486f40f8e8f8923ca0799aea84b58799754564"
-PKG_SHA256="e47eb678c681d80df138e897ee27c79f9b42e3517d55b1f0684e9a70361c8218"
+PKG_VERSION="b74b67f0f321875492968f7097b9d6e82a66d7df"
+PKG_SHA256="cc4855308af8eedd414c60f0638ef19e1b695e83f9dc1d62146cdab3d5915aba"
 PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.x.org/wiki/IntelGraphicsDriver/"


### PR DESCRIPTION
- gmmlib: update to 22.3.4
- media-driver: update to 23.1.3
- nv-codec-headers: update to 12.0.16.0
- nvidia-vaapi-driver: update to 0.0.9
- open-vm-tools: update to 12.2.0
- xf86-video-amdgpu: update to 23.0.0
- xf86-video-intel: update to githash 20230201