### PR TITLE
[le12] linux (RPi): update to 6.6.45

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="16d0ee22d2c0b32cc67db73ce03263b740bba2a7" # 6.6.42
-    PKG_SHA256="3deb61aeefb5dc4079b0a17e24054b97fc234c1cde89a22b3db631ae8f053f61"
+    PKG_VERSION="70c640ce992234aacba5a717f3fb47319f451431" # 6.6.44
+    PKG_SHA256="ae8a5a6d392529869c3f8e53f75946e0d5ccd7bfd46d8549972ef4cb7fb6f4af"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="70c640ce992234aacba5a717f3fb47319f451431" # 6.6.44
-    PKG_SHA256="ae8a5a6d392529869c3f8e53f75946e0d5ccd7bfd46d8549972ef4cb7fb6f4af"
+    PKG_VERSION="209e8a3e6646f25abb352fd5a8a4c2e855b1e952" # 6.6.45
+    PKG_SHA256="76fa23eda2d1690ac73e783fd11cabebe1f1f8ec8693f3491cda7d155df1b6d4"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/patches/raspberrypi/linux-010-pr6309-fix-no-signal-after-modeswitch.patch
+++ b/packages/linux/patches/raspberrypi/linux-010-pr6309-fix-no-signal-after-modeswitch.patch
@@ -1,0 +1,100 @@
+From 733e7a51a128e950d210ef3652f5427e4179e17a Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Mon, 12 Aug 2024 13:31:58 +0100
+Subject: [PATCH 1/3] drm/vc4: Add a delay after disabling hdmi phy output
+
+There appears to be a requirement for some devices
+(I'm testing with a 8K VRROOM 40Gbps HDMI switch)
+for a measable delay between removing the hdmi phy output from
+the old mode, to enabling the hdmi phy output for the new mode.
+
+Without the delay, a mode switch has a small change of getting a permanent
+'no signal', which requires a subsequent mode switch or a unplug/replug
+to redetect.
+
+Switching between 4kp24/25/30 modes fails about 5% of time in my testing.
+
+Add a delay to make it impossible to switch faster than this.
+
+Signed-off-by: Dom Cobley <popcornmix@gmail.com>
+---
+ drivers/gpu/drm/vc4/vc4_crtc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/vc4/vc4_crtc.c b/drivers/gpu/drm/vc4/vc4_crtc.c
+index 859ac51d06f3a..c85737f2b7f73 100644
+--- a/drivers/gpu/drm/vc4/vc4_crtc.c
++++ b/drivers/gpu/drm/vc4/vc4_crtc.c
+@@ -668,6 +668,7 @@ static void vc4_crtc_atomic_disable(struct drm_crtc *crtc,
+ 	 * someone was waiting it.
+ 	 */
+ 	vc4_crtc_send_vblank(crtc);
++	msleep(20);
+ }
+ 
+ static void vc4_crtc_atomic_enable(struct drm_crtc *crtc,
+
+From 75c37d08890881c02a5db5ef763ef7e97f4253d3 Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Tue, 13 Aug 2024 16:13:16 +0100
+Subject: [PATCH 2/3] drm/vc4: Implement vc6_hdmi_phy_disable
+
+The body of this function was missing so we don't reset the phy
+when disabling it.
+
+Signed-off-by: Dom Cobley <popcornmix@gmail.com>
+---
+ drivers/gpu/drm/vc4/vc4_hdmi_phy.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/gpu/drm/vc4/vc4_hdmi_phy.c b/drivers/gpu/drm/vc4/vc4_hdmi_phy.c
+index 0d55627148327..f36558932f083 100644
+--- a/drivers/gpu/drm/vc4/vc4_hdmi_phy.c
++++ b/drivers/gpu/drm/vc4/vc4_hdmi_phy.c
+@@ -1197,4 +1197,9 @@ void vc6_hdmi_phy_init(struct vc4_hdmi *vc4_hdmi,
+ 
+ void vc6_hdmi_phy_disable(struct vc4_hdmi *vc4_hdmi)
+ {
++	unsigned long flags;
++
++	spin_lock_irqsave(&vc4_hdmi->hw_lock, flags);
++	vc6_hdmi_reset_phy(vc4_hdmi);
++	spin_unlock_irqrestore(&vc4_hdmi->hw_lock, flags);
+ }
+
+From 1360bf475f7a12392e041bb80b20e21b677dcd4c Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Tue, 13 Aug 2024 17:18:51 +0100
+Subject: [PATCH 3/3] drm/vc4: Also power down the PLL core when resetting PHY
+
+The current reset code doesn't actually stop the hdmi output.
+That makes it difficult for displays to handle a mode set.
+
+Powering down the PLL does actually remove the hdmi signal
+and makes mode sets more reliable
+
+Signed-off-by: Dom Cobley <popcornmix@gmail.com>
+---
+ drivers/gpu/drm/vc4/vc4_hdmi_phy.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/vc4/vc4_hdmi_phy.c b/drivers/gpu/drm/vc4/vc4_hdmi_phy.c
+index f36558932f083..83801c2684250 100644
+--- a/drivers/gpu/drm/vc4/vc4_hdmi_phy.c
++++ b/drivers/gpu/drm/vc4/vc4_hdmi_phy.c
+@@ -137,6 +137,7 @@
+ #define VC6_HDMI_TX_PHY_PLL_REFCLK_REFCLK_SEL_CMOS	BIT(13)
+ #define VC6_HDMI_TX_PHY_PLL_REFCLK_REFFRQ_MASK		VC4_MASK(9, 0)
+ 
++#define VC6_HDMI_TX_PHY_PLL_POST_KDIV_BYPASS_EN		BIT(4)
+ #define VC6_HDMI_TX_PHY_PLL_POST_KDIV_CLK0_SEL_MASK	VC4_MASK(3, 2)
+ #define VC6_HDMI_TX_PHY_PLL_POST_KDIV_KDIV_MASK		VC4_MASK(1, 0)
+ 
+@@ -947,6 +948,7 @@ static void vc6_hdmi_reset_phy(struct vc4_hdmi *vc4_hdmi)
+ 
+ 	HDMI_WRITE(HDMI_TX_PHY_RESET_CTL, 0);
+ 	HDMI_WRITE(HDMI_TX_PHY_POWERUP_CTL, 0);
++	HDMI_WRITE(HDMI_TX_PHY_PLL_POST_KDIV, VC6_HDMI_TX_PHY_PLL_POST_KDIV_BYPASS_EN);
+ }
+ 
+ void vc6_hdmi_phy_init(struct vc4_hdmi *vc4_hdmi,

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="945d708fd0b200e62fcedd48236c7f9c43a44062"
-PKG_SHA256="54aebc76ea221ff5457b1833393ff9ffa928dd7dcc0ca8beb6ed4795ccafa21d"
+PKG_VERSION="ef2fc67d235d037b2b468813e646e20890fcea07"
+PKG_SHA256="c982ba891fcc63a9df711ae0c840e1a9cba083848658cd1f29a5f98d95d20dda"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.42 Kernel Configuration
+# Linux/arm 6.6.45 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -699,6 +699,7 @@ CONFIG_COMPACT_UNEVICTABLE_DEFAULT=1
 # CONFIG_PAGE_REPORTING is not set
 CONFIG_MIGRATION=y
 CONFIG_CONTIG_ALLOC=y
+CONFIG_PCP_BATCH_SCALE_MAX=5
 # CONFIG_KSM is not set
 CONFIG_DEFAULT_MMAP_MIN_ADDR=4096
 CONFIG_ARCH_WANT_GENERAL_HUGETLB=y

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.42 Kernel Configuration
+# Linux/arm 6.6.45 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -821,6 +821,7 @@ CONFIG_COMPACT_UNEVICTABLE_DEFAULT=1
 # CONFIG_PAGE_REPORTING is not set
 CONFIG_MIGRATION=y
 CONFIG_CONTIG_ALLOC=y
+CONFIG_PCP_BATCH_SCALE_MAX=5
 # CONFIG_KSM is not set
 CONFIG_DEFAULT_MMAP_MIN_ADDR=4096
 CONFIG_ARCH_WANT_GENERAL_HUGETLB=y

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.42 Kernel Configuration
+# Linux/arm64 6.6.45 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -902,6 +902,7 @@ CONFIG_COMPACT_UNEVICTABLE_DEFAULT=1
 # CONFIG_PAGE_REPORTING is not set
 CONFIG_MIGRATION=y
 CONFIG_CONTIG_ALLOC=y
+CONFIG_PCP_BATCH_SCALE_MAX=5
 CONFIG_PHYS_ADDR_T_64BIT=y
 # CONFIG_KSM is not set
 CONFIG_DEFAULT_MMAP_MIN_ADDR=4096

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.42 Kernel Configuration
+# Linux/arm64 6.6.45 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -904,6 +904,7 @@ CONFIG_COMPACT_UNEVICTABLE_DEFAULT=1
 # CONFIG_PAGE_REPORTING is not set
 CONFIG_MIGRATION=y
 CONFIG_CONTIG_ALLOC=y
+CONFIG_PCP_BATCH_SCALE_MAX=5
 CONFIG_PHYS_ADDR_T_64BIT=y
 # CONFIG_KSM is not set
 CONFIG_DEFAULT_MMAP_MIN_ADDR=4096


### PR DESCRIPTION
Backport of #9198 

Runtime tested on RPi3B+, RPi4 and RPi5