### PR TITLE
linux: rpi: add ntfs3 corruption fix patch

### DIFF
--- a/packages/linux/patches/raspberrypi/linux-999.99-fix-ntfs3-corruption.patch
+++ b/packages/linux/patches/raspberrypi/linux-999.99-fix-ntfs3-corruption.patch
@@ -1,0 +1,37 @@
+From bc49e7136a4bb926bb8743531ae54cc0c721e402 Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Tue, 11 Jun 2024 16:12:47 +0100
+Subject: [PATCH] fs/ntfs3: Fix memory corruption when page_size changes
+
+The rework in fs/ntfs3: Reduce stack usage
+changes log->page_size but doesn't change the associated
+log->page_mask and log->page_bits.
+
+That results in the bytes value in read_log_page
+getting a negative value, which is bad when it is
+passed to memcpy.
+
+The kernel panic can be observed when connecting an
+ntfs formatted drive that has previously been connected
+to a Windows machine to a Raspberry Pi 5, which by defauilt
+uses a 16K kernel pagesize.
+
+Fixes: 865e7a7700d9 ("fs/ntfs3: Reduce stack usage")
+Signed-off-by: Dom Cobley <popcornmix@gmail.com>
+---
+ fs/ntfs3/fslog.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/fs/ntfs3/fslog.c b/fs/ntfs3/fslog.c
+index 855519713bf79..b3b83565365e3 100644
+--- a/fs/ntfs3/fslog.c
++++ b/fs/ntfs3/fslog.c
+@@ -3906,6 +3906,8 @@ int log_replay(struct ntfs_inode *ni, bool *initialized)
+ 		log->l_size = log->orig_file_size;
+ 		log->page_size = norm_file_page(t32, &log->l_size,
+ 						t32 == DefaultLogPageSize);
++		log->page_mask = log->page_size - 1;
++		log->page_bits = blksize_bits(log->page_size);
+ 	}
+ 
+ 	if (log->page_size != t32 ||


### PR DESCRIPTION
backport of #9011 