### PR TITLE
[le12] iwd: update to 3.1

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="3.0"
-PKG_SHA256="bd167ab368b6ba302b6c948a4f41f02d233a12e20d5094b1c0393325309f8a60"
+PKG_VERSION="3.1"
+PKG_SHA256="a2b6d21315fdd0e060d5f75f5a0cc55018ea9d112a080f2ccd6dae2e1d923ac5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
+	Fix issue with handling OWE transition BSS selection.
+	Fix issue with handling oper class 136 starting frequency.
- backport #9475 