### PR TITLE
firmware-imx: update to 8.21

### DIFF
--- a/packages/linux-firmware/firmware-imx/package.mk
+++ b/packages/linux-firmware/firmware-imx/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="firmware-imx"
-PKG_VERSION="8.17"
-PKG_SHA256="1ee3c49ad8749867487f09d6e4472536fb809b667c1bb3c56511175b8974e3c6"
+PKG_VERSION="8.21"
+PKG_SHA256="c3447f0f813415ccea9dc2ef12080cb3ac8bbc0c67392a74fc7d59205eb5a672"
 PKG_ARCH="arm"
 PKG_LICENSE="other"
 PKG_SITE="http://www.freescale.com"


### PR DESCRIPTION
release notes:
- https://www.nxp.com/docs/en/release-note/IMX_LINUX_RELEASE_NOTES.pdf

Binary files updated in this release:
- firmware/hdmi/cadence/dpfw.bin
- firmware/hdmi/cadence/hdmitxfw.bin
- firmware/hdmi/cadence/signed_hdmi_imx8m.bin
- firmware/vpu/vpu_fw_imx8_dec.bin
- firmware/vpu/vpu_fw_imx8_enc.bin