### PR TITLE
Rust update to 1.73.0 and llvm to 17.0.2

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="16.0.6"
-PKG_SHA256="ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e"
+PKG_VERSION="17.0.2"
+PKG_SHA256="351562b14d42fcefcbf00cc1f327680a1062bbbf67a1e1ca6acb64c473b06394"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
-PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION}.src.tar.xz"
+PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION/-/}.src.tar.xz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain llvm:host zlib"
 PKG_LONGDESC="Low-Level Virtual Machine (LLVM) is a compiler infrastructure."

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="40568f88c3efc2f1640e2e881a23e91ee26ec829317c4bbfb70dbd90d2923da4"
+    PKG_SHA256="1195a1d37280802574d729cf00e0dadc63a7c9312a9ae3ef2cf99645f7be0a77"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="a638c58751ab1a60db59aaef8671edf1b0f851c16a69f0c78be1d4e096f3ca48"
+    PKG_SHA256="fa81a1431d26d77e56c73c5c7360f851e6f3c60867f36dfb62088634fcf30f6e"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="64eb3dbc8aa1c2ee2e5f12cb4fd0a714219ffec9f503f7bbaac4c92d68017ad7"
+    PKG_SHA256="7c3ce5738d570eaea97dd3d213ea73c8beda4f0c61e7486f95e497b7b10c4e2d"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="178fb79ab40f9608a642b1a7f1c864aa1943f95064195cc95df17b1a8fd775d5"
+    PKG_SHA256="cbaa2549b3accc63b424251fadc3a66d922541df22e736a355246d81998f4252"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="f17670e870cacebcb96010e6bd48b6830cffeae9f276de3e3bf48650a2efbbc2"
+    PKG_SHA256="5e21a4776d5bf00f9f938da43dcbfd0246932f9d23a5c0e670f917319dc93182"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="35d7f3099c801fc0899453318a538ec55b9a4641279943479912d7784236338b"
+    PKG_SHA256="96efb163a57b400152c357be0ea3a0dd902b56cc0df662b9ac951403c7c7b15b"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.72.1"
-PKG_SHA256="7f48845f6a52cdbb5d63fb0528fd5f520eb443275b55f98e328159f86568f895"
+PKG_VERSION="1.73.0"
+PKG_SHA256="96d62e6d1f2d21df7ac8acb3b9882411f9e7c7036173f7f2ede9e1f1f6b1bb3a"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="5243f95589dd0bf2d15695d60b5a83602ff4eb23f64df7b14e5ac205f1b7c1ba"
+    PKG_SHA256="628f57a45eb8143a7ac1acd5d6d01e3ae3cdf1ad11d151795ed765f6e5f3047e"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="0227a53178e71868c736f5ac9e572aba01280db27b9091a06f418aecfc58078d"
+    PKG_SHA256="117a67a06e74de1ad386b340a50332ffd5cce3aac58d07b972091c94eee10d51"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="df30342d3cc16c9688b6121301397489f2f07c2c8cbd074c74857cc70e61281b"
+    PKG_SHA256="14f383eb4d6e65ce01cc99f2c5cf5a78744239f29704f72fe84f11095af779f5"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- llvm: update to 17.0.2
  - https://discourse.llvm.org/t/llvm-17-0-1-released/73549
  - https://discourse.llvm.org/t/llvm-17-0-2-released/73840
- rust: update to 1.73.0
  - https://blog.rust-lang.org/2023/10/05/Rust-1.73.0.html 
  - cargo-snapshot: update to 1.73.0
  - rustc-snapshot: update to 1.73.0
  - rust-std-snapshot: update to 1.73.0