### PR TITLE
[le12] linux (RPi): update to 6.6.60

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="2e85eb0e4950c5ad27df5a3ba54300e89694eba4" # 6.6.57
-    PKG_SHA256="fbe512ed926af715aff02f3cbb78581c76d63791475555a71a019a81f8957061"
+    PKG_VERSION="1af976d476424009ac9d93313a9fad9cbb5498ae" # 6.6.58
+    PKG_SHA256="f80bb95adca44a0751a9bd50eb7ed8bbabddb3f7abc8e3393c1e33a3322c36f2"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="ce65ed02cb6707ae5c9f3a304f5b0124f4eed559" # 6.6.59
-    PKG_SHA256="cf440cccb745d4615dffeaa6636669e4539c12579c7f1c68f4ab87838cb85c21"
+    PKG_VERSION="d88807c99557a604eaca435ffa52f86c53092f89" # 6.6.59
+    PKG_SHA256="3bcc87cceff346a3ad1900430f4ca75984012619c3d57e07ac1b876e7f2e8469"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="3f11c402c97dbefd17632b8e11ea738c09117c0a" # 6.6.60
-    PKG_SHA256="394eda2e4ebe0ceb095f175ff8ef422210d742e5507dcb06d7d3e55618840b2a"
+    PKG_VERSION="66aef6ce3557edd9d58d794e4a800c5be49ca0e7" # 6.6.60
+    PKG_SHA256="6e9843b8954faa1e5195aaf3a76a43fcc2ddb6cd152f628605d0e2ce61f551ea"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="1af976d476424009ac9d93313a9fad9cbb5498ae" # 6.6.58
-    PKG_SHA256="f80bb95adca44a0751a9bd50eb7ed8bbabddb3f7abc8e3393c1e33a3322c36f2"
+    PKG_VERSION="37b55322c1b222a76da6f55492f181258814a168" # 6.6.59
+    PKG_SHA256="0576331a646dfa3ced896ed7ac3b96307604d6278b0588b3245a9e8cbcee1e60"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="37b55322c1b222a76da6f55492f181258814a168" # 6.6.59
-    PKG_SHA256="0576331a646dfa3ced896ed7ac3b96307604d6278b0588b3245a9e8cbcee1e60"
+    PKG_VERSION="624eb357e1a16385b3d6171e9194e4c5f8d4fd5f" # 6.6.59
+    PKG_SHA256="d8c09a40c18dba633a89bcac6a71ffc9791ba065335cdb91f39a74a7f4078e60"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="8ee418c866c263941fb468bc1eeab1d8059db705" # 6.6.57
-    PKG_SHA256="0e556ee6ae2013956f3edbb8a2ae01e79f3ec958b62e8e6b6e8316ea0375b795"
+    PKG_VERSION="527d6f5a7861e24c60d41e9706ec4589165321d1" # 6.6.57
+    PKG_SHA256="e1c771749464caa3d7c8b998a2378ce21d9fae50f4a0ce75c3b2a65eda41eaa0"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="527d6f5a7861e24c60d41e9706ec4589165321d1" # 6.6.57
-    PKG_SHA256="e1c771749464caa3d7c8b998a2378ce21d9fae50f4a0ce75c3b2a65eda41eaa0"
+    PKG_VERSION="2e85eb0e4950c5ad27df5a3ba54300e89694eba4" # 6.6.57
+    PKG_SHA256="fbe512ed926af715aff02f3cbb78581c76d63791475555a71a019a81f8957061"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="624eb357e1a16385b3d6171e9194e4c5f8d4fd5f" # 6.6.59
-    PKG_SHA256="d8c09a40c18dba633a89bcac6a71ffc9791ba065335cdb91f39a74a7f4078e60"
+    PKG_VERSION="ce65ed02cb6707ae5c9f3a304f5b0124f4eed559" # 6.6.59
+    PKG_SHA256="cf440cccb745d4615dffeaa6636669e4539c12579c7f1c68f4ab87838cb85c21"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="d88807c99557a604eaca435ffa52f86c53092f89" # 6.6.59
-    PKG_SHA256="3bcc87cceff346a3ad1900430f4ca75984012619c3d57e07ac1b876e7f2e8469"
+    PKG_VERSION="3f11c402c97dbefd17632b8e11ea738c09117c0a" # 6.6.60
+    PKG_SHA256="394eda2e4ebe0ceb095f175ff8ef422210d742e5507dcb06d7d3e55618840b2a"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/patches/raspberrypi/linux-001-Revert-DTS-bcm2712-re-enable-SD-slot-CQE-by-default-.patch
+++ b/packages/linux/patches/raspberrypi/linux-001-Revert-DTS-bcm2712-re-enable-SD-slot-CQE-by-default-.patch
@@ -1,0 +1,47 @@
+From be6a324c450c40a2c2c9461fcd8258ec07338d0a Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Wed, 13 Nov 2024 00:14:13 +0100
+Subject: [PATCH 1/3] Revert "DTS: bcm2712; re-enable SD slot CQE by default on
+ Pi 5"
+
+This reverts commit 48a15bc46004025776880a091d47a22e03449acc.
+
+CQE still seems to experimental and cause issues with some cards
+so keep it disabled by default for now.
+---
+ arch/arm/boot/dts/overlays/README                | 6 +++---
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts | 1 -
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/boot/dts/overlays/README b/arch/arm/boot/dts/overlays/README
+index 5c6344eb6f98..af1d82cffd47 100644
+--- a/arch/arm/boot/dts/overlays/README
++++ b/arch/arm/boot/dts/overlays/README
+@@ -378,9 +378,9 @@ Params:
+                                 non-lite SKU of CM4).
+                                 (default "on")
+ 
+-        sd_cqe                  Set to "off" to disable Command Queueing if you
+-                                have an incompatible Class A2 SD card
+-                                (Pi 5 only, default "on")
++        sd_cqe                  Use to enable Command Queueing on the SD
++                                interface for faster Class A2 card performance
++                                (Pi 5 only, default "off")
+ 
+         sd_overclock            Clock (in MHz) to use when the MMC framework
+                                 requests 50MHz
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+index a63ee4b678a1..56d416e82dd5 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+@@ -365,7 +365,6 @@ &sdio1 {
+ 	sd-uhs-sdr50;
+ 	sd-uhs-ddr50;
+ 	sd-uhs-sdr104;
+-	supports-cqe;
+ 	cd-gpios = <&gio_aon 5 GPIO_ACTIVE_LOW>;
+ 	//no-1-8-v;
+ 	status = "okay";
+-- 
+2.39.5
+

--- a/packages/linux/patches/raspberrypi/linux-002-dts-bcm2711-drop-numa_policy-from-bootargs.patch
+++ b/packages/linux/patches/raspberrypi/linux-002-dts-bcm2711-drop-numa_policy-from-bootargs.patch
@@ -1,0 +1,43 @@
+From 2d02a2c7531d2b7573237e0e7604b8d51c26583b Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Wed, 13 Nov 2024 00:16:47 +0100
+Subject: [PATCH 2/3] dts: bcm2711: drop numa_policy from bootargs
+
+We don't compile the kernel with NUMA so drop the numa parameter
+from bootargs.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts | 2 +-
+ arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
+index 71d228414b76..c48a0880539d 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
+@@ -148,7 +148,7 @@ soc {
+ 
+ / {
+ 	chosen {
+-		bootargs = "coherent_pool=1M snd_bcm2835.enable_headphones=0 cgroup_disable=memory numa_policy=interleave";
++		bootargs = "coherent_pool=1M snd_bcm2835.enable_headphones=0 cgroup_disable=memory";
+ 	};
+ 
+ 	aliases {
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+index eb3abcdbae6b..32453b394ded 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+@@ -3,7 +3,7 @@
+ 
+ / {
+ 	chosen {
+-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 cgroup_disable=memory numa_policy=interleave";
++		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 cgroup_disable=memory";
+ 	};
+ 
+ 	__overrides__ {
+-- 
+2.39.5
+

--- a/packages/linux/patches/raspberrypi/linux-003-dts-bcm2712-drop-numa_policy-from-bootargs.patch
+++ b/packages/linux/patches/raspberrypi/linux-003-dts-bcm2712-drop-numa_policy-from-bootargs.patch
@@ -1,0 +1,29 @@
+From 0d692f7a53559259b1532b0503788f557e5ff182 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Wed, 13 Nov 2024 00:16:47 +0100
+Subject: [PATCH 3/3] dts: bcm2712: drop numa_policy from bootargs
+
+We don't compile the kernel with NUMA so drop the numa parameter
+from bootargs.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+index 65abbb450daf..6bb6e81313b5 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+@@ -99,7 +99,7 @@ vdd_5v0_reg: fixedregulator_5v0 {
+ 
+ / {
+ 	chosen: chosen {
+-		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave";
++		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory";
+ 		stdout-path = "serial10:115200n8";
+ 	};
+ 
+-- 
+2.39.5
+

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="feeef0db2b537098cd7a4b53e6bdc9885a14ab01"
-PKG_SHA256="52717930ef9898456cf798016f1c68f1896b723cb89d5761d6af65d2aeb2db72"
+PKG_VERSION="482750873c8ab9b5dabe2f29ccabdd4ef8c4b98d"
+PKG_SHA256="bdf942904148c57e0e1aa0fbf8d2b0f5b4a74f604c596b4e6adfb5322782b62e"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="3c822369bec71a2f10514994b6f491d8e2323f9e"
-PKG_SHA256="9cb1ce430a84ce4790920ec5e55502751bd92797708eab6881ae56e15e396a4c"
+PKG_VERSION="e9717985d26205a790d5dbc77b8dbadcadb52e05"
+PKG_SHA256="ee4540a6ced3a177c21a13d8d1c3d7798315bab7bc481288e60e58b88a249eeb"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="89e9c75babbe7ba6fb3838f1a97a079758bc196f"
-PKG_SHA256="e742493d4d85bd6b0ab1def82ac04359a6ea2db153fae828d9b4cb7f23d83317"
+PKG_VERSION="cc0ad4698ee2c1b415285270a4e91229c63e19b5"
+PKG_SHA256="fb9ba96ad8d80e164dd75ea51e7b2d98da033d708ce4e97ebe684badbb843208"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="e9717985d26205a790d5dbc77b8dbadcadb52e05"
-PKG_SHA256="ee4540a6ced3a177c21a13d8d1c3d7798315bab7bc481288e60e58b88a249eeb"
+PKG_VERSION="89e9c75babbe7ba6fb3838f1a97a079758bc196f"
+PKG_SHA256="e742493d4d85bd6b0ab1def82ac04359a6ea2db153fae828d9b4cb7f23d83317"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.57 Kernel Configuration
+# Linux/arm 6.6.59 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -5147,6 +5147,7 @@ CONFIG_PWM_SYSFS=y
 CONFIG_PWM_BCM2835=m
 # CONFIG_PWM_CLK is not set
 # CONFIG_PWM_FSL_FTM is not set
+CONFIG_PWM_GPIO=m
 # CONFIG_PWM_PCA9685 is not set
 CONFIG_PWM_RASPBERRYPI_POE=m
 # CONFIG_PWM_RP1 is not set

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.57 Kernel Configuration
+# Linux/arm 6.6.59 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -5385,6 +5385,7 @@ CONFIG_PWM_SYSFS=y
 CONFIG_PWM_BCM2835=m
 # CONFIG_PWM_CLK is not set
 # CONFIG_PWM_FSL_FTM is not set
+CONFIG_PWM_GPIO=m
 # CONFIG_PWM_PCA9685 is not set
 CONFIG_PWM_RASPBERRYPI_POE=m
 # CONFIG_PWM_RP1 is not set

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.57 Kernel Configuration
+# Linux/arm64 6.6.59 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -6139,6 +6139,7 @@ CONFIG_PWM_BCM2835=m
 # CONFIG_PWM_CLK is not set
 # CONFIG_PWM_DWC is not set
 # CONFIG_PWM_FSL_FTM is not set
+CONFIG_PWM_GPIO=m
 # CONFIG_PWM_PCA9685 is not set
 CONFIG_PWM_RASPBERRYPI_POE=m
 # CONFIG_PWM_RP1 is not set

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.57 Kernel Configuration
+# Linux/arm64 6.6.59 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -6198,6 +6198,7 @@ CONFIG_PWM_BRCMSTB=y
 # CONFIG_PWM_CLK is not set
 # CONFIG_PWM_DWC is not set
 # CONFIG_PWM_FSL_FTM is not set
+CONFIG_PWM_GPIO=m
 # CONFIG_PWM_PCA9685 is not set
 CONFIG_PWM_RASPBERRYPI_POE=m
 CONFIG_PWM_RP1=y


### PR DESCRIPTION
Partial backport of #9492

The experimental NUMA emulation options on RPi4/5 are not enabled for LE12 and SD command queueing on RPi5 has been disabled by default as it still seems to cause some issues.

Runtime tested on RPi4 and RPi5