### PR TITLE
mariadb: workaround fix for arm32 compiles of 10.11.7

### DIFF
--- a/packages/addons/service/mariadb/patches/1063738-revert-c432c9ef.patch
+++ b/packages/addons/service/mariadb/patches/1063738-revert-c432c9ef.patch
@@ -1,0 +1,23 @@
+Date: Wed, 21 Feb 2024 20:34:12 -0800
+Subject: [PATCH] Revert compile_time_assert() changes from "MDEV-32862 MYSQL struct in C/C and server differs"
+
+This partially reverts commit c432c9ef19bf6ff40ab9551bcae202d7e1319878 which
+most likely caused the regression that broke builds on many 32-bit platforms.
+
+--- a/tests/mysql_client_fw.c
++++ b/tests/mysql_client_fw.c
+@@ -1430,14 +1430,6 @@ int main(int argc, char **argv)
+     tests_to_run[i]= NULL;
+   }
+ 
+-#ifdef _WIN32
+-  /* must be the same in C/C and embedded, 1208 on 64bit, 968 on 32bit */
+-  compile_time_assert(sizeof(MYSQL) == 60*sizeof(void*)+728);
+-#else
+-  /* must be the same in C/C and embedded, 1272 on 64bit, 964 on 32bit */
+-  compile_time_assert(sizeof(MYSQL) == 77*sizeof(void*)+656);
+-#endif
+-
+   if (mysql_server_init(embedded_server_arg_count,
+                         embedded_server_args,
+                         (char**) embedded_server_groups))


### PR DESCRIPTION
- https://jira.mariadb.org/browse/MDEV-33429
- https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/cad4f02094460d54b84de68f61ae1d879ab97222
- https://salsa.debian.org/mariadb-team/mariadb-server/-/raw/cad4f02094460d54b84de68f61ae1d879ab97222/debian/patches/1063738-revert-c432c9ef.patch