### PR TITLE
Minor package updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gtk3"
-PKG_VERSION="3.24.38"
-PKG_SHA256="ce11decf018b25bdd8505544a4f87242854ec88be054d9ade5f3a20444dd8ee7"
+PKG_VERSION="3.24.39"
+PKG_SHA256="1cac3e566b9b2f3653a458c08c2dcdfdca9f908037ac03c9d8564b4295778d79"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gtk+/${PKG_VERSION:0:4}/gtk+-${PKG_VERSION}.tar.xz"

--- a/packages/audio/fdk-aac/package.mk
+++ b/packages/audio/fdk-aac/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fdk-aac"
-PKG_VERSION="2.0.2"
-PKG_SHA256="7812b4f0cf66acda0d0fe4302545339517e702af7674dd04e5fe22a5ade16a90"
+PKG_VERSION="2.0.3"
+PKG_SHA256="e25671cd96b10bad896aa42ab91a695a9e573395262baed4e4a2ff178d6a3a78"
 PKG_LICENSE="fdk-aac"
 PKG_SITE="https://github.com/mstorsjo/fdk-aac"
 PKG_URL="https://github.com/mstorsjo/fdk-aac/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.377-2"
-PKG_SHA256="e1e79c12b975298ade94a9cf3f76d24a07ef2d25aa0bf4eebaeac9328ce7a2a7"
+PKG_VERSION="0.378"
+PKG_SHA256="098ea8db12a50290f4b23f7f521edf9c5bab25935d2740de17e4a487110b40c8"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/libcap-ng/package.mk
+++ b/packages/devel/libcap-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcap-ng"
-PKG_VERSION="0.8.3"
-PKG_SHA256="e542e9139961f0915ab5878427890cdc7762949fbe216bd0cb4ceedb309bb854"
+PKG_VERSION="0.8.4"
+PKG_SHA256="5615c76a61039e283a6bd107c4faf345ae5ad4dcd45907defe5e474d8fdb6fd2"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="https://github.com/stevegrubb/libcap-ng"
 PKG_URL="https://github.com/stevegrubb/libcap-ng/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libde265/package.mk
+++ b/packages/graphics/libde265/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libde265"
-PKG_VERSION="1.0.14"
-PKG_SHA256="99f46ef77a438be639aa3c5d9632c0670541c5ed5d386524d4199da2d30df28f"
+PKG_VERSION="1.0.15"
+PKG_SHA256="00251986c29d34d3af7117ed05874950c875dd9292d016be29d3b3762666511d"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="http://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libde265/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.118"
-PKG_SHA256="a777bd85f2b5fc9c57f886c82058300578317cafdbc77d0a769d7e9a9567ab88"
+PKG_VERSION="2.4.119"
+PKG_SHA256="0a49f12f09b5b6e68eaaaff3f02ca7cff9aa926939b212d343161d3e8ac56291"
 PKG_LICENSE="GPL"
 PKG_SITE="https://dri.freedesktop.org"
 PKG_URL="https://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.17.5"
-PKG_SHA256="38ab01938ef419dbebb98346dc0b1c8bb503a0449ea61a0e409a988786c2af5b"
+PKG_VERSION="1.17.6"
+PKG_SHA256="8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libraw/package.mk
+++ b/packages/graphics/libraw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libraw"
-PKG_VERSION="0.21.1"
-PKG_SHA256="630a6bcf5e65d1b1b40cdb8608bdb922316759bfb981c65091fec8682d1543cd"
+PKG_VERSION="0.21.2"
+PKG_SHA256="fe7288013206854baf6e4417d0fb63ba4ed7227bf36fff021992671c2dd34b03"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.libraw.org/"
 PKG_URL="https://www.libraw.org/data/LibRaw-${PKG_VERSION}.tar.gz"

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libssh"
-PKG_VERSION="0.10.5"
-PKG_SHA256="b60e2ff7f367b9eee2b5634d3a63303ddfede0e6a18dfca88c44a8770e7e4234"
+PKG_VERSION="0.10.6"
+PKG_SHA256="1861d498f5b6f1741b6abc73e608478491edcf9c9d4b6630eef6e74596de9dc1"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libssh.org/"
 PKG_URL="https://www.libssh.org/files/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.19.0"
-PKG_SHA256="30354c769a508f644cf5c9647ef1f3a346b6fb3e64034fc3a8a364f6986beeb1"
+PKG_VERSION="3.19.1"
+PKG_SHA256="abaa39b3a1b31ebf2daec51ce343accfdf3a2444c1af6572c281c6d821b55add"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pycryptodome"
 PKG_URL="https://github.com/Legrandin/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.96"
-PKG_SHA256="0010792b00689c1e51b8f3ffe2f10b182635079944b4a94fecb9cac6a6eaa2c4"
+PKG_VERSION="3.96.1"
+PKG_SHA256="81e080ec10883e9526418b73f27342c1c25e5de118401c8f105166f1e939670a"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
- libcap-ng: update to 0.8.4
- libraw: update to 0.21.2
- libheif: update to 1.17.6
- libdrm: update to 2.4.119
- libde265: update to 1.0.15
- gtk3: update to 3.24.39
- nss: update to 3.96.1
- fdk-aac: update to 2.0.3
- libssh: update to 0.10.6
- pycryptodome: update to 3.19.1
- hwdata: update to 0.378