### PR TITLE
u-boot: allow u-boot to build with swig-4.3.0

### DIFF
--- a/packages/tools/u-boot/patches/0001-libfdt-Fix-build-with-swig-4-3.0.patch
+++ b/packages/tools/u-boot/patches/0001-libfdt-Fix-build-with-swig-4-3.0.patch
@@ -1,0 +1,49 @@
+From 868c1409d2ec75b3d5b6c04eeac0ea3127893b66 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 26 Oct 2024 12:27:19 +0000
+Subject: [PATCH] libfdt: Fix build with swig 4.3.0
+
+Call SWIG_AppendOutput instead of SWIG_Python_AppendOutput so that
+is_void is handled within swig.
+
+Link: https://github.com/swig/swig/commit/cd39cf132c96a0887be07c826b80804d7677a701
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ scripts/dtc/pylibfdt/libfdt.i_shipped | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/dtc/pylibfdt/libfdt.i_shipped b/scripts/dtc/pylibfdt/libfdt.i_shipped
+index 56cc5d48f4..e4659489a9 100644
+--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
++++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
+@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
++		resultobj = SWIG_AppendOutput(resultobj, buff);
+ 	}
+ }
+ 
+@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
+ 
+ %typemap(argout) int *depth {
+         PyObject *val = Py_BuildValue("i", *arg$argnum);
+-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
++        resultobj = SWIG_AppendOutput(resultobj, val);
+ }
+ 
+ %apply int *depth { int *depth };
+@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
+            if (PyTuple_GET_SIZE(resultobj) == 0)
+               resultobj = val;
+            else
+-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
++              resultobj = SWIG_AppendOutput(resultobj, val);
+         }
+ }
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
ref:
- https://github.com/swig/swig/commit/cd39cf132c96a0887be07c826b80804d7677a701

during dtc build for img.gz u-boot fails. Patch sent upstream 
- https://lists.denx.de/pipermail/u-boot/2024-October/thread.html
- https://lists.denx.de/pipermail/u-boot/2024-October/569585.html

Fixes:
```
  HOSTLD  scripts/dtc/dtc
  LDS     u-boot.lds
  LDS     u-boot-elf.lds
scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_next_node’:
scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function ‘SWIG_Python_AppendOutput’
 5581 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c:1262:1: note: declared here
 1262 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_get_mem_rsv’:
scripts/dtc/pylibfdt/libfdt_wrap.c:6388:19: error: too few arguments to function ‘SWIG_Python_AppendOutput’
 6388 |       resultobj = SWIG_Python_AppendOutput(resultobj, val);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c:1262:1: note: declared here
 1262 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c:6397:19: error: too few arguments to function ‘SWIG_Python_AppendOutput’
 6397 |       resultobj = SWIG_Python_AppendOutput(resultobj, val);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c:1262:1: note: declared here
 1262 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_get_property_by_offset’:
scripts/dtc/pylibfdt/libfdt_wrap.c:6639:19: error: too few arguments to function ‘SWIG_Python_AppendOutput’
 6639 |       resultobj = SWIG_Python_AppendOutput(resultobj, buff);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c:1262:1: note: declared here
 1262 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_get_property’:
scripts/dtc/pylibfdt/libfdt_wrap.c:6702:19: error: too few arguments to function ‘SWIG_Python_AppendOutput’
 6702 |       resultobj = SWIG_Python_AppendOutput(resultobj, buff);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c:1262:1: note: declared here
 1262 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_get_property_w’:
scripts/dtc/pylibfdt/libfdt_wrap.c:6767:19: error: too few arguments to function ‘SWIG_Python_AppendOutput’
 6767 |       resultobj = SWIG_Python_AppendOutput(resultobj, buff);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c:1262:1: note: declared here
 1262 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
error: command '/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-iMX8.aarch64-13.0-devel/toolchain/bin/host-gcc' failed with exit code 1
make[3]: *** [scripts/dtc/pylibfdt/Makefile:33: rebuild] Error 1
make[2]: *** [scripts/Makefile.build:397: scripts/dtc/pylibfdt] Error 2
make[1]: *** [Makefile:2055: scripts_dtc] Error 2
make[1]: Leaving directory '/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-iMX8.aarch64-13.0-devel/build/u-boot-2024.10'
FAILURE: scripts/build u-boot during make_target (package.mk)
*********** FAILED COMMAND ***********
DEBUG=${PKG_DEBUG} CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" ARCH=arm _python_sysroot="${TOOLCHAIN}" _python_prefix=/ _python_exec_prefix=/ make ${UBOOT_TARGET} HOSTCC="${HOST_CC}" HOSTCFLAGS="-I${TOOLCHAIN}/include" HOSTLDFLAGS="${HOST_LDFLAGS}" HOSTSTRIP="true" CONFIG_MKIMAGE_DTC_PATH="scripts/dtc/dtc"
``` 
