### PR TITLE
Package updates

### DIFF
--- a/packages/audio/taglib/package.mk
+++ b/packages/audio/taglib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="taglib"
-PKG_VERSION="1.13"
-PKG_SHA256="58f08b4db3dc31ed152c04896ee9172d22052bc7ef12888028c01d8b1d60ade0"
+PKG_VERSION="1.13.1"
+PKG_SHA256="c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://taglib.org"
 PKG_URL="https://taglib.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva-utils"
-PKG_VERSION="2.18.2"
-PKG_SHA256="c4c0555c96ca678f9ac47fbb56f0ae56ca39fd50fe3553bae5cb13117bfcb406"
+PKG_VERSION="2.19.0"
+PKG_SHA256="4135992ab534d0cfd71a93c28e1a22f79c0003cf8d157ffd4621e5e482191b4f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"
 PKG_URL="https://github.com/intel/libva-utils/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.371"
-PKG_SHA256="8059ed6f696b5be4bf77c59d57fc26e35d9e579ba2629e325400a6eb8b91089f"
+PKG_VERSION="0.372"
+PKG_SHA256="aff121c1c7a7dec58414c5e21151a180d3a23628e21c12e3bef58e063a0dc228"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libjpeg-turbo"
-PKG_VERSION="2.1.4"
-PKG_SHA256="a78b05c0d8427a90eb5b4eb08af25309770c8379592bb0b8a863373128e6143f"
+PKG_VERSION="3.0.0"
+PKG_SHA256="171dae5d73560bc94006a7c0c3281bd9bfde6a34f7e41e66f930a1a9162bd7df"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libjpeg-turbo.org/"
 PKG_URL="https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/nvidia-vaapi-driver/package.mk
+++ b/packages/multimedia/nvidia-vaapi-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia-vaapi-driver"
-PKG_VERSION="0.0.9"
-PKG_SHA256="4d14302be650bb63a701b61062d31fa70bfef2f622f3b1f52c93fb9cab6ae698"
+PKG_VERSION="0.0.10"
+PKG_SHA256="df63b0832ccf9f74a90ff8b26d8e069606e0614d1748e35a857d2e53745ab95c"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/elFarto/nvidia-vaapi-driver"
 PKG_URL="https://github.com/elFarto/nvidia-vaapi-driver/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bluez"
-PKG_VERSION="5.66"
-PKG_SHA256="39fea64b590c9492984a0c27a89fc203e1cdc74866086efb8f4698677ab2b574"
+PKG_VERSION="5.68"
+PKG_SHA256="fc505e6445cb579a55cacee6821fe70d633921522043d322b696de0a175ff933"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/bluez/patches/bluez-13-configure-Check-ell-path.patch
+++ b/packages/network/bluez/patches/bluez-13-configure-Check-ell-path.patch
@@ -1,0 +1,34 @@
+From 124187ef9abed60a7c40f751153e9c4516cd1f91 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 1 Jul 2023 01:31:20 +0000
+Subject: [PATCH] configure: Check ell path
+
+Use of AC_CHECK_FILE prevents cross compilation.
+Instead use test to support cross compiling.
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ configure.ac | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index eff297960..bc7edfcd3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -298,9 +298,10 @@ if (test "${enable_external_ell}" = "yes"); then
+ 	AC_SUBST(ELL_LIBS)
+ fi
+ if (test "${enable_external_ell}" != "yes"); then
+-	AC_CHECK_FILE(${srcdir}/ell/ell.h, dummy=yes,
+-			AC_CHECK_FILE(${srcdir}/../ell/ell/ell.h, dummy=yes,
+-				AC_MSG_ERROR(ELL source is required or use --enable-external-ell)))
++	if (test ! -f ${srcdir}/ell/ell.h) &&
++			(test ! -f ${srcdir}/../ell/ell/ell.h); then
++				AC_MSG_ERROR(ELL source is required or use --enable-external-ell)
++	fi
+ fi
+ AM_CONDITIONAL(EXTERNAL_ELL, test "${enable_external_ell}" = "yes" ||
+ 				(test "${enable_btpclient}" != "yes" &&
+-- 
+2.34.1
+

--- a/packages/network/ethtool/package.mk
+++ b/packages/network/ethtool/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ethtool"
-PKG_VERSION="6.3"
-PKG_SHA256="d9425f0a3df138734001fccc4175fe178c025f938460ac25c4ebc39960168822"
+PKG_VERSION="6.4"
+PKG_SHA256="5eaa083e8108e1dd3876b2c803a1942a2763942715b7f6eb916e189adbb44972"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/pub/software/network/ethtool/"
 PKG_URL="https://www.kernel.org/pub/software/network/ethtool/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="9.5.0"
-PKG_SHA256="dca5045b139c65eda32895e743b51c0a697984c34b385d84576275d57b36027f"
+PKG_VERSION="10.0.0"
+PKG_SHA256="535d17e830427bec163027114ded1def9ab0350c99bf1d8cb10535032967f3a5"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.31"
-PKG_SHA256="a07fa722ed87676ec020d867714bc9a2f24c464da73912f39706eeef5219e238"
+PKG_VERSION="1.32"
+PKG_SHA256="7459799d340c8296b695ef857c07ddef24c5a09b09ab6a74f7b92640d2b1ba11"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/${PKG_NAME}/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- bluez: update to 5.68
- ethtool: update to 6.4
- hwdata: update to 0.372
- libjpeg-turbo: update to 3.0.0
- libva-utils: update to 2.19.0
- nvidia-vaapi-driver: update to 0.0.10
- Pillow: update to 10.0.0
- taglib: update to 1.13.1
- wayland-protocols: update to 1.32