### PR TITLE
xf86-video-nvidia: update to 545.29.06

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="xf86-video-nvidia"
 # Remember to run "python3 packages/x11/driver/xf86-video-nvidia/scripts/make_nvidia_udev.py" and commit
 # changes to "packages/x11/driver/xf86-video-nvidia/udev.d/96-nvidia.rules" whenever bumping version.
 # The build host may require installation of python3-lxml and python3-requests packages.
-PKG_VERSION="545.29.02"
-PKG_SHA256="b1b4059ca4685d35bbfa9c3350351956a74a2e4a3e0fb34f3fad3653d4fdafb1"
+PKG_VERSION="545.29.06"
+PKG_SHA256="22ce8f5f617ebf13f75510fc4f47ae307b067cc464ed59852631ba3cf149f26d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="https://www.nvidia.com/en-us/drivers/unix/"


### PR DESCRIPTION
release notes:
- https://www.nvidia.com/download/driverResults.aspx/216530/en-us/
  - Fixed a regression that prevented setting backlight brightness levels.
  - Fixed a bug that could lead to UI corruption in nvidia-installer on systems with more than one initramfs file per kernel.
  - Fixed a bug that caused games built on the Source 2 engine to hang when running under Xwayland.