### PR TITLE
Use /bin/dash as CONFIG_SHELL if it's installed on the build host

### DIFF
--- a/config/options
+++ b/config/options
@@ -144,6 +144,11 @@ if [ "${OEM}" = "yes" -o "${OEM}" = "no" ]; then
   OEM_SUPPORT="${OEM}"
 fi
 
+# use /bin/dash as config shell if installed on the build host
+if [ -z "${CONFIG_SHELL}" ] && [ -x "/bin/dash" ]; then
+  export CONFIG_SHELL="/bin/dash"
+fi
+
 check_config
 
 . config/graphic

--- a/config/show_config
+++ b/config/show_config
@@ -39,6 +39,7 @@ show_config() {
   config_message+="\n - CFLAGS:\t\t\t\t ${TARGET_CFLAGS}"
   config_message+="\n - LDFLAGS:\t\t\t\t $(sed 's/^ *//' <<< ${TARGET_LDFLAGS})"
   config_message+="\n - Local Ccache:\t\t\t ${LOCAL_CCACHE:-no}"
+  config_message+="\n - CONFIG_SHELL:\t\t\t ${CONFIG_SHELL:-auto}"
 
   # Misc. hardware configuration
 

--- a/packages/addons/addon-depends/argtable2/package.mk
+++ b/packages/addons/addon-depends/argtable2/package.mk
@@ -9,7 +9,7 @@ PKG_SITE="http://argtable.sourceforge.net/"
 PKG_URL="https://downloads.sourceforge.net/project/argtable/argtable/argtable-${PKG_VERSION}/argtable2-${PKG_VERSION:2:4}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Argtable is an open source ANSI C library that parses GNU-style command-line options."
-PKG_TOOLCHAIN="configure"
+PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"

--- a/packages/devel/libdaemon/package.mk
+++ b/packages/devel/libdaemon/package.mk
@@ -9,6 +9,7 @@ PKG_SITE="http://0pointer.de/lennart/projects/libdaemon/"
 PKG_URL="http://0pointer.de/lennart/projects/libdaemon/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="autotools:host make:host sed:host gcc:host"
 PKG_LONGDESC="A lightweight C library which eases the writing of UNIX daemons."
+PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_setpgrp_void=no \
                            --enable-static \


### PR DESCRIPTION
By default autotools configure scripts and libtool use bash as the config shell which is quite slow.

Using dash instead results in about 4-10% faster builds.

A clean RPi5 image builds in a Debian Bullseye chroot on my Ryzen 7950X box takes about 22 minutes instead of 23 and a RPi5 image rebuild from ccache takes about 8.5 instead of 9.5 minutes.

dash is the default system shell on Debian and Ubuntu systems so our CI builds should benefit from the improvement. On other distros dash is usually available as an optional package.

This PR doesn't suffer from the issues of the previous approach to use dash some 6 years ago (see #2785)  which we had to revert (see #2808)

By using /bin/dash from the build host (if available) instead of a self-built one fron our toolchain we avoid the long-path issue when building in some deep nested or long directory (the hashbang line in a script must not be longer than 127 bytes)

Back in 2018 a lot of the shipped configure scripts were build with old, buggy autotools/libtools version which resulted in build issues when using dash as a config shell but bash is the system (/bin/sh) shell.

Nowadays pretty much all packages ship with working configure scripts, only two ancient packages in LE (libdaemon and argtable2) come with old and buggy configure. Fortunately this is easy to solve by running autoreconf to bring the configure scripts up to date.

I successfully build tested image and full addon builds of RPi2, RPi5, Generic and Generic-legacy in a Debian Bookworm chroot with /bin/sh symlinked to bash, so I'm very optimistic this will also work fine on Arch/Fedora/... with dash installed