### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="22.1.8-Piers"
-PKG_SHA256="5bb7da3efed02397bc6f5965f3c5e2ee17fe4808d8443e113e4e99b5f3d40b6b"
+PKG_VERSION="22.1.9-Piers"
+PKG_SHA256="8cc2107b7132c78176197a9d536122ccb97e8d185bd4a8cc36c45858263306ea"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="22.3.1-Piers"
-PKG_SHA256="9cbf5ad94c0b6b6640676e353d7961b8bc8a393211a04b0fee2a9642a79f7e81"
+PKG_VERSION="22.4.1-Piers"
+PKG_SHA256="bc17457b90d3b8685bac55a276bdec1489f91b7eb7543f1a619b457a174f140c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 22.1.8-Piers to 22.1.9-Piers
- pvr.iptvsimple: update 22.3.1-Piers to 22.4.1-Piers