### PR TITLE
Revert "buildsystem: use distribution defined addon install path"

### DIFF
--- a/scripts/install_addon
+++ b/scripts/install_addon
@@ -29,7 +29,7 @@ install_addon_files "${ADDON_DIRECTORY}"
 debug_strip "${ADDON_DIRECTORY}"
 
 # pack_addon()
-ADDON_INSTALL_DIR="${TARGET_ADDONS}/${PKG_ADDON_ID}"
+ADDON_INSTALL_DIR="${TARGET_IMG}/${ADDONS}/${ADDON_VERSION}/${DEVICE:-${PROJECT}}/${TARGET_ARCH}/${PKG_ADDON_ID}"
 ADDONVER="$(xmlstarlet sel -t -v "/addon/@version" ${ADDON_BUILD}/${PKG_ADDON_ID}/addon.xml)"
 
 if [ -f ${ADDON_INSTALL_DIR}/${PKG_ADDON_ID}-${ADDONVER}.zip ]; then


### PR DESCRIPTION
This change caused addons explicitly built for a specific project/device to end up in the general ADDON_PROJECT folder (eg ARMv8) instead of the project/device specific folder.

This results in binaries compiled for different target architectures (eg cortex-a76 with AES extensions on RPi5 instead of cortex-a53 without AES extensions on our ARMv8 baseline device)  to end up in the wrong directory and  made it impossible to compile for both addon baseline options and device specific options, eg to do performance comparisons of different target architecture/options.

Our install script was fine before, so let's keep it this way