### PR TITLE
rust: update to 1.72.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="be9d4ffb39e0e39758fca3bf8ef4e98a2de6411cb6ee4e45eff3810316cba93d"
+    PKG_SHA256="95741a4cd2073adbd74a7c5596bb912abf4b2dfe00d70a9919cba4a836b7a0ff"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="d64e60f493788a8577b6f8d715d89f348630ed5fcbc61909740289e5a6971072"
+    PKG_SHA256="519a572195a119bda9f09cb00e3d82d1ee6f992d58b403c39c0d515d35bcc7f8"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="55760c2f20356fe5cb2a4aa105e20693a573048f1dbc9daa41a0983fc0930b15"
+    PKG_SHA256="4a401dfe7b3056dc0d42acbcd380b2b90f936577706ca74ef5327af0f5abd0a0"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="232afbb1b8673694742eba6444ee7c70294ca6da285cdeef9d43acd3f4c58ddc"
+    PKG_SHA256="41d259c6f84280fd0e7719fea03a7583ba54e33e8ac32a2a7b703ffb0aebb7d9"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="4720dee4efe1cbcf7c21ba3a5806dbfb6f7f04e67dec1a79c3fd61d5fd2deea3"
+    PKG_SHA256="4ef1c8df3dbc0160212afafc8bf643e5bbb40b0147b163f2f5e964a52fc8c217"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="31f392df564850d78be80adc625b06a3964a49ef5c519075b930f2042a422264"
+    PKG_SHA256="36f27513a6e4381f15b0cd14097c885af537f990cb6193cec3337c429367bf23"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.71.1"
-PKG_SHA256="6fa90d50d1d529a75f6cc349784de57d7ec0ba2419b09bde7d335c25bd4e472e"
+PKG_VERSION="1.72.0"
+PKG_SHA256="ea9d61bbb51d76b6ea681156f69f0e0596b59722f04414b01c6e100b4b5be3a1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="44a78d6643a2fc27324ec18e519f951bfa7e1040657fe9165c764375aea3b416"
+    PKG_SHA256="1948a80453956d494457dcced1942e2e204fb26d4e57e718ef1c7aa378efbedb"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="9247eae46b8fb9a4313a83089eaa4e484ccbcdedd5889256bc4329f516db7e94"
+    PKG_SHA256="1588da5bdb52d6be5d0d5135ad45cc2138073380993378ba143cc536663c29a6"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="9a8a12b6c2a6f67d75ead0f343f891b78672c59387d1be28b46f3161ec2b251d"
+    PKG_SHA256="5b5d7854a0d73368f15146c1aa47e4dbccf12762c93282f410a09a605929ce09"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
Announcement:
- https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html

updates:
- cargo-snapshot: update to 1.72.0
- rustc-snapshot: update to 1.72.0
- rust-std-snapshot: update to 1.72.0
- rust: update to 1.72.0