### PR TITLE
[le12] iwd: update to 2.22

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.21"
-PKG_SHA256="d911398242cdae78a474fe712de7bd138ddc39122f52709b52c8c3bf03716392"
+PKG_VERSION="2.22"
+PKG_SHA256="2c41c5da9924b90f8383b293b0c0b3d0bfb34fdc8822d8d0d37ec100707f263e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.20"
-PKG_SHA256="86827b97cb5b19ddecce36568c59378da2fae8cf37a0e2b9eacd1269f24c6f8e"
+PKG_VERSION="2.21"
+PKG_SHA256="d911398242cdae78a474fe712de7bd138ddc39122f52709b52c8c3bf03716392"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- backport of #9284 
- Backport of #9289
- Fix issue with pending scan requests after regdom update.
- Fix issue with handling the rearming of the roaming timeout.
- Fix issue with survey request and externally triggered scans.
- Fix issue with RSSI fallback when setting CQM threshold fails.
- Fix issue with FT-over-Air without offchannel support.
- Add support for per station Affinities property.