### PR TITLE
x265: fix cross compiled builds

### DIFF
--- a/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
@@ -14,5 +14,5 @@ PKG_TOOLCHAIN="make"
 
 pre_configure_target() {
   LDFLAGS+=" -ldl"
-  cmake -DCMAKE_INSTALL_PREFIX=/usr -G "Unix Makefiles" ./source
+  ${CMAKE} -G "Unix Makefiles" ./source
 }


### PR DESCRIPTION
use ${CMAKE} not cmake to build so as to use CMAKE_TOOLCHAIN_FILE and target the correct TARGET architecture.