### PR TITLE
mesa: update to 23.1.0

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -48,6 +48,10 @@ else
                            -Dglx=disabled"
 fi
 
+if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
+  PKG_MESON_OPTS_TARGET+=" -Dintel-xe-kmd=enabled"
+fi
+
 if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)"; then
   PKG_DEPENDS_TARGET+=" libglvnd"
   PKG_MESON_OPTS_TARGET+=" -Dglvnd=true"

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="23.0.3"
-PKG_SHA256="386362a5d80df3b096636b67f340e1ce67b705b44767d5bdd11d2ed1037192d5"
+PKG_VERSION="23.1.0"
+PKG_SHA256="a9dde3c76571c4806245a05bda1cceee347c3267127e9e549e4f4e225d92e992"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
@@ -13,8 +13,7 @@ PKG_LONGDESC="Mesa is a 3-D graphics library with an API."
 
 get_graphicdrivers
 
-PKG_MESON_OPTS_TARGET="-Ddri-drivers= \
-                       -Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
+PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
                        -Dgallium-omx=disabled \
                        -Dgallium-nine=false \


### PR DESCRIPTION
- mesa: enable intel-xe-kmd
- mesa: update to 23.1.0
- https://lists.freedesktop.org/archives/mesa-announce/2023-May/000720.html

```
=== tested on ===
Generic.x86_64-devel-20230511092738-b73f370
Linux nuc12 6.1.28-rc2 #1 SMP Thu May 11 08:37:42 UTC 2023 x86_64 GNU/Linux
Starting Kodi (21.0-ALPHA1 (20.90.101) Git:1a04aa12cb4e5457867451f41ab4dcdcd201b1a9). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2023-05-10 by GCC 13.1.0 for Linux x86 64-bit version 6.3.2 (393986)
Running on LibreELEC (heitbaum): devel-20230511092738-b73f370 12.0, kernel: Linux x86 64-bit version 6.1.28-rc2
FFmpeg version/source: 6.0
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0085.2022.0718.1739 07/18/2022
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.1.0
libva info: VA-API version 1.18.0
vainfo: VA-API version: 1.18 (libva 2.18.2)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.2.1 (5f0982d116)
```