### PR TITLE
librespot: fix cross compile builds with bindgen sysroot prefix

### DIFF
--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -28,6 +28,7 @@ make_target() {
   export CMAKE_TOOLCHAIN_FILE="${CMAKE_CONF}"
   export CMAKE_INSTALL_PREFIX="/usr"
 
+  export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=${SYSROOT_PREFIX}"
   export RUSTC_LINKER=${CC}
   cargo build \
     --target ${TARGET_NAME} \


### PR DESCRIPTION
- fixes cross compile builds of #9466 