### PR TITLE
scripts and tools: only use --passive-ftp for ftp: urls

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -22,7 +22,7 @@ pkg_lock_status "GETPKG" "${PKG_NAME}" "unpack" "downloading package..."
 
 PACKAGE_MIRROR="${DISTRO_MIRROR}/${PKG_NAME}/${PKG_SOURCE_NAME}"
 [ "${VERBOSE}" != "yes" ] && WGET_OPT=-q
-WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -c ${WGET_OPT} --progress=bar:force --show-progress -O ${PACKAGE}"
+WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --no-check-certificate -c ${WGET_OPT} --progress=bar:force --show-progress -O ${PACKAGE}"
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
 unset LD_LIBRARY_PATH
@@ -34,7 +34,8 @@ NBCHKS=2
 while [ ${NBWGET} -gt 0 -a ${NBCHKS} -gt 0 ]; do
   for url in "${PKG_URL}" "${PACKAGE_MIRROR}"; do
     rm -f "${PACKAGE}"
-    if ${WGET_CMD} "${url}"; then
+    [[ "${url}" =~ ^[fF][tT][pP]:* ]] && WGET_FTP=--passive-ftp || WGET_FTP=
+    if ${WGET_CMD} ${WGET_FTP} "${url}"; then
       CALC_SHA256=$(sha256sum "${PACKAGE}" | cut -d" " -f1)
 
       [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2

--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -357,7 +357,10 @@ class MyUtility(object):
     while attempts < retries:
       if stopped.is_set(): break
       attempts += 1
-      (result, output) = MyUtility.runcommand(msgs, "wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -O %s %s" % (filename_data, url), logfile=filename_log)
+      if url.startswith("ftp:"):
+        (result, output) = MyUtility.runcommand(msgs, "wget --output-file=- --timeout=30 --tries=3 --no-check-certificate -O %s %s" % (filename_data, url), logfile=filename_log)
+      else
+        (result, output) = MyUtility.runcommand(msgs, "wget --output-file=- --timeout=30 --tries=3 --passive-ftp --no-check-certificate -O %s %s" % (filename_data, url), logfile=filename_log)
       if result == 0:
         return True
 


### PR DESCRIPTION
All ftp:// urls have been migrated to http/https.

This change maintains the capability to retrieve ftp urls but only adds the —passive-ftp argument to wget if it is a ftp: url.

- fixes #9119 
