### PR TITLE
busybox: init: post update script hook

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -130,6 +130,7 @@ makeinstall_target() {
     cp ${PKG_DIR}/scripts/fs-resize ${INSTALL}/usr/lib/libreelec
     sed -e "s/@DISTRONAME@/${DISTRONAME}/g" \
         -i ${INSTALL}/usr/lib/libreelec/fs-resize
+    find_file_path config/post-update ${PKG_DIR}/scripts/post-update && cp -PRv ${FOUND_PATH} ${INSTALL}/usr/lib/libreelec
 
     if listcontains "${FIRMWARE}" "rpi-eeprom"; then
       cp ${PKG_DIR}/scripts/rpi-flash-firmware ${INSTALL}/usr/lib/libreelec

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -267,6 +267,13 @@ get_project_arch() {
   fi
 }
 
+get_distro_version() {
+  if [ -f ${1}/etc/os-release ]; then
+    . ${1}/etc/os-release
+    echo "${VERSION_ID}"
+  fi
+}
+
 # If the project/arch of current matches the update, then it is considered compatible.
 # Otherwise, mount the update SYSTEM partition and, if canupdate.sh is available,
 # call the script to determine if the current update file can be applied on to the
@@ -292,6 +299,14 @@ check_is_compatible() {
 
   old_project_arch="$(get_project_arch "/sysroot")" || return
   new_project_arch="$(get_project_arch "/update")" || return
+
+  # old image will be gone by the time post-update runs
+  if [ -f "/update/usr/lib/libreelec/post-update" ]; then
+    export OLD_PROJECT_ARCH=$old_project_arch
+    export NEW_PROJECT_ARCH=$new_project_arch
+    export OLD_DISTRO_VERSION="$(get_distro_version "/sysroot")"
+    export NEW_DISTRO_VERSION="$(get_distro_version "/update")"
+  fi
 
   # If old or new project/arch isn't available then could be very old (pre-/etc/os-release) build - have to trust it
   if [ -n "${old_project_arch}" -a -n "${new_project_arch}" ]; then
@@ -355,6 +370,18 @@ update_bootloader() {
       result="$(sh $SYSTEM_ROOT/usr/share/bootloader/update.sh 2>&1)"
       sync
       StopProgress "done"
+    [ -n "${result}" ] && echo "${result}"
+  fi
+}
+
+post_update_tasks() {
+  if [ -f "${SYSTEM_ROOT}/usr/lib/libreelec/post-update" ]; then
+    local result
+
+    StartProgress spinner "Running post update tasks... "
+      result="$(sh ${SYSTEM_ROOT}/usr/lib/libreelec/post-update 2>&1)"
+      sync
+    StopProgress "done"
     [ -n "${result}" ] && echo "${result}"
   fi
 }
@@ -932,6 +959,7 @@ check_update() {
   umount /sysroot
   update_file "System" "$UPDATE_SYSTEM" "/flash/$IMAGE_SYSTEM"
   update_bootloader
+  post_update_tasks
   do_cleanup
   do_reboot
 }

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -383,6 +383,7 @@ post_update_tasks() {
       sync
     StopProgress "done"
     [ -n "${result}" ] && echo "${result}"
+    sleep 10
   fi
 }
 

--- a/packages/sysutils/busybox/scripts/post-update
+++ b/packages/sysutils/busybox/scripts/post-update
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+# post-update script demo
+
+echo "BOOT_ROOT=${BOOT_ROOT}"
+echo "SYSTEM_ROOT=${SYSTEM_ROOT}"
+echo "OLD_PROJECT_ARCH=${OLD_PROJECT_ARCH}"
+echo "NEW_PROJECT_ARCH=${NEW_PROJECT_ARCH}"
+echo "OLD_DISTRO_VERSION=${OLD_DISTRO_VERSION}"
+echo "NEW_DISTRO_VERSION=${NEW_DISTRO_VERSION}"
+
+exit


### PR DESCRIPTION
This adds a post-update hook to buysbox's init to run a script from the new image. I've chosen to insert it between the update finishing making its changes and cleaning up prior to reboot.

The script may be per project, device, or distro wide via busybox package scripts. I've chosen new/old VERSION_ID and DEVICE.ARCH as the needed exports for the script. This should be enough for where the device is coming from and where it's going to. These are exported because by the time the hook runs, the old image is no longer available to query.

The temp commit is just the demo script echo'ing the exported variables and putting in a sleep delay to see the output. Normally, the script will echo any output after the script completes (not during progress). It should be dropped before merge.

A reminder that two updates needs to happen to see changes: once to update init to have the call, and the second to then run a post-update script.

WIP:
condense new/old project arch to one variable
any other information from old image?
other?