### PR TITLE
linux: rtw88: patch to reduce disconnects

### DIFF
--- a/packages/linux/patches/default/linux-111-rtw88-from-next.patch
+++ b/packages/linux/patches/default/linux-111-rtw88-from-next.patch
@@ -1,0 +1,37 @@
+From 53ee0b3b99edc6a47096bffef15695f5a895386f Mon Sep 17 00:00:00 2001
+From: Chih-Kang Chang <gary.chang@realtek.com>
+Date: Fri, 3 Nov 2023 10:08:51 +0800
+Subject: [PATCH] wifi: rtw88: fix RX filter in FIF_ALLMULTI flag
+
+The broadcast packets will be filtered in the FIF_ALLMULTI flag in
+the original code, which causes beacon packets to be filtered out
+and disconnection. Therefore, we fix it.
+
+Fixes: e3037485c68e ("rtw88: new Realtek 802.11ac driver")
+Signed-off-by: Chih-Kang Chang <gary.chang@realtek.com>
+Signed-off-by: Ping-Ke Shih <pkshih@realtek.com>
+Signed-off-by: Kalle Valo <kvalo@kernel.org>
+Link: https://lore.kernel.org/r/20231103020851.102238-1-pkshih@realtek.com
+---
+ drivers/net/wireless/realtek/rtw88/mac80211.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireless/realtek/rtw88/mac80211.c
+index a99b53d44267..d8d68f16014e 100644
+--- a/drivers/net/wireless/realtek/rtw88/mac80211.c
++++ b/drivers/net/wireless/realtek/rtw88/mac80211.c
+@@ -280,9 +280,9 @@ static void rtw_ops_configure_filter(struct ieee80211_hw *hw,
+ 
+ 	if (changed_flags & FIF_ALLMULTI) {
+ 		if (*new_flags & FIF_ALLMULTI)
+-			rtwdev->hal.rcr |= BIT_AM | BIT_AB;
++			rtwdev->hal.rcr |= BIT_AM;
+ 		else
+-			rtwdev->hal.rcr &= ~(BIT_AM | BIT_AB);
++			rtwdev->hal.rcr &= ~(BIT_AM);
+ 	}
+ 	if (changed_flags & FIF_FCSFAIL) {
+ 		if (*new_flags & FIF_FCSFAIL)
+-- 
+2.34.1
+

--- a/packages/linux/patches/raspberrypi/linux-111-rtw88-from-next.patch
+++ b/packages/linux/patches/raspberrypi/linux-111-rtw88-from-next.patch
@@ -1,0 +1,37 @@
+From 53ee0b3b99edc6a47096bffef15695f5a895386f Mon Sep 17 00:00:00 2001
+From: Chih-Kang Chang <gary.chang@realtek.com>
+Date: Fri, 3 Nov 2023 10:08:51 +0800
+Subject: [PATCH] wifi: rtw88: fix RX filter in FIF_ALLMULTI flag
+
+The broadcast packets will be filtered in the FIF_ALLMULTI flag in
+the original code, which causes beacon packets to be filtered out
+and disconnection. Therefore, we fix it.
+
+Fixes: e3037485c68e ("rtw88: new Realtek 802.11ac driver")
+Signed-off-by: Chih-Kang Chang <gary.chang@realtek.com>
+Signed-off-by: Ping-Ke Shih <pkshih@realtek.com>
+Signed-off-by: Kalle Valo <kvalo@kernel.org>
+Link: https://lore.kernel.org/r/20231103020851.102238-1-pkshih@realtek.com
+---
+ drivers/net/wireless/realtek/rtw88/mac80211.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireless/realtek/rtw88/mac80211.c
+index a99b53d44267..d8d68f16014e 100644
+--- a/drivers/net/wireless/realtek/rtw88/mac80211.c
++++ b/drivers/net/wireless/realtek/rtw88/mac80211.c
+@@ -280,9 +280,9 @@ static void rtw_ops_configure_filter(struct ieee80211_hw *hw,
+ 
+ 	if (changed_flags & FIF_ALLMULTI) {
+ 		if (*new_flags & FIF_ALLMULTI)
+-			rtwdev->hal.rcr |= BIT_AM | BIT_AB;
++			rtwdev->hal.rcr |= BIT_AM;
+ 		else
+-			rtwdev->hal.rcr &= ~(BIT_AM | BIT_AB);
++			rtwdev->hal.rcr &= ~(BIT_AM);
+ 	}
+ 	if (changed_flags & FIF_FCSFAIL) {
+ 		if (*new_flags & FIF_FCSFAIL)
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch is from wireless-next, it should be merged in 6.8.  It should resolve issues with frequent disconnects from beacon loss as reported by:
`iw wlan0 station dump`

This is caused by a bug in the driver that is filtering broadcast packets when FIF_ALLMULTI is disabled, when it should only filter multicast packets.  I would assume this would resolve the issue on all rtw88-based devices including SDIO devices.  I'm mainly using a USB dongle.

I have been running this for about two weeks on [RPi4 w/ 6.1 kernel](https://github.com/wagnerch/LibreELEC.tv/tree/rtw88-6.1.62) and it has resolved disconnect issues with the rtl8822bu dongle device.   I figured since all devices have moved to 6.6 (and since it is LTS then they are likely to stay on for the release of LE12) that this one patch from upstream would be important to include.

Currently running with this patch and all other upstream rtw88 patches since last night when 6.6 was bumped for RPi4.  Most of the other patches from 6.7 and wireless-next are cosmetic or regulatory changes for China, probably not worth the maintenance.