### PR TITLE
kodi: update to githash 8791707

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="fb44880453243477a1ef1857d5555d71b00433cb"
-PKG_SHA256="802679294951936148c9a53b0dd3666098c6fa35cb88c4d36c508d0af2a8b6a6"
+PKG_VERSION="87917079958ad5609be9f8fe3379823fa364205d"
+PKG_SHA256="faf66ba9e565f5ae11a8d146cf5ccb7770f13b0077bcde2c0d71af3f6a7afc0a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/fb44880453243477a1ef1857d5555d71b00433cb...87917079958ad5609be9f8fe3379823fa364205d

```
=== tested on ===
Generic.x86_64-devel-20250206110622-9759729
Linux nuc12 6.14.0-rc1 #1 SMP Thu Feb  6 10:24:47 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:87917079958ad5609be9f8fe3379823fa364205d). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-02-06 by GCC 15.0.1 for Linux x86 64-bit version 6.14.0 (396800)
Running on LibreELEC (heitbaum): devel-20250206110622-9759729 13.0, kernel: Linux x86 64-bit version 6.14.0-rc1
FFmpeg version/source: 7.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.0.0-rc2
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.1.1 (205227aa73)
```