### PR TITLE
RPi5: sync mesa patches with RPiOS 23.2.1-0+rpt2 version

### DIFF
--- a/projects/RPi/devices/RPi5/patches/mesa/0001-broadcom-cle-clif-common-simulator-add-7.1-version-o.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0001-broadcom-cle-clif-common-simulator-add-7.1-version-o.patch
@@ -1,7 +1,7 @@
 From f62aa2640f92796ff5216da0a5d3c8f46a2855b4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Mon, 26 Apr 2021 00:02:21 +0200
-Subject: [PATCH 001/139] broadcom(cle,clif,common,simulator): add 7.1 version
+Subject: [PATCH 001/142] broadcom(cle,clif,common,simulator): add 7.1 version
  on the list of versions to build
 
 This adds 7.1 to the list of available V3D_VERSION, and first changes

--- a/projects/RPi/devices/RPi5/patches/mesa/0002-broadcom-simulator-reset-CFG7-for-compute-dispatch-i.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0002-broadcom-simulator-reset-CFG7-for-compute-dispatch-i.patch
@@ -1,7 +1,7 @@
 From 9e85edd1b347b0e779b393f463f42044a720bcff Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 28 Sep 2021 13:16:49 +0200
-Subject: [PATCH 002/139] broadcom/simulator: reset CFG7 for compute dispatch
+Subject: [PATCH 002/142] broadcom/simulator: reset CFG7 for compute dispatch
  in v71
 
 This register is new in 7.x, it doesn't seem that we need to

--- a/projects/RPi/devices/RPi5/patches/mesa/0003-broadcom-cle-update-the-packet-definitions-for-new-g.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0003-broadcom-cle-update-the-packet-definitions-for-new-g.patch
@@ -1,7 +1,7 @@
 From 6f744bc4bec98f9769486d427e8e2d4e314ae056 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 29 Jun 2021 12:03:24 +0200
-Subject: [PATCH 003/139] broadcom/cle: update the packet definitions for new
+Subject: [PATCH 003/142] broadcom/cle: update the packet definitions for new
  generation v71
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/projects/RPi/devices/RPi5/patches/mesa/0004-broadcom-common-retrieve-V3D-revision-number.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0004-broadcom-common-retrieve-V3D-revision-number.patch
@@ -1,7 +1,7 @@
 From 569cbe4229df737ce5915c4be2cad534707fb4f7 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 9 Nov 2021 08:50:51 +0100
-Subject: [PATCH 004/139] broadcom/common: retrieve V3D revision number
+Subject: [PATCH 004/142] broadcom/common: retrieve V3D revision number
 
 The subrev field from the hub ident3 register is bumped with every
 hardware revision doing backwards incompatible changes so we want to

--- a/projects/RPi/devices/RPi5/patches/mesa/0005-broadcom-common-add-some-common-v71-helpers.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0005-broadcom-common-add-some-common-v71-helpers.patch
@@ -1,7 +1,7 @@
 From c260843c882d25bd31e308566b45d4517fda0fa2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 17 Nov 2021 14:40:47 +0100
-Subject: [PATCH 005/139] broadcom/common: add some common v71 helpers
+Subject: [PATCH 005/142] broadcom/common: add some common v71 helpers
 
 ---
  src/broadcom/common/v3d_util.c | 27 +++++++++++++++++++++++++++

--- a/projects/RPi/devices/RPi5/patches/mesa/0006-broadcom-qpu-add-comments-on-waddr-not-used-on-V3D-7.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0006-broadcom-qpu-add-comments-on-waddr-not-used-on-V3D-7.patch
@@ -1,7 +1,7 @@
 From a5211a4d71acc53183d2a90eb1694d8cce6eb44f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 5 Aug 2021 01:03:11 +0200
-Subject: [PATCH 006/139] broadcom/qpu: add comments on waddr not used on V3D
+Subject: [PATCH 006/142] broadcom/qpu: add comments on waddr not used on V3D
  7.x
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0007-broadcom-qpu-set-V3D-7.x-names-for-some-waddr-aliasi.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0007-broadcom-qpu-set-V3D-7.x-names-for-some-waddr-aliasi.patch
@@ -1,7 +1,7 @@
 From 0ccf3043e4a584e5592bb7fad737d5d98ed23db0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 5 Aug 2021 01:00:47 +0200
-Subject: [PATCH 007/139] broadcom/qpu: set V3D 7.x names for some waddr
+Subject: [PATCH 007/142] broadcom/qpu: set V3D 7.x names for some waddr
  aliasing
 
 V3D 7.x got rid of the accumulator, but still uses the values for

--- a/projects/RPi/devices/RPi5/patches/mesa/0008-broadcom-compiler-rename-small_imm-to-small_imm_b.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0008-broadcom-compiler-rename-small_imm-to-small_imm_b.patch
@@ -1,7 +1,7 @@
 From 18de3cc85cf8bbe294e044f7a12abe14e554de0a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Sun, 19 Sep 2021 03:20:18 +0200
-Subject: [PATCH 008/139] broadcom/compiler: rename small_imm to small_imm_b
+Subject: [PATCH 008/142] broadcom/compiler: rename small_imm to small_imm_b
 
 Current small_imm is associated with the "B" read address.
 

--- a/projects/RPi/devices/RPi5/patches/mesa/0009-broadcom-compiler-add-small_imm-a-c-d-on-v3d_qpu_sig.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0009-broadcom-compiler-add-small_imm-a-c-d-on-v3d_qpu_sig.patch
@@ -1,7 +1,7 @@
 From 0e87405fe73694c173b7ce14c3d60611f241922c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 5 Aug 2021 00:50:12 +0200
-Subject: [PATCH 009/139] broadcom/compiler: add small_imm a/c/d on v3d_qpu_sig
+Subject: [PATCH 009/142] broadcom/compiler: add small_imm a/c/d on v3d_qpu_sig
 
 small_imm_a, small_imm_c and small_imm_d added on top of the already
 existing small_imm_b, as V3D 7.1 defines 4 small immediates, tied to

--- a/projects/RPi/devices/RPi5/patches/mesa/0010-broadcom-qpu-add-v71-signal-map.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0010-broadcom-qpu-add-v71-signal-map.patch
@@ -1,7 +1,7 @@
 From eca19c911d9af3b0ab3b563ea65dc455e3d27987 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 4 Aug 2021 01:11:16 +0200
-Subject: [PATCH 010/139] broadcom/qpu: add v71 signal map
+Subject: [PATCH 010/142] broadcom/qpu: add v71 signal map
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/projects/RPi/devices/RPi5/patches/mesa/0011-broadcom-qpu-define-v3d_qpu_input-use-on-v3d_qpu_alu.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0011-broadcom-qpu-define-v3d_qpu_input-use-on-v3d_qpu_alu.patch
@@ -1,7 +1,7 @@
 From d10e67a396d713ec81fb133f3516e09fe1e067b6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 6 Aug 2021 01:22:31 +0200
-Subject: [PATCH 011/139] broadcom/qpu: define v3d_qpu_input, use on
+Subject: [PATCH 011/142] broadcom/qpu: define v3d_qpu_input, use on
  v3d_qpu_alu_instr
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/projects/RPi/devices/RPi5/patches/mesa/0012-broadcom-qpu-add-raddr-on-v3d_qpu_input.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0012-broadcom-qpu-add-raddr-on-v3d_qpu_input.patch
@@ -1,7 +1,7 @@
 From 52ea09792ff8a438ccdecac47b8415657be90098 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 6 Aug 2021 01:33:32 +0200
-Subject: [PATCH 012/139] broadcom/qpu: add raddr on v3d_qpu_input
+Subject: [PATCH 012/142] broadcom/qpu: add raddr on v3d_qpu_input
 
 On V3D 7.x mux are not used, and raddr_a/b/c/d are used instead
 

--- a/projects/RPi/devices/RPi5/patches/mesa/0013-broadcom-qpu-defining-shift-mask-for-raddr_c-d.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0013-broadcom-qpu-defining-shift-mask-for-raddr_c-d.patch
@@ -1,7 +1,7 @@
 From 3e5ad0881c2789619cdf65f40a44d5481e28e800 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 12 Aug 2021 02:24:02 +0200
-Subject: [PATCH 013/139] broadcom/qpu: defining shift/mask for raddr_c/d
+Subject: [PATCH 013/142] broadcom/qpu: defining shift/mask for raddr_c/d
 
 On V3D 7.x it replaces mul_a/b and add_a/b
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0014-broadcom-commmon-add-has_accumulators-field-on-v3d_d.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0014-broadcom-commmon-add-has_accumulators-field-on-v3d_d.patch
@@ -1,7 +1,7 @@
 From 81febf14fe05ad26e992275b911e8bc1e1416ebc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 17 Sep 2021 01:04:31 +0200
-Subject: [PATCH 014/139] broadcom/commmon: add has_accumulators field on
+Subject: [PATCH 014/142] broadcom/commmon: add has_accumulators field on
  v3d_device_info
 
 Even if we can just check for the version on the code, checking for

--- a/projects/RPi/devices/RPi5/patches/mesa/0015-broadcom-qpu-add-qpu_writes_rf0_implicitly-helper.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0015-broadcom-qpu-add-qpu_writes_rf0_implicitly-helper.patch
@@ -1,7 +1,7 @@
 From 7d42eca87b6e144697810405308d99d200dca62a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 15 Sep 2021 10:56:43 +0200
-Subject: [PATCH 015/139] broadcom/qpu: add qpu_writes_rf0_implicitly helper
+Subject: [PATCH 015/142] broadcom/qpu: add qpu_writes_rf0_implicitly helper
 
 On v71 rf0 replaces r5 as the register that gets updated implicitly
 with uniform loads, and gets the C coefficient with ldvary. This

--- a/projects/RPi/devices/RPi5/patches/mesa/0016-broadcom-qpu-add-pack-unpack-support-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0016-broadcom-qpu-add-pack-unpack-support-for-v71.patch
@@ -1,7 +1,7 @@
 From f0859613bd59e14fb21571e7978bb5c5d5e9c6d7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Sat, 7 Aug 2021 02:20:39 +0200
-Subject: [PATCH 016/139] broadcom/qpu: add pack/unpack support for v71
+Subject: [PATCH 016/142] broadcom/qpu: add pack/unpack support for v71
 
 Note that we provide new v71 alu pack/unpack methods. As there are a
 lot that it is equivalent, initially we tried to use existing methods

--- a/projects/RPi/devices/RPi5/patches/mesa/0017-broadcom-compiler-update-node-temp-translation-for-v.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0017-broadcom-compiler-update-node-temp-translation-for-v.patch
@@ -1,7 +1,7 @@
 From ebba9019461083687f6afd23ff0d4646c1a667cb Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Sun, 29 Jan 2023 00:27:11 +0100
-Subject: [PATCH 017/139] broadcom/compiler: update node/temp translation for
+Subject: [PATCH 017/142] broadcom/compiler: update node/temp translation for
  v71
 
 As the offset applied needs to take into account if we have

--- a/projects/RPi/devices/RPi5/patches/mesa/0018-broadcom-compiler-phys-index-depends-on-hw-version.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0018-broadcom-compiler-phys-index-depends-on-hw-version.patch
@@ -1,7 +1,7 @@
 From 9b2dfe0286212aba3687a06023cc5b4ce9944ee0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Mon, 23 Aug 2021 02:18:43 +0200
-Subject: [PATCH 018/139] broadcom/compiler: phys index depends on hw version
+Subject: [PATCH 018/142] broadcom/compiler: phys index depends on hw version
 
 For 7.1 there are not accumulators. So we replace the macro with a
 function call.

--- a/projects/RPi/devices/RPi5/patches/mesa/0019-broadcom-compiler-don-t-favor-select-accum-registers.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0019-broadcom-compiler-don-t-favor-select-accum-registers.patch
@@ -1,7 +1,7 @@
 From da0a3deadf86a46c8323267d3f6a49e442835608 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 17 Sep 2021 01:07:06 +0200
-Subject: [PATCH 019/139] broadcom/compiler: don't favor/select accum registers
+Subject: [PATCH 019/142] broadcom/compiler: don't favor/select accum registers
  for hw not supporting it
 
 Note that what we do is to just return false on the favor/select accum

--- a/projects/RPi/devices/RPi5/patches/mesa/0020-broadcom-vir-implement-is_no_op_mov-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0020-broadcom-vir-implement-is_no_op_mov-for-v71.patch
@@ -1,7 +1,7 @@
 From 6c04d7c917da6b38f8b2b4306ab03ed2ab7e6ce0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 9 Sep 2021 00:28:53 +0200
-Subject: [PATCH 020/139] broadcom/vir: implement is_no_op_mov for v71
+Subject: [PATCH 020/142] broadcom/vir: implement is_no_op_mov for v71
 
 Did some refactoring/splitting.
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0021-broadcom-compiler-update-vir_to_qpu-set_src-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0021-broadcom-compiler-update-vir_to_qpu-set_src-for-v71.patch
@@ -1,7 +1,7 @@
 From 7b5be2d9b178a45c34c22db2744639a6a8a216d1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 9 Sep 2021 01:18:54 +0200
-Subject: [PATCH 021/139] broadcom/compiler: update vir_to_qpu::set_src for v71
+Subject: [PATCH 021/142] broadcom/compiler: update vir_to_qpu::set_src for v71
 
 ---
  src/broadcom/compiler/vir_to_qpu.c | 47 ++++++++++++++++++++++++++----

--- a/projects/RPi/devices/RPi5/patches/mesa/0022-broadcom-qpu_schedule-add-process_raddr_deps.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0022-broadcom-qpu_schedule-add-process_raddr_deps.patch
@@ -1,7 +1,7 @@
 From fe89703008f2a3d6bfe6e260791f712013be5e48 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 9 Sep 2021 23:59:28 +0200
-Subject: [PATCH 022/139] broadcom/qpu_schedule: add process_raddr_deps
+Subject: [PATCH 022/142] broadcom/qpu_schedule: add process_raddr_deps
 
 On v71 we don't have muxes, but more raddr. Adding a equivalent add
 deps function.

--- a/projects/RPi/devices/RPi5/patches/mesa/0023-broadcom-qpu-update-disasm_raddr-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0023-broadcom-qpu-update-disasm_raddr-for-v71.patch
@@ -1,7 +1,7 @@
 From 20ce426df1ab2546332141f4bc4531ada754cdea Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 10 Sep 2021 01:20:44 +0200
-Subject: [PATCH 023/139] broadcom/qpu: update disasm_raddr for v71
+Subject: [PATCH 023/142] broadcom/qpu: update disasm_raddr for v71
 
 ---
  src/broadcom/qpu/qpu_disasm.c | 72 ++++++++++++++++++++++++++++++++---

--- a/projects/RPi/devices/RPi5/patches/mesa/0024-broadcom-qpu-return-false-on-qpu_writes_accumulatorX.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0024-broadcom-qpu-return-false-on-qpu_writes_accumulatorX.patch
@@ -1,7 +1,7 @@
 From 7263fa24a3c57b1dcd4d870670cda86ae89aa28c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 15 Sep 2021 10:55:49 +0200
-Subject: [PATCH 024/139] broadcom/qpu: return false on
+Subject: [PATCH 024/142] broadcom/qpu: return false on
  qpu_writes_accumulatorXX helpers for v71
 
 As for v71 doesn't have accumulators (devinfo->has_accumulators set to

--- a/projects/RPi/devices/RPi5/patches/mesa/0025-broadcom-compiler-add-support-for-varyings-on-nir-to.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0025-broadcom-compiler-add-support-for-varyings-on-nir-to.patch
@@ -1,7 +1,7 @@
 From 6a9611c5a22218388bba419174d3343e0cdf773b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 14 Sep 2021 10:42:55 +0200
-Subject: [PATCH 025/139] broadcom/compiler: add support for varyings on nir to
+Subject: [PATCH 025/142] broadcom/compiler: add support for varyings on nir to
  vir generation for v71
 
 Needs update as v71 doesn't have accumulators anymore, and ldvary uses

--- a/projects/RPi/devices/RPi5/patches/mesa/0026-broadcom-compiler-payload_w-is-loaded-on-rf3-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0026-broadcom-compiler-payload_w-is-loaded-on-rf3-for-v71.patch
@@ -1,7 +1,7 @@
 From 06af15a60f7a9c135893e5f8934b8030c1da95f9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 15 Sep 2021 01:14:15 +0200
-Subject: [PATCH 026/139] broadcom/compiler: payload_w is loaded on rf3 for v71
+Subject: [PATCH 026/142] broadcom/compiler: payload_w is loaded on rf3 for v71
 
 And in general rf0 is now used for other needs.
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0027-broadcom-qpu_schedule-update-write-deps-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0027-broadcom-qpu_schedule-update-write-deps-for-v71.patch
@@ -1,7 +1,7 @@
 From d38d8056903b9a4f96ab56261ac3b3c3be0af4fb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 15 Sep 2021 11:12:59 +0200
-Subject: [PATCH 027/139] broadcom/qpu_schedule: update write deps for v71
+Subject: [PATCH 027/142] broadcom/qpu_schedule: update write deps for v71
 
 We just need to add a write dep if rf0 is written implicitly.
 

--- a/projects/RPi/devices/RPi5/patches/mesa/0028-broadcom-compiler-update-register-classes-to-not-inc.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0028-broadcom-compiler-update-register-classes-to-not-inc.patch
@@ -1,7 +1,7 @@
 From 7e2a2be830b1672ab846389a46b5d09bad0f7a98 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 16 Sep 2021 00:49:25 +0200
-Subject: [PATCH 028/139] broadcom/compiler: update register classes to not
+Subject: [PATCH 028/142] broadcom/compiler: update register classes to not
  include accumulators on v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0029-broadcom-compiler-implement-reads-writes-too-soon-ch.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0029-broadcom-compiler-implement-reads-writes-too-soon-ch.patch
@@ -1,7 +1,7 @@
 From 0157228c729b8812dc4900fa24db63b7d27aa342 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 23 Sep 2021 11:19:58 +0200
-Subject: [PATCH 029/139] broadcom/compiler: implement "reads/writes too soon"
+Subject: [PATCH 029/142] broadcom/compiler: implement "reads/writes too soon"
  checks for v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0030-broadcom-compiler-implement-read-stall-check-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0030-broadcom-compiler-implement-read-stall-check-for-v71.patch
@@ -1,7 +1,7 @@
 From 3fb3333bdf9699157cf0a2bd46ba4c25058bc5c1 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 23 Sep 2021 11:44:59 +0200
-Subject: [PATCH 030/139] broadcom/compiler: implement read stall check for v71
+Subject: [PATCH 030/142] broadcom/compiler: implement read stall check for v71
 
 ---
  src/broadcom/compiler/qpu_schedule.c | 32 +++++++++++++++++-----------

--- a/projects/RPi/devices/RPi5/patches/mesa/0031-broadcom-compiler-add-a-v3d71_qpu_writes_waddr_expli.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0031-broadcom-compiler-add-a-v3d71_qpu_writes_waddr_expli.patch
@@ -1,7 +1,7 @@
 From cbe0a7a06a5fb9b3f28acba8c9cac362a6bc5324 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 6 Oct 2021 13:58:00 +0200
-Subject: [PATCH 031/139] broadcom/compiler: add a
+Subject: [PATCH 031/142] broadcom/compiler: add a
  v3d71_qpu_writes_waddr_explicitly helper
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0032-broadcom-compiler-prevent-rf2-3-usage-in-thread-end-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0032-broadcom-compiler-prevent-rf2-3-usage-in-thread-end-.patch
@@ -1,7 +1,7 @@
 From 92e91a9b22ae61dc9f39880e8fdaa7714789efdb Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 27 Sep 2021 11:49:24 +0200
-Subject: [PATCH 032/139] broadcom/compiler: prevent rf2-3 usage in thread end
+Subject: [PATCH 032/142] broadcom/compiler: prevent rf2-3 usage in thread end
  delay slots for v71
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/projects/RPi/devices/RPi5/patches/mesa/0033-broadcom-qpu-add-new-ADD-opcodes-for-FMOV-MOV-in-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0033-broadcom-qpu-add-new-ADD-opcodes-for-FMOV-MOV-in-v71.patch
@@ -1,7 +1,7 @@
 From 68a1545eb973e41608534ff05a9e84a86c046453 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 27 Sep 2021 13:26:04 +0200
-Subject: [PATCH 033/139] broadcom/qpu: add new ADD opcodes for FMOV/MOV in v71
+Subject: [PATCH 033/142] broadcom/qpu: add new ADD opcodes for FMOV/MOV in v71
 
 ---
  src/broadcom/qpu/qpu_instr.c |  5 +++++

--- a/projects/RPi/devices/RPi5/patches/mesa/0034-broadcom-qpu-fix-packing-unpacking-of-fmov-variants-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0034-broadcom-qpu-fix-packing-unpacking-of-fmov-variants-.patch
@@ -1,7 +1,7 @@
 From 8dbbb7e22b694fdc62376d112b3dc6105d556c63 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 4 Oct 2021 13:07:35 +0200
-Subject: [PATCH 034/139] broadcom/qpu: fix packing/unpacking of fmov variants
+Subject: [PATCH 034/142] broadcom/qpu: fix packing/unpacking of fmov variants
  for v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0035-broadcom-qpu-implement-switch-rules-for-fmin-fmax-fa.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0035-broadcom-qpu-implement-switch-rules-for-fmin-fmax-fa.patch
@@ -1,7 +1,7 @@
 From 63d0059ebef288afb0e2e746dadda8c2238bdfcb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 28 Sep 2021 01:17:08 +0200
-Subject: [PATCH 035/139] broadcom/qpu: implement switch rules for fmin/fmax
+Subject: [PATCH 035/142] broadcom/qpu: implement switch rules for fmin/fmax
  fadd/faddnf for v71
 
 They use the same opcodes, and switch between one and the other based

--- a/projects/RPi/devices/RPi5/patches/mesa/0036-broadcom-compiler-make-vir_write_rX-return-false-on-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0036-broadcom-compiler-make-vir_write_rX-return-false-on-.patch
@@ -1,7 +1,7 @@
 From c9f6faa3ddc91024b3d9dc67ce2221187daac128 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 29 Sep 2021 11:54:18 +0200
-Subject: [PATCH 036/139] broadcom/compiler: make vir_write_rX return false on
+Subject: [PATCH 036/142] broadcom/compiler: make vir_write_rX return false on
  platforms without accums
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0037-broadcom-compiler-rename-vir_writes_rX-to-vir_writes.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0037-broadcom-compiler-rename-vir_writes_rX-to-vir_writes.patch
@@ -1,7 +1,7 @@
 From 3d16229743e26b58735ed049ee982073f6034342 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 29 Sep 2021 12:03:50 +0200
-Subject: [PATCH 037/139] broadcom/compiler: rename vir_writes_rX to
+Subject: [PATCH 037/142] broadcom/compiler: rename vir_writes_rX to
  vir_writes_rX_implicitly
 
 Since that represents more accurately what they check..

--- a/projects/RPi/devices/RPi5/patches/mesa/0038-broadcom-compiler-only-handle-accumulator-classes-if.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0038-broadcom-compiler-only-handle-accumulator-classes-if.patch
@@ -1,7 +1,7 @@
 From 83fae160491737e8568b8fb5eaa5be4d2c8bf3c8 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 29 Sep 2021 12:10:31 +0200
-Subject: [PATCH 038/139] broadcom/compiler: only handle accumulator classes if
+Subject: [PATCH 038/142] broadcom/compiler: only handle accumulator classes if
  present
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0039-broadcom-compiler-don-t-assign-rf0-to-temps-across-i.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0039-broadcom-compiler-don-t-assign-rf0-to-temps-across-i.patch
@@ -1,7 +1,7 @@
 From fd77cc3204e7c69927f97ce2a1d55d2a47d77a27 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 29 Sep 2021 12:14:04 +0200
-Subject: [PATCH 039/139] broadcom/compiler: don't assign rf0 to temps across
+Subject: [PATCH 039/142] broadcom/compiler: don't assign rf0 to temps across
  implicit rf0 writes
 
 In platforms that don't have accumulators and have implicit writes to

--- a/projects/RPi/devices/RPi5/patches/mesa/0040-broadcom-compiler-CS-payload-registers-have-changed-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0040-broadcom-compiler-CS-payload-registers-have-changed-.patch
@@ -1,7 +1,7 @@
 From 9a08ae9f354a6da6d9d71b87800aca8b3df49e29 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 28 Sep 2021 13:37:28 +0200
-Subject: [PATCH 040/139] broadcom/compiler: CS payload registers have changed
+Subject: [PATCH 040/142] broadcom/compiler: CS payload registers have changed
  in v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0041-broadcom-compiler-don-t-schedule-rf0-writes-right-af.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0041-broadcom-compiler-don-t-schedule-rf0-writes-right-af.patch
@@ -1,7 +1,7 @@
 From 5477884196cb54a71f54fa6cad42c6d3326bde88 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Fri, 22 Oct 2021 13:39:48 +0200
-Subject: [PATCH 041/139] broadcom/compiler: don't schedule rf0 writes right
+Subject: [PATCH 041/142] broadcom/compiler: don't schedule rf0 writes right
  after ldvary
 
 ldvary writes rf0 implicitly on the next cycle so they would clash.

--- a/projects/RPi/devices/RPi5/patches/mesa/0042-broadcom-compiler-allow-instruction-merges-in-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0042-broadcom-compiler-allow-instruction-merges-in-v71.patch
@@ -1,7 +1,7 @@
 From 31623712c2f741d393767641f32d56c35150eda5 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 30 Sep 2021 13:22:48 +0200
-Subject: [PATCH 042/139] broadcom/compiler: allow instruction merges in v71
+Subject: [PATCH 042/142] broadcom/compiler: allow instruction merges in v71
 
 In v3d 4.x there were restrictions based on the number of raddrs used
 by the combined instructions, but we don't have these restrictions in

--- a/projects/RPi/devices/RPi5/patches/mesa/0043-broadcom-qpu-add-MOV-integer-packing-unpacking-varia.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0043-broadcom-qpu-add-MOV-integer-packing-unpacking-varia.patch
@@ -1,7 +1,7 @@
 From 959a0128654c94d84fda53ffc108971d3b3a817a Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 6 Oct 2021 09:27:43 +0200
-Subject: [PATCH 043/139] broadcom/qpu: add MOV integer packing/unpacking
+Subject: [PATCH 043/142] broadcom/qpu: add MOV integer packing/unpacking
  variants
 
 These are new in v71 and cover MOV on both the ADD and the MUL alus.

--- a/projects/RPi/devices/RPi5/patches/mesa/0044-broadcom-qpu-fail-packing-on-unhandled-mul-pack-unpa.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0044-broadcom-qpu-fail-packing-on-unhandled-mul-pack-unpa.patch
@@ -1,7 +1,7 @@
 From 2e86dd0c357d7b432ce6794ae22fbfae89ad186b Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 6 Oct 2021 12:01:10 +0200
-Subject: [PATCH 044/139] broadcom/qpu: fail packing on unhandled mul
+Subject: [PATCH 044/142] broadcom/qpu: fail packing on unhandled mul
  pack/unpack
 
 We are doing this for the ADD alu already and it may be helpful to

--- a/projects/RPi/devices/RPi5/patches/mesa/0045-broadcom-compiler-generalize-check-for-shaders-using.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0045-broadcom-compiler-generalize-check-for-shaders-using.patch
@@ -1,7 +1,7 @@
 From ed6bfa29d43b5a89ff070961454f1e82e23b4f45 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Fri, 8 Oct 2021 15:10:24 +0200
-Subject: [PATCH 045/139] broadcom/compiler: generalize check for shaders using
+Subject: [PATCH 045/142] broadcom/compiler: generalize check for shaders using
  pixel center W
 
 V3D 4.x has pixel center W in rf0 and V3D 7.x has it in rf3. We already

--- a/projects/RPi/devices/RPi5/patches/mesa/0046-broadcom-compiler-v71-isn-t-affected-by-double-round.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0046-broadcom-compiler-v71-isn-t-affected-by-double-round.patch
@@ -1,7 +1,7 @@
 From e1a0fa2c2010ef29b8cec798cd0fc99cf44f3a2d Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 14 Oct 2021 14:16:40 +0200
-Subject: [PATCH 046/139] broadcom/compiler: v71 isn't affected by
+Subject: [PATCH 046/142] broadcom/compiler: v71 isn't affected by
  double-rounding of viewport X,Y coords
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0047-broadcom-compiler-update-one-TMUWT-restriction-for-v.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0047-broadcom-compiler-update-one-TMUWT-restriction-for-v.patch
@@ -1,7 +1,7 @@
 From 697e6cf01b781b244404872f331a778b6d4e67da Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 19 Oct 2021 11:16:43 +0200
-Subject: [PATCH 047/139] broadcom/compiler: update one TMUWT restriction for
+Subject: [PATCH 047/142] broadcom/compiler: update one TMUWT restriction for
  v71
 
 TMUWT not allowed in the final instruction restriction doesn't apply

--- a/projects/RPi/devices/RPi5/patches/mesa/0048-broadcom-compiler-update-ldunif-ldvary-comment-for-v.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0048-broadcom-compiler-update-ldunif-ldvary-comment-for-v.patch
@@ -1,7 +1,7 @@
 From 26fea727a9f34b75a3fe3f6a806accaddcc317f6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 19 Oct 2021 11:51:32 +0200
-Subject: [PATCH 048/139] broadcom/compiler: update ldunif/ldvary comment for
+Subject: [PATCH 048/142] broadcom/compiler: update ldunif/ldvary comment for
  v71
 
 For v42 and below ldunif/ldvary write both on r5, but with a different

--- a/projects/RPi/devices/RPi5/patches/mesa/0049-broadcom-compiler-update-payload-registers-handling-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0049-broadcom-compiler-update-payload-registers-handling-.patch
@@ -1,7 +1,7 @@
 From 70456e27b039174f767010f96d9b649e5e42d84f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 19 Oct 2021 23:52:30 +0200
-Subject: [PATCH 049/139] broadcom/compiler: update payload registers handling
+Subject: [PATCH 049/142] broadcom/compiler: update payload registers handling
  when computing live intervals
 
 As for v71 the payload registers are not the same. Specifically now

--- a/projects/RPi/devices/RPi5/patches/mesa/0050-broadcom-compiler-update-peripheral-access-restricti.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0050-broadcom-compiler-update-peripheral-access-restricti.patch
@@ -1,7 +1,7 @@
 From f9a76b3a1e316e5ed6387819b87eaaf60f989a2b Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 26 Oct 2021 11:43:02 +0200
-Subject: [PATCH 050/139] broadcom/compiler: update peripheral access
+Subject: [PATCH 050/142] broadcom/compiler: update peripheral access
  restrictions for v71
 
 In V3D 4.x only a couple of simultaneous accesses where allowed, but

--- a/projects/RPi/devices/RPi5/patches/mesa/0051-broadcom-qpu-add-packing-for-fmov-on-ADD-alu.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0051-broadcom-qpu-add-packing-for-fmov-on-ADD-alu.patch
@@ -1,7 +1,7 @@
 From 3520cceb87fb2f9765ba7dbe2771fbd0cadca78d Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 26 Oct 2021 08:37:54 +0200
-Subject: [PATCH 051/139] broadcom/qpu: add packing for fmov on ADD alu
+Subject: [PATCH 051/142] broadcom/qpu: add packing for fmov on ADD alu
 
 ---
  src/broadcom/qpu/qpu_pack.c | 31 +++++++++++++++++++++++++++++++

--- a/projects/RPi/devices/RPi5/patches/mesa/0052-broadcom-compiler-handle-rf0-flops-storage-restricti.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0052-broadcom-compiler-handle-rf0-flops-storage-restricti.patch
@@ -1,7 +1,7 @@
 From 7c7ab15b3c9def4bc3bb5be492228a933c325f8a Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 6 Oct 2021 13:58:27 +0200
-Subject: [PATCH 052/139] broadcom/compiler: handle rf0 flops storage
+Subject: [PATCH 052/142] broadcom/compiler: handle rf0 flops storage
  restriction in v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0053-broadcom-compiler-enable-ldvary-pipelining-on-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0053-broadcom-compiler-enable-ldvary-pipelining-on-v71.patch
@@ -1,7 +1,7 @@
 From 0c6910721eb50b38b3388c2d2344b6ecfe0fee58 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 27 Oct 2021 11:35:12 +0200
-Subject: [PATCH 053/139] broadcom/compiler: enable ldvary pipelining on v71
+Subject: [PATCH 053/142] broadcom/compiler: enable ldvary pipelining on v71
 
 ---
  src/broadcom/compiler/qpu_schedule.c | 121 ++++++++++++++++++---------

--- a/projects/RPi/devices/RPi5/patches/mesa/0054-broadcom-compiler-try-to-use-ldunif-a-instead-of-ldu.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0054-broadcom-compiler-try-to-use-ldunif-a-instead-of-ldu.patch
@@ -1,7 +1,7 @@
 From 0670d642bb91fc68ce73f2d9fb88c482295a446d Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 28 Oct 2021 14:13:29 +0200
-Subject: [PATCH 054/139] broadcom/compiler: try to use ldunif(a) instead of
+Subject: [PATCH 054/142] broadcom/compiler: try to use ldunif(a) instead of
  ldunif(a)rf in v71
 
 The rf variants need to encode the destination in the cond bits, which

--- a/projects/RPi/devices/RPi5/patches/mesa/0055-broadcom-compiler-don-t-assign-rf0-to-temps-that-con.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0055-broadcom-compiler-don-t-assign-rf0-to-temps-that-con.patch
@@ -1,7 +1,7 @@
 From cbed3b97394da09c9ae644c79e098e3ba8b5c3e8 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Fri, 29 Oct 2021 13:00:56 +0200
-Subject: [PATCH 055/139] broadcom/compiler: don't assign rf0 to temps that
+Subject: [PATCH 055/142] broadcom/compiler: don't assign rf0 to temps that
  conflict with ldvary
 
 ldvary writes to rf0 implicitly, so we don't want to allocate rf0 to

--- a/projects/RPi/devices/RPi5/patches/mesa/0056-broadcom-compiler-convert-mul-to-add-when-needed-to-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0056-broadcom-compiler-convert-mul-to-add-when-needed-to-.patch
@@ -1,7 +1,7 @@
 From cbaa469c09974c1574b16f559173694904fe1bb0 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 25 Oct 2021 09:38:57 +0200
-Subject: [PATCH 056/139] broadcom/compiler: convert mul to add when needed to
+Subject: [PATCH 056/142] broadcom/compiler: convert mul to add when needed to
  allow merge
 
 V3D 7.x added 'mov' opcodes to the ADD alu, so now it is possible to

--- a/projects/RPi/devices/RPi5/patches/mesa/0057-broadcom-compiler-implement-small-immediates-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0057-broadcom-compiler-implement-small-immediates-for-v71.patch
@@ -1,7 +1,7 @@
 From b59b3725fb16f4ab1ac0db86a5452a4ed6176074 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 3 Nov 2021 10:34:19 +0100
-Subject: [PATCH 057/139] broadcom/compiler: implement small immediates for v71
+Subject: [PATCH 057/142] broadcom/compiler: implement small immediates for v71
 
 ---
  src/broadcom/compiler/qpu_schedule.c          | 90 +++++++++++++------

--- a/projects/RPi/devices/RPi5/patches/mesa/0058-broadcom-compiler-update-thread-end-restrictions-for.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0058-broadcom-compiler-update-thread-end-restrictions-for.patch
@@ -1,7 +1,7 @@
 From 3af87d2672da7c928ecf8a0a1cd1bef8a6729364 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 22 Nov 2021 12:56:03 +0100
-Subject: [PATCH 058/139] broadcom/compiler: update thread end restrictions for
+Subject: [PATCH 058/142] broadcom/compiler: update thread end restrictions for
  v7.x
 
 In 4.x it is not allowed to write to the register file in the last

--- a/projects/RPi/devices/RPi5/patches/mesa/0059-broadcom-compiler-update-ldvary-thread-switch-delay-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0059-broadcom-compiler-update-ldvary-thread-switch-delay-.patch
@@ -1,7 +1,7 @@
 From 7cfd5b808bb2f1cb17f57435cb5d411c4ac3aa6c Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 23 Nov 2021 10:04:49 +0100
-Subject: [PATCH 059/139] broadcom/compiler: update ldvary thread switch delay
+Subject: [PATCH 059/142] broadcom/compiler: update ldvary thread switch delay
  slot restriction for v7.x
 
 In V3D 7.x we don't have accumulators which would not survive a thread

--- a/projects/RPi/devices/RPi5/patches/mesa/0060-broadcom-compiler-lift-restriction-for-branch-msfign.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0060-broadcom-compiler-lift-restriction-for-branch-msfign.patch
@@ -1,7 +1,7 @@
 From ca4063d627cd31c589a8e8688f2876dd8211d1bc Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 25 Nov 2021 08:31:02 +0100
-Subject: [PATCH 060/139] broadcom/compiler: lift restriction for branch +
+Subject: [PATCH 060/142] broadcom/compiler: lift restriction for branch +
  msfign after setmsf for v7.x
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0061-broadcom-compiler-start-allocating-from-RF-4-in-V7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0061-broadcom-compiler-start-allocating-from-RF-4-in-V7.x.patch
@@ -1,7 +1,7 @@
 From 167510aa43bbcf06e57a64495cee40e8cdaf5f8b Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Fri, 26 Nov 2021 10:37:05 +0100
-Subject: [PATCH 061/139] broadcom/compiler: start allocating from RF 4 in V7.x
+Subject: [PATCH 061/142] broadcom/compiler: start allocating from RF 4 in V7.x
 
 In V3D 4.x we start at RF3 so that we allocate RF0-2 only if there
 aren't any other RFs available. This is useful with small shaders

--- a/projects/RPi/devices/RPi5/patches/mesa/0062-broadcom-compiler-validate-restrictions-after-TLB-Z-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0062-broadcom-compiler-validate-restrictions-after-TLB-Z-.patch
@@ -1,7 +1,7 @@
 From d47ea903b96e43b07bdef21f8026da818e30fcd1 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 25 Nov 2021 13:00:34 +0100
-Subject: [PATCH 062/139] broadcom/compiler: validate restrictions after TLB Z
+Subject: [PATCH 062/142] broadcom/compiler: validate restrictions after TLB Z
  write
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0063-broadcom-compiler-lift-restriction-on-vpmwt-in-last-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0063-broadcom-compiler-lift-restriction-on-vpmwt-in-last-.patch
@@ -1,7 +1,7 @@
 From 6cdf01fad49489b5fc66d231b527de5245d5de32 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 29 Nov 2021 13:23:11 +0100
-Subject: [PATCH 063/139] broadcom/compiler: lift restriction on vpmwt in last
+Subject: [PATCH 063/142] broadcom/compiler: lift restriction on vpmwt in last
  instruction for V3D 7.x
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0064-broadcom-compiler-fix-up-copy-propagation-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0064-broadcom-compiler-fix-up-copy-propagation-for-v71.patch
@@ -1,7 +1,7 @@
 From acc54637f0787ba4dc887130c25c628ccdaf4e38 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 9 Nov 2021 11:34:59 +0100
-Subject: [PATCH 064/139] broadcom/compiler: fix up copy propagation for v71
+Subject: [PATCH 064/142] broadcom/compiler: fix up copy propagation for v71
 
 Update rules for unsafe copy propagations to match v7.x.
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0065-broadcom-qpu-new-packing-conversion-v71-instructions.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0065-broadcom-qpu-new-packing-conversion-v71-instructions.patch
@@ -1,7 +1,7 @@
 From c340f7f1eb4a1e5c0fafe1ea2f801f2ebaf82d8d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 26 Nov 2021 01:24:12 +0100
-Subject: [PATCH 065/139] broadcom/qpu: new packing/conversion v71 instructions
+Subject: [PATCH 065/142] broadcom/qpu: new packing/conversion v71 instructions
 
 This commits adds the qpu definitions for several new v71
 instructions.

--- a/projects/RPi/devices/RPi5/patches/mesa/0066-nir-add-new-opcodes-to-map-new-v71-packing-conversio.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0066-nir-add-new-opcodes-to-map-new-v71-packing-conversio.patch
@@ -1,7 +1,7 @@
 From 4f33de7771621e15aae3e3c60c09fd5a2f29bdac Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 30 Nov 2021 02:39:20 +0100
-Subject: [PATCH 066/139] nir: add new opcodes to map new v71
+Subject: [PATCH 066/142] nir: add new opcodes to map new v71
  packing/conversion instructions
 
 Since v71, broadcom hw include specific packing/conversion

--- a/projects/RPi/devices/RPi5/patches/mesa/0067-broadcom-compiler-update-image-store-lowering-to-use.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0067-broadcom-compiler-update-image-store-lowering-to-use.patch
@@ -1,7 +1,7 @@
 From 381c29e3ff5237c89380cc53eb2271d1985f4e34 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 2 Dec 2021 13:26:43 +0100
-Subject: [PATCH 067/139] broadcom/compiler: update image store lowering to use
+Subject: [PATCH 067/142] broadcom/compiler: update image store lowering to use
  v71 new packing/conversion instructions
 
 Vulkan shaderdb stats with pattern dEQP-VK.image.*.with_format.*.*:

--- a/projects/RPi/devices/RPi5/patches/mesa/0068-broadcom-compiler-don-t-allocate-spill-base-to-rf0-i.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0068-broadcom-compiler-don-t-allocate-spill-base-to-rf0-i.patch
@@ -1,7 +1,7 @@
 From f6082e941a3454c8735df2ff2713ae49b3daa74f Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 18 Apr 2023 08:50:13 +0200
-Subject: [PATCH 068/139] broadcom/compiler: don't allocate spill base to rf0
+Subject: [PATCH 068/142] broadcom/compiler: don't allocate spill base to rf0
  in V3D 7.x
 
 Otherwise it can be stomped by instructions doing implicit rf0 writes.

--- a/projects/RPi/devices/RPi5/patches/mesa/0069-broadcom-compiler-improve-allocation-for-final-progr.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0069-broadcom-compiler-improve-allocation-for-final-progr.patch
@@ -1,7 +1,7 @@
 From 0e9577fbb18a026390f653ca22f5a98a69a5fe59 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 2 May 2023 10:12:37 +0200
-Subject: [PATCH 069/139] broadcom/compiler: improve allocation for final
+Subject: [PATCH 069/142] broadcom/compiler: improve allocation for final
  program instructions
 
 The last 3 instructions can't use specific registers so flag all the

--- a/projects/RPi/devices/RPi5/patches/mesa/0070-broadcom-compiler-don-t-assign-registers-to-unused-n.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0070-broadcom-compiler-don-t-assign-registers-to-unused-n.patch
@@ -1,7 +1,7 @@
 From 645fe451bcecbe3345a144222306d06fb39f6b9f Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 2 May 2023 10:17:47 +0200
-Subject: [PATCH 070/139] broadcom/compiler: don't assign registers to unused
+Subject: [PATCH 070/142] broadcom/compiler: don't assign registers to unused
  nodes/temps
 
 In programs with a lot of unused temps, if we don't do this, we may

--- a/projects/RPi/devices/RPi5/patches/mesa/0071-broadcom-compiler-only-assign-rf0-as-last-resort-in-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0071-broadcom-compiler-only-assign-rf0-as-last-resort-in-.patch
@@ -1,7 +1,7 @@
 From 851704169d59e28c5429b06d05e5ef952be893a2 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 15 May 2023 10:02:10 +0200
-Subject: [PATCH 071/139] broadcom/compiler: only assign rf0 as last resort in
+Subject: [PATCH 071/142] broadcom/compiler: only assign rf0 as last resort in
  V3D 7.x
 
 So we can use it for ldunif(a) and avoid generating ldunif(a)rf which

--- a/projects/RPi/devices/RPi5/patches/mesa/0072-v3dv-recover-non-conformant-warning-for-not-fully-su.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0072-v3dv-recover-non-conformant-warning-for-not-fully-su.patch
@@ -1,7 +1,7 @@
 From 0d3fd30d67ffc0195b0783e30ab6afbbe403310a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 28 Apr 2021 14:31:38 +0200
-Subject: [PATCH 072/139] v3dv: recover non-conformant warning for not fully
+Subject: [PATCH 072/142] v3dv: recover non-conformant warning for not fully
  supported hw
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0073-v3dv-meson-add-v71-hw-generation.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0073-v3dv-meson-add-v71-hw-generation.patch
@@ -1,7 +1,7 @@
 From 52b5ac62b367ae89574c8031fdcf7c1dae05c942 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 29 Jun 2021 11:59:53 +0200
-Subject: [PATCH 073/139] v3dv/meson: add v71 hw generation
+Subject: [PATCH 073/142] v3dv/meson: add v71 hw generation
 
 Starting point for v71 version inclusion.
 

--- a/projects/RPi/devices/RPi5/patches/mesa/0074-v3dv-expose-V3D-revision-number-in-device-name.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0074-v3dv-expose-V3D-revision-number-in-device-name.patch
@@ -1,7 +1,7 @@
 From 7aa016bca8bb1bf449ea79505692353c0bd174b8 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 10 Nov 2021 10:06:50 +0100
-Subject: [PATCH 074/139] v3dv: expose V3D revision number in device name
+Subject: [PATCH 074/142] v3dv: expose V3D revision number in device name
 
 ---
  src/broadcom/vulkan/v3dv_device.c | 6 ++++--

--- a/projects/RPi/devices/RPi5/patches/mesa/0075-v3dv-device-handle-new-rpi5-device-bcm2712.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0075-v3dv-device-handle-new-rpi5-device-bcm2712.patch
@@ -1,7 +1,7 @@
 From fb9e95b7e1d5987fd25e914635c4e09d81ea9561 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 10 Nov 2021 07:54:35 +0100
-Subject: [PATCH 075/139] v3dv/device: handle new rpi5 device (bcm2712)
+Subject: [PATCH 075/142] v3dv/device: handle new rpi5 device (bcm2712)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/projects/RPi/devices/RPi5/patches/mesa/0076-v3dv-cmd_buffer-emit-TILE_BINNING_MODE_CFG-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0076-v3dv-cmd_buffer-emit-TILE_BINNING_MODE_CFG-for-v71.patch
@@ -1,7 +1,7 @@
 From c4f957af4fb0e10abf0a7ffad4f7a468633b7d99 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 20 Jul 2021 14:00:44 +0200
-Subject: [PATCH 076/139] v3dv/cmd_buffer: emit TILE_BINNING_MODE_CFG for v71
+Subject: [PATCH 076/142] v3dv/cmd_buffer: emit TILE_BINNING_MODE_CFG for v71
 
 ---
  src/broadcom/vulkan/v3dvx_cmd_buffer.c | 9 ++++++++-

--- a/projects/RPi/devices/RPi5/patches/mesa/0077-v3dv-emit-TILE_RENDERING_MODE_CFG_COMMON-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0077-v3dv-emit-TILE_RENDERING_MODE_CFG_COMMON-for-v71.patch
@@ -1,7 +1,7 @@
 From 1934ac07df73cb685f6550b8b0f5b4f2ead11396 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 20 Jul 2021 14:33:00 +0200
-Subject: [PATCH 077/139] v3dv: emit TILE_RENDERING_MODE_CFG_COMMON for v71
+Subject: [PATCH 077/142] v3dv: emit TILE_RENDERING_MODE_CFG_COMMON for v71
 
 ---
  src/broadcom/vulkan/v3dvx_cmd_buffer.c  | 9 ++++++++-

--- a/projects/RPi/devices/RPi5/patches/mesa/0078-v3dv-cmd_buffer-emit-TILE_RENDERING_MODE_CFG_RENDER_.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0078-v3dv-cmd_buffer-emit-TILE_RENDERING_MODE_CFG_RENDER_.patch
@@ -1,7 +1,7 @@
 From f0f9eea3cad83ed8824c6a7686150327407a5286 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 22 Jul 2021 14:26:13 +0200
-Subject: [PATCH 078/139] v3dv/cmd_buffer: emit
+Subject: [PATCH 078/142] v3dv/cmd_buffer: emit
  TILE_RENDERING_MODE_CFG_RENDER_TARGET_PART1 for v71
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/projects/RPi/devices/RPi5/patches/mesa/0079-v3dvx-cmd_buffer-emit-CLEAR_RENDER_TARGETS-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0079-v3dvx-cmd_buffer-emit-CLEAR_RENDER_TARGETS-for-v71.patch
@@ -1,7 +1,7 @@
 From 7c89d8026fd550282d54933f37ffc2773869326f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Mon, 26 Jul 2021 15:08:11 +0200
-Subject: [PATCH 079/139] v3dvx/cmd_buffer: emit CLEAR_RENDER_TARGETS for v71
+Subject: [PATCH 079/142] v3dvx/cmd_buffer: emit CLEAR_RENDER_TARGETS for v71
 
 ---
  src/broadcom/vulkan/v3dvx_cmd_buffer.c | 2 +-

--- a/projects/RPi/devices/RPi5/patches/mesa/0080-v3dv-cmd_buffer-emit-CLIPPER_XY_SCALING-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0080-v3dv-cmd_buffer-emit-CLIPPER_XY_SCALING-for-v71.patch
@@ -1,7 +1,7 @@
 From 2eb29b57fde2acda76e12953b3a1050f3056b39d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Sun, 19 Sep 2021 23:37:32 +0200
-Subject: [PATCH 080/139] v3dv/cmd_buffer: emit CLIPPER_XY_SCALING for v71
+Subject: [PATCH 080/142] v3dv/cmd_buffer: emit CLIPPER_XY_SCALING for v71
 
 ---
  src/broadcom/vulkan/v3dvx_cmd_buffer.c | 7 ++++---

--- a/projects/RPi/devices/RPi5/patches/mesa/0081-v3dv-uniforms-update-VIEWPORT_X-Y_SCALE-uniforms-for.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0081-v3dv-uniforms-update-VIEWPORT_X-Y_SCALE-uniforms-for.patch
@@ -1,7 +1,7 @@
 From 611bf6a7445837c7e20416ff9f11a6dad9c543d7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 14 Sep 2021 10:08:19 +0200
-Subject: [PATCH 081/139] v3dv/uniforms: update VIEWPORT_X/Y_SCALE uniforms for
+Subject: [PATCH 081/142] v3dv/uniforms: update VIEWPORT_X/Y_SCALE uniforms for
  v71
 
 As the packet CLIPPER_XY scaling, this needs to be computed on 1/64ths

--- a/projects/RPi/devices/RPi5/patches/mesa/0082-v3dv-cmd_buffer-just-don-t-fill-up-early-z-fields-fo.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0082-v3dv-cmd_buffer-just-don-t-fill-up-early-z-fields-fo.patch
@@ -1,7 +1,7 @@
 From 3819efaf2bb6fd8bd9cd45d54fb7254377b2296a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 27 Jul 2021 14:02:30 +0200
-Subject: [PATCH 082/139] v3dv/cmd_buffer: just don't fill up early-z fields
+Subject: [PATCH 082/142] v3dv/cmd_buffer: just don't fill up early-z fields
  for CFG_BITS for v71
 
 For v71 early_z_enable/early_z_updates_enable is configured with

--- a/projects/RPi/devices/RPi5/patches/mesa/0083-v3dv-default-vertex-attribute-values-are-gen-dependa.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0083-v3dv-default-vertex-attribute-values-are-gen-dependa.patch
@@ -1,7 +1,7 @@
 From e3b1a578f45ea830d790970115b6de978d56edb8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 28 Jul 2021 12:01:38 +0200
-Subject: [PATCH 083/139] v3dv: default vertex attribute values are gen
+Subject: [PATCH 083/142] v3dv: default vertex attribute values are gen
  dependant
 
 Content, structure and size would depend on the generation. Even if it

--- a/projects/RPi/devices/RPi5/patches/mesa/0084-v3dv-pipeline-default-vertex-attributes-values-are-n.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0084-v3dv-pipeline-default-vertex-attributes-values-are-n.patch
@@ -1,7 +1,7 @@
 From 8464dc8869f3d2eccfecac7b4358cc0ffe05f081 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 28 Jul 2021 12:05:26 +0200
-Subject: [PATCH 084/139] v3dv/pipeline: default vertex attributes values are
+Subject: [PATCH 084/142] v3dv/pipeline: default vertex attributes values are
  not needed for v71
 
 There are not part of the shader state record.

--- a/projects/RPi/devices/RPi5/patches/mesa/0085-v3dv-pipeline-handle-GL_SHADER_STATE_RECORD-changed-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0085-v3dv-pipeline-handle-GL_SHADER_STATE_RECORD-changed-.patch
@@ -1,7 +1,7 @@
 From 339096598660ec34be8087007dd4d66581de1c4e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 28 Jul 2021 13:45:52 +0200
-Subject: [PATCH 085/139] v3dv/pipeline: handle GL_SHADER_STATE_RECORD changed
+Subject: [PATCH 085/142] v3dv/pipeline: handle GL_SHADER_STATE_RECORD changed
  size on v71
 
 It is likely that we would need more changes, as this packet changed,

--- a/projects/RPi/devices/RPi5/patches/mesa/0086-v3dv-setup-render-pass-color-clears-for-any-format-b.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0086-v3dv-setup-render-pass-color-clears-for-any-format-b.patch
@@ -1,7 +1,7 @@
 From 5b1342eb1e255d17619b1a7b33eaf7b31f5e50a5 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 22 Sep 2021 12:03:58 +0200
-Subject: [PATCH 086/139] v3dv: setup render pass color clears for any format
+Subject: [PATCH 086/142] v3dv: setup render pass color clears for any format
  bpp in v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0087-v3dv-setup-TLB-clear-color-for-meta-operations-in-v7.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0087-v3dv-setup-TLB-clear-color-for-meta-operations-in-v7.patch
@@ -1,7 +1,7 @@
 From ff5b5d4405b1d5600d7f1c4355202fd303f56700 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 22 Sep 2021 12:04:21 +0200
-Subject: [PATCH 087/139] v3dv: setup TLB clear color for meta operations in
+Subject: [PATCH 087/142] v3dv: setup TLB clear color for meta operations in
  v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0088-v3dv-fix-up-texture-shader-state-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0088-v3dv-fix-up-texture-shader-state-for-v71.patch
@@ -1,7 +1,7 @@
 From 1e9d7d69849fa646b331f7661c74ee138badc4bb Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 25 Oct 2021 01:37:12 +0200
-Subject: [PATCH 088/139] v3dv: fix up texture shader state for v71
+Subject: [PATCH 088/142] v3dv: fix up texture shader state for v71
 
 There are some new fields for YCbCr with pointers for the various
 planes in multi-planar formats. These need to match the base address

--- a/projects/RPi/devices/RPi5/patches/mesa/0089-v3dv-handle-new-texture-state-transfer-functions-in-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0089-v3dv-handle-new-texture-state-transfer-functions-in-.patch
@@ -1,7 +1,7 @@
 From 1f150a3a92741f7654a13626bd5b27b5575f2b76 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Mon, 25 Oct 2021 01:38:31 +0200
-Subject: [PATCH 089/139] v3dv: handle new texture state transfer functions in
+Subject: [PATCH 089/142] v3dv: handle new texture state transfer functions in
  v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0090-v3dv-implement-noop-job-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0090-v3dv-implement-noop-job-for-v71.patch
@@ -1,7 +1,7 @@
 From 45de9f019ee92635de9a505db58439f0f4561281 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 28 Sep 2021 08:14:11 +0200
-Subject: [PATCH 090/139] v3dv: implement noop job for v71
+Subject: [PATCH 090/142] v3dv: implement noop job for v71
 
 ---
  src/broadcom/vulkan/v3dvx_queue.c | 10 +++++++---

--- a/projects/RPi/devices/RPi5/patches/mesa/0091-v3dv-handle-render-pass-global-clear-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0091-v3dv-handle-render-pass-global-clear-for-v71.patch
@@ -1,7 +1,7 @@
 From 3e607bb28056bb52242be6878281efae84026813 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 28 Sep 2021 08:23:48 +0200
-Subject: [PATCH 091/139] v3dv: handle render pass global clear for v71
+Subject: [PATCH 091/142] v3dv: handle render pass global clear for v71
 
 ---
  src/broadcom/vulkan/v3dvx_cmd_buffer.c | 66 ++++++++++++++++----------

--- a/projects/RPi/devices/RPi5/patches/mesa/0092-v3dv-GFX-1461-does-not-affect-V3D-7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0092-v3dv-GFX-1461-does-not-affect-V3D-7.x.patch
@@ -1,7 +1,7 @@
 From 3794f6f08c559c4e442b57e992d501fb7d515b9b Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 28 Sep 2021 08:31:04 +0200
-Subject: [PATCH 092/139] v3dv: GFX-1461 does not affect V3D 7.x
+Subject: [PATCH 092/142] v3dv: GFX-1461 does not affect V3D 7.x
 
 ---
  src/broadcom/vulkan/v3dv_pass.c | 6 ++++--

--- a/projects/RPi/devices/RPi5/patches/mesa/0093-v3dv-update-thread-end-restrictions-validation-for-v.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0093-v3dv-update-thread-end-restrictions-validation-for-v.patch
@@ -1,7 +1,7 @@
 From 5be7f484210103e40b77fa3135042da4a8406659 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 28 Sep 2021 08:59:08 +0200
-Subject: [PATCH 093/139] v3dv: update thread end restrictions validation for
+Subject: [PATCH 093/142] v3dv: update thread end restrictions validation for
  v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0094-v3dv-handle-early-Z-S-clears-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0094-v3dv-handle-early-Z-S-clears-for-v71.patch
@@ -1,7 +1,7 @@
 From a751dff57b6d769f5b031054cc65415cc3b44c08 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 29 Sep 2021 08:22:59 +0200
-Subject: [PATCH 094/139] v3dv: handle early Z/S clears for v71
+Subject: [PATCH 094/142] v3dv: handle early Z/S clears for v71
 
 ---
  src/broadcom/vulkan/v3dvx_cmd_buffer.c | 30 ++++++++++++++++++++------

--- a/projects/RPi/devices/RPi5/patches/mesa/0095-v3dv-handle-RTs-with-no-color-targets-in-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0095-v3dv-handle-RTs-with-no-color-targets-in-v71.patch
@@ -1,7 +1,7 @@
 From 2add46ebce4760bf8349606201324ee0e6b1f9da Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 29 Sep 2021 09:07:28 +0200
-Subject: [PATCH 095/139] v3dv: handle RTs with no color targets in v71
+Subject: [PATCH 095/142] v3dv: handle RTs with no color targets in v71
 
 ---
  src/broadcom/vulkan/v3dvx_cmd_buffer.c | 11 +++++++++++

--- a/projects/RPi/devices/RPi5/patches/mesa/0096-v3dv-no-specific-separate_segments-flag-for-V3D-7.1.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0096-v3dv-no-specific-separate_segments-flag-for-V3D-7.1.patch
@@ -1,7 +1,7 @@
 From 019abbd34d2d904d6bb33f9fa4433cb53ca7899c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 1 Oct 2021 15:18:38 +0200
-Subject: [PATCH 096/139] v3dv: no specific separate_segments flag for V3D 7.1
+Subject: [PATCH 096/142] v3dv: no specific separate_segments flag for V3D 7.1
 
 On V3D 7.1 there is not a flag on the Shader State Record to specify
 if we are using shared or separate segments. This is done by setting

--- a/projects/RPi/devices/RPi5/patches/mesa/0097-v3dv-don-t-convert-floating-point-border-colors-in-v.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0097-v3dv-don-t-convert-floating-point-border-colors-in-v.patch
@@ -1,7 +1,7 @@
 From 4f6b4f91577ec04aab907d59d836d0c17731a9d0 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 7 Oct 2021 12:43:49 +0200
-Subject: [PATCH 097/139] v3dv: don't convert floating point border colors in
+Subject: [PATCH 097/142] v3dv: don't convert floating point border colors in
  v71
 
 The TMU does this for us now.

--- a/projects/RPi/devices/RPi5/patches/mesa/0098-v3dv-handle-Z-clipping-in-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0098-v3dv-handle-Z-clipping-in-v71.patch
@@ -1,7 +1,7 @@
 From d8083cb8f104e0f035f5b812e000a500fa52d66f Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Fri, 15 Oct 2021 13:06:31 +0200
-Subject: [PATCH 098/139] v3dv: handle Z clipping in v71
+Subject: [PATCH 098/142] v3dv: handle Z clipping in v71
 
 Fixes the following tests:
 

--- a/projects/RPi/devices/RPi5/patches/mesa/0099-broadcom-common-add-TFU-register-definitions-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0099-broadcom-common-add-TFU-register-definitions-for-v71.patch
@@ -1,7 +1,7 @@
 From 2925fa6dc936d9268a59d8d7d4a775e89fd3fbdb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 17 Nov 2021 11:33:59 +0100
-Subject: [PATCH 099/139] broadcom/common: add TFU register definitions for v71
+Subject: [PATCH 099/142] broadcom/common: add TFU register definitions for v71
 
 ---
  src/broadcom/common/v3d_tfu.h | 23 +++++++++++++++++++++++

--- a/projects/RPi/devices/RPi5/patches/mesa/0100-broadcom-simulator-TFU-register-names-changed-for-v7.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0100-broadcom-simulator-TFU-register-names-changed-for-v7.patch
@@ -1,7 +1,7 @@
 From 6d10aa8a64e009d4d1f4f05885621bd2d9a72465 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 23 Sep 2021 13:09:41 +0200
-Subject: [PATCH 100/139] broadcom/simulator: TFU register names changed for
+Subject: [PATCH 100/142] broadcom/simulator: TFU register names changed for
  v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0101-v3dv-add-support-for-TFU-jobs-in-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0101-v3dv-add-support-for-TFU-jobs-in-v71.patch
@@ -1,7 +1,7 @@
 From 780f012747f2cc6e816b1955081dbeca9a0abe5c Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 23 Sep 2021 12:12:18 +0200
-Subject: [PATCH 101/139] v3dv: add support for TFU jobs in v71
+Subject: [PATCH 101/142] v3dv: add support for TFU jobs in v71
 
 ---
  include/drm-uapi/v3d_drm.h              |  5 ++++

--- a/projects/RPi/devices/RPi5/patches/mesa/0102-v3dv-make-v3dv_viewport_compute_xform-depend-on-the-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0102-v3dv-make-v3dv_viewport_compute_xform-depend-on-the-.patch
@@ -1,7 +1,7 @@
 From 07cba940af2fe0c40641816bee280b57a40973fb Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 20 Oct 2021 11:22:11 +0200
-Subject: [PATCH 102/139] v3dv: make v3dv_viewport_compute_xform depend on the
+Subject: [PATCH 102/142] v3dv: make v3dv_viewport_compute_xform depend on the
  V3D version
 
 For 4.x we have a workaround for too small Z scale values that is

--- a/projects/RPi/devices/RPi5/patches/mesa/0103-v3dv-fix-depth-clipping-then-Z-scale-is-too-small-in.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0103-v3dv-fix-depth-clipping-then-Z-scale-is-too-small-in.patch
@@ -1,7 +1,7 @@
 From c6b60ee47c50474030f8a0a92bd4c6a071f926dc Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 14 Feb 2023 10:09:53 +0100
-Subject: [PATCH 103/139] v3dv: fix depth clipping then Z scale is too small in
+Subject: [PATCH 103/142] v3dv: fix depth clipping then Z scale is too small in
  V3D 7.x
 
 When the Z scale is too small guardband clipping may not clip

--- a/projects/RPi/devices/RPi5/patches/mesa/0104-v3d-add-a-non-conformant-warning-for-not-fully-suppo.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0104-v3d-add-a-non-conformant-warning-for-not-fully-suppo.patch
@@ -1,7 +1,7 @@
 From 46e2b22f43290e6fe92f5435af174c4b18bb6ef5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 21 Oct 2021 22:52:47 +0200
-Subject: [PATCH 104/139] v3d: add a non-conformant warning for not fully
+Subject: [PATCH 104/142] v3d: add a non-conformant warning for not fully
  supported hw
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0105-v3d-add-v71-hw-generation.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0105-v3d-add-v71-hw-generation.patch
@@ -1,7 +1,7 @@
 From 46ffdc57ac7fbe71e92b22e1fe93185f3d33a3ac Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 23 May 2023 23:32:37 +0200
-Subject: [PATCH 105/139] v3d: add v71 hw generation
+Subject: [PATCH 105/142] v3d: add v71 hw generation
 
 Starting point for v71 version inclusion:
  * Adds as one of the versions to be compiled on meson

--- a/projects/RPi/devices/RPi5/patches/mesa/0106-v3d-emit-TILE_BINNING_MODE_CFG-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0106-v3d-emit-TILE_BINNING_MODE_CFG-for-v71.patch
@@ -1,7 +1,7 @@
 From 1ef6241854666a00d43401039809f2470d3a2cc0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 20 Oct 2021 14:31:10 +0200
-Subject: [PATCH 106/139] v3d: emit TILE_BINNING_MODE_CFG for v71
+Subject: [PATCH 106/142] v3d: emit TILE_BINNING_MODE_CFG for v71
 
 ---
  src/gallium/drivers/v3d/v3dx_draw.c | 16 +++++++++++++++-

--- a/projects/RPi/devices/RPi5/patches/mesa/0107-v3d-emit-TILE_RENDERING_MODE_CFG_COMMON-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0107-v3d-emit-TILE_RENDERING_MODE_CFG_COMMON-for-v71.patch
@@ -1,7 +1,7 @@
 From dfdfcf3853d7178acff288a368dfc169018c186a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 20 Oct 2021 14:42:43 +0200
-Subject: [PATCH 107/139] v3d: emit TILE_RENDERING_MODE_CFG_COMMON for v71
+Subject: [PATCH 107/142] v3d: emit TILE_RENDERING_MODE_CFG_COMMON for v71
 
 ---
  src/gallium/drivers/v3d/v3dx_rcl.c | 13 +++++++++++--

--- a/projects/RPi/devices/RPi5/patches/mesa/0108-v3d-TILE_RENDERING_MODE_CFG_RENDER_TARGET_PART1.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0108-v3d-TILE_RENDERING_MODE_CFG_RENDER_TARGET_PART1.patch
@@ -1,7 +1,7 @@
 From 34b32f1ee504449e39529110631c389fa9e9e409 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 20 Oct 2021 15:12:15 +0200
-Subject: [PATCH 108/139] v3d: TILE_RENDERING_MODE_CFG_RENDER_TARGET_PART1
+Subject: [PATCH 108/142] v3d: TILE_RENDERING_MODE_CFG_RENDER_TARGET_PART1
 
 ---
  src/gallium/drivers/v3d/v3dx_rcl.c | 130 +++++++++++++++++++++++++----

--- a/projects/RPi/devices/RPi5/patches/mesa/0109-v3d-emit-CLEAR_RENDER_TARGETS-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0109-v3d-emit-CLEAR_RENDER_TARGETS-for-v71.patch
@@ -1,7 +1,7 @@
 From 8496282476420e7e5d9d31f6cfd87f3f3b136446 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 21 Oct 2021 01:47:29 +0200
-Subject: [PATCH 109/139] v3d: emit CLEAR_RENDER_TARGETS for v71
+Subject: [PATCH 109/142] v3d: emit CLEAR_RENDER_TARGETS for v71
 
 ---
  src/gallium/drivers/v3d/v3dx_rcl.c | 14 +++++++-------

--- a/projects/RPi/devices/RPi5/patches/mesa/0110-v3d-just-don-t-fill-up-early-z-fields-for-CFG_BITS-f.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0110-v3d-just-don-t-fill-up-early-z-fields-for-CFG_BITS-f.patch
@@ -1,7 +1,7 @@
 From 4de1ace1c7b3b6436a5de8e4c6a2f52d6308ff5c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 21 Oct 2021 13:09:03 +0200
-Subject: [PATCH 110/139] v3d: just don't fill up early-z fields for CFG_BITS
+Subject: [PATCH 110/142] v3d: just don't fill up early-z fields for CFG_BITS
  for v71
 
 v71 doesn't include early_z_enable/early_z_updates_enable. They are

--- a/projects/RPi/devices/RPi5/patches/mesa/0111-v3d-emit-CLIPPER_XY_SCALING-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0111-v3d-emit-CLIPPER_XY_SCALING-for-v71.patch
@@ -1,7 +1,7 @@
 From 0683f6db1cd50659829fe53f49427bfdacb707b6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 21 Oct 2021 13:14:32 +0200
-Subject: [PATCH 111/139] v3d: emit CLIPPER_XY_SCALING for v71
+Subject: [PATCH 111/142] v3d: emit CLIPPER_XY_SCALING for v71
 
 ---
  src/gallium/drivers/v3d/v3dx_emit.c | 7 ++++++-

--- a/projects/RPi/devices/RPi5/patches/mesa/0112-v3d-no-specific-separate_segments-flag-for-V3D-7.1.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0112-v3d-no-specific-separate_segments-flag-for-V3D-7.1.patch
@@ -1,7 +1,7 @@
 From 1d1aa5ce739644c72b44ffe547b7233ad19e26b5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 21 Oct 2021 13:19:49 +0200
-Subject: [PATCH 112/139] v3d: no specific separate_segments flag for V3D 7.1
+Subject: [PATCH 112/142] v3d: no specific separate_segments flag for V3D 7.1
 
 On V3D 7.1 there is not a flag on the Shader State Record to specify
 if we are using shared or separate segments. This is done by setting

--- a/projects/RPi/devices/RPi5/patches/mesa/0113-v3d-default-vertex-attributes-values-are-not-needed-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0113-v3d-default-vertex-attributes-values-are-not-needed-.patch
@@ -1,7 +1,7 @@
 From 3a790ddd27c8406c59426599fb9cadb5de5c024d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 21 Oct 2021 13:37:46 +0200
-Subject: [PATCH 113/139] v3d: default vertex attributes values are not needed
+Subject: [PATCH 113/142] v3d: default vertex attributes values are not needed
  for v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0114-v3d-uniforms-update-VIEWPORT_X-Y_SCALE-uniforms-for-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0114-v3d-uniforms-update-VIEWPORT_X-Y_SCALE-uniforms-for-.patch
@@ -1,7 +1,7 @@
 From 8e3a2a35df5789687993d05436602821186e1cf2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 21 Oct 2021 13:46:11 +0200
-Subject: [PATCH 114/139] v3d/uniforms: update VIEWPORT_X/Y_SCALE uniforms for
+Subject: [PATCH 114/142] v3d/uniforms: update VIEWPORT_X/Y_SCALE uniforms for
  v71
 
 As the packet CLIPPER_XY scaling, this needs to be computed on 1/64ths

--- a/projects/RPi/devices/RPi5/patches/mesa/0115-v3d-handle-new-texture-state-transfer-functions-in-v.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0115-v3d-handle-new-texture-state-transfer-functions-in-v.patch
@@ -1,7 +1,7 @@
 From aa6f70116d9e7be56cdb52b55d75419bf7209185 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Thu, 21 Oct 2021 23:21:02 +0200
-Subject: [PATCH 115/139] v3d: handle new texture state transfer functions in
+Subject: [PATCH 115/142] v3d: handle new texture state transfer functions in
  v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0116-v3d-handle-new-TEXTURE_SHADER_STATE-v71-YCbCr-fields.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0116-v3d-handle-new-TEXTURE_SHADER_STATE-v71-YCbCr-fields.patch
@@ -1,7 +1,7 @@
 From aefc98b6aefc38caa6f6efd421db6d02c42596a7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 22 Oct 2021 10:54:24 +0200
-Subject: [PATCH 116/139] v3d: handle new TEXTURE_SHADER_STATE v71 YCbCr fields
+Subject: [PATCH 116/142] v3d: handle new TEXTURE_SHADER_STATE v71 YCbCr fields
 
 There are some new fields for YCbCr with pointers for the various
 planes in multi-planar formats. These need to match the base address

--- a/projects/RPi/devices/RPi5/patches/mesa/0117-v3d-setup-render-pass-color-clears-for-any-format-bp.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0117-v3d-setup-render-pass-color-clears-for-any-format-bp.patch
@@ -1,7 +1,7 @@
 From fcb3fc1ead4344da59c4b26a81878d53f8f4a291 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 22 Oct 2021 11:40:49 +0200
-Subject: [PATCH 117/139] v3d: setup render pass color clears for any format
+Subject: [PATCH 117/142] v3d: setup render pass color clears for any format
  bpp in v71
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0118-v3d-GFX-1461-does-not-affect-V3D-7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0118-v3d-GFX-1461-does-not-affect-V3D-7.x.patch
@@ -1,7 +1,7 @@
 From ceb088c05f351b40df14069bd6e0de777288ece4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 22 Oct 2021 12:17:45 +0200
-Subject: [PATCH 118/139] v3d: GFX-1461 does not affect V3D 7.x
+Subject: [PATCH 118/142] v3d: GFX-1461 does not affect V3D 7.x
 
 ---
  src/gallium/drivers/v3d/v3dx_draw.c | 5 +++--

--- a/projects/RPi/devices/RPi5/patches/mesa/0119-v3d-don-t-convert-floating-point-border-colors-in-v7.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0119-v3d-don-t-convert-floating-point-border-colors-in-v7.patch
@@ -1,7 +1,7 @@
 From b44a8785c5436fb28b6734d3bac806d3a82c828d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 22 Oct 2021 13:41:09 +0200
-Subject: [PATCH 119/139] v3d: don't convert floating point border colors in
+Subject: [PATCH 119/142] v3d: don't convert floating point border colors in
  v71
 
 The TMU does this for us now.

--- a/projects/RPi/devices/RPi5/patches/mesa/0120-v3d-handle-Z-clipping-in-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0120-v3d-handle-Z-clipping-in-v71.patch
@@ -1,7 +1,7 @@
 From ecc1a5fa6b09a684a1e831c342121ec417f1a101 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 22 Oct 2021 14:26:29 +0200
-Subject: [PATCH 120/139] v3d: handle Z clipping in v71
+Subject: [PATCH 120/142] v3d: handle Z clipping in v71
 
 ---
  src/gallium/drivers/v3d/v3dx_emit.c | 15 ++++++++++++++-

--- a/projects/RPi/devices/RPi5/patches/mesa/0121-v3d-add-support-for-TFU-blit-in-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0121-v3d-add-support-for-TFU-blit-in-v71.patch
@@ -1,7 +1,7 @@
 From ecac3d8441b75011446b566320194df17beba352 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Wed, 27 Oct 2021 02:03:10 +0200
-Subject: [PATCH 121/139] v3d: add support for TFU blit in v71
+Subject: [PATCH 121/142] v3d: add support for TFU blit in v71
 
 TFU has changed on v71, specially on which registers to use, so that
 means that support code change across versions. So as part of this

--- a/projects/RPi/devices/RPi5/patches/mesa/0122-v3d-v3dv-fix-texture-state-array-stride-packing-for-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0122-v3d-v3dv-fix-texture-state-array-stride-packing-for-.patch
@@ -1,7 +1,7 @@
 From ed7e118a6cc0c9bba9f02929e98bc51252331950 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 16 May 2023 00:28:27 +0200
-Subject: [PATCH 122/139] v3d/v3dv: fix texture state array stride packing for
+Subject: [PATCH 122/142] v3d/v3dv: fix texture state array stride packing for
  V3D 7.1.5
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0123-v3d-v3dv-support-up-to-8-render-targets-in-v7.1.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0123-v3d-v3dv-support-up-to-8-render-targets-in-v7.1.patch
@@ -1,7 +1,7 @@
 From 48893b056a07b7eda4fe3dea7f068c403981b621 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Fri, 12 Nov 2021 10:35:59 +0100
-Subject: [PATCH 123/139] v3d,v3dv: support up to 8 render targets in v7.1+
+Subject: [PATCH 123/142] v3d,v3dv: support up to 8 render targets in v7.1+
 
 ---
  src/broadcom/common/v3d_limits.h       |  3 +-

--- a/projects/RPi/devices/RPi5/patches/mesa/0124-v3d-v3dv-don-t-use-max-internal-bpp-for-tile-sizing-.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0124-v3d-v3dv-don-t-use-max-internal-bpp-for-tile-sizing-.patch
@@ -1,7 +1,7 @@
 From cc5afd808039f3e0b81fe0615745b74cbb31d0bf Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 16 Nov 2021 11:26:17 +0100
-Subject: [PATCH 124/139] v3d,v3dv: don't use max internal bpp for tile sizing
+Subject: [PATCH 124/142] v3d,v3dv: don't use max internal bpp for tile sizing
  in V3D 7.x
 
 We can use the actual bpp of each color attachment to compute real

--- a/projects/RPi/devices/RPi5/patches/mesa/0125-v3dv-implement-depthBounds-support-for-v71.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0125-v3dv-implement-depthBounds-support-for-v71.patch
@@ -1,7 +1,7 @@
 From 210338b6b1b030d36acaebad504ed2bec4a2cd74 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Fri, 19 Nov 2021 10:51:37 +0100
-Subject: [PATCH 125/139] v3dv: implement depthBounds support for v71
+Subject: [PATCH 125/142] v3dv: implement depthBounds support for v71
 
 Just for for v71, as that feature is not supported by older hw.
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0126-v3d-v3dv-propagate-NaNs-bits-in-shader-state-records.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0126-v3d-v3dv-propagate-NaNs-bits-in-shader-state-records.patch
@@ -1,7 +1,7 @@
 From be6508ffef8c0e9fbc47175739db80a3eeff2cdb Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Fri, 3 Dec 2021 13:20:22 +0100
-Subject: [PATCH 126/139] v3d,v3dv: propagate NaNs bits in shader state records
+Subject: [PATCH 126/142] v3d,v3dv: propagate NaNs bits in shader state records
  are reserved in v7.x
 
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0127-v3dv-use-new-texture-shader-state-rb_swap-and-revers.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0127-v3dv-use-new-texture-shader-state-rb_swap-and-revers.patch
@@ -1,7 +1,7 @@
 From c74ba2b39e7b9fe6c5415c20c98cd231d2674df6 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Tue, 16 May 2023 00:38:40 +0200
-Subject: [PATCH 127/139] v3dv: use new texture shader state rb_swap and
+Subject: [PATCH 127/142] v3dv: use new texture shader state rb_swap and
  reverse fields in v3d 7.x
 
 In v3d 4.x we handle formats that are reversed or R/B swapped by

--- a/projects/RPi/devices/RPi5/patches/mesa/0128-v3dv-fix-color-write-mask-for-v3d-7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0128-v3dv-fix-color-write-mask-for-v3d-7.x.patch
@@ -1,7 +1,7 @@
 From ef1159ad68e4969992a61b1fcdf9103409f689ca Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 8 Feb 2023 08:41:12 +0100
-Subject: [PATCH 128/139] v3dv: fix color write mask for v3d 7.x
+Subject: [PATCH 128/142] v3dv: fix color write mask for v3d 7.x
 
 ---
  src/broadcom/vulkan/v3dvx_cmd_buffer.c | 10 ++++++++--

--- a/projects/RPi/devices/RPi5/patches/mesa/0129-v3d-v3dv-fix-depth-bias-for-v3d-7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0129-v3d-v3dv-fix-depth-bias-for-v3d-7.x.patch
@@ -1,7 +1,7 @@
 From aee0180b79a6a546d1e7263d89ef868016082687 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 8 Feb 2023 09:04:02 +0100
-Subject: [PATCH 129/139] v3d,v3dv: fix depth bias for v3d 7.x
+Subject: [PATCH 129/142] v3d,v3dv: fix depth bias for v3d 7.x
 
 In v3d 7.x we don't need to scale up depth bias for D16 buffers.
 ---

--- a/projects/RPi/devices/RPi5/patches/mesa/0130-v3d-v3dv-fix-compute-for-V3D-7.1.6.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0130-v3d-v3dv-fix-compute-for-V3D-7.1.6.patch
@@ -1,7 +1,7 @@
 From 221d4079c616752b249cefb352268fce5758b578 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Thu, 9 Mar 2023 19:05:19 +0100
-Subject: [PATCH 130/139] v3d,v3dv: fix compute for V3D 7.1.6+
+Subject: [PATCH 130/142] v3d,v3dv: fix compute for V3D 7.1.6+
 
 ---
  src/broadcom/vulkan/v3dv_cmd_buffer.c | 25 +++++++++++++++++++++----

--- a/projects/RPi/devices/RPi5/patches/mesa/0131-broadcom-add-performance-counters-for-V3D-7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0131-broadcom-add-performance-counters-for-V3D-7.x.patch
@@ -1,7 +1,7 @@
 From be6c7ba62dbdb9c5babd33a518a042dd554679d7 Mon Sep 17 00:00:00 2001
 From: "Juan A. Suarez Romero" <jasuarez@igalia.com>
 Date: Wed, 22 Feb 2023 09:43:40 +0100
-Subject: [PATCH 131/139] broadcom: add performance counters for V3D 7.x
+Subject: [PATCH 131/142] broadcom: add performance counters for V3D 7.x
 
 Some of the counters need to be defined correctly.
 

--- a/projects/RPi/devices/RPi5/patches/mesa/0132-broadcom-simulator-add-per-hw-version-calls.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0132-broadcom-simulator-add-per-hw-version-calls.patch
@@ -1,7 +1,7 @@
 From f7d5b57bca07eb9ba6fb292852e3b5057c0a8b8f Mon Sep 17 00:00:00 2001
 From: "Juan A. Suarez Romero" <jasuarez@igalia.com>
 Date: Mon, 20 Mar 2023 16:48:51 +0100
-Subject: [PATCH 132/139] broadcom/simulator: add per-hw version calls
+Subject: [PATCH 132/142] broadcom/simulator: add per-hw version calls
 
 Add a wrapper to allow calling the right simulator function based on the
 hardware under simulation.

--- a/projects/RPi/devices/RPi5/patches/mesa/0133-v3dv-expose-fullDrawIndexUint32-in-V3D-7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0133-v3dv-expose-fullDrawIndexUint32-in-V3D-7.x.patch
@@ -1,7 +1,7 @@
 From 151c13365703631f88ad77ba07afbd2ba9fa172c Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 31 May 2023 09:23:51 +0200
-Subject: [PATCH 133/139] v3dv: expose fullDrawIndexUint32 in V3D 7.x
+Subject: [PATCH 133/142] v3dv: expose fullDrawIndexUint32 in V3D 7.x
 
 ---
  src/broadcom/vulkan/v3dv_device.c | 5 +++--

--- a/projects/RPi/devices/RPi5/patches/mesa/0134-v3dv-expose-depthClamp-in-V3D-7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0134-v3dv-expose-depthClamp-in-V3D-7.x.patch
@@ -1,7 +1,7 @@
 From aec0c613e651984e577f580aedceb3561d6a3b19 Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 31 May 2023 10:38:59 +0200
-Subject: [PATCH 134/139] v3dv: expose depthClamp in V3D 7.x
+Subject: [PATCH 134/142] v3dv: expose depthClamp in V3D 7.x
 
 ---
  src/broadcom/vulkan/v3dv_device.c    | 2 +-

--- a/projects/RPi/devices/RPi5/patches/mesa/0135-v3dv-temporary-disable-EXT_acquire_drm_display.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0135-v3dv-temporary-disable-EXT_acquire_drm_display.patch
@@ -1,7 +1,7 @@
 From 6bd92fecf57b5b1ae3f1f665726c4a0c43d3d90e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alejandro=20Pi=C3=B1eiro?= <apinheiro@igalia.com>
 Date: Tue, 11 Apr 2023 13:11:39 +0200
-Subject: [PATCH 135/139] v3dv/temporary: disable EXT_acquire_drm_display
+Subject: [PATCH 135/142] v3dv/temporary: disable EXT_acquire_drm_display
 
 So we could made a conformance run, without the need to include the
 CTS patch for this issue:

--- a/projects/RPi/devices/RPi5/patches/mesa/0136-v3dv-expose-scalarBlockLayout-on-V3D-7.x.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0136-v3dv-expose-scalarBlockLayout-on-V3D-7.x.patch
@@ -1,7 +1,7 @@
 From 7960516490008ab42ab31e921369b1ffb8f67bde Mon Sep 17 00:00:00 2001
 From: Iago Toral Quiroga <itoral@igalia.com>
 Date: Wed, 21 Jun 2023 10:29:07 +0200
-Subject: [PATCH 136/139] v3dv: expose scalarBlockLayout on V3D 7.x
+Subject: [PATCH 136/142] v3dv: expose scalarBlockLayout on V3D 7.x
 
 This version of V3D doesn't have the restriction that vector accesses
 must not cross 16-byte boundaries.

--- a/projects/RPi/devices/RPi5/patches/mesa/0137-dri-Limit-the-max_num_back-to-2-on-COMPLETE_MODE_FLI.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0137-dri-Limit-the-max_num_back-to-2-on-COMPLETE_MODE_FLI.patch
@@ -1,7 +1,7 @@
 From b58e1d7fd1c315e6ada0ad9ec4961b65c88f0c2a Mon Sep 17 00:00:00 2001
 From: Jose Maria Casanova Crespo <jmcasanova@igalia.com>
 Date: Mon, 4 Oct 2021 14:30:30 +0200
-Subject: [PATCH 137/139] dri: Limit the max_num_back to 2 on
+Subject: [PATCH 137/142] dri: Limit the max_num_back to 2 on
  COMPLETE_MODE_FLIP present mode
 
 This is limiting the number of back buffers that mesa can allocate, so

--- a/projects/RPi/devices/RPi5/patches/mesa/0138-v3d-Ignore-SCANOUT-usage-flags-when-not-needed-under.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0138-v3d-Ignore-SCANOUT-usage-flags-when-not-needed-under.patch
@@ -1,7 +1,7 @@
 From d0f2a99045fa9835fea822ada58a344e2fdc1b13 Mon Sep 17 00:00:00 2001
 From: Jose Maria Casanova Crespo <jmcasanova@igalia.com>
 Date: Thu, 21 Oct 2021 22:04:57 +0200
-Subject: [PATCH 138/139] v3d: Ignore SCANOUT usage flags when not needed under
+Subject: [PATCH 138/142] v3d: Ignore SCANOUT usage flags when not needed under
  X
 
 These downstream patches force the usage of tiled formats

--- a/projects/RPi/devices/RPi5/patches/mesa/0139-Add-a-hack-to-avoid-the-shadow-tex-update-for-import.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0139-Add-a-hack-to-avoid-the-shadow-tex-update-for-import.patch
@@ -1,7 +1,7 @@
 From fc1fe85f01a67ef6e5758f1022950ad79b1b305a Mon Sep 17 00:00:00 2001
 From: Neil Roberts <nroberts@igalia.com>
 Date: Mon, 5 Jul 2021 20:19:06 +0200
-Subject: [PATCH 139/139] Add a hack to avoid the shadow tex update for
+Subject: [PATCH 139/142] Add a hack to avoid the shadow tex update for
  imported linear texs
 
 This adds a hacky interface so that an application can override the

--- a/projects/RPi/devices/RPi5/patches/mesa/0140-vc4-Fix-mask-RGBA-validation-at-YUV-blit.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0140-vc4-Fix-mask-RGBA-validation-at-YUV-blit.patch
@@ -1,0 +1,29 @@
+From 270deb428f1de371492a5e6185fe410c4329eab4 Mon Sep 17 00:00:00 2001
+From: Jose Maria Casanova Crespo <jmcasanova@igalia.com>
+Date: Mon, 25 Sep 2023 21:16:59 +0200
+Subject: [PATCH 140/142] vc4: Fix mask RGBA validation at YUV blit
+
+Solves regression on video players using GPU for
+video decoding that just displays the video in green.
+
+Fixes: d13da7782cd80 ("vc4: call blit paths in chain")
+---
+ src/gallium/drivers/vc4/vc4_blit.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/gallium/drivers/vc4/vc4_blit.c b/src/gallium/drivers/vc4/vc4_blit.c
+index 2cf65b5f585..87b2369b7ad 100644
+--- a/src/gallium/drivers/vc4/vc4_blit.c
++++ b/src/gallium/drivers/vc4/vc4_blit.c
+@@ -347,7 +347,7 @@ vc4_yuv_blit(struct pipe_context *pctx, struct pipe_blit_info *info)
+         struct vc4_resource *dst = vc4_resource(info->dst.resource);
+         bool ok;
+ 
+-        if (info->mask & PIPE_MASK_RGBA)
++        if (!(info->mask & PIPE_MASK_RGBA))
+                 return;
+ 
+         if (src->tiled)
+-- 
+2.39.2
+

--- a/projects/RPi/devices/RPi5/patches/mesa/0141-vc4-mark-buffers-as-initialized-at-vc4_texture_subda.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0141-vc4-mark-buffers-as-initialized-at-vc4_texture_subda.patch
@@ -1,0 +1,175 @@
+From f843fbceb381f8c82074e8b68583fbfe57c48a6e Mon Sep 17 00:00:00 2001
+From: Jose Maria Casanova Crespo <jmcasanova@igalia.com>
+Date: Thu, 8 Jun 2023 00:57:15 +0200
+Subject: [PATCH 141/142] vc4: mark buffers as initialized at
+ vc4_texture_subdata
+
+This fixes several tests when the initially uploaded buffer
+from CPU was being ignored because vc4_texture_subdata was not
+marking the resource as written/initialized.
+
+The usage flags management available at vc4_resource_transfer_map
+is generalized into vc4_map_usage_prep and reused at
+vc4_resource_transfer_map. This makes vc4 implementation more similar
+to v3d.
+
+This fixes 7 text in the following subgroups:
+  -dEQP-GLES2.functional.fbo.render.texsubimage.*
+  -dEQP-GLES2.functional.texture.specification.basic_copytexsubimage2d.*
+  -spec@arb_clear_texture@arb_clear_texture-*
+
+Cc: mesa-stable
+Reviewed-by: Juan A. Suarez <jasuarez@igalia.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25297>
+---
+ src/broadcom/ci/broadcom-rpi3-fails.txt | 11 ----
+ src/gallium/drivers/vc4/vc4_resource.c  | 71 +++++++++++++++----------
+ 2 files changed, 44 insertions(+), 38 deletions(-)
+
+diff --git a/src/broadcom/ci/broadcom-rpi3-fails.txt b/src/broadcom/ci/broadcom-rpi3-fails.txt
+index 5522310d91a..e49e77b1436 100644
+--- a/src/broadcom/ci/broadcom-rpi3-fails.txt
++++ b/src/broadcom/ci/broadcom-rpi3-fails.txt
+@@ -18,11 +18,6 @@ dEQP-GLES2.functional.clipping.line.wide_line_clip_viewport_corner,Fail
+ 
+ dEQP-GLES2.functional.depth_stencil_clear.depth_stencil_masked,Fail
+ 
+-# A glTexImage, glDraw, glTexSubImage sequence into a texture is missing what looks like the drawing.
+-dEQP-GLES2.functional.fbo.render.texsubimage.after_render_tex2d_rgba,Fail
+-# A glTexImage, glDraw, glTexSubImage, glDraw sequence into a texture is missing what looks like the first drawing.
+-dEQP-GLES2.functional.fbo.render.texsubimage.between_render_tex2d_rgba,Fail
+-
+ # Sampling grid slightly off in test 2?
+ dEQP-GLES2.functional.texture.filtering.2d.nearest_mipmap_linear_linear_mirror_rgba8888,Fail
+ dEQP-GLES2.functional.texture.filtering.2d.nearest_mipmap_linear_linear_repeat_rgba8888,Fail
+@@ -38,12 +33,6 @@ dEQP-GLES2.functional.texture.mipmap.2d.basic.nearest_linear_clamp_non_square,Fa
+ dEQP-GLES2.functional.texture.mipmap.2d.basic.nearest_linear_mirror_non_square,Fail
+ dEQP-GLES2.functional.texture.mipmap.2d.basic.nearest_linear_repeat_non_square,Fail
+ 
+-# Sequence of glTexImage, glDraw, glCopyTexSubImage.
+-# background red/green checkerboard on the left side is incorrectly white.
+-dEQP-GLES2.functional.texture.specification.basic_copytexsubimage2d.2d_rgba,Fail
+-# Maybe it was copied as RGB instead of RGBA?
+-dEQP-GLES2.functional.texture.specification.basic_copytexsubimage2d.cube_rgba,Fail
+-
+ # One of the pixels on the left edge near the bottom is wrong for both min and
+ # mag.  Also a line of pixels through the image in minification.
+ dEQP-GLES2.functional.texture.wrap.clamp_clamp_nearest_npot_etc1,Fail
+diff --git a/src/gallium/drivers/vc4/vc4_resource.c b/src/gallium/drivers/vc4/vc4_resource.c
+index ad2791aa972..0a3a435a46c 100644
+--- a/src/gallium/drivers/vc4/vc4_resource.c
++++ b/src/gallium/drivers/vc4/vc4_resource.c
+@@ -95,34 +95,13 @@ vc4_resource_transfer_unmap(struct pipe_context *pctx,
+         slab_free(&vc4->transfer_pool, ptrans);
+ }
+ 
+-static void *
+-vc4_resource_transfer_map(struct pipe_context *pctx,
+-                          struct pipe_resource *prsc,
+-                          unsigned level, unsigned usage,
+-                          const struct pipe_box *box,
+-                          struct pipe_transfer **pptrans)
++static void
++vc4_map_usage_prep(struct pipe_context *pctx,
++                   struct pipe_resource *prsc,
++                   unsigned usage)
+ {
+         struct vc4_context *vc4 = vc4_context(pctx);
+         struct vc4_resource *rsc = vc4_resource(prsc);
+-        struct vc4_transfer *trans;
+-        struct pipe_transfer *ptrans;
+-        enum pipe_format format = prsc->format;
+-        char *buf;
+-
+-        /* Upgrade DISCARD_RANGE to WHOLE_RESOURCE if the whole resource is
+-         * being mapped.
+-         */
+-        if ((usage & PIPE_MAP_DISCARD_RANGE) &&
+-            !(usage & PIPE_MAP_UNSYNCHRONIZED) &&
+-            !(prsc->flags & PIPE_RESOURCE_FLAG_MAP_PERSISTENT) &&
+-            prsc->last_level == 0 &&
+-            prsc->width0 == box->width &&
+-            prsc->height0 == box->height &&
+-            prsc->depth0 == box->depth &&
+-            prsc->array_size == 1 &&
+-            rsc->bo->private) {
+-                usage |= PIPE_MAP_DISCARD_WHOLE_RESOURCE;
+-        }
+ 
+         if (usage & PIPE_MAP_DISCARD_WHOLE_RESOURCE) {
+                 if (vc4_resource_bo_alloc(rsc)) {
+@@ -131,6 +110,8 @@ vc4_resource_transfer_map(struct pipe_context *pctx,
+                          */
+                         if (prsc->bind & PIPE_BIND_VERTEX_BUFFER)
+                                 vc4->dirty |= VC4_DIRTY_VTXBUF;
++                        if (prsc->bind & PIPE_BIND_CONSTANT_BUFFER)
++                                vc4->dirty |= VC4_DIRTY_CONSTBUF;
+                 } else {
+                         /* If we failed to reallocate, flush users so that we
+                          * don't violate any syncing requirements.
+@@ -139,7 +120,7 @@ vc4_resource_transfer_map(struct pipe_context *pctx,
+                 }
+         } else if (!(usage & PIPE_MAP_UNSYNCHRONIZED)) {
+                 /* If we're writing and the buffer is being used by the CL, we
+-                 * have to flush the CL first.  If we're only reading, we need
++                 * have to flush the CL first. If we're only reading, we need
+                  * to flush if the CL has written our buffer.
+                  */
+                 if (usage & PIPE_MAP_WRITE)
+@@ -152,6 +133,38 @@ vc4_resource_transfer_map(struct pipe_context *pctx,
+                 rsc->writes++;
+                 rsc->initialized_buffers = ~0;
+         }
++}
++
++static void *
++vc4_resource_transfer_map(struct pipe_context *pctx,
++                          struct pipe_resource *prsc,
++                          unsigned level, unsigned usage,
++                          const struct pipe_box *box,
++                          struct pipe_transfer **pptrans)
++{
++        struct vc4_context *vc4 = vc4_context(pctx);
++        struct vc4_resource *rsc = vc4_resource(prsc);
++        struct vc4_transfer *trans;
++        struct pipe_transfer *ptrans;
++        enum pipe_format format = prsc->format;
++        char *buf;
++
++        /* Upgrade DISCARD_RANGE to WHOLE_RESOURCE if the whole resource is
++         * being mapped.
++         */
++        if ((usage & PIPE_MAP_DISCARD_RANGE) &&
++            !(usage & PIPE_MAP_UNSYNCHRONIZED) &&
++            !(prsc->flags & PIPE_RESOURCE_FLAG_MAP_PERSISTENT) &&
++            prsc->last_level == 0 &&
++            prsc->width0 == box->width &&
++            prsc->height0 == box->height &&
++            prsc->depth0 == box->depth &&
++            prsc->array_size == 1 &&
++            rsc->bo->private) {
++                usage |= PIPE_MAP_DISCARD_WHOLE_RESOURCE;
++        }
++
++        vc4_map_usage_prep(pctx, prsc, usage);
+ 
+         trans = slab_zalloc(&vc4->transfer_pool);
+         if (!trans)
+@@ -240,8 +253,12 @@ vc4_texture_subdata(struct pipe_context *pctx,
+         }
+ 
+         /* Otherwise, map and store the texture data directly into the tiled
+-         * texture.
++         * texture.  Note that gallium's texture_subdata may be called with
++         * obvious usage flags missing!
+          */
++        vc4_map_usage_prep(pctx, prsc, usage | (PIPE_MAP_WRITE |
++                                                PIPE_MAP_DISCARD_RANGE));
++
+         void *buf;
+         if (usage & PIPE_MAP_UNSYNCHRONIZED)
+                 buf = vc4_bo_map_unsynchronized(rsc->bo);
+-- 
+2.39.2
+

--- a/projects/RPi/devices/RPi5/patches/mesa/0142-gallium-Add-kmsro-drivers-for-RP1-DSI-DPI-and-VEC-de.patch
+++ b/projects/RPi/devices/RPi5/patches/mesa/0142-gallium-Add-kmsro-drivers-for-RP1-DSI-DPI-and-VEC-de.patch
@@ -1,0 +1,43 @@
+From 3322c102282cf726ae575b122358060abd5b24db Mon Sep 17 00:00:00 2001
+From: Dave Stevenson <dave.stevenson@raspberrypi.com>
+Date: Thu, 5 Oct 2023 19:32:10 +0100
+Subject: [PATCH 142/142] gallium: Add kmsro drivers for RP1 DSI, DPI, and VEC
+ devices
+
+Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
+---
+ src/gallium/targets/dri/meson.build | 3 +++
+ src/gallium/targets/dri/target.c    | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/src/gallium/targets/dri/meson.build b/src/gallium/targets/dri/meson.build
+index fbec1da957b..59daf3b6fb6 100644
+--- a/src/gallium/targets/dri/meson.build
++++ b/src/gallium/targets/dri/meson.build
+@@ -68,6 +68,9 @@ libgallium_dri = shared_library(
+ 
+ foreach d : [[with_gallium_kmsro, [
+                'armada-drm_dri.so',
++               'drm-rp1-dpi_dri.so',
++               'drm-rp1-dsi_dri.so',
++               'drm-rp1-vec_dri.so',
+                'exynos_dri.so',
+                'hx8357d_dri.so',
+                'ili9225_dri.so',
+diff --git a/src/gallium/targets/dri/target.c b/src/gallium/targets/dri/target.c
+index d506869cbb4..ecb25edd03b 100644
+--- a/src/gallium/targets/dri/target.c
++++ b/src/gallium/targets/dri/target.c
+@@ -98,6 +98,9 @@ DEFINE_LOADER_DRM_ENTRYPOINT(tegra);
+ 
+ #if defined(GALLIUM_KMSRO)
+ DEFINE_LOADER_DRM_ENTRYPOINT(armada_drm)
++DEFINE_LOADER_DRM_ENTRYPOINT(drm_rp1_dpi)
++DEFINE_LOADER_DRM_ENTRYPOINT(drm_rp1_dsi)
++DEFINE_LOADER_DRM_ENTRYPOINT(drm_rp1_vec)
+ DEFINE_LOADER_DRM_ENTRYPOINT(exynos)
+ DEFINE_LOADER_DRM_ENTRYPOINT(hx8357d)
+ DEFINE_LOADER_DRM_ENTRYPOINT(ili9225)
+-- 
+2.39.2
+


### PR DESCRIPTION
This adds 3 (small) patches that RPiOS is using now

Runtime tested on RPi5