### PR TITLE
Add SwanStation game add-on

### DIFF
--- a/packages/emulation/libretro-swanstation/package.mk
+++ b/packages/emulation/libretro-swanstation/package.mk
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-swanstation"
+PKG_VERSION="fc37fce91dedeba6e4007012cfed8de626fb45cf"
+PKG_SHA256="d0b683021c079105c1f14be868390a6923614afdd36e6486a3b6b71b049922f4"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/kodi-game/swanstation"
+PKG_URL="https://github.com/kodi-game/swanstation/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="SwanStation is a Libretro core implementation of DuckStation, which is an emulator of the Sony PlayStation console."
+PKG_TOOLCHAIN="cmake"
+
+PKG_LIBNAME="swanstation_libretro.so"
+PKG_LIBPATH="./${PKG_LIBNAME}"
+PKG_LIBVAR="SWANSTATION_LIB"
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+fi
+
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+fi
+
+if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${VULKAN}"
+fi
+
+PKG_CMAKE_OPTS_TARGET="-DBUILD_NOGUI_FRONTEND=OFF \
+                       -DBUILD_QT_FRONTEND=OFF \
+                       -DBUILD_LIBRETRO_CORE=ON \
+                       -DENABLE_DISCORD_PRESENCE=OFF \
+                       -DUSE_DRMKMS=ON"
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.swanstation/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.swanstation/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.swanstation"
+PKG_VERSION="1.0.0.34-Omega"
+PKG_SHA256="cc7b78e772da5e5a6ecb14a1b700c5a09f3bb6d7ed546c0e0a41338179980bce"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.libretro.swanstation"
+PKG_URL="https://github.com/kodi-game/game.libretro.swanstation/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-swanstation"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.swanstation: SwanStation for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
Add the game add-on for SwanStation.

@garbear I've seen that the game add-ons are being updated by a script. I'm not sure if this is the correct way to add the add-on.