### PR TITLE
libheif: update to 1.19.2

### DIFF
--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.18.2"
-PKG_SHA256="c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf"
+PKG_VERSION="1.19.2"
+PKG_SHA256="f73eb786e75ef1f815ed3d37aca9eadd41dc1d26dfde11f8a4f92f911622d19e"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/tiff/patches/tiff-0001-cmake--Replace-CMath--CMath-with-direct-link-to-avoid-export-of-target.patch
+++ b/packages/graphics/tiff/patches/tiff-0001-cmake--Replace-CMath--CMath-with-direct-link-to-avoid-export-of-target.patch
@@ -1,0 +1,87 @@
+From 67f73084ca824e6c2465c47a5b67b16b5beca569 Mon Sep 17 00:00:00 2001
+From: Roger Leigh <rleigh@codelibre.net>
+Date: Thu, 14 Dec 2023 18:30:31 +0000
+Subject: [PATCH] cmake: Replace CMath::CMath with direct link to avoid export
+ of target
+
+Link with CMATH_LIBRARIES instead of CMath::CMath.  While this
+will still be exported, it will be available on the host system.
+---
+ cmake/FindCMath.cmake            | 12 +++---------
+ contrib/dbs/CMakeLists.txt       | 10 ++++++++--
+ libtiff/CMakeLists.txt           |  6 +++---
+ tools/unsupported/CMakeLists.txt |  5 ++++-
+ 4 files changed, 18 insertions(+), 15 deletions(-)
+
+diff --git a/cmake/FindCMath.cmake b/cmake/FindCMath.cmake
+index ad922180b..c4833af7e 100644
+--- a/cmake/FindCMath.cmake
++++ b/cmake/FindCMath.cmake
+@@ -55,18 +55,12 @@ if(CMath_FOUND)
+         set(CMath_INCLUDE_DIRS)
+     endif()
+     if(NOT CMath_LIBRARIES)
++        if(NOT CMath_LIBRARY)
++          unset(CMath_LIBRARY)
++        endif()
+         if (CMath_LIBRARY)
+             set(CMath_LIBRARIES ${CMath_LIBRARY})
+         endif()
+     endif()
+ 
+-    if(NOT TARGET CMath::CMath)
+-        if(CMath_LIBRARIES)
+-            add_library(CMath::CMath UNKNOWN IMPORTED)
+-            set_target_properties(CMath::CMath PROPERTIES
+-                  IMPORTED_LOCATION "${CMath_LIBRARY}")
+-        else()
+-            add_library(CMath::CMath INTERFACE IMPORTED)
+-        endif()
+-    endif()
+ endif()
+diff --git a/contrib/dbs/CMakeLists.txt b/contrib/dbs/CMakeLists.txt
+index 74b2a02a0..18b7ea8b4 100644
+--- a/contrib/dbs/CMakeLists.txt
++++ b/contrib/dbs/CMakeLists.txt
+@@ -26,13 +26,19 @@ add_executable(tiff-bi tiff-bi.c)
+ target_link_libraries(tiff-bi tiff tiff_port)
+ 
+ add_executable(tiff-grayscale tiff-grayscale.c)
+-target_link_libraries(tiff-grayscale tiff tiff_port CMath::CMath)
++target_link_libraries(tiff-grayscale PRIVATE tiff tiff_port)
++if(CMath_LIBRARIES)
++  target_link_libraries(tiff-grayscale PRIVATE ${CMath_LIBRARIES})
++endif()
+ 
+ add_executable(tiff-palette tiff-palette.c)
+ target_link_libraries(tiff-palette tiff tiff_port)
+ 
+ add_executable(tiff-rgb tiff-rgb.c)
+-target_link_libraries(tiff-rgb tiff tiff_port CMath::CMath)
++target_link_libraries(tiff-rgb PRIVATE tiff tiff_port)
++if(CMath_LIBRARIES)
++  target_link_libraries(tiff-rgb PRIVATE ${CMath_LIBRARIES})
++endif()
+ 
+ if(WEBP_SUPPORT AND EMSCRIPTEN)
+   # Emscripten is pretty finnicky about linker flags.
+diff --git a/libtiff/CMakeLists.txt b/libtiff/CMakeLists.txt
+index a8aa0c320..a65f3c230 100755
+--- a/libtiff/CMakeLists.txt
++++ b/libtiff/CMakeLists.txt
+@@ -184,9 +184,9 @@ if(WEBP_SUPPORT)
+   target_link_libraries(tiff PRIVATE WebP::webp)
+   string(APPEND tiff_requires_private " libwebp")
+ endif()
+-if(CMath_LIBRARY)
+-  target_link_libraries(tiff PRIVATE CMath::CMath)
+-  list(APPEND tiff_libs_private_list "${CMath_LIBRARY}")
++if(CMath_LIBRARIES)
++  target_link_libraries(tiff PRIVATE ${CMath_LIBRARIES})
++  list(APPEND tiff_libs_private_list "${CMath_LIBRARIES}")
+ endif()
+ 
+ set(tiff_libs_private_list "${tiff_libs_private_list}" PARENT_SCOPE)
+-- 
+GitLab
+


### PR DESCRIPTION
- libheif: update to 1.19.2
- tiff: fix static linkage
- https://github.com/strukturag/libheif/issues/1375
- https://gitlab.com/libtiff/libtiff/-/commit/67f73084ca824e6c2465c47a5b67b16b5beca569.patch
- https://gitlab.com/libtiff/libtiff/-/issues/625