### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="22.1.11-Piers"
-PKG_SHA256="d15722938bfa163196c77d20ae1e2133ac245a22a8554d3f4b28098b3e19efd8"
+PKG_VERSION="22.1.12-Piers"
+PKG_SHA256="f5880a23c4e3a366bde08b0acd9ccdfb7b69014028a1b2a563ae73f3e1c281e7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="22.0.2-Piers"
-PKG_SHA256="44232cc280dbfc1e5bed3a3afc2378b99fba28ad6485df42b81c52f5f48e7b03"
+PKG_VERSION="22.0.3-Piers"
+PKG_SHA256="6bd4acb94b81eb9004a795822e6416639f167d2641a1f05eaa5f44b925794217"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- inputstream.adaptive: update 22.1.11-Piers to 22.1.12-Piers
- peripheral.joystick: update 22.0.2-Piers to 22.0.3-Piers