### PR TITLE
Toolchain updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.19.5"
-PKG_SHA256="1c24a6a2bf71d64d0ca8e228028d6108521f06b6edc7bf6b34ed6d767a795809"
+PKG_VERSION="1.19.7"
+PKG_SHA256="1fe106fce9342c2a7ceeb04477341457cc9f0a3c07b9f2a993af09d654307f56"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/devel/elfutils/package.mk
+++ b/packages/devel/elfutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="elfutils"
-PKG_VERSION="0.188"
-PKG_SHA256="fb8b0e8d0802005b9a309c60c1d8de32dd2951b56f0c3a3cb56d21ce01595dff"
+PKG_VERSION="0.189"
+PKG_SHA256="39bd8f1a338e2b7cd4abc3ff11a0eddc6e690f69578a57478d8179b4148708c8"
 PKG_LICENSE="GPL"
 PKG_SITE="https://sourceware.org/elfutils/"
 PKG_URL="https://sourceware.org/elfutils/ftp/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fakeroot"
-PKG_VERSION="1.30.1"
-PKG_SHA256="32ebb1f421aca0db7141c32a8c104eb95d2b45c393058b9435fbf903dd2b6a75"
+PKG_VERSION="1.31"
+PKG_SHA256="63886d41e11c56c7170b9d9331cca086421b350d257338ef14daad98f77e202f"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://tracker.debian.org/pkg/fakeroot"
 PKG_URL="http://ftp.debian.org/debian/pool/main/f/fakeroot/${PKG_NAME}_${PKG_VERSION}.orig.tar.gz"

--- a/packages/lang/nasm/package.mk
+++ b/packages/lang/nasm/package.mk
@@ -3,11 +3,15 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nasm"
-PKG_VERSION="2.15.05"
-PKG_SHA256="3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f"
+PKG_VERSION="2.16.01"
+PKG_SHA256="c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"
 PKG_ARCH="x86_64"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.nasm.us/"
-PKG_URL="http://www.nasm.us/pub/nasm/releasebuilds/${PKG_VERSION}/nasm-${PKG_VERSION}.tar.xz"
+PKG_URL="https://www.nasm.us/pub/nasm/releasebuilds/${PKG_VERSION}/nasm-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host"
 PKG_LONGDESC="The Netwide Assembler, NASM, is an 80x86 and x86-64 assembler designed for portability and modularity."
+
+pre_configure_host() {
+  HOST_CONFIGURE_OPTS=$(echo ${HOST_CONFIGURE_OPTS} | sed -e "s|--disable-static||" -e "s|--enable-shared||")
+}

--- a/packages/lang/nasm/patches/nasm-0001-Make--handle-warning-files-while-building-in-a-directory.patch
+++ b/packages/lang/nasm/patches/nasm-0001-Make--handle-warning-files-while-building-in-a-directory.patch
@@ -1,0 +1,231 @@
+From 7e80d6b834cd792dbbd7a99fbff98e46cdd5789f Mon Sep 17 00:00:00 2001
+From: "H. Peter Anvin" <hpa@zytor.com>
+Date: Tue, 17 Jan 2023 13:05:55 -0800
+Subject: [PATCH] Make: handle warning files while building in a directory
+
+The dependency on the warning files breaks when we are building in a
+directory *and* the files already exist from being shipped with the
+distribution tarballs. The make VPATH simply isn't sophisticated
+enough to deal with it, so let the C compiler handle it by #including
+the generated file from a dummy C file.
+
+Reported-by: Rudi Heitbaum <rudi@heitbaum.com>
+Signed-off-by: H. Peter Anvin <hpa@zytor.com>
+---
+ Makefile.in          | 38 ++++++++++++++++++++------------------
+ Mkfiles/msvc.mak     | 14 +++++++-------
+ Mkfiles/openwcom.mak | 14 +++++++-------
+ doc/Makefile.in      |  2 +-
+ 6 files changed, 37 insertions(+), 34 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 148fcb50..95268fd2 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -37,8 +37,10 @@ AR		= @AR@
+ RANLIB		= @RANLIB@
+ STRIP		= @STRIP@
+ 
++tools		= $(top_srcdir)/tools
++
+ PERL		= perl
+-PERLFLAGS	= -I$(srcdir)/perllib -I$(srcdir)
++PERLFLAGS	= -I$(top_srcdir)/perllib -I$(srcdir)
+ RUNPERL         = $(PERL) $(PERLFLAGS)
+ 
+ PYTHON3		= python3
+@@ -65,8 +67,8 @@ LN_S		= @LN_S@
+ FIND		= find
+ 
+ # Binary suffixes
+-O              	= @OBJEXT@
+-X              	= @EXEEXT@
++O		= @OBJEXT@
++X		= @EXEEXT@
+ A		= @LIBEXT@
+ 
+ # Debug stuff
+@@ -194,14 +196,14 @@ PERLREQ = config/unconfig.h \
+ 	  x86/iflag.c x86/iflaggen.h \
+ 	  macros/macros.c \
+ 	  asm/pptok.ph asm/directbl.c asm/directiv.h \
+-	  asm/warnings.c include/warnings.h doc/warnings.src \
++	  $(WARNFILES) \
+ 	  misc/nasmtok.el \
+ 	  version.h version.mac version.mak nsis/version.nsh
+ 
+ INSDEP = x86/insns.dat x86/insns.pl x86/insns-iflags.ph x86/iflags.ph
+ 
+ config/unconfig.h: config/config.h.in
+-	$(RUNPERL) $(srcdir)/tools/unconfig.pl \
++	$(RUNPERL) $(tools)/unconfig.pl \
+ 		'$(srcdir)' config/config.h.in config/unconfig.h
+ 
+ x86/iflag.c: $(INSDEP)
+@@ -273,7 +275,7 @@ x86/regs.h: x86/regs.dat x86/regs.pl
+ # reasonable, but doesn't update the time stamp if the files aren't
+ # changed, to avoid rebuilding everything every time. Track the actual
+ # dependency by the empty file asm/warnings.time.
+-WARNFILES = asm/warnings.c include/warnings.h doc/warnings.src
++WARNFILES = asm/warnings_c.h include/warnings.h doc/warnings.src
+ 
+ warnings:
+ 	$(RM_F) $(WARNFILES) $(WARNFILES:=.time)
+@@ -283,11 +285,11 @@ asm/warnings.time: $(ALLOBJ_NW:.$(O)=.c)
+ 	: > asm/warnings.time
+ 	$(MAKE) $(WARNFILES:=.time)
+ 
+-asm/warnings.c.time: asm/warnings.pl asm/warnings.time
+-	$(RUNPERL) $(srcdir)/asm/warnings.pl c asm/warnings.c $(srcdir)
+-	: > asm/warnings.c.time
++asm/warnings_c.h.time: asm/warnings.pl asm/warnings.time
++	$(RUNPERL) $(srcdir)/asm/warnings.pl c asm/warnings_c.h $(srcdir)
++	: > asm/warnings_c.h.time
+ 
+-asm/warnings.c: asm/warnings.c.time
++asm/warnings_c.h: asm/warnings_c.h.time
+ 	@: Side effect
+ 
+ include/warnings.h.time: asm/warnings.pl asm/warnings.time
+@@ -506,8 +508,8 @@ EXTERNAL_DEPENDENCIES = 1
+ # the dependency information will remain external, so it doesn't
+ # pollute the git logs.
+ #
+-Makefile.dep: $(PERLREQ) tools/mkdep.pl config.status
+-	$(RUNPERL) tools/mkdep.pl -M Makefile.in -- $(DEPDIRS)
++Makefile.dep: $(PERLREQ) $(tools)/mkdep.pl config.status
++	$(RUNPERL) $(tools)/mkdep.pl -M Makefile.in -- $(DEPDIRS)
+ 
+ dep: Makefile.dep
+ 
+@@ -517,9 +519,9 @@ dep: Makefile.dep
+ # be invoked manually or via "make dist".  It should be run before
+ # creating release archives.
+ #
+-alldeps: $(PERLREQ) tools/syncfiles.pl tools/mkdep.pl
+-	$(RUNPERL) tools/syncfiles.pl Makefile.in Mkfiles/*.mak
+-	$(RUNPERL) tools/mkdep.pl -i -M Makefile.in Mkfiles/*.mak -- \
++alldeps: $(PERLREQ) $(tools)/syncfiles.pl $(tools)/mkdep.pl
++	$(RUNPERL) $(tools)/syncfiles.pl Makefile.in Mkfiles/*.mak
++	$(RUNPERL) $(tools)/mkdep.pl -i -M Makefile.in Mkfiles/*.mak -- \
+ 		$(DEPDIRS)
+ 	$(RM_F) *.dep
+ 	if [ -f config.status ]; then \
+@@ -528,9 +530,9 @@ alldeps: $(PERLREQ) tools/syncfiles.pl tools/mkdep.pl
+ 
+ # Strip internal dependency information from all Makefiles; this makes
+ # the output good for git checkin
+-cleandeps: $(PERLREQ) tools/syncfiles.pl tools/mkdep.pl
+-	$(RUNPERL) tools/syncfiles.pl Makefile.in Mkfiles/*.mak
+-	$(RUNPERL) tools/mkdep.pl -e -M Makefile.in Mkfiles/*.mak -- \
++cleandeps: $(PERLREQ) $(tools)/syncfiles.pl $(tools)/mkdep.pl
++	$(RUNPERL) $(tools)/syncfiles.pl Makefile.in Mkfiles/*.mak
++	$(RUNPERL) $(tools)/mkdep.pl -e -M Makefile.in Mkfiles/*.mak -- \
+ 		$(DEPDIRS)
+ 	$(RM_F) *.dep
+ 	if [ -f config.status ]; then \
+diff --git a/Mkfiles/msvc.mak b/Mkfiles/msvc.mak
+index cf71fffc..da71c5c6 100644
+--- a/Mkfiles/msvc.mak
++++ b/Mkfiles/msvc.mak
+@@ -153,14 +153,14 @@ PERLREQ = config\unconfig.h \
+ 	  x86\iflag.c x86\iflaggen.h \
+ 	  macros\macros.c \
+ 	  asm\pptok.ph asm\directbl.c asm\directiv.h \
+-	  asm\warnings.c include\warnings.h doc\warnings.src \
++	  $(WARNFILES) \
+ 	  misc\nasmtok.el \
+ 	  version.h version.mac version.mak nsis\version.nsh
+ 
+ INSDEP = x86\insns.dat x86\insns.pl x86\insns-iflags.ph x86\iflags.ph
+ 
+ config\unconfig.h: config\config.h.in
+-	$(RUNPERL) $(srcdir)\tools\unconfig.pl \
++	$(RUNPERL) $(tools)\unconfig.pl \
+ 		'$(srcdir)' config\config.h.in config\unconfig.h
+ 
+ x86\iflag.c: $(INSDEP)
+@@ -232,7 +232,7 @@ x86\regs.h: x86\regs.dat x86\regs.pl
+ # reasonable, but doesn't update the time stamp if the files aren't
+ # changed, to avoid rebuilding everything every time. Track the actual
+ # dependency by the empty file asm\warnings.time.
+-WARNFILES = asm\warnings.c include\warnings.h doc\warnings.src
++WARNFILES = asm\warnings_c.h include\warnings.h doc\warnings.src
+ 
+ warnings:
+ 	$(RM_F) $(WARNFILES) $(WARNFILES:=.time)
+@@ -242,11 +242,11 @@ asm\warnings.time: $(ALLOBJ_NW:.$(O)=.c)
+ 	: > asm\warnings.time
+ 	$(MAKE) $(WARNFILES:=.time)
+ 
+-asm\warnings.c.time: asm\warnings.pl asm\warnings.time
+-	$(RUNPERL) $(srcdir)\asm\warnings.pl c asm\warnings.c $(srcdir)
+-	: > asm\warnings.c.time
++asm\warnings_c.h.time: asm\warnings.pl asm\warnings.time
++	$(RUNPERL) $(srcdir)\asm\warnings.pl c asm\warnings_c.h $(srcdir)
++	: > asm\warnings_c.h.time
+ 
+-asm\warnings.c: asm\warnings.c.time
++asm\warnings_c.h: asm\warnings_c.h.time
+ 	@: Side effect
+ 
+ include\warnings.h.time: asm\warnings.pl asm\warnings.time
+diff --git a/Mkfiles/openwcom.mak b/Mkfiles/openwcom.mak
+index 5394d85d..605f9afe 100644
+--- a/Mkfiles/openwcom.mak
++++ b/Mkfiles/openwcom.mak
+@@ -166,14 +166,14 @@ PERLREQ = config\unconfig.h &
+ 	  x86\iflag.c x86\iflaggen.h &
+ 	  macros\macros.c &
+ 	  asm\pptok.ph asm\directbl.c asm\directiv.h &
+-	  asm\warnings.c include\warnings.h doc\warnings.src &
++	  $(WARNFILES) &
+ 	  misc\nasmtok.el &
+ 	  version.h version.mac version.mak nsis\version.nsh
+ 
+ INSDEP = x86\insns.dat x86\insns.pl x86\insns-iflags.ph x86\iflags.ph
+ 
+ config\unconfig.h: config\config.h.in
+-	$(RUNPERL) $(srcdir)\tools\unconfig.pl &
++	$(RUNPERL) $(tools)\unconfig.pl &
+ 		'$(srcdir)' config\config.h.in config\unconfig.h
+ 
+ x86\iflag.c: $(INSDEP)
+@@ -245,7 +245,7 @@ x86\regs.h: x86\regs.dat x86\regs.pl
+ # reasonable, but doesn't update the time stamp if the files aren't
+ # changed, to avoid rebuilding everything every time. Track the actual
+ # dependency by the empty file asm\warnings.time.
+-WARNFILES = asm\warnings.c include\warnings.h doc\warnings.src
++WARNFILES = asm\warnings_c.h include\warnings.h doc\warnings.src
+ 
+ warnings:
+ 	$(RM_F) $(WARNFILES) $(WARNFILES:=.time)
+@@ -255,11 +255,11 @@ asm\warnings.time: $(ALLOBJ_NW:.$(O)=.c)
+ 	: > asm\warnings.time
+ 	$(MAKE) $(WARNFILES:=.time)
+ 
+-asm\warnings.c.time: asm\warnings.pl asm\warnings.time
+-	$(RUNPERL) $(srcdir)\asm\warnings.pl c asm\warnings.c $(srcdir)
+-	: > asm\warnings.c.time
++asm\warnings_c.h.time: asm\warnings.pl asm\warnings.time
++	$(RUNPERL) $(srcdir)\asm\warnings.pl c asm\warnings_c.h $(srcdir)
++	: > asm\warnings_c.h.time
+ 
+-asm\warnings.c: asm\warnings.c.time
++asm\warnings_c.h: asm\warnings_c.h.time
+ 	@: Side effect
+ 
+ include\warnings.h.time: asm\warnings.pl asm\warnings.time
+diff --git a/doc/Makefile.in b/doc/Makefile.in
+index e92437a0..1c8393c5 100644
+--- a/doc/Makefile.in
++++ b/doc/Makefile.in
+@@ -20,7 +20,7 @@ INSTALL		= @INSTALL@
+ INSTALL_PROGRAM	= @INSTALL_PROGRAM@
+ INSTALL_DATA	= @INSTALL_DATA@
+ 
+-PERL		= perl -I$(srcdir)
++PERL		= perl -I$(top_srcdir)/perllib -I$(srcdir)
+ 
+ PDFOPT		= @PDFOPT@
+ 

--- a/packages/python/devel/MarkupSafe/package.mk
+++ b/packages/python/devel/MarkupSafe/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="MarkupSafe"
-PKG_VERSION="2.1.1"
-PKG_SHA256="7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"
+PKG_VERSION="2.1.2"
+PKG_SHA256="abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/MarkupSafe/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="9.3.0"
-PKG_SHA256="188b2a5fd445b2afa05bc0c1318ce49d4335ebbb69417fbb79acaf0a0784709e"
+PKG_VERSION="9.4.0"
+PKG_SHA256="494cee55efe8733d9744ba2d96fec067a15e22f37e6aefa14b01cc630e7cfb8c"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- elfutils: update to 0.189
- fakeroot: update to 1.31
- go: update to 1.19.7
- MarkupSafe: update to 2.1.2
- nasm: update to 2.16.01 and HSTS
- Pillow: update to 9.4.0