### PR TITLE
Vulkan update to 1.3.268

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.267"
-PKG_SHA256="72120553215bb631275a38a5359ad812837165ab8ddd8e33597dd52c7d80d627"
+PKG_VERSION="1.3.268"
+PKG_SHA256="d5c59d5fc3ab264006dfea1eb1a11f609ea5dfa8319a5aaca061007828012a78"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.266"
-PKG_SHA256="0b3451c3dbda492be010738fb90e5cf80aa32f66705cadd9a12c573e0e351fd3"
+PKG_VERSION="1.3.267"
+PKG_SHA256="72120553215bb631275a38a5359ad812837165ab8ddd8e33597dd52c7d80d627"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.266"
-PKG_SHA256="85574be4e16fac78ab822576a2913141ad21aad5a51974cc798891643c677654"
+PKG_VERSION="1.3.267"
+PKG_SHA256="a5ddca95db1faa0bc3ad958d3979d063846252bd5dff1f3ed5833cb20dc0ace5"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.267"
-PKG_SHA256="a5ddca95db1faa0bc3ad958d3979d063846252bd5dff1f3ed5833cb20dc0ace5"
+PKG_VERSION="1.3.268"
+PKG_SHA256="bddabbf8ebbbd38bdb58dfb50fbd94dbd84b8c39c34045e13c9ad46bd3cae167"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.267"
-PKG_SHA256="688f98736a2e02c6f9fcc7dc105046acf730c0fa374fe92ad1bc04bd92db70fd"
+PKG_VERSION="1.3.268"
+PKG_SHA256="07b08b45812da1e82921ac707076558ec9b2f6f00eefefb69b911a1ba0715294"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.266"
-PKG_SHA256="a7f580e43d9c1c31d727f7f3931060bc2466ffb1be113e60993e8c8e64be02b2"
+PKG_VERSION="1.3.267"
+PKG_SHA256="688f98736a2e02c6f9fcc7dc105046acf730c0fa374fe92ad1bc04bd92db70fd"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/blob/main/ChangeLog.adoc
- vulkan-headers: update to 1.3.268
- vulkan-loader: update to 1.3.268
- vulkan-tools: update to 1.3.268