### PR TITLE
docker: streamline systemd config

### DIFF
--- a/packages/addons/service/docker/source/system.d/service.system.docker.service
+++ b/packages/addons/service/docker/source/system.d/service.system.docker.service
@@ -4,7 +4,7 @@ Documentation=https://docs.docker.com
 After=network.target
 
 [Service]
-Type=idle
+Type=notify
 Environment=PATH=/bin:/sbin:/usr/bin:/usr/sbin:/storage/.kodi/addons/service.system.docker/bin
 ExecStartPre=/storage/.kodi/addons/service.system.docker/bin/docker-config
 EnvironmentFile=-/storage/.kodi/userdata/addon_data/service.system.docker/config/docker.conf
@@ -22,5 +22,5 @@ TimeoutStartSec=0
 Restart=on-abnormal
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=kodi.target
 Alias=docker.service


### PR DESCRIPTION
- Remove `kodi.service`'s indirect dependency on `docker.service` by changing `docker.service`'s install target from `multi-user.target` to `kodi.target`, which is after `kodi.service` is started so kodi start is not delayed due to docker service and containers.
- Change `docker.service`'s type back to `notify` so that other services that need to depend on `docker.service` do not prematurely start (currently `type=idle` results in other services starting as soon as docker service is started but before it's fully up)

# Overarching Issue:
`kodi.service` indirectly depends on `docker.service` through `multi-user.target`. This dependency causes `kodi.service` to be delayed due to `docker.service`, which can take a long time with many containers.

# Previous attempt:
In a prior PR, we attempted to fix the delay by changing `docker.service`'s type to `idle` instead of `notify`: https://github.com/LibreELEC/LibreELEC.tv/pull/4393
At first it seemed to work as systemd no longer waited for docker to be fully up before starting Kodi.
However in Nexus, docker takes some time to start up, during which time, other services that truly depend on docker (such as the docker addons) are started before docker is fully up and they fail.

# Current attempt:
This PR reverses the prior attempted fix by making systemd wait for docker to be fully up before starting dependency services. And this PR fixes the original issue of Kodi's start delay by tying `docker.service` to `kodi.target` instead of `multi-user.target`. Since `kodi.target` is after `kodi.service`, there should be no longer any delay

Here's a systemd plot with the proposed changes and a couple of docker addons:
![test7](https://github.com/LibreELEC/LibreELEC.tv/assets/541623/fedca315-a71d-43a2-9689-b1478683d7c7)
Kodi starts before docker is fully up, and the docker addons start after.

Here's a systemd plot with the proposed changes and the mariadb docker addon (that makes sure it is started before kodi)
![test6](https://github.com/LibreELEC/LibreELEC.tv/assets/541623/ccc12947-6fc3-40a6-94d3-df23530d4b90)
Kodi starts after mariadb is up, as expected.