### PR TITLE
xz: revert to 5.4.6

### DIFF
--- a/packages/compress/xz/package.mk
+++ b/packages/compress/xz/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xz"
-PKG_VERSION="5.6.1"
-PKG_SHA256="f334777310ca3ae9ba07206d78ed286a655aa3f44eec27854f740c26b2cd2ed0"
-PKG_LICENSE="0BSD"
+PKG_VERSION="5.4.6"
+PKG_SHA256="b92d4e3a438affcf13362a1305cd9d94ed47ddda22e456a42791e630a5644f5c"
+PKG_LICENSE="GPL"
 PKG_SITE="https://tukaani.org/xz/"
 PKG_URL="https://github.com/tukaani-project/xz/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host"


### PR DESCRIPTION
xz release tarballs 5.6.0 and 5.6.1 have been compromised with malicious code

https://www.openwall.com/lists/oss-security/2024/03/29/4
https://github.com/tukaani-project/xz/issues/92

Fixes: #8772