### PR TITLE
[le12] RPi: brcmfmac: disable SAE authentication offload

### DIFF
--- a/projects/RPi/packages/linux/modprobe.d/brcmfmac.conf
+++ b/projects/RPi/packages/linux/modprobe.d/brcmfmac.conf
@@ -1,0 +1,2 @@
+# Disable SAE authentication offload until it works with iwd
+options brcmfmac feature_disable=0x400000


### PR DESCRIPTION
Backport of #9477