### PR TITLE
tools/docker/noble: update to gcc-14

### DIFF
--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -18,8 +18,8 @@ RUN useradd docker -U -G sudo -m -s /bin/bash \
 RUN apt-get update
 
 RUN apt-get install -y \
-    wget bash bc gcc-13 cpp-13 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
-      unzip diffutils lzop make file g++-13 xfonts-utils xsltproc default-jre-headless python3 \
+    wget bash bc gcc-14 cpp-14 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
+      unzip diffutils lzop make file g++-14 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
       golang-go git openssh-client \
     --no-install-recommends
@@ -30,10 +30,10 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
 
 RUN rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
-    --slave /usr/bin/cpp cpp /usr/bin/cpp-13 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
-    --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
+    --slave /usr/bin/cpp cpp /usr/bin/cpp-14 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-14 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-14
 RUN update-alternatives --config gcc
 
 USER docker


### PR DESCRIPTION
Noble has now been updated with gcc-14.2.0 (was 14.0.1) 

Testing with 14.0.1 has been successful and now with a release gcc version 14.2.0 that aligns with our target compiler.