### PR TITLE
amlogic: pick mt7662 firmware to AMLGX image

### DIFF
--- a/projects/Amlogic/config/kernel-firmware.dat
+++ b/projects/Amlogic/config/kernel-firmware.dat
@@ -2,6 +2,8 @@ ath9k_htc
 ath10k/QCA9377
 mediatek/mt7668pr2h.bin
 mrvl/sd8897_uapsta.bin
+mt7662.bin
+mt7662_rom_patch.bin
 qca/nvm_00230302.bin
 qca/rampatch_00230302.bin
 rtlwifi/rtl8192cufw_TMSC.bin


### PR DESCRIPTION
From https://forum.libreelec.tv/thread/27616-cannot-use-netgear-a6210-rt76x2u-linux-driver/