### PR TITLE
Update upstreamed game addons

### DIFF
--- a/packages/emulation/libretro-bk/package.mk
+++ b/packages/emulation/libretro-bk/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bk"
-PKG_VERSION="ea37046ca174e39c63b7db5679b9c91387a75ea5"
-PKG_SHA256="87ea97a4d60e62836deb13af85adfd37dbe2fa4c5c2c1daaef98943e329396f2"
+PKG_VERSION="31af5ca5f307991eb596ed411d4d0e955c833421"
+PKG_SHA256="f90a9ecc31db054afd0f29690faf88ea6e695025e23526ec110df53b46ef08bc"
 PKG_LICENSE="NTP"
 PKG_SITE="https://github.com/libretro/bk-emulator"
 PKG_URL="https://github.com/libretro/bk-emulator/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bluemsx"
-PKG_VERSION="0dcb73adef9601ca70d94b3f4e3ba1b3b54edbc0"
-PKG_SHA256="a175df0324bee17ea2c217aebc329b06efe0e3086cf78547d945424c60423609"
+PKG_VERSION="1f6b5b393df17e746bec118902b1d1f6ed3e4109"
+PKG_SHA256="2de09c4b4bdcc5d9c9076940624151ae5fb47e39259a0367f8030cb51f842a35"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/blueMSX-libretro"
 PKG_URL="https://github.com/libretro/blueMSX-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mame2000/package.mk
+++ b/packages/emulation/libretro-mame2000/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame2000"
-PKG_VERSION="905808fbcc3adf8c610c1c60f0e41ce4b35db1c5"
-PKG_SHA256="7386a469086b7da90565e97f52e6ef02264a54262c82983dd1948ddef9bd4e63"
+PKG_VERSION="2ec60f6e1078cf9ba173e80432cc28fd4eea200f"
+PKG_SHA256="e9e39e0153970729a2b81898af140749118db56be2920600bcff29fe13c59658"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2000-libretro"
 PKG_URL="https://github.com/libretro/mame2000-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mame2003_plus/package.mk
+++ b/packages/emulation/libretro-mame2003_plus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame2003_plus"
-PKG_VERSION="ab725a7f30a133551742b400089e8fffdf29d84a"
-PKG_SHA256="294d0f7bf1c29417714cb24d2aab1f107a4a69fa4e7c574705bc34e214c62d51"
+PKG_VERSION="d1ea797420e2429a03aa019a29e8897de06fa860"
+PKG_SHA256="6584297717104e1718c1e5d479fefff6ce9c381b1e722b9f3ee82c5b8fc6515b"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"
 PKG_URL="https://github.com/libretro/mame2003-plus-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-prboom/package.mk
+++ b/packages/emulation/libretro-prboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-prboom"
-PKG_VERSION="ab05295d81fed2bb9db9f68a7ceeec7a544191d8"
-PKG_SHA256="e80c5ee26fcbb8c536907d9efb57104eb200b9f092108fe1982b6b3ec304b3f8"
+PKG_VERSION="2972aa92e0490194a37c9fb849ffc420abeb0ce4"
+PKG_SHA256="24e0223aa67871e6718bbff1ec87db3fe320de0b924cee29681a002253717a95"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-prboom"
 PKG_URL="https://github.com/libretro/libretro-prboom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-uae/package.mk
+++ b/packages/emulation/libretro-uae/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-uae"
-PKG_VERSION="3432007d28ef173707e2b32bd931932e5b74085d"
-PKG_SHA256="a376b0d39a30024519fd4a50496d79b62d57af658828cf1ed3f1f673d91f734d"
+PKG_VERSION="4493a194dd42e593914c26952ee8cb4ba750f596"
+PKG_SHA256="cc341eae2d546219ed18fa8b5aea17a2c7801f2133bfe7fb3f96dad313e14ccd"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-uae"
 PKG_URL="https://github.com/libretro/libretro-uae/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.atari800"
-PKG_VERSION="3.1.0.34-Nexus"
-PKG_SHA256="5501e28d28a91857b07276285f7e25d4a03ea6ff0a2afee89145fe85cd3c3882"
+PKG_VERSION="3.1.0.35-Nexus"
+PKG_SHA256="feb2e121d58b56bb2d89a0e00f736afd301eab9a22b3992f349757e16525c47e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bk/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bk/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bk"
-PKG_VERSION="1.0.0.29-Nexus"
-PKG_SHA256="7bcfcabdc363be4bf0fd974a1620ed8b3aec1cbcc1db3355ea10e05e3db2692f"
-PKG_REV="2"
+PKG_VERSION="1.0.0.30-Nexus"
+PKG_SHA256="bce2f4cd95c61abab5cd00d5bd4ae60a9908fdab5f3cb6e3d3e35e7dcd48cf65"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bk"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bluemsx"
-PKG_VERSION="0.0.1.40-Nexus"
-PKG_SHA256="a2eec9f1c76cf2bdc62bbfdcff55d0eada766ed9a857385e9e3a6740fc03d184"
-PKG_REV="2"
+PKG_VERSION="0.0.1.41-Nexus"
+PKG_SHA256="d29abd2464b9ced97126f2f9e17a865f594972510150e79fc17ae1dd75c564b4"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bluemsx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2000/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2000/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mame2000"
-PKG_VERSION="0.37.0.35-Nexus"
-PKG_SHA256="04c3f33a28466ac9ce53c3043b4dd5cd314d965b3085bb7631f2d6e01b9e90e1"
-PKG_REV="2"
+PKG_VERSION="0.37.0.36-Nexus"
+PKG_SHA256="c67d81c34d135eeb202e3a8f29983099b3b9d535802f1e76f85e3cde484e9947"
+PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2000"
 PKG_URL="https://github.com/kodi-game/game.libretro.mame2000/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mame2003_plus"
-PKG_VERSION="0.0.1.80-Nexus"
-PKG_SHA256="4ec54d21fceb101725df23de280b6a887874c984446ce4f7a0f5fc33a2397ff4"
-PKG_REV="2"
+PKG_VERSION="0.0.1.81-Nexus"
+PKG_SHA256="6b28ce08298bca71e3a78d565bdae86ef1d07b330d8f061419e0eb5a850962b5"
+PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2003_plus"
 PKG_URL="https://github.com/kodi-game/game.libretro.mame2003_plus/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.prboom"
-PKG_VERSION="2.5.0.48-Nexus"
-PKG_SHA256="0935e81a3d8a760224328a20ec8e053ef5e20791aaa049580bc8639a170e0398"
-PKG_REV="2"
+PKG_VERSION="2.5.0.49-Nexus"
+PKG_SHA256="a6b5c5c90326d326ca965c54910b22c3ce1707ac6daf6a0c2d8d5fc36c78e92b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.prboom"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.snes9x/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.snes9x"
-PKG_VERSION="1.62.3.50-Nexus"
-PKG_SHA256="80a34295c4608994f2650ab1b2dcf4129b9c9aa3a6d62ff79a347bcd2037f617"
-PKG_REV="2"
+PKG_VERSION="1.62.3.51-Nexus"
+PKG_SHA256="163af7ec6e7ad7784bd083f05fbbad81e44884389302abf360b722075e3e9c18"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.snes9x"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.uae/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.uae/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.uae"
-PKG_VERSION="5.0.0.72-Nexus"
-PKG_SHA256="f84c5caa16186efa76f8f7e6c408767aead15b1bbaeab5961ddf53d7d323d09c"
-PKG_REV="2"
+PKG_VERSION="5.0.0.73-Nexus"
+PKG_SHA256="4bce5c7321340c049e5cea6b9e5d2059040a80eff7adfbf9058a67a061a25f86"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.uae"


### PR DESCRIPTION
## Description

While following LE development I noticed emulators were updated in the following PRs:

* https://github.com/LibreELEC/LibreELEC.tv/pull/8871 (atari800, bluemsx, mame2000, mame2003_plus, prboom, snes9x, uae)
* https://github.com/LibreELEC/LibreELEC.tv/pull/8918 (picodrive)
* https://github.com/LibreELEC/LibreELEC.tv/pull/9038 (bk)

So I ran the CI script to rebase Kodi's emulators on each master branch, pulling in the patches that were submitted upstream for the affected emulators. Now Kodi's emulators include all LE patches so far.

## Motivation and Context

I noted all cores with upstream patches, and ran the CI script on those cores, which updates to the latest master, which should include the upstreamed patches.