### PR TITLE
v4l-utils: do not build with Qt even if Qt is found

### DIFF
--- a/packages/sysutils/v4l-utils/package.mk
+++ b/packages/sysutils/v4l-utils/package.mk
@@ -18,6 +18,8 @@ PKG_MESON_OPTS_TARGET="-Ddefault_library=static \
                        -Dbpf=enabled \
                        -Dgconv=disabled \
                        -Djpeg=disabled \
+                       -Dqvidcap=disabled \
+                       -Dqv4l2=disabled \
                        -Ddoxygen-doc=disabled"
 
 create_multi_keymap() {


### PR DESCRIPTION
While testing `scripts/create_addon` then `make image` it was found that v4l-utils picked up the Qt libraries and wanted to build the qt binaries. This PR disables these binaries from being built. Additional raising an issue to fix Qt to honour not installing in sysroot.