### PR TITLE
[le11] samba: update to 4.17.11

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.17.10"
-PKG_SHA256="00dbb0aac9f4cfee800f708f4e9098964a43a7646e618230706d532c9bb6c350"
+PKG_VERSION="4.17.11"
+PKG_SHA256="badcf603b211ec279a210679c370fba72dfa53f8fbeef8eb39486cd27bccceea"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.17.11.html

```
Release Announcements
---------------------

This is the latest stable release of the Samba 4.17 release series.


Changes since 4.17.10
---------------------

o  Jeremy Allison <[jra@samba.org](mailto:jra@samba.org)>
    * BUG 15419: Weird filename can cause assert to fail in
      openat_pathref_fsp_nosymlink().
    * BUG 15420: reply_sesssetup_and_X() can dereference uninitialized tmp
      pointer.
    * BUG 15430: Missing return in reply_exit_done().
    * BUG 15432: TREE_CONNECT without SETUP causes smbd to use uninitialized
      pointer.

o  Andrew Bartlett <[abartlet@samba.org](mailto:abartlet@samba.org)>
    * BUG 15401: Improve GetNChanges to address some (but not all "Azure AD
      Connect") syncronisation tool looping during the initial user sync
phase.
    * BUG 15407: Samba replication logs show (null) DN.
    * BUG 9959: Windows client join fails if a second container
CN=System exists
     somewhere.

o  Ralph Boehme <[slow@samba.org](mailto:slow@samba.org)>
    * BUG 15342: Spotlight sometimes returns no results on latest macOS.
    * BUG 15417: Renaming results in NT_STATUS_SHARING_VIOLATION if
previously
      attempted to remove the destination.
    * BUG 15427: Spotlight results return wrong date in result list.
    * BUG 15463: macOS mdfind returns only 50 results.

o  Volker Lendecke <[vl@samba.org](mailto:vl@samba.org)>
    * BUG 15346: 2-3min delays at reconnect with
smb2_validate_sequence_number:
      bad message_id 2.

o  Stefan Metzmacher <[metze@samba.org](mailto:metze@samba.org)>
    * BUG 15346: 2-3min delays at reconnect with
smb2_validate_sequence_number:
      bad message_id 2.
    * BUG 15441: samba-tool ntacl get segfault if aio_pthread appended.
    * BUG 15446: DCERPC_PKT_CO_CANCEL and DCERPC_PKT_ORPHANED can't be
parsed.

o  MikeLiu <[mikeliu@qnap.com](mailto:mikeliu@qnap.com)>
    * BUG 15453: File doesn't show when user doesn't have permission if
      aio_pthread is loaded.

o  Noel Power <[noel.power@suse.com](mailto:noel.power@suse.com)>
    * BUG 15384: net ads lookup (with unspecified realm) fails
    * BUG 15435: Regression DFS not working with widelinks = true.

o  Arvid Requate <[requate@univention.de](mailto:requate@univention.de)>
    * BUG 9959: Windows client join fails if a second container
CN=System exists
     somewhere.

o  Martin Schwenke <[mschwenke@ddn.com](mailto:mschwenke@ddn.com)>
    * BUG 15451: ctdb_killtcp fails to work with --enable-pcap and libpcap ≥
      1.9.1.

o  Jones Syue <[jonessyue@qnap.com](mailto:jonessyue@qnap.com)>
    * BUG 15441: samba-tool ntacl get segfault if aio_pthread appended.
    * BUG 15449: mdssvc: Do an early talloc_free() in _mdssvc_open().
```