### PR TITLE
Rockchip backport drm patch 6 13

### DIFF
--- a/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
+++ b/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
@@ -2834,3 +2834,98 @@ index 49619f794061..9915bf124374 100644
  	}
  
  	port = of_get_child_by_name(dev->of_node, "port");
+
+From 3303a206ae7474b2f8a5d17d8df9de08bac16ca5 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 8 Sep 2024 14:54:58 +0000
+Subject: [PATCH] drm/rockchip: dw_hdmi: Filter modes based on hdmiphy_clk
+
+RK3228 and RK3328 clock rate is being validated against a mpll config
+table intended for a Synopsys phy, and not the used inno-hdmi-phy.
+
+Instead get a reference to the hdmiphy clk and validate rates against
+it to enable use of HDMI2.0 modes, e.g. 4K@60Hz, on RK3228 and RK3328.
+
+For Synopsis phy the max_tmds_clock validation is sufficient.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Tested-by: Diederik de Haas <didi.debian@cknow.org> # Rock64
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://patchwork.freedesktop.org/patch/msgid/20240908145511.3331451-2-jonas@kwiboo.se
+---
+ drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c | 35 ++++++++++-----------
+ 1 file changed, 17 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+index 240552eb517f7e..36cc700766fd82 100644
+--- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
++++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+@@ -76,6 +76,7 @@ struct rockchip_hdmi {
+ 	struct rockchip_encoder encoder;
+ 	const struct rockchip_hdmi_chip_data *chip_data;
+ 	const struct dw_hdmi_plat_data *plat_data;
++	struct clk *hdmiphy_clk;
+ 	struct clk *ref_clk;
+ 	struct clk *grf_clk;
+ 	struct dw_hdmi *hdmi;
+@@ -251,10 +252,7 @@ dw_hdmi_rockchip_mode_valid(struct dw_hdmi *dw_hdmi, void *data,
+ 			    const struct drm_display_mode *mode)
+ {
+ 	struct rockchip_hdmi *hdmi = data;
+-	const struct dw_hdmi_mpll_config *mpll_cfg = rockchip_mpll_cfg;
+ 	int pclk = mode->clock * 1000;
+-	bool exact_match = hdmi->plat_data->phy_force_vendor;
+-	int i;
+ 
+ 	if (hdmi->chip_data->max_tmds_clock &&
+ 	    mode->clock > hdmi->chip_data->max_tmds_clock)
+@@ -263,26 +261,18 @@ dw_hdmi_rockchip_mode_valid(struct dw_hdmi *dw_hdmi, void *data,
+ 	if (hdmi->ref_clk) {
+ 		int rpclk = clk_round_rate(hdmi->ref_clk, pclk);
+ 
+-		if (abs(rpclk - pclk) > pclk / 1000)
++		if (rpclk < 0 || abs(rpclk - pclk) > pclk / 1000)
+ 			return MODE_NOCLOCK;
+ 	}
+ 
+-	for (i = 0; mpll_cfg[i].mpixelclock != (~0UL); i++) {
+-		/*
+-		 * For vendor specific phys force an exact match of the pixelclock
+-		 * to preserve the original behaviour of the driver.
+-		 */
+-		if (exact_match && pclk == mpll_cfg[i].mpixelclock)
+-			return MODE_OK;
+-		/*
+-		 * The Synopsys phy can work with pixelclocks up to the value given
+-		 * in the corresponding mpll_cfg entry.
+-		 */
+-		if (!exact_match && pclk <= mpll_cfg[i].mpixelclock)
+-			return MODE_OK;
++	if (hdmi->hdmiphy_clk) {
++		int rpclk = clk_round_rate(hdmi->hdmiphy_clk, pclk);
++
++		if (rpclk < 0 || abs(rpclk - pclk) > pclk / 1000)
++			return MODE_NOCLOCK;
+ 	}
+ 
+-	return MODE_BAD;
++	return MODE_OK;
+ }
+ 
+ static void dw_hdmi_rockchip_encoder_disable(struct drm_encoder *encoder)
+@@ -607,6 +597,15 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
+ 		return ret;
+ 	}
+ 
++	if (hdmi->phy) {
++		struct of_phandle_args clkspec;
++
++		clkspec.np = hdmi->phy->dev.of_node;
++		hdmi->hdmiphy_clk = of_clk_get_from_provider(&clkspec);
++		if (IS_ERR(hdmi->hdmiphy_clk))
++			hdmi->hdmiphy_clk = NULL;
++	}
++
+ 	if (hdmi->chip_data == &rk3568_chip_data) {
+ 		regmap_write(hdmi->regmap, RK3568_GRF_VO_CON1,
+ 			     HIWORD_UPDATE(RK3568_HDMI_SDAIN_MSK |

--- a/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
+++ b/projects/Rockchip/patches/linux/default/linux-1000-drm-rockchip.patch
@@ -2929,3 +2929,43 @@ index 240552eb517f7e..36cc700766fd82 100644
  	if (hdmi->chip_data == &rk3568_chip_data) {
  		regmap_write(hdmi->regmap, RK3568_GRF_VO_CON1,
  			     HIWORD_UPDATE(RK3568_HDMI_SDAIN_MSK |
+
+From 28f0ae48e7fdbd6cdcf3972c8d8686a529ae1ede Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 8 Sep 2024 14:55:03 +0000
+Subject: [PATCH] drm/rockchip: dw_hdmi: Enable 4K@60Hz mode on RK3399 and
+ RK356x
+
+Use a maximum TMDS clock rate limit of 594MHz to enable use of HDMI2.0
+modes, e.g. 4K@60Hz, on RK3399 and RK3568.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Tested-by: Diederik de Haas <didi.debian@cknow.org> # Quartz64 Model B
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://patchwork.freedesktop.org/patch/msgid/20240908145511.3331451-7-jonas@kwiboo.se
+---
+ drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+index 090d8c0f306f55..96e1097f993dc1 100644
+--- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
++++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+@@ -481,7 +481,7 @@ static struct rockchip_hdmi_chip_data rk3399_chip_data = {
+ 	.lcdsel_grf_reg = RK3399_GRF_SOC_CON20,
+ 	.lcdsel_big = HIWORD_UPDATE(0, RK3399_HDMI_LCDC_SEL),
+ 	.lcdsel_lit = HIWORD_UPDATE(RK3399_HDMI_LCDC_SEL, RK3399_HDMI_LCDC_SEL),
+-	.max_tmds_clock = 340000,
++	.max_tmds_clock = 594000,
+ };
+ 
+ static const struct dw_hdmi_plat_data rk3399_hdmi_drv_data = {
+@@ -495,7 +495,7 @@ static const struct dw_hdmi_plat_data rk3399_hdmi_drv_data = {
+ 
+ static struct rockchip_hdmi_chip_data rk3568_chip_data = {
+ 	.lcdsel_grf_reg = -1,
+-	.max_tmds_clock = 340000,
++	.max_tmds_clock = 594000,
+ };
+ 
+ static const struct dw_hdmi_plat_data rk3568_hdmi_drv_data = {


### PR DESCRIPTION
With the kernel update to version 6.12 and this commit https://github.com/LibreELEC/LibreELEC.tv/commit/9c7e6e06d97300356a29f87c3c56288c77d19c7d the test builds stopped working on my roc-3328-cc board (no hdmi signal) and probably on others soc too. 

To resolve this I backported these two patches from @Kwiboo which are included in the upcoming kernel 6.13 (so I think they are safe).

Unfortunately I don't have any board with rk3399 to do some tests


