### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.23.5"
-PKG_SHA256="742aa265a47019d2b87bd3d9c42fd7f1e2fed133557e64b0a3e8749925ce5123"
+PKG_VERSION="1.23.6"
+PKG_SHA256="06ca9da2305302a7ca1593afadf012494debf658a11e4e41119ee1ee160f77c7"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.3.81"
-PKG_SHA256="8d887594eb7e9b2f973d18a0fb37483d003b801ada315fe555dfb98eec00365f"
+PKG_VERSION="1.3.82"
+PKG_SHA256="51576cd492a6997d3ae2fbe91fb5943d407f1e0c081fc3699679e25f77757acb"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.5.7"
-PKG_SHA256="8cd43a582f68368ee5a915e97bf9dadc44d2dfe8c7bb4f96bb7b40ea2ed7848f"
+PKG_VERSION="0.5.8"
+PKG_SHA256="234667497c6b1dd2457e7f4566567fad6cde31e4cb8990c7d0f149cb45a3894a"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.4.3"
-PKG_SHA256="7c2180a62a3ca7ae58a1cbb1d912ab1c19bb5c112db2f6742b809d134bdac169"
+PKG_VERSION="3.4.4"
+PKG_SHA256="79a1c5a3de86e7daa0a456c502d60dc15debe105932ad6a0d25024908603f433"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/groovy/package.mk
+++ b/packages/devel/groovy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="groovy"
-PKG_VERSION="4.0.24"
-PKG_SHA256="dbff36835568bec2271876f70bfcca6deb80e1b179453cca934a502ea301bb80"
+PKG_VERSION="4.0.25"
+PKG_SHA256="822cad8e03388f23bf613d37f990b813bb4165fe389fd3fcc24f8b96476c30ef"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://groovy.apache.org"
 PKG_URL="https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-${PKG_VERSION}.zip"

--- a/packages/devel/pcre2/package.mk
+++ b/packages/devel/pcre2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcre2"
-PKG_VERSION="10.44"
-PKG_SHA256="d34f02e113cf7193a1ebf2770d3ac527088d485d4e047ed10e5d217c6ef5de96"
+PKG_VERSION="10.45"
+PKG_SHA256="21547f3516120c75597e5b30a992e27a592a31950b5140e7b8bfde3f192033c4"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.pcre.org/"
 PKG_URL="https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PKG_VERSION}/pcre2-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/talloc/package.mk
+++ b/packages/devel/talloc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="talloc"
-PKG_VERSION="2.4.2"
-PKG_SHA256="85ecf9e465e20f98f9950a52e9a411e14320bc555fa257d87697b7e7a9b1d8a6"
+PKG_VERSION="2.4.3"
+PKG_SHA256="dc46c40b9f46bb34dd97fe41f548b0e8b247b77a918576733c528e83abd854dd"
 PKG_LICENSE="LGPL-3.0-or-later"
 PKG_SITE="https://talloc.samba.org/"
 PKG_URL="https://www.samba.org/ftp/talloc/talloc-${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="25.1.0"
-PKG_SHA256="94178add6dd545bd14747c063863d87d7b4f3cbcaab5d660d2ae5310cbfe4553"
+PKG_VERSION="25.1.1"
+PKG_SHA256="db5788341789099cbfce212f64f428eb79739f578eabfcc6056f03f3029d3708"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Mako"
-PKG_VERSION="1.3.8"
-PKG_SHA256="577b97e414580d3e088d47c2dbbe9594aa7a5146ed2875d4dfa9075af2dd3cc8"
+PKG_VERSION="1.3.9"
+PKG_SHA256="b5d65ff3462870feec922dbccf38f6efb44e5714d7b593a656be86663d8600ac"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/Mako"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/mako-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/flit/package.mk
+++ b/packages/python/devel/flit/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flit"
-PKG_VERSION="3.9.0"
-PKG_SHA256="72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba"
+PKG_VERSION="3.10.1"
+PKG_SHA256="66e5b87874a0d6e39691f0e22f09306736b633548670ad3c09ec9db03c5662f7"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/flit-core/"
 PKG_URL="https://files.pythonhosted.org/packages/source/f/flit_core/flit_core-${PKG_VERSION}.tar.gz"

--- a/packages/security/gnutls/package.mk
+++ b/packages/security/gnutls/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnutls"
-PKG_VERSION="3.8.8"
-PKG_SHA256="ac4f020e583880b51380ed226e59033244bc536cad2623f2e26f5afa2939d8fb"
+PKG_VERSION="3.8.9"
+PKG_SHA256="69e113d802d1670c4d5ac1b99040b1f2d5c7c05daec5003813c049b5184820ed"
 PKG_LICENSE="LGPL2.1"
 PKG_SITE="https://gnutls.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKG_VERSION:0:3}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.107"
-PKG_SHA256="9899d93d395a319aeba95d41712f56ffa73adb1c538d8b1a634547d09423675c"
+PKG_VERSION="3.108"
+PKG_SHA256="12db2163548e3be4b572821280b579e8b68d6f7c6a91c32b231cab43fcaea564"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"


### PR DESCRIPTION
- flit: update to 3.10.1
- nss: update to 3.108
- go: update to 1.23.6
- Mako: update to 1.3.9
- media-driver: update to 25.1.1
- pcre2: update to 10.45
- groovy: update to 4.0.25
- gnutls: update to 3.8.9
- wireplumber: update to 0.5.8
- talloc: update to 2.4.3
- mariadb-connector-c: update to 3.4.4
- pipewire: update to 1.3.82
