### PR TITLE
Enable the nss-systemd service

### DIFF
--- a/packages/network/nss-mdns/config/nsswitch.conf
+++ b/packages/network/nss-mdns/config/nsswitch.conf
@@ -3,10 +3,10 @@
 # Example configuration of GNU Name Service Switch functionality.
 #
 
-passwd:		files
-group:		files
-shadow:		files
-gshadow:	files
+passwd:		files systemd
+group:		files [SUCCESS=merge] systemd
+shadow:		files systemd
+gshadow:	files systemd
 
 hosts:		files mdns_minimal [NOTFOUND=return] dns
 networks:	files dns

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -65,7 +65,8 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dlocaled=false \
                        -Dmachined=false \
                        -Dportabled=false \
-                       -Duserdb=false \
+                       -Duserdb=true \
+                       -Dnologin-path=/usr/sbin/nologin \
                        -Dhomed=disabled \
                        -Dnetworkd=false \
                        -Dtimedated=false \
@@ -88,7 +89,7 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dnss-myhostname=false \
                        -Dnss-mymachines=disabled \
                        -Dnss-resolve=disabled \
-                       -Dnss-systemd=false \
+                       -Dnss-systemd=true \
                        -Dman=disabled \
                        -Dhtml=disabled \
                        -Dlink-udev-shared=true \
@@ -303,4 +304,5 @@ post_install() {
   enable_service network-base.service
   enable_service systemd-timesyncd.service
   enable_service systemd-timesyncd-setup.service
+  enable_service systemd-userdbd.socket
 }

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -56,7 +56,8 @@ PKG_CONFIGURE_OPTS_TARGET="${UTILLINUX_CONFIG_DEFAULT} \
                            --enable-blkid \
                            --enable-lscpu \
                            --enable-lsfd \
-                           --enable-mount"
+                           --enable-mount \
+                           --enable-nologin"
 
 if [ "${SWAP_SUPPORT}" = "yes" ]; then
   PKG_CONFIGURE_OPTS_TARGET+=" --enable-swapon"


### PR DESCRIPTION
# Details of the nss-systemd service
- https://www.freedesktop.org/software/systemd/man/latest/nss-systemd.html#

# Background
Updated addon component `nqptp` which previously dropped root privileges has been changed to use CAP_NET_BIND_SERVICE functionality in systemd. Instead of creating a user/group in `/etc/passwd` use the `DynamicUser` systemd functionality. This functionality is independent of the `nss-systemd` service - but to allow user/group resolution - the `nss-systemd` service is required.

## Example status of systemd service using DynamicUser
```
nuc12:~ # systemctl status service.nqptp
● nqptp.service - NQPTP -- Not Quite PTP
     Loaded: loaded (/storage/.config/system.d/nqptp.service; linked; preset: disabled)
     Active: active (running) since Tue 2024-03-05 09:30:38 UTC; 2 days ago
   Main PID: 3698 (nqptp)
      Tasks: 1 (limit: 37511)
     Memory: 236.0K (peak: 340.0K)
        CPU: 16min 49.603s
     CGroup: /system.slice/nqptp.service
             └─3698 /storage/.kodi/addons/service.nqptp/bin/nqptp

Mar 05 09:30:38 nuc12 systemd[1]: Started nqptp.service.
```

## DynamicUser process (without nss-systemd)
```
nuc12:~ # ps -ef | grep nqptp
 3698 62946    16:49 /storage/.kodi/addons/service.nqptp/bin/nqptp
```

## DynamicUser process (with nss-systemd)
```
nuc12:~ # ps -ef | grep nqptp
 3698 nqptp     16:49 /storage/.kodi/addons/service.nqptp/bin/nqptp
```
## Example systemd service using DynamicUser
```
nuc12:~ # cat .config/system.d/service.nqptp.service 
[Unit]
Description=NQPTP -- Not Quite PTP
Wants=network-online.target
After=network.target network-online.target

[Service]
ExecStart=/storage/.kodi/addons/service.nqptp/bin/nqptp
DynamicUser=yes
User=nqptp
Group=nqptp
AmbientCapabilities=CAP_NET_BIND_SERVICE

[Install]                   
WantedBy=kodi.target
```

dynamic user wsdd2 seen below
```
# userdbctl
   NAME                           DISPOSITION        UID   GID REALNAME                     HOME                  SHELL
   root                           intrinsic            0     0 Root User                    /storage              /bin/sh
┌─ ↓ begin system users ↓         system               1     - First system user            -                     -
   avahi                          system              70    70 avahi-daemon                 /var/run/avahi-daemon /bin/sh
   dbus                           system              81    81 System message bus           /                     /bin/sh
   systemd-timesync               system             191   191 -                            /                     /bin/false
   systemd-network                system             193   193 -                            /                     /bin/sh
   systemd-oom                    system             194   194 systemd Userspace OOM Killer /                     /bin/false
   system                         system             430   430 service                      /var/run/connman      /bin/sh
└─ ↑ end system users ↑           system             999     - Last system user             -                     -
┌─ ↓ begin dynamic system users ↓ dynamic          61184     - First dynamic system user    -                     -
   wsdd2                          dynamic          61623 61623 Dynamic User                 /                     /usr/sbin/nologin
└─ ↑ end dynamic system users ↑   dynamic          65519     - Last dynamic system user     -                     -
   nobody                         intrinsic        65534 65534 Nobody                       /                     /bin/sh
┌─ ↓ begin container users ↓      container       524288     - First container user         -                     -
└─ ↑ end container users ↑        container   1879048191     - Last container user          -                     -

10 users listed.
``` 