### PR TITLE
busybox: init: fix toram when SYSTEM_IMAGE is with path

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -248,8 +248,8 @@ mount_part() {
 
 mount_sysroot() {
   if [ "$SYSTEM_TORAM" = "yes" ]; then
-    cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
-    mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+    cp "/flash/$IMAGE_SYSTEM" /dev/SYSTEM
+    mount_part "/dev/SYSTEM" "/sysroot" "ro,loop"
   else
     mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
   fi


### PR DESCRIPTION
For the SYSTEM copy to /dev always use /dev/SYSTEM as target name to not deal with fancy path or filenames.  
Thanks @HiassofT for clearing it up for me why it is best using /dev/SYSTEM.  
As far as i can tell all the rest of init is fine with BOOT_IMAGE and SYSTEM_IMAGE having slashes in there.  
Just toram was broken.