### PR TITLE
[le12] rpi-tools: backport of PR9592 - add gpiod support

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/gpiod/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/gpiod/package.mk
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="gpiod"
+PKG_VERSION="2.2.2"
+PKG_SHA256="aa4571f64e1070d38e4c14c491f69637ee73e23c801d3a418dde4d5410e5d53f"
+PKG_ARCH="arm aarch64"
+PKG_LICENSE="LGPLv2.1"
+PKG_SITE="https://pypi.org/project/gpiod/"
+PKG_URL="https://files.pythonhosted.org/packages/source/g/gpiod/gpiod-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain Python3 distutilscross:host"
+PKG_LONGDESC="These are the official Python bindings for libgpiod."
+PKG_TOOLCHAIN="manual"
+
+pre_configure_target() {
+  export PYTHONXCPREFIX="${SYSROOT_PREFIX}/usr"
+  export LDSHARED="${CC} -shared"
+  export CFLAGS="${CFLAGS} -fcommon"
+  export CPPFLAGS="${TARGET_CPPFLAGS} -I${SYSROOT_PREFIX}/usr/include/${PKG_PYTHON_VERSION}"
+}
+
+make_target() {
+  python3 setup.py build
+}

--- a/packages/addons/addon-depends/rpi-tools-depends/gpiod/patches/gpiod-2.2.2-setuptools.patch
+++ b/packages/addons/addon-depends/rpi-tools-depends/gpiod/patches/gpiod-2.2.2-setuptools.patch
@@ -1,0 +1,11 @@
+--- gpiod/setup.py.org	2024-11-12 14:29:25.000000000 +0100
++++ gpiod/setup.py	2024-12-09 20:44:57.736065397 +0100
+@@ -8,7 +8,7 @@
+ from setuptools.command.build_ext import build_ext as orig_build_ext
+ from setuptools.command.sdist import log
+ from setuptools.command.sdist import sdist as orig_sdist
+-from setuptools.errors import BaseError
++#from setuptools.errors import BaseError
+ 
+ LINK_SYSTEM_LIBGPIOD = getenv("LINK_SYSTEM_LIBGPIOD") == "1"
+ LIBGPIOD_MINIMUM_VERSION = "2.1"

--- a/packages/addons/tools/rpi-tools/package.mk
+++ b/packages/addons/tools/rpi-tools/package.mk
@@ -3,15 +3,15 @@
 
 PKG_NAME="rpi-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain lg-gpio gpiozero colorzero lan951x-led-ctl"
+PKG_DEPENDS_TARGET="toolchain lg-gpio gpiod gpiozero colorzero lan951x-led-ctl"
 PKG_SECTION="virtual"
 PKG_SHORTDESC="A bundle of tools and programs for use on the Raspberry Pi"
-PKG_LONGDESC="This bundle currently includes lg-gpio, gpiozero and lan951x-led-ctl"
+PKG_LONGDESC="This bundle currently includes lg-gpio, gpiod, gpiozero and lan951x-led-ctl"
 PKG_DISCAIMER="Raspberry Pi is a trademark of the Raspberry Pi Foundation http://www.raspberrypi.org"
 
 PKG_IS_ADDON="yes"
@@ -25,6 +25,8 @@ addon() {
     cp -PR $(get_build_dir lg-gpio)/liblgpio.so* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
     cp -PR $(get_build_dir lg-gpio)/PY_LGPIO/build/lib.linux*/* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
     patchelf --add-rpath '$ORIGIN' ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/_lgpio*.so
+    cp -PR $(get_build_dir gpiod)/build/lib.linux*/* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
+    patchelf --add-rpath '$ORIGIN' ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/gpiod/_ext*.so
     cp -PR $(get_build_dir gpiozero)/gpiozero ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
     cp -PR $(get_build_dir colorzero)/colorzero ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
 


### PR DESCRIPTION
EDIT: This is the backport of #9592 for LibreELEC 12

gpiod are the official Python bindings for libgpiod. libgpiod is already part of the system tools add-on, only these Python bindings are currently missing to be able to use it in Python scripts.

lgpio and gpiozero are easier to use, but currently have some insurmountable problems, as I have tried to explain here:

[Feature request: RPi-Tools with official Python bindings for libgpiod](https://forum.libreelec.tv/thread/29292-feature-request-rpi-tools-with-official-python-bindings-for-libgpiod/)