### PR TITLE
kernel config: Generic: support recent Intel devices

### DIFF
--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1657,7 +1657,7 @@ CONFIG_VGA_ARB_MAX_GPUS=16
 #
 # PCI controller drivers
 #
-# CONFIG_VMD is not set
+CONFIG_VMD=y
 
 #
 # Cadence-based PCIe controllers


### PR DESCRIPTION
Backport of #9316

Runtime tested, but without using the new supported devices