### PR TITLE
samba: update to 4.19.6

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.19.5"
-PKG_SHA256="0e2405b4cec29d0459621f4340a1a74af771ec7cffedff43250cad7f1f87605e"
+PKG_VERSION="4.19.6"
+PKG_SHA256="653b52095554dbc223c63b96af5cdf9e98c3e048549c5f56143d3b33dce1cef1"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.19.6.html