### PR TITLE
RTL8192DU: update to githash b65f878

### DIFF
--- a/packages/linux-drivers/RTL8192DU/package.mk
+++ b/packages/linux-drivers/RTL8192DU/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="RTL8192DU"
-PKG_VERSION="a82c83ec8d1363a8bd1e312378c1ba47971d0012"
-PKG_SHA256="be5ee40f289332b4eb9ca16a978dae5117ae2734b7292229dca09599df45b542"
+PKG_VERSION="b65f87820526cd8835c5cac19fd7e659c84e8215"
+PKG_SHA256="05b387a9d06df98cf444954818eb81d0d145c42d23f706e95cabfa96052ddf03"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/lwfinger/rtl8192du"
 PKG_URL="https://github.com/lwfinger/rtl8192du/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- includes upstreamed fix 6bce4b0c747e81ed0dbeeb4b86d4f90ab65c44a7 from #8759
- log:
  - https://github.com/lwfinger/rtl8192du/compare/a82c83ec8d1363a8bd1e312378c1ba47971d0012...b65f87820526cd8835c5cac19fd7e659c84e8215