### PR TITLE
bluez: update to 5.71

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bluez"
-PKG_VERSION="5.70"
-PKG_SHA256="37e372e916955e144cb882f888e4be40898f10ae3b7c213ddcdd55ee9c009278"
+PKG_VERSION="5.71"
+PKG_SHA256="b828d418c93ced1f55b616fb5482cf01537440bfb34fbda1a564f3ece94735d8"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
log:
- https://git.kernel.org/pub/scm/bluetooth/bluez.git/log/

fixes:
- Fix issue with not registering CSIS service.
- Fix issue with registering pairing callbacks.
- Fix issue with corruption during discovery filter parsing.