### PR TITLE
systemd: fix error in 70-local-keyboard.hwdb

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -24,7 +24,7 @@ evdev:input:b0005v0957p1001*
 
 # g7bts remote
 evdev:input:b0005v045Ep0041e0300*
- KEYBOARD_KEY_c0041=enter
+ KEYBOARD_KEY_c0041=enter
 
 # g20bts remote
 evdev:input:b0005v2B54p1600e0000*


### PR DESCRIPTION
introduced in https://github.com/LibreELEC/LibreELEC.tv/pull/7386

LibreELEC:~ # udevadm hwdb --update
/usr/lib/udev/hwdb.d/70-local-keyboard.hwdb:28: Property expected, ignoring record with no properties.