### PR TITLE
u-boot: update Allwinner patches for 2025.01

### DIFF
--- a/projects/Allwinner/devices/H2-plus/patches/u-boot/0001-DO-NOT-MERGE-sunxi-psci-Delegate-PSCI-to-SCPI.patch
+++ b/projects/Allwinner/devices/H2-plus/patches/u-boot/0001-DO-NOT-MERGE-sunxi-psci-Delegate-PSCI-to-SCPI.patch
@@ -1,7 +1,7 @@
-From 470309271de34eb8c24138f1ac15bd37966ed01a Mon Sep 17 00:00:00 2001
+From 03db81bb312e8a9503f52779da4b2007bc08954a Mon Sep 17 00:00:00 2001
 From: Samuel Holland <samuel@sholland.org>
 Date: Sat, 9 Oct 2021 23:01:05 -0500
-Subject: [PATCH 13/13] [DO NOT MERGE] sunxi: psci: Delegate PSCI to SCPI
+Subject: [PATCH 12/13] [DO NOT MERGE] sunxi: psci: Delegate PSCI to SCPI
 
 This adds a new PSCI implementation which communicates with SCP firmware
 running on the AR100 using the SCPI protocol. This allows it to support
@@ -10,44 +10,47 @@ suspend, and multiple reset methods.
 
 Signed-off-by: Samuel Holland <samuel@sholland.org>
 ---
- arch/arm/cpu/armv7/Kconfig           |   2 +-
- arch/arm/cpu/armv7/sunxi/Makefile    |   2 +-
- arch/arm/cpu/armv7/sunxi/psci-scpi.c | 451 +++++++++++++++++++++++++++
- 3 files changed, 453 insertions(+), 2 deletions(-)
+ arch/arm/cpu/armv7/Kconfig           |   1 +
+ arch/arm/cpu/armv7/sunxi/Makefile    |   4 +
+ arch/arm/cpu/armv7/sunxi/psci-scpi.c | 453 +++++++++++++++++++++++++++
+ 3 files changed, 468 insertions(+)
  create mode 100644 arch/arm/cpu/armv7/sunxi/psci-scpi.c
 
 diff --git a/arch/arm/cpu/armv7/Kconfig b/arch/arm/cpu/armv7/Kconfig
-index 06b477619334..948f4e8276fe 100644
+index ec3d31e750..9dccc12253 100644
 --- a/arch/arm/cpu/armv7/Kconfig
 +++ b/arch/arm/cpu/armv7/Kconfig
-@@ -44,7 +44,7 @@ config ARMV7_PSCI
+@@ -86,6 +86,7 @@ config ARMV7_PSCI
  choice
  	prompt "Supported PSCI version"
  	depends on ARMV7_PSCI
--	default ARMV7_PSCI_0_1 if ARCH_SUNXI
-+	default ARMV7_PSCI_1_1 if ARCH_SUNXI
++	default ARMV7_PSCI_1_1 if MACH_SUN8I_H3
+ 	default ARMV7_PSCI_0_1 if ARCH_SUNXI
  	default ARMV7_PSCI_1_0
  	help
- 	  Select the supported PSCI version.
 diff --git a/arch/arm/cpu/armv7/sunxi/Makefile b/arch/arm/cpu/armv7/sunxi/Makefile
-index 1d40d6a18dca..4a0c16deb459 100644
+index 3e975b366c..6473b9acbd 100644
 --- a/arch/arm/cpu/armv7/sunxi/Makefile
 +++ b/arch/arm/cpu/armv7/sunxi/Makefile
-@@ -11,7 +11,7 @@ obj-$(CONFIG_MACH_SUN6I)	+= tzpc.o
- obj-$(CONFIG_MACH_SUN8I_H3)	+= tzpc.o
+@@ -13,8 +13,12 @@ obj-$(CONFIG_MACH_SUN6I)	+= sram.o
+ obj-$(CONFIG_MACH_SUN8I)	+= sram.o
  
- ifndef CONFIG_SPL_BUILD
--obj-$(CONFIG_ARMV7_PSCI)	+= psci.o
+ ifndef CONFIG_XPL_BUILD
++ifdef CONFIG_MACH_SUN8I_H3
 +obj-$(CONFIG_ARMV7_PSCI)	+= psci-scpi.o
++else
+ obj-$(CONFIG_ARMV7_PSCI)	+= psci.o
  endif
++endif
  
- ifdef CONFIG_SPL_BUILD
+ ifdef CONFIG_XPL_BUILD
+ obj-y	+= fel_utils.o
 diff --git a/arch/arm/cpu/armv7/sunxi/psci-scpi.c b/arch/arm/cpu/armv7/sunxi/psci-scpi.c
 new file mode 100644
-index 000000000000..b3849b366e31
+index 0000000000..fea51eb456
 --- /dev/null
 +++ b/arch/arm/cpu/armv7/sunxi/psci-scpi.c
-@@ -0,0 +1,450 @@
+@@ -0,0 +1,453 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2016 Chen-Yu Tsai <wens@csie.org>
@@ -55,7 +58,6 @@ index 000000000000..b3849b366e31
 + */
 +
 +#include <asm/arch/cpu.h>
-+#include <asm/arch/cpucfg.h>
 +#include <asm/armv7.h>
 +#include <asm/gic.h>
 +#include <asm/io.h>
@@ -65,6 +67,19 @@ index 000000000000..b3849b366e31
 +
 +#define	GICD_BASE		(SUNXI_GIC400_BASE + GIC_DIST_OFFSET)
 +#define	GICC_BASE		(SUNXI_GIC400_BASE + GIC_CPU_OFFSET_A15)
++
++/*
++ * Offsets into the CPUCFG block applicable to most SUNXIs.
++ */
++#define SUNXI_CPU_RST(cpu)			(0x40 + (cpu) * 0x40 + 0x0)
++#define SUNXI_CPU_STATUS(cpu)			(0x40 + (cpu) * 0x40 + 0x8)
++#define SUNXI_GEN_CTRL				(0x184)
++#define SUNXI_SUPER_STANDY_FLAG			(0x1a0)
++#define SUNXI_PRIV0				(0x1a4)
++#define SUNXI_PRIV1				(0x1a8)
++#define SUN7I_CPU1_PWR_CLAMP			(0x1b0)
++#define SUN7I_CPU1_PWROFF			(0x1b4)
++#define SUNXI_DBG_CTRL1				(0x1e4)
 +
 +#define HW_ON			0
 +#define HW_OFF			1
@@ -156,15 +171,6 @@ index 000000000000..b3849b366e31
 +static bool __secure_data gic_dist_init;
 +
 +static u32 __secure_data lock;
-+
-+static inline u32 __secure read_mpidr(void)
-+{
-+	u32 val;
-+
-+	asm volatile ("mrc p15, 0, %0, c0, c0, 5" : "=r" (val));
-+
-+	return val;
-+}
 +
 +static void __secure scpi_begin_command(void)
 +{
@@ -445,14 +451,14 @@ index 000000000000..b3849b366e31
 +	struct sunxi_cpucfg_reg *cpucfg =
 +		(struct sunxi_cpucfg_reg *)SUNXI_CPUCFG_BASE;
 +
-+	writel((u32)entry, &cpucfg->priv0);
++	writel((u32)entry, SUNXI_CPUCFG_BASE + SUNXI_PRIV0);
 +
-+	if (IS_ENABLED(CONFIG_MACH_SUN8I_H3)) {
-+		/* Redirect CPU 0 to the secure monitor via the resume shim. */
-+		writel(0x16aaefe8, &cpucfg->super_standy_flag);
-+		writel(0xaa16efe8, &cpucfg->super_standy_flag);
-+		writel(SUNXI_RESUME_BASE, &cpucfg->priv1);
-+	}
++#ifdef CONFIG_MACH_SUN8I_H3
++	/* Redirect CPU 0 to the secure monitor via the resume shim. */
++	writel(0x16aaefe8, SUNXI_CPUCFG_BASE + SUNXI_SUPER_STANDY_FLAG);
++	writel(0xaa16efe8, SUNXI_CPUCFG_BASE + SUNXI_SUPER_STANDY_FLAG);
++	writel(CONFIG_SUNXI_RESUME_BASE, SUNXI_CPUCFG_BASE + SUNXI_PRIV1);
++#endif
 +}
 +#endif
 +
@@ -499,5 +505,5 @@ index 000000000000..b3849b366e31
 +	writel(0xff, GICC_BASE + GICC_PMR);
 +}
 -- 
-2.33.0
+2.34.1
 

--- a/projects/Allwinner/devices/H2-plus/patches/u-boot/0007-sunxi-psci-Add-support-for-H3-CPU-0-hotplug.patch
+++ b/projects/Allwinner/devices/H2-plus/patches/u-boot/0007-sunxi-psci-Add-support-for-H3-CPU-0-hotplug.patch
@@ -1,7 +1,7 @@
-From f15f4f36e023aaaeacdbebe16736119d1be3ac6b Mon Sep 17 00:00:00 2001
+From e814c64fcbd08fb588b7e52b7e968ed9feb2d747 Mon Sep 17 00:00:00 2001
 From: Samuel Holland <samuel@sholland.org>
 Date: Sat, 9 Oct 2021 17:12:57 -0500
-Subject: [PATCH 07/13] sunxi: psci: Add support for H3 CPU 0 hotplug
+Subject: [PATCH 06/13] sunxi: psci: Add support for H3 CPU 0 hotplug
 
 Due to a bug in the H3 SoC, where the CPU 0 hotplug flag cannot be
 written, resuming CPU 0 requires using the "Super Standby" code path in
@@ -21,17 +21,17 @@ PLL_PERIPH0 must be bypassed to prevent AHB1 from temporarily running at
 Signed-off-by: Samuel Holland <samuel@sholland.org>
 ---
  Makefile                        | 17 +++++++++++++++++
- arch/arm/cpu/armv7/sunxi/psci.c | 31 +++++++++++++++++++++++++++++++
- arch/arm/dts/sunxi-u-boot.dtsi  | 23 ++++++++++++++++++++++-
- include/configs/sun8i.h         |  4 ++++
- 4 files changed, 74 insertions(+), 1 deletion(-)
+ arch/arm/cpu/armv7/sunxi/psci.c | 32 ++++++++++++++++++++++++++++++++
+ arch/arm/dts/sunxi-u-boot.dtsi  | 23 ++++++++++++++++++++---
+ arch/arm/mach-sunxi/Kconfig     |  7 +++++++
+ 4 files changed, 76 insertions(+), 3 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index f911f7034430..9edcadfa9c47 100644
+index 8a04dfcf36..670c87c2ff 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -984,6 +984,23 @@ endif
- endif
+@@ -1024,6 +1024,23 @@ ifeq ($(CONFIG_ARCH_ROCKCHIP)_$(CONFIG_SPL_FRAMEWORK),y_)
+ INPUTS-y += u-boot.img
  endif
  
 +ifeq ($(CONFIG_MACH_SUN8I_H3)$(CONFIG_ARMV7_PSCI),yy)
@@ -55,7 +55,7 @@ index f911f7034430..9edcadfa9c47 100644
  	$(if $(CONFIG_SPL_X86_16BIT_INIT),spl/u-boot-spl.bin) \
  	$(if $(CONFIG_TPL_X86_16BIT_INIT),tpl/u-boot-tpl.bin)
 diff --git a/arch/arm/cpu/armv7/sunxi/psci.c b/arch/arm/cpu/armv7/sunxi/psci.c
-index 3448fe2edcaa..299bd3ba65e0 100644
+index 098e2b12bf..d76266d9c2 100644
 --- a/arch/arm/cpu/armv7/sunxi/psci.c
 +++ b/arch/arm/cpu/armv7/sunxi/psci.c
 @@ -10,6 +10,7 @@
@@ -64,38 +64,45 @@ index 3448fe2edcaa..299bd3ba65e0 100644
  
 +#include <asm/arch/clock.h>
  #include <asm/arch/cpu.h>
- #include <asm/arch/cpucfg.h>
- #include <asm/arch/prcm.h>
-@@ -141,6 +142,13 @@ static void __secure sunxi_set_entry_address(void *entry)
- 		(struct sunxi_cpucfg_reg *)SUNXI_CPUCFG_BASE;
- 
- 	writel((u32)entry, &cpucfg->priv0);
+ #include <asm/armv7.h>
+ #include <asm/gic.h>
+@@ -31,7 +32,9 @@
+ #define SUNXI_CPU_RST(cpu)			(0x40 + (cpu) * 0x40 + 0x0)
+ #define SUNXI_CPU_STATUS(cpu)			(0x40 + (cpu) * 0x40 + 0x8)
+ #define SUNXI_GEN_CTRL				(0x184)
++#define SUNXI_SUPER_STANDBY_FLAG		(0x1a0)
+ #define SUNXI_PRIV0				(0x1a4)
++#define SUNXI_PRIV1				(0x1a8)
+ #define SUN7I_CPU1_PWR_CLAMP			(0x1b0)
+ #define SUN7I_CPU1_PWROFF			(0x1b4)
+ #define SUNXI_DBG_CTRL1				(0x1e4)
+@@ -139,6 +142,13 @@ static void __secure sunxi_cpu_set_entry(int __always_unused cpu, void *entry)
+ 	} else {
+ 		writel((u32)entry, SUNXI_CPUCFG_BASE + SUNXI_PRIV0);
+ 	}
 +
-+	if (IS_ENABLED(CONFIG_MACH_SUN8I_H3)) {
++	if (CONFIG_SUNXI_RESUME_BASE) {
 +		/* Redirect CPU 0 to the secure monitor via the resume shim. */
-+		writel(0x16aaefe8, &cpucfg->super_standy_flag);
-+		writel(0xaa16efe8, &cpucfg->super_standy_flag);
-+		writel(SUNXI_RESUME_BASE, &cpucfg->priv1);
++		writel(0x16aaefe8, SUNXI_R_CPUCFG_BASE + SUNXI_SUPER_STANDBY_FLAG);
++		writel(0xaa16efe8, SUNXI_R_CPUCFG_BASE + SUNXI_SUPER_STANDBY_FLAG);
++		writel(CONFIG_SUNXI_RESUME_BASE, SUNXI_R_CPUCFG_BASE + SUNXI_PRIV1);
 +	}
  }
- #endif
  
-@@ -255,9 +263,12 @@ out:
+ static void __secure sunxi_cpu_set_power(int cpu, bool on)
+@@ -307,7 +317,9 @@ out:
  int __secure psci_cpu_on(u32 __always_unused unused, u32 mpidr, u32 pc,
  			 u32 context_id)
  {
 +	struct sunxi_ccm_reg *ccu = (struct sunxi_ccm_reg *)SUNXI_CCM_BASE;
- 	struct sunxi_cpucfg_reg *cpucfg =
- 		(struct sunxi_cpucfg_reg *)SUNXI_CPUCFG_BASE;
  	u32 cpu = (mpidr & 0x3);
-+	u32 cpu_clk;
-+	u32 bus_clk;
++	u32 bus_clk, cpu_clk;
  
  	/* store target PC and context id */
  	psci_save(cpu, pc, context_id);
-@@ -274,12 +285,32 @@ int __secure psci_cpu_on(u32 __always_unused unused, u32 mpidr, u32 pc,
+@@ -324,12 +336,32 @@ int __secure psci_cpu_on(u32 __always_unused unused, u32 mpidr, u32 pc,
  	/* Lock CPU (Disable external debug access) */
- 	clrbits_le32(&cpucfg->dbg_ctrl1, BIT(cpu));
+ 	sunxi_cpu_set_locking(cpu, true);
  
 +	if (IS_ENABLED(CONFIG_MACH_SUN8I_H3) && cpu == 0) {
 +		/* Save registers that will be clobbered by the BROM. */
@@ -110,7 +117,7 @@ index 3448fe2edcaa..299bd3ba65e0 100644
  	sunxi_cpu_set_power(cpu, true);
  
  	/* De-assert reset on target CPU */
- 	writel(BIT(1) | BIT(0), &cpucfg->cpu[cpu].rst);
+ 	sunxi_cpu_set_reset(cpu, false);
  
 +	if (IS_ENABLED(CONFIG_MACH_SUN8I_H3) && cpu == 0) {
 +		/* Spin until the BROM has clobbered the clock registers. */
@@ -123,37 +130,24 @@ index 3448fe2edcaa..299bd3ba65e0 100644
 +		clrbits_le32(&ccu->pll6_cfg, BIT(25));
 +	}
 +
- 	/* Unlock CPU (Disable external debug access) */
- 	setbits_le32(&cpucfg->dbg_ctrl1, BIT(cpu));
+ 	/* Unlock CPU (Reenable external debug access) */
+ 	sunxi_cpu_set_locking(cpu, false);
  
 diff --git a/arch/arm/dts/sunxi-u-boot.dtsi b/arch/arm/dts/sunxi-u-boot.dtsi
-index ad1f97632979..a2c74da81aa9 100644
+index ed1cb91eeb..8c6d36d4ac 100644
 --- a/arch/arm/dts/sunxi-u-boot.dtsi
 +++ b/arch/arm/dts/sunxi-u-boot.dtsi
-@@ -6,7 +6,11 @@
- #define ARCH "arm"
- #endif
- 
--#if defined(CONFIG_MACH_SUN50I) || defined(CONFIG_MACH_SUN50I_H5)
-+#if defined(CONFIG_MACH_SUN8I_H3)
-+#ifdef CONFIG_ARMV7_PSCI
-+#define RESUME_ADDR	SUNXI_RESUME_BASE
-+#endif
-+#elif defined(CONFIG_MACH_SUN50I) || defined(CONFIG_MACH_SUN50I_H5)
- #define BL31_ADDR	0x00044000
- #define SCP_ADDR	0x00050000
- #elif defined(CONFIG_MACH_SUN50I_H6)
-@@ -74,6 +78,20 @@
+@@ -77,6 +77,20 @@
  				};
  #endif
  
-+#ifdef RESUME_ADDR
++#if CONFIG_SUNXI_RESUME_BASE
 +				resume {
 +					description = "Super Standby resume image";
 +					type = "standalone";
 +					arch = ARCH;
 +					compression = "none";
-+					load = <RESUME_ADDR>;
++					load = <CONFIG_SUNXI_RESUME_BASE>;
 +
 +					blob-ext {
 +						filename = "u-boot-resume.img";
@@ -161,36 +155,46 @@ index ad1f97632979..a2c74da81aa9 100644
 +				};
 +#endif
 +
- #ifdef SCP_ADDR
+ #if CONFIG_SUNXI_SCP_BASE
  				scp {
  					description = "SCP firmware";
-@@ -107,6 +125,9 @@
+@@ -108,12 +122,15 @@
+ 					firmware = "atf";
+ #else
  					firmware = "uboot";
- #endif
- 					loadables =
-+#ifdef RESUME_ADDR
++#endif
++					loadables =
++#if CONFIG_SUNXI_RESUME_BASE
 +						    "resume",
-+#endif
- #ifdef SCP_ADDR
- 						    "scp",
  #endif
-diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
-index 563635636624..2f0d69bdfce2 100644
---- a/include/configs/sunxi-common.h
-+++ b/include/configs/sunxi-common.h
-@@ -15,6 +15,12 @@
- #include <asm/arch/cpu.h>
- #include <linux/stringify.h>
+ #if CONFIG_SUNXI_SCP_BASE
+-					loadables = "scp", "uboot";
+-#else
+-					loadables = "uboot";
++						    "scp",
+ #endif
++						    "uboot";
+ 					fdt = "fdt-SEQ";
+ 				};
+ 			};
+diff --git a/arch/arm/mach-sunxi/Kconfig b/arch/arm/mach-sunxi/Kconfig
+index b0fbda0aa0..48e750d070 100644
+--- a/arch/arm/mach-sunxi/Kconfig
++++ b/arch/arm/mach-sunxi/Kconfig
+@@ -164,6 +164,13 @@ config SUNXI_BL31_BASE
+ 	help
+ 	  Address where BL31 (TF-A) is loaded, or zero if BL31 is not used.
  
-+#ifdef SUNXI_SRAM_A2_SIZE
-+#define SUNXI_RESUME_BASE		(CONFIG_ARMV7_SECURE_BASE + \
-+					 CONFIG_ARMV7_SECURE_MAX_SIZE)
-+#define SUNXI_RESUME_SIZE		1024
-+#endif
++config SUNXI_RESUME_BASE
++	hex
++	default 0x00047c00 if MACH_SUN8I_H3
++	default 0x0
++	help
++	  Address where the resume shim is loaded, or zero if it is not used.
 +
- /* Serial & console */
- #define CONFIG_SYS_NS16550_SERIAL
- /* ns16550 reg in the low bits of cpu reg */
+ config SUNXI_SCP_BASE
+ 	hex
+ 	default 0x00050000 if MACH_SUN50I || MACH_SUN50I_H5
 -- 
-2.33.0
+2.34.1
 

--- a/projects/Allwinner/devices/H2-plus/patches/u-boot/0010-sunxi-Enable-support-for-SCP-firmware-on-H3.patch
+++ b/projects/Allwinner/devices/H2-plus/patches/u-boot/0010-sunxi-Enable-support-for-SCP-firmware-on-H3.patch
@@ -1,7 +1,7 @@
-From 92657de6d2ac3ae100a4d78cc37c729142f1a59b Mon Sep 17 00:00:00 2001
+From 2f330ad98dfb70c245b285d4d2d2a1fe5029fda8 Mon Sep 17 00:00:00 2001
 From: Samuel Holland <samuel@sholland.org>
 Date: Sat, 17 Apr 2021 13:33:54 -0500
-Subject: [PATCH 10/13] sunxi: Enable support for SCP firmware on H3
+Subject: [PATCH 09/13] sunxi: Enable support for SCP firmware on H3
 
 Now that issues with the BROM have been sorted out, we can implement
 PSCI system suspend on H3 by delegating to SCP firmware. Let's start by
@@ -10,28 +10,27 @@ valid firmware is loaded.
 
 Signed-off-by: Samuel Holland <samuel@sholland.org>
 ---
- arch/arm/dts/sunxi-u-boot.dtsi | 1 +
- board/sunxi/board.c            | 8 ++++++++
- include/configs/sun8i.h        | 3 +++
- 3 files changed, 12 insertions(+)
+ arch/arm/mach-sunxi/Kconfig | 1 +
+ board/sunxi/board.c         | 8 ++++++++
+ 2 files changed, 9 insertions(+)
 
-diff --git a/arch/arm/dts/sunxi-u-boot.dtsi b/arch/arm/dts/sunxi-u-boot.dtsi
-index a2c74da81aa9..ce062fe94052 100644
---- a/arch/arm/dts/sunxi-u-boot.dtsi
-+++ b/arch/arm/dts/sunxi-u-boot.dtsi
-@@ -9,6 +9,7 @@
- #if defined(CONFIG_MACH_SUN8I_H3)
- #ifdef CONFIG_ARMV7_PSCI
- #define RESUME_ADDR	SUNXI_RESUME_BASE
-+#define SCP_ADDR	SUNXI_SCP_BASE
- #endif
- #elif defined(CONFIG_MACH_SUN50I) || defined(CONFIG_MACH_SUN50I_H5)
- #define BL31_ADDR	0x00044000
+diff --git a/arch/arm/mach-sunxi/Kconfig b/arch/arm/mach-sunxi/Kconfig
+index 48e750d070..a6d5de9e3b 100644
+--- a/arch/arm/mach-sunxi/Kconfig
++++ b/arch/arm/mach-sunxi/Kconfig
+@@ -173,6 +173,7 @@ config SUNXI_RESUME_BASE
+ 
+ config SUNXI_SCP_BASE
+ 	hex
++	default 0x00048000 if MACH_SUN8I_H3
+ 	default 0x00050000 if MACH_SUN50I || MACH_SUN50I_H5
+ 	default 0x00114000 if MACH_SUN50I_H6
+ 	default 0x0
 diff --git a/board/sunxi/board.c b/board/sunxi/board.c
-index 2b7d655678d0..a25cd11f1124 100644
+index 39ecbe988f..b83d21ef08 100644
 --- a/board/sunxi/board.c
 +++ b/board/sunxi/board.c
-@@ -18,6 +18,7 @@
+@@ -19,6 +19,7 @@
  #include <init.h>
  #include <log.h>
  #include <mmc.h>
@@ -39,12 +38,12 @@ index 2b7d655678d0..a25cd11f1124 100644
  #include <axp_pmic.h>
  #include <generic-phy.h>
  #include <phy-sun4i-usb.h>
-@@ -957,6 +958,13 @@ int board_late_init(void)
+@@ -851,6 +852,13 @@ int board_late_init(void)
  	usb_ether_init();
  #endif
  
-+#ifdef SUNXI_SCP_BASE
-+	if (!rproc_load(0, SUNXI_SCP_BASE, SUNXI_SCP_MAX_SIZE)) {
++#ifdef CONFIG_REMOTEPROC_SUN6I_AR100
++	if (!rproc_load(0, CONFIG_SUNXI_SCP_BASE, 1)) {
 +		puts("Starting SCP...\n");
 +		rproc_start(0);
 +	}
@@ -53,20 +52,6 @@ index 2b7d655678d0..a25cd11f1124 100644
  	return 0;
  }
  
-diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
-index 2f0d69bdfce2..fda5b235a3e0 100644
---- a/include/configs/sunxi-common.h
-+++ b/include/configs/sunxi-common.h
-@@ -26,6 +26,9 @@
- #define SUNXI_RESUME_BASE		(CONFIG_ARMV7_SECURE_BASE + \
- 					 CONFIG_ARMV7_SECURE_MAX_SIZE)
- #define SUNXI_RESUME_SIZE		1024
-+
-+#define SUNXI_SCP_BASE			(SUNXI_RESUME_BASE + SUNXI_RESUME_SIZE)
-+#define SUNXI_SCP_MAX_SIZE		(16 * 1024)
- #endif
- 
- /*
 -- 
-2.33.0
+2.34.1
 

--- a/projects/Allwinner/devices/H3/patches/u-boot/0012-DO-NOT-MERGE-sunxi-psci-Delegate-PSCI-to-SCPI.patch
+++ b/projects/Allwinner/devices/H3/patches/u-boot/0012-DO-NOT-MERGE-sunxi-psci-Delegate-PSCI-to-SCPI.patch
@@ -12,7 +12,7 @@ Signed-off-by: Samuel Holland <samuel@sholland.org>
 ---
  arch/arm/cpu/armv7/Kconfig           |   1 +
  arch/arm/cpu/armv7/sunxi/Makefile    |   4 +
- arch/arm/cpu/armv7/sunxi/psci-scpi.c | 463 +++++++++++++++++++++++++++
+ arch/arm/cpu/armv7/sunxi/psci-scpi.c | 453 +++++++++++++++++++++++++++
  3 files changed, 468 insertions(+)
  create mode 100644 arch/arm/cpu/armv7/sunxi/psci-scpi.c
 
@@ -35,7 +35,7 @@ index 3e975b366c..6473b9acbd 100644
 @@ -13,8 +13,12 @@ obj-$(CONFIG_MACH_SUN6I)	+= sram.o
  obj-$(CONFIG_MACH_SUN8I)	+= sram.o
  
- ifndef CONFIG_SPL_BUILD
+ ifndef CONFIG_XPL_BUILD
 +ifdef CONFIG_MACH_SUN8I_H3
 +obj-$(CONFIG_ARMV7_PSCI)	+= psci-scpi.o
 +else
@@ -43,14 +43,14 @@ index 3e975b366c..6473b9acbd 100644
  endif
 +endif
  
- ifdef CONFIG_SPL_BUILD
+ ifdef CONFIG_XPL_BUILD
  obj-y	+= fel_utils.o
 diff --git a/arch/arm/cpu/armv7/sunxi/psci-scpi.c b/arch/arm/cpu/armv7/sunxi/psci-scpi.c
 new file mode 100644
 index 0000000000..fea51eb456
 --- /dev/null
 +++ b/arch/arm/cpu/armv7/sunxi/psci-scpi.c
-@@ -0,0 +1,462 @@
+@@ -0,0 +1,453 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2016 Chen-Yu Tsai <wens@csie.org>
@@ -171,15 +171,6 @@ index 0000000000..fea51eb456
 +static bool __secure_data gic_dist_init;
 +
 +static u32 __secure_data lock;
-+
-+static inline u32 __secure read_mpidr(void)
-+{
-+	u32 val;
-+
-+	asm volatile ("mrc p15, 0, %0, c0, c0, 5" : "=r" (val));
-+
-+	return val;
-+}
 +
 +static void __secure scpi_begin_command(void)
 +{

--- a/projects/Allwinner/devices/H3/patches/u-boot/0013-DO-NOT-MERGE-sunxi-Enable-SCP-SCPI-on-A33-as-well.patch
+++ b/projects/Allwinner/devices/H3/patches/u-boot/0013-DO-NOT-MERGE-sunxi-Enable-SCP-SCPI-on-A33-as-well.patch
@@ -32,7 +32,7 @@ index 6473b9acbd..033042666f 100644
 @@ -13,7 +13,7 @@ obj-$(CONFIG_MACH_SUN6I)	+= sram.o
  obj-$(CONFIG_MACH_SUN8I)	+= sram.o
  
- ifndef CONFIG_SPL_BUILD
+ ifndef CONFIG_XPL_BUILD
 -ifdef CONFIG_MACH_SUN8I_H3
 +ifneq ($(CONFIG_MACH_SUN8I_A33)$(CONFIG_MACH_SUN8I_H3),)
  obj-$(CONFIG_ARMV7_PSCI)	+= psci-scpi.o


### PR DESCRIPTION
- u-boot (Allwinner H2-plus): rebase patch for 2025.01
- u-boot (Allwinner H3): rebase patch for 2025.01
- ~u-boot (Amlogic): drop upstreamed patches for 2025.01~
- ~u-boot: update to 2025.01~

Notes:
- Qualcomm still does not build `No valid dtbs found`

All builds successful apart from afore mentioned Qualcomm
```

target/LibreELEC-A64.aarch64-13.0-devel-20250107140450-f88789f-orangepi-win.img.gz
target/LibreELEC-A64.aarch64-13.0-devel-20250107140450-f88789f-pine64.img.gz
target/LibreELEC-A64.aarch64-13.0-devel-20250107140450-f88789f-pine64-lts.img.gz
target/LibreELEC-A64.aarch64-13.0-devel-20250107140450-f88789f-pine64-plus.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-alta.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-bananapi-m2-pro.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-bananapi-m2s.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-bananapi-m5.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-box.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-khadas-vim2.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-khadas-vim3.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-khadas-vim3l.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-khadas-vim.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-lafrite.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-lepotato.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-nanopi-k2.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-odroid-c2.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-odroid-c4.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-odroid-hc4.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-odroid-n2.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-radxa-zero2.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-radxa-zero.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-solitude.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-wetek-core2.img.gz
target/LibreELEC-AMLGX.aarch64-13.0-devel-20250107130851-f88789f-wetek-play2.img.gz
target/LibreELEC-Exynos.arm-13.0-devel-20250107130549-f88789f-odroid-xu3.img.gz
target/LibreELEC-Exynos.arm-13.0-devel-20250107130549-f88789f-odroid-xu4.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-bananapi-m2p.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-beelink-x2.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-libretech-h3.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-nanopi-m1.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-orangepi-2.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-orangepi-pc.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-orangepi-pc-plus.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-orangepi-plus2e.img.gz
target/LibreELEC-H3.arm-13.0-devel-20250107211450-4587671-orangepi-plus.img.gz
target/LibreELEC-H5.aarch64-13.0-devel-20250107150752-f88789f-orangepi-pc2.img.gz
target/LibreELEC-H5.aarch64-13.0-devel-20250107150752-f88789f-tritium-h5.img.gz
target/LibreELEC-H6.aarch64-13.0-devel-20250107125956-f88789f-beelink-gs1.img.gz
target/LibreELEC-H6.aarch64-13.0-devel-20250107125956-f88789f-orangepi-3.img.gz
target/LibreELEC-H6.aarch64-13.0-devel-20250107125956-f88789f-orangepi-3-lts.img.gz
target/LibreELEC-H6.aarch64-13.0-devel-20250107125956-f88789f-orangepi-lite2.img.gz
target/LibreELEC-H6.aarch64-13.0-devel-20250107125956-f88789f-orangepi-one-plus.img.gz
target/LibreELEC-H6.aarch64-13.0-devel-20250107125956-f88789f-pine-h64.img.gz
target/LibreELEC-H6.aarch64-13.0-devel-20250107125956-f88789f-pine-h64-model-b.img.gz
target/LibreELEC-H6.aarch64-13.0-devel-20250107125956-f88789f-tanix-tx6.img.gz
target/LibreELEC-iMX6.arm-13.0-devel-20250107130258-f88789f-cubox.img.gz
target/LibreELEC-iMX6.arm-13.0-devel-20250107130258-f88789f-udoo.img.gz
target/LibreELEC-iMX6.arm-13.0-devel-20250107130258-f88789f-wandboard.img.gz
target/LibreELEC-iMX8.aarch64-13.0-devel-20250107130412-f88789f-mq-evk.img.gz
target/LibreELEC-iMX8.aarch64-13.0-devel-20250107130412-f88789f-phanbell.img.gz
target/LibreELEC-iMX8.aarch64-13.0-devel-20250107130412-f88789f-pico-mq.img.gz
target/LibreELEC-RK3288.arm-13.0-devel-20250107154041-f88789f-miqi.img.gz
target/LibreELEC-RK3288.arm-13.0-devel-20250107154041-f88789f-tinker.img.gz
target/LibreELEC-RK3328.aarch64-13.0-devel-20250107161129-f88789f-a1.img.gz
target/LibreELEC-RK3328.aarch64-13.0-devel-20250107161129-f88789f-roc-cc.img.gz
target/LibreELEC-RK3328.aarch64-13.0-devel-20250107161129-f88789f-rock64.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-hugsun-x99.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-khadas-edge.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-nanopc-t4.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-nanopi-m4.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-orangepi.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-rock-4c-plus.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-rock960.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-rock-pi-4.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-rock-pi-4-plus.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-rock-pi-n10.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-rockpro64.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-roc-pc.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-roc-pc-plus.img.gz
target/LibreELEC-RK3399.aarch64-13.0-devel-20250107164525-f88789f-sapphire.img.gz

```

