### PR TITLE
ntfs3g: service: avoid error on shutdown / update addon (1)

### DIFF
--- a/packages/addons/service/ntfs3g/package.mk
+++ b/packages/addons/service/ntfs3g/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ntfs3g"
-PKG_REV="0"
+PKG_REV="1"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain fuse ntfs-3g_ntfsprogs"
 PKG_SECTION="service"

--- a/packages/addons/service/ntfs3g/source/system.d/service.ntfs3g.service
+++ b/packages/addons/service/ntfs3g/source/system.d/service.ntfs3g.service
@@ -5,7 +5,7 @@ Before=samba-config.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/mount -o bind /storage/.kodi/addons/service.ntfs3g/bin/mount.ntfs3g /usr/sbin/mount.ntfs
-ExecStop=/usr/bin/umount /usr/sbin/mount.ntfs
+ExecStop=/bin/sh -c 'grep -q " /usr/sbin/mount.ntfs " /proc/self/mounts && umount /usr/sbin/mount.ntfs || true'
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
Suppress error on shutdown.:
```
Dec 05 19:29:44 lepxe12 systemd[1]: Unmounting usr-sbin-mount.ntfs.mount...

Dec 05 19:29:44 lepxe12 systemd[1]: usr-sbin-mount.ntfs.mount: Deactivated successfully.
Dec 05 19:29:44 lepxe12 systemd[1]: Unmounted usr-sbin-mount.ntfs.mount.

Dec 05 19:29:50 lepxe12 systemd[1]: Stopping service.ntfsfix-mount.service...
Dec 05 19:29:50 lepxe12 umount[1068]: umount: /usr/sbin/mount.ntfs: not mounted.
Dec 05 19:29:50 lepxe12 systemd[1]: service.ntfsfix-mount.service: Control process exited, code=exited, status=32/n/a
Dec 05 19:29:50 lepxe12 systemd[1]: service.ntfsfix-mount.service: Failed with result 'exit-code'.
Dec 05 19:29:50 lepxe12 systemd[1]: Stopped service.ntfsfix-mount.service.
```

Bind mount /usr/sbin/mount/ntfs.mount may already be unmounted due to parallel execution of
shutdown.target and umount.target.

Add mount check before unmounting.
