### PR TITLE
systemd/busybox: fix unit permissions after systemd v254 bump

### DIFF
--- a/packages/sysutils/busybox/system.d/var-log.mount
+++ b/packages/sysutils/busybox/system.d/var-log.mount
@@ -3,6 +3,7 @@ Description=Persistent Log Storage
 RequiresMountsFor=/var /storage
 Requires=storage-log.service
 After=storage-log.service
+DefaultDependencies=no
 ConditionKernelCommandLine=!installer
 ConditionKernelCommandLine=|debugging
 ConditionPathExists=|/storage/.cache/debug.libreelec

--- a/packages/sysutils/systemd/system.d/machine-id.service
+++ b/packages/sysutils/systemd/system.d/machine-id.service
@@ -3,7 +3,6 @@ Description=Setup machine-id
 DefaultDependencies=no
 Conflicts=shutdown.target
 Before=systemd-journald.service systemd-tmpfiles-setup-dev.service shutdown.target
-After=local-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
machine-id.service fix for:
```
systemd[1]: local-fs.target: Found ordering cycle on local-fs-pre.target/start
systemd[1]: local-fs.target: Found dependency on systemd-tmpfiles-setup-dev.service/start
systemd[1]: local-fs.target: Found dependency on machine-id.service/start
systemd[1]: local-fs.target: Found dependency on local-fs.target/start
systemd[1]: local-fs.target: Job local-fs-pre.target/start deleted to break ordering cycle starting with local-fs.target/start
```
Resolve #8077

var-log.mount fix for:
```
systemd[1]: local-fs.target: Found ordering cycle on var-log.mount/start
systemd[1]: local-fs.target: Found dependency on local-fs-pre.target/start
systemd[1]: local-fs.target: Found dependency on systemd-tmpfiles-setup-dev.service/start
systemd[1]: local-fs.target: Found dependency on machine-id.service/start
systemd[1]: local-fs.target: Found dependency on local-fs.target/start
systemd[1]: local-fs.target: Job var-log.mount/start deleted to break ordering cycle starting with local-fs.target/start
```
The cycle is only visible with enabled persistent logs.