### PR TITLE
Revert "curl: update to 8.12.0"

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="curl"
-PKG_VERSION="8.12.0"
-PKG_SHA256="9a4628c764be6b1a9909567c13e8e771041609df43b2158fcac4e05ea7097e5d"
+PKG_VERSION="8.10.1"
+PKG_SHA256="73a4b0e99596a09fa5924a4fb7e4b995a85fda0d18a2c02ab9cf134bebce04ee"
 PKG_LICENSE="MIT"
 PKG_SITE="https://curl.haxx.se"
 PKG_URL="https://curl.haxx.se/download/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/web/curl/patches/curl-01-allow_building_debug.patch
+++ b/packages/web/curl/patches/curl-01-allow_building_debug.patch
@@ -1,0 +1,16 @@
+
+When building debug image avoid:
+
+*/build/curl-8.7.1/lib/easy_lock.h:72:20: error: inlining failed in call to 'curl_simple_lock_lock': function not considered for inlining [-Werror=inline]
+
+
+--- a/CMake/PickyWarnings.cmake.org	2024-03-25 09:48:59.000000000 +0100
++++ b/CMake/PickyWarnings.cmake	2024-05-03 18:27:04.033468758 +0200
+@@ -60,7 +60,6 @@ if(PICKY_COMPILER)
+     list(APPEND WPICKY_ENABLE
+       -Wbad-function-cast                  # clang  2.7  gcc  2.95
+       -Wconversion                         # clang  2.7  gcc  2.95
+-      -Winline                             # clang  1.0  gcc  1.0
+       -Wmissing-declarations               # clang  1.0  gcc  2.7
+       -Wmissing-prototypes                 # clang  1.0  gcc  1.0
+       -Wnested-externs                     # clang  1.0  gcc  2.7


### PR DESCRIPTION
The new curl version causes crashes eg when downloading addons from the kodi repo.

Revert the bump until the issue is resolved