### PR TITLE
cacert.pem: update to 2024-02-14

### DIFF
--- a/packages/security/openssl/cert/cacert.pem
+++ b/packages/security/openssl/cert/cacert.pem
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Fri Feb  2 10:50:50 2024 GMT
+## Certificate data from Mozilla as of: Sun Feb 18 11:30:44 2024 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -14,7 +14,7 @@
 ## Just configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.29.
-## SHA256: d3604c12ac560fd4e3f5effda37095b23c0b129f016ef23c0c5c5f1725099b70
+## SHA256: 4d96bd539f4719e9ace493757afbe4a23ee8579de1c97fbebc50bba3c12e8c1e
 ##
 
 


### PR DESCRIPTION
Sha was updated on the source.

This commit updates cacert.pem certificate bundle with mk-ca-bundle.pl script using the content of [certdata][1] associated with mozilla/gecko-dev@66afa4a9c748ec7186a90adc735ec0fa278cee4e,

[1]: https://github.com/mozilla/gecko-dev/blob/66afa4a9c748ec7186a90adc735ec0fa278cee4e/security/nss/lib/ckfw/builtins/certdata.txt?raw=true