### PR TITLE
mesa: update to 24.0.5

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="24.0.4"
-PKG_SHA256="90febd30a098cbcd97ff62ecc3dcf5c93d76f7fa314de944cfce81951ba745f0"
+PKG_VERSION="24.0.5"
+PKG_SHA256="38cc245ca8faa3c69da6d2687f8906377001f63365348a62cc6f7fafb1e8c018"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
@@ -50,10 +50,6 @@ else
   PKG_MESON_OPTS_TARGET+=" -Dplatforms="" \
                            -Ddri3=disabled \
                            -Dglx=disabled"
-fi
-
-if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
-  PKG_MESON_OPTS_TARGET+=" -Dintel-xe-kmd=enabled"
 fi
 
 if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)"; then


### PR DESCRIPTION
Release notes:
- https://lists.freedesktop.org/archives/mesa-announce/2024-April/000754.html

build option change:
- https://gitlab.freedesktop.org/mesa/mesa/-/commit/066c61c7485e24394fe76d17d201bc479f7cbd16

```
=== tested on ===
Generic.x86_64-devel-20240411135107-065d63b
Linux nuc12 6.6.26 #1 SMP Thu Apr 11 13:35:43 UTC 2024 x86_64 GNU/Linux
Starting Kodi (21.0 (21.0.0) Git:21.0-Omega). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-04-09 by GCC 13.2.0 for Linux x86 64-bit version 6.6.25 (394777)
Running on LibreELEC (heitbaum): devel-20240411135107-065d63b 12.0, kernel: Linux x86 64-bit version 6.6.26
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0092.2024.0202.1711 02/02/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.0.5
libva info: VA-API version 1.21.0
vainfo: VA-API version: 1.21 (libva 2.21.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.2.0 (0ef54826e6)
```