### PR TITLE
busybox: createlog: don't include journal files of persistent logging

### DIFF
--- a/packages/sysutils/busybox/scripts/createlog
+++ b/packages/sysutils/busybox/scripts/createlog
@@ -137,7 +137,7 @@ mkdir -p $BASEDIR/$LOGDIR
 
 # varlog.log
   LOGFILE="06_varlog.log"
-  for i in $(find /var/log -type f); do
+  for i in $(find /var/log -name journal -prune -o -type f -print); do
     getlog_cmd cat $i
   done
 


### PR DESCRIPTION
When persistent logging is enabled the binary journal files are included into createlog's ZIP file.

Omit them to minimize the file size.