### PR TITLE
drop PKG_TOOLCHAIN hardcoding - already defaults to cmake

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-robotv/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-robotv/package.mk
@@ -10,7 +10,6 @@ PKG_URL="https://github.com/pipelka/vdr-plugin-robotv/archive/${PKG_VERSION}.tar
 PKG_DEPENDS_TARGET="toolchain vdr avahi"
 PKG_NEED_UNPACK="$(get_pkg_directory vdr)"
 PKG_LONGDESC="RoboTV is a Android TV based frontend for VDR."
-PKG_TOOLCHAIN="cmake"
 
 pre_configure_target() {
   VDR_DIR=$(get_build_dir vdr)

--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -12,7 +12,6 @@ PKG_DEPENDS_HOST="toolchain:host ncurses:host openssl:host"
 PKG_DEPENDS_TARGET="toolchain binutils boost bzip2 libaio libfmt libxml2 lz4 lzo ncurses openssl pcre2 systemd zlib mariadb:host"
 PKG_SHORTDESC="MariaDB is a community-developed fork of the MySQL."
 PKG_LONGDESC="MariaDB (${PKG_VERSION}) is a fast SQL database server and a drop-in replacement for MySQL."
-PKG_TOOLCHAIN="cmake"
 PKG_BUILD_FLAGS="-gold -sysroot"
 
 PKG_IS_ADDON="yes"


### PR DESCRIPTION
Cleanup TOOLCHAIN
- more #5970
  - mariadb: drop PKG_TOOLCHAIN hardcoding - already defaults to cmake
  - vdr-plugin-robotv: drop PKG_TOOLCHAIN hardcoding - already defaults to cmake