### PR TITLE
Fix chrome build

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/chrome-libXfixes/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libXfixes/package.mk
@@ -15,5 +15,5 @@ PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} \
 
 unpack() {
   mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.bz2 -C ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
 }


### PR DESCRIPTION
chrome-libXfixes: update package filename to match libXfixes
- Commit 5a91268dd1fadc20b85a1da7c0563f5eda66276d changed from .bz2 to .xz. Update chrome-libXfixes to match.