### PR TITLE
x265: fix x86_64 target compile on arm64 hosts

### DIFF
--- a/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
@@ -14,5 +14,5 @@ PKG_TOOLCHAIN="make"
 
 pre_configure_target() {
   LDFLAGS+=" -ldl"
-  cmake -DCMAKE_INSTALL_PREFIX=/usr -G "Unix Makefiles" ./source
+  ${CMAKE} -DCMAKE_INSTALL_PREFIX=/usr -G "Unix Makefiles" ./source
 }


### PR DESCRIPTION
Cross compiling x265 for x86_64 on an arm64 host fails as cmake auto-detects the host CPU. This fixes the issue.

Ping @ksooo 