### PR TITLE
Upstream patches

### DIFF
--- a/packages/addons/addon-depends/protobuf/patches/9936.patch
+++ b/packages/addons/addon-depends/protobuf/patches/9936.patch
@@ -1,0 +1,24 @@
+From fc7dc129f19fec7fe3211a39f13f6fe74c35cce6 Mon Sep 17 00:00:00 2001
+From: Adam Cozzette <acozzette@google.com>
+Date: Mon, 9 May 2022 19:03:39 +0000
+Subject: [PATCH] Use __constinit only in GCC 12.2 and up
+
+Fixes #9916. GCC appears to have a bug preventing our use of __constinit
+from working correctly, but this bug will be fixed in GCC 12.2.
+---
+ src/google/protobuf/port_def.inc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index dcb0ff758f1..289a42674cf 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -650,7 +650,7 @@
+      (!defined(__APPLE__) && __clang_major__ >= 12))
+ #define PROTOBUF_CONSTINIT [[clang::require_constant_initialization]]
+ #define PROTOBUF_CONSTEXPR constexpr
+-#elif PROTOBUF_GNUC_MIN(12, 0)
++#elif PROTOBUF_GNUC_MIN(12, 2)
+ #define PROTOBUF_CONSTINIT __constinit
+ #define PROTOBUF_CONSTEXPR constexpr
+ #else

--- a/packages/security/nss/patches/nss-20-Bug-1836781-Disabling-ASM-C25519-for-A-but-X86_64-r.patch
+++ b/packages/security/nss/patches/nss-20-Bug-1836781-Disabling-ASM-C25519-for-A-but-X86_64-r.patch
@@ -1,0 +1,29 @@
+From c07c4e073d95a25343cbf56b4a830a71e432869e Mon Sep 17 00:00:00 2001
+From: Natalia Kulatova <nkulatova@mozilla.com>
+Date: Mon, 5 Jun 2023 16:09:58 +0000
+Subject: [PATCH] Bug 1836781 - Disabling ASM C25519 for A but X86_64
+ r=bbeurdouche,nss-reviewers
+
+Differential Revision: https://phabricator.services.mozilla.com/D179969
+
+--HG--
+extra : moz-landing-system : lando
+---
+ nss/lib/freebl/Makefile | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/nss/lib/freebl/Makefile b/nss/lib/freebl/Makefile
+index 74e8e65459..ba7d83c4e3 100644
+--- a/nss/lib/freebl/Makefile
++++ b/nss/lib/freebl/Makefile
+@@ -568,7 +568,9 @@ ifneq ($(shell $(CC) -? 2>&1 >/dev/null </dev/null | sed -e 's/:.*//;1q'),lcc)
+             HAVE_INT128_SUPPORT = 1
+             DEFINES += -DHAVE_INT128_SUPPORT
+     else ifeq (1,$(CC_IS_GCC))
+-        SUPPORTS_VALE_CURVE25519 = 1
++        ifeq ($(CPU_ARCH),x86_64)
++            SUPPORTS_VALE_CURVE25519 = 1
++        endif
+         ifneq (,$(filter 4.6 4.7 4.8 4.9,$(word 1,$(GCC_VERSION)).$(word 2,$(GCC_VERSION))))
+             HAVE_INT128_SUPPORT = 1
+             DEFINES += -DHAVE_INT128_SUPPORT


### PR DESCRIPTION
- protobuf: Use __constinit only in GCC 12.2 and up
  - required due to use of jammy buildserver (which uses the host gcc-12.1)
- nss: fix Bug 1836781 - Disabling ASM C25519 for A but X86_64 r
  - build errors with ARMv8 aarch64