### PR TITLE
tz: update to 2023d

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2023c"
-PKG_SHA256="9aa20ef838183e58f09acca92098cf6aa6d8e229aecf24e098c3af2a38e596f8"
+PKG_VERSION="2023d"
+PKG_SHA256="487df6ff5f4a577fd96568d0fd0a22e8062b0ec59af7ad3e66b5dd23a85cfc1c"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Time zone and daylight-saving time data."
 
 pre_configure_target() {
-  PKG_MAKE_OPTS_TARGET="CC=${HOST_CC} LDFLAGS="
+  PKG_MAKE_OPTS_TARGET="CC=${HOST_CC} CFLAGS= LDFLAGS="
 }
 
 makeinstall_target() {


### PR DESCRIPTION
CFLAGS is no longer set as blank in the tz Makefile. Add the blank CFLAGS to our package.mk file https://github.com/eggert/tz/commit/c3ebd8e988462f248ff4dc576f669ef73448eaf5