### PR TITLE
Package updates

### DIFF
--- a/packages/devel/libffi/package.mk
+++ b/packages/devel/libffi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libffi"
-PKG_VERSION="3.4.4"
-PKG_SHA256="d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676"
+PKG_VERSION="3.4.5"
+PKG_SHA256="96fff4e589e3b239d888d9aa44b3ff30693c2ba1617f953925a70ddebcc102b2"
 PKG_LICENSE="GPL"
 PKG_SITE="http://sourceware.org/${PKG_NAME}/"
 PKG_URL="https://github.com/libffi/libffi/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.97"
-PKG_SHA256="a7a920d295998563b33d9e06c1a36b799201493d81b64537fab42f2a733411ce"
+PKG_VERSION="3.98"
+PKG_SHA256="59bb55a59b02e4004fc26ad0aa1a13fe8d73c6c90c447dd2f2efb73fb81083ed"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
- libffi: update to 3.4.5
  - https://github.com/libffi/libffi/releases/tag/v3.4.5
  - https://github.com/libffi/libffi/compare/v3.4.4...v3.4.5
- nss: update to 3.98