### PR TITLE
Update rust and llvm build to be built on arm and aarch64.

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -48,15 +48,27 @@ pre_configure() {
 }
 
 pre_configure_host() {
-  case "${TARGET_ARCH}" in
-    "arm")
-      LLVM_BUILD_TARGETS="X86\;ARM"
-      ;;
+  case "${MACHINE_HARDWARE_NAME}" in
     "aarch64")
-      LLVM_BUILD_TARGETS="X86\;AArch64"
+      LLVM_BUILD_TARGETS="AArch64"
+      ;;
+    "arm")
+      LLVM_BUILD_TARGETS="ARM"
       ;;
     "x86_64")
-      LLVM_BUILD_TARGETS="X86\;AMDGPU"
+      LLVM_BUILD_TARGETS="X86"
+      ;;
+  esac
+
+  case "${TARGET_ARCH}" in
+    "aarch64")
+      LLVM_BUILD_TARGETS+="\;AArch64"
+      ;;
+    "arm")
+      LLVM_BUILD_TARGETS+="\;ARM"
+      ;;
+    "x86_64")
+      LLVM_BUILD_TARGETS+="\;X86\;AMDGPU"
       ;;
   esac
 

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -3,9 +3,23 @@
 
 PKG_NAME="cargo-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="650e7a890a52869cd14e2305652bff775aec7fc2cf47fc62cf4a89ff07242333"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
-PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
 PKG_LONGDESC="cargo bootstrap package"
 PKG_TOOLCHAIN="manual"
+
+case "${MACHINE_HARDWARE_NAME}" in
+  "aarch64")
+    PKG_SHA256="8fd2d9806f0601feab1485f79e46d1441af2158c68abf56788ff355d5c6b4ab5"
+    PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
+    ;;
+  "arm")
+    PKG_SHA256="b932b2d562a1383b1fae5e2931f85fd5ea0cbb5da2c7605d5382d7d2680efd7f"
+    PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
+    ;;
+  "x86_64")
+    PKG_SHA256="650e7a890a52869cd14e2305652bff775aec7fc2cf47fc62cf4a89ff07242333"
+    PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
+    ;;
+esac
+PKG_SOURCE_NAME="cargo-snapshot_${PKG_VERSION}_${ARCH}.tar.xz"

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -3,9 +3,23 @@
 
 PKG_NAME="rust-std-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="0c0129717da1e27ccf2c56da950d2fe56973f71beec9e80ae6904b282d2f0ee9"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
-PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
 PKG_LONGDESC="rust std library bootstrap package"
 PKG_TOOLCHAIN="manual"
+
+case "${MACHINE_HARDWARE_NAME}" in
+  "aarch64")
+    PKG_SHA256="966e85187b6b76dc520b23aadc886c5fe54b209a21c68f959ff00ef8542b7f9f"
+    PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
+    ;;
+  "arm")
+    PKG_SHA256="6ad1231aeb34fef9c9db267859b0db3c6846bbade8227e6c9f456b6264c1278c"
+    PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
+    ;;
+  "x86_64")
+    PKG_SHA256="0c0129717da1e27ccf2c56da950d2fe56973f71beec9e80ae6904b282d2f0ee9"
+    PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
+    ;;
+esac
+PKG_SOURCE_NAME="rust-std-snapshot_${PKG_VERSION}_${ARCH}.tar.xz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -3,9 +3,23 @@
 
 PKG_NAME="rustc-snapshot"
 PKG_VERSION="$(get_pkg_version rust)"
-PKG_SHA256="7d891d3e9bc4f1151545c83cbe3bc6af9ed234388c45ca2e19641262f48615e2"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
-PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
 PKG_LONGDESC="rustc bootstrap compiler"
 PKG_TOOLCHAIN="manual"
+
+case "${MACHINE_HARDWARE_NAME}" in
+  "aarch64")
+    PKG_SHA256="71698cf444eef74050db821dc4df996c0f268615230099cde836e685e5b5465d"
+    PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
+    ;;
+  "arm")
+    PKG_SHA256="c5c8e339dccf1ca893434cd08516a399e991891668d219f335f35dcd251d2bb3"
+    PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
+    ;;
+  "x86_64")
+    PKG_SHA256="7d891d3e9bc4f1151545c83cbe3bc6af9ed234388c45ca2e19641262f48615e2"
+    PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
+    ;;
+esac
+PKG_SOURCE_NAME="rustc-snapshot_${PKG_VERSION}_${ARCH}.tar.xz"


### PR DESCRIPTION
- Update rust build to be built on arm and aarch64
- Update llvm build to be built on arm and aarch64
- Fixes #7937 