### PR TITLE
connman: update to 1.43

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="1cde7a6598a639d1f1eb16f7929f32919172ef10"
-PKG_SHA256="680320f1c3de0c283b2df0d61807cd0ca88e012dc3ec906a0414b20a5866f19d"
+PKG_VERSION="1.43"
+PKG_SHA256="22acfe9d5958d7983090232334a692eee66a12f3077e09e4f360276608156738"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-${PKG_VERSION}.tar.gz"

--- a/packages/network/connman/patches/connman-07-connman_gateway_add-fix-calculation-of-is_vpn6.patch
+++ b/packages/network/connman/patches/connman-07-connman_gateway_add-fix-calculation-of-is_vpn6.patch
@@ -1,0 +1,30 @@
+From b1ed80a459ec31ae217897b7a3347d123e08d379 Mon Sep 17 00:00:00 2001
+From: mglae <mglmail@arcor.de>
+Date: Sat, 14 Sep 2024 19:46:08 +0200
+Subject: __connman_gateway_add(): fix calculation of is_vpn6
+
+Fix commit 823d5a2 "connection: Refactor '__connman_connection_gateway_add'"
+---
+ src/gateway.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/gateway.c b/src/gateway.c
+index 16c87f83..b2c211e2 100644
+--- a/src/gateway.c
++++ b/src/gateway.c
+@@ -3704,10 +3704,10 @@ int __connman_gateway_add(struct connman_service *service,
+ 					is_gateway_config_vpn(
+ 						new_gateway->ipv4_config);
+ 
+-		is_vpn6 = do_ipv4 &&
+-					new_gateway->ipv4_config &&
++		is_vpn6 = do_ipv6 &&
++					new_gateway->ipv6_config &&
+ 					is_gateway_config_vpn(
+-						new_gateway->ipv4_config);
++						new_gateway->ipv6_config);
+ 
+ 	} else {
+ 		if (do_ipv4 && new_gateway->ipv4_config)
+-- 
+2.40.0


### PR DESCRIPTION
Set as **merge block** till positive test results of the testing against vpn are confirmed, so as not to have to revert as previously in these 2 PRs.
- #8427 and #8355

ver 1.43:
+	Fix issue with device creation when using LTE.
+	Fix issue with regulatory domain when powering up.
+	Fix issue with resolving ISO3166 code from timezone data.
+	Fix issue with handling DNS proxy zero termination of buffers.
+	Fix issue with handling DHCP packet length in L3 mode.
+	Fix issue with handling DHCP upper length checks.
+	Fix issue with handling IPv6 and URL parsing.
+	Fix issue with handling online check updates.
+	Fix issue with handling proxy method and WISPr.
+	Fix issue with handling default gateway setup.
+	Add support for low-priority default routes.