### PR TITLE
Linux 6.6.22

### DIFF
--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20231114"
-PKG_SHA256="cee26f311f7e2c039dd48cd30f995183bde9b98fb4c3039800e2ddaf5c090e55"
+PKG_VERSION="20240312"
+PKG_SHA256="9575c6d74491058bbf998c359d7f25f23655d97a31663a8ed6a98def2b0aaf2b"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"

--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwlwifi-firmware"
-PKG_VERSION="7ea40f2d15a1474f1c2b94a82b0545f5dd7399f8"
-PKG_SHA256="522dd6ec30056fd35ea0ea0385297f5c0c58ae21dd15ce31164c030c5003e2e3"
+PKG_VERSION="a1577a4f28dcc938bdcd892a1dfda3fa72b85117"
+PKG_SHA256="a2d254aef48f368742d217bd1d8d455f77dceb0ea5e0024f7c9a6a27dd48f442"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/iwlwifi-firmware"
 PKG_URL="https://github.com/LibreELEC/iwlwifi-firmware/archive/${PKG_VERSION}.tar.gz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,8 +29,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.6.21"
-    PKG_SHA256="ee0b430148da94d2b13608b8d80b007b7d281dc90e3f19b63cf9a9943810e457"
+    PKG_VERSION="6.6.22"
+    PKG_SHA256="23e3e7b56407250f5411bdab95763d0bc4e3a19dfa431d951df7eacabd61a2f4"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.6.21 Kernel Configuration
+# Linux/x86 6.6.22 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-libreelec-linux-gnu-gcc-13.2.0 (GCC) 13.2.0"
 CONFIG_CC_IS_GCC=y
@@ -500,6 +500,7 @@ CONFIG_CPU_IBRS_ENTRY=y
 CONFIG_CPU_SRSO=y
 # CONFIG_SLS is not set
 # CONFIG_GDS_FORCE_MITIGATION is not set
+CONFIG_MITIGATION_RFDS=y
 CONFIG_ARCH_HAS_ADD_PAGES=y
 
 #


### PR DESCRIPTION
### Linux kernel update for Generic RFDS (Intel) mitigation.
- Fix: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/admin-guide/hw-vuln/reg-file-data-sampling.rst?h=linux-6.6.y

### packages updated
- iwlwifi-firmware: update to githash a1577a4
- intel-ucode: update to 20240312
- linux (Generic): update .config for 6.6.22
- linux: update to 6.6.22

# 6.6.x mainline kernel update

- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.22

6.6.22 - 60 patches

### errors / fixes / issues / regressions / todo
- fixes
  - intel ucode updates
  - Intel iwlwifi 9000 firmware
  - Generic config

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.6.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.6
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/


### 6.6.22 Build tested on all of:

```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.6.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - 6.6.2-rc1 - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.6.22 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum

