### PR TITLE
Patches to support gcc-15 and -std=c23

### DIFF
--- a/packages/addons/addon-depends/comskip/patches/comskip-gcc15.patch
+++ b/packages/addons/addon-depends/comskip/patches/comskip-gcc15.patch
@@ -1,0 +1,11 @@
+--- a/comskip.c	2024-12-09 13:06:15.051318034 +0000
++++ b/comskip.c	2024-12-09 13:07:54.348640394 +0000
+@@ -976,7 +976,7 @@
+ int					FindUniformThreshold(double percentile);
+ void				OutputFrameArray(bool screenOnly);
+ void                OutputBlackArray();
+-void				OutputFrame();
++void				OutputFrame(int frame_number);
+ void				OpenOutputFiles();
+ void				InitializeFrameArray(long i);
+ void				InitializeBlackArray(long i);

--- a/packages/addons/addon-depends/dvb-tools-depends/dvbsnoop/patches/dvbsnoop-0004-fix-build-with-gcc-15.patch
+++ b/packages/addons/addon-depends/dvb-tools-depends/dvbsnoop/patches/dvbsnoop-0004-fix-build-with-gcc-15.patch
@@ -1,0 +1,80 @@
+From 3e29c53dd3f664b015d3048f22fb1235b37b63ed Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 8 Dec 2024 11:33:28 +0000
+Subject: [PATCH] fix build with gcc 15
+
+update function declarations to allow build without the follow errors:
+
+error: initialization of 'void (*)(void)' from incompatible pointer type
+       'void (*)(...)' [-Wincompatible-pointer-types]
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ src/misc/sig_abort.c     | 4 ++--
+ src/private/userdefs.c   | 2 +-
+ src/private/userdefs.h   | 4 ++--
+ src/sections/sectables.c | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/misc/sig_abort.c b/src/misc/sig_abort.c
+index c359804..7443281 100644
+--- a/src/misc/sig_abort.c
++++ b/src/misc/sig_abort.c
+@@ -37,8 +37,8 @@ static void NullHandler   (int sig_nr);
+ // catch these signals 
+ static struct {
+    	int 	sig;
+-   	void	(*new_handler)();
+-   	void	(*org_handler)();
++   	void	(*new_handler)(int);
++   	void	(*org_handler)(int);
+ } signalList[] = {
+ 	{ SIGHUP,  SmoothHandler,   NullHandler }, // -1  terminate smoothly
+ 	{ SIGQUIT, SmoothHandler,   NullHandler }, // -3  terminate smoothly
+diff --git a/src/private/userdefs.c b/src/private/userdefs.c
+index ee632fa..1a1bb89 100644
+--- a/src/private/userdefs.c
++++ b/src/private/userdefs.c
+@@ -50,7 +50,7 @@
+ 
+ typedef struct _PRIVATE_PROVIDER_FUNC {
+     char     *str;          /* e.g. "premiere.de" */
+-    void     (*func)();     /* function for getting table & descriptors */
++    void     (*func)(PRIV_SECTION_ID_FUNC **, PRIV_DESCR_ID_FUNC **);     /* function for getting table & descriptors */
+ } PRIV_PROVIDER_FUNC;
+ 
+ 
+diff --git a/src/private/userdefs.h b/src/private/userdefs.h
+index d4da7ae..e3062f1 100644
+--- a/src/private/userdefs.h
++++ b/src/private/userdefs.h
+@@ -25,14 +25,14 @@
+ 
+ typedef struct _PRIVATE_SECTION_STRUCTURES_FUNC {
+     u_int    table_id;         	/* section table ID */
+-    void     (*func)();  	/* function for table decoding */
++    void     (*func)(unsigned char *, int);  	/* function for table decoding */
+ } PRIV_SECTION_ID_FUNC;
+ 
+ 
+ typedef struct _PRIVATE_DESCRIPTOR_STRUCTURES_FUNC {
+     u_int      descriptor_tag; 	/* descriptor tag ID */
+     DTAG_SCOPE tag_scope;	/* MPEG, DVB_SI, DSMCC_STREAM, ... */
+-    void       (*func)();  	/* function for descriptor decoding */
++    void       (*func)(unsigned char *);  	/* function for descriptor decoding */
+ } PRIV_DESCR_ID_FUNC;
+ 
+ 
+diff --git a/src/sections/sectables.c b/src/sections/sectables.c
+index 58837df..8ddcb4a 100644
+--- a/src/sections/sectables.c
++++ b/src/sections/sectables.c
+@@ -181,7 +181,7 @@ void decodeSI_packet (u_char *buf, int len, u_int pid)
+ typedef struct _TABLE_IF_FUNC {
+     u_int    from;          /* e.g. from tabel_id 1  */
+     u_int    to;            /*      to   tabel_id 3  */
+-    void     (*func)();     /*      function for table decoding */
++    void     (*func)(unsigned char *, int);     /*      function for table decoding */
+ } TABLE_ID_FUNC;
+ 
+ 

--- a/packages/addons/addon-depends/dvb-tools-depends/t2scan/patches/t2scan-17-fix-building-with-gcc-15.patch
+++ b/packages/addons/addon-depends/dvb-tools-depends/t2scan/patches/t2scan-17-fix-building-with-gcc-15.patch
@@ -1,0 +1,70 @@
+From 8c7a865acea83d5144dd075ef40e0d4a3863b6b1 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 8 Dec 2024 11:51:12 +0000
+Subject: [PATCH] t2scan: fix -std=c23 build failure
+
+gcc-15 switched to -std=c23 by default:
+
+    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212
+
+As a result `t2scan` fails the build so only typedef int bool
+for __STDC_VERSION__ <= 201710L (C17)
+
+    ../tools.h:35:15: error: two or more data types in declaration specifiers
+       35 |   typedef int bool;
+          |               ^~~~
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ char-coding.h |  2 +-
+ emulate.c     |  2 +-
+ tools.h       | 10 ++++++----
+ 3 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/char-coding.h b/char-coding.h
+index 15bcdf9..93c78d2 100644
+--- a/char-coding.h
++++ b/char-coding.h
+@@ -31,7 +31,7 @@ int get_codepage_index(const char * codepage);
+ /*
+  * set the default charset that is used if a string does not include a charset definition in the first byte
+  */
+-void set_char_coding_default_charset();
++void set_char_coding_default_charset(char *);
+ 
+ /*
+  * reset default charset to the reset_to_charset
+diff --git a/emulate.c b/emulate.c
+index d0cd744..cfe7ebe 100644
+--- a/emulate.c
++++ b/emulate.c
+@@ -199,7 +199,7 @@ int  em_getproperty(struct dtv_properties * cmdseq) {
+ }
+ 
+ 
+-void em_lnb(int high_band, uint32_t high_val, uint32_t low_val) {
++void em_lnb(_Bool high_band, uint32_t high_val, uint32_t low_val) {
+   em_device.highband = high_band;
+   em_device.lnb_low = low_val;
+   em_device.lnb_high = high_val;
+diff --git a/tools.h b/tools.h
+index 20b6a0d..221580e 100644
+--- a/tools.h
++++ b/tools.h
+@@ -31,10 +31,12 @@
+ /*******************************************************************************
+ /* common typedefs && logging.
+  ******************************************************************************/
+-#ifndef bool
+-  typedef int bool;
+-  #define false 0
+-  #define true  !(false)
++#if defined __STDC__ && defined __STDC_VERSION__ && __STDC_VERSION__ <= 201710L
++  #ifndef bool
++    typedef int bool;
++    #define false 0
++    #define true  !(false)
++  #endif
+ #endif
+ 
+ #define min(a,b)  (b<a?b:a)

--- a/packages/addons/addon-depends/dvb-tools-depends/w_scan/patches/w_scan-0001-Fix-building-with-gcc15.patch
+++ b/packages/addons/addon-depends/dvb-tools-depends/w_scan/patches/w_scan-0001-Fix-building-with-gcc15.patch
@@ -1,0 +1,30 @@
+--- a/tools.h	2017-01-07 09:06:17.000000000 +0000
++++ b/tools.h	2024-12-07 09:14:24.126672083 +0000
+@@ -32,10 +32,12 @@
+ /*******************************************************************************
+ /* common typedefs && logging.
+  ******************************************************************************/
+-#ifndef bool
+-  typedef int bool;
+-  #define false 0
+-  #define true  !(false)
++#if defined __STDC__ && defined __STDC_VERSION__ && __STDC_VERSION__ <= 201710L
++  #ifndef bool
++    typedef int bool;
++    #define false 0
++    #define true  !(false)
++  #endif
+ #endif
+ 
+ #define min(a,b)  (b<a?b:a)
+--- a/emulate.c	2017-01-07 09:06:17.000000000 +0000
++++ b/emulate.c	2024-12-07 09:21:15.216943907 +0000
+@@ -199,7 +199,7 @@
+ }
+ 
+ 
+-void em_lnb(int high_band, uint32_t high_val, uint32_t low_val) {
++void em_lnb(bool high_band, uint32_t high_val, uint32_t low_val) {
+   em_device.highband = high_band;
+   em_device.lnb_low = low_val;
+   em_device.lnb_high = high_val;

--- a/packages/addons/addon-depends/multimedia-tools-depends/tstools/patches/fix-gcc15-build-44.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/tstools/patches/fix-gcc15-build-44.patch
@@ -1,0 +1,22 @@
+From a1f2a71b286135d89865bb0332cbe3db59cea300 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 9 Dec 2024 16:57:53 +1100
+Subject: [PATCH] fix build with gcc-15
+
+---
+ tsserve.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tsserve.c b/tsserve.c
+index d81042e..253ba0c 100644
+--- a/tsserve.c
++++ b/tsserve.c
+@@ -2958,7 +2958,7 @@ static void set_child_exit_handler();
+ /*
+  * Signal handler - catch children and stop them becoming zombies
+  */
+-static void on_child_exit()
++static void on_child_exit(int signum)
+ {
+ #if 0
+   print_msg("sighandler: starting\n");

--- a/packages/addons/addon-depends/network-tools-depends/iftop/patches/iftop-Fix-building-with-gcc15.patch
+++ b/packages/addons/addon-depends/network-tools-depends/iftop/patches/iftop-Fix-building-with-gcc15.patch
@@ -1,0 +1,26 @@
+From 322c1aa1e0cc8ab1770929c42a2c84befd86d0dc Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 9 Dec 2024 11:45:03 +0000
+Subject: [PATCH] fix gcc-15 build
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ cfgfile.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cfgfile.h b/cfgfile.h
+index 11ba475..55f9b9c 100644
+--- a/cfgfile.h
++++ b/cfgfile.h
+@@ -13,7 +13,7 @@ typedef struct {
+     int value;
+ } config_enumeration_type;
+ 
+-int read_config();
++int read_config(char *, int);
+ 
+ char *config_get_string(const char *directive);
+ int config_get_bool(const char *directive);
+-- 
+2.43.0
+

--- a/packages/addons/addon-depends/system-tools-depends/dtach/patches/0001-fix-gcc-15-build.patch
+++ b/packages/addons/addon-depends/system-tools-depends/dtach/patches/0001-fix-gcc-15-build.patch
@@ -1,0 +1,25 @@
+From 6d80909a8c0fd19717010a3c76fec560f988ca48 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 9 Dec 2024 12:35:09 +0000
+Subject: [PATCH] fix gcc-15 build
+
+---
+ attach.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/attach.c b/attach.c
+index 41a696c..e4a46bd 100644
+--- a/attach.c
++++ b/attach.c
+@@ -96,7 +96,7 @@ die(int sig)
+ 
+ /* Window size change. */
+ static RETSIGTYPE
+-win_change()
++win_change(int sig)
+ {
+ 	signal(SIGWINCH, win_change);
+ 	win_changed = 1;
+-- 
+2.43.0
+

--- a/packages/addons/addon-depends/system-tools-depends/usb-modeswitch/patches/fix-gcc-15-build.patch
+++ b/packages/addons/addon-depends/system-tools-depends/usb-modeswitch/patches/fix-gcc-15-build.patch
@@ -1,0 +1,20 @@
+--- a/usb_modeswitch.c	2020-07-10 15:48:03.000000000 +0000
++++ b/usb_modeswitch.c	2024-12-09 12:18:10.953574344 +0000
+@@ -570,7 +570,7 @@
+ 	/* Get current configuration of default device, note value if Configuration
+ 	 * parameter is set. Also sets active_config
+ 	 */
+-	currentConfigVal = get_current_config_value(dev);
++	currentConfigVal = get_current_config_value();
+ 	if (Configuration > -1) {
+ 		SHOW_PROGRESS(output,"Current configuration number is %d\n", currentConfigVal);
+ 	} else
+@@ -772,7 +772,7 @@
+ 	if (Configuration > 0) {
+ 		if (currentConfigVal != Configuration) {
+ 			if (switchConfiguration()) {
+-				currentConfigVal = get_current_config_value(dev);
++				currentConfigVal = get_current_config_value();
+ 				if (currentConfigVal == Configuration) {
+ 					SHOW_PROGRESS(output,"The configuration was set successfully\n");
+ 				} else {


### PR DESCRIPTION
These patches allow these addons to be compiled by a c23 (gcc-15) compiler. Only patches that can’t / won’t be in upstream because of maintenance have been included in this PR. Ongoing upstreaming is being done with all the other gcc-15 required changes packages

- comskip: fix gcc-15 build
  - non current (so local patch warranted)
- dtach: fix gcc-15 build
  - unmaintained upstream https://github.com/crigler/dtach/pull/21
- usb-modeswitch: fix gcc-15 build
  - upstreamed https://www.draisberghof.de/usb_modeswitch/bb/viewtopic.php?t=3122
- tstools: fix gcc-15 build
  - unmaintained upstream https://github.com/kynesim/tstools/pull/44
- t2scan: fix gcc-15 build
  - unmaintained upstream https://github.com/mighty-p/t2scan/pull/17
- iftop: fix gcc-15 build
  - unmaintained upstream - no access to git repo
- dvbsnoop: fix gcc-15 build
  - unmaintained upstream https://github.com/Duckbox-Developers/dvbsnoop/pull/4
- w_scan: fix gcc-15 build
  - unmaintained upstream