### PR TITLE
[le12] docker: update to 24.0.1 and addon (6) 

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="b31eb0343e8bb587e921a7630baa659896602072a77ad97720e5f2a8e48005e9"
+PKG_SHA256="f5916273959fb2df56424bb2c26d8b6feb9a148dd15eb400aedd5d3753e06959"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/docker/cli/releases
-export PKG_GIT_COMMIT="ef23cbc4315ae76c744e02d687c09548ede461bd"
+export PKG_GIT_COMMIT="680212238b47d4299b62ed55e3113a498cde3cef"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="23.0.6"
-PKG_SHA256="3bbd32f401f652cc15084d3c09bd7acd381571802beac9333fd63d803dc66c3e"
+PKG_VERSION="24.0.1"
+PKG_SHA256="cb8aa8ca7145cd8273b6eb2595ee5d7da2e97feec4b73936cb4ea8cbbe104028"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="9dbdbd4b6d7681bd18c897a6ba0376073c2a72ff"
+export PKG_GIT_COMMIT="463850e59e8af1258cad649ec6836d5e88d16fec"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/docker/moby/patches/moby-001-user-addon-storage-location.patch
+++ b/packages/addons/addon-depends/docker/moby/patches/moby-001-user-addon-storage-location.patch
@@ -6,7 +6,7 @@
 diff -Naur a/cmd/dockerd/daemon_unix.go b/cmd/dockerd/daemon_unix.go
 --- a/cmd/dockerd/daemon_unix.go	2022-06-03 10:30:24.000000000 -0700
 +++ b/cmd/dockerd/daemon_unix.go	2022-06-07 14:28:05.510327911 -0700
-@@ -25,7 +25,7 @@
+@@ -24,7 +24,7 @@
  
  func getDefaultDaemonConfigDir() (string, error) {
  	if !honorXDG {
@@ -49,7 +49,7 @@ diff -Naur a/integration/plugin/graphdriver/external_test.go b/integration/plugi
  	assert.NilError(t, err)
  }
  
-@@ -345,10 +345,10 @@
+@@ -344,10 +344,10 @@
  		respond(w, &graphDriverResponse{Size: size})
  	})
  
@@ -99,7 +99,7 @@ diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integra
 diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/docker_cli_network_unix_test.go
 --- a/integration-cli/docker_cli_network_unix_test.go	2022-06-03 10:30:24.000000000 -0700
 +++ b/integration-cli/docker_cli_network_unix_test.go	2022-06-07 14:28:05.558328640 -0700
-@@ -196,14 +196,14 @@
+@@ -195,14 +195,14 @@
  		}
  	})
  
@@ -117,7 +117,7 @@ diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/d
  	err = os.WriteFile(ipamFileName, []byte(url), 0644)
  	assert.NilError(c, err)
  }
-@@ -215,7 +215,7 @@
+@@ -214,7 +214,7 @@
  
  	s.server.Close()
  
@@ -129,7 +129,7 @@ diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/d
 diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_cli_swarm_test.go
 --- a/integration-cli/docker_cli_swarm_test.go	2022-06-03 10:30:24.000000000 -0700
 +++ b/integration-cli/docker_cli_swarm_test.go	2022-06-07 14:28:05.561328685 -0700
-@@ -770,14 +770,14 @@
+@@ -769,14 +769,14 @@
  		}
  	})
  
@@ -147,7 +147,7 @@ diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_c
  	err = os.WriteFile(ipamFileName, []byte(url), 0644)
  	assert.NilError(c, err)
  }
-@@ -789,7 +789,7 @@
+@@ -788,7 +788,7 @@
  	setupRemoteGlobalNetworkPlugin(c, mux, s.server.URL, globalNetworkPlugin, globalIPAMPlugin)
  	defer func() {
  		s.server.Close()
@@ -192,15 +192,22 @@ diff -Naur a/libnetwork/libnetwork_unix_test.go b/libnetwork/libnetwork_unix_tes
 diff -Naur a/pkg/plugins/discovery_unix.go b/pkg/plugins/discovery_unix.go
 --- a/pkg/plugins/discovery_unix.go	2022-06-03 10:30:24.000000000 -0700
 +++ b/pkg/plugins/discovery_unix.go	2022-06-07 14:28:05.615329505 -0700
-@@ -9,7 +9,7 @@
- 	"github.com/docker/docker/pkg/rootless"
- )
+@@ -15,7 +15,7 @@
+ 		return filepath.Join(configHome, "docker/plugins")
+ 	}
  
--const globalConfigPluginsPath = "/etc/docker/plugins"
-+const globalConfigPluginsPath = "/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins"
- const globalLibPluginsPath = "/usr/lib/docker/plugins"
+-	return "/etc/docker/plugins"
++	return "/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins"
+ }
  
- var globalSpecsPaths = []string{globalConfigPluginsPath, globalLibPluginsPath}
+ func rootlessLibPluginsPath() string {
+@@ -37,5 +37,5 @@
+ 		return []string{rootlessConfigPluginsPath(), rootlessLibPluginsPath()}
+ 	}
+ 
+-	return []string{"/etc/docker/plugins", "/usr/lib/docker/plugins"}
++	return []string{"/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", "/usr/lib/docker/plugins"}
+ }
 diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
 --- a/pkg/plugins/plugins.go	2022-06-03 10:30:24.000000000 -0700
 +++ b/pkg/plugins/plugins.go	2022-06-07 14:28:05.616329521 -0700

--- a/packages/addons/addon-depends/docker/moby/patches/moby-002-use-unconfined-seccomp-profile-as-default.patch
+++ b/packages/addons/addon-depends/docker/moby/patches/moby-002-use-unconfined-seccomp-profile-as-default.patch
@@ -1,6 +1,6 @@
 --- a/daemon/config/config.go	2022-06-03 10:30:24.000000000 -0700
 +++ b/daemon/config/config.go	2022-06-07 14:29:36.755713207 -0700
-@@ -59,7 +59,7 @@
+@@ -60,7 +60,7 @@
  	LinuxV2RuntimeName = "io.containerd.runc.v2"
  
  	// SeccompProfileDefault is the built-in default seccomp profile.
@@ -11,7 +11,7 @@
  	SeccompProfileUnconfined = "unconfined"
 --- a/daemon/daemon_unix.go	2022-06-03 10:30:24.000000000 -0700
 +++ b/daemon/daemon_unix.go	2022-06-07 14:34:55.315558083 -0700
-@@ -1711,8 +1711,6 @@
+@@ -1510,8 +1510,6 @@
  
  func (daemon *Daemon) setupSeccompProfile() error {
  	switch profile := daemon.configStore.SeccompProfile; profile {

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
docker: update to 24.0.1 and addon (6)
- cli: update to 24.0.1
- moby: update to 24.0.1

release notes:
- https://github.com/moby/moby/releases/tag/v24.0.0
- https://github.com/moby/moby/releases/tag/v24.0.1