### PR TITLE
kodi: update to githash 06e2280

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="f3f1df1eab2a38b7039e57635a6597b37510481a"
-PKG_SHA256="dfc46bc48a2d226bd121828b2370ea7be8ed38fc2a8dcd2cf2ed70fc4582a84a"
+PKG_VERSION="06e228046c9f1316c7585bd61bfa1e28e22382da"
+PKG_SHA256="c98d1f2851fea820d59b367452d15e52fbe1531822a7df35d48c4a021e952818"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update to Jan 25, 2024 release

```
=== tested on ===
Generic.x86_64-devel-20240125103536-a036c73
Linux nuc12 6.6.13 #1 SMP Mon Jan 22 12:01:33 UTC 2024 x86_64 GNU/Linux
Starting Kodi (21.0-BETA2 (20.90.821) Git:06e228046c9f1316c7585bd61bfa1e28e22382da). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-01-25 by GCC 13.2.0 for Linux x86 64-bit version 6.6.13 (394765)
Running on LibreELEC (heitbaum): devel-20240125103536-a036c73 12.0, kernel: Linux x86 64-bit version 6.6.13
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0088.2023.0505.1623 05/05/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.0.0-rc3
libva info: VA-API version 1.20.0
vainfo: VA-API version: 1.20 (libva 2.20.1)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.1.1 (b24241c48b)
```