### PR TITLE
wireplumber: enable possibility of extra config

### DIFF
--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -44,5 +44,16 @@ EOF
 }
 
 post_install() {
+  # config dir in /storage/.config/
+  mkdir -p $INSTALL/usr/config/wireplumber \
+    $INSTALL/usr/config/wireplumber/bluetooth.lua.d \
+    $INSTALL/usr/config/wireplumber/common \
+    $INSTALL/usr/config/wireplumber/main.lua.d \
+    $INSTALL/usr/config/wireplumber/policy.lua.d
+
+  # symlink for config
+  mkdir -p $INSTALL/etc
+  ln -s /storage/.config/wireplumber $INSTALL/etc/wireplumber
+
   enable_service wireplumber.service
 }


### PR DESCRIPTION
wireplumber is build without the user service and that is fine, because all is running as root.
But no extra config is possible, because /etc/wireplumber is read only and ~/.config/wireplumber is not used.
I linked the /etc/wireplumber to ~/.config/wireplumber and now extra config is possible.