### PR TITLE
[le12] Update dosbox game add-ons with new buttonmaps

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox-pure/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox-pure/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dosbox-pure"
-PKG_VERSION="0.9.7.25-Nexus"
-PKG_SHA256="392eae190bf335b170707b9c38359fb44f708e9e61bc0c3b67514247c8e59aa9"
+PKG_VERSION="0.9.7.26-Nexus"
+PKG_SHA256="62f883b0eb62d59a645c9870bf2c832a4e9cbee04cd61bc381258240a73236a2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dosbox"
-PKG_VERSION="0.74.0.25-Nexus"
-PKG_SHA256="6f52fb2ff65ce66f217dbd4719c7df765a13a8df8e08ada2bc8c6d829ebd43ec"
+PKG_VERSION="0.74.0.26-Nexus"
+PKG_SHA256="ec3c47d7a7cd2925d5212588554fcd7f93b43892a1ab0f0008fad38973fd505d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
## Description

This PR updates the two existing dosbox cores, dosbox and dosbox-pure, with buttonmaps added/corrected upstream:

* https://github.com/kodi-game/game.libretro.dosbox/pull/14
* https://github.com/kodi-game/game.libretro.dosbox-pure/pull/1

## How has this been tested?

Successfully compiled both dosbox cores for Generic x86.
