### PR TITLE
rust: update to 1.72.1

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="95741a4cd2073adbd74a7c5596bb912abf4b2dfe00d70a9919cba4a836b7a0ff"
+    PKG_SHA256="40568f88c3efc2f1640e2e881a23e91ee26ec829317c4bbfb70dbd90d2923da4"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="519a572195a119bda9f09cb00e3d82d1ee6f992d58b403c39c0d515d35bcc7f8"
+    PKG_SHA256="a638c58751ab1a60db59aaef8671edf1b0f851c16a69f0c78be1d4e096f3ca48"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="4a401dfe7b3056dc0d42acbcd380b2b90f936577706ca74ef5327af0f5abd0a0"
+    PKG_SHA256="64eb3dbc8aa1c2ee2e5f12cb4fd0a714219ffec9f503f7bbaac4c92d68017ad7"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="41d259c6f84280fd0e7719fea03a7583ba54e33e8ac32a2a7b703ffb0aebb7d9"
+    PKG_SHA256="178fb79ab40f9608a642b1a7f1c864aa1943f95064195cc95df17b1a8fd775d5"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="4ef1c8df3dbc0160212afafc8bf643e5bbb40b0147b163f2f5e964a52fc8c217"
+    PKG_SHA256="f17670e870cacebcb96010e6bd48b6830cffeae9f276de3e3bf48650a2efbbc2"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="36f27513a6e4381f15b0cd14097c885af537f990cb6193cec3337c429367bf23"
+    PKG_SHA256="35d7f3099c801fc0899453318a538ec55b9a4641279943479912d7784236338b"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.72.0"
-PKG_SHA256="ea9d61bbb51d76b6ea681156f69f0e0596b59722f04414b01c6e100b4b5be3a1"
+PKG_VERSION="1.72.1"
+PKG_SHA256="7f48845f6a52cdbb5d63fb0528fd5f520eb443275b55f98e328159f86568f895"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="1948a80453956d494457dcced1942e2e204fb26d4e57e718ef1c7aa378efbedb"
+    PKG_SHA256="5243f95589dd0bf2d15695d60b5a83602ff4eb23f64df7b14e5ac205f1b7c1ba"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="1588da5bdb52d6be5d0d5135ad45cc2138073380993378ba143cc536663c29a6"
+    PKG_SHA256="0227a53178e71868c736f5ac9e572aba01280db27b9091a06f418aecfc58078d"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="5b5d7854a0d73368f15146c1aa47e4dbccf12762c93282f410a09a605929ce09"
+    PKG_SHA256="df30342d3cc16c9688b6121301397489f2f07c2c8cbd074c74857cc70e61281b"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
Release notes:
- https://blog.rust-lang.org/2023/09/19/Rust-1.72.1.html

Packages
- cargo-snapshot: update to 1.72.1
- rustc-snapshot: update to 1.72.1
- rust-std-snapshot: update to 1.72.1
- rust: update to 1.72.1