### PR TITLE
development package updates

### DIFF
--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccache"
-PKG_VERSION="4.8"
-PKG_SHA256="b963ee3bf88d7266b8a0565e4ba685d5666357f0a7e364ed98adb0dc1191fcbb"
+PKG_VERSION="4.8.1"
+PKG_SHA256="87959b6819530b3dcaeb39992f585b9fc2c7120302809741378097774919fb6f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://ccache.dev/download.html"
 PKG_URL="https://github.com/ccache/ccache/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.26.3"
-PKG_SHA256="bbd8d39217509d163cb544a40d6428ac666ddc83e22905d3e52c925781f0f659"
+PKG_VERSION="3.26.4"
+PKG_SHA256="313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="16.0.3"
-PKG_SHA256="3b12e35332e10cf650578ae18247b91b04926d5427e1a6ae9a51d170a47cfbb2"
+PKG_VERSION="16.0.4"
+PKG_SHA256="cf3c2a1152ed7a99866bd7f12c24528ada6d9f6336afb7a08416938762004c9f"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
 PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION}.src.tar.xz"

--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.17.0"
-PKG_SHA256="d677199dc3f4d502d6d78bd8855f313eed427be4545bd6a8188c7fc0799ea379"
+PKG_VERSION="3.18.0"
+PKG_SHA256="60f58349c3d62a99bb87665b2a16afda87dc2d537a14aa45aaad1a3748b781ba"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pycryptodome"
 PKG_URL="https://github.com/Legrandin/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- ccache: update to 4.8.1
- cmake: update to 3.26.4
- llvm: update to 16.0.4
- pycryptodome: update to 3.18.0