### PR TITLE
inputstream.adaptive: backport upstream fix for build error

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/patches/001-backport-build-fix.patch
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/patches/001-backport-build-fix.patch
@@ -1,0 +1,23 @@
+From bd31b00a30dc022fb0384f5b263066f6d6d99e43 Mon Sep 17 00:00:00 2001
+From: Bernd Kuhls <bernd@kuhls.net>
+Date: Sat, 3 Aug 2024 12:01:47 +0200
+Subject: [PATCH] Fix build error with gcc 14
+
+src/decrypters/Helpers.h:55:13: error: 'uint8_t' was not declared in this scope
+   55 | std::vector<uint8_t> ConvertKidStrToBytes(std::string_view kidStr);
+---
+ src/decrypters/Helpers.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/decrypters/Helpers.h b/src/decrypters/Helpers.h
+index f66e15f3e..55dca4407 100644
+--- a/src/decrypters/Helpers.h
++++ b/src/decrypters/Helpers.h
+@@ -8,6 +8,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <string_view>
+ #include <vector>


### PR DESCRIPTION
see https://github.com/xbmc/inputstream.adaptive/pull/1625

build-tested for RPi5