### PR TITLE
package updates

### DIFF
--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.3.5"
-PKG_SHA256="c0fda1fa6e52dc85de27156cd847088a72d40d9de6514f7efa57c8d93134a54c"
+PKG_VERSION="3.3.6"
+PKG_SHA256="95006761ed80c17a24245c0b44a38850e47c8175201cf6ff6d5e1afcf2732dea"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/patchelf/package.mk
+++ b/packages/devel/patchelf/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="patchelf"
+PKG_VERSION="0.18.0"
+PKG_SHA256="1952b2a782ba576279c211ee942e341748fdb44997f704dd53def46cd055470b"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/NixOS/patchelf"
+PKG_URL="https://github.com/NixOS/patchelf/releases/download/${PKG_VERSION}/patchelf-${PKG_VERSION}.tar.bz2"
+PKG_DEPENDS_HOST="toolchain:host"
+PKG_LONGDESC="A small utility to modify the dynamic linker and RPATH of ELF executables"
+PKG_TOOLCHAIN="autotools"

--- a/packages/graphics/pango/package.mk
+++ b/packages/graphics/pango/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pango"
-PKG_VERSION="1.50.14"
-PKG_SHA256="1d67f205bfc318c27a29cfdfb6828568df566795df0cb51d2189cde7f2d581e8"
+PKG_VERSION="1.51.0"
+PKG_SHA256="74efc109ae6f903bbe6af77eaa2ac6094b8ee245a2e23f132a7a8f0862d1a9f5"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.pango.org/"
 PKG_URL="https://download.gnome.org/sources/pango/${PKG_VERSION:0:4}/pango-${PKG_VERSION}.tar.xz"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.55.1"
-PKG_SHA256="19490b7c8c2ded1cf7c3e3a54ef4304e3a7876ae2d950d60a81d0dc6053be419"
+PKG_VERSION="1.56.0"
+PKG_SHA256="65eee8021e9d3620589a4a4e91ce9983d802b5229f78f3313770e13f4d2720e9"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- mariadb-connector-c: update to 3.3.6
- nghttp2: update to 1.56.0
- pango: update to 1.51.0
- patchelf: initial package
  - to support #7602 activity