### PR TITLE
drop PKG_TOOLCHAIN hardcoding - already defaults to …

### DIFF
--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -10,7 +10,6 @@ PKG_SITE="https://tracker.debian.org/pkg/fakeroot"
 PKG_URL="http://ftp.debian.org/debian/pool/main/f/fakeroot/${PKG_NAME}_${PKG_VERSION}.orig.tar.gz"
 PKG_DEPENDS_HOST="ccache:host libcap:host autoconf:host libtool:host"
 PKG_LONGDESC="fakeroot provides a fake root environment by means of LD_PRELOAD and SYSV IPC (or TCP) trickery."
-PKG_TOOLCHAIN="configure"
 
 PKG_CONFIGURE_OPTS_HOST="--with-gnu-ld"
 

--- a/packages/tools/bcm2835-utils/package.mk
+++ b/packages/tools/bcm2835-utils/package.mk
@@ -10,7 +10,6 @@ PKG_SITE="https://github.com/raspberrypi/utils"
 PKG_URL="https://github.com/raspberrypi/utils/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain dtc"
 PKG_LONGDESC="Raspberry Pi related collection of scripts and simple applications"
-PKG_TOOLCHAIN="cmake"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin

--- a/packages/wayland/util/bemenu/package.mk
+++ b/packages/wayland/util/bemenu/package.mk
@@ -9,7 +9,6 @@ PKG_SITE="https://github.com/Cloudef/bemenu"
 PKG_URL="https://github.com/Cloudef/bemenu/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain glib wayland wayland-protocols cairo pango libxkbcommon"
 PKG_LONGDESC="Dynamic menu library and client program inspired by dmenu"
-PKG_TOOLCHAIN="make"
 
 PKG_MAKE_OPTS_TARGET="PREFIX=/usr clients wayland"
 

--- a/scripts/build
+++ b/scripts/build
@@ -104,7 +104,7 @@ if [ -z "${PKG_TOOLCHAIN}" -o "${PKG_TOOLCHAIN}" = "auto" ]; then
     PKG_TOOLCHAIN="cmake"
   elif [ -f "${PKG_CONFIGURE_SCRIPT}" ]; then
     PKG_TOOLCHAIN="configure"
-  elif [ -f "${PKG_BUILD}/Makefile" ]; then
+  elif [ -f "${PKG_BUILD}/GNUmakefile" -o -f "${PKG_BUILD}/Makefile" ]; then
     PKG_TOOLCHAIN="make"
   else
     die "Not possible to detect toolchain automatically. Add PKG_TOOLCHAIN= to package.mk"


### PR DESCRIPTION
Cleanup TOOLCHAIN (non addons)
- more #5970
- scripts/build: handle GNUmakefile in addition to Makefile for PKG_TOOLCHAIN=make
  - bemenu: drop PKG_TOOLCHAIN hardcoding - defaults to make
- bcm2835-utils: drop PKG_TOOLCHAIN hardcoding - already defaults to cmake
- fakeroot: drop PKG_TOOLCHAIN hardcoding - already defaults to configure