### PR TITLE
kodi: update drmprime-filter patches

### DIFF
--- a/packages/mediacenter/kodi/patches/drmprime-filter/0001-WIP-DVDVideoCodecDRMPRIME-add-support-for-filters.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0001-WIP-DVDVideoCodecDRMPRIME-add-support-for-filters.patch
@@ -1,7 +1,7 @@
-From 3f4e5cd94c1ad7e9361f68f04dba23aec06e0e49 Mon Sep 17 00:00:00 2001
+From 34badba6d106467d63ee2578662fd5f30276736c Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 20 Oct 2019 17:10:07 +0000
-Subject: [PATCH 1/6] WIP: DVDVideoCodecDRMPRIME: add support for filters
+Subject: [PATCH 1/7] WIP: DVDVideoCodecDRMPRIME: add support for filters
 
 ---
  .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 62 +++++++++++++++++--
@@ -9,10 +9,10 @@ Subject: [PATCH 1/6] WIP: DVDVideoCodecDRMPRIME: add support for filters
  2 files changed, 66 insertions(+), 6 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 80ca60290c..40cde1ba6e 100644
+index ab65c4ecd4..4cf36f83e6 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -27,6 +27,8 @@
+@@ -28,6 +28,8 @@
  extern "C"
  {
  #include <libavcodec/avcodec.h>
@@ -21,7 +21,7 @@ index 80ca60290c..40cde1ba6e 100644
  #include <libavutil/error.h>
  #include <libavutil/imgutils.h>
  #include <libavutil/opt.h>
-@@ -559,12 +561,30 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+@@ -595,12 +597,30 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
    pVideoPicture->dts = DVD_NOPTS_VALUE;
  }
  
@@ -56,7 +56,7 @@ index 80ca60290c..40cde1ba6e 100644
    if (ret == AVERROR(EAGAIN))
      return VC_BUFFER;
    else if (ret == AVERROR_EOF)
-@@ -581,11 +601,41 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
+@@ -617,11 +637,41 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
    {
      char err[AV_ERROR_MAX_STRING_SIZE] = {};
      av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
@@ -135,5 +135,5 @@ index db49d165e7..b5cacf1a3c 100644
    std::shared_ptr<IVideoBufferPool> m_videoBufferPool;
  };
 -- 
-2.34.1
+2.39.2
 

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0002-WIP-DRMPRIME-deinterlace-filter.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0002-WIP-DRMPRIME-deinterlace-filter.patch
@@ -1,7 +1,7 @@
-From a2f57bbd2c63fc0cf89304805e93f3b57ce55b58 Mon Sep 17 00:00:00 2001
+From ffdfcc832f82521c328e02912d707aa3b2b7ed20 Mon Sep 17 00:00:00 2001
 From: Jernej Skrabec <jernej.skrabec@siol.net>
 Date: Thu, 26 Dec 2019 11:01:51 +0100
-Subject: [PATCH 2/6] WIP: DRMPRIME deinterlace filter
+Subject: [PATCH 2/7] WIP: DRMPRIME deinterlace filter
 
 ---
  .../DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 379 +++++++++++++++---
@@ -9,18 +9,18 @@ Subject: [PATCH 2/6] WIP: DRMPRIME deinterlace filter
  2 files changed, 328 insertions(+), 60 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 40cde1ba6e..1843e72e55 100644
+index 4cf36f83e6..0d32d65ce4 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -19,6 +19,7 @@
- #include "threads/SingleLock.h"
+@@ -20,6 +20,7 @@
  #include "utils/CPUInfo.h"
+ #include "utils/StringUtils.h"
  #include "utils/log.h"
 +#include "utils/StringUtils.h"
  
  #if defined(HAVE_GBM)
  #include "windowing/gbm/WinSystemGbm.h"
-@@ -79,12 +80,15 @@ CDVDVideoCodecDRMPRIME::CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo)
+@@ -92,12 +93,15 @@ CDVDVideoCodecDRMPRIME::CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo)
    : CDVDVideoCodec(processInfo)
  {
    m_pFrame = av_frame_alloc();
@@ -36,7 +36,7 @@ index 40cde1ba6e..1843e72e55 100644
    avcodec_free_context(&m_pCodecContext);
  }
  
-@@ -341,8 +345,19 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
+@@ -376,8 +380,19 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
    }
  
    UpdateProcessInfo(m_pCodecContext, m_pCodecContext->pix_fmt);
@@ -57,7 +57,7 @@ index 40cde1ba6e..1843e72e55 100644
  
    return true;
  }
-@@ -418,6 +433,8 @@ void CDVDVideoCodecDRMPRIME::Reset()
+@@ -453,6 +468,8 @@ void CDVDVideoCodecDRMPRIME::Reset()
      return;
  
    Drain();
@@ -66,7 +66,7 @@ index 40cde1ba6e..1843e72e55 100644
  
    do
    {
-@@ -465,7 +482,7 @@ void CDVDVideoCodecDRMPRIME::Drain()
+@@ -500,7 +517,7 @@ void CDVDVideoCodecDRMPRIME::Drain()
    av_packet_free(&avpkt);
  }
  
@@ -75,7 +75,7 @@ index 40cde1ba6e..1843e72e55 100644
  {
    pVideoPicture->iWidth = m_pFrame->width;
    pVideoPicture->iHeight = m_pFrame->height;
-@@ -559,13 +576,238 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+@@ -595,13 +612,238 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
                             ? DVD_NOPTS_VALUE
                             : static_cast<double>(pts) * DVD_TIME_BASE / AV_TIME_BASE;
    pVideoPicture->dts = DVD_NOPTS_VALUE;
@@ -119,7 +119,9 @@ index 40cde1ba6e..1843e72e55 100644
  
 -CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
 +void CDVDVideoCodecDRMPRIME::FilterTest()
-+{
+ {
+-  if (!m_pFilterIn)
+-    return VC_PICTURE;
 +  const AVFilter* filter;
 +  void* opaque{};
 +
@@ -134,7 +136,7 @@ index 40cde1ba6e..1843e72e55 100644
 +      if (FilterOpen(name, true))
 +      {
 +        m_deintFilterName = name;
-+
+ 
 +        CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - found deinterlacing filter {}",
 +                  __FUNCTION__, name);
 +
@@ -298,9 +300,7 @@ index 40cde1ba6e..1843e72e55 100644
 +}
 +
 +void CDVDVideoCodecDRMPRIME::FilterClose()
- {
--  if (!m_pFilterIn)
--    return VC_PICTURE;
++{
 +  if (m_pFilterGraph)
 +  {
 +    CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecDRMPRIME::FilterClose - Freeing filter graph");
@@ -311,13 +311,13 @@ index 40cde1ba6e..1843e72e55 100644
 +    m_pFilterOut = nullptr;
 +  }
 +}
- 
++
 +CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
 +{
    int ret = av_buffersrc_add_frame(m_pFilterIn, m_pFrame);
    if (ret < 0)
    {
-@@ -581,21 +823,14 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
+@@ -617,21 +859,14 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterIn()
  
  CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterOut()
  {
@@ -343,7 +343,7 @@ index 40cde1ba6e..1843e72e55 100644
    }
    else if (ret)
    {
-@@ -606,71 +841,97 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterOut()
+@@ -642,71 +877,97 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::ProcessFilterOut()
      return VC_ERROR;
    }
  
@@ -517,5 +517,5 @@ index b5cacf1a3c..fab3431d40 100644
    AVFilterContext* m_pFilterIn = nullptr;
    AVFilterContext* m_pFilterOut = nullptr;
 -- 
-2.34.1
+2.39.2
 

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0003-DVDVideoCodecDRMPRIME-Avoid-exception-with-AV_PIX_FM.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0003-DVDVideoCodecDRMPRIME-Avoid-exception-with-AV_PIX_FM.patch
@@ -1,7 +1,7 @@
-From c2b50468de1a8a72a4e00e53492e4e26f2573490 Mon Sep 17 00:00:00 2001
+From 0960356b0af5c9e9e528b43e4e0134bf4c593564 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 27 Aug 2021 20:29:50 +0100
-Subject: [PATCH 3/6] DVDVideoCodecDRMPRIME: Avoid exception with
+Subject: [PATCH 3/7] DVDVideoCodecDRMPRIME: Avoid exception with
  AV_PIX_FMT_NONE
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 3/6] DVDVideoCodecDRMPRIME: Avoid exception with
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 1843e72e55..709311e75f 100644
+index 0d32d65ce4..3b0341a240 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -606,7 +606,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+@@ -642,7 +642,7 @@ bool CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
    if (!pVideoPicture->videoBuffer)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - videoBuffer:nullptr format:{}", __FUNCTION__,
@@ -22,5 +22,5 @@ index 1843e72e55..709311e75f 100644
      return false;
    }
 -- 
-2.34.1
+2.39.2
 

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0004-DVDVideoCodecDRMPRIME-Leave-deinterlace-filter-activ.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0004-DVDVideoCodecDRMPRIME-Leave-deinterlace-filter-activ.patch
@@ -1,7 +1,7 @@
-From 66833bc8221a9d5a5fbc625c3f0293a261bbd412 Mon Sep 17 00:00:00 2001
+From 8c70d13055955f129371fe99da9e0a0364e27854 Mon Sep 17 00:00:00 2001
 From: popcornmix <popcornmix@gmail.com>
 Date: Fri, 17 Sep 2021 15:23:16 +0100
-Subject: [PATCH 4/6] DVDVideoCodecDRMPRIME: Leave deinterlace filter active on
+Subject: [PATCH 4/7] DVDVideoCodecDRMPRIME: Leave deinterlace filter active on
  a progressive frame
 
 Interlaced content often has strange mixtures of interlace and progressive frames (e.g. IIPPPPIIPPPP)
@@ -14,10 +14,10 @@ be just copied by deinterlace filter
  1 file changed, 4 insertions(+)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 709311e75f..6ba0804904 100644
+index 3b0341a240..c214424ad1 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -856,6 +856,10 @@ std::string CDVDVideoCodecDRMPRIME::GetFilterChain(bool interlaced)
+@@ -892,6 +892,10 @@ std::string CDVDVideoCodecDRMPRIME::GetFilterChain(bool interlaced)
    if (!m_processInfo.Supports(mInt))
      mInt = m_processInfo.GetFallbackDeintMethod();
  
@@ -29,5 +29,5 @@ index 709311e75f..6ba0804904 100644
      filterChain += m_deintFilterName;
  
 -- 
-2.34.1
+2.39.2
 

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0005-SetVideoInterlaced-Set-and-unset-deinterlace-method-.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0005-SetVideoInterlaced-Set-and-unset-deinterlace-method-.patch
@@ -1,7 +1,7 @@
-From 6d40c431345c8bac66fb1a3bb06e29a0f944ac3d Mon Sep 17 00:00:00 2001
+From 540db79c945d141c64fae6b143374b08881181f5 Mon Sep 17 00:00:00 2001
 From: Dom Cobley <popcornmix@gmail.com>
 Date: Tue, 30 Nov 2021 16:05:06 +0000
-Subject: [PATCH 5/6] SetVideoInterlaced: Set and unset deinterlace method name
+Subject: [PATCH 5/7] SetVideoInterlaced: Set and unset deinterlace method name
  reported
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 5/6] SetVideoInterlaced: Set and unset deinterlace method name
  1 file changed, 2 insertions(+), 8 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 6ba0804904..9139233bc4 100644
+index c214424ad1..1be249cc89 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -770,14 +770,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -806,14 +806,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      return true;
    }
  
@@ -28,7 +28,7 @@ index 6ba0804904..9139233bc4 100644
  
    if (CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
    {
-@@ -795,6 +788,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -831,6 +824,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
  
  void CDVDVideoCodecDRMPRIME::FilterClose()
  {
@@ -37,5 +37,5 @@ index 6ba0804904..9139233bc4 100644
    {
      CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecDRMPRIME::FilterClose - Freeing filter graph");
 -- 
-2.34.1
+2.39.2
 

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0006-DVDVideoCodecDRMPRIME-Close-deinterlace-filter-on-er.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0006-DVDVideoCodecDRMPRIME-Close-deinterlace-filter-on-er.patch
@@ -1,7 +1,7 @@
-From e014499333c6ca6ef4dca3a15b8c81ec07d80c12 Mon Sep 17 00:00:00 2001
+From 695e383329041054ea1a01731e691fb254cd2469 Mon Sep 17 00:00:00 2001
 From: Dom Cobley <popcornmix@gmail.com>
 Date: Wed, 24 Nov 2021 20:21:28 +0000
-Subject: [PATCH 6/6] DVDVideoCodecDRMPRIME: Close deinterlace filter on error
+Subject: [PATCH 6/7] DVDVideoCodecDRMPRIME: Close deinterlace filter on error
 
 Otherwise we crash later with an invalid m_pFilterGraph pointer
 ---
@@ -9,10 +9,10 @@ Otherwise we crash later with an invalid m_pFilterGraph pointer
  1 file changed, 7 insertions(+)
 
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-index 9139233bc4..0b44d90f13 100644
+index 1be249cc89..b221cdaf75 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
-@@ -686,6 +686,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -722,6 +722,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: src: {} ({})",
                err, result);
@@ -20,7 +20,7 @@ index 9139233bc4..0b44d90f13 100644
      return false;
    }
  
-@@ -693,6 +694,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -729,6 +730,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (!par)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - unable to alloc buffersrc");
@@ -28,7 +28,7 @@ index 9139233bc4..0b44d90f13 100644
      return false;
    }
  
-@@ -708,6 +710,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -744,6 +746,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - av_buffersrc_parameters_set:  {} ({})",
                err, result);
@@ -36,7 +36,7 @@ index 9139233bc4..0b44d90f13 100644
      return false;
    }
    av_freep(&par);
-@@ -721,6 +724,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -757,6 +760,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      CLog::Log(LOGERROR,
                "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_create_filter: out: {} ({})",
                err, result);
@@ -44,7 +44,7 @@ index 9139233bc4..0b44d90f13 100644
      return false;
    }
  
-@@ -729,6 +733,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -765,6 +769,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (result < 0)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - failed settings pix formats");
@@ -52,7 +52,7 @@ index 9139233bc4..0b44d90f13 100644
      return false;
    }
  
-@@ -752,6 +757,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -788,6 +793,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
    if (result < 0)
    {
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_parse");
@@ -60,7 +60,7 @@ index 9139233bc4..0b44d90f13 100644
      return false;
    }
  
-@@ -761,6 +767,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
+@@ -797,6 +803,7 @@ bool CDVDVideoCodecDRMPRIME::FilterOpen(const std::string& filters, bool test)
      av_strerror(result, err, AV_ERROR_MAX_STRING_SIZE);
      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::FilterOpen - avfilter_graph_config:  {} ({})",
                err, result);
@@ -69,5 +69,5 @@ index 9139233bc4..0b44d90f13 100644
    }
  
 -- 
-2.34.1
+2.39.2
 

--- a/packages/mediacenter/kodi/patches/drmprime-filter/0007-DVDVideoCodecDRMPRIME-Fix-missing-flush-after-eof.patch
+++ b/packages/mediacenter/kodi/patches/drmprime-filter/0007-DVDVideoCodecDRMPRIME-Fix-missing-flush-after-eof.patch
@@ -1,0 +1,32 @@
+From dab227de4e1fbd6d1197b7c6532ae4d3e3ff9e81 Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Mon, 15 May 2023 12:50:16 +0100
+Subject: [PATCH 7/7] DVDVideoCodecDRMPRIME: Fix missing flush after eof
+
+---
+ .../VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+index b221cdaf75..a591a90885 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+@@ -927,7 +927,15 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
+   if (ret == AVERROR(EAGAIN))
+     return VC_BUFFER;
+   else if (ret == AVERROR_EOF)
++  {
++    if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
++    {
++      CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - flush buffers", __FUNCTION__);
++      avcodec_flush_buffers(m_pCodecContext);
++      SetCodecControl(m_codecControlFlags & ~DVD_CODEC_CTRL_DRAIN);
++    }
+     return VC_EOF;
++  }
+   else if (ret)
+   {
+     char err[AV_ERROR_MAX_STRING_SIZE] = {};
+-- 
+2.39.2
+


### PR DESCRIPTION
This should fix the "no video on live TV" issue reported here
https://github.com/xbmc/xbmc/issues/23222
https://forum.libreelec.tv/thread/27018-tvh-live-streaming-buggy/?postID=180416#post180416
