### PR TITLE
scripts/get_archive: force connection to github using TLSv1_2

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -34,7 +34,8 @@ NBCHKS=2
 while [ ${NBWGET} -gt 0 -a ${NBCHKS} -gt 0 ]; do
   for url in "${PKG_URL}" "${PACKAGE_MIRROR}"; do
     rm -f "${PACKAGE}"
-    if ${WGET_CMD} "${url}"; then
+    [[ "${url}" =~ github ]] && tls="--secure-protocol=TLSv1_2" || tls=""
+    if ${WGET_CMD} "${tls}" "${url}"; then
       CALC_SHA256=$(sha256sum "${PACKAGE}" | cut -d" " -f1)
 
       [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2


### PR DESCRIPTION
- see bug #8082

a quick TEMP fix. Not sure if the GitHub issue is transient.