### PR TITLE
[le12] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="21.4.5-Omega"
-PKG_SHA256="6e7d217b239f7cb935fd4f4024353ba995fcdb47078a35e0ae51ee5dcf8c8de8"
-PKG_REV="2"
+PKG_VERSION="21.4.6-Omega"
+PKG_SHA256="0729f28feed662a36ad5bbce92ff457030cde01f28352bab6e8571a7be0cb88d"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/inputstream.adaptive"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="21.1.14-Omega"
-PKG_SHA256="a8d5a726fd280ac576ab2bc6fda9d8e641f6c9a59b7b2c69d31b14e1827c72f6"
+PKG_VERSION="21.1.15-Omega"
+PKG_SHA256="b152c6f17291ede48850bf307e6d619ff803e1b26217ccec532d5c49a3ef7b84"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="21.0.3-Omega"
-PKG_SHA256="0389ccf10b67967dd08ee9c8e8200b0b3bec81527ac00e5263b1c7ae53f503ab"
-PKG_REV="2"
+PKG_VERSION="21.1.0-Omega"
+PKG_SHA256="220e292c58d22b3064f1ea6a717341d9d004384791aec8b409d6653b91817085"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.nextpvr"


### PR DESCRIPTION
- inputstream.adaptive: update 21.4.5-Omega to 21.4.6-Omega
- peripheral.joystick: update 21.1.14-Omega to 21.1.15-Omega
- pvr.nextpvr: update 21.0.3-Omega to 21.1.0-Omega