### PR TITLE
samba: update to 4.21.3

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.21.2"
-PKG_SHA256="bde66be3d2025cb949de38518ad2652f3795f824c7fa89d4e443ede1ae828ea6"
+PKG_VERSION="4.21.3"
+PKG_SHA256="ae2179a613e7a5d4088735ab100d4ca1cae0f92374d6307e22eaec13ad90125c"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.21.3.html