### PR TITLE
[le11] samba: update to 4.17.10

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.9"
-PKG_SHA256="ef1c327220f2bf433f44f85a3948785959960634f46cc84fb67389697b3490a6"
+PKG_VERSION="4.17.10"
+PKG_SHA256="00dbb0aac9f4cfee800f708f4e9098964a43a7646e618230706d532c9bb6c350"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.8"
-PKG_SHA256="712e537e1b09b739b6a607e0942503af92a3b2e244484b61264eb091efdfaad7"
+PKG_VERSION="4.17.9"
+PKG_SHA256="ef1c327220f2bf433f44f85a3948785959960634f46cc84fb67389697b3490a6"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- Backport of #7970
- Backport of #8000

Changes since 4.17.8
--------------------

o  Douglas Bagnall <douglas.bagnall@catalyst.net.nz>
   * BUG 15404: Backport --pidl-developer fixes.

o  Ralph Boehme <slow@samba.org>
   * BUG 15275: smbd_scavenger crashes when service smbd is stopped.
   * BUG 15378: vfs_fruit might cause a failing open for delete.

o  Samuel Cabrero <scabrero@samba.org>
   * BUG 14030: named crashes on DLZ zone update.

o  Volker Lendecke <vl@samba.org>
   * BUG 15361: winbind recurses into itself via rpcd_lsad.
   * BUG 15382: cli_list loops 100% CPU against pre-lanman2 servers.
   * BUG 15391: smbclient leaks fds with showacls.

o  Stefan Metzmacher <metze@samba.org>
   * BUG 15374: aes256 smb3 encryption algorithms are not allowed in smb3_sid_parse().
   * BUG 15413: winbindd gets stuck on NT_STATUS_RPC_SEC_PKG_ERROR.

o  Jones Syue <jonessyue@qnap.com>
   * BUG 15403: smbget memory leak if failed to download files recursively.