### PR TITLE
[le12] kodi: update to 7e5bb32

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="01bd800e6009571baf5103739582cde20444fbf9"
-PKG_SHA256="dad3833bdc7d76c7201e59874d0be9f126f30a6a6b3940bcd22a85618d2deaad"
+PKG_VERSION="7e5bb325bda3f121709578cf61f6fdfcd665260b"
+PKG_SHA256="38596d692996bb1b34d4da93f93cd2b1da5dba95d6653503d6360ae0bdf4abe2"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Pickup fixes for Python, Bookmarks, PVR

Build for all official supported platforms and run tested on RPi4, RPi5, Generis with my community release 240710