### PR TITLE
[le11] ttyd: update to 1.7.3 and addon (1)

### DIFF
--- a/packages/addons/service/ttyd/changelog.txt
+++ b/packages/addons/service/ttyd/changelog.txt
@@ -1,1 +1,2 @@
-initial release
+1
+- ttyd: update to 1.7.3

--- a/packages/addons/service/ttyd/package.mk
+++ b/packages/addons/service/ttyd/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ttyd"
-PKG_VERSION="1.7.2"
-PKG_SHA256="edc44cd5319c0c9d0858081496cae36fc5c54ee7722e0a547dde39537dfb63de"
-PKG_REV="0"
+PKG_VERSION="1.7.3"
+PKG_SHA256="c9cf5eece52d27c5d728000f11315d36cb400c6948d1964a34a7eae74b454099"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/tsl0922/ttyd"


### PR DESCRIPTION
- backport of #7657

release notes:
- https://github.com/tsl0922/ttyd/releases/tag/1.7.3

log:
- https://github.com/tsl0922/ttyd/compare/1.7.2...1.7.3