### PR TITLE
pipewire: hardwire extra config to ~/.config/pipewire

### DIFF
--- a/packages/audio/pipewire/patches/pipewire-100.01-hardwire-config-to-storage.patch
+++ b/packages/audio/pipewire/patches/pipewire-100.01-hardwire-config-to-storage.patch
@@ -1,0 +1,12 @@
+diff -Naur pipewire-1.0.3/meson.build pipewire-1.0.3.patch/meson.build
+--- pipewire-1.0.3/meson.build	2024-02-02 14:09:07.000000000 +0100
++++ pipewire-1.0.3.patch/meson.build	2024-03-22 11:49:32.002717707 +0100
+@@ -45,7 +45,7 @@
+ pipewire_localedir = prefix / get_option('localedir')
+ pipewire_sysconfdir = prefix / get_option('sysconfdir')
+ 
+-pipewire_configdir = pipewire_sysconfdir / 'pipewire'
++pipewire_configdir = '/storage/.config/pipewire'
+ pipewire_confdatadir = pipewire_datadir / 'pipewire'
+ modules_install_dir = pipewire_libdir / pipewire_name
+ 


### PR DESCRIPTION
pipewire is build without the user service and that is fine, because all is running as root.  
But no extra config is possible, because /etc/pipewrie is read only and ~/.config/pipewire is not used.  
I patched it so the system config dir, for extra config or overrides, is now /storage/.config/pipewire.

Build and tested for Generix 12b1.
```
LibreELEC (sky42): 11.95.1-#240322 (Generic.x86_64)
twang:~ # pw-config
{
  "config.path": "/storage/.config/pipewire/pipewire.conf"
}
twang:~ # rm .config/pipewire/pipewire.conf
twang:~ # pw-config
{
  "config.path": "/usr/share/pipewire/pipewire.conf"
}
```