### PR TITLE
linux: update to 6.12.7

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -30,8 +30,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="raspberrypi rtlwifi/after-6.12"
     ;;
   *)
-    PKG_VERSION="6.12.5"
-    PKG_SHA256="39207fce1ce42838e085261bae0af5ce4a0843aa777cfc0f5c49bc7729602bcd"
+    PKG_VERSION="6.12.7"
+    PKG_SHA256="f785fb648a0e0b66a943bb3228a4b6ed62c90b985cd1ebf69da5d38e589da0cf"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default rtlwifi/after-6.12"
     ;;

--- a/projects/NXP/devices/iMX6/linux/linux.arm.conf
+++ b/projects/NXP/devices/iMX6/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.12.5 Kernel Configuration
+# Linux/arm 6.12.7 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7a-libreelec-linux-gnueabihf-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1622,6 +1622,7 @@ CONFIG_PROC_EVENTS=y
 # CONFIG_FW_CFG_SYSFS is not set
 # CONFIG_TRUSTED_FOUNDATIONS is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 CONFIG_ARM_PSCI_FW=y
 # CONFIG_ARM_PSCI_CHECKER is not set
 

--- a/projects/NXP/devices/iMX8/linux/linux.aarch64.conf
+++ b/projects/NXP/devices/iMX8/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.5 Kernel Configuration
+# Linux/arm64 6.12.7 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1715,6 +1715,7 @@ CONFIG_ARM_SCPI_PROTOCOL=y
 # CONFIG_GOOGLE_FIRMWARE is not set
 CONFIG_IMX_DSP=m
 CONFIG_IMX_SCU=y
+CONFIG_IMX_SCMI_MISC_DRV=y
 CONFIG_ARM_PSCI_FW=y
 # CONFIG_ARM_PSCI_CHECKER is not set
 


### PR DESCRIPTION
- linux: update to 6.12.7
- linux (NXP iMX6): update .config for 6.12.7
- linux (NXP iMX8): update .config for 6.12.7

### packages updated
- linux: update to 6.12.x

### 6.12.x mainline kernel update
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.6
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.7


6.12.6 - 172 patches
6.12.7 - 160 patches

### errors / fixes / issues / regressions / todo
 
### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.12.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.12
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/

### 6.12.7 Build tested on all of:
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.12.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.12.7 - heitbaum
- Generic Generic (AMD 7840HS - SER7) - 6.12.7 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- NXP iMX6 (Coral Dev Board - Phanbell) - 6.12.7 - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum