### PR TITLE
gcc: update to 13.1.0

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/snapcast/patches/snapcast-03-1124-fix-gcc13.patch
+++ b/packages/addons/addon-depends/snapcast-depends/snapcast/patches/snapcast-03-1124-fix-gcc13.patch
@@ -1,0 +1,27 @@
+From 73c75ccb8eb20aa1514e8c86deb859e70bc63290 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Sat, 15 Apr 2023 10:20:47 +0100
+Subject: [PATCH] Fix build with GCC 13
+
+GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some
+are no longer transitively included.
+
+See https://gnu.org/software/gcc/gcc-13/porting_to.html.
+
+Bug: https://bugs.gentoo.org/894742
+---
+ common/sample_format.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/common/sample_format.hpp b/common/sample_format.hpp
+index 900655f7..b68d00a3 100644
+--- a/common/sample_format.hpp
++++ b/common/sample_format.hpp
+@@ -19,6 +19,7 @@
+ #ifndef SAMPLE_FORMAT_H
+ #define SAMPLE_FORMAT_H
+ 
++#include <cstdint>
+ #include <string>
+ 
+ 

--- a/packages/addons/addon-depends/ttyd-depends/libwebsockets/patches/libwebsockets-0001-PR2824.patch
+++ b/packages/addons/addon-depends/ttyd-depends/libwebsockets/patches/libwebsockets-0001-PR2824.patch
@@ -1,0 +1,28 @@
+From 722e44cb5b74cae206f47a6dc0d985eba8ed1b2e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 26 Jan 2023 17:17:49 -0800
+Subject: [PATCH] Fix -Werror=enum-int-mismatch in
+ lws_tls_server_abort_connection()
+
+GCC 13 is findinf this function signature mismatch.
+
+../git/lib/tls/openssl/openssl-server.c:713:1: error: conflicting types for 'lws_tls_server_abort_connection' due to enum/integer mismatch; have 'int(struct lws *)' [-Werror=enum-int-mismatch]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ lib/tls/openssl/openssl-server.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/tls/openssl/openssl-server.c b/lib/tls/openssl/openssl-server.c
+index f2e77324f..43d65e030 100644
+--- a/lib/tls/openssl/openssl-server.c
++++ b/lib/tls/openssl/openssl-server.c
+@@ -699,7 +699,7 @@ lws_tls_server_new_nonblocking(struct lws *wsi, lws_sockfd_type accept_fd)
+ 	return 0;
+ }
+ 
+-int
++enum lws_ssl_capable_status
+ lws_tls_server_abort_connection(struct lws *wsi)
+ {
+ 	if (wsi->tls.use_ssl)

--- a/packages/emulation/libretro-bsnes-hd/patches/bsnes_hd-002-fix-build-with-gcc-13.patch
+++ b/packages/emulation/libretro-bsnes-hd/patches/bsnes_hd-002-fix-build-with-gcc-13.patch
@@ -1,0 +1,26 @@
+From 587e496f667970d60b6ea29976c171da1681388e Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 27 Apr 2023 02:24:24 +1000
+Subject: [PATCH] Fix build with gcc-13
+
+Error was:
+In file included from ../nall/arithmetic.hpp:69:
+../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint4096_t&, const uint4096_t&, uint4096_t&, uint4096_t&)':
+../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
+  239 |   if(!rhs) throw std::runtime_error("division by zero");
+      |                       ^~~~~~~~~~~~~
+../nall/arithmetic/natural.hpp:239:23: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
+---
+ nall/arithmetic/natural.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/nall/arithmetic/natural.hpp b/nall/arithmetic/natural.hpp
+index fcc902b8..cc1bd907 100644
+--- a/nall/arithmetic/natural.hpp
++++ b/nall/arithmetic/natural.hpp
+@@ -1,3 +1,5 @@
++#include <stdexcept>
++
+ #define ConcatenateType(Size) uint##Size##_t
+ #define DeclareType(Size) ConcatenateType(Size)
+ 

--- a/packages/emulation/libretro-bsnes/patches/0002-PR60-fix-build-with-gcc13.patch
+++ b/packages/emulation/libretro-bsnes/patches/0002-PR60-fix-build-with-gcc13.patch
@@ -1,0 +1,26 @@
+From e15e3e639b86579775b30dd088eb3880341b9bbe Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 27 Apr 2023 02:27:49 +1000
+Subject: [PATCH] Fix build with gcc-13
+
+Error was:
+In file included from ../nall/arithmetic.hpp:69:
+../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint4096_t&, const uint4096_t&, uint4096_t&, uint4096_t&)':
+../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
+  239 |   if(!rhs) throw std::runtime_error("division by zero");
+      |                       ^~~~~~~~~~~~~
+../nall/arithmetic/natural.hpp:239:23: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
+---
+ nall/arithmetic/natural.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/nall/arithmetic/natural.hpp b/nall/arithmetic/natural.hpp
+index fcc902b8d..cc1bd907c 100644
+--- a/nall/arithmetic/natural.hpp
++++ b/nall/arithmetic/natural.hpp
+@@ -1,3 +1,5 @@
++#include <stdexcept>
++
+ #define ConcatenateType(Size) uint##Size##_t
+ #define DeclareType(Size) ConcatenateType(Size)
+ 

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc"
-PKG_VERSION="12.2.0"
-PKG_SHA256="e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff"
+PKG_VERSION="13.1.0"
+PKG_SHA256="61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://gcc.gnu.org/"
 PKG_URL="https://ftpmirror.gnu.org/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/patches/77.patch
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/patches/77.patch
@@ -1,0 +1,27 @@
+From 0d4d3fcf5c58dd16b3e9a7337189141b839e4ace Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 15 Apr 2023 07:41:15 +1000
+Subject: [PATCH] MidiScan: include missing <cstdint>
+
+gcc 13 moved some includes around and as a result <cstdint> is no longer transitively
+included [1]. Explicitly include it for uint{32,64}_t.
+
+[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ src/MidiScan.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/MidiScan.h b/src/MidiScan.h
+index 9c19bdf..ac959e0 100644
+--- a/src/MidiScan.h
++++ b/src/MidiScan.h
+@@ -8,6 +8,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/patches/PR63-fix-build-with-gcc-13.patch
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/patches/PR63-fix-build-with-gcc-13.patch
@@ -1,0 +1,27 @@
+From 47dcb3843e02abb69c52d6f0021bd2816b8317a5 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 27 Apr 2023 02:46:59 +1000
+Subject: [PATCH] include missing <cstdint> to support gcc-13
+
+gcc 13 moved some includes around and as a result <cstdint> is no longer transitively
+included [1]. Explicitly include it for uint{32,64}_t.
+
+[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ lib/TinyEXIF/TinyEXIF.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/TinyEXIF/TinyEXIF.h b/lib/TinyEXIF/TinyEXIF.h
+index 56354aa..b03d36b 100644
+--- a/lib/TinyEXIF/TinyEXIF.h
++++ b/lib/TinyEXIF/TinyEXIF.h
+@@ -34,6 +34,7 @@
+ #ifndef __TINYEXIF_H__
+ #define __TINYEXIF_H__
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/patches/PR55-fix-build-with-gcc-13.patch
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/patches/PR55-fix-build-with-gcc-13.patch
@@ -1,0 +1,27 @@
+From 69671899aed02e0da2730a858a6dc1c441e05932 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 27 Apr 2023 03:00:02 +1000
+Subject: [PATCH] include missing <cstdint> to support gcc-13
+
+gcc 13 moved some includes around and as a result <cstdint> is no longer transitively
+included [1]. Explicitly include it for uint{32,64}_t.
+
+[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ lib/TinyEXIF/TinyEXIF.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/TinyEXIF/TinyEXIF.h b/lib/TinyEXIF/TinyEXIF.h
+index 56354aa..b03d36b 100644
+--- a/lib/TinyEXIF/TinyEXIF.h
++++ b/lib/TinyEXIF/TinyEXIF.h
+@@ -34,6 +34,7 @@
+ #ifndef __TINYEXIF_H__
+ #define __TINYEXIF_H__
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 

--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/patches/1240-fix-gcc13.patch
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/patches/1240-fix-gcc13.patch
@@ -1,0 +1,111 @@
+From 7b5c284e63c1d6327db7551a0646cffcbaf9410f Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 26 Apr 2023 15:47:17 +0000
+Subject: [PATCH] include missing <cstdint> to support gcc-13
+
+gcc 13 moved some includes around and as a result <cstdint> is no longer transitively
+included [1]. Explicitly include it for uint{32,64}_t.
+
+[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ src/Iaes_decrypter.h        | 3 ++-
+ src/SSD_dll.h               | 1 +
+ src/utils/FileUtils.h       | 1 +
+ src/utils/PropertiesUtils.h | 1 +
+ src/utils/StringUtils.h     | 1 +
+ src/utils/Utils.h           | 1 +
+ 6 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/Iaes_decrypter.h b/src/Iaes_decrypter.h
+index 7fdf6046d..da992be95 100644
+--- a/src/Iaes_decrypter.h
++++ b/src/Iaes_decrypter.h
+@@ -10,6 +10,7 @@
+ 
+ #include <bento4/Ap4Types.h>
+ 
++#include <cstdint>
+ #include <string>
+ 
+ class IAESDecrypter
+@@ -31,4 +32,4 @@ class IAESDecrypter
+ 
+ private:
+   std::string m_licenseKey;
+-};
+\ No newline at end of file
++};
+diff --git a/src/SSD_dll.h b/src/SSD_dll.h
+index 4b2b70c1a..d23fcbe45 100644
+--- a/src/SSD_dll.h
++++ b/src/SSD_dll.h
+@@ -8,6 +8,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <stdarg.h> // va_list, va_start, va_arg, va_end
+ #include <string_view>
+ 
+diff --git a/src/utils/FileUtils.h b/src/utils/FileUtils.h
+index 40745b0d4..0924d8ff7 100644
+--- a/src/utils/FileUtils.h
++++ b/src/utils/FileUtils.h
+@@ -8,6 +8,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <string_view>
+ 
+diff --git a/src/utils/PropertiesUtils.h b/src/utils/PropertiesUtils.h
+index dee3e0a16..a658b835c 100644
+--- a/src/utils/PropertiesUtils.h
++++ b/src/utils/PropertiesUtils.h
+@@ -8,6 +8,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <map>
+ #include <string>
+ #include <utility>
+diff --git a/src/utils/StringUtils.h b/src/utils/StringUtils.h
+index 3f841a274..f209546fa 100644
+--- a/src/utils/StringUtils.h
++++ b/src/utils/StringUtils.h
+@@ -8,6 +8,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <string_view>
+ #include <vector>
+diff --git a/src/utils/Utils.h b/src/utils/Utils.h
+index 4966ece63..472a328c4 100644
+--- a/src/utils/Utils.h
++++ b/src/utils/Utils.h
+@@ -8,6 +8,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <map>
+ #include <string>
+ #include <string_view>
+diff --git a/src/common/AdaptiveDecrypter.h b/src/common/AdaptiveDecrypter.h
+index 4966ece63..472a328c4 100644
+--- a/src/common/AdaptiveDecrypter.h
++++ b/src/common/AdaptiveDecrypter.h
+@@ -10,6 +10,7 @@
+ 
+ #include "../CryptoMode.h"
+ 
++#include <cstdint>
+ #include <stdexcept>
+ #include <string_view>
+ 

--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/patches/PR238-fix-gcc-13-build.patch
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/patches/PR238-fix-gcc-13-build.patch
@@ -1,0 +1,47 @@
+From fd7bd5ad86fd0006ad571a051fa5d5603a47e4b4 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 26 Apr 2023 17:15:00 +0000
+Subject: [PATCH] include missing <cstdint> to support gcc-13
+
+gcc 13 moved some includes around and as a result <cstdint> is no longer transitively
+included [1]. Explicitly include it for uint{32,64}_t.
+
+[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ src/utils/DiskUtils.h | 1 +
+ src/utils/HttpProxy.h | 3 ++-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/utils/DiskUtils.h b/src/utils/DiskUtils.h
+index 79e34268..f900ec58 100644
+--- a/src/utils/DiskUtils.h
++++ b/src/utils/DiskUtils.h
+@@ -7,6 +7,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace ffmpegdirect
+diff --git a/src/utils/HttpProxy.h b/src/utils/HttpProxy.h
+index eb0c99cb..d203ce36 100644
+--- a/src/utils/HttpProxy.h
++++ b/src/utils/HttpProxy.h
+@@ -7,6 +7,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace ffmpegdirect
+@@ -36,4 +37,4 @@ namespace ffmpegdirect
+     std::string m_user;
+     std::string m_password;
+   };
+-} //namespace ffmpegdirect
+\ No newline at end of file
++} //namespace ffmpegdirect

--- a/packages/multimedia/media-driver/patches/1648.patch
+++ b/packages/multimedia/media-driver/patches/1648.patch
@@ -1,0 +1,288 @@
+From fd67cc3fbd3a362297afc7cc8d75560df62708de Mon Sep 17 00:00:00 2001
+From: Jay Yang <jay.yang@intel.com>
+Date: Fri, 21 Apr 2023 13:10:52 +0800
+Subject: [PATCH] Fix GCC13 build errors
+
+Fix #1639
+Fix #1640
+Fix #1641
+Signed-off-by: Jay Yang <jay.yang@intel.com>
+---
+ .../Xe_M/Xe_XPM/hw/mhw_vebox_xe_xpm.h         | 21 +++++++++++--------
+ .../hal/codechal_encode_csc_ds_mdf_g12.h      |  1 +
+ .../agnostic/gen12/hw/mhw_vebox_g12_X.h       |  1 +
+ .../gen12/hw/vdbox/mhw_vdbox_avp_generic.h    | 19 -----------------
+ .../gen9/codec/hal/codechal_encode_avc_g9.h   |  1 +
+ .../codec/hal/codechal_fei_hevc_g9_skl.cpp    |  3 ---
+ .../shared/mediacopy/media_copy_xe_hpm.h      |  1 +
+ .../shared/mediacopy/media_copy_xe_xpm_base.h |  1 +
+ .../shared/mediacopy/media_copy_xe_xpm_plus.h |  1 +
+ .../hucitf/decode_huc_packet_creator_g12.h    |  4 ++++
+ .../m12_0/shared/mediacopy/media_copy_m12_0.h |  1 +
+ .../mediacopy/media_copy_xe_lpm_plus_base.h   |  1 +
+ .../bufferMgr/encode_tracked_buffer_queue.cpp |  5 +++++
+ .../bufferMgr/encode_tracked_buffer_queue.h   |  2 +-
+ .../common/shared/media_debug_serializer.h    |  1 +
+ .../media_scalability_multipipe.cpp           |  2 +-
+ .../scalability/media_scalability_multipipe.h |  2 +-
+ 17 files changed, 33 insertions(+), 34 deletions(-)
+
+diff --git a/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_vebox_xe_xpm.h b/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_vebox_xe_xpm.h
+index b6b86a54ed..ae9a4be096 100644
+--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_vebox_xe_xpm.h
++++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/mhw_vebox_xe_xpm.h
+@@ -110,15 +110,6 @@ class MhwVeboxInterfaceXe_Xpm: public MhwVeboxInterfaceG12
+         PMOS_COMMAND_BUFFER                 pCmdBuffer,
+         PMHW_VEBOX_SURFACE_STATE_CMD_PARAMS pVeboxSurfaceStateCmdParams) override;
+ 
+-    void SetVeboxSurfaces(
+-        PMHW_VEBOX_SURFACE_PARAMS                  pSurfaceParam,
+-        PMHW_VEBOX_SURFACE_PARAMS                  pDerivedSurfaceParam,
+-        PMHW_VEBOX_SURFACE_PARAMS                  pSkinScoreSurfaceParam,
+-        mhw_vebox_xe_xpm::VEBOX_SURFACE_STATE_CMD *pVeboxSurfaceState,
+-        bool                                       bIsOutputSurface,
+-        bool                                       bDIEnable,
+-        bool                                       b3DlutEnable);
+-
+     MOS_STATUS FindVeboxGpuNodeToUse(
+         PMHW_VEBOX_GPUNODE_LIMIT pGpuNodeLimit) override;
+ 
+@@ -144,6 +135,18 @@ class MhwVeboxInterfaceXe_Xpm: public MhwVeboxInterfaceG12
+     uint32_t m_indexofVebox              = 0;
+     uint32_t m_numofVebox                = 1;
+     uint32_t m_usingSfc                  = 0;
++   
++    using MhwVeboxInterfaceG12::SetVeboxSurfaces;
++
++    void SetVeboxSurfaces(
++        PMHW_VEBOX_SURFACE_PARAMS                  pSurfaceParam,
++        PMHW_VEBOX_SURFACE_PARAMS                  pDerivedSurfaceParam,
++        PMHW_VEBOX_SURFACE_PARAMS                  pSkinScoreSurfaceParam,
++        mhw_vebox_xe_xpm::VEBOX_SURFACE_STATE_CMD *pVeboxSurfaceState,
++        bool                                       bIsOutputSurface,
++        bool                                       bDIEnable,
++        bool                                       b3DlutEnable);
++
+ };
+ 
+ #endif // __MHW_VEBOX_XE_XPM_H__
+diff --git a/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_mdf_g12.h b/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_mdf_g12.h
+index 3dd276a748..ce21993da7 100644
+--- a/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_mdf_g12.h
++++ b/media_driver/agnostic/gen12/codec/hal/codechal_encode_csc_ds_mdf_g12.h
+@@ -202,6 +202,7 @@ class CodechalEncodeCscDsMdfG12 : public CodechalEncodeCscDsG12
+ 
+      MOS_STATUS CscKernel(
+         KernelParams* pParams) override;
++    using CodechalEncodeCscDsG12::InitKernelStateCsc;
+     MOS_STATUS InitKernelStateCsc(KernelParams* pParams);
+     MOS_STATUS SetupKernelArgsCSC(CmKernel *cmKrnCSCDS, SurfaceParamsCscMdf* surfaceparams);
+     MOS_STATUS SetCurbeCscforMDF(CMRT_UMD::vector<uint32_t, 10> & curbeData);
+diff --git a/media_driver/agnostic/gen12/hw/mhw_vebox_g12_X.h b/media_driver/agnostic/gen12/hw/mhw_vebox_g12_X.h
+index 64e2ffe462..d0c2d6ca5e 100644
+--- a/media_driver/agnostic/gen12/hw/mhw_vebox_g12_X.h
++++ b/media_driver/agnostic/gen12/hw/mhw_vebox_g12_X.h
+@@ -336,6 +336,7 @@ class MhwVeboxInterfaceG12 : public MhwVeboxInterfaceGeneric<mhw_vebox_g12_X>
+     MOS_STATUS ValidateVeboxScalabilityConfig();
+ #endif
+ 
++protected:
+     void SetVeboxSurfaces(
+         PMHW_VEBOX_SURFACE_PARAMS                 pSurfaceParam,
+         PMHW_VEBOX_SURFACE_PARAMS                 pDerivedSurfaceParam,
+diff --git a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_avp_generic.h b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_avp_generic.h
+index ae1bd88cb2..fb2fc0fe86 100644
+--- a/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_avp_generic.h
++++ b/media_driver/agnostic/gen12/hw/vdbox/mhw_vdbox_avp_generic.h
+@@ -95,24 +95,5 @@ class MhwVdboxAvpInterfaceGeneric : public MhwVdboxAvpInterface
+ 
+         return eStatus;
+     }
+-
+-    MOS_STATUS AddAvpBsdObjectCmd(
+-        PMOS_COMMAND_BUFFER                 cmdBuffer,
+-        MhwVdboxAvpBsdParams                *params)
+-    {
+-        MOS_STATUS eStatus = MOS_STATUS_SUCCESS;
+-
+-        MHW_FUNCTION_ENTER;
+-        MHW_MI_CHK_NULL(m_osInterface);
+-
+-        typename TAvpCmds::AVP_BSD_OBJECT_CMD   cmd;
+-
+-        cmd.DW1.IndirectBsdDataLength       = params->m_bsdDataLength;
+-        cmd.DW2.IndirectDataStartAddress    = params->m_bsdDataStartOffset;
+-
+-        MHW_MI_CHK_STATUS(m_osInterface->pfnAddCommand(cmdBuffer, &cmd, sizeof(cmd)));
+-
+-        return eStatus;
+-    }
+ };
+ #endif
+diff --git a/media_driver/agnostic/gen9/codec/hal/codechal_encode_avc_g9.h b/media_driver/agnostic/gen9/codec/hal/codechal_encode_avc_g9.h
+index f981860946..a735bb46cf 100644
+--- a/media_driver/agnostic/gen9/codec/hal/codechal_encode_avc_g9.h
++++ b/media_driver/agnostic/gen9/codec/hal/codechal_encode_avc_g9.h
+@@ -5668,6 +5668,7 @@ class CodechalEncodeAvcEncG9 : public CodechalEncodeAvcEnc
+     MOS_STATUS GetStatusReport(
+         void *status,
+         uint16_t numStatus) override;
++    using CodechalEncodeAvcEnc::GetStatusReport;
+ 
+ #if USE_CODECHAL_DEBUG_TOOL
+ protected:
+diff --git a/media_driver/agnostic/gen9_skl/codec/hal/codechal_fei_hevc_g9_skl.cpp b/media_driver/agnostic/gen9_skl/codec/hal/codechal_fei_hevc_g9_skl.cpp
+index 8da01da3f0..59c0480653 100644
+--- a/media_driver/agnostic/gen9_skl/codec/hal/codechal_fei_hevc_g9_skl.cpp
++++ b/media_driver/agnostic/gen9_skl/codec/hal/codechal_fei_hevc_g9_skl.cpp
+@@ -6410,9 +6410,6 @@ MOS_STATUS CodechalFeiHevcStateG9Skl::FreeEncResources()
+ 
+      m_cmKernelMap.clear();
+ 
+-     CmKernelMapType deallocator;
+-     m_cmKernelMap.swap(deallocator);
+-
+ #endif
+ 
+     return eStatus;
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/shared/mediacopy/media_copy_xe_hpm.h b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/shared/mediacopy/media_copy_xe_hpm.h
+index b43087e93c..23bf56075c 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/shared/mediacopy/media_copy_xe_hpm.h
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/shared/mediacopy/media_copy_xe_hpm.h
+@@ -50,6 +50,7 @@ class MediaCopyState_Xe_Hpm: public MediaCopyBaseState
+     //!
+     //! \brief    init function.
+     virtual MOS_STATUS Initialize(  PMOS_INTERFACE  osInterface, MhwInterfaces *mhwInterfaces);
++    using MediaCopyBaseState::Initialize;
+ 
+     //!
+     //! \brief    render format support.
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_copy_xe_xpm_base.h b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_copy_xe_xpm_base.h
+index 8075553c0d..14c291a4a1 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_copy_xe_xpm_base.h
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_copy_xe_xpm_base.h
+@@ -49,6 +49,7 @@ class MediaCopyStateXe_Xpm_Base: public MediaCopyBaseState
+     //!
+     //! \brief    init function.
+     virtual MOS_STATUS Initialize(  PMOS_INTERFACE  osInterface, MhwInterfaces *mhwInterfaces);
++    using MediaCopyBaseState::Initialize;
+ 
+     //!
+     //! \brief    surface copy pre process.
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_plus/shared/mediacopy/media_copy_xe_xpm_plus.h b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_plus/shared/mediacopy/media_copy_xe_xpm_plus.h
+index 99f7bfe525..e24f42963f 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_plus/shared/mediacopy/media_copy_xe_xpm_plus.h
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_plus/shared/mediacopy/media_copy_xe_xpm_plus.h
+@@ -50,6 +50,7 @@ class MediaCopyStateXe_Xpm_Plus: public MediaCopyBaseState
+     //!
+     //! \brief    init function.
+     virtual MOS_STATUS Initialize(PMOS_INTERFACE osInterface, MhwInterfaces *mhwInterfaces);
++    using MediaCopyBaseState::Initialize;
+ 
+     //!
+     //! \brief    render format support.
+diff --git a/media_driver/media_softlet/agnostic/gen12_base/codec/hal/dec/shared/hucitf/decode_huc_packet_creator_g12.h b/media_driver/media_softlet/agnostic/gen12_base/codec/hal/dec/shared/hucitf/decode_huc_packet_creator_g12.h
+index 682c9352bd..1774ff6dcf 100644
+--- a/media_driver/media_softlet/agnostic/gen12_base/codec/hal/dec/shared/hucitf/decode_huc_packet_creator_g12.h
++++ b/media_driver/media_softlet/agnostic/gen12_base/codec/hal/dec/shared/hucitf/decode_huc_packet_creator_g12.h
+@@ -48,6 +48,10 @@ class HucPacketCreatorG12 : public HucPacketCreatorBase
+         MediaPipeline       *pipeline,
+         MediaTask           *task,
+         CodechalHwInterface *hwInterface);
++        
++    using HucPacketCreatorBase::CreateHucCopyPkt;
++    using HucPacketCreatorBase::CreateProbUpdatePkt;
++    using HucPacketCreatorBase::CreateStreamOutInterface;
+     MEDIA_CLASS_DEFINE_END(decode__HucPacketCreatorG12)
+ };
+ 
+diff --git a/media_driver/media_softlet/agnostic/m12/m12_0/shared/mediacopy/media_copy_m12_0.h b/media_driver/media_softlet/agnostic/m12/m12_0/shared/mediacopy/media_copy_m12_0.h
+index 25e5972b7d..7e267011ad 100644
+--- a/media_driver/media_softlet/agnostic/m12/m12_0/shared/mediacopy/media_copy_m12_0.h
++++ b/media_driver/media_softlet/agnostic/m12/m12_0/shared/mediacopy/media_copy_m12_0.h
+@@ -51,6 +51,7 @@ class MediaCopyStateM12_0: public MediaCopyBaseState
+     //!
+     //! \brief    init function.
+     virtual MOS_STATUS Initialize(  PMOS_INTERFACE  osInterface, MhwInterfaces *mhwInterfaces);
++    using MediaCopyBaseState::Initialize;
+ 
+     //!
+     //! \brief    render format support.
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_copy_xe_lpm_plus_base.h b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_copy_xe_lpm_plus_base.h
+index 1f3c14ff44..5775a81732 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_copy_xe_lpm_plus_base.h
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_copy_xe_lpm_plus_base.h
+@@ -48,6 +48,7 @@ class MediaCopyStateXe_Lpm_Plus_Base: public MediaCopyBaseState
+     //!
+     //! \brief    init function.
+     virtual MOS_STATUS Initialize(PMOS_INTERFACE osInterface, MhwInterfacesNext *mhwInterfaces);
++    using MediaCopyBaseState::Initialize;
+ 
+     //!
+     //! \brief    render format support.
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer_queue.cpp b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer_queue.cpp
+index ccd75e3d97..5c53583b02 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer_queue.cpp
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer_queue.cpp
+@@ -154,4 +154,9 @@ MOS_STATUS BufferQueue::DestoryResource(void* resource)
+     return MOS_STATUS_SUCCESS;
+ }
+ 
++void BufferQueue::SetResourceType(ResourceType resType)
++{ 
++    m_resourceType = resType; 
++}
++
+ }
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer_queue.h b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer_queue.h
+index 6ef9424e8c..4aa0898c4d 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer_queue.h
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/encode_tracked_buffer_queue.h
+@@ -87,7 +87,7 @@ class BufferQueue
+     //!
+     bool SafeToDestory();
+ 
+-    void SetResourceType(ResourceType resType) { m_resourceType = resType; }
++    void SetResourceType(ResourceType resType);
+ 
+ protected:
+     //!
+diff --git a/media_softlet/agnostic/common/shared/media_debug_serializer.h b/media_softlet/agnostic/common/shared/media_debug_serializer.h
+index 77e5fced2d..90d64ad24f 100644
+--- a/media_softlet/agnostic/common/shared/media_debug_serializer.h
++++ b/media_softlet/agnostic/common/shared/media_debug_serializer.h
+@@ -34,6 +34,7 @@
+ #include <string>
+ #include <typeinfo>
+ #include <type_traits>
++#include <stdint.h>
+ #include "media_class_trace.h"
+ 
+ template <typename T, typename = void>
+diff --git a/media_softlet/agnostic/common/shared/scalability/media_scalability_multipipe.cpp b/media_softlet/agnostic/common/shared/scalability/media_scalability_multipipe.cpp
+index 06b107b6bb..fe08b67aeb 100644
+--- a/media_softlet/agnostic/common/shared/scalability/media_scalability_multipipe.cpp
++++ b/media_softlet/agnostic/common/shared/scalability/media_scalability_multipipe.cpp
+@@ -29,7 +29,7 @@
+ 
+ #include "media_scalability_multipipe.h"
+ 
+-MOS_STATUS MediaScalabilityMultiPipe::UpdateState()
++MOS_STATUS MediaScalabilityMultiPipe::UpdateState(void *statePars)
+ {
+     return MOS_STATUS_SUCCESS;
+ }
+diff --git a/media_softlet/agnostic/common/shared/scalability/media_scalability_multipipe.h b/media_softlet/agnostic/common/shared/scalability/media_scalability_multipipe.h
+index 9f848dcde5..81d3f334b3 100644
+--- a/media_softlet/agnostic/common/shared/scalability/media_scalability_multipipe.h
++++ b/media_softlet/agnostic/common/shared/scalability/media_scalability_multipipe.h
+@@ -50,7 +50,7 @@ class MediaScalabilityMultiPipe: public MediaScalability
+     //! \return MOS_STATUS
+     //!         MOS_STATUS_SUCCESS if success, else fail reason
+     //!
+-    virtual MOS_STATUS UpdateState();
++    virtual MOS_STATUS UpdateState(void *statePars);
+ 
+ protected:
+     inline bool IsFirstPipe() { return (m_currentPipe == 0) ? true : false; }

--- a/packages/security/nss/patches/nss-11-D174822-allow-build-with-gcc-13.patch
+++ b/packages/security/nss/patches/nss-11-D174822-allow-build-with-gcc-13.patch
@@ -1,0 +1,77 @@
+diff --git a/nss/cmd/ecperf/ecperf.c b/nss/cmd/ecperf/ecperf.c
+--- a/nss/cmd/ecperf/ecperf.c
++++ b/nss/cmd/ecperf/ecperf.c
+@@ -51,10 +51,11 @@
+     int iters = threadData->iters;
+     unsigned char sigData[256];
+     SECItem sig;
+     CK_SESSION_HANDLE session;
+     CK_RV crv;
++    void *tmp = NULL;
+ 
+     threadData->status = SECSuccess;
+     threadData->count = 0;
+ 
+     /* get our thread's session */
+@@ -66,10 +67,11 @@
+     }
+ 
+     if (threadData->isSign) {
+         sig.data = sigData;
+         sig.len = sizeof(sigData);
++        tmp = threadData->p2;
+         threadData->p2 = (void *)&sig;
+     }
+ 
+     while (iters--) {
+         threadData->status = (*op)(session, threadData->p1,
+@@ -77,27 +79,33 @@
+         if (threadData->status != SECSuccess) {
+             break;
+         }
+         threadData->count++;
+     }
++
++    if (threadData->isSign) {
++        threadData->p2 = tmp;
++    }
+     return;
+ }
+ 
+ void
+ genericThread(void *data)
+ {
+     ThreadData *threadData = (ThreadData *)data;
+     int iters = threadData->iters;
+     unsigned char sigData[256];
+     SECItem sig;
++    void *tmp = NULL;
+ 
+     threadData->status = SECSuccess;
+     threadData->count = 0;
+ 
+     if (threadData->isSign) {
+         sig.data = sigData;
+         sig.len = sizeof(sigData);
++        tmp = threadData->p2;
+         threadData->p2 = (void *)&sig;
+     }
+ 
+     while (iters--) {
+         threadData->status = (*threadData->op)(threadData->p1,
+@@ -105,10 +113,14 @@
+         if (threadData->status != SECSuccess) {
+             break;
+         }
+         threadData->count++;
+     }
++
++    if (threadData->isSign) {
++        threadData->p2 = tmp;
++    }
+     return;
+ }
+ 
+ /* Time iter repetitions of operation op. */
+ SECStatus
+

--- a/packages/wayland/waylandpp/patches/waylandpp-0001-PR71-support-build-with-gcc13.patch
+++ b/packages/wayland/waylandpp/patches/waylandpp-0001-PR71-support-build-with-gcc13.patch
@@ -1,0 +1,57 @@
+From 3c441910aa25f57df2a4db55f75f5d99cea86620 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Sun, 8 Jan 2023 18:24:53 +0000
+Subject: [PATCH] add missing <cstdint> include
+
+Upcoming `gcc-13` made `<string>` leaner and does not include `<cstdint>`
+implicitly anymore. As a result build fails without the change as:
+
+    [  2%] Building CXX object CMakeFiles/wayland-scanner++.dir/scanner/scanner.cpp.o
+    scanner/scanner.cpp:378:3: error: 'uint32_t' does not name a type
+      378 |   uint32_t width = 0;
+          |   ^~~~~~~~
+---
+ include/wayland-client.hpp | 1 +
+ scanner/scanner.cpp        | 3 +++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/include/wayland-client.hpp b/include/wayland-client.hpp
+index a3f782b..4598a0e 100644
+--- a/include/wayland-client.hpp
++++ b/include/wayland-client.hpp
+@@ -29,6 +29,7 @@
+ /** \file */
+ 
+ #include <atomic>
++#include <cstdint>
+ #include <functional>
+ #include <memory>
+ #include <string>
+diff --git a/scanner/scanner.cpp b/scanner/scanner.cpp
+index bebd71e..37cf7ff 100644
+--- a/scanner/scanner.cpp
++++ b/scanner/scanner.cpp
+@@ -23,6 +23,7 @@
+ #include <vector>
+ #include <cctype>
+ #include <cmath>
++#include <cstdint>
+ #include <stdexcept>
+ 
+ #include "pugixml.hpp"
+@@ -1106,6 +1107,7 @@ int main(int argc, char *argv[])
+   wayland_hpp << "#pragma once" << std::endl
+               << std::endl
+               << "#include <array>" << std::endl
++              << "#include <cstdint>" << std::endl
+               << "#include <functional>" << std::endl
+               << "#include <memory>" << std::endl
+               << "#include <string>" << std::endl
+@@ -1125,6 +1127,7 @@ int main(int argc, char *argv[])
+     wayland_server_hpp << "#pragma once" << std::endl
+                        << std::endl
+                        << "#include <array>" << std::endl
++                       << "#include <cstdint>" << std::endl
+                        << "#include <functional>" << std::endl
+                        << "#include <memory>" << std::endl
+                        << "#include <string>" << std::endl


### PR DESCRIPTION
Packages that need,to,be updated before this PR can be moved forward
- ~~mariadb - patch to be included in 10.11.3~~
  - ~~https://jira.mariadb.org/browse/MDEV-31057~~
  - ~~https://github.com/MariaDB/server/commit/cf4a16b5557be5fb3568c1de0d6cc0a18291afc9~~
  - These patches are included in the #7826 10.11.3 release
- media-driver - not yet incorporated
  - https://github.com/intel/media-driver/pull/1648
- nss - patch already in nss master

other minors that the plan is to go with the patch:
- https://github.com/warmcat/libwebsockets/pull/2824
- https://github.com/badaix/snapcast/pull/1124 (just waiting on a release)
- Kodi addons (all have been accepted into master)
- https://github.com/NilsBrause/waylandpp/pull/71

All gcc-13 “build error” fixes are upstream patches (or have been submitted to upstream)

Build testing with all target .img (x86_64/arm/aarch64) is working (including Wayland)
All addons build correctly (ARMv7,ARMv8.arm,ARMv8.aarch64,Generic,Generic-legacy)
- No workarounds using -Wno-error have been needed

### Reference
- #7766 includes the fix for inputstream.adaptive