### PR TITLE
Addon build fixes

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squeezelite"
-PKG_VERSION="c751ef146265c243cdbd7c0353dd0b70ab51730c"
-PKG_SHA256="19fd23ca52039b4e216ff74e7d93b7fd8079ab8bfd63d5fb2286bfb743e334ed"
+PKG_VERSION="279ac086053239323f5c4df965342e3be5d10671"
+PKG_SHA256="ff5fb3e7896e5f537b1ff0789162bbac45a76961dd93d4896d26726fef9c72e7"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/ralph-irving/squeezelite"
 PKG_URL="https://github.com/ralph-irving/squeezelite/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/snapcast-depends/snapcast/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/snapcast/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapcast"
-PKG_VERSION="0.29.0"
-PKG_SHA256="ecfb2c96a4920adc4121b1180b37bb86566c359914c14831c0abea4e65d23f92"
+PKG_VERSION="6190041e863968d76b6d16140bba90be6dff848f"
+PKG_SHA256="ca13a28abfa3d3d3386875526fa6faa281a4c52f94588924ddadc3369c7fa5cd"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/badaix/snapcast"
-PKG_URL="https://github.com/badaix/snapcast/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/badaix/snapcast/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain aixlog alsa-lib asio avahi flac libvorbis popl pulseaudio boost opus"
 PKG_LONGDESC="Synchronous multi-room audio player."
 PKG_BUILD_FLAGS="-sysroot"

--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapclient"
-PKG_VERSION="0.28.0"
-PKG_REV="1"
+PKG_VERSION="0.29.0"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain alsa-plugins snapcast"

--- a/packages/addons/service/snapserver/package.mk
+++ b/packages/addons/service/snapserver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapserver"
-PKG_VERSION="0.28.0"
-PKG_REV="1"
+PKG_VERSION="0.29.0"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain nqptp shairport-sync snapcast"

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="boost"
-PKG_VERSION="1.86.0"
-PKG_SHA256="1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b"
+PKG_VERSION="1.87.0"
+PKG_SHA256="af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.boost.org/"
 PKG_URL="https://boostorg.jfrog.io/artifactory/main/release/${PKG_VERSION}/source/${PKG_NAME}_${PKG_VERSION//./_}.tar.bz2"


### PR DESCRIPTION
- snapclient: update addon (2)
- snapserver: update addon (2)
  - snapcast: update to githash 6190041
  - boost: update to 1.87.0
- multimedia-tools: update addon (2)
  - squeezelite: update to githash 279ac08 (2.0.0.1507)

other fixes required:
- shairport-sync (due to ffmpeg - upstream is fixed, but nqptp needs to be reworked)
- game.libretro
- inputstream.ffmpegdirect - reliant on https://github.com/xbmc/inputstream.ffmpegdirect/pull/304 and release