### PR TITLE
gptfdisk: update to 1.09.2 / fs_resize: improvements

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -23,7 +23,7 @@ if [ -e /storage/.please_resize_me ] ; then
 
   # get disk: /dev/sdx2 -> /dev/sdx, /dev/mmcblkxp2 -> /dev/mmcblkx
   case $PART in
-    "/dev/mmcblk"*)
+    "/dev/mmcblk"*|"/dev/nvme"*)
       DISK=$(echo $PART | sed s/p2$//g)
       ;;
     *)

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -3,22 +3,35 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 
+StartProgressLog() {
+  if [ "$1" = "spinner" ]; then
+    echo "*** $3" >>$LOG
+  fi
+  StartProgress "$@"
+}
+
 if [ -e /storage/.please_resize_me ] ; then
   . /usr/lib/libreelec/functions
 
   hidecursor
+
+  mount -o remount,rw /flash
+  LOG=/flash/fs-resize.log
+  date -Iseconds >>$LOG
 
   # this sh** was never intended to be used
   # on already installed and runing system
   if [ -d /storage/.kodi -o -d /storage/.config -o -d /storage/.cache ] ; then
     rm -f /storage/.please_resize_me
     sync
-    echo "Resizing is not permitted - the system has already been initialised."
+    echo "Resizing is not permitted - the system has already been initialised." | tee -a $LOG
+    mount -o remount,ro /flash
     StartProgress countdown "Rebooting in 15s... " 15 "NOW"
     reboot -f
   fi
 
   # get the disk. /storage on 2nd partition
+  echo $(grep "/storage " /proc/mounts) >>$LOG
   PART=$(grep "/storage " /proc/mounts | cut -d" " -f1 | grep '2$')
 
   # get disk: /dev/sdx2 -> /dev/sdx, /dev/mmcblkxp2 -> /dev/mmcblkx
@@ -34,6 +47,8 @@ if [ -e /storage/.please_resize_me ] ; then
   rm -f /storage/.please_resize_me
   sync
 
+  echo "DISK: $DISK  PART: $PART" >>$LOG
+
   # just in case
   if [ ! -z "$DISK" -a ! -z "$PART" ] ; then
     umount $PART
@@ -46,16 +61,17 @@ if [ -e /storage/.please_resize_me ] ; then
     # identify the partition scheme, and if gpt fix minor issues such as gpt header not at end of disk
     SCHEME=$(blkid -s PTTYPE -o value $DISK)
     if [ "$SCHEME" = "gpt" ]; then
-      StartProgress spinner "Checking layout...      " "sgdisk -e $DISK &>/dev/null"
+      StartProgressLog spinner "Checking layout...      " "sgdisk -e $DISK >>$LOG 2>&1"
     fi
 
-    StartProgress spinner "Resizing partition...   " "parted -s -m $DISK resizepart 2 100% &>/dev/null"
-    StartProgress spinner "Checking file system... " "e2fsck -f -p $PART &>/dev/null"
-    StartProgress spinner "Resizing file system... " "resize2fs $PART &>/dev/null"
+    StartProgressLog spinner "Resizing partition...   " "parted -s -m $DISK resizepart 2 100% >>$LOG 2>&1"
+    StartProgressLog spinner "Checking file system... " "e2fsck -f -p $PART >>$LOG 2>&1"
+    StartProgressLog spinner "Resizing file system... " "resize2fs $PART >>$LOG 2>&1"
     StartProgress countdown "Rebooting in 15s...     " 15 "NOW"
   else
     echo "Partition was not detected - resizing aborted."
     StartProgress countdown "Rebooting in 15s... " 15 "NOW"
   fi
+  mount -o remount,ro /flash
 fi
 reboot -f &>/dev/null

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -53,6 +53,9 @@ if [ -e /storage/.please_resize_me ] ; then
     StartProgress spinner "Checking file system... " "e2fsck -f -p $PART &>/dev/null"
     StartProgress spinner "Resizing file system... " "resize2fs $PART &>/dev/null"
     StartProgress countdown "Rebooting in 15s...     " 15 "NOW"
+  else
+    echo "Partition was not detected - resizing aborted."
+    StartProgress countdown "Rebooting in 15s... " 15 "NOW"
   fi
 fi
 reboot -f &>/dev/null

--- a/packages/sysutils/gptfdisk/patches/0001-Fix-failure-crash-of-sgdisk-when-compiled-with-lates.patch
+++ b/packages/sysutils/gptfdisk/patches/0001-Fix-failure-crash-of-sgdisk-when-compiled-with-lates.patch
@@ -1,0 +1,57 @@
+From 5d5e76d369a412bfb3d2cebb5fc0a7509cef878d Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Fri, 15 Apr 2022 18:10:14 -0400
+Subject: [PATCH 01/12] Fix failure & crash of sgdisk when compiled with latest
+ popt (commit 740; presumably eventually release 1.19)
+
+---
+ NEWS      | 8 ++++++++
+ gptcl.cc  | 2 +-
+ support.h | 2 +-
+ 3 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/NEWS b/NEWS
+index c7add56..9e153fd 100644
+--- a/NEWS
++++ b/NEWS
+@@ -1,3 +1,11 @@
++1.0.10 (?/??/2022):
++-------------------
++
++- Fixed problem that caused sgdisk to crash with errors about being unable
++  to read the disk's partition table when compiled with the latest popt
++  (commit 740, which is pre-release as I type; presumably version 1.19 and
++  later once released).
++
+ 1.0.9 (4/14/2022):
+ ------------------
+ 
+diff --git a/gptcl.cc b/gptcl.cc
+index 34c9421..0d578eb 100644
+--- a/gptcl.cc
++++ b/gptcl.cc
+@@ -155,7 +155,7 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+    } // while
+ 
+    // Assume first non-option argument is the device filename....
+-   device = (char*) poptGetArg(poptCon);
++   device = strdup((char*) poptGetArg(poptCon));
+    poptResetContext(poptCon);
+ 
+    if (device != NULL) {
+diff --git a/support.h b/support.h
+index 8ba9ad1..f91f1bc 100644
+--- a/support.h
++++ b/support.h
+@@ -8,7 +8,7 @@
+ #include <stdlib.h>
+ #include <string>
+ 
+-#define GPTFDISK_VERSION "1.0.9"
++#define GPTFDISK_VERSION "1.0.9.1"
+ 
+ #if defined (__FreeBSD__) || defined (__FreeBSD_kernel__) || defined (__APPLE__)
+ // Darwin (Mac OS) & FreeBSD: disk IOCTLs are different, and there is no lseek64
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0002-Updated-guid.cc-to-deal-with-minor-change-in-libuuid.patch
+++ b/packages/sysutils/gptfdisk/patches/0002-Updated-guid.cc-to-deal-with-minor-change-in-libuuid.patch
@@ -1,0 +1,39 @@
+From 6a8416cbd12d55f882bb751993b94f72d338d96f Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Sat, 16 Apr 2022 09:32:04 -0400
+Subject: [PATCH 02/12] Updated guid.cc to deal with minor change in libuuid
+
+---
+ NEWS    | 2 ++
+ guid.cc | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/NEWS b/NEWS
+index 9e153fd..9ec7e63 100644
+--- a/NEWS
++++ b/NEWS
+@@ -6,6 +6,8 @@
+   (commit 740, which is pre-release as I type; presumably version 1.19 and
+   later once released).
+ 
++- Updated guid.cc to deal with minor change in libuuid.
++
+ 1.0.9 (4/14/2022):
+ ------------------
+ 
+diff --git a/guid.cc b/guid.cc
+index 1e73ab7..d3e4fd5 100644
+--- a/guid.cc
++++ b/guid.cc
+@@ -141,7 +141,7 @@ void GUIDData::Zero(void) {
+ void GUIDData::Randomize(void) {
+    int i, uuidGenerated = 0;
+ 
+-#ifdef _UUID_UUID_H
++#if defined (_UUID_UUID_H) || defined (_UL_LIBUUID_UUID_H)
+    uuid_generate(uuidData);
+    ReverseBytes(&uuidData[0], 4);
+    ReverseBytes(&uuidData[4], 2);
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0003-Updated-URLs-in-man-pages-to-HTTPS-rather-than-HTTP.patch
+++ b/packages/sysutils/gptfdisk/patches/0003-Updated-URLs-in-man-pages-to-HTTPS-rather-than-HTTP.patch
@@ -1,0 +1,115 @@
+From 913f7b48647bdbd23fdc4abccf2168b061273aa4 Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Tue, 26 Apr 2022 15:46:49 -0400
+Subject: [PATCH 03/12] Updated URLs in man pages to HTTPS rather than HTTP
+
+---
+ cgdisk.8   | 8 ++++----
+ fixparts.8 | 4 ++--
+ gdisk.8    | 8 ++++----
+ sgdisk.8   | 8 ++++----
+ 4 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/cgdisk.8 b/cgdisk.8
+index e3b5cb4..bc83d4b 100644
+--- a/cgdisk.8
++++ b/cgdisk.8
+@@ -25,7 +25,7 @@ disks.
+ 
+ For information on MBR vs. GPT, as well as GPT terminology and structure,
+ see the extended GPT fdisk documentation at
+-\fIhttp://www.rodsbooks.com/gdisk/\fR or consult Wikipedia.
++\fIhttps://www.rodsbooks.com/gdisk/\fR or consult Wikipedia.
+ 
+ The \fBcgdisk\fR program employs a user interface similar to that of Linux's
+ \fBcfdisk\fR, but \fBcgdisk\fR modifies GPT partitions. It also has the
+@@ -389,11 +389,11 @@ Contributors:
+ .BR sgdisk (8),
+ .BR fixparts (8).
+ 
+-\fIhttp://en.wikipedia.org/wiki/GUID_Partition_Table\fR
++\fIhttps://en.wikipedia.org/wiki/GUID_Partition_Table\fR
+ 
+-\fIhttp://developer.apple.com/technotes/tn2006/tn2166.html\fR
++\fIhttps://developer.apple.com/technotes/tn2006/tn2166.html\fR
+ 
+-\fIhttp://www.rodsbooks.com/gdisk/\fR
++\fIhttps://www.rodsbooks.com/gdisk/\fR
+ 
+ .SH "AVAILABILITY"
+ The \fBcgdisk\fR command is part of the \fIGPT fdisk\fR package and is
+diff --git a/fixparts.8 b/fixparts.8
+index da7462a..25d05ad 100644
+--- a/fixparts.8
++++ b/fixparts.8
+@@ -273,9 +273,9 @@ Contributors:
+ .BR gdisk (8),
+ .BR sgdisk (8).
+ 
+-\fIhttp://en.wikipedia.org/wiki/Master_boot_record\fR
++\fIhttps://en.wikipedia.org/wiki/Master_boot_record\fR
+ 
+-\fIhttp://www.rodsbooks.com/fixparts/\fR
++\fIhttps://www.rodsbooks.com/fixparts/\fR
+ 
+ .SH "AVAILABILITY"
+ The \fBfixparts\fR command is part of the \fIGPT fdisk\fR package and is
+diff --git a/gdisk.8 b/gdisk.8
+index b826b89..8c9929b 100644
+--- a/gdisk.8
++++ b/gdisk.8
+@@ -27,7 +27,7 @@ recovery options require you to understand the distinctions between the
+ main and backup data, as well as between the GPT headers and the partition
+ tables. For information on MBR vs. GPT, as well as GPT terminology and
+ structure, see the extended \fBgdisk\fR documentation at
+-\fIhttp://www.rodsbooks.com/gdisk/\fR or consult Wikipedia.
++\fIhttps://www.rodsbooks.com/gdisk/\fR or consult Wikipedia.
+ 
+ The \fBgdisk\fR program employs a user interface similar to that of Linux's
+ \fBfdisk\fR, but \fBgdisk\fR modifies GPT partitions. It also has the
+@@ -702,11 +702,11 @@ Contributors:
+ .BR sgdisk (8),
+ .BR fixparts (8).
+ 
+-\fIhttp://en.wikipedia.org/wiki/GUID_Partition_Table\fR
++\fIhttps://en.wikipedia.org/wiki/GUID_Partition_Table\fR
+ 
+-\fIhttp://developer.apple.com/technotes/tn2006/tn2166.html\fR
++\fIhttps://developer.apple.com/technotes/tn2006/tn2166.html\fR
+ 
+-\fIhttp://www.rodsbooks.com/gdisk/\fR
++\fIhttps://www.rodsbooks.com/gdisk/\fR
+ 
+ .SH "AVAILABILITY"
+ The \fBgdisk\fR command is part of the \fIGPT fdisk\fR package and is
+diff --git a/sgdisk.8 b/sgdisk.8
+index b966a13..4e5a15a 100644
+--- a/sgdisk.8
++++ b/sgdisk.8
+@@ -23,7 +23,7 @@ recovery options require you to understand the distinctions between the
+ main and backup data, as well as between the GPT headers and the partition
+ tables. For information on MBR vs. GPT, as well as GPT terminology and
+ structure, see the extended \fBgdisk\fR documentation at
+-\fIhttp://www.rodsbooks.com/gdisk/\fR or consult Wikipedia.
++\fIhttps://www.rodsbooks.com/gdisk/\fR or consult Wikipedia.
+ 
+ The \fBsgdisk\fR program employs a user interface that's based entirely on
+ the command line, making it suitable for use in scripts or by experts who
+@@ -632,11 +632,11 @@ Contributors:
+ .BR sfdisk (8),
+ .BR fixparts (8).
+ 
+-\fIhttp://en.wikipedia.org/wiki/GUID_Partition_Table\fR
++\fIhttps://en.wikipedia.org/wiki/GUID_Partition_Table\fR
+ 
+-\fIhttp://developer.apple.com/technotes/tn2006/tn2166.html\fR
++\fIhttps://developer.apple.com/technotes/tn2006/tn2166.html\fR
+ 
+-\fIhttp://www.rodsbooks.com/gdisk/\fR
++\fIhttps://www.rodsbooks.com/gdisk/\fR
+ 
+ .SH "AVAILABILITY"
+ The \fBsgdisk\fR command is part of the \fIGPT fdisk\fR package and is
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0004-Fix-NULL-dereference-when-duplicating-string-argumen.patch
+++ b/packages/sysutils/gptfdisk/patches/0004-Fix-NULL-dereference-when-duplicating-string-argumen.patch
@@ -1,0 +1,40 @@
+From f5de3401b974ce103ffd93af8f9d43505a04aaf9 Mon Sep 17 00:00:00 2001
+From: Damian Kurek <starfire24680@gmail.com>
+Date: Thu, 7 Jul 2022 03:39:16 +0000
+Subject: [PATCH 04/12] Fix NULL dereference when duplicating string argument
+
+poptGetArg can return NULL if there are no additional arguments, which
+makes strdup dereference NULL on strlen
+---
+ gptcl.cc | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/gptcl.cc b/gptcl.cc
+index 0d578eb..ab95239 100644
+--- a/gptcl.cc
++++ b/gptcl.cc
+@@ -155,10 +155,11 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+    } // while
+ 
+    // Assume first non-option argument is the device filename....
+-   device = strdup((char*) poptGetArg(poptCon));
+-   poptResetContext(poptCon);
++   device = (char*) poptGetArg(poptCon);
+ 
+    if (device != NULL) {
++      device = strdup(device);
++      poptResetContext(poptCon);
+       JustLooking(); // reset as necessary
+       BeQuiet(); // Tell called functions to be less verbose & interactive
+       if (LoadPartitions((string) device)) {
+@@ -498,6 +499,7 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+          cerr << "Error encountered; not saving changes.\n";
+          retval = 4;
+       } // if
++      free(device);
+    } // if (device != NULL)
+    poptFreeContext(poptCon);
+    return retval;
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0005-Use-64bit-time_t-on-linux-as-well.patch
+++ b/packages/sysutils/gptfdisk/patches/0005-Use-64bit-time_t-on-linux-as-well.patch
@@ -1,0 +1,34 @@
+From 7dfa8984f5a30f313d8675ff6097c8592d636d10 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 12 Dec 2022 12:50:07 -0800
+Subject: [PATCH 05/12] Use 64bit time_t on linux as well
+
+Alias 64bit version of stat functions to original functions
+we are already passing -D_FILE_OFFSET_BITS=64 in linux Makefile
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ diskio-unix.cc | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/diskio-unix.cc b/diskio-unix.cc
+index 7780aeb..0897c56 100644
+--- a/diskio-unix.cc
++++ b/diskio-unix.cc
+@@ -37,8 +37,12 @@
+ 
+ using namespace std;
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(__linux__)
+ #define off64_t off_t
++#define stat64 stat
++#define fstat64 fstat
++#define lstat64 lstat
++#define lseek64 lseek
+ #endif
+ 
+ // Returns the official "real" name for a shortened version of same.
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0006-Allow-partition-dynamically-allocated-by-largest-new.patch
+++ b/packages/sysutils/gptfdisk/patches/0006-Allow-partition-dynamically-allocated-by-largest-new.patch
@@ -1,0 +1,38 @@
+From caf30c022c5f659bb7a5e52272c6aeca94098c70 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Joaqu=C3=ADn=20Shourabi=20Porcel?= <david@djsp.eu>
+Date: Sat, 28 Jan 2023 16:19:16 +0100
+Subject: [PATCH 06/12] Allow partition dynamically allocated by --largest-new
+ to be referenced by other options
+
+The documentation for the option --new explains that:
+
+> [a] partnum value of 0 causes the program to use the first available
+> partition number. Subsequent uses of the -A (--attributes), -c
+> (--change-name), -t (--typecode), and -u (--partition-guid) options
+> may also use 0 to refer to the same partition.
+
+Although the documentation for the option --largest-new does not mention
+such functionality, I expected it, and was puzzled when it didn't work.
+---
+ gptcl.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/gptcl.cc b/gptcl.cc
+index 0d578eb..e8d394a 100644
+--- a/gptcl.cc
++++ b/gptcl.cc
+@@ -331,8 +331,10 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+                   startSector = FindFirstInLargest();
+                   Align(&startSector);
+                   endSector = FindLastInFree(startSector, alignEnd);
+-                  if (largestPartNum <= 0)
++                  if (largestPartNum <= 0) {
+                      largestPartNum = FindFirstFreePart() + 1;
++                     newPartNum = largestPartNum - 1;
++                  }
+                   if (CreatePartition(largestPartNum - 1, startSector, endSector)) {
+                      saveData = 1;
+                   } else {
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0007-Document-recent-merge.patch
+++ b/packages/sysutils/gptfdisk/patches/0007-Document-recent-merge.patch
@@ -1,0 +1,31 @@
+From 3c4a9fbd1d71fbd3aff0c83ec3ac9b2a0d9ba748 Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Sun, 5 Mar 2023 10:57:24 -0500
+Subject: [PATCH 07/12] Document recent merge.
+
+---
+ NEWS | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/NEWS b/NEWS
+index 9ec7e63..f9f7f19 100644
+--- a/NEWS
++++ b/NEWS
+@@ -1,4 +1,4 @@
+-1.0.10 (?/??/2022):
++1.0.10 (?/??/2023):
+ -------------------
+ 
+ - Fixed problem that caused sgdisk to crash with errors about being unable
+@@ -8,6 +8,8 @@
+ 
+ - Updated guid.cc to deal with minor change in libuuid.
+ 
++- Fixed potential NULL derefernce bug in sgdisk.
++
+ 1.0.9 (4/14/2022):
+ ------------------
+ 
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0008-Document-recent-mergest.patch
+++ b/packages/sysutils/gptfdisk/patches/0008-Document-recent-mergest.patch
@@ -1,0 +1,49 @@
+From e7a566bd96573b3f71001d0215dab93dcdd120d9 Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Sun, 5 Mar 2023 11:26:49 -0500
+Subject: [PATCH 08/12] Document recent mergest
+
+---
+ NEWS     | 7 ++++++-
+ sgdisk.8 | 7 +++++--
+ 2 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/NEWS b/NEWS
+index f9f7f19..8d5b365 100644
+--- a/NEWS
++++ b/NEWS
+@@ -8,7 +8,12 @@
+ 
+ - Updated guid.cc to deal with minor change in libuuid.
+ 
+-- Fixed potential NULL derefernce bug in sgdisk.
++- Fixed potential NULL derefernce bug in sgdisk. Thanks to Damian Kurek
++  for this fix.
++
++- The partition number of "0" can now be used to reference newly-created
++  partitions when the --largest-new=0 option to sgdisk is used. Thanks to
++  David Joaquín Shourabi Porcel for this improvement.
+ 
+ 1.0.9 (4/14/2022):
+ ------------------
+diff --git a/sgdisk.8 b/sgdisk.8
+index 4e5a15a..fa53b29 100644
+--- a/sgdisk.8
++++ b/sgdisk.8
+@@ -370,8 +370,11 @@ to use the first available partition number. Subsequent uses of the
+ .B \-N, \-\-largest\-new=num
+ Create a new partition that fills the largest available block of space on
+ the disk. You can use the \fI\-a\fR (\fI\-\-set\-alignment\fR) option to
+-adjust the alignment, if desired. A num value of 0 causes the program to
+-use the first available partition number.
++adjust the alignment, if desired. A num value of 0 causes the program to use
++the first available partition number. Subsequent uses of the \fI\-A\fR
++(\fI\-\-attributes\fR), \fI\-c\fR (\fI\-\-change\-name\fR), \fI\-t\fR
++(\fI\-\-typecode\fR), and \fI\-u\fR (\fI\-\-partition\-guid\fR) options may
++also use \fI0\fR to refer to the same partition.
+ 
+ .TP 
+ .B \-o, \-\-clear
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0009-Do-some-explicit-casts-in-gptcurses.cc-to-eliminate-.patch
+++ b/packages/sysutils/gptfdisk/patches/0009-Do-some-explicit-casts-in-gptcurses.cc-to-eliminate-.patch
@@ -1,0 +1,69 @@
+From 42eea87e89bdbf4c4548e88428513717a601e05d Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Mon, 6 Mar 2023 14:21:35 -0500
+Subject: [PATCH 09/12] Do some explicit casts in gptcurses.cc to eliminate
+ compiler warnings.
+
+---
+ NEWS         |  3 +++
+ gptcurses.cc | 13 +++++++------
+ 2 files changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/NEWS b/NEWS
+index 8d5b365..dc1660e 100644
+--- a/NEWS
++++ b/NEWS
+@@ -15,6 +15,9 @@
+   partitions when the --largest-new=0 option to sgdisk is used. Thanks to
+   David Joaquín Shourabi Porcel for this improvement.
+ 
++- Make explicit casts in gptcurses.cc to eliminate compiler warnings about
++  mis-matched types in printw() statements.
++
+ 1.0.9 (4/14/2022):
+ ------------------
+ 
+diff --git a/gptcurses.cc b/gptcurses.cc
+index 8b0ae91..64cc514 100644
+--- a/gptcurses.cc
++++ b/gptcurses.cc
+@@ -333,13 +333,13 @@ void GPTDataCurses::ShowInfo(int partNum) {
+    printw("Partition GUID code: %s (%s)\n", partitions[partNum].GetType().AsString().c_str(),
+           partitions[partNum].GetTypeName().c_str());
+    printw("Partition unique GUID: %s\n", partitions[partNum].GetUniqueGUID().AsString().c_str());
+-   printw("First sector: %lld (at %s)\n", partitions[partNum].GetFirstLBA(),
++   printw("First sector: %llu (at %s)\n", (long long unsigned int) partitions[partNum].GetFirstLBA(),
+           BytesToIeee(partitions[partNum].GetFirstLBA(), blockSize).c_str());
+-   printw("Last sector: %lld (at %s)\n", partitions[partNum].GetLastLBA(),
++   printw("Last sector: %llu (at %s)\n", (long long unsigned int) partitions[partNum].GetLastLBA(),
+           BytesToIeee(partitions[partNum].GetLastLBA(), blockSize).c_str());
+    size = partitions[partNum].GetLastLBA() - partitions[partNum].GetFirstLBA() + 1;
+-   printw("Partition size: %lld sectors (%s)\n", size, BytesToIeee(size, blockSize).c_str());
+-   printw("Attribute flags: %016llx\n", partitions[partNum].GetAttributes().GetAttributes());
++   printw("Partition size: %llu sectors (%s)\n", (long long unsigned int) size, BytesToIeee(size, blockSize).c_str());
++   printw("Attribute flags: %016llx\n", (long long unsigned int) partitions[partNum].GetAttributes().GetAttributes());
+    #ifdef USE_UTF16
+    partitions[partNum].GetDescription().extract(0, NAME_SIZE , temp, NAME_SIZE );
+    printw("Partition name: '%s'\n", temp);
+@@ -447,7 +447,8 @@ void GPTDataCurses::MakeNewPart(void) {
+       clrtoeol();
+       newFirstLBA = currentSpace->firstLBA;
+       Align(&newFirstLBA);
+-      printw("First sector (%lld-%lld, default = %lld): ", newFirstLBA, currentSpace->lastLBA, newFirstLBA);
++      printw("First sector (%llu-%llu, default = %llu): ", (long long unsigned int) newFirstLBA,
++             (long long unsigned int) currentSpace->lastLBA, (long long unsigned int) newFirstLBA);
+       echo();
+       getnstr(inLine, 79);
+       noecho();
+@@ -461,7 +462,7 @@ void GPTDataCurses::MakeNewPart(void) {
+    while ((newLastLBA > currentSpace->lastLBA) || (newLastLBA < newFirstLBA)) {
+       move(LINES - 3, 0);
+       clrtoeol();
+-      printw("Size in sectors or {KMGTP} (default = %lld): ", size);
++      printw("Size in sectors or {KMGTP} (default = %llu): ", (long long unsigned int) size);
+       echo();
+       getnstr(inLine, 79);
+       noecho();
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0010-Truncate-decimal-inputs-e.g.-9.5G-becomes-9G.patch
+++ b/packages/sysutils/gptfdisk/patches/0010-Truncate-decimal-inputs-e.g.-9.5G-becomes-9G.patch
@@ -1,0 +1,49 @@
+From e1cc654ef71996d836c5d051278130f50f768f84 Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Mon, 6 Mar 2023 17:22:32 -0500
+Subject: [PATCH 10/12] Truncate decimal inputs (e.g., '9.5G' becomes '9G')
+
+---
+ support.cc | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/support.cc b/support.cc
+index 0d3bd6f..3cbabf7 100644
+--- a/support.cc
++++ b/support.cc
+@@ -124,6 +124,8 @@ char GetYN(void) {
+ // inValue works out to something outside the range low-high, returns the
+ // computed value; the calling function is responsible for checking the
+ // validity of this value.
++// If inValue contains a decimal number (e.g., "9.5G"), quietly truncate it
++// (to "9G" in this example).
+ // NOTE: There's a difference in how GCC and VC++ treat oversized values
+ // (say, "999999999999999999999") read via the ">>" operator; GCC turns
+ // them into the maximum value for the type, whereas VC++ turns them into
+@@ -158,6 +160,15 @@ uint64_t IeeeToInt(string inValue, uint64_t sSize, uint64_t low, uint64_t high,
+       badInput = 1;
+    inString >> response >> suffix;
+    suffix = toupper(suffix);
++   foundAt = suffixes.find(suffix);
++   // If suffix is invalid, try to find a valid one. Done because users
++   // sometimes enter decimal numbers; when they do, suffix becomes
++   // '.', and we need to truncate the number and find the real suffix.
++   while (foundAt > (suffixes.length() - 1) && inString.peek() != -1) {
++      inString >> suffix;
++      foundAt = suffixes.find(suffix);
++      suffix = toupper(suffix);
++   }
+ 
+    // If no response, or if response == 0, use default (def)
+    if ((inValue.length() == 0) || (response == 0)) {
+@@ -167,7 +178,6 @@ uint64_t IeeeToInt(string inValue, uint64_t sSize, uint64_t low, uint64_t high,
+    } // if
+ 
+    // Find multiplication and division factors for the suffix
+-   foundAt = suffixes.find(suffix);
+    if (foundAt != string::npos) {
+       bytesPerUnit = UINT64_C(1) << (10 * (foundAt + 1));
+       mult = bytesPerUnit / sSize;
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0011-Document-previous-merge.patch
+++ b/packages/sysutils/gptfdisk/patches/0011-Document-previous-merge.patch
@@ -1,0 +1,44 @@
+From 0e7d63502f6ea68b5c56036c493e72e83b3f145d Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Mon, 6 Mar 2023 17:28:18 -0500
+Subject: [PATCH 11/12] Document previous merge
+
+---
+ NEWS      | 7 +++++++
+ support.h | 2 +-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/NEWS b/NEWS
+index dc1660e..5c6dfa1 100644
+--- a/NEWS
++++ b/NEWS
+@@ -18,6 +18,13 @@
+ - Make explicit casts in gptcurses.cc to eliminate compiler warnings about
+   mis-matched types in printw() statements.
+ 
++- In previous versions, rEFInd accepted only integer values for partition
++  start points, end points, and sizes, and it interpreted decimal values
++  incorrectly. That is, if you typed "+9.5G" as the partition end point,
++  you'd end up with something just 9 sectors in size. This version now
++  truncates decimal numbers to their integral values, so you'd get a 9 GiB
++  partition instead.
++
+ 1.0.9 (4/14/2022):
+ ------------------
+ 
+diff --git a/support.h b/support.h
+index f91f1bc..4a9f414 100644
+--- a/support.h
++++ b/support.h
+@@ -8,7 +8,7 @@
+ #include <stdlib.h>
+ #include <string>
+ 
+-#define GPTFDISK_VERSION "1.0.9.1"
++#define GPTFDISK_VERSION "1.0.9.2"
+ 
+ #if defined (__FreeBSD__) || defined (__FreeBSD_kernel__) || defined (__APPLE__)
+ // Darwin (Mac OS) & FreeBSD: disk IOCTLs are different, and there is no lseek64
+-- 
+2.31.1
+

--- a/packages/sysutils/gptfdisk/patches/0012-Minor-code-cleanup-based-on-valgrind-analysis.patch
+++ b/packages/sysutils/gptfdisk/patches/0012-Minor-code-cleanup-based-on-valgrind-analysis.patch
@@ -1,0 +1,38 @@
+From cb4bf320748f701a0ed835d4a410f2960f1ce0bd Mon Sep 17 00:00:00 2001
+From: Rod Smith <rodsmith@rodsbooks.com>
+Date: Fri, 10 Mar 2023 13:28:00 -0500
+Subject: [PATCH 12/12] Minor code cleanup based on valgrind analysis
+
+---
+ NEWS   | 2 ++
+ gpt.cc | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/NEWS b/NEWS
+index 5c6dfa1..29d99e3 100644
+--- a/NEWS
++++ b/NEWS
+@@ -18,6 +18,8 @@
+ - Make explicit casts in gptcurses.cc to eliminate compiler warnings about
+   mis-matched types in printw() statements.
+ 
++- Minor code cleanup based on valgrind analysis.
++
+ - In previous versions, rEFInd accepted only integer values for partition
+   start points, end points, and sizes, and it interpreted decimal values
+   incorrectly. That is, if you typed "+9.5G" as the partition end point,
+diff --git a/gpt.cc b/gpt.cc
+index 76cd9ad..24d6918 100644
+--- a/gpt.cc
++++ b/gpt.cc
+@@ -80,6 +80,7 @@ GPTData::GPTData(void) {
+    beQuiet = 0;
+    whichWasUsed = use_new;
+    mainHeader.numParts = 0;
++   mainHeader.firstUsableLBA = 0;
+    mainHeader.lastUsableLBA = 0;
+    numParts = 0;
+    SetGPTSize(NUM_GPT_ENTRIES);
+-- 
+2.31.1
+


### PR DESCRIPTION
Since update to 1.09 `sgdisk -e /dev/<device>` is failing in fs_resize.

The issue was reported in [forum](https://forum.libreelec.tv/thread/26882-libreelec-11-0-0-generic-for-virtual-machines-cannot-be-updated/).

After add adding logging the error was visible. 

There is no gptfdisk 1.09.2 source available on  Sourceforge. To avoid issues with downloading from git the upstream patches are added.

To ease research on future errors the logging code is included in this PR, it only creates a short log on success:
```
2023-03-26T11:36:57+0000
/dev/sda2 /storage ext4 rw,noatime 0 0
DISK: /dev/sda  PART: /dev/sda2
*** sgdisk -e /dev/sda >>/flash/fs-resize.log 2>&1
Warning: The kernel is still using the old partition table.
The new table will be used at the next reboot or after you
run partprobe(8) or kpartx(8)
The operation has completed successfully.
*** parted -s -m /dev/sda resizepart 2 100% >>/flash/fs-resize.log 2>&1
*** e2fsck -f -p /dev/sda2 >>/flash/fs-resize.log 2>&1
STORAGE: 11/8192 files (0.0% non-contiguous), 6938/32768 blocks
*** resize2fs /dev/sda2 >>/flash/fs-resize.log 2>&1
resize2fs 1.46.6 (1-Feb-2023)
Resizing the filesystem on /dev/sda2 to 3665900 (1k) blocks.
The filesystem on /dev/sda2 is now 3665900 (1k) blocks long.
```

Adding support for NVME devices (see installer) and improve error messages.

