### PR TITLE
[le11] wireless-regdb: update to 2023.05.03

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2023.02.13"
-PKG_SHA256="fe81e8a8694dc4753a45087a1c4c7e1b48dee5a59f5f796ce374ea550f0b2e73"
+PKG_VERSION="2023.05.03"
+PKG_SHA256="f254d08ab3765aeae2b856222e11a95d44aef519a6663877c71ef68fae4c8c12"
 PKG_LICENSE="GPL"
 PKG_SITE="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
log:
- https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git

backport of 
- #7839