### PR TITLE
Package updates

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.0.2"
-PKG_SHA256="c2b502b98044ebed61fa9e28e3c14e8bd646a2c21cfb9678f174e431bc75faf3"
+PKG_VERSION="1.0.3"
+PKG_SHA256="bddb29b9310c344ca069df410f6f02b7f3d8c518811c0505c7fe62d8428fd767"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="24.1.2"
-PKG_SHA256="3bea7e8a490556dc413e459146ad69ca89cbc76d86cbd2856ea4b4f999b74025"
+PKG_VERSION="24.1.3"
+PKG_SHA256="a024e96abd662193e4295f427a76c5894087503df46bd82c0e5bea103e44b171"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/python/devel/MarkupSafe/package.mk
+++ b/packages/python/devel/MarkupSafe/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="MarkupSafe"
-PKG_VERSION="2.1.4"
-PKG_SHA256="3aae9af4cac263007fd6309c64c6ab4506dd2b79382d9d19a1994f9240b8db4f"
+PKG_VERSION="2.1.5"
+PKG_SHA256="d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/MarkupSafe/"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/x11/app/xkbcomp/package.mk
+++ b/packages/x11/app/xkbcomp/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xkbcomp"
-PKG_VERSION="1.4.6"
-PKG_SHA256="fa50d611ef41e034487af7bd8d8c718df53dd18002f591cca16b0384afc58e98"
+PKG_VERSION="1.4.7"
+PKG_SHA256="0a288114e5f44e31987042c79aecff1ffad53a8154b8ec971c24a69a80f81f77"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- media-driver: update to 24.1.3
- pipewire: update to 1.0.3
- MarkupSafe: update to 2.1.5
- xkbcomp: update to 1.4.7