### PR TITLE
[LE11] kernel update to fix 6.1.70 cifs regression

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="280d1a9b43916acd15b4c6b6edccf4c70d4adc51" # 6.1.71
-    PKG_SHA256="d22227165df5939258b20ba331e5a89c9096e3970263d430955616f76c387d8f"
+    PKG_VERSION="db53b52e7a54b6eed59dbbfb6f4b19ac6ed4edb3" # 6.1.72
+    PKG_SHA256="7211cd729ac63e005b1c81a20aac0c1b0cc4ba3a483b799705ad691f6074e720"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,8 +29,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.1.71"
-    PKG_SHA256="2df774dd53f9ffd4e57ebf804cf597709295df6a304fe261d25220a134b7f041"
+    PKG_VERSION="6.1.73"
+    PKG_SHA256="6cad48706bf1cde342613dca2a2cd6dd4f79f88f9e4d356263564e4b2a5d7e87"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;


### PR DESCRIPTION
This is to fix [REGRESSION 6.1.70] system calls with CIFS mounts failing with "Resource temporarily unavailable".

Build and runtime tested Generic and RPi5