### PR TITLE
kodi: update to githash 65703fe

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="3f6829c18a74f3ca68d4644cec33aa2294f443ea"
-PKG_SHA256="ada10eb9f7d89cf6d328582d3d747cbceb34513aca01e3a355a86a8f9be80a36"
+PKG_VERSION="65703fe91c077d8cc11be4ba10221b56cd38d30b"
+PKG_SHA256="74dbd28a417509f7a7c3a60648ade60b193bc5d34d1c24afb6e3235d1443015a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
log:
- https://github.com/xbmc/xbmc/compare/3f6829c18a74f3ca68d4644cec33aa2294f443ea...65703fe91c077d8cc11be4ba10221b56cd38d30b

```
=== tested on ===
Generic.x86_64-devel-20241116021420-660ae2e
Linux nuc12 6.12.0-rc7 #1 SMP Thu Nov 14 05:59:14 UTC 2024 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:65703fe91c077d8cc11be4ba10221b56cd38d30b). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2024-11-16 by GCC 14.2.0 for Linux x86 64-bit version 6.12.0 (396288)
Running on LibreELEC (heitbaum): devel-20241116021420-660ae2e 13.0, kernel: Linux x86 64-bit version 6.12.0-rc7
FFmpeg version/source: 6.0.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
[    0.000000] DMI: Memory slots populated: 1/2
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.3.0-rc2
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.4.1 (b8f992d22f)
```