### PR TITLE
Kodi wayland build fixes

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="e078727d9fe0af67ffb8f6cfc1611d718bcc631d21da69eddcfcf6535a31e76e"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre2 swig:host libass curl exiv2 fontconfig fribidi tinyxml tinyxml2 libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid libdvdnav libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog"
+PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre2 swig:host libass curl exiv2 fontconfig fribidi tinyxml tinyxml2 libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid libdvdnav libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog libxkbcommon"
 PKG_DEPENDS_UNPACK="commons-lang3 commons-text groovy"
 PKG_DEPENDS_HOST="toolchain"
 PKG_LONGDESC="A free and open source cross-platform media player."
@@ -218,7 +218,7 @@ configure_package() {
   fi
 
   if [ ! "${KODIPLAYER_DRIVER}" = "default" -a "${DISPLAYSERVER}" = "no" ]; then
-    PKG_DEPENDS_TARGET+=" ${KODIPLAYER_DRIVER} libinput libxkbcommon libdisplay-info"
+    PKG_DEPENDS_TARGET+=" ${KODIPLAYER_DRIVER} libinput libdisplay-info"
     if [ "${OPENGLES_SUPPORT}" = yes -a "${KODIPLAYER_DRIVER}" = "${OPENGLES}" ]; then
       KODI_PLATFORM="-DCORE_PLATFORM_NAME=gbm -DAPP_RENDER_SYSTEM=gles"
       CFLAGS+=" -DEGL_NO_X11"

--- a/packages/mediacenter/kodi/patches/kodi-999.20-headers-only.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.20-headers-only.patch
@@ -1,6 +1,8 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0ef3151592bf..9460fd5895d2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -68,6 +68,7 @@ include(CMakeDependentOption)
+@@ -80,6 +80,7 @@ include(CMakeDependentOption)
  include(cmake/scripts/common/DependencyOptions.cmake)
  
  # general
@@ -8,7 +10,7 @@
  option(VERBOSE            "Enable verbose output?" OFF)
  option(ENABLE_CLANGTIDY   "Enable clang-tidy support?" OFF)
  option(ENABLE_CPPCHECK    "Enable cppcheck support?" OFF)
-@@ -144,6 +145,7 @@ core_find_git_rev(APP_SCMID FULL)
+@@ -154,6 +155,7 @@ core_find_git_rev(APP_SCMID FULL)
  set(AUDIO_BACKENDS_LIST "" CACHE STRING "Available audio backends")
  set(GL_INTERFACES_LIST "" CACHE STRING "Available GL interfaces")
  
@@ -16,7 +18,7 @@
  # Dynamically loaded libraries built with the project
  add_custom_target(${APP_NAME_LC}-libraries)
  set(LIBRARY_FILES "" CACHE STRING "" FORCE)
-@@ -587,6 +589,7 @@ endif()
+@@ -607,6 +609,7 @@ endif()
  if(FFMPEG_CREATE_SHARED_LIBRARY)
    set(CMAKE_CXX_CREATE_SHARED_LIBRARY "${FFMPEG_CREATE_SHARED_LIBRARY}")
  endif()
@@ -24,9 +26,24 @@
  
  # Platform specific additional extra targets
  if(EXISTS ${CMAKE_SOURCE_DIR}/cmake/scripts/${CORE_SYSTEM_NAME}/ExtraTargets.cmake)
+diff --git a/cmake/scripts/linux/ExtraTargets.cmake b/cmake/scripts/linux/ExtraTargets.cmake
+index 36757cef4125..38164342208a 100644
+--- a/cmake/scripts/linux/ExtraTargets.cmake
++++ b/cmake/scripts/linux/ExtraTargets.cmake
+@@ -36,5 +36,7 @@ if("wayland" IN_LIST CORE_PLATFORM_NAME_LC)
+   # Dummy target for dependencies
+   add_custom_target(generate-wayland-extra-protocols DEPENDS wayland-extra-protocols.hpp)
+ 
+-  add_dependencies(lib${APP_NAME_LC} generate-wayland-extra-protocols)
++  if(NOT HEADERS_ONLY)
++    add_dependencies(lib${APP_NAME_LC} generate-wayland-extra-protocols)
++  endif()
+ endif()
+diff --git a/cmake/scripts/linux/Install.cmake b/cmake/scripts/linux/Install.cmake
+index 90b50c48f649..da01ea04cb05 100644
 --- a/cmake/scripts/linux/Install.cmake
 +++ b/cmake/scripts/linux/Install.cmake
-@@ -45,6 +45,7 @@ configure_file(${CMAKE_SOURCE_DIR}/tools
+@@ -45,6 +45,7 @@ configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi.desktop.in
  configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi.metainfo.xml.in
                 ${CORE_BUILD_DIR}/${APP_PACKAGE}.metainfo.xml @ONLY)
  


### PR DESCRIPTION
Refresh Kodi headers only patch to fix #8271 and promote libxkbcommon to common kodi target dependency so it can be build separately.