### PR TITLE
Allwinner: linux: Fix OrangePi 3 LTS ethernet

### DIFF
--- a/projects/Allwinner/patches/linux/0041-OrangePi-3-LTS-support.patch
+++ b/projects/Allwinner/patches/linux/0041-OrangePi-3-LTS-support.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 000000000000..6a5df1103a90
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts
-@@ -0,0 +1,318 @@
+@@ -0,0 +1,316 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +// Copyright (C) 2023 Jernej Skrabec <jernej.skrabec@gmail.com>
 +// Based on sun50i-h6-orangepi-3.dts, which is:
@@ -131,10 +131,10 @@ index 000000000000..6a5df1103a90
 +&emac {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&ext_rgmii_pins>;
-+	phy-mode = "rgmii";
++	phy-mode = "rgmii-rxid";
 +	phy-handle = <&ext_rgmii_phy>;
 +	phy-supply = <&reg_gmac_3v3>;
-+	allwinner,rx-delay-ps = <1500>;
++	allwinner,rx-delay-ps = <0>;
 +	allwinner,tx-delay-ps = <700>;
 +	status = "okay";
 +};
@@ -161,12 +161,10 @@ index 000000000000..6a5df1103a90
 +		reg = <1>;
 +
 +		motorcomm,clk-out-frequency-hz = <125000000>;
-+		motorcomm,keep-pll-enabled;
-+		motorcomm,auto-sleep-disabled;
 +
 +		reset-gpios = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
 +		reset-assert-us = <15000>;
-+		reset-deassert-us = <40000>;
++		reset-deassert-us = <100000>;
 +	};
 +};
 +


### PR DESCRIPTION
Ethernet timings are off, adjust them to match BSP kernel version. Tested by forum user.