### PR TITLE
mesa: update to 23.1.2

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="23.1.1"
-PKG_SHA256="a2679031ed5b73b29c4f042ac64d96f83b0cfe4858617de32e2efc196c653a40"
+PKG_VERSION="23.1.2"
+PKG_SHA256="60b1f3adb1561830c158bf3c68508943674fb9d69f384c3c7289694385ab5c7e"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release notes:
- https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/docs/relnotes/23.1.2.rst

```
=== tested on ===
Generic.x86_64-devel-20230609063903-6b3beba
Linux nuc12 6.3.6 #1 SMP Thu Jun  8 10:18:02 UTC 2023 x86_64 GNU/Linux
Starting Kodi (21.0-ALPHA1 (20.90.101) Git:1a04aa12cb4e5457867451f41ab4dcdcd201b1a9). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2023-06-07 by GCC 13.1.0 for Linux x86 64-bit version 6.4.0 (394240)
Running on LibreELEC (heitbaum): devel-20230609063903-6b3beba 12.0, kernel: Linux x86 64-bit version 6.3.6
FFmpeg version/source: 6.0
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0087.2023.0306.1931 03/06/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.1.2
libva info: VA-API version 1.18.0
vainfo: VA-API version: 1.18 (libva 2.18.2)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.2.3 (213e1d1f4d)
```