### PR TITLE
heimdal: fix CFLAGS override after ebff2c7ca0

### DIFF
--- a/packages/devel/heimdal/package.mk
+++ b/packages/devel/heimdal/package.mk
@@ -15,7 +15,7 @@ PKG_BUILD_FLAGS="-parallel"
 
 pre_configure_host() {
   # configure step misconfigures with gcc 14 unless this error is degraded to a warning
-  export CFLAGS=-Wno-error=implicit-function-declaration
+  export CFLAGS+=" -Wno-error=implicit-function-declaration"
 }
 
 PKG_CONFIGURE_OPTS_HOST="ac_cv_prog_COMPILE_ET=no \


### PR DESCRIPTION
Build system CFLAGS should only be expanded, not replaced. 

See discussion in #8935 