### PR TITLE
Rockchip: rk3328 and rk339 builds are 64bit, fix build instructions in README.md

### DIFF
--- a/projects/Rockchip/devices/RK3328/README.md
+++ b/projects/Rockchip/devices/RK3328/README.md
@@ -4,9 +4,9 @@ This is a SoC device for RK3328
 
 **Build**
 
-* `PROJECT=Rockchip DEVICE=RK3328 ARCH=arm UBOOT_SYSTEM=a1 make image`
-* `PROJECT=Rockchip DEVICE=RK3328 ARCH=arm UBOOT_SYSTEM=roc-cc make image`
-* `PROJECT=Rockchip DEVICE=RK3328 ARCH=arm UBOOT_SYSTEM=rock64 make image`
+* `PROJECT=Rockchip DEVICE=RK3328 ARCH=aarch64 UBOOT_SYSTEM=a1 make image`
+* `PROJECT=Rockchip DEVICE=RK3328 ARCH=aarch64 UBOOT_SYSTEM=roc-cc make image`
+* `PROJECT=Rockchip DEVICE=RK3328 ARCH=aarch64 UBOOT_SYSTEM=rock64 make image`
 
 **How to use on an Android device**
 - Flash image to a sd-card

--- a/projects/Rockchip/devices/RK3399/README.md
+++ b/projects/Rockchip/devices/RK3399/README.md
@@ -4,16 +4,16 @@ This is a SoC device for RK3399
 
 **Build**
 
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=hugsun-x99 make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=khadas-edge make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=nanopc-t4 make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=nanopi-m4 make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=orangepi make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock960 make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-4 make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-4-plus make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rock-pi-n10 make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=rockpro64 make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=roc-pc make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=roc-pc-plus make image`
-* `PROJECT=Rockchip DEVICE=RK3399 ARCH=arm UBOOT_SYSTEM=sapphire make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=hugsun-x99 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=khadas-edge make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=nanopc-t4 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=nanopi-m4 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=orangepi make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=rock960 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=rock-pi-4 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=rock-pi-4-plus make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=rock-pi-n10 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=rockpro64 make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=roc-pc make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=roc-pc-plus make image`
+* `PROJECT=Rockchip DEVICE=RK3399 ARCH=aarch64 UBOOT_SYSTEM=sapphire make image`


### PR DESCRIPTION
Fixed build commands in the README.md file to comply with the move to 64-bit architecture.

Cheers
Michele