### PR TITLE
iwd, connman and iwlwifi-firmware package updates

### DIFF
--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwlwifi-firmware"
-PKG_VERSION="485808423700ecc05455a8f657e66b0216d84929"
-PKG_SHA256="71ba7e7654a4869f517251bcccea82a6d90eed7b29c8f9d8823e634735bbd7ab"
+PKG_VERSION="af0a2980965fde82edf51e80f160a3af23a477c4"
+PKG_SHA256="3c5c5d67457669b09dd0fdc57083caf9f7afccce4261279600dfe0fd00de2f35"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/iwlwifi-firmware"
 PKG_URL="https://github.com/LibreELEC/iwlwifi-firmware/archive/${PKG_VERSION}.tar.gz"

--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="1cde7a6598a639d1f1eb16f7929f32919172ef10"
-PKG_SHA256="680320f1c3de0c283b2df0d61807cd0ca88e012dc3ec906a0414b20a5866f19d"
+PKG_VERSION="f785c755330ffa7e052f0ee86cf62db76859498c"
+PKG_SHA256="133db24529771cc0e7fa5d835b738e0302f4515d6caa4e73ee0f638e128de021"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-${PKG_VERSION}.tar.gz"

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.10"
-PKG_SHA256="6bc2ea9dda2a053ca1b1610ea1042ab809943da7016be76bad3914aa94da91c1"
+PKG_VERSION="2.11"
+PKG_SHA256="37052abc176d9885c98537c403ab496500ed03977b2273397275c02c7352b66e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- connman: update to githash f785c75
  - https://git.kernel.org/pub/scm/network/connman/connman.git
- iwd: update to 2.11
  - https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/?id=e8e5d91e5a6be397bc6e56fe1bc2c71061eb2615
  - https://git.kernel.org/pub/scm/network/wireless/iwd.git/log/
- iwlwifi-firmware: update to githash af0a298
  - https://github.com/LibreELEC/iwlwifi-firmware/pull/47