### PR TITLE
usbmuxd: remove sed errors

### DIFF
--- a/packages/addons/addon-depends/libusbmuxd/package.mk
+++ b/packages/addons/addon-depends/libusbmuxd/package.mk
@@ -18,7 +18,9 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
 
 configure_package() {
   # if using a git hash as a package version - set RELEASE_VERSION
-  export RELEASE_VERSION="$(sed -n '1,/RE/s/Version \(.*\)/\1/p' ${PKG_BUILD}/NEWS)-git-${PKG_VERSION:0:7}"
+  if [ -f ${PKG_BUILD}/NEWS ]; then
+    export RELEASE_VERSION="$(sed -n '1,/RE/s/Version \(.*\)/\1/p' ${PKG_BUILD}/NEWS)-git-${PKG_VERSION:0:7}"
+  fi
 }
 
 post_configure_target() {

--- a/packages/addons/service/usbmuxd/package.mk
+++ b/packages/addons/service/usbmuxd/package.mk
@@ -26,7 +26,9 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
 
 configure_package() {
   # if using a git hash as a package version - set RELEASE_VERSION
-  export RELEASE_VERSION="$(sed -n '1,/RE/s/Version \(.*\)/\1/p' ${PKG_BUILD}/NEWS)-git-${PKG_VERSION:0:7}"
+  if [ -f ${PKG_BUILD}/NEWS ]; then
+    export RELEASE_VERSION="$(sed -n '1,/RE/s/Version \(.*\)/\1/p' ${PKG_BUILD}/NEWS)-git-${PKG_VERSION:0:7}"
+  fi
 }
 
 post_configure_target() {


### PR DESCRIPTION
NEWS file is not present yet.
```
sed: can't read /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/usbmuxd-360619c5f721f93f0b9d8af1a2df0b926fbcf281/NEWS: No such file or directory
sed: can't read /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/usbmuxd-360619c5f721f93f0b9d8af1a2df0b926fbcf281/NEWS: No such file or directory
sed: can't read /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/usbmuxd-360619c5f721f93f0b9d8af1a2df0b926fbcf281/NEWS: No such file or directory
UNPACK      usbmuxd
sed: can't read /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/usbmuxd-360619c5f721f93f0b9d8af1a2df0b926fbcf281/NEWS: No such file or directory
UNPACK      libimobiledevice-glue
    FIXCONFIG      /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/libimobiledevice-glue-1.2.0/
BUILD      libimobiledevice-glue (target)
    TOOLCHAIN      autotools
    AUTORECONF      libimobiledevice-glue
autoreconf: export WARNINGS=
autoreconf: Entering directory '/data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/libimobiledevice-glue-1.2.0'
```