### PR TITLE
slang: dont build with pcre

### DIFF
--- a/packages/devel/slang/package.mk
+++ b/packages/devel/slang/package.mk
@@ -8,11 +8,12 @@ PKG_SHA256="f9145054ae131973c61208ea82486d5dd10e3c5cdad23b7c4a0617743c8f5a18"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.jedsoft.org/slang/"
 PKG_URL="https://www.jedsoft.org/releases/slang/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
-PKG_DEPENDS_TARGET="toolchain pcre"
+PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A library designed to allow a developer to create robust multi-platform software."
 PKG_BUILD_FLAGS="-parallel"
 
-PKG_CONFIGURE_OPTS_TARGET="--without-onig"
+PKG_CONFIGURE_OPTS_TARGET="--without-pcre \
+                           --without-onig"
 
 pre_configure_target() {
  # slang fails to build in subdirs


### PR DESCRIPTION
Drop the `slang` dependency: `pcre`.
`slang` is used only by `newt` which is used only by `installer`

installer > newt > slang > ~~pcre~~

- continuing cleanup of #6798 