### PR TITLE
u-boot: update Amlogic patches to fix Odroid N2 boot

### DIFF
--- a/projects/Amlogic/patches/u-boot/u-boot-0001-LOCAL-configs-meson64-prevent-stdout-stderr-on-video.patch
+++ b/projects/Amlogic/patches/u-boot/u-boot-0001-LOCAL-configs-meson64-prevent-stdout-stderr-on-video.patch
@@ -1,7 +1,7 @@
-From db00d83004cdd497b491ce348f1ccd53f1394c9a Mon Sep 17 00:00:00 2001
+From 0d04eb6409191d48adc9e1d347a94af06d84351e Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Fri, 13 Nov 2020 02:09:36 +0000
-Subject: [PATCH 1/6] LOCAL: configs: meson64: prevent stdout/stderr on
+Subject: [PATCH 1/2] LOCAL: configs: meson64: prevent stdout/stderr on
  videoconsole
 
 Several devices have CONFIG_VIDEO enabled which causes stdout/stderr

--- a/projects/Amlogic/patches/u-boot/u-boot-0002-LOCAL-board-amlogic-odroid-n2-remove-amlogic-prefix-.patch
+++ b/projects/Amlogic/patches/u-boot/u-boot-0002-LOCAL-board-amlogic-odroid-n2-remove-amlogic-prefix-.patch
@@ -1,0 +1,29 @@
+From e4e38f7442b36cba26eae9edc69f7804e87a6a36 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Tue, 3 Aug 2021 18:42:55 +0000
+Subject: [PATCH 2/2] LOCAL: board: amlogic: odroid-n2: remove /amlogic/ prefix
+ for dtb path
+
+Remove the /amlogic/ prefix to align with current LE dtb locations.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ board/amlogic/odroid-n2/odroid-n2.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/board/amlogic/odroid-n2/odroid-n2.c b/board/amlogic/odroid-n2/odroid-n2.c
+index a4bcc62174a..f840afbfd67 100644
+--- a/board/amlogic/odroid-n2/odroid-n2.c
++++ b/board/amlogic/odroid-n2/odroid-n2.c
+@@ -63,7 +63,7 @@ static void odroid_set_fdtfile(char *soc, char *variant)
+ {
+ 	char s[128];
+ 
+-	snprintf(s, sizeof(s), "amlogic/meson-%s-odroid-%s.dtb", soc, variant);
++	snprintf(s, sizeof(s), "meson-%s-odroid-%s.dtb", soc, variant);
+ 	env_set("fdtfile", s);
+ }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
This resolves an issue with FDTDIR boot on Odroid N2/N2+ devices reported in the forums.