### PR TITLE
Package updates

### DIFF
--- a/packages/debug/xorg-intel-gpu-tools/package.mk
+++ b/packages/debug/xorg-intel-gpu-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xorg-intel-gpu-tools"
-PKG_VERSION="1.28"
-PKG_SHA256="ffcbdf61bd495803d9ae9dfa83e2fe04b8f583a2296fe059c1d5dd135a8a3b15"
+PKG_VERSION="1.29"
+PKG_SHA256="e0fe0d0f088cb50090b212f28b8960fb1e6160c681f5bea0654973aaa9909d8f"
 PKG_LICENSE="GPL"
 PKG_DEPENDS_TARGET="toolchain cairo elfutils kmod libdrm procps-ng systemd"
 PKG_SITE="https://gitlab.freedesktop.org/drm/igt-gpu-tools"

--- a/packages/graphics/spirv-llvm-translator/package.mk
+++ b/packages/graphics/spirv-llvm-translator/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spirv-llvm-translator"
-PKG_VERSION="18.1.3"
-PKG_SHA256="d896f35102c3ba9e16ead7b4db53b75e6131982cdb36a3324f17c68a43598759"
+PKG_VERSION="18.1.4"
+PKG_SHA256="7d2d0fe478f4b6c5cc1fcb689a1b75506e353633d61d45191be5e6aaf18b9456"
 PKG_LICENSE="LLVM"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="74.1.0"
-PKG_SHA256="bea195a800f510ba3a2bc65645c88b7e016fe36709fefc58a880c4ae8a0138d7"
+PKG_VERSION="74.1.2"
+PKG_SHA256="95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="expat"
-PKG_VERSION="2.6.2"
-PKG_SHA256="ee14b4c5d8908b1bec37ad937607eab183d4d9806a08adee472c3c3121d27364"
+PKG_VERSION="2.6.3"
+PKG_SHA256="274db254a6979bde5aad404763a704956940e465843f2a9bd9ed7af22e2c0efc"
 PKG_LICENSE="OSS"
 PKG_SITE="https://libexpat.github.io"
 PKG_URL="https://github.com/libexpat/libexpat/releases/download/R_${PKG_VERSION//./_}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qemu"
-PKG_VERSION="9.0.2"
-PKG_SHA256="a8c3f596aece96da3b00cafb74baafa0d14515eafb8ed1ee3f7f5c2d0ebf02b6"
+PKG_VERSION="9.1.0"
+PKG_SHA256="816b7022a8ba7c2ac30e2e0cf973e826f6bcc8505339603212c5ede8e94d7834"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.qemu.org"
 PKG_URL="https://download.qemu.org/qemu-${PKG_VERSION}.tar.xz"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.62.1"
-PKG_SHA256="2345d4dc136fda28ce243e0bb21f2e7e8ef6293d62c799abbf6f633a6887af72"
+PKG_VERSION="1.63.0"
+PKG_SHA256="4879c75dd32a74421b9857924449460b8341796c0613ba114ab2188e4622354b"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXi/package.mk
+++ b/packages/x11/lib/libXi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXi"
-PKG_VERSION="1.8.1"
-PKG_SHA256="89bfc0e814f288f784202e6e5f9b362b788ccecdeb078670145eacd8749656a7"
+PKG_VERSION="1.8.2"
+PKG_SHA256="d0e0555e53d6e2114eabfa44226ba162d2708501a25e18d99cfb35c094c6c104"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.x.org/"
 PKG_URL="https://www.x.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- libXi: update to 1.8.2
- qemu: update to 9.1.0
- setuptools: update to 74.1.2
- xorg-intel-gpu-tools: update to 1.29
- expat: update to 2.6.3
- spirv-llvm-translator: update to 18.1.4
- nghttp2: update to 1.63.0