### PR TITLE
kodi: remove cputempcommand from advancedsettings.xml

### DIFF
--- a/packages/mediacenter/kodi/config/advancedsettings.xml
+++ b/packages/mediacenter/kodi/config/advancedsettings.xml
@@ -1,5 +1,4 @@
 <advancedsettings version="1.0">
-  <cputempcommand>/usr/bin/cputemp</cputempcommand>
   <gputempcommand>/usr/bin/gputemp</gputempcommand>
 
   <showexitbutton>false</showexitbutton>


### PR DESCRIPTION
This is no longer neccessary since kodi already supports reading the CPU temperature from the various hwmon sysfs entries.

Our downstream "cputemp" scripts are still included for now as the downstream "gputemp" scripts (which are still needed) symlink to them. This should be cleaned up at a later point.