### PR TITLE
iwd: update to 2.13

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.12"
-PKG_SHA256="6b71a78c1e1a0200c6b0097efe0f4055a76f445c0e17cdd6225d89538d7dc35e"
+PKG_VERSION="2.13"
+PKG_SHA256="5c58d0cc7c2c81540a515a7487330468c61615d23031af47be15f694fbfbc8b3"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Log: https://git.kernel.org/pub/scm/network/wireless/iwd.git/

ver 2.13:
+	Fix issue with handling netconfig and roaming conditions.
+	Fix issue with logging requirement for CMD_EXTERNAL_AUTH.
+	Fix issue with using OpenSSL 3.2 installations.