### PR TITLE
rust: update to 1.84.0

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -99,7 +99,7 @@ pre_configure_host() {
 }
 
 post_make_host() {
-  ninja ${NINJA_OPTS} llvm-config llvm-tblgen
+  ninja ${NINJA_OPTS} llvm-config llvm-objcopy llvm-tblgen
 
   if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
     ninja ${NINJA_OPTS} llvm-as llvm-link llvm-spirv opt
@@ -109,6 +109,7 @@ post_make_host() {
 post_makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/bin
     cp -a bin/llvm-config ${TOOLCHAIN}/bin
+    cp -a bin/llvm-objcopy ${TOOLCHAIN}/bin
     cp -a bin/llvm-tblgen ${TOOLCHAIN}/bin
 
   if listcontains "${GRAPHIC_DRIVERS}" "iris"; then

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="5b96aba48790acfacea60a6643a4f30d7edc13e9189ad36b41bbacdad13d49e1"
+    PKG_SHA256="68d4ad239b6d1e810e7b8591636dc408cb2c1e89661329fed906febf9c0a9d98"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="6e72f235d4ebce15eb2eaeaecaa9b29b21df7df64bd71ace55d2c85b7bdf0453"
+    PKG_SHA256="48228ae35953bb6261b1a8dbc36b1cf2f41ffd052d62d494fffdb760c68c0b61"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="de834a4062d9cd200f8e0cdca894c0b98afe26f1396d80765df828880a39b98c"
+    PKG_SHA256="6c2371488db92a09cd50a1b4045c022f3cf2c643285b3b21105ab5f9b64fd6b6"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="8804f673809c5c3db11ba354b5cf9724aed68884771fa32af4b3472127a76028"
+    PKG_SHA256="023f0b6153b23ac0e9686c2ab95bc393ee3e295b166bb36de3b4dfb53e3913e0"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="1d71e107b7cd96ad90e45fa402475c96ea9420290740be90168205137f3163ab"
+    PKG_SHA256="b2a92aa3b5116e2f48cd1a854da5dc308cffad989bb68b9d12e983ed72dcc7a7"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="c88fe6cb22f9d2721f26430b6bdd291e562da759e8629e2b4c7eb2c7cad705f2"
+    PKG_SHA256="770237080b9310d126350c3bd70820bd91064c2e96c29ab5f2e002b31b5bd067"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.83.0"
-PKG_SHA256="722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e"
+PKG_VERSION="1.84.0"
+PKG_SHA256="15cee7395b07ffde022060455b3140366ec3a12cbbea8f1ef2ff371a9cca51bf"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -53,6 +53,7 @@ rpath = true
 channel = "stable"
 codegen-tests = false
 optimize = true
+download-rustc = false
 
 [build]
 submodules = false

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="aa5d075f9903682e5171f359948717d32911bed8c39e0395042e625652062ea9"
+    PKG_SHA256="9f5650aece53e083b933a57e5a8e0e2db4479f52ec897d5b6d0f77be6cd50498"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="a0f74aab6e9a4d911a261f5bbe24f41066d41e80aa7a68abc754f3bc776037e1"
+    PKG_SHA256="1b10d12ab6b31b699d7e169a907d8b8e4e4abe465f4b50e9fccfcd56b504362d"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="6ec40e0405c8cbed3b786a97d374c144b012fc831b7c22b535f8ecb524f495ad"
+    PKG_SHA256="a1737d86f80b31a6d48a6726726275dc068ecb930c9635b13aa59999486de837"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- rust: update to 1.84.0
  - cargo-snapshot: update to 1.84.0
  - rust-std-snapshot: update to 1.84.0
  - rustc-snapshot: update to 1.84.0
- llvm: build llvm-objcopy required for rust 1.84.0