### PR TITLE
v4l-utils: add patch to fix crash in ir-keytable

### DIFF
--- a/packages/sysutils/v4l-utils/patches/v4l-utils-001-fix-keytable-crash.patch
+++ b/packages/sysutils/v4l-utils/patches/v4l-utils-001-fix-keytable-crash.patch
@@ -1,0 +1,47 @@
+From f39acb7f375887e5ecf09128609318d717eda51d Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Wed, 20 Dec 2023 16:28:26 +0100
+Subject: [PATCH] keytable: fix segfault when reading legacy keymaps
+
+Since commit ae1492611432 ("keytable: remove line length limits")
+ir-keytable crashes when reading keymaps in legacy (non-toml) format
+and valgrind reports an UMR:
+
+valgrind ir-keytable -w /etc/rc_keymaps/hiastest
+...
+==83788== Conditional jump or move depends on uninitialised value(s)
+==83788==    at 0x48E8B8C: getdelim (iogetdelim.c:59)
+==83788==    by 0x1105C6: getline (stdio.h:120)
+==83788==    by 0x1105C6: parse_plain_keymap (keymap.c:98)
+==83788==    by 0x1105C6: parse_keymap (keymap.c:533)
+==83788==    by 0x112798: parse_opt (keytable.c:569)
+==83788==    by 0x4986E50: group_parse (argp-parse.c:257)
+==83788==    by 0x4986E50: parser_parse_opt (argp-parse.c:747)
+==83788==    by 0x4986E50: parser_parse_next (argp-parse.c:867)
+==83788==    by 0x4986E50: argp_parse (argp-parse.c:921)
+==83788==    by 0x10E470: main (keytable.c:2071)
+
+Fix this by properly initializing line to NULL so getline will allocate
+a buffer instead of using some random memory locations.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ utils/common/keymap.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utils/common/keymap.c b/utils/common/keymap.c
+index 04c5ef54723c..21c1c0b5d581 100644
+--- a/utils/common/keymap.c
++++ b/utils/common/keymap.c
+@@ -75,7 +75,7 @@ static error_t parse_plain_keymap(char *fname, struct keymap **keymap, bool verb
+ {
+ 	FILE *fin;
+ 	int line_no = 0;
+-	char *scancode, *keycode, *line;
++	char *scancode, *keycode, *line = NULL;
+ 	size_t line_size;
+ 	struct scancode_entry *se;
+ 	struct keymap *map;
+-- 
+2.39.2
+


### PR DESCRIPTION
Recent keytable changes missed to properly initialize a buffer pointer so it used random memory when reading keymaps in legacy format and crashed:

```
LibreELEC:~ # ir-keytable -w .config/rc_keymaps/hauppauge
Segmentation fault (core dumped)
```

Patch also sent upstream: https://lore.kernel.org/linux-media/20231220160003.84042-1-hias@horus.com/T/#u