### PR TITLE
kodi: extend power button udev rule to match on 32bit systems as well

### DIFF
--- a/packages/mediacenter/kodi/config/70-libinput-ignore-power-button.rules
+++ b/packages/mediacenter/kodi/config/70-libinput-ignore-power-button.rules
@@ -8,5 +8,8 @@ IMPORT{parent}="KEY"
 # match devices that only generate KEY_POWER (code 116) events
 ENV{KEY}=="10000000000000 0", ENV{LIBINPUT_IGNORE_DEVICE}="1"
 
+# 32bit systems report the bitmap in 32bit chunks
+ENV{KEY}=="100000 0 0 0", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+
 LABEL="end"
 


### PR DESCRIPTION
This is a follow-up bugfix to #8165, the bitmap reporting in udev differs on 32bit and 64bit systems...