### PR TITLE
Vulkan update to 1.3.271

### DIFF
--- a/packages/graphics/vulkan/volk/package.mk
+++ b/packages/graphics/vulkan/volk/package.mk
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="volk"
+PKG_VERSION="1.3.270"
+PKG_SHA256="95530bc7850b0358e4bad899eb653f882ee8a08088257d90c5042cec02208f52"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/zeux/volk"
+PKG_URL="https://github.com/zeux/volk/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Meta loader for Vulkan API"
+
+PKG_CMAKE_OPTS_TARGET="-DVOLK_INSTALL=on"

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.270"
-PKG_SHA256="908e4e3881df8003744279ebdb0acd195c35d3792b2855e5488871956f90a7ee"
+PKG_VERSION="1.3.271"
+PKG_SHA256="694223d738729b6d660129efbc876522921e54965f292cf69ec2f15565c6b3dc"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.270"
-PKG_SHA256="464293bd8be1545365518327168c676aadab7a88fa516054cd59fb3f6f83a1d5"
+PKG_VERSION="1.3.271"
+PKG_SHA256="348b6db7a8af4e46ffdd7f494f7fe994f572fc0b7473be98338a0a8a4a3d5725"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.270"
-PKG_SHA256="8b570500f99a8133fff1a55e82dc7bf2bb5afacdfecd6fc08c45d2fe2a85d9ad"
+PKG_VERSION="1.3.271"
+PKG_SHA256="8cbc2fd27326de0e7d16ceab6463f4c1c116f8c0699e5621cdc0eded07f3105a"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain vulkan-loader glslang:host Python3:host"
+PKG_DEPENDS_TARGET="toolchain volk vulkan-loader glslang:host Python3:host"
 PKG_LONGDESC="This project provides Khronos official Vulkan Tools and Utilities."
 
 configure_package() {


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/blob/main/ChangeLog.adoc
- vulkan-headers: update to 1.3.271
- vulkan-loader: update to 1.3.271
- vulkan-tools: update to 1.3.271
- volk: initial package