### PR TITLE
mesa: update to 24.3.0

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="24.2.6"
-PKG_SHA256="2b68c4a6f204c1999815a457299f81c41ba7bf48c4674b0b2d1d8864f41f3709"
+PKG_VERSION="24.3.0-rc1"
+PKG_SHA256="5a09bfabb143f3c6a74e5456118ae41c891424a43c4d7c9df82645fe74c8c9a4"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
@@ -22,14 +22,12 @@ PKG_MESON_OPTS_HOST="-Dglvnd=disabled \
                      -Dgallium-drivers=iris \
                      -Dgallium-vdpau=disabled \
                      -Dplatforms= \
-                     -Ddri3=disabled \
                      -Dglx=disabled \
                      -Dvulkan-drivers="
 
 PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
                        -Dgallium-rusticl=false \
-                       -Dgallium-omx=disabled \
                        -Dgallium-nine=false \
                        -Dgallium-opencl=disabled \
                        -Dshader-cache=enabled \
@@ -44,23 +42,19 @@ PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dbuild-tests=false \
                        -Ddraw-use-llvm=false \
                        -Dmicrosoft-clc=disabled \
-                       -Dselinux=false \
                        -Dosmesa=false"
 
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr"
   export X11_INCLUDES=
   PKG_MESON_OPTS_TARGET+=" -Dplatforms=x11 \
-                           -Ddri3=enabled \
                            -Dglx=dri"
 elif [ "${DISPLAYSERVER}" = "wl" ]; then
   PKG_DEPENDS_TARGET+=" wayland wayland-protocols"
   PKG_MESON_OPTS_TARGET+=" -Dplatforms=wayland \
-                           -Ddri3=disabled \
                            -Dglx=disabled"
 else
   PKG_MESON_OPTS_TARGET+=" -Dplatforms="" \
-                           -Ddri3=disabled \
                            -Dglx=disabled"
 fi
 

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="24.3.0-rc1"
-PKG_SHA256="5a09bfabb143f3c6a74e5456118ae41c891424a43c4d7c9df82645fe74c8c9a4"
+PKG_VERSION="24.3.0-rc2"
+PKG_SHA256="3bcc1be0ae71eabb18d51c0bd9c84374e6dc4594a1b3261cd24901263c971e35"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"

--- a/projects/RPi/patches/mesa/0001-gallium-Add-kmsro-drivers-for-RP1-DSI-DPI-and-VEC-de.patch
+++ b/projects/RPi/patches/mesa/0001-gallium-Add-kmsro-drivers-for-RP1-DSI-DPI-and-VEC-de.patch
@@ -7,8 +7,7 @@ Subject: [PATCH 1/3] gallium: Add kmsro drivers for RP1 DSI, DPI, and VEC
 Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
 ---
  src/gallium/targets/dril/meson.build | 3 +++
- src/gallium/targets/dri/dri_target.c | 3 +++
- 2 files changed, 6 insertions(+)
+ 1 files changed, 3 insertions(+)
 
 diff --git a/src/gallium/targets/dril/meson.build b/src/gallium/targets/dril/meson.build
 index 66619bba0db..443923772e8 100644
@@ -24,20 +23,6 @@ index 66619bba0db..443923772e8 100644
                 'exynos_dri.so',
                 'gm12u320_dri.so',
                 'hdlcd_dri.so',
-diff --git a/src/gallium/targets/dri/dri_target.c b/src/gallium/targets/dri/dri_target.c
-index 9d3069eb004..79f60a7224a 100644
---- a/src/gallium/targets/dri/dri_target.c
-+++ b/src/gallium/targets/dri/dri_target.c
-@@ -101,6 +101,9 @@
- 
- #if defined(GALLIUM_KMSRO)
- DEFINE_LOADER_DRM_ENTRYPOINT(armada_drm)
-+DEFINE_LOADER_DRM_ENTRYPOINT(drm_rp1_dpi)
-+DEFINE_LOADER_DRM_ENTRYPOINT(drm_rp1_dsi)
-+DEFINE_LOADER_DRM_ENTRYPOINT(drm_rp1_vec)
- DEFINE_LOADER_DRM_ENTRYPOINT(exynos)
- DEFINE_LOADER_DRM_ENTRYPOINT(gm12u320)
- DEFINE_LOADER_DRM_ENTRYPOINT(hdlcd)
 -- 
 2.39.2
 


### PR DESCRIPTION
dri3: https://gitlab.freedesktop.org/mesa/mesa/-/commit/8f6fca89aa1812b03da6d9f7fac3966955abc41e
gallium-omx: https://gitlab.freedesktop.org/mesa/mesa/-/commit/9b6c27a320ab4b0fcf1fb16220ae7c3d3f06f7df
selinux: https://gitlab.freedesktop.org/mesa/mesa/-/commit/894c4f0c7889fbaeea3e4ab289cb505eb3643976

rpi-dri: https://gitlab.freedesktop.org/mesa/mesa/-/commit/80cc7d0c3455e9a44324cd8482a3807f00640794

ann:
24.3.0-rc1: https://lists.freedesktop.org/archives/mesa-announce/2024-November/000783.html

### 24.3.0-rc1 Build tested on all of:
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build mesa
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build mesa
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build mesa
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build mesa
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build mesa
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build mesa
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build mesa
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build mesa
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build mesa
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build mesa
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build mesa
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build mesa
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build mesa
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build mesa

PROJECT=Amlogic ARCH=aarch64 DEVICE=AMLGX s/build mesa

PROJECT=RPi ARCH=arm DEVICE=RPi2 s/build mesa
PROJECT=RPi ARCH=aarch64 DEVICE=RPi4 s/build mesa
PROJECT=RPi ARCH=aarch64 DEVICE=RPi5 s/build mesa
```