### PR TITLE
iwd: update to 2.16

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.15"
-PKG_SHA256="bac5d236ac0a0dc3c576e8f362d64b7467e9d5c4b94c1a33a4c8ce5d325a82f1"
+PKG_VERSION="2.16"
+PKG_SHA256="c1a82032e994861e794cf3b5a16d07ae1aa03a6674f716c73408ffeae2a233ba"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
ver 2.16:
+	Fix issue with uninitialized variable and DPP encrypt.
+	Fix issue with Access Point mode and ATTR_MAC validation.
+	Fix issue with Access Point mode and frequency attributes.
+	Fix issue with P2P and handling client info description.
+	Fix issue with P2P and handling parsing of service info.
+	Fix issue with netconfig and handling domain list.
+	Add support for forcing a default ECC group.