### PR TITLE
Revert "groovy: update to 4.0.19"

### DIFF
--- a/packages/devel/groovy/package.mk
+++ b/packages/devel/groovy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="groovy"
-PKG_VERSION="4.0.19"
-PKG_SHA256="41b5ac00bd86e5beff108002cf328724ce533f0dfcb7d8f8073071385378fd22"
+PKG_VERSION="4.0.18"
+PKG_SHA256="4b03aa472ec7848d272893348a656be05d1b3502b30770ea57efa158e61154a6"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://groovy.apache.org"
 PKG_URL="https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-${PKG_VERSION}.zip"


### PR DESCRIPTION
This reverts commit 6ea9e1e58d0f95c4504b30d821b97a09962ca8f8.

builds with 4.0.19 are not consistently building.

```
[1566/1695] Generating AddonModuleXbmcaddon.i.cpp
FAILED: build/swig/AddonModuleXbmcaddon.i.cpp /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/.aarch64-libreelec-linux-gnu/build/swig/AddonModuleXbmcaddon.i.cpp cd /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/.aarch64-libreelec-linux-gnu/build/swig && /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/toolchain/bin/swig -w401 -c++ -o AddonModuleXbmcaddon.i.xml -xml -I/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/xbmc -xmllang python /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/xbmc/interfaces/swig/../swig/AddonModuleXbmcaddon.i && /usr/bin/java --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED -cp /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/groovy-4.0.19/lib/*:/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/commons-lang3-3.14.0/*:/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/commons-text-1.11.0/*:/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/tools/codegenerator:/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/xbmc/interfaces/swig/../python groovy.ui.GroovyMain /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/tools/codegenerator/Generator.groovy AddonModuleXbmcaddon.i.xml /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/xbmc/interfaces/swig/../python/PythonSwig.cpp.template AddonModuleXbmcaddon.i.cpp > /dev/null Error: Unable to initialize main class groovy.ui.GroovyMain Caused by: java.lang.NoClassDefFoundError: picocli/CommandLine$ParameterException [1567/1695] Generating AddonModuleXbmcdrm.i.cpp
FAILED: build/swig/AddonModuleXbmcdrm.i.cpp /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/.aarch64-libreelec-linux-gnu/build/swig/AddonModuleXbmcdrm.i.cpp cd /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/.aarch64-libreelec-linux-gnu/build/swig && /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/toolchain/bin/swig -w401 -c++ -o AddonModuleXbmcdrm.i.xml -xml -I/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/xbmc -xmllang python /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/xbmc/interfaces/swig/../swig/AddonModuleXbmcdrm.i && /usr/bin/java --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED -cp /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/groovy-4.0.19/lib/*:/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/commons-lang3-3.14.0/*:/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/commons-text-1.11.0/*:/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/tools/codegenerator:/build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/xbmc/interfaces/swig/../python groovy.ui.GroovyMain /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/tools/codegenerator/Generator.groovy AddonModuleXbmcdrm.i.xml /build/build.LibreELEC-Dragonboard.aarch64-12.0-devel/build/kodi-7075efedfbf13f4f5bfa28e2fa57d7421ff5ab92/xbmc/interfaces/swig/../python/PythonSwig.cpp.template AddonModuleXbmcdrm.i.cpp > /dev/null Error: Unable to initialize main class groovy.ui.GroovyMain Caused by: java.lang.NoClassDefFoundError: picocli/CommandLine$ParameterException
```