### PR TITLE
kodi: update to githash e085b62

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="21.0b3-Omega"
-PKG_SHA256="2a3dceb32d5d6ef0536b7f55e4f0a1ad2872b8bebb36bd6f5c12f9a8d0064560"
+PKG_VERSION="e085b62f103a3714a0efcc8ead1bd498bb92fcdd"
+PKG_SHA256="617ba5331a06d82ab3cb747937c41585ccdb76dc75e7a97a2d32bf111dc175d5"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log
- https://github.com/xbmc/xbmc/compare/21.0b3-Omega...e085b62f103a3714a0efcc8ead1bd498bb92fcdd

should fix
- https://forum.libreelec.tv/thread/28095-pvr-vuplus-webinterface-cannot-be-reached-since/?postID=188292&highlight=pvr.vuplus#post188292
- https://github.com/xbmc/xbmc/issues/24629
- https://github.com/xbmc/xbmc/pull/24733
