### PR TITLE
iwd: update to 2.12

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.11"
-PKG_SHA256="37052abc176d9885c98537c403ab496500ed03977b2273397275c02c7352b66e"
+PKG_VERSION="2.12"
+PKG_SHA256="6b71a78c1e1a0200c6b0097efe0f4055a76f445c0e17cdd6225d89538d7dc35e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
log:
- https://git.kernel.org/pub/scm/network/wireless/iwd.git/log/

ver 2.12:
- Fix issue with DPP extra settings not being used.
- Fix issue with DPP and PRF+ handling on AARCH64.
- Add support for SAE password identifiers.