### PR TITLE
libxml2: update to 2.12.1

### DIFF
--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.11.6"
-PKG_SHA256="edd54dd02b9a594a2e98ac7842e01253fe39f9a5d9a394139b1e67925cebed01"
+PKG_VERSION="2.12.1"
+PKG_SHA256="8c7e368b1830028f6f4f0e3d128d317f8c49a32e66f4b87ce59a017bdf6514af"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"

--- a/packages/textproc/xmlstarlet/patches/xmlstarlet-0246-fix-compile-with-libxml-2-12-0.patch
+++ b/packages/textproc/xmlstarlet/patches/xmlstarlet-0246-fix-compile-with-libxml-2-12-0.patch
@@ -1,0 +1,66 @@
+From ac9f4ca6e3f2d4cfd4a3a8f08d09be81af8fdf92 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 21 Nov 2023 09:14:53 +0000
+Subject: [PATCH 1/2] xmlCleanupGlobals is a noop and not available in libxml2
+ 2.12.0
+
+---
+ src/xml_edit.c | 2 --
+ 1 files changed, 2 deletions(-)
+
+diff --git a/src/xml_edit.c b/src/xml_edit.c
+index e199178e..85a0a9f4 100644
+--- a/src/xml_edit.c
++++ b/src/xml_edit.c
+@@ -558,7 +558,6 @@ edOutput(const char* filename, const XmlEdAction* ops, int ops_count,
+     {
+         cleanupNSArr(ns_arr);
+         xmlCleanupParser();
+-        xmlCleanupGlobals();
+         exit(EXIT_BAD_FILE);
+     }
+ 
+@@ -752,6 +751,5 @@ edMain(int argc, char **argv)
+     xmlFree(ops);
+     cleanupNSArr(ns_arr);
+     xmlCleanupParser();
+-    xmlCleanupGlobals();
+     return 0;
+ }
+
+From 3c0eb2cf04848e902228bb147471c73803354fa8 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 21 Nov 2023 09:32:02 +0000
+Subject: [PATCH 2/2] missing headers since libxml2 2.12.0
+
+---
+ src/trans.c      | 3 +++
+ src/xml_format.c | 1 +
+ 2 files changed, 4 insertions(+)
+
+diff --git a/src/trans.c b/src/trans.c
+index 3603436f..cb2b0709 100644
+--- a/src/trans.c
++++ b/src/trans.c
+@@ -1,6 +1,9 @@
+ /*  $Id: trans.c,v 1.19 2004/11/22 02:28:21 mgrouch Exp $  */
+ 
+ #include <config.h>
++
++#include <libxml/xmlsave.h>
++
+ #include "trans.h"
+ #include "xmlstar.h"
+ 
+diff --git a/src/xml_format.c b/src/xml_format.c
+index e9da4df8..32a5f3d6 100644
+--- a/src/xml_format.c
++++ b/src/xml_format.c
+@@ -35,6 +35,7 @@ THE SOFTWARE.
+ #include <libxml/xmlmemory.h>
+ #include <libxml/debugXML.h>
+ #include <libxml/xmlIO.h>
++#include <libxml/xmlsave.h>
+ #include <libxml/HTMLtree.h>
+ #include <libxml/xinclude.h>
+ #include <libxml/xpath.h>


### PR DESCRIPTION
- libxml2: update to 2.12.1
- xmlstarlet: fix compile with libxml2 2.12.0
  - https://github.com/dimitern/xmlstarlet/pull/246
  - https://github.com/dimitern/xmlstarlet/issues/245