### PR TITLE
pcre: do not build pcrecpp

### DIFF
--- a/packages/devel/pcre/package.mk
+++ b/packages/devel/pcre/package.mk
@@ -17,12 +17,14 @@ PKG_BUILD_FLAGS="+pic"
 PKG_CONFIGURE_OPTS_HOST="--prefix=${TOOLCHAIN} \
              --enable-static \
              --enable-utf8 \
+             --disable-cpp \
              --enable-unicode-properties \
              --with-gnu-ld"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
              --enable-static \
              --enable-utf8 \
+             --disable-cpp \
              --enable-pcre16 \
              --enable-unicode-properties \
              --with-gnu-ld"


### PR DESCRIPTION
- Since https://github.com/xbmc/xbmc/pull/24128
- pcrecpp is no longer used.
- Ref: #6798
