### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/pcsc-lite/package.mk
+++ b/packages/addons/addon-depends/pcsc-lite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcsc-lite"
-PKG_VERSION="2.0.1"
-PKG_SHA256="5edcaf5d4544403bdab6ee2b5d6c02c6f97ea64eebf0825b8d0fa61ba417dada"
+PKG_VERSION="2.0.3"
+PKG_SHA256="f42ee9efa489e9ff5d328baefa26f9c515be65021856e78d99ad1f0ead9ec85d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pcsclite.apdu.fr"
 PKG_URL="https://pcsclite.apdu.fr/files/pcsc-lite-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpiod"
-PKG_VERSION="2.1"
-PKG_SHA256="fd6ed4b2c674fe6cc3b481880f6cde1eea79e296e95a139b85401eaaea6de3fc"
+PKG_VERSION="2.1.1"
+PKG_SHA256="0af43a6089d69f9d075cf67ca2ae5972b9081e38e6b3d46cea37d67e2df6fb9b"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
 PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.17.05"
-PKG_SHA256="48964a0de5838acfed5c78d78d5f4a1d86974883d5537ccc55df019a0186a1b5"
+PKG_VERSION="0.17.06"
+PKG_SHA256="f81dc1ea7f2a821dab11e46cf3a3a893ad45299e51e6976041306871ddbc7f5d"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="d462213eec758e84079adce0f55fcf6dc201b00b"
-PKG_SHA256="aec60ad7c0ab0badbb0dcf5150aea514ea1c21d4cf73fcb646b0c42c2bdd69f5"
-PKG_VERSION_NUMBER="11726"
-PKG_REV="0"
+PKG_VERSION="eafedca0d96364ca8e1f035cf30afa0f3fa9186b"
+PKG_SHA256="f73130a0ae1a2b8d31cd3f5d2709f04936724fb8d4a69e0c4c1a59f69b107be3"
+PKG_VERSION_NUMBER="11741"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.streamboard.tv/oscam/wiki"

--- a/packages/addons/service/pcscd/package.mk
+++ b/packages/addons/service/pcscd/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="pcscd"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.27.3"
-PKG_SHA256="3fe25b863bb3a0f74bc95a7afa71bdaa2a79971542962236be5d85f469aa897d"
-PKG_REV="0"
+PKG_VERSION="1.27.4"
+PKG_SHA256="6ce00ab281ee5eb0dc73c3664f36235137ca22b2911e375b8feead0038fb80a1"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- system-tools: update addon (1)
  - libgpiod: update to 2.1.1
  - stress-ng: update to 0.17.06
- oscam: update to 11741 and addon (1)
  - pcsc-lite: update to 2.0.3
- pcscd: update addon (1)
  - pcsc-lite: update to 2.0.3
- syncthing: update to 1.27.4 and addon (1)