### PR TITLE
system-tools: add tree to add-on

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/tree/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/tree/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="tree"
+PKG_VERSION="2.1.1"
+PKG_SHA256="1b70253994dca48a59d6ed99390132f4d55c486bf0658468f8520e7e63666a06"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/Old-Man-Programmer/tree"
+PKG_URL="https://github.com/Old-Man-Programmer/tree/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Tree is utility for displaying a dictionary tree's contents including files, directories, and links."
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+  make tree CXX=${CXX} CC=${CC}
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+    cp -p tree ${INSTALL}/usr/bin/
+}

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -11,7 +11,7 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of system tools and programs"
-PKG_LONGDESC="This bundle currently includes 7-zip, autossh, bottom, diffutils, dool, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, libgpiod, lm_sensors, lshw, mc, mmc-utils, mtpfs, nmon, patch, pv, screen, smartmontools, stress-ng, unrar, usb-modeswitch and vim."
+PKG_LONGDESC="This bundle currently includes 7-zip, autossh, bottom, diffutils, dool, dtach, efibootmgr, encfs, evtest, fdupes, file, getscancodes, hddtemp, hd-idle, hid_mapper, htop, i2c-tools, inotify-tools, jq, libgpiod, lm_sensors, lshw, mc, mmc-utils, mtpfs, nmon, patch, pv, screen, smartmontools, stress-ng, tree, unrar, usb-modeswitch and vim."
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="System Tools"
@@ -49,6 +49,7 @@ PKG_DEPENDS_TARGET="toolchain \
                     sdparm \
                     smartmontools \
                     stress-ng \
+                    tree \
                     unrar \
                     usb-modeswitch \
                     vim"
@@ -176,6 +177,9 @@ addon() {
 
     # stress-ng
     cp -P $(get_install_dir stress-ng)/usr/bin/stress-ng ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+
+    # tree
+    cp -P $(get_install_dir tree)/usr/bin/tree ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 
     # unrar
     cp -P $(get_install_dir unrar)/usr/bin/unrar ${ADDON_BUILD}/${PKG_ADDON_ID}/bin


### PR DESCRIPTION
This adds the `tree` binary to system-tools.