### PR TITLE
linux (amlogic): readd patches for amlogic kernel version

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -20,7 +20,7 @@ case "${LINUX}" in
     PKG_SHA256="740368c264d071200577ef745c1e06362564daefd941c7c562905853c6f16598"
     PKG_URL="https://github.com/torvalds/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
-    PKG_PATCH_DIRS="default rtlwifi/6.10 rtlwifi/6.11"
+    PKG_PATCH_DIRS="amlogic rtlwifi/6.10 rtlwifi/6.11"
     ;;
   raspberrypi)
     PKG_VERSION="d6a3a3f106010d9576a700148220842cac4c5739" # 6.6.50

--- a/packages/linux/patches/amlogic/linux-051-ouya_controller_support.patch
+++ b/packages/linux/patches/amlogic/linux-051-ouya_controller_support.patch
@@ -1,0 +1,206 @@
+commit 5a596921a4636e62843a59b7eab7b87b70a6d296
+Author: Lukas Rusak <lorusak@gmail.com>
+Date:   Sun May 6 22:03:11 2018 -0700
+
+    HID: add ouya HID driver
+    
+    This driver is a simple implementation to get the controller working and mapped properly.
+    This driver does not include functionality for the touchpad (yet). The original driver
+    was taken from from the ouya linux tree and has been simplified. It seems there may have
+    been other versions of the controller present that had a broken report descriptor. I have
+    removed that for now.
+
+diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
+index 60252fd796f6..6be2c454e72e 100644
+--- a/drivers/hid/Kconfig
++++ b/drivers/hid/Kconfig
+@@ -659,6 +659,12 @@ config HID_ORTEK
+ 	   - Ortek WKB-2000
+ 	   - Skycable wireless presenter
+ 
++config HID_OUYA
++	tristate "OUYA Game Controller"
++	depends on USB_HID
++	help
++	  Support for OUYA Game Controller.
++
+ config HID_PANTHERLORD
+ 	tristate "Pantherlord/GreenAsia game controller"
+ 	depends on HID
+diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
+index 17a8bd97da9d..4425890934e4 100644
+--- a/drivers/hid/Makefile
++++ b/drivers/hid/Makefile
+@@ -71,6 +71,7 @@ obj-$(CONFIG_HID_MULTITOUCH)	+= hid-multitouch.o
+ obj-$(CONFIG_HID_NTI)			+= hid-nti.o
+ obj-$(CONFIG_HID_NTRIG)		+= hid-ntrig.o
+ obj-$(CONFIG_HID_ORTEK)		+= hid-ortek.o
++obj-$(CONFIG_HID_OUYA)		+= hid-ouya.o
+ obj-$(CONFIG_HID_PRODIKEYS)	+= hid-prodikeys.o
+ obj-$(CONFIG_HID_PANTHERLORD)	+= hid-pl.o
+ obj-$(CONFIG_HID_PENMOUNT)	+= hid-penmount.o
+diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
+index 0b5cc910f62e..0528efb825fa 100644
+--- a/drivers/hid/hid-ids.h
++++ b/drivers/hid/hid-ids.h
+@@ -859,6 +859,9 @@
+ #define USB_DEVICE_ID_ORTEK_WKB2000	0x2000
+ #define USB_DEVICE_ID_ORTEK_IHOME_IMAC_A210S	0x8003
+ 
++#define USB_VENDOR_ID_OUYA 0x2836
++#define USB_DEVICE_ID_OUYA_CONTROLLER 0x0001
++
+ #define USB_VENDOR_ID_PLANTRONICS	0x047f
+ 
+ #define USB_VENDOR_ID_PANASONIC		0x04da
+diff --git a/drivers/hid/hid-ouya.c b/drivers/hid/hid-ouya.c
+new file mode 100644
+index 000000000000..4344a47b40af
+--- /dev/null
++++ b/drivers/hid/hid-ouya.c
+@@ -0,0 +1,131 @@
++/*
++ *  HID driver for OUYA Game Controller(s)
++ *
++ *  Copyright (c) 2013 OUYA
++ *  Copyright (c) 2013 Gregorios Leach <optikflux@gmail.com>
++ *  Copyright (c) 2018 Lukas Rusak <lorusak@gmail.com>
++ */
++
++#include <linux/device.h>
++#include <linux/hid.h>
++#include <linux/input.h>
++#include <linux/module.h>
++
++#include "hid-ids.h"
++
++static const unsigned int ouya_absmap[] = {
++	[0x30] = ABS_X,		/* left stick X */
++	[0x31] = ABS_Y,		/* left stick Y */
++	[0x32] = ABS_Z,		/* L2 */
++	[0x33] = ABS_RX,	/* right stick X */
++	[0x34] = ABS_RY,	/* right stick Y */
++	[0x35] = ABS_RZ,	/* R2 */
++};
++
++static const unsigned int ouya_keymap[] = {
++	[0x1] = BTN_SOUTH,	/* O */
++	[0x2] = BTN_WEST,	/* U */
++	[0x3] = BTN_NORTH,	/* Y */
++	[0x4] = BTN_EAST,	/* A */
++	[0x5] = BTN_TL,		/* L1 */
++	[0x6] = BTN_TR,		/* R1 */
++	[0x7] = BTN_THUMBL,	/* L3 */
++	[0x8] = BTN_THUMBR,	/* R3 */
++	[0x9] = BTN_DPAD_UP,	/* Up */
++	[0xa] = BTN_DPAD_DOWN,	/* Down */
++	[0xb] = BTN_DPAD_LEFT,	/* Left */
++	[0xc] = BTN_DPAD_RIGHT, /* Right */
++	[0xd] = BTN_TL2,	/* L2 */
++	[0xe] = BTN_TR2,	/* R2 */
++	[0xf] = BTN_MODE,	/* Power */
++};
++
++static int ouya_input_mapping(struct hid_device *hdev, struct hid_input *hi,
++			       struct hid_field *field, struct hid_usage *usage,
++			       unsigned long **bit, int *max)
++{
++	if ((usage->hid & HID_USAGE_PAGE) == HID_UP_BUTTON) {
++		unsigned int key = usage->hid & HID_USAGE;
++
++		if (key >= ARRAY_SIZE(ouya_keymap))
++			return -1;
++
++		key = ouya_keymap[key];
++		hid_map_usage_clear(hi, usage, bit, max, EV_KEY, key);
++
++		return 1;
++
++	} else if ((usage->hid & HID_USAGE_PAGE) == HID_UP_GENDESK) {
++		unsigned int abs = usage->hid & HID_USAGE;
++
++		if (abs >= ARRAY_SIZE(ouya_absmap))
++			return -1;
++
++		abs = ouya_absmap[abs];
++		hid_map_usage_clear(hi, usage, bit, max, EV_ABS, abs);
++
++		return 1;
++	}
++
++	return 0;
++}
++
++static int ouya_probe(struct hid_device *hdev, const struct hid_device_id *id)
++{
++	int ret;
++
++	ret = hid_parse(hdev);
++	if (ret) {
++		hid_err(hdev, "parse failed\n");
++		goto err_free;
++	}
++
++	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT | HID_CONNECT_HIDDEV_FORCE);
++	if (ret) {
++		hid_err(hdev, "hw start failed\n");
++		goto err_free;
++	}
++
++	return 0;
++
++err_free:
++	return ret;
++}
++
++static void ouya_remove(struct hid_device *hdev)
++{
++	hid_hw_stop(hdev);
++	kfree(hid_get_drvdata(hdev));
++}
++
++static const struct hid_device_id ouya_devices[] = {
++	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_OUYA, USB_DEVICE_ID_OUYA_CONTROLLER) },
++	{ }
++};
++MODULE_DEVICE_TABLE(hid, ouya_devices);
++
++static struct hid_driver ouya_driver = {
++	.name = "ouya",
++	.id_table = ouya_devices,
++	.input_mapping = ouya_input_mapping,
++	.probe = ouya_probe,
++	.remove = ouya_remove,
++};
++
++static int __init ouya_init(void)
++{
++	return hid_register_driver(&ouya_driver);
++}
++
++static void __exit ouya_exit(void)
++{
++	hid_unregister_driver(&ouya_driver);
++}
++
++module_init(ouya_init);
++module_exit(ouya_exit);
++
++MODULE_LICENSE("GPL");
++MODULE_AUTHOR("Lukas Rusak <lorusak@gmail.com>");
++MODULE_AUTHOR("Gregorios Leach <optikflux@gmail.com>");
++MODULE_DESCRIPTION("Ouya Controller Driver");
+diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
+index 587e2681a53f..b5adc13e0df1 100644
+--- a/drivers/hid/hid-quirks.c
++++ b/drivers/hid/hid-quirks.c
+@@ -538,6 +538,9 @@ static const struct hid_device_id hid_have_special_driver[] = {
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_ORTEK, USB_DEVICE_ID_ORTEK_IHOME_IMAC_A210S) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_SKYCABLE, USB_DEVICE_ID_SKYCABLE_WIRELESS_PRESENTER) },
+ #endif
++#if IS_ENABLED(CONFIG_HID_OUYA)
++	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_OUYA, USB_DEVICE_ID_OUYA_CONTROLLER) },
++#endif
+ #if IS_ENABLED(CONFIG_HID_PANTHERLORD)
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_GAMERON, USB_DEVICE_ID_GAMERON_DUAL_PSX_ADAPTOR) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_GAMERON, USB_DEVICE_ID_GAMERON_DUAL_PCS_ADAPTOR) },

--- a/packages/linux/patches/amlogic/linux-058.05-hid_sony-add_autorepeat_for_PS3_remotes.patch
+++ b/packages/linux/patches/amlogic/linux-058.05-hid_sony-add_autorepeat_for_PS3_remotes.patch
@@ -1,0 +1,72 @@
+From 7051422474e4c4e302ede3d07ffd8ef2682e07a2 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Tue, 22 Apr 2014 16:05:14 +0300
+Subject: [PATCH] [RFC] hid/sony: add autorepeat for PS3 remotes
+
+adapted to 4.6
+
+Betreff: [RFC] hid/sony: add autorepeat for PS3 remotes
+Von: David Dillow <dave@thedillows.org>
+Datum: 28.06.2013 04:28
+An: linux-input@vger.kernel.org
+Kopie (CC): Stephan Raue <stephan@openelec.tv>
+
+Some applications using the PS3 remote would like to have autorepeat
+from the device. Use the input subsystem's software emulation to provide
+this capability, and enable those that don't need it to turn it off.
+---
+I'm not sure this is the correct approach, or if it is even appropriate
+for a remote to do autorepeat. However, the media/rc subsystem does do
+it by default, and it's been requested by users, so there is at least
+some demand.
+
+This compiled against the hid-sony driver with the PS3 remote changes
+merged, but I have done no testing of it. If the approach seems
+reasonable, I'll try to test it when the MythTV is idle.
+
+Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>
+---
+ drivers/hid/hid-sony.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/drivers/hid/hid-sony.c b/drivers/hid/hid-sony.c
+index 310436a..84f7f41 100644
+--- a/drivers/hid/hid-sony.c
++++ b/drivers/hid/hid-sony.c
+@@ -1120,6 +1120,25 @@ static int ps3remote_mapping(struct hid_device *hdev, struct hid_input *hi,
+ 	return 1;
+ }
+ 
++static int ps3remote_setup_repeat(struct hid_device *hdev)
++{
++	struct hid_input *hidinput = list_first_entry(&hdev->inputs,
++						 struct hid_input, list);
++	struct input_dev *input = hidinput->input;
++
++	/*
++	 * Set up autorepeat defaults per the remote control subsystem;
++	 * this must be done after hid_hw_start(), as having these non-zero
++	 * at the time of input_register_device() tells the input system that
++	 * the hardware does the autorepeat, and the PS3 remote does not.
++	*/
++	set_bit(EV_REP, input->evbit);
++	input->rep[REP_DELAY]  = 500;
++	input->rep[REP_PERIOD] = 125;
++
++	return 0;
++}
++
+ static u8 *sony_report_fixup(struct hid_device *hdev, u8 *rdesc,
+ 		unsigned int *rsize)
+ {
+@@ -2372,6 +2391,8 @@ static int sony_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 		sony_init_output_report(sc, dualshock4_send_output_report);
+ 	} else if (sc->quirks & MOTION_CONTROLLER) {
+ 		sony_init_output_report(sc, motion_send_output_report);
++	} else if (sc->quirks & PS3REMOTE) {
++		ret = ps3remote_setup_repeat(hdev);
+ 	} else {
+ 		ret = 0;
+ 	}
+-- 
+2.5.0

--- a/packages/linux/patches/amlogic/linux-062-imon_pad_ignore_diagonal.patch
+++ b/packages/linux/patches/amlogic/linux-062-imon_pad_ignore_diagonal.patch
@@ -1,0 +1,21 @@
+diff -Naur linux-3.16.1/drivers/media/rc/imon.c linux-3.16.1.patch/drivers/media/rc/imon.c
+--- linux-3.16.1/drivers/media/rc/imon.c	2014-08-14 04:36:35.000000000 +0200
++++ linux-3.16.1.patch/drivers/media/rc/imon.c	2014-08-15 13:57:16.587620642 +0200
+@@ -1344,6 +1344,17 @@
+ 			}
+ 		} else {
+ 			/*
++			 * For users without stabilized, just ignore any value getting
++			 * to close to the diagonal.
++			 */
++			if ((abs(rel_y) < 2 && abs(rel_x) < 2) ||
++				abs(abs(rel_y) - abs(rel_x)) < 2 ) {
++				spin_lock_irqsave(&ictx->kc_lock, flags);
++				ictx->kc = KEY_UNKNOWN;
++				spin_unlock_irqrestore(&ictx->kc_lock, flags);
++				return;
++			}
++			/*
+ 			 * Hack alert: instead of using keycodes, we have
+ 			 * to use hard-coded scancodes here...
+ 			 */

--- a/packages/linux/patches/amlogic/linux-999-no-lzma-in-x86-perf-build.patch
+++ b/packages/linux/patches/amlogic/linux-999-no-lzma-in-x86-perf-build.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/perf/Makefile.config b/tools/perf/Makefile.config
+index 0294bfb6c5f8..153036bbed7e 100644
+--- a/tools/perf/Makefile.config
++++ b/tools/perf/Makefile.config
+@@ -35,7 +35,7 @@ ifeq ($(SRCARCH),x86)
+   ifeq (${IS_64_BIT}, 1)
+     CFLAGS += -DHAVE_ARCH_X86_64_SUPPORT -DHAVE_SYSCALL_TABLE -I$(OUTPUT)arch/x86/include/generated
+     ARCH_INCLUDE = ../../arch/x86/lib/memcpy_64.S ../../arch/x86/lib/memset_64.S
+-    LIBUNWIND_LIBS = -lunwind-x86_64 -lunwind -llzma
++    LIBUNWIND_LIBS = -lunwind-x86_64 -lunwind
+     $(call detected,CONFIG_X86_64)
+   else
+     LIBUNWIND_LIBS = -lunwind-x86 -llzma -lunwind

--- a/packages/linux/patches/amlogic/linux-999.02-0001-pm-disable-async-suspend-resume-by-default.patch
+++ b/packages/linux/patches/amlogic/linux-999.02-0001-pm-disable-async-suspend-resume-by-default.patch
@@ -1,0 +1,25 @@
+From c314d9af9d774c052bea324e1a140ccdba0ca070 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Tue, 8 Apr 2014 14:02:53 +0300
+Subject: [PATCH] pm: disable async suspend/resume by default
+
+---
+ kernel/power/main.c |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/kernel/power/main.c b/kernel/power/main.c
+index 1d1bf63..361db93 100644
+--- a/kernel/power/main.c
++++ b/kernel/power/main.c
+@@ -46,7 +46,7 @@ int pm_notifier_call_chain(unsigned long val)
+ }
+ 
+ /* If set, devices may be suspended and resumed asynchronously. */
+-int pm_async_enabled = 1;
++int pm_async_enabled = 0;
+ 
+ static ssize_t pm_async_show(struct kobject *kobj, struct kobj_attribute *attr,
+ 			     char *buf)
+-- 
+1.7.2.5
+


### PR DESCRIPTION
The rebased linux-058.05-hid_sony-add_autorepeat_for_PS3_remotes.patch rejects for 6.9.5. Add the old version again and put all the patches into an amlogic subdirectory.

This fixes the amlogic build.