### PR TITLE
Update libfmt to 10.1.1 with spdlog 1.12.0

### DIFF
--- a/packages/devel/flatbuffers/package.mk
+++ b/packages/devel/flatbuffers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flatbuffers"
-PKG_VERSION="23.3.3"
-PKG_SHA256="8aff985da30aaab37edf8e5b02fda33ed4cbdd962699a8e2af98fdef306f4e4d"
+PKG_VERSION="23.5.26"
+PKG_SHA256="1cce06b17cddd896b6d73cc047e36a254fb8df4d7ea18a46acf16c4c0cd3f3f3"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/google/flatbuffers"
 PKG_URL="https://github.com/google/flatbuffers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libfmt"
-PKG_VERSION="9.1.0"
-PKG_SHA256="5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2"
+PKG_VERSION="10.1.1"
+PKG_SHA256="78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/fmtlib/fmt"
 PKG_URL="https://github.com/fmtlib/fmt/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/spdlog/package.mk
+++ b/packages/devel/spdlog/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spdlog"
-PKG_VERSION="1.11.0"
-PKG_SHA256="ca5cae8d6cac15dae0ec63b21d6ad3530070650f68076f3a4a862ca293a858bb"
+PKG_VERSION="1.12.0"
+PKG_SHA256="4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/gabime/spdlog"
 PKG_URL="https://github.com/gabime/spdlog/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- libfmt: update to 10.1.0
  - https://github.com/fmtlib/fmt/releases/tag/10.0.0
  - https://github.com/fmtlib/fmt/releases/tag/10.1.0
  - https://github.com/fmtlib/fmt/releases/tag/10.1.1
- spdlog: update to 1.12.0
  - https://github.com/gabime/spdlog/releases/tag/v1.12.0
- flatbuffers: update to 23.5.26

Dependant on 
- #7951
- https://github.com/xbmc/xbmc/pull/23453