### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="21.3.5-Omega"
-PKG_SHA256="b28ccbd489d9b69779fd818ee158f69ebd6fd85b1f0410ffc8098ff0c8665bdc"
-PKG_REV="3"
+PKG_VERSION="22.0.0-Piers"
+PKG_SHA256="905793fcd3150036e199749619b0d7c7db81b359296fa42fae8189f82ec6f50c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL2+"
 PKG_SITE="https://github.com/xbmc/inputstream.ffmpegdirect"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.rtmp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.rtmp/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.rtmp"
-PKG_VERSION="21.1.0-Omega"
-PKG_SHA256="193fabb14cd9d92baecf7319c50ba183bc6254385bf187fe2a726159134df2a9"
-PKG_REV="2"
+PKG_VERSION="22.0.0-Piers"
+PKG_SHA256="0b5ce569adb8939dcb958e7dc8b8c0e4e2680f130368ef64ef900e2c412680a2"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/inputstream.rtmp"


### PR DESCRIPTION
- inputstream.ffmpegdirect: update 21.3.5-Omega to 22.0.0-Piers
- inputstream.rtmp: update 21.1.0-Omega to 22.0.0-Piers