### PR TITLE
mesa: drop unnecessary kmsro option

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -45,7 +45,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
-    GALLIUM_DRIVERS+=" etnaviv kmsro"
+    GALLIUM_DRIVERS+=" etnaviv"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
@@ -74,7 +74,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "lima"; then
-    GALLIUM_DRIVERS+=" kmsro lima"
+    GALLIUM_DRIVERS+=" lima"
     V4L2_SUPPORT="yes"
   fi
 
@@ -99,7 +99,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
-    GALLIUM_DRIVERS+=" kmsro panfrost"
+    GALLIUM_DRIVERS+=" panfrost"
     VULKAN_DRIVERS_MESA+=" panfrost"
     V4L2_SUPPORT="yes"
   fi
@@ -132,7 +132,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "vc4"; then
-    GALLIUM_DRIVERS+=" vc4 v3d kmsro"
+    GALLIUM_DRIVERS+=" vc4 v3d"
     VULKAN_DRIVERS_MESA+=" broadcom"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"


### PR DESCRIPTION
ref:
- https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30463
- Updates #9103 removing now obsolete option