### PR TITLE
Minor package updates

### DIFF
--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.3.1"
-PKG_SHA256="d734e4cf488be763cf123e5976f3154f0094815093eecdf71e0e9ae148431883"
+PKG_VERSION="2.3.2"
+PKG_SHA256="cd610810f30566e28fb98c36501f00446a06fa6bae3dc562c8cd3868fe1c0fc7"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/audio/fluidsynth/patches/libsndfile-use-static-libraries.patch
+++ b/packages/audio/fluidsynth/patches/libsndfile-use-static-libraries.patch
@@ -1,10 +1,10 @@
---- a/CMakeLists.txt	2021-09-12 13:53:14.192948082 +1000
-+++ b/CMakeLists.txt	2021-09-12 13:54:27.389413149 +1000
-@@ -535,6 +535,7 @@
-            LIBSNDFILE_STATIC_LDFLAGS MATCHES "vorbis" OR
-            LIBSNDFILE_STATIC_LDFLAGS_OTHER MATCHES "vorbis" )
-         set ( LIBSNDFILE_HASVORBIS 1 )
-+        set ( LIBSNDFILE_LIBRARIES ${LIBSNDFILE_STATIC_LIBRARIES} )
-     else ()
-         message ( NOTICE "Seems like libsndfile was compiled without OGG/Vorbis support." )
-     endif ()
+--- a/CMakeLists.txt	2023-04-02 15:54:17.000000000 +0000
++++ b/CMakeLists.txt	2023-04-14 15:18:28.037536898 +0000
+@@ -539,6 +539,7 @@
+         list( APPEND PC_REQUIRES_PRIV "sndfile")
+         if ( SndFile_WITH_EXTERNAL_LIBS )
+             set ( LIBSNDFILE_HASVORBIS 1 )
++            set ( LIBSNDFILE_LIBRARIES ${LIBSNDFILE_STATIC_LIBRARIES} )
+         else (SndFile_WITH_EXTERNAL_LIBS)
+             message ( NOTICE "Seems like libsndfile was compiled without OGG/Vorbis support." )
+         endif (SndFile_WITH_EXTERNAL_LIBS)

--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.6.9"
-PKG_SHA256="479e975abb7dc0fa9cad41bdd31f255d78d43e0726546208058d3c3fcf7b6e5a"
+PKG_VERSION="0.6.10"
+PKG_SHA256="c25be8dc0dac23cec025487e58f195e4d14f7d94aeddd5fe46b21c04f1ce2774"
 PKG_LICENSE="BSD"
 PKG_SITE="https://lib.openmpt.org/libopenmpt/"
 PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/audio/openal-soft/package.mk
+++ b/packages/audio/openal-soft/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openal-soft"
-PKG_VERSION="1.23.0"
-PKG_SHA256="af2abf9cb539c9d66296a83ba63a75eb5868658d0f0b28b27c556f45e70c5231"
+PKG_VERSION="1.23.1"
+PKG_SHA256="dfddf3a1f61059853c625b7bb03de8433b455f2f79f89548cbcbd5edca3d4a4a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openal.org/"
 PKG_URL="https://github.com/kcat/openal-soft/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="boost"
-PKG_VERSION="1.81.0"
-PKG_SHA256="71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa"
+PKG_VERSION="1.82.0"
+PKG_SHA256="a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.boost.org/"
 PKG_URL="https://boostorg.jfrog.io/artifactory/main/release/${PKG_VERSION}/source/${PKG_NAME}_${PKG_VERSION//./_}.tar.bz2"

--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.76.1"
-PKG_SHA256="43dc0f6a126958f5b454136c4398eab420249c16171a769784486e25f2fda19f"
+PKG_VERSION="2.76.2"
+PKG_SHA256="24f3847857b1d8674cdb0389a36edec0f13c666cd3ce727ecd340eb9da8aca9e"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/mimalloc/package.mk
+++ b/packages/devel/mimalloc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mimalloc"
-PKG_VERSION="2.1.1"
-PKG_SHA256="38b9660d0d1b8a732160191609b64057d8ccc3811ab18b7607bc93ca63a6010f"
+PKG_VERSION="2.1.2"
+PKG_SHA256="2b1bff6f717f9725c70bf8d79e4786da13de8a270059e4ba0bdd262ae7be46eb"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/microsoft/mimalloc"
 PKG_URL="https://github.com/microsoft/mimalloc/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="7.1.0"
-PKG_SHA256="f135a61cd464c9ed6bc9823764c188f276c3850a8dc904628de2a87966b7077b"
+PKG_VERSION="7.2.0"
+PKG_SHA256="fc5560c807eae0efd5f95b5aa4c65800c7a8eed6642008a6b1e7e3ffff7873cc"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.15.1"
-PKG_SHA256="28d5a376fe7954d2d03453f983aaa0b7486f475c27c7806bda31df9102325556"
+PKG_VERSION="1.15.2"
+PKG_SHA256="7a4c6077f45180926583e2087571371bdd9cb21b6e6fada85a6fbd544f26a0e2"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.6.2"
-PKG_SHA256="42d561a9af150b21bc914e3b7aa09f88013d2ffa6d5ce75a025a3b34caa948d4"
+PKG_VERSION="2.6.3"
+PKG_SHA256="13b207a376d8880507c74ff78aabc3778a9da47c89f1e247dcee3c7237138ff6"
 PKG_LICENSE="GPL"
 PKG_SITE="https://openvpn.net"
 PKG_URL="https://swupdate.openvpn.org/community/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/system/simplejson/package.mk
+++ b/packages/python/system/simplejson/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="simplejson"
-PKG_VERSION="3.18.4"
-PKG_SHA256="6197cfebe659ac802a686b5408494115a7062b45cdf37679c4d6a9d4f39649b7"
+PKG_VERSION="3.19.1"
+PKG_SHA256="6277f60848a7d8319d27d2be767a7546bc965535b28070e310b3a9af90604a4c"
 PKG_LICENSE="OSS"
 PKG_SITE="http://pypi.org/project/simplejson"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpg-error"
-PKG_VERSION="1.46"
-PKG_SHA256="b7e11a64246bbe5ef37748de43b245abd72cfcd53c9ae5e7fc5ca59f1c81268d"
+PKG_VERSION="1.47"
+PKG_SHA256="9e3c670966b96ecc746c28c2c419541e3bcb787d1a73930f5e5f5e1bcbbb9bdb"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.gnupg.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libgpg-error/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/sysutils/parted/package.mk
+++ b/packages/sysutils/parted/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="parted"
-PKG_VERSION="3.5"
-PKG_SHA256="4938dd5c1c125f6c78b1f4b3e297526f18ee74aa43d45c248578b1d2470c05a2"
+PKG_VERSION="3.6"
+PKG_SHA256="3b43dbe33cca0f9a18601ebab56b7852b128ec1a3df3a9b30ccde5e73359e612"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/parted/"
 PKG_URL="http://ftpmirror.gnu.org/parted/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.10.3"
-PKG_SHA256="302bbb86400b8505bebfbf7b3d1986e9aa05073198979f258eed4be481ff5f83"
+PKG_VERSION="2.10.4"
+PKG_SHA256="7465aa31a44fd93bc79ede260ee9f0e19623f4630eaa90b93977c80daa6300bf"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- boost: update to 1.82.0
- fluidsynth: update to 2.3.2
- glib: update to 2.76.2
- harfbuzz: update to 7.2.0
- libgpg-error: update to 1.47
- libheif: update to 1.15.2
- libopenmpt: update to 0.6.10
- libxml2: update to 2.10.4
- mimalloc: update to 2.1.2
- openal-soft: update to 1.23.1
- openvpn: update to 2.6.3
- parted: update to 3.6
- simplejson: update to 3.19.1