### PR TITLE
Package updates

### DIFF
--- a/packages/network/libnfs/package.mk
+++ b/packages/network/libnfs/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnfs"
-PKG_VERSION="5.0.2"
-PKG_SHA256="637e56643b19da9fba98f06847788c4dad308b723156a64748041035dcdf9bd3"
+PKG_VERSION="5.0.3"
+PKG_SHA256="d945cb4f4c8f82ee1f3640893a168810f794a28e1010bb007ec5add345e9df3e"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="https://github.com/sahlberg/libnfs"
 PKG_URL="https://github.com/sahlberg/libnfs/archive/libnfs-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
libnfs: update to 5.0.3 

This is the final release of the old API before we merge the next-gen
branch and switch to a new major version.

log:
- https://github.com/sahlberg/libnfs/compare/libnfs-5.0.2...libnfs-5.0.3