### PR TITLE
Fix AMLGX build on aarch64 

### DIFF
--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -8,10 +8,11 @@ PKG_SHA256="0ea0d11a1660a1e63f960f157b197abe6d0c8cb3255be24e1fb3815930b9bdc5"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_HOST="toolchain:host libidn2:host nettle:host zlib:host"
 PKG_DEPENDS_TARGET="toolchain libidn2 nettle zlib"
 PKG_LONGDESC="A library which provides a secure layer over a reliable transport layer."
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-doc \
+PKG_CONFIGURE_OPTS_COMMON="--disable-doc \
                            --disable-full-test-suite \
                            --disable-guile \
                            --disable-libdane \
@@ -25,6 +26,9 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-doc \
                            --with-included-unistring \
                            --without-p11-kit \
                            --without-tpm"
+
+PKG_CONFIGURE_OPTS_HOST="${PKG_CONFIGURE_OPTS_COMMON}"
+PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_COMMON}"
 
 post_configure_target() {
   libtool_remove_rpath libtool

--- a/packages/security/nettle/package.mk
+++ b/packages/security/nettle/package.mk
@@ -8,11 +8,15 @@ PKG_SHA256="ccfeff981b0ca71bbd6fbcb054f407c60ffb644389a5be80d6716d5b550c6ce3"
 PKG_LICENSE="GPL2"
 PKG_SITE="http://www.lysator.liu.se/~nisse/nettle"
 PKG_URL="https://ftp.gnu.org/gnu/nettle/nettle-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="toolchain:host gmp:host"
 PKG_DEPENDS_TARGET="toolchain gmp"
 PKG_LONGDESC="A low-level cryptographic library."
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-documentation \
+PKG_CONFIGURE_OPTS_COMMON="--disable-documentation \
                            --disable-openssl"
+
+PKG_CONFIGURE_OPTS_HOST="${PKG_CONFIGURE_OPTS_COMMON}"
+PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_COMMON}"
 
 if target_has_feature neon; then
   PKG_CONFIGURE_OPTS_TARGET+=" --enable-arm-neon"

--- a/packages/security/nettle/patches/nettle-0001-host-lib64.patch
+++ b/packages/security/nettle/patches/nettle-0001-host-lib64.patch
@@ -1,0 +1,22 @@
+--- a/configure	2023-06-01 18:40:35.000000000 +0000
++++ b/configure	2023-06-24 08:24:18.442874885 +0000
+@@ -6631,7 +6631,7 @@
+ 	  # symlink names. Use -P option, and hope it's portable enough.
+ 	  test -d /usr/lib${ABI} \
+ 	    && (cd /usr/lib${ABI} && pwd -P | grep >/dev/null "/lib${ABI}"'$') \
+-	    && libdir='${exec_prefix}/'"lib${ABI}"
++	    && libdir='${exec_prefix}/'"lib"
+ 	fi
+ 	;;
+       # On freebsd, it seems 32-bit libraries are in lib32,
+--- a/configure.ac	2023-06-01 18:40:35.000000000 +0000
++++ b/configure.ac	2023-06-24 08:24:18.442874885 +0000
+@@ -431,7 +431,7 @@
+ 	  # symlink names. Use -P option, and hope it's portable enough.
+ 	  test -d /usr/lib${ABI} \
+ 	    && (cd /usr/lib${ABI} && pwd -P | grep >/dev/null "/lib${ABI}"'$') \
+-	    && libdir='${exec_prefix}/'"lib${ABI}"
++	    && libdir='${exec_prefix}/'"lib"
+ 	fi
+ 	;;
+       # On freebsd, it seems 32-bit libraries are in lib32,

--- a/packages/textproc/libidn2/package.mk
+++ b/packages/textproc/libidn2/package.mk
@@ -7,12 +7,16 @@ PKG_SHA256="93caba72b4e051d1f8d4f5a076ab63c99b77faee019b72b9783b267986dbb45f"
 PKG_LICENSE="LGPL3"
 PKG_SITE="https://www.gnu.org/software/libidn/"
 PKG_URL="https://ftpmirror.gnu.org/gnu/libidn/libidn2-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Free software implementation of IDNA2008, Punycode and TR46."
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-doc \
+PKG_CONFIGURE_OPTS_COMMON="--disable-doc \
                            --enable-shared \
                            --disable-static"
+
+PKG_CONFIGURE_OPTS_HOST="${PKG_CONFIGURE_OPTS_COMMON}"
+PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_COMMON}"
 
 post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/bin

--- a/packages/tools/amlogic-boot-fip/package.mk
+++ b/packages/tools/amlogic-boot-fip/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="amlogic-boot-fip"
 PKG_LICENSE="nonfree"
-PKG_VERSION="e96b6a694380ff07d5a9e4be644ffe254bd18512"
-PKG_SHA256="2cc06bc7d5647fd8c0025181fa42c4a8ef0ed16b918a1fa2060ea83c22e47b20"
+PKG_VERSION="0312a79cc65bf7bb3d66d33ad0660b66146bd36d"
+PKG_SHA256="437d479c0bb4694113051aadbab393b705fcc0df4a3a5bf3543235226a443c4d"
 PKG_SITE="https://github.com/LibreELEC/amlogic-boot-fip"
 PKG_URL="https://github.com/LibreELEC/amlogic-boot-fip/archive/${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="Firmware Image Package (FIP) sources used to sign Amlogic u-boot binaries in LibreELEC images"

--- a/packages/tools/u-boot-tools/package.mk
+++ b/packages/tools/u-boot-tools/package.mk
@@ -6,7 +6,7 @@ PKG_VERSION="$(get_pkg_version u-boot)"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"
 PKG_URL=""
-PKG_DEPENDS_HOST="ccache:host bison:host flex:host openssl:host pkg-config:host"
+PKG_DEPENDS_HOST="ccache:host bison:host flex:host gnutls:host openssl:host pkg-config:host"
 PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems."
 PKG_DEPENDS_UNPACK+=" u-boot"
 
@@ -16,7 +16,7 @@ unpack() {
 }
 
 make_host() {
-  make qemu-x86_64_defconfig HOSTCC="${HOST_CC}" HOSTCFLAGS="-I${TOOLCHAIN}/include" HOSTLDFLAGS="${HOST_LDFLAGS}"
+  make tools-only_defconfig HOSTCC="${HOST_CC}" HOSTCFLAGS="-I${TOOLCHAIN}/include" HOSTLDFLAGS="${HOST_LDFLAGS}"
   make tools-only HOSTCC="${HOST_CC}" HOSTCFLAGS="-I${TOOLCHAIN}/include" HOSTLDFLAGS="${HOST_LDFLAGS}"
 }
 


### PR DESCRIPTION
Use architecture independent u-boot-tools configuration. 
- https://u-boot.readthedocs.io/en/latest/build/tools.html