### PR TITLE
media-driver: update to 24.3.0

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="24.2.5"
-PKG_SHA256="dec2210c1f824a721e4ea6f66f5899e300801b3e7fae232d3f8a94db38c2edd1"
+PKG_VERSION="24.3.0"
+PKG_SHA256="b6728607e4d05739bce27124605993011b468781043ce34bb1a51919196f2d15"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/patches/media-driver-999.02-Refactor-for-build-issue.patch
+++ b/packages/multimedia/media-driver/patches/media-driver-999.02-Refactor-for-build-issue.patch
@@ -1,0 +1,138 @@
+From 47bae3c809c9f5b11793b76b5edfd7704adb4080 Mon Sep 17 00:00:00 2001
+From: Chen_Ke <ke3.chen@intel.com>
+Date: Fri, 12 Jul 2024 11:42:04 +0800
+Subject: [PATCH] [VP] Refactor for build issue
+
+Refactor for build issue: Avoid storing the address of local variable
+---
+ media_common/agnostic/common/hw/mhw_render.h      |  1 +
+ media_common/agnostic/common/hw/mhw_state_heap.h  |  2 --
+ .../agnostic/common/hw/mhw_render_cmdpar.h        |  1 +
+ .../shared/packet/media_render_cmd_packet.cpp     |  4 ++--
+ .../shared/packet/media_render_cmd_packet.h       |  4 ++--
+ .../common/vp/hal/packet/vp_render_kernel_obj.cpp | 15 +++++----------
+ .../common/vp/hal/packet/vp_render_kernel_obj.h   |  3 ++-
+ 7 files changed, 13 insertions(+), 17 deletions(-)
+
+diff --git a/media_common/agnostic/common/hw/mhw_render.h b/media_common/agnostic/common/hw/mhw_render.h
+index b551ab1337..36c895c299 100644
+--- a/media_common/agnostic/common/hw/mhw_render.h
++++ b/media_common/agnostic/common/hw/mhw_render.h
+@@ -312,6 +312,7 @@ typedef struct _MHW_GPGPU_WALKER_PARAMS
+ 
+     bool                       hasBarrier;
+     PMHW_INLINE_DATA_PARAMS    inlineDataParamBase;
++    uint32_t                   inlineDataParamSize;
+ 
+ } MHW_GPGPU_WALKER_PARAMS, *PMHW_GPGPU_WALKER_PARAMS;
+ 
+diff --git a/media_common/agnostic/common/hw/mhw_state_heap.h b/media_common/agnostic/common/hw/mhw_state_heap.h
+index 49add60823..2f9afff0af 100644
+--- a/media_common/agnostic/common/hw/mhw_state_heap.h
++++ b/media_common/agnostic/common/hw/mhw_state_heap.h
+@@ -83,8 +83,6 @@ typedef struct MHW_BLOCK_MANAGER *PMHW_BLOCK_MANAGER;
+ 
+ #define MHW_INVALID_SYNC_TAG            0xFFFFFFFF
+ 
+-#define MAX_INLINE_DATA_PARAMS          32
+-
+ enum MW_RENDER_ENGINE_ADDRESS_SHIFT
+ {
+     MHW_STATE_HEAP_SURFACE_STATE_SHIFT = 0
+diff --git a/media_softlet/agnostic/common/hw/mhw_render_cmdpar.h b/media_softlet/agnostic/common/hw/mhw_render_cmdpar.h
+index 4c01d351ce..a8004bbbb9 100644
+--- a/media_softlet/agnostic/common/hw/mhw_render_cmdpar.h
++++ b/media_softlet/agnostic/common/hw/mhw_render_cmdpar.h
+@@ -65,6 +65,7 @@ struct MHW_HEAPS_RESOURCE
+ {
+     PMOS_RESOURCE          presInstructionBuffer = nullptr;
+     PMHW_INLINE_DATA_PARAMS inlineDataParamsBase   = nullptr;
++    uint32_t                inlineDataParamSize   = 0;
+ };
+ 
+ enum MHW_VFE_SLICE_DISABLE
+diff --git a/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.cpp b/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.cpp
+index dc9d6896ba..c18cbf4b4f 100644
+--- a/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.cpp
++++ b/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.cpp
+@@ -1264,8 +1264,8 @@ MOS_STATUS RenderCmdPacket::PrepareComputeWalkerParams(KERNEL_WALKER_PARAMS para
+ 
+     gpgpuWalker.SLMSize           = params.slmSize;
+     gpgpuWalker.hasBarrier        = params.hasBarrier;
+-    gpgpuWalker.inlineDataParamBase   = params.inlineDataParams;
+-
++    gpgpuWalker.inlineDataParamBase   = params.inlineDataParamBase;
++    gpgpuWalker.inlineDataParamSize = params.inlineDataParamSize;
+     return MOS_STATUS_SUCCESS;
+ }
+ 
+diff --git a/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.h b/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.h
+index 89ac89d9a5..7e6b0aa8a1 100644
+--- a/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.h
++++ b/media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.h
+@@ -120,8 +120,8 @@ typedef struct _KERNEL_WALKER_PARAMS
+ 
+     bool                                hasBarrier;
+     uint32_t                            slmSize;
+-    MHW_INLINE_DATA_PARAMS              inlineDataParams[MAX_INLINE_DATA_PARAMS];
+-    uint32_t                            inlineDataParamNum;
++    PMHW_INLINE_DATA_PARAMS             inlineDataParamBase;
++    uint32_t                            inlineDataParamSize;
+ }KERNEL_WALKER_PARAMS, * PKERNEL_WALKER_PARAMS;
+ 
+ typedef struct _KERNEL_PACKET_RENDER_DATA
+diff --git a/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.cpp b/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.cpp
+index d6630cbd5f..dbd5b12d1d 100644
+--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.cpp
++++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.cpp
+@@ -740,7 +740,7 @@ void VpRenderKernelObj::DumpSurface(VP_SURFACE* pSurface, PCCHAR fileName)
+ #endif
+ }
+ 
+-MOS_STATUS VpRenderKernelObj::SetInlineDataParameter(KERNEL_WALKER_PARAMS &walkerParam, KRN_ARG args, RENDERHAL_INTERFACE *renderhal)
++MOS_STATUS VpRenderKernelObj::SetInlineDataParameter(KRN_ARG args, RENDERHAL_INTERFACE *renderhal)
+ {
+     VP_FUNC_CALL();
+     MHW_INLINE_DATA_PARAMS inlineDataPar = {};
+@@ -762,15 +762,10 @@ MOS_STATUS VpRenderKernelObj::SetInlineDataParameter(KERNEL_WALKER_PARAMS &walke
+     {
+         inlineDataPar.isPtrType = false;
+     }
+-    if (walkerParam.inlineDataParamNum < MAX_INLINE_DATA_PARAMS)
+-    {
+-        walkerParam.inlineDataParams[walkerParam.inlineDataParamNum] = inlineDataPar;
+-        walkerParam.inlineDataParamNum++;
+-    }
+-    else
+-    {
+-        VP_RENDER_ASSERTMESSAGE("Exceed max inline data params!");
+-    }
++
++    // walkerParam.inlineDataParamBase will add m_inlineDataParams.data() in each kernel
++    // walkerParam.inlineDataParamSize will add m_inlineDataParams.size() in each kernel
++    m_inlineDataParams.push_back(inlineDataPar);
+ 
+     return MOS_STATUS_SUCCESS;
+ }
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.h b/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.h
+index 8b9abf9dca..8d095730cd 100644
+--- a/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.h
++++ b/media_softlet/agnostic/common/vp/hal/packet/vp_render_kernel_obj.h
+@@ -537,7 +537,7 @@ class VpRenderKernelObj
+ 
+     virtual MOS_STATUS InitRenderHalSurfaceCMF(MOS_SURFACE* src, PRENDERHAL_SURFACE renderHalSurface);
+ 
+-    virtual MOS_STATUS SetInlineDataParameter(KERNEL_WALKER_PARAMS &walkerParam, KRN_ARG args, RENDERHAL_INTERFACE *renderhal);
++    virtual MOS_STATUS SetInlineDataParameter(KRN_ARG args, RENDERHAL_INTERFACE *renderhal);
+ 
+     virtual MOS_STATUS UpdateBindlessSurfaceResource(SurfaceType surf, std::set<uint32_t> surfStateOffset)
+     {
+@@ -617,6 +617,7 @@ class VpRenderKernelObj
+     bool                                                    m_useIndependentSamplerGroup = false; //true means multi kernels has their own stand alone sampler states group. only can be true when m_isAdvKernel is true.
+ 
+     std::shared_ptr<mhw::vebox::Itf>                        m_veboxItf = nullptr;
++    std ::vector<MHW_INLINE_DATA_PARAMS>                    m_inlineDataParams = {};
+ 
+ MEDIA_CLASS_DEFINE_END(vp__VpRenderKernelObj)
+ };


### PR DESCRIPTION
include upstream fix
- https://github.com/intel/media-driver/commit/47bae3c809c9f5b11793b76b5edfd7704adb4080
- https://github.com/intel/media-driver/issues/1834

change log:
- https://github.com/intel/media-driver/compare/intel-media-24.2.5...intel-media-24.3.0

```
=== tested on ===
Generic.x86_64-devel-20240722094119-5a65c42
Linux nuc12 6.10.0 #1 SMP Fri Jul 19 10:48:33 UTC 2024 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:9052d5b00e48855654a8bf8f5d38dc789f2a0e11). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-07-19 by GCC 14.1.0 for Linux x86 64-bit version 6.10.0 (395776)
Running on LibreELEC (heitbaum): devel-20240722094119-5a65c42 13.0, kernel: Linux x86 64-bit version 6.10.0
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0092.2024.0202.1711 02/02/2024
[    0.000000] DMI: Memory slots populated: 1/2
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.2.0-rc1
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.3.0 (0164293526)
```