### PR TITLE
kodi: update to current master

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="21.0a3-Omega"
-PKG_SHA256="1b4e1ef18a53897667e4a26122f82fc7a196952a3377868afe036cb9ed27571d"
+PKG_VERSION="d8b39703961b141a3e8588f77b9e0e91d5c11e55"
+PKG_SHA256="4d4cd84074c6b906fceb682732c0b37ea4d947b4ce62c1c14308c387044c2913"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
The cmake breakage https://github.com/xbmc/xbmc/issues/23887 has been fixed, so it's a good time to update kodi again.

Runtime tested on RPi5