### PR TITLE
samba: Added Apple TimeMachine backup share feature

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -77,7 +77,7 @@ configure_package() {
   PKG_SAMBA_TARGET="smbclient,client/smbclient,smbtree,nmblookup,testparm"
 
   if [ "${SAMBA_SERVER}" = "yes" ]; then
-    PKG_SAMBA_TARGET+=",nmbd,rpcd_classic,rpcd_epmapper,rpcd_winreg,samba-dcerpcd,smbpasswd,smbd/smbd"
+    PKG_SAMBA_TARGET+=",nmbd,rpcd_classic,rpcd_epmapper,rpcd_winreg,samba-dcerpcd,smbpasswd,smbd/smbd,vfs_fruit,vfs_catia,vfs_streams_xattr"
   fi
 }
 
@@ -154,6 +154,10 @@ perform_manual_install() {
       cp -PR bin/default/source3/rpc_server/rpcd_classic ${INSTALL}/usr/libexec/samba
       cp -PR bin/default/source3/rpc_server/rpcd_epmapper ${INSTALL}/usr/libexec/samba
       cp -PR bin/default/source3/rpc_server/rpcd_winreg ${INSTALL}/usr/libexec/samba
+
+    mkdir -p ${INSTALL}/usr/lib/vfs
+      cp ${PKG_BUILD}/bin/modules/vfs/* ${INSTALL}/usr/lib/vfs/
+
   fi
 }
 


### PR DESCRIPTION
Add samba vfs modules : catia, fruit, streams_xattr
Change sample config with Time Machine backup share - commented by default
See : https://wiki.samba.org/index.php/Configure_Samba_to_Work_Better_with_Mac_OS_X

Tested on Generic-legacy.x86_64
