### PR TITLE
samba: update to 4.21.0

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.20.4"
-PKG_SHA256="3a92e97eaeb345b6b32232f503e14d34f03a7aa64c451fe8c258a11bbda908e5"
+PKG_VERSION="4.21.0"
+PKG_SHA256="09bb56db4ce003cafdbebe9bad368c4f4ff1945f732d18077d52f36ab20cef88"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.21.0rc1.html
- https://www.samba.org/samba/history/samba-4.21.0rc2.html
- https://www.samba.org/samba/history/samba-4.21.0rc3.html
- https://www.samba.org/samba/history/samba-4.21.0rc4.html
- https://www.samba.org/samba/history/samba-4.21.0.html