### PR TITLE
Revert "elfutils: update to 0.192"

### DIFF
--- a/packages/devel/elfutils/package.mk
+++ b/packages/devel/elfutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="elfutils"
-PKG_VERSION="0.192"
-PKG_SHA256="616099beae24aba11f9b63d86ca6cc8d566d968b802391334c91df54eab416b4"
+PKG_VERSION="0.191"
+PKG_SHA256="df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871"
 PKG_LICENSE="GPL"
 PKG_SITE="https://sourceware.org/elfutils/"
 PKG_URL="https://sourceware.org/elfutils/ftp/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/elfutils/patches/elfutils-002-libdw--Don-t-use-INTUSE-in-libdwP-h-str_offsets_base_off.patch
+++ b/packages/devel/elfutils/patches/elfutils-002-libdw--Don-t-use-INTUSE-in-libdwP-h-str_offsets_base_off.patch
@@ -1,0 +1,37 @@
+From: Mark Wielaard <mark@klomp.org>
+Date: Sat, 2 Mar 2024 23:45:34 +0000 (+0100)
+Subject: libdw: Don't use INTUSE in libdwP.h str_offsets_base_off
+X-Git-Url: https://sourceware.org/git/?p=elfutils.git;a=commitdiff_plain;h=7cf4586e5b429c0fa74d3ae73f49e6cda6660e93;hp=18a015c0b0787ba5acb39801ab7c17dac50f584d
+
+libdw: Don't use INTUSE in libdwP.h str_offsets_base_off
+
+readelf.c cheats and include libdwP.h, which is an internal only
+header of libdw. It really shouldn't do that, but there are some
+internals that readelf currently needs. The str_offsets_base_off
+function used by readelf uses INTUSE when calling dwarf_get_units.
+This is a micro optimization useful inside libdw so a public
+function can be called directly, skipping a PLT call. This can
+cause issues linking readelf since it might not be able to call
+the internal function, since readelf.c isn't part of libdw itself.
+Just drop the INTUSE.
+
+	* libdw/libdwP.h (str_offsets_base_off): Don't use INTUSE
+	when calling dwarf_get_units.
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+---
+
+diff --git a/libdw/libdwP.h b/libdw/libdwP.h
+index 8b2f06fa5..c1c84ed35 100644
+--- a/libdw/libdwP.h
++++ b/libdw/libdwP.h
+@@ -1153,8 +1153,7 @@ str_offsets_base_off (Dwarf *dbg, Dwarf_CU *cu)
+   if (cu == NULL && dbg != NULL)
+     {
+       Dwarf_CU *first_cu;
+-      if (INTUSE(dwarf_get_units) (dbg, NULL, &first_cu,
+-				   NULL, NULL, NULL, NULL) == 0)
++      if (dwarf_get_units (dbg, NULL, &first_cu, NULL, NULL, NULL, NULL) == 0)
+ 	cu = first_cu;
+     }
+ 


### PR DESCRIPTION
This reverts commit d393833d053c9bc4775765b22c2220977e26ae30.

Builds failing across arch - (eu code)
```
/build/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libelf.a(elf_begin.o):elf_begin.c:function file_read_elf:(.text+0x38b): error: undefined reference to 'eu_search_tree_init'
/build/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libelf.a(elf_begin.o):elf_begin.c:function file_read_elf:(.text+0x4cb): error: undefined reference to 'eu_search_tree_init'
/build/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libelf.a(elf_end.o):elf_end.c:function elf_end:(.text+0xb0): error: undefined reference to 'eu_search_tree_fini'
``` 