### PR TITLE
Addon updates 

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="73f914421db873d1a19d4d15e8ae21bebc35079f3034f574dfc6cd0449edcf89"
+PKG_SHA256="a2b31d4c8143c8b126e98a359639f51727fc83fc1e61670efbdeaa7dea92fd5a"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="5650f9b10226d75e8e9a490a31cc3e5b846e0034"
+export PKG_GIT_COMMIT="912c1ddf8a3eb97595c5ea967d01c0fc18666409"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/cli/patches/cli-0001-path-for-cli-plugins.patch
+++ b/packages/addons/addon-depends/docker/cli/patches/cli-0001-path-for-cli-plugins.patch
@@ -1,11 +1,13 @@
 --- a/cli-plugins/manager/manager_unix.go	2023-02-03 11:54:16.746399916 +0000
 +++ b/cli-plugins/manager/manager_unix.go	2023-02-03 11:59:04.528175595 +0000
-@@ -4,6 +4,6 @@
- package manager
- 
+@@ -13,8 +13,6 @@
+ //
+ // [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs
  var defaultSystemPluginDirs = []string{
--	"/usr/local/lib/docker/cli-plugins", "/usr/local/libexec/docker/cli-plugins",
--	"/usr/lib/docker/cli-plugins", "/usr/libexec/docker/cli-plugins",
+-	"/usr/local/lib/docker/cli-plugins",
+-	"/usr/local/libexec/docker/cli-plugins",
+-	"/usr/lib/docker/cli-plugins",
+-	"/usr/libexec/docker/cli-plugins",
 +	"/storage/.kodi/addons/service.system.docker/cli-plugins",
 +	"/storage/.kodi/userdata/addon_data/service.system.docker/docker/cli-plugins",
  }

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="26.1.4"
-PKG_SHA256="74d3f38f2b88399012e0b889e6408d81e2d198437deda71da6d1da72dcc8afcc"
+PKG_VERSION="27.0.2"
+PKG_SHA256="2705abdd7a8a47ec88c0d2f0f31eede01ba4aa5ae8b5ab0e2c4ee25e7c314521"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="de5c9cf0b96e4e172b96db54abababa4a328462f"
+export PKG_GIT_COMMIT="e953d76450b64bd64b2374137b0580223a114fdb"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.1.12"
-PKG_SHA256="be31b07d6a54a8f234016501c300ad04b6c428c56588e7eca8c3b663308db208"
+PKG_VERSION="1.1.13"
+PKG_SHA256="789d5749a08ef1fbe5d1999b67883206a68a4e58e6ca0151c411d678f3480b25"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-export PKG_GIT_COMMIT="51d5e94601ceffbbd85688df1c928ecccbfa4685"
+export PKG_GIT_COMMIT="58aa9203c123022138b22cf96540c284876a7910"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/jellyfin/package.mk
+++ b/packages/addons/service/jellyfin/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="jellyfin"
 PKG_VERSION="1.0"
-PKG_VERSION_NUMBER="10.8.13"
-PKG_REV="0"
+PKG_VERSION_NUMBER="10.9.7"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://jellyfin.org/"

--- a/packages/addons/service/jellyfin/source/bin/jellyfin-downloader
+++ b/packages/addons/service/jellyfin/source/bin/jellyfin-downloader
@@ -9,7 +9,7 @@ oe_setup_addon service.jellyfin
 ICON="${ADDON_DIR}/resources/icon.png"
 CONTROL_FILE="/tmp/curl.done"
 DATA_FILE="/tmp/curl.data"
-JELLYFIN_FILE="jellyfin_@JELLYFIN_VERSION@.tar.gz"
+JELLYFIN_FILE="jellyfin_@JELLYFIN_VERSION@.tar.xz"
 
 # check for enough free disk space
 if [ $(df . | awk 'END {print $4}') -lt 200000 ]; then
@@ -42,7 +42,7 @@ echo "Downloading Jellyfin"
 # download Jellyfin
 rm -f ${CONTROL_FILE} ${DATA_FILE}
 (
-  curl -L -# -O -C - https://repo.jellyfin.org/releases/server/portable/versions/stable/combined/@JELLYFIN_VERSION@/${JELLYFIN_FILE} 2>${DATA_FILE}
+  curl -L -# -O -C - https://repo.jellyfin.org/files/server/portable/stable/v@JELLYFIN_VERSION@/any/${JELLYFIN_FILE} 2>${DATA_FILE}
   touch ${CONTROL_FILE}
 ) | \
   while [ : ]; do
@@ -59,7 +59,7 @@ kodi-send --action="Notification(Extracting Jellyfin,Starting,1000,${ICON})" >/d
 
 # extract JELLYFIN_FILE to libs directory
 mkdir ${ADDON_DIR}/libs
-tar xf ${JELLYFIN_FILE} -C ${ADDON_DIR}/libs --strip-components=2
+tar xf ${JELLYFIN_FILE} -C ${ADDON_DIR}/libs --strip-components=1
 
 # cleanup
 cd ${ADDON_DIR}

--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="btrfs-progs"
-PKG_VERSION="6.8.1"
-PKG_SHA256="9aa72e2646a8ed5e24d37cb70af4e3e526ba5a541fc547c5613e11ced05ab490"
-PKG_REV="1"
+PKG_VERSION="6.9.1"
+PKG_SHA256="e866b32d2f5e995084d80954e01b3a001e7516dacd426dfdabf5d7002ebe2442"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.readthedocs.io/"


### PR DESCRIPTION
- docker: update to 27.0.2 and addon (4)- runc: update to 1.1.13
  - cli: update to 27.0.2
  - moby: update to 27.0.2
- btrfs-progs: update to 6.9.1 and addon (2)
- jellyfin: update to 10.9.7 and addon (1)