### PR TITLE
disable explicitly glib introspection for host builds. Otherwise a ho…

### DIFF
--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -15,6 +15,7 @@ PKG_LONGDESC="A library which includes support routines for C such as lists, tre
 PKG_MESON_OPTS_HOST="-Ddefault_library=static \
                      -Dinstalled_tests=false \
                      -Dlibmount=disabled \
+                     -Dintrospection=disabled \
                      -Dtests=false"
 
 PKG_MESON_OPTS_TARGET="-Ddefault_library=shared \


### PR DESCRIPTION
disable explicitly glib introspection for host builds. Otherwise a host installation of gobject-introspection could lead to build problems.

The meson.build contains

`gir_scanner = find_program('g-ir-scanner', required: get_option('introspection')) 
enable_gir = get_option('introspection').allowed() and gir_scanner.found() and meson.can_run_host_binaries()`

and find_program finds the g-ir-scanner in /usr/bin on the host system and the build of glib fails.