### PR TITLE
[le12] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="21.2.0-Omega"
-PKG_SHA256="f78bc2715f6ac88e433fc99717adca5d349c2015b2820d1e88f7caf7fd476915"
+PKG_VERSION="21.2.1-Omega"
+PKG_SHA256="136ebdd1836a68fb586cc3f4e688ad926342b6fde5691aaf299b8f56c6da263c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="21.1.6-Omega"
-PKG_SHA256="5edf825503f15980d0722083aa886944764a81daa0e8bd0ae3d14abd0302b474"
+PKG_VERSION="21.1.7-Omega"
+PKG_SHA256="80b64a8347111099b96aad6fed71d33ed46ba21838eab377b2eb4e807cdee563"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 21.2.0-Omega to 21.2.1-Omega
- peripheral.joystick: update 21.1.6-Omega to 21.1.7-Omega