### PR TITLE
Addon updates for docker and podman

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="7676968253f0b5ca3a44213c8a92c570284e7146d464a95b6ed11050bd09238c"
+PKG_SHA256="abd16e3911bc7bbd00596ebe4f58baf3d577160d99eefd749a908507ddfc587b"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="a187fa5d2d0d5f12db920734e425afc758e98ead"
+export PKG_GIT_COMMIT="9f9e4058019a37304dc6572ffcbb409d529b59d8"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.0.1"
-PKG_SHA256="a2958e6c97dcc44d2b3fc5f1e0c5cfb267d4620b26b51ff52cbe7bd07678707d"
+PKG_VERSION="2.0.2"
+PKG_SHA256="472747a7a6b360a0864bab0ee00a8a6f51da5795171e6a60ab17aa80cbd850a2"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="88aa2f531d6c2922003cc7929e51daf1c14caa0a"
+export PKG_GIT_COMMIT="c507a0257ea6462fbd6f5ba4f5c74facb04021f4"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="27.5.0"
-PKG_SHA256="f24e988f7b061ae25146f3be9fcdcab54f2e2bd820acc95dfbb29ce43ef47811"
+PKG_VERSION="27.5.1"
+PKG_SHA256="0d071c1773c855778d85590e01b924c1857000fd786485f4b674a3be2d3b893c"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="38b84dce32c45732606fe09ffebef8b29a783644"
+export PKG_GIT_COMMIT="4c9b3b011ae4c30145a7b344c870bdda01b454e2"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.23.6"
-PKG_SHA256="06ca9da2305302a7ca1593afadf012494debf658a11e4e41119ee1ee160f77c7"
+PKG_VERSION="1.24.0"
+PKG_SHA256="4f47402534b970bcf9f92a7af40de20f77ed7c1a295c5aec650b0f1e52c5e026"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/libseccomp/package.mk
+++ b/packages/addons/addon-depends/libseccomp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libseccomp"
-PKG_VERSION="2.5.5"
-PKG_SHA256="248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375"
+PKG_VERSION="2.6.0"
+PKG_SHA256="83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="https://github.com/seccomp/libseccomp"
 PKG_URL="https://github.com/seccomp/libseccomp/releases/download/v${PKG_VERSION}/libseccomp-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/podman/gpgme/package.mk
+++ b/packages/addons/addon-depends/podman/gpgme/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gpgme"
-PKG_VERSION="1.24.1"
-PKG_SHA256="ea05d0258e71061d61716584ec34cef59330a91340571edc46b78374973ba85f"
+PKG_VERSION="1.24.2"
+PKG_SHA256="e11b1a0e361777e9e55f48a03d89096e2abf08c63d84b7017cfe1dce06639581"
 PKG_LICENSE="gpgme"
 PKG_SITE="https://gnupg.org/software/gpgme/index.html"
 PKG_URL="https://gnupg.org/ftp/gcrypt/gpgme/gpgme-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/podman/netavark/package.mk
+++ b/packages/addons/addon-depends/podman/netavark/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="netavark"
-PKG_VERSION="1.13.1"
-PKG_SHA256="b3698021677fb3b0fd1dc5f669fd62b49a7f4cf26bb70f977663f6d1a5046a31"
+PKG_VERSION="1.14.0"
+PKG_SHA256="d2ded5412e5037e84f79a28c774378c864aa6f6e43023dd88891c70cfaf963ef"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/containers/netavark"
 PKG_URL="https://github.com/containers/netavark/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/podman/podman-bin/package.mk
+++ b/packages/addons/addon-depends/podman/podman-bin/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman-bin"
-PKG_VERSION="5.3.1"
-PKG_SHA256="5b4e9ddce69cc2c8c8b8529e90093ae3ea9cb2959e2fceb98469b282dbffbcc7"
+PKG_VERSION="5.4.0"
+PKG_SHA256="e5efb825558624d0539dac94847c39aafec68e6d4dd712435ff4ec1b17044b69"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io/"
 PKG_URL="https://github.com/containers/podman/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Podman: A tool for managing OCI containers and pods."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containers/podman
-export PKG_GIT_COMMIT="4cbdfde5d862dcdbe450c0f1d76ad75360f67a3c"
+export PKG_GIT_COMMIT="f9f7d48b24b1ca4403f189caaeab1cb8ff4a9aa2"
 
 PKG_PODMAN_BUILDTAGS="exclude_graphdriver_devicemapper \
                       exclude_graphdriver_btrfs \

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/podman/package.mk
+++ b/packages/addons/service/podman/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io"

--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -22,11 +22,11 @@ RUN apt-get install -y \
     curl bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.21-go git openssh-client rsync \
+      golang-1.22-go git openssh-client rsync \
     --no-install-recommends \
-    && ln -s /usr/lib/go-1.21 /usr/lib/go \
-    && ln -s /usr/lib/go-1.21/bin/go /usr/bin/go \
-    && ln -s /usr/lib/go-1.21/bin/gofmt /usr/bin/gofmt
+    && ln -s /usr/lib/go-1.22 /usr/lib/go \
+    && ln -s /usr/lib/go-1.22/bin/go /usr/bin/go \
+    && ln -s /usr/lib/go-1.22/bin/gofmt /usr/bin/gofmt
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
   apt-get install -y libc6-amd64-cross qemu-user-binfmt --no-install-recommends; \

--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -21,8 +21,11 @@ RUN apt-get install -y \
     curl bash bc gcc-14 cpp-14 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-14 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-go git openssh-client rsync \
-    --no-install-recommends
+      golang-1.23-go git openssh-client rsync \
+    --no-install-recommends \
+    && ln -s /usr/lib/go-1.23 /usr/lib/go \
+    && ln -s /usr/lib/go-1.23/bin/go /usr/bin/go \
+    && ln -s /usr/lib/go-1.23/bin/gofmt /usr/bin/gofmt
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
   apt-get install -y libc6-amd64-cross qemu-user-binfmt --no-install-recommends; \


### PR DESCRIPTION
- tools/docker/jammy: update to building with go-1.22
- tools/docker/noble: update to building with go-1.23
- go: update to 1.24.0
- docker: update to 27.5.1 and addon (7)
  - cli: update to 27.5.1
  - moby: update to 27.5.1
- podman: update to 5.4.0 and addon (3)
  - podman-bin: update to 5.4.0
- containerd: update to 2.0.2
- netavark: update to 1.14.0
- libseccomp: update to 2.6.0
- gpgme: update to 1.24.2