### PR TITLE
librespot: update to 0.6.0 and addon (1)

### DIFF
--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -3,15 +3,15 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="librespot"
-PKG_VERSION="299b7dec20b45b9fa19a4a46252079e8a8b7a8ba"
+PKG_VERSION="0.6.0"
 PKG_VERSION_DATE="2023-12-06"
-PKG_SHA256="3699d2f15065222a769e57fec22b51e3d355c2d9837b49c3ec3ef16d2ace4b35"
-PKG_REV="0"
+PKG_SHA256="9ec881edb11e37d31a2b41dd30d56a3413445eedb720e1b0d278567dccfca8fc"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/librespot-org/librespot/"
-PKG_URL="https://github.com/librespot-org/librespot/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain alsa-lib avahi pulseaudio cargo:host"
+PKG_URL="https://github.com/librespot-org/librespot/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain alsa-lib avahi pulseaudio bindgen-cli:host cargo:host cmake:host"
 PKG_SECTION="service"
 PKG_SHORTDESC="Librespot: play Spotify through Kodi using a Spotify app as a remote"
 PKG_LONGDESC="Librespot (${PKG_VERSION_DATE}) lets you play Spotify through Kodi using a Spotify app as a remote."
@@ -23,6 +23,11 @@ PKG_ADDON_TYPE="xbmc.service"
 PKG_MAINTAINER="Anton Voyl (awiouy)"
 
 make_target() {
+  # build of the crate aws-lc-rs fails when CMAKE is set. Set the required toolchain.
+  unset CMAKE
+  export CMAKE_TOOLCHAIN_FILE="${CMAKE_CONF}"
+  export CMAKE_INSTALL_PREFIX="/usr"
+
   export RUSTC_LINKER=${CC}
   cargo build \
     --target ${TARGET_NAME} \

--- a/packages/rust/bindgen-cli/package.mk
+++ b/packages/rust/bindgen-cli/package.mk
@@ -1,0 +1,27 @@
+# spdx-license-identifier: gpl-2.0-only
+# copyright (c) 2024-present team libreelec (https://libreelec.tv)
+
+PKG_NAME="bindgen-cli"
+PKG_VERSION="0.69.5"
+PKG_SHA256="30e69cd65a9f5ed08d8cf1b75626c13f39fce9a843cb109fbf778c8dd402439f"
+PKG_LICENSE="BSD-3-Clause"
+PKG_SITE="https://rust-lang.github.io/rust-bindgen/"
+PKG_URL="https://github.com/rust-lang/rust-bindgen/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="cargo:host"
+PKG_LONGDESC="Automatically generates Rust FFI bindings to C and some C++ libraries"
+PKG_TOOLCHAIN="manual"
+
+configure_host() {
+  cd ${PKG_BUILD}
+}
+
+make_host() {
+  cd ${PKG_BUILD}
+
+  cargo build -v --target ${RUST_HOST} --release
+}
+
+makeinstall_host() {
+  mkdir -p ${TOOLCHAIN}/bin
+    cp -a ${PKG_BUILD}/.${RUST_HOST}/target/${RUST_HOST}/release/bindgen ${TOOLCHAIN}/bin/
+}


### PR DESCRIPTION
release notes:
- https://github.com/librespot-org/librespot/releases/tag/v0.6.0
- dependency
  - bindgen-cli: update to 0.69.5
- https://github.com/librespot-org/librespot/issues/1392