### PR TITLE
Optional systemd-nspawn support

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -193,6 +193,9 @@
   DEBUG_GROUPS="kodi+=kodi+,kodi-platform+,p8-platform+,!mesa"
   DEBUG_GROUP_YES="kodi+"
 
+# include systemd-nspawn support (yes / no)
+  NSPAWN_SUPPORT="no"
+
 # build and install iSCSI support - iscsistart (yes / no)
   ISCSI_SUPPORT="no"
 

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -265,6 +265,9 @@ post_makeinstall_target() {
   ln -sf /storage/.config/logind.conf.d ${INSTALL}/etc/systemd/logind.conf.d
   ln -sf /storage/.config/sleep.conf.d ${INSTALL}/etc/systemd/sleep.conf.d
   ln -sf /storage/.config/timesyncd.conf.d ${INSTALL}/etc/systemd/timesyncd.conf.d
+  if [ "${NSPAWN_SUPPORT}" = "yes" ]; then
+    ln -sf /storage/.config/nspawn ${INSTALL}/etc/systemd/nspawn
+  fi
   safe_remove ${INSTALL}/etc/sysctl.d
   ln -sf /storage/.config/sysctl.d ${INSTALL}/etc/sysctl.d
   safe_remove ${INSTALL}/etc/tmpfiles.d

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -63,7 +63,6 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dlogind=true \
                        -Dhostnamed=true \
                        -Dlocaled=false \
-                       -Dmachined=false \
                        -Dportabled=false \
                        -Duserdb=false \
                        -Dhomed=disabled \
@@ -106,6 +105,12 @@ if [ "${PROJECT}" = "Generic" ]; then
   PKG_MESON_OPTS_TARGET+=" -Defi=true"
 else
   PKG_MESON_OPTS_TARGET+=" -Defi=false"
+fi
+
+if [ "${NSPAWN_SUPPORT}" = "yes" ]; then
+  PKG_MESON_OPTS_TARGET+=" -Dmachined=true"
+else
+  PKG_MESON_OPTS_TARGET+=" -Dmachined=false"
 fi
 
 pre_configure_target() {
@@ -156,8 +161,10 @@ post_makeinstall_target() {
   sed '/^ConditionNeedsUpdate=.*$/d' -i ${INSTALL}/usr/lib/systemd/system/systemd-hwdb-update.service
 
   # remove nspawn
-  safe_remove ${INSTALL}/usr/bin/systemd-nspawn
-  safe_remove ${INSTALL}/usr/lib/systemd/system/systemd-nspawn@.service
+  if [ ${NSPAWN_SUPPORT} != "yes" ]; then
+    safe_remove ${INSTALL}/usr/bin/systemd-nspawn
+    safe_remove ${INSTALL}/usr/lib/systemd/system/systemd-nspawn@.service
+  fi
 
   # remove timedatectl
   safe_remove ${INSTALL}/usr/bin/timedatectl

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -164,6 +164,10 @@ post_makeinstall_target() {
   if [ ${NSPAWN_SUPPORT} != "yes" ]; then
     safe_remove ${INSTALL}/usr/bin/systemd-nspawn
     safe_remove ${INSTALL}/usr/lib/systemd/system/systemd-nspawn@.service
+    safe_remove ${INSTALL}/usr/lib/tmpfiles.d/z_02_systemd-nspawn.conf
+    safe_remove ${INSTALL}/usr/lib/systemd/system/nspawn-symlink.service
+  else
+    find_file_path scripts/nspawn-symlink && cp -PRv ${FOUND_PATH} ${INSTALL}/usr/bin
   fi
 
   # remove timedatectl
@@ -313,4 +317,7 @@ post_install() {
   enable_service network-base.service
   enable_service systemd-timesyncd.service
   enable_service systemd-timesyncd-setup.service
+  if [ "${NSPAWN_SUPPORT}" = "yes" ]; then
+    enable_service nspawn-symlink.service
+  fi
 }

--- a/packages/sysutils/systemd/scripts/nspawn-symlink
+++ b/packages/sysutils/systemd/scripts/nspawn-symlink
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for entry in $(find /storage/containers -mindepth 1 -maxdepth 1); do
+    ln -s "${entry}" /var/lib/machines/
+done

--- a/packages/sysutils/systemd/system.d/nspawn-symlink.service
+++ b/packages/sysutils/systemd/system.d/nspawn-symlink.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Make symlinks from /storage/containers to /var/lib/machines
+After=systemd-tmpfiles-setup.service
+Requires=systemd-tmpfiles-setup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/nspawn-symlink
+RemainAfterExit=yes
+
+[Install]
+WantedBy=basic.target

--- a/packages/sysutils/systemd/tmpfiles.d/z_02_systemd-nspawn.conf
+++ b/packages/sysutils/systemd/tmpfiles.d/z_02_systemd-nspawn.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2024-present Team LibreELEC (https://libreleec.tv)
+
+d       /storage/containers     0755    root root - -


### PR DESCRIPTION
This adds systemd-nspawn and machined to the image, locked behind the NSPAWN_SUPPORT distribution option. It's not enabled by default.

Systemd-nspawn is systemd's chroot, container, and virtual machine manager. This has enough for the first two; VM support is unknown and not my interest. It can run whole OSes, or single applications. I've only tested running an OS. My understanding is that it can run images made by docker (via --oci-bundle=), but I haven't tried it.

/var/lib/machines is the recommended location containers are expected. This has a helper service to get that populated based on the contents of /storage/containers. 

systemd-nspawn, machinectl, and systemd-machined combined are somewhere around 600KB uncompressed.

If you're going to try it, and want containers to start on boot, `machines.target` needs to be enabled first (the machine too).

If using a full OS, machinectl's login defaults the terminal to vt220, so no color on the console. Add an environment override in the container to set TERM to xterm to get color back. Alternatively, use machinectl shell or systemd-nspawn directly to avoid this.