### PR TITLE
glibc: update to 2.38.1 (githash 44f757a)

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glibc"
-PKG_VERSION="2.38"
-PKG_SHA256="fb82998998b2b29965467bc1b69d152e9c307d2cf301c9eafb4555b770ef3fd2"
+PKG_VERSION="44f757a6364a546359809d48c76b3debd26e77d4"
+PKG_SHA256="9acdc19250bc6872265ec77eb9347cc0def5535c6017b0465385bce16bbbe619"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/libc/"
-PKG_URL="https://ftp.gnu.org/pub/gnu/glibc/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://github.com/bminor/glibc/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="ccache:host autotools:host linux:host gcc:bootstrap pigz:host Python3:host"
 PKG_DEPENDS_INIT="glibc"
 PKG_LONGDESC="The Glibc package contains the main C library."


### PR DESCRIPTION
ref:
- https://github.com/bminor/glibc/commits/release/2.38/master
- https://github.com/bminor/glibc/blob/release/2.38/master/NEWS

Security related changes:

  CVE-2023-4527: If the system is configured in no-aaaa mode via /etc/resolv.conf, getaddrinfo is called for the AF_UNSPEC address family, and a DNS response is received over TCP that is larger than 2048 bytes, getaddrinfo may potentially disclose stack contents via the returned address data, or crash.

  CVE-2023-4806: When an NSS plugin only implements the _gethostbyname2_r and _getcanonname_r callbacks, getaddrinfo could use memory that was freed during buffer resizing, potentially causing a crash or read or write to arbitrary memory.

  CVE-2023-5156: The fix for CVE-2023-4806 introduced a memory leak when an application calls getaddrinfo for AF_INET6 with AI_CANONNAME, AI_ALL and AI_V4MAPPED flags set.

  CVE-2023-4911: If a tunable of the form NAME=NAME=VAL is passed in the environment of a setuid program and NAME is valid, it may result in a buffer overflow, which could be exploited to achieve escalated privileges.  This flaw was introduced in glibc 2.34.

The following bugs are resolved with this release:

  [30723] posix_memalign repeatedly scans long bin lists
  [30789] sem_open will fail on multithreaded scenarios when semaphore
    file doesn't exist (O_CREAT)
  [30804] F_GETLK, F_SETLK, and F_SETLKW value change for powerpc64 with
    -D_FILE_OFFSET_BITS=64
  [30842] Stack read overflow in getaddrinfo in no-aaaa mode (CVE-2023-4527)