### PR TITLE
dvb-tools: list dvb-apps binaries in the add-on description

### DIFF
--- a/packages/addons/tools/dvb-tools/package.mk
+++ b/packages/addons/tools/dvb-tools/package.mk
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="DVB-Tools: is a bundle of dvb tools and programs"
-PKG_LONGDESC="This bundle currently includes blindscan-s2, dvb-apps, dvblast, dvbsnoop, mumudvb, szap-s2, tune-s2, t2scan and w_scan."
+PKG_LONGDESC="This bundle currently includes blindscan-s2, dvb-apps (dvbdate, dvbnet, dvbscan, dvbtraffic, femon, scan, {acst}zap), dvblast, dvbsnoop, mumudvb, szap-s2, tune-s2, t2scan and w_scan."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="DVB Tools"


### PR DESCRIPTION
The current add-on description doesn't list things like `dvbscan` though it's included with dvb-apps, so expand the text to mention all binaries we include. No need to bump the rev or backport the change as it's purely cosmetic.