### PR TITLE
iwd: update to 3.0

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="2.22"
-PKG_SHA256="2c41c5da9924b90f8383b293b0c0b3d0bfb34fdc8822d8d0d37ec100707f263e"
+PKG_VERSION="3.0"
+PKG_SHA256="bd167ab368b6ba302b6c948a4f41f02d233a12e20d5094b1c0393325309f8a60"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Log
- https://git.kernel.org/pub/scm/network/wireless/iwd.git/
- ver 3.0:
  +	Fix issue with handling alpha2 code for United Kingdom.
  +	Fix issue with handling empty TX/RX bitrate attributes.
  +	Fix issue with handling RSSI polling fallback workaround.
  +	Fix issue with handling harmless cloned information elements.
  +	Add experimental support for External Authentication feature.