### PR TITLE
Minor package updates

### DIFF
--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.41.1"
+PKG_VERSION="3.41.2"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="4dadfbeab9f8e16c695d4fbbc51c16b2f77fb97ff4c1c3d139919dfc038c9e33"
+PKG_SHA256="e98c100dd1da4e30fa460761dab7c0b91a50b785e167f8c57acc46514fae9499"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2023/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"

--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.76.0"
-PKG_SHA256="525bb703b807142e1aee5ccf222c344e8064b21c0c45677ef594e587874c6797"
+PKG_VERSION="2.76.1"
+PKG_SHA256="43dc0f6a126958f5b454136c4398eab420249c16171a769784486e25f2fda19f"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/libcap/package.mk
+++ b/packages/devel/libcap/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcap"
-PKG_VERSION="2.67"
-PKG_SHA256="ce9b22fdc271beb6dae7543da5f74cf24cb82e6848cfd088a5a069dec5ea5198"
+PKG_VERSION="2.68"
+PKG_SHA256="90be3b6d41be5f81ae4b03ec76012b0d27c829293684f6c05b65d5f9cce724b2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libcap/libcap.git/log/"
 PKG_URL="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.6.1"
-PKG_SHA256="8cbc4fd8ce27b85107b449833c3b30fb05f1ca3c81b46a0ba8658036944266bc"
+PKG_VERSION="2.6.2"
+PKG_SHA256="42d561a9af150b21bc914e3b7aa09f88013d2ffa6d5ce75a025a3b34caa948d4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://openvpn.net"
 PKG_URL="https://swupdate.openvpn.org/community/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/fuse3/package.mk
+++ b/packages/sysutils/fuse3/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fuse3"
-PKG_VERSION="3.14.0"
-PKG_SHA256="96115b2a8ff34bd1e0c7b00c5dfd8297571d7e165042b94498c9a26356a9a70a"
+PKG_VERSION="3.14.1"
+PKG_SHA256="126919d72b46b3e0eb58a9c6933a2a50c36f2ea69f61fe9e78bdba9f463ffa20"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libfuse/libfuse/"
 PKG_URL="https://github.com/libfuse/libfuse/releases/download/fuse-${PKG_VERSION}/fuse-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- sqlite: update to 3.41.2
- glib: update to 2.76.1
- fuse3: update to 3.14.1
- libcap: update to 2.68
- openvpn: update to 2.6.2