### PR TITLE
fakeroot: fix missing header file race condition

### DIFF
--- a/packages/devel/fakeroot/patches/fakeroot-002-fix-missing-header-file-race-condition-1041674.patch
+++ b/packages/devel/fakeroot/patches/fakeroot-002-fix-missing-header-file-race-condition-1041674.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.am	2023-07-21 22:53:36.152522891 +0000
++++ b/Makefile.am	2023-07-22 00:12:21.796916350 +0000
+@@ -58,6 +58,8 @@
+ 
+ libfakeroot.lo:libfakeroot.c wrapdef.h wrapstruct.h wraptmpf.h
+ 
++libfakeroot_time64.c:wrapped.h
++
+ fakerootconfig.h: ./config.status
+ 	CONFIG_FILES= CONFIG_HEADERS= /bin/sh ./config.status
+ 


### PR DESCRIPTION
Unable to reproduce the build issue on my buildhost, but believe the proposed patch attached should fix the build issue on the GHA CI/CD. 
- https://github.com/LibreELEC/actions/actions/runs/5623416630/job/15238056958

ref:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1041674
