### PR TITLE
kodi GBM: shut down kodi when case power button is pressed

### DIFF
--- a/packages/mediacenter/kodi/config/70-libinput-ignore-power-button.rules
+++ b/packages/mediacenter/kodi/config/70-libinput-ignore-power-button.rules
@@ -1,0 +1,12 @@
+# Ignore power button input devices in libinput so logind can handle them
+ACTION=="remove", GOTO="end"
+SUBSYSTEM!="input", GOTO="end"
+KERNEL!="event*", GOTO="end"
+
+IMPORT{parent}="KEY"
+
+# match devices that only generate KEY_POWER (code 116) events
+ENV{KEY}=="10000000000000 0", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+
+LABEL="end"
+

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -407,6 +407,12 @@ post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/cache/libreelec
     cp ${PKG_DIR}/config/network_wait ${INSTALL}/usr/cache/libreelec
 
+  # GBM: install udev rule to ignore the power button in libinput/kodi so logind can handle it
+  if [ "${DISPLAYSERVER}" = "no" ]; then
+    mkdir -p ${INSTALL}/usr/lib/udev/rules.d/
+    cp ${PKG_DIR}/config/70-libinput-ignore-power-button.rules ${INSTALL}/usr/lib/udev/rules.d/
+  fi
+
   # update addon manifest
   ADDON_MANIFEST=${INSTALL}/usr/share/kodi/system/addon-manifest.xml
   xmlstarlet ed -L -d "/addons/addon[text()='service.xbmc.versioncheck']" ${ADDON_MANIFEST}

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -203,7 +203,11 @@ post_makeinstall_target() {
 
   # tune logind.conf
   sed -e "s,^.*HandleLidSwitch=.*$,HandleLidSwitch=ignore,g" -i ${INSTALL}/etc/systemd/logind.conf
-  sed -e "s,^.*HandlePowerKey=.*$,HandlePowerKey=ignore,g" -i ${INSTALL}/etc/systemd/logind.conf
+  if [ "${DISPLAYSERVER}" = "no" ]; then
+    sed -e "s,^.*HandlePowerKey=.*$,HandlePowerKey=poweroff,g" -i ${INSTALL}/etc/systemd/logind.conf
+  else
+    sed -e "s,^.*HandlePowerKey=.*$,HandlePowerKey=ignore,g" -i ${INSTALL}/etc/systemd/logind.conf
+  fi
 
   # replace systemd-machine-id-setup with ours
   safe_remove ${INSTALL}/usr/lib/systemd/system/systemd-machine-id-commit.service


### PR DESCRIPTION
This is a follow-up to #8161 fixing the "kodi shows shutdown menu instead of powering down" issue on GBM.

Note: as I'm not familiar with X11 or wayland in LE I won't tackle that in this PR and leave that to others to fix in a separate PR.

On GBM the issue is quite easy to fix as kodi will grab the input devices. So all we need to do is prevent libinput (and thus kodi) from handling the system / case / ACPI power button input devices and then leave it to logind to shut down the system when the power button is pressed.

All other input devices, like USB/RF/BT remotes or keyboards which have a power button will be handled by kodi and pressing the power button on those devices will show the shutdown menu.

logind won't "see" events from those devices as kodi has grabbed them.

But logind will "see" the events from the power button input devices and can gracefully shutdown the system when the "case" power button is pressed.

Matching for "case" power button devices is performed by examining the bitmask of supported key events. If it only contains KEY_POWER we identify it as a "case" power button (bit 116 in the bitmask has to be set, but nothing else).

This works fine both on the usual "ACPI power button" input devices on PCs and also eg on RPi4 with the gpio-shutdown dtoverlay.

Runtime tested on RPi4 with the gpio-shutdown dtoverlay (short GPIO pins 5 and 6 to power down/up the RPi4) and a RF remote with USB receiver that shows up as a "keyboard" in kodi. The former shut down kodi while the latter brought up the shutdown menu