### PR TITLE
package updates

### DIFF
--- a/packages/debug/xorg-intel-gpu-tools/package.mk
+++ b/packages/debug/xorg-intel-gpu-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xorg-intel-gpu-tools"
-PKG_VERSION="1.29"
-PKG_SHA256="e0fe0d0f088cb50090b212f28b8960fb1e6160c681f5bea0654973aaa9909d8f"
+PKG_VERSION="1.30"
+PKG_SHA256="b29f969d54cc620756f75517971fb3197e1488eec60af720a18a0ba7ab541ab1"
 PKG_LICENSE="GPL"
 PKG_DEPENDS_TARGET="toolchain cairo elfutils kmod libdrm procps-ng systemd"
 PKG_SITE="https://gitlab.freedesktop.org/drm/igt-gpu-tools"

--- a/packages/devel/commons-text/package.mk
+++ b/packages/devel/commons-text/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="commons-text"
-PKG_VERSION="1.12.0"
-PKG_SHA256="265a149c7e0c1ebfe019bbe0226f8c1f6474811054d459145510ea2eed93a11a"
+PKG_VERSION="1.13.0"
+PKG_SHA256="a690c1e868a373f2d0fa5e7e89f5359b24e544d1b5e310f5a709d95a03a95df5"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://commons.apache.org/proper/commons-text/"
 PKG_URL="https://archive.apache.org/dist/commons/text/binaries/commons-text-${PKG_VERSION}-bin.tar.gz"

--- a/packages/graphics/spirv-headers/package.mk
+++ b/packages/graphics/spirv-headers/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-headers"
 # The SPIRV-Headers pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-headers pkg_version.
-PKG_VERSION="2a9b6f951c7d6b04b6c21fe1bf3f475b68b84801"
-PKG_SHA256="1698e1373bd6e59a263acef821c4d955c561b991feb6db8199833ef19ffe8a37"
+PKG_VERSION="3f17b2af6784bfa2c5aa5dbb8e0e74a607dd8b3b"
+PKG_SHA256="2301e11e5c77213258d6863bf4e6c607a8c6431fa8336e98ac6a2131bd6284f8"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/spirv-tools/package.mk
+++ b/packages/graphics/spirv-tools/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-tools"
 # The SPIRV-Tools pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools pkg_version.
-PKG_VERSION="6dcc7e350a0b9871a825414d42329e44b0eb8109"
-PKG_SHA256="e3665378ab0ae8efb327027ee103d10c3c9e05823dea8b28893c00886ffe1a23"
+PKG_VERSION="4d2f0b40bfe290dea6c6904dafdf7fd8328ba346"
+PKG_SHA256="41481a45441d92b2404aa06bdecbb0302f22636335be4e19023632c83fa89aa1"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers pkg_version/s need to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools & spirv-headers pkg_version/s.
-PKG_VERSION="15.0.0"
-PKG_SHA256="c31c8c2e89af907507c0631273989526ee7d5cdf7df95ececd628fd7b811e064"
+PKG_VERSION="15.1.0"
+PKG_SHA256="4bdcd8cdb330313f0d4deed7be527b0ac1c115ff272e492853a6e98add61b4bc"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/x11/lib/libICE/package.mk
+++ b/packages/x11/lib/libICE/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libICE"
-PKG_VERSION="1.1.1"
-PKG_SHA256="03e77afaf72942c7ac02ccebb19034e6e20f456dcf8dddadfeb572aa5ad3e451"
+PKG_VERSION="1.1.2"
+PKG_SHA256="974e4ed414225eb3c716985df9709f4da8d22a67a2890066bc6dfc89ad298625"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libSM/package.mk
+++ b/packages/x11/lib/libSM/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libSM"
-PKG_VERSION="1.2.4"
-PKG_SHA256="fdcbe51e4d1276b1183da77a8a4e74a137ca203e0bcfb20972dd5f3347e97b84"
+PKG_VERSION="1.2.5"
+PKG_SHA256="2af9e12da5ef670dc3a7bce1895c9c0f1bfb0cb9e64e8db40fcc33f883bd20bc"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXau/package.mk
+++ b/packages/x11/lib/libXau/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXau"
-PKG_VERSION="1.0.11"
-PKG_SHA256="f3fa3282f5570c3f6bd620244438dbfbdd580fc80f02f549587a0f8ab329bbeb"
+PKG_VERSION="1.0.12"
+PKG_SHA256="74d0e4dfa3d39ad8939e99bda37f5967aba528211076828464d2777d477fc0fb"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"
@@ -12,4 +12,6 @@ PKG_DEPENDS_TARGET="toolchain util-macros xorgproto"
 PKG_LONGDESC="X authorization file management libary"
 PKG_BUILD_FLAGS="+pic"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared --enable-xthreads"
+PKG_MESON_OPTS_TARGET="-Ddefault_library=static \
+                       -Dprefer_static=true \
+                       -Dxthreads=true"

--- a/packages/x11/lib/libXrender/package.mk
+++ b/packages/x11/lib/libXrender/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXrender"
-PKG_VERSION="0.9.11"
-PKG_SHA256="bc53759a3a83d1ff702fb59641b3d2f7c56e05051fa0cfa93501166fa782dc24"
+PKG_VERSION="0.9.12"
+PKG_SHA256="b832128da48b39c8d608224481743403ad1691bf4e554e4be9c174df171d1b97"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libXxf86vm/package.mk
+++ b/packages/x11/lib/libXxf86vm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXxf86vm"
-PKG_VERSION="1.1.5"
-PKG_SHA256="247fef48b3e0e7e67129e41f1e789e8d006ba47dba1c0cdce684b9b703f888e7"
+PKG_VERSION="1.1.6"
+PKG_SHA256="96af414c73ce1d5449ad04be7f9f27fa8330f844b6dda843ef22e3e1befb3ee3"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.X.org"
 PKG_URL="http://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libxcvt/package.mk
+++ b/packages/x11/lib/libxcvt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxcvt"
-PKG_VERSION="0.1.2"
-PKG_SHA256="0561690544796e25cfbd71806ba1b0d797ffe464e9796411123e79450f71db38"
+PKG_VERSION="0.1.3"
+PKG_SHA256="a929998a8767de7dfa36d6da4751cdbeef34ed630714f2f4a767b351f2442e01"
 PKG_LICENSE="OSS"
 PKG_SITE="https://gitlab.freedesktop.org/xorg/lib/libxcvt"
 PKG_URL="https://www.x.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/lib/libxshmfence/package.mk
+++ b/packages/x11/lib/libxshmfence/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxshmfence"
-PKG_VERSION="1.3.2"
-PKG_SHA256="870df257bc40b126d91b5a8f1da6ca8a524555268c50b59c0acd1a27f361606f"
+PKG_VERSION="1.3.3"
+PKG_SHA256="d4a4df096aba96fea02c029ee3a44e11a47eb7f7213c1a729be83e85ec3fde10"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- xorg-intel-gpu-tools: update to 1.30
- libxcvt: update to 0.1.3
- libxshmfence: update to 1.3.3
- libXxf86vm: update to 1.1.6
- libXrender: update to 0.9.12
- libXau: update to 1.0.12 and meson
- libSM: update to 1.2.5
- libICE: update to 1.1.2
- commons-text: update to 1.13.0
- glslang: update to 15.1.0
- spirv-tools: update to githash 4d2f0b4
- spirv-headers: update to githash 3f17b2a