### PR TITLE
ccache: update to 4.10

### DIFF
--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccache"
-PKG_VERSION="4.9.1"
-PKG_SHA256="4c03bc840699127d16c3f0e6112e3f40ce6a230d5873daa78c60a59c7ef59d25"
+PKG_VERSION="4.10"
+PKG_SHA256="83630b5e922b998ab2538823e0cad962c0f956fad1fcf443dd5288269a069660"
 PKG_LICENSE="GPL"
 PKG_SITE="https://ccache.dev/download.html"
 PKG_URL="https://github.com/ccache/ccache/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_HOST="cmake:host make:host zstd:host"
+PKG_DEPENDS_HOST="cmake:host make:host zstd:host libfmt:host xxHash:host"
 PKG_LONGDESC="A compiler cache to speed up re-compilation of C/C++ code by caching."
 # Override toolchain as ninja is not built yet
 PKG_TOOLCHAIN="cmake-make"
@@ -25,8 +25,8 @@ configure_host() {
         -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN} \
         -DENABLE_DOCUMENTATION=OFF \
         -DREDIS_STORAGE_BACKEND=OFF \
-        -DZSTD_FROM_INTERNET=OFF \
         -DENABLE_TESTING=OFF \
+        -DDEPS=SYSTEM \
         ..
 }
 

--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -7,12 +7,29 @@ PKG_SHA256="1250e4cc58bf06ee631567523f48848dc4596133e163f02615c97f78bab6c811"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/fmtlib/fmt"
 PKG_URL="https://github.com/fmtlib/fmt/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="cmake:host make:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="fmt is an open-source formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams."
+PKG_TOOLCHAIN="cmake-make"
+PKG_BUILD_FLAGS="+local-cc"
 
-PKG_CMAKE_OPTS_TARGET="-DCMAKE_CXX_STANDARD=14 \
+PKG_CMAKE_OPTS_COMMON="-DCMAKE_CXX_STANDARD=14 \
                        -DCMAKE_CXX_EXTENSIONS:BOOL=OFF \
                        -DFMT_DOC=OFF \
                        -DFMT_INSTALL=ON \
                        -DFMT_TEST=OFF \
                        -DBUILD_SHARED_LIBS=ON"
+
+PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_COMMON}"
+
+configure_host() {
+  # custom cmake build to override the LOCAL_CC/CXX
+  cp ${CMAKE_CONF} cmake-ccache.conf
+
+  echo "SET(CMAKE_C_COMPILER   ${CC})"  >> cmake-ccache.conf
+  echo "SET(CMAKE_CXX_COMPILER ${CXX})" >> cmake-ccache.conf
+  cmake -DCMAKE_TOOLCHAIN_FILE=cmake-ccache.conf \
+        -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN} \
+        ${PKG_CMAKE_OPTS_COMMON} \
+        ..
+}

--- a/packages/devel/xxHash/package.mk
+++ b/packages/devel/xxHash/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="xxHash"
+PKG_VERSION="0.8.2"
+PKG_SHA256="baee0c6afd4f03165de7a4e67988d16f0f2b257b51d0e3cb91909302a26a79c4"
+PKG_LICENSE="BSD-2-Clause"
+PKG_SITE="https://xxhash.com"
+PKG_URL="https://github.com/Cyan4973/xxHash/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="make:host"
+PKG_LONGDESC="Extremely fast non-cryptographic hash algorithm"
+PKG_BUILD_FLAGS="+local-cc"
+
+pre_configure_host() {
+  export prefix=${TOOLCHAIN}/usr
+}


### PR DESCRIPTION
- ccache: update to 4.10
  - Release notes:
  - https://ccache.dev/releasenotes.html#_ccache_4_10
- libfmt: add host build
- xxHash: initial package