### PR TITLE
[le12] libmediainfo: fix build

### DIFF
--- a/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/depends/libmediainfo/package.mk
@@ -36,9 +36,8 @@ makeinstall_target() {
     mkdir -p ${INSTALL}/usr/include/MediaInfo/${i}/
     cp -aP ../../../Source/MediaInfo/${i}/*.h ${INSTALL}/usr/include/MediaInfo/${i}/
   done
+
+  # only install static library, so mediainfo does not build with shared library
   cp -P .libs/libmediainfo.a ${INSTALL}/usr/lib
-  
-  # move shared lib so mediainfo will not detect it and perform a static build
-  mkdir -p ${INSTALL}/shared-lib
-  cp -P .libs/libmediainfo.so* ${INSTALL}/shared-lib
+  cp -P libmediainfo.pc ${INSTALL}/usr/lib/pkgconfig
 }


### PR DESCRIPTION
- revert change introduced with 282b913aefed4599ada598991eae323412373b66 (#9470)
- go with upstream eb952e7746ad13f1eacc2d4367d9d9709af3e16e