### PR TITLE
linux (RPi): update to 6.1.68

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="3d9d7e7b2aa312f79f8034a9d42b7e7ccb92c54b" # 6.1.66
-    PKG_SHA256="208f312c08bdd56ef07fd38b6034346edcfd151d78fed4dfb885f993326f8c5d"
+    PKG_VERSION="e41b05a8fc73f95425aceaf15a68fc25da1d1fe5" # 6.1.68
+    PKG_SHA256="5fe1431f895940007f99ddef0594308f164173e131c9f7dfa573b12d99d4fcd2"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="7e22b8ff470c813d0331f8ef64b6c08125b179cc"
-PKG_SHA256="82ea46670b44a08e982963a42ade2ad831d808987ca846d484ee4ba1a914522c"
+PKG_VERSION="77402b6527906d6608204877d6dc40d547be4653"
+PKG_SHA256="93b2f71fa683523f640ca6ed2be7f08b9d5a1e25cf5539c004bcc4546539fa7a"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="b57586ead2576f1b36e69bb5625e531d14767eb2"
-PKG_SHA256="20d0f2b3e37431583e099e8f9377cd3fdf218efb6db30c3c345a37446467c78e"
+PKG_VERSION="7e22b8ff470c813d0331f8ef64b6c08125b179cc"
+PKG_SHA256="82ea46670b44a08e982963a42ade2ad831d808987ca846d484ee4ba1a914522c"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Runtime tested on RPi 3B+, RPi 4 and RPi 5