### PR TITLE
Python3: update to 3.11.4

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.11.3"
-PKG_SHA256="8a5db99c961a7ecf27c75956189c9602c968751f11dbeae2b900dbff1c085b5e"
+PKG_VERSION="3.11.4"
+PKG_SHA256="2f0e409df2ab57aa9fc4cbddfb976af44e4e55bf6f619eee6bc5c2297264a7f6"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.python.org/"
 PKG_URL="https://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"

--- a/packages/lang/Python3/patches/0012-Add-an-option-to-disable-lib2to3.patch
+++ b/packages/lang/Python3/patches/0012-Add-an-option-to-disable-lib2to3.patch
@@ -48,9 +48,9 @@ index 403380e181..f5d0573067 100644
 -		lib2to3/tests/data \
 -		lib2to3/tests/data/fixers \
 -		lib2to3/tests/data/fixers/myfixes \
- 		test test/audiodata \
- 		test/capath test/cjkencodings \
- 		test/data test/decimaltestdata \
+ 		test \
+ 		test/audiodata \
+ 		test/capath \
 @@ -2013,6 +2010,14 @@ ifeq (@PYDOC@,yes)
  LIBSUBDIRS += pydoc_data
  endif

--- a/packages/lang/Python3/patches/0014-Add-an-option-to-disable-the-tk-module.patch
+++ b/packages/lang/Python3/patches/0014-Add-an-option-to-disable-the-tk-module.patch
@@ -26,15 +26,16 @@ index 9f4cdf14cf..4f83911200 100644
  		tomllib \
  		turtledemo \
  		unittest \
-@@ -2001,8 +2000,6 @@ TESTSUBDIRS=	ctypes/test \
- 		test/tracedmodules \
- 		test/xmltestdata test/xmltestdata/c14n-20 \
+@@ -2001,9 +2000,6 @@ TESTSUBDIRS=	ctypes/test \
+ 		test/xmltestdata \
+ 		test/xmltestdata/c14n-20 \
  		test/ziptestdata \
--		tkinter/test tkinter/test/test_tkinter \
+-		tkinter/test \
+-		tkinter/test/test_tkinter \
 -		tkinter/test/test_ttk \
- 		unittest/test unittest/test/testmock
+ 		unittest/test \
+ 		unittest/test/testmock
  
- ifeq (@PYDOC@,yes)
 @@ -2021,6 +2018,13 @@ ifeq (@SQLITE3@,yes)
  LIBSUBDIRS += sqlite3
  endif


### PR DESCRIPTION
Tested on 
```
nuc12:~/.kodi/temp # head kodi.log
2023-06-07 11:30:04.953 T:2637     info <general>: -----------------------------------------------------------------------
2023-06-07 11:30:04.953 T:2637     info <general>: Starting Kodi (21.0-ALPHA1 (20.90.101) Git:1a04aa12cb4e5457867451f41ab4dcdcd201b1a9). Platform: Linux x86 64-bit
2023-06-07 11:30:04.953 T:2637     info <general>: Using Release Kodi x64
2023-06-07 11:30:04.953 T:2637     info <general>: Kodi compiled 2023-06-07 by GCC 13.1.0 for Linux x86 64-bit version 6.4.0 (394240)
2023-06-07 11:30:04.953 T:2637     info <general>: Running on LibreELEC (heitbaum): devel-20230607090404-e409313 12.0, kernel: Linux x86 64-bit version 6.4.0-rc5
2023-06-07 11:30:04.953 T:2637     info <general>: FFmpeg version/source: 6.0
2023-06-07 11:30:04.953 T:2637     info <general>: Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
2023-06-07 11:30:04.953 T:2637     info <general>: special://xbmc/ is mapped to: /usr/share/kodi/
2023-06-07 11:30:04.953 T:2637     info <general>: special://xbmcbin/ is mapped to: /usr/lib/kodi
2023-06-07 11:30:04.953 T:2637     info <general>: special://xbmcbinaddons/ is mapped to: /usr/lib/kodi/addons
nuc12:~/.kodi/temp # grep -e 3.11.4 kodi.log
2023-06-07 21:30:07.935 T:2881     info <general>: script.module.slyguy - Python Version: 3.11.4 (main, Jun  7 2023, 09:16:28) [GCC 13.1.0]
                                                   Python version  : 3.11.4 (main, Jun  7 2023, 09:16:28) [GCC 13.1.0]
                                                   Python version  : 3.11.4 (main, Jun  7 2023, 09:16:28) [GCC 13.1.0]
```