### PR TITLE
cleanup package formatting

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -24,7 +24,7 @@ configure_target() {
   export VERSION=${PKG_VERSION}
   export BUILDTIME="$(date --utc)"
 
-  cat > "${PKG_BUILD}/go.mod" << EOF
+  cat >"${PKG_BUILD}/go.mod" <<EOF
 module github.com/docker/cli
 
 go 1.18

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -31,7 +31,7 @@ configure_target() {
   export VERSION=${PKG_VERSION}
   export BUILDTIME="$(date --utc)"
 
-  cat > "${PKG_BUILD}/go.mod" << EOF
+  cat >"${PKG_BUILD}/go.mod" <<EOF
 module github.com/docker/docker
 
 go 1.18

--- a/packages/addons/addon-depends/docker/tini/package.mk
+++ b/packages/addons/addon-depends/docker/tini/package.mk
@@ -13,7 +13,7 @@ PKG_LONGDESC="Tini is a simplest init system."
 
 PKG_MAKE_OPTS_TARGET="tini-static"
 
-pre_configure_target(){
+pre_configure_target() {
   sed -i "s|@tini_VERSION_GIT@| - git.${PKG_VERSION}|" ${PKG_BUILD}/src/tiniConfig.h.in
 }
 

--- a/packages/addons/addon-depends/ffmpegx/package.mk
+++ b/packages/addons/addon-depends/ffmpegx/package.mk
@@ -35,7 +35,7 @@ pre_configure_target() {
   cd ${PKG_BUILD}
   rm -rf .${TARGET_NAME}
 
-# HW encoders
+  # HW encoders
 
   # Generic
   if [[ "${TARGET_ARCH}" = "x86_64" ]]; then
@@ -69,7 +69,7 @@ pre_configure_target() {
     --enable-encoder=libx265"
   fi
 
-# Encoders
+  # Encoders
     PKG_FFMPEG_ENCODERS="\
     `#Video encoders` \
     --enable-libvpx \
@@ -91,7 +91,7 @@ pre_configure_target() {
     --enable-libvorbis \
     --enable-encoder=libvorbis"
 
-# X11 grab for screen recording
+  # X11 grab for screen recording
   if [ "${DISPLAYSERVER}" = "x11" ]; then
     PKG_FFMPEG_LIBS+=" -lX11"
     PKG_FFMPEG_X11_GRAB="\
@@ -165,6 +165,6 @@ configure_target() {
     --enable-libxml2 \
     \
     `#Advanced options` \
-    --disable-hardcoded-tables \
+    --disable-hardcoded-tables
 
 }

--- a/packages/addons/addon-depends/libid3tag/package.mk
+++ b/packages/addons/addon-depends/libid3tag/package.mk
@@ -14,6 +14,6 @@ PKG_LONGDESC="A library for id3 tagging."
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared"
 
-post_makeinstall_target(){
- cp ${PKG_BUILD}/id3tag.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+post_makeinstall_target() {
+  cp ${PKG_BUILD}/id3tag.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig
 }

--- a/packages/addons/addon-depends/libmad/package.mk
+++ b/packages/addons/addon-depends/libmad/package.mk
@@ -19,7 +19,7 @@ fi
 
 post_makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
-  cat > ${SYSROOT_PREFIX}/usr/lib/pkgconfig/mad.pc << "EOF"
+  cat >${SYSROOT_PREFIX}/usr/lib/pkgconfig/mad.pc  <<"EOF"
 prefix=/usr
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib

--- a/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
@@ -23,8 +23,8 @@ PKG_CONFIGURE_OPTS_TARGET="LIBS=-lpthread \
                            --disable-canusb"
 
 pre_configure_target() {
-# When cross-compiling, configure can't set linux version
-# forcing it
+  # When cross-compiling, configure can't set linux version
+  # forcing it
   sed -i -e 's/ac_cv_linux_vers=unknown/ac_cv_linux_vers=2/' ../configure
 }
 

--- a/packages/addons/addon-depends/network-tools-depends/nmap/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/nmap/package.mk
@@ -23,7 +23,7 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --with-zenmap=no"
 
 pre_configure_target() {
-# nmap fails to build in subdirs
+  # nmap fails to build in subdirs
   cd ${PKG_BUILD}
     rm -rf .${TARGET_NAME}
 

--- a/packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
@@ -26,4 +26,3 @@ make_target() {
     python setup.py build
   )
 }
-

--- a/packages/addons/addon-depends/system-tools-depends/dool/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/dool/package.mk
@@ -20,6 +20,6 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
   cp -p dool ${INSTALL}/usr/bin
   cp -pr plugins ${INSTALL}/usr/bin
-  printf "#!/bin/sh\n\necho \"\${0} has been replaced by dool\"" > ${INSTALL}/usr/bin/dstat
+  printf "#!/bin/sh\n\necho \"\${0} has been replaced by dool\"" >${INSTALL}/usr/bin/dstat
   chmod 755 ${INSTALL}/usr/bin/dstat
 }

--- a/packages/addons/addon-depends/system-tools-depends/screen/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/screen/package.mk
@@ -18,4 +18,3 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_utempter_h=no \
                            --disable-use-locale \
                            --disable-telnet \
                            --disable-socket-dir"
-

--- a/packages/addons/addon-depends/system-tools-depends/vim/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/vim/package.mk
@@ -48,8 +48,8 @@ pre_makeinstall_target() {
 
 post_makeinstall_target() {
   (
-  cd ${INSTALL}/storage/.kodi/addons/virtual.system-tools/data/vim
-  rm -r doc tutor gvimrc_example.vim
-  mv vimrc_example.vim vimrc
+    cd ${INSTALL}/storage/.kodi/addons/virtual.system-tools/data/vim
+    rm -r doc tutor gvimrc_example.vim
+    mv vimrc_example.vim vimrc
   )
 }

--- a/packages/addons/addon-depends/vdr/package.mk
+++ b/packages/addons/addon-depends/vdr/package.mk
@@ -23,7 +23,7 @@ pre_configure_target() {
 }
 
 pre_make_target() {
-  cat > Make.config <<EOF
+  cat >Make.config <<EOF
   PLUGINLIBDIR = /usr/lib/vdr
   PREFIX = /usr
   VIDEODIR = /storage/videos

--- a/packages/addons/service/hyperion/package.mk
+++ b/packages/addons/service/hyperion/package.mk
@@ -53,7 +53,7 @@ pre_build_target() {
 }
 
 pre_configure_target() {
-  echo "" > ../cmake/FindGitVersion.cmake
+  echo "" >../cmake/FindGitVersion.cmake
 }
 
 addon() {

--- a/packages/addons/service/prometheus-node-exporter/package.mk
+++ b/packages/addons/service/prometheus-node-exporter/package.mk
@@ -37,4 +37,3 @@ addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
   cp -P ${PKG_BUILD}/bin/prometheus-node-exporter ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
 }
-

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -43,8 +43,7 @@ addon() {
      ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
 
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/rsyslog
-  for l in $(find ${PKG_INSTALL}/usr/lib -name *.so)
-  do
+  for l in $(find ${PKG_INSTALL}/usr/lib -name *.so); do
     cp ${l} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/rsyslog/
   done
 }

--- a/packages/addons/service/tigervnc/package.mk
+++ b/packages/addons/service/tigervnc/package.mk
@@ -33,8 +33,8 @@ _pkg_copy_lib() {
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private}
 
-  cp ${PKG_BUILD}/.${TARGET_NAME}/unix/vncconfig/vncconfig     \
-     ${PKG_BUILD}/.${TARGET_NAME}/unix/vncpasswd/vncpasswd     \
+  cp ${PKG_BUILD}/.${TARGET_NAME}/unix/vncconfig/vncconfig \
+     ${PKG_BUILD}/.${TARGET_NAME}/unix/vncpasswd/vncpasswd \
      ${PKG_BUILD}/.${TARGET_NAME}/unix/x0vncserver/x0vncserver \
      ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
 

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -86,15 +86,15 @@ pre_configure_target() {
                              --disable-bintray_cache \
                              --python=${TOOLCHAIN}/bin/python"
 
-# fails to build in subdirs
+  # fails to build in subdirs
   cd ${PKG_BUILD}
   rm -rf .${TARGET_NAME}
 
-# pass ffmpegx to build
+  # pass ffmpegx to build
   CFLAGS+=" -I$(get_install_dir ffmpegx)/usr/local/include"
   LDFLAGS+=" -L$(get_install_dir ffmpegx)/usr/local/lib"
 
-# pass libhdhomerun to build
+  # pass libhdhomerun to build
   CFLAGS+=" -I${SYSROOT_PREFIX}/usr/include/hdhomerun"
 
   export CROSS_COMPILE="${TARGET_PREFIX}"

--- a/packages/addons/service/tvheadend43/package.mk
+++ b/packages/addons/service/tvheadend43/package.mk
@@ -86,15 +86,15 @@ pre_configure_target() {
                              --disable-bintray_cache \
                              --python=${TOOLCHAIN}/bin/python"
 
-# fails to build in subdirs
+  # fails to build in subdirs
   cd ${PKG_BUILD}
   rm -rf .${TARGET_NAME}
 
-# pass ffmpegx to build
+  # pass ffmpegx to build
   CFLAGS+=" -I$(get_install_dir ffmpegx)/usr/local/include"
   LDFLAGS+=" -L$(get_install_dir ffmpegx)/usr/local/lib"
 
-# pass libhdhomerun to build
+  # pass libhdhomerun to build
   CFLAGS+=" -I${SYSROOT_PREFIX}/usr/include/hdhomerun"
 
   export CROSS_COMPILE="${TARGET_PREFIX}"

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -37,7 +37,7 @@ addon() {
   cp -P $(get_build_dir vdr-plugin-vnsiserver)/vnsiserver/allowed_hosts.conf ${ADDON_BUILD}/${PKG_ADDON_ID}/config/plugins/vnsiserver
 
   touch ${ADDON_BUILD}/${PKG_ADDON_ID}/config/channels.conf
-  echo '0.0.0.0/0' >> ${ADDON_BUILD}/${PKG_ADDON_ID}/config/svdrphosts.conf
+  echo '0.0.0.0/0' >>${ADDON_BUILD}/${PKG_ADDON_ID}/config/svdrphosts.conf
 
   # copy static files
   cp -PR $(get_build_dir vdr-plugin-restfulapi)/web/* \

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -101,6 +101,6 @@ addon() {
     ln -s iwconfig ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/iwspy
     ln -s iwconfig ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/iwpriv
 
-    find ${ADDON_BUILD}/${PKG_ADDON_ID}/bin -type f | \
+    find ${ADDON_BUILD}/${PKG_ADDON_ID}/bin -type f |
       xargs patchelf --add-rpath '${ORIGIN}/../lib.private'
 }

--- a/packages/addons/tools/rpi-tools/package.mk
+++ b/packages/addons/tools/rpi-tools/package.mk
@@ -19,7 +19,6 @@ PKG_ADDON_NAME="Raspberry Pi Tools"
 PKG_ADDON_TYPE="xbmc.python.module"
 PKG_ADDON_PROJECTS="RPi ARM"
 
-
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
     cp -PR $(get_build_dir lg-gpio)/liblgpio.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -191,6 +191,6 @@ addon() {
     cp -P $(get_install_dir vim)/usr/bin/vim ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -Pa $(get_install_dir vim)/storage/.kodi/addons/virtual.system-tools/data/vim/ ${ADDON_BUILD}/${PKG_ADDON_ID}/data
 
-    scanelf -EET_EXEC -RBF %F ${ADDON_BUILD}/${PKG_ADDON_ID}/bin | \
+    scanelf -EET_EXEC -RBF %F ${ADDON_BUILD}/${PKG_ADDON_ID}/bin |
       xargs patchelf --add-rpath '${ORIGIN}/../lib.private'
 }

--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -31,8 +31,8 @@ post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/share/sounds
   rm -rf ${INSTALL}/usr/lib/systemd/system
 
-# remove default udev rule to restore mixer configs, we install our own.
-# so we avoid resetting our soundconfig
+  # remove default udev rule to restore mixer configs, we install our own.
+  # so we avoid resetting our soundconfig
   rm -rf ${INSTALL}/usr/lib/udev/rules.d/90-alsa-restore.rules
 
   mkdir -p ${INSTALL}/.noinstall

--- a/packages/audio/espeak-ng/package.mk
+++ b/packages/audio/espeak-ng/package.mk
@@ -14,8 +14,14 @@ PKG_TOOLCHAIN="autotools"
 
 make_host() {
   mkdir phsource dictsource
-  (cd dictsource; ln -s ../../dictsource/* .)
-  (cd phsource; ln -s ../../phsource/* .)
+  (
+    cd dictsource
+    ln -s ../../dictsource/* .
+  )
+  (
+    cd phsource
+    ln -s ../../phsource/* .
+  )
   cp -aP ../espeak-ng-data .
   make DESTDIR=$(pwd) -j1
 }

--- a/packages/audio/libfreeaptx/package.mk
+++ b/packages/audio/libfreeaptx/package.mk
@@ -25,7 +25,7 @@ makeinstall_target() {
     cp -a ${PKG_NAME##*lib}.h ${SYSROOT_PREFIX}/usr/include/
 
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
-    cat > ${SYSROOT_PREFIX}/usr/lib/pkgconfig/${PKG_NAME}.pc << EOF
+    cat >${SYSROOT_PREFIX}/usr/lib/pkgconfig/${PKG_NAME}.pc <<EOF
 prefix=/usr
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib

--- a/packages/audio/openal-soft/package.mk
+++ b/packages/audio/openal-soft/package.mk
@@ -15,4 +15,3 @@ PKG_CMAKE_OPTS_TARGET="-DALSOFT_BACKEND_OSS=off \
                        -DALSOFT_BACKEND_WAVE=off \
                        -DALSOFT_EXAMPLES=off \
                        -DALSOFT_UTILS=off"
-

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -27,7 +27,7 @@ post_makeinstall_target() {
   # ref https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/0da29f38181e391160fa8702623050b8544ec775
   # ref https://github.com/PipeWire/wireplumber/blob/master/docs/rst/daemon/configuration/migration.rst
   # ref https://github.com/PipeWire/wireplumber/blob/master/docs/rst/daemon/configuration/features.rst
-  cat > ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-session-dbus-dependent-features.conf << EOF
+  cat >${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-session-dbus-dependent-features.conf <<EOF
 wireplumber.profiles = {
   main = {
     monitor.alsa.reserve-device = disabled
@@ -37,7 +37,7 @@ wireplumber.profiles = {
 }
 EOF
 
-  cat > ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-v4l2.conf << EOF
+  cat >${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-v4l2.conf <<EOF
 wireplumber.profiles = {
   main = {
     monitor.v4l2 = disabled
@@ -45,7 +45,7 @@ wireplumber.profiles = {
 }
 EOF
 
-  cat > ${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-bluez-hfphsp-backend.conf << EOF
+  cat >${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-bluez-hfphsp-backend.conf <<EOF
 monitor.bluez.properties = {
   bluez5.hfphsp-backend = "none"
 }

--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -23,8 +23,8 @@ configure_host() {
   # custom cmake build to override the LOCAL_CC/CXX
   cp ${CMAKE_CONF} cmake-zstd.conf
 
-  echo "SET(CMAKE_C_COMPILER   ${CC})"  >> cmake-zstd.conf
-  echo "SET(CMAKE_CXX_COMPILER ${CXX})" >> cmake-zstd.conf
+  echo "SET(CMAKE_C_COMPILER   ${CC})"  >>cmake-zstd.conf
+  echo "SET(CMAKE_CXX_COMPILER ${CXX})" >>cmake-zstd.conf
 
   cmake -DCMAKE_TOOLCHAIN_FILE=cmake-zstd.conf \
         -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN} \

--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -23,34 +23,34 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-static \
                            --with-gnu-ld"
 
 pre_configure_target() {
-# sqlite fails to compile with fast-math link time optimization.
+  # sqlite fails to compile with fast-math link time optimization.
   CFLAGS=$(echo ${CFLAGS} | sed -e "s|-Ofast|-O3|g")
   CFLAGS=$(echo ${CFLAGS} | sed -e "s|-ffast-math||g")
 
-# This option adds additional logic to the ANALYZE command and to the query planner
-# that can help SQLite to chose a better query plan under certain situations. The
-# ANALYZE command is enhanced to collect histogram data from each index and store
-# that data in the sqlite_stat4 table. The query planner will then use the histogram
-# data to help it make better index choices.
+  # This option adds additional logic to the ANALYZE command and to the query planner
+  # that can help SQLite to chose a better query plan under certain situations. The
+  # ANALYZE command is enhanced to collect histogram data from each index and store
+  # that data in the sqlite_stat4 table. The query planner will then use the histogram
+  # data to help it make better index choices.
   CFLAGS+=" -DSQLITE_ENABLE_STAT4"
 
-# When this C-preprocessor macro is defined, SQLite includes some additional APIs
-# that provide convenient access to meta-data about tables and queries. The APIs that
-# are enabled by this option are:
-#  - sqlite3_column_database_name()
-#  - sqlite3_column_database_name16()
-#  - sqlite3_column_table_name()
-#  - sqlite3_column_table_name16()
-#  - sqlite3_column_origin_name()
-#  - sqlite3_column_origin_name16()
-#  - sqlite3_table_column_metadata()
+  # When this C-preprocessor macro is defined, SQLite includes some additional APIs
+  # that provide convenient access to meta-data about tables and queries. The APIs that
+  # are enabled by this option are:
+  #  - sqlite3_column_database_name()
+  #  - sqlite3_column_database_name16()
+  #  - sqlite3_column_table_name()
+  #  - sqlite3_column_table_name16()
+  #  - sqlite3_column_origin_name()
+  #  - sqlite3_column_origin_name16()
+  #  - sqlite3_table_column_metadata()
   CFLAGS+=" -DSQLITE_ENABLE_COLUMN_METADATA=1"
 
-# This macro sets the default limit on the amount of memory that will be used for
-# memory-mapped I/O for each open database file. If the N is zero, then memory
-# mapped I/O is disabled by default. This compile-time limit and the
-# SQLITE_MAX_MMAP_SIZE can be modified at start-time using the
-# sqlite3_config(SQLITE_CONFIG_MMAP_SIZE) call, or at run-time using the
-# mmap_size pragma.
+  # This macro sets the default limit on the amount of memory that will be used for
+  # memory-mapped I/O for each open database file. If the N is zero, then memory
+  # mapped I/O is disabled by default. This compile-time limit and the
+  # SQLITE_MAX_MMAP_SIZE can be modified at start-time using the
+  # sqlite3_config(SQLITE_CONFIG_MMAP_SIZE) call, or at run-time using the
+  # mmap_size pragma.
   CFLAGS+=" -DSQLITE_TEMP_STORE=3 -DSQLITE_DEFAULT_MMAP_SIZE=268435456"
 }

--- a/packages/devel/arm-mem/package.mk
+++ b/packages/devel/arm-mem/package.mk
@@ -35,7 +35,7 @@ makeinstall_target() {
     cp -P ${PKG_LIB_ARM_MEM} ${INSTALL}/usr/lib
 
   mkdir -p ${INSTALL}/etc
-    echo "/usr/lib/${PKG_LIB_ARM_MEM}" >> ${INSTALL}/etc/ld.so.preload
+    echo "/usr/lib/${PKG_LIB_ARM_MEM}" >>${INSTALL}/etc/ld.so.preload
 }
 
 makeinstall_init() {
@@ -43,5 +43,5 @@ makeinstall_init() {
     cp -P ${PKG_LIB_ARM_MEM} ${INSTALL}/usr/lib
 
   mkdir -p ${INSTALL}/etc
-    echo "/usr/lib/${PKG_LIB_ARM_MEM}" >> ${INSTALL}/etc/ld.so.preload
+    echo "/usr/lib/${PKG_LIB_ARM_MEM}" >>${INSTALL}/etc/ld.so.preload
 }

--- a/packages/devel/autoconf-archive/package.mk
+++ b/packages/devel/autoconf-archive/package.mk
@@ -14,9 +14,9 @@ PKG_LONGDESC="autoconf-archive is an package of m4 macros"
 PKG_CONFIGURE_OPTS_HOST="--target=${TARGET_NAME} --prefix=${TOOLCHAIN}"
 
 makeinstall_host() {
-# make install
+  # make install
   make prefix=${SYSROOT_PREFIX}/usr install
 
-# remove problematic m4 file
+  # remove problematic m4 file
   rm -rf ${SYSROOT_PREFIX}/usr/share/aclocal/ax_prog_cc_for_build.m4
 }

--- a/packages/devel/bison/package.mk
+++ b/packages/devel/bison/package.mk
@@ -15,8 +15,8 @@ PKG_BUILD_FLAGS="-parallel"
 PKG_CONFIGURE_OPTS_HOST="--disable-rpath --with-gnu-ld"
 
 post_configure_host() {
-# The configure system causes Bison to be built without support for
-# internationalization of error messages if a bison program is not already in
-# ${PATH}. The following addition will correct this:
-  echo '#define YYENABLE_NLS 1' >> lib/config.h
+  # The configure system causes Bison to be built without support for
+  # internationalization of error messages if a bison program is not already in
+  # ${PATH}. The following addition will correct this:
+  echo '#define YYENABLE_NLS 1' >>lib/config.h
 }

--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -35,10 +35,10 @@ configure_target() {
                   --with-python=${TOOLCHAIN}/bin/python \
                   --with-python-root=${SYSROOT_PREFIX}/usr
 
-  echo "using gcc : $(${CC} -v 2>&1  | tail -n 1 |awk '{print $3}') : ${CC}  : <compileflags>\"${CFLAGS}\" <linkflags>\"${LDFLAGS}\" ;" \
-    > tools/build/src/user-config.jam
-  echo "using python : ${PKG_PYTHON_VERSION/#python} : ${TOOLCHAIN} : ${SYSROOT_PREFIX}/usr/include : ${SYSROOT_PREFIX}/usr/lib ;" \
-    >> tools/build/src/user-config.jam
+  echo "using gcc : $(${CC} -v 2>&1  | tail -n 1 | awk '{print $3}') : ${CC}  : <compileflags>\"${CFLAGS}\" <linkflags>\"${LDFLAGS}\" ;" \
+    >tools/build/src/user-config.jam
+  echo "using python : ${PKG_PYTHON_VERSION#python} : ${TOOLCHAIN} : ${SYSROOT_PREFIX}/usr/include : ${SYSROOT_PREFIX}/usr/lib ;" \
+    >>tools/build/src/user-config.jam
 }
 
 makeinstall_target() {

--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -18,8 +18,8 @@ configure_host() {
   # custom cmake build to override the LOCAL_CC/CXX
   cp ${CMAKE_CONF} cmake-ccache.conf
 
-  echo "SET(CMAKE_C_COMPILER   ${CC})"  >> cmake-ccache.conf
-  echo "SET(CMAKE_CXX_COMPILER ${CXX})" >> cmake-ccache.conf
+  echo "SET(CMAKE_C_COMPILER   ${CC})"  >>cmake-ccache.conf
+  echo "SET(CMAKE_CXX_COMPILER ${CXX})" >>cmake-ccache.conf
 
   cmake -DCMAKE_TOOLCHAIN_FILE=cmake-ccache.conf \
         -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN} \
@@ -31,20 +31,20 @@ configure_host() {
 }
 
 post_makeinstall_host() {
-# setup ccache
+  # setup ccache
   if [ -z "${CCACHE_DISABLE}" ]; then
     CCACHE_DIR="${BUILD_CCACHE_DIR}" ${TOOLCHAIN}/bin/ccache --max-size=${CCACHE_CACHE_SIZE}
     CCACHE_DIR="${BUILD_CCACHE_DIR}" ${TOOLCHAIN}/bin/ccache --set-config compression_level=${CCACHE_COMPRESSLEVEL}
   fi
 
-  cat > ${TOOLCHAIN}/bin/host-gcc <<EOF
+  cat >${TOOLCHAIN}/bin/host-gcc <<EOF
 #!/bin/sh
 ${TOOLCHAIN}/bin/ccache ${LOCAL_CC} "\$@"
 EOF
 
   chmod +x ${TOOLCHAIN}/bin/host-gcc
 
-  cat > ${TOOLCHAIN}/bin/host-g++ <<EOF
+  cat >${TOOLCHAIN}/bin/host-g++ <<EOF
 #!/bin/sh
 ${TOOLCHAIN}/bin/ccache ${LOCAL_CXX} "\$@"
 EOF

--- a/packages/devel/flex/package.mk
+++ b/packages/devel/flex/package.mk
@@ -19,7 +19,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_realloc_0_nonnull=yes \
                            ac_cv_func_malloc_0_nonnull=yes"
 
 post_makeinstall_host() {
-  cat > ${TOOLCHAIN}/bin/lex << "EOF"
+  cat >${TOOLCHAIN}/bin/lex  <<"EOF"
 #!/bin/sh
 exec flex "$@"
 EOF

--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -49,7 +49,7 @@ post_unpack() {
 }
 
 pre_configure_target() {
-# Filter out some problematic *FLAGS
+  # Filter out some problematic *FLAGS
   export CFLAGS=$(echo ${CFLAGS} | sed -e "s|-ffast-math||g")
   export CFLAGS=$(echo ${CFLAGS} | sed -e "s|-Ofast|-O2|g")
   export CFLAGS=$(echo ${CFLAGS} | sed -e "s|-O.|-O2|g")
@@ -101,8 +101,8 @@ post_makeinstall_target() {
     cp -a ${INSTALL}/usr/share/i18n/locales ${INSTALL}/.noinstall
     mv ${INSTALL}/usr/share/i18n/charmaps ${INSTALL}/.noinstall
 
-# cleanup
-# remove any programs we don't want/need, keeping only those we want
+  # cleanup
+  # remove any programs we don't want/need, keeping only those we want
   for f in $(find ${INSTALL}/usr/bin -type f); do
     listcontains "${GLIBC_INCLUDE_BIN}" "$(basename "${f}")" || safe_remove "${f}"
   done
@@ -112,7 +112,7 @@ post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/lib/*.o
   safe_remove ${INSTALL}/var
 
-# add UTF-8 charmap
+  # add UTF-8 charmap
   mkdir -p ${INSTALL}/usr/share/i18n/charmaps
     cp -PR ${INSTALL}/.noinstall/charmaps/UTF-8.gz ${INSTALL}/usr/share/i18n/charmaps
 
@@ -123,7 +123,7 @@ post_makeinstall_target() {
       cp -PR ${PKG_BUILD}/localedata/locales/POSIX ${INSTALL}/usr/share/i18n/locales
   fi
 
-# create default configs
+  # create default configs
   mkdir -p ${INSTALL}/etc
     cp ${PKG_DIR}/config/nsswitch-target.conf ${INSTALL}/etc/nsswitch.conf
     cp ${PKG_DIR}/config/host.conf ${INSTALL}/etc
@@ -151,7 +151,7 @@ makeinstall_init() {
 }
 
 post_makeinstall_init() {
-# create default configs
+  # create default configs
   mkdir -p ${INSTALL}/etc
     cp ${PKG_DIR}/config/nsswitch-init.conf ${INSTALL}/etc/nsswitch.conf
 }

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -11,7 +11,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="hwdata contains various hardware identification and configuration data, such as the pci.ids and usb.ids databases"
 
 pre_configure_target() {
-# hwdata fails to build in subdirs
+  # hwdata fails to build in subdirs
   cd ${PKG_BUILD}
     rm -rf .${TARGET_NAME}
 

--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -26,8 +26,8 @@ configure_host() {
   # custom cmake build to override the LOCAL_CC/CXX
   cp ${CMAKE_CONF} cmake-ccache.conf
 
-  echo "SET(CMAKE_C_COMPILER   ${CC})"  >> cmake-ccache.conf
-  echo "SET(CMAKE_CXX_COMPILER ${CXX})" >> cmake-ccache.conf
+  echo "SET(CMAKE_C_COMPILER   ${CC})"  >>cmake-ccache.conf
+  echo "SET(CMAKE_CXX_COMPILER ${CXX})" >>cmake-ccache.conf
   cmake -DCMAKE_TOOLCHAIN_FILE=cmake-ccache.conf \
         -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN} \
         ${PKG_CMAKE_OPTS_COMMON} \

--- a/packages/devel/popt/package.mk
+++ b/packages/devel/popt/package.mk
@@ -12,11 +12,11 @@ PKG_DEPENDS_TARGET="cmake:host gcc:host"
 PKG_LONGDESC="The popt library exists essentially for parsing command-line options."
 
 pre_configure_target() {
- cd ${PKG_BUILD}
- rm -rf .${TARGET_NAME}
+  cd ${PKG_BUILD}
+  rm -rf .${TARGET_NAME}
 }
 
 pre_configure_host() {
- cd ${PKG_BUILD}
- rm -rf .${HOST_NAME}
+  cd ${PKG_BUILD}
+  rm -rf .${HOST_NAME}
 }

--- a/packages/devel/slang/package.mk
+++ b/packages/devel/slang/package.mk
@@ -16,14 +16,14 @@ PKG_CONFIGURE_OPTS_TARGET="--without-pcre \
                            --without-onig"
 
 pre_configure_target() {
- # slang fails to build in subdirs
- cd ${PKG_BUILD}
- sed -i 's|RPATH=".*"|RPATH=""|' configure
- rm -rf .${TARGET_NAME}
+  # slang fails to build in subdirs
+  cd ${PKG_BUILD}
+  sed -i 's|RPATH=".*"|RPATH=""|' configure
+  rm -rf .${TARGET_NAME}
 }
 
 pre_configure_host() {
- # slang fails to build in subdirs
- cd ${PKG_BUILD}
- rm -rf .${HOST_NAME}
+  # slang fails to build in subdirs
+  cd ${PKG_BUILD}
+  rm -rf .${HOST_NAME}
 }

--- a/packages/emulation/libretro-2048/package.mk
+++ b/packages/emulation/libretro-2048/package.mk
@@ -19,5 +19,5 @@ PKG_LIBVAR="2048_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-81/package.mk
+++ b/packages/emulation/libretro-81/package.mk
@@ -19,5 +19,5 @@ PKG_LIBVAR="81_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-a5200/package.mk
+++ b/packages/emulation/libretro-a5200/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="A5200_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-atari800/package.mk
+++ b/packages/emulation/libretro-atari800/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="ATARI800_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-bsnes/package.mk
+++ b/packages/emulation/libretro-beetle-bsnes/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="BEETLE-BSNES_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-gba/package.mk
+++ b/packages/emulation/libretro-beetle-gba/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="BEETLE-GBA_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-lynx/package.mk
+++ b/packages/emulation/libretro-beetle-lynx/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="BEETLE-LYNX_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-ngp/package.mk
+++ b/packages/emulation/libretro-beetle-ngp/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="BEETLE-NGP_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-pce-fast/package.mk
+++ b/packages/emulation/libretro-beetle-pce-fast/package.mk
@@ -20,5 +20,5 @@ PKG_LIBVAR="BEETLE-PCE-FAST_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-pce/package.mk
+++ b/packages/emulation/libretro-beetle-pce/package.mk
@@ -20,5 +20,5 @@ PKG_LIBVAR="BEETLE-FAST_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-pcfx/package.mk
+++ b/packages/emulation/libretro-beetle-pcfx/package.mk
@@ -28,5 +28,5 @@ PKG_LIBVAR="BEETLE-PCFX_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-psx/package.mk
+++ b/packages/emulation/libretro-beetle-psx/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="HAVE_CDROM=1 LINK_STATIC_LIBCPLUSPLUS=0"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-saturn/package.mk
+++ b/packages/emulation/libretro-beetle-saturn/package.mk
@@ -20,5 +20,5 @@ PKG_LIBVAR="BEETLE-SATURN_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-supergrafx/package.mk
+++ b/packages/emulation/libretro-beetle-supergrafx/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="BEETLE-SUPERGRAFX_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-vb/package.mk
+++ b/packages/emulation/libretro-beetle-vb/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="BEETLE-VB_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-beetle-wswan/package.mk
+++ b/packages/emulation/libretro-beetle-wswan/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="BEETLE-WSWAN_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-bk/package.mk
+++ b/packages/emulation/libretro-bk/package.mk
@@ -20,5 +20,5 @@ PKG_LIBVAR="BK_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-blastem/package.mk
+++ b/packages/emulation/libretro-blastem/package.mk
@@ -21,5 +21,5 @@ PKG_LIBVAR="BLASTEM_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -20,5 +20,5 @@ PKG_LIBVAR="BLUEMSX_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-bnes/package.mk
+++ b/packages/emulation/libretro-bnes/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="BNES_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-bsnes-hd/package.mk
+++ b/packages/emulation/libretro-bsnes-hd/package.mk
@@ -23,5 +23,5 @@ PKG_LIBVAR="BSNES-HD_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-bsnes-mercury-performance/package.mk
+++ b/packages/emulation/libretro-bsnes-mercury-performance/package.mk
@@ -24,5 +24,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-bsnes/package.mk
+++ b/packages/emulation/libretro-bsnes/package.mk
@@ -24,5 +24,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-bsnes2014-performance/package.mk
+++ b/packages/emulation/libretro-bsnes2014-performance/package.mk
@@ -24,5 +24,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-cannonball/package.mk
+++ b/packages/emulation/libretro-cannonball/package.mk
@@ -18,7 +18,7 @@ PKG_LIBVAR="CANNONBALL_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   mkdir -p ${SYSROOT_PREFIX}/usr/share/retroarch/system/cannonball/res/
   cp -v res/{tilemap.bin,tilepatch.bin} docs/license.txt ${SYSROOT_PREFIX}/usr/share/retroarch/system/cannonball/res/

--- a/packages/emulation/libretro-cap32/package.mk
+++ b/packages/emulation/libretro-cap32/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="CAP32_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-dinothawr/package.mk
+++ b/packages/emulation/libretro-dinothawr/package.mk
@@ -22,7 +22,7 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   mkdir -p ${SYSROOT_PREFIX}/usr/share/retroarch/system
   cp -rv dinothawr ${SYSROOT_PREFIX}/usr/share/retroarch/system/dinothawr

--- a/packages/emulation/libretro-dosbox-pure/package.mk
+++ b/packages/emulation/libretro-dosbox-pure/package.mk
@@ -27,5 +27,5 @@ make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-dosbox/package.mk
+++ b/packages/emulation/libretro-dosbox/package.mk
@@ -24,5 +24,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-fbneo/package.mk
+++ b/packages/emulation/libretro-fbneo/package.mk
@@ -35,7 +35,7 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   mkdir -p ${SYSROOT_PREFIX}/usr/share/libretro-database/fbneo
   cp -vr dats/* ${SYSROOT_PREFIX}/usr/share/libretro-database/fbneo

--- a/packages/emulation/libretro-fceumm/package.mk
+++ b/packages/emulation/libretro-fceumm/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-f Makefile.libretro"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-fmsx/package.mk
+++ b/packages/emulation/libretro-fmsx/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="FMSX_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-fuse/package.mk
+++ b/packages/emulation/libretro-fuse/package.mk
@@ -25,5 +25,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-gambatte/package.mk
+++ b/packages/emulation/libretro-gambatte/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-f Makefile.libretro"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-genplus/package.mk
+++ b/packages/emulation/libretro-genplus/package.mk
@@ -30,5 +30,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-gw/package.mk
+++ b/packages/emulation/libretro-gw/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-f Makefile.libretro"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-handy/package.mk
+++ b/packages/emulation/libretro-handy/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="HANDY_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-hatari/package.mk
+++ b/packages/emulation/libretro-hatari/package.mk
@@ -26,5 +26,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-mame2000/package.mk
+++ b/packages/emulation/libretro-mame2000/package.mk
@@ -22,5 +22,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-mame2003_plus/package.mk
+++ b/packages/emulation/libretro-mame2003_plus/package.mk
@@ -22,7 +22,7 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   mkdir -p ${SYSROOT_PREFIX}/usr/share/libretro-database/mame2003-plus
   cp -v metadata/mame2003-plus.xml ${SYSROOT_PREFIX}/usr/share/libretro-database/mame2003-plus/
@@ -31,5 +31,5 @@ makeinstall_target() {
   cp -rv metadata/artwork ${SYSROOT_PREFIX}/usr/share/retroarch/system/mame2003-plus
   cp -v metadata/{cheat,hiscore,history}.dat ${SYSROOT_PREFIX}/usr/share/retroarch/system/mame2003-plus
   # something must be in a folder in order to include it in the image, so why not some instructions
-  echo "Put your samples here." > ${SYSROOT_PREFIX}/usr/share/retroarch/system/mame2003-plus/samples/readme.txt
+  echo "Put your samples here." >${SYSROOT_PREFIX}/usr/share/retroarch/system/mame2003-plus/samples/readme.txt
 }

--- a/packages/emulation/libretro-mame2010/package.mk
+++ b/packages/emulation/libretro-mame2010/package.mk
@@ -34,7 +34,7 @@ make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   mkdir -p ${SYSROOT_PREFIX}/usr/share/libretro-database/mame2010
   cp -v metadata/mame2010.xml ${SYSROOT_PREFIX}/usr/share/libretro-database/mame2010/

--- a/packages/emulation/libretro-mesen-s/package.mk
+++ b/packages/emulation/libretro-mesen-s/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-C Libretro/"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-mesen/package.mk
+++ b/packages/emulation/libretro-mesen/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-C Libretro/"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-mgba/package.mk
+++ b/packages/emulation/libretro-mgba/package.mk
@@ -28,5 +28,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-mrboom/package.mk
+++ b/packages/emulation/libretro-mrboom/package.mk
@@ -24,5 +24,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-nestopia/package.mk
+++ b/packages/emulation/libretro-nestopia/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-C libretro/"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-nx/package.mk
+++ b/packages/emulation/libretro-nx/package.mk
@@ -18,7 +18,7 @@ PKG_LIBVAR="NX_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   mkdir -p ${SYSROOT_PREFIX}/usr/share/retroarch/system/nxengine
   cp -vr datafiles/* ${SYSROOT_PREFIX}/usr/share/retroarch/system/nxengine

--- a/packages/emulation/libretro-o2em/package.mk
+++ b/packages/emulation/libretro-o2em/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="O2EM_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-opera/package.mk
+++ b/packages/emulation/libretro-opera/package.mk
@@ -22,5 +22,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -52,5 +52,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-picodrive/package.mk
+++ b/packages/emulation/libretro-picodrive/package.mk
@@ -35,5 +35,5 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-pokemini/package.mk
+++ b/packages/emulation/libretro-pokemini/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-f Makefile.libretro"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-prboom/package.mk
+++ b/packages/emulation/libretro-prboom/package.mk
@@ -18,7 +18,7 @@ PKG_LIBVAR="PRBOOM_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   mkdir -p ${SYSROOT_PREFIX}/usr/share/retroarch/system/
   cp -v prboom.wad ${SYSROOT_PREFIX}/usr/share/retroarch/system/

--- a/packages/emulation/libretro-prosystem/package.mk
+++ b/packages/emulation/libretro-prosystem/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="PROSYSTEM_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-quicknes/package.mk
+++ b/packages/emulation/libretro-quicknes/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="QUICKNES_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-sameboy/package.mk
+++ b/packages/emulation/libretro-sameboy/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-C libretro/"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-scummvm/package.mk
+++ b/packages/emulation/libretro-scummvm/package.mk
@@ -33,13 +33,13 @@ makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
   cp scummvm_libretro.info ${SYSROOT_PREFIX}/usr/lib/
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   # unpack files to retroarch-system folder and create basic ini file
   mkdir -p ${SYSROOT_PREFIX}/usr/share/retroarch/system
   unzip scummvm.zip -d ${SYSROOT_PREFIX}/usr/share/retroarch/system
 
-  cat << EOF > ${SYSROOT_PREFIX}/usr/share/retroarch/system/scummvm.ini
+  cat <<EOF  >${SYSROOT_PREFIX}/usr/share/retroarch/system/scummvm.ini
 [scummvm]
 extrapath=/tmp/system/scummvm/extra
 browser_lastpath=/tmp/system/scummvm/extra

--- a/packages/emulation/libretro-snes9x/package.mk
+++ b/packages/emulation/libretro-snes9x/package.mk
@@ -24,5 +24,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-snes9x2002/package.mk
+++ b/packages/emulation/libretro-snes9x2002/package.mk
@@ -24,5 +24,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-snes9x2010/package.mk
+++ b/packages/emulation/libretro-snes9x2010/package.mk
@@ -26,5 +26,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-stella/package.mk
+++ b/packages/emulation/libretro-stella/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-C ../src/os/libretro -f Makefile"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-supafaust/package.mk
+++ b/packages/emulation/libretro-supafaust/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="SUPAFAUST_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-tgbdual/package.mk
+++ b/packages/emulation/libretro-tgbdual/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="TGBDUAL_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-tyrquake/package.mk
+++ b/packages/emulation/libretro-tyrquake/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="TYRQUAKE_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-uae/package.mk
+++ b/packages/emulation/libretro-uae/package.mk
@@ -18,7 +18,7 @@ PKG_LIBVAR="UAE_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   mkdir -p ${SYSROOT_PREFIX}/usr/share/retroarch/system/uae_data
   cp -vR ${PKG_BUILD}/sources/uae_data/* ${SYSROOT_PREFIX}/usr/share/retroarch/system/uae_data/

--- a/packages/emulation/libretro-uae4arm/package.mk
+++ b/packages/emulation/libretro-uae4arm/package.mk
@@ -34,7 +34,7 @@ pre_configure_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 
   cp -v capsimg.so ${SYSROOT_PREFIX}/usr/lib/
 }

--- a/packages/emulation/libretro-vbam/package.mk
+++ b/packages/emulation/libretro-vbam/package.mk
@@ -20,5 +20,5 @@ PKG_MAKE_OPTS_TARGET="-C ../src/libretro/"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-vecx/package.mk
+++ b/packages/emulation/libretro-vecx/package.mk
@@ -42,5 +42,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-vice_x128/package.mk
+++ b/packages/emulation/libretro-vice_x128/package.mk
@@ -22,5 +22,5 @@ make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-vice_x64/package.mk
+++ b/packages/emulation/libretro-vice_x64/package.mk
@@ -22,5 +22,5 @@ make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-vice_xplus4/package.mk
+++ b/packages/emulation/libretro-vice_xplus4/package.mk
@@ -22,5 +22,5 @@ make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-vice_xvic/package.mk
+++ b/packages/emulation/libretro-vice_xvic/package.mk
@@ -22,5 +22,5 @@ make_target() {
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-virtualjaguar/package.mk
+++ b/packages/emulation/libretro-virtualjaguar/package.mk
@@ -18,5 +18,5 @@ PKG_LIBVAR="VIRTUALJAGUAR_LIB"
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/emulation/libretro-yabause/package.mk
+++ b/packages/emulation/libretro-yabause/package.mk
@@ -36,5 +36,5 @@ fi
 makeinstall_target() {
   mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
   cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
-  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
 }

--- a/packages/graphics/kmsxx/package.mk
+++ b/packages/graphics/kmsxx/package.mk
@@ -15,4 +15,3 @@ PKG_MESON_OPTS_TARGET="-Ddefault_library=shared \
                        -Dkmscube=false \
                        -Domap=disabled \
                        -Dpykms=disabled"
-

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -62,9 +62,8 @@ listcontains "${GRAPHIC_DRIVERS}" "etnaviv" &&
 
 post_makeinstall_target() {
   # Remove all test programs installed by install-test-programs=true except modetest
-  for PKG_LIBDRM_TEST in \
-    drmdevice modeprint proptest vbltest
-  do
+  PKG_LIBDRM_LIST="drmdevice modeprint proptest vbltest"
+  for PKG_LIBDRM_TEST in ${PKG_LIBDRM_LIST}; do
     safe_remove ${INSTALL}/usr/bin/${PKG_LIBDRM_TEST}
   done
 

--- a/packages/graphics/libglvnd/package.mk
+++ b/packages/graphics/libglvnd/package.mk
@@ -16,7 +16,7 @@ configure_package() {
   fi
 }
 
-pre_configure_target(){
+pre_configure_target() {
   PKG_MESON_OPTS_TARGET="-Dgles1=false"
 
   if [ "${OPENGLES_SUPPORT}" = "no" ]; then

--- a/packages/graphics/nvidia/package.mk
+++ b/packages/graphics/nvidia/package.mk
@@ -96,9 +96,9 @@ makeinstall_target() {
       ln -sf libnvidia-vulkan-producer.so.1              ${INSTALL}/usr/lib/libnvidia-vulkan-producer.so
 
     mkdir -p ${INSTALL}/usr/share/vulkan/implicit_layer.d
-      sed "s#libGLX_nvidia.so.0#libEGL_nvidia.so.0#" nvidia_layers.json > ${INSTALL}/usr/share/vulkan/implicit_layer.d/nvidia_layers.json
+      sed "s#libGLX_nvidia.so.0#libEGL_nvidia.so.0#" nvidia_layers.json >${INSTALL}/usr/share/vulkan/implicit_layer.d/nvidia_layers.json
     mkdir -p ${INSTALL}/usr/share/vulkan/icd.d
-      sed "s#libGLX_nvidia.so.0#libEGL_nvidia.so.0#" nvidia_icd.json > ${INSTALL}/usr/share/vulkan/icd.d/nvidia_icd.json
+      sed "s#libGLX_nvidia.so.0#libEGL_nvidia.so.0#" nvidia_icd.json >${INSTALL}/usr/share/vulkan/icd.d/nvidia_icd.json
   fi
 
   # CUDA

--- a/packages/lang/gcc-aarch64/package.mk
+++ b/packages/lang/gcc-aarch64/package.mk
@@ -65,7 +65,7 @@ post_makeinstall_host() {
 
   rm -f ${PKG_GCC_PREFIX}gcc
 
-cat > ${PKG_GCC_PREFIX}gcc <<EOF
+  cat >${PKG_GCC_PREFIX}gcc <<EOF
 #!/bin/sh
 ${TOOLCHAIN}/bin/ccache ${CROSS_CC} "\$@"
 EOF

--- a/packages/lang/gcc-arm-none-eabi/package.mk
+++ b/packages/lang/gcc-arm-none-eabi/package.mk
@@ -64,7 +64,7 @@ post_makeinstall_host() {
 
   rm -f ${PKG_GCC_PREFIX}gcc
 
-cat > ${PKG_GCC_PREFIX}gcc <<EOF
+  cat >${PKG_GCC_PREFIX}gcc <<EOF
 #!/bin/sh
 ${TOOLCHAIN}/bin/ccache ${CROSS_CC} "\$@"
 EOF

--- a/packages/lang/gcc-or1k/package.mk
+++ b/packages/lang/gcc-or1k/package.mk
@@ -65,7 +65,7 @@ post_makeinstall_host() {
 
   rm -f ${PKG_GCC_PREFIX}gcc
 
-cat > ${PKG_GCC_PREFIX}gcc <<EOF
+  cat >${PKG_GCC_PREFIX}gcc <<EOF
 #!/bin/sh
 ${TOOLCHAIN}/bin/ccache ${CROSS_CC} "\$@"
 EOF

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -19,7 +19,7 @@ if [ "${MOLD_SUPPORT}" = "yes" ]; then
 fi
 
 case ${TARGET_ARCH} in
-  arm|riscv64)
+  arm | riscv64)
     OPTS_LIBATOMIC="--enable-libatomic"
     ;;
   *)
@@ -89,7 +89,7 @@ post_makeinstall_bootstrap() {
 
   rm -f ${TARGET_PREFIX}gcc
 
-cat > ${TARGET_PREFIX}gcc <<EOF
+  cat >${TARGET_PREFIX}gcc <<EOF
 #!/bin/sh
 ${TOOLCHAIN}/bin/ccache ${CROSS_CC} "\$@"
 EOF
@@ -129,7 +129,7 @@ post_makeinstall_host() {
 
   rm -f ${TARGET_PREFIX}gcc
 
-cat > ${TARGET_PREFIX}gcc <<EOF
+  cat >${TARGET_PREFIX}gcc <<EOF
 #!/bin/sh
 ${TOOLCHAIN}/bin/ccache ${CROSS_CC} "\$@"
 EOF
@@ -141,7 +141,7 @@ EOF
 
   [ ! -f "${CROSS_CXX}" ] && mv ${TARGET_PREFIX}g++ ${CROSS_CXX}
 
-cat > ${TARGET_PREFIX}g++ <<EOF
+  cat >${TARGET_PREFIX}g++ <<EOF
 #!/bin/sh
 ${TOOLCHAIN}/bin/ccache ${CROSS_CXX} "\$@"
 EOF
@@ -157,11 +157,11 @@ EOF
 }
 
 configure_target() {
- : # reuse configure_host()
+  : # reuse configure_host()
 }
 
 make_target() {
- : # reuse make_host()
+  : # reuse make_host()
 }
 
 makeinstall_target() {
@@ -174,11 +174,11 @@ makeinstall_target() {
 }
 
 configure_init() {
- : # reuse configure_host()
+  : # reuse configure_host()
 }
 
 make_init() {
- : # reuse make_host()
+  : # reuse make_host()
 }
 
 makeinstall_init() {

--- a/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
@@ -36,7 +36,7 @@ post_makeinstall_target() {
           exit 1
         fi
       done
-    done < ${fwlist}
+    done <${fwlist}
   done
 
   mkdir -p ${INSTALL}/usr/bin

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -57,15 +57,15 @@ makeinstall_target() {
           echo "ERROR: Firmware file ${fwfile} does not exist - aborting"
           exit 1
         fi
-      done <<< "$(cd ${PKG_FW_SOURCE} && eval "find "${fwline}"")"
-    done < "${fwlist}"
+      done <<<"$(cd ${PKG_FW_SOURCE} && eval "find "${fwline}"")"
+    done <"${fwlist}"
   done
 
   PKG_KERNEL_CFG_FILE=$(kernel_config_path) || die
 
   # The following files are RPi specific and installed by brcmfmac_sdio-firmware-rpi instead.
   # They are also not required at all if the kernel is not suitably configured.
-  if listcontains "${FIRMWARE}" "brcmfmac_sdio-firmware-rpi" || \
+  if listcontains "${FIRMWARE}" "brcmfmac_sdio-firmware-rpi" ||
      ! grep -q "^CONFIG_BRCMFMAC_SDIO=y" ${PKG_KERNEL_CFG_FILE}; then
     rm -fr ${FW_TARGET_DIR}/brcm/brcmfmac43430*-sdio.*
     rm -fr ${FW_TARGET_DIR}/brcm/brcmfmac43455*-sdio.*

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -103,7 +103,8 @@ makeinstall_host() {
 }
 
 pre_make_target() {
-  ( cd ${ROOT}
+  ( 
+    cd ${ROOT}
     rm -rf ${BUILD}/initramfs
     rm -f ${STAMPS_INSTALL}/initramfs/install_target ${STAMPS_INSTALL}/*/install_init
     ${SCRIPTS}/install initramfs
@@ -182,7 +183,7 @@ pre_make_target() {
     kernel_make oldconfig
   else
     # accept default answers for .config changes
-    yes "" | kernel_make oldconfig > /dev/null
+    yes "" | kernel_make oldconfig >/dev/null
   fi
 
   if [ -f "${DISTRO_DIR}/${DISTRO}/kernel_options" ]; then
@@ -196,7 +197,7 @@ pre_make_target() {
       if [ "$(${PKG_BUILD}/scripts/config --state ${OPTION%%=*})" != "$(echo ${OPTION##*=} | tr -d '"')" ]; then
         MISSING_KERNEL_OPTIONS+="\t${OPTION}\n"
       fi
-    done < ${DISTRO_DIR}/${DISTRO}/kernel_options
+    done <${DISTRO_DIR}/${DISTRO}/kernel_options
 
     if [ -n "${MISSING_KERNEL_OPTIONS}" ]; then
       print_color CLR_WARNING "LINUX: kernel options not correct: \n${MISSING_KERNEL_OPTIONS%%}\nPlease run ./tools/check_kernel_config\n"
@@ -218,7 +219,8 @@ make_target() {
   DTC_FLAGS=-@ kernel_make ${KERNEL_TARGET} ${KERNEL_MAKE_EXTRACMD} modules
 
   if [ "${PKG_BUILD_PERF}" = "yes" ]; then
-    ( cd tools/perf
+    ( 
+      cd tools/perf
 
       # arch specific perf build args
       case "${TARGET_ARCH}" in
@@ -260,9 +262,9 @@ make_target() {
     if [ "${KERNEL_UIMAGE_COMP}" != "none" ]; then
       COMPRESSED_SIZE=$(stat -t "arch/${TARGET_KERNEL_ARCH}/boot/${KERNEL_TARGET}" | awk '{print $2}')
       # align to 1 MiB
-      COMPRESSED_SIZE=$(( ((${COMPRESSED_SIZE} - 1 >> 20) + 1) << 20 ))
-      PKG_KERNEL_UIMAGE_LOADADDR=$(printf '%X' "$(( ${KERNEL_UIMAGE_LOADADDR} + ${COMPRESSED_SIZE} ))")
-      PKG_KERNEL_UIMAGE_ENTRYADDR=$(printf '%X' "$(( ${KERNEL_UIMAGE_ENTRYADDR} + ${COMPRESSED_SIZE} ))")
+      COMPRESSED_SIZE=$((((${COMPRESSED_SIZE} - 1 >> 20) + 1) << 20))
+      PKG_KERNEL_UIMAGE_LOADADDR=$(printf '%X' "$((${KERNEL_UIMAGE_LOADADDR} + ${COMPRESSED_SIZE}))")
+      PKG_KERNEL_UIMAGE_ENTRYADDR=$(printf '%X' "$((${KERNEL_UIMAGE_ENTRYADDR} + ${COMPRESSED_SIZE}))")
     else
       PKG_KERNEL_UIMAGE_LOADADDR=${KERNEL_UIMAGE_LOADADDR}
       PKG_KERNEL_UIMAGE_ENTRYADDR=${KERNEL_UIMAGE_ENTRYADDR}

--- a/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
@@ -19,11 +19,11 @@ PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.ui.screensaver"
 
 if [ ! "${OPENGL}" = "no" ]; then
-# for OpenGL (GLX) support
+  # for OpenGL (GLX) support
   PKG_DEPENDS_TARGET+=" ${OPENGL} glew"
 fi
 
 if [ "${OPENGLES_SUPPORT}" = yes ]; then
-# for OpenGL-ES support
+  # for OpenGL-ES support
   PKG_DEPENDS_TARGET+=" ${OPENGLES}"
 fi

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -19,11 +19,11 @@ PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.player.musicviz"
 
 if [ ! "${OPENGL}" = "no" ]; then
-# for OpenGL (GLX) support
+  # for OpenGL (GLX) support
   PKG_DEPENDS_TARGET+=" ${OPENGL} glew"
 fi
 
 if [ "${OPENGLES_SUPPORT}" = yes ]; then
-# for OpenGL-ES support
+  # for OpenGL-ES support
   PKG_DEPENDS_TARGET+=" ${OPENGLES}"
 fi

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -73,7 +73,7 @@ configure_package() {
     KODI_ALSA="-DENABLE_ALSA=ON"
   else
     KODI_ALSA="-DENABLE_ALSA=OFF"
- fi
+  fi
 
   if [ "${KODI_PULSEAUDIO_SUPPORT}" = yes ]; then
     PKG_DEPENDS_TARGET+=" pulseaudio"
@@ -136,13 +136,17 @@ configure_package() {
   fi
 
   case "${KODI_MYSQL_SUPPORT}" in
-    mysql)   PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} mysql"
-             KODI_MYSQL="-DENABLE_MYSQLCLIENT=ON -DENABLE_MARIADBCLIENT=OFF"
-             ;;
-    mariadb) PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} mariadb-connector-c"
-             KODI_MYSQL="-DENABLE_MARIADBCLIENT=ON -DENABLE_MYSQLCLIENT=OFF"
-             ;;
-    *)       KODI_MYSQL="-DENABLE_MYSQLCLIENT=OFF -DENABLE_MARIADBCLIENT=OFF"
+    mysql)
+      PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} mysql"
+      KODI_MYSQL="-DENABLE_MYSQLCLIENT=ON -DENABLE_MARIADBCLIENT=OFF"
+      ;;
+    mariadb)
+      PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} mariadb-connector-c"
+      KODI_MYSQL="-DENABLE_MARIADBCLIENT=ON -DENABLE_MYSQLCLIENT=OFF"
+      ;;
+    *)
+      KODI_MYSQL="-DENABLE_MYSQLCLIENT=OFF -DENABLE_MARIADBCLIENT=OFF"
+      ;;
   esac
 
   if [ "${KODI_AIRPLAY_SUPPORT}" = yes ]; then
@@ -291,13 +295,13 @@ configure_package() {
 configure_host() {
   setup_toolchain target:cmake
   cmake ${CMAKE_GENERATOR_NINJA} \
-        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CONF} \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-        -DHEADERS_ONLY=ON \
-        ${KODI_ARCH} \
-        ${KODI_NEON} \
-        ${KODI_PLATFORM} ..
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CONF} \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+    -DHEADERS_ONLY=ON \
+    ${KODI_ARCH} \
+    ${KODI_NEON} \
+    ${KODI_PLATFORM} ..
 }
 
 make_host() {
@@ -319,9 +323,9 @@ pre_configure_target() {
 
 post_makeinstall_target() {
   mkdir -p ${INSTALL}/.noinstall
-    mv ${INSTALL}/usr/share/kodi/addons/skin.estuary \
-       ${INSTALL}/usr/share/kodi/addons/service.xbmc.versioncheck \
-       ${INSTALL}/.noinstall
+  mv ${INSTALL}/usr/share/kodi/addons/skin.estuary \
+     ${INSTALL}/usr/share/kodi/addons/service.xbmc.versioncheck \
+     ${INSTALL}/.noinstall
 
   rm -rf ${INSTALL}/usr/bin/kodi
   rm -rf ${INSTALL}/usr/bin/kodi-standalone
@@ -334,53 +338,53 @@ post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/share/xsessions
 
   mkdir -p ${INSTALL}/usr/lib/kodi
-    cp ${PKG_DIR}/scripts/kodi-config ${INSTALL}/usr/lib/kodi
-    cp ${PKG_DIR}/scripts/kodi-safe-mode ${INSTALL}/usr/lib/kodi
-    cp ${PKG_DIR}/scripts/kodi.sh ${INSTALL}/usr/lib/kodi
+  cp ${PKG_DIR}/scripts/kodi-config ${INSTALL}/usr/lib/kodi
+  cp ${PKG_DIR}/scripts/kodi-safe-mode ${INSTALL}/usr/lib/kodi
+  cp ${PKG_DIR}/scripts/kodi.sh ${INSTALL}/usr/lib/kodi
 
-    # Configure safe mode triggers - default 5 restarts within 900 seconds/15 minutes
-    sed -e "s|@KODI_MAX_RESTARTS@|${KODI_MAX_RESTARTS:-5}|g" \
-        -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
-        -i ${INSTALL}/usr/lib/kodi/kodi.sh
+  # Configure safe mode triggers - default 5 restarts within 900 seconds/15 minutes
+  sed -e "s|@KODI_MAX_RESTARTS@|${KODI_MAX_RESTARTS:-5}|g" \
+      -e "s|@KODI_MAX_SECONDS@|${KODI_MAX_SECONDS:-900}|g" \
+      -i ${INSTALL}/usr/lib/kodi/kodi.sh
 
-    if [ "${KODI_PIPEWIRE_SUPPORT}" = "yes" ]; then
-      KODI_AUDIO_ARGS="--audio-backend=pipewire"
-    elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
-      KODI_AUDIO_ARGS="--audio-backend=alsa+pulseaudio"
-    elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
-      KODI_AUDIO_ARGS="--audio-backend=pulseaudio"
-    elif [ "${KODI_PULSEAUDIO_SUPPORT}" != "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
-      KODI_AUDIO_ARGS="--audio-backend=alsa"
-    fi
+  if [ "${KODI_PIPEWIRE_SUPPORT}" = "yes" ]; then
+    KODI_AUDIO_ARGS="--audio-backend=pipewire"
+  elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+    KODI_AUDIO_ARGS="--audio-backend=alsa+pulseaudio"
+  elif [ "${KODI_PULSEAUDIO_SUPPORT}" = "yes" -a "${KODI_ALSA_SUPPORT}" != "yes" ]; then
+    KODI_AUDIO_ARGS="--audio-backend=pulseaudio"
+  elif [ "${KODI_PULSEAUDIO_SUPPORT}" != "yes" -a "${KODI_ALSA_SUPPORT}" = "yes" ]; then
+    KODI_AUDIO_ARGS="--audio-backend=alsa"
+  fi
 
-    # adjust audio output device to what was built
-    sed "s/@KODI_AUDIO_ARGS@/${KODI_AUDIO_ARGS}/" ${PKG_DIR}/config/kodi.conf.in > ${INSTALL}/usr/lib/kodi/kodi.conf
+  # adjust audio output device to what was built
+  sed "s/@KODI_AUDIO_ARGS@/${KODI_AUDIO_ARGS}/" ${PKG_DIR}/config/kodi.conf.in >${INSTALL}/usr/lib/kodi/kodi.conf
 
-    # set default display environment
-    if [ "${DISPLAYSERVER}" = "x11" ]; then
-      echo "DISPLAY=:0.0" >> ${INSTALL}/usr/lib/kodi/kodi.conf
-    elif [ "${DISPLAYSERVER}" = "wl" ]; then
-      echo "WAYLAND_DISPLAY=wayland-1" >> ${INSTALL}/usr/lib/kodi/kodi.conf
-    fi
+  # set default display environment
+  if [ "${DISPLAYSERVER}" = "x11" ]; then
+    echo "DISPLAY=:0.0" >>${INSTALL}/usr/lib/kodi/kodi.conf
+  elif [ "${DISPLAYSERVER}" = "wl" ]; then
+    echo "WAYLAND_DISPLAY=wayland-1" >>${INSTALL}/usr/lib/kodi/kodi.conf
+  fi
 
-    # nvidia: Enable USLEEP to reduce CPU load while rendering
-    if listcontains "${GRAPHIC_DRIVERS}" "nvidia" || listcontains "${GRAPHIC_DRIVERS}" "nvidia-legacy"; then
-      echo "__GL_YIELD=USLEEP" >> ${INSTALL}/usr/lib/kodi/kodi.conf
-    fi
+  # nvidia: Enable USLEEP to reduce CPU load while rendering
+  if listcontains "${GRAPHIC_DRIVERS}" "nvidia" || listcontains "${GRAPHIC_DRIVERS}" "nvidia-legacy"; then
+    echo "__GL_YIELD=USLEEP" >>${INSTALL}/usr/lib/kodi/kodi.conf
+  fi
 
   mkdir -p ${INSTALL}/usr/sbin
-    cp ${PKG_DIR}/scripts/service-addon-wrapper ${INSTALL}/usr/sbin
+  cp ${PKG_DIR}/scripts/service-addon-wrapper ${INSTALL}/usr/sbin
 
   mkdir -p ${INSTALL}/usr/bin
-    cp ${PKG_DIR}/scripts/kodi-remote ${INSTALL}/usr/bin
-    cp ${PKG_DIR}/scripts/setwakeup.sh ${INSTALL}/usr/bin
-    cp ${PKG_DIR}/scripts/pastekodi ${INSTALL}/usr/bin
-    ln -sf /usr/bin/pastekodi ${INSTALL}/usr/bin/pastecrash
+  cp ${PKG_DIR}/scripts/kodi-remote ${INSTALL}/usr/bin
+  cp ${PKG_DIR}/scripts/setwakeup.sh ${INSTALL}/usr/bin
+  cp ${PKG_DIR}/scripts/pastekodi ${INSTALL}/usr/bin
+  ln -sf /usr/bin/pastekodi ${INSTALL}/usr/bin/pastecrash
 
   mkdir -p ${INSTALL}/usr/share/kodi/addons
-    cp -R ${PKG_DIR}/config/repository.libreelec.tv ${INSTALL}/usr/share/kodi/addons
-    sed -e "s|@ADDON_URL@|${ADDON_URL}|g" -i ${INSTALL}/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
-    sed -e "s|@ADDON_VERSION@|${ADDON_VERSION}|g" -i ${INSTALL}/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
+  cp -R ${PKG_DIR}/config/repository.libreelec.tv ${INSTALL}/usr/share/kodi/addons
+  sed -e "s|@ADDON_URL@|${ADDON_URL}|g" -i ${INSTALL}/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
+  sed -e "s|@ADDON_VERSION@|${ADDON_VERSION}|g" -i ${INSTALL}/usr/share/kodi/addons/repository.libreelec.tv/addon.xml
 
   mkdir -p ${INSTALL}/usr/share/kodi/config
 
@@ -389,28 +393,28 @@ post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/share/kodi/system/settings
 
   ${PKG_DIR}/scripts/xml_merge.py ${PKG_DIR}/config/guisettings.xml \
-                                ${PROJECT_DIR}/${PROJECT}/kodi/guisettings.xml \
-                                ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/kodi/guisettings.xml \
-                                > ${INSTALL}/usr/share/kodi/config/guisettings.xml
+                                  ${PROJECT_DIR}/${PROJECT}/kodi/guisettings.xml \
+                                  ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/kodi/guisettings.xml \
+                                  >${INSTALL}/usr/share/kodi/config/guisettings.xml
 
   ${PKG_DIR}/scripts/xml_merge.py ${PKG_DIR}/config/sources.xml \
-                                ${PROJECT_DIR}/${PROJECT}/kodi/sources.xml \
-                                ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/kodi/sources.xml \
-                                > ${INSTALL}/usr/share/kodi/config/sources.xml
+                                  ${PROJECT_DIR}/${PROJECT}/kodi/sources.xml \
+                                  ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/kodi/sources.xml \
+                                  >${INSTALL}/usr/share/kodi/config/sources.xml
 
   ${PKG_DIR}/scripts/xml_merge.py ${PKG_DIR}/config/advancedsettings.xml \
-                                ${PROJECT_DIR}/${PROJECT}/kodi/advancedsettings.xml \
-                                ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/kodi/advancedsettings.xml \
-                                > ${INSTALL}/usr/share/kodi/system/advancedsettings.xml
+                                  ${PROJECT_DIR}/${PROJECT}/kodi/advancedsettings.xml \
+                                  ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/kodi/advancedsettings.xml \
+                                  >${INSTALL}/usr/share/kodi/system/advancedsettings.xml
 
   ${PKG_DIR}/scripts/xml_merge.py ${PKG_DIR}/config/appliance.xml \
-                                ${PKG_APPLIANCE_XML} \
-                                ${PROJECT_DIR}/${PROJECT}/kodi/appliance.xml \
-                                ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/kodi/appliance.xml \
-                                > ${INSTALL}/usr/share/kodi/system/settings/appliance.xml
+                                  ${PKG_APPLIANCE_XML} \
+                                  ${PROJECT_DIR}/${PROJECT}/kodi/appliance.xml \
+                                  ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/kodi/appliance.xml \
+                                  >${INSTALL}/usr/share/kodi/system/settings/appliance.xml
 
   mkdir -p ${INSTALL}/usr/cache/libreelec
-    cp ${PKG_DIR}/config/network_wait ${INSTALL}/usr/cache/libreelec
+  cp ${PKG_DIR}/config/network_wait ${INSTALL}/usr/cache/libreelec
 
   # GBM: install udev rule to ignore the power button in libinput/kodi so logind can handle it
   if [ "${DISPLAYSERVER}" = "no" ]; then
@@ -437,7 +441,7 @@ post_makeinstall_target() {
 
   if [ "${KODI_EXTRA_FONTS}" = yes ]; then
     mkdir -p ${INSTALL}/usr/share/kodi/media/Fonts
-      cp ${PKG_DIR}/fonts/*.ttf ${INSTALL}/usr/share/kodi/media/Fonts
+    cp ${PKG_DIR}/fonts/*.ttf ${INSTALL}/usr/share/kodi/media/Fonts
   fi
 
   # Compile kodi Python site-packages to .pyc bytecode, and remove .py source code

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -26,8 +26,9 @@ case "${PROJECT}" in
   *)
     PKG_PATCH_DIRS+=" v4l2-request v4l2-drmprime"
     case "${PROJECT}" in
-      Allwinner|Rockchip)
+      Allwinner | Rockchip)
         PKG_PATCH_DIRS+=" vf-deinterlace-v4l2m2m"
+        ;;
     esac
     ;;
 esac
@@ -35,9 +36,9 @@ esac
 post_unpack() {
   # Fix FFmpeg version
   if [ "${PROJECT}" = "Amlogic" ]; then
-    echo "${PKG_FFMPEG_BRANCH}-${PKG_VERSION:0:7}" > ${PKG_BUILD}/VERSION
+    echo "${PKG_FFMPEG_BRANCH}-${PKG_VERSION:0:7}" >${PKG_BUILD}/VERSION
   else
-    echo "${PKG_VERSION}" > ${PKG_BUILD}/RELEASE
+    echo "${PKG_VERSION}" >${PKG_BUILD}/RELEASE
   fi
 }
 

--- a/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
+++ b/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
@@ -188,11 +188,10 @@ pre_configure_target() {
 post_makeinstall_target() {
   # clean up
   safe_remove ${INSTALL}/usr/bin
-  for PKG_GST_PLUGINS_BAD in \
-    libgstadaptivedemux libgstbadaudio libgstbasecamerabinsrc libgstcodecs \
-    libgstinsertbin libgstisoff libgstmpegts libgstphotography libgstplayer \
-    libgstsctp libgsttranscoder libgsturidownloader libgstwebrtc
-  do
+  PKG_GST_PLUGINS_BAD_LIST="libgstadaptivedemux libgstbadaudio libgstbasecamerabinsrc libgstcodecs \
+                            libgstinsertbin libgstisoff libgstmpegts libgstphotography libgstplayer \
+                            libgstsctp libgsttranscoder libgsturidownloader libgstwebrtc"
+  for PKG_GST_PLUGINS_BAD in ${PKG_GST_PLUGINS_BAD_LIST}; do
     safe_remove ${INSTALL}/usr/lib/${PKG_GST_PLUGINS_BAD}-1.0*
   done
   safe_remove ${INSTALL}/usr/share

--- a/packages/multimedia/intel-vaapi-driver/package.mk
+++ b/packages/multimedia/intel-vaapi-driver/package.mk
@@ -23,4 +23,3 @@ fi
 PKG_MESON_OPTS_TARGET="-Denable_hybrid_codec=false \
                        -Denable_tests=false \
                        ${DISPLAYSERVER_LIBVA}"
-

--- a/packages/multimedia/nv-codec-headers/package.mk
+++ b/packages/multimedia/nv-codec-headers/package.mk
@@ -10,6 +10,6 @@ PKG_URL="https://github.com/FFmpeg/nv-codec-headers/archive/n${PKG_VERSION}.tar.
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="FFmpeg version of headers required to interface with Nvidias codec APIs."
 
-makeinstall_target(){
+makeinstall_target() {
   make DESTDIR=${SYSROOT_PREFIX} PREFIX=/usr install
 }

--- a/packages/multimedia/rtmpdump/package.mk
+++ b/packages/multimedia/rtmpdump/package.mk
@@ -66,7 +66,7 @@ makeinstall_target() {
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/sbin
 
-#  # to be removed: hack for "compatibility"
-#  mkdir -p ${INSTALL}/usr/lib
-#    ln -sf librtmp.so.1 ${INSTALL}/usr/lib/librtmp.so.0
+  #  # to be removed: hack for "compatibility"
+  #  mkdir -p ${INSTALL}/usr/lib
+  #    ln -sf librtmp.so.1 ${INSTALL}/usr/lib/librtmp.so.0
 }

--- a/packages/network/avahi/package.mk
+++ b/packages/network/avahi/package.mk
@@ -64,15 +64,15 @@ post_configure_target() {
 }
 
 post_makeinstall_target() {
-# disable wide-area
+  # disable wide-area
   sed -e "s,^.*enable-wide-area=.*$,enable-wide-area=no,g" -i ${INSTALL}/etc/avahi/avahi-daemon.conf
-# publish-hinfo
+  # publish-hinfo
   sed -e "s,^.*publish-hinfo=.*$,publish-hinfo=no,g" -i ${INSTALL}/etc/avahi/avahi-daemon.conf
-# publish-workstation
+  # publish-workstation
   sed -e "s,^.*publish-workstation=.*$,publish-workstation=no,g" -i ${INSTALL}/etc/avahi/avahi-daemon.conf
-# browse domains?
+  # browse domains?
   sed -e "s,^.*browse-domains=.*$,# browse-domains=,g" -i ${INSTALL}/etc/avahi/avahi-daemon.conf
-# set root user as default
+  # set root user as default
   sed -e "s,<port>22</port>,<port>22</port>\n    <txt-record>path=/storage</txt-record>\n    <txt-record>u=root</txt-record>,g" -i ${INSTALL}/etc/avahi/services/sftp-ssh.service
 
   rm -rf ${INSTALL}/etc/avahi/avahi-dnsconfd.action

--- a/packages/network/bluez/package.mk
+++ b/packages/network/bluez/package.mk
@@ -40,7 +40,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-dependency-tracking \
                            storagedir=/storage/.cache/bluetooth"
 
 pre_configure_target() {
-# bluez fails to build in subdirs
+  # bluez fails to build in subdirs
   cd ${PKG_BUILD}
     rm -rf .${TARGET_NAME}
 
@@ -62,8 +62,8 @@ post_makeinstall_target() {
         -e "s|^#\[Policy\]|\[Policy\]|g" \
         -e "s|^#AutoEnable.*|AutoEnable=true|g" \
         -e "s|^#JustWorksRepairing.*|JustWorksRepairing=always|g"
-    echo "[General]" > ${INSTALL}/etc/bluetooth/input.conf
-    echo "ClassicBondedOnly=false" >> ${INSTALL}/etc/bluetooth/input.conf
+    echo "[General]" >${INSTALL}/etc/bluetooth/input.conf
+    echo "ClassicBondedOnly=false" >>${INSTALL}/etc/bluetooth/input.conf
 
   mkdir -p ${INSTALL}/usr/share/services
     cp -P ${PKG_DIR}/default.d/*.conf ${INSTALL}/usr/share/services

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -39,4 +39,3 @@ post_makeinstall_target() {
 post_install() {
   enable_service iwd.service
 }
-

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -20,7 +20,7 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
                        -DWITH_INTERNAL_DOC=OFF"
 
 makeinstall_target() {
-# install static library only
+  # install static library only
   mkdir -p ${SYSROOT_PREFIX}/usr/lib
     cp ${PKG_BUILD}/.${TARGET_NAME}/src/libssh.a ${SYSROOT_PREFIX}/usr/lib
 

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -82,14 +82,14 @@ configure_package() {
 }
 
 pre_configure_target() {
-# samba uses its own build directory
+  # samba uses its own build directory
   cd ${PKG_BUILD}
     rm -rf .${TARGET_NAME}
 
-# work around link issues
+  # work around link issues
   export LDFLAGS="${LDFLAGS} -lreadline -lncurses"
 
-# support 64-bit offsets and seeks on 32-bit platforms
+  # support 64-bit offsets and seeks on 32-bit platforms
   if [ "${TARGET_ARCH}" = "arm" ]; then
     export CFLAGS+=" -D_FILE_OFFSET_BITS=64 -D_OFF_T_DEFINED_ -Doff_t=off64_t -Dlseek=lseek64"
   fi
@@ -97,7 +97,7 @@ pre_configure_target() {
 
 configure_target() {
   cp ${PKG_DIR}/config/samba4-cache.txt ${PKG_BUILD}/cache.txt
-    echo "Checking uname machine type: \"${TARGET_ARCH}\"" >> ${PKG_BUILD}/cache.txt
+    echo "Checking uname machine type: \"${TARGET_ARCH}\"" >>${PKG_BUILD}/cache.txt
 
   export COMPILE_ET=${TOOLCHAIN}/bin/heimdal_compile_et
   export ASN1_COMPILE=${TOOLCHAIN}/bin/heimdal_asn1_compile

--- a/packages/network/sshpass/package.mk
+++ b/packages/network/sshpass/package.mk
@@ -10,7 +10,7 @@ PKG_URL="https://downloads.sourceforge.net/sshpass/sshpass-${PKG_VERSION}.tar.gz
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="sshpass: a tool for non-interactive ssh password auth"
 
-pre_configure_target(){
+pre_configure_target() {
   export ac_cv_func_malloc_0_nonnull=yes
   export ac_cv_func_realloc_0_nonnull=yes
 }

--- a/packages/print/freetype/package.mk
+++ b/packages/print/freetype/package.mk
@@ -20,10 +20,11 @@ PKG_CONFIGURE_OPTS_TARGET="LIBPNG_CFLAGS=-I${SYSROOT_PREFIX}/usr/include \
 
 pre_configure_target() {
   # unset LIBTOOL because freetype uses its own
-    ( cd ..
-      unset LIBTOOL
-      sh autogen.sh
-    )
+  (
+    cd ..
+    unset LIBTOOL
+    sh autogen.sh
+  )
 }
 
 post_makeinstall_target() {

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -27,12 +27,12 @@ configure_host() {
       # the arm target is special because we specify the subarch. ie armv8a
       cp -a ${PKG_DIR}/targets/arm-libreelec-linux-gnueabihf.json ${PKG_BUILD}/targets/${TARGET_NAME}.json
       ;;
-    "aarch64"|"x86_64")
+    "aarch64" | "x86_64")
       cp -a ${PKG_DIR}/targets/${TARGET_NAME}.json ${PKG_BUILD}/targets/${TARGET_NAME}.json
       ;;
   esac
 
-  cat > ${PKG_BUILD}/config.toml <<END
+  cat >${PKG_BUILD}/config.toml  <<END
 change-id = 102579
 
 [target.${TARGET_NAME}]
@@ -80,10 +80,10 @@ mandir = "${TOOLCHAIN}/share/man"
 
 END
 
-CARGO_HOME="${PKG_BUILD}/cargo_home"
-mkdir -p "${CARGO_HOME}"
+  CARGO_HOME="${PKG_BUILD}/cargo_home"
+  mkdir -p "${CARGO_HOME}"
 
-cat > ${CARGO_HOME}/config << END
+  cat >${CARGO_HOME}/config <<END
 [target.${TARGET_NAME}]
 linker = "${TARGET_PREFIX}gcc"
 
@@ -99,7 +99,6 @@ progress.when = 'always'
 progress.width = 80
 
 END
-
 }
 
 make_host() {

--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="A library that defines common error values for all GnuPG component
 pre_configure_target() {
   PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=${HOST_CC} --enable-static --disable-shared --disable-nls --disable-rpath --with-gnu-ld --with-pic"
 
-# inspired by openembedded
+  # inspired by openembedded
   case ${TARGET_ARCH} in
     aarch64)
       GPGERROR_TUPLE=aarch64-unknown-linux-gnu

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -21,14 +21,14 @@ make_host() {
   rm -rf ${PKG_BUILD}/dist
 
   INCLUDES="-I${TOOLCHAIN}/include" \
-  make BUILD_OPT=1 USE_64=1 \
-     PREFIX=${TOOLCHAIN} \
-     NSPR_INCLUDE_DIR=${TOOLCHAIN}/include/nspr \
-     USE_SYSTEM_ZLIB=1 ZLIB_LIBS="-lz -L${TOOLCHAIN}/lib" \
-     SKIP_SHLIBSIGN=1 \
-     NSS_TESTS="dummy" \
-     CC=${CC} LDFLAGS="${LDFLAGS} -L${TOOLCHAIN}/lib" \
-     V=1
+    make BUILD_OPT=1 USE_64=1 \
+    PREFIX=${TOOLCHAIN} \
+    NSPR_INCLUDE_DIR=${TOOLCHAIN}/include/nspr \
+    USE_SYSTEM_ZLIB=1 ZLIB_LIBS="-lz -L${TOOLCHAIN}/lib" \
+    SKIP_SHLIBSIGN=1 \
+    NSS_TESTS="dummy" \
+    CC=${CC} LDFLAGS="${LDFLAGS} -L${TOOLCHAIN}/lib" \
+    V=1
 }
 
 makeinstall_host() {
@@ -54,18 +54,18 @@ make_target() {
   rm -rf ${PKG_BUILD}/dist
 
   make BUILD_OPT=1 ${TARGET_USE_64} ${TARGET_x86_64} \
-     NSS_USE_SYSTEM_SQLITE=1 \
-     NSPR_INCLUDE_DIR=${SYSROOT_PREFIX}/usr/include/nspr \
-     NSS_USE_SYSTEM_SQLITE=1 \
-     USE_SYSTEM_ZLIB=1 ZLIB_LIBS=-lz \
-     SKIP_SHLIBSIGN=1 \
-     OS_TEST=${TARGET_ARCH} \
-     NSS_TESTS="dummy" \
-     NSINSTALL=${TOOLCHAIN}/bin/nsinstall \
-     CPU_ARCH_TAG=${TARGET_ARCH} \
-     CC=${CC} \
-     LDFLAGS="${LDFLAGS} -L${SYSROOT_PREFIX}/usr/lib" \
-     V=1
+    NSS_USE_SYSTEM_SQLITE=1 \
+    NSPR_INCLUDE_DIR=${SYSROOT_PREFIX}/usr/include/nspr \
+    NSS_USE_SYSTEM_SQLITE=1 \
+    USE_SYSTEM_ZLIB=1 ZLIB_LIBS=-lz \
+    SKIP_SHLIBSIGN=1 \
+    OS_TEST=${TARGET_ARCH} \
+    NSS_TESTS="dummy" \
+    NSINSTALL=${TOOLCHAIN}/bin/nsinstall \
+    CPU_ARCH_TAG=${TARGET_ARCH} \
+    CC=${CC} \
+    LDFLAGS="${LDFLAGS} -L${SYSROOT_PREFIX}/usr/lib" \
+    V=1
 }
 
 makeinstall_target() {

--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -153,8 +153,8 @@ makeinstall_target() {
 }
 
 post_install() {
-  echo "chmod 4755 ${INSTALL}/usr/bin/busybox" >> ${FAKEROOT_SCRIPT}
-  echo "chmod 000 ${INSTALL}/usr/cache/shadow" >> ${FAKEROOT_SCRIPT}
+  echo "chmod 4755 ${INSTALL}/usr/bin/busybox" >>${FAKEROOT_SCRIPT}
+  echo "chmod 000 ${INSTALL}/usr/cache/shadow" >>${FAKEROOT_SCRIPT}
 
   add_user root "${ROOT_PASSWORD}" 0 0 "Root User" "/storage" "/bin/sh"
   add_group root 0

--- a/packages/sysutils/dbus/package.mk
+++ b/packages/sysutils/dbus/package.mk
@@ -43,6 +43,6 @@ post_install() {
   add_group dbus 81
   add_group netdev 497
 
-  echo "chmod 4750 ${INSTALL}/usr/lib/dbus/dbus-daemon-launch-helper" >> ${FAKEROOT_SCRIPT}
-  echo "chown 0:81 ${INSTALL}/usr/lib/dbus/dbus-daemon-launch-helper" >> ${FAKEROOT_SCRIPT}
+  echo "chmod 4750 ${INSTALL}/usr/lib/dbus/dbus-daemon-launch-helper" >>${FAKEROOT_SCRIPT}
+  echo "chown 0:81 ${INSTALL}/usr/lib/dbus/dbus-daemon-launch-helper" >>${FAKEROOT_SCRIPT}
 }

--- a/packages/sysutils/eventlircd/package.mk
+++ b/packages/sysutils/eventlircd/package.mk
@@ -16,7 +16,7 @@ PKG_CONFIGURE_OPTS_TARGET="--with-udev-dir=/usr/lib/udev \
                            --with-lircd-socket=/run/lirc/lircd"
 
 post_makeinstall_target() {
-# install our own evmap files and udev rules
+  # install our own evmap files and udev rules
   rm -rf ${INSTALL}/etc/eventlircd.d
   rm -rf ${INSTALL}/usr/lib/udev/rules.d
   rm -rf ${INSTALL}/usr/lib/udev/lircd_helper

--- a/packages/sysutils/evrepeat/package.mk
+++ b/packages/sysutils/evrepeat/package.mk
@@ -9,4 +9,3 @@ PKG_SITE="https://github.com/HiassofT/evrepeat"
 PKG_URL="https://github.com/HiassofT/evrepeat/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Tool to view and change linux input device repeat settings"
-

--- a/packages/sysutils/kmod/package.mk
+++ b/packages/sysutils/kmod/package.mk
@@ -34,7 +34,7 @@ post_makeinstall_host() {
 }
 
 post_makeinstall_target() {
-# make symlinks for compatibility
+  # make symlinks for compatibility
   mkdir -p ${INSTALL}/usr/sbin
     ln -sf /usr/bin/kmod ${INSTALL}/usr/sbin/lsmod
     ln -sf /usr/bin/kmod ${INSTALL}/usr/sbin/insmod
@@ -46,6 +46,6 @@ post_makeinstall_target() {
   mkdir -p ${INSTALL}/etc
     ln -sf /storage/.config/modprobe.d ${INSTALL}/etc/modprobe.d
 
-# add user modprobe.d dir
+  # add user modprobe.d dir
   mkdir -p ${INSTALL}/usr/config/modprobe.d
 }

--- a/packages/sysutils/open-iscsi/package.mk
+++ b/packages/sysutils/open-iscsi/package.mk
@@ -79,7 +79,7 @@ makeinstall_target() {
 
     sed -i -e "s:= /sbin/iscsid:= /usr/sbin/iscsid:" ${INSTALL}/etc/iscsi/iscsid.conf
 
-    echo "InitiatorName=$(${TOOLCHAIN}/bin/iscsi-iname)" > ${INSTALL}/etc/iscsi/initiatorname.iscsi
+    echo "InitiatorName=$(${TOOLCHAIN}/bin/iscsi-iname)" >${INSTALL}/etc/iscsi/initiatorname.iscsi
 }
 
 post_install() {

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -183,10 +183,10 @@ post_makeinstall_target() {
 
   # distro preset policy
   safe_remove ${INSTALL}/usr/lib/systemd/system-preset/*
-  echo "disable *" > ${INSTALL}/usr/lib/systemd/system-preset/99-default.preset
+  echo "disable *" >${INSTALL}/usr/lib/systemd/system-preset/99-default.preset
 
   safe_remove ${INSTALL}/usr/lib/systemd/user-preset/*
-  echo "disable *" > ${INSTALL}/usr/lib/systemd/user-preset/90-systemd.preset
+  echo "disable *" >${INSTALL}/usr/lib/systemd/user-preset/90-systemd.preset
 
   # remove networkd
   safe_remove ${INSTALL}/usr/lib/systemd/network

--- a/packages/sysutils/udevil/package.mk
+++ b/packages/sysutils/udevil/package.mk
@@ -18,7 +18,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-systemd \
                            --with-setfacl-prog=/usr/bin/setfacl"
 
 makeinstall_target() {
- : # nothing to install
+  : # nothing to install
 }
 
 post_makeinstall_target() {
@@ -30,7 +30,7 @@ post_makeinstall_target() {
     cp -PR src/udevil ${INSTALL}/usr/bin
 
   mkdir -p ${INSTALL}/usr/sbin
-  echo -e '#!/bin/sh\nexec /usr/bin/mount -t ntfs3 "$@"' > ${INSTALL}/usr/sbin/mount.ntfs
+  echo -e '#!/bin/sh\nexec /usr/bin/mount -t ntfs3 "$@"' >${INSTALL}/usr/sbin/mount.ntfs
   chmod 755 ${INSTALL}/usr/sbin/mount.ntfs
 }
 

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -85,14 +85,14 @@ post_makeinstall_target() {
       cp -PR ${PKG_DIR}/scripts/mount-swap ${INSTALL}/usr/lib/libreelec
 
     mkdir -p ${INSTALL}/etc
-      cat ${PKG_DIR}/config/swap.conf | \
+      cat ${PKG_DIR}/config/swap.conf |
         sed -e "s,@SWAPFILESIZE@,${SWAPFILESIZE},g" \
             -e "s,@SWAP_ENABLED_DEFAULT@,${SWAP_ENABLED_DEFAULT},g" \
-            > ${INSTALL}/etc/swap.conf
+            >${INSTALL}/etc/swap.conf
   fi
 }
 
-post_install () {
+post_install()  {
   if [ "${SWAP_SUPPORT}" = "yes" ]; then
     enable_service swap.service
   fi

--- a/packages/sysutils/v4l-utils/package.mk
+++ b/packages/sysutils/v4l-utils/package.mk
@@ -29,7 +29,7 @@ create_multi_keymap() {
       map="${INSTALL}/usr/lib/udev/rc_keymaps/${f}.toml"
       [ -e "${map}" ] && cat "${map}"
     done
-  ) > ${INSTALL}/usr/lib/udev/rc_keymaps/${name}.toml
+  ) >${INSTALL}/usr/lib/udev/rc_keymaps/${name}.toml
 }
 
 post_makeinstall_target() {
@@ -62,7 +62,7 @@ post_makeinstall_target() {
     for f in ${PKG_DIR}/keymaps/*; do
       if [ -e ${f} ]; then
         keymap=$(basename ${f})
-        cat ${f} > ${INSTALL}/usr/lib/udev/rc_keymaps/${keymap}
+        cat ${f} >${INSTALL}/usr/lib/udev/rc_keymaps/${keymap}
       fi
     done
   )
@@ -74,7 +74,7 @@ post_makeinstall_target() {
     # use multi-keymap instead of default one
     sed -i '/^\*\s*rc-rc6-mce\s*rc6_mce/d' ${INSTALL}/etc/rc_maps.cfg
 
-    cat << EOF >> ${INSTALL}/etc/rc_maps.cfg
+    cat <<EOF  >>${INSTALL}/etc/rc_maps.cfg
 #
 # Custom LibreELEC configuration starts here
 #

--- a/packages/sysutils/wait-time-sync/package.mk
+++ b/packages/sysutils/wait-time-sync/package.mk
@@ -9,7 +9,6 @@ PKG_URL=""
 PKG_DEPENDS_TARGET="make:host gcc:host"
 PKG_LONGDESC="A simple tool and systemd service to wait until NTP time is synced"
 
-
 post_install() {
   enable_service wait-time-sync.service
 }

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -21,8 +21,7 @@ makeinstall_target() {
         cp -PRv fixup4x.dat ${INSTALL}/usr/share/bootloader/fixup.dat
         cp -PRv start4x.elf ${INSTALL}/usr/share/bootloader/start.elf
         ;;
-      RPi5)
-        ;;
+      RPi5) ;;
       *)
         cp -PRv bootcode.bin ${INSTALL}/usr/share/bootloader
         cp -PRv fixup_x.dat ${INSTALL}/usr/share/bootloader/fixup.dat

--- a/packages/tools/crust/package.mk
+++ b/packages/tools/crust/package.mk
@@ -35,14 +35,14 @@ make_target() {
 
   make distclean
   if [ "${BUILD_WITH_DEBUG}" = "yes" ]; then
-    echo "CONFIG_DEBUG_LOG=y" >> configs/${CRUST_CONFIG}
+    echo "CONFIG_DEBUG_LOG=y" >>configs/${CRUST_CONFIG}
   else
-    echo "CONFIG_SERIAL=n" >> configs/${CRUST_CONFIG}
+    echo "CONFIG_SERIAL=n" >>configs/${CRUST_CONFIG}
   fi
   # Boards with a PMIC need to disable CONFIG_PMIC_SHUTDOWN to get CIR wakeup from suspend
-  echo "CONFIG_PMIC_SHUTDOWN=n" >> configs/${CRUST_CONFIG}
-  echo "CONFIG_CIR=y" >> configs/${CRUST_CONFIG}
-  echo "CONFIG_CEC=y" >> configs/${CRUST_CONFIG}
+  echo "CONFIG_PMIC_SHUTDOWN=n" >>configs/${CRUST_CONFIG}
+  echo "CONFIG_CIR=y" >>configs/${CRUST_CONFIG}
+  echo "CONFIG_CEC=y" >>configs/${CRUST_CONFIG}
   make ${CRUST_CONFIG} BUILDCC=host-gcc
   make scp
 }

--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -23,17 +23,9 @@ post_makeinstall_target() {
   cp -a ${PKG_DIR}/config/* ${INSTALL}/etc/
 
   mkdir -p ${INSTALL}/usr/share/nano
-  for FILE_TYPES in \
-    css \
-    html \
-    java \
-    javascript \
-    json \
-    php \
-    python \
-    sh \
-    xml
-  do
-    cp -a ${PKG_BUILD}/syntax/${FILE_TYPES}.nanorc ${INSTALL}/usr/share/nano/
+
+  PKG_FILE_LIST="css html java javascript json php python sh xml"
+  for PKG_FILE_TYPES in ${PKG_FILE_LIST}; do
+    cp -a ${PKG_BUILD}/syntax/${PKG_FILE_TYPES}.nanorc ${INSTALL}/usr/share/nano/
   done
 }

--- a/packages/tools/newt/package.mk
+++ b/packages/tools/newt/package.mk
@@ -16,13 +16,13 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-nls \
                            --without-tcl"
 
 pre_configure_target() {
- # newt fails to build in subdirs
- cd ${PKG_BUILD}
- rm -rf .${TARGET_NAME}
+  # newt fails to build in subdirs
+  cd ${PKG_BUILD}
+  rm -rf .${TARGET_NAME}
 }
 
 pre_configure_host() {
- # newt fails to build in subdirs
- cd ${PKG_BUILD}
- rm -rf .${HOST_NAME}
+  # newt fails to build in subdirs
+  cd ${PKG_BUILD}
+  rm -rf .${HOST_NAME}
 }

--- a/packages/tools/procps-ng/package.mk
+++ b/packages/tools/procps-ng/package.mk
@@ -35,5 +35,5 @@ makeinstall_target() {
 
   sed 's@proc/misc.h@procps/misc.h@' \
     ${PKG_BUILD}/library/include/readproc.h \
-    > ${SYSROOT_PREFIX}/usr/include/libproc2/readproc.h
+    >${SYSROOT_PREFIX}/usr/include/libproc2/readproc.h
 }

--- a/packages/tools/syslinux/package.mk
+++ b/packages/tools/syslinux/package.mk
@@ -16,7 +16,7 @@ PKG_LONGDESC="The SYSLINUX project covers lightweight linux bootloaders."
 pre_configure_target() {
   PKG_MAKE_OPTS_TARGET="CC=${CC} AR=${AR} RANLIB=${RANLIB} installer"
 
-# Unset all compiler FLAGS
+  # Unset all compiler FLAGS
   unset CFLAGS
   unset CPPFLAGS
   unset CXXFLAGS

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -28,7 +28,7 @@ post_patch() {
   if [ -n "${UBOOT_SYSTEM}" ] && find_file_path bootloader/config; then
     PKG_CONFIG_FILE="${PKG_BUILD}/configs/$(${ROOT}/${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} ${UBOOT_SYSTEM} config)"
     if [ -f "${PKG_CONFIG_FILE}" ]; then
-      cat ${FOUND_PATH} >> "${PKG_CONFIG_FILE}"
+      cat ${FOUND_PATH} >>"${PKG_CONFIG_FILE}"
     fi
   fi
 }

--- a/packages/virtual/mediacenter/package.mk
+++ b/packages/virtual/mediacenter/package.mk
@@ -18,20 +18,20 @@ if [ "${MEDIACENTER}" = "kodi" ]; then
     PKG_DEPENDS_TARGET+=" ${MEDIACENTER}-theme-${i}"
   done
 
-# python-based tool for kodi management
+  # python-based tool for kodi management
   PKG_DEPENDS_TARGET+=" texturecache.py"
 
-# some python stuff needed for various addons
+  # some python stuff needed for various addons
   PKG_DEPENDS_TARGET="${PKG_DEPENDS_TARGET} Pillow \
-                                          simplejson \
-                                          pycryptodome"
+                                            simplejson \
+                                            pycryptodome"
 
-# settings addon
+  # settings addon
   if [ -n "${DISTRO_PKG_SETTINGS}" ]; then
     PKG_DEPENDS_TARGET+=" ${DISTRO_PKG_SETTINGS}"
   fi
 
-# other packages
+  # other packages
   PKG_DEPENDS_TARGET+=" xmlstarlet"
 
   if [ "${JOYSTICK_SUPPORT}" = "yes" ]; then

--- a/packages/virtual/network/package.mk
+++ b/packages/virtual/network/package.mk
@@ -37,4 +37,3 @@ fi
 if [ "${NFS_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" nfs-utils"
 fi
-

--- a/packages/wayland/util/bemenu/package.mk
+++ b/packages/wayland/util/bemenu/package.mk
@@ -12,10 +12,10 @@ PKG_LONGDESC="Dynamic menu library and client program inspired by dmenu"
 
 PKG_MAKE_OPTS_TARGET="PREFIX=/usr clients wayland"
 
-makeinstall_target(){
+makeinstall_target() {
   make DESTDIR=${INSTALL} PREFIX=/usr install-libs install-bins install-wayland install-pkgconfig
 }
 
-post_makeinstall_target(){
+post_makeinstall_target() {
   ln -sf libbemenu.so.${PKG_VERSION} ${INSTALL}/usr/lib/libbemenu.so.0
 }

--- a/packages/wayland/util/foot/package.mk
+++ b/packages/wayland/util/foot/package.mk
@@ -17,7 +17,7 @@ PKG_MESON_OPTS_TARGET="-Ddocs=disabled \
                        -Dterminfo=disabled \
                        -Ddefault-terminfo=xterm"
 
-post_makeinstall_target(){
+post_makeinstall_target() {
   # clean up
   safe_remove ${INSTALL}/usr/share/*
 

--- a/packages/x11/other/fontconfig/package.mk
+++ b/packages/x11/other/fontconfig/package.mk
@@ -21,7 +21,7 @@ PKG_CONFIGURE_OPTS_TARGET="--with-arch=${TARGET_ARCH} \
                            --disable-rpath"
 
 pre_configure_target() {
-# ensure we dont use '-O3' optimization.
+  # ensure we dont use '-O3' optimization.
   CFLAGS=$(echo ${CFLAGS} | sed -e "s|-O3|-O2|")
   CXXFLAGS=$(echo ${CXXFLAGS} | sed -e "s|-O3|-O2|")
   CFLAGS+=" -I${PKG_BUILD}"


### PR DESCRIPTION
the package variant of https://github.com/LibreELEC/LibreELEC.tv/pull/9057

The current style follows the standard style guide from here https://google.github.io/styleguide/shellguide.html .
I tried to not include any functional change.

That PR is mainly focus to:
- indents
- remove useless spaces
- proper spaces around pipes etc
- case statement wrappings 
- redirect operators will not followed by a space (we had a 50:50 mix with and without spaces)

```
find packages/ -type f -iname package.mk -print0 | while read -r -d '' file_name; do
  ./shfmt_v3.8.0_linux_amd64 -i 2 -ci -kp -w "$file_name"
done
```

Caveats, at some packages we are doing wrong intends by design. That breaks automated formatting. This is not changed for now.
For example 
```
post_makeinstall_target() {
  mkdir -p ${INSTALL}/usr/lib/samba
    cp ${PKG_DIR}/scripts/samba-config ${INSTALL}/usr/lib/samba
    cp ${PKG_DIR}/scripts/samba-autoshare ${INSTALL}/usr/lib/samba

  if find_file_path config/smb.conf; then
    mkdir -p ${INSTALL}/etc/samba
      cp ${FOUND_PATH} ${INSTALL}/etc/samba
    mkdir -p ${INSTALL}/usr/config
      cp ${INSTALL}/etc/samba/smb.conf ${INSTALL}/usr/config/samba.conf.sample
  fi

  mkdir -p ${INSTALL}/usr/bin
    cp -PR bin/default/source3/client/smbclient ${INSTALL}/usr/bin
    cp -PR bin/default/source3/utils/smbtree ${INSTALL}/usr/bin
    cp -PR bin/default/source3/utils/nmblookup ${INSTALL}/usr/bin
    cp -PR bin/default/source3/utils/testparm ${INSTALL}/usr/bin

  if [ "${SAMBA_SERVER}" = "yes" ]; then
    mkdir -p ${INSTALL}/usr/bin
      cp -PR bin/default/source3/utils/smbpasswd ${INSTALL}/usr/bin

    mkdir -p ${INSTALL}/usr/lib/systemd/system
      cp ${PKG_DIR}/system.d.opt/* ${INSTALL}/usr/lib/systemd/system

    mkdir -p ${INSTALL}/usr/share/services
      cp -P ${PKG_DIR}/default.d/*.conf ${INSTALL}/usr/share/services
  fi
}
```
