### PR TITLE
bluez: update to 5.75

### DIFF
--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bluez"
-PKG_VERSION="5.73"
-PKG_SHA256="257e9075ce05c70d48c5defd254e78c418416f7584b45f9dddc884ff88e3fc53"
+PKG_VERSION="5.75"
+PKG_SHA256="988cb3c4551f6e3a667708a578f5ca9f93fc896508f98f08709be4f8ab033c2f"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/bluez/patches/bluez-50-shared-uhid--Fix-crash-if-bt_uhid_destroy-free-replay.patch
+++ b/packages/network/bluez/patches/bluez-50-shared-uhid--Fix-crash-if-bt_uhid_destroy-free-replay.patch
@@ -1,0 +1,45 @@
+From b94f1be656f34ea1363f5566ef63b847234c6dea Mon Sep 17 00:00:00 2001
+From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Date: Mon, 15 Apr 2024 10:48:58 -0400
+Subject: [PATCH] shared/uhid: Fix crash if bt_uhid_destroy free replay
+ structure
+
+Id replay structured has been allocated it shall be set back to NULL
+after calling uhid_replay_free otherwise it may cause the following
+crash:
+
+Invalid read of size 1
+   at 0x1D8FC4: bt_uhid_record (uhid.c:116)
+   by 0x1D912C: uhid_read_handler (uhid.c:158)
+   by 0x201A64: watch_callback (io-glib.c:157)
+   by 0x48D4198: g_main_dispatch.lto_priv.0 (gmain.c:3344)
+   by 0x49333BE: UnknownInlinedFun (gmain.c:4152)
+   by 0x49333BE: g_main_context_iterate_unlocked.isra.0 (gmain.c:4217)
+   by 0x48D4DC6: g_main_loop_run (gmain.c:4419)
+   by 0x2020F4: mainloop_run (mainloop-glib.c:66)
+   by 0x20254B: mainloop_run_with_signal (mainloop-notify.c:188)
+   by 0x12D6D4: main (main.c:1456)
+ Address 0x53ae9c0 is 0 bytes inside a block of size 40 free'd
+   at 0x48468CF: free (vg_replace_malloc.c:985)
+   by 0x1D8E19: uhid_replay_free (uhid.c:68)
+   by 0x1D8E19: uhid_replay_free (uhid.c:59)
+   by 0x1D8E19: bt_uhid_destroy (uhid.c:509)
+   by 0x1591F5: uhid_disconnect (device.c:183)
+
+Fixes: https://github.com/bluez/bluez/issues/815
+---
+ src/shared/uhid.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/shared/uhid.c b/src/shared/uhid.c
+index c1092b707..1f071b958 100644
+--- a/src/shared/uhid.c
++++ b/src/shared/uhid.c
+@@ -507,6 +507,7 @@ int bt_uhid_destroy(struct bt_uhid *uhid)
+ 
+ 	uhid->created = false;
+ 	uhid_replay_free(uhid->replay);
++	uhid->replay = NULL;
+ 
+ 	return err;
+ }


### PR DESCRIPTION
Attempt to address issue reported at https://forum.libreelec.tv/thread/28431-libreelec-omega-12-beta2/?postID=191001#post191001

seems to be addressed in 5.75 (with the post patch) read https://github.com/bluez/bluez/issues/777#issuecomment-2058613174 and the following 2 comments.

post ver 5.75:
- shared/uhid: Fix crash if bt_uhid_destroy free replay structure

ver 5.75:
- Fix issue with build system and header inclusion.

ver 5.74:
- Fix issue with not enabling Wideband Speech when available.
- Fix issue with UserspaceHID and Bluetooth Classic devices.
- Fix issue with checking for services being connected.
- Fix issue with GATT client connection creation.
- Fix issue with OBEX and small file transfers.
- Fix issue with handling pairing with Apple AirPods.

log:
- https://git.kernel.org/pub/scm/bluetooth/bluez.git/log/