### PR TITLE
wireplumber: hardwire extra config to ~/.config/wireplumber

### DIFF
--- a/packages/audio/wireplumber/patches/wireplumber-100.01-hardwire-config-to-storage.patch
+++ b/packages/audio/wireplumber/patches/wireplumber-100.01-hardwire-config-to-storage.patch
@@ -1,0 +1,12 @@
+diff -Naur wireplumber-0.4.17/meson.build wireplumber-0.4.17.patch/meson.build
+--- wireplumber-0.4.17/meson.build	2023-12-03 19:05:19.000000000 +0100
++++ wireplumber-0.4.17.patch/meson.build	2024-03-22 11:50:40.226276019 +0100
+@@ -16,7 +16,7 @@
+ wireplumber_bin_dir = get_option('prefix') / get_option('bindir')
+ wireplumber_module_dir = get_option('prefix') / get_option('libdir') / 'wireplumber-' + wireplumber_api_version
+ wireplumber_data_dir = get_option('prefix') / get_option('datadir') / 'wireplumber'
+-wireplumber_config_dir = get_option('prefix') / get_option('sysconfdir') / 'wireplumber'
++wireplumber_config_dir = '/storage/.config/wireplumber'
+ wireplumber_locale_dir = get_option('prefix') / get_option('localedir')
+ 
+ cc = meson.get_compiler('c')


### PR DESCRIPTION
wireplumber is build without the user service and that is fine, because all is running as root.  
But no extra config is possible, because /etc/wireplumber is read only and ~/.config/wireplumber is not used.
I patched it so the system config dir, for extra config or overrides, is now /storage/.config/wireplumber.

@heitbaum The patch applys to 0.5.0 too, but not yet build and config tested. My build system is still busy compiling my 12b1.

Build and tested for Generix 12b1 with a HDMI passthrough config /storage/.config/wireplumber/main.lua.d/51-alsa.lua. Without this file HDMI passthrough does not work, so i am fairly sure the patch does what it is supposed to do.