### PR TITLE
[le12] Addon updates

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bottom"
-PKG_VERSION="0.9.6"
-PKG_SHA256="202130e0d7c362d0d0cf211f6a13e31be3a02f13f998f88571e59a7735d60667"
+PKG_VERSION="0.9.7"
+PKG_SHA256="29c3f75323ae0245576ea23268bb0956757352bf3b16d05f511357655b9cc71e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ClementTsang/bottom"
 PKG_URL="https://github.com/ClementTsang/bottom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/depends/libmtp/patches/libmtp-0001-dont-execute-compiled-tools.patch
+++ b/packages/addons/addon-depends/system-tools-depends/depends/libmtp/patches/libmtp-0001-dont-execute-compiled-tools.patch
@@ -1,6 +1,12 @@
 diff -Naur a/Makefile.am b/Makefile.am
 --- a/Makefile.am	2015-10-07 00:43:15.000000000 -0700
 +++ b/Makefile.am	2016-04-22 14:16:07.656866841 -0700
+@@ -1,4 +1,4 @@
+-SUBDIRS=src examples util doc
++SUBDIRS=src util
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ pkgconfigdir=$(libdir)/pkgconfig
 @@ -11,21 +11,6 @@
  if USE_LINUX
  udevrulesdir=@UDEV@/rules.d
@@ -35,6 +41,15 @@ diff -Naur a/Makefile.in b/Makefile.in
  RECURSIVE_CLEAN_TARGETS = mostlyclean-recursive clean-recursive	\
    distclean-recursive maintainer-clean-recursive
  am__recursive_targets = \
+@@ -371,7 +371,7 @@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-SUBDIRS = src examples util doc
++SUBDIRS = src util
+ ACLOCAL_AMFLAGS = -I m4
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libmtp.pc
 @@ -452,21 +452,8 @@
  
  distclean-libtool:

--- a/packages/addons/addon-depends/system-tools-depends/fdupes/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/fdupes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fdupes"
-PKG_VERSION="2.3.1"
-PKG_SHA256="2482b4b8c931bd17cea21f4c27fa4747b877523029d57f794a2b48e6c378db17"
+PKG_VERSION="2.3.2"
+PKG_SHA256="808d8decbe7fa41cab407ae4b7c14bfc27b8cb62227540c3dcb6caf980592ac7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/adrianlopezroche/fdupes"
 PKG_URL="https://github.com/adrianlopezroche/fdupes/releases/download/v${PKG_VERSION}/fdupes-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/mtpfs/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mtpfs/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mtpfs"
-PKG_VERSION="d228a21b07062170e05fb71a7a7bf4a74ad559e1"
-PKG_SHA256="4b89e014201a01634022a6348874361f5ca729e455b8c1f9990fa10647590b52"
+PKG_VERSION="2bd9b5a33ad70a2238e086ffb07907f20a1e0101"
+PKG_SHA256="732d5d450cfefd9df0e53ed6b188e1428298d8f81aaa8b5bf24ad31b9fddbe8f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.adebenham.com/mtpfs/"
 PKG_URL="https://github.com/cjd/mtpfs/archive/${PKG_VERSION}.tar.gz"
@@ -17,4 +17,5 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-mad"
 # TODO: mtpfs runs host utils while building, fix and set
 pre_configure_target() {
   export LIBS="-lusb-1.0 -ludev"
+  TARGET_CONFIGURE_OPTS=$(echo ${TARGET_CONFIGURE_OPTS} | sed -e "s|--disable-static||" -e "s|--enable-shared||")
 }

--- a/packages/addons/addon-depends/system-tools-depends/pv/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/pv/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pv"
-PKG_VERSION="1.8.10"
-PKG_SHA256="d4c90c17cfcd44aa96b98237731e4f811e071d4c2052a689d2d81e6671f571b1"
+PKG_VERSION="1.8.12"
+PKG_SHA256="9687f9deedb09d0dc00d80c30691f0c91282c0d5d8fa7d6a2a085c8742c2cd7c"
 PKG_LICENSE="GNU"
 PKG_SITE="http://www.ivarch.com/programs/pv.shtml"
 PKG_URL="http://www.ivarch.com/programs/sources/pv-${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -3,10 +3,10 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="librespot"
-PKG_VERSION="886617e41c2177d0cb184cb761aa64acc8695a88"
+PKG_VERSION="299b7dec20b45b9fa19a4a46252079e8a8b7a8ba"
 PKG_VERSION_DATE="2023-12-06"
-PKG_SHA256="c53fa249e2ff7c75d51f4cbe9867e9ca6a60a0d714c2810fab16a29d113b2144"
-PKG_REV="0"
+PKG_SHA256="3699d2f15065222a769e57fec22b51e3d355c2d9837b49c3ec3ef16d2ace4b35"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/librespot-org/librespot/"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- backport of #9122
- system-tools: update addon (4)
  - fdupes: update to 2.3.2
  - bottom: update to 0.9.7
  - pv: update to 1.8.12
  - mtpfs: update to githash 2bd9b5a
    - libmtp: do not build examples or docs