### PR TITLE
[le12] iwd: update to 2.4

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.3"
-PKG_SHA256="b0506d797a8bfb88f3c3eeea5e49dcf4ee8e6cef118f57c118e587eeb377ac64"
+PKG_VERSION="2.4"
+PKG_SHA256="3a9c5e7ade45162e5c78b3d7035a2f4a6e20ba6b5974097c35a8f615493012f9"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
ver 2.4:
+	Fix issue with FT-over-Air and same channel operation.
+	Fix issue with AP mode and missing support for GTK.
+	Fix issue with AP mode and channel switch event.
+	Fix issue with SSID string conversion handling.