### PR TITLE
bluez: fix relocation of dbus-1/bluetooth.conf

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -55,7 +55,6 @@ post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/lib/systemd
   safe_remove ${INSTALL}/usr/bin/bluemoon
   safe_remove ${INSTALL}/usr/bin/ciptool
-  safe_remove ${INSTALL}/usr/share/dbus-1
 
   mkdir -p ${INSTALL}/etc/bluetooth
     cp src/main.conf ${INSTALL}/etc/bluetooth


### PR DESCRIPTION
- https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=fc6f5856d1775b39712b35049307afdd65df3d27
- https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=8b6432a8728f87aa328bd67f07a35a1e755d75e6
- https://github.com/bluez/bluez/pull/565

@smp79 / @chewitt / @lrusak - as reported / the suggested links. Indeed the make was generating the bluetooth.conf in the correct location, but we were safe_removing it.

built and run. Bluetooth again running as expected.