### PR TITLE
Rust update to 1.84.1

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="68d4ad239b6d1e810e7b8591636dc408cb2c1e89661329fed906febf9c0a9d98"
+    PKG_SHA256="51455991bb2c3246af7312712e130313ed7969eb4befd5a50baf285bf21e8f46"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="48228ae35953bb6261b1a8dbc36b1cf2f41ffd052d62d494fffdb760c68c0b61"
+    PKG_SHA256="ce62bdf0f8532d62689b3d71576084cc8a11970af52915bb261fd76de7e868e9"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="6c2371488db92a09cd50a1b4045c022f3cf2c643285b3b21105ab5f9b64fd6b6"
+    PKG_SHA256="792214e185297d8a3fa65949f9f3001ddd7cc06e1e8afd2a042f7ca5a8af727b"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="023f0b6153b23ac0e9686c2ab95bc393ee3e295b166bb36de3b4dfb53e3913e0"
+    PKG_SHA256="fac5c60fa657975860c9947dc1638f8b8a21e6492c9218433e3116d4a6e1ed97"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="b2a92aa3b5116e2f48cd1a854da5dc308cffad989bb68b9d12e983ed72dcc7a7"
+    PKG_SHA256="39cec7bdc3a4c5a7b9501e808c007f13617f12fb954b424925cf53c4dd3fb817"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="770237080b9310d126350c3bd70820bd91064c2e96c29ab5f2e002b31b5bd067"
+    PKG_SHA256="553727eeee81f1b1e7f3c7b7fd023abfb62fe5aff7fe0b1c81d3b5b92ab8a474"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.84.0"
-PKG_SHA256="15cee7395b07ffde022060455b3140366ec3a12cbbea8f1ef2ff371a9cca51bf"
+PKG_VERSION="1.84.1"
+PKG_SHA256="5e2fb5d49628a549f7671b2ccf9855ab379fd442831a7c2af16e0cdcc31bb375"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -33,7 +33,7 @@ configure_host() {
   esac
 
   cat >${PKG_BUILD}/config.toml  <<END
-change-id = 102579
+change-id = 133207
 
 [llvm]
 download-ci-llvm = false

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="9f5650aece53e083b933a57e5a8e0e2db4479f52ec897d5b6d0f77be6cd50498"
+    PKG_SHA256="f4241e0d8b38789f1d99603b5fd1a307d6946a1eac18b80938b804da99bf105e"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="1b10d12ab6b31b699d7e169a907d8b8e4e4abe465f4b50e9fccfcd56b504362d"
+    PKG_SHA256="de84144a97d8a93b8b092803b69d9fe3a5f61acb09b3120155068441c28e984e"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="a1737d86f80b31a6d48a6726726275dc068ecb930c9635b13aa59999486de837"
+    PKG_SHA256="ae9e4c996707a7152443639bd09de49afdcc37830ff8561872e718b0600a4fcf"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- rust: update to 1.84.1
  - rustc-snapshot: update to 1.84.1
  - rust-std-snapshot: update to 1.84.1
  - cargo-snapshot: update to 1.84.1
