### PR TITLE
media-driver: update to 23.1.6

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="23.1.5"
-PKG_SHA256="31481bc1959f743e66f3ba532aade2da05a95c12ebfaf63a4c8dc3d3d6174427"
+PKG_VERSION="23.1.6"
+PKG_SHA256="f69bf559fb96c9094df7badd73e373d4c4efb9a4e96738b8dc1e3e0fd9933956"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
Intel Media Driver 2023Q1 Release - 23.1.6
- https://github.com/intel/media-driver/releases/tag/intel-media-23.1.6

log:
- https://github.com/intel/media-driver/compare/intel-media-23.1.5...intel-media-23.1.6
- Minor change from 23.1.5