### PR TITLE
media-driver: update to 24.2.4

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="24.2.3"
-PKG_SHA256="d8b085e5a0bfe8714f716fc96a36bf287827388e5a668a2f39b41cf3b2026f9c"
+PKG_VERSION="24.2.4"
+PKG_SHA256="2f65a08ebd2f0111c079f2839621fab4f648ecd15cccdd8eecd96a1217880b63"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20240529125629-b849cfc
Linux nuc12 6.10.0-rc1 #1 SMP Tue May 28 13:24:17 UTC 2024 x86_64 GNU/Linux
Starting Kodi (21.0 (21.0.0) Git:21.0-Omega). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-05-29 by GCC 14.1.0 for Linux x86 64-bit version 6.10.0 (395776)
Running on LibreELEC (heitbaum): devel-20240529125629-b849cfc 13.0, kernel: Linux x86 64-bit version 6.10.0-rc1
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0092.2024.0202.1711 02/02/2024
[    0.000000] DMI: Memory slots populated: 1/2
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.1.0
libva info: VA-API version 1.21.0
vainfo: VA-API version: 1.21 (libva 2.21.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.2.4 (b849cfc772)
```