### PR TITLE
xxHash: fix toolchain target directory

### DIFF
--- a/packages/devel/xxHash/package.mk
+++ b/packages/devel/xxHash/package.mk
@@ -12,5 +12,5 @@ PKG_LONGDESC="Extremely fast non-cryptographic hash algorithm"
 PKG_BUILD_FLAGS="+local-cc"
 
 pre_configure_host() {
-  export prefix=${TOOLCHAIN}/usr
+  export prefix=${TOOLCHAIN}
 }


### PR DESCRIPTION
ref:
https://github.com/LibreELEC/LibreELEC.tv/pull/8945#discussion_r1623416529 

Thanks for spotting my error and fixing @mglae - yes ubuntu had the .so in `/lib/x86_64-linux-gnu/libxxhash.so.0` and I didnt notice as it picked up the headers fine.

