### PR TITLE
scripts/image: Fix RPi4 and RPi5 noobs build

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -427,10 +427,6 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
       fi
     done
 
-    cp -PR ${INSTALL}/usr/share/bootloader/bootcode.bin ${RELEASE_DIR}/${NOOBS_DISTRO}/System/
-    cp -PR ${INSTALL}/usr/share/bootloader/fixup.dat ${RELEASE_DIR}/${NOOBS_DISTRO}/System/
-    cp -PR ${INSTALL}/usr/share/bootloader/start.elf ${RELEASE_DIR}/${NOOBS_DISTRO}/System/
-
     # Copy system files
     cp ${TARGET_IMG}/${IMAGE_NAME}.system ${RELEASE_DIR}/${NOOBS_DISTRO}/System/SYSTEM
     cp ${TARGET_IMG}/${IMAGE_NAME}.kernel ${RELEASE_DIR}/${NOOBS_DISTRO}/System/kernel.img


### PR DESCRIPTION
When making the boodloader files optional I forgot to remove the code that unconditionally copies the bootloader files which broke noobs build for RPi4 and RPi5. Drop the code, the files are already copied by the for loop above.