### PR TITLE
libcdio: add patch to remove lfs shms

### DIFF
--- a/packages/audio/libcdio/package.mk
+++ b/packages/audio/libcdio/package.mk
@@ -12,11 +12,6 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A CD-ROM reading and control library."
 PKG_BUILD_FLAGS="+pic"
 
-#workaround gcc-14 erroring with lseek64
-if [ "${ARCH}" = "arm" ]; then
-  TARGET_CFLAGS+=" -Wno-implicit-function-declaration"
-fi
-
 # package specific configure options
 PKG_CONFIGURE_OPTS_TARGET="--enable-cxx \
                            --disable-cpp-progs \

--- a/packages/audio/libcdio/patches/0002-remove-lfs-shms.patch
+++ b/packages/audio/libcdio/patches/0002-remove-lfs-shms.patch
@@ -1,0 +1,87 @@
+From 79a15b760e0b5e81b29953acada3a963c3f8eba9 Mon Sep 17 00:00:00 2001
+From: Alfred Wingate <parona@protonmail.com>
+Date: Mon, 20 May 2024 22:02:08 +0300
+Subject: [PATCH] Do not use LFS shims, rely on _FILE_OFFSET_BITS=64
+
+See https://savannah.gnu.org/bugs/?65751 and https://bugs.gentoo.org/918988
+
+Setting _FILE_OFFSET_BITS=64 is enough to get the LFS interface,
+using LFS shims is unnecessary on 64-bit systems and they may
+not be available on 32-bit systems on glibc.
+
+Signed-off-by: Alfred Wingate <parona@protonmail.com>
+---
+ configure.ac               |  8 ++++----
+ lib/driver/_cdio_generic.c | 12 +-----------
+ lib/driver/_cdio_stdio.c   |  6 +-----
+ 3 files changed, 6 insertions(+), 20 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0399a718..5ea300fe 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -547,10 +547,10 @@ AC_DEFINE_UNQUOTED(LIBCDIO_SOURCE_PATH, "$LIBCDIO_SOURCE_PATH",
+ 	[Full path to libcdio top_sourcedir.])
+ AC_SUBST(LIBCDIO_SOURCE_PATH)
+ 
+-AC_CHECK_FUNCS( [chdir drand48 fseeko fseeko64 ftruncate geteuid getgid \
+-		 getuid getpwuid gettimeofday lseek64 lstat memcpy memset mkstemp rand \
+-		 seteuid setegid snprintf setenv strndup unsetenv tzset sleep \
+-		 _stati64 usleep vsnprintf readlink realpath gmtime_r localtime_r] )
++AC_CHECK_FUNCS( [chdir drand48 fseeko ftruncate geteuid getgid getuid \
++		 getpwuid gettimeofday lstat memcpy memset mkstemp rand seteuid \
++		 setegid snprintf setenv strndup unsetenv tzset sleep _stati64 \
++		 usleep vsnprintf readlink realpath gmtime_r localtime_r] )
+ 
+ # check for timegm() support
+ AC_CHECK_FUNC(timegm, AC_DEFINE(HAVE_TIMEGM,1,
+diff --git a/lib/driver/_cdio_generic.c b/lib/driver/_cdio_generic.c
+index 4a7fcadf..f5c8c402 100644
+--- a/lib/driver/_cdio_generic.c
++++ b/lib/driver/_cdio_generic.c
+@@ -55,16 +55,6 @@
+ #define PATH_MAX 4096
+ #endif
+ 
+-/* If available and LFS is enabled, try to use lseek64 */
+-#if defined(HAVE_LSEEK64) && defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
+-#if defined(_MSC_VER)
+-#include <io.h>
+-#endif
+-#define CDIO_LSEEK lseek64
+-#else
+-#define CDIO_LSEEK lseek
+-#endif
+-
+ /*!
+   Eject media -- there's nothing to do here. We always return -2.
+   Should we also free resources?
+@@ -170,7 +160,7 @@ off_t
+ cdio_generic_lseek (void *user_data, off_t offset, int whence)
+ {
+   generic_img_private_t *p_env = user_data;
+-  return CDIO_LSEEK(p_env->fd, offset, whence);
++  return lseek(p_env->fd, offset, whence);
+ }
+ 
+ /*!
+diff --git a/lib/driver/_cdio_stdio.c b/lib/driver/_cdio_stdio.c
+index 1d46b156..c26a35d0 100644
+--- a/lib/driver/_cdio_stdio.c
++++ b/lib/driver/_cdio_stdio.c
+@@ -47,11 +47,7 @@
+ #include "_cdio_stdio.h"
+ #include "cdio_assert.h"
+ 
+-/* On 32 bit platforms, fseek can only access streams of 2 GB or less.
+-   Prefer fseeko/fseeko64, that take a 64 bit offset when LFS is enabled */
+-#if defined(HAVE_FSEEKO64) && defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
+-#define CDIO_FSEEK fseeko64
+-#elif defined(HAVE_FSEEKO)
++#if defined(HAVE_FSEEKO)
+ #define CDIO_FSEEK fseeko
+ #else
+ #define CDIO_FSEEK fseek
+-- 
+2.45.1
+


### PR DESCRIPTION
Upstream fix that removes the need for the 32 bit workaround

fixes:
- libcdio: gcc-14 error on 32-bit targets
- https://savannah.gnu.org/bugs/?65751