### PR TITLE
Toolchain package updates

### DIFF
--- a/packages/debug/libunwind/package.mk
+++ b/packages/debug/libunwind/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libunwind"
-PKG_VERSION="1.7.0"
-PKG_SHA256="e357fac5c203ea714230c3045b7e3aee4854112a3a72c391d81eedf1a5c7ca93"
+PKG_VERSION="1.7.2"
+PKG_SHA256="c76c4f340071ede486af6342d50e17747f7b0db1c05077c8f7c677c09b324f73"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.nongnu.org/libunwind/"
 PKG_URL="https://github.com/libunwind/libunwind/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.27.0"
-PKG_SHA256="aaeddb6b28b993d0a6e32c88123d728a17561336ab90e0bf45032383564d3cb8"
+PKG_VERSION="3.27.1"
+PKG_SHA256="b1a6b0135fa11b94476e90f5b32c4c8fad480bf91cf22d0ded98ce22c5132004"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/devel/mold/package.mk
+++ b/packages/devel/mold/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mold"
-PKG_VERSION="1.11.0"
-PKG_SHA256="99318eced81b09a77e4c657011076cc8ec3d4b6867bd324b8677974545bc4d6f"
-PKG_LICENSE="AGPL-3.0-or-later"
+PKG_VERSION="2.0.0"
+PKG_SHA256="2ae8a22db09cbff626df74c945079fa29c1e5f60bbe02502dcf69191cf43527b"
+PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/rui314/mold"
 PKG_URL="https://github.com/rui314/mold/archive/refs/tags/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="cmake:host zlib:host zstd:host openssl:host tbb:host mimalloc:host"

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc"
-PKG_VERSION="13.1.0"
-PKG_SHA256="61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86"
+PKG_VERSION="13.2.0"
+PKG_SHA256="e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://gcc.gnu.org/"
 PKG_URL="https://ftpmirror.gnu.org/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- gcc: update to 13.2.0
- mold: update to 2.0.0 and license change to MIT
- cmake: update to 3.27.1
- libunwind: update to 1.7.2