### PR TITLE
rust: update to 1.76.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="cf367bccbc97ba86b4cf8a0141c9c270523e38f865dc7220b3cfdd79b67200ed"
+    PKG_SHA256="d0c54d824e64b7313a974409541ca3a157b3ed7299865786bd0c440b0e073091"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="9bc818b9adef237dafa2999f5c613db97c4be262385190863e2a4f25e030956b"
+    PKG_SHA256="427eff597f3801987959a97a1ee5d5df57c56875a7adada41b45e72b46edfb4d"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="6ac164e7da969a1d524f747f22792e9aa08bc7446f058314445a4f3c1d31a6bd"
+    PKG_SHA256="30ec0ad9fca443ec12c544f9ce448dacdde411a45b9042961938b650e918ccfb"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="2ea0dc380ac1fced245bafadafd0da50167a4a416b6011e3d73ba3e657a71d15"
+    PKG_SHA256="c0c579d9321da855109a2b6c7d7c9e01549db37e8490f058cfdc0012bef394cd"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="c42114c9fb2ba1426c9dd648b6dc991217f95b8997cc7f5cbcf677068647827e"
+    PKG_SHA256="3b9a6af550679c82cf205b665962de86d067e9ccfc392c754217519dbf2bce52"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="136b132199f7bbda2aa0bbff6d1e6ae7d5fca2994a2f2a432a5e99de224b6314"
+    PKG_SHA256="e41150b52d923a3bbe166c4ecc5719f56576274b0d034d764768aee279ae2063"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.75.0"
-PKG_SHA256="5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088"
+PKG_VERSION="1.76.0"
+PKG_SHA256="9e5cff033a7f0d2266818982ad90e4d3e4ef8f8ee1715776c6e25073a136c021"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="b1d7bb8b0420b71585cf9c4eb5fd1e986fd83edc2d393510b54a9b20272386a3"
+    PKG_SHA256="a299b5053d2771c24e3d5787caa0317ea729618700acacf2eeb95e345a92529c"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="d04dc49e614f395618bb400f9644db90d2496c6f587cdb6105202c87644fa9c2"
+    PKG_SHA256="f398547fd5ad0e2f5904ace4eddaf74c615d0a75221b36ed2667fbb9a6324714"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="2824ba4045acdddfa436da4f0bb72807b64a089aa2e7c9a66ca1a3a571114ce7"
+    PKG_SHA256="9fadfcf71bc6a0ddfd026b9624163faf1c5689dd4a1f7cc1f857167ade4aa6eb"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
Release notes:
- https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html