### PR TITLE
bluez: support input.conf to handle PS3 controllers

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -62,6 +62,8 @@ post_makeinstall_target() {
         -e "s|^#\[Policy\]|\[Policy\]|g" \
         -e "s|^#AutoEnable.*|AutoEnable=true|g" \
         -e "s|^#JustWorksRepairing.*|JustWorksRepairing=always|g"
+    echo "[General]" > ${INSTALL}/etc/bluetooth/input.conf
+    echo "ClassicBondedOnly=false" >> ${INSTALL}/etc/bluetooth/input.conf
 
   mkdir -p ${INSTALL}/usr/share/services
     cp -P ${PKG_DIR}/default.d/*.conf ${INSTALL}/usr/share/services


### PR DESCRIPTION
This solves a connection issue with Bluez reported in the forums: https://forum.libreelec.tv/thread/27897-12-0-nightly-can-t-connect-sony-ps3-bluetooth-remote/ and sourced from https://github.com/bluez/bluez/issues/696 and https://github.com/bluez/bluez/issues/673. AFAICT there's no impact on other input devices; a new config setting was added and this disables the new setting effectively restoring the original behaviour.