### PR TITLE
systemd: network-base: add hostname and localhost to hosts.conf if not present [LE11]

### DIFF
--- a/packages/sysutils/systemd/config/hosts.conf
+++ b/packages/sysutils/systemd/config/hosts.conf
@@ -3,8 +3,8 @@
 # This configuration file allows you to manually map hostnames to
 # IP addresses
 
-# Format:  <ipaddress> <hostname1> <hostname2>
-# Example: 192.168.0.3 libreelec libreelec.mynetwork
+# Format:  <ipaddress> <fqdn> <alias1> <alias2>
+# Example: 192.168.0.3 libreelec.mynetwork libreelec
 
 # NOTE: do not edit /etc/hosts directly
 # edit /storage/.config/hosts.conf then reboot

--- a/packages/sysutils/systemd/scripts/network-base-setup
+++ b/packages/sysutils/systemd/scripts/network-base-setup
@@ -1,4 +1,11 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+check_hosts() {
+  grep -v "^#" /run/libreelec/hosts | grep "${1}"
+}
+
 
 # setup hostname
 if [ -f /storage/.cache/hostname ]; then
@@ -9,13 +16,27 @@ fi
 rm -f /run/libreelec/hosts
 if [ -f /storage/.config/hosts.conf ]; then
   cat /storage/.config/hosts.conf > /run/libreelec/hosts
+  # add localhost to hosts if not present
+  LOCALHOST_HOSTS=$(check_hosts "localhost")
+  if [ -z "${LOCALHOST_HOSTS}" ]; then
+    {
+      echo "127.0.0.1 localhost"
+      echo "::1 localhost ip6-localhost ip6-loopback"
+    } >> /run/libreelec/hosts
+  fi
+  # add HOSTNAME to hosts if not present
+  HOSTNAME=$(cat /proc/sys/kernel/hostname)
+  HOSTNAME_HOSTS=$(check_hosts "${HOSTNAME}")
+  if [ -z "${HOSTNAME_HOSTS}" ]; then
+    echo "127.0.1.1 ${HOSTNAME}" >> /run/libreelec/hosts
+  fi
 fi
 
 # setup /etc/resolv.conf
 rm -f /run/libreelec/resolv.conf
 if [ -f /storage/.config/resolv.conf ]; then
   cat /storage/.config/resolv.conf > /run/libreelec/resolv.conf
-elif [ -f /dev/.kernel_ipconfig -a -f /proc/net/pnp ]; then
+elif [ -f /dev/.kernel_ipconfig ] && [ -f /proc/net/pnp ]; then
   cat /proc/net/pnp > /run/libreelec/resolv.conf
 else
   cat << EOF > /run/libreelec/resolv.conf


### PR DESCRIPTION
Backport of #7696. This is the other half of https://github.com/LibreELEC/service.libreelec.settings/pull/292 which is in LE11. 

The two together move adding hostname and localhost to /etc/hosts from the addon to the image.

WIP as I haven't tested on LE11. I'm not expecting any actual further work to be needed. Opening because I expect the bugfix to be needed.