### PR TITLE
build: use system rsync

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="linux"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kernel.org"
-PKG_DEPENDS_HOST="ccache:host rsync:host"
+PKG_DEPENDS_HOST="ccache:host"
 PKG_DEPENDS_TARGET="linux:host kmod:host keyutils openssl:host ${KERNEL_EXTRA_DEPENDS_TARGET}"
 PKG_NEED_UNPACK="${LINUX_DEPENDS} $(get_pkg_directory initramfs) $(get_pkg_variable initramfs PKG_NEED_UNPACK)"
 PKG_LONGDESC="This package contains a precompiled kernel image and the modules."

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -70,6 +70,7 @@ dep_map=(
   [patch]=patch
   [perl]=perl
   [rdfind]=rdfind
+  [rsync]=rsync
   [sed]=sed
   [tar]=tar
   [unzip]=unzip

--- a/tools/docker/bookworm/Dockerfile
+++ b/tools/docker/bookworm/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++ xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.21-go/bookworm-backports git openssh-client \
+      golang-1.21-go/bookworm-backports git openssh-client rsync \
     --no-install-recommends \
     && ln -s /usr/lib/go-1.21 /usr/lib/go \
     && ln -s /usr/lib/go-1.21/bin/go /usr/bin/go \

--- a/tools/docker/focal/Dockerfile
+++ b/tools/docker/focal/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     wget bash bc gcc-10 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-10 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
-      golang-1.18-go git openssh-client \
+      golang-1.18-go git openssh-client rsync \
     --no-install-recommends \
  && ln -s /usr/lib/go-1.18 /usr/lib/go \
  && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y \
     wget bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.21-go git openssh-client \
+      golang-1.21-go git openssh-client rsync \
     --no-install-recommends \
     && ln -s /usr/lib/go-1.21 /usr/lib/go \
     && ln -s /usr/lib/go-1.21/bin/go /usr/bin/go \

--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y \
     wget bash bc gcc-14 cpp-14 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-14 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-go git openssh-client \
+      golang-go git openssh-client rsync \
     --no-install-recommends
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \


### PR DESCRIPTION
rsync:host is used solely by the linux kernel build as a fancy file copy. We're not doing something special with our rsync:host build, so switch to a system provided rsync. My belief is that most dev systems already have rsync installed.