### PR TITLE
gnutls: update to 3.8.0

### DIFF
--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.7.8"
-PKG_SHA256="c58ad39af0670efe6a8aee5e3a8b2331a1200418b64b7c51977fb396d4617114"
+PKG_VERSION="3.8.0"
+PKG_SHA256="0ea0d11a1660a1e63f960f157b197abe6d0c8cb3255be24e1fb3815930b9bdc5"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release notes:
- https://lists.gnupg.org/pipermail/gnutls-help/2023-February/004816.html
- https://gnutls.org/security-new.html#GNUTLS-SA-2020-07-14