### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="22.1.7-Piers"
-PKG_SHA256="5220b1fdc842f235dfe931c4be44ef08452e115600340f74afbfff876c9afb92"
+PKG_VERSION="22.1.8-Piers"
+PKG_SHA256="5bb7da3efed02397bc6f5965f3c5e2ee17fe4808d8443e113e4e99b5f3d40b6b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.asteroids"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="492d826efa7a252ce62a1bebf075fe9b0c0cf452929f4cd6f228003f6e445b82"
-PKG_REV="6"
+PKG_VERSION="22.0.2-Piers"
+PKG_SHA256="3db8595fa121290fa857bf590404cd70ae910ce90c2273477baf72194e1ae2b4"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.asteroids"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.biogenesis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.biogenesis/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.biogenesis"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="dfc291fbafe16444f3a5a5f886ba562b5d7b16ed77f4302017fbbe5f5ef9a82d"
-PKG_REV="2"
+PKG_VERSION="22.0.2-Piers"
+PKG_SHA256="acb3e0c7885e4a0f766403d9c58e540ea09c75cf8926a83ba24bad725ad755d0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.biogenesis"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.greynetic"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="e060f69a7c403a5d7bb59058dc38e8c6a6ea1aa7bc9b82f8ffa7c5e94ede0866"
-PKG_REV="2"
+PKG_VERSION="22.0.2-Piers"
+PKG_SHA256="f8e6f772e40ad5cfb3493011fbae6062d7f3ab0c03f614842687505af2194da3"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.greynetic"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.pingpong/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.pingpong/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.pingpong"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="72b3c9be5b65afe7fbc6d496eb7700786d88811bfafcd131a3219a646d30805d"
-PKG_REV="2"
+PKG_VERSION="22.0.2-Piers"
+PKG_SHA256="d87bd7ec62721dc547834ef637a319a5d2355cce3d6b650cf18f0cf619bc4b3b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.pingpong"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.pyro"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="ec981d070cccdfaa9116244e80a63d86c37f67dccd11aacfcc66dcfcbb608ce1"
-PKG_REV="2"
+PKG_VERSION="22.0.2-Piers"
+PKG_SHA256="1a3f19ed1328c87b63be21f6d2fe068d01c338906cad280c5630011a6caab83d"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.pyro"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.stars"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="5ea0d19c3ef94e9603a0e06c78ae01cd6f9227da7b505eaa7d4527ca6018ea03"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="6a0543489dff170c2132f46da509c8ffd8d1e6265a0b07d8792e9189d573d737"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.stars"


### PR DESCRIPTION
- inputstream.adaptive: update 22.1.7-Piers to 22.1.8-Piers
- screensaver.asteroids: update 20.2.0-Nexus to 22.0.2-Piers
- screensaver.biogenesis: update 20.1.0-Nexus to 22.0.2-Piers
- screensaver.greynetic: update 20.2.0-Nexus to 22.0.2-Piers
- screensaver.pingpong: update 20.2.0-Nexus to 22.0.2-Piers
- screensaver.pyro: update 20.1.0-Nexus to 22.0.2-Piers
- screensaver.stars: update 20.1.0-Nexus to 22.0.1-Piers