### PR TITLE
[le12] openssh: update to 9.8p1

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="9.7p1"
-PKG_SHA256="490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd"
+PKG_VERSION="9.8p1"
+PKG_SHA256="dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Backport of OpenSSH to LE12 - This release contains fixes for two security problems, one critical
and one minor.

Change log:
- https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ChangeLog

Release notes:
- https://www.openssh.com/releasenotes.html#9.8p1

Release notes:
- https://www.openssh.com/txt/release-9.8p1