### PR TITLE
package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.21.1"
-PKG_SHA256="4e2aab0485bd985bd67ebb1e70e3627bcca827317b88ce2aaeb251bd59ecbc80"
+PKG_VERSION="1.21.2"
+PKG_SHA256="addfe1b5b47ff2e60a2204c8f6e900ded4092869d8aeb89aa16d817311049f93"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.80"
-PKG_SHA256="0bbaf3d46649ac2217f0bbf68dda7e62f1f2cf6b7f3025e364cf7205d1499ef9"
+PKG_VERSION="0.3.81"
+PKG_SHA256="241bd06703e41e30d26e096301337547ef5be1201919996c10045758673e691d"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.27.6"
-PKG_SHA256="ef3056df528569e0e8956f6cf38806879347ac6de6a4ff7e4105dc4578732cfb"
+PKG_VERSION="3.27.7"
+PKG_SHA256="08f71a106036bf051f692760ef9558c0577c42ac39e96ba097e7662bd4158d8e"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/devel/gettext/package.mk
+++ b/packages/devel/gettext/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gettext"
-PKG_VERSION="0.22.2"
-PKG_SHA256="4c82fbfe5e53d71a97c634aa98a898b9da807b08b27410f6a4641e8bb44dc4b2"
+PKG_VERSION="0.22.3"
+PKG_SHA256="b838228b3f8823a6c1eddf07297197c4db13f7e1b173b9ef93f3f945a63080b6"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/s/gettext/"
 PKG_URL="https://ftp.gnu.org/pub/gnu/gettext/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.374"
-PKG_SHA256="2a0988bf5e97e49159d7f02a5e02a719c8976d4ec883a8abb635149d221ceca0"
+PKG_VERSION="0.375"
+PKG_SHA256="69ffbfe4801c12c2d66d51f98044beec35afa406b1baa619c57b25a9b62b43a0"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/dav1d/package.mk
+++ b/packages/multimedia/dav1d/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dav1d"
-PKG_VERSION="1.2.1"
-PKG_SHA256="4e33eb61ec54c768a16da0cf8fa0928b4c4593f5f804a3c887d4a21c318340b2"
+PKG_VERSION="1.3.0"
+PKG_SHA256="6d8be2741c505c47f8f1ced3c9cc427759243436553d01d1acce201f87b39e71"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.videolan.org/projects/dav1d.html"
 PKG_URL="https://downloads.videolan.org/pub/videolan/dav1d/${PKG_VERSION}/dav1d-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/nv-codec-headers/package.mk
+++ b/packages/multimedia/nv-codec-headers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nv-codec-headers"
-PKG_VERSION="12.0.16.0"
-PKG_SHA256="2a1533b65f55f9da52956faf0627ed3b74868ac0c7f269990edd21369113b48f"
+PKG_VERSION="12.1.14.0"
+PKG_SHA256="2fefaa227d2a3b4170797796425a59d1dd2ed5fd231db9b4244468ba327acd0b"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/FFmpeg/nv-codec-headers"
 PKG_URL="https://github.com/FFmpeg/nv-codec-headers/archive/n${PKG_VERSION}.tar.gz"

--- a/packages/network/libtirpc/package.mk
+++ b/packages/network/libtirpc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libtirpc"
-PKG_VERSION="1.3.3"
-PKG_SHA256="6474e98851d9f6f33871957ddee9714fdcd9d8a5ee9abb5a98d63ea2e60e12f3"
+PKG_VERSION="1.3.4"
+PKG_SHA256="1e0b0c7231c5fa122e06c0609a76723664d068b0dba3b8219b63e6340b347860"
 PKG_LICENSE="GPL"
 PKG_SITE="https://sourceforge.net/projects/libtirpc/"
 PKG_URL="https://downloads.sourceforge.net/project/libtirpc/libtirpc/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="9.4p1"
-PKG_SHA256="3608fd9088db2163ceb3e600c85ab79d0de3d221e59192ea1923e23263866a85"
+PKG_VERSION="9.5p1"
+PKG_SHA256="f026e7b79ba7fb540f75182af96dc8a8f1db395f922bbc9f6ca603672686086b"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/system/simplejson/package.mk
+++ b/packages/python/system/simplejson/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="simplejson"
-PKG_VERSION="3.19.1"
-PKG_SHA256="6277f60848a7d8319d27d2be767a7546bc965535b28070e310b3a9af90604a4c"
+PKG_VERSION="3.19.2"
+PKG_SHA256="9eb442a2442ce417801c912df68e1f6ccfcd41577ae7274953ab3ad24ef7d82c"
 PKG_LICENSE="OSS"
 PKG_SITE="http://pypi.org/project/simplejson"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/x11/data/xkeyboard-config/package.mk
+++ b/packages/x11/data/xkeyboard-config/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xkeyboard-config"
-PKG_VERSION="2.39"
-PKG_SHA256="5ac5f533eff7b0c116805fe254fd79b2c9882700a4f9f2c070f8c4eae5aaa682"
+PKG_VERSION="2.40"
+PKG_SHA256="7a3dba1bec7dc7191432da021242d17c9cf6c89690e6c57b0de048ff8c9d2ae3"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://www.x.org/releases/individual/data/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXrandr/package.mk
+++ b/packages/x11/lib/libXrandr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXrandr"
-PKG_VERSION="1.5.3"
-PKG_SHA256="897639014a78e1497704d669c5dd5682d721931a4452c89a7ba62676064eb428"
+PKG_VERSION="1.5.4"
+PKG_SHA256="1ad5b065375f4a85915aa60611cc6407c060492a214d7f9daf214be752c3b4d3"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- cmake: update to 3.27.7
- dav1d: update to 1.3.0
- gettext: update to 0.22.3
- go: update to 1.21.2
- hwdata: update to 0.375
- libtirpc: update to 1.3.4
- libXrandr: update to 1.5.4
- nv-codec-headers: update to 12.1.14.0
- openssh: update to 9.5p1
- pipewire: update to 0.3.81
- simplejson: update to 3.19.2
- xkeyboard-config: update to 2.40