### PR TITLE
scripts/build: properly honor strip build flag

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -167,7 +167,7 @@ TARGET_MESON_OPTS="--prefix=/usr \
                    --libexecdir=/usr/lib \
                    --localstatedir=/var \
                    --buildtype=${MESON_BUILD_TYPE}"
-if [ ${BUILD_WITH_DEBUG} != yes ] && flag_enabled "strip" "yes"; then
+if [ "${BUILD_WITH_DEBUG}" != "yes" ] && flag_enabled "strip" "yes"; then
   TARGET_MESON_OPTS+=" -Dstrip=true"
 fi
 
@@ -524,7 +524,7 @@ if [ "${TARGET}" = "target" -o "${TARGET}" = "init" ]; then
 
     python_fix_abi "${INSTALL}"
 
-    if [ ! "${BUILD_WITH_DEBUG}" = "yes" ]; then
+    if [ "${BUILD_WITH_DEBUG}" != "yes" ] && flag_enabled "strip" "yes"; then
       ${STRIP} $(find ${INSTALL} \
         -type f -name "*.so*" \
         ! -name "ld-*.so" \


### PR DESCRIPTION
Package building honor's the strip flag so we can prevent executables from being stripped.

But copying files to INSTALL ignored that flag which meant the flag had practically no effect.

Fix this by using the same logic as we do in the meson strip handling in line 170 and in config/functions