### PR TITLE
xf86-video-nvidia-legacy: patches for linux-6.8 and gcc-14.1

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia-legacy/patches/xf86-video-nvidia-legacy-100.15-kernel-6.8.patch
+++ b/packages/x11/driver/xf86-video-nvidia-legacy/patches/xf86-video-nvidia-legacy-100.15-kernel-6.8.patch
@@ -1,0 +1,11 @@
+diff -Naur a/kernel/conftest.sh b/kernel/conftest.sh
+--- a/kernel/conftest.sh	2024-03-17 06:12:58.410530788 +0000
++++ b/kernel/conftest.sh	2024-03-17 06:12:58.410530788 +0000
+@@ -1573,6 +1573,7 @@
+         ;;
+ 
+         drm_available)
++            return
+             #
+             # Determine if the DRM subsystem is usable
+             #

--- a/packages/x11/driver/xf86-video-nvidia-legacy/patches/xf86-video-nvidia-legacy-100.16-gcc-14.patch
+++ b/packages/x11/driver/xf86-video-nvidia-legacy/patches/xf86-video-nvidia-legacy-100.16-gcc-14.patch
@@ -1,0 +1,24 @@
+diff -Naur a/kernel/conftest.sh b/kernel/conftest.sh
+--- a/kernel/conftest.sh	2024-05-10 16:44:09.219463660 +0000
++++ b/kernel/conftest.sh	2024-05-10 16:45:33.696827888 +0000
+@@ -196,7 +196,7 @@
+ }
+ 
+ build_cflags() {
+-    BASE_CFLAGS="-O2 -D__KERNEL__ \
++    BASE_CFLAGS="-O2 -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM"
+ 
+diff -Naur a/kernel/uvm/conftest.sh b/kernel/uvm/conftest.sh
+--- a/kernel/uvm/conftest.sh	2024-05-10 16:44:09.206130218 +0000
++++ b/kernel/uvm/conftest.sh	2024-05-10 16:45:45.273592434 +0000
+@@ -196,7 +196,7 @@
+ }
+ 
+ build_cflags() {
+-    BASE_CFLAGS="-O2 -D__KERNEL__ \
++    BASE_CFLAGS="-O2 -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM"
+ 


### PR DESCRIPTION
source:
- https://aur.archlinux.org/packages/nvidia-340xx
- Bring forward patch from #8890 to allow gcc-14.1 compile