### PR TITLE
RPi4: enable 4kp60 output by default

### DIFF
--- a/projects/RPi/devices/RPi4/config/config.txt
+++ b/projects/RPi/devices/RPi4/config/config.txt
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
+################################################################################
+# Bootloader configuration
+# config.txt version v1 (do not remove or change this line!)
+################################################################################
+# For more options and information see
+# http://rpf.io/configtxt
+################################################################################
+
+# Default GPU memory split, 76MB are needed for H264 decoder
+gpu_mem=76
+
+# Don't send initial active source message.
+# Avoids bringing CEC (enabled TV) out of standby and channel switch when
+# rebooting.
+hdmi_ignore_cec_init=1
+
+# Enable 4kp60 output on the first HDMI connector
+hdmi_enable_4kp60=1
+
+[all]
+################################################################################
+# Use distroconfig-composite.txt instead of distroconfig.txt to enable
+# composite video output.
+# The composite video mode needs to be configured in cmdline.txt:
+# For PAL add: video=Composite-1:720x576@50ie
+# For NTSC add: video=Composite-1:720x480@60ie
+################################################################################
+include distroconfig.txt
+#include distroconfig-composite.txt
+
+# uncomment to enable analog audio output
+#dtparam=audio=on
+#audio_pwm_mode=1
+
+# uncomment to enable infrared remote receiver connected to GPIO 18
+#dtoverlay=gpio-ir,gpio_pin=18
+


### PR DESCRIPTION
Align RPi4 with RPi5 which supports 4kp60 output OOTB.

Note that this will only affect new installations, config.txt on existing installations won't be altered by this change.