### PR TITLE
media-driver: update to 24.1.1

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="24.1.0"
-PKG_SHA256="cc9d88da01a0a487fc0229d78c8a2cda83fa878c5da3f07dfba1fe449efeec85"
+PKG_VERSION="24.1.1"
+PKG_SHA256="da90f3c38176936f6315bb4b0f04f6f83080f9a6a228294538aa6befe9ce20e0"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
Log:
- https://github.com/intel/media-driver/compare/intel-media-24.1.0...intel-media-24.1.1 
```
=== tested on ===
Generic.x86_64-devel-20240110113615-9110fee
Linux nuc12 6.6.10 #1 SMP Tue Jan  9 20:18:34 UTC 2024 x86_64 GNU/Linux
Starting Kodi (21.0-BETA2 (20.90.821) Git:f6e78bff33d97e0de5ae5894d80d7f72b9b72f7d). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-01-09 by GCC 13.2.0 for Linux x86 64-bit version 6.6.10 (394762)
Running on LibreELEC (heitbaum): devel-20240110113615-9110fee 12.0, kernel: Linux x86 64-bit version 6.6.10
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0088.2023.0505.1623 05/05/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 23.3.2
libva info: VA-API version 1.20.0
vainfo: VA-API version: 1.20 (libva 2.20.1)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.1.1 (5d853abf95)
```