### PR TITLE
Package updates

### DIFF
--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.7.6"
-PKG_SHA256="162d72a306bb2e114c24fa25267d0d0a0ac16f39fd95a5c0dfc75a666ee5e4f5"
+PKG_VERSION="0.7.7"
+PKG_SHA256="58c6a28972126828a6f658e084aee7aa8f8bfdb75a0bd0e345c7ff2a6d9ef08c"
 PKG_LICENSE="BSD"
 PKG_SITE="https://lib.openmpt.org/libopenmpt/"
 PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.0.5"
-PKG_SHA256="c5a5de26d684a1a84060ad7b6131654fb2835e03fccad85059be92f8e3ffe993"
+PKG_VERSION="1.0.6"
+PKG_SHA256="aaaaa9825f313f0acc64bd046776da8a2f31e270f20351ecf97438d15aebce79"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.3.9"
-PKG_SHA256="062b9ec5c26cbb236a78f0ba26981272053f59bdfc113040bab904a9da36d31f"
+PKG_VERSION="3.3.10"
+PKG_SHA256="0a79088af2fbde4dbe6655dbc51bbb272b606c0d9116745697e08879e70198a7"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/debug/strace/package.mk
+++ b/packages/debug/strace/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="strace"
-PKG_VERSION="6.8"
-PKG_SHA256="ba6950a96824cdf93a584fa04f0a733896d2a6bc5f0ad9ffe505d9b41e970149"
+PKG_VERSION="6.9"
+PKG_SHA256="da189e990a82e3ca3a5a4631012f7ecfd489dab459854d82d8caf6a865c1356a"
 PKG_LICENSE="BSD"
 PKG_SITE="https://strace.io/"
 PKG_URL="https://strace.io/files/${PKG_VERSION}/strace-${PKG_VERSION}.tar.xz"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.29.2"
-PKG_SHA256="36db4b6926aab741ba6e4b2ea2d99c9193222132308b4dc824d4123cb730352e"
+PKG_VERSION="3.29.3"
+PKG_SHA256="252aee1448d49caa04954fd5e27d189dd51570557313e7b281636716a238bccb"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/devel/libbpf/package.mk
+++ b/packages/devel/libbpf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libbpf"
-PKG_VERSION="1.4.1"
-PKG_SHA256="cc01a3a05d25e5978c20be7656f14eb8b6fcb120bb1c7e8041e497814fc273cb"
+PKG_VERSION="1.4.2"
+PKG_SHA256="cfa2b6fbafab9608a2ab90d0eaf64f05c27dbf76d81bed516385e825f1aad502"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/libbpf/libbpf"
 PKG_URL="https://github.com/libbpf/libbpf/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/libplist/package.mk
+++ b/packages/devel/libplist/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="libplist"
-PKG_VERSION="2.4.0"
-PKG_SHA256="3f5868ae15b117320c1ff5e71be53d29469d4696c4085f89db1975705781a7cd"
+PKG_VERSION="2.6.0"
+PKG_SHA256="67be9ee3169366589c92dc7c22809b90f51911dd9de22520c39c9a64fb047c9c"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.libimobiledevice.org/"
 PKG_URL="https://github.com/libimobiledevice/libplist/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/mimalloc/package.mk
+++ b/packages/devel/mimalloc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mimalloc"
-PKG_VERSION="2.1.4"
-PKG_SHA256="ef31a7c593866a35883b2090654a8d6136a1cf06f22b577b4e1c818b1b0a8796"
+PKG_VERSION="2.1.6"
+PKG_SHA256="0ec960b656f8623de35012edacb988f8edcc4c90d2ce6c19f1d290fbb4872ccc"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/microsoft/mimalloc"
 PKG_URL="https://github.com/microsoft/mimalloc/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/assimp/package.mk
+++ b/packages/graphics/assimp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="assimp"
-PKG_VERSION="5.4.0"
-PKG_SHA256="a90f77b0269addb2f381b00c09ad47710f2aab6b1d904f5e9a29953c30104d3f"
+PKG_VERSION="5.4.1"
+PKG_SHA256="a1bf71c4eb851ca336bba301730cd072b366403e98e3739d6a024f6313b8f954"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/assimp/assimp"
 PKG_URL="https://github.com/assimp/assimp/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="8.4.0"
-PKG_SHA256="af4ea73e25ab748c8c063b78c2f88e48833db9b2ac369e29bd115702e789755e"
+PKG_VERSION="8.5.0"
+PKG_SHA256="77e4f7f98f3d86bf8788b53e6832fb96279956e1c3961988ea3d4b7ca41ddc27"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/libjpeg-turbo/package.mk
+++ b/packages/graphics/libjpeg-turbo/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libjpeg-turbo"
-PKG_VERSION="3.0.2"
-PKG_SHA256="29f2197345aafe1dcaadc8b055e4cbec9f35aad2a318d61ea081f835af2eebe9"
+PKG_VERSION="3.0.3"
+PKG_SHA256="a649205a90e39a548863a3614a9576a3fb4465f8e8e66d54999f127957c25b21"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libjpeg-turbo.org/"
 PKG_URL="https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/nvidia-vaapi-driver/package.mk
+++ b/packages/multimedia/nvidia-vaapi-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia-vaapi-driver"
-PKG_VERSION="0.0.11"
-PKG_SHA256="3e1ed95d7e2b2b1377c9cb59c3e7caaf960134694e9441e1d91c38f224d1d5d9"
+PKG_VERSION="0.0.12"
+PKG_SHA256="435974aeab87cd2cd5c849d18ec4932d5bdf9d6f021385f185c9bf33d7cb2422"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/elFarto/nvidia-vaapi-driver"
 PKG_URL="https://github.com/elFarto/nvidia-vaapi-driver/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.20.0"
-PKG_SHA256="02672542510ac6e5d0c91c0c14d90ab4e6ec397c709e952c6da3a6e0b4d5a42f"
+PKG_VERSION="4.20.1"
+PKG_SHA256="f93c3af5295340d08106c7c0dcfb85e4f85057dfd14587aa8817beb31aff88f7"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Mako"
-PKG_VERSION="1.3.3"
-PKG_SHA256="e16c01d9ab9c11f7290eef1cfefc093fb5a45ee4a3da09e2fec2e4d1bae54e73"
+PKG_VERSION="1.3.5"
+PKG_SHA256="48dbc20568c1d276a2698b36d968fa76161bf127194907ea6fc594fa81f943bc"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/Mako"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/ninja/package.mk
+++ b/packages/python/devel/ninja/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ninja"
-PKG_VERSION="1.12.0"
-PKG_SHA256="8b2c86cd483dc7fcb7975c5ec7329135d210099a89bc7db0590a07b0bbfe49a5"
+PKG_VERSION="1.12.1"
+PKG_SHA256="821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a"
 PKG_LICENSE="Apache"
 PKG_SITE="https://ninja-build.org/"
 PKG_URL="https://github.com/ninja-build/ninja/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.99"
-PKG_SHA256="5f29fea64b3234b33a615b6df40469e239a4168ac0909106bd00e6490b274c31"
+PKG_VERSION="3.100"
+PKG_SHA256="f806cee99be87d55f927e976316e1686b534b64f7a687ac05ba413da7e22d9ba"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="systemd"
-PKG_VERSION="255.5"
-PKG_SHA256="95e419f0bd80fde9f169533e070348beb94073d9a58daf505d719ed3ebfd2411"
+PKG_VERSION="255.6"
+PKG_SHA256="7efc8ce8272a64ff32dc4a27cdc7179973d01e7c63d7b2a66df7ed9795574c04"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd-stable/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.12.6"
-PKG_SHA256="69f08b81d4532d285ceea4cdb017eb2d948cb87c34c1d64248a92be90e84132d"
+PKG_VERSION="2.12.7"
+PKG_SHA256="f86f918e2884675cc0778c644fbc15e3ccbf06fb7fcf24eacd286976c99a6266"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.61.0"
-PKG_SHA256="c0e660175b9dc429f11d25b9507a834fb752eea9135ab420bb7cb7e9dbcc9654"
+PKG_VERSION="1.62.0"
+PKG_SHA256="26798308fa0a12dabdb7ba8c77f74383019d3a0f1f36d25958b836af22474958"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- strace: update to 6.9
- pipewire: update to 1.0.6
- systemd: update to 255.6
- nvidia-vaapi-driver: update to 0.0.12
- cmake: update to 3.29.3
- samba: update to 4.20.1
- libopenmpt: update to 0.7.7
- harfbuzz: update to 8.5.0
- Mako: update to 1.3.5
- nss: update to 3.100
- ninja: update to 1.12.1
- nghttp2: update to 1.62.0
- mimalloc: update to 2.1.6
- mariadb-connector-c: update to 3.3.10
- libxml2: update to 2.12.7
- libplist: update to 2.6.0
- libjpeg-turbo: update to 3.0.3
- libbpf: update to 1.4.2
- assimp: update to 5.4.1