### PR TITLE
[le12] kodi: update to 2b2d09e

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="21.1-Omega"
-PKG_SHA256="ad6e40b0912c8318635f0501dc1f7f27ce3a29e671f2ddb608cad34babae80ef"
+PKG_VERSION="2b2d09e2902fa6cff8ceb2da99c9fca87743a509"
+PKG_SHA256="59330b8117906ab3d7c78cb8d827febbcad74732850fe0153f0b848f70fcd56b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Runtime tested on RPi5

- MediaSession: Properly update when pressing stop
- [BP] Restore Library Scan Performance
- [backport][subtitles][libass] Fallback value for no PlayResY
- [BP][Libcdio-gplv3] Fix crash on macOS (upstream patch)
- [Omega][Android] Fix resuming paused media playback not working via play/pau…
- [backport][CharArrayParser] Skip malformed EOL
- [partial backport][GUI][GUIDialogSubtitleSettings] Add missing original flag support
- [addons] add missing flag to filesystem translation from binary add-ons - Backport
- [BP][UPnP] Do not scan for external subs for UPnP renderer
- [Omega][PVR] [PVR] Async EPG update: Fix removal of EPG events notified as ' deleted', take 2
- [Omega][PVR] Context menu item 'Start recording': Fix to respect other runni…
- [Omega][PVR] Context menu item 'Stop recording': Fix visibility condition for EPG gap tags
- [Omega][PVR] Async EPG update: Fix removal of EPG events notified as 'deleted'.
- [Omega][PVR][video] Fix loading of recording folder resume information.
- [Omega][PVR] EPG search fixes
- [Omega][video] Video navigation window: Replace context menu items 'Set acto…
- [Omega][dvdread] fix warning 'gcc_struct' attribute directive ignored
- [backport v21] CPUInfo: make sure m_cpuFeatures is initialized
- [Backport][Windows] Fix Discovery of MAC Address
- [Backport] Android default buttonmaps and generic controllers
- Backport #25657 (OSMC remote keymapping)
- [Backport][Windows] Fix crash when audio device not has 'PKEY_Device_EnumeratorName' property