### PR TITLE
i2c-tools: add back binaries installation

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/i2c-tools/package.mk
@@ -25,6 +25,10 @@ make_target() {
 }
 
 makeinstall_target() {
+  make  DESTDIR=${INSTALL} \
+        PREFIX="/usr" \
+        prefix="/usr" \
+        install
   (
     cd py-smbus
     exec_thread_safe python_target_env python3 setup.py install --root=${INSTALL} --prefix=/usr


### PR DESCRIPTION
commit 472dda0a4d0f90240f6645e0e8a743f184233937 ("i2c-tools: Don't use distutilscross") accidentally dropped the binaries installation so building the system-tools addon failed as it could not find the i2cdetect etc binaries.

Add the install back (minus python installation)