### PR TITLE
libheif: update to 1.16.1

### DIFF
--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.15.2"
-PKG_SHA256="7a4c6077f45180926583e2087571371bdd9cb21b6e6fada85a6fbd544f26a0e2"
+PKG_VERSION="1.16.1"
+PKG_SHA256="ac15b54b6d7c315710e156d119b8a1bfc89f29621e99222b2750b1f31c9c3558"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
release notes:
- https://github.com/strukturag/libheif/releases