### PR TITLE
move xz (lzma) support out of sysroot

### DIFF
--- a/packages/compress/xz/package.mk
+++ b/packages/compress/xz/package.mk
@@ -8,21 +8,10 @@ PKG_SHA256="0b54f79df85912504de0b14aec7971e3f964491af1812d83447005807513cd9e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://tukaani.org/xz/"
 PKG_URL="https://github.com/tukaani-project/xz/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_HOST="ccache:host"
 PKG_DEPENDS_TARGET="autotools:host gcc:host"
 PKG_LONGDESC="A free general-purpose data compression software with high compression ratio."
-PKG_BUILD_FLAGS="+pic +pic:host"
+PKG_BUILD_FLAGS="+pic -sysroot"
 PKG_TOOLCHAIN="configure"
-
-# never build shared or k0p happens when building
-# on fedora due to host selinux/liblzma
-PKG_CONFIGURE_OPTS_HOST="--disable-shared --enable-static \
-                         --disable-lzmadec \
-                         --disable-lzmainfo \
-                         --enable-lzma-links \
-                         --disable-nls \
-                         --disable-scripts \
-                         --enable-symbol-versions=no"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -114,6 +114,13 @@ post_make_target() {
   sed -e "s,\([\'|\ ]\)/usr/lib,\1${SYSROOT_PREFIX}/usr/lib,g" -i ${PKG_SYSCONFIG_FILE}
 }
 
+pre_configure_target() {
+  export PYTHON_MODULES_INCLUDE="${TARGET_INCDIR}"
+  export PYTHON_MODULES_LIB="${TARGET_LIBDIR}"
+  export DISABLED_EXTENSIONS="${PKG_PY_DISABLED_MODULES}"
+  export PKG_CONFIG_PATH="$(get_install_dir xz)/usr/lib/pkgconfig:${PKG_CONFIG_PATH}"
+}
+
 post_makeinstall_target() {
   ln -sf ${PKG_PYTHON_VERSION} ${INSTALL}/usr/bin/python
 

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -17,3 +17,9 @@ PKG_LONGDESC="pvr.iptvsimple"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.pvrclient"
+
+pre_configure_target() {
+  ls -la  ../Findlzma.cmake
+  sed -i -e "s#^find_path(LZMA_INCLUDE_DIRS lzma.h#find_path(LZMA_INCLUDE_DIRS lzma.h PATHS $(get_install_dir xz)/usr/include NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH#" \
+         -e "s#^find_library(LZMA_LIBRARIES NAMES lzma liblzma#find_library(LZMA_LIBRARIES NAMES lzma liblzma PATHS $(get_install_dir xz)/usr/lib NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH#" ../Findlzma.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -16,3 +16,9 @@ PKG_LONGDESC="vfs.libarchive"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.vfs"
+
+pre_configure_target() {
+  export LibLZMA_ROOT="$(get_install_dir xz)/usr"
+  sed -i -e 's/^cmake_minimum_required(VERSION 3.5)/cmake_minimum_required(VERSION 3.12)/' \
+         -e 's/^find_package(LibLZMA REQUIRED)/set(CMAKE_FIND_OLD_ROOT_PATH ${CMAKE_FIND_ROOT_PATH})\nset(CMAKE_FIND_ROOT_PATH "")\nfind_package(LibLZMA REQUIRED)\nset(CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_OLD_ROOT_PATH})/' ../CMakeLists.txt
+}


### PR DESCRIPTION
The follow changes allow the xz package to be moved out of sysroot
- The pre_configure_target for vfs.libarchive and pvr.iptvsimple allow xz to be linked in from outside the sysroot

xz:host is actually not used. 
These are the changes to the packages:
- squashfs-tools: drop xz support
  - all images are currently zstd
- toolchain: drop xz:host DEPEND
- linux: drop xz:host DEPEND
- Python3: drop xz:host DEPEND

xz target changes:
- vfs.libarchive: use non sysroot xz
- pvr.iptvsimple: use non sysroot xz
- inputstream.ffmpegdirect: does not use xz

xz: drop host build

This PR maintains xz in the LE image: that being:
- `image/system/usr/lib/python3.11/lib-dynload/_lzma.so`
