### PR TITLE
mesa: update to 24.1.4

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="24.1.3"
-PKG_SHA256="63236426b25a745ba6aa2d6daf8cd769d5ea01887b0745ab7124d2ef33a9020d"
+PKG_VERSION="24.1.4"
+PKG_SHA256="7cf7c6f665263ad0122889c1d4b076654c1eedea7a2f38c69c8c51579937ade1"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
The bugfix release 24.1.4 is now available.

If you find any issues, please report them here:
https://gitlab.freedesktop.org/mesa/mesa/-/issues/new

The next bugfix release is due in two weeks, on July 31st.

Cheers,
  Eric

PS: for those waiting for 24.2.0-rc1, it will be a bit late, although
hopefully less than 48h from now.

---

Aleksi Sapon (1):
      lavapipe: build "Windows" check should use the host machine, not the `platforms` option.

Connor Abbott (3):
      tu: Make cs writeable for GMEM loads when FDM is enabled
      tu: Fix fdm_apply_load_coords patchpoint size
      ir3: Fix stg/ldg immediate offset on a7xx

Dave Airlie (2):
      anv/video: use correct offset for MPR row store scratch buffer.
      radv/video: advertise mutable/extended for dst video images.

David Rosca (1):
      Reapply "radeonsi/vcn: AV1 skip the redundant bs resize"

Doug Brown (1):
      xa: add missing stride setup in renderer_draw_yuv

Eric Engestrom (8):
      docs: add sha256sum for 24.1.3
      [24.1 only] ci: disable rustfmt
      .pick_status.json: Update to d9e41e8a8ca3a8a22628513b44764fa7675ec288
      .pick_status.json: Update to ae3e0ae26a4678b317727dc08ae64aee6577374d
      .pick_status.json: Update to a04dc1a4517bbe359fb246a79cd38c99f250c826
      .pick_status.json: Update to 2d260314f101540298edf973f5393e3468ed84ba
      docs: add release notes for 24.1.4
      VERSION: bump for 24.1.4

Erico Nunes (1):
      lima: fix surface reload flags assignment

Faith Ekstrand (5):
      nvk: Silently fail to enumerate if not on nouveau
      nvk: Bump the sparse alignment requirement on buffers to 64K
      nvk: Align sparse-bound images to the sparse binding size
      zink/kopper: Set VK_COMPOSITE_ALPHA_OPAQUE_BIT when PresentOpaque is set
      nvk: Drop the sparse alignment back down to 4096

Karol Herbst (8):
      rusticl/program: move binary parsing into its own function
      rusticl/program: make binary API not crash on errors
      rusticl/program: use blob.h to parse binaries
      rusticl/program: update binary format
      rusticl/buffer: harden bound checks against overflows
      rusticl/context: move SVM pointer tracking into own type
      rusticl/ptr: add a few APIs to TrackedPointers
      rusticl/memory: complete rework on how mapping is implemented

Kenneth Graunke (1):
      intel/nir: Don't needlessly split u2f16 for nir_type_uint32

Konstantin Seurer (1):
      radv: Fix smooth lines with dynamic polygon mode and topology

Marek Olšák (5):
      ac/surface: finish display DCC for gfx11.5
      radeonsi: replace si_shader::scratch_bo with scratch_va, don't set it on gfx11+
      radeonsi: don't update compute scratch if the compute shader doesn't use it
      ac: add radeon_info::has_scratch_base_registers
      radeonsi: lock a mutex when updating scratch_va for compute shaders

Mary Guillemard (1):
      pan/kmod: Avoid deadlock on VA allocation failure on panthor

MastaG (1):
      gallivm: Call StringMapIterator from llvm:: scope

Mike Blumenkrantz (7):
      st/pbo: fix MESA_COMPUTE_PBO=spec crash on shutdown
      st/pbo_compute: special case stencil extraction from Z24S8
      zink: propagate valid buffer range to real buffer when mapping staging
      zink: track the "real" buffer range from replacement buffers
      zink: modify some buffer mapping behavior for buffer replacement srcs
      mesa/st: load state params for feedback draws with allow_st_finalize_nir_twice
      egl/x11/sw: fix partial image uploads

Patrick Lerda (1):
      st/pbo_compute: fix async->nir memory leak

Paulo Zanoni (2):
      anv: reimplement the anv_fake_nonlocal_memory workaround
      iris: fix iris_xe_wait_exec_queue_idle() on release builds

Pierre-Eric Pelloux-Prayer (4):
      radeonsi: fix buffer_size in si_compute_shorten_ubyte_buffer
      Revert "ac, radeonsi: remove has_syncobj, has_fence_to_handle"
      winsys/radeon: fill lds properties
      radeonsi: fix crash in si_update_tess_io_layout_state for gfx8 and earlier

Samuel Pitoiset (1):
      radv: disable VK_EXT_sampler_filter_minmax on TAHITI and VERDE

Sviatoslav Peleshko (1):
      mesa: Fix PopAttrib not restoring states that changed on deeper stack level

Tatsuyuki Ishi (1):
      vk_cmd_queue_gen: Exclude CmdDispatchGraphAMDX

Tim Huang (2):
      amd: add GFX v11.5.2 support
      amd/vpelib: support VPE IP v6.1.3

msizanoen (1):
      egl/wayland: Fix direct scanout with EGL_EXT_present_opaque

git tag: mesa-24.1.4

https://mesa.freedesktop.org/archive/mesa-24.1.4.tar.xz
SHA256: 7cf7c6f665263ad0122889c1d4b076654c1eedea7a2f38c69c8c51579937ade1  mesa-24.1.4.tar.xz
SHA512: 0293f1493685888e5d2f0e616645c937e5a9c348fcb654b050b7c42bfdade1518c508920e456cf8be0033dceab4570a916db87dbb454174e425d91e9c05d0748  mesa-24.1.4.tar.xz
PGP:  https://mesa.freedesktop.org/archive/mesa-24.1.4.tar.xz.sig