### PR TITLE
kodi: change remote power button behaviour to show the shutdown menu

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-995.21-keymaps-change-remote-poweroff-action-to-show-shutdo.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.21-keymaps-change-remote-poweroff-action-to-show-shutdo.patch
@@ -1,0 +1,26 @@
+From 5604be6a6701e0bd68cb36fadb05cecba57f7887 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Fri, 22 Sep 2023 23:41:51 +0200
+Subject: [PATCH] keymaps: change remote poweroff action to show shutdown menu
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ system/keymaps/remote.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/system/keymaps/remote.xml b/system/keymaps/remote.xml
+index c122b99188..baebf679c0 100644
+--- a/system/keymaps/remote.xml
++++ b/system/keymaps/remote.xml
+@@ -50,7 +50,7 @@
+       <volumeplus>VolumeUp</volumeplus>
+       <volumeminus>VolumeDown</volumeminus>
+       <mute>Mute</mute>
+-      <power>ShutDown()</power>
++      <power>ActivateWindow(ShutdownMenu)</power>
+       <myvideo>ActivateWindow(Videos)</myvideo>
+       <mymusic>ActivateWindow(Music)</mymusic>
+       <mypictures>ActivateWindow(Pictures)</mypictures>
+-- 
+2.39.2
+


### PR DESCRIPTION
Kodi's default power button handling is OK for typical HTPCs with window systems but it's the exact opposite of what users (and I) expect from a mediacenter appliance:

When pressing the power button on the (PC, RPi, ...) case users expect that LE/kodi shuts down - but instead kodi shows the shutdown menu and there's no way to shut down LE/kodi except grabbing a keyboard or remote and pressing enter or OK to perform the shutdown (pressing the power button again would just make the menu disappear).

OTOH When (accidentally) pressing the power button on an (IR) remote LE/kodi immediately shuts down - which is pretty bad as most devices (like eg RPi and others as well without special configuration) can't be powered up again by the IR remote and pressing the OK button to confirm that the shutdown was actually wanted is no problem at all (it's on the same input device and just another press away).

Lots of people have posted about this odd configuration on our forums, opened GH issues,  and/or bitched about having to manually add the config changes to their LE installations and I think it's best to finally get rid of the odd default config and be done with it by **EDIT** ~~adding two one-liner patches (maintenance burden of those downstream patches should be extremely low)~~ at least changing the remote button behaviour to also show the shutdown menu.

**EDIT** Fixing the case power button behaviour is trickier and left for a separate PR
