### PR TITLE
[le12] samba: update to 4.17.10

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.9"
-PKG_SHA256="ef1c327220f2bf433f44f85a3948785959960634f46cc84fb67389697b3490a6"
+PKG_VERSION="4.17.10"
+PKG_SHA256="00dbb0aac9f4cfee800f708f4e9098964a43a7646e618230706d532c9bb6c350"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
```
                   ===============================
                   Release Notes for Samba 4.17.10
                            July 19, 2023
                   ===============================


This is a security release in order to address the following defects:

o CVE-2022-2127:  When winbind is used for NTLM authentication, a maliciously
                  crafted request can trigger an out-of-bounds read in winbind
                  and possibly crash it.
                  https://www.samba.org/samba/security/CVE-2022-2127.html

o CVE-2023-3347:  SMB2 packet signing is not enforced if an admin configured
                  "server signing = required" or for SMB2 connections to Domain
                  Controllers where SMB2 packet signing is mandatory.
                  https://www.samba.org/samba/security/CVE-2023-3347.html

o CVE-2023-34966: An infinite loop bug in Samba's mdssvc RPC service for
                  Spotlight can be triggered by an unauthenticated attacker by
                  issuing a malformed RPC request.
                  https://www.samba.org/samba/security/CVE-2023-34966.html

o CVE-2023-34967: Missing type validation in Samba's mdssvc RPC service for
                  Spotlight can be used by an unauthenticated attacker to
                  trigger a process crash in a shared RPC mdssvc worker process.
                  https://www.samba.org/samba/security/CVE-2023-34967.html

o CVE-2023-34968: As part of the Spotlight protocol Samba discloses the server-
                  side absolute path of shares and files and directories in
                  search results.
                  https://www.samba.org/samba/security/CVE-2023-34968.html


Changes since 4.17.9
--------------------

o  Ralph Boehme <slow@samba.org>
   * BUG 15072: CVE-2022-2127.
   * BUG 15340: CVE-2023-34966.
   * BUG 15341: CVE-2023-34967.
   * BUG 15388: CVE-2023-34968.
   * BUG 15397: CVE-2023-3347.

o  Volker Lendecke <vl@samba.org>
   * BUG 15072: CVE-2022-2127.

o  Stefan Metzmacher <metze@samba.org>
   * BUG 15418: Secure channel faulty since Windows 10/11 update 07/2023.
```