### PR TITLE
busybox/resizefs: make fs online during resize2fs

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -58,10 +58,12 @@ if [ -e /storage/.please_resize_me ] ; then
     echo "Please do not reboot or turn off your @DISTRONAME@ device!"
     echo ""
 
-    StartProgressLog spinner "Resizing partition...   " "parted -s -f -m $DISK resizepart 2 100% >>$LOG 2>&1"
-    StartProgressLog spinner "Checking file system... " "e2fsck -f -p $PART >>$LOG 2>&1"
-    StartProgressLog spinner "Resizing file system... " "resize2fs $PART >>$LOG 2>&1"
-    StartProgress countdown "Rebooting in 15s...     " 15 "NOW"
+    StartProgressLog spinner "Resizing partition...     " "parted -s -f -m $DISK resizepart 2 100% >>$LOG 2>&1"
+    StartProgressLog spinner "Checking file system...   " "e2fsck -f -p $PART >>$LOG 2>&1"
+    StartProgressLog spinner "Mounting file system...   " "mount $PART /storage >>$LOG 2>&1"
+    StartProgressLog spinner "Resizing file system...   " "resize2fs $PART >>$LOG 2>&1"
+    StartProgressLog spinner "Unmounting file system... " "umount /storage >>$LOG 2>&1"
+    StartProgress countdown "Rebooting in 15s...       " 15 "NOW"
   else
     echo "Partition was not detected - resizing aborted."
     StartProgress countdown "Rebooting in 15s... " 15 "NOW"


### PR DESCRIPTION
see [1] - online resize is recommended

[1] https://bugs.launchpad.net/ubuntu/+source/e2fsprogs/+bug/1796788/comments/2

Some Lakka users (RPi5 / SD card 64/128GB, NVMe drive 2TB) reported that the ext4 partition was not resized properly during the first boot.

fs-resize.log:
```
2023-04-03T20:58:37+00:00
/dev/mmcblk0p2 /storage ext4 rw,noatime 0 0
DISK: /dev/mmcblk0  PART: /dev/mmcblk0p2
*** parted -s -m /dev/mmcblk0 resizepart 2 100% >>/flash/fs-resize.log 2>&1
*** e2fsck -f -p /dev/mmcblk0p2 >>/flash/fs-resize.log 2>&1
LAKKA_DISK: 11/8192 files (9.1% non-contiguous), 1549/8192 blocks
*** resize2fs /dev/mmcblk0p2 >>/flash/fs-resize.log 2>&1
resize2fs 1.47.0 (5-Feb-2023)
resize2fs: Illegal doubly indirect block found while trying to resize /dev/mmcblk0p2
Please run 'e2fsck -fy /dev/mmcblk0p2' to fix the filesystem
after the aborted resize operation.
Resizing the filesystem on /dev/mmcblk0p2 to 29913088 (4k) blocks.
```

First we tried to solve resize issue with forcing 4k blocks in the `scripts/mkimage` script for the `ext4` partition (adding `-b 4096` to `mke2fs` command), but that did not solve the issue - just a note that 4k blocks are mentioned above, but by default `mke2fs` creates the 32MB partition with 1k blocks (difference to upstream).

Mounting the partition before calling `resize2fs` (and unmounting after) resolves the issue.