### PR TITLE
[le12] Addon updates

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet6-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet6-runtime"
-PKG_VERSION="6.0.31"
+PKG_VERSION="6.0.32"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="09da2d3fa2facebffeac4185ae1532f61a93f71dffbdb9e3efb0a27bfcf414ce"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/088b0ba5-2eaa-4815-a5c2-3517b99d059c/f6d18014064903be5fa2f654f51f5ce0/aspnetcore-runtime-6.0.31-linux-arm64.tar.gz"
+    PKG_SHA256="70d7035083bc2b330709eb6208d082a3cfc18839425b31bccff032aadc66c212"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/7b3ead1a-441d-42b9-ac91-1253ed8aee48/044d517eaff9f65e18e3e27f4d825d34/aspnetcore-runtime-6.0.32-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="4c35436362adf4aef7f12af49d892f32dab58135895ebbf43209fb3dc9ddb1d3"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/dbcc9954-e476-416b-9411-f65a6d265e67/5a64d97dbae939763192831e828f58d9/aspnetcore-runtime-6.0.31-linux-arm.tar.gz"
+    PKG_SHA256="1500178b218dc218c1465b9b60b248c8780dccb15b62a56641d03c8d816eff16"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/d5106f1a-d140-4c8c-b480-001824b72768/7e9cf426bf45040eadfcc8bb20227b6d/aspnetcore-runtime-6.0.32-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="f03fdd09e114028a3e4751d7504280cbf1264ca72bf69aa87bc8489348b46e64"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/c8c7ccb6-b0f8-4448-a542-ed153838cac3/f104b5cc6c11109c0b48e2bb8f5b6cef/aspnetcore-runtime-6.0.31-linux-x64.tar.gz"
+    PKG_SHA256="ee937f7c03f4e908c3dcb0f1c063bd911bc08f7a30d49ea41f084fa403b923f0"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/99f90118-96b4-4d06-97ad-d779715319f6/aecf393f9b9d362b66b93a47d90cfa8d/aspnetcore-runtime-6.0.32-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet8-runtime"
-PKG_VERSION="8.0.6"
+PKG_VERSION="8.0.7"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="2d03221eb786ad84b865aa5eca84ad79bb2e8cde57e96cac9e0c4edaaec14c0f"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/ccdcbb70-a5e9-4753-b6e3-4461ce56a69d/240803fc1ffba38ab3603778c03e9b87/aspnetcore-runtime-8.0.6-linux-arm64.tar.gz"
+    PKG_SHA256="61a21ef486e0075ba2c68aaceee0429d731414611d2291e1c7056cd3e5d955bb"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/421d499f-85cb-43dd-97b2-8ebfd06dda8a/61b03be4662125e4af044c7881e66f0e/aspnetcore-runtime-8.0.7-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="b621a6cee65890a123bbf6282fc23190a8abe12af76279a1aa799b0e82f814bf"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/c27a9707-8627-43d3-837e-fa144bab2984/40f243e656752b87ff033e568d49b510/aspnetcore-runtime-8.0.6-linux-arm.tar.gz"
+    PKG_SHA256="9ad9398327a6cb239e7bda239f29a9db64838676113d5a2e54d9319b443f52e7"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/d37fc703-70c6-46f2-a5a1-b60f45fd71d0/6a74aa0bb89feb7f795df1ea92d030bf/aspnetcore-runtime-8.0.7-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="d4f8ce14e12aba9ca970c15c1ce09486bffc930fe05d4520678763562ca6b48b"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/ce31d92b-b514-4f9c-843b-29c466871369/b332eba5641cbc6eed1e3a98480972d2/aspnetcore-runtime-8.0.6-linux-x64.tar.gz"
+    PKG_SHA256="e55bc969b1cb58f96b927127b5c448a15ea844cfc94387f6e35ab585d94abc93"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/06cbb934-ef54-4627-8848-a24a879f2130/52d4247944cee754ec8f4fd617d502a6/aspnetcore-runtime-8.0.7-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/service/jellyfin/package.mk
+++ b/packages/addons/service/jellyfin/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="jellyfin"
 PKG_VERSION="1.0"
-PKG_VERSION_NUMBER="10.9.7"
-PKG_REV="1"
+PKG_VERSION_NUMBER="10.9.8"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://jellyfin.org/"

--- a/packages/addons/service/prometheus-node-exporter/package.mk
+++ b/packages/addons/service/prometheus-node-exporter/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="prometheus-node-exporter"
-PKG_VERSION="1.8.1"
-PKG_SHA256="6a2dc6b0be27fa089574f2c32cee3673bbf4c6749c84f1d08f8c374e0908c0ad"
-PKG_REV="2"
+PKG_VERSION="1.8.2"
+PKG_SHA256="f615c70be816550498dd6a505391dbed1a896705eff842628de13a1fa7654e8f"
+PKG_REV="3"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://github.com/prometheus/node_exporter"
 PKG_URL="https://github.com/prometheus/node_exporter/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"


### PR DESCRIPTION
- backport of #9109

- jellyfin: update to 10.9.8 and addon (2)
- prometheus-node-exporter: update to 1.8.2 and addon (3)
- dotnet-runtime: update to 6.0.32 and 8.0.7 and addon (2)
  - aspnet8-runtime: update to 8.0.7
  - aspnet6-runtime: update to 6.0.32