### PR TITLE
linux: update to 6.12.y

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -30,8 +30,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="raspberrypi rtlwifi/after-6.12"
     ;;
   *)
-    PKG_VERSION="6.12.9"
-    PKG_SHA256="87be0360df0931b340d2bac35161a548070fbc3a8c352c49e21e96666c26aeb4"
+    PKG_VERSION="6.12.10"
+    PKG_SHA256="4a516e5ed748537a73cb42ec47fbbeb6df8b1298e8892c29c0e91de79095b297"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default rtlwifi/after-6.12"
     ;;

--- a/projects/Allwinner/linux/linux.aarch64.conf
+++ b/projects/Allwinner/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.5 Kernel Configuration
+# Linux/arm64 6.12.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1576,6 +1576,7 @@ CONFIG_ARM_SCPI_PROTOCOL=y
 # CONFIG_FIRMWARE_MEMMAP is not set
 # CONFIG_ARM_FFA_TRANSPORT is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 CONFIG_ARM_PSCI_FW=y
 # CONFIG_ARM_PSCI_CHECKER is not set
 

--- a/projects/Allwinner/linux/linux.arm.conf
+++ b/projects/Allwinner/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.12.5 Kernel Configuration
+# Linux/arm 6.12.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7ve-libreelec-linux-gnueabihf-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1502,6 +1502,7 @@ CONFIG_SUNXI_RSB=y
 # CONFIG_FW_CFG_SYSFS is not set
 # CONFIG_TRUSTED_FOUNDATIONS is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 CONFIG_ARM_PSCI_FW=y
 # CONFIG_ARM_PSCI_CHECKER is not set
 

--- a/projects/Generic/linux/linux.x86_64.conf
+++ b/projects/Generic/linux/linux.x86_64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.12.5 Kernel Configuration
+# Linux/x86 6.12.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1817,6 +1817,8 @@ CONFIG_EFI_CUSTOM_SSDT_OVERLAYS=y
 # CONFIG_EFI_DISABLE_RUNTIME is not set
 # CONFIG_EFI_COCO_SECRET is not set
 # end of EFI (Extensible Firmware Interface) Support
+
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 
 #
 # Qualcomm firmware drivers

--- a/projects/Qualcomm/devices/Dragonboard/linux/linux.aarch64.conf
+++ b/projects/Qualcomm/devices/Dragonboard/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.5 Kernel Configuration
+# Linux/arm64 6.12.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1781,6 +1781,7 @@ CONFIG_EFI_CUSTOM_SSDT_OVERLAYS=y
 # CONFIG_EFI_COCO_SECRET is not set
 # end of EFI (Extensible Firmware Interface) Support
 
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 CONFIG_ARM_PSCI_FW=y
 # CONFIG_ARM_PSCI_CHECKER is not set
 

--- a/projects/Rockchip/devices/RK3288/linux/default/linux.arm.conf
+++ b/projects/Rockchip/devices/RK3288/linux/default/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.12.5 Kernel Configuration
+# Linux/arm 6.12.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7ve-libreelec-linux-gnueabihf-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1528,6 +1528,7 @@ CONFIG_ARM_SCPI_PROTOCOL=m
 # CONFIG_FW_CFG_SYSFS is not set
 # CONFIG_TRUSTED_FOUNDATIONS is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 
 #
 # Qualcomm firmware drivers

--- a/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.5 Kernel Configuration
+# Linux/arm64 6.12.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1616,6 +1616,7 @@ CONFIG_GENERIC_ARCH_TOPOLOGY=y
 CONFIG_ARM_SCPI_PROTOCOL=y
 # CONFIG_ARM_FFA_TRANSPORT is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 CONFIG_ARM_PSCI_FW=y
 # CONFIG_ARM_PSCI_CHECKER is not set
 

--- a/projects/Rockchip/devices/RK3399/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3399/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.5 Kernel Configuration
+# Linux/arm64 6.12.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1699,6 +1699,7 @@ CONFIG_ARM_SCPI_PROTOCOL=y
 # CONFIG_FW_CFG_SYSFS is not set
 # CONFIG_ARM_FFA_TRANSPORT is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 CONFIG_ARM_PSCI_FW=y
 # CONFIG_ARM_PSCI_CHECKER is not set
 

--- a/projects/Samsung/linux/linux.arm.conf
+++ b/projects/Samsung/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.12.5 Kernel Configuration
+# Linux/arm 6.12.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="armv7ve-libreelec-linux-gnueabihf-gcc-14.2.0 (GCC) 14.2.0"
 CONFIG_CC_IS_GCC=y
@@ -1502,6 +1502,7 @@ CONFIG_ARM_CCI400_PORT_CTRL=y
 # CONFIG_FW_CFG_SYSFS is not set
 # CONFIG_TRUSTED_FOUNDATIONS is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
+# CONFIG_IMX_SCMI_MISC_DRV is not set
 
 #
 # Qualcomm firmware drivers


### PR DESCRIPTION
- linux: update to 6.12.10

### packages updated
- linux: update to 6.12.x

### 6.12.x mainline kernel update
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.10


6.12.10 - 189 patches

### errors / fixes / issues / regressions / todo
- 

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.12.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.12
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/

### 6.12.10 Build tested on all of:
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.12.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.12.10 - heitbaum
- Generic Generic (AMD 7840HS - SER7) - 6.12.10 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- NXP iMX6 (Coral Dev Board - Phanbell) - 6.12.10 - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum