### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="21.4.0-Omega"
-PKG_SHA256="ac80846ea43d160b03c980c6253e916dbf6e9a21790deeb388563ab2632d423d"
+PKG_VERSION="21.4.1-Omega"
+PKG_SHA256="94d0b45e8757122850de41f3a5ed6a356bdf35732f3aba3c2daa3306ddf3ed80"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.teleboy"
-PKG_VERSION="20.3.4-Nexus"
-PKG_SHA256="199730d6023a39a9227b29b3ac100c06fc40fbb6c0adf65c3a35ea6449ffc5ba"
-PKG_REV="4"
+PKG_VERSION="21.0.0-Omega"
+PKG_SHA256="335bc3d8753df3f607361c268dcf15634291dea5d59a4817bae55a0bb8b0939b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rbuehlma/pvr.teleboy"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="20.3.7-Nexus"
-PKG_SHA256="c75ba4710d7e85cf516005ee3eca6d677e2fc018abaf490c881bc6552eb32929"
+PKG_VERSION="21.0.1-Omega"
+PKG_SHA256="5908de86c038b3565d8b3a8d4578d4cac0d37287fc039808542b874d9fb2bffa"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 21.4.0-Omega to 21.4.1-Omega
- pvr.teleboy: update 20.3.4-Nexus to 21.0.0-Omega
- pvr.zattoo: update 20.3.7-Nexus to 21.0.1-Omega