### PR TITLE
Addon fixes for gcc-14.1

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/unclutter/patches/unclutter-0001-fix-gcc-14-1-build.patch
+++ b/packages/addons/addon-depends/chrome-depends/unclutter/patches/unclutter-0001-fix-gcc-14-1-build.patch
@@ -1,0 +1,74 @@
+--- a/unclutter.c	2007-02-05 23:13:12.000000000 +0000
++++ b/unclutter.c	2024-05-23 07:41:37.115416042 +0000
+@@ -37,14 +37,15 @@
+ #include <X11/Xutil.h>
+ #include <X11/Xproto.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include "vroot.h"
+ 
+ char *progname;
+-pexit(str)char *str;{
++int pexit(str)char *str;{
+     fprintf(stderr,"%s: %s\n",progname,str);
+     exit(1);
+ }
+-usage(){
++void usage(){
+     pexit("usage:\n\
+ 	-display <display>\n\
+ 	-idle <seconds>		time between polls to detect idleness.\n\
+@@ -79,6 +80,7 @@
+ {
+     if(error->error_code!=BadWindow)
+ 	(*defaulthandler)(display,error);
++    return 0;
+ }
+ 
+ char **names;	/* -> argv list of names to avoid */
+@@ -87,7 +89,7 @@
+  * return true if window has a wm_name and the start of it matches
+  * one of the given names to avoid
+  */
+-nameinlist(display,window)
++int nameinlist(display,window)
+ Display *display;
+ Window window;
+ {
+@@ -109,7 +111,7 @@
+  * return true if window has a wm_name and one of the given names to avoid
+  * matches anywhere in that string
+  */
+-matchinlist(display,window)
++int matchinlist(display,window)
+ Display *display;
+ Window window;
+ {
+@@ -131,7 +133,7 @@
+ /*
+  * create a small 1x1 cursor with all pixels masked out on the given screen.
+  */
+-createnullcursor(display,root)
++Cursor createnullcursor(display,root)
+ Display *display;
+ Window root;
+ {
+@@ -155,7 +157,7 @@
+     return cursor;
+ }
+ 
+-main(argc,argv)char **argv;{
++int main(argc,argv)int argc;char **argv;{
+     Display *display;
+     int screen,oldx = -99,oldy = -99,numscreens;
+     int doroot = 0, jitter = 0, idletime = 5, usegrabmethod = 0, waitagain = 0,
+--- a/vroot.h	2007-02-05 22:52:40.000000000 +0000
++++ b/vroot.h	2024-05-23 07:59:50.811488716 +0000
+@@ -40,6 +40,7 @@
+ static Window
+ VirtualRootWindow(dpy, screen)
+ Display *dpy;
++int screen;
+ {
+ 	static Display *save_dpy = (Display *)0;
+ 	static int save_screen = -1;

--- a/packages/addons/addon-depends/tslib/patches/tslib-40-fix-gcc-14-1.patch
+++ b/packages/addons/addon-depends/tslib/patches/tslib-40-fix-gcc-14-1.patch
@@ -1,0 +1,10 @@
+--- a/src/ts_reconfig.c	2024-05-23 07:01:59.264165839 +0000
++++ b/src/ts_reconfig.c	2024-05-23 07:01:54.034129359 +0000
+@@ -16,6 +16,7 @@
+ #include <unistd.h>
+ #endif
+ #include <dlfcn.h>
++#include <string.h>
+ 
+ #include "tslib-private.h"
+ 

--- a/packages/addons/service/lcdd/patches/lcdd-0.5.6-dm140_henlar_v0.2.patch
+++ b/packages/addons/service/lcdd/patches/lcdd-0.5.6-dm140_henlar_v0.2.patch
@@ -141,7 +141,7 @@ index 0000000..56f9219
 +	p->gFlags = 0;
 +	p->gDisplayMode = VFD_MODE_NONE;
 +	
-+	if ((p->framebuf = (char *) calloc(1, p->height)) == NULL)
++	if ((p->framebuf = (char **) calloc(1, p->height)) == NULL)
 +	{
 +	  report(RPT_CRIT, "Allocating memory for framebuffer Failed\n");
 +	  return -1;
@@ -362,7 +362,7 @@ new file mode 100644
 index 0000000..0bb565c
 --- /dev/null
 +++ b/server/drivers/led.c
-@@ -0,0 +1,1065 @@
+@@ -0,0 +1,1066 @@
 +/* File modified by Henrik Larsson 2007 to interface with LCDproc API
 + */
 +
@@ -394,6 +394,7 @@ index 0000000..0bb565c
 +#include "libvfd.h"
 +#include "shared/report.h"
 +#include "dm140.h"
++#include "led.h"
 +
 +
 +//**************************************************************

--- a/packages/emulation/libretro-picodrive/patches/picodrive-02-fix-build-gcc-14-1.patch
+++ b/packages/emulation/libretro-picodrive/patches/picodrive-02-fix-build-gcc-14-1.patch
@@ -1,0 +1,11 @@
+--- a/pico/carthw/svp/compiler.c	2024-05-23 07:19:59.237513012 +0000
++++ b/pico/carthw/svp/compiler.c	2024-05-23 07:19:48.767443545 +0000
+@@ -1797,7 +1797,7 @@
+ 
+ 	if (tcache_ptr - (u32 *)tcache > DRC_TCACHE_SIZE/4) {
+ 		elprintf(EL_ANOMALY|EL_STATUS|EL_SVP, "tcache overflow!\n");
+-		fflush(stdout);
++		fflush((RFILE *)stdout);
+ 		exit(1);
+ 	}
+ 

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -17,6 +17,11 @@ PKG_CMAKE_OPTS_TARGET="-DENABLE_CCACHE=1 \
                        -DENABLE_TESTS=0 \
                        -DENABLE_TOOLS=0"
 
+#workaround gcc-14 erroring with neon declarations
+if [ "${ARCH}" = "arm" ]; then
+  TARGET_CFLAGS+=" -Wno-implicit-function-declaration"
+fi
+
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   PKG_DEPENDS_TARGET+=" nasm:host"
 elif ! target_has_feature neon; then


### PR DESCRIPTION
- lcdd: fix gcc-14 build
  - fixes local dm140 patch
- aom: workaround gcc-14 error on 32-bit targets
  - https://bugs.chromium.org/p/aomedia/issues/detail?id=3576
- unclutter: fix gcc-14 build
  - fixes unmaintained upstream
- libretro-picodrive: fix gcc-14 build on arm32
  - https://github.com/libretro/picodrive/issues/227
  - https://github.com/LibreELEC/LibreELEC.tv/issues/8917
- tslib: fix gcc-14 build
  - https://github.com/LibreELEC/LibreELEC.tv/issues/8916