### PR TITLE
meson: use chosen linker

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -609,13 +609,16 @@ EOF
 }
 
 create_meson_conf_target() {
+  local linker="$(get_target_linker)"
   local properties
   properties="PKG_MESON_PROPERTIES_${1^^}"
 
   cat > $2 <<EOF
 [binaries]
 c = '$TARGET_CC'
+c_ld = '$linker'
 cpp = '$TARGET_CXX'
+cpp_ld = '$linker'
 ar = '$TARGET_AR'
 strip = '$TARGET_STRIP'
 pkg-config = '$PKG_CONFIG'


### PR DESCRIPTION
meson requires setting the linker via c_ld/cpp_ld.
This now links meson based package builds with the chosen DEFAULT_LINKER.