### PR TITLE
LibreELEC-settings: update to b920d5d

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="458469cd4aa8dfcae6aaa6c67ec298cb9ab0f29e"
-PKG_SHA256="9b70ba61458484f0d2c8892c2d8560e6b3de42119a0859cd242b42a26963ef0f"
+PKG_VERSION="b920d5d83a8a7445d121d2f920169444111bf93c"
+PKG_SHA256="d8147068b6172250d98d41fafd7d6dbaa286074932b537214bf0dab95fe9e99a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Only noticeable change for users is a bugfix for setting the hostname via the addon on new installs where `/storage/.cache/hostname` does not already exist.