### PR TITLE
NXP: iMX8: atf: Fix building v2.9

### DIFF
--- a/packages/tools/atf/package.mk
+++ b/packages/tools/atf/package.mk
@@ -21,7 +21,7 @@ fi
 
 make_target() {
   if [ "${ATF_PLATFORM}" = "imx8mq" ]; then
-    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="--param=min-pagesize=0" make PLAT=${ATF_PLATFORM} bl31
+    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="" make PLAT=${ATF_PLATFORM} LOG_LEVEL=0 bl31
   else
     CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="" make PLAT=${ATF_PLATFORM} bl31
   fi

--- a/projects/NXP/devices/iMX8/patches/atf/imx8mq-remove-ram-retention.patch
+++ b/projects/NXP/devices/iMX8/patches/atf/imx8mq-remove-ram-retention.patch
@@ -1,0 +1,124 @@
+diff --git a/plat/imx/imx8m/ddr/dram.c b/plat/imx/imx8m/ddr/dram.c
+index b5f697334e91..6adbdbf92eff 100644
+--- a/plat/imx/imx8m/ddr/dram.c
++++ b/plat/imx/imx8m/ddr/dram.c
+@@ -21,11 +21,6 @@ struct dram_info dram_info;
+ /* lock used for DDR DVFS */
+ spinlock_t dfs_lock;
+ 
+-#if defined(PLAT_imx8mq)
+-/* ocram used to dram timing */
+-static uint8_t dram_timing_saved[13 * 1024] __aligned(8);
+-#endif
+-
+ static volatile uint32_t wfe_done;
+ static volatile bool wait_ddrc_hwffc_done = true;
+ static unsigned int dev_fsp = 0x1;
+@@ -36,31 +31,6 @@ static uint32_t fsp_init_reg[3][4] = {
+ 	{ DDRC_FREQ2_INIT3(0), DDRC_FREQ2_INIT4(0), DDRC_FREQ2_INIT6(0), DDRC_FREQ2_INIT7(0) },
+ };
+ 
+-#if defined(PLAT_imx8mq)
+-static inline struct dram_cfg_param *get_cfg_ptr(void *ptr,
+-		void *old_base, void *new_base)
+-{
+-	uintptr_t offset = (uintptr_t)ptr & ~((uintptr_t)old_base);
+-
+-	return (struct dram_cfg_param *)(offset + new_base);
+-}
+-
+-/* copy the dram timing info from DRAM to OCRAM */
+-void imx8mq_dram_timing_copy(struct dram_timing_info *from)
+-{
+-	struct dram_timing_info *info = (struct dram_timing_info *)dram_timing_saved;
+-
+-	/* copy the whole 13KB content used for dram timing info */
+-	memcpy(dram_timing_saved, from, sizeof(dram_timing_saved));
+-
+-	/* correct the header after copied into ocram */
+-	info->ddrc_cfg = get_cfg_ptr(info->ddrc_cfg, from, dram_timing_saved);
+-	info->ddrphy_cfg = get_cfg_ptr(info->ddrphy_cfg, from, dram_timing_saved);
+-	info->ddrphy_trained_csr = get_cfg_ptr(info->ddrphy_trained_csr, from, dram_timing_saved);
+-	info->ddrphy_pie = get_cfg_ptr(info->ddrphy_pie, from, dram_timing_saved);
+-}
+-#endif
+-
+ #if defined(PLAT_imx8mp)
+ static uint32_t lpddr4_mr_read(unsigned int mr_rank, unsigned int mr_addr)
+ {
+@@ -231,10 +201,6 @@ void dram_info_init(unsigned long dram_timing_base)
+ 	dram_info.boot_fsp = current_fsp;
+ 	dram_info.current_fsp = current_fsp;
+ 
+-#if defined(PLAT_imx8mq)
+-	imx8mq_dram_timing_copy((struct dram_timing_info *)dram_timing_base);
+-	dram_timing_base = (unsigned long) dram_timing_saved;
+-#endif
+ 	get_mr_values(dram_info.mr_table);
+ 
+ 	dram_info.timing_info = (struct dram_timing_info *)dram_timing_base;
+diff --git a/plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c b/plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c
+index 7065a658614f..3c66baa291d6 100644
+--- a/plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c
++++ b/plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c
+@@ -21,7 +21,6 @@
+ #include <lib/xlat_tables/xlat_tables_v2.h>
+ #include <plat/common/platform.h>
+ 
+-#include <dram.h>
+ #include <gpc.h>
+ #include <imx_aipstz.h>
+ #include <imx_uart.h>
+@@ -49,8 +48,6 @@ static const mmap_region_t imx_mmap[] = {
+ 	MAP_REGION_FLAT(IMX_ROM_BASE, IMX_ROM_SIZE, MT_MEMORY | MT_RO), /* ROM map */
+ 	MAP_REGION_FLAT(IMX_AIPS_BASE, IMX_AIPS_SIZE, MT_DEVICE | MT_RW), /* AIPS map */
+ 	MAP_REGION_FLAT(IMX_GIC_BASE, IMX_GIC_SIZE, MT_DEVICE | MT_RW), /* GIC map */
+-	MAP_REGION_FLAT(IMX_DDRPHY_BASE, IMX_DDR_IPS_SIZE, MT_DEVICE | MT_RW), /* DDRMIX map */
+-	MAP_REGION_FLAT(IMX_DRAM_BASE, IMX_DRAM_SIZE, MT_MEMORY | MT_RW | MT_NS),
+ 	{0},
+ };
+ 
+@@ -229,8 +226,6 @@ void bl31_platform_setup(void)
+ 
+ 	/* gpc init */
+ 	imx_gpc_init();
+-
+-	dram_info_init(SAVED_DRAM_TIMING_BASE);
+ }
+ 
+ entry_point_info_t *bl31_plat_get_next_image_ep_info(unsigned int type)
+diff --git a/plat/imx/imx8m/imx8mq/imx8mq_psci.c b/plat/imx/imx8m/imx8mq/imx8mq_psci.c
+index 3375ce71bc95..e5c54261a5f9 100644
+--- a/plat/imx/imx8m/imx8mq/imx8mq_psci.c
++++ b/plat/imx/imx8m/imx8mq/imx8mq_psci.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2018-2023, ARM Limited and Contributors. All rights reserved.
++ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+  *
+  * SPDX-License-Identifier: BSD-3-Clause
+  */
+@@ -13,7 +13,6 @@
+ #include <lib/mmio.h>
+ #include <lib/psci/psci.h>
+ 
+-#include <dram.h>
+ #include <gpc.h>
+ #include <imx8m_psci.h>
+ #include <plat_imx8.h>
+@@ -80,7 +79,6 @@ void imx_domain_suspend(const psci_power_state_t *target_state)
+ 
+ 	if (is_local_state_retn(SYSTEM_PWR_STATE(target_state))) {
+ 		imx_set_sys_lpm(core_id, true);
+-		dram_enter_retention();
+ 		imx_anamix_override(true);
+ 	}
+ }
+@@ -93,7 +91,6 @@ void imx_domain_suspend_finish(const psci_power_state_t *target_state)
+ 	/* check the system level status */
+ 	if (is_local_state_retn(SYSTEM_PWR_STATE(target_state))) {
+ 		imx_anamix_override(false);
+-		dram_exit_retention();
+ 		imx_set_sys_lpm(core_id, false);
+ 		imx_clear_rbc_count();
+ 	}


### PR DESCRIPTION
It seems that official ATF doesn't support iMX8mq anymore:
https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/commit/?id=e3c07d2f5a082d8bb1684ca026d1789a77b3c870

However, with two tricks (log removal, reverting feature that uses most RAM) it's possible to make it build again. Maybe we should look into NXP fork for the future.