### PR TITLE
binutils: update to 2.44

### DIFF
--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.43.1"
-PKG_SHA256="13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd"
+PKG_VERSION="2.44"
+PKG_SHA256="67be9198476cc37436e2801de649f4ad80bf0d02430d86aff63c6b59b6e23987"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/binutils/"
-PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-with-gold-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host bison:host flex:host linux:host"
 PKG_DEPENDS_TARGET="toolchain zlib binutils:host"
 PKG_LONGDESC="A GNU collection of binary utilities."

--- a/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
+++ b/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
@@ -12,9 +12,9 @@ Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 
 --- a/ld/ldfile.c
 +++ b/ld/ldfile.c
-@@ -103,6 +103,17 @@ ldfile_add_library_path (const char *nam
+@@ -314,6 +314,17 @@ ldfile_add_library_path (const char *nam
    if (!cmdline && config.only_cmd_line_lib_dirs)
-     return NULL;
+     return;
  
 +  /* skip those directories when linking */
 +  if ((!strncmp (name, "/lib", 4)) ||
@@ -24,7 +24,7 @@ Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 +  {
 +    einfo (_("%P: warning: library search path \"%s\" is unsafe for "
 +             "cross-compilation, ignore it\n"), name);
-+    return NULL;
++    return;
 +  }
 +
    new_dirs = (search_dirs_type *) xmalloc (sizeof (search_dirs_type));


### PR DESCRIPTION
release notes:
- https://sourceware.org/pipermail/binutils/2025-February/139195.html

In a change to our previous practice, in this release the binutils-2.44.tar tarball does not contain the sources for the gold linker.  This is because the gold linker is now deprecated and will eventually be removed unless volunteers step forward and offer to continue development and maintenance.

The gold sources can be found in the binutils-with-gold-2.44.tar tarballs.  Going forward, odd numbered releases of the binutils (2.45, 2.47, etc) will just have the binutils.2.xx.tar tarballs, whilst even numbered releases will have both the binutils-2.xx.tar and the binutils-with-gold-2.xx.tar tarballs.  Eventually this will stop and gold will be dropped altogether.