### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="835b10a5c4e4bd205bdae99a3683cbac711def9594eb5ff6e9874d7c8db1fd26"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="579a62df16ad2db681ae3e7a90f66cc53944f5b500d2fa73cec7fb244c2e84ad"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.argustv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="22.3.0-Piers"
-PKG_SHA256="d9b74805de9078ba852ca9eb617d924a95269279da458b1ebbb3f80fa7e3ede1"
-PKG_REV="2"
+PKG_VERSION="22.4.0-Piers"
+PKG_SHA256="24caa810bb2148effbac08639f1ca6a023cf9ea3c7d0e2e432e10f314201bbbc"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.demo"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvblink"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="6b52f6020c1bfd48198e461e85f9d6496ab56a43f51621244e6973290b2d3bf9"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="1f932ea98fc3e21481e2f6724ea85a211788044f3b7a0cc925d87f994af4a185"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.dvblink"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvbviewer"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="2dd0ff7ad301581b8f55be9bb43cb3493fdc2722f2aae0745427fb00943341f3"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="b5ebbd6ecfd8da04b310cb5f6e44850d4a3de4cbd62c9924e1b3510daa99da2e"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.dvbviewer"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.filmon"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="93f19dde2c438292ffba2da8883706609d94fbe21a090988940f846b94d064b1"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="77a12f0b1fe1ca0b1f2e5cd5c66452a60bde1c09d0dbb6ddd741dc1a4b99d4a0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.filmon"

--- a/packages/mediacenter/kodi-binary-addons/pvr.freebox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.freebox/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.freebox"
-PKG_VERSION="22.1.0.1-Piers"
-PKG_SHA256="b4907e7e4af47222242d97d808823e908e1c9bd5c46ecfc919565517020b4f02"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="400829cfdbaaf5c98aff602cfb84837e5ea0680b9365a3b32235ab280c53c7ef"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/aassif/pvr.freebox"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hdhomerun"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="d50781bc2d487cf6625d39f7013f97ce9cd69320025a63dc30ffc4f0b689d857"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="e38b343f71754d67115eaa78016428cf1d4822e211ff82baffb662e9a54cbff3"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hdhomerun"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="22.4.2-Piers"
-PKG_SHA256="495bdb27beda9d47cbb91d10fd01b4560432c6ff6af0e9ae21c22890c86ba01f"
+PKG_VERSION="22.5.0-Piers"
+PKG_SHA256="e4983c2a7fe2729faba71eb42a63fa4612f175f598fa1c8a677ae36da4298a13"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="22.2.2-Piers"
-PKG_SHA256="9f8e3ab1d83c94db063b1642ef2ac15d1d1964b6b3d4a9c0d1844c47e210bf6b"
+PKG_VERSION="22.3.0-Piers"
+PKG_SHA256="960d790aac995bf3521a15036ff29eae4c44b93afa3f1dc275ae7a297f709b45"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="22.1.1-Piers"
-PKG_SHA256="af8a0528552b7890b0a64dd654fb3d17dd8caf8ed52d0a9b961c5d00237af191"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="9866496f00db03bb1f4ce816151c9d46060a26ba8a862c950a9c860f08b9b51b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="9a70c4fbf046512dea31f4883c791028879e898768145c23f7fbf9e4b0e4ec37"
+PKG_VERSION="22.3.0-Piers"
+PKG_SHA256="087f994adab946d0e398c35cccd2f5e6951767372b23c0a220ef6d90664e614f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.njoy"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="11e8e187cd9747c49124add495fb53cb79a14ca03b4b0a2b78fb9799555cf937"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="ba117de0150ab8de5af8b65c57083808a4b4a556168c7ac0509bffc37144671a"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.njoy"

--- a/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.octonet"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="88e386a4f845fadc49b871121c9469c0b5766e88551438f53251cda9820efc64"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="ccd00a4d1f6683ba6d418bd75c1e8c2b50b7ae794abb1625548fea36aebdcc31"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/DigitalDevices/pvr.octonet"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.pctv"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="a6fb959dad55a6559896410fcd1b821768368b9bed20ee5bea0bab4bfd71747c"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="3d84929f6fedfb2fffe55034a042f4d9db27e76e0e58b9a078a15cae8a02a50d"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.pctv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.plutotv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.plutotv/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.plutotv"
-PKG_VERSION="22.1.1-Piers"
-PKG_SHA256="c7627b9cd525f97a3173cd0be458236edc7bedc5cc82b3dd9e6b9bbae09436c0"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="e84add7bef9f8edf4ca032785d657ef5054db9e813e51ceb6868fb92c6b5bfc7"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.plutotv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.sledovanitv.cz"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="db9706e98ae2821497e8a65c4c64e6f8bb78e30d1b808c0cad669ce87618c6e7"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="65d6ec16a2984937bad17511f47547e4f14fb1256ac86103437f3d164e5f358e"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/palinek/pvr.sledovanitv.cz"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="2f2567f90235702bbf3be2e7646e1c2c6c49d70a6b1035fe0c5d80cfa26b59cd"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="58423b65d63c36a50f3b0f63166b1a820a45c86defe4425efefff4a31989848e"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.stalker"

--- a/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.teleboy"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="dcf727c7b577a1dafb8beaf4c35a3e3e25a3db4fcb762f880d05356dc098b0a4"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="11bdf3b64618d5b8f9dfbfb91194350ebfb62d8be6c36c372e39b32f48a9dcd8"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rbuehlma/pvr.teleboy"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vbox"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="47c7bba536999d8d0d014daf78e01bd0991770109a256cca81156702145863ae"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="5a5f8fe89cb4ca73694b15226264eceb39b96e9ee5379e1d613870134d67fe17"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vbox"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="3818e9a45eeb6972b93cee979e44091e0024a4185e1eacbdfa5fabfe75a6d12a"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="82f02e463ad44460b3a7bed775dff8ea89f52fcc9de5ea5a453cb5db443e7597"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vdr.vnsi"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="103e6b61b95db9b2500157802deaf130c152e915868f15daab339a097c811fb3"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="12d79faf0050e5a3df9ea3bdd290002bb8d617a442c053423881b8a7fa29d5db"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.vuplus"

--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.waipu"
-PKG_VERSION="22.1.1-Piers"
-PKG_SHA256="bef8e4ca1dd1f75903511544668fcd11cdd454ea7bf54466c4ad9f376ebad9d6"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="ffad8562d947889afe6a78b4c2036cce47f70363cab045282bf06eab63b9e173"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="dca63cde42a57297f5dcf32f595c7f59e1b1dabe358d8851c292aaaf667421ae"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="a0409f319589ec00eafe363f7284261b7fd4d80677ba079d1d5dc0ff7165e3ae"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.wmc"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="22.1.0-Piers"
-PKG_SHA256="830bd9d95392cd5b28b8d4bb672ea5ce2e71caa1b315fbf605c1b9e8965dd3c8"
-PKG_REV="2"
+PKG_VERSION="22.2.0-Piers"
+PKG_SHA256="a6c1d19acc69142fe4ddc0bc186c5aa371d8e43820b56300c72b2ff6644a7e43"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rbuehlma/pvr.zattoo"


### PR DESCRIPTION
- pvr.argustv: update 22.1.0-Piers to 22.2.0-Piers
- pvr.demo: update 22.3.0-Piers to 22.4.0-Piers
- pvr.dvblink: update 22.1.0-Piers to 22.2.0-Piers
- pvr.dvbviewer: update 22.1.0-Piers to 22.2.0-Piers
- pvr.filmon: update 22.1.0-Piers to 22.2.0-Piers
- pvr.freebox: update 22.1.0.1-Piers to 22.2.0-Piers
- pvr.hdhomerun: update 22.1.0-Piers to 22.2.0-Piers
- pvr.hts: update 22.4.2-Piers to 22.5.0-Piers
- pvr.iptvsimple: update 22.2.2-Piers to 22.3.0-Piers
- pvr.mediaportal.tvserver: update 22.1.1-Piers to 22.2.0-Piers
- pvr.nextpvr: update 22.2.0-Piers to 22.3.0-Piers
- pvr.njoy: update 22.1.0-Piers to 22.2.0-Piers
- pvr.octonet: update 22.1.0-Piers to 22.2.0-Piers
- pvr.pctv: update 22.1.0-Piers to 22.2.0-Piers
- pvr.plutotv: update 22.1.1-Piers to 22.2.0-Piers
- pvr.sledovanitv.cz: update 22.1.0-Piers to 22.2.0-Piers
- pvr.stalker: update 22.1.0-Piers to 22.2.0-Piers
- pvr.teleboy: update 22.1.0-Piers to 22.2.0-Piers
- pvr.vbox: update 22.1.0-Piers to 22.2.0-Piers
- pvr.vdr.vnsi: update 22.1.0-Piers to 22.2.0-Piers
- pvr.vuplus: update 22.1.0-Piers to 22.2.0-Piers
- pvr.waipu: update 22.1.1-Piers to 22.2.0-Piers
- pvr.wmc: update 22.1.0-Piers to 22.2.0-Piers
- pvr.zattoo: update 22.1.0-Piers to 22.2.0-Piers