### PR TITLE
Addon updates 

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="d361896cd02deb3bd160c627401eba2cd8e2513a085c55427319bea8c6412ad4"
+PKG_SHA256="73f914421db873d1a19d4d15e8ae21bebc35079f3034f574dfc6cd0449edcf89"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="b72abbb6f0351eb22e5c7bdbba9112fef6b41429"
+export PKG_GIT_COMMIT="5650f9b10226d75e8e9a490a31cc3e5b846e0034"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.7.17"
-PKG_SHA256="fa16a85b3759a716728c00dda2fff8484b3811f62250724b77d05c115c4522a7"
+PKG_VERSION="1.7.18"
+PKG_SHA256="91685cebd50e3f353a402adadf61e2a6aeda3f63754fa0fcc978a043e00acac4"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="3a4de459a68952ffb703bbe7f2290861a75b6b67"
+export PKG_GIT_COMMIT="ae71819c4f5e67bb4d5ae76a6b735f29cc25774e"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="26.1.3"
-PKG_SHA256="2f51e2dd1c122e364510c95f66e94b7fff9d5199545484e92c2e52b0efcdc2e6"
+PKG_VERSION="26.1.4"
+PKG_SHA256="74d3f38f2b88399012e0b889e6408d81e2d198437deda71da6d1da72dcc8afcc"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="8e96db1c328d0467b015768e42a62c0f834970bb"
+export PKG_GIT_COMMIT="de5c9cf0b96e4e172b96db54abababa4a328462f"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.22.3"
-PKG_SHA256="a6ec566a848966c33154bb7d7f13be593a13365de48f4cb599a3cfdc9779ecd7"
+PKG_VERSION="1.22.4"
+PKG_SHA256="8e035e7418ae53a20a4c9eedc906e5c43e8c31f5bfc044d2f9f70dc409cd88b1"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="10.11.8"
-PKG_REV="1"
-PKG_SHA256="5f04f3e33d9f1cbeff05e79c54d41d302630500c995aee72b0638e2f9dfcdf0f"
+PKG_VERSION="11.4.2"
+PKG_REV="2"
+PKG_SHA256="8c600e38adb899316c1cb11c68b87979668f4fb9d858000e347e6d8b7abe51b0"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://downloads.mariadb.com/MariaDB/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- docker: update to 26.1.4 and addon (2)
  - containerd: update to 1.7.18
  - cli: update to 26.1.4
  - moby: update to 26.1.4
  - go: update to 1.22.4
- mariadb: update to 11.4.2 and addon (2)