### PR TITLE
jellyfin: update to 10.10.1 and addon (2)

### DIFF
--- a/packages/addons/service/jellyfin/package.mk
+++ b/packages/addons/service/jellyfin/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="jellyfin"
 PKG_VERSION="1.0"
-PKG_VERSION_NUMBER="10.9.11"
-PKG_REV="1"
+PKG_VERSION_NUMBER="10.10.1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://jellyfin.org/"


### PR DESCRIPTION
release notes:
- https://github.com/jellyfin/jellyfin/releases/tag/v10.10.0
- https://github.com/jellyfin/jellyfin/releases/tag/v10.10.1