### PR TITLE
mesa: update to 24.2.7

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="24.2.6"
-PKG_SHA256="2b68c4a6f204c1999815a457299f81c41ba7bf48c4674b0b2d1d8864f41f3709"
+PKG_VERSION="24.2.7"
+PKG_SHA256="a0ce37228679647268a83b3652d859dcf23d6f6430d751489d4464f6de6459fd"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
The bugfix release 24.2.7 is now available.

If you find any issues, please report them here:
https://gitlab.freedesktop.org/mesa/mesa/-/issues/new

The next bugfix release is due in two weeks, on November 27th.

Cheers,
  Eric

---

Benjamin Herrenschmidt (1):
      dril: Fixup order of pixel formats in drilConfigs

Christian Gmeiner (1):
      etnaviv: Fix incorrect pipe_nn creation

Connor Abbott (1):
      ir3: Fix detection of nontrivial continues

David Rosca (1):
      radeonsi/vcn: Enable VCN4 AV1 encode WA

Eric Engestrom (11):
      docs: add sha sum for 24.2.6
      .pick_status.json: Update to ab1479ae6a845d2c7beeb0fed6e2153cc2b16c5e
      .pick_status.json: Update to fe50011ddb35077c0d4cc2b31d56f8dd1376d5a2
      meson: add dependencies needed by wsi_common_x11.c even on non-drm platforms
      .pick_status.json: Update to 4d09cd7fa590cbd52d8772d5a251fab8b0874ab7
      .pick_status.json: Mark 5cd054ebe5512aeac80e08528d8363335d0aeeb8 as denominated
      .pick_status.json: Update to b32d0d4b4588bf207a9b85b03f2f1c7bb9e72d57
      ci: raise priority of release manager pipelines
      lima/ci: marking two failures as known to make the ci useful again
      docs: add release notes for 24.2.7
      VERSION: bump for 24.2.7

Ian Romanick (2):
      brw/copy: Don't copy propagate through smaller entry dest size
      brw/cse: Don't eliminate instructions that write flags

Job Noorman (1):
      ir3/ra: prevent moving source intervals for shared collects

Jose Maria Casanova Crespo (1):
      v3d: Enable Early-Z with discards when depth updates are disabled

Karmjit Mahil (3):
      tu: Fix push_set host memory leak on command buffer reset
      tu: Fix potential alloc of 0 size
      nir: Fix `no_lower_set` leak on early return

Karol Herbst (2):
      nv/codegen: Do not use a zero immediate for tex instructions
      nvc0: return NULL instead of asserting in nvc0_resource_from_user_memory

Lionel Landwerlin (5):
      anv: avoid L3 fabric flush in pipeline barriers
      vulkan/runtime: fix allocation failure handling
      anv: fix even set/reset on blitter engine
      anv: add texture cache inval after binding pool update
      anv: update shader descriptor resource limits

Lucas Fryzek (1):
      lp: Only close udmabuf handle if its valid

M Henning (2):
      nvk/cmd_buffer: Pass count to set_root_array
      nvk: Fix invalidation of NVK_CBUF_TYPE_DYNAMIC_UBO

Marek Olšák (2):
      radeonsi/gfx11: fix Z corruption for Blender
      radeonsi/gfx12: fix AMD_DEBUG=nodcc not working

Matt Turner (1):
      anv: Align anv_descriptor_pool::host_mem

Mike Blumenkrantz (1):
      zink: stop leaking precompiled generated tcs

Patrick Lerda (1):
      r600: fix sfn_nir_legalize_image_load_store cubearray behavior

Paulo Zanoni (1):
      brw: add a NOP in between WHILE instructions on LNL

Rhys Perry (1):
      aco: don't byte align global VMEM loads if it might be unsafe

Rob Clark (3):
      util/primconvert: Avoid OoB with improbable draws
      freedreno: Fix tile-per-pipe debug overrides
      freedreno/a6xx: Stop exposing MSAA image load/store harder

Samuel Pitoiset (2):
      radv: add missing L2 non-coherent image case for mipmaps with DCC/HTILE on GFX11
      radv: cleanup tools related resources when destroying logical device

Timur Kristóf (1):
      radv: Flush L2 cache for non-L2-coherent images in EndCommandBuffer.

Tomeu Vizoso (1):
      etnaviv/ml: Fix includes

itycodes (1):
      intel: Fix a typo in intel_device_info.c:has_get_tiling

git tag: mesa-24.2.7
