### PR TITLE
[LE11] Allwinner: u-boot: Fix sporadic DRAM size misdetection

### DIFF
--- a/projects/Allwinner/patches/u-boot/0014-unreliable-dram.patch
+++ b/projects/Allwinner/patches/u-boot/0014-unreliable-dram.patch
@@ -1,0 +1,40 @@
+From: megous@megous.com
+Date: Mon, 29 Jul 2019 01:39:42 +0200
+Subject: [U-Boot] [PATCH] Fix unreliable detection of DRAM size on Orange Pi 3
+
+From: Ondrej Jirman <megous@megous.com>
+
+Orange Pi 3 has 2 GiB of DRAM, that sometime get misdetected
+as 4 GiB, due to false negative result from mctl_mem_matches()
+when detecting number of column address bits. This leads to
+u-boot detecting more address bits than there are and the
+boot process hangs shortly after.
+
+In mctl_mem_matches() we need to wait for each write to finish,
+separately. Without this, the check is not reliable for some
+unknown reason, probably having to do with unpredictable memory
+access ordering.
+
+Patch was made with help from André Przywara, who noticed that
+my original idea about detection failing due to read-back from
+cache without involving DRAM was false, because data cache is
+still of at the time of the DRAM size autodetection.
+
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+Cc: André Przywara <andre.przywara@arm.com>
+---
+ arch/arm/mach-sunxi/dram_helpers.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/mach-sunxi/dram_helpers.c b/arch/arm/mach-sunxi/dram_helpers.c
+index 239ab421a8..6dba448638 100644
+--- a/arch/arm/mach-sunxi/dram_helpers.c
++++ b/arch/arm/mach-sunxi/dram_helpers.c
+@@ -30,6 +30,7 @@ bool mctl_mem_matches(u32 offset)
+ {
+ 	/* Try to write different values to RAM at two addresses */
+ 	writel(0, CONFIG_SYS_SDRAM_BASE);
++	dsb();
+ 	writel(0xaa55aa55, (ulong)CONFIG_SYS_SDRAM_BASE + offset);
+ 	dsb();
+ 	/* Check if the same value is actually observed when reading back */


### PR DESCRIPTION
With this patch applied, I couldn't replicate DRAM size mis-detection issue anymore.