### PR TITLE
game.libretro: Update to v20.2.6

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro"
-PKG_VERSION="20.2.3-Nexus"
-PKG_SHA256="e6ca0ab29eca52679438ce2226a68df60bc77c0ec4ced7495d7db71119fe2da9"
+PKG_VERSION="20.2.6-Nexus"
+PKG_SHA256="32b24c0d67046e41d703c70a432ba8209163bafc8ca88afc8181be4d6693efb4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
### Changes since v20.2.5:

  * Added support for OEM 102 key
  * Added support for analog sticks in Vice cores
  * Fixed Appveyor CI

### Changes since v20.2.4:

  * Fixed broken left shoulder in fallback buttonmap

### Changes since v20.2.3:

  * Fixed add-on using console to log instead of Kodi API