### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="23c71579553465a609453e269db7e1916052e5d41fd13e7277e62c826029643b"
+PKG_SHA256="7676968253f0b5ca3a44213c8a92c570284e7146d464a95b6ed11050bd09238c"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="b9d17eaebb55b7652ce37ae5c7c52fcb34194956"
+export PKG_GIT_COMMIT="a187fa5d2d0d5f12db920734e425afc758e98ead"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="27.4.1"
-PKG_SHA256="ab0389f1e64f74626667dc773cfc21ac9bb686bacf62b14f15c5b5888ca95313"
+PKG_VERSION="27.5.0"
+PKG_SHA256="f24e988f7b061ae25146f3be9fcdcab54f2e2bd820acc95dfbb29ce43ef47811"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="c710b88579fcb5e0d53f96dcae976d79323b9166"
+export PKG_GIT_COMMIT="38b84dce32c45732606fe09ffebef8b29a783644"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.2.3"
-PKG_SHA256="b12ba86441c259225374640db1cbf915168a04d94e471ec936684df2f05423a0"
+PKG_VERSION="1.2.4"
+PKG_SHA256="9785c144c97974b52b6091b7a79168b73681ff574bc8438b44f3f5f8c112f171"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-export PKG_GIT_COMMIT="0d37cfd4b557771e555a184d5a78d0ed4bdb79a5"
+export PKG_GIT_COMMIT="6c52b3fc541fb26fe8c374d5f58112a0a5dbda66"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/addon-depends/system-tools-depends/pv/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/pv/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pv"
-PKG_VERSION="1.9.25"
-PKG_SHA256="162495aabb1cb842186cb224995e3d5f60a9f527a49ccbd8212383cc72b7c36c"
+PKG_VERSION="1.9.27"
+PKG_SHA256="253659dc86569363f065f5e881e135a0c9594b987f34a19b104c7414a2d2c479"
 PKG_LICENSE="GNU"
 PKG_SITE="http://www.ivarch.com/programs/pv.shtml"
 PKG_URL="http://www.ivarch.com/programs/sources/pv-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.18.07"
-PKG_SHA256="e2adaab67a70f4f98863d88d92e5805a31adce4559de52419e4f556e2ddeada6"
+PKG_VERSION="0.18.09"
+PKG_SHA256="0694f2c24eb5d839fe11f41adc2c0ea31bb7e9c1a53316fc251847d1d55f6344"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-live/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-live/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-live"
-PKG_VERSION="3.3.12"
-PKG_SHA256="59a9ebf70b5d66827276388b1fe4608a039ab1c78e7e4e866602e54c9339a1ce"
+PKG_VERSION="3.4.0"
+PKG_SHA256="68d23987cd548eb7b65faf7e56934700b95225e67053129345cf07ecbdc6618c"
 PKG_LICENSE="GPL"
 PKG_SITE="http://live.vdr-developer.org/en/index.php"
 PKG_URL="https://github.com/MarkusEh/vdr-plugin-live/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-streamdev/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-streamdev/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-streamdev"
-PKG_VERSION="0.6.3"
-PKG_SHA256="a678653dfb2641bc9dea9a1bd3b2400f3edbe697953364cf597f76d93cfaea2c"
+PKG_VERSION="0.6.4"
+PKG_SHA256="1698afccb5fde1ea4e40794ae187fa42ce7fc38af48c12ecd3fa1d3154c6c794"
 PKG_LICENSE="GPL"
 PKG_SITE="http://projects.vdr-developer.org/projects/plg-streamdev"
 PKG_URL="https://github.com/vdr-projects/vdr-plugin-streamdev/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-streamdev/patches/vdr-plugin-streamdev-03_i18n.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-streamdev/patches/vdr-plugin-streamdev-03_i18n.patch
@@ -1,17 +1,17 @@
 --- a/Makefile	2017-09-30 21:31:48.000000000 +0200
 +++ b/Makefile	2021-01-12 23:26:57.857536391 +0100
-@@ -71,12 +71,14 @@ all: client server
+@@ -70,12 +70,14 @@ all: client server
  client:
- 	$(MAKE) -C ./tools
- 	$(MAKE) -C ./client
-+	$(MAKE) -C ./client install-i18n
+ 	$(Q)$(MAKE) --no-print-directory -C ./tools
+ 	$(Q)$(MAKE) --no-print-directory -C ./client
++	$(Q)$(MAKE) --no-print-directory -C ./client install-i18n
  
  server:
- 	$(MAKE) -C ./tools
- 	$(MAKE) -C ./libdvbmpeg
- 	$(MAKE) -C ./remux
- 	$(MAKE) -C ./server
-+	$(MAKE) -C ./server install-i18n
+ 	$(Q)$(MAKE) --no-print-directory -C ./tools
+ 	$(Q)$(MAKE) --no-print-directory -C ./libdvbmpeg
+ 	$(Q)$(MAKE) --no-print-directory -C ./remux
+ 	$(Q)$(MAKE) --no-print-directory -C ./server
++	$(Q)$(MAKE) --no-print-directory -C ./server install-i18n
  
  install-client: client
- 	$(MAKE) -C ./client install
+ 	$(Q)$(MAKE) --no-print-directory -C ./client install

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.28.1"
-PKG_SHA256="e965995bfa3b3cf62d935246a259e764703d4aedfa030ec310a287dca0e1459a"
-PKG_REV="3"
+PKG_VERSION="1.29.2"
+PKG_SHA256="c7b6bc36af1af6f1cb304f4ec4c16743760ef6e8b3586f31dc11439d5d5fd427"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="vdr-addon"
 PKG_VERSION="2.7.3"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- syncthing: update to 1.29.2 and addon (4)
- docker: update to 27.5.0 and addon (6)
  - cli: update to 27.5.0
  - moby: update to 27.5.0
  - runc: update to 1.2.4
- system-tools: update addon (5)
  - pv: update to 1.9.27
  - stress-ng: update to 0.18.09
- vdr-addon: update addon (5)
  - vdr-plugin-streamdev: update to 0.6.4
  - vdr-plugin-live: update to 3.4.0