### PR TITLE
[le12] linux (RPi): update to 6.6.42

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="d2813c02131b9ddf938277f4123da7ccbd113ea7" # 6.6.35
-    PKG_SHA256="a443bcb9f4548db18b8774e448ed4ed811abc26b32cf017e0ae691abc2789db9"
+    PKG_VERSION="769634f344626ed73bcda14c91b567067974d7b2" # 6.6.36
+    PKG_SHA256="19ab60b80ef79f73451ee11d16851d3446d0c22bde5d3e669106cbde3d1a4cbb"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="769634f344626ed73bcda14c91b567067974d7b2" # 6.6.36
-    PKG_SHA256="19ab60b80ef79f73451ee11d16851d3446d0c22bde5d3e669106cbde3d1a4cbb"
+    PKG_VERSION="82197e1692c6cd865dca4d474dd434a4a0cf2042" # 6.6.37
+    PKG_SHA256="44272cd67b63642fe8750b18c8afcb2e973230e454ccb7c729cf5e456fc25865"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="31eb43be8cad2818b4458cf1fd2dfa60031ee5f4" # 6.6.40
-    PKG_SHA256="7e3d6092db3639467c6fd0a2fa3fb6a38cc7b90705474be250b1e868c4785649"
+    PKG_VERSION="8457fd6b2d76cd8c8771f09165ce3734b398bc8c" # 6.6.41
+    PKG_SHA256="c7ee3be3b054b444f1bdaf18516fea4e3a50faab7768b610aa014324e8df3b6d"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="e6c1e862b2b8150a419f4208e5bd7749662b16a1" # 6.6.39
-    PKG_SHA256="15084d1bff4cc14e164e61cfab034d2f6f13b513a5d98cd4880e8c3de4fba6b0"
+    PKG_VERSION="1abc413af44652d6a76d5b5c2afe90788595008e" # 6.6.39
+    PKG_SHA256="e9cccac2dca61ac28b0ef5103425c939ffabe649554c6f4bd076bba7d6832022"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="485d11cfa7df2d2deb39c9b3455cebcb1a85cea2" # 6.6.42
-    PKG_SHA256="de43f2cb9f9525ff42a1f59e9443227ea2f2555e0c903386951e4170b58dba15"
+    PKG_VERSION="16d0ee22d2c0b32cc67db73ce03263b740bba2a7" # 6.6.42
+    PKG_SHA256="3deb61aeefb5dc4079b0a17e24054b97fc234c1cde89a22b3db631ae8f053f61"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="8457fd6b2d76cd8c8771f09165ce3734b398bc8c" # 6.6.41
-    PKG_SHA256="c7ee3be3b054b444f1bdaf18516fea4e3a50faab7768b610aa014324e8df3b6d"
+    PKG_VERSION="485d11cfa7df2d2deb39c9b3455cebcb1a85cea2" # 6.6.42
+    PKG_SHA256="de43f2cb9f9525ff42a1f59e9443227ea2f2555e0c903386951e4170b58dba15"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="1abc413af44652d6a76d5b5c2afe90788595008e" # 6.6.39
-    PKG_SHA256="e9cccac2dca61ac28b0ef5103425c939ffabe649554c6f4bd076bba7d6832022"
+    PKG_VERSION="31eb43be8cad2818b4458cf1fd2dfa60031ee5f4" # 6.6.40
+    PKG_SHA256="7e3d6092db3639467c6fd0a2fa3fb6a38cc7b90705474be250b1e868c4785649"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="82197e1692c6cd865dca4d474dd434a4a0cf2042" # 6.6.37
-    PKG_SHA256="44272cd67b63642fe8750b18c8afcb2e973230e454ccb7c729cf5e456fc25865"
+    PKG_VERSION="e6c1e862b2b8150a419f4208e5bd7749662b16a1" # 6.6.39
+    PKG_SHA256="15084d1bff4cc14e164e61cfab034d2f6f13b513a5d98cd4880e8c3de4fba6b0"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="645bdf63ebb5ffd754bc5bff90c3d38d6cc309da"
-PKG_SHA256="e5f409519f8a66bbfcba388f55d54179de301e6ffe16f050e2833f4733531f4a"
+PKG_VERSION="571e78a2129578784e81a4312468bb92cc8d623d"
+PKG_SHA256="0cc053360d57482e128f31743d447947f14bf20af0b6eb61da89be99f129dc05"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="80be2d6d14c44964fd807e079eb5ad7225e49e5a"
-PKG_SHA256="0f893e35977e5b4dc62676c290f417a84ade155e8b88d9a40162668e4d516b93"
+PKG_VERSION="be8232be753fc0b4f5d9251bc38242dec6299f3c"
+PKG_SHA256="a6b79749da46bd603c0706c929b13f78190b31333bfee5aca1fb903df05751fb"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="be8232be753fc0b4f5d9251bc38242dec6299f3c"
-PKG_SHA256="a6b79749da46bd603c0706c929b13f78190b31333bfee5aca1fb903df05751fb"
+PKG_VERSION="945d708fd0b200e62fcedd48236c7f9c43a44062"
+PKG_SHA256="54aebc76ea221ff5457b1833393ff9ffa928dd7dcc0ca8beb6ed4795ccafa21d"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.37 Kernel Configuration
+# Linux/arm 6.6.39 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -2220,6 +2220,7 @@ CONFIG_SPI_BCM2835AUX=m
 # CONFIG_SPI_MICROCHIP_CORE_QSPI is not set
 # CONFIG_SPI_OC_TINY is not set
 # CONFIG_SPI_PL022 is not set
+# CONFIG_SPI_RP2040_GPIO_BRIDGE is not set
 # CONFIG_SPI_SC18IS602 is not set
 # CONFIG_SPI_SIFIVE is not set
 # CONFIG_SPI_MXIC is not set

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.39 Kernel Configuration
+# Linux/arm 6.6.42 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -5881,6 +5881,7 @@ CONFIG_CMA_ALIGNMENT=8
 # CONFIG_DMA_API_DEBUG is not set
 # CONFIG_DMA_MAP_BENCHMARK is not set
 CONFIG_SGL_ALLOC=y
+CONFIG_FORCE_NR_CPUS=y
 CONFIG_DQL=y
 CONFIG_GLOB=y
 # CONFIG_GLOB_SELFTEST is not set

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.35 Kernel Configuration
+# Linux/arm 6.6.37 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3154,7 +3154,6 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
-# CONFIG_VIDEO_RASPBERRYPI_PISP_BE is not set
 # CONFIG_VIDEO_RP1_CFE is not set
 
 #

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.37 Kernel Configuration
+# Linux/arm 6.6.39 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -2447,6 +2447,7 @@ CONFIG_SPI_BCM2835AUX=m
 # CONFIG_SPI_MICROCHIP_CORE_QSPI is not set
 # CONFIG_SPI_OC_TINY is not set
 # CONFIG_SPI_PL022 is not set
+# CONFIG_SPI_RP2040_GPIO_BRIDGE is not set
 # CONFIG_SPI_SC18IS602 is not set
 # CONFIG_SPI_SIFIVE is not set
 # CONFIG_SPI_MXIC is not set

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.39 Kernel Configuration
+# Linux/arm 6.6.42 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -6142,7 +6142,6 @@ CONFIG_CMA_ALIGNMENT=8
 # CONFIG_DMA_API_DEBUG is not set
 # CONFIG_DMA_MAP_BENCHMARK is not set
 CONFIG_SGL_ALLOC=y
-# CONFIG_FORCE_NR_CPUS is not set
 CONFIG_CPU_RMAP=y
 CONFIG_DQL=y
 CONFIG_GLOB=y

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.35 Kernel Configuration
+# Linux/arm 6.6.37 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3388,7 +3388,6 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
-# CONFIG_VIDEO_RASPBERRYPI_PISP_BE is not set
 # CONFIG_VIDEO_RP1_CFE is not set
 
 #

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.37 Kernel Configuration
+# Linux/arm64 6.6.39 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3028,6 +3028,7 @@ CONFIG_SPI_BCM2835AUX=m
 # CONFIG_SPI_PCI1XXXX is not set
 # CONFIG_SPI_PL022 is not set
 # CONFIG_SPI_PXA2XX is not set
+# CONFIG_SPI_RP2040_GPIO_BRIDGE is not set
 # CONFIG_SPI_SC18IS602 is not set
 # CONFIG_SPI_SIFIVE is not set
 # CONFIG_SPI_MXIC is not set

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.35 Kernel Configuration
+# Linux/arm64 6.6.37 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -4012,7 +4012,6 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
-# CONFIG_VIDEO_RASPBERRYPI_PISP_BE is not set
 # CONFIG_VIDEO_RP1_CFE is not set
 
 #

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.39 Kernel Configuration
+# Linux/arm64 6.6.42 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -6938,7 +6938,6 @@ CONFIG_CMA_ALIGNMENT=8
 # CONFIG_DMA_API_DEBUG is not set
 # CONFIG_DMA_MAP_BENCHMARK is not set
 CONFIG_SGL_ALLOC=y
-# CONFIG_FORCE_NR_CPUS is not set
 CONFIG_CPU_RMAP=y
 CONFIG_DQL=y
 CONFIG_GLOB=y

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.35 Kernel Configuration
+# Linux/arm64 6.6.37 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -4031,7 +4031,6 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
-CONFIG_VIDEO_RASPBERRYPI_PISP_BE=m
 CONFIG_VIDEO_RP1_CFE=m
 
 #

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.39 Kernel Configuration
+# Linux/arm64 6.6.42 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -7005,7 +7005,6 @@ CONFIG_CMA_ALIGNMENT=8
 # CONFIG_DMA_API_DEBUG is not set
 # CONFIG_DMA_MAP_BENCHMARK is not set
 CONFIG_SGL_ALLOC=y
-# CONFIG_FORCE_NR_CPUS is not set
 CONFIG_CPU_RMAP=y
 CONFIG_DQL=y
 CONFIG_GLOB=y

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.37 Kernel Configuration
+# Linux/arm64 6.6.39 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -3043,6 +3043,7 @@ CONFIG_SPI_DW_MMIO=m
 # CONFIG_SPI_PCI1XXXX is not set
 # CONFIG_SPI_PL022 is not set
 # CONFIG_SPI_PXA2XX is not set
+# CONFIG_SPI_RP2040_GPIO_BRIDGE is not set
 # CONFIG_SPI_SC18IS602 is not set
 # CONFIG_SPI_SIFIVE is not set
 # CONFIG_SPI_MXIC is not set


### PR DESCRIPTION
Backport of #9142 

Runtime tested on RPi4 and RPi5