### PR TITLE
libcap: update to 2.67

### DIFF
--- a/packages/devel/libcap/package.mk
+++ b/packages/devel/libcap/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcap"
-PKG_VERSION="2.66"
-PKG_SHA256="15c40ededb3003d70a283fe587a36b7d19c8b3b554e33f86129c059a4bb466b2"
+PKG_VERSION="2.67"
+PKG_SHA256="ce9b22fdc271beb6dae7543da5f74cf24cb82e6848cfd088a5a069dec5ea5198"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libcap/libcap.git/log/"
 PKG_URL="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Log:
- https://git.kernel.org/pub/scm/libs/libcap/libcap.git/log/

release notes:
- https://sites.google.com/site/fullycapable/release-notes-for-libcap?authuser=0#h.o8papfkfh1x9