### PR TITLE
vdr-addon: update addon to (4) 

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/sources/Makefile
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/sources/Makefile
@@ -34,7 +34,7 @@ LDFLAGS += $(shell pkg-config --libs $(LIBREPFUNC))
 UNCRUSTIFY_FILES = scanner.cpp scanner.h scanfilter.cpp scanfilter.h statemachine.h statemachine.cpp
 
 OBJS = $(PLUGIN).o common.o menusetup.o satellites.o scanner.o
-OBJS += scanfilter.o statemachine.o countries.o
+OBJS += scanfilter.o statemachine.o countries.o si_ext.o
 
 all: libvdr-$(PLUGIN).so i18n
 

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscancontrol/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscancontrol/package.mk
@@ -25,5 +25,6 @@ make_target() {
   make VDRDIR=${VDR_DIR} \
     INCLUDES="-I." \
     LIBDIR="." \
-    LOCALEDIR="./locale"
+    LOCALEDIR="./locale" \
+    install
 }

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/package.mk
@@ -23,7 +23,8 @@ make_target() {
   VDR_DIR=$(get_build_dir vdr)
   make VDRDIR=${VDR_DIR} \
     LIBDIR="." \
-    LOCALEDIR="./locale"
+    LOCALEDIR="./locale" \
+    install
 }
 
 post_make_target() {

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="vdr-addon"
 PKG_VERSION="2.6.4"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -49,12 +49,14 @@ addon() {
   cp -P $(get_build_dir vdr-plugin-xmltv2vdr)/dist/epgdata2xmltv/epgdata2xmltv.dist ${ADDON_BUILD}/${PKG_ADDON_ID}/config/epgsources/epgdata2xmltv
 
   # copy binaries
-  for pkg in ddci2 dummydevice dvbapi eepg epgfixer epgsearch iptv live restfulapi robotv satip vnsiserver wirbelscan wirbelscancontrol xmltv2vdr; do
-    cp -PR $(get_build_dir vdr-plugin-${pkg})/libvdr*.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/plugin
+  for pkg in ddci2 dummydevice dvbapi eepg epgfixer epgsearch iptv live restfulapi robotv satip \
+              vnsiserver wirbelscan wirbelscancontrol xmltv2vdr; do
+    cp -PR $(get_build_dir vdr-plugin-${pkg})/libvdr*.so.* ${ADDON_BUILD}/${PKG_ADDON_ID}/plugin
   done
 
-  # copy locale (omit ddci, dummydevice, robotv, wirbelscancontrol, xmltv2vdr)
-  for pkg in dvbapi eepg epgfixer epgsearch iptv live restfulapi satip vnsiserver wirbelscan; do
+  # copy locale (omit ddci, dummydevice, robotv)
+  for pkg in dvbapi eepg epgfixer epgsearch iptv live restfulapi satip vnsiserver wirbelscan \
+             wirbelscancontrol xmltv2vdr; do
     cp -PR $(get_build_dir vdr-plugin-${pkg})/locale/* ${ADDON_BUILD}/${PKG_ADDON_ID}/locale
   done
 


### PR DESCRIPTION
Since #8310 vdr-addon is not starting any more:
```
vdr[10336]: [10336] ERROR: /storage/.kodi/addons/service.multimedia.vdr-addon/plugin/libvdr-wirbelscancontrol.so.2.6.3: cannot open shared object file: No such file or directory
```
Only libvdr-wirbelscancontrol.so is available.Similar issue for vdr-plugin-xmltv2vdr.

With #8320 vdr-plugin-wirbelscan is failing because of missing object file:
```
vdr[3586]: [3586] ERROR: /storage/.kodi/addons/service.multimedia.vdr-addon/plugin/libvdr-wirbelscan.so.2.6.3: undefined symbol: _ZTVN8SI_EACEM14LogicalChannelE
```

Runtime tested by starting vdr-addon with all plugins enabled and DVB-T scan via script.config.vdr