### PR TITLE
install default dbus policies for the system bus into /usr/share/dbus-1/system.d

### DIFF
--- a/packages/network/avahi/patches/avahi-0001-dbus--Use-non-deprecated-installation-path.patch
+++ b/packages/network/avahi/patches/avahi-0001-dbus--Use-non-deprecated-installation-path.patch
@@ -1,0 +1,30 @@
+From 0ab222c6601535f078f88e9d72b2c70cba03de23 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Sat, 21 May 2022 19:02:11 +0200
+Subject: [PATCH] dbus: Use non-deprecated installation path
+
+Quoting from D-Bus 1.14.0 release notes:
+
+> Third-party software should install default dbus policies for the system
+>  bus into ${datadir}/dbus-1/system.d (this has been supported since dbus
+> 1.10, released in August 2015). Installing default dbus policies in
+>  ${sysconfdir}/dbus-1/system.d is now considered to be deprecated.
+
+https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-1.14.0/NEWS#L45-51
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 58db8c70f..959e96768 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -674,7 +674,7 @@ if test "x$HAVE_DBUS" = "xyes" ; then
+     if ! test -z "$with_dbus_sys" ; then
+         DBUS_SYS_DIR="$with_dbus_sys"
+     else
+-        DBUS_SYS_DIR="${sysconfdir}/dbus-1/system.d"
++        DBUS_SYS_DIR="${datadir}/dbus-1/system.d"
+     fi
+     AC_SUBST(DBUS_SYS_DIR)
+ 

--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -40,7 +40,7 @@ PKG_CONFIGURE_OPTS_TARGET="--srcdir=.. \
                            --disable-stats \
                            --enable-client \
                            --enable-datafiles \
-                           --with-dbusconfdir=/etc \
+                           --with-dbusconfdir=/usr/share \
                            --with-systemdunitdir=/usr/lib/systemd/system \
                            --disable-silent-rules \
                            --disable-wifi \


### PR DESCRIPTION
- with the recent #8098 fix for bluez relocating its dbus-1 config to /usr/share as documented in the dbus 1.14.0 Deprecations. This PR completes the move. It includes avahi’s upstream patch and the configure change for connman.
- Pulseaudio 16.99.1 (17.x) has incorporated this change, and once released will finalise this cleanup.

Ref: https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-1.14.0/NEWS#L45-51

once this PR is added the below will be the directory layout. Presently avahi, connman and pulseaudio are in /etc/dbus-1/system.d

```
nuc12:~ # ls /etc/dbus-1
session.conf  system.conf
nuc12:~ # ls /usr/share/dbus-1/system.d/
avahi-dbus.conf                 org.freedesktop.login1.conf
bluetooth.conf                  org.freedesktop.oom1.conf
connman-vpn-dbus.conf           org.freedesktop.systemd1.conf
connman.conf                    org.freedesktop.timesync1.conf
iwd-dbus.conf                   pulseaudio-system.conf
org.freedesktop.hostname1.conf
```