### PR TITLE
pipewire: enable possibility of extra config

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -86,6 +86,13 @@ post_install() {
   # note that the pipewire user is added to the audio and video groups in systemd/package.mk
   # todo: maybe there is a better way to add users to groups in the future?
 
+  # config dir in /storage/.config/
+  mkdir -p $INSTALL/usr/config/pipewire
+
+  # symlink for config
+  mkdir -p $INSTALL/etc
+  ln -s /storage/.config/pipewire $INSTALL/etc/pipewire
+
   enable_service pipewire.socket
   enable_service pipewire.service
 }


### PR DESCRIPTION
pipewire is build without the user service and that is fine, because all is running as root.
But no extra config is possible, because /etc/pipewrie is read only and ~/.config/pipewire is not used.
I linked the /etc/pipewrie to ~/.config/pipewire and now extra config is possible.