### PR TITLE
stress-ng: workaround cross compilation issue since 0.15.09

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/patches/stress-ng-0001-workaround-cross-compilation-issue.patch
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/patches/stress-ng-0001-workaround-cross-compilation-issue.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.config	2023-07-13 07:58:21.000000000 +0000
++++ b/Makefile.config	2023-07-16 05:05:35.766646855 +0000
+@@ -311,7 +311,7 @@
+ compiler: configdir
+ 	@echo "checking compiler ..."
+ 	@$(CC) test/test-compiler.c -o test/test-compiler
+-	@echo "" > $(CONFIGS)/$$(./test/test-compiler)
++	@echo "" > $(CONFIGS)/HAVE_COMPILER_GCC
+ 	@rm -f test/test-compiler
+ 	$(call check,test-glibc,HAVE_GLIBC,using glibc)
+ 


### PR DESCRIPTION
- ref: https://github.com/ColinIanKing/stress-ng/issues/300
- fixes #7981 