### PR TITLE
mesa: update to 24.0.3

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="24.0.2"
-PKG_SHA256="94e28a8edad06d8ed2b83eb53f253b9eb5aa62c3080f939702e1b3039b56c9e8"
+PKG_VERSION="24.0.3"
+PKG_SHA256="77aec9a2a37b7d3596ea1640b3cc53d0b5d9b3b52abed89de07e3717e91bfdbe"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Hello everyone,

The bugfix release 24.0.3 is now available.

If you find any issues, please report them here:
https://gitlab.freedesktop.org/mesa/mesa/-/issues/new

The next bugfix release is due in two weeks, on March 27th.

Cheers,
  Eric

---

Boyuan Zhang (1):
      meson: bump the minimal required vdpau version to 1.4

Caio Oliveira (1):
      intel/compiler: Fix SIMD lowering when instruction needs a larger SIMD

Chia-I Wu (1):
      aco: fix nir_op_pack_32_4x8 handling

Christian Gmeiner (1):
      etnaviv: Fix how we determine the max supported number of varyings

Corentin Noël (1):
      zink: Return early if the file descriptor could not have been duplicated/acquired

Daniel Schürmann (1):
      radv: fix initialization of radv_shader_layout->use_dynamic_descriptors

Danylo Piliaiev (1):
      tu: Fix dynamic state not always being emitted

David Heidelberg (6):
      drm-shim: Avoid invalid file and time bits combination
      ci/intel: decompose anv-tgl-test so we can specify custom devices for TGL
      ci/intel: add acer-cp514-2h-11{30,60}g7-volteer
      ci/intel: move machine definition to the intel-tgl-skqp job
      ci/intel: split asus-cx9400-volteer into acer-cp514-2h-11{30,60}g7-volteer
      intel/tools: avoid invalid time and file bits combination

David Rosca (1):
      radeonsi/vcn: Use temporal_layer_index to select temporal layer

Eric Engestrom (8):
      docs: add sha256sum for 24.0.2
      .pick_status.json: Update to 7792ee1c15379d95ccb20ce34352473f2bb2bfbd
      .pick_status.json: Update to f3fe1f2f18d7ccc8a7cf85cd88c4bdf426445702
      .pick_status.json: Update to e1afffe7fa7bd8e1cd1f7e58cfa2f33faf889628
      .pick_status.json: Mark a367cd49314a993d09168e790d3090a2303a48d9 as denominated
      .pick_status.json: Update to 9a57b1df5395bbcaa6f48ea851860bedc7ceefb9
      docs: add release notes for 24.0.3
      VERSION: bump for 24.0.3

Eric R. Smith (1):
      panfrost: protect alpha calculation from accessing non-existent component

Faith Ekstrand (4):
      nvk: Return os_page_size for minMemoryMapAlignment
      nvk: Document the register name for the helper load workaround
      nvk: Always wait for the FALCON in set_priv_reg
      nvk: Disable the Out Of Range Address exception

Felix DeGrood (1):
      driconf: add SotTR DX12 to Intel XeSS workaround

Friedrich Vock (3):
      radv/rt: Handle monolithic pipelines in capture/replay
      radv: Set SCRATCH_EN for RT pipelines based on dynamic stack size
      radv/rt: Fix frontface culling with emulated RT

Georg Lehmann (6):
      aco: create pseudo instructions with correct struct
      aco/post-ra: rename overwritten_subdword to allow additional uses
      aco/post-ra: assume scc is going to be overwritten by phis at end of blocks
      aco: store if pseudo instr needs scratch reg
      aco/post-ra: track pseudo scratch sgpr/scc clobber
      aco/ssa_elimination: check if pseudo scratch reg overwrittes regs used for v_cmpx opt

Gert Wollny (2):
      zink: use only ZINK_BIND_DESCRIPTOR
      zink/nir-to-spirv: Make sure sampleid for InterpolateAtSample is int

Ian Romanick (1):
      i915: Fix value returned for PIPE_CAP_MAX_TEXTURE_CUBE_LEVELS

Jesse Natalie (3):
      wgl: Check for stw_device->screen before trying to destroy it
      wgl: Initialize DEVMODE struct
      nir_lower_tex_shadow: For old-style shadows, use vec4(result, 0, 0, 1)

Job Noorman (1):
      ir3: fix alignment of spill slots

Jonathan Gray (1):
      intel/dev: update DG2 device names

Jose Maria Casanova Crespo (1):
      ci: Adds /usr/local/bin to PATH at piglit-traces.sh

José Roberto de Souza (1):
      iris/xe: Consider pat_index while unbinding the bo

Juan A. Suarez Romero (2):
      v3d: add load_fep_w_v3d intrinsic
      v3d: fix line coords with perspective projection

Karol Herbst (1):
      rusticl/event: we need to call the CL_COMPLETE callback on errors as well

Kenneth Graunke (2):
      intel/brw: Allow CSE on TXF_CMS_W_GFX12_LOGICAL
      iris: Fix tessellation evaluation shaders that use scratch

Konstantin Seurer (2):
      radv/rt: Use doubles inside intersect_ray_amd_software_tri
      radv/rt: Fix raygen_imported condition

Lionel Landwerlin (3):
      anv: fix non matching image/view format attachment resolve
      anv: fix incorrect ISL usage in buffer view creation
      anv/iris/blorp: use the right MOCS values for each engine

Mike Blumenkrantz (16):
      zink: apply all storage memory masks to control barriers if no modes are specified
      zink: emit SpvCapabilityImageMSArray for ms arrayed storage images
      zink: null out bo usage when allocating from slab
      zink: fix unsynchronized read-mapping of device-local buffers
      zink: force max buffer alignment on return ptrs for mapped staging buffers
      zink: fix stencil-only blitting with stencil fallback
      vulkan/dispatch_table: add an uncompacted version of the table
      zink: use uncompacted vk_dispatch_table
      egl/dri2: use the right egl platform enum
      zink: stop enabling EXT_conservative_rasterization
      zink: fix PIPE_CAP_MAX_SHADER_PATCH_VARYINGS
      zink: call CmdSetRasterizationStreamEXT when using shader objects
      nvk: bump NVK_PUSH_MAX_SYNCS to 256
      util/blitter: iterate samples in stencil_fallback
      mesa: fix CopyTexImage format compatibility checks for ES
      driconf: add radv_zero_vram for Crystal Project (1637730)

Oskar Viljasaar (1):
      compiler/types: Fix glsl_dvec*_type() helpers

Patrick Lerda (2):
      r300: fix constants_remap_table memory leak
      radeonsi/gfx10: fix main_shader_part_ngg_es memory leak

Pierre-Eric Pelloux-Prayer (1):
      radeonsi: try to disable dcc if compute_blit is the only option

Rhys Perry (1):
      aco: don't combine linear and normal VGPR copies

Robert Beckett (1):
      vulkan/wsi: fix force_bgra8_unorm_first

Rohan Garg (1):
      anv, blorp: Set COMPUTE_WALKER Message SIMD field

Samuel Pitoiset (5):
      radv: fix conditional rendering with direct mesh+task draws and multiview
      radv: fix conditional rendering on compute queue on GFX6
      radv: add missing conditional rendering for indirect dispatches on GFX6
      radv: enable radv_zero_vram for RAGE2
      util/u_debug: fix parsing of "all" again

Simon Ser (1):
      egl/wayland: ensure wl_drm is available before use

Tapani Pälli (4):
      iris: make sure aux is disabled for external objects
      anv: make sure aux is disabled for memory objects
      hasvk: make sure aux is disabled for memory objects
      crocus: make sure aux is disabled for memory objects

Vasily Khoruzhick (4):
      lima: ppir: always use vec4 for output register
      lima: ppir: use dummy program if FS has empty body
      lima: gpir: abort compilation if load_uniform instrinsic src isn't const
      lima: update expected CI failures

Yiwei Zhang (1):
      venus: fix ffb batch prepare for a corner case and avoid a memcpy UB

qbojj (1):
      vulkan: Fix calculation of flags in vk_graphics_pipeline_state_fill

git tag: mesa-24.0.3

https://mesa.freedesktop.org/archive/mesa-24.0.3.tar.xz
SHA256: 77aec9a2a37b7d3596ea1640b3cc53d0b5d9b3b52abed89de07e3717e91bfdbe  mesa-24.0.3.tar.xz
SHA512: 76b3b479877c40f729d7f530af4e3577fa74363edcd3d9474350d498a51dbb761fc034b39bee8547e97c30fd3a520cbc50c742d5a187746e83ddab1df44f37e9  mesa-24.0.3.tar.xz
PGP:  https://mesa.freedesktop.org/archive/mesa-24.0.3.tar.xz.sig