### PR TITLE
[le12] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="21.0.1-Omega"
-PKG_SHA256="fa0c0bffe41140a224701d4fa1a73c09a45ef0a9f309cc5ad33cdf13795f7812"
-PKG_REV="2"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="9e8c92b49433f46ae681055762ca4c152481b258c9163a1119c1ca08d7e9fd7c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.mediaportal.tvserver"

--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.waipu"
-PKG_VERSION="21.5.1-Omega"
-PKG_SHA256="bad2902e3f890d3e8984e59ec77d4ec666808d36f45decb661fe8e2b8efb410b"
-PKG_REV="2"
+PKG_VERSION="21.6.0-Omega"
+PKG_SHA256="0db467d4986c36efb0c837dd728fc6322d3021fe2d8c93da9355b63f210fa0ca"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/flubshi/pvr.waipu"


### PR DESCRIPTION
- pvr.mediaportal.tvserver: update 21.0.1-Omega to 21.0.2-Omega
- pvr.waipu: update 21.5.1-Omega to 21.6.0-Omega