### PR TITLE
Fix LD_LIBRARY_PATH update

### DIFF
--- a/packages/mediacenter/kodi/profile.d/99-kodi.conf
+++ b/packages/mediacenter/kodi/profile.d/99-kodi.conf
@@ -9,9 +9,8 @@ export PATH
 
 # LD_LIBRARY_PATH
 for addon in /storage/.kodi/addons/*/lib /usr/lib/kodi/addons/*/lib; do
-  [ -d "$addon" ] && (
-    files="$(find $addon ! -type d -name '*.so*' -maxdepth 1)"
+  [ -d "$addon" ] &&
+    files="$(find $addon ! -type d -name '*.so*' -maxdepth 1)" &&
     [ ! -z "$files" ] && LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$addon"
-  )
 done
 export LD_LIBRARY_PATH


### PR DESCRIPTION
After  [065d3f5], LD_LIBRARY_PATH is not updated, even when there are *.so inside $addon/lib dirs.

Changing LD_LIBRARY_PATH in a set of code between parenthesis will keep the change only inside that scope.
I propose replacing the parenthesis as follows.