### PR TITLE
samba: move directory creation to busybox or kodi tmpfiles.d

### DIFF
--- a/packages/mediacenter/kodi/tmpfiles.d/kodi-userdirs.conf
+++ b/packages/mediacenter/kodi/tmpfiles.d/kodi-userdirs.conf
@@ -2,8 +2,14 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
+d    /storage/downloads          0755 root root - -
+d    /storage/emulators          0755 root root - -
 d    /storage/music              0755 root root - -
+d    /storage/picons/tvh         0755 root root - -
+d    /storage/picons/vdr         0755 root root - -
 d    /storage/pictures           0755 root root - -
+d    /storage/recordings         0755 root root - -
+d    /storage/screenshots        0755 root root - -
 d    /storage/tvshows            0755 root root - -
 d    /storage/videos             0755 root root - -
-d    /storage/screenshots        0755 root root - -
+d    /storage/.kodi/userdata     0755 root root - -

--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -53,7 +53,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/.update
 
 [Videos]
   path = /storage/videos
@@ -61,7 +60,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/videos
 
 [Music]
   path = /storage/music
@@ -69,7 +67,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/music
 
 [TV Shows]
   path = /storage/tvshows
@@ -77,7 +74,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/tvshows
 
 [Recordings]
   path = /storage/recordings
@@ -85,7 +81,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/recordings
 
 [Downloads]
   path = /storage/downloads
@@ -93,7 +88,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/downloads
 
 [Pictures]
   path = /storage/pictures
@@ -101,7 +95,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/pictures
 
 [Emulators]
   path = /storage/emulators
@@ -109,7 +102,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/emulators
 
 [Configfiles]
   path = /storage/.config
@@ -117,7 +109,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/.config
 
 [Userdata]
   path = /storage/.kodi/userdata
@@ -125,7 +116,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/.kodi/userdata
 
 [Screenshots]
   path = /storage/screenshots
@@ -133,7 +123,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/screenshots
 
 [Logfiles]
   path = /storage/logfiles
@@ -141,7 +130,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/logfiles
   root preexec = createlog
 
 [Backup]
@@ -150,7 +138,6 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/backup
 
 [Picons]
   path = /storage/picons
@@ -158,4 +145,3 @@
   browseable = yes
   public = yes
   writeable = yes
-  root preexec = mkdir -p /storage/picons/tvh /storage/picons/vdr

--- a/packages/sysutils/busybox/tmpfiles.d/z_01_busybox.conf
+++ b/packages/sysutils/busybox/tmpfiles.d/z_01_busybox.conf
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 d    /var/media                0755 root root - -
 
 d    /storage/backup           0755 root root - -
+d    /storage/logfiles         0755 root root - -
 d    /storage/.update          0755 root root - -
 d    /storage/.cache/cores     0755 root root - -
 d    /storage/.cache/kernel-overlays  0755 root root - -


### PR DESCRIPTION
Samba has the option to run commands before entering shared directories. This has been used to create the directories, as well as run createlog for the logfiles special share.

This moves the directory creation to boot time, instead of attempting every time the share is accessed. For the logfiles share, the createlog script itself will create /storage/logfiles if needed before moving the zipped logs there.

systemd-tempfiles-setup.service is called early in boot, so I don't see a need to alter kodi or samba startup service files. See `systemctl list-dependencies systemd-tempfiles-setup.service --all --reverse`