### PR TITLE
LibreELEC-settings: use importlib instead of imp Python module

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/package.mk
+++ b/packages/mediacenter/LibreELEC-settings/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="LibreELEC-settings"
-PKG_VERSION="b36ea367e5cd62e360db56390813d669b5e02d6a"
-PKG_SHA256="869ecdde218a85c8476c675045ec4f6c2737c17a1087dc06db25a1b33a651b74"
+PKG_VERSION="779f1d3dbe6f0bd49d6a3e707e33242908504ed0"
+PKG_SHA256="7bff5b4fc292a7da231f8b3ec3bdff86f8a1fe16bc1be758ca25c07bdc15193f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL="https://github.com/LibreELEC/service.libreelec.settings/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- Required for support of #9218 - https://github.com/LibreELEC/service.libreelec.settings/pull/325