### PR TITLE
fakeroot: Fix GCC14 build

### DIFF
--- a/packages/devel/fakeroot/patches/gcc14-build.patch
+++ b/packages/devel/fakeroot/patches/gcc14-build.patch
@@ -1,0 +1,24 @@
+diff -Nur a/communicate.c b/communicate.c
+--- a/communicate.c	2024-06-06 20:15:57.000000000 +0200
++++ b/communicate.c	2024-08-09 19:13:07.667507740 +0200
+@@ -576,7 +576,7 @@
+                &fm,
+                sizeof(fm)-sizeof(fm.mtype),0,0);
+ 
+-      ptr = &fm;
++      ptr = (uint8_t*)&fm;
+       for (k=0; k<16; k++) {
+         magic_candidate = *(uint32_t*)&ptr[k];
+         if (magic_candidate == FAKEROOT_MAGIC_LE || magic_candidate == FAKEROOT_MAGIC_BE) {
+diff -Nur a/faked.c b/faked.c
+--- a/faked.c	2024-06-25 02:22:18.000000000 +0200
++++ b/faked.c	2024-08-09 19:11:00.784630579 +0200
+@@ -1089,7 +1089,7 @@
+   do {
+     r=msgrcv(msg_get,&fm,sizeof(struct fake_msg_buf),0,0);
+ 
+-    ptr = &fm;
++    ptr = (uint8_t*)&fm;
+     for (k=0; k<16; k++) {
+       magic_candidate = *(uint32_t*)&ptr[k];
+       if (magic_candidate == FAKEROOT_MAGIC_LE || magic_candidate == FAKEROOT_MAGIC_BE) {


### PR DESCRIPTION
On Arch, fakeroot build fails due to new GCC14 policy that implicit pointer conversion between incompatible types will not be allowed anymore.

Fix issue by adding explicit pointer cast until upstream is fixed.

Upstream bug reports:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074945
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074365