### PR TITLE
udevil: support custom udevil.conf in /storage/.config

### DIFF
--- a/packages/sysutils/udevil/package.mk
+++ b/packages/sysutils/udevil/package.mk
@@ -24,6 +24,7 @@ makeinstall_target() {
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/etc/udevil
     cp ${PKG_DIR}/config/udevil.conf ${INSTALL}/etc/udevil
+    ln -sf /storage/.config/udevil.conf ${INSTALL}/etc/udevil/udevil-user-root.conf
 
   mkdir -p ${INSTALL}/usr/bin
     cp -PR src/udevil ${INSTALL}/usr/bin


### PR DESCRIPTION
This allows user to eg change ntfs (or all) mounts to read-only to prevent filesystem corruption in case of power loss