### PR TITLE
[le11] linux (RPi): update to 6.1.31

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="83cf6b410113c98ebfd0b7fef70b1a7c9539b0b9" # 6.1.27
-    PKG_SHA256="be28f607f945ee7083af61608f29ced824db87fc7b49bff4e4c7d64ca8581935"
+    PKG_VERSION="dbcb82357ef21be47841ba39d117b626d715af31" # 6.1.28
+    PKG_SHA256="2177e857d824d0b5e9a6210d035cddcfea98157600db4ca50c92ab9f8d8accd9"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="2e774281403e225fdf2ff73d0d6642a752b8ddf9" # 6.1.29
-    PKG_SHA256="c759f5b0f0a4883106e8e3b8c8fd75c1890524defe1c16182b58d66fa6ff64f6"
+    PKG_VERSION="3a4603db1c0e33167153244deb198c2b13370f98" # 6.1.31
+    PKG_SHA256="6e3b2323687c66bdd1cbb2547b0a11c5d9ad69d7dab1400a4055183c8e20f3c2"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="1229967a3ab861660b6d31ccdc8526bd44712b13" # 6.1.28
-    PKG_SHA256="67daf12920b0f36d0aa7b4443a4c976c02441ad8b6ecc3c839f9d88327e962d3"
+    PKG_VERSION="4d4880099b91ca4f180cc9d1c47b7005b4b7f3f0" # 6.1.28
+    PKG_SHA256="8b1aec299586c8b6b75f30b1f50bd668cd5d6e0165f6e508033a910dfe01fc1d"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="dbcb82357ef21be47841ba39d117b626d715af31" # 6.1.28
-    PKG_SHA256="2177e857d824d0b5e9a6210d035cddcfea98157600db4ca50c92ab9f8d8accd9"
+    PKG_VERSION="1229967a3ab861660b6d31ccdc8526bd44712b13" # 6.1.28
+    PKG_SHA256="67daf12920b0f36d0aa7b4443a4c976c02441ad8b6ecc3c839f9d88327e962d3"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="4d4880099b91ca4f180cc9d1c47b7005b4b7f3f0" # 6.1.28
-    PKG_SHA256="8b1aec299586c8b6b75f30b1f50bd668cd5d6e0165f6e508033a910dfe01fc1d"
+    PKG_VERSION="2e774281403e225fdf2ff73d0d6642a752b8ddf9" # 6.1.29
+    PKG_SHA256="c759f5b0f0a4883106e8e3b8c8fd75c1890524defe1c16182b58d66fa6ff64f6"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="bf7419c961e8b65854fd73ec29fbc515087539e8"
-PKG_SHA256="49c2e92accc58d10ddcf0a7a7eb2385c674ac57610c0f5b1e4dfea0e9983f353"
+PKG_VERSION="75d3a760469130cb537e5d8d504f892336abd62b"
+PKG_SHA256="a71573a80149b1c2c4b6d5ec1527ef011611c6883a0cf06c02961fe518384307"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Backport of #7892
Runtime tested on RPi4