### PR TITLE
X11 and Wayland updates

### DIFF
--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.22.1"
-PKG_SHA256="e13f6f118cfbbdc0b6e0edd5e3504abd96a8d0e33dc67cba31c6942c449f77af"
+PKG_VERSION="1.23.0"
+PKG_SHA256="fad7011705a21f500229199f789f3e3e794b4c9826b70073745cdaec23bc1d0b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xorg-server"
-PKG_VERSION="21.1.7"
-PKG_SHA256="d9c60b2dd0ec52326ca6ab20db0e490b1ff4f566f59ca742d6532e92795877bb"
+PKG_VERSION="21.1.8"
+PKG_SHA256="38aadb735650c8024ee25211c190bf8aad844c5f59632761ab1ef4c4d5aeb152"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
 PKG_URL="https://www.x.org/releases/individual/xserver/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
### security release 

- xorg-server: update to 21.1.8
  - https://lists.x.org/archives/xorg/2023-March/061313.html
  - https://lists.x.org/archives/xorg-announce/2023-March/003374.html
- libinput: update to 1.23.0
  - https://lists.freedesktop.org/archives/wayland-devel/2023-March/042642.html