### PR TITLE
systemd: add UR02 BT remote device to 70-local-keyboard.hwdb

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -86,6 +86,10 @@ evdev:input:b0003v2252p1037*
 evdev:input:b0005v005Dp0001*
  KEYBOARD_KEY_c0041=enter
 
+# UR02 remote
+evdev:input:b0005v0508p1980*
+ KEYBOARD_KEY_c0041=enter
+
 # wechip g20 remote
 evdev:input:b0003v4842p0001*
  KEYBOARD_KEY_c0041=enter


### PR DESCRIPTION
This adds support for the OK key on the "UR02" BlueTooth remote, as documented in the forum: https://forum.libreelec.tv/thread/28787-rpi5-trying-to-get-bluetooth-remote-ok-button-to-send-an-enter-code/