### PR TITLE
linux: backport anysee usb patch from Linux 6.10

### DIFF
--- a/packages/linux/patches/linux-999.99-backport-media-anysee-accept-read-buffers-of-length-1.patch
+++ b/packages/linux/patches/linux-999.99-backport-media-anysee-accept-read-buffers-of-length-1.patch
@@ -1,0 +1,49 @@
+From 826beca0ce76876507372349da860a986078eacd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Istv=C3=A1n=20V=C3=A1radi?= <ivaradi@varadiistvan.hu>
+Date: Tue, 13 Feb 2024 21:20:32 +0100
+Subject: [PATCH] media: anysee: accept read buffers of length 1 in
+ anysee_master_xfer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+anysee_master_xfer currently accepts read messages of length 2 only.
+However, several frontends, e.g. tda10023 send buffers of length 1,
+containing an 8-bit register number (see tda10023_readreg).
+These buffers are rejected currently, making many Anysee variants
+to not work. In these cases the "Unsupported Anysee version"
+message is logged.
+
+This patch alters the function to accept buffers of a length of 1 too.
+
+Signed-off-by: István Váradi <ivaradi@varadiistvan.hu>
+Signed-off-by: Hans Verkuil <hverkuil-cisco@xs4all.nl>
+[hverkuil: add spaces around '<', fix typo in 'sevaral']
+---
+ drivers/media/usb/dvb-usb-v2/anysee.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/usb/dvb-usb-v2/anysee.c b/drivers/media/usb/dvb-usb-v2/anysee.c
+index a1235d0cce92..8699846eb416 100644
+--- a/drivers/media/usb/dvb-usb-v2/anysee.c
++++ b/drivers/media/usb/dvb-usb-v2/anysee.c
+@@ -202,14 +202,14 @@ static int anysee_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msg,
+ 
+ 	while (i < num) {
+ 		if (num > i + 1 && (msg[i+1].flags & I2C_M_RD)) {
+-			if (msg[i].len != 2 || msg[i + 1].len > 60) {
++			if (msg[i].len < 1 || msg[i].len > 2 || msg[i + 1].len > 60) {
+ 				ret = -EOPNOTSUPP;
+ 				break;
+ 			}
+ 			buf[0] = CMD_I2C_READ;
+ 			buf[1] = (msg[i].addr << 1) | 0x01;
+ 			buf[2] = msg[i].buf[0];
+-			buf[3] = msg[i].buf[1];
++			buf[3] = (msg[i].len < 2) ? 0 : msg[i].buf[1];
+ 			buf[4] = msg[i].len-1;
+ 			buf[5] = msg[i+1].len;
+ 			ret = anysee_ctrl_msg(d, buf, 6, msg[i+1].buf,
+-- 
+2.34.1
+


### PR DESCRIPTION
This backports a kernel patch from Linux 6.10 to LE12 to resolve an issue with Anysee USB DVB sticks reported in the forum: https://forum.libreelec.tv/thread/28025-tv-adapter-drivers-missing-from-11-0-4/?postID=192938#post192938