### PR TITLE
Update Atari emulators for authetic buttonmaps

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro.a5200/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.a5200/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.a5200"
-PKG_VERSION="2.0.2.15-Nexus"
-PKG_SHA256="eb49aa0dc4f3e7d8798af3de503274f92f63469695ffc619aaca8131966203d1"
-PKG_REV="2"
+PKG_VERSION="2.0.2.17-Nexus"
+PKG_SHA256="6bf181be1c93dd510be1491712ffb695c9db87ee19c3ef7bbd4a78a4bcaed1cf"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/kodi-game/game.libretro.a5200"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.atari800"
-PKG_VERSION="3.1.0.33-Nexus"
-PKG_SHA256="7211f8f1c62e685788c9161b4b8849384df06acea9b6c94f7c77273f59a8423d"
-PKG_REV="2"
+PKG_VERSION="3.1.0.34-Nexus"
+PKG_SHA256="5501e28d28a91857b07276285f7e25d4a03ea6ff0a2afee89145fe85cd3c3882"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.atari800"


### PR DESCRIPTION
## Description

This PR updates the two Atari emulators for the recent buttonmap changes that make controllers act closer to the original hardware.

For more info, see the tracking issue: https://github.com/kodi-game/controller-topology-project/issues/303

Includes the following changes:

* atari800 - https://github.com/kodi-game/game.libretro.atari800/pull/7
* a5200 - https://github.com/kodi-game/game.libretro.a5200/pull/1

## How has this been tested?

I verified that the latest versions were on the Kodi mirrors:

![screenshot00002](https://github.com/LibreELEC/LibreELEC.tv/assets/531482/f78d8693-9c1a-4666-873c-a7e49a7c5eed)

![screenshot00003](https://github.com/LibreELEC/LibreELEC.tv/assets/531482/959648ad-6bdd-4302-8830-cdf26ae26a26)
