### PR TITLE
Toolchain Package updates 

### DIFF
--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gdb"
-PKG_VERSION="13.1"
-PKG_SHA256="115ad5c18d69a6be2ab15882d365dda2a2211c14f480b3502c6eba576e2e95a0"
+PKG_VERSION="13.2"
+PKG_SHA256="fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/gdb/"
 PKG_URL="https://ftp.gnu.org/gnu/gdb/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="16.0.4"
-PKG_SHA256="cf3c2a1152ed7a99866bd7f12c24528ada6d9f6336afb7a08416938762004c9f"
+PKG_VERSION="16.0.5"
+PKG_SHA256="37f540124b9cfd4680666e649f557077f9937c9178489cea285a672e714b2863"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
 PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION}.src.tar.xz"

--- a/packages/python/devel/MarkupSafe/package.mk
+++ b/packages/python/devel/MarkupSafe/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="MarkupSafe"
-PKG_VERSION="2.1.2"
-PKG_SHA256="abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"
+PKG_VERSION="2.1.3"
+PKG_SHA256="af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/MarkupSafe/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="1.1.0"
-PKG_SHA256="d9616c44cd6c53689ff8f05fc6958a693f2e17c3472a8daf83cee55dabff829f"
+PKG_VERSION="1.1.1"
+PKG_SHA256="d04b541f97ca439fb82fab7d0d480988be4bd4e62563a5ca35fadb5400727b1c"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cargo-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="336eeabf231a7665c26c127a37b8aefffe28cb087c5c8d4ba0460419f5f8eff2"
+PKG_SHA256="650e7a890a52869cd14e2305652bff775aec7fc2cf47fc62cf4a89ff07242333"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rust-std-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="4c95739e6f0f1d4defd937f6d60360b566e051dfb2fa71879d0f9751392f3709"
+PKG_SHA256="0c0129717da1e27ccf2c56da950d2fe56973f71beec9e80ae6904b282d2f0ee9"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.69.0"
-PKG_SHA256="fb05971867ad6ccabbd3720279f5a94b99f61024923187b56bb5c455fa3cf60f"
+PKG_VERSION="1.70.0"
+PKG_SHA256="b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rustc-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="70e97ab5b9600328b977268fc92ca4aa53064e4e97468df35215d4396e509279"
+PKG_SHA256="7d891d3e9bc4f1151545c83cbe3bc6af9ed234388c45ca2e19641262f48615e2"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"

--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qemu"
-PKG_VERSION="8.0.0"
-PKG_SHA256="bb60f0341531181d6cc3969dd19a013d0427a87f918193970d9adb91131e56d0"
+PKG_VERSION="8.0.2"
+PKG_SHA256="f060abd435fbe6794125e2c398568ffc3cfa540042596907a8b18edca34cf6a5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.qemu.org"
 PKG_URL="https://download.qemu.org/qemu-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- gdb: update to 13.2
- llvm: update to 16.0.5
- MarkupSafe: update to 2.1.3
- meson: update to 1.1.1
- qemu: update to 8.0.2
- rust: update to 1.70.0
  - cargo-snapshot: update to 1.70.0
  - rustc-snapshot: update to 1.70.0
  - rust-std-snapshot: update to 1.70.0