### PR TITLE
amlogic: include rtl8761bu firmware

### DIFF
--- a/projects/Amlogic/config/kernel-firmware.dat
+++ b/projects/Amlogic/config/kernel-firmware.dat
@@ -17,6 +17,8 @@ rtw88/rtw8822c_fw.bin
 rtw88/rtw8822c_wow_fw.bin
 rtl_bt/rtl8723bs_fw.bin
 rtl_bt/rtl8723bs_config-OBDA8723.bin
+rtl_bt/rtl8761bu_config.bin
+rtl_bt/rtl8761bu_fw.bin
 rtl_bt/rtl8821c_config.bin
 rtl_bt/rtl8821c_fw.bin
 rtl_bt/rtl8822cs_config.bin


### PR DESCRIPTION
Pick the rtl8176bu firmware for future AMLGX LE12 images. Fixes #8853. I'll submit the same change to master along with a kernel bump in the near future.