### PR TITLE
[le11] linux: add patch to fix broken channel map reporting in hdmi-codec

### DIFF
--- a/packages/linux/patches/default/linux-022-ASoC-hdmi-codec-Fix-broken-channel-map-reporting.patch
+++ b/packages/linux/patches/default/linux-022-ASoC-hdmi-codec-Fix-broken-channel-map-reporting.patch
@@ -1,0 +1,52 @@
+From a154f37e6803ffeb77156ba2c3e23c00c511c60d Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Thu, 7 Sep 2023 20:33:25 +0200
+Subject: [PATCH] ASoC: hdmi-codec: Fix broken channel map reporting
+
+Commit 5fe680b23327 ("ASoC: hdmi-codec: fix channel info for
+compressed formats") accidentally changed hcp->chmap_idx from
+ca_id, the CEA channel allocation ID, to idx, the index to
+the table of channel mappings ordered by preference.
+
+This resulted in wrong channel maps being reported to userspace,
+eg for 5.1 "FL,FR,LFE,FC" was reported instead of the expected
+"FL,FR,LFE,FC,RL,RR":
+
+~ # speaker-test -c 6 -t sine
+...
+ 0 - Front Left
+ 3 - Front Center
+ 1 - Front Right
+ 2 - LFE
+ 4 - Unknown
+ 5 - Unknown
+
+~ # amixer cget iface=PCM,name='Playback Channel Map' | grep ': values'
+  : values=3,4,8,7,0,0,0,0
+
+Revert this incorrect change so that channel maps are properly
+reported again.
+
+Fixes: 5fe680b23327 ("ASoC: hdmi-codec: fix channel info for compressed formats")
+Cc: stable@vger.kernel.org
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ sound/soc/codecs/hdmi-codec.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sound/soc/codecs/hdmi-codec.c b/sound/soc/codecs/hdmi-codec.c
+index 13689e718d36f..c8e48225598f8 100644
+--- a/sound/soc/codecs/hdmi-codec.c
++++ b/sound/soc/codecs/hdmi-codec.c
+@@ -531,7 +531,7 @@ static int hdmi_codec_fill_codec_params(struct snd_soc_dai *dai,
+ 	hp->sample_rate = sample_rate;
+ 	hp->channels = channels;
+ 
+-	hcp->chmap_idx = idx;
++	hcp->chmap_idx = ca_id;
+ 
+ 	return 0;
+ }
+-- 
+2.39.2
+

--- a/packages/linux/patches/raspberrypi/linux-022-ASoC-hdmi-codec-Fix-broken-channel-map-reporting.patch
+++ b/packages/linux/patches/raspberrypi/linux-022-ASoC-hdmi-codec-Fix-broken-channel-map-reporting.patch
@@ -1,0 +1,52 @@
+From a154f37e6803ffeb77156ba2c3e23c00c511c60d Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Thu, 7 Sep 2023 20:33:25 +0200
+Subject: [PATCH] ASoC: hdmi-codec: Fix broken channel map reporting
+
+Commit 5fe680b23327 ("ASoC: hdmi-codec: fix channel info for
+compressed formats") accidentally changed hcp->chmap_idx from
+ca_id, the CEA channel allocation ID, to idx, the index to
+the table of channel mappings ordered by preference.
+
+This resulted in wrong channel maps being reported to userspace,
+eg for 5.1 "FL,FR,LFE,FC" was reported instead of the expected
+"FL,FR,LFE,FC,RL,RR":
+
+~ # speaker-test -c 6 -t sine
+...
+ 0 - Front Left
+ 3 - Front Center
+ 1 - Front Right
+ 2 - LFE
+ 4 - Unknown
+ 5 - Unknown
+
+~ # amixer cget iface=PCM,name='Playback Channel Map' | grep ': values'
+  : values=3,4,8,7,0,0,0,0
+
+Revert this incorrect change so that channel maps are properly
+reported again.
+
+Fixes: 5fe680b23327 ("ASoC: hdmi-codec: fix channel info for compressed formats")
+Cc: stable@vger.kernel.org
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ sound/soc/codecs/hdmi-codec.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sound/soc/codecs/hdmi-codec.c b/sound/soc/codecs/hdmi-codec.c
+index 13689e718d36f..c8e48225598f8 100644
+--- a/sound/soc/codecs/hdmi-codec.c
++++ b/sound/soc/codecs/hdmi-codec.c
+@@ -531,7 +531,7 @@ static int hdmi_codec_fill_codec_params(struct snd_soc_dai *dai,
+ 	hp->sample_rate = sample_rate;
+ 	hp->channels = channels;
+ 
+-	hcp->chmap_idx = idx;
++	hcp->chmap_idx = ca_id;
+ 
+ 	return 0;
+ }
+-- 
+2.39.2
+


### PR DESCRIPTION
Backport of #8122