### PR TITLE
glibc update to 2.38 and binutils 2.41

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/patches/fmpegx-0001-Fixes-assembling-with-binutils-as-2.41.patch
+++ b/packages/addons/addon-depends/ffmpegx/patches/fmpegx-0001-Fixes-assembling-with-binutils-as-2.41.patch
@@ -1,0 +1,84 @@
+From effadce6c756247ea8bae32dc13bb3e6f464f0eb Mon Sep 17 00:00:00 2001
+From: =?utf8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+Date: Sun, 16 Jul 2023 18:18:02 +0300
+Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+ instructions within inline assembly
+
+Fixes assembling with binutils as >= 2.41
+
+Upstream: http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=effadce6c756247ea8bae32dc13bb3e6f464f0eb
+
+Bug reports for this change in binutils:
+https://fftrac-bg.ffmpeg.org/ticket/10405
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108941
+https://sourceware.org/bugzilla/show_bug.cgi?id=30578
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
+---
+ libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed19..ca7e2dffc1 100644
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+-- 
+2.30.2
+

--- a/packages/audio/alsa-utils/patches/alsa-utils-PR225.patch
+++ b/packages/audio/alsa-utils/patches/alsa-utils-PR225.patch
@@ -1,0 +1,36 @@
+From f912b09ec2737e4a479396f4696f7a97213fd3d0 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 22 Jul 2023 15:36:09 +0000
+Subject: [PATCH] alsactl: add define to compile with glibc 2.38
+
+strlcat and strlcpy have been added to glibc 2.38.
+update the defines to use the glibc versions, and not conflict with
+string.h.
+
+ref:
+- https://sourceware.org/git/?p=glibc.git;a=commit;h=454a20c8756c9c1d55419153255fc7692b3d2199
+---
+ alsactl/init_sysdeps.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/alsactl/init_sysdeps.c b/alsactl/init_sysdeps.c
+index 3aca1b4..f09b1ae 100644
+--- a/alsactl/init_sysdeps.c
++++ b/alsactl/init_sysdeps.c
+@@ -18,6 +18,7 @@
+  */
+ 
+ #if defined(__GLIBC__) && !(defined(__UCLIBC__) && defined(__USE_BSD))
++#if !(__GLIBC_PREREQ(2, 38))
+ static size_t strlcpy(char *dst, const char *src, size_t size)
+ {
+ 	size_t bytes = 0;
+@@ -60,4 +61,5 @@ static size_t strlcat(char *dst, const char *src, size_t size)
+ 	*q = '\0';
+ 	return bytes;
+ }
++#endif /* !(__GLIBC_PREREQ(2, 38)) */
+ #endif /* __GLIBC__ */
+-- 
+2.34.1
+

--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.40"
-PKG_SHA256="0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1"
+PKG_VERSION="2.41"
+PKG_SHA256="ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/binutils/"
 PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glibc"
-PKG_VERSION="2.37"
-PKG_SHA256="2257eff111a1815d74f46856daaf40b019c1e553156c69d48ba0cbfc1bb91a43"
+PKG_VERSION="2.38"
+PKG_SHA256="fb82998998b2b29965467bc1b69d152e9c307d2cf301c9eafb4555b770ef3fd2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/libc/"
 PKG_URL="https://ftp.gnu.org/pub/gnu/glibc/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -26,6 +26,7 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --disable-sanity-checks \
                            --enable-add-ons \
                            --enable-bind-now \
+                           --enable-crypt \
                            --with-elf \
                            --with-tls \
                            --with-__thread \

--- a/packages/multimedia/ffmpeg/patches/fmpegx-0001-Fixes-assembling-with-binutils-as-2.41.patch
+++ b/packages/multimedia/ffmpeg/patches/fmpegx-0001-Fixes-assembling-with-binutils-as-2.41.patch
@@ -1,0 +1,84 @@
+From effadce6c756247ea8bae32dc13bb3e6f464f0eb Mon Sep 17 00:00:00 2001
+From: =?utf8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+Date: Sun, 16 Jul 2023 18:18:02 +0300
+Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+ instructions within inline assembly
+
+Fixes assembling with binutils as >= 2.41
+
+Upstream: http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=effadce6c756247ea8bae32dc13bb3e6f464f0eb
+
+Bug reports for this change in binutils:
+https://fftrac-bg.ffmpeg.org/ticket/10405
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108941
+https://sourceware.org/bugzilla/show_bug.cgi?id=30578
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
+---
+ libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed19..ca7e2dffc1 100644
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+-- 
+2.30.2
+

--- a/packages/network/libdnet/package.mk
+++ b/packages/network/libdnet/package.mk
@@ -13,9 +13,7 @@ PKG_LONGDESC="A simplified, portable interface to several low-level networking r
 PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_strlcat=no \
-                           ac_cv_func_strlcpy=no \
-                           --enable-static \
+PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \
                            --disable-python"
 


### PR DESCRIPTION
- glibc: update to 2.38
  - alsactl: add define to compile with glibc 2.38
    - https://github.com/alsa-project/alsa-utils/pull/225
  - libdnet: update to compile with glibc 2.38
- binutils: update to 2.41