### PR TITLE
curl: update to 8.1.1

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="curl"
-PKG_VERSION="8.1.0"
-PKG_SHA256="6bd80ad4f07187015911216ee7185b90d285ac5162aed1bded144f9f93232a3c"
+PKG_VERSION="8.1.1"
+PKG_SHA256="08a948e061929645597c1ef7194e07b308b22084ff03fa7400b465e6c05149e5"
 PKG_LICENSE="MIT"
 PKG_SITE="https://curl.haxx.se"
 PKG_URL="https://curl.haxx.se/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- https://curl.se/changes.html#8_1_1
- https://daniel.haxx.se/blog/2023/05/23/curl-8-1-1-lets-do-this/

I've experienced breaking issues with curl-8.1.0 - "URL format invalid" on some perfectly innocuous CDN https:// URLs. With 8.1.1, those issues are gone for me. None of the earlier versions that I happened to run exhibit this issue either - this includes at least curl-8.0.1, plus whichever versions of curl are shipped in stable releases of 9.2 and 10.0, plus `12.0-nightly-20230405-d4ddf07`

Therefore, I suggest updating to already-available 8.1.1 soon, to keep one source of known issues out.