### PR TITLE
Generic: switch to OpenGL

### DIFF
--- a/packages/graphics/glu/package.mk
+++ b/packages/graphics/glu/package.mk
@@ -12,4 +12,8 @@ PKG_DEPENDS_TARGET="toolchain libglvnd mesa"
 PKG_NEED_UNPACK="$(get_pkg_directory mesa)"
 PKG_LONGDESC="libglu is the The OpenGL utility library"
 
-PKG_MESON_OPTS_TARGET="-Dgl_provider=gl"
+if [ "${DISPLAYSERVER}" = "x11" ]; then
+  PKG_MESON_OPTS_TARGET="-Dgl_provider=gl"
+else
+  PKG_MESON_OPTS_TARGET="-Dgl_provider=glvnd"
+fi

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -67,7 +67,9 @@ if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
   PKG_MESON_OPTS_TARGET+=" -Dintel-clc=system"
 fi
 
-if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)"; then
+if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)" ||
+              [ "${OPENGL_SUPPORT}" = "yes" ] &&
+              [ "${DISPLAYSERVER}" != "x11" ]; then
   PKG_DEPENDS_TARGET+=" libglvnd"
   PKG_MESON_OPTS_TARGET+=" -Dglvnd=enabled"
 else

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -58,6 +58,24 @@ configure_package() {
                    -DAPP_RENDER_SYSTEM=gles \
                    -DWAYLANDPP_SCANNER=${TOOLCHAIN}/bin/wayland-scanner++ \
                    -DWAYLANDPP_PROTOCOLS_DIR=${SYSROOT_PREFIX}/usr/share/waylandpp/protocols"
+  else # GBM
+    if [ ! "${KODIPLAYER_DRIVER}" = "default" ]; then
+      PKG_DEPENDS_TARGET+=" ${KODIPLAYER_DRIVER}"
+    fi
+    PKG_DEPENDS_TARGET+=" libinput libdisplay-info"
+    KODI_PLATFORM="-DCORE_PLATFORM_NAME=gbm"
+    if [ ! "${OPENGL}" = "no" ]; then
+      KODI_PLATFORM+=" -DAPP_RENDER_SYSTEM=gl"
+    else
+      KODI_PLATFORM+=" -DAPP_RENDER_SYSTEM=gles"
+    fi
+    CFLAGS+=" -DEGL_NO_X11"
+    CXXFLAGS+=" -DEGL_NO_X11"
+    if [ "${PROJECT}" = "Generic" ]; then
+      PKG_APPLIANCE_XML="${PKG_DIR}/config/appliance-gbm-generic.xml"
+    else
+      PKG_APPLIANCE_XML="${PKG_DIR}/config/appliance-gbm.xml"
+    fi 
   fi
 
   if [ ! "${OPENGL}" = "no" ]; then
@@ -215,20 +233,6 @@ configure_package() {
     KODI_ARCH="-DWITH_CPU=${TARGET_ARCH}"
   else
     KODI_ARCH="-DWITH_ARCH=${TARGET_ARCH}"
-  fi
-
-  if [ ! "${KODIPLAYER_DRIVER}" = "default" -a "${DISPLAYSERVER}" = "no" ]; then
-    PKG_DEPENDS_TARGET+=" ${KODIPLAYER_DRIVER} libinput libdisplay-info"
-    if [ "${OPENGLES_SUPPORT}" = yes -a "${KODIPLAYER_DRIVER}" = "${OPENGLES}" ]; then
-      KODI_PLATFORM="-DCORE_PLATFORM_NAME=gbm -DAPP_RENDER_SYSTEM=gles"
-      CFLAGS+=" -DEGL_NO_X11"
-      CXXFLAGS+=" -DEGL_NO_X11"
-      if [ "${PROJECT}" = "Generic" ]; then
-        PKG_APPLIANCE_XML="${PKG_DIR}/config/appliance-gbm-generic.xml"
-      else
-        PKG_APPLIANCE_XML="${PKG_DIR}/config/appliance-gbm.xml"
-      fi
-    fi
   fi
 
   if [ "${PROJECT}" = "Allwinner" -o "${PROJECT}" = "Rockchip" -o "${PROJECT}" = "RPi" ]; then

--- a/projects/Generic/devices/Generic-gl/options
+++ b/projects/Generic/devices/Generic-gl/options
@@ -1,0 +1,25 @@
+# OpenGL(X) implementation to use (mesa / no)
+  OPENGL="mesa"
+
+# OpenGL-ES implementation to use (mesa / no)
+  OPENGLES="no"
+
+# Vulkan implementation to use (vulkan-loader / no)
+  VULKAN="no"
+
+# Displayserver to use (weston / x11 / no)
+  DISPLAYSERVER="no"
+
+# Windowmanager to use (fluxbox / weston / no)
+  WINDOWMANAGER="no"
+
+# KODI Player implementation to use (mesa / default)
+  KODIPLAYER_DRIVER="mesa"
+
+# set the addon project
+  ADDON_PROJECT="Generic"
+
+# Mesa 3D Graphic drivers to use (all / crocus,i915,iris,r300,r600,radeonsi,vmware,virtio)
+# Space separated list is supported,
+# e.g. GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"
+  GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"

--- a/projects/Generic/filesystem/usr/share/bootloader/canupdate.sh
+++ b/projects/Generic/filesystem/usr/share/bootloader/canupdate.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 # Allow upgrades between different Generic builds
-if [ "$1" = "Virtual.x86_64" -o "$1" = "Generic.x86_64" -o "$1" = "Generic-legacy.x86_64" -o "$1" = "gbm.x86_64" -o "$1" = "wayland.x86_64" -o "$1" = "x11.x86_64" ]; then
+if [ "$1" = "Virtual.x86_64" -o "$1" = "Generic.x86_64" -o "$1" = "Generic-gl.x86_64" -o "$1" = "Generic-legacy.x86_64" -o "$1" = "gbm.x86_64" -o "$1" = "wayland.x86_64" -o "$1" = "x11.x86_64" ]; then
   exit 0
 else
   exit 1


### PR DESCRIPTION
OpenGL has several advantages over current OpenGL ES Generic images:

1. HQ upscaler improvements
2. Dithering support
3. Future Retroplayer OpenGL shader support
4. Colour management support

HDR passthrough would be functional after https://github.com/xbmc/xbmc/pull/26406 is merged.