### PR TITLE
tools/docker: jammy: support qemu amd64 on aarch64

### DIFF
--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -4,8 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get dist-upgrade -y \
- && apt-get install -y locales sudo \
- && rm -rf /var/lib/apt/lists/*
+ && apt-get install -y locales sudo
 
 RUN locale-gen en_US.UTF-8 \
  && update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en
@@ -17,13 +16,24 @@ RUN adduser --disabled-password --gecos '' docker \
  && adduser docker sudo \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get install -y \
     wget bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
       golang-go git openssh-client \
-    --no-install-recommends \
- && rm -rf /var/lib/apt/lists/*
+    --no-install-recommends
+
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse' > /etc/apt/sources.list.d/amd64.list; \
+  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
+  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
+  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
+  apt-get update; \
+  dpkg --add-architecture amd64; \
+  apt-get install -y libc6:amd64 qemu-user-binfmt --no-install-recommends; \
+ fi
+
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 \
     --slave /usr/bin/cpp cpp /usr/bin/cpp-12 \


### PR DESCRIPTION
Testing with Ampere A1 - build was failing `checkdeps` on Rockchip and Amlogic images
- This has been tested with `actions`.
- Required for build of Amlogic and Rockchip images
- Fixes checkdeps requirement for: qemu-user-binfmt and libc6:amd64

https://github.com/LibreELEC/LibreELEC.tv/blob/5755426aea7b892389cb165c3bf3ceb9a484c8ef/scripts/checkdeps#L95-#L105

- There is a further build issue using a aarch64 build host - #7926 - tracking separately