### PR TITLE
bluez: update to 5.72

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bluez"
-PKG_VERSION="5.71"
-PKG_SHA256="b828d418c93ced1f55b616fb5482cf01537440bfb34fbda1a564f3ece94735d8"
+PKG_VERSION="5.72"
+PKG_SHA256="499d7fa345a996c1bb650f5c6749e1d929111fa6ece0be0e98687fee6124536e"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
ver 5.72:
+	Fix issue with BAP and handling stream IO linking.
+	Fix issue with BAP and setup of multiple streams per endpoint.
+	Fix issue with AVDTP and potential incorrect transaction label.
+	Fix issue with A2DP and handling crash on suspend.
+	Fix issue with GATT database and an invalid pointer.
+	Add support for AICS service.