### PR TITLE
[le12] docker: update to 24.0.2 and addon (1)

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="f5916273959fb2df56424bb2c26d8b6feb9a148dd15eb400aedd5d3753e06959"
+PKG_SHA256="632357aa58d7f5e16ce87dbd73641c5f65c25b6501e3917ac4f0ce553a01e0bc"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/docker/cli/releases
-export PKG_GIT_COMMIT="680212238b47d4299b62ed55e3113a498cde3cef"
+export PKG_GIT_COMMIT="cb74dfcd853482dd43cb553106b1e0cd237acb3e"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.7.1"
-PKG_SHA256="fd844af82afda7242d8eba5e0086c5a0d54ddc3041c1bbdd4d3c62bfee844e3a"
+PKG_VERSION="1.7.2"
+PKG_SHA256="68d20562c3164f61f2ec6951edb002bf12cd58b21448e0ab04c5ec56d4dcac43"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-PKG_GIT_COMMIT="78f51771157abb6c9ed224c22013cdf09962315d"
+PKG_GIT_COMMIT="0cae528dd6cb557f7201036e9f43420650207b58"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="24.0.1"
-PKG_SHA256="cb8aa8ca7145cd8273b6eb2595ee5d7da2e97feec4b73936cb4ea8cbbe104028"
+PKG_VERSION="24.0.2"
+PKG_SHA256="f4bc7d7cc2ee3671371ae80fd624e61f0598e614b5c235012581f8ec1d593aa0"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="463850e59e8af1258cad649ec6836d5e88d16fec"
+export PKG_GIT_COMMIT="659604f9ee60f147020bdd444b26e4b5c636dc28"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.20.4"
-PKG_SHA256="3bcdd27c4b5a6fad1fa3ce1f6a7e522cd6f939d9151ca1e89f40b81ef7caeefe"
+PKG_VERSION="1.20.5"
+PKG_SHA256="a6a973d94004fb63331b151d2453b9b58a6d58cc046b86ae86033cd0f02fcaef"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
- cli: update to 24.0.2
- containerd: update to 1.7.2
  - release notes: https://github.com/containerd/containerd/releases/tag/v1.7.2
- go: update to 1.20.5
- moby: update to 24.0.2
  - release notes: https://github.com/moby/moby/releases/tag/v24.0.2