### PR TITLE
dotnet-runtime: update aspnet6-runtime to 6.0.27 and addon (2)

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet6-runtime"
-PKG_VERSION="6.0.26"
+PKG_VERSION="6.0.27"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="bb599cf64b0dc4b4cefbf8aec7a37801d6f89f030ac5ed98eeaf8a11f1e595b3"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/cfc40e77-a6de-481f-812d-6867289e2d8b/eeedeebccc412fd01110d8b59050754d/aspnetcore-runtime-6.0.26-linux-arm64.tar.gz"
+    PKG_SHA256="8acc813922d3bd6d3cdc10448a62ea6af5dba18ac3137d47dde453d324f53766"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/6be3e44e-1306-422b-845c-9313589bbeb0/d76f133799f6b2c8e3ea7dc9d92b7a03/aspnetcore-runtime-6.0.27-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="3fedc16eb901bc42c354eaa62f082ed600c357327b3b65c3b080e6f6473a17dc"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/c1d42ac0-cd0c-4188-b260-1667a7443534/f0d1a0b4b88432f1c8d31b467d8548f0/aspnetcore-runtime-6.0.26-linux-arm.tar.gz"
+    PKG_SHA256="14f9db2f396b041c27655dbd8435159a0f570112bafe70abfc6275d99800d32c"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/d339df74-9573-4ca1-9835-61a829e3fcf4/6937d0f4650f3622dbcdbe8a1717f212/aspnetcore-runtime-6.0.27-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="8860633eaf2d24fb5d62913b05a97880f6ca2e9ed4f1e4112e52debe06c994cf"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/b63daa46-51f4-480e-ad03-ef2c5a6a2885/ae059763456991305109bf98b3a67640/aspnetcore-runtime-6.0.26-linux-x64.tar.gz"
+    PKG_SHA256="18e11c64d046295a4f5b4164b4142f676b2989977a0ed32c9481783476a63b28"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/d3e6b8a2-f7de-441e-a3af-c18b7584034b/9f15be4d095b7bbb751222b4d68a17e3/aspnetcore-runtime-6.0.27-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="aspnet8-runtime"
+PKG_VERSION="8.0.2"
+PKG_LICENSE="MIT"
+PKG_SITE="https://dotnet.microsoft.com/"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="ASP.NET Core Runtime enables you to run existing web/server applications."
+PKG_TOOLCHAIN="manual"
+
+case "${ARCH}" in
+  "aarch64")
+    PKG_SHA256="107074b613c48ffcd311670bc34df93f63fce33938ac35770c3db1969da770ef"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/bdfd0216-539e-4dfd-81ea-1b7a77dda929/59a62884bdb8684ef0e4f434eaea0ca3/aspnetcore-runtime-8.0.2-linux-arm64.tar.gz"
+    ;;
+  "arm")
+    PKG_SHA256="940a9e0f89330924a5aed8dedaadb6220f4504f42b5c676e1f6a77060595bb49"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/272dbea2-057e-4032-9857-7e00b476ceec/3c472df94b1c3f5e0d009cbccc9256a6/aspnetcore-runtime-8.0.2-linux-arm.tar.gz"
+    ;;
+  "x86_64")
+    PKG_SHA256="9748a8c44b20219b7529b8dde8c17aa07dfadb0206609ea6ce7329269379a121"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/d6d79cc3-df2f-4680-96ff-a7198f461139/df025000eaf5beb85d9137274a8c53ea/aspnetcore-runtime-8.0.2-linux-x64.tar.gz"
+    ;;
+esac
+PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -6,10 +6,10 @@ PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
-PKG_DEPENDS_TARGET="toolchain icu aspnet6-runtime"
+PKG_DEPENDS_TARGET="toolchain icu aspnet6-runtime aspnet8-runtime"
 PKG_SECTION="tools"
 PKG_SHORTDESC="ASP.NET Core Runtime"
-PKG_LONGDESC="ASP.NET Core Runtime ($(get_pkg_version aspnet6-runtime)) enables you to run existing console/web/server applications."
+PKG_LONGDESC="ASP.NET Core Runtime ($(get_pkg_version aspnet6-runtime)) and ($(get_pkg_version aspnet8-runtime)) enables you to run existing console/web/server applications."
 PKG_TOOLCHAIN="manual"
 
 PKG_IS_ADDON="yes"
@@ -20,12 +20,24 @@ PKG_MAINTAINER="Anton Voyl (awiouy)"
 
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    # aspnet6-runtime
     cp -r $(get_build_dir aspnet6-runtime)/* \
           ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    # aspnet8-runtime
+    cp -r $(get_build_dir aspnet8-runtime)/* \
+          ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
+    # aspnet6-runtime
     cp -L $(get_install_dir icu)/usr/lib/lib*.so.?? \
           ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/shared/Microsoft.NETCore.App/$(get_pkg_version aspnet6-runtime)
+    # aspnet8-runtime
+    cp -L $(get_install_dir icu)/usr/lib/lib*.so.?? \
+          ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/shared/Microsoft.NETCore.App/$(get_pkg_version aspnet8-runtime)
 
+    # aspnet6-runtime
     sed -e "s/\"System.Reflection.Metadata.MetadataUpdater.IsSupported\": false/&,\n      \"System.Globalization.AppLocalIcu\": \"$(get_pkg_version icu | cut -f 1 -d -)\"/" \
       -i ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/shared/Microsoft.NETCore.App/$(get_pkg_version aspnet6-runtime)/Microsoft.NETCore.App.runtimeconfig.json
+    # aspnet8-runtime
+    sed -e "s/\"tfm\": \"net8.0\"/&,\n    \"configProperties\": {\n      \"System.Globalization.AppLocalIcu\": \"$(get_pkg_version icu | cut -f 1 -d -)\"\n    }/" \
+      -i ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/shared/Microsoft.NETCore.App/$(get_pkg_version aspnet8-runtime)/Microsoft.NETCore.App.runtimeconfig.json
 }


### PR DESCRIPTION
Includes newly added aspnet8-runtime (8.0.2)
- tested with Jellyfin 2.9.y (including icu shared libraries)
