### PR TITLE
Addon updates 

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet8-runtime"
-PKG_VERSION="8.0.11"
+PKG_VERSION="8.0.12"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="4f83cb39dbd515ea8319a8c2c32f041a2972301343cd31621c4bb402a300cfd6"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/64a9f696-b039-4a73-b705-288fbf9c2e8f/c36bc24d6d359c019408b4f94ee67b59/aspnetcore-runtime-8.0.11-linux-arm64.tar.gz"
+    PKG_SHA256="1c2b31eb0d1059f259822c651362d870efd21c5308a037dcc389a5e459b05573"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/8953c6fe-3542-4cee-b022-a50e029882a5/1bbce821b1ae97ed11b305dd708c0437/aspnetcore-runtime-8.0.12-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="a3b38882b0df6b1d320a921111e678d792658af23d36dadb678bca9f9c98bc19"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/003f180b-e695-4094-bc3f-ef6473883d43/e861cb56edd58b05b03b5a92cf995f12/aspnetcore-runtime-8.0.11-linux-arm.tar.gz"
+    PKG_SHA256="5299c03e7de25e61e0c49cec0ca80642f541c142833c1ded9881c730f010da75"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/26fe9c15-40f6-4eb5-88fd-63d98eb259fa/c36789f8460b7e20371c38129d7fc160/aspnetcore-runtime-8.0.12-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="3fc75c38783b282140d2e2513c570f76991101b3f895b67a6ae8fba2a2d96399"
-    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/6f89757c-3dde-4c3a-96a0-b04b1bde2c92/6a3591b360ed0f9d1118b97560b89625/aspnetcore-runtime-8.0.11-linux-x64.tar.gz"
+    PKG_SHA256="8a441b42051607dc914b14b1a6271abbf81f72ba0579fcb21aabd8e845d68a70"
+    PKG_URL="https://download.visualstudio.microsoft.com/download/pr/df752f45-7e9f-4d13-8568-a88adda5aa04/9d59726fb38525b4956cbb1e1fe8a2c8/aspnetcore-runtime-8.0.12-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.23.4"
-PKG_SHA256="ec4a641e8919b21eb6d189a9d0621008015c2bb6fd204fd65fdfeb4c68d9301a"
+PKG_VERSION="1.23.5"
+PKG_SHA256="742aa265a47019d2b87bd3d9c42fd7f1e2fed133557e64b0a3e8749925ce5123"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/pcsc-lite/package.mk
+++ b/packages/addons/addon-depends/pcsc-lite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcsc-lite"
-PKG_VERSION="2.3.0"
-PKG_SHA256="1acca22d2891d43ffe6d782740d32e78150d4fcc99e8a3cc763abaf546060d3d"
+PKG_VERSION="2.3.1"
+PKG_SHA256="a641d44d57affe1edd8365dd75307afc307e7eefb4e7ad839f6f146baa41ed56"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pcsclite.apdu.fr"
 PKG_URL="https://pcsclite.apdu.fr/files/pcsc-lite-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/polkit/package.mk
+++ b/packages/addons/addon-depends/polkit/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="polkit"
-PKG_VERSION="125"
-PKG_SHA256="ea5cd6e6e2afa6bad938ee770bf0c2cd9317910f37956faeba2869adcf3747d1"
+PKG_VERSION="126"
+PKG_SHA256="2814a7281989f6baa9e57bd33bbc5e148827e2721ccef22aaf28ab2b376068e8"
 PKG_LICENSE="GPL"
 PKG_SITE="https://polkit.pages.freedesktop.org/polkit"
 PKG_URL="https://github.com/polkit-org/polkit/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/jellyfin/package.mk
+++ b/packages/addons/service/jellyfin/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="jellyfin"
 PKG_VERSION="1.0"
-PKG_VERSION_NUMBER="10.10.3"
-PKG_REV="4"
+PKG_VERSION_NUMBER="10.10.5"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://jellyfin.org/"

--- a/packages/addons/service/librespot/package.mk
+++ b/packages/addons/service/librespot/package.mk
@@ -3,14 +3,14 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="librespot"
-PKG_VERSION="0.6.0"
+PKG_VERSION="0e9a3def83b4adb216b353eef3348c29de4edf69"
 PKG_VERSION_DATE="2023-12-06"
-PKG_SHA256="9ec881edb11e37d31a2b41dd30d56a3413445eedb720e1b0d278567dccfca8fc"
-PKG_REV="2"
+PKG_SHA256="08c027dde27802a77e887968d50ae5794a6e23beb1ebf67f5cef729ad30d742d"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/librespot-org/librespot/"
-PKG_URL="https://github.com/librespot-org/librespot/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/librespot-org/librespot/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain alsa-lib avahi pulseaudio bindgen-cli:host cargo:host cmake:host"
 PKG_SECTION="service"
 PKG_SHORTDESC="Librespot: play Spotify through Kodi using a Spotify app as a remote"

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="11799"
-PKG_SHA256="10e7ffb153c66b4f29c21dd5a239d1186f988e918e8ff2673a4ea5fb9073a209"
-PKG_REV="1"
+PKG_VERSION="11866"
+PKG_SHA256="648fb783c020aed40e715be95c43c3dced199ccddbe80ce8378a067bc94886c9"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"

--- a/packages/addons/service/oscam/patches/oscam-02-link-with-ludev.patch
+++ b/packages/addons/service/oscam/patches/oscam-02-link-with-ludev.patch
@@ -1,14 +1,14 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -498,7 +498,7 @@ add_library (${csoscam} STATIC ${csoscam
- 
- set (exe_name "oscam")
+@@ -621,7 +621,7 @@
+ 	set (exe_name "oscam-upx")
+ endif (NOT USE_COMPRESS EQUAL 1)
  add_executable (${exe_name} ${exe_srcs} ${exe_hdrs})
 -target_link_libraries (${exe_name} ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt minilzo)
 +target_link_libraries (${exe_name} ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt minilzo udev)
- if(HAVE_LIBRT AND HAVE_LIBUSB)
- 	if (LIBUSBDIR)
- 		set (libusb_link "imp_libusb")
+ if (WITH_SIGNING EQUAL 1)
+ 	SIGN_COMMAND_OSCAM()
+ endif (WITH_SIGNING EQUAL 1)
 --- a/utils/CMakeLists.txt
 +++ b/utils/CMakeLists.txt
 @@ -12,7 +12,7 @@ file (GLOB all_srcs ${exe_srcs})

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"

--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.4.2"
-PKG_SHA256="22797942575e10347dab52ec43ebb9d3ace1d9b8569b271f434e2e1b1a4fe897"
+PKG_VERSION="2.4.3"
+PKG_SHA256="a92aa83d2ff09a1a6d6186e81d8182bd2958947dffca77a6490ffd41b3ec9dc7"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.fluidsynth"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="dd8ca6386a3beed360c1d2f989cd81553baf81652007fdfd478a28b44b68db10"
-PKG_REV="13"
+PKG_REV="14"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.fluidsynth"


### PR DESCRIPTION
- jellyfin: update to 10.10.5 and addon (5)
- oscam: update to 11866 and addon (2)
  - polkit: update to 126
  - pcsc-lite: update to 2.3.1
- librespot: update to githash 0e9a3de and addon (3)
- go: update to 1.23.5
- dotnet-runtime: update to 8.0.12 and addon (3)
  - aspnet8-runtime: update to 8.0.12
- audiodecoder.fluidsynth: update fluidsynth to 2.4.3 and addon (14)
  - fluidsynth: update to 2.4.3