### PR TITLE
linux: update to 6.11.4

### DIFF
--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwlwifi-firmware"
-PKG_VERSION="2b5e91d4c70a92c974aaf9d9b25f2d2d692d31fa"
-PKG_SHA256="2cc00f6a89014a828d2272fdb79c675de3af4c52ceeeae7f030e965fc2a3dfd6"
+PKG_VERSION="f87fe9746aad98639b882996122d8e8c39a13c44"
+PKG_SHA256="f48f7aba3836744e97f6336f9f8e5f472f1fe798d04f8a8422b9f7d6271839f5"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/iwlwifi-firmware"
 PKG_URL="https://github.com/LibreELEC/iwlwifi-firmware/archive/${PKG_VERSION}.tar.gz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -30,8 +30,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.9 rtlwifi/6.10 rtlwifi/6.11"
     ;;
   *)
-    PKG_VERSION="6.11"
-    PKG_SHA256="55d2c6c025ebc27810c748d66325dd5bc601e8d32f8581d9e77673529bdacb2e"
+    PKG_VERSION="6.11.4"
+    PKG_SHA256="bd54b0a0a46574919706698b1411ec48cf2a58345c4d8990e414acc4730e8f55"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Allwinner/linux/linux.aarch64.conf
+++ b/projects/Allwinner/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.11.0 Kernel Configuration
+# Linux/arm64 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -3709,7 +3709,6 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Chips&Media media platform drivers
 #
-# CONFIG_VIDEO_E5010_JPEG_ENC is not set
 
 #
 # Intel media platform drivers
@@ -6890,6 +6889,9 @@ CONFIG_KEYS=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 CONFIG_SECURITY=y
 CONFIG_SECURITYFS=y
 # CONFIG_SECURITY_NETWORK is not set

--- a/projects/Allwinner/linux/linux.arm.conf
+++ b/projects/Allwinner/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.11.0 Kernel Configuration
+# Linux/arm 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7ve-libreelec-linux-gnueabihf-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -3411,7 +3411,6 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Chips&Media media platform drivers
 #
-# CONFIG_VIDEO_E5010_JPEG_ENC is not set
 
 #
 # Intel media platform drivers
@@ -6416,6 +6415,9 @@ CONFIG_KEYS=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 # CONFIG_SECURITY is not set
 CONFIG_SECURITYFS=y
 # CONFIG_HARDENED_USERCOPY is not set

--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.11.0 Kernel Configuration
+# Linux/x86 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -4137,7 +4137,6 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Chips&Media media platform drivers
 #
-# CONFIG_VIDEO_E5010_JPEG_ENC is not set
 
 #
 # Intel media platform drivers
@@ -6789,6 +6788,9 @@ CONFIG_KEYS_REQUEST_CACHE=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 # CONFIG_SECURITY is not set
 CONFIG_SECURITYFS=y
 # CONFIG_INTEL_TXT is not set

--- a/projects/NXP/devices/iMX6/linux/linux.arm.conf
+++ b/projects/NXP/devices/iMX6/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.11.0 Kernel Configuration
+# Linux/arm 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7a-libreelec-linux-gnueabihf-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -3946,7 +3946,6 @@ CONFIG_VIDEO_MEM2MEM_DEINTERLACE=m
 #
 CONFIG_VIDEO_CODA=y
 CONFIG_VIDEO_IMX_VDOA=y
-# CONFIG_VIDEO_E5010_JPEG_ENC is not set
 
 #
 # Intel media platform drivers
@@ -3991,7 +3990,6 @@ CONFIG_VIDEO_IMX_VDOA=y
 #
 # Raspberry Pi media platform drivers
 #
-# CONFIG_VIDEO_RASPBERRYPI_PISP_BE is not set
 
 #
 # Renesas media platform drivers
@@ -7205,6 +7203,9 @@ CONFIG_KEYS=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 # CONFIG_SECURITY is not set
 CONFIG_SECURITYFS=y
 # CONFIG_HARDENED_USERCOPY is not set

--- a/projects/Qualcomm/devices/Dragonboard/linux/linux.aarch64.conf
+++ b/projects/Qualcomm/devices/Dragonboard/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.11.0 Kernel Configuration
+# Linux/arm64 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -7137,6 +7137,9 @@ CONFIG_KEYS=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 CONFIG_SECURITY=y
 CONFIG_SECURITYFS=y
 # CONFIG_SECURITY_NETWORK is not set

--- a/projects/Rockchip/devices/RK3288/linux/default/linux.arm.conf
+++ b/projects/Rockchip/devices/RK3288/linux/default/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.11.0 Kernel Configuration
+# Linux/arm 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7ve-libreelec-linux-gnueabihf-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -3647,7 +3647,6 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Chips&Media media platform drivers
 #
-# CONFIG_VIDEO_E5010_JPEG_ENC is not set
 
 #
 # Intel media platform drivers
@@ -6788,6 +6787,9 @@ CONFIG_KEYS=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 # CONFIG_SECURITY is not set
 # CONFIG_SECURITYFS is not set
 # CONFIG_HARDENED_USERCOPY is not set

--- a/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.11.0 Kernel Configuration
+# Linux/arm64 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -3564,7 +3564,6 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Chips&Media media platform drivers
 #
-# CONFIG_VIDEO_E5010_JPEG_ENC is not set
 
 #
 # Intel media platform drivers
@@ -6648,6 +6647,9 @@ CONFIG_KEYS=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 CONFIG_SECURITY=y
 # CONFIG_SECURITYFS is not set
 # CONFIG_SECURITY_NETWORK is not set

--- a/projects/Rockchip/devices/RK3399/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3399/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.11.0 Kernel Configuration
+# Linux/arm64 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -4100,7 +4100,6 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Chips&Media media platform drivers
 #
-# CONFIG_VIDEO_E5010_JPEG_ENC is not set
 
 #
 # Intel media platform drivers
@@ -4138,7 +4137,6 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
-# CONFIG_VIDEO_RASPBERRYPI_PISP_BE is not set
 
 #
 # Renesas media platform drivers
@@ -7461,6 +7459,9 @@ CONFIG_KEYS=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 CONFIG_SECURITY=y
 # CONFIG_SECURITYFS is not set
 # CONFIG_SECURITY_NETWORK is not set

--- a/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
+++ b/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
@@ -633,30 +633,6 @@ index 38dded2baaf7..9e460b7e14a4 100644
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
-Date: Wed, 8 Jan 2020 21:07:50 +0000
-Subject: [PATCH] clk: rockchip: set parent rate for DCLK_VOP clock on rk3228
-
-Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
----
- drivers/clk/rockchip/clk-rk3228.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/drivers/clk/rockchip/clk-rk3228.c b/drivers/clk/rockchip/clk-rk3228.c
-index a24a35553e13..7343d2d7676b 100644
---- a/drivers/clk/rockchip/clk-rk3228.c
-+++ b/drivers/clk/rockchip/clk-rk3228.c
-@@ -409,7 +409,7 @@ static struct rockchip_clk_branch rk3228_clk_branches[] __initdata = {
- 			RK2928_CLKSEL_CON(29), 0, 3, DFLAGS),
- 	DIV(0, "sclk_vop_pre", "sclk_vop_src", 0,
- 			RK2928_CLKSEL_CON(27), 8, 8, DFLAGS),
--	MUX(DCLK_VOP, "dclk_vop", mux_dclk_vop_p, 0,
-+	MUX(DCLK_VOP, "dclk_vop", mux_dclk_vop_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT,
- 			RK2928_CLKSEL_CON(27), 1, 1, MFLAGS),
- 
- 	FACTOR(0, "xin12m", "xin24m", 0, 1, 2),
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sat, 10 Oct 2020 14:32:21 +0000
 Subject: [PATCH] drm/rockchip: vop: split rk3288 vop
 
@@ -2644,37 +2620,6 @@ index ae4c49e84470..92e621f2714f 100644
  };
  
  static const u16 csc_coeff_rgb_full_to_rgb_limited[3][4] = {
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Tue, 1 Jun 2021 19:24:37 +0200
-Subject: [PATCH] drm/rockchip: allow 4096px width modes
-
-There is not reason to limit vop output to 3840px width modes.
-Also drop the limitation from dw_hdmi_rockchip_mode_valid, since
-the max dimenstions of the actual vop version is validated in
-vop_crtc_mode_valid anyways.
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- drivers/gpu/drm/rockchip/rockchip_drm_vop.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
-diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
-index ef0a078c22f4..49619f794061 100644
---- a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
-+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
-@@ -424,8 +424,8 @@ static void scl_vop_cal_scl_fac(struct vop *vop, const struct vop_win_data *win,
- 	if (info->is_yuv)
- 		is_yuv = true;
- 
--	if (dst_w > 3840) {
--		DRM_DEV_ERROR(vop->dev, "Maximum dst width (3840) exceeded\n");
-+	if (dst_w > 4096) {
-+		DRM_DEV_ERROR(vop->dev, "Maximum dst width (4096) exceeded\n");
- 		return;
- 	}
- 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>

--- a/projects/Samsung/linux/linux.arm.conf
+++ b/projects/Samsung/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.11.0 Kernel Configuration
+# Linux/arm 6.11.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7ve-libreelec-linux-gnueabihf-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -3241,7 +3241,6 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Chips&Media media platform drivers
 #
-# CONFIG_VIDEO_E5010_JPEG_ENC is not set
 
 #
 # Intel media platform drivers
@@ -3278,7 +3277,6 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
-# CONFIG_VIDEO_RASPBERRYPI_PISP_BE is not set
 
 #
 # Renesas media platform drivers
@@ -6139,6 +6137,9 @@ CONFIG_KEYS=y
 # CONFIG_ENCRYPTED_KEYS is not set
 CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_SECURITY_DMESG_RESTRICT is not set
+CONFIG_PROC_MEM_ALWAYS_FORCE=y
+# CONFIG_PROC_MEM_FORCE_PTRACE is not set
+# CONFIG_PROC_MEM_NO_FORCE is not set
 # CONFIG_SECURITY is not set
 CONFIG_SECURITYFS=y
 # CONFIG_HARDENED_USERCOPY is not set


### PR DESCRIPTION
### packages updated
- linux: update to 6.11.x
- iwlwifi-firmware: update to githash f87fe97

### 6.11.x mainline kernel update
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.11.1
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.11.2
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.11.3
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.11.4

6.11.1 - 12 patches
6.11.2 - 695 patches
6.11.3 - 558 patches
6.11.4 - 212 patches

 
### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.11.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.11.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.11
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/

### 6.11.4 Build tested on all of:
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.11.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel ADL - NUC12) - TBA - heitbaum
- Generic Generic (AMD 7840HS - SER7) - TBA - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- NXP iMX6 (Coral Dev Board - Phanbell) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum