### PR TITLE
samba: samba-config: call smbpasswd with valid smb.conf

### DIFF
--- a/packages/network/samba/scripts/samba-config
+++ b/packages/network/samba/scripts/samba-config
@@ -98,14 +98,15 @@ if [ ! -f /storage/.cache/services/samba.disabled ]; then
     # processing continues, so if user chooses root as username, second line overrides the first
     # this is done always in case user uses passwords in userconf.
     # many thanks to viljoviitanen for this
-    printf "%s\n%s" "${SAMBA_PASSWORD}" "${SAMBA_PASSWORD}" | smbpasswd -s -a root >/dev/null 2>&1
-    printf 'nobody = root\nroot = "%s"\n' "${SAMBA_USERNAME}" > /run/samba/samba.map
-
     sed -e 's|^.[ \t]*.public.=.*|  public = no |' \
         -e 's|^.[ \t]*.username map.=.*||' \
         -e 's|^.[ \t]*.security.=.*|  security = user\n  username map = /run/samba/samba.map|' \
         -e 's|^.[ \t]*.map.to.guest.=.*|  map to guest = Never|' \
         -i ${SMB_TMP}
+
+    printf "%s\n%s" "${SAMBA_PASSWORD}" "${SAMBA_PASSWORD}" | smbpasswd -c ${SMB_TMP} -s -a root
+    printf 'nobody = root\nroot = "%s"\n' "${SAMBA_USERNAME}" > /run/samba/samba.map
+
   else
     sed -e 's|^.[ \t]*.public.=.*|  public = yes |' \
         -e 's|^.[ \t]*.username map.=.*||' \


### PR DESCRIPTION
Fixup for 6a7c071568, reported in the [forum](https://forum.libreelec.tv/thread/27142-samba-auth-settings-for-local-shares-not-persisting-after-reboots/). 

smbpasswd requires a valid smb.conf, use fresh created tempfile as parameter. Allow logging to journal to make future errors visible.
