### PR TITLE
[le12] mariadb: update to 10.11.3 and addon (2)

### DIFF
--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="10.11.2"
-PKG_REV="1"
-PKG_SHA256="1c89dee0caed0f68bc2a1d203eb98a123150e6a179f6ee0f1fc0ba3f08dc71dc"
+PKG_VERSION="10.11.3"
+PKG_REV="2"
+PKG_SHA256="b065b0f32a6e9fd479e566fd6671450379886d8dda2d9a7ef930af1e5c26c0c7"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://downloads.mariadb.com/MariaDB/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/mariadb/patches/mariadb-0001-disable-plugin-auth-pam.patch
+++ b/packages/addons/service/mariadb/patches/mariadb-0001-disable-plugin-auth-pam.patch
@@ -11,7 +11,7 @@ diff --git a/cmake/build_configurations/mysql_release.cmake b/cmake/build_config
 index 37a6c45..e2a4ba8 100644
 --- a/cmake/build_configurations/mysql_release.cmake
 +++ b/cmake/build_configurations/mysql_release.cmake
-@@ -124,7 +124,7 @@ ENDIF()
+@@ -147,7 +147,7 @@ ENDIF()
  
  IF(UNIX)
    SET(WITH_EXTRA_CHARSETS all CACHE STRING "")
@@ -19,7 +19,7 @@ index 37a6c45..e2a4ba8 100644
 +  SET(PLUGIN_AUTH_PAM NO CACHE BOOL "")
  
    IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-     IF(NOT IGNORE_AIO_CHECK)
+     FIND_PACKAGE(URING)
 -- 
 2.7.4
 


### PR DESCRIPTION
release notes:
- https://mariadb.com/kb/en/mariadb-10-11-3-release-notes/
- The update supports gcc-13.1.0