### PR TITLE
brcmfmac_sdio-firmware: update to githash d4382f9

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware"
-PKG_VERSION="3aecdd07c78afb000ddc6eb541b540c963d6485e"
-PKG_SHA256="32aff889797d9f84d6d1b1813f71435cf274202cc712a12de6c567f8bd7b344a"
+PKG_VERSION="d4382f99141ef7bc0a9a9e65ab5fa3d90e8fe968"
+PKG_SHA256="2bbe39941c97ae3713f219002e5d6d692e3d47fc167fe642be1d9f2f014d4f05"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/brcmfmac_sdio-firmware"
 PKG_URL="https://github.com/LibreELEC/brcmfmac_sdio-firmware/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- includes https://github.com/LibreELEC/brcmfmac_sdio-firmware/pull/36