### PR TITLE
config/functions: in meson cross-file set ipc_rmid_deferred_release = true

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -641,6 +641,7 @@ $(python3 -c "import os; print('cpp_args = {}'.format([x for x in os.getenv('TAR
 $(python3 -c "import os; print('cpp_link_args = {}'.format([x for x in os.getenv('TARGET_LDFLAGS').split()]))")
 
 [properties]
+ipc_rmid_deferred_release = true
 needs_exe_wrapper = true
 root = '$SYSROOT_PREFIX/usr'
 ${!properties}


### PR DESCRIPTION
meson: allow skipping of run check for IPC_RMID_DEFERRED_RELEASE
- https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/134

needed for:
- 727fdb8b72b123050627e62a3009bb057dc59754
- I missed adding this in #7635 
