### PR TITLE
templates: issue template improvements and links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: Bug Report
 about: Describe this issue
 title: "[BUG]"
 labels: ISSUE NEEDS REVIEW
@@ -8,21 +8,21 @@ assignees: ''
 ---
 
 ### Describe the bug
-<!--- A clear description of what the bug is. -->
+<!-- A clear description of what the bug is. -->
 
-### To Reproduce
+### How to reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Play '....'
 3. See error
 
-### Informations
- - LE Version: [e.g. 9.2.1]
+### Information
+ - LibreELEC Version: [e.g. 9.2.1]
  - Hardware Platform: [e.g. RPi3]
 
 ### Log file
-<!-- Add log files (https://libreelec.wiki/how_to/provide_logfile) that we can search for errors. -->
+<!-- Add debug log files (https://libreelec.wiki/how_to/provide_logfile) that we can search for errors. -->
 
-### Additional context
-<!--- Add any other context about the problem here. -->
+### Context
+<!-- Add any context about the problem here. -->
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Help and Support
+    url: https://forum.libreelec.tv
+    about: Please ask for help and post questions in the forum
+  - name: Feature Requests
+    url: https://forum.libreelec.tv/board/18-feature-requests/
+    about: Please make feature requests via the forum


### PR DESCRIPTION
This cleans up the bug-report template a little, and we add links for general help and feature requests that take users to the forum. See https://github.com/python/cpython/issues/new/choose for an example of the latter.