### PR TITLE
glibc: update enable-kernel=6.12.0

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -31,7 +31,7 @@ PKG_CONFIGURE_OPTS_TARGET="BASH_SHELL=/bin/sh \
                            --with-__thread \
                            --with-binutils=${BUILD}/toolchain/bin \
                            --with-headers=${SYSROOT_PREFIX}/usr/include \
-                           --enable-kernel=6.6.0 \
+                           --enable-kernel=6.12.0 \
                            --without-cvs \
                            --without-gd \
                            --disable-build-nscd \


### PR DESCRIPTION
Now all kernels are 6.12, update the api to 6.12.