### PR TITLE
alsa-lib: don't build with largefile support

### DIFF
--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -21,6 +21,7 @@ fi
 
 PKG_CONFIGURE_OPTS_TARGET="${PKG_ALSA_DEBUG} \
                            --disable-dependency-tracking \
+                           --disable-largefile \
                            --with-plugindir=/usr/lib/alsa \
                            --disable-python"
 


### PR DESCRIPTION
alsa-lib 1.2.10 enabled large file support by default on 32bit platforms which leads to a crash when kodi, speaker-test etc try to access the dmix PCM.

Disable large file support in configure to fix this.

See also: https://forum.libreelec.tv/thread/27500-libreelec-nightly-rpi2-latest-builds-fail-to-boot/

ping @heitbaum 