### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bottom"
-PKG_VERSION="0.9.6"
-PKG_SHA256="202130e0d7c362d0d0cf211f6a13e31be3a02f13f998f88571e59a7735d60667"
+PKG_VERSION="0.9.7"
+PKG_SHA256="29c3f75323ae0245576ea23268bb0956757352bf3b16d05f511357655b9cc71e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ClementTsang/bottom"
 PKG_URL="https://github.com/ClementTsang/bottom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/depends/libmtp/patches/libmtp-0001-dont-execute-compiled-tools.patch
+++ b/packages/addons/addon-depends/system-tools-depends/depends/libmtp/patches/libmtp-0001-dont-execute-compiled-tools.patch
@@ -1,6 +1,12 @@
 diff -Naur a/Makefile.am b/Makefile.am
 --- a/Makefile.am	2015-10-07 00:43:15.000000000 -0700
 +++ b/Makefile.am	2016-04-22 14:16:07.656866841 -0700
+@@ -1,4 +1,4 @@
+-SUBDIRS=src examples util doc
++SUBDIRS=src util
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ pkgconfigdir=$(libdir)/pkgconfig
 @@ -11,21 +11,6 @@
  if USE_LINUX
  udevrulesdir=@UDEV@/rules.d
@@ -35,6 +41,15 @@ diff -Naur a/Makefile.in b/Makefile.in
  RECURSIVE_CLEAN_TARGETS = mostlyclean-recursive clean-recursive	\
    distclean-recursive maintainer-clean-recursive
  am__recursive_targets = \
+@@ -371,7 +371,7 @@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-SUBDIRS = src examples util doc
++SUBDIRS = src util
+ ACLOCAL_AMFLAGS = -I m4
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libmtp.pc
 @@ -452,21 +452,8 @@
  
  distclean-libtool:

--- a/packages/addons/addon-depends/system-tools-depends/fdupes/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/fdupes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fdupes"
-PKG_VERSION="2.3.1"
-PKG_SHA256="2482b4b8c931bd17cea21f4c27fa4747b877523029d57f794a2b48e6c378db17"
+PKG_VERSION="2.3.2"
+PKG_SHA256="808d8decbe7fa41cab407ae4b7c14bfc27b8cb62227540c3dcb6caf980592ac7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/adrianlopezroche/fdupes"
 PKG_URL="https://github.com/adrianlopezroche/fdupes/releases/download/v${PKG_VERSION}/fdupes-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/mtpfs/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mtpfs/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mtpfs"
-PKG_VERSION="d228a21b07062170e05fb71a7a7bf4a74ad559e1"
-PKG_SHA256="4b89e014201a01634022a6348874361f5ca729e455b8c1f9990fa10647590b52"
+PKG_VERSION="2bd9b5a33ad70a2238e086ffb07907f20a1e0101"
+PKG_SHA256="732d5d450cfefd9df0e53ed6b188e1428298d8f81aaa8b5bf24ad31b9fddbe8f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.adebenham.com/mtpfs/"
 PKG_URL="https://github.com/cjd/mtpfs/archive/${PKG_VERSION}.tar.gz"
@@ -17,4 +17,5 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-mad"
 # TODO: mtpfs runs host utils while building, fix and set
 pre_configure_target() {
   export LIBS="-lusb-1.0 -ludev"
+  TARGET_CONFIGURE_OPTS=$(echo ${TARGET_CONFIGURE_OPTS} | sed -e "s|--disable-static||" -e "s|--enable-shared||")
 }

--- a/packages/addons/addon-depends/system-tools-depends/pv/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/pv/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pv"
-PKG_VERSION="1.8.10"
-PKG_SHA256="d4c90c17cfcd44aa96b98237731e4f811e071d4c2052a689d2d81e6671f571b1"
+PKG_VERSION="1.8.12"
+PKG_SHA256="9687f9deedb09d0dc00d80c30691f0c91282c0d5d8fa7d6a2a085c8742c2cd7c"
 PKG_LICENSE="GNU"
 PKG_SITE="http://www.ivarch.com/programs/pv.shtml"
 PKG_URL="http://www.ivarch.com/programs/sources/pv-${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="librespot"
-PKG_VERSION="886617e41c2177d0cb184cb761aa64acc8695a88"
+PKG_VERSION="299b7dec20b45b9fa19a4a46252079e8a8b7a8ba"
 PKG_VERSION_DATE="2023-12-06"
-PKG_SHA256="c53fa249e2ff7c75d51f4cbe9867e9ca6a60a0d714c2810fab16a29d113b2144"
-PKG_REV="0"
+PKG_SHA256="3699d2f15065222a769e57fec22b51e3d355c2d9837b49c3ec3ef16d2ace4b35"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/librespot-org/librespot/"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="4ca5e9bd141b0111387ea1aa0355f87eb8d0da52fbc616cefa4ecde4997aa65b"
+    PKG_SHA256="b4951714774b1b83d1b3bd38205d9fcd6f072def15f771fade9041ea3ebe2fd2"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="60c8274fdfbf335f740fdb5987b5f2be24e74eda1ae40021ee94368999f29ed7"
+    PKG_SHA256="01befaca1c3ecea79625acec41b39b753440854509325f0f10f99da5b86b033d"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="07fcadd27b645ad58ff4dae5ef166fd730311bbae8f25f6640fe1bfd2a1f3c3c"
+    PKG_SHA256="5602ba863f5276cfaa7ed3a8dd94d187fbd0319a1b4bbb9284e77fb6b7168a41"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="519abf4757fbd8d7e3bb4e4cfdc362ded972c1d95f04675684df2d31e8c0899b"
+    PKG_SHA256="5911cc5af031648b29b42aaa1fe77d577848db08d9a400eada1e803960e78c4c"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="fa6f5f03b68faf9b4449266e4836bcae24027fba7a3822a48822d772fc76c064"
+    PKG_SHA256="a33d2116a5439e53308eacba334735b63c13587b5a6aae6e4ac54d4849027e90"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="2c914483c0882d44af2e50a181cbd2c953d672d50b31aa669ee2346cade1f108"
+    PKG_SHA256="c722cba93c9627e04a6a5ecc749cde9dda39f15e4d02fb6ae8d0b27e02e6488a"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.79.0"
-PKG_SHA256="172ecf3c7d1f9d9fb16cd2a628869782670416ded0129e524a86751f961448c0"
+PKG_VERSION="1.80.0"
+PKG_SHA256="6f606c193f230f6b2cae4576f7b24d50f5f9b25dff11dbf9b22f787d3521d672"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="9c847b42b81325d25a9240e33bf03fa8652f5dd321ae90a9a7a58b46bf124b17"
+    PKG_SHA256="198b5a04c25de5e9c56ff36b9110e2cfbdadf789de2c7c6d6ea9a26fd12ba165"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="019a2b9792ee38a30823b96b6d63e5094b92a1dff197ab30b63f1a6568da533e"
+    PKG_SHA256="5aed84d75bd21c28d61ddf3c7006dc12126528641afd6250d5603b48492b8fb7"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="a04cf42022d0a5faf01c31082bfb1dde9c38409f0ca6da90a3e40faa03e797ae"
+    PKG_SHA256="ef1692e3d67236868d32ef26f96f47792b1c3a3f9747bbe05c63742464307c4f"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- rustc-snapshot: update to 1.80.0
- rust-std-snapshot: update to 1.80.0
- cargo-snapshot: update to 1.80.0
- rust: update to 1.80.0
- librespot: update to githash 299b7de and addon (1)
- system-tools: update addon (4)
  - fdupes: update to 2.3.2
  - bottom: update to 0.9.7
  - pv: update to 1.8.12
  - mtpfs: update to githash 2bd9b5a
    - libmtp: do not build examples or docs