### PR TITLE
busybox: use mke2fs instead of resize2fs

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -47,10 +47,13 @@ if [ -e /storage/.please_resize_me ] ; then
   rm -f /storage/.please_resize_me
   sync
 
-  echo "DISK: $DISK  PART: $PART" >>$LOG
+  LABEL=$(blkid -o value -s LABEL $PART)
+  UUID=$(blkid -o value -s UUID $PART)
+
+  echo "DISK: $DISK  PART: $PART  LABEL: $LABEL  UUID: $UUID" >>$LOG
 
   # just in case
-  if [ ! -z "$DISK" -a ! -z "$PART" ] ; then
+  if [ ! -z "$DISK" -a ! -z "$PART" -a ! -z "$UUID" ] ; then
     umount $PART
 
     echo "PARTITION RESIZING IN PROGRESS"
@@ -59,8 +62,8 @@ if [ -e /storage/.please_resize_me ] ; then
     echo ""
 
     StartProgressLog spinner "Resizing partition...   " "parted -s -f -m $DISK resizepart 2 100% >>$LOG 2>&1"
+    StartProgressLog spinner "Creating file system... " "mke2fs -F -q -t ext4 -m 0 -L \"$LABEL\" -U \"$UUID\" $PART >>$LOG 2>&1"
     StartProgressLog spinner "Checking file system... " "e2fsck -f -p $PART >>$LOG 2>&1"
-    StartProgressLog spinner "Resizing file system... " "resize2fs $PART >>$LOG 2>&1"
     StartProgress countdown "Rebooting in 15s...     " 15 "NOW"
   else
     echo "Partition was not detected - resizing aborted."


### PR DESCRIPTION
This ensures the /storage filesystem will have the correct options (block size, inode_ratio etc) for the target partition size.
