### PR TITLE
vfs.libarchive: libarchive to 3.7.7 and update addon (9)

### DIFF
--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -28,7 +28,7 @@ PKG_CMAKE_OPTS_TARGET="-DCMAKE_POSITION_INDEPENDENT_CODE=1 \
                        -DENABLE_LIBGCC=ON \
                        -DENABLE_LIBXML2=OFF \
                        -DENABLE_LZ4=ON \
-                       -DENABLE_LZMA=OFF \
+                       -DENABLE_LZMA=ON \
                        -DENABLE_LZO=ON \
                        -DENABLE_MBEDTLS=OFF \
                        -DENABLE_NETTLE=OFF \

--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libarchive"
-PKG_VERSION="3.7.5"
-PKG_SHA256="ca74ff8f99dd40ab8a8274424d10a12a7ec3f4428dd35aee9fdda8bdb861b570"
+PKG_VERSION="3.7.7"
+PKG_SHA256="879acd83c3399c7caaee73fe5f7418e06087ab2aaf40af3e99b9e29beb29faee"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libarchive.org"
 PKG_URL="https://www.libarchive.org/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -43,4 +43,5 @@ PKG_CMAKE_OPTS_TARGET="-DCMAKE_POSITION_INDEPENDENT_CODE=1 \
                        -DENABLE_WERROR=0 \
                        -DENABLE_XATTR=ON \
                        -DENABLE_ZLIB=ON \
-                       -DENABLE_ZSTD=ON"
+                       -DENABLE_ZSTD=ON \
+                       -DPOSIX_REGEX_LIB=LIBPCRE2POSIX"

--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -8,7 +8,7 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://www.libarchive.org"
 PKG_URL="https://www.libarchive.org/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="cmake:host ninja:host"
-PKG_DEPENDS_TARGET="cmake:host gcc:host"
+PKG_DEPENDS_TARGET="cmake:host gcc:host bzip2 lz4 lzo openssl pcre2 xz zlib zstd"
 PKG_SHORTDESC="A multi-format archive and compression library."
 
 PKG_CMAKE_OPTS_TARGET="-DCMAKE_POSITION_INDEPENDENT_CODE=1 \

--- a/packages/devel/elfutils/package.mk
+++ b/packages/devel/elfutils/package.mk
@@ -9,7 +9,7 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://sourceware.org/elfutils/"
 PKG_URL="https://sourceware.org/elfutils/ftp/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
 PKG_DEPENDS_HOST="autoconf:host automake:host m4:host make:host zlib:host"
-PKG_DEPENDS_TARGET="toolchain zlib elfutils:host"
+PKG_DEPENDS_TARGET="toolchain zlib elfutils:host libarchive"
 PKG_LONGDESC="A collection of utilities to handle ELF objects."
 PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="+pic -cfg-libs -cfg-libs:host"
@@ -39,6 +39,10 @@ PKG_CONFIGURE_OPTS_TARGET="utrace_cv_cc_biarch=false \
                            --with-zlib \
                            --without-bzlib \
                            --without-lzma"
+
+pre_configure_target() {
+  export PKG_CONFIG="${PKG_CONFIG} --static"
+}
 
 post_makeinstall_target() {
   # don't install progs into sysroot

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="vfs.libarchive"
 PKG_VERSION="20.3.0-Nexus"
 PKG_SHA256="06be9bfcda3e676e0757ea9602351d67f2bf0aa9aa9e408b14d947772a615e4f"
-PKG_REV="8"
+PKG_REV="9"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/vfs.libarchive"


### PR DESCRIPTION
- libarchive: fix target DEPENDS
- libarchive: force use of pcre2
- libarchive: include LZMA (.xz)
- libarchive: update to 3.7.7
- [elfutils: build with libarchive](https://github.com/LibreELEC/LibreELEC.tv/pull/9621/commits/18125dcb28047a37b0197755ea08054d925ddef8) 
[18125dc](https://github.com/LibreELEC/LibreELEC.tv/pull/9621/commits/18125dcb28047a37b0197755ea08054d925ddef8)
  - building without libarchive can not be done if libarchive is detected. update the dependancies and allow correct linking with pkg-config --static