### PR TITLE
Updates to service.nextpvr for v7

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
@@ -20,7 +20,7 @@ configure_target() {
         --host=${TARGET_NAME} \
         --build=${HOST_NAME} \
         --enable-static \
-        --disable-shared \
+        --enable-shared \
         --prefix=/usr \
         --enable-visibility
 }
@@ -36,6 +36,8 @@ makeinstall_target() {
     mkdir -p ${INSTALL}/usr/include/MediaInfo/${i}/
     cp -aP ../../../Source/MediaInfo/${i}/*.h ${INSTALL}/usr/include/MediaInfo/${i}/
   done
-  cp -P .libs/* ${INSTALL}/usr/lib
+
+  # only install static library, so mediainfo does not build with shared library
+  cp -P .libs/libmediainfo.a ${INSTALL}/usr/lib
   cp -P libmediainfo.pc ${INSTALL}/usr/lib/pkgconfig
 }

--- a/packages/addons/service/nextpvr/package.mk
+++ b/packages/addons/service/nextpvr/package.mk
@@ -2,13 +2,13 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nextpvr"
-PKG_VERSION="6.1.5~Omega"
-PKG_ADDON_VERSION="6.1.5~4"
+PKG_VERSION="7.0.0~Piers"
+PKG_ADDON_VERSION="7.0.0~1"
 PKG_REV="0"
 PKG_ARCH="any"
 PKG_LICENSE="NextPVR"
 PKG_SITE="https://nextpvr.com"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain libhdhomerun libmediainfo comskip"
 PKG_SECTION="service"
 PKG_SHORTDESC="NextPVR Server"
 PKG_LONGDESC="NextPVR is a personal video recorder application. It allows to watch or record live TV, provides great features like series recordings and web scheduling."
@@ -25,4 +25,13 @@ addon() {
 
 post_install_addon() {
   sed -e "s/@NEXTPVR_VERSION@/${PKG_ADDON_VERSION}/g" -i "${INSTALL}/bin/nextpvr-downloader"
+
+  mkdir -p ${INSTALL}/{lbin,lib.private}
+  cp $(get_build_dir libmediainfo)/Project/GNU/Library/.libs/libmediainfo.so ${INSTALL}/lib.private
+  cp -P $(get_build_dir libhdhomerun)/hdhomerun_config ${INSTALL}/lbin
+  cp -P $(get_install_dir comskip)/usr/bin/comskip ${INSTALL}/lbin
+  if [ "${TARGET_ARCH}" = "x86_64" ]; then
+    cp -P $(get_install_dir x265)/usr/lib/libx265.so.212 ${INSTALL}/lib.private
+    patchelf --add-rpath '${ORIGIN}/../lib.private' ${INSTALL}/lbin/comskip
+  fi
 }

--- a/packages/addons/service/nextpvr/source/addon.py
+++ b/packages/addons/service/nextpvr/source/addon.py
@@ -75,6 +75,8 @@ class Controller():
             xbmc.log('Running: %s' % command, xbmc.LOGDEBUG)
             os.system(command)
             os.remove(archive)
+            command = 'find {0}/DeviceHost -name DeviceHostLinux -exec chmod 755 {{}} \;'.format(dest_folder)
+            os.system(command)
             xbmcgui.Dialog().notification(ADDON_NAME, LS(30039), xbmcgui.NOTIFICATION_INFO)
             xbmc.log('NPVR.zip installed', xbmc.LOGDEBUG)
             if xbmcgui.Dialog().yesno("NextPVR Server", LS(30020)):

--- a/packages/addons/service/nextpvr/source/bin/nextpvr-downloader
+++ b/packages/addons/service/nextpvr/source/bin/nextpvr-downloader
@@ -61,6 +61,12 @@ fi
 # extract NextPVR
 kodi-send --action="Notification(Extracting NextPVR,starting,1000,${ICON})" >/dev/null
 mkdir -p ${ADDON_DIR}/nextpvr-bin
+
+chmod +x ${ADDON_DIR}/lbin/hdhomerun_config
+chmod +x ${ADDON_DIR}/lbin/comskip
+ln -s ${ADDON_DIR}/lbin/hdhomerun_config ${ADDON_DIR}/nextpvr-bin
+ln -s ${ADDON_DIR}/lib.private/libmediainfo.so ${ADDON_DIR}/nextpvr-bin
+
 unzip ${NEXTPVR_FILE} -d ${ADDON_DIR}/nextpvr-bin >/dev/null
 
 if [ "$(uname -m)" != "x86_64" ]; then

--- a/packages/addons/service/nextpvr/source/sleep.d/nextpvr.power
+++ b/packages/addons/service/nextpvr/source/sleep.d/nextpvr.power
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+. /etc/profile
+
+oe_setup_addon service.nextpvr
+
+SERVICE="service.nextpvr"
+
+case "$1" in
+  pre)
+    if systemctl is-active "$SERVICE" &>/dev/null ; then
+      systemctl stop "$SERVICE"
+      for module in $REMOVE_MODULES ; do
+        rmmod $module
+      done
+    fi
+    ;;
+  post)
+    if systemctl is-enabled "$SERVICE" &>/dev/null ; then
+      for module in $REMOVE_MODULES ; do
+        modprobe $module
+      done
+      systemctl start "$SERVICE"
+    fi
+    ;;
+esac


### PR DESCRIPTION
libmediainfo:  Currently libmediainfo only builds the static library.  Allow creation of shared library for applications that need it.  Tested with service.nextpvr, standalone mediainfo unchanged.

service.nextpvr: changes for v7 

- add libmediainfo.so and  hdhomerun_config
- add power management reset after sleep
- fix binary  not being marked +x  on manual updates
