### PR TITLE
tools/docker/focal: update Dockerfile to use golang-1.20

### DIFF
--- a/tools/docker/focal/Dockerfile
+++ b/tools/docker/focal/Dockerfile
@@ -20,10 +20,12 @@ RUN adduser --disabled-password --gecos '' docker \
 RUN apt-get update && apt-get install -y \
     curl bash bc gcc-10 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-10 xfonts-utils xsltproc default-jre-headless python3 \
-      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
-      golang-1.18-go git openssh-client rsync \
+      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
+      golang-1.20-go git openssh-client rsync \
     --no-install-recommends \
- && ln -s /usr/lib/go-1.18 /usr/lib/go \
+ && ln -s /usr/lib/go-1.20 /usr/lib/go \
+ && ln -s /usr/lib/go-1.20/bin/go /usr/bin/go \
+ && ln -s /usr/lib/go-1.20/bin/gofmt /usr/bin/gofmt \
  && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \


### PR DESCRIPTION
Update focal Dockerfile inline with jammy/noble to allow golang in LE13 to be compiled. Golang-1.18 is too old to bootstrap. Include rdfind. 

Note: focal will go EOL April 2025 - so the Dockerfile is planned to dropped at this time.