### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.22.0"
-PKG_SHA256="4245b5abef11f8e66a6f887d784f26758fd7dd8ccedad524429b470cce3fa8e3"
+PKG_VERSION="1.22.1"
+PKG_SHA256="e6dbc2e591b577ef7d3cb0f6572568521c2dcfe8c7521f1253fe23fd624cdc56"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fakeroot"
-PKG_VERSION="1.33"
-PKG_SHA256="e157d8e5c64d3a755707791e9be93296c6d249d5c4478bf941b675d49c47757d"
+PKG_VERSION="1.34"
+PKG_SHA256="5727f16d8903792588efa7a9f8ef8ce71f8756e746b62e45162e7735662e56bb"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://tracker.debian.org/pkg/fakeroot"
 PKG_URL="http://ftp.debian.org/debian/pool/main/f/fakeroot/${PKG_NAME}_${PKG_VERSION}.orig.tar.gz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.379"
-PKG_SHA256="b98ef646d530d5fd3afa3180efbf7c8e22d3da0088f5836f41ee25380d87b092"
+PKG_VERSION="0.380"
+PKG_SHA256="e5ca061d9e0b9b177bed8d16f94b4cd54ce9eebd1ec115f7cf2174d3a6052049"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/pango/package.mk
+++ b/packages/graphics/pango/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pango"
-PKG_VERSION="1.52.0"
-PKG_SHA256="1ec8518879c3f43224499f08e8ecbbdf4a5d302ed6cd3853b4fa949f82b89a9b"
+PKG_VERSION="1.52.1"
+PKG_SHA256="58728a0a2d86f60761208df9493033d18ecb2497abac80ee1a274ad0c6e55f0f"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.pango.org/"
 PKG_URL="https://download.gnome.org/sources/pango/${PKG_VERSION:0:4}/pango-${PKG_VERSION}.tar.xz"

--- a/packages/sysutils/kmod/package.mk
+++ b/packages/sysutils/kmod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="kmod"
-PKG_VERSION="31"
-PKG_SHA256="f5a6949043cc72c001b728d8c218609c5a15f3c33d75614b78c79418fcf00d80"
+PKG_VERSION="32"
+PKG_SHA256="630ed0d92275a88cb9a7bf68f5700e911fdadaf02e051cf2e4680ff8480bd492"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
 PKG_URL="https://www.kernel.org/pub/linux/utils/kernel/kmod/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- pango: update to 1.52.1
- kmod: update to 32
  - https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/diff/NEWS?id=41faa59711742c1476d59985011ee0f27ed91d30
- hwdata: update to 0.380
  - https://github.com/vcrhonek/hwdata/compare/v0.379...v0.380
- go: update to 1.22.1
- fakeroot: update to 1.34 
  - https://salsa.debian.org/clint/fakeroot/-/commits/master/?ref_type=HEADS