### PR TITLE
samba: update to 4.17.8

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.7"
-PKG_SHA256="95c9c16b654a88cfaefd958052dd573e2f85ecdf114e4ecec3187537a094d919"
+PKG_VERSION="4.17.8"
+PKG_SHA256="712e537e1b09b739b6a607e0942503af92a3b2e244484b61264eb091efdfaad7"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
ann:
- https://lists.samba.org/archive/samba-announce/2023/000635.html

backport of:
- #7830 