### PR TITLE
kodi: update to 8fd6170

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="d8b39703961b141a3e8588f77b9e0e91d5c11e55"
-PKG_SHA256="4d4cd84074c6b906fceb682732c0b37ea4d947b4ce62c1c14308c387044c2913"
+PKG_VERSION="8fd61703c7af55869b317ebe7e069f3f0c00099c"
+PKG_SHA256="f55c76788d720ea056babbf15b1e6072b03b79a676efd18c137c199201366d26"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
After latest bump PVR radio stations do not work any more.

See https://forum.libreelec.tv/thread/27629-no-tvh-radio-playback-since-rpi4-test-build-13th-october/

Can confirm the issue with VNSI. Updating to current HEAD let radio play again

Tested on Generic-legacy.