### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="22.3.0-Piers"
-PKG_SHA256="bf773b39f78629c78961933dd81604bedd55528b2cf7c7a754cd9ee6fbb90847"
+PKG_VERSION="22.3.1-Piers"
+PKG_SHA256="5622552311a34b12a8f4ecaa74baee283020010059783aadc7578cb7dd442ba8"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="22.4.0-Piers"
-PKG_SHA256="24caa810bb2148effbac08639f1ca6a023cf9ea3c7d0e2e432e10f314201bbbc"
+PKG_VERSION="22.4.1-Piers"
+PKG_SHA256="d750aaa908d4f5472e5f8f0a39c1124ab160e01eea8afbf2c9c986b6be09bbc9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvblink"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="1f932ea98fc3e21481e2f6724ea85a211788044f3b7a0cc925d87f994af4a185"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="bd2ea86fd32a5e783bc68c2381082a93cb4dccdbc71e0190f7883d3e5a23ff4f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.dvbviewer"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="b5ebbd6ecfd8da04b310cb5f6e44850d4a3de4cbd62c9924e1b3510daa99da2e"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="9d825950f54bf0edb206c65f8bd01339b6ec405086a8278a28fbd29af395b281"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.filmon"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="77a12f0b1fe1ca0b1f2e5cd5c66452a60bde1c09d0dbb6ddd741dc1a4b99d4a0"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="7e3e1dd0dd3efb1c314b799867774806bb08f5b672afd24d5148208523f89451"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.hdhomerun"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="e38b343f71754d67115eaa78016428cf1d4822e211ff82baffb662e9a54cbff3"
-PKG_REV="2"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="b1e21bd8e7d33cf3bc20fd1794e88c3d92b4990f4e0c5911235b67413ec72704"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hdhomerun"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="22.4.1-Piers"
-PKG_SHA256="bc17457b90d3b8685bac55a276bdec1489f91b7eb7543f1a619b457a174f140c"
+PKG_VERSION="22.4.2-Piers"
+PKG_SHA256="40b2875e1c9f0daa57cf3adbbcaf9cb7a563c47f10d24453fe56e7aa83091f2d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="9866496f00db03bb1f4ce816151c9d46060a26ba8a862c950a9c860f08b9b51b"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="b90bd8f542a6337c18730726ca4bfa7df78e55c0d63c31bd4c465dea8e6b9b16"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.njoy"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="ba117de0150ab8de5af8b65c57083808a4b4a556168c7ac0509bffc37144671a"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="1eb19a9f5ccad6e36d53f684d54f0b84fd3bb82c59fd92f121013c51d5f0f11d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.pctv"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="3d84929f6fedfb2fffe55034a042f4d9db27e76e0e58b9a078a15cae8a02a50d"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="15cc7b75ff5d1f36693d86bcd47a61d58c1fd171c6ac96e10717d3741133a4c1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="58423b65d63c36a50f3b0f63166b1a820a45c86defe4425efefff4a31989848e"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="be8fc0147481ed85ad0ac40d500e094e1a7c4bbe7ce946d741b733cdb6a8d33f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vbox"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="5a5f8fe89cb4ca73694b15226264eceb39b96e9ee5379e1d613870134d67fe17"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="6b330d6286aa197eef86369268e2d6e704eb7b0668bd6544caf104a3b1c640ff"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="82f02e463ad44460b3a7bed775dff8ea89f52fcc9de5ea5a453cb5db443e7597"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="d5e697b6704c3d1e4aa8a9e52e84af9f04c7cb90019f3d4965362e205aea47ee"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="22.3.1-Piers"
-PKG_SHA256="378ac93ae7cacabf12e17ff8ec86c8f149a871f045d7e452d69b5697633e12b7"
+PKG_VERSION="22.3.2-Piers"
+PKG_SHA256="aa986391c30a9d4da585cf2938120945528996e8ea697e263aa9279c85b80866"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="a0409f319589ec00eafe363f7284261b7fd4d80677ba079d1d5dc0ff7165e3ae"
+PKG_VERSION="22.2.1-Piers"
+PKG_SHA256="ad607816a61e7b1226aa48d7c0021be052675fae98268389ef581036c8b70d07"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- pvr.argustv: update 22.3.0-Piers to 22.3.1-Piers
- pvr.demo: update 22.4.0-Piers to 22.4.1-Piers
- pvr.dvblink: update 22.2.0-Piers to 22.2.1-Piers
- pvr.dvbviewer: update 22.2.0-Piers to 22.2.1-Piers
- pvr.filmon: update 22.2.0-Piers to 22.2.1-Piers
- pvr.hdhomerun: update 22.2.0-Piers to 22.2.1-Piers
- pvr.iptvsimple: update 22.4.1-Piers to 22.4.2-Piers
- pvr.mediaportal.tvserver: update 22.2.0-Piers to 22.2.1-Piers
- pvr.njoy: update 22.2.0-Piers to 22.2.1-Piers
- pvr.pctv: update 22.2.0-Piers to 22.2.1-Piers
- pvr.stalker: update 22.2.0-Piers to 22.2.1-Piers
- pvr.vbox: update 22.2.0-Piers to 22.2.1-Piers
- pvr.vdr.vnsi: update 22.2.0-Piers to 22.2.1-Piers
- pvr.vuplus: update 22.3.1-Piers to 22.3.2-Piers
- pvr.wmc: update 22.2.0-Piers to 22.2.1-Piers