### PR TITLE
docker: update to 24.0.7 and addon (1)

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="c1a4a580ced3633e489c5c9869a20198415da44df7023fdc200d425cdf5fa652"
+PKG_SHA256="72a54d131c28938221c81bd08364459fed9c71c093d4d615d324aaf31de6db1d"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/docker/cli/releases
-export PKG_GIT_COMMIT="cb74dfcd853482dd43cb553106b1e0cd237acb3e"
+export PKG_GIT_COMMIT="afdd53b4e341be38d2056a42113b938559bb1d94"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.7.5"
-PKG_SHA256="9bc75f80943334d44bb57f83661431001fc9ec1ebd834740ce6b442598edeed2"
+PKG_VERSION="1.7.8"
+PKG_SHA256="891b84e614b491ab1d3bd5c8f4fb119e4929c24762e149e83e181e72d687f706"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-PKG_GIT_COMMIT="0cae528dd6cb557f7201036e9f43420650207b58"
+PKG_GIT_COMMIT="8e4b0bde866788eec76735cc77c4720144248fb7"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="24.0.6"
-PKG_SHA256="29a8ee54e9ea008b40eebca42dec8b67ab257eb8ac175f67e79c110e4187d7d2"
+PKG_VERSION="24.0.7"
+PKG_SHA256="16a2cb4cf4d314a070085e0df06e3a6bd9ec678d28715b64060af694fc9051d5"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="659604f9ee60f147020bdd444b26e4b5c636dc28"
+export PKG_GIT_COMMIT="311b9ff0aa93aa55880e1e5f8871c4fb69583426"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
docker: update to 24.0.7 and addon (1)
- cli: update to 24.0.7
- containerd: update to 1.7.8
- moby: update to 24.0.7

```
nuc12:~ # docker version
Client:
 Version:           24.0.7
 API version:       1.43
 Go version:        go1.21.3
 Git commit:        afdd53b4e341be38d2056a42113b938559bb1d94
 Built:             Sun Oct 29 10:13:49 UTC 2023
 OS/Arch:           linux/amd64
 Context:           default

Server:
 Engine:
  Version:          library-import
  API version:      1.43 (minimum version 1.12)
  Go version:       go1.21.3
  Git commit:       library-import
  Built:            library-import
  OS/Arch:          linux/amd64
  Experimental:     true
 containerd:
  Version:          1.7.8
  GitCommit:        8e4b0bde866788eec76735cc77c4720144248fb7
 runc:
  Version:          1.1.9
  GitCommit:        6724737f999df9ee0d8ca5c6d7b81f97adc34374
 docker-init:
  Version:          0.19.0
  GitCommit:
```