### PR TITLE
linux: update to 6.6.28

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,8 +29,8 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;
   *)
-    PKG_VERSION="6.6.26"
-    PKG_SHA256="af54b449f4fb93b8e8daa346144a7309e8e95174bd962c4b5917cf56120456d9"
+    PKG_VERSION="6.6.28"
+    PKG_SHA256="818716ed13e7dba6aaeae24e3073993e260812ed128d10272e94b922ee6d3394"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.6.26 Kernel Configuration
+# Linux/x86 6.6.28 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-libreelec-linux-gnu-gcc-13.2.0 (GCC) 13.2.0"
 CONFIG_CC_IS_GCC=y
@@ -501,9 +501,7 @@ CONFIG_CPU_SRSO=y
 # CONFIG_SLS is not set
 # CONFIG_GDS_FORCE_MITIGATION is not set
 CONFIG_MITIGATION_RFDS=y
-# CONFIG_SPECTRE_BHI_ON is not set
-# CONFIG_SPECTRE_BHI_OFF is not set
-CONFIG_SPECTRE_BHI_AUTO=y
+CONFIG_MITIGATION_SPECTRE_BHI=y
 CONFIG_ARCH_HAS_ADD_PAGES=y
 
 #

--- a/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
+++ b/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
@@ -1699,16 +1699,16 @@ index d1ae42757242..7b2cde230b87 100644
  				reg = <1>;
  				remote-endpoint = <&edp_in_vopl>;
 @@ -1227,10 +1222,6 @@ hdmi_in_vopb: endpoint@0 {
- 					reg = <0>;
  					remote-endpoint = <&vopb_out_hdmi>;
  				};
+ 
 -				hdmi_in_vopl: endpoint@1 {
 -					reg = <1>;
 -					remote-endpoint = <&vopl_out_hdmi>;
 -				};
  			};
  		};
- 	};
+ 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 index 92c2207e686c..980b12cb0a49 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi


### PR DESCRIPTION
### packages updated
- linux: update to 6.6.26

# 6.6.x mainline kernel update

- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.27
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.28

6.6.27 - 114 patches
6.6.28 - 122 patches

### errors / fixes / issues / regressions / todo
- fixes
  - Spectre BHI

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.6.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.6
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/


### 6.6.28 Build tested on all of:

```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.6.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - 6.6.2-rc1 - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.6.28 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum
