### PR TITLE
wireplumber: update to 0.5.2

### DIFF
--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.4.17"
-PKG_SHA256="a12534fd9c1ecf9fbc09f79192d9d57c9ab7bf01da82615ab4103b2f8e2e91a7"
+PKG_VERSION="0.5.1"
+PKG_SHA256="9b776f5481a52f11b30ed46f8baf743534857b74ca3d3dc09a5b1602d5d5a466"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
@@ -25,21 +25,30 @@ post_makeinstall_target() {
   sed '/^\[Service\]/a Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket' -i ${INSTALL}/usr/lib/systemd/system/wireplumber.service
 
   # ref https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/0da29f38181e391160fa8702623050b8544ec775
-  cat > ${INSTALL}/usr/share/wireplumber/main.lua.d/89-disable-session-dbus-dependent-features.lua << EOF
-alsa_monitor.properties["alsa.reserve"] = false
-default_access.properties["enable-flatpak-portal"] = false
+  # ref https://github.com/PipeWire/wireplumber/blob/master/docs/rst/daemon/configuration/migration.rst
+  # ref https://github.com/PipeWire/wireplumber/blob/master/docs/rst/daemon/configuration/features.rst
+  cat > ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-session-dbus-dependent-features.conf << EOF
+wireplumber.profiles = {
+  main = {
+    monitor.alsa.reserve-device = disabled
+    monitor.bluez.seat-monitoring = disabled
+    support.portal-permissionstore = disabled
+  }
+}
 EOF
 
-  cat > ${INSTALL}/usr/share/wireplumber/main.lua.d/89-disable-v4l2.lua << EOF
-v4l2_monitor.enabled = false
+  cat > ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-v4l2.conf << EOF
+wireplumber.profiles = {
+  main = {
+    monitor.v4l2 = disabled
+  }
+}
 EOF
 
-  cat > ${INSTALL}/usr/share/wireplumber/bluetooth.lua.d/89-disable-session-dbus-dependent-features.lua << EOF
-bluez_monitor.properties["with-logind"] = false
-EOF
-
-  cat > ${INSTALL}/usr/share/wireplumber/bluetooth.lua.d/89-disable-bluez-hfphsp-backend.lua << EOF
-bluez_monitor.properties["bluez5.hfphsp-backend"] = "none"
+  cat > ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-bluez-hfphsp-backend.conf << EOF
+monitor.bluez.properties = {
+  bluez5.hfphsp-backend = "none"
+}
 EOF
 }
 

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.5.1"
-PKG_SHA256="9b776f5481a52f11b30ed46f8baf743534857b74ca3d3dc09a5b1602d5d5a466"
+PKG_VERSION="0.5.2"
+PKG_SHA256="24ecc2323f7c39fe577b50903c324cfcbb77b9ea2da01baffd3467c9dbad1d8a"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
includes the migration of the lua config to json as:
- https://www.collabora.com/news-and-blog/blog/2022/10/27/from-lua-to-json-refactoring-wireplumber-configuration-system/
- https://github.com/PipeWire/wireplumber/blob/master/docs/rst/daemon/configuration/migration.rst
+ https://github.com/PipeWire/wireplumber/blob/master/docs/rst/daemon/configuration/features.rst

this version checks the following directories for configurations.
```
strace /usr/bin/wireplumber  2>&1 | grep conf | grep wireplumber

newfstatat(AT_FDCWD, "/storage/.config/wireplumber/wireplumber.conf", 0x7ffc0b543c10, 0) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/etc/xdg/wireplumber/wireplumber.conf", 0x7ffc0b543c10, 0) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/etc/wireplumber/wireplumber.conf", 0x7ffc0b543c10, 0) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/usr/local/share/wireplumber/wireplumber.conf", 0x7ffc0b543c10, 0) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/usr/share/wireplumber/wireplumber.conf", {st_mode=S_IFREG|0644, st_size=22611, ...}, 0) = 0

With these being the files it opened.

openat(AT_FDCWD, "/usr/share/wireplumber/wireplumber.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/usr/share/wireplumber/wireplumber.conf.d/89-disable-bluez-hfphsp-backend.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/usr/share/wireplumber/wireplumber.conf.d/89-disable-session-dbus-dependent-features.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/usr/share/wireplumber/wireplumber.conf.d/89-disable-v4l2.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/usr/share/wireplumber/wireplumber.conf.d/alsa-vm.conf", O_RDONLY|O_CLOEXEC) = 3

```

this has been technical run tested, but validation of the config migration and “does it work as expected” required.