### PR TITLE
eventlircd: bump to fix assert issue with systemd udev

### DIFF
--- a/packages/sysutils/eventlircd/package.mk
+++ b/packages/sysutils/eventlircd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="eventlircd"
-PKG_VERSION="fd511a9cc7de6af4517604fdc2b3f0f5b64c2a81"
-PKG_SHA256="4c7a93d31845085272e497611159910af69e37a0f70925f36880ba40f4693e23"
+PKG_VERSION="8f20b3196bf7085b6c90d86f1602fb29e3965cbc"
+PKG_SHA256="029ad9eb554bdfd65fe285c9bef9f5eea7c3b0d97a84dd99a2eb65f80c1848fe"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/eventlircd"
 PKG_URL="https://github.com/LibreELEC/eventlircd/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
This resolves forum reports of non working IR since the most revent systemd bump.