### PR TITLE
linux: update to 6.6.26

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,8 +29,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.6.25"
-    PKG_SHA256="99d210be87908233a55b0fadc0dccd3b95926c0651b6b82e37350b2029de1f44"
+    PKG_VERSION="6.6.26"
+    PKG_SHA256="af54b449f4fb93b8e8daa346144a7309e8e95174bd962c4b5917cf56120456d9"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.6.22 Kernel Configuration
+# Linux/x86 6.6.26 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-libreelec-linux-gnu-gcc-13.2.0 (GCC) 13.2.0"
 CONFIG_CC_IS_GCC=y
@@ -501,6 +501,9 @@ CONFIG_CPU_SRSO=y
 # CONFIG_SLS is not set
 # CONFIG_GDS_FORCE_MITIGATION is not set
 CONFIG_MITIGATION_RFDS=y
+# CONFIG_SPECTRE_BHI_ON is not set
+# CONFIG_SPECTRE_BHI_OFF is not set
+CONFIG_SPECTRE_BHI_AUTO=y
 CONFIG_ARCH_HAS_ADD_PAGES=y
 
 #


### PR DESCRIPTION
### packages updated
- linux: update to 6.6.26

# 6.6.x mainline kernel update

- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.26

6.6.26 - 255 patches

### errors / fixes / issues / regressions / todo
- fixes
  - https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2bb69f5fc72183e1c62547d900f560d0e9334925

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.6.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.6
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/


### 6.6.26 Build tested on all of:

```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.6.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - 6.6.2-rc1 - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.6.26 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum
