### PR TITLE
linux (RPi): update to 6.6.28

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="576cc10e1ed50a9eacffc7a05c796051d7343ea4" # 6.6.28
-    PKG_SHA256="dab3052783c68c46a5bc645b1c38d9705da995ab42823566518b62eb1fa1ef97"
+    PKG_VERSION="5bb5d12217a4a8c5371ab73610dd0a0c38e0f9c1" # 6.6.28
+    PKG_SHA256="c0e2ee047cb968b1e4a04cb15cbcf76d79df10fbea177487e2106789eaaae8c6"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="18851c5d16707ee628bd771da8822e9402ec7a1a" # 6.6.26
-    PKG_SHA256="d9c44392716ec0d89a74efd4b9c4a166e8f8c71a2511e0ad88882c56aee77d0c"
+    PKG_VERSION="576cc10e1ed50a9eacffc7a05c796051d7343ea4" # 6.6.28
+    PKG_SHA256="dab3052783c68c46a5bc645b1c38d9705da995ab42823566518b62eb1fa1ef97"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="b654c77c1dc1f57d92a2f014bdcd8cb9d4f51640" # 6.6.26
-    PKG_SHA256="da957b7b2df490a074536461f2105dc4bc0bf47eda4e2be903ddbfb4a441763c"
+    PKG_VERSION="18851c5d16707ee628bd771da8822e9402ec7a1a" # 6.6.26
+    PKG_SHA256="d9c44392716ec0d89a74efd4b9c4a166e8f8c71a2511e0ad88882c56aee77d0c"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="45319db29eb5e4f67feab5c4194bc1f28c574ed0"
-PKG_SHA256="3e23e77ad27cb6a61b43b3ff82d9a56b4d075e5ad1ebcbe985c86c68dad4fd40"
+PKG_VERSION="5476720d52cf579dc1627715262b30ba1242525e"
+PKG_SHA256="91430d6b50cd85e4cab0bd9ca12967a5f08b18b43ff4d9fed65676a932d7d302"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="c0a207f4524418d4f7d7266934dc7a1ae92110bf"
-PKG_SHA256="e89a7e30de7d34fe65165b8fe20b44c7d772bf79a051f1352f903d03b3412522"
+PKG_VERSION="7a1a01c24f48f800ff9ac6fe43fe1e109abf5f9d"
+PKG_SHA256="ace758ba263927e5a568c8e89f362d1b15c0041dbae797ee22c83cb0f44380b1"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="61023cbd32725a07e094f9b2d01df302f4ddabba"
-PKG_SHA256="be98e4a81a4816e66ea6ccb53e7db9490c19f19a87b0c7115cac4f875dc8f465"
+PKG_VERSION="c0a207f4524418d4f7d7266934dc7a1ae92110bf"
+PKG_SHA256="e89a7e30de7d34fe65165b8fe20b44c7d772bf79a051f1352f903d03b3412522"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Runtime tested on RPi4 and RPi5

This should fix the Hifiberry DAC+ Pro and video decode issues reported on the forum
https://forum.libreelec.tv/thread/28386-rpi-4-choppy-audio-with-hifiberry-dac2-pro/
https://forum.libreelec.tv/thread/28391-cvideoplayeraudio-process-stream-stalled/