### PR TITLE
gstreamer update to 1.22.4

### DIFF
--- a/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-bad"
-PKG_VERSION="1.22.3"
-PKG_SHA256="e1798fee2d86127f0637481c607f983293bf0fd81aad70a5c7b47205af3621d8"
+PKG_VERSION="1.22.4"
+PKG_SHA256="eaaf53224565eaabd505ca39c6d5769719b45795cf532ce1ceb60e1b2ebe99ac"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-bad.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-bad/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gstreamer/gst-plugins-base/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-base/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gst-plugins-base"
-PKG_VERSION="1.22.3"
-PKG_SHA256="1c596289a0d4207380233eba8c36a932c4d1aceba19932937d9b57c24cef89f3"
+PKG_VERSION="1.22.4"
+PKG_SHA256="292424e82dea170528c42b456f62a89532bcabc0508f192e34672fb86f68e5b8"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-base.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-base/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gstreamer/gstreamer/package.mk
+++ b/packages/multimedia/gstreamer/gstreamer/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gstreamer"
-PKG_VERSION="1.22.3"
-PKG_SHA256="9ffeab95053f9f6995eb3b3da225e88f21c129cd60da002d3f795db70d6d5974"
+PKG_VERSION="1.22.4"
+PKG_SHA256="11cb0498bc16b93d8b99d22f75f829b8d0abfd8254840b2120618db5532dc655"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org"
 PKG_URL="https://gstreamer.freedesktop.org/src/gstreamer/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
https://gstreamer.freedesktop.org/
- gst-plugins-bad: update to 1.22.4
- gst-plugins-base: update to 1.22.4
- gstreamer: update to 1.22.4