### PR TITLE
kodi: update to githash 3f6829c

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="32b04718c65a90f87e409674c4ef984b087b8657"
-PKG_SHA256="607366e6df98a77bcdf110fdfbc3e4e6c8764c3c152466dd79c250d0f561f237"
+PKG_VERSION="3f6829c18a74f3ca68d4644cec33aa2294f443ea"
+PKG_SHA256="ada10eb9f7d89cf6d328582d3d747cbceb34513aca01e3a355a86a8f9be80a36"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
log:
- https://github.com/xbmc/xbmc/compare/32b04718c65a90f87e409674c4ef984b087b8657...3f6829c18a74f3ca68d4644cec33aa2294f443ea

```
=== tested on ===
Generic.x86_64-devel-20241102113922-dd90bad
Linux nuc12 6.12.0-rc5 #1 SMP Sat Nov  2 11:40:10 UTC 2024 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:3f6829c18a74f3ca68d4644cec33aa2294f443ea). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-11-02 by GCC 14.2.0 for Linux x86 64-bit version 6.12.0 (396288)
Running on LibreELEC (heitbaum): devel-20241102113922-dd90bad 13.0, kernel: Linux x86 64-bit version 6.12.0-rc5
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0093.2024.0508.2037 05/08/2024
[    0.000000] DMI: Memory slots populated: 1/2
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.2.6
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.4.1 (ccd80ca73b)
```