### PR TITLE
mpv-drmprime: update to 0.37.0

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/libplacebo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/libplacebo/package.mk
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libplacebo"
+PKG_VERSION="6.338.1"
+PKG_SHA256="3c9a68b325c00e6f2f16d58774fd3a9bb63c0f27c10c2285438ad813b2d05ae1"
+PKG_LICENSE="LGPLv2.1"
+PKG_SITE="https://code.videolan.org/videolan/libplacebo"
+PKG_URL="https://github.com/haasn/libplacebo/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain glad:host"
+PKG_DEPENDS_UNPACK="vulkan-headers"
+PKG_LONGDESC="Reusable library for GPU-accelerated image/video processing primitives and shaders"
+PKG_BUILD_FLAGS="-sysroot"
+
+PKG_MESON_OPTS_TARGET="-Ddefault_library=static \
+                       -Dprefer_static=true \
+                       -Dvulkan=disabled \
+                       -Dvk-proc-addr=disabled \
+                       -Dd3d11=disabled \
+                       -Dglslang=disabled \
+                       -Dshaderc=disabled \
+                       -Dlcms=disabled \
+                       -Ddovi=disabled \
+                       -Dlibdovi=disabled \
+                       -Ddemos=false"
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  PKG_MESON_OPTS_TARGET+=" -Dopengl=enabled -Dgl-proc-addr=enabled"
+else
+  PKG_MESON_OPTS_TARGET+=" -Dopengl=disabled -Dgl-proc-addr=disabled"
+fi
+
+pre_configure_target() {
+  export TARGET_CFLAGS+=" -I$(get_build_dir vulkan-headers)/include"
+}
+
+post_makeinstall_target() {
+  sed 's/^Libs:.*-lplacebo/& -lstdc++/' -i ${INSTALL}/usr/lib/pkgconfig/libplacebo.pc
+}

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/package.mk
@@ -2,32 +2,32 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpv-drmprime"
-PKG_VERSION="0.36.0"
-PKG_SHA256="29abc44f8ebee013bb2f9fe14d80b30db19b534c679056e4851ceadf5a5e8bf6"
+PKG_VERSION="0.37.0"
+PKG_SHA256="1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mpv.io/"
 PKG_URL="https://github.com/mpv-player/mpv/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain waf:host alsa ffmpeg libass libdrm lua52"
+PKG_DEPENDS_TARGET="toolchain alsa ffmpeg libass libdrm libplacebo lua52"
 PKG_LONGDESC="A media player based on MPlayer and mplayer2. It supports a wide variety of video file formats, audio and video codecs, and subtitle types."
-PKG_TOOLCHAIN="manual"
 PKG_BUILD_FLAGS="-sysroot"
 
-PKG_MANUAL_OPTS_TARGET="--prefix=/usr \
-                        --disable-libarchive \
-                        --enable-lua \
-                        --disable-javascript \
-                        --disable-uchardet \
-                        --disable-rubberband \
-                        --disable-lcms2 \
-                        --disable-vapoursynth \
-                        --disable-jack \
-                        --disable-wayland \
-                        --disable-x11 \
-                        --disable-vulkan \
-                        --disable-caca \
-                        --enable-drm \
-                        --enable-gbm \
-                        --enable-egl-drm"
+PKG_MESON_OPTS_TARGET="--prefix=/usr \
+                        -Dlibarchive=disabled \
+                        -Dlua=enabled \
+                        -Djavascript=disabled \
+                        -Duchardet=disabled \
+                        -Drubberband=disabled \
+                        -Dlcms2=disabled \
+                        -Dvapoursynth=disabled \
+                        -Djack=disabled \
+                        -Dwayland=disabled \
+                        -Dx11=disabled \
+                        -Dvulkan=disabled \
+                        -Dcaca=disabled \
+                        -Ddrm=enabled \
+                        -Dgbm=enabled \
+                        -Degl-drm=enabled \
+                        -Dmanpage-build=disabled"
 
 if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGLES}"
@@ -39,40 +39,25 @@ fi
 
 if [ "${VAAPI_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" libva"
-  PKG_MANUAL_OPTS_TARGET+=" --enable-vaapi --enable-vaapi-drm"
+  PKG_MESON_OPTS_TARGET+=" -Dvaapi=enabled -Dvaapi-drm=enabled"
 else
-  PKG_MANUAL_OPTS_TARGET+=" --disable-vaapi"
+  PKG_MESON_OPTS_TARGET+=" -Dvaapi=disabled"
 fi
 
 if [ "${PULSEAUDIO_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" pulseaudio"
-  PKG_MANUAL_OPTS_TARGET+=" --enable-pulse"
+  PKG_MESON_OPTS_TARGET+=" -Dpulse=enabled"
 else
-  PKG_MANUAL_OPTS_TARGET+=" --disable-pulse"
+  PKG_MESON_OPTS_TARGET+=" -Dpulse=disabled"
 fi
 
 if [ "${KODI_BLURAY_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" libbluray"
-  PKG_MANUAL_OPTS_TARGET+=" --enable-libbluray"
+  PKG_MESON_OPTS_TARGET+=" -Dlibbluray=enabled"
 else
-  PKG_MANUAL_OPTS_TARGET+=" --disable-libbluray"
+  PKG_MESON_OPTS_TARGET+=" -Dlibbluray=disabled"
 fi
 
 pre_configure_target() {
-#mpv does not build in the .TARGET_NAME
-  cd ${PKG_BUILD}
-    rm -rf .${TARGET_NAME}
-}
-
-configure_target() {
-  waf configure ${PKG_MANUAL_OPTS_TARGET}
-}
-
-make_target() {
-  waf build
-}
-
-makeinstall_target() {
-  waf install --destdir=${INSTALL}
-  rm -r ${INSTALL}/usr/share
+  export PKG_CONFIG_PATH="$(get_install_dir libplacebo)/usr/lib/pkgconfig:${PKG_CONFIG_PATH}"
 }

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/patches/mpv-drmprime-0001-meson-also-expose-present_sync-for-VT-only-after.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpv-drmprime/patches/mpv-drmprime-0001-meson-also-expose-present_sync-for-VT-only-after.patch
@@ -1,0 +1,41 @@
+From e575ec4fc3654387c7358bd3640877ef32628d2c Mon Sep 17 00:00:00 2001
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Wed, 22 Nov 2023 19:44:13 +0100
+Subject: [PATCH] meson: also expose present_sync for VT-only after
+ a96d04f19d73
+
+$ meson setup --auto-features=disabled -Ddrm=enabled -Degl=enabled -Dgbm=enabled -Degl-drm=enabled /tmp/mpv_build
+$ meson compile -C /tmp/mpv_build
+[...]
+ld: error: undefined symbol: mp_present_initialize
+>>> referenced by drm_common.c
+>>>               libmpv.so.2.2.0.p/video_out_drm_common.c.o:(vo_drm_init)
+
+ld: error: undefined symbol: present_sync_update_values
+>>> referenced by drm_common.c
+>>>               libmpv.so.2.2.0.p/video_out_drm_common.c.o:(drm_pflip_cb)
+
+ld: error: undefined symbol: present_sync_swap
+>>> referenced by drm_common.c
+>>>               libmpv.so.2.2.0.p/video_out_drm_common.c.o:(drm_pflip_cb)
+
+ld: error: undefined symbol: present_sync_get_info
+>>> referenced by vo_drm.c
+>>>               libmpv.so.2.2.0.p/video_out_vo_drm.c.o:(get_vsync)
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index a3c3430dd47b..6fd5afa5122a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1049,7 +1049,7 @@ if features['xv']
+     sources += files('video/out/vo_xv.c')
+ endif
+ 
+-if features['wayland'] or features['x11']
++if features['wayland'] or features['x11'] or features['drm']
+     sources += ('video/out/present_sync.c')
+ endif
+ 

--- a/packages/python/graphics/glad/package.mk
+++ b/packages/python/graphics/glad/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="glad"
+PKG_VERSION="2.0.4"
+PKG_SHA256="02629644c242dcc27c58222bd2c001d5e2f3765dbbcfd796542308bddebab401"
+PKG_LICENSE="MIT"
+PKG_SITE="https://glad.dav1d.de"
+PKG_URL="https://github.com/Dav1dde/glad/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Multi-Language Vulkan/GL/GLES/EGL/GLX/WGL Loader-Generator based on the official specs"
+PKG_TOOLCHAIN="manual"
+
+makeinstall_host() {
+  export DONT_BUILD_LEGACY_PYC=1
+  exec_thread_safe python3 setup.py install --prefix=${TOOLCHAIN}
+}


### PR DESCRIPTION
- mpv has been migrated to meson from waf
- requires glad:host and libplacebo:target
- release notes:
  - https://github.com/mpv-player/mpv/releases/tag/v0.37.0 

