### PR TITLE
[LE12] Allwinner: brcmfmac_sdio-firmware: update filter

### DIFF
--- a/projects/Allwinner/firmwares/brcmfmac_sdio-firmware.dat
+++ b/projects/Allwinner/firmwares/brcmfmac_sdio-firmware.dat
@@ -2,3 +2,4 @@
 BCM43430A1.def
 BCM43430A1.vim
 *.txt
+brcmfmac43456-sdio.bin


### PR DESCRIPTION
It turns out that one FW is missing, which is used on OrangePi 3.