### PR TITLE
imagedecoder.heif: fix crashing kodi

### DIFF
--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -12,7 +12,9 @@ PKG_LONGDESC="A HEIF file format decoder and encoder."
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
-                       -DWITH_EXAMPLES=OFF"
+                       -DWITH_EXAMPLES=OFF \
+                       -DWITH_AOM_DECODER=OFF \
+                       -DWITH_AOM_ENCODER=OFF"
 
 pre_configure_target() {
   export CXXFLAGS="${CXXFLAGS} -Wno-unused-variable"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.heif"
 PKG_VERSION="20.1.0-Nexus"
 PKG_SHA256="17f50aada11528c02db2ff3871a355c89709ab7e2a5e6b5e33957b790cf207ff"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"


### PR DESCRIPTION
When using imagedecoder.heif kodi is crashing with
```
 kodi.sh[944]: /usr/lib/kodi/kodi.bin: symbol lookup error: /storage/.kodi/addons/imagedecoder.heif/imagedecoder.heif.so.20.1.0: undefined symbol: aom_codec_version
```
Reported in the [forum](https://forum.libreelec.tv/thread/27931-heif-add-on-does-not-work-for-libreelect-kodi-on-pi-v5/)

libheif can be build with different decoders and encoders. libaom (package aom) is detected and used after being installed to sysroot for ffmpegex. But imagedecoder.heif is only linking with libde265.

With this fix usage of libaom is explicit disabled.

Tested on Generic.

Backport of #8467 