### PR TITLE
Package updates

### DIFF
--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.42"
-PKG_SHA256="f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800"
+PKG_VERSION="2.43"
+PKG_SHA256="b53606f443ac8f01d1d5fc9c39497f2af322d99e14cea5c0b4b124d630379365"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/binutils/"
 PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
+++ b/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
@@ -14,7 +14,7 @@ Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 +++ b/ld/ldfile.c
 @@ -103,6 +103,17 @@ ldfile_add_library_path (const char *nam
    if (!cmdline && config.only_cmd_line_lib_dirs)
-     return;
+     return NULL;
  
 +  /* skip those directories when linking */
 +  if ((!strncmp (name, "/lib", 4)) ||
@@ -24,7 +24,7 @@ Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 +  {
 +    einfo (_("%P: warning: library search path \"%s\" is unsafe for "
 +             "cross-compilation, ignore it\n"), name);
-+    return;
++    return NULL;
 +  }
 +
    new_dirs = (search_dirs_type *) xmalloc (sizeof (search_dirs_type));

--- a/packages/devel/commons-lang3/package.mk
+++ b/packages/devel/commons-lang3/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="commons-lang3"
-PKG_VERSION="3.15.0"
-PKG_SHA256="5da23a6a328803936263d52e64974c0ae6769084f771b8ada4c5c98f7de5c84e"
+PKG_VERSION="3.16.0"
+PKG_SHA256="0c97775a9e8a37b1e4cfd0993ad27c28bf6fc2611857a80ff5769805cea53a0a"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://commons.apache.org/proper/commons-lang/"
 PKG_URL="https://dlcdn.apache.org/commons/lang/binaries/commons-lang3-${PKG_VERSION}-bin.tar.gz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.384"
-PKG_SHA256="caa496a6203084ee3404c688a75ea05b4b10eec93340c503199647216127f347"
+PKG_VERSION="0.385"
+PKG_SHA256="577219d44d9686e8177f6291adbff7bacdd785ad4e8a8d0c4b2a14dbf850d6ac"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/mold/package.mk
+++ b/packages/devel/mold/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mold"
-PKG_VERSION="2.32.1"
-PKG_SHA256="f3c9a527d884c635834fe7d79b3de959b00783bf9446280ea274d996f0335825"
+PKG_VERSION="2.33.0"
+PKG_SHA256="37b3aacbd9b6accf581b92ba1a98ca418672ae330b78fe56ae542c2dcb10a155"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/rui314/mold"
 PKG_URL="https://github.com/rui314/mold/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.18.1"
-PKG_SHA256="8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76"
+PKG_VERSION="1.18.2"
+PKG_SHA256="c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="b4951714774b1b83d1b3bd38205d9fcd6f072def15f771fade9041ea3ebe2fd2"
+    PKG_SHA256="a8c4f1ab2f65e7579eb80153fd1ca9a0b365ca31ca6ae0ebd34156e0724dfc60"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="01befaca1c3ecea79625acec41b39b753440854509325f0f10f99da5b86b033d"
+    PKG_SHA256="2263a9b81f388a66d204214dd02c6c29dc7b27dbf18803797431a6a87bf53213"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="5602ba863f5276cfaa7ed3a8dd94d187fbd0319a1b4bbb9284e77fb6b7168a41"
+    PKG_SHA256="da9340b3249f08656cd4fe10e47aa292c7cd79903870a5863064731a00b5b27e"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="5911cc5af031648b29b42aaa1fe77d577848db08d9a400eada1e803960e78c4c"
+    PKG_SHA256="8fc4bfc3a5fe64f8530964a5ea3bda95e39357eff14d6a8bb24f010ecc912923"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="a33d2116a5439e53308eacba334735b63c13587b5a6aae6e4ac54d4849027e90"
+    PKG_SHA256="f0dd131f05e0801fcff35a23015fe83027865b936bccd402c8a9164400d27769"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="c722cba93c9627e04a6a5ecc749cde9dda39f15e4d02fb6ae8d0b27e02e6488a"
+    PKG_SHA256="b793405538d8b6ec1632779efa8835b07b8987db2008c5c9c809bc4b17dcb121"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.80.0"
-PKG_SHA256="6f606c193f230f6b2cae4576f7b24d50f5f9b25dff11dbf9b22f787d3521d672"
+PKG_VERSION="1.80.1"
+PKG_SHA256="2c0b8f643942dcb810cbcc50f292564b1b6e44db5d5f45091153996df95d2dc4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="198b5a04c25de5e9c56ff36b9110e2cfbdadf789de2c7c6d6ea9a26fd12ba165"
+    PKG_SHA256="fc21ca734504c3d0ccaf361f05cb491142c365ce8a326f942206b0199c49bbb4"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="5aed84d75bd21c28d61ddf3c7006dc12126528641afd6250d5603b48492b8fb7"
+    PKG_SHA256="a77a76f0d5c83e48785f5de0266680782ff10af00c5c3f9edbb1656f42ef85ca"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="ef1692e3d67236868d32ef26f96f47792b1c3a3f9747bbe05c63742464307c4f"
+    PKG_SHA256="0367f069b49560af5c61810530d4721ad13eecfcb48952e67a2c32be903d5043"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/sysutils/exfatprogs/package.mk
+++ b/packages/sysutils/exfatprogs/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="exfatprogs"
-PKG_VERSION="1.2.4"
-PKG_SHA256="ad38126dfd9f74f8c6ecb35ddfd34d2582601d6c3ff26756610b8418360c8ee2"
+PKG_VERSION="1.2.5"
+PKG_SHA256="f27160dcc1ddd17c96cd41a6ceef7037adc2796ab5c5633d3d85cf532c3ee2f0"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/exfatprogs/exfatprogs"
 PKG_URL="https://github.com/exfatprogs/exfatprogs/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- exfatprogs: update to 1.2.5
- hwdata: update to 0.385
- commons-lang3: update to 3.16.0
- libheif: update to 1.18.2
- mold: update to 2.33.0
- binutils: update to 2.43
- rust: update to 1.80.1
  - cargo-snapshot: update to 1.80.1
  - rust-std-snapshot: update to 1.80.1
  - rustc-snapshot: update to 1.80.1