### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.21.7"
-PKG_SHA256="7f91837da624a43d9cdaf869513c2fbc3478775d72695f513f612c75288d9f45"
+PKG_VERSION="1.22.0"
+PKG_SHA256="4245b5abef11f8e66a6f887d784f26758fd7dd8ccedad524429b470cce3fa8e3"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/go/patches/go-0001-add-ca-cert-location.patch
+++ b/packages/addons/addon-depends/go/patches/go-0001-add-ca-cert-location.patch
@@ -2,9 +2,11 @@ diff --git a/src/crypto/x509/root_linux.go b/src/crypto/x509/root_linux.go
 index ad6ce5cae7..763c686fed 100644
 --- a/src/crypto/x509/root_linux.go
 +++ b/src/crypto/x509/root_linux.go
-@@ -20,4 +20,5 @@ var certDirectories = []string{
- 	"/etc/ssl/certs",               // SLES10/SLES11, https://golang.org/issue/12139
- 	"/etc/pki/tls/certs",           // Fedora/RHEL
- 	"/system/etc/security/cacerts", // Android
-+	"/etc/ssl",                     // LibreELEC
+@@ -20,6 +20,7 @@ var certDirectories = []string{
+ var certDirectories = []string{
+ 	"/etc/ssl/certs",     // SLES10/SLES11, https://golang.org/issue/12139
+ 	"/etc/pki/tls/certs", // Fedora/RHEL
++	"/etc/ssl",           // LibreELEC
  }
+ 
+ func init() {

--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libmediainfo"
-PKG_VERSION="23.11"
-PKG_SHA256="197e54fcc79e3c0d5df44a8f58dc4e018bc2f85d13fa3bed54af3dc56d5e853d"
+PKG_VERSION="24.01"
+PKG_SHA256="a02dfc6689f485cec06fa12a3414c3c3aa2853b4dde18aeab4b54a56c8316259"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/libmediainfo/${PKG_VERSION}/libmediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mediainfo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mediainfo"
-PKG_VERSION="23.11"
-PKG_SHA256="801cb1b0d1bffcc1226deca6212a1ee35322e8bb12630a33bbb07a92a8a8c9c3"
+PKG_VERSION="24.01"
+PKG_SHA256="72fda0ee2e87e1effd5f5c85741ff1aa66cba10248cdfea87afaa4e98d956c65"
 PKG_LICENSE="GPL"
 PKG_SITE="https://mediaarea.net/en/MediaInfo/Download/Source"
 PKG_URL="https://mediaarea.net/download/source/mediainfo/${PKG_VERSION}/mediainfo_${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/rpi-tools-depends/gpiozero/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/gpiozero/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gpiozero"
-PKG_VERSION="2.0"
-PKG_SHA256="403bcc9e7f24f0877653e7fced91ba51508d5197c9d1f80e383fe6693b9c3c27"
+PKG_VERSION="2.0.1"
+PKG_SHA256="d4ea1952689ec7e331f9d4ebc9adb15f1d01c2c9dcfabb72e752c9869ab7e97e"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/RPi-Distro/python-gpiozero"

--- a/packages/addons/addon-depends/ttyd-depends/libuv/package.mk
+++ b/packages/addons/addon-depends/ttyd-depends/libuv/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libuv"
-PKG_VERSION="1.47.0"
-PKG_SHA256="d50af7e6d72526db137e66fad812421c8a1cae09d146b0ec2bb9a22c5f23ba93"
+PKG_VERSION="1.48.0"
+PKG_SHA256="8c253adb0f800926a6cbd1c6576abae0bc8eb86a4f891049b72f9e5b7dc58f33"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libuv/libuv"
 PKG_URL="https://github.com/libuv/libuv/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="1.3.2"
-PKG_SHA256="0c5d2153e3ab080e6b33474a6947e7f1ab8057e7f116d33ccbe2bd710a3ab0b1"
-PKG_REV="1"
+PKG_VERSION="1.3.3"
+PKG_SHA256="c5b2a854ceeb54b9260dccaebc47144a0233b358ab63df1e48a74710ed9366d5"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.27.2"
-PKG_SHA256="2a621655e09fdce8a5784ea0f65c5e9773b844ad966686916e68468cbd44813c"
-PKG_REV="1"
+PKG_VERSION="1.27.3"
+PKG_SHA256="3fe25b863bb3a0f74bc95a7afa71bdaa2a79971542962236be5d85f469aa897d"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/service/ttyd/package.mk
+++ b/packages/addons/service/ttyd/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="ttyd"
 PKG_VERSION="1.7.4"
 PKG_SHA256="300d8cef4b0b32b0ec30d7bf4d3721a5d180e22607f9467a95ab7b6d9652ca9b"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/tsl0922/ttyd"

--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="btrfs-progs"
-PKG_VERSION="6.7"
-PKG_SHA256="fd1ea129dbf9ab0084e781b770da0e5161d6793340333dca97433c4a631f48ca"
-PKG_REV="2"
+PKG_VERSION="6.7.1"
+PKG_SHA256="0a961c4ec5e81bbaf5cf9de2eddb9348f01b80b15e06f1037549217bd7502cbc"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.readthedocs.io/"

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/rpi-tools/package.mk
+++ b/packages/addons/tools/rpi-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="rpi-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/graphics/pango/package.mk
+++ b/packages/graphics/pango/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pango"
-PKG_VERSION="1.51.0"
-PKG_SHA256="74efc109ae6f903bbe6af77eaa2ac6094b8ee245a2e23f132a7a8f0862d1a9f5"
+PKG_VERSION="1.51.2"
+PKG_SHA256="3dba407f2b5fc117e192f3025f0a1cc8edc1fd9b934b1c578b2b97342139415a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.pango.org/"
 PKG_URL="https://download.gnome.org/sources/pango/${PKG_VERSION:0:4}/pango-${PKG_VERSION}.tar.xz"

--- a/packages/python/graphics/glad/package.mk
+++ b/packages/python/graphics/glad/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glad"
-PKG_VERSION="2.0.4"
-PKG_SHA256="02629644c242dcc27c58222bd2c001d5e2f3765dbbcfd796542308bddebab401"
+PKG_VERSION="2.0.5"
+PKG_SHA256="850351f1960f3fed775f0b696d7f17615f306beb56be38a20423284627626df1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://glad.dav1d.de"
 PKG_URL="https://github.com/Dav1dde/glad/archive/refs/tags/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- syncthing: update to 1.27.3 and addon (2)
- btrfs-progs: update to 6.7.1 and addon (3)
- minisatip: update to 1.3.3 and addon (2)
- rpi-tools: update addon (1)
  - gpiozero: update to 2.0.1
- multimedia-tools: update addon (2)
  - mediainfo: update to 24.01
  - libmediainfo: update to 24.01
  - glad: update to 2.0.5
- ttyd: update addon (1)
  - libuv: update to 1.48.0
- pango: update to 1.51.2
- go: update to 1.22.0