### PR TITLE
Package updates

### DIFF
--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.3.6"
-PKG_SHA256="95006761ed80c17a24245c0b44a38850e47c8175201cf6ff6d5e1afcf2732dea"
+PKG_VERSION="3.3.7"
+PKG_SHA256="029b91473a42f822611e92e01b7af05c3ed8def7ab14665ffbb78947ccf0d6a5"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/debug/libva-utils/package.mk
+++ b/packages/debug/libva-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva-utils"
-PKG_VERSION="2.19.0"
-PKG_SHA256="4135992ab534d0cfd71a93c28e1a22f79c0003cf8d157ffd4621e5e482191b4f"
+PKG_VERSION="2.20.0"
+PKG_SHA256="1a5e3c3c24677a6b4bbee21042c4c06b0a2c62e56ebb1baa4e712392b5c72f9b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/01org/libva-utils"
 PKG_URL="https://github.com/intel/libva-utils/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.27.4"
-PKG_SHA256="0a905ca8635ca81aa152e123bdde7e54cbe764fdd9a70d62af44cad8b92967af"
+PKG_VERSION="3.27.5"
+PKG_SHA256="5175e8fe1ca9b1dd09090130db7201968bcce1595971ff9e9998c2f0765004c9"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/devel/json-glib/package.mk
+++ b/packages/devel/json-glib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="json-glib"
-PKG_VERSION="1.6.6"
-PKG_SHA256="bf4d1cd6c343ce13b9258e6703a0411a3b659887b65877e85a2aa488ae18b865"
+PKG_VERSION="1.8.0"
+PKG_SHA256="97bc058fad49ebf5195ec539240370454ef6589d2b97bf626d7a9e2353d25e3f"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/GNOME/json-glib"
 PKG_URL="https://github.com/GNOME/json-glib/archive/${PKG_VERSION}.tar.gz"

--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="10.0.0"
-PKG_SHA256="535d17e830427bec163027114ded1def9ab0350c99bf1d8cb10535032967f3a5"
+PKG_VERSION="10.0.1"
+PKG_SHA256="5df55f87434f1b42d9ebe4247ed50a0f0742cd1ad5be2820e3d1b1f4b4bc696f"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.18.0"
-PKG_SHA256="60f58349c3d62a99bb87665b2a16afda87dc2d537a14aa45aaad1a3748b781ba"
+PKG_VERSION="3.19.0"
+PKG_SHA256="30354c769a508f644cf5c9647ef1f3a346b6fb3e64034fc3a8a364f6986beeb1"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pycryptodome"
 PKG_URL="https://github.com/Legrandin/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- cmake: update to 3.27.5
- json-glib: update to 1.8.0
- libva-utils: update to 2.20.0
- mariadb-connector-c: update to 3.3.7
- Pillow: update to 10.0.1
- pycryptodome: update to 3.19.0