### PR TITLE
[le11] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="20.3.9-Nexus"
-PKG_SHA256="02bc1048115c4affd0bf3f6cbb6ea15b06b1830831ba1892668334b99f7097a7"
+PKG_VERSION="20.3.11-Nexus"
+PKG_SHA256="ed266d2a51efcd0952cfacc8549350282dce07f7c0e885eeb41d662f123e12a6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="20.1.9-Nexus"
-PKG_SHA256="b1b379e7eb24a16702745c78a57b2f246a013becf5c2daf7579651cbf2188b82"
+PKG_VERSION="20.1.10-Nexus"
+PKG_SHA256="b72277358df77ed79a0e7f3ae7e9799d02692fb30408cf6e5325ce7e5a34f597"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="20.3.11-Nexus"
-PKG_SHA256="2ba11498d9cdededb78ed515f7964e0e155776b78b6d34d127fca07b679840e7"
+PKG_VERSION="20.3.13-Nexus"
+PKG_SHA256="5a2fa7655b3c62912341f453a98df81fa47e53c3c54a4e9bea47a4a85f4d2a20"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 20.3.9-Nexus to 20.3.11-Nexus
- peripheral.joystick: update 20.1.9-Nexus to 20.1.10-Nexus
- pvr.zattoo: update 20.3.11-Nexus to 20.3.13-Nexus