### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="20.6.1-Nexus"
-PKG_SHA256="d56cf6673bd1008c50e76990f77ffb4a3b6af2ef26968fd217f0d6dbb11328b1"
-PKG_REV="2"
+PKG_VERSION="20.6.2-Nexus"
+PKG_SHA256="e77bd87f1f4d1abc06e32d0347a0bb635bc129bec43a07864cb8a9e6b0e4d374"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hts"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="20.8.1-Nexus"
-PKG_SHA256="9077b3cd7b74d05ef2ac1d30b9ffb32232e39fd9620a7bbd9a9cb01fcbb638f9"
-PKG_REV="2"
+PKG_VERSION="20.9.1-Nexus"
+PKG_SHA256="9871e305db254b064d836242962d5b57560245984efa5bd76067baa893594bef"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.iptvsimple"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="20.4.0-Nexus"
-PKG_SHA256="a781cfdf3a9d5d592eed5152200e69acf1214712f06c6b99573a1a01dadd62f5"
-PKG_REV="5"
+PKG_VERSION="20.4.1-Nexus"
+PKG_SHA256="f26e2a9f1e9d83c5b44a8875b1f9cd37a0dbe59faf08002f083a4db95c9f84e0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vdr.vnsi"


### PR DESCRIPTION
- pvr.hts: update 20.6.1-Nexus to 20.6.2-Nexus
- pvr.iptvsimple: update 20.8.1-Nexus to 20.9.1-Nexus
- pvr.vdr.vnsi: update 20.4.0-Nexus to 20.4.1-Nexus