### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.21.2"
-PKG_SHA256="addfe1b5b47ff2e60a2204c8f6e900ded4092869d8aeb89aa16d817311049f93"
+PKG_VERSION="1.21.3"
+PKG_SHA256="ef050538144510993878a24240d07cb7cc1da411784de1e0c36d16dffcf80aac"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="0.3.81"
-PKG_SHA256="241bd06703e41e30d26e096301337547ef5be1201919996c10045758673e691d"
+PKG_VERSION="0.3.82"
+PKG_SHA256="180283e33ebb4fbcfefa25f1f1c23df1c0f084ea890c9394fa0a7ba7d13d789a"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.4.14"
-PKG_SHA256="b160424ce7c3eeeccba388726f6a448f53501d25085e5fa1bf6c690c1bcd85ea"
+PKG_VERSION="0.4.15"
+PKG_SHA256="389f5ebce1193419900f5dbc6647df8e3176731a0514ab33ae2afab1cdd8a415"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.43.1"
+PKG_VERSION="3.43.2"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="39116c94e76630f22d54cd82c3cea308565f1715f716d1b2527f1c9c969ba4d9"
+PKG_SHA256="6d422b6f62c4de2ca80d61860e3a3fb693554d2f75bb1aaca743ccc4d6f609f0"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2023/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"

--- a/packages/devel/shared-mime-info/package.mk
+++ b/packages/devel/shared-mime-info/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="shared-mime-info"
-PKG_VERSION="2.2"
-PKG_SHA256="418c480019d9865f67f922dfb88de00e9f38bf971205d55cdffab50432919e61"
+PKG_VERSION="2.3"
+PKG_SHA256="96ac085d82e2e654e40e34c13d97b74f6657357ee6b443d922695adcf548961c"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://freedesktop.org/wiki/Software/shared-mime-info/"
 PKG_URL="https://gitlab.freedesktop.org/xdg/${PKG_NAME}/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/multimedia/libva/package.mk
+++ b/packages/multimedia/libva/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libva"
-PKG_VERSION="2.19.0"
-PKG_SHA256="8cb5e2a9287a76b12c0b6cb96f4f27a0321bbe693df43cd950e5d4542db7f227"
+PKG_VERSION="2.20.0"
+PKG_SHA256="117f8d658a5fc9ea406ca80a3eb4ae1d70b15a54807c9ed77199c812bed73b60"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iptables"
-PKG_VERSION="1.8.9"
-PKG_SHA256="ef6639a43be8325a4f8ea68123ffac236cb696e8c78501b64e8106afb008c87f"
+PKG_VERSION="1.8.10"
+PKG_SHA256="5cc255c189356e317d070755ce9371eb63a1b783c34498fb8c30264f3cc59c9c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.netfilter.org/"
 PKG_URL="https://www.netfilter.org/projects/iptables/files/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.19.0"
-PKG_SHA256="28f98ceab75a6a59432912fa110fc8c716abcab1ed6d8bdd4393d178acff3d20"
+PKG_VERSION="4.19.1"
+PKG_SHA256="ce3b7f0d18bf91aa5fd646e8bb385a3b35375b703c6e5123b02b85a1abc81879"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/fuse3/package.mk
+++ b/packages/sysutils/fuse3/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fuse3"
-PKG_VERSION="3.16.1"
-PKG_SHA256="75a7140ce2d4589eda2784d2279be9d2b273a9b6b0f79ecb871dc4dded046fb5"
+PKG_VERSION="3.16.2"
+PKG_SHA256="f797055d9296b275e981f5f62d4e32e089614fc253d1ef2985851025b8a0ce87"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libfuse/libfuse/"
 PKG_URL="https://github.com/libfuse/libfuse/releases/download/fuse-${PKG_VERSION}/fuse-${PKG_VERSION}.tar.gz"

--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbcommon"
-PKG_VERSION="1.5.0"
-PKG_SHA256="560f11c4bbbca10f495f3ef7d3a6aa4ca62b4f8fb0b52e7d459d18a26e46e017"
+PKG_VERSION="1.6.0"
+PKG_SHA256="0edc14eccdd391514458bc5f5a4b99863ed2d651e4dd761a90abf4f46ef99c2b"
 PKG_LICENSE="MIT"
 PKG_SITE="https://xkbcommon.org"
 PKG_URL="https://xkbcommon.org/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/util/foot/package.mk
+++ b/packages/wayland/util/foot/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="foot"
-PKG_VERSION="1.15.3"
-PKG_SHA256="65006a0643ec185a0e24578365e2e7469ddeba6bd543645a15d9bbb5ec501670"
+PKG_VERSION="1.16.1"
+PKG_SHA256="43df31d457ee1f30909d12875a18845e66277def32a25d9754c96995c58d179a"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/foot/"
 PKG_URL="https://codeberg.org/dnkl/foot/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/util/wlr-randr/package.mk
+++ b/packages/wayland/util/wlr-randr/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wlr-randr"
-PKG_VERSION="0.3.0"
-PKG_SHA256="f6e0bea3b41673adbc0ab707d5d93bfdcd3fc6f43c46377565865c3440f81eb4"
+PKG_VERSION="0.3.1"
+PKG_SHA256="918420f134fc094da0cd9cc5112b65f623abd773964bff5fa57e221204506ab2"
 PKG_LICENSE="MIT"
 PKG_SITE="https://git.sr.ht/~emersion/wlr-randr"
 PKG_URL="https://git.sr.ht/~emersion/wlr-randr/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.56.0"
-PKG_SHA256="65eee8021e9d3620589a4a4e91ce9983d802b5229f78f3313770e13f4d2720e9"
+PKG_VERSION="1.57.0"
+PKG_SHA256="9210b0113109f43be526ac5835d58a701411821a4d39e155c40d67c40f47a958"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- foot: update to 1.16.1
- fuse3: update to 3.16.2
- go: update to 1.21.3
- iptables: update to 1.8.10
- libva: update to 2.20.0
- libxkbcommon: update to 1.6.0
- nghttp2: update to 1.57.0
- pipewire: update to 0.3.82
- samba: update to 4.19.1
- shared-mime-info: update to 2.3
- sqlite: update to 3.43.2
- wireplumber: update to 0.4.15
- wlr-randr: update to 0.3.1