### PR TITLE
dockerfiles: update packages for aarch64 to amd64 crosscompiles

### DIFF
--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -29,13 +29,7 @@ RUN apt-get install -y \
     && ln -s /usr/lib/go-1.21/bin/gofmt /usr/bin/gofmt
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse' > /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  apt-get update; \
-  dpkg --add-architecture amd64; \
-  apt-get install -y libc6:amd64 qemu-user-binfmt --no-install-recommends; \
+  apt-get install -y libc6-amd64-cross qemu-user-binfmt --no-install-recommends; \
  fi
 
 RUN rm -rf /var/lib/apt/lists/*

--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -25,13 +25,7 @@ RUN apt-get install -y \
     --no-install-recommends
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble main restricted universe multiverse' > /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-security main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-backports main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  apt-get update; \
-  dpkg --add-architecture amd64; \
-  apt-get install -y libc6:amd64 qemu-user-binfmt --no-install-recommends; \
+  apt-get install -y libc6-amd64-cross qemu-user-binfmt --no-install-recommends; \
  fi
 
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Untested. This should resolve #9056. If it doesn't, changes in scripts/checkdeps for aarch64 hosts need to be revisited.

@heitbaum 