### PR TITLE
Minor package updates

### DIFF
--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.7.0"
-PKG_SHA256="411796b55aef73cab09c7a6e65d33f1d7bf4ee7fc2dade6bc8de5138dedcc6d1"
+PKG_VERSION="0.7.1"
+PKG_SHA256="bf175d26448bb133f74714f3a8859e7000b93522fb3577559dffc037161910f9"
 PKG_LICENSE="BSD"
 PKG_SITE="https://lib.openmpt.org/libopenmpt/"
 PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.70"
-PKG_SHA256="e9a86d592dea6ee28c67b82c17bd6ba10afd1c880decfcf4b3e7c5421f146d38"
+PKG_VERSION="0.3.71"
+PKG_SHA256="070dcf83c514903d603351921c7829014c8d9162c49ae5a043290c920f6a6363"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/debug/strace/package.mk
+++ b/packages/debug/strace/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="strace"
-PKG_VERSION="6.2"
-PKG_SHA256="0c7d38a449416268d3004029a220a15a77c2206a03cc88120f37f46e949177e8"
+PKG_VERSION="6.3"
+PKG_SHA256="e17878e301506c1cc301611118ad14efee7f8bcef63b27ace5d290acce7bb731"
 PKG_LICENSE="BSD"
 PKG_SITE="https://strace.io/"
 PKG_URL="https://strace.io/files/${PKG_VERSION}/strace-${PKG_VERSION}.tar.xz"

--- a/packages/debug/strace/patches/strace-0003-fix-build-with-linux6-3-2.patch
+++ b/packages/debug/strace/patches/strace-0003-fix-build-with-linux6-3-2.patch
@@ -1,0 +1,29 @@
+From 8f691206e4aa769cc99e264f1c15ae6956789f91 Mon Sep 17 00:00:00 2001
+From: "Dmitry V. Levin" <ldv@strace.io>
+Date: Mon, 15 May 2023 08:00:00 +0000
+Subject: [PATCH] configure: do not take the SUBLEVEL part of the kernel
+ version into account
+
+* configure.ac: When deciding whether to use bundled version of kernel
+headers, ignore the SUBLEVEL part of the kernel version, assuming that
+any potential changes in UAPI introduced in stable kernels are not
+important.
+
+Resolves: https://github.com/strace/strace/issues/253
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index efd0632e80..f12ad7a725 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -278,7 +278,7 @@ AC_CACHE_CHECK(
+ 	[AS_IF([test $enable_bundled = check],
+ 	       [AC_COMPILE_IFELSE(
+ 			[AC_LANG_PROGRAM([#include <linux/version.h>
+-#define USE_OS_HEADERS (LINUX_VERSION_CODE > ]linux_version_code[ ? 1 : -1)],
++#define USE_OS_HEADERS ((LINUX_VERSION_CODE >> 8) > (]linux_version_code[ >> 8) ? 1 : -1)],
+ 					 [[int i[USE_OS_HEADERS];]]
+ 			 )
+ 			],

--- a/packages/devel/fribidi/package.mk
+++ b/packages/devel/fribidi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fribidi"
-PKG_VERSION="1.0.12"
-PKG_SHA256="0cd233f97fc8c67bb3ac27ce8440def5d3ffacf516765b91c2cc654498293495"
+PKG_VERSION="1.0.13"
+PKG_SHA256="7fa16c80c81bd622f7b198d31356da139cc318a63fc7761217af4130903f54a2"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://fribidi.freedesktop.org/"
 PKG_URL="https://github.com/fribidi/fribidi/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/libcap/package.mk
+++ b/packages/devel/libcap/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcap"
-PKG_VERSION="2.68"
-PKG_SHA256="90be3b6d41be5f81ae4b03ec76012b0d27c829293684f6c05b65d5f9cce724b2"
+PKG_VERSION="2.69"
+PKG_SHA256="f311f8f3dad84699d0566d1d6f7ec943a9298b28f714cae3c931dfd57492d7eb"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libcap/libcap.git/log/"
 PKG_URL="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="7.2.0"
-PKG_SHA256="fc5560c807eae0efd5f95b5aa4c65800c7a8eed6642008a6b1e7e3ffff7873cc"
+PKG_VERSION="7.3.0"
+PKG_SHA256="20770789749ac9ba846df33983dbda22db836c70d9f5d050cb9aa5347094a8fb"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/lang/lua54/package.mk
+++ b/packages/lang/lua54/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lua54"
-PKG_VERSION="5.4.5"
-PKG_SHA256="59df426a3d50ea535a460a452315c4c0d4e1121ba72ff0bdde58c2ef31d6f444"
+PKG_VERSION="5.4.6"
+PKG_SHA256="7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.lua.org"
 PKG_URL="http://www.lua.org/ftp/lua-${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="3.6.0"
-PKG_SHA256="a4a6c0fab685da743b796662a928fcdf7ae60594edc306efb73e78a17ea6cde6"
+PKG_VERSION="3.6.1"
+PKG_SHA256="42b862f58b3d00bd3902d2dc469526574f5b012e5b178e6a9652845a113d6887"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="https://storage.googleapis.com/aom-releases/libaom-${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="23.2.0"
-PKG_SHA256="c7f79f0534e9832d22faf0ab7efedac75fb8726698f49877ca965d8255a9c38d"
+PKG_VERSION="23.2.1"
+PKG_SHA256="3796fea4201e24310b3d100b64cfb288fb92b93ce9de54526efa43e2ea68853a"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/network/ethtool/package.mk
+++ b/packages/network/ethtool/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ethtool"
-PKG_VERSION="6.2"
-PKG_SHA256="86df0114064d4d73f6bf72bf03e85c33964a519ee0c1d1ba65005ad2d0e570e1"
+PKG_VERSION="6.3"
+PKG_SHA256="d9425f0a3df138734001fccc4175fe178c025f938460ac25c4ebc39960168822"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/pub/software/network/ethtool/"
 PKG_URL="https://www.kernel.org/pub/software/network/ethtool/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.6.3"
-PKG_SHA256="13b207a376d8880507c74ff78aabc3778a9da47c89f1e247dcee3c7237138ff6"
+PKG_VERSION="2.6.4"
+PKG_SHA256="371a2a323a99a79299b9b4caa4a31bc7b2cdff63236e68d429f3ee50e75f3dd4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://openvpn.net"
 PKG_URL="https://swupdate.openvpn.org/community/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/security/nettle/package.mk
+++ b/packages/security/nettle/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nettle"
-PKG_VERSION="3.8.1"
-PKG_SHA256="364f3e2b77cd7dcde83fd7c45219c834e54b0c75e428b6f894a23d12dd41cbfe"
+PKG_VERSION="3.9"
+PKG_SHA256="0ee7adf5a7201610bb7fe0acbb7c9b3be83be44904dd35ebbcd965cd896bfeaa"
 PKG_LICENSE="GPL2"
 PKG_SITE="http://www.lysator.liu.se/~nisse/nettle"
 PKG_URL="https://ftp.gnu.org/gnu/nettle/nettle-${PKG_VERSION}.tar.gz"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.89"
-PKG_SHA256="e40012df101331eadb87cfdb204969ab2a4b9a81735deba94fe5501aff12fd65"
+PKG_VERSION="3.89.1"
+PKG_SHA256="7381c5524afc108dfcb66c72f12e85b8885b4af5250e516df9fb0a194e5b1ea3"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"

--- a/packages/sysutils/libevdev/package.mk
+++ b/packages/sysutils/libevdev/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libevdev"
-PKG_VERSION="1.13.0"
-PKG_SHA256="9edf2006cc86a5055279647c38ec923d11a821ee4dc2c3033e8d20e8ee237cd9"
+PKG_VERSION="1.13.1"
+PKG_SHA256="06a77bf2ac5c993305882bc1641017f5bec1592d6d1b64787bad492ab34f2f36"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libevdev/"
 PKG_URL="http://www.freedesktop.org/software/libevdev/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/sysutils/pciutils/package.mk
+++ b/packages/sysutils/pciutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pciutils"
-PKG_VERSION="3.9.0"
-PKG_SHA256="cdea7ae97239dee23249a09c68a19a287a3f109fbeb2c232ebb616cb38599012"
+PKG_VERSION="3.10.0"
+PKG_SHA256="238a2e27166730e53a17fe07bfad229e07fa39b618117e5944b6d7eda9fbb0e9"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mj.ucw.cz/pciutils.shtml"
 PKG_URL="https://www.kernel.org/pub/software/utils/pciutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.11.2"
-PKG_SHA256="4da725ea3a87b49659dcd3742351319202f9f5317e45d0f3ead95f374e9a27ff"
+PKG_VERSION="2.11.3"
+PKG_SHA256="44b38be302a103c62f80e792478a505365693349a76ea6b98e9c68aab8eab9e0"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"

--- a/packages/textproc/libxslt/package.mk
+++ b/packages/textproc/libxslt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxslt"
-PKG_VERSION="1.1.37"
-PKG_SHA256="6dbeb21aa8c938e6a39010901c0e84122bb87225b4af31f76feb4e3a5b138a5c"
+PKG_VERSION="1.1.38"
+PKG_SHA256="5c7855f989cfa9ece9901a4e106d018f091b5bf742c8161f559c0b1cb561d076"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org/xslt/"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- aom: update to 3.6.1
- ethtool: update to 6.3
- harfbuzz: update to 7.3.0
- libcap: update to 2.69
- libevdev: update to 1.13.1
- fribidi: update to 1.0.13
- libopenmpt: update to 0.7.1
- libxml2: update to 2.11.3
- libxslt: update to 1.1.38
- lua54: update to 5.4.6
- media-driver: update to 23.2.1
- nettle: update to 3.9
- nss: update to 3.89.1
- openvpn: update to 2.6.4
- pciutils: update to 3.10.0
- pipewire: update to 0.3.71
- strace: update to 6.3