### PR TITLE
RTL8812AU: Fix change_beacon for kernel 6.7

### DIFF
--- a/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-PR1134.patch
+++ b/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-PR1134.patch
@@ -1,0 +1,30 @@
+From c0d16813f5af3b464cdb6dd415c83d1f238e3548 Mon Sep 17 00:00:00 2001
+From: CamiKaseM7 <camilorivasramunni@gmail.com>
+Date: Tue, 16 Jan 2024 03:44:34 -0300
+Subject: [PATCH] Fix change_beacon for kernel 6.7
+
+---
+ os_dep/linux/ioctl_cfg80211.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+index 510fa4547..a1358047d 100644
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -5283,9 +5283,16 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 	return ret;
+ }
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
++static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
++		struct cfg80211_ap_update *params)
++{
++	struct cfg80211_beacon_data *info = &params->beacon; 
++#else
+ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
+ 		struct cfg80211_beacon_data *info)
+ {
++#endif
+ 	int ret = 0;
+ 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
+ 


### PR DESCRIPTION
Required patch for RTL8812AU to compile with kernel 6.7
- https://github.com/aircrack-ng/rtl8812au/pull/1134