### PR TITLE
mesa: update to 24.0.0

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="23.3.4"
-PKG_SHA256="df12d765be4650fe532860b18aa18e6da1d0b07d1a21dfdfe04660e6b7bac39a"
+PKG_VERSION="24.0.0"
+PKG_SHA256="dc7e8c077bc5884df95478263b34bdebb7e88e600689cb56fb07be2b8c304c36"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20240201053824-b7f7563
Linux nuc12 6.6.14 #1 SMP Tue Jan 30 20:11:32 UTC 2024 x86_64 GNU/Linux
Starting Kodi (21.0-BETA2 (20.90.822) Git:cabba8df735f50a317a229be4f5d6a3b7ad2fbc3). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-02-01 by GCC 13.2.0 for Linux x86 64-bit version 6.6.14 (394766)
Running on LibreELEC (heitbaum): devel-20240201053824-b7f7563 12.0, kernel: Linux x86 64-bit version 6.6.14
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0088.2023.0505.1623 05/05/2023
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.0.0
libva info: VA-API version 1.20.0
vainfo: VA-API version: 1.20 (libva 2.20.1)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.1.2 (30b4e85697)
```