### PR TITLE
libdrm: keep modeprint and proptest too

### DIFF
--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -46,9 +46,9 @@ listcontains "${GRAPHIC_DRIVERS}" "etnaviv" &&
   PKG_MESON_OPTS_TARGET+=" -Detnaviv=enabled" || PKG_MESON_OPTS_TARGET+=" -Detnaviv=disabled"
 
 post_makeinstall_target() {
-  # Remove all test programs installed by install-test-programs=true except modetest
+  # Remove all test programs installed by install-test-programs=true except modetest, modeprint and proptest
   for PKG_LIBDRM_TEST in \
-    drmdevice modeprint proptest vbltest
+    drmdevice vbltest
   do
     safe_remove ${INSTALL}/usr/bin/${PKG_LIBDRM_TEST}
   done


### PR DESCRIPTION
This will add around 12KB (i did try gzip -9) to the image.  
The proptest is need to activate a Intel GPU 10 bin workaround.