### PR TITLE
taglib: update to 2.0

### DIFF
--- a/packages/audio/taglib/package.mk
+++ b/packages/audio/taglib/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="taglib"
-PKG_VERSION="1.13.1"
-PKG_SHA256="c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b"
+PKG_VERSION="2.0"
+PKG_SHA256="e36ea877a6370810b97d84cf8f72b1e4ed205149ab3ac8232d44c850f38a2859"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://taglib.org"
 PKG_URL="https://taglib.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain cmake:host zlib"
+PKG_DEPENDS_TARGET="toolchain cmake:host utfcpp zlib"
 PKG_LONGDESC="TagLib is a library for reading and editing the meta-data of several popular audio formats."
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_EXAMPLES=OFF \

--- a/packages/devel/utfcpp/package.mk
+++ b/packages/devel/utfcpp/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="utfcpp"
+PKG_VERSION="4.0.4"
+PKG_SHA256="7c8a403d0c575d52473c8644cd9eb46c6ba028d2549bc3e0cdc2d45f5cfd78a0"
+PKG_LICENSE="BSL"
+PKG_SITE="https://github.com/nemtrif/utfcpp"
+PKG_URL="https://github.com/nemtrif/utfcpp/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="UTF-8 with C++ in a Portable Way"


### PR DESCRIPTION
Release notes: https://taglib.org/

Kodi updated:
- https://github.com/xbmc/xbmc/pull/24339
- https://github.com/xbmc/xbmc/pull/24577
- https://github.com/LibreELEC/LibreELEC.tv/pull/8561/commits/d108bf373030a16361045b8ab74b9e722b51b9b0

depends on
- #8561 

new dependancy:
- utfcpp: initial package