### PR TITLE
[le12] docker: update to 24.0.4 and addon (2)

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="a59902b54124c03cfd394ca56f3a625a4f332e2cc5f5512f34a04bfe2b0f297c"
+PKG_SHA256="dc1d025fd16b113a1a7e2a5d34c30409613d9c4ec313937f17bf34991caf597f"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="24.0.3"
-PKG_SHA256="71d21d4533ebc2f344a3c0f21f5791bdd4a41a30ce158697a3bb3c4b6f3d89d6"
+PKG_VERSION="24.0.4"
+PKG_SHA256="84f6196fc58ae263376a4ce25b5136d567a93aa82e723504a29f0415bd1fa4f4"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
log:
- https://github.com/moby/moby/compare/v24.0.3...v24.0.4

Fix a regression introduced during 24.0.3 that causes a panic during live-restore of containers with bind mounts.