### PR TITLE
mesa: do not use LLVM for gallium draw

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -28,6 +28,7 @@ PKG_MESON_OPTS_TARGET="-Ddri-drivers= \
                        -Dlibunwind=disabled \
                        -Dlmsensors=disabled \
                        -Dbuild-tests=false \
+                       -Ddraw-use-llvm=false \
                        -Dselinux=false \
                        -Dosmesa=false"
 


### PR DESCRIPTION
When `mesa` finds llvm, it compiles “gallium draw” with llvm, this is subsequently linked into the `iris_dri.so` - this can be checked using `readelf` with the `LLVMInitializeX86TargetInfo` symbol being present.

the build of the libLLVM library doesn’t include X86 in the target (only AMDGPU)

https://github.com/LibreELEC/LibreELEC.tv/blob/97410801443b391895b8a626b7811ba4e71b8038/packages/lang/llvm/package.mk#L91

so don’t let mesa build to use llvm for the TARGET_ARCH (only AMDGPU - which is “supported as per mesa PR 9259)

- Fixes #7764

ref:
- https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/9259

maybe candidate for backport.

Reason for this appearing now is - change in handling the dlopen?