### PR TITLE
Audio package updates

### DIFF
--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.3.0"
-PKG_SHA256="1df5a1afb91acf3b945b7fdb89ac0d99877622161d9b5155533da59113eaaa20"
+PKG_VERSION="2.3.1"
+PKG_SHA256="d734e4cf488be763cf123e5976f3154f0094815093eecdf71e0e9ae148431883"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.6.6"
-PKG_SHA256="6ddb9e26a430620944891796fefb1bbb38bd9148f6cfc558810c0d3f269876c7"
+PKG_VERSION="0.6.9"
+PKG_SHA256="479e975abb7dc0fa9cad41bdd31f255d78d43e0726546208058d3c3fcf7b6e5a"
 PKG_LICENSE="BSD"
 PKG_SITE="https://lib.openmpt.org/libopenmpt/"
 PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/audio/openal-soft/package.mk
+++ b/packages/audio/openal-soft/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openal-soft"
-PKG_VERSION="1.22.2"
-PKG_SHA256="3e58f3d4458f5ee850039b1a6b4dac2343b3a5985a6a2e7ae2d143369c5b8135"
+PKG_VERSION="1.23.0"
+PKG_SHA256="af2abf9cb539c9d66296a83ba63a75eb5868658d0f0b28b27c556f45e70c5231"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openal.org/"
 PKG_URL="https://github.com/kcat/openal-soft/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.66"
-PKG_SHA256="36b6028434c16aacfc6695073b7ca4996c5476eb92833340566d27538b635508"
+PKG_VERSION="0.3.67"
+PKG_SHA256="f7edca705353ca247d9f0e5e1ef91287e4b7677d373a39cfb2df78509dde4e84"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.4.13"
-PKG_SHA256="2c3cd85a743249d418a64b137adaea475e9d36a3bb31e4230da83458c4d99e48"
+PKG_VERSION="0.4.14"
+PKG_SHA256="b160424ce7c3eeeccba388726f6a448f53501d25085e5fa1bf6c690c1bcd85ea"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.fluidsynth"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="dd8ca6386a3beed360c1d2f989cd81553baf81652007fdfd478a28b44b68db10"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.fluidsynth"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.openmpt"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="388fb4c9fcb5bd9edc978e3db5f54fa531c7f397393f3e421757e4e0de2d9c54"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.openmpt"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fsuae/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fsuae/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.fsuae"
 PKG_VERSION="0.0.1.3-Matrix"
 PKG_SHA256="24421d10b45ab85bc6f1ff08e1322551111b239939ff8358b90027c336619200"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fsuae"


### PR DESCRIPTION
- fluidsynth: update to 2.3.1
- libopenmpt: update to 0.6.9
- openal-soft: update to 1.23.0
- pipewire: update to 0.3.67
- wireplumber: update to 0.4.14
- audiodecoder.fluidsynth: rebuild with fluidsynth 2.3.1
- audiodecoder.openmpt: rebuild with libopenmpt 0.6.9
- game.libretro.fsuae: rebuild with opensl-soft 1.23.0