### PR TITLE
intel-ucode: update to 20230808

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20230613"
-PKG_SHA256="894d822d2347222a2595d4fc47d358e01d35a54780123100c317dfc31b1b0cc9"
+PKG_VERSION="20230808"
+PKG_SHA256="fe49bb719441f20335ed6004090ab38cdc374134d36d4f5d30be7ed93b820313"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"


### PR DESCRIPTION
release notes:
    - https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20230808

on ADL `[    0.000000] microcode: updated early: 0x42a -> 0x42c, date = 2023-04-18`