### PR TITLE
build/curl: error when 400 series status code received on download

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -23,7 +23,7 @@ pkg_lock_status "GETPKG" "${PKG_NAME}" "unpack" "downloading package..."
 PACKAGE_MIRROR="${DISTRO_MIRROR}/${PKG_NAME}/${PKG_SOURCE_NAME}"
 
 [ "${VERBOSE}" != "yes" ] && GET_OPT="--silent --show-error"
-GET_CMD="curl ${GET_OPT} --connect-timeout 30 --retry 3 --continue-at - --location --max-redirs 5 --output ${PACKAGE}"
+GET_CMD="curl ${GET_OPT} --fail --connect-timeout 30 --retry 3 --continue-at - --location --max-redirs 5 --output ${PACKAGE}"
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
 unset LD_LIBRARY_PATH

--- a/tools/distro-tool
+++ b/tools/distro-tool
@@ -357,7 +357,7 @@ class MyUtility(object):
     while attempts < retries:
       if stopped.is_set(): break
       attempts += 1
-      (result, output) = MyUtility.runcommand(msgs, f"curl --silent --show-error --connect-timeout 30 --retry 3 --continue-at - --location --max-redirs 5 --output {filename_data} {url}", logfile=filename_log)
+      (result, output) = MyUtility.runcommand(msgs, f"curl --silent --show-error --fail --connect-timeout 30 --retry 3 --continue-at - --location --max-redirs 5 --output {filename_data} {url}", logfile=filename_log)
       if result == 0:
         return True
 


### PR DESCRIPTION
See https://github.com/LibreELEC/LibreELEC.tv/pull/9347#issuecomment-2423525708

Default downloads the error page instead of giving an error.