### PR TITLE
Update Mr.Boom game add-on

### DIFF
--- a/packages/emulation/libretro-mrboom/package.mk
+++ b/packages/emulation/libretro-mrboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mrboom"
-PKG_VERSION="4a7261f27febcfa17cca9ae082190fa4a3800a5f"
-PKG_SHA256="369ee2840ac8497526db2cd90426b6587c6f801a67b4d0187b6be5e21ecce7f1"
+PKG_VERSION="256caa125cdb94d99eea5a98d6b9bb14f90c34ff"
+PKG_SHA256="8f41a29cd454a25ca9d828e2107000de88366f58f42cc51843e0f849574363eb"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libretro/mrboom-libretro"
 PKG_URL="https://github.com/kodi-game/mrboom-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mrboom/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mrboom"
-PKG_VERSION="5.3.0.157-Nexus"
-PKG_SHA256="d787f26566297eb0408865859115c82b6f70b04cb20e8ce83871b17941e12cca"
-PKG_REV="2"
+PKG_VERSION="5.5.0.160-Nexus"
+PKG_SHA256="8eb0b10950474893c8af6aa7d33d7d2edb7f54a3e073b7b1e1d1c2da1e6dfa0a"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mrboom"


### PR DESCRIPTION
## Description

This PR updates the Mr.Boom core from v5.3 to v5.5.

This is not part of a normal update cycle, but a forum user noticed the Mr.Boom crashed when opening on FlatPak ([report](https://forum.kodi.tv/showthread.php?tid=173361&pid=3192377#pid3192377)).

As we debug the issue, I'm getting Mr.Boom on master everywhere to help debug the issue.