### PR TITLE
busybox: fix not x86 builds with 1.37.0

### DIFF
--- a/packages/sysutils/busybox/patches/busybox-90-tls-fix-not-x86-fix-CONFIG_FEATURE_TLS_SHA1-y-CONFIG.patch
+++ b/packages/sysutils/busybox/patches/busybox-90-tls-fix-not-x86-fix-CONFIG_FEATURE_TLS_SHA1-y-CONFIG.patch
@@ -1,0 +1,27 @@
+From ca2cc021326f3f846ead76675c419942633819f2 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 29 Sep 2024 17:45:43 +0000
+Subject: [PATCH] tls: fix not x86: fix CONFIG_FEATURE_TLS_SHA1=y +
+ CONFIG_SHA1_HWACCEL=y
+
+---
+ libbb/hash_md5_sha.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libbb/hash_md5_sha.c b/libbb/hash_md5_sha.c
+index 57a801459..75a61c32c 100644
+--- a/libbb/hash_md5_sha.c
++++ b/libbb/hash_md5_sha.c
+@@ -1313,7 +1313,9 @@ unsigned FAST_FUNC sha1_end(sha1_ctx_t *ctx, void *resbuf)
+ 	hash_size = 8;
+ 	if (ctx->process_block == sha1_process_block64
+ #if ENABLE_SHA1_HWACCEL
++# if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+ 	 || ctx->process_block == sha1_process_block64_shaNI
++# endif
+ #endif
+ 	) {
+ 		hash_size = 5;
+-- 
+2.43.0
+


### PR DESCRIPTION
tls: fix not x86: fix CONFIG_FEATURE_TLS_SHA1=y + CONFIG_SHA1_HWACCEL=y
- http://lists.busybox.net/pipermail/busybox/2024-September/090943.html
- http://lists.busybox.net/pipermail/busybox/2024-September/090944.html
