### PR TITLE
add libdisplay-info dependency for gbm builds

### DIFF
--- a/packages/devel/libdisplay-info/package.mk
+++ b/packages/devel/libdisplay-info/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libdisplay-info"
+PKG_VERSION="0.1.1"
+PKG_SHA256="0d8731588e9f82a9cac96324a3d7c82e2ba5b1b5e006143fefe692c74069fb60"
+PKG_LICENSE="MIT"
+PKG_SITE="https://gitlab.freedesktop.org/emersion/libdisplay-info"
+PKG_URL="https://gitlab.freedesktop.org/emersion/libdisplay-info/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain hwdata"
+PKG_LONGDESC="EDID and DisplayID library"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -213,7 +213,7 @@ configure_package() {
   fi
 
   if [ ! "${KODIPLAYER_DRIVER}" = "default" -a "${DISPLAYSERVER}" = "no" ]; then
-    PKG_DEPENDS_TARGET+=" ${KODIPLAYER_DRIVER} libinput libxkbcommon"
+    PKG_DEPENDS_TARGET+=" ${KODIPLAYER_DRIVER} libinput libxkbcommon libdisplay-info"
     if [ "${OPENGLES_SUPPORT}" = yes -a "${KODIPLAYER_DRIVER}" = "${OPENGLES}" ]; then
       KODI_PLATFORM="-DCORE_PLATFORM_NAME=gbm -DAPP_RENDER_SYSTEM=gles"
       CFLAGS+=" -DEGL_NO_X11"


### PR DESCRIPTION
This adds support for [libdisplay-info](https://gitlab.freedesktop.org/emersion/libdisplay-info).

This is required by the upcoming Kodi PR -> https://github.com/xbmc/xbmc/pull/19141