### PR TITLE
ffmpeg, ffmpegx: allow dash demuxer by enabling libxml2

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="9b16b8731d78e596b4be0d720428ca42df642bb2d78342881ff7f5bc29fc9623"
 PKG_LICENSE="GPL-3.0-only"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="https://ffmpeg.org/releases/ffmpeg-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain aom bzip2 openssl lame libvorbis opus x264 zlib"
+PKG_DEPENDS_TARGET="toolchain aom bzip2 openssl lame libvorbis libxml2 opus x264 zlib"
 PKG_LONGDESC="FFmpegx is an complete FFmpeg build to support encoding and decoding."
 PKG_BUILD_FLAGS="-sysroot"
 
@@ -162,6 +162,7 @@ configure_target() {
     --enable-pic \
     --disable-gnutls \
     --enable-openssl \
+    --enable-libxml2 \
     \
     `#Advanced options` \
     --disable-hardcoded-tables \

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -29,8 +29,4 @@ addon() {
     cp -PL $(get_install_dir x265)/usr/lib/libx265.so.209 \
            ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
   fi
-  if [ "${DISPLAYSERVER}" = "x11" ]; then
-    cp -PL $(get_install_dir libxcb)/usr/lib/{libxcb.so.1,libxcb-shm.so.0,libxcb-shape.so.0,libxcb-xfixes.so.0} \
-           ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
-  fi
 }

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="9b16b8731d78e596b4be0d720428ca42df642bb2d78342881ff7f5bc29fc9623"
 PKG_LICENSE="GPL-3.0-only"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="http://ffmpeg.org/releases/ffmpeg-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex"
+PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex libxml2"
 PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
 PKG_PATCH_DIRS="libreelec"
 
@@ -227,6 +227,7 @@ configure_target() {
               --disable-libvpx \
               --disable-libx264 \
               --disable-libxavs \
+              --enable-libxml2 \
               --disable-libxvid \
               --enable-zlib \
               --enable-asm \


### PR DESCRIPTION
As reported in the [forum](https://forum.libreelec.tv/thread/28654-ffmpeg-cannot-stream-and-decode-with-mpeg-dash/) MPEG-DASH demuxer is missing in LE ffmpeg.

DASH demuxer is only build with libxml2 enabled. Do this on both ffmpeg and ffmpegx.

Copying libxcb* libs is not required when building ffmpeg-tools for
Generic-legacy (X11), they are part of the image.

Backport of #8992