### PR TITLE
[le12] mesa: update to 24.0.9

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="24.0.8"
-PKG_SHA256="d1ed86a266d5b7b8c136ae587ef5618ed1a9837a43440f3713622bf0123bf5c1"
+PKG_VERSION="24.0.9"
+PKG_SHA256="51aa686ca4060e38711a9e8f60c8f1efaa516baf411946ed7f2c265cd582ca4c"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
**This is the last update for mesa as used by LE12**

[ANNOUNCE] mesa 24.0.9

Hello everyone,

The bugfix release 24.0.9 is now available.

This is the last release of the 24.0 series. Users are encouraged to
switch to the 24.1 series to continue receiving bugfixes.

Cheers,
  Eric

---

Alexandre Marquet (1):
      pan/mdg: quirk to disable auto32

David Heidelberg (2):
      subprojects: uprev perfetto to v45.0
      ci/nouveau: move disabled jobs back from include into main gitlab-ci.yml

David Rosca (1):
      frontends/va: Fix leak when destroying VAEncCodedBufferType

Eric Engestrom (13):
      docs: add sha256sum for 24.0.8
      .pick_status.json: Update to 18c736bcfc55b8fa309ede02332b9c7a2ca22e78
      .pick_status.json: Mark 01bac643f6c088f7537edf18f2d4094881c1ecda as denominated
      .pick_status.json: Update to 4b6f7613c0bd161548f1bd45d42b65b4841a278a
      .pick_status.json: Mark eefe34127f8e8ae2ba91a7837b9dfef999dc3f87 as denominated
      .pick_status.json: Update to a1ea0956b46778d0331e4ef60ebd2be057fd0e9f
      .pick_status.json: Mark 410ca6a3e99c5c1c9c91f0f79bf43a35103cbd98 as denominated
      freedreno/a6xx: fix kernel -> compute handling
      panfrost: mark tests as fixed
      panfrost/ci: add missing genxml trigger path
      .pick_status.json: Update to 6f713a764fb412567caaabd9ae574822e79da383
      docs: add release notes for 24.0.9
      VERSION: bump for 24.0.9

Eric R. Smith (4):
      get_color_read_type: make sure format/type combo is legal for gles
      glsl: test both inputs when sorting varyings for xfb
      panfrost: fix some omissions in valhall flow control
      panfrost: change default rounding mode for samplers

Friedrich Vock (2):
      radv: Use max_se instead of num_se where appropriate
      radeonsi: Use max_se instead of num_se where appropriate

Iago Toral Quiroga (4):
      broadcom/compiler: make add_node return the node index
      broadcom/compiler: don't assign payload registers to spilling setup temps
      broadcom/compiler: apply payload conflict to spill setup before RA
      v3dv: fix incorrect index buffer size

Iván Briano (1):
      anv: check cmd_buffer is on a transfer queue more properly

Jose Maria Casanova Crespo (8):
      v3d: fix CLE MMU errors avoiding using last bytes of CL BOs.
      v3dv: fix CLE MMU errors avoiding using last bytes of CL BOs.
      v3d: Increase alignment to 16k on CL BO on RPi5
      v3dv: Increase alignment to 16k on CL BO on RPi5
      v3dv: V3D_CL_MAX_INSTR_SIZE bytes in last CL instruction not needed
      v3dv: Emit stencil draw clear if needed for GFXH-1461
      v3dv: really fix CLE MMU errors on 7.1HW Rpi5
      v3d: really fix CLE MMU errors on 7.1HW Rpi5

Juan A. Suarez Romero (1):
      ci: define SNMP base interface on runner

Karol Herbst (5):
      gallium/vl: stub vl_video_buffer_create_as_resource
      gallium/vl: remove stubs which are defined in mesa_util
      meson: centralize galliumvl_stub handling
      rusticl: link against libgalliumvl_stub
      rusticl/event: fix deadlock when calling clGetEventProfilingInfo inside callbacks

Kevin Chuang (1):
      anv: Properly fetch partial results in vkGetQueryPoolResults

Lionel Landwerlin (5):
      anv: use weak_ref mode for global pipeline caches
      anv: fix shader identifier handling
      intel/brw: ensure find_live_channel don't access arch register without sync
      anv: fix utrace compute walker timestamp captures
      anv: fix timestamp copies from secondary buffers

Renato Pereyra (1):
      anv: Attempt to compile all pipelines even after errors

Rhys Perry (3):
      aco: create lcssa phis for continue_or_break loops when necessary
      aco: create lcssa phis for continue_or_break loops when necessary
      radv: malloc graphics pipeline stages

Samuel Pitoiset (6):
      radv: allow 3d views with VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT
      radv: set image view descriptors as buffer for non-graphics GPU
      radv: mark some formats as unsupported on GFX8/CARRIZO
      radv: only set ALPHA_IS_ON_MSB if the image has DCC on GFX6-9
      radv: fix setting a custom pitch for CB on GFX10_3+
      radv: fix flushing DB meta cache on GFX11.5

Tapani Pälli (1):
      anv/android: enable emulated astc for applications

Yusuf Khan (1):
      zink/query: begin time elapsed queries even if we arent in a rp

git tag: mesa-24.0.9

https://mesa.freedesktop.org/archive/mesa-24.0.9.tar.xz
SHA256: 51aa686ca4060e38711a9e8f60c8f1efaa516baf411946ed7f2c265cd582ca4c  mesa-24.0.9.tar.xz
SHA512: de2ee6c9df1fc106ee10befe0a76be1e9cfe83d65dbdb83bad6d8d7cfaa085232fb115293a1a790b37b50b1fe14bd58aafbcfe5a15e953b5901a7105d57569a5  mesa-24.0.9.tar.xz
PGP:  https://mesa.freedesktop.org/archive/mesa-24.0.9.tar.xz.sig