### PR TITLE
[le12] tools addon updates 

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmediainfo"
-PKG_VERSION="23.07"
-PKG_SHA256="60456c8b2ab8769a6081d96fd7be86db4fe32520e4a022397cb22cacf47ce820"
+PKG_VERSION="23.10"
+PKG_SHA256="76ebe502e0f310b559d5dd90727d9aafd5fabaaeca3442f38e629dfc07da0d22"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/libmediainfo/${PKG_VERSION}/libmediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mediainfo"
-PKG_VERSION="23.07"
-PKG_SHA256="b6d7da9e29995fd34a22100825b843e74c32c7bc67adb01166b1beedea49f5d0"
+PKG_VERSION="23.10"
+PKG_SHA256="b743ae2521d9d8e8b9a5850d7c2a29de30ba777db52738d0dfba17cc046776e7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/mediainfo/${PKG_VERSION}/mediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mesa-demos/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mesa-demos/package.mk
@@ -2,18 +2,15 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa-demos"
-PKG_VERSION="8.4.0"
-PKG_SHA256="01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d"
+PKG_VERSION="9.0.0"
+PKG_SHA256="3046a3d26a7b051af7ebdd257a5f23bfeb160cad6ed952329cdff1e9f1ed496b"
 PKG_ARCH="x86_64"
 PKG_LICENSE="OSS"
-PKG_SITE="http://www.mesa3d.org/"
-PKG_URL="ftp://ftp.freedesktop.org/pub/mesa/demos/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_SITE="https://www.mesa3d.org/"
+PKG_URL="https://archive.mesa3d.org/demos/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libX11 mesa glu glew"
 PKG_LONGDESC="Mesa 3D demos - installed are the well known glxinfo and glxgears."
-PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="-sysroot"
-
-PKG_CONFIGURE_OPTS_TARGET="--without-glut"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpg123"
-PKG_VERSION="1.31.3"
-PKG_SHA256="1ca77d3a69a5ff845b7a0536f783fee554e1041139a6b978f6afe14f5814ad1a"
+PKG_VERSION="1.32.3"
+PKG_SHA256="2d9913a57d4ee8f497a182c6e82582602409782a4fb481e989feebf4435867b4"
 PKG_LICENSE="LGPLv2"
 PKG_SITE="https://www.mpg123.org/"
 PKG_URL="https://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squeezelite"
-PKG_VERSION="bc72c0de3fff771540a2a45aaafafed539387b3c" # 2022-04-10 # 1.9.9.1403
-PKG_SHA256="5aa312d678a593b9a08f79e080a6ebe329d8fc40e6507e28b6705807c408bf7a"
+PKG_VERSION="8581aba8b1b67af272b89b62a7a9b56082307ab6"
+PKG_SHA256="bf290e6543c365e2ea6aaf818acbfe24aadcaabb266b2dc723926428f4ec30c9"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ralph-irving/squeezelite"
 PKG_URL="https://github.com/ralph-irving/squeezelite/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/network-tools-depends/iperf/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/iperf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iperf"
-PKG_VERSION="3.14"
-PKG_SHA256="bbafa2c9687f0f7fe00947dc779b83c91663911e22460005c0ad4623797b3dbd"
+PKG_VERSION="3.15"
+PKG_SHA256="d287baa6f0ef4fc27160e2c9ae2fd7a03ce3ae303292e3b5455bce7ae633ad58"
 PKG_LICENSE="BSD"
 PKG_SITE="http://software.es.net/iperf/"
 PKG_URL="https://github.com/esnet/iperf/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/network-tools-depends/irssi/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/irssi/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="irssi"
-PKG_VERSION="1.4.4"
-PKG_SHA256="fefe9ec8c7b1475449945c934a2360ab12693454892be47a6d288c63eb107ead"
+PKG_VERSION="1.4.5"
+PKG_SHA256="72a951cb0ad622785a8962801f005a3a412736c7e7e3ce152f176287c52fe062"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.irssi.org/"
 PKG_URL="https://github.com/irssi/irssi/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/system-tools-depends/depends/oniguruma/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/depends/oniguruma/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oniguruma"
-PKG_VERSION="6.9.8"
-PKG_SHA256="28cd62c1464623c7910565fb1ccaaa0104b2fe8b12bcd646e81f73b47535213e"
+PKG_VERSION="6.9.9"
+PKG_SHA256="60162bd3b9fc6f4886d4c7a07925ffd374167732f55dce8c491bfd9cd818a6cf"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/kkos/oniguruma"
 PKG_URL="https://github.com/kkos/oniguruma/releases/download/v${PKG_VERSION}/onig-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpiod"
-PKG_VERSION="2.0.2"
-PKG_SHA256="3532e1dbaffdc2c5965a761a0750f2691ee49aad273ddbbd93acf6a727b1b65c"
+PKG_VERSION="2.1"
+PKG_SHA256="fd6ed4b2c674fe6cc3b481880f6cde1eea79e296e95a139b85401eaaea6de3fc"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
 PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/pv/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/pv/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pv"
-PKG_VERSION="1.7.24"
-PKG_SHA256="3bf43c5809c8d50066eaeaea5a115f6503c57a38c151975b710aa2bee857b65e"
+PKG_VERSION="1.8.0"
+PKG_SHA256="5cec4f737826a0eddab471dd3b75a587bd29a2e7cfa30068d57f29439a251fdf"
 PKG_LICENSE="GNU"
 PKG_SITE="http://www.ivarch.com/programs/pv.shtml"
 PKG_URL="http://www.ivarch.com/programs/sources/pv-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.16.05"
-PKG_SHA256="ecb56e42a5ac6d94385de10ae8163a4fe50116d6b07e3ff61752d3854b630037"
+PKG_VERSION="0.17.00"
+PKG_SHA256="eca62128f4918edc6d1e309f426a223968f44b304b737275443ec9e62855d42e"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -26,6 +26,12 @@ PKG_DEPENDS_TARGET="toolchain \
                     tsdecrypt \
                     tstools"
 
+if [ "${TARGET_ARCH}" = "x86_64" ]; then
+  if [ "${DEVICE}" = "x11" -o "${DEVICE}" = "Generic-legacy" ]; then
+    PKG_DEPENDS_TARGET+=" mesa-demos"
+  fi
+fi
+
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
     # alsamixer
@@ -48,4 +54,11 @@ addon() {
 
     # tstools
     cp -P $(get_install_dir tstools)/usr/bin/* ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
+
+    if [ "${TARGET_ARCH}" = "x86_64" ]; then
+      if [ "${DEVICE}" = "x11" -o "${DEVICE}" = "Generic-legacy" ]; then
+        # mesa-demos
+        cp -P $(get_install_dir mesa-demos)/usr/bin/* ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
+      fi
+    fi
 }

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- system-tools: update addon (2)
  - libgpiod: update to 2.1
  - stress-ng: update to 0.17.00
  - pv: update to 1.8.0
  - oniguruma: update to 6.9.9
- network-tools: update addon (1)
  - irssi: update to 1.4.5
  - iperf: update to 3.15
- multimedia-tools: update addon (1)
  - squeezelite: update to githash 8581aba (1.9.9.1449)
  - mpg123: update to 1.32.3
  - libmediainfo: update to 23.10
  - mediainfo: update to 23.10
  - multimedia-tools: add back mesa-demos for X11 builds
  - mesa-demos: update to 9.0.0 and PKG_URL and meson