### PR TITLE
[le11] jellyfin: update to 10.8.10 and addon (1)

### DIFF
--- a/packages/addons/service/jellyfin/changelog.txt
+++ b/packages/addons/service/jellyfin/changelog.txt
@@ -1,1 +1,2 @@
-initial release
+1
+- jellyfin: update to 10.8.10

--- a/packages/addons/service/jellyfin/package.mk
+++ b/packages/addons/service/jellyfin/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="jellyfin"
 PKG_VERSION="1.0"
-PKG_VERSION_NUMBER="10.8.9"
-PKG_REV="0"
+PKG_VERSION_NUMBER="10.8.10"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://jellyfin.org/"


### PR DESCRIPTION
- https://github.com/jellyfin/jellyfin/releases/tag/v10.8.10

CRITICAL SECURITY ADVISORY: [GHSA-9p5f-5x8v-x65m](https://github.com/jellyfin/jellyfin/security/advisories/GHSA-9p5f-5x8v-x65m) and [GHSA-89hp-h43h-r5pq](https://github.com/jellyfin/jellyfin-web/security/advisories/GHSA-89hp-h43h-r5pq) can be combined to allow remote code execution for any authenticated Jellyfin user including non-admin users. While the particular execution mechanism of the former dates to the 10.8.0 release, the latter was present for all Jellyfin releases before this point. It is thus absolutely critical for all Jellyfin administrators, regardless of version, to upgrade to this version if they allow any untrusted users and/or expose their instance to the Internet.