### PR TITLE
[le11] linux (RPi): update to 6.1.62

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="17f135b742c4edb340afb365873c3a574f7e16cb" # 6.1.61
-    PKG_SHA256="4d3a2af178ac6ed8f35b773836c8d216493a850aeb80932b379348e2df0cf5d2"
+    PKG_VERSION="f9f480b04f1dc280bd4411477f5ee7336361367b" # 6.1.61
+    PKG_SHA256="0da8bc8e1f5b53714c7af851889bed1c360b15bff8b894bd201b5b5aec8e230c"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="5a52cae54a05499a8487f392cf5dfc3d8a837e6f" # 6.1.58
-    PKG_SHA256="2a59fa0d11a2892f25c89c774bede0640703fac7ea5dc51e2386b160c323817c"
+    PKG_VERSION="17f135b742c4edb340afb365873c3a574f7e16cb" # 6.1.61
+    PKG_SHA256="4d3a2af178ac6ed8f35b773836c8d216493a850aeb80932b379348e2df0cf5d2"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="f9f480b04f1dc280bd4411477f5ee7336361367b" # 6.1.61
-    PKG_SHA256="0da8bc8e1f5b53714c7af851889bed1c360b15bff8b894bd201b5b5aec8e230c"
+    PKG_VERSION="6137fb168c08bd8c41c8421bf26f09ed29479f08" # 6.1.61
+    PKG_SHA256="cc97eaaee95720db47c1f64f300ee209e72005de47560a6a183c70529b880502"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="6137fb168c08bd8c41c8421bf26f09ed29479f08" # 6.1.61
-    PKG_SHA256="cc97eaaee95720db47c1f64f300ee209e72005de47560a6a183c70529b880502"
+    PKG_VERSION="3fdb0eb8be5803a16fc308b8441cdcdeafbb944e" # 6.1.62
+    PKG_SHA256="a44b7d642fc2d80a8cfd05d0b461ecbff019680932754b3f9190bb22be9b8fe2"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="a75b0368e094d86aaee000b917514b51cb0d2eee"
-PKG_SHA256="b0afe373b22820dc7baa76f1dacad6b1a711ac1df55ab7ec607d77b1193cab69"
+PKG_VERSION="aded0825e3a2b6108c5bba7e0d823ddcdeb0d2d3"
+PKG_SHA256="3195d07108c9ffd8d93b94e1bb45cb4133ad302b4a9b2d703c9c25fac1743367"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="aded0825e3a2b6108c5bba7e0d823ddcdeb0d2d3"
-PKG_SHA256="3195d07108c9ffd8d93b94e1bb45cb4133ad302b4a9b2d703c9c25fac1743367"
+PKG_VERSION="6b14e84a2fb2e1f7220a404f65e7e0985f07c9e5"
+PKG_SHA256="3907711bb2ff78a0e9120709b72b04d6d010f93f79d525af0454d3d27a772aca"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/projects/RPi/devices/RPi5/options
+++ b/projects/RPi/devices/RPi5/options
@@ -9,7 +9,7 @@
     NOOBS_SUPPORTED_MODELS='"Pi 5"'
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
-    FIRMWARE="${FIRMWARE} rpi-eeprom"
+    FIRMWARE="${FIRMWARE} rpi-eeprom flashrom"
 
   # set the addon project
     ADDON_PROJECT="ARMv8"


### PR DESCRIPTION
Backport of #8338 

Runtime tested on RPi4 and RPi5