### PR TITLE
media-driver: update to 25.1.0

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="24.4.4"
-PKG_SHA256="3000723faf4dc56eb8276f402c4aa798459bbce860b408a0c480d863b28130ed"
+PKG_VERSION="25.1.0"
+PKG_SHA256="94178add6dd545bd14747c063863d87d7b4f3cbcaab5d660d2ae5310cbfe4553"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
ref: https://github.com/intel/media-driver/releases/tag/intel-media-25.1.0

```
=== tested on ===
Generic.x86_64-devel-20250114003445-a0d41fd
Linux nuc12 6.12.9 #1 SMP Mon Jan 13 10:15:57 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:8a0d510be81c055b29b7006d7e123270e4a0a534). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-01-13 by GCC 15.0.0 for Linux x86 64-bit version 6.12.9 (396297)
Running on LibreELEC (heitbaum): devel-20250114003445-a0d41fd 13.0, kernel: Linux x86 64-bit version 6.12.9
FFmpeg version/source: 7.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 24.3.3
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.1.0 (7f065ba105)
```