### PR TITLE
kodi: update to githash a808b55

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="87d2d6f84799224f5fe63a6bba3e973e84e18fef"
-PKG_SHA256="682fe2afa246bc708407914a12baff4c76839443afafee0b7b199da856fb89e2"
+PKG_VERSION="a808b5564c8416e2d84ca75b05e5bfd0fd4451c3"
+PKG_SHA256="913dc90402b9c72d284ef1f79ffd80d5ef1b160ccad8855549ad49a07de8fd8c"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.10-handle-SIGTERM.patch
@@ -112,9 +112,9 @@ so, when shutdown/reboot is requested:
    unsigned int m_ProcessedExternalDecay = 0;      /*!< counts to close door after a few frames of no python activity */
    int m_ExitCode{EXITCODE_QUIT};
 +  bool m_ExitCodeSet = false;
+   std::shared_ptr<CFileItem> m_itemCurrentFile; //!< Currently playing file
+   CEvent m_playerEvent;
  };
- 
- XBMC_GLOBAL_REF(CApplication,g_application);
 --- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
 +++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
 @@ -79,8 +79,6 @@ CLogindUPowerSyscall::~CLogindUPowerSysc


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20240105085514-3145359
Linux nuc12 6.6.9 #1 SMP Fri Jan  5 08:14:40 UTC 2024 x86_64 GNU/Linux
Starting Kodi (21.0-BETA2 (20.90.821) Git:a808b5564c8416e2d84ca75b05e5bfd0fd4451c3). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-01-05 by GCC 13.2.0 for Linux x86 64-bit version 6.6.9 (394761)
Running on LibreELEC (heitbaum): devel-20240105085514-3145359 12.0, kernel: Linux x86 64-bit version 6.6.9
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0088.2023.0505.1623 05/05/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.3.2
libva info: VA-API version 1.20.0
vainfo: VA-API version: 1.20 (libva 2.20.1)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.1.0 (8d996aea97)
```