### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/ccid/package.mk
+++ b/packages/addons/addon-depends/ccid/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccid"
-PKG_VERSION="1.5.4"
-PKG_SHA256="6e832adc172ecdcfdee2b56f33144684882cbe972daff1938e7a9c73a64f88bf"
+PKG_VERSION="1.5.5"
+PKG_SHA256="194708f75fe369d45dd7c15e8b3e8a7db8b49cfc5557574ca2a2e76ef12ca0ca"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://ccid.apdu.fr"
 PKG_URL="https://ccid.apdu.fr/files/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.50.0"
-PKG_SHA256="e9f5a8c8235c9dd963b2171de9120301129c677dde933955e1df618b949c4adc"
+PKG_VERSION="2.51.0"
+PKG_SHA256="8dd07c6160e3115f4f77e2205963449def6822a3dc85d495c5db389f56663037"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.gnome.org/"
 PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gtk3"
-PKG_VERSION="3.24.39"
-PKG_SHA256="1cac3e566b9b2f3653a458c08c2dcdfdca9f908037ac03c9d8564b4295778d79"
+PKG_VERSION="3.24.41"
+PKG_SHA256="47da61487af3087a94bc49296fd025ca0bc02f96ef06c556e7c8988bd651b6fa"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gtk+/${PKG_VERSION:0:4}/gtk+-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet6-runtime"
-PKG_VERSION="6.0.25"
+PKG_VERSION="6.0.26"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="1c652059f51c82847a68f0827a164d3e6bbda54ab9fe951c2ed22213bc4d3535"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/8f085f4e-ce83-494f-add1-7e6d4e04f90e/398b661de84bda4d74b5c04fa709eadb/aspnetcore-runtime-6.0.25-linux-arm64.tar.gz"
+    PKG_SHA256="bb599cf64b0dc4b4cefbf8aec7a37801d6f89f030ac5ed98eeaf8a11f1e595b3"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/cfc40e77-a6de-481f-812d-6867289e2d8b/eeedeebccc412fd01110d8b59050754d/aspnetcore-runtime-6.0.26-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="10ab3b8b6964cb87b4be458c9a3195dfff01fb20b95ec0bd7c80b43cf4f8087a"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/88cf902b-08e0-4329-b2cf-7d0ab104d97d/287edc7e830d810424d62f6efc5c577a/aspnetcore-runtime-6.0.25-linux-arm.tar.gz"
+    PKG_SHA256="3fedc16eb901bc42c354eaa62f082ed600c357327b3b65c3b080e6f6473a17dc"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/c1d42ac0-cd0c-4188-b260-1667a7443534/f0d1a0b4b88432f1c8d31b467d8548f0/aspnetcore-runtime-6.0.26-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="b4ef19514e6b45f893d6b0f6f436ec01338fcca197faa25e88f0d3a5a0c6c5d0"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/0cf64d28-dec3-4553-b38d-8f526e6f64b0/0bf8e79d48da8cb4913bc1c969653e9a/aspnetcore-runtime-6.0.25-linux-x64.tar.gz"
+    PKG_SHA256="8860633eaf2d24fb5d62913b05a97880f6ca2e9ed4f1e4112e52debe06c994cf"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/b63daa46-51f4-480e-ad03-ef2c5a6a2885/ae059763456991305109bf98b3a67640/aspnetcore-runtime-6.0.26-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/libvpx/package.mk
+++ b/packages/addons/addon-depends/libvpx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libvpx"
-PKG_VERSION="1.13.1"
-PKG_SHA256="00dae80465567272abd077f59355f95ac91d7809a2d3006f9ace2637dd429d14"
+PKG_VERSION="1.14.0"
+PKG_SHA256="5f21d2db27071c8a46f1725928a10227ae45c5cd1cad3727e4aafbe476e321fa"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="https://github.com/webmproject/libvpx/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/libplacebo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/libplacebo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libplacebo"
-PKG_VERSION="6.338.1"
-PKG_SHA256="3c9a68b325c00e6f2f16d58774fd3a9bb63c0f27c10c2285438ad813b2d05ae1"
+PKG_VERSION="6.338.2"
+PKG_SHA256="2f1e624e09d72a8c9db70f910f7560e764a1c126dae42acc5b3bcef836a7aec6"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="https://code.videolan.org/videolan/libplacebo"
 PKG_URL="https://github.com/haasn/libplacebo/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpg123"
-PKG_VERSION="1.32.3"
-PKG_SHA256="2d9913a57d4ee8f497a182c6e82582602409782a4fb481e989feebf4435867b4"
+PKG_VERSION="1.32.4"
+PKG_SHA256="5a99664338fb2f751b662f40ee25804d0c9db6b575dcb5ce741c6dc64224a08a"
 PKG_LICENSE="LGPLv2"
 PKG_SITE="https://www.mpg123.org/"
 PKG_URL="https://downloads.sourceforge.net/sourceforge/mpg123/mpg123-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squeezelite"
-PKG_VERSION="8581aba8b1b67af272b89b62a7a9b56082307ab6"
-PKG_SHA256="bf290e6543c365e2ea6aaf818acbfe24aadcaabb266b2dc723926428f4ec30c9"
+PKG_VERSION="6de9e229aa4cc7c3131ff855f3ead39581127090"
+PKG_SHA256="99c20c32c26256c6fb3afd219ecefaf58dc0a56f41a6bfb4e6263f9482974ba3"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ralph-irving/squeezelite"
 PKG_URL="https://github.com/ralph-irving/squeezelite/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/polkit/package.mk
+++ b/packages/addons/addon-depends/polkit/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="polkit"
-PKG_VERSION="123"
-PKG_SHA256="72d9119b0aa35da871fd0660601d812c7a3d6af7e4e53e237840b71bb43d0c63"
+PKG_VERSION="124"
+PKG_SHA256="a4693bb00a8eaa6fbf766b9771dd9e1e11343678dee7e14539b9d6a808f00166"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.freedesktop.org/software/polkit/docs/latest/"
 PKG_URL="https://gitlab.freedesktop.org/polkit/polkit/-/archive/${PKG_VERSION}/polkit-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/system-tools-depends/htop/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/htop/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="htop"
-PKG_VERSION="3.2.2"
-PKG_SHA256="3829c742a835a0426db41bb039d1b976420c21ec65e93b35cd9bfd2d57f44ac8"
+PKG_VERSION="3.3.0"
+PKG_SHA256="1e5cc328eee2bd1acff89f860e3179ea24b85df3ac483433f92a29977b14b045"
 PKG_LICENSE="GPL"
 PKG_SITE="https://hisham.hm/htop"
 PKG_URL="https://github.com/htop-dev/htop/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/lshw/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/lshw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lshw"
-PKG_VERSION="02.19.2"
-PKG_SHA256="9bb347ac87142339a366a1759ac845e3dbb337ec000aa1b99b50ac6758a80f80"
+PKG_VERSION="02.20"
+PKG_SHA256="06d9cf122422220e5dc94e8ea5b01816a69bb6b59368f63d7f21fff31fc6922a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://ezix.org/project/wiki/HardwareLiSter"
 PKG_URL="http://ezix.org/software/files/lshw-B.${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.17.03"
-PKG_SHA256="3646118dcd683bf1929357e67d36c75f950e849db48f26d298b11028e78f3e7a"
+PKG_VERSION="0.17.04"
+PKG_SHA256="60c37d8b1effc5772fb30f638e20b1de01e0488e274e283301c3fd6c707d8538"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -4,8 +4,8 @@
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
 # curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
-PKG_VERSION_NUMBER="119.0.6045.105"
-PKG_REV="0"
+PKG_VERSION_NUMBER="121.0.6167.85"
+PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/addons/service/pcscd/package.mk
+++ b/packages/addons/service/pcscd/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="pcscd"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="3.8.0"
-PKG_SHA256="a768d3e54c7f00cd38b01208d1ae52d671be410cfc387ff7881ea71c855f3600"
+PKG_VERSION="3.8.1"
+PKG_SHA256="dedc65060812a7df801c0270a2fe8bd773c6bb0b601f2144ecfbc62dc0f671ca"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="https://storage.googleapis.com/aom-releases/libaom-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- ffmpeg-tools: update addon (1)
  - aom: update to 3.8.1
  - libvpx: update to 1.14.0
- dotnet-runtime: update aspnet6-runtime to 6.0.26 and addon (1)
  - aspnet6-runtime: update to 6.0.26
- chrome: update to 121.0.6167.85 and addon (1)
  - at-spi2-core: update to 2.51.0
  - gtk3: update to 3.24.41
- pcscd: update addon (1)
  - polkit: update to 124
  - ccid: update to 1.5.5
- system-tools: update addon (2)
  - htop: update to 3.3.0
  - stress-ng: update to 0.17.04
  - lshw: update to 02.20
- multimedia-tools: update addon (1)
  - mpg123: update to 1.32.4
  - squeezelite: update to githash 6de9e22 (2.0.0.1465)
  - libplacebo: update to 6.338.2