### PR TITLE
Vulkan update to 1.4.306

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.4.305"
-PKG_SHA256="7581c5ed0337ffeef0707651561f722700081bc69c62c582c470cd77c2be0920"
+PKG_VERSION="1.4.306"
+PKG_SHA256="18f4b4de873d071ddd7b73ea48e2ec4e7c6133e2ebb6b4236ca2345acd056994"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.4.305"
-PKG_SHA256="1f2992538ee6a9d7ff3e00fdc8dc0c3a03a6235ebb2a1b7ee2179a13bc1c5c06"
+PKG_VERSION="1.4.306"
+PKG_SHA256="983576dd502555fa1d5bd157917febf155d10428dd27cb89bce91bece48c6d07"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.4.305"
-PKG_SHA256="55c25e50172428f36e63cc9644c25fcda2a558b31158283f2cbba685f0b94572"
+PKG_VERSION="1.4.306"
+PKG_SHA256="8e3c3df74fa8e6408cbb772d20012c3fdf0bf1b3e363e18e909b6c99d5b489a2"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/blob/main/ChangeLog.adoc
- vulkan-headers: update to 1.4.306
- vulkan-loader: update to 1.4.306
- vulkan-tools: update to 1.4.306