### PR TITLE
buildsystem: support optional configuration of local console login

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -87,6 +87,8 @@
 # debug tty path
   DEBUG_TTY="/dev/tty3"
 
+# local console login prompt (yes / no)
+  LOCAL_LOGIN="no"
 
 ### KODI SETTINGS ###
 # Mediacenter to use (kodi / no)

--- a/packages/sysutils/systemd/system.d/getty@tty0.service
+++ b/packages/sysutils/systemd/system.d/getty@tty0.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Getty on %I
+After=getty-pre.target
+Before=getty.target
+IgnoreOnIsolate=yes
+ConditionPathExists=/dev/tty0
+
+[Service]
+ExecStart=-/sbin/agetty -o '-p -- \\u' --noissue --noclear --nohostname - $TERM
+Type=idle
+Restart=always
+RestartSec=0
+UtmpIdentifier=%I
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+ImportCredential=agetty.*
+ImportCredential=login.*
+UnsetEnvironment=LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION
+
+[Install]
+WantedBy=getty.target
+DefaultInstance=tty1

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -59,6 +59,10 @@ PKG_CONFIGURE_OPTS_TARGET="${UTILLINUX_CONFIG_DEFAULT} \
                            --enable-mount \
                            --enable-nologin"
 
+if [ "${LOCAL_LOGIN}" = "yes" ]; then
+  PKG_CONFIGURE_OPTS_TARGET+=" --enable-agetty"
+fi
+
 if [ "${SWAP_SUPPORT}" = "yes" ]; then
   PKG_CONFIGURE_OPTS_TARGET+=" --enable-swapon"
 fi


### PR DESCRIPTION
This PR adds buildsystem support for configuring a local console login prompt. This is useful for images that do not auto-boot into a full-screen app like Kodi, e.g. a minimal appliance-like image for Docker containers. The default is "no" so no functional change to existing LibreELEC images.

Tested with a Docker appliance OVA running under ESXi - it would be be good to validate the changes with other build projects and some real hardware.