### PR TITLE
kodi: update to latest master

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.2sf"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="247ad2d9e1df00304882b40d80bc8fd70a4efd2bf2613163c24177d36649247c"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.2sf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.asap"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="9f54285866766b80d0d0c5210561678579d396591ab16cf70c83c4968bfbc8ba"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.asap"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.dumb"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="d2ef04e80645f0bd1c9d31c9633d2a27d1757198fbcd2d43d00c84889e6ae585"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.dumb"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.gme"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="5aaec959e92f4af2684aa0439576d7f576f28a0a43f50439a6f38d0738792bdc"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gme"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.gsf"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="b09dcb379bdc536117a956b10b37cf50c8afaa65337993c44a6847d382d7e2a5"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.modplug/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.modplug/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.modplug"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="619ba20ea19dd9aea15e7d30aa12a146b412c7fcd9e709528f6758e82a3d85e7"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.modplug"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.ncsf"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="31b25846a9b8213306456eb6f8ab8fdaeede5cad35627e77aff2c422f370b211"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.ncsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.nosefart"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="2f7a92bfaddcd5aa63e2ea7348ae9eeefd07dee2aba46840ce5376677e2abc19"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.nosefart"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.openmpt"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="388fb4c9fcb5bd9edc978e3db5f54fa531c7f397393f3e421757e4e0de2d9c54"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.openmpt"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.organya"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="df5db2c94161c7c578d672a8cc36bdbde6c345142c9bb5212759ad0dc30fd59d"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.organya"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.qsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.qsf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.qsf"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="3116bb31b3fe53b85675ba664a7a8d5885e157940a4bcf57b96050844b11a377"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.qsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="audiodecoder.sacd"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="6d54f6cf81e13aadcec1b43689551feba6e9426453a758d955e96348ba996277"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.sacd"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.sidplay"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="ab1f89237c91bc7157557f42dadcff50a7191eb7285ee668543defce9f1efcf2"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.sidplay"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.snesapu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.snesapu/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.snesapu"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="f216a7d25c864986618118236c575687ab62d129a16cb1f73c15860948d9ac92"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.snesapu"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ssf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ssf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.ssf"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="c2d5fbba35d2d73ed5891567d507f77bc64fa447dfcb4474f5d58594e9a07b2d"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.ssf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.stsound/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.stsound/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.stsound"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="a8138fb075a480c59d7041a9408eca6e52dc88f188daed519cd9e684b430f333"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.stsound"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.timidity"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="ef1b384090df3c2c78d00ed33de1d989ce802702b0a9aa13575946409a5cd0f1"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.timidity"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.upse"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="d9f75e5cbab3ba5fc391cb40e0585bf22fad0eebfaf002d1d58bc896b6f2a5d6"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.upse"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.usf"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="3ce9ef8823c773d894fd0018455ea5000e9b5a64f3cd8d66ddb4cf8f6c9ea836"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.usf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.vgmstream"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="72367d7196f8049ef1fae426d32d3de1eac56bd4cb5a8fc38a6ba0c3da1b23d8"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.vgmstream"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.wsr"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="e8f8e06b61fbf612d59d689c38a6acade485aabae2382f3fbbedb0ce0c00048d"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.wsr"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audioencoder.flac"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="71daf8c35bbf644591600fef93412cd068a6bf6173d2258dc243ee04c8e5b091"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.flac"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audioencoder.lame"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="90f36ee0b4972669ed2876eae2502e58d86287aacdbf4bb25180aca01385e1c1"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.lame"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audioencoder.vorbis"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="359e972ddcc498727620ff224a82f970fa2ae22b71ea6ab30b96898dffe6f1f9"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.vorbis"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.wav/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.wav/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audioencoder.wav"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="1baf69cca688ebd389705ea2bef2c5285ba75dcfd0d0b534b6ab1e61c0020979"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.wav"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.heif"
 PKG_VERSION="20.1.0-Nexus"
 PKG_SHA256="17f50aada11528c02db2ff3871a355c89709ab7e2a5e6b5e33957b790cf207ff"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.mpo"
 PKG_VERSION="20.1.0-Nexus"
 PKG_SHA256="a6f38f95e5e844f75365ae083ca0a78c012bb4dc670770b3dd5d99160a64187f"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.mpo"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.raw"
 PKG_VERSION="20.1.0-Nexus"
 PKG_SHA256="6235c0be431bbb814b3e464753af9ad17febf6001f77cbf030e6c6e1cdc41a04"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.raw"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="inputstream.adaptive"
 PKG_VERSION="21.0.3-Omega"
 PKG_SHA256="18980cf2dfaa8308358c037fd8cc0cd14243964604bad7713c3bc718e78caa1e"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/inputstream.adaptive"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="inputstream.ffmpegdirect"
 PKG_VERSION="21.0.0-Omega"
 PKG_SHA256="cb20b0951ab95815c75c48daded322e9aef74c5937de386878a17f9589b5933e"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"
 PKG_SITE="https://github.com/xbmc/inputstream.ffmpegdirect"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.rtmp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.rtmp/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="inputstream.rtmp"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="6a6129dca822e1447c0945ddf9cc6dbff1203dab313395d27efb4669a0ef3370"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/inputstream.rtmp"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="peripheral.joystick"
 PKG_VERSION="21.1.1-Omega"
 PKG_SHA256="ab21290d406685bdc2b51d2b5fb42948ec8b49130b9ad5633a1ad57efacb8d85"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/peripheral.joystick"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="peripheral.xarcade"
 PKG_VERSION="21.0.0-Omega"
 PKG_SHA256="56f5e976c53f6911ce4179126807da82d8fec1ead092c2add1d97e48e3468d8a"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/peripheral.xarcade"

--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.argustv"
 PKG_VERSION="20.5.0-Nexus"
 PKG_SHA256="c4b18a0abf4ba0a797509d79c4291c4e69589a6482c6ec85f5d9bdae63ea3f35"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.argustv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.demo"
 PKG_VERSION="20.5.0-Nexus"
 PKG_SHA256="8f4d8f06e7dbeefdf6148abb06347c4d92b9edd4a818c7efd1e204a65a9556d2"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.demo"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.dvblink"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="71a9fa64bdf7d784afc28f8b686fcdc00d9fea536c2aad1464e76e3b7648ed41"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.dvblink"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.dvbviewer"
 PKG_VERSION="20.4.0-Nexus"
 PKG_SHA256="dc79db0486c7ef75b4b23c4dfe94115cb12e1903c3700ef4eef04fc517fcd039"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.dvbviewer"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.filmon"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="dfd2a7b64d2b647ba3f7bfba05676a593c3284e2298becfed68b82e441a69b33"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.filmon"

--- a/packages/mediacenter/kodi-binary-addons/pvr.freebox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.freebox/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.freebox"
 PKG_VERSION="21.0.0-Omega"
 PKG_SHA256="d309e3d073d7dbfc387ae8498f4d0b974785d4d5621e79bd83058c8e73de67f2"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/aassif/pvr.freebox"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.hdhomerun"
 PKG_VERSION="20.4.0-Nexus"
 PKG_SHA256="3872265e00fc748ba327aaa91beece747936f55d16356051cdd04b0b70a353c0"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hdhomerun"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.hts"
 PKG_VERSION="21.0.1-Omega"
 PKG_SHA256="0e65dd3ae19363a7e70fbe03b9c3ae7e8d6c419774205e6e343606e870cc0f44"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hts"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.iptvsimple"
 PKG_VERSION="21.2.1-Omega"
 PKG_SHA256="62291307c0deaa82977a2c407831bb996ded3fd0574423b628d164d89c15bf9e"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.iptvsimple"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.mediaportal.tvserver"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="a61efdadb56c65e081f8b2e99f2d5b32b3c932ca1954243548710be57c8b70b8"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.mediaportal.tvserver"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.mythtv"
 PKG_VERSION="20.3.2-Nexus"
 PKG_SHA256="b1ad428bec882d3e852240cbef2378803635b530545a08421ff3baf0611a29e7"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/janbar/pvr.mythtv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.nextpvr"
 PKG_VERSION="20.4.0-Nexus"
 PKG_SHA256="9b9ae55b126ee0ca42a94d2a447167c0d61be36de336a4b236c0879b9b0832e3"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.nextpvr"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.njoy"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="0e8dc8ddce7830878c816da0836bdf5558c0dd388c48019012735a518eeefb04"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.njoy"

--- a/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.octonet"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="cc83ada3b3d1dbf3d42fa41f2b221c640cdc9fd505a1c76e7b479f99fe1ec8c5"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/DigitalDevices/pvr.octonet"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.pctv"
 PKG_VERSION="20.4.0-Nexus"
 PKG_SHA256="c99d3ef085c4900e0c03e5e37047dc136efced78ed245d07bc286468a31e8a65"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.pctv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.plutotv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.plutotv/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.plutotv"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="d38a6bf4debc442849d01faedadcccb1b07debe850cd3c9a5789508233d22256"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.plutotv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.sledovanitv.cz"
 PKG_VERSION="21.0.0-Omega"
 PKG_SHA256="bfebc639ac76d94068a0a1796fa77e220918e3a87203b8f2f96aef1f3ab0fdc4"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/palinek/pvr.sledovanitv.cz"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.stalker"
 PKG_VERSION="20.3.1-Nexus"
 PKG_SHA256="8fdd4ab4cf28d7255550b4c351a397b7ce8eb1aa1f12e93bce7d61a951fbd6f3"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.stalker"

--- a/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.teleboy"
 PKG_VERSION="20.3.4-Nexus"
 PKG_SHA256="199730d6023a39a9227b29b3ac100c06fc40fbb6c0adf65c3a35ea6449ffc5ba"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rbuehlma/pvr.teleboy"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.vbox"
 PKG_VERSION="21.1.2-Omega"
 PKG_SHA256="6909016c3d89b5eddae5098b033e0cce1ea3140e05b4175e1c50611add7ab408"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vbox"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.vdr.vnsi"
 PKG_VERSION="21.0.1-Omega"
 PKG_SHA256="ff74ad9023a4f10ad4be77b37f94786478ccbaa0ad719618448d750074797165"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vdr.vnsi"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.vuplus"
 PKG_VERSION="21.1.1-Omega"
 PKG_SHA256="f9bd295fda0c21f60989440dfa74ebaf386f5264bf7a045f6c7cc9fd012e7907"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vuplus"

--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.waipu"
 PKG_VERSION="21.1.0-Omega"
 PKG_SHA256="01a34737aa8a87a32f15bb9debfef92020c95c61202b9a946312caa06a550bd3"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/flubshi/pvr.waipu"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.wmc"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="f045d871789ef3d36e1a7c7361ea35be4e14a395e75446519e937be70d2433b4"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.wmc"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.zattoo"
 PKG_VERSION="20.3.6-Nexus"
 PKG_SHA256="82e4aa32e794c35c3b718c55fdbc27ed387c59b45a11e25fc4b5d066526a463d"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rbuehlma/pvr.zattoo"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.asteroids"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="492d826efa7a252ce62a1bebf075fe9b0c0cf452929f4cd6f228003f6e445b82"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.asteroids"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="screensaver.shadertoy"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="91500d2c4eb97390d77fbaf5700ee472c41afa30cb76c6ecbe7e2683a14795fc"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.shadertoy"

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="vfs.libarchive"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="06be9bfcda3e676e0757ea9602351d67f2bf0aa9aa9e408b14d947772a615e4f"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/vfs.libarchive"

--- a/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="vfs.rar"
 PKG_VERSION="20.1.0-Nexus"
 PKG_SHA256="50870b24a3663f8d8d88802b327a8fd2fec441a9fed952baf71faba6854a8e1b"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/vfs.rar"

--- a/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="vfs.sftp"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="66f139d3d06c06d03ceccdcee12b79d3886bd0ea7aec662341736f1c9bdd63e2"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/xbmc/vfs.sftp"

--- a/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="visualization.fishbmc"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="168788d7cd292edf9c13c0e0e0148f19b2ecd35edd8f65f24240dff99f01677a"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.fishbmc"

--- a/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="visualization.goom"
 PKG_VERSION="20.1.1-Nexus"
 PKG_SHA256="75102a8c3f066a889493b77fbe26070be78c6dff8e7d44ebda89295ddb2da3b0"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.goom"

--- a/packages/mediacenter/kodi-binary-addons/visualization.matrix/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.matrix/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="visualization.matrix"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="f0b76edf45df7161d8525fa2ba623dee64ca66d515342e942100dc46c8220553"
-PKG_REV="4"
+PKG_REV="5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.matrix"
 PKG_URL="https://github.com/xbmc/visualization.matrix/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.shadertoy"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="2f97a34f74ee3e3e1d9fe8cfd37796564f8f88eb4c07d60b27ff635d64a5a724"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.shadertoy"

--- a/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.spectrum"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="1c405ea9b6f43ba5f24df13ebce12cb428369279336deb97790917aa675c809f"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.spectrum"

--- a/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="visualization.starburst"
 PKG_VERSION="20.2.0-Nexus"
 PKG_SHA256="0d63b38ba8d5b3bac542546b1ecfb7d722b79652da485d75b22086e26ef4f825"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.starburst"

--- a/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.waveform"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="865e72a5f2ed8fd53469518280cbe26f9516467d091009fe5e012ea0d85d5edd"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.waveform"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="497636acc7dabb03b88872d8ef5607140a342608"
-PKG_SHA256="f1cdbcefce6937c4ba0ea5f647c14bb7aba94758e6766645d2eab4fadcee6d42"
+PKG_VERSION="847a347839a895419d191237e5e1cfd3ed19720c"
+PKG_SHA256="047032c39244eea0759e067b3a836a3e8911dc60fa41c41c5c54d43fc4db1740"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Runtime tested on RPi4.

I've also rev-bumped all kodi binary addons, current version of inputstream.adaptive in our repo was flagged incompatible, rebuilding it helped - probably other kodi addons may need the rebuild, too