### PR TITLE
Rockchip: RK3399: add support for Nanopi M4 2GB version

### DIFF
--- a/projects/Rockchip/README.md
+++ b/projects/Rockchip/README.md
@@ -20,6 +20,7 @@ This project is for Rockchip SoC devices
 * [Khadas Edge](devices/RK3399)
 * [FriendlyARM NanoPC-T4](devices/RK3399)
 * [FriendlyARM NanoPi M4](devices/RK3399)
+* [FriendlyARM NanoPi M4 2GB](devices/RK3399)
 * [Orange Pi RK3399](devices/RK3399)
 * [PINE64 RockPro64](devices/RK3399)
 * [Radxa ROCK Pi 4](devices/RK3399)

--- a/projects/Rockchip/devices/RK3399/README.md
+++ b/projects/Rockchip/devices/RK3399/README.md
@@ -8,6 +8,7 @@ This is a SoC device for RK3399
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=khadas-edge make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=nanopc-t4 make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=nanopi-m4 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=nanopi-m4-2gb make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=orangepi make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock960 make image`
 * `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-4 make image`

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -316,6 +316,10 @@ devices = \
         'dtb': 'rk3399-nanopi-m4.dtb',
         'config': 'nanopi-m4-rk3399_defconfig'
       },
+      'nanopi-m4-2gb': {
+        'dtb': 'rk3399-nanopi-m4-2gb.dtb',
+        'config': 'nanopi-m4-2gb-rk3399_defconfig'
+      },
       'orangepi': {
         'dtb': 'rk3399-orangepi.dtb',
         'config': 'orangepi-rk3399_defconfig'


### PR DESCRIPTION
add the Nanopi M4 2GB version target, which already supported by upstream u-boot since v2020.10

see more @ https://github.com/u-boot/u-boot/commit/d597e613745155d2c48ed90617b3fce81af92fbd