### PR TITLE
argononecontrol: add package (support for the Argon ONE cases)

### DIFF
--- a/packages/addons/service/argononecontrol/package.mk
+++ b/packages/addons/service/argononecontrol/package.mk
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="argononecontrol"
+PKG_VERSION="1.1.7"
+PKG_SHA256="a8aeb581dc28b216816f56f8a6327f37edd7c1c403fcf18bfbb77e4eb20d045e"
+PKG_REV="0"
+PKG_ARCH="aarch64"
+PKG_MAINTAINER="HungerHa"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/HungerHa/libreelec_addon_argononecontrol"
+PKG_URL="https://github.com/HungerHa/libreelec_addon_argononecontrol/archive/refs/tags/v$PKG_VERSION.tar.gz"
+PKG_SECTION="service"
+PKG_SHORTDESC="Argon ONE Control"
+PKG_LONGDESC="Support for RPi4/5 Argon ONE case features including the power button, fan speed, and the Argon IR remote. One-time restart required."
+PKG_TOOLCHAIN="manual"
+PKG_DEPENDS_TARGET="xmlstarlet:host 7-zip:host"
+PKG_IS_ADDON="yes"
+PKG_ADDON_NAME="Argon ONE Control"
+PKG_ADDON_TYPE="xbmc.service"
+PKG_ADDON_PROJECTS="RPi ARM"
+
+addon() {
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}
+  cp -P ${PKG_BUILD}/source/addon.xml ${ADDON_BUILD}/${PKG_ADDON_ID}
+  cp -P ${PKG_BUILD}/changelog.txt ${ADDON_BUILD}/${PKG_ADDON_ID}
+  cp -P ${PKG_BUILD}/README.md ${ADDON_BUILD}/${PKG_ADDON_ID}
+  cp -P ${PKG_BUILD}/source/LICENSE ${ADDON_BUILD}/${PKG_ADDON_ID}
+  cp -P ${PKG_BUILD}/source/default.py ${ADDON_BUILD}/${PKG_ADDON_ID}
+  cp -P ${PKG_BUILD}/source/main.py ${ADDON_BUILD}/${PKG_ADDON_ID}
+  cp -PR ${PKG_BUILD}/source/resources ${ADDON_BUILD}/${PKG_ADDON_ID}
+}
+
+post_install_addon() {
+  rm ${ADDON_BUILD}/${PKG_ADDON_ID}/resources/fanart.png
+}


### PR DESCRIPTION
During the continuous development of the ArgonForty Device Configuration add-on I was asked several times, like: “Why is the addon not installable out-of-the-box”. I think now it is in a state where that is possible...

The addon is required for the RPi4/5 Argon ONE cases. It provides the fan control and ensures that the shutdown works properly and power button events working as well. Additional it enables the IR receiver and provides support for the Argon Remote.

https://github.com/HungerHa/libreelec_package_argonforty-device

It would be nice, if it could be part of the LibreELEC addon repo.