### PR TITLE
update_binary-addons: fix error at exit

### DIFF
--- a/tools/mkpkg/update_binary-addons
+++ b/tools/mkpkg/update_binary-addons
@@ -241,4 +241,6 @@ done
 
 rm -rf "${TMPDIR}"
 
-[ -d "${TMP_REPO_DIR}" ] && rm -rf "${TMP_REPO_DIR}"
+if [ -d "${TMP_REPO_DIR}" ]; then
+  rm -rf "${TMP_REPO_DIR}"
+fi


### PR DESCRIPTION
I am not 100% sure why it happens (bash corner case?) but without that change the script exit with error code 1 even at a successful run.