### PR TITLE
inputstream.adaptive: update 22.1.0-Piers to 22.1.1-Piers

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="a4a7e500a05ddc519cc4f92cf019ecc70d52cd1358a0c881eb1f312c2ca2c7f5"
+PKG_VERSION="22.1.1-Piers"
+PKG_SHA256="4ad931b71157feee15930d7978128a3e68dc7bc880ec551509cf31e44709e8f4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/multimedia/bento4/package.mk
+++ b/packages/multimedia/bento4/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bento4"
-PKG_VERSION="1.6.0-641-2-Omega"
-PKG_SHA256="3e4970a33700f1844513bb0c86c0c2de9f638bdc03547d2b7421f558962b85f1"
+PKG_VERSION="1.6.0-641-3-Omega"
+PKG_SHA256="a9b231b63159b3a4d9e47c5328b476308852bf092ccb9ce98f7cf46a386465ce"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.bento4.com"
 PKG_URL="https://github.com/xbmc/Bento4/archive/refs/tags/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- includes [bento4: update to 1.6.0-641-3-Omega](https://github.com/LibreELEC/LibreELEC.tv/pull/9149/commits/6aa61c24de6140d04b9fd6d85652b70b683942d1)