### PR TITLE
libarchive: add upstream patch around error handling

### DIFF
--- a/packages/compress/libarchive/patches/libarchive-upstreamed-more-robust-error-PR2101.patch
+++ b/packages/compress/libarchive/patches/libarchive-upstreamed-more-robust-error-PR2101.patch
@@ -1,0 +1,26 @@
+From e200fd8abfb4cf895a1cab4d89b67e6eefe83942 Mon Sep 17 00:00:00 2001
+From: Ed Maste <emaste@FreeBSD.org>
+Date: Fri, 29 Mar 2024 16:38:11 -0400
+Subject: [PATCH] tar: make error reporting more robust and use correct errno
+
+As discussed in #1609.
+---
+ tar/read.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/tar/read.c b/tar/read.c
+index af3d3f423..a7f14a07b 100644
+--- a/tar/read.c
++++ b/tar/read.c
+@@ -371,8 +371,9 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
+ 			if (r != ARCHIVE_OK) {
+ 				if (!bsdtar->verbose)
+ 					safe_fprintf(stderr, "%s", archive_entry_pathname(entry));
+-				fprintf(stderr, ": %s: ", archive_error_string(a));
+-				fprintf(stderr, "%s", strerror(errno));
++				safe_fprintf(stderr, ": %s: %s",
++				    archive_error_string(a),
++				    strerror(archive_errno(a)));
+ 				if (!bsdtar->verbose)
+ 					fprintf(stderr, "\n");
+ 				bsdtar->return_value = 1;


### PR DESCRIPTION
This adds an upstreamed patch for libarchive that revises a change made by the xz-utils maintainer. Upstream PR here: https://github.com/libarchive/libarchive/pull/2101

Tested by installed and running several addons. Not sure what else uses libarchive.