### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.21.6"
-PKG_SHA256="ed8d28ba53d0998d9788355ceb50229ff1a4c0bae70b4c3c372f6f5a686c1d86"
+PKG_VERSION="1.21.7"
+PKG_SHA256="7f91837da624a43d9cdaf869513c2fbc3478775d72695f513f612c75288d9f45"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.378"
-PKG_SHA256="098ea8db12a50290f4b23f7f521edf9c5bab25935d2740de17e4a487110b40c8"
+PKG_VERSION="0.379"
+PKG_SHA256="b98ef646d530d5fd3afa3180efbf7c8e22d3da0088f5836f41ee25380d87b092"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/jasper/package.mk
+++ b/packages/graphics/jasper/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jasper"
-PKG_VERSION="4.1.2"
-PKG_SHA256="64937eee9377f59d6222e443ed643857729c5378e627f54cdb1995776405be18"
+PKG_VERSION="4.2.0"
+PKG_SHA256="c9a3e35c95447f530b006fab6634a2dadec70276cc3e42c343b9e5ce5a1f2b6b"
 PKG_LICENSE="OpenSource"
 PKG_SITE="http://www.ece.uvic.ca/~mdadams/jasper/"
 PKG_URL="https://github.com/jasper-software/jasper/archive/refs/tags/version-${PKG_VERSION}.tar.gz"

--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="expat"
-PKG_VERSION="2.5.0"
-PKG_SHA256="ef2420f0232c087801abf705e89ae65f6257df6b7931d37846a193ef2e8cdcbe"
+PKG_VERSION="2.6.0"
+PKG_SHA256="cb5f5a8ea211e1cabd59be0a933a52e3c02cc326e86a4d387d8d218e7ee47a3e"
 PKG_LICENSE="OSS"
 PKG_SITE="https://libexpat.github.io"
 PKG_URL="https://github.com/libexpat/libexpat/releases/download/R_${PKG_VERSION//./_}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- go: update to 1.21.7
- jasper: update to 4.2.0
- hwdata: update to 0.379
- expat: update to 2.6.0