### PR TITLE
[le11] tz: update to 2023b

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2022g"
-PKG_SHA256="cc1169a43591201964ba6977ce8a63bb9cbe2d6e6bdcde34cd609f50e9866039"
+PKG_VERSION="2023b"
+PKG_SHA256="1d4f516a6a6fa8948e2c6e47352756a7bb922b236930eebacbadd784f883acf4"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
News:
- https://github.com/eggert/tz/blob/71faa2a55db2c9f21f4099b58c28536673982e0a/NEWS

- Backport of #7684 