### PR TITLE
kodi: update to githash 251a25f with taglib-2.0.2

### DIFF
--- a/packages/audio/taglib/package.mk
+++ b/packages/audio/taglib/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="taglib"
-PKG_VERSION="1.13.1"
-PKG_SHA256="c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b"
+PKG_VERSION="2.0.2"
+PKG_SHA256="0de288d7fe34ba133199fd8512f19cc1100196826eafcb67a33b224ec3a59737"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://taglib.org"
 PKG_URL="https://taglib.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain cmake:host zlib"
+PKG_DEPENDS_TARGET="toolchain cmake:host utfcpp zlib"
 PKG_LONGDESC="TagLib is a library for reading and editing the meta-data of several popular audio formats."
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_EXAMPLES=OFF \

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="8a0d510be81c055b29b7006d7e123270e4a0a534"
-PKG_SHA256="5a269d52e1e99e8ff166b2d18d6b59d6b2b9ed6e3e34eab4b1b90a39bdde537f"
+PKG_VERSION="251a25f0022bd889012ddd2cdc7f8935020327ba"
+PKG_SHA256="fe126835c62dc5eb0e9e909323f6f19667141559850d928219b13ce845793ef3"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- taglib: update to 2.0.2
  - https://github.com/xbmc/xbmc/pull/26278 (fixes 32-bit builds)
- kodi: update to githash 251a25f
  - log: https://github.com/xbmc/xbmc/compare/8a0d510be81c055b29b7006d7e123270e4a0a534...251a25f0022bd889012ddd2cdc7f8935020327ba