### PR TITLE
media-driver: update to 23.2.3

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="23.2.2"
-PKG_SHA256="37ade2e150483b2720969e2b52270fb2b2d80754a3f32631f72aad41be29d8b5"
+PKG_VERSION="23.2.3"
+PKG_SHA256="e443ecb925bd030dc848766445a11848f92a6a01cf45b04671d374dcc3706964"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
Log:
- https://github.com/intel/media-driver/compare/intel-media-23.2.2...intel-media-23.2.3 

```
=== tested on ===
Generic.x86_64-devel-20230531125537-1498f16
Linux nuc12 6.3.5 #1 SMP Wed May 31 11:34:55 UTC 2023 x86_64 GNU/Linux
Starting Kodi (21.0-ALPHA1 (20.90.101) Git:1a04aa12cb4e5457867451f41ab4dcdcd201b1a9). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2023-05-28 by GCC 13.1.0 for Linux x86 64-bit version 6.4.0 (394240)
Running on LibreELEC (heitbaum): devel-20230531125537-1498f16 12.0, kernel: Linux x86 64-bit version 6.3.5
FFmpeg version/source: 6.0
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0087.2023.0306.1931 03/06/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.1.1
libva info: VA-API version 1.18.0
vainfo: VA-API version: 1.18 (libva 2.18.2)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.2.3 (1498f16934)
```