### PR TITLE
openssh: update to 9.6p1

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="9.5p1"
-PKG_SHA256="f026e7b79ba7fb540f75182af96dc8a8f1db395f922bbc9f6ca603672686086b"
+PKG_VERSION="9.6p1"
+PKG_SHA256="910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Change log:
- https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ChangeLog

Release notes:
- https://www.openssh.com/releasenotes.html#9.6p1

Release notes:
- https://www.openssh.com/txt/release-9.6p1