### PR TITLE
rust: update to 1.83.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="05c0d904a82cddb8a00b0bbdd276ad7e24dea62a7b6c380413ab1e5a4ed70a56"
+    PKG_SHA256="5b96aba48790acfacea60a6643a4f30d7edc13e9189ad36b41bbacdad13d49e1"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="eb98ac225f08ebd50eaed439eca687ba074344bd50ae7d95fff9a07a7ccc0899"
+    PKG_SHA256="6e72f235d4ebce15eb2eaeaecaa9b29b21df7df64bd71ace55d2c85b7bdf0453"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="97aeae783874a932c4500f4d36473297945edf6294d63871784217d608718e70"
+    PKG_SHA256="de834a4062d9cd200f8e0cdca894c0b98afe26f1396d80765df828880a39b98c"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="1359ac1f3a123ae5da0ee9e47b98bb9e799578eefd9f347ff9bafd57a1d74a7f"
+    PKG_SHA256="8804f673809c5c3db11ba354b5cf9724aed68884771fa32af4b3472127a76028"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="fa379cc69b23782cbaddf66025889bf5ca9c32ddb60766fe158b43cfe49a2b2b"
+    PKG_SHA256="1d71e107b7cd96ad90e45fa402475c96ea9420290740be90168205137f3163ab"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="2eca3d36f7928f877c334909f35fe202fbcecce109ccf3b439284c2cb7849594"
+    PKG_SHA256="c88fe6cb22f9d2721f26430b6bdd291e562da759e8629e2b4c7eb2c7cad705f2"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.82.0"
-PKG_SHA256="7c53f4509eda184e174efa6ba7d5eeb586585686ce8edefc781a2b11a7cf512a"
+PKG_VERSION="1.83.0"
+PKG_SHA256="722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -34,6 +34,9 @@ configure_host() {
 
   cat >${PKG_BUILD}/config.toml  <<END
 change-id = 102579
+
+[llvm]
+download-ci-llvm = false
 
 [target.${TARGET_NAME}]
 llvm-config = "${TOOLCHAIN}/bin/llvm-config"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="2958e667202819f6ba1ea88a2a36d7b6a49aad7e460b79ebbb5cf9221b96f599"
+    PKG_SHA256="aa5d075f9903682e5171f359948717d32911bed8c39e0395042e625652062ea9"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="a3174f8d6b25ac452da100ca0e35066e02b871952cbdc9f9023f36e1305f4d01"
+    PKG_SHA256="a0f74aab6e9a4d911a261f5bbe24f41066d41e80aa7a68abc754f3bc776037e1"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="90b61494f5ccfd4d1ca9a5ce4a0af49a253ca435c701d9c44e3e44b5faf70cb8"
+    PKG_SHA256="6ec40e0405c8cbed3b786a97d374c144b012fc831b7c22b535f8ecb524f495ad"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- rustc-snapshot: update to 1.83.0
- rust-std-snapshot: update to 1.83.0
- cargo-snapshot: update to 1.83.0
- rust: update to 1.83.0
  - [INFO] The `build.profiler` option now tries to use source code from `download-ci-llvm` if possible, instead of checking out the `src/llvm-project` submodule.
    - PR Link https://github.com/rust-lang/rust/pull/129295