### PR TITLE
wayland: copy wayland.xml to SYSROOT

### DIFF
--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -16,7 +16,7 @@ configure_package() {
   if [ "${DISPLAYSERVER}" = "x11" ]; then
     PKG_DEPENDS_TARGET+=" libxcb libX11"
   elif [ "${DISPLAYSERVER}" = "wl" ]; then
-    PKG_DEPENDS_TARGET+=" wayland"
+    PKG_DEPENDS_TARGET+=" wayland wayland-protocols"
   fi
 }
 

--- a/packages/wayland/wayland/package.mk
+++ b/packages/wayland/wayland/package.mk
@@ -30,4 +30,6 @@ pre_configure_target() {
 
 post_makeinstall_host() {
   cp ${TOOLCHAIN}/lib/pkgconfig/wayland-scanner.pc ${SYSROOT_PREFIX}/usr/lib/pkgconfig/
+  mkdir -p ${SYSROOT_PREFIX}/usr/share/wayland
+    cp ${TOOLCHAIN}/share/wayland/wayland.xml ${SYSROOT_PREFIX}/usr/share/wayland/
 }


### PR DESCRIPTION
vulkan-tools requires wayland.xml when building wayland target with vulkan support. when wayland.xml is missing, build of vulkan-tools fails with following error:

    CMake Error in cube/CMakeLists.txt:
      Cannot find source file:

        [...]/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/share/wayland/wayland.xml

      Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
      .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
      .f95 .f03 .hip .ispc