### PR TITLE
meson: update to 1.5.0

### DIFF
--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="1.4.1"
-PKG_SHA256="1b8aad738a5f6ae64294cc8eaba9a82988c1c420204484ac02ef782e5bba5f49"
+PKG_VERSION="1.5.0"
+PKG_SHA256="45d7b8653c1e5139df35b33be2dd5b2d040c5b2c6129f9a7c890d507e33312b8"
 PKG_LICENSE="Apache"
 PKG_SITE="https://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
release notes:
- https://github.com/mesonbuild/meson/blob/master/docs/markdown/Release-notes-for-1.5.0.md