### PR TITLE
vdr-addon: update to 2.7.1 and addon (1)

### DIFF
--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-eepg/patches/vdr-plugin-eepg-PR2-fix-build-with-vdr-2-7-1.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-eepg/patches/vdr-plugin-eepg-PR2-fix-build-with-vdr-2-7-1.patch
@@ -1,0 +1,148 @@
+From c958894e6a4fffff58b0dc276fc978616560192d Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 13 Sep 2024 13:22:54 +0000
+Subject: [PATCH] fix build with vdr 2.7.1
+
+---
+ eepg.c         | 12 ++++++++++++
+ eit2.c         |  8 ++++++++
+ epghandler.c   | 13 +++++++++++++
+ equivhandler.c |  9 +++++++++
+ util.c         |  9 +++++++++
+ 5 files changed, 51 insertions(+)
+
+diff --git a/eepg.c b/eepg.c
+index a78819d..d39581d 100644
+--- a/eepg.c
++++ b/eepg.c
+@@ -1324,12 +1324,20 @@ void cFilterEEPG::WriteToSchedule(tChannelID channelID, cSchedules* pSchedules,
+   cEvent *Event = NULL;
+   if (ps/*[eq]*/) {
+ 
++#if APIVERSNUM >= 20502
++      Event = (cEvent *) ps->GetEventById (EventId); //since Nagra uses consistent EventIds, try this first
++#else
+       Event = (cEvent *) ps->GetEvent (EventId); //since Nagra uses consistent EventIds, try this first
++#endif
+       bool TableIdMatches = false;
+       if (Event)
+         TableIdMatches = (Event->TableID() == TableId);
+       if (!Event || !TableIdMatches || abs(Event->StartTime() - (time_t) StartTime) > Duration * 60) //if EventId does not match, or it matched with wrong TableId, then try with StartTime
++#if APIVERSNUM >= 20502
++        Event = (cEvent *) ps->GetEventByTime (StartTime);
++#else
+         Event = (cEvent *) ps->GetEvent (EventId, StartTime);
++#endif
+   }
+   cEvent *newEvent = NULL;
+   if (!Event) {  //event is new
+@@ -3477,7 +3485,11 @@ void cFilterEEPG::ProcessPremiere(const u_char *& Data)
+               }
+ 
+               bool newEvent = false;
++#if APIVERSNUM >= 20502
++              cEvent *pEvent = (cEvent *) pSchedule->GetEventById (EventId);
++#else
+               cEvent *pEvent = (cEvent *) pSchedule->GetEvent (EventId, -1);
++#endif
+               if (!pEvent) {
+                 LogI(2, "(new)\n");
+                 pEvent = new cEvent (EventId);
+diff --git a/eit2.c b/eit2.c
+index 9ee190d..31aa816 100644
+--- a/eit2.c
++++ b/eit2.c
+@@ -32,7 +32,11 @@ cEvent* cEIT2::ProcessEitEvent(cSchedule* pSchedule,const SI::EIT::Event* EitEve
+   //    int versionNumber = getVersionNumber();
+ 
+   cEvent *newEvent = NULL;
++#if APIVERSNUM >= 20502
++  cEvent *pEvent = (cEvent *) pSchedule->GetEventByTime (EitEvent->getStartTime ());
++#else
+   cEvent *pEvent = (cEvent *) pSchedule->GetEvent (EitEvent->getEventId (), EitEvent->getStartTime ());
++#endif
+   if (!pEvent) {
+     if (OnlyRunningStatus)
+       return NULL;
+@@ -243,7 +247,11 @@ void cEIT2::ProcessEventDescriptors(bool ExternalData, int Source, u_char Tid,
+           tChannelID(Source, channel->Nid(), channel->Tid(), tsed->getReferenceServiceId()));
+         if (!rSchedule)
+           break;
++#if APIVERSNUM >= 20502
++        rEvent = rSchedule->GetEventById(tsed->getReferenceEventId());
++#else
+         rEvent = rSchedule->GetEvent(tsed->getReferenceEventId());
++#endif
+         if (!rEvent)
+           break;
+         pEvent->SetTitle(rEvent->Title());
+diff --git a/epghandler.c b/epghandler.c
+index 1e2db9f..a81bc86 100644
+--- a/epghandler.c
++++ b/epghandler.c
+@@ -66,10 +66,23 @@ bool cEEpgHandler::HandleEitEvent(cSchedule* Schedule,
+   modified = false;
+   //VDR creates new event if the EitEvent StartTime is different than EEPG time so
+   //the EPG event has to be deleted but the data should be kept
++#if APIVERSNUM >= 20502
++  const cEvent *ev;
++  if (EitEvent->getStartTime() > 0){
++    ev = schedule->GetEventByTime(EitEvent->getStartTime());
++  } else {
++    ev = schedule->GetEventById(EitEvent->getEventId());
++  }
++#else
+   const cEvent* ev = schedule->GetEvent(EitEvent->getEventId(),EitEvent->getStartTime());
++#endif
+   searchDuplicates = !ev; //if the event exist with a same start time, it is handled by SetShortText/SetDescription
+   if (!ev){
++#if APIVERSNUM >= 20502
++      ev = schedule->GetEventById(EitEvent->getEventId());
++#else
+       ev = schedule->GetEvent(EitEvent->getEventId());
++#endif
+       // remove shifted duplicates with same ID
+       if (ev && ((ev->StartTime()>EitEvent->getStartTime() && ev->StartTime() < EitEvent->getStartTime()+EitEvent->getDuration())
+           || (EitEvent->getStartTime() > ev->StartTime() && EitEvent->getStartTime() < ev->EndTime()))) {
+diff --git a/equivhandler.c b/equivhandler.c
+index 75007ec..cd23d38 100644
+--- a/equivhandler.c
++++ b/equivhandler.c
+@@ -143,7 +143,16 @@ void cEquivHandler::updateEquivalent(cSchedules * Schedules, tChannelID channelI
+     if (equChannel) {
+       LogD(2, prep("found Equivalent channel %s"), *equChannelID.ToString());
+       cSchedule *pSchedule = (cSchedule *) Schedules->GetSchedule (equChannel, true);
++#if APIVERSNUM >= 20502
++      cEvent *pEqvEvent;
++      if (pEvent->StartTime() > 0){
++        pEqvEvent = (cEvent *) pSchedule->GetEventByTime (pEvent->StartTime());
++      } else {
++        pEqvEvent = (cEvent *) pSchedule->GetEventById (pEvent->EventID());
++      }
++#else
+       cEvent *pEqvEvent = (cEvent *) pSchedule->GetEvent (pEvent->EventID(), pEvent->StartTime());
++#endif
+       if (pEqvEvent) {
+         LogD(3, prep("equivalent event exists"));
+         if (pEqvEvent == pEvent) {
+diff --git a/util.c b/util.c
+index 1109181..029fcc6 100644
+--- a/util.c
++++ b/util.c
+@@ -214,7 +214,16 @@ void cAddEventThread::Action(void)
+       while (((*it).second->First()) != NULL) {
+         cEvent* event = (*it).second->First();
+ 
++#if APIVERSNUM >= 20502
++        cEvent *pEqvEvent;
++        if (event->StartTime() > 0){
++          pEqvEvent = (cEvent *) schedule->GetEventByTime (event->StartTime());
++        } else {
++          pEqvEvent = (cEvent *) schedule->GetEventById (event->EventID());
++        }
++#else
+         cEvent *pEqvEvent = (cEvent *) schedule->GetEvent (event->EventID(), event->StartTime());
++#endif
+         if (pEqvEvent){
+           (*it).second->Del(event);
+         } else {

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-epgsearch/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-epgsearch/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-epgsearch"
-PKG_VERSION="2.4.2"
-PKG_SHA256="7c0a03c22fedbc73a34220da0edf3293a903185c412d5b20fb48d72f2e4fd118"
+PKG_VERSION="2.4.3"
+PKG_SHA256="3824a72be529391ce26d00f0323b9d71572855c1c660bae9d30064f42366aadf"
 PKG_LICENSE="GPL"
 PKG_SITE="http://winni.vdr-developer.org/epgsearch/"
 PKG_URL="https://github.com/vdr-projects/vdr-plugin-epgsearch/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-live/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-live/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-live"
-PKG_VERSION="3.3.5"
-PKG_SHA256="8b41fe5c885e9f2e4fab470feda89742885567885d93b6435692ce1c7c320fee"
+PKG_VERSION="3.3.6"
+PKG_SHA256="2dc11ab4d68ce7100d8dca8eef65bc81280e30493bd7670ec661714b2bf18211"
 PKG_LICENSE="GPL"
 PKG_SITE="http://live.vdr-developer.org/en/index.php"
 PKG_URL="https://github.com/MarkusEh/vdr-plugin-live/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-restfulapi/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-restfulapi/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-restfulapi"
-PKG_VERSION="0.2.6.6"
-PKG_SHA256="a392c8ac9da58bce06674208711a786209ce802e77f93b48d21e424fa79f5eba"
+PKG_VERSION="be8a3a60af7e8926cb28c06e6b6d2adc2c2ed968"
+PKG_SHA256="18cb9b6735f5ac2060ecedd6043a09bc742bd5132f33ef8a0155ddfe266b9dc2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/yavdr/vdr-plugin-restfulapi"
-PKG_URL="https://github.com/yavdr/${PKG_NAME}/archive/refs/tags/${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/yavdr/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain vdr cxxtools vdr-plugin-wirbelscan"
 PKG_NEED_UNPACK="$(get_pkg_directory vdr) $(get_pkg_directory vdr-plugin-wirbelscan)"
 PKG_LONGDESC="Allows to access many internals of the VDR via a restful API."

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-wirbelscan"
-PKG_VERSION="2023.10.15"
-PKG_SHA256="58ab069bf3719053f9601c129607785a89bcf13008ed5c70fa010e815134490f"
+PKG_VERSION="2024.09.15"
+PKG_SHA256="22317c5a919834d70aee309248e7fb8b9f458819dee0e5ccdbedee7fdada8913"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gen2vdr.de/wirbel/wirbelscan/index2.html"
 PKG_URL="https://www.gen2vdr.de/wirbel/wirbelscan/vdr-wirbelscan-${PKG_VERSION}.tgz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/patches/vdr-plugin-xmltv2vdr-04-fixed-import-for-vdr-2-7-1.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-xmltv2vdr/patches/vdr-plugin-xmltv2vdr-04-fixed-import-for-vdr-2-7-1.patch
@@ -1,0 +1,44 @@
+From 4ee9769b5746240247c3a01f4000afdf8fc56857 Mon Sep 17 00:00:00 2001
+From: joed74 <gh@dolze.de>
+Date: Tue, 10 Sep 2024 15:57:59 +0200
+Subject: [PATCH] Fixed import for vdr 2.7.1
+
+---
+ import.cpp | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/import.cpp b/import.cpp
+index 1bb1849..8c73024 100644
+--- a/import.cpp
++++ b/import.cpp
+@@ -86,7 +86,11 @@ cEvent *cImport::SearchVDREventByTitle(cEPGSource *source, cSchedule* schedule,
+     const char *cxTitle=conv->Convert(Title);
+ 
+     // 2nd with StartTime
++#if VDRVERSNUM >= 20701
++    cEvent *f=(cEvent *) schedule->GetEventByTime(StartTime+hint);
++#else
+     cEvent *f=(cEvent *) schedule->GetEvent((tEventID) 0,StartTime+hint);
++#endif
+     if (f)
+     {
+         if (!strcasecmp(f->Title(),cxTitle))
+@@ -188,10 +192,18 @@ cEvent *cImport::SearchVDREvent(cEPGSource *source, cSchedule* schedule, cXMLTVE
+ 
+     // try to find an event,
+     // 1st with our own EventID
++#if VDRVERSNUM >= 20701
++    if (xevent->EITEventID()) f=(cEvent *) schedule->GetEventById(xevent->EITEventID());
++#else
+     if (xevent->EITEventID()) f=(cEvent *) schedule->GetEvent(xevent->EITEventID());
++#endif
+     if (f) return f;
+ 
++#if VDRVERSNUM >= 20701
++    if (xevent->EventID() && append) f=(cEvent *) schedule->GetEventById(xevent->EITEventID());
++#else
+     if (xevent->EventID() && append) f=(cEvent *) schedule->GetEvent(xevent->EventID());
++#endif
+     if (f) return f;
+ 
+     f=SearchVDREventByTitle(source, schedule, xevent->Title(), xevent->StartTime(),

--- a/packages/addons/addon-depends/vdr/package.mk
+++ b/packages/addons/addon-depends/vdr/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr"
-PKG_VERSION="2.6.9"
-PKG_SHA256="e7364485a6b2f2192359fa5547bcf48ebb8265c96737f933c3d464f80b59a204"
+PKG_VERSION="2.7.1"
+PKG_SHA256="ae3010a5297891f55b3d11b19fe15cd868f24250da8554e985ab163e19d98026"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvdr.de"
 PKG_URL="http://git.tvdr.de/?p=vdr.git;a=snapshot;h=refs/tags/${PKG_VERSION};sf=tbz2"

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-addon"
-PKG_VERSION="2.6.9"
-PKG_REV="0"
+PKG_VERSION="2.7.1"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- vdr: update to 2.7.1
- vdr-plugin-eepg: fix build with vdr 2.7.1
- vdr-plugin-epgsearch: update to 2.4.3
- vdr-plugin-live: update to 3.3.6
- vdr-plugin-restfulapi: update to githash be8a3a6
- vdr-plugin-wirbelscan: update to 2024.09.15
- vdr-plugin-xmltv2vdr: Fixed import for vdr 2.7.1