### PR TITLE
kodi (Generic): add temp patch to revert xbmc/23921 commit

### DIFF
--- a/projects/Generic/patches/kodi/000-temp-revert-fences.patch
+++ b/projects/Generic/patches/kodi/000-temp-revert-fences.patch
@@ -1,0 +1,456 @@
+diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
+index 9d0065bdaf..535e3bce31 100644
+--- a/xbmc/utils/EGLFence.cpp
++++ b/xbmc/utils/EGLFence.cpp
+@@ -22,14 +22,6 @@ CEGLFence::CEGLFence(EGLDisplay display)
+     m_eglGetSyncAttribKHR(
+         CEGLUtils::GetRequiredProcAddress<PFNEGLGETSYNCATTRIBKHRPROC>("eglGetSyncAttribKHR"))
+ {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-  m_eglDupNativeFenceFDANDROID =
+-      CEGLUtils::GetRequiredProcAddress<PFNEGLDUPNATIVEFENCEFDANDROIDPROC>(
+-          "eglDupNativeFenceFDANDROID");
+-  m_eglClientWaitSyncKHR =
+-      CEGLUtils::GetRequiredProcAddress<PFNEGLCLIENTWAITSYNCKHRPROC>("eglClientWaitSyncKHR");
+-  m_eglWaitSyncKHR = CEGLUtils::GetRequiredProcAddress<PFNEGLWAITSYNCKHRPROC>("eglWaitSyncKHR");
+-#endif
+ }
+ 
+ void CEGLFence::CreateFence()
+@@ -79,65 +71,3 @@ bool CEGLFence::IsSignaled()
+ 
+   return false;
+ }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-EGLSyncKHR CEGLFence::CreateFence(int fd)
+-{
+-  CEGLAttributes<1> attributeList;
+-  attributeList.Add({{EGL_SYNC_NATIVE_FENCE_FD_ANDROID, fd}});
+-
+-  EGLSyncKHR fence =
+-      m_eglCreateSyncKHR(m_display, EGL_SYNC_NATIVE_FENCE_ANDROID, attributeList.Get());
+-
+-  if (fence == EGL_NO_SYNC_KHR)
+-  {
+-    CEGLUtils::Log(LOGERROR, "failed to create EGL sync object");
+-    return nullptr;
+-  }
+-
+-  return fence;
+-}
+-
+-void CEGLFence::CreateGPUFence()
+-{
+-  m_gpuFence = CreateFence(EGL_NO_NATIVE_FENCE_FD_ANDROID);
+-}
+-
+-void CEGLFence::CreateKMSFence(int fd)
+-{
+-  m_kmsFence = CreateFence(fd);
+-}
+-
+-EGLint CEGLFence::FlushFence()
+-{
+-  EGLint fd = m_eglDupNativeFenceFDANDROID(m_display, m_gpuFence);
+-  if (fd == EGL_NO_NATIVE_FENCE_FD_ANDROID)
+-    CEGLUtils::Log(LOGERROR, "failed to duplicate EGL fence fd");
+-
+-  m_eglDestroySyncKHR(m_display, m_gpuFence);
+-
+-  return fd;
+-}
+-
+-void CEGLFence::WaitSyncGPU()
+-{
+-  if (!m_kmsFence)
+-    return;
+-
+-  if (m_eglWaitSyncKHR(m_display, m_kmsFence, 0) != EGL_TRUE)
+-    CEGLUtils::Log(LOGERROR, "failed to create EGL sync point");
+-}
+-
+-void CEGLFence::WaitSyncCPU()
+-{
+-  if (!m_kmsFence)
+-    return;
+-
+-  EGLint status{EGL_FALSE};
+-
+-  while (status != EGL_CONDITION_SATISFIED_KHR)
+-    status = m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR);
+-
+-  m_eglDestroySyncKHR(m_display, m_kmsFence);
+-}
+-#endif
+diff --git a/xbmc/utils/EGLFence.h b/xbmc/utils/EGLFence.h
+index 03c246b60b..bd96444e47 100644
+--- a/xbmc/utils/EGLFence.h
++++ b/xbmc/utils/EGLFence.h
+@@ -30,14 +30,6 @@ public:
+   void DestroyFence();
+   bool IsSignaled();
+ 
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-  void CreateKMSFence(int fd);
+-  void CreateGPUFence();
+-  EGLint FlushFence();
+-  void WaitSyncGPU();
+-  void WaitSyncCPU();
+-#endif
+-
+ private:
+   EGLDisplay m_display{nullptr};
+   EGLSyncKHR m_fence{nullptr};
+@@ -45,17 +37,6 @@ private:
+   PFNEGLCREATESYNCKHRPROC m_eglCreateSyncKHR{nullptr};
+   PFNEGLDESTROYSYNCKHRPROC m_eglDestroySyncKHR{nullptr};
+   PFNEGLGETSYNCATTRIBKHRPROC m_eglGetSyncAttribKHR{nullptr};
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-  EGLSyncKHR CreateFence(int fd);
+-
+-  EGLSyncKHR m_gpuFence{EGL_NO_SYNC_KHR};
+-  EGLSyncKHR m_kmsFence{EGL_NO_SYNC_KHR};
+-
+-  PFNEGLDUPNATIVEFENCEFDANDROIDPROC m_eglDupNativeFenceFDANDROID{nullptr};
+-  PFNEGLCLIENTWAITSYNCKHRPROC m_eglClientWaitSyncKHR{nullptr};
+-  PFNEGLWAITSYNCKHRPROC m_eglWaitSyncKHR{nullptr};
+-#endif
+ };
+ 
+ }
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index f334156d89..34c8c16fe4 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
+   SetFullScreen(true, resMutable, false);
+ }
+ 
+-void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
++void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
+ {
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
+     bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
+   }
+ 
+-  m_DRM->FlipPage(bo, rendered, videoLayer, async);
++  m_DRM->FlipPage(bo, rendered, videoLayer);
+ 
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
+ bool CWinSystemGbm::Hide()
+ {
+   bool ret = m_DRM->SetActive(false);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+ bool CWinSystemGbm::Show(bool raise)
+ {
+   bool ret = m_DRM->SetActive(true);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 879d0f58f8..a800acef6b 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -49,7 +49,7 @@ public:
+   bool DisplayHardwareScalingEnabled() override;
+   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
+ 
+-  void FlipPage(bool rendered, bool videoLayer, bool async);
++  void FlipPage(bool rendered, bool videoLayer);
+ 
+   bool CanDoWindowed() override { return false; }
+   void UpdateResolutions() override;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+index ee27fba1bd..83a59413f7 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+     return false;
+   }
+ 
+-  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
+-      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
+-  {
+-    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+-  }
+-  else
+-  {
+-    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
+-                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
+-  }
+-
+   return true;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+index fbd52354ee..84f863d6d3 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+@@ -9,7 +9,6 @@
+ #pragma once
+ 
+ #include "WinSystemGbm.h"
+-#include "utils/EGLFence.h"
+ #include "utils/EGLUtils.h"
+ #include "windowing/linux/WinSystemEGL.h"
+ 
+@@ -47,8 +46,6 @@ protected:
+   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
+   virtual bool CreateContext() = 0;
+ 
+-  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
+-
+   struct delete_CVaapiProxy
+   {
+     void operator()(CVaapiProxy *p) const;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index adbb539f21..e4ff49c618 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index ad80abf46c..0d071c31f1 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index ff7f137d60..029b5cae81 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
+     }
+ 
+-    if (m_inFenceFd != -1)
+-    {
+-      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
+-      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
+-    }
+   }
+   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
+   {
+@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+               strerror(errno));
+   }
+ 
+-  if (m_inFenceFd != -1)
+-  {
+-    close(m_inFenceFd);
+-    m_inFenceFd = -1;
+-  }
+-
+   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+   {
+     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
+@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   m_req = m_atomicRequestQueue.back().get();
+ }
+ 
+-void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   struct drm_fb *drm_fb = nullptr;
+-  uint32_t flags = 0;
+ 
+   if (rendered)
+   {
+@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
+       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
+       return;
+     }
+-
+-    if (async && !m_need_modeset)
+-      flags |= DRM_MODE_ATOMIC_NONBLOCK;
+   }
+ 
++  uint32_t flags = 0;
++
+   if (m_need_modeset)
+   {
+     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
+index 6b19657587..ca2cd9a1d0 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
+@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
+ public:
+   CDRMAtomic() = default;
+   ~CDRMAtomic() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+index 4e9c3a6b9f..418d067e70 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
+   return true;
+ }
+ 
+-void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   if (rendered || videoLayer)
+   {
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
+index e763f298f7..2b7ff45617 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.h
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
+@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
+ public:
+   CDRMLegacy() = default;
+   ~CDRMLegacy() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
+index f92f716fc4..5327e35570 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.h
++++ b/xbmc/windowing/gbm/drm/DRMUtils.h
+@@ -15,7 +15,6 @@
+ #include "windowing/Resolution.h"
+ #include "windowing/gbm/GBMUtils.h"
+ 
+-#include <utility>
+ #include <vector>
+ 
+ #include <gbm.h>
+@@ -40,7 +39,7 @@ class CDRMUtils
+ public:
+   CDRMUtils() = default;
+   virtual ~CDRMUtils();
+-  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
++  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
+   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
+   virtual bool SetActive(bool active) { return false; }
+   virtual bool InitDrm();
+@@ -63,13 +62,6 @@ public:
+   static uint32_t FourCCWithAlpha(uint32_t fourcc);
+   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
+ 
+-  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
+-  int TakeOutFenceFd()
+-  {
+-    int fd{-1};
+-    return std::exchange(m_outFenceFd, fd);
+-  }
+-
+ protected:
+   bool OpenDrm(bool needConnector);
+   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
+@@ -86,9 +78,6 @@ protected:
+   int m_width = 0;
+   int m_height = 0;
+ 
+-  int m_inFenceFd{-1};
+-  int m_outFenceFd{-1};
+-
+   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
+ 
+ private:
+diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+index bba0db9a53..4270d4ecb2 100644
+--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
++++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
+ public:
+   COffScreenModeSetting() = default;
+   ~COffScreenModeSetting() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
++  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
+   bool SetActive(bool active) override { return false; }
+   bool InitDrm() override;


### PR DESCRIPTION
The change causes kodi to disbale the last image or a black screen when coming out of sleep.

- fixes #8488
- https://github.com/xbmc/xbmc/issues/24760
- https://github.com/xbmc/xbmc/pull/23921
- https://forum.libreelec.tv/thread/28349-kodi-black-screen-after-waking-from-sleep/?postID=190197#post190202