### PR TITLE
change_addon_version: add binary-addons

### DIFF
--- a/tools/change_addon_version
+++ b/tools/change_addon_version
@@ -39,6 +39,19 @@ update_package() {
   git diff --quiet HEAD $REF -- packages/addons || { echo "git commit \"addons: reset version\"" && git commit -qs -m "addons: reset version" "packages/addons"; }
 }
 
+update_binary_addons() {
+  # update package.mk
+  for package_mk in $(find packages/mediacenter/kodi-binary-addons -type f -name "package.mk"); do
+    PKG_REV="$(grep -oP -m 1 '(?<=PKG_REV=\").*(?=\")' ${package_mk} || true)"
+    sed -e "s|PKG_REV=.*|PKG_REV=\"$(($PKG_REV + 1))\"|" -i "${package_mk}"
+    unset PKG_REV
+  done
+
+  # commit changes
+  # avoid errors at commit by checking if changes are available
+  git diff --quiet HEAD $REF -- packages/mediacenter/kodi-binary-addons || { echo "git commit \"addons: bump kodi-binary-addons\"" && git commit -qs -m "addons: bump kodi-binary-addons" "packages/mediacenter/kodi-binary-addons"; }
+}
+
 # check if whiptail is installed and directly execute script when argument is supplied
 if [ -z "$1" ]; then
   if ! command -v whiptail >/dev/null 2>&1; then
@@ -50,6 +63,7 @@ else
   BUMP_ADDON_VERSION="$1"
   update_addon_version
   update_package
+  update_binary_addons
   exit
 fi
 
@@ -62,6 +76,7 @@ case $OPTION in
   "1")
     update_addon_version
     update_package
+    update_binary_addons
     ;;
   "2")
     BUMP_ADDON_VERSION=$(whiptail --inputbox "Enter ADDON-VERSION:" 10 25 ${DISTRO_ADDON_VERSION} 3>&1 1>&2 2>&3)
@@ -69,6 +84,7 @@ case $OPTION in
     if [ $EXITSTATUS = 0 ]; then
       update_addon_version
       update_package
+      update_binary_addons
     else
       exit
     fi

--- a/tools/change_addon_version
+++ b/tools/change_addon_version
@@ -21,6 +21,8 @@ update_addon_version() {
 
   echo "git commit \"distro: bump ADDON_VERSION to ${BUMP_ADDON_VERSION}\""
   git commit -qs -m "distro: bump ADDON_VERSION to ${BUMP_ADDON_VERSION}" "${DISTRIBUTION_PATH}"
+  # wait for slow fs otherwise lock errors at git
+  sync
 }
 
 update_package() {
@@ -37,6 +39,8 @@ update_package() {
   # commit changes
   # avoid errors at commit by checking if changes are available
   git diff --quiet HEAD $REF -- packages/addons || { echo "git commit \"addons: reset version\"" && git commit -qs -m "addons: reset version" "packages/addons"; }
+  # wait for slow fs otherwise lock errors at git
+  sync
 }
 
 update_binary_addons() {
@@ -50,6 +54,8 @@ update_binary_addons() {
   # commit changes
   # avoid errors at commit by checking if changes are available
   git diff --quiet HEAD $REF -- packages/mediacenter/kodi-binary-addons || { echo "git commit \"addons: bump kodi-binary-addons\"" && git commit -qs -m "addons: bump kodi-binary-addons" "packages/mediacenter/kodi-binary-addons"; }
+  # wait for slow fs otherwise lock errors at git
+  sync
 }
 
 # check if whiptail is installed and directly execute script when argument is supplied


### PR DESCRIPTION
Could anyone with linux test this ? I get some error that is likely due slow git at WSL.

```
cvh@CvH:/mnt/d/LE$ ./tools/change_addon_version
git commit "distro: bump ADDON_VERSION to 12.80.1"
git commit "addons: reset version"
fatal: Unable to create '/mnt/d/LE/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
git commit "addons: bump kodi-binary-addons"
```