### PR TITLE
Vulkan update to 1.3.278

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.3.277"
-PKG_SHA256="33e0c000f1e9a8019e4b86106d62b64133314a13fef712390c1f0563f4920614"
+PKG_VERSION="1.3.278"
+PKG_SHA256="590cd0506be759972d0c714550c49bb90a1cc9c9e5337a10724bca6cdfd56dbe"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.3.277"
-PKG_SHA256="066d866278b210b6809398083cad143c9c6df9858bd15bd614f95cde7d4a560d"
+PKG_VERSION="1.3.278"
+PKG_SHA256="a22ea209ef1a0fe2ae77dbb355d700d20971f1bc8937efe52d885bd8bcbc447b"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.3.277"
-PKG_SHA256="487dd46f82a07ab445dc5338aa978bdacebf20f816ec0cede3d3a7e036d1a925"
+PKG_VERSION="1.3.278"
+PKG_SHA256="d3b18d3922b59e307597bd78c5ef260ad944767fd6d55644eec8e4971ab7517a"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/blob/main/ChangeLog.adoc
- vulkan-headers: update to 1.3.278
- vulkan-loader: update to 1.3.278
- vulkan-tools: update to 1.3.278