### PR TITLE
libmicrohttpd: swap to shared library

### DIFF
--- a/packages/web/libmicrohttpd/package.mk
+++ b/packages/web/libmicrohttpd/package.mk
@@ -11,8 +11,8 @@ PKG_URL="http://ftpmirror.gnu.org/libmicrohttpd/${PKG_NAME}-${PKG_VERSION}.tar.g
 PKG_DEPENDS_TARGET="toolchain gnutls"
 PKG_LONGDESC="A small C library that is supposed to make it easy to run an HTTP server as part of another application."
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
-                           --enable-static \
+PKG_CONFIGURE_OPTS_TARGET="--enable-shared \
+                           --disable-static \
                            --disable-examples \
                            --disable-curl \
                            --enable-https"


### PR DESCRIPTION
libmicrohttpd: swap to shared library
- confirmed that this works with both Omega and P
- slight reduction of file size
- https://github.com/xbmc/xbmc/pull/25228#issuecomment-2137087948

the kodi.bin + the .so is actually smaller than that of the kodi.bin compiled against .a

```
232680 May 29 09:44 build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/libmicrohttpd-1.0.1/usr/lib/libmicrohttpd.so.12.62.1

359688 May 25 09:19 build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/libmicrohttpd-1.0.1/usr/lib/libmicrohttpd.a

26878992 May 29 10:24 build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/kodi-42120bb9047912b9379dadffdbdef9968062cf70/usr/lib/kodi/kodi.bin

26635528 May 29 10:02 build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/kodi-42120bb9047912b9379dadffdbdef9968062cf70/usr/lib/kodi/kodi.bin 

Kodi is 243464 smaller with the .so
Overall 10784 bytes smaller
```
