### PR TITLE
network-base-setup: change fallback dns to cloudflare 1.1.1.1

### DIFF
--- a/packages/sysutils/systemd/scripts/network-base-setup
+++ b/packages/sysutils/systemd/scripts/network-base-setup
@@ -39,7 +39,7 @@ elif [ -f /dev/.kernel_ipconfig ] && [ -f /proc/net/pnp ]; then
   cat /proc/net/pnp >/run/libreelec/resolv.conf
 else
   cat <<EOF >/run/libreelec/resolv.conf
-nameserver 8.8.8.8
-nameserver 8.8.4.4
+nameserver 1.1.1.1
+nameserver 1.0.0.1
 EOF
 fi


### PR DESCRIPTION
This changes the default fallback DNS servers to Cloudflare's 1.1.1.1 service. User chosen or connman managed DNS servers are still preferred over this. My understanding is that Cloudflare's public DNS is more performant than Google's offering.