### PR TITLE
game.libretro: Update to v21.0.5

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="995fe54a5b5b296cd43d5029efd445fbb467c4623ecb9f21bd20f96d123b6b57"
+PKG_VERSION="21.0.5-Omega"
+PKG_SHA256="f5b9297d5b565a64ce747070488b849a5e98db6943913dfa9a3fb9913ed374c4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
### Changes since v21.0.4:

  * Added support for OEM 102 key (https://github.com/kodi-game/game.libretro/pull/115)
  * Added support for analog sticks in Vice cores (https://github.com/kodi-game/game.libretro/pull/116)
  * Fixed Appveyor CI (https://github.com/kodi-game/game.libretro/pull/119)

### Changes since v21.0.3:

  * Fixed broken left should button in fallback buttonmap (https://github.com/kodi-game/game.libretro/pull/113)

### Changes since v21.0.2:

  * Allow topology to specify type and subclass (https://github.com/kodi-game/game.libretro/pull/105)