### PR TITLE
rust: update to 1.75.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="1e634b91432f5cf51ba8baa84bc8a05f39e2826c02288119488951cc9c19ab3e"
+    PKG_SHA256="cf367bccbc97ba86b4cf8a0141c9c270523e38f865dc7220b3cfdd79b67200ed"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="906238776998c3f730f38e51bed195a58bffd03f17bc63b0da9d8369552bab80"
+    PKG_SHA256="9bc818b9adef237dafa2999f5c613db97c4be262385190863e2a4f25e030956b"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="3ea1159af625c281a9d4486efbeb51e1a24ccba58a39db230af38fa331a95f34"
+    PKG_SHA256="6ac164e7da969a1d524f747f22792e9aa08bc7446f058314445a4f3c1d31a6bd"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="a776e7b41991ef7a50706d1f9b7752a8d963e67297bfc22471d6e68d544349cc"
+    PKG_SHA256="2ea0dc380ac1fced245bafadafd0da50167a4a416b6011e3d73ba3e657a71d15"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="5f1b890faa083afd97ed53c67d859f4de89abe9a059b48c98217d8ee015bedeb"
+    PKG_SHA256="c42114c9fb2ba1426c9dd648b6dc991217f95b8997cc7f5cbcf677068647827e"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="df435e3254c03ccbfc9e733ae33b399f5f99bd488974bc07d8b1db91a12ee95b"
+    PKG_SHA256="136b132199f7bbda2aa0bbff6d1e6ae7d5fca2994a2f2a432a5e99de224b6314"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.74.1"
-PKG_SHA256="67db3e22fc9921c885baae5953ba144fc474cde29ec69ab56d43ce764206231d"
+PKG_VERSION="1.75.0"
+PKG_SHA256="5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="d0e5e641fd8726c9ddabb685a03f3846b3c716b8950334ebf3b18987affe82fe"
+    PKG_SHA256="b1d7bb8b0420b71585cf9c4eb5fd1e986fd83edc2d393510b54a9b20272386a3"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="8a4b07e43cf1d4c162b29f93a9cd4ef8b55f024050a65d15975a98ba48432eb3"
+    PKG_SHA256="d04dc49e614f395618bb400f9644db90d2496c6f587cdb6105202c87644fa9c2"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="b30e2d1b6b139874caa3fc81fbc3098e88cf01b98e891ce591d12ad4f0299437"
+    PKG_SHA256="2824ba4045acdddfa436da4f0bb72807b64a089aa2e7c9a66ca1a3a571114ce7"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
rust: update to 1.75.0
- cargo-snapshot: update to 1.75.0
- rustc-snapshot: update to 1.75.0
- rust-std-snapshot: update to 1.75.0
