### PR TITLE
tz: update to 2025a

### DIFF
--- a/packages/sysutils/tz/package.mk
+++ b/packages/sysutils/tz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tz"
-PKG_VERSION="2024b"
-PKG_SHA256="557c41d8eb5c29387a9d496db87c4aeb4f2ac8a2b6d5f60e869a8cade26e679c"
+PKG_VERSION="2025a"
+PKG_SHA256="d0f35d0a3b5ca1bb25539b159c1338135a4f59b0d423381ecafa31d0449caea5"
 PKG_LICENSE="Public Domain"
 PKG_SITE="http://www.iana.org/time-zones"
 PKG_URL="https://github.com/eggert/tz/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
log: https://github.com/eggert/tz/compare/2024b...2025a