### PR TITLE
inputstream.adaptive: update 21.5.0-Omega to 21.5.1-Omega

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="21.5.0-Omega"
-PKG_SHA256="ea9ca25a222eda6d9a60d8dd509194db58d92b491759bf17acb49736cd4393c6"
+PKG_VERSION="21.5.1-Omega"
+PKG_SHA256="51d8f72fcaa7d2b0a8342154a69a1678b17d93f4b3b1c105ae89a46f39b93958"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/multimedia/bento4/package.mk
+++ b/packages/multimedia/bento4/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bento4"
-PKG_VERSION="1.6.0-641-Omega"
-PKG_SHA256="f1f8cfa4f7cb651b609e587f825607cb4b06fe5b08af876fd0154a434f9a5315"
+PKG_VERSION="1.6.0-641-3-Omega"
+PKG_SHA256="a9b231b63159b3a4d9e47c5328b476308852bf092ccb9ce98f7cf46a386465ce"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.bento4.com"
 PKG_URL="https://github.com/xbmc/Bento4/archive/refs/tags/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- includes [bento4: update to 1.6.0-641-3-Omega](https://github.com/LibreELEC/LibreELEC.tv/pull/9149/commits/6aa61c24de6140d04b9fd6d85652b70b683942d1)