### PR TITLE
Update retroplayer add-ons to latest versions

### DIFF
--- a/packages/emulation/libretro-81/package.mk
+++ b/packages/emulation/libretro-81/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-81"
-PKG_VERSION="6d1b4d26aa9870133616fcfb5a763ca138ae25d1"
-PKG_SHA256="a7b261e1bd44d16d560bc660398f25ee21e06ff8d028ed6df2d09c087e93e3aa"
+PKG_VERSION="525d5c18f1ff3fc54c37e083a475225d9179d59d"
+PKG_SHA256="e4611e88159e3a77efe3b029f9edfa40127e98cb8af0e1a9d320cc4d3d137708"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/81-libretro"
 PKG_URL="https://github.com/libretro/81-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-a5200/package.mk
+++ b/packages/emulation/libretro-a5200/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-a5200"
-PKG_VERSION="27141a4328cfc41112655de03c55275f1c246062"
-PKG_SHA256="659f57445fdc5fb83df9ab1dff322e2971363a79f6948ed6b1e28c61e119ca57"
+PKG_VERSION="0942c88d64cad6853b539f51b39060a9de0cbcab"
+PKG_SHA256="cb84b9f158510f0b2e5f687f249f103ab26c322f4b3971935b08af70c426464b"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://github.com/libretro/a5200"
 PKG_URL="https://github.com/libretro/a5200/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-atari800/package.mk
+++ b/packages/emulation/libretro-atari800/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-atari800"
-PKG_VERSION="86be15db82e8c4275a7854d8b61839e87f06ef30"
-PKG_SHA256="5ac5339f8c80c464528b465488d399c5a7f02dc0597799f3ca5fe77c822a52da"
+PKG_VERSION="410d7bf0c215f3444793a9cec51c129e7b67c400"
+PKG_SHA256="b144e60c6f3e0ceada87833f0526f5a791acb9bf331a25b280af62bffd9d8e78"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-atari800"
 PKG_URL="https://github.com/libretro/libretro-atari800/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-lynx/package.mk
+++ b/packages/emulation/libretro-beetle-lynx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-lynx"
-PKG_VERSION="2ce6244d04e45718df16f1fd05a4d7613ed54db0"
-PKG_SHA256="7b6fd783ad48a298c4a067fabab0b2b4381eb8a5ddcd0eabd5bbd0b7d1b11b90"
+PKG_VERSION="48909ddd1aba4de034d9c1da70c460b1724daa3b"
+PKG_SHA256="f6b02e047f6cd978134da64f84a6cb75d03f93744f0fb2de90655806f6c93156"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-lynx-libretro"
 PKG_URL="https://github.com/libretro/beetle-lynx-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-ngp/package.mk
+++ b/packages/emulation/libretro-beetle-ngp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-ngp"
-PKG_VERSION="65460e3a9ad529f6901caf669abbda11f437ab55"
-PKG_SHA256="2d866f6be840b5cbcf6c4159b860d8cb0dffd00c540d230c98de48941d12c38e"
+PKG_VERSION="673c3d924ff33d71c6a342b170eff5359244df1f"
+PKG_SHA256="0026c53bfa3a689be293ef228b83e108049c5952435344a921a353c946092638"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-ngp-libretro"
 PKG_URL="https://github.com/libretro/beetle-ngp-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-pce-fast/package.mk
+++ b/packages/emulation/libretro-beetle-pce-fast/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-pce-fast"
-PKG_VERSION="7ff6d867dbde199185f462070c1c1b5b84affe79"
-PKG_SHA256="864ffaf464f9231347ba8eaa83d3585fa256aa6d000bb75ab42e189ac51b4f0a"
+PKG_VERSION="c90471d77c86cf9011a0462b5bb99ffafecd6d6c"
+PKG_SHA256="bbca58c5d80a76bb9b828420c600e740381ce41c1824c3c643feafb44cd94829"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-pce-fast-libretro"
 PKG_URL="https://github.com/libretro/beetle-pce-fast-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-pce/package.mk
+++ b/packages/emulation/libretro-beetle-pce/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-pce"
-PKG_VERSION="69d356663a3092a315ffac10eff1d47e9a967de0"
-PKG_SHA256="82453beed5390cca8684942a9ba585d8dfa5b3c826cbfb9444b0083d57479874"
+PKG_VERSION="a439221000e47e62d2da32b7ee4b9eb59e3acc2a"
+PKG_SHA256="d5cf32aaf77bd0ec1ec6f4c6cd426b99a2a0381c6a6f1e60f971ee9343319322"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-pce-libretro"
 PKG_URL="https://github.com/libretro/beetle-pce-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-psx/package.mk
+++ b/packages/emulation/libretro-beetle-psx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-psx"
-PKG_VERSION="e49c439ef3cbadca2f113a331f822a03b581027e"
-PKG_SHA256="54ad6062a62afc1e20d256ffb23148cd34c22870bda9f75d99dab285b0774707"
+PKG_VERSION="2a3f2562bce0a367c4fd13dd29ed4b2241c40175"
+PKG_SHA256="6a6ab862d880cba9fd80ef57b26733b4f8f9ee36ee5c2e1cd5c5b80df575f635"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-psx-libretro"
 PKG_URL="https://github.com/libretro/beetle-psx-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-supergrafx/package.mk
+++ b/packages/emulation/libretro-beetle-supergrafx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-supergrafx"
-PKG_VERSION="e33d73cc6f3e0721e10e3bd7a3031213c8b03977"
-PKG_SHA256="ae1c94edfe6f823b636b40cbc4a9a53bfbf2931fe119f6eba292835136c4ed23"
+PKG_VERSION="81e08f0a81f443eddacfe58557d1534c50ecd6a3"
+PKG_SHA256="1c226f290e7f0865ad5c6da191aafb91009c3c02b8c5a21743ba20210b92f622"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-supergrafx-libretro"
 PKG_URL="https://github.com/libretro/beetle-supergrafx-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-vb/package.mk
+++ b/packages/emulation/libretro-beetle-vb/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-vb"
-PKG_VERSION="732a8f701e671bf032165730fdf8bd96fb5ca7bb"
-PKG_SHA256="e6f9a7a9a157cbba50b27398a188eb0c15286b278e5bca566e2865731c9823bc"
+PKG_VERSION="9d1bd03f21dac7897f65269e1095496331efce8b"
+PKG_SHA256="7c3d8fd2f8535be7de6f76be010ec6d34837d7c30caeb0096cae6e5c1e07c442"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-vb-libretro"
 PKG_URL="https://github.com/libretro/beetle-vb-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-wswan/package.mk
+++ b/packages/emulation/libretro-beetle-wswan/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-wswan"
-PKG_VERSION="a0ddcd3f084f5b4eb06acb6e03b8c4707a2f6123"
-PKG_SHA256="7dd7fa267f39a22f0176e5fa8608c853a65dc64122d7df402f6e6d8f59bd10f6"
+PKG_VERSION="32bf70a3032a138baa969c22445f4b7821632c30"
+PKG_SHA256="457028d9ec6e76e0ec3e2e69a40b1bac392dae4fa4aca724c8a1500dbc54fc8c"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-wswan-libretro"
 PKG_URL="https://github.com/libretro/beetle-wswan-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bluemsx"
-PKG_VERSION="e21bf74bddb79ad1bbe20b4d964e7515269c669b"
-PKG_SHA256="bd53a42e03ef010a7d3d73a7c5516c9149feeac23e7ee74640ea3cb126b2a575"
+PKG_VERSION="e8a4280bcbd149d1e020adcd9469ad9d8bd67412"
+PKG_SHA256="a9ee6d5922651e64d48e37e5a4a22bc08bc27d213adabaaa4283d92d8ab97fa5"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/blueMSX-libretro"
 PKG_URL="https://github.com/libretro/blueMSX-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bsnes-mercury-performance/package.mk
+++ b/packages/emulation/libretro-bsnes-mercury-performance/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bsnes-mercury-performance"
-PKG_VERSION="fb9a41fe9bc230a07c4506cad3cbf21d3fa635b4"
-PKG_SHA256="5217be2136f120f2ed2aa3bd5225c039c6e45d618b88ceed1f607d8e3b3d79b6"
+PKG_VERSION="60c204ca17941704110885a815a65c740572326f"
+PKG_SHA256="906d88cfe52a1561fb7b026beba96467a4a827ed538a069fbba9249db11ac81a"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/bsnes-mercury"
 PKG_URL="https://github.com/libretro/bsnes-mercury/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bsnes/package.mk
+++ b/packages/emulation/libretro-bsnes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bsnes"
-PKG_VERSION="4f4e22e83a92e2e3999e5792f52085e1ecd662e2"
-PKG_SHA256="f04bdbeb5a06ae694c5e0217e8a56235c10f25c95462d521423c42c8c2a2296a"
+PKG_VERSION="c4b27b3ae44a712dbe90e159bdba43df0c9f57de"
+PKG_SHA256="bca29e7d611ba3649b7653a76b9443d52057597d4102d84d9c7485dfd45cf20b"
 PKG_LICENSE="GPLv3/ISC"
 PKG_SITE="https://github.com/libretro/bsnes"
 PKG_URL="https://github.com/libretro/bsnes-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bsnes2014-performance/package.mk
+++ b/packages/emulation/libretro-bsnes2014-performance/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bsnes2014-performance"
-PKG_VERSION="78dc66f8c09dc0117d55ee4249186674385386e5"
-PKG_SHA256="8ff114549a964af928c472d0bb67e9cba5841bd1be87e2ee4f8bf89d185af089"
+PKG_VERSION="a9c12bad40ad9a7a5fa0139a25a10f1c24d56bb2"
+PKG_SHA256="5fb077879474be5a201232d26f12271eb5c4b7f436247db26487398e94f7a325"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/bsnes2014"
 PKG_URL="https://github.com/libretro/bsnes2014/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-cannonball/package.mk
+++ b/packages/emulation/libretro-cannonball/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-cannonball"
-PKG_VERSION="93ca14d7074b400fc3ed9ba8cefe0622f8d76176"
-PKG_SHA256="168461f67d658ceaf5c0607c2c851c829f37491319c7167877a85fe162625e9f"
+PKG_VERSION="c5487ee342ec2596f733a211b812e338cdba8ad8"
+PKG_SHA256="1204832c8eed713640fee84d90b4c39ffac7a2ecdfd881442dd0ed83c2113e94"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/cannonball"
 PKG_URL="https://github.com/libretro/cannonball/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-cap32/package.mk
+++ b/packages/emulation/libretro-cap32/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-cap32"
-PKG_VERSION="0e3edf8ef45966b375c652efb044ffea46d33200"
-PKG_SHA256="aeb8be7b5cccd65c91ce6a58eb274ef26c6d15831fcf0a2f2d3ea04acf58d825"
+PKG_VERSION="4a071f2c004273abf0f9fa0640b36f6664d8381a"
+PKG_SHA256="a45aceb1294a94bcc04824f33ff1cd01fa7bbfdcb8610b9a15755472a386e53f"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-cap32"
 PKG_URL="https://github.com/libretro/libretro-cap32/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-dosbox-pure/package.mk
+++ b/packages/emulation/libretro-dosbox-pure/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-dosbox-pure"
-PKG_VERSION="4fdb557e415698aae5bd90b076f76437f5e9b0b4"
-PKG_SHA256="a523019fd18123eda4dfd04d5ea458d24ce670c0c30c9ce01b2b9be94870968e"
+PKG_VERSION="ec951632d4cbf015e2c520128b31f2714679bd89"
+PKG_SHA256="d805fc1132c7d825564ce13d5f419815791141eef9ccdc28d8b2370f32f8fc20"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/dosbox-pure"
 PKG_URL="https://github.com/libretro/dosbox-pure/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-fbneo/package.mk
+++ b/packages/emulation/libretro-fbneo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-fbneo"
-PKG_VERSION="3d1495688c2a1322b42a575e8c43a9cb589960f2"
-PKG_SHA256="835c21d3c40505572a10cc38ecdcdf32509642427b1e277e5e79f542fe144547"
+PKG_VERSION="a65d2e7128b20649d49767d5acebe712cd2faaec"
+PKG_SHA256="7f322323b965e2e66f26587f41bbf41799a3c902b8e13cc41ac9779b84d931f7"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/fbneo"
 PKG_URL="https://github.com/libretro/FBNeo/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-fceumm/package.mk
+++ b/packages/emulation/libretro-fceumm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-fceumm"
-PKG_VERSION="f068818c4d68620c31eca0c02a5891ee3096b645"
-PKG_SHA256="d6446b1775ae16cf84033071a37babd2f77c15de92bc78df070356d4336d2944"
+PKG_VERSION="76bde1c45707db6c5947c35b9c3e46dea4eb6258"
+PKG_SHA256="dcd69be3d0bf21f5b9389690514c91cb545e79a78085eed5051e82ad3dba8ff4"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-fceumm"
 PKG_URL="https://github.com/libretro/libretro-fceumm/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-gambatte/package.mk
+++ b/packages/emulation/libretro-gambatte/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-gambatte"
-PKG_VERSION="e6bcb9f43c13f44fbf4a30153e3885b3dd174443"
-PKG_SHA256="08e4c84b7bb4d8c31ea49789a0349a6b773cfa05be62d7cba730f9c00fee684b"
+PKG_VERSION="9b232311f4f462a5dc26187b511ea361d30c5959"
+PKG_SHA256="8dda54d766201b92cdf0d000e2c64b977ebb2b12b1c7a2d1c02cc804dc55a8d5"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/gambatte-libretro"
 PKG_URL="https://github.com/libretro/gambatte-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-genplus/package.mk
+++ b/packages/emulation/libretro-genplus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-genplus"
-PKG_VERSION="9f8f5bc44e402e75ce895b8d5259a67d04fed448"
-PKG_SHA256="c3643a6e9051fb06ca0186bb99e729255210c3d533862459f1a5f142b0d3ea25"
+PKG_VERSION="f18eea1ef3cce66c50e556138b41579d2ea08ad3"
+PKG_SHA256="d0ee73a23497cc3ceadc0afc2097f681a13bdb0b315553a5fbb44f129bebd414"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/ekeeke/Genesis-Plus-GX"
 PKG_URL="https://github.com/libretro/Genesis-Plus-GX/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-handy/package.mk
+++ b/packages/emulation/libretro-handy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-handy"
-PKG_VERSION="63db085af671bad2929078c55434623b7d4632a1"
-PKG_SHA256="3e95202814d7dd16a0bf1277aa4dcc82acd82a5fcee9965db103133f274383b8"
+PKG_VERSION="0559d3397f689ea453b986311aeac8dbd33afb0b"
+PKG_SHA256="49323a78e8aed122552479945a0eeb0de3052342f3c93b9bfc16edf39f8d2237"
 PKG_LICENSE="Zlib"
 PKG_SITE="https://github.com/libretro/libretro-handy"
 PKG_URL="https://github.com/libretro/libretro-handy/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-hatari/package.mk
+++ b/packages/emulation/libretro-hatari/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-hatari"
-PKG_VERSION="00a46e1ed216e3b51b1cd829e04a36caf30a0338"
-PKG_SHA256="06a745a1094c46320a1980d5c0f69bf04481e169b56179021bf59f549252f2a8"
+PKG_VERSION="a4c9eb0bb79e47a2870c12b04566c1f8d25e4bf3"
+PKG_SHA256="aa7ed51717a45c604a4b85bc84f6101a9cb56798266dd6ed50eae62c263b324e"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/hatari"
 PKG_URL="https://github.com/libretro/hatari/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mame2000/package.mk
+++ b/packages/emulation/libretro-mame2000/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame2000"
-PKG_VERSION="720b8ad4cbd76abd57b9aeced9ba541dc8476f7f"
-PKG_SHA256="abc2e9ec7889b41a0c4b46db43bdb1e3eaecb9e8812d6e2059319b964143fd4b"
+PKG_VERSION="1472da3a39ab14fff8325b1f51a1dfdb8eabb5c8"
+PKG_SHA256="e70d596045b9753084329caee49767e0ca1fb2567657a6a1fbeb3b486c594df9"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2000-libretro"
 PKG_URL="https://github.com/libretro/mame2000-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mame2003_plus/package.mk
+++ b/packages/emulation/libretro-mame2003_plus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame2003_plus"
-PKG_VERSION="71766e8f0cadb80eb6c735a76581a94b2c87769d"
-PKG_SHA256="6c306db2eeb65880ced66e5415a2251a49d863a6d8345d59017d08d483093212"
+PKG_VERSION="eddec6d603a21d5620ff6a2cb890ec90133cdb02"
+PKG_SHA256="882ec1c0607cc4a0de6f33bcc47adf4c479caf02809cbeb9559ea420b720421b"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"
 PKG_URL="https://github.com/libretro/mame2003-plus-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mrboom/package.mk
+++ b/packages/emulation/libretro-mrboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mrboom"
-PKG_VERSION="2d603a2dccff15db944e04ed6a1cefc4750e463f"
-PKG_SHA256="2e30ff53ea0a77062c22cf44f81e4eb8130d3f98757d0c4c0d856a9030eb1a8c"
+PKG_VERSION="4a7261f27febcfa17cca9ae082190fa4a3800a5f"
+PKG_SHA256="369ee2840ac8497526db2cd90426b6587c6f801a67b4d0187b6be5e21ecce7f1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libretro/mrboom-libretro"
 PKG_URL="https://github.com/kodi-game/mrboom-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-o2em/package.mk
+++ b/packages/emulation/libretro-o2em/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-o2em"
-PKG_VERSION="a2a12472fde910b6089ac3ca6de805bd58a9c999"
-PKG_SHA256="19cff8eff5227a955158e10a5a37790300ad89312033f9f1df542dad5b3caf4e"
+PKG_VERSION="44fe5f306033242f7d74144105e19a7d4939477e"
+PKG_SHA256="0aaf148c82347827fcbcb2c66b5456d6eb021af218dd3e445ee08056320de28b"
 PKG_LICENSE="Artistic-2.0"
 PKG_SITE="https://github.com/libretro/libretro-o2em"
 PKG_URL="https://github.com/libretro/libretro-o2em/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-opera/package.mk
+++ b/packages/emulation/libretro-opera/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-opera"
-PKG_VERSION="8a49bb8877611037438aeb857cb182f41ee0e3a1"
-PKG_SHA256="48f94380633808ea01f4608f03ceb6b4b10709ba18abf1df6665f06ae839e7a7"
+PKG_VERSION="100ae1e7decefe1f17d98cfcb9f2af4ff8452691"
+PKG_SHA256="48da27e7cfea9b23169d856188ad4c2fcc1a34240fb4c5af6c4a52b165e4c6ba"
 PKG_LICENSE="LGPL with additional notes"
 PKG_SITE="https://github.com/libretro/opera-libretro"
 PKG_URL="https://github.com/libretro/opera-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-pcsx-rearmed"
-PKG_VERSION="4373e29de72c917dbcd04ec2a5fb685e69d9def3"
-PKG_SHA256="85560938cdad30be5994e935d35b0b4b8a12f6d2ca39c0034bfaa3d98cbcb11a"
+PKG_VERSION="162bbc5e3cc5415a0bce81c553bc95db19b618ec"
+PKG_SHA256="a4f33f7adcdfb42e65fcb3d849262823dfaddbf9987b953b56489bd101492472"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="https://github.com/libretro/pcsx_rearmed/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-picodrive"
-PKG_VERSION="471eac7ba2824881ceb868ae730bb0bb4bd0ec32"
-PKG_SHA256="090dab421c2d4d4bb977fbfc7e231d651c7cc91974c158564bbad4b202239f80"
+PKG_VERSION="79c23b3d5765598ac1dfbf7de9a6650751ba13fe"
+PKG_SHA256="60be6019154c09db808754bc8427f68d404fc6548a99c995441d4f0a6d9a0e3a"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/picodrive"
 PKG_URL="https://github.com/kodi-game/picodrive/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-prosystem/package.mk
+++ b/packages/emulation/libretro-prosystem/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-prosystem"
-PKG_VERSION="3db33d880ba78f3be0178e6ce651623731598137"
-PKG_SHA256="9a55031cc6fb7be3362538cfab824d4b8922b81be745ce096cacb1e057a34af0"
+PKG_VERSION="4202ac5bdb2ce1a21f84efc0e26d75bb5aa7e248"
+PKG_SHA256="7ede172f560ae79b0a5420f7be388d2c99f6cd1585547b021e85de6f32ccc87f"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/prosystem-libretro"
 PKG_URL="https://github.com/libretro/prosystem-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-snes9x/package.mk
+++ b/packages/emulation/libretro-snes9x/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-snes9x"
-PKG_VERSION="46f8a6b73e75d389d9e0acc8c7d40b178e22dad3"
-PKG_SHA256="465b1a011b81f0ef204ea05b21983351b92c3a5805920686fefe228f6c985fb8"
+PKG_VERSION="ec4ebfc8f3819a9522fcb8e53eed985090017b1b"
+PKG_SHA256="0599dc74a5bac048134a3aaac3625d8e9a6fe7765a8388396353b70ac13a2607"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/snes9x"
 PKG_URL="https://github.com/libretro/snes9x/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-stella/package.mk
+++ b/packages/emulation/libretro-stella/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-stella"
-PKG_VERSION="d47cdb3d3ea4485207d2842c26ec126646bd25f4"
-PKG_SHA256="aa4100027248003a88f4b83c3b571c0e42d8cc078552a0f4b3e8e95f4191fcc8"
+PKG_VERSION="e05761311af89768b1e42879d89eb7f03a51f4da"
+PKG_SHA256="6abf6a03fa5a0b7b355450906b81f430d5e1838dec3bfbb025fc04be6f98d249"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/stella-emu/stella"
 PKG_URL="https://github.com/stella-emu/stella/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-tyrquake/package.mk
+++ b/packages/emulation/libretro-tyrquake/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-tyrquake"
-PKG_VERSION="77217664a09afe893a06be8e3e8f9611184636f8"
-PKG_SHA256="a86b131743a5a46dd7be0ecfdb42e2454df0bb7d629a2c6cd589cb0cbc9351b2"
+PKG_VERSION="df0d3afb623b143beb76a5b1adf2d377953bfdf2"
+PKG_SHA256="173bfc01c39d85b7c339ca1ccfec748334cce7e4bcd5dc9df08c9c1ddba31c88"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/tyrquake"
 PKG_URL="https://github.com/libretro/tyrquake/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-uae/package.mk
+++ b/packages/emulation/libretro-uae/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-uae"
-PKG_VERSION="8800b86264ea919eea337202077047e5220a76cb"
-PKG_SHA256="f54712a26aa696127d86ec1eba095dd5803dc110389112f0c581ff99e7e0385d"
+PKG_VERSION="9332f19b8c7386c69508cc51aca21c747629690d"
+PKG_SHA256="6b180d5c8457af1aa38bbde392d8e9e3844a51412ad1cad2025d8db65b7837cb"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-uae"
 PKG_URL="https://github.com/libretro/libretro-uae/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vbam/package.mk
+++ b/packages/emulation/libretro-vbam/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vbam"
-PKG_VERSION="790618102dea1a4c94a115e4f3e8b432eb53adee"
-PKG_SHA256="cbfdcc2e7bb440c4cdc69f85ee1c6fe23b3cbc37375862f26a351f7db8583b00"
+PKG_VERSION="3683938ec7636e6f5b9201d4a0a6cc12a4062bcf"
+PKG_SHA256="44f51ad7f208d25a73d581fe86b32f61da50d7abccedcc05d550f85709b6aa15"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/visualboyadvance-m/visualboyadvance-m"
 PKG_URL="https://github.com/visualboyadvance-m/visualboyadvance-m/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vice_x128/package.mk
+++ b/packages/emulation/libretro-vice_x128/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vice_x128"
-PKG_VERSION="83c501343f1976628c2647ac203700643a55351a"
-PKG_SHA256="ae2aa586a5b9222e3b798e3249e647fc40f148c43dc3404dd0d09ed7d4a2f7de"
+PKG_VERSION="a2385eb1103a9f5c86333bae0f308ca678fc7d82"
+PKG_SHA256="2c4a0d182387d352fd2d0542b7639d4b2e307ea10ef811852f305723f7f91503"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"
 PKG_URL="https://github.com/libretro/vice-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vice_x64/package.mk
+++ b/packages/emulation/libretro-vice_x64/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vice_x64"
-PKG_VERSION="83c501343f1976628c2647ac203700643a55351a"
-PKG_SHA256="ae2aa586a5b9222e3b798e3249e647fc40f148c43dc3404dd0d09ed7d4a2f7de"
+PKG_VERSION="a2385eb1103a9f5c86333bae0f308ca678fc7d82"
+PKG_SHA256="2c4a0d182387d352fd2d0542b7639d4b2e307ea10ef811852f305723f7f91503"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"
 PKG_URL="https://github.com/libretro/vice-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vice_xplus4/package.mk
+++ b/packages/emulation/libretro-vice_xplus4/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vice_xplus4"
-PKG_VERSION="83c501343f1976628c2647ac203700643a55351a"
-PKG_SHA256="ae2aa586a5b9222e3b798e3249e647fc40f148c43dc3404dd0d09ed7d4a2f7de"
+PKG_VERSION="a2385eb1103a9f5c86333bae0f308ca678fc7d82"
+PKG_SHA256="2c4a0d182387d352fd2d0542b7639d4b2e307ea10ef811852f305723f7f91503"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"
 PKG_URL="https://github.com/libretro/vice-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vice_xvic/package.mk
+++ b/packages/emulation/libretro-vice_xvic/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vice_xvic"
-PKG_VERSION="83c501343f1976628c2647ac203700643a55351a"
-PKG_SHA256="ae2aa586a5b9222e3b798e3249e647fc40f148c43dc3404dd0d09ed7d4a2f7de"
+PKG_VERSION="a2385eb1103a9f5c86333bae0f308ca678fc7d82"
+PKG_SHA256="2c4a0d182387d352fd2d0542b7639d4b2e307ea10ef811852f305723f7f91503"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"
 PKG_URL="https://github.com/libretro/vice-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.2048"
-PKG_VERSION="1.0.0.137-Nexus"
-PKG_SHA256="06f2e17a25270bc8df0f5ae2aaccc19feff95d98aa0d0452100ceacbf7684f29"
+PKG_VERSION="1.0.0.138-Nexus"
+PKG_SHA256="777ab04cf1e7ccc04903cd48d3b9ccf3496111e762614875737a93e2dfdc26d8"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.81/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.81/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.81"
-PKG_VERSION="1.0.0.24-Nexus"
-PKG_SHA256="ad495c36b8e1ca80eb321dc5321c75a5ab2edb10f8c0e87a3db828e8461b9c36"
+PKG_VERSION="1.0.0.25-Nexus"
+PKG_SHA256="839103081272cf27c6da5d50805a256966c35a4fda923cd48408af9fa6a51f37"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.a5200/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.a5200/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.a5200"
-PKG_VERSION="2.0.2.7-Nexus"
-PKG_SHA256="fede7e229c6d9e6e2e3491cd9444b0b9581004ecf33f765cc76b81a0af18a1b9"
+PKG_VERSION="2.0.2.13-Nexus"
+PKG_SHA256="e8ce2af94f8ef20cfebd06bd45cdb5a50d1c618bd6fb2aef68605ccbbc727393"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.atari800"
-PKG_VERSION="3.1.0.28-Nexus"
-PKG_SHA256="c13aad1c5ecead95bc8f684f4fb427b1a68176b7eeaef456c4b74c6f374a99ae"
+PKG_VERSION="3.1.0.30-Nexus"
+PKG_SHA256="c4353616511af6de6ef3e4d018359ab8e1d3cfd181b1eefec5229cd5d7580946"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-bsnes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-bsnes"
-PKG_VERSION="0.9.26.27-Nexus"
-PKG_SHA256="8fc3cd7a630e6493216c30d0acdf67b09d8ce51cc89da1a573fa6d20faff6aec"
+PKG_VERSION="0.9.26.29-Nexus"
+PKG_SHA256="9e9355e93588ae6823e752f615ca0e4423033eb0ef4618704da3f11dba2122b1"
 PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-bsnes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-gba/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-gba"
-PKG_VERSION="0.9.36.27-Nexus"
-PKG_SHA256="bae9eb576db2052c82fb1e0cca7e2986b76d4f40f0ae7d6e7112c1b74844d234"
+PKG_VERSION="0.9.36.29-Nexus"
+PKG_SHA256="5f03a646509e846984e7e59a870eaa7db9cb91cae425a0ace83ec3bfcb9774f1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-lynx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-lynx"
-PKG_VERSION="1.24.0.50-Nexus"
-PKG_SHA256="6418571237427dd42f0a5b673789a0569d958c678166cfb35df9242482ec20ea"
+PKG_VERSION="1.24.0.51-Nexus"
+PKG_SHA256="ce67bf59813c77913859165db57c009c3825cbcc0f19c25f042cd81a4f565288"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-ngp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-ngp"
-PKG_VERSION="1.29.0.35-Nexus"
-PKG_SHA256="520e7ee830329b2d2f7d19db2f0616acc97e1ec75d66b3bcb6d2229f19ef0142"
+PKG_VERSION="1.29.0.36-Nexus"
+PKG_SHA256="5700d810d8c181acc49ac1037d9d11cd970a2df992bb3fac83d28ea2f7c9c8ee"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-pce-fast"
-PKG_VERSION="1.31.0.43-Nexus"
-PKG_SHA256="727fdb875a7a3f797db2f3a591939d18314805a91a3611ec8d38e3247f049248"
+PKG_VERSION="1.31.0.45-Nexus"
+PKG_SHA256="5d18280a224e663862017da6f6d1159390d88eeac7c1b6a0361ffba01ed16059"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-pce"
-PKG_VERSION="1.29.0.22-Nexus"
-PKG_SHA256="2d1f2c473f4ef3d94373d06e28b92d171315d2ae38662a839e8fb89c2dcdb307"
+PKG_VERSION="1.29.0.25-Nexus"
+PKG_SHA256="54da902c7bd7f185f2fe149b9532010a011b40da9474a91cee8e102209ae86c0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pcfx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-pcfx"
-PKG_VERSION="0.9.36.36-Nexus"
-PKG_SHA256="e3039a7f6cffab3dbc14475439d1ba686a67593b4c817ae7961a1507beb6585c"
+PKG_VERSION="0.9.36.39-Nexus"
+PKG_SHA256="21a0332864477b6496387a294321315e5e04deeb360c0b0deb7c32510d0ba3c3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-psx"
-PKG_VERSION="0.9.44.53-Nexus"
-PKG_SHA256="245ff683a9af397970814816c7b6771ca8e19c7245380c4b4c04e2e1eec59bc9"
+PKG_VERSION="0.9.44.57-Nexus"
+PKG_SHA256="bfb2c63c3eb9ea7face9d8227102195276a92620b52bc79861538f3a590220cc"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-saturn"
-PKG_VERSION="1.29.0.40-Nexus"
-PKG_SHA256="cf5752a5fe09274bd9bb0ff0b67c465a34ffebc98c8d87cc33c7366b9532d8aa"
+PKG_VERSION="1.29.0.43-Nexus"
+PKG_SHA256="70d7bc65c06c2198245dd7e904e65a3d8f6e5a719805c9f948ff4d6f8662a53f"
 PKG_REV="1"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-saturn"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-supergrafx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-supergrafx"
-PKG_VERSION="1.29.0.39-Nexus"
-PKG_SHA256="b56a23f07990dc22731099b87ae63f869e2522b6704c71ff24aee728fa560b8e"
+PKG_VERSION="1.29.0.41-Nexus"
+PKG_SHA256="01aa844f384ba0a6a6ecb236cea0c6076ab0d92880178052d89410a60ffc85da"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-vb"
-PKG_VERSION="1.31.0.34-Nexus"
-PKG_SHA256="4026531e4846df9b0554f959874a8cbc8f2f306ad86b1ca987808f833a567fd1"
+PKG_VERSION="1.31.0.36-Nexus"
+PKG_SHA256="f9cd45e85613e238b710f2f95d67f795cea1b203900fecb5d56575b4ea3da03c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-wswan/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-wswan"
-PKG_VERSION="0.9.35.41-Nexus"
-PKG_SHA256="d4bbe056a91912da9d6d947468e08486fe79c3669035303dc6848490a5aeaa6e"
+PKG_VERSION="0.9.35.44-Nexus"
+PKG_SHA256="7b6c1f584373b21fe31e5f918aa115642068b4d2cab9f8d2fe767a47e7cf00eb"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bk/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bk/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bk"
-PKG_VERSION="1.0.0.25-Nexus"
-PKG_SHA256="2ea57adfd95a0dbdb8c92c758a84a4e0e22cae8acb9e389b22c27b55d2baf147"
+PKG_VERSION="1.0.0.27-Nexus"
+PKG_SHA256="9a4c9ad23d4270c21db4a97bdf8edb9a078dbae1c0da84100ef7289b21e47e96"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.blastem/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.blastem/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.blastem"
-PKG_VERSION="0.6.3.27-Nexus"
-PKG_SHA256="372812afd06fd7208979f12f3481c56c55c24a63e41e886fc4b8aefbeefd0e63"
+PKG_VERSION="0.6.3.29-Nexus"
+PKG_SHA256="328eb3ef40cbf3ea91ed9ddfd517d28fcaeb212d958b8b3172af3f4a3426401b"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv3"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bluemsx"
-PKG_VERSION="0.0.1.36-Nexus"
-PKG_SHA256="4747f0eeaa999e4be81eb1c89619557d09f77caf4729a88a7da5b60f1af24eda"
+PKG_VERSION="0.0.1.38-Nexus"
+PKG_SHA256="5e9d506beb730fd1f1b51a10a84a4f83762c012951b7fba4996bb65fe6b4ee29"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bnes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bnes"
-PKG_VERSION="0.83.0.26-Nexus"
-PKG_SHA256="c37f1cedf30c3f24689ab2aee9810e836b14dbdca663b6e57c27dff425bfbc1b"
+PKG_VERSION="0.83.0.28-Nexus"
+PKG_SHA256="f84ae4d5e9597ae1d787bc5ee35cb891ad7e40e7f145c1d6b1551dff62a5b1ca"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-hd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-hd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes-hd"
-PKG_VERSION="10.6.0.5-Nexus"
-PKG_SHA256="ab3d5bd5307f9fdfab96208ff7912a71ed9c6090d96190c2e09ab8ccc6c7686a"
+PKG_VERSION="10.6.0.7-Nexus"
+PKG_SHA256="6f0b00cfb791496bb83c69c5b044366be15bf651e8372c4ae7ba1430bd004df9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury-performance/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes-mercury-performance"
-PKG_VERSION="0.94.0.31-Nexus"
-PKG_SHA256="ee1df8f91be81234f4749016e1d1376aaf4a3edea1941664a5470ee1e3225391"
+PKG_VERSION="0.94.0.33-Nexus"
+PKG_SHA256="8c6a54fed3e56ae06f4e7b809480abffe59a0b4946545e98cec0eef1f3aa5e23"
 PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-mercury-performance"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes"
-PKG_VERSION="115.0.0.7-Nexus"
-PKG_SHA256="db04ffd921dda12d1bcdea7dd373f4e6b94e0cbcec5e959342ba4f38bb19277f"
+PKG_VERSION="115.0.0.9-Nexus"
+PKG_SHA256="e6ed11492ace4b824ac7aed06d48b0c1a05b8512b50ee966adac1c3d541f3269"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes2014-performance/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes2014-performance/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes2014-performance"
-PKG_VERSION="0.94.0.16-Nexus"
-PKG_SHA256="cfe5354eec27036c4e259ede793b5ecc33303598ad15e910db42cd9758ec993d"
+PKG_VERSION="0.94.0.18-Nexus"
+PKG_SHA256="a40dde2db132f138a0f7f464df91e2b7b73c9fb13b35a2e7241079cf88504a6c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.cannonball/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.cannonball/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.cannonball"
-PKG_VERSION="0.0.1.29-Nexus"
-PKG_SHA256="046d0b83b62493d6dd5d3731735e4fcb47823d69ab3c29c67b370455fb30c94b"
+PKG_VERSION="0.0.1.30-Nexus"
+PKG_SHA256="4126c10661db5a46746578ab8e8355c84c45309a6e4c4af078d2b7098ccfe69e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.cap32"
-PKG_VERSION="4.5.3.36-Nexus"
-PKG_SHA256="b82a95dadc8c637bf3f42f0f30216f9c667f5a9c1de697fdea58492417b536cb"
+PKG_VERSION="4.5.3.38-Nexus"
+PKG_SHA256="454bd2b99121b9f122acdf862f343541a64abfbce69df29ec918f09cae6a8e49"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dinothawr"
-PKG_VERSION="1.0.0.35-Nexus"
-PKG_SHA256="3e93d3fde08ba80cfb216f082d599dc3efcbe8aebbd283cc96f3624dde4f894e"
+PKG_VERSION="1.0.0.36-Nexus"
+PKG_SHA256="10000d2db26ebb0103cb681cbd65d5546f4676e3e650ec0579a38c1c2e8d16d6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox-pure/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox-pure/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dosbox-pure"
-PKG_VERSION="0.9.7.26-Nexus"
-PKG_SHA256="62f883b0eb62d59a645c9870bf2c832a4e9cbee04cd61bc381258240a73236a2"
+PKG_VERSION="0.9.7.27-Nexus"
+PKG_SHA256="c4c58c63514e4f8ae507bb2cb048c502b4a521f453cd22092fd74ad605e96c85"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dosbox"
-PKG_VERSION="0.74.0.26-Nexus"
-PKG_SHA256="ec3c47d7a7cd2925d5212588554fcd7f93b43892a1ab0f0008fad38973fd505d"
+PKG_VERSION="0.74.0.27-Nexus"
+PKG_SHA256="07719c523ff68a81a1beb835953623795e30768e9ff3b2ad5e8f640db2b94704"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fbneo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fbneo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fbneo"
-PKG_VERSION="1.0.0.71-Nexus"
-PKG_SHA256="a5550ba8d228403fc8b2fa21f610698bd08dba85ce12513ba176a41d98bf34fb"
+PKG_VERSION="1.0.0.72-Nexus"
+PKG_SHA256="cbc1fc5a719384accedb95450a3eb084fe5b615b27e241e56534eb810c573e32"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fceumm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fceumm"
-PKG_VERSION="0.0.1.51-Nexus"
-PKG_SHA256="3ef8742061493df779c5d09626fdd20db300bfbab0ceecc6b4e51383638e2fd7"
+PKG_VERSION="0.0.1.52-Nexus"
+PKG_SHA256="904d3edc70dc9fedd370690b15de6f56960cedc7ff283805495363cfd9621aa3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fmsx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fmsx"
-PKG_VERSION="6.0.0.38-Nexus"
-PKG_SHA256="a477564bda9f409379cf7e28567dab1f8ef3e602a53d626d2214e0dfb5444d0d"
+PKG_VERSION="6.0.0.39-Nexus"
+PKG_SHA256="79ecfa47ea96c343ffed3dc1e31f0fb373c0e144ad46e941fbc9bdc33ea109c0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fuse/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fuse"
-PKG_VERSION="1.6.0.35-Nexus"
-PKG_SHA256="3870447ddea26364a2bcd75161cef8e43c068aca8344b843526ab6c943c57304"
+PKG_VERSION="1.6.0.36-Nexus"
+PKG_SHA256="91c88f97cfcc88ace5096a1f351cc89aa7877fabcc182af8b8b610d3bdb735a9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.gambatte"
-PKG_VERSION="0.5.0.45-Nexus"
-PKG_SHA256="16ae05f3f4c015c40cf9fbda9928d66398b4959fe82b7c1a9b254093d62d377d"
+PKG_VERSION="0.5.0.48-Nexus"
+PKG_SHA256="e01d9df1400a4d6145531b57f1bdf4de23d9a5f050f450307b75a8acc895f79e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.genplus"
-PKG_VERSION="1.7.4.53-Nexus"
-PKG_SHA256="d5632abbd74ebc603ab832a55ac2eb8d0cf4d81cb664eca221f055bcdd130c8f"
+PKG_VERSION="1.7.4.57-Nexus"
+PKG_SHA256="627c98c93f04e5b568ed3017e77b8628600bf21b68de6e3a10aa2336a8ae74a9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.gw"
-PKG_VERSION="1.6.3.29-Nexus"
-PKG_SHA256="b71a60eee8d3ab97840e63fb890ab37d03991078681546cc8eedc624bafbb605"
+PKG_VERSION="1.6.3.30-Nexus"
+PKG_SHA256="6c5b2c119413f0a086c5b62beee229f5da0c1136ba6e787beff9033d0f2850d0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.handy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.handy"
-PKG_VERSION="0.97.0.37-Nexus"
-PKG_SHA256="d84e17ce80ad050bc6c7518cdc7cf1bc350ef8cead045c01192bf8da9b57ee1f"
+PKG_VERSION="0.97.0.39-Nexus"
+PKG_SHA256="cb2e0104be35cf1ffcef1265402f3c337e47568886782771e94cb49a4244d9c2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.hatari/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.hatari"
-PKG_VERSION="1.8.0.36-Nexus"
-PKG_SHA256="4149ef4db6c194ad2704f391f8cc0b8d8846fb48500b8fedc19d793424bea77d"
+PKG_VERSION="1.8.0.37-Nexus"
+PKG_SHA256="76daef44c147b8b18a11a556765864504d0ebe3b4ce291c343283d6905ccd343"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2000/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2000/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mame2000"
-PKG_VERSION="0.37.0.32-Nexus"
-PKG_SHA256="41b87ee39c811897e5d369b6d4f798c40374afcaaaf88028722646cc5e8a0469"
+PKG_VERSION="0.37.0.33-Nexus"
+PKG_SHA256="b970e3bfb9536657b01888da5f85810200d7ea597f32a9d01ca056944dec479b"
 PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2000"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mame2003_plus"
-PKG_VERSION="0.0.1.76-Nexus"
-PKG_SHA256="f8f0d4b662349b90e1f162734cbabf5aef3f745e75dce13ee23a0250060c239a"
+PKG_VERSION="0.0.1.77-Nexus"
+PKG_SHA256="2c244705b8d06ae205cabddeaccea38013886c7d3d351d1f5408769128fc91cd"
 PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2003_plus"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2010/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2010/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mame2010"
-PKG_VERSION="0.139.0.25-Nexus"
-PKG_SHA256="e631deafac2cbd8e32ac02d518318c1541e4f4db1e1d613e778aa175149295e0"
+PKG_VERSION="0.139.0.26-Nexus"
+PKG_SHA256="8240fbfe426ac2febdee7ccfc3df144dbd9087a497b0a7312732715c25fc270f"
 PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2010"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mesen-s/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mesen-s/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mesen-s"
-PKG_VERSION="0.4.0.15-Nexus"
-PKG_SHA256="c7ffddbc3e8fd5ceae4ff766043068bcc351f2a2ab031ac0f55c721097c4551e"
+PKG_VERSION="0.4.0.16-Nexus"
+PKG_SHA256="59f5541bdded4e08e747b8a6ab7904a1888d2274c533bdd154255e7a03e6e8e7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mesen/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mesen/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mesen"
-PKG_VERSION="0.9.9.32-Nexus"
-PKG_SHA256="5ef4126590ab3072a9a58388ec4e608971d306c4eadf969df9bc5d808674e33a"
+PKG_VERSION="0.9.9.33-Nexus"
+PKG_SHA256="cffd97d6040d680790ba5b7d87b56f1e3d56bc33b07685b8a22e1992866c8f47"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mgba/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mgba"
-PKG_VERSION="0.11.0.44-Nexus"
-PKG_SHA256="55a3b258d0a723c51d548126872b43785dd731c1749b6c06fe4a71dbc3e384db"
+PKG_VERSION="0.11.0.48-Nexus"
+PKG_SHA256="60683a9dd3f4d7a45b66017ae561a839196f0a11fe2d6f33b1a5e3b9077ddc99"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mrboom"
-PKG_VERSION="5.2.0.151-Nexus"
-PKG_SHA256="cf5369eaa5044403f53791ca7126f5e8e68d1297e995d4cf94a3c0fc92ceeb2f"
+PKG_VERSION="5.3.0.154-Nexus"
+PKG_SHA256="262bb7cde86eaeaeee85c45b0a50343aeccf8e31751c814a8e44dc94623349d0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.nestopia"
-PKG_VERSION="1.52.0.41-Nexus"
-PKG_SHA256="279e93a43fab8f525b27a693f8ceb1012905581e1415f31a99f3aab0b08ae35e"
+PKG_VERSION="1.52.0.42-Nexus"
+PKG_SHA256="d98b848f156f1bf5fae11248a5fd5c0b986688d6b10774fd8f39dd8be6270d8a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.nx"
-PKG_VERSION="1.0.0.37-Nexus"
-PKG_SHA256="6bf371436a78b873a434a670d676f35ddd90d0e2195427b1bd404dcf93c1bcd1"
+PKG_VERSION="1.0.0.38-Nexus"
+PKG_SHA256="7f94446c7eb6c3d8338db38429e1913445e02375c90dd9f47821b3e0c87ba316"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.o2em/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.o2em"
-PKG_VERSION="1.18.0.42-Nexus"
-PKG_SHA256="508d75a02a01b19a7be5e3019aead3389369322b2c9dd7aabad58d0def60a1a1"
+PKG_VERSION="1.18.0.44-Nexus"
+PKG_SHA256="da387bc357974446984b947588a0538c105e52d349d341278a03c24e1b29d34b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.opera/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.opera/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.opera"
-PKG_VERSION="1.0.0.37-Nexus"
-PKG_SHA256="874bb2b68c8130b92759ff7fca0312170d83f94eb430e8daf8d613f2fe6eb998"
+PKG_VERSION="1.0.0.38-Nexus"
+PKG_SHA256="eff593a2fd6ed5c2e40fa1327b7b1f02f111a6bcc100fbdf9498cd4f0dfd00a1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.pcsx-rearmed"
-PKG_VERSION="23.0.0.49-Nexus"
-PKG_SHA256="62b540d9f77a3706269e52fc42f6942b7338732a58ce99104931eadb3c842cfb"
+PKG_VERSION="23.0.0.51-Nexus"
+PKG_SHA256="56b0d9ce08d9d5000e7794625085950c631b0cc6cddb4ebcdcfd4a09b56efdc9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.picodrive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.picodrive"
-PKG_VERSION="1.99.0.38-Nexus"
-PKG_SHA256="694df000949989308caadd6aa88eda2b207efae07f5d240a00b1480fe469f143"
+PKG_VERSION="2.00.0.42-Nexus"
+PKG_SHA256="efbaf181e025b3445fa8c9fc41498ca3ea452f716d11f2ee940bcd7d5629b794"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pokemini/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pokemini/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.pokemini"
-PKG_VERSION="0.60.0.37-Nexus"
-PKG_SHA256="8559e7c207a6413f2037d023cbbf6da1e7d40173c8484b85b791b2f35a1750ed"
+PKG_VERSION="0.60.0.38-Nexus"
+PKG_SHA256="1a118c26ab8c7081659dfbbfced0d6a1bff3d80e928d32ce56e91b9b3bc87ac2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.prboom"
-PKG_VERSION="2.5.0.43-Nexus"
-PKG_SHA256="d7f1ba35d61aa3e309e59ecac433b77a679bdd63837c5712dd19286c0e4ae847"
+PKG_VERSION="2.5.0.46-Nexus"
+PKG_SHA256="5195eac168b9e58a2cfd8d6cb2b437bd28ee3adbc6f613cb52bb0c7b75b7546c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prosystem/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.prosystem"
-PKG_VERSION="1.3.0.38-Nexus"
-PKG_SHA256="95d597ec309af387cdec5190728837cbb0eaed652b443d1c0c5b413b3ac20a54"
+PKG_VERSION="1.3.0.40-Nexus"
+PKG_SHA256="cd6b5bb9e8ffd42ccca50360d9b47a5f0acf45c50d242a465a5fc5b06cdcec2f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.quicknes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.quicknes"
-PKG_VERSION="1.0.0.40-Nexus"
-PKG_SHA256="07558af07e1df81114a13f47f1e57b9607cbe62ae6318bc746c775c4af529f5b"
+PKG_VERSION="1.0.0.41-Nexus"
+PKG_SHA256="b6aaddee872cd08c6498c14f4ff00474bf2991bb24958c8cee065355e469c92d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.sameboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.sameboy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.sameboy"
-PKG_VERSION="0.15.4.37-Nexus"
-PKG_SHA256="6b4837f5d79b32b76ccb5645ac603248a50ed3a0b3a0f0a07b726a22ec33f8f8"
+PKG_VERSION="0.15.4.39-Nexus"
+PKG_SHA256="0b0633b293a04cb4816823e1abbf2dc7f3617d9f025376288e9174332ed5a991"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.scummvm"
-PKG_VERSION="2.7.0.37-Nexus"
-PKG_SHA256="da7b3b77478140c50741df331679f95bad14227d2faded98c223da85f148155b"
+PKG_VERSION="2.7.0.38-Nexus"
+PKG_SHA256="ce9b0762892a304929d7fb5d9abefd587ab51b77bb32149b864ca442048c94e9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.snes9x"
-PKG_VERSION="1.62.3.46-Nexus"
-PKG_SHA256="582cc2171f3edd55beec2dd4027c45d393a790783b02acb3214172771196e5a1"
+PKG_VERSION="1.62.3.47-Nexus"
+PKG_SHA256="709d1096cfa72474058d58ea17afe66106c53149b3dd00b397ab708cec563522"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2002/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2002/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.snes9x2002"
-PKG_VERSION="7.2.0.38-Nexus"
-PKG_SHA256="affb92764141a0941ef21acf156a7dcbd7afac81a3ae6ab9a9e64aeb6a31accc"
+PKG_VERSION="7.2.0.40-Nexus"
+PKG_SHA256="adfed8543e277e32138d195be517c8643d212238639f12f0bce9580f9a605dff"
 PKG_REV="1"
 # neon optimizations make it only useful for arm
 PKG_ARCH="arm"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2010/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x2010/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.snes9x2010"
-PKG_VERSION="1.52.4.39-Nexus"
-PKG_SHA256="26f25f36da94afd11e8234cdbbaede73fbfad77a5670dbcfa5696f1f3c9c415a"
+PKG_VERSION="1.52.4.40-Nexus"
+PKG_SHA256="1e738dcc12a798005e00ffb34c3547cbfc1611812edbded6a152bc0f0b17509e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.stella"
-PKG_VERSION="7.0.0.44-Nexus"
-PKG_SHA256="ebefa54e7954267fcfaf785651ea56a9d71136cb962038cfd6a3aac9efefb701"
+PKG_VERSION="7.0.0.46-Nexus"
+PKG_SHA256="d9cbe3b16c3b0d5a82a0cb577a9f3816d4bd4b2221af96ade623d7ff3f3cd8eb"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.supafaust/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.supafaust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.supafaust"
-PKG_VERSION="1.29.0.26-Nexus"
-PKG_SHA256="44760e653c00edef196abb2f0d70fa720ace2705b4e3ce077bff86c678b42bcd"
+PKG_VERSION="1.29.0.27-Nexus"
+PKG_SHA256="7d125f72acceb895ce9d1435f34eb73976616f92668bbd2027f8ab8b2d6ad2c1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2+"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tgbdual/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.tgbdual"
-PKG_VERSION="0.8.3.32-Nexus"
-PKG_SHA256="3f15e40f35ba401eb89bf20a8290325ee9fbe316f6883991384479cf0bc5e63d"
+PKG_VERSION="0.8.3.33-Nexus"
+PKG_SHA256="e567cc4528ee4e40d83feb209b2bc889c390eb91350e31b1dc9052784f9d41a7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.tyrquake"
-PKG_VERSION="0.62.0.40-Nexus"
-PKG_SHA256="db8f8dae285ca9126be2f1a6fa0d0f3201b015685aa9f9eed660e04a50aff135"
+PKG_VERSION="0.62.0.41-Nexus"
+PKG_SHA256="4e760bba2a3981dccf08c9c61467ab437211caacbe2212de6342ff5e995f4d97"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.uae/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.uae/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.uae"
-PKG_VERSION="4.9.1.59-Nexus"
-PKG_SHA256="99b3c3e6b9fa94619006ec47b199b7cb42681193ecbf660b2b8bd33d9a205f27"
+PKG_VERSION="5.0.0.66-Nexus"
+PKG_SHA256="1fe96d66fb9839b4b530516fd50604fc3f9b44398d4087d471761552a2d9cff1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.uae4arm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.uae4arm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.uae4arm"
-PKG_VERSION="0.5.0.5-Nexus"
-PKG_SHA256="5bae0409bc5cbeb756f8a07b2b4cdc368c63e89950097fd36b6d499169cde623"
+PKG_VERSION="0.5.0.6-Nexus"
+PKG_SHA256="8d45dc40b1d506de08a2d886a6cc477964390b1df2352b30b9f9f2fb3869dc2b"
 PKG_REV="1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vbam"
-PKG_VERSION="2.1.5.38-Nexus"
-PKG_SHA256="457df5267347a50f99b4cdaca16702ccbc78e5803bfd6605881648c57d2d2457"
+PKG_VERSION="2.1.7.40-Nexus"
+PKG_SHA256="269c7101bcb3a2b97f534355dd7651303897681d2bda5e1abf45d6c7add5eb80"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vecx"
-PKG_VERSION="1.2.0.38-Nexus"
-PKG_SHA256="ccb22201eee4ec820f42c627469dafa51600aed372aa94623df5dfa20d756464"
+PKG_VERSION="1.2.0.39-Nexus"
+PKG_SHA256="c7f6f28f8824a8040d46eba718b52211e8fbfe0ca2b6d893eaf407cef5975e21"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice_x128/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice_x128/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vice_x128"
-PKG_VERSION="3.7.0.9-Nexus"
-PKG_SHA256="d1a031537d55df286b71488ed205aec4e9f0f8c58cdf1bafb6002e464bbe2387"
+PKG_VERSION="3.7.0.12-Nexus"
+PKG_SHA256="589ca0e363781d8ebc6afcdb969e29f3343d16dab50058613497fefab2add313"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice_x64/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice_x64/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vice_x64"
-PKG_VERSION="3.7.0.46-Nexus"
-PKG_SHA256="831e693db4e606bec93254ad73d03d51abe4560259266d0fca43a1cc9aeeff38"
+PKG_VERSION="3.7.0.50-Nexus"
+PKG_SHA256="55db85d39010959659ca3c8e7e3eec0cb6905bbc3a67d3f737e39187b9dd0c5c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice_xplus4/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice_xplus4/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vice_xplus4"
-PKG_VERSION="3.7.0.11-Nexus"
-PKG_SHA256="52f94e315788601a87c7f46bceb6790079d2a21a288a7d9c4ad7d78e2281a875"
+PKG_VERSION="3.7.0.14-Nexus"
+PKG_SHA256="34ff8b9ba6265eb654f728d49e4bb42efbf45c91595f8f2eb916ccc350cb8b28"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice_xvic/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice_xvic/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vice_xvic"
-PKG_VERSION="3.7.0.10-Nexus"
-PKG_SHA256="07f342d637cab0ff881e028e9c0eba485e3beb62a78562e3beaa6df39bb78674"
+PKG_VERSION="3.7.0.13-Nexus"
+PKG_SHA256="ee9dcc754676fe334585e5495b2ce22e278242c7253057e0da310cacc1977b9a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.virtualjaguar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.virtualjaguar"
-PKG_VERSION="2.1.0.38-Nexus"
-PKG_SHA256="2e40f49e6b445d70c293bee25aa51494a2b16fa03cf9d8f18786b466eb732797"
+PKG_VERSION="2.1.0.39-Nexus"
+PKG_SHA256="3ecdb174c9cca0fa8affaa0f01a8ac4ea720c575bbb18c59360f335852ad0202"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.yabause"
-PKG_VERSION="0.9.15.47-Nexus"
-PKG_SHA256="ef597b8d59f63c7aea72d6e0929ea318b24d4d17ecc363e42546ef6e3a504e9c"
+PKG_VERSION="0.9.15.51-Nexus"
+PKG_SHA256="b6a0d6b1015fdd5fcd1667e43f3872ff8275a7bb9983dcfb30f2699cdc1ddf90"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
## Description

We've made some improvements to a few game add-ons, so I did a rebase/rebuild of the entire kodi-game org.

In addition to updating to the latest versions of the libretro org, we've made the following improvements:

* **beetle-psx** - Removed non-existing buttons and updated icon (https://github.com/kodi-game/game.libretro.beetle-psx/pull/20)
* **genplus** - Added new controller types (https://github.com/kodi-game/game.libretro.genplus/pull/13)
* **pcsx-rearmed** - Removed non-existing buttons (https://github.com/kodi-game/game.libretro.pcsx-rearmed/pull/26)
* **picodrive** - Added new controller types, updated icon (https://github.com/kodi-game/game.libretro.picodrive/pull/8)

## How has this been tested?

I compiled all cores (except for uae4arm) for Generic x86_64.

beetle-psx originally had a linking error, but I couldn't identify any commits since that last update that would cause this: https://github.com/libretro/beetle-psx-libretro/commits

I tried building the old version, then cleaned the packages, updated again, and now I can't reproduce the build error.