### PR TITLE
mc: fix build with local libpcre2-dev package

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/mc/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mc/package.mk
@@ -34,6 +34,7 @@ PKG_CONFIGURE_OPTS_TARGET=" \
   --enable-vfs-sftp \
   --enable-vfs-tar \
   --with-search-engine=pcre2 \
+  --with-pcre2=${SYSROOT_PREFIX}/usr \
   --without-x"
 
 pre_configure_target() {


### PR DESCRIPTION
Since pcre2 was introduced in mc, it doesn't build on host systems where libpcre2-dev is installed locally.

Add a configure option to point to the sysroot, where mc should search for pcre2.