### PR TITLE
Vulkan update to 1.3.249

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.248"
-PKG_SHA256="8db01a812b244e8e1073dce3d0d5ba94fc4ebb71c6c5e6640f94644aec79e510"
+PKG_VERSION="1.3.249"
+PKG_SHA256="3d957cc9d07c22b35226c931ac9253321d3b56a769794081a970ccce6b1bbed7"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.248"
-PKG_SHA256="5a5e51c568ea4344fa93c562eca730359a9562c4656dad53d2cc3f4807ec2307"
+PKG_VERSION="1.3.249"
+PKG_SHA256="dad9cda73559b277e9b188f5222bedcbf39b35a201d23a2c35dba25953511311"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.248"
-PKG_SHA256="9f06f13e588034e323df9222532b76518ace8bf5e4eb4ca9fbc6960addf03a93"
+PKG_VERSION="1.3.249"
+PKG_SHA256="08aad8545bbee2019ef8a836f66aabb94c6492ead0cbf7e931461266b1bb7030"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/blob/main/ChangeLog.adoc
- vulkan-headers: update to 1.3.249
- vulkan-loader: update to 1.3.249
- vulkan-tools: update to 1.3.249