### PR TITLE
talloc: don't build python modules

### DIFF
--- a/packages/devel/talloc/package.mk
+++ b/packages/devel/talloc/package.mk
@@ -23,6 +23,7 @@ configure_package() {
                       --cross-compile \
                       --cross-answers=${PKG_BUILD}/cache.txt \
                       --hostcc=gcc \
+                      --disable-python \
                       --disable-rpath \
                       --disable-rpath-install \
                       --disable-rpath-private-install"


### PR DESCRIPTION
currently clean builds fail because talloc is looking for python but package.mk doesn't have a dependency on Python3.

eg scripts/build_mt talloc
```
Checking for python version >= 3.6.0                                                            : 3.12.7
python-config                                                                                   : /home/hias/libreelec/libreelec-master/build.LibreELEC-RPi5.aarch64-13.0-devel/toolchain/aarch64-libreelec-linux-gnu/sysroot/usr/bin/python3-config
Checking for library python3.12 in LIBPATH_PYEMBED                                              : not found 
Checking for library python3.12 in LIBDIR                                                       : not found
Checking for library python3.12 in python_LIBPL                                                 : not found 
Checking for library python3.12 in $prefix/libs                                                 : not found
Checking for library python3.12 in $INCLUDEPY/../libs                                           : not found 
Checking for library python3.12m in LIBPATH_PYEMBED                                             : not found
Checking for library python3.12m in LIBDIR                                                      : not found
Checking for library python3.12m in python_LIBPL                                                : not found
Checking for library python3.12m in $prefix/libs                                                : not found
Checking for library python3.12m in $INCLUDEPY/../libs                                          : not found
Checking for library python312 in LIBPATH_PYEMBED                                               : not found
Checking for library python312 in LIBDIR                                                        : not found
Checking for library python312 in python_LIBPL                                                  : not found
Checking for library python312 in $prefix/libs                                                  : not found
Checking for library python312 in $INCLUDEPY/../libs                                            : not found
Checking for header Python.h                                                                    : Could not build a Python embedded interpreter 
The configuration failed
(complete log in /home/hias/libreelec/libreelec-master/build.LibreELEC-RPi5.aarch64-13.0-devel/build/talloc-2.4.2/bin/config.log)
FAILURE: scripts/build talloc:target during configure_target (package.mk)
*********** FAILED COMMAND ***********
PYTHON_CONFIG="${SYSROOT_PREFIX}/usr/bin/python3-config" python_LDFLAGS="" python_LIBDIR="" PYTHON=${TOOLCHAIN}/bin/python3 ./configure ${PKG_CONFIGURE_OPTS}
**************************************
FAILURE: scripts/build talloc:target has failed!
```

As only the shared lib is installed to target, but not the python modules, simply disable python modules to fix builds.