### PR TITLE
nss: update to 3.95

### DIFF
--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.93"
-PKG_SHA256="4a5b5df21f8accc65b80d38b6acf8b017a5d03b5f81f0d23295a11575f300183"
+PKG_VERSION="3.95"
+PKG_SHA256="05a3955b48ac991c28604dee465527810bd5acf3c2879f09cd86eb83ffd8f79d"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"

--- a/packages/security/nss/patches/0001-Revert-Bug-1827303-Softoken-C_-calls-should-use-syst.patch
+++ b/packages/security/nss/patches/0001-Revert-Bug-1827303-Softoken-C_-calls-should-use-syst.patch
@@ -1,0 +1,329 @@
+From 4d40ae4e120bf69e27f9f9331c3fedaf01a48edd Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 3 Oct 2023 15:57:07 +0000
+Subject: [PATCH] Revert "Bug 1827303 Softoken C_ calls should use system FIPS
+ setting to select NSC_ or FC_ variants."
+
+This reverts commit e91f174eeb34e5acfa9f01bb194905168c82bef9.
+---
+ lib/freebl/nsslowhash.c                       | 32 ++++++++++++-
+ lib/freebl/stubs.c                            | 44 ------------------
+ lib/freebl/stubs.h                            |  1 -
+ lib/pk11wrap/pk11util.c                       | 23 +++++++++-
+ lib/softoken/pkcs11.c                         | 35 --------------
+ lib/util/nssutil.def                          |  6 ---
+ lib/util/secport.c                            | 46 -------------------
+ lib/util/secport.h                            |  1 -
+ 9 files changed, 53 insertions(+), 140 deletions(-)
+
+diff --git a/nss/lib/freebl/nsslowhash.c b/nss/lib/freebl/nsslowhash.c
+index cf9e8ac52..7a22a357e 100644
+--- a/nss/lib/freebl/nsslowhash.c
++++ b/nss/lib/freebl/nsslowhash.c
+@@ -23,6 +23,36 @@ struct NSSLOWHASHContextStr {
+     void *hashCtxt;
+ };
+ 
++#ifndef NSS_FIPS_DISABLED
++static int
++nsslow_GetFIPSEnabled(void)
++{
++#ifdef LINUX
++    FILE *f;
++    char d;
++    size_t size;
++    const char *env;
++
++    env = PR_GetEnvSecure("NSS_FIPS");
++    if (env && (*env == 'y' || *env == 'f' || *env == '1' || *env == 't')) {
++        return 1;
++    }
++
++    f = fopen("/proc/sys/crypto/fips_enabled", "r");
++    if (!f)
++        return 0;
++
++    size = fread(&d, 1, 1, f);
++    fclose(f);
++    if (size != 1)
++        return 0;
++    if (d != '1')
++        return 0;
++#endif /* LINUX */
++    return 1;
++}
++#endif /* NSS_FIPS_DISABLED */
++
+ static NSSLOWInitContext dummyContext = { 0 };
+ static PRBool post_failed = PR_TRUE;
+ 
+@@ -36,7 +66,7 @@ NSSLOW_Init(void)
+ #ifndef NSS_FIPS_DISABLED
+     /* make sure the FIPS product is installed if we are trying to
+      * go into FIPS mode */
+-    if (NSS_GetSystemFIPSEnabled()) {
++    if (nsslow_GetFIPSEnabled()) {
+         if (BL_FIPSEntryOK(PR_TRUE, PR_FALSE) != SECSuccess) {
+             PORT_SetError(SEC_ERROR_LIBRARY_FAILURE);
+             post_failed = PR_TRUE;
+diff --git a/nss/lib/freebl/stubs.c b/nss/lib/freebl/stubs.c
+index a79cf69a2..a20d7abf3 100644
+--- a/nss/lib/freebl/stubs.c
++++ b/nss/lib/freebl/stubs.c
+@@ -182,9 +182,6 @@ STUB_DECLARE(SECOidTag, SECOID_FindOIDTag_Util, (const SECItem *oid));
+ STUB_DECLARE(int, NSS_SecureMemcmp, (const void *a, const void *b, size_t n));
+ STUB_DECLARE(unsigned int, NSS_SecureMemcmpZero, (const void *mem, size_t n));
+ STUB_DECLARE(void, NSS_SecureSelect, (void *dest, const void *src0, const void *src1, size_t n, unsigned char b));
+-#ifndef NSS_FIPS_DISABLED
+-STUB_DECLARE(PRBool, NSS_GetSystemFIPSEnabled, (void));
+-#endif
+ 
+ #define PORT_ZNew_stub(type) (type *)PORT_ZAlloc_stub(sizeof(type))
+ #define PORT_New_stub(type) (type *)PORT_Alloc_stub(sizeof(type))
+@@ -715,47 +712,6 @@ NSS_SecureSelect_stub(void *dest, const void *src0, const void *src1, size_t n,
+     abort();
+ }
+ 
+-#ifndef NSS_FIPS_DISABLED
+-PRBool
+-NSS_GetSystemFIPSEnabled_stub(void)
+-{
+-    STUB_SAFE_CALL0(NSS_GetSystemFIPSEnabled);
+-    const char *env;
+-
+-    /* The environment variable is active for all platforms */
+-    env = PR_GetEnvSecure_stub("NSS_FIPS");
+-    /* we generally accept y, Y, 1, FIPS, TRUE, and ON as turning on FIPS
+-     * mode. Anything else is considered 'off' */
+-    if (env && (*env == 'y' || *env == '1' || *env == 'Y' ||
+-                (strcasecmp(env, "fips") == 0) ||
+-                (strcasecmp(env, "true") == 0) ||
+-                (strcasecmp(env, "on") == 0))) {
+-        return PR_TRUE;
+-    }
+-
+-/* currently only Linux has a system FIPS indicator. Add others here
+- * as they become available/known */
+-#ifdef LINUX
+-    {
+-        FILE *f;
+-        char d;
+-        size_t size;
+-        f = fopen("/proc/sys/crypto/fips_enabled", "r");
+-        if (!f)
+-            return PR_FALSE;
+-
+-        size = fread(&d, 1, 1, f);
+-        fclose(f);
+-        if (size != 1)
+-            return PR_FALSE;
+-        if (d == '1')
+-            return PR_TRUE;
+-    }
+-#endif /* LINUX */
+-    return PR_FALSE;
+-}
+-#endif /* NSS_FIPS_DISABLED = 0 */
+-
+ #ifdef FREEBL_NO_WEAK
+ 
+ static const char *nsprLibName = SHLIB_PREFIX "nspr4." SHLIB_SUFFIX;
+diff --git a/nss/lib/freebl/stubs.h b/nss/lib/freebl/stubs.h
+index 58cb9d085..f773e1043 100644
+--- a/nss/lib/freebl/stubs.h
++++ b/nss/lib/freebl/stubs.h
+@@ -43,7 +43,6 @@
+ #define NSS_SecureMemcmp NSS_SecureMemcmp_stub
+ #define NSS_SecureMemcmpZero NSS_SecureMemcmpZero_stub
+ #define NSS_SecureSelect NSS_SecureSelect_stub
+-#define NSS_GetSystemFIPSEnabled NSS_GetSystemFIPSEnabled_stub
+ 
+ #define PR_Assert PR_Assert_stub
+ #define PR_Access PR_Access_stub
+diff --git a/nss/lib/pk11wrap/pk11util.c b/nss/lib/pk11wrap/pk11util.c
+index e15a0774e..2584ec3e8 100644
+--- a/nss/lib/pk11wrap/pk11util.c
++++ b/nss/lib/pk11wrap/pk11util.c
+@@ -99,7 +99,28 @@ SECMOD_Shutdown()
+ PRBool
+ SECMOD_GetSystemFIPSEnabled(void)
+ {
+-    return NSS_GetSystemFIPSEnabled();
++#ifdef LINUX
++#ifndef NSS_FIPS_DISABLED
++    FILE *f;
++    char d;
++    size_t size;
++
++    f = fopen("/proc/sys/crypto/fips_enabled", "r");
++    if (!f) {
++        return PR_FALSE;
++    }
++
++    size = fread(&d, 1, sizeof(d), f);
++    fclose(f);
++    if (size != sizeof(d)) {
++        return PR_FALSE;
++    }
++    if (d == '1') {
++        return PR_TRUE;
++    }
++#endif
++#endif
++    return PR_FALSE;
+ }
+ 
+ /*
+diff --git a/nss/lib/softoken/pkcs11.c b/nss/lib/softoken/pkcs11.c
+index 8e7872f8b..64b7892d0 100644
+--- a/nss/lib/softoken/pkcs11.c
++++ b/nss/lib/softoken/pkcs11.c
+@@ -93,17 +93,6 @@ static PRIntervalTime loginWaitTime;
+ 
+ #include "pkcs11f.h"
+ 
+-#ifndef NSS_FIPS_DISABLE
+-/* ------------- forward declare all the FIPS functions ------------- */
+-#undef CK_NEED_ARG_LIST
+-#undef CK_PKCS11_FUNCTION_INFO
+-
+-#define CK_PKCS11_FUNCTION_INFO(name) CK_RV __PASTE(F, name)
+-#define CK_NEED_ARG_LIST 1
+-
+-#include "pkcs11f.h"
+-#endif
+-
+ /* build the crypto module table */
+ static CK_FUNCTION_LIST_3_0 sftk_funcList = {
+     { CRYPTOKI_VERSION_MAJOR, CRYPTOKI_VERSION_MINOR },
+@@ -2508,15 +2497,7 @@ NSC_GetFunctionList(CK_FUNCTION_LIST_PTR *pFunctionList)
+ CK_RV
+ C_GetFunctionList(CK_FUNCTION_LIST_PTR *pFunctionList)
+ {
+-#ifdef NSS_FIPS_DISABLED
+     return NSC_GetFunctionList(pFunctionList);
+-#else
+-    if (NSS_GetSystemFIPSEnabled()) {
+-        return FC_GetFunctionList(pFunctionList);
+-    } else {
+-        return NSC_GetFunctionList(pFunctionList);
+-    }
+-#endif
+ }
+ 
+ CK_RV
+@@ -2537,15 +2518,7 @@ NSC_GetInterfaceList(CK_INTERFACE_PTR interfaces, CK_ULONG_PTR pulCount)
+ CK_RV
+ C_GetInterfaceList(CK_INTERFACE_PTR interfaces, CK_ULONG_PTR pulCount)
+ {
+-#ifdef NSS_FIPS_DISABLED
+     return NSC_GetInterfaceList(interfaces, pulCount);
+-#else
+-    if (NSS_GetSystemFIPSEnabled()) {
+-        return FC_GetInterfaceList(interfaces, pulCount);
+-    } else {
+-        return NSC_GetInterfaceList(interfaces, pulCount);
+-    }
+-#endif
+ }
+ 
+ /*
+@@ -2578,15 +2551,7 @@ CK_RV
+ C_GetInterface(CK_UTF8CHAR_PTR pInterfaceName, CK_VERSION_PTR pVersion,
+                CK_INTERFACE_PTR_PTR ppInterface, CK_FLAGS flags)
+ {
+-#ifdef NSS_FIPS_DISABLED
+     return NSC_GetInterface(pInterfaceName, pVersion, ppInterface, flags);
+-#else
+-    if (NSS_GetSystemFIPSEnabled()) {
+-        return FC_GetInterface(pInterfaceName, pVersion, ppInterface, flags);
+-    } else {
+-        return NSC_GetInterface(pInterfaceName, pVersion, ppInterface, flags);
+-    }
+-#endif
+ }
+ 
+ static PLHashNumber
+diff --git a/nss/lib/util/nssutil.def b/nss/lib/util/nssutil.def
+index 01f362c2a..a48794e47 100644
+--- a/nss/lib/util/nssutil.def
++++ b/nss/lib/util/nssutil.def
+@@ -354,9 +354,3 @@ NSS_SecureSelect;
+ ;+    local:
+ ;+       *;
+ ;+};
+-;+NSSUTIL_3.94 {         # NSS Utilities 3.94 release
+-;+    global:
+-NSS_GetSystemFIPSEnabled;
+-;+    local:
+-;+       *;
+-;+};
+diff --git a/nss/lib/util/secport.c b/nss/lib/util/secport.c
+index 30215a80f..fb5223d64 100644
+--- a/nss/lib/util/secport.c
++++ b/nss/lib/util/secport.c
+@@ -877,49 +877,3 @@ NSS_SecureSelect(void *dest, const void *src0, const void *src1, size_t n, unsig
+         ((unsigned char *)dest)[i] = s0i ^ (mask & (s0i ^ s1i));
+     }
+ }
+-
+-/*
+- * consolidate all the calls to get the system FIPS status in one spot.
+- * This function allows an environment variable to override what is returned.
+- */
+-PRBool
+-NSS_GetSystemFIPSEnabled(void)
+-{
+-/* if FIPS is disabled in NSS, always return FALSE, even if the environment
+- * variable is set, or the system is in FIPS mode */
+-#ifndef NSS_FIPS_DISABLED
+-    const char *env;
+-
+-    /* The environment variable is active for all platforms */
+-    env = PR_GetEnvSecure("NSS_FIPS");
+-    /* we generally accept y, Y, 1, FIPS, TRUE, and ON as turning on FIPS
+-     * mode. Anything else is considered 'off' */
+-    if (env && (*env == 'y' || *env == '1' || *env == 'Y' ||
+-                (PORT_Strcasecmp(env, "fips") == 0) ||
+-                (PORT_Strcasecmp(env, "true") == 0) ||
+-                (PORT_Strcasecmp(env, "on") == 0))) {
+-        return PR_TRUE;
+-    }
+-
+-/* currently only Linux has a system FIPS indicator. Add others here
+- * as they become available/known */
+-#ifdef LINUX
+-    {
+-        FILE *f;
+-        char d;
+-        size_t size;
+-        f = fopen("/proc/sys/crypto/fips_enabled", "r");
+-        if (!f)
+-            return PR_FALSE;
+-
+-        size = fread(&d, 1, 1, f);
+-        fclose(f);
+-        if (size != 1)
+-            return PR_FALSE;
+-        if (d == '1')
+-            return PR_TRUE;
+-    }
+-#endif /* LINUX */
+-#endif /* NSS_FIPS_DISABLED == 0 */
+-    return PR_FALSE;
+-}
+diff --git a/nss/lib/util/secport.h b/nss/lib/util/secport.h
+index d58b3f2f9..fa587b28a 100644
+--- a/nss/lib/util/secport.h
++++ b/nss/lib/util/secport.h
+@@ -262,7 +262,6 @@ extern int NSS_PutEnv(const char *envVarName, const char *envValue);
+ extern int NSS_SecureMemcmp(const void *a, const void *b, size_t n);
+ extern unsigned int NSS_SecureMemcmpZero(const void *mem, size_t n);
+ extern void NSS_SecureSelect(void *dest, const void *src0, const void *src1, size_t n, unsigned char b);
+-extern PRBool NSS_GetSystemFIPSEnabled(void);
+ 
+ /*
+  * Load a shared library called "newShLibName" in the same directory as
+-- 
+2.34.1
+


### PR DESCRIPTION
- includes a revert of 1827303 which was introduced in 3.94 (not yet fixed in 3.95)
  - potential workaround was to compile with FIPS which was discounted, upstream have acknowledged that it should compile with the options being used
- upstream bug - https://bugzilla.mozilla.org/show_bug.cgi?id=1856668