### PR TITLE
Add /opt to root base layout

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -140,7 +140,7 @@ rm -rf ${STAMPS_INSTALL}
 mkdir -p ${INSTALL}
 
 # Create base layout of LibreELEC read-only file system
-for directory in etc dev proc run sys tmp usr var flash storage; do
+for directory in opt etc dev proc run sys tmp usr var flash storage; do
   mkdir -p ${INSTALL}/${directory}
 done
 


### PR DESCRIPTION
The opt folder can be overlayed and opens at least the possibility to add a destination for package manager, namely Entware.
Tested on version 12, Generic-legacy.x86_64