### PR TITLE
Custom cpu features support for x86_64

### DIFF
--- a/config/arch.x86_64
+++ b/config/arch.x86_64
@@ -15,16 +15,16 @@
 
 # build with microarchitecture feature support defined by the TARGET_CPU value
 # see https://gitlab.com/x86-psABIs/x86-64-ABI/-/wikis/home for further details
-  TARGET_FEATURES="64bit cmov cx8 fpu fxsr mmx osfxsr sce sse sse2"
-  TARGET_FEATURES_X86_64_V2="cmpxchg16b lahf-sahf popcnt sse3 sse4_1 sse4_2 ssse3"
-  TARGET_FEATURES_X86_64_V3="avx avx2 bmi1 bmi2 f16c fma lzcnt movbe osxsave"
-  if [ "${TARGET_CPU}" = "x86-64" ]; then
-    TARGET_FEATURES+=" no_sahf"
-  elif [ "${TARGET_CPU}" = "x86-64-v2" ]; then
-    TARGET_FEATURES+=" ${TARGET_FEATURES_X86_64_V2}"
-  elif [ "${TARGET_CPU}" = "x86-64-v3" ]; then
-    TARGET_FEATURES+=" ${TARGET_FEATURES_X86_64_V2} ${TARGET_FEATURES_X86_64_V3}"
-  else
-    TARGET_FEATURES+=" UNKNOWN_ADDITIONAL_CPU_SPECIFIC_FEATURES"
+  if [ -z "${TARGET_FEATURES}" ]; then
+    TARGET_FEATURES="64bit cmov cx8 fpu fxsr mmx osfxsr sce sse sse2"
+    TARGET_FEATURES_X86_64_V2="cmpxchg16b lahf-sahf popcnt sse3 sse4_1 sse4_2 ssse3"
+    TARGET_FEATURES_X86_64_V3="avx avx2 bmi1 bmi2 f16c fma lzcnt movbe osxsave"
+    if [ "${TARGET_CPU}" = "x86-64" ]; then
+      TARGET_FEATURES+=" no_sahf"
+    elif [ "${TARGET_CPU}" = "x86-64-v2" ]; then
+      TARGET_FEATURES+=" ${TARGET_FEATURES_X86_64_V2}"
+    elif [ "${TARGET_CPU}" = "x86-64-v3" ]; then
+      TARGET_FEATURES+=" ${TARGET_FEATURES_X86_64_V2} ${TARGET_FEATURES_X86_64_V3}"
+    fi
   fi
   TARGET_FEATURES="$(echo ${TARGET_FEATURES} | xargs -n1 | sort -u | xargs)"


### PR DESCRIPTION
The idea is to provide flexible way to specify a custom CPU feature list, the same way is it's done in `arch.arm` and `arch.aarch64`