### PR TITLE
system-tools: drop gpiofind

### DIFF
--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -133,7 +133,7 @@ addon() {
     cp -P $(get_install_dir oniguruma)/usr/lib/{libonig.so,libonig.so.5,libonig.so.5.*.*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
 
     # libgpiod
-    cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpiofind,gpioget,gpioinfo,gpiomon,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpioget,gpioinfo,gpiomon,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # lm_sensors
     cp -P $(get_install_dir lm_sensors)/usr/bin/sensors ${ADDON_BUILD}/${PKG_ADDON_ID}/bin 2>/dev/null || :


### PR DESCRIPTION
fix build error

from the libgpiod release notes:

libgpiod v2.0
=============

This is a major release that breaks compatiblity with the v1.6.x series. The entire data model has been overhauled in order to make using the library more intuitive and less cumbersome, while also making the code future-proof and extensible. Please refer to the documentation for details.

New features:
- rework the entire API: core C library as well as C++ and Python bindings
- rework the command-line tools in order to make them more line-name-oriented
- drop gpiofind as tools can now resolve line names on their own
- add the interactive mode to gpioset
- add Rust bindings
- make tests work with the gpio-sim kernel module