### PR TITLE
tools/docker/jammy: update build-host golang to 1.21

### DIFF
--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y \
     wget bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-go git openssh-client \
+      golang-1.21-go git openssh-client \
     --no-install-recommends
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \


### PR DESCRIPTION
the build host to have a later version of golang to build go-1.22.
    
Building Go cmd/dist using /usr/lib/go. (go1.18.1 linux/amd64) found packages main (build.go) and building_Go_requires_Go_1_20_6_or_later (notgo120.go) in /build/build.LibreELEC-ARMv8.aarch64-12.0-devel/build/go-1.22.0/src/cmd/dist

solution to update jammy Dockerfile to include go-1.21 (which is the latest in the jammy repo)