### PR TITLE
media-driver: update to 24.4.1

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="24.4.0"
-PKG_SHA256="334f3d3d8382dce7cafd028bd0f433e0328f25ffd8e9f33947138475c1757935"
+PKG_VERSION="24.4.1"
+PKG_SHA256="cbc2ccdae2cf84bd1e36a9d5acec4861922ae68f849e89ddcc2f2c5579bd6022"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20241026093451-55aea88
Linux nuc12 6.12.0-rc4 #1 SMP Sat Oct 26 09:51:06 UTC 2024 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:32b04718c65a90f87e409674c4ef984b087b8657). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-10-26 by GCC 14.2.0 for Linux x86 64-bit version 6.12.0 (396288)
Running on LibreELEC (heitbaum): devel-20241026093451-55aea88 13.0, kernel: Linux x86 64-bit version 6.12.0-rc4
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0093.2024.0508.2037 05/08/2024
[    0.000000] DMI: Memory slots populated: 1/2
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.2.5
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.4.1 (55aea8865c)
```