### PR TITLE
autoconf: update to 2.72

### DIFF
--- a/packages/devel/autoconf/package.mk
+++ b/packages/devel/autoconf/package.mk
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="autoconf"
-PKG_VERSION="2.71"
-PKG_SHA256="f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4"
+PKG_VERSION="2.72"
+PKG_SHA256="ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a"
 PKG_LICENSE="GPL"
-PKG_SITE="http://sources.redhat.com/autoconf/"
-PKG_URL="http://ftpmirror.gnu.org/autoconf/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_SITE="https://www.gnu.org/software/autoconf/"
+PKG_URL="https://ftpmirror.gnu.org/autoconf/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host m4:host gettext:host"
 PKG_LONGDESC="A GNU tool for automatically configuring source code."
 

--- a/packages/devel/heimdal/patches/1229.patch
+++ b/packages/devel/heimdal/patches/1229.patch
@@ -1,0 +1,23 @@
+From 2b372170c894ed9aa3fe2fca976f3541ea7041d9 Mon Sep 17 00:00:00 2001
+From: Bernd Kuhls <bernd@kuhls.net>
+Date: Sat, 10 Feb 2024 09:33:48 +0100
+Subject: [PATCH] cf/largefile.m4: Fix build with autoconf-2.72
+
+Fixes https://github.com/heimdal/heimdal/issues/1201
+---
+ cf/largefile.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cf/largefile.m4 b/cf/largefile.m4
+index 5c54897be4..cdbbc55431 100644
+--- a/cf/largefile.m4
++++ b/cf/largefile.m4
+@@ -10,7 +10,7 @@ dnl with generated code, such as lex
+ if test "$enable_largefile" != no -a "$ac_cv_sys_large_files" != no; then
+ 	CPPFLAGS="$CPPFLAGS -D_LARGE_FILES=$ac_cv_sys_large_files"
+ fi
+-if test "$enable_largefile" != no -a "$ac_cv_sys_file_offset_bits" != no; then
++if test "$enable_largefile" != no -a "$ac_cv_sys_file_offset_bits" != no && test -n "$ac_cv_sys_file_offset_bits"; then
+ 	CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
+ fi
+ ])


### PR DESCRIPTION
[autoconf: update to 2.72](https://github.com/LibreELEC/LibreELEC.tv/commit/8f716d55bb8358db685dd56e198e6a33c05585fa)
- [heimdal: Fix build with autoconf-2.72](https://github.com/LibreELEC/LibreELEC.tv/commit/9613191541e5306f2a189b967a6f6b1333f59332)
- https://github.com/heimdal/heimdal/issues/1201
- https://github.com/heimdal/heimdal/pull/1229