### PR TITLE
package updates 

### DIFF
--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.41.2"
+PKG_VERSION="3.42.0"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="e98c100dd1da4e30fa460761dab7c0b91a50b785e167f8c57acc46514fae9499"
+PKG_SHA256="7abcfd161c6e2742ca5c6c0895d1f853c940f203304a0b49da4e1eca5d088ca6"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2023/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"

--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20230512"
-PKG_SHA256="58f3321dcf900175d87d5b39455138c2a24e69df4ba997fb44e3e0d19e531ad1"
+PKG_VERSION="20230516"
+PKG_SHA256="ad8cbc5a273f4640003f6a3f1b129ac6a046f3498ce037921ebac1adf267e55d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="23.2.1"
-PKG_SHA256="3796fea4201e24310b3d100b64cfb288fb92b93ce9de54526efa43e2ea68853a"
+PKG_VERSION="23.2.2"
+PKG_SHA256="37ade2e150483b2720969e2b52270fb2b2d80754a3f32631f72aad41be29d8b5"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="busybox"
-PKG_VERSION="1.36.0"
-PKG_SHA256="542750c8af7cb2630e201780b4f99f3dcceeb06f505b479ec68241c1e6af61a5"
+PKG_VERSION="1.36.1"
+PKG_SHA256="b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.busybox.net"
 PKG_URL="https://busybox.net/downloads/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/sysutils/exfatprogs/package.mk
+++ b/packages/sysutils/exfatprogs/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="exfatprogs"
-PKG_VERSION="1.2.0"
-PKG_SHA256="56d9a49465deafc367d428afc71c8098705a30ee19a3cdf3c5320650b8880742"
+PKG_VERSION="1.2.1"
+PKG_SHA256="a6f3b1fb4bd37835c8f8cb421aac4eb75b880a51342b29850c4063973162227b"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/exfatprogs/exfatprogs"
 PKG_URL="https://github.com/exfatprogs/exfatprogs/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="util-linux"
-PKG_VERSION="2.38.1"
-PKG_SHA256="60492a19b44e6cf9a3ddff68325b333b8b52b6c59ce3ebd6a0ecaa4c5117e84f"
+PKG_VERSION="2.39"
+PKG_SHA256="32b30a336cda903182ed61feb3e9b908b762a5e66fe14e43efb88d37162075cb"
 PKG_LICENSE="GPL"
 PKG_URL="https://www.kernel.org/pub/linux/utils/util-linux/v$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host autoconf:host automake:host intltool:host libtool:host pkg-config:host"

--- a/packages/sysutils/util-linux/patches/util-linux-01-fix-pkgconf.patch
+++ b/packages/sysutils/util-linux/patches/util-linux-01-fix-pkgconf.patch
@@ -29,7 +29,9 @@ diff --git a/libmount/mount.pc.in b/libmount/mount.pc.in
 index 2c32797..c8112c6 100644
 --- a/libmount/mount.pc.in
 +++ b/libmount/mount.pc.in
-@@ -1,7 +1,7 @@
+@@ -10,9 +10,9 @@
+ # (at your option) any later version.
+ #
  prefix=@prefix@
 -exec_prefix=@exec_prefix@
 -libdir=@usrlib_execdir@

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.11.3"
-PKG_SHA256="44b38be302a103c62f80e792478a505365693349a76ea6b98e9c68aab8eab9e0"
+PKG_VERSION="2.11.4"
+PKG_SHA256="a9493ae091f58037dd5e73fc6035a4907eae58e2cc4756abc4e6253ee6036166"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"

--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="curl"
-PKG_VERSION="8.0.1"
-PKG_SHA256="0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0"
+PKG_VERSION="8.1.0"
+PKG_SHA256="6bd80ad4f07187015911216ee7185b90d285ac5162aed1bded144f9f93232a3c"
 PKG_LICENSE="MIT"
 PKG_SITE="https://curl.haxx.se"
 PKG_URL="https://curl.haxx.se/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.52.0"
-PKG_SHA256="3ea9f0439e60469ad4d39cb349938684ffb929dd7e8e06a7bffe9f9d21f8ba7d"
+PKG_VERSION="1.53.0"
+PKG_SHA256="b867184254e5a29b0ba68413aa14f8b0ce1142a371761374598dec092dabb809"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"

--- a/packages/x11/app/setxkbmap/package.mk
+++ b/packages/x11/app/setxkbmap/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setxkbmap"
-PKG_VERSION="1.3.3"
-PKG_SHA256="b560c678da6930a0da267304fa3a41cc5df39a96a5e23d06f14984c87b6f587b"
+PKG_VERSION="1.3.4"
+PKG_SHA256="be8d8554d40e981d1b93b5ff82497c9ad2259f59f675b38f1b5e84624c07fade"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- busybox: update to 1.36.1
- curl: update to 8.1.0
- exfatprogs: update to 1.2.1
- intel-ucode: update to 20230516 (documentation only)
- libxml2: update to 2.11.4
- media-driver: update to 23.2.2
- nghttp2: update to 1.53.0
- setxkbmap: update to 1.3.4
- sqlite: update to 3.42.0
- util-linux: update to 2.39