### PR TITLE
RPi: brcmfmac: disable SAE authentication offload

### DIFF
--- a/projects/RPi/packages/linux/modprobe.d/brcmfmac.conf
+++ b/projects/RPi/packages/linux/modprobe.d/brcmfmac.conf
@@ -1,0 +1,2 @@
+# Disable SAE authentication offload until it works with iwd
+options brcmfmac feature_disable=0x400000


### PR DESCRIPTION
iwd is unable to connect with WPA3 networks with current firmware/driver combo, disable offload until it is fixed.

https://forum.libreelec.tv/thread/29155-rpi5-network-disappeared/