### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.23.3"
-PKG_SHA256="a179458ab932cbc54a75db1a9f239216c083902db554fcffe0546b7df2235f10"
+PKG_VERSION="1.23.4"
+PKG_SHA256="ec4a641e8919b21eb6d189a9d0621008015c2bb6fd204fd65fdfeb4c68d9301a"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.5.6"
-PKG_SHA256="ce7b7217d880bed1438e408ea412716a259cb46b09f597bfd652a577dc60185c"
+PKG_VERSION="0.5.7"
+PKG_SHA256="8cd43a582f68368ee5a915e97bf9dadc44d2dfe8c7bb4f96bb7b40ea2ed7848f"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.389"
-PKG_SHA256="34813e6821a5dab0f663a363026e4d17e880e5f5f2ed49244c42263b226ff98a"
+PKG_VERSION="0.390"
+PKG_SHA256="f10684093d2a7780de8a96d3dd8a2dd544ed6136dd359197750c42bb08ce526f"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.123"
-PKG_SHA256="a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e"
+PKG_VERSION="2.4.124"
+PKG_SHA256="ac36293f61ca4aafaf4b16a2a7afff312aa4f5c37c9fbd797de9e3c0863ca379"
 PKG_LICENSE="GPL"
 PKG_SITE="https://dri.freedesktop.org"
 PKG_URL="https://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="19.1.4"
-PKG_SHA256="3aa2d2d2c7553164ad5c6f3b932b31816e422635e18620c9349a7da95b98d811"
+PKG_VERSION="19.1.5"
+PKG_SHA256="bd8445f554aae33d50d3212a15e993a667c0ad1b694ac1977f3463db3338e542"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
 PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION/-/}.src.tar.xz"

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Mako"
-PKG_VERSION="1.3.6"
-PKG_SHA256="9ec3a1583713479fae654f83ed9fa8c9a4c16b7bb0daba0e6bbebff50c0d983d"
+PKG_VERSION="1.3.7"
+PKG_SHA256="20405b1232e0759f0e7d87b01f6bb94fce0761747f1cb876ecf90bd512d0b639"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/Mako"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/mako-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="systemd"
-PKG_VERSION="256.8"
-PKG_SHA256="b3d003b4f6d1ab0bfae0cf7a37c4aa559923c49bc8e9d1331b7459e12ebc357a"
+PKG_VERSION="256.9"
+PKG_SHA256="9f2bda967a30ec4602e7ea93d565eb43670ca1dffbb808c72758d5f0213508c8"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/x11/lib/pixman/package.mk
+++ b/packages/x11/lib/pixman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pixman"
-PKG_VERSION="0.44.0"
-PKG_SHA256="ea55473db5ec9f068bbf4d14ec3186b742804bf74fdc782fc89aa87d2656fc46"
+PKG_VERSION="0.44.2"
+PKG_SHA256="50baf820dde0c5ff9714d03d2df4970f606a3d3b1024f5404c0398a9821cc4b0"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.x.org/"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- libdrm: update to 2.4.124
- hwdata: update to 0.390
- go: update to 1.23.4
- Mako: update to 1.3.7
- llvm: update to 19.1.5
- systemd: update to 256.9
- pixman: update to 0.44.2
- wireplumber: update to 0.5.7