### PR TITLE
atf: update to 2.11.0

### DIFF
--- a/packages/tools/atf/package.mk
+++ b/packages/tools/atf/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2018-present Team LibreELEC
 
 PKG_NAME="atf"
-PKG_VERSION="2.10.0"
-PKG_SHA256="696b8e53923aac4474532da7dd681f0bd044b329732facd65aeabea3e61adca9"
+PKG_VERSION="2.11.0"
+PKG_SHA256="8c0412be8ceca9d3838daa4b6e7bee7d5a6d591aa05170a3fba2cbc415e2f7fc"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="https://github.com/ARM-software/arm-trusted-firmware"
-PKG_URL="https://github.com/ARM-software/arm-trusted-firmware/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/TrustedFirmware-A/trusted-firmware-a/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="ARM Trusted Firmware is a reference implementation of secure world software, including a Secure Monitor executing at Exception Level 3 and various Arm interface standards."
 PKG_TOOLCHAIN="manual"
@@ -20,6 +20,8 @@ if [ "${ATF_PLATFORM}" = "rk3399" ]; then
 fi
 
 make_target() {
+  # As of atf 2.11.0 - the supported compile for .S is gcc (not as.)
+  unset AS
   if [ "${ATF_PLATFORM}" = "imx8mq" ]; then
     CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="" make PLAT=${ATF_PLATFORM} LOG_LEVEL=0 bl31
   else


### PR DESCRIPTION
Changelog and release notes:
- https://trustedfirmware-a.readthedocs.io/en/latest/change-log.html

build error with iMX8 (all other builds are successful)
```
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-iMX8.aarch64-13.0-devel/toolchain/bin/aarch64-libreelec-linux-gnu-ld: /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-iMX8.aarch64-13.0-devel/build/atf-2.11.0/build/imx8mq/release/bl31/bl31.elf section `.coherent_ram' will not fit in region `RAM'
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-iMX8.aarch64-13.0-devel/toolchain/bin/aarch64-libreelec-linux-gnu-ld: BL31 image has exceeded its limit.
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-iMX8.aarch64-13.0-devel/toolchain/bin/aarch64-libreelec-linux-gnu-ld: region `RAM' overflowed by 12288 bytes
make: *** [Makefile:1524: /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-iMX8.aarch64-13.0-devel/build/atf-2.11.0/build/imx8mq/release/bl31/bl31.elf] Error 1
```