### PR TITLE
treewide: rename xbmc to kodi

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -144,7 +144,7 @@
 # build with MySQL support (mariadb / none)
   KODI_MYSQL_SUPPORT="mariadb"
 
-# build xbmc with optical drive support (yes / no)
+# build Kodi with optical drive support (yes / no)
   KODI_OPTICAL_SUPPORT="yes"
 
 # build with AirPlay support (stream videos from iDevices to KODI) (yes / no)

--- a/packages/addons/service/boblightd/config/boblight.X11.sample
+++ b/packages/addons/service/boblightd/config/boblight.X11.sample
@@ -1,1 +1,1 @@
-# Nothing needed in this file, just rename to boblight.X11 if not using XBMC addon
+# Nothing needed in this file, just rename to boblight.X11 if not using Kodi addon

--- a/packages/addons/service/mpd/source/config/mpd.conf
+++ b/packages/addons/service/mpd/source/config/mpd.conf
@@ -194,7 +194,7 @@ state_file "/storage/.kodi/userdata/addon_data/service.multimedia.mpd/state"
 #
 # A BIG FAT WARNING
 #
-# This may block your xbmc audio. It might also play no audio at all,
+# This may block your Kodi audio. It might also play no audio at all,
 # if streamsilence is enabled and you try to use the very same device.
 #
 ###############################################################################

--- a/packages/sysutils/eventlircd/evmap/03_0755_2626.evmap
+++ b/packages/sysutils/eventlircd/evmap/03_0755_2626.evmap
@@ -50,7 +50,7 @@
  KEY_BACKSPACE     = KEY_EXIT          # BACK
 
  alt+KEY_F4        = KEY_CLOSE         # Close
- meta+KEY_D        = KEY_INFO          # Desktop, remapped to Info in XBMC
- KEY_COMPOSE       = KEY_EPG           # More, remapped to Context Menu in XBMC
+ meta+KEY_D        = KEY_INFO          # Desktop, remapped to Info in Kodi
+ KEY_COMPOSE       = KEY_EPG           # More, remapped to Context Menu in Kodi
  ctrl+KEY_R        = KEY_RECORD        # Record
  KEY_ESC           = KEY_DELETE        # Clear

--- a/packages/sysutils/eventlircd/evmap/03_13ec_0006.evmap
+++ b/packages/sysutils/eventlircd/evmap/03_13ec_0006.evmap
@@ -12,5 +12,5 @@
  KEY_PVR           = KEY_MEDIA         # Home
  KEY_AUX           = KEY_CAMERA        # Photo
 
- KEY_MENU          = KEY_EPG           # Menu (used for XBMC's context menu)
- KEY_K             = KEY_EPG           # Title (used for XBMC's context menu)
+ KEY_MENU          = KEY_EPG           # Menu (used for Kodi's context menu)
+ KEY_K             = KEY_EPG           # Title (used for Kodi's context menu)

--- a/packages/tools/installer/system.d/installer.service
+++ b/packages/tools/installer/system.d/installer.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=XBMC Media Center
+Description=Kodi Media Center
 Requires=installer.target
 
 [Service]

--- a/projects/ARM/options
+++ b/projects/ARM/options
@@ -63,7 +63,7 @@
   # build with MySQL support (mariadb / none)
     KODI_MYSQL_SUPPORT="no"
 
-  # build xbmc with optical drive support (yes / no)
+  # build Kodi with optical drive support (yes / no)
     KODI_OPTICAL_SUPPORT="no"
 
   # build with AirPlay support (stream videos from iDevices to KODI) (yes / no)


### PR DESCRIPTION
Given that I was asked to alter xbmc to kodi in a previous PR[^1], I went hunting to see if there were any other remaining instances. This is what I found that were minimally invasive. I also did a minor whitespace lint. Hopefully this isn't too annoying and you could forgive this whimsical way for me to contribute to the project.

[^1]: https://github.com/LibreELEC/LibreELEC.tv/pull/9715/files#diff-eb53bd9f4cb2c48c40ff014a0039b6c3fc5b0b1cdb484b873abdd2adf4774b48