### PR TITLE
ply: add python-ply package

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -109,7 +109,7 @@ else
 fi
 
 if [ "${VULKAN_SUPPORT}" = "yes" ]; then
-  PKG_DEPENDS_TARGET+=" ${VULKAN} vulkan-tools"
+  PKG_DEPENDS_TARGET+=" ${VULKAN} vulkan-tools ply:host"
   PKG_MESON_OPTS_TARGET+=" -Dvulkan-drivers=${VULKAN_DRIVERS_MESA// /,}"
 else
   PKG_MESON_OPTS_TARGET+=" -Dvulkan-drivers="

--- a/packages/python/devel/ply/package.mk
+++ b/packages/python/devel/ply/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="ply"
+PKG_VERSION="3.11"
+PKG_SHA256="00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
+PKG_LICENSE="BSD-3-Clause"
+PKG_SITE="https://pypi.org/project/ply"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="Python3:host setuptools:host"
+PKG_LONGDESC="PLY is yet another implementation of lex and yacc for Python."
+PKG_TOOLCHAIN="python"


### PR DESCRIPTION
ply is required by mesa package when building vulkan drivers, otherwise following error is thrown:
```
Problem encountered: Python (3.x) ply module required to build GRL kernels.
```