### PR TITLE
systemd: network-base: alter hosts.conf if contents still default

### DIFF
--- a/packages/sysutils/systemd/config/hosts.conf
+++ b/packages/sysutils/systemd/config/hosts.conf
@@ -3,8 +3,8 @@
 # This configuration file allows you to manually map hostnames to
 # IP addresses
 
-# Format:  <ipaddress> <hostname1> <hostname2>
-# Example: 192.168.0.3 libreelec libreelec.mynetwork
+# Format:  <ipaddress> <fqdn> <alias1> <alias2>
+# Example: 192.168.0.3 libreelec.mynetwork libreelec
 
 # NOTE: do not edit /etc/hosts directly
 # edit /storage/.config/hosts.conf then reboot

--- a/packages/sysutils/systemd/scripts/network-base-setup
+++ b/packages/sysutils/systemd/scripts/network-base-setup
@@ -1,4 +1,11 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+check_hosts() {
+  grep -v "^#" /run/libreelec/hosts | grep "${1}"
+}
+
 
 # setup hostname
 if [ -f /storage/.cache/hostname ]; then
@@ -9,13 +16,27 @@ fi
 rm -f /run/libreelec/hosts
 if [ -f /storage/.config/hosts.conf ]; then
   cat /storage/.config/hosts.conf > /run/libreelec/hosts
+  # add localhost to hosts if not present
+  LOCALHOST_HOSTS=$(check_hosts "localhost")
+  if [ -z "${LOCALHOST_HOSTS}" ]; then
+    {
+      echo "127.0.0.1 localhost"
+      echo "::1 localhost ip6-localhost ip6-loopback"
+    } >> /run/libreelec/hosts
+  fi
+  # add HOSTNAME to hosts if not present
+  HOSTNAME=$(cat /proc/sys/kernel/hostname)
+  HOSTNAME_HOSTS=$(check_hosts "${HOSTNAME}")
+  if [ -z "${HOSTNAME_HOSTS}" ]; then
+    echo "127.0.1.1 ${HOSTNAME}" >> /run/libreelec/hosts
+  fi
 fi
 
 # setup /etc/resolv.conf
 rm -f /run/libreelec/resolv.conf
 if [ -f /storage/.config/resolv.conf ]; then
   cat /storage/.config/resolv.conf > /run/libreelec/resolv.conf
-elif [ -f /dev/.kernel_ipconfig -a -f /proc/net/pnp ]; then
+elif [ -f /dev/.kernel_ipconfig ] && [ -f /proc/net/pnp ]; then
   cat /proc/net/pnp > /run/libreelec/resolv.conf
 else
   cat << EOF > /run/libreelec/resolv.conf


### PR DESCRIPTION
This partially addresses #7674. Another part will be needed in the settings addon.

In short, the settings addon will just append localhost entries to user or image set /etc/hosts. This moves settings to the network-base.service, and makes adding entries contingent on the image's hosts.conf matching the same content as the one located in /storage. If there is any mismatch, no changes are made.

127.0.1.1 is added as the hostname's hosts entry as recommended by Debian's reference manual: https://qref.sourceforge.net/quick/ch-gateway.en.html see 10.4. It's for applications that believe the hostname should resolve to an address.

I don't believe it's enabled, but my understanding is ipv6 has only the one localhost address so there's no change to be made there.

The intended change in the settings addon is to change hostname.set_hostname() to just editing the hostname file in /storage and then restarting network-base.service (which just runs this script).

I'm not terribly thrilled about this approach because if the image's hosts.conf is updated, then existing installs will still have the hosts.conf from the original install. That would be detected as a user made change, which it isn't. This would be the kind of gotcha that gets forgotten about.

Also adds license header and shellcheck change.