### PR TITLE
elfutils: cleanup _CONFIGURE_OPTS

### DIFF
--- a/packages/devel/elfutils/package.mk
+++ b/packages/devel/elfutils/package.mk
@@ -40,6 +40,14 @@ PKG_CONFIGURE_OPTS_TARGET="utrace_cv_cc_biarch=false \
                            --without-bzlib \
                            --without-lzma"
 
+pre_configure_host() {
+  HOST_CONFIGURE_OPTS=$(echo ${HOST_CONFIGURE_OPTS} | sed -e "s|--disable-static||" -e "s|--enable-shared||")
+}
+
+pre_configure_target() {
+  TARGET_CONFIGURE_OPTS=$(echo ${TARGET_CONFIGURE_OPTS} | sed -e "s|--disable-static||" -e "s|--enable-shared||")
+}
+
 post_makeinstall_target() {
   # don't install progs into sysroot
   rm -fr ${SYSROOT_PREFIX}/usr/bin


### PR DESCRIPTION
remove unknown options from build.
- fixes build warning:
  - `configure: WARNING: unrecognized options: --disable-static, --enable-shared`