### PR TITLE
Revert "taglib: update to 2.0"

### DIFF
--- a/packages/audio/taglib/package.mk
+++ b/packages/audio/taglib/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="taglib"
-PKG_VERSION="2.0"
-PKG_SHA256="e36ea877a6370810b97d84cf8f72b1e4ed205149ab3ac8232d44c850f38a2859"
+PKG_VERSION="1.13.1"
+PKG_SHA256="c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://taglib.org"
 PKG_URL="https://taglib.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain cmake:host utfcpp zlib"
+PKG_DEPENDS_TARGET="toolchain cmake:host zlib"
 PKG_LONGDESC="TagLib is a library for reading and editing the meta-data of several popular audio formats."
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_EXAMPLES=OFF \


### PR DESCRIPTION
This reverts commit 580a168e889cfa7b301a8fa3f9ae26274578d1c8.

further work is required to fully support taglib-2.0 in Kodi. The 64 bit compiles are fine, but 32 bit compiles fail. A further WIP patch to Kodi as below aligns all of the Kodi taglib overrides with the taglib.h (long was changed to off_t in taglib 2.0.)

```
From 57e7f16d7c172f92278c1df70c6b22764768f4b4 Mon Sep 17 00:00:00 2001
From: Rudi Heitbaum <rudi@heitbaum.com>
Date: Wed, 31 Jan 2024 07:06:50 +0000
Subject: [PATCH] update remaining custom taglib definitions for compile on 32bit

---
 xbmc/music/tags/TagLibVFSStream.cpp | 18 +++++++++++++++++-
 xbmc/music/tags/TagLibVFSStream.h   | 18 +++++++++++++++++-
 2 files changed, 34 insertions(+), 2 deletions(-)

diff --git a/xbmc/music/tags/TagLibVFSStream.cpp b/xbmc/music/tags/TagLibVFSStream.cpp
index c5f9c2473f..6d22ee85af 100644
--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -59,7 +59,7 @@ FileName TagLibVFSStream::name() const
  * Reads a block of size \a length at the current get pointer.
  */
 #if (TAGLIB_MAJOR_VERSION >= 2)
-ByteVector TagLibVFSStream::readBlock(unsigned long length)
+ByteVector TagLibVFSStream::readBlock(size_t length)
 #else
 ByteVector TagLibVFSStream::readBlock(TagLib::ulong length)
 #endif
@@ -282,7 +282,11 @@ bool TagLibVFSStream::isOpen() const
  *
  * \see Position
  */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+void TagLibVFSStream::seek(TagLib::offset_t offset, Position p)
+#else
 void TagLibVFSStream::seek(long offset, Position p)
+#endif
 {
   const long fileLen = length();
   if (m_bIsReadOnly && fileLen > 0)
@@ -340,7 +344,11 @@ void TagLibVFSStream::clear()
 /*!
  * Returns the current offset within the file.
  */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+TagLib::offset_t TagLibVFSStream::tell() const
+#else
 long TagLibVFSStream::tell() const
+#endif
 {
   int64_t pos = m_file.GetPosition();
   if(pos > LONG_MAX)
@@ -352,7 +360,11 @@ long TagLibVFSStream::tell() const
 /*!
  * Returns the length of the file.
  */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+TagLib::offset_t TagLibVFSStream::length()
+#else
 long TagLibVFSStream::length()
+#endif
 {
   return (long)m_file.GetLength();
 }
@@ -360,7 +372,11 @@ long TagLibVFSStream::length()
 /*!
  * Truncates the file to a \a length.
  */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+void TagLibVFSStream::truncate(TagLib::offset_t length)
+#else
 void TagLibVFSStream::truncate(long length)
+#endif
 {
   m_file.Truncate(length);
 }
diff --git a/xbmc/music/tags/TagLibVFSStream.h b/xbmc/music/tags/TagLibVFSStream.h
index 2302c04dd9..c416e35b59 100644
--- a/xbmc/music/tags/TagLibVFSStream.h
+++ b/xbmc/music/tags/TagLibVFSStream.h
@@ -38,7 +38,7 @@ namespace MUSIC_INFO
      * Reads a block of size \a length at the current get pointer.
      */
 #if (TAGLIB_MAJOR_VERSION >= 2)
-    TagLib::ByteVector readBlock(unsigned long length) override;
+    TagLib::ByteVector readBlock(size_t length) override;
 #else
     TagLib::ByteVector readBlock(TagLib::ulong length) override;
 #endif
@@ -99,7 +99,11 @@ namespace MUSIC_INFO
      *
      * \see Position
      */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    void seek(TagLib::offset_t offset, TagLib::IOStream::Position p = Beginning) override;
+#else
     void seek(long offset, TagLib::IOStream::Position p = Beginning) override;
+#endif
 
     /*!
      * Reset the end-of-file and error flags on the file.
@@ -109,17 +113,29 @@ namespace MUSIC_INFO
     /*!
      * Returns the current offset within the file.
      */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    TagLib::offset_t tell() const override;
+#else
     long tell() const override;
+#endif
 
     /*!
      * Returns the length of the file.
      */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    TagLib::offset_t length() override;
+#else
     long length() override;
+#endif
 
     /*!
      * Truncates the file to a \a length.
      */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    void truncate(TagLib::offset_t length) override;
+#else
     void truncate(long length) override;
+#endif
 
   protected:
     /*!
-- 
2.43.0

From bb42b828bef0a6db4ddd1641133a4e2ce426af02 Mon Sep 17 00:00:00 2001
From: Rudi Heitbaum <rudi@heitbaum.com>
Date: Wed, 31 Jan 2024 11:34:15 +0000
Subject: [PATCH] remove implicit conversions - long to off_t

---
 xbmc/music/tags/TagLibVFSStream.cpp | 30 +++++++++++++++++++++++------
 1 file changed, 24 insertions(+), 6 deletions(-)

diff --git a/xbmc/music/tags/TagLibVFSStream.cpp b/xbmc/music/tags/TagLibVFSStream.cpp
index 6d22ee85af..0bf04daab1 100644
--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -137,12 +137,14 @@ void TagLibVFSStream::insert(const ByteVector &data, TagLib::ulong start, TagLib
     bufferLength += bufferSize();
 
   // Set where to start the reading and writing.
-  long readPosition = start + replace;
-  long writePosition = start;
   ByteVector buffer;
 #if (TAGLIB_MAJOR_VERSION >= 2)
+  TagLib::offset_t readPosition = start + replace;
+  TagLib::offset_t writePosition = start;
   ByteVector aboutToOverwrite(static_cast<unsigned int>(bufferLength));
 #else
+  long readPosition = start + replace;
+  long writePosition = start;
   ByteVector aboutToOverwrite(static_cast<TagLib::uint>(bufferLength));
 #endif
 
@@ -217,12 +219,13 @@ void TagLibVFSStream::removeBlock(TagLib::ulong start, TagLib::ulong length)
   TagLib::ulong bufferLength = bufferSize();
 #endif
 
-  long readPosition = start + length;
-  long writePosition = start;
-
 #if (TAGLIB_MAJOR_VERSION >= 2)
+  TagLib::offset_t readPosition = start + length;
+  TagLib::offset_t writePosition = start;
   ByteVector buffer(static_cast<unsigned int>(bufferLength));
 #else
+  long readPosition = start + length;
+  long writePosition = start;
   ByteVector buffer(static_cast<TagLib::uint>(bufferLength));
 #endif
 
@@ -288,10 +291,18 @@ void TagLibVFSStream::seek(TagLib::offset_t offset, Position p)
 void TagLibVFSStream::seek(long offset, Position p)
 #endif
 {
+#if (TAGLIB_MAJOR_VERSION >= 2)
+  const TagLib::offset_t fileLen = length();
+#else
   const long fileLen = length();
+#endif
   if (m_bIsReadOnly && fileLen > 0)
   {
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    TagLib::offset_t startPos;
+#else
     long startPos;
+#endif
     if (p == Beginning)
       startPos = 0;
     else if (p == Current)
@@ -354,7 +365,11 @@ long TagLibVFSStream::tell() const
   if(pos > LONG_MAX)
     return -1;
   else
+#if (TAGLIB_MAJOR_VERSION >= 2)
     return (long)pos;
+#else
+    return (TagLib::offset_t)pos;
+#endif
 }
 
 /*!
@@ -362,12 +377,15 @@ long TagLibVFSStream::tell() const
  */
 #if (TAGLIB_MAJOR_VERSION >= 2)
 TagLib::offset_t TagLibVFSStream::length()
+{
+  return (TagLib::offset_t)m_file.GetLength();
+}
 #else
 long TagLibVFSStream::length()
-#endif
 {
   return (long)m_file.GetLength();
 }
+#endif
 
 /*!
  * Truncates the file to a \a length.
-- 
2.43.0
```