### PR TITLE
lg-gpio: fix wrong CROSS_PREFIX

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
@@ -19,7 +19,7 @@ pre_configure_target() {
 }
 
 make_target() {
-  make liblgpio.so CROSS_PREFIX=${TARGET_KERNEL_PREFIX}
+  make liblgpio.so CROSS_PREFIX=${TARGET_PREFIX}
   (
     cd PY_LGPIO
     swig -python lgpio.i


### PR DESCRIPTION
This fixes ARMv8.arm build

build tested for ARMv8.arm, RPi2 and RPi5