### PR TITLE
[le12] linux (RPi): update to 6.6.31

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="dda85fda5b2dda7c4e2ba18770bd2033313006d2" # 6.6.30
-    PKG_SHA256="55de2075e2b4d21b3d4f3159bc686dcbd938f6d61e56b21c51b58ef6919f1ac2"
+    PKG_VERSION="886f86f97c0b64322aec955f62d9b1fd3330304e" # 6.6.30
+    PKG_SHA256="83a2c5ae5ffc39cf62211ac65e3078951f8a76a549b06a260decf56d135ec354"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="886f86f97c0b64322aec955f62d9b1fd3330304e" # 6.6.30
-    PKG_SHA256="83a2c5ae5ffc39cf62211ac65e3078951f8a76a549b06a260decf56d135ec354"
+    PKG_VERSION="1ac74d2f9773922731a11bc329ae2710fce172d4" # 6.6.31
+    PKG_SHA256="961ce72e339ca024c6dd1ae57c0dfc25ab1f39eee9699813a535f138b31d670c"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="1ac74d2f9773922731a11bc329ae2710fce172d4" # 6.6.31
-    PKG_SHA256="961ce72e339ca024c6dd1ae57c0dfc25ab1f39eee9699813a535f138b31d670c"
+    PKG_VERSION="573f8fd0abf1d63ef719672a3c26e7abc0169620" # 6.6.31
+    PKG_SHA256="61f3e50e8841787ab3c8dff0e26ded2a4f4ff671603f6be8f7bcc61286eaf037"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="2b2c8103ff4b1b6d64345af5864f25841199e2dd"
-PKG_SHA256="d9c9d48ec635764a2a6d9c3744653bfcbd4a7078186b16d16811e3cf1d0be346"
+PKG_VERSION="61fb89536fc94a57c1e0afd42617849b6d0cac37"
+PKG_SHA256="952c6348b65cbeca05da449dce3fa5f307d54997b1a9788e235eb1ac403ae21e"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="9a5a522ee8a17d4d445b4bb108c4da75bed829fe"
-PKG_SHA256="414cbdf196a93a72e67d761adf4b66404a11e68a2a003261bc90649b6c2a2c5a"
+PKG_VERSION="2b2c8103ff4b1b6d64345af5864f25841199e2dd"
+PKG_SHA256="d9c9d48ec635764a2a6d9c3744653bfcbd4a7078186b16d16811e3cf1d0be346"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Backport of #8924 

Runtime tested on RPi5