### PR TITLE
Package updates

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.2.1"
-PKG_SHA256="ee26d1e906a930b283d759628de978dc2514522d68f9566f89b1497b2b534f76"
+PKG_VERSION="1.2.2"
+PKG_SHA256="8255d7b7c6d7844ed20b5bb9cc7af66ddcaba32fee9902728471de7c02213bac"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.30.1"
-PKG_SHA256="df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1"
+PKG_VERSION="3.30.2"
+PKG_SHA256="46074c781eccebc433e98f0bbfa265ca3fd4381f245ca3b140e7711531d60db2"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/spirv-llvm-translator/package.mk
+++ b/packages/graphics/spirv-llvm-translator/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spirv-llvm-translator"
-PKG_VERSION="18.1.2"
-PKG_SHA256="4724372934041c8feb8bcafea1c9d086ab2de9f323599068943ef61ddb0bca51"
+PKG_VERSION="18.1.3"
+PKG_SHA256="d896f35102c3ba9e16ead7b4db53b75e6131982cdb36a3324f17c68a43598759"
 PKG_LICENSE="LLVM"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/x11/lib/libXfont2/package.mk
+++ b/packages/x11/lib/libXfont2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXfont2"
-PKG_VERSION="2.0.6"
-PKG_SHA256="74ca20017eb0fb3f56d8d5e60685f560fc85e5ff3d84c61c4cb891e40c27aef4"
+PKG_VERSION="2.0.7"
+PKG_SHA256="8b7b82fdeba48769b69433e8e3fbb984a5f6bf368b0d5f47abeec49de3e58efb"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXtst/package.mk
+++ b/packages/x11/lib/libXtst/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXtst"
-PKG_VERSION="1.2.4"
-PKG_SHA256="84f5f30b9254b4ffee14b5b0940e2622153b0d3aed8286a3c5b7eeb340ca33c8"
+PKG_VERSION="1.2.5"
+PKG_SHA256="b50d4c25b97009a744706c1039c598f4d8e64910c9fde381994e1cae235d9242"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- spirv-llvm-translator: update to 18.1.3
- cmake: update to 3.30.2
- libXtst: update to 1.2.5
- libXfont2: update to 2.0.7
- pipewire: update to 1.2.2