### PR TITLE
[le12] u-boot (RK3328): BACKPORT: Set efuse auto mode and timing control

### DIFF
--- a/projects/Rockchip/patches/u-boot/0001-rockchip-rk3328-BACKPORT-Set-efuse-auto-mode-and-timing-control.patch
+++ b/projects/Rockchip/patches/u-boot/0001-rockchip-rk3328-BACKPORT-Set-efuse-auto-mode-and-timing-control.patch
@@ -1,0 +1,102 @@
+From 5708e8eeae53ad8ce605afdf61e5a83162dc5131 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 7 Jan 2024 18:18:33 +0000
+Subject: [PATCH] rockchip: rk3328: Set efuse auto mode and timing control
+
+Reading from efuse return zero when mainline TF-A is used.
+
+  => dump_efuse
+  00000000: 00 00 00 00  ....
+  00000004: 00 00 00 00  ....
+  00000008: 00 00 00 00  ....
+  0000000c: 00 00 00 00  ....
+  00000010: 00 00 00 00  ....
+  00000014: 00 00 00 00  ....
+  00000018: 00 00 00 00  ....
+  0000001c: 00 00 00 00  ....
+
+However, when vendor TF-A blobs is used reading from efuse works.
+
+Change to use auto mode, enable finish and auto access err interrupts
+and set timing control using same values that vendor TF-A blob use to
+fix this.
+
+With this efuse can be read when either of mainline TF-A or vendor blob
+is used.
+
+  => dump_efuse
+  00000000: 52 4b 33 82  RK3.
+  00000004: 00 fe 21 55  ..!U
+  00000008: 52 4b 57 34  RKW4
+  0000000c: 35 30 32 39  5029
+  00000010: 00 00 00 00  ....
+  00000014: 08 25 0c 0f  .%..
+  00000018: 02 0d 08 00  ....
+  0000001c: 00 00 f0 00  ....
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+---
+ arch/arm/mach-rockchip/rk3328/rk3328.c | 38 ++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/arch/arm/mach-rockchip/rk3328/rk3328.c b/arch/arm/mach-rockchip/rk3328/rk3328.c
+index de17b886827..ca623c0d3d0 100644
+--- a/arch/arm/mach-rockchip/rk3328/rk3328.c
++++ b/arch/arm/mach-rockchip/rk3328/rk3328.c
+@@ -19,6 +19,23 @@ DECLARE_GLOBAL_DATA_PTR;
+ #define GRF_BASE		0xFF100000
+ #define UART2_BASE		0xFF130000
+ #define FW_DDR_CON_REG		0xFF7C0040
++#define EFUSE_NS_BASE		0xFF260000
++
++#define EFUSE_MOD		0x0000
++#define EFUSE_INT_CON		0x0014
++#define EFUSE_T_CSB_P		0x0028
++#define EFUSE_T_PGENB_P		0x002C
++#define EFUSE_T_LOAD_P		0x0030
++#define EFUSE_T_ADDR_P		0x0034
++#define EFUSE_T_STROBE_P	0x0038
++#define EFUSE_T_CSB_R		0x003C
++#define EFUSE_T_PGENB_R		0x0040
++#define EFUSE_T_LOAD_R		0x0044
++#define EFUSE_T_ADDR_R		0x0048
++#define EFUSE_T_STROBE_R	0x004C
++
++#define EFUSE_USER_MODE		0x1
++#define EFUSE_TIMING(s, l)	(((s) << 16) | (l))
+ 
+ const char * const boot_devices[BROM_LAST_BOOTSOURCE + 1] = {
+ 	[BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",
+@@ -50,10 +67,31 @@ struct mm_region *mem_map = rk3328_mem_map;
+ int arch_cpu_init(void)
+ {
+ #ifdef CONFIG_SPL_BUILD
++	u32 reg;
++
+ 	/* We do some SoC one time setting here. */
+ 
+ 	/* Disable the ddr secure region setting to make it non-secure */
+ 	rk_setreg(FW_DDR_CON_REG, 0x200);
++
++	/* Use efuse auto mode */
++	reg = readl(EFUSE_NS_BASE + EFUSE_MOD);
++	writel(reg & ~EFUSE_USER_MODE, EFUSE_NS_BASE + EFUSE_MOD);
++
++	/* Enable efuse finish and auto access err interrupt */
++	writel(0x07, EFUSE_NS_BASE + EFUSE_INT_CON);
++
++	/* Set efuse timing control */
++	writel(EFUSE_TIMING(1, 241), EFUSE_NS_BASE + EFUSE_T_CSB_P);
++	writel(EFUSE_TIMING(1, 241), EFUSE_NS_BASE + EFUSE_T_PGENB_P);
++	writel(EFUSE_TIMING(1, 241), EFUSE_NS_BASE + EFUSE_T_LOAD_P);
++	writel(EFUSE_TIMING(1, 241), EFUSE_NS_BASE + EFUSE_T_ADDR_P);
++	writel(EFUSE_TIMING(2, 240), EFUSE_NS_BASE + EFUSE_T_STROBE_P);
++	writel(EFUSE_TIMING(1, 4), EFUSE_NS_BASE + EFUSE_T_CSB_R);
++	writel(EFUSE_TIMING(1, 4), EFUSE_NS_BASE + EFUSE_T_PGENB_R);
++	writel(EFUSE_TIMING(1, 4), EFUSE_NS_BASE + EFUSE_T_LOAD_R);
++	writel(EFUSE_TIMING(1, 4), EFUSE_NS_BASE + EFUSE_T_ADDR_R);
++	writel(EFUSE_TIMING(2, 3), EFUSE_NS_BASE + EFUSE_T_STROBE_R);
+ #endif
+ 	return 0;
+ }

--- a/projects/Rockchip/patches/u-boot/0004-rockchip-rk3328-Set-VOP-QoS-to-high-priority.patch
+++ b/projects/Rockchip/patches/u-boot/0004-rockchip-rk3328-Set-VOP-QoS-to-high-priority.patch
@@ -18,19 +18,19 @@ diff --git a/arch/arm/mach-rockchip/rk3328/rk3328.c b/arch/arm/mach-rockchip/rk3
 index de17b88682..58300bdf3f 100644
 --- a/arch/arm/mach-rockchip/rk3328/rk3328.c
 +++ b/arch/arm/mach-rockchip/rk3328/rk3328.c
-@@ -19,6 +19,8 @@ DECLARE_GLOBAL_DATA_PTR;
+@@ -16,6 +16,8 @@ DECLARE_GLOBAL_DATA_PTR;
  #define GRF_BASE		0xFF100000
  #define UART2_BASE		0xFF130000
  #define FW_DDR_CON_REG		0xFF7C0040
 +#define QOS_VOP_OFFSET		0xFF760080
 +#define QOS_VOP_PRIORITY	0x8
+ #define EFUSE_NS_BASE		0xFF260000
  
- const char * const boot_devices[BROM_LAST_BOOTSOURCE + 1] = {
- 	[BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",
+ #define EFUSE_MOD		0x0000
 @@ -54,6 +56,9 @@ int arch_cpu_init(void)
- 
- 	/* Disable the ddr secure region setting to make it non-secure */
- 	rk_setreg(FW_DDR_CON_REG, 0x200);
+ 	writel(EFUSE_TIMING(1, 4), EFUSE_NS_BASE + EFUSE_T_LOAD_R);
+ 	writel(EFUSE_TIMING(1, 4), EFUSE_NS_BASE + EFUSE_T_ADDR_R);
+ 	writel(EFUSE_TIMING(2, 3), EFUSE_NS_BASE + EFUSE_T_STROBE_R);
 +#else
 +	printf("Setting VOP QoS\n");
 +	rk_setreg(QOS_VOP_OFFSET + QOS_VOP_PRIORITY, 0xF);


### PR DESCRIPTION
Backport commit https://github.com/u-boot/u-boot/commit/5708e8eeae53ad8ce605afdf61e5a83162dc5131 that enables efuse and fixes a bug related to video resolutions <=720p (as discussed here https://github.com/LibreELEC/LibreELEC.tv/pull/8868)
