### PR TITLE
scripts/mkimage: create storage filesystem without orphan_file option

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -92,7 +92,7 @@ dd if="${DISK}" of="${LE_TMP}/part2.ext4" bs=512 count=0 seek="${STORAGE_PART_CO
 
 # create filesystem on part2
 echo "image: creating filesystem on part2..."
-mke2fs -F -q -t ext4 -m 0 "${LE_TMP}/part2.ext4"
+mke2fs -F -q -t ext4 -O ^orphan_file -m 0 "${LE_TMP}/part2.ext4"
 tune2fs -L "${DISTRO_DISKLABEL}" -U ${UUID_STORAGE} "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 e2fsck -n "${LE_TMP}/part2.ext4" >"${SAVE_ERROR}" 2>&1 || show_error
 sync


### PR DESCRIPTION
resize2fs creates a filesystem with unclean orphan file when resizing to more than 32GB if the orphan_file option is enabled, resulting in an unmountable storage partition after initial resize.

Explicitly disable the option until the issue is resolved.

Fixes: #8099