### PR TITLE
[le12] iwd: update to 2.20

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.19"
-PKG_SHA256="9d0b934e51580316919796aa0357590971fc0df244b273fa10e154c268374f91"
+PKG_VERSION="2.20"
+PKG_SHA256="86827b97cb5b19ddecce36568c59378da2fae8cf37a0e2b9eacd1269f24c6f8e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- backport of #9251 
- ver 2.20:
+	Fix issue with PKEX timeout and number of frequencies used.
+	Fix issue with handling logic for handshake failures.
+	Fix issue with handling ConnectedAccessPoint signal.