### PR TITLE
Minor compat fixes for gcc-14.1

### DIFF
--- a/packages/tools/bcm2835-utils/patches/bcm2835-utils-86.patch
+++ b/packages/tools/bcm2835-utils/patches/bcm2835-utils-86.patch
@@ -1,0 +1,29 @@
+From 4e4e5736b5c69de3c68c5c02ceddfbe42eb8f915 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 22 May 2024 21:29:31 +1000
+Subject: [PATCH] vclog: fix compiler error with gcc-14.1
+
+Fixes:
+
+./vclog/vclog.c:199:30: error: 'msg.size' may be used uninitialized [-Werror=maybe-uninitialized]
+  199 |             payload_len = msg.size - sizeof(msg_hdr_t);
+      |                           ~~~^~~~~
+./vclog/vclog.c:193:23: note: 'msg' declared here
+  193 |             msg_hdr_t msg;
+      |                       ^~~
+---
+ vclog/vclog.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vclog/vclog.c b/vclog/vclog.c
+index 85e1366..34590fd 100644
+--- a/vclog/vclog.c
++++ b/vclog/vclog.c
+@@ -194,6 +194,7 @@ int32_t main(int32_t argc, char *argv[])
+             uint32_t payload_pos;
+             uint32_t payload_len;
+ 
++            msg.size = 0;
+             payload_pos = log_copy_wrap(log_buffer, log_size,
+                                         read_pos, sizeof(msg), (char *)&msg);
+             payload_len = msg.size - sizeof(msg_hdr_t);

--- a/packages/tools/bcm2835-utils/patches/bcm2835-utils-88.patch
+++ b/packages/tools/bcm2835-utils/patches/bcm2835-utils-88.patch
@@ -1,0 +1,39 @@
+From dc0fd4723907775bdfc3ffb2a612a04d60789ed8 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 22 May 2024 22:04:56 +1000
+Subject: [PATCH] vclog: fix max realloc compiler error
+
+Fixes
+
+./vclog/vclog.c:211:34: error: argument 2 value '4294967288' exceeds maximum object size 2147483647 [-Werror=alloc-size-larger-than=]
+  211 |                 payload_buffer = realloc(payload_buffer, payload_buffer_size);
+      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In file included from ./vclog/vclog.c:17:
+../../toolchain/armv7ve-libreelec-linux-gnueabihf/sysroot/usr/include/stdlib.h:683:14: note: in a call to allocation function 'realloc' declared here
+  683 | extern void *realloc (void *__ptr, size_t __size)
+      |              ^~~~~~~
+---
+ vclog/vclog.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/vclog/vclog.c b/vclog/vclog.c
+index 85e1366..24e2b1e 100644
+--- a/vclog/vclog.c
++++ b/vclog/vclog.c
+@@ -72,6 +72,7 @@ enum
+ };
+ 
+ #define MAX(x, y) (((x) > (y)) ? (x) : (y))
++#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+ #define ARRAY_SIZE(_a) (sizeof(_a)/sizeof(_a[0]))
+ 
+ #define FBIODMACOPY _IOW('z', 0x22, struct fb_dmacopy)
+@@ -207,7 +208,7 @@ int32_t main(int32_t argc, char *argv[])
+             if (payload_len > payload_buffer_size)
+             {
+                 payload_buffer_size = MAX(payload_len, 100); // skip some churn
+-                payload_buffer = realloc(payload_buffer, payload_buffer_size);
++                payload_buffer = realloc(payload_buffer, MIN(INT32_MAX, payload_buffer_size));
+                 if (!payload_buffer)
+                     die("Out of memory");
+             }

--- a/packages/x11/xserver/xorg-server/patches/xorg-server-1560-fix-cast-for-gcc14-1.patch
+++ b/packages/x11/xserver/xorg-server/patches/xorg-server-1560-fix-cast-for-gcc14-1.patch
@@ -1,0 +1,33 @@
+From 70c7dafbd54f94a2a0f1d113cb5536ade62585fb Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 22 May 2024 04:47:12 +0000
+Subject: [PATCH] os/access: fix pointer type mismatch
+
+Fixes compile error with gcc-14.1.0
+
+../os/access.c: In function 'siHostnameAddrMatch':
+../os/access.c:1873:27: error: assignment to 'const char **' from incompatible pointer type 'char **' [-Wincompatible-pointer-types]
+ 1873 |             for (addrlist = hp->h_addr_list; *addrlist; addrlist++)
+      |                           ^
+
+Signed-off-by: Rudi Heitbaum rudi@heitbaum.com
+---
+ os/access.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/os/access.c b/os/access.c
+index c7a2ab8c56..e694cd7925 100644
+--- a/os/access.c
++++ b/os/access.c
+@@ -1882,7 +1882,7 @@ siHostnameAddrMatch(int family, void *addr, int len,
+         if ((hp = _XGethostbyname(hostname, hparams)) != NULL) {
+ #ifdef h_addr                   /* new 4.3bsd version of gethostent */
+             /* iterate over the addresses */
+-            for (addrlist = hp->h_addr_list; *addrlist; addrlist++)
++            for (addrlist = (const char **) hp->h_addr_list; *addrlist; addrlist++)
+ #else
+             addrlist = &hp->h_addr;
+ #endif
+-- 
+GitLab
+


### PR DESCRIPTION
- bcm2835-utils: fix gcc-14 build
  - https://github.com/raspberrypi/utils/pull/86
  - https://github.com/raspberrypi/utils/pull/88
- xorg-server: fix gcc-14 build