### PR TITLE
game.libretro: Update for buffer overflow fix

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro"
-PKG_VERSION="21.0.6-Omega"
-PKG_SHA256="823d2f15f524b9aa589d82c61c427933937351caa56a4c32054d9236896a8f5f"
-PKG_REV="2"
+PKG_VERSION="21.0.7-Omega"
+PKG_SHA256="18548b996401ca009f282441044ce8f4324533906505a739b4dc0172211ddcc9"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro"


### PR DESCRIPTION
## Description

This PR updates game.libretro with an input fix and a video buffer overflow fix.

Contains the following two PRs:

* https://github.com/kodi-game/game.libretro/pull/124 - It was causing input to fail for NDS cores
* https://github.com/kodi-game/game.libretro/pull/126 - affects cores that request a second software buffer of different size within the same run, such as PCSX-ReARMed
