### PR TITLE
[le12] kodi: update to current Omega HEAD

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="2b2d09e2902fa6cff8ceb2da99c9fca87743a509"
-PKG_SHA256="59330b8117906ab3d7c78cb8d827febbcad74732850fe0153f0b848f70fcd56b"
+PKG_VERSION="d71ae7be88251b04b9332b9c321efae47f9e179e"
+PKG_SHA256="090e0cc02f50e29548b46001821754d037776fe49da4b1bc12da3146761132cc"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/projects/Allwinner/patches/kodi/000-temp-revert-fences.patch
+++ b/projects/Allwinner/patches/kodi/000-temp-revert-fences.patch
@@ -1,5 +1,451 @@
+From 711a8784ecf9a8193ec33c80d3e63723efa3617b Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:16 +0100
+Subject: [PATCH 1/4] Revert "CEGLFence: Ignore improper atomic drmrequest when
+ async rendering and"
+
+This reverts commit 396e4b286f0c104d41facca3ca7633f21f0907da.
+---
+ xbmc/utils/EGLFence.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
 diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
-index 9d0065bdaf..535e3bce31 100644
+index 58a9ec1683be..9d0065bdaf07 100644
+--- a/xbmc/utils/EGLFence.cpp
++++ b/xbmc/utils/EGLFence.cpp
+@@ -133,7 +133,11 @@ void CEGLFence::WaitSyncCPU()
+   if (!m_kmsFence)
+     return;
+ 
+-  if (m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR) != EGL_FALSE)
+-    m_eglDestroySyncKHR(m_display, m_kmsFence);
++  EGLint status{EGL_FALSE};
++
++  while (status != EGL_CONDITION_SATISFIED_KHR)
++    status = m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR);
++
++  m_eglDestroySyncKHR(m_display, m_kmsFence);
+ }
+ #endif
+-- 
+2.39.5
+
+
+From 95536ae880d43c38721fe346d52ff0b2efc7aa67 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:21 +0100
+Subject: [PATCH 2/4] Revert "CDRMAtomic: Backlog only the last known good
+ drmrequest"
+
+This reverts commit e13ba25f11c1d1315033701f078bd15d2433ddd3.
+---
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index 70ae92e9482d..ff7f137d60e6 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -149,11 +149,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   {
+     CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
+               strerror(errno));
+-    m_atomicRequestQueue.pop_back();
+-  }
+-  else if (m_atomicRequestQueue.size() > 1)
+-  {
+-    m_atomicRequestQueue.pop_front();
+   }
+ 
+   if (m_inFenceFd != -1)
+@@ -169,6 +164,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+                 strerror(errno));
+   }
+ 
++  if (m_atomicRequestQueue.size() > 1)
++    m_atomicRequestQueue.pop_back();
++
+   m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
+   m_req = m_atomicRequestQueue.back().get();
+ }
+-- 
+2.39.5
+
+
+From ee236db5f93c6c6eae8d28c8ed6b40897d5920b3 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:02 +0100
+Subject: [PATCH 3/4] Revert "CDRMAtomic: add support for using
+ DRM_MODE_ATOMIC_NONBLOCK"
+
+This reverts commit e9710033029d86efa0c18a6121d2c6376f74ef10.
+---
+ xbmc/windowing/gbm/WinSystemGbm.cpp           |  8 +++---
+ xbmc/windowing/gbm/WinSystemGbm.h             |  2 +-
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp | 11 --------
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.h   |  3 ---
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 26 +-----------------
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp | 27 +------------------
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp          | 19 +++----------
+ xbmc/windowing/gbm/drm/DRMAtomic.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.cpp          |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMUtils.h             | 13 +--------
+ xbmc/windowing/gbm/drm/OffScreenModeSetting.h |  2 +-
+ 12 files changed, 15 insertions(+), 102 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index 72497a215684..ba472fc29079 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
+   SetFullScreen(true, resMutable, false);
+ }
+ 
+-void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
++void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
+ {
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
+     bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get();
+   }
+ 
+-  m_DRM->FlipPage(bo, rendered, videoLayer, async);
++  m_DRM->FlipPage(bo, rendered, videoLayer);
+ 
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
+ bool CWinSystemGbm::Hide()
+ {
+   bool ret = m_DRM->SetActive(false);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+ bool CWinSystemGbm::Show(bool raise)
+ {
+   bool ret = m_DRM->SetActive(true);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 9609675d7220..8993b6d27865 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -49,7 +49,7 @@ public:
+   bool DisplayHardwareScalingEnabled() override;
+   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
+ 
+-  void FlipPage(bool rendered, bool videoLayer, bool async);
++  void FlipPage(bool rendered, bool videoLayer);
+ 
+   bool CanDoWindowed() override { return false; }
+   void UpdateResolutions() override;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+index fac914d5e9f2..2fb742efed35 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+     return false;
+   }
+ 
+-  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
+-      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
+-  {
+-    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+-  }
+-  else
+-  {
+-    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
+-                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
+-  }
+-
+   return true;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+index fbd52354ee7f..84f863d6d321 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+@@ -9,7 +9,6 @@
+ #pragma once
+ 
+ #include "WinSystemGbm.h"
+-#include "utils/EGLFence.h"
+ #include "utils/EGLUtils.h"
+ #include "windowing/linux/WinSystemEGL.h"
+ 
+@@ -47,8 +46,6 @@ protected:
+   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
+   virtual bool CreateContext() = 0;
+ 
+-  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
+-
+   struct delete_CVaapiProxy
+   {
+     void operator()(CVaapiProxy *p) const;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index adbb539f210d..e4ff49c61835 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index ad80abf46c3e..0d071c31f168 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index ff7f137d60e6..029b5cae813e 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
+     }
+ 
+-    if (m_inFenceFd != -1)
+-    {
+-      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
+-      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
+-    }
+   }
+   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
+   {
+@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+               strerror(errno));
+   }
+ 
+-  if (m_inFenceFd != -1)
+-  {
+-    close(m_inFenceFd);
+-    m_inFenceFd = -1;
+-  }
+-
+   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+   {
+     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
+@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   m_req = m_atomicRequestQueue.back().get();
+ }
+ 
+-void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   struct drm_fb *drm_fb = nullptr;
+-  uint32_t flags = 0;
+ 
+   if (rendered)
+   {
+@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
+       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
+       return;
+     }
+-
+-    if (async && !m_need_modeset)
+-      flags |= DRM_MODE_ATOMIC_NONBLOCK;
+   }
+ 
++  uint32_t flags = 0;
++
+   if (m_need_modeset)
+   {
+     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
+index 6b196575878f..ca2cd9a1d0c9 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
+@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
+ public:
+   CDRMAtomic() = default;
+   ~CDRMAtomic() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+index 4e9c3a6b9f3d..418d067e7024 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
+   return true;
+ }
+ 
+-void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   if (rendered || videoLayer)
+   {
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
+index e763f298f75a..2b7ff4561728 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.h
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
+@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
+ public:
+   CDRMLegacy() = default;
+   ~CDRMLegacy() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
+index f92f716fc4f3..5327e3557046 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.h
++++ b/xbmc/windowing/gbm/drm/DRMUtils.h
+@@ -15,7 +15,6 @@
+ #include "windowing/Resolution.h"
+ #include "windowing/gbm/GBMUtils.h"
+ 
+-#include <utility>
+ #include <vector>
+ 
+ #include <gbm.h>
+@@ -40,7 +39,7 @@ class CDRMUtils
+ public:
+   CDRMUtils() = default;
+   virtual ~CDRMUtils();
+-  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
++  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
+   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
+   virtual bool SetActive(bool active) { return false; }
+   virtual bool InitDrm();
+@@ -63,13 +62,6 @@ public:
+   static uint32_t FourCCWithAlpha(uint32_t fourcc);
+   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
+ 
+-  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
+-  int TakeOutFenceFd()
+-  {
+-    int fd{-1};
+-    return std::exchange(m_outFenceFd, fd);
+-  }
+-
+ protected:
+   bool OpenDrm(bool needConnector);
+   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
+@@ -86,9 +78,6 @@ protected:
+   int m_width = 0;
+   int m_height = 0;
+ 
+-  int m_inFenceFd{-1};
+-  int m_outFenceFd{-1};
+-
+   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
+ 
+ private:
+diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+index bba0db9a53dd..4270d4ecb242 100644
+--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
++++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
+ public:
+   COffScreenModeSetting() = default;
+   ~COffScreenModeSetting() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
++  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
+   bool SetActive(bool active) override { return false; }
+   bool InitDrm() override;
+-- 
+2.39.5
+
+
+From 543af77563f706cd70a5c2975f5fe217bf24024a Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:46 +0100
+Subject: [PATCH 4/4] Revert "CEGLFence: add support for using
+ EGL_KHR_fence_sync and EGL_ANDROID_native_fence_sync"
+
+This reverts commit ba17e5b45c5bd36ef65089f35049da82a290bb01.
+---
+ xbmc/utils/EGLFence.cpp | 70 -----------------------------------------
+ xbmc/utils/EGLFence.h   | 19 -----------
+ 2 files changed, 89 deletions(-)
+
+diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
+index 9d0065bdaf07..535e3bce3197 100644
 --- a/xbmc/utils/EGLFence.cpp
 +++ b/xbmc/utils/EGLFence.cpp
 @@ -22,14 +22,6 @@ CEGLFence::CEGLFence(EGLDisplay display)
@@ -84,7 +530,7 @@ index 9d0065bdaf..535e3bce31 100644
 -}
 -#endif
 diff --git a/xbmc/utils/EGLFence.h b/xbmc/utils/EGLFence.h
-index 03c246b60b..bd96444e47 100644
+index 03c246b60b67..bd96444e47e5 100644
 --- a/xbmc/utils/EGLFence.h
 +++ b/xbmc/utils/EGLFence.h
 @@ -30,14 +30,6 @@ public:
@@ -120,337 +566,6 @@ index 03c246b60b..bd96444e47 100644
  };
  
  }
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
-index f334156d89..34c8c16fe4 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
-@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
-   SetFullScreen(true, resMutable, false);
- }
- 
--void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-+void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
- {
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-     bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
-   }
- 
--  m_DRM->FlipPage(bo, rendered, videoLayer, async);
-+  m_DRM->FlipPage(bo, rendered, videoLayer);
- 
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
- bool CWinSystemGbm::Hide()
- {
-   bool ret = m_DRM->SetActive(false);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
- bool CWinSystemGbm::Show(bool raise)
- {
-   bool ret = m_DRM->SetActive(true);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
-index 879d0f58f8..a800acef6b 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.h
-+++ b/xbmc/windowing/gbm/WinSystemGbm.h
-@@ -49,7 +49,7 @@ public:
-   bool DisplayHardwareScalingEnabled() override;
-   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
- 
--  void FlipPage(bool rendered, bool videoLayer, bool async);
-+  void FlipPage(bool rendered, bool videoLayer);
- 
-   bool CanDoWindowed() override { return false; }
-   void UpdateResolutions() override;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-index ee27fba1bd..83a59413f7 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
-     return false;
-   }
- 
--  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
--      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
--  {
--    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
--  }
--  else
--  {
--    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
--                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
--  }
--
-   return true;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-index fbd52354ee..84f863d6d3 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-@@ -9,7 +9,6 @@
- #pragma once
- 
- #include "WinSystemGbm.h"
--#include "utils/EGLFence.h"
- #include "utils/EGLUtils.h"
- #include "windowing/linux/WinSystemEGL.h"
- 
-@@ -47,8 +46,6 @@ protected:
-   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
-   virtual bool CreateContext() = 0;
- 
--  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
--
-   struct delete_CVaapiProxy
-   {
-     void operator()(CVaapiProxy *p) const;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-index adbb539f21..e4ff49c618 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-index ad80abf46c..0d071c31f1 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-index ff7f137d60..029b5cae81 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
-     }
- 
--    if (m_inFenceFd != -1)
--    {
--      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
--      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
--    }
-   }
-   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
-   {
-@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-               strerror(errno));
-   }
- 
--  if (m_inFenceFd != -1)
--  {
--    close(m_inFenceFd);
--    m_inFenceFd = -1;
--  }
--
-   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
-   {
-     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
-@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-   m_req = m_atomicRequestQueue.back().get();
- }
- 
--void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   struct drm_fb *drm_fb = nullptr;
--  uint32_t flags = 0;
- 
-   if (rendered)
-   {
-@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
-       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
-       return;
-     }
--
--    if (async && !m_need_modeset)
--      flags |= DRM_MODE_ATOMIC_NONBLOCK;
-   }
- 
-+  uint32_t flags = 0;
-+
-   if (m_need_modeset)
-   {
-     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
-index 6b19657587..ca2cd9a1d0 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.h
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
-@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
- public:
-   CDRMAtomic() = default;
-   ~CDRMAtomic() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-index 4e9c3a6b9f..418d067e70 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
-   return true;
- }
- 
--void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   if (rendered || videoLayer)
-   {
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
-index e763f298f7..2b7ff45617 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.h
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
-@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
- public:
-   CDRMLegacy() = default;
-   ~CDRMLegacy() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
-index f92f716fc4..5327e35570 100644
---- a/xbmc/windowing/gbm/drm/DRMUtils.h
-+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
-@@ -15,7 +15,6 @@
- #include "windowing/Resolution.h"
- #include "windowing/gbm/GBMUtils.h"
- 
--#include <utility>
- #include <vector>
- 
- #include <gbm.h>
-@@ -40,7 +39,7 @@ class CDRMUtils
- public:
-   CDRMUtils() = default;
-   virtual ~CDRMUtils();
--  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
-+  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
-   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
-   virtual bool SetActive(bool active) { return false; }
-   virtual bool InitDrm();
-@@ -63,13 +62,6 @@ public:
-   static uint32_t FourCCWithAlpha(uint32_t fourcc);
-   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
- 
--  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
--  int TakeOutFenceFd()
--  {
--    int fd{-1};
--    return std::exchange(m_outFenceFd, fd);
--  }
--
- protected:
-   bool OpenDrm(bool needConnector);
-   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
-@@ -86,9 +78,6 @@ protected:
-   int m_width = 0;
-   int m_height = 0;
- 
--  int m_inFenceFd{-1};
--  int m_outFenceFd{-1};
--
-   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
- 
- private:
-diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-index bba0db9a53..4270d4ecb2 100644
---- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
- public:
-   COffScreenModeSetting() = default;
-   ~COffScreenModeSetting() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
-+  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
-   bool SetActive(bool active) override { return false; }
-   bool InitDrm() override;
+-- 
+2.39.5
+

--- a/projects/Amlogic/patches/kodi/000-temp-revert-fences.patch
+++ b/projects/Amlogic/patches/kodi/000-temp-revert-fences.patch
@@ -1,5 +1,451 @@
+From 711a8784ecf9a8193ec33c80d3e63723efa3617b Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:16 +0100
+Subject: [PATCH 1/4] Revert "CEGLFence: Ignore improper atomic drmrequest when
+ async rendering and"
+
+This reverts commit 396e4b286f0c104d41facca3ca7633f21f0907da.
+---
+ xbmc/utils/EGLFence.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
 diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
-index 9d0065bdaf..535e3bce31 100644
+index 58a9ec1683be..9d0065bdaf07 100644
+--- a/xbmc/utils/EGLFence.cpp
++++ b/xbmc/utils/EGLFence.cpp
+@@ -133,7 +133,11 @@ void CEGLFence::WaitSyncCPU()
+   if (!m_kmsFence)
+     return;
+ 
+-  if (m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR) != EGL_FALSE)
+-    m_eglDestroySyncKHR(m_display, m_kmsFence);
++  EGLint status{EGL_FALSE};
++
++  while (status != EGL_CONDITION_SATISFIED_KHR)
++    status = m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR);
++
++  m_eglDestroySyncKHR(m_display, m_kmsFence);
+ }
+ #endif
+-- 
+2.39.5
+
+
+From 95536ae880d43c38721fe346d52ff0b2efc7aa67 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:21 +0100
+Subject: [PATCH 2/4] Revert "CDRMAtomic: Backlog only the last known good
+ drmrequest"
+
+This reverts commit e13ba25f11c1d1315033701f078bd15d2433ddd3.
+---
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index 70ae92e9482d..ff7f137d60e6 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -149,11 +149,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   {
+     CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
+               strerror(errno));
+-    m_atomicRequestQueue.pop_back();
+-  }
+-  else if (m_atomicRequestQueue.size() > 1)
+-  {
+-    m_atomicRequestQueue.pop_front();
+   }
+ 
+   if (m_inFenceFd != -1)
+@@ -169,6 +164,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+                 strerror(errno));
+   }
+ 
++  if (m_atomicRequestQueue.size() > 1)
++    m_atomicRequestQueue.pop_back();
++
+   m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
+   m_req = m_atomicRequestQueue.back().get();
+ }
+-- 
+2.39.5
+
+
+From ee236db5f93c6c6eae8d28c8ed6b40897d5920b3 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:02 +0100
+Subject: [PATCH 3/4] Revert "CDRMAtomic: add support for using
+ DRM_MODE_ATOMIC_NONBLOCK"
+
+This reverts commit e9710033029d86efa0c18a6121d2c6376f74ef10.
+---
+ xbmc/windowing/gbm/WinSystemGbm.cpp           |  8 +++---
+ xbmc/windowing/gbm/WinSystemGbm.h             |  2 +-
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp | 11 --------
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.h   |  3 ---
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 26 +-----------------
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp | 27 +------------------
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp          | 19 +++----------
+ xbmc/windowing/gbm/drm/DRMAtomic.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.cpp          |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMUtils.h             | 13 +--------
+ xbmc/windowing/gbm/drm/OffScreenModeSetting.h |  2 +-
+ 12 files changed, 15 insertions(+), 102 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index 72497a215684..ba472fc29079 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
+   SetFullScreen(true, resMutable, false);
+ }
+ 
+-void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
++void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
+ {
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
+     bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get();
+   }
+ 
+-  m_DRM->FlipPage(bo, rendered, videoLayer, async);
++  m_DRM->FlipPage(bo, rendered, videoLayer);
+ 
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
+ bool CWinSystemGbm::Hide()
+ {
+   bool ret = m_DRM->SetActive(false);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+ bool CWinSystemGbm::Show(bool raise)
+ {
+   bool ret = m_DRM->SetActive(true);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 9609675d7220..8993b6d27865 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -49,7 +49,7 @@ public:
+   bool DisplayHardwareScalingEnabled() override;
+   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
+ 
+-  void FlipPage(bool rendered, bool videoLayer, bool async);
++  void FlipPage(bool rendered, bool videoLayer);
+ 
+   bool CanDoWindowed() override { return false; }
+   void UpdateResolutions() override;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+index fac914d5e9f2..2fb742efed35 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+     return false;
+   }
+ 
+-  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
+-      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
+-  {
+-    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+-  }
+-  else
+-  {
+-    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
+-                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
+-  }
+-
+   return true;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+index fbd52354ee7f..84f863d6d321 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+@@ -9,7 +9,6 @@
+ #pragma once
+ 
+ #include "WinSystemGbm.h"
+-#include "utils/EGLFence.h"
+ #include "utils/EGLUtils.h"
+ #include "windowing/linux/WinSystemEGL.h"
+ 
+@@ -47,8 +46,6 @@ protected:
+   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
+   virtual bool CreateContext() = 0;
+ 
+-  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
+-
+   struct delete_CVaapiProxy
+   {
+     void operator()(CVaapiProxy *p) const;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index adbb539f210d..e4ff49c61835 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index ad80abf46c3e..0d071c31f168 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index ff7f137d60e6..029b5cae813e 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
+     }
+ 
+-    if (m_inFenceFd != -1)
+-    {
+-      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
+-      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
+-    }
+   }
+   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
+   {
+@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+               strerror(errno));
+   }
+ 
+-  if (m_inFenceFd != -1)
+-  {
+-    close(m_inFenceFd);
+-    m_inFenceFd = -1;
+-  }
+-
+   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+   {
+     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
+@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   m_req = m_atomicRequestQueue.back().get();
+ }
+ 
+-void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   struct drm_fb *drm_fb = nullptr;
+-  uint32_t flags = 0;
+ 
+   if (rendered)
+   {
+@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
+       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
+       return;
+     }
+-
+-    if (async && !m_need_modeset)
+-      flags |= DRM_MODE_ATOMIC_NONBLOCK;
+   }
+ 
++  uint32_t flags = 0;
++
+   if (m_need_modeset)
+   {
+     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
+index 6b196575878f..ca2cd9a1d0c9 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
+@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
+ public:
+   CDRMAtomic() = default;
+   ~CDRMAtomic() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+index 4e9c3a6b9f3d..418d067e7024 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
+   return true;
+ }
+ 
+-void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   if (rendered || videoLayer)
+   {
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
+index e763f298f75a..2b7ff4561728 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.h
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
+@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
+ public:
+   CDRMLegacy() = default;
+   ~CDRMLegacy() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
+index f92f716fc4f3..5327e3557046 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.h
++++ b/xbmc/windowing/gbm/drm/DRMUtils.h
+@@ -15,7 +15,6 @@
+ #include "windowing/Resolution.h"
+ #include "windowing/gbm/GBMUtils.h"
+ 
+-#include <utility>
+ #include <vector>
+ 
+ #include <gbm.h>
+@@ -40,7 +39,7 @@ class CDRMUtils
+ public:
+   CDRMUtils() = default;
+   virtual ~CDRMUtils();
+-  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
++  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
+   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
+   virtual bool SetActive(bool active) { return false; }
+   virtual bool InitDrm();
+@@ -63,13 +62,6 @@ public:
+   static uint32_t FourCCWithAlpha(uint32_t fourcc);
+   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
+ 
+-  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
+-  int TakeOutFenceFd()
+-  {
+-    int fd{-1};
+-    return std::exchange(m_outFenceFd, fd);
+-  }
+-
+ protected:
+   bool OpenDrm(bool needConnector);
+   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
+@@ -86,9 +78,6 @@ protected:
+   int m_width = 0;
+   int m_height = 0;
+ 
+-  int m_inFenceFd{-1};
+-  int m_outFenceFd{-1};
+-
+   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
+ 
+ private:
+diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+index bba0db9a53dd..4270d4ecb242 100644
+--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
++++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
+ public:
+   COffScreenModeSetting() = default;
+   ~COffScreenModeSetting() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
++  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
+   bool SetActive(bool active) override { return false; }
+   bool InitDrm() override;
+-- 
+2.39.5
+
+
+From 543af77563f706cd70a5c2975f5fe217bf24024a Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:46 +0100
+Subject: [PATCH 4/4] Revert "CEGLFence: add support for using
+ EGL_KHR_fence_sync and EGL_ANDROID_native_fence_sync"
+
+This reverts commit ba17e5b45c5bd36ef65089f35049da82a290bb01.
+---
+ xbmc/utils/EGLFence.cpp | 70 -----------------------------------------
+ xbmc/utils/EGLFence.h   | 19 -----------
+ 2 files changed, 89 deletions(-)
+
+diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
+index 9d0065bdaf07..535e3bce3197 100644
 --- a/xbmc/utils/EGLFence.cpp
 +++ b/xbmc/utils/EGLFence.cpp
 @@ -22,14 +22,6 @@ CEGLFence::CEGLFence(EGLDisplay display)
@@ -84,7 +530,7 @@ index 9d0065bdaf..535e3bce31 100644
 -}
 -#endif
 diff --git a/xbmc/utils/EGLFence.h b/xbmc/utils/EGLFence.h
-index 03c246b60b..bd96444e47 100644
+index 03c246b60b67..bd96444e47e5 100644
 --- a/xbmc/utils/EGLFence.h
 +++ b/xbmc/utils/EGLFence.h
 @@ -30,14 +30,6 @@ public:
@@ -120,337 +566,6 @@ index 03c246b60b..bd96444e47 100644
  };
  
  }
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
-index f334156d89..34c8c16fe4 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
-@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
-   SetFullScreen(true, resMutable, false);
- }
- 
--void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-+void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
- {
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-     bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
-   }
- 
--  m_DRM->FlipPage(bo, rendered, videoLayer, async);
-+  m_DRM->FlipPage(bo, rendered, videoLayer);
- 
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
- bool CWinSystemGbm::Hide()
- {
-   bool ret = m_DRM->SetActive(false);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
- bool CWinSystemGbm::Show(bool raise)
- {
-   bool ret = m_DRM->SetActive(true);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
-index 879d0f58f8..a800acef6b 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.h
-+++ b/xbmc/windowing/gbm/WinSystemGbm.h
-@@ -49,7 +49,7 @@ public:
-   bool DisplayHardwareScalingEnabled() override;
-   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
- 
--  void FlipPage(bool rendered, bool videoLayer, bool async);
-+  void FlipPage(bool rendered, bool videoLayer);
- 
-   bool CanDoWindowed() override { return false; }
-   void UpdateResolutions() override;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-index ee27fba1bd..83a59413f7 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
-     return false;
-   }
- 
--  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
--      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
--  {
--    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
--  }
--  else
--  {
--    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
--                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
--  }
--
-   return true;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-index fbd52354ee..84f863d6d3 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-@@ -9,7 +9,6 @@
- #pragma once
- 
- #include "WinSystemGbm.h"
--#include "utils/EGLFence.h"
- #include "utils/EGLUtils.h"
- #include "windowing/linux/WinSystemEGL.h"
- 
-@@ -47,8 +46,6 @@ protected:
-   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
-   virtual bool CreateContext() = 0;
- 
--  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
--
-   struct delete_CVaapiProxy
-   {
-     void operator()(CVaapiProxy *p) const;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-index adbb539f21..e4ff49c618 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-index ad80abf46c..0d071c31f1 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-index ff7f137d60..029b5cae81 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
-     }
- 
--    if (m_inFenceFd != -1)
--    {
--      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
--      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
--    }
-   }
-   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
-   {
-@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-               strerror(errno));
-   }
- 
--  if (m_inFenceFd != -1)
--  {
--    close(m_inFenceFd);
--    m_inFenceFd = -1;
--  }
--
-   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
-   {
-     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
-@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-   m_req = m_atomicRequestQueue.back().get();
- }
- 
--void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   struct drm_fb *drm_fb = nullptr;
--  uint32_t flags = 0;
- 
-   if (rendered)
-   {
-@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
-       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
-       return;
-     }
--
--    if (async && !m_need_modeset)
--      flags |= DRM_MODE_ATOMIC_NONBLOCK;
-   }
- 
-+  uint32_t flags = 0;
-+
-   if (m_need_modeset)
-   {
-     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
-index 6b19657587..ca2cd9a1d0 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.h
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
-@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
- public:
-   CDRMAtomic() = default;
-   ~CDRMAtomic() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-index 4e9c3a6b9f..418d067e70 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
-   return true;
- }
- 
--void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   if (rendered || videoLayer)
-   {
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
-index e763f298f7..2b7ff45617 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.h
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
-@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
- public:
-   CDRMLegacy() = default;
-   ~CDRMLegacy() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
-index f92f716fc4..5327e35570 100644
---- a/xbmc/windowing/gbm/drm/DRMUtils.h
-+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
-@@ -15,7 +15,6 @@
- #include "windowing/Resolution.h"
- #include "windowing/gbm/GBMUtils.h"
- 
--#include <utility>
- #include <vector>
- 
- #include <gbm.h>
-@@ -40,7 +39,7 @@ class CDRMUtils
- public:
-   CDRMUtils() = default;
-   virtual ~CDRMUtils();
--  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
-+  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
-   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
-   virtual bool SetActive(bool active) { return false; }
-   virtual bool InitDrm();
-@@ -63,13 +62,6 @@ public:
-   static uint32_t FourCCWithAlpha(uint32_t fourcc);
-   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
- 
--  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
--  int TakeOutFenceFd()
--  {
--    int fd{-1};
--    return std::exchange(m_outFenceFd, fd);
--  }
--
- protected:
-   bool OpenDrm(bool needConnector);
-   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
-@@ -86,9 +78,6 @@ protected:
-   int m_width = 0;
-   int m_height = 0;
- 
--  int m_inFenceFd{-1};
--  int m_outFenceFd{-1};
--
-   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
- 
- private:
-diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-index bba0db9a53..4270d4ecb2 100644
---- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
- public:
-   COffScreenModeSetting() = default;
-   ~COffScreenModeSetting() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
-+  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
-   bool SetActive(bool active) override { return false; }
-   bool InitDrm() override;
+-- 
+2.39.5
+

--- a/projects/Generic/patches/kodi/000-temp-revert-fences.patch
+++ b/projects/Generic/patches/kodi/000-temp-revert-fences.patch
@@ -1,5 +1,451 @@
+From 711a8784ecf9a8193ec33c80d3e63723efa3617b Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:16 +0100
+Subject: [PATCH 1/4] Revert "CEGLFence: Ignore improper atomic drmrequest when
+ async rendering and"
+
+This reverts commit 396e4b286f0c104d41facca3ca7633f21f0907da.
+---
+ xbmc/utils/EGLFence.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
 diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
-index 9d0065bdaf..535e3bce31 100644
+index 58a9ec1683be..9d0065bdaf07 100644
+--- a/xbmc/utils/EGLFence.cpp
++++ b/xbmc/utils/EGLFence.cpp
+@@ -133,7 +133,11 @@ void CEGLFence::WaitSyncCPU()
+   if (!m_kmsFence)
+     return;
+ 
+-  if (m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR) != EGL_FALSE)
+-    m_eglDestroySyncKHR(m_display, m_kmsFence);
++  EGLint status{EGL_FALSE};
++
++  while (status != EGL_CONDITION_SATISFIED_KHR)
++    status = m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR);
++
++  m_eglDestroySyncKHR(m_display, m_kmsFence);
+ }
+ #endif
+-- 
+2.39.5
+
+
+From 95536ae880d43c38721fe346d52ff0b2efc7aa67 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:21 +0100
+Subject: [PATCH 2/4] Revert "CDRMAtomic: Backlog only the last known good
+ drmrequest"
+
+This reverts commit e13ba25f11c1d1315033701f078bd15d2433ddd3.
+---
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index 70ae92e9482d..ff7f137d60e6 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -149,11 +149,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   {
+     CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
+               strerror(errno));
+-    m_atomicRequestQueue.pop_back();
+-  }
+-  else if (m_atomicRequestQueue.size() > 1)
+-  {
+-    m_atomicRequestQueue.pop_front();
+   }
+ 
+   if (m_inFenceFd != -1)
+@@ -169,6 +164,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+                 strerror(errno));
+   }
+ 
++  if (m_atomicRequestQueue.size() > 1)
++    m_atomicRequestQueue.pop_back();
++
+   m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
+   m_req = m_atomicRequestQueue.back().get();
+ }
+-- 
+2.39.5
+
+
+From ee236db5f93c6c6eae8d28c8ed6b40897d5920b3 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:02 +0100
+Subject: [PATCH 3/4] Revert "CDRMAtomic: add support for using
+ DRM_MODE_ATOMIC_NONBLOCK"
+
+This reverts commit e9710033029d86efa0c18a6121d2c6376f74ef10.
+---
+ xbmc/windowing/gbm/WinSystemGbm.cpp           |  8 +++---
+ xbmc/windowing/gbm/WinSystemGbm.h             |  2 +-
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp | 11 --------
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.h   |  3 ---
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 26 +-----------------
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp | 27 +------------------
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp          | 19 +++----------
+ xbmc/windowing/gbm/drm/DRMAtomic.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.cpp          |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMUtils.h             | 13 +--------
+ xbmc/windowing/gbm/drm/OffScreenModeSetting.h |  2 +-
+ 12 files changed, 15 insertions(+), 102 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index 72497a215684..ba472fc29079 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
+   SetFullScreen(true, resMutable, false);
+ }
+ 
+-void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
++void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
+ {
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
+     bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get();
+   }
+ 
+-  m_DRM->FlipPage(bo, rendered, videoLayer, async);
++  m_DRM->FlipPage(bo, rendered, videoLayer);
+ 
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
+ bool CWinSystemGbm::Hide()
+ {
+   bool ret = m_DRM->SetActive(false);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+ bool CWinSystemGbm::Show(bool raise)
+ {
+   bool ret = m_DRM->SetActive(true);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 9609675d7220..8993b6d27865 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -49,7 +49,7 @@ public:
+   bool DisplayHardwareScalingEnabled() override;
+   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
+ 
+-  void FlipPage(bool rendered, bool videoLayer, bool async);
++  void FlipPage(bool rendered, bool videoLayer);
+ 
+   bool CanDoWindowed() override { return false; }
+   void UpdateResolutions() override;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+index fac914d5e9f2..2fb742efed35 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+     return false;
+   }
+ 
+-  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
+-      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
+-  {
+-    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+-  }
+-  else
+-  {
+-    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
+-                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
+-  }
+-
+   return true;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+index fbd52354ee7f..84f863d6d321 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+@@ -9,7 +9,6 @@
+ #pragma once
+ 
+ #include "WinSystemGbm.h"
+-#include "utils/EGLFence.h"
+ #include "utils/EGLUtils.h"
+ #include "windowing/linux/WinSystemEGL.h"
+ 
+@@ -47,8 +46,6 @@ protected:
+   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
+   virtual bool CreateContext() = 0;
+ 
+-  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
+-
+   struct delete_CVaapiProxy
+   {
+     void operator()(CVaapiProxy *p) const;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index adbb539f210d..e4ff49c61835 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index ad80abf46c3e..0d071c31f168 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index ff7f137d60e6..029b5cae813e 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
+     }
+ 
+-    if (m_inFenceFd != -1)
+-    {
+-      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
+-      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
+-    }
+   }
+   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
+   {
+@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+               strerror(errno));
+   }
+ 
+-  if (m_inFenceFd != -1)
+-  {
+-    close(m_inFenceFd);
+-    m_inFenceFd = -1;
+-  }
+-
+   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+   {
+     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
+@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   m_req = m_atomicRequestQueue.back().get();
+ }
+ 
+-void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   struct drm_fb *drm_fb = nullptr;
+-  uint32_t flags = 0;
+ 
+   if (rendered)
+   {
+@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
+       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
+       return;
+     }
+-
+-    if (async && !m_need_modeset)
+-      flags |= DRM_MODE_ATOMIC_NONBLOCK;
+   }
+ 
++  uint32_t flags = 0;
++
+   if (m_need_modeset)
+   {
+     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
+index 6b196575878f..ca2cd9a1d0c9 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
+@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
+ public:
+   CDRMAtomic() = default;
+   ~CDRMAtomic() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+index 4e9c3a6b9f3d..418d067e7024 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
+   return true;
+ }
+ 
+-void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   if (rendered || videoLayer)
+   {
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
+index e763f298f75a..2b7ff4561728 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.h
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
+@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
+ public:
+   CDRMLegacy() = default;
+   ~CDRMLegacy() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
+index f92f716fc4f3..5327e3557046 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.h
++++ b/xbmc/windowing/gbm/drm/DRMUtils.h
+@@ -15,7 +15,6 @@
+ #include "windowing/Resolution.h"
+ #include "windowing/gbm/GBMUtils.h"
+ 
+-#include <utility>
+ #include <vector>
+ 
+ #include <gbm.h>
+@@ -40,7 +39,7 @@ class CDRMUtils
+ public:
+   CDRMUtils() = default;
+   virtual ~CDRMUtils();
+-  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
++  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
+   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
+   virtual bool SetActive(bool active) { return false; }
+   virtual bool InitDrm();
+@@ -63,13 +62,6 @@ public:
+   static uint32_t FourCCWithAlpha(uint32_t fourcc);
+   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
+ 
+-  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
+-  int TakeOutFenceFd()
+-  {
+-    int fd{-1};
+-    return std::exchange(m_outFenceFd, fd);
+-  }
+-
+ protected:
+   bool OpenDrm(bool needConnector);
+   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
+@@ -86,9 +78,6 @@ protected:
+   int m_width = 0;
+   int m_height = 0;
+ 
+-  int m_inFenceFd{-1};
+-  int m_outFenceFd{-1};
+-
+   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
+ 
+ private:
+diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+index bba0db9a53dd..4270d4ecb242 100644
+--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
++++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
+ public:
+   COffScreenModeSetting() = default;
+   ~COffScreenModeSetting() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
++  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
+   bool SetActive(bool active) override { return false; }
+   bool InitDrm() override;
+-- 
+2.39.5
+
+
+From 543af77563f706cd70a5c2975f5fe217bf24024a Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:46 +0100
+Subject: [PATCH 4/4] Revert "CEGLFence: add support for using
+ EGL_KHR_fence_sync and EGL_ANDROID_native_fence_sync"
+
+This reverts commit ba17e5b45c5bd36ef65089f35049da82a290bb01.
+---
+ xbmc/utils/EGLFence.cpp | 70 -----------------------------------------
+ xbmc/utils/EGLFence.h   | 19 -----------
+ 2 files changed, 89 deletions(-)
+
+diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
+index 9d0065bdaf07..535e3bce3197 100644
 --- a/xbmc/utils/EGLFence.cpp
 +++ b/xbmc/utils/EGLFence.cpp
 @@ -22,14 +22,6 @@ CEGLFence::CEGLFence(EGLDisplay display)
@@ -84,7 +530,7 @@ index 9d0065bdaf..535e3bce31 100644
 -}
 -#endif
 diff --git a/xbmc/utils/EGLFence.h b/xbmc/utils/EGLFence.h
-index 03c246b60b..bd96444e47 100644
+index 03c246b60b67..bd96444e47e5 100644
 --- a/xbmc/utils/EGLFence.h
 +++ b/xbmc/utils/EGLFence.h
 @@ -30,14 +30,6 @@ public:
@@ -120,337 +566,6 @@ index 03c246b60b..bd96444e47 100644
  };
  
  }
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
-index f334156d89..34c8c16fe4 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
-@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
-   SetFullScreen(true, resMutable, false);
- }
- 
--void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-+void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
- {
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-     bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
-   }
- 
--  m_DRM->FlipPage(bo, rendered, videoLayer, async);
-+  m_DRM->FlipPage(bo, rendered, videoLayer);
- 
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
- bool CWinSystemGbm::Hide()
- {
-   bool ret = m_DRM->SetActive(false);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
- bool CWinSystemGbm::Show(bool raise)
- {
-   bool ret = m_DRM->SetActive(true);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
-index 879d0f58f8..a800acef6b 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.h
-+++ b/xbmc/windowing/gbm/WinSystemGbm.h
-@@ -49,7 +49,7 @@ public:
-   bool DisplayHardwareScalingEnabled() override;
-   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
- 
--  void FlipPage(bool rendered, bool videoLayer, bool async);
-+  void FlipPage(bool rendered, bool videoLayer);
- 
-   bool CanDoWindowed() override { return false; }
-   void UpdateResolutions() override;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-index ee27fba1bd..83a59413f7 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
-     return false;
-   }
- 
--  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
--      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
--  {
--    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
--  }
--  else
--  {
--    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
--                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
--  }
--
-   return true;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-index fbd52354ee..84f863d6d3 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-@@ -9,7 +9,6 @@
- #pragma once
- 
- #include "WinSystemGbm.h"
--#include "utils/EGLFence.h"
- #include "utils/EGLUtils.h"
- #include "windowing/linux/WinSystemEGL.h"
- 
-@@ -47,8 +46,6 @@ protected:
-   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
-   virtual bool CreateContext() = 0;
- 
--  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
--
-   struct delete_CVaapiProxy
-   {
-     void operator()(CVaapiProxy *p) const;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-index adbb539f21..e4ff49c618 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-index ad80abf46c..0d071c31f1 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-index ff7f137d60..029b5cae81 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
-     }
- 
--    if (m_inFenceFd != -1)
--    {
--      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
--      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
--    }
-   }
-   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
-   {
-@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-               strerror(errno));
-   }
- 
--  if (m_inFenceFd != -1)
--  {
--    close(m_inFenceFd);
--    m_inFenceFd = -1;
--  }
--
-   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
-   {
-     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
-@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-   m_req = m_atomicRequestQueue.back().get();
- }
- 
--void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   struct drm_fb *drm_fb = nullptr;
--  uint32_t flags = 0;
- 
-   if (rendered)
-   {
-@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
-       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
-       return;
-     }
--
--    if (async && !m_need_modeset)
--      flags |= DRM_MODE_ATOMIC_NONBLOCK;
-   }
- 
-+  uint32_t flags = 0;
-+
-   if (m_need_modeset)
-   {
-     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
-index 6b19657587..ca2cd9a1d0 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.h
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
-@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
- public:
-   CDRMAtomic() = default;
-   ~CDRMAtomic() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-index 4e9c3a6b9f..418d067e70 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
-   return true;
- }
- 
--void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   if (rendered || videoLayer)
-   {
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
-index e763f298f7..2b7ff45617 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.h
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
-@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
- public:
-   CDRMLegacy() = default;
-   ~CDRMLegacy() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
-index f92f716fc4..5327e35570 100644
---- a/xbmc/windowing/gbm/drm/DRMUtils.h
-+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
-@@ -15,7 +15,6 @@
- #include "windowing/Resolution.h"
- #include "windowing/gbm/GBMUtils.h"
- 
--#include <utility>
- #include <vector>
- 
- #include <gbm.h>
-@@ -40,7 +39,7 @@ class CDRMUtils
- public:
-   CDRMUtils() = default;
-   virtual ~CDRMUtils();
--  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
-+  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
-   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
-   virtual bool SetActive(bool active) { return false; }
-   virtual bool InitDrm();
-@@ -63,13 +62,6 @@ public:
-   static uint32_t FourCCWithAlpha(uint32_t fourcc);
-   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
- 
--  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
--  int TakeOutFenceFd()
--  {
--    int fd{-1};
--    return std::exchange(m_outFenceFd, fd);
--  }
--
- protected:
-   bool OpenDrm(bool needConnector);
-   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
-@@ -86,9 +78,6 @@ protected:
-   int m_width = 0;
-   int m_height = 0;
- 
--  int m_inFenceFd{-1};
--  int m_outFenceFd{-1};
--
-   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
- 
- private:
-diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-index bba0db9a53..4270d4ecb2 100644
---- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
- public:
-   COffScreenModeSetting() = default;
-   ~COffScreenModeSetting() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
-+  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
-   bool SetActive(bool active) override { return false; }
-   bool InitDrm() override;
+-- 
+2.39.5
+

--- a/projects/RPi/patches/kodi/000-temp-revert-fences.patch
+++ b/projects/RPi/patches/kodi/000-temp-revert-fences.patch
@@ -1,5 +1,451 @@
+From 711a8784ecf9a8193ec33c80d3e63723efa3617b Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:16 +0100
+Subject: [PATCH 1/4] Revert "CEGLFence: Ignore improper atomic drmrequest when
+ async rendering and"
+
+This reverts commit 396e4b286f0c104d41facca3ca7633f21f0907da.
+---
+ xbmc/utils/EGLFence.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
 diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
-index 9d0065bdaf..535e3bce31 100644
+index 58a9ec1683be..9d0065bdaf07 100644
+--- a/xbmc/utils/EGLFence.cpp
++++ b/xbmc/utils/EGLFence.cpp
+@@ -133,7 +133,11 @@ void CEGLFence::WaitSyncCPU()
+   if (!m_kmsFence)
+     return;
+ 
+-  if (m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR) != EGL_FALSE)
+-    m_eglDestroySyncKHR(m_display, m_kmsFence);
++  EGLint status{EGL_FALSE};
++
++  while (status != EGL_CONDITION_SATISFIED_KHR)
++    status = m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR);
++
++  m_eglDestroySyncKHR(m_display, m_kmsFence);
+ }
+ #endif
+-- 
+2.39.5
+
+
+From 95536ae880d43c38721fe346d52ff0b2efc7aa67 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:21 +0100
+Subject: [PATCH 2/4] Revert "CDRMAtomic: Backlog only the last known good
+ drmrequest"
+
+This reverts commit e13ba25f11c1d1315033701f078bd15d2433ddd3.
+---
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index 70ae92e9482d..ff7f137d60e6 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -149,11 +149,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   {
+     CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
+               strerror(errno));
+-    m_atomicRequestQueue.pop_back();
+-  }
+-  else if (m_atomicRequestQueue.size() > 1)
+-  {
+-    m_atomicRequestQueue.pop_front();
+   }
+ 
+   if (m_inFenceFd != -1)
+@@ -169,6 +164,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+                 strerror(errno));
+   }
+ 
++  if (m_atomicRequestQueue.size() > 1)
++    m_atomicRequestQueue.pop_back();
++
+   m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
+   m_req = m_atomicRequestQueue.back().get();
+ }
+-- 
+2.39.5
+
+
+From ee236db5f93c6c6eae8d28c8ed6b40897d5920b3 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:02 +0100
+Subject: [PATCH 3/4] Revert "CDRMAtomic: add support for using
+ DRM_MODE_ATOMIC_NONBLOCK"
+
+This reverts commit e9710033029d86efa0c18a6121d2c6376f74ef10.
+---
+ xbmc/windowing/gbm/WinSystemGbm.cpp           |  8 +++---
+ xbmc/windowing/gbm/WinSystemGbm.h             |  2 +-
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp | 11 --------
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.h   |  3 ---
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 26 +-----------------
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp | 27 +------------------
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp          | 19 +++----------
+ xbmc/windowing/gbm/drm/DRMAtomic.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.cpp          |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMUtils.h             | 13 +--------
+ xbmc/windowing/gbm/drm/OffScreenModeSetting.h |  2 +-
+ 12 files changed, 15 insertions(+), 102 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index 72497a215684..ba472fc29079 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
+   SetFullScreen(true, resMutable, false);
+ }
+ 
+-void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
++void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
+ {
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
+     bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get();
+   }
+ 
+-  m_DRM->FlipPage(bo, rendered, videoLayer, async);
++  m_DRM->FlipPage(bo, rendered, videoLayer);
+ 
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
+ bool CWinSystemGbm::Hide()
+ {
+   bool ret = m_DRM->SetActive(false);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+ bool CWinSystemGbm::Show(bool raise)
+ {
+   bool ret = m_DRM->SetActive(true);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 9609675d7220..8993b6d27865 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -49,7 +49,7 @@ public:
+   bool DisplayHardwareScalingEnabled() override;
+   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
+ 
+-  void FlipPage(bool rendered, bool videoLayer, bool async);
++  void FlipPage(bool rendered, bool videoLayer);
+ 
+   bool CanDoWindowed() override { return false; }
+   void UpdateResolutions() override;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+index fac914d5e9f2..2fb742efed35 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+     return false;
+   }
+ 
+-  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
+-      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
+-  {
+-    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+-  }
+-  else
+-  {
+-    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
+-                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
+-  }
+-
+   return true;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+index fbd52354ee7f..84f863d6d321 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+@@ -9,7 +9,6 @@
+ #pragma once
+ 
+ #include "WinSystemGbm.h"
+-#include "utils/EGLFence.h"
+ #include "utils/EGLUtils.h"
+ #include "windowing/linux/WinSystemEGL.h"
+ 
+@@ -47,8 +46,6 @@ protected:
+   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
+   virtual bool CreateContext() = 0;
+ 
+-  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
+-
+   struct delete_CVaapiProxy
+   {
+     void operator()(CVaapiProxy *p) const;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index adbb539f210d..e4ff49c61835 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index ad80abf46c3e..0d071c31f168 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index ff7f137d60e6..029b5cae813e 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
+     }
+ 
+-    if (m_inFenceFd != -1)
+-    {
+-      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
+-      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
+-    }
+   }
+   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
+   {
+@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+               strerror(errno));
+   }
+ 
+-  if (m_inFenceFd != -1)
+-  {
+-    close(m_inFenceFd);
+-    m_inFenceFd = -1;
+-  }
+-
+   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+   {
+     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
+@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   m_req = m_atomicRequestQueue.back().get();
+ }
+ 
+-void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   struct drm_fb *drm_fb = nullptr;
+-  uint32_t flags = 0;
+ 
+   if (rendered)
+   {
+@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
+       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
+       return;
+     }
+-
+-    if (async && !m_need_modeset)
+-      flags |= DRM_MODE_ATOMIC_NONBLOCK;
+   }
+ 
++  uint32_t flags = 0;
++
+   if (m_need_modeset)
+   {
+     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
+index 6b196575878f..ca2cd9a1d0c9 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
+@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
+ public:
+   CDRMAtomic() = default;
+   ~CDRMAtomic() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+index 4e9c3a6b9f3d..418d067e7024 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
+   return true;
+ }
+ 
+-void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   if (rendered || videoLayer)
+   {
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
+index e763f298f75a..2b7ff4561728 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.h
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
+@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
+ public:
+   CDRMLegacy() = default;
+   ~CDRMLegacy() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
+index f92f716fc4f3..5327e3557046 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.h
++++ b/xbmc/windowing/gbm/drm/DRMUtils.h
+@@ -15,7 +15,6 @@
+ #include "windowing/Resolution.h"
+ #include "windowing/gbm/GBMUtils.h"
+ 
+-#include <utility>
+ #include <vector>
+ 
+ #include <gbm.h>
+@@ -40,7 +39,7 @@ class CDRMUtils
+ public:
+   CDRMUtils() = default;
+   virtual ~CDRMUtils();
+-  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
++  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
+   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
+   virtual bool SetActive(bool active) { return false; }
+   virtual bool InitDrm();
+@@ -63,13 +62,6 @@ public:
+   static uint32_t FourCCWithAlpha(uint32_t fourcc);
+   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
+ 
+-  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
+-  int TakeOutFenceFd()
+-  {
+-    int fd{-1};
+-    return std::exchange(m_outFenceFd, fd);
+-  }
+-
+ protected:
+   bool OpenDrm(bool needConnector);
+   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
+@@ -86,9 +78,6 @@ protected:
+   int m_width = 0;
+   int m_height = 0;
+ 
+-  int m_inFenceFd{-1};
+-  int m_outFenceFd{-1};
+-
+   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
+ 
+ private:
+diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+index bba0db9a53dd..4270d4ecb242 100644
+--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
++++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
+ public:
+   COffScreenModeSetting() = default;
+   ~COffScreenModeSetting() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
++  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
+   bool SetActive(bool active) override { return false; }
+   bool InitDrm() override;
+-- 
+2.39.5
+
+
+From 543af77563f706cd70a5c2975f5fe217bf24024a Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:46 +0100
+Subject: [PATCH 4/4] Revert "CEGLFence: add support for using
+ EGL_KHR_fence_sync and EGL_ANDROID_native_fence_sync"
+
+This reverts commit ba17e5b45c5bd36ef65089f35049da82a290bb01.
+---
+ xbmc/utils/EGLFence.cpp | 70 -----------------------------------------
+ xbmc/utils/EGLFence.h   | 19 -----------
+ 2 files changed, 89 deletions(-)
+
+diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
+index 9d0065bdaf07..535e3bce3197 100644
 --- a/xbmc/utils/EGLFence.cpp
 +++ b/xbmc/utils/EGLFence.cpp
 @@ -22,14 +22,6 @@ CEGLFence::CEGLFence(EGLDisplay display)
@@ -84,7 +530,7 @@ index 9d0065bdaf..535e3bce31 100644
 -}
 -#endif
 diff --git a/xbmc/utils/EGLFence.h b/xbmc/utils/EGLFence.h
-index 03c246b60b..bd96444e47 100644
+index 03c246b60b67..bd96444e47e5 100644
 --- a/xbmc/utils/EGLFence.h
 +++ b/xbmc/utils/EGLFence.h
 @@ -30,14 +30,6 @@ public:
@@ -120,337 +566,6 @@ index 03c246b60b..bd96444e47 100644
  };
  
  }
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
-index f334156d89..34c8c16fe4 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
-@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
-   SetFullScreen(true, resMutable, false);
- }
- 
--void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-+void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
- {
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-     bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
-   }
- 
--  m_DRM->FlipPage(bo, rendered, videoLayer, async);
-+  m_DRM->FlipPage(bo, rendered, videoLayer);
- 
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
- bool CWinSystemGbm::Hide()
- {
-   bool ret = m_DRM->SetActive(false);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
- bool CWinSystemGbm::Show(bool raise)
- {
-   bool ret = m_DRM->SetActive(true);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
-index 879d0f58f8..a800acef6b 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.h
-+++ b/xbmc/windowing/gbm/WinSystemGbm.h
-@@ -49,7 +49,7 @@ public:
-   bool DisplayHardwareScalingEnabled() override;
-   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
- 
--  void FlipPage(bool rendered, bool videoLayer, bool async);
-+  void FlipPage(bool rendered, bool videoLayer);
- 
-   bool CanDoWindowed() override { return false; }
-   void UpdateResolutions() override;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-index ee27fba1bd..83a59413f7 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
-     return false;
-   }
- 
--  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
--      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
--  {
--    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
--  }
--  else
--  {
--    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
--                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
--  }
--
-   return true;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-index fbd52354ee..84f863d6d3 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-@@ -9,7 +9,6 @@
- #pragma once
- 
- #include "WinSystemGbm.h"
--#include "utils/EGLFence.h"
- #include "utils/EGLUtils.h"
- #include "windowing/linux/WinSystemEGL.h"
- 
-@@ -47,8 +46,6 @@ protected:
-   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
-   virtual bool CreateContext() = 0;
- 
--  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
--
-   struct delete_CVaapiProxy
-   {
-     void operator()(CVaapiProxy *p) const;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-index adbb539f21..e4ff49c618 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-index ad80abf46c..0d071c31f1 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-index ff7f137d60..029b5cae81 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
-     }
- 
--    if (m_inFenceFd != -1)
--    {
--      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
--      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
--    }
-   }
-   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
-   {
-@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-               strerror(errno));
-   }
- 
--  if (m_inFenceFd != -1)
--  {
--    close(m_inFenceFd);
--    m_inFenceFd = -1;
--  }
--
-   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
-   {
-     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
-@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-   m_req = m_atomicRequestQueue.back().get();
- }
- 
--void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   struct drm_fb *drm_fb = nullptr;
--  uint32_t flags = 0;
- 
-   if (rendered)
-   {
-@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
-       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
-       return;
-     }
--
--    if (async && !m_need_modeset)
--      flags |= DRM_MODE_ATOMIC_NONBLOCK;
-   }
- 
-+  uint32_t flags = 0;
-+
-   if (m_need_modeset)
-   {
-     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
-index 6b19657587..ca2cd9a1d0 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.h
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
-@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
- public:
-   CDRMAtomic() = default;
-   ~CDRMAtomic() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-index 4e9c3a6b9f..418d067e70 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
-   return true;
- }
- 
--void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   if (rendered || videoLayer)
-   {
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
-index e763f298f7..2b7ff45617 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.h
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
-@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
- public:
-   CDRMLegacy() = default;
-   ~CDRMLegacy() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
-index f92f716fc4..5327e35570 100644
---- a/xbmc/windowing/gbm/drm/DRMUtils.h
-+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
-@@ -15,7 +15,6 @@
- #include "windowing/Resolution.h"
- #include "windowing/gbm/GBMUtils.h"
- 
--#include <utility>
- #include <vector>
- 
- #include <gbm.h>
-@@ -40,7 +39,7 @@ class CDRMUtils
- public:
-   CDRMUtils() = default;
-   virtual ~CDRMUtils();
--  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
-+  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
-   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
-   virtual bool SetActive(bool active) { return false; }
-   virtual bool InitDrm();
-@@ -63,13 +62,6 @@ public:
-   static uint32_t FourCCWithAlpha(uint32_t fourcc);
-   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
- 
--  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
--  int TakeOutFenceFd()
--  {
--    int fd{-1};
--    return std::exchange(m_outFenceFd, fd);
--  }
--
- protected:
-   bool OpenDrm(bool needConnector);
-   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
-@@ -86,9 +78,6 @@ protected:
-   int m_width = 0;
-   int m_height = 0;
- 
--  int m_inFenceFd{-1};
--  int m_outFenceFd{-1};
--
-   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
- 
- private:
-diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-index bba0db9a53..4270d4ecb2 100644
---- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
- public:
-   COffScreenModeSetting() = default;
-   ~COffScreenModeSetting() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
-+  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
-   bool SetActive(bool active) override { return false; }
-   bool InitDrm() override;
+-- 
+2.39.5
+

--- a/projects/Rockchip/patches/kodi/000-temp-revert-fences.patch
+++ b/projects/Rockchip/patches/kodi/000-temp-revert-fences.patch
@@ -1,5 +1,451 @@
+From 711a8784ecf9a8193ec33c80d3e63723efa3617b Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:16 +0100
+Subject: [PATCH 1/4] Revert "CEGLFence: Ignore improper atomic drmrequest when
+ async rendering and"
+
+This reverts commit 396e4b286f0c104d41facca3ca7633f21f0907da.
+---
+ xbmc/utils/EGLFence.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
 diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
-index 9d0065bdaf..535e3bce31 100644
+index 58a9ec1683be..9d0065bdaf07 100644
+--- a/xbmc/utils/EGLFence.cpp
++++ b/xbmc/utils/EGLFence.cpp
+@@ -133,7 +133,11 @@ void CEGLFence::WaitSyncCPU()
+   if (!m_kmsFence)
+     return;
+ 
+-  if (m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR) != EGL_FALSE)
+-    m_eglDestroySyncKHR(m_display, m_kmsFence);
++  EGLint status{EGL_FALSE};
++
++  while (status != EGL_CONDITION_SATISFIED_KHR)
++    status = m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR);
++
++  m_eglDestroySyncKHR(m_display, m_kmsFence);
+ }
+ #endif
+-- 
+2.39.5
+
+
+From 95536ae880d43c38721fe346d52ff0b2efc7aa67 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:05:21 +0100
+Subject: [PATCH 2/4] Revert "CDRMAtomic: Backlog only the last known good
+ drmrequest"
+
+This reverts commit e13ba25f11c1d1315033701f078bd15d2433ddd3.
+---
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index 70ae92e9482d..ff7f137d60e6 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -149,11 +149,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   {
+     CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
+               strerror(errno));
+-    m_atomicRequestQueue.pop_back();
+-  }
+-  else if (m_atomicRequestQueue.size() > 1)
+-  {
+-    m_atomicRequestQueue.pop_front();
+   }
+ 
+   if (m_inFenceFd != -1)
+@@ -169,6 +164,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+                 strerror(errno));
+   }
+ 
++  if (m_atomicRequestQueue.size() > 1)
++    m_atomicRequestQueue.pop_back();
++
+   m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
+   m_req = m_atomicRequestQueue.back().get();
+ }
+-- 
+2.39.5
+
+
+From ee236db5f93c6c6eae8d28c8ed6b40897d5920b3 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:02 +0100
+Subject: [PATCH 3/4] Revert "CDRMAtomic: add support for using
+ DRM_MODE_ATOMIC_NONBLOCK"
+
+This reverts commit e9710033029d86efa0c18a6121d2c6376f74ef10.
+---
+ xbmc/windowing/gbm/WinSystemGbm.cpp           |  8 +++---
+ xbmc/windowing/gbm/WinSystemGbm.h             |  2 +-
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp | 11 --------
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.h   |  3 ---
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 26 +-----------------
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp | 27 +------------------
+ xbmc/windowing/gbm/drm/DRMAtomic.cpp          | 19 +++----------
+ xbmc/windowing/gbm/drm/DRMAtomic.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.cpp          |  2 +-
+ xbmc/windowing/gbm/drm/DRMLegacy.h            |  2 +-
+ xbmc/windowing/gbm/drm/DRMUtils.h             | 13 +--------
+ xbmc/windowing/gbm/drm/OffScreenModeSetting.h |  2 +-
+ 12 files changed, 15 insertions(+), 102 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index 72497a215684..ba472fc29079 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
+   SetFullScreen(true, resMutable, false);
+ }
+ 
+-void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
++void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
+ {
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
+     bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get();
+   }
+ 
+-  m_DRM->FlipPage(bo, rendered, videoLayer, async);
++  m_DRM->FlipPage(bo, rendered, videoLayer);
+ 
+   if (m_videoLayerBridge && !videoLayer)
+   {
+@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
+ bool CWinSystemGbm::Hide()
+ {
+   bool ret = m_DRM->SetActive(false);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+ bool CWinSystemGbm::Show(bool raise)
+ {
+   bool ret = m_DRM->SetActive(true);
+-  FlipPage(false, false, false);
++  FlipPage(false, false);
+   return ret;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 9609675d7220..8993b6d27865 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -49,7 +49,7 @@ public:
+   bool DisplayHardwareScalingEnabled() override;
+   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
+ 
+-  void FlipPage(bool rendered, bool videoLayer, bool async);
++  void FlipPage(bool rendered, bool videoLayer);
+ 
+   bool CanDoWindowed() override { return false; }
+   void UpdateResolutions() override;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+index fac914d5e9f2..2fb742efed35 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+     return false;
+   }
+ 
+-  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
+-      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
+-  {
+-    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+-  }
+-  else
+-  {
+-    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
+-                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
+-  }
+-
+   return true;
+ }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+index fbd52354ee7f..84f863d6d321 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+@@ -9,7 +9,6 @@
+ #pragma once
+ 
+ #include "WinSystemGbm.h"
+-#include "utils/EGLFence.h"
+ #include "utils/EGLUtils.h"
+ #include "windowing/linux/WinSystemEGL.h"
+ 
+@@ -47,8 +46,6 @@ protected:
+   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
+   virtual bool CreateContext() = 0;
+ 
+-  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
+-
+   struct delete_CVaapiProxy
+   {
+     void operator()(CVaapiProxy *p) const;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index adbb539f210d..e4ff49c61835 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index ad80abf46c3e..0d071c31f168 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+   {
+     if (rendered)
+     {
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_DRM->TakeOutFenceFd();
+-        if (fd != -1)
+-        {
+-          m_eglFence->CreateKMSFence(fd);
+-          m_eglFence->WaitSyncGPU();
+-        }
+-
+-        m_eglFence->CreateGPUFence();
+-      }
+-#endif
+-
+       if (!m_eglContext.TrySwapBuffers())
+       {
+         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+         throw std::runtime_error("eglSwapBuffers failed");
+       }
+-
+-#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+-      if (m_eglFence)
+-      {
+-        int fd = m_eglFence->FlushFence();
+-        m_DRM->SetInFenceFd(fd);
+-
+-        m_eglFence->WaitSyncCPU();
+-      }
+-#endif
+     }
+-
+-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
++    CWinSystemGbm::FlipPage(rendered, videoLayer);
+ 
+     if (m_dispReset && m_dispResetTimer.IsTimePast())
+     {
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+index ff7f137d60e6..029b5cae813e 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
+     }
+ 
+-    if (m_inFenceFd != -1)
+-    {
+-      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
+-      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
+-    }
+   }
+   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
+   {
+@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+               strerror(errno));
+   }
+ 
+-  if (m_inFenceFd != -1)
+-  {
+-    close(m_inFenceFd);
+-    m_inFenceFd = -1;
+-  }
+-
+   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+   {
+     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
+@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
+   m_req = m_atomicRequestQueue.back().get();
+ }
+ 
+-void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   struct drm_fb *drm_fb = nullptr;
+-  uint32_t flags = 0;
+ 
+   if (rendered)
+   {
+@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
+       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
+       return;
+     }
+-
+-    if (async && !m_need_modeset)
+-      flags |= DRM_MODE_ATOMIC_NONBLOCK;
+   }
+ 
++  uint32_t flags = 0;
++
+   if (m_need_modeset)
+   {
+     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
+index 6b196575878f..ca2cd9a1d0c9 100644
+--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
++++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
+@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
+ public:
+   CDRMAtomic() = default;
+   ~CDRMAtomic() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+index 4e9c3a6b9f3d..418d067e7024 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
+   return true;
+ }
+ 
+-void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
++void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+ {
+   if (rendered || videoLayer)
+   {
+diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
+index e763f298f75a..2b7ff4561728 100644
+--- a/xbmc/windowing/gbm/drm/DRMLegacy.h
++++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
+@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
+ public:
+   CDRMLegacy() = default;
+   ~CDRMLegacy() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
++  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
+   bool SetActive(bool active) override;
+   bool InitDrm() override;
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
+index f92f716fc4f3..5327e3557046 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.h
++++ b/xbmc/windowing/gbm/drm/DRMUtils.h
+@@ -15,7 +15,6 @@
+ #include "windowing/Resolution.h"
+ #include "windowing/gbm/GBMUtils.h"
+ 
+-#include <utility>
+ #include <vector>
+ 
+ #include <gbm.h>
+@@ -40,7 +39,7 @@ class CDRMUtils
+ public:
+   CDRMUtils() = default;
+   virtual ~CDRMUtils();
+-  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
++  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
+   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
+   virtual bool SetActive(bool active) { return false; }
+   virtual bool InitDrm();
+@@ -63,13 +62,6 @@ public:
+   static uint32_t FourCCWithAlpha(uint32_t fourcc);
+   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
+ 
+-  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
+-  int TakeOutFenceFd()
+-  {
+-    int fd{-1};
+-    return std::exchange(m_outFenceFd, fd);
+-  }
+-
+ protected:
+   bool OpenDrm(bool needConnector);
+   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
+@@ -86,9 +78,6 @@ protected:
+   int m_width = 0;
+   int m_height = 0;
+ 
+-  int m_inFenceFd{-1};
+-  int m_outFenceFd{-1};
+-
+   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
+ 
+ private:
+diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+index bba0db9a53dd..4270d4ecb242 100644
+--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
++++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
+ public:
+   COffScreenModeSetting() = default;
+   ~COffScreenModeSetting() override = default;
+-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
++  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
+   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
+   bool SetActive(bool active) override { return false; }
+   bool InitDrm() override;
+-- 
+2.39.5
+
+
+From 543af77563f706cd70a5c2975f5fe217bf24024a Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 31 Dec 2024 13:07:46 +0100
+Subject: [PATCH 4/4] Revert "CEGLFence: add support for using
+ EGL_KHR_fence_sync and EGL_ANDROID_native_fence_sync"
+
+This reverts commit ba17e5b45c5bd36ef65089f35049da82a290bb01.
+---
+ xbmc/utils/EGLFence.cpp | 70 -----------------------------------------
+ xbmc/utils/EGLFence.h   | 19 -----------
+ 2 files changed, 89 deletions(-)
+
+diff --git a/xbmc/utils/EGLFence.cpp b/xbmc/utils/EGLFence.cpp
+index 9d0065bdaf07..535e3bce3197 100644
 --- a/xbmc/utils/EGLFence.cpp
 +++ b/xbmc/utils/EGLFence.cpp
 @@ -22,14 +22,6 @@ CEGLFence::CEGLFence(EGLDisplay display)
@@ -84,7 +530,7 @@ index 9d0065bdaf..535e3bce31 100644
 -}
 -#endif
 diff --git a/xbmc/utils/EGLFence.h b/xbmc/utils/EGLFence.h
-index 03c246b60b..bd96444e47 100644
+index 03c246b60b67..bd96444e47e5 100644
 --- a/xbmc/utils/EGLFence.h
 +++ b/xbmc/utils/EGLFence.h
 @@ -30,14 +30,6 @@ public:
@@ -120,337 +566,6 @@ index 03c246b60b..bd96444e47 100644
  };
  
  }
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
-index f334156d89..34c8c16fe4 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
-@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
-   SetFullScreen(true, resMutable, false);
- }
- 
--void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-+void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
- {
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
-     bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
-   }
- 
--  m_DRM->FlipPage(bo, rendered, videoLayer, async);
-+  m_DRM->FlipPage(bo, rendered, videoLayer);
- 
-   if (m_videoLayerBridge && !videoLayer)
-   {
-@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
- bool CWinSystemGbm::Hide()
- {
-   bool ret = m_DRM->SetActive(false);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
- bool CWinSystemGbm::Show(bool raise)
- {
-   bool ret = m_DRM->SetActive(true);
--  FlipPage(false, false, false);
-+  FlipPage(false, false);
-   return ret;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
-index 879d0f58f8..a800acef6b 100644
---- a/xbmc/windowing/gbm/WinSystemGbm.h
-+++ b/xbmc/windowing/gbm/WinSystemGbm.h
-@@ -49,7 +49,7 @@ public:
-   bool DisplayHardwareScalingEnabled() override;
-   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
- 
--  void FlipPage(bool rendered, bool videoLayer, bool async);
-+  void FlipPage(bool rendered, bool videoLayer);
- 
-   bool CanDoWindowed() override { return false; }
-   void UpdateResolutions() override;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-index ee27fba1bd..83a59413f7 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
-@@ -58,17 +58,6 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
-     return false;
-   }
- 
--  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
--      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
--  {
--    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
--  }
--  else
--  {
--    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
--                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
--  }
--
-   return true;
- }
- 
-diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-index fbd52354ee..84f863d6d3 100644
---- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
-@@ -9,7 +9,6 @@
- #pragma once
- 
- #include "WinSystemGbm.h"
--#include "utils/EGLFence.h"
- #include "utils/EGLUtils.h"
- #include "windowing/linux/WinSystemEGL.h"
- 
-@@ -47,8 +46,6 @@ protected:
-   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
-   virtual bool CreateContext() = 0;
- 
--  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
--
-   struct delete_CVaapiProxy
-   {
-     void operator()(CVaapiProxy *p) const;
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-index adbb539f21..e4ff49c618 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-@@ -119,37 +119,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-index ad80abf46c..0d071c31f1 100644
---- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
-@@ -128,38 +128,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
-   {
-     if (rendered)
-     {
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_DRM->TakeOutFenceFd();
--        if (fd != -1)
--        {
--          m_eglFence->CreateKMSFence(fd);
--          m_eglFence->WaitSyncGPU();
--        }
--
--        m_eglFence->CreateGPUFence();
--      }
--#endif
--
-       if (!m_eglContext.TrySwapBuffers())
-       {
-         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-         throw std::runtime_error("eglSwapBuffers failed");
-       }
--
--#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
--      if (m_eglFence)
--      {
--        int fd = m_eglFence->FlushFence();
--        m_DRM->SetInFenceFd(fd);
--
--        m_eglFence->WaitSyncCPU();
--      }
--#endif
-     }
--
--    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
-+    CWinSystemGbm::FlipPage(rendered, videoLayer);
- 
-     if (m_dispReset && m_dispResetTimer.IsTimePast())
-     {
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-index ff7f137d60..029b5cae81 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
-@@ -111,11 +111,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-       AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
-     }
- 
--    if (m_inFenceFd != -1)
--    {
--      AddProperty(m_crtc, "OUT_FENCE_PTR", reinterpret_cast<uint64_t>(&m_outFenceFd));
--      AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
--    }
-   }
-   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
-   {
-@@ -151,12 +146,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-               strerror(errno));
-   }
- 
--  if (m_inFenceFd != -1)
--  {
--    close(m_inFenceFd);
--    m_inFenceFd = -1;
--  }
--
-   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
-   {
-     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
-@@ -171,10 +160,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
-   m_req = m_atomicRequestQueue.back().get();
- }
- 
--void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   struct drm_fb *drm_fb = nullptr;
--  uint32_t flags = 0;
- 
-   if (rendered)
-   {
-@@ -189,11 +177,10 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
-       CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
-       return;
-     }
--
--    if (async && !m_need_modeset)
--      flags |= DRM_MODE_ATOMIC_NONBLOCK;
-   }
- 
-+  uint32_t flags = 0;
-+
-   if (m_need_modeset)
-   {
-     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.h b/xbmc/windowing/gbm/drm/DRMAtomic.h
-index 6b19657587..ca2cd9a1d0 100644
---- a/xbmc/windowing/gbm/drm/DRMAtomic.h
-+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
-@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
- public:
-   CDRMAtomic() = default;
-   ~CDRMAtomic() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.cpp b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-index 4e9c3a6b9f..418d067e70 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
-@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
-   return true;
- }
- 
--void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
-+void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
- {
-   if (rendered || videoLayer)
-   {
-diff --git a/xbmc/windowing/gbm/drm/DRMLegacy.h b/xbmc/windowing/gbm/drm/DRMLegacy.h
-index e763f298f7..2b7ff45617 100644
---- a/xbmc/windowing/gbm/drm/DRMLegacy.h
-+++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
-@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
- public:
-   CDRMLegacy() = default;
-   ~CDRMLegacy() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
-+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
-   bool SetActive(bool active) override;
-   bool InitDrm() override;
-diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
-index f92f716fc4..5327e35570 100644
---- a/xbmc/windowing/gbm/drm/DRMUtils.h
-+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
-@@ -15,7 +15,6 @@
- #include "windowing/Resolution.h"
- #include "windowing/gbm/GBMUtils.h"
- 
--#include <utility>
- #include <vector>
- 
- #include <gbm.h>
-@@ -40,7 +39,7 @@ class CDRMUtils
- public:
-   CDRMUtils() = default;
-   virtual ~CDRMUtils();
--  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
-+  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
-   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
-   virtual bool SetActive(bool active) { return false; }
-   virtual bool InitDrm();
-@@ -63,13 +62,6 @@ public:
-   static uint32_t FourCCWithAlpha(uint32_t fourcc);
-   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
- 
--  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
--  int TakeOutFenceFd()
--  {
--    int fd{-1};
--    return std::exchange(m_outFenceFd, fd);
--  }
--
- protected:
-   bool OpenDrm(bool needConnector);
-   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
-@@ -86,9 +78,6 @@ protected:
-   int m_width = 0;
-   int m_height = 0;
- 
--  int m_inFenceFd{-1};
--  int m_outFenceFd{-1};
--
-   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
- 
- private:
-diff --git a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-index bba0db9a53..4270d4ecb2 100644
---- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
-@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
- public:
-   COffScreenModeSetting() = default;
-   ~COffScreenModeSetting() override = default;
--  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
-+  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
-   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
-   bool SetActive(bool active) override { return false; }
-   bool InitDrm() override;
+-- 
+2.39.5
+


### PR DESCRIPTION
Runtime tested on RPi5.

The fences-revert patch now also reverts the async rendering fixes backport PR, like we do in LE master - see https://github.com/LibreELEC/LibreELEC.tv/pull/9436#issuecomment-2438028362 and https://github.com/xbmc/xbmc/pull/25588#issuecomment-2381332226