### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="21.1.18-Omega"
-PKG_SHA256="226366b69536579d1adccb8548ba20c1b094876ce481bab81f744affa71bb305"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="4af955aba316164168d5fa1b2b3c175e77762741e3d1251a2172d96648e43a8c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/peripheral.joystick"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.xarcade"
-PKG_VERSION="22.0.0-Piers"
-PKG_SHA256="2006fb1e908dd8b45ef75226c37458b4e249f705ce40deedb7691b3101c3594b"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="c88574779fdce588adf509b5f543b12bdc25e7b023c9d7dc6169cd2473b2f25e"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/peripheral.xarcade"


### PR DESCRIPTION
- peripheral.joystick: update 21.1.18-Omega to 22.0.1-Piers
- peripheral.xarcade: update 22.0.0-Piers to 22.0.1-Piers