### PR TITLE
[LE11] linux: default kernel update 6.1.80

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,8 +29,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.1.74"
-    PKG_SHA256="b7fbd1d79faed2ce3570ef79dc1223e4e19c868b86326b14a435db56ebbb2022"
+    PKG_VERSION="6.1.80"
+    PKG_SHA256="568ecaaebb8b87c7c8246bba67bc83402972bf34f5811651a2d3cd548ff7b671"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;


### PR DESCRIPTION
build tested for
- A64.arm
- Generic-legacy.x86_64
- Generic.x86_64
- H3.arm
- H5.arm
- H6.arm
- R40.arm
- RK3288.arm
- RK3328.arm
- RK3399.arm


runtime tested on my N100
- Generic.x86_64