### PR TITLE
libretro-mame2000: fix build with aarch64

### DIFF
--- a/packages/emulation/libretro-mame2000/patches/libretro-mame2000-106-fix-build-with-aarch64.patch
+++ b/packages/emulation/libretro-mame2000/patches/libretro-mame2000-106-fix-build-with-aarch64.patch
@@ -1,0 +1,23 @@
+From c6005d40d6807f58d2092fd337aff4e0cbd4f89a Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 25 Apr 2023 21:43:35 +1000
+Subject: [PATCH] Update aarch64.c
+
+Drop use of macro expansion and update to using __asm__
+---
+ src/libretro/libretro-common/libco/aarch64.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libretro/libretro-common/libco/aarch64.c b/src/libretro/libretro-common/libco/aarch64.c
+index eef31a3..38dcbdb 100644
+--- a/src/libretro/libretro-common/libco/aarch64.c
++++ b/src/libretro/libretro-common/libco/aarch64.c
+@@ -22,7 +22,7 @@ extern "C" {
+ static thread_local uint64_t co_active_buffer[64];
+ static thread_local cothread_t co_active_handle;
+ 
+-asm (
++__asm__ (
+       ".globl co_switch_aarch64\n"
+       ".globl _co_switch_aarch64\n"
+       "co_switch_aarch64:\n"


### PR DESCRIPTION
- https://github.com/libretro/mame2000-libretro/pull/106
- https://github.com/libretro/mame2000-libretro/issues/105
- Fixes #7673 