### PR TITLE
glibc: all kernels now 6.6

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -31,7 +31,7 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --with-__thread \
                            --with-binutils=${BUILD}/toolchain/bin \
                            --with-headers=${SYSROOT_PREFIX}/usr/include \
-                           --enable-kernel=6.1.0 \
+                           --enable-kernel=6.6.0 \
                            --without-cvs \
                            --without-gd \
                            --disable-build-nscd \


### PR DESCRIPTION
- https://man7.org/tlpi/api_changes/