### PR TITLE
ncurses: compile with --enable-sigwinch

### DIFF
--- a/packages/devel/ncurses/package.mk
+++ b/packages/devel/ncurses/package.mk
@@ -58,7 +58,8 @@ PKG_CONFIGURE_OPTS_TARGET="--without-ada \
                            --disable-warnings \
                            --disable-home-terminfo \
                            --disable-assertions \
-                           --enable-leaks"
+                           --enable-leaks \
+                           --enable-sigwinch"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-termcap \
                          --with-termlib \


### PR DESCRIPTION
when building htop with ncurses it was identified that KEY_RESIZE was not available due to NCURSES_SIGWINCH not being set. Add the option to ncurses to allow correct build of htop.

ref:
- https://github.com/htop-dev/htop/issues/1474
- This is since the ncurses-6.5 6fe28ff9b9554450764ed7aa21fd553a39379344