### PR TITLE
heimdal: fix configuration with gcc 14

### DIFF
--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -13,6 +13,11 @@ PKG_LONGDESC="Kerberos 5, PKIX, CMS, GSS-API, SPNEGO, NTLM, Digest-MD5 and, SASL
 PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="-parallel"
 
+pre_configure_host() {
+  # configure step misconfigures with gcc 14 unless this error is degraded to a warning
+  export CFLAGS=-Wno-error=implicit-function-declaration
+}
+
 PKG_CONFIGURE_OPTS_HOST="ac_cv_prog_COMPILE_ET=no \
                          --enable-static --disable-shared \
                          --without-openldap \


### PR DESCRIPTION
On distros, which already use gcc 14, e.g. Arch, heimdal fails to build due to a misconfiguration. Heimdal autotools scripts heavily depend on implicit function declarations. This approach was elevated to an error with gcc14. Explicitly downgrade it to a warning until heimdal configuration is not fixed.