### PR TITLE
iwd: update to 2.6

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.5"
-PKG_SHA256="3441effed58297b63779e706c74884234acb874b07872f8b55e0da28729fda32"
+PKG_VERSION="2.6"
+PKG_SHA256="f7ac93aeef672604f5b5194ca038035ae222925be392c4345873c9742f477797"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
log:
- https://git.kernel.org/pub/scm/network/wireless/iwd.git/log/