### PR TITLE
system-tools: add gpiod (official Python bindings for libgpiod)

### DIFF
--- a/packages/addons/addon-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/libgpiod/package.mk
@@ -7,9 +7,18 @@ PKG_SHA256="ae35329db7027c740e90c883baf27c26311f0614e6a7b115771b28188b992aec"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
 PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain Python3 setuptools:host"
 PKG_LONGDESC="Tools for interacting with the linux GPIO character device."
 PKG_TOOLCHAIN="autotools"
-PKG_BUILD_FLAGS="+pic"
+PKG_BUILD_FLAGS="+pic -sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-tools --disable-shared"
+
+post_make_target() {
+  (
+    LDFLAGS+=" -L${PKG_BUILD}/.${TARGET_NAME}/lib/.libs"
+    CFLAGS+=" -I${PKG_BUILD}/include"
+    cd ../bindings/python
+    python_target_env python3 -m build -n -w -x
+  )
+}

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"
@@ -137,6 +137,7 @@ addon() {
 
     # libgpiod
     cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpioget,gpioinfo,gpiomon,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -PR $(get_build_dir libgpiod)/bindings/python/build/lib.linux*/* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
 
     # lm_sensors
     cp -P $(get_install_dir lm_sensors)/usr/bin/sensors ${ADDON_BUILD}/${PKG_ADDON_ID}/bin 2>/dev/null || :


### PR DESCRIPTION
gpiod are the official Python bindings for libgpiod. libgpiod is already part of the system tools add-on, only these Python bindings are currently missing to be able to use it in Python scripts.

lgpio and gpiozero are easier to use, but currently have some insurmountable problems, as I have tried to explain here:

[Feature request: RPi-Tools with official Python bindings for libgpiod](https://forum.libreelec.tv/thread/29292-feature-request-rpi-tools-with-official-python-bindings-for-libgpiod/)