### PR TITLE
Kernel firmware update and rdfind

### DIFF
--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="20231030"
-PKG_SHA256="c98d200fc4a3120de1a594713ce34e135819dff23e883a4ed387863ba25679c7"
+PKG_VERSION="20231111"
+PKG_SHA256="8d4959c1293ff8a6e40ac3d265205297a3e93e4fe5e8e25a7d16cfed78cbb098"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-${PKG_VERSION}.tar.xz"

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -69,6 +69,7 @@ dep_map=(
   [make]=make
   [patch]=patch
   [perl]=perl
+  [rdfind]=rdfind
   [sed]=sed
   [tar]=tar
   [unzip]=unzip

--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -19,7 +19,7 @@ RUN adduser --disabled-password --gecos '' docker \
 RUN apt-get install -y \
     wget bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
-      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
+      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
       golang-go git openssh-client \
     --no-install-recommends
 

--- a/tools/docker/kinetic/Dockerfile
+++ b/tools/docker/kinetic/Dockerfile
@@ -20,7 +20,7 @@ RUN adduser --disabled-password --gecos '' docker \
 RUN apt-get update && apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++ xfonts-utils xsltproc default-jre-headless python3 \
-      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
+      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
       golang-go git openssh-client \
     --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/lunar/Dockerfile
+++ b/tools/docker/lunar/Dockerfile
@@ -20,7 +20,7 @@ RUN adduser --disabled-password --gecos '' docker \
 RUN apt-get update && apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++ xfonts-utils xsltproc default-jre-headless python3 \
-      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
+      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
       golang-go git openssh-client \
     --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/sid/Dockerfile
+++ b/tools/docker/sid/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip unzip diffutils lzop make file \
     g++ xfonts-utils xsltproc default-jre-headless python3 \
     libc6-dev libncurses5-dev \
-    libjson-perl libxml-parser-perl libparse-yapp-perl \
+    libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
     golang-go \
     git openssh-client \
     --no-install-recommends \


### PR DESCRIPTION
Since https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=cf8315ded9b422d2e8b620ffe8bb661221639c8f kernel-firmware requires rdfind. 

It is not possible to set a PKG_DEPENDS…=“rdfind:host” in kernel-firmware as `scripts/build linux` initiates an unpack which does not have a DEPENDS.

```
$ scripts/build linux
UNPACK      intel-ucode
UNPACK      kernel-firmware
ERROR: rdfind is not installed
FAILURE: scripts/unpack kernel-firmware during post_patch (package.mk)
*********** FAILED COMMAND ***********
${PKG_CURRENT_CALL} "${@}"
**************************************
*********** FAILED COMMAND ***********
${SCRIPTS}/unpack "${p}" "${PARENT_PKG}"
**************************************
*********** FAILED COMMAND ***********
${SCRIPTS}/unpack "${PKG_NAME}" "${PARENT_PKG}"
**************************************
```