### PR TITLE
gcc: update to 14.1

### DIFF
--- a/packages/addons/addon-depends/argtable2/patches/argtable2-01_fix_gcc-14_build.patch
+++ b/packages/addons/addon-depends/argtable2/patches/argtable2-01_fix_gcc-14_build.patch
@@ -1,0 +1,22 @@
+From 812680199b0e474c83cdc8bd331178afcaaad862 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 4 May 2024 12:07:33 +0000
+Subject: [PATCH] fix build with gcc-14
+
+add missing header
+---
+ src/arg_int.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/arg_int.c b/src/arg_int.c
+index 29c20e5..bc5ab06 100644
+--- a/src/arg_int.c
++++ b/src/arg_int.c
+@@ -27,6 +27,7 @@ USA.
+ /* #ifdef HAVE_STDLIB_H */
+ #include <stdlib.h>
+ /* #endif */
++#include <ctype.h>
+ 
+ #include "argtable2.h"
+ #include <limits.h>

--- a/packages/addons/addon-depends/dvb-tools-depends/t2scan/patches/t2scan-15-fix-building-with-gcc-14.1.0.patch
+++ b/packages/addons/addon-depends/dvb-tools-depends/t2scan/patches/t2scan-15-fix-building-with-gcc-14.1.0.patch
@@ -1,0 +1,104 @@
+From 40f5e11bf9977f5daf48c15a899d17814557fc5b Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 7 May 2024 17:34:47 +1000
+Subject: [PATCH 1/3] fix building with gcc-14.1
+
+../countries.c: In function 'choose_country':
+../countries.c:121:84: error: assignment to 'int *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
+  121 |                    plplist[0] = -1; plplist[1] = 1; plplist[2] = 0; plplist_length = 3;
+      |
+---
+ countries.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/countries.c b/countries.c
+index b61d86d..6295cd5 100644
+--- a/countries.c
++++ b/countries.c
+@@ -118,7 +118,8 @@ int choose_country (const char * country,
+ 
+                 case    AT:     //      AUSTRIA
+                 case    IT:     //      ITALY
+-                   plplist[0] = -1; plplist[1] = 1; plplist[2] = 0; plplist_length = 3;
++                   plplist[0] = -1; plplist[1] = 1; plplist[2] = 0;
++                   *plplist_length = 3;
+                 case    BE:     //      BELGIUM
+                 case    CH:     //      SWITZERLAND
+                 case    CO:     //      COLOMBIA, DVB-C + DVB-T2
+
+From b3e1a2b588134f3c546ba0e9a15511da38a8fdc6 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 7 May 2024 17:40:25 +1000
+Subject: [PATCH 2/3] fix calloc warnings
+
+warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
+---
+ parse-dvbscan.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/parse-dvbscan.c b/parse-dvbscan.c
+index 72f1cb8..11950b9 100644
+--- a/parse-dvbscan.c
++++ b/parse-dvbscan.c
+@@ -128,7 +128,7 @@ void parse_t2scan_flags(const char * input_buffer, struct t2scan_flags * flags)
+ 
+ int dvbscan_parse_tuningdata(const char * tuningdata, struct t2scan_flags * flags) {
+         FILE * initdata = NULL;
+-        char * buf = (char *) calloc(sizeof(char), MAX_LINE_LENGTH);
++        char * buf = (char *) calloc(MAX_LINE_LENGTH, sizeof(char));
+         enum __dvbscan_args arg;
+         struct transponder * tn;
+         int count = 0;
+@@ -147,7 +147,7 @@ int dvbscan_parse_tuningdata(const char * tuningdata, struct t2scan_flags * flag
+                 }
+ 
+         while (fgets(buf, MAX_LINE_LENGTH, initdata) != NULL) {
+-                char * copy = (char *) calloc(sizeof(char), strlen(buf) + 1);
++                char * copy = (char *) calloc(strlen(buf) + 1, sizeof(char));
+                 char * token;
+ 
+                 if (copy == NULL) {
+
+From d5071e9fdb3f14194f72ead51d1353b6c05caa80 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 8 May 2024 08:19:11 +1000
+Subject: [PATCH 3/3] fix building with gcc-14.1
+
+fixes:
+
+../scan.c: In function 'network_scan':
+../scan.c:2413:29: error: assignment to 'int *' from incompatible pointer type 'int (*)[256]' [-Wincompatible-pointer-types]
+ 2413 |                  my_plplist = &plplist;
+      |                             ^
+../scan.c:2417:29: error: assignment to 'int *' from incompatible pointer type 'int (*)[256]' [-Wincompatible-pointer-types]
+ 2417 |                  my_plplist = &user_plplist;
+      |                             ^
+../scan.c:2420:29: error: assignment to 'int *' from incompatible pointer type 'int (*)[256]' [-Wincompatible-pointer-types]
+ 2420 |                  my_plplist = &plplist;
+      |                             ^
+---
+ scan.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scan.c b/scan.c
+index 17fdb3c..5341a1a 100644
+--- a/scan.c
++++ b/scan.c
+@@ -2410,14 +2410,14 @@ static void network_scan(int frontend_fd, int tuning_data) {
+               // plp loop
+               if (delsys == SYS_DVBT2 && (!multistream)) {
+                  // multistream is not supported, so use plp id -1 ("autodetection") as only value to scan
+-                 my_plplist = &plplist;
++                 my_plplist = plplist;
+                  my_plplist[0] = -1;
+                  my_plplist_length = 1;
+               } else if (delsys == SYS_DVBT2 && use_user_plplist) {
+-                 my_plplist = &user_plplist;
++                 my_plplist = user_plplist;
+                  my_plplist_length = user_plplist_length;
+               } else if (delsys == SYS_DVBT2) {
+-                 my_plplist = &plplist;
++                 my_plplist = plplist;
+                  my_plplist_length = plplist_length;
+               } else {
+                  // for legacy DVB-T (or ATSC) there is nothing such as PLPs

--- a/packages/addons/addon-depends/multimedia-tools-depends/opencaster/patches/opencaster-04_fix-gcc-14-build.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/opencaster/patches/opencaster-04_fix-gcc-14-build.patch
@@ -1,0 +1,64 @@
+From 667f3fc30ab8e4cabedb03cf13ba5729858b2211 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 4 May 2024 11:10:47 +0000
+Subject: [PATCH] fix build with gcc-14
+
+---
+ tools/dsmcc-receive/carousel.c | 1 +
+ tools/mpe2sec/mpe.c            | 2 +-
+ tools/sec2ts/sec2ts.c          | 4 +++-
+ tools/tsdiscont/tsdiscont.c    | 1 +
+ 4 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/tools/dsmcc-receive/carousel.c b/tools/dsmcc-receive/carousel.c
+index 40547ef..44da078 100644
+--- a/tools/dsmcc-receive/carousel.c
++++ b/tools/dsmcc-receive/carousel.c
+@@ -32,6 +32,7 @@
+ #include "dsmcc.h"
+ #include "biop.h"
+ #include "utils.h"
++#include "filter.h"
+ 
+ 
+ int
+diff --git a/tools/mpe2sec/mpe.c b/tools/mpe2sec/mpe.c
+index 18417af..3d30fd7 100644
+--- a/tools/mpe2sec/mpe.c
++++ b/tools/mpe2sec/mpe.c
+@@ -29,7 +29,7 @@ static char padding[184];
+ static char ip_device[IFNAMSIZ];
+ static char s[180];
+ static const char *Id = "$Id: mpe.c 25 2011-10-13 15:35:18Z jfbcable $";
+-const MPE_HEADER_LEN=12;
++const int MPE_HEADER_LEN=12;
+ int tun_fd = -1;
+ 
+ #ifdef IFF_TUN
+diff --git a/tools/sec2ts/sec2ts.c b/tools/sec2ts/sec2ts.c
+index b97fff4..7b8c884 100644
+--- a/tools/sec2ts/sec2ts.c
++++ b/tools/sec2ts/sec2ts.c
+@@ -154,7 +154,9 @@ int main(int argc, char *argv[])
+ 	/* Start to process sections */
+ 	not_finished = 1;
+ 	if(stuff){
+-		section_next = 1;
++		// this is bad code as it is used as a flag in the below while loop
++		// cast the 1 to pointer to allow compile with gcc-14
++		section_next = (unsigned char *) 1;
+ 	} else {
+ 		section_next = get_section(&section_size_next, fd_in);
+ 	}
+diff --git a/tools/tsdiscont/tsdiscont.c b/tools/tsdiscont/tsdiscont.c
+index e6f6cd1..19e3398 100644
+--- a/tools/tsdiscont/tsdiscont.c
++++ b/tools/tsdiscont/tsdiscont.c
+@@ -24,6 +24,7 @@
+ #include <stdlib.h>
+ #include <sys/types.h>
+ #include <inttypes.h>
++#include <arpa/inet.h>
+ 
+ #define TS_HEADER_SIZE 4
+ #define TS_PACKET_SIZE 188

--- a/packages/addons/addon-depends/multimedia-tools-depends/tsdecrypt/patches/tsdecrypt-01_fix_gcc-14_build.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/tsdecrypt/patches/tsdecrypt-01_fix_gcc-14_build.patch
@@ -1,0 +1,47 @@
+From 70e4aa204cf7809c91b782fa59646dfa11bad53f Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 4 May 2024 11:33:54 +0000
+Subject: [PATCH] fix build with gcc-14
+
+---
+ camd-newcamd.c | 1 +
+ filter.c       | 1 +
+ process.c      | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/camd-newcamd.c b/camd-newcamd.c
+index 48ad567..0d87735 100644
+--- a/camd-newcamd.c
++++ b/camd-newcamd.c
+@@ -18,6 +18,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <crypt.h>
+ 
+ #include "libfuncs/libfuncs.h"
+ 
+diff --git a/filter.c b/filter.c
+index 2cac2dc..ea440e9 100644
+--- a/filter.c
++++ b/filter.c
+@@ -14,6 +14,7 @@
+  */
+ #include <ctype.h>
+ #include <string.h>
++#include <stdlib.h>
+ 
+ #include "data.h"
+ #include "filter.h"
+diff --git a/process.c b/process.c
+index ab3be80..d3e7fb3 100644
+--- a/process.c
++++ b/process.c
+@@ -14,6 +14,7 @@
+  */
+ #include <unistd.h>
+ #include <string.h>
++#include <stdlib.h>
+ #include <sys/uio.h>
+ 
+ #include "bitstream.h"

--- a/packages/addons/addon-depends/network-tools-depends/ncftp/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/ncftp/package.mk
@@ -18,7 +18,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_librtmp_rtmp_h=yes \
             --without-curses"
 
 pre_configure_target() {
-  export CFLAGS="${CFLAGS} -I../"
+  export CFLAGS="${CFLAGS} -I../ -DHAVE_STDLIB_H=1"
 }
 
 pre_build_target() {

--- a/packages/addons/addon-depends/network-tools-depends/ncftp/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/ncftp/package.mk
@@ -19,6 +19,9 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_librtmp_rtmp_h=yes \
 
 pre_configure_target() {
   export CFLAGS="${CFLAGS} -I../ -DHAVE_STDLIB_H=1"
+
+  #workaround gcc-14 erroring with incompatible pointer type
+  CFLAGS+=" -Wno-incompatible-pointer-types"
 }
 
 pre_build_target() {

--- a/packages/addons/addon-depends/system-tools-depends/hid_mapper/patches/hid_mapper-02_include-sys-time.patch
+++ b/packages/addons/addon-depends/system-tools-depends/hid_mapper/patches/hid_mapper-02_include-sys-time.patch
@@ -2,11 +2,12 @@ diff --git a/hid.c b/hid.c
 index 2830b58..a652222 100644
 --- a/hid.c
 +++ b/hid.c
-@@ -22,6 +22,7 @@
+@@ -23,6 +23,8 @@
  #include <unistd.h>
  #include <dirent.h>
  #include <stdio.h>
 +#include <sys/time.h>
++#include <string.h>
  
  #define SYSFS_HIDRAW_CLASS_PATH "/sys/class/hidraw"
  

--- a/packages/addons/addon-depends/system-tools-depends/screen/patches/screen-01_fix_gcc-14_build.patch
+++ b/packages/addons/addon-depends/system-tools-depends/screen/patches/screen-01_fix_gcc-14_build.patch
@@ -1,0 +1,12 @@
+diff --git a/pty.c b/pty.c
+index 6791fd5..9ef1471 100644
+--- a/pty.c
++++ b/pty.c
+@@ -30,6 +30,7 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <signal.h>
++#include <pty.h>
+ 
+ #if defined(__OpenBSD__)
+ #include <utils.h>  /* for openpty() */

--- a/packages/addons/service/mariadb/patches/mariadb-0002--fix-gcc14-build.patch
+++ b/packages/addons/service/mariadb/patches/mariadb-0002--fix-gcc14-build.patch
@@ -1,0 +1,13 @@
+--- a/tests/async_queries.c	2024-05-17 14:42:48.465859634 +0000
++++ b/tests/async_queries.c	2024-05-17 14:42:36.322436756 +0000
+@@ -31,7 +31,9 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
+-#include <event.h>
++#include <event2/event_struct.h>
++#include <event2/event_compat.h>
++#include <event2/event.h>
+ 
+ #define SL(s) (s), sizeof(s)
+ static const char *my_groups[]= { "client", NULL };

--- a/packages/audio/libcdio/package.mk
+++ b/packages/audio/libcdio/package.mk
@@ -12,6 +12,11 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A CD-ROM reading and control library."
 PKG_BUILD_FLAGS="+pic"
 
+#workaround gcc-14 erroring with lseek64
+if [ "${ARCH}" = "arm" ]; then
+  TARGET_CFLAGS+=" -Wno-implicit-function-declaration"
+fi
+
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-cxx \
                            --disable-cpp-progs \

--- a/packages/compress/zip/patches/fix-compile-with-gcc14.patch
+++ b/packages/compress/zip/patches/fix-compile-with-gcc14.patch
@@ -1,0 +1,121 @@
+--- a/timezone.c	2004-11-13 08:35:12.000000000 +0000
++++ b/timezone.c	2024-05-01 09:22:13.780112533 +0000
+@@ -39,6 +39,7 @@
+ 
+ #include "zip.h"
+ #include "timezone.h"
++#include <time.h>
+ #include <ctype.h>
+ #include <errno.h>
+ 
+--- a/unix/configure	2008-06-20 03:32:20.000000000 +0000
++++ b/unix/configure	2024-05-01 09:27:12.149292690 +0000
+@@ -509,17 +509,68 @@
+ # Check for missing functions
+ # add NO_'function_name' to flags if missing
+ 
+-for func in rmdir strchr strrchr rename mktemp mktime mkstemp
+-do
+-  echo Check for $func
+-  echo "int main(){ $func(); return 0; }" > conftest.c
+-  $CC $BFLAG -o conftest conftest.c >/dev/null 2>/dev/null
+-  [ $? -ne 0 ] && CFLAGS="${CFLAGS} -DNO_`echo $func | tr '[a-z]' '[A-Z]'`"
+-done
++echo Check for rmdir
++cat > conftest.c << _EOF_
++#include <unistd.h>
++int main() { rmdir(""); return 0; }
++_EOF_
++$CC -o conftest conftest.c >/dev/null 2>/dev/null
++[ $? -ne 0 ] && CFLAGS="${CFLAGS} -DNO_RMDIR"
++
++echo Check for strchr
++cat > conftest.c << _EOF_
++#include <string.h>
++int main() { strchr("", 0); return 0; }
++_EOF_
++$CC -o conftest conftest.c >/dev/null 2>/dev/null
++[ $? -ne 0 ] && CFLAGS="${CFLAGS} -DNO_STRCHR"
++
++echo Check for strrchr
++cat > conftest.c << _EOF_
++#include <string.h>
++int main() { strrchr("",0); return 0; }
++_EOF_
++$CC -o conftest conftest.c >/dev/null 2>/dev/null
++[ $? -ne 0 ] && CFLAGS="${CFLAGS} -DNO_STRRCHR"
++
++echo Check for rename
++cat > conftest.c << _EOF_
++#include <stdio.h>
++int main() { rename("",""); return 0; }
++_EOF_
++$CC -o conftest conftest.c >/dev/null 2>/dev/null
++[ $? -ne 0 ] && CFLAGS="${CFLAGS} -DNO_RENAME"
++
++echo Check for mktemp
++cat > conftest.c << _EOF_
++#include <stdlib.h>
++int main() { mktemp(""); return 0; }
++_EOF_
++$CC -o conftest conftest.c >/dev/null 2>/dev/null
++[ $? -ne 0 ] && CFLAGS="${CFLAGS} -DNO_MKTEMP"
++
++echo Check for mktime
++cat > conftest.c << _EOF_
++#include <time.h>
++int main() { struct tm *t; mktime(t); return 0; }
++_EOF_
++$CC -o conftest conftest.c >/dev/null 2>/dev/null
++[ $? -ne 0 ] && CFLAGS="${CFLAGS} -DNO_MKTIME"
++
++echo Check for mkstemp
++cat > conftest.c << _EOF_
++#include <stdlib.h>
++int main() { mkstemp(""); return 0; }
++_EOF_
++$CC -o conftest conftest.c >/dev/null 2>/dev/null
++[ $? -ne 0 ] && CFLAGS="${CFLAGS} -DNO_MKSTEMP"
+ 
+ 
+ echo Check for memset
+-echo "int main(){ char k; memset(&k,0,0); return 0; }" > conftest.c
++cat > conftest.c << _EOF_
++#include <string.h>
++int main() { char k; memset(&k,0,0); return 0; }
++_EOF_
+ $CC -o conftest conftest.c >/dev/null 2>/dev/null
+ [ $? -ne 0 ] && CFLAGS="${CFLAGS} -DZMEM"
+ 
+@@ -544,7 +595,7 @@
+ echo Check for errno declaration
+ cat > conftest.c << _EOF_
+ #include <errno.h>
+-main()
++int main()
+ {
+   errno = 0;
+   return 0;
+@@ -556,6 +607,7 @@
+ 
+ echo Check for directory libraries
+ cat > conftest.c << _EOF_
++#include <dirent.h>
+ int main() { return closedir(opendir(".")); }
+ _EOF_
+ 
+@@ -621,11 +673,13 @@
+ 
+ echo Check for valloc
+ cat > conftest.c << _EOF_
+-main()
++#include <stdlib.h>
++int main()
+ {
+ #ifdef MMAP
+     valloc();
+ #endif
++    return 0;
+ }
+ _EOF_
+ $CC ${CFLAGS} -c conftest.c > /dev/null 2>/dev/null

--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -58,7 +58,8 @@ PKG_CONFIGURE_OPTS_TARGET="--without-ada \
                            --disable-warnings \
                            --disable-home-terminfo \
                            --disable-assertions \
-                           --enable-leaks"
+                           --enable-leaks \
+                           --enable-sigwinch"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-termcap \
                          --with-termlib \

--- a/packages/devel/rapidjson/patches/rapidjson-0002-Removed-non-compiling-assignment-operator.-Fixed-718.patch
+++ b/packages/devel/rapidjson/patches/rapidjson-0002-Removed-non-compiling-assignment-operator.-Fixed-718.patch
@@ -1,0 +1,25 @@
+From 3b2441b87f99ab65f37b141a7b548ebadb607b96 Mon Sep 17 00:00:00 2001
+From: Janusz Chorko <janusz.chorko@apdu.pl>
+Date: Fri, 26 Aug 2016 21:17:38 +0200
+Subject: [PATCH] Removed non-compiling assignment operator. Fixed #718
+
+---
+ include/rapidjson/document.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/include/rapidjson/document.h b/include/rapidjson/document.h
+index e3e20dfb..b0f1f70b 100644
+--- a/include/rapidjson/document.h
++++ b/include/rapidjson/document.h
+@@ -316,8 +316,6 @@ struct GenericStringRef {
+ 
+     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
+ 
+-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+-
+     //! implicit conversion to plain CharType pointer
+     operator const Ch *() const { return s; }
+ 
+-- 
+2.43.0
+

--- a/packages/devel/rapidjson/patches/rapidjson-0003-Explicitly-disable-copy-assignment-operator.patch
+++ b/packages/devel/rapidjson/patches/rapidjson-0003-Explicitly-disable-copy-assignment-operator.patch
@@ -1,0 +1,25 @@
+From 862c39be371278a45a88d4d1d75164be57bb7e2d Mon Sep 17 00:00:00 2001
+From: Janusz Chorko <janusz.chorko@apdu.pl>
+Date: Fri, 26 Aug 2016 21:26:50 +0200
+Subject: [PATCH] Explicitly disable copy assignment operator
+
+---
+ include/rapidjson/document.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/rapidjson/document.h b/include/rapidjson/document.h
+index b0f1f70b..19f5a6a5 100644
+--- a/include/rapidjson/document.h
++++ b/include/rapidjson/document.h
+@@ -326,6 +326,8 @@ private:
+     //! Disallow construction from non-const array
+     template<SizeType N>
+     GenericStringRef(CharType (&str)[N]) /* = delete */;
++    //! Copy assignment operator not permitted - immutable type
++    GenericStringRef& operator=(const GenericStringRef& rhs) /* = delete */;
+ };
+ 
+ //! Mark a character pointer as constant string
+-- 
+2.43.0
+

--- a/packages/emulation/libretro-atari800/package.mk
+++ b/packages/emulation/libretro-atari800/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-atari800"
-PKG_VERSION="410d7bf0c215f3444793a9cec51c129e7b67c400"
-PKG_SHA256="b144e60c6f3e0ceada87833f0526f5a791acb9bf331a25b280af62bffd9d8e78"
+PKG_VERSION="8bfa3b80f6a2db365dfd1e8a6c06b7b0844327cf"
+PKG_SHA256="c1fee7ff0a87ff2ca1dc1d9ace1bb3a66615a299c0f4e796e75ba97c680852bb"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-atari800"
 PKG_URL="https://github.com/libretro/libretro-atari800/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bk/patches/libretro-bk-0001-recast-assignment.patch
+++ b/packages/emulation/libretro-bk/patches/libretro-bk-0001-recast-assignment.patch
@@ -1,0 +1,22 @@
+From f686a53014a7670344540090e3da4f7be2301a4e Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 19 May 2024 15:42:29 +1000
+Subject: [PATCH] Recast to target type
+
+---
+ libretro.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libretro.c b/libretro.c
+index db5ad34..6ec89de 100644
+--- a/libretro.c
++++ b/libretro.c
+@@ -668,7 +668,7 @@ void platform_disk_init(disk_t *disks) {
+ 		if (disk_size[i]) {
+ 			disks[i].length = disk_size[i];
+ 			disks[i].ro = 0;
+-			disks[i].image = diskptr;
++			disks[i].image = (short unsigned int *)diskptr;
+ 		} else {
+ 			disks[i].length = 0;
+ 			disks[i].ro = 0;

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bluemsx"
-PKG_VERSION="e8a4280bcbd149d1e020adcd9469ad9d8bd67412"
-PKG_SHA256="a9ee6d5922651e64d48e37e5a4a22bc08bc27d213adabaaa4283d92d8ab97fa5"
+PKG_VERSION="0dcb73adef9601ca70d94b3f4e3ba1b3b54edbc0"
+PKG_SHA256="a175df0324bee17ea2c217aebc329b06efe0e3086cf78547d945424c60423609"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/blueMSX-libretro"
 PKG_URL="https://github.com/libretro/blueMSX-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mame2000/package.mk
+++ b/packages/emulation/libretro-mame2000/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame2000"
-PKG_VERSION="1472da3a39ab14fff8325b1f51a1dfdb8eabb5c8"
-PKG_SHA256="e70d596045b9753084329caee49767e0ca1fb2567657a6a1fbeb3b486c594df9"
+PKG_VERSION="905808fbcc3adf8c610c1c60f0e41ce4b35db1c5"
+PKG_SHA256="7386a469086b7da90565e97f52e6ef02264a54262c82983dd1948ddef9bd4e63"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2000-libretro"
 PKG_URL="https://github.com/libretro/mame2000-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mame2003_plus/package.mk
+++ b/packages/emulation/libretro-mame2003_plus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame2003_plus"
-PKG_VERSION="84f35d3af006daf28b46912d2f67014f8fe95d6f"
-PKG_SHA256="27b117b86ebb7e39847fe987106ee097cbab4f5cac2337c37784ba9f89b11904"
+PKG_VERSION="ab725a7f30a133551742b400089e8fffdf29d84a"
+PKG_SHA256="294d0f7bf1c29417714cb24d2aab1f107a4a69fa4e7c574705bc34e214c62d51"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"
 PKG_URL="https://github.com/libretro/mame2003-plus-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-prboom/package.mk
+++ b/packages/emulation/libretro-prboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-prboom"
-PKG_VERSION="6ec854969fd9dec33bb2cab350f05675d1158969"
-PKG_SHA256="1ea963565c7a50a991056b7b8bb1e577a0dcf6f341e718cda293995fa279ba52"
+PKG_VERSION="ab05295d81fed2bb9db9f68a7ceeec7a544191d8"
+PKG_SHA256="e80c5ee26fcbb8c536907d9efb57104eb200b9f092108fe1982b6b3ec304b3f8"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-prboom"
 PKG_URL="https://github.com/libretro/libretro-prboom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-snes9x/package.mk
+++ b/packages/emulation/libretro-snes9x/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-snes9x"
-PKG_VERSION="ec4ebfc8f3819a9522fcb8e53eed985090017b1b"
-PKG_SHA256="0599dc74a5bac048134a3aaac3625d8e9a6fe7765a8388396353b70ac13a2607"
+PKG_VERSION="3265c0ac05ec595f9cedd020d76e7f39bf081538"
+PKG_SHA256="4abc999d084016d77c264912557bb55b55343db13db9b0f79d7763733dcb19af"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/snes9x"
 PKG_URL="https://github.com/libretro/snes9x/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-uae/package.mk
+++ b/packages/emulation/libretro-uae/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-uae"
-PKG_VERSION="8f4544314c4b178cc0abde7a20b65d2d425d2d0a"
-PKG_SHA256="deea3246bc982f60b5e2a972dc6177587ae4ca89550433cfb2a54f54e0988af4"
+PKG_VERSION="3432007d28ef173707e2b32bd931932e5b74085d"
+PKG_SHA256="a376b0d39a30024519fd4a50496d79b62d57af658828cf1ed3f1f673d91f734d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-uae"
 PKG_URL="https://github.com/libretro/libretro-uae/archive/${PKG_VERSION}.tar.gz"

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc"
-PKG_VERSION="13.2.0"
-PKG_SHA256="e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da"
+PKG_VERSION="14.1.0"
+PKG_SHA256="e283c654987afe3de9d8080bc0bd79534b5ca0d681a73a11ff2b5d3767426840"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://gcc.gnu.org/"
 PKG_URL="https://ftpmirror.gnu.org/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/lang/gcc/patches/gcc-0001-Revert-Arm-Block-predication-on-atomics-PR111235.patch
+++ b/packages/lang/gcc/patches/gcc-0001-Revert-Arm-Block-predication-on-atomics-PR111235.patch
@@ -1,0 +1,516 @@
+From 4e9ce2c862668c88b2be04beebdd5a6ba13074bb Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 19 May 2024 01:23:31 +0000
+Subject: [PATCH] Revert "Arm: Block predication on atomics [PR111235]"
+
+This reverts commit 0731889c026bfe8d55c4851422ca5ec9d037f7a0.
+---
+ gcc/config/arm/constraints.md                 |   9 +-
+ gcc/config/arm/sync.md                        | 219 ++++++++----------
+ gcc/config/arm/unspecs.md                     |   4 +-
+ gcc/testsuite/gcc.dg/rtl/arm/stl-cond.c       |  61 +++++
+ .../gcc.target/arm/atomic_loaddi_7.c          |   2 +-
+ .../gcc.target/arm/atomic_loaddi_8.c          |   2 +-
+ gcc/testsuite/gcc.target/arm/pr111235.c       |  39 ----
+ 7 files changed, 168 insertions(+), 168 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.dg/rtl/arm/stl-cond.c
+ delete mode 100644 gcc/testsuite/gcc.target/arm/pr111235.c
+
+diff --git a/gcc/config/arm/constraints.md b/gcc/config/arm/constraints.md
+index cd159670145..c6159eecf89 100644
+--- a/gcc/config/arm/constraints.md
++++ b/gcc/config/arm/constraints.md
+@@ -36,7 +36,7 @@
+ ;; in Thumb-1 state: Pa, Pb, Pc, Pd, Pe
+ ;; in Thumb-2 state: Ha, Pj, PJ, Ps, Pt, Pu, Pv, Pw, Px, Py, Pz, Rd, Rf, Rb, Ra,
+ ;;		     Rg, Ri
+-;; in all states: Pg
++;; in all states: Pf, Pg
+ 
+ ;; The following memory constraints have been used:
+ ;; in ARM/Thumb-2 state: Uh, Ut, Uv, Uy, Un, Um, Us, Up, Uf, Ux, Ul
+@@ -239,6 +239,13 @@
+   (and (match_code "const_int")
+        (match_test "TARGET_THUMB1 && ival >= 256 && ival <= 510")))
+ 
++(define_constraint "Pf"
++  "Memory models except relaxed, consume or release ones."
++  (and (match_code "const_int")
++       (match_test "!is_mm_relaxed (memmodel_from_int (ival))
++		    && !is_mm_consume (memmodel_from_int (ival))
++		    && !is_mm_release (memmodel_from_int (ival))")))
++
+ (define_constraint "Pg"
+   "@internal In Thumb-2 state a constant in range 1 to 32"
+   (and (match_code "const_int")
+diff --git a/gcc/config/arm/sync.md b/gcc/config/arm/sync.md
+index df8dbe170ca..4f0a13f6c0f 100644
+--- a/gcc/config/arm/sync.md
++++ b/gcc/config/arm/sync.md
+@@ -62,110 +62,68 @@
+    (set_attr "conds" "unconditional")
+    (set_attr "predicable" "no")])
+ 
+-(define_insn "arm_atomic_load<mode>"
+-  [(set (match_operand:QHSI 0 "register_operand" "=r,l")
++(define_insn "atomic_load<mode>"
++  [(set (match_operand:QHSI 0 "register_operand" "=r,r,l")
+     (unspec_volatile:QHSI
+-      [(match_operand:QHSI 1 "memory_operand" "m,m")]
+-      VUNSPEC_LDR))]
+-  ""
+-  "ldr<sync_sfx>\t%0, %1"
+-  [(set_attr "arch" "32,any")])
+-
+-(define_insn "arm_atomic_load_acquire<mode>"
+-  [(set (match_operand:QHSI 0 "register_operand" "=r")
+-    (unspec_volatile:QHSI
+-      [(match_operand:QHSI 1 "arm_sync_memory_operand" "Q")]
++      [(match_operand:QHSI 1 "arm_sync_memory_operand" "Q,Q,Q")
++       (match_operand:SI 2 "const_int_operand" "n,Pf,n")]	;; model
+       VUNSPEC_LDA))]
+   "TARGET_HAVE_LDACQ"
+-  "lda<sync_sfx>\t%0, %C1"
+-)
++  {
++    if (aarch_mm_needs_acquire (operands[2]))
++      {
++	if (TARGET_THUMB1)
++	  return "lda<sync_sfx>\t%0, %1";
++	else
++	  return "lda<sync_sfx>%?\t%0, %1";
++      }
++    else
++      {
++	if (TARGET_THUMB1)
++	  return "ldr<sync_sfx>\t%0, %1";
++	else
++	  return "ldr<sync_sfx>%?\t%0, %1";
++      }
++  }
++  [(set_attr "arch" "32,v8mb,any")
++   (set_attr "predicable" "yes")])
+ 
+-(define_insn "arm_atomic_store<mode>"
+-  [(set (match_operand:QHSI 0 "memory_operand" "=m,m")
+-    (unspec_volatile:QHSI
+-      [(match_operand:QHSI 1 "register_operand" "r,l")]
+-      VUNSPEC_STR))]
+-  ""
+-  "str<sync_sfx>\t%1, %0";
+-  [(set_attr "arch" "32,any")])
+-
+-(define_insn "arm_atomic_store_release<mode>"
+-  [(set (match_operand:QHSI 0 "arm_sync_memory_operand" "=Q")
++(define_insn "atomic_store<mode>"
++  [(set (match_operand:QHSI 0 "memory_operand" "=Q,Q,Q")
+     (unspec_volatile:QHSI
+-      [(match_operand:QHSI 1 "register_operand" "r")]
++      [(match_operand:QHSI 1 "general_operand" "r,r,l")
++       (match_operand:SI 2 "const_int_operand" "n,Pf,n")]	;; model
+       VUNSPEC_STL))]
+   "TARGET_HAVE_LDACQ"
+-  "stl<sync_sfx>\t%1, %C0")
+-
+-
+-(define_expand "atomic_load<mode>"
+-  [(match_operand:QHSI 0 "register_operand")		;; val out
+-   (match_operand:QHSI 1 "arm_sync_memory_operand")	;; memory
+-   (match_operand:SI 2 "const_int_operand")]		;; model
+-  ""
+-{
+-  memmodel model = memmodel_from_int (INTVAL (operands[2]));
+-
+-  if (TARGET_HAVE_LDACQ && !is_mm_relaxed (model))
+-    {
+-      emit_insn (gen_arm_atomic_load_acquire<mode> (operands[0], operands[1]));
+-      DONE;
+-    }
+-
+-  /* The seq_cst model needs a barrier before the load to block reordering with
+-     earlier accesses.  */
+-  if (is_mm_seq_cst (model))
+-    expand_mem_thread_fence (model);
+-
+-  emit_insn (gen_arm_atomic_load<mode> (operands[0], operands[1]));
+-
+-  /* All non-relaxed models need a barrier after the load when load-acquire
+-     instructions are not available.  */
+-  if (!is_mm_relaxed (model))
+-    expand_mem_thread_fence (model);
+-
+-  DONE;
+-})
+-
+-(define_expand "atomic_store<mode>"
+-  [(match_operand:QHSI 0 "arm_sync_memory_operand")	;; memory
+-   (match_operand:QHSI 1 "register_operand")		;; store value
+-   (match_operand:SI 2 "const_int_operand")]		;; model
+-  ""
+-{
+-  memmodel model = memmodel_from_int (INTVAL (operands[2]));
+-
+-  if (TARGET_HAVE_LDACQ && !is_mm_relaxed (model))
+-    {
+-      emit_insn (gen_arm_atomic_store_release<mode> (operands[0], operands[1]));
+-      DONE;
+-    }
+-
+-  /* All non-relaxed models need a barrier after the load when load-acquire
+-     instructions are not available.  */
+-  if (!is_mm_relaxed (model))
+-    expand_mem_thread_fence (model);
+-
+-  emit_insn (gen_arm_atomic_store<mode> (operands[0], operands[1]));
+-
+-  /* The seq_cst model needs a barrier after the store to block reordering with
+-     later accesses.  */
+-  if (is_mm_seq_cst (model))
+-    expand_mem_thread_fence (model);
+-
+-  DONE;
+-})
++  {
++    if (aarch_mm_needs_release (operands[2]))
++      {
++	if (TARGET_THUMB1)
++	  return "stl<sync_sfx>\t%1, %0";
++	else
++	  return "stl<sync_sfx>%?\t%1, %0";
++      }
++    else
++      {
++	if (TARGET_THUMB1)
++	  return "str<sync_sfx>\t%1, %0";
++	else
++	  return "str<sync_sfx>%?\t%1, %0";
++      }
++  }
++  [(set_attr "arch" "32,v8mb,any")
++   (set_attr "predicable" "yes")])
+ 
+ ;; An LDRD instruction usable by the atomic_loaddi expander on LPAE targets
+ 
+ (define_insn "arm_atomic_loaddi2_ldrd"
+   [(set (match_operand:DI 0 "register_operand" "=r")
+ 	(unspec_volatile:DI
+-	  [(match_operand:DI 1 "memory_operand" "m")]
++	  [(match_operand:DI 1 "arm_sync_memory_operand" "Q")]
+ 	    VUNSPEC_LDRD_ATOMIC))]
+   "ARM_DOUBLEWORD_ALIGN && TARGET_HAVE_LPAE"
+-  "ldrd\t%0, %H0, %1"
+-)
++  "ldrd%?\t%0, %H0, %C1"
++  [(set_attr "predicable" "yes")])
+ 
+ ;; There are three ways to expand this depending on the architecture
+ ;; features available.  As for the barriers, a load needs a barrier
+@@ -194,11 +152,6 @@
+       DONE;
+     }
+ 
+-  /* The seq_cst model needs a barrier before the load to block reordering with
+-     earlier accesses.  */
+-  if (is_mm_seq_cst (model))
+-    expand_mem_thread_fence (model);
+-
+   /* On LPAE targets LDRD and STRD accesses to 64-bit aligned
+      locations are 64-bit single-copy atomic.  We still need barriers in the
+      appropriate places to implement the ordering constraints.  */
+@@ -207,6 +160,7 @@
+   else
+     emit_insn (gen_arm_load_exclusivedi (operands[0], operands[1]));
+ 
++
+   /* All non-relaxed models need a barrier after the load when load-acquire
+      instructions are not available.  */
+   if (!is_mm_relaxed (model))
+@@ -492,42 +446,54 @@
+   [(set_attr "arch" "32,v8mb")])
+ 
+ (define_insn "arm_load_exclusive<mode>"
+-  [(set (match_operand:SI 0 "s_register_operand" "=r")
++  [(set (match_operand:SI 0 "s_register_operand" "=r,r")
+         (zero_extend:SI
+ 	  (unspec_volatile:NARROW
+-	    [(match_operand:NARROW 1 "mem_noofs_operand" "Ua")]
++	    [(match_operand:NARROW 1 "mem_noofs_operand" "Ua,Ua")]
+ 	    VUNSPEC_LL)))]
+   "TARGET_HAVE_LDREXBH"
+-  "ldrex<sync_sfx>\t%0, %C1"
+-)
++  "@
++   ldrex<sync_sfx>%?\t%0, %C1
++   ldrex<sync_sfx>\t%0, %C1"
++  [(set_attr "arch" "32,v8mb")
++   (set_attr "predicable" "yes")])
+ 
+ (define_insn "arm_load_acquire_exclusive<mode>"
+-  [(set (match_operand:SI 0 "s_register_operand" "=r")
++  [(set (match_operand:SI 0 "s_register_operand" "=r,r")
+         (zero_extend:SI
+ 	  (unspec_volatile:NARROW
+-	    [(match_operand:NARROW 1 "mem_noofs_operand" "Ua")]
++	    [(match_operand:NARROW 1 "mem_noofs_operand" "Ua,Ua")]
+ 	    VUNSPEC_LAX)))]
+   "TARGET_HAVE_LDACQ"
+-  "ldaex<sync_sfx>\\t%0, %C1"
+-)
++  "@
++   ldaex<sync_sfx>%?\\t%0, %C1
++   ldaex<sync_sfx>\\t%0, %C1"
++  [(set_attr "arch" "32,v8mb")
++   (set_attr "predicable" "yes")])
+ 
+ (define_insn "arm_load_exclusivesi"
+-  [(set (match_operand:SI 0 "s_register_operand" "=r")
++  [(set (match_operand:SI 0 "s_register_operand" "=r,r")
+ 	(unspec_volatile:SI
+-	  [(match_operand:SI 1 "mem_noofs_operand" "Ua")]
++	  [(match_operand:SI 1 "mem_noofs_operand" "Ua,Ua")]
+ 	  VUNSPEC_LL))]
+   "TARGET_HAVE_LDREX"
+-  "ldrex\t%0, %C1"
+-)
++  "@
++   ldrex%?\t%0, %C1
++   ldrex\t%0, %C1"
++  [(set_attr "arch" "32,v8mb")
++   (set_attr "predicable" "yes")])
+ 
+ (define_insn "arm_load_acquire_exclusivesi"
+-  [(set (match_operand:SI 0 "s_register_operand" "=r")
++  [(set (match_operand:SI 0 "s_register_operand" "=r,r")
+ 	(unspec_volatile:SI
+-	  [(match_operand:SI 1 "mem_noofs_operand" "Ua")]
++	  [(match_operand:SI 1 "mem_noofs_operand" "Ua,Ua")]
+ 	  VUNSPEC_LAX))]
+   "TARGET_HAVE_LDACQ"
+-  "ldaex\t%0, %C1"
+-)
++  "@
++   ldaex%?\t%0, %C1
++   ldaex\t%0, %C1"
++  [(set_attr "arch" "32,v8mb")
++   (set_attr "predicable" "yes")])
+ 
+ (define_insn "arm_load_exclusivedi"
+   [(set (match_operand:DI 0 "s_register_operand" "=r")
+@@ -535,8 +501,8 @@
+ 	  [(match_operand:DI 1 "mem_noofs_operand" "Ua")]
+ 	  VUNSPEC_LL))]
+   "TARGET_HAVE_LDREXD"
+-  "ldrexd\t%0, %H0, %C1"
+-)
++  "ldrexd%?\t%0, %H0, %C1"
++  [(set_attr "predicable" "yes")])
+ 
+ (define_insn "arm_load_acquire_exclusivedi"
+   [(set (match_operand:DI 0 "s_register_operand" "=r")
+@@ -544,8 +510,8 @@
+ 	  [(match_operand:DI 1 "mem_noofs_operand" "Ua")]
+ 	  VUNSPEC_LAX))]
+   "TARGET_HAVE_LDACQEXD && ARM_DOUBLEWORD_ALIGN"
+-  "ldaexd\t%0, %H0, %C1"
+-)
++  "ldaexd%?\t%0, %H0, %C1"
++  [(set_attr "predicable" "yes")])
+ 
+ (define_insn "arm_store_exclusive<mode>"
+   [(set (match_operand:SI 0 "s_register_operand" "=&r")
+@@ -564,11 +530,14 @@
+ 	   Note that the 1st register always gets the
+ 	   lowest word in memory.  */
+ 	gcc_assert ((REGNO (operands[2]) & 1) == 0 || TARGET_THUMB2);
+-	return "strexd\t%0, %2, %H2, %C1";
++	return "strexd%?\t%0, %2, %H2, %C1";
+       }
+-    return "strex<sync_sfx>\t%0, %2, %C1";
++    if (TARGET_THUMB1)
++      return "strex<sync_sfx>\t%0, %2, %C1";
++    else
++      return "strex<sync_sfx>%?\t%0, %2, %C1";
+   }
+-)
++  [(set_attr "predicable" "yes")])
+ 
+ (define_insn "arm_store_release_exclusivedi"
+   [(set (match_operand:SI 0 "s_register_operand" "=&r")
+@@ -581,16 +550,20 @@
+   {
+     /* See comment in arm_store_exclusive<mode> above.  */
+     gcc_assert ((REGNO (operands[2]) & 1) == 0 || TARGET_THUMB2);
+-    return "stlexd\t%0, %2, %H2, %C1";
++    return "stlexd%?\t%0, %2, %H2, %C1";
+   }
+-)
++  [(set_attr "predicable" "yes")])
+ 
+ (define_insn "arm_store_release_exclusive<mode>"
+-  [(set (match_operand:SI 0 "s_register_operand" "=&r")
++  [(set (match_operand:SI 0 "s_register_operand" "=&r,&r")
+ 	(unspec_volatile:SI [(const_int 0)] VUNSPEC_SLX))
+-   (set (match_operand:QHSI 1 "mem_noofs_operand" "=Ua")
++   (set (match_operand:QHSI 1 "mem_noofs_operand" "=Ua,Ua")
+ 	(unspec_volatile:QHSI
+-	  [(match_operand:QHSI 2 "s_register_operand" "r")]
++	  [(match_operand:QHSI 2 "s_register_operand" "r,r")]
+ 	  VUNSPEC_SLX))]
+   "TARGET_HAVE_LDACQ"
+-  "stlex<sync_sfx>\t%0, %2, %C1")
++  "@
++   stlex<sync_sfx>%?\t%0, %2, %C1
++   stlex<sync_sfx>\t%0, %2, %C1"
++  [(set_attr "arch" "32,v8mb")
++   (set_attr "predicable" "yes")])
+diff --git a/gcc/config/arm/unspecs.md b/gcc/config/arm/unspecs.md
+index 46ac8b37157..ffc09b2febc 100644
+--- a/gcc/config/arm/unspecs.md
++++ b/gcc/config/arm/unspecs.md
+@@ -221,10 +221,8 @@
+   VUNSPEC_SC		; Represent a store-register-exclusive.
+   VUNSPEC_LAX		; Represent a load-register-acquire-exclusive.
+   VUNSPEC_SLX		; Represent a store-register-release-exclusive.
+-  VUNSPEC_LDA		; Represent a load-register-acquire.
+-  VUNSPEC_LDR		; Represent a load-register-relaxed.
++  VUNSPEC_LDA		; Represent a store-register-acquire.
+   VUNSPEC_STL		; Represent a store-register-release.
+-  VUNSPEC_STR		; Represent a store-register-relaxed.
+   VUNSPEC_GET_FPSCR	; Represent fetch of FPSCR content.
+   VUNSPEC_SET_FPSCR	; Represent assign of FPSCR content.
+   VUNSPEC_SET_FPSCR_NZCVQC	; Represent assign of FPSCR_nzcvqc content.
+diff --git a/gcc/testsuite/gcc.dg/rtl/arm/stl-cond.c b/gcc/testsuite/gcc.dg/rtl/arm/stl-cond.c
+new file mode 100644
+index 00000000000..e47ca6bf36d
+--- /dev/null
++++ b/gcc/testsuite/gcc.dg/rtl/arm/stl-cond.c
+@@ -0,0 +1,61 @@
++/* { dg-do compile { target arm*-*-* } } */
++/* { dg-require-effective-target arm_arm_ok } */
++/* { dg-require-effective-target arm_arch_v8a_ok } */
++/* { dg-options "-O2 -marm" } */
++/* { dg-add-options arm_arch_v8a } */
++
++/* We want to test that the STL instruction gets the conditional
++   suffix when under a COND_EXEC.  However, COND_EXEC is very hard to
++   generate from C code because the atomic_store expansion adds a compiler
++   barrier before the insn, preventing if-conversion.  So test the output
++   here with a hand-crafted COND_EXEC wrapped around an STL.  */
++
++void __RTL (startwith ("final")) foo (int *a, int b)
++{
++(function "foo"
++  (param "a"
++    (DECL_RTL (reg/v:SI r0))
++    (DECL_RTL_INCOMING (reg:SI r0))
++  )
++  (param "b"
++    (DECL_RTL (reg/v:SI r1))
++    (DECL_RTL_INCOMING (reg:SI r1))
++  )
++  (insn-chain
++    (block 2
++	(edge-from entry (flags "FALLTHRU"))
++	(cnote 5 [bb 2] NOTE_INSN_BASIC_BLOCK)
++
++  (insn:TI 7 (parallel [
++	(set (reg:CC cc)
++	     (compare:CC (reg:SI r1)
++			 (const_int 0)))
++	(set (reg/v:SI r1)
++	     (reg:SI r1 ))
++        ])  ;; {*movsi_compare0}
++     (nil))
++
++  ;; A conditional atomic store-release: STLNE for Armv8-A.
++  (insn 10 (cond_exec (ne (reg:CC cc)
++	   (const_int 0))
++	(set (mem/v:SI (reg/v/f:SI r0) [-1  S4 A32])
++		(unspec_volatile:SI [
++		(reg/v:SI r1)
++		(const_int 3)
++		] VUNSPEC_STL))) ;; {*p atomic_storesi}
++	(expr_list:REG_DEAD (reg:CC cc)
++	(expr_list:REG_DEAD (reg/v:SI r1)
++	(expr_list:REG_DEAD (reg/v/f:SI r0)
++		(nil)))))
++      (edge-to exit (flags "FALLTHRU"))
++    ) ;; block 2
++  ) ;; insn-chain
++  (crtl
++    (return_rtx
++      (reg/i:SI r0)
++    ) ;; return_rtx
++  ) ;; crtl
++) ;; function
++}
++
++/* { dg-final { scan-assembler "stlne" } } */
+diff --git a/gcc/testsuite/gcc.target/arm/atomic_loaddi_7.c b/gcc/testsuite/gcc.target/arm/atomic_loaddi_7.c
+index 79e36edbb8f..6743663f1e6 100644
+--- a/gcc/testsuite/gcc.target/arm/atomic_loaddi_7.c
++++ b/gcc/testsuite/gcc.target/arm/atomic_loaddi_7.c
+@@ -6,4 +6,4 @@
+ #include "atomic_loaddi_seq_cst.x"
+ 
+ /* { dg-final { scan-assembler-times "ldrexd\tr\[0-9\]+, r\[0-9\]+, \\\[r\[0-9\]+\\\]" 1 } } */
+-/* { dg-final { scan-assembler-times "dmb\tish" 2 } } */
++/* { dg-final { scan-assembler-times "dmb\tish" 1 } } */
+diff --git a/gcc/testsuite/gcc.target/arm/atomic_loaddi_8.c b/gcc/testsuite/gcc.target/arm/atomic_loaddi_8.c
+index 7241d361313..f7bd3e5a2b5 100644
+--- a/gcc/testsuite/gcc.target/arm/atomic_loaddi_8.c
++++ b/gcc/testsuite/gcc.target/arm/atomic_loaddi_8.c
+@@ -6,4 +6,4 @@
+ #include "atomic_loaddi_seq_cst.x"
+ 
+ /* { dg-final { scan-assembler-times "ldrd\tr\[0-9\]+, r\[0-9\]+, \\\[r\[0-9\]+\\\]" 1 } } */
+-/* { dg-final { scan-assembler-times "dmb\tish" 2 } } */
++/* { dg-final { scan-assembler-times "dmb\tish" 1 } } */
+diff --git a/gcc/testsuite/gcc.target/arm/pr111235.c b/gcc/testsuite/gcc.target/arm/pr111235.c
+deleted file mode 100644
+index b06a5bfb8e2..00000000000
+--- a/gcc/testsuite/gcc.target/arm/pr111235.c
++++ /dev/null
+@@ -1,39 +0,0 @@
+-/* { dg-do compile } */
+-/* { dg-options "-O2" } */
+-/* { dg-require-effective-target arm_arch_v7a_ok } */
+-/* { dg-add-options arm_arch_v7a } */
+-
+-#include <stdatomic.h>
+-
+-int t0 (int *p, int x)
+-{
+-  if (x > 100)
+-    x = atomic_load_explicit (p, memory_order_relaxed);
+-  return x + 1;
+-}
+-
+-long long t1 (long long *p, int x)
+-{
+-  if (x > 100)
+-    x = atomic_load_explicit (p, memory_order_relaxed);
+-  return x + 1;
+-}
+-
+-void t2 (int *p, int x)
+-{
+-  if (x > 100)
+-    atomic_store_explicit (p, x, memory_order_relaxed);
+-}
+-
+-void t3 (long long *p, int x)
+-{
+-  if (x > 100)
+-    atomic_store_explicit (p, x, memory_order_relaxed);
+-}
+-
+-/* { dg-final { scan-assembler-times "ldrexd\tr\[0-9\]+, r\[0-9\]+, \\\[r\[0-9\]+\\\]" 2 } } */
+-/* { dg-final { scan-assembler-not "ldrgt" } } */
+-/* { dg-final { scan-assembler-not "ldrdgt" } } */
+-/* { dg-final { scan-assembler-not "ldrexdgt" } } */
+-/* { dg-final { scan-assembler-not "strgt" } } */
+-/* { dg-final { scan-assembler-not "strdgt" } } */
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/patches/audiodecoder.usf-51-fix-gcc-14-build.patch
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/patches/audiodecoder.usf-51-fix-gcc-14-build.patch
@@ -1,0 +1,113 @@
+From 6f958ddf533753ce7aec12edf3b53a8025a4aabd Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 4 May 2024 10:03:44 +0000
+Subject: [PATCH] fix gcc-14 errors and warnings
+
+---
+ lib/lazyusf/audiolib.c |  6 +++---
+ lib/lazyusf/cpu_hle.c  |  2 +-
+ lib/lazyusf/main.c     | 16 ++++++++--------
+ lib/lazyusf/memory.c   |  8 ++++----
+ src/USFCodec.cpp       |  2 +-
+ 5 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/lib/lazyusf/audiolib.c b/lib/lazyusf/audiolib.c
+index c567928..f94fef0 100644
+--- a/lib/lazyusf/audiolib.c
++++ b/lib/lazyusf/audiolib.c
+@@ -53,9 +53,9 @@ int alUnLink(usf_state_t * state, int paddr) {
+ //	_asm int 3
+ 
+ 	if (element->next)
+-        elementNext->prev = element->prev;
+-    if (element->prev)
+-        elementPrev->next = element->next;
++        	elementNext->prev = element->prev;
++	if (element->prev)
++        	elementPrev->next = element->next;
+ 	return 1;
+ }
+ 
+diff --git a/lib/lazyusf/cpu_hle.c b/lib/lazyusf/cpu_hle.c
+index 6b04ced..a6e1ca7 100644
+--- a/lib/lazyusf/cpu_hle.c
++++ b/lib/lazyusf/cpu_hle.c
+@@ -55,7 +55,7 @@ _HLE_Entry entrys[] = {
+ 
+ //char foundlist[2048];
+ 
+-int sort_entrys(void * a, void * b)
++int sort_entrys(const void * a, const void * b)
+ {
+ 	_HLE_Entry * _a = (_HLE_Entry *)a;
+ 	_HLE_Entry * _b = (_HLE_Entry *)b;
+diff --git a/lib/lazyusf/main.c b/lib/lazyusf/main.c
+index bcc55f3..554e1fc 100644
+--- a/lib/lazyusf/main.c
++++ b/lib/lazyusf/main.c
+@@ -20,18 +20,18 @@ void StopEmulation(usf_state_t * state)
+ 
+ void DisplayError (usf_state_t * state, char * Message, ...) {
+ 	va_list ap;
+-    
+-    size_t len = strlen( state->error_message );
+-    
+-    if ( len )
+-        state->error_message[ len++ ] = '\n';
++
++	size_t len = strlen( state->error_message );
++
++	if ( len )
++		state->error_message[ len++ ] = '\n';
+ 
+ 	va_start( ap, Message );
+ 	vsprintf( state->error_message + len, Message, ap );
+ 	va_end( ap );
+-    
+-    state->last_error = state->error_message;
+-    StopEmulation( state );
++
++	state->last_error = state->error_message;
++	StopEmulation( state );
+ 
+ 	//printf("Error: %s\n", Msg);
+ }
+diff --git a/lib/lazyusf/memory.c b/lib/lazyusf/memory.c
+index 444e501..3bd4ab6 100644
+--- a/lib/lazyusf/memory.c
++++ b/lib/lazyusf/memory.c
+@@ -445,8 +445,8 @@ uint32_t r4300i_SB_VAddr ( usf_state_t * state, uint32_t VAddr, uint8_t Value )
+ 	address = state->TLB_Map[VAddr >> 12];
+ 
+ 	if (address == 0) { return 0; }
+-    if (address + (VAddr ^ 3) - (uintptr_t)state->N64MEM < state->RdramSize)
+-        *(uint8_t *)(address + (VAddr ^ 3)) = Value;
++	if (address + (VAddr ^ 3) - (uintptr_t)state->N64MEM < state->RdramSize)
++        	*(uint8_t *)(address + (VAddr ^ 3)) = Value;
+ 
+ 	return 1;
+ }
+@@ -489,8 +489,8 @@ uint32_t r4300i_SH_VAddr ( usf_state_t * state, uint32_t VAddr, uint16_t Value )
+ 	address = state->TLB_Map[VAddr >> 12];
+ 
+ 	if (address == 0) { return 0; }
+-    if (address + 1 + (VAddr ^ 2) - (uintptr_t)state->N64MEM < state->RdramSize)
+-        *(uint16_t *)(address + (VAddr ^ 2)) = Value;
++	if (address + 1 + (VAddr ^ 2) - (uintptr_t)state->N64MEM < state->RdramSize)
++        	*(uint16_t *)(address + (VAddr ^ 2)) = Value;
+ 	return 1;
+ }
+ 
+diff --git a/src/USFCodec.cpp b/src/USFCodec.cpp
+index 703e22c..7a439d0 100644
+--- a/src/USFCodec.cpp
++++ b/src/USFCodec.cpp
+@@ -298,7 +298,7 @@ bool CUSFCodec::CheckEndReached(uint8_t* buffer, int size)
+ 
+   if (buffer && buffer[0] == 0)
+   {
+-    for (unsigned int i = 0; i < size; i++)
++    for (int i = 0; i < size; i++)
+     {
+       if (buffer[i] != 0)
+       {

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/patches/pvr.stalker-223-fix-gcc-14-build.patch
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/patches/pvr.stalker-223-fix-gcc-14-build.patch
@@ -1,0 +1,22 @@
+From 9286f1d7f21f309cfadd35c9872a7d42eb6a4495 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 5 May 2024 00:50:22 +1000
+Subject: [PATCH] Fix missing stdlib.h header
+
+Required for compiling with gcc-14
+---
+ lib/libstalkerclient/xmltv.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/libstalkerclient/xmltv.c b/lib/libstalkerclient/xmltv.c
+index afe8555..c8fbab7 100644
+--- a/lib/libstalkerclient/xmltv.c
++++ b/lib/libstalkerclient/xmltv.c
+@@ -23,6 +23,7 @@
+ 
+ #include <errno.h>
+ #include <inttypes.h>
++#include <stdlib.h>
+ #include <string.h>
+ 
+ #include "util.h"

--- a/packages/mediacenter/kodi/patches/kodi-999.30-fix-gcc-14-compile.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.30-fix-gcc-14-compile.patch
@@ -1,0 +1,52 @@
+From 2bf5ab07731b3d4160196e6b8d9ab9e25bea2ef9 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 2 May 2024 08:02:42 +0000
+Subject: [PATCH 1/2] add missing c++ headers
+
+Add missing headers which are no longer indirectly included by
+other headers, fixes build with gcc-14
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+index d42c19bb2cd4a..142974591b1a7 100644
+--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
++++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+@@ -17,6 +17,7 @@
+ 
+ #include "platform/posix/filesystem/SMBWSDiscovery.h"
+ 
++#include <algorithm>
+ #include <array>
+ #include <chrono>
+ #include <mutex>
+
+From b6ddd8fb25ef20e8adb9a9f9b53bebf0cee3a970 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 2 May 2024 08:05:00 +0000
+Subject: [PATCH 2/2] Geometry: fix template-id not allowed for constructor
+
+fixes gcc-14 error:
+- warning: template-id not allowed for constructor in C++20
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ xbmc/utils/Geometry.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/utils/Geometry.h b/xbmc/utils/Geometry.h
+index 1bf4624d06d18..90e4275165a48 100644
+--- a/xbmc/utils/Geometry.h
++++ b/xbmc/utils/Geometry.h
+@@ -177,7 +177,7 @@ template <typename T> class CSizeGen
+     return {m_w, m_h};
+   }
+ 
+-  template<class U> explicit CSizeGen<T>(const CSizeGen<U>& rhs)
++  template<class U> explicit CSizeGen(const CSizeGen<U>& rhs)
+   {
+     CheckSet(static_cast<T> (rhs.m_w), static_cast<T> (rhs.m_h));
+   }

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -11,6 +11,8 @@ PKG_URL="https://github.com/intel/media-driver/archive/intel-media-${PKG_VERSION
 PKG_DEPENDS_TARGET="toolchain libva libdrm gmmlib"
 PKG_LONGDESC="media-driver: The Intel(R) Media Driver for VAAPI is a new VA-API (Video Acceleration API) user mode driver supporting hardware accelerated decoding, encoding, and video post processing for GEN based graphics hardware."
 
+TARGET_CXXFLAGS+=" -Wno-error=template-id-cdtor"
+
 PKG_CMAKE_OPTS_TARGET="-DBUILD_CMRTLIB=OFF \
                        -DBUILD_KERNELS=ON \
                        -DBUILD_TYPE=release \

--- a/packages/network/bluez/patches/bluez-21-hciattach-add-QCA9377-Tuffello-support.patch
+++ b/packages/network/bluez/patches/bluez-21-hciattach-add-QCA9377-Tuffello-support.patch
@@ -953,7 +953,7 @@ index 000000000..9a7f222c4
 +		return ret;
 +	}
 +
-+	while (getline(&line, &bytes_read, pfile) > 0 ) {
++	while (getline(&line, (size_t *)&bytes_read, pfile) > 0 ) {
 +		if (line[0] != '#'  && line[0] != '\n') {
 +			pch = memchr(line, '=', strlen(line));
 +			if (pch != NULL) {

--- a/packages/sysutils/lirc/package.mk
+++ b/packages/sysutils/lirc/package.mk
@@ -32,6 +32,9 @@ pre_configure_target() {
 
 post_configure_target() {
   libtool_remove_rpath libtool
+
+  nodots=$(grep "#define VERSION_NODOTS" ../lib/lirc/config.h)
+  sed -i "s/^#define VERSION_NODOTS.*/${nodots}/" config.h
 }
 
 post_makeinstall_target() {


### PR DESCRIPTION
Fixes:
- ~~game.libretro.mame2003_plus~~
  - ~~https://github.com/libretro/mame2003-plus-libretro/issues/1721~~
- ~~game.libretro.atari800~~
  - ~~https://github.com/libretro/libretro-atari800/issues/94~~
  - ~~Upstream patch (to be merged) included https://github.com/libretro/libretro-atari800/pull/92~~
- ~~game.libretro.bluemsx~~
  - ~~https://github.com/libretro/blueMSX-libretro/issues/169~~
  - ~~https://github.com/libretro/blueMSX-libretro/pull/170~~
  - ~~https://github.com/libretro/blueMSX-libretro/pull/167~~
- game.libretro.bk
  - https://github.com/xttx/bk-emulator/issues/1
  - https://github.com/libretro/bk-emulator/pull/24
  - Workaround applied
  - #libretro-bk: fix gcc-14 build
- ~~game.libretro.uae~~
  - ~~https://github.com/libretro/libretro-uae/issues/656~~
  - ~~Upstream patch included https://github.com/libretro/libretro-uae/pull/657~~
  - ~~Workaround applied~~
  - ~~`#workaround gcc-14 erroring with incompatible pointer type`~~
  - ~~`TARGET_CFLAGS+=" -Wno-incompatible-pointer-types"`~~
- network-tools
  - ncftp - email sent to ncftp support
  - Fix applied
  - ncftp: define HAVE_STDLIB_H fixes gcc-14 missing header 
  - Workaround applied
  - `#workaround gcc-14 erroring with incompatible pointer type`
  - `CFLAGS+=" -Wno-incompatible-pointer-types"`
- ~~dvb-tools~~
  - ~~t2scan~~
    - ~~https://github.com/mighty-p/t2scan/issues/16~~
    - ~~https://github.com/mighty-p/t2scan/pull/15~~
- ~~mariadb (a single test failure)~~
  - ~~https://jira.mariadb.org/browse/MDEV-34072~~
  - ~~event.h fix added~~
- ~~kodi (for 32 bit targets)~~
  - ~~https://github.com/xbmc/xbmc/issues/25221~~
  - ~~#8899~~
- ~~gcc:host~~
  - ~~libsanitizer doesn’t build~~
  - ~~patch added~~
  - ~~gcc regression https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115153~~

Required patches/changes - all upstreamed:
- hid_mapper: fix gcc-14 build
- argtable2: fix gcc-14 build
- tsdecrypt: fix gcc-14 build
- opencaster: fix gcc-14 build
- audiodecoder.usf: fix gcc-14 build
- pvr.stalker: fix gcc-14 build
- rapidjson: fix gcc-14 build
- screen: fix gcc-14 build
- kodi: fix gcc-14 build
- media-driver: workaround for gcc-14.1 change
  - https://github.com/intel/media-driver/issues/1797
- bluez: fix gcc-14 build
- lirc: fix gcc-14 build
- ~~mariadb-connector-c: Fix GCC 14 -Wcalloc-transposed-args~~
  - ~~Revert "mariadb-connector-c: Fix GCC 14 -Wcalloc-transposed-args"~~
  - ~~Now upstream in 3.3.10~~
- libcdio: workaround gcc-14 error
  - https://savannah.gnu.org/bugs/?65751
- zip: fix gcc-14 build
- ncurses: compile with --enable-sigwinch
- libretro-snes9x: update to githash 3265c0a
- libretro-prboom: update to githash ab05295
- libretro-mame2000: update to githash 905808f
- libretro-mame2003_plus: update to githash ab725a7
- t2scan: fix gcc-14 build
- libretro-bk: fix gcc-14 build
- libcdio: workaround gcc-14 error on 32-bit targets
- ncftp: define HAVE_STDLIB_H fixes gcc-14 missing header
- ncftp: workaround gcc-14 error incompatible-pointer-types
- mariadb: fix gcc-14 build
- libretro-bluemsx: update to githash 0dcb73a
- gcc: 14.1.0: revert Arm: Block predication on atomics [PR111235]
- libretro-atari800: update to githash 8bfa3b8
- libretro-uae: update to githash 3432007

