### PR TITLE
kodi: update to githash bdc4ab8

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="a808b5564c8416e2d84ca75b05e5bfd0fd4451c3"
-PKG_SHA256="913dc90402b9c72d284ef1f79ffd80d5ef1b160ccad8855549ad49a07de8fd8c"
+PKG_VERSION="bdc4ab89ae787d359f47a0148ef95d512e0be4a9"
+PKG_SHA256="805d43803c758b7ee8096ae6605f44e4326509c6e998ddffd8ae978d14fadf42"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
may resolve #8365

```
=== tested on ===
Generic.x86_64-devel-20240107083254-5cf49e4
Linux nuc12 6.6.10 #1 SMP Sat Jan  6 04:32:31 UTC 2024 x86_64 GNU/Linux
Starting Kodi (21.0-BETA2 (20.90.821) Git:bdc4ab89ae787d359f47a0148ef95d512e0be4a9). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-01-07 by GCC 13.2.0 for Linux x86 64-bit version 6.6.10 (394762)
Running on LibreELEC (heitbaum): devel-20240107083254-5cf49e4 12.0, kernel: Linux x86 64-bit version 6.6.10
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0088.2023.0505.1623 05/05/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.3.2
libva info: VA-API version 1.20.0
vainfo: VA-API version: 1.20 (libva 2.20.1)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.1.0 (fd3a59e085)
```