### PR TITLE
samba: update to 4.20.4

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.20.2"
-PKG_SHA256="f969ffed58ccf3e85cbbcc0e33a1726d025c2b40f42a653b1125b82b92d2e0e5"
+PKG_VERSION="4.20.3"
+PKG_SHA256="afd5a9bb03e5c921c4c1d4e4b4fa6ea16cf798d94e5e5bffb9fd61716641cf30"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.20.3"
-PKG_SHA256="afd5a9bb03e5c921c4c1d4e4b4fa6ea16cf798d94e5e5bffb9fd61716641cf30"
+PKG_VERSION="4.20.4"
+PKG_SHA256="3a92e97eaeb345b6b32232f503e14d34f03a7aa64c451fe8c258a11bbda908e5"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/samba/patches/samba-200-4.11-fix-ASN1-bso14164.patch
+++ b/packages/network/samba/patches/samba-200-4.11-fix-ASN1-bso14164.patch
@@ -40,10 +40,10 @@ diff --git a/wscript_configure_embedded_heimdal b/wscript_configure_embedded_hei
 index 8c55ae2..4fdae80 100644
 --- a/wscript_configure_embedded_heimdal
 +++ b/wscript_configure_embedded_heimdal
-@@ -6,3 +6,14 @@
- 
- conf.define('USING_EMBEDDED_HEIMDAL', 1)
- conf.RECURSE('third_party/heimdal_build')
+@@ -13,3 +13,14 @@
+ # when this will be available also in
+ # system libraries...
+ conf.define('HAVE_CLIENT_GSS_C_CHANNEL_BOUND_FLAG', 1)
 +
 +def check_system_heimdal_binary(name):
 +    if conf.LIB_MAY_BE_BUNDLED(name):


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.20.3.html
- https://www.samba.org/samba/history/samba-4.20.4.html