### PR TITLE
X11 Updates

### DIFF
--- a/packages/x11/driver/xf86-input-libinput/package.mk
+++ b/packages/x11/driver/xf86-input-libinput/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xf86-input-libinput"
-PKG_VERSION="1.2.1"
-PKG_SHA256="8151db5b9ddb317c0ce92dcb62da9a8db5079e5b8a95b60abc854da21e7e971b"
+PKG_VERSION="1.3.0"
+PKG_SHA256="1446ba20a22bc968b5a4a0b4dbc3b8e037c50d9c59ac75fa3f7fc506c58c1abb"
 PKG_LICENSE="MIT"
-PKG_SITE="http://www.freedesktop.org/wiki/Software/libinput/"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/driver/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain libinput"
+PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/driver/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain libinput xorg-server"
 PKG_LONGDESC="This is an X driver based on libinput."
 PKG_TOOLCHAIN="autotools"
 

--- a/packages/x11/lib/libXfixes/package.mk
+++ b/packages/x11/lib/libXfixes/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXfixes"
-PKG_VERSION="6.0.0"
-PKG_SHA256="a7c1a24da53e0b46cac5aea79094b4b2257321c621b258729bc3139149245b4c"
+PKG_VERSION="6.0.1"
+PKG_SHA256="b695f93cd2499421ab02d22744458e650ccc88c1d4c8130d60200213abc02d58"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
-PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11"
 PKG_LONGDESC="X Fixes Library"
 PKG_BUILD_FLAGS="+pic"

--- a/packages/x11/lib/libXt/package.mk
+++ b/packages/x11/lib/libXt/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXt"
-PKG_VERSION="1.2.1"
-PKG_SHA256="679cc08f1646dbd27f5e48ffe8dd49406102937109130caab02ca32c083a3d60"
+PKG_VERSION="1.3.0"
+PKG_SHA256="52820b3cdb827d08dc90bdfd1b0022a3ad8919b57a39808b12591973b331bf91"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.X.org"
-PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.X.org"
+PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11 libSM"
 PKG_LONGDESC="libXt provides the X Toolkit Intrinsics library, an abstract widget library upon which other toolkits are based."
 


### PR DESCRIPTION
- xf86-input-libinput: update to 1.3.0
- libXt: update to 1.3.0
- libXfixes: update to 6.0.1