### PR TITLE
[LE12] Allwinner: linux: Attempt at fixing OPi3 LTS net stability issue

### DIFF
--- a/projects/Allwinner/patches/linux/0041-OrangePi-3-LTS-support.patch
+++ b/projects/Allwinner/patches/linux/0041-OrangePi-3-LTS-support.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 000000000000..6a5df1103a90
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts
-@@ -0,0 +1,316 @@
+@@ -0,0 +1,318 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +// Copyright (C) 2023 Jernej Skrabec <jernej.skrabec@gmail.com>
 +// Based on sun50i-h6-orangepi-3.dts, which is:
@@ -161,6 +161,8 @@ index 000000000000..6a5df1103a90
 +		reg = <1>;
 +
 +		motorcomm,clk-out-frequency-hz = <125000000>;
++		motorcomm,keep-pll-enabled;
++		motorcomm,auto-sleep-disabled;
 +
 +		reset-gpios = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
 +		reset-assert-us = <15000>;


### PR DESCRIPTION
This fix is included on other OrangePi boards with same Ethernet PHY, so it probably helps. It certainly doesn't hurt. I didn't have any issue with ethernet during my testing, so let's see if it solves the issue for others too.