### PR TITLE
X11 updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.47.1"
-PKG_SHA256="c6ba7c160434edebf09d2936933569c936f6ec972301766f2bdac5a4d418153c"
+PKG_VERSION="2.48.0"
+PKG_SHA256="905a5b6f1790b68ee803bffa9f5fab4ceb591fb4fae0b2f8c612c54f1d4e8a30"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.gnome.org/"
 PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/libXft/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/libXft/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXft"
-PKG_VERSION="2.3.7"
-PKG_SHA256="79f0b37c45007381c371a790c2754644ad955166dbf2a48e3625032e9bdd4f71"
+PKG_VERSION="2.3.8"
+PKG_SHA256="5e8c3c4bc2d4c0a40aef6b4b38ed2fb74301640da29f6528154b5009b1c6dd49"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXft-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXi/package.mk
+++ b/packages/x11/lib/libXi/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXi"
-PKG_VERSION="1.8"
-PKG_SHA256="2ed181446a61c7337576467870bc5336fc9e222a281122d96c4d39a3298bba00"
+PKG_VERSION="1.8.1"
+PKG_SHA256="89bfc0e814f288f784202e6e5f9b362b788ccecdeb078670145eacd8749656a7"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.x.org/"
-PKG_URL="https://www.x.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.x.org/"
+PKG_URL="https://www.x.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11 libXfixes libXext"
 PKG_LONGDESC="LibXi provides an X Window System client interface to the XINPUT extension to the X protocol."
 PKG_BUILD_FLAGS="+pic"


### PR DESCRIPTION
- at-spi2-core: update to 2.48.0
- libXft: update to 2.3.8
- libXi: update to 1.8.1