### PR TITLE
Package updates

### DIFF
--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.5.5"
-PKG_SHA256="49075cd5c2f4820839a9e69d4a22386bc280c62b92c153af9be39ca439d45a09"
+PKG_VERSION="0.5.6"
+PKG_SHA256="ce7b7217d880bed1438e408ea412716a259cb46b09f597bfd652a577dc60185c"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.386"
-PKG_SHA256="6473dc3ac9ba94195afea6dafa68e9dd2127af270f83e3e035186d38669f7144"
+PKG_VERSION="0.387"
+PKG_SHA256="8c6be8f0863a8ff5c83b2c46aa525b503b30d42792ed57891c40849de543e1ee"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/libbpf/package.mk
+++ b/packages/devel/libbpf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libbpf"
-PKG_VERSION="1.4.5"
-PKG_SHA256="e225c1fe694b9540271b1f2f15eb882c21c34511ba7b8835b0a13003b3ebde8c"
+PKG_VERSION="1.4.6"
+PKG_SHA256="d4cf3ee697d9bd959ad3c0f5c6757370a2559e54448761271e15a23c31c1082e"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/libbpf/libbpf"
 PKG_URL="https://github.com/libbpf/libbpf/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="24.3.2"
-PKG_SHA256="0e0e94b2a75d2725431353f5556738b390aace907a5e696782bff10c1915eb13"
+PKG_VERSION="24.3.3"
+PKG_SHA256="5eb35a1dd601c75ccc3af3c5b21acc82b245ae79ac8d7264f99215be8d064194"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/python/devel/pybuild/package.mk
+++ b/packages/python/devel/pybuild/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pybuild"
-PKG_VERSION="1.2.1"
-PKG_SHA256="526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d"
+PKG_VERSION="1.2.2"
+PKG_SHA256="119b2fb462adef986483438377a13b2f42064a2a3a4161f24a0cca698a07ac8c"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/build/"
 PKG_URL="https://files.pythonhosted.org/packages/source/b/build/build-${PKG_VERSION}.tar.gz"

--- a/packages/python/graphics/glad/package.mk
+++ b/packages/python/graphics/glad/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glad"
-PKG_VERSION="2.0.6"
-PKG_SHA256="61a70234dc7da467cceb07fcdd6dec1213d6143a1b6b19ccc5d7b64cc247ea47"
+PKG_VERSION="2.0.7"
+PKG_SHA256="45f5754fc91de428a840e6ad0237a5577c342b53448527ee073d055c9f8fc767"
 PKG_LICENSE="MIT"
 PKG_SITE="https://glad.dav1d.de"
 PKG_URL="https://github.com/Dav1dde/glad/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="a8c4f1ab2f65e7579eb80153fd1ca9a0b365ca31ca6ae0ebd34156e0724dfc60"
+    PKG_SHA256="76f8927e4923c26c51b60ef99a29f3609843b3a2730f0bdf2ea6958626f11b11"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="2263a9b81f388a66d204214dd02c6c29dc7b27dbf18803797431a6a87bf53213"
+    PKG_SHA256="4ccb670c1336c54fae917b045520793330d670cce953f49ce859da9dbbb8a28d"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="da9340b3249f08656cd4fe10e47aa292c7cd79903870a5863064731a00b5b27e"
+    PKG_SHA256="c50ee4b1ae8695461930e36d5465dddb7c7a0e0f0aa6cbd60de120b17c38b841"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="8fc4bfc3a5fe64f8530964a5ea3bda95e39357eff14d6a8bb24f010ecc912923"
+    PKG_SHA256="85567f037cee338f8ec8f9b6287a7f200d221658a996cba254abc91606ece6f4"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="f0dd131f05e0801fcff35a23015fe83027865b936bccd402c8a9164400d27769"
+    PKG_SHA256="bb146097d9e5f2173cdd7afa4e813f5e68688da371171427d60778e7220e6ec5"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="b793405538d8b6ec1632779efa8835b07b8987db2008c5c9c809bc4b17dcb121"
+    PKG_SHA256="6ddf80f254e8eea9956308ba89fd68e1ac7885853df9239b07bbc9f047b7562f"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.80.1"
-PKG_SHA256="2c0b8f643942dcb810cbcc50f292564b1b6e44db5d5f45091153996df95d2dc4"
+PKG_VERSION="1.81.0"
+PKG_SHA256="872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="fc21ca734504c3d0ccaf361f05cb491142c365ce8a326f942206b0199c49bbb4"
+    PKG_SHA256="301f651f38f8c52ebaad0ac7eb211a5ea25c3b690686d1c265febeee62d2c6fc"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="a77a76f0d5c83e48785f5de0266680782ff10af00c5c3f9edbb1656f42ef85ca"
+    PKG_SHA256="8296d253467270e0fea3ace51ee0f997f7614feb83337b319e51cd6d22026baa"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="0367f069b49560af5c61810530d4721ad13eecfcb48952e67a2c32be903d5043"
+    PKG_SHA256="988a4e4cdecebe4f4a0c52ec4ade5a5bfc58d6958969f5b1e8aac033bda2613e"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nano"
-PKG_VERSION="8.1"
-PKG_SHA256="93b3e3e9155ae389fe9ccf9cb7ab380eac29602835ba3077b22f64d0f0cbe8cb"
+PKG_VERSION="8.2"
+PKG_SHA256="d5ad07dd862facae03051c54c6535e54c7ed7407318783fcad1ad2d7076fffeb"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.nano-editor.org/"
 PKG_URL="https://www.nano-editor.org/dist/v${PKG_VERSION%%.*}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- hwdata: update to 0.387
- pybuild: update to 1.2.2
- wireplumber: update to 0.5.6
- rust: update to 1.81.0
  - rustc-snapshot: update to 1.81.0
  - rust-std-snapshot: update to 1.81.0
  - cargo-snapshot: update to 1.81.0
- nano: update to 8.2
- media-driver: update to 24.3.3
- libbpf: update to 1.4.6
- glad: update to 2.0.7