### PR TITLE
Vulkan update to 1.3.262

### DIFF
--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers pkg_version/s need to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools & spirv-headers pkg_version/s.
-PKG_VERSION="12.3.1"
-PKG_SHA256="a57836a583b3044087ac51bb0d5d2d803ff84591d55f89087fc29ace42a8b9a8"
+PKG_VERSION="13.0.0"
+PKG_SHA256="bcda732434f829aa74414ea0e06d329ec8ac28637c38a0de45e17c8fd25a4715"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-headers/package.mk
+++ b/packages/graphics/vulkan/spirv-headers/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-headers"
 # The SPIRV-Headers pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-headers pkg_version.
-PKG_VERSION="f1ba373ef03752ee9f6f2b898bea1213f93e1ef2"
-PKG_SHA256="a73040eb4fca2b480b1ca6e542444a94ecf429837e0b6deb3e2f873e654a4174"
+PKG_VERSION="124a9665e464ef98b8b718d572d5f329311061eb"
+PKG_SHA256="a039140fa01380be8cbe19bbb4f1bb475a620bac7eb80b290fd407c5ff1118e0"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-tools/package.mk
+++ b/packages/graphics/vulkan/spirv-tools/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-tools"
 # The SPIRV-Tools pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools pkg_version.
-PKG_VERSION="4b6bd5a665ba0529747af3a0bc808732b7e78f48"
-PKG_SHA256="890d9e33b8bb79a8799a2887b442e55c93db0a4db94252339c915a1d90857505"
+PKG_VERSION="89ca3aa571fe238944b31e88d5d8fe75fab0227a"
+PKG_SHA256="6f401744c1f1e1fb30f39f189a18858b3e98000ce3bf0537b634d2cab78bda40"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.261"
-PKG_SHA256="0c67b2b76a7d6534c0f98085dbbcd4a1ac945b15b269bc81ee7dbe6cf28d53bb"
+PKG_VERSION="1.3.262"
+PKG_SHA256="317e467a5fb2eaa6a18b984ec70fdbfaccd93595a3e6f4bcceca7d3fab280505"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.261"
-PKG_SHA256="85d13004c81b032baf7cc4c2de0b2cb57072a86855d7ca7fc9a813621da275ba"
+PKG_VERSION="1.3.262"
+PKG_SHA256="3bbaa5ee64058a89949eb777de66ce94bfe3141892514172cfc9451c756802d5"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.261"
-PKG_SHA256="2e9a1b380f4e494934c72e2b2fb77d2c3ae03ba19fd36ffad65529413108db2f"
+PKG_VERSION="1.3.262"
+PKG_SHA256="8c77d02694d0516ae2ba3f3718745647e87e788ef93faabb2e3674ff32608010"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/blob/main/ChangeLog.adoc
- glslang: update to 13.0.0
- spirv-headers: update to githash 124a966
- spirv-tools: update to githash 89ca3aa
- vulkan-headers: update to 1.3.262
- vulkan-loader: update to 1.3.262
- vulkan-tools: update to 1.3.262