### PR TITLE
kodi: support change to Groovy/Apache commons binaries

### DIFF
--- a/packages/devel/commons-lang3/package.mk
+++ b/packages/devel/commons-lang3/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="commons-lang3"
+PKG_VERSION="3.14.0"
+PKG_SHA256="317c3e3fcd5fcca3781a7996ff1e0c50c13244ee961e94e5f6f6d84b84733b16"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://commons.apache.org/proper/commons-lang/"
+PKG_URL="https://dlcdn.apache.org/commons/lang/binaries/commons-lang3-${PKG_VERSION}-bin.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Apache Commons Lang provides a host of helper utilities for the java.lang API"
+PKG_TOOLCHAIN="manual"

--- a/packages/devel/commons-text/package.mk
+++ b/packages/devel/commons-text/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="commons-text"
+PKG_VERSION="1.11.0"
+PKG_SHA256="4169cb90571fb28fad4c5eea7c1c994c18f1995452f73e8ea7a86087c0e3822e"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://commons.apache.org/proper/commons-text/"
+PKG_URL="https://dlcdn.apache.org/commons/text/binaries/commons-text-${PKG_VERSION}-bin.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Apache Commons Text is a library focused on algorithms working on strings"
+PKG_TOOLCHAIN="manual"

--- a/packages/devel/groovy/package.mk
+++ b/packages/devel/groovy/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="groovy"
+PKG_VERSION="4.0.16"
+PKG_SHA256="b8c3bec88a3f5a62235d9429a97e371032bf7216f3e28724823a9169dd10befc"
+PKG_LICENSE="Apache-2.0"
+PKG_SITE="https://groovy.apache.org"
+PKG_URL="https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-${PKG_VERSION}.zip"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Apache Groovy is a Java-syntax-compatible object-oriented programming language for the Java platform."
+PKG_TOOLCHAIN="manual"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="21.0b2-Omega"
-PKG_SHA256="b9d6ecbb8769cdfe00cbbe5da5c330a7624eee50cffb87d87f6271033f1ee74b"
+PKG_VERSION="87d2d6f84799224f5fe63a6bba3e973e84e18fef"
+PKG_SHA256="682fe2afa246bc708407914a12baff4c76839443afafee0b7b199da856fb89e2"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="b9d6ecbb8769cdfe00cbbe5da5c330a7624eee50cffb87d87f6271033f1ee74b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre swig:host libass curl fontconfig fribidi tinyxml tinyxml2 libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid libdvdnav libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog"
+PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre swig:host libass commons-lang3 commons-text curl fontconfig fribidi groovy tinyxml tinyxml2 libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid libdvdnav libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog"
 PKG_DEPENDS_HOST="toolchain"
 PKG_LONGDESC="A free and open source cross-platform media player."
 PKG_BUILD_FLAGS="+speed"
@@ -259,6 +259,9 @@ configure_package() {
                          -DENABLE_INTERNAL_FLATBUFFERS=OFF \
                          -DENABLE_LCMS2=OFF \
                          -DADDONS_CONFIGURE_AT_STARTUP=OFF \
+                         -Dgroovy_SOURCE_DIR=$(get_build_dir groovy) \
+                         -Dapache-commons-lang_SOURCE_DIR=$(get_build_dir commons-lang3) \
+                         -Dapache-commons-text_SOURCE_DIR=$(get_build_dir commons-text) \
                          ${PKG_KODI_USE_LTO} \
                          ${PKG_KODI_LINKER} \
                          ${KODI_ARCH} \


### PR DESCRIPTION
Support change introduced in Kodi 
- https://github.com/xbmc/xbmc/pull/24199

Includes
- commons-lang3: initial package
- commons-text: initial package
- groovy: initial package
- kodi: support change to Groovy/Apache commons binaries

```
=== tested on ===
Generic.x86_64-devel-20231213130757-6bd6735
Linux nuc12 6.6.7-rc1 #1 SMP Tue Dec 12 12:47:59 UTC 2023 x86_64 GNU/Linux
Starting Kodi (21.0-BETA2 (20.90.821) Git:87d2d6f84799224f5fe63a6bba3e973e84e18fef). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2023-12-13 by GCC 13.2.0 for Linux x86 64-bit version 6.6.7 (394759)
Running on LibreELEC (heitbaum): devel-20231213130757-6bd6735 12.0, kernel: Linux x86 64-bit version 6.6.7-rc1
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0088.2023.0505.1623 05/05/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.3.0
libva info: VA-API version 1.20.0
vainfo: VA-API version: 1.20 (libva 2.20.1)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.4.3 (844c0c2b93)
```