### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bottom"
-PKG_VERSION="0.9.7"
-PKG_SHA256="29c3f75323ae0245576ea23268bb0956757352bf3b16d05f511357655b9cc71e"
+PKG_VERSION="0.10.2"
+PKG_SHA256="1db45fe9bc1fabb62d67bf8a1ea50c96e78ff4d2a5e25bf8ae8880e3ad5af80a"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ClementTsang/bottom"
 PKG_URL="https://github.com/ClementTsang/bottom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/libgpiod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpiod"
-PKG_VERSION="2.1.2"
-PKG_SHA256="b1bdf1e3f75238695f93e442062bafc069170f2bf4f0cd4b8e049ca67131a1f0"
+PKG_VERSION="2.1.3"
+PKG_SHA256="8d80ea022ae78122aa525308e7423b83064bff278fcd9cd045b94b4f81f8057d"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
 PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/mc/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mc"
-PKG_VERSION="4.8.31"
-PKG_SHA256="24191cf8667675b8e31fc4a9d18a0a65bdc0598c2c5c4ea092494cd13ab4ab1a"
+PKG_VERSION="4.8.32"
+PKG_SHA256="4ddc83d1ede9af2363b3eab987f54b87cf6619324110ce2d3a0e70944d1359fe"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.midnight-commander.org"
 PKG_URL="http://ftp.midnight-commander.org/mc-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/system-tools-depends/mmc-utils/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mmc-utils/package.mk
@@ -2,11 +2,13 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mmc-utils"
-PKG_VERSION="613495ecaca97a19fa7f8f3ea23306472b36453c"
-PKG_SHA256="1c76924aa3f636af70bd841bc1dcd85d5728ef1d4326921da30cbab7d643e2a7"
+PKG_VERSION="123fd8b2ac3933be1319486fb1f32236a4a86a7c"
+PKG_SHA256="d718338740cc75c8b0b54647a0522baff1824a31d4f9ee7d0d022405d07284f6"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/doc/html/latest/driver-api/mmc/mmc-tools.html"
 PKG_URL="https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Configure MMC storage devices from userspace."
 PKG_BUILD_FLAGS="-sysroot"
+
+PKG_MAKE_OPTS_TARGET+=" C="

--- a/packages/addons/addon-depends/system-tools-depends/pv/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/pv/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pv"
-PKG_VERSION="1.8.12"
-PKG_SHA256="9687f9deedb09d0dc00d80c30691f0c91282c0d5d8fa7d6a2a085c8742c2cd7c"
+PKG_VERSION="1.8.13"
+PKG_SHA256="e2bde058d0d3bfe03e60a6eedef6a179991f5cc698d1bac01b64a86f5a8c17af"
 PKG_LICENSE="GNU"
 PKG_SITE="http://www.ivarch.com/programs/pv.shtml"
 PKG_URL="http://www.ivarch.com/programs/sources/pv-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.18.01"
-PKG_SHA256="30465ee60a32d9018d0de8a78cfeaa576e869b6e6db87e3628d0704dbe61b561"
+PKG_VERSION="0.18.02"
+PKG_SHA256="45eac8d354df5be26c9675ec7fc24910f846e47eb6b151e9955d6eae30cfe060"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-satip/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-satip/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-satip"
-PKG_VERSION="20240224"
-PKG_SHA256="0b288a5a7b05924dbf479e95aee83ada4ea640539a563564dab83193a3fa65c9"
+PKG_VERSION="20240720"
+PKG_SHA256="2a9709bfb31a3745c18c867a543d708eddbf4c41af898555e4a0daa63a2199a7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://vdr-projects.github.io/"
 PKG_URL="https://github.com/wirbel-at-vdr-portal/vdr-plugin-satip/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr/package.mk
+++ b/packages/addons/addon-depends/vdr/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr"
-PKG_VERSION="2.6.7"
-PKG_SHA256="b27addea2d1cd6919d03d865a14ae043cacc600b1e4670530ef3bbeb6b3083e1"
+PKG_VERSION="2.6.9"
+PKG_SHA256="e7364485a6b2f2192359fa5547bcf48ebb8265c96737f933c3d464f80b59a204"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvdr.de"
 PKG_URL="http://git.tvdr.de/?p=vdr.git;a=snapshot;h=refs/tags/${PKG_VERSION};sf=tbz2"

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rsyslog"
-PKG_VERSION="8.2406.0"
-PKG_SHA256="1343e0269dd32166ffde04d7ceebfa0e7146cf1dbc6962c56bf428c61f01a7df"
-PKG_REV="1"
+PKG_VERSION="8.2408.0"
+PKG_SHA256="8bb2f15f9bf9bb7e635182e3d3e370bfc39d08bf35a367dce9714e186f787206"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rsyslog"

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-addon"
-PKG_VERSION="2.6.7"
-PKG_REV="0"
+PKG_VERSION="2.6.9"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.3.5"
-PKG_SHA256="f89e8e983ecfb4a5b4f5d8c2b9157ed18d15ed2e36246fa782f18abaea550e0d"
+PKG_VERSION="2.3.6"
+PKG_SHA256="3340d73286b28fe6e5150fbe12648d4640e86c64c228878b572773bd08cac531"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.fluidsynth"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="dd8ca6386a3beed360c1d2f989cd81553baf81652007fdfd478a28b44b68db10"
-PKG_REV="9"
+PKG_REV="10"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.fluidsynth"


### PR DESCRIPTION
- audiodecoder.fluidsynth: update addon (10)
  - fluidsynth: update to 2.3.6
- rsyslog: update to 8.2408.0 and addon (2)
- system-tools: update addon (5)
  - stress-ng: update to 0.18.02
  - mc: update to 4.8.32
  - bottom: update to 0.10.2
  - libgpiod: update to 2.1.3
  - mmc-utils: update to githash 123fd8b (2024-08-01)
  - pv: update to 1.8.13
- vdr-addon: update to 2.6.9 and addon (1)
  - vdr: update to 2.6.9
  - vdr-plugin-satip: update to 20240720