### PR TITLE
[le12] samba: update to 4.19.0

### DIFF
--- a/packages/network/samba/config/samba4-cache.txt
+++ b/packages/network/samba/config/samba4-cache.txt
@@ -45,4 +45,4 @@ Checking whether fcntl supports flags to send direct I/O availability signals: O
 Checking whether fcntl supports setting/geting hints: OK
 Checking for gnutls fips mode support: NO
 Checking for readlink breakage: NO
-
+Checking whether fcntl supports setting/getting hints: OK

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.10"
-PKG_SHA256="00dbb0aac9f4cfee800f708f4e9098964a43a7646e618230706d532c9bb6c350"
+PKG_VERSION="4.19.0"
+PKG_SHA256="28f98ceab75a6a59432912fa110fc8c716abcab1ed6d8bdd4393d178acff3d20"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"
@@ -20,12 +20,6 @@ configure_package() {
     SMB_AVAHI="--enable-avahi"
   else
     SMB_AVAHI="--disable-avahi"
-  fi
-
-  if [ "${TARGET_ARCH}" = x86_64 ]; then
-    SMB_AESNI="--accel-aes=intelaesni"
-  else
-    SMB_AESNI="--accel-aes=none"
   fi
 
   PKG_CONFIGURE_OPTS="--prefix=/usr \

--- a/packages/network/samba/patches/samba-200-4.11-fix-ASN1-bso14164.patch
+++ b/packages/network/samba/patches/samba-200-4.11-fix-ASN1-bso14164.patch
@@ -34,8 +34,7 @@ BUG: https://bugzilla.samba.org/show_bug.cgi?id=14164
 Signed-off-by: Uri Simchoni <uri@samba.org>
 ---
  wscript_configure_embedded_heimdal | 11 +++++++++++
- wscript_configure_system_heimdal   | 11 -----------
- 2 files changed, 11 insertions(+), 11 deletions(-)
+ 1 files changed, 11 insertions(+)
 
 diff --git a/wscript_configure_embedded_heimdal b/wscript_configure_embedded_heimdal
 index 8c55ae2..4fdae80 100644
@@ -56,33 +55,6 @@ index 8c55ae2..4fdae80 100644
 +
 +check_system_heimdal_binary("compile_et")
 +check_system_heimdal_binary("asn1_compile")
-diff --git a/wscript_configure_system_heimdal b/wscript_configure_system_heimdal
-index 235fa19..4f4a83cd 100644
---- a/wscript_configure_system_heimdal
-+++ b/wscript_configure_system_heimdal
-@@ -37,14 +37,6 @@ def check_system_heimdal_lib(name, functions='', headers='', onlyif=None):
-     conf.define('USING_SYSTEM_%s' % name.upper(), 1)
-     return True
- 
--def check_system_heimdal_binary(name):
--    if conf.LIB_MAY_BE_BUNDLED(name):
--        return False
--    if not conf.find_program(name, var=name.upper()):
--        return False
--    conf.define('USING_SYSTEM_%s' % name.upper(), 1)
--    return True
--
- check_system_heimdal_lib("com_err", "com_right_r com_err", "com_err.h")
- 
- if check_system_heimdal_lib("roken", "rk_socket_set_reuseaddr", "roken.h"):
-@@ -86,7 +78,4 @@ finally:
- #if conf.CHECK_BUNDLED_SYSTEM('tommath', checkfunctions='mp_init', headers='tommath.h'):
- #    conf.define('USING_SYSTEM_TOMMATH', 1)
- 
--check_system_heimdal_binary("compile_et")
--check_system_heimdal_binary("asn1_compile")
--
- conf.env.KRB5_VENDOR = 'heimdal'
 -- 
 2.20.1
 


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.18.0.html
- https://download.samba.org/pub/samba/rc/samba-4.19.0rc1.WHATSNEW.txt
- https://www.samba.org/samba/history/samba-4.19.0rc1.html
- https://www.samba.org/samba/history/samba-4.19.0rc2.html
- https://www.samba.org/samba/history/samba-4.19.0rc3.html
- https://www.samba.org/samba/history/samba-4.19.0rc4.html
- https://www.samba.org/samba/history/samba-4.19.0.html

drop accel-aes:
- https://github.com/samba-team/samba/commit/95c843de926ec46ab9d52ae8394250f93ee843c4