### PR TITLE
kodi: update to current master

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="847a347839a895419d191237e5e1cfd3ed19720c"
-PKG_SHA256="047032c39244eea0759e067b3a836a3e8911dc60fa41c41c5c54d43fc4db1740"
+PKG_VERSION="12048c03a762328e2b7d537486155bc50a6fcc80"
+PKG_SHA256="20ccc20e578e684bf457c0b8f9fc1bb92aacc34bf2d3d19c69a240545bb2606a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
This needs to be merged together with the ffmpeg 6.0 update PR #7735

Runtime tested on RPi4

```
2023-04-11 15:48:13.199 T:839      info <general>: Starting Kodi (21.0-ALPHA1 (20.90.101) Git:12048c03a762328e2b7d537486155bc50a6fcc80). Platform: Linux ARM 64-bit
2023-04-11 15:48:13.199 T:839      info <general>: Using Release Kodi x64
2023-04-11 15:48:13.199 T:839      info <general>: Kodi compiled 2023-04-11 by GCC 12.2.0 for Linux ARM 64-bit version 6.1.21 (393493)
2023-04-11 15:48:13.199 T:839      info <general>: Running on BCM2835 with LibreELEC (HiassofT): devel-20230411130334-c454ebc 12.0, kernel: Linux ARM 64-bit version 6.1.21
2023-04-11 15:48:13.199 T:839      info <general>: FFmpeg version/source: 6.0
```