### PR TITLE
nvidia: update to 525.116.03 fixes wayland build with kernel 6.3

### DIFF
--- a/packages/graphics/nvidia/package.mk
+++ b/packages/graphics/nvidia/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia"
-PKG_VERSION="520.56.06"
-PKG_SHA256="e46ae5f497bd75370c8dea19cf3766d1bf4ae62e6343bc3c31b9a6d523f21eb3"
+PKG_VERSION="525.116.03"
+PKG_SHA256="47d32cabbc01af0f4d64e9cb45e9a451f3401b475ea155dfb7f840cba97b99e8"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="https://www.nvidia.com/en-us/drivers/unix/"
@@ -59,8 +59,8 @@ makeinstall_target() {
 
   # Wayland
   mkdir -p ${INSTALL}/usr/lib
-    cp -p libnvidia-egl-wayland.so.1.1.9  ${INSTALL}/usr/lib/
-    ln -sf libnvidia-egl-wayland.so.1.1.9 ${INSTALL}/usr/lib/libnvidia-egl-wayland.so.1
+    cp -p libnvidia-egl-wayland.so.1.1.10  ${INSTALL}/usr/lib/
+    ln -sf libnvidia-egl-wayland.so.1.1.10 ${INSTALL}/usr/lib/libnvidia-egl-wayland.so.1
     ln -sf libnvidia-egl-wayland.so.1     ${INSTALL}/usr/lib/libnvidia-egl-wayland.so
 
   mkdir -p ${INSTALL}/usr/share/egl/egl_external_platform.d


### PR DESCRIPTION
Wayland version 520.56.06 of nvidia fails to compile - due to changes in kernel apis in 6.2/6.3.
Update to latest stable nvidia driver. 
- https://www.nvidia.com/Download/driverResults.aspx/204639/en-us/