### PR TITLE
Python3: update to 3.11.5

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.11.4"
-PKG_SHA256="2f0e409df2ab57aa9fc4cbddfb976af44e4e55bf6f619eee6bc5c2297264a7f6"
+PKG_VERSION="3.11.5"
+PKG_SHA256="85cd12e9cf1d6d5a45f17f7afe1cebe7ee628d3282281c492e86adf636defa3f"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.python.org/"
 PKG_URL="https://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Announcement:
- https://pythoninsider.blogspot.com/2023/08/python-3115-31013-3918-and-3818-is-now.html 

```
=== tested on ===
Python Version: 3.11.5 (main, Aug 25 2023, 12:43:15) [GCC 13.2.0]
Generic.x86_64-devel-20230825122859-af08c28
Linux nuc12 6.5.0-rc7 #1 SMP Fri Aug 25 12:50:16 UTC 2023 x86_64 GNU/Linux
Starting Kodi (21.0-ALPHA2 (20.90.201) Git:f5ab9fd5d2d6d3589470208a774bbfa757a63ee9). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2023-08-25 by GCC 13.2.0 for Linux x86 64-bit version 6.5.0 (394496)
Running on LibreELEC (heitbaum): devel-20230825122859-af08c28 12.0, kernel: Linux x86 64-bit version 6.5.0-rc7
FFmpeg version/source: 6.0
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0088.2023.0505.1623 05/05/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.1.6
libva info: VA-API version 1.19.0
vainfo: VA-API version: 1.19 (libva 2.19.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.3.1 (af08c2816e)
```