### PR TITLE
Part 2 - Keep addon introduced private shared libraries private to the addon

### DIFF
--- a/packages/addons/service/boblightd/package.mk
+++ b/packages/addons/service/boblightd/package.mk
@@ -42,19 +42,20 @@ makeinstall_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-  cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/.libs/libboblight.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/.libs/libboblight.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-  cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/boblightd ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-  cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/boblight-constant ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-  if [ "${DISPLAYSERVER}" = "x11" ]; then
-    cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/boblight-X11 ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-  fi
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/boblightd ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/boblight-constant ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    if [ "${DISPLAYSERVER}" = "x11" ]; then
+      cp -P ${PKG_BUILD}/.${TARGET_NAME}/src/boblight-X11 ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    fi
+    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/boblight-*
 
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/config
-  cp -R ${PKG_DIR}/config/boblight.conf ${ADDON_BUILD}/${PKG_ADDON_ID}/config
-  if [ "${DISPLAYSERVER}" = "x11" ]; then
-    cp -R ${PKG_DIR}/config/boblight.X11.sample ${ADDON_BUILD}/${PKG_ADDON_ID}/config
-  fi
+    cp -R ${PKG_DIR}/config/boblight.conf ${ADDON_BUILD}/${PKG_ADDON_ID}/config
+    if [ "${DISPLAYSERVER}" = "x11" ]; then
+      cp -R ${PKG_DIR}/config/boblight.X11.sample ${ADDON_BUILD}/${PKG_ADDON_ID}/config
+    fi
 }

--- a/packages/addons/service/lcdd/package.mk
+++ b/packages/addons/service/lcdd/package.mk
@@ -42,9 +42,11 @@ addon() {
 
   cp -PR ${PKG_INSTALL}/etc/LCDd.conf ${ADDON_BUILD}/${PKG_ADDON_ID}/config/
   cp -PR ${PKG_INSTALL}/usr/lib       ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
+  patchelf --add-rpath '$ORIGIN/../../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/lcdproc/glcd.so
   cp -PR ${PKG_INSTALL}/usr/sbin      ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
 
-  cp -L $(get_install_dir serdisplib)/usr/lib/libserdisp.so.2 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+  cp -L $(get_install_dir serdisplib)/usr/lib/libserdisp.so.2 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
   sed -e "s|^DriverPath=.*$|DriverPath=/storage/.kodi/addons/service.lcdd/lib/lcdproc/|" \
       -e "s|^#Foreground=.*$|Foreground=no|" \

--- a/packages/addons/service/minidlna/package.mk
+++ b/packages/addons/service/minidlna/package.mk
@@ -34,8 +34,9 @@ pre_configure_target() {
 
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-  cp -P ${PKG_INSTALL}/usr/sbin/minidlnad ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P ${PKG_INSTALL}/usr/sbin/minidlnad ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/minidlnad
 
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-  cp -p $(get_install_dir libexif)/usr/lib/libexif.so.12 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -p $(get_install_dir libexif)/usr/lib/libexif.so.12 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 }

--- a/packages/addons/service/tigervnc/package.mk
+++ b/packages/addons/service/tigervnc/package.mk
@@ -27,11 +27,11 @@ makeinstall_target() {
 # find ${1}.so.[0-9]* in ${2} and copy it to dest
 _pkg_copy_lib() {
   find "${2}/usr/lib" -regextype sed -regex ".*/${1}\.so\.[0-9]*" \
-    -exec cp {} "${ADDON_BUILD}/${PKG_ADDON_ID}/lib" \;
+    -exec cp {} "${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private" \;
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private}
 
   cp ${PKG_BUILD}/.${TARGET_NAME}/unix/vncconfig/vncconfig     \
      ${PKG_BUILD}/.${TARGET_NAME}/unix/vncpasswd/vncpasswd     \

--- a/packages/addons/service/tigervnc/source/bin/tigervnc.start
+++ b/packages/addons/service/tigervnc/source/bin/tigervnc.start
@@ -11,4 +11,6 @@ then
   cp "$ADDON_DIR/config/passwd" "$ADDON_HOME/passwd"
 fi
 
+LD_LIBRARY_PATH=$ADDON_DIR/lib.private:$LD_LIBRARY_PATH
+
 x0vncserver -PasswordFile="$ADDON_HOME/passwd" -rfbport="$vnc_port"

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -111,7 +111,7 @@ post_makeinstall_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
   cp ${PKG_DIR}/addon.xml ${ADDON_BUILD}/${PKG_ADDON_ID}
 
@@ -124,7 +124,9 @@ addon() {
   cp -P $(get_install_dir comskip)/usr/bin/comskip ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
   if [ "${TARGET_ARCH}" = "x86_64" ]; then
-    cp -P $(get_install_dir x265)/usr/lib/libx265.so.199 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+    mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -P $(get_install_dir x265)/usr/lib/libx265.so.199 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{comskip,tvheadend}
   fi
 
   # dvb-scan files

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -25,7 +25,7 @@ PKG_ADDON_REQUIRES="pvr.vdr.vnsi:0.0.0 script.config.vdr:0.0.0"
 
 addon() {
   # create dirs
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib,plugin,locale}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private,plugin,locale}
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/config/epgsources
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/config/plugins/{eepg,epgfixer,epgsearch,streamdev-server,vnsiserver}
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/res/plugins/{live,restfulapi}
@@ -53,6 +53,7 @@ addon() {
               vnsiserver wirbelscan wirbelscancontrol xmltv2vdr; do
     cp -PR $(get_build_dir vdr-plugin-${pkg})/libvdr*.so.* ${ADDON_BUILD}/${PKG_ADDON_ID}/plugin
   done
+  patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/plugin/libvdr-live.so.*
 
   # copy locale (omit ddci, dummydevice, robotv)
   for pkg in dvbapi eepg epgfixer epgsearch iptv live restfulapi satip vnsiserver wirbelscan \
@@ -67,7 +68,7 @@ addon() {
         $(get_build_dir vdr-plugin-streamdev)/server/locale/* \
         ${ADDON_BUILD}/${PKG_ADDON_ID}/locale
 
-  cp -PL $(get_install_dir tntnet)/usr/lib/libtntnet.so.13 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+  cp -PL $(get_install_dir tntnet)/usr/lib/libtntnet.so.13 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
   cp -P $(get_build_dir vdr)/vdr ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/vdr.bin
   cp -PR $(get_build_dir vdr)/locale/* ${ADDON_BUILD}/${PKG_ADDON_ID}/locale

--- a/packages/addons/tools/flirc_util/package.mk
+++ b/packages/addons/tools/flirc_util/package.mk
@@ -30,7 +30,8 @@ make_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private}
     cp -P ${PKG_BUILD}/build/flirc_util ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
-    cp -P $(get_install_dir hidapi)/usr/lib/libhidapi-hidraw.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
+    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/flirc_util
+    cp -P $(get_install_dir hidapi)/usr/lib/libhidapi-hidraw.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 }


### PR DESCRIPTION
second batch of migrate to lib.private
- follow on from #8342
- part of #7602

packages updated
- boblightd: enable lib.private via RPATH
- flirc_util: enable lib.private via RPATH
- lcdproc: enable lib.private via RPATH
- minidlna: enable lib.private via RPATH
- tigervnc: enable lib.private via start script LD_LIBRARY_PATH
- tvheadend42: enable lib.private via RPATH
- vdr-addon: enable lib.private via RPATH
  - only `libvdr-live` needed updating

remaining lib/*.so* in `addons` are only:
```
./jre.zulu:target/tools.jre.zulu/lib/libX11.so.6
./jre.zulu:target/tools.jre.zulu/lib/libXrender.so.1
./jre.zulu:target/tools.jre.zulu/lib/libxcb.so.1
./jre.zulu:target/tools.jre.zulu/lib/libXi.so.6
./jre.zulu:target/tools.jre.zulu/lib/libXtst.so.6
./jre.zulu:target/tools.jre.zulu/lib/libXinerama.so.1
./jre.zulu:target/tools.jre.zulu/lib/libXext.so.6
./sundtek-mediatv:target/driver.dvb.sundtek-mediatv/lib/libmediaclient.so
./sundtek-mediatv:target/driver.dvb.sundtek-mediatv/lib/libmcsimple.so
```