### PR TITLE
chrome: conditionally extract deb file

### DIFF
--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -5,7 +5,7 @@ PKG_NAME="chrome"
 PKG_VERSION="1.0"
 # curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
 PKG_VERSION_NUMBER="123.0.6312.122"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/addons/browser/chrome/source/bin/deb_extract_data
+++ b/packages/addons/browser/chrome/source/bin/deb_extract_data
@@ -3,16 +3,28 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
+import os
 import sys
+
 sys.path.append('/storage/.kodi/addons/browser.chrome/resources')
 import unix_ar
 import tarfile
+
 
 if len(sys.argv) != 3:
     print("Parameter error", file=sys.stderr)
     sys.exit(1)
 
-ar = unix_ar.open(sys.argv[1])
-tarball = ar.open('data.tar.xz/')
-tar = tarfile.open(fileobj=tarball)
-tar.extractall(path=sys.argv[2])
+if os.path.isfile(sys.argv[1]):
+    try:
+        ar = unix_ar.open(sys.argv[1])
+    except ValueError:
+        print(f"Unable to open archive: {sys.argv[1]}", file=sys.stderr)
+        sys.exit(1)
+    else:
+        tarball = ar.open('data.tar.xz/')
+        tar = tarfile.open(fileobj=tarball)
+        tar.extractall(path=sys.argv[2])
+else:
+    print(f"File not found: {sys.argv[1]}", file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
This change's the chrome addon's deb_extract_data from unconditionally trying to extract a file to confirming that file exists first, and adds an error if it fails to open it.

This hopefully makes the error messages from https://github.com/LibreELEC/LibreELEC.tv/pull/8783#issuecomment-2029819224 less ??? to a user.

This is untested, but pylint didn't overly complain; someone on generic needs to confirm it functions.