### PR TITLE
Vulkan update to 1.3.266

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.265"
-PKG_SHA256="24076540521da1eceecfb56235cb0361a01fb24a306cbefe874c949bf2d2e9a4"
+PKG_VERSION="1.3.266"
+PKG_SHA256="0b3451c3dbda492be010738fb90e5cf80aa32f66705cadd9a12c573e0e351fd3"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.265"
-PKG_SHA256="fffca4a5e6daf3bbe18585f96bf7cad8cf173ebf3fa4d00b755108bd0b129bd8"
+PKG_VERSION="1.3.266"
+PKG_SHA256="85574be4e16fac78ab822576a2913141ad21aad5a51974cc798891643c677654"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.265"
-PKG_SHA256="f212a0f7f5b5adc5b64acc060e461a48e0c3cf6a0984a9f5b0621db52d02d133"
+PKG_VERSION="1.3.266"
+PKG_SHA256="a7f580e43d9c1c31d727f7f3931060bc2466ffb1be113e60993e8c8e64be02b2"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.01-cmakelists-opts.patch
+++ b/packages/graphics/vulkan/vulkan-tools/patches/vulkan-tools-995.01-cmakelists-opts.patch
@@ -12,14 +12,14 @@ index 422b7d2cc..d123c9dc5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -34,6 +34,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
- option(BUILD_CUBE "Build cube" ON)
  option(BUILD_VULKANINFO "Build vulkaninfo" ON)
  option(BUILD_ICD "Build icd" ON)
+ option(ENABLE_ADDRESS_SANITIZER "Use address sanitization")
 +option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
 +option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
 +option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
 +option(BUILD_WSI_DIRECTFB_SUPPORT "Build DirectFB WSI support" OFF)
 +set(CUBE_WSI_SELECTION "XCB" CACHE STRING "Select WSI target for vkcube (XCB, XLIB, WAYLAND, DIRECTFB, DISPLAY)")
  
- if (UNIX AND NOT APPLE) # i.e. Linux
-     option(ENABLE_ADDRESS_SANITIZER "Use addres sanitization" OFF)
+ if(WIN32)
+     # Optional: Allow specify the exact version used in the vulkaninfo executable


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/blob/main/ChangeLog.adoc
- vulkan-headers: update to 1.3.266
- vulkan-loader: update to 1.3.266
- vulkan-tools: update to 1.3.266