### PR TITLE
mesa: update to 23.3.1

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="23.3.0"
-PKG_SHA256="50f729dd60ed6335b989095baad81ef5edf7cfdd4b4b48b9b955917cb07d69c5"
+PKG_VERSION="23.3.1"
+PKG_SHA256="6e48126d70fdb3f20ffeb246ca0c2e41ffdc835f0663a03d4526b8bf5db41de6"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20231214101154-d6d7c91
Linux nuc12 6.6.7 #1 SMP Thu Dec 14 10:29:50 UTC 2023 x86_64 GNU/Linux
Starting Kodi (21.0-BETA2 (20.90.821) Git:87d2d6f84799224f5fe63a6bba3e973e84e18fef). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2023-12-14 by GCC 13.2.0 for Linux x86 64-bit version 6.6.7 (394759)
Running on LibreELEC (heitbaum): devel-20231214101154-d6d7c91 12.0, kernel: Linux x86 64-bit version 6.6.7
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0088.2023.0505.1623 05/05/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.3.1
libva info: VA-API version 1.20.0
vainfo: VA-API version: 1.20 (libva 2.20.1)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 23.4.3 (d6d7c91ae1)
```