### PR TITLE
dotnet-runtime: update aspnet6-runtime to 6.0.15

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet6-runtime"
-PKG_VERSION="6.0.14"
+PKG_VERSION="6.0.15"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="c25a09594965b241ee42ddb41d5fb68afab1b58e37a68317f2678a7cf7309a8b"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/10762208-8896-423a-b7f3-5084c7548ce7/620af5c42e5a4087478890294dbe39fb/aspnetcore-runtime-6.0.14-linux-arm64.tar.gz"
+    PKG_SHA256="b37cf63d5962b2f67288a78b6541151c458bc9e67baaf5d5852b2214e858070b"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/0d9619a1-af06-40c6-9816-46d08c9e42d6/744ecc09a1058822dc08ae17a3dc9c77/aspnetcore-runtime-6.0.15-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="da7f9e231476cfb5f52f1f469a1ef22b5bb052a0ce53af97b21b70bca0abef0a"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/4fac9144-1998-4d99-8000-6f8c8a19e9a3/3d722a6e310cf82c898f91138971be5b/aspnetcore-runtime-6.0.14-linux-arm.tar.gz"
+    PKG_SHA256="70afd74a6a070f629fcf44571582eec026442c4530f69afc142b92667542932c"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/c7eade0f-81ff-4587-a58e-647702814ec4/1b8c56efc82990ee986d8dd52a9a09ab/aspnetcore-runtime-6.0.15-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="721dc8e29892dcaaaab4bc7d2e8630a98d349f2d832855156f7b7898d1a55b07"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/092f7e69-2e23-40b3-8f36-628d25ac7109/4995e4e141b26ea049163af84592222c/aspnetcore-runtime-6.0.14-linux-x64.tar.gz"
+    PKG_SHA256="930b6254500e53a4f0d87b5551840a3ac8882e93797cf1e23da40652085d44dd"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/4518a0d8-9a6b-4836-ada9-096afa24efd0/ad0d8ccefb6b6a36dc108417b74775cb/aspnetcore-runtime-6.0.15-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"


### PR DESCRIPTION
- [dotnet-runtime: update aspnet6-runtime to 6.0.15](https://github.com/LibreELEC/LibreELEC.tv/commit/f317798a0bd42c9b005de4e460ebb3d39598e95d)