### PR TITLE
kodi: update to githash 8020920 (2023-02-03)

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="cabba8df735f50a317a229be4f5d6a3b7ad2fbc3"
-PKG_SHA256="3da8ba22c7edbcc1d60ce73fe7d333a44dd66f99ca8bb3fe1a6effef7a66a0e9"
+PKG_VERSION="80209208f0aed03fc13abb56afceccd3328accfe"
+PKG_SHA256="89ee0eced62b12e13f29aac94b082a855411804729b6a034755c07b6beab5757"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
log:
- https://github.com/xbmc/xbmc/compare/cabba8df735f50a317a229be4f5d6a3b7ad2fbc3...827936d3f0cc2fc39499b3019586d4e7a10ef743