### PR TITLE
libmicrohttpd: update to 0.9.76

### DIFF
--- a/packages/web/libmicrohttpd/package.mk
+++ b/packages/web/libmicrohttpd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmicrohttpd"
-PKG_VERSION="0.9.75"
-PKG_SHA256="9278907a6f571b391aab9644fd646a5108ed97311ec66f6359cebbedb0a4e3bb"
+PKG_VERSION="0.9.76"
+PKG_SHA256="f0b1547b5a42a6c0f724e8e1c1cb5ce9c4c35fb495e7d780b9930d35011ceb4c"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="http://www.gnu.org/software/libmicrohttpd/"
 PKG_URL="http://ftpmirror.gnu.org/libmicrohttpd/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Ann:
- https://lists.gnu.org/archive/html/libmicrohttpd/2023-02/msg00000.html

GNU libmicrohttpd 0.9.76 released with just one small change that fixes a security problem in the MHD_PostProcessor where malformed inputs can be used to crash the server (for denial-of-service). While the bug is not believed to be exploitable in other ways and only applies for applications that use the (optional) MHD_PostProcessing logic, we of course encourage everyone to upgrade.

Thanks to Gynvael Coldwind and Dejan Alvadzijevic for responsibly disclosing the problem and even proposing a good solution.
