### PR TITLE
linux (RPi): update to 6.1.66

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="0ad213e156d8961c9ce3fea4d5eefc6e3f20ee7a" # 6.1.65
-    PKG_SHA256="7ca3c09c893d129dd356909e5cb6928f5299b4c4f4f30e230fcfba676e2a8969"
+    PKG_VERSION="3d9d7e7b2aa312f79f8034a9d42b7e7ccb92c54b" # 6.1.66
+    PKG_SHA256="208f312c08bdd56ef07fd38b6034346edcfd151d78fed4dfb885f993326f8c5d"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.57 Kernel Configuration
+# Linux/arm 6.1.66 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3207,6 +3207,7 @@ CONFIG_VIDEO_CAMERA_SENSOR=y
 # CONFIG_VIDEO_OV5675 is not set
 # CONFIG_VIDEO_OV5693 is not set
 # CONFIG_VIDEO_OV5695 is not set
+# CONFIG_VIDEO_OV64A40 is not set
 # CONFIG_VIDEO_OV6650 is not set
 # CONFIG_VIDEO_OV7251 is not set
 # CONFIG_VIDEO_OV7640 is not set
@@ -3238,6 +3239,7 @@ CONFIG_VIDEO_CAMERA_SENSOR=y
 # CONFIG_VIDEO_AD5398 is not set
 # CONFIG_VIDEO_AD5820 is not set
 # CONFIG_VIDEO_AK7375 is not set
+# CONFIG_VIDEO_BU64754 is not set
 # CONFIG_VIDEO_DW9714 is not set
 # CONFIG_VIDEO_DW9768 is not set
 # CONFIG_VIDEO_DW9807_VCM is not set

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.57 Kernel Configuration
+# Linux/arm 6.1.66 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3439,6 +3439,7 @@ CONFIG_VIDEO_CAMERA_SENSOR=y
 # CONFIG_VIDEO_OV5675 is not set
 # CONFIG_VIDEO_OV5693 is not set
 # CONFIG_VIDEO_OV5695 is not set
+# CONFIG_VIDEO_OV64A40 is not set
 # CONFIG_VIDEO_OV6650 is not set
 # CONFIG_VIDEO_OV7251 is not set
 # CONFIG_VIDEO_OV7640 is not set
@@ -3470,6 +3471,7 @@ CONFIG_VIDEO_CAMERA_SENSOR=y
 # CONFIG_VIDEO_AD5398 is not set
 # CONFIG_VIDEO_AD5820 is not set
 # CONFIG_VIDEO_AK7375 is not set
+# CONFIG_VIDEO_BU64754 is not set
 # CONFIG_VIDEO_DW9714 is not set
 # CONFIG_VIDEO_DW9768 is not set
 # CONFIG_VIDEO_DW9807_VCM is not set

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.57 Kernel Configuration
+# Linux/arm64 6.1.66 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -4035,6 +4035,7 @@ CONFIG_VIDEO_CAMERA_SENSOR=y
 # CONFIG_VIDEO_OV5675 is not set
 # CONFIG_VIDEO_OV5693 is not set
 # CONFIG_VIDEO_OV5695 is not set
+# CONFIG_VIDEO_OV64A40 is not set
 # CONFIG_VIDEO_OV6650 is not set
 # CONFIG_VIDEO_OV7251 is not set
 # CONFIG_VIDEO_OV7640 is not set
@@ -4066,6 +4067,7 @@ CONFIG_VIDEO_CAMERA_SENSOR=y
 # CONFIG_VIDEO_AD5398 is not set
 # CONFIG_VIDEO_AD5820 is not set
 # CONFIG_VIDEO_AK7375 is not set
+# CONFIG_VIDEO_BU64754 is not set
 # CONFIG_VIDEO_DW9714 is not set
 # CONFIG_VIDEO_DW9768 is not set
 # CONFIG_VIDEO_DW9807_VCM is not set

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.57 Kernel Configuration
+# Linux/arm64 6.1.66 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -4053,6 +4053,7 @@ CONFIG_VIDEO_CAMERA_SENSOR=y
 # CONFIG_VIDEO_OV5675 is not set
 # CONFIG_VIDEO_OV5693 is not set
 # CONFIG_VIDEO_OV5695 is not set
+# CONFIG_VIDEO_OV64A40 is not set
 # CONFIG_VIDEO_OV6650 is not set
 # CONFIG_VIDEO_OV7251 is not set
 # CONFIG_VIDEO_OV7640 is not set
@@ -4084,6 +4085,7 @@ CONFIG_VIDEO_CAMERA_SENSOR=y
 # CONFIG_VIDEO_AD5398 is not set
 # CONFIG_VIDEO_AD5820 is not set
 # CONFIG_VIDEO_AK7375 is not set
+# CONFIG_VIDEO_BU64754 is not set
 # CONFIG_VIDEO_DW9714 is not set
 # CONFIG_VIDEO_DW9768 is not set
 # CONFIG_VIDEO_DW9807_VCM is not set


### PR DESCRIPTION
Kernel 6.1.64 introduced an ext4 regression which has been fixed in 6.1.66. See eg
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1057843
https://lore.kernel.org/stable/20231205122122.dfhhoaswsfscuhc3@quack3/

Runtime tested on RPi4