### PR TITLE
Fix building with fmt >= 10

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.09-use-a-wrapper-to-setup-service-addons.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.09-use-a-wrapper-to-setup-service-addons.patch
@@ -37,7 +37,7 @@ index f6aabfc615..496e1fcfa0 100644
 +      contextStr = "pre-uninstall";
 +      break;
 +    default:
-+      contextStr = StringUtils::Format("unknown(%d)", context);
++      contextStr = StringUtils::Format("unknown({})", static_cast<ADDON::LE_ADDON_CONTEXT>(context));
 +      break;
 +    }
 +


### PR DESCRIPTION
use explicit cast to ADDON::LE_ADDON_CONTEXT when formatting
this patch is required in addition to kodi PR23453 to build with libfmt-10

ref: https://github.com/xbmc/xbmc/pull/23453

future PR will be raised for libfmt-10 which will require updated spdlog