### PR TITLE
Add mount.nfs and mount.cifs helpers

### DIFF
--- a/packages/devel/libevent/package.mk
+++ b/packages/devel/libevent/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libevent"
+PKG_VERSION="2.1.12"
+PKG_SHA256="92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"
+PKG_LICENSE="BSD-3-Clause"
+PKG_SITE="https://libevent.org/"
+PKG_URL="https://github.com/libevent/libevent/releases/download/release-${PKG_VERSION}-stable/libevent-${PKG_VERSION}-stable.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="libevent – an event notification library"
+
+PKG_CMAKE_OPTS_TARGET="-DEVENT__LIBRARY_TYPE=STATIC \
+                       -DEVENT__DISABLE_DEBUG_MODE=ON \
+                       -DEVENT__DISABLE_MM_REPLACEMENT=ON \
+                       -DEVENT__DISABLE_THREAD_SUPPORT=ON \
+                       -DEVENT__DISABLE_OPENSSL=ON \
+                       -DEVENT__DISABLE_BENCHMARK=ON \
+                       -DEVENT__DISABLE_TESTS=ON \
+                       -DEVENT__DISABLE_REGRESS=ON \
+                       -DEVENT__DISABLE_SAMPLES=ON"

--- a/packages/network/cifs-utils/package.mk
+++ b/packages/network/cifs-utils/package.mk
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="cifs-utils"
+PKG_VERSION="7.0"
+PKG_SHA256="0defaab85bd3ea46ffc45ab41fb0d0ad54d05ae2cfaa7e503de86d4f12bc8161"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://wiki.samba.org/index.php/LinuxCIFS_utils"
+PKG_URL="https://download.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-${PKG_VERSION}.tar.bz2"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Linux CIFS userspace utilities"
+
+PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
+                           ac_cv_func_realloc_0_nonnull=yes \
+                           --disable-cifsupcall \
+                           --disable-cifscreds \
+                           --disable-cifsidmap \
+                           --disable-cifsacl \
+                           --disable-smbinfo \
+                           --disable-pythontools \
+                           --disable-pam \
+                           --disable-man \
+                           --disable-systemd"
+
+makeinstall_target() {
+  mkdir -p "${INSTALL}/usr/sbin/"
+    cp -PR mount.cifs "${INSTALL}/usr/sbin/"
+    ln -s mount.cifs "${INSTALL}/usr/sbin/mount.smb3"
+}

--- a/packages/network/nfs-utils/package.mk
+++ b/packages/network/nfs-utils/package.mk
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="nfs-utils"
+PKG_VERSION="2.6.4"
+PKG_SHA256="01b3b0fb9c7d0bbabf5114c736542030748c788ec2fd9734744201e9b0a1119d"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="http://www.linux-nfs.org/"
+PKG_URL="https://www.kernel.org/pub/linux/utils/nfs-utils/${PKG_VERSION}/nfs-utils-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain keyutils libevent libtirpc rpcbind sqlite util-linux"
+PKG_LONGDESC="Linux NFS userland utility package"
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-gss \
+                           --disable-nfsv41 \
+                           --disable-nfsdcld \
+                           --disable-nfsrahead \
+                           --disable-nfsdcltrack \
+                           --disable-ldap"
+
+pre_configure_target() {
+  cd ${PKG_BUILD}
+  rm -rf .${TARGET_NAME}
+}
+
+makeinstall_target() {
+  mkdir -p "${INSTALL}/usr/sbin/"
+    cp -PR utils/mount/mount.nfs "${INSTALL}/usr/sbin/"
+    ln -s mount.nfs "${INSTALL}/usr/sbin/mount.nfs4"
+    ln -s mount.nfs "${INSTALL}/usr/sbin/umount.nfs"
+    ln -s mount.nfs "${INSTALL}/usr/sbin/umount.nfs4"
+}

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -18,11 +18,6 @@ if [ "${NANO_EDITOR}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" nano"
 fi
 
-# nfs support
-if [ "${NFS_SUPPORT}" = yes ]; then
-  PKG_DEPENDS_TARGET+=" rpcbind"
-fi
-
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" pciutils"
 fi

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -29,3 +29,8 @@ fi
 if [ "${ISCSI_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" open-iscsi"
 fi
+
+if [ "${NFS_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" nfs-utils"
+fi
+

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -18,6 +18,10 @@ if [ "${SAMBA_SERVER}" = "yes" ] || [ "${SAMBA_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" samba"
 fi
 
+if [ "${SAMBA_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" cifs-utils"
+fi
+
 if [ "${OPENVPN_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" openvpn"
 fi


### PR DESCRIPTION
This fixes nfs and cifs mount issues since switching to util-linux's mount in #8497

Building nfs-utils is a bit of a beast, neither libevent nor sqlite are needed for mount.nfs but they are hard dependencies in configure.ac and it's not easy to only build mount.nfs. At least libevent is quite small and as I only build it as a static lib it doesn't impact image size. Any suggestions for build improvements are welcome, though.

Tested on RPi5 mounting cifs and nfs4 shares from my Debian Bookworm box using mount on the command line