### PR TITLE
openssl: update to 3.3.1

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="3.3.0"
-PKG_SHA256="53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02"
+PKG_VERSION="3.3.1"
+PKG_SHA256="777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://www.openssl.org"
 PKG_URL="https://www.openssl.org/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.openssl.org

Release notes:
- https://www.openssl.org/news/vulnerabilities.html