### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/libplacebo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/libplacebo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libplacebo"
-PKG_VERSION="6.338.2"
-PKG_SHA256="2f1e624e09d72a8c9db70f910f7560e764a1c126dae42acc5b3bcef836a7aec6"
+PKG_VERSION="7.349.0"
+PKG_SHA256="627e32439a0b3d2b90368ead7e919f470ee7446c87cc0f7841bbe319b23aa8b1"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="https://code.videolan.org/videolan/libplacebo"
 PKG_URL="https://github.com/haasn/libplacebo/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccache"
-PKG_VERSION="4.10"
-PKG_SHA256="83630b5e922b998ab2538823e0cad962c0f956fad1fcf443dd5288269a069660"
+PKG_VERSION="4.10.1"
+PKG_SHA256="3a43442ce3916ea48bb6ccf6f850891cbff01d1feddff7cd4bbd49c5cf1188f6"
 PKG_LICENSE="GPL"
 PKG_SITE="https://ccache.dev/download.html"
 PKG_URL="https://github.com/ccache/ccache/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/ccache/patches/ccache-0001-fix-libfmt-detection.patch
+++ b/packages/devel/ccache/patches/ccache-0001-fix-libfmt-detection.patch
@@ -1,0 +1,77 @@
+From 71f772e9d3d4f8045cfa7bccd03bd21c1e8fbef1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Holger=20Hoffst=C3=A4tte?= <holger@applied-asynchrony.com>
+Date: Tue, 2 Jul 2024 15:46:44 +0200
+Subject: [PATCH] build: Try harder to determine FMT_VERSION (#1478)
+
+fmt-11.0 moved the FMT_VERSION from core.h to base.h, so try the
+new header first and then fall back to the old one.
+
+Closes: #1477
+---
+ cmake/FindFmt.cmake | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/FindFmt.cmake b/cmake/FindFmt.cmake
+index 55126a3172..0619f4615e 100644
+--- a/cmake/FindFmt.cmake
++++ b/cmake/FindFmt.cmake
+@@ -3,11 +3,19 @@ mark_as_advanced(FMT_INCLUDE_DIR FMT_LIBRARY)
+ if(DEP_FMT STREQUAL "BUNDLED")
+   message(STATUS "Using bundled Fmt as requested")
+ else()
+-  find_path(FMT_INCLUDE_DIR fmt/core.h)
++  find_path(FMT_INCLUDE_DIR fmt/base.h fmt/core.h)
+   find_library(FMT_LIBRARY fmt)
+   if(FMT_INCLUDE_DIR AND FMT_LIBRARY)
+-    file(READ "${FMT_INCLUDE_DIR}/fmt/core.h" _fmt_core_h)
+-    string(REGEX MATCH "#define FMT_VERSION ([0-9]+)" _ "${_fmt_core_h}")
++    file(READ "${FMT_INCLUDE_DIR}/fmt/base.h" _fmt_base_h)
++    string(REGEX MATCH "#define FMT_VERSION ([0-9]+)" _ "${_fmt_base_h}")
++    if("${CMAKE_MATCH_0}" STREQUAL "")
++      file(READ "${FMT_INCLUDE_DIR}/fmt/core.h" _fmt_core_h)
++      string(REGEX MATCH "#define FMT_VERSION ([0-9]+)" _ "${_fmt_core_h}")
++    endif()
++    if("${CMAKE_MATCH_0}" STREQUAL "")
++      message(FATAL_ERROR "FMT_VERSION not found")
++      return()
++    endif()
+     math(EXPR _fmt_major "${CMAKE_MATCH_1} / 10000")
+     math(EXPR _fmt_minor "${CMAKE_MATCH_1} / 100 % 100")
+     math(EXPR _fmt_patch "${CMAKE_MATCH_1} % 100")
+From 3b09afc5f792f0bd0a15cf6b8408ea40eb069787 Mon Sep 17 00:00:00 2001
+From: Joel Rosdahl <joel@rosdahl.net>
+Date: Tue, 2 Jul 2024 17:05:43 +0200
+Subject: [PATCH] build: Fix detection of Fmt version for Fmt<11
+
+Fixes regression in 71f772e9d3d4f8045cfa7bccd03bd21c1e8fbef1.
+---
+ cmake/FindFmt.cmake | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/cmake/FindFmt.cmake b/cmake/FindFmt.cmake
+index 0619f4615e..7c39291eca 100644
+--- a/cmake/FindFmt.cmake
++++ b/cmake/FindFmt.cmake
+@@ -3,15 +3,16 @@ mark_as_advanced(FMT_INCLUDE_DIR FMT_LIBRARY)
+ if(DEP_FMT STREQUAL "BUNDLED")
+   message(STATUS "Using bundled Fmt as requested")
+ else()
+-  find_path(FMT_INCLUDE_DIR fmt/base.h fmt/core.h)
++  find_path(FMT_INCLUDE_DIR NAMES fmt/base.h fmt/core.h)
+   find_library(FMT_LIBRARY fmt)
+   if(FMT_INCLUDE_DIR AND FMT_LIBRARY)
+-    file(READ "${FMT_INCLUDE_DIR}/fmt/base.h" _fmt_base_h)
+-    string(REGEX MATCH "#define FMT_VERSION ([0-9]+)" _ "${_fmt_base_h}")
+-    if("${CMAKE_MATCH_0}" STREQUAL "")
+-      file(READ "${FMT_INCLUDE_DIR}/fmt/core.h" _fmt_core_h)
+-      string(REGEX MATCH "#define FMT_VERSION ([0-9]+)" _ "${_fmt_core_h}")
++    if(EXISTS "${FMT_INCLUDE_DIR}/fmt/base.h")
++      set(_fmt_h base.h)
++    else()
++      set(_fmt_h core.h)
+     endif()
++    file(READ "${FMT_INCLUDE_DIR}/fmt/${_fmt_h}" _fmt_h_content)
++    string(REGEX MATCH "#define FMT_VERSION ([0-9]+)" _ "${_fmt_h_content}")
+     if("${CMAKE_MATCH_0}" STREQUAL "")
+       message(FATAL_ERROR "FMT_VERSION not found")
+       return()

--- a/packages/devel/json-glib/package.mk
+++ b/packages/devel/json-glib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="json-glib"
-PKG_VERSION="1.8.0"
-PKG_SHA256="97bc058fad49ebf5195ec539240370454ef6589d2b97bf626d7a9e2353d25e3f"
+PKG_VERSION="1.9.2"
+PKG_SHA256="277c3b7fc98712e30115ee3a60c3eac8acc34570cb98d3ff78de85ed804e0c80"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/GNOME/json-glib"
 PKG_URL="https://github.com/GNOME/json-glib/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/tbb/package.mk
+++ b/packages/devel/tbb/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tbb"
-PKG_VERSION="2021.12.0"
-PKG_SHA256="c7bb7aa69c254d91b8f0041a71c5bcc3936acb64408a1719aec0b2b7639dd84f"
+PKG_VERSION="2021.13.0"
+PKG_SHA256="3ad5dd08954b39d113dc5b3f8a8dc6dc1fd5250032b7c491eb07aed5c94133e1"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/oneapi-src/oneTBB"
 PKG_URL="https://github.com/oneapi-src/oneTBB/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="8.5.0"
-PKG_SHA256="77e4f7f98f3d86bf8788b53e6832fb96279956e1c3961988ea3d4b7ca41ddc27"
+PKG_VERSION="9.0.0"
+PKG_SHA256="a41b272ceeb920c57263ec851604542d9ec85ee3030506d94662067c7b6ab89e"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.121"
-PKG_SHA256="909084a505d7638887f590b70791b3bbd9069c710c948f5d1f1ce6d080cdfcab"
+PKG_VERSION="2.4.122"
+PKG_SHA256="d9f5079b777dffca9300ccc56b10a93588cdfbc9dde2fae111940dfb6292f251"
 PKG_LICENSE="GPL"
 PKG_SITE="https://dri.freedesktop.org"
 PKG_URL="https://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/spirv-headers/package.mk
+++ b/packages/graphics/spirv-headers/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-headers"
 # The SPIRV-Headers pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-headers pkg_version.
-PKG_VERSION="4f7b471f1a66b6d06462cd4ba57628cc0cd087d7"
-PKG_SHA256="7ea8624762d0e217aced805d73d84b7ceb4d37439abd182c2714ad97d7fe3f13"
+PKG_VERSION="2acb319af38d43be3ea76bfabf3998e5281d8d12"
+PKG_SHA256="425da1e3e4ba8de41dc8c8273d281ae82f1e18a397ec476649df3c832e242329"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/spirv-llvm-translator/package.mk
+++ b/packages/graphics/spirv-llvm-translator/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spirv-llvm-translator"
-PKG_VERSION="18.1.1"
-PKG_SHA256="c1c7aee4ea23a6a1089bb7f7bad198c28ada65c5b7671434562fe0241d8674d6"
+PKG_VERSION="18.1.2"
+PKG_SHA256="4724372934041c8feb8bcafea1c9d086ab2de9f323599068943ef61ddb0bca51"
 PKG_LICENSE="LLVM"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/spirv-tools/package.mk
+++ b/packages/graphics/spirv-tools/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-tools"
 # The SPIRV-Tools pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools pkg_version.
-PKG_VERSION="dd4b663e13c07fea4fbb3f70c1c91c86731099f7"
-PKG_SHA256="03ee1a2c06f3b61008478f4abe9423454e53e580b9488b47c8071547c6a9db47"
+PKG_VERSION="0cfe9e7219148716dfd30b37f4d21753f098707a"
+PKG_SHA256="a5277538fec0868452b1f616553c2fca80939a6a3ee0b7322e21ff063750a482"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers pkg_version/s need to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools & spirv-headers pkg_version/s.
-PKG_VERSION="14.2.0"
-PKG_SHA256="14a2edbb509cb3e51a9a53e3f5e435dbf5971604b4b833e63e6076e8c0a997b5"
+PKG_VERSION="14.3.0"
+PKG_SHA256="be6339048e20280938d9cb399fcdd06e04f8654d43e170e8cce5a56c9a754284"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.3.20"
-PKG_SHA256="227c1614d4817154b4e6fbfb667ba2b231ea7aa53796d91f1800af9aeb703f59"
+PKG_VERSION="22.4.1"
+PKG_SHA256="451fbe2eac26533a896ca0da0356354ecc38680f273fce7d121c6a22251ed21e"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/libass/package.mk
+++ b/packages/multimedia/libass/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libass"
-PKG_VERSION="0.17.2"
-PKG_SHA256="e8261b51d66ba933fe99248c6fdd8767ed96c5a7e5363c83992c735a2c2fbf74"
+PKG_VERSION="0.17.3"
+PKG_SHA256="eae425da50f0015c21f7b3a9c7262a910f0218af469e22e2931462fed3c50959"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/libass/libass"
 PKG_URL="https://github.com/libass/libass/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="10.3.0"
-PKG_SHA256="5a2f1a812237bf9bd57f283422f46ca97a1c3d43d5f67b9bf8a0d499c4b97c85"
+PKG_VERSION="10.4.0"
+PKG_SHA256="e70284e8605a5b7ccb37e5bfd4634598ca2c43c7f2c353572351ccf72c031004"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.8.5"
-PKG_SHA256="66269a2cfe0e1c2dabec87bdbbd8ab656f396edd9a40dd006978e003cfa52bfc"
+PKG_VERSION="3.8.6"
+PKG_SHA256="2e1588aae53cb32d43937f1f4eca28febd9c0c7aa1734fc5dd61a7e81e0ebcdd"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/sysutils/open-vm-tools/package.mk
+++ b/packages/sysutils/open-vm-tools/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="open-vm-tools"
-PKG_VERSION="12.4.0"
-PKG_SHA256="ba091c58f0d61c2896418c7d04506a7ea44c7594401209928270576fa018c23a"
+PKG_VERSION="12.4.5"
+PKG_SHA256="1e36b41ddb7a2672158842297a08115ff8369bb8f6b80c9df144a22cb5f28550"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/vmware/open-vm-tools"

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.26.0"
-PKG_SHA256="8c582b86c6865aaee2516ee96b299cef60c98e113d1391bbd2683eac08221a07"
+PKG_VERSION="1.26.1"
+PKG_SHA256="da0ac450902a2aef29028bcab0bec26eb5e08b4c36ffc2925746d807794991b6"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- libplacebo: update to 7.349.0
- libinput: update to 1.26.1
- libdrm: update to 2.4.122
- libass: update to 0.17.3
- json-glib: update to 1.9.2
- harfbuzz: update to 9.0.0
- gmmlib: update to 22.4.1
- gnutls: update to 3.8.6
- glslang: update to 14.3.0
- spirv-tools: update to githash 0cfe9e7
- spirv-headers: update to githash 2acb319
- open-vm-tools: update to 12.4.5
- spirv-llvm-translator: update to 18.1.2
- tbb: update to 2021.13.0
- ccache: update to 4.10.1
- Pillow: update to 10.4.0