### PR TITLE
procps update to 4.x and dependency of xorg-intel-gpu-tools

### DIFF
--- a/packages/debug/xorg-intel-gpu-tools/package.mk
+++ b/packages/debug/xorg-intel-gpu-tools/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xorg-intel-gpu-tools"
-PKG_VERSION="1.27.1"
-PKG_SHA256="93b9a4816ed22b5145bb61024314c8a65caeea991ce93027643f1d40723bf417"
+PKG_VERSION="1.28"
+PKG_SHA256="ffcbdf61bd495803d9ae9dfa83e2fe04b8f583a2296fe059c1d5dd135a8a3b15"
 PKG_LICENSE="GPL"
-PKG_DEPENDS_TARGET="toolchain cairo procps-ng"
+PKG_DEPENDS_TARGET="toolchain cairo kmod procps-ng systemd"
 PKG_SITE="https://gitlab.freedesktop.org/drm/igt-gpu-tools"
 PKG_URL="https://www.x.org/releases/individual/app/igt-gpu-tools-${PKG_VERSION}.tar.xz"
 PKG_LONGDESC="Test suite and tools for DRM/KMS drivers"

--- a/packages/tools/procps-ng/package.mk
+++ b/packages/tools/procps-ng/package.mk
@@ -22,6 +22,10 @@ PKG_MAKE_OPTS_TARGET="src/free src/top/top library/libproc2.la library/libproc2.
 
 PKG_MAKEINSTALL_OPTS_TARGET="install-libLTLIBRARIES install-pkgconfigDATA install-library_libproc2_la_includeHEADERS"
 
+pre_configure_target() {
+  sed -i -e "s/UNKNOWN/${PKG_VERSION}/" ../configure
+}
+
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
     cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/free ${INSTALL}/usr/bin

--- a/packages/tools/procps-ng/package.mk
+++ b/packages/tools/procps-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="procps-ng"
-PKG_VERSION="3.3.17"
-PKG_SHA256="8374d281f91e5fc9bb9ea8dc991b25331e3a2b0299b46f22c633f7fb6bcb0764"
+PKG_VERSION="4.0.4"
+PKG_SHA256="08dbaaaae6afe8d5fbeee8aa3f8b460b01c5e09ce4706b161846f067103a2cf2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://gitlab.com/procps-ng/procps"
 PKG_URL="https://gitlab.com/procps-ng/procps/-/archive/v${PKG_VERSION}/procps-v${PKG_VERSION}.tar.bz2"
@@ -18,14 +18,18 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            --disable-modern-top \
                            --enable-static"
 
-PKG_MAKE_OPTS_TARGET="free top/top proc/libprocps.la proc/libprocps.pc"
+PKG_MAKE_OPTS_TARGET="src/free src/top/top library/libproc2.la library/libproc2.pc"
 
-PKG_MAKEINSTALL_OPTS_TARGET="install-libLTLIBRARIES install-pkgconfigDATA install-proc_libprocps_la_includeHEADERS"
+PKG_MAKEINSTALL_OPTS_TARGET="install-libLTLIBRARIES install-pkgconfigDATA install-library_libproc2_la_includeHEADERS"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
-    cp -P ${PKG_BUILD}/.${TARGET_NAME}/free ${INSTALL}/usr/bin
-    cp -P ${PKG_BUILD}/.${TARGET_NAME}/top/top ${INSTALL}/usr/bin
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/free ${INSTALL}/usr/bin
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/top/top ${INSTALL}/usr/bin
 
   make DESTDIR=${SYSROOT_PREFIX} -j1 ${PKG_MAKEINSTALL_OPTS_TARGET}
+
+  sed 's@proc/misc.h@procps/misc.h@' \
+    ${PKG_BUILD}/library/include/readproc.h \
+    > ${SYSROOT_PREFIX}/usr/include/libproc2/readproc.h
 }


### PR DESCRIPTION
Update of procps was blocked due to the dependency on xorg-intel-gpu-tools.
xorg-intel-gpu-tools 1.28 has now been release which supports procps-ng.

- https://gitlab.com/procps-ng/procps/-/blob/master/NEWS
- https://cgit.freedesktop.org/xorg/app/intel-gpu-tools/commit/?id=31ec677ca24e7ed86e35f367f40a29d3d9f51c06
- https://cgit.freedesktop.org/xorg/app/intel-gpu-tools/tree/NEWS