### PR TITLE
ntfs-3g_ntfsprogs: partial package restore to include mkfs.ntfs and ntfsfix

### DIFF
--- a/config/show_config
+++ b/config/show_config
@@ -83,6 +83,7 @@ show_config() {
   if [ "${SWAP_SUPPORT}" = "yes" ]; then
     config_message+="\n   - Swapfile default size:\t\t ${SWAPFILESIZE}"
   fi
+  config_message+="\n - NTFS Tools Support (ntfsprogs):\t\t ${NTFSPROGS}"
 
   # Network service configuration
 

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -223,6 +223,9 @@
 # This adds support for parted and mkfs.ext3/4 to initramfs for OEM usage
   INITRAMFS_PARTED_SUPPORT="no"
 
+# build and install NTFS tools (ntfsprogs) support (yes / no)
+  NTFSPROGS="yes"
+
 # build and install nano text editor (yes / no)
   NANO_EDITOR="yes"
 

--- a/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
+++ b/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="ntfs-3g_ntfsprogs"
+PKG_VERSION="2022.10.3"
+PKG_SHA256="f20e36ee68074b845e3629e6bced4706ad053804cbaf062fbae60738f854170c"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/tuxera/ntfs-3g"
+PKG_URL="https://tuxera.com/opensource/${PKG_NAME}-${PKG_VERSION}.tgz"
+PKG_DEPENDS_TARGET="toolchain libgcrypt"
+PKG_LONGDESC="Tools used with NTFS filesystems."
+PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+lto"
+
+PKG_CONFIGURE_OPTS_TARGET="--exec-prefix=/usr/ \
+                           --disable-dependency-tracking \
+                           --disable-library \
+                           --enable-posix-acls \
+                           --enable-mtab \
+                           --enable-ntfsprogs \
+                           --disable-ntfs-3g \
+                           --disable-crypto \
+                           --with-fuse=external \
+                           --with-uuid"
+
+post_makeinstall_target() {
+  rm -rf ${INSTALL}/usr/bin/ntfscat
+  rm -rf ${INSTALL}/usr/bin/ntfscluster
+  rm -rf ${INSTALL}/usr/bin/ntfscmp
+  rm -rf ${INSTALL}/usr/bin/ntfsls
+  rm -rf ${INSTALL}/usr/sbin/ntfsclone
+  rm -rf ${INSTALL}/usr/sbin/ntfscp
+  rm -rf ${INSTALL}/usr/sbin/ntfsundelete
+
+  mkdir -p ${INSTALL}/usr/sbin
+    ln -sf /usr/sbin/mkntfs ${INSTALL}/usr/sbin/mkfs.ntfs
+}

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -28,6 +28,9 @@ fi
 # Automounter support
 [ "${UDEVIL}" = "yes" ] && PKG_DEPENDS_TARGET+=" udevil"
 
+# NTFS tools support
+[ "${NTFSPROGS}" = "yes" ] && PKG_DEPENDS_TARGET+=" ntfs-3g_ntfsprogs"
+
 # Remote support
 [ "${REMOTE_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" remote"
 


### PR DESCRIPTION
PR #5838 removed NTFS-3G to switch NTFS filesystem support away from FUSE to in-kernel drivers. It also removed the tool `mkfs.ntfs` which has no upstream equivalent. This PR reinstates the package to the buildsystem but with changes to only build ntfsprogs (not NTFS-3G) and pick the `mkfs.ntfs` and `ntfsfix` tools to the image. The `ntfsfix` tool can fix only basic issues so it's not a replacement for `chkdsk.exe` on a Windows host, but hopefully it allows users to resolve most of the simple dirty-filesystem issues we're seeing an uptick in since the in-kernel driver switch. NB: This PR does not change how NTFS drives are mounted.