### PR TITLE
ffmpeg: update to 6.0

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -14,9 +14,9 @@ PKG_PATCH_DIRS="libreelec"
 
 case "${PROJECT}" in
   Amlogic)
-    PKG_VERSION="f9638b6331277e53ecd9276db5fe6dcd91d44c57"
-    PKG_FFMPEG_BRANCH="dev/4.4/rpi_import_1"
-    PKG_SHA256="3b42cbffd15d95d59e402475fcdb1aaac9ae6a8404a521b95d1fe79c6b2baad4"
+    PKG_VERSION="6859fc2a8791c0fcc25851b77fed15a691ceb332"
+    PKG_FFMPEG_BRANCH="dev/6.0/rpi_import_1"
+    PKG_SHA256="d9ba353b5ab95489bb999cec958bed154534ccb46c154fb8b9d6848188f7ef8c"
     PKG_URL="https://github.com/jc-kynesim/rpi-ffmpeg/archive/${PKG_VERSION}.tar.gz"
     ;;
   RPi)

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ffmpeg"
-PKG_VERSION="5.1.2"
-PKG_SHA256="619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc"
+PKG_VERSION="6.0"
+PKG_SHA256="57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082"
 PKG_LICENSE="GPL-3.0-only"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="http://ffmpeg.org/releases/ffmpeg-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/ffmpeg/patches/libreelec/ffmpeg-001-libreelec.patch
+++ b/packages/multimedia/ffmpeg/patches/libreelec/ffmpeg-001-libreelec.patch
@@ -1,4 +1,4 @@
-From 3c53cf80b0de8af387694a464bdce294988d0fa5 Mon Sep 17 00:00:00 2001
+From 2836d9b400c063b4332cdf6bb6f1a3719822eaed Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Wed, 10 Apr 2019 13:39:21 -0700
 Subject: [PATCH 1/2] libavcodec/libdav1d: add libdav1d_get_format method to
@@ -18,10 +18,10 @@ decoding is properly activated.
  1 file changed, 11 insertions(+)
 
 diff --git a/libavcodec/libdav1d.c b/libavcodec/libdav1d.c
-index 0a46cf2264..1f4e708bcf 100644
+index 2488a709c7..48c8658a22 100644
 --- a/libavcodec/libdav1d.c
 +++ b/libavcodec/libdav1d.c
-@@ -66,6 +66,16 @@ static const enum AVPixelFormat pix_fmt_rgb[3] = {
+@@ -64,6 +64,16 @@ static const enum AVPixelFormat pix_fmt_rgb[3] = {
      AV_PIX_FMT_GBRP, AV_PIX_FMT_GBRP10, AV_PIX_FMT_GBRP12,
  };
  
@@ -38,7 +38,7 @@ index 0a46cf2264..1f4e708bcf 100644
  static void libdav1d_log_callback(void *opaque, const char *fmt, va_list vl)
  {
      AVCodecContext *c = opaque;
-@@ -390,6 +400,7 @@ static int libdav1d_receive_frame(AVCodecContext *c, AVFrame *frame)
+@@ -424,6 +434,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
      if (res < 0)
          goto fail;
  
@@ -47,7 +47,7 @@ index 0a46cf2264..1f4e708bcf 100644
      frame->height = p->p.h;
      if (c->width != p->p.w || c->height != p->p.h) {
 
-From 3af25a2cae2ad3152e2969eefd9f13c9bb183969 Mon Sep 17 00:00:00 2001
+From 19913e020c8760e8a760439a07bcb50273643324 Mon Sep 17 00:00:00 2001
 From: chewitt <github@chrishewitt.net>
 Date: Sun, 11 Aug 2019 07:08:19 +0000
 Subject: [PATCH 2/2] add long-term yuv2rgb logging patch
@@ -57,10 +57,10 @@ Subject: [PATCH 2/2] add long-term yuv2rgb logging patch
  1 file changed, 4 deletions(-)
 
 diff --git a/libswscale/yuv2rgb.c b/libswscale/yuv2rgb.c
-index 6ee483d12a..c22161741b 100644
+index 9c3f5e23c6..2a10527365 100644
 --- a/libswscale/yuv2rgb.c
 +++ b/libswscale/yuv2rgb.c
-@@ -688,10 +688,6 @@ SwsFunc ff_yuv2rgb_get_func_ptr(SwsContext *c)
+@@ -690,10 +690,6 @@ SwsFunc ff_yuv2rgb_get_func_ptr(SwsContext *c)
      if (t)
          return t;
  

--- a/packages/multimedia/ffmpeg/patches/rpi/ffmpeg-001-rpi.patch
+++ b/packages/multimedia/ffmpeg/patches/rpi/ffmpeg-001-rpi.patch
@@ -1,7 +1,7 @@
-From 2443e873ef3a82087fad1d392a26bf1d8a1cc9d5 Mon Sep 17 00:00:00 2001
+From 504df93cfe5416b394755e79b7b81ee0119cf09c Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 26 Apr 2021 12:34:50 +0100
-Subject: [PATCH 001/120] Add pi configs and scripts
+Subject: [PATCH 001/121] Add pi configs and scripts
 
 ---
  pi-util/BUILD.txt                  |  59 ++++++++
@@ -1679,10 +1679,10 @@ index 0000000000..5935a11ca5
 +    do_logparse(args.logfile)
 +
 
-From bde822d2612b59911b0eb44409c8815aa4ff1fef Mon Sep 17 00:00:00 2001
+From f3eaadb27a5bc6db07d33ce0814d796e8cee623e Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 11:27:39 +0100
-Subject: [PATCH 002/120] Add sand pix fmts & conversion fns
+Subject: [PATCH 002/121] Add sand pix fmts & conversion fns
 
 ---
  configure                     |   3 +
@@ -1703,18 +1703,18 @@ Subject: [PATCH 002/120] Add sand pix fmts & conversion fns
  create mode 100644 libavutil/rpi_sand_fns.h
 
 diff --git a/configure b/configure
-index ba5793b2ff..a0213c039a 100755
+index b6616f00b6..27112ced58 100755
 --- a/configure
 +++ b/configure
-@@ -343,6 +343,7 @@ External library support:
-   --enable-libmfx          enable Intel MediaSDK (AKA Quick Sync Video) code via libmfx [no]
+@@ -344,6 +344,7 @@ External library support:
+   --enable-libvpl          enable Intel oneVPL code via libvpl if libmfx is not used [no]
    --enable-libnpp          enable Nvidia Performance Primitives-based code [no]
    --enable-mmal            enable Broadcom Multi-Media Abstraction Layer (Raspberry Pi) via MMAL [no]
 +  --enable-sand            enable sand video formats [rpi]
    --disable-nvdec          disable Nvidia video decoding acceleration (via hwaccel) [autodetect]
    --disable-nvenc          disable Nvidia video encoding code [autodetect]
    --enable-omx             enable OpenMAX IL code [no]
-@@ -1941,6 +1942,7 @@ FEATURE_LIST="
+@@ -1930,6 +1931,7 @@ FEATURE_LIST="
      omx_rpi
      runtime_cpudetect
      safe_bitstream_reader
@@ -1722,7 +1722,7 @@ index ba5793b2ff..a0213c039a 100755
      shared
      small
      static
-@@ -2501,6 +2503,7 @@ CONFIG_EXTRA="
+@@ -2495,6 +2497,7 @@ CONFIG_EXTRA="
      rtpdec
      rtpenc_chain
      rv34dsp
@@ -1731,10 +1731,10 @@ index ba5793b2ff..a0213c039a 100755
      sinewin
      snappy
 diff --git a/libavutil/Makefile b/libavutil/Makefile
-index 9435a0bfb0..a2dc31c198 100644
+index dc9012f9a8..e33f5db099 100644
 --- a/libavutil/Makefile
 +++ b/libavutil/Makefile
-@@ -72,6 +72,7 @@ HEADERS = adler32.h                                                     \
+@@ -73,6 +73,7 @@ HEADERS = adler32.h                                                     \
            rational.h                                                    \
            replaygain.h                                                  \
            ripemd.h                                                      \
@@ -1742,7 +1742,7 @@ index 9435a0bfb0..a2dc31c198 100644
            samplefmt.h                                                   \
            sha.h                                                         \
            sha512.h                                                      \
-@@ -191,6 +192,7 @@ OBJS-$(CONFIG_MACOS_KPERF)              += macos_kperf.o
+@@ -192,6 +193,7 @@ OBJS-$(CONFIG_MACOS_KPERF)              += macos_kperf.o
  OBJS-$(CONFIG_MEDIACODEC)               += hwcontext_mediacodec.o
  OBJS-$(CONFIG_OPENCL)                   += hwcontext_opencl.o
  OBJS-$(CONFIG_QSV)                      += hwcontext_qsv.o
@@ -1750,7 +1750,7 @@ index 9435a0bfb0..a2dc31c198 100644
  OBJS-$(CONFIG_VAAPI)                    += hwcontext_vaapi.o
  OBJS-$(CONFIG_VIDEOTOOLBOX)             += hwcontext_videotoolbox.o
  OBJS-$(CONFIG_VDPAU)                    += hwcontext_vdpau.o
-@@ -211,6 +213,7 @@ SKIPHEADERS-$(CONFIG_D3D11VA)          += hwcontext_d3d11va.h
+@@ -212,6 +214,7 @@ SKIPHEADERS-$(CONFIG_D3D11VA)          += hwcontext_d3d11va.h
  SKIPHEADERS-$(CONFIG_DXVA2)            += hwcontext_dxva2.h
  SKIPHEADERS-$(CONFIG_QSV)              += hwcontext_qsv.h
  SKIPHEADERS-$(CONFIG_OPENCL)           += hwcontext_opencl.h
@@ -2647,12 +2647,12 @@ index 0000000000..447f367bea
 +#endif // AVUTIL_ARM_SAND_NEON_H
 +
 diff --git a/libavutil/pixdesc.c b/libavutil/pixdesc.c
-index 6e57a82cb6..3b7b136ce3 100644
+index 62a2ae08d9..cb73521ea7 100644
 --- a/libavutil/pixdesc.c
 +++ b/libavutil/pixdesc.c
-@@ -2491,6 +2491,50 @@ static const AVPixFmtDescriptor av_pix_fmt_descriptors[AV_PIX_FMT_NB] = {
-         },
-         .flags = AV_PIX_FMT_FLAG_PLANAR,
+@@ -2717,6 +2717,50 @@ static const AVPixFmtDescriptor av_pix_fmt_descriptors[AV_PIX_FMT_NB] = {
+         .flags = AV_PIX_FMT_FLAG_RGB | AV_PIX_FMT_FLAG_FLOAT |
+                  AV_PIX_FMT_FLAG_ALPHA,
      },
 +    [AV_PIX_FMT_SAND128] = {
 +        .name = "sand128",
@@ -2702,10 +2702,10 @@ index 6e57a82cb6..3b7b136ce3 100644
  
  static const char * const color_range_names[] = {
 diff --git a/libavutil/pixfmt.h b/libavutil/pixfmt.h
-index 2d3927cc3f..b0dae0fe83 100644
+index 37c2c79e01..22f70007c3 100644
 --- a/libavutil/pixfmt.h
 +++ b/libavutil/pixfmt.h
-@@ -349,6 +349,12 @@ enum AVPixelFormat {
+@@ -377,6 +377,12 @@ enum AVPixelFormat {
  
      AV_PIX_FMT_Y210BE,    ///< packed YUV 4:2:2 like YUYV422, 20bpp, data in the high bits, big-endian
      AV_PIX_FMT_Y210LE,    ///< packed YUV 4:2:2 like YUYV422, 20bpp, data in the high bits, little-endian
@@ -3500,33 +3500,31 @@ index 0000000000..634b55e800
 +#endif
 +
 
-From 3d994f09aa704c80cd2e0496c00f5767f88244cc Mon Sep 17 00:00:00 2001
+From 89b8d6ac2a886749d4594656083753e682de05a7 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 11:36:47 +0100
-Subject: [PATCH 003/120] Add aarch64 asm sand conv functions
+Subject: [PATCH 003/121] Add aarch64 asm sand conv functions
 
 Many thanks to eiler.mike@gmail.com (Michael Eiler) for these
 optimizations
 ---
- libavutil/aarch64/Makefile        |   4 +-
+ libavutil/aarch64/Makefile        |   2 +
  libavutil/aarch64/rpi_sand_neon.S | 676 ++++++++++++++++++++++++++++++
  libavutil/aarch64/rpi_sand_neon.h |  55 +++
  libavutil/rpi_sand_fn_pw.h        |   4 +-
  libavutil/rpi_sand_fns.c          |   3 +
- 5 files changed, 739 insertions(+), 3 deletions(-)
+ 5 files changed, 738 insertions(+), 2 deletions(-)
  create mode 100644 libavutil/aarch64/rpi_sand_neon.S
  create mode 100644 libavutil/aarch64/rpi_sand_neon.h
 
 diff --git a/libavutil/aarch64/Makefile b/libavutil/aarch64/Makefile
-index 5613813ba8..ab8bcfcf34 100644
+index eba0151337..1b44beab39 100644
 --- a/libavutil/aarch64/Makefile
 +++ b/libavutil/aarch64/Makefile
-@@ -1,4 +1,6 @@
- OBJS += aarch64/cpu.o                                                 \
-         aarch64/float_dsp_init.o                                      \
+@@ -4,3 +4,5 @@ OBJS += aarch64/cpu.o                                                 \
  
--NEON-OBJS += aarch64/float_dsp_neon.o
-+NEON-OBJS += aarch64/float_dsp_neon.o                                 \
+ NEON-OBJS += aarch64/float_dsp_neon.o                                 \
+              aarch64/tx_float_neon.o                                  \
 +             aarch64/rpi_sand_neon.o                                  \
 +
 diff --git a/libavutil/aarch64/rpi_sand_neon.S b/libavutil/aarch64/rpi_sand_neon.S
@@ -4309,10 +4307,10 @@ index ed0261b02f..1f543e9357 100644
  #define HAVE_SAND_ASM 0
  #endif
 
-From 0d53002c00ccc9c51321f423a62cb04e523a908f Mon Sep 17 00:00:00 2001
+From 247025a42ae09d6c9c5d4128a5e4b288b7b3047c Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 11:56:02 +0100
-Subject: [PATCH 004/120] Add raw encoding for sand
+Subject: [PATCH 004/121] Add raw encoding for sand
 
 ---
  libavcodec/raw.c    |  6 +++
@@ -4320,10 +4318,10 @@ Subject: [PATCH 004/120] Add raw encoding for sand
  2 files changed, 96 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/raw.c b/libavcodec/raw.c
-index a371bb36c4..5e965dfa08 100644
+index 1e5b48d1e0..1e689f9ee0 100644
 --- a/libavcodec/raw.c
 +++ b/libavcodec/raw.c
-@@ -294,6 +294,12 @@ static const PixelFormatTag raw_pix_fmt_tags[] = {
+@@ -295,6 +295,12 @@ static const PixelFormatTag raw_pix_fmt_tags[] = {
      { AV_PIX_FMT_RGB565LE,MKTAG( 3 ,  0 ,  0 ,  0 ) }, /* flipped RGB565LE */
      { AV_PIX_FMT_YUV444P, MKTAG('Y', 'V', '2', '4') }, /* YUV444P, swapped UV */
  
@@ -4337,7 +4335,7 @@ index a371bb36c4..5e965dfa08 100644
  };
  
 diff --git a/libavcodec/rawenc.c b/libavcodec/rawenc.c
-index 34d7a1bef4..0cd8eaffee 100644
+index 8c577006d9..594a77c42a 100644
 --- a/libavcodec/rawenc.c
 +++ b/libavcodec/rawenc.c
 @@ -24,6 +24,7 @@
@@ -4458,10 +4456,10 @@ index 34d7a1bef4..0cd8eaffee 100644
          return ret;
  
 
-From dd7e385da41ab751d41a44d6395b4cc841b2839a Mon Sep 17 00:00:00 2001
+From ac6961f424b56563dc793b6bc002a8c04cb1bc36 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 12:02:09 +0100
-Subject: [PATCH 005/120] Deal with the lack of trivial sand cropping
+Subject: [PATCH 005/121] Deal with the lack of trivial sand cropping
 
 ---
  fftools/ffmpeg.c        |  4 ++--
@@ -4471,10 +4469,10 @@ Subject: [PATCH 005/120] Deal with the lack of trivial sand cropping
  4 files changed, 25 insertions(+), 4 deletions(-)
 
 diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
-index e7384f052a..c68f96006b 100644
+index d721a5e721..15e084f0b2 100644
 --- a/fftools/ffmpeg.c
 +++ b/fftools/ffmpeg.c
-@@ -1953,8 +1953,8 @@ static int ifilter_send_frame(InputFilter *ifilter, AVFrame *frame, int keep_ref
+@@ -1993,8 +1993,8 @@ static int ifilter_send_frame(InputFilter *ifilter, AVFrame *frame, int keep_ref
                         av_channel_layout_compare(&ifilter->ch_layout, &frame->ch_layout);
          break;
      case AVMEDIA_TYPE_VIDEO:
@@ -4486,10 +4484,10 @@ index e7384f052a..c68f96006b 100644
      }
  
 diff --git a/fftools/ffmpeg_filter.c b/fftools/ffmpeg_filter.c
-index 0845c631a5..a052635927 100644
+index 1f5bbf6c4d..f888307762 100644
 --- a/fftools/ffmpeg_filter.c
 +++ b/fftools/ffmpeg_filter.c
-@@ -1175,8 +1175,8 @@ int ifilter_parameters_from_frame(InputFilter *ifilter, const AVFrame *frame)
+@@ -1281,8 +1281,8 @@ int ifilter_parameters_from_frame(InputFilter *ifilter, const AVFrame *frame)
  
      ifilter->format = frame->format;
  
@@ -4501,7 +4499,7 @@ index 0845c631a5..a052635927 100644
  
      ifilter->sample_rate         = frame->sample_rate;
 diff --git a/libavutil/frame.c b/libavutil/frame.c
-index 4c16488c66..6ff74a919b 100644
+index 9545477acc..48621e4098 100644
 --- a/libavutil/frame.c
 +++ b/libavutil/frame.c
 @@ -16,6 +16,8 @@
@@ -4523,7 +4521,7 @@ index 4c16488c66..6ff74a919b 100644
  
  #if FF_API_OLD_CHANNEL_LAYOUT
  #define CHECK_CHANNELS_CONSISTENCY(frame) \
-@@ -875,6 +880,12 @@ int av_frame_apply_cropping(AVFrame *frame, int flags)
+@@ -874,6 +879,12 @@ int av_frame_apply_cropping(AVFrame *frame, int flags)
          (frame->crop_top + frame->crop_bottom) >= frame->height)
          return AVERROR(ERANGE);
  
@@ -4537,10 +4535,10 @@ index 4c16488c66..6ff74a919b 100644
      if (!desc)
          return AVERROR_BUG;
 diff --git a/libavutil/frame.h b/libavutil/frame.h
-index 33fac2054c..a112e296f7 100644
+index 2580269549..3a9d323325 100644
 --- a/libavutil/frame.h
 +++ b/libavutil/frame.h
-@@ -940,6 +940,16 @@ int av_frame_apply_cropping(AVFrame *frame, int flags);
+@@ -957,6 +957,16 @@ int av_frame_apply_cropping(AVFrame *frame, int flags);
   */
  const char *av_frame_side_data_name(enum AVFrameSideDataType type);
  
@@ -4558,10 +4556,10 @@ index 33fac2054c..a112e296f7 100644
   * @}
   */
 
-From 15e1a26da5d1b6a244a8a663dd469010c1da55e6 Mon Sep 17 00:00:00 2001
+From 9a08431f7790507b0374d9585dfc736000c1bd42 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 12:31:16 +0100
-Subject: [PATCH 006/120] Add an unsand filter
+Subject: [PATCH 006/121] Add an unsand filter
 
 ---
  configure                |   1 +
@@ -4573,10 +4571,10 @@ Subject: [PATCH 006/120] Add an unsand filter
  create mode 100644 libavfilter/vf_unsand.c
 
 diff --git a/configure b/configure
-index a0213c039a..c8674a7dad 100755
+index 27112ced58..7712482bd5 100755
 --- a/configure
 +++ b/configure
-@@ -3748,6 +3748,7 @@ tonemap_opencl_filter_deps="opencl const_nan"
+@@ -3754,6 +3754,7 @@ tonemap_opencl_filter_deps="opencl const_nan"
  transpose_opencl_filter_deps="opencl"
  transpose_vaapi_filter_deps="vaapi VAProcPipelineCaps_rotation_flags"
  transpose_vulkan_filter_deps="vulkan spirv_compiler"
@@ -4585,10 +4583,10 @@ index a0213c039a..c8674a7dad 100755
  uspp_filter_deps="gpl avcodec"
  vaguedenoiser_filter_deps="gpl"
 diff --git a/libavfilter/Makefile b/libavfilter/Makefile
-index 30cc329fb6..6db336e74a 100644
+index b3d3d981dd..c14fc995a0 100644
 --- a/libavfilter/Makefile
 +++ b/libavfilter/Makefile
-@@ -509,6 +509,7 @@ OBJS-$(CONFIG_TRANSPOSE_VAAPI_FILTER)        += vf_transpose_vaapi.o vaapi_vpp.o
+@@ -518,6 +518,7 @@ OBJS-$(CONFIG_TRANSPOSE_VAAPI_FILTER)        += vf_transpose_vaapi.o vaapi_vpp.o
  OBJS-$(CONFIG_TRANSPOSE_VULKAN_FILTER)       += vf_transpose_vulkan.o vulkan.o vulkan_filter.o
  OBJS-$(CONFIG_TRIM_FILTER)                   += trim.o
  OBJS-$(CONFIG_UNPREMULTIPLY_FILTER)          += vf_premultiply.o framesync.o
@@ -4597,10 +4595,10 @@ index 30cc329fb6..6db336e74a 100644
  OBJS-$(CONFIG_UNSHARP_OPENCL_FILTER)         += vf_unsharp_opencl.o opencl.o \
                                                  opencl/unsharp.o
 diff --git a/libavfilter/allfilters.c b/libavfilter/allfilters.c
-index 5ebacfde27..4bf3a5cfd8 100644
+index d7db46c2af..b990a00152 100644
 --- a/libavfilter/allfilters.c
 +++ b/libavfilter/allfilters.c
-@@ -483,6 +483,7 @@ extern const AVFilter ff_vf_trim;
+@@ -490,6 +490,7 @@ extern const AVFilter ff_vf_trim;
  extern const AVFilter ff_vf_unpremultiply;
  extern const AVFilter ff_vf_unsharp;
  extern const AVFilter ff_vf_unsharp_opencl;
@@ -4609,10 +4607,10 @@ index 5ebacfde27..4bf3a5cfd8 100644
  extern const AVFilter ff_vf_uspp;
  extern const AVFilter ff_vf_v360;
 diff --git a/libavfilter/buffersrc.c b/libavfilter/buffersrc.c
-index a3190468bb..1ba381ca9f 100644
+index ba17450b93..0dbe5d2335 100644
 --- a/libavfilter/buffersrc.c
 +++ b/libavfilter/buffersrc.c
-@@ -204,7 +204,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
+@@ -201,7 +201,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
  
          switch (ctx->outputs[0]->type) {
          case AVMEDIA_TYPE_VIDEO:
@@ -4856,17 +4854,17 @@ index 0000000000..7100f2fc9b
 +};
 +
 
-From 5737587f9f3566b8e963d7059136bf6d2f987810 Mon Sep 17 00:00:00 2001
+From 6e61007b19544c573f1c2a4c6060d3d24b8d500e Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 12:37:07 +0100
-Subject: [PATCH 007/120] Reduce mmal compile warnings
+Subject: [PATCH 007/121] Reduce mmal compile warnings
 
 ---
  libavcodec/mmaldec.c | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/libavcodec/mmaldec.c b/libavcodec/mmaldec.c
-index 7fd24ad3b7..03cf5c3bba 100644
+index 3092f58510..6f41b41ac4 100644
 --- a/libavcodec/mmaldec.c
 +++ b/libavcodec/mmaldec.c
 @@ -24,6 +24,9 @@
@@ -4888,10 +4886,10 @@ index 7fd24ad3b7..03cf5c3bba 100644
  
  #include "avcodec.h"
 
-From 32db01e1f0c7aa86adad47a013d6ffe2eccae5b8 Mon Sep 17 00:00:00 2001
+From 01aff455665e8f889330519096912ad0005add3c Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 17:56:16 +0100
-Subject: [PATCH 008/120] Add chroma location to hevc parse
+Subject: [PATCH 008/121] Add chroma location to hevc parse
 
 ---
  libavcodec/hevc_parser.c | 13 +++++++++++++
@@ -4899,7 +4897,7 @@ Subject: [PATCH 008/120] Add chroma location to hevc parse
  2 files changed, 26 insertions(+)
 
 diff --git a/libavcodec/hevc_parser.c b/libavcodec/hevc_parser.c
-index 59f9a0ff3e..8b3fee6329 100644
+index 59f9a0ff3e..4ae7222e8b 100644
 --- a/libavcodec/hevc_parser.c
 +++ b/libavcodec/hevc_parser.c
 @@ -97,6 +97,19 @@ static int hevc_parse_slice_header(AVCodecParserContext *s, H2645NAL *nal,
@@ -4907,8 +4905,8 @@ index 59f9a0ff3e..8b3fee6329 100644
      avctx->level    = ps->sps->ptl.general_ptl.level_idc;
  
 +    if (ps->sps->chroma_format_idc == 1) {
-+        avctx->chroma_sample_location = ps->sps->vui.chroma_loc_info_present_flag ?
-+            ps->sps->vui.chroma_sample_loc_type_top_field + 1 :
++        avctx->chroma_sample_location = ps->sps->vui.common.chroma_loc_info_present_flag ?
++            ps->sps->vui.common.chroma_sample_loc_type_top_field + 1 :
 +            AVCHROMA_LOC_LEFT;
 +    }
 +    else if (ps->sps->chroma_format_idc == 2 ||
@@ -4923,16 +4921,16 @@ index 59f9a0ff3e..8b3fee6329 100644
          num = ps->vps->vps_num_units_in_tick;
          den = ps->vps->vps_time_scale;
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index f8f981e838..00e14f0115 100644
+index 567e8d81d4..b6cfea64d3 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -340,6 +340,19 @@ static void export_stream_params(HEVCContext *s, const HEVCSPS *sps)
- 
-     ff_set_sar(avctx, sps->vui.sar);
+@@ -347,6 +347,19 @@ static void export_stream_params(HEVCContext *s, const HEVCSPS *sps)
+     else
+         avctx->color_range = AVCOL_RANGE_MPEG;
  
 +    if (sps->chroma_format_idc == 1) {
-+        avctx->chroma_sample_location = sps->vui.chroma_loc_info_present_flag ?
-+            sps->vui.chroma_sample_loc_type_top_field + 1 :
++        avctx->chroma_sample_location = sps->vui.common.chroma_loc_info_present_flag ?
++            sps->vui.common.chroma_sample_loc_type_top_field + 1 :
 +            AVCHROMA_LOC_LEFT;
 +    }
 +    else if (sps->chroma_format_idc == 2 ||
@@ -4943,14 +4941,14 @@ index f8f981e838..00e14f0115 100644
 +        avctx->chroma_sample_location = AVCHROMA_LOC_UNSPECIFIED;
 +    }
 +
-     if (sps->vui.video_signal_type_present_flag)
-         avctx->color_range = sps->vui.video_full_range_flag ? AVCOL_RANGE_JPEG
-                                                             : AVCOL_RANGE_MPEG;
+     if (sps->vui.common.colour_description_present_flag) {
+         avctx->color_primaries = sps->vui.common.colour_primaries;
+         avctx->color_trc       = sps->vui.common.transfer_characteristics;
 
-From afc9e6c5f8f092de1a7c8a686abd87f7be06e14c Mon Sep 17 00:00:00 2001
+From c80aad5d2fb373f7564e4257b1272f2decb06dd0 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 26 Sep 2022 18:20:50 +0100
-Subject: [PATCH 009/120] hwaccel: Add .abort_frame & use in hevcdec
+Subject: [PATCH 009/121] hwaccel: Add .abort_frame & use in hevcdec
 
 ---
  libavcodec/avcodec.h | 11 +++++++++++
@@ -4958,10 +4956,10 @@ Subject: [PATCH 009/120] hwaccel: Add .abort_frame & use in hevcdec
  2 files changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/avcodec.h b/libavcodec/avcodec.h
-index cb5c25bf63..62a3ca4d85 100644
+index 39881a1d2b..32bc78e2be 100644
 --- a/libavcodec/avcodec.h
 +++ b/libavcodec/avcodec.h
-@@ -2212,6 +2212,17 @@ typedef struct AVHWAccel {
+@@ -2221,6 +2221,17 @@ typedef struct AVHWAccel {
       * that avctx->hwaccel_priv_data is invalid.
       */
      int (*frame_params)(AVCodecContext *avctx, AVBufferRef *hw_frames_ctx);
@@ -4980,10 +4978,10 @@ index cb5c25bf63..62a3ca4d85 100644
  
  /**
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index 00e14f0115..ec3dd3cfa7 100644
+index b6cfea64d3..8a0246fa21 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -3517,8 +3517,13 @@ static int hevc_decode_frame(AVCodecContext *avctx, AVFrame *rframe,
+@@ -3375,8 +3375,13 @@ static int hevc_decode_frame(AVCodecContext *avctx, AVFrame *rframe,
  
      s->ref = NULL;
      ret    = decode_nal_units(s, avpkt->data, avpkt->size);
@@ -4999,10 +4997,10 @@ index 00e14f0115..ec3dd3cfa7 100644
      if (avctx->hwaccel) {
          if (s->ref && (ret = avctx->hwaccel->end_frame(avctx)) < 0) {
 
-From 376135da2c0d311cad5287b8ee0055ea1e4c1eaf Mon Sep 17 00:00:00 2001
+From 317722fd652d9a1c1700319c80fc71acf68ddde6 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 26 Sep 2022 18:26:17 +0100
-Subject: [PATCH 010/120] hwaccel: Add CAP_MT_SAFE for accels that can use
+Subject: [PATCH 010/121] hwaccel: Add CAP_MT_SAFE for accels that can use
  multi-thread
 
 ---
@@ -5023,10 +5021,10 @@ index 721424912c..c43ad55245 100644
  
  typedef struct AVCodecHWConfigInternal {
 diff --git a/libavcodec/pthread_frame.c b/libavcodec/pthread_frame.c
-index 43d6cc8ff4..d98b885b0e 100644
+index d9d5afaa82..2cc89a41f5 100644
 --- a/libavcodec/pthread_frame.c
 +++ b/libavcodec/pthread_frame.c
-@@ -217,7 +217,8 @@ FF_ENABLE_DEPRECATION_WARNINGS
+@@ -204,7 +204,8 @@ static attribute_align_arg void *frame_worker_thread(void *arg)
  
          /* if the previous thread uses hwaccel then we take the lock to ensure
           * the threads don't run concurrently */
@@ -5036,7 +5034,7 @@ index 43d6cc8ff4..d98b885b0e 100644
              pthread_mutex_lock(&p->parent->hwaccel_mutex);
              p->hwaccel_serializing = 1;
          }
-@@ -656,7 +657,9 @@ void ff_thread_finish_setup(AVCodecContext *avctx) {
+@@ -590,7 +591,9 @@ void ff_thread_finish_setup(AVCodecContext *avctx) {
  
      if (!(avctx->active_thread_type&FF_THREAD_FRAME)) return;
  
@@ -5048,10 +5046,10 @@ index 43d6cc8ff4..d98b885b0e 100644
          p->hwaccel_serializing = 1;
      }
 
-From 653671fba5f2ac43703576d3d8ee41bbf175f003 Mon Sep 17 00:00:00 2001
+From 9005b263450e154a5ec5258fda17d5998fe7896b Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 17:59:08 +0100
-Subject: [PATCH 011/120] Weak link utils
+Subject: [PATCH 011/121] Weak link utils
 
 ---
  libavcodec/weak_link.c | 102 +++++++++++++++++++++++++++++++++++++++++
@@ -5198,10 +5196,10 @@ index 0000000000..415b6a27a0
 +
 +
 
-From 172b496797b51a4c2638acacf45c8f6be03faf95 Mon Sep 17 00:00:00 2001
+From 824be1710ca96d97c86836fdac0e7dcd28a4b92e Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 19:23:26 +0100
-Subject: [PATCH 012/120] Add v4l2_req V4L2 request H265 drm_prime decode
+Subject: [PATCH 012/121] Add v4l2_req V4L2 request H265 drm_prime decode
 
 Has the abiliy to switch between kernel API versions at runtime. This
 could be removed later once teher is no chance of usage on an old
@@ -5251,7 +5249,7 @@ kernel.
  create mode 100644 libavcodec/v4l2_request_hevc.h
 
 diff --git a/configure b/configure
-index c8674a7dad..b64a6cf822 100755
+index 7712482bd5..199aa2b3d5 100755
 --- a/configure
 +++ b/configure
 @@ -281,6 +281,7 @@ External library support:
@@ -5262,7 +5260,7 @@ index c8674a7dad..b64a6cf822 100755
    --enable-libv4l2         enable libv4l2/v4l-utils [no]
    --enable-libvidstab      enable video stabilization using vid.stab [no]
    --enable-libvmaf         enable vmaf filter via libvmaf [no]
-@@ -350,6 +351,7 @@ External library support:
+@@ -351,6 +352,7 @@ External library support:
    --enable-omx-rpi         enable OpenMAX IL code for Raspberry Pi [no]
    --enable-rkmpp           enable Rockchip Media Process Platform code [no]
    --disable-v4l2-m2m       disable V4L2 mem2mem code [autodetect]
@@ -5270,7 +5268,7 @@ index c8674a7dad..b64a6cf822 100755
    --disable-vaapi          disable Video Acceleration API (mainly Unix/Intel) code [autodetect]
    --disable-vdpau          disable Nvidia Video Decode and Presentation API for Unix code [autodetect]
    --disable-videotoolbox   disable VideoToolbox code [autodetect]
-@@ -1870,6 +1872,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1858,6 +1860,7 @@ EXTERNAL_LIBRARY_LIST="
      libtheora
      libtwolame
      libuavs3d
@@ -5278,7 +5276,7 @@ index c8674a7dad..b64a6cf822 100755
      libv4l2
      libvmaf
      libvorbis
-@@ -1925,6 +1928,7 @@ HWACCEL_LIBRARY_LIST="
+@@ -1914,6 +1917,7 @@ HWACCEL_LIBRARY_LIST="
      mmal
      omx
      opencl
@@ -5286,7 +5284,7 @@ index c8674a7dad..b64a6cf822 100755
  "
  
  DOCUMENT_LIST="
-@@ -3014,6 +3018,7 @@ d3d11va_deps="dxva_h ID3D11VideoDecoder ID3D11VideoContext"
+@@ -3002,6 +3006,7 @@ d3d11va_deps="dxva_h ID3D11VideoDecoder ID3D11VideoContext"
  dxva2_deps="dxva2api_h DXVA2_ConfigPictureDecode ole32 user32"
  ffnvcodec_deps_any="libdl LoadLibrary"
  nvdec_deps="ffnvcodec"
@@ -5294,7 +5292,7 @@ index c8674a7dad..b64a6cf822 100755
  vaapi_x11_deps="xlib_x11"
  videotoolbox_hwaccel_deps="videotoolbox pthreads"
  videotoolbox_hwaccel_extralibs="-framework QuartzCore"
-@@ -3057,6 +3062,8 @@ hevc_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_HEVC"
+@@ -3045,6 +3050,8 @@ hevc_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_HEVC"
  hevc_dxva2_hwaccel_select="hevc_decoder"
  hevc_nvdec_hwaccel_deps="nvdec"
  hevc_nvdec_hwaccel_select="hevc_decoder"
@@ -5303,7 +5301,7 @@ index c8674a7dad..b64a6cf822 100755
  hevc_vaapi_hwaccel_deps="vaapi VAPictureParameterBufferHEVC"
  hevc_vaapi_hwaccel_select="hevc_decoder"
  hevc_vdpau_hwaccel_deps="vdpau VdpPictureInfoHEVC"
-@@ -6638,6 +6645,7 @@ enabled libtwolame        && require libtwolame twolame.h twolame_init -ltwolame
+@@ -6696,6 +6703,7 @@ enabled libtwolame        && require libtwolame twolame.h twolame_init -ltwolame
                               { check_lib libtwolame twolame.h twolame_encode_buffer_float32_interleaved -ltwolame ||
                                 die "ERROR: libtwolame must be installed and version must be >= 0.3.10"; }
  enabled libuavs3d         && require_pkg_config libuavs3d "uavs3d >= 1.1.41" uavs3d.h uavs3d_decode
@@ -5311,7 +5309,7 @@ index c8674a7dad..b64a6cf822 100755
  enabled libv4l2           && require_pkg_config libv4l2 libv4l2 libv4l2.h v4l2_ioctl
  enabled libvidstab        && require_pkg_config libvidstab "vidstab >= 0.98" vid.stab/libvidstab.h vsMotionDetectInit
  enabled libvmaf           && require_pkg_config libvmaf "libvmaf >= 2.0.0" libvmaf.h vmaf_init
-@@ -6739,6 +6747,10 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
+@@ -6798,6 +6806,10 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
                                 { enabled libdrm ||
                                   die "ERROR: rkmpp requires --enable-libdrm"; }
                               }
@@ -5322,7 +5320,7 @@ index c8674a7dad..b64a6cf822 100755
  enabled vapoursynth       && require_pkg_config vapoursynth "vapoursynth-script >= 42" VSScript.h vsscript_init
  
  
-@@ -6821,6 +6833,8 @@ if enabled v4l2_m2m; then
+@@ -6880,6 +6892,8 @@ if enabled v4l2_m2m; then
      check_cc vp9_v4l2_m2m linux/videodev2.h "int i = V4L2_PIX_FMT_VP9;"
  fi
  
@@ -5332,10 +5330,10 @@ index c8674a7dad..b64a6cf822 100755
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
  
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 457ec58377..df7659d0b8 100644
+index 389253f5d0..2d440b5648 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -162,6 +162,8 @@ OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
+@@ -170,6 +170,8 @@ OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
  OBJS-$(CONFIG_VP56DSP)                 += vp56dsp.o
  OBJS-$(CONFIG_VP8DSP)                  += vp8dsp.o
  OBJS-$(CONFIG_V4L2_M2M)                += v4l2_m2m.o v4l2_context.o v4l2_buffers.o v4l2_fmt.o
@@ -5344,7 +5342,7 @@ index 457ec58377..df7659d0b8 100644
  OBJS-$(CONFIG_WMA_FREQS)               += wma_freqs.o
  OBJS-$(CONFIG_WMV2DSP)                 += wmv2dsp.o
  
-@@ -972,6 +974,8 @@ OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
+@@ -996,6 +998,8 @@ OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_NVDEC_HWACCEL)         += nvdec_hevc.o
  OBJS-$(CONFIG_HEVC_QSV_HWACCEL)           += qsvdec.o
@@ -5852,10 +5850,10 @@ index 0000000000..7cbbbf055f
 +
 +#endif
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index ec3dd3cfa7..a2c43b888b 100644
+index 8a0246fa21..2867cb2e16 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -415,6 +415,7 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
+@@ -416,6 +416,7 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
  #define HWACCEL_MAX (CONFIG_HEVC_DXVA2_HWACCEL + \
                       CONFIG_HEVC_D3D11VA_HWACCEL * 2 + \
                       CONFIG_HEVC_NVDEC_HWACCEL + \
@@ -5863,7 +5861,7 @@ index ec3dd3cfa7..a2c43b888b 100644
                       CONFIG_HEVC_VAAPI_HWACCEL + \
                       CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL + \
                       CONFIG_HEVC_VDPAU_HWACCEL)
-@@ -441,6 +442,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
+@@ -442,6 +443,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
  #endif
  #if CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL
          *fmt++ = AV_PIX_FMT_VIDEOTOOLBOX;
@@ -5873,7 +5871,7 @@ index ec3dd3cfa7..a2c43b888b 100644
  #endif
          break;
      case AV_PIX_FMT_YUV420P10:
-@@ -462,6 +466,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
+@@ -463,6 +467,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
  #endif
  #if CONFIG_HEVC_NVDEC_HWACCEL
          *fmt++ = AV_PIX_FMT_CUDA;
@@ -5883,7 +5881,7 @@ index ec3dd3cfa7..a2c43b888b 100644
  #endif
          break;
      case AV_PIX_FMT_YUV444P:
-@@ -3915,6 +3922,9 @@ const FFCodec ff_hevc_decoder = {
+@@ -3749,6 +3756,9 @@ const FFCodec ff_hevc_decoder = {
  #if CONFIG_HEVC_NVDEC_HWACCEL
                                 HWACCEL_NVDEC(hevc),
  #endif
@@ -10673,22 +10671,22 @@ index 0000000000..f14f594564
 +
 +#endif
 
-From 297e4d885dd99aa0d1703c854fcb1f926d60abbb Mon Sep 17 00:00:00 2001
+From c99a0fe4d59212079de9bed222114abf95f7c989 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 27 Apr 2021 19:30:36 +0100
-Subject: [PATCH 013/120] Add no_cvt_hw option to ffmpeg
+Subject: [PATCH 013/121] Add no_cvt_hw option to ffmpeg
 
 ---
  fftools/ffmpeg.c     | 6 ++++--
- fftools/ffmpeg.h     | 1 +
+ fftools/ffmpeg.h     | 2 ++
  fftools/ffmpeg_opt.c | 3 +++
- 3 files changed, 8 insertions(+), 2 deletions(-)
+ 3 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
-index c68f96006b..e98f0b8149 100644
+index 15e084f0b2..5dc2cd73c1 100644
 --- a/fftools/ffmpeg.c
 +++ b/fftools/ffmpeg.c
-@@ -1965,6 +1965,9 @@ static int ifilter_send_frame(InputFilter *ifilter, AVFrame *frame, int keep_ref
+@@ -2005,6 +2005,9 @@ static int ifilter_send_frame(InputFilter *ifilter, AVFrame *frame, int keep_ref
          (ifilter->hw_frames_ctx && ifilter->hw_frames_ctx->data != frame->hw_frames_ctx->data))
          need_reinit = 1;
  
@@ -10698,7 +10696,7 @@ index c68f96006b..e98f0b8149 100644
      if (sd = av_frame_get_side_data(frame, AV_FRAME_DATA_DISPLAYMATRIX)) {
          if (!ifilter->displaymatrix || memcmp(sd->data, ifilter->displaymatrix, sizeof(int32_t) * 9))
              need_reinit = 1;
-@@ -2220,8 +2223,7 @@ static int decode_video(InputStream *ist, AVPacket *pkt, int *got_output, int64_
+@@ -2274,8 +2277,7 @@ static int decode_video(InputStream *ist, AVPacket *pkt, int *got_output, int64_
          decoded_frame->top_field_first = ist->top_field_first;
  
      ist->frames_decoded++;
@@ -10709,22 +10707,23 @@ index c68f96006b..e98f0b8149 100644
          if (err < 0)
              goto fail;
 diff --git a/fftools/ffmpeg.h b/fftools/ffmpeg.h
-index 391a35cf50..f43438b1ed 100644
+index f1412f6446..8f478619b3 100644
 --- a/fftools/ffmpeg.h
 +++ b/fftools/ffmpeg.h
-@@ -626,6 +626,7 @@ extern enum VideoSyncMethod video_sync_method;
+@@ -729,6 +729,8 @@ extern enum VideoSyncMethod video_sync_method;
  extern float frame_drop_threshold;
  extern int do_benchmark;
  extern int do_benchmark_all;
 +extern int no_cvt_hw;
- extern int do_deinterlace;
++extern int do_deinterlace;
  extern int do_hex_dump;
  extern int do_pkt_dump;
+ extern int copy_ts;
 diff --git a/fftools/ffmpeg_opt.c b/fftools/ffmpeg_opt.c
-index 6e18a4a23e..877689f8bc 100644
+index 055275d813..761db36588 100644
 --- a/fftools/ffmpeg_opt.c
 +++ b/fftools/ffmpeg_opt.c
-@@ -162,6 +162,7 @@ enum VideoSyncMethod video_sync_method = VSYNC_AUTO;
+@@ -71,6 +71,7 @@ enum VideoSyncMethod video_sync_method = VSYNC_AUTO;
  float frame_drop_threshold = 0;
  int do_benchmark      = 0;
  int do_benchmark_all  = 0;
@@ -10732,7 +10731,7 @@ index 6e18a4a23e..877689f8bc 100644
  int do_hex_dump       = 0;
  int do_pkt_dump       = 0;
  int copy_ts           = 0;
-@@ -3718,6 +3719,8 @@ const OptionDef options[] = {
+@@ -1427,6 +1428,8 @@ const OptionDef options[] = {
          "add timings for benchmarking" },
      { "benchmark_all",  OPT_BOOL | OPT_EXPERT,                       { &do_benchmark_all },
        "add timings for each task" },
@@ -10742,24 +10741,24 @@ index 6e18a4a23e..877689f8bc 100644
        "write program-readable progress information", "url" },
      { "stdin",          OPT_BOOL | OPT_EXPERT,                       { &stdin_interaction },
 
-From 1707f2fac047809232ec19c6c9f038461ff1ec94 Mon Sep 17 00:00:00 2001
+From 27e0c78a2df53fb2337bee4c383cdb58cbbc717e Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 28 Apr 2021 10:16:39 +0100
-Subject: [PATCH 014/120] Add vout_drm
+Subject: [PATCH 014/121] Add vout_drm
 
 ---
  configure                |   4 +
  libavdevice/Makefile     |   1 +
  libavdevice/alldevices.c |   1 +
- libavdevice/drm_vout.c   | 636 +++++++++++++++++++++++++++++++++++++++
- 4 files changed, 642 insertions(+)
+ libavdevice/drm_vout.c   | 638 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 644 insertions(+)
  create mode 100644 libavdevice/drm_vout.c
 
 diff --git a/configure b/configure
-index b64a6cf822..e6440cd9f3 100755
+index 199aa2b3d5..49744cab19 100755
 --- a/configure
 +++ b/configure
-@@ -345,6 +345,7 @@ External library support:
+@@ -346,6 +346,7 @@ External library support:
    --enable-libnpp          enable Nvidia Performance Primitives-based code [no]
    --enable-mmal            enable Broadcom Multi-Media Abstraction Layer (Raspberry Pi) via MMAL [no]
    --enable-sand            enable sand video formats [rpi]
@@ -10767,7 +10766,7 @@ index b64a6cf822..e6440cd9f3 100755
    --disable-nvdec          disable Nvidia video decoding acceleration (via hwaccel) [autodetect]
    --disable-nvenc          disable Nvidia video encoding code [autodetect]
    --enable-omx             enable OpenMAX IL code [no]
-@@ -1951,6 +1952,7 @@ FEATURE_LIST="
+@@ -1940,6 +1941,7 @@ FEATURE_LIST="
      small
      static
      swscale_alpha
@@ -10775,7 +10774,7 @@ index b64a6cf822..e6440cd9f3 100755
  "
  
  # this list should be kept in linking order
-@@ -3549,8 +3551,10 @@ sndio_indev_deps="sndio"
+@@ -3559,8 +3561,10 @@ sndio_indev_deps="sndio"
  sndio_outdev_deps="sndio"
  v4l2_indev_deps_any="linux_videodev2_h sys_videoio_h"
  v4l2_indev_suggest="libv4l2"
@@ -10787,7 +10786,7 @@ index b64a6cf822..e6440cd9f3 100755
  xcbgrab_indev_deps="libxcb"
  xcbgrab_indev_suggest="libxcb_shm libxcb_shape libxcb_xfixes"
 diff --git a/libavdevice/Makefile b/libavdevice/Makefile
-index bbe2f69dcc..447dbfdf9a 100644
+index 8a62822b69..36aac30186 100644
 --- a/libavdevice/Makefile
 +++ b/libavdevice/Makefile
 @@ -48,6 +48,7 @@ OBJS-$(CONFIG_SNDIO_OUTDEV)              += sndio_enc.o sndio.o
@@ -10799,23 +10798,23 @@ index bbe2f69dcc..447dbfdf9a 100644
  OBJS-$(CONFIG_XV_OUTDEV)                 += xv.o
  
 diff --git a/libavdevice/alldevices.c b/libavdevice/alldevices.c
-index 22323a0a44..23351f0316 100644
+index 8a90fcb5d7..e2a8669f27 100644
 --- a/libavdevice/alldevices.c
 +++ b/libavdevice/alldevices.c
-@@ -51,6 +51,7 @@ extern const AVOutputFormat ff_sndio_muxer;
+@@ -52,6 +52,7 @@ extern const FFOutputFormat ff_sndio_muxer;
  extern const AVInputFormat  ff_v4l2_demuxer;
- extern const AVOutputFormat ff_v4l2_muxer;
+ extern const FFOutputFormat ff_v4l2_muxer;
  extern const AVInputFormat  ff_vfwcap_demuxer;
-+extern const AVOutputFormat ff_vout_drm_muxer;
++extern const FFOutputFormat ff_vout_drm_muxer;
  extern const AVInputFormat  ff_xcbgrab_demuxer;
- extern const AVOutputFormat ff_xv_muxer;
+ extern const FFOutputFormat ff_xv_muxer;
  
 diff --git a/libavdevice/drm_vout.c b/libavdevice/drm_vout.c
 new file mode 100644
-index 0000000000..15ed1b8825
+index 0000000000..cfb33ce7c3
 --- /dev/null
 +++ b/libavdevice/drm_vout.c
-@@ -0,0 +1,636 @@
+@@ -0,0 +1,638 @@
 +/*
 + * Copyright (c) 2020 John Cox for Raspberry Pi Trading
 + *
@@ -10843,7 +10842,7 @@ index 0000000000..15ed1b8825
 +#include "libavutil/opt.h"
 +#include "libavutil/pixdesc.h"
 +#include "libavutil/hwcontext_drm.h"
-+#include "libavformat/internal.h"
++#include "libavformat/mux.h"
 +#include "avdevice.h"
 +
 +#include "pthread.h"
@@ -11435,42 +11434,44 @@ index 0000000000..15ed1b8825
 +    .category   = AV_CLASS_CATEGORY_DEVICE_VIDEO_OUTPUT,
 +};
 +
-+AVOutputFormat ff_vout_drm_muxer = {
-+    .name           = "vout_drm",
-+    .long_name      = NULL_IF_CONFIG_SMALL("Drm video output device"),
++FFOutputFormat ff_vout_drm_muxer = {
++    .p = {
++        .name           = "vout_drm",
++        .long_name      = NULL_IF_CONFIG_SMALL("Drm video output device"),
++        .audio_codec    = AV_CODEC_ID_NONE,
++        .video_codec    = AV_CODEC_ID_WRAPPED_AVFRAME,
++        .flags          = AVFMT_NOFILE | AVFMT_VARIABLE_FPS | AVFMT_NOTIMESTAMPS,
++        .priv_class     = &drm_vout_class,
++    },
 +    .priv_data_size = sizeof(drm_display_env_t),
-+    .audio_codec    = AV_CODEC_ID_NONE,
-+    .video_codec    = AV_CODEC_ID_WRAPPED_AVFRAME,
 +    .write_header   = drm_vout_write_header,
 +    .write_packet   = drm_vout_write_packet,
 +    .write_uncoded_frame = drm_vout_write_frame,
 +    .write_trailer  = drm_vout_write_trailer,
 +    .control_message = drm_vout_control_message,
-+    .flags          = AVFMT_NOFILE | AVFMT_VARIABLE_FPS | AVFMT_NOTIMESTAMPS,
-+    .priv_class     = &drm_vout_class,
 +    .init           = drm_vout_init,
 +    .deinit         = drm_vout_deinit,
 +};
 +
 
-From 4b2ffa315b5a20a84a38e17e74d8a2e6b778b200 Mon Sep 17 00:00:00 2001
+From cc536672adf4eefeaec16e9808f583c693ad7819 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 28 Apr 2021 11:34:18 +0100
-Subject: [PATCH 015/120] Add vout_egl
+Subject: [PATCH 015/121] Add vout_egl
 
 ---
  configure                |   6 +
  libavdevice/Makefile     |   1 +
  libavdevice/alldevices.c |   1 +
- libavdevice/egl_vout.c   | 809 +++++++++++++++++++++++++++++++++++++++
- 4 files changed, 817 insertions(+)
+ libavdevice/egl_vout.c   | 811 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 819 insertions(+)
  create mode 100644 libavdevice/egl_vout.c
 
 diff --git a/configure b/configure
-index e6440cd9f3..8424d451fb 100755
+index 49744cab19..b41663c794 100755
 --- a/configure
 +++ b/configure
-@@ -346,6 +346,7 @@ External library support:
+@@ -347,6 +347,7 @@ External library support:
    --enable-mmal            enable Broadcom Multi-Media Abstraction Layer (Raspberry Pi) via MMAL [no]
    --enable-sand            enable sand video formats [rpi]
    --enable-vout-drm        enable the vout_drm module - for internal testing only [no]
@@ -11478,7 +11479,7 @@ index e6440cd9f3..8424d451fb 100755
    --disable-nvdec          disable Nvidia video decoding acceleration (via hwaccel) [autodetect]
    --disable-nvenc          disable Nvidia video encoding code [autodetect]
    --enable-omx             enable OpenMAX IL code [no]
-@@ -1830,6 +1831,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1818,6 +1819,7 @@ EXTERNAL_LIBRARY_LIST="
      libdav1d
      libdc1394
      libdrm
@@ -11486,7 +11487,7 @@ index e6440cd9f3..8424d451fb 100755
      libflite
      libfontconfig
      libfreetype
-@@ -1953,6 +1955,7 @@ FEATURE_LIST="
+@@ -1942,6 +1944,7 @@ FEATURE_LIST="
      static
      swscale_alpha
      vout_drm
@@ -11494,7 +11495,7 @@ index e6440cd9f3..8424d451fb 100755
  "
  
  # this list should be kept in linking order
-@@ -3555,6 +3558,8 @@ v4l2_outdev_deps="libdrm"
+@@ -3565,6 +3568,8 @@ v4l2_outdev_deps="libdrm"
  v4l2_outdev_deps_any="linux_videodev2_h sys_videoio_h"
  v4l2_outdev_suggest="libv4l2"
  vout_drm_outdev_deps="libdrm vout_drm"
@@ -11503,7 +11504,7 @@ index e6440cd9f3..8424d451fb 100755
  vfwcap_indev_deps="vfw32 vfwcap_defines"
  xcbgrab_indev_deps="libxcb"
  xcbgrab_indev_suggest="libxcb_shm libxcb_shape libxcb_xfixes"
-@@ -6556,6 +6561,7 @@ enabled libdav1d          && require_pkg_config libdav1d "dav1d >= 0.5.0" "dav1d
+@@ -6596,6 +6601,7 @@ enabled libdav1d          && require_pkg_config libdav1d "dav1d >= 0.5.0" "dav1d
  enabled libdavs2          && require_pkg_config libdavs2 "davs2 >= 1.6.0" davs2.h davs2_decoder_open
  enabled libdc1394         && require_pkg_config libdc1394 libdc1394-2 dc1394/dc1394.h dc1394_new
  enabled libdrm            && require_pkg_config libdrm libdrm xf86drm.h drmGetVersion
@@ -11512,7 +11513,7 @@ index e6440cd9f3..8424d451fb 100755
                                 { require libfdk_aac fdk-aac/aacenc_lib.h aacEncOpen -lfdk-aac &&
                                   warn "using libfdk without pkg-config"; } }
 diff --git a/libavdevice/Makefile b/libavdevice/Makefile
-index 447dbfdf9a..8d83b0f19e 100644
+index 36aac30186..0989cb895f 100644
 --- a/libavdevice/Makefile
 +++ b/libavdevice/Makefile
 @@ -49,6 +49,7 @@ OBJS-$(CONFIG_V4L2_INDEV)                += v4l2.o v4l2-common.o timefilter.o
@@ -11524,23 +11525,23 @@ index 447dbfdf9a..8d83b0f19e 100644
  OBJS-$(CONFIG_XV_OUTDEV)                 += xv.o
  
 diff --git a/libavdevice/alldevices.c b/libavdevice/alldevices.c
-index 23351f0316..90d81d69ac 100644
+index e2a8669f27..ffb410b92d 100644
 --- a/libavdevice/alldevices.c
 +++ b/libavdevice/alldevices.c
-@@ -52,6 +52,7 @@ extern const AVInputFormat  ff_v4l2_demuxer;
- extern const AVOutputFormat ff_v4l2_muxer;
+@@ -53,6 +53,7 @@ extern const AVInputFormat  ff_v4l2_demuxer;
+ extern const FFOutputFormat ff_v4l2_muxer;
  extern const AVInputFormat  ff_vfwcap_demuxer;
- extern const AVOutputFormat ff_vout_drm_muxer;
-+extern const AVOutputFormat ff_vout_egl_muxer;
+ extern const FFOutputFormat ff_vout_drm_muxer;
++extern const FFOutputFormat ff_vout_egl_muxer;
  extern const AVInputFormat  ff_xcbgrab_demuxer;
- extern const AVOutputFormat ff_xv_muxer;
+ extern const FFOutputFormat ff_xv_muxer;
  
 diff --git a/libavdevice/egl_vout.c b/libavdevice/egl_vout.c
 new file mode 100644
-index 0000000000..0195c9d026
+index 0000000000..7b9c610ace
 --- /dev/null
 +++ b/libavdevice/egl_vout.c
-@@ -0,0 +1,809 @@
+@@ -0,0 +1,811 @@
 +/*
 + * Copyright (c) 2020 John Cox for Raspberry Pi Trading
 + *
@@ -11575,7 +11576,7 @@ index 0000000000..0195c9d026
 +#include "libavutil/pixdesc.h"
 +#include "libavutil/imgutils.h"
 +#include "libavutil/hwcontext_drm.h"
-+#include "libavformat/internal.h"
++#include "libavformat/mux.h"
 +#include "avdevice.h"
 +
 +#include "pthread.h"
@@ -12333,28 +12334,30 @@ index 0000000000..0195c9d026
 +    .category   = AV_CLASS_CATEGORY_DEVICE_VIDEO_OUTPUT,
 +};
 +
-+AVOutputFormat ff_vout_egl_muxer = {
-+    .name           = "vout_egl",
-+    .long_name      = NULL_IF_CONFIG_SMALL("Egl video output device"),
++FFOutputFormat ff_vout_egl_muxer = {
++    .p = {
++        .name           = "vout_egl",
++        .long_name      = NULL_IF_CONFIG_SMALL("Egl video output device"),
++        .audio_codec    = AV_CODEC_ID_NONE,
++        .video_codec    = AV_CODEC_ID_WRAPPED_AVFRAME,
++        .flags          = AVFMT_NOFILE | AVFMT_VARIABLE_FPS | AVFMT_NOTIMESTAMPS,
++        .priv_class     = &egl_vout_class,
++    },
 +    .priv_data_size = sizeof(egl_display_env_t),
-+    .audio_codec    = AV_CODEC_ID_NONE,
-+    .video_codec    = AV_CODEC_ID_WRAPPED_AVFRAME,
 +    .write_header   = egl_vout_write_header,
 +    .write_packet   = egl_vout_write_packet,
 +    .write_uncoded_frame = egl_vout_write_frame,
 +    .write_trailer  = egl_vout_write_trailer,
 +    .control_message = egl_vout_control_message,
-+    .flags          = AVFMT_NOFILE | AVFMT_VARIABLE_FPS | AVFMT_NOTIMESTAMPS,
-+    .priv_class     = &egl_vout_class,
 +    .init           = egl_vout_init,
 +    .deinit         = egl_vout_deinit,
 +};
 +
 
-From 183f6ae1b65b695630c8ac8a7cb5659a2ded42f6 Mon Sep 17 00:00:00 2001
+From 867bd7c243e66a1c1756878e20df8f35db8025ec Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 28 Apr 2021 12:51:22 +0100
-Subject: [PATCH 016/120] V4L2 stateful rework
+Subject: [PATCH 016/121] V4L2 stateful rework
 
 ---
  libavcodec/Makefile       |   3 +-
@@ -12363,15 +12366,15 @@ Subject: [PATCH 016/120] V4L2 stateful rework
  libavcodec/v4l2_context.c | 536 +++++++++++++++++++++++++++---------
  libavcodec/v4l2_context.h |  20 +-
  libavcodec/v4l2_m2m.c     |  20 +-
- libavcodec/v4l2_m2m.h     |  33 ++-
- libavcodec/v4l2_m2m_dec.c | 448 ++++++++++++++++++++++++++----
- 8 files changed, 1288 insertions(+), 356 deletions(-)
+ libavcodec/v4l2_m2m.h     |  31 +++
+ libavcodec/v4l2_m2m_dec.c | 446 ++++++++++++++++++++++++++----
+ 8 files changed, 1286 insertions(+), 354 deletions(-)
 
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index df7659d0b8..a40c46bf93 100644
+index 2d440b5648..e1aa0ba014 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -161,7 +161,8 @@ OBJS-$(CONFIG_VIDEODSP)                += videodsp.o
+@@ -169,7 +169,8 @@ OBJS-$(CONFIG_VIDEODSP)                += videodsp.o
  OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
  OBJS-$(CONFIG_VP56DSP)                 += vp56dsp.o
  OBJS-$(CONFIG_VP8DSP)                  += vp8dsp.o
@@ -13220,7 +13223,7 @@ index 3d2ff1b9a5..111526aee3 100644
  /**
   * Enqueues a V4L2Buffer
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index e891649f92..cbbd0551a7 100644
+index a40be94690..be76068af3 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -27,11 +27,13 @@
@@ -13229,7 +13232,7 @@ index e891649f92..cbbd0551a7 100644
  #include <poll.h>
 +#include "libavutil/avassert.h"
  #include "libavcodec/avcodec.h"
- #include "libavcodec/internal.h"
+ #include "decode.h"
  #include "v4l2_buffers.h"
  #include "v4l2_fmt.h"
  #include "v4l2_m2m.h"
@@ -14085,10 +14088,10 @@ index 6f7460c89a..59009d11d1 100644
  /**
   * Enqueues a buffer to a V4L2Context from an AVFrame
 diff --git a/libavcodec/v4l2_m2m.c b/libavcodec/v4l2_m2m.c
-index 984936004d..50a192933b 100644
+index 602efb7a16..516e6d9858 100644
 --- a/libavcodec/v4l2_m2m.c
 +++ b/libavcodec/v4l2_m2m.c
-@@ -214,13 +214,7 @@ int ff_v4l2_m2m_codec_reinit(V4L2m2mContext *s)
+@@ -216,13 +216,7 @@ int ff_v4l2_m2m_codec_reinit(V4L2m2mContext *s)
          av_log(log_ctx, AV_LOG_ERROR, "capture VIDIOC_STREAMOFF\n");
  
      /* 2. unmap the capture buffers (v4l2 and ffmpeg):
@@ -14102,7 +14105,7 @@ index 984936004d..50a192933b 100644
      ff_v4l2_context_release(&s->capture);
  
      /* 3. get the new capture format */
-@@ -257,6 +251,8 @@ static void v4l2_m2m_destroy_context(void *opaque, uint8_t *context)
+@@ -259,6 +253,8 @@ static void v4l2_m2m_destroy_context(void *opaque, uint8_t *context)
      av_frame_free(&s->frame);
      av_packet_unref(&s->buf_pkt);
  
@@ -14111,7 +14114,7 @@ index 984936004d..50a192933b 100644
      av_free(s);
  }
  
-@@ -268,6 +264,11 @@ int ff_v4l2_m2m_codec_end(V4L2m2mPriv *priv)
+@@ -270,6 +266,11 @@ int ff_v4l2_m2m_codec_end(V4L2m2mPriv *priv)
      if (!s)
          return 0;
  
@@ -14123,7 +14126,7 @@ index 984936004d..50a192933b 100644
      if (s->fd >= 0) {
          ret = ff_v4l2_context_set_status(&s->output, VIDIOC_STREAMOFF);
          if (ret)
-@@ -280,7 +281,14 @@ int ff_v4l2_m2m_codec_end(V4L2m2mPriv *priv)
+@@ -282,7 +283,14 @@ int ff_v4l2_m2m_codec_end(V4L2m2mPriv *priv)
  
      ff_v4l2_context_release(&s->output);
  
@@ -14139,7 +14142,7 @@ index 984936004d..50a192933b 100644
  
      return 0;
 diff --git a/libavcodec/v4l2_m2m.h b/libavcodec/v4l2_m2m.h
-index b67b216331..24a9c94864 100644
+index 04d86d7b92..24a9c94864 100644
 --- a/libavcodec/v4l2_m2m.h
 +++ b/libavcodec/v4l2_m2m.h
 @@ -30,6 +30,7 @@
@@ -14150,13 +14153,10 @@ index b67b216331..24a9c94864 100644
  #include "v4l2_context.h"
  
  #define container_of(ptr, type, member) ({ \
-@@ -38,7 +39,18 @@
- 
- #define V4L_M2M_DEFAULT_OPTS \
+@@ -40,6 +41,17 @@
      { "num_output_buffers", "Number of buffers in the output context",\
--        OFFSET(num_output_buffers), AV_OPT_TYPE_INT, { .i64 = 16 }, 6, INT_MAX, FLAGS }
-+        OFFSET(num_output_buffers), AV_OPT_TYPE_INT, { .i64 = 16 }, 2, INT_MAX, FLAGS }
-+
+         OFFSET(num_output_buffers), AV_OPT_TYPE_INT, { .i64 = 16 }, 2, INT_MAX, FLAGS }
+ 
 +#define FF_V4L2_M2M_TRACK_SIZE 128
 +typedef struct V4L2m2mTrackEl {
 +    int     discard;   // If we see this buffer its been flushed, so discard
@@ -14167,9 +14167,10 @@ index b67b216331..24a9c94864 100644
 +    int64_t pkt_duration;
 +    int64_t track_pts;
 +} V4L2m2mTrackEl;
- 
++
  typedef struct V4L2m2mContext {
      char devname[PATH_MAX];
+     int fd;
 @@ -53,6 +65,7 @@ typedef struct V4L2m2mContext {
      sem_t refsync;
      atomic_uint refcount;
@@ -14211,7 +14212,7 @@ index b67b216331..24a9c94864 100644
  
  /**
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 8a51dec3fa..e1d34f4ccd 100644
+index 4944d08511..7f6033ac2c 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -23,6 +23,10 @@
@@ -14742,12 +14743,10 @@ index 8a51dec3fa..e1d34f4ccd 100644
  }
  
  #define OFFSET(x) offsetof(V4L2m2mPriv, x)
-@@ -226,10 +569,16 @@ static av_cold int v4l2_decode_close(AVCodecContext *avctx)
- static const AVOption options[] = {
+@@ -227,9 +570,15 @@ static const AVOption options[] = {
      V4L_M2M_DEFAULT_OPTS,
      { "num_capture_buffers", "Number of buffers in the capture context",
--        OFFSET(num_capture_buffers), AV_OPT_TYPE_INT, {.i64 = 20}, 20, INT_MAX, FLAGS },
-+        OFFSET(num_capture_buffers), AV_OPT_TYPE_INT, {.i64 = 20}, 2, INT_MAX, FLAGS },
+         OFFSET(num_capture_buffers), AV_OPT_TYPE_INT, {.i64 = 20}, 2, INT_MAX, FLAGS },
 +    { "pixel_format", "Pixel format to be used by the decoder", OFFSET(pix_fmt), AV_OPT_TYPE_PIXEL_FMT, {.i64 = AV_PIX_FMT_NONE}, AV_PIX_FMT_NONE, AV_PIX_FMT_NB, FLAGS },
      { NULL},
  };
@@ -14760,14 +14759,15 @@ index 8a51dec3fa..e1d34f4ccd 100644
  #define M2MDEC_CLASS(NAME) \
      static const AVClass v4l2_m2m_ ## NAME ## _dec_class = { \
          .class_name = #NAME "_v4l2m2m_decoder", \
-@@ -250,10 +599,15 @@ static const AVOption options[] = {
+@@ -250,11 +599,16 @@ static const AVOption options[] = {
          .init           = v4l2_decode_init, \
          FF_CODEC_RECEIVE_FRAME_CB(v4l2_receive_frame), \
          .close          = v4l2_decode_close, \
 +        .flush          = v4l2_decode_flush, \
          .bsfs           = bsf_name, \
          .p.capabilities = AV_CODEC_CAP_HARDWARE | AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AVOID_PROBING, \
-         .caps_internal  = FF_CODEC_CAP_SETS_PKT_DTS | FF_CODEC_CAP_INIT_CLEANUP, \
+         .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE | \
+                           FF_CODEC_CAP_SETS_PKT_DTS | FF_CODEC_CAP_INIT_CLEANUP, \
          .p.wrapper_name = "v4l2m2m", \
 +        .p.pix_fmts     = (const enum AVPixelFormat[]) { AV_PIX_FMT_DRM_PRIME, \
 +                                                         AV_PIX_FMT_NV12, \
@@ -14777,10 +14777,10 @@ index 8a51dec3fa..e1d34f4ccd 100644
  
  M2MDEC(h264,  "H.264", AV_CODEC_ID_H264,       "h264_mp4toannexb");
 
-From d01e2d278c959db020910e62071dd0abe460b0e7 Mon Sep 17 00:00:00 2001
+From 12f8f12326b83dd3c22084f8922705d79a13d195 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 10 Jun 2021 18:46:21 +0100
-Subject: [PATCH 017/120] Fix crash in hw_device_default_name if type not found
+Subject: [PATCH 017/121] Fix crash in hw_device_default_name if type not found
  (NONE)
 
 ---
@@ -14788,7 +14788,7 @@ Subject: [PATCH 017/120] Fix crash in hw_device_default_name if type not found
  1 file changed, 2 insertions(+)
 
 diff --git a/fftools/ffmpeg_hw.c b/fftools/ffmpeg_hw.c
-index 14e702bd92..4194647faa 100644
+index 88fa782470..740a5e7153 100644
 --- a/fftools/ffmpeg_hw.c
 +++ b/fftools/ffmpeg_hw.c
 @@ -75,6 +75,8 @@ static char *hw_device_default_name(enum AVHWDeviceType type)
@@ -14801,10 +14801,10 @@ index 14e702bd92..4194647faa 100644
      name = av_malloc(index_pos + 4);
      if (!name)
 
-From 40f4215a999a91398f8e627efe4de2674610d0c6 Mon Sep 17 00:00:00 2001
+From 7f6bce459e683bff3a0b972922fbcc808e9177a6 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 10 Jun 2021 18:59:18 +0100
-Subject: [PATCH 018/120] Allow v4l2m2m to select non-drm_prime output formats
+Subject: [PATCH 018/121] Allow v4l2m2m to select non-drm_prime output formats
 
 ---
  libavcodec/v4l2_buffers.c |  2 +-
@@ -14825,7 +14825,7 @@ index a003934ca1..1ca1128db6 100644
              }
  
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index e1d34f4ccd..d258fed28b 100644
+index 7f6033ac2c..a4b5a4e7e9 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -455,10 +455,10 @@ static av_cold int v4l2_decode_init(AVCodecContext *avctx)
@@ -14859,7 +14859,7 @@ index e1d34f4ccd..d258fed28b 100644
      }
  
      s->device_ref = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_DRM);
-@@ -606,6 +611,7 @@ static const AVCodecHWConfigInternal *v4l2_m2m_hw_configs[] = {
+@@ -607,6 +612,7 @@ static const AVCodecHWConfigInternal *v4l2_m2m_hw_configs[] = {
          .p.wrapper_name = "v4l2m2m", \
          .p.pix_fmts     = (const enum AVPixelFormat[]) { AV_PIX_FMT_DRM_PRIME, \
                                                           AV_PIX_FMT_NV12, \
@@ -14868,10 +14868,10 @@ index e1d34f4ccd..d258fed28b 100644
          .hw_configs     = v4l2_m2m_hw_configs, \
      }
 
-From 353911de1297691582400e34c2edc23b128b1d09 Mon Sep 17 00:00:00 2001
+From 9b0d964b727d98271f7f2f4dcdbcb1b41a429e2b Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 10 Jun 2021 18:59:38 +0100
-Subject: [PATCH 019/120] Fix YUV420P output from v4l2m2m
+Subject: [PATCH 019/121] Fix YUV420P output from v4l2m2m
 
 Also put get_width get_height inlines in header as they are generally
 useful.
@@ -14910,7 +14910,7 @@ index 1ca1128db6..f4c11ca8d0 100644
  
      default:
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index cbbd0551a7..5404fb1e94 100644
+index be76068af3..6fe2586627 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -55,16 +55,6 @@ static inline AVCodecContext *logger(V4L2Context *ctx)
@@ -14985,10 +14985,10 @@ index 24a9c94864..8f054f2f50 100644
 +
  #endif /* AVCODEC_V4L2_M2M_H */
 
-From 1dec95facf260599f9297a9bebc6227fddfebb07 Mon Sep 17 00:00:00 2001
+From 14e9b4bf1b34b3d1e1e6a4fc755cc595416e7d7b Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 10 Jun 2021 19:23:44 +0100
-Subject: [PATCH 020/120] Report buffer overflows in v4l2m2m
+Subject: [PATCH 020/121] Report buffer overflows in v4l2m2m
 
 ---
  libavcodec/v4l2_buffers.c | 14 ++++++++++----
@@ -15045,7 +15045,7 @@ index f4c11ca8d0..de31f7ced9 100644
  
  int ff_v4l2_buffer_avpkt_to_buf(const AVPacket *pkt, V4L2Buffer *out)
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 5404fb1e94..5f89b5047c 100644
+index 6fe2586627..81aced0c2b 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -824,7 +824,10 @@ int ff_v4l2_context_enqueue_packet(V4L2Context* ctx, const AVPacket* pkt,
@@ -15061,10 +15061,10 @@ index 5404fb1e94..5f89b5047c 100644
  
      return ff_v4l2_buffer_enqueue(avbuf);
 
-From 6b1946de881162e8d2e256b029a75f1e5804332f Mon Sep 17 00:00:00 2001
+From 072907a7fcf160d12972997d24fdf62641687ea4 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 14 Jun 2021 11:55:16 +0100
-Subject: [PATCH 021/120] Increase V4L2 H264 stateful coded buffer size
+Subject: [PATCH 021/121] Increase V4L2 H264 stateful coded buffer size
 
 Try to set a min size of frame size / 2 for bitbuffers passed to V4l2.
 This fixes a few streams that have large I-frames.  You would hope
@@ -15081,7 +15081,7 @@ sensible now.
  3 files changed, 53 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 5f89b5047c..fc8325a18d 100644
+index 81aced0c2b..a17ae027a6 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -902,7 +902,29 @@ int ff_v4l2_context_get_format(V4L2Context* ctx, int probe)
@@ -15133,7 +15133,7 @@ index 59009d11d1..37b0431400 100644
       * Indexed array of pointers to V4L2Buffers
       */
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index d258fed28b..b37b005d3f 100644
+index a4b5a4e7e9..1851acbc93 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -450,6 +450,27 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -15185,10 +15185,10 @@ index d258fed28b..b37b005d3f 100644
      /* the client requests the codec to generate DRM frames:
       *   - data[0] will therefore point to the returned AVDRMFrameDescriptor
 
-From 2a241b27bf5862a2faadecff08c2d936bb40b087 Mon Sep 17 00:00:00 2001
+From 6087c8c054e1ff3d2e6e62d5e32705d079928b64 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 28 Jun 2021 12:13:35 +0100
-Subject: [PATCH 022/120] Fix raw video s.t. it respects any remaining cropping
+Subject: [PATCH 022/121] Fix raw video s.t. it respects any remaining cropping
 
 This fixes the long standing CONFWIN_A conformance test failure for drm.
 ---
@@ -15197,7 +15197,7 @@ This fixes the long standing CONFWIN_A conformance test failure for drm.
  2 files changed, 130 insertions(+), 14 deletions(-)
 
 diff --git a/libavcodec/rawenc.c b/libavcodec/rawenc.c
-index 0cd8eaffee..f80d402ce3 100644
+index 594a77c42a..8ca0379e12 100644
 --- a/libavcodec/rawenc.c
 +++ b/libavcodec/rawenc.c
 @@ -124,32 +124,41 @@ static int raw_sand30_as_yuv420(AVCodecContext *avctx, AVPacket *pkt,
@@ -15455,10 +15455,10 @@ index 7a9fdbd263..baf18920fa 100644
      map = av_frame_alloc();
      if (!map)
 
-From c29e1648b05579d84323a5bd5ce8987228115e1c Mon Sep 17 00:00:00 2001
+From 597858c11fbfbe0f54c1b68d9683025929258bc1 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 13 Aug 2021 15:38:28 +0100
-Subject: [PATCH 023/120] Set frame interlace from V4L2 buffer field
+Subject: [PATCH 023/121] Set frame interlace from V4L2 buffer field
 
 ---
  libavcodec/v4l2_buffers.c | 12 ++++++++++++
@@ -15495,10 +15495,10 @@ index de31f7ced9..97b8eb1db3 100644
      /* these values are updated also during re-init in v4l2_process_driver_event */
      frame->height = ctx->height;
 
-From ad065684c270f1e44d53188f89affd913e338696 Mon Sep 17 00:00:00 2001
+From 05906e2086b5087d615485ec9a09b1493dbb32e1 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 13 Aug 2021 16:11:53 +0100
-Subject: [PATCH 024/120] Fix V4L2 stateful to avoid crash if flush before
+Subject: [PATCH 024/121] Fix V4L2 stateful to avoid crash if flush before
  start
 
 ---
@@ -15506,7 +15506,7 @@ Subject: [PATCH 024/120] Fix V4L2 stateful to avoid crash if flush before
  1 file changed, 4 insertions(+)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index fc8325a18d..d6243f6b80 100644
+index a17ae027a6..eb901e8fab 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -713,6 +713,10 @@ static int v4l2_get_coded_format(V4L2Context* ctx, uint32_t *p)
@@ -15521,10 +15521,10 @@ index fc8325a18d..d6243f6b80 100644
          struct V4L2Buffer * const buf = (struct V4L2Buffer *)ctx->bufrefs[i]->data;
          if (buf->status == V4L2BUF_IN_DRIVER)
 
-From 3769927973cd27b00743800c8680d33d5982a4fe Mon Sep 17 00:00:00 2001
+From 7157b6032e759078a7d751e5dd5762970f3d1e8c Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 9 Sep 2021 17:44:13 +0100
-Subject: [PATCH 025/120] Copy properties from frame to v4l2 buffer
+Subject: [PATCH 025/121] Copy properties from frame to v4l2 buffer
 
 Now copies all the properties in ff_v4l2_buffer_avframe_to_buf that
 ff_v4l2_buffer_buf_to_avframe copies
@@ -15692,10 +15692,10 @@ index 97b8eb1db3..126d2a17f4 100644
      return v4l2_buffer_swframe_to_buf(frame, out);
  }
 
-From c2c1b11af72cd8bba8140922ff4adab1132f5c3a Mon Sep 17 00:00:00 2001
+From 15415ab226f966fd12e70d79fde3cb80f3d09144 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 17 Nov 2021 16:49:01 +0000
-Subject: [PATCH 026/120] ffmpeg: Do not inc DTS on no decode output
+Subject: [PATCH 026/121] ffmpeg: Do not inc DTS on no decode output
 
 V4L2 H264 decode has long latency and sometimes spits out a long stream
 of output without input. In this case incrementing DTS is wrong. There
@@ -15706,10 +15706,10 @@ the cases which cause problems
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
-index e98f0b8149..517324df3a 100644
+index 5dc2cd73c1..ba0c1898cf 100644
 --- a/fftools/ffmpeg.c
 +++ b/fftools/ffmpeg.c
-@@ -2420,7 +2420,12 @@ static int process_input_packet(InputStream *ist, const AVPacket *pkt, int no_eo
+@@ -2609,7 +2609,12 @@ static int process_input_packet(InputStream *ist, const AVPacket *pkt, int no_eo
          case AVMEDIA_TYPE_VIDEO:
              ret = decode_video    (ist, repeating ? NULL : avpkt, &got_output, &duration_pts, !pkt,
                                     &decode_failed);
@@ -15724,10 +15724,10 @@ index e98f0b8149..517324df3a 100644
                      duration_dts = av_rescale_q(pkt->duration, ist->st->time_base, AV_TIME_BASE_Q);
                  } else if(ist->dec_ctx->framerate.num != 0 && ist->dec_ctx->framerate.den != 0) {
 
-From 4aec8304fb35312e36766efa6844cb4be3b03f50 Mon Sep 17 00:00:00 2001
+From 7bf6c062ed8a1e635aa5722c0072724f236daf00 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 17 Nov 2021 17:32:59 +0000
-Subject: [PATCH 027/120] v4l2_m2m_dec: Adjust timebase if H264
+Subject: [PATCH 027/121] v4l2_m2m_dec: Adjust timebase if H264
 
 Adjust AVCodecContext time_base if H264 in the same way that the
 software decoder does.
@@ -15736,7 +15736,7 @@ software decoder does.
  1 file changed, 10 insertions(+)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index b37b005d3f..5c4c199a79 100644
+index 1851acbc93..aa1e5c1597 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -481,6 +481,16 @@ static av_cold int v4l2_decode_init(AVCodecContext *avctx)
@@ -15757,10 +15757,10 @@ index b37b005d3f..5c4c199a79 100644
      ret = ff_v4l2_m2m_create_context(priv, &s);
      if (ret < 0)
 
-From 818e77a19bbaa4c8d51d68338f801ae4c236fd81 Mon Sep 17 00:00:00 2001
+From 3cd23a761397ae75ed032c1687da5d6b76ddaaaa Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 17 Nov 2021 17:38:27 +0000
-Subject: [PATCH 028/120] v4l2_m2m_dec: Produce best guess PTSs if none
+Subject: [PATCH 028/121] v4l2_m2m_dec: Produce best guess PTSs if none
  supplied
 
 Filter scheduling gets confused by missing PTSs and makes poor guesses
@@ -15802,7 +15802,7 @@ index 8f054f2f50..82feb0afdb 100644
      int req_pkt;
  
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 5c4c199a79..eb19ec422f 100644
+index aa1e5c1597..a5a2afbd27 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -42,6 +42,62 @@
@@ -15892,10 +15892,10 @@ index 5c4c199a79..eb19ec422f 100644
      output = &s->output;
  
 
-From 95182698a54c9656e004479023bcc3bef5b4c6fa Mon Sep 17 00:00:00 2001
+From ee8be1e900f98212b6c4940980cc7a80becfc07c Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 17 Nov 2021 17:59:27 +0000
-Subject: [PATCH 029/120] v4l2_m2m_dec: Try harder to get an initial frame
+Subject: [PATCH 029/121] v4l2_m2m_dec: Try harder to get an initial frame
 
 If the input Q is full then wait on a short timeout for a capture frame
 rather than stuffing yet still another frame into the input if we could
@@ -15907,7 +15907,7 @@ buffering that ends up confusing the rest of the system.
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index d6243f6b80..3c01e95ea1 100644
+index eb901e8fab..ee5dc7b8d4 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -381,7 +381,7 @@ static V4L2Buffer* v4l2_dequeue_v4l2buf(V4L2Context *ctx, int timeout)
@@ -15920,7 +15920,7 @@ index d6243f6b80..3c01e95ea1 100644
      } else {
          pfd.events =  POLLOUT | POLLWRNORM;
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index eb19ec422f..f05f2927e6 100644
+index a5a2afbd27..b49f470c0a 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -442,7 +442,7 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -15933,10 +15933,10 @@ index eb19ec422f..f05f2927e6 100644
                  if (dst_rv == AVERROR_EOF && (s->draining || s->capture.done))
                      av_log(avctx, AV_LOG_DEBUG, "Dequeue EOF: draining=%d, cap.done=%d\n",
 
-From e979ff9809197ad46c299031c4ee39facdadef31 Mon Sep 17 00:00:00 2001
+From 72da14331c2160a12b69d666d493e0e74c5e8914 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 17 Nov 2021 18:04:56 +0000
-Subject: [PATCH 030/120] Add a V4L2 M2M deinterlace filter
+Subject: [PATCH 030/121] Add a V4L2 M2M deinterlace filter
 
 Add a V4L2 deinterlace filter that will accept DRMPRIME frames.
 
@@ -15958,7 +15958,7 @@ lost at end of stream as the V4L2 filter has no flush control.
  create mode 100644 libavfilter/vf_deinterlace_v4l2m2m.c
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 3c01e95ea1..964c17ac0e 100644
+index ee5dc7b8d4..440dfaaba5 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -498,10 +498,10 @@ dequeue:
@@ -15975,22 +15975,22 @@ index 3c01e95ea1..964c17ac0e 100644
          avbuf = (V4L2Buffer *)ctx->bufrefs[buf.index]->data;
          avbuf->status = V4L2BUF_AVAILABLE;
 diff --git a/libavfilter/Makefile b/libavfilter/Makefile
-index 6db336e74a..394e61a0c2 100644
+index c14fc995a0..0e7b5856bd 100644
 --- a/libavfilter/Makefile
 +++ b/libavfilter/Makefile
-@@ -254,6 +254,7 @@ OBJS-$(CONFIG_DEFLATE_FILTER)                += vf_neighbor.o
+@@ -262,6 +262,7 @@ OBJS-$(CONFIG_DEFLATE_FILTER)                += vf_neighbor.o
  OBJS-$(CONFIG_DEFLICKER_FILTER)              += vf_deflicker.o
- OBJS-$(CONFIG_DEINTERLACE_QSV_FILTER)        += vf_deinterlace_qsv.o
+ OBJS-$(CONFIG_DEINTERLACE_QSV_FILTER)        += vf_vpp_qsv.o
  OBJS-$(CONFIG_DEINTERLACE_VAAPI_FILTER)      += vf_deinterlace_vaapi.o vaapi_vpp.o
 +OBJS-$(CONFIG_DEINTERLACE_V4L2M2M_FILTER)    += vf_deinterlace_v4l2m2m.o
  OBJS-$(CONFIG_DEJUDDER_FILTER)               += vf_dejudder.o
  OBJS-$(CONFIG_DELOGO_FILTER)                 += vf_delogo.o
  OBJS-$(CONFIG_DENOISE_VAAPI_FILTER)          += vf_misc_vaapi.o vaapi_vpp.o
 diff --git a/libavfilter/allfilters.c b/libavfilter/allfilters.c
-index 4bf3a5cfd8..9b17c37eb3 100644
+index b990a00152..357ff61ca8 100644
 --- a/libavfilter/allfilters.c
 +++ b/libavfilter/allfilters.c
-@@ -242,6 +242,7 @@ extern const AVFilter ff_vf_derain;
+@@ -248,6 +248,7 @@ extern const AVFilter ff_vf_derain;
  extern const AVFilter ff_vf_deshake;
  extern const AVFilter ff_vf_deshake_opencl;
  extern const AVFilter ff_vf_despill;
@@ -17274,10 +17274,10 @@ index 0000000000..1a933b7e0a
 +    .activate       = deint_v4l2m2m_activate,
 +};
 
-From 6f07e022369785213d78b1f211e47adab47f4df2 Mon Sep 17 00:00:00 2001
+From 0fb00e51d1ca40eed22bfc66b7f309fdc56229bc Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 2 Dec 2021 17:49:55 +0000
-Subject: [PATCH 031/120] Put no_pts_rescale in context which makes more sense
+Subject: [PATCH 031/121] Put no_pts_rescale in context which makes more sense
  than an arg
 
 ---
@@ -17429,7 +17429,7 @@ index 111526aee3..641e0e147b 100644
  /**
   * Extracts the data from an AVFrame to a V4L2Buffer
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 964c17ac0e..9de5838256 100644
+index 440dfaaba5..64540a37b3 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -808,7 +808,7 @@ int ff_v4l2_context_enqueue_frame(V4L2Context* ctx, const AVFrame* frame)
@@ -17510,7 +17510,7 @@ index 37b0431400..4cc164886c 100644
  /**
   * Enqueues a buffer to a V4L2Context from an AVFrame
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index f05f2927e6..d341f14a3d 100644
+index b49f470c0a..36754b314a 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -360,7 +360,7 @@ static int try_enqueue_src(AVCodecContext * const avctx, V4L2m2mContext * const
@@ -17555,17 +17555,17 @@ index f05f2927e6..d341f14a3d 100644
      /* the client requests the codec to generate DRM frames:
       *   - data[0] will therefore point to the returned AVDRMFrameDescriptor
 
-From 57ce5bd1dce97117cce25c215265582c6236784b Mon Sep 17 00:00:00 2001
+From 5e36908e6f2f06b68e85873cbcd421c0973f6409 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 8 Dec 2021 15:00:37 +0000
-Subject: [PATCH 032/120] Use bitbuf min size for all streams
+Subject: [PATCH 032/121] Use bitbuf min size for all streams
 
 ---
  libavcodec/v4l2_m2m_dec.c | 5 +----
  1 file changed, 1 insertion(+), 4 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index d341f14a3d..422a89edec 100644
+index 36754b314a..48a6810d18 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -507,15 +507,12 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -17586,10 +17586,10 @@ index d341f14a3d..422a89edec 100644
      // H.264 Annex A table A-1 gives minCR which is either 2 or 4
      // unfortunately that doesn't yield an actually useful limit
 
-From 71a71bd52921753815acf5ad5c4e3288597f1cb4 Mon Sep 17 00:00:00 2001
+From 5fcbcd31761eea31dc0157793f558eaaadfe2ac3 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 3 Dec 2021 12:54:18 +0000
-Subject: [PATCH 033/120] Track pending frames in v4l2 stateful
+Subject: [PATCH 033/121] Track pending frames in v4l2 stateful
 
 Track which frames are pending decode in the v4l2 stateful decoder.
 This relies on DTS & PTS having some relationship to reality, so
@@ -17645,7 +17645,7 @@ index 82feb0afdb..3f86809623 100644
      pts_stats_t pts_stat;
  
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 422a89edec..859fecdb77 100644
+index 48a6810d18..d8ebb466cd 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -242,22 +242,24 @@ static inline unsigned int pts_to_track(AVCodecContext *avctx, const int64_t pts
@@ -17844,10 +17844,10 @@ index 422a89edec..859fecdb77 100644
      // resend extradata
      s->extdata_sent = 0;
 
-From 7931bfc9d3e4f30dcc3ab00557c3d0cb2d504516 Mon Sep 17 00:00:00 2001
+From 6fae7b3f42c8e9e431a59323c0faa6c88fe951d9 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 15 Dec 2021 17:58:21 +0000
-Subject: [PATCH 034/120] Use pending tracking to reduce v4l2 latency
+Subject: [PATCH 034/121] Use pending tracking to reduce v4l2 latency
 
 If there are more than 5 pending decodes outstanding then add a small
 timeout to the capture poll to reduce the rate at which frames are
@@ -17857,7 +17857,7 @@ added.
  1 file changed, 36 insertions(+), 22 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 859fecdb77..4d2ef92cbe 100644
+index d8ebb466cd..7e7e4729d0 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -370,16 +370,19 @@ static inline int stream_started(const V4L2m2mContext * const s) {
@@ -17967,10 +17967,10 @@ index 859fecdb77..4d2ef92cbe 100644
  #if 0
      if (dst_rv == 0)
 
-From 4425e0ed76c02fcd6dcf84e29c8e28a5aa7bbaf5 Mon Sep 17 00:00:00 2001
+From 175abd2eb961a3718a660e1f9eda08b37b01b309 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 15 Dec 2021 12:23:54 +0000
-Subject: [PATCH 035/120] Allow logger() to take const ctx
+Subject: [PATCH 035/121] Allow logger() to take const ctx
 
 ---
  libavcodec/v4l2_buffers.c | 2 +-
@@ -17991,7 +17991,7 @@ index 22da6bd722..39c0094aec 100644
      return buf_to_m2mctx(buf)->avctx;
  }
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 9de5838256..9833e903c2 100644
+index 64540a37b3..d3df48aed4 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -43,14 +43,14 @@ struct v4l2_format_update {
@@ -18012,10 +18012,10 @@ index 9de5838256..9833e903c2 100644
      return ctx_to_m2mctx(ctx)->avctx;
  }
 
-From be9d93d6adcb4d4286e39adde9f192eca7812d52 Mon Sep 17 00:00:00 2001
+From 21d4f3f644c45084c621cb5aa577169bf5c15017 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 15 Dec 2021 13:00:27 +0000
-Subject: [PATCH 036/120] Track numbere of bufs qed with an atomic
+Subject: [PATCH 036/121] Track numbere of bufs qed with an atomic
 
 Safer and faster than counting status
 ---
@@ -18051,7 +18051,7 @@ index 39c0094aec..2cf7be6632 100644
      avbuf->status = V4L2BUF_IN_DRIVER;
  
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 9833e903c2..59cc7f0e76 100644
+index d3df48aed4..268a057e53 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -599,7 +599,7 @@ static int v4l2_release_buffers(V4L2Context* ctx)
@@ -18086,17 +18086,17 @@ index 4cc164886c..a4176448d5 100644
  
      AVMutex lock;
 
-From c9b50f79590acfc352d7023dba4263acfe7b1f29 Mon Sep 17 00:00:00 2001
+From b2fa4ab3d63924597b8c3659123b145a786a2c13 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 9 Dec 2021 12:01:25 +0000
-Subject: [PATCH 037/120] Clear pkt_buf on flush
+Subject: [PATCH 037/121] Clear pkt_buf on flush
 
 ---
  libavcodec/v4l2_m2m_dec.c | 3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 4d2ef92cbe..94a32a5eee 100644
+index 7e7e4729d0..09ec496351 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -715,6 +715,9 @@ static void v4l2_decode_flush(AVCodecContext *avctx)
@@ -18110,10 +18110,10 @@ index 4d2ef92cbe..94a32a5eee 100644
      // so mark all frames we are tracking to be discarded if they appear
      xlat_flush(&s->xlat);
 
-From bdf67cec94f343dbd6dc7708ee96ea645ae7d9cb Mon Sep 17 00:00:00 2001
+From 16cf94cb5e1d11f4c3a6b8a43557383ce78112e0 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 15 Dec 2021 12:52:56 +0000
-Subject: [PATCH 038/120] Rework v4l2 buffer dequeue
+Subject: [PATCH 038/121] Rework v4l2 buffer dequeue
 
 ---
  libavcodec/v4l2_context.c | 543 ++++++++++++++++++--------------------
@@ -18124,7 +18124,7 @@ Subject: [PATCH 038/120] Rework v4l2 buffer dequeue
  5 files changed, 327 insertions(+), 373 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 59cc7f0e76..fe21218710 100644
+index 268a057e53..d765181645 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -73,19 +73,27 @@ static AVRational v4l2_get_sar(V4L2Context *ctx)
@@ -18848,10 +18848,10 @@ index a4176448d5..565858a1ed 100644
       * PTS rescale not wanted
       * If the PTS is just a dummy frame count then rescale is
 diff --git a/libavcodec/v4l2_m2m.c b/libavcodec/v4l2_m2m.c
-index 50a192933b..5b38ad3598 100644
+index 516e6d9858..e26bd74c3e 100644
 --- a/libavcodec/v4l2_m2m.c
 +++ b/libavcodec/v4l2_m2m.c
-@@ -233,7 +233,6 @@ int ff_v4l2_m2m_codec_reinit(V4L2m2mContext *s)
+@@ -235,7 +235,6 @@ int ff_v4l2_m2m_codec_reinit(V4L2m2mContext *s)
  
      /* 5. complete reinit */
      s->draining = 0;
@@ -18901,7 +18901,7 @@ index 3f86809623..d71f6b721c 100644
  
  #endif /* AVCODEC_V4L2_M2M_H */
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 94a32a5eee..d09b9f6a6d 100644
+index 09ec496351..e4b6569ba5 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -113,9 +113,6 @@ static int check_output_streamon(AVCodecContext *const avctx, V4L2m2mContext *co
@@ -19147,17 +19147,17 @@ index 94a32a5eee..d09b9f6a6d 100644
      // so mark all frames we are tracking to be discarded if they appear
      xlat_flush(&s->xlat);
 
-From e44ac2d67a09e89678c0b6a13329295f0755c22d Mon Sep 17 00:00:00 2001
+From a2519f7a512edde7433aced70de4464e21805693 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 9 Dec 2021 18:51:00 +0000
-Subject: [PATCH 039/120] Honor result of ff_get_format if possible
+Subject: [PATCH 039/121] Honor result of ff_get_format if possible
 
 ---
  libavcodec/v4l2_m2m_dec.c | 6 +++++-
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index d09b9f6a6d..db87cc5d72 100644
+index e4b6569ba5..c9655bcc3b 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -615,15 +615,19 @@ static av_cold int v4l2_decode_init(AVCodecContext *avctx)
@@ -19182,10 +19182,10 @@ index d09b9f6a6d..db87cc5d72 100644
      s->device_ref = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_DRM);
      if (!s->device_ref) {
 
-From 2e5821bb8fb333bd971878796f721544f9c26df0 Mon Sep 17 00:00:00 2001
+From a1cd1cb98e48c631392b385ccac5ab7b09bb5ee9 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 14 Dec 2021 16:11:10 +0000
-Subject: [PATCH 040/120] Add an always-reinit quirk
+Subject: [PATCH 040/121] Add an always-reinit quirk
 
 ---
  libavcodec/v4l2_context.c |  7 +++++--
@@ -19194,7 +19194,7 @@ Subject: [PATCH 040/120] Add an always-reinit quirk
  3 files changed, 42 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index fe21218710..6e2e5f24ad 100644
+index d765181645..c11b5e6863 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -188,6 +188,9 @@ static int do_source_change(V4L2m2mContext * const s)
@@ -19237,7 +19237,7 @@ index d71f6b721c..f1923bb26d 100644
  
  typedef struct V4L2m2mPriv {
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index db87cc5d72..f39f3e7ee2 100644
+index c9655bcc3b..e2b10f5e3a 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -540,6 +540,34 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -19288,10 +19288,10 @@ index db87cc5d72..f39f3e7ee2 100644
  
  static av_cold int v4l2_decode_close(AVCodecContext *avctx)
 
-From 69d3d78fb855652b5816833ec619ef90c9bb33b3 Mon Sep 17 00:00:00 2001
+From 2470968adf0d28bbaf310e782720dd00d57d7bf6 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 4 Jan 2022 16:58:31 +0000
-Subject: [PATCH 041/120] v4l2_buffers: rework flags for keyframe
+Subject: [PATCH 041/121] v4l2_buffers: rework flags for keyframe
 
 Previously flags could become confused and keyframe info could be lost.
 This fixes that and removes the duplicate flags field in V4L2Buffer.
@@ -19361,7 +19361,7 @@ index 641e0e147b..3b7ca4d99e 100644
  
  } V4L2Buffer;
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 6e2e5f24ad..d8a86e8261 100644
+index c11b5e6863..53b522d43e 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -527,6 +527,22 @@ get_qbuf(V4L2Context * const ctx, V4L2Buffer ** const ppavbuf, const int timeout
@@ -19397,10 +19397,10 @@ index 6e2e5f24ad..d8a86e8261 100644
  
      return NULL;
 
-From 95cdef2adcd0623098b34a2f7ce489c0af4a819a Mon Sep 17 00:00:00 2001
+From 5dc38f5d088beea4da57e82969643cc831c40cf0 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 22 Mar 2022 11:44:30 +0000
-Subject: [PATCH 042/120] v4l2m2m: Rework decode to wait for missing buffer,
+Subject: [PATCH 042/121] v4l2m2m: Rework decode to wait for missing buffer,
  add dynamic pending
 
 Previously receive_frame exited with EAGAIN if no capture buffer
@@ -19441,7 +19441,7 @@ index 62d1c26053..8c4f18dbed 100644
      return 0;
  }
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index d8a86e8261..1aff16c1de 100644
+index 53b522d43e..7ddb759810 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -300,6 +300,7 @@ static int v4l2_stop_encode(V4L2Context *ctx)
@@ -19521,7 +19521,7 @@ index f1923bb26d..9a20447030 100644
      pts_stats_t pts_stat;
  
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index f39f3e7ee2..ab3584238d 100644
+index e2b10f5e3a..2e30449dfc 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -251,7 +251,8 @@ xlat_pts_out(AVCodecContext *const avctx,
@@ -19617,10 +19617,10 @@ index f39f3e7ee2..ab3584238d 100644
      capture = &s->capture;
      output = &s->output;
 
-From 123466d58bdd4529fea70395f8201c78bfc5bc8a Mon Sep 17 00:00:00 2001
+From 33765b769b4301e03f31b65e225fcdb0eff4c0e4 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 25 Mar 2022 15:37:58 +0000
-Subject: [PATCH 043/120] v4l2_m2m2_dec: Avoid loop if unable to resize buffers
+Subject: [PATCH 043/121] v4l2_m2m2_dec: Avoid loop if unable to resize buffers
 
 If source change signals a buffer size that cannot be honored give up
 rather than looping indefinitely.  This happens on Pi if (say) a
@@ -19630,7 +19630,7 @@ rather than looping indefinitely.  This happens on Pi if (say) a
  1 file changed, 11 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 1aff16c1de..e4c848d6da 100644
+index 7ddb759810..007a58c8f1 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -205,8 +205,9 @@ static int do_source_change(V4L2m2mContext * const s)
@@ -19664,10 +19664,10 @@ index 1aff16c1de..e4c848d6da 100644
              avctx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
              avctx->sw_pix_fmt = s->capture.av_pix_fmt;
 
-From 38f2aeca1d38db698686a41f87147d97e18e88db Mon Sep 17 00:00:00 2001
+From bb7ad2392ce83149a1ba40ecacb36e051b6bf785 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 25 Mar 2022 18:14:40 +0000
-Subject: [PATCH 044/120] v4l2dec: Improve size/format validation on init
+Subject: [PATCH 044/121] v4l2dec: Improve size/format validation on init
 
 ---
  libavcodec/v4l2_m2m_dec.c      | 84 ++++++++++++++++++++++++++++++++--
@@ -19675,7 +19675,7 @@ Subject: [PATCH 044/120] v4l2dec: Improve size/format validation on init
  2 files changed, 92 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index ab3584238d..f598072b94 100644
+index 2e30449dfc..8dcadf461b 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -592,6 +592,76 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -19806,10 +19806,10 @@ index b0a5930844..76ab0916cd 100644
          av_log(avctx, AV_LOG_WARNING, "Failed to find any V4L2 devices\n");
          return (AVERROR(-ret));
 
-From 1c64aa3f328d594db17b90d837c2435b5ab1f460 Mon Sep 17 00:00:00 2001
+From 4646b558c0e45f506578a5a452820f55983abc82 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 13 Apr 2022 16:05:56 +0000
-Subject: [PATCH 045/120] v4l2 stateless hevc: Add another API variation for
+Subject: [PATCH 045/121] v4l2 stateless hevc: Add another API variation for
  linux 5.18
 
 This is probably going to be a short lived variation and may end up
@@ -19828,10 +19828,10 @@ being reverted if no release using it ever ends up in the wild.
  create mode 100644 libavcodec/v4l2_req_hevc_v3.c
 
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index a40c46bf93..09962a810b 100644
+index e1aa0ba014..2b3c16185d 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -976,7 +976,7 @@ OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
+@@ -1000,7 +1000,7 @@ OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_NVDEC_HWACCEL)         += nvdec_hevc.o
  OBJS-$(CONFIG_HEVC_QSV_HWACCEL)           += qsvdec.o
  OBJS-$(CONFIG_HEVC_V4L2REQUEST_HWACCEL)   += v4l2_request_hevc.o v4l2_req_decode_q.o\
@@ -20252,10 +20252,10 @@ index f14f594564..ed48d62e2d 100644
  
  #endif
 
-From 920f91ffbcd3b8f4834ff6d903df7212a958486d Mon Sep 17 00:00:00 2001
+From 92160173e701aa7e2f1011e63596e48d15e691a9 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 3 May 2022 12:44:42 +0000
-Subject: [PATCH 046/120] Remove V4l2 frame size check for meson-vdec
+Subject: [PATCH 046/121] Remove V4l2 frame size check for meson-vdec
 
 ---
  libavcodec/v4l2_m2m.h     |  3 ++-
@@ -20277,7 +20277,7 @@ index 9a20447030..6bd5e8eda7 100644
      unsigned int quirks;
  
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index f598072b94..8328a78930 100644
+index 8dcadf461b..888ba67fea 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -604,6 +604,10 @@ check_size(AVCodecContext * const avctx, V4L2m2mContext * const s)
@@ -20312,10 +20312,10 @@ index f598072b94..8328a78930 100644
      av_log(avctx, AV_LOG_DEBUG, "Driver '%s': Quirks=%#x\n", cap.driver, s->quirks);
      return 0;
 
-From 6d0e620abd7501c0c365e6f94b8937b55e7adf8f Mon Sep 17 00:00:00 2001
+From 8ba5576e7fcd24c2f450f0295cc3b6d8e82e8649 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 23 May 2022 18:05:20 +0100
-Subject: [PATCH 047/120] v4l2m2m_dec: Make some error rturns a bit more robust
+Subject: [PATCH 047/121] v4l2m2m_dec: Make some error rturns a bit more robust
 
 ---
  libavcodec/v4l2_context.c |  5 ++---
@@ -20323,7 +20323,7 @@ Subject: [PATCH 047/120] v4l2m2m_dec: Make some error rturns a bit more robust
  2 files changed, 16 insertions(+), 12 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index e4c848d6da..c0d257e5d3 100644
+index 007a58c8f1..b3662aedaa 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -765,7 +765,7 @@ static int stuff_all_buffers(AVCodecContext * avctx, V4L2Context* ctx)
@@ -20346,7 +20346,7 @@ index e4c848d6da..c0d257e5d3 100644
          av_log(avctx, AV_LOG_ERROR, "%s set status %d (%s) failed: err=%d\n", ctx->name,
                 cmd, (cmd == VIDIOC_STREAMON) ? "ON" : "OFF", err);
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 8328a78930..00d2d46d5d 100644
+index 888ba67fea..88a341aae2 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -110,16 +110,21 @@ static int check_output_streamon(AVCodecContext *const avctx, V4L2m2mContext *co
@@ -20381,10 +20381,10 @@ index 8328a78930..00d2d46d5d 100644
  
  static int v4l2_try_start(AVCodecContext *avctx)
 
-From e1a8efe55dd299dfecd9c0ada3b497d7c6f50cd8 Mon Sep 17 00:00:00 2001
+From aafa5968f8713319be35cf26069c98566d5bf59b Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 24 May 2022 17:02:58 +0000
-Subject: [PATCH 048/120] v4l2m2m_dec: Support in-pkt AV_PKT_DATA_NEW_EXTRADATA
+Subject: [PATCH 048/121] v4l2m2m_dec: Support in-pkt AV_PKT_DATA_NEW_EXTRADATA
 
 Support packet side-data containing AV_PKT_DATA_NEW_EXTRADATA.  Should
 also detect and complain about unexpected streams of empty packets.
@@ -20398,10 +20398,10 @@ NEW_EXTRADATA side data.
  3 files changed, 50 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m.c b/libavcodec/v4l2_m2m.c
-index 5b38ad3598..728932fadc 100644
+index e26bd74c3e..6dd01e2e00 100644
 --- a/libavcodec/v4l2_m2m.c
 +++ b/libavcodec/v4l2_m2m.c
-@@ -249,6 +249,7 @@ static void v4l2_m2m_destroy_context(void *opaque, uint8_t *context)
+@@ -251,6 +251,7 @@ static void v4l2_m2m_destroy_context(void *opaque, uint8_t *context)
      av_frame_unref(s->frame);
      av_frame_free(&s->frame);
      av_packet_unref(&s->buf_pkt);
@@ -20424,7 +20424,7 @@ index 6bd5e8eda7..19d618698d 100644
  #define FF_V4L2_QUIRK_REINIT_ALWAYS             1
  #define FF_V4L2_QUIRK_ENUM_FRAMESIZES_BROKEN    2
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 00d2d46d5d..2f20fc9ad8 100644
+index 88a341aae2..392a68f0c7 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -343,7 +343,46 @@ static int try_enqueue_src(AVCodecContext * const avctx, V4L2m2mContext * const
@@ -20491,17 +20491,17 @@ index 00d2d46d5d..2f20fc9ad8 100644
      if (ret == AVERROR(EAGAIN)) {
          // Out of input buffers - keep packet
 
-From 0797fef446b16f03214043e93e7dadaace02e6e6 Mon Sep 17 00:00:00 2001
+From e9bced67bdb40096d31067d41956276e9e1af11a Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 24 May 2022 20:02:48 +0000
-Subject: [PATCH 049/120] v4l2m2m_dec: Catch repeated Q fulls
+Subject: [PATCH 049/121] v4l2m2m_dec: Catch repeated Q fulls
 
 ---
  libavcodec/v4l2_m2m_dec.c | 8 +++++++-
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 2f20fc9ad8..4765fe0d5e 100644
+index 392a68f0c7..7e17044706 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -504,13 +504,14 @@ static int qbuf_wait(AVCodecContext * const avctx, V4L2Context * const ctx)
@@ -20533,10 +20533,10 @@ index 2f20fc9ad8..4765fe0d5e 100644
          // (a) we haven't already got one AND
          // (b) enqueue returned a status indicating that decode should be attempted
 
-From 8c842b220b9d55ff37f7149f198d6dfba532558f Mon Sep 17 00:00:00 2001
+From 0c974e4da2c0311836145f2fd42081d40eb15998 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 25 May 2022 15:22:12 +0000
-Subject: [PATCH 050/120] Remove requirement for epoxy & libudev config options
+Subject: [PATCH 050/121] Remove requirement for epoxy & libudev config options
 
 ---
  configure              | 26 +++++++++++++++++---------
@@ -20544,7 +20544,7 @@ Subject: [PATCH 050/120] Remove requirement for epoxy & libudev config options
  2 files changed, 17 insertions(+), 11 deletions(-)
 
 diff --git a/configure b/configure
-index 8424d451fb..a8e7ee5dab 100755
+index b41663c794..fdc95146bf 100755
 --- a/configure
 +++ b/configure
 @@ -205,6 +205,7 @@ External library support:
@@ -20564,7 +20564,7 @@ index 8424d451fb..a8e7ee5dab 100755
    --enable-libv4l2         enable libv4l2/v4l-utils [no]
    --enable-libvidstab      enable video stabilization using vid.stab [no]
    --enable-libvmaf         enable vmaf filter via libvmaf [no]
-@@ -1759,7 +1760,9 @@ EXTERNAL_AUTODETECT_LIBRARY_LIST="
+@@ -1747,7 +1748,9 @@ EXTERNAL_AUTODETECT_LIBRARY_LIST="
      avfoundation
      bzlib
      coreimage
@@ -20574,7 +20574,7 @@ index 8424d451fb..a8e7ee5dab 100755
      libxcb
      libxcb_shm
      libxcb_shape
-@@ -1831,7 +1834,6 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1819,7 +1822,6 @@ EXTERNAL_LIBRARY_LIST="
      libdav1d
      libdc1394
      libdrm
@@ -20582,7 +20582,7 @@ index 8424d451fb..a8e7ee5dab 100755
      libflite
      libfontconfig
      libfreetype
-@@ -1875,7 +1877,6 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1863,7 +1865,6 @@ EXTERNAL_LIBRARY_LIST="
      libtheora
      libtwolame
      libuavs3d
@@ -20590,7 +20590,7 @@ index 8424d451fb..a8e7ee5dab 100755
      libv4l2
      libvmaf
      libvorbis
-@@ -3557,9 +3558,8 @@ v4l2_indev_suggest="libv4l2"
+@@ -3567,9 +3568,8 @@ v4l2_indev_suggest="libv4l2"
  v4l2_outdev_deps="libdrm"
  v4l2_outdev_deps_any="linux_videodev2_h sys_videoio_h"
  v4l2_outdev_suggest="libv4l2"
@@ -20602,7 +20602,7 @@ index 8424d451fb..a8e7ee5dab 100755
  vfwcap_indev_deps="vfw32 vfwcap_defines"
  xcbgrab_indev_deps="libxcb"
  xcbgrab_indev_suggest="libxcb_shm libxcb_shape libxcb_xfixes"
-@@ -6316,6 +6316,12 @@ if enabled xlib; then
+@@ -6355,6 +6355,12 @@ if enabled xlib; then
          disable xlib
  fi
  
@@ -20615,7 +20615,7 @@ index 8424d451fb..a8e7ee5dab 100755
  check_headers direct.h
  check_headers dirent.h
  check_headers dxgidebug.h
-@@ -6561,7 +6567,6 @@ enabled libdav1d          && require_pkg_config libdav1d "dav1d >= 0.5.0" "dav1d
+@@ -6601,7 +6607,6 @@ enabled libdav1d          && require_pkg_config libdav1d "dav1d >= 0.5.0" "dav1d
  enabled libdavs2          && require_pkg_config libdavs2 "davs2 >= 1.6.0" davs2.h davs2_decoder_open
  enabled libdc1394         && require_pkg_config libdc1394 libdc1394-2 dc1394/dc1394.h dc1394_new
  enabled libdrm            && require_pkg_config libdrm libdrm xf86drm.h drmGetVersion
@@ -20623,7 +20623,7 @@ index 8424d451fb..a8e7ee5dab 100755
  enabled libfdk_aac        && { check_pkg_config libfdk_aac fdk-aac "fdk-aac/aacenc_lib.h" aacEncOpen ||
                                 { require libfdk_aac fdk-aac/aacenc_lib.h aacEncOpen -lfdk-aac &&
                                   warn "using libfdk without pkg-config"; } }
-@@ -6655,7 +6660,6 @@ enabled libtwolame        && require libtwolame twolame.h twolame_init -ltwolame
+@@ -6713,7 +6718,6 @@ enabled libtwolame        && require libtwolame twolame.h twolame_init -ltwolame
                               { check_lib libtwolame twolame.h twolame_encode_buffer_float32_interleaved -ltwolame ||
                                 die "ERROR: libtwolame must be installed and version must be >= 0.3.10"; }
  enabled libuavs3d         && require_pkg_config libuavs3d "uavs3d >= 1.1.41" uavs3d.h uavs3d_decode
@@ -20631,7 +20631,7 @@ index 8424d451fb..a8e7ee5dab 100755
  enabled libv4l2           && require_pkg_config libv4l2 libv4l2 libv4l2.h v4l2_ioctl
  enabled libvidstab        && require_pkg_config libvidstab "vidstab >= 0.98" vid.stab/libvidstab.h vsMotionDetectInit
  enabled libvmaf           && require_pkg_config libvmaf "libvmaf >= 2.0.0" libvmaf.h vmaf_init
-@@ -6760,9 +6764,13 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
+@@ -6819,9 +6823,13 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
  enabled v4l2_request      && { enabled libdrm ||
                                 die "ERROR: v4l2-request requires --enable-libdrm"; } &&
                               { enabled libudev ||
@@ -20660,10 +20660,10 @@ index 65576846e8..37cea71756 100755
   --enable-vout-drm\
   $SHARED_LIBS\
 
-From c01515bd877dcdcdef86babbe93bdd847236d886 Mon Sep 17 00:00:00 2001
+From 9f234d8cbde2829e6a70fd3cb6324998df8a31f3 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 27 May 2022 09:36:51 +0000
-Subject: [PATCH 051/120] hevc: If hwaccel avoid creation of s/w only vars
+Subject: [PATCH 051/121] hevc: If hwaccel avoid creation of s/w only vars
 
 ---
  libavcodec/hevc_refs.c | 35 +++++++++++++++++++++--------------
@@ -20671,7 +20671,7 @@ Subject: [PATCH 051/120] hevc: If hwaccel avoid creation of s/w only vars
  2 files changed, 50 insertions(+), 27 deletions(-)
 
 diff --git a/libavcodec/hevc_refs.c b/libavcodec/hevc_refs.c
-index 6a70c817b0..829943f910 100644
+index 811e8feff8..f7cf14eabc 100644
 --- a/libavcodec/hevc_refs.c
 +++ b/libavcodec/hevc_refs.c
 @@ -98,18 +98,22 @@ static HEVCFrame *alloc_frame(HEVCContext *s)
@@ -20708,7 +20708,7 @@ index 6a70c817b0..829943f910 100644
  
          frame->frame->top_field_first  = s->sei.picture_timing.picture_struct == AV_PICTURE_STRUCTURE_TOP_FIELD;
          frame->frame->interlaced_frame = (s->sei.picture_timing.picture_struct == AV_PICTURE_STRUCTURE_TOP_FIELD) || (s->sei.picture_timing.picture_struct == AV_PICTURE_STRUCTURE_BOTTOM_FIELD);
-@@ -284,14 +288,17 @@ static int init_slice_rpl(HEVCContext *s)
+@@ -297,14 +301,17 @@ static int init_slice_rpl(HEVCContext *s)
      int ctb_count    = frame->ctb_count;
      int ctb_addr_ts  = s->ps.pps->ctb_addr_rs_to_ts[s->sh.slice_segment_addr];
      int i;
@@ -20730,10 +20730,10 @@ index 6a70c817b0..829943f910 100644
      return 0;
  }
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index a2c43b888b..cd13de2603 100644
+index 2867cb2e16..17f53322fb 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -524,6 +524,16 @@ static int set_sps(HEVCContext *s, const HEVCSPS *sps,
+@@ -536,6 +536,16 @@ static int set_sps(HEVCContext *s, const HEVCSPS *sps,
      if (!sps)
          return 0;
  
@@ -20750,7 +20750,7 @@ index a2c43b888b..cd13de2603 100644
      ret = pic_arrays_init(s, sps);
      if (ret < 0)
          goto fail;
-@@ -3028,11 +3038,13 @@ static int hevc_frame_start(HEVCContext *s)
+@@ -2890,11 +2900,13 @@ static int hevc_frame_start(HEVCContext *s)
                             ((s->ps.sps->height >> s->ps.sps->log2_min_cb_size) + 1);
      int ret;
  
@@ -20769,7 +20769,7 @@ index a2c43b888b..cd13de2603 100644
  
      s->is_decoded        = 0;
      s->first_nal_type    = s->nal_unit_type;
-@@ -3580,15 +3592,19 @@ static int hevc_ref_frame(HEVCContext *s, HEVCFrame *dst, HEVCFrame *src)
+@@ -3438,15 +3450,19 @@ static int hevc_ref_frame(HEVCContext *s, HEVCFrame *dst, HEVCFrame *src)
          dst->needs_fg = 1;
      }
  
@@ -20798,10 +20798,10 @@ index a2c43b888b..cd13de2603 100644
      dst->rpl_buf = av_buffer_ref(src->rpl_buf);
      if (!dst->rpl_buf)
 
-From 0d7f7c86342a306c9d547c97e9602537ffa3cd0f Mon Sep 17 00:00:00 2001
+From bb2ddc480634141bed9afd3f66e7f63f5091bb2f Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 30 May 2022 17:51:44 +0100
-Subject: [PATCH 052/120] rpi_sand: Add SAND30->NV12 conversion
+Subject: [PATCH 052/121] rpi_sand: Add SAND30->NV12 conversion
 
 C code only. Reworks the hwcontext_drm conversion to use the
 rpi_sand_fns generic frame convert fn rather than calling the
@@ -21020,10 +21020,10 @@ index 634b55e800..462ccb8abd 100644
  // w/h in pixels
  void av_rpi_sand16_to_sand8(uint8_t * dst, const unsigned int dst_stride1, const unsigned int dst_stride2,
 
-From bc6fdb0674a89cb9f83538beff47cf54e78a4502 Mon Sep 17 00:00:00 2001
+From b55c351e6954c800229d97dc6c982ca8f998c848 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 1 Jun 2022 17:49:26 +0000
-Subject: [PATCH 053/120] rpi_sand: Add SAND30->NV12 asm for Armv7 & Armv8
+Subject: [PATCH 053/121] rpi_sand: Add SAND30->NV12 asm for Armv7 & Armv8
 
 Also reworks the previous Armv8 SAND30->Y16 function in a slightly more
 efficient way that makes it look more like the Armv7 version.
@@ -21959,10 +21959,10 @@ index 256c3d532f..b6071e2928 100644
          ff_rpi_sand30_lines_to_planar_y8(dst, dst_stride, src, stride1, stride2, _x, y, _w, h);
          return;
 
-From 34163b056f9425a5e75440dc045459e451aafc0b Mon Sep 17 00:00:00 2001
+From 24c3eef4487a36d5189ecd934b65a7c6a0b53d03 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 7 Jun 2022 14:46:12 +0000
-Subject: [PATCH 054/120] v4l2_m2m_enc: Add the ability to encode DRM_PRIME
+Subject: [PATCH 054/121] v4l2_m2m_enc: Add the ability to encode DRM_PRIME
  frames
 
 ---
@@ -22269,7 +22269,7 @@ index 3b7ca4d99e..1ac32c5989 100644
  
  #endif // AVCODEC_V4L2_BUFFERS_H
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index c0d257e5d3..3ed5234be4 100644
+index b3662aedaa..7a707d21fc 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -43,6 +43,160 @@ struct v4l2_format_update {
@@ -22645,7 +22645,7 @@ index 0efff58f18..21265f1bd7 100644
      AVBufferRef *frames_ref;
      atomic_int q_count;
 diff --git a/libavcodec/v4l2_m2m.c b/libavcodec/v4l2_m2m.c
-index 728932fadc..e29df41729 100644
+index 6dd01e2e00..1e30d15fd8 100644
 --- a/libavcodec/v4l2_m2m.c
 +++ b/libavcodec/v4l2_m2m.c
 @@ -35,6 +35,14 @@
@@ -22673,7 +22673,7 @@ index 728932fadc..e29df41729 100644
      atomic_init(&s->refcount, 0);
      sem_init(&s->refsync, 0, 0);
  
-@@ -332,35 +342,38 @@ int ff_v4l2_m2m_codec_init(V4L2m2mPriv *priv)
+@@ -334,35 +344,38 @@ int ff_v4l2_m2m_codec_init(V4L2m2mPriv *priv)
      return v4l2_configure_contexts(s);
  }
  
@@ -22739,7 +22739,7 @@ index 19d618698d..d6cdaf65e1 100644
      xlat_track_t xlat;
      int pending_hw;
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 4765fe0d5e..e61464b499 100644
+index 7e17044706..fbbfc81342 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -169,96 +169,17 @@ static int v4l2_prepare_decoder(V4L2m2mContext *s)
@@ -22973,7 +22973,7 @@ index 4765fe0d5e..e61464b499 100644
      /* the client requests the codec to generate DRM frames:
       *   - data[0] will therefore point to the returned AVDRMFrameDescriptor
 diff --git a/libavcodec/v4l2_m2m_enc.c b/libavcodec/v4l2_m2m_enc.c
-index 20f81df750..db6014d8e3 100644
+index 9a0837ecf3..05ff6ba726 100644
 --- a/libavcodec/v4l2_m2m_enc.c
 +++ b/libavcodec/v4l2_m2m_enc.c
 @@ -24,6 +24,8 @@
@@ -23334,10 +23334,10 @@ index 20f81df750..db6014d8e3 100644
          av_log(avctx, AV_LOG_ERROR, "Encoder requires %s pixel format.\n", desc->name);
          return AVERROR(EINVAL);
 
-From 1fa3b2c14f3d237de415b1dd924ffc9b0c6f2ced Mon Sep 17 00:00:00 2001
+From 6b437ce70582c67971aa81871a6694a08b709784 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 8 Jun 2022 16:13:31 +0000
-Subject: [PATCH 055/120] v4l2_m2m_dec: Use DTS for best effort PTS if PTS is
+Subject: [PATCH 055/121] v4l2_m2m_dec: Use DTS for best effort PTS if PTS is
  always NO_PTS
 
 If we do have DTS but don't have PTS then assume PTS=DTS.
@@ -23350,7 +23350,7 @@ useful in any way.
  3 files changed, 9 insertions(+), 6 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 3ed5234be4..0225f6ba64 100644
+index 7a707d21fc..6b97eab41e 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -73,7 +73,6 @@ xlat_pts_pkt_in(AVCodecContext *const avctx, xlat_track_t *const x, const AVPack
@@ -23400,7 +23400,7 @@ index d6cdaf65e1..ee72beb052 100644
      V4L2m2mTrackEl track_els[FF_V4L2_M2M_TRACK_SIZE];
  } xlat_track_t;
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index e61464b499..bb809be41e 100644
+index fbbfc81342..485a96f4b4 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -177,7 +177,13 @@ set_best_effort_pts(AVCodecContext *const avctx,
@@ -23419,10 +23419,10 @@ index e61464b499..bb809be41e 100644
             frame->pts, frame->best_effort_timestamp, frame->pkt_dts);
  }
 
-From 07fbbc149d1aa6fc6e151a7f65505be873c27982 Mon Sep 17 00:00:00 2001
+From ec8d1c2c0b6bd3544e5e30500a167fc31abde17a Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 30 Jun 2022 15:59:23 +0000
-Subject: [PATCH 056/120] v4l2: Update H265 request for current API
+Subject: [PATCH 056/121] v4l2: Update H265 request for current API
 
 This works with v9 of the H265 patch set which hopefully will be the
 last one. Hevc controls extracted from patched v4l2-controls into
@@ -23440,10 +23440,10 @@ those will be used instead.
  create mode 100644 libavcodec/v4l2_req_hevc_v4.c
 
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 09962a810b..a8951ddcbe 100644
+index 2b3c16185d..d433a71236 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -976,7 +976,7 @@ OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
+@@ -1000,7 +1000,7 @@ OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_NVDEC_HWACCEL)         += nvdec_hevc.o
  OBJS-$(CONFIG_HEVC_QSV_HWACCEL)           += qsvdec.o
  OBJS-$(CONFIG_HEVC_V4L2REQUEST_HWACCEL)   += v4l2_request_hevc.o v4l2_req_decode_q.o\
@@ -24208,10 +24208,10 @@ index ed48d62e2d..d4adb3f812 100644
  
  #endif
 
-From e5cfb02fc431551da622c3ccaaf16d25afecf9e5 Mon Sep 17 00:00:00 2001
+From 21a348ae3282318fa96d3a6e2c70f3d4b90a7d52 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Sun, 3 Jul 2022 13:40:41 +0000
-Subject: [PATCH 057/120] v4l2_req: Observe limit on size of slice_array
+Subject: [PATCH 057/121] v4l2_req: Observe limit on size of slice_array
 
 This in fact provides some minor simplifications by combing the
 multi-slice and single-slice paths.
@@ -24339,10 +24339,10 @@ index d4adb3f812..0029e23309 100644
      req_decode_q decode_q;
  
 
-From 73ba75fbab29c26cd8b362b5f450d4e0beb4ed1f Mon Sep 17 00:00:00 2001
+From 4f1d74cc8eea6a1bd6f2317a10c0ecf620315dec Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 4 Jul 2022 14:43:20 +0100
-Subject: [PATCH 058/120] v4l2_req: Add entry point offsets array control
+Subject: [PATCH 058/121] v4l2_req: Add entry point offsets array control
 
 ---
  libavcodec/v4l2_req_hevc_vx.c  | 88 +++++++++++++++++++++++++++-------
@@ -24577,10 +24577,10 @@ index 0029e23309..99c90064ea 100644
      req_decode_q decode_q;
  
 
-From 9cc5b21fa37450d7ab43163637cbf26718ffe92d Mon Sep 17 00:00:00 2001
+From d0e5ed2dff1b8f8909ceb968cb3afe2b20093fda Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 4 Jul 2022 16:22:54 +0100
-Subject: [PATCH 059/120] v4l2_req: Support Annex B
+Subject: [PATCH 059/121] v4l2_req: Support Annex B
 
 ---
  libavcodec/v4l2_req_hevc_vx.c | 61 +++++++++++++++++++++++------------
@@ -24691,10 +24691,10 @@ index 43ef6631ed..5e0db9850a 100644
      ctrls[1].value = ctx->start_code;
  
 
-From 6dc0b1d851ef47fb198d32eb3088cfaa6b792d08 Mon Sep 17 00:00:00 2001
+From a75506e18a964c9f50efa224a3fa4179c9ef2127 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 4 Jul 2022 18:24:03 +0100
-Subject: [PATCH 060/120] v4l2_req: Add frame mode decode
+Subject: [PATCH 060/121] v4l2_req: Add frame mode decode
 
 ---
  libavcodec/v4l2_req_hevc_vx.c | 69 +++++++++++++++++++++++------------
@@ -24817,10 +24817,10 @@ index 5e0db9850a..ada53d0d44 100644
      ctrls[1].value = ctx->start_code;
  
 
-From eb9fe927c6582fba732e8d655072b2ce03099679 Mon Sep 17 00:00:00 2001
+From 9cf01f1485dcf71bcad7981d45029425d9abf115 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 5 Jul 2022 12:54:22 +0000
-Subject: [PATCH 061/120] v4l2_req: Fix probe for frame based decode
+Subject: [PATCH 061/121] v4l2_req: Fix probe for frame based decode
 
 ---
  libavcodec/v4l2_req_hevc_vx.c | 33 +++++++++++++++++++++++----------
@@ -24900,10 +24900,10 @@ index ada53d0d44..5d083016f8 100644
  static int
  set_controls(AVCodecContext * const avctx, V4L2RequestContextHEVC * const ctx)
 
-From d01df5c9199285c04b8b31aec41ea0ae2ecaaecf Mon Sep 17 00:00:00 2001
+From e7a62226f26073149d35c89268f56e17c8f45d76 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 26 Jul 2022 15:46:14 +0000
-Subject: [PATCH 062/120] vf_deinterlace_v4l2m2m: Support NV12 through
+Subject: [PATCH 062/121] vf_deinterlace_v4l2m2m: Support NV12 through
  deinterlace
 
 Supports NV12 (though not yet NV12M) through deinterlace.
@@ -25226,10 +25226,10 @@ index 1a933b7e0a..1a3bef5bcb 100644
  
      if (n < 6) {
 
-From 234480a99c88f30b201dc16c9ffc8d7f22212be3 Mon Sep 17 00:00:00 2001
+From 3d07826bcf588ad0384d00b210415664aa4489fb Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 19 Aug 2022 15:29:11 +0000
-Subject: [PATCH 063/120] v4l2_req: Enable use of MMAP for buffer alloc
+Subject: [PATCH 063/121] v4l2_req: Enable use of MMAP for buffer alloc
 
 Use MMAP rather than DMABUF if either the dmabuf device can't be opened
 or create_buf doesn't set the capability.
@@ -25958,10 +25958,10 @@ index cd79aad563..5cf17dd5e3 100644
      return 0;
  
 
-From ea0d413ee122f53e6697919884c92a3505c6ae52 Mon Sep 17 00:00:00 2001
+From 79c2fcac56586ce9eea0cc8c6b13d2cd54f3e468 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 22 Aug 2022 12:35:40 +0000
-Subject: [PATCH 064/120] Set buffer lengths on DQ
+Subject: [PATCH 064/121] Set buffer lengths on DQ
 
 ---
  libavcodec/v4l2_req_media.c | 8 ++++++++
@@ -25987,10 +25987,10 @@ index 910ac77bb6..1a9944774a 100644
      be->status = (buffer.flags & V4L2_BUF_FLAG_ERROR) ? QENT_ERROR : QENT_DONE;
      return be;
 
-From f15e0e5b59b559e4ffb9c3e6673b1815900f0ff3 Mon Sep 17 00:00:00 2001
+From 8f3245ca1e4b2ec7e13fc2f3bffbc964ee8fc290 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 22 Aug 2022 17:11:24 +0000
-Subject: [PATCH 065/120] Fix compile if videodev2.h defines V4L2 HEVC request
+Subject: [PATCH 065/121] Fix compile if videodev2.h defines V4L2 HEVC request
  API
 
 If videodev2.h does define the HEVC request API it is really hard to
@@ -26005,10 +26005,10 @@ against the system includes and remove the back compatability.
  5 files changed, 17 insertions(+), 9 deletions(-)
 
 diff --git a/configure b/configure
-index a8e7ee5dab..f555f60dc8 100755
+index fdc95146bf..5c00a183e3 100755
 --- a/configure
 +++ b/configure
-@@ -1957,6 +1957,7 @@ FEATURE_LIST="
+@@ -1946,6 +1946,7 @@ FEATURE_LIST="
      swscale_alpha
      vout_drm
      vout_egl
@@ -26016,7 +26016,7 @@ index a8e7ee5dab..f555f60dc8 100755
  "
  
  # this list should be kept in linking order
-@@ -6853,6 +6854,14 @@ fi
+@@ -6912,6 +6913,14 @@ fi
  
  check_func_headers "linux/media.h linux/videodev2.h" v4l2_timeval_to_ns
  check_cc hevc_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_HEVC_SLICE;"
@@ -26032,10 +26032,10 @@ index a8e7ee5dab..f555f60dc8 100755
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
  
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index a8951ddcbe..928756850f 100644
+index d433a71236..11f183c9b9 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -975,8 +975,8 @@ OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
+@@ -999,8 +999,8 @@ OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_NVDEC_HWACCEL)         += nvdec_hevc.o
  OBJS-$(CONFIG_HEVC_QSV_HWACCEL)           += qsvdec.o
@@ -26114,10 +26114,10 @@ index 5cf17dd5e3..614a1b4d99 100644
          av_log(avctx, AV_LOG_ERROR, "No HEVC version probed successfully\n");
          ret = AVERROR(EINVAL);
 
-From 6b41732aaec86b0ade91003419b89035940b32fe Mon Sep 17 00:00:00 2001
+From 35ec6af32c4f05b076f84ab343a8fc0d3263ba44 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 12 Sep 2022 17:59:22 +0100
-Subject: [PATCH 066/120] v4l2_m2m_enc: Send headers in in pkt side_data
+Subject: [PATCH 066/121] v4l2_m2m_enc: Send headers in in pkt side_data
 
 If GLOBAL_HEADERS are requested then we can't provide them at init time
 so send as NEW_EXTRADATA side data in a similar way to some AV1
@@ -26127,7 +26127,7 @@ encoders.
  1 file changed, 23 insertions(+), 10 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_enc.c b/libavcodec/v4l2_m2m_enc.c
-index db6014d8e3..c98f2129dc 100644
+index 05ff6ba726..099ad23928 100644
 --- a/libavcodec/v4l2_m2m_enc.c
 +++ b/libavcodec/v4l2_m2m_enc.c
 @@ -544,14 +544,12 @@ dequeue:
@@ -26195,10 +26195,10 @@ index db6014d8e3..c98f2129dc 100644
  
  static av_cold int v4l2_encode_init(AVCodecContext *avctx)
 
-From b8ea626474687c921372b04b138d6b1ed94fb67e Mon Sep 17 00:00:00 2001
+From dfc754491cea9192945b92ca9c8d3919321e30ad Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 14 Sep 2022 15:44:10 +0000
-Subject: [PATCH 067/120] matroskaenc: Allow H264 SPS/PPS headers in packet
+Subject: [PATCH 067/121] matroskaenc: Allow H264 SPS/PPS headers in packet
  sidedata
 
 ---
@@ -26206,10 +26206,10 @@ Subject: [PATCH 067/120] matroskaenc: Allow H264 SPS/PPS headers in packet
  1 file changed, 22 insertions(+), 4 deletions(-)
 
 diff --git a/libavformat/matroskaenc.c b/libavformat/matroskaenc.c
-index 1256bdfe36..fae9509442 100644
+index 113541bd9a..61e4c976ef 100644
 --- a/libavformat/matroskaenc.c
 +++ b/libavformat/matroskaenc.c
-@@ -75,6 +75,10 @@
+@@ -77,6 +77,10 @@
  
  #define IS_WEBM(mkv) (CONFIG_WEBM_MUXER && CONFIG_MATROSKA_MUXER ? \
                        ((mkv)->mode == MODE_WEBM) : CONFIG_WEBM_MUXER)
@@ -26220,7 +26220,7 @@ index 1256bdfe36..fae9509442 100644
  #define IS_SEEKABLE(pb, mkv) (((pb)->seekable & AVIO_SEEKABLE_NORMAL) && \
                                !(mkv)->is_live)
  
-@@ -1119,8 +1123,12 @@ static int mkv_assemble_native_codecprivate(AVFormatContext *s, AVIOContext *dyn
+@@ -1121,8 +1125,12 @@ static int mkv_assemble_native_codecprivate(AVFormatContext *s, AVIOContext *dyn
      case AV_CODEC_ID_WAVPACK:
          return put_wv_codecpriv(dyn_cp, extradata, extradata_size);
      case AV_CODEC_ID_H264:
@@ -26235,7 +26235,7 @@ index 1256bdfe36..fae9509442 100644
      case AV_CODEC_ID_HEVC:
          return ff_isom_write_hvcc(dyn_cp, extradata,
                                    extradata_size, 0);
-@@ -2726,8 +2734,8 @@ static int mkv_check_new_extra_data(AVFormatContext *s, const AVPacket *pkt)
+@@ -2731,8 +2739,8 @@ static int mkv_check_new_extra_data(AVFormatContext *s, const AVPacket *pkt)
          }
          break;
  #endif
@@ -26246,7 +26246,7 @@ index 1256bdfe36..fae9509442 100644
      case AV_CODEC_ID_AV1:
          if (side_data_size && mkv->track.bc && !par->extradata_size) {
              // If the reserved space doesn't suffice, only write
-@@ -2739,6 +2747,16 @@ static int mkv_check_new_extra_data(AVFormatContext *s, const AVPacket *pkt)
+@@ -2744,6 +2752,16 @@ static int mkv_check_new_extra_data(AVFormatContext *s, const AVPacket *pkt)
          } else if (!par->extradata_size)
              return AVERROR_INVALIDDATA;
          break;
@@ -26264,20 +26264,20 @@ index 1256bdfe36..fae9509442 100644
          if (side_data_size)
              av_log(s, AV_LOG_DEBUG, "Ignoring new extradata in a packet for stream %d.\n", pkt->stream_index);
 
-From aa58b31d5d68abcf5989c747e1d1cde5223813e3 Mon Sep 17 00:00:00 2001
+From 30c6ca4e24ae2acbd7f7f122f5275beb62b625c6 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 14 Sep 2022 15:55:15 +0000
-Subject: [PATCH 068/120] movenc: Allow H264 SPS/PPS headers in packet sidedata
+Subject: [PATCH 068/121] movenc: Allow H264 SPS/PPS headers in packet sidedata
 
 ---
  libavformat/movenc.c | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index 5608afde42..0f2e236eaa 100644
+index c4fcb5f8b1..891adbf7b2 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
-@@ -6318,6 +6318,7 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
+@@ -6343,6 +6343,7 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
      if (trk->par->codec_id == AV_CODEC_ID_MP4ALS ||
              trk->par->codec_id == AV_CODEC_ID_AAC ||
              trk->par->codec_id == AV_CODEC_ID_AV1 ||
@@ -26286,10 +26286,10 @@ index 5608afde42..0f2e236eaa 100644
          size_t side_size;
          uint8_t *side = av_packet_get_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA, &side_size);
 
-From 840df546f21f95cc80eeb3f224d53c6dc19f34b9 Mon Sep 17 00:00:00 2001
+From 1c7c3e99e9ed90f241aecbe7b2269229587d1e03 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 26 Sep 2022 12:45:05 +0100
-Subject: [PATCH 069/120] Allow ffmpeg to select codec internal hwfmts if
+Subject: [PATCH 069/121] Allow ffmpeg to select codec internal hwfmts if
  no_cvt_hw
 
 This allows the selection of DRM_PRIME from v4l2m2m without forcing it
@@ -26301,10 +26301,10 @@ Not utterly sure this is the right method for 5.1 but it does work
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
-index 517324df3a..697b8a71cf 100644
+index ba0c1898cf..839da7b472 100644
 --- a/fftools/ffmpeg.c
 +++ b/fftools/ffmpeg.c
-@@ -2571,12 +2571,15 @@ static enum AVPixelFormat get_format(AVCodecContext *s, const enum AVPixelFormat
+@@ -2763,12 +2763,15 @@ static enum AVPixelFormat get_format(AVCodecContext *s, const enum AVPixelFormat
              break;
  
          if (ist->hwaccel_id == HWACCEL_GENERIC ||
@@ -26323,10 +26323,10 @@ index 517324df3a..697b8a71cf 100644
                      continue;
                  if (config->pix_fmt == *p)
 
-From 21b9406798673c6d6275fc7b2f96975b7733e49b Mon Sep 17 00:00:00 2001
+From ecf273fd02e8aafe8775b1f291b9664b1b49572e Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 1 Sep 2022 11:42:41 +0000
-Subject: [PATCH 070/120] vf_deinterlace_v4l2m2m: Add a v4l2m2m scaler
+Subject: [PATCH 070/121] vf_deinterlace_v4l2m2m: Add a v4l2m2m scaler
 
 The logic for running an isp based scaler is pretty much identical to
 that for the deinterlacer so add to the deinterlacer. This requires
@@ -26339,10 +26339,10 @@ based on operation.
  2 files changed, 877 insertions(+), 247 deletions(-)
 
 diff --git a/libavfilter/allfilters.c b/libavfilter/allfilters.c
-index 9b17c37eb3..7c651f5a9d 100644
+index 357ff61ca8..d504fa1bc8 100644
 --- a/libavfilter/allfilters.c
 +++ b/libavfilter/allfilters.c
-@@ -415,6 +415,7 @@ extern const AVFilter ff_vf_scale;
+@@ -421,6 +421,7 @@ extern const AVFilter ff_vf_scale;
  extern const AVFilter ff_vf_scale_cuda;
  extern const AVFilter ff_vf_scale_npp;
  extern const AVFilter ff_vf_scale_qsv;
@@ -27806,10 +27806,10 @@ index 1a3bef5bcb..2df39ec0f1 100644
 +};
 +
 
-From 84d071e7f04ac67ee2071c4512a635f0c4388b40 Mon Sep 17 00:00:00 2001
+From 7e7147d50bc6e3f13834525dba3a47d170422f07 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 22 Sep 2022 14:54:46 +0000
-Subject: [PATCH 071/120] v4l2_m2m: Adjust buffer allocation based on min/max
+Subject: [PATCH 071/121] v4l2_m2m: Adjust buffer allocation based on min/max
  controls
 
 Clip requested buffer count to min/max declared by driver.
@@ -27821,7 +27821,7 @@ minimum which helps with flow control.
  1 file changed, 19 insertions(+)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 0225f6ba64..5754a9fda7 100644
+index 6b97eab41e..ba36689ff3 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -1187,6 +1187,7 @@ fail_release:
@@ -27858,10 +27858,10 @@ index 0225f6ba64..5754a9fda7 100644
      if (ret < 0)
          goto fail_unref_hwframes;
 
-From 35d480e28ddaa7a68d06f00a52deb97f53e251d8 Mon Sep 17 00:00:00 2001
+From b69a2707a192ac509174899233a094373a3f5dc9 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 22 Sep 2022 15:00:12 +0000
-Subject: [PATCH 072/120] v4l2_m2m_dec: If src Q is full then wait indefinitely
+Subject: [PATCH 072/121] v4l2_m2m_dec: If src Q is full then wait indefinitely
  for buffer
 
 If it is not possible to add another buffer to the src Q then alawys
@@ -27875,7 +27875,7 @@ the current scheme confuses ffmpegs pipeline scheduling.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index bb809be41e..e67e06313f 100644
+index 485a96f4b4..bb183097f6 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -456,9 +456,9 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -27891,10 +27891,10 @@ index bb809be41e..e67e06313f 100644
              // Dequeue frame will unref any previous contents of frame
              // if it returns success so we don't need an explicit unref
 
-From 9bfc5748f3b1325c598af5426f689ccc291087ec Mon Sep 17 00:00:00 2001
+From b1d37be81bbf683a0eb16923c9b9f045fd0ea0c0 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 22 Sep 2022 15:12:27 +0000
-Subject: [PATCH 073/120] vf_deinterlace_v4l2m2m: Add Q name to structure for
+Subject: [PATCH 073/121] vf_deinterlace_v4l2m2m: Add Q name to structure for
  debug
 
 ---
@@ -27925,10 +27925,10 @@ index 2df39ec0f1..4edecc02bf 100644
      ctx->field_order = V4L2_FIELD_ANY;
  
 
-From 0a3064022e113153f6eaba307b7d982b1c350df7 Mon Sep 17 00:00:00 2001
+From 794a5bfc3ec74fdc7664508a287a075708d5deef Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 22 Sep 2022 16:08:42 +0000
-Subject: [PATCH 074/120] v4l2_m2m_enc: Set src buffer count to min+2 by
+Subject: [PATCH 074/121] v4l2_m2m_enc: Set src buffer count to min+2 by
  default
 
 Set output.num_buffers to 0 by default which will then be set to min+2
@@ -27940,7 +27940,7 @@ creating deadlock in the ffmpeg filter chain.
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_enc.c b/libavcodec/v4l2_m2m_enc.c
-index c98f2129dc..bc0c2d4245 100644
+index 099ad23928..b8ba815c37 100644
 --- a/libavcodec/v4l2_m2m_enc.c
 +++ b/libavcodec/v4l2_m2m_enc.c
 @@ -672,9 +672,10 @@ static av_cold int v4l2_encode_close(AVCodecContext *avctx)
@@ -27957,10 +27957,10 @@ index c98f2129dc..bc0c2d4245 100644
  static const AVOption mpeg4_options[] = {
      V4L_M2M_CAPTURE_OPTS,
 
-From 738e263692a00f5a9c4ba37e17a0950d1fdeed6f Mon Sep 17 00:00:00 2001
+From 85c42743046a05b347f33b1933e6d52ea1d17e00 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 22 Sep 2022 16:13:57 +0000
-Subject: [PATCH 075/120] vf_deinterlace_m2m: For deinterlace set outlink FR to
+Subject: [PATCH 075/121] vf_deinterlace_m2m: For deinterlace set outlink FR to
  twice inlink
 
 We used to set the outlink framerate to unknown but it turns out that
@@ -27994,10 +27994,10 @@ index 4edecc02bf..c52dae1c44 100644
      if (inlink->sample_aspect_ratio.num)
          outlink->sample_aspect_ratio = av_mul_q((AVRational){outlink->h * inlink->w, outlink->w * inlink->h}, inlink->sample_aspect_ratio);
 
-From 898b4ef41bfe2a2638f15850f752f04f9a9993bb Mon Sep 17 00:00:00 2001
+From 34a24bc0b0d427c75659d3907cb75afb6a9dc255 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 23 Sep 2022 11:30:56 +0000
-Subject: [PATCH 076/120] v4l2m2m: Add ff_v4l2_dq_all to drain all buffers from
+Subject: [PATCH 076/121] v4l2m2m: Add ff_v4l2_dq_all to drain all buffers from
  a Q
 
 Useful for where (encode) we might have drmprime buffers that we want to
@@ -28008,7 +28008,7 @@ return to the source ASAP.
  2 files changed, 13 insertions(+), 6 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 5754a9fda7..eaaec44666 100644
+index ba36689ff3..4a359bf45e 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -707,17 +707,22 @@ clean_v4l2_buffer(V4L2Buffer * const avbuf)
@@ -28052,10 +28052,10 @@ index 21265f1bd7..523c53e97d 100644
 +
  #endif // AVCODEC_V4L2_CONTEXT_H
 
-From 6d3e970647486212d614e5d77a4140fbffa12544 Mon Sep 17 00:00:00 2001
+From 95dfc168c74f7b0f282c1b2ad9deb8fba10a7ce5 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 23 Sep 2022 11:38:36 +0000
-Subject: [PATCH 077/120] v4l2_m2m_enc: DQ output more frequently
+Subject: [PATCH 077/121] v4l2_m2m_enc: DQ output more frequently
 
 Ensure that we DQ any released src buffers on every op to avoid deadlock
 with source.
@@ -28067,7 +28067,7 @@ should be integrated into dq_buf, but that is a further reaching delta.
  1 file changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_enc.c b/libavcodec/v4l2_m2m_enc.c
-index bc0c2d4245..d8ee7fd2f2 100644
+index b8ba815c37..a992a3cccc 100644
 --- a/libavcodec/v4l2_m2m_enc.c
 +++ b/libavcodec/v4l2_m2m_enc.c
 @@ -421,6 +421,8 @@ static int v4l2_send_frame(AVCodecContext *avctx, const AVFrame *frame)
@@ -28111,10 +28111,10 @@ index bc0c2d4245..d8ee7fd2f2 100644
      }
  
 
-From 236301167a8103afaffbdf1ad43616c1af8383c4 Mon Sep 17 00:00:00 2001
+From a40b1c38b0615fce0c0d9eb97510ab9e77b3e1ac Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 26 Sep 2022 18:20:00 +0100
-Subject: [PATCH 078/120] conf_native: Remove --enable-rpi from all builds
+Subject: [PATCH 078/121] conf_native: Remove --enable-rpi from all builds
 
 ---
  pi-util/conf_native.sh | 5 +++--
@@ -28145,10 +28145,10 @@ index 37cea71756..f22d531ca4 100755
   --enable-libdrm\
   --enable-vout-egl\
 
-From 7c875c257b3d0ff913ced3ae2bc6b6a4c150b7cc Mon Sep 17 00:00:00 2001
+From 8fddfc8f1e3c95caded18705ed29be0ae95517bc Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 29 Sep 2022 19:48:08 +0000
-Subject: [PATCH 079/120] v4l2_m2m_dec: Deal correctly with avcC H264 data in
+Subject: [PATCH 079/121] v4l2_m2m_dec: Deal correctly with avcC H264 data in
  extradata
 
 Decoders expect AnnexB style headers, mkv and similar formats have
@@ -28172,7 +28172,7 @@ index ee72beb052..babf101d65 100644
  
  #define FF_V4L2_QUIRK_REINIT_ALWAYS             1
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index e67e06313f..6ffd28e76d 100644
+index bb183097f6..6bd9926b3f 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -46,6 +46,71 @@
@@ -28388,10 +28388,10 @@ index e67e06313f..6ffd28e76d 100644
          return ret;
  
 
-From 62f6924639cee07142ebc2567c693fb1304ac44c Mon Sep 17 00:00:00 2001
+From 70227ebbc2999bc49075a3b683392d94618ecd89 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 30 Sep 2022 14:20:23 +0000
-Subject: [PATCH 080/120] v4l2_request_hevc: Fix up
+Subject: [PATCH 080/121] v4l2_request_hevc: Fix up
  V4L2_CID_CODEC_STATELESS_BASE if missing
 
 ---
@@ -28417,10 +28417,10 @@ index 7829d82084..c02fdbe5a8 100644
  
  #define V4L2_CID_STATELESS_HEVC_SPS		(V4L2_CID_CODEC_STATELESS_BASE + 400)
 
-From 76ad115bb301a2b4bd27135557a4e0b4653e8d5f Mon Sep 17 00:00:00 2001
+From 22d2000382839dbd04588af1bb20cc9d9b3a4362 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Sat, 1 Oct 2022 13:40:57 +0000
-Subject: [PATCH 081/120] vf_deinterlace_v4l2m2m: Fix compile on m/c without
+Subject: [PATCH 081/121] vf_deinterlace_v4l2m2m: Fix compile on m/c without
  V4L2 SAND
 
 ---
@@ -28551,10 +28551,10 @@ index c52dae1c44..716789f988 100644
          break;
      }
 
-From 7539260084d21d63a5dfd989891cc34a8d2e42c8 Mon Sep 17 00:00:00 2001
+From f06f9ee41bf0f6f74240503f0cb427328cf6792f Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Sun, 2 Oct 2022 12:36:43 +0000
-Subject: [PATCH 082/120] configure: Fix v4l2_req_hevc_vx setup; set after deps
+Subject: [PATCH 082/121] configure: Fix v4l2_req_hevc_vx setup; set after deps
  fixups
 
 ---
@@ -28562,10 +28562,10 @@ Subject: [PATCH 082/120] configure: Fix v4l2_req_hevc_vx setup; set after deps
  1 file changed, 3 insertions(+), 6 deletions(-)
 
 diff --git a/configure b/configure
-index f555f60dc8..c51b342cd2 100755
+index 5c00a183e3..94c8161b91 100755
 --- a/configure
 +++ b/configure
-@@ -6855,12 +6855,6 @@ fi
+@@ -6914,12 +6914,6 @@ fi
  check_func_headers "linux/media.h linux/videodev2.h" v4l2_timeval_to_ns
  check_cc hevc_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_HEVC_SLICE;"
  disable v4l2_req_hevc_vx
@@ -28578,7 +28578,7 @@ index f555f60dc8..c51b342cd2 100755
  
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
-@@ -7350,6 +7344,9 @@ check_deps $CONFIG_LIST       \
+@@ -7415,6 +7409,9 @@ check_deps $CONFIG_LIST       \
  
  enabled threads && ! enabled pthreads && ! enabled atomics_native && die "non pthread threading without atomics not supported, try adding --enable-pthreads or --cpu=i486 or higher if you are on x86"
  
@@ -28589,10 +28589,10 @@ index f555f60dc8..c51b342cd2 100755
  haiku)
      disable memalign
 
-From d8ffedb056a1c5f5e6f6737d20fecc1aa0b3ed93 Mon Sep 17 00:00:00 2001
+From 7d7709fb68561711f893269227147974fd6a46f3 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Sat, 1 Oct 2022 12:39:45 +0000
-Subject: [PATCH 083/120] vf_deinterlace_v4l2m2m: Ensure we get consistent
+Subject: [PATCH 083/121] vf_deinterlace_v4l2m2m: Ensure we get consistent
  final frames
 
 On getting EOS at the input of the filster do not simply drop everything
@@ -28941,10 +28941,10 @@ index 716789f988..ce875c2c61 100644
      ctx->logctx = NULL;  // Log to NULL works, log to missing crashes
      pts_track_uninit(&ctx->track);
 
-From 6a37ed2a2d181e63e6a73c13fe20302818c21427 Mon Sep 17 00:00:00 2001
+From f893891df8f4e7738b2d9b49df4386fb160eb25f Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 5 Oct 2022 16:12:02 +0000
-Subject: [PATCH 084/120] v4l2_m2m_dec: Rework decode pending heuristic
+Subject: [PATCH 084/121] v4l2_m2m_dec: Rework decode pending heuristic
 
 The old code measured the length of the entire Q in the decoder and
 attempted to dynamically guess an appropriate length. This was prone to
@@ -28973,7 +28973,7 @@ index babf101d65..26a7161042 100644
      pts_stats_t pts_stat;
  
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 6ffd28e76d..de2d39de9a 100644
+index 6bd9926b3f..bec9b22fcf 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -349,41 +349,54 @@ static void
@@ -29112,10 +29112,10 @@ index 6ffd28e76d..de2d39de9a 100644
      capture = &s->capture;
      output = &s->output;
 
-From 105c1cbdf43c288573620276ae8a90c2177fb428 Mon Sep 17 00:00:00 2001
+From 7048e7e6b8621cf09b96cc7e44b8d82ba8619913 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Fri, 21 Oct 2022 13:48:07 +0000
-Subject: [PATCH 085/120] pthread_frame: Fix MT hwaccel. Recent change broke
+Subject: [PATCH 085/121] pthread_frame: Fix MT hwaccel. Recent change broke
  it.
 
 Revert the effects of 35aa7e70e7ec350319e7634a30d8d8aa1e6ecdda if the
@@ -29125,10 +29125,10 @@ hwaccel is marked MT_SAFE.
  1 file changed, 36 insertions(+), 12 deletions(-)
 
 diff --git a/libavcodec/pthread_frame.c b/libavcodec/pthread_frame.c
-index d98b885b0e..1169ca945c 100644
+index 2cc89a41f5..b14f8e9360 100644
 --- a/libavcodec/pthread_frame.c
 +++ b/libavcodec/pthread_frame.c
-@@ -244,7 +244,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
+@@ -231,7 +231,7 @@ static attribute_align_arg void *frame_worker_thread(void *arg)
              p->hwaccel_serializing = 0;
              pthread_mutex_unlock(&p->parent->hwaccel_mutex);
          }
@@ -29137,7 +29137,7 @@ index d98b885b0e..1169ca945c 100644
  
          if (p->async_serializing) {
              p->async_serializing = 0;
-@@ -332,6 +332,12 @@ FF_ENABLE_DEPRECATION_WARNINGS
+@@ -319,6 +319,12 @@ FF_ENABLE_DEPRECATION_WARNINGS
          }
  
          dst->hwaccel_flags = src->hwaccel_flags;
@@ -29150,7 +29150,7 @@ index d98b885b0e..1169ca945c 100644
  
          err = av_buffer_replace(&dst->internal->pool, src->internal->pool);
          if (err < 0)
-@@ -462,10 +468,13 @@ static int submit_packet(PerThreadContext *p, AVCodecContext *user_avctx,
+@@ -434,10 +440,13 @@ static int submit_packet(PerThreadContext *p, AVCodecContext *user_avctx,
      }
  
      /* transfer the stashed hwaccel state, if any */
@@ -29168,7 +29168,7 @@ index d98b885b0e..1169ca945c 100644
  
      av_packet_unref(p->avpkt);
      ret = av_packet_ref(p->avpkt, avpkt);
-@@ -676,9 +685,12 @@ void ff_thread_finish_setup(AVCodecContext *avctx) {
+@@ -610,9 +619,12 @@ void ff_thread_finish_setup(AVCodecContext *avctx) {
       * this is done here so that this worker thread can wipe its own hwaccel
       * state after decoding, without requiring synchronization */
      av_assert0(!p->parent->stash_hwaccel);
@@ -29184,7 +29184,7 @@ index d98b885b0e..1169ca945c 100644
  
      pthread_mutex_lock(&p->progress_mutex);
      if(atomic_load(&p->state) == STATE_SETUP_FINISHED){
-@@ -733,6 +745,15 @@ void ff_frame_thread_free(AVCodecContext *avctx, int thread_count)
+@@ -667,6 +679,15 @@ void ff_frame_thread_free(AVCodecContext *avctx, int thread_count)
  
      park_frame_worker_threads(fctx, thread_count);
  
@@ -29200,7 +29200,7 @@ index d98b885b0e..1169ca945c 100644
      for (i = 0; i < thread_count; i++) {
          PerThreadContext *p = &fctx->threads[i];
          AVCodecContext *ctx = p->avctx;
-@@ -781,10 +802,13 @@ void ff_frame_thread_free(AVCodecContext *avctx, int thread_count)
+@@ -710,10 +731,13 @@ void ff_frame_thread_free(AVCodecContext *avctx, int thread_count)
  
      /* if we have stashed hwaccel state, move it to the user-facing context,
       * so it will be freed in avcodec_close() */
@@ -29219,10 +29219,10 @@ index d98b885b0e..1169ca945c 100644
      av_freep(&avctx->internal->thread_ctx);
  }
 
-From e00ca15321f0cbe2a63475e3c611ee15fb3ee4f3 Mon Sep 17 00:00:00 2001
+From 033056bd8ec63b16fe081446f70f41b5d5789b81 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 18 Oct 2022 13:18:27 +0000
-Subject: [PATCH 086/120] v4l2_req: Add swfmt to init logging
+Subject: [PATCH 086/121] v4l2_req: Add swfmt to init logging
 
 (cherry picked from commit dfa03b702baaf2952bcd2bbf8badcc2f9c961ddf)
 ---
@@ -29256,10 +29256,10 @@ index 614a1b4d99..767ecb036a 100644
      return 0;
  
 
-From e5ff4d9a8c7fffc587444bfbb9bd8578b1cb5d1a Mon Sep 17 00:00:00 2001
+From 70779e742b93015e3e8aaa8f945a12d35917844d Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 18 Oct 2022 13:39:54 +0000
-Subject: [PATCH 087/120] v4l2_m2m: Avoid polling on a queue that is streamoff
+Subject: [PATCH 087/121] v4l2_m2m: Avoid polling on a queue that is streamoff
 
 (cherry picked from commit b2658bc56d3034a17db7f39597fc7d71bfe9a43b)
 ---
@@ -29267,7 +29267,7 @@ Subject: [PATCH 087/120] v4l2_m2m: Avoid polling on a queue that is streamoff
  1 file changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index eaaec44666..3e527f666d 100644
+index 4a359bf45e..b296dc111c 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -578,6 +578,11 @@ get_event(V4L2m2mContext * const m)
@@ -29301,10 +29301,10 @@ index eaaec44666..3e527f666d 100644
              return AVERROR(ENOSPC);
          }
 
-From e75dba3f588461affa4a54a856418107efa036b0 Mon Sep 17 00:00:00 2001
+From 438fed3702eb689f836c885ebbd813e48d4d4c4a Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 18 Oct 2022 14:07:04 +0000
-Subject: [PATCH 088/120] v4l2_m2m: Add function to get number of queued
+Subject: [PATCH 088/121] v4l2_m2m: Add function to get number of queued
  buffers
 
 (cherry picked from commit f9ac6485c00b4531dcff354222aef450b29728f4)
@@ -29333,10 +29333,10 @@ index 523c53e97d..8e4f681643 100644
 +
  #endif // AVCODEC_V4L2_CONTEXT_H
 
-From 3d886c89bfbcb13e230181bb611c1c2d9e235543 Mon Sep 17 00:00:00 2001
+From 95ff4a65ed4c88ea7e02ee55e260e37a0ce2ba88 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 18 Oct 2022 14:48:20 +0000
-Subject: [PATCH 089/120] v4l2_m2m: Add timeouts to dq_all and dequeue_packet
+Subject: [PATCH 089/121] v4l2_m2m: Add timeouts to dq_all and dequeue_packet
 
 Add timeouts and use them to have better flow control in encode
 
@@ -29348,7 +29348,7 @@ Add timeouts and use them to have better flow control in encode
  3 files changed, 43 insertions(+), 16 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 3e527f666d..042c6a976c 100644
+index b296dc111c..7031f3d340 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -712,13 +712,19 @@ clean_v4l2_buffer(V4L2Buffer * const avbuf)
@@ -29434,7 +29434,7 @@ index 8e4f681643..5afed3e6ec 100644
  /**
   * Returns the number of buffers currently queued
 diff --git a/libavcodec/v4l2_m2m_enc.c b/libavcodec/v4l2_m2m_enc.c
-index d8ee7fd2f2..40bbe499f0 100644
+index a992a3cccc..d0d27e5bc2 100644
 --- a/libavcodec/v4l2_m2m_enc.c
 +++ b/libavcodec/v4l2_m2m_enc.c
 @@ -420,16 +420,24 @@ static int v4l2_send_frame(AVCodecContext *avctx, const AVFrame *frame)
@@ -29502,10 +29502,10 @@ index d8ee7fd2f2..40bbe499f0 100644
              return ret;
      }
 
-From 41810850e382858c2c74453c472c3c4278e69286 Mon Sep 17 00:00:00 2001
+From e6654c1997a6f4dfd43b0f74b0168f5d644c1c74 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 18 Oct 2022 14:23:32 +0000
-Subject: [PATCH 090/120] v4l2_m2m_enc: Improve debug trace
+Subject: [PATCH 090/121] v4l2_m2m_enc: Improve debug trace
 
 (cherry picked from commit 113e89daffb329a0cd3d920abd483a4025664bf5)
 ---
@@ -29513,7 +29513,7 @@ Subject: [PATCH 090/120] v4l2_m2m_enc: Improve debug trace
  1 file changed, 10 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_enc.c b/libavcodec/v4l2_m2m_enc.c
-index 40bbe499f0..2c81031336 100644
+index d0d27e5bc2..c8c2de3d47 100644
 --- a/libavcodec/v4l2_m2m_enc.c
 +++ b/libavcodec/v4l2_m2m_enc.c
 @@ -427,6 +427,7 @@ static int v4l2_send_frame(AVCodecContext *avctx, const AVFrame *frame)
@@ -29562,10 +29562,10 @@ index 40bbe499f0..2c81031336 100644
      av_packet_unref(avpkt);
      return ret;
 
-From e0b4608b940bb16b8326fa6680c22bf5513cceac Mon Sep 17 00:00:00 2001
+From 02dca2b845125af7ec6dfb68bdc34726a45fee9c Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 18 Oct 2022 13:22:36 +0000
-Subject: [PATCH 091/120] v4l2_m2m_enc: Copy dest packets to memory if short of
+Subject: [PATCH 091/121] v4l2_m2m_enc: Copy dest packets to memory if short of
  v4l2 buffers
 
 (cherry picked from commit aa4ebbda400b42db952fc713b26927fc8636b0e5)
@@ -29574,7 +29574,7 @@ Subject: [PATCH 091/120] v4l2_m2m_enc: Copy dest packets to memory if short of
  1 file changed, 16 insertions(+)
 
 diff --git a/libavcodec/v4l2_m2m_enc.c b/libavcodec/v4l2_m2m_enc.c
-index 2c81031336..3773297543 100644
+index c8c2de3d47..c23187e6e6 100644
 --- a/libavcodec/v4l2_m2m_enc.c
 +++ b/libavcodec/v4l2_m2m_enc.c
 @@ -621,6 +621,22 @@ dequeue:
@@ -29601,10 +29601,10 @@ index 2c81031336..3773297543 100644
      capture->first_buf = 0;
      return 0;
 
-From 4b1a4ef2e33c2d4c463bf052843715ee35604625 Mon Sep 17 00:00:00 2001
+From ced9a7d442a04be08fc23e0af310312299a5d5a0 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 19 Oct 2022 11:00:16 +0000
-Subject: [PATCH 092/120] v4l2_m2m_dec: Fix pts_best_effort guessing for
+Subject: [PATCH 092/121] v4l2_m2m_dec: Fix pts_best_effort guessing for
  initial pts
 
 (cherry picked from commit 1af32e5c87586a0f7e76cdf19a012ddbcf3eac67)
@@ -29613,7 +29613,7 @@ Subject: [PATCH 092/120] v4l2_m2m_dec: Fix pts_best_effort guessing for
  1 file changed, 2 insertions(+)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index de2d39de9a..73ce427052 100644
+index bec9b22fcf..47b2735f82 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -113,6 +113,8 @@ log_dump(void * logctx, int lvl, const void * const data, const size_t len)
@@ -29626,10 +29626,10 @@ index de2d39de9a..73ce427052 100644
              stats->last_interval == 0 ||
              stats->last_count >= STATS_LAST_COUNT_MAX)
 
-From 519f5e1936caab8436e105d1732e61f8eb538f45 Mon Sep 17 00:00:00 2001
+From 3e3cf6ed7280d8ad4f3eed17a6d18c2df3c0cd31 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 19 Oct 2022 14:47:04 +0000
-Subject: [PATCH 093/120] v4l2_m2m_enc: Wait for frame or space in src Q in
+Subject: [PATCH 093/121] v4l2_m2m_enc: Wait for frame or space in src Q in
  rx_pkt
 
 If receive_packet we should ensure that there is space in the source Q
@@ -29642,7 +29642,7 @@ the source Q is currently full.
  1 file changed, 19 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_enc.c b/libavcodec/v4l2_m2m_enc.c
-index 3773297543..684acf9dc7 100644
+index c23187e6e6..524e9424a5 100644
 --- a/libavcodec/v4l2_m2m_enc.c
 +++ b/libavcodec/v4l2_m2m_enc.c
 @@ -415,13 +415,17 @@ static int fmt_eq(const struct v4l2_format * const a, const struct v4l2_format *
@@ -29688,10 +29688,10 @@ index 3773297543..684acf9dc7 100644
          return (s->draining && ret == AVERROR(EAGAIN)) ? AVERROR_EOF : ret;
  
 
-From 6039d4edf2ee1b2e037666b896d924347583dd75 Mon Sep 17 00:00:00 2001
+From de9ec2bf6421b199aad9ea9dc7896a46c8813d94 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 19 Oct 2022 14:54:29 +0000
-Subject: [PATCH 094/120] vf_deinterlace_v4l2m2m: Print dts rather that NOPTS
+Subject: [PATCH 094/121] vf_deinterlace_v4l2m2m: Print dts rather that NOPTS
  in trace
 
 (cherry picked from commit e9b468f35f0c6ad9bfe96f5a05e449afa8ae074a)
@@ -29715,10 +29715,10 @@ index ce875c2c61..7c6751b69c 100644
             avctx->inputs[0]->status_in, avctx->inputs[0]->status_out, avctx->outputs[0]->status_in, avctx->outputs[0]->status_out);
  
 
-From ff3a6c6b3085192be00feb501e0a692dda941f07 Mon Sep 17 00:00:00 2001
+From d71a0a173240e18d518ae0b921ac43849524bd66 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 19 Oct 2022 14:55:21 +0000
-Subject: [PATCH 095/120] vf_deinterlace_v4l2m2m: Ignore "wanted" when
+Subject: [PATCH 095/121] vf_deinterlace_v4l2m2m: Ignore "wanted" when
  processing input
 
 If we gate send a frame to the outlink on its frame_wanted flag then we
@@ -29748,10 +29748,10 @@ index 7c6751b69c..a173a291f8 100644
          AVFrame * frame = av_frame_alloc();
          int rv;
 
-From 7ba15c81a923b2e63974e36034492597559cb07b Mon Sep 17 00:00:00 2001
+From 842e0a00288f9a2a862720990791b8eca9546955 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 19 Oct 2022 15:00:43 +0000
-Subject: [PATCH 096/120] conf_native: Add --enable-gpl
+Subject: [PATCH 096/121] conf_native: Add --enable-gpl
 
 (cherry picked from commit bab9bf4a2e39391940d88af2ce5d70236ac21f15)
 ---
@@ -29771,10 +29771,10 @@ index f22d531ca4..082d9b5832 100755
   $RPIOPTS\
   --extra-cflags="-ggdb $RPI_KEEPS $RPI_DEFINES $RPI_INCLUDES"\
 
-From 577cd088426ecffbce2ab88c40869f690a57ead0 Mon Sep 17 00:00:00 2001
+From bf9aaf30818308a4651e00a2a64a0f65dc9a36e5 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 15 Nov 2022 13:33:00 +0000
-Subject: [PATCH 097/120] egl_vout: Make formatting consistent - no code
+Subject: [PATCH 097/121] egl_vout: Make formatting consistent - no code
  changes
 
 ---
@@ -29782,7 +29782,7 @@ Subject: [PATCH 097/120] egl_vout: Make formatting consistent - no code
  1 file changed, 369 insertions(+), 372 deletions(-)
 
 diff --git a/libavdevice/egl_vout.c b/libavdevice/egl_vout.c
-index 0195c9d026..8fd3c58bac 100644
+index 7b9c610ace..a52cabb082 100644
 --- a/libavdevice/egl_vout.c
 +++ b/libavdevice/egl_vout.c
 @@ -48,20 +48,20 @@
@@ -30755,17 +30755,17 @@ index 0195c9d026..8fd3c58bac 100644
  
  };
 
-From 06d2761f87ee240f2604f19659ad00ee34c728b4 Mon Sep 17 00:00:00 2001
+From 4d3a3973a07994b0a6ec35626e514fc40f439fe3 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 12 Dec 2022 16:49:43 +0000
-Subject: [PATCH 098/120] v4l2m2m: reporganise get_raw_format for loop logic
+Subject: [PATCH 098/121] v4l2m2m: reporganise get_raw_format for loop logic
 
 ---
  libavcodec/v4l2_context.c | 16 +++++-----------
  1 file changed, 5 insertions(+), 11 deletions(-)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 042c6a976c..fcd5fdf359 100644
+index 7031f3d340..79a31cf930 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -828,28 +828,22 @@ static int v4l2_get_raw_format(V4L2Context* ctx, enum AVPixelFormat *p)
@@ -30803,10 +30803,10 @@ index 042c6a976c..fcd5fdf359 100644
  
      return AVERROR(EINVAL);
 
-From 01a67c1059c5003c29d5177f1067156c95a82e58 Mon Sep 17 00:00:00 2001
+From 123c5ef429ec6bd7d1875d621df88bb2ad7af0bd Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 12 Dec 2022 17:49:12 +0000
-Subject: [PATCH 099/120] drm_vout: Set zpos on the plane we pick to ensure it
+Subject: [PATCH 099/121] drm_vout: Set zpos on the plane we pick to ensure it
  is at the front
 
 ---
@@ -30814,7 +30814,7 @@ Subject: [PATCH 099/120] drm_vout: Set zpos on the plane we pick to ensure it
  1 file changed, 33 insertions(+), 5 deletions(-)
 
 diff --git a/libavdevice/drm_vout.c b/libavdevice/drm_vout.c
-index 15ed1b8825..8369dc6411 100644
+index cfb33ce7c3..9bd9e04421 100644
 --- a/libavdevice/drm_vout.c
 +++ b/libavdevice/drm_vout.c
 @@ -115,9 +115,11 @@ static int find_plane(struct AVFormatContext * const avctx,
@@ -30873,10 +30873,10 @@ index 15ed1b8825..8369dc6411 100644
  
  static void da_uninit(drm_display_env_t * const de, drm_aux_t * da)
 
-From a92f752c7f6c5ba8d10d0d28bd5e00b01e1f20ef Mon Sep 17 00:00:00 2001
+From 0ee1c3b41774d05595376f8d25de2a901dbb12c7 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 12 Dec 2022 17:51:46 +0000
-Subject: [PATCH 100/120] drm_vout: Only set modifier flag and pass modifiers
+Subject: [PATCH 100/121] drm_vout: Only set modifier flag and pass modifiers
  if there are some
 
 ---
@@ -30884,7 +30884,7 @@ Subject: [PATCH 100/120] drm_vout: Only set modifier flag and pass modifiers
  1 file changed, 12 insertions(+), 5 deletions(-)
 
 diff --git a/libavdevice/drm_vout.c b/libavdevice/drm_vout.c
-index 8369dc6411..ccb9484668 100644
+index 9bd9e04421..a56adea866 100644
 --- a/libavdevice/drm_vout.c
 +++ b/libavdevice/drm_vout.c
 @@ -34,6 +34,7 @@
@@ -30933,17 +30933,17 @@ index 8369dc6411..ccb9484668 100644
              return -1;
          }
 
-From fb14b3bd5f5377118bd36c7fa59c97a323c76937 Mon Sep 17 00:00:00 2001
+From 4534e6981c1718eaeec4c5f58cdf5592ee7f0329 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 12 Dec 2022 17:52:58 +0000
-Subject: [PATCH 101/120] drm_vout: Fix typo in error message
+Subject: [PATCH 101/121] drm_vout: Fix typo in error message
 
 ---
  libavdevice/drm_vout.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavdevice/drm_vout.c b/libavdevice/drm_vout.c
-index ccb9484668..0510834942 100644
+index a56adea866..351abf1d60 100644
 --- a/libavdevice/drm_vout.c
 +++ b/libavdevice/drm_vout.c
 @@ -596,7 +596,7 @@ static int drm_vout_init(struct AVFormatContext * s)
@@ -30956,17 +30956,17 @@ index ccb9484668..0510834942 100644
      }
  
 
-From 0bf60f487e3f61f7d2f464f0fa682ecb8f942daf Mon Sep 17 00:00:00 2001
+From 0469d1fb132a0d55593611c56e83733efe58045b Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 12 Dec 2022 18:00:41 +0000
-Subject: [PATCH 102/120] drm_vout: Add option to name the drm_module to use
+Subject: [PATCH 102/121] drm_vout: Add option to name the drm_module to use
 
 ---
  libavdevice/drm_vout.c | 8 +++++---
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/libavdevice/drm_vout.c b/libavdevice/drm_vout.c
-index 0510834942..07dc656777 100644
+index 351abf1d60..491e1dc608 100644
 --- a/libavdevice/drm_vout.c
 +++ b/libavdevice/drm_vout.c
 @@ -70,7 +70,9 @@ typedef struct drm_display_env_s
@@ -31009,10 +31009,10 @@ index 0510834942..07dc656777 100644
  };
  
 
-From b44057a48d104b374eed0ac0f0d635b024af6930 Mon Sep 17 00:00:00 2001
+From 61cb9fc3ce06e0ecaeeec3add143bc3a82956853 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 13 Dec 2022 13:01:00 +0000
-Subject: [PATCH 103/120] dmabufs: Rework to allow for non-CMA backends
+Subject: [PATCH 103/121] dmabufs: Rework to allow for non-CMA backends
 
 ---
  libavcodec/v4l2_req_dmabufs.c | 161 ++++++++++++++++++++++++----------
@@ -31263,10 +31263,10 @@ index c4bbed18c6..1c3a5e861f 100644
 +}
  
 
-From 108360ef02f6c16872147cb1d8b8b4fe906a6f67 Mon Sep 17 00:00:00 2001
+From 288807720443bbddf4c83c3589d1877c7fd418c3 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 13 Dec 2022 13:07:58 +0000
-Subject: [PATCH 104/120] dmabufs: Use unref rather than deleet on cmabufs_ctl
+Subject: [PATCH 104/121] dmabufs: Use unref rather than deleet on cmabufs_ctl
 
 ---
  libavcodec/v4l2_req_dmabufs.c  | 12 +++++++++++-
@@ -31351,17 +31351,17 @@ index 767ecb036a..db7ed13b6d 100644
      devscan_delete(&ctx->devscan);
      return ret;
 
-From 067f436e1d053af11bb6c8d6ba42dede164247c0 Mon Sep 17 00:00:00 2001
+From 9115f40c5f55873102312085f2e328d1a2101ae4 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 13 Dec 2022 14:21:40 +0000
-Subject: [PATCH 105/120] egl_vout: Remove redundant & completely broken debug
+Subject: [PATCH 105/121] egl_vout: Remove redundant & completely broken debug
 
 ---
  libavdevice/egl_vout.c | 25 -------------------------
  1 file changed, 25 deletions(-)
 
 diff --git a/libavdevice/egl_vout.c b/libavdevice/egl_vout.c
-index 8fd3c58bac..c2659e96dc 100644
+index a52cabb082..afc7afd13e 100644
 --- a/libavdevice/egl_vout.c
 +++ b/libavdevice/egl_vout.c
 @@ -515,31 +515,6 @@ static int do_display(AVFormatContext *const s, egl_display_env_t *const de, AVF
@@ -31397,10 +31397,10 @@ index 8fd3c58bac..c2659e96dc 100644
  
      glClearColor(0.5, 0.5, 0.5, 0.5);
 
-From ba04b91800e5a17ff1cee5023d94e304037cd7d5 Mon Sep 17 00:00:00 2001
+From 34711d5a1429213b6f4cf8ad163e8e8d108626e7 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 13 Dec 2022 16:12:12 +0000
-Subject: [PATCH 106/120] v4l2m2m: Use offset from querybuf rather than always
+Subject: [PATCH 106/121] v4l2m2m: Use offset from querybuf rather than always
  0
 
 ---
@@ -31452,10 +31452,10 @@ index 1ac32c5989..d91d5d1dd0 100644
          size_t length;
      } plane_info[VIDEO_MAX_PLANES];
 
-From e7b15fa9f59f25e074a1f59ed5d16e158bdf8a76 Mon Sep 17 00:00:00 2001
+From 15458be3fe79c14f4fdcc2ad786508d1b647c914 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 13 Dec 2022 17:57:27 +0000
-Subject: [PATCH 107/120] v4l2m2m: Fix crash if init errors out before setting
+Subject: [PATCH 107/121] v4l2m2m: Fix crash if init errors out before setting
  avctx
 
 ---
@@ -31463,10 +31463,10 @@ Subject: [PATCH 107/120] v4l2m2m: Fix crash if init errors out before setting
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/v4l2_m2m.c b/libavcodec/v4l2_m2m.c
-index e29df41729..cc4503dcae 100644
+index 1e30d15fd8..ac6bae0dc3 100644
 --- a/libavcodec/v4l2_m2m.c
 +++ b/libavcodec/v4l2_m2m.c
-@@ -276,7 +276,7 @@ int ff_v4l2_m2m_codec_end(V4L2m2mPriv *priv)
+@@ -278,7 +278,7 @@ int ff_v4l2_m2m_codec_end(V4L2m2mPriv *priv)
  
      av_log(s->avctx, AV_LOG_DEBUG, "V4L2 Codec end\n");
  
@@ -31476,10 +31476,10 @@ index e29df41729..cc4503dcae 100644
  
      if (s->fd >= 0) {
 
-From 536e74b776084d66d33730114c96cfc17866180a Mon Sep 17 00:00:00 2001
+From 9f7f94c680b8aaedede9b3bcad37b645216cfcff Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 13 Dec 2022 18:10:30 +0000
-Subject: [PATCH 108/120] v4l2_buffers: Add and use ctx_to_m2mctx + error debug
+Subject: [PATCH 108/121] v4l2_buffers: Add and use ctx_to_m2mctx + error debug
 
 ---
  libavcodec/v4l2_buffers.c | 22 +++++++++++++++-------
@@ -31543,10 +31543,10 @@ index 5ca58ea593..e28ef2d1e8 100644
      }
  
 
-From c691e8309d798048c52c8c32427c50cfcbe65055 Mon Sep 17 00:00:00 2001
+From 6b8bb2c41828351cd3a6f40be353696ae36450b7 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 13 Dec 2022 18:53:22 +0000
-Subject: [PATCH 109/120] v4l2m2m: Add ability to use cma alloced dmabufs as
+Subject: [PATCH 109/121] v4l2m2m: Add ability to use cma alloced dmabufs as
  well as v4l2 mmap
 
 ---
@@ -31559,10 +31559,10 @@ Subject: [PATCH 109/120] v4l2m2m: Add ability to use cma alloced dmabufs as
  6 files changed, 71 insertions(+), 24 deletions(-)
 
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 928756850f..daf7456d73 100644
+index 11f183c9b9..8b1d669834 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -162,7 +162,7 @@ OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
+@@ -170,7 +170,7 @@ OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
  OBJS-$(CONFIG_VP56DSP)                 += vp56dsp.o
  OBJS-$(CONFIG_VP8DSP)                  += vp8dsp.o
  OBJS-$(CONFIG_V4L2_M2M)                += v4l2_m2m.o v4l2_context.o v4l2_buffers.o v4l2_fmt.o\
@@ -31690,7 +31690,7 @@ index d91d5d1dd0..444ad94b14 100644
  
  /**
 diff --git a/libavcodec/v4l2_m2m.c b/libavcodec/v4l2_m2m.c
-index cc4503dcae..cb95031610 100644
+index ac6bae0dc3..f802687b1b 100644
 --- a/libavcodec/v4l2_m2m.c
 +++ b/libavcodec/v4l2_m2m.c
 @@ -34,6 +34,7 @@
@@ -31725,7 +31725,7 @@ index cc4503dcae..cb95031610 100644
          return 0;
      }
  
-@@ -291,6 +294,7 @@ int ff_v4l2_m2m_codec_end(V4L2m2mPriv *priv)
+@@ -293,6 +296,7 @@ int ff_v4l2_m2m_codec_end(V4L2m2mPriv *priv)
  
      ff_v4l2_context_release(&s->output);
  
@@ -31763,7 +31763,7 @@ index 26a7161042..0f41f94694 100644
  } V4L2m2mPriv;
  
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 73ce427052..663cb60a60 100644
+index 47b2735f82..4d17057298 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -41,6 +41,7 @@
@@ -31804,10 +31804,10 @@ index 73ce427052..663cb60a60 100644
  };
  
 
-From a6fb8bbf969abb06e18ac5b3fd5ad4b24791f228 Mon Sep 17 00:00:00 2001
+From 499bcdc4ed82c737ceab166a07b46e8ed8ccbc88 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 13 Dec 2022 19:05:47 +0000
-Subject: [PATCH 110/120] testfilt: Skeleton of hw filter test code
+Subject: [PATCH 110/121] testfilt: Skeleton of hw filter test code
 
 ---
  pi-util/testfilt.py | 83 +++++++++++++++++++++++++++++++++++++++++++++
@@ -31904,10 +31904,10 @@ index 0000000000..b322dac0c2
 +                                   "-c:v", "h264_v4l2m2m", "-b:v", "2M"], ".mkv",
 +            [valid_regex(r'Output stream #0:0 \(video\): 900 frames encoded; 900 packets muxed')])
 
-From f3e75d79420faff8244d53cf60b555df4d1549f3 Mon Sep 17 00:00:00 2001
+From 50ac318a472fd98e1e58605316ea6a2e8cde0a04 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Thu, 5 Jan 2023 14:39:30 +0000
-Subject: [PATCH 111/120] pixfmt: Add a #define to indicate presence of SAND
+Subject: [PATCH 111/121] pixfmt: Add a #define to indicate presence of SAND
  formats
 
 ---
@@ -31915,10 +31915,10 @@ Subject: [PATCH 111/120] pixfmt: Add a #define to indicate presence of SAND
  1 file changed, 2 insertions(+)
 
 diff --git a/libavutil/pixfmt.h b/libavutil/pixfmt.h
-index b0dae0fe83..c917e5ac62 100644
+index 22f70007c3..5cc780e7d5 100644
 --- a/libavutil/pixfmt.h
 +++ b/libavutil/pixfmt.h
-@@ -350,6 +350,8 @@ enum AVPixelFormat {
+@@ -378,6 +378,8 @@ enum AVPixelFormat {
      AV_PIX_FMT_Y210BE,    ///< packed YUV 4:2:2 like YUYV422, 20bpp, data in the high bits, big-endian
      AV_PIX_FMT_Y210LE,    ///< packed YUV 4:2:2 like YUYV422, 20bpp, data in the high bits, little-endian
  // RPI - not on ifdef so can be got at by calling progs
@@ -31928,17 +31928,17 @@ index b0dae0fe83..c917e5ac62 100644
      AV_PIX_FMT_SAND64_10,  ///< 4:2:0 10-bit  64x*Y stripe, 32x*UV stripe, then next x stripe, mysterious padding
      AV_PIX_FMT_SAND64_16,  ///< 4:2:0 16-bit  64x*Y stripe, 32x*UV stripe, then next x stripe, mysterious padding
 
-From 1f8906af1d2a493b1b594e7329cdef219e1660f8 Mon Sep 17 00:00:00 2001
+From 23a3132e094d449ea05657704c0cffc3f0762c28 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 11 Jan 2023 16:30:37 +0000
-Subject: [PATCH 112/120] v4l2_m2m_dec: Fix initial pkt send if no extradata
+Subject: [PATCH 112/121] v4l2_m2m_dec: Fix initial pkt send if no extradata
 
 ---
  libavcodec/v4l2_m2m_dec.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 663cb60a60..1668945cff 100644
+index 4d17057298..9daf05adfe 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -240,7 +240,7 @@ copy_extradata(AVCodecContext * const avctx,
@@ -31960,10 +31960,10 @@ index 663cb60a60..1668945cff 100644
  
      if (ret == AVERROR(EAGAIN)) {
 
-From 1beaf80a9f23aa703c50d1882117ccf1de8a3eb4 Mon Sep 17 00:00:00 2001
+From f4f6b9f1af137153e574c704804033e83f2ed1a8 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 16 Jan 2023 16:05:09 +0000
-Subject: [PATCH 113/120] v4l2m2m_dec: Make capture timeout long once pending
+Subject: [PATCH 113/121] v4l2m2m_dec: Make capture timeout long once pending
  count > 31
 
 For some applications (ffmpeg command line) the current heuristic of adding
@@ -32003,7 +32003,7 @@ index 0f41f94694..ded1478a49 100644
  
      /* Reference to a frame. Only used during encoding */
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 1668945cff..32d5548707 100644
+index 9daf05adfe..c8ab883d7e 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -582,7 +582,7 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -32057,19 +32057,19 @@ index 1668945cff..32d5548707 100644
      output->done = 0;
      capture->done = 0;
 
-From 97544fd1ff03633266534860fc4c66fc8e9ca0a1 Mon Sep 17 00:00:00 2001
+From 39f49cdaefa4483914f703c3f352c8894b3b81fd Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 6 Feb 2023 19:23:16 +0000
-Subject: [PATCH 114/120] Initial buffersink alloc callback code
+Subject: [PATCH 114/121] Initial buffersink alloc callback code
 
 (cherry picked from commit dde8d3c8f3cc279b9b92ed4f10a2e3990f4aadeb)
 ---
- libavfilter/buffersink.c | 22 ++++++++++++++++++++++
+ libavfilter/buffersink.c | 44 ++++++++++++++++++++++++++++++++++++++++
  libavfilter/buffersink.h |  3 +++
- 2 files changed, 25 insertions(+)
+ 2 files changed, 47 insertions(+)
 
 diff --git a/libavfilter/buffersink.c b/libavfilter/buffersink.c
-index e269cf72d1..d3c82aabf3 100644
+index 306c283f77..d3c82aabf3 100644
 --- a/libavfilter/buffersink.c
 +++ b/libavfilter/buffersink.c
 @@ -62,6 +62,11 @@ typedef struct BufferSinkContext {
@@ -32084,7 +32084,7 @@ index e269cf72d1..d3c82aabf3 100644
  } BufferSinkContext;
  
  #define NB_ITEMS(list) (list ## _size / sizeof(*list))
-@@ -154,6 +159,22 @@ int attribute_align_arg av_buffersink_get_samples(AVFilterContext *ctx,
+@@ -154,6 +159,44 @@ int attribute_align_arg av_buffersink_get_samples(AVFilterContext *ctx,
      return get_frame_internal(ctx, frame, 0, nb_samples);
  }
  
@@ -32104,10 +32104,32 @@ index e269cf72d1..d3c82aabf3 100644
 +    return 0;
 +}
 +
- #if FF_API_BUFFERSINK_ALLOC
- AVBufferSinkParams *av_buffersink_params_alloc(void)
++#if FF_API_BUFFERSINK_ALLOC
++AVBufferSinkParams *av_buffersink_params_alloc(void)
++{
++    static const int pixel_fmts[] = { AV_PIX_FMT_NONE };
++    AVBufferSinkParams *params = av_malloc(sizeof(AVBufferSinkParams));
++    if (!params)
++        return NULL;
++
++    params->pixel_fmts = pixel_fmts;
++    return params;
++}
++
++AVABufferSinkParams *av_abuffersink_params_alloc(void)
++{
++    AVABufferSinkParams *params = av_mallocz(sizeof(AVABufferSinkParams));
++
++    if (!params)
++        return NULL;
++    return params;
++}
++#endif
++
+ static av_cold int common_init(AVFilterContext *ctx)
  {
-@@ -403,6 +424,7 @@ static const AVFilterPad avfilter_vsink_buffer_inputs[] = {
+     BufferSinkContext *buf = ctx->priv;
+@@ -381,6 +424,7 @@ static const AVFilterPad avfilter_vsink_buffer_inputs[] = {
      {
          .name = "default",
          .type = AVMEDIA_TYPE_VIDEO,
@@ -32116,10 +32138,10 @@ index e269cf72d1..d3c82aabf3 100644
  };
  
 diff --git a/libavfilter/buffersink.h b/libavfilter/buffersink.h
-index 01e7c747d8..52fbb9cac6 100644
+index 64e08de53e..09737d322f 100644
 --- a/libavfilter/buffersink.h
 +++ b/libavfilter/buffersink.h
-@@ -202,6 +202,9 @@ int av_buffersink_get_frame(AVFilterContext *ctx, AVFrame *frame);
+@@ -166,6 +166,9 @@ int av_buffersink_get_frame(AVFilterContext *ctx, AVFrame *frame);
   */
  int av_buffersink_get_samples(AVFilterContext *ctx, AVFrame *frame, int nb_samples);
  
@@ -32130,10 +32152,10 @@ index 01e7c747d8..52fbb9cac6 100644
   * @}
   */
 
-From a5ffdc0751f0dad65cfd0757590760ac669d11e5 Mon Sep 17 00:00:00 2001
+From a63ae21e74ae48f1aedac53c18142b7596d041ad Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 30 Jan 2023 17:23:12 +0000
-Subject: [PATCH 115/120] v4l2_m2m_dec: Add a profile check
+Subject: [PATCH 115/121] v4l2_m2m_dec: Add a profile check
 
 Check the profile in avctx aginst what the v4l2 driver advertises. If
 the driver doesn't support the check then just accept anything.
@@ -32144,7 +32166,7 @@ the driver doesn't support the check then just accept anything.
  1 file changed, 125 insertions(+)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 32d5548707..b0735e8b62 100644
+index c8ab883d7e..098adf4821 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -715,6 +715,127 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -32287,10 +32309,10 @@ index 32d5548707..b0735e8b62 100644
  }
  
 
-From 99a716c8858e97ac48c688a7d3229ab529fb0591 Mon Sep 17 00:00:00 2001
+From f734a6ead04a8381fccfae53066866a02a9516d2 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Wed, 1 Feb 2023 17:24:39 +0000
-Subject: [PATCH 116/120] v4l2_m2m_dec: Add extradata parse for h264 & hevc
+Subject: [PATCH 116/121] v4l2_m2m_dec: Add extradata parse for h264 & hevc
 
 If we have extradata we can extract profile & level and potentailly
 other useful info from it. Use the codec parser to get it if the decoder
@@ -32302,7 +32324,7 @@ is configured.
  1 file changed, 83 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index b0735e8b62..636a825ab9 100644
+index 098adf4821..e64bc707d3 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -21,6 +21,8 @@
@@ -32418,10 +32440,10 @@ index b0735e8b62..636a825ab9 100644
      if (ret < 0)
          return ret;
 
-From 413f6a651d941c10bbf612eb787414cc213d02c6 Mon Sep 17 00:00:00 2001
+From e28421e397743a94f5e37327ad234f59b6ae613d Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 20 Mar 2023 18:12:51 +0000
-Subject: [PATCH 117/120] clean_usr_libs: Now wipes the include files too
+Subject: [PATCH 117/121] clean_usr_libs: Now wipes the include files too
 
 When swapping ffmpeg versions obsolete makefiles could confuse
 configure utilities.
@@ -32455,10 +32477,10 @@ index b3b2d5509d..01bd6a6a22 100755
  rm -f $U/libavcodec.*
  rm -f $U/libavdevice.*
 
-From b76725ec990f3821793371a5f4b23b0243dbec97 Mon Sep 17 00:00:00 2001
+From dcabd30310b88b45359609bac27d5d0f9bbc6dc1 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Mon, 20 Mar 2023 18:15:08 +0000
-Subject: [PATCH 118/120] vulkan: Add missing decode extension defines
+Subject: [PATCH 118/121] vulkan: Add missing decode extension defines
 
 When building on bookworm the video decode extension names
 were missing. This adds them. I expect this patch will be
@@ -32468,7 +32490,7 @@ obsolete shortly but it solves a current problem.
  1 file changed, 8 insertions(+)
 
 diff --git a/libavutil/hwcontext_vulkan.c b/libavutil/hwcontext_vulkan.c
-index 237caa4bc0..522acd1d88 100644
+index 2a9b5f4aac..11e7945f18 100644
 --- a/libavutil/hwcontext_vulkan.c
 +++ b/libavutil/hwcontext_vulkan.c
 @@ -57,6 +57,14 @@
@@ -32487,10 +32509,10 @@ index 237caa4bc0..522acd1d88 100644
      VkFence fence;
      VkQueue queue;
 
-From 2bb2705c22cb11473129a21b5e4dcbfae3f5f79d Mon Sep 17 00:00:00 2001
+From 0231c208843a5badc799590eb5b9de907d1c26b2 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 21 Mar 2023 14:20:05 +0000
-Subject: [PATCH 119/120] v4l2_m2m_dec: Fix config file for finding if decoder
+Subject: [PATCH 119/121] v4l2_m2m_dec: Fix config file for finding if decoder
  enabled
 
 Fixes parsing of extradata for profile testing. 5.x changed where that
@@ -32500,7 +32522,7 @@ info is defined.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 636a825ab9..2215c6989f 100644
+index e64bc707d3..91136f03da 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -21,7 +21,7 @@
@@ -32513,10 +32535,10 @@ index 636a825ab9..2215c6989f 100644
  #include <linux/videodev2.h>
  #include <sys/ioctl.h>
 
-From 16b34ca779f373728ad4056a40eab70773ed5596 Mon Sep 17 00:00:00 2001
+From 822baefed69372b3380144ab44226e2c6ad3e298 Mon Sep 17 00:00:00 2001
 From: John Cox <jc@kynesim.co.uk>
 Date: Tue, 21 Mar 2023 14:23:20 +0000
-Subject: [PATCH 120/120] v4l2_m2m_dec: Display profile given if skipped in
+Subject: [PATCH 120/121] v4l2_m2m_dec: Display profile given if skipped in
  debug
 
 ---
@@ -32524,7 +32546,7 @@ Subject: [PATCH 120/120] v4l2_m2m_dec: Display profile given if skipped in
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 2215c6989f..7681279fc2 100644
+index 91136f03da..d124c7b1fc 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -792,7 +792,7 @@ check_profile(AVCodecContext *const avctx, V4L2m2mContext *const s)
@@ -32535,4 +32557,60 @@ index 2215c6989f..7681279fc2 100644
 +        av_log(avctx, AV_LOG_VERBOSE, "Profile %d <= 0 - check skipped\n", avctx->profile);
          return 0;
      }
+ 
+
+From 6859fc2a8791c0fcc25851b77fed15a691ceb332 Mon Sep 17 00:00:00 2001
+From: John Cox <jc@kynesim.co.uk>
+Date: Wed, 22 Mar 2023 16:08:08 +0000
+Subject: [PATCH 121/121] conf_native: Fix for 64-bit kernel with 32-bit
+ userspace
+
+(cherry picked from commit 5bb1e09cea95b4215c6904b9b1a726e83bc5d327)
+---
+ pi-util/conf_native.sh | 32 +++++++++++++++++++++-----------
+ 1 file changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/pi-util/conf_native.sh b/pi-util/conf_native.sh
+index 082d9b5832..0a7d230f1b 100755
+--- a/pi-util/conf_native.sh
++++ b/pi-util/conf_native.sh
+@@ -33,18 +33,28 @@ RPI_LIBDIRS=
+ RPI_DEFINES=
+ RPI_EXTRALIBS=
+ 
+-if [ "$MC" == "arm64" ]; then
+-  echo "M/C aarch64"
+-  A=aarch64-linux-gnu
+-  B=arm64
+-elif [ "$MC" == "armhf" ]; then
+-  echo "M/C armv7"
+-  A=arm-linux-gnueabihf
+-  B=armv7
+-  MCOPTS="--arch=armv6t2 --cpu=cortex-a7"
+-  RPI_DEFINES=-mfpu=neon-vfpv4
++# uname -m gives kernel type which may not have the same
++# 32/64bitness as userspace :-( getconf shoudl provide the answer
++# but use uname to check we are on the right processor
++MC=`uname -m`
++LB=`getconf LONG_BIT`
++if [ "$MC" == "armv7l" ] || [ "$MC" == "aarch64" ]; then
++  if [ "$LB" == "32" ]; then
++    echo "M/C armv7"
++    A=arm-linux-gnueabihf
++    B=armv7
++    MCOPTS="--arch=armv6t2 --cpu=cortex-a7"
++    RPI_DEFINES=-mfpu=neon-vfpv4
++  elif [ "$LB" == "64" ]; then
++    echo "M/C aarch64"
++    A=aarch64-linux-gnu
++    B=arm64
++  else
++    echo "Unknown LONG_BIT name: $LB"
++    exit 1
++  fi
+ else
+-  echo Unexpected architecture $MC
++  echo "Unknown machine name: $MC"
+   exit 1
+ fi
  

--- a/packages/multimedia/ffmpeg/patches/v4l2-drmprime/ffmpeg-001-v4l2-drmprime.patch
+++ b/packages/multimedia/ffmpeg/patches/v4l2-drmprime/ffmpeg-001-v4l2-drmprime.patch
@@ -1,7 +1,7 @@
-From c4be609d822229be09cd9dd6f64cad716b0a48ce Mon Sep 17 00:00:00 2001
+From d08054c6eb2bb041e554b9fa24013d521f7ff024 Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Tue, 24 Apr 2018 23:00:23 -0700
-Subject: [PATCH 1/9] libavcodec: v4l2m2m: output AVDRMFrameDescriptor
+Subject: [PATCH 1/8] libavcodec: v4l2m2m: output AVDRMFrameDescriptor
 
 This allows for a zero-copy output by exporting the v4l2 buffer then wrapping that buffer
 in the AVDRMFrameDescriptor like it is done in rkmpp.
@@ -282,7 +282,7 @@ index 3d2ff1b9a5..b82c990dcc 100644
       * of how many context-refs we are holding. */
      AVBufferRef *context_ref;
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index e891649f92..4de23e687c 100644
+index a40be94690..5bbab77c1e 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -441,22 +441,54 @@ static int v4l2_release_buffers(V4L2Context* ctx)
@@ -345,7 +345,7 @@ index e891649f92..4de23e687c 100644
  
  static inline int v4l2_try_raw_format(V4L2Context* ctx, enum AVPixelFormat pixfmt)
 diff --git a/libavcodec/v4l2_m2m.h b/libavcodec/v4l2_m2m.h
-index b67b216331..0fbd19a013 100644
+index 04d86d7b92..4251efcb86 100644
 --- a/libavcodec/v4l2_m2m.h
 +++ b/libavcodec/v4l2_m2m.h
 @@ -66,6 +66,9 @@ typedef struct V4L2m2mContext {
@@ -359,7 +359,7 @@ index b67b216331..0fbd19a013 100644
  
  typedef struct V4L2m2mPriv {
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 8a51dec3fa..d916a3b726 100644
+index 4944d08511..9a2b922fb1 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -23,6 +23,9 @@
@@ -410,10 +410,10 @@ index 8a51dec3fa..d916a3b726 100644
  #define M2MDEC_CLASS(NAME) \
      static const AVClass v4l2_m2m_ ## NAME ## _dec_class = { \
          .class_name = #NAME "_v4l2m2m_decoder", \
-@@ -253,6 +273,9 @@ static const AVOption options[] = {
-         .bsfs           = bsf_name, \
+@@ -254,6 +274,9 @@ static const AVOption options[] = {
          .p.capabilities = AV_CODEC_CAP_HARDWARE | AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AVOID_PROBING, \
-         .caps_internal  = FF_CODEC_CAP_SETS_PKT_DTS | FF_CODEC_CAP_INIT_CLEANUP, \
+         .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE | \
+                           FF_CODEC_CAP_SETS_PKT_DTS | FF_CODEC_CAP_INIT_CLEANUP, \
 +        .p.pix_fmts     = (const enum AVPixelFormat[]) { AV_PIX_FMT_DRM_PRIME, \
 +                                                         AV_PIX_FMT_NONE}, \
 +        .hw_configs     = v4l2_m2m_hw_configs, \
@@ -421,10 +421,10 @@ index 8a51dec3fa..d916a3b726 100644
      }
  
 
-From bb47b0e2ce4dda5ddeb4568d2b0260ec950d68cd Mon Sep 17 00:00:00 2001
+From bb9db9b85e0f1c99a4b6cd9bea2d86ce64af05b5 Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Thu, 16 Aug 2018 21:09:40 -0700
-Subject: [PATCH 2/9] libavcodec: v4l2m2m: depends on libdrm
+Subject: [PATCH 2/8] libavcodec: v4l2m2m: depends on libdrm
 
 ---
  configure                 | 1 +
@@ -432,10 +432,10 @@ Subject: [PATCH 2/9] libavcodec: v4l2m2m: depends on libdrm
  2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index ba5793b2ff..1872046e0e 100755
+index b6616f00b6..09a824a579 100755
 --- a/configure
 +++ b/configure
-@@ -3539,6 +3539,7 @@ sndio_indev_deps="sndio"
+@@ -3549,6 +3549,7 @@ sndio_indev_deps="sndio"
  sndio_outdev_deps="sndio"
  v4l2_indev_deps_any="linux_videodev2_h sys_videoio_h"
  v4l2_indev_suggest="libv4l2"
@@ -457,10 +457,10 @@ index 07662b5fc3..d41558527c 100644
  #include <sys/ioctl.h>
  #include <sys/mman.h>
 
-From a362c4ec155e5e38c7a1ed3d3c57054ba09d9945 Mon Sep 17 00:00:00 2001
+From 22928b7f1ae1054f303a50c60f9fc5f5d0c7c08b Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Thu, 16 Aug 2018 21:10:13 -0700
-Subject: [PATCH 3/9] libavcodec: v4l2m2m: set format_modifier to
+Subject: [PATCH 3/8] libavcodec: v4l2m2m: set format_modifier to
  DRM_FORMAT_MOD_LINEAR
 
 ---
@@ -485,10 +485,10 @@ index d41558527c..95c8a1e409 100644
      }
  
 
-From d4c8398a40baae35c79c1baf7e99306edda53e1a Mon Sep 17 00:00:00 2001
+From 87182c63602793c3310b207400bf77c8f2d0d1d8 Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Thu, 16 Aug 2018 21:10:53 -0700
-Subject: [PATCH 4/9] libavcodec: v4l2m2m: only mmap the buffer when it is
+Subject: [PATCH 4/8] libavcodec: v4l2m2m: only mmap the buffer when it is
  output type and drm prime is used
 
 ---
@@ -529,17 +529,17 @@ index 95c8a1e409..0a65f32cb2 100644
  
          if (avbuf->plane_info[i].mm_addr == MAP_FAILED)
 
-From 5c468fefad99503d2fe53e5a83ef29a409f0abaa Mon Sep 17 00:00:00 2001
+From edc89c1d0214e9fbc3c33ea26efe9a86456931c4 Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Thu, 16 Aug 2018 21:11:38 -0700
-Subject: [PATCH 5/9] libavcodec: v4l2m2m: allow using software pixel formats
+Subject: [PATCH 5/8] libavcodec: v4l2m2m: allow using software pixel formats
 
 ---
  libavcodec/v4l2_m2m_dec.c | 11 ++++++++++-
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index d916a3b726..7787a2c185 100644
+index 9a2b922fb1..11b893cc65 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -217,8 +217,16 @@ static av_cold int v4l2_decode_init(AVCodecContext *avctx)
@@ -560,19 +560,19 @@ index d916a3b726..7787a2c185 100644
  
      s->avctx = avctx;
      ret = ff_v4l2_m2m_codec_init(priv);
-@@ -274,6 +282,7 @@ static const AVCodecHWConfigInternal *v4l2_m2m_hw_configs[] = {
-         .p.capabilities = AV_CODEC_CAP_HARDWARE | AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AVOID_PROBING, \
-         .caps_internal  = FF_CODEC_CAP_SETS_PKT_DTS | FF_CODEC_CAP_INIT_CLEANUP, \
+@@ -275,6 +283,7 @@ static const AVCodecHWConfigInternal *v4l2_m2m_hw_configs[] = {
+         .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE | \
+                           FF_CODEC_CAP_SETS_PKT_DTS | FF_CODEC_CAP_INIT_CLEANUP, \
          .p.pix_fmts     = (const enum AVPixelFormat[]) { AV_PIX_FMT_DRM_PRIME, \
 +                                                         AV_PIX_FMT_NV12, \
                                                           AV_PIX_FMT_NONE}, \
          .hw_configs     = v4l2_m2m_hw_configs, \
          .p.wrapper_name = "v4l2m2m", \
 
-From dd923e56e054df2f1bb275cef039b82e94fcbcb6 Mon Sep 17 00:00:00 2001
+From 180e12f23b20ff358956fd6cb24db665535cad04 Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Mon, 24 Sep 2018 13:39:31 -0700
-Subject: [PATCH 6/9] libavcodec: v4l2m2m: implement hwcontext
+Subject: [PATCH 6/8] libavcodec: v4l2m2m: implement hwcontext
 
 ---
  libavcodec/v4l2_buffers.c | 22 ++++++++++++++++++++++
@@ -635,7 +635,7 @@ index 6f7460c89a..02fbb6eec3 100644
  
  /**
 diff --git a/libavcodec/v4l2_m2m.h b/libavcodec/v4l2_m2m.h
-index 0fbd19a013..adf5997bb5 100644
+index 4251efcb86..1082b9dad2 100644
 --- a/libavcodec/v4l2_m2m.h
 +++ b/libavcodec/v4l2_m2m.h
 @@ -67,6 +67,8 @@ typedef struct V4L2m2mContext {
@@ -648,7 +648,7 @@ index 0fbd19a013..adf5997bb5 100644
      int output_drm;
  } V4L2m2mContext;
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 7787a2c185..9aca68e48c 100644
+index 11b893cc65..6f67aabcbd 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -35,6 +35,7 @@
@@ -677,51 +677,10 @@ index 7787a2c185..9aca68e48c 100644
      ret = ff_v4l2_m2m_codec_init(priv);
      if (ret) {
 
-From 32ca7163c62887aa4b4032bbd5858a03bf3e145e Mon Sep 17 00:00:00 2001
-From: Lukas Rusak <lorusak@gmail.com>
-Date: Mon, 4 May 2020 13:01:29 -0700
-Subject: [PATCH 7/9] libavcodec: v4l2m2m: allow lower minimum buffer values
-
-There is no reason to enforce a high minimum. In the context
-of streaming only a few output buffers and capture buffers
-are even needed for continuous playback. This also helps
-alleviate memory pressure when decoding 4K media.
----
- libavcodec/v4l2_m2m.h     | 2 +-
- libavcodec/v4l2_m2m_dec.c | 2 +-
- 2 files changed, 2 insertions(+), 2 deletions(-)
-
-diff --git a/libavcodec/v4l2_m2m.h b/libavcodec/v4l2_m2m.h
-index adf5997bb5..1082b9dad2 100644
---- a/libavcodec/v4l2_m2m.h
-+++ b/libavcodec/v4l2_m2m.h
-@@ -38,7 +38,7 @@
- 
- #define V4L_M2M_DEFAULT_OPTS \
-     { "num_output_buffers", "Number of buffers in the output context",\
--        OFFSET(num_output_buffers), AV_OPT_TYPE_INT, { .i64 = 16 }, 6, INT_MAX, FLAGS }
-+        OFFSET(num_output_buffers), AV_OPT_TYPE_INT, { .i64 = 16 }, 2, INT_MAX, FLAGS }
- 
- typedef struct V4L2m2mContext {
-     char devname[PATH_MAX];
-diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 9aca68e48c..7afc81180d 100644
---- a/libavcodec/v4l2_m2m_dec.c
-+++ b/libavcodec/v4l2_m2m_dec.c
-@@ -260,7 +260,7 @@ static av_cold int v4l2_decode_close(AVCodecContext *avctx)
- static const AVOption options[] = {
-     V4L_M2M_DEFAULT_OPTS,
-     { "num_capture_buffers", "Number of buffers in the capture context",
--        OFFSET(num_capture_buffers), AV_OPT_TYPE_INT, {.i64 = 20}, 20, INT_MAX, FLAGS },
-+        OFFSET(num_capture_buffers), AV_OPT_TYPE_INT, {.i64 = 20}, 2, INT_MAX, FLAGS },
-     { NULL},
- };
- 
-
-From 199d87bed11be1665913b88d7cae9417f48afa37 Mon Sep 17 00:00:00 2001
+From 8c64981ace0a08bdc7eb445125a70f691ed829cb Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Wed, 6 May 2020 11:12:58 -0700
-Subject: [PATCH 8/9] libavcodec: v4l2m2m: add option to specify pixel format
+Subject: [PATCH 7/8] libavcodec: v4l2m2m: add option to specify pixel format
  used by the decoder
 
 ---
@@ -731,7 +690,7 @@ Subject: [PATCH 8/9] libavcodec: v4l2m2m: add option to specify pixel format
  3 files changed, 12 insertions(+)
 
 diff --git a/libavcodec/v4l2_context.c b/libavcodec/v4l2_context.c
-index 4de23e687c..49ef4a684f 100644
+index 5bbab77c1e..3bd1f37c75 100644
 --- a/libavcodec/v4l2_context.c
 +++ b/libavcodec/v4l2_context.c
 @@ -517,6 +517,8 @@ static inline int v4l2_try_raw_format(V4L2Context* ctx, enum AVPixelFormat pixfm
@@ -778,7 +737,7 @@ index 1082b9dad2..943a8923c4 100644
  
  /**
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index 7afc81180d..de89d0ff18 100644
+index 6f67aabcbd..279f26cbe6 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -261,6 +261,7 @@ static const AVOption options[] = {
@@ -790,17 +749,17 @@ index 7afc81180d..de89d0ff18 100644
  };
  
 
-From 38c65aab679c04e4dd5a58f889844e68e34c80ab Mon Sep 17 00:00:00 2001
+From 807bf8da5fa9f28443b5eee9429fb2478171e8f7 Mon Sep 17 00:00:00 2001
 From: Lukas Rusak <lorusak@gmail.com>
 Date: Mon, 24 Sep 2018 13:39:56 -0700
-Subject: [PATCH 9/9] libavcodec: v4l2m2m: implement flush
+Subject: [PATCH 8/8] libavcodec: v4l2m2m: implement flush
 
 ---
  libavcodec/v4l2_m2m_dec.c | 36 ++++++++++++++++++++++++++++++++++++
  1 file changed, 36 insertions(+)
 
 diff --git a/libavcodec/v4l2_m2m_dec.c b/libavcodec/v4l2_m2m_dec.c
-index de89d0ff18..3278627553 100644
+index 279f26cbe6..8f1dd4a886 100644
 --- a/libavcodec/v4l2_m2m_dec.c
 +++ b/libavcodec/v4l2_m2m_dec.c
 @@ -254,6 +254,41 @@ static av_cold int v4l2_decode_close(AVCodecContext *avctx)
@@ -852,4 +811,4 @@ index de89d0ff18..3278627553 100644
 +        .flush          = v4l2_decode_flush, \
          .bsfs           = bsf_name, \
          .p.capabilities = AV_CODEC_CAP_HARDWARE | AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AVOID_PROBING, \
-         .caps_internal  = FF_CODEC_CAP_SETS_PKT_DTS | FF_CODEC_CAP_INIT_CLEANUP, \
+         .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE | \

--- a/packages/multimedia/ffmpeg/patches/v4l2-request/ffmpeg-001-v4l2-request.patch
+++ b/packages/multimedia/ffmpeg/patches/v4l2-request/ffmpeg-001-v4l2-request.patch
@@ -1,4 +1,4 @@
-From baea39c4a1898a8eb89548196722ae56b1e27515 Mon Sep 17 00:00:00 2001
+From 61a3cdcb354186f574bf3220de0472370fa53ccd Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Mon, 3 Dec 2018 23:48:04 +0100
 Subject: [PATCH 01/13] avutil: add av_buffer_pool_flush()
@@ -12,7 +12,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  2 files changed, 18 insertions(+)
 
 diff --git a/libavutil/buffer.c b/libavutil/buffer.c
-index 54590be566..1af892b348 100644
+index e4562a79b1..09da632c00 100644
 --- a/libavutil/buffer.c
 +++ b/libavutil/buffer.c
 @@ -319,6 +319,19 @@ static void buffer_pool_free(AVBufferPool *pool)
@@ -52,7 +52,7 @@ index e1ef5b7f07..fde9bae4f6 100644
   * Mark the pool as being available for freeing. It will actually be freed only
   * once all the allocated buffers associated with the pool are released. Thus it
 
-From 91c471c226611f23d0eb07a7c5975470a01be985 Mon Sep 17 00:00:00 2001
+From 3fe3baf21ef5c934699bfc0aefb4b2b4180c2c72 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 15 Dec 2018 22:32:16 +0100
 Subject: [PATCH 02/13] Add common V4L2 request API code
@@ -70,7 +70,7 @@ Signed-off-by: Alex Bee <knaerzche@gmail.com>
  create mode 100644 libavcodec/v4l2_request.h
 
 diff --git a/configure b/configure
-index ba5793b2ff..0ccfd0ac36 100755
+index b6616f00b6..6167b122e0 100755
 --- a/configure
 +++ b/configure
 @@ -281,6 +281,7 @@ External library support:
@@ -81,7 +81,7 @@ index ba5793b2ff..0ccfd0ac36 100755
    --enable-libv4l2         enable libv4l2/v4l-utils [no]
    --enable-libvidstab      enable video stabilization using vid.stab [no]
    --enable-libvmaf         enable vmaf filter via libvmaf [no]
-@@ -349,6 +350,7 @@ External library support:
+@@ -350,6 +351,7 @@ External library support:
    --enable-omx-rpi         enable OpenMAX IL code for Raspberry Pi [no]
    --enable-rkmpp           enable Rockchip Media Process Platform code [no]
    --disable-v4l2-m2m       disable V4L2 mem2mem code [autodetect]
@@ -89,7 +89,7 @@ index ba5793b2ff..0ccfd0ac36 100755
    --disable-vaapi          disable Video Acceleration API (mainly Unix/Intel) code [autodetect]
    --disable-vdpau          disable Nvidia Video Decode and Presentation API for Unix code [autodetect]
    --disable-videotoolbox   disable VideoToolbox code [autodetect]
-@@ -1869,6 +1871,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1857,6 +1859,7 @@ EXTERNAL_LIBRARY_LIST="
      libtheora
      libtwolame
      libuavs3d
@@ -97,7 +97,7 @@ index ba5793b2ff..0ccfd0ac36 100755
      libv4l2
      libvmaf
      libvorbis
-@@ -1924,6 +1927,7 @@ HWACCEL_LIBRARY_LIST="
+@@ -1913,6 +1916,7 @@ HWACCEL_LIBRARY_LIST="
      mmal
      omx
      opencl
@@ -105,7 +105,7 @@ index ba5793b2ff..0ccfd0ac36 100755
  "
  
  DOCUMENT_LIST="
-@@ -3011,6 +3015,7 @@ d3d11va_deps="dxva_h ID3D11VideoDecoder ID3D11VideoContext"
+@@ -2999,6 +3003,7 @@ d3d11va_deps="dxva_h ID3D11VideoDecoder ID3D11VideoContext"
  dxva2_deps="dxva2api_h DXVA2_ConfigPictureDecode ole32 user32"
  ffnvcodec_deps_any="libdl LoadLibrary"
  nvdec_deps="ffnvcodec"
@@ -113,7 +113,7 @@ index ba5793b2ff..0ccfd0ac36 100755
  vaapi_x11_deps="xlib_x11"
  videotoolbox_hwaccel_deps="videotoolbox pthreads"
  videotoolbox_hwaccel_extralibs="-framework QuartzCore"
-@@ -6634,6 +6639,7 @@ enabled libtwolame        && require libtwolame twolame.h twolame_init -ltwolame
+@@ -6692,6 +6697,7 @@ enabled libtwolame        && require libtwolame twolame.h twolame_init -ltwolame
                               { check_lib libtwolame twolame.h twolame_encode_buffer_float32_interleaved -ltwolame ||
                                 die "ERROR: libtwolame must be installed and version must be >= 0.3.10"; }
  enabled libuavs3d         && require_pkg_config libuavs3d "uavs3d >= 1.1.41" uavs3d.h uavs3d_decode
@@ -121,7 +121,7 @@ index ba5793b2ff..0ccfd0ac36 100755
  enabled libv4l2           && require_pkg_config libv4l2 libv4l2 libv4l2.h v4l2_ioctl
  enabled libvidstab        && require_pkg_config libvidstab "vidstab >= 0.98" vid.stab/libvidstab.h vsMotionDetectInit
  enabled libvmaf           && require_pkg_config libvmaf "libvmaf >= 2.0.0" libvmaf.h vmaf_init
-@@ -6735,6 +6741,10 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
+@@ -6794,6 +6800,10 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
                                 { enabled libdrm ||
                                   die "ERROR: rkmpp requires --enable-libdrm"; }
                               }
@@ -132,7 +132,7 @@ index ba5793b2ff..0ccfd0ac36 100755
  enabled vapoursynth       && require_pkg_config vapoursynth "vapoursynth-script >= 42" VSScript.h vsscript_init
  
  
-@@ -6817,6 +6827,8 @@ if enabled v4l2_m2m; then
+@@ -6876,6 +6886,8 @@ if enabled v4l2_m2m; then
      check_cc vp9_v4l2_m2m linux/videodev2.h "int i = V4L2_PIX_FMT_VP9;"
  fi
  
@@ -142,10 +142,10 @@ index ba5793b2ff..0ccfd0ac36 100755
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
  
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 457ec58377..3cb7dede11 100644
+index 389253f5d0..0148242ed0 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -162,6 +162,7 @@ OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
+@@ -170,6 +170,7 @@ OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
  OBJS-$(CONFIG_VP56DSP)                 += vp56dsp.o
  OBJS-$(CONFIG_VP8DSP)                  += vp8dsp.o
  OBJS-$(CONFIG_V4L2_M2M)                += v4l2_m2m.o v4l2_context.o v4l2_buffers.o v4l2_fmt.o
@@ -1279,7 +1279,7 @@ index 0000000000..58d2aa70af
 +
 +#endif /* AVCODEC_V4L2_REQUEST_H */
 
-From 1aa288b7f95876298e88eff71af50c350a51f30a Mon Sep 17 00:00:00 2001
+From 04ba66bab9951753498cb21080b53826dcec7a26 Mon Sep 17 00:00:00 2001
 From: Boris Brezillon <boris.brezillon@collabora.com>
 Date: Wed, 22 May 2019 14:44:22 +0200
 Subject: [PATCH 03/13] h264dec: add ref_pic_marking and pic_order_cnt bit_size
@@ -1295,10 +1295,10 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  2 files changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/h264_slice.c b/libavcodec/h264_slice.c
-index d56722a5c2..3e239ae6f0 100644
+index 7767e16cf1..e782a69200 100644
 --- a/libavcodec/h264_slice.c
 +++ b/libavcodec/h264_slice.c
-@@ -1838,7 +1838,7 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
+@@ -1670,7 +1670,7 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
      unsigned int slice_type, tmp, i;
      int field_pic_flag, bottom_field_flag;
      int first_slice = sl == h->slice_ctx && !h->current_slice;
@@ -1307,7 +1307,7 @@ index d56722a5c2..3e239ae6f0 100644
  
      if (first_slice)
          av_assert0(!h->setup_finished);
-@@ -1929,6 +1929,7 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
+@@ -1761,6 +1761,7 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
  
      sl->poc_lsb = 0;
      sl->delta_poc_bottom = 0;
@@ -1315,7 +1315,7 @@ index d56722a5c2..3e239ae6f0 100644
      if (sps->poc_type == 0) {
          sl->poc_lsb = get_bits(&sl->gb, sps->log2_max_poc_lsb);
  
-@@ -1943,6 +1944,7 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
+@@ -1775,6 +1776,7 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
          if (pps->pic_order_present == 1 && picture_structure == PICT_FRAME)
              sl->delta_poc[1] = get_se_golomb(&sl->gb);
      }
@@ -1323,7 +1323,7 @@ index d56722a5c2..3e239ae6f0 100644
  
      sl->redundant_pic_count = 0;
      if (pps->redundant_pic_cnt_present)
-@@ -1982,9 +1984,11 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
+@@ -1814,9 +1816,11 @@ static int h264_slice_header_parse(const H264Context *h, H264SliceContext *sl,
  
      sl->explicit_ref_marking = 0;
      if (nal->ref_idc) {
@@ -1356,7 +1356,7 @@ index 9a1ec1bace..a87415f822 100644
  
  /**
 
-From efdc653700b45efb64af73060330b95e26aa99c5 Mon Sep 17 00:00:00 2001
+From 08b9d91572ac849db0680eb5f172920f6a0bc961 Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Sat, 15 Dec 2018 22:32:16 +0100
 Subject: [PATCH 04/13] Add V4L2 request API h264 hwaccel
@@ -1374,10 +1374,10 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  create mode 100644 libavcodec/v4l2_request_h264.c
 
 diff --git a/configure b/configure
-index 0ccfd0ac36..4f98dec7b1 100755
+index 6167b122e0..b3ca83bf2b 100755
 --- a/configure
 +++ b/configure
-@@ -3045,6 +3045,8 @@ h264_dxva2_hwaccel_deps="dxva2"
+@@ -3033,6 +3033,8 @@ h264_dxva2_hwaccel_deps="dxva2"
  h264_dxva2_hwaccel_select="h264_decoder"
  h264_nvdec_hwaccel_deps="nvdec"
  h264_nvdec_hwaccel_select="h264_decoder"
@@ -1386,7 +1386,7 @@ index 0ccfd0ac36..4f98dec7b1 100755
  h264_vaapi_hwaccel_deps="vaapi"
  h264_vaapi_hwaccel_select="h264_decoder"
  h264_vdpau_hwaccel_deps="vdpau"
-@@ -6828,6 +6830,7 @@ if enabled v4l2_m2m; then
+@@ -6887,6 +6889,7 @@ if enabled v4l2_m2m; then
  fi
  
  check_func_headers "linux/media.h linux/videodev2.h" v4l2_timeval_to_ns
@@ -1395,10 +1395,10 @@ index 0ccfd0ac36..4f98dec7b1 100755
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 3cb7dede11..54f8ed670b 100644
+index 0148242ed0..26004171b3 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -966,6 +966,7 @@ OBJS-$(CONFIG_H264_D3D11VA_HWACCEL)       += dxva2_h264.o
+@@ -990,6 +990,7 @@ OBJS-$(CONFIG_H264_D3D11VA_HWACCEL)       += dxva2_h264.o
  OBJS-$(CONFIG_H264_DXVA2_HWACCEL)         += dxva2_h264.o
  OBJS-$(CONFIG_H264_NVDEC_HWACCEL)         += nvdec_h264.o
  OBJS-$(CONFIG_H264_QSV_HWACCEL)           += qsvdec.o
@@ -1407,10 +1407,10 @@ index 3cb7dede11..54f8ed670b 100644
  OBJS-$(CONFIG_H264_VDPAU_HWACCEL)         += vdpau_h264.o
  OBJS-$(CONFIG_H264_VIDEOTOOLBOX_HWACCEL)  += videotoolbox.o
 diff --git a/libavcodec/h264_slice.c b/libavcodec/h264_slice.c
-index 3e239ae6f0..335dc2cac1 100644
+index e782a69200..3d0d45b2a3 100644
 --- a/libavcodec/h264_slice.c
 +++ b/libavcodec/h264_slice.c
-@@ -792,6 +792,7 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
+@@ -778,6 +778,7 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
  #define HWACCEL_MAX (CONFIG_H264_DXVA2_HWACCEL + \
                       (CONFIG_H264_D3D11VA_HWACCEL * 2) + \
                       CONFIG_H264_NVDEC_HWACCEL + \
@@ -1418,7 +1418,7 @@ index 3e239ae6f0..335dc2cac1 100644
                       CONFIG_H264_VAAPI_HWACCEL + \
                       CONFIG_H264_VIDEOTOOLBOX_HWACCEL + \
                       CONFIG_H264_VDPAU_HWACCEL)
-@@ -881,6 +882,9 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
+@@ -867,6 +868,9 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
  #endif
  #if CONFIG_H264_VAAPI_HWACCEL
              *fmt++ = AV_PIX_FMT_VAAPI;
@@ -1429,10 +1429,10 @@ index 3e239ae6f0..335dc2cac1 100644
              if (h->avctx->codec->pix_fmts)
                  choices = h->avctx->codec->pix_fmts;
 diff --git a/libavcodec/h264dec.c b/libavcodec/h264dec.c
-index 2a5b53ea56..dcba237b4f 100644
+index 2d691731c5..33cc25e1d3 100644
 --- a/libavcodec/h264dec.c
 +++ b/libavcodec/h264dec.c
-@@ -1099,6 +1099,9 @@ const FFCodec ff_h264_decoder = {
+@@ -1093,6 +1093,9 @@ const FFCodec ff_h264_decoder = {
  #endif
  #if CONFIG_H264_VIDEOTOOLBOX_HWACCEL
                                 HWACCEL_VIDEOTOOLBOX(h264),
@@ -1917,7 +1917,7 @@ index 0000000000..c960c9c887
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 
-From a1e633c09c135ff68937f1d25bbffc18c8cb55d1 Mon Sep 17 00:00:00 2001
+From ef1f67b26f8fddd19b08864710f689f23f7fa68f Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 15 Dec 2018 22:32:16 +0100
 Subject: [PATCH 05/13] Add V4L2 request API mpeg2 hwaccel
@@ -1933,10 +1933,10 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  create mode 100644 libavcodec/v4l2_request_mpeg2.c
 
 diff --git a/configure b/configure
-index 4f98dec7b1..c173884edb 100755
+index b3ca83bf2b..4283447b2f 100755
 --- a/configure
 +++ b/configure
-@@ -3085,6 +3085,8 @@ mpeg2_dxva2_hwaccel_deps="dxva2"
+@@ -3073,6 +3073,8 @@ mpeg2_dxva2_hwaccel_deps="dxva2"
  mpeg2_dxva2_hwaccel_select="mpeg2video_decoder"
  mpeg2_nvdec_hwaccel_deps="nvdec"
  mpeg2_nvdec_hwaccel_select="mpeg2video_decoder"
@@ -1945,7 +1945,7 @@ index 4f98dec7b1..c173884edb 100755
  mpeg2_vaapi_hwaccel_deps="vaapi"
  mpeg2_vaapi_hwaccel_select="mpeg2video_decoder"
  mpeg2_vdpau_hwaccel_deps="vdpau"
-@@ -6831,6 +6833,7 @@ fi
+@@ -6890,6 +6892,7 @@ fi
  
  check_func_headers "linux/media.h linux/videodev2.h" v4l2_timeval_to_ns
  check_cc h264_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_H264_SLICE;"
@@ -1954,10 +1954,10 @@ index 4f98dec7b1..c173884edb 100755
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 54f8ed670b..65ead12255 100644
+index 26004171b3..47cc14558c 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -985,6 +985,7 @@ OBJS-$(CONFIG_MPEG2_D3D11VA_HWACCEL)      += dxva2_mpeg2.o
+@@ -1009,6 +1009,7 @@ OBJS-$(CONFIG_MPEG2_D3D11VA_HWACCEL)      += dxva2_mpeg2.o
  OBJS-$(CONFIG_MPEG2_DXVA2_HWACCEL)        += dxva2_mpeg2.o
  OBJS-$(CONFIG_MPEG2_NVDEC_HWACCEL)        += nvdec_mpeg12.o
  OBJS-$(CONFIG_MPEG2_QSV_HWACCEL)          += qsvdec.o
@@ -1978,10 +1978,10 @@ index 014b95f0c0..3b675dd9f8 100644
  extern const AVHWAccel ff_mpeg2_vdpau_hwaccel;
  extern const AVHWAccel ff_mpeg2_videotoolbox_hwaccel;
 diff --git a/libavcodec/mpeg12dec.c b/libavcodec/mpeg12dec.c
-index e9bde48f7a..8c007756b4 100644
+index 457d985265..4b90f07b54 100644
 --- a/libavcodec/mpeg12dec.c
 +++ b/libavcodec/mpeg12dec.c
-@@ -1137,6 +1137,9 @@ static const enum AVPixelFormat mpeg2_hwaccel_pixfmt_list_420[] = {
+@@ -1134,6 +1134,9 @@ static const enum AVPixelFormat mpeg2_hwaccel_pixfmt_list_420[] = {
  #endif
  #if CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL
      AV_PIX_FMT_VIDEOTOOLBOX,
@@ -1991,7 +1991,7 @@ index e9bde48f7a..8c007756b4 100644
  #endif
      AV_PIX_FMT_YUV420P,
      AV_PIX_FMT_NONE
-@@ -2935,6 +2938,9 @@ const FFCodec ff_mpeg2video_decoder = {
+@@ -2919,6 +2922,9 @@ const FFCodec ff_mpeg2video_decoder = {
  #endif
  #if CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL
                          HWACCEL_VIDEOTOOLBOX(mpeg2),
@@ -2167,7 +2167,7 @@ index 0000000000..84d53209c7
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 
-From 6bccc47f7ee6267b0c99318ab4cc47978161cef9 Mon Sep 17 00:00:00 2001
+From 1e84c65220903fe21301c520e4490ab3c0db9c83 Mon Sep 17 00:00:00 2001
 From: Boris Brezillon <boris.brezillon@collabora.com>
 Date: Wed, 22 May 2019 14:46:58 +0200
 Subject: [PATCH 06/13] Add V4L2 request API vp8 hwaccel
@@ -2185,10 +2185,10 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  create mode 100644 libavcodec/v4l2_request_vp8.c
 
 diff --git a/configure b/configure
-index c173884edb..ec16d26391 100755
+index 4283447b2f..794bd7f4d6 100755
 --- a/configure
 +++ b/configure
-@@ -3117,6 +3117,8 @@ vc1_vdpau_hwaccel_deps="vdpau"
+@@ -3105,6 +3105,8 @@ vc1_vdpau_hwaccel_deps="vdpau"
  vc1_vdpau_hwaccel_select="vc1_decoder"
  vp8_nvdec_hwaccel_deps="nvdec"
  vp8_nvdec_hwaccel_select="vp8_decoder"
@@ -2197,7 +2197,7 @@ index c173884edb..ec16d26391 100755
  vp8_vaapi_hwaccel_deps="vaapi"
  vp8_vaapi_hwaccel_select="vp8_decoder"
  vp9_d3d11va_hwaccel_deps="d3d11va DXVA_PicParams_VP9"
-@@ -6834,6 +6836,7 @@ fi
+@@ -6893,6 +6895,7 @@ fi
  check_func_headers "linux/media.h linux/videodev2.h" v4l2_timeval_to_ns
  check_cc h264_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_H264_SLICE;"
  check_cc mpeg2_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_MPEG2_SLICE;"
@@ -2206,10 +2206,10 @@ index c173884edb..ec16d26391 100755
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 65ead12255..aed145ecb6 100644
+index 47cc14558c..7da4fd1a87 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -1000,6 +1000,7 @@ OBJS-$(CONFIG_VC1_QSV_HWACCEL)            += qsvdec.o
+@@ -1024,6 +1024,7 @@ OBJS-$(CONFIG_VC1_QSV_HWACCEL)            += qsvdec.o
  OBJS-$(CONFIG_VC1_VAAPI_HWACCEL)          += vaapi_vc1.o
  OBJS-$(CONFIG_VC1_VDPAU_HWACCEL)          += vdpau_vc1.o
  OBJS-$(CONFIG_VP8_NVDEC_HWACCEL)          += nvdec_vp8.o
@@ -2231,7 +2231,7 @@ index 3b675dd9f8..6f9f078001 100644
  extern const AVHWAccel ff_vp9_d3d11va2_hwaccel;
 diff --git a/libavcodec/v4l2_request_vp8.c b/libavcodec/v4l2_request_vp8.c
 new file mode 100644
-index 0000000000..bc0fc40072
+index 0000000000..e169030213
 --- /dev/null
 +++ b/libavcodec/v4l2_request_vp8.c
 @@ -0,0 +1,180 @@
@@ -2266,16 +2266,16 @@ index 0000000000..bc0fc40072
 +                                        av_unused uint32_t       size)
 +{
 +    const VP8Context *s = avctx->priv_data;
-+    V4L2RequestControlsVP8 *controls = s->framep[VP56_FRAME_CURRENT]->hwaccel_picture_private;
++    V4L2RequestControlsVP8 *controls = s->framep[VP8_FRAME_CURRENT]->hwaccel_picture_private;
 +
 +    memset(&controls->ctrl, 0, sizeof(controls->ctrl));
-+    return ff_v4l2_request_reset_frame(avctx, s->framep[VP56_FRAME_CURRENT]->tf.f);
++    return ff_v4l2_request_reset_frame(avctx, s->framep[VP8_FRAME_CURRENT]->tf.f);
 +}
 +
 +static int v4l2_request_vp8_end_frame(AVCodecContext *avctx)
 +{
 +    const VP8Context *s = avctx->priv_data;
-+    V4L2RequestControlsVP8 *controls = s->framep[VP56_FRAME_CURRENT]->hwaccel_picture_private;
++    V4L2RequestControlsVP8 *controls = s->framep[VP8_FRAME_CURRENT]->hwaccel_picture_private;
 +    struct v4l2_ext_control control[] = {
 +        {
 +            .id = V4L2_CID_STATELESS_VP8_FRAME,
@@ -2284,7 +2284,7 @@ index 0000000000..bc0fc40072
 +        },
 +    };
 +
-+    return ff_v4l2_request_decode_frame(avctx, s->framep[VP56_FRAME_CURRENT]->tf.f,
++    return ff_v4l2_request_decode_frame(avctx, s->framep[VP8_FRAME_CURRENT]->tf.f,
 +                                        control, FF_ARRAY_ELEMS(control));
 +}
 +
@@ -2293,7 +2293,7 @@ index 0000000000..bc0fc40072
 +                                         uint32_t size)
 +{
 +    const VP8Context *s = avctx->priv_data;
-+    V4L2RequestControlsVP8 *controls = s->framep[VP56_FRAME_CURRENT]->hwaccel_picture_private;
++    V4L2RequestControlsVP8 *controls = s->framep[VP8_FRAME_CURRENT]->hwaccel_picture_private;
 +    struct v4l2_ctrl_vp8_frame *frame = &controls->ctrl;
 +    const uint8_t *data = buffer + 3 + 7 * s->keyframe;
 +    unsigned int i, j, k;
@@ -2316,18 +2316,18 @@ index 0000000000..bc0fc40072
 +    frame->coder_state.range = s->coder_state_at_header_end.range;
 +    frame->coder_state.value = s->coder_state_at_header_end.value;
 +    frame->coder_state.bit_count = s->coder_state_at_header_end.bit_count;
-+    if (s->framep[VP56_FRAME_PREVIOUS])
-+        frame->last_frame_ts = ff_v4l2_request_get_capture_timestamp(s->framep[VP56_FRAME_PREVIOUS]->tf.f);
-+    if (s->framep[VP56_FRAME_GOLDEN])
-+        frame->golden_frame_ts = ff_v4l2_request_get_capture_timestamp(s->framep[VP56_FRAME_GOLDEN]->tf.f);
-+    if (s->framep[VP56_FRAME_GOLDEN2])
-+        frame->alt_frame_ts = ff_v4l2_request_get_capture_timestamp(s->framep[VP56_FRAME_GOLDEN2]->tf.f);
++    if (s->framep[VP8_FRAME_PREVIOUS])
++        frame->last_frame_ts = ff_v4l2_request_get_capture_timestamp(s->framep[VP8_FRAME_PREVIOUS]->tf.f);
++    if (s->framep[VP8_FRAME_GOLDEN])
++        frame->golden_frame_ts = ff_v4l2_request_get_capture_timestamp(s->framep[VP8_FRAME_GOLDEN]->tf.f);
++    if (s->framep[VP8_FRAME_ALTREF])
++        frame->alt_frame_ts = ff_v4l2_request_get_capture_timestamp(s->framep[VP8_FRAME_ALTREF]->tf.f);
 +    frame->flags |= s->invisible ? 0 : V4L2_VP8_FRAME_FLAG_SHOW_FRAME;
 +    frame->flags |= s->mbskip_enabled ? V4L2_VP8_FRAME_FLAG_MB_NO_SKIP_COEFF : 0;
 +    frame->flags |= (s->profile & 0x4) ? V4L2_VP8_FRAME_FLAG_EXPERIMENTAL : 0;
 +    frame->flags |= s->keyframe ? V4L2_VP8_FRAME_FLAG_KEY_FRAME : 0;
-+    frame->flags |= s->sign_bias[VP56_FRAME_GOLDEN] ? V4L2_VP8_FRAME_FLAG_SIGN_BIAS_GOLDEN : 0;
-+    frame->flags |= s->sign_bias[VP56_FRAME_GOLDEN2] ? V4L2_VP8_FRAME_FLAG_SIGN_BIAS_ALT : 0;
++    frame->flags |= s->sign_bias[VP8_FRAME_GOLDEN] ? V4L2_VP8_FRAME_FLAG_SIGN_BIAS_GOLDEN : 0;
++    frame->flags |= s->sign_bias[VP8_FRAME_ALTREF] ? V4L2_VP8_FRAME_FLAG_SIGN_BIAS_ALT : 0;
 +    frame->segment.flags |= s->segmentation.enabled ? V4L2_VP8_SEGMENT_FLAG_ENABLED : 0;
 +    frame->segment.flags |= s->segmentation.update_map ? V4L2_VP8_SEGMENT_FLAG_UPDATE_MAP : 0;
 +    frame->segment.flags |= s->segmentation.update_feature_data ? V4L2_VP8_SEGMENT_FLAG_UPDATE_FEATURE_DATA : 0;
@@ -2392,7 +2392,7 @@ index 0000000000..bc0fc40072
 +    frame->quant.uv_dc_delta = s->quant.uvdc_delta;
 +    frame->quant.uv_ac_delta = s->quant.uvac_delta;
 +
-+    return ff_v4l2_request_append_output_buffer(avctx, s->framep[VP56_FRAME_CURRENT]->tf.f, buffer, size);
++    return ff_v4l2_request_append_output_buffer(avctx, s->framep[VP8_FRAME_CURRENT]->tf.f, buffer, size);
 +}
 +
 +static int v4l2_request_vp8_init(AVCodecContext *avctx)
@@ -2416,10 +2416,10 @@ index 0000000000..bc0fc40072
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 diff --git a/libavcodec/vp8.c b/libavcodec/vp8.c
-index f521f2c9de..a4799fca09 100644
+index db2419deaf..ad5e6e8f2b 100644
 --- a/libavcodec/vp8.c
 +++ b/libavcodec/vp8.c
-@@ -180,6 +180,9 @@ static enum AVPixelFormat get_pixel_format(VP8Context *s)
+@@ -206,6 +206,9 @@ static enum AVPixelFormat get_pixel_format(VP8Context *s)
  #endif
  #if CONFIG_VP8_NVDEC_HWACCEL
          AV_PIX_FMT_CUDA,
@@ -2429,7 +2429,7 @@ index f521f2c9de..a4799fca09 100644
  #endif
          AV_PIX_FMT_YUV420P,
          AV_PIX_FMT_NONE,
-@@ -2976,6 +2979,9 @@ const FFCodec ff_vp8_decoder = {
+@@ -3007,6 +3010,9 @@ const FFCodec ff_vp8_decoder = {
  #endif
  #if CONFIG_VP8_NVDEC_HWACCEL
                                 HWACCEL_NVDEC(vp8),
@@ -2440,7 +2440,7 @@ index f521f2c9de..a4799fca09 100644
                                 NULL
                             },
 
-From 26e5e1407717e88c508abfb24ae329036bb1a99e Mon Sep 17 00:00:00 2001
+From e5df38921bf3a7f918c7e05b0207e3fde6c65017 Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Sat, 15 Dec 2018 22:32:16 +0100
 Subject: [PATCH 07/13] Add V4L2 request API hevc hwaccel
@@ -2459,10 +2459,10 @@ Signed-off-by: Alex Bee <knaerzche@gmail.com>
  create mode 100644 libavcodec/v4l2_request_hevc.c
 
 diff --git a/configure b/configure
-index ec16d26391..d366652e51 100755
+index 794bd7f4d6..2565ce8d7c 100755
 --- a/configure
 +++ b/configure
-@@ -3061,6 +3061,8 @@ hevc_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_HEVC"
+@@ -3049,6 +3049,8 @@ hevc_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_HEVC"
  hevc_dxva2_hwaccel_select="hevc_decoder"
  hevc_nvdec_hwaccel_deps="nvdec"
  hevc_nvdec_hwaccel_select="hevc_decoder"
@@ -2471,7 +2471,7 @@ index ec16d26391..d366652e51 100755
  hevc_vaapi_hwaccel_deps="vaapi VAPictureParameterBufferHEVC"
  hevc_vaapi_hwaccel_select="hevc_decoder"
  hevc_vdpau_hwaccel_deps="vdpau VdpPictureInfoHEVC"
-@@ -6835,6 +6837,7 @@ fi
+@@ -6894,6 +6896,7 @@ fi
  
  check_func_headers "linux/media.h linux/videodev2.h" v4l2_timeval_to_ns
  check_cc h264_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_H264_SLICE;"
@@ -2480,10 +2480,10 @@ index ec16d26391..d366652e51 100755
  check_cc vp8_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_VP8_FRAME;"
  
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index aed145ecb6..33ce5fc359 100644
+index 7da4fd1a87..cd08740e75 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -974,6 +974,7 @@ OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
+@@ -998,6 +998,7 @@ OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
  OBJS-$(CONFIG_HEVC_NVDEC_HWACCEL)         += nvdec_hevc.o
  OBJS-$(CONFIG_HEVC_QSV_HWACCEL)           += qsvdec.o
@@ -2492,10 +2492,10 @@ index aed145ecb6..33ce5fc359 100644
  OBJS-$(CONFIG_HEVC_VDPAU_HWACCEL)         += vdpau_hevc.o h265_profile_level.o
  OBJS-$(CONFIG_MJPEG_NVDEC_HWACCEL)        += nvdec_mjpeg.o
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index f8f981e838..8db5649b55 100644
+index 567e8d81d4..79b821e7e5 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -402,6 +402,7 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
+@@ -403,6 +403,7 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
  #define HWACCEL_MAX (CONFIG_HEVC_DXVA2_HWACCEL + \
                       CONFIG_HEVC_D3D11VA_HWACCEL * 2 + \
                       CONFIG_HEVC_NVDEC_HWACCEL + \
@@ -2503,7 +2503,7 @@ index f8f981e838..8db5649b55 100644
                       CONFIG_HEVC_VAAPI_HWACCEL + \
                       CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL + \
                       CONFIG_HEVC_VDPAU_HWACCEL)
-@@ -428,6 +429,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
+@@ -429,6 +430,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
  #endif
  #if CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL
          *fmt++ = AV_PIX_FMT_VIDEOTOOLBOX;
@@ -2513,7 +2513,7 @@ index f8f981e838..8db5649b55 100644
  #endif
          break;
      case AV_PIX_FMT_YUV420P10:
-@@ -449,6 +453,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
+@@ -450,6 +454,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
  #endif
  #if CONFIG_HEVC_NVDEC_HWACCEL
          *fmt++ = AV_PIX_FMT_CUDA;
@@ -2523,7 +2523,7 @@ index f8f981e838..8db5649b55 100644
  #endif
          break;
      case AV_PIX_FMT_YUV444P:
-@@ -3905,6 +3912,9 @@ const FFCodec ff_hevc_decoder = {
+@@ -3739,6 +3746,9 @@ const FFCodec ff_hevc_decoder = {
  #endif
  #if CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL
                                 HWACCEL_VIDEOTOOLBOX(hevc),
@@ -3231,7 +3231,7 @@ index 0000000000..3e2b9a575e
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 
-From 24e1336751a0d7346ea149aa3cbe9445e12b885e Mon Sep 17 00:00:00 2001
+From 760b6f7d4662d5c5d3bc6292a53a40e8fc2fc18d Mon Sep 17 00:00:00 2001
 From: Boris Brezillon <boris.brezillon@collabora.com>
 Date: Thu, 12 Dec 2019 16:13:55 +0100
 Subject: [PATCH 08/13] Add V4L2 request API VP9 hwaccel
@@ -3250,10 +3250,10 @@ Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
  create mode 100644 libavcodec/v4l2_request_vp9.c
 
 diff --git a/configure b/configure
-index d366652e51..78d0c5a420 100755
+index 2565ce8d7c..081174babb 100755
 --- a/configure
 +++ b/configure
-@@ -3131,6 +3131,8 @@ vp9_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_VP9"
+@@ -3119,6 +3119,8 @@ vp9_dxva2_hwaccel_deps="dxva2 DXVA_PicParams_VP9"
  vp9_dxva2_hwaccel_select="vp9_decoder"
  vp9_nvdec_hwaccel_deps="nvdec"
  vp9_nvdec_hwaccel_select="vp9_decoder"
@@ -3262,7 +3262,7 @@ index d366652e51..78d0c5a420 100755
  vp9_vaapi_hwaccel_deps="vaapi VADecPictureParameterBufferVP9_bit_depth"
  vp9_vaapi_hwaccel_select="vp9_decoder"
  vp9_vdpau_hwaccel_deps="vdpau VdpPictureInfoVP9"
-@@ -6840,6 +6842,7 @@ check_cc h264_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_H264_SLICE;"
+@@ -6899,6 +6901,7 @@ check_cc h264_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_H264_SLICE;"
  check_cc hevc_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_HEVC_SLICE;"
  check_cc mpeg2_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_MPEG2_SLICE;"
  check_cc vp8_v4l2_request linux/videodev2.h "int i = V4L2_PIX_FMT_VP8_FRAME;"
@@ -3271,10 +3271,10 @@ index d366652e51..78d0c5a420 100755
  check_headers sys/videoio.h
  test_code cc sys/videoio.h "struct v4l2_frmsizeenum vfse; vfse.discrete.width = 0;" && enable_sanitized struct_v4l2_frmivalenum_discrete
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 33ce5fc359..6561518e0e 100644
+index cd08740e75..e2c957763a 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -1006,6 +1006,7 @@ OBJS-$(CONFIG_VP8_VAAPI_HWACCEL)          += vaapi_vp8.o
+@@ -1030,6 +1030,7 @@ OBJS-$(CONFIG_VP8_VAAPI_HWACCEL)          += vaapi_vp8.o
  OBJS-$(CONFIG_VP9_D3D11VA_HWACCEL)        += dxva2_vp9.o
  OBJS-$(CONFIG_VP9_DXVA2_HWACCEL)          += dxva2_vp9.o
  OBJS-$(CONFIG_VP9_NVDEC_HWACCEL)          += nvdec_vp9.o
@@ -3583,10 +3583,10 @@ index 0000000000..ec0300f66d
 +    .caps_internal  = HWACCEL_CAP_ASYNC_SAFE,
 +};
 diff --git a/libavcodec/vp9.c b/libavcodec/vp9.c
-index fee79fb45b..bd7dc4f53a 100644
+index 7c0a246446..9cc36960eb 100644
 --- a/libavcodec/vp9.c
 +++ b/libavcodec/vp9.c
-@@ -184,6 +184,7 @@ static int update_size(AVCodecContext *avctx, int w, int h)
+@@ -185,6 +185,7 @@ static int update_size(AVCodecContext *avctx, int w, int h)
  #define HWACCEL_MAX (CONFIG_VP9_DXVA2_HWACCEL + \
                       CONFIG_VP9_D3D11VA_HWACCEL * 2 + \
                       CONFIG_VP9_NVDEC_HWACCEL + \
@@ -3594,7 +3594,7 @@ index fee79fb45b..bd7dc4f53a 100644
                       CONFIG_VP9_VAAPI_HWACCEL + \
                       CONFIG_VP9_VDPAU_HWACCEL + \
                       CONFIG_VP9_VIDEOTOOLBOX_HWACCEL)
-@@ -212,6 +213,9 @@ static int update_size(AVCodecContext *avctx, int w, int h)
+@@ -213,6 +214,9 @@ static int update_size(AVCodecContext *avctx, int w, int h)
  #if CONFIG_VP9_NVDEC_HWACCEL
              *fmtp++ = AV_PIX_FMT_CUDA;
  #endif
@@ -3604,7 +3604,7 @@ index fee79fb45b..bd7dc4f53a 100644
  #if CONFIG_VP9_VAAPI_HWACCEL
              *fmtp++ = AV_PIX_FMT_VAAPI;
  #endif
-@@ -226,6 +230,9 @@ static int update_size(AVCodecContext *avctx, int w, int h)
+@@ -227,6 +231,9 @@ static int update_size(AVCodecContext *avctx, int w, int h)
  #if CONFIG_VP9_NVDEC_HWACCEL
              *fmtp++ = AV_PIX_FMT_CUDA;
  #endif
@@ -3614,16 +3614,16 @@ index fee79fb45b..bd7dc4f53a 100644
  #if CONFIG_VP9_VAAPI_HWACCEL
              *fmtp++ = AV_PIX_FMT_VAAPI;
  #endif
-@@ -379,7 +386,7 @@ static av_always_inline int inv_recenter_nonneg(int v, int m)
+@@ -387,7 +394,7 @@ static av_always_inline int inv_recenter_nonneg(int v, int m)
  }
  
  // differential forward probability updates
--static int update_prob(VP56RangeCoder *c, int p)
-+static int read_prob_delta(VP56RangeCoder *c)
+-static int update_prob(VPXRangeCoder *c, int p)
++static int read_prob_delta(VPXRangeCoder *c)
  {
      static const uint8_t inv_map_table[255] = {
            7,  20,  33,  46,  59,  72,  85,  98, 111, 124, 137, 150, 163, 176,
-@@ -433,8 +440,13 @@ static int update_prob(VP56RangeCoder *c, int p)
+@@ -441,8 +448,13 @@ static int update_prob(VPXRangeCoder *c, int p)
          av_assert2(d < FF_ARRAY_ELEMS(inv_map_table));
      }
  
@@ -3639,7 +3639,7 @@ index fee79fb45b..bd7dc4f53a 100644
  }
  
  static int read_colorspace_details(AVCodecContext *avctx)
-@@ -700,7 +712,8 @@ static int decode_frame_header(AVCodecContext *avctx,
+@@ -708,7 +720,8 @@ static int decode_frame_header(AVCodecContext *avctx,
                                           get_bits(&s->gb, 8) : 255;
          }
  
@@ -3649,7 +3649,7 @@ index fee79fb45b..bd7dc4f53a 100644
              s->s.h.segmentation.absolute_vals = get_bits1(&s->gb);
              for (i = 0; i < 8; i++) {
                  if ((s->s.h.segmentation.feat[i].q_enabled = get_bits1(&s->gb)))
-@@ -900,6 +913,8 @@ static int decode_frame_header(AVCodecContext *avctx,
+@@ -908,6 +921,8 @@ static int decode_frame_header(AVCodecContext *avctx,
       * as explicit copies if the fw update is missing (and skip the copy upon
       * fw update)? */
      s->prob.p = s->prob_ctx[c].p;
@@ -3658,33 +3658,33 @@ index fee79fb45b..bd7dc4f53a 100644
  
      // txfm updates
      if (s->s.h.lossless) {
-@@ -911,18 +926,25 @@ static int decode_frame_header(AVCodecContext *avctx,
+@@ -919,18 +934,25 @@ static int decode_frame_header(AVCodecContext *avctx,
  
          if (s->s.h.txfmmode == TX_SWITCHABLE) {
              for (i = 0; i < 2; i++)
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                    s->prob.p.tx8p[i] = update_prob(&s->c, s->prob.p.tx8p[i]);
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.tx8p[i] = read_prob_delta(&s->c);
 +                    s->prob.p.tx8p[i] = update_prob(s->prob.p.tx8p[i],
 +                                                    s->prob_raw.p.tx8p[i]);
 +                }
              for (i = 0; i < 2; i++)
                  for (j = 0; j < 2; j++)
--                    if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                    if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                        s->prob.p.tx16p[i][j] =
 -                            update_prob(&s->c, s->prob.p.tx16p[i][j]);
-+                    if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                    if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                        s->prob_raw.p.tx16p[i][j] = read_prob_delta(&s->c);
 +                        s->prob.p.tx16p[i][j] = update_prob(s->prob.p.tx16p[i][j],
 +                                                            s->prob_raw.p.tx16p[i][j]);
 +                    }
              for (i = 0; i < 2; i++)
                  for (j = 0; j < 3; j++)
--                    if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                    if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                        s->prob.p.tx32p[i][j] =
 -                            update_prob(&s->c, s->prob.p.tx32p[i][j]);
-+                    if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                    if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                        s->prob_raw.p.tx32p[i][j] = read_prob_delta(&s->c);
 +                        s->prob.p.tx32p[i][j] = update_prob(s->prob.p.tx32p[i][j],
 +                                                            s->prob_raw.p.tx32p[i][j]);
@@ -3692,7 +3692,7 @@ index fee79fb45b..bd7dc4f53a 100644
          }
      }
  
-@@ -934,15 +956,18 @@ static int decode_frame_header(AVCodecContext *avctx,
+@@ -942,15 +964,18 @@ static int decode_frame_header(AVCodecContext *avctx,
                  for (k = 0; k < 2; k++)
                      for (l = 0; l < 6; l++)
                          for (m = 0; m < 6; m++) {
@@ -3702,10 +3702,10 @@ index fee79fb45b..bd7dc4f53a 100644
                              if (m >= 3 && l == 0) // dc only has 3 pt
                                  break;
                              for (n = 0; n < 3; n++) {
--                                if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                                if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                                    p[n] = update_prob(&s->c, r[n]);
 -                                else
-+                                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                                    pd[n] = read_prob_delta(&s->c);
 +                                    p[n] = update_prob(r[n], pd[n]);
 +                                } else {
@@ -3714,7 +3714,7 @@ index fee79fb45b..bd7dc4f53a 100644
                              }
                              memcpy(&p[3], ff_vp9_model_pareto8[p[2]], 8);
                          }
-@@ -957,7 +982,7 @@ static int decode_frame_header(AVCodecContext *avctx,
+@@ -965,7 +990,7 @@ static int decode_frame_header(AVCodecContext *avctx,
                                  break;
                              memcpy(p, r, 3);
                              memcpy(&p[3], ff_vp9_model_pareto8[p[2]], 8);
@@ -3723,13 +3723,13 @@ index fee79fb45b..bd7dc4f53a 100644
          }
          if (s->s.h.txfmmode == i)
              break;
-@@ -965,25 +990,37 @@ static int decode_frame_header(AVCodecContext *avctx,
+@@ -973,25 +998,37 @@ static int decode_frame_header(AVCodecContext *avctx,
  
      // mode updates
      for (i = 0; i < 3; i++)
--        if (vp56_rac_get_prob_branchy(&s->c, 252))
+-        if (vpx_rac_get_prob_branchy(&s->c, 252))
 -            s->prob.p.skip[i] = update_prob(&s->c, s->prob.p.skip[i]);
-+        if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++        if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +            s->prob_raw.p.skip[i] = read_prob_delta(&s->c);
 +            s->prob.p.skip[i] = update_prob(s->prob.p.skip[i],
 +                                            s->prob_raw.p.skip[i]);
@@ -3737,8 +3737,8 @@ index fee79fb45b..bd7dc4f53a 100644
      if (!s->s.h.keyframe && !s->s.h.intraonly) {
          for (i = 0; i < 7; i++)
              for (j = 0; j < 3; j++)
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.mv_mode[i][j] = read_prob_delta(&s->c);
                      s->prob.p.mv_mode[i][j] =
 -                        update_prob(&s->c, s->prob.p.mv_mode[i][j]);
@@ -3749,8 +3749,8 @@ index fee79fb45b..bd7dc4f53a 100644
          if (s->s.h.filtermode == FILTER_SWITCHABLE)
              for (i = 0; i < 4; i++)
                  for (j = 0; j < 2; j++)
--                    if (vp56_rac_get_prob_branchy(&s->c, 252))
-+                    if (vp56_rac_get_prob_branchy(&s->c, 252)) {
+-                    if (vpx_rac_get_prob_branchy(&s->c, 252))
++                    if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                        s->prob_raw.p.filter[i][j] = read_prob_delta(&s->c);
                          s->prob.p.filter[i][j] =
 -                            update_prob(&s->c, s->prob.p.filter[i][j]);
@@ -3759,22 +3759,22 @@ index fee79fb45b..bd7dc4f53a 100644
 +                    }
  
          for (i = 0; i < 4; i++)
--            if (vp56_rac_get_prob_branchy(&s->c, 252))
+-            if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                s->prob.p.intra[i] = update_prob(&s->c, s->prob.p.intra[i]);
-+            if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++            if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                s->prob_raw.p.intra[i] = read_prob_delta(&s->c);
 +                s->prob.p.intra[i] = update_prob(s->prob.p.intra[i],
 +                                                 s->prob_raw.p.intra[i]);
 +            }
  
          if (s->s.h.allowcompinter) {
-             s->s.h.comppredmode = vp8_rac_get(&s->c);
-@@ -991,92 +1028,134 @@ static int decode_frame_header(AVCodecContext *avctx,
-                 s->s.h.comppredmode += vp8_rac_get(&s->c);
+             s->s.h.comppredmode = vp89_rac_get(&s->c);
+@@ -999,92 +1036,134 @@ static int decode_frame_header(AVCodecContext *avctx,
+                 s->s.h.comppredmode += vp89_rac_get(&s->c);
              if (s->s.h.comppredmode == PRED_SWITCHABLE)
                  for (i = 0; i < 5; i++)
--                    if (vp56_rac_get_prob_branchy(&s->c, 252))
-+                    if (vp56_rac_get_prob_branchy(&s->c, 252)) {
+-                    if (vpx_rac_get_prob_branchy(&s->c, 252))
++                    if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                        s->prob_raw.p.comp[i] = read_prob_delta(&s->c);
                          s->prob.p.comp[i] =
 -                            update_prob(&s->c, s->prob.p.comp[i]);
@@ -3786,16 +3786,16 @@ index fee79fb45b..bd7dc4f53a 100644
  
          if (s->s.h.comppredmode != PRED_COMPREF) {
              for (i = 0; i < 5; i++) {
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.single_ref[i][0] = read_prob_delta(&s->c);
                      s->prob.p.single_ref[i][0] =
 -                        update_prob(&s->c, s->prob.p.single_ref[i][0]);
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
 +                        update_prob(s->prob.p.single_ref[i][0],
 +                                    s->prob_raw.p.single_ref[i][0]);
 +                }
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.single_ref[i][1] = read_prob_delta(&s->c);
                      s->prob.p.single_ref[i][1] =
 -                        update_prob(&s->c, s->prob.p.single_ref[i][1]);
@@ -3807,8 +3807,8 @@ index fee79fb45b..bd7dc4f53a 100644
  
          if (s->s.h.comppredmode != PRED_SINGLEREF) {
              for (i = 0; i < 5; i++)
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.comp_ref[i] = read_prob_delta(&s->c);
                      s->prob.p.comp_ref[i] =
 -                        update_prob(&s->c, s->prob.p.comp_ref[i]);
@@ -3819,8 +3819,8 @@ index fee79fb45b..bd7dc4f53a 100644
  
          for (i = 0; i < 4; i++)
              for (j = 0; j < 9; j++)
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.y_mode[i][j] = read_prob_delta(&s->c);
                      s->prob.p.y_mode[i][j] =
 -                        update_prob(&s->c, s->prob.p.y_mode[i][j]);
@@ -3831,8 +3831,8 @@ index fee79fb45b..bd7dc4f53a 100644
          for (i = 0; i < 4; i++)
              for (j = 0; j < 4; j++)
                  for (k = 0; k < 3; k++)
--                    if (vp56_rac_get_prob_branchy(&s->c, 252))
-+                    if (vp56_rac_get_prob_branchy(&s->c, 252)) {
+-                    if (vpx_rac_get_prob_branchy(&s->c, 252))
++                    if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                        s->prob_raw.p.partition[i][j][k] = read_prob_delta(&s->c);
                          s->prob.p.partition[3 - i][j][k] =
 -                            update_prob(&s->c,
@@ -3843,48 +3843,48 @@ index fee79fb45b..bd7dc4f53a 100644
  
          // mv fields don't use the update_prob subexp model for some reason
          for (i = 0; i < 3; i++)
--            if (vp56_rac_get_prob_branchy(&s->c, 252))
--                s->prob.p.mv_joint[i] = (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
-+            if (vp56_rac_get_prob_branchy(&s->c, 252)) {
-+                s->prob_raw.p.mv_joint[i] = (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+-            if (vpx_rac_get_prob_branchy(&s->c, 252))
+-                s->prob.p.mv_joint[i] = (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
++            if (vpx_rac_get_prob_branchy(&s->c, 252)) {
++                s->prob_raw.p.mv_joint[i] = (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                s->prob.p.mv_joint[i] = s->prob_raw.p.mv_joint[i];
 +            }
  
          for (i = 0; i < 2; i++) {
--            if (vp56_rac_get_prob_branchy(&s->c, 252))
+-            if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                s->prob.p.mv_comp[i].sign =
-+            if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++            if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                s->prob_raw.p.mv_comp[i].sign =
-                     (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+                     (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                s->prob.p.mv_comp[i].sign =
 +                    s->prob_raw.p.mv_comp[i].sign;
 +            }
  
              for (j = 0; j < 10; j++)
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                    s->prob.p.mv_comp[i].classes[j] =
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.mv_comp[i].classes[j] =
-                         (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+                         (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                    s->prob.p.mv_comp[i].classes[j] =
 +                        s->prob_raw.p.mv_comp[i].classes[j];
 +                }
  
--            if (vp56_rac_get_prob_branchy(&s->c, 252))
+-            if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                s->prob.p.mv_comp[i].class0 =
-+            if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++            if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                s->prob_raw.p.mv_comp[i].class0 =
-                     (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+                     (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                s->prob.p.mv_comp[i].class0 =
 +                    s->prob_raw.p.mv_comp[i].class0;
 +            }
  
              for (j = 0; j < 10; j++)
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                    s->prob.p.mv_comp[i].bits[j] =
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.mv_comp[i].bits[j] =
-                         (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+                         (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                    s->prob.p.mv_comp[i].bits[j] =
 +                        s->prob_raw.p.mv_comp[i].bits[j];
 +                }
@@ -3893,21 +3893,21 @@ index fee79fb45b..bd7dc4f53a 100644
          for (i = 0; i < 2; i++) {
              for (j = 0; j < 2; j++)
                  for (k = 0; k < 3; k++)
--                    if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                    if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                        s->prob.p.mv_comp[i].class0_fp[j][k] =
-+                    if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                    if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                        s->prob_raw.p.mv_comp[i].class0_fp[j][k] =
-                             (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+                             (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                        s->prob.p.mv_comp[i].class0_fp[j][k] =
 +                            s->prob_raw.p.mv_comp[i].class0_fp[j][k];
 +                    }
  
              for (j = 0; j < 3; j++)
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                    s->prob.p.mv_comp[i].fp[j] =
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.mv_comp[i].fp[j] =
-                         (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+                         (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                    s->prob.p.mv_comp[i].fp[j] =
 +                        s->prob_raw.p.mv_comp[i].fp[j];
 +                }
@@ -3915,27 +3915,27 @@ index fee79fb45b..bd7dc4f53a 100644
  
          if (s->s.h.highprecisionmvs) {
              for (i = 0; i < 2; i++) {
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                    s->prob.p.mv_comp[i].class0_hp =
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.mv_comp[i].class0_hp =
-                         (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+                         (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                    s->prob.p.mv_comp[i].class0_hp =
 +                        s->prob_raw.p.mv_comp[i].class0_hp;
 +                }
  
--                if (vp56_rac_get_prob_branchy(&s->c, 252))
+-                if (vpx_rac_get_prob_branchy(&s->c, 252))
 -                    s->prob.p.mv_comp[i].hp =
-+                if (vp56_rac_get_prob_branchy(&s->c, 252)) {
++                if (vpx_rac_get_prob_branchy(&s->c, 252)) {
 +                    s->prob_raw.p.mv_comp[i].hp =
-                         (vp8_rac_get_uint(&s->c, 7) << 1) | 1;
+                         (vp89_rac_get_uint(&s->c, 7) << 1) | 1;
 +                    s->prob.p.mv_comp[i].hp =
 +                        s->prob_raw.p.mv_comp[i].hp;
 +                }
              }
          }
      }
-@@ -1902,6 +1981,9 @@ const FFCodec ff_vp9_decoder = {
+@@ -1906,6 +1985,9 @@ const FFCodec ff_vp9_decoder = {
  #if CONFIG_VP9_VDPAU_HWACCEL
                                 HWACCEL_VDPAU(vp9),
  #endif
@@ -3946,10 +3946,10 @@ index fee79fb45b..bd7dc4f53a 100644
                                 HWACCEL_VIDEOTOOLBOX(vp9),
  #endif
 diff --git a/libavcodec/vp9dec.h b/libavcodec/vp9dec.h
-index 9cbd5839a8..74b854691e 100644
+index de7aba0458..5935ba6227 100644
 --- a/libavcodec/vp9dec.h
 +++ b/libavcodec/vp9dec.h
-@@ -132,6 +132,10 @@ typedef struct VP9Context {
+@@ -135,6 +135,10 @@ typedef struct VP9Context {
          ProbContext p;
          uint8_t coef[4][2][2][6][6][11];
      } prob;
@@ -3961,10 +3961,10 @@ index 9cbd5839a8..74b854691e 100644
      // contextual (above) cache
      uint8_t *above_partition_ctx;
 diff --git a/libavcodec/vp9shared.h b/libavcodec/vp9shared.h
-index ebaa11d2c1..3469a7312d 100644
+index 543a496df8..a5028d4b39 100644
 --- a/libavcodec/vp9shared.h
 +++ b/libavcodec/vp9shared.h
-@@ -131,6 +131,7 @@ typedef struct VP9BitstreamHeader {
+@@ -137,6 +137,7 @@ typedef struct VP9BitstreamHeader {
          uint8_t temporal;
          uint8_t absolute_vals;
          uint8_t update_map;
@@ -3973,7 +3973,7 @@ index ebaa11d2c1..3469a7312d 100644
          uint8_t pred_prob[3];
          struct {
 
-From 3da495ee6fe1d8cf4bebde0a089bcd14e7a7785e Mon Sep 17 00:00:00 2001
+From 5057eb96b2adbff022a1abd8d5b06f369f908d51 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Mon, 29 Apr 2019 22:08:59 +0000
 Subject: [PATCH 09/13] HACK: hwcontext_drm: do not require drm device
@@ -4000,7 +4000,7 @@ index 7a9fdbd263..6297d1f9b6 100644
      if (hwctx->fd < 0)
          return AVERROR(errno);
 
-From 735160c215246efb0b99014978cac558fb775488 Mon Sep 17 00:00:00 2001
+From fce915b2195b3c4d74b8b40e0d5aa9ba4dcecd33 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Fri, 15 May 2020 16:54:05 +0000
 Subject: [PATCH 10/13] WIP: add NV15 and NV20 support
@@ -4012,10 +4012,10 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  2 files changed, 35 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/h264_slice.c b/libavcodec/h264_slice.c
-index 335dc2cac1..23807756c5 100644
+index 3d0d45b2a3..f7af51b28e 100644
 --- a/libavcodec/h264_slice.c
 +++ b/libavcodec/h264_slice.c
-@@ -822,10 +822,17 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
+@@ -808,10 +808,17 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
                  *fmt++ = AV_PIX_FMT_GBRP10;
              } else
                  *fmt++ = AV_PIX_FMT_YUV444P10;
@@ -4035,7 +4035,7 @@ index 335dc2cac1..23807756c5 100644
          break;
      case 12:
          if (CHROMA444(h)) {
-@@ -868,6 +875,9 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
+@@ -854,6 +861,9 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
              else
                  *fmt++ = AV_PIX_FMT_YUV444P;
          } else if (CHROMA422(h)) {
@@ -4087,7 +4087,7 @@ index e7faf100f0..c77d3a8cb1 100644
      default:
          return -1;
 
-From 94dd83848ec99174057dd9c9747dfeff0a416a3a Mon Sep 17 00:00:00 2001
+From 943156690cb35cdcb177538d9e795f5755b03b3e Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Mon, 27 Jul 2020 23:15:45 +0000
 Subject: [PATCH 11/13] HACK: define drm NV15 and NV20 format
@@ -4116,7 +4116,7 @@ index c77d3a8cb1..19c41f2b3f 100644
  {
      V4L2RequestDescriptor *req = (V4L2RequestDescriptor*)frame->data[0];
 
-From bbedc169415db75791a60082ec80942e891ad5f3 Mon Sep 17 00:00:00 2001
+From 28e490b972e644113237d6a3f48b0c7fd6cb011e Mon Sep 17 00:00:00 2001
 From: Alex Bee <knaerzche@gmail.com>
 Date: Sat, 22 Oct 2022 22:23:22 +0200
 Subject: [PATCH 12/13] HACK: Revert "lavc/pthread_frame: always transfer
@@ -4128,10 +4128,10 @@ This reverts commit 96c78e50a66a3b443eb2f237e2554ab84b8a12ce.
  1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/libavcodec/pthread_frame.c b/libavcodec/pthread_frame.c
-index 43d6cc8ff4..80c15b35be 100644
+index d9d5afaa82..800f7a2377 100644
 --- a/libavcodec/pthread_frame.c
 +++ b/libavcodec/pthread_frame.c
-@@ -458,13 +458,13 @@ static int submit_packet(PerThreadContext *p, AVCodecContext *user_avctx,
+@@ -430,13 +430,13 @@ static int submit_packet(PerThreadContext *p, AVCodecContext *user_avctx,
              pthread_mutex_unlock(&p->mutex);
              return err;
          }
@@ -4152,7 +4152,7 @@ index 43d6cc8ff4..80c15b35be 100644
      av_packet_unref(p->avpkt);
      ret = av_packet_ref(p->avpkt, avpkt);
 
-From 1d0bcfaf182c8b51b001485bc7e7e6db0ceabc4e Mon Sep 17 00:00:00 2001
+From fe61bbb249a3a9ae96447ded7ef538d7034783e5 Mon Sep 17 00:00:00 2001
 From: Alex Bee <knaerzche@gmail.com>
 Date: Sat, 22 Oct 2022 22:24:07 +0200
 Subject: [PATCH 13/13] HACK: Revert "lavc/pthread_frame: avoid leaving stale
@@ -4164,10 +4164,10 @@ This reverts commit 35aa7e70e7ec350319e7634a30d8d8aa1e6ecdda.
  1 file changed, 12 insertions(+), 35 deletions(-)
 
 diff --git a/libavcodec/pthread_frame.c b/libavcodec/pthread_frame.c
-index 80c15b35be..8faea75a49 100644
+index 800f7a2377..5acc261e60 100644
 --- a/libavcodec/pthread_frame.c
 +++ b/libavcodec/pthread_frame.c
-@@ -147,12 +147,6 @@ typedef struct FrameThreadContext {
+@@ -132,12 +132,6 @@ typedef struct FrameThreadContext {
                                      * Set for the first N packets, where N is the number of threads.
                                      * While it is set, ff_thread_en/decode_frame won't return any results.
                                      */
@@ -4179,8 +4179,8 @@ index 80c15b35be..8faea75a49 100644
 -    void            *stash_hwaccel_priv;
  } FrameThreadContext;
  
- #if FF_API_THREAD_SAFE_CALLBACKS
-@@ -233,17 +227,9 @@ FF_ENABLE_DEPRECATION_WARNINGS
+ static void async_lock(FrameThreadContext *fctx)
+@@ -220,17 +214,9 @@ static attribute_align_arg void *frame_worker_thread(void *arg)
              ff_thread_finish_setup(avctx);
  
          if (p->hwaccel_serializing) {
@@ -4198,7 +4198,7 @@ index 80c15b35be..8faea75a49 100644
  
          if (p->async_serializing) {
              p->async_serializing = 0;
-@@ -307,6 +293,9 @@ static int update_context_from_thread(AVCodecContext *dst, AVCodecContext *src,
+@@ -294,6 +280,9 @@ static int update_context_from_thread(AVCodecContext *dst, AVCodecContext *src,
          dst->color_range = src->color_range;
          dst->chroma_sample_location = src->chroma_sample_location;
  
@@ -4208,7 +4208,7 @@ index 80c15b35be..8faea75a49 100644
          dst->sample_rate    = src->sample_rate;
          dst->sample_fmt     = src->sample_fmt;
  #if FF_API_OLD_CHANNEL_LAYOUT
-@@ -319,6 +308,8 @@ FF_ENABLE_DEPRECATION_WARNINGS
+@@ -306,6 +295,8 @@ FF_ENABLE_DEPRECATION_WARNINGS
          if (err < 0)
              return err;
  
@@ -4217,7 +4217,7 @@ index 80c15b35be..8faea75a49 100644
          if (!!dst->hw_frames_ctx != !!src->hw_frames_ctx ||
              (dst->hw_frames_ctx && dst->hw_frames_ctx->data != src->hw_frames_ctx->data)) {
              av_buffer_unref(&dst->hw_frames_ctx);
-@@ -458,12 +449,6 @@ static int submit_packet(PerThreadContext *p, AVCodecContext *user_avctx,
+@@ -430,12 +421,6 @@ static int submit_packet(PerThreadContext *p, AVCodecContext *user_avctx,
              pthread_mutex_unlock(&p->mutex);
              return err;
          }
@@ -4230,7 +4230,7 @@ index 80c15b35be..8faea75a49 100644
      }
  
      av_packet_unref(p->avpkt);
-@@ -669,14 +654,6 @@ void ff_thread_finish_setup(AVCodecContext *avctx) {
+@@ -603,14 +588,6 @@ void ff_thread_finish_setup(AVCodecContext *avctx) {
          async_lock(p->parent);
      }
  
@@ -4245,7 +4245,7 @@ index 80c15b35be..8faea75a49 100644
      pthread_mutex_lock(&p->progress_mutex);
      if(atomic_load(&p->state) == STATE_SETUP_FINISHED){
          av_log(avctx, AV_LOG_WARNING, "Multiple ff_thread_finish_setup() calls\n");
-@@ -730,6 +707,13 @@ void ff_frame_thread_free(AVCodecContext *avctx, int thread_count)
+@@ -664,6 +641,13 @@ void ff_frame_thread_free(AVCodecContext *avctx, int thread_count)
  
      park_frame_worker_threads(fctx, thread_count);
  
@@ -4259,7 +4259,7 @@ index 80c15b35be..8faea75a49 100644
      for (i = 0; i < thread_count; i++) {
          PerThreadContext *p = &fctx->threads[i];
          AVCodecContext *ctx = p->avctx;
-@@ -776,13 +760,6 @@ void ff_frame_thread_free(AVCodecContext *avctx, int thread_count)
+@@ -705,13 +689,6 @@ void ff_frame_thread_free(AVCodecContext *avctx, int thread_count)
      av_freep(&fctx->threads);
      ff_pthread_free(fctx, thread_ctx_offsets);
  

--- a/packages/multimedia/ffmpeg/patches/vf-deinterlace-v4l2m2m/ffmpeg-001-vf-deinterlace-v4l2m2m.patch
+++ b/packages/multimedia/ffmpeg/patches/vf-deinterlace-v4l2m2m/ffmpeg-001-vf-deinterlace-v4l2m2m.patch
@@ -1,4 +1,4 @@
-From d14859b090dc3b2e1bd761698b947b0b55e4d831 Mon Sep 17 00:00:00 2001
+From d38cb51a9362250b53aa9c7637b17d90718f5f65 Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Tue, 3 Dec 2019 21:01:18 +0100
 Subject: [PATCH] Add V4L2 m2m deinterlace filter
@@ -12,22 +12,22 @@ Signed-off-by: Alex Bee <knaerzche@gmail.com>
  create mode 100644 libavfilter/vf_deinterlace_v4l2m2m.c
 
 diff --git a/libavfilter/Makefile b/libavfilter/Makefile
-index 30cc329fb6..2fe6ab223e 100644
+index b3d3d981dd..9103e3b395 100644
 --- a/libavfilter/Makefile
 +++ b/libavfilter/Makefile
-@@ -254,6 +254,7 @@ OBJS-$(CONFIG_DEFLATE_FILTER)                += vf_neighbor.o
+@@ -262,6 +262,7 @@ OBJS-$(CONFIG_DEFLATE_FILTER)                += vf_neighbor.o
  OBJS-$(CONFIG_DEFLICKER_FILTER)              += vf_deflicker.o
- OBJS-$(CONFIG_DEINTERLACE_QSV_FILTER)        += vf_deinterlace_qsv.o
+ OBJS-$(CONFIG_DEINTERLACE_QSV_FILTER)        += vf_vpp_qsv.o
  OBJS-$(CONFIG_DEINTERLACE_VAAPI_FILTER)      += vf_deinterlace_vaapi.o vaapi_vpp.o
 +OBJS-$(CONFIG_DEINTERLACE_V4L2M2M_FILTER)    += vf_deinterlace_v4l2m2m.o
  OBJS-$(CONFIG_DEJUDDER_FILTER)               += vf_dejudder.o
  OBJS-$(CONFIG_DELOGO_FILTER)                 += vf_delogo.o
  OBJS-$(CONFIG_DENOISE_VAAPI_FILTER)          += vf_misc_vaapi.o vaapi_vpp.o
 diff --git a/libavfilter/allfilters.c b/libavfilter/allfilters.c
-index 5ebacfde27..4b74bac3c8 100644
+index d7db46c2af..075f065f3c 100644
 --- a/libavfilter/allfilters.c
 +++ b/libavfilter/allfilters.c
-@@ -234,6 +234,7 @@ extern const AVFilter ff_vf_dedot;
+@@ -240,6 +240,7 @@ extern const AVFilter ff_vf_dedot;
  extern const AVFilter ff_vf_deflate;
  extern const AVFilter ff_vf_deflicker;
  extern const AVFilter ff_vf_deinterlace_qsv;

--- a/projects/RPi/patches/kodi/0006-fixup-ffmpeg-avformats.patch
+++ b/projects/RPi/patches/kodi/0006-fixup-ffmpeg-avformats.patch
@@ -1,0 +1,24 @@
+From 12b3f602eb11e348e29c61ad162734dab3f51520 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 21 Mar 2023 19:53:12 +0100
+Subject: [PATCH] fixup DVDVideoCodecDRMPRIME av formats for latest ffmpeg
+
+---
+ xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index f9c69d6871..1030ed4aa3 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+@@ -337,7 +337,6 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
+   m_pCodecContext->bits_per_coded_sample = hints.bitsperpixel;
+   m_pCodecContext->time_base.num = 1;
+   m_pCodecContext->time_base.den = DVD_TIME_BASE;
+-  m_pCodecContext->thread_safe_callbacks = 1;
+   m_pCodecContext->thread_count = CServiceBroker::GetCPUInfo()->GetCPUCount();
+ 
+   if (hints.extradata && hints.extrasize > 0)
+-- 
+2.39.2
+

--- a/tools/ffmpeg/gen-patches.sh
+++ b/tools/ffmpeg/gen-patches.sh
@@ -2,7 +2,7 @@
 
 # base ffmpeg version
 FFMPEG_REPO="git://source.ffmpeg.org/ffmpeg.git"
-FFMPEG_VERSION="n5.1.2"
+FFMPEG_VERSION="n6.0"
 
 KODI_FFMPEG_REPO="https://github.com/xbmc/FFmpeg"
 KODI_FFMPEG_VERSION="5.1.2-Nexus-Alpha3"
@@ -34,11 +34,11 @@ create_patch() {
       ;;
     libreelec)
       REPO="https://github.com/LibreELEC/FFmpeg"
-      REFSPEC="5.1.2-libreelec-misc"
+      REFSPEC="6.0-libreelec-misc"
       ;;
     rpi)
       REPO="https://github.com/jc-kynesim/rpi-ffmpeg"
-      REFSPEC="test/5.1.2/main"
+      REFSPEC="dev/6.0/rpi_import_1"
       ;;
     *)
       echo "illegal feature set ${FEATURE_SET}"

--- a/tools/ffmpeg/gen-patches.sh
+++ b/tools/ffmpeg/gen-patches.sh
@@ -4,9 +4,6 @@
 FFMPEG_REPO="git://source.ffmpeg.org/ffmpeg.git"
 FFMPEG_VERSION="n6.0"
 
-KODI_FFMPEG_REPO="https://github.com/xbmc/FFmpeg"
-KODI_FFMPEG_VERSION="5.1.2-Nexus-Alpha3"
-
 ALL_FEATURE_SETS="v4l2-drmprime v4l2-request libreelec rpi vf-deinterlace-v4l2m2m"
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
This PR depends on the kodi ffmpeg 6.0 bump https://github.com/xbmc/xbmc/pull/22967 which isn't merged yet so I'm creating it as draft.

I've updated all ffmpeg patches and switched the AML ffmpeg version to current RPi version, so everything should build fine.

Runtime testing on RPi looks good so far