### PR TITLE
[le12] mariadb: revert to 11.4.3 and addon (5)

### DIFF
--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="11.4.5"
-PKG_REV="4"
-PKG_SHA256="ff6595f8c482f9921e39b97fa1122377a69f0dcbd92553c6b9032cbf0e9b5354"
+PKG_VERSION="11.4.3"
+PKG_REV="5"
+PKG_SHA256="6f0017b9901bb1897de0eed21caef9ffa9d66ef559345a0d8a6f011308413ece"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://archive.mariadb.org/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
This reverts commit 0e8535cc3e69302584a3e72f84a2e0e67ad30d81. mariadb is failing with thread_stack size in 11.4.4 and 11.4.5
https://forum.libreelec.tv/thread/29487-mariadb-addon-not-starting/