### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="20.5.0-Nexus"
-PKG_SHA256="a849b6b4d5ce740ec3552d244acc4c7a4d64792358428f5154236052473d5734"
-PKG_REV="5"
+PKG_VERSION="21.0.0-Omega"
+PKG_SHA256="cb20b0951ab95815c75c48daded322e9aef74c5937de386878a17f9589b5933e"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"
 PKG_SITE="https://github.com/xbmc/inputstream.ffmpegdirect"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="20.6.1-Nexus"
-PKG_SHA256="d56cf6673bd1008c50e76990f77ffb4a3b6af2ef26968fd217f0d6dbb11328b1"
-PKG_REV="2"
+PKG_VERSION="21.0.1-Omega"
+PKG_SHA256="0e65dd3ae19363a7e70fbe03b9c3ae7e8d6c419774205e6e343606e870cc0f44"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hts"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="21.1.1-Omega"
-PKG_SHA256="ca4ba74f7546df1e46b32fd4a569084fa0a2ca4a0947e0abc4a716127350f5ec"
+PKG_VERSION="21.2.0-Omega"
+PKG_SHA256="43c023c338e4bb948baeb0dbe2bac0489df1d100aa29f9df59995396309eff42"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="20.4.0-Nexus"
-PKG_SHA256="a781cfdf3a9d5d592eed5152200e69acf1214712f06c6b99573a1a01dadd62f5"
-PKG_REV="5"
+PKG_VERSION="21.0.1-Omega"
+PKG_SHA256="ff74ad9023a4f10ad4be77b37f94786478ccbaa0ad719618448d750074797165"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vdr.vnsi"


### PR DESCRIPTION
- inputstream.ffmpegdirect: update 20.5.0-Nexus to 21.0.0-Omega
- pvr.hts: update 20.6.1-Nexus to 21.0.1-Omega
- pvr.iptvsimple: update 21.1.1-Omega to 21.2.0-Omega
- pvr.vdr.vnsi: update 20.4.0-Nexus to 21.0.1-Omega

- Fixes #7672 
  - https://github.com/xbmc/inputstream.ffmpegdirect/pull/233