### PR TITLE
[LE13] pkg-config: remove gettext dependency

### DIFF
--- a/packages/devel/pkg-config/package.mk
+++ b/packages/devel/pkg-config/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/software/pkgconfig/"
 PKG_URL="http://pkg-config.freedesktop.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_HOST="gettext:host"
+PKG_DEPENDS_HOST="make:host"
 PKG_LONGDESC="A system for managing library compile/link flags that works with automake and autoconf."
 PKG_BUILD_FLAGS="+local-cc"
 


### PR DESCRIPTION
It's not needed since 0.27.1, which was released 12 years ago... This also relaxes dependencies and fixes contention point of build schedule.