### PR TITLE
[le12] system-tools: update to addon (1)

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bottom"
-PKG_VERSION="0.6.8"
-PKG_SHA256="4e4eb251972a7af8c46dd36bcf1335fea334fb670569434fbfd594208905b2d9"
+PKG_VERSION="0.8.0"
+PKG_SHA256="0fe6a826d18570ab33b2af3b26ce28c61e3aa830abb2b622f2c3b81da802437a"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ClementTsang/bottom"
 PKG_URL="https://github.com/ClementTsang/bottom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/diffutils/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/diffutils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="diffutils"
-PKG_VERSION="3.8"
-PKG_SHA256="a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec"
+PKG_VERSION="3.9"
+PKG_SHA256="d80d3be90a201868de83d78dad3413ad88160cc53bcc36eb9eaf7c20dbf023f1"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/diffutils/"
 PKG_URL="http://ftpmirror.gnu.org/diffutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/system-tools-depends/htop/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/htop/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="htop"
-PKG_VERSION="3.2.1"
-PKG_SHA256="b5ffac1949a8daaabcffa659c0964360b5008782aae4dfa7702d2323cfb4f438"
+PKG_VERSION="3.2.2"
+PKG_SHA256="3829c742a835a0426db41bb039d1b976420c21ec65e93b35cd9bfd2d57f44ac8"
 PKG_LICENSE="GPL"
 PKG_SITE="https://hisham.hm/htop"
 PKG_URL="https://github.com/htop-dev/htop/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpiod"
-PKG_VERSION="1.6.4"
-PKG_SHA256="829d4ac268df07853609d67cfc7f476e9aa736cb2a68a630be99e8fad197be0a"
+PKG_VERSION="2.0"
+PKG_SHA256="62071ac22872d9b936408e4a067d15edcdd61dce864ace8725eacdaefe23b898"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
 PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/lshw/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/lshw/package.mk
@@ -12,5 +12,6 @@ PKG_LONGDESC="A small tool to provide detailed information on the hardware confi
 PKG_BUILD_FLAGS="-sysroot"
 
 make_target() {
+  export VERSION="B.${PKG_VERSION}"
   make CXX=${CXX} -C src/
 }

--- a/packages/addons/addon-depends/system-tools-depends/mc/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mc"
-PKG_VERSION="4.8.28"
-PKG_SHA256="e994d9be9a7172e9ac4a4ad62107921f6aa312e668b056dfe5b8bcebbaf53803"
+PKG_VERSION="4.8.29"
+PKG_SHA256="773a453112fb6d175a322f042f583af4ad4566d7424fadcfb0f5b61b18c631ca"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.midnight-commander.org"
 PKG_URL="http://ftp.midnight-commander.org/mc-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.15.01"
-PKG_SHA256="2168627350d8e3b7f4571732d6117ab054a9851600899c30ad82fd3c9649d644"
+PKG_VERSION="0.15.06"
+PKG_SHA256="c38cefcf0a83f6c65aed7c36e57a9a1ee8373418ef71cf089a75b0661dcd4623"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="unrar"
-PKG_VERSION="6.2.3"
-PKG_SHA256="120936e41f826cd63d77a580aeea64c1b79fd3e2434f58ce8184e783b51e5b01"
+PKG_VERSION="6.2.6"
+PKG_SHA256="0c2d4cbc8b34d0e3bec7b474e0f52bbcc6c4320ec089b4141223ee355f63c318"
 PKG_LICENSE="free"
 PKG_SITE="https://www.rarlab.com/rar_add.htm"
 PKG_URL="https://www.rarlab.com/rar/unrarsrc-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vim"
-PKG_VERSION="9.0.1413"
-PKG_SHA256="c2b4fdb50ec2ac5f83bd87661563af9298877a14dc174d7492e562565f1c0815"
+PKG_VERSION="9.0.1417"
+PKG_SHA256="02c67859046f7c0206afb909061763cf40747c6bf40c22bb6efaf9c06be41591"
 PKG_LICENSE="VIM"
 PKG_SITE="http://www.vim.org/"
 PKG_URL="https://github.com/vim/vim/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vim"
-PKG_VERSION="9.0.1065"
-PKG_SHA256="f3db36c8ebe665ee750f6b729d6fe25de9dac202829f1f7390ceb62955750dc9"
+PKG_VERSION="9.0.1413"
+PKG_SHA256="c2b4fdb50ec2ac5f83bd87661563af9298877a14dc174d7492e562565f1c0815"
 PKG_LICENSE="VIM"
 PKG_SITE="http://www.vim.org/"
 PKG_URL="https://github.com/vim/vim/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
system-tools: update to addon (1)
- bottom: update to 0.8.0
- diffutils: update to 3.9
- htop: update to 3.2.2
- libgpiod: update to 2.0
- lshw: fix lshw -version display
- mc: update to 4.8.29
- stress-ng: update to 0.15.06
- unrar: update to 6.2.6
- vim: update to 9.0.1413