### PR TITLE
udevil: improve mount.ntfs script

### DIFF
--- a/packages/sysutils/udevil/package.mk
+++ b/packages/sysutils/udevil/package.mk
@@ -28,9 +28,7 @@ post_makeinstall_target() {
     cp -PR src/udevil ${INSTALL}/usr/bin
 
   mkdir -p ${INSTALL}/usr/sbin
-  echo '#!/bin/sh'                 > ${INSTALL}/usr/sbin/mount.ntfs
-  echo '/usr/sbin/modprobe ntfs3' >> ${INSTALL}/usr/sbin/mount.ntfs
-  echo '/usr/bin/mount "$@"'      >> ${INSTALL}/usr/sbin/mount.ntfs
+  echo -e '#!/bin/sh\nexec /usr/bin/mount -tntfs3 "$@"' > ${INSTALL}/usr/sbin/mount.ntfs
   chmod 755 ${INSTALL}/usr/sbin/mount.ntfs
 }
 


### PR DESCRIPTION
When mounting a single ntfs file system there is log spam generated. This PR removes e.g. the following lines of mounting /dev/sda2 (extracted from [here](https://forum.libreelec.tv/thread/26917-ext-hds-not-mounted-after-11-01-update/?postID=179118#post179118)):

```
Mar 30 21:44:04.086628 LibreELEC kernel: ext3: Unknown parameter 'fmask'
Mar 30 21:44:04.109778 LibreELEC kernel: ext2: Unknown parameter 'fmask'
Mar 30 21:44:04.109819 LibreELEC kernel: ext4: Unknown parameter 'fmask'
Mar 30 21:44:04.109839 LibreELEC kernel: squashfs: Unknown parameter 'fmask'
Mar 30 21:44:04.113141 LibreELEC kernel: F2FS-fs (sda2): Magic Mismatch, valid(0xf2f52010) - read(0x8e0e8966)
Mar 30 21:44:04.113157 LibreELEC kernel: F2FS-fs (sda2): Can't find valid F2FS filesystem in 1th superblock
Mar 30 21:44:04.119707 LibreELEC kernel: F2FS-fs (sda2): Magic Mismatch, valid(0xf2f52010) - read(0x0)
Mar 30 21:44:04.119759 LibreELEC kernel: F2FS-fs (sda2): Can't find valid F2FS filesystem in 2th superblock
Mar 30 21:44:04.153100 LibreELEC kernel: fuseblk: Unknown parameter 'fmask'
```

ntfs3 fs is explicit mounted in `mount.ntfs` by '-tntfs3'. The ntfs3 module is loaded automatically.

Backport of #7740