### PR TITLE
v4l-utils: fix meson.build for rc_keymaps

### DIFF
--- a/packages/sysutils/v4l-utils/patches/v4l-utils-001-fix-meson-rc-keymaps.patch
+++ b/packages/sysutils/v4l-utils/patches/v4l-utils-001-fix-meson-rc-keymaps.patch
@@ -1,0 +1,32 @@
+From 4321b7651f2c0e76172ff742ecbd9f63fd24845a Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 8 Dec 2023 11:29:04 +0000
+Subject: [PATCH] keytable: meson not passing rc_keymaps system directory
+
+In the meson build ir_keytable_system_dir is used as the parent directory
+for both rc_keymaps and rules.d, whereas udevrulesdir was defined
+sepeartely in the configure script. Update the -DIR_KEYTABLE_SYSTEM_DIR
+to include the rc_keymaps subdirectory aligning with the install_data
+functions.
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ utils/keytable/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utils/keytable/meson.build b/utils/keytable/meson.build
+index 0ca08a18..4130a4be 100644
+--- a/utils/keytable/meson.build
++++ b/utils/keytable/meson.build
+@@ -17,7 +17,7 @@ ir_keytable_system_dir = udevdir
+ ir_keytable_user_dir = get_option('sysconfdir') / 'rc_keymaps'
+ 
+ ir_keytable_c_args = [
+-    '-DIR_KEYTABLE_SYSTEM_DIR="@0@"'.format(ir_keytable_system_dir),
++    '-DIR_KEYTABLE_SYSTEM_DIR="@0@"'.format(ir_keytable_system_dir / 'rc_keymaps'),
+     '-DIR_KEYTABLE_USER_DIR="@0@"'.format(ir_keytable_user_dir),
+ ]
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
logic for keytablesystemdir changed between configure and meson

was

AC_SUBST([keytablesystemdir], [$with_udevdir/rc_keymaps]) AC_SUBST([keytableuserdir], [$sysconfdir/rc_keymaps]) AC_SUBST([udevrulesdir], [$with_udevdir/rules.d])

is now the following and the -D is missing the rc_keymaps, where as previously udevrulesdir was defined seperately
- https://git.linuxtv.org/v4l-utils.git/tree/utils/keytable/meson.build?h=v4l-utils-1.26.0#n16 lines 16-22 and 62-70