### PR TITLE
Keep addon introduced private shared libraries private to the addon

### DIFF
--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -29,7 +29,7 @@ make_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,config,lib,resources}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,config,lib.private,resources}
 
   # config
   cp -P ${PKG_DIR}/config/* ${ADDON_BUILD}/${PKG_ADDON_ID}/config
@@ -57,7 +57,7 @@ addon() {
          $(get_install_dir libxss)/usr/lib/libXss.so.1 \
          $(get_install_dir chrome-libXtst)/usr/lib/libXtst.so.6 \
          $(get_install_dir pango)/usr/lib/{libpangocairo-1.0.so.0,libpango-1.0.so.0,libpangoft2-1.0.so.0} \
-         ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+         ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
   # unix_ar
   cp -P $(get_build_dir unix_ar)/unix_ar.py ${ADDON_BUILD}/${PKG_ADDON_ID}/resources

--- a/packages/addons/browser/chrome/source/bin/chrome-start
+++ b/packages/addons/browser/chrome/source/bin/chrome-start
@@ -22,13 +22,13 @@ chmod +x $ADDON_DIR/chrome-bin/chrome
 chmod 4755 $ADDON_DIR/chrome-bin/chrome-sandbox
 
 # make sure we use "own" gtk/pango/nss/etc
-export LD_LIBRARY_PATH=$ADDON_DIR/lib
+export LD_LIBRARY_PATH=$ADDON_DIR/lib.private
 
 # configure pango/pixbuf
 export PANGO_RC_FILE=$ADDON_DIR/config/pangorc
 export GDK_PIXBUF_MODULE_FILE=$ADDON_DIR/config/pixbuf.loaders.cache
 
-# font rendering in gtk widgets is brokeen with nvidia blob. use our Xdefaults
+# font rendering in gtk widgets is broken with nvidia blob. use our Xdefaults
 export XENVIRONMENT=$ADDON_DIR/config/Xdefaults
 
 # start unclutter
@@ -39,7 +39,7 @@ then
 fi
 
 # vaapi
-LIBVA_DRIVERS_PATH="/usr/lib/dri:$ADDON_DIR/lib"
+LIBVA_DRIVERS_PATH="/usr/lib/dri:$ADDON_DIR/lib.private"
 LIBVA_DRIVER_NAME=''
 case $VAAPI_MODE in
   'intel')

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -37,8 +37,9 @@ addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp ${PKG_BUILD}/.${TARGET_NAME}/target/${TARGET_NAME}/release/librespot \
        ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/librespot
 
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
     cp $(get_build_dir avahi)/avahi-compat-libdns_sd/.libs/libdns_sd.so.1 \
-       ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+       ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 }

--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -102,7 +102,9 @@ addon() {
   # copy mpd cli binary
   cp -P $(get_install_dir mpd-mpc)/usr/bin/mpc ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-  cp -p $(get_install_dir libmpdclient)/usr/lib/libmpdclient.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-  cp -p $(get_install_dir libmpdclient)/usr/lib/libmpdclient.so.2 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{mpc,mpd}
+
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+  cp -p $(get_install_dir libmpdclient)/usr/lib/libmpdclient.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+  cp -p $(get_install_dir libmpdclient)/usr/lib/libmpdclient.so.2 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 }

--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -18,11 +18,12 @@ PKG_ADDON_TYPE="xbmc.service.library"
 PKG_MAINTAINER="Anton Voyl (awiouy)"
 
 addon() {
-  mkdir -p "${ADDON_BUILD}/${PKG_ADDON_ID}/bin"
-  cp "$(get_install_dir snapcast)/usr/bin/snapclient" \
-     "${ADDON_BUILD}/${PKG_ADDON_ID}/bin"
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private}
 
-  mkdir -p "${ADDON_BUILD}/${PKG_ADDON_ID}/lib"
-  cp "$(get_install_dir alsa-plugins)/usr/lib/alsa"/*.so \
-     "${ADDON_BUILD}/${PKG_ADDON_ID}/lib"
+  cp $(get_install_dir snapcast)/usr/bin/snapclient \
+     ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+  patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/snapclient
+
+  cp $(get_install_dir alsa-plugins)/usr/lib/alsa/*.so \
+     ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 }

--- a/packages/addons/service/ttyd/package.mk
+++ b/packages/addons/service/ttyd/package.mk
@@ -20,11 +20,11 @@ PKG_ADDON_TYPE="xbmc.service"
 
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-  cp -P ${PKG_INSTALL}/usr/bin/ttyd ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P ${PKG_INSTALL}/usr/bin/ttyd ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-  cp -p $(get_install_dir json-c)/usr/lib/libjson-c.so.5 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-  cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets.so.19 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-  cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets-evlib_uv.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-  cp -p $(get_install_dir libuv)/usr/lib/libuv.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -p $(get_install_dir json-c)/usr/lib/libjson-c.so.5 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets.so.19 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -p $(get_install_dir libwebsockets)/usr/lib/libwebsockets-evlib_uv.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -p $(get_install_dir libuv)/usr/lib/libuv.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 }

--- a/packages/addons/service/ttyd/source/bin/ttyd.start
+++ b/packages/addons/service/ttyd/source/bin/ttyd.start
@@ -9,6 +9,8 @@ oe_setup_addon service.ttyd
 
 chmod a+x $ADDON_DIR/bin/*
 
+LD_LIBRARY_PATH=$ADDON_DIR/lib.private:$LD_LIBRARY_PATH
+
 if [ "$TTYD_NOLOGIN" = "true" ]; then
   TTYD_NOLOGIN="bash"
 elif [ "$TTYD_NOLOGIN" = "false" ]; then

--- a/packages/addons/service/tvheadend43/package.mk
+++ b/packages/addons/service/tvheadend43/package.mk
@@ -111,7 +111,7 @@ post_makeinstall_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
   cp ${PKG_DIR}/addon.xml ${ADDON_BUILD}/${PKG_ADDON_ID}
 
@@ -124,7 +124,9 @@ addon() {
   cp -P $(get_install_dir comskip)/usr/bin/comskip ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
   if [ "${TARGET_ARCH}" = "x86_64" ]; then
-    cp -P $(get_install_dir x265)/usr/lib/libx265.so.199 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+    mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -P $(get_install_dir x265)/usr/lib/libx265.so.199 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{comskip,tvheadend}
   fi
 
   # dvb-scan files

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -23,7 +23,9 @@ addon() {
     cp -r $(get_build_dir aspnet6-runtime)/* \
           ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
     cp -L $(get_install_dir icu)/usr/lib/lib*.so.?? \
-          ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
+          ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/shared/Microsoft.NETCore.App/$(get_pkg_version aspnet6-runtime)
+
+    sed -e "s/\"System.Reflection.Metadata.MetadataUpdater.IsSupported\": false/&,\n      \"System.Globalization.AppLocalIcu\": \"$(get_pkg_version icu | cut -f 1 -d -)\"/" \
+      -i ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/shared/Microsoft.NETCore.App/$(get_pkg_version aspnet6-runtime)/Microsoft.NETCore.App.runtimeconfig.json
 }

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -19,17 +19,18 @@ PKG_ADDON_NAME="FFmpeg Tools"
 PKG_ADDON_TYPE="xbmc.python.script"
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private}
 
   cp -L $(get_install_dir ffmpegx)/usr/local/bin/* ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+  patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/*
 
   # libs
   if [ "${TARGET_ARCH}" = "x86_64" ]; then
     cp -PL $(get_install_dir x265)/usr/lib/libx265.so.199 \
-           ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+           ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
   fi
   if [ "${DISPLAYSERVER}" = "x11" ]; then
     cp -PL $(get_install_dir libxcb)/usr/lib/{libxcb.so.1,libxcb-shm.so.0,libxcb-shape.so.0,libxcb-xfixes.so.0} \
-           ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+           ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
   fi
 }

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -35,19 +35,19 @@ PKG_DEPENDS_TARGET="toolchain \
                     wireless_tools"
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private}
     # bwm-ng
     cp -P $(get_install_dir bwm-ng)/usr/bin/bwm-ng ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # fuse
     cp -P $(get_install_dir fuse)/usr/bin/{fusermount,ulockmgr_server} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir fuse)/usr/sbin/mount.fuse ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-    cp -P $(get_install_dir fuse)/usr/lib/{libfuse.so*,libulockmgr.so*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+    cp -P $(get_install_dir fuse)/usr/lib/{libfuse.so*,libulockmgr.so*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
     # fuse3
     cp -P $(get_install_dir fuse3)/usr/bin/fusermount3 ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir fuse3)/usr/sbin/mount.fuse3  ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-    cp -P $(get_install_dir fuse3)/usr/lib/libfuse3.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+    cp -P $(get_install_dir fuse3)/usr/lib/libfuse3.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
     # iftop
     cp -P $(get_install_dir iftop)/usr/sbin/iftop ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
@@ -100,4 +100,7 @@ addon() {
     ln -s iwconfig ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/iwlist
     ln -s iwconfig ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/iwspy
     ln -s iwconfig ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/iwpriv
+
+    find ${ADDON_BUILD}/${PKG_ADDON_ID}/bin -type f | \
+      xargs patchelf --add-rpath '$ORIGIN/../lib.private'
 }

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -61,7 +61,7 @@ if [ "${TARGET_ARCH}" = "x86_64" ]; then
 fi
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,data,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,data,lib.private}
 
     # 7-zip
     cp -P $(get_install_dir 7-zip)/usr/bin/7zz ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
@@ -100,7 +100,7 @@ addon() {
     # fuse
     cp -P $(get_install_dir fuse)/usr/bin/{fusermount,ulockmgr_server} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P $(get_install_dir fuse)/usr/sbin/mount.fuse ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-    cp -P $(get_install_dir fuse)/usr/lib/{libfuse.so*,libulockmgr.so*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+    cp -P $(get_install_dir fuse)/usr/lib/{libfuse.so*,libulockmgr.so*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
     # getscancodes
     cp -P $(get_install_dir getscancodes)/usr/bin/getscancodes ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
@@ -120,17 +120,18 @@ addon() {
 
     # i2c-tools
     cp -P $(get_install_dir i2c-tools)/usr/sbin/{i2cdetect,i2cdump,i2cget,i2cset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-    cp -P $(get_install_dir i2c-tools)/usr/lib/${PKG_PYTHON_VERSION}/site-packages/smbus.so ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0
-    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/libi2c.so.0.1.1
+    cp -P $(get_install_dir i2c-tools)/usr/lib/${PKG_PYTHON_VERSION}/site-packages/smbus.so \
+      ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/libi2c.so
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/libi2c.so.0
+    cp -P $(get_install_dir i2c-tools)/usr/lib/libi2c.so.0.1.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/libi2c.so.0.1.1
 
     # inotify-tools
     cp -P $(get_install_dir inotify-tools)/usr/bin/{inotifywait,inotifywatch} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # jq
     cp -P $(get_install_dir jq)/usr/bin/jq ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-    cp -P $(get_install_dir oniguruma)/usr/lib/{libonig.so,libonig.so.5,libonig.so.5.*.*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+    cp -P $(get_install_dir oniguruma)/usr/lib/{libonig.so,libonig.so.5,libonig.so.5.*.*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
     # libgpiod
     cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpioget,gpioinfo,gpiomon,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
@@ -184,4 +185,7 @@ addon() {
     # vim
     cp -P $(get_install_dir vim)/usr/bin/vim ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -Pa $(get_install_dir vim)/storage/.kodi/addons/virtual.system-tools/data/vim/ ${ADDON_BUILD}/${PKG_ADDON_ID}/data
+
+    scanelf -EET_EXEC -RBF %F ${ADDON_BUILD}/${PKG_ADDON_ID}/bin | \
+      xargs patchelf --add-rpath '$ORIGIN/../lib.private'
 }

--- a/packages/mediacenter/kodi/profile.d/99-kodi.conf
+++ b/packages/mediacenter/kodi/profile.d/99-kodi.conf
@@ -9,6 +9,9 @@ export PATH
 
 # LD_LIBRARY_PATH
 for addon in /storage/.kodi/addons/*/lib /usr/lib/kodi/addons/*/lib; do
-  [ -d "$addon" ] && LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$addon"
+  [ -d "$addon" ] && (
+    files="$(find $addon ! -type d -name '*.so*' -maxdepth 1)"
+    [ ! -z "$files" ] && LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$addon"
+  )
 done
 export LD_LIBRARY_PATH


### PR DESCRIPTION
- Following on from #6094 which removed incorrect stored RPATH/RUNPATH directories in the binaries, this new PR addresses #7602 in which private share libraries are made available system wide.

This PR addresses 3 specific areas:
- reduce the number of paths being added to LD_LIBRARY_PATH - a6cd2720475ac71f1ce6a475d3ad7c54a6e40ecb
- use lib.private for private shared libraries and update calling binaries with `'$ORIGIN/../lib.private'`. This keeps the shared libraries from polluting the LD_LIBRARY_PATH.
  - in the case of addons like chrome, which set an LD_LIBRARY_PATH in there startup script, continue to use this method - but - target the lib.private
  - for addons like dotnet that have internal dlopen approch available - use them - ref: https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#app-local-icu
- allow for binaries that have not got the environment set to find the required shared libraries - e.g. #7589 when called in systemd

This PR includes that addons I’m regularly using. 
- Initial testing looks correct. 
- My LD_LIBRARY_PATH is now `LD_LIBRARY_PATH='/usr/lib:/usr/lib/pulseaudio'`
- Feedback on this before I continue with the other addons.

### Some historical background of the following error if some one has it?
The code written in a6cd2720475ac71f1ce6a475d3ad7c54a6e40ecb checks for lib directories with .so files. It seems that the `find: /usr/lib/kodi/addons/*/lib: No such file or directory` does not have any addons using this format, peripheral.joystick has the shared libraries located at it’s addon directory.

See
```
nuc12:~ # find /usr/lib/kodi/addons ! -type d
/usr/lib/kodi/addons/peripheral.joystick/peripheral.joystick.so
/usr/lib/kodi/addons/peripheral.joystick/peripheral.joystick.so.21.0
/usr/lib/kodi/addons/peripheral.joystick/peripheral.joystick.so.21.1.7
```