### PR TITLE
Vulkan update to 1.4.307

### DIFF
--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.4.306"
-PKG_SHA256="18f4b4de873d071ddd7b73ea48e2ec4e7c6133e2ebb6b4236ca2345acd056994"
+PKG_VERSION="1.4.307"
+PKG_SHA256="6e8445bc12c1e2702c27f4f02d1a057fb83f40cc56c6a8e4583141d4eaad90d4"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.4.306"
-PKG_SHA256="983576dd502555fa1d5bd157917febf155d10428dd27cb89bce91bece48c6d07"
+PKG_VERSION="1.4.307"
+PKG_SHA256="661f7b7d1536538420771372dd8050f2d224fcf3a023f31d66ea76d8af7b911e"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.4.306"
-PKG_SHA256="8e3c3df74fa8e6408cbb772d20012c3fdf0bf1b3e363e18e909b6c99d5b489a2"
+PKG_VERSION="1.4.307"
+PKG_SHA256="4f0baeaf078c2a9d298b87d6d6ef85c3faf08f0f95b8a7d7d7ff243c6de2707c"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/blob/main/ChangeLog.adoc
- vulkan-headers: update to 1.4.307
- vulkan-loader: update to 1.4.307
- vulkan-tools: update to 1.4.307