### PR TITLE
tvheadend43: remove alpha label

### DIFF
--- a/packages/addons/service/tvheadend43/package.mk
+++ b/packages/addons/service/tvheadend43/package.mk
@@ -19,7 +19,7 @@ PKG_LONGDESC="Tvheadend (${PKG_VERSION_NUMBER}): is a TV streaming server for Li
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_IS_ADDON="yes"
-PKG_ADDON_NAME="Tvheadend Server 4.3 (Alpha)"
+PKG_ADDON_NAME="Tvheadend Server 4.3"
 PKG_ADDON_TYPE="xbmc.service"
 
 # basic transcoding options


### PR DESCRIPTION
Tvheadend 4.3 is the recommended version for users to install (4.2 is effectively EOL) so remove the "Alpha" label.