### PR TITLE
package updates

### DIFF
--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-lib"
-PKG_VERSION="1.2.12"
-PKG_SHA256="4868cd908627279da5a634f468701625be8cc251d84262c7e5b6a218391ad0d2"
+PKG_VERSION="1.2.13"
+PKG_SHA256="8c4ff37553cbe89618e187e4c779f71a9bb2a8b27b91f87ed40987cc9233d8f6"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.alsa-project.org/"
 PKG_URL="https://www.alsa-project.org/files/pub/lib/alsa-lib-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/alsa-ucm-conf/package.mk
+++ b/packages/audio/alsa-ucm-conf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-ucm-conf"
-PKG_VERSION="1.2.12"
-PKG_SHA256="168e7c0549b7bf8991092fa2bfb903631df779dc4c43ee8f4277fcb772d8c035"
+PKG_VERSION="1.2.13"
+PKG_SHA256="4483b6e3983cca08fd326a73fbae449b5036e444fb1a07c0dee74b504b7ab5af"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="https://www.alsa-project.org/"
 PKG_URL="https://www.alsa-project.org/files/pub/lib/alsa-ucm-conf-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/alsa-utils/package.mk
+++ b/packages/audio/alsa-utils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="alsa-utils"
-PKG_VERSION="1.2.12"
-PKG_SHA256="98bc6677d0c0074006679051822324a0ab0879aea558a8f68b511780d30cd924"
+PKG_VERSION="1.2.13"
+PKG_SHA256="1702a6b1cdf9ba3e996ecbc1ddcf9171e6808f5961d503d0f27e80ee162f1daa"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.alsa-project.org/"
 PKG_URL="https://www.alsa-project.org/files/pub/utils/alsa-utils-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/groovy/package.mk
+++ b/packages/devel/groovy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="groovy"
-PKG_VERSION="4.0.23"
-PKG_SHA256="7089dd7a1e84adc814d616f5ec2f7d7dac2044a0a0457f3341b3b92d30204229"
+PKG_VERSION="4.0.24"
+PKG_SHA256="dbff36835568bec2271876f70bfcca6deb80e1b179453cca934a502ea301bb80"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://groovy.apache.org"
 PKG_URL="https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-${PKG_VERSION}.zip"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.19.2"
-PKG_SHA256="f73eb786e75ef1f815ed3d37aca9eadd41dc1d26dfde11f8a4f92f911622d19e"
+PKG_VERSION="1.19.3"
+PKG_SHA256="1e6d3bb5216888a78fbbf5fd958cd3cf3b941aceb002d2a8d635f85cc59a8599"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20241029"
-PKG_SHA256="1cae9cde48fb44444ed40ce045c34a1debbc8cfff3fb84e44c62798459f818c3"
+PKG_VERSION="20241112"
+PKG_SHA256="37246208ef68039be752438c72400a688a2238df13a7f5282497c80be2d8366d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="75.4.0"
-PKG_SHA256="1dc484f5cf56fd3fe7216d7b8df820802e7246cfb534a1db2aa64f14fcb9cdcb"
+PKG_VERSION="75.5.0"
+PKG_SHA256="5c4ccb41111392671f02bb5f8436dfc5a9a7185e80500531b133f5775c4163ef"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/waf/package.mk
+++ b/packages/python/devel/waf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="waf"
-PKG_VERSION="2.1.3"
-PKG_SHA256="d580873e9461c55fb91fa03d21eb9872c3acbdec6793448ab50746958d3d7757"
+PKG_VERSION="2.1.4"
+PKG_SHA256="2a128298be763e23987780b8993cefae3dc362596e46906f7ec2ed4795028c26"
 PKG_LICENSE="MIT"
 PKG_SITE="https://waf.io"
 PKG_URL="https://waf.io/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.13.4"
-PKG_SHA256="ba783b43e8b3475cbd2b1ef40474da6a4465105ee9818d76cd3ac7863550afce"
+PKG_VERSION="2.13.5"
+PKG_SHA256="0d87484ecf395eca1e178976966f20885b050253695d5605646b66982df61325"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- waf: update to 2.1.4
- setuptools: update to 75.5.0
- libxml2: update to 2.13.5
- groovy: update to 4.0.24
- alsa-utils: update to 1.2.13
- alsa-ucm-conf: update to 1.2.13
- alsa-lib: update to 1.2.13
- intel-ucode: update to 20241112
- libheif: update to 1.19.3