### PR TITLE
libdnet: update to 1.18.0

### DIFF
--- a/packages/network/libdnet/package.mk
+++ b/packages/network/libdnet/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdnet"
-PKG_VERSION="1.14"
-PKG_SHA256="592599c54a57102a177270f3a2caabda2c2ac7768b977d7458feba97da923dfe"
+PKG_VERSION="1.18.0"
+PKG_SHA256="a4a82275c7d83b85b1daac6ebac9461352731922161f1dcdcccd46c318f583c9"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/ofalk/libdnet"
 PKG_URL="https://github.com/ofalk/libdnet/archive/${PKG_NAME}-${PKG_VERSION}.tar.gz"
@@ -13,11 +13,11 @@ PKG_LONGDESC="A simplified, portable interface to several low-level networking r
 PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared \
-                           --disable-python"
-
 pre_configure_target() {
+  PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+                             --disable-shared \
+                             --enable-check=no"
+
   export CFLAGS+=" -I${PKG_BUILD}/include"
 }
 


### PR DESCRIPTION
libdnet 1.14 fails to compile with autoconf-2.72 . Libdnet has been in the backlog for a long time, as it had required libcheck (it no longer requires libcheck) - so upgrading. Only used by open-vm-tools.
- #8999

release notes:
- https://github.com/ofalk/libdnet/releases/tag/libdnet-1.16.1
- https://github.com/ofalk/libdnet/releases/tag/libdnet-1.16.2
- https://github.com/ofalk/libdnet/releases/tag/libdnet-1.16.3
- https://github.com/ofalk/libdnet/releases/tag/libdnet-1.16.4
- https://github.com/ofalk/libdnet/releases/tag/libdnet-1.17.0
- https://github.com/ofalk/libdnet/releases/tag/libdnet-1.18.0

log:
- https://github.com/ofalk/libdnet/compare/libdnet-1.16.1...libdnet-1.18.0