### PR TITLE
lz4: build lz4c which is required for kernel builds

### DIFF
--- a/packages/compress/lz4/package.mk
+++ b/packages/compress/lz4/package.mk
@@ -14,6 +14,8 @@ PKG_LONGDESC="lz4 data compressor/decompressor"
 configure_package() {
   PKG_CMAKE_SCRIPT="${PKG_BUILD}/build/cmake/CMakeLists.txt"
 
+  PKG_CMAKE_OPTS_HOST="-DLZ4_BUILD_LEGACY_LZ4C=ON"
+
   PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=0 \
                          -DLZ4_BUILD_CLI=OFF \
                          -DCMAKE_POSITION_INDEPENDENT_CODE=0"

--- a/packages/compress/lz4/patches/lz4-PR1479-add-back-lz4c-target.patch
+++ b/packages/compress/lz4/patches/lz4-PR1479-add-back-lz4c-target.patch
@@ -1,0 +1,37 @@
+From 696966175798849201e31cdd6649441171a185b6 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 28 Jul 2024 01:25:23 +0000
+Subject: [PATCH] add back lz4c target but default to OFF
+
+Partially revert "removed lz4c target"
+This reverts commit 65998fecaffe7828df7b2bd9c04e9392e9704a0b.
+---
+ build/cmake/CMakeLists.txt | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/build/cmake/CMakeLists.txt b/build/cmake/CMakeLists.txt
+index c372733aa..c25b720fa 100644
+--- a/build/cmake/CMakeLists.txt
++++ b/build/cmake/CMakeLists.txt
+@@ -32,6 +32,7 @@ project(LZ4 VERSION ${LZ4_VERSION_STRING} LANGUAGES C)
+ 
+ 
+ option(LZ4_BUILD_CLI "Build lz4 program" ON)
++option(LZ4_BUILD_LEGACY_LZ4C "Build lz4c program with legacy argument support" OFF)
+ 
+ 
+ # Determine if LZ4 is being built as part of another project.
+@@ -144,6 +145,13 @@ if (LZ4_BUILD_CLI)
+   set_target_properties(lz4cli PROPERTIES OUTPUT_NAME lz4)
+ endif()
+ 
++# lz4c
++if (LZ4_BUILD_LEGACY_LZ4C)
++  list(APPEND LZ4_PROGRAMS_BUILT lz4c)
++  add_executable(lz4c ${LZ4_CLI_SOURCES})
++  set_target_properties(lz4c PROPERTIES COMPILE_DEFINITIONS "ENABLE_LZ4C_LEGACY_OPTIONS")
++endif()
++
+ # Extra warning flags
+ if(MSVC)
+   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /W4")


### PR DESCRIPTION
lz4c was dropped from upstream lz4 cmake, add it back
- https://github.com/lz4/lz4/issues/1478
- https://github.com/lz4/lz4/pull/1460
- https://github.com/lz4/lz4/pull/1479
- a8ce4388530f21f15d08b80fc19cd34ca3e3e43e

Stops builds of Exynos, Rockchip and Allwinner
```
$ git grep lz4:host
projects/Allwinner/options:    KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
projects/Rockchip/options:    KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
projects/Samsung/options:    KERNEL_EXTRA_DEPENDS_TARGET="lz4:host"
```