### PR TITLE
Fix linux builds due to rtw backported patch

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -20,14 +20,14 @@ case "${LINUX}" in
     PKG_SHA256=""
     PKG_URL="https://github.com/torvalds/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
-    PKG_PATCH_DIRS="default rtlwifi/6.12 rtlwifi/after-6.12"
+    PKG_PATCH_DIRS="default rtlwifi/6.11.2 rtlwifi/6.12 rtlwifi/after-6.12"
     ;;
   raspberrypi)
     PKG_VERSION="8ee418c866c263941fb468bc1eeab1d8059db705" # 6.6.57
     PKG_SHA256="0e556ee6ae2013956f3edbb8a2ae01e79f3ec958b62e8e6b6e8316ea0375b795"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
-    PKG_PATCH_DIRS="raspberrypi rtlwifi/6.9 rtlwifi/6.10 rtlwifi/6.11 rtlwifi/6.12 rtlwifi/after-6.12"
+    PKG_PATCH_DIRS="raspberrypi rtlwifi/6.9 rtlwifi/6.10 rtlwifi/6.11 rtlwifi/6.11.2 rtlwifi/6.12 rtlwifi/after-6.12"
     ;;
   *)
     PKG_VERSION="6.11.4"

--- a/packages/linux/patches/rtlwifi/6.11.2/0001-6.11.2-wifi-rtw88-8703b-Fix-reported-RX-band-width.patch
+++ b/packages/linux/patches/rtlwifi/6.11.2/0001-6.11.2-wifi-rtw88-8703b-Fix-reported-RX-band-width.patch
@@ -1,0 +1,36 @@
+From aefa7a3a7cbe6c7de08fd7a7447c797a97c2e0cf Mon Sep 17 00:00:00 2001
+From: Bitterblue Smith <rtl8821cerfe2@gmail.com>
+Date: Tue, 23 Jul 2024 22:32:59 +0300
+Subject: [PATCH 2/7] wifi: rtw88: 8703b: Fix reported RX band width
+
+The definition of GET_RX_DESC_BW is incorrect. Fix it according to the
+GET_RX_STATUS_DESC_BW_8703B macro from the official driver.
+
+Tested only with RTL8812AU, which uses the same bits.
+
+Cc: stable@vger.kernel.org
+Fixes: 9bb762b3a957 ("wifi: rtw88: Add definitions for 8703b chip")
+Signed-off-by: Bitterblue Smith <rtl8821cerfe2@gmail.com>
+Tested-by: Fiona Klute <fiona.klute@gmx.de>
+Signed-off-by: Ping-Ke Shih <pkshih@realtek.com>
+Link: https://patch.msgid.link/1cfed9d5-4304-4b96-84c5-c347f59fedb9@gmail.com
+---
+ drivers/net/wireless/realtek/rtw88/rx.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/rx.h b/drivers/net/wireless/realtek/rtw88/rx.h
+index d3668c4efc24..8a072dd3d73c 100644
+--- a/drivers/net/wireless/realtek/rtw88/rx.h
++++ b/drivers/net/wireless/realtek/rtw88/rx.h
+@@ -41,7 +41,7 @@ enum rtw_rx_desc_enc {
+ #define GET_RX_DESC_TSFL(rxdesc)                                               \
+ 	le32_get_bits(*((__le32 *)(rxdesc) + 0x05), GENMASK(31, 0))
+ #define GET_RX_DESC_BW(rxdesc)                                                 \
+-	(le32_get_bits(*((__le32 *)(rxdesc) + 0x04), GENMASK(31, 24)))
++	(le32_get_bits(*((__le32 *)(rxdesc) + 0x04), GENMASK(5, 4)))
+ 
+ void rtw_rx_stats(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 		  struct sk_buff *skb);
+-- 
+2.43.0
+


### PR DESCRIPTION
Fix RPi and Amlogic builds due to rtw patch that was backported (and then dropped from the 6.12 directory) from 6.12 to 6.11.2