### PR TITLE
gmp: configure and acinclude.m4: fix -std=c23 build failure

### DIFF
--- a/packages/devel/gmp/patches/0001-acinclude.m4-fix-std-c23-build-failure.patch
+++ b/packages/devel/gmp/patches/0001-acinclude.m4-fix-std-c23-build-failure.patch
@@ -1,0 +1,73 @@
+From 396d0ca56134936a8b89cba07518bcf8c4c14dc6 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 21 Jan 2025 10:18:09 +0000
+Subject: [PATCH V2] acinclude.m4: fix -std=c23 build failure
+
+Add prototype to configure test function as c23 removes unprototyped
+functions.
+
+gcc-15 switched to -std=c23 by default:
+
+    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212
+
+As a result `configure` fails with:
+    conftest.c: In function 'f':
+    conftest.c:12:48: error: too many arguments to function 'g'; expected 0, have 6
+       12 | for(i=0;i<1;i++){if(e(got,got,9,d[i].n)==0)h();g(i,d[i].src,d[i].n,got,d[i].want,9);if(d[i].n)h();}}
+          |                                                ^ ~
+    conftest.c:7:6: note: declared here
+        7 | void g(){}
+          |      ^
+
+Upstream: hg log --patch --rev 18477:8e7bb4ae7a18
+Link: https://gmplib.org/list-archives/gmp-bugs/2024-November/005550.html
+Link: https://gmplib.org/list-archives/gmp-devel/2025-January/006281.html
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+v2:
+- update prototype to allow type checking
+---
+ acinclude.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index fddb5fb07a..2d41de6328 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long reliability test 1],
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,const t1 *,t1,t1 *,const t1 *,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+-- 
+2.43.0
+
+From c32b367226696744ee3a5e5eb4f372f4931c78f1 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 31 Jan 2025 04:24:59 +0000
+Subject: [PATCH] configure: fix -std=c23 build failure
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 7910aa0970..bd4342d124 100755
+--- a/configure
++++ b/configure
+@@ -6568,7 +6568,7 @@ if test "$gmp_prog_cc_works" = yes; then
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,const t1 *,t1,t1 *,const t1 *,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+-- 
+2.43.0
+


### PR DESCRIPTION
Upstreamed:

Add prototype to configure test function as c23 removes unprototyped functions.

gcc-15 switched to -std=c23 by default:

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212

As a result `configure` fails with:
    conftest.c: In function 'f':
    conftest.c:12:48: error: too many arguments to function 'g'; expected 0, have 6
       12 | for(i=0;i<1;i++){if(e(got,got,9,d[i].n)==0)h();g(i,d[i].src,d[i].n,got,d[i].want,9);if(d[i].n)h();}}
          |                                                ^ ~
    conftest.c:7:6: note: declared here
        7 | void g(){}
          |      ^

Upstream: hg log --patch --rev 18477:8e7bb4ae7a18
Link: https://gmplib.org/list-archives/gmp-bugs/2024-November/005550.html
Link: https://gmplib.org/list-archives/gmp-devel/2025-January/006281.html