### PR TITLE
systemd: remove timedatectl

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -159,6 +159,9 @@ post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/bin/systemd-nspawn
   safe_remove ${INSTALL}/usr/lib/systemd/system/systemd-nspawn@.service
 
+  # remove timedatectl
+  safe_remove ${INSTALL}/usr/bin/timedatectl
+
   # remove unneeded generators
   for gen in ${INSTALL}/usr/lib/systemd/system-generators/*; do
     case "${gen}" in


### PR DESCRIPTION
This does nothing without timedated enabled:

`Failed to query server: The name org.freedesktop.timedate1 was not provided by any .service files`