### PR TITLE
[le12] network-tools: update addon (2) 

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libpcap"
-PKG_VERSION="1.10.3"
-PKG_SHA256="2a8885c403516cf7b0933ed4b14d6caa30e02052489ebd414dc75ac52e7559e6"
+PKG_VERSION="1.10.4"
+PKG_SHA256="ed19a0383fad72e3ad435fd239d7cd80d64916b87269550159d20e47160ebe5f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.tcpdump.org/"
 PKG_URL="https://www.tcpdump.org/release/libpcap-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/network-tools-depends/iperf/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/iperf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iperf"
-PKG_VERSION="3.13"
-PKG_SHA256="a49d23fe0d3b1482047ad7f3b9e384c69657a63b486c4e3f0ce512a077d94434"
+PKG_VERSION="3.13-mt1"
+PKG_SHA256="093e48e14fdbde0761c31c5899a81b36b11078b17411bb8b3723c1e32285d404"
 PKG_LICENSE="BSD"
 PKG_SITE="http://software.es.net/iperf/"
 PKG_URL="https://github.com/esnet/iperf/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/network-tools-depends/irssi/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/irssi/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="irssi"
-PKG_VERSION="1.4.3"
-PKG_SHA256="b93f715223a322e67f42b61a08a512ae29e34bd4a53d7f223766660aaa5a0434"
+PKG_VERSION="1.4.4"
+PKG_SHA256="fefe9ec8c7b1475449945c934a2360ab12693454892be47a6d288c63eb107ead"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.irssi.org/"
 PKG_URL="https://github.com/irssi/irssi/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tcpdump"
-PKG_VERSION="4.99.3"
-PKG_SHA256="ad75a6ed3dc0d9732945b2e5483cb41dc8b4b528a169315e499c6861952e73b3"
+PKG_VERSION="4.99.4"
+PKG_SHA256="0232231bb2f29d6bf2426e70a08a7e0c63a0d59a9b44863b7f5e2357a6e49fea"
 PKG_SITE="https://www.tcpdump.org/"
 PKG_URL="https://www.tcpdump.org/release/tcpdump-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libpcap libtirpc"

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- iperf: update to 3.13-mt1
- irssi: update to 1.4.4
- libpcap: update to 1.10.4
- tcpdump: update to 4.99.