### PR TITLE
Fix ScummVM game add-on

### DIFF
--- a/packages/emulation/libretro-scummvm/package.mk
+++ b/packages/emulation/libretro-scummvm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-scummvm"
-PKG_VERSION="6fa7403b8b1b6e18e3a3d02120b38aad6a73ad26"
-PKG_SHA256="8b636d4a366962c381d8eeb5cc70f5fc598e9039eb2b89e4b006ea3c3f7969a9"
+PKG_VERSION="8ce898dcc55e56b75b12ba2a5023bb062e918198"
+PKG_SHA256="25c0c9684120a04a648cd1d5bdcde2cdd60fda415f7c739e8556dd7f0dae3ade"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/scummvm"
 PKG_URL="https://github.com/libretro/scummvm/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.scummvm/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.scummvm"
-PKG_VERSION="2.7.0.38-Nexus"
-PKG_SHA256="ce9b0762892a304929d7fb5d9abefd587ab51b77bb32149b864ca442048c94e9"
-PKG_REV="3"
+PKG_VERSION="2.9.0.40-Nexus"
+PKG_SHA256="d018d3e46000bc935497c8893ec07e4d652b72672d834f5810902e193537e018"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.scummvm"


### PR DESCRIPTION
## Description

ScummVM is currently broken - see add-on history here: https://github.com/kodi-game/kodi-game-scripting/pull/123

This PR updates ScummVM to the latest master, from v2.7.0 to v2.9.0.

Marked as draft until ScummVM is fully working in Kodi again.