### PR TITLE
ffmpegx: arm: allow 32-bit arm compile with binutils 2.43

### DIFF
--- a/packages/addons/addon-depends/ffmpegx/patches/ffmpeg-002-libavcodec-arm-mlpdsp_armv5te-fix-label-format-to-wo.patch
+++ b/packages/addons/addon-depends/ffmpegx/patches/ffmpeg-002-libavcodec-arm-mlpdsp_armv5te-fix-label-format-to-wo.patch
@@ -1,0 +1,52 @@
+From 0b541aa54b9573d8eef7401a0cc58c422fe60a9a Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@arm.com>
+Date: Thu, 8 Aug 2024 18:04:17 +0100
+Subject: [PATCH] libavcodec/arm/mlpdsp_armv5te: fix label format to work with
+ binutils 2.43
+
+binutils 2.43 has stricter validation for labels[1] and results in errors
+when building ffmpeg for armv5:
+
+src/libavcodec/arm/mlpdsp_armv5te.S:232: Error: junk at end of line, first unrecognized character is `0'
+
+Remove the leading zero in the "01" label to resolve this error.
+
+[1] https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=226749d5a6ff0d5c607d6428d6c81e1e7e7a994b
+
+Upstream-Status: Submitted [https://ffmpeg.org//pipermail/ffmpeg-devel/2024-August/332149.html]
+Signed-off-by: Ross Burton <ross.burton@arm.com>
+---
+ libavcodec/arm/mlpdsp_armv5te.S | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/arm/mlpdsp_armv5te.S b/libavcodec/arm/mlpdsp_armv5te.S
+index 4f9aa48..d315686 100644
+--- a/libavcodec/arm/mlpdsp_armv5te.S
++++ b/libavcodec/arm/mlpdsp_armv5te.S
+@@ -229,7 +229,7 @@ A .endif
+   .endif
+ 
+         // Begin loop
+-01:
++1:
+   .if TOTAL_TAPS == 0
+         // Things simplify a lot in this case
+         // In fact this could be pipelined further if it's worth it...
+@@ -241,7 +241,7 @@ A .endif
+         str     ST0, [PST, #-4]!
+         str     ST0, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
+         str     ST0, [PSAMP], #4 * MAX_CHANNELS
+-        bne     01b
++        bne     1b
+   .else
+     .if \fir_taps & 1
+       .set LOAD_REG, 1
+@@ -333,7 +333,7 @@ T       orr     AC0, AC0, AC1
+         str     ST3, [PST, #-4]!
+         str     ST2, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
+         str     ST3, [PSAMP], #4 * MAX_CHANNELS
+-        bne     01b
++        bne     1b
+   .endif
+         b       99f
+ 


### PR DESCRIPTION
- Copy of #9166 (but for ffmpegx)

ref:
- https://lists.ffmpeg.org/pipermail/ffmpeg-devel/2024-August/332149.html

included patch
- libavcodec/arm/mlpdsp_armv5te: fix label format to work with binutils 2.43
- copy of ffmpeg patch
  - commit cf501cb3e3ebef62712dec00109df50532c6f29e (origin/ffmpeg)