### PR TITLE
Package updates

### DIFF
--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.30.2"
-PKG_SHA256="46074c781eccebc433e98f0bbfa265ca3fd4381f245ca3b140e7711531d60db2"
+PKG_VERSION="3.30.3"
+PKG_SHA256="6d5de15b6715091df7f5441007425264bdd477809f80333fdf95f846aaff88e4"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/devel/commons-lang3/package.mk
+++ b/packages/devel/commons-lang3/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="commons-lang3"
-PKG_VERSION="3.16.0"
-PKG_SHA256="0c97775a9e8a37b1e4cfd0993ad27c28bf6fc2611857a80ff5769805cea53a0a"
+PKG_VERSION="3.17.0"
+PKG_SHA256="08b93712bed7f48725d93c44d70c71e7e661af390f22f0f3e6ba61e3af3cea36"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://commons.apache.org/proper/commons-lang/"
 PKG_URL="https://archive.apache.org/dist/commons/lang/binaries/commons-lang3-${PKG_VERSION}-bin.tar.gz"

--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.81.2"
-PKG_SHA256="ce84b241b84750a3d42c78c456976fac57f2d2726a110f2ba059c052a4349d1c"
+PKG_VERSION="2.82.0"
+PKG_SHA256="f4c82ada51366bddace49d7ba54b33b4e4d6067afa3008e4847f41cb9b5c38d3"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.385"
-PKG_SHA256="577219d44d9686e8177f6291adbff7bacdd785ad4e8a8d0c4b2a14dbf850d6ac"
+PKG_VERSION="0.386"
+PKG_SHA256="6473dc3ac9ba94195afea6dafa68e9dd2127af270f83e3e035186d38669f7144"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/json-glib/package.mk
+++ b/packages/devel/json-glib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="json-glib"
-PKG_VERSION="1.9.2"
-PKG_SHA256="277c3b7fc98712e30115ee3a60c3eac8acc34570cb98d3ff78de85ed804e0c80"
+PKG_VERSION="1.10.0"
+PKG_SHA256="447890f9de2a04c312871768208f6c8aeec4069392af7605bc77e61165dcb374"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/GNOME/json-glib"
 PKG_URL="https://github.com/GNOME/json-glib/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/assimp/package.mk
+++ b/packages/graphics/assimp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="assimp"
-PKG_VERSION="5.4.2"
-PKG_SHA256="7414861a7b038e407b510e8b8c9e58d5bf8ca76c9dfe07a01d20af388ec5086a"
+PKG_VERSION="5.4.3"
+PKG_SHA256="66dfbaee288f2bc43172440a55d0235dfc7bf885dda6435c038e8000e79582cb"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/assimp/assimp"
 PKG_URL="https://github.com/assimp/assimp/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.122"
-PKG_SHA256="d9f5079b777dffca9300ccc56b10a93588cdfbc9dde2fae111940dfb6292f251"
+PKG_VERSION="2.4.123"
+PKG_SHA256="a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://dri.freedesktop.org"
 PKG_URL="https://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/gmmlib/package.mk
+++ b/packages/multimedia/gmmlib/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gmmlib"
-PKG_VERSION="22.5.0"
-PKG_SHA256="a3f37dff076503b833ce2dc5c0f9cf854ad706c7857fa6a70972716342efe523"
+PKG_VERSION="22.5.1"
+PKG_SHA256="6dec8eccf0df4924b44de37afa0fd835684328778784dcd556df826b0a71e54f"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="24.3.1"
-PKG_SHA256="98702b946edb24454a3b780f8dd5b3091c6c795478467c1c00fe4d16c4371291"
+PKG_VERSION="24.3.2"
+PKG_SHA256="0e0e94b2a75d2725431353f5556738b390aace907a5e696782bff10c1915eb13"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libssh"
-PKG_VERSION="0.10.6"
-PKG_SHA256="1861d498f5b6f1741b6abc73e608478491edcf9c9d4b6630eef6e74596de9dc1"
+PKG_VERSION="0.11.1"
+PKG_SHA256="14b7dcc72e91e08151c58b981a7b570ab2663f630e7d2837645d5a9c612c1b79"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.libssh.org/"
 PKG_URL="https://www.libssh.org/files/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/network/nfs-utils/package.mk
+++ b/packages/network/nfs-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nfs-utils"
-PKG_VERSION="2.6.4"
-PKG_SHA256="01b3b0fb9c7d0bbabf5114c736542030748c788ec2fd9734744201e9b0a1119d"
+PKG_VERSION="2.7.1"
+PKG_SHA256="885c948a84a58bca4148f459588f9a7369dbb40dcc466f04e455c6b10fd0aa48"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://www.linux-nfs.org/"
 PKG_URL="https://www.kernel.org/pub/linux/utils/nfs-utils/${PKG_VERSION}/nfs-utils-${PKG_VERSION}.tar.xz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="74.0.0"
-PKG_SHA256="a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e"
+PKG_VERSION="74.1.0"
+PKG_SHA256="bea195a800f510ba3a2bc65645c88b7e016fe36709fefc58a880c4ae8a0138d7"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="73.0.1"
-PKG_SHA256="d59a3e788ab7e012ab2c4baed1b376da6366883ee20d7a5fc426816e3d7b1193"
+PKG_VERSION="74.0.0"
+PKG_SHA256="a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/libevdev/package.mk
+++ b/packages/sysutils/libevdev/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libevdev"
-PKG_VERSION="1.13.2"
-PKG_SHA256="3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48"
+PKG_VERSION="1.13.3"
+PKG_SHA256="abf1aace86208eebdd5d3550ffded4c8d73bb405b796d51c389c9d0604cbcfbf"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libevdev/"
 PKG_URL="http://www.freedesktop.org/software/libevdev/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.36"
-PKG_SHA256="71fd4de05e79f9a1ca559fac30c1f8365fa10346422f9fe795f74d77b9ef7e92"
+PKG_VERSION="1.37"
+PKG_SHA256="a70e9be924f2e8688e6824dceaf6188faacd5ae218dfac8d0a3d0976211ef326"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/${PKG_NAME}/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- media-driver: update to 24.3.2
- libdrm: update to 2.4.123
- glib: update to 2.82.0
- nfs-utils: update to 2.7.1
- setuptools: update to 74.0.0
- cmake: update to 3.30.3
- wayland-protocols: update to 1.37
- json-glib: update to 1.10.0
- libevdev: update to 1.13.3
- setuptools: update to 74.1.0
- hwdata: update to 0.386
- gmmlib: update to 22.5.1
- libssh: update to 0.11.1
- commons-lang3: update to 3.17.0
- assimp: update to 5.4.3
