### PR TITLE
samba: update to 4.20.0

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.19.6"
-PKG_SHA256="653b52095554dbc223c63b96af5cdf9e98c3e048549c5f56143d3b33dce1cef1"
+PKG_VERSION="4.20.0"
+PKG_SHA256="02672542510ac6e5d0c91c0c14d90ab4e6ec397c709e952c6da3a6e0b4d5a42f"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.20.0rc1.html
- https://www.samba.org/samba/history/samba-4.20.0rc2.html
- https://www.samba.org/samba/history/samba-4.20.0rc3.html
- https://www.samba.org/samba/history/samba-4.20.0rc4.html
- https://www.samba.org/samba/history/samba-4.20.0.html