### PR TITLE
kodi: Fix python installation dir

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-995.20-python-lib-dir.patch
+++ b/packages/mediacenter/kodi/patches/kodi-995.20-python-lib-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/scripts/linux/Install.cmake b/cmake/scripts/linux/Install.cmake
+index 90b50c48f649..58e40ed82987 100644
+--- a/cmake/scripts/linux/Install.cmake
++++ b/cmake/scripts/linux/Install.cmake
+@@ -199,7 +199,7 @@ install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME}Config.cm
+ 
+ if(ENABLE_EVENTCLIENTS)
+   find_package(PythonInterpreter REQUIRED)
+-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from sysconfig import get_path; print(get_path('platlib', scheme='posix_prefix'))"
++  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from sysconfig import get_path; print(get_path('platlib', scheme='posix_prefix', vars={'platbase':'${CMAKE_INSTALL_PREFIX}'}))"
+                   OUTPUT_VARIABLE PYTHON_LIB_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+   # Install kodi-eventclients-common BT python files
+   install(PROGRAMS ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/bt/__init__.py


### PR DESCRIPTION
Recent Kodi switch from distutils to sysconfig to find python installation folder breaks cross-compilation (python lib is installed in wrong folder.) Fix it with suggestion from https://github.com/xbmc/xbmc/issues/25275 until issue is not resolved upstream.

This fixes kodi-remote util, which very useful during testing and debugging.