### PR TITLE
Package updates

### DIFF
--- a/packages/devel/swig/package.mk
+++ b/packages/devel/swig/package.mk
@@ -13,7 +13,6 @@ PKG_LONGDESC="SWIG is a software development tool that connects programs written
 PKG_TOOLCHAIN="configure"
 
 PKG_CONFIGURE_OPTS_HOST="--program-suffix=4.0 \
-                         --with-pcre-prefix=${TOOLCHAIN} \
                          --with-boost=no \
                          --without-pcre \
                          --without-x \

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="8.2.2"
-PKG_SHA256="e433ad85fbdf57f680be29479b3f964577379aaf319f557eb76569f0ecbc90f3"
+PKG_VERSION="8.3.0"
+PKG_SHA256="109501eaeb8bde3eadb25fab4164e993fbace29c3d775bcaa1c1e58e2f15f847"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -3,13 +3,14 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openvpn"
-PKG_VERSION="2.6.6"
-PKG_SHA256="3b074f392818b31aa529b84f76e8b5e4ad03fca764924f46d906bceaaf421034"
+PKG_VERSION="2.6.7"
+PKG_SHA256="ee9877340b1d8de47eb5b52712c3366855fa6a4a1955bf950c68577bd2039913"
 PKG_LICENSE="GPL"
 PKG_SITE="https://openvpn.net"
 PKG_URL="https://swupdate.openvpn.org/community/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libcap-ng lz4 lzo openssl"
 PKG_LONGDESC="A full featured SSL VPN software solution that integrates OpenVPN server capabilities."
+PKG_TOOLCHAIN="configure"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_have_decl_TUNSETPERSIST=no \
                            --disable-server \


### PR DESCRIPTION
- harfbuzz: update to 8.3.0
- openvpn: update to 2.6.7
- swig: cleanup PKG_CONFIGURE_OPTS
  - swig:host doesn’t use pcre. (also swig has been updated to use pcre2)
  - #6798