### PR TITLE
busybox: init: fix toram when SYSTEM_IMAGE is with path

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -248,8 +248,8 @@ mount_part() {
 
 mount_sysroot() {
   if [ "$SYSTEM_TORAM" = "yes" ]; then
-    cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
-    mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+    cp /flash/$IMAGE_SYSTEM /dev/${IMAGE_SYSTEM//\//_}
+    mount_part "/dev/${IMAGE_SYSTEM//\//_}" "/sysroot" "ro,loop"
   else
     mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
   fi


### PR DESCRIPTION
For the SYSTEM copy to /dev i just replaced / with _ to fix it.  
By choice i did not just use the filename, so one can see which system image is loaded if the path is e.g. /boot/le/12/Generic/SYSTEM.  
As far as i can tell all the rest of init is fine with BOOT_IMAGE and SYSTEM_IMAGE having slashes in there.  
Just toram was broken.

Build Generic, RPi and tested on Generic.