### PR TITLE
pixman: Adjust arm assembly for binutils-2.43

### DIFF
--- a/packages/x11/lib/pixman/patches/pixman-0001-adjust-arm-assembly-for-binutils-change.patch
+++ b/packages/x11/lib/pixman/patches/pixman-0001-adjust-arm-assembly-for-binutils-change.patch
@@ -1,0 +1,104 @@
+From 865e6ce00bb79a6b925ed4c2c436e1533e4472aa Mon Sep 17 00:00:00 2001
+From: Mike Hommey <mh@glandium.org>
+Date: Fri, 12 Jul 2024 11:11:17 -0400
+Subject: [PATCH] pixman: Adjust arm assembly for binutils change
+
+A change in the latest version of binutils broke building pixman for arm.
+
+The binutils change:
+https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=226749d5a6ff0d5c607d6428d6c81e1e7e7a994b
+
+Closes: https://gitlab.freedesktop.org/pixman/pixman/-/issues/96
+---
+ pixman/pixman-arm-simd-asm.S | 44 ++++++++++++++++++------------------
+ 1 file changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/pixman/pixman-arm-simd-asm.S b/pixman/pixman-arm-simd-asm.S
+index 34d38f1..3dfe723 100644
+--- a/pixman/pixman-arm-simd-asm.S
++++ b/pixman/pixman-arm-simd-asm.S
+@@ -820,13 +820,13 @@ generate_composite_function \
+ .macro over_white_8888_8888_ca_1pixel_tail
+         mvn     TMP0, WK1
+         teq     WK1, WK1, asr #32
+-        bne     01f
+-        bcc     03f
++        bne     1f
++        bcc     3f
+         mov     WK3, WK1
+-        b       02f
+-01:     over_white_8888_8888_ca_combine WK1, WK3
+-02:     pixst   , 4, 3, DST
+-03:
++        b       2f
++1:      over_white_8888_8888_ca_combine WK1, WK3
++2:      pixst   , 4, 3, DST
++3:
+ .endm
+ 
+ .macro over_white_8888_8888_ca_2pixels_head
+@@ -837,21 +837,21 @@ generate_composite_function \
+         pixld   , 8, 3, DST
+         mvn     TMP0, WK1
+         teq     WK1, WK1, asr #32
+-        bne     01f
++        bne     1f
+         movcs   WK3, WK1
+-        bcs     02f
++        bcs     2f
+         teq     WK2, #0
+-        beq     05f
+-        b       02f
+-01:     over_white_8888_8888_ca_combine WK1, WK3
+-02:     mvn     TMP0, WK2
++        beq     5f
++        b       2f
++1:      over_white_8888_8888_ca_combine WK1, WK3
++2:      mvn     TMP0, WK2
+         teq     WK2, WK2, asr #32
+-        bne     03f
++        bne     3f
+         movcs   WK4, WK2
+-        b       04f
+-03:     over_white_8888_8888_ca_combine WK2, WK4
+-04:     pixst   , 8, 3, DST
+-05:
++        b       4f
++3:      over_white_8888_8888_ca_combine WK2, WK4
++4:      pixst   , 8, 3, DST
++5:
+ .endm
+ 
+ .macro over_white_8888_8888_ca_process_head  cond, numbytes, firstreg, unaligned_src, unaligned_mask, preload
+@@ -1067,9 +1067,9 @@ generate_composite_function \
+   .if \offset != 0
+         ldrb    ORIG_W, [SRC, #\offset]
+   .endif
+-        beq     01f
++        beq     1f
+         teq     STRIDE_M, #0xFF
+-        beq     02f
++        beq     2f
+  .endif
+         uxtb16  SCRATCH, \d                 /* rb_dest */
+         uxtb16  \d, \d, ror #8               /* ag_dest */
+@@ -1079,13 +1079,13 @@ generate_composite_function \
+         uxtab16 \d, \d, \d, ror #8
+         mov     SCRATCH, SCRATCH, ror #8
+         sel     \d, SCRATCH, \d
+-        b       02f
++        b       2f
+  .if \offset == 0
+ 48:     /* Last mov d,#0 of the set - used as part of shortcut for
+          * source values all 0 */
+  .endif
+-01:     mov     \d, #0
+-02:
++1:      mov     \d, #0
++2:
+ .endm
+ 
+ .macro in_reverse_8888_8888_tail  numbytes, reg1, reg2, reg3, reg4
+-- 
+GitLab
+


### PR DESCRIPTION
Fixes arm 32 bit CI builds
- patch is from upstream
- https://gitlab.freedesktop.org/pixman/pixman/-/commit/865e6ce00bb79a6b925ed4c2c436e1533e4472aa

==

A change in the latest version of binutils broke building pixman for arm.

The binutils change:
https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=226749d5a6ff0d5c607d6428d6c81e1e7e7a994b

Closes: https://gitlab.freedesktop.org/pixman/pixman/-/issues/96
