### PR TITLE
Rust update to 1.74.1

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="a18dc9132cf76ccba90bcbb53b56a4d37ebfb34845f61e79f7b5d4710a269647"
+    PKG_SHA256="1e634b91432f5cf51ba8baa84bc8a05f39e2826c02288119488951cc9c19ab3e"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="e650c511248386c3cda6f9a14b3b7b3aca7571f0018ab72df8c9f092bb4fb1f2"
+    PKG_SHA256="906238776998c3f730f38e51bed195a58bffd03f17bc63b0da9d8369552bab80"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="f219386d4569c40b660518e99267afff428c13bf980bda7a614c8d4038d013f6"
+    PKG_SHA256="3ea1159af625c281a9d4486efbeb51e1a24ccba58a39db230af38fa331a95f34"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="c5ad01692bc08ce6f4db2ac815be63498b45013380c71f22b3d33bf3be767270"
+    PKG_SHA256="a776e7b41991ef7a50706d1f9b7752a8d963e67297bfc22471d6e68d544349cc"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="8c493e78f14e9468d2a270a8ce0e4447d68924be692415aa1882c1173fd2163d"
+    PKG_SHA256="5f1b890faa083afd97ed53c67d859f4de89abe9a059b48c98217d8ee015bedeb"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="548413213012e2f62b08ed8a913a51210ae7402619027224580176031f2789ea"
+    PKG_SHA256="df435e3254c03ccbfc9e733ae33b399f5f99bd488974bc07d8b1db91a12ee95b"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.74.0"
-PKG_SHA256="882b584bc321c5dcfe77cdaa69f277906b936255ef7808fcd5c7492925cf1049"
+PKG_VERSION="1.74.1"
+PKG_SHA256="67db3e22fc9921c885baae5953ba144fc474cde29ec69ab56d43ce764206231d"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="a49bb365481913ead305658e7e9dc621da7895036b840fb57b1bc85c721d07e6"
+    PKG_SHA256="d0e5e641fd8726c9ddabb685a03f3846b3c716b8950334ebf3b18987affe82fe"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="92001f00d2121cd1e66d84b7467880f65b016ea2ccb5145c0628cc2dbc0bf326"
+    PKG_SHA256="8a4b07e43cf1d4c162b29f93a9cd4ef8b55f024050a65d15975a98ba48432eb3"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="7d464be2ae0d6ce69f056d1ea9a8ce2b3b1d537418caea216fdd303903972181"
+    PKG_SHA256="b30e2d1b6b139874caa3fc81fbc3098e88cf01b98e891ce591d12ad4f0299437"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- cargo-snapshot: update to 1.74.1
- rustc-snapshot: update to 1.74.1
- rust-std-snapshot: update to 1.74.1
- rust: update to 1.74.1