### PR TITLE
[le12] Addon updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="e60fddb2bd2b4e19790d26b786c930e70fa935168373ef08055f74bbc450bce8"
+PKG_SHA256="df7d44387166d90954e290dfbe0a278649bf71d0e89933615bdc0757580b68e4"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="d01f264bccd8bed2e3c038054a04b99533478ab8"
+export PKG_GIT_COMMIT="ce1223035ac3ab8922717092e63a184cf67b493d"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="1.7.20"
-PKG_SHA256="c4268561e514a2e8322bc8cdd39113d5e164fb31c2cef76f479d683395ea9bd6"
+PKG_VERSION="1.7.23"
+PKG_SHA256="393bfde8ca1766a0bca3441e18eddc3f5a5c8d97ef676bde0d6c9903e1b0ec0c"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="8fc6bcff51318944179630522a095cc9dbf9f353"
+export PKG_GIT_COMMIT="57f17b0a6295a39009d861b89e3b3b87b005ca27"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="27.1.2"
-PKG_SHA256="8c9b5fa44f0272726484c925d4d05f0aa189053ed8be9b27447bc116df1e99c9"
+PKG_VERSION="27.3.1"
+PKG_SHA256="d18208d9e0b6421307342cdef266193984c97c87177b9262b1113e6e9e7e020e"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="f9522e5e96c3ab5a6b8a643d15a92700ca864da6"
+export PKG_GIT_COMMIT="41ca978a0a5400cc24b274137efa9f25517fcc0b"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/docker/moby/patches/moby-001-user-addon-storage-location.patch
+++ b/packages/addons/addon-depends/docker/moby/patches/moby-001-user-addon-storage-location.patch
@@ -4,8 +4,8 @@
 #
 #
 diff -Naur a/cmd/dockerd/daemon_unix.go b/cmd/dockerd/daemon_unix.go
---- a/cmd/dockerd/daemon_unix.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/cmd/dockerd/daemon_unix.go	2024-01-06 03:43:42.144311172 +0000
+--- a/cmd/dockerd/daemon_unix.go	2024-09-06 09:57:40.000000000 +0000
++++ b/cmd/dockerd/daemon_unix.go	2024-09-10 06:47:41.951753985 +0000
 @@ -23,7 +23,7 @@
  
  func getDefaultDaemonConfigDir() (string, error) {
@@ -16,8 +16,8 @@ diff -Naur a/cmd/dockerd/daemon_unix.go b/cmd/dockerd/daemon_unix.go
  	// NOTE: CLI uses ~/.docker while the daemon uses ~/.config/docker, because
  	// ~/.docker was not designed to store daemon configurations.
 diff -Naur a/cmd/dockerd/options.go b/cmd/dockerd/options.go
---- a/cmd/dockerd/options.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/cmd/dockerd/options.go	2024-01-06 03:43:42.144311172 +0000
+--- a/cmd/dockerd/options.go	2024-09-06 09:57:40.000000000 +0000
++++ b/cmd/dockerd/options.go	2024-09-10 06:47:41.951753985 +0000
 @@ -39,7 +39,7 @@
  	//
  	//   - DOCKER_CONFIG only affects TLS certificates, but does not change the
@@ -37,8 +37,8 @@ diff -Naur a/cmd/dockerd/options.go b/cmd/dockerd/options.go
  	//     needed for rootless, but perhaps could be used for non-rootless(?)
  	//   - When changing  the location for TLS config, (ideally) they should
 diff -Naur a/integration/plugin/authz/authz_plugin_test.go b/integration/plugin/authz/authz_plugin_test.go
---- a/integration/plugin/authz/authz_plugin_test.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/integration/plugin/authz/authz_plugin_test.go	2024-01-06 03:43:42.100977532 +0000
+--- a/integration/plugin/authz/authz_plugin_test.go	2024-09-06 09:57:40.000000000 +0000
++++ b/integration/plugin/authz/authz_plugin_test.go	2024-09-10 06:47:41.908420295 +0000
 @@ -56,15 +56,15 @@
  
  	ctrl = &authorizationController{}
@@ -59,9 +59,9 @@ diff -Naur a/integration/plugin/authz/authz_plugin_test.go b/integration/plugin/
  		ctrl = nil
  	})
 diff -Naur a/integration/plugin/graphdriver/external_test.go b/integration/plugin/graphdriver/external_test.go
---- a/integration/plugin/graphdriver/external_test.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/integration/plugin/graphdriver/external_test.go	2024-01-06 03:43:42.100977532 +0000
-@@ -87,7 +87,7 @@
+--- a/integration/plugin/graphdriver/external_test.go	2024-09-06 09:57:40.000000000 +0000
++++ b/integration/plugin/graphdriver/external_test.go	2024-09-10 06:47:41.908420295 +0000
+@@ -88,7 +88,7 @@
  
  	sserver.Close()
  	jserver.Close()
@@ -70,7 +70,7 @@ diff -Naur a/integration/plugin/graphdriver/external_test.go b/integration/plugi
  	assert.NilError(t, err)
  }
  
-@@ -351,10 +351,10 @@
+@@ -352,10 +352,10 @@
  		respond(w, &graphDriverResponse{Size: size})
  	})
  
@@ -84,8 +84,8 @@ diff -Naur a/integration/plugin/graphdriver/external_test.go b/integration/plugi
  	assert.NilError(t, err)
  }
 diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integration-cli/docker_cli_external_volume_driver_test.go
---- a/integration-cli/docker_cli_external_volume_driver_test.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/integration-cli/docker_cli_external_volume_driver_test.go	2024-01-06 03:43:42.487646940 +0000
+--- a/integration-cli/docker_cli_external_volume_driver_test.go	2024-09-06 09:57:40.000000000 +0000
++++ b/integration-cli/docker_cli_external_volume_driver_test.go	2024-09-10 06:47:42.278423345 +0000
 @@ -262,10 +262,10 @@
  		send(w, `{"Capabilities": { "Scope": "global" }}`)
  	})
@@ -118,27 +118,27 @@ diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integra
  	assert.NilError(c, err)
  	defer os.RemoveAll(specPath)
 diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/docker_cli_network_unix_test.go
---- a/integration-cli/docker_cli_network_unix_test.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/integration-cli/docker_cli_network_unix_test.go	2024-01-06 03:43:42.487646940 +0000
-@@ -201,14 +201,14 @@
+--- a/integration-cli/docker_cli_network_unix_test.go	2024-09-06 09:57:40.000000000 +0000
++++ b/integration-cli/docker_cli_network_unix_test.go	2024-09-10 06:47:42.278423345 +0000
+@@ -225,14 +225,14 @@
  		}
  	})
  
 -	err := os.MkdirAll("/etc/docker/plugins", 0o755)
 +	err := os.MkdirAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", 0o755)
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  
 -	fileName := fmt.Sprintf("/etc/docker/plugins/%s.spec", netDrv)
 +	fileName := fmt.Sprintf("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/%s.spec", netDrv)
  	err = os.WriteFile(fileName, []byte(url), 0o644)
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  
 -	ipamFileName := fmt.Sprintf("/etc/docker/plugins/%s.spec", ipamDrv)
 +	ipamFileName := fmt.Sprintf("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/%s.spec", ipamDrv)
  	err = os.WriteFile(ipamFileName, []byte(url), 0o644)
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  }
-@@ -220,7 +220,7 @@
+@@ -244,7 +244,7 @@
  
  	s.server.Close()
  
@@ -148,27 +148,27 @@ diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/d
  }
  
 diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_cli_swarm_test.go
---- a/integration-cli/docker_cli_swarm_test.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/integration-cli/docker_cli_swarm_test.go	2024-01-06 03:43:42.494313654 +0000
-@@ -793,14 +793,14 @@
+--- a/integration-cli/docker_cli_swarm_test.go	2024-09-06 09:57:40.000000000 +0000
++++ b/integration-cli/docker_cli_swarm_test.go	2024-09-10 06:47:42.281756705 +0000
+@@ -823,14 +823,14 @@
  		}
  	})
  
 -	err := os.MkdirAll("/etc/docker/plugins", 0o755)
 +	err := os.MkdirAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", 0o755)
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  
 -	fileName := fmt.Sprintf("/etc/docker/plugins/%s.spec", netDrv)
 +	fileName := fmt.Sprintf("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/%s.spec", netDrv)
  	err = os.WriteFile(fileName, []byte(url), 0o644)
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  
 -	ipamFileName := fmt.Sprintf("/etc/docker/plugins/%s.spec", ipamDrv)
 +	ipamFileName := fmt.Sprintf("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/%s.spec", ipamDrv)
  	err = os.WriteFile(ipamFileName, []byte(url), 0o644)
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  }
-@@ -813,7 +813,7 @@
+@@ -843,7 +843,7 @@
  	setupRemoteGlobalNetworkPlugin(c, mux, s.server.URL, globalNetworkPlugin, globalIPAMPlugin)
  	defer func() {
  		s.server.Close()
@@ -178,9 +178,9 @@ diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_c
  	}()
  
 diff -Naur a/libnetwork/drivers/remote/driver_test.go b/libnetwork/drivers/remote/driver_test.go
---- a/libnetwork/drivers/remote/driver_test.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/libnetwork/drivers/remote/driver_test.go	2024-01-06 03:43:42.480980226 +0000
-@@ -41,7 +41,7 @@
+--- a/libnetwork/drivers/remote/driver_test.go	2024-09-06 09:57:40.000000000 +0000
++++ b/libnetwork/drivers/remote/driver_test.go	2024-09-10 06:47:42.268423262 +0000
+@@ -42,7 +42,7 @@
  }
  
  func setupPlugin(t *testing.T, name string, mux *http.ServeMux) func() {
@@ -190,9 +190,9 @@ diff -Naur a/libnetwork/drivers/remote/driver_test.go b/libnetwork/drivers/remot
  		specPath = filepath.Join(os.Getenv("programdata"), "docker", "plugins")
  	}
 diff -Naur a/libnetwork/ipams/remote/remote_test.go b/libnetwork/ipams/remote/remote_test.go
---- a/libnetwork/ipams/remote/remote_test.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/libnetwork/ipams/remote/remote_test.go	2024-01-06 03:43:42.470980156 +0000
-@@ -36,7 +36,7 @@
+--- a/libnetwork/ipams/remote/remote_test.go	2024-09-06 09:57:40.000000000 +0000
++++ b/libnetwork/ipams/remote/remote_test.go	2024-09-10 06:47:42.261756541 +0000
+@@ -38,7 +38,7 @@
  }
  
  func setupPlugin(t *testing.T, name string, mux *http.ServeMux) func() {
@@ -202,8 +202,8 @@ diff -Naur a/libnetwork/ipams/remote/remote_test.go b/libnetwork/ipams/remote/re
  		specPath = filepath.Join(os.Getenv("programdata"), "docker", "plugins")
  	}
 diff -Naur a/libnetwork/libnetwork_unix_test.go b/libnetwork/libnetwork_unix_test.go
---- a/libnetwork/libnetwork_unix_test.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/libnetwork/libnetwork_unix_test.go	2024-01-06 03:43:42.484313584 +0000
+--- a/libnetwork/libnetwork_unix_test.go	2024-09-06 09:57:40.000000000 +0000
++++ b/libnetwork/libnetwork_unix_test.go	2024-09-10 06:47:42.271756623 +0000
 @@ -2,4 +2,4 @@
  
  package libnetwork_test
@@ -211,9 +211,9 @@ diff -Naur a/libnetwork/libnetwork_unix_test.go b/libnetwork/libnetwork_unix_tes
 -var specPath = "/etc/docker/plugins"
 +var specPath = "/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins"
 diff -Naur a/pkg/plugins/discovery.go b/pkg/plugins/discovery.go
---- a/pkg/plugins/discovery.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/pkg/plugins/discovery.go	2024-01-06 03:43:42.107644246 +0000
-@@ -120,12 +120,12 @@
+--- a/pkg/plugins/discovery.go	2024-09-06 09:57:40.000000000 +0000
++++ b/pkg/plugins/discovery.go	2024-09-10 06:47:41.915087017 +0000
+@@ -128,12 +128,12 @@
  //
  // On Unix in non-rootless mode:
  //
@@ -229,8 +229,8 @@ diff -Naur a/pkg/plugins/discovery.go b/pkg/plugins/discovery.go
  func SpecsPaths() []string {
  	return specsPaths()
 diff -Naur a/pkg/plugins/discovery_unix.go b/pkg/plugins/discovery_unix.go
---- a/pkg/plugins/discovery_unix.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/pkg/plugins/discovery_unix.go	2024-01-06 03:43:42.107644246 +0000
+--- a/pkg/plugins/discovery_unix.go	2024-09-06 09:57:40.000000000 +0000
++++ b/pkg/plugins/discovery_unix.go	2024-09-10 06:47:41.915087017 +0000
 @@ -12,7 +12,7 @@
  	if configHome, err := homedir.GetConfigHome(); err != nil {
  		return filepath.Join(configHome, "docker/plugins")
@@ -248,8 +248,8 @@ diff -Naur a/pkg/plugins/discovery_unix.go b/pkg/plugins/discovery_unix.go
 +	return []string{"/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", "/usr/lib/docker/plugins"}
  }
 diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
---- a/pkg/plugins/plugins.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/pkg/plugins/plugins.go	2024-01-06 03:43:42.107644246 +0000
+--- a/pkg/plugins/plugins.go	2024-09-06 09:57:40.000000000 +0000
++++ b/pkg/plugins/plugins.go	2024-09-10 06:47:41.915087017 +0000
 @@ -4,7 +4,7 @@
  // Docker discovers plugins by looking for them in the plugin directory whenever
  // a user or container tries to use one by name. UNIX domain socket files must
@@ -260,8 +260,8 @@ diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
  // its name if it exists.
  //
 diff -Naur a/registry/config_unix.go b/registry/config_unix.go
---- a/registry/config_unix.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/registry/config_unix.go	2024-01-06 03:43:42.487646940 +0000
+--- a/registry/config_unix.go	2024-09-06 09:57:40.000000000 +0000
++++ b/registry/config_unix.go	2024-09-10 06:47:42.275089984 +0000
 @@ -5,7 +5,7 @@
  // defaultCertsDir is the platform-specific default directory where certificates
  // are stored. On Linux, it may be overridden through certsDir, for example, when
@@ -272,8 +272,8 @@ diff -Naur a/registry/config_unix.go b/registry/config_unix.go
  // cleanPath is used to ensure that a directory name is valid on the target
  // platform. It will be passed in something *similar* to a URL such as
 diff -Naur a/registry/search_endpoint_v1.go b/registry/search_endpoint_v1.go
---- a/registry/search_endpoint_v1.go	2024-01-04 15:38:22.000000000 +0000
-+++ b/registry/search_endpoint_v1.go	2024-01-06 03:43:42.487646940 +0000
+--- a/registry/search_endpoint_v1.go	2024-09-06 09:57:40.000000000 +0000
++++ b/registry/search_endpoint_v1.go	2024-09-10 06:47:42.278423345 +0000
 @@ -54,7 +54,7 @@
  		if endpoint.IsSecure {
  			// If registry is secure and HTTPS failed, show user the error and tell them about `--insecure-registry`

--- a/packages/addons/addon-depends/ffmpegx-depends/x264/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x264/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="x264"
-PKG_VERSION="7ed753b10a61d0be95f683289dfb925b800b0676"
-PKG_SHA256="1bdf238ef065e711c4cf436046917de4a7a3e920a0b0ae1fa0f528ab23f17b12"
+PKG_VERSION="4613ac3c15fd75cebc4b9f65b7fb95e70a3acce1"
+PKG_SHA256="2a1b197fd1fbc85045794f18c9353648a9ae3cbe194b7b92d523d096f9445464"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.videolan.org/developers/x264.html"
 PKG_URL="https://code.videolan.org/videolan/x264/-/archive/${PKG_VERSION}/x264-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="x265"
-PKG_VERSION="3.6"
-PKG_SHA256="eccd9ee41ba64c55bb906ea79d28b563fdfb4fd3b7626746a0e5f8c9581491b5"
+PKG_VERSION="4.0"
+PKG_SHA256="a5b6b1176a6cbf6905cdc3fcc464d6bc626cb72ea886751e8fe445f85aa5e386"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.videolan.org/developers/x265.html"

--- a/packages/addons/addon-depends/ffmpegx/patches/ffmpeg-03-lavc-libx265--unbreak-build-for-X265-BUILD---210.patch
+++ b/packages/addons/addon-depends/ffmpegx/patches/ffmpeg-03-lavc-libx265--unbreak-build-for-X265-BUILD---210.patch
@@ -1,0 +1,96 @@
+From 1f801dfdb5066aadf0ade9cb5e94d620f33eacdc Mon Sep 17 00:00:00 2001
+From: Gyan Doshi <ffmpeg@gyani.pro>
+Date: Sun, 11 Aug 2024 12:51:50 +0530
+Subject: [PATCH] lavc/libx265: unbreak build for X265_BUILD >= 210
+
+x265 added support for alpha starting with build 210.
+While doing so, x265_encoder_encode() changed its fifth arg to
+an array of pointers to x265_picture. This broke building lavc/libx265.c
+
+This patch simply unbreaks the build and maintains existing single-layer
+non-alpha encoding support.
+
+Fixes #11130
+---
+ libavcodec/libx265.c | 40 ++++++++++++++++++++++++++++++----------
+ 1 file changed, 30 insertions(+), 10 deletions(-)
+
+diff --git a/libavcodec/libx265.c b/libavcodec/libx265.c
+index 0dc7ab6eeb6a3..3bc3b5a03e9fc 100644
+--- a/libavcodec/libx265.c
++++ b/libavcodec/libx265.c
+@@ -661,7 +661,13 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
+ {
+     libx265Context *ctx = avctx->priv_data;
+     x265_picture x265pic;
+-    x265_picture x265pic_out = { 0 };
++#if X265_BUILD >= 210
++    x265_picture x265pic_layers_out[MAX_SCALABLE_LAYERS];
++    x265_picture* x265pic_lyrptr_out[MAX_SCALABLE_LAYERS];
++#else
++    x265_picture x265pic_solo_out = { 0 };
++#endif
++    x265_picture* x265pic_out;
+     x265_nal *nal;
+     x265_sei *sei;
+     uint8_t *dst;
+@@ -798,8 +804,16 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
+ #endif
+     }
+ 
++#if X265_BUILD >= 210
++    for (i = 0; i < MAX_SCALABLE_LAYERS; i++)
++        x265pic_lyrptr_out[i] = &x265pic_layers_out[i];
++
++    ret = ctx->api->encoder_encode(ctx->encoder, &nal, &nnal,
++                                   pic ? &x265pic : NULL, x265pic_lyrptr_out);
++#else
+     ret = ctx->api->encoder_encode(ctx->encoder, &nal, &nnal,
+-                                   pic ? &x265pic : NULL, &x265pic_out);
++                                   pic ? &x265pic : NULL, &x265pic_solo_out);
++#endif
+ 
+     for (i = 0; i < sei->numPayloads; i++)
+         av_free(sei->payloads[i].payload);
+@@ -829,10 +843,16 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
+             pkt->flags |= AV_PKT_FLAG_KEY;
+     }
+ 
+-    pkt->pts = x265pic_out.pts;
+-    pkt->dts = x265pic_out.dts;
++#if X265_BUILD >= 210
++    x265pic_out = x265pic_lyrptr_out[0];
++#else
++    x265pic_out = &x265pic_solo_out;
++#endif
++
++    pkt->pts = x265pic_out->pts;
++    pkt->dts = x265pic_out->dts;
+ 
+-    switch (x265pic_out.sliceType) {
++    switch (x265pic_out->sliceType) {
+     case X265_TYPE_IDR:
+     case X265_TYPE_I:
+         pict_type = AV_PICTURE_TYPE_I;
+@@ -850,16 +870,16 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
+     }
+ 
+ #if X265_BUILD >= 130
+-    if (x265pic_out.sliceType == X265_TYPE_B)
++    if (x265pic_out->sliceType == X265_TYPE_B)
+ #else
+-    if (x265pic_out.frameData.sliceType == 'b')
++    if (x265pic_out->frameData.sliceType == 'b')
+ #endif
+         pkt->flags |= AV_PKT_FLAG_DISPOSABLE;
+ 
+-    ff_side_data_set_encoder_stats(pkt, x265pic_out.frameData.qp * FF_QP2LAMBDA, NULL, 0, pict_type);
++    ff_side_data_set_encoder_stats(pkt, x265pic_out->frameData.qp * FF_QP2LAMBDA, NULL, 0, pict_type);
+ 
+-    if (x265pic_out.userData) {
+-        int idx = (int)(intptr_t)x265pic_out.userData - 1;
++    if (x265pic_out->userData) {
++        int idx = (int)(intptr_t)x265pic_out->userData - 1;
+         ReorderedData *rd = &ctx->rd[idx];
+ 
+         pkt->duration           = rd->duration;

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.22.6"
-PKG_SHA256="71cbf4f555da51df93f71b1726c69f2e80f62bbe2e7ce1c5c39c3d57fa385b14"
+PKG_VERSION="1.23.2"
+PKG_SHA256="fc3448a68fca887ceb0e0d4357d0ecd05d54a78e052f8667b283e745c87e7f2e"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
+++ b/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="apache-ant"
-PKG_VERSION="1.10.14"
-PKG_SHA256="a0456ecbf934b41dca74747413f2da7eafe40355fbdf5bfd38d8f3713dd828cd"
+PKG_VERSION="1.10.15"
+PKG_SHA256="4d5bb20cee34afbad17782de61f4f422c5a03e4d2dffc503bcbd0651c3d3c396"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://ant.apache.org/"
 PKG_URL="https://archive.apache.org/dist/ant/binaries/${PKG_NAME}-${PKG_VERSION}-bin.tar.xz"

--- a/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libpcap"
-PKG_VERSION="1.10.4"
-PKG_SHA256="ed19a0383fad72e3ad435fd239d7cd80d64916b87269550159d20e47160ebe5f"
+PKG_VERSION="1.10.5"
+PKG_SHA256="37ced90a19a302a7f32e458224a00c365c117905c2cd35ac544b6880a81488f0"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.tcpdump.org/"
 PKG_URL="https://www.tcpdump.org/release/libpcap-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/tcpdump/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tcpdump"
-PKG_VERSION="4.99.4"
-PKG_SHA256="0232231bb2f29d6bf2426e70a08a7e0c63a0d59a9b44863b7f5e2357a6e49fea"
+PKG_VERSION="4.99.5"
+PKG_SHA256="8c75856e00addeeadf70dad67c9ff3dd368536b2b8563abf6854d7c764cd3adb"
 PKG_SITE="https://www.tcpdump.org/"
 PKG_URL="https://www.tcpdump.org/release/tcpdump-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libpcap libtirpc"

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.1.13"
-PKG_SHA256="789d5749a08ef1fbe5d1999b67883206a68a4e58e6ca0151c411d678f3480b25"
+PKG_VERSION="1.2.0"
+PKG_SHA256="25072beb84f4adae316a968241dc74ac30982d38e4459635074aa9e9d87d3de7"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-export PKG_GIT_COMMIT="58aa9203c123022138b22cf96540c284876a7910"
+export PKG_GIT_COMMIT="0b9fa21be2bcba45f6d9d748b4bcf70cfbffbc19"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/addon-depends/system-tools-depends/pv/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/pv/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pv"
-PKG_VERSION="1.8.13"
-PKG_SHA256="e2bde058d0d3bfe03e60a6eedef6a179991f5cc698d1bac01b64a86f5a8c17af"
+PKG_VERSION="1.8.14"
+PKG_SHA256="0cc18811a4809a587d4b11d47691bbc0ad83a5d95d2c2606af74ea7b4a674756"
 PKG_LICENSE="GNU"
 PKG_SITE="http://www.ivarch.com/programs/pv.shtml"
 PKG_URL="http://www.ivarch.com/programs/sources/pv-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/screen/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/screen/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screen"
-PKG_VERSION="4.9.1"
-PKG_SHA256="26cef3e3c42571c0d484ad6faf110c5c15091fbf872b06fa7aa4766c7405ac69"
+PKG_VERSION="5.0.0"
+PKG_SHA256="f04a39d00a0e5c7c86a55338808903082ad5df4d73df1a2fd3425976aed94971"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/screen/"
 PKG_URL="https://ftpmirror.gnu.org/screen/${PKG_NAME}-${PKG_VERSION}.tar.gz"
@@ -13,9 +13,6 @@ PKG_BUILD_FLAGS="-sysroot -parallel"
 PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_utempter_h=no \
-                           --enable-colors256 \
                            --disable-pam \
-                           --disable-use-locale \
                            --disable-telnet \
                            --disable-socket-dir"
-

--- a/packages/addons/addon-depends/system-tools-depends/screen/patches/screen-0001.patch
+++ b/packages/addons/addon-depends/system-tools-depends/screen/patches/screen-0001.patch
@@ -1,0 +1,114 @@
+diff -Nu screen-5.0.0/display.c screen-5.0.0/display.c
+--- screen-5.0.0/display.c	2024-08-28 19:55:03.000000000 +0000
++++ screen-5.0.0/display.c	2024-08-29 18:08:34.942979909 +0000
+@@ -47,7 +47,7 @@
+ #include "mark.h"
+ #include "misc.h"
+ #include "process.h"
+-#include "pty.h"
++#include "screen-pty.h"
+ #include "resize.h"
+ #include "termcap.h"
+ #include "tty.h"
+diff -Nu screen-5.0.0/Makefile.in screen-5.0.0/Makefile.in
+--- screen-5.0.0/Makefile.in	2024-08-28 19:55:03.000000000 +0000
++++ screen-5.0.0/Makefile.in	2024-08-29 18:10:05.120409357 +0000
+@@ -66,7 +66,7 @@
+ 	$(CC) $(LDFLAGS) -o $@ $(OFILES) $(LIBS)
+ 
+ .c.o:
+-	$(CC) -c $(CPPFLAGS) $(CFLAGS) $< -o $@
++	$(CC) -c -I$(srcdir) $(CPPFLAGS) $(CFLAGS) $< -o $@
+ 
+ check: $(TESTBIN)
+ 	for f in $(TESTBIN); do \
+@@ -197,12 +197,12 @@
+  logfile.h mark.h input.h
+ tty.o: tty.c config.h screen.h os.h ansi.h sched.h acls.h comm.h layer.h \
+  term.h image.h canvas.h display.h layout.h viewport.h window.h logfile.h \
+- fileio.h misc.h pty.h telnet.h tty.h
++ fileio.h misc.h screen-pty.h telnet.h tty.h
+ term.o: term.c term.h
+ window.o: window.c config.h screen.h os.h ansi.h sched.h acls.h comm.h \
+  layer.h term.h image.h canvas.h display.h layout.h viewport.h window.h \
+  logfile.h winmsg.h winmsgbuf.h winmsgcond.h backtick.h fileio.h help.h \
+- input.h mark.h misc.h process.h pty.h resize.h telnet.h termcap.h tty.h \
++ input.h mark.h misc.h process.h screen-pty.h resize.h telnet.h termcap.h tty.h \
+  utmp.h
+ utmp.o: utmp.c config.h screen.h os.h ansi.h sched.h acls.h comm.h \
+  layer.h term.h image.h canvas.h display.h layout.h viewport.h window.h \
+@@ -229,7 +229,7 @@
+ display.o: display.c config.h screen.h os.h ansi.h sched.h acls.h comm.h \
+  layer.h term.h image.h canvas.h display.h layout.h viewport.h window.h \
+  logfile.h winmsg.h winmsgbuf.h winmsgcond.h backtick.h encoding.h mark.h \
+- misc.h process.h pty.h resize.h termcap.h tty.h
++ misc.h process.h screen-pty.h resize.h termcap.h tty.h
+ comm.o: comm.c config.h os.h screen.h ansi.h sched.h acls.h comm.h \
+  layer.h term.h image.h canvas.h display.h layout.h viewport.h window.h \
+  logfile.h
+diff -Nu screen-5.0.0/pty.c screen-5.0.0/pty.c
+--- screen-5.0.0/pty.c	2024-08-28 19:55:03.000000000 +0000
++++ screen-5.0.0/pty.c	2024-08-29 18:09:06.889919017 +0000
+@@ -28,7 +28,7 @@
+ 
+ #include "config.h"
+ 
+-#include "pty.h"
++#include "screen-pty.h"
+ 
+ #include <sys/ioctl.h>
+ 
+diff -Nu screen-5.0.0/pty.h screen-5.0.0/pty.h
+--- screen-5.0.0/pty.h	2024-08-28 19:55:03.000000000 +0000
++++ screen-5.0.0/pty.h	1970-01-01 00:00:00.000000000 +0000
+@@ -1,11 +0,0 @@
+-#ifndef SCREEN_PTY_H
+-#define SCREEN_PTY_H
+-
+-int   OpenPTY (char **);
+-int  ClosePTY (int);
+-
+-/* global variables */
+-
+-extern int pty_preopen;
+-
+-#endif /* SCREEN_PTY_H */
+diff -Nu screen-5.0.0/screen-pty.h screen-5.0.0/screen-pty.h
+--- screen-5.0.0/screen-pty.h	1970-01-01 00:00:00.000000000 +0000
++++ screen-5.0.0/screen-pty.h	2024-08-28 19:55:03.000000000 +0000
+@@ -0,0 +1,11 @@
++#ifndef SCREEN_PTY_H
++#define SCREEN_PTY_H
++
++int   OpenPTY (char **);
++int  ClosePTY (int);
++
++/* global variables */
++
++extern int pty_preopen;
++
++#endif /* SCREEN_PTY_H */
+diff -Nu screen-5.0.0/tty.c screen-5.0.0/tty.c
+--- screen-5.0.0/tty.c	2024-08-28 19:55:03.000000000 +0000
++++ screen-5.0.0/tty.c	2024-08-29 18:09:19.073355563 +0000
+@@ -44,7 +44,7 @@
+ #include "screen.h"
+ #include "fileio.h"
+ #include "misc.h"
+-#include "pty.h"
++#include "screen-pty.h"
+ #include "telnet.h"
+ #include "tty.h"
+ 
+diff -Nu screen-5.0.0/window.c screen-5.0.0/window.c
+--- screen-5.0.0/window.c	2024-08-28 19:55:03.000000000 +0000
++++ screen-5.0.0/window.c	2024-08-29 18:14:12.542433618 +0000
+@@ -48,7 +48,7 @@
+ #include "mark.h"
+ #include "misc.h"
+ #include "process.h"
+-#include "pty.h"
++#include "screen-pty.h"
+ #include "resize.h"
+ #include "telnet.h"
+ #include "termcap.h"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.18.02"
-PKG_SHA256="45eac8d354df5be26c9675ec7fc24910f846e47eb6b151e9955d6eae30cfe060"
+PKG_VERSION="0.18.04"
+PKG_SHA256="c76cf067e582fb8a066d47207bbccc6d0d4175ba700b5d122909132d79e7f6ea"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/jellyfin/package.mk
+++ b/packages/addons/service/jellyfin/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="jellyfin"
 PKG_VERSION="1.0"
-PKG_VERSION_NUMBER="10.9.9"
-PKG_REV="3"
+PKG_VERSION_NUMBER="10.9.11"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://jellyfin.org/"

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="1.3.30"
-PKG_SHA256="0eafadd7c15ba713a17fead0da8b21c36149a15fcc91fa31766f8ffbca27075c"
-PKG_REV="3"
+PKG_VERSION="1.3.35"
+PKG_SHA256="e0b9f97d57e1692629dbd5906fda59301805ed3e3d3a3d8311e9f2ce40a7cccf"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/catalinii/minisatip"
@@ -22,11 +22,11 @@ PKG_ADDON_TYPE="xbmc.service"
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-netcv \
                            --enable-dvbca \
-                           --enable-dvbaes \
                            --enable-dvbcsa \
                            --with-xml2=$(get_install_dir libxml2)/usr/include/libxml2"
 
 pre_configure_target() {
+  TARGET_CONFIGURE_OPTS=$(echo ${TARGET_CONFIGURE_OPTS} | sed -e "s|--disable-static||" -e "s|--enable-shared||")
   cd ${PKG_BUILD}
     rm -rf .${TARGET_NAME}
 }

--- a/packages/addons/service/tvheadend42/package.mk
+++ b/packages/addons/service/tvheadend42/package.mk
@@ -5,12 +5,12 @@ PKG_NAME="tvheadend42"
 PKG_VERSION="5bdcfd8ac97b3337e1c7911ae24127df76fa693a"
 PKG_SHA256="b562a26248cdc02dc94cc62038deea172668fa4c079b2ea4e1b4220f3b1d34f5"
 PKG_VERSION_NUMBER="4.2.8-36"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"
 PKG_URL="https://github.com/tvheadend/tvheadend/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain avahi comskip curl dvb-apps libdvbcsa libhdhomerun \
+PKG_DEPENDS_TARGET="toolchain argtable2 avahi comskip curl dvb-apps libdvbcsa libhdhomerun \
                     libiconv openssl pngquant:host Python3:host dtv-scan-tables"
 PKG_DEPENDS_CONFIG="ffmpegx"
 PKG_SECTION="service"
@@ -125,8 +125,8 @@ addon() {
 
   if [ "${TARGET_ARCH}" = "x86_64" ]; then
     mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
-    cp -P $(get_install_dir x265)/usr/lib/libx265.so.209 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
-    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{comskip,tvheadend}
+    cp -P $(get_install_dir x265)/usr/lib/libx265.so.212 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{comskip,tvheadend}
   fi
 
   # dvb-scan files

--- a/packages/addons/service/tvheadend43/package.mk
+++ b/packages/addons/service/tvheadend43/package.mk
@@ -5,12 +5,12 @@ PKG_NAME="tvheadend43"
 PKG_VERSION="3dcb7ecf36666dcb43211a84141b1b645c9ca757"
 PKG_SHA256="c7c8414bca5304276cc8f07aa291e36b50e1190d441f2af2ce256631b7c033c2"
 PKG_VERSION_NUMBER="4.3-2180"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"
 PKG_URL="https://github.com/tvheadend/tvheadend/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain avahi comskip curl dvb-apps ffmpegx libdvbcsa libhdhomerun \
+PKG_DEPENDS_TARGET="toolchain argtable2 avahi comskip curl dvb-apps ffmpegx libdvbcsa libhdhomerun \
                     libiconv openssl pcre2 pngquant:host Python3:host dtv-scan-tables"
 PKG_DEPENDS_CONFIG="ffmpegx"
 PKG_SECTION="service"
@@ -125,8 +125,8 @@ addon() {
 
   if [ "${TARGET_ARCH}" = "x86_64" ]; then
     mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
-    cp -P $(get_install_dir x265)/usr/lib/libx265.so.209 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
-    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{comskip,tvheadend}
+    cp -P $(get_install_dir x265)/usr/lib/libx265.so.212 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{comskip,tvheadend}
   fi
 
   # dvb-scan files

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="ffmpeg-tools"
 PKG_VERSION="1.0"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -26,7 +26,7 @@ addon() {
 
   # libs
   if [ "${TARGET_ARCH}" = "x86_64" ]; then
-    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.209 \
+    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.212 \
            ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
   fi
 }

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- backport of #9299
- backport of #9437
- jellyfin: update to 10.9.11 and addon (4)
- minisatip: update to 1.3.35 and addon (4)
- tvheadend43: update addon (2)
- tvheadend42: update addon (1)
- ffmpeg-tools: update addon (3)
- x265: update to 4.0
- x264: update to githash 4613ac3
- ffmpegx: lavc/libx265: unbreak build for X265_BUILD >= 210
- - docker: update to 27.3.1 and addon (7) 
  - runc: update to 1.2.0 
  - cli: update to 27.3.1 
  - moby: update to 27.3.1 
  - containerd: update to 1.7.23 
  - go: update to 1.23.2 
- apache-ant: update to 1.10.15 
- network-tools: update addon (2) 
  - libpcap: update to 1.10.5 
  - tcpdump: update to 4.99.5 
- system-tools: update addon (6) 
  - stress-ng: update to 0.18.04 
  - pv: update to 1.8.14 
  - screen: update to 5.0.0

