### PR TITLE
minor package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.21.5"
-PKG_SHA256="20acc9b538ccc9368ca3061849d8ff466f10c71fd858af5a0940fce3c3dbe4db"
+PKG_VERSION="1.21.6"
+PKG_SHA256="ed8d28ba53d0998d9788355ceb50229ff1a4c0bae70b4c3c372f6f5a686c1d86"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.0.0"
-PKG_SHA256="f91ef1d1161b37aae6e21b9671917d97097e2664c83d919ba3a0793d6fbc543d"
+PKG_VERSION="1.0.1"
+PKG_SHA256="23f7a3c1227e0dbc6c859d2ae56e0f3866749e4bc2e6193e3b6cadf5a037bd8e"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/jasper/package.mk
+++ b/packages/graphics/jasper/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jasper"
-PKG_VERSION="4.1.1"
-PKG_SHA256="57299e40db869cee4ea410c021f18ced793796db8c053dd987afc7b876afda96"
+PKG_VERSION="4.1.2"
+PKG_SHA256="64937eee9377f59d6222e443ed643857729c5378e627f54cdb1995776405be18"
 PKG_LICENSE="OpenSource"
 PKG_SITE="http://www.ece.uvic.ca/~mdadams/jasper/"
 PKG_URL="https://github.com/jasper-software/jasper/archive/refs/tags/version-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/Jinja2/package.mk
+++ b/packages/python/devel/Jinja2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Jinja2"
-PKG_VERSION="3.1.2"
-PKG_SHA256="31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"
+PKG_VERSION="3.1.3"
+PKG_SHA256="ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/Jinja2/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.19.1"
-PKG_SHA256="abaa39b3a1b31ebf2daec51ce343accfdf3a2444c1af6572c281c6d821b55add"
+PKG_VERSION="3.20.0"
+PKG_SHA256="35019dff66c25db80d0c739b9c7b59bb0f61551897681c6dbdbdd0f7198f780f"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pycryptodome"
 PKG_URL="https://github.com/Legrandin/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- jasper: update to 4.1.2
- pipewire: update to 1.0.1
- pycryptodome: update to 3.20.0
- Jinja2: update to 3.1.3
- go: update to 1.21.6