### PR TITLE
bento4: update to 1.6.0-641-Omega

### DIFF
--- a/packages/multimedia/bento4/package.mk
+++ b/packages/multimedia/bento4/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bento4"
-PKG_VERSION="1.6.0-639-8-Omega"
-PKG_SHA256="d7fc48e52f0037ce977d7f54c49d4f8936cca0e58447c9ce7c55ab64d268e23d"
+PKG_VERSION="1.6.0-641-Omega"
+PKG_SHA256="f1f8cfa4f7cb651b609e587f825607cb4b06fe5b08af876fd0154a434f9a5315"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.bento4.com"
 PKG_URL="https://github.com/xbmc/Bento4/archive/refs/tags/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
log:
- https://github.com/xbmc/Bento4/compare/1.6.0-639-8-Omega...1.6.0-641-Omega

1.6.0-641-Omega Latest
- Updated to upstream release v1.6.0-641
- Cleanup to remove unused code (from revert commit 1b208a7)