### PR TITLE
[le11] snapclient and snapserver: update shairport-sync to 4.2 and addon (2)

### DIFF
--- a/packages/addons/addon-depends/snapcast-depends/asio/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/asio/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="asio"
-PKG_VERSION="1.27.0"
-PKG_SHA256="9bee8e50236ce7752325efde38cae223cbc85759ed49509d9cbc5d55458332d9"
+PKG_VERSION="1.28.0"
+PKG_SHA256="5c2af07ef73b42a2d48e34c0ecbf41cd40dc823bc681bf5833c129384999c963"
 PKG_LICENSE="BSL"
 PKG_SITE="http://think-async.com/Asio"
 PKG_URL="https://github.com/chriskohlhoff/asio/archive/asio-${PKG_VERSION//./-}.zip"

--- a/packages/addons/addon-depends/snapcast-depends/nqptp/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/nqptp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nqptp"
-PKG_VERSION="c71b49a3556ba8547ee28482cb31a97fe99298aa"
-PKG_SHA256="02ed710ed37269adbede06fcd4e12892cc0f9d14d5c68b7f45d67b8694bff1e4"
+PKG_VERSION="1.2.1"
+PKG_SHA256="fab700572961ca81addb405e8bd4bd57c47259f91e7e8e0f5f82240c38c63ce5"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/mikebrady/nqptp"
 PKG_URL="https://github.com/mikebrady/nqptp/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/snapcast-depends/shairport-sync/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/shairport-sync/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="shairport-sync"
-PKG_VERSION="4.1.1"
-PKG_SHA256="e55caad73dcd36341baf8947cf5e0923997370366d6caf3dd917b345089c4a20"
+PKG_VERSION="4.2"
+PKG_SHA256="649d95eede8b9284b2e8b9c97d18c1c64cffae0a6c75bc4f03e3ae494a3e25b6"
 PKG_LICENSE="OSS"
 PKG_SITE="https://github.com/mikebrady/shairport-sync"
 PKG_URL="https://github.com/mikebrady/shairport-sync/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/snapclient/changelog.txt
+++ b/packages/addons/service/snapclient/changelog.txt
@@ -1,3 +1,8 @@
+2
+- asio: update to 1.28.0
+- nqptp: update to 1.2.1
+- shairport-sync: update to 4.2
+
 1
 - asio: update to 1.27.0
 - snapcast: update to 0.27.0

--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="snapclient"
 PKG_VERSION="0.27.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain alsa-plugins snapcast"

--- a/packages/addons/service/snapserver/changelog.txt
+++ b/packages/addons/service/snapserver/changelog.txt
@@ -1,3 +1,8 @@
+2
+- asio: update to 1.28.0
+- nqptp: update to 1.2.1
+- shairport-sync: update to 4.2
+
 1
 - asio: update to 1.27.0
 - snapcast: update to 0.27.0

--- a/packages/addons/service/snapserver/package.mk
+++ b/packages/addons/service/snapserver/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="snapserver"
 PKG_VERSION="0.27.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain nqptp shairport-sync snapcast"


### PR DESCRIPTION
- backport of #7876 

- asio: update to 1.28.0
- nqptp: update to 1.2.1
- shairport-sync: update to 4.2
- snapclient: update shairport-sync to 4.2 and addon (2)
- snapserver: update shairport-sync to 4.2 and addon (2)