### PR TITLE
[le12] tz: update to 2024b

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2024a"
-PKG_SHA256="1f562444eb9a646ac9eb4cf7ed9a149e00f7834e373032dd0b2cc773341924a8"
+PKG_VERSION="2024b"
+PKG_SHA256="557c41d8eb5c29387a9d496db87c4aeb4f2ac8a2b6d5f60e869a8cade26e679c"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- backport of #9272 

log:
- https://github.com/eggert/tz/compare/2024a...2024b