### PR TITLE
Development tool package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.20.5"
-PKG_SHA256="a6a973d94004fb63331b151d2453b9b58a6d58cc046b86ae86033cd0f02fcaef"
+PKG_VERSION="1.20.6"
+PKG_SHA256="baaebb7ad7f0054ac4f7fd39ec6e1fec17e187301cc479f499fab7ac61ca58c7"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.26.4"
-PKG_SHA256="313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208"
+PKG_VERSION="3.27.0"
+PKG_SHA256="aaeddb6b28b993d0a6e32c88123d728a17561336ab90e0bf45032383564d3cb8"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fakeroot"
-PKG_VERSION="1.31"
-PKG_SHA256="63886d41e11c56c7170b9d9331cca086421b350d257338ef14daad98f77e202f"
+PKG_VERSION="1.32.1"
+PKG_SHA256="c072b0f65bafc4cc5b6112f7c61185f5170ce4cb0c410d1681c1af4a183e94e6"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://tracker.debian.org/pkg/fakeroot"
 PKG_URL="http://ftp.debian.org/debian/pool/main/f/fakeroot/${PKG_NAME}_${PKG_VERSION}.orig.tar.gz"

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="1.1.1"
-PKG_SHA256="d04b541f97ca439fb82fab7d0d480988be4bd4e62563a5ca35fadb5400727b1c"
+PKG_VERSION="1.2.0"
+PKG_SHA256="1c0b634fe6b6a7072e398647f1bf392048577068a5c92ae44d04085dab0ded6f"
 PKG_LICENSE="Apache"
 PKG_SITE="http://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="8fd2d9806f0601feab1485f79e46d1441af2158c68abf56788ff355d5c6b4ab5"
+    PKG_SHA256="13e8ff23d6af976a45f3ab451bf698e318a8d1823d588ff8a989555096f894a8"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="b932b2d562a1383b1fae5e2931f85fd5ea0cbb5da2c7605d5382d7d2680efd7f"
+    PKG_SHA256="58676cd9935d148d0faff5c72fb5ea67995245ccdbd3df6b5f7d7637fb696a62"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="650e7a890a52869cd14e2305652bff775aec7fc2cf47fc62cf4a89ff07242333"
+    PKG_SHA256="fe6fb520f59966300ee661d18b37c36cb3e614877c4c01dfedf987b8a9c577e9"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="966e85187b6b76dc520b23aadc886c5fe54b209a21c68f959ff00ef8542b7f9f"
+    PKG_SHA256="58542a0ab1162ce05a45eb751793782dc24c5bf8eb9a7467317f254260305ea6"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="6ad1231aeb34fef9c9db267859b0db3c6846bbade8227e6c9f456b6264c1278c"
+    PKG_SHA256="452fda324514d5c2431a6c66f376a1369b7199cfa0464f8e669af3b196dabccc"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="0c0129717da1e27ccf2c56da950d2fe56973f71beec9e80ae6904b282d2f0ee9"
+    PKG_SHA256="98ae6530c3a41167e9d93d11ea078be98a02f6d809a06d0d51af3ce0f73150d7"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.70.0"
-PKG_SHA256="b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c"
+PKG_VERSION="1.71.0"
+PKG_SHA256="a667e4abdc5588ebfea35c381e319d840ffbf8d2dbfb79771730573642034c96"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="71698cf444eef74050db821dc4df996c0f268615230099cde836e685e5b5465d"
+    PKG_SHA256="e61b6e34df8c3a002798a9f627c4da701d66f9fc066a70264e354b03d06e6722"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="c5c8e339dccf1ca893434cd08516a399e991891668d219f335f35dcd251d2bb3"
+    PKG_SHA256="c24287f1e694bc51080fa7d26e3c08a8971978e72f8c6184a2d61f58f7744df8"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="7d891d3e9bc4f1151545c83cbe3bc6af9ed234388c45ca2e19641262f48615e2"
+    PKG_SHA256="c293d906769671d1cd18e945671bbd14e0b8a41df5075c47f33e6086fc8a1558"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- rust-std-snapshot: update to 1.71.0
- cargo-snapshot: update to 1.71.0
- rustc-snapshot: update to 1.71.0
- rust: update to 1.71.0
- fakeroot: update to 1.32.1
- go: update to 1.20.6
- cmake: update to 3.27.0
- meson: update to 1.2.0