### PR TITLE
pipewire: enable for all images, but dont start if alsa or pulse in on

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -107,7 +107,7 @@
   PULSEAUDIO_SUPPORT="yes"
 
 # build and install pipewire support (yes / no)
-  PIPEWIRE_SUPPORT="no"
+  PIPEWIRE_SUPPORT="yes"
 
 # build and install eSpeak-NG support (yes / no)
   ESPEAK_SUPPORT="no"
@@ -164,7 +164,7 @@
   KODI_PULSEAUDIO_SUPPORT="yes"
 
 # build kodi with pipewire support (yes/no)
-  KODI_PIPEWIRE_SUPPORT="no"
+  KODI_PIPEWIRE_SUPPORT="yes"
 
 ### KODI ADDONS ###
 

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -86,6 +86,9 @@ post_install() {
   # note that the pipewire user is added to the audio and video groups in systemd/package.mk
   # todo: maybe there is a better way to add users to groups in the future?
 
-  enable_service pipewire.socket
-  enable_service pipewire.service
+  # enable only if pipewire is the only enabled audio backend
+  if [ "${KODI_PIPEWIRE_SUPPORT}" = "yes" -a "${KODI_PULSEAUDIO_SUPPORT}" != "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
+    enable_service pipewire.socket
+    enable_service pipewire.service
+  fi
 }

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -44,5 +44,8 @@ EOF
 }
 
 post_install() {
-  enable_service wireplumber.service
+  # enable only if pipewire is the only enabled audio backend
+  if [ "${KODI_PIPEWIRE_SUPPORT}" = "yes" -a "${KODI_PULSEAUDIO_SUPPORT}" != "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
+    enable_service wireplumber.service
+  fi
 }

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -89,10 +89,6 @@ configure_package() {
   if [ "${KODI_PIPEWIRE_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" pipewire"
     KODI_PIPEWIRE="-DENABLE_PIPEWIRE=ON"
-
-    if [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -o "${KODI_ALSA_SUPPORT}" = "yes" ]; then
-      die "KODI_PULSEAUDIO_SUPPORT and KODI_ALSA_SUPPORT cannot be used with KODI_PIPEWIRE_SUPPORT"
-    fi
   else
     KODI_PIPEWIRE="-DENABLE_PIPEWIRE=OFF"
   fi
@@ -341,17 +337,19 @@ post_makeinstall_target() {
         -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
         -i ${INSTALL}/usr/lib/kodi/kodi.sh
 
-    if [ "${KODI_PIPEWIRE_SUPPORT}" = "yes" ]; then
-      KODI_AUDIO_ARGS="--audio-backend=pipewire"
-    elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+    # define our default audio config
+    # override at runtime in /storage/.config/kodi.conf
+    if [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
       KODI_AUDIO_ARGS="--audio-backend=alsa+pulseaudio"
-    elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
-      KODI_AUDIO_ARGS="--audio-backend=pulseaudio"
     elif [ "${KODI_PULSEAUDIO_SUPPORT}" != "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
       KODI_AUDIO_ARGS="--audio-backend=alsa"
+    elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
+      KODI_AUDIO_ARGS="--audio-backend=pulseaudio"
+    elif [ "${KODI_PIPEWIRE_SUPPORT}" = "yes" ]; then
+      KODI_AUDIO_ARGS="--audio-backend=pipewire"
     fi
 
-    # adjust audio output device to what was built
+    # adjust default audio backend to our preference above
     sed "s/@KODI_AUDIO_ARGS@/${KODI_AUDIO_ARGS}/" ${PKG_DIR}/config/kodi.conf.in > ${INSTALL}/usr/lib/kodi/kodi.conf
 
     # set default display environment

--- a/packages/virtual/image/package.mk
+++ b/packages/virtual/image/package.mk
@@ -21,10 +21,6 @@ PKG_LONGDESC="Root package used to build and create complete image"
 
 [ "${PIPEWIRE_SUPPORT}" = "yes" ] && PKG_DEPENDS_TARGET+=" pipewire wireplumber"
 
-if [ "${PULSEAUDIO_SUPPORT}" = "yes" -a "${PIPEWIRE_SUPPORT}" = "yes" ]; then
-  die "PULSEAUDIO_SUPPORT and PIPEWIRE_SUPPORT cannot be enabled together"
-fi
-
 # Automounter support
 [ "${UDEVIL}" = "yes" ] && PKG_DEPENDS_TARGET+=" udevil"
 


### PR DESCRIPTION
This makes it possible to use pipewire without compiling a extra image. The pipewire and wireplumber services are disabled it any of alsa or pulseaudio is enabled.  
If pipewire is the only enabled kodi audio backend services are enabled.

To use pipewire/wireplumber:
```
systemctl mask pulseaudio.service
systemctl enable pipewire.socket pipewire.service wireplumber.service
sed -i '/^KODI_AUDIO_ARGS=/d' /storage/.config/kodi.conf
echo "KODI_AUDIO_ARGS=\"--audio-backend=pipewire\"" >>/storage/.config/kodi.conf
reboot
```

And back to alsa+pulseaudio
```
systemctl disable pipewire.socket pipewire.service wireplumber.service
systemctl unmask pulseaudio.service
sed -i '/^KODI_AUDIO_ARGS=/d' /storage/.config/kodi.conf
reboot
```

I build it for Generic / RPI and tested on Generic. For testing without building it you can use my community 12b1 builds, where this PR is already included.