### PR TITLE
kernel-firmware: update to 20240909

### DIFF
--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="20240811"
-PKG_SHA256="58f1a14b800e3d1967986197d83c81f1ad14b7898a557133c58df0c02c538082"
+PKG_VERSION="20240909"
+PKG_SHA256="943fbd19883cf8eadf89e0b22422549db056557b1ecd30a56400615971369671"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-${PKG_VERSION}.tar.xz"
@@ -73,12 +73,6 @@ makeinstall_target() {
 
   # brcm pcie firmware is only needed by x86_64
   [ "${TARGET_ARCH}" != "x86_64" ] && rm -fr ${FW_TARGET_DIR}/brcm/*-pcie.*
-
-  # Upstream doesn't name the file correctly so we need to symlink it
-  if [ -f "${FW_TARGET_DIR}/rtl_bt/rtl8723bs_config-OBDA8723.bin" ]; then
-    #cd "${FW_TARGET_DIR}/rtl_bt"
-    ln -s "rtl8723bs_config-OBDA8723.bin" "${FW_TARGET_DIR}/rtl_bt/rtl8723bs_config.bin"
-  fi
 
   # Cleanup - which may be project or device specific
   find_file_path scripts/cleanup.sh && ${FOUND_PATH} ${FW_TARGET_DIR} || true


### PR DESCRIPTION
drop now upstreamed change
- https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/rtl_bt/rtl8723bs_config.bin?id=2bb8fb26599302c9cbc69a5aff329a8559c91e48

```
rename rtl8723bs_config-OBDA8723.bin -> rtl_bt/rtl8723bs_config.bin
The setting works for numerous rtl8723 series of devices so let's use
the default naming so it works by default everywhere and link the
device specific names to the generic config.
```