### PR TITLE
Remove libtool preserved temporary RPATH/RUNPATH from "shared object" ELF binaries (libraries/executables)

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/inotify-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/inotify-tools/package.mk
@@ -17,3 +17,7 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --disable-doxygen"
 pre_configure_target() {
   CXXFLAGS+=" -Wno-error=unused-parameter"
 }
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/addons/service/boblightd/package.mk
+++ b/packages/addons/service/boblightd/package.mk
@@ -37,6 +37,10 @@ fi
 
 PKG_CONFIGURE_OPTS_TARGET="${EXTRAOPTS} --without-portaudio"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 makeinstall_target() {
   : # nothing to do here
 }

--- a/packages/addons/service/proftpd/package.mk
+++ b/packages/addons/service/proftpd/package.mk
@@ -44,6 +44,10 @@ pre_configure_target() {
   rm -rf .${TARGET_NAME}
 }
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp ${PKG_INSTALL}/usr/sbin/proftpd ${ADDON_BUILD}/${PKG_ADDON_ID}/bin

--- a/packages/addons/service/usbmuxd/package.mk
+++ b/packages/addons/service/usbmuxd/package.mk
@@ -23,6 +23,10 @@ PKG_DISCLAIMER="Additional data charges may occur. The LibreELEC team doesn't ta
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            ac_cv_func_realloc_0_nonnull=yes"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 makeinstall_target() {
   :
 }

--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -21,6 +21,10 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-alsaconf \
                            --disable-rst2man \
                            --disable-xmlto"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/lib ${INSTALL}/var
   rm -rf ${INSTALL}/usr/share/alsa/speaker-test


### PR DESCRIPTION
- Follow up for #6094 - there has been 1 regression and 4 missed since the previous batch.

### regression
- alsa-utils: remove RPATH

### addons (missed last time)
- boblightd: remove RPATH
- inotify-tools: remove RPATH
- proftpd: remove RPATH
- usbmuxd: remove RPATH
